### PR TITLE
Feat/wam c transitive closure kernel

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -17,7 +17,7 @@ Base verified locally:
 
 Active branch:
 
-- `investigate/wam-c-next-benchmark-demand`
+- `feat/wam-c-transitive-closure-kernel`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -73,6 +73,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | `atom_concat/3` builtin support | Done | Explicit deterministic atom concatenation and split modes have direct executable smoke coverage |
 | Generated Prolog builtin parity smoke | Done | Generated WAM-to-C executable smoke exercises `functor/3`, `arg/3`, and `atom_concat/3` together |
 | Benchmark-demand scan | Done | `dev`/`10x` accumulated TSV+LMDB C targets and `dev`/`10x` lowered-helper targets preserve output parity; accumulated C kernel path shows no meaningful speedup over no-kernels and is much slower than optimized Prolog at `10x` |
+| `transitive_closure2` native kernel | Done | C shared-kernel detector accepts `transitive_closure2`, emits detected setup, registers a native arity-2 foreign handler, and covers direct plus detected-project executable smokes |
 
 ## Current C Target Baseline
 
@@ -97,8 +98,8 @@ The C target is now a credible small WAM backend:
 - Can opt into a prototype lowered-helper path for constant fact-only
   predicates, plus same-arity alias bodies that call those native fact helpers,
   emitted as native C foreign handlers behind `call_foreign` trampolines.
-- Supports a deterministic native `category_ancestor/4` handler over an
-  in-memory category-parent edge table.
+- Supports deterministic native `category_ancestor/4` and `transitive_closure2`
+  handlers over an in-memory edge table.
 - Supports loading category-parent facts from TSV through a small
   `WamFactSource` interface.
 - Supports collecting all integer hop results for native `category_ancestor/4`
@@ -143,8 +144,8 @@ missing important target features; `Missing` = no comparable C path yet.
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
 | Negation / control builtins | Partial | Broader | Broader | C likely needs explicit tests for `\+/1`, cut interactions, and if-then-else lowering. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
-| Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup and all-hop collection; the next benchmark-demand gap is shared-kernel breadth, starting with `transitive_closure2`. |
-| Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`; Haskell and Rust cover a broader shared-kernel registry, so C should add the next kernel one at a time. |
+| Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, and native `transitive_closure2`; continue adding shared kernels one at a time. |
+| Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4` and `transitive_closure2`; Haskell and Rust cover a broader shared-kernel registry. |
 | Lowered/native helper functions | Partial/Done | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, comparison-filter helpers, rejection metadata, repeated-variable filter hardening, empty-result rejection metadata, and projected body-call helper expansion. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
@@ -155,16 +156,16 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-transitive-closure-kernel`
+### 1. `feat/wam-c-transitive-distance-kernel`
 
 Goal: add the next shared recursive kernel to C from the Haskell/Rust parity
-surface, starting with `transitive_closure2`.
+surface, continuing from `transitive_closure2` to `transitive_distance3`.
 
 Scope:
 
 - Extend the C recursive-kernel registration path beyond `category_ancestor/4`
-  for the shared `transitive_closure2` detector.
-- Add a native C handler and executable smoke for a small binary edge closure.
+  and `transitive_closure2` for the shared `transitive_distance3` detector.
+- Add a native C handler and executable smoke for a small binary edge distance.
 - Keep TSV/LMDB fact loading out of scope unless the small in-memory kernel
   path exposes a need for it.
 
@@ -172,12 +173,13 @@ Status: recommended next.
 
 Reason:
 
-- The benchmark-demand scan did not find an output-parity failure in the current
-  C matrix surfaces.
-- It did find that accumulated C WAM has no useful kernel delta at `10x`, while
-  Haskell and Rust already model multiple shared recursive kernels. The narrow
-  parity move is therefore adding one more shared kernel kind, not expanding the
-  builtin set speculatively.
+- `transitive_closure2` is now covered through direct native registration and
+  detected-project setup.
+- `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` records
+  `transitive_distance3/3` as a measured Haskell multi-output kernel benchmark,
+  so it is a better C parity target than another speculative builtin.
+- Haskell and Rust already cover `transitive_distance3`; it can reuse the edge
+  traversal surface while adding an integer distance output.
 
 ### 2. `investigate/wam-c-accumulated-runtime-cost`
 
@@ -210,6 +212,28 @@ Evidence:
 | Accumulated C dev parity | `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 1 --baseline-target prolog-accumulated` | All outputs match across Prolog, TSV C, and LMDB C targets. |
 | Lowered-helper dev/10x parity | `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev,10x --target-sets c-wam-lowered-helper --repetitions 1 --baseline-target c-wam-lowered-helper-interpreted` | Lowered and interpreted helper outputs match at `dev` and `10x`. |
 | Accumulated C 10x parity and kernel delta | `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10x --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 1 --baseline-target prolog-accumulated` | All outputs match, but C WAM is about `0.03x` versus optimized Prolog and C kernels are only `1.004x` to `1.014x` versus no-kernels. |
+
+### Completed Shared Kernel Slice: `feat/wam-c-transitive-closure-kernel`
+
+Goal: add the next shared recursive kernel to C from the Haskell/Rust parity
+surface.
+
+Evidence:
+
+| Surface | Coverage |
+|---|---|
+| Kernel support predicate | `wam_c_supported_kernel/1` accepts `recursive_kernel(transitive_closure2, ...)`. |
+| Detected setup emission | `generate_setup_detected_kernels_c/2` emits `wam_register_transitive_closure_kernel`. |
+| Runtime handler | `wam_transitive_closure_handler` supports bound-target reachability and first-solution unbound target mode over registered in-memory edges. |
+| Direct executable smoke | `tc_ancestor/2` succeeds for direct and recursive edges, binds an unbound target, and fails for a reversed edge. |
+| Detected-project smoke | Generated project detection lowers `tc_ancestor/2` to a `call_foreign` trampoline and runs through `setup_detected_wam_c_kernels`. |
+
+Performance note:
+
+- `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` repeatedly points to native kernel
+  dispatch as the meaningful hybrid-WAM speedup lever. For C, the immediate
+  goal should stay on broadening native shared kernels before tuning the general
+  WAM instruction dispatch loop.
 
 ## Completed Atom Concat Builtin
 
@@ -288,8 +312,9 @@ After hash-bucket row dispatch but before compact row tables:
 
 ## Suggested Immediate Next Step
 
-Proceed with `feat/wam-c-transitive-closure-kernel`.
+Proceed with `feat/wam-c-transitive-distance-kernel`.
 
-Keep it narrow: add the shared `transitive_closure2` kernel path and a small
-executable smoke first. Treat broader fact storage, LMDB loading, and runtime
-profiling as follow-up branches unless this slice exposes a direct blocker.
+Keep it narrow: add `transitive_distance3` over the same in-memory edge surface
+and prove direct plus detected-project executable smokes. Treat broader fact
+storage, LMDB loading, and runtime profiling as follow-up branches unless this
+slice exposes a direct blocker.

--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,18 +4,20 @@ Status date: 2026-05-16
 
 Base verified locally:
 
+- `main` at `a20d6d75` (`Merge pull request #2202 from s243a/test/wam-c-builtins-real-prolog-smoke`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `main` at `c0085bce` (`Merge pull request #2198 from s243a/bench/csharp-query-page-relation-backends`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
-- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py`
+- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/test_wam_c_lowered_helper_scale_regression.py`
 - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev,10x --target-sets c-wam-lowered-helper --repetitions 1 --baseline-target c-wam-lowered-helper-interpreted`
-- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels --repetitions 1`
+- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 1 --baseline-target prolog-accumulated`
+- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10x --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 1 --baseline-target prolog-accumulated`
+- `git diff --check`
 
 Active branch:
 
-- `test/wam-c-builtins-real-prolog-smoke`
+- `investigate/wam-c-next-benchmark-demand`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -69,7 +71,8 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Lowered helper next-shape selection | Done | Selected term-shape builtin parity as the next narrow helper-adjacent surface and added C `functor/3` runtime support because Haskell and Rust already cover richer structure inspection paths |
 | `arg/3` builtin support | Done | Deterministic positive-index argument extraction for structures and lists has direct executable smoke coverage |
 | `atom_concat/3` builtin support | Done | Explicit deterministic atom concatenation and split modes have direct executable smoke coverage |
-| Generated Prolog builtin parity smoke | In progress | Active branch exercises `functor/3`, `arg/3`, and `atom_concat/3` together through generated WAM-to-C code |
+| Generated Prolog builtin parity smoke | Done | Generated WAM-to-C executable smoke exercises `functor/3`, `arg/3`, and `atom_concat/3` together |
+| Benchmark-demand scan | Done | `dev`/`10x` accumulated TSV+LMDB C targets and `dev`/`10x` lowered-helper targets preserve output parity; accumulated C kernel path shows no meaningful speedup over no-kernels and is much slower than optimized Prolog at `10x` |
 
 ## Current C Target Baseline
 
@@ -140,8 +143,8 @@ missing important target features; `Missing` = no comparable C path yet.
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
 | Negation / control builtins | Partial | Broader | Broader | C likely needs explicit tests for `\+/1`, cut interactions, and if-then-else lowering. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
-| Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup and all-hop collection; add more kernel kinds only after runtime support exists. |
-| Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`; broaden as more native C kernels land. |
+| Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup and all-hop collection; the next benchmark-demand gap is shared-kernel breadth, starting with `transitive_closure2`. |
+| Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`; Haskell and Rust cover a broader shared-kernel registry, so C should add the next kernel one at a time. |
 | Lowered/native helper functions | Partial/Done | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, comparison-filter helpers, rejection metadata, repeated-variable filter hardening, empty-result rejection metadata, and projected body-call helper expansion. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
@@ -152,39 +155,61 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `test/wam-c-builtins-real-prolog-smoke`
+### 1. `feat/wam-c-transitive-closure-kernel`
 
-Goal: exercise the accumulated builtin parity surface through generated Prolog,
-not just hand-authored WAM snippets.
+Goal: add the next shared recursive kernel to C from the Haskell/Rust parity
+surface, starting with `transitive_closure2`.
 
 Scope:
 
-- Add a generated Prolog executable smoke that uses `functor/3`, `arg/3`, and
-  `atom_concat/3` together.
-- Keep it small and deterministic so the normal WAM-C test suite remains cheap.
+- Extend the C recursive-kernel registration path beyond `category_ancestor/4`
+  for the shared `transitive_closure2` detector.
+- Add a native C handler and executable smoke for a small binary edge closure.
+- Keep TSV/LMDB fact loading out of scope unless the small in-memory kernel
+  path exposes a need for it.
 
-Status: active.
+Status: recommended next.
 
-Selected scope:
+Reason:
 
-| Candidate | Decision | Reason |
-|---|---:|---|
-| Combined generated-Prolog success path | Active | Confirms the compiler emits builtin calls that the C runtime can execute together. |
-| Bound-output failure path | Active | Confirms generated code rejects a wrong composed label deterministically. |
-| Broad builtin matrix | Defer | The full builtin surface should be demand-driven rather than expanded preemptively. |
+- The benchmark-demand scan did not find an output-parity failure in the current
+  C matrix surfaces.
+- It did find that accumulated C WAM has no useful kernel delta at `10x`, while
+  Haskell and Rust already model multiple shared recursive kernels. The narrow
+  parity move is therefore adding one more shared kernel kind, not expanding the
+  builtin set speculatively.
 
-### 2. `investigate/wam-c-next-benchmark-demand`
+### 2. `investigate/wam-c-accumulated-runtime-cost`
+
+Goal: explain why the accumulated C WAM effective-distance target is much
+slower than optimized Prolog at `10x`.
+
+Scope:
+
+- Profile generated `c-wam-accumulated` and `c-wam-accumulated-no-kernels` runs
+  at `10x`.
+- Identify whether the cost is WAM dispatch, fact lookup, repeated setup,
+  generated query shape, or native-kernel integration overhead.
+- Keep this separate from `transitive_closure2` unless the same root cause
+  blocks the new kernel.
+
+Status: recommended after the next shared-kernel slice, or sooner if runtime
+performance becomes the blocking question.
+
+### Completed Investigation: `investigate/wam-c-next-benchmark-demand`
 
 Goal: choose the next C parity gap from an actual benchmark or generated-program
 failure instead of adding builtins speculatively.
 
-Scope:
+Evidence:
 
-- Run the existing WAM-C benchmark/generator surfaces and identify the next
-  unsupported runtime or compiler feature from real failures.
-- Prefer one narrow branch per missing feature.
-
-Status: recommended after this branch.
+| Surface | Command | Outcome |
+|---|---|---|
+| Target registry | `python3 examples/benchmark/benchmark_effective_distance_matrix.py --list-targets` | C exposes accumulated TSV, accumulated LMDB, and lowered-helper target sets. |
+| Kernel-pair registry | `python3 examples/benchmark/benchmark_effective_distance_matrix.py --list-kernel-pairs` | C exposes accumulated TSV and LMDB kernels-on/no-kernels pairs. |
+| Accumulated C dev parity | `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 1 --baseline-target prolog-accumulated` | All outputs match across Prolog, TSV C, and LMDB C targets. |
+| Lowered-helper dev/10x parity | `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev,10x --target-sets c-wam-lowered-helper --repetitions 1 --baseline-target c-wam-lowered-helper-interpreted` | Lowered and interpreted helper outputs match at `dev` and `10x`. |
+| Accumulated C 10x parity and kernel delta | `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10x --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 1 --baseline-target prolog-accumulated` | All outputs match, but C WAM is about `0.03x` versus optimized Prolog and C kernels are only `1.004x` to `1.014x` versus no-kernels. |
 
 ## Completed Atom Concat Builtin
 
@@ -263,8 +288,8 @@ After hash-bucket row dispatch but before compact row tables:
 
 ## Suggested Immediate Next Step
 
-Continue validating `test/wam-c-lowered-helper-larger-scale-regression`.
+Proceed with `feat/wam-c-transitive-closure-kernel`.
 
-The active branch should keep the local regression focused on `100x`; `1k`
-remains useful for occasional calibration but is too slow for routine local
-validation.
+Keep it narrow: add the shared `transitive_closure2` kernel path and a small
+executable smoke first. Treat broader fact storage, LMDB loading, and runtime
+profiling as follow-up branches unless this slice exposes a direct blocker.

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -247,8 +247,11 @@ int wam_run_predicate(WamState *state, const char *pred, WamValue *args, int ari
 bool wam_execute_builtin(WamState *state, const char *op, int arity);
 bool wam_execute_foreign_predicate(WamState *state, const char *pred, int arity);
 void wam_register_category_parent(WamState *state, const char *child, const char *parent);
+void wam_register_transitive_edge(WamState *state, const char *child, const char *parent);
 void wam_register_category_ancestor_kernel(WamState *state, const char *pred, int max_depth);
+void wam_register_transitive_closure_kernel(WamState *state, const char *pred);
 bool wam_category_ancestor_handler(WamState *state, const char *pred, int arity);
+bool wam_transitive_closure_handler(WamState *state, const char *pred, int arity);
 void wam_fact_source_init(WamFactSource *source);
 void wam_fact_source_close(WamFactSource *source);
 bool wam_fact_source_load_tsv(WamState *state, WamFactSource *source, const char *path);

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -132,6 +132,7 @@ detect_kernels([PI|Rest], Kernels) :-
     detect_kernels(Rest, RestKernels).
 
 wam_c_supported_kernel(recursive_kernel(category_ancestor, _Pred, _ConfigOps)).
+wam_c_supported_kernel(recursive_kernel(transitive_closure2, _Pred, _ConfigOps)).
 
 %% generate_setup_detected_kernels_c(+DetectedKernels, -CCode)
 %  Emit C startup wiring for detected kernels. This function registers only
@@ -150,6 +151,10 @@ wam_c_kernel_registration_line(Key-recursive_kernel(category_ancestor, _Pred, Co
     format(atom(Line),
            '    wam_register_category_ancestor_kernel(state, "~w", ~w);',
            [Key, MaxDepth]).
+wam_c_kernel_registration_line(Key-recursive_kernel(transitive_closure2, _Pred, _ConfigOps), Line) :-
+    format(atom(Line),
+           '    wam_register_transitive_closure_kernel(state, "~w");',
+           [Key]).
 
 wam_c_kernel_max_depth(ConfigOps, MaxDepth) :-
     (   member(max_depth(MaxDepth0), ConfigOps),
@@ -2269,6 +2274,10 @@ void wam_register_category_parent(WamState *state, const char *child, const char
     state->category_edge_count++;
 }
 
+void wam_register_transitive_edge(WamState *state, const char *child, const char *parent) {
+    wam_register_category_parent(state, child, parent);
+}
+
 void wam_fact_source_init(WamFactSource *source) {
     memset(source, 0, sizeof(WamFactSource));
 }
@@ -2437,6 +2446,10 @@ void wam_register_category_ancestor_kernel(WamState *state, const char *pred, in
     wam_register_foreign_predicate(state, pred, 4, wam_category_ancestor_handler);
 }
 
+void wam_register_transitive_closure_kernel(WamState *state, const char *pred) {
+    wam_register_foreign_predicate(state, pred, 2, wam_transitive_closure_handler);
+}
+
 static bool wam_value_as_atom(WamState *state, WamValue value, const char **out) {
     WamValue *cell = wam_deref_ptr(state, &value);
     if (cell->tag != VAL_ATOM) return false;
@@ -2565,6 +2578,66 @@ bool wam_category_ancestor_handler(WamState *state, const char *pred, int arity)
     bool ok = wam_unify(state, &state->A[2], &result);
     wam_int_results_close(&results);
     return ok;
+}
+
+static bool wam_transitive_closure_dfs(WamState *state,
+                                       const char *start,
+                                       const char *target,
+                                       int depth,
+                                       const char **visited,
+                                       int visited_len,
+                                       const char **result_out) {
+    for (int i = 0; i < state->category_edge_count; i++) {
+        CategoryEdge *edge = &state->category_edges[i];
+        if (strcmp(edge->child, start) != 0) continue;
+        if (wam_visited_array_contains(visited, visited_len, edge->parent)) continue;
+        if (!target || strcmp(edge->parent, target) == 0) {
+            *result_out = edge->parent;
+            return true;
+        }
+    }
+
+    if (depth >= 64 || visited_len >= 64) return false;
+
+    for (int i = 0; i < state->category_edge_count; i++) {
+        CategoryEdge *edge = &state->category_edges[i];
+        if (strcmp(edge->child, start) != 0) continue;
+        if (wam_visited_array_contains(visited, visited_len, edge->parent)) continue;
+        visited[visited_len] = edge->parent;
+        if (wam_transitive_closure_dfs(state, edge->parent, target, depth + 1,
+                                       visited, visited_len + 1, result_out)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool wam_transitive_closure_handler(WamState *state, const char *pred, int arity) {
+    (void)pred;
+    if (arity != 2) return false;
+
+    const char *start = NULL;
+    if (!wam_value_as_atom(state, state->A[0], &start)) return false;
+
+    WamValue *target_cell = wam_deref_ptr(state, &state->A[1]);
+    const char *target = NULL;
+    if (target_cell->tag == VAL_ATOM) {
+        target = target_cell->data.atom;
+    } else if (!val_is_unbound(*target_cell)) {
+        return false;
+    }
+
+    const char *visited[64];
+    int visited_len = 0;
+    visited[visited_len++] = start;
+    const char *result = NULL;
+    if (!wam_transitive_closure_dfs(state, start, target, 0, visited, visited_len, &result)) {
+        return false;
+    }
+    if (target) return true;
+
+    WamValue result_value = val_atom(result);
+    return wam_unify(state, &state->A[1], &result_value);
 }
 '.
 

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -265,6 +265,18 @@ test_category_ancestor_kernel_generation :-
     ;   fail_test(Test, 'category_ancestor native kernel helpers missing')
     ).
 
+test_transitive_closure_kernel_generation :-
+    Test = 'WAM-C: transitive_closure2 native kernel helpers generated',
+    (   compile_wam_runtime_to_c([], RuntimeCode),
+        atom_string(RuntimeCode, S),
+        sub_string(S, _, _, _, 'void wam_register_transitive_edge'),
+        sub_string(S, _, _, _, 'void wam_register_transitive_closure_kernel'),
+        sub_string(S, _, _, _, 'bool wam_transitive_closure_handler'),
+        sub_string(S, _, _, _, 'wam_transitive_closure_dfs')
+    ->  pass(Test)
+    ;   fail_test(Test, 'transitive_closure2 native kernel helpers missing')
+    ).
+
 test_fact_source_generation :-
     Test = 'WAM-C: file FactSource helpers generated',
     (   compile_wam_runtime_to_c([], RuntimeCode),
@@ -302,6 +314,20 @@ test_kernel_detector_setup_generation :-
         pass(Test)
     ;   cleanup_wam_c_detector_category_ancestor,
         fail_test(Test, 'detected kernel setup missing')
+    ).
+
+test_transitive_closure_detector_setup_generation :-
+    Test = 'WAM-C: shared kernel detector emits transitive_closure2 setup',
+    setup_wam_c_detector_transitive_closure,
+    (   detect_kernels([user:tc_ancestor/2], Detected),
+        Detected = ['tc_ancestor/2'-_Kernel],
+        generate_setup_detected_kernels_c(Detected, SetupCode),
+        sub_atom(SetupCode, _, _, _, 'setup_detected_wam_c_kernels'),
+        sub_atom(SetupCode, _, _, _, 'wam_register_transitive_closure_kernel(state, "tc_ancestor/2")')
+    ->  cleanup_wam_c_detector_transitive_closure,
+        pass(Test)
+    ;   cleanup_wam_c_detector_transitive_closure,
+        fail_test(Test, 'detected transitive_closure2 setup missing')
     ).
 
 test_kernel_detector_project_generation :-
@@ -874,6 +900,16 @@ test_category_ancestor_kernel_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_transitive_closure_kernel_executable_smoke :-
+    Test = 'WAM-C: transitive_closure2 native kernel executable smoke',
+    (   gcc_available
+    ->  (   run_transitive_closure_kernel_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'transitive_closure2 native kernel executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_fact_source_executable_smoke :-
     Test = 'WAM-C: file FactSource executable smoke',
     (   gcc_available
@@ -911,6 +947,16 @@ test_kernel_detector_executable_smoke :-
     ->  (   run_kernel_detector_executable_smoke
         ->  pass(Test)
         ;   fail_test(Test, 'detected category_ancestor executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
+test_transitive_closure_detector_executable_smoke :-
+    Test = 'WAM-C: detected transitive_closure2 executable smoke',
+    (   gcc_available
+    ->  (   run_transitive_closure_detector_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'detected transitive_closure2 executable failed')
         )
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
@@ -1193,6 +1239,25 @@ run_category_ancestor_kernel_executable_smoke :-
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
 
+run_transitive_closure_kernel_executable_smoke :-
+    WamCode = 'tc_ancestor/2:\n    call_foreign tc_ancestor/2, 2\n    proceed',
+    compile_wam_predicate_to_c(user:tc_ancestor/2, WamCode, [], PredCode),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_transitive_closure_smoke', Stamp, TmpBase),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(RuntimePath, RuntimeCode),
+    format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+    write_text_file(PredPath, PredTranslationUnit),
+    wam_c_transitive_closure_smoke_main(MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
 run_fact_source_executable_smoke :-
     WamCode = 'category_ancestor/4:\n    call_foreign category_ancestor/4, 4\n    proceed',
     compile_wam_predicate_to_c(user:category_ancestor/4, WamCode, [], PredCode),
@@ -1250,6 +1315,25 @@ run_kernel_detector_executable_smoke :-
         run_c_smoke_plain(ExePath)
     ->  cleanup_wam_c_detector_category_ancestor
     ;   cleanup_wam_c_detector_category_ancestor,
+        fail
+    ).
+
+run_transitive_closure_detector_executable_smoke :-
+    setup_wam_c_detector_transitive_closure,
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_transitive_detector_smoke', Stamp, ProjectDir),
+    directory_file_path(ProjectDir, 'wam_runtime.c', RuntimePath),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    directory_file_path(ProjectDir, 'main.c', MainPath),
+    directory_file_path(ProjectDir, 'wam_c_transitive_detector_smoke', ExePath),
+    (   write_wam_c_project([user:tc_ancestor/2], [], ProjectDir),
+        wam_c_transitive_closure_detector_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, LibPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_detector_transitive_closure
+    ;   cleanup_wam_c_detector_transitive_closure,
         fail
     ).
 
@@ -1723,6 +1807,20 @@ cleanup_wam_c_detector_category_ancestor :-
     retractall(user:max_depth(_)),
     retractall(user:category_ancestor(_, _, _, _)).
 
+setup_wam_c_detector_transitive_closure :-
+    cleanup_wam_c_detector_transitive_closure,
+    assertz((user:tc_parent(tom, bob))),
+    assertz((user:tc_parent(bob, ann))),
+    assertz((user:tc_ancestor(X, Y) :-
+        tc_parent(X, Y))),
+    assertz((user:tc_ancestor(X, Y) :-
+        tc_parent(X, Z),
+        tc_ancestor(Z, Y))).
+
+cleanup_wam_c_detector_transitive_closure :-
+    retractall(user:tc_parent(_, _)),
+    retractall(user:tc_ancestor(_, _)).
+
 run_c_smoke(ExePath) :-
     format(atom(LogPath), '~w.asan.log', [ExePath]),
     run_c_smoke_once(ExePath, LogPath, Status),
@@ -2096,6 +2194,66 @@ int main(void) {
 }
 ').
 
+wam_c_transitive_closure_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_tc_ancestor_2(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_tc_ancestor_2(&state);
+    wam_register_transitive_edge(&state, "tom", "bob");
+    wam_register_transitive_edge(&state, "bob", "ann");
+    wam_register_transitive_edge(&state, "bob", "pat");
+    wam_register_transitive_closure_kernel(&state, "tc_ancestor/2");
+
+    WamValue recursive_args[2] = {
+        val_atom("tom"),
+        val_atom("ann")
+    };
+    int recursive_rc = wam_run_predicate(&state, "tc_ancestor/2", recursive_args, 2);
+    if (recursive_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue direct_args[2] = {
+        val_atom("tom"),
+        val_atom("bob")
+    };
+    int direct_rc = wam_run_predicate(&state, "tc_ancestor/2", direct_args, 2);
+    if (direct_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue output_args[2] = {
+        val_atom("bob"),
+        val_unbound("Target")
+    };
+    int output_rc = wam_run_predicate(&state, "tc_ancestor/2", output_args, 2);
+    if (output_rc != 0 || state.P != WAM_HALT ||
+        state.A[1].tag != VAL_ATOM || strcmp(state.A[1].data.atom, "ann") != 0) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    WamValue fail_args[2] = {
+        val_atom("ann"),
+        val_atom("tom")
+    };
+    int fail_rc = wam_run_predicate(&state, "tc_ancestor/2", fail_args, 2);
+    if (fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_kernel_detector_smoke_main(
 '#include "wam_runtime.h"
 
@@ -2129,6 +2287,36 @@ int main(void) {
     int rc = wam_run_predicate(&state, "category_ancestor/4", args, 4);
     if (rc != 0 || state.P != WAM_HALT ||
         state.A[2].tag != VAL_INT || state.A[2].data.integer != 2) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
+wam_c_transitive_closure_detector_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_tc_ancestor_2(WamState* state);
+void setup_detected_wam_c_kernels(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_tc_ancestor_2(&state);
+    setup_detected_wam_c_kernels(&state);
+
+    wam_register_transitive_edge(&state, "tom", "bob");
+    wam_register_transitive_edge(&state, "bob", "ann");
+
+    WamValue args[2] = {
+        val_atom("tom"),
+        val_atom("ann")
+    };
+    int rc = wam_run_predicate(&state, "tc_ancestor/2", args, 2);
+    if (rc != 0 || state.P != WAM_HALT) {
         wam_free_state(&state);
         return 10;
     }
@@ -3116,9 +3304,11 @@ run_tests_once :-
     test_builtin_call_generation,
     test_call_foreign_generation,
     test_category_ancestor_kernel_generation,
+    test_transitive_closure_kernel_generation,
     test_fact_source_generation,
     test_streaming_foreign_results_generation,
     test_kernel_detector_setup_generation,
+    test_transitive_closure_detector_setup_generation,
     test_kernel_detector_project_generation,
     test_lowered_fact_helper_generation,
     test_lowered_helper_planner_metadata,
@@ -3140,9 +3330,11 @@ run_tests_once :-
     test_builtin_call_executable_smoke,
     test_call_foreign_executable_smoke,
     test_category_ancestor_kernel_executable_smoke,
+    test_transitive_closure_kernel_executable_smoke,
     test_fact_source_executable_smoke,
     test_lmdb_fact_source_executable_smoke,
     test_kernel_detector_executable_smoke,
+    test_transitive_closure_detector_executable_smoke,
     test_streaming_foreign_results_executable_smoke,
     test_real_prolog_builtin_executable_smoke,
     test_real_prolog_term_builtin_executable_smoke,


### PR DESCRIPTION
# Add WAM-C transitive closure kernel support

## Summary

- refreshes the WAM-C roadmap with the benchmark-demand scan results and next branch guidance
- adds C support for the shared `transitive_closure2` recursive-kernel detector
- emits detected-kernel setup for `transitive_closure2` via `wam_register_transitive_closure_kernel`
- adds a native arity-2 C foreign handler over registered in-memory edges
- covers both direct registration and detected-project execution for `tc_ancestor/2`

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/test_wam_c_lowered_helper_scale_regression.py`
- `git diff --check`

## Notes

This PR includes the prior roadmap investigation commit because this branch was
started from `investigate/wam-c-next-benchmark-demand`. The implementation
commit adds the first post-investigation shared-kernel parity slice.
