### PR TITLE
feat(wam-clojure): lower atom_string/2

### DIFF
--- a/PR_WAM_CLOJURE_ATOM_STRING.md
+++ b/PR_WAM_CLOJURE_ATOM_STRING.md
@@ -1,0 +1,20 @@
+# feat(wam-clojure): lower atom_string/2
+
+## Summary
+
+- Adds direct lowered Clojure WAM support for `atom_string/2`.
+- Adds a runtime helper for bidirectional atom/text unification in the Clojure WAM scaffold.
+- Treats raw EDN strings and symbols as atom-like text in this helper path, matching the existing CLI smoke-test encoding.
+- Extends lowered-emitter and runtime smoke coverage for forward, reverse, mismatch, and unbound-pair cases.
+
+## Notes
+
+- The implementation follows the current Clojure WAM representation where atom-like text and strings are collapsed for generated runtime purposes.
+- `string_to_atom/2` is intentionally not enabled in this PR because it is not currently registered in the central WAM builtin table. The helper accepts a `string_to_atom/2` predicate key internally so that a later registry PR can wire it without changing the runtime semantics.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -460,6 +460,10 @@ clojure_direct_builtin("atom_chars/2", "2").
 clojure_direct_builtin("atom_chars/2", 2).
 clojure_direct_builtin('atom_chars/2', "2").
 clojure_direct_builtin('atom_chars/2', 2).
+clojure_direct_builtin("atom_string/2", "2").
+clojure_direct_builtin("atom_string/2", 2).
+clojure_direct_builtin('atom_string/2', "2").
+clojure_direct_builtin('atom_string/2', 2).
 clojure_direct_builtin("string_codes/2", "2").
 clojure_direct_builtin("string_codes/2", 2).
 clojure_direct_builtin('string_codes/2', "2").
@@ -842,6 +846,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     ),
     !,
     format(atom(Expr), '(runtime/apply-text-conversion-solution ~w "~w")', [S, Op]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "atom_string/2" ; Op == 'atom_string/2'),
+    !,
+    format(atom(Expr), '(runtime/apply-atom-string-solution ~w "~w")', [S, Op]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "char_code/2" ; Op == 'char_code/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -950,6 +950,7 @@
   (cond
     (atom-term? value) (deintern-atom (:intern-context state) (:id value))
     (string? value) value
+    (symbol? value) (name value)
     :else nil))
 
 (defn number-text [value]
@@ -1036,6 +1037,37 @@
             (if ok
               (advance unified-state)
               (backtrack state)))
+          (backtrack state)))
+
+      :else
+      (backtrack state))))
+
+(defn unify-text-atom-value [state value text]
+  (if (or (string? value) (symbol? value))
+    [(= (str value) text) state]
+    (let [[next-state out-term] (intern-text-atom state text)]
+      (unify-values next-state value out-term))))
+
+(defn apply-atom-string-solution [state pred]
+  (let [atom-reg (if (= pred "string_to_atom/2") "A2" "A1")
+        string-reg (if (= pred "string_to_atom/2") "A1" "A2")
+        atom-value (deref-value (:bindings state)
+                                (or (reg-get-raw state atom-reg) ::unbound))
+        string-value (deref-value (:bindings state)
+                                  (or (reg-get-raw state string-reg) ::unbound))
+        atom-text-value (atom-text state atom-value)
+        string-text-value (atom-text state string-value)]
+    (cond
+      (some? atom-text-value)
+      (let [[ok unified-state] (unify-text-atom-value state string-value atom-text-value)]
+        (if ok
+          (advance unified-state)
+          (backtrack state)))
+
+      (some? string-text-value)
+      (let [[ok unified-state] (unify-text-atom-value state atom-value string-text-value)]
+        (if ok
+          (advance unified-state)
           (backtrack state)))
 
       :else
@@ -1977,6 +2009,9 @@
 
           "atom_chars/2"
           (apply-text-conversion-solution state (:pred instr))
+
+          "atom_string/2"
+          (apply-atom-string-solution state (:pred instr))
 
           "string_codes/2"
           (apply-text-conversion-solution state (:pred instr))

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -704,6 +704,16 @@ test(simple_builtin_atom_codes_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_atom_string_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_atom_string/2:\nbuiltin_call atom_string/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_atom_string/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_atom_string/2, WamCode, [], Code),
+        has(Code, "runtime/apply-atom-string-solution"),
+        has(Code, "atom_string/2"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_number_chars_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_number_chars/2:\nbuiltin_call number_chars/2, 2\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -147,6 +147,9 @@
 :- dynamic user:wam_atom_codes_reverse/0.
 :- dynamic user:wam_atom_chars_guard/2.
 :- dynamic user:wam_atom_chars_reverse/0.
+:- dynamic user:wam_atom_string_guard/2.
+:- dynamic user:wam_atom_string_reverse/0.
+:- dynamic user:wam_atom_string_unbound_pair/1.
 :- dynamic user:wam_string_codes_guard/2.
 :- dynamic user:wam_string_codes_reverse/0.
 :- dynamic user:wam_string_chars_guard/2.
@@ -341,6 +344,9 @@ user:wam_atom_codes_guard(A, C) :- atom_codes(A, C).
 user:wam_atom_codes_reverse :- atom_codes(A, [102,111,111]), A = foo.
 user:wam_atom_chars_guard(A, C) :- atom_chars(A, C).
 user:wam_atom_chars_reverse :- atom_chars(A, [f,o,o]), A = foo.
+user:wam_atom_string_guard(A, S) :- atom_string(A, S).
+user:wam_atom_string_reverse :- atom_string(A, world), A = world.
+user:wam_atom_string_unbound_pair(_) :- user:wam_unbound_arg(A), user:wam_unbound_arg(S), atom_string(A, S).
 user:wam_string_codes_guard(A, C) :- string_codes(A, C).
 user:wam_string_codes_reverse :- string_codes(A, [102,111,111]), A = foo.
 user:wam_string_chars_guard(A, C) :- string_chars(A, C).
@@ -540,6 +546,9 @@ run_smoke :-
           user:wam_atom_codes_reverse/0,
           user:wam_atom_chars_guard/2,
           user:wam_atom_chars_reverse/0,
+          user:wam_atom_string_guard/2,
+          user:wam_atom_string_reverse/0,
+          user:wam_atom_string_unbound_pair/1,
           user:wam_string_codes_guard/2,
           user:wam_string_codes_reverse/0,
           user:wam_string_chars_guard/2,
@@ -892,6 +901,10 @@ smoke_cases([
     case('wam_atom_chars_guard/2', args(foo, '[f,o,o]'), "true"),
     case('wam_atom_chars_guard/2', args(foo, '[f,o]'), "false"),
     case('wam_atom_chars_reverse/0', no_args, "true"),
+    case('wam_atom_string_guard/2', args(hello, hello), "true"),
+    case('wam_atom_string_guard/2', args(hello, world), "false"),
+    case('wam_atom_string_reverse/0', no_args, "true"),
+    case('wam_atom_string_unbound_pair/1', a, "false"),
     case('wam_string_codes_guard/2', args(foo, '[102,111,111]'), "true"),
     case('wam_string_codes_guard/2', args(foo, '[102,111]'), "false"),
     case('wam_string_codes_reverse/0', no_args, "true"),
@@ -1260,6 +1273,7 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-ground-nested-unbound-1"),
     has(CoreCode, "defn lowered-wam-atom-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-atom-chars-guard-2"),
+    has(CoreCode, "defn lowered-wam-atom-string-guard-2"),
     has(CoreCode, "defn lowered-wam-string-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-string-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-char-code-guard-2"),
@@ -1270,6 +1284,7 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-sub-atom-extract-0"),
     has(CoreCode, "runtime/ground-term?"),
     has(CoreCode, "runtime/apply-text-conversion-solution"),
+    has(CoreCode, "runtime/apply-atom-string-solution"),
     has(CoreCode, "runtime/apply-char-code-solution"),
     has(CoreCode, "runtime/apply-atom-concat-solution"),
     has(CoreCode, "runtime/apply-atom-length-solution"),


### PR DESCRIPTION
## Summary

- Adds direct lowered Clojure WAM support for `atom_string/2`.
- Adds a runtime helper for bidirectional atom/text unification in the Clojure WAM scaffold.
- Treats raw EDN strings and symbols as atom-like text in this helper path, matching the existing CLI smoke-test encoding.
- Extends lowered-emitter and runtime smoke coverage for forward, reverse, mismatch, and unbound-pair cases.

## Notes

- The implementation follows the current Clojure WAM representation where atom-like text and strings are collapsed for generated runtime purposes.
- `string_to_atom/2` is intentionally not enabled in this PR because it is not currently registered in the central WAM builtin table. The helper accepts a `string_to_atom/2` predicate key internally so that a later registry PR can wire it without changing the runtime semantics.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
