### PR TITLE
feat(wam-cpp): module-qualified meta-call + random library

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -2657,6 +2657,7 @@ compile_wam_runtime_to_cpp(_Options,
 #include <cmath>
 #include <cstdio>
 #include <limits>
+#include <random>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -2665,6 +2666,15 @@ namespace wam_cpp {
 
 // Forward declarations for free functions defined later in this TU.
 static int standard_order_cmp(const Value& a, const Value& b);
+
+// Process-wide PRNG for the random/* family. Mersenne Twister 64-bit
+// with the standard default seed (5489) so unseeded runs are
+// reproducible; set_random(seed(N)) replaces it, set_random(seed(random))
+// re-seeds from std::random_device.
+static std::mt19937_64& cpp_global_rng() {
+    static std::mt19937_64 rng(5489);
+    return rng;
+}
 
 // ----------------------------------------------------------------------
 // Cell helpers
@@ -4911,6 +4921,106 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         pc += 1; return true;
     }
 
+    // ---- random/1 --------------------------------------------------
+    // random(-X) -- X is a Float in [0, 1).
+    if (op == "random/1") {
+        std::uniform_real_distribution<double> dist(0.0, 1.0);
+        Value r = Value::Float(dist(cpp_global_rng()));
+        CellPtr tgt = get_cell("A1");
+        if (tgt->is_unbound()) { bind_cell(tgt, r); pc += 1; return true; }
+        if (!unify_cells(tgt, std::make_shared<Cell>(r))) return false;
+        pc += 1; return true;
+    }
+
+    // ---- random_between/3 ------------------------------------------
+    // random_between(+L, +H, -X) -- X is an Integer in [L, H] inclusive.
+    // Throws type_error on non-integer bounds; fails if L > H.
+    if (op == "random_between/3") {
+        Value lv = *get_cell("A1");
+        Value hv = *get_cell("A2");
+        if (lv.is_unbound() || hv.is_unbound())
+            return throw_iso_error(make_instantiation_error());
+        if (lv.tag != Value::Tag::Integer)
+            return throw_iso_error(make_type_error("integer", lv));
+        if (hv.tag != Value::Tag::Integer)
+            return throw_iso_error(make_type_error("integer", hv));
+        if (lv.i > hv.i) return false;
+        std::uniform_int_distribution<std::int64_t> dist(lv.i, hv.i);
+        Value r = Value::Integer(dist(cpp_global_rng()));
+        CellPtr tgt = get_cell("A3");
+        if (tgt->is_unbound()) { bind_cell(tgt, r); pc += 1; return true; }
+        if (!unify_cells(tgt, std::make_shared<Cell>(r))) return false;
+        pc += 1; return true;
+    }
+
+    // ---- random_member/2 -------------------------------------------
+    // random_member(-X, +List) -- X is a uniformly random element of List.
+    // Empty List fails; same shape as member but picks one item.
+    if (op == "random_member/2") {
+        std::vector<CellPtr> items;
+        CellPtr lc = get_cell("A2");
+        for (;;) {
+            Value lv = *lc;
+            if (lv.tag == Value::Tag::Atom && lv.s == "[]") break;
+            if (lv.tag != Value::Tag::Compound || lv.s != "[|]/2"
+                || lv.args.size() != 2) return false;
+            items.push_back(lv.args[0]);
+            lc = lv.args[1];
+        }
+        if (items.empty()) return false;
+        std::uniform_int_distribution<std::size_t> dist(0, items.size() - 1);
+        std::size_t idx = dist(cpp_global_rng());
+        if (!unify_cells(get_cell("A1"), items[idx])) return false;
+        pc += 1; return true;
+    }
+
+    // ---- random_permutation/2 --------------------------------------
+    // random_permutation(+List, -PermList) -- Fisher-Yates shuffle of List
+    // via std::shuffle on a copy of the cell pointers.
+    if (op == "random_permutation/2") {
+        std::vector<CellPtr> items;
+        CellPtr lc = get_cell("A1");
+        for (;;) {
+            Value lv = *lc;
+            if (lv.tag == Value::Tag::Atom && lv.s == "[]") break;
+            if (lv.tag != Value::Tag::Compound || lv.s != "[|]/2"
+                || lv.args.size() != 2) return false;
+            items.push_back(lv.args[0]);
+            lc = lv.args[1];
+        }
+        std::shuffle(items.begin(), items.end(), cpp_global_rng());
+        CellPtr list = std::make_shared<Cell>(Value::Atom("[]"));
+        for (auto it = items.rbegin(); it != items.rend(); ++it) {
+            std::vector<CellPtr> ca;
+            ca.push_back(*it);
+            ca.push_back(list);
+            list = std::make_shared<Cell>(
+                Value::Compound("[|]/2", std::move(ca)));
+        }
+        if (!unify_cells(get_cell("A2"), list)) return false;
+        pc += 1; return true;
+    }
+
+    // ---- set_random/1 ----------------------------------------------
+    // set_random(seed(Seed))    -- seed with integer Seed.
+    // set_random(seed(random))  -- seed from std::random_device.
+    if (op == "set_random/1") {
+        Value a = *get_cell("A1");
+        if (a.tag != Value::Tag::Compound || a.s != "seed/1"
+            || a.args.size() != 1)
+            return throw_iso_error(make_domain_error("random_option", a));
+        Value sv = *a.args[0];
+        if (sv.tag == Value::Tag::Integer) {
+            cpp_global_rng().seed((std::uint64_t)sv.i);
+        } else if (sv.tag == Value::Tag::Atom && sv.s == "random") {
+            std::random_device rd;
+            cpp_global_rng().seed(rd());
+        } else {
+            return throw_iso_error(make_domain_error("seed_value", sv));
+        }
+        pc += 1; return true;
+    }
+
     // ---- I/O -------------------------------------------------------
     // All write paths route through emit_output / emit_output_char so
     // with_output_to/2 can intercept them into a capture buffer.
@@ -7153,6 +7263,12 @@ bool WamState::dispatch_call_meta(const std::string& op,
     }
     // Resolve the goal''s base name and existing args.
     Value goal = deref(*goal_cell);
+    // Strip Module:Goal wrapping (compound ":/2" -- treat as transparent
+    // for our single-module runtime; the module qualifier becomes a no-op).
+    while (goal.tag == Value::Tag::Compound
+           && goal.s == ":/2" && goal.args.size() == 2) {
+        goal = deref(*goal.args[1]);
+    }
     std::string base_name;
     std::size_t base_arity = 0;
     std::vector<CellPtr> all_args;
@@ -7188,6 +7304,11 @@ bool WamState::dispatch_phrase_call(bool has_rest, std::size_t after_pc) {
         ? get_cell("A3")
         : std::make_shared<Cell>(Value::Atom("[]"));
     Value goal = deref(*goal_cell);
+    // Strip Module:Goal wrapping so phrase(user:greeting, L) works.
+    while (goal.tag == Value::Tag::Compound
+           && goal.s == ":/2" && goal.args.size() == 2) {
+        goal = deref(*goal.args[1]);
+    }
     std::string base_name;
     std::size_t base_arity = 0;
     std::vector<CellPtr> all_args;

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1481,6 +1481,11 @@ is_builtin_pred(must_be, 2).        % type check with type_error throw
 is_builtin_pred(string_chars, 2).   % alias for atom_chars/2 (atoms = strings).
 is_builtin_pred(string_codes, 2).   % alias for atom_codes/2.
 is_builtin_pred(string_code, 3).    % string_code(+Index, +String, -Code), 1-based.
+is_builtin_pred(random, 1).             % random(-X), X in [0, 1) Float.
+is_builtin_pred(random_between, 3).     % random_between(+L, +H, -X), Integer.
+is_builtin_pred(random_member, 2).      % random_member(-X, +List).
+is_builtin_pred(random_permutation, 2). % random_permutation(+List, -Perm).
+is_builtin_pred(set_random, 1).         % set_random(seed(N|random)).
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -204,6 +204,18 @@
 :- dynamic user:wam_cpp_test_dcg_loop_empty/0.
 :- dynamic user:wam_cpp_test_dcg_loop_three/0.
 :- dynamic user:wam_cpp_test_dcg_phrase3/0.
+:- dynamic user:wam_cpp_test_phrase_mq/0.
+:- dynamic user:wam_cpp_test_call_mq/0.
+:- dynamic user:wam_cpp_test_random_range/0.
+:- dynamic user:wam_cpp_test_rb_in_range/0.
+:- dynamic user:wam_cpp_test_rb_seeded_eq/0.
+:- dynamic user:wam_cpp_test_rb_low_eq_high/0.
+:- dynamic user:wam_cpp_test_rb_low_gt_high/0.
+:- dynamic user:wam_cpp_test_rm_in_list/0.
+:- dynamic user:wam_cpp_test_rm_empty/0.
+:- dynamic user:wam_cpp_test_rp_length/0.
+:- dynamic user:wam_cpp_test_rp_invariant/0.
+:- dynamic user:wam_cpp_test_rp_empty/0.
 :- dynamic user:wam_cpp_test_enum_member/0.
 
 user:wam_cpp_test_member_yes   :- member(b, [a, b, c]).
@@ -330,6 +342,43 @@ user:wam_cpp_test_dcg_loop_three  :- phrase(dcg_loop(L), [a, b, c]),
 user:wam_cpp_test_dcg_phrase3     :- phrase(dcg_greeting,
                                            [hello, world, extra], R),
                                      R = [extra].
+% Module-qualified meta-call: phrase(user:Goal, ...) and call(user:Goal, ...).
+% The dispatcher strips a leading Module: from the goal cell.
+user:wam_cpp_test_phrase_mq       :- phrase(user:dcg_greeting, [hello, world]).
+user:wam_cpp_test_call_mq         :-
+    G = user:atom_concat(a, b),
+    call(G, R),
+    R = ab.
+% Random library: random/1, random_between/3, random_member/2,
+% random_permutation/2, set_random/1. Tests use set_random(seed(N)) for
+% repeatability where reproducibility matters; others just check
+% constraints (range, membership, length, permutation invariant).
+user:wam_cpp_test_random_range    :- random(X), X >= 0.0, X < 1.0.
+user:wam_cpp_test_rb_in_range     :-
+    set_random(seed(42)),
+    random_between(1, 10, X),
+    X >= 1, X =< 10.
+user:wam_cpp_test_rb_seeded_eq    :-
+    set_random(seed(42)),
+    random_between(1, 1000000, X),
+    set_random(seed(42)),
+    random_between(1, 1000000, Y),
+    X = Y.
+user:wam_cpp_test_rb_low_eq_high  :- random_between(5, 5, X), X = 5.
+user:wam_cpp_test_rb_low_gt_high  :- \+ random_between(10, 5, _).
+user:wam_cpp_test_rm_in_list      :-
+    random_member(X, [a, b, c, d]),
+    member(X, [a, b, c, d]).
+user:wam_cpp_test_rm_empty        :- \+ random_member(_, []).
+user:wam_cpp_test_rp_length       :-
+    set_random(seed(1)),
+    random_permutation([1, 2, 3, 4, 5], P),
+    length(P, 5).
+user:wam_cpp_test_rp_invariant    :-
+    set_random(seed(1)),
+    random_permutation([a, b, c], P),
+    msort(P, [a, b, c]).
+user:wam_cpp_test_rp_empty        :- random_permutation([], []).
 user:wam_cpp_test_enum_member  :- findall(X, member(X, [a, b, c]), L),
                                   L = [a, b, c].
 
@@ -3121,6 +3170,49 @@ test(cpp_e2e_dcg, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_dcg_loop_empty/0',      [], true),
           run_query(BinPath, 'wam_cpp_test_dcg_loop_three/0',      [], true),
           run_query(BinPath, 'wam_cpp_test_dcg_phrase3/0',         [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_meta_call_and_random, [condition(cpp_compiler_available)]) :-
+    % Module-qualified meta-call polish (phrase(user:G, L) +
+    % call(user:G, X)) plus the random library: random/1,
+    % random_between/3, random_member/2, random_permutation/2,
+    % set_random/1. Reproducibility tests use set_random(seed(N))
+    % before twin calls and check the results match.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_mr', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_phrase_mq/0,
+                               user:wam_cpp_test_call_mq/0,
+                               user:wam_cpp_test_random_range/0,
+                               user:wam_cpp_test_rb_in_range/0,
+                               user:wam_cpp_test_rb_seeded_eq/0,
+                               user:wam_cpp_test_rb_low_eq_high/0,
+                               user:wam_cpp_test_rb_low_gt_high/0,
+                               user:wam_cpp_test_rm_in_list/0,
+                               user:wam_cpp_test_rm_empty/0,
+                               user:wam_cpp_test_rp_length/0,
+                               user:wam_cpp_test_rp_invariant/0,
+                               user:wam_cpp_test_rp_empty/0,
+                               % DCG-expanded predicate dcg_greeting/2 is
+                               % already in user from the cpp_e2e_dcg
+                               % bundle's defining clauses; we re-include
+                               % it here for this bundle's link.
+                               user:dcg_greeting/2],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_phrase_mq/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_call_mq/0',         [], true),
+          run_query(BinPath, 'wam_cpp_test_random_range/0',    [], true),
+          run_query(BinPath, 'wam_cpp_test_rb_in_range/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_rb_seeded_eq/0',    [], true),
+          run_query(BinPath, 'wam_cpp_test_rb_low_eq_high/0',  [], true),
+          run_query(BinPath, 'wam_cpp_test_rb_low_gt_high/0',  [], true),
+          run_query(BinPath, 'wam_cpp_test_rm_in_list/0',      [], true),
+          run_query(BinPath, 'wam_cpp_test_rm_empty/0',        [], true),
+          run_query(BinPath, 'wam_cpp_test_rp_length/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_rp_invariant/0',    [], true),
+          run_query(BinPath, 'wam_cpp_test_rp_empty/0',        [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Two complementary additions sharing a single PR.

### 1) Module-qualified meta-call polish (follow-up to #2241)

Both `dispatch_call_meta` and `dispatch_phrase_call` now strip a leading `Module:` from the goal cell. So these forms now work the same as the unqualified ones:

```prolog
phrase(user:dcg_greeting, [hello, world])
call(user:atom_concat(a, b), R)
```

The strip is a `while`-loop so nested wrappings (`lib:user:goal`) also collapse. Our runtime is single-module so the qualifier is treated as a no-op rather than a routing concern. Resolves the "known limitation" called out in #2241.

### 2) Random library

- **`random/1`** — `random(-X)`, X is Float in `[0, 1)`.
- **`random_between/3`** — `random_between(+L, +H, -X)`, X Integer in `[L, H]` inclusive. Type-errors on non-integer bounds, fails when `L > H`, `instantiation_error` on unbound bounds.
- **`random_member/2`** — `random_member(-X, +List)`, X uniformly random from List. Empty list fails.
- **`random_permutation/2`** — `random_permutation(+List, -Perm)` via `std::shuffle` on a copy of cell pointers.
- **`set_random/1`** — `set_random(seed(N))` seeds with Integer N; `set_random(seed(random))` seeds from `std::random_device`. Throws `domain_error` for malformed options.

PRNG is a process-wide `std::mt19937_64` wrapped in a function-local static (`cpp_global_rng()`), default seed 5489 so unseeded runs are reproducible. Tests that compare twin calls explicitly call `set_random(seed(N))` twice for repeatability.

### Tests

One new `cpp_e2e_meta_call_and_random` bundle with **12 cases**:

- `phrase` + `call` with `user:` module qualifier.
- `random/1` range bound `[0, 1)`.
- `random_between`: in-range, seed parity (twin calls match after twin seeds), `low == high`, `low > high` (fails).
- `random_member`: in-list, empty (fails).
- `random_permutation`: length preservation, `msort` invariant (same elements modulo order), empty → empty.

Full `test_wam_cpp_generator` suite (348 tests) passes; `test_wam_target` unchanged and green.

## Test plan

- [x] Smoke test `/tmp` — all 15 cases pass.
- [x] `test_wam_target` regression — all green.
- [x] Full `test_wam_cpp_generator` (348 tests) — all green.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_