### PR TITLE
feat(csharp-query): use source policy in generated providers

### DIFF
--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -3652,9 +3652,7 @@ build_provider_method(ProviderSection, Method) :-
                 throw new ArgumentException($"Unknown UNIFYWEAVER_RELATION_SOURCE_MODE: {Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_SOURCE_MODE")}");
             }
 
-            var sourceMode = configuredSourceMode == RelationSourceMode.Auto
-                ? RelationSourceMode.Preload
-                : configuredSourceMode;
+            var sourceMode = RelationSourceModePolicy.ResolveGraphBenchmarkMode(configuredSourceMode, "generated-query");
             var configuredProvider = new ConfiguredDelimitedRelationProvider(
                 sourceMode,
                 Environment.GetEnvironmentVariable("UNIFYWEAVER_RELATION_ARTIFACT_DIR"));

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -1750,7 +1750,9 @@ verify_single_plan_codegen_avoids_duplicate_fact_population :-
     count_substring(Source, 'memoryProvider.AddFact(new PredicateId("test_fact", 2), "alice", "bob");', 1),
     count_substring(Source, 'memoryProvider.AddFact(new PredicateId("test_fact", 2), "bob", "charlie");', 1),
     count_substring(Source, 'var configuredProvider = BuildProvider();', 1),
-    count_substring(Source, 'return (configuredProvider.Provider, CachedPlan.Value);', 1).
+    count_substring(Source, 'return (configuredProvider.Provider, CachedPlan.Value);', 1),
+    sub_string(Source, _, _, _, 'RelationSourceModePolicy.ResolveGraphBenchmarkMode(configuredSourceMode, "generated-query")'),
+    \+ sub_string(Source, _, _, _, 'configuredSourceMode == RelationSourceMode.Auto').
 
 verify_ground_relation_arg_plan :-
     csharp_query_target:build_query_plan(test_sale_amount_for_alice/1, [target(csharp_query)], Plan),


### PR DESCRIPTION
  ## Summary

  - update generated C# query providers to resolve `auto` through `RelationSourceModePolicy.ResolveGraphBenchmarkMode`
  - remove the stale inline `auto => preload` fallback from the generic C# query target generator
  - add render coverage to ensure generated source keeps using the runtime policy helper

  ## Verification

  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py`
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj`
  - `git diff --check`