### PR TITLE
Feat/wam go last builtin

### DIFF
--- a/PR_go_wam_last_builtin.md
+++ b/PR_go_wam_last_builtin.md
@@ -1,0 +1,27 @@
+# PR Title
+
+Add Go WAM last builtin parity
+
+# PR Description
+
+## Summary
+
+- Add deterministic `last/2` support to the generated Go WAM runtime.
+- Route Go WAM `call`/`execute` instructions for `last/2` through `BuiltinCall` using the Go-local direct builtin path.
+- Fix generated cons-chain traversal so nested heap-tail placeholders resolve to the actual following cons cells.
+- Add list-aware unification between flat Go list values and generated cons-chain list terms.
+- Extend generated Go WAM builtin E2E coverage for non-empty list success and empty-list failure.
+- Update the Go WAM parity audit for the expanded Clojure/R/C++ list-builtin surface.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl tests/test_wam_go_generator.pl tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(last/2,2), X), writeln(X), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -11,7 +11,7 @@ current cross-target builtin/runtime baseline.
 | Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries, indexed atom fact streams, `member/2` builtin retries | Choice point stack with normal, builtin, and fact-stream resume states | Present for current resume-state baseline |
 | Direct fact dispatch | `call_indexed_atom_fact2`, `AtomFact2Source` registry, TSV-backed and LMDB-artifact atom fact loading, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Present for current external atom fact-source baseline |
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
-| Structural builtins | `member/2`, `memberchk/2`, `length/2`, `append/3`, `reverse/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `reverse/2` | Present for current baseline structural checks, with one expanded cross-target list builtin |
+| Structural builtins | `member/2`, `memberchk/2`, `length/2`, `append/3`, `reverse/2`, `last/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `reverse/2` and `last/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2` | Includes `=</2` | Present for current baseline comparisons |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
@@ -37,6 +37,9 @@ current cross-target builtin/runtime baseline.
 - Deterministic `reverse/2` is now covered by the generated Go WAM builtin E2E
   test for both forward and reverse-list binding modes, closing one richer
   Clojure/R/C++ list-builtin parity gap.
+- Deterministic `last/2` is now covered by the generated Go WAM builtin E2E
+  test for non-empty list success and empty-list failure, closing another
+  richer Clojure/R/C++ list-builtin parity gap.
 - Go WAM choice points now have explicit generated-runtime coverage for normal
   clause retries, indexed alternatives, foreign stream retries, indexed atom
   fact streams, and `member/2` builtin retries.

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -425,6 +425,9 @@ wam_go_direct_builtin("memberchk/2", 2, 'memberchk/2').
 wam_go_direct_builtin(reverse/2, 2, 'reverse/2').
 wam_go_direct_builtin('reverse/2', 2, 'reverse/2').
 wam_go_direct_builtin("reverse/2", 2, 'reverse/2').
+wam_go_direct_builtin(last/2, 2, 'last/2').
+wam_go_direct_builtin('last/2', 2, 'last/2').
+wam_go_direct_builtin("last/2", 2, 'last/2').
 
 wam_instruction_to_go_literal(get_constant(C, Ai), GoLiteral) :-
     go_value_literal(C, GoVal),

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -647,6 +647,26 @@ func rawListHeadTail(list *List) (Value, Value, bool) {
 	return list.Elements[0], &List{Elements: list.Elements[1:]}, true
 }
 
+func (vm *WamState) heapConsAfterUnbound(v *Unbound) (Value, bool) {
+	for i := 0; i < vm.HeapLen; i++ {
+		cell := vm.Heap[i]
+		if cell == v && i+1 < vm.HeapLen {
+			next := vm.deref(vm.Heap[i+1])
+			switch t := next.(type) {
+			case *Compound:
+				if isConsFunctor(t.Functor) && len(t.Args) == 2 {
+					return next, true
+				}
+			case *Structure:
+				if isConsFunctor(t.Functor) && len(t.Args) == 2 {
+					return next, true
+				}
+			}
+		}
+	}
+	return nil, false
+}
+
 func (vm *WamState) listHeadTail(list *List) (Value, Value, bool) {
 	switch len(list.Elements) {
 	case 0:
@@ -660,6 +680,11 @@ func (vm *WamState) listHeadTail(list *List) (Value, Value, bool) {
 		}
 		if isEmptyListValue(tail) {
 			return list.Elements[0], emptyListAtom, true
+		}
+		if u, ok := tail.(*Unbound); ok {
+			if next, ok := vm.heapConsAfterUnbound(u); ok {
+				return list.Elements[0], next, true
+			}
 		}
 		switch t := tail.(type) {
 		case *Compound:
@@ -687,10 +712,22 @@ func (vm *WamState) valueListHeadTail(v Value) (Value, Value, bool) {
 		return vm.listHeadTail(t)
 	case *Compound:
 		if isConsFunctor(t.Functor) && len(t.Args) == 2 {
+			tail := vm.deref(t.Args[1])
+			if u, ok := tail.(*Unbound); ok {
+				if next, ok := vm.heapConsAfterUnbound(u); ok {
+					return t.Args[0], next, true
+				}
+			}
 			return t.Args[0], t.Args[1], true
 		}
 	case *Structure:
 		if isConsFunctor(t.Functor) && len(t.Args) == 2 {
+			tail := vm.deref(t.Args[1])
+			if u, ok := tail.(*Unbound); ok {
+				if next, ok := vm.heapConsAfterUnbound(u); ok {
+					return t.Args[0], next, true
+				}
+			}
 			return t.Args[0], t.Args[1], true
 		}
 	}
@@ -1151,6 +1188,12 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			return vm.Unify(arg1, &List{Elements: reversed})
 		}
 		return false
+	case "last/2":
+		items, ok := vm.listToSlice(arg1)
+		if !ok || len(items) == 0 {
+			return false
+		}
+		return vm.Unify(arg2, items[len(items)-1])
 	case "functor/3":
 		t := vm.deref(arg1)
 		if isUnbound(t) {
@@ -1345,6 +1388,15 @@ func (vm *WamState) Unify(v1, v2 Value) bool {
 
 	if valueEquals(v1, v2) {
 		return true
+	}
+
+	if isEmptyListValue(v1) || isEmptyListValue(v2) {
+		return isEmptyListValue(v1) && isEmptyListValue(v2)
+	}
+	h1, t1, ok1 := vm.valueListHeadTail(v1)
+	h2, t2, ok2 := vm.valueListHeadTail(v2)
+	if ok1 || ok2 {
+		return ok1 && ok2 && vm.Unify(h1, h2) && vm.Unify(t1, t2)
 	}
 
 	f1, args1 := decompose(v1)

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -10,6 +10,7 @@
 :- dynamic user:test_member_collect/0.
 :- dynamic user:test_memberchk_builtin/0.
 :- dynamic user:test_reverse_builtin/0.
+:- dynamic user:test_last_builtin/0.
 :- dynamic user:test_set_aggregate/0.
 :- dynamic user:test_unify_builtin/0.
 :- dynamic user:test_neg_fact/1.
@@ -64,6 +65,13 @@ test(builtins_execution) :-
                 reverse(L, [z,y]),
                 L = [y,z]
             )),
+          assertz(user:test_last_builtin :-
+            (   last([a,b,c], X),
+                X == c,
+                last([only], Y),
+                Y == only,
+                \+ last([], _)
+            )),
           assertz(user:test_set_aggregate :-
             (   aggregate_all(set(X), member(X, [a,b,a]), S),
                 length(S, 2),
@@ -90,6 +98,7 @@ test(builtins_execution) :-
           retractall(user:test_member_collect),
           retractall(user:test_memberchk_builtin),
           retractall(user:test_reverse_builtin),
+          retractall(user:test_last_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
           retractall(user:test_neg_fact(_)),
@@ -99,7 +108,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_reverse_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -132,6 +141,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "=/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "memberchk/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "reverse/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "last/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "\\\\+/1"')),
     assertion(sub_string(LibCode, _, _, _, 'AggType: "set"')),
 
@@ -193,6 +203,14 @@ func main() {
 		fmt.Println("REVERSE_FAILURE")
 	}
 
+	lastVM := wam.NewWamState(wam.Test_last_builtinCode, wam.Test_last_builtinLabels)
+	lastVM.PC = wam.Test_last_builtinStartPC
+	if lastVM.Run() {
+		fmt.Println("LAST_SUCCESS")
+	} else {
+		fmt.Println("LAST_FAILURE")
+	}
+
 	setVM := wam.NewWamState(wam.Test_set_aggregateCode, wam.Test_set_aggregateLabels)
 	setVM.PC = wam.Test_set_aggregateStartPC
 	if setVM.Run() {
@@ -247,6 +265,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "MEMBER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "MEMBERCHK_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "REVERSE_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "LAST_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NEG_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM last builtin parity

## Summary

- Add deterministic `last/2` support to the generated Go WAM runtime.
- Route Go WAM `call`/`execute` instructions for `last/2` through `BuiltinCall` using the Go-local direct builtin path.
- Fix generated cons-chain traversal so nested heap-tail placeholders resolve to the actual following cons cells.
- Add list-aware unification between flat Go list values and generated cons-chain list terms.
- Extend generated Go WAM builtin E2E coverage for non-empty list success and empty-list failure.
- Update the Go WAM parity audit for the expanded Clojure/R/C++ list-builtin surface.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl tests/test_wam_go_generator.pl tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(last/2,2), X), writeln(X), halt"`
- `git diff --check`
