### PR TITLE
refactor(wam): share parser-dependent body walker

### DIFF
--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
@@ -70,10 +70,11 @@ builtins should dispatch to a native parser, and whether a target should reject
 parser-dependent builtins at generation time.
 
 The same module also defines `parser_dependent_builtin/1`, the broad catalogue
-of builtins that may require runtime source-term parsing, and
-`parser_dependent_goal/2`, the shape-aware classifier used by target writers.
-For example, `term_to_atom/2` only needs a parser when the source-text argument
-is statically visible.
+of builtins that may require runtime source-term parsing,
+`parser_dependent_goal/2`, the shape-aware single-call classifier, and
+`parser_dependent_body_goal/2`, the recursive body walker used by target
+writers. For example, `term_to_atom/2` only needs a parser when the source-text
+argument is statically visible.
 
 Target defaults should be conservative:
 

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -66,7 +66,7 @@
 :- use_module('../core/recursive_kernel_detection',
              [detect_recursive_kernel/4, kernel_config/2]).
 :- use_module(wam_runtime_parser_capability,
-             [parser_dependent_goal/2,
+             [parser_dependent_body_goal/2,
               wam_target_runtime_parser/3]).
 
 % ============================================================================
@@ -1835,7 +1835,7 @@ validate_r_runtime_parser_mode(_Predicates, _Mode).
 r_predicates_parser_dependency(Predicates, Pred, Builtin) :-
     member(Pred, Predicates),
     r_predicate_clause(Pred, _Head, Body),
-    r_goal_uses_parser_builtin(Body, Builtin),
+    parser_dependent_body_goal(Body, Builtin),
     !.
 
 r_predicate_clause(Module:Name/Arity, Head, Body) :-
@@ -1845,27 +1845,6 @@ r_predicate_clause(Module:Name/Arity, Head, Body) :-
 r_predicate_clause(Name/Arity, Head, Body) :-
     functor(Head, Name, Arity),
     clause(user:Head, Body).
-
-r_goal_uses_parser_builtin(Goal, Builtin) :-
-    nonvar(Goal),
-    (   parser_dependent_goal(Goal, Builtin)
-    ->  true
-    ;   r_goal_child(Goal, Child),
-        r_goal_uses_parser_builtin(Child, Builtin)
-    ).
-
-r_goal_child((A, _), A).
-r_goal_child((_, B), B).
-r_goal_child((A ; _), A).
-r_goal_child((_ ; B), B).
-r_goal_child((A -> _), A).
-r_goal_child((_ -> B), B).
-r_goal_child((*->(A, _)), A).
-r_goal_child((*->(_, B)), B).
-r_goal_child(\+(A), A).
-r_goal_child(not(A), A).
-r_goal_child(once(A), A).
-r_goal_child(call(A), A).
 
 % ============================================================================
 % HELPERS

--- a/src/unifyweaver/targets/wam_runtime_parser_capability.pl
+++ b/src/unifyweaver/targets/wam_runtime_parser_capability.pl
@@ -2,6 +2,7 @@
     wam_target_runtime_parser/3,
     parser_dependent_builtin/1,
     parser_dependent_goal/2,
+    parser_dependent_body_goal/2,
     target_supports_runtime_parser_mode/2
 ]).
 
@@ -57,6 +58,20 @@ parser_dependent_goal_(Goal, Builtin) :-
     parser_dependent_builtin(Builtin),
     Builtin \= term_to_atom/2.
 
+%% parser_dependent_body_goal(+BodyGoal, -Builtin)
+%
+% True when BodyGoal contains a statically visible parser-dependent
+% goal. Walks the common source-level control forms target writers see
+% before WAM lowering.
+parser_dependent_body_goal(Body0, Builtin) :-
+    nonvar(Body0),
+    strip_module_qualifier(Body0, Body),
+    (   parser_dependent_goal(Body, Builtin)
+    ->  true
+    ;   parser_body_child(Body, Child),
+        parser_dependent_body_goal(Child, Builtin)
+    ).
+
 %% target_supports_runtime_parser_mode(+Target, ?Mode)
 %
 % Capability facts used by the resolver. Keep this conservative:
@@ -106,3 +121,16 @@ strip_module_qualifier(Module:Goal, Stripped) :-
     !,
     strip_module_qualifier(Goal, Stripped).
 strip_module_qualifier(Goal, Goal).
+
+parser_body_child((A, _), A).
+parser_body_child((_, B), B).
+parser_body_child((A ; _), A).
+parser_body_child((_ ; B), B).
+parser_body_child((A -> _), A).
+parser_body_child((_ -> B), B).
+parser_body_child((*->(A, _)), A).
+parser_body_child((*->(_, B)), B).
+parser_body_child(\+(A), A).
+parser_body_child(not(A), A).
+parser_body_child(once(A), A).
+parser_body_child(call(A), A).

--- a/tests/test_wam_runtime_parser_capability.pl
+++ b/tests/test_wam_runtime_parser_capability.pl
@@ -58,4 +58,29 @@ test(parser_dependent_goal_term_to_atom_reverse) :-
 test(parser_dependent_goal_term_to_atom_both_bound) :-
     parser_dependent_goal(term_to_atom(f(a), 'f(a)'), term_to_atom/2).
 
+test(parser_dependent_body_goal_conjunction) :-
+    parser_dependent_body_goal((true, read_term_from_atom('f(a)', _)),
+                               read_term_from_atom/2).
+
+test(parser_dependent_body_goal_disjunction) :-
+    parser_dependent_body_goal((fail ; read(_, _)), read/2).
+
+test(parser_dependent_body_goal_if_then) :-
+    parser_dependent_body_goal((true -> term_to_atom(_, 'f(a)')),
+                               term_to_atom/2).
+
+test(parser_dependent_body_goal_wrappers) :-
+    parser_dependent_body_goal(once(call(read_term_from_atom('f(a)', _))),
+                               read_term_from_atom/2).
+
+test(parser_dependent_body_goal_negation) :-
+    parser_dependent_body_goal(\+(read_term_from_atom('f(a)', _)),
+                               read_term_from_atom/2).
+
+test(parser_dependent_body_goal_forward_term_to_atom_ignored, [fail]) :-
+    parser_dependent_body_goal((true, term_to_atom(f(a), _)), _).
+
+test(parser_dependent_body_goal_module_qualified_body) :-
+    once(parser_dependent_body_goal(user:(true, read(_, _)), read/2)).
+
 :- end_tests(wam_runtime_parser_capability).


### PR DESCRIPTION
## Summary

Moves recursive parser-dependency body traversal into the shared runtime parser capability module.

The previous shared classifier handled a single goal shape, while WAM-R still owned the traversal through conjunctions, disjunctions, wrappers, and control forms. This PR centralizes that traversal as `parser_dependent_body_goal/2` so future target integrations can reuse one shared generation-time validator.

## Details

- Adds `parser_dependent_body_goal/2` to `wam_runtime_parser_capability.pl`.
- Walks common source-level control forms:
  - conjunction
  - disjunction
  - if-then
  - soft-cut
  - `\+/1`
  - `not/1`
  - `once/1`
  - `call/1`
  - module-qualified bodies
- Keeps `parser_dependent_goal/2` as the shape-aware single-call classifier.
- Updates WAM-R parser-disabled validation to call the shared body walker directly.
- Removes WAM-R's local parser-dependency body traversal helper.
- Adds shared unit tests for the recursive walker.
- Updates the runtime parser transpilation spec to document the body-level classifier.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_runtime_parser_capability.pl`
- `swipl -q -s tests/test_wam_r_generator.pl -g "run_tests([wam_r_generator:runtime_parser_mode_metadata,wam_r_generator:runtime_parser_mode_option_off,wam_r_generator:runtime_parser_off_rejects_parser_dependent_builtin,wam_r_generator:runtime_parser_off_allows_term_to_atom_forward,wam_r_generator:runtime_parser_off_rejects_term_to_atom_reverse])" -t halt`
- `git diff --check HEAD`

## Notes

This is a generation-time validation refactor only. It does not change runtime parser execution.
