### PR TITLE
refactor(wam): share parser-dependent goal classifier

### DIFF
--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
@@ -69,8 +69,11 @@ writers decide whether to include parser library predicates, whether parser
 builtins should dispatch to a native parser, and whether a target should reject
 parser-dependent builtins at generation time.
 
-The same module also defines `parser_dependent_builtin/1`, the catalogue of
-builtins that require runtime source-term parsing.
+The same module also defines `parser_dependent_builtin/1`, the broad catalogue
+of builtins that may require runtime source-term parsing, and
+`parser_dependent_goal/2`, the shape-aware classifier used by target writers.
+For example, `term_to_atom/2` only needs a parser when the source-text argument
+is statically visible.
 
 Target defaults should be conservative:
 

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -66,7 +66,7 @@
 :- use_module('../core/recursive_kernel_detection',
              [detect_recursive_kernel/4, kernel_config/2]).
 :- use_module(wam_runtime_parser_capability,
-             [parser_dependent_builtin/1,
+             [parser_dependent_goal/2,
               wam_target_runtime_parser/3]).
 
 % ============================================================================
@@ -1848,28 +1848,11 @@ r_predicate_clause(Name/Arity, Head, Body) :-
 
 r_goal_uses_parser_builtin(Goal, Builtin) :-
     nonvar(Goal),
-    (   r_goal_parser_dependency(Goal, Builtin)
+    (   parser_dependent_goal(Goal, Builtin)
     ->  true
     ;   r_goal_child(Goal, Child),
         r_goal_uses_parser_builtin(Child, Builtin)
     ).
-
-r_goal_parser_dependency(Module:Goal, Builtin) :-
-    atom(Module),
-    nonvar(Goal),
-    !,
-    r_goal_parser_dependency(Goal, Builtin).
-r_goal_parser_dependency(term_to_atom(_Term, AtomText), term_to_atom/2) :-
-    !,
-    nonvar(AtomText).
-r_goal_parser_dependency(Goal, Builtin) :-
-    r_goal_builtin_pi(Goal, Builtin),
-    parser_dependent_builtin(Builtin),
-    Builtin \= term_to_atom/2.
-
-r_goal_builtin_pi(Goal, Name/Arity) :-
-    callable(Goal),
-    functor(Goal, Name, Arity).
 
 r_goal_child((A, _), A).
 r_goal_child((_, B), B).

--- a/src/unifyweaver/targets/wam_runtime_parser_capability.pl
+++ b/src/unifyweaver/targets/wam_runtime_parser_capability.pl
@@ -1,6 +1,7 @@
 :- module(wam_runtime_parser_capability, [
     wam_target_runtime_parser/3,
     parser_dependent_builtin/1,
+    parser_dependent_goal/2,
     target_supports_runtime_parser_mode/2
 ]).
 
@@ -34,6 +35,27 @@ parser_dependent_builtin(read/2).
 parser_dependent_builtin(read_term_from_atom/2).
 parser_dependent_builtin(read_term_from_atom/3).
 parser_dependent_builtin(term_to_atom/2).
+
+%% parser_dependent_goal(+Goal, -Builtin)
+%
+% True when Goal is a statically visible call shape that needs a
+% runtime source-term parser. `term_to_atom/2` is mode-sensitive:
+% forward rendering does not parse, but a visible nonvar atom/text
+% argument means reverse parsing is possible and requires a parser.
+parser_dependent_goal(Goal0, Builtin) :-
+    nonvar(Goal0),
+    strip_module_qualifier(Goal0, Goal),
+    parser_dependent_goal_(Goal, Builtin).
+
+parser_dependent_goal_(term_to_atom(_Term, AtomText), term_to_atom/2) :-
+    !,
+    nonvar(AtomText).
+parser_dependent_goal_(Goal, Builtin) :-
+    callable(Goal),
+    functor(Goal, Name, Arity),
+    Builtin = Name/Arity,
+    parser_dependent_builtin(Builtin),
+    Builtin \= term_to_atom/2.
 
 %% target_supports_runtime_parser_mode(+Target, ?Mode)
 %
@@ -77,3 +99,10 @@ target_runtime_parser_mode_(wam_r, compiled(prolog_term_parser)).
 normalize_runtime_parser_target(r, wam_r) :- !.
 normalize_runtime_parser_target(wam_r, wam_r) :- !.
 normalize_runtime_parser_target(Target, Target).
+
+strip_module_qualifier(Module:Goal, Stripped) :-
+    atom(Module),
+    nonvar(Goal),
+    !,
+    strip_module_qualifier(Goal, Stripped).
+strip_module_qualifier(Goal, Goal).

--- a/tests/test_wam_runtime_parser_capability.pl
+++ b/tests/test_wam_runtime_parser_capability.pl
@@ -42,4 +42,20 @@ test(parser_dependent_builtin_catalogue) :-
                       read_term_from_atom/3,
                       term_to_atom/2]).
 
+test(parser_dependent_goal_read) :-
+    parser_dependent_goal(read(_, _), read/2).
+
+test(parser_dependent_goal_module_qualified) :-
+    once(parser_dependent_goal(user:read_term_from_atom('f(a)', _),
+                               read_term_from_atom/2)).
+
+test(parser_dependent_goal_term_to_atom_forward_fails, [fail]) :-
+    parser_dependent_goal(term_to_atom(f(a), _), _).
+
+test(parser_dependent_goal_term_to_atom_reverse) :-
+    parser_dependent_goal(term_to_atom(_, 'f(a)'), term_to_atom/2).
+
+test(parser_dependent_goal_term_to_atom_both_bound) :-
+    parser_dependent_goal(term_to_atom(f(a), 'f(a)'), term_to_atom/2).
+
 :- end_tests(wam_runtime_parser_capability).


### PR DESCRIPTION
## Summary

Centralizes parser-dependent goal classification in the shared runtime parser capability module.

WAM-R previously had local logic for deciding whether a statically visible goal needs runtime source-term parsing, including the mode-sensitive `term_to_atom/2` special case. This PR moves that call-shape logic into `wam_runtime_parser_capability.pl` so future target integrations can reuse the same behavior.

## Details

- Adds `parser_dependent_goal/2` to `wam_runtime_parser_capability.pl`.
- Keeps `parser_dependent_builtin/1` as the broad builtin catalogue.
- Handles module-qualified parser calls.
- Treats `term_to_atom/2` mode-sensitively:
  - forward rendering does not require a parser;
  - reverse parsing with a statically visible atom/text argument requires a parser.
- Updates WAM-R parser-disabled validation to call the shared classifier.
- Adds shared unit tests for direct parser calls, module-qualified calls, and `term_to_atom/2` modes.
- Updates the runtime parser transpilation spec to document the shape-aware classifier.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_runtime_parser_capability.pl`
- `swipl -q -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:runtime_parser_mode_metadata,wam_r_generator:runtime_parser_mode_option_off,wam_r_generator:runtime_parser_off_rejects_parser_dependent_builtin,wam_r_generator:runtime_parser_off_allows_term_to_atom_forward,wam_r_generator:runtime_parser_off_rejects_term_to_atom_reverse])" -t halt`
- `git diff --check HEAD`

## Notes

This is a refactor of generation-time validation only. It does not change runtime parser execution.
