### PR TITLE
Feat/wam go nth list builtins

### DIFF
--- a/PR_go_wam_nth_list_builtins.md
+++ b/PR_go_wam_nth_list_builtins.md
@@ -1,0 +1,26 @@
+# PR Title
+
+Add Go WAM nth list builtin parity
+
+# PR Description
+
+## Summary
+
+- Add deterministic `nth0/3` and `nth1/3` support to the generated Go WAM runtime.
+- Route Go WAM `call`/`execute` instructions for `nth0/3` and `nth1/3` through `BuiltinCall` using the Go-local direct builtin path.
+- Cover `nth0(+Index,+List,?Elem)` and `nth1(+Index,+List,?Elem)` for in-range element lookup and out-of-range failure.
+- Update the Go WAM parity audit for the expanded Clojure/R/C++ indexed-list builtin surface.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl tests/test_wam_go_generator.pl tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(nth0/3,3), X), writeln(X), halt"`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(nth1/3,3), X), writeln(X), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -11,7 +11,7 @@ current cross-target builtin/runtime baseline.
 | Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries, indexed atom fact streams, `member/2` builtin retries | Choice point stack with normal, builtin, and fact-stream resume states | Present for current resume-state baseline |
 | Direct fact dispatch | `call_indexed_atom_fact2`, `AtomFact2Source` registry, TSV-backed and LMDB-artifact atom fact loading, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Present for current external atom fact-source baseline |
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
-| Structural builtins | `member/2`, `memberchk/2`, `length/2`, `append/3`, `reverse/2`, `last/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `reverse/2` and `last/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
+| Structural builtins | `member/2`, `memberchk/2`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `reverse/2`, `last/2`, `nth0/3`, and `nth1/3` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2` | Includes `=</2` | Present for current baseline comparisons |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
@@ -40,6 +40,9 @@ current cross-target builtin/runtime baseline.
 - Deterministic `last/2` is now covered by the generated Go WAM builtin E2E
   test for non-empty list success and empty-list failure, closing another
   richer Clojure/R/C++ list-builtin parity gap.
+- Deterministic `nth0/3` and `nth1/3` are now covered by the generated Go WAM
+  builtin E2E test for in-range element lookup and out-of-range failure,
+  matching the Clojure/R deterministic indexed-list surface.
 - Go WAM choice points now have explicit generated-runtime coverage for normal
   clause retries, indexed alternatives, foreign stream retries, indexed atom
   fact streams, and `member/2` builtin retries.

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -428,6 +428,12 @@ wam_go_direct_builtin("reverse/2", 2, 'reverse/2').
 wam_go_direct_builtin(last/2, 2, 'last/2').
 wam_go_direct_builtin('last/2', 2, 'last/2').
 wam_go_direct_builtin("last/2", 2, 'last/2').
+wam_go_direct_builtin(nth0/3, 3, 'nth0/3').
+wam_go_direct_builtin('nth0/3', 3, 'nth0/3').
+wam_go_direct_builtin("nth0/3", 3, 'nth0/3').
+wam_go_direct_builtin(nth1/3, 3, 'nth1/3').
+wam_go_direct_builtin('nth1/3', 3, 'nth1/3').
+wam_go_direct_builtin("nth1/3", 3, 'nth1/3').
 
 wam_instruction_to_go_literal(get_constant(C, Ai), GoLiteral) :-
     go_value_literal(C, GoVal),

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1194,6 +1194,25 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			return false
 		}
 		return vm.Unify(arg2, items[len(items)-1])
+	case "nth0/3", "nth1/3":
+		idxVal := vm.deref(arg1)
+		idxInt, ok := idxVal.(*Integer)
+		if !ok {
+			return false
+		}
+		items, ok := vm.listToSlice(arg2)
+		if !ok {
+			return false
+		}
+		base := int64(0)
+		if op == "nth1/3" {
+			base = 1
+		}
+		idx := idxInt.Val - base
+		if idx < 0 || idx >= int64(len(items)) {
+			return false
+		}
+		return vm.Unify(arg3, items[int(idx)])
 	case "functor/3":
 		t := vm.deref(arg1)
 		if isUnbound(t) {

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -11,6 +11,7 @@
 :- dynamic user:test_memberchk_builtin/0.
 :- dynamic user:test_reverse_builtin/0.
 :- dynamic user:test_last_builtin/0.
+:- dynamic user:test_nth_builtin/0.
 :- dynamic user:test_set_aggregate/0.
 :- dynamic user:test_unify_builtin/0.
 :- dynamic user:test_neg_fact/1.
@@ -72,6 +73,20 @@ test(builtins_execution) :-
                 Y == only,
                 \+ last([], _)
             )),
+          assertz(user:test_nth_builtin :-
+            (   nth0(0, [a,b,c], A),
+                A == a,
+                nth0(1, [a,b,c], B),
+                B == b,
+                nth1(1, [a,b,c], C),
+                C == a,
+                nth1(3, [a,b,c], D),
+                D == c,
+                \+ nth0(-1, [a,b,c], _),
+                \+ nth0(3, [a,b,c], _),
+                \+ nth1(0, [a,b,c], _),
+                \+ nth1(4, [a,b,c], _)
+            )),
           assertz(user:test_set_aggregate :-
             (   aggregate_all(set(X), member(X, [a,b,a]), S),
                 length(S, 2),
@@ -99,6 +114,7 @@ test(builtins_execution) :-
           retractall(user:test_memberchk_builtin),
           retractall(user:test_reverse_builtin),
           retractall(user:test_last_builtin),
+          retractall(user:test_nth_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
           retractall(user:test_neg_fact(_)),
@@ -108,7 +124,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -142,6 +158,8 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "memberchk/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "reverse/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "last/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "nth0/3"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "nth1/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "\\\\+/1"')),
     assertion(sub_string(LibCode, _, _, _, 'AggType: "set"')),
 
@@ -211,6 +229,14 @@ func main() {
 		fmt.Println("LAST_FAILURE")
 	}
 
+	nthVM := wam.NewWamState(wam.Test_nth_builtinCode, wam.Test_nth_builtinLabels)
+	nthVM.PC = wam.Test_nth_builtinStartPC
+	if nthVM.Run() {
+		fmt.Println("NTH_SUCCESS")
+	} else {
+		fmt.Println("NTH_FAILURE")
+	}
+
 	setVM := wam.NewWamState(wam.Test_set_aggregateCode, wam.Test_set_aggregateLabels)
 	setVM.PC = wam.Test_set_aggregateStartPC
 	if setVM.Run() {
@@ -266,6 +292,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "MEMBERCHK_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "REVERSE_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "LAST_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "NTH_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NEG_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM nth list builtin parity

## Summary

- Add deterministic `nth0/3` and `nth1/3` support to the generated Go WAM runtime.
- Route Go WAM `call`/`execute` instructions for `nth0/3` and `nth1/3` through `BuiltinCall` using the Go-local direct builtin path.
- Cover `nth0(+Index,+List,?Elem)` and `nth1(+Index,+List,?Elem)` for in-range element lookup and out-of-range failure.
- Update the Go WAM parity audit for the expanded Clojure/R/C++ indexed-list builtin surface.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl tests/test_wam_go_generator.pl tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(nth0/3,3), X), writeln(X), halt"`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(nth1/3,3), X), writeln(X), halt"`
- `git diff --check`
