### PR TITLE
feat(wam-clojure): add succ/2 builtin

### DIFF
--- a/PR_WAM_CLOJURE_SUCC_BUILTIN.md
+++ b/PR_WAM_CLOJURE_SUCC_BUILTIN.md
@@ -1,0 +1,31 @@
+# PR Title
+
+feat(wam-clojure): add succ/2 builtin
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM support for `succ/2`.
+- Direct-lowers `succ/2` to a runtime helper instead of routing through the interpreted builtin path.
+- Supports conservative integer forward and backward modes.
+- Fails cleanly for negative predecessors, non-positive successor back mode, and unbound/unbound mode.
+- Adds lowered-emitter and runtime smoke coverage.
+
+## Semantics
+
+`succ/2` succeeds when the second argument is the successor of the first argument.
+
+The implementation supports:
+
+- `succ(+N, ?M)` when `N` is a nonnegative integer.
+- `succ(?N, +M)` when `M` is a positive integer.
+
+Unsupported or invalid modes fail cleanly rather than raising ISO-style errors.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -308,6 +308,10 @@ clojure_direct_builtin("=\\=/2", "2").
 clojure_direct_builtin("=\\=/2", 2).
 clojure_direct_builtin('=\\=/2', "2").
 clojure_direct_builtin('=\\=/2', 2).
+clojure_direct_builtin("succ/2", "2").
+clojure_direct_builtin("succ/2", 2).
+clojure_direct_builtin('succ/2', "2").
+clojure_direct_builtin('succ/2', 2).
 clojure_direct_builtin("is/2", "2").
 clojure_direct_builtin("is/2", 2).
 clojure_direct_builtin('is/2', "2").
@@ -641,6 +645,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr),
            '(let [left (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) right (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound))] (if (runtime/arithmetic-not-equal? ~w left right) (runtime/advance ~w) (runtime/backtrack ~w)))',
            [S, S, S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "succ/2" ; Op == 'succ/2'),
+    !,
+    format(atom(Expr), '(runtime/apply-succ-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "is/2" ; Op == 'is/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -520,6 +520,27 @@
 (defn arithmetic-greater-or-equal? [state left right]
   (arithmetic-compare? state >= left right))
 
+(defn apply-succ-solution [state]
+  (let [pred (deref-value (:bindings state)
+                          (or (reg-get-raw state "A1") ::unbound))
+        succ (deref-value (:bindings state)
+                          (or (reg-get-raw state "A2") ::unbound))]
+    (cond
+      (and (integer? pred) (not (neg? pred)))
+      (let [[ok next-state] (unify-values state succ (inc pred))]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+
+      (and (integer? succ) (pos? succ))
+      (let [[ok next-state] (unify-values state pred (dec succ))]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+
+      :else
+      (backtrack state))))
+
 (defn arithmetic-result-term [value]
   (cond
     (integer? value) value
@@ -1520,6 +1541,9 @@
             (if (arithmetic-not-equal? state left right)
               (advance state)
               (backtrack state)))
+
+          "succ/2"
+          (apply-succ-solution state)
 
           "is/2"
           (let [left (deref-value (:bindings state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -240,6 +240,13 @@ test(simple_builtin_arithmetic_not_equal_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/backtrack")
     )).
 
+test(simple_builtin_succ_is_direct_lowered_in_prefix) :-
+    once((
+        lower_predicate_to_clojure(test_succ/2, [builtin_call('succ/2', 2), proceed], [], Code),
+        has(Code, "runtime/apply-succ-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_is_is_direct_lowered_in_prefix) :-
     once((
         lower_predicate_to_clojure(test_is/2, [builtin_call('is/2', 2), proceed], [], Code),

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -147,6 +147,9 @@
 :- dynamic user:wam_arith_eq_float/1.
 :- dynamic user:wam_arith_neq_42/1.
 :- dynamic user:wam_arith_eq_unbound/1.
+:- dynamic user:wam_succ_guard/2.
+:- dynamic user:wam_succ_negative/1.
+:- dynamic user:wam_succ_unbound_pair/1.
 :- dynamic user:wam_arith_lt_42/1.
 :- dynamic user:wam_arith_gt_42/1.
 :- dynamic user:wam_arith_le_42/1.
@@ -308,6 +311,9 @@ user:wam_arith_eq_42(X) :- X =:= 42.
 user:wam_arith_eq_float(X) :- X =:= 3.5.
 user:wam_arith_neq_42(X) :- X =\= 42.
 user:wam_arith_eq_unbound(_) :- user:wam_unbound_arg(Y), Y =:= 42.
+user:wam_succ_guard(N, M) :- succ(N, M).
+user:wam_succ_negative(M) :- succ(-1, M).
+user:wam_succ_unbound_pair(_) :- user:wam_unbound_arg(N), user:wam_unbound_arg(M), succ(N, M).
 user:wam_arith_lt_42(X) :- X < 42.
 user:wam_arith_gt_42(X) :- X > 42.
 user:wam_arith_le_42(X) :- X =< 42.
@@ -474,6 +480,9 @@ run_smoke :-
           user:wam_arith_eq_float/1,
           user:wam_arith_neq_42/1,
           user:wam_arith_eq_unbound/1,
+          user:wam_succ_guard/2,
+          user:wam_succ_negative/1,
+          user:wam_succ_unbound_pair/1,
           user:wam_arith_lt_42/1,
           user:wam_arith_gt_42/1,
           user:wam_arith_le_42/1,
@@ -793,6 +802,13 @@ smoke_cases([
     case('wam_arith_neq_42/1', 3.5, "true"),
     case('wam_arith_neq_42/1', 42, "false"),
     case('wam_arith_eq_unbound/1', a, "false"),
+    case('wam_succ_guard/2', args(1, 2), "true"),
+    case('wam_succ_guard/2', args(1, 3), "false"),
+    case('wam_succ_guard/2', args(0, 1), "true"),
+    case('wam_succ_guard/2', args(2, 3), "true"),
+    case('wam_succ_guard/2', args(2, 2), "false"),
+    case('wam_succ_negative/1', 0, "false"),
+    case('wam_succ_unbound_pair/1', a, "false"),
     case('wam_arith_lt_42/1', 3.5, "true"),
     case('wam_arith_lt_42/1', 42, "false"),
     case('wam_arith_gt_42/1', 43, "true"),
@@ -1122,6 +1138,9 @@ assert_lowered_arithmetic_comparison_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-arith-eq-float-1"),
     has(CoreCode, "defn lowered-wam-arith-neq-42-1"),
     has(CoreCode, "defn lowered-wam-arith-eq-unbound-1"),
+    has(CoreCode, "defn lowered-wam-succ-guard-2"),
+    has(CoreCode, "defn lowered-wam-succ-negative-1"),
+    has(CoreCode, "defn lowered-wam-succ-unbound-pair-1"),
     has(CoreCode, "defn lowered-wam-arith-lt-42-1"),
     has(CoreCode, "defn lowered-wam-arith-gt-42-1"),
     has(CoreCode, "defn lowered-wam-arith-le-42-1"),
@@ -1136,6 +1155,7 @@ assert_lowered_arithmetic_comparison_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-arith-is-unbound-1"),
     has(CoreCode, "runtime/arithmetic-equal?"),
     has(CoreCode, "runtime/arithmetic-not-equal?"),
+    has(CoreCode, "runtime/apply-succ-solution"),
     has(CoreCode, "runtime/eval-arithmetic-term"),
     has(CoreCode, "runtime/arithmetic-less?"),
     has(CoreCode, "runtime/arithmetic-greater?"),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM support for `succ/2`.
- Direct-lowers `succ/2` to a runtime helper instead of routing through the interpreted builtin path.
- Supports conservative integer forward and backward modes.
- Fails cleanly for negative predecessors, non-positive successor back mode, and unbound/unbound mode.
- Adds lowered-emitter and runtime smoke coverage.

## Semantics

`succ/2` succeeds when the second argument is the successor of the first argument.

The implementation supports:

- `succ(+N, ?M)` when `N` is a nonnegative integer.
- `succ(?N, +M)` when `M` is a positive integer.

Unsupported or invalid modes fail cleanly rather than raising ISO-style errors.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
