### PR TITLE
feat(wam-lua): validate runtime parser mode

### DIFF
--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
@@ -87,6 +87,9 @@ the disabled mode does not silently generate a runtime that still accepts
 source-term parsing calls.
 `term_to_atom/2` is treated mode-sensitively: forward rendering remains valid
 with the parser disabled, while statically visible reverse parsing is rejected.
+Lua also consumes the shared hook as a no-parser target: it records
+`runtime_parser = none` metadata and rejects parser-dependent bodies rather
+than emitting parser stubs.
 
 The hook should be independent of the WAM items API. A target can skip WAM text
 generation at build time and still need runtime source-term parsing.

--- a/src/unifyweaver/targets/wam_lua_target.pl
+++ b/src/unifyweaver/targets/wam_lua_target.pl
@@ -38,6 +38,10 @@
     wam_lua_lowerable/3,
     lower_predicate_to_lua/4
 ]).
+:- use_module(wam_runtime_parser_capability, [
+    parser_dependent_body_goal/2,
+    wam_target_runtime_parser/3
+]).
 
 :- multifile user:wam_lua_emit_mode/1.
 
@@ -696,6 +700,9 @@ lua_foreign_handler_entry(handler(Pred/Arity, HandlerCode), Entry) :-
     format(string(Entry), '  [~w] = ~w', [Q, HandlerCode]).
 
 write_wam_lua_project(Predicates, Options, ProjectDir) :-
+    wam_target_runtime_parser(wam_lua, Options, RuntimeParserMode),
+    validate_lua_runtime_parser_mode(Predicates, RuntimeParserMode),
+    lua_runtime_parser_mode_literal(RuntimeParserMode, RuntimeParserModeCode),
     make_directory_path(ProjectDir),
     directory_file_path(ProjectDir, 'lua', LuaDir),
     make_directory_path(LuaDir),
@@ -709,7 +716,8 @@ write_wam_lua_project(Predicates, Options, ProjectDir) :-
     lua_foreign_handlers_code(Options, ForeignHandlers),
     write_runtime_source(LuaDir),
     write_program_source(LuaDir, InstrBody, LabelBody, DispatchBody,
-                         WrapperCode, InternSeed, ForeignHandlers, LoweredCode, InlineFactsCode, FactSourcesCode).
+                         WrapperCode, InternSeed, ForeignHandlers, LoweredCode, InlineFactsCode, FactSourcesCode,
+                         RuntimeParserModeCode).
 
 write_runtime_source(LuaDir) :-
     find_template('templates/targets/lua_wam/runtime.lua.mustache', Template),
@@ -719,7 +727,8 @@ write_runtime_source(LuaDir) :-
     write_file(Path, Content).
 
 write_program_source(LuaDir, InstrBody, LabelBody, DispatchBody,
-                     WrapperCode, InternSeed, ForeignHandlers, LoweredCode, InlineFactsCode, FactSourcesCode) :-
+                     WrapperCode, InternSeed, ForeignHandlers, LoweredCode, InlineFactsCode, FactSourcesCode,
+                     RuntimeParserModeCode) :-
     find_template('templates/targets/lua_wam/program.lua.mustache', Template),
     get_time(T), format_time(string(Date), "%Y-%m-%d", T),
     render_template(Template,
@@ -732,9 +741,48 @@ write_program_source(LuaDir, InstrBody, LabelBody, DispatchBody,
          'foreign_handlers'=ForeignHandlers,
          'lowered_functions'=LoweredCode,
          'inline_facts'=InlineFactsCode,
-         'fact_sources'=FactSourcesCode], Content),
+         'fact_sources'=FactSourcesCode,
+         'runtime_parser_mode'=RuntimeParserModeCode], Content),
     directory_file_path(LuaDir, 'generated_program.lua', Path),
     write_file(Path, Content).
+
+lua_runtime_parser_mode_literal(none,
+    '{ kind = "none", entry = nil, source = nil }') :- !.
+lua_runtime_parser_mode_literal(native(Entry), Code) :-
+    !,
+    lua_string_literal(Entry, EntryLit),
+    format(string(Code),
+           '{ kind = "native", entry = ~w, source = nil }',
+           [EntryLit]).
+lua_runtime_parser_mode_literal(compiled(SourceModule), Code) :-
+    lua_string_literal(SourceModule, SourceLit),
+    format(string(Code),
+           '{ kind = "compiled", entry = nil, source = ~w }',
+           [SourceLit]).
+
+validate_lua_runtime_parser_mode(Predicates, none) :-
+    !,
+    (   lua_predicates_parser_dependency(Predicates, Pred, Builtin)
+    ->  throw(error(permission_error(use, runtime_parser, Builtin),
+                    context(write_wam_lua_project/3,
+                            parser_disabled_for_predicate(Pred))))
+    ;   true
+    ).
+validate_lua_runtime_parser_mode(_Predicates, _Mode).
+
+lua_predicates_parser_dependency(Predicates, Pred, Builtin) :-
+    member(Pred, Predicates),
+    lua_predicate_clause(Pred, _Head, Body),
+    parser_dependent_body_goal(Body, Builtin),
+    !.
+
+lua_predicate_clause(Module:Name/Arity, Head, Body) :-
+    !,
+    functor(Head, Name, Arity),
+    clause(Module:Head, Body).
+lua_predicate_clause(Name/Arity, Head, Body) :-
+    functor(Head, Name, Arity),
+    clause(user:Head, Body).
 
 write_file(Path, Content) :-
     setup_call_cleanup(open(Path, write, Stream), write(Stream, Content), close(Stream)).

--- a/templates/targets/lua_wam/program.lua.mustache
+++ b/templates/targets/lua_wam/program.lua.mustache
@@ -44,6 +44,7 @@ local shared_program = {
   foreign_handlers = foreign_handlers,
   inline_facts = inline_facts,
   fact_sources = fact_sources,
+  runtime_parser = {{runtime_parser_mode}},
   indexed_atom_fact2 = {},
   intern_table = intern_table
 }

--- a/tests/test_wam_lua_generator.pl
+++ b/tests/test_wam_lua_generator.pl
@@ -62,6 +62,8 @@
 :- dynamic user:wam_lua_naf_member/0.
 :- dynamic user:wam_lua_naf_member_no/0.
 :- dynamic user:wam_lua_write_line/0.
+:- dynamic user:wam_lua_parser_dep/0.
+:- dynamic user:wam_lua_t2a_forward/0.
 
 user:wam_lua_fact(a).
 user:wam_lua_choice(a).
@@ -250,6 +252,52 @@ test(project_layout) :-
         ),
         delete_directory_and_contents(TmpDir)
     ).
+
+test(runtime_parser_mode_metadata) :-
+    unique_lua_tmp_dir('tmp_lua_parser_mode', TmpDir),
+    setup_call_cleanup(
+        write_wam_lua_project([user:wam_lua_fact/1], [], TmpDir),
+        ( directory_file_path(TmpDir, 'lua/generated_program.lua', Program),
+          read_file_to_string(Program, Code, []),
+          assertion(sub_string(Code, _, _, _,
+                               'runtime_parser = { kind = "none", entry = nil, source = nil }'))
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(runtime_parser_native_request_errors,
+     [error(domain_error(runtime_parser_mode(wam_lua), native))]) :-
+    unique_lua_tmp_dir('tmp_lua_parser_native_err', TmpDir),
+    call_cleanup(
+        write_wam_lua_project([user:wam_lua_fact/1],
+                              [runtime_parser(native)],
+                              TmpDir),
+        (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true)).
+
+test(runtime_parser_none_rejects_parser_dependent_builtin,
+     [error(permission_error(use, runtime_parser, read_term_from_atom/2))]) :-
+    retractall(user:wam_lua_parser_dep),
+    assertz((user:wam_lua_parser_dep :-
+        read_term_from_atom('f(a)', _))),
+    unique_lua_tmp_dir('tmp_lua_parser_mode_reject', TmpDir),
+    call_cleanup(
+        write_wam_lua_project([user:wam_lua_parser_dep/0], [], TmpDir),
+        (   retractall(user:wam_lua_parser_dep),
+            (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true)
+        )).
+
+test(runtime_parser_none_allows_term_to_atom_forward) :-
+    once((
+        retractall(user:wam_lua_t2a_forward),
+        assertz((user:wam_lua_t2a_forward :-
+            term_to_atom(f(a), _))),
+        unique_lua_tmp_dir('tmp_lua_parser_t2a_fwd', TmpDir),
+        call_cleanup(
+            write_wam_lua_project([user:wam_lua_t2a_forward/0], [], TmpDir),
+            (   retractall(user:wam_lua_t2a_forward),
+                (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true)
+            ))
+    )).
 
 test(instructions_and_labels) :-
     unique_lua_tmp_dir('tmp_lua_instrs', TmpDir),


### PR DESCRIPTION
## Summary

Wires the shared runtime parser capability hook into the Lua WAM target as a no-parser validation target.

Lua does not currently provide a Prolog source-term parser, so this PR records `runtime_parser = none` metadata and rejects parser-dependent predicate bodies at generation time instead of emitting ambiguous parser stubs.

## Details

- Resolves `wam_target_runtime_parser(wam_lua, Options, Mode)` in `write_wam_lua_project/3`.
- Records the resolved parser mode in generated Lua program metadata.
- Uses shared `parser_dependent_body_goal/2` to reject parser-dependent bodies when Lua resolves to `none`.
- Keeps forward `term_to_atom/2` valid because it does not require parsing.
- Raises the shared unsupported-mode domain error for explicit `runtime_parser(native)` on Lua.
- Adds focused Lua generator tests for parser-mode metadata, unsupported native mode, parser-dependent rejection, and forward `term_to_atom/2`.
- Updates the runtime parser transpilation plan to note Lua is now a no-parser validation target.

## Verification

- `swipl -q -s tests/test_wam_lua_generator.pl -g "run_tests([wam_lua_generator:runtime_parser_mode_metadata,wam_lua_generator:runtime_parser_native_request_errors,wam_lua_generator:runtime_parser_none_rejects_parser_dependent_builtin,wam_lua_generator:runtime_parser_none_allows_term_to_atom_forward])" -t halt`
- `swipl -q -g run_tests -t halt tests/test_wam_runtime_parser_capability.pl`
- `git diff --check HEAD`

## Notes

This does not add a Lua runtime Prolog parser. It only enforces and records the existing no-parser capability state.
