### PR TITLE
Add Go WAM term-order comparison builtins

### DIFF
--- a/PR_go_wam_term_order_builtins.md
+++ b/PR_go_wam_term_order_builtins.md
@@ -1,0 +1,24 @@
+# PR Title
+
+Add Go WAM term-order comparison builtins
+
+# PR Description
+
+## Summary
+
+- Adds generated Go WAM runtime support for `@</2`, `@=</2`, `@>/2`, `@>=/2`, and `compare/3`.
+- Registers the term-order predicates as direct Go WAM builtins so compiled calls emit `BuiltinCall` instructions.
+- Extends the generated Go builtin E2E test to cover atom ordering, integer ordering, mixed atom/integer ordering, and `compare/3` results.
+- Updates the Go WAM parity audit to record the expanded term-order comparison surface against the Clojure and Haskell-oriented baseline.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- direct emitter checks for `@</2`, `@=</2`, `@>/2`, `@>=/2`, and `compare/3`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -13,7 +13,7 @@ current cross-target builtin/runtime baseline.
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
 | Structural builtins | `member/2`, `memberchk/2`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
-| Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2` | Includes `=</2` | Present for current baseline comparisons |
+| Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` | Includes `=</2`; Haskell mode analysis and Clojure lowering also cover term-order comparisons | Present for current baseline comparisons, with expanded term-order coverage |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
 | Term inspection | `functor/3`, `arg/3` | `functor/3`, `arg/3` | Present |
 | Univ | `=../2` compose/decompose | `=../2` compose/decompose | Present |
@@ -50,6 +50,11 @@ current cross-target builtin/runtime baseline.
   builtin E2E test for standard ordered sorting, duplicate removal in
   `sort/2`, duplicate preservation in `msort/2`, mixed atom/integer ordering,
   and malformed-list failure, matching the Clojure/R ordered-list surface.
+- Term-order comparisons `@</2`, `@=</2`, `@>/2`, `@>=/2`, and `compare/3`
+  are now covered by the generated Go WAM builtin E2E test over the same
+  atom/integer ordering used by Go WAM sort and indexed-switch ordering,
+  matching the Clojure term-order lowering surface and the Haskell mode
+  analysis baseline.
 - Go WAM choice points now have explicit generated-runtime coverage for normal
   clause retries, indexed alternatives, foreign stream retries, indexed atom
   fact streams, and `member/2` builtin retries.

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -443,6 +443,17 @@ wam_go_direct_builtin("sort/2", 2, 'sort/2').
 wam_go_direct_builtin(msort/2, 2, 'msort/2').
 wam_go_direct_builtin('msort/2', 2, 'msort/2').
 wam_go_direct_builtin("msort/2", 2, 'msort/2').
+wam_go_direct_builtin('@</2', 2, '@</2').
+wam_go_direct_builtin("@</2", 2, '@</2').
+wam_go_direct_builtin('@=</2', 2, '@=</2').
+wam_go_direct_builtin("@=</2", 2, '@=</2').
+wam_go_direct_builtin('@>/2', 2, '@>/2').
+wam_go_direct_builtin("@>/2", 2, '@>/2').
+wam_go_direct_builtin('@>=/2', 2, '@>=/2').
+wam_go_direct_builtin("@>=/2", 2, '@>=/2').
+wam_go_direct_builtin(compare/3, 3, 'compare/3').
+wam_go_direct_builtin('compare/3', 3, 'compare/3').
+wam_go_direct_builtin("compare/3", 3, 'compare/3').
 
 wam_instruction_to_go_literal(get_constant(C, Ai), GoLiteral) :-
     go_value_literal(C, GoVal),

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1048,6 +1048,24 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 
 	case "==/2": return valueEquals(vm.deref(arg1), vm.deref(arg2))
 	case "\\==/2": return !valueEquals(vm.deref(arg1), vm.deref(arg2))
+	case "@</2":
+		return compareValues(vm.deref(arg1), vm.deref(arg2)) < 0
+	case "@=</2":
+		return compareValues(vm.deref(arg1), vm.deref(arg2)) <= 0
+	case "@>/2":
+		return compareValues(vm.deref(arg1), vm.deref(arg2)) > 0
+	case "@>=/2":
+		return compareValues(vm.deref(arg1), vm.deref(arg2)) >= 0
+	case "compare/3":
+		cmp := compareValues(vm.deref(arg2), vm.deref(arg3))
+		switch {
+		case cmp < 0:
+			return vm.Unify(arg1, internAtom("<"))
+		case cmp > 0:
+			return vm.Unify(arg1, internAtom(">"))
+		default:
+			return vm.Unify(arg1, internAtom("="))
+		}
 	case "=/2": return vm.Unify(arg1, arg2)
 	case "\\=/2":
 		clone := vm.Clone()

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -14,6 +14,7 @@
 :- dynamic user:test_nth_builtin/0.
 :- dynamic user:test_numlist_builtin/0.
 :- dynamic user:test_sort_builtin/0.
+:- dynamic user:test_term_order_builtin/0.
 :- dynamic user:test_set_aggregate/0.
 :- dynamic user:test_unify_builtin/0.
 :- dynamic user:test_neg_fact/1.
@@ -106,6 +107,17 @@ test(builtins_execution) :-
                 \+ sort([a|b], _),
                 \+ msort([a|b], _)
             )),
+          assertz(user:test_term_order_builtin :-
+            (   bar @< foo,
+                foo @=< foo,
+                2 @> 1,
+                2 @>= 2,
+                bar @< 1,
+                \+ 1 @< bar,
+                compare(<, bar, foo),
+                compare(=, foo, foo),
+                compare(>, 2, 1)
+            )),
           assertz(user:test_set_aggregate :-
             (   aggregate_all(set(X), member(X, [a,b,a]), S),
                 length(S, 2),
@@ -136,6 +148,7 @@ test(builtins_execution) :-
           retractall(user:test_nth_builtin),
           retractall(user:test_numlist_builtin),
           retractall(user:test_sort_builtin),
+          retractall(user:test_term_order_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
           retractall(user:test_neg_fact(_)),
@@ -145,7 +158,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -184,6 +197,11 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "numlist/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "sort/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "msort/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "@</2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "@=</2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "@>/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "@>=/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "compare/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "\\\\+/1"')),
     assertion(sub_string(LibCode, _, _, _, 'AggType: "set"')),
 
@@ -277,6 +295,14 @@ func main() {
 		fmt.Println("SORT_FAILURE")
 	}
 
+	termOrderVM := wam.NewWamState(wam.Test_term_order_builtinCode, wam.Test_term_order_builtinLabels)
+	termOrderVM.PC = wam.Test_term_order_builtinStartPC
+	if termOrderVM.Run() {
+		fmt.Println("TERM_ORDER_SUCCESS")
+	} else {
+		fmt.Println("TERM_ORDER_FAILURE")
+	}
+
 	setVM := wam.NewWamState(wam.Test_set_aggregateCode, wam.Test_set_aggregateLabels)
 	setVM.PC = wam.Test_set_aggregateStartPC
 	if setVM.Run() {
@@ -335,6 +361,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "NTH_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NUMLIST_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SORT_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "TERM_ORDER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NEG_SUCCESS")),


### PR DESCRIPTION
## Summary

- Adds generated Go WAM runtime support for `@</2`, `@=</2`, `@>/2`, `@>=/2`, and `compare/3`.
- Registers the term-order predicates as direct Go WAM builtins so compiled calls emit `BuiltinCall` instructions.
- Extends the generated Go builtin E2E test to cover atom ordering, integer ordering, mixed atom/integer ordering, and `compare/3` results.
- Updates the Go WAM parity audit to record the expanded term-order comparison surface against the Clojure and Haskell-oriented baseline.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- direct emitter checks for `@</2`, `@=</2`, `@>/2`, `@>=/2`, and `compare/3`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`
