### PR TITLE
bench(csharp-query): Report policy-vs-measured artifact diffs

### DIFF
--- a/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
+++ b/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
@@ -118,6 +118,21 @@ POLICY_HEADERS = [
     "values_by_mode",
 ]
 
+POLICY_COMPARE_HEADERS = [
+    "scale",
+    "relation",
+    "rows",
+    "distinct_categories",
+    "lookup_keys",
+    "access_shape",
+    "metric",
+    "policy_mode",
+    "best_artifact_mode",
+    "best_artifact_value",
+    "status",
+    "values_by_mode",
+]
+
 ACCESS_SHAPE_METRICS = (
     ("lookup_c0", "lookup_ms_by_mode"),
     ("lookup_c1", "lookup_col1_ms_by_mode"),
@@ -139,6 +154,11 @@ class SummaryRow:
 
 @dataclass(frozen=True)
 class PolicyRow:
+    values: dict[str, str]
+
+
+@dataclass(frozen=True)
+class PolicyCompareRow:
     values: dict[str, str]
 
 
@@ -624,6 +644,58 @@ def policy_rows_from_summaries(rows: list[SummaryRow]) -> list[PolicyRow]:
     return policy_rows
 
 
+def effective_distance_policy_mode(relation: str, row_count: int, access_shape: str) -> str:
+    if relation == "article_category" and row_count >= 5_000_000:
+        return {
+            "lookup_c0": "lmdb",
+            "lookup_c1": "mmap-array",
+            "bucket_c0": "delimited-artifact",
+            "bucket_c1": "mmap-array",
+            "scan": "mmap-array",
+            "storage": "mmap-array",
+        }.get(access_shape, "binary-artifact")
+
+    if relation in {"article_category", "category_parent"}:
+        return {
+            "lookup_c0": "mmap-array",
+            "lookup_c1": "mmap-array",
+            "bucket_c0": "mmap-array",
+            "bucket_c1": "mmap-array",
+            "scan": "mmap-array",
+            "storage": "mmap-array",
+        }.get(access_shape, "binary-artifact")
+
+    return "binary-artifact"
+
+
+def policy_compare_rows_from_summaries(rows: list[SummaryRow]) -> list[PolicyCompareRow]:
+    compare_rows: list[PolicyCompareRow] = []
+    for policy_row in policy_rows_from_summaries(rows):
+        base = policy_row.values
+        row_count = int(base["rows"])
+        policy_mode = effective_distance_policy_mode(base["relation"], row_count, base["access_shape"])
+        best_artifact_mode = base["best_artifact_mode"]
+        compare_rows.append(
+            PolicyCompareRow(
+                {
+                    "scale": base["scale"],
+                    "relation": base["relation"],
+                    "rows": base["rows"],
+                    "distinct_categories": base["distinct_categories"],
+                    "lookup_keys": base["lookup_keys"],
+                    "access_shape": base["access_shape"],
+                    "metric": base["metric"],
+                    "policy_mode": policy_mode,
+                    "best_artifact_mode": best_artifact_mode,
+                    "best_artifact_value": base["best_artifact_value"],
+                    "status": "match" if policy_mode == best_artifact_mode else "diff",
+                    "values_by_mode": base["values_by_mode"],
+                }
+            )
+        )
+    return compare_rows
+
+
 def render_summary_tsv(rows: list[SummaryRow]) -> str:
     lines = ["\t".join(SUMMARY_HEADERS)]
     lines.extend("\t".join(row.values[column] for column in SUMMARY_HEADERS) for row in rows)
@@ -680,6 +752,30 @@ def render_policy_markdown(rows: list[PolicyRow]) -> str:
         value = {column: markdown_cell(cell) for column, cell in row.values.items()}
         lines.append(
             "| {scale} | {relation} | {rows} | {access_shape} | {metric} | {best_mode} | {best_value} | {best_artifact_mode} | {best_artifact_value} | {values_by_mode} |".format(
+                **value
+            )
+        )
+    return "\n".join(lines)
+
+
+def render_policy_compare_tsv(rows: list[PolicyCompareRow]) -> str:
+    lines = ["\t".join(POLICY_COMPARE_HEADERS)]
+    lines.extend("\t".join(row.values[column] for column in POLICY_COMPARE_HEADERS) for row in rows)
+    return "\n".join(lines)
+
+
+def render_policy_compare_markdown(rows: list[PolicyCompareRow]) -> str:
+    def markdown_cell(value: str) -> str:
+        return value.replace("|", "<br>")
+
+    lines = [
+        "| Scale | Relation | Rows | Access shape | Metric | Policy mode | Best artifact mode | Best artifact value | Status | Values by mode |",
+        "| --- | --- | ---: | --- | --- | --- | --- | ---: | --- | --- |",
+    ]
+    for row in rows:
+        value = {column: markdown_cell(cell) for column, cell in row.values.items()}
+        lines.append(
+            "| {scale} | {relation} | {rows} | {access_shape} | {metric} | {policy_mode} | {best_artifact_mode} | {best_artifact_value} | {status} | {values_by_mode} |".format(
                 **value
             )
         )
@@ -781,6 +877,8 @@ def main(argv: list[str] | None = None) -> int:
             "summary-full-markdown",
             "policy-tsv",
             "policy-markdown",
+            "policy-compare-tsv",
+            "policy-compare-markdown",
         ),
         default="tsv",
     )
@@ -877,6 +975,10 @@ def main(argv: list[str] | None = None) -> int:
         print(render_policy_tsv(policy_rows_from_summaries(summaries)))
     elif args.format == "policy-markdown":
         print(render_policy_markdown(policy_rows_from_summaries(summaries)))
+    elif args.format == "policy-compare-tsv":
+        print(render_policy_compare_tsv(policy_compare_rows_from_summaries(summaries)))
+    elif args.format == "policy-compare-markdown":
+        print(render_policy_compare_markdown(policy_compare_rows_from_summaries(summaries)))
     elif args.format == "markdown":
         print(render_markdown(rows))
     else:

--- a/tests/test_csharp_query_effective_distance_artifact_backends.py
+++ b/tests/test_csharp_query_effective_distance_artifact_backends.py
@@ -301,6 +301,69 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
         self.assertIn("| dev | category_parent | 6 | lookup_c0 | ms | mmap-array | 1.250 |", markdown)
         self.assertIn("lmdb:2.000<br>mmap-array:1.250<br>preload:1.500", markdown)
 
+    def test_policy_compare_rows_report_runtime_policy_match_and_diff(self) -> None:
+        row = MODULE.SummaryRow(
+            {
+                "scale": "enwiki_page_5m",
+                "relation": "article_category",
+                "rows": "5000000",
+                "distinct_categories": "1918305",
+                "lookup_keys": "128",
+                "best_lookup_mode": "lmdb",
+                "best_lookup_col1_mode": "preload",
+                "best_bucket_mode": "mmap-array",
+                "best_bucket_col1_mode": "mmap-array",
+                "best_scan_mode": "preload",
+                "smallest_artifact_mode": "mmap-array",
+                "lookup_ms_by_mode": "lmdb:3.251|mmap-array:3.288|preload:4.000",
+                "lookup_col1_ms_by_mode": "lmdb:1219.110|mmap-array:236.382|preload:20.000",
+                "bucket_ms_by_mode": "delimited-artifact:400.000|lmdb:500.000|mmap-array:350.000|preload:600.000",
+                "bucket_col1_ms_by_mode": "delimited-artifact:600.000|lmdb:700.000|mmap-array:350.000|preload:500.000",
+                "scan_ms_by_mode": "lmdb:900.000|mmap-array:850.000|preload:50.000",
+                "artifact_bytes_by_mode": "lmdb:142443019|mmap-array:80000643|preload:0",
+            }
+        )
+
+        rows = MODULE.policy_compare_rows_from_summaries([row])
+        by_shape = {policy.values["access_shape"]: policy.values for policy in rows}
+
+        self.assertEqual(by_shape["lookup_c0"]["policy_mode"], "lmdb")
+        self.assertEqual(by_shape["lookup_c0"]["best_artifact_mode"], "lmdb")
+        self.assertEqual(by_shape["lookup_c0"]["status"], "match")
+        self.assertEqual(by_shape["bucket_c0"]["policy_mode"], "delimited-artifact")
+        self.assertEqual(by_shape["bucket_c0"]["best_artifact_mode"], "mmap-array")
+        self.assertEqual(by_shape["bucket_c0"]["status"], "diff")
+        self.assertEqual(by_shape["storage"]["policy_mode"], "mmap-array")
+        self.assertEqual(by_shape["storage"]["status"], "match")
+
+    def test_policy_compare_renderers_include_status(self) -> None:
+        rows = [
+            MODULE.PolicyCompareRow(
+                {
+                    "scale": "dev",
+                    "relation": "category_parent",
+                    "rows": "6",
+                    "distinct_categories": "4",
+                    "lookup_keys": "2",
+                    "access_shape": "lookup_c0",
+                    "metric": "ms",
+                    "policy_mode": "mmap-array",
+                    "best_artifact_mode": "lmdb",
+                    "best_artifact_value": "1.250",
+                    "status": "diff",
+                    "values_by_mode": "lmdb:1.250|mmap-array:2.000",
+                }
+            )
+        ]
+
+        tsv = MODULE.render_policy_compare_tsv(rows)
+        markdown = MODULE.render_policy_compare_markdown(rows)
+        self.assertTrue(tsv.startswith("scale\trelation\trows\tdistinct_categories\tlookup_keys\taccess_shape"))
+        self.assertIn("\tlookup_c0\tms\tmmap-array\tlmdb\t1.250\tdiff\t", tsv)
+        self.assertIn("| Access shape | Metric | Policy mode | Best artifact mode |", markdown)
+        self.assertIn("| dev | category_parent | 6 | lookup_c0 | ms | mmap-array | lmdb | 1.250 | diff |", markdown)
+        self.assertIn("lmdb:1.250<br>mmap-array:2.000", markdown)
+
     def test_artifact_root_reuses_existing_manifests(self) -> None:
         if shutil.which("dotnet") is None:
             self.skipTest("dotnet is not available")


### PR DESCRIPTION
  ## Summary

  - Adds `policy-compare-tsv` and `policy-compare-markdown` formats to the C# effective-distance artifact backend benchmark.
  - Reports the runtime policy-selected artifact mode beside the measured best artifact mode for each access shape.
  - Marks each row as `match` or `diff` so policy calibration gaps are visible without manually comparing benchmark tables.
  - Adds test coverage for matching and divergent policy outcomes, plus TSV and Markdown renderers.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py tests/test_csharp_query_lmdb_provider_smoke.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime_lmdb/UnifyWeaver.QueryRuntime.Lmdb.csproj`
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
  - `git diff --check`