### PR TITLE
feat(wam-cpp): read/1 + read_term/1 — stdin term reading

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -3423,6 +3423,54 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         pc += 1; return true;
     }
 
+    // ---- read/1, read_term/1 ----------------------------------------
+    // Read a term from stdin, terminated by `.` (followed by EOF or
+    // whitespace). Bind A1 to the parsed term. On EOF before any
+    // input, bind A1 to the atom `end_of_file` (per ISO). Uses
+    // parse_term (added in #2189) so the syntax matches what
+    // term_to_atom/2 produces.
+    if (op == "read/1" || op == "read_term/1") {
+        std::string buf;
+        bool got_period = false;
+        while (true) {
+            int ch = std::getc(stdin);
+            if (ch == EOF) break;
+            buf.push_back(static_cast<char>(ch));
+            // Terminator: a `.` followed by whitespace or EOF.
+            if (ch == ''.'') {
+                int peek = std::getc(stdin);
+                if (peek == EOF) {
+                    buf.pop_back(); // drop the period
+                    got_period = true;
+                    break;
+                }
+                if (peek == '' '' || peek == ''\\t'' || peek == ''\\n'') {
+                    buf.pop_back();
+                    got_period = true;
+                    break;
+                }
+                // Not a real terminator (e.g. floating-point digit). Push back.
+                std::ungetc(peek, stdin);
+            }
+        }
+        CellPtr tgt = get_cell("A1");
+        if (buf.empty() && !got_period) {
+            // EOF before any input → end_of_file.
+            Value eof = Value::Atom("end_of_file");
+            if (tgt->is_unbound()) { bind_cell(tgt, eof); pc += 1; return true; }
+            if (!unify_cells(tgt, std::make_shared<Cell>(eof))) return false;
+            pc += 1; return true;
+        }
+        std::size_t pos = 0;
+        CellPtr parsed;
+        if (!parse_term(buf, pos, parsed)) return false;
+        parse_skip_ws(buf, pos);
+        if (pos != buf.size()) return false; // trailing non-ws garbage
+        if (tgt->is_unbound()) { bind_cell(tgt, *parsed); pc += 1; return true; }
+        if (!unify_cells(tgt, parsed)) return false;
+        pc += 1; return true;
+    }
+
     if (op == "split_string/4") {
         auto read_str = [&](CellPtr c, std::string& out) -> bool {
             Value v = deref(*c);

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1487,6 +1487,8 @@ is_builtin_pred(atom_concat, 3).  % (+, +, ?) — concatenation.
 is_builtin_pred(atom_length, 2).  % atom → length in chars.
 is_builtin_pred(split_string, 4). % split string by separator chars.
 is_builtin_pred(term_to_atom, 2). % bidirectional canonical-form term ↔ atom.
+is_builtin_pred(read, 1).         % stdin: read a term terminated by `.`.
+is_builtin_pred(read_term, 1).    % alias for read/1.
 is_builtin_pred(char_code, 2).    % char-atom ↔ integer code.
 is_builtin_pred(assertz, 1).      % dynamic db: append fact.
 is_builtin_pred(asserta, 1).      % dynamic db: prepend fact.

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -1824,6 +1824,40 @@ user:wam_cpp_test_tta_roundtrip :-
     term_to_atom(T, A),
     T = foo(a, b, c).
 
+% read/1 + read_term/1 — stdin term reading using the canonical-form
+% parser from #2189. Terminator is `.` followed by whitespace or EOF.
+% Pre-EOF empty input yields atom `end_of_file` (per ISO).
+:- dynamic user:wam_cpp_test_read_atom/0.
+:- dynamic user:wam_cpp_test_read_int/0.
+:- dynamic user:wam_cpp_test_read_compound/0.
+:- dynamic user:wam_cpp_test_read_list/0.
+:- dynamic user:wam_cpp_test_read_eof/0.
+:- dynamic user:wam_cpp_test_read_term_atom/0.
+
+user:wam_cpp_test_read_atom :-
+    read(T),
+    T = hello.
+
+user:wam_cpp_test_read_int :-
+    read(T),
+    T = 42.
+
+user:wam_cpp_test_read_compound :-
+    read(T),
+    T = foo(1, bar).
+
+user:wam_cpp_test_read_list :-
+    read(T),
+    T = [a, b, c].
+
+user:wam_cpp_test_read_eof :-
+    read(T),
+    T = end_of_file.
+
+user:wam_cpp_test_read_term_atom :-
+    read_term(T),
+    T = just_an_atom.
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -6285,6 +6319,88 @@ test(cpp_e2e_tta_roundtrip,
     ).
 
 % ------------------------------------------------------------------
+% read/1 + read_term/1 — stdin term reading. Tests pipe input to
+% the child via run_query_with_stdin, which writes the supplied
+% text + closes the child''s stdin before reading stdout.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_read_atom, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_read_atom', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_read_atom/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_with_stdin(BinPath, 'wam_cpp_test_read_atom/0',
+                               [], "hello.\n", true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_read_int, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_read_int', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_read_int/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_with_stdin(BinPath, 'wam_cpp_test_read_int/0',
+                               [], "42.\n", true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_read_compound, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_read_compound', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_read_compound/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_with_stdin(BinPath,
+                               'wam_cpp_test_read_compound/0',
+                               [], "foo(1, bar).\n", true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_read_list, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_read_list', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_read_list/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_with_stdin(BinPath, 'wam_cpp_test_read_list/0',
+                               [], "[a, b, c].\n", true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_read_eof, [condition(cpp_compiler_available)]) :-
+    % Empty stdin → atom end_of_file.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_read_eof', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_read_eof/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_with_stdin(BinPath, 'wam_cpp_test_read_eof/0',
+                               [], "", true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_read_term_atom,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_read_term_atom', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_read_term_atom/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_with_stdin(BinPath,
+                               'wam_cpp_test_read_term_atom/0',
+                               [], "just_an_atom.\n", true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
 % Arithmetic builtins: succ/2 (direct bidirectional) and between/3
 % (helper-injected, nondet via the standard two-clause definition).
 % ------------------------------------------------------------------
@@ -6421,6 +6537,24 @@ run_query_stdout(BinPath, PredKey, Args, Status, ExpPrint) :-
     string_concat(ExpPrint, StatusStr, ExpWithStatus),
     string_concat(ExpWithStatus, "\n", Expected),
     assertion(Output == Expected).
+
+% run_query_with_stdin(+BinPath, +PredKey, +Args, +StdinText, +Expected)
+%  Pipes StdinText to the child''s stdin, then runs the same shape
+%  of assertion as run_query (trimmed stdout matches "true"/"false").
+%  Used for read_term/1 etc. tests that consume input.
+run_query_with_stdin(BinPath, PredKey, Args, StdinText, Expected) :-
+    maplist(atom_string, Args, ArgStrs),
+    process_create(BinPath, [PredKey|ArgStrs],
+                   [stdin(pipe(In)), stdout(pipe(Out)),
+                    stderr(null), process(PID)]),
+    write(In, StdinText),
+    close(In),
+    read_string(Out, _, Output),
+    close(Out),
+    process_wait(PID, _),
+    normalize_space(string(Trimmed), Output),
+    expected_str(Expected, ExpStr),
+    assertion(Trimmed == ExpStr).
 
 % ------------------------------------------------------------------
 % ISO error configuration — plumbing PR tests. The key swap tables


### PR DESCRIPTION
## Summary

Adds `read(?Term)` and `read_term(?Term)` — read a term from stdin terminated by `.` (followed by whitespace or EOF), then parse it via the canonical-form term parser from #2189. The two are aliases.

```prolog
?- read(T).      % stdin: "foo(1, bar)."
T = foo(1, bar).
```

## Details

- Empty stdin (EOF before any input) binds `Term` to the atom `end_of_file` (per ISO).
- A `.` immediately followed by a digit isn't a terminator — `3.14.` parses as float `3.14`, not int `3` followed by end. The reader peeks the next char and pushes back via `ungetc` when it's a digit.
- Syntax matches `term_to_atom/2`'s reverse mode (canonical form: integer, float, atom, var, list, compound).

## Test infrastructure

New `run_query_with_stdin/5` helper in `test_wam_cpp_generator.pl`:

```prolog
run_query_with_stdin(BinPath, PredKey, Args, StdinText, Expected) :-
    ...
    process_create(BinPath, [PredKey|ArgStrs],
                   [stdin(pipe(In)), stdout(pipe(Out)),
                    stderr(null), process(PID)]),
    write(In, StdinText),
    close(In),
    ...
```

Pipes a supplied string to the child's stdin before reading stdout. Pairs with the existing `run_query/4` and `run_query_stdout/5`.

## Test plan

- [x] 6 new e2e tests:
  - read an atom (`hello.` → `T = hello`)
  - read an integer (`42.` → `T = 42`)
  - read a compound (`foo(1, bar).` → `T = foo(1, bar)`)
  - read a list (`[a, b, c].` → `T = [a, b, c]`)
  - EOF (empty stdin) → `T = end_of_file`
  - `read_term/1` alias works the same
- [x] Full `test_wam_cpp_generator.pl` suite passes (~310 tests)
- [x] `test_wam_target.pl` passes

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_