### PR TITLE
feat(wam-clojure): add delete/3 builtin

### DIFF
--- a/PR_WAM_CLOJURE_DELETE_BUILTIN.md
+++ b/PR_WAM_CLOJURE_DELETE_BUILTIN.md
@@ -1,0 +1,27 @@
+# PR Title
+
+feat(wam-clojure): add delete/3 builtin
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM support for `delete/3`.
+- Uses the existing `term-identical?` helper so removal follows identity semantics, matching the target list-builtin plan.
+- Reuses the existing proper-list conversion and `list->term` helpers.
+- Direct-lowers `delete/3` to a runtime helper instead of stepping through the interpreted builtin path.
+- Fails cleanly for improper or unbound input lists.
+- Adds lowered-emitter and runtime smoke coverage.
+
+## Semantics
+
+`delete/3` accepts a proper list in the first argument, removes all elements identical to the second argument, and unifies the third argument with the resulting list.
+
+This initial Clojure WAM implementation is deterministic and conservative: it supports the common `(+List, +Elem, ?Rest)` mode and fails for unbound input lists rather than generating lists relationally.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -404,6 +404,10 @@ clojure_direct_builtin("nth1/3", "3").
 clojure_direct_builtin("nth1/3", 3).
 clojure_direct_builtin('nth1/3', "3").
 clojure_direct_builtin('nth1/3', 3).
+clojure_direct_builtin("delete/3", "3").
+clojure_direct_builtin("delete/3", 3).
+clojure_direct_builtin('delete/3', "3").
+clojure_direct_builtin('delete/3', 3).
 clojure_direct_builtin("sort/2", "2").
 clojure_direct_builtin("sort/2", 2).
 clojure_direct_builtin('sort/2', "2").
@@ -697,6 +701,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "nth1/3" ; Op == 'nth1/3'),
     !,
     format(atom(Expr), '(runtime/apply-nth1-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "delete/3" ; Op == 'delete/3'),
+    !,
+    format(atom(Expr), '(runtime/apply-delete-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "sort/2" ; Op == 'sort/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -825,6 +825,22 @@
         (backtrack state))
       (backtrack state))))
 
+(defn apply-delete-solution [state]
+  (let [list-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        elem (deref-value (:bindings state)
+                          (or (reg-get-raw state "A2") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A3") ::unbound))]
+    (if-let [items (proper-list-items state list-value)]
+      (let [kept (remove #(term-identical? state % elem) items)
+            result-term (list->term (:intern-context state) kept)
+            [ok next-state] (unify-values state out result-term)]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+      (backtrack state))))
+
 (defn apply-sort-solution [state]
   (let [list-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A1") ::unbound))
@@ -1614,6 +1630,9 @@
 
           "nth1/3"
           (apply-nth1-solution state)
+
+          "delete/3"
+          (apply-delete-solution state)
 
           "sort/2"
           (apply-sort-solution state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -586,6 +586,15 @@ test(simple_builtin_nth1_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_delete_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_delete/3:\nbuiltin_call delete/3, 3\nproceed\n",
+        wam_clojure_lowerable(test_delete/3, WamCode, deterministic),
+        lower_predicate_to_clojure(test_delete/3, WamCode, [], Code),
+        has(Code, "runtime/apply-delete-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_sort_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_sort/2:\nbuiltin_call sort/2, 2\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -104,6 +104,9 @@
 :- dynamic user:wam_nth1_bad_list/1.
 :- dynamic user:wam_nth1_unbound_index/1.
 :- dynamic user:wam_nth1_unbound_list/1.
+:- dynamic user:wam_delete_guard/3.
+:- dynamic user:wam_delete_bad_list/1.
+:- dynamic user:wam_delete_unbound_list/1.
 :- dynamic user:wam_sort_guard/2.
 :- dynamic user:wam_sort_bad_list/1.
 :- dynamic user:wam_sort_unbound_list/1.
@@ -252,6 +255,9 @@ user:wam_nth1_out_of_range(X) :- nth1(4, [a,b,c], X).
 user:wam_nth1_bad_list(X) :- nth1(2, [a|b], X).
 user:wam_nth1_unbound_index(X) :- user:wam_unbound_arg(N), nth1(N, [a,b,c], X).
 user:wam_nth1_unbound_list(X) :- user:wam_unbound_arg(L), nth1(1, L, X).
+user:wam_delete_guard(L, Elem, Rest) :- delete(L, Elem, Rest).
+user:wam_delete_bad_list(Rest) :- delete([a|b], a, Rest).
+user:wam_delete_unbound_list(Rest) :- user:wam_unbound_arg(L), delete(L, a, Rest).
 user:wam_sort_guard(L, S) :- sort(L, S).
 user:wam_sort_bad_list(S) :- sort([a|b], S).
 user:wam_sort_unbound_list(S) :- user:wam_unbound_arg(L), sort(L, S).
@@ -405,6 +411,9 @@ run_smoke :-
           user:wam_nth1_bad_list/1,
           user:wam_nth1_unbound_index/1,
           user:wam_nth1_unbound_list/1,
+          user:wam_delete_guard/3,
+          user:wam_delete_bad_list/1,
+          user:wam_delete_unbound_list/1,
           user:wam_sort_guard/2,
           user:wam_sort_bad_list/1,
           user:wam_sort_unbound_list/1,
@@ -485,6 +494,7 @@ run_smoke :-
     assert_lowered_last_builtin_emitted(TmpDir),
     assert_lowered_nth0_builtin_emitted(TmpDir),
     assert_lowered_nth1_builtin_emitted(TmpDir),
+    assert_lowered_delete_builtin_emitted(TmpDir),
     assert_lowered_sort_builtin_emitted(TmpDir),
     assert_lowered_msort_builtin_emitted(TmpDir),
     assert_lowered_copy_term_builtin_emitted(TmpDir),
@@ -675,6 +685,12 @@ smoke_cases([
     case('wam_nth1_bad_list/1', a, "false"),
     case('wam_nth1_unbound_index/1', a, "false"),
     case('wam_nth1_unbound_list/1', a, "false"),
+    case('wam_delete_guard/3', args('[a,b,a,c]', a, '[b,c]'), "true"),
+    case('wam_delete_guard/3', args('[a,b,a,c]', z, '[a,b,a,c]'), "true"),
+    case('wam_delete_guard/3', args('[f(a),f(b),f(a)]', 'f(a)', '[f(b)]'), "true"),
+    case('wam_delete_guard/3', args('[a,b,a,c]', a, '[a,b,c]'), "false"),
+    case('wam_delete_bad_list/1', '[]', "false"),
+    case('wam_delete_unbound_list/1', '[]', "false"),
     case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b,c]'), "true"),
     case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b]'), "false"),
     case('wam_sort_guard/2', args('[f(b),f(a),a]', '[a,f(a),f(b)]'), "true"),
@@ -964,6 +980,14 @@ assert_lowered_nth1_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-nth1-unbound-list-1"),
     has(CoreCode, "runtime/apply-nth1-solution").
 
+assert_lowered_delete_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-delete-guard-3"),
+    has(CoreCode, "defn lowered-wam-delete-bad-list-1"),
+    has(CoreCode, "defn lowered-wam-delete-unbound-list-1"),
+    has(CoreCode, "runtime/apply-delete-solution").
+
 assert_lowered_sort_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
@@ -1222,12 +1246,15 @@ prolog_term_string_to_edn('[b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"b\
 prolog_term_string_to_edn('[c]', "{:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}") :- !.
 prolog_term_string_to_edn('[a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[a,b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn('[a,b,a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn('[a,a,b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn('[c,b,a]', "{:tag :struct :functor \"[|]/2\" :args [\"c\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[b,a]', "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[b,a,a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn('[f(b),f(a),a]', "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[a,f(a),f(b)]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn('[f(a),f(b),f(a)]', "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn('[f(b)]', "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} \"[]\"]}") :- !.
 prolog_term_string_to_edn('[a|b]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"b\"]}") :- !.
 prolog_term_string_to_edn("f(a)", "{:tag :struct :functor \"f/1\" :args [\"a\"]}") :- !.
 prolog_term_string_to_edn("f(a,b)", "{:tag :struct :functor \"f/2\" :args [\"a\" \"b\"]}") :- !.
@@ -1240,12 +1267,15 @@ prolog_term_string_to_edn("[b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"b\
 prolog_term_string_to_edn("[c]", "{:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}") :- !.
 prolog_term_string_to_edn("[a,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[a,b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn("[a,b,a,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn("[a,a,b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn("[c,b,a]", "{:tag :struct :functor \"[|]/2\" :args [\"c\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[b,a]", "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[b,a,a,c]", "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn("[f(b),f(a),a]", "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[a,f(a),f(b)]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn("[f(a),f(b),f(a)]", "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"a\"]} \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn("[f(b)]", "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"f/1\" :args [\"b\"]} \"[]\"]}") :- !.
 prolog_term_string_to_edn(Atom, Atom).
 
 find_clojure_classpath(ClassPath) :-


### PR DESCRIPTION
## Summary

- Adds Clojure WAM support for `delete/3`.
- Uses the existing `term-identical?` helper so removal follows identity semantics, matching the target list-builtin plan.
- Reuses the existing proper-list conversion and `list->term` helpers.
- Direct-lowers `delete/3` to a runtime helper instead of stepping through the interpreted builtin path.
- Fails cleanly for improper or unbound input lists.
- Adds lowered-emitter and runtime smoke coverage.

## Semantics

`delete/3` accepts a proper list in the first argument, removes all elements identical to the second argument, and unifies the third argument with the resulting list.

This initial Clojure WAM implementation is deterministic and conservative: it supports the common `(+List, +Elem, ?Rest)` mode and fails for unbound input lists rather than generating lists relationally.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
