### PR TITLE
bench(csharp-query): Measure policy-configured artifact access shapes

### DIFF
--- a/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
+++ b/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
@@ -1346,6 +1346,63 @@ static long ArtifactBytesForStorageKind(
     };
 }
 
+static void BenchmarkPolicyConfiguredProvider(
+    string scale,
+    string relation,
+    string modeSuffix,
+    RelationArtifactAccessShape accessShape,
+    PredicateId predicate,
+    IReadOnlyList<object> lookupKeys,
+    IReadOnlyList<object> lookupKeysColumn1,
+    int lookupRepetitions,
+    string binaryManifest,
+    string delimitedManifest,
+    string lmdbManifest,
+    string mmapManifest,
+    string binaryDir,
+    string delimitedDir,
+    string lmdbDir,
+    string mmapDir,
+    int rowCount,
+    int distinctCategories)
+{
+    var policyStorageKind = RelationArtifactAccessPolicy.ResolveEffectiveDistanceArtifactStorageKind(
+        relation,
+        rowCount,
+        accessShape);
+    BenchmarkProvider(
+        scale,
+        relation,
+        $"policy-configured-{modeSuffix}",
+        () =>
+        {
+            var provider = new ConfiguredDelimitedRelationProvider(RelationSourceMode.ArtifactPrebuilt);
+            if (!provider.RegisterEffectiveDistancePrebuiltArtifacts(
+                predicate,
+                relation,
+                rowCount,
+                accessShape,
+                new[] { binaryManifest, delimitedManifest, lmdbManifest, mmapManifest },
+                new IRelationArtifactProviderFactory[]
+                {
+                    new LmdbRelationArtifactProviderFactory(),
+                    new DefaultRelationArtifactProviderFactory(),
+                }))
+            {
+                throw new InvalidOperationException($"policy-configured-{modeSuffix} provider could not open any prebuilt artifact");
+            }
+
+            return provider.Provider;
+        },
+        predicate,
+        lookupKeys,
+        lookupKeysColumn1,
+        lookupRepetitions,
+        ArtifactBytesForStorageKind(policyStorageKind, binaryDir, delimitedDir, lmdbDir, lmdbManifest, mmapDir),
+        rowCount,
+        distinctCategories);
+}
+
 var scale = ReadArg(args, "--scale", "dev");
 var scaleDir = ReadArg(args, "--scale-dir", "");
 var relation = ReadArg(args, "--relation", "category_parent");
@@ -1527,39 +1584,99 @@ BenchmarkProvider(
     DirectorySize(mmapDir),
     rows.Count,
     distinctCategories);
-var policyStorageKind = RelationArtifactAccessPolicy.ResolveEffectiveDistanceArtifactStorageKind(
-    relation,
-    rows.Count,
-    RelationArtifactAccessShape.LookupColumn0);
-BenchmarkProvider(
+BenchmarkPolicyConfiguredProvider(
     scale,
     relation,
-    "policy-configured",
-    () =>
-    {
-        var provider = new ConfiguredDelimitedRelationProvider(RelationSourceMode.ArtifactPrebuilt);
-        if (!provider.RegisterEffectiveDistancePrebuiltArtifacts(
-            predicate,
-            relation,
-            rows.Count,
-            RelationArtifactAccessShape.LookupColumn0,
-            new[] { binaryManifest, delimitedManifest, lmdbManifest, mmapManifest },
-            new IRelationArtifactProviderFactory[]
-            {
-                new LmdbRelationArtifactProviderFactory(),
-                new DefaultRelationArtifactProviderFactory(),
-            }))
-        {
-            throw new InvalidOperationException("policy-configured provider could not open any prebuilt artifact");
-        }
-
-        return provider.Provider;
-    },
+    "lookup-c0",
+    RelationArtifactAccessShape.LookupColumn0,
     predicate,
     lookupKeys,
     lookupKeysColumn1,
     lookupRepetitions,
-    ArtifactBytesForStorageKind(policyStorageKind, binaryDir, delimitedDir, lmdbDir, lmdbManifest, mmapDir),
+    binaryManifest,
+    delimitedManifest,
+    lmdbManifest,
+    mmapManifest,
+    binaryDir,
+    delimitedDir,
+    lmdbDir,
+    mmapDir,
+    rows.Count,
+    distinctCategories);
+BenchmarkPolicyConfiguredProvider(
+    scale,
+    relation,
+    "lookup-c1",
+    RelationArtifactAccessShape.LookupColumn1,
+    predicate,
+    lookupKeys,
+    lookupKeysColumn1,
+    lookupRepetitions,
+    binaryManifest,
+    delimitedManifest,
+    lmdbManifest,
+    mmapManifest,
+    binaryDir,
+    delimitedDir,
+    lmdbDir,
+    mmapDir,
+    rows.Count,
+    distinctCategories);
+BenchmarkPolicyConfiguredProvider(
+    scale,
+    relation,
+    "bucket-c0",
+    RelationArtifactAccessShape.BucketColumn0,
+    predicate,
+    lookupKeys,
+    lookupKeysColumn1,
+    lookupRepetitions,
+    binaryManifest,
+    delimitedManifest,
+    lmdbManifest,
+    mmapManifest,
+    binaryDir,
+    delimitedDir,
+    lmdbDir,
+    mmapDir,
+    rows.Count,
+    distinctCategories);
+BenchmarkPolicyConfiguredProvider(
+    scale,
+    relation,
+    "bucket-c1",
+    RelationArtifactAccessShape.BucketColumn1,
+    predicate,
+    lookupKeys,
+    lookupKeysColumn1,
+    lookupRepetitions,
+    binaryManifest,
+    delimitedManifest,
+    lmdbManifest,
+    mmapManifest,
+    binaryDir,
+    delimitedDir,
+    lmdbDir,
+    mmapDir,
+    rows.Count,
+    distinctCategories);
+BenchmarkPolicyConfiguredProvider(
+    scale,
+    relation,
+    "scan",
+    RelationArtifactAccessShape.Scan,
+    predicate,
+    lookupKeys,
+    lookupKeysColumn1,
+    lookupRepetitions,
+    binaryManifest,
+    delimitedManifest,
+    lmdbManifest,
+    mmapManifest,
+    binaryDir,
+    delimitedDir,
+    lmdbDir,
+    mmapDir,
     rows.Count,
     distinctCategories);
 """

--- a/tests/test_csharp_query_effective_distance_artifact_backends.py
+++ b/tests/test_csharp_query_effective_distance_artifact_backends.py
@@ -93,13 +93,24 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
 
         lines = result.stdout.strip().splitlines()
-        self.assertEqual(len(lines), 7)
+        self.assertEqual(len(lines), 11)
         headers = lines[0].split("\t")
         rows = [dict(zip(headers, line.split("\t"))) for line in lines[1:]]
 
         self.assertEqual(
             [row["mode"] for row in rows],
-            ["preload", "binary-artifact", "delimited-artifact", "lmdb", "mmap-array", "policy-configured"],
+            [
+                "preload",
+                "binary-artifact",
+                "delimited-artifact",
+                "lmdb",
+                "mmap-array",
+                "policy-configured-lookup-c0",
+                "policy-configured-lookup-c1",
+                "policy-configured-bucket-c0",
+                "policy-configured-bucket-c1",
+                "policy-configured-scan",
+            ],
         )
         self.assertEqual({row["scale"] for row in rows}, {"dev"})
         self.assertEqual({row["run"] for row in rows}, {"1"})
@@ -109,7 +120,7 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
         self.assertEqual({row["lookup_col1_hash"] for row in rows}, {rows[0]["lookup_col1_hash"]})
         self.assertEqual({row["bucket_hash"] for row in rows}, {rows[0]["bucket_hash"]})
         self.assertEqual({row["bucket_col1_hash"] for row in rows}, {rows[0]["bucket_col1_hash"]})
-        self.assertEqual(rows[-1]["mode"], "policy-configured")
+        self.assertEqual(rows[-1]["mode"], "policy-configured-scan")
 
         for row in rows:
             self.assertGreater(int(row["rows"]), 0)
@@ -183,9 +194,17 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
         lines = result.stdout.strip().splitlines()
         headers = lines[0].split("\t")
         rows = [dict(zip(headers, line.split("\t"))) for line in lines[1:]]
-        self.assertEqual(len(rows), 6)
+        self.assertEqual(len(rows), 10)
         self.assertEqual({row["relation"] for row in rows}, {"article_category"})
-        self.assertIn("policy-configured", {row["mode"] for row in rows})
+        self.assertTrue(
+            {
+                "policy-configured-lookup-c0",
+                "policy-configured-lookup-c1",
+                "policy-configured-bucket-c0",
+                "policy-configured-bucket-c1",
+                "policy-configured-scan",
+            }.issubset({row["mode"] for row in rows})
+        )
         self.assertEqual({row["scan_hash"] for row in rows}, {rows[0]["scan_hash"]})
         self.assertEqual({row["lookup_hash"] for row in rows}, {rows[0]["lookup_hash"]})
         self.assertEqual({row["lookup_col1_hash"] for row in rows}, {rows[0]["lookup_col1_hash"]})


### PR DESCRIPTION
  ## Summary

  - Extends the C# effective-distance artifact backend benchmark from one `policy-configured` row to separate access-shape
  rows.
  - Adds policy-routed benchmark rows for lookup-c0, lookup-c1, bucket-c0, bucket-c1, and scan.
  - Opens each policy-configured row through `ConfiguredDelimitedRelationProvider.RegisterEffectiveDistancePrebuiltArtifacts`
  with the matching `RelationArtifactAccessShape`.
  - Updates tests to assert all access-shape rows are emitted and remain hash-equivalent to the existing backend rows.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py tests/test_csharp_query_lmdb_provider_smoke.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime_lmdb/UnifyWeaver.QueryRuntime.Lmdb.csproj`
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
  - `git diff --check`