### PR TITLE
feat(wam-elixir): bagof/3 + setof/3 basics via inlining

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -1533,6 +1533,12 @@ instr_from_parts(["switch_on_constant"|Entries], switch_on_constant(Entries)).
 instr_from_parts(["switch_on_constant_a2"|Entries], switch_on_constant_a2(Entries)).
 instr_from_parts(["proceed"], proceed).
 instr_from_parts(["begin_aggregate", Type, ValReg, ResReg], begin_aggregate(Type, ValReg, ResReg)).
+% bagof/setof inlining (inline_bagof_setof(true)) emits a 4th token —
+% the witness/quantifier list — that the WAM compiler uses for group
+% backtracking. PR 1 ignores the witness (no grouping yet); future
+% witness-group PR can read it.
+instr_from_parts(["begin_aggregate", Type, ValReg, ResReg, _Witness],
+                 begin_aggregate(Type, ValReg, ResReg)).
 instr_from_parts(["end_aggregate", ValReg], end_aggregate(ValReg)).
 instr_from_parts(Parts, raw(Combined)) :-
     atomic_list_concat(Parts, ' ', Combined).

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -1450,6 +1450,18 @@ compile_utility_helpers_to_elixir(Code) :-
         # raised by execute_throw. See WAM_ELIXIR_GAPS_SPECIFICATION.md
         # PR #2 §4.
         execute_catch(state)
+      {"^/2", 2} ->
+        # Existential quantifier transparency. Var^Goal means
+        # "existentially quantify Var inside Goal" — for bagof/setof
+        # WITHOUT witness-group backtracking (PR 1 scope), this is
+        # just dispatch the Goal (A2) and ignore the binder (A1).
+        # Once witness grouping lands, the binder will be used to
+        # skip Var when computing free-variables-of-Goal.
+        #
+        # Load A2 into A1 and dispatch as a 1-arity meta-call.
+        goal_term = deref_var(state, get_reg(state, 2))
+        prepared = %{state | regs: Map.put(state.regs, 1, goal_term)}
+        dispatch_call_meta(prepared, 1, state.cp)
       {"throw/1", 1} ->
         # throw(Term). Deep-copy the term (independent of catch
         # boundary), then BEAM-throw {:wam_throw, copy} so the
@@ -2603,12 +2615,79 @@ compile_aggregate_helpers_to_elixir(Code) :-
                 is the canonical Prolog semantics for max/min over
                 an empty bag.
   """
+  # Standard order of terms (ISO §7.2): Var < Number < Atom <
+  # String < Compound. Within each class, natural ordering. Compound
+  # terms compare by arity then functor name then args (recursive).
+  # Used by :setof to produce sorted, dedup-ready output. Bag values
+  # are atomic (strings/numbers/atoms) or {:struct, "name/arity",
+  # [args]} from deep_copy_value/2 — the captured-value shape is
+  # what we sort.
+  def standard_term_compare(a, b) do
+    standard_term_compare_lt(a, b)
+  end
+
+  defp term_class({:unbound, _}), do: 0
+  defp term_class(v) when is_number(v), do: 1
+  defp term_class(v) when is_atom(v), do: 2
+  defp term_class(v) when is_binary(v), do: 3
+  defp term_class({:struct, _, _}), do: 4
+  defp term_class({:str, _}), do: 4
+  defp term_class({:ref, _}), do: 4
+  defp term_class(_), do: 5
+
+  defp standard_term_compare_lt(a, b) do
+    ca = term_class(a)
+    cb = term_class(b)
+    cond do
+      ca != cb -> ca <= cb
+      ca == 1 -> a <= b   # numbers
+      ca == 2 -> Atom.to_string(a) <= Atom.to_string(b)
+      ca == 3 -> a <= b   # binaries (atoms-as-strings + actual strings)
+      ca == 4 -> compound_lt(a, b)
+      true -> true        # fallback for unknowns; deterministic order
+    end
+  end
+
+  defp compound_lt({:struct, name_a, args_a}, {:struct, name_b, args_b}) do
+    arity_a = length(args_a)
+    arity_b = length(args_b)
+    cond do
+      arity_a != arity_b -> arity_a <= arity_b
+      name_a != name_b -> name_a <= name_b
+      true -> args_list_lt(args_a, args_b)
+    end
+  end
+  defp compound_lt(a, b), do: inspect(a) <= inspect(b)
+
+  defp args_list_lt([], []), do: true
+  defp args_list_lt([a | as], [b | bs]) do
+    cond do
+      a == b -> args_list_lt(as, bs)
+      true -> standard_term_compare_lt(a, b)
+    end
+  end
+  defp args_list_lt(_, _), do: true
+
   def finalise_aggregate(state, agg_cp, rest_cps, agg_type) do
     accum_rev = Enum.reverse(agg_cp.agg_accum)
     result =
       case agg_type do
         t when t in [:collect, :findall, :aggregate_all, :bag] -> accum_rev
         :set -> Enum.uniq(accum_rev)
+        # bagof/setof differ from bag/set in that they FAIL when no
+        # solutions exist (ISO semantics). bagof returns the list as-is;
+        # setof additionally sorts in standard term order + dedups.
+        :bagof ->
+          if accum_rev == [],
+            do: throw({:fail, state}),
+            else: accum_rev
+        :setof ->
+          if accum_rev == [],
+            do: throw({:fail, state}),
+            else:
+              accum_rev
+              |> Enum.sort(&standard_term_compare/2)
+              |> Enum.uniq()
         :sum -> Enum.sum(accum_rev)
         :count -> length(accum_rev)
         :max ->

--- a/tests/test_wam_elixir_classic_programs.pl
+++ b/tests/test_wam_elixir_classic_programs.pl
@@ -227,6 +227,66 @@ user:elx_compound_eq_mismatch_functor :- foo(1) = bar(1).
 % Arity mismatch fails (same name, different arity = different functor).
 user:elx_compound_eq_mismatch_arity :- foo(1, 2) = foo(1).
 
+% --- bagof/setof basics (follow-up) ---
+% Requires inline_bagof_setof(true) option on WAM-compile so the
+% compiler emits begin_aggregate bagof/setof inline rather than a
+% meta-call (which the Elixir runtime doesn't dispatch).
+%
+% Tests use multi-clause user facts rather than member/2 because
+% Elixir's member/2 builtin is a deterministic boolean check, not
+% an enumerator with choice points. Multi-clause facts give the
+% WAM compiler try_me_else / retry_me_else / trust_me dispatch
+% which IS the backtracking enumeration we need.
+:- dynamic user:bs_int/1.
+user:bs_int(1).
+user:bs_int(2).
+user:bs_int(3).
+:- dynamic user:bs_atom/1.
+user:bs_atom(c).
+user:bs_atom(a).
+user:bs_atom(b).
+:- dynamic user:bs_dup/1.
+user:bs_dup(a).
+user:bs_dup(b).
+user:bs_dup(a).
+user:bs_dup(c).
+user:bs_dup(b).
+:- dynamic user:bs_int_unsorted/1.
+user:bs_int_unsorted(3).
+user:bs_int_unsorted(1).
+user:bs_int_unsorted(2).
+:- dynamic user:bs_pair/2.
+user:bs_pair(a, 1).
+user:bs_pair(b, 2).
+user:bs_pair(c, 3).
+% bs_none/1 has one clause that always fails. Needs at least one
+% clause so the WAM compiler emits a predicate module (zero-clause
+% predicates fail to compile). The body's fail/0 makes enumeration
+% produce no solutions, which is what bagof_fails_empty needs.
+:- dynamic user:bs_none/1.
+user:bs_none(_) :- fail.
+
+:- dynamic user:elx_bagof_basic/1.
+:- dynamic user:elx_bagof_fails_empty/0.
+:- dynamic user:elx_setof_basic/1.
+:- dynamic user:elx_setof_dedups/1.
+:- dynamic user:elx_setof_sorts_ints/1.
+:- dynamic user:elx_bagof_with_quantifier/1.
+% bagof collects all solutions, returns the list.
+user:elx_bagof_basic(R) :- bagof(X, bs_int(X), R).
+% bagof fails when no solutions.
+user:elx_bagof_fails_empty :- bagof(_X, bs_none(_X), _R).
+% setof sorts atoms.
+user:elx_setof_basic(R) :- setof(X, bs_atom(X), R).
+% setof dedups.
+user:elx_setof_dedups(R) :- setof(X, bs_dup(X), R).
+% setof sorts integers in standard order.
+user:elx_setof_sorts_ints(R) :- setof(X, bs_int_unsorted(X), R).
+% ^/2 transparency: Y^bs_pair(X, Y) — Y existentially quantified.
+% The thrown ^/2 functor is dispatched transparently to its A2.
+user:elx_bagof_with_quantifier(R) :-
+    bagof(X, Y^bs_pair(X, Y), R).
+
 % ============================================================
 % elixir_available — same gating pattern as the Scala suite
 % ============================================================
@@ -579,6 +639,62 @@ test(compound_eq_mismatch_arity) :-
         verify_elixir_args(TmpDir, 'elx_compound_eq_mismatch_arity/0',
                            [], "false")).
 
+% --- bagof/setof tests ---
+% All pass inline_bagof_setof(true) so the WAM compiler inlines
+% bagof/setof into begin_aggregate / end_aggregate (which the Elixir
+% runtime already supports). Without this option the compiler emits
+% `execute bagof/3` which the Elixir runtime cannot dispatch (no
+% meta-call findall/bagof/setof; deferred to a separate PR).
+
+test(bagof_basic) :-
+    with_elixir_project(
+        [user:elx_bagof_basic/1, user:bs_int/1],
+        [inline_bagof_setof(true)],
+        TmpDir,
+        verify_elixir_args(TmpDir, 'elx_bagof_basic/1',
+                           ['[1,2,3]'], "true")).
+
+test(bagof_fails_empty) :-
+    with_elixir_project(
+        [user:elx_bagof_fails_empty/0, user:bs_none/1],
+        [inline_bagof_setof(true)],
+        TmpDir,
+        verify_elixir_args(TmpDir, 'elx_bagof_fails_empty/0',
+                           [], "false")).
+
+test(setof_basic) :-
+    with_elixir_project(
+        [user:elx_setof_basic/1, user:bs_atom/1],
+        [inline_bagof_setof(true)],
+        TmpDir,
+        verify_elixir_args(TmpDir, 'elx_setof_basic/1',
+                           ['[a,b,c]'], "true")).
+
+test(setof_dedups) :-
+    with_elixir_project(
+        [user:elx_setof_dedups/1, user:bs_dup/1],
+        [inline_bagof_setof(true)],
+        TmpDir,
+        verify_elixir_args(TmpDir, 'elx_setof_dedups/1',
+                           ['[a,b,c]'], "true")).
+
+test(setof_sorts_ints) :-
+    with_elixir_project(
+        [user:elx_setof_sorts_ints/1, user:bs_int_unsorted/1],
+        [inline_bagof_setof(true)],
+        TmpDir,
+        verify_elixir_args(TmpDir, 'elx_setof_sorts_ints/1',
+                           ['[1,2,3]'], "true")).
+
+test(bagof_with_quantifier) :-
+    % Tests ^/2 transparency through the inlined dispatch path.
+    with_elixir_project(
+        [user:elx_bagof_with_quantifier/1, user:bs_pair/2],
+        [inline_bagof_setof(true)],
+        TmpDir,
+        verify_elixir_args(TmpDir, 'elx_bagof_with_quantifier/1',
+                           ['[a,b,c]'], "true")).
+
 :- end_tests(wam_elixir_classic_programs).
 
 % ============================================================
@@ -594,7 +710,10 @@ with_elixir_project(Preds, ExtraOpts0, TmpDir, Goal) :-
     append(ExtraOpts, BaseOpts, AllOpts),
     % Compile each predicate to WAM, then write the project. This is
     % the same shape examples/debug_wam_elixir_ancestor.pl uses.
-    compile_predicates_to_wam(Preds, PredWamPairs),
+    % WAM-compile options forwarded from ExtraOpts include
+    % inline_bagof_setof(true) so bagof/setof tests inline correctly.
+    wam_compile_opts(ExtraOpts, WamOpts),
+    compile_predicates_to_wam(Preds, WamOpts, PredWamPairs),
     write_wam_elixir_project(PredWamPairs, AllOpts, TmpDir),
     % Copy the shared driver script into the project root. Resolved
     % at consult time via prolog_load_context so the path stays
@@ -621,13 +740,29 @@ classic_driver_path(P) :- classic_driver_path_fact(P).
 %  Module=user). Compiles each to WAM bytecode and packages as
 %  `Name/Arity-WamCode` pairs, the format `write_wam_elixir_project/3`
 %  expects.
-compile_predicates_to_wam([], []).
-compile_predicates_to_wam([Mod:Name/Arity | Rest], [Name/Arity-WamCode | RestPairs]) :-
-    (   wam_target:compile_predicate_to_wam(Name/Arity, [], WamCode) -> true
-    ;   wam_target:compile_predicate_to_wam(Mod:Name/Arity, [], WamCode) -> true
+compile_predicates_to_wam(Preds, Pairs) :-
+    compile_predicates_to_wam(Preds, [], Pairs).
+
+compile_predicates_to_wam([], _Opts, []).
+compile_predicates_to_wam([Mod:Name/Arity | Rest], Opts,
+                          [Name/Arity-WamCode | RestPairs]) :-
+    (   wam_target:compile_predicate_to_wam(Name/Arity, Opts, WamCode) -> true
+    ;   wam_target:compile_predicate_to_wam(Mod:Name/Arity, Opts, WamCode) -> true
     ;   throw(error(wam_compile_failed(Mod:Name/Arity), _))
     ),
-    compile_predicates_to_wam(Rest, RestPairs).
+    compile_predicates_to_wam(Rest, Opts, RestPairs).
+
+%% wam_compile_opts(+ExtraOpts, -WamOpts)
+%  Filter the project-level ExtraOpts to just the ones
+%  compile_predicate_to_wam understands. Currently:
+%    - inline_bagof_setof/1 (so bagof/setof tests inline rather than
+%      hitting the missing meta-call dispatch)
+wam_compile_opts(ExtraOpts, WamOpts) :-
+    findall(O, ( member(O, ExtraOpts),
+                 forwardable_wam_opt(O)
+               ), WamOpts).
+
+forwardable_wam_opt(inline_bagof_setof(_)).
 
 %% verify_elixir_args(+ProjectDir, +PredKey, +Args, +Expected)
 %


### PR DESCRIPTION
## Summary

Second [`WAM_ELIXIR_GAPS_SPECIFICATION.md`](docs/design/WAM_ELIXIR_GAPS_SPECIFICATION.md) §9 follow-up. Adds `bagof/3` and `setof/3` support by piggybacking on the existing inline aggregate infrastructure (`begin_aggregate` / `end_aggregate` / `aggregate_collect` / `finalise_aggregate`).

Mirrors C++ commit `4087bfa1`'s scope: **basic bagof/setof semantics plus `^/2` existential quantifier transparency**. Witness-group backtracking (full ISO grouping, where multiple free-var combinations produce multiple bags) is deferred to a follow-up; this PR ships the single-bag flat-list behaviour that covers the majority of real-world bagof/setof uses.

## Four pieces

### 1) 4-arg `begin_aggregate` parser + lowering

The WAM compiler emits `begin_aggregate bagof, Y1, X2, ''` (4 tokens) when `inline_bagof_setof(true)` is set — the extra 4th token is the witness/quantifier list for future grouping. The Elixir lowered emitter previously only handled the 3-token form. New `instr_from_parts` arm ignores the witness arg (no grouping in this PR); existing `wam_elixir_lower_instr` for `begin_aggregate/3` is reused.

### 2) `:bagof` and `:setof` agg-type cases in `finalise_aggregate`

| Type | Semantics |
| --- | --- |
| `:bagof` | Like `:bag`, but throws `{:fail, state}` when `accum_rev` is `[]` (ISO empty-bag semantics; matches C++). |
| `:setof` | Sorts via `standard_term_compare/2`, dedups via `Enum.uniq/1`, throws `{:fail, state}` when empty. |

New `standard_term_compare/2` + helpers implement ISO §7.2 standard order of terms: `Var < Number < Atom < String < Compound`. Compounds compare by arity, then functor name, then args recursively. Handles atomic values (numbers/atoms/binaries) directly and `{:struct, "name/arity", [args]}` compound shapes produced by `deep_copy_value/2`.

### 3) `^/2` transparency in `execute_builtin`

`Var^Goal` means "existentially quantify `Var` inside `Goal`" — for bagof/setof WITHOUT witness grouping (this PR's scope), this is just "dispatch `Goal`, ignore the binder." New builtin arm loads A2 (the inner goal) into A1 and dispatches as a 1-arity meta-call. Once witness grouping lands, the binder (A1) will be used to skip `Var` when computing free-variables-of-Goal.

### 4) Test harness option forwarding

`compile_predicates_to_wam/2` in `tests/test_wam_elixir_classic_programs.pl` gains a 3-arg form that accepts and forwards WAM-compile options. New `wam_compile_opts/2` helper filters `ExtraOpts` down to options `compile_predicate_to_wam/3` understands (currently just `inline_bagof_setof/1`).

## Test plan

### E2E tests (6 new)

| Test | Body | Expected |
| --- | --- | --- |
| `bagof_basic` | `bagof(X, bs_int(X), R)` | `R = [1, 2, 3]` |
| `bagof_fails_empty` | bagof over predicate with no solutions | predicate fails (empty bag) |
| `setof_basic` | `setof(X, bs_atom(X), R)` | `R = [a, b, c]` (sorted) |
| `setof_dedups` | `setof(X, bs_dup(X), R)` | `R = [a, b, c]` (no duplicates) |
| `setof_sorts_ints` | `setof(X, bs_int_unsorted(X), R)` | `R = [1, 2, 3]` (standard order) |
| `bagof_with_quantifier` | `bagof(X, Y^bs_pair(X, Y), R)` | `R = [a, b, c]` (tests `^/2`) |

All tests use multi-clause user FACTS rather than `member/2` for the enumeration source. **Reason:** Elixir's `member/2` builtin is a deterministic boolean check, not a backtracking enumerator. Multi-clause facts give the WAM compiler `try_me_else` / `retry_me_else` / `trust_me` dispatch which IS the proper enumeration via choice points. Filed as a known limitation worth addressing in a follow-up (enumerating `member/2`).

### Regression

- [x] All 43 e2e tests pass (3 classic + 4 call/N + 6 catch/throw + 5 is_iso/is_lax + 14 ISO sweep + 5 compound-eq + 6 bagof/setof)
- [x] Ackermann at ~25-26s — within variance bands established across PRs #1-#5; no regression attributable to this PR

## Deferred / out of scope

- **Witness-group backtracking** — full ISO bagof/setof where free vars beyond Template produce multiple bags. Mirrors C++ PR #2112; can be a follow-up if needed.
- **Meta-call dispatch for findall/bagof/setof** — today bagof/setof rely on `inline_bagof_setof(true)`; without that flag the WAM compiler emits `execute bagof/3` which the Elixir runtime cannot dispatch. Inlining covers all sensible uses; the meta-call path would matter only for goals constructed at runtime via `call/N`.
- **Enumerating `member/2` with choice points** — today's `member/2` is a deterministic boolean check; backtracking enumeration via member requires user-defined member. Worth addressing but separable from bagof/setof itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)