### PR TITLE
bench(csharp-query): document million LMDB probe

### DIFF
--- a/docs/targets/csharp-query-high-performance-sources.md
+++ b/docs/targets/csharp-query-high-performance-sources.md
@@ -293,6 +293,12 @@ need manual override:
   `--artifact-root` and reuses existing backend artifacts by default; use
   `--refresh-artifacts` to rebuild, matching the Haskell benchmark's explicit
   LMDB refresh convention.
+  The first local 1M enwiki-capped probe kept the same policy conclusion:
+  `mmap-array` won lookup and bucket access, `preload` won full scan, and LMDB
+  was smaller than binary/delimited artifacts but larger and slower than the
+  fixed-width mmap array for this arity-2 support relation. Treat LMDB as a
+  large-data comparison point or dependency-backed alternative here, not a
+  default `auto` policy winner yet.
   Haskell's LMDB cache modes remain a higher-level query-locality policy; this
   C# query benchmark intentionally isolates backend scan, lookup, and bucket
   access before adding cache-policy comparisons.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -278,6 +278,17 @@ python examples/benchmark/benchmark_csharp_query_effective_distance_artifact_bac
 fields, which is more useful when deciding whether LMDB is competitive at a
 larger scale.
 
+On this checkout's first 1M enwiki-capped probe, `mmap-array` still won lookup
+and bucket access, while `preload` won full scan. LMDB remained smaller than
+binary and delimited artifacts, but did not beat mmap-array on access time:
+
+| Scale | Best lookup | Best bucket | Best scan | LMDB artifact bytes | Mmap-array artifact bytes | LMDB lookup ms | Mmap-array lookup ms |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: |
+| `rust_lmdb_1m` | `mmap-array` | `mmap-array` | `preload` | 53,432,717 | 8,000,569 | 5.464 | 2.296 |
+
+That means the measured 1M result is still a benchmark result, not a reason to
+promote LMDB into the default `auto` policy for this arity-2 support relation.
+
 Pass `--artifact-root <dir>` to keep backend artifacts across benchmark runs.
 Existing binary, delimited, LMDB, and mmap-array manifests are reused by
 default, matching the Haskell benchmark convention of not regenerating LMDB


### PR DESCRIPTION
  ## Summary

  - Document the first 1M enwiki-capped Rust LMDB probe result.
  - Record that `mmap-array` still wins lookup and bucket access, while `preload` wins full scan.
  - Clarify that LMDB remains a large-data comparison point for this arity-2 support relation, not a default `auto` policy
  winner yet.

  ## Verification

  - `git diff --check`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py examples/
  benchmark/benchmark_csharp_query_rust_lmdb_sink.py examples/benchmark/prepare_csharp_query_enwiki_category_fixture.py`
  - Live 1M LMDB-only probe under `/tmp`
  - Live 1M full backend comparison under `/tmp`