### PR TITLE
feat(csharp-query): route configured prebuilt artifacts by policy

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -4785,6 +4785,130 @@ namespace UnifyWeaver.QueryRuntime
         }
     }
 
+    public sealed class PredicateRoutingRelationProvider : IRetentionAwareRelationProvider, IIndexedRelationProvider, IIndexedRelationBucketProvider, IIndexedRelationBucketJoinProvider, IRelationCardinalityProvider
+    {
+        private readonly IRelationProvider _fallback;
+        private readonly Dictionary<PredicateId, IRelationProvider> _providers = new();
+
+        public PredicateRoutingRelationProvider(IRelationProvider fallback)
+        {
+            _fallback = fallback ?? throw new ArgumentNullException(nameof(fallback));
+        }
+
+        public void Register(PredicateId predicate, IRelationProvider provider)
+        {
+            _providers[predicate] = provider ?? throw new ArgumentNullException(nameof(provider));
+        }
+
+        public IEnumerable<object[]> GetFacts(PredicateId predicate)
+        {
+            return Resolve(predicate).GetFacts(predicate);
+        }
+
+        public bool TryBindRelation(PredicateId predicate, RelationRetentionMode preferredMode, out RelationBinding binding)
+        {
+            if (Resolve(predicate) is IRetentionAwareRelationProvider provider &&
+                provider.TryBindRelation(predicate, preferredMode, out binding))
+            {
+                return true;
+            }
+
+            binding = default;
+            return false;
+        }
+
+        public bool TryLookupFacts(PredicateId predicate, int columnIndex, IEnumerable<object> keys, out IEnumerable<object[]> facts)
+        {
+            if (Resolve(predicate) is IIndexedRelationProvider provider &&
+                provider.TryLookupFacts(predicate, columnIndex, keys, out facts))
+            {
+                return true;
+            }
+
+            facts = default!;
+            return false;
+        }
+
+        public bool TryReadIndexedBuckets(PredicateId predicate, int columnIndex, out IEnumerable<IndexedRelationBucket> buckets)
+        {
+            if (Resolve(predicate) is IIndexedRelationBucketProvider provider &&
+                provider.TryReadIndexedBuckets(predicate, columnIndex, out buckets))
+            {
+                return true;
+            }
+
+            buckets = default!;
+            return false;
+        }
+
+        public bool TryReadBucketJoinRows(
+            PredicateId leftPredicate,
+            int leftColumnIndex,
+            object[]? leftPattern,
+            Func<object[], bool>? leftFilter,
+            PredicateId rightPredicate,
+            int rightColumnIndex,
+            object[]? rightPattern,
+            Func<object[], bool>? rightFilter,
+            KeyJoinNode join,
+            out IEnumerable<object[]> rows)
+        {
+            if (_providers.TryGetValue(leftPredicate, out var leftProvider) &&
+                ReferenceEquals(leftProvider, Resolve(rightPredicate)) &&
+                leftProvider is IIndexedRelationBucketJoinProvider bucketJoinProvider &&
+                bucketJoinProvider.TryReadBucketJoinRows(
+                    leftPredicate,
+                    leftColumnIndex,
+                    leftPattern,
+                    leftFilter,
+                    rightPredicate,
+                    rightColumnIndex,
+                    rightPattern,
+                    rightFilter,
+                    join,
+                    out rows))
+            {
+                return true;
+            }
+
+            if (_fallback is IIndexedRelationBucketJoinProvider bucketJoinFallback &&
+                bucketJoinFallback.TryReadBucketJoinRows(
+                    leftPredicate,
+                    leftColumnIndex,
+                    leftPattern,
+                    leftFilter,
+                    rightPredicate,
+                    rightColumnIndex,
+                    rightPattern,
+                    rightFilter,
+                    join,
+                    out rows))
+            {
+                return true;
+            }
+
+            rows = default!;
+            return false;
+        }
+
+        public bool TryGetRelationCardinality(PredicateId predicate, out long rowCount)
+        {
+            if (Resolve(predicate) is IRelationCardinalityProvider provider &&
+                provider.TryGetRelationCardinality(predicate, out rowCount))
+            {
+                return true;
+            }
+
+            rowCount = 0;
+            return false;
+        }
+
+        private IRelationProvider Resolve(PredicateId predicate)
+        {
+            return _providers.TryGetValue(predicate, out var provider) ? provider : _fallback;
+        }
+    }
+
     internal sealed class CachedResultRows
     {
         private readonly IReadOnlyList<object[]>? _objectRows;
@@ -5266,6 +5390,7 @@ namespace UnifyWeaver.QueryRuntime
     public sealed class ConfiguredDelimitedRelationProvider
     {
         private readonly List<RelationSourceRegistrationTrace> _registrations = new();
+        private PredicateRoutingRelationProvider? _policyArtifactProvider;
 
         public RelationSourceMode SourceMode { get; }
 
@@ -5275,7 +5400,7 @@ namespace UnifyWeaver.QueryRuntime
 
         public DelimitedRelationArtifactProvider? DelimitedArtifactProvider { get; }
 
-        public IRelationProvider Provider => (IRelationProvider?)ArtifactProvider ?? (IRelationProvider?)DelimitedArtifactProvider ?? MemoryProvider;
+        public IRelationProvider Provider => _policyArtifactProvider ?? (IRelationProvider?)ArtifactProvider ?? (IRelationProvider?)DelimitedArtifactProvider ?? MemoryProvider;
 
         public string? ArtifactDirectory { get; }
 
@@ -5368,6 +5493,57 @@ namespace UnifyWeaver.QueryRuntime
             }
         }
 
+        public bool RegisterPolicyGuidedPrebuiltArtifacts(
+            PredicateId predicate,
+            string preferredStorageKind,
+            IEnumerable<string> manifestPaths,
+            IEnumerable<IRelationArtifactProviderFactory>? factories = null)
+        {
+            if (preferredStorageKind is null) throw new ArgumentNullException(nameof(preferredStorageKind));
+            EnsurePrebuiltArtifactMode();
+
+            if (!RelationArtifactProviderOpenPolicy.TryOpenPreferred(
+                predicate,
+                manifestPaths,
+                preferredStorageKind,
+                MemoryProvider,
+                factories,
+                out var opened))
+            {
+                return false;
+            }
+
+            RegisterPolicyArtifactProvider(predicate, opened);
+            return true;
+        }
+
+        public bool RegisterEffectiveDistancePrebuiltArtifacts(
+            PredicateId predicate,
+            string relationName,
+            long rowCount,
+            RelationArtifactAccessShape accessShape,
+            IEnumerable<string> manifestPaths,
+            IEnumerable<IRelationArtifactProviderFactory>? factories = null)
+        {
+            EnsurePrebuiltArtifactMode();
+
+            if (!RelationArtifactProviderOpenPolicy.TryOpenEffectiveDistanceArtifact(
+                predicate,
+                relationName,
+                rowCount,
+                accessShape,
+                manifestPaths,
+                MemoryProvider,
+                factories,
+                out var opened))
+            {
+                return false;
+            }
+
+            RegisterPolicyArtifactProvider(predicate, opened);
+            return true;
+        }
+
         private void RecordRegistration(PredicateId predicate, string storageKind)
         {
             _registrations.Add(new RelationSourceRegistrationTrace(
@@ -5375,6 +5551,22 @@ namespace UnifyWeaver.QueryRuntime
                 SourceMode,
                 storageKind,
                 predicate.Arity));
+        }
+
+        private void EnsurePrebuiltArtifactMode()
+        {
+            if (SourceMode != RelationSourceMode.ArtifactPrebuilt)
+            {
+                throw new InvalidOperationException("Policy-guided prebuilt artifact registration requires ArtifactPrebuilt source mode.");
+            }
+        }
+
+        private void RegisterPolicyArtifactProvider(PredicateId predicate, RelationArtifactProviderOpenResult opened)
+        {
+            _policyArtifactProvider ??= new PredicateRoutingRelationProvider(
+                (IRelationProvider?)ArtifactProvider ?? (IRelationProvider?)DelimitedArtifactProvider ?? MemoryProvider);
+            _policyArtifactProvider.Register(predicate, opened.Provider);
+            RecordRegistration(predicate, opened.StorageKind);
         }
     }
 

--- a/tests/test_csharp_query_source_mode_policy.py
+++ b/tests/test_csharp_query_source_mode_policy.py
@@ -166,9 +166,12 @@ class CSharpQuerySourceModePolicyTests(unittest.TestCase):
             "public sealed record RelationArtifactProviderOpenResult",
             "public interface IRelationArtifactProviderFactory",
             "public sealed class DefaultRelationArtifactProviderFactory",
+            "public sealed class PredicateRoutingRelationProvider",
             "public static class RelationArtifactProviderOpenPolicy",
             "TryOpenPreferred(",
             "TryOpenEffectiveDistanceArtifact(",
+            "RegisterPolicyGuidedPrebuiltArtifacts(",
+            "RegisterEffectiveDistancePrebuiltArtifacts(",
             "new[] { new DefaultRelationArtifactProviderFactory() }",
             "BinaryRelationArtifactManifest.CurrentFormat:",
             "DelimitedRelationArtifactManifest.CurrentFormat:",
@@ -399,6 +402,102 @@ sealed class ThrowingRelationArtifactProviderFactory : IRelationArtifactProvider
         result = default!;
         throw new InvalidDataException("wrong manifest format for this provider");
     }
+}
+""",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                ["dotnet", "run", "--project", str(project_path)],
+                cwd=tmp_path,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=120,
+            )
+            self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+
+    def test_configured_provider_policy_guided_prebuilt_artifact_smoke(self) -> None:
+        if shutil.which("dotnet") is None:
+            self.skipTest("dotnet is not available")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            project_path = tmp_path / "ConfiguredPolicyArtifactSmoke.csproj"
+            program_path = tmp_path / "Program.cs"
+            project_path.write_text(
+                f"""\
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="{QUERY_RUNTIME_PROJECT}" />
+  </ItemGroup>
+</Project>
+""",
+                encoding="utf-8",
+            )
+            program_path.write_text(
+                """\
+using UnifyWeaver.QueryRuntime;
+
+static void Assert(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException(message);
+    }
+}
+
+var root = Path.Combine(Path.GetTempPath(), "uw-configured-policy-artifact-" + Guid.NewGuid().ToString("N"));
+Directory.CreateDirectory(root);
+var inputPath = Path.Combine(root, "article_category.tsv");
+File.WriteAllText(inputPath, "article\\tcategory\\n1\\t10\\n1\\t11\\n2\\t11\\n");
+
+var predicate = new PredicateId("article_category", 2);
+var source = new DelimitedRelationSource(inputPath, '\t', 1, 2);
+var binaryManifest = BinaryRelationArtifactBuilder.BuildFromDelimited(predicate, source, Path.Combine(root, "binary"));
+var mmapManifest = MmapArrayRelationArtifactBuilder.BuildFromDelimited(predicate, source, Path.Combine(root, "mmap"));
+
+var fallbackPredicate = new PredicateId("fallback_relation", 1);
+var configuredProvider = new ConfiguredDelimitedRelationProvider(RelationSourceMode.ArtifactPrebuilt);
+configuredProvider.MemoryProvider.AddFact(fallbackPredicate, "fallback");
+
+Assert(
+    configuredProvider.RegisterEffectiveDistancePrebuiltArtifacts(
+        predicate,
+        "article_category",
+        1_000_000,
+        RelationArtifactAccessShape.LookupColumn0,
+        new[] { binaryManifest, mmapManifest }),
+    "policy-guided configured registration failed");
+
+var registration = configuredProvider.SnapshotRegistrations().Single();
+Assert(registration.StorageKind == RelationArtifactAccessPolicy.MmapArrayArtifactStorageKind, $"storage kind was {registration.StorageKind}");
+Assert(configuredProvider.Provider.GetFacts(predicate).Count() == 3, "configured provider did not read prebuilt rows");
+Assert(configuredProvider.Provider.GetFacts(fallbackPredicate).Single()[0].Equals("fallback"), "configured provider did not preserve fallback memory rows");
+
+Assert(configuredProvider.Provider is IIndexedRelationProvider, "configured provider should expose indexed provider interface");
+var indexedProvider = (IIndexedRelationProvider)configuredProvider.Provider;
+Assert(indexedProvider.TryLookupFacts(predicate, 0, new object[] { 1 }, out var lookupRows), "indexed lookup failed");
+Assert(lookupRows.Count() == 2, "indexed lookup returned wrong row count");
+
+try
+{
+    var preloadProvider = new ConfiguredDelimitedRelationProvider(RelationSourceMode.Preload);
+    preloadProvider.RegisterPolicyGuidedPrebuiltArtifacts(
+        predicate,
+        RelationArtifactAccessPolicy.MmapArrayArtifactStorageKind,
+        new[] { mmapManifest });
+    throw new InvalidOperationException("preload source mode should reject prebuilt artifact registration");
+}
+catch (InvalidOperationException)
+{
 }
 """,
                 encoding="utf-8",


### PR DESCRIPTION
# Route configured prebuilt artifacts through source policy
  
  ## Summary

  - Adds a predicate-routing relation provider so configured C# query providers can route specific predicates to policy-
  selected artifact providers while preserving fallback rows.
  - Adds configured-provider helpers for policy-guided prebuilt artifact registration, including effective-distance access-
  shape policy selection.
  - Extends the C# policy smoke tests to verify mmap selection, fallback behavior, indexed lookup support, and rejection
  outside `ArtifactPrebuilt` mode.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py`
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj`
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
  - `git diff --check`