### PR TITLE
feat(wam-cpp): split_string/4

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -3366,6 +3366,67 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         pc += 1; return true;
     }
 
+    // ---- split_string/4 ---------------------------------------------
+    // split_string(+String, +SepChars, +PadChars, -SubStrings).
+    // Walks String left-to-right, splitting on any char in SepChars.
+    // Each resulting substring has any leading/trailing chars in
+    // PadChars stripped. Adjacent separators produce empty
+    // substrings. Empty SepChars means "no splits, just pad".
+    if (op == "split_string/4") {
+        auto read_str = [&](CellPtr c, std::string& out) -> bool {
+            Value v = deref(*c);
+            if (v.tag == Value::Tag::Atom) { out = v.s; return true; }
+            if (v.tag == Value::Tag::Integer) {
+                out = std::to_string(v.i); return true;
+            }
+            if (v.tag == Value::Tag::Float) {
+                out = render(v); return true;
+            }
+            return false;
+        };
+        std::string str, seps, pads;
+        if (!read_str(get_cell("A1"), str)) return false;
+        if (!read_str(get_cell("A2"), seps)) return false;
+        if (!read_str(get_cell("A3"), pads)) return false;
+        auto in_chars = [](char c, const std::string& set) -> bool {
+            return set.find(c) != std::string::npos;
+        };
+        // Split.
+        std::vector<std::string> parts;
+        std::string current;
+        for (char c : str) {
+            if (in_chars(c, seps)) {
+                parts.push_back(std::move(current));
+                current.clear();
+            } else {
+                current.push_back(c);
+            }
+        }
+        parts.push_back(std::move(current));
+        // Strip pad chars from each part''s ends.
+        for (auto& p : parts) {
+            std::size_t start = 0;
+            while (start < p.size() && in_chars(p[start], pads)) ++start;
+            std::size_t end = p.size();
+            while (end > start && in_chars(p[end - 1], pads)) --end;
+            p = p.substr(start, end - start);
+        }
+        // Build the result list.
+        CellPtr result = std::make_shared<Cell>(Value::Atom("[]"));
+        for (auto it = parts.rbegin(); it != parts.rend(); ++it) {
+            CellPtr head = std::make_shared<Cell>(Value::Atom(*it));
+            std::vector<CellPtr> cons_args;
+            cons_args.push_back(head);
+            cons_args.push_back(result);
+            result = std::make_shared<Cell>(
+                Value::Compound("[|]/2", std::move(cons_args)));
+        }
+        CellPtr tgt = get_cell("A4");
+        if (tgt->is_unbound()) { bind_cell(tgt, *result); pc += 1; return true; }
+        if (!unify_cells(tgt, result)) return false;
+        pc += 1; return true;
+    }
+
     // ---- char_code/2 ------------------------------------------------
     // Bidirectional. (+Char, ?Code) → unify Code with the integer code
     // of single-char atom Char. (?Char, +Code) → build the single-char

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1485,6 +1485,7 @@ is_builtin_pred(atom_chars, 2).   % atom ↔ list of single-char atoms.
 is_builtin_pred(number_codes, 2). % number ↔ list of integer codes.
 is_builtin_pred(atom_concat, 3).  % (+, +, ?) — concatenation.
 is_builtin_pred(atom_length, 2).  % atom → length in chars.
+is_builtin_pred(split_string, 4). % split string by separator chars.
 is_builtin_pred(char_code, 2).    % char-atom ↔ integer code.
 is_builtin_pred(assertz, 1).      % dynamic db: append fact.
 is_builtin_pred(asserta, 1).      % dynamic db: prepend fact.

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -1701,6 +1701,60 @@ user:wam_cpp_test_wot_nested :-
     Outer = ac,
     Inner = b.
 
+% split_string/4 — separator-based splitting with optional pad-char
+% stripping. Walks the input left-to-right, splitting on any char in
+% SepChars; adjacent separators produce empty substrings. After
+% splitting, each substring has leading/trailing chars in PadChars
+% stripped. Empty SepChars = "no splits, just pad the whole input".
+:- dynamic user:wam_cpp_test_split_simple/0.
+:- dynamic user:wam_cpp_test_split_empty/0.
+:- dynamic user:wam_cpp_test_split_single/0.
+:- dynamic user:wam_cpp_test_split_double_sep/0.
+:- dynamic user:wam_cpp_test_split_pad/0.
+:- dynamic user:wam_cpp_test_split_sep_and_pad/0.
+:- dynamic user:wam_cpp_test_split_multi_sep/0.
+:- dynamic user:wam_cpp_test_split_pad_trailing/0.
+:- dynamic user:wam_cpp_test_split_atom_input/0.
+
+user:wam_cpp_test_split_simple :-
+    split_string("a,b,c", ",", "", L),
+    L = ["a","b","c"].
+
+user:wam_cpp_test_split_empty :-
+    split_string("", ",", "", L),
+    L = [""].
+
+user:wam_cpp_test_split_single :-
+    split_string("hello", ",", "", L),
+    L = ["hello"].
+
+user:wam_cpp_test_split_double_sep :-
+    split_string("a,,b", ",", "", L),
+    L = ["a","","b"].
+
+% No separators — just pad the whole input.
+user:wam_cpp_test_split_pad :-
+    split_string(" hello ", "", " ", L),
+    L = ["hello"].
+
+user:wam_cpp_test_split_sep_and_pad :-
+    split_string("a , b , c", ",", " ", L),
+    L = ["a","b","c"].
+
+% Multiple separator chars in the set.
+user:wam_cpp_test_split_multi_sep :-
+    split_string("a,b;c,d", ",;", "", L),
+    L = ["a","b","c","d"].
+
+user:wam_cpp_test_split_pad_trailing :-
+    split_string("abc   ", "", " ", L),
+    L = ["abc"].
+
+% Atom input works too (atom ≡ string in this runtime).
+user:wam_cpp_test_split_atom_input :-
+    split_string('a,b,c', ",", "", L),
+    L = ["a","b","c"].
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -5897,6 +5951,120 @@ test(cpp_e2e_wot_nested, [condition(cpp_compiler_available)]) :-
                               [emit_main(true)], TmpDir),
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath, 'wam_cpp_test_wot_nested/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% split_string/4 — separator + pad string splitting.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_split_simple, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_split_simple', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_split_simple/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_split_simple/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_split_empty, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_split_empty', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_split_empty/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_split_empty/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_split_single, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_split_single', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_split_single/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_split_single/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_split_double_sep,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_split_dsep', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_split_double_sep/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_split_double_sep/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_split_pad, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_split_pad', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_split_pad/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_split_pad/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_split_sep_and_pad,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_split_sp', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_split_sep_and_pad/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_split_sep_and_pad/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_split_multi_sep,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_split_msep', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_split_multi_sep/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_split_multi_sep/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_split_pad_trailing,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_split_padt', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_test_split_pad_trailing/0],
+            [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_split_pad_trailing/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_split_atom_input,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_split_atom', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_split_atom_input/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath,
+                    'wam_cpp_test_split_atom_input/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Adds `split_string(+String, +SepChars, +PadChars, -SubStrings)` — the standard string-splitting builtin alongside `sub_atom/5` and the atom-conversion family.

```prolog
?- split_string("a,b,c", ",", "", L).
L = ["a","b","c"].

?- split_string("a,,b", ",", "", L).         % adjacent seps → empty
L = ["a","","b"].

?- split_string(" hello ", "", " ", L).      % empty seps = pad-only
L = ["hello"].

?- split_string("a , b , c", ",", " ", L).   % split then pad
L = ["a","b","c"].

?- split_string("a,b;c,d", ",;", "", L).     % multi-char SepChars
L = ["a","b","c","d"].
```

## Implementation

Direct builtin (no helper-injection): walks the input char by char, splitting on any char in `SepChars`; adjacent separators produce empty substrings. Each substring then has leading/trailing chars in `PadChars` stripped — empty `SepChars` means "no splits, just pad the whole input".

Accepts atoms or strings interchangeably for input and the char sets (atoms ≡ strings in this runtime); integers / floats are rendered via the format path so `split_string(123, ",", ...)` works.

## Test plan

- [x] 9 new e2e tests:
  - simple comma-split
  - empty input → `[""]`
  - single substring (no separators in input)
  - adjacent separators → empty element preserved
  - pad-only mode (empty `SepChars`)
  - sep + pad together (typical CSV-with-spaces case)
  - multi-char `SepChars` (`",;"` as set)
  - trailing pad chars stripped
  - atom input compat
- [x] Full `test_wam_cpp_generator.pl` suite passes (~290 tests)
- [x] `test_wam_target.pl` passes

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_