### PR TITLE
bench(csharp-query): Measure policy-configured effective-distance artifacts

### DIFF
--- a/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
+++ b/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
@@ -1328,6 +1328,24 @@ static void BenchmarkProvider(
         bucketCol1Hash);
 }
 
+static long ArtifactBytesForStorageKind(
+    string storageKind,
+    string binaryDir,
+    string delimitedDir,
+    string lmdbDir,
+    string lmdbManifest,
+    string mmapDir)
+{
+    return storageKind switch
+    {
+        RelationArtifactAccessPolicy.BinaryArtifactStorageKind => DirectorySize(binaryDir),
+        RelationArtifactAccessPolicy.DelimitedArtifactStorageKind => DirectorySize(delimitedDir),
+        RelationArtifactAccessPolicy.LmdbArtifactStorageKind => DirectorySize(lmdbDir) + new FileInfo(lmdbManifest).Length,
+        RelationArtifactAccessPolicy.MmapArrayArtifactStorageKind => DirectorySize(mmapDir),
+        _ => 0L,
+    };
+}
+
 var scale = ReadArg(args, "--scale", "dev");
 var scaleDir = ReadArg(args, "--scale-dir", "");
 var relation = ReadArg(args, "--relation", "category_parent");
@@ -1507,6 +1525,41 @@ BenchmarkProvider(
     lookupKeysColumn1,
     lookupRepetitions,
     DirectorySize(mmapDir),
+    rows.Count,
+    distinctCategories);
+var policyStorageKind = RelationArtifactAccessPolicy.ResolveEffectiveDistanceArtifactStorageKind(
+    relation,
+    rows.Count,
+    RelationArtifactAccessShape.LookupColumn0);
+BenchmarkProvider(
+    scale,
+    relation,
+    "policy-configured",
+    () =>
+    {
+        var provider = new ConfiguredDelimitedRelationProvider(RelationSourceMode.ArtifactPrebuilt);
+        if (!provider.RegisterEffectiveDistancePrebuiltArtifacts(
+            predicate,
+            relation,
+            rows.Count,
+            RelationArtifactAccessShape.LookupColumn0,
+            new[] { binaryManifest, delimitedManifest, lmdbManifest, mmapManifest },
+            new IRelationArtifactProviderFactory[]
+            {
+                new LmdbRelationArtifactProviderFactory(),
+                new DefaultRelationArtifactProviderFactory(),
+            }))
+        {
+            throw new InvalidOperationException("policy-configured provider could not open any prebuilt artifact");
+        }
+
+        return provider.Provider;
+    },
+    predicate,
+    lookupKeys,
+    lookupKeysColumn1,
+    lookupRepetitions,
+    ArtifactBytesForStorageKind(policyStorageKind, binaryDir, delimitedDir, lmdbDir, lmdbManifest, mmapDir),
     rows.Count,
     distinctCategories);
 """

--- a/tests/test_csharp_query_effective_distance_artifact_backends.py
+++ b/tests/test_csharp_query_effective_distance_artifact_backends.py
@@ -93,13 +93,13 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
 
         lines = result.stdout.strip().splitlines()
-        self.assertEqual(len(lines), 6)
+        self.assertEqual(len(lines), 7)
         headers = lines[0].split("\t")
         rows = [dict(zip(headers, line.split("\t"))) for line in lines[1:]]
 
         self.assertEqual(
             [row["mode"] for row in rows],
-            ["preload", "binary-artifact", "delimited-artifact", "lmdb", "mmap-array"],
+            ["preload", "binary-artifact", "delimited-artifact", "lmdb", "mmap-array", "policy-configured"],
         )
         self.assertEqual({row["scale"] for row in rows}, {"dev"})
         self.assertEqual({row["run"] for row in rows}, {"1"})
@@ -109,6 +109,7 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
         self.assertEqual({row["lookup_col1_hash"] for row in rows}, {rows[0]["lookup_col1_hash"]})
         self.assertEqual({row["bucket_hash"] for row in rows}, {rows[0]["bucket_hash"]})
         self.assertEqual({row["bucket_col1_hash"] for row in rows}, {rows[0]["bucket_col1_hash"]})
+        self.assertEqual(rows[-1]["mode"], "policy-configured")
 
         for row in rows:
             self.assertGreater(int(row["rows"]), 0)
@@ -182,8 +183,9 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
         lines = result.stdout.strip().splitlines()
         headers = lines[0].split("\t")
         rows = [dict(zip(headers, line.split("\t"))) for line in lines[1:]]
-        self.assertEqual(len(rows), 5)
+        self.assertEqual(len(rows), 6)
         self.assertEqual({row["relation"] for row in rows}, {"article_category"})
+        self.assertIn("policy-configured", {row["mode"] for row in rows})
         self.assertEqual({row["scan_hash"] for row in rows}, {rows[0]["scan_hash"]})
         self.assertEqual({row["lookup_hash"] for row in rows}, {rows[0]["lookup_hash"]})
         self.assertEqual({row["lookup_col1_hash"] for row in rows}, {rows[0]["lookup_col1_hash"]})


### PR DESCRIPTION
  ## Summary

  - Adds a `policy-configured` backend row to the C# effective-distance artifact backend benchmark.
  - Opens the benchmark relation through `ConfiguredDelimitedRelationProvider.RegisterEffectiveDistancePrebuiltArtifacts`.
  - Makes binary, delimited, LMDB, and mmap manifests available, then lets `RelationArtifactAccessPolicy` choose the lookup-c0
  provider.
  - Updates benchmark tests to expect the policy-configured row and verify output hashes still match the existing backend
  rows.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py tests/test_csharp_query_lmdb_provider_smoke.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime_lmdb/UnifyWeaver.QueryRuntime.Lmdb.csproj`
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
  - `git diff --check`