### PR TITLE
bench(csharp-query): add actionable policy compare report

### DIFF
--- a/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
+++ b/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
@@ -127,6 +127,8 @@ POLICY_COMPARE_HEADERS = [
     "access_shape",
     "metric",
     "policy_mode",
+    "policy_artifact_value",
+    "policy_vs_best",
     "best_artifact_mode",
     "best_artifact_value",
     "status",
@@ -675,6 +677,20 @@ def policy_compare_rows_from_summaries(rows: list[SummaryRow]) -> list[PolicyCom
         row_count = int(base["rows"])
         policy_mode = effective_distance_policy_mode(base["relation"], row_count, base["access_shape"])
         best_artifact_mode = base["best_artifact_mode"]
+        values_by_mode = parse_mode_values(base["values_by_mode"])
+        policy_value = values_by_mode.get(policy_mode)
+        best_artifact_value = float(base["best_artifact_value"])
+        policy_value_text = "" if policy_value is None else format_policy_value(policy_value, base["metric"])
+        if policy_value is None or best_artifact_value <= 0:
+            policy_vs_best = ""
+        else:
+            policy_vs_best = f"{policy_value / best_artifact_value:.3f}x"
+        if policy_value is None:
+            status = "missing-policy-mode"
+        elif policy_mode == best_artifact_mode:
+            status = "match"
+        else:
+            status = "diff"
         compare_rows.append(
             PolicyCompareRow(
                 {
@@ -686,14 +702,20 @@ def policy_compare_rows_from_summaries(rows: list[SummaryRow]) -> list[PolicyCom
                     "access_shape": base["access_shape"],
                     "metric": base["metric"],
                     "policy_mode": policy_mode,
+                    "policy_artifact_value": policy_value_text,
+                    "policy_vs_best": policy_vs_best,
                     "best_artifact_mode": best_artifact_mode,
                     "best_artifact_value": base["best_artifact_value"],
-                    "status": "match" if policy_mode == best_artifact_mode else "diff",
+                    "status": status,
                     "values_by_mode": base["values_by_mode"],
                 }
             )
         )
     return compare_rows
+
+
+def policy_actionable_rows(rows: list[PolicyCompareRow]) -> list[PolicyCompareRow]:
+    return [row for row in rows if row.values["status"] != "match"]
 
 
 def render_summary_tsv(rows: list[SummaryRow]) -> str:
@@ -769,17 +791,25 @@ def render_policy_compare_markdown(rows: list[PolicyCompareRow]) -> str:
         return value.replace("|", "<br>")
 
     lines = [
-        "| Scale | Relation | Rows | Access shape | Metric | Policy mode | Best artifact mode | Best artifact value | Status | Values by mode |",
-        "| --- | --- | ---: | --- | --- | --- | --- | ---: | --- | --- |",
+        "| Scale | Relation | Rows | Access shape | Metric | Policy mode | Policy artifact value | Policy vs best | Best artifact mode | Best artifact value | Status | Values by mode |",
+        "| --- | --- | ---: | --- | --- | --- | ---: | ---: | --- | ---: | --- | --- |",
     ]
     for row in rows:
         value = {column: markdown_cell(cell) for column, cell in row.values.items()}
         lines.append(
-            "| {scale} | {relation} | {rows} | {access_shape} | {metric} | {policy_mode} | {best_artifact_mode} | {best_artifact_value} | {status} | {values_by_mode} |".format(
+            "| {scale} | {relation} | {rows} | {access_shape} | {metric} | {policy_mode} | {policy_artifact_value} | {policy_vs_best} | {best_artifact_mode} | {best_artifact_value} | {status} | {values_by_mode} |".format(
                 **value
             )
         )
     return "\n".join(lines)
+
+
+def render_policy_actionable_tsv(rows: list[PolicyCompareRow]) -> str:
+    return render_policy_compare_tsv(policy_actionable_rows(rows))
+
+
+def render_policy_actionable_markdown(rows: list[PolicyCompareRow]) -> str:
+    return render_policy_compare_markdown(policy_actionable_rows(rows))
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -879,6 +909,8 @@ def main(argv: list[str] | None = None) -> int:
             "policy-markdown",
             "policy-compare-tsv",
             "policy-compare-markdown",
+            "policy-actionable-tsv",
+            "policy-actionable-markdown",
         ),
         default="tsv",
     )
@@ -979,6 +1011,10 @@ def main(argv: list[str] | None = None) -> int:
         print(render_policy_compare_tsv(policy_compare_rows_from_summaries(summaries)))
     elif args.format == "policy-compare-markdown":
         print(render_policy_compare_markdown(policy_compare_rows_from_summaries(summaries)))
+    elif args.format == "policy-actionable-tsv":
+        print(render_policy_actionable_tsv(policy_compare_rows_from_summaries(summaries)))
+    elif args.format == "policy-actionable-markdown":
+        print(render_policy_actionable_markdown(policy_compare_rows_from_summaries(summaries)))
     elif args.format == "markdown":
         print(render_markdown(rows))
     else:

--- a/tests/test_csharp_query_effective_distance_artifact_backends.py
+++ b/tests/test_csharp_query_effective_distance_artifact_backends.py
@@ -329,11 +329,17 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
 
         self.assertEqual(by_shape["lookup_c0"]["policy_mode"], "lmdb")
         self.assertEqual(by_shape["lookup_c0"]["best_artifact_mode"], "lmdb")
+        self.assertEqual(by_shape["lookup_c0"]["policy_artifact_value"], "3.251")
+        self.assertEqual(by_shape["lookup_c0"]["policy_vs_best"], "1.000x")
         self.assertEqual(by_shape["lookup_c0"]["status"], "match")
         self.assertEqual(by_shape["bucket_c0"]["policy_mode"], "delimited-artifact")
         self.assertEqual(by_shape["bucket_c0"]["best_artifact_mode"], "mmap-array")
+        self.assertEqual(by_shape["bucket_c0"]["policy_artifact_value"], "400.000")
+        self.assertEqual(by_shape["bucket_c0"]["policy_vs_best"], "1.143x")
         self.assertEqual(by_shape["bucket_c0"]["status"], "diff")
         self.assertEqual(by_shape["storage"]["policy_mode"], "mmap-array")
+        self.assertEqual(by_shape["storage"]["policy_artifact_value"], "80000643")
+        self.assertEqual(by_shape["storage"]["policy_vs_best"], "1.000x")
         self.assertEqual(by_shape["storage"]["status"], "match")
 
     def test_policy_compare_renderers_include_status(self) -> None:
@@ -348,6 +354,8 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
                     "access_shape": "lookup_c0",
                     "metric": "ms",
                     "policy_mode": "mmap-array",
+                    "policy_artifact_value": "2.000",
+                    "policy_vs_best": "1.600x",
                     "best_artifact_mode": "lmdb",
                     "best_artifact_value": "1.250",
                     "status": "diff",
@@ -359,10 +367,86 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
         tsv = MODULE.render_policy_compare_tsv(rows)
         markdown = MODULE.render_policy_compare_markdown(rows)
         self.assertTrue(tsv.startswith("scale\trelation\trows\tdistinct_categories\tlookup_keys\taccess_shape"))
-        self.assertIn("\tlookup_c0\tms\tmmap-array\tlmdb\t1.250\tdiff\t", tsv)
-        self.assertIn("| Access shape | Metric | Policy mode | Best artifact mode |", markdown)
-        self.assertIn("| dev | category_parent | 6 | lookup_c0 | ms | mmap-array | lmdb | 1.250 | diff |", markdown)
+        self.assertIn("\tlookup_c0\tms\tmmap-array\t2.000\t1.600x\tlmdb\t1.250\tdiff\t", tsv)
+        self.assertIn("| Access shape | Metric | Policy mode | Policy artifact value |", markdown)
+        self.assertIn("| dev | category_parent | 6 | lookup_c0 | ms | mmap-array | 2.000 | 1.600x | lmdb | 1.250 | diff |", markdown)
         self.assertIn("lmdb:1.250<br>mmap-array:2.000", markdown)
+
+    def test_policy_compare_reports_missing_policy_mode(self) -> None:
+        row = MODULE.SummaryRow(
+            {
+                "scale": "dev",
+                "relation": "category_parent",
+                "rows": "6",
+                "distinct_categories": "4",
+                "lookup_keys": "2",
+                "best_lookup_mode": "lmdb",
+                "best_lookup_col1_mode": "lmdb",
+                "best_bucket_mode": "lmdb",
+                "best_bucket_col1_mode": "lmdb",
+                "best_scan_mode": "lmdb",
+                "smallest_artifact_mode": "lmdb",
+                "lookup_ms_by_mode": "lmdb:1.250",
+                "lookup_col1_ms_by_mode": "lmdb:1.250",
+                "bucket_ms_by_mode": "lmdb:1.250",
+                "bucket_col1_ms_by_mode": "lmdb:1.250",
+                "scan_ms_by_mode": "lmdb:1.250",
+                "artifact_bytes_by_mode": "lmdb:1024",
+            }
+        )
+
+        rows = MODULE.policy_compare_rows_from_summaries([row])
+        by_shape = {policy.values["access_shape"]: policy.values for policy in rows}
+
+        self.assertEqual(by_shape["lookup_c0"]["policy_mode"], "mmap-array")
+        self.assertEqual(by_shape["lookup_c0"]["policy_artifact_value"], "")
+        self.assertEqual(by_shape["lookup_c0"]["policy_vs_best"], "")
+        self.assertEqual(by_shape["lookup_c0"]["status"], "missing-policy-mode")
+
+    def test_policy_actionable_rows_filter_matches(self) -> None:
+        rows = [
+            MODULE.PolicyCompareRow(
+                {
+                    "scale": "dev",
+                    "relation": "category_parent",
+                    "rows": "6",
+                    "distinct_categories": "4",
+                    "lookup_keys": "2",
+                    "access_shape": "lookup_c0",
+                    "metric": "ms",
+                    "policy_mode": "mmap-array",
+                    "policy_artifact_value": "1.250",
+                    "policy_vs_best": "1.000x",
+                    "best_artifact_mode": "mmap-array",
+                    "best_artifact_value": "1.250",
+                    "status": "match",
+                    "values_by_mode": "mmap-array:1.250",
+                }
+            ),
+            MODULE.PolicyCompareRow(
+                {
+                    "scale": "dev",
+                    "relation": "category_parent",
+                    "rows": "6",
+                    "distinct_categories": "4",
+                    "lookup_keys": "2",
+                    "access_shape": "bucket_c0",
+                    "metric": "ms",
+                    "policy_mode": "mmap-array",
+                    "policy_artifact_value": "2.000",
+                    "policy_vs_best": "1.600x",
+                    "best_artifact_mode": "lmdb",
+                    "best_artifact_value": "1.250",
+                    "status": "diff",
+                    "values_by_mode": "lmdb:1.250|mmap-array:2.000",
+                }
+            ),
+        ]
+
+        actionable = MODULE.policy_actionable_rows(rows)
+        self.assertEqual([row.values["access_shape"] for row in actionable], ["bucket_c0"])
+        self.assertNotIn("lookup_c0", MODULE.render_policy_actionable_tsv(rows))
+        self.assertIn("bucket_c0", MODULE.render_policy_actionable_markdown(rows))
 
     def test_artifact_root_reuses_existing_manifests(self) -> None:
         if shutil.which("dotnet") is None:


### PR DESCRIPTION
  ## Summary

  - Adds policy-selected artifact values and policy-vs-best ratios to the effective-distance artifact backend policy compare
  report.
  - Adds `policy-actionable-tsv` and `policy-actionable-markdown` formats that filter the report to non-matching or missing
  policy choices.
  - Covers ratio reporting, missing policy modes, and actionable filtering in tests.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py tests/test_csharp_query_lmdb_provider_smoke.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `git diff --check`