### PR TITLE
feat(csharp-query): add policy-guided artifact opener

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -614,6 +614,91 @@ namespace UnifyWeaver.QueryRuntime
         }
     }
 
+    public static class RelationArtifactProviderOpenPolicy
+    {
+        public static bool TryOpenPreferred(
+            PredicateId predicate,
+            IEnumerable<string> manifestPaths,
+            string preferredStorageKind,
+            IRelationProvider? fallback,
+            IEnumerable<IRelationArtifactProviderFactory>? factories,
+            out RelationArtifactProviderOpenResult result)
+        {
+            if (manifestPaths is null) throw new ArgumentNullException(nameof(manifestPaths));
+            if (preferredStorageKind is null) throw new ArgumentNullException(nameof(preferredStorageKind));
+
+            var effectiveFactories = (factories ?? new[] { new DefaultRelationArtifactProviderFactory() }).ToArray();
+            RelationArtifactProviderOpenResult? firstOpenable = null;
+
+            foreach (var manifestPath in manifestPaths)
+            {
+                if (string.IsNullOrWhiteSpace(manifestPath))
+                {
+                    continue;
+                }
+
+                foreach (var factory in effectiveFactories)
+                {
+                    RelationArtifactProviderOpenResult opened;
+                    try
+                    {
+                        if (!factory.TryOpen(predicate, manifestPath, fallback, out opened))
+                        {
+                            continue;
+                        }
+                    }
+                    catch (InvalidDataException)
+                    {
+                        continue;
+                    }
+                    catch (JsonException)
+                    {
+                        continue;
+                    }
+
+                    firstOpenable ??= opened;
+                    if (string.Equals(opened.StorageKind, preferredStorageKind, StringComparison.Ordinal))
+                    {
+                        result = opened;
+                        return true;
+                    }
+                }
+            }
+
+            if (firstOpenable is { } fallbackResult)
+            {
+                result = fallbackResult;
+                return true;
+            }
+
+            result = default!;
+            return false;
+        }
+
+        public static bool TryOpenEffectiveDistanceArtifact(
+            PredicateId predicate,
+            string relationName,
+            long rowCount,
+            RelationArtifactAccessShape accessShape,
+            IEnumerable<string> manifestPaths,
+            IRelationProvider? fallback,
+            IEnumerable<IRelationArtifactProviderFactory>? factories,
+            out RelationArtifactProviderOpenResult result)
+        {
+            var preferredStorageKind = RelationArtifactAccessPolicy.ResolveEffectiveDistanceArtifactStorageKind(
+                relationName,
+                rowCount,
+                accessShape);
+            return TryOpenPreferred(
+                predicate,
+                manifestPaths,
+                preferredStorageKind,
+                fallback,
+                factories,
+                out result);
+        }
+    }
+
     internal static class RelationArtifactManifestFormatReader
     {
         public static string ReadFormat(string manifestPath)

--- a/tests/test_csharp_query_source_mode_policy.py
+++ b/tests/test_csharp_query_source_mode_policy.py
@@ -166,6 +166,10 @@ class CSharpQuerySourceModePolicyTests(unittest.TestCase):
             "public sealed record RelationArtifactProviderOpenResult",
             "public interface IRelationArtifactProviderFactory",
             "public sealed class DefaultRelationArtifactProviderFactory",
+            "public static class RelationArtifactProviderOpenPolicy",
+            "TryOpenPreferred(",
+            "TryOpenEffectiveDistanceArtifact(",
+            "new[] { new DefaultRelationArtifactProviderFactory() }",
             "BinaryRelationArtifactManifest.CurrentFormat:",
             "DelimitedRelationArtifactManifest.CurrentFormat:",
             "new BinaryRelationArtifactProvider(fallback)",
@@ -277,6 +281,125 @@ AssertEqual(
         5_000_000,
         RelationArtifactAccessShape.LookupColumn0),
     "unknown relation fallback");
+""",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                ["dotnet", "run", "--project", str(project_path)],
+                cwd=tmp_path,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=120,
+            )
+            self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+
+    def test_runtime_policy_guided_artifact_open_compiled_smoke(self) -> None:
+        if shutil.which("dotnet") is None:
+            self.skipTest("dotnet is not available")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            project_path = tmp_path / "PolicyGuidedOpenSmoke.csproj"
+            program_path = tmp_path / "Program.cs"
+            project_path.write_text(
+                f"""\
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="{QUERY_RUNTIME_PROJECT}" />
+  </ItemGroup>
+</Project>
+""",
+                encoding="utf-8",
+            )
+            program_path.write_text(
+                """\
+using UnifyWeaver.QueryRuntime;
+
+static void Assert(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException(message);
+    }
+}
+
+var root = Path.Combine(Path.GetTempPath(), "uw-policy-guided-open-" + Guid.NewGuid().ToString("N"));
+Directory.CreateDirectory(root);
+var inputPath = Path.Combine(root, "edges.tsv");
+File.WriteAllText(inputPath, "child\\tparent\\n1\\t2\\n1\\t3\\n2\\t4\\n");
+var predicate = new PredicateId("edge", 2);
+var source = new DelimitedRelationSource(inputPath, '\t', 1, 2);
+var binaryManifest = BinaryRelationArtifactBuilder.BuildFromDelimited(predicate, source, Path.Combine(root, "binary"));
+var mmapManifest = MmapArrayRelationArtifactBuilder.BuildFromDelimited(predicate, source, Path.Combine(root, "mmap"));
+var manifests = new[] { binaryManifest, mmapManifest };
+
+Assert(
+    RelationArtifactProviderOpenPolicy.TryOpenPreferred(
+        predicate,
+        manifests,
+        RelationArtifactAccessPolicy.MmapArrayArtifactStorageKind,
+        fallback: null,
+        factories: null,
+        out var mmapOpened),
+    "preferred mmap open failed");
+Assert(mmapOpened.StorageKind == RelationArtifactAccessPolicy.MmapArrayArtifactStorageKind, $"storage kind was {mmapOpened.StorageKind}");
+
+Assert(
+    RelationArtifactProviderOpenPolicy.TryOpenPreferred(
+        predicate,
+        manifests,
+        RelationArtifactAccessPolicy.LmdbArtifactStorageKind,
+        fallback: null,
+        factories: null,
+        out var fallbackOpened),
+    "fallback open failed");
+Assert(fallbackOpened.StorageKind == RelationArtifactAccessPolicy.BinaryArtifactStorageKind, $"fallback storage kind was {fallbackOpened.StorageKind}");
+
+Assert(
+    RelationArtifactProviderOpenPolicy.TryOpenPreferred(
+        predicate,
+        manifests,
+        RelationArtifactAccessPolicy.MmapArrayArtifactStorageKind,
+        fallback: null,
+        factories: new IRelationArtifactProviderFactory[] { new ThrowingRelationArtifactProviderFactory(), new DefaultRelationArtifactProviderFactory() },
+        out var skippedThrowingOpened),
+    "throwing factory should be skipped");
+Assert(skippedThrowingOpened.StorageKind == RelationArtifactAccessPolicy.MmapArrayArtifactStorageKind, $"skipped factory storage kind was {skippedThrowingOpened.StorageKind}");
+
+Assert(
+    RelationArtifactProviderOpenPolicy.TryOpenEffectiveDistanceArtifact(
+        predicate,
+        "article_category",
+        1_000_000,
+        RelationArtifactAccessShape.LookupColumn0,
+        manifests,
+        fallback: null,
+        factories: null,
+        out var policyOpened),
+    "effective-distance policy open failed");
+Assert(policyOpened.StorageKind == RelationArtifactAccessPolicy.MmapArrayArtifactStorageKind, $"policy storage kind was {policyOpened.StorageKind}");
+
+sealed class ThrowingRelationArtifactProviderFactory : IRelationArtifactProviderFactory
+{
+    public bool TryOpen(
+        PredicateId predicate,
+        string manifestPath,
+        IRelationProvider? fallback,
+        out RelationArtifactProviderOpenResult result)
+    {
+        result = default!;
+        throw new InvalidDataException("wrong manifest format for this provider");
+    }
+}
 """,
                 encoding="utf-8",
             )


### PR DESCRIPTION
  ## Summary

  - add `RelationArtifactProviderOpenPolicy` to choose an artifact provider from available manifests by preferred storage kind
  - support effective-distance access-shape preferences through `RelationArtifactAccessPolicy`
  - fall back to the first openable artifact when the preferred provider is unavailable
  - skip invalid factory/manifest attempts so optional providers such as LMDB can be registered without breaking core fallback
  behavior

  ## Verification

  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py`
  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 -m py_compile tests/test_csharp_query_source_mode_policy.py examples/benchmark/
  benchmark_csharp_query_effective_distance_artifact_backends.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj`
  - `git diff --check`