### PR TITLE
feat(wam-clojure): add nth1/3 builtin

### DIFF
--- a/PR_WAM_CLOJURE_NTH1_BUILTIN.md
+++ b/PR_WAM_CLOJURE_NTH1_BUILTIN.md
@@ -1,0 +1,26 @@
+# PR Title
+
+feat(wam-clojure): add nth1/3 builtin
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM support for `nth1/3`.
+- Reuses the existing proper-list conversion and unification helpers.
+- Direct-lowers `nth1/3` to a runtime helper instead of stepping through the interpreted builtin path.
+- Fails cleanly for zero, negative, out-of-range, unbound, or non-integer indexes and for improper or unbound input lists.
+- Adds lowered-emitter and runtime smoke coverage.
+
+## Semantics
+
+`nth1/3` accepts a positive integer index in the first argument and a proper list in the second argument, then unifies the third argument with the item at that one-based index.
+
+This initial Clojure WAM implementation is deterministic and conservative: it supports the common `(+Index, +List, ?Elem)` mode and fails for unbound index/list arguments rather than enumerating indexes or generating lists relationally.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -400,6 +400,10 @@ clojure_direct_builtin("nth0/3", "3").
 clojure_direct_builtin("nth0/3", 3).
 clojure_direct_builtin('nth0/3', "3").
 clojure_direct_builtin('nth0/3', 3).
+clojure_direct_builtin("nth1/3", "3").
+clojure_direct_builtin("nth1/3", 3).
+clojure_direct_builtin('nth1/3', "3").
+clojure_direct_builtin('nth1/3', 3).
 clojure_direct_builtin("sort/2", "2").
 clojure_direct_builtin("sort/2", 2).
 clojure_direct_builtin('sort/2', "2").
@@ -688,6 +692,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "nth0/3" ; Op == 'nth0/3'),
     !,
     format(atom(Expr), '(runtime/apply-nth0-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "nth1/3" ; Op == 'nth1/3'),
+    !,
+    format(atom(Expr), '(runtime/apply-nth1-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "sort/2" ; Op == 'sort/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -806,6 +806,25 @@
         (backtrack state))
       (backtrack state))))
 
+(defn apply-nth1-solution [state]
+  (let [index-value (deref-value (:bindings state)
+                                 (or (reg-get-raw state "A1") ::unbound))
+        list-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A2") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A3") ::unbound))]
+    (if (and (integer? index-value) (pos? index-value))
+      (if-let [items (proper-list-items state list-value)]
+        (let [zero-index (dec index-value)]
+          (if (< zero-index (count items))
+            (let [[ok next-state] (unify-values state out (nth items zero-index))]
+              (if ok
+                (advance next-state)
+                (backtrack state)))
+            (backtrack state)))
+        (backtrack state))
+      (backtrack state))))
+
 (defn apply-sort-solution [state]
   (let [list-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A1") ::unbound))
@@ -1592,6 +1611,9 @@
 
           "nth0/3"
           (apply-nth0-solution state)
+
+          "nth1/3"
+          (apply-nth1-solution state)
 
           "sort/2"
           (apply-sort-solution state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -577,6 +577,15 @@ test(simple_builtin_nth0_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_nth1_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_nth1/3:\nbuiltin_call nth1/3, 3\nproceed\n",
+        wam_clojure_lowerable(test_nth1/3, WamCode, deterministic),
+        lower_predicate_to_clojure(test_nth1/3, WamCode, [], Code),
+        has(Code, "runtime/apply-nth1-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_sort_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_sort/2:\nbuiltin_call sort/2, 2\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -97,6 +97,13 @@
 :- dynamic user:wam_nth0_bad_list/1.
 :- dynamic user:wam_nth0_unbound_index/1.
 :- dynamic user:wam_nth0_unbound_list/1.
+:- dynamic user:wam_nth1_guard/3.
+:- dynamic user:wam_nth1_zero/1.
+:- dynamic user:wam_nth1_negative/1.
+:- dynamic user:wam_nth1_out_of_range/1.
+:- dynamic user:wam_nth1_bad_list/1.
+:- dynamic user:wam_nth1_unbound_index/1.
+:- dynamic user:wam_nth1_unbound_list/1.
 :- dynamic user:wam_sort_guard/2.
 :- dynamic user:wam_sort_bad_list/1.
 :- dynamic user:wam_sort_unbound_list/1.
@@ -238,6 +245,13 @@ user:wam_nth0_out_of_range(X) :- nth0(3, [a,b,c], X).
 user:wam_nth0_bad_list(X) :- nth0(1, [a|b], X).
 user:wam_nth0_unbound_index(X) :- user:wam_unbound_arg(N), nth0(N, [a,b,c], X).
 user:wam_nth0_unbound_list(X) :- user:wam_unbound_arg(L), nth0(0, L, X).
+user:wam_nth1_guard(N, L, X) :- nth1(N, L, X).
+user:wam_nth1_zero(X) :- nth1(0, [a,b,c], X).
+user:wam_nth1_negative(X) :- nth1(-1, [a,b,c], X).
+user:wam_nth1_out_of_range(X) :- nth1(4, [a,b,c], X).
+user:wam_nth1_bad_list(X) :- nth1(2, [a|b], X).
+user:wam_nth1_unbound_index(X) :- user:wam_unbound_arg(N), nth1(N, [a,b,c], X).
+user:wam_nth1_unbound_list(X) :- user:wam_unbound_arg(L), nth1(1, L, X).
 user:wam_sort_guard(L, S) :- sort(L, S).
 user:wam_sort_bad_list(S) :- sort([a|b], S).
 user:wam_sort_unbound_list(S) :- user:wam_unbound_arg(L), sort(L, S).
@@ -384,6 +398,13 @@ run_smoke :-
           user:wam_nth0_bad_list/1,
           user:wam_nth0_unbound_index/1,
           user:wam_nth0_unbound_list/1,
+          user:wam_nth1_guard/3,
+          user:wam_nth1_zero/1,
+          user:wam_nth1_negative/1,
+          user:wam_nth1_out_of_range/1,
+          user:wam_nth1_bad_list/1,
+          user:wam_nth1_unbound_index/1,
+          user:wam_nth1_unbound_list/1,
           user:wam_sort_guard/2,
           user:wam_sort_bad_list/1,
           user:wam_sort_unbound_list/1,
@@ -463,6 +484,7 @@ run_smoke :-
     assert_lowered_reverse_builtin_emitted(TmpDir),
     assert_lowered_last_builtin_emitted(TmpDir),
     assert_lowered_nth0_builtin_emitted(TmpDir),
+    assert_lowered_nth1_builtin_emitted(TmpDir),
     assert_lowered_sort_builtin_emitted(TmpDir),
     assert_lowered_msort_builtin_emitted(TmpDir),
     assert_lowered_copy_term_builtin_emitted(TmpDir),
@@ -643,6 +665,16 @@ smoke_cases([
     case('wam_nth0_bad_list/1', a, "false"),
     case('wam_nth0_unbound_index/1', a, "false"),
     case('wam_nth0_unbound_list/1', a, "false"),
+    case('wam_nth1_guard/3', args(1, '[a,b,c]', a), "true"),
+    case('wam_nth1_guard/3', args(2, '[a,b,c]', b), "true"),
+    case('wam_nth1_guard/3', args(3, '[a,b,c]', c), "true"),
+    case('wam_nth1_guard/3', args(2, '[a,b,c]', c), "false"),
+    case('wam_nth1_zero/1', a, "false"),
+    case('wam_nth1_negative/1', a, "false"),
+    case('wam_nth1_out_of_range/1', a, "false"),
+    case('wam_nth1_bad_list/1', a, "false"),
+    case('wam_nth1_unbound_index/1', a, "false"),
+    case('wam_nth1_unbound_list/1', a, "false"),
     case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b,c]'), "true"),
     case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b]'), "false"),
     case('wam_sort_guard/2', args('[f(b),f(a),a]', '[a,f(a),f(b)]'), "true"),
@@ -919,6 +951,18 @@ assert_lowered_nth0_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-nth0-unbound-index-1"),
     has(CoreCode, "defn lowered-wam-nth0-unbound-list-1"),
     has(CoreCode, "runtime/apply-nth0-solution").
+
+assert_lowered_nth1_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-nth1-guard-3"),
+    has(CoreCode, "defn lowered-wam-nth1-zero-1"),
+    has(CoreCode, "defn lowered-wam-nth1-negative-1"),
+    has(CoreCode, "defn lowered-wam-nth1-out-of-range-1"),
+    has(CoreCode, "defn lowered-wam-nth1-bad-list-1"),
+    has(CoreCode, "defn lowered-wam-nth1-unbound-index-1"),
+    has(CoreCode, "defn lowered-wam-nth1-unbound-list-1"),
+    has(CoreCode, "runtime/apply-nth1-solution").
 
 assert_lowered_sort_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM support for `nth1/3`.
- Reuses the existing proper-list conversion and unification helpers.
- Direct-lowers `nth1/3` to a runtime helper instead of stepping through the interpreted builtin path.
- Fails cleanly for zero, negative, out-of-range, unbound, or non-integer indexes and for improper or unbound input lists.
- Adds lowered-emitter and runtime smoke coverage.

## Semantics

`nth1/3` accepts a positive integer index in the first argument and a proper list in the second argument, then unifies the third argument with the item at that one-based index.

This initial Clojure WAM implementation is deterministic and conservative: it supports the common `(+Index, +List, ?Elem)` mode and fails for unbound index/list arguments rather than enumerating indexes or generating lists relationally.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
