### PR TITLE
feat(wam-c): add functor builtin support

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,7 +5,7 @@ Status date: 2026-05-16
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `ab60ee06` (`Merge pull request #2163 from s243a/perf/wam-c-lowered-helper-compile-size`)
+- `main` at `662e2b18` (`Merge pull request #2167 from s243a/test/wam-c-lowered-helper-larger-scale-regression`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
@@ -15,7 +15,7 @@ Base verified locally:
 
 Active branch:
 
-- `test/wam-c-lowered-helper-larger-scale-regression`
+- `feat/wam-c-lowered-helper-next-shape-selection`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -65,7 +65,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper larger-scale calibration | Done | Self-contained lowered-helper scales no longer require matching `data/benchmark/<scale>` directories; `25x`, `100x`, and `1k` preserve output parity |
 | Lowered helper indexed row dispatch | Done | First-argument hash-bucket dispatch preserves unbound-argument fallback and gives `1k` lowered-helper runtime around 5.8x faster than interpreted in local calibration |
 | Lowered helper compile/code-size compaction | Done | Compact static row tables plus bucket row-index arrays reduce `1k` generated `lib.c` from 12.8 MB to 2.6 MB and compile time from 151.75s to 0.98s |
-| Lowered helper larger-scale regression | In progress | Active branch promotes `100x` into the focused local lowered-helper parity regression while leaving `1k` as calibration-only because it costs about 31s end to end |
+| Lowered helper larger-scale regression | Done | `tests/test_wam_c_lowered_helper_scale_regression.py` now promotes `100x` into the focused local lowered-helper parity regression while leaving `1k` as calibration-only because it costs about 31s end to end |
+| Lowered helper next-shape selection | In progress | Active branch selects term-shape builtin parity as the next narrow helper-adjacent surface, starting with C `functor/3` runtime support because Haskell and Rust already cover richer structure inspection paths |
 
 ## Current C Target Baseline
 
@@ -82,8 +83,10 @@ The C target is now a credible small WAM backend:
   second-argument constant dispatch, and direct list dispatch.
 - Uses a tagged `InstructionPayload` union instead of a single wide instruction
   struct.
-- Supports basic `builtin_call` delegation for tested builtins:
-  `atom/1`, `integer/1`, `is_list/1`, `=/2`, and `is/2`.
+- Supports `builtin_call` delegation for tested builtins:
+  `atom/1`, `integer/1`, `number/1`, `var/1`, `nonvar/1`,
+  `compound/1`, `is_list/1`, `=/2`, `is/2`, arithmetic comparisons, and
+  active-branch `functor/3`.
 - Supports deterministic `call_foreign` dispatch through a C handler registry.
 - Can opt into a prototype lowered-helper path for constant fact-only
   predicates, plus same-arity alias bodies that call those native fact helpers,
@@ -130,7 +133,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | First-arg indexing | Done | Done | Done | C has constants, structures, mixed term, and list dispatch. |
 | Second-arg indexing | Partial | Partial/Done | Partial/Done | C has constant A2 dispatch; broaden tests if this becomes hot. |
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
-| Builtin calls | Partial | Broader | Broader | C has a small builtin set. Add `functor/3`, `arg/3`, `atom_concat/3`, arithmetic comparisons as needed. |
+| Builtin calls | Partial | Broader | Broader | C has a growing builtin set. Active branch adds `functor/3`; next likely term-shape gaps are `arg/3` and `atom_concat/3` if benchmark surfaces need them. |
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
 | Negation / control builtins | Partial | Broader | Broader | C likely needs explicit tests for `\+/1`, cut interactions, and if-then-else lowering. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
@@ -146,38 +149,50 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `test/wam-c-lowered-helper-larger-scale-regression`
+### 1. `feat/wam-c-lowered-helper-next-shape-selection`
 
-Goal: pin the cheapest useful larger-scale regression point now that runtime
-and compile cost are both acceptable.
-
-Scope:
-
-- Add `100x` to the focused local lowered-helper parity regression.
-- Assert interpreted/lowered hash parity and expected row counts for `dev`,
-  `10x`, and `100x`.
-- Keep `1k` as documented calibration-only for now because it costs about 31s
-  in the normal matrix path.
-
-Status: active.
-
-Routine-scale selection:
-
-| Scale | Normal matrix wall-clock | Rows | Decision |
-|---|---:|---:|---|
-| `100x` | 8.53s | 1600 | Promote to local regression |
-| `1k` | 30.84s | 4000 | Keep as calibration-only |
-
-### 2. `feat/wam-c-lowered-helper-next-shape-selection`
-
-Goal: choose the next lowered-helper feature gap now that scaled row dispatch
-has local regression coverage.
+Goal: choose and pin the next helper-adjacent feature gap now that scaled row
+dispatch has local regression coverage.
 
 Scope:
 
 - Compare remaining C gaps against the Haskell and Rust hybrid WAM examples.
 - Prefer a narrow helper shape or builtin needed by existing benchmark surfaces.
-- Avoid broad CI expansion until the next target surface is stable.
+- Start with `functor/3` because it is a compact term-shape primitive that
+  supports structure introspection/construction without broad CI expansion.
+
+Status: active.
+
+Selected next-shape rationale:
+
+| Candidate | Decision | Reason |
+|---|---:|---|
+| `functor/3` | Active | Small term-shape builtin with Haskell/Rust precedent and direct C runtime coverage potential. |
+| `arg/3` | Next likely branch | Complements `functor/3`, but term argument extraction needs a separate focused smoke. |
+| `atom_concat/3` | Later | Useful, but less directly tied to lowered helper row/structure shape selection. |
+| Aggregates | Defer | Needs broader term-copy/list construction support and would be too large for this branch. |
+
+### 2. `feat/wam-c-arg-builtin`
+
+Goal: add the next narrow term-inspection builtin after `functor/3`.
+
+Scope:
+
+- Implement deterministic `arg/3` read/extraction mode for structures and lists.
+- Add direct executable smoke coverage before using it in generated Prolog.
+- Keep construction and non-deterministic modes out of scope unless an existing
+  benchmark needs them.
+
+Status: recommended after this branch.
+
+## Completed Larger-Scale Selection
+
+Routine-scale selection from the merged larger-scale regression branch:
+
+| Scale | Normal matrix wall-clock | Rows | Decision |
+|---|---:|---:|---|
+| `100x` | 8.53s | 1600 | Promoted to local regression |
+| `1k` | 30.84s | 4000 | Keep as calibration-only |
 
 ## Completed Calibration
 

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -2033,6 +2033,68 @@ static bool wam_eval_arith(WamState *state, WamValue value, int *out) {
     return false;
 }
 
+static bool wam_term_functor(WamState *state, WamValue term,
+                             WamValue *name_out, int *arity_out) {
+    WamValue *cell = wam_deref_ptr(state, &term);
+    if (cell->tag == VAL_ATOM) {
+        *name_out = *cell;
+        *arity_out = 0;
+        return true;
+    }
+    if (cell->tag == VAL_INT) {
+        *name_out = *cell;
+        *arity_out = 0;
+        return true;
+    }
+    if (cell->tag == VAL_LIST) {
+        *name_out = val_atom(".");
+        *arity_out = 2;
+        return true;
+    }
+    if (cell->tag != VAL_STR) return false;
+
+    WamValue *functor = &state->H_array[cell->data.ref_addr];
+    if (functor->tag != VAL_ATOM) return false;
+    const char *slash = strrchr(functor->data.atom, ''/'');
+    if (!slash) return false;
+    char *end = NULL;
+    long arity = strtol(slash + 1, &end, 10);
+    if (!end || *end != 0 || arity < 0 || arity > 255) return false;
+
+    size_t len = (size_t)(slash - functor->data.atom);
+    char name_buf[256];
+    if (len >= sizeof(name_buf)) return false;
+    memcpy(name_buf, functor->data.atom, len);
+    name_buf[len] = 0;
+    *name_out = val_atom(wam_intern_atom(state, name_buf));
+    *arity_out = (int)arity;
+    return true;
+}
+
+static bool wam_make_structure_from_functor(WamState *state,
+                                            const char *name,
+                                            int arity,
+                                            WamValue *out) {
+    char functor_buf[320];
+    int written = snprintf(functor_buf, sizeof(functor_buf), "%s/%d", name, arity);
+    if (written < 0 || (size_t)written >= sizeof(functor_buf)) return false;
+
+    int required = state->H + 1 + arity;
+    if (required >= state->H_cap) {
+        if (state->H_cap == 0) state->H_cap = WAM_INITIAL_CAP;
+        while (required >= state->H_cap) state->H_cap *= 2;
+        state->H_array = realloc(state->H_array, sizeof(WamValue) * state->H_cap);
+    }
+
+    out->tag = VAL_STR;
+    out->data.ref_addr = state->H;
+    state->H_array[state->H++] = val_atom(wam_intern_atom(state, functor_buf));
+    for (int i = 0; i < arity; i++) {
+        state->H_array[state->H++] = val_unbound("_");
+    }
+    return true;
+}
+
 bool wam_execute_builtin(WamState *state, const char *op, int arity) {
     if (strcmp(op, "true/0") == 0 && arity == 0) return true;
     if ((strcmp(op, "fail/0") == 0 || strcmp(op, "false/0") == 0) && arity == 0) return false;
@@ -2062,6 +2124,30 @@ bool wam_execute_builtin(WamState *state, const char *op, int arity) {
         if (!wam_eval_arith(state, state->A[1], &result)) return false;
         WamValue value = val_int(result);
         return wam_unify(state, &state->A[0], &value);
+    }
+
+    if (strcmp(op, "functor/3") == 0 && arity == 3) {
+        WamValue *term = wam_deref_ptr(state, &state->A[0]);
+        if (!val_is_unbound(*term)) {
+            WamValue name = val_unbound("Name");
+            int term_arity = 0;
+            if (!wam_term_functor(state, state->A[0], &name, &term_arity)) return false;
+            WamValue arity_value = val_int(term_arity);
+            return wam_unify(state, &state->A[1], &name) &&
+                   wam_unify(state, &state->A[2], &arity_value);
+        }
+
+        WamValue *name = wam_deref_ptr(state, &state->A[1]);
+        WamValue *arity_cell = wam_deref_ptr(state, &state->A[2]);
+        if (arity_cell->tag != VAL_INT || arity_cell->data.integer < 0) return false;
+        if (arity_cell->data.integer == 0) {
+            if (name->tag != VAL_ATOM && name->tag != VAL_INT) return false;
+            return wam_unify(state, &state->A[0], name);
+        }
+        if (name->tag != VAL_ATOM) return false;
+        WamValue structure;
+        if (!wam_make_structure_from_functor(state, name->data.atom, arity_cell->data.integer, &structure)) return false;
+        return wam_unify(state, &state->A[0], &structure);
     }
 
     if (arity == 2) {

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -1127,7 +1127,7 @@ run_multi_predicate_setup_executable_smoke :-
     run_c_smoke_plain(ExePath).
 
 run_builtin_call_executable_smoke :-
-    WamCode = 'wam_c_builtin_atom/1:\n    builtin_call atom/1, 1\n    proceed\nwam_c_builtin_is/2:\n    builtin_call is/2, 2\n    proceed',
+    WamCode = 'wam_c_builtin_atom/1:\n    builtin_call atom/1, 1\n    proceed\nwam_c_builtin_is/2:\n    builtin_call is/2, 2\n    proceed\nwam_c_builtin_functor/3:\n    builtin_call functor/3, 3\n    proceed',
     compile_wam_predicate_to_c(user:wam_c_builtin_atom/1, WamCode, [], PredCode),
     compile_wam_runtime_to_c([], RuntimeCode),
     get_time(Now),
@@ -1820,6 +1820,16 @@ wam_c_builtin_smoke_main(
 
 void setup_wam_c_builtin_atom_1(WamState* state);
 
+static WamValue make_binary_struct(WamState *state, const char *functor, WamValue left, WamValue right) {
+    WamValue term;
+    term.tag = VAL_STR;
+    term.data.ref_addr = state->H;
+    state->H_array[state->H++] = val_atom(functor);
+    state->H_array[state->H++] = left;
+    state->H_array[state->H++] = right;
+    return term;
+}
+
 int main(void) {
     WamState state;
     wam_state_init(&state);
@@ -1844,6 +1854,26 @@ int main(void) {
     if (is_rc != 0 || state.A[0].tag != VAL_INT || state.A[0].data.integer != 7) {
         wam_free_state(&state);
         return 30;
+    }
+
+    WamValue pair_term = make_binary_struct(&state, "pair/2", val_atom("left"), val_int(9));
+    WamValue functor_read_args[3] = { pair_term, val_unbound("Name"), val_unbound("Arity") };
+    int functor_read_rc = wam_run_predicate(&state, "wam_c_builtin_functor/3", functor_read_args, 3);
+    if (functor_read_rc != 0 || state.P != WAM_HALT ||
+        state.A[1].tag != VAL_ATOM || strcmp(state.A[1].data.atom, "pair") != 0 ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 2) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    WamValue functor_make_args[3] = { val_unbound("Term"), val_atom("edge"), val_int(2) };
+    int functor_make_rc = wam_run_predicate(&state, "wam_c_builtin_functor/3", functor_make_args, 3);
+    if (functor_make_rc != 0 || state.P != WAM_HALT ||
+        state.A[0].tag != VAL_STR ||
+        state.H_array[state.A[0].data.ref_addr].tag != VAL_ATOM ||
+        strcmp(state.H_array[state.A[0].data.ref_addr].data.atom, "edge/2") != 0) {
+        wam_free_state(&state);
+        return 50;
     }
 
     wam_free_state(&state);


### PR DESCRIPTION
# Add WAM-C `functor/3` builtin support

## Summary

- adds WAM-C runtime support for `functor/3` in both inspection and structure-construction modes
- extends the builtin executable smoke to cover `functor/3` read and make paths
- refreshes `WAM_C_TARGET_NEXT_STEPS.md` after the larger-scale regression merge and records `arg/3` as the next recommended narrow term-inspection branch

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/test_wam_c_lowered_helper_scale_regression.py`
- `git diff --check`
