### PR TITLE
feat(wam-clojure): add select/3 builtin

### DIFF
--- a/PR_WAM_CLOJURE_SELECT_BUILTIN.md
+++ b/PR_WAM_CLOJURE_SELECT_BUILTIN.md
@@ -1,0 +1,26 @@
+# PR Title
+
+feat(wam-clojure): add select/3 builtin
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM support for `select/3`.
+- Direct-lowers `select/3` to a runtime helper instead of stepping through the interpreted builtin path.
+- Reuses the existing multi-solution result-binding path to enumerate one-removal list candidates.
+- Supports conservative proper-list mode and fails cleanly for improper or unbound input lists.
+- Adds lowered-emitter and runtime smoke coverage.
+
+## Semantics
+
+`select/3` accepts a proper list in the second argument, removes one element at a time, and unifies the first argument with the removed element and the third argument with the remaining list.
+
+This initial Clojure WAM implementation supports the common `(?Elem, +List, ?Rest)` mode. It intentionally does not generate candidate input lists from an unbound second argument.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -404,6 +404,10 @@ clojure_direct_builtin("nth1/3", "3").
 clojure_direct_builtin("nth1/3", 3).
 clojure_direct_builtin('nth1/3', "3").
 clojure_direct_builtin('nth1/3', 3).
+clojure_direct_builtin("select/3", "3").
+clojure_direct_builtin("select/3", 3).
+clojure_direct_builtin('select/3', "3").
+clojure_direct_builtin('select/3', 3).
 clojure_direct_builtin("delete/3", "3").
 clojure_direct_builtin("delete/3", 3).
 clojure_direct_builtin('delete/3', "3").
@@ -701,6 +705,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "nth1/3" ; Op == 'nth1/3'),
     !,
     format(atom(Expr), '(runtime/apply-nth1-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "select/3" ; Op == 'select/3'),
+    !,
+    format(atom(Expr),
+           '(let [list-value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound))] (runtime/apply-select-solution ~w (inc (:pc ~w)) list-value))',
+           [S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "delete/3" ; Op == 'delete/3'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -825,6 +825,21 @@
         (backtrack state))
       (backtrack state))))
 
+(defn select-solution-results [state items]
+  (let [ctx (:intern-context state)
+        indexed-items (vec items)]
+    (mapv (fn [idx]
+            {:bindings {1 (nth indexed-items idx)
+                        3 (list->term ctx (concat (subvec indexed-items 0 idx)
+                                                  (subvec indexed-items (inc idx))))}})
+          (range (count indexed-items)))))
+
+(defn apply-select-solution [base-state resume-pc list-value]
+  (if-let [items (proper-list-items base-state list-value)]
+    (apply-first-foreign-solution base-state resume-pc
+                                  (select-solution-results base-state items))
+    (backtrack base-state)))
+
 (defn apply-delete-solution [state]
   (let [list-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A1") ::unbound))
@@ -1630,6 +1645,11 @@
 
           "nth1/3"
           (apply-nth1-solution state)
+
+          "select/3"
+          (let [list-value (deref-value (:bindings state)
+                                        (or (reg-get-raw state "A2") ::unbound))]
+            (apply-select-solution state (inc (:pc state)) list-value))
 
           "delete/3"
           (apply-delete-solution state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -586,6 +586,15 @@ test(simple_builtin_nth1_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_select_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_select/3:\nbuiltin_call select/3, 3\nproceed\n",
+        wam_clojure_lowerable(test_select/3, WamCode, deterministic),
+        lower_predicate_to_clojure(test_select/3, WamCode, [], Code),
+        has(Code, "runtime/apply-select-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_delete_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_delete/3:\nbuiltin_call delete/3, 3\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -104,6 +104,10 @@
 :- dynamic user:wam_nth1_bad_list/1.
 :- dynamic user:wam_nth1_unbound_index/1.
 :- dynamic user:wam_nth1_unbound_list/1.
+:- dynamic user:wam_select_guard/3.
+:- dynamic user:wam_select_backtrack/2.
+:- dynamic user:wam_select_bad_list/1.
+:- dynamic user:wam_select_unbound_list/1.
 :- dynamic user:wam_delete_guard/3.
 :- dynamic user:wam_delete_bad_list/1.
 :- dynamic user:wam_delete_unbound_list/1.
@@ -255,6 +259,10 @@ user:wam_nth1_out_of_range(X) :- nth1(4, [a,b,c], X).
 user:wam_nth1_bad_list(X) :- nth1(2, [a|b], X).
 user:wam_nth1_unbound_index(X) :- user:wam_unbound_arg(N), nth1(N, [a,b,c], X).
 user:wam_nth1_unbound_list(X) :- user:wam_unbound_arg(L), nth1(1, L, X).
+user:wam_select_guard(Elem, List, Rest) :- select(Elem, List, Rest).
+user:wam_select_backtrack(Elem, Rest) :- select(Elem, [a,b,c], Rest), Elem = b.
+user:wam_select_bad_list(Rest) :- select(a, [a|b], Rest).
+user:wam_select_unbound_list(Rest) :- user:wam_unbound_arg(L), select(a, L, Rest).
 user:wam_delete_guard(L, Elem, Rest) :- delete(L, Elem, Rest).
 user:wam_delete_bad_list(Rest) :- delete([a|b], a, Rest).
 user:wam_delete_unbound_list(Rest) :- user:wam_unbound_arg(L), delete(L, a, Rest).
@@ -411,6 +419,10 @@ run_smoke :-
           user:wam_nth1_bad_list/1,
           user:wam_nth1_unbound_index/1,
           user:wam_nth1_unbound_list/1,
+          user:wam_select_guard/3,
+          user:wam_select_backtrack/2,
+          user:wam_select_bad_list/1,
+          user:wam_select_unbound_list/1,
           user:wam_delete_guard/3,
           user:wam_delete_bad_list/1,
           user:wam_delete_unbound_list/1,
@@ -494,6 +506,7 @@ run_smoke :-
     assert_lowered_last_builtin_emitted(TmpDir),
     assert_lowered_nth0_builtin_emitted(TmpDir),
     assert_lowered_nth1_builtin_emitted(TmpDir),
+    assert_lowered_select_builtin_emitted(TmpDir),
     assert_lowered_delete_builtin_emitted(TmpDir),
     assert_lowered_sort_builtin_emitted(TmpDir),
     assert_lowered_msort_builtin_emitted(TmpDir),
@@ -685,6 +698,13 @@ smoke_cases([
     case('wam_nth1_bad_list/1', a, "false"),
     case('wam_nth1_unbound_index/1', a, "false"),
     case('wam_nth1_unbound_list/1', a, "false"),
+    case('wam_select_guard/3', args(a, '[a,b,c]', '[b,c]'), "true"),
+    case('wam_select_guard/3', args(b, '[a,b,c]', '[a,c]'), "true"),
+    case('wam_select_guard/3', args(z, '[a,b,c]', '[a,b,c]'), "false"),
+    case('wam_select_guard/3', args(a, '[a,b,c]', '[a,c]'), "false"),
+    case('wam_select_backtrack/2', args(b, '[a,c]'), "true"),
+    case('wam_select_bad_list/1', '[b,c]', "false"),
+    case('wam_select_unbound_list/1', '[b,c]', "false"),
     case('wam_delete_guard/3', args('[a,b,a,c]', a, '[b,c]'), "true"),
     case('wam_delete_guard/3', args('[a,b,a,c]', z, '[a,b,a,c]'), "true"),
     case('wam_delete_guard/3', args('[f(a),f(b),f(a)]', 'f(a)', '[f(b)]'), "true"),
@@ -979,6 +999,15 @@ assert_lowered_nth1_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-nth1-unbound-index-1"),
     has(CoreCode, "defn lowered-wam-nth1-unbound-list-1"),
     has(CoreCode, "runtime/apply-nth1-solution").
+
+assert_lowered_select_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-select-guard-3"),
+    has(CoreCode, "defn lowered-wam-select-backtrack-2"),
+    has(CoreCode, "defn lowered-wam-select-bad-list-1"),
+    has(CoreCode, "defn lowered-wam-select-unbound-list-1"),
+    has(CoreCode, "runtime/apply-select-solution").
 
 assert_lowered_delete_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM support for `select/3`.
- Direct-lowers `select/3` to a runtime helper instead of stepping through the interpreted builtin path.
- Reuses the existing multi-solution result-binding path to enumerate one-removal list candidates.
- Supports conservative proper-list mode and fails cleanly for improper or unbound input lists.
- Adds lowered-emitter and runtime smoke coverage.

## Semantics

`select/3` accepts a proper list in the second argument, removes one element at a time, and unifies the first argument with the removed element and the third argument with the remaining list.

This initial Clojure WAM implementation supports the common `(?Elem, +List, ?Rest)` mode. It intentionally does not generate candidate input lists from an unbound second argument.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
