### PR TITLE
Add Go WAM LMDB atom fact-source adapter

### DIFF
--- a/PR_go_wam_lmdb_fact_source.md
+++ b/PR_go_wam_lmdb_fact_source.md
@@ -1,0 +1,32 @@
+# PR Title
+
+Add Go WAM LMDB atom fact-source adapter
+
+# PR Description
+
+## Summary
+
+- Adds `register_lmdb_atom_fact2(...)` setup generation for Go WAM foreign setup specs.
+- Adds generated Go `registerLmdbAtomFact2` and an `lmdbAtomFact2Source` implementing the existing `AtomFact2Source` interface.
+- Dispatches LMDB-backed `Scan` and `LookupArg1` through the existing `lmdb_relation_artifact` helper command, avoiding a new generated-project Go dependency.
+- Supports `UW_LMDB_RELATION_ARTIFACT_BIN` so deployments or tests can provide the concrete helper path.
+- Adds generated-Go E2E coverage using a mock LMDB artifact helper.
+- Updates the Go parity audit to mark direct external atom fact-source support as covered for the current baseline, while leaving an optional native Go LMDB binding as a future dependency-policy decision.
+
+## Verification
+
+```sh
+swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
+swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl tests/test_wam_go_generator.pl tests/test_go_wam_builtins.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
+swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"
+git diff --check
+```
+
+## Follow-Up
+
+- Consider an optional native Go LMDB build-tag implementation if the project settles on a Go LMDB dependency policy.

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -9,7 +9,7 @@ current cross-target builtin/runtime baseline.
 | Area | Go support | Rust/Haskell baseline | Status |
 | --- | --- | --- | --- |
 | Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries, `member/2` builtin retries | Choice point stack with normal, builtin, and fact-stream resume states | Partial |
-| Direct fact dispatch | `call_indexed_atom_fact2`, `AtomFact2Source` registry, TSV-backed atom fact loading, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Partial: no LMDB FactSource adaptor |
+| Direct fact dispatch | `call_indexed_atom_fact2`, `AtomFact2Source` registry, TSV-backed and LMDB-artifact atom fact loading, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Present for current external atom fact-source baseline |
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
 | Structural builtins | `member/2`, `length/2`, `append/3` | `member/2`, `length/2`; Rust `append/3` is explicitly unimplemented | Present for current baseline structural checks |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
@@ -47,13 +47,18 @@ current cross-target builtin/runtime baseline.
 - Inline and TSV atom fact pairs now register through a Go `AtomFact2Source`
   interface with `Scan` and `LookupArg1`, matching the Haskell FactSource shape
   while preserving the existing indexed pair table used by native kernels.
+- LMDB relation artifacts can now be registered as Go `AtomFact2Source`
+  adapters via the existing `lmdb_relation_artifact` helper command. The helper
+  path defaults to `lmdb_relation_artifact` and can be overridden with
+  `UW_LMDB_RELATION_ARTIFACT_BIN`, so tests and deployments can provide the
+  concrete LMDB reader without adding a generated-project Go dependency.
 
 ## Recommended Follow-Up Order
 
-1. Add a concrete LMDB-backed `AtomFact2Source` implementation if Go should
-   close the remaining direct-fact parity gap.
-2. Continue broadening generated Go WAM E2E coverage for control behavior that
+1. Continue broadening generated Go WAM E2E coverage for control behavior that
    remains marked partial.
+2. If Go should avoid a helper process for LMDB, add an optional native Go
+   LMDB build-tag path once a dependency policy is settled.
 
 ## Verification Commands
 

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -657,6 +657,10 @@ go_foreign_setup_line(register_tsv_atom_fact2(Pred/Arity, Path), Line) :-
     escape_go_string(Path, EscapedPath),
     format(atom(Line), '    if err := vm.registerTsvAtomFact2("~w/~w", "~w"); err != nil { panic(err) }',
         [Pred, Arity, EscapedPath]).
+go_foreign_setup_line(register_lmdb_atom_fact2(Pred/Arity, ArtifactDir), Line) :-
+    escape_go_string(ArtifactDir, EscapedArtifactDir),
+    format(atom(Line), '    if err := vm.registerLmdbAtomFact2("~w/~w", "~w"); err != nil { panic(err) }',
+        [Pred, Arity, EscapedArtifactDir]).
 go_foreign_setup_line(register_foreign_string_config(Pred/Arity, Key, ValuePred/ValueArity), Line) :-
     format(atom(Line), '    vm.registerForeignStringConfig("~w/~w", "~w", "~w/~w")',
         [Pred, Arity, Key, ValuePred, ValueArity]).
@@ -2311,6 +2315,12 @@ func (vm *WamState) registerTsvAtomFact2(predKey string, path string) error {
     return nil
 }
 
+func (vm *WamState) registerLmdbAtomFact2(predKey string, artifactDir string) error {
+    source := newLmdbAtomFact2Source(predKey, artifactDir)
+    vm.Ctx.AtomFact2Sources[predKey] = source
+    return nil
+}
+
 func (vm *WamState) registerIndexedWeightedEdgeTriples(predKey string, triples []WeightedEdgeTriple) {
     vm.Ctx.IndexedWeightedEdgeTriples[predKey] = triples
 }
@@ -2373,6 +2383,67 @@ func (source *staticAtomFact2Source) LookupArg1(left string) []AtomPair {
         return nil
     }
     return append([]AtomPair(nil), source.byLeft[left]...)
+}
+
+type lmdbAtomFact2Source struct {
+    predKey string
+    artifactDir string
+    helperBin string
+}
+
+func newLmdbAtomFact2Source(predKey string, artifactDir string) *lmdbAtomFact2Source {
+    helperBin := os.Getenv("UW_LMDB_RELATION_ARTIFACT_BIN")
+    if helperBin == "" {
+        helperBin = "lmdb_relation_artifact"
+    }
+    return &lmdbAtomFact2Source{predKey: predKey, artifactDir: artifactDir, helperBin: helperBin}
+}
+
+func (source *lmdbAtomFact2Source) Scan() []AtomPair {
+    if source == nil {
+        return nil
+    }
+    return source.run("scan", source.artifactDir, source.predKey)
+}
+
+func (source *lmdbAtomFact2Source) LookupArg1(left string) []AtomPair {
+    if source == nil {
+        return nil
+    }
+    return source.run("get", source.artifactDir, source.predKey, left)
+}
+
+func (source *lmdbAtomFact2Source) run(args ...string) []AtomPair {
+    if source.helperBin == "" {
+        return nil
+    }
+    output, err := exec.Command(source.helperBin, args...).Output()
+    if err != nil {
+        return nil
+    }
+    return parseAtomFact2Rows(string(output))
+}
+
+func parseAtomFact2Rows(output string) []AtomPair {
+    lines := strings.Split(output, "\\n")
+    pairs := make([]AtomPair, 0, len(lines))
+    for _, line := range lines {
+        line = strings.TrimSpace(line)
+        if line == "" {
+            continue
+        }
+        cols := strings.Split(line, "\\t")
+        if len(cols) < 2 {
+            continue
+        }
+        left := strings.TrimSpace(cols[0])
+        right := strings.TrimSpace(cols[1])
+        if left == "" || right == "" {
+            continue
+        }
+        pairs = append(pairs, AtomPair{Left: left, Right: right})
+    }
+    return pairs
 }
 
 func (vm *WamState) applyForeignResult(predKey string, resultRegs []int, result Value) bool {

--- a/templates/targets/go_wam/runtime.go.mustache
+++ b/templates/targets/go_wam/runtime.go.mustache
@@ -3,6 +3,7 @@ package {{package_name}}
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"runtime"
 	"sort"
 	"strings"
@@ -12,6 +13,7 @@ import (
 var (
 	_ = fmt.Sprintf
 	_ = os.ReadFile
+	_ = exec.Command
 	_ = runtime.GOMAXPROCS
 	_ = strings.Split
 	_ sync.Locker = (*sync.Mutex)(nil)

--- a/tests/test_wam_go_foreign_lowering.pl
+++ b/tests/test_wam_go_foreign_lowering.pl
@@ -129,11 +129,19 @@ test(tsv_atom_fact2_setup_generation) :-
     wam_go_target:go_foreign_setup_line(register_tsv_atom_fact2(edge/2, '/tmp/edge.tsv'), Line),
     assertion(Line == '    if err := vm.registerTsvAtomFact2("edge/2", "/tmp/edge.tsv"); err != nil { panic(err) }').
 
+test(lmdb_atom_fact2_setup_generation) :-
+    wam_go_target:go_foreign_setup_line(register_lmdb_atom_fact2(edge/2, '/tmp/edge_artifact'), Line),
+    assertion(Line == '    if err := vm.registerLmdbAtomFact2("edge/2", "/tmp/edge_artifact"); err != nil { panic(err) }').
+
 test(atom_fact2_source_registry_runtime_shape) :-
     wam_go_target:compile_wam_runtime_to_go([], RuntimeCode),
     atom_string(RuntimeCode, Runtime),
     assertion(sub_string(Runtime, _, _, _, 'type staticAtomFact2Source struct')),
     assertion(sub_string(Runtime, _, _, _, 'func newStaticAtomFact2Source(pairs []AtomPair) *staticAtomFact2Source')),
+    assertion(sub_string(Runtime, _, _, _, 'type lmdbAtomFact2Source struct')),
+    assertion(sub_string(Runtime, _, _, _, 'func newLmdbAtomFact2Source(predKey string, artifactDir string) *lmdbAtomFact2Source')),
+    assertion(sub_string(Runtime, _, _, _, 'func (vm *WamState) registerLmdbAtomFact2(predKey string, artifactDir string) error')),
+    assertion(sub_string(Runtime, _, _, _, 'exec.Command(source.helperBin, args...).Output()')),
     assertion(sub_string(Runtime, _, _, _, 'func (vm *WamState) registerAtomFact2Source(predKey string, source AtomFact2Source)')),
     assertion(sub_string(Runtime, _, _, _, 'pairs = source.LookupArg1(key)')),
     read_file_to_string('templates/targets/go_wam/state.go.mustache', State, []),
@@ -302,6 +310,40 @@ func TestForeignGraphKernels(t *testing.T) {
     }
     if got, ok := tsvVM.deref(tsvTarget).(*Atom); !ok || got.Name != "z" {
         t.Fatalf("expected second tsv target z, got %#v", tsvVM.deref(tsvTarget))
+    }
+
+    helperPath := filepath.Join(t.TempDir(), "lmdb_relation_artifact_mock")
+    helperScript := "#!/bin/sh\\n" +
+        "if [ \\"$1\\" = \\"get\\" ]; then\\n" +
+        "  if [ \\"$4\\" = \\"x\\" ]; then printf \\"x\\\\ty\\\\nx\\\\tz\\\\n\\"; fi\\n" +
+        "elif [ \\"$1\\" = \\"scan\\" ]; then\\n" +
+        "  printf \\"x\\\\ty\\\\nx\\\\tz\\\\na\\\\tb\\\\n\\"\\n" +
+        "fi\\n"
+    if err := os.WriteFile(helperPath, []byte(helperScript), 0755); err != nil {
+        t.Fatalf("write lmdb helper mock: %v", err)
+    }
+    t.Setenv("UW_LMDB_RELATION_ARTIFACT_BIN", helperPath)
+    lmdbVM := NewWamState([]Instruction{&CallIndexedAtomFact2{Pred: "lmdb_edge/2"}, &Proceed{}}, map[string]int{})
+    if err := lmdbVM.registerLmdbAtomFact2("lmdb_edge/2", filepath.Join(t.TempDir(), "edge_artifact")); err != nil {
+        t.Fatalf("register lmdb facts: %v", err)
+    }
+    if _, ok := lmdbVM.Ctx.AtomFact2Sources["lmdb_edge/2"]; !ok {
+        t.Fatalf("expected LMDB source to register through AtomFact2Sources")
+    }
+    lmdbTarget := &Unbound{Name: "LMDB_TARGET", Idx: 1}
+    lmdbVM.Regs[0] = internAtom("x")
+    lmdbVM.Regs[1] = lmdbTarget
+    if !lmdbVM.Run() {
+        t.Fatalf("lmdb-backed call_indexed_atom_fact2 failed")
+    }
+    if got, ok := lmdbVM.deref(lmdbTarget).(*Atom); !ok || got.Name != "y" {
+        t.Fatalf("expected first lmdb target y, got %#v", lmdbVM.deref(lmdbTarget))
+    }
+    if !lmdbVM.backtrack() {
+        t.Fatalf("expected second lmdb fact result")
+    }
+    if got, ok := lmdbVM.deref(lmdbTarget).(*Atom); !ok || got.Name != "z" {
+        t.Fatalf("expected second lmdb target z, got %#v", lmdbVM.deref(lmdbTarget))
     }
 
     factVM := NewWamState([]Instruction{&CallIndexedAtomFact2{Pred: "edge/2"}, &Proceed{}}, map[string]int{})


### PR DESCRIPTION
## Summary

- Adds `register_lmdb_atom_fact2(...)` setup generation for Go WAM foreign setup specs.
- Adds generated Go `registerLmdbAtomFact2` and an `lmdbAtomFact2Source` implementing the existing `AtomFact2Source` interface.
- Dispatches LMDB-backed `Scan` and `LookupArg1` through the existing `lmdb_relation_artifact` helper command, avoiding a new generated-project Go dependency.
- Supports `UW_LMDB_RELATION_ARTIFACT_BIN` so deployments or tests can provide the concrete helper path.
- Adds generated-Go E2E coverage using a mock LMDB artifact helper.
- Updates the Go parity audit to mark direct external atom fact-source support as covered for the current baseline, while leaving an optional native Go LMDB binding as a future dependency-policy decision.

## Verification

```sh
swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl
swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl tests/test_wam_go_generator.pl tests/test_go_wam_builtins.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"
git diff --check
```

## Follow-Up

- Consider an optional native Go LMDB build-tag implementation if the project settles on a Go LMDB dependency policy.
