### PR TITLE
feat(wam-elixir): ISO-errors plumbing — config loader, rewrite hook, …

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -19,7 +19,17 @@
     compile_wam_predicate_to_elixir/4,   % +Pred/Arity, +WamCode, +Options, -Code
     write_wam_elixir_project/3,          % +Predicates, +Options, +ProjectDir
     wam_elixir_case/2,                   % +InstrName, -ElixirCode
-    wam_elixir_resolve_emit_mode/2       % +Options, -Mode
+    wam_elixir_resolve_emit_mode/2,      % +Options, -Mode
+    % ISO errors plumbing (PR #3) — see WAM_ELIXIR_GAPS_SPECIFICATION.md
+    % §3 PR #3. Key tables shipped empty so all predicates below are
+    % no-op rewrites; the first ISO-aware builtin lands in PR #4.
+    iso_errors_resolve_options/2,        % +Options, -Config
+    iso_errors_load_config/2,            % +File, -Config
+    iso_errors_mode_for/3,               % +Config, +PI, -Mode
+    iso_errors_warn_multi_module/2,      % +Config, +Predicates
+    iso_errors_rewrite/4,                % +Config, +PI, +Items0, -Items
+    wam_elixir_iso_audit/3,              % +Predicates, +Options, -Audit
+    wam_elixir_iso_audit_report/1        % +Audit
 ]).
 
 :- use_module(library(lists)).
@@ -1445,6 +1455,73 @@ compile_utility_helpers_to_elixir(Code) :-
       # stack will catch and try to match.
       throw({:wam_throw, thrown_copy})
     end
+  end
+
+  # ---- ISO error term constructors (PR #3) -------------------------
+  #
+  # Mirrors the C++ runtime helpers from wam_cpp_target.pl:
+  #   make_instantiation_error  -> instantiation_error (atom)
+  #   make_type_error/2         -> type_error(Expected, Culprit)
+  #   make_domain_error/2       -> domain_error(Domain, Culprit)
+  #   make_evaluation_error/1   -> evaluation_error(Kind)
+  #
+  # These build the *inner* error term. throw_iso_error/2 wraps it
+  # in the outer error/2 (with Context = a fresh unbound), binds it
+  # into A1, then dispatches via execute_throw so the existing
+  # catch/3 machinery (PR #2) handles unwinding to a matching
+  # catcher.
+  #
+  # No builtin uses these yet — they exist so PR #4 (is_iso/2 +
+  # is_lax/2) can ship runtime-only changes without revisiting the
+  # generator side.
+
+  @doc """
+  Build instantiation_error inner term — an atom per ISO.
+
+  All make_*_error/* helpers return {state, term} for API uniformity,
+  even when (as here) no heap allocation is needed.
+  """
+  def make_instantiation_error(state), do: {state, "instantiation_error"}
+
+  @doc "Build type_error(Expected, Culprit) inner term. Returns {state, term}."
+  def make_type_error(state, expected, culprit) when is_binary(expected) do
+    {:ok, s, t} = build_compound_term(state, "type_error", [expected, culprit])
+    {s, t}
+  end
+
+  @doc "Build domain_error(Domain, Culprit) inner term. Returns {state, term}."
+  def make_domain_error(state, domain, culprit) when is_binary(domain) do
+    {:ok, s, t} = build_compound_term(state, "domain_error", [domain, culprit])
+    {s, t}
+  end
+
+  @doc "Build evaluation_error(Kind) inner term. Returns {state, term}."
+  def make_evaluation_error(state, kind) when is_binary(kind) do
+    {:ok, s, t} = build_compound_term(state, "evaluation_error", [kind])
+    {s, t}
+  end
+
+  @doc """
+  Throw an ISO-style error from a builtin.
+
+  Wraps the inner err_term in `error(ErrTerm, _)` (Context is a fresh
+  unbound var per SPEC §5), binds it into A1, then dispatches via
+  execute_throw. execute_throw raises {:wam_throw, _} which the
+  nearest enclosing execute_catch (PR #2) catches and tries to match
+  against its catcher pattern.
+
+  Returns whatever execute_throw returns: :fail when no catcher
+  matches anywhere, otherwise control transfers to the matched
+  catchers recovery goal. Callers should treat this as a tail call
+  out of the current builtin; the return value flows back through
+  execute_builtin to the dispatch sites wrapper.
+  """
+  def throw_iso_error(state, err_term) do
+    fresh_context = {:unbound, make_ref()}
+    {:ok, state2, error_compound} =
+      build_compound_term(state, "error", [err_term, fresh_context])
+    state3 = %{state2 | regs: Map.put(state2.regs, 1, error_compound)}
+    execute_throw(state3)
   end
 
   # Restore state from a CatcherFrame snapshot:
@@ -5321,3 +5398,312 @@ generate_elixir_dispatcher(Predicates, Options, Code) :-
     end
   end
 end', [CasesStr]).
+
+% ============================================================================
+% ISO error configuration (PR #3 — plumbing)
+% ============================================================================
+%
+% Per-predicate ISO-error dispatch. See:
+%   docs/design/WAM_ELIXIR_PARITY_PHILOSOPHY.md
+%   docs/design/WAM_ELIXIR_GAPS_SPECIFICATION.md
+%
+% Mirrors C++ commit f7d2c932 (feat(wam-cpp): ISO-errors plumbing).
+%
+% This PR ships the API but does NOT wire iso_errors_rewrite/4 into
+% the actual compilation flow. Two reasons:
+%   1. Key tables iso_errors_default_to_iso/2 and
+%      iso_errors_default_to_lax/2 are empty — every default key
+%      passes through unchanged, so wiring would be a no-op walk.
+%   2. The Elixir lowered emitter parses WAM text line-by-line
+%      (no items-list intermediate). Wiring the rewrite cleanly
+%      requires either a small refactor to add an items pre-pass,
+%      or a brittle text-level token-replacement. Both are deferred
+%      to PR #4 where the first table entry makes the wiring earn
+%      its complexity.
+%
+% PR #3 ships: API + audit predicate + runtime helpers, all as
+% standalone exports. Behaviour is identical to pre-PR-#3.
+
+%% iso_errors_default_to_iso(+DefaultKey, -IsoKey)
+%  Maps a default builtin key (e.g. "is/2") to its ISO flavour
+%  ("is_iso/2"). Empty in this PR. Declared `dynamic` so calls
+%  with no clauses simply fail (rather than throwing
+%  existence_error) and so PR #4 can populate it either as
+%  asserted facts or as ordinary static clauses below this line.
+:- dynamic iso_errors_default_to_iso/2.
+:- dynamic iso_errors_default_to_lax/2.
+:- discontiguous iso_errors_default_to_iso/2.
+:- discontiguous iso_errors_default_to_lax/2.
+
+%% iso_errors_resolve_options(+Options, -Config)
+%  Merges the (optional) file config with inline options into one
+%  iso_config(Default, Overrides) struct. Inline options override
+%  file entries for the same PI.
+iso_errors_resolve_options(Options, iso_config(Default, Overrides)) :-
+    (   option(iso_errors_config(File), Options)
+    ->  iso_errors_load_config(File, iso_config(FileDefault, FileOv))
+    ;   FileDefault = false, FileOv = []
+    ),
+    iso_errors_inline_default(Options, FileDefault, Default),
+    iso_errors_inline_overrides(Options, InlineOv),
+    iso_errors_merge_overrides(FileOv, InlineOv, Overrides).
+
+iso_errors_inline_default(Options, FileDefault, Default) :-
+    (   member(iso_errors(M), Options),
+        (M == true ; M == false)
+    ->  Default = M
+    ;   Default = FileDefault
+    ).
+
+iso_errors_inline_overrides(Options, InlineOv) :-
+    findall(PI-Mode,
+            ( member(iso_errors(PI, Mode), Options),
+              (Mode == true ; Mode == false),
+              iso_errors_valid_pi(PI)
+            ),
+            InlineOv).
+
+% Accepts both bare Name/Arity and Module:Name/Arity.
+iso_errors_valid_pi(Name/Arity) :- atom(Name), integer(Arity), Arity >= 0, !.
+iso_errors_valid_pi(Module:Name/Arity) :-
+    atom(Module), atom(Name), integer(Arity), Arity >= 0.
+
+iso_errors_merge_overrides(FileOv, InlineOv, Merged) :-
+    exclude(iso_errors_shadowed(InlineOv), FileOv, Kept),
+    append(Kept, InlineOv, Merged).
+
+iso_errors_shadowed(InlineOv, PI-_) :-
+    member(InlinePI-_, InlineOv),
+    iso_errors_pi_matches(InlinePI, PI), !.
+
+% PI matching: bare Name/Arity matches Module:Name/Arity in any
+% module; Module:Name/Arity matches only its own module.
+iso_errors_pi_matches(PI, PI) :- !.
+iso_errors_pi_matches(Name/Arity, _:Name/Arity) :-
+    atom(Name), integer(Arity), !.
+iso_errors_pi_matches(_:Name/Arity, Name/Arity) :-
+    atom(Name), integer(Arity), !.
+
+%% iso_errors_load_config(+File, -Config)
+%  Reads a Prolog facts file and extracts iso_errors_default/1 +
+%  iso_errors_override/2 terms. Unrecognised terms are silently
+%  ignored. Returns iso_config(false, []) on I/O error.
+iso_errors_load_config(File, iso_config(Default, Overrides)) :-
+    catch(
+        setup_call_cleanup(
+            open(File, read, Stream),
+            iso_errors_read_terms(Stream, RawTerms),
+            close(Stream)),
+        _,
+        RawTerms = []),
+    iso_errors_extract_terms(RawTerms, false, [], Default, RevOv),
+    reverse(RevOv, Overrides).
+
+iso_errors_read_terms(Stream, Terms) :-
+    read_term(Stream, T, []),
+    ( T == end_of_file
+    -> Terms = []
+    ; Terms = [T|Rest],
+      iso_errors_read_terms(Stream, Rest)
+    ).
+
+iso_errors_extract_terms([], D, Ov, D, Ov).
+iso_errors_extract_terms([T|Rest], D0, Ov0, D, Ov) :-
+    (   T = iso_errors_default(NewD), (NewD == true ; NewD == false)
+    ->  iso_errors_extract_terms(Rest, NewD, Ov0, D, Ov)
+    ;   T = iso_errors_override(PI, Mode),
+        (Mode == true ; Mode == false),
+        iso_errors_valid_pi(PI)
+    ->  iso_errors_extract_terms(Rest, D0, [PI-Mode|Ov0], D, Ov)
+    ;   iso_errors_extract_terms(Rest, D0, Ov0, D, Ov)
+    ).
+
+%% iso_errors_mode_for(+Config, +PI, -Mode)
+%  Resolves a predicate's ISO mode. Bare Name/Arity in overrides
+%  matches Module:Name/Arity in any module and vice versa. Falls
+%  back to the config's default when no override matches.
+iso_errors_mode_for(iso_config(Default, Overrides), PI, Mode) :-
+    (   member(OvPI-OvMode, Overrides),
+        iso_errors_pi_matches(OvPI, PI)
+    ->  Mode = OvMode
+    ;   Mode = Default
+    ).
+
+%% iso_errors_warn_multi_module(+Config, +Predicates)
+%  Emits a user_error warning for each bare override that matches
+%  predicates from more than one module in the input list. Catches
+%  the safe_div/2-in-two-modules footgun (SPEC §1).
+iso_errors_warn_multi_module(iso_config(_, Overrides), Predicates) :-
+    forall(member(OvPI-_, Overrides),
+           iso_errors_check_override_scope(OvPI, Predicates)).
+
+iso_errors_check_override_scope(Name/Arity, Predicates) :-
+    atom(Name), integer(Arity), !,
+    findall(M, ( member(P, Predicates),
+                 iso_errors_pi_module(P, Name, Arity, M)
+               ), Modules),
+    list_to_set(Modules, Unique),
+    (   Unique = [_, _ | _]
+    ->  length(Unique, N),
+        format(user_error,
+               'Warning: iso_errors_override(~w/~w, _) matches ~w predicates~n         in different modules (~w).~n         Qualify with `mod:~w/~w` for module-scoped overrides.~n',
+               [Name, Arity, N, Unique, Name, Arity])
+    ;   true
+    ).
+iso_errors_check_override_scope(_, _).
+
+iso_errors_pi_module(Module:Name/Arity, Name, Arity, Module) :- !.
+iso_errors_pi_module(Name/Arity,         Name, Arity, user).
+% Predicates list arrives as Pred/Arity-WamCode pairs in this target;
+% extract the PI for module checking.
+iso_errors_pi_module(Pred/Arity-_, Name, Arity, user) :-
+    atom(Pred), Pred = Name, !.
+
+%% iso_errors_rewrite(+Config, +PI, +Items0, -Items)
+%  Rewrites the default-form builtin_call keys for one predicate.
+%  Explicit *_iso / *_lax keys pass through unchanged. With empty
+%  key tables (this PR), the rewrite is a no-op.
+%
+%  Item shape: matches the de-facto items vocabulary the WAM
+%  compiler emits (mirrors C++; see WAM_ITEMS_API_SPECIFICATION.md
+%  §2 for the canonical list). Targets that haven't migrated to the
+%  Items API yet can still call this on their own ad-hoc item form
+%  as long as the keyed shapes (builtin_call/2, put_structure/2,
+%  call/2, execute/1) match.
+iso_errors_rewrite(Config, PI, Items0, Items) :-
+    iso_errors_mode_for(Config, PI, Mode),
+    maplist(iso_errors_rewrite_item(Mode), Items0, Items).
+
+% Two surfaces to rewrite for an ISO-relevant builtin:
+% - builtin_call("is/2", _) — direct call form.
+% - put_structure("is/2", _) — data form when `is/2` appears inside
+%   a meta-goal (catch(Goal, ...) builds is(X, Expr) into A1).
+% Plus call/execute for completeness.
+iso_errors_rewrite_item(true, builtin_call(Key, N), builtin_call(IsoKey, N)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(true, put_structure(Key, Reg), put_structure(IsoKey, Reg)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(true, call(Key, N), call(IsoKey, N)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(true, execute(Key), execute(IsoKey)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(false, builtin_call(Key, N), builtin_call(LaxKey, N)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(false, put_structure(Key, Reg), put_structure(LaxKey, Reg)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(false, call(Key, N), call(LaxKey, N)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(false, execute(Key), execute(LaxKey)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(_, Item, Item).
+
+%% wam_elixir_iso_audit(+Predicates, +Options, -Audit)
+%  Read-only inspection of how each predicate's builtin_call sites
+%  would resolve under the given options. Returns a list of
+%  audit(PI, Mode, Sites). Each Site is:
+%    site(PC, OrigKey, ResolvedKey, Source, WouldChangeOnFlip)
+%  Source is one of: default, explicit_iso, explicit_lax.
+%
+%  Predicates may arrive as bare PIs (Pred/Arity) or as the
+%  Pred/Arity-WamCode pairs that write_wam_elixir_project/3 uses.
+%  Both shapes are supported.
+wam_elixir_iso_audit(Predicates, Options, Audit) :-
+    iso_errors_resolve_options(Options, Config),
+    findall(audit(PI, Mode, Sites), (
+        member(P, Predicates),
+        iso_errors_audit_normalise_pi(P, PI),
+        iso_errors_mode_for(Config, PI, Mode),
+        iso_errors_audit_predicate(PI, Mode, Sites)
+    ), Audit).
+
+iso_errors_audit_normalise_pi(Pred/Arity-_, Pred/Arity) :- !.
+iso_errors_audit_normalise_pi(PI, PI).
+
+iso_errors_audit_predicate(PI, Mode, Sites) :-
+    (   catch(
+            ( wam_target:compile_predicate_to_wam(PI, [], WamText),
+              iso_errors_audit_parse_lines(WamText, Items)
+            ),
+            _, fail)
+    ->  iso_errors_audit_walk(Items, 0, Mode, [], SitesRev),
+        reverse(SitesRev, Sites)
+    ;   Sites = []
+    ).
+
+% Light-weight WAM-text parser for the audit. Only recognises the
+% builtin_call shape that the audit cares about — everything else
+% becomes an opaque `other` item that the walker advances past.
+iso_errors_audit_parse_lines(WamText, Items) :-
+    atom_string(WamText, S),
+    split_string(S, "\n", "", Lines),
+    maplist(iso_errors_audit_parse_one, Lines, MaybeItems),
+    exclude(==(skip), MaybeItems, Items).
+
+iso_errors_audit_parse_one(Line, Item) :-
+    split_string(Line, " \t", " \t", Parts0),
+    exclude(==(""), Parts0, Parts),
+    iso_errors_audit_classify_line(Parts, Item).
+
+iso_errors_audit_classify_line([], skip).
+iso_errors_audit_classify_line([Tok], Item) :-
+    string_concat(_, ":", Tok), !,   % label line, e.g. "foo/2:"
+    Item = label.
+iso_errors_audit_classify_line(["builtin_call", KeyComma, _ArityStr], Item) :- !,
+    string_concat(Key, ",", KeyComma),
+    Item = builtin_call(Key, 0).
+iso_errors_audit_classify_line(["builtin_call", Key, _ArityStr], Item) :- !,
+    Item = builtin_call(Key, 0).
+iso_errors_audit_classify_line(_, other).
+
+iso_errors_audit_walk([], _, _, Acc, Acc).
+iso_errors_audit_walk([label|Rest], PC, Mode, Acc, Out) :- !,
+    iso_errors_audit_walk(Rest, PC, Mode, Acc, Out).
+iso_errors_audit_walk([builtin_call(Key, _)|Rest], PC, Mode, Acc, Out) :- !,
+    iso_errors_audit_classify(Key, Mode, Source, Resolved, Flip),
+    Site = site(PC, Key, Resolved, Source, Flip),
+    PC1 is PC + 1,
+    iso_errors_audit_walk(Rest, PC1, Mode, [Site|Acc], Out).
+iso_errors_audit_walk([_|Rest], PC, Mode, Acc, Out) :-
+    PC1 is PC + 1,
+    iso_errors_audit_walk(Rest, PC1, Mode, Acc, Out).
+
+% Classify a builtin_call key. Explicit *_iso/N or *_lax/N suffix
+% always wins; otherwise it's a default site whose resolution
+% depends on Mode and the (currently empty) swap tables.
+iso_errors_audit_classify(Key, _Mode, explicit_iso, Key, false) :-
+    iso_errors_key_has_suffix(Key, "_iso"), !.
+iso_errors_audit_classify(Key, _Mode, explicit_lax, Key, false) :-
+    iso_errors_key_has_suffix(Key, "_lax"), !.
+iso_errors_audit_classify(Key, Mode, default, Resolved, Flip) :-
+    iso_errors_resolve_default(Key, Mode, Resolved),
+    iso_errors_other_mode(Mode, OtherMode),
+    iso_errors_resolve_default(Key, OtherMode, OtherResolved),
+    ( Resolved == OtherResolved -> Flip = false ; Flip = true ).
+
+iso_errors_resolve_default(Key, true, IsoKey) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_resolve_default(Key, false, LaxKey) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_resolve_default(Key, _, Key).
+
+iso_errors_other_mode(true,  false).
+iso_errors_other_mode(false, true).
+
+iso_errors_key_has_suffix(Key, Suffix) :-
+    ( atom(Key) -> atom_string(Key, KS) ; KS = Key ),
+    split_string(KS, "/", "", Parts),
+    Parts = [Name | _],
+    string_concat(_, Suffix, Name).
+
+%% wam_elixir_iso_audit_report(+Audit)
+%  Human-readable pretty-print of an audit result.
+wam_elixir_iso_audit_report([]).
+wam_elixir_iso_audit_report([audit(PI, Mode, Sites)|Rest]) :-
+    format('~w [~w]~n', [PI, Mode]),
+    (   Sites == []
+    ->  format('  (no builtin_call sites)~n', [])
+    ;   forall(member(site(PC, Orig, Res, Src, Flip), Sites),
+               format('  pc=~w  ~w -> ~w  (~w)  flip-changes=~w~n',
+                      [PC, Orig, Res, Src, Flip]))
+    ),
+    wam_elixir_iso_audit_report(Rest).

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -260,6 +260,97 @@ test_wam_throw_top_level_wrapper :-
                   'wam_throw catch arm missing from predicate run(args) wrapper')
     ).
 
+%% ISO errors plumbing tests (PR #3)
+
+test_iso_errors_config_loader :-
+    Test = 'WAM-Elixir: ISO errors config loader parses Prolog facts',
+    % Write a sample config to a tempfile, load it, verify mode_for/3
+    % returns the expected modes for several PI shapes.
+    tmp_file_stream(text, Path, Stream),
+    format(Stream,
+        ":- encoding(utf8).~n~c~n",
+        [0'%]),
+    format(Stream, "iso_errors_default(true).~n", []),
+    format(Stream, "iso_errors_override(legacy_lookup/3, false).~n", []),
+    format(Stream, "iso_errors_override(experimental:my_pred/2, true).~n", []),
+    format(Stream, "iso_errors_override(unsafe_div/3, false).~n", []),
+    close(Stream),
+    (   iso_errors_resolve_options([iso_errors_config(Path)], Config),
+        % Default is true (from iso_errors_default fact).
+        iso_errors_mode_for(Config, untouched/2, true),
+        % Bare override matches in any module.
+        iso_errors_mode_for(Config, legacy_lookup/3, false),
+        iso_errors_mode_for(Config, anymod:legacy_lookup/3, false),
+        % Module-qualified override matches only its own module.
+        iso_errors_mode_for(Config, experimental:my_pred/2, true),
+        iso_errors_mode_for(Config, other:my_pred/2, true),
+        % Unrelated PI falls back to default.
+        iso_errors_mode_for(Config, totally:other/0, true)
+    ->  pass(Test)
+    ;   fail_test(Test, 'config loader / mode resolution mismatch')
+    ),
+    catch(delete_file(Path), _, true).
+
+test_iso_errors_inline_wins :-
+    Test = 'WAM-Elixir: ISO errors inline option overrides file config',
+    % File says pred_x is false; inline option says true. Inline wins.
+    tmp_file_stream(text, Path, Stream),
+    format(Stream, "iso_errors_default(false).~n", []),
+    format(Stream, "iso_errors_override(pred_x/2, false).~n", []),
+    close(Stream),
+    Options = [
+        iso_errors_config(Path),
+        iso_errors(true),                 % flips global default
+        iso_errors(pred_x/2, true)        % flips pred_x
+    ],
+    (   iso_errors_resolve_options(Options, Config),
+        iso_errors_mode_for(Config, pred_x/2, true),       % inline won
+        iso_errors_mode_for(Config, untouched_pred/0, true) % global default flipped
+    ->  pass(Test)
+    ;   fail_test(Test, 'inline option did not override file config')
+    ),
+    catch(delete_file(Path), _, true).
+
+test_iso_errors_audit_empty_tables :-
+    Test = 'WAM-Elixir: iso audit returns default-source records (tables empty)',
+    % With empty rewrite tables, every default-form builtin_call site
+    % resolves to source=default, resolved==original, flip-changes=false.
+    setup_call_cleanup(
+        ( assertz((iso_audit_test:foo(X) :- X is 1 + 1)) ),
+        (   wam_elixir_iso_audit([iso_audit_test:foo/1], [], Audit),
+            % Audit should contain one entry for foo/1.
+            Audit = [audit(_, _, Sites)],
+            % Find the is/2 site, verify its classification.
+            ( member(site(_, "is/2", "is/2", default, false), Sites)
+            ->  pass(Test)
+            ;   fail_test(Test,
+                          'audit did not classify is/2 as default with no flip-change')
+            )
+        ),
+        retractall(iso_audit_test:foo(_))
+    ).
+
+test_iso_errors_multi_module_warning :-
+    Test = 'WAM-Elixir: iso config bare-PI multi-module warning fires (smoke)',
+    % Smoke test: warn_multi_module/2 succeeds for both shapes (one
+    % bare-PI matching multiple modules; one bare-PI matching one
+    % module). Stderr text capture is intentionally not gated — that
+    % requires fragile stream redirection. The test verifies the
+    % predicate runs cleanly; manual inspection during development
+    % verifies the warning text. The C++ equivalent test follows the
+    % same pattern (test_iso_errors_multi_module_warning in
+    % tests/test_wam_cpp_generator.pl).
+    Config = iso_config(false, [safe_div/2 - true]),
+    MultiModulePreds = [mod_a:safe_div/2, mod_b:safe_div/2, util:safe_div/2],
+    SingleModulePreds = [mod_a:safe_div/2],
+    EmptyPreds = [],
+    (   iso_errors_warn_multi_module(Config, MultiModulePreds),
+        iso_errors_warn_multi_module(Config, SingleModulePreds),
+        iso_errors_warn_multi_module(Config, EmptyPreds)
+    ->  pass(Test)
+    ;   fail_test(Test, 'warn_multi_module/2 failed on one of the shapes')
+    ).
+
 test_true_zero_builtin :-
     Test = 'WAM-Elixir: true/0 builtin arm exists',
     (   compile_wam_helpers_to_elixir([], Code),
@@ -2893,6 +2984,10 @@ run_tests :-
     test_catch_throw_builtin_arms,
     test_catch_throw_step_arms,
     test_wam_throw_top_level_wrapper,
+    test_iso_errors_config_loader,
+    test_iso_errors_inline_wins,
+    test_iso_errors_audit_empty_tables,
+    test_iso_errors_multi_module_warning,
     test_elixir_idioms,
     test_immutable_state_updates,
     test_functional_run_loop,


### PR DESCRIPTION
  ## Summary

  PR #3 from [`WAM_ELIXIR_GAPS_SPECIFICATION.md`](docs/design/WAM_ELIXIR_GAPS_SPECIFICATION.md) §3.
  Plumbing that PRs #4-5 will build on. Mirrors C++ commit `f7d2c932`.

  **Behaviour change: NONE.** The two key swap tables are empty so
  the rewrite is a no-op; no builtin uses the runtime helpers yet.
  All 13 existing e2e tests still pass byte-identical to pre-PR-#3.

  ### Generator side (~280 LOC)

  | Predicate | Role |
  |---|---|
  | `iso_errors_default_to_iso/2` + `iso_errors_default_to_lax/2` | `:- dynamic`, both empty. PR #4 populates one entry;
   PR #5 fills the rest. |
  | `iso_errors_resolve_options/2` | Merges file config + inline options. Inline wins. |
  | `iso_errors_load_config/2` | Reads a flat Prolog facts file (no module decl, no directives). Forward-compat —
  unrecognised terms silently ignored. |
  | `iso_errors_mode_for/3` | Resolves PI → Mode. Bare `Name/Arity` matches `Module:Name/Arity` in any module and vice
  versa. |
  | `iso_errors_warn_multi_module/2` | Emits `user_error` warning for each bare override matching predicates from >1
  module (the `safe_div/2`-in-two-modules footgun from SPEC §1). |
  | `iso_errors_rewrite/4` | Walks Items, rewrites default-form keys via the swap tables. Explicit `*_iso/N` / `*_lax/N`
   pass through unchanged. |
  | `wam_elixir_iso_audit/3` + `_report/1` | Read-only inspection. Includes a light-weight WAM-text parser (just the
  `builtin_call` shape that the audit cares about). Predicates may arrive as bare PIs OR `Pred/Arity-WamCode` pairs. |

  ### Why `iso_errors_rewrite/4` is shipped but NOT wired into `write_wam_elixir_project/3`

  1. **Tables are empty** — wiring would be a no-op walk.
  2. **Elixir's lowered emitter parses WAM text line-by-line** (no items-list intermediate). Wiring cleanly requires
  either an items pre-pass refactor OR a brittle text-level token-replacement; both are deferred to PR #4 where the
  first table entry makes the wiring earn its complexity.

  This differs slightly from the C++ pattern (which already had `parse_pred_blocks/2` as an items intermediate and could
   wire the rewrite trivially).

  ### Runtime side (~50 LOC in WamRuntime template)

  | Helper | Builds |
  |---|---|
  | `make_instantiation_error/1` | `"instantiation_error"` atom |
  | `make_type_error/3` | `type_error(Expected, Culprit)` |
  | `make_domain_error/3` | `domain_error(Domain, Culprit)` |
  | `make_evaluation_error/2` | `evaluation_error(Kind)` |
  | `throw_iso_error/2` | Wraps inner err in `error(ErrTerm, Context)` (Context = fresh unbound per SPEC §5), binds into
   A1, dispatches via `execute_throw` (PR #2) |

  All `make_*_error` helpers return `{state, term}` for API uniformity, even when (as for `instantiation_error`) no heap
   allocation is needed.

  ## Test plan

  ### Unit tests (`tests/test_wam_elixir_target.pl`) — 4 new

  - [x] `test_iso_errors_config_loader` — writes a sample 4-line config to a tempfile, loads it, verifies `mode_for/3`
  against four PI shapes (default fallback, bare match in any module, module-qualified match, unrelated PI → default)
  - [x] `test_iso_errors_inline_wins` — file config + inline options with conflicting values. Verifies inline-wins
  precedence for both global default and per-PI overrides
  - [x] `test_iso_errors_audit_empty_tables` — with empty rewrite tables, every default-form site resolves to
  `source=default`, `resolved=original`, `would_change_on_flip=false`
  - [x] `test_iso_errors_multi_module_warning` — smoke test that `warn_multi_module/2` succeeds for empty /
  single-module / multi-module shapes. Stderr text capture intentionally not gated (mirrors C++ test pattern); manual
  inspection during dev verifies warning format

  ### Regression

  - [x] All existing unit tests pass
  - [x] All 13 e2e tests pass (3 classic + 4 call/N + 6 catch/throw)

  ## Reviewer notes

  - The `iso_errors_pi_module/4` predicate has 3 clauses including a special case for `Pred/Arity-_` pairs (since
  `write_wam_elixir_project/3` uses that shape). The C++ version only had 2 clauses since it always works with bare PIs.
  - The audit predicate's mini-parser (`iso_errors_audit_parse_lines/2`) only recognises `builtin_call` shapes —
  everything else becomes opaque `other`. It's a deliberate minimal parser for the audit's narrow use case; the full
  Items API (separate roadmap) would replace it.
  - Stderr-text capture for the multi-module warning test was attempted with stream redirection but proved fragile.
  Followed the C++ test's approach (smoke-test the predicate, manual inspection of warning text during dev).

  🤖 Generated with [Claude Code](https://claude.com/claude-code)