### PR TITLE
feat(wam-cpp): numlist/3 + sort/2 + msort/2 + select/3

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -793,6 +793,32 @@ helper_predicate_items(Items) :-
         put_value("X3", "A2"),
         deallocate,
         execute("member/2"),
+        % --- select/3 ----------------------------------------------------
+        % select(X, [X|T], T).
+        % select(X, [Y|T], [Y|R]) :- select(X, T, R).
+        label("select/3"),
+        try_me_else("L_cpp_select_3_2"),
+        get_variable("X1", "A1"),
+        get_list("A2"),
+        unify_value("X1"),
+        unify_variable("X2"),
+        get_value("X2", "A3"),
+        proceed,
+        label("L_cpp_select_3_2"),
+        trust_me,
+        allocate,
+        get_variable("Y1", "A1"),
+        get_list("A2"),
+        unify_variable("X3"),
+        unify_variable("Y2"),
+        get_list("A3"),
+        unify_value("X3"),
+        unify_variable("Y3"),
+        put_value("Y1", "A1"),
+        put_value("Y2", "A2"),
+        put_value("Y3", "A3"),
+        deallocate,
+        execute("select/3"),
         % --- length/2 ----------------------------------------------------
         % length([], 0).
         % length([_|T], N) :- length(T, M), N is M + 1.
@@ -3212,6 +3238,76 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         if (!unify_cells(tgt, std::make_shared<Cell>(ov))) return false;
         pc += 1; return true;
     }
+    // ---- numlist/3 --------------------------------------------------
+    // numlist(+Low, +High, -List) — generate [Low, Low+1, ..., High].
+    // Empty list if Low > High. Both bounds must be integers.
+    if (op == "numlist/3") {
+        Value lv = deref(*get_cell("A1"));
+        Value hv = deref(*get_cell("A2"));
+        if (lv.tag != Value::Tag::Integer
+            || hv.tag != Value::Tag::Integer) return false;
+        std::int64_t lo = lv.i, hi = hv.i;
+        // Build the list bottom-up (tail = [], cons each value).
+        CellPtr list = std::make_shared<Cell>(Value::Atom("[]"));
+        for (std::int64_t i = hi; i >= lo; --i) {
+            CellPtr head = std::make_shared<Cell>(Value::Integer(i));
+            std::vector<CellPtr> cons_args;
+            cons_args.push_back(head);
+            cons_args.push_back(list);
+            list = std::make_shared<Cell>(
+                Value::Compound("[|]/2", std::move(cons_args)));
+        }
+        CellPtr tgt = get_cell("A3");
+        if (tgt->is_unbound()) { bind_cell(tgt, *list); pc += 1; return true; }
+        if (!unify_cells(tgt, list)) return false;
+        pc += 1; return true;
+    }
+
+    // ---- sort/2, msort/2 --------------------------------------------
+    // sort(+List, -Sorted) — standard order, dedup.
+    // msort(+List, -Sorted) — standard order, NO dedup (stable).
+    if (op == "sort/2" || op == "msort/2") {
+        // Walk A1 as a list, deep-copying each element so subsequent
+        // unifications can''t mutate the sort key.
+        std::vector<CellPtr> items;
+        CellPtr lc = get_cell("A1");
+        for (;;) {
+            Value lv = deref(*lc);
+            if (lv.tag == Value::Tag::Atom && lv.s == "[]") break;
+            if (lv.tag != Value::Tag::Compound || lv.s != "[|]/2"
+                || lv.args.size() != 2) return false;
+            // Take the cell directly — sort/msort don''t recurse into
+            // user code, so binding mutations can''t race with the
+            // sort''s element comparisons.
+            items.push_back(lv.args[0]);
+            lc = lv.args[1];
+        }
+        std::stable_sort(items.begin(), items.end(),
+            [](const CellPtr& a, const CellPtr& b) {
+                return standard_order_cmp(*a, *b) < 0;
+            });
+        if (op == "sort/2") {
+            // Dedup adjacent equals.
+            items.erase(std::unique(items.begin(), items.end(),
+                [](const CellPtr& a, const CellPtr& b) {
+                    return standard_order_cmp(*a, *b) == 0;
+                }), items.end());
+        }
+        // Build result list.
+        CellPtr result = std::make_shared<Cell>(Value::Atom("[]"));
+        for (auto it = items.rbegin(); it != items.rend(); ++it) {
+            std::vector<CellPtr> cons_args;
+            cons_args.push_back(*it);
+            cons_args.push_back(result);
+            result = std::make_shared<Cell>(
+                Value::Compound("[|]/2", std::move(cons_args)));
+        }
+        CellPtr tgt = get_cell("A2");
+        if (tgt->is_unbound()) { bind_cell(tgt, *result); pc += 1; return true; }
+        if (!unify_cells(tgt, result)) return false;
+        pc += 1; return true;
+    }
+
     // ---- functor/3 -------------------------------------------------
     if (op == "functor/3") {
         CellPtr t = get_cell("A1");

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1479,6 +1479,10 @@ is_builtin_pred(compare, 3).      % standard order: -1 / 0 / +1 as atom.
 is_builtin_pred(char_type, 2).    % char classification + case conv.
 is_builtin_pred(upcase_atom, 2).  % whole-atom case conversion: upper.
 is_builtin_pred(downcase_atom, 2).% whole-atom case conversion: lower.
+is_builtin_pred(numlist, 3).      % integer range generator: [Lo..Hi].
+is_builtin_pred(sort, 2).         % stable sort + dedup (std order).
+is_builtin_pred(msort, 2).        % stable sort, NO dedup (std order).
+is_builtin_pred(select, 3).       % nondet list element selection.
 % Note: sub_atom/5 is nondeterministic; like findall/bagof/setof it
 % goes through the Call/Execute dispatch path (not is_builtin_pred)
 % so dispatch_sub_atom can manage its own CP machinery.

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -1351,6 +1351,70 @@ user:wam_cpp_test_downcase_atom :-
     downcase_atom('WORLD', R),
     R = world.
 
+% numlist/3, sort/2, msort/2, select/3 — common list utilities.
+% numlist/sort/msort are direct builtins (deterministic). select/3
+% is helper-injected (nondet via try_me_else/trust_me) so
+% findall/select enumerates every (Elem, Rest) pair.
+:- dynamic user:wam_cpp_test_numlist/0.
+:- dynamic user:wam_cpp_test_numlist_empty/0.
+:- dynamic user:wam_cpp_test_numlist_single/0.
+:- dynamic user:wam_cpp_test_sort/0.
+:- dynamic user:wam_cpp_test_sort_mixed/0.
+:- dynamic user:wam_cpp_test_sort_empty/0.
+:- dynamic user:wam_cpp_test_msort/0.
+:- dynamic user:wam_cpp_test_select_bound/0.
+:- dynamic user:wam_cpp_test_select_all/0.
+:- dynamic user:wam_cpp_test_select_missing/0.
+:- dynamic user:wam_cpp_test_numlist_then_sort/0.
+
+user:wam_cpp_test_numlist :-
+    numlist(1, 5, L),
+    L = [1, 2, 3, 4, 5].
+
+user:wam_cpp_test_numlist_empty :-
+    numlist(5, 3, L),
+    L = [].
+
+user:wam_cpp_test_numlist_single :-
+    numlist(7, 7, L),
+    L = [7].
+
+user:wam_cpp_test_sort :-
+    sort([3, 1, 2, 1, 3], L),
+    L = [1, 2, 3].
+
+% sort across categories — exercises standard_order_cmp.
+user:wam_cpp_test_sort_mixed :-
+    sort([foo, 1, bar, 2], L),
+    L = [1, 2, bar, foo].
+
+user:wam_cpp_test_sort_empty :-
+    sort([], L),
+    L = [].
+
+% msort keeps duplicates and is stable.
+user:wam_cpp_test_msort :-
+    msort([3, 1, 2, 1, 3], L),
+    L = [1, 1, 2, 3, 3].
+
+user:wam_cpp_test_select_bound :-
+    select(b, [a, b, c], R),
+    R = [a, c].
+
+% select/3 nondet via findall — every (Elem, Rest) pair surfaced.
+user:wam_cpp_test_select_all :-
+    findall(X-R, select(X, [a, b, c], R), L),
+    L = [a-[b,c], b-[a,c], c-[a,b]].
+
+user:wam_cpp_test_select_missing :-
+    \+ select(z, [a, b, c], _).
+
+% Composition guard: numlist builds the list, sort dedups it.
+user:wam_cpp_test_numlist_then_sort :-
+    numlist(1, 4, L),
+    sort([3, 2, 1, 4, 2 | L], S),
+    S = [1, 2, 3, 4].
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -4805,6 +4869,139 @@ test(cpp_e2e_downcase_atom, [condition(cpp_compiler_available)]) :-
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath,
                     'wam_cpp_test_downcase_atom/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% numlist/3, sort/2, msort/2, select/3 — list utilities.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_numlist, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_numlist', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_numlist/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_numlist/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_numlist_empty, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_numlist_empty', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_numlist_empty/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_numlist_empty/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_numlist_single, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_numlist_single', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_numlist_single/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_numlist_single/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_sort, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_sort', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_sort/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_sort/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_sort_mixed, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_sort_mixed', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_sort_mixed/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_sort_mixed/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_sort_empty, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_sort_empty', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_sort_empty/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_sort_empty/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_msort, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_msort', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_msort/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_msort/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_select_bound, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_select_bound', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_select_bound/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_select_bound/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_select_all, [condition(cpp_compiler_available)]) :-
+    % select/3 nondet — findall enumerates every (Elem, Rest) pair.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_select_all', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_select_all/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_select_all/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_select_missing, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_select_missing', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_select_missing/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_select_missing/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_numlist_then_sort,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_nlsort', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_test_numlist_then_sort/0],
+            [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_numlist_then_sort/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Four common list utilities. `numlist`, `sort`, `msort` are direct builtins; `select/3` is helper-injected so it backtracks through every element.

| Builtin | Mode | Behaviour |
|---|---|---|
| `numlist/3` | `(+, +, -)` | `numlist(1, 5, L)` → `L=[1,2,3,4,5]`; empty if `Low > High` |
| `sort/2` | `(+, ?)` | standard order, stable, **dedups** adjacent equals |
| `msort/2` | `(+, ?)` | standard order, stable, **no dedup** |
| `select/3` | nondet | `select(?Elem, ?List, ?Rest)` — one of N alternatives per choice point |

## Implementation

- **`numlist/3`** — reads `Low` / `High` as integers, builds the list bottom-up (tail = `[]`, cons each value).
- **`sort/2` / `msort/2`** — walk A1 as a list (collecting `CellPtr`s, no deep-copy since these don't recurse into user code), `std::stable_sort` with `standard_order_cmp` from #2156, then build the result. `sort/2` additionally `std::unique`s by `standard_order_cmp == 0`.
- **`select/3`** — helper-injected as the standard 2-clause definition:
  ```prolog
  select(X, [X|T], T).
  select(X, [Y|T], [Y|R]) :- select(X, T, R).
  ```
  Compiled to `try_me_else`/`trust_me` so `findall` enumerates every match.

All four in `is_builtin_pred` so the compiler emits `builtin_call` directly (helper-injected ones get dispatched via the label-map lookup in `BuiltinCall`).

## Test plan

- [x] 11 new e2e tests:
  - `numlist` basic, empty (`Low > High`), single element
  - `sort` basic, mixed categories (atom + int — exercises standard_order), empty list
  - `msort` retains duplicates
  - `select` bound element, nondet via findall (enumerates all 3 splits of `[a,b,c]`), missing element fails
  - `numlist` → `sort` composition guard
- [x] Full `test_wam_cpp_generator.pl` suite passes
- [x] `test_wam_target.pl` passes

## Note on the quote-roundtrip bug

The WAM-text quote-roundtrip bug (digit-only quoted atoms like `'5'` re-emit as integers) is **not** addressed here — it touches the shared tokenizer plus the `constant_to_X_term` helpers in `wam_cpp_target`, `wam_lua_target`, `wam_scala_target`, `wam_python_lowered_emitter`, and friends. Worth a focused follow-up PR.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_