### PR TITLE
feat(csharp-query): add access-shape artifact policy

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -348,6 +348,12 @@ an access-shape policy instead of choosing one backend for the whole relation:
 | --- | --- | ---: | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: |
 | `enwiki_page_5m` | `article_category` | 5,000,000 | `lmdb` | `preload` | `delimited-artifact` | `mmap-array` | `preload` | 142,443,019 | 80,000,643 | 3.251 / 1,219.110 | 3.288 / 236.382 |
 
+The runtime-side `RelationArtifactAccessPolicy` keeps this as a
+dependency-free storage-kind recommendation layer. It can name optional
+providers such as `lmdb_artifact` without making `UnifyWeaver.QueryRuntime.Core`
+reference LightningDB; actual provider availability is still decided by the
+project that opts into the corresponding artifact integration.
+
 Pass `--artifact-root <dir>` to keep backend artifacts across benchmark runs.
 Existing binary, delimited, LMDB, and mmap-array manifests are reused by
 default, matching the Haskell benchmark convention of not regenerating LMDB

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -87,6 +87,16 @@ namespace UnifyWeaver.QueryRuntime
         ArtifactPrebuilt
     }
 
+    public enum RelationArtifactAccessShape
+    {
+        LookupColumn0,
+        LookupColumn1,
+        BucketColumn0,
+        BucketColumn1,
+        Scan,
+        Storage
+    }
+
     public enum ClosureRelationRetentionStrategy
     {
         Auto,
@@ -193,6 +203,63 @@ namespace UnifyWeaver.QueryRuntime
                 "shortest-path" => RelationSourceMode.Preload,
                 "weighted-shortest-path" => RelationSourceMode.Preload,
                 _ => RelationSourceMode.Preload,
+            };
+        }
+    }
+
+    public static class RelationArtifactAccessPolicy
+    {
+        public const string BinaryArtifactStorageKind = "binary_artifact";
+        public const string DelimitedArtifactStorageKind = "delimited_artifact";
+        public const string LmdbArtifactStorageKind = "lmdb_artifact";
+        public const string MmapArrayArtifactStorageKind = "mmap_array_artifact";
+
+        private const long LargePageRelationRowThreshold = 5_000_000L;
+
+        public static string ResolveEffectiveDistanceArtifactStorageKind(
+            string relationName,
+            long rowCount,
+            RelationArtifactAccessShape accessShape)
+        {
+            if (string.Equals(relationName, "article_category", StringComparison.Ordinal)
+                && rowCount >= LargePageRelationRowThreshold)
+            {
+                return accessShape switch
+                {
+                    RelationArtifactAccessShape.LookupColumn0 => LmdbArtifactStorageKind,
+                    RelationArtifactAccessShape.BucketColumn0 => DelimitedArtifactStorageKind,
+                    RelationArtifactAccessShape.LookupColumn1 => MmapArrayArtifactStorageKind,
+                    RelationArtifactAccessShape.BucketColumn1 => MmapArrayArtifactStorageKind,
+                    RelationArtifactAccessShape.Scan => MmapArrayArtifactStorageKind,
+                    RelationArtifactAccessShape.Storage => MmapArrayArtifactStorageKind,
+                    _ => throw new ArgumentOutOfRangeException(nameof(accessShape), accessShape, null)
+                };
+            }
+
+            if (string.Equals(relationName, "article_category", StringComparison.Ordinal)
+                || string.Equals(relationName, "category_parent", StringComparison.Ordinal))
+            {
+                return accessShape switch
+                {
+                    RelationArtifactAccessShape.LookupColumn0 => MmapArrayArtifactStorageKind,
+                    RelationArtifactAccessShape.LookupColumn1 => MmapArrayArtifactStorageKind,
+                    RelationArtifactAccessShape.BucketColumn0 => MmapArrayArtifactStorageKind,
+                    RelationArtifactAccessShape.BucketColumn1 => MmapArrayArtifactStorageKind,
+                    RelationArtifactAccessShape.Scan => MmapArrayArtifactStorageKind,
+                    RelationArtifactAccessShape.Storage => MmapArrayArtifactStorageKind,
+                    _ => throw new ArgumentOutOfRangeException(nameof(accessShape), accessShape, null)
+                };
+            }
+
+            return accessShape switch
+            {
+                RelationArtifactAccessShape.LookupColumn0 => BinaryArtifactStorageKind,
+                RelationArtifactAccessShape.LookupColumn1 => BinaryArtifactStorageKind,
+                RelationArtifactAccessShape.BucketColumn0 => BinaryArtifactStorageKind,
+                RelationArtifactAccessShape.BucketColumn1 => BinaryArtifactStorageKind,
+                RelationArtifactAccessShape.Scan => BinaryArtifactStorageKind,
+                RelationArtifactAccessShape.Storage => BinaryArtifactStorageKind,
+                _ => throw new ArgumentOutOfRangeException(nameof(accessShape), accessShape, null)
             };
         }
     }

--- a/tests/test_csharp_query_source_mode_policy.py
+++ b/tests/test_csharp_query_source_mode_policy.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import shutil
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -24,6 +27,7 @@ SCAN_CALIBRATION_ARTIFACT = ROOT / "examples" / "benchmark" / "csharp_query_scan
 SCAN_WORKLOAD_PREFIX = "scan-materialization:"
 SMALL_PREBUILT_ARTIFACT_ROW_THRESHOLD = 7_500
 QUERY_RUNTIME_SOURCE = ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
+QUERY_RUNTIME_PROJECT = ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "UnifyWeaver.QueryRuntime.Core.csproj"
 
 
 class CSharpQuerySourceModePolicyTests(unittest.TestCase):
@@ -177,6 +181,115 @@ class CSharpQuerySourceModePolicyTests(unittest.TestCase):
 
         self.assertNotIn("LightningDB", runtime_source)
         self.assertNotIn("LmdbRelationProvider", runtime_source)
+
+    def test_runtime_has_dependency_free_access_shape_artifact_policy(self) -> None:
+        runtime_source = QUERY_RUNTIME_SOURCE.read_text()
+
+        expected_contract = [
+            "public enum RelationArtifactAccessShape",
+            "LookupColumn0",
+            "LookupColumn1",
+            "BucketColumn0",
+            "BucketColumn1",
+            "public static class RelationArtifactAccessPolicy",
+            'public const string BinaryArtifactStorageKind = "binary_artifact"',
+            'public const string DelimitedArtifactStorageKind = "delimited_artifact"',
+            'public const string LmdbArtifactStorageKind = "lmdb_artifact"',
+            'public const string MmapArrayArtifactStorageKind = "mmap_array_artifact"',
+            "ResolveEffectiveDistanceArtifactStorageKind(",
+            "private const long LargePageRelationRowThreshold = 5_000_000L",
+            "RelationArtifactAccessShape.LookupColumn0 => LmdbArtifactStorageKind",
+            "RelationArtifactAccessShape.BucketColumn0 => DelimitedArtifactStorageKind",
+            "RelationArtifactAccessShape.LookupColumn1 => MmapArrayArtifactStorageKind",
+            "RelationArtifactAccessShape.BucketColumn1 => MmapArrayArtifactStorageKind",
+            "RelationArtifactAccessShape.Storage => MmapArrayArtifactStorageKind",
+        ]
+
+        for expected in expected_contract:
+            with self.subTest(expected=expected):
+                self.assertIn(expected, runtime_source)
+
+        self.assertIn('string.Equals(relationName, "article_category", StringComparison.Ordinal)', runtime_source)
+        self.assertIn('string.Equals(relationName, "category_parent", StringComparison.Ordinal)', runtime_source)
+
+    def test_runtime_access_shape_artifact_policy_compiled_smoke(self) -> None:
+        if shutil.which("dotnet") is None:
+            self.skipTest("dotnet is not available")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            project_path = tmp_path / "AccessShapePolicySmoke.csproj"
+            program_path = tmp_path / "Program.cs"
+            project_path.write_text(
+                f"""\
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="{QUERY_RUNTIME_PROJECT}" />
+  </ItemGroup>
+</Project>
+""",
+                encoding="utf-8",
+            )
+            program_path.write_text(
+                """\
+using UnifyWeaver.QueryRuntime;
+
+static void AssertEqual(string expected, string actual, string label)
+{
+    if (!string.Equals(expected, actual, StringComparison.Ordinal))
+    {
+        throw new InvalidOperationException($"{label}: expected {expected}, got {actual}");
+    }
+}
+
+AssertEqual(
+    RelationArtifactAccessPolicy.LmdbArtifactStorageKind,
+    RelationArtifactAccessPolicy.ResolveEffectiveDistanceArtifactStorageKind(
+        "article_category",
+        5_000_000,
+        RelationArtifactAccessShape.LookupColumn0),
+    "large page lookup column 0");
+AssertEqual(
+    RelationArtifactAccessPolicy.DelimitedArtifactStorageKind,
+    RelationArtifactAccessPolicy.ResolveEffectiveDistanceArtifactStorageKind(
+        "article_category",
+        5_000_000,
+        RelationArtifactAccessShape.BucketColumn0),
+    "large page bucket column 0");
+AssertEqual(
+    RelationArtifactAccessPolicy.MmapArrayArtifactStorageKind,
+    RelationArtifactAccessPolicy.ResolveEffectiveDistanceArtifactStorageKind(
+        "article_category",
+        1_000_000,
+        RelationArtifactAccessShape.LookupColumn0),
+    "smaller page lookup column 0");
+AssertEqual(
+    RelationArtifactAccessPolicy.BinaryArtifactStorageKind,
+    RelationArtifactAccessPolicy.ResolveEffectiveDistanceArtifactStorageKind(
+        "unknown_relation",
+        5_000_000,
+        RelationArtifactAccessShape.LookupColumn0),
+    "unknown relation fallback");
+""",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                ["dotnet", "run", "--project", str(project_path)],
+                cwd=tmp_path,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=120,
+            )
+            self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
 
     @staticmethod
     def _source_mode_member(source_mode: str) -> str:


### PR DESCRIPTION
  ## Summary

  - add a dependency-free `RelationArtifactAccessPolicy` to the C# query runtime
  - introduce access-shape categories for column-0 lookup, column-1 lookup, bucket streaming, scan, and storage
  - encode measured effective-distance artifact recommendations without adding LightningDB to `QueryRuntime.Core`
  - document that optional providers such as LMDB remain integration/project-level dependencies

  ## Verification

  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj`
  - `python3 -m py_compile tests/test_csharp_query_source_mode_policy.py tests/
  test_csharp_query_effective_distance_artifact_backends.py examples/benchmark/
  benchmark_csharp_query_effective_distance_artifact_backends.py`
  - `git diff --check`