### PR TITLE
feat(wam-clojure): add nth0 builtin

### DIFF
--- a/PR_WAM_CLOJURE_NTH0_BUILTIN.md
+++ b/PR_WAM_CLOJURE_NTH0_BUILTIN.md
@@ -1,0 +1,26 @@
+# PR Title
+
+feat(wam-clojure): add nth0/3 builtin
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM support for `nth0/3`.
+- Reuses the existing proper-list conversion and unification helpers.
+- Direct-lowers `nth0/3` to a runtime helper instead of stepping through the interpreted builtin path.
+- Fails cleanly for negative, out-of-range, unbound, or non-integer indexes and for improper or unbound input lists.
+- Adds lowered-emitter and runtime smoke coverage.
+
+## Semantics
+
+`nth0/3` accepts a non-negative integer index in the first argument and a proper list in the second argument, then unifies the third argument with the item at that zero-based index.
+
+This initial Clojure WAM implementation is deterministic and conservative: it supports the common `(+Index, +List, ?Elem)` mode and fails for unbound index/list arguments rather than enumerating indexes or generating lists relationally.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -396,6 +396,10 @@ clojure_direct_builtin("last/2", "2").
 clojure_direct_builtin("last/2", 2).
 clojure_direct_builtin('last/2', "2").
 clojure_direct_builtin('last/2', 2).
+clojure_direct_builtin("nth0/3", "3").
+clojure_direct_builtin("nth0/3", 3).
+clojure_direct_builtin('nth0/3', "3").
+clojure_direct_builtin('nth0/3', 3).
 clojure_direct_builtin("sort/2", "2").
 clojure_direct_builtin("sort/2", 2).
 clojure_direct_builtin('sort/2', "2").
@@ -679,6 +683,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "last/2" ; Op == 'last/2'),
     !,
     format(atom(Expr), '(runtime/apply-last-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "nth0/3" ; Op == 'nth0/3'),
+    !,
+    format(atom(Expr), '(runtime/apply-nth0-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "sort/2" ; Op == 'sort/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -788,6 +788,24 @@
         (backtrack state))
       (backtrack state))))
 
+(defn apply-nth0-solution [state]
+  (let [index-value (deref-value (:bindings state)
+                                 (or (reg-get-raw state "A1") ::unbound))
+        list-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A2") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A3") ::unbound))]
+    (if (and (integer? index-value) (not (neg? index-value)))
+      (if-let [items (proper-list-items state list-value)]
+        (if (< index-value (count items))
+          (let [[ok next-state] (unify-values state out (nth items index-value))]
+            (if ok
+              (advance next-state)
+              (backtrack state)))
+          (backtrack state))
+        (backtrack state))
+      (backtrack state))))
+
 (defn apply-sort-solution [state]
   (let [list-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A1") ::unbound))
@@ -1571,6 +1589,9 @@
 
           "last/2"
           (apply-last-solution state)
+
+          "nth0/3"
+          (apply-nth0-solution state)
 
           "sort/2"
           (apply-sort-solution state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -568,6 +568,15 @@ test(simple_builtin_last_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_nth0_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_nth0/3:\nbuiltin_call nth0/3, 3\nproceed\n",
+        wam_clojure_lowerable(test_nth0/3, WamCode, deterministic),
+        lower_predicate_to_clojure(test_nth0/3, WamCode, [], Code),
+        has(Code, "runtime/apply-nth0-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_sort_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_sort/2:\nbuiltin_call sort/2, 2\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -91,6 +91,12 @@
 :- dynamic user:wam_last_empty/1.
 :- dynamic user:wam_last_bad_list/1.
 :- dynamic user:wam_last_unbound_list/1.
+:- dynamic user:wam_nth0_guard/3.
+:- dynamic user:wam_nth0_negative/1.
+:- dynamic user:wam_nth0_out_of_range/1.
+:- dynamic user:wam_nth0_bad_list/1.
+:- dynamic user:wam_nth0_unbound_index/1.
+:- dynamic user:wam_nth0_unbound_list/1.
 :- dynamic user:wam_sort_guard/2.
 :- dynamic user:wam_sort_bad_list/1.
 :- dynamic user:wam_sort_unbound_list/1.
@@ -226,6 +232,12 @@ user:wam_last_guard(L, X) :- last(L, X).
 user:wam_last_empty(X) :- last([], X).
 user:wam_last_bad_list(X) :- last([a|b], X).
 user:wam_last_unbound_list(X) :- user:wam_unbound_arg(L), last(L, X).
+user:wam_nth0_guard(N, L, X) :- nth0(N, L, X).
+user:wam_nth0_negative(X) :- nth0(-1, [a,b,c], X).
+user:wam_nth0_out_of_range(X) :- nth0(3, [a,b,c], X).
+user:wam_nth0_bad_list(X) :- nth0(1, [a|b], X).
+user:wam_nth0_unbound_index(X) :- user:wam_unbound_arg(N), nth0(N, [a,b,c], X).
+user:wam_nth0_unbound_list(X) :- user:wam_unbound_arg(L), nth0(0, L, X).
 user:wam_sort_guard(L, S) :- sort(L, S).
 user:wam_sort_bad_list(S) :- sort([a|b], S).
 user:wam_sort_unbound_list(S) :- user:wam_unbound_arg(L), sort(L, S).
@@ -366,6 +378,12 @@ run_smoke :-
           user:wam_last_empty/1,
           user:wam_last_bad_list/1,
           user:wam_last_unbound_list/1,
+          user:wam_nth0_guard/3,
+          user:wam_nth0_negative/1,
+          user:wam_nth0_out_of_range/1,
+          user:wam_nth0_bad_list/1,
+          user:wam_nth0_unbound_index/1,
+          user:wam_nth0_unbound_list/1,
           user:wam_sort_guard/2,
           user:wam_sort_bad_list/1,
           user:wam_sort_unbound_list/1,
@@ -444,6 +462,7 @@ run_smoke :-
     assert_lowered_append_builtin_emitted(TmpDir),
     assert_lowered_reverse_builtin_emitted(TmpDir),
     assert_lowered_last_builtin_emitted(TmpDir),
+    assert_lowered_nth0_builtin_emitted(TmpDir),
     assert_lowered_sort_builtin_emitted(TmpDir),
     assert_lowered_msort_builtin_emitted(TmpDir),
     assert_lowered_copy_term_builtin_emitted(TmpDir),
@@ -615,6 +634,15 @@ smoke_cases([
     case('wam_last_empty/1', a, "false"),
     case('wam_last_bad_list/1', a, "false"),
     case('wam_last_unbound_list/1', a, "false"),
+    case('wam_nth0_guard/3', args(0, '[a,b,c]', a), "true"),
+    case('wam_nth0_guard/3', args(1, '[a,b,c]', b), "true"),
+    case('wam_nth0_guard/3', args(2, '[a,b,c]', c), "true"),
+    case('wam_nth0_guard/3', args(1, '[a,b,c]', c), "false"),
+    case('wam_nth0_negative/1', a, "false"),
+    case('wam_nth0_out_of_range/1', a, "false"),
+    case('wam_nth0_bad_list/1', a, "false"),
+    case('wam_nth0_unbound_index/1', a, "false"),
+    case('wam_nth0_unbound_list/1', a, "false"),
     case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b,c]'), "true"),
     case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b]'), "false"),
     case('wam_sort_guard/2', args('[f(b),f(a),a]', '[a,f(a),f(b)]'), "true"),
@@ -880,6 +908,17 @@ assert_lowered_last_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-last-bad-list-1"),
     has(CoreCode, "defn lowered-wam-last-unbound-list-1"),
     has(CoreCode, "runtime/apply-last-solution").
+
+assert_lowered_nth0_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-nth0-guard-3"),
+    has(CoreCode, "defn lowered-wam-nth0-negative-1"),
+    has(CoreCode, "defn lowered-wam-nth0-out-of-range-1"),
+    has(CoreCode, "defn lowered-wam-nth0-bad-list-1"),
+    has(CoreCode, "defn lowered-wam-nth0-unbound-index-1"),
+    has(CoreCode, "defn lowered-wam-nth0-unbound-list-1"),
+    has(CoreCode, "runtime/apply-nth0-solution").
 
 assert_lowered_sort_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM support for `nth0/3`.
- Reuses the existing proper-list conversion and unification helpers.
- Direct-lowers `nth0/3` to a runtime helper instead of stepping through the interpreted builtin path.
- Fails cleanly for negative, out-of-range, unbound, or non-integer indexes and for improper or unbound input lists.
- Adds lowered-emitter and runtime smoke coverage.

## Semantics

`nth0/3` accepts a non-negative integer index in the first argument and a proper list in the second argument, then unifies the third argument with the item at that zero-based index.

This initial Clojure WAM implementation is deterministic and conservative: it supports the common `(+Index, +List, ?Elem)` mode and fails for unbound index/list arguments rather than enumerating indexes or generating lists relationally.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
