### PR TITLE
bench(csharp-query): report backend comparison details

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -257,6 +257,27 @@ python examples/benchmark/benchmark_csharp_query_rust_lmdb_sink.py \
 Starting with smaller caps is useful before moving to `500k_cats` or
 `1m_cats`.
 
+After preparing scale-local Rust LMDB artifacts, run the full backend
+comparison against the same scale roots to compare `preload`,
+`binary-artifact`, `delimited-artifact`, `lmdb`, and `mmap-array`:
+
+```bash
+python examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py \
+  --scales rust_lmdb_100k,rust_lmdb_500k \
+  --benchmark-root /tmp/uw-csharp-query-rust-lmdb \
+  --artifact-root /tmp/uw-csharp-query-rust-lmdb-artifacts \
+  --use-scale-lmdb-artifact \
+  --lookup-keys 64 \
+  --lookup-repetitions 1 \
+  --repetitions 1 \
+  --format summary-full-markdown
+```
+
+`summary-full-markdown` includes the same best-mode columns as
+`summary-markdown` plus per-mode median lookup, bucket, scan, and artifact-size
+fields, which is more useful when deciding whether LMDB is competitive at a
+larger scale.
+
 Pass `--artifact-root <dir>` to keep backend artifacts across benchmark runs.
 Existing binary, delimited, LMDB, and mmap-array manifests are reused by
 default, matching the Haskell benchmark convention of not regenerating LMDB

--- a/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
+++ b/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
@@ -490,6 +490,21 @@ def render_summary_markdown(rows: list[SummaryRow]) -> str:
     return "\n".join(lines)
 
 
+def render_summary_full_markdown(rows: list[SummaryRow]) -> str:
+    lines = [
+        "| Scale | Rows | Categories | Lookup keys | Best lookup | Best bucket | Best scan | Smallest artifact | Lookup ms by mode | Bucket ms by mode | Scan ms by mode | Artifact bytes by mode |",
+        "| --- | ---: | ---: | ---: | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        value = row.values
+        lines.append(
+            "| {scale} | {rows} | {distinct_categories} | {lookup_keys} | {best_lookup_mode} | {best_bucket_mode} | {best_scan_mode} | {smallest_artifact_mode} | {lookup_ms_by_mode} | {bucket_ms_by_mode} | {scan_ms_by_mode} | {artifact_bytes_by_mode} |".format(
+                **value
+            )
+        )
+    return "\n".join(lines)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Compare C# query artifact backends on the real effective-distance category_parent/2 relation."
@@ -571,7 +586,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--format",
-        choices=("tsv", "markdown", "summary-tsv", "summary-markdown"),
+        choices=("tsv", "markdown", "summary-tsv", "summary-markdown", "summary-full-markdown"),
         default="tsv",
     )
     parser.add_argument("--keep-temp", action="store_true", help="keep the generated C# benchmark project")
@@ -656,6 +671,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.format == "summary-tsv":
         print(render_summary_tsv(summarize(rows)))
+    elif args.format == "summary-full-markdown":
+        print(render_summary_full_markdown(summarize(rows)))
     elif args.format == "summary-markdown":
         print(render_summary_markdown(summarize(rows)))
     elif args.format == "markdown":

--- a/tests/test_csharp_query_effective_distance_artifact_backends.py
+++ b/tests/test_csharp_query_effective_distance_artifact_backends.py
@@ -146,6 +146,28 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
         self.assertIn("| dev |", result.stdout)
         self.assertIn("Smallest artifact", result.stdout)
 
+    def test_summary_full_markdown_reports_timing_details(self) -> None:
+        row = MODULE.SummaryRow(
+            {
+                "scale": "rust_lmdb_500k",
+                "rows": "500000",
+                "distinct_categories": "225697",
+                "lookup_keys": "64",
+                "best_lookup_mode": "mmap-array",
+                "best_bucket_mode": "mmap-array",
+                "best_scan_mode": "preload",
+                "smallest_artifact_mode": "mmap-array",
+                "lookup_ms_by_mode": "lmdb:2.087|mmap-array:1.250",
+                "bucket_ms_by_mode": "lmdb:718.217|mmap-array:250.000",
+                "scan_ms_by_mode": "lmdb:129.326|preload:1.000",
+                "artifact_bytes_by_mode": "lmdb:27971980|mmap-array:4000000",
+            }
+        )
+        output = MODULE.render_summary_full_markdown([row])
+        self.assertIn("Lookup ms by mode", output)
+        self.assertIn("lmdb:2.087|mmap-array:1.250", output)
+        self.assertIn("Artifact bytes by mode", output)
+
     def test_artifact_root_reuses_existing_manifests(self) -> None:
         if shutil.which("dotnet") is None:
             self.skipTest("dotnet is not available")


### PR DESCRIPTION
  ## Summary

  - Add `summary-full-markdown` output for C# query effective-distance artifact backend comparisons.
  - Include per-mode lookup, bucket, scan, and artifact-size details in markdown summaries.
  - Document the 100k/500k backend comparison flow using Rust-sink-prepared LMDB artifacts.

  ## Verification

  - `python3 -m unittest tests/test_csharp_query_effective_distance_artifact_backends.py tests/
  test_csharp_query_rust_lmdb_sink_benchmark.py tests/test_prepare_csharp_query_enwiki_category_fixture.py tests/
  test_csharp_query_lmdb_provider_smoke.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py examples/
  benchmark/benchmark_csharp_query_rust_lmdb_sink.py examples/benchmark/prepare_csharp_query_enwiki_category_fixture.py tests/
  test_csharp_query_effective_distance_artifact_backends.py tests/test_csharp_query_rust_lmdb_sink_benchmark.py tests/
  test_prepare_csharp_query_enwiki_category_fixture.py`
  - `git diff --check`
  - Live 100k/500k backend comparison under `/tmp`