### PR TITLE
docs: generalize WAM ISO error status

### DIFF
--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
@@ -91,6 +91,11 @@ Lua also consumes the shared hook as a no-parser target: it records
 `runtime_parser = none` metadata and rejects parser-dependent bodies rather
 than emitting parser stubs.
 
+Status: this hook is implemented and covered by
+`tests/test_wam_runtime_parser_capability.pl`, with R and Lua as the initial
+consumers. The remaining work is target-by-target adoption, not inventing the
+contract.
+
 The hook should be independent of the WAM items API. A target can skip WAM text
 generation at build time and still need runtime source-term parsing.
 

--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_PHILOSOPHY.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_PHILOSOPHY.md
@@ -10,6 +10,15 @@ UnifyWeaver has two parser problems that should stay separate:
 PR #2086 addresses the first problem. Runtime parser transpilation addresses
 the second one.
 
+Related status docs:
+
+- `RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md` — the target-runtime
+  contract and current R status.
+- `RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md` — phased rollout.
+- `WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` — a separate cross-target runtime
+  feature effort that uses a similar "reference target first, then generalize"
+  documentation pattern.
+
 The R target already demonstrates why the runtime parser matters. Its
 `read/2`, `read_term_from_atom/2,3`, reverse `term_to_atom/2`, and CLI argument
 parsing all need an operator-aware Prolog term parser in the generated runtime.

--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
@@ -153,6 +153,13 @@ The R target currently has an inline parser in `runtime.R.mustache`, while
 `prolog_term_parser.pl` compiles to WAM-R and runs representative parser
 drivers end to end.
 
+The shared generator-side capability hook has also landed in
+`src/unifyweaver/targets/wam_runtime_parser_capability.pl`. R defaults to
+`native(...)`; Lua records `none` and rejects statically visible
+parser-dependent bodies instead of emitting silent stubs. Other targets should
+opt in only after they have compile and runtime proof tests for the selected
+mode.
+
 The compile and runtime guard is:
 
 ```text

--- a/docs/design/WAM_CPP_ISO_ERRORS_PHILOSOPHY.md
+++ b/docs/design/WAM_CPP_ISO_ERRORS_PHILOSOPHY.md
@@ -8,6 +8,8 @@ configuring Prolog predicates."
 
 Companion docs:
 - `WAM_CPP_ISO_ERRORS_SPECIFICATION.md` — the concrete shape we ship.
+- `WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` — how the C++ design generalizes
+  across targets, and which targets have adopted it.
 
 ## 1. What ISO errors are
 
@@ -246,10 +248,11 @@ context-switch.
 
 - **Runtime mode switching.** The mode is fixed at compile time. No
   `set_prolog_flag(iso, true)` equivalent.
-- **Wildcard / module-level rules.** Overrides are per
-  predicate-indicator. If a module wants all its predicates ISO, it
-  lists them. We can add wildcards (`module:*` or `*/*`) later
-  without breaking the per-predicate form.
+- **Wildcard rules.** Overrides are per predicate-indicator. Module-qualified
+  predicate indicators (`module:name/arity`) are now supported by the C++ spec
+  and implementation. If a module wants all its predicates ISO, it still lists
+  them one by one. We can add wildcards (`module:*` or `*/*`) later without
+  breaking the per-predicate form.
 - **Builtins not currently shipped.** `atom_length/2`, `functor/3`,
   `arg/3`, etc. would need their own audit when added — see the
   perf discussion in §2.
@@ -310,11 +313,12 @@ with the implementation, not the docs.
 ## 9. Audit tooling
 
 User feedback called this out as a good idea; moving it from
-"probably not" into the plan.
+"probably not" into the plan. This has now shipped for C++ as
+`wam_cpp_iso_audit/3`; Elixir mirrors the same idea with
+`wam_elixir_iso_audit/3`.
 
-Ship a `wam_cpp_iso_audit/3` predicate alongside the rewrite. Given
-a predicate list and a config, it walks each predicate's compiled
-WAM and reports:
+The C++ audit predicate takes a predicate list and a config, walks each
+predicate's compiled WAM, and reports:
 
 - Which `builtin_call` sites would resolve to ISO vs lax under the
   current config.

--- a/docs/design/WAM_CPP_ISO_ERRORS_SPECIFICATION.md
+++ b/docs/design/WAM_CPP_ISO_ERRORS_SPECIFICATION.md
@@ -1,8 +1,11 @@
 # WAM C++: ISO Error Terms — Specification
 
-Concrete shape of the ISO-error dispatch we're implementing in
+Concrete shape of the ISO-error dispatch implemented in
 `wam_cpp_target.pl`. For *why* each decision, see
 `WAM_CPP_ISO_ERRORS_PHILOSOPHY.md`.
+
+This is now the shipped C++ reference shape. For cross-target adoption status,
+see `WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`.
 
 ## 1. Config schema
 
@@ -414,8 +417,8 @@ test_iso_errors_audit                — given a sample config +
                                         fields.
 ```
 
-Once the first ISO builtin lands (PR #2 in §10), one more
-correctness test gates the catch-with-unbound-context path:
+The first ISO builtin also added a correctness test for the
+catch-with-unbound-context path:
 
 ```
 cpp_e2e_iso_unbound_context — Goal that throws an ISO error;
@@ -451,19 +454,15 @@ shape.
 
 ## 10. Implementation phasing
 
-This is sized for **three small PRs** so each is reviewable:
+This originally landed as **three small PR-sized phases** so each part stayed
+reviewable. All three phases are now represented in the C++ target:
 
-1. **Plumbing PR**: config loader, `iso_errors_rewrite/4` machinery,
-   default→iso and default→lax key tables (initially empty),
-   `throw_iso_error` runtime helper, audit predicate + pretty
-   printer. No behavior change yet — tables are empty so nothing
-   gets rewritten. Smoke-tested by config-loader + audit unit tests.
-2. **First builtin PR**: add `is_iso/2` and `is_lax/2` registrations
-   and the matching entries to both key tables. Tests cover
-   lax-still-works + ISO-throws + explicit-lax-bypass-of-rewrite.
-3. **Sweep PR**: add the remaining arith compares + `succ_iso/2` /
-   `succ_lax/2` and their table entries. Tests for each. Also
-   ships the lax IEEE-754 float-divide behavior change documented
-   in §6.1.
+1. **Plumbing**: config loader, `iso_errors_rewrite/4` machinery,
+   `throw_iso_error` runtime helper, audit predicate + pretty printer.
+2. **First builtin**: `is_iso/2` and `is_lax/2` registrations and
+   matching entries in both key tables.
+3. **Sweep**: arithmetic compare variants plus `succ_iso/2` /
+   `succ_lax/2`, including the lax IEEE-754 float-divide behavior
+   documented in §6.1.
 
 Future builtins follow the §7 pattern incrementally.

--- a/docs/design/WAM_ELIXIR_GAPS_SPECIFICATION.md
+++ b/docs/design/WAM_ELIXIR_GAPS_SPECIFICATION.md
@@ -5,6 +5,11 @@ closing `wam_elixir_target.pl`'s feature gap with the C++ WAM
 target. For *why* each decision, see
 `WAM_ELIXIR_PARITY_PHILOSOPHY.md`.
 
+Status note: the original catch/throw and ISO-error roadmap has largely landed.
+The tables below now distinguish shipped work from remaining parity gaps. For
+the generalized ISO-error contract, see
+`WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`.
+
 Scope boundary vs other Elixir docs:
 - This doc: **feature parity** (catch/throw, ISO errors, meta-call).
 - `WAM_ELIXIR_CORRECTNESS_GAPS.md`: bug fixes in existing features.
@@ -21,15 +26,15 @@ Survey columns: ✅ shipped · ⚠️ partial · ❌ missing.
 |---|---|---|---|---|---|
 | `is/2` | ✅ | ✅ | ✅ | ✅ | All four. |
 | Arith compares (`>/2`, `</2`, `>=/2`, `=</2`, `=:=/2`) | ✅ | ✅ | ✅ | ⚠️ | Haskell partial — needs audit. |
-| `=\=/2` | ❌ | ✅ | ❌ | ❌ | Trivial gap; bundle with sweep. |
+| `=\=/2` | ✅ | ✅ | ❌ | ❌ | Shipped with Elixir ISO compare sweep. |
 | `\+/1` (negation as failure) | ✅ | ✅ | ⚠️ | ⚠️ | |
 | `not/1` | ✅ | ✅ | ⚠️ | ⚠️ | Alias for `\+/1`. |
 | `findall/3` | ⚠️ | ✅ | ⚠️ | ⚠️ | Elixir has partial — needs gap-closing audit. |
 | `call/N` (meta-call) | ⚠️ | ✅ | ⚠️ | ⚠️ | Required by `catch/3`. |
-| `catch/3` | ❌ | ✅ | ❌ | ❌ | **Foundation for ISO error stack.** |
-| `throw/1` | ❌ | ✅ | ❌ | ❌ | |
+| `catch/3` | ✅ | ✅ | ❌ | ❌ | Foundation for ISO error stack. |
+| `throw/1` | ✅ | ✅ | ❌ | ❌ | |
 | `bagof/3`, `setof/3` | ❌ | ✅ | ❌ | ❌ | Out of initial scope. |
-| `succ/2` | ❌ | ✅ | ❌ | ❌ | |
+| `succ/2` | ✅ | ✅ | ❌ | ❌ | |
 | `between/3` | ❌ | ❌ | ❌ | ❌ | All targets missing. |
 | `format/1`, `format/2` | ✅ | ✅ | ✅ | ✅ | |
 
@@ -37,17 +42,17 @@ Survey columns: ✅ shipped · ⚠️ partial · ❌ missing.
 
 | Component | Elixir | C++ | Notes |
 |---|---|---|---|
-| `iso_errors_default_to_iso/2` table | ❌ | ✅ | 8 entries in C++. |
-| `iso_errors_default_to_lax/2` table | ❌ | ✅ | |
-| `iso_errors_resolve_options/2` config loader | ❌ | ✅ | |
-| `iso_errors_rewrite/4` per-pred dispatch | ❌ | ✅ | |
-| Audit predicate (`wam_*_iso_audit/3`) | ❌ | ✅ | |
-| Runtime: `make_type_error` / `make_*_error` | ❌ | ✅ | |
-| Runtime: `throw_iso_error` helper | ❌ | ✅ | Depends on `throw/1` runtime. |
-| `is_iso/2` + `is_lax/2` | ❌ | ✅ | First ISO-aware builtin. |
-| `succ_iso/2` + `succ_lax/2` | ❌ | ✅ | |
-| Iso/lax variants of arith compares | ❌ | ✅ | |
-| Lax IEEE-754 float divide (inf/nan) | ❌ | ✅ | Small breaking change vs current Elixir. |
+| `iso_errors_default_to_iso/2` table | ✅ | ✅ | 8 entries in both. |
+| `iso_errors_default_to_lax/2` table | ✅ | ✅ | |
+| `iso_errors_resolve_options/2` config loader | ✅ | ✅ | |
+| `iso_errors_rewrite/4` per-pred dispatch | ✅ | ✅ | Elixir also has text-path rewrite helpers. |
+| Audit predicate (`wam_*_iso_audit/3`) | ✅ | ✅ | |
+| Runtime: `make_type_error` / `make_*_error` | ✅ | ✅ | |
+| Runtime: `throw_iso_error` helper | ✅ | ✅ | Depends on `throw/1` runtime. |
+| `is_iso/2` + `is_lax/2` | ✅ | ✅ | First ISO-aware builtin. |
+| `succ_iso/2` + `succ_lax/2` | ✅ | ✅ | |
+| Iso/lax variants of arith compares | ✅ | ✅ | |
+| Lax IEEE-754 float divide (inf/nan) | ✅ | ✅ | Small breaking change vs original Elixir behavior. |
 
 ### 1.3 Meta-call and synthetic ops
 
@@ -85,7 +90,7 @@ required.
                                   ▼
                        [ISO errors plumbing]
                        (config loader, rewrite,
-                        audit, key tables empty)
+                        audit, key tables)
                                   │
                                   ├──────────────────────┐
                                   ▼                      ▼
@@ -109,9 +114,11 @@ as a tail call regardless of Goal's shape — including
 current meta-call is partial; the audit in PR #1 below
 determines whether it's enough.
 
-## 3. Per-PR phasing
+## 3. Original Per-PR Phasing
 
-Five PRs in the initial roadmap. Sized small for review.
+Five PRs were planned in the initial roadmap and sized small for review. The
+catch/throw and ISO-error portions have since landed; the remaining value of
+this section is historical context plus guidance for future target ports.
 
 ### PR #1 — `call/N` meta-call audit + completion
 

--- a/docs/design/WAM_ELIXIR_PARITY_PHILOSOPHY.md
+++ b/docs/design/WAM_ELIXIR_PARITY_PHILOSOPHY.md
@@ -35,34 +35,35 @@ Related Elixir-specific docs (different scope):
   internally for `:fail` propagation across choice-point retry
   (see `wam_elixir_target.pl:423-426`).
 
-What it lacks, vs the C++ reference:
+What remains incomplete, vs the C++ reference:
 
-- `catch/3` and `throw/1` — Prolog-level exception handling.
-- ISO error machinery: `is_iso/2` / `is_lax/2`, the iso/lax
-  variants of arithmetic compares, `succ_iso/2`, the per-predicate
-  rewrite hook, the config loader, the audit predicate.
 - A full meta-call surface: `call/N`, goal-term dispatch (`,/2`,
   `;/2`, `->/2` as data passed to `catch` / `findall`),
   `bagof/3`, `setof/3`.
 - Items API consumption — Elixir is one of 11 targets that still
   parses WAM text.
 
-The Rust and Haskell targets sit roughly where Elixir does on
-these axes. C++ pulled ahead through the recent ISO + meta-call
-PR series (#2079 → #2088 → #2106 → #2112). Closing the Elixir gap
-puts it level with C++ and ahead of Rust/Haskell on exception
-semantics.
+The original version of this doc listed `catch/3`, `throw/1`, and the ISO
+error machinery as missing. Those pieces have now landed: Elixir has the
+three-form ISO tables, config loader, per-predicate rewrite, audit predicate,
+`is_iso/2` / `is_lax/2`, arithmetic compare variants, and `succ_iso/2` /
+`succ_lax/2`. The remaining parity work is therefore more about meta-call
+completeness, aggregate builtins, and Items API migration than the ISO-error
+stack itself.
+
+The Rust and Haskell targets now sit behind C++ and Elixir on exception
+semantics. C++ was the first implementation; Elixir is the second adopter and
+proves the three-form ISO design generalizes beyond C++.
 
 ## 2. Why now, and why Elixir
 
 Three forces converging:
 
-- **The ISO error stack landed cleanly for C++.** That work
+- **The ISO error stack landed cleanly for C++ and then Elixir.** That work
   established a reusable shape — three-form keys (default / iso /
-  lax), per-predicate config-driven rewrite, audit predicate. The
-  next target to adopt this pattern proves it generalises and gives
-  the design a second consumer that informs whether anything in the
-  C++ shape was accidentally C++-specific.
+  lax), per-predicate config-driven rewrite, audit predicate. Elixir's adoption
+  proves it generalises and gives the design a second consumer that informs
+  whether anything in the C++ shape was accidentally C++-specific.
 - **Elixir is the natural second adopter.** Rust and Haskell
   haven't received recent feature investment; their generators are
   smaller and could fall further behind without surfacing pressure

--- a/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
+++ b/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
@@ -1,0 +1,128 @@
+# WAM ISO Errors - Cross-Target Status
+
+This note generalizes the C++ ISO-error design into the reusable target
+contract, and records how much of that contract has shipped so far.
+
+Companion docs:
+
+- `WAM_CPP_ISO_ERRORS_PHILOSOPHY.md` - why the three-form design was chosen.
+- `WAM_CPP_ISO_ERRORS_SPECIFICATION.md` - concrete C++ implementation shape.
+- `WAM_ELIXIR_GAPS_SPECIFICATION.md` - Elixir parity inventory.
+- `RUNTIME_PARSER_TRANSPILATION_PHILOSOPHY.md` - a separate cross-target
+  runtime-parser effort; related because both are target-runtime libraries, but
+  independent of ISO-error dispatch.
+
+## Shared Contract
+
+Targets that adopt ISO runtime errors should expose three callable forms for
+each audited builtin:
+
+| Form | Example | Meaning |
+|---|---|---|
+| Default | `is/2` | Rewritten by the generator according to the enclosing predicate's ISO mode. |
+| Explicit ISO | `is_iso/2` | Always throws structured ISO errors. |
+| Explicit lax | `is_lax/2` | Always preserves lax/fail-style behavior. |
+
+The generator resolves default call sites at compile time, per predicate. A
+runtime-wide `iso_errors` flag is intentionally avoided: it adds hot-path
+branches, makes per-predicate migration awkward, and makes explicit lax/ISO
+overrides harder to reason about.
+
+The shared config shape is a Prolog facts file:
+
+```prolog
+iso_errors_default(true).
+iso_errors_override(legacy_lookup/3, false).
+iso_errors_override(experimental:my_pred/2, true).
+```
+
+Inline options may override the file:
+
+```prolog
+write_wam_TARGET_project(Preds, [
+    iso_errors_config('config/iso_errors.pl'),
+    iso_errors(false),
+    iso_errors(my_pred/2, true)
+], Dir).
+```
+
+Bare `Name/Arity` overrides match predicates in any module. A
+`Module:Name/Arity` override is module-scoped. Targets should warn when a bare
+override matches multiple modules, because that is usually a migration
+footgun.
+
+## Current Implementation Status
+
+Survey columns: shipped means code and tests exist in the target today.
+
+| Component | C++ | Elixir | Other WAM targets |
+|---|---|---|---|
+| Prolog config loader (`iso_errors_config/1`, inline overrides) | shipped | shipped | not adopted |
+| Bare-PI multi-module warning | shipped | shipped | not adopted |
+| Per-predicate default rewrite | shipped | shipped | not adopted |
+| Text-path rewrite coverage (`builtin_call`, `put_structure`, `call`, `execute`) | shipped | shipped | target-specific |
+| Audit predicate and report | `wam_cpp_iso_audit/3` | `wam_elixir_iso_audit/3` | not adopted |
+| `catch/3` + `throw/1` substrate | shipped | shipped | mostly missing/partial |
+| Error constructors and `throw_iso_error` helper | shipped | shipped | not adopted |
+| `is_iso/2` / `is_lax/2` | shipped | shipped | not adopted |
+| ISO/lax arithmetic compares | shipped | shipped | not adopted |
+| `succ_iso/2` / `succ_lax/2` | shipped | shipped | not adopted |
+| Lax IEEE-754 float divide behavior | shipped | shipped | not adopted |
+
+The C++ and Elixir targets are therefore the current reference consumers. C++
+was the first implementation; Elixir proves the design is not C++-specific.
+Python, R, Lua, Haskell, Rust, and the remaining targets should not be described
+as ISO-error compatible until they adopt the same catch/throw substrate,
+three-form builtin keys, and per-predicate rewrite.
+
+## What Counts As Adoption
+
+A target should not claim this feature after adding only `is_iso/2`. The
+minimum useful adoption unit is:
+
+1. Runtime support for Prolog `catch/3` and `throw/1`.
+2. Constructors for `error(ErrorType, Context)` terms.
+3. The shared config shape, including inline overrides.
+4. Per-predicate rewriting of default builtin keys.
+5. Explicit `_iso` and `_lax` keys that survive mode flips.
+6. Tests showing ISO-mode default calls throw, lax-mode defaults fail or use
+   lax behavior, and explicit overrides bypass the rewrite.
+7. An audit predicate or equivalent report that shows reviewers what each call
+   site resolves to.
+
+The audit predicate name can remain target-specific until at least three
+targets need it. At that point, the shared pieces are good candidates for a
+common Prolog helper module:
+
+- config loading and merge precedence;
+- predicate-indicator matching and bare-PI warnings;
+- default/ISO/lax key tables;
+- audit record formatting.
+
+## Relationship To Runtime Parser Transpilation
+
+ISO errors and runtime parser transpilation solve different problems.
+
+ISO errors are about how existing runtime operations report malformed
+arguments. The key design choice is compile-time dispatch among default,
+explicit ISO, and explicit lax builtins.
+
+Runtime parser transpilation is about letting generated programs parse Prolog
+source text at runtime. The R target is the reference consumer because it has
+`read/2`, `read_term_from_atom/2,3`, reverse `term_to_atom/2`, and CLI term
+parsing. R currently keeps its native inline parser as the hot path, while the
+portable parser in `src/unifyweaver/core/prolog_term_parser.pl` acts as the
+cross-target semantic source and compile/runtime guard.
+
+The two efforts may meet when parser-dependent builtins need ISO-style error
+reporting, but neither depends on the other.
+
+## Remaining Work
+
+- Extract shared ISO config/audit helpers once a third target adopts the design.
+- Decide which target should be the next adopter based on real `catch/3` /
+  arithmetic-error users, not just target popularity.
+- Keep C++ and Elixir docs in sync with the shipped state; older parity plans
+  should be treated as history once their PR sequence has landed.
+- Expand the builtin table only after each builtin is audited for ISO term
+  shape, lax behavior, and happy-path cost.

--- a/docs/design/WAM_ITEMS_API_PHILOSOPHY.md
+++ b/docs/design/WAM_ITEMS_API_PHILOSOPHY.md
@@ -147,15 +147,15 @@ a one-line `swap_key_in_item/3` walk over a typed list. With text,
 each new shape is "what does the WAM printer write here? hope I
 didn't miss a case."
 
-PR #3 of the ISO sweep (arith compares + `succ_iso/2`) needs the
-same multi-shape rewrite for `>/2`, `</2`, `>=/2`, `=</2`,
-`=:=/2`, `=\=/2`, `succ/2`. That's seven more keys × four shapes
-= 28 rewrite rules to write defensively in text-land, vs 14 table
-entries in items-land.
+The later ISO sweep (arith compares + `succ_iso/2`) needed the same
+multi-shape rewrite for `>/2`, `</2`, `>=/2`, `=</2`, `=:=/2`, `=\=/2`,
+`succ/2`. That was seven more keys × four shapes = 28 rewrite rules to write
+defensively in text-land, vs 14 table entries in items-land.
 
-The items API isn't a prerequisite for shipping the ISO sweep, but
-**doing the items refactor first** would make the sweep half the
-size and its rewrite rules trivially auditable.
+The items API was not a prerequisite for shipping the ISO sweep; the C++ and
+Elixir sweeps landed against the text/items compatibility layer. The lesson
+still holds for future targets: doing the items refactor first makes
+per-key rewrites smaller and easier to audit.
 
 ## 5. Migration scope
 

--- a/docs/design/WAM_ITEMS_API_SPECIFICATION.md
+++ b/docs/design/WAM_ITEMS_API_SPECIFICATION.md
@@ -467,8 +467,7 @@ Why phase 1 alone before any target migration:
 - The items pipeline + text printer are the **load-bearing
   refactor**. Text round-trip tests prove it works.
 - Once landed, target migrations are independent and small. They
-  can stack with other PRs (e.g. resume the ISO sweep on the C++
-  target after Phase 2 PR #3 migrates wam_cpp_target).
+  can stack with other PRs that need structured instruction rewrites.
 - Each migration PR is small enough that bisecting any regression
   is trivial.
 
@@ -481,15 +480,13 @@ Why migrate small targets first:
   edge cases. Better to handle those after the pattern is proven
   on three or four lighter targets.
 
-## 9. ISO-sweep interaction
+## 9. ISO-Sweep Interaction
 
-PR #3 of the ISO sweep (arith compares + `succ_iso/2`) is on hold
-behind this refactor in the C++ target. After Phase 1 + Phase 2 PR
-for wam_cpp_target lands, the ISO sweep ships against the items
-API, with a single rewrite rule per ISO-aware key (instead of four
-shape-specific rules per key). Net: the ISO sweep gets ~70 LOC
-smaller.
+The C++ ISO sweep (arith compares + `succ_iso/2`) did not stay blocked on this
+refactor; it shipped against the existing text/items compatibility path. That
+means the C++ and Elixir ISO implementations still carry multi-shape rewrite
+logic for `builtin_call`, `put_structure`, `call`, and `execute`.
 
-If items-API migration takes too long, the ISO sweep can land
-against text-parsing as designed. Doc updated to reflect whichever
-order ships first.
+The interaction remains important for future target migrations. Once a target
+consumes structured WAM items directly, ISO rewrites become a single
+`swap_key_in_item/3`-style pass instead of several text-shape rules per key.


### PR DESCRIPTION
## Summary

- add a cross-target ISO error status/design note
- update C++ ISO error docs to describe the shipped implementation rather than pending work
- update Elixir parity docs to reflect the landed catch/throw and ISO error stack
- clarify runtime parser transpilation status for the shared capability hook, R, and Lua
- refresh Items API notes now that the C++/Elixir ISO sweeps landed against the existing compatibility path

## Validation

- `git diff --check`

## Notes

This is documentation-only. The new cross-target ISO note records C++ and Elixir as the current reference consumers and lists the minimum adoption bar for future targets.
