### PR TITLE
feat(wam-cpp): include_stdlib option + assertion/1

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -510,14 +510,12 @@ static const int _wam_cpp_setup_register = []() {
 :- discontiguous iso_errors_default_to_iso/2.
 :- discontiguous iso_errors_default_to_lax/2.
 
-% predsort/3 stdlib: defined as ordinary user-module Prolog clauses
-% asserted at module load. The compile path picks them up via
-% clause/2 like any other user predicate. Users opt in by including
-% user:predsort/3 plus the four helper predicates in their
-% write_wam_cpp_project predicate list. Doing it this way (rather
-% than as a C++ builtin or runtime-preload bytecode) re-uses the
-% just-polished module-qualified meta-call dispatcher for the
-% call(P, Order, A, B) comparator invocation.
+% predsort/3 stdlib + assertion/1: defined as ordinary user-module
+% Prolog clauses asserted at module load. The compile path picks
+% them up via clause/2 like any other user predicate. Users opt in
+% either by including the specific helpers in their predicate list,
+% or via the include_stdlib(true|List) option to
+% write_wam_cpp_project, which auto-prepends the registered helpers.
 :- (   current_predicate(user:wam_cpp_predsort_/5)
    ->  true
    ;   assertz((user:predsort(P, L, S) :-
@@ -546,6 +544,35 @@ static const int _wam_cpp_setup_register = []() {
        assertz((user:wam_cpp_predmerge_(>, P, H1, H2, T1, T2, [H2|R]) :-
            wam_cpp_predmerge(P, [H1|T1], T2, R)))
    ).
+:- (   current_predicate(user:assertion/1)
+   ->  true
+   ;   assertz((user:assertion(G) :-
+           ( call(G)
+           -> true
+           ;  throw(error(assertion_failed, G))
+           )))
+   ).
+
+%% stdlib_feature_predicates(+Feature, -Predicates)
+%  Registry mapping a stdlib feature name to its predicate
+%  indicators (in compile order — main first, helpers after). Used
+%  by write_wam_cpp_project's include_stdlib option to auto-prepend
+%  the right helpers without callers having to spell them out.
+stdlib_feature_predicates(predsort, [
+    user:predsort/3,
+    user:wam_cpp_predsort_/5,
+    user:wam_cpp_sort2/4,
+    user:wam_cpp_predmerge/4,
+    user:wam_cpp_predmerge_/7
+]).
+stdlib_feature_predicates(assertion, [
+    user:assertion/1
+]).
+
+%% all_stdlib_features(-Features)
+%  List of every known stdlib feature, in a stable order. Used when
+%  the caller passes include_stdlib(true).
+all_stdlib_features([predsort, assertion]).
 
 % is/2 — first ISO-aware builtin. ISO-mode predicates get their
 % default is/2 calls rewritten to is_iso/2 (which throws on bad
@@ -1719,7 +1746,8 @@ parse_switch_term(Tokens, Labels, ConstsCpp, StructsCpp, ListPC) :-
 %    cpp/wam_runtime.h
 %    cpp/wam_runtime.cpp
 %    cpp/generated_program.cpp
-write_wam_cpp_project(Predicates, Options, ProjectDir) :-
+write_wam_cpp_project(Predicates0, Options, ProjectDir) :-
+    expand_stdlib_predicates(Predicates0, Options, Predicates),
     make_directory_path(ProjectDir),
     directory_file_path(ProjectDir, 'cpp', CppDir),
     make_directory_path(CppDir),
@@ -1893,6 +1921,45 @@ foreign_pred_keys_from_options(Options, Keys) :-
     ->  Keys = Keys0
     ;   Keys = []
     ).
+
+%% expand_stdlib_predicates(+Predicates0, +Options, -Predicates)
+%  Honours the include_stdlib option: prepends helper predicate
+%  indicators for each requested feature. Duplicates (when the user
+%  already listed a helper explicitly) are removed.
+%
+%  Option shapes:
+%    include_stdlib(true)            -- include every known feature
+%    include_stdlib(false)           -- no expansion (the default)
+%    include_stdlib([F1, F2, ...])   -- include only listed features
+%    include_stdlib(F)               -- single-feature shorthand
+expand_stdlib_predicates(Predicates0, Options, Predicates) :-
+    (   member(include_stdlib(Spec), Options)
+    ->  resolve_stdlib_features(Spec, Features),
+        findall(Extras,
+                ( member(F, Features),
+                  stdlib_feature_predicates(F, Extras)
+                ),
+                NestedExtras),
+        flatten_once(NestedExtras, AllExtras),
+        % Append user-supplied entries last so we don't shadow their
+        % explicit ordering; then dedupe keeping first occurrence.
+        append(AllExtras, Predicates0, Combined),
+        dedupe_keep_first(Combined, Predicates)
+    ;   Predicates = Predicates0
+    ).
+
+resolve_stdlib_features(true, Features) :- !, all_stdlib_features(Features).
+resolve_stdlib_features(false, []) :- !.
+resolve_stdlib_features(List, List) :- is_list(List), !.
+resolve_stdlib_features(F, [F]).
+
+flatten_once([], []).
+flatten_once([L|Ls], Out) :- append(L, Rest, Out), flatten_once(Ls, Rest).
+
+dedupe_keep_first([], []).
+dedupe_keep_first([H|T], [H|Out]) :-
+    exclude(==(H), T, T1),
+    dedupe_keep_first(T1, Out).
 
 write_text_file(Path, Content) :-
     setup_call_cleanup(

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -227,6 +227,9 @@
 :- dynamic user:wam_cpp_test_predsort_by_key/0.
 :- dynamic user:wam_cpp_test_predsort_empty/0.
 :- dynamic user:wam_cpp_test_predsort_single/0.
+:- dynamic user:wam_cpp_test_assertion_ok/0.
+:- dynamic user:wam_cpp_test_assertion_fail/0.
+:- dynamic user:wam_cpp_test_assertion_expr/0.
 :- dynamic user:wam_cpp_test_enum_member/0.
 
 user:wam_cpp_test_member_yes   :- member(b, [a, b, c]).
@@ -423,6 +426,19 @@ user:wam_cpp_test_predsort_by_key  :-
     L = [a-1, b-2, c-3].
 user:wam_cpp_test_predsort_empty   :- predsort(dcg_cmp_int, [], []).
 user:wam_cpp_test_predsort_single  :- predsort(dcg_cmp_int, [42], [42]).
+% assertion/1 (wam_cpp_target auto-asserts the user-module clause):
+%   assertion(true) succeeds silently; assertion(false) / fail throws
+%   error(assertion_failed, Goal). The include_stdlib option (also new)
+%   makes write_wam_cpp_project auto-prepend the helpers.
+user:wam_cpp_test_assertion_ok      :- assertion(true), assertion(1 =:= 1).
+user:wam_cpp_test_assertion_fail    :-
+    catch(assertion(fail),
+          error(assertion_failed, fail),
+          true).
+user:wam_cpp_test_assertion_expr    :-
+    catch(assertion(1 =:= 2),
+          error(assertion_failed, _),
+          true).
 user:wam_cpp_test_enum_member  :- findall(X, member(X, [a, b, c]), L),
                                   L = [a, b, c].
 
@@ -3306,6 +3322,32 @@ test(cpp_e2e_sort_customization, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_predsort_by_key/0',  [], true),
           run_query(BinPath, 'wam_cpp_test_predsort_empty/0',   [], true),
           run_query(BinPath, 'wam_cpp_test_predsort_single/0',  [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_stdlib_autoinclude_and_assertion,
+     [condition(cpp_compiler_available)]) :-
+    % include_stdlib(true) auto-prepends every registered stdlib
+    % feature's helpers, so the caller's predicate list doesn't need
+    % to spell out predsort/3's 4 helpers. assertion/1 is the new
+    % stdlib feature delivered in this PR -- asserts (call(G) -> true
+    % ; throw(error(assertion_failed, G))) and so a failed assertion
+    % is observable via catch/3.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_stdlib', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_predsort_asc/0,
+                               user:wam_cpp_test_assertion_ok/0,
+                               user:wam_cpp_test_assertion_fail/0,
+                               user:wam_cpp_test_assertion_expr/0,
+                               user:dcg_cmp_int/3],
+                              [emit_main(true), include_stdlib(true)],
+                              TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_predsort_asc/0',   [], true),
+          run_query(BinPath, 'wam_cpp_test_assertion_ok/0',   [], true),
+          run_query(BinPath, 'wam_cpp_test_assertion_fail/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_assertion_expr/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Polishes the UX caveat from PR #2246 and lands `assertion/1` (deferred since PR #2239).

### `include_stdlib` option

`write_wam_cpp_project` now accepts an `include_stdlib(Spec)` option that auto-prepends the helper predicates for the listed stdlib features. Three accepted shapes:

```prolog
write_wam_cpp_project(MyPreds, [emit_main(true), include_stdlib(true)],         Dir).
write_wam_cpp_project(MyPreds, [emit_main(true), include_stdlib([predsort, assertion])], Dir).
write_wam_cpp_project(MyPreds, [emit_main(true), include_stdlib(predsort)],     Dir).
```

Default is no expansion — the option is opt-in to avoid surprising callers who curate their predicate list manually.

Internally, `expand_stdlib_predicates/3` resolves the spec, looks up each feature's helpers via `stdlib_feature_predicates/2`, prepends them, then dedupes (keeping the first occurrence so a user-spelled entry retains its position). Both `compile_predicates_for_project` and `emit_setup_function` consume the expanded list, so the C++ output and CLI shim entry table both reflect the auto-inclusion.

### Registered stdlib features

| Feature   | Helpers prepended                                                                                  |
|-----------|---------------------------------------------------------------------------------------------------|
| predsort  | `predsort/3`, `wam_cpp_predsort_/5`, `wam_cpp_sort2/4`, `wam_cpp_predmerge/4`, `wam_cpp_predmerge_/7` |
| assertion | `assertion/1`                                                                                      |

### `assertion/1`

Asserted as a user-module Prolog clause at module load (same approach as predsort/3), so the existing compile path handles it via `clause/2`. The body is the standard rewrite:

```prolog
assertion(G) :- ( call(G) -> true ; throw(error(assertion_failed, G)) ).
```

Failed goals (including arithmetic mismatches like `1 =:= 2`) raise `error(assertion_failed, G)` and are observable via `catch/3`.

### Tests

One new `cpp_e2e_stdlib_autoinclude_and_assertion` bundle with **4 cases**:

- predsort ascending via auto-included helpers (no manual `wam_cpp_*` predicates in the caller's list — verifies the auto-include path).
- `assertion(true)` and `assertion(1 =:= 1)`: silent success.
- `assertion(fail)` caught as `error(assertion_failed, fail)`.
- `assertion(1 =:= 2)` caught as `error(assertion_failed, _)`.

Full `test_wam_cpp_generator` suite (350 tests) passes; `test_wam_target` unchanged and green.

## Test plan

- [x] Smoke test `/tmp` — 4 cases via `include_stdlib(true)` + 2 cases via list/single-feature shorthand.
- [x] `test_wam_target` regression — all green.
- [x] Full `test_wam_cpp_generator` (350 tests) — all green.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_