### PR TITLE
feat(wam-python): validate runtime parser mode

### DIFF
--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -42,6 +42,10 @@
 	parse_wam_text_py/2,
 	python_func_name/2
 ]).
+:- use_module(wam_runtime_parser_capability, [
+	parser_dependent_body_goal/2,
+	wam_target_runtime_parser/3
+]).
 
 % ============================================================================
 % TOP-LEVEL ENTRY POINT
@@ -1344,6 +1348,8 @@ compile_wam_runtime_to_python(_Options, PythonCode) :-
 %  Follows the same layout as write_wam_fsharp_project/3 in wam_fsharp_target.pl.
 write_wam_python_project(Predicates, Options, ProjectDir) :-
 	option(module_name(ModuleName), Options, 'wam_generated'),
+	wam_target_runtime_parser(wam_python, Options, RuntimeParserMode),
+	validate_python_runtime_parser_mode(Predicates, RuntimeParserMode),
 
 	% Create directory structure
 	make_directory_path(ProjectDir),
@@ -1356,7 +1362,7 @@ write_wam_python_project(Predicates, Options, ProjectDir) :-
 	write_file(InitPath, ""),
 
 	% Generate predicates.py
-	compile_all_predicates(Predicates, Options, PredicatesCode),
+	compile_all_predicates(Predicates, [runtime_parser_mode(RuntimeParserMode)|Options], PredicatesCode),
 	directory_file_path(ProjectDir, 'predicates.py', PredPath),
 	write_file(PredPath, PredicatesCode),
 
@@ -1402,6 +1408,10 @@ is_ffi_predicate(Functor, Arity, Options) :-
 compile_all_predicates([], _Options, "# No predicates compiled\n").
 compile_all_predicates(Predicates, Options, Code) :-
 	Predicates \= [],
+	option(runtime_parser_mode(RuntimeParserMode), Options, none),
+	python_runtime_parser_mode_literal(RuntimeParserMode, RuntimeParserModeCode),
+	format(string(RuntimeParserLine), 'RUNTIME_PARSER = ~w~n~n',
+	       [RuntimeParserModeCode]),
 	plan_python_predicates(Predicates, Options, Plans),
 	lowered_route_set(Plans, Options, LoweredSet),
 	maplist(compile_planned_predicate(Options, LoweredSet), Plans, PredCodes),
@@ -1416,10 +1426,47 @@ compile_all_predicates(Predicates, Options, Code) :-
 		'X1,X2,X3,X4,X5,X6,X7,X8,X9,X10 = 1,2,3,4,5,6,7,8,9,10\n',
 		'X11,X12,X13,X14,X15,X16,X17,X18,X19,X20 = 11,12,13,14,15,16,17,18,19,20\n',
 		'Y1,Y2,Y3,Y4,Y5,Y6,Y7,Y8,Y9,Y10 = 201,202,203,204,205,206,207,208,209,210\n',
-		'Y11,Y12,Y13,Y14,Y15,Y16,Y17,Y18,Y19,Y20 = 211,212,213,214,215,216,217,218,219,220\n\n'
+		'Y11,Y12,Y13,Y14,Y15,Y16,Y17,Y18,Y19,Y20 = 211,212,213,214,215,216,217,218,219,220\n',
+		RuntimeParserLine
 		| PredCodes
 	], '\n\n', PredSection),
 	atomic_list_concat([PredSection, '\n\n', BuildProgramCode], Code).
+
+python_runtime_parser_mode_literal(none,
+	'{"kind": "none", "entry": None, "source": None}') :- !.
+python_runtime_parser_mode_literal(native(Entry), Code) :-
+	!,
+	format(string(Code),
+	       '{"kind": "native", "entry": "~w", "source": None}',
+	       [Entry]).
+python_runtime_parser_mode_literal(compiled(SourceModule), Code) :-
+	format(string(Code),
+	       '{"kind": "compiled", "entry": None, "source": "~w"}',
+	       [SourceModule]).
+
+validate_python_runtime_parser_mode(Predicates, none) :-
+	!,
+	(   python_predicates_parser_dependency(Predicates, Pred, Builtin)
+	->  throw(error(permission_error(use, runtime_parser, Builtin),
+	                context(write_wam_python_project/3,
+	                        parser_disabled_for_predicate(Pred))))
+	;   true
+	).
+validate_python_runtime_parser_mode(_Predicates, _Mode).
+
+python_predicates_parser_dependency(Predicates, Pred, Builtin) :-
+	member(Pred, Predicates),
+	python_predicate_clause(Pred, _Head, Body),
+	parser_dependent_body_goal(Body, Builtin),
+	!.
+
+python_predicate_clause(Module:Name/Arity, Head, Body) :-
+	!,
+	functor(Head, Name, Arity),
+	clause(Module:Head, Body).
+python_predicate_clause(Name/Arity, Head, Body) :-
+	functor(Head, Name, Arity),
+	clause(user:Head, Body).
 
 plan_python_predicates(Predicates, Options, Plans) :-
 	maplist(plan_python_predicate(Options), Predicates, Plans).

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -377,6 +377,67 @@ test(static_runtime_run_wam_four_args, [nondet]) :-
 :- end_tests(wam_python_phase_b).
 
 % ============================================================================
+% Runtime parser capability metadata and validation
+% ============================================================================
+
+python_parser_tmp_dir(Prefix, TmpDir) :-
+	tmp_file(Prefix, TmpDir),
+	catch(delete_directory_and_contents(TmpDir), _, true),
+	make_directory_path(TmpDir).
+
+python_parser_cleanup_tmp_dir(TmpDir) :-
+	catch(delete_directory_and_contents(TmpDir), _, true).
+
+:- begin_tests(wam_python_runtime_parser_mode).
+
+test(runtime_parser_mode_metadata) :-
+	setup_call_cleanup(
+		user:python_parser_tmp_dir('tmp_wam_python_parser_mode', ProjectDir),
+		(   wam_python_target:write_wam_python_project([user:py_parser_fact/1], [], ProjectDir),
+			directory_file_path(ProjectDir, 'predicates.py', PredicatesPath),
+			read_file_to_string(PredicatesPath, Code, []),
+			assertion(sub_string(Code, _, _, _,
+				'RUNTIME_PARSER = {"kind": "none", "entry": None, "source": None}'))
+		),
+		user:python_parser_cleanup_tmp_dir(ProjectDir)).
+
+test(runtime_parser_native_request_errors,
+     [error(domain_error(runtime_parser_mode(wam_python), native))]) :-
+	setup_call_cleanup(
+		user:python_parser_tmp_dir('tmp_wam_python_parser_native_err', ProjectDir),
+		wam_python_target:write_wam_python_project([user:py_parser_fact/1],
+			[runtime_parser(native)],
+			ProjectDir),
+		user:python_parser_cleanup_tmp_dir(ProjectDir)).
+
+test(runtime_parser_none_rejects_parser_dependent_builtin,
+     [error(permission_error(use, runtime_parser, read_term_from_atom/2))]) :-
+	setup_call_cleanup(
+		(   retractall(user:py_parser_dep),
+			assertz((user:py_parser_dep :-
+				read_term_from_atom('f(a)', _))),
+			user:python_parser_tmp_dir('tmp_wam_python_parser_reject', ProjectDir)
+		),
+		wam_python_target:write_wam_python_project([user:py_parser_dep/0], [], ProjectDir),
+		(   retractall(user:py_parser_dep),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
+test(runtime_parser_none_allows_term_to_atom_forward) :-
+	setup_call_cleanup(
+		(   retractall(user:py_t2a_forward),
+			assertz((user:py_t2a_forward :-
+				term_to_atom(f(a), _))),
+			user:python_parser_tmp_dir('tmp_wam_python_parser_t2a_fwd', ProjectDir)
+		),
+		wam_python_target:write_wam_python_project([user:py_t2a_forward/0], [], ProjectDir),
+		(   retractall(user:py_t2a_forward),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
+:- end_tests(wam_python_runtime_parser_mode).
+
+% ============================================================================
 % Phase C: Lowered emitter — deterministic detection, func naming, emit
 % ============================================================================
 

--- a/tests/test_wam_runtime_parser_capability.pl
+++ b/tests/test_wam_runtime_parser_capability.pl
@@ -23,9 +23,16 @@ test(r_can_opt_into_compiled_parser) :-
 test(unknown_target_defaults_to_none) :-
     wam_target_runtime_parser(wam_lua, [], none).
 
+test(python_defaults_to_none) :-
+    wam_target_runtime_parser(wam_python, [], none).
+
 test(unknown_target_native_request_errors,
      [error(domain_error(runtime_parser_mode(wam_lua), native))]) :-
     wam_target_runtime_parser(wam_lua, [runtime_parser(native)], _).
+
+test(python_native_request_errors,
+     [error(domain_error(runtime_parser_mode(wam_python), native))]) :-
+    wam_target_runtime_parser(wam_python, [runtime_parser(native)], _).
 
 test(unknown_target_compiled_request_errors,
      [error(domain_error(runtime_parser_mode(wam_lua), compiled))]) :-


### PR DESCRIPTION
## Summary

- Wire WAM-Python into the shared runtime parser capability resolver.
- Emit `RUNTIME_PARSER` metadata in generated `predicates.py`, currently marking Python as `none`.
- Reject source clauses that require runtime term parsing when WAM-Python has no parser available.
- Add shared capability and WAM-Python target tests for parser-mode metadata and validation.

## Notes

WAM-Python does not currently provide a native or compiled runtime Prolog term parser. This PR makes that explicit instead of silently allowing parser-dependent predicates such as `read_term_from_atom/2` or reverse `term_to_atom/2`.

Forward `term_to_atom/2` remains allowed because it renders an already-bound term and does not require parsing source text.

## Tests

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_runtime_parser_capability.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_python_target.pl`
