### PR TITLE
perf(wam-c): compact lowered helper rows

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,7 +5,7 @@ Status date: 2026-05-16
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `736d0b02` (`Merge pull request #2152 from s243a/feat/wam-c-lowered-helper-larger-scale-calibration`)
+- `main` at `db35f30c` (`Merge pull request #2159 from s243a/perf/wam-c-lowered-helper-indexed-rows`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
@@ -15,7 +15,7 @@ Base verified locally:
 
 Active branch:
 
-- `perf/wam-c-lowered-helper-indexed-rows`
+- `perf/wam-c-lowered-helper-compile-size`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -63,7 +63,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper scaled benchmark workload | Done | `dev` emits 16 normalized rows and `10x` emits 160 rows for the same projection-shape workload, with interpreted and lowered output hashes matching per scale |
 | Lowered helper scale regression coverage | Done | `tests/test_wam_c_lowered_helper_scale_regression.py` pins `dev`/`10x` row counts and interpreted/lowered hash parity |
 | Lowered helper larger-scale calibration | Done | Self-contained lowered-helper scales no longer require matching `data/benchmark/<scale>` directories; `25x`, `100x`, and `1k` preserve output parity |
-| Lowered helper indexed row dispatch | In progress | Active branch adds first-argument hash-bucket dispatch for lowered fact/filter helper rows while preserving the unbound-argument fallback |
+| Lowered helper indexed row dispatch | Done | First-argument hash-bucket dispatch preserves unbound-argument fallback and gives `1k` lowered-helper runtime around 5.8x faster than interpreted in local calibration |
+| Lowered helper compile/code-size compaction | In progress | Active branch emits compact static row tables plus bucket row-index arrays instead of duplicating full row-check code per generated row |
 
 ## Current C Target Baseline
 
@@ -144,23 +145,65 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `perf/wam-c-lowered-helper-indexed-rows`
+### 1. `perf/wam-c-lowered-helper-compile-size`
 
-Goal: make native lowered-helper row lookup fast enough at larger scales before
-expanding routine validation.
+Goal: reduce generated lowered-helper C size and compile cost before promoting
+larger scales into routine validation.
 
 Scope:
 
-- Generate a first-argument hash-bucket dispatch path for lowered fact,
-  filtered-fact, and comparison-filter helper rows.
-- Preserve the existing full row scan for unbound first arguments so generator
-  semantics do not change.
-- Re-run the `25x`, `100x`, and `1k` calibration before promoting any larger
-  routine scale.
+- Emit compact static row tables for lowered fact, filtered-fact, and
+  comparison-filter helpers.
+- Keep the first-argument hash-bucket runtime dispatch by storing compact
+  bucket row-index arrays.
+- Measure generated `lib.c` size and compile time for `100x` and `1k` lowered
+  helper projects.
 
 Status: active.
 
-Baseline calibration before indexed row dispatch:
+Compile/code-size baseline after indexed row dispatch but before compaction:
+
+| Scale | `lib.c` size | Compile real time |
+|---|---:|---:|
+| `100x` | 5,120,321 bytes | 33.77s |
+| `1k` | 12,750,113 bytes | 151.75s |
+
+Current active-branch compile/code-size result with compact row tables:
+
+| Scale | `lib.c` size | Compile real time |
+|---|---:|---:|
+| `100x` | 1,123,743 bytes | 0.51s |
+| `1k` | 2,601,727 bytes | 0.98s |
+
+Runtime calibration after compaction:
+
+`python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 25x,100x,1k --target-sets c-wam-lowered-helper --repetitions 3 --baseline-target c-wam-lowered-helper-interpreted`
+
+| Scale | Rows | Output parity | Lowered median | Interpreted median | Lowered speedup vs interpreted |
+|---|---:|---:|---:|---:|---:|
+| `25x` | 400 | match | 0.002s | 0.003s | 1.25x |
+| `100x` | 1600 | match | 0.003s | 0.007s | 2.46x |
+| `1k` | 4000 | match | 0.005s | 0.030s | 5.89x |
+
+The compact representation preserves the indexed runtime win while making `1k`
+compilation routine-scale again.
+
+### 2. `test/wam-c-lowered-helper-larger-scale-regression`
+
+Goal: decide and pin the cheapest larger-scale regression point now that
+runtime and compile cost are both acceptable.
+
+Scope:
+
+- Compare `100x` and `1k` wall-clock cost in the normal matrix path.
+- Add a focused local regression for the selected scale if it is cheap enough
+  for routine validation.
+- Keep GitHub Actions out of scope unless the target surface becomes stable
+  enough that CI failures are likely actionable.
+
+## Historical Calibration
+
+Before indexed row dispatch:
 
 `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 25x,100x,1k --target-sets c-wam-lowered-helper --repetitions 3 --baseline-target c-wam-lowered-helper-interpreted`
 
@@ -170,14 +213,7 @@ Baseline calibration before indexed row dispatch:
 | `100x` | 1600 | match | 0.026s | 0.008s | 0.30x |
 | `1k` | 4000 | match | 0.179s | 0.030s | 0.17x |
 
-The useful result is correctness, not speed. The current lowered helper emits
-native row checks that preserve output parity, but it is slower than the
-interpreted path at larger scales, so there is no strong reason to promote
-`1k` into routine regression coverage yet.
-
-Current active-branch calibration with hash-bucket row dispatch:
-
-`python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 25x,100x,1k --target-sets c-wam-lowered-helper --repetitions 3 --baseline-target c-wam-lowered-helper-interpreted`
+After hash-bucket row dispatch but before compact row tables:
 
 | Scale | Rows | Output parity | Lowered median | Interpreted median | Lowered speedup vs interpreted |
 |---|---:|---:|---:|---:|---:|
@@ -185,27 +221,9 @@ Current active-branch calibration with hash-bucket row dispatch:
 | `100x` | 1600 | match | 0.004s | 0.008s | 1.81x |
 | `1k` | 4000 | match | 0.005s | 0.031s | 5.79x |
 
-The runtime result is now strong enough to justify the native row dispatch path.
-The remaining concern is generated C compile/code-size cost at larger scales,
-which was noticeable during the full calibration sweep.
-
-### 2. `perf/wam-c-lowered-helper-compile-size`
-
-Goal: reduce generated lowered-helper C size and compile cost before promoting
-larger scales into routine validation.
-
-Scope:
-
-- Measure generated `lib.c` size and compile time for `100x` and `1k` lowered
-  helper projects.
-- Look for compact static row-table emission or shared row-check helpers that
-  preserve the hash-bucket runtime win.
-- Only then decide whether `1k` belongs in routine local regression coverage.
-
 ## Suggested Immediate Next Step
 
-Continue validating `perf/wam-c-lowered-helper-indexed-rows`.
+Continue validating `perf/wam-c-lowered-helper-compile-size`.
 
-The active branch now has a clear runtime win at `1k`; validate the generated
-code shape, then keep compile/code-size work separate unless a small obvious
-cleanup appears.
+The active branch now has both runtime and compile-time evidence. If the final
+focused gates stay green, it should be ready for PR.

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -421,18 +421,144 @@ lowered_fact_helper_for_predicate(PredIndicator, Rows, Key, Code, SetupLine) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),
     format(atom(Key), '~w/~w', [Pred, Arity]),
     wam_c_symbol_name(Pred, Arity, Symbol),
-    wam_c_lowered_fact_dispatch(Arity, Rows, BodyCode),
-    format(atom(Code),
-'static bool ~w(WamState *state, const char *pred, int arity) {
-    (void)pred;
-    if (arity != ~w) return false;
-~w
-    return false;
-}',
-           [Symbol, Arity, BodyCode]),
+    wam_c_lowered_fact_helper_code(Symbol, Arity, Rows, Code),
     format(atom(SetupLine),
            '    wam_register_foreign_predicate(state, "~w", ~w, ~w);',
            [Key, Arity, Symbol]).
+
+wam_c_lowered_fact_helper_code(Symbol, 0, Rows, Code) :-
+    !,
+    wam_c_lowered_fact_dispatch(0, Rows, BodyCode),
+    format(atom(Code),
+'static bool ~w(WamState *state, const char *pred, int arity) {
+    (void)pred;
+    if (arity != 0) return false;
+~w
+    return false;
+}',
+           [Symbol, BodyCode]).
+wam_c_lowered_fact_helper_code(Symbol, Arity, Rows, Code) :-
+    Arity > 0,
+    length(Rows, RowCount),
+    format(atom(RowTableSymbol), '~w_rows', [Symbol]),
+    format(atom(ScanSymbol), '~w_scan_rows', [Symbol]),
+    wam_c_lowered_static_row_table(RowTableSymbol, Arity, Rows, RowTableCode),
+    lowered_fact_bucket_arrays(Symbol, Rows, BucketArraysCode, DispatchCasesCode, BucketCount),
+    Mask is BucketCount - 1,
+    format(atom(Code),
+'~w
+
+static bool ~w(WamState *state, WamValue **cells, const int *row_indices, int row_count) {
+    for (int row_pos = 0; row_pos < row_count; row_pos++) {
+        int row_index = row_indices ? row_indices[row_pos] : row_pos;
+        bool match = true;
+        for (int col = 0; col < ~w; col++) {
+            if (!val_is_unbound(*cells[col]) && !val_equal(*cells[col], ~w[row_index][col])) {
+                match = false;
+                break;
+            }
+        }
+        if (match) {
+            for (int col = 0; col < ~w; col++) {
+                if (val_is_unbound(*cells[col])) {
+                    trail_binding(state, cells[col]);
+                    *cells[col] = ~w[row_index][col];
+                }
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
+~w
+
+static bool ~w(WamState *state, const char *pred, int arity) {
+    (void)pred;
+    if (arity != ~w) return false;
+    WamValue *cells[~w];
+    for (int i = 0; i < ~w; i++) cells[i] = wam_deref_ptr(state, &state->A[i]);
+    if (!val_is_unbound(*cells[0])) {
+        unsigned int bucket = 0;
+        if (cells[0]->tag == VAL_ATOM) {
+            bucket = wam_hash_string(cells[0]->data.atom) & ~w;
+        } else if (cells[0]->tag == VAL_INT) {
+            bucket = ((unsigned int)cells[0]->data.integer * 2654435761u) & ~w;
+        } else {
+            return false;
+        }
+        switch (bucket) {
+~w
+        default:
+            return false;
+        }
+    }
+    return ~w(state, cells, NULL, ~w);
+}',
+           [RowTableCode, ScanSymbol, Arity, RowTableSymbol, Arity, RowTableSymbol,
+            BucketArraysCode, Symbol, Arity, Arity, Arity, Mask, Mask, DispatchCasesCode,
+            ScanSymbol, RowCount]).
+
+wam_c_lowered_static_row_table(RowTableSymbol, Arity, Rows, Code) :-
+    maplist(wam_c_lowered_static_row, Rows, RowCodes),
+    atomic_list_concat(RowCodes, ',\n', RowInitCode),
+    format(atom(Code),
+'static const WamValue ~w[][~w] = {
+~w
+};',
+           [RowTableSymbol, Arity, RowInitCode]).
+
+wam_c_lowered_static_row(Args, Code) :-
+    maplist(c_static_value_literal, Args, ValueCodes),
+    atomic_list_concat(ValueCodes, ', ', ValuesCode),
+    format(atom(Code), '    { ~w }', [ValuesCode]).
+
+c_static_value_literal(Atom, Lit) :-
+    atom(Atom),
+    !,
+    format(atom(Lit), '{ .tag = VAL_ATOM, .data.atom = "~w" }', [Atom]).
+c_static_value_literal(Int, Lit) :-
+    integer(Int),
+    format(atom(Lit), '{ .tag = VAL_INT, .data.integer = ~w }', [Int]).
+
+lowered_fact_bucket_arrays(Symbol, Rows, ArraysCode, CasesCode, BucketCount) :-
+    findall(First, member([First|_], Rows), FirstValues0),
+    sort(FirstValues0, FirstValues),
+    length(FirstValues, FirstValueCount),
+    lowered_fact_bucket_count(FirstValueCount, BucketCount),
+    findall(Bucket,
+            lowered_fact_bucket_for_values(FirstValues, BucketCount, Bucket),
+            Buckets),
+    findall(ArrayCode-CaseCode,
+            (   member(Bucket, Buckets),
+                lowered_fact_bucket_row_indices(Rows, BucketCount, Bucket, RowIndices),
+                lowered_fact_bucket_symbols(Symbol, Bucket, ArraySymbol),
+                lowered_fact_bucket_array(ArraySymbol, RowIndices, ArrayCode),
+                length(RowIndices, RowIndexCount),
+                format(atom(CaseCode),
+'        case ~w:
+            return ~w_scan_rows(state, cells, ~w, ~w);',
+                       [Bucket, Symbol, ArraySymbol, RowIndexCount])
+            ),
+            Pairs),
+    findall(Array, member(Array-_, Pairs), Arrays),
+    findall(Case, member(_-Case, Pairs), Cases),
+    atomic_list_concat(Arrays, '\n', ArraysCode),
+    atomic_list_concat(Cases, '\n', CasesCode).
+
+lowered_fact_bucket_row_indices(Rows, BucketCount, Bucket, RowIndices) :-
+    findall(Index,
+            (   nth0(Index, Rows, [First|_]),
+                lowered_fact_first_arg_bucket(First, BucketCount, Bucket)
+            ),
+            RowIndices).
+
+lowered_fact_bucket_symbols(Symbol, Bucket, ArraySymbol) :-
+    format(atom(ArraySymbol), '~w_bucket_~w_rows', [Symbol, Bucket]).
+
+lowered_fact_bucket_array(ArraySymbol, RowIndices, Code) :-
+    atomic_list_concat(RowIndices, ', ', RowIndexCode),
+    format(atom(Code), 'static const int ~w[] = { ~w };', [ArraySymbol, RowIndexCode]).
 
 lowered_body_call_helper(PredIndicator, AvailableKeys, CalleeKey, CalleeArity) :-
     predicate_indicator_parts(PredIndicator, _Module, Pred, Arity),

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -338,7 +338,9 @@ test_lowered_fact_helper_generation :-
         sub_string(LibS, _, _, _, 'if (!val_is_unbound(*cells[0]))'),
         sub_string(LibS, _, _, _, 'bucket = wam_hash_string(cells[0]->data.atom)'),
         sub_string(LibS, _, _, _, 'switch (bucket)'),
-        sub_string(LibS, _, _, _, 'if (val_equal(*cells[0], val_atom("a")))'),
+        sub_string(LibS, _, _, _, 'static const WamValue wam_c_lowered_wam_c_lowered_pair_2_rows[][2]'),
+        sub_string(LibS, _, _, _, 'wam_c_lowered_wam_c_lowered_pair_2_scan_rows'),
+        sub_string(LibS, _, _, _, '.data.atom = "a"'),
         sub_string(LibS, _, _, _, 'void setup_lowered_wam_c_helpers'),
         sub_string(LibS, _, _, _, 'wam_register_foreign_predicate(state, "wam_c_lowered_pair/2", 2'),
         sub_string(LibS, _, _, _, 'INSTR_CALL_FOREIGN'),
@@ -561,9 +563,9 @@ test_lowered_filtered_fact_helper_generation :-
         sub_string(LibS, _, _, _, '// - lowered wam_c_filter_keep/1: filtered_fact'),
         sub_string(LibS, _, _, _, 'static bool wam_c_lowered_wam_c_filter_keep_1'),
         sub_string(LibS, _, _, _, 'if (!val_is_unbound(*cells[0]))'),
-        sub_string(LibS, _, _, _, 'if (val_equal(*cells[0], val_atom("a")))'),
-        sub_string(LibS, _, _, _, 'val_atom("a")'),
-        sub_string(LibS, _, _, _, 'val_atom("c")'),
+        sub_string(LibS, _, _, _, 'wam_c_lowered_wam_c_filter_keep_1_scan_rows'),
+        sub_string(LibS, _, _, _, '.data.atom = "a"'),
+        sub_string(LibS, _, _, _, '.data.atom = "c"'),
         sub_string(LibS, _, _, _, '.pred = "wam_c_filter_keep/1"')
     ->  pass(Test)
     ;   fail_test(Test, 'lowered filtered fact helper was not emitted')
@@ -597,8 +599,8 @@ test_lowered_comparison_filter_helper_generation :-
         read_file_to_string(LibPath, LibS, []),
         sub_string(LibS, _, _, _, '// - lowered wam_c_filter_small/1: comparison_filtered_fact'),
         sub_string(LibS, _, _, _, 'static bool wam_c_lowered_wam_c_filter_small_1'),
-        sub_string(LibS, _, _, _, 'val_atom("a")'),
-        sub_string(LibS, _, _, _, 'val_atom("b")'),
+        sub_string(LibS, _, _, _, '.data.atom = "a"'),
+        sub_string(LibS, _, _, _, '.data.atom = "b"'),
         sub_string(LibS, _, _, _, '.pred = "wam_c_filter_small/1"')
     ->  pass(Test)
     ;   fail_test(Test, 'lowered comparison-filter helper was not emitted')
@@ -644,7 +646,7 @@ test_lowered_repeated_variable_filter_generation :-
         sub_string(LibS, _, _, _, '// - lowered wam_c_repeat_small/1: comparison_filtered_fact'),
         sub_string(LibS, _, _, _, 'static bool wam_c_lowered_wam_c_repeat_keep_1'),
         sub_string(LibS, _, _, _, 'static bool wam_c_lowered_wam_c_repeat_small_1'),
-        sub_string(LibS, _, _, _, 'val_atom("a")')
+        sub_string(LibS, _, _, _, '.data.atom = "a"')
     ->  pass(Test)
     ;   fail_test(Test, 'repeated-variable filter helpers did not preserve row constraints')
     ),


### PR DESCRIPTION
# Compact WAM-C lowered-helper row emission

## Summary

- Replace duplicated lowered-helper row-check code with compact static `WamValue` row tables.
- Preserve first-argument hash-bucket dispatch using compact bucket row-index arrays.
- Update WAM-C generation assertions to pin the compact table and scan-helper shape.
- Refresh the WAM-C roadmap with compile-size, compile-time, and runtime calibration results.

## Validation

- `python3 tests/test_benchmark_target_matrix.py`
- `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/test_wam_c_lowered_helper_scale_regression.py`
- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 25x,100x,1k --target-sets c-wam-lowered-helper --repetitions 3 --baseline-target c-wam-lowered-helper-interpreted`
- `git diff --check`

## Calibration

- `100x` generated `lib.c`: `5,120,321` bytes -> `1,123,743` bytes; compile `33.77s` -> `0.51s`.
- `1k` generated `lib.c`: `12,750,113` bytes -> `2,601,727` bytes; compile `151.75s` -> `0.98s`.
- `1k` lowered-helper runtime parity still matches interpreted mode; lowered median was `0.005s` versus interpreted `0.030s`.
