### PR TITLE
feat(wam-elixir): compound-vs-compound unify + structured catch patterns

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -173,7 +173,7 @@ render_compiled_module(CamelMod, CamelPred, PredIndicator, PredStr, ShapeComment
       # the BEAM stack matched the thrown term) reaches here. Mirror
       # the empty-catcher_frames case in execute_throw — diagnostic
       # to stderr, return :fail rather than crash.
-      {:wam_throw, term} ->
+      {:wam_throw, term, _heap, _heap_len} ->
         IO.puts(:stderr, "Uncaught Prolog throw: #{inspect(term)}")
         :fail
       error ->
@@ -232,7 +232,7 @@ render_inline_data_module(CamelMod, CamelPred, PredStr, Arity, ShapeComment,
       {:fail, _} -> :fail
       {:return, result} -> result
       # PR #2: uncaught Prolog throw -> :fail + stderr (not crash).
-      {:wam_throw, term} ->
+      {:wam_throw, term, _heap, _heap_len} ->
         IO.puts(:stderr, "Uncaught Prolog throw: #{inspect(term)}")
         :fail
       error ->
@@ -328,7 +328,7 @@ render_external_source_module(CamelMod, CamelPred, PredStr, Arity, ShapeComment,
       {:fail, _} -> :fail
       {:return, result} -> result
       # PR #2: uncaught Prolog throw -> :fail + stderr (not crash).
-      {:wam_throw, term} ->
+      {:wam_throw, term, _heap, _heap_len} ->
         IO.puts(:stderr, "Uncaught Prolog throw: #{inspect(term)}")
         :fail
       error ->

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -809,9 +809,48 @@ compile_utility_helpers_to_elixir(Code) :-
         {:unbound, id} = v2
         new_state = state |> trail_binding(id) |> put_reg(id, v1)
         {:ok, new_state}
+      # Structural unification of two compound terms. Both args are
+      # {:ref, addr} pointing to {:str, "name/arity"} heap cells.
+      # If functors + arities match, walk arg lists pairwise. Args
+      # are derefd against the LATEST state inside unify_arg_list so
+      # bindings made by earlier arg unifies are visible to later
+      # ones. Partial-fail leaves bindings in the trail; the callers
+      # choice-point unwinds them via unwind_trail on backtrack —
+      # same contract as every other unify branch.
+      #
+      # Without this clause, error(K, _) = error(type_error, ctx)
+      # falls to the :fail arm even though the two compounds are
+      # structurally compatible. That broke catch-pattern matching
+      # with structured error/2 terms throughout PRs #2-#5; this
+      # closes the gap.
+      match?({:ref, _}, v1) and match?({:ref, _}, v2) ->
+        {:ref, addr1} = v1
+        {:ref, addr2} = v2
+        case {Map.get(state.heap, addr1), Map.get(state.heap, addr2)} do
+          {{:str, fn_name}, {:str, fn_name}} ->
+            arity = parse_functor_arity(fn_name)
+            args1 = heap_slice(state, addr1 + 1, arity)
+            args2 = heap_slice(state, addr2 + 1, arity)
+            unify_arg_list(state, args1, args2)
+          _ -> :fail
+        end
       true -> :fail
     end
   end
+
+  # Walk two arg lists pairwise, threading state. Each arg is derefd
+  # against the LATEST state so bindings made by earlier unifies are
+  # visible. Returns {:ok, state} on success, :fail otherwise.
+  defp unify_arg_list(state, [], []), do: {:ok, state}
+  defp unify_arg_list(state, [a | as], [b | bs]) do
+    a_d = deref_var(state, a)
+    b_d = deref_var(state, b)
+    case unify(state, a_d, b_d) do
+      {:ok, new_state} -> unify_arg_list(new_state, as, bs)
+      :fail -> :fail
+    end
+  end
+  defp unify_arg_list(_, _, _), do: :fail
 
   @doc "Execute a builtin predicate"
   def execute_builtin(state, op, arity) do
@@ -1617,12 +1656,20 @@ compile_utility_helpers_to_elixir(Code) :-
           %{post_state | catcher_frames: tl(post_state.catcher_frames)}
       end
     catch
-      {:wam_throw, thrown_term} ->
+      {:wam_throw, thrown_term, thrown_heap, thrown_heap_len} ->
         # A throw fired somewhere inside the dispatched goal. Try
         # to unify the thrown term against our catcher pattern.
         # First restore state from the snapshot (rolls back any
         # bindings the goal made before throwing).
-        restored = restore_from_catcher_frame(state_with_frame, frame)
+        restored0 = restore_from_catcher_frame(state_with_frame, frame)
+        # Merge the throw-time heap so the thrown terms {:ref, _}
+        # cells resolve. Without this, structured-pattern catchers
+        # against compound thrown terms silently fail because the
+        # heap cells are not visible from the catch-time state. See
+        # execute_throw for the full rationale.
+        restored = %{restored0 |
+                     heap: Map.merge(restored0.heap, thrown_heap),
+                     heap_len: max(restored0.heap_len, thrown_heap_len)}
         # Unify catcher pattern against the thrown term. On match,
         # bindings to pattern vars persist into the recovery goal.
         case unify(restored, frame.catcher_term, thrown_term) do
@@ -1638,7 +1685,7 @@ compile_utility_helpers_to_elixir(Code) :-
           :fail ->
             # No match. Re-throw to outer catcher (BEAM unwinds
             # past us to the next enclosing try/catch).
-            throw({:wam_throw, thrown_term})
+            throw({:wam_throw, thrown_term, thrown_heap, thrown_heap_len})
         end
     end
   end
@@ -1648,8 +1695,18 @@ compile_utility_helpers_to_elixir(Code) :-
     # leaves are independent of the catch boundary — the catcher
     # sees the value as it was at throw time, even if the
     # original vars get rolled back during state restoration.
+    #
+    # Compound-unify follow-up: bundle the post-copy heap + heap_len
+    # with the throw so execute_catch can merge them into its
+    # restored state before unifying. Without this, the thrown
+    # terms {:ref, _} addresses point to cells in state2.heap
+    # that do not exist in the catch-time state (the catch captured
+    # state BEFORE the goal ran, including its heap allocations).
+    # That made structured-pattern catchers like error(K, _) silently
+    # fail to match — they ARE structurally compatible but the
+    # catch could not reach the thrown terms heap cells.
     raw = deref_var(state, get_reg(state, 1))
-    {_state2, thrown_copy, _vmap} = deep_copy_with_fresh_vars(state, raw, %{})
+    {state2, thrown_copy, _vmap} = deep_copy_with_fresh_vars(state, raw, %{})
 
     if state.catcher_frames == [] do
       # No catcher exists anywhere on the BEAM call stack. ISO
@@ -1660,8 +1717,8 @@ compile_utility_helpers_to_elixir(Code) :-
       :fail
     else
       # At least one frame exists. Throw — execute_catch up the
-      # stack will catch and try to match.
-      throw({:wam_throw, thrown_copy})
+      # stack will catch, merge the heap, then unify.
+      throw({:wam_throw, thrown_copy, state2.heap, state2.heap_len})
     end
   end
 
@@ -4398,7 +4455,7 @@ compile_wam_predicate_to_elixir(Pred/Arity, WamCode, _Options, Code) :-
       end
     catch
       # PR #2: uncaught Prolog throw -> :fail + stderr (not crash).
-      {:wam_throw, term} ->
+      {:wam_throw, term, _heap, _heap_len} ->
         IO.puts(:stderr, "Uncaught Prolog throw: #{inspect(term)}")
         :fail
     end

--- a/tests/test_wam_elixir_classic_programs.pl
+++ b/tests/test_wam_elixir_classic_programs.pl
@@ -92,15 +92,12 @@ user:elx_call_extras(R) :- call(append, [a, b], [c, d], R).
 :- dynamic user:elx_catch_fail_propagates/0.
 % Atomic catcher matches atomic thrown term.
 user:elx_catch_match :- catch(throw(foo), foo, true).
-% Compound thrown term, unbound catcher binds to the whole compound.
-% NOTE: structural compound-vs-compound unification (e.g., catcher
-% pattern `error(_, _)`) is a pre-existing runtime limitation —
-% unify/3 only handles `v1 == v2` equality or unbound binding, not
-% recursive compound walk. Filed as a follow-up; not catch-specific.
-% Once compound-unify lands, this test should change to:
-%   catch(throw(error(type_error, ctx)), error(_, _), true).
+% Compound thrown term + STRUCTURED catcher pattern. Now possible
+% post-compound-unify follow-up — verifies that error(_, _) matches
+% the thrown error(type_error, ctx) structurally (functor + arity
+% + recursive arg unify). Wildcards bind to anything.
 user:elx_catch_compound :- catch(throw(error(type_error, ctx)),
-                                 _Caught, true).
+                                 error(_, _), true).
 % Goal proceeds normally; recovery (fail) NOT invoked.
 user:elx_catch_no_throw :- catch(true, _, fail).
 % Throw with no enclosing catch — wrapper converts to :fail + stderr.
@@ -125,12 +122,17 @@ user:elx_catch_fail_propagates :- catch(fail, _, true).
 :- dynamic user:elx_iso_is_zero_divisor/0.
 :- dynamic user:elx_iso_is_succeeds/1.
 :- dynamic user:elx_explicit_lax_fails/0.
-% RHS unbound -> instantiation_error throw -> catch matches.
-user:elx_iso_is_instantiation :- catch(is_iso(_X, _Y), _, true).
-% RHS is non-evaluable atom -> type_error(evaluable, foo/0) throw.
-user:elx_iso_is_type_error :- catch(is_iso(_X, foo), _, true).
-% RHS is 1//0 -> evaluation_error(zero_divisor) throw.
-user:elx_iso_is_zero_divisor :- catch(is_iso(_X, 1//0), _, true).
+% Structured catchers (compound-unify follow-up): each one verifies
+% not just that *something* threw, but that the right ISO error
+% shape was thrown.
+user:elx_iso_is_instantiation :-
+    catch(is_iso(_X, _Y), error(instantiation_error, _), true).
+user:elx_iso_is_type_error :-
+    catch(is_iso(_X, foo), error(type_error(evaluable, _), _), true).
+user:elx_iso_is_zero_divisor :-
+    catch(is_iso(_X, 1//0),
+          error(evaluation_error(zero_divisor), _),
+          true).
 % Happy path: is_iso(X, 1+1) succeeds with X=2 (no throw).
 user:elx_iso_is_succeeds(R) :- is_iso(X, 1 + 1), R = X.
 % Explicit is_lax bypasses rewrite — same lax behaviour as is/2.
@@ -160,12 +162,15 @@ user:elx_explicit_lax_fails :- is_lax(_X, foo).
 :- dynamic user:elx_lax_float_divzero_fails/0.
 
 % --- Arith compare iso/lax/bypass (representative on >, <, >=) ---
-% >: ISO throws instantiation_error for unbound operand.
-user:elx_iso_compare_instantiation :- catch((_X > 5), _, true).
-% <: ISO throws type_error(evaluable, foo/0) for atom operand.
-user:elx_iso_compare_type :- catch((foo < 5), _, true).
-% =:=: ISO throws evaluation_error(zero_divisor) for 1//0 operand.
-user:elx_iso_compare_zero_divide :- catch((1 // 0 =:= 0), _, true).
+% Structured catchers verify the thrown error shape per SPEC.
+user:elx_iso_compare_instantiation :-
+    catch((_X > 5), error(instantiation_error, _), true).
+user:elx_iso_compare_type :-
+    catch((foo < 5), error(type_error(evaluable, _), _), true).
+user:elx_iso_compare_zero_divide :-
+    catch((1 // 0 =:= 0),
+          error(evaluation_error(zero_divisor), _),
+          true).
 % Lax: silent fail (no throw, no crash).
 user:elx_lax_compare_silent :- (_X > 5).
 % Explicit >_lax in iso-mode predicate bypasses rewrite -> silent fail.
@@ -173,9 +178,16 @@ user:elx_lax_compare_silent :- (_X > 5).
 user:elx_explicit_lax_compare_in_iso :- '>_lax'(_X, 5).
 
 % --- succ_iso/2 (three ISO error modes + happy path) ---
-user:elx_iso_succ_unbound  :- catch(succ_iso(_X, _Y), _, true).
-user:elx_iso_succ_negative :- catch(succ_iso(-1, _X), _, true).
-user:elx_iso_succ_y_zero   :- catch(succ_iso(_X, 0),  _, true).
+user:elx_iso_succ_unbound :-
+    catch(succ_iso(_X, _Y), error(instantiation_error, _), true).
+user:elx_iso_succ_negative :-
+    catch(succ_iso(-1, _X),
+          error(type_error(not_less_than_zero, _), _),
+          true).
+user:elx_iso_succ_y_zero :-
+    catch(succ_iso(_X, 0),
+          error(domain_error(not_less_than_zero, _), _),
+          true).
 % Happy path: forward + backward succ via default form (now rewritten
 % to succ_lax/2 in default mode; same body).
 user:elx_succ_happy_forward(R)  :- succ(3, X), R = X.
@@ -187,11 +199,33 @@ user:elx_succ_explicit_lax_in_iso :- succ_lax(-1, _X).
 
 % --- IEEE-754 float divide-by-zero ---
 % ISO: throws evaluation_error(zero_divisor) (caught by iso_term_has_zero_divide
-% before eval_arith).
-user:elx_iso_float_divzero :- catch((_R is 1.0 / 0.0), _, true).
+% before eval_arith). Structured catcher verifies the error shape.
+user:elx_iso_float_divzero :-
+    catch((_R is 1.0 / 0.0),
+          error(evaluation_error(zero_divisor), _),
+          true).
 % Lax: silently fails (BEAM cannot produce IEEE inf/nan from
 % arithmetic without raising — see PR #5 deferred IEEE-754 note).
 user:elx_lax_float_divzero_fails :- _R is 1.0 / 0.0.
+
+% --- Compound unify (follow-up) — focused tests outside the ISO context ---
+% These exercise the new compound-vs-compound clause in unify/3
+% directly via the =/2 body-unification builtin.
+:- dynamic user:elx_compound_eq_ground/0.
+:- dynamic user:elx_compound_eq_binds/1.
+:- dynamic user:elx_compound_eq_nested/1.
+:- dynamic user:elx_compound_eq_mismatch_functor/0.
+:- dynamic user:elx_compound_eq_mismatch_arity/0.
+% Two structurally-equal ground compounds unify.
+user:elx_compound_eq_ground :- foo(1, 2) = foo(1, 2).
+% Compound unify binds a variable inside the pattern.
+user:elx_compound_eq_binds(R) :- foo(X, 2) = foo(7, 2), R = X.
+% Nested compound: outer arg is itself a compound — recurses.
+user:elx_compound_eq_nested(R) :- pair(inner(X, b), c) = pair(inner(a, b), c), R = X.
+% Functor mismatch fails.
+user:elx_compound_eq_mismatch_functor :- foo(1) = bar(1).
+% Arity mismatch fails (same name, different arity = different functor).
+user:elx_compound_eq_mismatch_arity :- foo(1, 2) = foo(1).
 
 % ============================================================
 % elixir_available — same gating pattern as the Scala suite
@@ -514,6 +548,35 @@ test(lax_float_divzero_fails) :-
     % current Elixir behaviour matches the pre-IEEE C++ baseline.
     with_elixir_project([user:elx_lax_float_divzero_fails/0], _Opts, TmpDir,
         verify_elixir_args(TmpDir, 'elx_lax_float_divzero_fails/0',
+                           [], "false")).
+
+% --- Compound unify tests (focused, outside ISO context) ---
+
+test(compound_eq_ground) :-
+    % foo(1, 2) = foo(1, 2) — two ground compounds, structurally equal.
+    with_elixir_project([user:elx_compound_eq_ground/0], _Opts, TmpDir,
+        verify_elixir_args(TmpDir, 'elx_compound_eq_ground/0', [], "true")).
+
+test(compound_eq_binds_variable) :-
+    % foo(X, 2) = foo(7, 2), R = X — X bound to 7 via compound unify.
+    with_elixir_project([user:elx_compound_eq_binds/1], _Opts, TmpDir,
+        verify_elixir_args(TmpDir, 'elx_compound_eq_binds/1', ['7'], "true")).
+
+test(compound_eq_nested) :-
+    % pair(inner(X, b), c) = pair(inner(a, b), c), R = X — recursion.
+    with_elixir_project([user:elx_compound_eq_nested/1], _Opts, TmpDir,
+        verify_elixir_args(TmpDir, 'elx_compound_eq_nested/1', ['a'], "true")).
+
+test(compound_eq_mismatch_functor) :-
+    % foo(1) = bar(1) — different functors, fail.
+    with_elixir_project([user:elx_compound_eq_mismatch_functor/0], _Opts, TmpDir,
+        verify_elixir_args(TmpDir, 'elx_compound_eq_mismatch_functor/0',
+                           [], "false")).
+
+test(compound_eq_mismatch_arity) :-
+    % foo(1, 2) = foo(1) — same name, different arity = different functor.
+    with_elixir_project([user:elx_compound_eq_mismatch_arity/0], _Opts, TmpDir,
+        verify_elixir_args(TmpDir, 'elx_compound_eq_mismatch_arity/0',
                            [], "false")).
 
 :- end_tests(wam_elixir_classic_programs).

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -253,7 +253,7 @@ test_wam_throw_top_level_wrapper :-
     (   compile_wam_predicate_to_elixir(noop/0,
             "noop/0:\n    proceed", [], PredCode),
         atom_string(PredCode, S),
-        sub_string(S, _, _, _, '{:wam_throw, term}'),
+        sub_string(S, _, _, _, '{:wam_throw, term, _heap, _heap_len}'),
         sub_string(S, _, _, _, 'Uncaught Prolog throw')
     ->  pass(Test)
     ;   fail_test(Test,
@@ -386,6 +386,21 @@ test_iso_errors_sweep_runtime_arms :-
         sub_string(S, _, _, _, 'op in [">/2", ">_lax/2"]')
     ->  pass(Test)
     ;   fail_test(Test, 'one or more sweep runtime arms missing')
+    ).
+
+test_unify_compound_clause_present :-
+    Test = 'WAM-Elixir: unify/3 has compound-vs-compound clause + unify_arg_list helper',
+    (   compile_wam_helpers_to_elixir([], Code),
+        atom_string(Code, S),
+        % The compound-unify guard.
+        sub_string(S, _, _, _,
+                   'match?({:ref, _}, v1) and match?({:ref, _}, v2)'),
+        % Same-functor pattern check (variable repeated in both halves of the tuple).
+        sub_string(S, _, _, _, '{{:str, fn_name}, {:str, fn_name}}'),
+        % Recursive arg walker.
+        sub_string(S, _, _, _, 'defp unify_arg_list(state, [a | as], [b | bs])')
+    ->  pass(Test)
+    ;   fail_test(Test, 'compound-unify clause or unify_arg_list missing')
     ).
 
 test_iso_errors_sweep_rewrite_text :-
@@ -3101,6 +3116,7 @@ run_tests :-
     test_iso_errors_is_table_populated,
     test_iso_errors_sweep_table_populated,
     test_iso_errors_sweep_runtime_arms,
+    test_unify_compound_clause_present,
     test_iso_errors_sweep_rewrite_text,
     test_iso_errors_rewrite_text_default_mode,
     test_iso_errors_rewrite_text_iso_mode,


### PR DESCRIPTION
## Summary

First WAM_ELIXIR_GAPS §9 follow-up. Closes a pre-existing runtime
limitation that affected catch-pattern matching throughout PRs #2-#5.

### Background

`unify/3` had 5 arms — equality, two heap-ref-unbound binds, two id-unbound binds, catch-all `:fail`. It handled atomic terms and unbound binding but **NOT two compound `{:ref, _}` terms** pointing to `{:str, "name/arity"}` heap structures. That meant body unification like `error(K, _) = error(type_error, ctx)` fell through to `:fail`, which broke catch-pattern matching against compound thrown terms throughout the ISO error series.

Tests in PR #2 / #4 / #5 worked around this with unbound `_` catchers — losing the bind-verification coverage the structured patterns were supposed to provide.

### Changes

**1) New `unify/3` clause for compound-vs-compound:**

```elixir
match?({:ref, _}, v1) and match?({:ref, _}, v2) ->
  # Same-functor pattern match in tuple ({{:str, fn_name},
  # {:str, fn_name}}), recursive arg walk via unify_arg_list/3.
```

`unify_arg_list/3` walks two arg lists pairwise, threading state so bindings made by earlier arg-unifies are visible to later ones via deref against the latest state.

**2) `execute_throw` + `execute_catch`: bundle heap with the throw.**

Compound unify worked for direct `=/2` but FAILED through throw/catch because the deep-copy allocated cells in `state2` which got discarded — the catch-time state's heap didn't contain them.

Fix: throw shape becomes `{:wam_throw, term, heap, heap_len}`. `execute_catch` merges these into `restored.heap` before unifying. Re-throw on no-match preserves the bundle. Top-level wrappers (3 in lowered + 1 in interpreter) updated to ignore the heap fields when logging uncaught throws.

### Retrofitted tests (11)

The tests that used unbound `_` catchers because of the limitation now use **structured patterns** that verify the thrown term shape:

| Test | New pattern |
| --- | --- |
| `catch_match_compound` | `error(_, _)` |
| `iso_is_instantiation` | `error(instantiation_error, _)` |
| `iso_is_type_error` | `error(type_error(evaluable, _), _)` |
| `iso_is_zero_divisor` | `error(evaluation_error(zero_divisor), _)` |
| `iso_compare_instantiation` | `error(instantiation_error, _)` |
| `iso_compare_type_error` | `error(type_error(evaluable, _), _)` |
| `iso_compare_zero_divide` | `error(evaluation_error(zero_divisor), _)` |
| `iso_succ_unbound_throws` | `error(instantiation_error, _)` |
| `iso_succ_negative_throws` | `error(type_error(not_less_than_zero, _), _)` |
| `iso_succ_y_zero_domain_throws` | `error(domain_error(not_less_than_zero, _), _)` |
| `iso_float_divzero_throws` | `error(evaluation_error(zero_divisor), _)` |

These now exercise the structured-pattern match through the **full compile + throw + catch + unify pipeline**.

### New focused tests (5 e2e + 1 unit)

| Test | Body | Expected |
| --- | --- | --- |
| `compound_eq_ground` | `foo(1, 2) = foo(1, 2)` | true |
| `compound_eq_binds_variable` | `foo(X, 2) = foo(7, 2), R = X` | R=7 |
| `compound_eq_nested` | `pair(inner(X, b), c) = pair(inner(a, b), c), R = X` | R=a (recurses) |
| `compound_eq_mismatch_functor` | `foo(1) = bar(1)` | false |
| `compound_eq_mismatch_arity` | `foo(1, 2) = foo(1)` | false |
| `test_unify_compound_clause_present` | (unit) gates new clause + helper emit | — |

## Test plan

- [x] All 37 e2e tests pass (3 classic + 4 call/N + 6 catch/throw + 5 is_iso/is_lax + 14 ISO sweep + 5 new compound-eq)
- [x] All unit tests pass
- [x] 11 retrofitted tests verify the structured-pattern match works end-to-end

## Limitations / out of scope

- **IEEE-754 lax float-divide** still deferred (BEAM arithmetic limitation; unrelated to unify).
- **Lists vs compounds** aren't unified structurally yet — list cons cells use a different heap shape than compound structures. Existing list-aware paths (`wam_list_member?` etc.) cover the cases that matter today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)