### PR TITLE
feat(wam-cpp): with_output_to/2 — capture goal output

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -412,14 +412,14 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     helper_predicate_items(HelperItems),
     flatten_blocks([HelperItems|PerPredItems], AllItems),
     walk_blocks(AllItems, Labels, FlatInstrs0),
-    % Append twelve trailing synthetic-return instructions for the
+    % Append thirteen trailing synthetic-return instructions for the
     % meta-call control-flow surface — see WamState for each pc''s
     % role.
     append(FlatInstrs0,
            [catch_return, negation_return, findall_collect,
             conj_return, disj_alt, if_then_commit, if_then_else,
             aggregate_next_group, dynamic_next_clause, sub_atom_next,
-            body_next, retract_next],
+            body_next, retract_next, output_capture_return],
            FlatInstrs),
     length(FlatInstrs0, CatchReturnPC),
     NegationReturnPC is CatchReturnPC + 1,
@@ -433,6 +433,7 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     SubAtomNextPC is CatchReturnPC + 9,
     BodyNextPC is CatchReturnPC + 10,
     RetractNextPC is CatchReturnPC + 11,
+    OutputCaptureReturnPC is CatchReturnPC + 12,
     findall(LabelLine, (
         member(NameStr-PC, Labels),
         format(atom(LabelLine),
@@ -462,6 +463,7 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     vm.sub_atom_next_pc = ~w;
     vm.body_next_pc = ~w;
     vm.retract_next_pc = ~w;
+    vm.output_capture_return_pc = ~w;
 ~w
 ~w
 }
@@ -472,7 +474,7 @@ static const int _wam_cpp_setup_register = []() {
 ', [Reserve, CatchReturnPC, NegationReturnPC, FindallCollectPC,
     ConjReturnPC, DisjAltPC, IfThenCommitPC, IfThenElsePC,
     AggregateNextGroupPC, DynamicNextClausePC, SubAtomNextPC,
-    BodyNextPC, RetractNextPC,
+    BodyNextPC, RetractNextPC, OutputCaptureReturnPC,
     LabelBody, InstrBody]).
 
 % ============================================================================
@@ -1544,6 +1546,8 @@ instr_to_setup_line(body_next, _Labels, Line) :- !,
     Line = '    vm.instrs.push_back(Instruction::BodyNext());'.
 instr_to_setup_line(retract_next, _Labels, Line) :- !,
     Line = '    vm.instrs.push_back(Instruction::RetractNext());'.
+instr_to_setup_line(output_capture_return, _Labels, Line) :- !,
+    Line = '    vm.instrs.push_back(Instruction::OutputCaptureReturn());'.
 instr_to_setup_line(Instr, _Labels, Line) :-
     wam_instruction_to_cpp_literal(Instr, Lit),
     format(atom(Line), '    vm.instrs.push_back(~w);', [Lit]).
@@ -1917,7 +1921,7 @@ struct Instruction {
         SwitchOnConstant, SwitchOnStructure, SwitchOnTerm,
         CatchReturn, NegationReturn, FindallCollect, ConjReturn, DisjAlt,
         IfThenCommit, IfThenElse, AggregateNextGroup, DynamicNextClause,
-        SubAtomNext, BodyNext, RetractNext
+        SubAtomNext, BodyNext, RetractNext, OutputCaptureReturn
     };
     // Sentinel pc values for switch-table entries that should not jump.
     static constexpr std::size_t SWITCH_DEFAULT = static_cast<std::size_t>(-1);
@@ -2041,6 +2045,8 @@ struct Instruction {
         { Instruction i; i.op = Op::BodyNext; return i; }
     static Instruction RetractNext()
         { Instruction i; i.op = Op::RetractNext; return i; }
+    static Instruction OutputCaptureReturn()
+        { Instruction i; i.op = Op::OutputCaptureReturn; return i; }
 };
 
 struct TrailEntry {
@@ -2326,6 +2332,28 @@ struct WamState {
     // Both setvals deep-copy the input to give the stored term
     // independent vars.
     std::unordered_map<std::string, CellPtr> nb_globals;
+    // Output capture for with_output_to/2. Each frame holds a sink
+    // cell (atom(V) / string(V) / codes(V)) and a growing buffer
+    // that the I/O builtins append to instead of writing stdout
+    // while the frame is on top. The goal''s continuation is
+    // output_capture_return_pc, which pops the frame and unifies
+    // the buffer with the sink. Backtrack drops the frame at the
+    // frame''s base_cp_count (parallel to CatcherFrame).
+    struct OutputCaptureFrame {
+        CellPtr     sink;          // the atom(V) / string(V) / codes(V)
+        std::string buffer;
+        std::size_t saved_cp = 0;
+        std::size_t base_cp_count = 0;
+        std::size_t base_agg_count = 0;
+        std::size_t base_catcher_count = 0;
+        std::size_t trail_mark = 0;
+        std::size_t saved_cut_barrier = 0;
+        std::unordered_map<std::string, CellPtr> saved_regs;
+        std::vector<ModeFrame> saved_mode_stack;
+        std::vector<EnvFrame> saved_env_stack;
+    };
+    std::vector<OutputCaptureFrame> output_capture_frames;
+    std::size_t output_capture_return_pc = 0;
     // Iteration state for retract/1''s nondeterministic behaviour.
     // Each successful retract removes the matched clause; on
     // backtrack, retract_try_next continues from where it left off
@@ -2480,6 +2508,13 @@ struct WamState {
     bool    sub_atom_try_next();
     bool    execute_catch();
     bool    execute_throw();
+    // Output emission helper. When output_capture_frames is non-empty,
+    // appends to the top frame''s buffer. Otherwise writes to stdout.
+    // All I/O builtins (write/nl/writeln/print/display/tab/
+    // write_canonical/format) route through this so with_output_to/2
+    // can intercept their output.
+    void    emit_output(const std::string& s);
+    void    emit_output_char(char c);
 
     // ---- ISO error term helpers --------------------------------------
     // Construct error(ErrTerm, _) with a fresh unbound Context slot,
@@ -3901,40 +3936,42 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
     }
 
     // ---- I/O -------------------------------------------------------
+    // All write paths route through emit_output / emit_output_char so
+    // with_output_to/2 can intercept them into a capture buffer.
     if (op == "write/1") {
-        std::printf("%s", render(*get_cell("A1")).c_str());
+        emit_output(render(*get_cell("A1")));
         std::fflush(stdout);
         pc += 1; return true;
     }
     if (op == "nl/0") {
-        std::printf("\\n");
+        emit_output_char(''\\n'');
         std::fflush(stdout);
         pc += 1; return true;
     }
     if (op == "write_atom/1" || op == "writeln/1") {
-        std::printf("%s\\n", render(*get_cell("A1")).c_str());
+        emit_output(render(*get_cell("A1")));
+        emit_output_char(''\\n'');
         std::fflush(stdout);
         pc += 1; return true;
     }
     // print/1 — alias for write/1 (no portray hook in this runtime).
     if (op == "print/1") {
-        std::printf("%s", render(*get_cell("A1")).c_str());
+        emit_output(render(*get_cell("A1")));
         std::fflush(stdout);
         pc += 1; return true;
     }
     // display/1 — write a term without operator notation. Our render
     // path doesn''t use operator syntax anyway, so display == write.
     if (op == "display/1") {
-        std::printf("%s", render(*get_cell("A1")).c_str());
+        emit_output(render(*get_cell("A1")));
         std::fflush(stdout);
         pc += 1; return true;
     }
-    // tab/1 — write N spaces to stdout. N must be a non-negative
-    // integer; otherwise fail.
+    // tab/1 — write N spaces. N must be a non-negative integer.
     if (op == "tab/1") {
         Value n = deref(*get_cell("A1"));
         if (n.tag != Value::Tag::Integer || n.i < 0) return false;
-        for (std::int64_t i = 0; i < n.i; ++i) std::fputc('' '', stdout);
+        for (std::int64_t i = 0; i < n.i; ++i) emit_output_char('' '');
         std::fflush(stdout);
         pc += 1; return true;
     }
@@ -3973,22 +4010,59 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
                 }
             }
             if (needs_quote) {
-                std::fputc(39, stdout); // opening single quote
+                emit_output_char(static_cast<char>(39)); // opening quote
                 for (unsigned char c : s) {
-                    if (c == 39 || c == 92) std::fputc(92, stdout);
-                    std::fputc(c, stdout);
+                    if (c == 39 || c == 92) emit_output_char(static_cast<char>(92));
+                    emit_output_char(static_cast<char>(c));
                 }
-                std::fputc(39, stdout); // closing single quote
+                emit_output_char(static_cast<char>(39)); // closing quote
             } else {
-                std::printf("%s", s.c_str());
+                emit_output(s);
             }
             std::fflush(stdout);
             pc += 1; return true;
         }
-        std::printf("%s", render(v).c_str());
+        emit_output(render(v));
         std::fflush(stdout);
         pc += 1; return true;
     }
+    // ---- with_output_to/2 -------------------------------------------
+    // with_output_to(+Sink, :Goal): capture Goal''s output into Sink.
+    // Sink is atom(V) / string(V) / codes(V). The I/O builtins write
+    // to the top OutputCaptureFrame''s buffer while it''s active; when
+    // Goal proceeds normally, control lands at output_capture_return_pc
+    // which pops the frame and unifies the buffer with Sink.
+    if (op == "with_output_to/2") {
+        Value sv = deref(*get_cell("A1"));
+        if (sv.tag != Value::Tag::Compound || sv.args.size() != 1
+            || (sv.s != "atom/1" && sv.s != "string/1"
+                && sv.s != "codes/1")) return false;
+        OutputCaptureFrame f;
+        f.sink = get_cell("A1");
+        // saved_cp: for the direct BuiltinCall instr path, pc + 1
+        // is the next instruction. For invoke_goal_as_call goal-term
+        // dispatch, the caller pre-sets cp = after_pc so we use that.
+        f.saved_cp = (cp != 0) ? cp : (pc + 1);
+        f.base_cp_count = choice_points.size();
+        f.base_agg_count = aggregate_frames.size();
+        f.base_catcher_count = catcher_frames.size();
+        f.trail_mark = trail.size();
+        f.saved_cut_barrier = cut_barrier;
+        f.saved_regs = regs;
+        f.saved_mode_stack = mode_stack;
+        f.saved_env_stack = env_stack;
+        std::size_t my_depth = output_capture_frames.size();
+        output_capture_frames.push_back(std::move(f));
+        CellPtr goal = get_cell("A2");
+        if (!invoke_goal_as_call(goal, output_capture_return_pc)) {
+            // Goal failed to dispatch — pop and propagate.
+            if (output_capture_frames.size() > my_depth)
+                output_capture_frames.pop_back();
+            return false;
+        }
+        return true;
+    }
+
     // ---- format/1, format/2, format/3 -------------------------------
     // Walks the format string, expanding ~-directives.
     // Supported: ~w (write), ~p (print, same as ~w), ~a (atom),
@@ -4105,7 +4179,7 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         }
         // Dispatch on destination (format/3) or just print (format/1, /2).
         if (!is_f3) {
-            std::fwrite(buf.data(), 1, buf.size(), stdout);
+            emit_output(buf);
             std::fflush(stdout);
             pc += 1; return true;
         }
@@ -4113,7 +4187,7 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         Value dv = deref(*get_cell("A1"));
         if (dv.tag == Value::Tag::Atom) {
             if (dv.s == "user_output") {
-                std::fwrite(buf.data(), 1, buf.size(), stdout);
+                emit_output(buf);
                 std::fflush(stdout);
                 pc += 1; return true;
             }
@@ -4714,6 +4788,47 @@ bool WamState::step(const Instruction& instr) {
             // the just-removed clause).
             if (!choice_points.empty()) choice_points.pop_back();
             return retract_try_next();
+        }
+        case Instruction::Op::OutputCaptureReturn: {
+            // Reached when a with_output_to/2 goal proceeds normally.
+            // Pop the OutputCaptureFrame, unify the captured buffer
+            // with the sink (atom/string/codes), and continue at the
+            // saved_cp.
+            if (output_capture_frames.empty()) return false;
+            OutputCaptureFrame f = std::move(output_capture_frames.back());
+            output_capture_frames.pop_back();
+            Value sink = deref(*f.sink);
+            if (sink.tag != Value::Tag::Compound
+                || sink.args.size() != 1) return false;
+            CellPtr tgt = sink.args[0];
+            Value out_v;
+            if (sink.s == "atom/1" || sink.s == "string/1") {
+                out_v = Value::Atom(f.buffer);
+            } else if (sink.s == "codes/1") {
+                // Build a list of integer codes from buf bottom-up.
+                CellPtr list = std::make_shared<Cell>(Value::Atom("[]"));
+                for (auto it = f.buffer.rbegin();
+                     it != f.buffer.rend(); ++it) {
+                    CellPtr head = std::make_shared<Cell>(Value::Integer(
+                        static_cast<std::int64_t>(
+                            static_cast<unsigned char>(*it))));
+                    std::vector<CellPtr> ca;
+                    ca.push_back(head);
+                    ca.push_back(list);
+                    list = std::make_shared<Cell>(
+                        Value::Compound("[|]/2", std::move(ca)));
+                }
+                out_v = *list;
+            } else {
+                return false;
+            }
+            if (tgt->is_unbound()) bind_cell(tgt, out_v);
+            else if (!unify_cells(tgt,
+                std::make_shared<Cell>(out_v))) return false;
+            if (f.saved_cp == 0) { halt = true; return true; }
+            pc = f.saved_cp;
+            cp = 0;
+            return true;
         }
         case Instruction::Op::Proceed: {
             if (cp == 0) { halt = true; return true; }
@@ -5725,6 +5840,20 @@ bool WamState::invoke_goal_as_call(CellPtr goal_cell, std::size_t after_pc) {
         if (key == "setof/3")   { cp = after_pc; return dispatch_aggregate_call("setof", after_pc); }
         if (key == "sub_atom/5") return dispatch_sub_atom(after_pc);
         if (key == "retract/1") return dispatch_retract(after_pc);
+        if (key == "with_output_to/2") {
+            // Set cp = after_pc so the builtin captures the correct
+            // continuation. The builtin saves cp as saved_cp; without
+            // this, it would use pc + 1 (which only makes sense for
+            // the direct BuiltinCall instr — not for goal-term
+            // dispatch where pc points at a synthetic op).
+            cp = after_pc;
+            // Saved_cp inside the builtin will then == after_pc.
+            // We call builtin() directly here so the goal-term path
+            // doesn''t fall through to the generic post-builtin
+            // continuation override below.
+            if (!builtin(key, 2)) return false;
+            return true;
+        }
         // ^/2 — existential quantification. For find-style
         // aggregation (which is all this runtime currently
         // supports for bagof/setof) ^/2 is transparent: invoke A2
@@ -6017,6 +6146,25 @@ bool WamState::aggregate_bind_next_group() {
     return true;
 }
 
+// Output emission router. with_output_to/2 pushes an
+// OutputCaptureFrame; while one is on top, all I/O builtins write
+// here instead of stdout, so the goal''s output gets captured.
+void WamState::emit_output(const std::string& s) {
+    if (!output_capture_frames.empty()) {
+        output_capture_frames.back().buffer += s;
+    } else {
+        std::fwrite(s.data(), 1, s.size(), stdout);
+    }
+}
+
+void WamState::emit_output_char(char c) {
+    if (!output_capture_frames.empty()) {
+        output_capture_frames.back().buffer.push_back(c);
+    } else {
+        std::fputc(static_cast<unsigned char>(c), stdout);
+    }
+}
+
 // catch(Goal, Catcher, Recovery): push a CatcherFrame snapshotting
 // current VM state, then dispatch to Goal as a tail-call whose
 // continuation is the auto-injected CatchReturn instruction.
@@ -6282,6 +6430,32 @@ bool WamState::backtrack() {
             // Restore regs/env/mode/cp/cut so the world looks exactly
             // as it did at catch entry, then continue backtracking
             // outside the catch.
+            regs        = std::move(f.saved_regs);
+            mode_stack  = std::move(f.saved_mode_stack);
+            env_stack   = std::move(f.saved_env_stack);
+            cp          = f.saved_cp;
+            cut_barrier = f.saved_cut_barrier;
+            continue;
+        }
+        // OutputCaptureFrame: with_output_to/2 goal failed. Drop the
+        // frame and the partially-accumulated buffer; propagate the
+        // failure outside.
+        if (!output_capture_frames.empty()
+            && choice_points.size() == output_capture_frames.back().base_cp_count
+            && (aggregate_frames.empty()
+                || aggregate_frames.back().base_cp_count
+                       <= output_capture_frames.back().base_cp_count)
+            && (catcher_frames.empty()
+                || catcher_frames.back().base_cp_count
+                       <= output_capture_frames.back().base_cp_count))
+        {
+            OutputCaptureFrame f = std::move(output_capture_frames.back());
+            output_capture_frames.pop_back();
+            while (trail.size() > f.trail_mark) {
+                TrailEntry t = std::move(trail.back());
+                trail.pop_back();
+                *t.cell = std::move(t.prev);
+            }
             regs        = std::move(f.saved_regs);
             mode_stack  = std::move(f.saved_mode_stack);
             env_stack   = std::move(f.saved_env_stack);

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1476,6 +1476,7 @@ is_builtin_pred(writeln, 1).        % I/O — write/1 + nl/0.
 is_builtin_pred(print, 1).          % I/O — alias for write/1.
 is_builtin_pred(tab, 1).            % I/O — N spaces.
 is_builtin_pred(write_canonical, 1).% I/O — quote atoms as needed.
+is_builtin_pred(with_output_to, 2). % I/O — capture goal''s output.
 is_builtin_pred(format, 1).  % I/O — formatted output, ~-directives.
 is_builtin_pred(format, 2).
 is_builtin_pred(format, 3).

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -1641,6 +1641,66 @@ user:wam_cpp_test_wc_quoted :- write_canonical('hello world'), nl.
 % it from an integer.
 user:wam_cpp_test_wc_digit_atom :- write_canonical('5'), nl.
 
+% with_output_to/2 — capture write/format output into an atom,
+% string, or codes list. Pushes an OutputCaptureFrame; while the
+% frame is on top, all I/O builtins route through emit_output()
+% which appends to the frame''s buffer instead of writing stdout.
+% On goal success, OutputCaptureReturn pops the frame and unifies
+% the buffer with the sink (atom/string/codes per the sink shape).
+:- dynamic user:wam_cpp_test_wot_basic/0.
+:- dynamic user:wam_cpp_test_wot_multi/0.
+:- dynamic user:wam_cpp_test_wot_format/0.
+:- dynamic user:wam_cpp_test_wot_string/0.
+:- dynamic user:wam_cpp_test_wot_codes/0.
+:- dynamic user:wam_cpp_test_wot_empty/0.
+:- dynamic user:wam_cpp_test_wot_goal_fails/0.
+:- dynamic user:wam_cpp_test_wot_tab/0.
+:- dynamic user:wam_cpp_test_wot_nested/0.
+
+user:wam_cpp_test_wot_basic :-
+    with_output_to(atom(A), write(hello)),
+    A = hello.
+
+% Multi-write via conjunction.
+user:wam_cpp_test_wot_multi :-
+    with_output_to(atom(A), (write(foo), write(bar))),
+    A = foobar.
+
+user:wam_cpp_test_wot_format :-
+    with_output_to(atom(A), format("X = ~w", [42])),
+    A = 'X = 42'.
+
+user:wam_cpp_test_wot_string :-
+    with_output_to(string(S), write(test)),
+    S = test.
+
+user:wam_cpp_test_wot_codes :-
+    with_output_to(codes(C), write(ab)),
+    C = [97, 98].
+
+user:wam_cpp_test_wot_empty :-
+    with_output_to(atom(A), true),
+    A = ''.
+
+user:wam_cpp_test_wot_goal_fails :-
+    \+ with_output_to(atom(_), fail).
+
+% tab routes through emit_output too.
+user:wam_cpp_test_wot_tab :-
+    with_output_to(atom(A), (write(x), tab(3), write(y))),
+    A = 'x   y'.
+
+% Nested capture: inner frame intercepts only its own goal''s
+% output; outer continues to capture the rest. Regression guard
+% for the saved_cp handling via invoke_goal_as_call dispatch.
+user:wam_cpp_test_wot_nested :-
+    with_output_to(atom(Outer),
+        (write(a),
+         with_output_to(atom(Inner), write(b)),
+         write(c))),
+    Outer = ac,
+    Inner = b.
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -5728,6 +5788,115 @@ test(cpp_e2e_wc_digit_atom,
         ( build_e2e_binary(TmpDir, BinPath),
           run_query_stdout(BinPath, 'wam_cpp_test_wc_digit_atom/0',
                            [], true, "'5'\n")
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% with_output_to/2 — capture I/O into an atom/string/codes.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_wot_basic, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_wot_basic', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_wot_basic/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_wot_basic/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_wot_multi, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_wot_multi', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_wot_multi/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_wot_multi/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_wot_format, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_wot_format', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_wot_format/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_wot_format/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_wot_string, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_wot_string', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_wot_string/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_wot_string/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_wot_codes, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_wot_codes', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_wot_codes/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_wot_codes/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_wot_empty, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_wot_empty', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_wot_empty/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_wot_empty/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_wot_goal_fails,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_wot_fails', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_wot_goal_fails/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_wot_goal_fails/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_wot_tab, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_wot_tab', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_wot_tab/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_wot_tab/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_wot_nested, [condition(cpp_compiler_available)]) :-
+    % Nested capture regression guard: ensures the inner frame''s
+    % saved_cp uses after_pc from invoke_goal_as_call (not pc + 1
+    % which is meaningless when the builtin is dispatched as a
+    % goal-term).
+    unique_cpp_tmp_dir('tmp_cpp_e2e_wot_nested', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_wot_nested/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_wot_nested/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Adds `with_output_to(+Sink, :Goal)` — run `Goal` with its I/O captured into `Sink` (`atom(V)` / `string(V)` / `codes(V)`). The natural complement to `format(atom(...))` from #2131, but for capturing arbitrary `write` / `format` / `nl` / `tab` sequences as a single string.

```prolog
?- with_output_to(atom(A), (write(foo), write(bar))).
A = foobar.

?- with_output_to(codes(C), format("X = ~w", [42])).
C = [88, 32, 61, 32, 52, 50].   % "X = 42"
```

## Implementation

- `WamState` gains an `OutputCaptureFrame` stack. While non-empty, the top frame's buffer absorbs all I/O builtin output.
- `emit_output` / `emit_output_char` helpers route either to the top buffer or to stdout. Every I/O builtin (`write/1`, `nl/0`, `writeln/1`, `print/1`, `display/1`, `tab/1`, `write_canonical/1`, and `format/1..3`'s stdout case) now goes through them.
- New `OutputCaptureReturn` synthetic op + `output_capture_return_pc`. `with_output_to/2` pushes a frame and dispatches `Goal` with `cp = output_capture_return_pc`; on success, the op pops the frame and unifies the buffer with `Sink` (`Atom` for `atom(V)` / `string(V)`, code-list for `codes(V)`). On `Goal` failure, the `backtrack` pass pops the frame at `base_cp_count` (parallel to `CatcherFrame`).

## Continuation-pc fix for goal-term dispatch

When `with_output_to/2` is invoked as a **goal-term** (via `invoke_goal_as_call` — e.g. nested inside another conjunction), `pc + 1` is the wrong `saved_cp` because `pc` points at the dispatching synthetic op. Special-cased in `invoke_goal_as_call` to pre-set `cp = after_pc`, and the builtin uses `cp` when non-zero, else `pc + 1`. The direct `BuiltinCall` path is unchanged. Caught by the nested-capture test.

## Test plan

- [x] 9 new e2e tests:
  - basic capture (`write` into `atom(A)`)
  - multi-write via conjunction
  - format inside capture
  - `string(S)` sink variant
  - `codes(C)` sink variant (integer codes)
  - empty buffer when goal writes nothing
  - goal-fail fails the whole `with_output_to`
  - `tab` captured into the buffer
  - **nested** capture (regression guard for the `saved_cp` / `after_pc` fix)
- [x] Full `test_wam_cpp_generator.pl` suite passes (~280 tests)
- [x] `test_wam_target.pl` passes

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_