### PR TITLE
feat(wam-clojure): add numlist/3 builtin

### DIFF
--- a/PR_WAM_CLOJURE_NUMLIST_BUILTIN.md
+++ b/PR_WAM_CLOJURE_NUMLIST_BUILTIN.md
@@ -1,0 +1,26 @@
+# PR Title
+
+feat(wam-clojure): add numlist/3 builtin
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM support for `numlist/3`.
+- Direct-lowers `numlist/3` to a runtime helper instead of stepping through the interpreted builtin path.
+- Supports integer `Low`, integer `High`, and output-list unification.
+- Fails cleanly for `Low > High` and unbound/non-integer bounds.
+- Adds lowered-emitter and runtime smoke coverage.
+
+## Semantics
+
+`numlist/3` accepts integer lower and upper bounds and unifies the third argument with the proper list of integers from `Low` through `High`, inclusive.
+
+This initial Clojure WAM implementation is conservative: it supports the common `(+Low, +High, ?List)` mode and fails for unsupported modes or invalid bounds rather than raising ISO-style errors.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -408,6 +408,10 @@ clojure_direct_builtin("select/3", "3").
 clojure_direct_builtin("select/3", 3).
 clojure_direct_builtin('select/3', "3").
 clojure_direct_builtin('select/3', 3).
+clojure_direct_builtin("numlist/3", "3").
+clojure_direct_builtin("numlist/3", 3).
+clojure_direct_builtin('numlist/3', "3").
+clojure_direct_builtin('numlist/3', 3).
 clojure_direct_builtin("delete/3", "3").
 clojure_direct_builtin("delete/3", 3).
 clojure_direct_builtin('delete/3', "3").
@@ -712,6 +716,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr),
            '(let [list-value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound))] (runtime/apply-select-solution ~w (inc (:pc ~w)) list-value))',
            [S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "numlist/3" ; Op == 'numlist/3'),
+    !,
+    format(atom(Expr), '(runtime/apply-numlist-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "delete/3" ; Op == 'delete/3'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -840,6 +840,21 @@
                                   (select-solution-results base-state items))
     (backtrack base-state)))
 
+(defn apply-numlist-solution [state]
+  (let [low (deref-value (:bindings state)
+                         (or (reg-get-raw state "A1") ::unbound))
+        high (deref-value (:bindings state)
+                          (or (reg-get-raw state "A2") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A3") ::unbound))]
+    (if (and (integer? low) (integer? high) (<= low high))
+      (let [result-term (list->term (:intern-context state) (range low (inc high)))
+            [ok next-state] (unify-values state out result-term)]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+      (backtrack state))))
+
 (defn apply-delete-solution [state]
   (let [list-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A1") ::unbound))
@@ -1650,6 +1665,9 @@
           (let [list-value (deref-value (:bindings state)
                                         (or (reg-get-raw state "A2") ::unbound))]
             (apply-select-solution state (inc (:pc state)) list-value))
+
+          "numlist/3"
+          (apply-numlist-solution state)
 
           "delete/3"
           (apply-delete-solution state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -595,6 +595,15 @@ test(simple_builtin_select_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_numlist_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_numlist/3:\nbuiltin_call numlist/3, 3\nproceed\n",
+        wam_clojure_lowerable(test_numlist/3, WamCode, deterministic),
+        lower_predicate_to_clojure(test_numlist/3, WamCode, [], Code),
+        has(Code, "runtime/apply-numlist-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_delete_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_delete/3:\nbuiltin_call delete/3, 3\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -108,6 +108,9 @@
 :- dynamic user:wam_select_backtrack/2.
 :- dynamic user:wam_select_bad_list/1.
 :- dynamic user:wam_select_unbound_list/1.
+:- dynamic user:wam_numlist_guard/3.
+:- dynamic user:wam_numlist_high_before_low/1.
+:- dynamic user:wam_numlist_unbound_low/1.
 :- dynamic user:wam_delete_guard/3.
 :- dynamic user:wam_delete_bad_list/1.
 :- dynamic user:wam_delete_unbound_list/1.
@@ -263,6 +266,9 @@ user:wam_select_guard(Elem, List, Rest) :- select(Elem, List, Rest).
 user:wam_select_backtrack(Elem, Rest) :- select(Elem, [a,b,c], Rest), Elem = b.
 user:wam_select_bad_list(Rest) :- select(a, [a|b], Rest).
 user:wam_select_unbound_list(Rest) :- user:wam_unbound_arg(L), select(a, L, Rest).
+user:wam_numlist_guard(Low, High, List) :- numlist(Low, High, List).
+user:wam_numlist_high_before_low(List) :- numlist(3, 1, List).
+user:wam_numlist_unbound_low(List) :- user:wam_unbound_arg(Low), numlist(Low, 3, List).
 user:wam_delete_guard(L, Elem, Rest) :- delete(L, Elem, Rest).
 user:wam_delete_bad_list(Rest) :- delete([a|b], a, Rest).
 user:wam_delete_unbound_list(Rest) :- user:wam_unbound_arg(L), delete(L, a, Rest).
@@ -423,6 +429,9 @@ run_smoke :-
           user:wam_select_backtrack/2,
           user:wam_select_bad_list/1,
           user:wam_select_unbound_list/1,
+          user:wam_numlist_guard/3,
+          user:wam_numlist_high_before_low/1,
+          user:wam_numlist_unbound_low/1,
           user:wam_delete_guard/3,
           user:wam_delete_bad_list/1,
           user:wam_delete_unbound_list/1,
@@ -507,6 +516,7 @@ run_smoke :-
     assert_lowered_nth0_builtin_emitted(TmpDir),
     assert_lowered_nth1_builtin_emitted(TmpDir),
     assert_lowered_select_builtin_emitted(TmpDir),
+    assert_lowered_numlist_builtin_emitted(TmpDir),
     assert_lowered_delete_builtin_emitted(TmpDir),
     assert_lowered_sort_builtin_emitted(TmpDir),
     assert_lowered_msort_builtin_emitted(TmpDir),
@@ -705,6 +715,11 @@ smoke_cases([
     case('wam_select_backtrack/2', args(b, '[a,c]'), "true"),
     case('wam_select_bad_list/1', '[b,c]', "false"),
     case('wam_select_unbound_list/1', '[b,c]', "false"),
+    case('wam_numlist_guard/3', args(1, 3, '[1,2,3]'), "true"),
+    case('wam_numlist_guard/3', args(2, 2, '[2]'), "true"),
+    case('wam_numlist_guard/3', args(1, 3, '[1,3]'), "false"),
+    case('wam_numlist_high_before_low/1', '[]', "false"),
+    case('wam_numlist_unbound_low/1', '[1,2,3]', "false"),
     case('wam_delete_guard/3', args('[a,b,a,c]', a, '[b,c]'), "true"),
     case('wam_delete_guard/3', args('[a,b,a,c]', z, '[a,b,a,c]'), "true"),
     case('wam_delete_guard/3', args('[f(a),f(b),f(a)]', 'f(a)', '[f(b)]'), "true"),
@@ -1009,6 +1024,14 @@ assert_lowered_select_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-select-unbound-list-1"),
     has(CoreCode, "runtime/apply-select-solution").
 
+assert_lowered_numlist_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-numlist-guard-3"),
+    has(CoreCode, "defn lowered-wam-numlist-high-before-low-1"),
+    has(CoreCode, "defn lowered-wam-numlist-unbound-low-1"),
+    has(CoreCode, "runtime/apply-numlist-solution").
+
 assert_lowered_delete_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
@@ -1269,6 +1292,9 @@ prolog_term_string_to_edn('f(a,b)', "{:tag :struct :functor \"f/2\" :args [\"a\"
 prolog_term_string_to_edn('f(b)', "{:tag :struct :functor \"f/1\" :args [\"b\"]}") :- !.
 prolog_term_string_to_edn('[a]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}") :- !.
 prolog_term_string_to_edn('[42]', "{:tag :struct :functor \"[|]/2\" :args [42 \"[]\"]}") :- !.
+prolog_term_string_to_edn('[1,2,3]', "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [2 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn('[1,3]', "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}") :- !.
+prolog_term_string_to_edn('[2]', "{:tag :struct :functor \"[|]/2\" :args [2 \"[]\"]}") :- !.
 prolog_term_string_to_edn('[f,a,b]', "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[a,b]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
@@ -1290,6 +1316,9 @@ prolog_term_string_to_edn("f(a,b)", "{:tag :struct :functor \"f/2\" :args [\"a\"
 prolog_term_string_to_edn("f(b)", "{:tag :struct :functor \"f/1\" :args [\"b\"]}") :- !.
 prolog_term_string_to_edn("[a]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}") :- !.
 prolog_term_string_to_edn("[42]", "{:tag :struct :functor \"[|]/2\" :args [42 \"[]\"]}") :- !.
+prolog_term_string_to_edn("[1,2,3]", "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [2 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn("[1,3]", "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}") :- !.
+prolog_term_string_to_edn("[2]", "{:tag :struct :functor \"[|]/2\" :args [2 \"[]\"]}") :- !.
 prolog_term_string_to_edn("[f,a,b]", "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[a,b]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.


### PR DESCRIPTION
## Summary

- Adds Clojure WAM support for `numlist/3`.
- Direct-lowers `numlist/3` to a runtime helper instead of stepping through the interpreted builtin path.
- Supports integer `Low`, integer `High`, and output-list unification.
- Fails cleanly for `Low > High` and unbound/non-integer bounds.
- Adds lowered-emitter and runtime smoke coverage.

## Semantics

`numlist/3` accepts integer lower and upper bounds and unifies the third argument with the proper list of integers from `Low` through `High`, inclusive.

This initial Clojure WAM implementation is conservative: it supports the common `(+Low, +High, ?List)` mode and fails for unsupported modes or invalid bounds rather than raising ISO-style errors.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
