### PR TITLE
feat(wam-cpp): term_variables/2, numbervars/3, =@=/2, unifiable/3

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -1862,6 +1862,7 @@ compile_wam_runtime_header_to_cpp(_Options,
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace wam_cpp {
@@ -4507,6 +4508,151 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         }
         std::string functor = items[0].s + "/" + std::to_string(items.size() - 1);
         bind_cell(t, Value::Compound(functor, std::move(args)));
+        pc += 1; return true;
+    }
+
+    // ---- term_variables/2 ------------------------------------------
+    // Walk +Term and collect a list of the unique unbound cells in
+    // left-to-right order of first occurrence. Each shared variable
+    // appears once. Identity is by CellPtr (shared_ptr address).
+    if (op == "term_variables/2") {
+        std::vector<CellPtr> vars;
+        std::unordered_set<Value*> seen;
+        std::function<void(CellPtr)> walk = [&](CellPtr c) {
+            if (!c) return;
+            if (c->is_unbound()) {
+                if (seen.insert(c.get()).second) vars.push_back(c);
+                return;
+            }
+            if (c->tag == Value::Tag::Compound) {
+                for (auto& a : c->args) walk(a);
+            }
+        };
+        walk(get_cell("A1"));
+        CellPtr list = std::make_shared<Value>(Value::Atom("[]"));
+        for (auto it = vars.rbegin(); it != vars.rend(); ++it) {
+            std::vector<CellPtr> ca;
+            ca.push_back(*it);
+            ca.push_back(list);
+            list = std::make_shared<Value>(
+                Value::Compound("[|]/2", std::move(ca)));
+        }
+        if (!unify_cells(get_cell("A2"), list)) return false;
+        pc += 1; return true;
+    }
+
+    // ---- numbervars/3 ----------------------------------------------
+    // numbervars(+Term, +Start, -End). For each free variable in Term
+    // (left-to-right first occurrence), bind it to ''$VAR''(N) where N
+    // starts at Start and increments. End is one past the last N.
+    if (op == "numbervars/3") {
+        Value sv = *get_cell("A2");
+        if (sv.tag != Value::Tag::Integer) return false;
+        std::int64_t n = sv.i;
+        std::unordered_set<Value*> seen;
+        std::function<void(CellPtr)> walk = [&](CellPtr c) {
+            if (!c) return;
+            if (c->is_unbound()) {
+                if (seen.insert(c.get()).second) {
+                    std::vector<CellPtr> ca;
+                    ca.push_back(std::make_shared<Value>(Value::Integer(n++)));
+                    bind_cell(c, Value::Compound("$VAR/1", std::move(ca)));
+                }
+                return;
+            }
+            if (c->tag == Value::Tag::Compound) {
+                for (auto& a : c->args) walk(a);
+            }
+        };
+        walk(get_cell("A1"));
+        Value end_v = Value::Integer(n);
+        CellPtr tgt = get_cell("A3");
+        if (tgt->is_unbound()) { bind_cell(tgt, end_v); pc += 1; return true; }
+        if (!unify_cells(tgt, std::make_shared<Value>(end_v))) return false;
+        pc += 1; return true;
+    }
+
+    // ---- =@=/2 and \\=@=/2 (variant equivalence) -------------------
+    // Two terms are variant if they''re structurally identical
+    // modulo a bijective variable renaming. Walk both in parallel
+    // maintaining two maps (A->B and B->A) so each unbound cell on
+    // one side maps to exactly one on the other.
+    if (op == "=@=/2" || op == "\\\\=@=/2") {
+        std::unordered_map<Value*, Value*> ab, ba;
+        std::function<bool(CellPtr,CellPtr)> variant = [&](CellPtr a, CellPtr b) -> bool {
+            if (!a || !b) return false;
+            bool au = a->is_unbound(), bu = b->is_unbound();
+            if (au && bu) {
+                Value* ap = a.get(); Value* bp = b.get();
+                auto it1 = ab.find(ap);
+                auto it2 = ba.find(bp);
+                if (it1 == ab.end() && it2 == ba.end()) {
+                    ab[ap] = bp; ba[bp] = ap; return true;
+                }
+                if (it1 != ab.end() && it2 != ba.end()
+                    && it1->second == bp && it2->second == ap) return true;
+                return false;
+            }
+            if (au != bu) return false;
+            if (a->tag != b->tag) return false;
+            switch (a->tag) {
+                case Value::Tag::Atom:    return a->s == b->s;
+                case Value::Tag::Integer: return a->i == b->i;
+                case Value::Tag::Float:   return a->f == b->f;
+                case Value::Tag::Compound:
+                    if (a->s != b->s || a->args.size() != b->args.size())
+                        return false;
+                    for (std::size_t k = 0; k < a->args.size(); ++k)
+                        if (!variant(a->args[k], b->args[k])) return false;
+                    return true;
+                default: return false;
+            }
+        };
+        bool eq = variant(get_cell("A1"), get_cell("A2"));
+        bool want = (op == "=@=/2");
+        if (eq != want) return false;
+        pc += 1; return true;
+    }
+
+    // ---- unifiable/3 -----------------------------------------------
+    // unifiable(?Term1, ?Term2, -Bindings). Succeeds iff Term1 and
+    // Term2 unify, and unifies A3 with the resulting bindings as a
+    // list of ''=''(Var, Value) pairs. Does NOT leave the actual
+    // bindings in place -- we undo via the trail after recording.
+    if (op == "unifiable/3") {
+        std::size_t mark = trail.size();
+        if (!unify_cells(get_cell("A1"), get_cell("A2"))) {
+            // unify_cells may have pushed partial bindings before failing.
+            while (trail.size() > mark) {
+                *trail.back().cell = trail.back().prev;
+                trail.pop_back();
+            }
+            return false;
+        }
+        // Collect bindings list while bindings are still in effect.
+        std::vector<CellPtr> pairs;
+        for (std::size_t k = mark; k < trail.size(); ++k) {
+            std::vector<CellPtr> ca;
+            ca.push_back(trail[k].cell); // the variable
+            // Snapshot the bound value (post-binding) into a fresh cell.
+            ca.push_back(std::make_shared<Value>(*trail[k].cell));
+            pairs.push_back(std::make_shared<Value>(
+                Value::Compound("=/2", std::move(ca))));
+        }
+        // Undo so the original variables become unbound again.
+        while (trail.size() > mark) {
+            *trail.back().cell = trail.back().prev;
+            trail.pop_back();
+        }
+        CellPtr list = std::make_shared<Value>(Value::Atom("[]"));
+        for (auto it = pairs.rbegin(); it != pairs.rend(); ++it) {
+            std::vector<CellPtr> ca;
+            ca.push_back(*it);
+            ca.push_back(list);
+            list = std::make_shared<Value>(
+                Value::Compound("[|]/2", std::move(ca)));
+        }
+        if (!unify_cells(get_cell("A3"), list)) return false;
         pc += 1; return true;
     }
 

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1469,6 +1469,11 @@ is_builtin_pred(functor, 3). % term inspection: name/arity read or construct
 is_builtin_pred(arg, 3).     % term inspection: Nth argument access
 is_builtin_pred((=..), 2).   % term inspection: univ (decompose/compose)
 is_builtin_pred(copy_term, 2). % term inspection: fresh-variable copy
+is_builtin_pred(term_variables, 2). % collect unbound vars in left-to-right order
+is_builtin_pred(numbervars, 3).     % bind free vars to $VAR(N) in sequence
+is_builtin_pred((=@=), 2).          % variant equivalence (modulo var renaming)
+is_builtin_pred((\=@=), 2).         % not variant
+is_builtin_pred(unifiable, 3).      % non-binding unification + bindings list
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -139,6 +139,23 @@
 :- dynamic user:wam_cpp_test_length_bad/0.
 :- dynamic user:wam_cpp_test_copy_basic/0.
 :- dynamic user:wam_cpp_test_copy_atom/0.
+:- dynamic user:wam_cpp_test_tv_ground/0.
+:- dynamic user:wam_cpp_test_tv_one/0.
+:- dynamic user:wam_cpp_test_tv_shared/0.
+:- dynamic user:wam_cpp_test_tv_nested/0.
+:- dynamic user:wam_cpp_test_nv_shared/0.
+:- dynamic user:wam_cpp_test_nv_start10/0.
+:- dynamic user:wam_cpp_test_nv_ground/0.
+:- dynamic user:wam_cpp_test_variant_yes/0.
+:- dynamic user:wam_cpp_test_variant_share/0.
+:- dynamic user:wam_cpp_test_variant_shape/0.
+:- dynamic user:wam_cpp_test_variant_atom/0.
+:- dynamic user:wam_cpp_test_variant_bind/0.
+:- dynamic user:wam_cpp_test_variant_neq/0.
+:- dynamic user:wam_cpp_test_uni_simple/0.
+:- dynamic user:wam_cpp_test_uni_fail/0.
+:- dynamic user:wam_cpp_test_uni_two/0.
+:- dynamic user:wam_cpp_test_uni_ground/0.
 :- dynamic user:wam_cpp_test_enum_member/0.
 
 user:wam_cpp_test_member_yes   :- member(b, [a, b, c]).
@@ -149,6 +166,44 @@ user:wam_cpp_test_length_zero  :- length([], 0).
 user:wam_cpp_test_length_bad   :- length([a, b, c], 5).
 user:wam_cpp_test_copy_basic   :- copy_term(foo(X, X, _Y), T), T = foo(A, A, _B).
 user:wam_cpp_test_copy_atom    :- copy_term(hello, T), T = hello.
+% term_variables/2: collect free vars in left-to-right first-occurrence
+% order. Each shared variable appears once.
+user:wam_cpp_test_tv_ground    :- term_variables(foo(1, 2, 3), L), L = [].
+user:wam_cpp_test_tv_one       :- term_variables(foo(_X, 1), L), L = [_].
+user:wam_cpp_test_tv_shared    :- term_variables(foo(X, _Y, X), L),
+                                  L = [X, _], var(X).
+user:wam_cpp_test_tv_nested    :- term_variables(p(q(_X, _Y), r(_Y, _Z)), L),
+                                  length(L, 3).
+% numbervars/3: bind free vars to $VAR(N) starting at Start.
+user:wam_cpp_test_nv_shared    :-
+    T = foo(X, Y, X),
+    numbervars(T, 0, End),
+    End = 2,
+    T = foo('$VAR'(0), '$VAR'(1), '$VAR'(0)).
+user:wam_cpp_test_nv_start10   :-
+    T = pair(_, _),
+    numbervars(T, 10, End),
+    End = 12,
+    T = pair('$VAR'(10), '$VAR'(11)).
+user:wam_cpp_test_nv_ground    :- numbervars(hello, 0, 0).
+% =@=/2 and \=@=/2: variant equivalence.
+user:wam_cpp_test_variant_yes  :- foo(_, _, _) =@= foo(_, _, _).
+user:wam_cpp_test_variant_share :- foo(X, _, X) =@= foo(A, _, A).
+user:wam_cpp_test_variant_shape :- \+ (foo(_, _) =@= foo(_, _, _)).
+user:wam_cpp_test_variant_atom :- \+ (foo(_) =@= bar(_)).
+user:wam_cpp_test_variant_bind :- \+ (foo(a, X) =@= foo(X, a)).
+user:wam_cpp_test_variant_neq  :- foo(_, _) \=@= foo(X, X).
+% unifiable/3: non-binding unification + bindings list.
+user:wam_cpp_test_uni_simple   :-
+    unifiable(X, foo(a), B),
+    B = [X = foo(a)],
+    var(X).
+user:wam_cpp_test_uni_fail     :- \+ unifiable(foo(a), foo(b), _).
+user:wam_cpp_test_uni_two      :-
+    unifiable(p(X, Y), p(1, 2), B),
+    B = [X=1, Y=2],
+    var(X), var(Y).
+user:wam_cpp_test_uni_ground   :- unifiable(hello, hello, []).
 user:wam_cpp_test_enum_member  :- findall(X, member(X, [a, b, c]), L),
                                   L = [a, b, c].
 
@@ -2749,6 +2804,53 @@ test(cpp_e2e_term_inspection_extended, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_ground_atom/0',        [], true),
           run_query(BinPath, 'wam_cpp_test_ground_guard/0',       [], true),
           run_query(BinPath, 'wam_cpp_test_ground_guard_not/0',   [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_term_variables, [condition(cpp_compiler_available)]) :-
+    % term_variables/2, numbervars/3, =@=/2, \=@=/2, unifiable/3.
+    % All operate by walking the term and using cell-pointer identity
+    % to track which variables are which. unifiable/3 also relies on
+    % the trail to capture-and-undo the unification result.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_tvars', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_tv_ground/0,
+                               user:wam_cpp_test_tv_one/0,
+                               user:wam_cpp_test_tv_shared/0,
+                               user:wam_cpp_test_tv_nested/0,
+                               user:wam_cpp_test_nv_shared/0,
+                               user:wam_cpp_test_nv_start10/0,
+                               user:wam_cpp_test_nv_ground/0,
+                               user:wam_cpp_test_variant_yes/0,
+                               user:wam_cpp_test_variant_share/0,
+                               user:wam_cpp_test_variant_shape/0,
+                               user:wam_cpp_test_variant_atom/0,
+                               user:wam_cpp_test_variant_bind/0,
+                               user:wam_cpp_test_variant_neq/0,
+                               user:wam_cpp_test_uni_simple/0,
+                               user:wam_cpp_test_uni_fail/0,
+                               user:wam_cpp_test_uni_two/0,
+                               user:wam_cpp_test_uni_ground/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_tv_ground/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_tv_one/0',        [], true),
+          run_query(BinPath, 'wam_cpp_test_tv_shared/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_tv_nested/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_nv_shared/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_nv_start10/0',    [], true),
+          run_query(BinPath, 'wam_cpp_test_nv_ground/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_variant_yes/0',   [], true),
+          run_query(BinPath, 'wam_cpp_test_variant_share/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_variant_shape/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_variant_atom/0',  [], true),
+          run_query(BinPath, 'wam_cpp_test_variant_bind/0',  [], true),
+          run_query(BinPath, 'wam_cpp_test_variant_neq/0',   [], true),
+          run_query(BinPath, 'wam_cpp_test_uni_simple/0',    [], true),
+          run_query(BinPath, 'wam_cpp_test_uni_fail/0',      [], true),
+          run_query(BinPath, 'wam_cpp_test_uni_two/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_uni_ground/0',    [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Adds the term-variable inspection tier: walking a term to find, re-bind, or compare its free variables. All four builtins share the same identity model — `CellPtr` (shared_ptr) address equality.

### New builtins

- **`term_variables/2`** — `term_variables(+Term, -Vars)`. Walks Term collecting unique unbound cells in left-to-right order of first occurrence. Shared variables appear once.

- **`numbervars/3`** — `numbervars(+Term, +Start, -End)`. For each fresh free variable in Term (left-to-right first occurrence), binds it to `'$VAR'(N)` starting at Start. End is one past the last N. Bindings go through `bind_cell`, so they're trailed and reversible on backtrack like any other binding.

- **`=@=/2` and `\=@=/2`** — Variant equivalence: structurally identical modulo bijective variable renaming. Walks both sides in parallel maintaining two cell-pointer maps (A→B and B→A) to enforce the bijection. Atomic terms must match exactly; compounds match recursively.

- **`unifiable/3`** — `unifiable(?T1, ?T2, -Bindings)`. Tries to unify T1 and T2, and if it succeeds, captures the trail diff as a list of `'='(Var, Value)` pairs in Bindings, then undoes the bindings so the original variables stay unbound. Captures via `trail_mark` before `unify_cells` and walks `trail[mark..end]` to build the pairs.

### Wiring

- All four registered as `is_builtin_pred` in `wam_target.pl` so callers compile to `builtin_call` directly (not via the Execute opcode's fallback path).
- `<unordered_set>` added to the runtime header for the seen-cell tracking in `term_variables`/`numbervars`.

### Tests

One new `cpp_e2e_term_variables` bundle with **17 cases**:

- `term_variables/2`: ground term, single var, shared-var dedupe, nested compound.
- `numbervars/3`: `Start=0` with shared vars, `Start=10`, ground term (End == Start).
- `=@=/2` / `\=@=/2`: variant yes (same shape, both with shared vars); not-variant for shape mismatch, atom mismatch, and bind-pattern mismatch (`foo(a, X) =@= foo(X, a)` must fail because X→X self-loop breaks the bijection); `\=@=` positive direction.
- `unifiable/3`: single bind (`X` ↔ `foo(a)`), fail (`foo(a) ≠ foo(b)`), two-var bind, and ground-term identity (Bindings = `[]`).

Full `test_wam_cpp_generator` suite (344 tests) passes; `test_wam_target` unchanged and green.

## Test plan

- [x] Smoke test `/tmp` — all 19 cases pass.
- [x] `test_wam_target` regression — all green.
- [x] Full `test_wam_cpp_generator` (344 tests) — all green.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_