### PR TITLE
feat(wam-clojure): add atom and number text conversions

### DIFF
--- a/PR_WAM_CLOJURE_ATOM_NUMBER_CONVERSIONS.md
+++ b/PR_WAM_CLOJURE_ATOM_NUMBER_CONVERSIONS.md
@@ -1,0 +1,40 @@
+# PR Title
+
+feat(wam-clojure): add atom and number text conversions
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM support for `atom_codes/2`, `atom_chars/2`, `number_codes/2`, and `number_chars/2`.
+- Direct-lowers these conversion builtins to a shared runtime helper instead of routing through the interpreted builtin path.
+- Supports deterministic forward and reverse modes.
+- Updates the runtime intern context when reverse atom/char conversion creates atoms at runtime.
+- Adds lowered-emitter and runtime smoke coverage for success, mismatch, reverse construction, and unsupported unbound/unbound mode.
+
+## Semantics
+
+The implementation supports:
+
+- `atom_codes(+Atom, ?Codes)`
+- `atom_codes(?Atom, +Codes)`
+- `atom_chars(+Atom, ?Chars)`
+- `atom_chars(?Atom, +Chars)`
+- `number_codes(+Number, ?Codes)`
+- `number_codes(?Number, +Codes)`
+- `number_chars(+Number, ?Chars)`
+- `number_chars(?Number, +Chars)`
+
+Unsupported or ambiguous modes fail cleanly rather than raising ISO-style errors.
+
+## Notes
+
+- Code-list parsing accepts raw integer code points and decimal atom/string code-point literals to match current Clojure WAM literal normalization.
+- `number_chars/2` smoke coverage avoids source-level quoted digit atoms in generated WAM text because that path currently emits Clojure-hostile escape sequences.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -452,6 +452,22 @@ clojure_direct_builtin("ground/1", "1").
 clojure_direct_builtin("ground/1", 1).
 clojure_direct_builtin('ground/1', "1").
 clojure_direct_builtin('ground/1', 1).
+clojure_direct_builtin("atom_codes/2", "2").
+clojure_direct_builtin("atom_codes/2", 2).
+clojure_direct_builtin('atom_codes/2', "2").
+clojure_direct_builtin('atom_codes/2', 2).
+clojure_direct_builtin("atom_chars/2", "2").
+clojure_direct_builtin("atom_chars/2", 2).
+clojure_direct_builtin('atom_chars/2', "2").
+clojure_direct_builtin('atom_chars/2', 2).
+clojure_direct_builtin("number_codes/2", "2").
+clojure_direct_builtin("number_codes/2", 2).
+clojure_direct_builtin('number_codes/2', "2").
+clojure_direct_builtin('number_codes/2', 2).
+clojure_direct_builtin("number_chars/2", "2").
+clojure_direct_builtin("number_chars/2", 2).
+clojure_direct_builtin('number_chars/2', "2").
+clojure_direct_builtin('number_chars/2', 2).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
@@ -783,6 +799,15 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr),
            '(let [value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound))] (if (runtime/ground-term? ~w value) (runtime/advance ~w) (runtime/backtrack ~w)))',
            [S, S, S, S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (   Op == "atom_codes/2" ; Op == 'atom_codes/2'
+    ;   Op == "atom_chars/2" ; Op == 'atom_chars/2'
+    ;   Op == "number_codes/2" ; Op == 'number_codes/2'
+    ;   Op == "number_chars/2" ; Op == 'number_chars/2'
+    ),
+    !,
+    format(atom(Expr), '(runtime/apply-text-conversion-solution ~w "~w")', [S, Op]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     clojure_unary_guard_test(Op, TestExpr),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -946,6 +946,100 @@
           (backtrack state)))
       (backtrack state))))
 
+(defn atom-text [state value]
+  (cond
+    (atom-term? value) (deintern-atom (:intern-context state) (:id value))
+    (string? value) value
+    :else nil))
+
+(defn number-text [value]
+  (when (number? value)
+    (str value)))
+
+(defn intern-text-atom [state text]
+  (let [[ctx id] (intern-atom (:intern-context state) text)]
+    [(assoc state :intern-context ctx) (atom-term id)]))
+
+(defn intern-char-terms [state chars]
+  (loop [s state
+         remaining chars
+         out []]
+    (if-let [ch (first remaining)]
+      (let [[next-state atom] (intern-text-atom s (str ch))]
+        (recur next-state (rest remaining) (conj out atom)))
+      [s out])))
+
+(defn code-list-term [state text]
+  [state (list->term (:intern-context state) (map int text))])
+
+(defn char-list-term [state text]
+  (let [[next-state chars] (intern-char-terms state text)]
+    [next-state (list->term (:intern-context next-state) chars)]))
+
+(declare parse-number-text)
+
+(defn code-point-value [state value]
+  (cond
+    (integer? value) value
+    (atom-term? value) (parse-number-text (deintern-atom (:intern-context state) (:id value)))
+    (string? value) (parse-number-text value)
+    :else nil))
+
+(defn code-list-text [state list-value]
+  (when-let [items (proper-list-items state list-value)]
+    (let [codes (map #(code-point-value state %) items)]
+      (when (every? #(and (integer? %) (not (neg? %)) (<= % 65535)) codes)
+        (apply str (map char codes))))))
+
+(defn char-list-text [state list-value]
+  (when-let [items (proper-list-items state list-value)]
+    (let [chars (map #(atom-text state %) items)]
+      (when (every? #(and (string? %) (= 1 (count %))) chars)
+        (apply str chars)))))
+
+(defn parse-number-text [text]
+  (try
+    (if (str/includes? text ".")
+      (Double/parseDouble text)
+      (Long/parseLong text))
+    (catch Exception _ nil)))
+
+(defn apply-text-conversion-solution [state pred]
+  (let [left (deref-value (:bindings state)
+                          (or (reg-get-raw state "A1") ::unbound))
+        right (deref-value (:bindings state)
+                           (or (reg-get-raw state "A2") ::unbound))
+        codes? (or (= pred "atom_codes/2") (= pred "number_codes/2"))
+        atom? (or (= pred "atom_codes/2") (= pred "atom_chars/2"))
+        value-text (if atom? (atom-text state left) (number-text left))
+        list-text (if codes? (code-list-text state right) (char-list-text state right))]
+    (cond
+      (some? value-text)
+      (let [[next-state list-term] (if codes?
+                                     (code-list-term state value-text)
+                                     (char-list-term state value-text))
+            [ok unified-state] (unify-values next-state right list-term)]
+        (if ok
+          (advance unified-state)
+          (backtrack state)))
+
+      (some? list-text)
+      (if atom?
+        (let [[next-state atom-term] (intern-text-atom state list-text)
+              [ok unified-state] (unify-values next-state left atom-term)]
+          (if ok
+            (advance unified-state)
+            (backtrack state)))
+        (if-let [number-value (parse-number-text list-text)]
+          (let [[ok unified-state] (unify-values state left number-value)]
+            (if ok
+              (advance unified-state)
+              (backtrack state)))
+          (backtrack state)))
+
+      :else
+      (backtrack state))))
+
 (defn ground-term? [state value]
   (let [bindings (:bindings state)]
     (letfn [(ground* [term seen]
@@ -1753,6 +1847,18 @@
             (if (ground-term? state value)
               (advance state)
               (backtrack state)))
+
+          "atom_codes/2"
+          (apply-text-conversion-solution state (:pred instr))
+
+          "atom_chars/2"
+          (apply-text-conversion-solution state (:pred instr))
+
+          "number_codes/2"
+          (apply-text-conversion-solution state (:pred instr))
+
+          "number_chars/2"
+          (apply-text-conversion-solution state (:pred instr))
 
           "!/0"
           (-> state

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -694,6 +694,26 @@ test(simple_builtin_ground_is_direct_lowered_in_prefix) :-
         has(Code, "runtime/backtrack")
     )).
 
+test(simple_builtin_atom_codes_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_atom_codes/2:\nbuiltin_call atom_codes/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_atom_codes/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_atom_codes/2, WamCode, [], Code),
+        has(Code, "runtime/apply-text-conversion-solution"),
+        has(Code, "atom_codes/2"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
+test(simple_builtin_number_chars_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_number_chars/2:\nbuiltin_call number_chars/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_number_chars/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_number_chars/2, WamCode, [], Code),
+        has(Code, "runtime/apply-text-conversion-solution"),
+        has(Code, "number_chars/2"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(terminal_execute_ground_is_direct_lowered_as_succeeding_builtin) :-
     once((
         WamCode = "test_execute_ground/1:\nallocate\ndeallocate\nexecute ground/1\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -143,6 +143,14 @@
 :- dynamic user:wam_ground_guard/1.
 :- dynamic user:wam_ground_unbound/1.
 :- dynamic user:wam_ground_nested_unbound/1.
+:- dynamic user:wam_atom_codes_guard/2.
+:- dynamic user:wam_atom_codes_reverse/0.
+:- dynamic user:wam_atom_chars_guard/2.
+:- dynamic user:wam_atom_chars_reverse/0.
+:- dynamic user:wam_number_codes_guard/2.
+:- dynamic user:wam_number_codes_reverse/0.
+:- dynamic user:wam_number_chars_guard/2.
+:- dynamic user:wam_text_conversion_unbound_pair/1.
 :- dynamic user:wam_arith_eq_42/1.
 :- dynamic user:wam_arith_eq_float/1.
 :- dynamic user:wam_arith_neq_42/1.
@@ -307,6 +315,14 @@ user:wam_univ_compose_bad_functor :- user:wam_unbound_arg(F), _T =.. [F, a].
 user:wam_ground_guard(X) :- ground(X).
 user:wam_ground_unbound(_) :- user:wam_unbound_arg(Y), ground(Y).
 user:wam_ground_nested_unbound(_) :- user:wam_unbound_arg(Y), ground(f(Y)).
+user:wam_atom_codes_guard(A, C) :- atom_codes(A, C).
+user:wam_atom_codes_reverse :- atom_codes(A, [102,111,111]), A = foo.
+user:wam_atom_chars_guard(A, C) :- atom_chars(A, C).
+user:wam_atom_chars_reverse :- atom_chars(A, [f,o,o]), A = foo.
+user:wam_number_codes_guard(N, C) :- number_codes(N, C).
+user:wam_number_codes_reverse :- number_codes(N, [52,50]), N =:= 42.
+user:wam_number_chars_guard(N, C) :- number_chars(N, C).
+user:wam_text_conversion_unbound_pair(_) :- user:wam_unbound_arg(A), user:wam_unbound_arg(C), atom_codes(A, C).
 user:wam_arith_eq_42(X) :- X =:= 42.
 user:wam_arith_eq_float(X) :- X =:= 3.5.
 user:wam_arith_neq_42(X) :- X =\= 42.
@@ -476,6 +492,14 @@ run_smoke :-
           user:wam_ground_guard/1,
           user:wam_ground_unbound/1,
           user:wam_ground_nested_unbound/1,
+          user:wam_atom_codes_guard/2,
+          user:wam_atom_codes_reverse/0,
+          user:wam_atom_chars_guard/2,
+          user:wam_atom_chars_reverse/0,
+          user:wam_number_codes_guard/2,
+          user:wam_number_codes_reverse/0,
+          user:wam_number_chars_guard/2,
+          user:wam_text_conversion_unbound_pair/1,
           user:wam_arith_eq_42/1,
           user:wam_arith_eq_float/1,
           user:wam_arith_neq_42/1,
@@ -796,6 +820,18 @@ smoke_cases([
     case('wam_ground_guard/1', '[a,b]', "true"),
     case('wam_ground_unbound/1', a, "false"),
     case('wam_ground_nested_unbound/1', a, "false"),
+    case('wam_atom_codes_guard/2', args(foo, '[102,111,111]'), "true"),
+    case('wam_atom_codes_guard/2', args(foo, '[102,111]'), "false"),
+    case('wam_atom_codes_reverse/0', no_args, "true"),
+    case('wam_atom_chars_guard/2', args(foo, '[f,o,o]'), "true"),
+    case('wam_atom_chars_guard/2', args(foo, '[f,o]'), "false"),
+    case('wam_atom_chars_reverse/0', no_args, "true"),
+    case('wam_number_codes_guard/2', args(42, '[52,50]'), "true"),
+    case('wam_number_codes_guard/2', args(42, '[52]'), "false"),
+    case('wam_number_codes_reverse/0', no_args, "true"),
+    case('wam_number_chars_guard/2', args(42, '[''4'',''2'']'), "true"),
+    case('wam_number_chars_guard/2', args(42, '[''4'']'), "false"),
+    case('wam_text_conversion_unbound_pair/1', a, "false"),
     case('wam_arith_eq_42/1', 42, "true"),
     case('wam_arith_eq_42/1', 3.5, "false"),
     case('wam_arith_eq_float/1', 3.5, "true"),
@@ -1129,7 +1165,12 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-ground-guard-1"),
     has(CoreCode, "defn lowered-wam-ground-unbound-1"),
     has(CoreCode, "defn lowered-wam-ground-nested-unbound-1"),
-    has(CoreCode, "runtime/ground-term?").
+    has(CoreCode, "defn lowered-wam-atom-codes-guard-2"),
+    has(CoreCode, "defn lowered-wam-atom-chars-guard-2"),
+    has(CoreCode, "defn lowered-wam-number-codes-guard-2"),
+    has(CoreCode, "defn lowered-wam-number-chars-guard-2"),
+    has(CoreCode, "runtime/ground-term?"),
+    has(CoreCode, "runtime/apply-text-conversion-solution").
 
 assert_lowered_arithmetic_comparison_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
@@ -1329,15 +1370,25 @@ prolog_term_string_to_edn("c", "\"c\"") :- !.
 prolog_term_string_to_edn("d", "\"d\"") :- !.
 prolog_term_string_to_edn(f, "\"f\"") :- !.
 prolog_term_string_to_edn("f", "\"f\"") :- !.
+prolog_term_string_to_edn(foo, "\"foo\"") :- !.
+prolog_term_string_to_edn("foo", "\"foo\"") :- !.
 prolog_term_string_to_edn("z", "\"z\"") :- !.
 prolog_term_string_to_edn('f(a)', "{:tag :struct :functor \"f/1\" :args [\"a\"]}") :- !.
 prolog_term_string_to_edn('f(a,b)', "{:tag :struct :functor \"f/2\" :args [\"a\" \"b\"]}") :- !.
 prolog_term_string_to_edn('f(b)', "{:tag :struct :functor \"f/1\" :args [\"b\"]}") :- !.
 prolog_term_string_to_edn('[a]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}") :- !.
 prolog_term_string_to_edn('[42]', "{:tag :struct :functor \"[|]/2\" :args [42 \"[]\"]}") :- !.
+prolog_term_string_to_edn('[52]', "{:tag :struct :functor \"[|]/2\" :args [52 \"[]\"]}") :- !.
+prolog_term_string_to_edn('[52,50]', "{:tag :struct :functor \"[|]/2\" :args [52 {:tag :struct :functor \"[|]/2\" :args [50 \"[]\"]}]}") :- !.
+prolog_term_string_to_edn('[102,111]', "{:tag :struct :functor \"[|]/2\" :args [102 {:tag :struct :functor \"[|]/2\" :args [111 \"[]\"]}]}") :- !.
+prolog_term_string_to_edn('[102,111,111]', "{:tag :struct :functor \"[|]/2\" :args [102 {:tag :struct :functor \"[|]/2\" :args [111 {:tag :struct :functor \"[|]/2\" :args [111 \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[1,2,3]', "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [2 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[1,3]', "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[2]', "{:tag :struct :functor \"[|]/2\" :args [2 \"[]\"]}") :- !.
+prolog_term_string_to_edn('[f,o]', "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"o\" \"[]\"]}]}") :- !.
+prolog_term_string_to_edn('[f,o,o]', "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"o\" {:tag :struct :functor \"[|]/2\" :args [\"o\" \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn('[''4'']', "{:tag :struct :functor \"[|]/2\" :args [\"4\" \"[]\"]}") :- !.
+prolog_term_string_to_edn('[''4'',''2'']', "{:tag :struct :functor \"[|]/2\" :args [\"4\" {:tag :struct :functor \"[|]/2\" :args [\"2\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[f,a,b]', "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[a,b]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
@@ -1359,9 +1410,17 @@ prolog_term_string_to_edn("f(a,b)", "{:tag :struct :functor \"f/2\" :args [\"a\"
 prolog_term_string_to_edn("f(b)", "{:tag :struct :functor \"f/1\" :args [\"b\"]}") :- !.
 prolog_term_string_to_edn("[a]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}") :- !.
 prolog_term_string_to_edn("[42]", "{:tag :struct :functor \"[|]/2\" :args [42 \"[]\"]}") :- !.
+prolog_term_string_to_edn("[52]", "{:tag :struct :functor \"[|]/2\" :args [52 \"[]\"]}") :- !.
+prolog_term_string_to_edn("[52,50]", "{:tag :struct :functor \"[|]/2\" :args [52 {:tag :struct :functor \"[|]/2\" :args [50 \"[]\"]}]}") :- !.
+prolog_term_string_to_edn("[102,111]", "{:tag :struct :functor \"[|]/2\" :args [102 {:tag :struct :functor \"[|]/2\" :args [111 \"[]\"]}]}") :- !.
+prolog_term_string_to_edn("[102,111,111]", "{:tag :struct :functor \"[|]/2\" :args [102 {:tag :struct :functor \"[|]/2\" :args [111 {:tag :struct :functor \"[|]/2\" :args [111 \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[1,2,3]", "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [2 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[1,3]", "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[2]", "{:tag :struct :functor \"[|]/2\" :args [2 \"[]\"]}") :- !.
+prolog_term_string_to_edn("[f,o]", "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"o\" \"[]\"]}]}") :- !.
+prolog_term_string_to_edn("[f,o,o]", "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"o\" {:tag :struct :functor \"[|]/2\" :args [\"o\" \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn("['4']", "{:tag :struct :functor \"[|]/2\" :args [\"4\" \"[]\"]}") :- !.
+prolog_term_string_to_edn("['4','2']", "{:tag :struct :functor \"[|]/2\" :args [\"4\" {:tag :struct :functor \"[|]/2\" :args [\"2\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[f,a,b]", "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[a,b]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.


### PR DESCRIPTION
## Summary

- Adds Clojure WAM support for `atom_codes/2`, `atom_chars/2`, `number_codes/2`, and `number_chars/2`.
- Direct-lowers these conversion builtins to a shared runtime helper instead of routing through the interpreted builtin path.
- Supports deterministic forward and reverse modes.
- Updates the runtime intern context when reverse atom/char conversion creates atoms at runtime.
- Adds lowered-emitter and runtime smoke coverage for success, mismatch, reverse construction, and unsupported unbound/unbound mode.

## Semantics

The implementation supports:

- `atom_codes(+Atom, ?Codes)`
- `atom_codes(?Atom, +Codes)`
- `atom_chars(+Atom, ?Chars)`
- `atom_chars(?Atom, +Chars)`
- `number_codes(+Number, ?Codes)`
- `number_codes(?Number, +Codes)`
- `number_chars(+Number, ?Chars)`
- `number_chars(?Number, +Chars)`

Unsupported or ambiguous modes fail cleanly rather than raising ISO-style errors.

## Notes

- Code-list parsing accepts raw integer code points and decimal atom/string code-point literals to match current Clojure WAM literal normalization.
- `number_chars/2` smoke coverage avoids source-level quoted digit atoms in generated WAM text because that path currently emits Clojure-hostile escape sequences.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
