### PR TITLE
feat(wam-clojure): add memberchk/2 builtin

### DIFF
--- a/PR_WAM_CLOJURE_MEMBERCHK_BUILTIN.md
+++ b/PR_WAM_CLOJURE_MEMBERCHK_BUILTIN.md
@@ -1,0 +1,28 @@
+# PR Title
+
+feat(wam-clojure): add memberchk/2 builtin
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM support for `memberchk/2`.
+- Direct-lowers `memberchk/2` to a deterministic runtime helper.
+- Reuses the existing proper-list traversal used by `member/2`.
+- Avoids choicepoint creation so `memberchk/2` commits to the first successful match.
+- Adds lowered-emitter and runtime smoke coverage.
+
+## Semantics
+
+`memberchk/2` scans a proper list in the second argument and succeeds on the first element that unifies with the first argument.
+
+Unlike `member/2`, this implementation is deterministic: it advances immediately on the first match and does not leave alternatives for backtracking.
+
+Unsupported cases such as unbound or improper input lists fail cleanly.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -384,6 +384,10 @@ clojure_direct_builtin("member/2", "2").
 clojure_direct_builtin("member/2", 2).
 clojure_direct_builtin('member/2', "2").
 clojure_direct_builtin('member/2', 2).
+clojure_direct_builtin("memberchk/2", "2").
+clojure_direct_builtin("memberchk/2", 2).
+clojure_direct_builtin('memberchk/2', "2").
+clojure_direct_builtin('memberchk/2', 2).
 clojure_direct_builtin("append/3", "3").
 clojure_direct_builtin("append/3", 3).
 clojure_direct_builtin('append/3', "3").
@@ -682,6 +686,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr),
            '(let [elem (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) list-value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound))] (runtime/apply-member-solution ~w (inc (:pc ~w)) elem list-value))',
            [S, S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "memberchk/2" ; Op == 'memberchk/2'),
+    !,
+    format(atom(Expr),
+           '(let [elem (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) list-value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound))] (runtime/apply-memberchk-solution ~w elem list-value))',
+           [S, S, S, S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "append/3" ; Op == 'append/3'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -725,6 +725,32 @@
         :else
         (backtrack base-state)))))
 
+(defn apply-memberchk-solution [base-state elem list-value]
+  (let [bindings (:bindings base-state)
+        empty-list (normalize-literal-atom (:intern-context base-state) "[]")
+        list-functor (list-functor-term (:intern-context base-state))]
+    (loop [cur (deref-value bindings list-value)
+           seen #{}]
+      (cond
+        (interned-equal? cur empty-list)
+        (backtrack base-state)
+
+        (or (= cur ::unbound) (logic-var? cur) (contains? seen cur))
+        (backtrack base-state)
+
+        (and (structure-term? cur)
+             (interned-equal? (:functor cur) list-functor)
+             (= 2 (count (:args cur))))
+        (let [head (first (:args cur))
+              tail (second (:args cur))
+              [ok next-state] (unify-values base-state elem head)]
+          (if ok
+            (advance next-state)
+            (recur (deref-value bindings tail) (conj seen cur))))
+
+        :else
+        (backtrack base-state)))))
+
 (defn append-split-results [state items]
   (let [ctx (:intern-context state)]
     (mapv (fn [idx]
@@ -1639,6 +1665,13 @@
                 list-value (deref-value (:bindings state)
                                         (or (reg-get-raw state "A2") ::unbound))]
             (apply-member-solution state (inc (:pc state)) elem list-value))
+
+          "memberchk/2"
+          (let [elem (deref-value (:bindings state)
+                                  (or (reg-get-raw state "A1") ::unbound))
+                list-value (deref-value (:bindings state)
+                                        (or (reg-get-raw state "A2") ::unbound))]
+            (apply-memberchk-solution state elem list-value))
 
           "append/3"
           (let [left (deref-value (:bindings state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -537,6 +537,15 @@ test(simple_builtin_member_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_memberchk_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_memberchk/2:\nbuiltin_call memberchk/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_memberchk/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_memberchk/2, WamCode, [], Code),
+        has(Code, "runtime/apply-memberchk-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_append_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_append/3:\nbuiltin_call append/3, 3\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -80,6 +80,9 @@
 :- dynamic user:wam_member_guard/2.
 :- dynamic user:wam_member_backtrack_b/0.
 :- dynamic user:wam_member_unbound_list/1.
+:- dynamic user:wam_memberchk_guard/2.
+:- dynamic user:wam_memberchk_first_only_fail/0.
+:- dynamic user:wam_memberchk_unbound_list/1.
 :- dynamic user:wam_append_guard/3.
 :- dynamic user:wam_append_bad_left/1.
 :- dynamic user:wam_append_unbound_left/1.
@@ -238,6 +241,9 @@ user:wam_length_unbound_list(N) :- user:wam_unbound_arg(Y), length(Y, N).
 user:wam_member_guard(X, L) :- member(X, L).
 user:wam_member_backtrack_b :- member(X, [a,b]), X = b.
 user:wam_member_unbound_list(X) :- user:wam_unbound_arg(Y), member(X, Y).
+user:wam_memberchk_guard(X, L) :- memberchk(X, L).
+user:wam_memberchk_first_only_fail :- memberchk(X, [a,b]), X = b.
+user:wam_memberchk_unbound_list(X) :- user:wam_unbound_arg(Y), memberchk(X, Y).
 user:wam_append_guard(A, B, C) :- append(A, B, C).
 user:wam_append_bad_left(C) :- append([a|b], [c], C).
 user:wam_append_unbound_left(C) :- user:wam_unbound_arg(A), append(A, [b], C).
@@ -401,6 +407,9 @@ run_smoke :-
           user:wam_member_guard/2,
           user:wam_member_backtrack_b/0,
           user:wam_member_unbound_list/1,
+          user:wam_memberchk_guard/2,
+          user:wam_memberchk_first_only_fail/0,
+          user:wam_memberchk_unbound_list/1,
           user:wam_append_guard/3,
           user:wam_append_bad_left/1,
           user:wam_append_unbound_left/1,
@@ -510,6 +519,7 @@ run_smoke :-
     assert_lowered_is_list_builtin_emitted(TmpDir),
     assert_lowered_length_builtin_emitted(TmpDir),
     assert_lowered_member_builtin_emitted(TmpDir),
+    assert_lowered_memberchk_builtin_emitted(TmpDir),
     assert_lowered_append_builtin_emitted(TmpDir),
     assert_lowered_reverse_builtin_emitted(TmpDir),
     assert_lowered_last_builtin_emitted(TmpDir),
@@ -667,6 +677,11 @@ smoke_cases([
     case('wam_member_guard/2', args(c, '[a,b]'), "false"),
     case('wam_member_backtrack_b/0', no_args, "true"),
     case('wam_member_unbound_list/1', a, "false"),
+    case('wam_memberchk_guard/2', args(a, '[a,b]'), "true"),
+    case('wam_memberchk_guard/2', args(b, '[a,b]'), "true"),
+    case('wam_memberchk_guard/2', args(c, '[a,b]'), "false"),
+    case('wam_memberchk_first_only_fail/0', no_args, "false"),
+    case('wam_memberchk_unbound_list/1', a, "false"),
     case('wam_append_guard/3', args('[a]', '[b,c]', '[a,b,c]'), "true"),
     case('wam_append_guard/3', args('[]', '[a,b]', '[a,b]'), "true"),
     case('wam_append_guard/3', args('[a,b]', '[]', '[a,b]'), "true"),
@@ -965,6 +980,14 @@ assert_lowered_member_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-member-backtrack-b-0"),
     has(CoreCode, "defn lowered-wam-member-unbound-list-1"),
     has(CoreCode, "runtime/apply-member-solution").
+
+assert_lowered_memberchk_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-memberchk-guard-2"),
+    has(CoreCode, "defn lowered-wam-memberchk-first-only-fail-0"),
+    has(CoreCode, "defn lowered-wam-memberchk-unbound-list-1"),
+    has(CoreCode, "runtime/apply-memberchk-solution").
 
 assert_lowered_append_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM support for `memberchk/2`.
- Direct-lowers `memberchk/2` to a deterministic runtime helper.
- Reuses the existing proper-list traversal used by `member/2`.
- Avoids choicepoint creation so `memberchk/2` commits to the first successful match.
- Adds lowered-emitter and runtime smoke coverage.

## Semantics

`memberchk/2` scans a proper list in the second argument and succeeds on the first element that unifies with the first argument.

Unlike `member/2`, this implementation is deterministic: it advances immediately on the first match and does not leave alternatives for backtracking.

Unsupported cases such as unbound or improper input lists fail cleanly.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
