### PR TITLE
Feat/wam go numlist builtin

### DIFF
--- a/PR_go_wam_numlist_builtin.md
+++ b/PR_go_wam_numlist_builtin.md
@@ -1,0 +1,25 @@
+# PR Title
+
+Add Go WAM numlist builtin parity
+
+# PR Description
+
+## Summary
+
+- Add deterministic `numlist/3` support to the generated Go WAM runtime.
+- Route Go WAM `call`/`execute` instructions for `numlist/3` through `BuiltinCall` using the Go-local direct builtin path.
+- Cover `numlist(+Low,+High,-List)` for closed integer range construction, singleton range construction, and `Low > High` failure.
+- Update the Go WAM parity audit for the expanded Clojure/R range-list builtin surface.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl tests/test_wam_go_generator.pl tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(numlist/3,3), X), writeln(X), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -11,7 +11,7 @@ current cross-target builtin/runtime baseline.
 | Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries, indexed atom fact streams, `member/2` builtin retries | Choice point stack with normal, builtin, and fact-stream resume states | Present for current resume-state baseline |
 | Direct fact dispatch | `call_indexed_atom_fact2`, `AtomFact2Source` registry, TSV-backed and LMDB-artifact atom fact loading, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Present for current external atom fact-source baseline |
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
-| Structural builtins | `member/2`, `memberchk/2`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `reverse/2`, `last/2`, `nth0/3`, and `nth1/3` | Present for current baseline structural checks, with expanded cross-target list builtins |
+| Structural builtins | `member/2`, `memberchk/2`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, and `numlist/3` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2` | Includes `=</2` | Present for current baseline comparisons |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
@@ -43,6 +43,9 @@ current cross-target builtin/runtime baseline.
 - Deterministic `nth0/3` and `nth1/3` are now covered by the generated Go WAM
   builtin E2E test for in-range element lookup and out-of-range failure,
   matching the Clojure/R deterministic indexed-list surface.
+- Deterministic `numlist/3` is now covered by the generated Go WAM builtin E2E
+  test for closed integer range construction and `Low > High` failure,
+  matching the Clojure/R range-list surface.
 - Go WAM choice points now have explicit generated-runtime coverage for normal
   clause retries, indexed alternatives, foreign stream retries, indexed atom
   fact streams, and `member/2` builtin retries.

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -434,6 +434,9 @@ wam_go_direct_builtin("nth0/3", 3, 'nth0/3').
 wam_go_direct_builtin(nth1/3, 3, 'nth1/3').
 wam_go_direct_builtin('nth1/3', 3, 'nth1/3').
 wam_go_direct_builtin("nth1/3", 3, 'nth1/3').
+wam_go_direct_builtin(numlist/3, 3, 'numlist/3').
+wam_go_direct_builtin('numlist/3', 3, 'numlist/3').
+wam_go_direct_builtin("numlist/3", 3, 'numlist/3').
 
 wam_instruction_to_go_literal(get_constant(C, Ai), GoLiteral) :-
     go_value_literal(C, GoVal),

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1213,6 +1213,17 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			return false
 		}
 		return vm.Unify(arg3, items[int(idx)])
+	case "numlist/3":
+		lo, ok1 := vm.deref(arg1).(*Integer)
+		hi, ok2 := vm.deref(arg2).(*Integer)
+		if !ok1 || !ok2 || lo.Val > hi.Val {
+			return false
+		}
+		items := make([]Value, 0, hi.Val-lo.Val+1)
+		for n := lo.Val; n <= hi.Val; n++ {
+			items = append(items, &Integer{Val: n})
+		}
+		return vm.Unify(arg3, &List{Elements: items})
 	case "functor/3":
 		t := vm.deref(arg1)
 		if isUnbound(t) {

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -12,6 +12,7 @@
 :- dynamic user:test_reverse_builtin/0.
 :- dynamic user:test_last_builtin/0.
 :- dynamic user:test_nth_builtin/0.
+:- dynamic user:test_numlist_builtin/0.
 :- dynamic user:test_set_aggregate/0.
 :- dynamic user:test_unify_builtin/0.
 :- dynamic user:test_neg_fact/1.
@@ -87,6 +88,13 @@ test(builtins_execution) :-
                 \+ nth1(0, [a,b,c], _),
                 \+ nth1(4, [a,b,c], _)
             )),
+          assertz(user:test_numlist_builtin :-
+            (   numlist(2, 5, L),
+                L = [2,3,4,5],
+                numlist(3, 3, S),
+                S = [3],
+                \+ numlist(5, 2, _)
+            )),
           assertz(user:test_set_aggregate :-
             (   aggregate_all(set(X), member(X, [a,b,a]), S),
                 length(S, 2),
@@ -115,6 +123,7 @@ test(builtins_execution) :-
           retractall(user:test_reverse_builtin),
           retractall(user:test_last_builtin),
           retractall(user:test_nth_builtin),
+          retractall(user:test_numlist_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
           retractall(user:test_neg_fact(_)),
@@ -124,7 +133,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -160,6 +169,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "last/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "nth0/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "nth1/3"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "numlist/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "\\\\+/1"')),
     assertion(sub_string(LibCode, _, _, _, 'AggType: "set"')),
 
@@ -237,6 +247,14 @@ func main() {
 		fmt.Println("NTH_FAILURE")
 	}
 
+	numlistVM := wam.NewWamState(wam.Test_numlist_builtinCode, wam.Test_numlist_builtinLabels)
+	numlistVM.PC = wam.Test_numlist_builtinStartPC
+	if numlistVM.Run() {
+		fmt.Println("NUMLIST_SUCCESS")
+	} else {
+		fmt.Println("NUMLIST_FAILURE")
+	}
+
 	setVM := wam.NewWamState(wam.Test_set_aggregateCode, wam.Test_set_aggregateLabels)
 	setVM.PC = wam.Test_set_aggregateStartPC
 	if setVM.Run() {
@@ -293,6 +311,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "REVERSE_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "LAST_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NTH_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "NUMLIST_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NEG_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM numlist builtin parity

## Summary

- Add deterministic `numlist/3` support to the generated Go WAM runtime.
- Route Go WAM `call`/`execute` instructions for `numlist/3` through `BuiltinCall` using the Go-local direct builtin path.
- Cover `numlist(+Low,+High,-List)` for closed integer range construction, singleton range construction, and `Low > High` failure.
- Update the Go WAM parity audit for the expanded Clojure/R range-list builtin surface.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl tests/test_wam_go_generator.pl tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(numlist/3,3), X), writeln(X), halt"`
- `git diff --check`
