### PR TITLE
feat(wam-clojure): add forward atom concat builtin

### DIFF
--- a/PR_WAM_CLOJURE_ATOM_CONCAT_FORWARD.md
+++ b/PR_WAM_CLOJURE_ATOM_CONCAT_FORWARD.md
@@ -1,0 +1,29 @@
+# PR Title
+
+feat(wam-clojure): add forward atom concat builtin
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM support for deterministic forward `atom_concat/3`.
+- Adds `string_concat/3` as an alias over the same atom/string representation.
+- Direct-lowers concat calls to a runtime helper instead of routing through the interpreted builtin path.
+- Interns the concatenated output atom in the runtime intern context.
+- Adds lowered-emitter and runtime smoke coverage for success, mismatch, runtime-created output atoms, alias behavior, and unsupported reverse/unbound mode.
+
+## Semantics
+
+The implementation supports:
+
+- `atom_concat(+Left, +Right, ?Out)`
+- `string_concat(+Left, +Right, ?Out)`
+
+Unsupported reverse/split modes fail cleanly for now. This keeps the branch deterministic and avoids introducing nondeterministic split enumeration in the same change.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -468,6 +468,14 @@ clojure_direct_builtin("number_chars/2", "2").
 clojure_direct_builtin("number_chars/2", 2).
 clojure_direct_builtin('number_chars/2', "2").
 clojure_direct_builtin('number_chars/2', 2).
+clojure_direct_builtin("atom_concat/3", "3").
+clojure_direct_builtin("atom_concat/3", 3).
+clojure_direct_builtin('atom_concat/3', "3").
+clojure_direct_builtin('atom_concat/3', 3).
+clojure_direct_builtin("string_concat/3", "3").
+clojure_direct_builtin("string_concat/3", 3).
+clojure_direct_builtin('string_concat/3', "3").
+clojure_direct_builtin('string_concat/3', 3).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
@@ -808,6 +816,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     ),
     !,
     format(atom(Expr), '(runtime/apply-text-conversion-solution ~w "~w")', [S, Op]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (   Op == "atom_concat/3" ; Op == 'atom_concat/3'
+    ;   Op == "string_concat/3" ; Op == 'string_concat/3'
+    ),
+    !,
+    format(atom(Expr), '(runtime/apply-atom-concat-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     clojure_unary_guard_test(Op, TestExpr),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1040,6 +1040,23 @@
       :else
       (backtrack state))))
 
+(defn apply-atom-concat-solution [state]
+  (let [left (deref-value (:bindings state)
+                          (or (reg-get-raw state "A1") ::unbound))
+        right (deref-value (:bindings state)
+                           (or (reg-get-raw state "A2") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A3") ::unbound))
+        left-text (atom-text state left)
+        right-text (atom-text state right)]
+    (if (and (some? left-text) (some? right-text))
+      (let [[next-state atom] (intern-text-atom state (str left-text right-text))
+            [ok unified-state] (unify-values next-state out atom)]
+        (if ok
+          (advance unified-state)
+          (backtrack state)))
+      (backtrack state))))
+
 (defn ground-term? [state value]
   (let [bindings (:bindings state)]
     (letfn [(ground* [term seen]
@@ -1859,6 +1876,12 @@
 
           "number_chars/2"
           (apply-text-conversion-solution state (:pred instr))
+
+          "atom_concat/3"
+          (apply-atom-concat-solution state)
+
+          "string_concat/3"
+          (apply-atom-concat-solution state)
 
           "!/0"
           (-> state

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -714,6 +714,15 @@ test(simple_builtin_number_chars_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_atom_concat_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_atom_concat/3:\nbuiltin_call atom_concat/3, 3\nproceed\n",
+        wam_clojure_lowerable(test_atom_concat/3, WamCode, deterministic),
+        lower_predicate_to_clojure(test_atom_concat/3, WamCode, [], Code),
+        has(Code, "runtime/apply-atom-concat-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(terminal_execute_ground_is_direct_lowered_as_succeeding_builtin) :-
     once((
         WamCode = "test_execute_ground/1:\nallocate\ndeallocate\nexecute ground/1\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -151,6 +151,10 @@
 :- dynamic user:wam_number_codes_reverse/0.
 :- dynamic user:wam_number_chars_guard/2.
 :- dynamic user:wam_text_conversion_unbound_pair/1.
+:- dynamic user:wam_atom_concat_guard/3.
+:- dynamic user:wam_atom_concat_new_atom/0.
+:- dynamic user:wam_atom_concat_unbound_left/1.
+:- dynamic user:wam_string_concat_guard/3.
 :- dynamic user:wam_arith_eq_42/1.
 :- dynamic user:wam_arith_eq_float/1.
 :- dynamic user:wam_arith_neq_42/1.
@@ -323,6 +327,10 @@ user:wam_number_codes_guard(N, C) :- number_codes(N, C).
 user:wam_number_codes_reverse :- number_codes(N, [52,50]), N =:= 42.
 user:wam_number_chars_guard(N, C) :- number_chars(N, C).
 user:wam_text_conversion_unbound_pair(_) :- user:wam_unbound_arg(A), user:wam_unbound_arg(C), atom_codes(A, C).
+user:wam_atom_concat_guard(A, B, C) :- atom_concat(A, B, C).
+user:wam_atom_concat_new_atom :- atom_concat(fo, o, X), X = foo.
+user:wam_atom_concat_unbound_left(C) :- user:wam_unbound_arg(A), atom_concat(A, o, C).
+user:wam_string_concat_guard(A, B, C) :- string_concat(A, B, C).
 user:wam_arith_eq_42(X) :- X =:= 42.
 user:wam_arith_eq_float(X) :- X =:= 3.5.
 user:wam_arith_neq_42(X) :- X =\= 42.
@@ -500,6 +508,10 @@ run_smoke :-
           user:wam_number_codes_reverse/0,
           user:wam_number_chars_guard/2,
           user:wam_text_conversion_unbound_pair/1,
+          user:wam_atom_concat_guard/3,
+          user:wam_atom_concat_new_atom/0,
+          user:wam_atom_concat_unbound_left/1,
+          user:wam_string_concat_guard/3,
           user:wam_arith_eq_42/1,
           user:wam_arith_eq_float/1,
           user:wam_arith_neq_42/1,
@@ -832,6 +844,11 @@ smoke_cases([
     case('wam_number_chars_guard/2', args(42, '[''4'',''2'']'), "true"),
     case('wam_number_chars_guard/2', args(42, '[''4'']'), "false"),
     case('wam_text_conversion_unbound_pair/1', a, "false"),
+    case('wam_atom_concat_guard/3', args(fo, o, foo), "true"),
+    case('wam_atom_concat_guard/3', args(fo, o, bar), "false"),
+    case('wam_atom_concat_new_atom/0', no_args, "true"),
+    case('wam_atom_concat_unbound_left/1', foo, "false"),
+    case('wam_string_concat_guard/3', args(fo, o, foo), "true"),
     case('wam_arith_eq_42/1', 42, "true"),
     case('wam_arith_eq_42/1', 3.5, "false"),
     case('wam_arith_eq_float/1', 3.5, "true"),
@@ -1169,8 +1186,10 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-atom-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-number-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-number-chars-guard-2"),
+    has(CoreCode, "defn lowered-wam-atom-concat-guard-3"),
     has(CoreCode, "runtime/ground-term?"),
-    has(CoreCode, "runtime/apply-text-conversion-solution").
+    has(CoreCode, "runtime/apply-text-conversion-solution"),
+    has(CoreCode, "runtime/apply-atom-concat-solution").
 
 assert_lowered_arithmetic_comparison_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
@@ -1370,8 +1389,14 @@ prolog_term_string_to_edn("c", "\"c\"") :- !.
 prolog_term_string_to_edn("d", "\"d\"") :- !.
 prolog_term_string_to_edn(f, "\"f\"") :- !.
 prolog_term_string_to_edn("f", "\"f\"") :- !.
+prolog_term_string_to_edn(fo, "\"fo\"") :- !.
+prolog_term_string_to_edn("fo", "\"fo\"") :- !.
 prolog_term_string_to_edn(foo, "\"foo\"") :- !.
 prolog_term_string_to_edn("foo", "\"foo\"") :- !.
+prolog_term_string_to_edn(o, "\"o\"") :- !.
+prolog_term_string_to_edn("o", "\"o\"") :- !.
+prolog_term_string_to_edn(bar, "\"bar\"") :- !.
+prolog_term_string_to_edn("bar", "\"bar\"") :- !.
 prolog_term_string_to_edn("z", "\"z\"") :- !.
 prolog_term_string_to_edn('f(a)', "{:tag :struct :functor \"f/1\" :args [\"a\"]}") :- !.
 prolog_term_string_to_edn('f(a,b)', "{:tag :struct :functor \"f/2\" :args [\"a\" \"b\"]}") :- !.


### PR DESCRIPTION
## Summary

- Adds Clojure WAM support for deterministic forward `atom_concat/3`.
- Adds `string_concat/3` as an alias over the same atom/string representation.
- Direct-lowers concat calls to a runtime helper instead of routing through the interpreted builtin path.
- Interns the concatenated output atom in the runtime intern context.
- Adds lowered-emitter and runtime smoke coverage for success, mismatch, runtime-created output atoms, alias behavior, and unsupported reverse/unbound mode.

## Semantics

The implementation supports:

- `atom_concat(+Left, +Right, ?Out)`
- `string_concat(+Left, +Right, ?Out)`

Unsupported reverse/split modes fail cleanly for now. This keeps the branch deterministic and avoids introducing nondeterministic split enumeration in the same change.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
