### PR TITLE
bench(csharp-query): report access-shape artifact policies

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -161,6 +161,11 @@ Use `--format tsv` or `--format markdown` for raw per-run rows. Use
 median timings and report the best lookup, bucket, scan, and artifact-size
 backend. Summary output includes the relation name because `category_parent/2`
 and `article_category/2` have different cardinalities and access distributions.
+Use `policy-tsv` or `policy-markdown` when the consumer needs one row per
+access shape. Policy output reports the best overall mode and the best
+artifact-backed mode separately, so an in-memory `preload` scan win does not
+hide the best external artifact for column-0 lookup, column-1 lookup, bucket
+streaming, or storage.
 At the checked-in 300-10k scales this is expected to favor preload or
 mmap-array; LMDB is primarily retained as the larger-data comparison point for
 future 50k+ style runs where memory pressure matters.
@@ -335,7 +340,9 @@ high-level policy conclusion held:
 At 5M English page-category rows, the result stops being a simple
 `mmap-array` sweep. LMDB narrowly wins column-0 point lookup, `mmap-array`
 keeps the much faster column-1 lookup and smallest artifact, delimited edges
-out column-0 bucket streaming, and preload still wins full scan:
+out column-0 bucket streaming, and preload still wins full scan. Use
+`--format policy-markdown` for this scale when translating the measurement into
+an access-shape policy instead of choosing one backend for the whole relation:
 
 | Scale | Relation | Rows | Best lookup c0 | Best lookup c1 | Best bucket c0 | Best bucket c1 | Best scan | LMDB artifact bytes | Mmap-array artifact bytes | LMDB lookup c0/c1 ms | Mmap-array lookup c0/c1 ms |
 | --- | --- | ---: | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: |

--- a/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
+++ b/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
@@ -103,6 +103,29 @@ SUMMARY_HEADERS = [
     "artifact_bytes_by_mode",
 ]
 
+POLICY_HEADERS = [
+    "scale",
+    "relation",
+    "rows",
+    "distinct_categories",
+    "lookup_keys",
+    "access_shape",
+    "metric",
+    "best_mode",
+    "best_value",
+    "best_artifact_mode",
+    "best_artifact_value",
+    "values_by_mode",
+]
+
+ACCESS_SHAPE_METRICS = (
+    ("lookup_c0", "lookup_ms_by_mode"),
+    ("lookup_c1", "lookup_col1_ms_by_mode"),
+    ("bucket_c0", "bucket_ms_by_mode"),
+    ("bucket_c1", "bucket_col1_ms_by_mode"),
+    ("scan", "scan_ms_by_mode"),
+)
+
 
 @dataclass(frozen=True)
 class BenchmarkRow:
@@ -111,6 +134,11 @@ class BenchmarkRow:
 
 @dataclass(frozen=True)
 class SummaryRow:
+    values: dict[str, str]
+
+
+@dataclass(frozen=True)
+class PolicyRow:
     values: dict[str, str]
 
 
@@ -514,6 +542,88 @@ def format_mode_values(values: dict[str, float], digits: int = 3) -> str:
     return "|".join(f"{mode}:{format_value(values[mode])}" for mode in sorted(values))
 
 
+def parse_mode_values(value: str) -> dict[str, float]:
+    parsed: dict[str, float] = {}
+    if not value:
+        return parsed
+    for item in value.split("|"):
+        mode, raw = item.rsplit(":", 1)
+        parsed[mode] = float(raw)
+    return parsed
+
+
+def format_policy_value(value: float, metric: str) -> str:
+    if metric == "artifact_bytes":
+        return str(int(value))
+    return f"{value:.3f}"
+
+
+def select_best(values: dict[str, float], *, include_preload: bool) -> tuple[str, float]:
+    candidates = {
+        mode: value
+        for mode, value in values.items()
+        if include_preload or mode != "preload"
+    }
+    if not candidates:
+        return "", 0.0
+    mode = min(candidates, key=candidates.get)
+    return mode, candidates[mode]
+
+
+def policy_rows_from_summaries(rows: list[SummaryRow]) -> list[PolicyRow]:
+    policy_rows: list[PolicyRow] = []
+    for row in rows:
+        base = row.values
+        for access_shape, column in ACCESS_SHAPE_METRICS:
+            values = parse_mode_values(base[column])
+            best_mode, best_value = select_best(values, include_preload=True)
+            best_artifact_mode, best_artifact_value = select_best(values, include_preload=False)
+            policy_rows.append(
+                PolicyRow(
+                    {
+                        "scale": base["scale"],
+                        "relation": base["relation"],
+                        "rows": base["rows"],
+                        "distinct_categories": base["distinct_categories"],
+                        "lookup_keys": base["lookup_keys"],
+                        "access_shape": access_shape,
+                        "metric": "ms",
+                        "best_mode": best_mode,
+                        "best_value": format_policy_value(best_value, "ms"),
+                        "best_artifact_mode": best_artifact_mode,
+                        "best_artifact_value": format_policy_value(best_artifact_value, "ms"),
+                        "values_by_mode": base[column],
+                    }
+                )
+            )
+
+        artifact_values = {
+            mode: value
+            for mode, value in parse_mode_values(base["artifact_bytes_by_mode"]).items()
+            if mode != "preload"
+        }
+        best_artifact_mode, best_artifact_value = select_best(artifact_values, include_preload=True)
+        policy_rows.append(
+            PolicyRow(
+                {
+                    "scale": base["scale"],
+                    "relation": base["relation"],
+                    "rows": base["rows"],
+                    "distinct_categories": base["distinct_categories"],
+                    "lookup_keys": base["lookup_keys"],
+                    "access_shape": "storage",
+                    "metric": "artifact_bytes",
+                    "best_mode": best_artifact_mode,
+                    "best_value": format_policy_value(best_artifact_value, "artifact_bytes"),
+                    "best_artifact_mode": best_artifact_mode,
+                    "best_artifact_value": format_policy_value(best_artifact_value, "artifact_bytes"),
+                    "values_by_mode": format_mode_values(artifact_values, digits=0),
+                }
+            )
+        )
+    return policy_rows
+
+
 def render_summary_tsv(rows: list[SummaryRow]) -> str:
     lines = ["\t".join(SUMMARY_HEADERS)]
     lines.extend("\t".join(row.values[column] for column in SUMMARY_HEADERS) for row in rows)
@@ -546,6 +656,30 @@ def render_summary_full_markdown(rows: list[SummaryRow]) -> str:
         value = row.values
         lines.append(
             "| {scale} | {relation} | {rows} | {distinct_categories} | {lookup_keys} | {best_lookup_mode} | {best_lookup_col1_mode} | {best_bucket_mode} | {best_bucket_col1_mode} | {best_scan_mode} | {smallest_artifact_mode} | {lookup_ms_by_mode} | {lookup_col1_ms_by_mode} | {bucket_ms_by_mode} | {bucket_col1_ms_by_mode} | {scan_ms_by_mode} | {artifact_bytes_by_mode} |".format(
+                **value
+            )
+        )
+    return "\n".join(lines)
+
+
+def render_policy_tsv(rows: list[PolicyRow]) -> str:
+    lines = ["\t".join(POLICY_HEADERS)]
+    lines.extend("\t".join(row.values[column] for column in POLICY_HEADERS) for row in rows)
+    return "\n".join(lines)
+
+
+def render_policy_markdown(rows: list[PolicyRow]) -> str:
+    def markdown_cell(value: str) -> str:
+        return value.replace("|", "<br>")
+
+    lines = [
+        "| Scale | Relation | Rows | Access shape | Metric | Best mode | Best value | Best artifact mode | Best artifact value | Values by mode |",
+        "| --- | --- | ---: | --- | --- | --- | ---: | --- | ---: | --- |",
+    ]
+    for row in rows:
+        value = {column: markdown_cell(cell) for column, cell in row.values.items()}
+        lines.append(
+            "| {scale} | {relation} | {rows} | {access_shape} | {metric} | {best_mode} | {best_value} | {best_artifact_mode} | {best_artifact_value} | {values_by_mode} |".format(
                 **value
             )
         )
@@ -639,7 +773,15 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--format",
-        choices=("tsv", "markdown", "summary-tsv", "summary-markdown", "summary-full-markdown"),
+        choices=(
+            "tsv",
+            "markdown",
+            "summary-tsv",
+            "summary-markdown",
+            "summary-full-markdown",
+            "policy-tsv",
+            "policy-markdown",
+        ),
         default="tsv",
     )
     parser.add_argument("--keep-temp", action="store_true", help="keep the generated C# benchmark project")
@@ -724,12 +866,17 @@ def main(argv: list[str] | None = None) -> int:
                 )
             )
 
+    summaries = summarize(rows) if args.format.startswith(("summary-", "policy-")) else []
     if args.format == "summary-tsv":
-        print(render_summary_tsv(summarize(rows)))
+        print(render_summary_tsv(summaries))
     elif args.format == "summary-full-markdown":
-        print(render_summary_full_markdown(summarize(rows)))
+        print(render_summary_full_markdown(summaries))
     elif args.format == "summary-markdown":
-        print(render_summary_markdown(summarize(rows)))
+        print(render_summary_markdown(summaries))
+    elif args.format == "policy-tsv":
+        print(render_policy_tsv(policy_rows_from_summaries(summaries)))
+    elif args.format == "policy-markdown":
+        print(render_policy_markdown(policy_rows_from_summaries(summaries)))
     elif args.format == "markdown":
         print(render_markdown(rows))
     else:

--- a/tests/test_csharp_query_effective_distance_artifact_backends.py
+++ b/tests/test_csharp_query_effective_distance_artifact_backends.py
@@ -217,6 +217,69 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
         self.assertIn("lmdb:2.500|mmap-array:1.750", output)
         self.assertIn("Artifact bytes by mode", output)
 
+    def test_policy_rows_report_best_overall_and_artifact_modes(self) -> None:
+        row = MODULE.SummaryRow(
+            {
+                "scale": "enwiki_page_5m",
+                "relation": "article_category",
+                "rows": "5000000",
+                "distinct_categories": "1918305",
+                "lookup_keys": "128",
+                "best_lookup_mode": "lmdb",
+                "best_lookup_col1_mode": "preload",
+                "best_bucket_mode": "delimited-artifact",
+                "best_bucket_col1_mode": "mmap-array",
+                "best_scan_mode": "preload",
+                "smallest_artifact_mode": "mmap-array",
+                "lookup_ms_by_mode": "lmdb:3.251|mmap-array:3.288|preload:4.000",
+                "lookup_col1_ms_by_mode": "lmdb:1219.110|mmap-array:236.382|preload:20.000",
+                "bucket_ms_by_mode": "delimited-artifact:400.000|lmdb:500.000|mmap-array:450.000|preload:600.000",
+                "bucket_col1_ms_by_mode": "delimited-artifact:600.000|lmdb:700.000|mmap-array:350.000|preload:500.000",
+                "scan_ms_by_mode": "lmdb:900.000|mmap-array:850.000|preload:50.000",
+                "artifact_bytes_by_mode": "lmdb:142443019|mmap-array:80000643|preload:0",
+            }
+        )
+        rows = MODULE.policy_rows_from_summaries([row])
+        by_shape = {policy.values["access_shape"]: policy.values for policy in rows}
+
+        self.assertEqual(by_shape["lookup_c0"]["best_mode"], "lmdb")
+        self.assertEqual(by_shape["lookup_c0"]["best_artifact_mode"], "lmdb")
+        self.assertEqual(by_shape["lookup_c1"]["best_mode"], "preload")
+        self.assertEqual(by_shape["lookup_c1"]["best_artifact_mode"], "mmap-array")
+        self.assertEqual(by_shape["scan"]["best_mode"], "preload")
+        self.assertEqual(by_shape["scan"]["best_artifact_mode"], "mmap-array")
+        self.assertEqual(by_shape["storage"]["best_mode"], "mmap-array")
+        self.assertEqual(by_shape["storage"]["best_value"], "80000643")
+        self.assertNotIn("preload:0", by_shape["storage"]["values_by_mode"])
+
+    def test_policy_renderers_include_access_shape_rows(self) -> None:
+        rows = [
+            MODULE.PolicyRow(
+                {
+                    "scale": "dev",
+                    "relation": "category_parent",
+                    "rows": "6",
+                    "distinct_categories": "4",
+                    "lookup_keys": "2",
+                    "access_shape": "lookup_c0",
+                    "metric": "ms",
+                    "best_mode": "mmap-array",
+                    "best_value": "1.250",
+                    "best_artifact_mode": "mmap-array",
+                    "best_artifact_value": "1.250",
+                    "values_by_mode": "lmdb:2.000|mmap-array:1.250|preload:1.500",
+                }
+            )
+        ]
+
+        tsv = MODULE.render_policy_tsv(rows)
+        markdown = MODULE.render_policy_markdown(rows)
+        self.assertTrue(tsv.startswith("scale\trelation\trows\tdistinct_categories\tlookup_keys\taccess_shape"))
+        self.assertIn("\tlookup_c0\tms\tmmap-array\t1.250\tmmap-array\t1.250\t", tsv)
+        self.assertIn("| Access shape | Metric | Best mode |", markdown)
+        self.assertIn("| dev | category_parent | 6 | lookup_c0 | ms | mmap-array | 1.250 |", markdown)
+        self.assertIn("lmdb:2.000<br>mmap-array:1.250<br>preload:1.500", markdown)
+
     def test_artifact_root_reuses_existing_manifests(self) -> None:
         if shutil.which("dotnet") is None:
             self.skipTest("dotnet is not available")


### PR DESCRIPTION
  ## Summary

  - add `policy-tsv` and `policy-markdown` output formats to the C# effective-distance artifact backend benchmark
  - report one policy row per access shape, including lookup c0/c1, bucket c0/c1, scan, and storage
  - separate best overall mode from best artifact-backed mode so `preload` wins do not hide the best external artifact choice
  - document the policy output for translating large relation measurements into backend-selection guidance

  ## Verification

  - `python3 -m unittest tests/test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py --scales dev --relation
  article_category --lookup-keys 4 --lookup-repetitions 1 --repetitions 1 --format policy-markdown`
  - `git diff --check`