### PR TITLE
test(csharp-query): smoke actionable policy report format

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -166,6 +166,21 @@ access shape. Policy output reports the best overall mode and the best
 artifact-backed mode separately, so an in-memory `preload` scan win does not
 hide the best external artifact for column-0 lookup, column-1 lookup, bucket
 streaming, or storage.
+Use `policy-compare-tsv` or `policy-compare-markdown` to compare the current
+effective-distance source policy against the measured best artifact-backed
+mode. Use `policy-actionable-tsv` or `policy-actionable-markdown` to suppress
+matching rows and show only policy differences or missing policy modes, with
+the policy-selected value and policy-vs-best ratio included for triage:
+
+```bash
+python examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py \
+  --scales dev \
+  --lookup-keys 4 \
+  --lookup-repetitions 1 \
+  --repetitions 1 \
+  --format policy-actionable-markdown
+```
+
 At the checked-in 300-10k scales this is expected to favor preload or
 mmap-array; LMDB is primarily retained as the larger-data comparison point for
 future 50k+ style runs where memory pressure matters.

--- a/tests/test_csharp_query_effective_distance_artifact_backends.py
+++ b/tests/test_csharp_query_effective_distance_artifact_backends.py
@@ -161,6 +161,38 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
         self.assertIn("| dev |", result.stdout)
         self.assertIn("Smallest artifact", result.stdout)
 
+    def test_policy_actionable_markdown_cli_reports_policy_diffs(self) -> None:
+        if shutil.which("dotnet") is None:
+            self.skipTest("dotnet is not available")
+        if not LIGHTNINGDB_PACKAGE.exists():
+            self.skipTest("LightningDB 0.21.0 package is not available in the local NuGet cache")
+
+        result = subprocess.run(
+            [
+                "python3",
+                str(SCRIPT),
+                "--scales",
+                "dev",
+                "--lookup-keys",
+                "4",
+                "--lookup-repetitions",
+                "1",
+                "--repetitions",
+                "1",
+                "--format",
+                "policy-actionable-markdown",
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=180,
+        )
+        self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        self.assertIn("| Policy mode | Policy artifact value | Policy vs best |", result.stdout)
+        self.assertIn("| diff |", result.stdout)
+        self.assertNotIn("| match |", result.stdout)
+
     def test_dev_article_category_relation_reports_all_backends(self) -> None:
         if shutil.which("dotnet") is None:
             self.skipTest("dotnet is not available")


### PR DESCRIPTION
  ## Summary

  - Documents `policy-compare-*` and `policy-actionable-*` formats for the C# effective-distance artifact backend benchmark.
  - Adds a README example for generating the actionable policy markdown report.
  - Adds a CLI smoke test for `--format policy-actionable-markdown` on the `dev` fixture.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py tests/test_csharp_query_lmdb_provider_smoke.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `git diff --check`