### PR TITLE
feat(wam-cpp): single-char I/O — get_char/get_code/peek_char/put_char/put_code

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -3471,6 +3471,50 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         pc += 1; return true;
     }
 
+    // ---- get_char/1, get_code/1, peek_char/1 ------------------------
+    // Single-char input. On EOF, get_char/peek_char bind A1 to atom
+    // `end_of_file`; get_code binds A1 to -1 (per ISO).
+    if (op == "get_char/1" || op == "peek_char/1") {
+        int ch = std::getc(stdin);
+        if (op == "peek_char/1" && ch != EOF) std::ungetc(ch, stdin);
+        Value v;
+        if (ch == EOF) v = Value::Atom("end_of_file");
+        else v = Value::Atom(std::string(1,
+            static_cast<char>(static_cast<unsigned char>(ch))));
+        CellPtr tgt = get_cell("A1");
+        if (tgt->is_unbound()) { bind_cell(tgt, v); pc += 1; return true; }
+        if (!unify_cells(tgt, std::make_shared<Cell>(v))) return false;
+        pc += 1; return true;
+    }
+    if (op == "get_code/1") {
+        int ch = std::getc(stdin);
+        Value v = Value::Integer(static_cast<std::int64_t>(ch)); // -1 on EOF
+        CellPtr tgt = get_cell("A1");
+        if (tgt->is_unbound()) { bind_cell(tgt, v); pc += 1; return true; }
+        if (!unify_cells(tgt, std::make_shared<Cell>(v))) return false;
+        pc += 1; return true;
+    }
+
+    // ---- put_char/1, put_code/1 -------------------------------------
+    // Single-char output. Routes through emit_output_char so the byte
+    // is captured by an enclosing with_output_to/2.
+    if (op == "put_char/1") {
+        Value v = deref(*get_cell("A1"));
+        if (v.tag != Value::Tag::Atom || v.s.size() != 1) return false;
+        emit_output_char(v.s[0]);
+        std::fflush(stdout);
+        pc += 1; return true;
+    }
+    if (op == "put_code/1") {
+        Value v = deref(*get_cell("A1"));
+        if (v.tag != Value::Tag::Integer || v.i < 0 || v.i > 255)
+            return false;
+        emit_output_char(static_cast<char>(
+            static_cast<unsigned char>(v.i)));
+        std::fflush(stdout);
+        pc += 1; return true;
+    }
+
     if (op == "split_string/4") {
         auto read_str = [&](CellPtr c, std::string& out) -> bool {
             Value v = deref(*c);

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1489,6 +1489,11 @@ is_builtin_pred(split_string, 4). % split string by separator chars.
 is_builtin_pred(term_to_atom, 2). % bidirectional canonical-form term ↔ atom.
 is_builtin_pred(read, 1).         % stdin: read a term terminated by `.`.
 is_builtin_pred(read_term, 1).    % alias for read/1.
+is_builtin_pred(get_char, 1).     % stdin: read one char as atom.
+is_builtin_pred(get_code, 1).     % stdin: read one char as int code.
+is_builtin_pred(peek_char, 1).    % stdin: peek one char (un-consumed).
+is_builtin_pred(put_char, 1).     % stdout: write one single-char atom.
+is_builtin_pred(put_code, 1).     % stdout: write one int code as char.
 is_builtin_pred(char_code, 2).    % char-atom ↔ integer code.
 is_builtin_pred(assertz, 1).      % dynamic db: append fact.
 is_builtin_pred(asserta, 1).      % dynamic db: prepend fact.

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -1858,6 +1858,51 @@ user:wam_cpp_test_read_term_atom :-
     read_term(T),
     T = just_an_atom.
 
+% get_char/1, get_code/1, peek_char/1, put_char/1, put_code/1 —
+% single-char I/O. EOF behaviour: get_char/peek_char → atom
+% end_of_file; get_code → -1. put_* routes through emit_output_char
+% so with_output_to/2 captures the bytes.
+:- dynamic user:wam_cpp_test_get_char/0.
+:- dynamic user:wam_cpp_test_get_code/0.
+:- dynamic user:wam_cpp_test_get_char_eof/0.
+:- dynamic user:wam_cpp_test_get_code_eof/0.
+:- dynamic user:wam_cpp_test_peek_char/0.
+:- dynamic user:wam_cpp_test_put_char/0.
+:- dynamic user:wam_cpp_test_put_code/0.
+:- dynamic user:wam_cpp_test_put_in_capture/0.
+
+user:wam_cpp_test_get_char :- get_char(C), C = h.
+
+user:wam_cpp_test_get_code :- get_code(C), C = 104.
+
+user:wam_cpp_test_get_char_eof :-
+    get_char(C),
+    C = end_of_file.
+
+user:wam_cpp_test_get_code_eof :-
+    get_code(C),
+    C = -1.
+
+% peek_char/1 doesn''t consume the byte — the subsequent get_char/1
+% sees the same character.
+user:wam_cpp_test_peek_char :-
+    peek_char(C1),
+    get_char(C2),
+    C1 = a,
+    C2 = a.
+
+user:wam_cpp_test_put_char :-
+    put_char(a), put_char(b), put_char(c), nl.
+
+user:wam_cpp_test_put_code :-
+    put_code(72), put_code(105), nl.  % "Hi\n"
+
+% Capture put_char + put_code via with_output_to/2 — confirms
+% they route through emit_output_char (not direct stdout).
+user:wam_cpp_test_put_in_capture :-
+    with_output_to(atom(A), (put_char(x), put_code(89))),
+    A = 'xY'.
+
 % succ/2 + between/3 fixtures. succ is a direct bidirectional builtin;
 % between is helper-injected and exercises the nondet path via findall.
 :- dynamic user:wam_cpp_test_succ_fwd/0.
@@ -6396,6 +6441,117 @@ test(cpp_e2e_read_term_atom,
           run_query_with_stdin(BinPath,
                                'wam_cpp_test_read_term_atom/0',
                                [], "just_an_atom.\n", true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% ------------------------------------------------------------------
+% get_char/1, get_code/1, peek_char/1, put_char/1, put_code/1 —
+% single-char I/O. Input tests pipe one char via stdin; output
+% tests assert exact stdout bytes.
+% ------------------------------------------------------------------
+
+test(cpp_e2e_get_char, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_get_char', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_get_char/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_with_stdin(BinPath, 'wam_cpp_test_get_char/0',
+                               [], "h", true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_get_code, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_get_code', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_get_code/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_with_stdin(BinPath, 'wam_cpp_test_get_code/0',
+                               [], "h", true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_get_char_eof,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_get_char_eof', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_get_char_eof/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_with_stdin(BinPath,
+                               'wam_cpp_test_get_char_eof/0',
+                               [], "", true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_get_code_eof,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_get_code_eof', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_get_code_eof/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_with_stdin(BinPath,
+                               'wam_cpp_test_get_code_eof/0',
+                               [], "", true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_peek_char, [condition(cpp_compiler_available)]) :-
+    % peek_char/1 doesn''t consume — subsequent get_char/1 sees the
+    % same byte. One char of stdin satisfies both reads.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_peek_char', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_peek_char/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_with_stdin(BinPath, 'wam_cpp_test_peek_char/0',
+                               [], "a", true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_put_char, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_put_char', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_put_char/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_stdout(BinPath, 'wam_cpp_test_put_char/0', [],
+                           true, "abc\n")
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_put_code, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_put_code', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_put_code/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query_stdout(BinPath, 'wam_cpp_test_put_code/0', [],
+                           true, "Hi\n")
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_put_in_capture,
+     [condition(cpp_compiler_available)]) :-
+    % Capture regression guard — put_char/put_code route through
+    % emit_output_char so with_output_to/2 sees them.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_put_capture', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_put_in_capture/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_put_in_capture/0',
+                    [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Completes the I/O vocabulary alongside `read_term/1` (#2194) and the existing `write`/`format`/`with_output_to` family.

| Builtin | Behaviour |
|---|---|
| `get_char(-C)` | read one char from stdin; on EOF, `C = end_of_file` |
| `get_code(-N)` | read one char as integer code; on EOF, `N = -1` |
| `peek_char(-C)` | peek one char (un-consumed via `ungetc`); same EOF handling |
| `put_char(+C)` | write a single-char atom's char to stdout |
| `put_code(+N)` | write an integer code (0..255) as a byte |

`put_char` and `put_code` route through `emit_output_char` so an enclosing `with_output_to/2` captures them — confirmed by a regression test that asserts `put_char(x), put_code(89)` inside a capture produces the atom `'xY'`.

## Test plan

- [x] 8 new e2e tests using `run_query_with_stdin` (input cases) and `run_query_stdout` (output cases):
  - `get_char("h")` → `C = h`
  - `get_code("h")` → `N = 104`
  - `get_char` on empty stdin → `C = end_of_file`
  - `get_code` on empty stdin → `N = -1`
  - `peek_char` doesn't consume — subsequent `get_char` sees the same byte
  - `put_char(a), put_char(b), put_char(c), nl` → stdout `"abc\n"`
  - `put_code(72), put_code(105), nl` → stdout `"Hi\n"`
  - **with_output_to capture**: `put_char(x), put_code(89)` → captured atom `'xY'` (regression guard for `emit_output_char` routing)
- [x] Full `test_wam_cpp_generator.pl` suite passes (~320 tests)
- [x] `test_wam_target.pl` passes

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_