### PR TITLE
feat(wam-cpp): trig + log/exp + constants in eval_arith

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -2761,6 +2761,18 @@ Value WamState::eval_arith(CellPtr c, bool& ok) const {
         case Value::Tag::Float:
             return v;
         case Value::Tag::Atom:
+            // SWI-style arithmetic constants. pi/e are doubles;
+            // inf/nan come from <cmath> + <limits>.
+            if (v.s == "pi") return Value::Float(3.14159265358979323846);
+            if (v.s == "e")  return Value::Float(2.71828182845904523536);
+            if (v.s == "inf" || v.s == "infinite")
+                return Value::Float(std::numeric_limits<double>::infinity());
+            if (v.s == "nan")
+                return Value::Float(std::nan(""));
+            if (v.s == "max_tagged_integer")
+                return Value::Integer(std::numeric_limits<std::int64_t>::max());
+            if (v.s == "min_tagged_integer")
+                return Value::Integer(std::numeric_limits<std::int64_t>::min());
             // Numeric atoms ("5", "-3.14") are tolerated for robustness.
             try {
                 std::size_t pos;
@@ -2803,6 +2815,19 @@ Value WamState::eval_arith(CellPtr c, bool& ok) const {
                                        : (a.f < 0 ? -1.0 : 0.0));
                 }
                 if (v.s == "sqrt/1") return Value::Float(std::sqrt(as_d1(a)));
+                // Trig + transcendentals: all promote Integer to
+                // double and always return Float.
+                if (v.s == "sin/1") return Value::Float(std::sin(as_d1(a)));
+                if (v.s == "cos/1") return Value::Float(std::cos(as_d1(a)));
+                if (v.s == "tan/1") return Value::Float(std::tan(as_d1(a)));
+                if (v.s == "asin/1") return Value::Float(std::asin(as_d1(a)));
+                if (v.s == "acos/1") return Value::Float(std::acos(as_d1(a)));
+                if (v.s == "atan/1") return Value::Float(std::atan(as_d1(a)));
+                if (v.s == "sinh/1") return Value::Float(std::sinh(as_d1(a)));
+                if (v.s == "cosh/1") return Value::Float(std::cosh(as_d1(a)));
+                if (v.s == "tanh/1") return Value::Float(std::tanh(as_d1(a)));
+                if (v.s == "log/1") return Value::Float(std::log(as_d1(a)));
+                if (v.s == "exp/1") return Value::Float(std::exp(as_d1(a)));
                 if (v.s == "truncate/1")
                     return Value::Integer((std::int64_t)std::trunc(as_d1(a)));
                 if (v.s == "floor/1")
@@ -2881,6 +2906,17 @@ Value WamState::eval_arith(CellPtr c, bool& ok) const {
             // both args are int and the exponent is non-negative.
             if (v.s == "**/2") {
                 return Value::Float(std::pow(as_d(a), as_d(b)));
+            }
+            // atan2(Y, X) -- standard library order.
+            if (v.s == "atan2/2") {
+                return Value::Float(std::atan2(as_d(a), as_d(b)));
+            }
+            // log(Base, X) -- log of X to base Base. Standard
+            // identity: log(X) / log(Base).
+            if (v.s == "log/2") {
+                double base = as_d(a);
+                double x = as_d(b);
+                return Value::Float(std::log(x) / std::log(base));
             }
             if (v.s == "^/2") {
                 if (either_float || b.i < 0) {

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -58,6 +58,20 @@
 :- dynamic user:wam_cpp_test_shr/0.
 :- dynamic user:wam_cpp_test_arith_compose1/0.
 :- dynamic user:wam_cpp_test_arith_compose2/0.
+:- dynamic user:wam_cpp_test_pi/0.
+:- dynamic user:wam_cpp_test_e/0.
+:- dynamic user:wam_cpp_test_nan/0.
+:- dynamic user:wam_cpp_test_sin_zero/0.
+:- dynamic user:wam_cpp_test_cos_pi/0.
+:- dynamic user:wam_cpp_test_tan_zero/0.
+:- dynamic user:wam_cpp_test_asin_one/0.
+:- dynamic user:wam_cpp_test_atan2_diag/0.
+:- dynamic user:wam_cpp_test_cosh_zero/0.
+:- dynamic user:wam_cpp_test_exp_zero/0.
+:- dynamic user:wam_cpp_test_log_e/0.
+:- dynamic user:wam_cpp_test_log_base/0.
+:- dynamic user:wam_cpp_test_exp_log/0.
+:- dynamic user:wam_cpp_test_pythag_one/0.
 :- dynamic user:wam_cpp_is_atom/1.
 :- dynamic user:wam_cpp_is_int/1.
 :- dynamic user:wam_cpp_is_num/1.
@@ -2147,6 +2161,23 @@ user:wam_cpp_test_shl          :- X is 1 << 5, X = 32.
 user:wam_cpp_test_shr          :- X is 64 >> 3, X = 8.
 user:wam_cpp_test_arith_compose1 :- X is max(abs(-5), abs(-3)), X = 5.
 user:wam_cpp_test_arith_compose2 :- X is floor(sqrt(50)), X = 7.
+% Transcendentals: trig (sin/cos/tan + inverses), hyperbolic, log/exp,
+% constants (pi/e/inf/nan). All return Float.
+user:wam_cpp_test_pi          :- X is pi, X > 3.14, X < 3.15.
+user:wam_cpp_test_e           :- X is e, X > 2.71, X < 2.72.
+user:wam_cpp_test_nan         :- X is nan, \+ (X =:= X).
+user:wam_cpp_test_sin_zero    :- X is sin(0), X =:= 0.0.
+user:wam_cpp_test_cos_pi      :- X is cos(pi), X > -1.001, X < -0.999.
+user:wam_cpp_test_tan_zero    :- X is tan(0), X =:= 0.0.
+user:wam_cpp_test_asin_one    :- X is asin(1), Y is pi/2, X > Y - 0.001, X < Y + 0.001.
+user:wam_cpp_test_atan2_diag  :- X is atan2(1, 1), Y is pi/4, X > Y - 0.001, X < Y + 0.001.
+user:wam_cpp_test_cosh_zero   :- X is cosh(0), X =:= 1.0.
+user:wam_cpp_test_exp_zero    :- X is exp(0), X =:= 1.0.
+user:wam_cpp_test_log_e       :- X is log(e), X > 0.999, X < 1.001.
+user:wam_cpp_test_log_base    :- X is log(10, 1000), X > 2.999, X < 3.001.
+user:wam_cpp_test_exp_log     :- X is exp(log(5)), X > 4.999, X < 5.001.
+user:wam_cpp_test_pythag_one  :- X is sin(pi/4) ** 2 + cos(pi/4) ** 2,
+                                 X > 0.999, X < 1.001.
 % Type checks
 user:wam_cpp_is_atom(X)        :- atom(X).
 user:wam_cpp_is_int(X)         :- integer(X).
@@ -2569,6 +2600,46 @@ test(cpp_e2e_arith_expansion, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_shr/0',             [], true),
           run_query(BinPath, 'wam_cpp_test_arith_compose1/0',  [], true),
           run_query(BinPath, 'wam_cpp_test_arith_compose2/0',  [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_arith_transcendentals, [condition(cpp_compiler_available)]) :-
+    % Transcendentals: trig (sin/cos/tan + inverses), hyperbolic
+    % (sinh/cosh/tanh), log/exp with base, constants pi/e/nan, plus a
+    % Pythagorean identity check using `**`.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_trig', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_pi/0,
+                               user:wam_cpp_test_e/0,
+                               user:wam_cpp_test_nan/0,
+                               user:wam_cpp_test_sin_zero/0,
+                               user:wam_cpp_test_cos_pi/0,
+                               user:wam_cpp_test_tan_zero/0,
+                               user:wam_cpp_test_asin_one/0,
+                               user:wam_cpp_test_atan2_diag/0,
+                               user:wam_cpp_test_cosh_zero/0,
+                               user:wam_cpp_test_exp_zero/0,
+                               user:wam_cpp_test_log_e/0,
+                               user:wam_cpp_test_log_base/0,
+                               user:wam_cpp_test_exp_log/0,
+                               user:wam_cpp_test_pythag_one/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_pi/0',           [], true),
+          run_query(BinPath, 'wam_cpp_test_e/0',            [], true),
+          run_query(BinPath, 'wam_cpp_test_nan/0',          [], true),
+          run_query(BinPath, 'wam_cpp_test_sin_zero/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_cos_pi/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_tan_zero/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_asin_one/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_atan2_diag/0',   [], true),
+          run_query(BinPath, 'wam_cpp_test_cosh_zero/0',    [], true),
+          run_query(BinPath, 'wam_cpp_test_exp_zero/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_log_e/0',        [], true),
+          run_query(BinPath, 'wam_cpp_test_log_base/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_exp_log/0',      [], true),
+          run_query(BinPath, 'wam_cpp_test_pythag_one/0',   [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Adds the transcendental tier to `eval_arith`, sitting on top of the basic-functions + bit-ops expansion that landed in #2213.

### Constants

Handled in the Atom case (before numeric-string parsing):

- `pi`, `e` — float doubles.
- `inf` / `infinite`, `nan` — IEEE 754 values via `<cmath>` + `<limits>`.
- `max_tagged_integer`, `min_tagged_integer` — Integer bounds (`int64_t::max()` / `::min()`).

### New unary functions (all return Float)

- Trig: `sin/1`, `cos/1`, `tan/1`
- Inverse trig: `asin/1`, `acos/1`, `atan/1`
- Hyperbolic: `sinh/1`, `cosh/1`, `tanh/1`
- Log/exp: `log/1`, `exp/1`

### New binary functions (all return Float)

- `atan2/2` — `atan2(Y, X)`, standard library argument order.
- `log/2` — `log(Base, X)`, computed as `log(X) / log(Base)`.

### Tests

One new `cpp_e2e_arith_transcendentals` bundle with **14 cases**:

- Constants: `pi`, `e`, `nan` (with NaN-not-equal-to-itself).
- Trig values: `sin(0) = 0`, `cos(pi) = -1`, `tan(0) = 0`, `asin(1) = pi/2`, `atan2(1, 1) = pi/4`.
- Hyperbolic: `cosh(0) = 1`.
- Log/exp: `exp(0) = 1`, `log(e) = 1`, `log(10, 1000) = 3`, `exp(log(5)) = 5` (round-trip).
- Composition: `sin(pi/4)**2 + cos(pi/4)**2 = 1` (Pythagorean identity).

Full `test_wam_cpp_generator` suite (343 tests) passes; `test_wam_target` unchanged and green.

## Test plan

- [x] Smoke test `/tmp` — all 23 cases pass.
- [x] `test_wam_target` regression — all green.
- [x] Full `test_wam_cpp_generator` (343 tests) — all green.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_