### PR TITLE
feat(wam-clojure): add string text conversion aliases

### DIFF
--- a/PR_WAM_CLOJURE_STRING_TEXT_ALIASES.md
+++ b/PR_WAM_CLOJURE_STRING_TEXT_ALIASES.md
@@ -1,0 +1,19 @@
+# PR Title
+
+feat(wam-clojure): add string text conversion aliases
+
+# PR Description
+
+## Summary
+
+- Adds direct lowered Clojure WAM support for `string_codes/2` and `string_chars/2`.
+- Routes both aliases through the existing text conversion helper used by atom and number conversions.
+- Treats string aliases as atom-style text conversions, matching the current Clojure WAM atom/string representation.
+- Extends lowered-emitter and runtime smoke coverage for forward and reverse string code/char conversion.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -460,6 +460,14 @@ clojure_direct_builtin("atom_chars/2", "2").
 clojure_direct_builtin("atom_chars/2", 2).
 clojure_direct_builtin('atom_chars/2', "2").
 clojure_direct_builtin('atom_chars/2', 2).
+clojure_direct_builtin("string_codes/2", "2").
+clojure_direct_builtin("string_codes/2", 2).
+clojure_direct_builtin('string_codes/2', "2").
+clojure_direct_builtin('string_codes/2', 2).
+clojure_direct_builtin("string_chars/2", "2").
+clojure_direct_builtin("string_chars/2", 2).
+clojure_direct_builtin('string_chars/2', "2").
+clojure_direct_builtin('string_chars/2', 2).
 clojure_direct_builtin("number_codes/2", "2").
 clojure_direct_builtin("number_codes/2", 2).
 clojure_direct_builtin('number_codes/2', "2").
@@ -823,6 +831,8 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (   Op == "atom_codes/2" ; Op == 'atom_codes/2'
     ;   Op == "atom_chars/2" ; Op == 'atom_chars/2'
+    ;   Op == "string_codes/2" ; Op == 'string_codes/2'
+    ;   Op == "string_chars/2" ; Op == 'string_chars/2'
     ;   Op == "number_codes/2" ; Op == 'number_codes/2'
     ;   Op == "number_chars/2" ; Op == 'number_chars/2'
     ),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1009,8 +1009,9 @@
                           (or (reg-get-raw state "A1") ::unbound))
         right (deref-value (:bindings state)
                            (or (reg-get-raw state "A2") ::unbound))
-        codes? (or (= pred "atom_codes/2") (= pred "number_codes/2"))
-        atom? (or (= pred "atom_codes/2") (= pred "atom_chars/2"))
+        codes? (or (= pred "atom_codes/2") (= pred "string_codes/2") (= pred "number_codes/2"))
+        atom? (or (= pred "atom_codes/2") (= pred "atom_chars/2")
+                  (= pred "string_codes/2") (= pred "string_chars/2"))
         value-text (if atom? (atom-text state left) (number-text left))
         list-text (if codes? (code-list-text state right) (char-list-text state right))]
     (cond
@@ -1943,6 +1944,12 @@
           (apply-text-conversion-solution state (:pred instr))
 
           "atom_chars/2"
+          (apply-text-conversion-solution state (:pred instr))
+
+          "string_codes/2"
+          (apply-text-conversion-solution state (:pred instr))
+
+          "string_chars/2"
           (apply-text-conversion-solution state (:pred instr))
 
           "number_codes/2"

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -714,6 +714,26 @@ test(simple_builtin_number_chars_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_string_codes_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_string_codes/2:\nbuiltin_call string_codes/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_string_codes/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_string_codes/2, WamCode, [], Code),
+        has(Code, "runtime/apply-text-conversion-solution"),
+        has(Code, "string_codes/2"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
+test(simple_builtin_string_chars_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_string_chars/2:\nbuiltin_call string_chars/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_string_chars/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_string_chars/2, WamCode, [], Code),
+        has(Code, "runtime/apply-text-conversion-solution"),
+        has(Code, "string_chars/2"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_atom_concat_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_atom_concat/3:\nbuiltin_call atom_concat/3, 3\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -147,6 +147,10 @@
 :- dynamic user:wam_atom_codes_reverse/0.
 :- dynamic user:wam_atom_chars_guard/2.
 :- dynamic user:wam_atom_chars_reverse/0.
+:- dynamic user:wam_string_codes_guard/2.
+:- dynamic user:wam_string_codes_reverse/0.
+:- dynamic user:wam_string_chars_guard/2.
+:- dynamic user:wam_string_chars_reverse/0.
 :- dynamic user:wam_number_codes_guard/2.
 :- dynamic user:wam_number_codes_reverse/0.
 :- dynamic user:wam_number_chars_guard/2.
@@ -333,6 +337,10 @@ user:wam_atom_codes_guard(A, C) :- atom_codes(A, C).
 user:wam_atom_codes_reverse :- atom_codes(A, [102,111,111]), A = foo.
 user:wam_atom_chars_guard(A, C) :- atom_chars(A, C).
 user:wam_atom_chars_reverse :- atom_chars(A, [f,o,o]), A = foo.
+user:wam_string_codes_guard(A, C) :- string_codes(A, C).
+user:wam_string_codes_reverse :- string_codes(A, [102,111,111]), A = foo.
+user:wam_string_chars_guard(A, C) :- string_chars(A, C).
+user:wam_string_chars_reverse :- string_chars(A, [f,o,o]), A = foo.
 user:wam_number_codes_guard(N, C) :- number_codes(N, C).
 user:wam_number_codes_reverse :- number_codes(N, [52,50]), N =:= 42.
 user:wam_number_chars_guard(N, C) :- number_chars(N, C).
@@ -524,6 +532,10 @@ run_smoke :-
           user:wam_atom_codes_reverse/0,
           user:wam_atom_chars_guard/2,
           user:wam_atom_chars_reverse/0,
+          user:wam_string_codes_guard/2,
+          user:wam_string_codes_reverse/0,
+          user:wam_string_chars_guard/2,
+          user:wam_string_chars_reverse/0,
           user:wam_number_codes_guard/2,
           user:wam_number_codes_reverse/0,
           user:wam_number_chars_guard/2,
@@ -868,6 +880,12 @@ smoke_cases([
     case('wam_atom_chars_guard/2', args(foo, '[f,o,o]'), "true"),
     case('wam_atom_chars_guard/2', args(foo, '[f,o]'), "false"),
     case('wam_atom_chars_reverse/0', no_args, "true"),
+    case('wam_string_codes_guard/2', args(foo, '[102,111,111]'), "true"),
+    case('wam_string_codes_guard/2', args(foo, '[102,111]'), "false"),
+    case('wam_string_codes_reverse/0', no_args, "true"),
+    case('wam_string_chars_guard/2', args(foo, '[f,o,o]'), "true"),
+    case('wam_string_chars_guard/2', args(foo, '[f,o]'), "false"),
+    case('wam_string_chars_reverse/0', no_args, "true"),
     case('wam_number_codes_guard/2', args(42, '[52,50]'), "true"),
     case('wam_number_codes_guard/2', args(42, '[52]'), "false"),
     case('wam_number_codes_reverse/0', no_args, "true"),
@@ -1225,6 +1243,8 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-ground-nested-unbound-1"),
     has(CoreCode, "defn lowered-wam-atom-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-atom-chars-guard-2"),
+    has(CoreCode, "defn lowered-wam-string-codes-guard-2"),
+    has(CoreCode, "defn lowered-wam-string-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-number-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-number-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-atom-concat-guard-3"),


### PR DESCRIPTION
## Summary

- Adds direct lowered Clojure WAM support for `string_codes/2` and `string_chars/2`.
- Routes both aliases through the existing text conversion helper used by atom and number conversions.
- Treats string aliases as atom-style text conversions, matching the current Clojure WAM atom/string representation.
- Extends lowered-emitter and runtime smoke coverage for forward and reverse string code/char conversion.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
