### PR TITLE
fix(wam-r): allow term_to_atom forward without parser

### DIFF
--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
@@ -85,6 +85,8 @@ When R resolves to `runtime_parser(off)`, the project writer rejects requested
 predicates whose statically visible bodies call parser-dependent builtins, so
 the disabled mode does not silently generate a runtime that still accepts
 source-term parsing calls.
+`term_to_atom/2` is treated mode-sensitively: forward rendering remains valid
+with the parser disabled, while statically visible reverse parsing is rejected.
 
 The hook should be independent of the WAM items API. A target can skip WAM text
 generation at build time and still need runtime source-term parsing.

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -1848,18 +1848,25 @@ r_predicate_clause(Name/Arity, Head, Body) :-
 
 r_goal_uses_parser_builtin(Goal, Builtin) :-
     nonvar(Goal),
-    (   r_goal_builtin_pi(Goal, Builtin),
-        parser_dependent_builtin(Builtin)
+    (   r_goal_parser_dependency(Goal, Builtin)
     ->  true
     ;   r_goal_child(Goal, Child),
         r_goal_uses_parser_builtin(Child, Builtin)
     ).
 
-r_goal_builtin_pi(Module:Goal, Builtin) :-
+r_goal_parser_dependency(Module:Goal, Builtin) :-
     atom(Module),
     nonvar(Goal),
     !,
-    r_goal_builtin_pi(Goal, Builtin).
+    r_goal_parser_dependency(Goal, Builtin).
+r_goal_parser_dependency(term_to_atom(_Term, AtomText), term_to_atom/2) :-
+    !,
+    nonvar(AtomText).
+r_goal_parser_dependency(Goal, Builtin) :-
+    r_goal_builtin_pi(Goal, Builtin),
+    parser_dependent_builtin(Builtin),
+    Builtin \= term_to_atom/2.
+
 r_goal_builtin_pi(Goal, Name/Arity) :-
     callable(Goal),
     functor(Goal, Name, Arity).

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -34,6 +34,8 @@
 :- dynamic user:wam_r_pair/1.
 :- dynamic user:wam_r_list/1.
 :- dynamic user:wam_r_parser_dep/0.
+:- dynamic user:wam_r_t2a_forward/0.
+:- dynamic user:wam_r_t2a_reverse/0.
 
 user:wam_r_fact(a).
 user:wam_r_choice_fact(a).
@@ -134,6 +136,37 @@ test(runtime_parser_off_rejects_parser_dependent_builtin,
             [runtime_parser(off)],
             TmpDir),
         (   retractall(user:wam_r_parser_dep),
+            (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true)
+        )).
+
+test(runtime_parser_off_allows_term_to_atom_forward) :-
+    once((
+        retractall(user:wam_r_t2a_forward),
+        assertz((user:wam_r_t2a_forward :-
+            term_to_atom(f(a), _))),
+        unique_r_tmp_dir('tmp_r_parser_mode_t2a_fwd', TmpDir),
+        call_cleanup(
+            write_wam_r_project(
+                [user:wam_r_t2a_forward/0],
+                [runtime_parser(off)],
+                TmpDir),
+            (   retractall(user:wam_r_t2a_forward),
+                (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true)
+            ))
+    )).
+
+test(runtime_parser_off_rejects_term_to_atom_reverse,
+     [error(permission_error(use, runtime_parser, term_to_atom/2))]) :-
+    retractall(user:wam_r_t2a_reverse),
+    assertz((user:wam_r_t2a_reverse :-
+        term_to_atom(_, 'f(a)'))),
+    unique_r_tmp_dir('tmp_r_parser_mode_t2a_rev', TmpDir),
+    call_cleanup(
+        write_wam_r_project(
+            [user:wam_r_t2a_reverse/0],
+            [runtime_parser(off)],
+            TmpDir),
+        (   retractall(user:wam_r_t2a_reverse),
             (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true)
         )).
 


### PR DESCRIPTION
## Summary

Refines WAM-R `runtime_parser(off)` validation so `term_to_atom/2` is treated mode-sensitively.

Forward `term_to_atom/2` renders a term to text and does not need the runtime parser, so it should remain valid when parser support is disabled. Reverse `term_to_atom/2` parses source text into a term and is still rejected.

## Details

- Updates WAM-R parser-disabled validation to inspect the call shape for `term_to_atom/2`.
- Allows statically visible forward calls such as `term_to_atom(f(a), A)` with `runtime_parser(off)`.
- Rejects statically visible reverse calls such as `term_to_atom(T, 'f(a)')` with `permission_error(use, runtime_parser, term_to_atom/2)`.
- Adds focused WAM-R generator tests for both forward and reverse cases.
- Updates the runtime parser transpilation plan to document the mode-sensitive behavior.

## Verification

- `swipl -q -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:runtime_parser_mode_metadata,wam_r_generator:runtime_parser_mode_option_off,wam_r_generator:runtime_parser_off_rejects_parser_dependent_builtin,wam_r_generator:runtime_parser_off_allows_term_to_atom_forward,wam_r_generator:runtime_parser_off_rejects_term_to_atom_reverse])" -t halt`
- `swipl -q -g run_tests -t halt tests/test_wam_runtime_parser_capability.pl`
- `git diff --check HEAD`

## Notes

This is generation-time validation only. It does not change the R runtime parser implementation.
