### PR TITLE
test(wam-c): pin 100x lowered helper scale

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,7 +5,7 @@ Status date: 2026-05-16
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `db35f30c` (`Merge pull request #2159 from s243a/perf/wam-c-lowered-helper-indexed-rows`)
+- `main` at `ab60ee06` (`Merge pull request #2163 from s243a/perf/wam-c-lowered-helper-compile-size`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
@@ -15,7 +15,7 @@ Base verified locally:
 
 Active branch:
 
-- `perf/wam-c-lowered-helper-compile-size`
+- `test/wam-c-lowered-helper-larger-scale-regression`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -64,7 +64,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper scale regression coverage | Done | `tests/test_wam_c_lowered_helper_scale_regression.py` pins `dev`/`10x` row counts and interpreted/lowered hash parity |
 | Lowered helper larger-scale calibration | Done | Self-contained lowered-helper scales no longer require matching `data/benchmark/<scale>` directories; `25x`, `100x`, and `1k` preserve output parity |
 | Lowered helper indexed row dispatch | Done | First-argument hash-bucket dispatch preserves unbound-argument fallback and gives `1k` lowered-helper runtime around 5.8x faster than interpreted in local calibration |
-| Lowered helper compile/code-size compaction | In progress | Active branch emits compact static row tables plus bucket row-index arrays instead of duplicating full row-check code per generated row |
+| Lowered helper compile/code-size compaction | Done | Compact static row tables plus bucket row-index arrays reduce `1k` generated `lib.c` from 12.8 MB to 2.6 MB and compile time from 151.75s to 0.98s |
+| Lowered helper larger-scale regression | In progress | Active branch promotes `100x` into the focused local lowered-helper parity regression while leaving `1k` as calibration-only because it costs about 31s end to end |
 
 ## Current C Target Baseline
 
@@ -145,21 +146,40 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `perf/wam-c-lowered-helper-compile-size`
+### 1. `test/wam-c-lowered-helper-larger-scale-regression`
 
-Goal: reduce generated lowered-helper C size and compile cost before promoting
-larger scales into routine validation.
+Goal: pin the cheapest useful larger-scale regression point now that runtime
+and compile cost are both acceptable.
 
 Scope:
 
-- Emit compact static row tables for lowered fact, filtered-fact, and
-  comparison-filter helpers.
-- Keep the first-argument hash-bucket runtime dispatch by storing compact
-  bucket row-index arrays.
-- Measure generated `lib.c` size and compile time for `100x` and `1k` lowered
-  helper projects.
+- Add `100x` to the focused local lowered-helper parity regression.
+- Assert interpreted/lowered hash parity and expected row counts for `dev`,
+  `10x`, and `100x`.
+- Keep `1k` as documented calibration-only for now because it costs about 31s
+  in the normal matrix path.
 
 Status: active.
+
+Routine-scale selection:
+
+| Scale | Normal matrix wall-clock | Rows | Decision |
+|---|---:|---:|---|
+| `100x` | 8.53s | 1600 | Promote to local regression |
+| `1k` | 30.84s | 4000 | Keep as calibration-only |
+
+### 2. `feat/wam-c-lowered-helper-next-shape-selection`
+
+Goal: choose the next lowered-helper feature gap now that scaled row dispatch
+has local regression coverage.
+
+Scope:
+
+- Compare remaining C gaps against the Haskell and Rust hybrid WAM examples.
+- Prefer a narrow helper shape or builtin needed by existing benchmark surfaces.
+- Avoid broad CI expansion until the next target surface is stable.
+
+## Completed Calibration
 
 Compile/code-size baseline after indexed row dispatch but before compaction:
 
@@ -168,7 +188,7 @@ Compile/code-size baseline after indexed row dispatch but before compaction:
 | `100x` | 5,120,321 bytes | 33.77s |
 | `1k` | 12,750,113 bytes | 151.75s |
 
-Current active-branch compile/code-size result with compact row tables:
+Compile/code-size result with compact row tables:
 
 | Scale | `lib.c` size | Compile real time |
 |---|---:|---:|
@@ -187,19 +207,6 @@ Runtime calibration after compaction:
 
 The compact representation preserves the indexed runtime win while making `1k`
 compilation routine-scale again.
-
-### 2. `test/wam-c-lowered-helper-larger-scale-regression`
-
-Goal: decide and pin the cheapest larger-scale regression point now that
-runtime and compile cost are both acceptable.
-
-Scope:
-
-- Compare `100x` and `1k` wall-clock cost in the normal matrix path.
-- Add a focused local regression for the selected scale if it is cheap enough
-  for routine validation.
-- Keep GitHub Actions out of scope unless the target surface becomes stable
-  enough that CI failures are likely actionable.
 
 ## Historical Calibration
 
@@ -223,7 +230,8 @@ After hash-bucket row dispatch but before compact row tables:
 
 ## Suggested Immediate Next Step
 
-Continue validating `perf/wam-c-lowered-helper-compile-size`.
+Continue validating `test/wam-c-lowered-helper-larger-scale-regression`.
 
-The active branch now has both runtime and compile-time evidence. If the final
-focused gates stay green, it should be ready for PR.
+The active branch should keep the local regression focused on `100x`; `1k`
+remains useful for occasional calibration but is too slow for routine local
+validation.

--- a/tests/test_wam_c_lowered_helper_scale_regression.py
+++ b/tests/test_wam_c_lowered_helper_scale_regression.py
@@ -13,7 +13,7 @@ MATRIX_SCRIPT = ROOT / "examples" / "benchmark" / "benchmark_effective_distance_
 
 
 class WamCLoweredHelperScaleRegressionTests(unittest.TestCase):
-    def test_dev_and_10x_scales_preserve_lowered_helper_output_parity(self) -> None:
+    def test_dev_10x_and_100x_scales_preserve_lowered_helper_output_parity(self) -> None:
         if shutil.which("swipl") is None:
             self.skipTest("swipl is not available")
         if shutil.which("gcc") is None:
@@ -24,7 +24,7 @@ class WamCLoweredHelperScaleRegressionTests(unittest.TestCase):
                 sys.executable,
                 str(MATRIX_SCRIPT),
                 "--scales",
-                "dev,10x",
+                "dev,10x,100x",
                 "--target-sets",
                 "c-wam-lowered-helper",
                 "--repetitions",
@@ -52,7 +52,7 @@ class WamCLoweredHelperScaleRegressionTests(unittest.TestCase):
             "c-wam-lowered-helper-interpreted",
         }
 
-        for scale, expected_rows in {"dev": 16, "10x": 160}.items():
+        for scale, expected_rows in {"dev": 16, "10x": 160, "100x": 1600}.items():
             rows_for_scale = {
                 row["target"]: row
                 for row in target_rows
@@ -82,10 +82,24 @@ class WamCLoweredHelperScaleRegressionTests(unittest.TestCase):
                 if row["scale"] == "10x" and row["target"] in targets
             },
         )
+        self.assertNotEqual(
+            {
+                row["stdout_sha256"]
+                for row in target_rows
+                if row["scale"] == "10x" and row["target"] in targets
+            },
+            {
+                row["stdout_sha256"]
+                for row in target_rows
+                if row["scale"] == "100x" and row["target"] in targets
+            },
+        )
         self.assertIn("dev\tall_outputs\tmatch", result.stdout)
         self.assertIn("10x\tall_outputs\tmatch", result.stdout)
+        self.assertIn("100x\tall_outputs\tmatch", result.stdout)
         self.assertIn("dev\thybrid-wam-lowered-helper_outputs\tmatch", result.stdout)
         self.assertIn("10x\thybrid-wam-lowered-helper_outputs\tmatch", result.stdout)
+        self.assertIn("100x\thybrid-wam-lowered-helper_outputs\tmatch", result.stdout)
 
     def _parse_target_rows(self, stdout: str) -> list[dict[str, str]]:
         lines = [line for line in stdout.splitlines() if line]


### PR DESCRIPTION
# Pin 100x WAM-C lowered-helper regression coverage

## Summary

- Extend the focused WAM-C lowered-helper scale regression from `dev,10x` to `dev,10x,100x`.
- Assert the expected `100x` row count of `1600` rows for both interpreted and lowered modes.
- Keep interpreted/lowered output hash parity checks per scale.
- Add a distinct hash check so `100x` proves it is exercising a larger generated workload than `10x`.
- Update the WAM-C roadmap to mark compile-size compaction complete and keep `1k` as calibration-only because it costs about 31 seconds in the normal matrix path.

## Validation

- `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/test_wam_c_lowered_helper_scale_regression.py`
- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `git diff --check`

## Scale Decision

- `100x`: about `8.53s` in the normal matrix path, `1600` rows, promoted to local regression.
- `1k`: about `30.84s` in the normal matrix path, `4000` rows, left as calibration-only.
