### PR TITLE
feat(wam-cpp): keysort/2 + pairs_keys/values/keys_values

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -1161,6 +1161,84 @@ helper_predicate_items(Items) :-
         put_value("Y5", "A5"),
         deallocate,
         execute("foldl/5"),
+        % --- pairs_keys/2 ------------------------------------------------
+        % pairs_keys([], []).
+        % pairs_keys([K-_|T], [K|KT]) :- pairs_keys(T, KT).
+        label("pairs_keys/2"),
+        try_me_else("L_cpp_pairs_keys_2_2"),
+        get_constant("[]", "A1"),
+        get_constant("[]", "A2"),
+        proceed,
+        label("L_cpp_pairs_keys_2_2"),
+        trust_me,
+        allocate,
+        get_list("A1"),
+        unify_variable("X3"),
+        unify_variable("Y2"),
+        get_structure("-/2", "X3"),
+        unify_variable("X4"),
+        unify_variable("X5"),
+        get_list("A2"),
+        unify_value("X4"),
+        unify_variable("Y3"),
+        put_value("Y2", "A1"),
+        put_value("Y3", "A2"),
+        deallocate,
+        execute("pairs_keys/2"),
+        % --- pairs_values/2 ----------------------------------------------
+        % pairs_values([], []).
+        % pairs_values([_-V|T], [V|VT]) :- pairs_values(T, VT).
+        label("pairs_values/2"),
+        try_me_else("L_cpp_pairs_values_2_2"),
+        get_constant("[]", "A1"),
+        get_constant("[]", "A2"),
+        proceed,
+        label("L_cpp_pairs_values_2_2"),
+        trust_me,
+        allocate,
+        get_list("A1"),
+        unify_variable("X3"),
+        unify_variable("Y2"),
+        get_structure("-/2", "X3"),
+        unify_variable("X4"),
+        unify_variable("X5"),
+        get_list("A2"),
+        unify_value("X5"),
+        unify_variable("Y3"),
+        put_value("Y2", "A1"),
+        put_value("Y3", "A2"),
+        deallocate,
+        execute("pairs_values/2"),
+        % --- pairs_keys_values/3 -----------------------------------------
+        % pairs_keys_values([], [], []).
+        % pairs_keys_values([K-V|T], [K|KT], [V|VT]) :-
+        %     pairs_keys_values(T, KT, VT).
+        label("pairs_keys_values/3"),
+        try_me_else("L_cpp_pairs_kv_3_2"),
+        get_constant("[]", "A1"),
+        get_constant("[]", "A2"),
+        get_constant("[]", "A3"),
+        proceed,
+        label("L_cpp_pairs_kv_3_2"),
+        trust_me,
+        allocate,
+        get_list("A1"),
+        unify_variable("X4"),
+        unify_variable("Y2"),
+        get_structure("-/2", "X4"),
+        unify_variable("X5"),
+        unify_variable("X6"),
+        get_list("A2"),
+        unify_value("X5"),
+        unify_variable("Y3"),
+        get_list("A3"),
+        unify_value("X6"),
+        unify_variable("Y4"),
+        put_value("Y2", "A1"),
+        put_value("Y3", "A2"),
+        put_value("Y4", "A3"),
+        deallocate,
+        execute("pairs_keys_values/3"),
         % --- length/2 ----------------------------------------------------
         % length([], 0).
         % length([_|T], N) :- length(T, M), N is M + 1.
@@ -3636,6 +3714,47 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
                 }), items.end());
         }
         // Build result list.
+        CellPtr result = std::make_shared<Cell>(Value::Atom("[]"));
+        for (auto it = items.rbegin(); it != items.rend(); ++it) {
+            std::vector<CellPtr> cons_args;
+            cons_args.push_back(*it);
+            cons_args.push_back(result);
+            result = std::make_shared<Cell>(
+                Value::Compound("[|]/2", std::move(cons_args)));
+        }
+        CellPtr tgt = get_cell("A2");
+        if (tgt->is_unbound()) { bind_cell(tgt, *result); pc += 1; return true; }
+        if (!unify_cells(tgt, result)) return false;
+        pc += 1; return true;
+    }
+
+    // ---- keysort/2 --------------------------------------------------
+    // keysort(+Pairs, -Sorted) — stable sort of Key-Value pairs by
+    // Key (standard order). Pairs must be ground at the head; the
+    // Value side is opaque (sorted only by Key). Items that aren''t
+    // -/2 pairs cause failure.
+    if (op == "keysort/2") {
+        std::vector<CellPtr> items;
+        CellPtr lc = get_cell("A1");
+        for (;;) {
+            Value lv = deref(*lc);
+            if (lv.tag == Value::Tag::Atom && lv.s == "[]") break;
+            if (lv.tag != Value::Tag::Compound || lv.s != "[|]/2"
+                || lv.args.size() != 2) return false;
+            // Validate that the head is a -/2 pair.
+            Value hv = deref(*lv.args[0]);
+            if (hv.tag != Value::Tag::Compound || hv.s != "-/2"
+                || hv.args.size() != 2) return false;
+            items.push_back(lv.args[0]);
+            lc = lv.args[1];
+        }
+        // Stable sort by the pair''s Key (args[0]) — Values stay in
+        // their original relative order on key ties.
+        std::stable_sort(items.begin(), items.end(),
+            [](const CellPtr& a, const CellPtr& b) {
+                return standard_order_cmp(*(a->args[0]),
+                                          *(b->args[0])) < 0;
+            });
         CellPtr result = std::make_shared<Cell>(Value::Atom("[]"));
         for (auto it = items.rbegin(); it != items.rend(); ++it) {
             std::vector<CellPtr> cons_args;

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1492,6 +1492,10 @@ is_builtin_pred(exclude, 3).      % filter: drop elems where Goal succeeds.
 is_builtin_pred(partition, 4).    % split into pass + fail lists.
 is_builtin_pred(foldl, 4).        % left fold over one list.
 is_builtin_pred(foldl, 5).        % left fold over two lists in parallel.
+is_builtin_pred(keysort, 2).      % stable sort of Key-Value pairs by Key.
+is_builtin_pred(pairs_keys, 2).   % extract keys from Key-Value pairs.
+is_builtin_pred(pairs_values, 2). % extract values from Key-Value pairs.
+is_builtin_pred(pairs_keys_values, 3). % split pairs into parallel lists.
 % Note: sub_atom/5 is nondeterministic; like findall/bagof/setof it
 % goes through the Call/Execute dispatch path (not is_builtin_pred)
 % so dispatch_sub_atom can manage its own CP machinery.

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -1511,6 +1511,56 @@ user:wam_cpp_test_foldl5 :-
     foldl(wam_cpp_join4, [1, 2, 3], [10, 20, 30], 0, Sum),
     Sum = 66.
 
+% keysort/2 + pairs_keys/2 + pairs_values/2 + pairs_keys_values/3 —
+% common idioms for sorting / decomposing Key-Value pair lists.
+% keysort is a direct builtin using standard_order_cmp on the pair''s
+% Key (args[0] of -/2). The pairs_* builtins are helper-injected
+% recursive Prolog defs.
+:- dynamic user:wam_cpp_test_keysort/0.
+:- dynamic user:wam_cpp_test_keysort_stable/0.
+:- dynamic user:wam_cpp_test_keysort_empty/0.
+:- dynamic user:wam_cpp_test_pairs_keys/0.
+:- dynamic user:wam_cpp_test_pairs_keys_empty/0.
+:- dynamic user:wam_cpp_test_pairs_values/0.
+:- dynamic user:wam_cpp_test_pairs_kv/0.
+:- dynamic user:wam_cpp_test_keysort_then_values/0.
+
+user:wam_cpp_test_keysort :-
+    keysort([b-2, a-1, c-3], L),
+    L = [a-1, b-2, c-3].
+
+% Stable: equal keys preserve original Value order.
+user:wam_cpp_test_keysort_stable :-
+    keysort([b-1, a-2, b-3, a-4], L),
+    L = [a-2, a-4, b-1, b-3].
+
+user:wam_cpp_test_keysort_empty :-
+    keysort([], L),
+    L = [].
+
+user:wam_cpp_test_pairs_keys :-
+    pairs_keys([a-1, b-2, c-3], K),
+    K = [a, b, c].
+
+user:wam_cpp_test_pairs_keys_empty :-
+    pairs_keys([], K),
+    K = [].
+
+user:wam_cpp_test_pairs_values :-
+    pairs_values([a-1, b-2, c-3], V),
+    V = [1, 2, 3].
+
+user:wam_cpp_test_pairs_kv :-
+    pairs_keys_values([a-1, b-2, c-3], K, V),
+    K = [a, b, c],
+    V = [1, 2, 3].
+
+% Composition: sort by key, then pull values.
+user:wam_cpp_test_keysort_then_values :-
+    keysort([c-30, a-10, b-20], Sorted),
+    pairs_values(Sorted, Vs),
+    Vs = [10, 20, 30].
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -5284,6 +5334,112 @@ test(cpp_e2e_foldl5, [condition(cpp_compiler_available)]) :-
                               [emit_main(true)], TmpDir),
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath, 'wam_cpp_test_foldl5/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% keysort/2 + pairs_keys/2 + pairs_values/2 + pairs_keys_values/3 —
+% Key-Value pair list utilities.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_keysort, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_keysort', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_keysort/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_keysort/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_keysort_stable,
+     [condition(cpp_compiler_available)]) :-
+    % Stability regression guard — keys b/a appear twice; their
+    % original Value-order must be preserved on key ties.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_ks_stable', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_keysort_stable/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_keysort_stable/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_keysort_empty,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_ks_empty', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_keysort_empty/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_keysort_empty/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_pairs_keys, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_pairs_keys', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_pairs_keys/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_pairs_keys/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_pairs_keys_empty,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_pk_empty', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_test_pairs_keys_empty/0],
+            [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_pairs_keys_empty/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_pairs_values, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_pairs_values', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_pairs_values/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_pairs_values/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_pairs_kv, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_pairs_kv', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_pairs_kv/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_pairs_kv/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_keysort_then_values,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_ks_then', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_test_keysort_then_values/0],
+            [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_keysort_then_values/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Key-Value pair list utilities — the natural `sort/2` companion for tag-sorted or grouped-by-key data.

| Builtin | Behaviour |
|---|---|
| `keysort(+Pairs, -Sorted)` | stable sort by Key (standard order); Values stay in original order on key ties |
| `pairs_keys(+Pairs, -Keys)` | extract Keys into a parallel list |
| `pairs_values(+Pairs, -Values)` | extract Values into a parallel list |
| `pairs_keys_values(+Pairs, -Keys, -Values)` | split into two parallel lists in one pass |

## Implementation

- **`keysort/2`** is a direct builtin: walks the input list collecting `-/2` cell pointers, `std::stable_sort` with a comparator that compares **just the K cell** via `standard_order_cmp` (from #2156), then rebuilds the list. Fails on non-pair items.

- **`pairs_keys` / `pairs_values` / `pairs_keys_values`** are helper-injected as 2-clause recursive Prolog, parallel to `maplist/N` etc. The pair is decomposed via `get_structure "-/2"` on the X-reg holding the head cell — read-mode unification gives us the K and V cells directly.

`is_builtin_pred` entries for all four.

## Test plan

- [x] 8 new e2e tests:
  - `keysort` basic
  - `keysort` stability with duplicate keys (regression guard for `stable_sort` choice)
  - `keysort` empty list
  - `pairs_keys` + empty input
  - `pairs_values`
  - `pairs_keys_values`
  - `keysort` → `pairs_values` composition guard
- [x] Full `test_wam_cpp_generator.pl` suite passes
- [x] `test_wam_target.pl` passes

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_