### PR TITLE
feat(wam-clojure): add lowered atom length builtin

### DIFF
--- a/PR_WAM_CLOJURE_ATOM_LENGTH.md
+++ b/PR_WAM_CLOJURE_ATOM_LENGTH.md
@@ -1,0 +1,18 @@
+# PR Title
+
+feat(wam-clojure): add lowered atom length builtin
+
+# PR Description
+
+## Summary
+
+- Adds direct lowered Clojure WAM support for `atom_length/2`.
+- Adds `string_length/2` as the same runtime path, matching the current Clojure WAM atom/string text representation.
+- Extends runtime smoke coverage for success, mismatch, unbound input failure, and string alias behavior.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -476,6 +476,14 @@ clojure_direct_builtin("string_concat/3", "3").
 clojure_direct_builtin("string_concat/3", 3).
 clojure_direct_builtin('string_concat/3', "3").
 clojure_direct_builtin('string_concat/3', 3).
+clojure_direct_builtin("atom_length/2", "2").
+clojure_direct_builtin("atom_length/2", 2).
+clojure_direct_builtin('atom_length/2', "2").
+clojure_direct_builtin('atom_length/2', 2).
+clojure_direct_builtin("string_length/2", "2").
+clojure_direct_builtin("string_length/2", 2).
+clojure_direct_builtin('string_length/2', "2").
+clojure_direct_builtin('string_length/2', 2).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
@@ -823,6 +831,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     ),
     !,
     format(atom(Expr), '(runtime/apply-atom-concat-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (   Op == "atom_length/2" ; Op == 'atom_length/2'
+    ;   Op == "string_length/2" ; Op == 'string_length/2'
+    ),
+    !,
+    format(atom(Expr), '(runtime/apply-atom-length-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     clojure_unary_guard_test(Op, TestExpr),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1057,6 +1057,19 @@
           (backtrack state)))
       (backtrack state))))
 
+(defn apply-atom-length-solution [state]
+  (let [value (deref-value (:bindings state)
+                           (or (reg-get-raw state "A1") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A2") ::unbound))
+        text (atom-text state value)]
+    (if (some? text)
+      (let [[ok next-state] (unify-values state out (count text))]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+      (backtrack state))))
+
 (defn ground-term? [state value]
   (let [bindings (:bindings state)]
     (letfn [(ground* [term seen]
@@ -1882,6 +1895,12 @@
 
           "string_concat/3"
           (apply-atom-concat-solution state)
+
+          "atom_length/2"
+          (apply-atom-length-solution state)
+
+          "string_length/2"
+          (apply-atom-length-solution state)
 
           "!/0"
           (-> state

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -723,6 +723,15 @@ test(simple_builtin_atom_concat_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_atom_length_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_atom_length/2:\nbuiltin_call atom_length/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_atom_length/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_atom_length/2, WamCode, [], Code),
+        has(Code, "runtime/apply-atom-length-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(terminal_execute_ground_is_direct_lowered_as_succeeding_builtin) :-
     once((
         WamCode = "test_execute_ground/1:\nallocate\ndeallocate\nexecute ground/1\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -155,6 +155,9 @@
 :- dynamic user:wam_atom_concat_new_atom/0.
 :- dynamic user:wam_atom_concat_unbound_left/1.
 :- dynamic user:wam_string_concat_guard/3.
+:- dynamic user:wam_atom_length_guard/2.
+:- dynamic user:wam_atom_length_unbound/1.
+:- dynamic user:wam_string_length_guard/2.
 :- dynamic user:wam_arith_eq_42/1.
 :- dynamic user:wam_arith_eq_float/1.
 :- dynamic user:wam_arith_neq_42/1.
@@ -331,6 +334,9 @@ user:wam_atom_concat_guard(A, B, C) :- atom_concat(A, B, C).
 user:wam_atom_concat_new_atom :- atom_concat(fo, o, X), X = foo.
 user:wam_atom_concat_unbound_left(C) :- user:wam_unbound_arg(A), atom_concat(A, o, C).
 user:wam_string_concat_guard(A, B, C) :- string_concat(A, B, C).
+user:wam_atom_length_guard(A, N) :- atom_length(A, N).
+user:wam_atom_length_unbound(N) :- user:wam_unbound_arg(A), atom_length(A, N).
+user:wam_string_length_guard(A, N) :- string_length(A, N).
 user:wam_arith_eq_42(X) :- X =:= 42.
 user:wam_arith_eq_float(X) :- X =:= 3.5.
 user:wam_arith_neq_42(X) :- X =\= 42.
@@ -512,6 +518,9 @@ run_smoke :-
           user:wam_atom_concat_new_atom/0,
           user:wam_atom_concat_unbound_left/1,
           user:wam_string_concat_guard/3,
+          user:wam_atom_length_guard/2,
+          user:wam_atom_length_unbound/1,
+          user:wam_string_length_guard/2,
           user:wam_arith_eq_42/1,
           user:wam_arith_eq_float/1,
           user:wam_arith_neq_42/1,
@@ -849,6 +858,10 @@ smoke_cases([
     case('wam_atom_concat_new_atom/0', no_args, "true"),
     case('wam_atom_concat_unbound_left/1', foo, "false"),
     case('wam_string_concat_guard/3', args(fo, o, foo), "true"),
+    case('wam_atom_length_guard/2', args(foo, 3), "true"),
+    case('wam_atom_length_guard/2', args(foo, 2), "false"),
+    case('wam_atom_length_unbound/1', 0, "false"),
+    case('wam_string_length_guard/2', args(foo, 3), "true"),
     case('wam_arith_eq_42/1', 42, "true"),
     case('wam_arith_eq_42/1', 3.5, "false"),
     case('wam_arith_eq_float/1', 3.5, "true"),
@@ -1187,9 +1200,11 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-number-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-number-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-atom-concat-guard-3"),
+    has(CoreCode, "defn lowered-wam-atom-length-guard-2"),
     has(CoreCode, "runtime/ground-term?"),
     has(CoreCode, "runtime/apply-text-conversion-solution"),
-    has(CoreCode, "runtime/apply-atom-concat-solution").
+    has(CoreCode, "runtime/apply-atom-concat-solution"),
+    has(CoreCode, "runtime/apply-atom-length-solution").
 
 assert_lowered_arithmetic_comparison_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds direct lowered Clojure WAM support for `atom_length/2`.
- Adds `string_length/2` as the same runtime path, matching the current Clojure WAM atom/string text representation.
- Extends runtime smoke coverage for success, mismatch, unbound input failure, and string alias behavior.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
