### PR TITLE
feat(wam-cpp): sort/4 + predsort/3 (custom comparator)

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -510,6 +510,43 @@ static const int _wam_cpp_setup_register = []() {
 :- discontiguous iso_errors_default_to_iso/2.
 :- discontiguous iso_errors_default_to_lax/2.
 
+% predsort/3 stdlib: defined as ordinary user-module Prolog clauses
+% asserted at module load. The compile path picks them up via
+% clause/2 like any other user predicate. Users opt in by including
+% user:predsort/3 plus the four helper predicates in their
+% write_wam_cpp_project predicate list. Doing it this way (rather
+% than as a C++ builtin or runtime-preload bytecode) re-uses the
+% just-polished module-qualified meta-call dispatcher for the
+% call(P, Order, A, B) comparator invocation.
+:- (   current_predicate(user:wam_cpp_predsort_/5)
+   ->  true
+   ;   assertz((user:predsort(P, L, S) :-
+           length(L, N), wam_cpp_predsort_(N, P, L, _, S))),
+       assertz((user:wam_cpp_predsort_(2, P, [X1, X2|T], T, R) :- !,
+           call(P, O, X1, X2), wam_cpp_sort2(O, X1, X2, R))),
+       assertz((user:wam_cpp_predsort_(1, _, [X|T], T, [X]) :- !)),
+       assertz((user:wam_cpp_predsort_(0, _, T, T, []) :- !)),
+       assertz((user:wam_cpp_predsort_(N, P, L1, L3, R) :-
+           N1 is N // 2, N2 is N - N1,
+           wam_cpp_predsort_(N1, P, L1, L2, R1),
+           wam_cpp_predsort_(N2, P, L2, L3, R2),
+           wam_cpp_predmerge(P, R1, R2, R))),
+       assertz((user:wam_cpp_sort2(<, A, B, [A, B]))),
+       assertz((user:wam_cpp_sort2(=, A, _, [A]))),
+       assertz((user:wam_cpp_sort2(>, A, B, [B, A]))),
+       assertz((user:wam_cpp_predmerge(_, [], R, R) :- !)),
+       assertz((user:wam_cpp_predmerge(_, R, [], R) :- !)),
+       assertz((user:wam_cpp_predmerge(P, [H1|T1], [H2|T2], R) :-
+           call(P, O, H1, H2),
+           wam_cpp_predmerge_(O, P, H1, H2, T1, T2, R))),
+       assertz((user:wam_cpp_predmerge_(<, P, H1, H2, T1, T2, [H1|R]) :-
+           wam_cpp_predmerge(P, T1, [H2|T2], R))),
+       assertz((user:wam_cpp_predmerge_(=, P, H1, _, T1, T2, [H1|R]) :-
+           wam_cpp_predmerge(P, T1, T2, R))),
+       assertz((user:wam_cpp_predmerge_(>, P, H1, H2, T1, T2, [H2|R]) :-
+           wam_cpp_predmerge(P, [H1|T1], T2, R)))
+   ).
+
 % is/2 — first ISO-aware builtin. ISO-mode predicates get their
 % default is/2 calls rewritten to is_iso/2 (which throws on bad
 % RHS); lax-mode predicates rewrite to is_lax/2 (a no-op rename
@@ -4430,6 +4467,72 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
                 Value::Compound("[|]/2", std::move(cons_args)));
         }
         CellPtr tgt = get_cell("A2");
+        if (tgt->is_unbound()) { bind_cell(tgt, *result); pc += 1; return true; }
+        if (!unify_cells(tgt, result)) return false;
+        pc += 1; return true;
+    }
+
+    // ---- sort/4 -----------------------------------------------------
+    // sort(+Key, +Order, +List, -Sorted)
+    //   Key:   0 for whole-term, N>0 for the Nth arg of a compound.
+    //   Order: @<  ascending,  dup keys removed.
+    //          @=< ascending,  dup keys kept (stable).
+    //          @>  descending, dup keys removed.
+    //          @>= descending, dup keys kept (stable).
+    if (op == "sort/4") {
+        Value kv = *get_cell("A1");
+        Value ov = *get_cell("A2");
+        if (kv.tag != Value::Tag::Integer)
+            return throw_iso_error(make_type_error("integer", kv));
+        if (ov.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", ov));
+        std::int64_t key_pos = kv.i;
+        if (key_pos < 0)
+            return throw_iso_error(make_domain_error("not_less_than_zero", kv));
+        bool ascending, dedup;
+        if      (ov.s == "@<")  { ascending = true;  dedup = true;  }
+        else if (ov.s == "@=<") { ascending = true;  dedup = false; }
+        else if (ov.s == "@>")  { ascending = false; dedup = true;  }
+        else if (ov.s == "@>=") { ascending = false; dedup = false; }
+        else return throw_iso_error(make_domain_error("order", ov));
+        std::vector<CellPtr> items;
+        CellPtr lc = get_cell("A3");
+        for (;;) {
+            Value lv = deref(*lc);
+            if (lv.tag == Value::Tag::Atom && lv.s == "[]") break;
+            if (lv.tag != Value::Tag::Compound || lv.s != "[|]/2"
+                || lv.args.size() != 2) return false;
+            items.push_back(lv.args[0]);
+            lc = lv.args[1];
+        }
+        auto extract_key = [key_pos](const CellPtr& c) -> CellPtr {
+            if (key_pos == 0) return c;
+            if (c->tag == Value::Tag::Compound
+                && (std::size_t)key_pos <= c->args.size())
+                return c->args[key_pos - 1];
+            return c; // fall back to whole-term comparison
+        };
+        std::stable_sort(items.begin(), items.end(),
+            [&](const CellPtr& a, const CellPtr& b) {
+                int cmp = standard_order_cmp(*extract_key(a), *extract_key(b));
+                return ascending ? (cmp < 0) : (cmp > 0);
+            });
+        if (dedup) {
+            items.erase(std::unique(items.begin(), items.end(),
+                [&](const CellPtr& a, const CellPtr& b) {
+                    return standard_order_cmp(*extract_key(a),
+                                              *extract_key(b)) == 0;
+                }), items.end());
+        }
+        CellPtr result = std::make_shared<Cell>(Value::Atom("[]"));
+        for (auto it = items.rbegin(); it != items.rend(); ++it) {
+            std::vector<CellPtr> cons_args;
+            cons_args.push_back(*it);
+            cons_args.push_back(result);
+            result = std::make_shared<Cell>(
+                Value::Compound("[|]/2", std::move(cons_args)));
+        }
+        CellPtr tgt = get_cell("A4");
         if (tgt->is_unbound()) { bind_cell(tgt, *result); pc += 1; return true; }
         if (!unify_cells(tgt, result)) return false;
         pc += 1; return true;

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1486,6 +1486,7 @@ is_builtin_pred(random_between, 3).     % random_between(+L, +H, -X), Integer.
 is_builtin_pred(random_member, 2).      % random_member(-X, +List).
 is_builtin_pred(random_permutation, 2). % random_permutation(+List, -Perm).
 is_builtin_pred(set_random, 1).         % set_random(seed(N|random)).
+is_builtin_pred(sort, 4).               % sort(+Key, +Order, +List, -Sorted).
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -216,6 +216,17 @@
 :- dynamic user:wam_cpp_test_rp_length/0.
 :- dynamic user:wam_cpp_test_rp_invariant/0.
 :- dynamic user:wam_cpp_test_rp_empty/0.
+:- dynamic user:wam_cpp_test_sort4_asc_dedup/0.
+:- dynamic user:wam_cpp_test_sort4_asc_keep/0.
+:- dynamic user:wam_cpp_test_sort4_desc_dedup/0.
+:- dynamic user:wam_cpp_test_sort4_desc_keep/0.
+:- dynamic user:wam_cpp_test_sort4_by_first/0.
+:- dynamic user:wam_cpp_test_sort4_empty/0.
+:- dynamic user:wam_cpp_test_predsort_asc/0.
+:- dynamic user:wam_cpp_test_predsort_desc/0.
+:- dynamic user:wam_cpp_test_predsort_by_key/0.
+:- dynamic user:wam_cpp_test_predsort_empty/0.
+:- dynamic user:wam_cpp_test_predsort_single/0.
 :- dynamic user:wam_cpp_test_enum_member/0.
 
 user:wam_cpp_test_member_yes   :- member(b, [a, b, c]).
@@ -379,6 +390,39 @@ user:wam_cpp_test_rp_invariant    :-
     random_permutation([a, b, c], P),
     msort(P, [a, b, c]).
 user:wam_cpp_test_rp_empty        :- random_permutation([], []).
+% sort/4 (key + order options) and predsort/3 (custom comparator).
+% sort/4 is a C++ builtin; predsort/3 lives as user-module Prolog
+% asserted at module load (with wam_cpp_predsort_/5, wam_cpp_sort2/4,
+% wam_cpp_predmerge/4, wam_cpp_predmerge_/7 helpers).
+user:dcg_cmp_int(O, A, B) :- compare(O, A, B).
+user:dcg_cmp_int_desc(O1, A, B) :-
+    compare(O0, A, B),
+    ( O0 == < -> O1 = >
+    ; O0 == > -> O1 = <
+    ; O1 = O0
+    ).
+user:dcg_cmp_by_first(O, A-_, B-_) :- compare(O, A, B).
+user:wam_cpp_test_sort4_asc_dedup  :- sort(0, @<, [3, 1, 2, 1, 3], L),
+                                      L = [1, 2, 3].
+user:wam_cpp_test_sort4_asc_keep   :- sort(0, @=<, [3, 1, 2, 1, 3], L),
+                                      L = [1, 1, 2, 3, 3].
+user:wam_cpp_test_sort4_desc_dedup :- sort(0, @>, [3, 1, 2, 1, 3], L),
+                                      L = [3, 2, 1].
+user:wam_cpp_test_sort4_desc_keep  :- sort(0, @>=, [3, 1, 2, 1, 3], L),
+                                      L = [3, 3, 2, 1, 1].
+user:wam_cpp_test_sort4_by_first   :-
+    sort(1, @<, [pair(b, 2), pair(a, 1), pair(c, 3), pair(a, 9)], L),
+    L = [pair(a, 1), pair(b, 2), pair(c, 3)].
+user:wam_cpp_test_sort4_empty      :- sort(0, @<, [], []).
+user:wam_cpp_test_predsort_asc     :-
+    predsort(dcg_cmp_int, [3, 1, 2, 1, 3], L), L = [1, 2, 3].
+user:wam_cpp_test_predsort_desc    :-
+    predsort(dcg_cmp_int_desc, [1, 3, 2, 5, 4], L), L = [5, 4, 3, 2, 1].
+user:wam_cpp_test_predsort_by_key  :-
+    predsort(dcg_cmp_by_first, [b-2, a-1, c-3, a-9], L),
+    L = [a-1, b-2, c-3].
+user:wam_cpp_test_predsort_empty   :- predsort(dcg_cmp_int, [], []).
+user:wam_cpp_test_predsort_single  :- predsort(dcg_cmp_int, [42], [42]).
 user:wam_cpp_test_enum_member  :- findall(X, member(X, [a, b, c]), L),
                                   L = [a, b, c].
 
@@ -3213,6 +3257,55 @@ test(cpp_e2e_meta_call_and_random, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_rp_length/0',       [], true),
           run_query(BinPath, 'wam_cpp_test_rp_invariant/0',    [], true),
           run_query(BinPath, 'wam_cpp_test_rp_empty/0',        [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_sort_customization, [condition(cpp_compiler_available)]) :-
+    % sort/4: Key (0 for whole-term, N for Nth compound arg) +
+    % Order (@< / @=< / @> / @>=). @< and @> remove duplicate keys;
+    % @=< and @>= keep them.
+    % predsort/3: stdlib mergesort with user comparator that returns
+    % <, =, or >. Equal pairs are deduped. Implemented as ordinary
+    % user-module Prolog asserted at wam_cpp_target.pl load time so
+    % the existing compile path handles it -- caller must include
+    % the four helper predicates in addition to predsort/3 itself.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_sortp', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_sort4_asc_dedup/0,
+                               user:wam_cpp_test_sort4_asc_keep/0,
+                               user:wam_cpp_test_sort4_desc_dedup/0,
+                               user:wam_cpp_test_sort4_desc_keep/0,
+                               user:wam_cpp_test_sort4_by_first/0,
+                               user:wam_cpp_test_sort4_empty/0,
+                               user:wam_cpp_test_predsort_asc/0,
+                               user:wam_cpp_test_predsort_desc/0,
+                               user:wam_cpp_test_predsort_by_key/0,
+                               user:wam_cpp_test_predsort_empty/0,
+                               user:wam_cpp_test_predsort_single/0,
+                               user:dcg_cmp_int/3,
+                               user:dcg_cmp_int_desc/3,
+                               user:dcg_cmp_by_first/3,
+                               % predsort/3 stdlib helpers asserted by
+                               % wam_cpp_target.pl at module load.
+                               user:predsort/3,
+                               user:wam_cpp_predsort_/5,
+                               user:wam_cpp_sort2/4,
+                               user:wam_cpp_predmerge/4,
+                               user:wam_cpp_predmerge_/7],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_sort4_asc_dedup/0',  [], true),
+          run_query(BinPath, 'wam_cpp_test_sort4_asc_keep/0',   [], true),
+          run_query(BinPath, 'wam_cpp_test_sort4_desc_dedup/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_sort4_desc_keep/0',  [], true),
+          run_query(BinPath, 'wam_cpp_test_sort4_by_first/0',   [], true),
+          run_query(BinPath, 'wam_cpp_test_sort4_empty/0',      [], true),
+          run_query(BinPath, 'wam_cpp_test_predsort_asc/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_predsort_desc/0',    [], true),
+          run_query(BinPath, 'wam_cpp_test_predsort_by_key/0',  [], true),
+          run_query(BinPath, 'wam_cpp_test_predsort_empty/0',   [], true),
+          run_query(BinPath, 'wam_cpp_test_predsort_single/0',  [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Sort customization, in two complementary forms.

### `sort/4` — keyed sort with order options

```prolog
sort(+Key, +Order, +List, -Sorted)
```

- **`Key`**: `0` for whole-term comparison; `N>0` for the Nth argument of a compound (falls back to whole-term for non-compounds at that position).
- **`Order`**:
  - `@<` ascending, dup keys removed.
  - `@=<` ascending, dup keys kept (stable).
  - `@>` descending, dup keys removed.
  - `@>=` descending, dup keys kept (stable).

Implemented as a C++ builtin using `std::stable_sort` + `std::unique` with `standard_order_cmp` on the extracted key. Type-errors on non-integer `Key` or non-atom `Order`; `domain_error` for bad order atom or negative `Key`.

### `predsort/3` — custom-comparator sort

```prolog
predsort(:Comparator, +List, -Sorted)
```

Mergesort with a user-defined 3-arg comparator that returns one of `<`, `=`, `>` on each comparison. Equal pairs (`Order = =`) are deduplicated. Sourced from the standard SWI implementation: divide+conquer halving with `predmerge` for the merge step.

**Implementation approach**: ordinary user-module Prolog asserted at module-load time inside `wam_cpp_target.pl`. This re-uses the module-qualified meta-call dispatcher from PR #2245 to handle the `call(P, Order, A, B)` comparator invocation — without needing new bytecode-preload infrastructure or recursive-VM machinery.

**UX caveat**: callers must include the four helper predicates alongside `predsort/3`:

```prolog
write_wam_cpp_project(
    [user:my_test/0, user:my_cmp/3,
     user:predsort/3,
     user:wam_cpp_predsort_/5,
     user:wam_cpp_sort2/4,
     user:wam_cpp_predmerge/4,
     user:wam_cpp_predmerge_/7],
    [emit_main(true)], Dir).
```

A future PR could add an auto-include mechanism (e.g. an option like `include_stdlib(true)` that prepends these automatically).

### Tests

One new `cpp_e2e_sort_customization` bundle with **11 cases**:

- **`sort/4`**: four orderings (`@<`, `@=<`, `@>`, `@>=`) on a shared list, sort by first-arg key, empty list.
- **`predsort/3`**: ascending (via `compare/3`), descending (via a comparator that swaps `<`/`>`), by first-arg key with dedup, empty + singleton edge cases.

Full `test_wam_cpp_generator` suite (349 tests) passes; `test_wam_target` unchanged and green.

## Test plan

- [x] Smoke test `/tmp` — all 12 cases pass.
- [x] `test_wam_target` regression — all green.
- [x] Full `test_wam_cpp_generator` (349 tests) — all green.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_