### PR TITLE
feat(wam-c): Add WAM-C `arg/3` builtin support

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,7 +5,7 @@ Status date: 2026-05-16
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `662e2b18` (`Merge pull request #2167 from s243a/test/wam-c-lowered-helper-larger-scale-regression`)
+- `main` at `5f2db069` (`Merge pull request #2185 from s243a/feat/wam-c-lowered-helper-next-shape-selection`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
@@ -15,7 +15,7 @@ Base verified locally:
 
 Active branch:
 
-- `feat/wam-c-lowered-helper-next-shape-selection`
+- `feat/wam-c-arg-builtin`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -66,7 +66,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper indexed row dispatch | Done | First-argument hash-bucket dispatch preserves unbound-argument fallback and gives `1k` lowered-helper runtime around 5.8x faster than interpreted in local calibration |
 | Lowered helper compile/code-size compaction | Done | Compact static row tables plus bucket row-index arrays reduce `1k` generated `lib.c` from 12.8 MB to 2.6 MB and compile time from 151.75s to 0.98s |
 | Lowered helper larger-scale regression | Done | `tests/test_wam_c_lowered_helper_scale_regression.py` now promotes `100x` into the focused local lowered-helper parity regression while leaving `1k` as calibration-only because it costs about 31s end to end |
-| Lowered helper next-shape selection | In progress | Active branch selects term-shape builtin parity as the next narrow helper-adjacent surface, starting with C `functor/3` runtime support because Haskell and Rust already cover richer structure inspection paths |
+| Lowered helper next-shape selection | Done | Selected term-shape builtin parity as the next narrow helper-adjacent surface and added C `functor/3` runtime support because Haskell and Rust already cover richer structure inspection paths |
+| `arg/3` builtin support | In progress | Active branch adds deterministic positive-index argument extraction for structures and lists, with direct executable smoke coverage |
 
 ## Current C Target Baseline
 
@@ -85,8 +86,8 @@ The C target is now a credible small WAM backend:
   struct.
 - Supports `builtin_call` delegation for tested builtins:
   `atom/1`, `integer/1`, `number/1`, `var/1`, `nonvar/1`,
-  `compound/1`, `is_list/1`, `=/2`, `is/2`, arithmetic comparisons, and
-  active-branch `functor/3`.
+  `compound/1`, `is_list/1`, `=/2`, `is/2`, arithmetic comparisons,
+  `functor/3`, and active-branch `arg/3`.
 - Supports deterministic `call_foreign` dispatch through a C handler registry.
 - Can opt into a prototype lowered-helper path for constant fact-only
   predicates, plus same-arity alias bodies that call those native fact helpers,
@@ -133,7 +134,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | First-arg indexing | Done | Done | Done | C has constants, structures, mixed term, and list dispatch. |
 | Second-arg indexing | Partial | Partial/Done | Partial/Done | C has constant A2 dispatch; broaden tests if this becomes hot. |
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
-| Builtin calls | Partial | Broader | Broader | C has a growing builtin set. Active branch adds `functor/3`; next likely term-shape gaps are `arg/3` and `atom_concat/3` if benchmark surfaces need them. |
+| Builtin calls | Partial | Broader | Broader | C has a growing builtin set. Active branch adds `arg/3`; next likely term/string gap is `atom_concat/3` if benchmark surfaces need it. |
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
 | Negation / control builtins | Partial | Broader | Broader | C likely needs explicit tests for `\+/1`, cut interactions, and if-then-else lowering. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
@@ -149,30 +150,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-lowered-helper-next-shape-selection`
-
-Goal: choose and pin the next helper-adjacent feature gap now that scaled row
-dispatch has local regression coverage.
-
-Scope:
-
-- Compare remaining C gaps against the Haskell and Rust hybrid WAM examples.
-- Prefer a narrow helper shape or builtin needed by existing benchmark surfaces.
-- Start with `functor/3` because it is a compact term-shape primitive that
-  supports structure introspection/construction without broad CI expansion.
-
-Status: active.
-
-Selected next-shape rationale:
-
-| Candidate | Decision | Reason |
-|---|---:|---|
-| `functor/3` | Active | Small term-shape builtin with Haskell/Rust precedent and direct C runtime coverage potential. |
-| `arg/3` | Next likely branch | Complements `functor/3`, but term argument extraction needs a separate focused smoke. |
-| `atom_concat/3` | Later | Useful, but less directly tied to lowered helper row/structure shape selection. |
-| Aggregates | Defer | Needs broader term-copy/list construction support and would be too large for this branch. |
-
-### 2. `feat/wam-c-arg-builtin`
+### 1. `feat/wam-c-arg-builtin`
 
 Goal: add the next narrow term-inspection builtin after `functor/3`.
 
@@ -183,7 +161,35 @@ Scope:
 - Keep construction and non-deterministic modes out of scope unless an existing
   benchmark needs them.
 
+Status: active.
+
+Selected scope:
+
+| Candidate | Decision | Reason |
+|---|---:|---|
+| Structure `arg/3` extraction | Active | Complements `functor/3` and uses the existing `name/arity` heap layout. |
+| List `arg/3` extraction | Active | Keeps C list pairs aligned with term-inspection semantics. |
+| `arg/3` construction modes | Defer | Broader behavior is not needed by current benchmark surfaces. |
+| `atom_concat/3` | Later | Useful, but less directly tied to lowered helper row/structure shape selection. |
+| Aggregates | Defer | Needs broader term-copy/list construction support and would be too large for this branch. |
+
+### 2. `feat/wam-c-atom-concat-builtin`
+
+Goal: add a narrow string/atom builtin only after term-inspection coverage lands.
+
+Scope:
+
+- Implement the common deterministic `atom_concat/3` modes needed by generated
+  benchmark surfaces.
+- Keep mode coverage explicit in tests so unsupported modes fail predictably.
+
 Status: recommended after this branch.
+
+## Completed Next-Shape Selection
+
+The merged `feat/wam-c-lowered-helper-next-shape-selection` branch selected
+term-shape builtin parity and added `functor/3` support before this `arg/3`
+branch.
 
 ## Completed Larger-Scale Selection
 

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -2095,6 +2095,29 @@ static bool wam_make_structure_from_functor(WamState *state,
     return true;
 }
 
+static bool wam_term_arg(WamState *state, int index, WamValue term, WamValue **out) {
+    if (index <= 0) return false;
+    WamValue *cell = wam_deref_ptr(state, &term);
+    if (cell->tag == VAL_LIST) {
+        if (index > 2) return false;
+        *out = &state->H_array[cell->data.ref_addr + index - 1];
+        return true;
+    }
+    if (cell->tag != VAL_STR) return false;
+
+    WamValue *functor = &state->H_array[cell->data.ref_addr];
+    if (functor->tag != VAL_ATOM) return false;
+    const char *slash = strrchr(functor->data.atom, ''/'');
+    if (!slash) return false;
+    char *end = NULL;
+    long arity = strtol(slash + 1, &end, 10);
+    if (!end || *end != 0 || arity < 0 || arity > 255) return false;
+    if (index > arity) return false;
+
+    *out = &state->H_array[cell->data.ref_addr + index];
+    return true;
+}
+
 bool wam_execute_builtin(WamState *state, const char *op, int arity) {
     if (strcmp(op, "true/0") == 0 && arity == 0) return true;
     if ((strcmp(op, "fail/0") == 0 || strcmp(op, "false/0") == 0) && arity == 0) return false;
@@ -2148,6 +2171,14 @@ bool wam_execute_builtin(WamState *state, const char *op, int arity) {
         WamValue structure;
         if (!wam_make_structure_from_functor(state, name->data.atom, arity_cell->data.integer, &structure)) return false;
         return wam_unify(state, &state->A[0], &structure);
+    }
+
+    if (strcmp(op, "arg/3") == 0 && arity == 3) {
+        WamValue *index = wam_deref_ptr(state, &state->A[0]);
+        if (index->tag != VAL_INT) return false;
+        WamValue *arg = NULL;
+        if (!wam_term_arg(state, index->data.integer, state->A[1], &arg)) return false;
+        return wam_unify(state, &state->A[2], arg);
     }
 
     if (arity == 2) {

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -1127,7 +1127,7 @@ run_multi_predicate_setup_executable_smoke :-
     run_c_smoke_plain(ExePath).
 
 run_builtin_call_executable_smoke :-
-    WamCode = 'wam_c_builtin_atom/1:\n    builtin_call atom/1, 1\n    proceed\nwam_c_builtin_is/2:\n    builtin_call is/2, 2\n    proceed\nwam_c_builtin_functor/3:\n    builtin_call functor/3, 3\n    proceed',
+    WamCode = 'wam_c_builtin_atom/1:\n    builtin_call atom/1, 1\n    proceed\nwam_c_builtin_is/2:\n    builtin_call is/2, 2\n    proceed\nwam_c_builtin_functor/3:\n    builtin_call functor/3, 3\n    proceed\nwam_c_builtin_arg/3:\n    builtin_call arg/3, 3\n    proceed',
     compile_wam_predicate_to_c(user:wam_c_builtin_atom/1, WamCode, [], PredCode),
     compile_wam_runtime_to_c([], RuntimeCode),
     get_time(Now),
@@ -1830,6 +1830,15 @@ static WamValue make_binary_struct(WamState *state, const char *functor, WamValu
     return term;
 }
 
+static WamValue make_list_pair(WamState *state, WamValue head, WamValue tail) {
+    WamValue list;
+    list.tag = VAL_LIST;
+    list.data.ref_addr = state->H;
+    state->H_array[state->H++] = head;
+    state->H_array[state->H++] = tail;
+    return list;
+}
+
 int main(void) {
     WamState state;
     wam_state_init(&state);
@@ -1874,6 +1883,30 @@ int main(void) {
         strcmp(state.H_array[state.A[0].data.ref_addr].data.atom, "edge/2") != 0) {
         wam_free_state(&state);
         return 50;
+    }
+
+    WamValue arg_struct_args[3] = { val_int(2), pair_term, val_unbound("Arg") };
+    int arg_struct_rc = wam_run_predicate(&state, "wam_c_builtin_arg/3", arg_struct_args, 3);
+    if (arg_struct_rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 9) {
+        wam_free_state(&state);
+        return 60;
+    }
+
+    WamValue list_term = make_list_pair(&state, val_atom("head"), val_atom("tail"));
+    WamValue arg_list_args[3] = { val_int(1), list_term, val_unbound("Head") };
+    int arg_list_rc = wam_run_predicate(&state, "wam_c_builtin_arg/3", arg_list_args, 3);
+    if (arg_list_rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_ATOM || strcmp(state.A[2].data.atom, "head") != 0) {
+        wam_free_state(&state);
+        return 70;
+    }
+
+    WamValue arg_fail_args[3] = { val_int(3), list_term, val_unbound("Out") };
+    int arg_fail_rc = wam_run_predicate(&state, "wam_c_builtin_arg/3", arg_fail_args, 3);
+    if (arg_fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 80;
     }
 
     wam_free_state(&state);


### PR DESCRIPTION
## Summary

- adds deterministic WAM-C `arg/3` support for positive-index extraction from structures and list pairs
- extends the builtin executable smoke to cover structure extraction, list extraction, and out-of-range failure
- refreshes `WAM_C_TARGET_NEXT_STEPS.md` after the `functor/3` merge and records `atom_concat/3` as the next recommended narrow builtin branch

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/test_wam_c_lowered_helper_scale_regression.py`
- `git diff --check`
