### PR TITLE
Feat/wam go reverse builtin

### DIFF
--- a/PR_go_wam_reverse_builtin.md
+++ b/PR_go_wam_reverse_builtin.md
@@ -1,0 +1,24 @@
+# PR Title
+
+Add Go WAM reverse builtin parity
+
+# PR Description
+
+## Summary
+
+- Add deterministic `reverse/2` support to the generated Go WAM runtime.
+- Route Go WAM `call`/`execute` instructions for `reverse/2` through `BuiltinCall` using the existing Go-local direct builtin path.
+- Extend generated Go WAM builtin E2E coverage for both forward and reverse-list binding modes.
+- Update the Go WAM parity audit to record the expanded Clojure/R/C++ list-builtin parity surface.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl tests/test_wam_go_generator.pl tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -11,7 +11,7 @@ current cross-target builtin/runtime baseline.
 | Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries, indexed atom fact streams, `member/2` builtin retries | Choice point stack with normal, builtin, and fact-stream resume states | Present for current resume-state baseline |
 | Direct fact dispatch | `call_indexed_atom_fact2`, `AtomFact2Source` registry, TSV-backed and LMDB-artifact atom fact loading, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Present for current external atom fact-source baseline |
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
-| Structural builtins | `member/2`, `memberchk/2`, `length/2`, `append/3` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented | Present for current baseline structural checks |
+| Structural builtins | `member/2`, `memberchk/2`, `length/2`, `append/3`, `reverse/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `reverse/2` | Present for current baseline structural checks, with one expanded cross-target list builtin |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2` | Includes `=</2` | Present for current baseline comparisons |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
@@ -34,6 +34,9 @@ current cross-target builtin/runtime baseline.
 - Deterministic `memberchk/2` is now covered by the generated Go WAM builtin
   E2E test, committing to the first unifiable list element without adding
   builtin choice points.
+- Deterministic `reverse/2` is now covered by the generated Go WAM builtin E2E
+  test for both forward and reverse-list binding modes, closing one richer
+  Clojure/R/C++ list-builtin parity gap.
 - Go WAM choice points now have explicit generated-runtime coverage for normal
   clause retries, indexed alternatives, foreign stream retries, indexed atom
   fact streams, and `member/2` builtin retries.

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -422,6 +422,9 @@ wam_go_direct_builtin(Pred, Arity) :-
 wam_go_direct_builtin(memberchk/2, 2, 'memberchk/2').
 wam_go_direct_builtin('memberchk/2', 2, 'memberchk/2').
 wam_go_direct_builtin("memberchk/2", 2, 'memberchk/2').
+wam_go_direct_builtin(reverse/2, 2, 'reverse/2').
+wam_go_direct_builtin('reverse/2', 2, 'reverse/2').
+wam_go_direct_builtin("reverse/2", 2, 'reverse/2').
 
 wam_instruction_to_go_literal(get_constant(C, Ai), GoLiteral) :-
     go_value_literal(C, GoVal),

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1125,6 +1125,32 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 		if !ok1 || !ok2 { return false }
 		combined := &List{Elements: append(append([]Value{}, l1...), l2...)}
 		return vm.Unify(arg3, combined)
+	case "reverse/2":
+		d1 := vm.deref(arg1)
+		d2 := vm.deref(arg2)
+		if !isUnbound(d1) {
+			items, ok := vm.listToSlice(d1)
+			if !ok {
+				return false
+			}
+			reversed := append([]Value{}, items...)
+			for i, j := 0, len(reversed)-1; i < j; i, j = i+1, j-1 {
+				reversed[i], reversed[j] = reversed[j], reversed[i]
+			}
+			return vm.Unify(arg2, &List{Elements: reversed})
+		}
+		if !isUnbound(d2) {
+			items, ok := vm.listToSlice(d2)
+			if !ok {
+				return false
+			}
+			reversed := append([]Value{}, items...)
+			for i, j := 0, len(reversed)-1; i < j; i, j = i+1, j-1 {
+				reversed[i], reversed[j] = reversed[j], reversed[i]
+			}
+			return vm.Unify(arg1, &List{Elements: reversed})
+		}
+		return false
 	case "functor/3":
 		t := vm.deref(arg1)
 		if isUnbound(t) {

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -9,6 +9,7 @@
 :- dynamic user:test_term_builtins/0.
 :- dynamic user:test_member_collect/0.
 :- dynamic user:test_memberchk_builtin/0.
+:- dynamic user:test_reverse_builtin/0.
 :- dynamic user:test_set_aggregate/0.
 :- dynamic user:test_unify_builtin/0.
 :- dynamic user:test_neg_fact/1.
@@ -57,6 +58,12 @@ test(builtins_execution) :-
                 X == a,
                 \+ memberchk(z, [a,b,c])
             )),
+          assertz(user:test_reverse_builtin :-
+            (   reverse([a,b,c], R),
+                R = [c,b,a],
+                reverse(L, [z,y]),
+                L = [y,z]
+            )),
           assertz(user:test_set_aggregate :-
             (   aggregate_all(set(X), member(X, [a,b,a]), S),
                 length(S, 2),
@@ -82,6 +89,7 @@ test(builtins_execution) :-
           retractall(user:test_term_builtins),
           retractall(user:test_member_collect),
           retractall(user:test_memberchk_builtin),
+          retractall(user:test_reverse_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
           retractall(user:test_neg_fact(_)),
@@ -91,7 +99,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_reverse_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -123,6 +131,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "copy_term/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "=/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "memberchk/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "reverse/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "\\\\+/1"')),
     assertion(sub_string(LibCode, _, _, _, 'AggType: "set"')),
 
@@ -174,6 +183,14 @@ func main() {
 		fmt.Println("MEMBERCHK_SUCCESS")
 	} else {
 		fmt.Println("MEMBERCHK_FAILURE")
+	}
+
+	reverseVM := wam.NewWamState(wam.Test_reverse_builtinCode, wam.Test_reverse_builtinLabels)
+	reverseVM.PC = wam.Test_reverse_builtinStartPC
+	if reverseVM.Run() {
+		fmt.Println("REVERSE_SUCCESS")
+	} else {
+		fmt.Println("REVERSE_FAILURE")
 	}
 
 	setVM := wam.NewWamState(wam.Test_set_aggregateCode, wam.Test_set_aggregateLabels)
@@ -229,6 +246,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "TERM_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "MEMBER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "MEMBERCHK_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "REVERSE_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NEG_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM reverse builtin parity

## Summary

- Add deterministic `reverse/2` support to the generated Go WAM runtime.
- Route Go WAM `call`/`execute` instructions for `reverse/2` through `BuiltinCall` using the existing Go-local direct builtin path.
- Extend generated Go WAM builtin E2E coverage for both forward and reverse-list binding modes.
- Update the Go WAM parity audit to record the expanded Clojure/R/C++ list-builtin parity surface.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl tests/test_wam_go_generator.pl tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`
