### PR TITLE
feat(wam-clojure): lower char_code/2

### DIFF
--- a/PR_WAM_CLOJURE_CHAR_CODE.md
+++ b/PR_WAM_CLOJURE_CHAR_CODE.md
@@ -1,0 +1,21 @@
+# feat(wam-clojure): lower char_code/2
+
+## Summary
+
+- Adds direct lowered Clojure WAM support for `char_code/2`.
+- Adds a runtime helper for bidirectional single-character atom/code conversion.
+- Wires `char_code/2` into the generated Clojure runtime builtin dispatcher.
+- Extends lowered-emitter and runtime smoke coverage for forward, reverse, mismatch, bad-character, and unbound-pair cases.
+
+## Notes
+
+- The helper accepts a bound one-character atom/string and unifies the code argument with its integer code point.
+- Reverse mode accepts a bound valid integer code point and interns/unifies the corresponding one-character atom.
+- Invalid character terms, invalid codes, and unbound/unbound mode fail conservatively.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -476,6 +476,10 @@ clojure_direct_builtin("number_chars/2", "2").
 clojure_direct_builtin("number_chars/2", 2).
 clojure_direct_builtin('number_chars/2', "2").
 clojure_direct_builtin('number_chars/2', 2).
+clojure_direct_builtin("char_code/2", "2").
+clojure_direct_builtin("char_code/2", 2).
+clojure_direct_builtin('char_code/2', "2").
+clojure_direct_builtin('char_code/2', 2).
 clojure_direct_builtin("atom_concat/3", "3").
 clojure_direct_builtin("atom_concat/3", 3).
 clojure_direct_builtin('atom_concat/3', "3").
@@ -838,6 +842,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     ),
     !,
     format(atom(Expr), '(runtime/apply-text-conversion-solution ~w "~w")', [S, Op]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "char_code/2" ; Op == 'char_code/2'),
+    !,
+    format(atom(Expr), '(runtime/apply-char-code-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (   Op == "atom_concat/3" ; Op == 'atom_concat/3'

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1041,6 +1041,38 @@
       :else
       (backtrack state))))
 
+(defn char-code-text [state value]
+  (let [text (atom-text state value)]
+    (when (and (string? text) (= 1 (count text)))
+      text)))
+
+(defn valid-char-code? [value]
+  (and (integer? value) (not (neg? value)) (<= value 65535)))
+
+(defn apply-char-code-solution [state]
+  (let [char-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        code-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A2") ::unbound))
+        char-text (char-code-text state char-value)
+        code (code-point-value state code-value)]
+    (cond
+      (some? char-text)
+      (let [[ok unified-state] (unify-values state code-value (int (first char-text)))]
+        (if ok
+          (advance unified-state)
+          (backtrack state)))
+
+      (valid-char-code? code)
+      (let [[next-state atom-term] (intern-text-atom state (str (char code)))
+            [ok unified-state] (unify-values next-state char-value atom-term)]
+        (if ok
+          (advance unified-state)
+          (backtrack state)))
+
+      :else
+      (backtrack state))))
+
 (defn apply-atom-concat-solution [state]
   (let [left (deref-value (:bindings state)
                           (or (reg-get-raw state "A1") ::unbound))
@@ -1957,6 +1989,9 @@
 
           "number_chars/2"
           (apply-text-conversion-solution state (:pred instr))
+
+          "char_code/2"
+          (apply-char-code-solution state)
 
           "atom_concat/3"
           (apply-atom-concat-solution state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -734,6 +734,15 @@ test(simple_builtin_string_chars_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_char_code_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_char_code/2:\nbuiltin_call char_code/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_char_code/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_char_code/2, WamCode, [], Code),
+        has(Code, "runtime/apply-char-code-solution"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_atom_concat_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_atom_concat/3:\nbuiltin_call atom_concat/3, 3\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -151,6 +151,10 @@
 :- dynamic user:wam_string_codes_reverse/0.
 :- dynamic user:wam_string_chars_guard/2.
 :- dynamic user:wam_string_chars_reverse/0.
+:- dynamic user:wam_char_code_guard/2.
+:- dynamic user:wam_char_code_reverse/0.
+:- dynamic user:wam_char_code_bad_char/0.
+:- dynamic user:wam_char_code_unbound_pair/1.
 :- dynamic user:wam_number_codes_guard/2.
 :- dynamic user:wam_number_codes_reverse/0.
 :- dynamic user:wam_number_chars_guard/2.
@@ -341,6 +345,10 @@ user:wam_string_codes_guard(A, C) :- string_codes(A, C).
 user:wam_string_codes_reverse :- string_codes(A, [102,111,111]), A = foo.
 user:wam_string_chars_guard(A, C) :- string_chars(A, C).
 user:wam_string_chars_reverse :- string_chars(A, [f,o,o]), A = foo.
+user:wam_char_code_guard(C, N) :- char_code(C, N).
+user:wam_char_code_reverse :- char_code(C, 65), C = 'A'.
+user:wam_char_code_bad_char :- char_code(ab, _).
+user:wam_char_code_unbound_pair(_) :- user:wam_unbound_arg(C), user:wam_unbound_arg(N), char_code(C, N).
 user:wam_number_codes_guard(N, C) :- number_codes(N, C).
 user:wam_number_codes_reverse :- number_codes(N, [52,50]), N =:= 42.
 user:wam_number_chars_guard(N, C) :- number_chars(N, C).
@@ -536,6 +544,10 @@ run_smoke :-
           user:wam_string_codes_reverse/0,
           user:wam_string_chars_guard/2,
           user:wam_string_chars_reverse/0,
+          user:wam_char_code_guard/2,
+          user:wam_char_code_reverse/0,
+          user:wam_char_code_bad_char/0,
+          user:wam_char_code_unbound_pair/1,
           user:wam_number_codes_guard/2,
           user:wam_number_codes_reverse/0,
           user:wam_number_chars_guard/2,
@@ -886,6 +898,11 @@ smoke_cases([
     case('wam_string_chars_guard/2', args(foo, '[f,o,o]'), "true"),
     case('wam_string_chars_guard/2', args(foo, '[f,o]'), "false"),
     case('wam_string_chars_reverse/0', no_args, "true"),
+    case('wam_char_code_guard/2', args(a, 97), "true"),
+    case('wam_char_code_guard/2', args(a, 98), "false"),
+    case('wam_char_code_reverse/0', no_args, "true"),
+    case('wam_char_code_bad_char/0', no_args, "false"),
+    case('wam_char_code_unbound_pair/1', a, "false"),
     case('wam_number_codes_guard/2', args(42, '[52,50]'), "true"),
     case('wam_number_codes_guard/2', args(42, '[52]'), "false"),
     case('wam_number_codes_reverse/0', no_args, "true"),
@@ -1245,6 +1262,7 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-atom-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-string-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-string-chars-guard-2"),
+    has(CoreCode, "defn lowered-wam-char-code-guard-2"),
     has(CoreCode, "defn lowered-wam-number-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-number-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-atom-concat-guard-3"),
@@ -1252,6 +1270,7 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-sub-atom-extract-0"),
     has(CoreCode, "runtime/ground-term?"),
     has(CoreCode, "runtime/apply-text-conversion-solution"),
+    has(CoreCode, "runtime/apply-char-code-solution"),
     has(CoreCode, "runtime/apply-atom-concat-solution"),
     has(CoreCode, "runtime/apply-atom-length-solution"),
     has(CoreCode, "runtime/apply-sub-atom-solution").


### PR DESCRIPTION
## Summary

- Adds direct lowered Clojure WAM support for `char_code/2`.
- Adds a runtime helper for bidirectional single-character atom/code conversion.
- Wires `char_code/2` into the generated Clojure runtime builtin dispatcher.
- Extends lowered-emitter and runtime smoke coverage for forward, reverse, mismatch, bad-character, and unbound-pair cases.

## Notes

- The helper accepts a bound one-character atom/string and unifies the code argument with its integer code point.
- Reverse mode accepts a bound valid integer code point and interns/unifies the corresponding one-character atom.
- Invalid character terms, invalid codes, and unbound/unbound mode fail conservatively.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
