### PR TITLE
Feat/wam go sort builtins

### DIFF
--- a/PR_go_wam_sort_builtins.md
+++ b/PR_go_wam_sort_builtins.md
@@ -1,0 +1,24 @@
+# PR Title
+
+Add Go WAM sort and msort builtins
+
+# PR Description
+
+## Summary
+
+- Adds generated Go WAM runtime support for deterministic `sort/2` and `msort/2`.
+- Registers both predicates as direct Go WAM builtins so compiled calls emit `BuiltinCall` instructions.
+- Extends the generated Go builtin E2E test to cover sorted output, duplicate removal for `sort/2`, duplicate preservation for `msort/2`, mixed atom/integer ordering, and malformed-list failure.
+- Updates the Go WAM parity audit to record the closed structural-list parity gap against the broader cross-target baseline.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- direct emitter checks for `call(sort/2,2)` and `call(msort/2,2)`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -11,7 +11,7 @@ current cross-target builtin/runtime baseline.
 | Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries, indexed atom fact streams, `member/2` builtin retries | Choice point stack with normal, builtin, and fact-stream resume states | Present for current resume-state baseline |
 | Direct fact dispatch | `call_indexed_atom_fact2`, `AtomFact2Source` registry, TSV-backed and LMDB-artifact atom fact loading, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Present for current external atom fact-source baseline |
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
-| Structural builtins | `member/2`, `memberchk/2`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, and `numlist/3` | Present for current baseline structural checks, with expanded cross-target list builtins |
+| Structural builtins | `member/2`, `memberchk/2`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2` | Includes `=</2` | Present for current baseline comparisons |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
@@ -46,6 +46,10 @@ current cross-target builtin/runtime baseline.
 - Deterministic `numlist/3` is now covered by the generated Go WAM builtin E2E
   test for closed integer range construction and `Low > High` failure,
   matching the Clojure/R range-list surface.
+- Deterministic `sort/2` and `msort/2` are now covered by the generated Go WAM
+  builtin E2E test for standard ordered sorting, duplicate removal in
+  `sort/2`, duplicate preservation in `msort/2`, mixed atom/integer ordering,
+  and malformed-list failure, matching the Clojure/R ordered-list surface.
 - Go WAM choice points now have explicit generated-runtime coverage for normal
   clause retries, indexed alternatives, foreign stream retries, indexed atom
   fact streams, and `member/2` builtin retries.

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -437,6 +437,12 @@ wam_go_direct_builtin("nth1/3", 3, 'nth1/3').
 wam_go_direct_builtin(numlist/3, 3, 'numlist/3').
 wam_go_direct_builtin('numlist/3', 3, 'numlist/3').
 wam_go_direct_builtin("numlist/3", 3, 'numlist/3').
+wam_go_direct_builtin(sort/2, 2, 'sort/2').
+wam_go_direct_builtin('sort/2', 2, 'sort/2').
+wam_go_direct_builtin("sort/2", 2, 'sort/2').
+wam_go_direct_builtin(msort/2, 2, 'msort/2').
+wam_go_direct_builtin('msort/2', 2, 'msort/2').
+wam_go_direct_builtin("msort/2", 2, 'msort/2').
 
 wam_instruction_to_go_literal(get_constant(C, Ai), GoLiteral) :-
     go_value_literal(C, GoVal),

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"math"
 	"runtime"
-	"strings"
+	"sort"
 	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -1224,6 +1225,26 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			items = append(items, &Integer{Val: n})
 		}
 		return vm.Unify(arg3, &List{Elements: items})
+	case "sort/2", "msort/2":
+		items, ok := vm.listToSlice(arg1)
+		if !ok {
+			return false
+		}
+		sorted := append([]Value(nil), items...)
+		sort.SliceStable(sorted, func(i, j int) bool {
+			return compareValues(vm.deref(sorted[i]), vm.deref(sorted[j])) < 0
+		})
+		if op == "sort/2" {
+			deduped := make([]Value, 0, len(sorted))
+			for _, item := range sorted {
+				item = vm.deref(item)
+				if len(deduped) == 0 || compareValues(vm.deref(deduped[len(deduped)-1]), item) != 0 {
+					deduped = append(deduped, item)
+				}
+			}
+			sorted = deduped
+		}
+		return vm.Unify(arg2, &List{Elements: sorted})
 	case "functor/3":
 		t := vm.deref(arg1)
 		if isUnbound(t) {

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -13,6 +13,7 @@
 :- dynamic user:test_last_builtin/0.
 :- dynamic user:test_nth_builtin/0.
 :- dynamic user:test_numlist_builtin/0.
+:- dynamic user:test_sort_builtin/0.
 :- dynamic user:test_set_aggregate/0.
 :- dynamic user:test_unify_builtin/0.
 :- dynamic user:test_neg_fact/1.
@@ -95,6 +96,16 @@ test(builtins_execution) :-
                 S = [3],
                 \+ numlist(5, 2, _)
             )),
+          assertz(user:test_sort_builtin :-
+            (   sort([3,1,2,1,3], S),
+                S = [1,2,3],
+                msort([3,1,2,1,3], M),
+                M = [1,1,2,3,3],
+                sort([foo,1,bar,2], Mixed),
+                Mixed = [bar,foo,1,2],
+                \+ sort([a|b], _),
+                \+ msort([a|b], _)
+            )),
           assertz(user:test_set_aggregate :-
             (   aggregate_all(set(X), member(X, [a,b,a]), S),
                 length(S, 2),
@@ -124,6 +135,7 @@ test(builtins_execution) :-
           retractall(user:test_last_builtin),
           retractall(user:test_nth_builtin),
           retractall(user:test_numlist_builtin),
+          retractall(user:test_sort_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
           retractall(user:test_neg_fact(_)),
@@ -133,7 +145,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -170,6 +182,8 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "nth0/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "nth1/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "numlist/3"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "sort/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "msort/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "\\\\+/1"')),
     assertion(sub_string(LibCode, _, _, _, 'AggType: "set"')),
 
@@ -255,6 +269,14 @@ func main() {
 		fmt.Println("NUMLIST_FAILURE")
 	}
 
+	sortVM := wam.NewWamState(wam.Test_sort_builtinCode, wam.Test_sort_builtinLabels)
+	sortVM.PC = wam.Test_sort_builtinStartPC
+	if sortVM.Run() {
+		fmt.Println("SORT_SUCCESS")
+	} else {
+		fmt.Println("SORT_FAILURE")
+	}
+
 	setVM := wam.NewWamState(wam.Test_set_aggregateCode, wam.Test_set_aggregateLabels)
 	setVM.PC = wam.Test_set_aggregateStartPC
 	if setVM.Run() {
@@ -312,6 +334,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "LAST_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NTH_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NUMLIST_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "SORT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NEG_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM sort and msort builtins

## Summary

- Adds generated Go WAM runtime support for deterministic `sort/2` and `msort/2`.
- Registers both predicates as direct Go WAM builtins so compiled calls emit `BuiltinCall` instructions.
- Extends the generated Go builtin E2E test to cover sorted output, duplicate removal for `sort/2`, duplicate preservation for `msort/2`, mixed atom/integer ordering, and malformed-list failure.
- Updates the Go WAM parity audit to record the closed structural-list parity gap against the broader cross-target baseline.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- direct emitter checks for `call(sort/2,2)` and `call(msort/2,2)`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`
