### PR TITLE
test(wam-c): cover generated term builtins

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -5,7 +5,7 @@ Status date: 2026-05-16
 Base verified locally:
 
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `953caaf6` (`Merge pull request #2187 from s243a/feat/wam-c-arg-builtin`)
+- `main` at `c0085bce` (`Merge pull request #2198 from s243a/bench/csharp-query-page-relation-backends`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
@@ -15,7 +15,7 @@ Base verified locally:
 
 Active branch:
 
-- `feat/wam-c-atom-concat-builtin`
+- `test/wam-c-builtins-real-prolog-smoke`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -68,7 +68,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper larger-scale regression | Done | `tests/test_wam_c_lowered_helper_scale_regression.py` now promotes `100x` into the focused local lowered-helper parity regression while leaving `1k` as calibration-only because it costs about 31s end to end |
 | Lowered helper next-shape selection | Done | Selected term-shape builtin parity as the next narrow helper-adjacent surface and added C `functor/3` runtime support because Haskell and Rust already cover richer structure inspection paths |
 | `arg/3` builtin support | Done | Deterministic positive-index argument extraction for structures and lists has direct executable smoke coverage |
-| `atom_concat/3` builtin support | In progress | Active branch adds explicit deterministic atom concatenation and split modes with direct executable smoke coverage |
+| `atom_concat/3` builtin support | Done | Explicit deterministic atom concatenation and split modes have direct executable smoke coverage |
+| Generated Prolog builtin parity smoke | In progress | Active branch exercises `functor/3`, `arg/3`, and `atom_concat/3` together through generated WAM-to-C code |
 
 ## Current C Target Baseline
 
@@ -88,7 +89,7 @@ The C target is now a credible small WAM backend:
 - Supports `builtin_call` delegation for tested builtins:
   `atom/1`, `integer/1`, `number/1`, `var/1`, `nonvar/1`,
   `compound/1`, `is_list/1`, `=/2`, `is/2`, arithmetic comparisons,
-  `functor/3`, `arg/3`, and active-branch `atom_concat/3`.
+  `functor/3`, `arg/3`, and `atom_concat/3`.
 - Supports deterministic `call_foreign` dispatch through a C handler registry.
 - Can opt into a prototype lowered-helper path for constant fact-only
   predicates, plus same-arity alias bodies that call those native fact helpers,
@@ -135,7 +136,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | First-arg indexing | Done | Done | Done | C has constants, structures, mixed term, and list dispatch. |
 | Second-arg indexing | Partial | Partial/Done | Partial/Done | C has constant A2 dispatch; broaden tests if this becomes hot. |
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
-| Builtin calls | Partial | Broader | Broader | C has a growing builtin set. Active branch adds `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
+| Builtin calls | Partial | Broader | Broader | C has a growing builtin set. Active branch adds generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
 | Negation / control builtins | Partial | Broader | Broader | C likely needs explicit tests for `\+/1`, cut interactions, and if-then-else lowering. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
@@ -151,32 +152,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-atom-concat-builtin`
-
-Goal: add a narrow string/atom builtin after term-inspection coverage lands.
-
-Scope:
-
-- Implement deterministic `atom_concat/3` modes:
-  bound left plus bound right produces/checks whole,
-  bound suffix plus bound whole extracts prefix, and
-  bound prefix plus bound whole extracts suffix.
-- Keep unsupported ambiguous split modes failing predictably.
-- Add direct executable smoke coverage before using it in generated Prolog.
-
-Status: active.
-
-Selected scope:
-
-| Candidate | Decision | Reason |
-|---|---:|---|
-| `atom_concat(A, B, C)` with `A` and `B` bound | Active | Deterministic construction/check mode needed for simple generated atom composition. |
-| `atom_concat(A, Suffix, Whole)` with suffix and whole bound | Active | Deterministic prefix extraction without enumerating splits. |
-| `atom_concat(Prefix, B, Whole)` with prefix and whole bound | Active | Deterministic suffix extraction without enumerating splits. |
-| Ambiguous split enumeration | Defer | Would require nondeterministic result generation and choicepoint integration. |
-| Aggregates | Defer | Needs broader term-copy/list construction support and would be too large for this branch. |
-
-### 2. `test/wam-c-builtins-real-prolog-smoke`
+### 1. `test/wam-c-builtins-real-prolog-smoke`
 
 Goal: exercise the accumulated builtin parity surface through generated Prolog,
 not just hand-authored WAM snippets.
@@ -187,7 +163,34 @@ Scope:
   `atom_concat/3` together.
 - Keep it small and deterministic so the normal WAM-C test suite remains cheap.
 
+Status: active.
+
+Selected scope:
+
+| Candidate | Decision | Reason |
+|---|---:|---|
+| Combined generated-Prolog success path | Active | Confirms the compiler emits builtin calls that the C runtime can execute together. |
+| Bound-output failure path | Active | Confirms generated code rejects a wrong composed label deterministically. |
+| Broad builtin matrix | Defer | The full builtin surface should be demand-driven rather than expanded preemptively. |
+
+### 2. `investigate/wam-c-next-benchmark-demand`
+
+Goal: choose the next C parity gap from an actual benchmark or generated-program
+failure instead of adding builtins speculatively.
+
+Scope:
+
+- Run the existing WAM-C benchmark/generator surfaces and identify the next
+  unsupported runtime or compiler feature from real failures.
+- Prefer one narrow branch per missing feature.
+
 Status: recommended after this branch.
+
+## Completed Atom Concat Builtin
+
+The merged `feat/wam-c-atom-concat-builtin` branch added deterministic
+`atom_concat/3` composition and split modes before this generated-Prolog smoke
+branch.
 
 ## Completed Arg Builtin
 

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -925,6 +925,16 @@ test_real_prolog_builtin_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_real_prolog_term_builtin_executable_smoke :-
+    Test = 'WAM-C: real Prolog term builtin executable smoke',
+    (   gcc_available
+    ->  (   run_real_prolog_term_builtin_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'real Prolog term builtin executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_real_prolog_multiclause_executable_smoke :-
     Test = 'WAM-C: real Prolog multi-clause executable smoke',
     (   gcc_available
@@ -1285,6 +1295,39 @@ run_real_prolog_builtin_executable_smoke :-
         run_c_smoke_plain(ExePath)
     ->  retractall(user:wam_c_real_builtin(_, _))
     ;   retractall(user:wam_c_real_builtin(_, _)),
+        fail
+    ).
+
+run_real_prolog_term_builtin_executable_smoke :-
+    assertz((user:wam_c_real_term_builtins(T, Label) :-
+        functor(T, Name, Arity),
+        Arity = 2,
+        N is 2,
+        arg(N, T, Arg),
+        atom_concat(Name, '_', Prefix),
+        atom_concat(Prefix, Arg, Label))),
+    (   compile_predicate_to_wam(user:wam_c_real_term_builtins/2, [], WamCode),
+        sub_string(WamCode, _, _, _, 'builtin_call functor/3, 3'),
+        sub_string(WamCode, _, _, _, 'builtin_call arg/3, 3'),
+        sub_string(WamCode, _, _, _, 'builtin_call atom_concat/3, 3'),
+        compile_wam_predicate_to_c(user:wam_c_real_term_builtins/2, WamCode, [], PredCode),
+        compile_wam_runtime_to_c([], RuntimeCode),
+        get_time(Now),
+        Stamp is round(Now * 1000000),
+        wam_c_temp_path('unifyweaver_wam_c_real_term_builtin_smoke', Stamp, TmpBase),
+        format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+        format(atom(PredPath), '~w_pred.c', [TmpBase]),
+        format(atom(MainPath), '~w_main.c', [TmpBase]),
+        format(atom(ExePath), '~w_bin', [TmpBase]),
+        write_text_file(RuntimePath, RuntimeCode),
+        format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+        write_text_file(PredPath, PredTranslationUnit),
+        wam_c_real_term_builtin_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  retractall(user:wam_c_real_term_builtins(_, _))
+    ;   retractall(user:wam_c_real_term_builtins(_, _)),
         fail
     ).
 
@@ -2735,6 +2778,47 @@ int main(void) {
 }
 ').
 
+wam_c_real_term_builtin_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_real_term_builtins_2(WamState* state);
+
+static WamValue make_binary_struct(WamState *state, const char *functor, WamValue left, WamValue right) {
+    WamValue term;
+    term.tag = VAL_STR;
+    term.data.ref_addr = state->H;
+    state->H_array[state->H++] = val_atom(functor);
+    state->H_array[state->H++] = left;
+    state->H_array[state->H++] = right;
+    return term;
+}
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_real_term_builtins_2(&state);
+
+    WamValue pair_term = make_binary_struct(&state, "pair/2", val_atom("left"), val_atom("right"));
+    WamValue ok_args[2] = { pair_term, val_atom("pair_right") };
+    int ok_rc = wam_run_predicate(&state, "wam_c_real_term_builtins/2", ok_args, 2);
+    if (ok_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue unary_term = make_binary_struct(&state, "pair/2", val_atom("left"), val_atom("wrong"));
+    WamValue fail_args[2] = { unary_term, val_atom("pair_right") };
+    int fail_rc = wam_run_predicate(&state, "wam_c_real_term_builtins/2", fail_args, 2);
+    if (fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_real_multi_smoke_main(
 '#include "wam_runtime.h"
 
@@ -3061,6 +3145,7 @@ run_tests_once :-
     test_kernel_detector_executable_smoke,
     test_streaming_foreign_results_executable_smoke,
     test_real_prolog_builtin_executable_smoke,
+    test_real_prolog_term_builtin_executable_smoke,
     test_real_prolog_multiclause_executable_smoke,
     test_real_prolog_structure_index_executable_smoke,
     test_real_prolog_is_list_executable_smoke,


### PR DESCRIPTION
# Cover WAM-C term builtins through generated Prolog

## Summary

- adds a generated-Prolog executable smoke that compiles a predicate using `functor/3`, `arg/3`, and `atom_concat/3` through WAM-to-C
- covers both the success path with the expected composed atom label and the failure path with an incorrect bound label
- refreshes `WAM_C_TARGET_NEXT_STEPS.md` after the `atom_concat/3` merge and records benchmark-demand investigation as the next recommended WAM-C step

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/test_wam_c_lowered_helper_scale_regression.py`
- `git diff --check`
