### PR TITLE
feat(wam-clojure): add multi-mode sub_atom builtin

### DIFF
--- a/PR_WAM_CLOJURE_SUB_ATOM.md
+++ b/PR_WAM_CLOJURE_SUB_ATOM.md
@@ -1,0 +1,19 @@
+# PR Title
+
+feat(wam-clojure): add multi-mode sub_atom builtin
+
+# PR Description
+
+## Summary
+
+- Adds direct lowered Clojure WAM support for `sub_atom/5`.
+- Implements multi-mode substring enumeration for variable `Before`, `Length`, `After`, and `SubAtom` against a ground source atom.
+- Reuses the existing foreign-solution choice point path so later goals can backtrack into additional substring candidates.
+- Extends runtime smoke coverage for extraction, prefix/suffix checks, later-match backtracking, no-match failure, and unbound source failure.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -484,6 +484,10 @@ clojure_direct_builtin("string_length/2", "2").
 clojure_direct_builtin("string_length/2", 2).
 clojure_direct_builtin('string_length/2', "2").
 clojure_direct_builtin('string_length/2', 2).
+clojure_direct_builtin("sub_atom/5", "5").
+clojure_direct_builtin("sub_atom/5", 5).
+clojure_direct_builtin('sub_atom/5', "5").
+clojure_direct_builtin('sub_atom/5', 5).
 clojure_direct_builtin("!/0", "0").
 clojure_direct_builtin("!/0", 0).
 clojure_direct_builtin('!/0', "0").
@@ -838,6 +842,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     ),
     !,
     format(atom(Expr), '(runtime/apply-atom-length-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "sub_atom/5" ; Op == 'sub_atom/5'),
+    !,
+    format(atom(Expr), '(runtime/apply-sub-atom-solution ~w (inc (:pc ~w)))', [S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     clojure_unary_guard_test(Op, TestExpr),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1070,6 +1070,67 @@
           (backtrack state)))
       (backtrack state))))
 
+(declare apply-first-foreign-solution)
+
+(defn sub-atom-int-value [state value]
+  (cond
+    (integer? value) value
+    (atom-term? value) (parse-number-text (atom-text state value))
+    (string? value) (parse-number-text value)
+    :else nil))
+
+(defn sub-atom-solution-results [state text before length after sub]
+  (let [n (count text)
+        before-spec (if-let [n* (sub-atom-int-value state before)]
+                      (when (and (integer? n*) (not (neg? n*)) (<= n* n)) n*)
+                      (when (or (= before ::unbound) (logic-var? before)) ::var))
+        length-spec (if-let [n* (sub-atom-int-value state length)]
+                      (when (and (integer? n*) (not (neg? n*)) (<= n* n)) n*)
+                      (when (or (= length ::unbound) (logic-var? length)) ::var))
+        after-spec (if-let [n* (sub-atom-int-value state after)]
+                     (when (and (integer? n*) (not (neg? n*)) (<= n* n)) n*)
+                     (when (or (= after ::unbound) (logic-var? after)) ::var))
+        sub-text (cond
+                   (atom-term? sub) (atom-text state sub)
+                   (or (= sub ::unbound) (logic-var? sub)) ::var
+                   :else nil)]
+    (when (and (some? before-spec)
+               (some? length-spec)
+               (some? after-spec)
+               (some? sub-text))
+      (let [before-range (if (= before-spec ::var) (range (inc n)) [before-spec])]
+        (vec
+         (for [b before-range
+               l (if (= length-spec ::var) (range (inc (- n b))) [length-spec])
+               :when (<= (+ b l) n)
+               :let [a (- n b l)
+                     piece (subs text b (+ b l))
+                     bindings (cond-> {}
+                                (= before-spec ::var) (assoc 2 b)
+                                (= length-spec ::var) (assoc 3 l)
+                                (= after-spec ::var) (assoc 4 a)
+                                (= sub-text ::var) (assoc 5 piece))]
+               :when (and (or (= after-spec ::var) (= after-spec a))
+                          (or (= sub-text ::var) (= sub-text piece)))]
+           {:bindings bindings}))))))
+
+(defn apply-sub-atom-solution [base-state resume-pc]
+  (let [source (deref-value (:bindings base-state)
+                            (or (reg-get-raw base-state "A1") ::unbound))
+        before (deref-value (:bindings base-state)
+                            (or (reg-get-raw base-state "A2") ::unbound))
+        length (deref-value (:bindings base-state)
+                            (or (reg-get-raw base-state "A3") ::unbound))
+        after (deref-value (:bindings base-state)
+                           (or (reg-get-raw base-state "A4") ::unbound))
+        sub (deref-value (:bindings base-state)
+                         (or (reg-get-raw base-state "A5") ::unbound))
+        text (atom-text base-state source)]
+    (if-let [results (and (some? text)
+                          (sub-atom-solution-results base-state text before length after sub))]
+      (apply-first-foreign-solution base-state resume-pc results)
+      (backtrack base-state))))
+
 (defn ground-term? [state value]
   (let [bindings (:bindings state)]
     (letfn [(ground* [term seen]
@@ -1901,6 +1962,9 @@
 
           "string_length/2"
           (apply-atom-length-solution state)
+
+          "sub_atom/5"
+          (apply-sub-atom-solution state (inc (:pc state)))
 
           "!/0"
           (-> state

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -732,6 +732,15 @@ test(simple_builtin_atom_length_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_sub_atom_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_sub_atom/5:\nbuiltin_call sub_atom/5, 5\nproceed\n",
+        wam_clojure_lowerable(test_sub_atom/5, WamCode, deterministic),
+        lower_predicate_to_clojure(test_sub_atom/5, WamCode, [], Code),
+        has(Code, "runtime/apply-sub-atom-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(terminal_execute_ground_is_direct_lowered_as_succeeding_builtin) :-
     once((
         WamCode = "test_execute_ground/1:\nallocate\ndeallocate\nexecute ground/1\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -158,6 +158,13 @@
 :- dynamic user:wam_atom_length_guard/2.
 :- dynamic user:wam_atom_length_unbound/1.
 :- dynamic user:wam_string_length_guard/2.
+:- dynamic user:wam_sub_atom_extract/0.
+:- dynamic user:wam_sub_atom_prefix/0.
+:- dynamic user:wam_sub_atom_suffix/0.
+:- dynamic user:wam_sub_atom_backtrack_later_before/0.
+:- dynamic user:wam_sub_atom_length_bound_later_before/0.
+:- dynamic user:wam_sub_atom_no_match/0.
+:- dynamic user:wam_sub_atom_unbound_source/1.
 :- dynamic user:wam_arith_eq_42/1.
 :- dynamic user:wam_arith_eq_float/1.
 :- dynamic user:wam_arith_neq_42/1.
@@ -337,6 +344,13 @@ user:wam_string_concat_guard(A, B, C) :- string_concat(A, B, C).
 user:wam_atom_length_guard(A, N) :- atom_length(A, N).
 user:wam_atom_length_unbound(N) :- user:wam_unbound_arg(A), atom_length(A, N).
 user:wam_string_length_guard(A, N) :- string_length(A, N).
+user:wam_sub_atom_extract :- sub_atom(hello, 1, 3, A, S), A =:= 1, S = ell.
+user:wam_sub_atom_prefix :- sub_atom(hello, 0, 3, _, hel).
+user:wam_sub_atom_suffix :- sub_atom(hello, _, 3, 0, llo).
+user:wam_sub_atom_backtrack_later_before :- sub_atom(abcabc, B, _, _, b), B =:= 4.
+user:wam_sub_atom_length_bound_later_before :- sub_atom(abcabc, B, 1, _, b), B =:= 4.
+user:wam_sub_atom_no_match :- sub_atom(abc, _, _, _, xyz).
+user:wam_sub_atom_unbound_source(_) :- user:wam_unbound_arg(A), sub_atom(A, 0, 1, _, _).
 user:wam_arith_eq_42(X) :- X =:= 42.
 user:wam_arith_eq_float(X) :- X =:= 3.5.
 user:wam_arith_neq_42(X) :- X =\= 42.
@@ -521,6 +535,13 @@ run_smoke :-
           user:wam_atom_length_guard/2,
           user:wam_atom_length_unbound/1,
           user:wam_string_length_guard/2,
+          user:wam_sub_atom_extract/0,
+          user:wam_sub_atom_prefix/0,
+          user:wam_sub_atom_suffix/0,
+          user:wam_sub_atom_backtrack_later_before/0,
+          user:wam_sub_atom_length_bound_later_before/0,
+          user:wam_sub_atom_no_match/0,
+          user:wam_sub_atom_unbound_source/1,
           user:wam_arith_eq_42/1,
           user:wam_arith_eq_float/1,
           user:wam_arith_neq_42/1,
@@ -862,6 +883,13 @@ smoke_cases([
     case('wam_atom_length_guard/2', args(foo, 2), "false"),
     case('wam_atom_length_unbound/1', 0, "false"),
     case('wam_string_length_guard/2', args(foo, 3), "true"),
+    case('wam_sub_atom_extract/0', no_args, "true"),
+    case('wam_sub_atom_prefix/0', no_args, "true"),
+    case('wam_sub_atom_suffix/0', no_args, "true"),
+    case('wam_sub_atom_backtrack_later_before/0', no_args, "true"),
+    case('wam_sub_atom_length_bound_later_before/0', no_args, "true"),
+    case('wam_sub_atom_no_match/0', no_args, "false"),
+    case('wam_sub_atom_unbound_source/1', a, "false"),
     case('wam_arith_eq_42/1', 42, "true"),
     case('wam_arith_eq_42/1', 3.5, "false"),
     case('wam_arith_eq_float/1', 3.5, "true"),
@@ -1201,10 +1229,12 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-number-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-atom-concat-guard-3"),
     has(CoreCode, "defn lowered-wam-atom-length-guard-2"),
+    has(CoreCode, "defn lowered-wam-sub-atom-extract-0"),
     has(CoreCode, "runtime/ground-term?"),
     has(CoreCode, "runtime/apply-text-conversion-solution"),
     has(CoreCode, "runtime/apply-atom-concat-solution"),
-    has(CoreCode, "runtime/apply-atom-length-solution").
+    has(CoreCode, "runtime/apply-atom-length-solution"),
+    has(CoreCode, "runtime/apply-sub-atom-solution").
 
 assert_lowered_arithmetic_comparison_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds direct lowered Clojure WAM support for `sub_atom/5`.
- Implements multi-mode substring enumeration for variable `Before`, `Length`, `After`, and `SubAtom` against a ground source atom.
- Reuses the existing foreign-solution choice point path so later goals can backtrack into additional substring candidates.
- Extends runtime smoke coverage for extraction, prefix/suffix checks, later-match backtracking, no-match failure, and unbound source failure.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
