### PR TITLE
Feat/wam go succ builtin

### DIFF
--- a/PR_go_wam_succ_builtin.md
+++ b/PR_go_wam_succ_builtin.md
@@ -1,0 +1,24 @@
+# PR Title
+
+Add Go WAM succ builtin
+
+# PR Description
+
+## Summary
+
+- Adds generated Go WAM runtime support for bidirectional `succ/2`.
+- Registers `succ/2` as a direct Go WAM builtin so compiled calls emit `BuiltinCall` instructions.
+- Extends the generated Go builtin E2E test to cover forward binding, reverse binding, matching integer pairs, mismatch failure, negative predecessor failure, non-positive successor failure, and both-unbound failure.
+- Updates the Go WAM parity audit to record the expanded successor arithmetic surface against the sibling Clojure and Elixir baseline.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- direct emitter check for `succ/2`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -13,6 +13,7 @@ current cross-target builtin/runtime baseline.
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
 | Structural builtins | `member/2`, `memberchk/2`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
+| Arithmetic builtins | `is/2`, `succ/2` | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir | Present for current baseline arithmetic checks, with expanded successor coverage |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` | Includes `=</2`; Haskell mode analysis and Clojure lowering also cover term-order comparisons | Present for current baseline comparisons, with expanded term-order coverage |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
 | Term inspection | `functor/3`, `arg/3` | `functor/3`, `arg/3` | Present |
@@ -55,6 +56,10 @@ current cross-target builtin/runtime baseline.
   atom/integer ordering used by Go WAM sort and indexed-switch ordering,
   matching the Clojure term-order lowering surface and the Haskell mode
   analysis baseline.
+- Bidirectional `succ/2` is now covered by the generated Go WAM builtin E2E
+  test for forward binding, reverse binding, matching integer pairs, mismatch
+  failure, negative predecessor failure, non-positive successor failure, and
+  both-unbound failure, matching the sibling Clojure/Elixir successor surface.
 - Go WAM choice points now have explicit generated-runtime coverage for normal
   clause retries, indexed alternatives, foreign stream retries, indexed atom
   fact streams, and `member/2` builtin retries.

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -454,6 +454,9 @@ wam_go_direct_builtin("@>=/2", 2, '@>=/2').
 wam_go_direct_builtin(compare/3, 3, 'compare/3').
 wam_go_direct_builtin('compare/3', 3, 'compare/3').
 wam_go_direct_builtin("compare/3", 3, 'compare/3').
+wam_go_direct_builtin(succ/2, 2, 'succ/2').
+wam_go_direct_builtin('succ/2', 2, 'succ/2').
+wam_go_direct_builtin("succ/2", 2, 'succ/2').
 
 wam_instruction_to_go_literal(get_constant(C, Ai), GoLiteral) :-
     go_value_literal(C, GoVal),

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1035,6 +1035,32 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 		v1, ok1 := vm.evalArithmetic(arg1)
 		v2, ok2 := vm.evalArithmetic(arg2)
 		return ok1 && ok2 && v1 >= v2
+	case "succ/2":
+		a := vm.deref(arg1)
+		b := vm.deref(arg2)
+		aInt, aIsInt := a.(*Integer)
+		bInt, bIsInt := b.(*Integer)
+		aUnbound := isUnbound(a)
+		bUnbound := isUnbound(b)
+		if aUnbound && bUnbound {
+			return false
+		}
+		if !aUnbound && !aIsInt {
+			return false
+		}
+		if !bUnbound && !bIsInt {
+			return false
+		}
+		if aIsInt {
+			if aInt.Val < 0 {
+				return false
+			}
+			return vm.Unify(arg2, &Integer{Val: aInt.Val + 1})
+		}
+		if bIsInt && bInt.Val > 0 {
+			return vm.Unify(arg1, &Integer{Val: bInt.Val - 1})
+		}
+		return false
 
 	case "var/1": return isUnbound(vm.deref(arg1))
 	case "nonvar/1": return !isUnbound(vm.deref(arg1))

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -15,6 +15,7 @@
 :- dynamic user:test_numlist_builtin/0.
 :- dynamic user:test_sort_builtin/0.
 :- dynamic user:test_term_order_builtin/0.
+:- dynamic user:test_succ_builtin/0.
 :- dynamic user:test_set_aggregate/0.
 :- dynamic user:test_unify_builtin/0.
 :- dynamic user:test_neg_fact/1.
@@ -118,6 +119,17 @@ test(builtins_execution) :-
                 compare(=, foo, foo),
                 compare(>, 2, 1)
             )),
+          assertz(user:test_succ_builtin :-
+            (   succ(0, 1),
+                succ(2, X),
+                X =:= 3,
+                succ(Y, 4),
+                Y =:= 3,
+                \+ succ(1, 1),
+                \+ succ(-1, _),
+                \+ succ(_, 0),
+                \+ succ(_, _)
+            )),
           assertz(user:test_set_aggregate :-
             (   aggregate_all(set(X), member(X, [a,b,a]), S),
                 length(S, 2),
@@ -149,6 +161,7 @@ test(builtins_execution) :-
           retractall(user:test_numlist_builtin),
           retractall(user:test_sort_builtin),
           retractall(user:test_term_order_builtin),
+          retractall(user:test_succ_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
           retractall(user:test_neg_fact(_)),
@@ -158,7 +171,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -202,6 +215,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "@>/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "@>=/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "compare/3"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "succ/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "\\\\+/1"')),
     assertion(sub_string(LibCode, _, _, _, 'AggType: "set"')),
 
@@ -303,6 +317,14 @@ func main() {
 		fmt.Println("TERM_ORDER_FAILURE")
 	}
 
+	succVM := wam.NewWamState(wam.Test_succ_builtinCode, wam.Test_succ_builtinLabels)
+	succVM.PC = wam.Test_succ_builtinStartPC
+	if succVM.Run() {
+		fmt.Println("SUCC_SUCCESS")
+	} else {
+		fmt.Println("SUCC_FAILURE")
+	}
+
 	setVM := wam.NewWamState(wam.Test_set_aggregateCode, wam.Test_set_aggregateLabels)
 	setVM.PC = wam.Test_set_aggregateStartPC
 	if setVM.Run() {
@@ -362,6 +384,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "NUMLIST_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SORT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "TERM_ORDER_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "SUCC_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NEG_SUCCESS")),


### PR DESCRIPTION
# PR Add Go WAM succ builtin

## Summary

- Adds generated Go WAM runtime support for bidirectional `succ/2`.
- Registers `succ/2` as a direct Go WAM builtin so compiled calls emit `BuiltinCall` instructions.
- Extends the generated Go builtin E2E test to cover forward binding, reverse binding, matching integer pairs, mismatch failure, negative predecessor failure, non-positive successor failure, and both-unbound failure.
- Updates the Go WAM parity audit to record the expanded successor arithmetic surface against the sibling Clojure and Elixir baseline.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- direct emitter check for `succ/2`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`
