### PR TITLE
feat(wam-c): add weighted shortest path kernel

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,7 +4,7 @@ Status date: 2026-05-17
 
 Base verified locally:
 
-- `main` at `07e04153` (`Merge pull request #2225 from s243a/feat/csharp-query-effective-distance-policy-provider-benchmark`)
+- `main` at `991062ba` (`Merge pull request #2227 from s243a/feat/wam-c-transitive-step-parent-distance-kernel`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
@@ -17,7 +17,7 @@ Base verified locally:
 
 Active branch:
 
-- `feat/wam-c-transitive-step-parent-distance-kernel`
+- `feat/wam-c-weighted-shortest-path-kernel`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -77,6 +77,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | `transitive_distance3` native kernel | Done | C shared-kernel detector accepts `transitive_distance3`, emits detected setup, registers a native arity-3 foreign handler, and covers direct plus detected-project executable smokes |
 | `transitive_parent_distance4` native kernel | Done | C shared-kernel detector accepts `transitive_parent_distance4`, emits detected setup, registers a native arity-4 foreign handler, and covers direct plus detected-project executable smokes |
 | `transitive_step_parent_distance5` native kernel | Done | C shared-kernel detector accepts `transitive_step_parent_distance5`, emits detected setup, registers a native arity-5 foreign handler, and covers direct plus detected-project executable smokes |
+| `weighted_shortest_path3` native kernel | Done | C shared-kernel detector accepts `weighted_shortest_path3`, emits detected setup, registers a native arity-3 foreign handler, and covers direct plus detected-project executable smokes over integer weighted edges |
 
 ## Current C Target Baseline
 
@@ -103,7 +104,8 @@ The C target is now a credible small WAM backend:
   emitted as native C foreign handlers behind `call_foreign` trampolines.
 - Supports deterministic native `category_ancestor/4`, `transitive_closure2`,
   `transitive_distance3`, `transitive_parent_distance4`, and
-  `transitive_step_parent_distance5` handlers over an in-memory edge table.
+  `transitive_step_parent_distance5` handlers over an in-memory edge table,
+  plus `weighted_shortest_path3` over in-memory integer weighted edges.
 - Supports loading category-parent facts from TSV through a small
   `WamFactSource` interface.
 - Supports collecting all integer hop results for native `category_ancestor/4`
@@ -144,48 +146,48 @@ missing important target features; `Missing` = no comparable C path yet.
 | First-arg indexing | Done | Done | Done | C has constants, structures, mixed term, and list dispatch. |
 | Second-arg indexing | Partial | Partial/Done | Partial/Done | C has constant A2 dispatch; broaden tests if this becomes hot. |
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
-| Builtin calls | Partial | Broader | Broader | C has a growing builtin set. Active branch adds generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
+| Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
 | Negation / control builtins | Partial | Broader | Broader | C likely needs explicit tests for `\+/1`, cut interactions, and if-then-else lowering. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
-| Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, and native transitive closure/distance/parent-distance/step-parent-distance handlers; continue adding shared kernels one at a time. |
-| Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`, `transitive_closure2`, `transitive_distance3`, `transitive_parent_distance4`, and `transitive_step_parent_distance5`; Haskell and Rust cover a broader shared-kernel registry. |
+| Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, and integer-weighted shortest path; continue adding shared kernels one at a time. |
+| Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`, `transitive_closure2`, `transitive_distance3`, `transitive_parent_distance4`, `transitive_step_parent_distance5`, and `weighted_shortest_path3`; Haskell and Rust cover a broader shared-kernel registry. |
 | Lowered/native helper functions | Partial/Done | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, comparison-filter helpers, rejection metadata, repeated-variable filter hardening, empty-result rejection metadata, and projected body-call helper expansion. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
 | Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB `kernels_on`/`kernels_off`; next gap is larger artifact layouts. |
 | Classic-program e2e suite | Partial/Done | Partial/Done | Partial/Done | C now covers generated Fibonacci-style recursion with arithmetic; add Ackermann-style depth only if routine runtime stays acceptable. |
-| Memory lifecycle | Partial/Done | Runtime-managed | Runtime-managed | Active branch adds an ASAN lifecycle smoke and fixes stale top-level choicepoints plus indexed `retry_me_else` without an active choicepoint. |
+| Memory lifecycle | Partial/Done | Runtime-managed | Runtime-managed | C has ASAN lifecycle smoke coverage for repeated setup, indexed clauses, fact-source loading, native kernel dispatch, and repeated top-level calls. |
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-weighted-shortest-path-kernel`
+### 1. `feat/wam-c-astar-shortest-path-kernel`
 
 Goal: add the next shared recursive kernel to C from the Haskell/Rust parity
-surface, continuing from unweighted BFS-style kernels to
-`weighted_shortest_path3`.
+surface, continuing from Dijkstra-style weighted shortest paths to
+`astar_shortest_path4`.
 
 Scope:
 
-- Extend the C recursive-kernel registration path beyond `category_ancestor/4`
-  and the existing transitive kernels for the shared
-  `weighted_shortest_path3` detector.
-- Add a native C handler and executable smoke for a small weighted edge result.
-- Keep TSV/LMDB fact loading out of scope unless the small in-memory kernel
-  path exposes a need for it.
+- Extend the C recursive-kernel registration path beyond the existing
+  transitive and weighted shortest-path kernels for the shared
+  `astar_shortest_path4` detector.
+- Add a native C handler and executable smoke for a small weighted edge result
+  with an admissible direct-distance heuristic.
+- Keep TSV/LMDB fact loading and floating-point result support out of scope
+  unless the small in-memory kernel path exposes a direct need for it.
 
 Status: recommended next.
 
 Reason:
 
-- `transitive_step_parent_distance5` is now covered through direct native
-  registration and detected-project setup.
+- `weighted_shortest_path3` is now covered through direct native registration
+  and detected-project setup over integer weighted edges.
 - `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` records
-  `weighted_shortest_path3/3` as the next measured native kernel after the
-  unweighted BFS family.
-- Haskell and Rust already cover `weighted_shortest_path3`; it is the next
-  shared-kernel parity move before A*.
+  `weighted_shortest_path3/3` before the broader A* family.
+- Haskell and Rust already cover `astar_shortest_path4`; it is the next
+  shared-kernel parity move after weighted shortest path.
 
 ### 2. `investigate/wam-c-accumulated-runtime-cost`
 
@@ -286,6 +288,21 @@ Evidence:
 | Direct executable smoke | `tc_step_parent_distance/5` succeeds for direct and recursive edges, binds unbound target/step/parent/distance, accepts bound step/parent/distance, and fails for a reversed edge. |
 | Detected-project smoke | Generated project detection lowers `tc_step_parent_distance/5` to a `call_foreign` trampoline and runs through `setup_detected_wam_c_kernels`. |
 
+### Completed Shared Kernel Slice: `feat/wam-c-weighted-shortest-path-kernel`
+
+Goal: add the first measured weighted shared recursive kernel to C from the
+Haskell/Rust parity surface.
+
+Evidence:
+
+| Surface | Coverage |
+|---|---|
+| Kernel support predicate | `wam_c_supported_kernel/1` accepts `recursive_kernel(weighted_shortest_path3, ...)`. |
+| Detected setup emission | `generate_setup_detected_kernels_c/2` emits `wam_register_weighted_shortest_path_kernel`. |
+| Runtime handler | `wam_weighted_shortest_path_handler` supports bound-target reachability, first-solution unbound target mode, and integer shortest-weight binding over registered in-memory weighted edges. |
+| Direct executable smoke | `weighted_path/3` chooses the lower-cost two-hop route over a higher-cost direct-looking alternative, accepts a bound weight, binds an unbound target/weight, and fails for a reversed edge. |
+| Detected-project smoke | Generated project detection lowers `weighted_path/3` to a `call_foreign` trampoline and runs through `setup_detected_wam_c_kernels`. |
+
 ## Completed Atom Concat Builtin
 
 The merged `feat/wam-c-atom-concat-builtin` branch added deterministic
@@ -363,9 +380,10 @@ After hash-bucket row dispatch but before compact row tables:
 
 ## Suggested Immediate Next Step
 
-Proceed with `feat/wam-c-weighted-shortest-path-kernel`.
+Proceed with `feat/wam-c-astar-shortest-path-kernel`.
 
-Keep it narrow: add `weighted_shortest_path3` over a small in-memory weighted
-edge surface and prove direct plus detected-project executable smokes. Treat
-broader fact storage, LMDB loading, and runtime profiling as follow-up branches
-unless this slice exposes a direct blocker.
+Keep it narrow: add `astar_shortest_path4` over small in-memory weighted and
+direct-distance edge surfaces and prove direct plus detected-project executable
+smokes. Treat broader fact storage, LMDB loading, floating-point output, and
+runtime profiling as follow-up branches unless this slice exposes a direct
+blocker.

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -113,6 +113,12 @@ typedef struct {
 } CategoryEdge;
 
 typedef struct {
+    const char *source;
+    const char *target;
+    int weight;
+} WeightedEdge;
+
+typedef struct {
     CategoryEdge *edges;
     int edge_count;
     int edge_cap;
@@ -237,6 +243,11 @@ struct WamState {
     int category_edge_count;
     int category_edge_cap;
     int category_max_depth;
+
+    /* Native weighted_shortest_path3 kernel data */
+    WeightedEdge *weighted_edges;
+    int weighted_edge_count;
+    int weighted_edge_cap;
 };
 
 bool step_wam(WamState* state, Instruction* instr);
@@ -248,16 +259,19 @@ bool wam_execute_builtin(WamState *state, const char *op, int arity);
 bool wam_execute_foreign_predicate(WamState *state, const char *pred, int arity);
 void wam_register_category_parent(WamState *state, const char *child, const char *parent);
 void wam_register_transitive_edge(WamState *state, const char *child, const char *parent);
+void wam_register_weighted_edge(WamState *state, const char *source, const char *target, int weight);
 void wam_register_category_ancestor_kernel(WamState *state, const char *pred, int max_depth);
 void wam_register_transitive_closure_kernel(WamState *state, const char *pred);
 void wam_register_transitive_distance_kernel(WamState *state, const char *pred);
 void wam_register_transitive_parent_distance_kernel(WamState *state, const char *pred);
 void wam_register_transitive_step_parent_distance_kernel(WamState *state, const char *pred);
+void wam_register_weighted_shortest_path_kernel(WamState *state, const char *pred);
 bool wam_category_ancestor_handler(WamState *state, const char *pred, int arity);
 bool wam_transitive_closure_handler(WamState *state, const char *pred, int arity);
 bool wam_transitive_distance_handler(WamState *state, const char *pred, int arity);
 bool wam_transitive_parent_distance_handler(WamState *state, const char *pred, int arity);
 bool wam_transitive_step_parent_distance_handler(WamState *state, const char *pred, int arity);
+bool wam_weighted_shortest_path_handler(WamState *state, const char *pred, int arity);
 void wam_fact_source_init(WamFactSource *source);
 void wam_fact_source_close(WamFactSource *source);
 bool wam_fact_source_load_tsv(WamState *state, WamFactSource *source, const char *path);

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -136,6 +136,7 @@ wam_c_supported_kernel(recursive_kernel(transitive_closure2, _Pred, _ConfigOps))
 wam_c_supported_kernel(recursive_kernel(transitive_distance3, _Pred, _ConfigOps)).
 wam_c_supported_kernel(recursive_kernel(transitive_parent_distance4, _Pred, _ConfigOps)).
 wam_c_supported_kernel(recursive_kernel(transitive_step_parent_distance5, _Pred, _ConfigOps)).
+wam_c_supported_kernel(recursive_kernel(weighted_shortest_path3, _Pred, _ConfigOps)).
 
 %% generate_setup_detected_kernels_c(+DetectedKernels, -CCode)
 %  Emit C startup wiring for detected kernels. This function registers only
@@ -169,6 +170,10 @@ wam_c_kernel_registration_line(Key-recursive_kernel(transitive_parent_distance4,
 wam_c_kernel_registration_line(Key-recursive_kernel(transitive_step_parent_distance5, _Pred, _ConfigOps), Line) :-
     format(atom(Line),
            '    wam_register_transitive_step_parent_distance_kernel(state, "~w");',
+           [Key]).
+wam_c_kernel_registration_line(Key-recursive_kernel(weighted_shortest_path3, _Pred, _ConfigOps), Line) :-
+    format(atom(Line),
+           '    wam_register_weighted_shortest_path_kernel(state, "~w");',
            [Key]).
 
 wam_c_kernel_max_depth(ConfigOps, MaxDepth) :-
@@ -1998,6 +2003,7 @@ void wam_free_state(WamState *state) {
     free(state->B_array);
     free(state->E_array);
     free(state->category_edges);
+    free(state->weighted_edges);
     memset(state, 0, sizeof(WamState));
 }
 
@@ -2293,6 +2299,17 @@ void wam_register_transitive_edge(WamState *state, const char *child, const char
     wam_register_category_parent(state, child, parent);
 }
 
+void wam_register_weighted_edge(WamState *state, const char *source, const char *target, int weight) {
+    if (state->weighted_edge_count >= state->weighted_edge_cap) {
+        state->weighted_edge_cap = state->weighted_edge_cap ? state->weighted_edge_cap * 2 : WAM_INITIAL_CAP;
+        state->weighted_edges = realloc(state->weighted_edges, sizeof(WeightedEdge) * state->weighted_edge_cap);
+    }
+    state->weighted_edges[state->weighted_edge_count].source = wam_intern_atom(state, source);
+    state->weighted_edges[state->weighted_edge_count].target = wam_intern_atom(state, target);
+    state->weighted_edges[state->weighted_edge_count].weight = weight;
+    state->weighted_edge_count++;
+}
+
 void wam_fact_source_init(WamFactSource *source) {
     memset(source, 0, sizeof(WamFactSource));
 }
@@ -2475,6 +2492,10 @@ void wam_register_transitive_parent_distance_kernel(WamState *state, const char 
 
 void wam_register_transitive_step_parent_distance_kernel(WamState *state, const char *pred) {
     wam_register_foreign_predicate(state, pred, 5, wam_transitive_step_parent_distance_handler);
+}
+
+void wam_register_weighted_shortest_path_kernel(WamState *state, const char *pred) {
+    wam_register_foreign_predicate(state, pred, 3, wam_weighted_shortest_path_handler);
 }
 
 static bool wam_value_as_atom(WamState *state, WamValue value, const char **out) {
@@ -2885,6 +2906,113 @@ bool wam_transitive_step_parent_distance_handler(WamState *state, const char *pr
            wam_unify(state, &state->A[2], &step_value) &&
            wam_unify(state, &state->A[3], &parent_value) &&
            wam_unify(state, &state->A[4], &distance_value);
+}
+
+static bool wam_weighted_shortest_path_dijkstra(WamState *state,
+                                                const char *start,
+                                                const char *target,
+                                                const char **target_out,
+                                                int *weight_out) {
+    const char *nodes[256];
+    int distances[256];
+    bool done[256];
+    int node_count = 0;
+    const int inf = 1073741823;
+
+    nodes[node_count] = start;
+    distances[node_count] = 0;
+    done[node_count] = false;
+    node_count++;
+
+    while (true) {
+        int best_idx = -1;
+        int best_distance = inf;
+        for (int i = 0; i < node_count; i++) {
+            if (!done[i] && distances[i] < best_distance) {
+                best_idx = i;
+                best_distance = distances[i];
+            }
+        }
+        if (best_idx < 0) break;
+
+        done[best_idx] = true;
+        const char *node = nodes[best_idx];
+        if (target && strcmp(node, target) == 0 && best_distance > 0) {
+            *target_out = node;
+            *weight_out = best_distance;
+            return true;
+        }
+
+        for (int i = 0; i < state->weighted_edge_count; i++) {
+            WeightedEdge *edge = &state->weighted_edges[i];
+            if (edge->weight < 0) continue;
+            if (strcmp(edge->source, node) != 0) continue;
+            int next_idx = -1;
+            for (int j = 0; j < node_count; j++) {
+                if (strcmp(nodes[j], edge->target) == 0) {
+                    next_idx = j;
+                    break;
+                }
+            }
+            if (next_idx < 0) {
+                if (node_count >= 256) return false;
+                next_idx = node_count;
+                nodes[next_idx] = edge->target;
+                distances[next_idx] = inf;
+                done[next_idx] = false;
+                node_count++;
+            }
+            if (best_distance <= inf - edge->weight &&
+                best_distance + edge->weight < distances[next_idx]) {
+                distances[next_idx] = best_distance + edge->weight;
+            }
+        }
+    }
+
+    if (!target) {
+        int best_idx = -1;
+        int best_distance = inf;
+        for (int i = 0; i < node_count; i++) {
+            if (strcmp(nodes[i], start) != 0 && distances[i] < best_distance) {
+                best_idx = i;
+                best_distance = distances[i];
+            }
+        }
+        if (best_idx >= 0) {
+            *target_out = nodes[best_idx];
+            *weight_out = best_distance;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool wam_weighted_shortest_path_handler(WamState *state, const char *pred, int arity) {
+    (void)pred;
+    if (arity != 3) return false;
+
+    const char *start = NULL;
+    if (!wam_value_as_atom(state, state->A[0], &start)) return false;
+
+    WamValue *target_cell = wam_deref_ptr(state, &state->A[1]);
+    const char *target = NULL;
+    if (target_cell->tag == VAL_ATOM) {
+        target = target_cell->data.atom;
+    } else if (!val_is_unbound(*target_cell)) {
+        return false;
+    }
+
+    const char *result_target = NULL;
+    int result_weight = 0;
+    if (!wam_weighted_shortest_path_dijkstra(state, start, target,
+                                             &result_target, &result_weight)) {
+        return false;
+    }
+
+    WamValue target_value = val_atom(result_target);
+    WamValue weight_value = val_int(result_weight);
+    return wam_unify(state, &state->A[1], &target_value) &&
+           wam_unify(state, &state->A[2], &weight_value);
 }
 '.
 

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -310,6 +310,18 @@ test_transitive_step_parent_distance_kernel_generation :-
     ;   fail_test(Test, 'transitive_step_parent_distance5 native kernel helpers missing')
     ).
 
+test_weighted_shortest_path_kernel_generation :-
+    Test = 'WAM-C: weighted_shortest_path3 native kernel helpers generated',
+    (   compile_wam_runtime_to_c([], RuntimeCode),
+        atom_string(RuntimeCode, S),
+        sub_string(S, _, _, _, 'void wam_register_weighted_edge'),
+        sub_string(S, _, _, _, 'void wam_register_weighted_shortest_path_kernel'),
+        sub_string(S, _, _, _, 'bool wam_weighted_shortest_path_handler'),
+        sub_string(S, _, _, _, 'wam_weighted_shortest_path_dijkstra')
+    ->  pass(Test)
+    ;   fail_test(Test, 'weighted_shortest_path3 native kernel helpers missing')
+    ).
+
 test_fact_source_generation :-
     Test = 'WAM-C: file FactSource helpers generated',
     (   compile_wam_runtime_to_c([], RuntimeCode),
@@ -403,6 +415,20 @@ test_transitive_step_parent_distance_detector_setup_generation :-
         pass(Test)
     ;   cleanup_wam_c_detector_transitive_step_parent_distance,
         fail_test(Test, 'detected transitive_step_parent_distance5 setup missing')
+    ).
+
+test_weighted_shortest_path_detector_setup_generation :-
+    Test = 'WAM-C: shared kernel detector emits weighted_shortest_path3 setup',
+    setup_wam_c_detector_weighted_shortest_path,
+    (   detect_kernels([user:weighted_path/3], Detected),
+        Detected = ['weighted_path/3'-_Kernel],
+        generate_setup_detected_kernels_c(Detected, SetupCode),
+        sub_atom(SetupCode, _, _, _, 'setup_detected_wam_c_kernels'),
+        sub_atom(SetupCode, _, _, _, 'wam_register_weighted_shortest_path_kernel(state, "weighted_path/3")')
+    ->  cleanup_wam_c_detector_weighted_shortest_path,
+        pass(Test)
+    ;   cleanup_wam_c_detector_weighted_shortest_path,
+        fail_test(Test, 'detected weighted_shortest_path3 setup missing')
     ).
 
 test_kernel_detector_project_generation :-
@@ -1015,6 +1041,16 @@ test_transitive_step_parent_distance_kernel_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_weighted_shortest_path_kernel_executable_smoke :-
+    Test = 'WAM-C: weighted_shortest_path3 native kernel executable smoke',
+    (   gcc_available
+    ->  (   run_weighted_shortest_path_kernel_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'weighted_shortest_path3 native kernel executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_fact_source_executable_smoke :-
     Test = 'WAM-C: file FactSource executable smoke',
     (   gcc_available
@@ -1092,6 +1128,16 @@ test_transitive_step_parent_distance_detector_executable_smoke :-
     ->  (   run_transitive_step_parent_distance_detector_executable_smoke
         ->  pass(Test)
         ;   fail_test(Test, 'detected transitive_step_parent_distance5 executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
+test_weighted_shortest_path_detector_executable_smoke :-
+    Test = 'WAM-C: detected weighted_shortest_path3 executable smoke',
+    (   gcc_available
+    ->  (   run_weighted_shortest_path_detector_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'detected weighted_shortest_path3 executable failed')
         )
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
@@ -1450,6 +1496,25 @@ run_transitive_step_parent_distance_kernel_executable_smoke :-
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
 
+run_weighted_shortest_path_kernel_executable_smoke :-
+    WamCode = 'weighted_path/3:\n    call_foreign weighted_path/3, 3\n    proceed',
+    compile_wam_predicate_to_c(user:weighted_path/3, WamCode, [], PredCode),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_weighted_shortest_path_smoke', Stamp, TmpBase),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(RuntimePath, RuntimeCode),
+    format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+    write_text_file(PredPath, PredTranslationUnit),
+    wam_c_weighted_shortest_path_smoke_main(MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
 run_fact_source_executable_smoke :-
     WamCode = 'category_ancestor/4:\n    call_foreign category_ancestor/4, 4\n    proceed',
     compile_wam_predicate_to_c(user:category_ancestor/4, WamCode, [], PredCode),
@@ -1583,6 +1648,25 @@ run_transitive_step_parent_distance_detector_executable_smoke :-
         run_c_smoke_plain(ExePath)
     ->  cleanup_wam_c_detector_transitive_step_parent_distance
     ;   cleanup_wam_c_detector_transitive_step_parent_distance,
+        fail
+    ).
+
+run_weighted_shortest_path_detector_executable_smoke :-
+    setup_wam_c_detector_weighted_shortest_path,
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_weighted_shortest_path_detector_smoke', Stamp, ProjectDir),
+    directory_file_path(ProjectDir, 'wam_runtime.c', RuntimePath),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    directory_file_path(ProjectDir, 'main.c', MainPath),
+    directory_file_path(ProjectDir, 'wam_c_weighted_shortest_path_detector_smoke', ExePath),
+    (   write_wam_c_project([user:weighted_path/3], [], ProjectDir),
+        wam_c_weighted_shortest_path_detector_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, LibPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_detector_weighted_shortest_path
+    ;   cleanup_wam_c_detector_weighted_shortest_path,
         fail
     ).
 
@@ -2117,6 +2201,23 @@ setup_wam_c_detector_transitive_step_parent_distance :-
 cleanup_wam_c_detector_transitive_step_parent_distance :-
     retractall(user:tspd_parent(_, _)),
     retractall(user:tc_step_parent_distance(_, _, _, _, _)).
+
+setup_wam_c_detector_weighted_shortest_path :-
+    cleanup_wam_c_detector_weighted_shortest_path,
+    assertz((user:test_weighted_edge(tom, bob, 5))),
+    assertz((user:test_weighted_edge(tom, eve, 1))),
+    assertz((user:test_weighted_edge(eve, ann, 1))),
+    assertz((user:test_weighted_edge(bob, ann, 1))),
+    assertz((user:weighted_path(X, Y, W) :-
+        test_weighted_edge(X, Y, W))),
+    assertz((user:weighted_path(X, Y, W) :-
+        test_weighted_edge(X, Z, W0),
+        weighted_path(Z, Y, W1),
+        W is W0 + W1)).
+
+cleanup_wam_c_detector_weighted_shortest_path :-
+    retractall(user:test_weighted_edge(_, _, _)),
+    retractall(user:weighted_path(_, _, _)).
 
 run_c_smoke(ExePath) :-
     format(atom(LogPath), '~w.asan.log', [ExePath]),
@@ -2767,6 +2868,73 @@ int main(void) {
 }
 ').
 
+wam_c_weighted_shortest_path_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_weighted_path_3(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_weighted_path_3(&state);
+    wam_register_weighted_edge(&state, "tom", "bob", 5);
+    wam_register_weighted_edge(&state, "tom", "eve", 1);
+    wam_register_weighted_edge(&state, "eve", "ann", 1);
+    wam_register_weighted_edge(&state, "bob", "ann", 1);
+    wam_register_weighted_shortest_path_kernel(&state, "weighted_path/3");
+
+    WamValue shortest_args[3] = {
+        val_atom("tom"),
+        val_atom("ann"),
+        val_unbound("Weight")
+    };
+    int shortest_rc = wam_run_predicate(&state, "weighted_path/3", shortest_args, 3);
+    if (shortest_rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 2) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue direct_args[3] = {
+        val_atom("bob"),
+        val_atom("ann"),
+        val_int(1)
+    };
+    int direct_rc = wam_run_predicate(&state, "weighted_path/3", direct_args, 3);
+    if (direct_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue output_args[3] = {
+        val_atom("tom"),
+        val_unbound("Target"),
+        val_unbound("Weight")
+    };
+    int output_rc = wam_run_predicate(&state, "weighted_path/3", output_args, 3);
+    if (output_rc != 0 || state.P != WAM_HALT ||
+        state.A[1].tag != VAL_ATOM || strcmp(state.A[1].data.atom, "eve") != 0 ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 1) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    WamValue fail_args[3] = {
+        val_atom("ann"),
+        val_atom("tom"),
+        val_unbound("Weight")
+    };
+    int fail_rc = wam_run_predicate(&state, "weighted_path/3", fail_args, 3);
+    if (fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_kernel_detector_smoke_main(
 '#include "wam_runtime.h"
 
@@ -2932,6 +3100,40 @@ int main(void) {
         state.A[2].tag != VAL_ATOM || strcmp(state.A[2].data.atom, "bob") != 0 ||
         state.A[3].tag != VAL_ATOM || strcmp(state.A[3].data.atom, "bob") != 0 ||
         state.A[4].tag != VAL_INT || state.A[4].data.integer != 2) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
+wam_c_weighted_shortest_path_detector_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_weighted_path_3(WamState* state);
+void setup_detected_wam_c_kernels(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_weighted_path_3(&state);
+    setup_detected_wam_c_kernels(&state);
+
+    wam_register_weighted_edge(&state, "tom", "bob", 5);
+    wam_register_weighted_edge(&state, "tom", "eve", 1);
+    wam_register_weighted_edge(&state, "eve", "ann", 1);
+    wam_register_weighted_edge(&state, "bob", "ann", 1);
+
+    WamValue args[3] = {
+        val_atom("tom"),
+        val_atom("ann"),
+        val_unbound("Weight")
+    };
+    int rc = wam_run_predicate(&state, "weighted_path/3", args, 3);
+    if (rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 2) {
         wam_free_state(&state);
         return 10;
     }
@@ -3923,6 +4125,7 @@ run_tests_once :-
     test_transitive_distance_kernel_generation,
     test_transitive_parent_distance_kernel_generation,
     test_transitive_step_parent_distance_kernel_generation,
+    test_weighted_shortest_path_kernel_generation,
     test_fact_source_generation,
     test_streaming_foreign_results_generation,
     test_kernel_detector_setup_generation,
@@ -3930,6 +4133,7 @@ run_tests_once :-
     test_transitive_distance_detector_setup_generation,
     test_transitive_parent_distance_detector_setup_generation,
     test_transitive_step_parent_distance_detector_setup_generation,
+    test_weighted_shortest_path_detector_setup_generation,
     test_kernel_detector_project_generation,
     test_lowered_fact_helper_generation,
     test_lowered_helper_planner_metadata,
@@ -3955,6 +4159,7 @@ run_tests_once :-
     test_transitive_distance_kernel_executable_smoke,
     test_transitive_parent_distance_kernel_executable_smoke,
     test_transitive_step_parent_distance_kernel_executable_smoke,
+    test_weighted_shortest_path_kernel_executable_smoke,
     test_fact_source_executable_smoke,
     test_lmdb_fact_source_executable_smoke,
     test_kernel_detector_executable_smoke,
@@ -3962,6 +4167,7 @@ run_tests_once :-
     test_transitive_distance_detector_executable_smoke,
     test_transitive_parent_distance_detector_executable_smoke,
     test_transitive_step_parent_distance_detector_executable_smoke,
+    test_weighted_shortest_path_detector_executable_smoke,
     test_streaming_foreign_results_executable_smoke,
     test_real_prolog_builtin_executable_smoke,
     test_real_prolog_term_builtin_executable_smoke,


### PR DESCRIPTION
# Add WAM-C weighted shortest path kernel

## Summary

- Add native WAM-C support for the shared `weighted_shortest_path3` recursive kernel.
- Register the kernel through explicit shared-kernel metadata and detector-generated setup.
- Add in-memory integer weighted edges plus a Dijkstra-style native handler for shortest weighted paths.
- Add direct and detected-project executable smokes covering shortest-route selection, bound-weight success, unbound target/weight binding, and unreachable reverse-path failure.
- Refresh `WAM_C_TARGET_NEXT_STEPS.md` to record this completed slice and move the recommended next branch to A* shortest path coverage.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/test_wam_c_lowered_helper_scale_regression.py`
- `git diff --check`
