### PR TITLE
chore: add optional examples/more submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "tools/agent-loop/prototype"]
 	path = tools/agent-loop/prototype
 	url = git@github.com:s243a/uwsal.git
+[submodule "examples/more"]
+	path = examples/more
+	url = git@github.com:s243a/UnifyWeaver_Examples.git


### PR DESCRIPTION
## Summary

- Adds `examples/more` as an optional submodule pointing to `git@github.com:s243a/UnifyWeaver_Examples.git`.
- Updates the submodule pointer to include generated effective-distance artifacts.
- Adds generated Haskell effective-distance benchmark code under:
  - `examples/more/graph/effect_dist/haskell/gen/lmdb_l2_parallel_ffi/`
- Adds generated Rust comparison code under:
  - `examples/more/graph/effect_dist/rust/gen/lowered_parallel_ffi/`
- Documents the effective-distance graph problem, why the generated artifacts live outside the main repo, and links back to the main benchmark driver, Haskell/Rust generators, and Rust MySQL/LMDB parser.

## Notes

The generated Haskell profile uses:

```sh
swipl -q -s examples/benchmark/generate_wam_haskell_matrix_benchmark.pl -- \
  data/benchmark/10k/facts.pl \
  examples/more/graph/effect_dist/haskell/gen/lmdb_l2_parallel_ffi \
  accumulated functions kernels_on resident_auto
```

That selects lowered Haskell functions, FFI kernels, LMDB resident mode, sharded L2 cache, and generated parallel WAM choice-point support.

## Verification

- `cargo check` in `examples/more/graph/effect_dist/rust/gen/lowered_parallel_ffi`
- Debian proot:
  - installed `liblmdb-dev` and `pkg-config`
  - `cabal update`
  - `cabal build` in `examples/more/graph/effect_dist/haskell/gen/lmdb_l2_parallel_ffi`

The Haskell build completed and linked `wam-haskell-matrix-bench`. It emitted existing generated-code overlapping-pattern warnings in `WamRuntime.hs`, but no build failure.
