### PR TITLE
feat(wam-c): add transitive step parent distance kernel

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,7 +4,7 @@ Status date: 2026-05-17
 
 Base verified locally:
 
-- `main` at `3abf6366` (`Merge pull request #2220 from s243a/feat/csharp-query-lmdb-policy-factory-smoke`)
+- `main` at `07e04153` (`Merge pull request #2225 from s243a/feat/csharp-query-effective-distance-policy-provider-benchmark`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
@@ -17,7 +17,7 @@ Base verified locally:
 
 Active branch:
 
-- `feat/wam-c-transitive-parent-distance-kernel`
+- `feat/wam-c-transitive-step-parent-distance-kernel`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -76,6 +76,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | `transitive_closure2` native kernel | Done | C shared-kernel detector accepts `transitive_closure2`, emits detected setup, registers a native arity-2 foreign handler, and covers direct plus detected-project executable smokes |
 | `transitive_distance3` native kernel | Done | C shared-kernel detector accepts `transitive_distance3`, emits detected setup, registers a native arity-3 foreign handler, and covers direct plus detected-project executable smokes |
 | `transitive_parent_distance4` native kernel | Done | C shared-kernel detector accepts `transitive_parent_distance4`, emits detected setup, registers a native arity-4 foreign handler, and covers direct plus detected-project executable smokes |
+| `transitive_step_parent_distance5` native kernel | Done | C shared-kernel detector accepts `transitive_step_parent_distance5`, emits detected setup, registers a native arity-5 foreign handler, and covers direct plus detected-project executable smokes |
 
 ## Current C Target Baseline
 
@@ -101,8 +102,8 @@ The C target is now a credible small WAM backend:
   predicates, plus same-arity alias bodies that call those native fact helpers,
   emitted as native C foreign handlers behind `call_foreign` trampolines.
 - Supports deterministic native `category_ancestor/4`, `transitive_closure2`,
-  `transitive_distance3`, and `transitive_parent_distance4` handlers over an
-  in-memory edge table.
+  `transitive_distance3`, `transitive_parent_distance4`, and
+  `transitive_step_parent_distance5` handlers over an in-memory edge table.
 - Supports loading category-parent facts from TSV through a small
   `WamFactSource` interface.
 - Supports collecting all integer hop results for native `category_ancestor/4`
@@ -147,8 +148,8 @@ missing important target features; `Missing` = no comparable C path yet.
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
 | Negation / control builtins | Partial | Broader | Broader | C likely needs explicit tests for `\+/1`, cut interactions, and if-then-else lowering. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
-| Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native `transitive_closure2`, native `transitive_distance3`, and native `transitive_parent_distance4`; continue adding shared kernels one at a time. |
-| Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`, `transitive_closure2`, `transitive_distance3`, and `transitive_parent_distance4`; Haskell and Rust cover a broader shared-kernel registry. |
+| Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, and native transitive closure/distance/parent-distance/step-parent-distance handlers; continue adding shared kernels one at a time. |
+| Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`, `transitive_closure2`, `transitive_distance3`, `transitive_parent_distance4`, and `transitive_step_parent_distance5`; Haskell and Rust cover a broader shared-kernel registry. |
 | Lowered/native helper functions | Partial/Done | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, comparison-filter helpers, rejection metadata, repeated-variable filter hardening, empty-result rejection metadata, and projected body-call helper expansion. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
@@ -159,19 +160,18 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-transitive-step-parent-distance-kernel`
+### 1. `feat/wam-c-weighted-shortest-path-kernel`
 
 Goal: add the next shared recursive kernel to C from the Haskell/Rust parity
-surface, continuing from `transitive_parent_distance4` to
-`transitive_step_parent_distance5`.
+surface, continuing from unweighted BFS-style kernels to
+`weighted_shortest_path3`.
 
 Scope:
 
 - Extend the C recursive-kernel registration path beyond `category_ancestor/4`
   and the existing transitive kernels for the shared
-  `transitive_step_parent_distance5` detector.
-- Add a native C handler and executable smoke for a small binary edge
-  step-parent-distance result.
+  `weighted_shortest_path3` detector.
+- Add a native C handler and executable smoke for a small weighted edge result.
 - Keep TSV/LMDB fact loading out of scope unless the small in-memory kernel
   path exposes a need for it.
 
@@ -179,13 +179,13 @@ Status: recommended next.
 
 Reason:
 
-- `transitive_parent_distance4` is now covered through direct native
+- `transitive_step_parent_distance5` is now covered through direct native
   registration and detected-project setup.
 - `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` records
-  `transitive_step_parent_distance5` alongside `transitive_parent_distance4`
-  as part of the measured wide-output BFS kernel set.
-- Haskell and Rust already cover `transitive_step_parent_distance5`; it can
-  reuse the edge traversal surface while adding a first-step output.
+  `weighted_shortest_path3/3` as the next measured native kernel after the
+  unweighted BFS family.
+- Haskell and Rust already cover `weighted_shortest_path3`; it is the next
+  shared-kernel parity move before A*.
 
 ### 2. `investigate/wam-c-accumulated-runtime-cost`
 
@@ -271,6 +271,21 @@ Evidence:
 | Direct executable smoke | `tc_parent_distance/4` succeeds for direct and recursive edges, binds unbound target/parent/distance, accepts bound parent/distance, and fails for a reversed edge. |
 | Detected-project smoke | Generated project detection lowers `tc_parent_distance/4` to a `call_foreign` trampoline and runs through `setup_detected_wam_c_kernels`. |
 
+### Completed Shared Kernel Slice: `feat/wam-c-transitive-step-parent-distance-kernel`
+
+Goal: add the final measured unweighted wide-output shared recursive kernel to
+C from the Haskell/Rust parity surface.
+
+Evidence:
+
+| Surface | Coverage |
+|---|---|
+| Kernel support predicate | `wam_c_supported_kernel/1` accepts `recursive_kernel(transitive_step_parent_distance5, ...)`. |
+| Detected setup emission | `generate_setup_detected_kernels_c/2` emits `wam_register_transitive_step_parent_distance_kernel`. |
+| Runtime handler | `wam_transitive_step_parent_distance_handler` supports bound-target reachability, first-solution unbound target mode, first-step binding, parent binding, and integer distance binding over registered in-memory edges. |
+| Direct executable smoke | `tc_step_parent_distance/5` succeeds for direct and recursive edges, binds unbound target/step/parent/distance, accepts bound step/parent/distance, and fails for a reversed edge. |
+| Detected-project smoke | Generated project detection lowers `tc_step_parent_distance/5` to a `call_foreign` trampoline and runs through `setup_detected_wam_c_kernels`. |
+
 ## Completed Atom Concat Builtin
 
 The merged `feat/wam-c-atom-concat-builtin` branch added deterministic
@@ -348,9 +363,9 @@ After hash-bucket row dispatch but before compact row tables:
 
 ## Suggested Immediate Next Step
 
-Proceed with `feat/wam-c-transitive-step-parent-distance-kernel`.
+Proceed with `feat/wam-c-weighted-shortest-path-kernel`.
 
-Keep it narrow: add `transitive_step_parent_distance5` over the same in-memory
+Keep it narrow: add `weighted_shortest_path3` over a small in-memory weighted
 edge surface and prove direct plus detected-project executable smokes. Treat
 broader fact storage, LMDB loading, and runtime profiling as follow-up branches
 unless this slice exposes a direct blocker.

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -252,10 +252,12 @@ void wam_register_category_ancestor_kernel(WamState *state, const char *pred, in
 void wam_register_transitive_closure_kernel(WamState *state, const char *pred);
 void wam_register_transitive_distance_kernel(WamState *state, const char *pred);
 void wam_register_transitive_parent_distance_kernel(WamState *state, const char *pred);
+void wam_register_transitive_step_parent_distance_kernel(WamState *state, const char *pred);
 bool wam_category_ancestor_handler(WamState *state, const char *pred, int arity);
 bool wam_transitive_closure_handler(WamState *state, const char *pred, int arity);
 bool wam_transitive_distance_handler(WamState *state, const char *pred, int arity);
 bool wam_transitive_parent_distance_handler(WamState *state, const char *pred, int arity);
+bool wam_transitive_step_parent_distance_handler(WamState *state, const char *pred, int arity);
 void wam_fact_source_init(WamFactSource *source);
 void wam_fact_source_close(WamFactSource *source);
 bool wam_fact_source_load_tsv(WamState *state, WamFactSource *source, const char *path);

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -135,6 +135,7 @@ wam_c_supported_kernel(recursive_kernel(category_ancestor, _Pred, _ConfigOps)).
 wam_c_supported_kernel(recursive_kernel(transitive_closure2, _Pred, _ConfigOps)).
 wam_c_supported_kernel(recursive_kernel(transitive_distance3, _Pred, _ConfigOps)).
 wam_c_supported_kernel(recursive_kernel(transitive_parent_distance4, _Pred, _ConfigOps)).
+wam_c_supported_kernel(recursive_kernel(transitive_step_parent_distance5, _Pred, _ConfigOps)).
 
 %% generate_setup_detected_kernels_c(+DetectedKernels, -CCode)
 %  Emit C startup wiring for detected kernels. This function registers only
@@ -164,6 +165,10 @@ wam_c_kernel_registration_line(Key-recursive_kernel(transitive_distance3, _Pred,
 wam_c_kernel_registration_line(Key-recursive_kernel(transitive_parent_distance4, _Pred, _ConfigOps), Line) :-
     format(atom(Line),
            '    wam_register_transitive_parent_distance_kernel(state, "~w");',
+           [Key]).
+wam_c_kernel_registration_line(Key-recursive_kernel(transitive_step_parent_distance5, _Pred, _ConfigOps), Line) :-
+    format(atom(Line),
+           '    wam_register_transitive_step_parent_distance_kernel(state, "~w");',
            [Key]).
 
 wam_c_kernel_max_depth(ConfigOps, MaxDepth) :-
@@ -2468,6 +2473,10 @@ void wam_register_transitive_parent_distance_kernel(WamState *state, const char 
     wam_register_foreign_predicate(state, pred, 4, wam_transitive_parent_distance_handler);
 }
 
+void wam_register_transitive_step_parent_distance_kernel(WamState *state, const char *pred) {
+    wam_register_foreign_predicate(state, pred, 5, wam_transitive_step_parent_distance_handler);
+}
+
 static bool wam_value_as_atom(WamState *state, WamValue value, const char **out) {
     WamValue *cell = wam_deref_ptr(state, &value);
     if (cell->tag != VAL_ATOM) return false;
@@ -2793,6 +2802,89 @@ bool wam_transitive_parent_distance_handler(WamState *state, const char *pred, i
     return wam_unify(state, &state->A[1], &target_value) &&
            wam_unify(state, &state->A[2], &parent_value) &&
            wam_unify(state, &state->A[3], &distance_value);
+}
+
+static bool wam_transitive_step_parent_distance_bfs(WamState *state,
+                                                    const char *start,
+                                                    const char *target,
+                                                    const char **target_out,
+                                                    const char **step_out,
+                                                    const char **parent_out,
+                                                    int *distance_out) {
+    const char *queue_nodes[256];
+    const char *queue_steps[256];
+    int queue_distances[256];
+    const char *visited[256];
+    int head = 0;
+    int tail = 0;
+    int visited_len = 0;
+
+    queue_nodes[tail] = start;
+    queue_steps[tail] = start;
+    queue_distances[tail++] = 0;
+    visited[visited_len++] = start;
+
+    while (head < tail) {
+        const char *node = queue_nodes[head];
+        const char *first_step = queue_steps[head];
+        int distance = queue_distances[head++];
+        for (int i = 0; i < state->category_edge_count; i++) {
+            CategoryEdge *edge = &state->category_edges[i];
+            if (strcmp(edge->child, node) != 0) continue;
+            if (wam_visited_array_contains(visited, visited_len, edge->parent)) continue;
+            int next_distance = distance + 1;
+            const char *next_step = (distance == 0) ? edge->parent : first_step;
+            if (!target || strcmp(edge->parent, target) == 0) {
+                *target_out = edge->parent;
+                *step_out = next_step;
+                *parent_out = node;
+                *distance_out = next_distance;
+                return true;
+            }
+            if (tail >= 256 || visited_len >= 256) return false;
+            visited[visited_len++] = edge->parent;
+            queue_nodes[tail] = edge->parent;
+            queue_steps[tail] = next_step;
+            queue_distances[tail++] = next_distance;
+        }
+    }
+    return false;
+}
+
+bool wam_transitive_step_parent_distance_handler(WamState *state, const char *pred, int arity) {
+    (void)pred;
+    if (arity != 5) return false;
+
+    const char *start = NULL;
+    if (!wam_value_as_atom(state, state->A[0], &start)) return false;
+
+    WamValue *target_cell = wam_deref_ptr(state, &state->A[1]);
+    const char *target = NULL;
+    if (target_cell->tag == VAL_ATOM) {
+        target = target_cell->data.atom;
+    } else if (!val_is_unbound(*target_cell)) {
+        return false;
+    }
+
+    const char *result_target = NULL;
+    const char *result_step = NULL;
+    const char *result_parent = NULL;
+    int result_distance = 0;
+    if (!wam_transitive_step_parent_distance_bfs(state, start, target,
+                                                 &result_target, &result_step,
+                                                 &result_parent,
+                                                 &result_distance)) {
+        return false;
+    }
+
+    WamValue target_value = val_atom(result_target);
+    WamValue step_value = val_atom(result_step);
+    WamValue parent_value = val_atom(result_parent);
+    WamValue distance_value = val_int(result_distance);
+    return wam_unify(state, &state->A[1], &target_value) &&
+           wam_unify(state, &state->A[2], &step_value) &&
+           wam_unify(state, &state->A[3], &parent_value) &&
+           wam_unify(state, &state->A[4], &distance_value);
 }
 '.
 

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -299,6 +299,17 @@ test_transitive_parent_distance_kernel_generation :-
     ;   fail_test(Test, 'transitive_parent_distance4 native kernel helpers missing')
     ).
 
+test_transitive_step_parent_distance_kernel_generation :-
+    Test = 'WAM-C: transitive_step_parent_distance5 native kernel helpers generated',
+    (   compile_wam_runtime_to_c([], RuntimeCode),
+        atom_string(RuntimeCode, S),
+        sub_string(S, _, _, _, 'void wam_register_transitive_step_parent_distance_kernel'),
+        sub_string(S, _, _, _, 'bool wam_transitive_step_parent_distance_handler'),
+        sub_string(S, _, _, _, 'wam_transitive_step_parent_distance_bfs')
+    ->  pass(Test)
+    ;   fail_test(Test, 'transitive_step_parent_distance5 native kernel helpers missing')
+    ).
+
 test_fact_source_generation :-
     Test = 'WAM-C: file FactSource helpers generated',
     (   compile_wam_runtime_to_c([], RuntimeCode),
@@ -378,6 +389,20 @@ test_transitive_parent_distance_detector_setup_generation :-
         pass(Test)
     ;   cleanup_wam_c_detector_transitive_parent_distance,
         fail_test(Test, 'detected transitive_parent_distance4 setup missing')
+    ).
+
+test_transitive_step_parent_distance_detector_setup_generation :-
+    Test = 'WAM-C: shared kernel detector emits transitive_step_parent_distance5 setup',
+    setup_wam_c_detector_transitive_step_parent_distance,
+    (   detect_kernels([user:tc_step_parent_distance/5], Detected),
+        Detected = ['tc_step_parent_distance/5'-_Kernel],
+        generate_setup_detected_kernels_c(Detected, SetupCode),
+        sub_atom(SetupCode, _, _, _, 'setup_detected_wam_c_kernels'),
+        sub_atom(SetupCode, _, _, _, 'wam_register_transitive_step_parent_distance_kernel(state, "tc_step_parent_distance/5")')
+    ->  cleanup_wam_c_detector_transitive_step_parent_distance,
+        pass(Test)
+    ;   cleanup_wam_c_detector_transitive_step_parent_distance,
+        fail_test(Test, 'detected transitive_step_parent_distance5 setup missing')
     ).
 
 test_kernel_detector_project_generation :-
@@ -980,6 +1005,16 @@ test_transitive_parent_distance_kernel_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_transitive_step_parent_distance_kernel_executable_smoke :-
+    Test = 'WAM-C: transitive_step_parent_distance5 native kernel executable smoke',
+    (   gcc_available
+    ->  (   run_transitive_step_parent_distance_kernel_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'transitive_step_parent_distance5 native kernel executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_fact_source_executable_smoke :-
     Test = 'WAM-C: file FactSource executable smoke',
     (   gcc_available
@@ -1047,6 +1082,16 @@ test_transitive_parent_distance_detector_executable_smoke :-
     ->  (   run_transitive_parent_distance_detector_executable_smoke
         ->  pass(Test)
         ;   fail_test(Test, 'detected transitive_parent_distance4 executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
+test_transitive_step_parent_distance_detector_executable_smoke :-
+    Test = 'WAM-C: detected transitive_step_parent_distance5 executable smoke',
+    (   gcc_available
+    ->  (   run_transitive_step_parent_distance_detector_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'detected transitive_step_parent_distance5 executable failed')
         )
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
@@ -1386,6 +1431,25 @@ run_transitive_parent_distance_kernel_executable_smoke :-
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
 
+run_transitive_step_parent_distance_kernel_executable_smoke :-
+    WamCode = 'tc_step_parent_distance/5:\n    call_foreign tc_step_parent_distance/5, 5\n    proceed',
+    compile_wam_predicate_to_c(user:tc_step_parent_distance/5, WamCode, [], PredCode),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_step_parent_distance_smoke', Stamp, TmpBase),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(RuntimePath, RuntimeCode),
+    format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+    write_text_file(PredPath, PredTranslationUnit),
+    wam_c_transitive_step_parent_distance_smoke_main(MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
 run_fact_source_executable_smoke :-
     WamCode = 'category_ancestor/4:\n    call_foreign category_ancestor/4, 4\n    proceed',
     compile_wam_predicate_to_c(user:category_ancestor/4, WamCode, [], PredCode),
@@ -1500,6 +1564,25 @@ run_transitive_parent_distance_detector_executable_smoke :-
         run_c_smoke_plain(ExePath)
     ->  cleanup_wam_c_detector_transitive_parent_distance
     ;   cleanup_wam_c_detector_transitive_parent_distance,
+        fail
+    ).
+
+run_transitive_step_parent_distance_detector_executable_smoke :-
+    setup_wam_c_detector_transitive_step_parent_distance,
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_step_parent_distance_detector_smoke', Stamp, ProjectDir),
+    directory_file_path(ProjectDir, 'wam_runtime.c', RuntimePath),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    directory_file_path(ProjectDir, 'main.c', MainPath),
+    directory_file_path(ProjectDir, 'wam_c_step_parent_distance_detector_smoke', ExePath),
+    (   write_wam_c_project([user:tc_step_parent_distance/5], [], ProjectDir),
+        wam_c_transitive_step_parent_distance_detector_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, LibPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_detector_transitive_step_parent_distance
+    ;   cleanup_wam_c_detector_transitive_step_parent_distance,
         fail
     ).
 
@@ -2018,6 +2101,22 @@ setup_wam_c_detector_transitive_parent_distance :-
 cleanup_wam_c_detector_transitive_parent_distance :-
     retractall(user:tpd_parent(_, _)),
     retractall(user:tc_parent_distance(_, _, _, _)).
+
+setup_wam_c_detector_transitive_step_parent_distance :-
+    cleanup_wam_c_detector_transitive_step_parent_distance,
+    assertz((user:tspd_parent(tom, bob))),
+    assertz((user:tspd_parent(bob, ann))),
+    assertz((user:tspd_parent(bob, pat))),
+    assertz((user:tc_step_parent_distance(X, Y, Y, X, 1) :-
+        tspd_parent(X, Y))),
+    assertz((user:tc_step_parent_distance(X, Y, Step, Parent, D) :-
+        tspd_parent(X, Step),
+        tc_step_parent_distance(Step, Y, _Inner, Parent, D0),
+        D is D0 + 1)).
+
+cleanup_wam_c_detector_transitive_step_parent_distance :-
+    retractall(user:tspd_parent(_, _)),
+    retractall(user:tc_step_parent_distance(_, _, _, _, _)).
 
 run_c_smoke(ExePath) :-
     format(atom(LogPath), '~w.asan.log', [ExePath]),
@@ -2590,6 +2689,84 @@ int main(void) {
 }
 ').
 
+wam_c_transitive_step_parent_distance_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_tc_step_parent_distance_5(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_tc_step_parent_distance_5(&state);
+    wam_register_transitive_edge(&state, "tom", "bob");
+    wam_register_transitive_edge(&state, "bob", "ann");
+    wam_register_transitive_edge(&state, "bob", "pat");
+    wam_register_transitive_step_parent_distance_kernel(&state, "tc_step_parent_distance/5");
+
+    WamValue recursive_args[5] = {
+        val_atom("tom"),
+        val_atom("ann"),
+        val_unbound("Step"),
+        val_unbound("Parent"),
+        val_unbound("Distance")
+    };
+    int recursive_rc = wam_run_predicate(&state, "tc_step_parent_distance/5", recursive_args, 5);
+    if (recursive_rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_ATOM || strcmp(state.A[2].data.atom, "bob") != 0 ||
+        state.A[3].tag != VAL_ATOM || strcmp(state.A[3].data.atom, "bob") != 0 ||
+        state.A[4].tag != VAL_INT || state.A[4].data.integer != 2) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue direct_args[5] = {
+        val_atom("tom"),
+        val_atom("bob"),
+        val_atom("bob"),
+        val_atom("tom"),
+        val_int(1)
+    };
+    int direct_rc = wam_run_predicate(&state, "tc_step_parent_distance/5", direct_args, 5);
+    if (direct_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue output_args[5] = {
+        val_atom("bob"),
+        val_unbound("Target"),
+        val_unbound("Step"),
+        val_unbound("Parent"),
+        val_unbound("Distance")
+    };
+    int output_rc = wam_run_predicate(&state, "tc_step_parent_distance/5", output_args, 5);
+    if (output_rc != 0 || state.P != WAM_HALT ||
+        state.A[1].tag != VAL_ATOM || strcmp(state.A[1].data.atom, "ann") != 0 ||
+        state.A[2].tag != VAL_ATOM || strcmp(state.A[2].data.atom, "ann") != 0 ||
+        state.A[3].tag != VAL_ATOM || strcmp(state.A[3].data.atom, "bob") != 0 ||
+        state.A[4].tag != VAL_INT || state.A[4].data.integer != 1) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    WamValue fail_args[5] = {
+        val_atom("ann"),
+        val_atom("tom"),
+        val_unbound("Step"),
+        val_unbound("Parent"),
+        val_unbound("Distance")
+    };
+    int fail_rc = wam_run_predicate(&state, "tc_step_parent_distance/5", fail_args, 5);
+    if (fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_kernel_detector_smoke_main(
 '#include "wam_runtime.h"
 
@@ -2719,6 +2896,42 @@ int main(void) {
     if (rc != 0 || state.P != WAM_HALT ||
         state.A[2].tag != VAL_ATOM || strcmp(state.A[2].data.atom, "bob") != 0 ||
         state.A[3].tag != VAL_INT || state.A[3].data.integer != 2) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
+wam_c_transitive_step_parent_distance_detector_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_tc_step_parent_distance_5(WamState* state);
+void setup_detected_wam_c_kernels(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_tc_step_parent_distance_5(&state);
+    setup_detected_wam_c_kernels(&state);
+
+    wam_register_transitive_edge(&state, "tom", "bob");
+    wam_register_transitive_edge(&state, "bob", "ann");
+
+    WamValue args[5] = {
+        val_atom("tom"),
+        val_atom("ann"),
+        val_unbound("Step"),
+        val_unbound("Parent"),
+        val_unbound("Distance")
+    };
+    int rc = wam_run_predicate(&state, "tc_step_parent_distance/5", args, 5);
+    if (rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_ATOM || strcmp(state.A[2].data.atom, "bob") != 0 ||
+        state.A[3].tag != VAL_ATOM || strcmp(state.A[3].data.atom, "bob") != 0 ||
+        state.A[4].tag != VAL_INT || state.A[4].data.integer != 2) {
         wam_free_state(&state);
         return 10;
     }
@@ -3709,12 +3922,14 @@ run_tests_once :-
     test_transitive_closure_kernel_generation,
     test_transitive_distance_kernel_generation,
     test_transitive_parent_distance_kernel_generation,
+    test_transitive_step_parent_distance_kernel_generation,
     test_fact_source_generation,
     test_streaming_foreign_results_generation,
     test_kernel_detector_setup_generation,
     test_transitive_closure_detector_setup_generation,
     test_transitive_distance_detector_setup_generation,
     test_transitive_parent_distance_detector_setup_generation,
+    test_transitive_step_parent_distance_detector_setup_generation,
     test_kernel_detector_project_generation,
     test_lowered_fact_helper_generation,
     test_lowered_helper_planner_metadata,
@@ -3739,12 +3954,14 @@ run_tests_once :-
     test_transitive_closure_kernel_executable_smoke,
     test_transitive_distance_kernel_executable_smoke,
     test_transitive_parent_distance_kernel_executable_smoke,
+    test_transitive_step_parent_distance_kernel_executable_smoke,
     test_fact_source_executable_smoke,
     test_lmdb_fact_source_executable_smoke,
     test_kernel_detector_executable_smoke,
     test_transitive_closure_detector_executable_smoke,
     test_transitive_distance_detector_executable_smoke,
     test_transitive_parent_distance_detector_executable_smoke,
+    test_transitive_step_parent_distance_detector_executable_smoke,
     test_streaming_foreign_results_executable_smoke,
     test_real_prolog_builtin_executable_smoke,
     test_real_prolog_term_builtin_executable_smoke,


### PR DESCRIPTION
# Add WAM-C transitive step parent distance kernel

## Summary

- Add native WAM-C support for the shared `transitive_step_parent_distance5` recursive kernel.
- Register the kernel through both explicit shared-kernel metadata and detector-generated setup.
- Add executable WAM-C smoke tests covering direct, recursive, unbound-target, and failing reverse-path cases.
- Refresh `WAM_C_TARGET_NEXT_STEPS.md` to record this completed slice and move the recommended next branch to weighted shortest path coverage.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/test_wam_c_lowered_helper_scale_regression.py`
- `git diff --check`
