### PR TITLE
feat(wam-c): add astar shortest path kernel

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,7 +4,7 @@ Status date: 2026-05-17
 
 Base verified locally:
 
-- `main` at `991062ba` (`Merge pull request #2227 from s243a/feat/wam-c-transitive-step-parent-distance-kernel`)
+- `main` at `dba9ab10` (`Merge pull request #2232 from s243a/feat/wam-c-weighted-shortest-path-kernel`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
@@ -17,7 +17,7 @@ Base verified locally:
 
 Active branch:
 
-- `feat/wam-c-weighted-shortest-path-kernel`
+- `feat/wam-c-astar-shortest-path-kernel`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -78,6 +78,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | `transitive_parent_distance4` native kernel | Done | C shared-kernel detector accepts `transitive_parent_distance4`, emits detected setup, registers a native arity-4 foreign handler, and covers direct plus detected-project executable smokes |
 | `transitive_step_parent_distance5` native kernel | Done | C shared-kernel detector accepts `transitive_step_parent_distance5`, emits detected setup, registers a native arity-5 foreign handler, and covers direct plus detected-project executable smokes |
 | `weighted_shortest_path3` native kernel | Done | C shared-kernel detector accepts `weighted_shortest_path3`, emits detected setup, registers a native arity-3 foreign handler, and covers direct plus detected-project executable smokes over integer weighted edges |
+| `astar_shortest_path4` native kernel | Done | C shared-kernel detector accepts `astar_shortest_path4`, emits detected setup, registers a native arity-4 foreign handler, and covers direct plus detected-project executable smokes over integer weighted and direct-distance edges |
 
 ## Current C Target Baseline
 
@@ -105,7 +106,8 @@ The C target is now a credible small WAM backend:
 - Supports deterministic native `category_ancestor/4`, `transitive_closure2`,
   `transitive_distance3`, `transitive_parent_distance4`, and
   `transitive_step_parent_distance5` handlers over an in-memory edge table,
-  plus `weighted_shortest_path3` over in-memory integer weighted edges.
+  plus `weighted_shortest_path3` and `astar_shortest_path4` over in-memory
+  integer weighted edges.
 - Supports loading category-parent facts from TSV through a small
   `WamFactSource` interface.
 - Supports collecting all integer hop results for native `category_ancestor/4`
@@ -150,8 +152,8 @@ missing important target features; `Missing` = no comparable C path yet.
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
 | Negation / control builtins | Partial | Broader | Broader | C likely needs explicit tests for `\+/1`, cut interactions, and if-then-else lowering. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
-| Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, and integer-weighted shortest path; continue adding shared kernels one at a time. |
-| Shared kernel detector integration | Partial | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`, `transitive_closure2`, `transitive_distance3`, `transitive_parent_distance4`, `transitive_step_parent_distance5`, and `weighted_shortest_path3`; Haskell and Rust cover a broader shared-kernel registry. |
+| Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, integer-weighted shortest path, and integer A* shortest path; remaining parity gaps are broader integration details. |
+| Shared kernel detector integration | Partial/Done | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`, `transitive_closure2`, `transitive_distance3`, `transitive_parent_distance4`, `transitive_step_parent_distance5`, `weighted_shortest_path3`, and `astar_shortest_path4`; Haskell and Rust still have broader wrapper/fact-layout integration. |
 | Lowered/native helper functions | Partial/Done | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, comparison-filter helpers, rejection metadata, repeated-variable filter hardening, empty-result rejection metadata, and projected body-call helper expansion. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
 | LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
@@ -162,34 +164,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-astar-shortest-path-kernel`
-
-Goal: add the next shared recursive kernel to C from the Haskell/Rust parity
-surface, continuing from Dijkstra-style weighted shortest paths to
-`astar_shortest_path4`.
-
-Scope:
-
-- Extend the C recursive-kernel registration path beyond the existing
-  transitive and weighted shortest-path kernels for the shared
-  `astar_shortest_path4` detector.
-- Add a native C handler and executable smoke for a small weighted edge result
-  with an admissible direct-distance heuristic.
-- Keep TSV/LMDB fact loading and floating-point result support out of scope
-  unless the small in-memory kernel path exposes a direct need for it.
-
-Status: recommended next.
-
-Reason:
-
-- `weighted_shortest_path3` is now covered through direct native registration
-  and detected-project setup over integer weighted edges.
-- `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` records
-  `weighted_shortest_path3/3` before the broader A* family.
-- Haskell and Rust already cover `astar_shortest_path4`; it is the next
-  shared-kernel parity move after weighted shortest path.
-
-### 2. `investigate/wam-c-accumulated-runtime-cost`
+### 1. `investigate/wam-c-accumulated-runtime-cost`
 
 Goal: explain why the accumulated C WAM effective-distance target is much
 slower than optimized Prolog at `10x`.
@@ -205,6 +180,32 @@ Scope:
 
 Status: recommended after the next shared-kernel slice, or sooner if runtime
 performance becomes the blocking question.
+
+Reason:
+
+- The measured shared-kernel family is now covered in C through
+  `astar_shortest_path4` at the small in-memory integer-weight level.
+- Previous benchmark-demand evidence showed accumulated C WAM is still about
+  `0.03x` versus optimized Prolog at `10x`, and native kernels barely move the
+  accumulated target relative to no-kernels.
+- Before adding broader fact-storage or wrapper integration, the next useful
+  question is where that runtime cost is coming from.
+
+### 2. `feat/wam-c-native-kernel-float-output`
+
+Goal: close the output-type parity gap for weighted/A* native kernels by adding
+a C runtime representation for floating-point results.
+
+Scope:
+
+- Add a `VAL_FLOAT` or equivalent runtime value representation.
+- Extend foreign-handler unification and smoke assertions for weighted/A*
+  results that are not exact integers.
+- Keep benchmark integration separate unless the value representation itself
+  proves stable.
+
+Status: recommended after the runtime-cost investigation, or sooner if a
+concrete generated benchmark requires float output.
 
 ### Completed Investigation: `investigate/wam-c-next-benchmark-demand`
 
@@ -303,6 +304,21 @@ Evidence:
 | Direct executable smoke | `weighted_path/3` chooses the lower-cost two-hop route over a higher-cost direct-looking alternative, accepts a bound weight, binds an unbound target/weight, and fails for a reversed edge. |
 | Detected-project smoke | Generated project detection lowers `weighted_path/3` to a `call_foreign` trampoline and runs through `setup_detected_wam_c_kernels`. |
 
+### Completed Shared Kernel Slice: `feat/wam-c-astar-shortest-path-kernel`
+
+Goal: add the goal-directed weighted shared recursive kernel to C from the
+Haskell/Rust parity surface.
+
+Evidence:
+
+| Surface | Coverage |
+|---|---|
+| Kernel support predicate | `wam_c_supported_kernel/1` accepts `recursive_kernel(astar_shortest_path4, ...)`. |
+| Detected setup emission | `generate_setup_detected_kernels_c/2` emits `wam_register_astar_shortest_path_kernel`. |
+| Runtime handler | `wam_astar_shortest_path_handler` requires bound source, target, and integer dimensionality, then binds an integer shortest weight using registered weighted edges and optional direct-distance heuristic edges. |
+| Direct executable smoke | `astar_path/4` chooses the lower-cost two-hop route, accepts a bound weight, rejects an unbound dimensionality argument, and fails for a reversed edge. |
+| Detected-project smoke | Generated project detection lowers `astar_path/4` to a `call_foreign` trampoline and runs through `setup_detected_wam_c_kernels`. |
+
 ## Completed Atom Concat Builtin
 
 The merged `feat/wam-c-atom-concat-builtin` branch added deterministic
@@ -380,10 +396,9 @@ After hash-bucket row dispatch but before compact row tables:
 
 ## Suggested Immediate Next Step
 
-Proceed with `feat/wam-c-astar-shortest-path-kernel`.
+Proceed with `investigate/wam-c-accumulated-runtime-cost`.
 
-Keep it narrow: add `astar_shortest_path4` over small in-memory weighted and
-direct-distance edge surfaces and prove direct plus detected-project executable
-smokes. Treat broader fact storage, LMDB loading, floating-point output, and
-runtime profiling as follow-up branches unless this slice exposes a direct
-blocker.
+Keep it narrow: profile the existing accumulated C WAM effective-distance
+targets at `10x`, identify whether the dominant cost is WAM dispatch, fact
+lookup, repeated setup, generated query shape, or native-kernel integration
+overhead, and document a concrete next implementation branch from that evidence.

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -248,6 +248,9 @@ struct WamState {
     WeightedEdge *weighted_edges;
     int weighted_edge_count;
     int weighted_edge_cap;
+    WeightedEdge *direct_distance_edges;
+    int direct_distance_edge_count;
+    int direct_distance_edge_cap;
 };
 
 bool step_wam(WamState* state, Instruction* instr);
@@ -260,18 +263,21 @@ bool wam_execute_foreign_predicate(WamState *state, const char *pred, int arity)
 void wam_register_category_parent(WamState *state, const char *child, const char *parent);
 void wam_register_transitive_edge(WamState *state, const char *child, const char *parent);
 void wam_register_weighted_edge(WamState *state, const char *source, const char *target, int weight);
+void wam_register_direct_distance_edge(WamState *state, const char *source, const char *target, int distance);
 void wam_register_category_ancestor_kernel(WamState *state, const char *pred, int max_depth);
 void wam_register_transitive_closure_kernel(WamState *state, const char *pred);
 void wam_register_transitive_distance_kernel(WamState *state, const char *pred);
 void wam_register_transitive_parent_distance_kernel(WamState *state, const char *pred);
 void wam_register_transitive_step_parent_distance_kernel(WamState *state, const char *pred);
 void wam_register_weighted_shortest_path_kernel(WamState *state, const char *pred);
+void wam_register_astar_shortest_path_kernel(WamState *state, const char *pred);
 bool wam_category_ancestor_handler(WamState *state, const char *pred, int arity);
 bool wam_transitive_closure_handler(WamState *state, const char *pred, int arity);
 bool wam_transitive_distance_handler(WamState *state, const char *pred, int arity);
 bool wam_transitive_parent_distance_handler(WamState *state, const char *pred, int arity);
 bool wam_transitive_step_parent_distance_handler(WamState *state, const char *pred, int arity);
 bool wam_weighted_shortest_path_handler(WamState *state, const char *pred, int arity);
+bool wam_astar_shortest_path_handler(WamState *state, const char *pred, int arity);
 void wam_fact_source_init(WamFactSource *source);
 void wam_fact_source_close(WamFactSource *source);
 bool wam_fact_source_load_tsv(WamState *state, WamFactSource *source, const char *path);

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -137,6 +137,7 @@ wam_c_supported_kernel(recursive_kernel(transitive_distance3, _Pred, _ConfigOps)
 wam_c_supported_kernel(recursive_kernel(transitive_parent_distance4, _Pred, _ConfigOps)).
 wam_c_supported_kernel(recursive_kernel(transitive_step_parent_distance5, _Pred, _ConfigOps)).
 wam_c_supported_kernel(recursive_kernel(weighted_shortest_path3, _Pred, _ConfigOps)).
+wam_c_supported_kernel(recursive_kernel(astar_shortest_path4, _Pred, _ConfigOps)).
 
 %% generate_setup_detected_kernels_c(+DetectedKernels, -CCode)
 %  Emit C startup wiring for detected kernels. This function registers only
@@ -174,6 +175,10 @@ wam_c_kernel_registration_line(Key-recursive_kernel(transitive_step_parent_dista
 wam_c_kernel_registration_line(Key-recursive_kernel(weighted_shortest_path3, _Pred, _ConfigOps), Line) :-
     format(atom(Line),
            '    wam_register_weighted_shortest_path_kernel(state, "~w");',
+           [Key]).
+wam_c_kernel_registration_line(Key-recursive_kernel(astar_shortest_path4, _Pred, _ConfigOps), Line) :-
+    format(atom(Line),
+           '    wam_register_astar_shortest_path_kernel(state, "~w");',
            [Key]).
 
 wam_c_kernel_max_depth(ConfigOps, MaxDepth) :-
@@ -2004,6 +2009,7 @@ void wam_free_state(WamState *state) {
     free(state->E_array);
     free(state->category_edges);
     free(state->weighted_edges);
+    free(state->direct_distance_edges);
     memset(state, 0, sizeof(WamState));
 }
 
@@ -2310,6 +2316,17 @@ void wam_register_weighted_edge(WamState *state, const char *source, const char 
     state->weighted_edge_count++;
 }
 
+void wam_register_direct_distance_edge(WamState *state, const char *source, const char *target, int distance) {
+    if (state->direct_distance_edge_count >= state->direct_distance_edge_cap) {
+        state->direct_distance_edge_cap = state->direct_distance_edge_cap ? state->direct_distance_edge_cap * 2 : WAM_INITIAL_CAP;
+        state->direct_distance_edges = realloc(state->direct_distance_edges, sizeof(WeightedEdge) * state->direct_distance_edge_cap);
+    }
+    state->direct_distance_edges[state->direct_distance_edge_count].source = wam_intern_atom(state, source);
+    state->direct_distance_edges[state->direct_distance_edge_count].target = wam_intern_atom(state, target);
+    state->direct_distance_edges[state->direct_distance_edge_count].weight = distance;
+    state->direct_distance_edge_count++;
+}
+
 void wam_fact_source_init(WamFactSource *source) {
     memset(source, 0, sizeof(WamFactSource));
 }
@@ -2496,6 +2513,10 @@ void wam_register_transitive_step_parent_distance_kernel(WamState *state, const 
 
 void wam_register_weighted_shortest_path_kernel(WamState *state, const char *pred) {
     wam_register_foreign_predicate(state, pred, 3, wam_weighted_shortest_path_handler);
+}
+
+void wam_register_astar_shortest_path_kernel(WamState *state, const char *pred) {
+    wam_register_foreign_predicate(state, pred, 4, wam_astar_shortest_path_handler);
 }
 
 static bool wam_value_as_atom(WamState *state, WamValue value, const char **out) {
@@ -3013,6 +3034,107 @@ bool wam_weighted_shortest_path_handler(WamState *state, const char *pred, int a
     WamValue weight_value = val_int(result_weight);
     return wam_unify(state, &state->A[1], &target_value) &&
            wam_unify(state, &state->A[2], &weight_value);
+}
+
+static int wam_astar_heuristic(WamState *state, const char *node, const char *target) {
+    for (int i = 0; i < state->direct_distance_edge_count; i++) {
+        WeightedEdge *edge = &state->direct_distance_edges[i];
+        if (strcmp(edge->source, node) == 0 && strcmp(edge->target, target) == 0) {
+            return edge->weight < 0 ? 0 : edge->weight;
+        }
+    }
+    return 0;
+}
+
+static bool wam_astar_shortest_path_search(WamState *state,
+                                           const char *start,
+                                           const char *target,
+                                           int dimensionality,
+                                           int *weight_out) {
+    const char *nodes[256];
+    int distances[256];
+    bool done[256];
+    int node_count = 0;
+    const int inf = 1073741823;
+    (void)dimensionality;
+
+    nodes[node_count] = start;
+    distances[node_count] = 0;
+    done[node_count] = false;
+    node_count++;
+
+    while (true) {
+        int best_idx = -1;
+        int best_score = inf;
+        int best_distance = inf;
+        for (int i = 0; i < node_count; i++) {
+            if (done[i]) continue;
+            int heuristic = wam_astar_heuristic(state, nodes[i], target);
+            int score = distances[i] <= inf - heuristic ? distances[i] + heuristic : inf;
+            if (score < best_score || (score == best_score && distances[i] < best_distance)) {
+                best_idx = i;
+                best_score = score;
+                best_distance = distances[i];
+            }
+        }
+        if (best_idx < 0) break;
+
+        done[best_idx] = true;
+        const char *node = nodes[best_idx];
+        if (strcmp(node, target) == 0 && best_distance > 0) {
+            *weight_out = best_distance;
+            return true;
+        }
+
+        for (int i = 0; i < state->weighted_edge_count; i++) {
+            WeightedEdge *edge = &state->weighted_edges[i];
+            if (edge->weight < 0) continue;
+            if (strcmp(edge->source, node) != 0) continue;
+            int next_idx = -1;
+            for (int j = 0; j < node_count; j++) {
+                if (strcmp(nodes[j], edge->target) == 0) {
+                    next_idx = j;
+                    break;
+                }
+            }
+            if (next_idx < 0) {
+                if (node_count >= 256) return false;
+                next_idx = node_count;
+                nodes[next_idx] = edge->target;
+                distances[next_idx] = inf;
+                done[next_idx] = false;
+                node_count++;
+            }
+            if (best_distance <= inf - edge->weight &&
+                best_distance + edge->weight < distances[next_idx]) {
+                distances[next_idx] = best_distance + edge->weight;
+            }
+        }
+    }
+    return false;
+}
+
+bool wam_astar_shortest_path_handler(WamState *state, const char *pred, int arity) {
+    (void)pred;
+    if (arity != 4) return false;
+
+    const char *start = NULL;
+    const char *target = NULL;
+    if (!wam_value_as_atom(state, state->A[0], &start)) return false;
+    if (!wam_value_as_atom(state, state->A[1], &target)) return false;
+
+    WamValue *dim_cell = wam_deref_ptr(state, &state->A[2]);
+    if (dim_cell->tag != VAL_INT) return false;
+
+    int result_weight = 0;
+    if (!wam_astar_shortest_path_search(state, start, target,
+                                        dim_cell->data.integer,
+                                        &result_weight)) {
+        return false;
+    }
+
+    WamValue weight_value = val_int(result_weight);
+    return wam_unify(state, &state->A[3], &weight_value);
 }
 '.
 

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -322,6 +322,18 @@ test_weighted_shortest_path_kernel_generation :-
     ;   fail_test(Test, 'weighted_shortest_path3 native kernel helpers missing')
     ).
 
+test_astar_shortest_path_kernel_generation :-
+    Test = 'WAM-C: astar_shortest_path4 native kernel helpers generated',
+    (   compile_wam_runtime_to_c([], RuntimeCode),
+        atom_string(RuntimeCode, S),
+        sub_string(S, _, _, _, 'void wam_register_direct_distance_edge'),
+        sub_string(S, _, _, _, 'void wam_register_astar_shortest_path_kernel'),
+        sub_string(S, _, _, _, 'bool wam_astar_shortest_path_handler'),
+        sub_string(S, _, _, _, 'wam_astar_shortest_path_search')
+    ->  pass(Test)
+    ;   fail_test(Test, 'astar_shortest_path4 native kernel helpers missing')
+    ).
+
 test_fact_source_generation :-
     Test = 'WAM-C: file FactSource helpers generated',
     (   compile_wam_runtime_to_c([], RuntimeCode),
@@ -429,6 +441,20 @@ test_weighted_shortest_path_detector_setup_generation :-
         pass(Test)
     ;   cleanup_wam_c_detector_weighted_shortest_path,
         fail_test(Test, 'detected weighted_shortest_path3 setup missing')
+    ).
+
+test_astar_shortest_path_detector_setup_generation :-
+    Test = 'WAM-C: shared kernel detector emits astar_shortest_path4 setup',
+    setup_wam_c_detector_astar_shortest_path,
+    (   detect_kernels([user:astar_path/4], Detected),
+        Detected = ['astar_path/4'-_Kernel],
+        generate_setup_detected_kernels_c(Detected, SetupCode),
+        sub_atom(SetupCode, _, _, _, 'setup_detected_wam_c_kernels'),
+        sub_atom(SetupCode, _, _, _, 'wam_register_astar_shortest_path_kernel(state, "astar_path/4")')
+    ->  cleanup_wam_c_detector_astar_shortest_path,
+        pass(Test)
+    ;   cleanup_wam_c_detector_astar_shortest_path,
+        fail_test(Test, 'detected astar_shortest_path4 setup missing')
     ).
 
 test_kernel_detector_project_generation :-
@@ -1051,6 +1077,16 @@ test_weighted_shortest_path_kernel_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_astar_shortest_path_kernel_executable_smoke :-
+    Test = 'WAM-C: astar_shortest_path4 native kernel executable smoke',
+    (   gcc_available
+    ->  (   run_astar_shortest_path_kernel_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'astar_shortest_path4 native kernel executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_fact_source_executable_smoke :-
     Test = 'WAM-C: file FactSource executable smoke',
     (   gcc_available
@@ -1138,6 +1174,16 @@ test_weighted_shortest_path_detector_executable_smoke :-
     ->  (   run_weighted_shortest_path_detector_executable_smoke
         ->  pass(Test)
         ;   fail_test(Test, 'detected weighted_shortest_path3 executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
+test_astar_shortest_path_detector_executable_smoke :-
+    Test = 'WAM-C: detected astar_shortest_path4 executable smoke',
+    (   gcc_available
+    ->  (   run_astar_shortest_path_detector_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'detected astar_shortest_path4 executable failed')
         )
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
@@ -1515,6 +1561,25 @@ run_weighted_shortest_path_kernel_executable_smoke :-
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
 
+run_astar_shortest_path_kernel_executable_smoke :-
+    WamCode = 'astar_path/4:\n    call_foreign astar_path/4, 4\n    proceed',
+    compile_wam_predicate_to_c(user:astar_path/4, WamCode, [], PredCode),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_astar_shortest_path_smoke', Stamp, TmpBase),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(RuntimePath, RuntimeCode),
+    format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+    write_text_file(PredPath, PredTranslationUnit),
+    wam_c_astar_shortest_path_smoke_main(MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
 run_fact_source_executable_smoke :-
     WamCode = 'category_ancestor/4:\n    call_foreign category_ancestor/4, 4\n    proceed',
     compile_wam_predicate_to_c(user:category_ancestor/4, WamCode, [], PredCode),
@@ -1667,6 +1732,25 @@ run_weighted_shortest_path_detector_executable_smoke :-
         run_c_smoke_plain(ExePath)
     ->  cleanup_wam_c_detector_weighted_shortest_path
     ;   cleanup_wam_c_detector_weighted_shortest_path,
+        fail
+    ).
+
+run_astar_shortest_path_detector_executable_smoke :-
+    setup_wam_c_detector_astar_shortest_path,
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_astar_shortest_path_detector_smoke', Stamp, ProjectDir),
+    directory_file_path(ProjectDir, 'wam_runtime.c', RuntimePath),
+    directory_file_path(ProjectDir, 'lib.c', LibPath),
+    directory_file_path(ProjectDir, 'main.c', MainPath),
+    directory_file_path(ProjectDir, 'wam_c_astar_shortest_path_detector_smoke', ExePath),
+    (   write_wam_c_project([user:astar_path/4], [], ProjectDir),
+        wam_c_astar_shortest_path_detector_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, LibPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_detector_astar_shortest_path
+    ;   cleanup_wam_c_detector_astar_shortest_path,
         fail
     ).
 
@@ -2218,6 +2302,31 @@ setup_wam_c_detector_weighted_shortest_path :-
 cleanup_wam_c_detector_weighted_shortest_path :-
     retractall(user:test_weighted_edge(_, _, _)),
     retractall(user:weighted_path(_, _, _)).
+
+setup_wam_c_detector_astar_shortest_path :-
+    cleanup_wam_c_detector_astar_shortest_path,
+    assertz((user:direct_dist_pred(test_direct_distance/3))),
+    assertz((user:dimensionality(5))),
+    assertz((user:test_astar_edge(tom, bob, 5))),
+    assertz((user:test_astar_edge(tom, eve, 1))),
+    assertz((user:test_astar_edge(eve, ann, 1))),
+    assertz((user:test_astar_edge(bob, ann, 1))),
+    assertz((user:test_direct_distance(tom, ann, 2))),
+    assertz((user:test_direct_distance(eve, ann, 1))),
+    assertz((user:test_direct_distance(bob, ann, 1))),
+    assertz((user:astar_path(X, Y, _Dim, W) :-
+        test_astar_edge(X, Y, W))),
+    assertz((user:astar_path(X, Y, Dim, W) :-
+        test_astar_edge(X, Z, W0),
+        astar_path(Z, Y, Dim, W1),
+        W is W0 + W1)).
+
+cleanup_wam_c_detector_astar_shortest_path :-
+    retractall(user:direct_dist_pred(_)),
+    retractall(user:dimensionality(_)),
+    retractall(user:test_astar_edge(_, _, _)),
+    retractall(user:test_direct_distance(_, _, _)),
+    retractall(user:astar_path(_, _, _, _)).
 
 run_c_smoke(ExePath) :-
     format(atom(LogPath), '~w.asan.log', [ExePath]),
@@ -2935,6 +3044,82 @@ int main(void) {
 }
 ').
 
+wam_c_astar_shortest_path_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_astar_path_4(WamState* state);
+
+static void register_astar_edges(WamState *state) {
+    wam_register_weighted_edge(state, "tom", "bob", 5);
+    wam_register_weighted_edge(state, "tom", "eve", 1);
+    wam_register_weighted_edge(state, "eve", "ann", 1);
+    wam_register_weighted_edge(state, "bob", "ann", 1);
+    wam_register_direct_distance_edge(state, "tom", "ann", 2);
+    wam_register_direct_distance_edge(state, "eve", "ann", 1);
+    wam_register_direct_distance_edge(state, "bob", "ann", 1);
+}
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_astar_path_4(&state);
+    register_astar_edges(&state);
+    wam_register_astar_shortest_path_kernel(&state, "astar_path/4");
+
+    WamValue shortest_args[4] = {
+        val_atom("tom"),
+        val_atom("ann"),
+        val_int(5),
+        val_unbound("Weight")
+    };
+    int shortest_rc = wam_run_predicate(&state, "astar_path/4", shortest_args, 4);
+    if (shortest_rc != 0 || state.P != WAM_HALT ||
+        state.A[3].tag != VAL_INT || state.A[3].data.integer != 2) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue direct_args[4] = {
+        val_atom("bob"),
+        val_atom("ann"),
+        val_int(5),
+        val_int(1)
+    };
+    int direct_rc = wam_run_predicate(&state, "astar_path/4", direct_args, 4);
+    if (direct_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue bad_dim_args[4] = {
+        val_atom("tom"),
+        val_atom("ann"),
+        val_unbound("Dim"),
+        val_unbound("Weight")
+    };
+    int bad_dim_rc = wam_run_predicate(&state, "astar_path/4", bad_dim_args, 4);
+    if (bad_dim_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    WamValue fail_args[4] = {
+        val_atom("ann"),
+        val_atom("tom"),
+        val_int(5),
+        val_unbound("Weight")
+    };
+    int fail_rc = wam_run_predicate(&state, "astar_path/4", fail_args, 4);
+    if (fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_kernel_detector_smoke_main(
 '#include "wam_runtime.h"
 
@@ -3134,6 +3319,44 @@ int main(void) {
     int rc = wam_run_predicate(&state, "weighted_path/3", args, 3);
     if (rc != 0 || state.P != WAM_HALT ||
         state.A[2].tag != VAL_INT || state.A[2].data.integer != 2) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
+wam_c_astar_shortest_path_detector_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_astar_path_4(WamState* state);
+void setup_detected_wam_c_kernels(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_astar_path_4(&state);
+    setup_detected_wam_c_kernels(&state);
+
+    wam_register_weighted_edge(&state, "tom", "bob", 5);
+    wam_register_weighted_edge(&state, "tom", "eve", 1);
+    wam_register_weighted_edge(&state, "eve", "ann", 1);
+    wam_register_weighted_edge(&state, "bob", "ann", 1);
+    wam_register_direct_distance_edge(&state, "tom", "ann", 2);
+    wam_register_direct_distance_edge(&state, "eve", "ann", 1);
+    wam_register_direct_distance_edge(&state, "bob", "ann", 1);
+
+    WamValue args[4] = {
+        val_atom("tom"),
+        val_atom("ann"),
+        val_int(5),
+        val_unbound("Weight")
+    };
+    int rc = wam_run_predicate(&state, "astar_path/4", args, 4);
+    if (rc != 0 || state.P != WAM_HALT ||
+        state.A[3].tag != VAL_INT || state.A[3].data.integer != 2) {
         wam_free_state(&state);
         return 10;
     }
@@ -4126,6 +4349,7 @@ run_tests_once :-
     test_transitive_parent_distance_kernel_generation,
     test_transitive_step_parent_distance_kernel_generation,
     test_weighted_shortest_path_kernel_generation,
+    test_astar_shortest_path_kernel_generation,
     test_fact_source_generation,
     test_streaming_foreign_results_generation,
     test_kernel_detector_setup_generation,
@@ -4134,6 +4358,7 @@ run_tests_once :-
     test_transitive_parent_distance_detector_setup_generation,
     test_transitive_step_parent_distance_detector_setup_generation,
     test_weighted_shortest_path_detector_setup_generation,
+    test_astar_shortest_path_detector_setup_generation,
     test_kernel_detector_project_generation,
     test_lowered_fact_helper_generation,
     test_lowered_helper_planner_metadata,
@@ -4160,6 +4385,7 @@ run_tests_once :-
     test_transitive_parent_distance_kernel_executable_smoke,
     test_transitive_step_parent_distance_kernel_executable_smoke,
     test_weighted_shortest_path_kernel_executable_smoke,
+    test_astar_shortest_path_kernel_executable_smoke,
     test_fact_source_executable_smoke,
     test_lmdb_fact_source_executable_smoke,
     test_kernel_detector_executable_smoke,
@@ -4168,6 +4394,7 @@ run_tests_once :-
     test_transitive_parent_distance_detector_executable_smoke,
     test_transitive_step_parent_distance_detector_executable_smoke,
     test_weighted_shortest_path_detector_executable_smoke,
+    test_astar_shortest_path_detector_executable_smoke,
     test_streaming_foreign_results_executable_smoke,
     test_real_prolog_builtin_executable_smoke,
     test_real_prolog_term_builtin_executable_smoke,


### PR DESCRIPTION
# Add WAM-C A* shortest path kernel

## Summary

- Add native WAM-C support for the shared `astar_shortest_path4` recursive kernel.
- Register the A* kernel through explicit shared-kernel metadata and detector-generated setup.
- Add in-memory direct-distance heuristic edges alongside the existing integer weighted edge storage.
- Add a goal-directed native arity-4 handler that requires bound source, target, and dimensionality arguments, then binds the shortest integer path cost.
- Add direct and detected-project executable smokes covering shortest-route selection, bound-cost success, unbound-dimensionality rejection, and unreachable reverse-path failure.
- Refresh `WAM_C_TARGET_NEXT_STEPS.md` to record this completed slice and move the recommended next branch to accumulated-runtime-cost investigation.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
- `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
- `python3 tests/test_benchmark_target_matrix.py`
- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/test_wam_c_lowered_helper_scale_regression.py`
- `git diff --check`
