### PR TITLE
feat(wam-c): add transitive distance kernel

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,7 +4,7 @@ Status date: 2026-05-16
 
 Base verified locally:
 
-- `main` at `a20d6d75` (`Merge pull request #2202 from s243a/test/wam-c-builtins-real-prolog-smoke`)
+- `main` at `64c67e47` (`Merge pull request #2215 from s243a/feat/wam-c-transitive-closure-kernel`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
@@ -17,7 +17,7 @@ Base verified locally:
 
 Active branch:
 
-- `feat/wam-c-transitive-closure-kernel`
+- `feat/wam-c-transitive-distance-kernel`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -74,6 +74,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Generated Prolog builtin parity smoke | Done | Generated WAM-to-C executable smoke exercises `functor/3`, `arg/3`, and `atom_concat/3` together |
 | Benchmark-demand scan | Done | `dev`/`10x` accumulated TSV+LMDB C targets and `dev`/`10x` lowered-helper targets preserve output parity; accumulated C kernel path shows no meaningful speedup over no-kernels and is much slower than optimized Prolog at `10x` |
 | `transitive_closure2` native kernel | Done | C shared-kernel detector accepts `transitive_closure2`, emits detected setup, registers a native arity-2 foreign handler, and covers direct plus detected-project executable smokes |
+| `transitive_distance3` native kernel | Done | C shared-kernel detector accepts `transitive_distance3`, emits detected setup, registers a native arity-3 foreign handler, and covers direct plus detected-project executable smokes |
 
 ## Current C Target Baseline
 
@@ -98,8 +99,8 @@ The C target is now a credible small WAM backend:
 - Can opt into a prototype lowered-helper path for constant fact-only
   predicates, plus same-arity alias bodies that call those native fact helpers,
   emitted as native C foreign handlers behind `call_foreign` trampolines.
-- Supports deterministic native `category_ancestor/4` and `transitive_closure2`
-  handlers over an in-memory edge table.
+- Supports deterministic native `category_ancestor/4`, `transitive_closure2`,
+  and `transitive_distance3` handlers over an in-memory edge table.
 - Supports loading category-parent facts from TSV through a small
   `WamFactSource` interface.
 - Supports collecting all integer hop results for native `category_ancestor/4`
@@ -144,8 +145,8 @@ missing important target features; `Missing` = no comparable C path yet.
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
 | Negation / control builtins | Partial | Broader | Broader | C likely needs explicit tests for `\+/1`, cut interactions, and if-then-else lowering. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
-| Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, and native `transitive_closure2`; continue adding shared kernels one at a time. |
-| Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4` and `transitive_closure2`; Haskell and Rust cover a broader shared-kernel registry. |
+| Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native `transitive_closure2`, and native `transitive_distance3`; continue adding shared kernels one at a time. |
+| Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`, `transitive_closure2`, and `transitive_distance3`; Haskell and Rust cover a broader shared-kernel registry. |
 | Lowered/native helper functions | Partial/Done | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, comparison-filter helpers, rejection metadata, repeated-variable filter hardening, empty-result rejection metadata, and projected body-call helper expansion. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
@@ -156,16 +157,19 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-transitive-distance-kernel`
+### 1. `feat/wam-c-transitive-parent-distance-kernel`
 
 Goal: add the next shared recursive kernel to C from the Haskell/Rust parity
-surface, continuing from `transitive_closure2` to `transitive_distance3`.
+surface, continuing from `transitive_distance3` to
+`transitive_parent_distance4`.
 
 Scope:
 
 - Extend the C recursive-kernel registration path beyond `category_ancestor/4`
-  and `transitive_closure2` for the shared `transitive_distance3` detector.
-- Add a native C handler and executable smoke for a small binary edge distance.
+  and the existing transitive kernels for the shared
+  `transitive_parent_distance4` detector.
+- Add a native C handler and executable smoke for a small binary edge
+  parent-distance result.
 - Keep TSV/LMDB fact loading out of scope unless the small in-memory kernel
   path exposes a need for it.
 
@@ -173,13 +177,13 @@ Status: recommended next.
 
 Reason:
 
-- `transitive_closure2` is now covered through direct native registration and
+- `transitive_distance3` is now covered through direct native registration and
   detected-project setup.
 - `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` records
-  `transitive_distance3/3` as a measured Haskell multi-output kernel benchmark,
-  so it is a better C parity target than another speculative builtin.
-- Haskell and Rust already cover `transitive_distance3`; it can reuse the edge
-  traversal surface while adding an integer distance output.
+  `transitive_parent_distance4` alongside `transitive_distance3` as part of the
+  measured wide-output BFS kernel set.
+- Haskell and Rust already cover `transitive_parent_distance4`; it can reuse the
+  edge traversal surface while adding a parent output.
 
 ### 2. `investigate/wam-c-accumulated-runtime-cost`
 
@@ -234,6 +238,21 @@ Performance note:
   dispatch as the meaningful hybrid-WAM speedup lever. For C, the immediate
   goal should stay on broadening native shared kernels before tuning the general
   WAM instruction dispatch loop.
+
+### Completed Shared Kernel Slice: `feat/wam-c-transitive-distance-kernel`
+
+Goal: add the next measured shared recursive kernel to C from the Haskell/Rust
+parity surface.
+
+Evidence:
+
+| Surface | Coverage |
+|---|---|
+| Kernel support predicate | `wam_c_supported_kernel/1` accepts `recursive_kernel(transitive_distance3, ...)`. |
+| Detected setup emission | `generate_setup_detected_kernels_c/2` emits `wam_register_transitive_distance_kernel`. |
+| Runtime handler | `wam_transitive_distance_handler` supports bound-target reachability, first-solution unbound target mode, and integer distance binding over registered in-memory edges. |
+| Direct executable smoke | `tc_distance/3` succeeds for direct and recursive edges, binds an unbound target and distance, accepts a bound distance, and fails for a reversed edge. |
+| Detected-project smoke | Generated project detection lowers `tc_distance/3` to a `call_foreign` trampoline and runs through `setup_detected_wam_c_kernels`. |
 
 ## Completed Atom Concat Builtin
 
@@ -312,9 +331,9 @@ After hash-bucket row dispatch but before compact row tables:
 
 ## Suggested Immediate Next Step
 
-Proceed with `feat/wam-c-transitive-distance-kernel`.
+Proceed with `feat/wam-c-transitive-parent-distance-kernel`.
 
-Keep it narrow: add `transitive_distance3` over the same in-memory edge surface
-and prove direct plus detected-project executable smokes. Treat broader fact
-storage, LMDB loading, and runtime profiling as follow-up branches unless this
-slice exposes a direct blocker.
+Keep it narrow: add `transitive_parent_distance4` over the same in-memory edge
+surface and prove direct plus detected-project executable smokes. Treat broader
+fact storage, LMDB loading, and runtime profiling as follow-up branches unless
+this slice exposes a direct blocker.

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -250,8 +250,10 @@ void wam_register_category_parent(WamState *state, const char *child, const char
 void wam_register_transitive_edge(WamState *state, const char *child, const char *parent);
 void wam_register_category_ancestor_kernel(WamState *state, const char *pred, int max_depth);
 void wam_register_transitive_closure_kernel(WamState *state, const char *pred);
+void wam_register_transitive_distance_kernel(WamState *state, const char *pred);
 bool wam_category_ancestor_handler(WamState *state, const char *pred, int arity);
 bool wam_transitive_closure_handler(WamState *state, const char *pred, int arity);
+bool wam_transitive_distance_handler(WamState *state, const char *pred, int arity);
 void wam_fact_source_init(WamFactSource *source);
 void wam_fact_source_close(WamFactSource *source);
 bool wam_fact_source_load_tsv(WamState *state, WamFactSource *source, const char *path);

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -133,6 +133,7 @@ detect_kernels([PI|Rest], Kernels) :-
 
 wam_c_supported_kernel(recursive_kernel(category_ancestor, _Pred, _ConfigOps)).
 wam_c_supported_kernel(recursive_kernel(transitive_closure2, _Pred, _ConfigOps)).
+wam_c_supported_kernel(recursive_kernel(transitive_distance3, _Pred, _ConfigOps)).
 
 %% generate_setup_detected_kernels_c(+DetectedKernels, -CCode)
 %  Emit C startup wiring for detected kernels. This function registers only
@@ -154,6 +155,10 @@ wam_c_kernel_registration_line(Key-recursive_kernel(category_ancestor, _Pred, Co
 wam_c_kernel_registration_line(Key-recursive_kernel(transitive_closure2, _Pred, _ConfigOps), Line) :-
     format(atom(Line),
            '    wam_register_transitive_closure_kernel(state, "~w");',
+           [Key]).
+wam_c_kernel_registration_line(Key-recursive_kernel(transitive_distance3, _Pred, _ConfigOps), Line) :-
+    format(atom(Line),
+           '    wam_register_transitive_distance_kernel(state, "~w");',
            [Key]).
 
 wam_c_kernel_max_depth(ConfigOps, MaxDepth) :-
@@ -2450,6 +2455,10 @@ void wam_register_transitive_closure_kernel(WamState *state, const char *pred) {
     wam_register_foreign_predicate(state, pred, 2, wam_transitive_closure_handler);
 }
 
+void wam_register_transitive_distance_kernel(WamState *state, const char *pred) {
+    wam_register_foreign_predicate(state, pred, 3, wam_transitive_distance_handler);
+}
+
 static bool wam_value_as_atom(WamState *state, WamValue value, const char **out) {
     WamValue *cell = wam_deref_ptr(state, &value);
     if (cell->tag != VAL_ATOM) return false;
@@ -2638,6 +2647,71 @@ bool wam_transitive_closure_handler(WamState *state, const char *pred, int arity
 
     WamValue result_value = val_atom(result);
     return wam_unify(state, &state->A[1], &result_value);
+}
+
+static bool wam_transitive_distance_bfs(WamState *state,
+                                        const char *start,
+                                        const char *target,
+                                        const char **target_out,
+                                        int *distance_out) {
+    const char *queue_nodes[256];
+    int queue_distances[256];
+    const char *visited[256];
+    int head = 0;
+    int tail = 0;
+    int visited_len = 0;
+
+    queue_nodes[tail] = start;
+    queue_distances[tail++] = 0;
+    visited[visited_len++] = start;
+
+    while (head < tail) {
+        const char *node = queue_nodes[head];
+        int distance = queue_distances[head++];
+        for (int i = 0; i < state->category_edge_count; i++) {
+            CategoryEdge *edge = &state->category_edges[i];
+            if (strcmp(edge->child, node) != 0) continue;
+            if (wam_visited_array_contains(visited, visited_len, edge->parent)) continue;
+            int next_distance = distance + 1;
+            if (!target || strcmp(edge->parent, target) == 0) {
+                *target_out = edge->parent;
+                *distance_out = next_distance;
+                return true;
+            }
+            if (tail >= 256 || visited_len >= 256) return false;
+            visited[visited_len++] = edge->parent;
+            queue_nodes[tail] = edge->parent;
+            queue_distances[tail++] = next_distance;
+        }
+    }
+    return false;
+}
+
+bool wam_transitive_distance_handler(WamState *state, const char *pred, int arity) {
+    (void)pred;
+    if (arity != 3) return false;
+
+    const char *start = NULL;
+    if (!wam_value_as_atom(state, state->A[0], &start)) return false;
+
+    WamValue *target_cell = wam_deref_ptr(state, &state->A[1]);
+    const char *target = NULL;
+    if (target_cell->tag == VAL_ATOM) {
+        target = target_cell->data.atom;
+    } else if (!val_is_unbound(*target_cell)) {
+        return false;
+    }
+
+    const char *result_target = NULL;
+    int result_distance = 0;
+    if (!wam_transitive_distance_bfs(state, start, target, &result_target, &result_distance)) {
+        return false;
+    }
+
+    WamValue target_value = val_atom(result_target);
+    WamValue distance_value = val_int(result_distance);
+    return wam_unify(state, &state->A[1], &target_value) &&
+           wam_unify(state, &state->A[2], &distance_value);
 }
 '.
 

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -277,6 +277,17 @@ test_transitive_closure_kernel_generation :-
     ;   fail_test(Test, 'transitive_closure2 native kernel helpers missing')
     ).
 
+test_transitive_distance_kernel_generation :-
+    Test = 'WAM-C: transitive_distance3 native kernel helpers generated',
+    (   compile_wam_runtime_to_c([], RuntimeCode),
+        atom_string(RuntimeCode, S),
+        sub_string(S, _, _, _, 'void wam_register_transitive_distance_kernel'),
+        sub_string(S, _, _, _, 'bool wam_transitive_distance_handler'),
+        sub_string(S, _, _, _, 'wam_transitive_distance_bfs')
+    ->  pass(Test)
+    ;   fail_test(Test, 'transitive_distance3 native kernel helpers missing')
+    ).
+
 test_fact_source_generation :-
     Test = 'WAM-C: file FactSource helpers generated',
     (   compile_wam_runtime_to_c([], RuntimeCode),
@@ -328,6 +339,20 @@ test_transitive_closure_detector_setup_generation :-
         pass(Test)
     ;   cleanup_wam_c_detector_transitive_closure,
         fail_test(Test, 'detected transitive_closure2 setup missing')
+    ).
+
+test_transitive_distance_detector_setup_generation :-
+    Test = 'WAM-C: shared kernel detector emits transitive_distance3 setup',
+    setup_wam_c_detector_transitive_distance,
+    (   detect_kernels([user:tc_distance/3], Detected),
+        Detected = ['tc_distance/3'-_Kernel],
+        generate_setup_detected_kernels_c(Detected, SetupCode),
+        sub_atom(SetupCode, _, _, _, 'setup_detected_wam_c_kernels'),
+        sub_atom(SetupCode, _, _, _, 'wam_register_transitive_distance_kernel(state, "tc_distance/3")')
+    ->  cleanup_wam_c_detector_transitive_distance,
+        pass(Test)
+    ;   cleanup_wam_c_detector_transitive_distance,
+        fail_test(Test, 'detected transitive_distance3 setup missing')
     ).
 
 test_kernel_detector_project_generation :-
@@ -910,6 +935,16 @@ test_transitive_closure_kernel_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_transitive_distance_kernel_executable_smoke :-
+    Test = 'WAM-C: transitive_distance3 native kernel executable smoke',
+    (   gcc_available
+    ->  (   run_transitive_distance_kernel_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'transitive_distance3 native kernel executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_fact_source_executable_smoke :-
     Test = 'WAM-C: file FactSource executable smoke',
     (   gcc_available
@@ -957,6 +992,16 @@ test_transitive_closure_detector_executable_smoke :-
     ->  (   run_transitive_closure_detector_executable_smoke
         ->  pass(Test)
         ;   fail_test(Test, 'detected transitive_closure2 executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
+test_transitive_distance_detector_executable_smoke :-
+    Test = 'WAM-C: detected transitive_distance3 executable smoke',
+    (   gcc_available
+    ->  (   run_transitive_distance_detector_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'detected transitive_distance3 executable failed')
         )
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
@@ -1258,6 +1303,25 @@ run_transitive_closure_kernel_executable_smoke :-
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
 
+run_transitive_distance_kernel_executable_smoke :-
+    WamCode = 'tc_distance/3:\n    call_foreign tc_distance/3, 3\n    proceed',
+    compile_wam_predicate_to_c(user:tc_distance/3, WamCode, [], PredCode),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_transitive_distance_smoke', Stamp, TmpBase),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(RuntimePath, RuntimeCode),
+    format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+    write_text_file(PredPath, PredTranslationUnit),
+    wam_c_transitive_distance_smoke_main(MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
 run_fact_source_executable_smoke :-
     WamCode = 'category_ancestor/4:\n    call_foreign category_ancestor/4, 4\n    proceed',
     compile_wam_predicate_to_c(user:category_ancestor/4, WamCode, [], PredCode),
@@ -1334,6 +1398,25 @@ run_transitive_closure_detector_executable_smoke :-
         run_c_smoke_plain(ExePath)
     ->  cleanup_wam_c_detector_transitive_closure
     ;   cleanup_wam_c_detector_transitive_closure,
+        fail
+    ).
+
+run_transitive_distance_detector_executable_smoke :-
+    setup_wam_c_detector_transitive_distance,
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_distance_detector_smoke', Stamp, ProjectDir),
+    directory_file_path(ProjectDir, 'wam_runtime.c', RuntimePath),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    directory_file_path(ProjectDir, 'main.c', MainPath),
+    directory_file_path(ProjectDir, 'wam_c_distance_detector_smoke', ExePath),
+    (   write_wam_c_project([user:tc_distance/3], [], ProjectDir),
+        wam_c_transitive_distance_detector_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, LibPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_detector_transitive_distance
+    ;   cleanup_wam_c_detector_transitive_distance,
         fail
     ).
 
@@ -1821,6 +1904,22 @@ cleanup_wam_c_detector_transitive_closure :-
     retractall(user:tc_parent(_, _)),
     retractall(user:tc_ancestor(_, _)).
 
+setup_wam_c_detector_transitive_distance :-
+    cleanup_wam_c_detector_transitive_distance,
+    assertz((user:td_parent(tom, bob))),
+    assertz((user:td_parent(bob, ann))),
+    assertz((user:td_parent(bob, pat))),
+    assertz((user:tc_distance(X, Y, 1) :-
+        td_parent(X, Y))),
+    assertz((user:tc_distance(X, Y, D) :-
+        td_parent(X, Z),
+        tc_distance(Z, Y, D0),
+        D is D0 + 1)).
+
+cleanup_wam_c_detector_transitive_distance :-
+    retractall(user:td_parent(_, _)),
+    retractall(user:tc_distance(_, _, _)).
+
 run_c_smoke(ExePath) :-
     format(atom(LogPath), '~w.asan.log', [ExePath]),
     run_c_smoke_once(ExePath, LogPath, Status),
@@ -2254,6 +2353,72 @@ int main(void) {
 }
 ').
 
+wam_c_transitive_distance_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_tc_distance_3(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_tc_distance_3(&state);
+    wam_register_transitive_edge(&state, "tom", "bob");
+    wam_register_transitive_edge(&state, "bob", "ann");
+    wam_register_transitive_edge(&state, "bob", "pat");
+    wam_register_transitive_distance_kernel(&state, "tc_distance/3");
+
+    WamValue recursive_args[3] = {
+        val_atom("tom"),
+        val_atom("ann"),
+        val_unbound("Distance")
+    };
+    int recursive_rc = wam_run_predicate(&state, "tc_distance/3", recursive_args, 3);
+    if (recursive_rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 2) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue direct_args[3] = {
+        val_atom("tom"),
+        val_atom("bob"),
+        val_int(1)
+    };
+    int direct_rc = wam_run_predicate(&state, "tc_distance/3", direct_args, 3);
+    if (direct_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue output_args[3] = {
+        val_atom("bob"),
+        val_unbound("Target"),
+        val_unbound("Distance")
+    };
+    int output_rc = wam_run_predicate(&state, "tc_distance/3", output_args, 3);
+    if (output_rc != 0 || state.P != WAM_HALT ||
+        state.A[1].tag != VAL_ATOM || strcmp(state.A[1].data.atom, "ann") != 0 ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 1) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    WamValue fail_args[3] = {
+        val_atom("ann"),
+        val_atom("tom"),
+        val_unbound("Distance")
+    };
+    int fail_rc = wam_run_predicate(&state, "tc_distance/3", fail_args, 3);
+    if (fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_kernel_detector_smoke_main(
 '#include "wam_runtime.h"
 
@@ -2317,6 +2482,38 @@ int main(void) {
     };
     int rc = wam_run_predicate(&state, "tc_ancestor/2", args, 2);
     if (rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
+wam_c_transitive_distance_detector_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_tc_distance_3(WamState* state);
+void setup_detected_wam_c_kernels(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_tc_distance_3(&state);
+    setup_detected_wam_c_kernels(&state);
+
+    wam_register_transitive_edge(&state, "tom", "bob");
+    wam_register_transitive_edge(&state, "bob", "ann");
+
+    WamValue args[3] = {
+        val_atom("tom"),
+        val_atom("ann"),
+        val_unbound("Distance")
+    };
+    int rc = wam_run_predicate(&state, "tc_distance/3", args, 3);
+    if (rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 2) {
         wam_free_state(&state);
         return 10;
     }
@@ -3305,10 +3502,12 @@ run_tests_once :-
     test_call_foreign_generation,
     test_category_ancestor_kernel_generation,
     test_transitive_closure_kernel_generation,
+    test_transitive_distance_kernel_generation,
     test_fact_source_generation,
     test_streaming_foreign_results_generation,
     test_kernel_detector_setup_generation,
     test_transitive_closure_detector_setup_generation,
+    test_transitive_distance_detector_setup_generation,
     test_kernel_detector_project_generation,
     test_lowered_fact_helper_generation,
     test_lowered_helper_planner_metadata,
@@ -3331,10 +3530,12 @@ run_tests_once :-
     test_call_foreign_executable_smoke,
     test_category_ancestor_kernel_executable_smoke,
     test_transitive_closure_kernel_executable_smoke,
+    test_transitive_distance_kernel_executable_smoke,
     test_fact_source_executable_smoke,
     test_lmdb_fact_source_executable_smoke,
     test_kernel_detector_executable_smoke,
     test_transitive_closure_detector_executable_smoke,
+    test_transitive_distance_detector_executable_smoke,
     test_streaming_foreign_results_executable_smoke,
     test_real_prolog_builtin_executable_smoke,
     test_real_prolog_term_builtin_executable_smoke,


### PR DESCRIPTION
# Add WAM-C transitive distance kernel support

## Summary

- adds C support for the shared `transitive_distance3` recursive-kernel detector
- emits detected-kernel setup for `transitive_distance3` via `wam_register_transitive_distance_kernel`
- adds a native arity-3 C foreign handler over registered in-memory edges
- covers direct and detected-project execution for `tc_distance/3`
- refreshes the WAM-C roadmap and points the next shared-kernel slice at `transitive_parent_distance4`

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/test_wam_c_lowered_helper_scale_regression.py`
- `git diff --check`

## Notes

This branch is a narrow continuation of the shared-kernel parity work after
`transitive_closure2`. It keeps TSV/LMDB fact loading and runtime profiling out
of scope, using the existing in-memory edge surface for the first
`transitive_distance3` C slice.
