### PR TITLE
feat(csharp-query): clarify mmap array id strategy

### DIFF
--- a/docs/targets/csharp-query-high-performance-sources.md
+++ b/docs/targets/csharp-query-high-performance-sources.md
@@ -178,8 +178,17 @@ manifest should reserve the field from the start:
 }
 ```
 
+The current C# builder only emits `provided_id` artifacts and marks
+`source_ids_preserved` in the manifest. It deliberately rejects `position_id`
+until an explicit intern-table or position-mapping step exists; otherwise the
+manifest would claim remapped IDs while the data still contains source values.
+
 This is likely the right comparison point for effective-distance and graph
-workloads once preprocessing is explicit.
+workloads once preprocessing is explicit. That is workload-specific: LMDB still
+has an important advantage for database-like access patterns because it can
+serve arbitrary B-tree lookups over the stored key space, while the current
+mmap-array provider is intentionally narrow: sorted fixed-width rows, binary
+search on column 0, and bucket streaming in that same order.
 
 ## Hash/Block-Sharded File Path
 

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -336,6 +336,8 @@ namespace UnifyWeaver.QueryRuntime
     public sealed class MmapArrayRelationArtifactManifest
     {
         public const string CurrentFormat = "unifyweaver.mmap_array_relation.v1";
+        public const string ProvidedIdStrategy = "provided_id";
+        public const string PositionIdStrategy = "position_id";
 
         public string Format { get; set; } = CurrentFormat;
 
@@ -351,11 +353,13 @@ namespace UnifyWeaver.QueryRuntime
 
         public long RowCount { get; set; }
 
-        public string IdStrategy { get; set; } = "provided_id";
+        public string IdStrategy { get; set; } = ProvidedIdStrategy;
 
         public int IdWidth { get; set; } = 32;
 
         public string ValueEncoding { get; set; } = "int32_le";
+
+        public bool SourceIdsPreserved { get; set; } = true;
 
         public int SortColumn { get; set; } = 0;
 
@@ -404,9 +408,19 @@ namespace UnifyWeaver.QueryRuntime
                 throw new InvalidDataException($"Mmap array relation artifact row count must be non-negative: {manifestPath}");
             }
 
-            if (IdStrategy is not ("provided_id" or "position_id"))
+            if (IdStrategy is not (ProvidedIdStrategy or PositionIdStrategy))
             {
                 throw new InvalidDataException($"Mmap array relation artifact has unsupported id strategy '{IdStrategy}': {manifestPath}");
+            }
+
+            if (IdStrategy == ProvidedIdStrategy && !SourceIdsPreserved)
+            {
+                throw new InvalidDataException($"Mmap array relation artifact provided_id strategy must preserve source IDs: {manifestPath}");
+            }
+
+            if (IdStrategy == PositionIdStrategy && SourceIdsPreserved)
+            {
+                throw new InvalidDataException($"Mmap array relation artifact position_id strategy must not claim source ID preservation: {manifestPath}");
             }
 
             if (IdWidth != 32 || !string.Equals(ValueEncoding, "int32_le", StringComparison.Ordinal))
@@ -2292,10 +2306,17 @@ namespace UnifyWeaver.QueryRuntime
             DelimitedRelationSource source,
             string artifactDirectory,
             string? artifactName = null,
-            string idStrategy = "provided_id")
+            string idStrategy = MmapArrayRelationArtifactManifest.ProvidedIdStrategy)
         {
             if (artifactDirectory is null) throw new ArgumentNullException(nameof(artifactDirectory));
             Directory.CreateDirectory(artifactDirectory);
+
+            if (idStrategy != MmapArrayRelationArtifactManifest.ProvidedIdStrategy)
+            {
+                throw new NotSupportedException(
+                    "Mmap array relation artifact builder currently supports only provided_id; " +
+                    "position_id requires an explicit intern-table mapping step.");
+            }
 
             if (predicate.Arity != 2 || source.ExpectedWidth != 2)
             {
@@ -2334,6 +2355,7 @@ namespace UnifyWeaver.QueryRuntime
                 IdStrategy = idStrategy,
                 IdWidth = 32,
                 ValueEncoding = "int32_le",
+                SourceIdsPreserved = true,
                 SortColumn = 0,
                 SourcePath = source.InputPath,
                 SourceLength = sourceInfo?.Length,

--- a/tests/test_csharp_query_mmap_array_provider_smoke.py
+++ b/tests/test_csharp_query_mmap_array_provider_smoke.py
@@ -110,6 +110,7 @@ class CSharpQueryMmapArrayProviderSmokeTests(unittest.TestCase):
 
 
 SMOKE_PROGRAM = r"""
+using System.Text.Json;
 using UnifyWeaver.QueryRuntime;
 
 static void Assert(bool condition, string message)
@@ -135,6 +136,21 @@ File.WriteAllLines(sourcePath, new[]
 var predicate = new PredicateId("edge", 2);
 var source = new DelimitedRelationSource(sourcePath, '\t', 1, 2);
 var manifestPath = MmapArrayRelationArtifactBuilder.BuildFromDelimited(predicate, source, Path.Combine(root, "edge-mmap"));
+var manifest = JsonSerializer.Deserialize<MmapArrayRelationArtifactManifest>(File.ReadAllText(manifestPath))
+    ?? throw new InvalidOperationException("manifest did not deserialize");
+Assert(manifest.IdStrategy == MmapArrayRelationArtifactManifest.ProvidedIdStrategy, $"id strategy was {manifest.IdStrategy}");
+Assert(manifest.IdWidth == 32, $"id width was {manifest.IdWidth}");
+Assert(manifest.ValueEncoding == "int32_le", $"value encoding was {manifest.ValueEncoding}");
+Assert(manifest.SourceIdsPreserved, "provided_id manifest did not preserve source IDs");
+
+try
+{
+    MmapArrayRelationArtifactBuilder.BuildFromDelimited(predicate, source, Path.Combine(root, "edge-position-mmap"), idStrategy: MmapArrayRelationArtifactManifest.PositionIdStrategy);
+    throw new InvalidOperationException("position_id builder path should not be implemented without an intern table");
+}
+catch (NotSupportedException)
+{
+}
 
 var provider = new MmapArrayRelationArtifactProvider();
 provider.RegisterArtifact(predicate, manifestPath);


### PR DESCRIPTION
  ## Summary

  - Add explicit mmap-array manifest constants for `provided_id` and `position_id`.
  - Record and validate `SourceIdsPreserved` so `provided_id` artifacts cannot falsely claim remapped IDs.
  - Reject `position_id` builds until an explicit intern-table or position-mapping step exists.
  - Document the workload caveat: LMDB remains useful for database-like B-tree lookup workloads, while the current mmap-array
  path is a narrow fixed-width sorted array backend.

  ## Verification

  - `python3 -m unittest tests/test_csharp_query_mmap_array_provider_smoke.py`
  - `python3 -m unittest tests/test_csharp_query_mmap_array_provider_smoke.py tests/
  test_csharp_query_effective_distance_artifact_backends.py tests/test_csharp_query_lmdb_provider_smoke.py`
  - `python3 -m py_compile tests/test_csharp_query_mmap_array_provider_smoke.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `git diff --check`