### PR TITLE
Feat/wam go memberchk builtin

### DIFF
--- a/PR_go_wam_memberchk_builtin.md
+++ b/PR_go_wam_memberchk_builtin.md
@@ -1,0 +1,24 @@
+# PR Title
+
+Add Go WAM memberchk builtin parity
+
+# PR Description
+
+## Summary
+
+- Add deterministic `memberchk/2` support to the generated Go WAM runtime.
+- Route Go WAM `call`/`execute` instructions for `memberchk/2` through `BuiltinCall` without broadening the shared WAM builtin table for other targets.
+- Extend generated Go WAM builtin E2E coverage to verify first-match commitment and negative membership failure.
+- Update the Go WAM parity audit to include `memberchk/2` in the structural builtin surface.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl tests/test_wam_go_generator.pl tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -11,7 +11,7 @@ current cross-target builtin/runtime baseline.
 | Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries, indexed atom fact streams, `member/2` builtin retries | Choice point stack with normal, builtin, and fact-stream resume states | Present for current resume-state baseline |
 | Direct fact dispatch | `call_indexed_atom_fact2`, `AtomFact2Source` registry, TSV-backed and LMDB-artifact atom fact loading, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Present for current external atom fact-source baseline |
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
-| Structural builtins | `member/2`, `length/2`, `append/3` | `member/2`, `length/2`; Rust `append/3` is explicitly unimplemented | Present for current baseline structural checks |
+| Structural builtins | `member/2`, `memberchk/2`, `length/2`, `append/3` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented | Present for current baseline structural checks |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2` | Includes `=</2` | Present for current baseline comparisons |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
@@ -31,6 +31,9 @@ current cross-target builtin/runtime baseline.
   are now deduplicated like Haskell's `nub` behavior.
 - `member/2` now pushes builtin choice points for later list members, so
   `findall/3` can collect every unifiable element.
+- Deterministic `memberchk/2` is now covered by the generated Go WAM builtin
+  E2E test, committing to the first unifiable list element without adding
+  builtin choice points.
 - Go WAM choice points now have explicit generated-runtime coverage for normal
   clause retries, indexed alternatives, foreign stream retries, indexed atom
   fact streams, and `member/2` builtin retries.

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -416,6 +416,13 @@ write_file(Path, Content) :-
 %% wam_instruction_to_go_literal(+WamInstr, -GoLiteral)
 %  Converts a WAM instruction term to a Go struct literal string.
 
+wam_go_direct_builtin(Pred, Arity) :-
+    wam_go_direct_builtin(Pred, Arity, _Op).
+
+wam_go_direct_builtin(memberchk/2, 2, 'memberchk/2').
+wam_go_direct_builtin('memberchk/2', 2, 'memberchk/2').
+wam_go_direct_builtin("memberchk/2", 2, 'memberchk/2').
+
 wam_instruction_to_go_literal(get_constant(C, Ai), GoLiteral) :-
     go_value_literal(C, GoVal),
     go_reg_index(Ai, AiIdx),
@@ -471,10 +478,20 @@ wam_instruction_to_go_literal(set_constant(C), GoLiteral) :-
 wam_instruction_to_go_literal(allocate, '&Allocate{}').
 wam_instruction_to_go_literal(deallocate, '&Deallocate{}').
 wam_instruction_to_go_literal(call(P, N), GoLiteral) :-
+    wam_go_direct_builtin(P, N, Op),
+    !,
+    escape_go_string(Op, EscapedPred),
+    format(atom(GoLiteral), '&BuiltinCall{Op: "~w", Arity: ~w}', [EscapedPred, N]).
+wam_instruction_to_go_literal(call(P, N), GoLiteral) :-
     format(atom(GoLiteral), '&Call{Pred: "~w", Arity: ~w}', [P, N]).
 wam_instruction_to_go_literal(call_indexed_atom_fact2(Pred), GoLiteral) :-
     escape_go_string(Pred, EscapedPred),
     format(atom(GoLiteral), '&CallIndexedAtomFact2{Pred: "~w"}', [EscapedPred]).
+wam_instruction_to_go_literal(execute(P), GoLiteral) :-
+    wam_go_direct_builtin(P, N, Op),
+    !,
+    escape_go_string(Op, EscapedPred),
+    format(atom(GoLiteral), '&BuiltinCall{Op: "~w", Arity: ~w}', [EscapedPred, N]).
 wam_instruction_to_go_literal(execute(P), GoLiteral) :-
     format(atom(GoLiteral), '&Execute{Pred: "~w"}', [P]).
 wam_instruction_to_go_literal(proceed, '&Proceed{}').
@@ -1001,6 +1018,9 @@ wam_line_to_go_literal(["call", P, N], PredIndicator, Options, GoLit) :-
     (   number_string(Num, CN) -> true ; Num = 0 ),
     (   go_foreign_rewrite_call(Options, PredIndicator, CP, Num, ForeignPred, ForeignArity)
     ->  format(atom(GoLit), '&CallForeign{Pred: "~w", Arity: ~w}', [ForeignPred, ForeignArity])
+    ;   wam_go_direct_builtin(CP, Num, Op)
+    ->  escape_go_string(Op, EscapedPred),
+        format(atom(GoLit), '&BuiltinCall{Op: "~w", Arity: ~w}', [EscapedPred, CN])
     ;   format(atom(GoLit), '&Call{Pred: "~w", Arity: ~w}', [CP, CN])
     ).
 wam_line_to_go_literal(["call_indexed_atom_fact2", Pred], _PredIndicator, _Options, GoLit) :-
@@ -1010,6 +1030,9 @@ wam_line_to_go_literal(["execute", P], PredIndicator, Options, GoLit) :-
     clean_comma(P, CP),
     (   go_foreign_rewrite_execute(Options, PredIndicator, CP, ForeignPred, ForeignArity)
     ->  format(atom(GoLit), '&CallForeign{Pred: "~w", Arity: ~w}', [ForeignPred, ForeignArity])
+    ;   wam_go_direct_builtin(CP, Num, Op)
+    ->  escape_go_string(Op, EscapedPred),
+        format(atom(GoLit), '&BuiltinCall{Op: "~w", Arity: ~w}', [EscapedPred, Num])
     ;   format(atom(GoLit), '&Execute{Pred: "~w"}', [CP])
     ).
 wam_line_to_go_literal(["jump", L], GoLit) :-

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1102,6 +1102,23 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			vm.unwindTrailTo(mark)
 			v = vm.deref(tail)
 		}
+	case "memberchk/2":
+		v := vm.deref(arg2)
+		for {
+			if isEmptyListValue(v) {
+				return false
+			}
+			head, tail, ok := vm.valueListHeadTail(v)
+			if !ok {
+				return false
+			}
+			mark := vm.TrailLen
+			if vm.Unify(arg1, head) {
+				return true
+			}
+			vm.unwindTrailTo(mark)
+			v = vm.deref(tail)
+		}
 	case "append/3":
 		l1, ok1 := vm.listToSlice(arg1)
 		l2, ok2 := vm.listToSlice(arg2)

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -8,6 +8,7 @@
 :- dynamic user:test_builtins/1.
 :- dynamic user:test_term_builtins/0.
 :- dynamic user:test_member_collect/0.
+:- dynamic user:test_memberchk_builtin/0.
 :- dynamic user:test_set_aggregate/0.
 :- dynamic user:test_unify_builtin/0.
 :- dynamic user:test_neg_fact/1.
@@ -51,6 +52,11 @@ test(builtins_execution) :-
                 member(a, L),
                 member(b, L)
             )),
+          assertz(user:test_memberchk_builtin :-
+            (   memberchk(X, [a,b,c]),
+                X == a,
+                \+ memberchk(z, [a,b,c])
+            )),
           assertz(user:test_set_aggregate :-
             (   aggregate_all(set(X), member(X, [a,b,a]), S),
                 length(S, 2),
@@ -75,6 +81,7 @@ test(builtins_execution) :-
         ( retractall(user:test_builtins(_)),
           retractall(user:test_term_builtins),
           retractall(user:test_member_collect),
+          retractall(user:test_memberchk_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
           retractall(user:test_neg_fact(_)),
@@ -84,7 +91,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -115,6 +122,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "=../2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "copy_term/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "=/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "memberchk/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "\\\\+/1"')),
     assertion(sub_string(LibCode, _, _, _, 'AggType: "set"')),
 
@@ -158,6 +166,14 @@ func main() {
 		fmt.Println("MEMBER_SUCCESS")
 	} else {
 		fmt.Println("MEMBER_FAILURE")
+	}
+
+	memberchkVM := wam.NewWamState(wam.Test_memberchk_builtinCode, wam.Test_memberchk_builtinLabels)
+	memberchkVM.PC = wam.Test_memberchk_builtinStartPC
+	if memberchkVM.Run() {
+		fmt.Println("MEMBERCHK_SUCCESS")
+	} else {
+		fmt.Println("MEMBERCHK_FAILURE")
 	}
 
 	setVM := wam.NewWamState(wam.Test_set_aggregateCode, wam.Test_set_aggregateLabels)
@@ -212,6 +228,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "SUCCESS: X=3")),
         assertion(sub_string(FullOutput, _, _, _, "TERM_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "MEMBER_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "MEMBERCHK_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NEG_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM memberchk builtin parity

## Summary

- Add deterministic `memberchk/2` support to the generated Go WAM runtime.
- Route Go WAM `call`/`execute` instructions for `memberchk/2` through `BuiltinCall` without broadening the shared WAM builtin table for other targets.
- Extend generated Go WAM builtin E2E coverage to verify first-match commitment and negative membership failure.
- Update the Go WAM parity audit to include `memberchk/2` in the structural builtin surface.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl tests/test_wam_go_generator.pl tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`
