### PR TITLE
feat(wam-python): add catch throw runtime support

### DIFF
--- a/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
+++ b/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
@@ -62,7 +62,7 @@ Survey columns: shipped means code and tests exist in the target today.
 | Per-predicate default rewrite | shipped | shipped | not adopted |
 | Text-path rewrite coverage (`builtin_call`, `put_structure`, `call`, `execute`) | shipped | shipped | target-specific |
 | Audit predicate and report | `wam_cpp_iso_audit/3` | `wam_elixir_iso_audit/3` | not adopted |
-| `catch/3` + `throw/1` substrate | shipped | shipped | mostly missing/partial |
+| `catch/3` + `throw/1` substrate | shipped | shipped | Python shipped; others mostly missing/partial |
 | Error constructors and `throw_iso_error` helper | shipped | shipped | not adopted |
 | `is_iso/2` / `is_lax/2` | shipped | shipped | not adopted |
 | ISO/lax arithmetic compares | shipped | shipped | not adopted |
@@ -71,9 +71,10 @@ Survey columns: shipped means code and tests exist in the target today.
 
 The C++ and Elixir targets are therefore the current reference consumers. C++
 was the first implementation; Elixir proves the design is not C++-specific.
-Python, R, Lua, Haskell, Rust, and the remaining targets should not be described
-as ISO-error compatible until they adopt the same catch/throw substrate,
-three-form builtin keys, and per-predicate rewrite.
+Python has now adopted the catch/throw substrate, but it should not be described
+as ISO-error compatible until it also adopts error constructors, three-form
+builtin keys, and per-predicate rewrite. R, Lua, Haskell, Rust, and the
+remaining targets are still mostly missing or partial on this stack.
 
 ## What Counts As Adoption
 

--- a/docs/design/WAM_PYTHON_PARITY_AUDIT.md
+++ b/docs/design/WAM_PYTHON_PARITY_AUDIT.md
@@ -29,18 +29,19 @@ matters for parity.
 
 ## ISO Error Readiness
 
-Python is **not yet an ISO-error adopter**. It has the arithmetic and
-comparison builtin surface that would eventually receive `_iso` and `_lax`
-forms, but it is missing the exception substrate and generator plumbing that
-the C++ and Elixir targets use.
+Python is **not yet an ISO-error adopter**. It now has the Prolog-level
+`catch/3` and `throw/1` substrate plus the arithmetic and comparison builtin
+surface that would eventually receive `_iso` and `_lax` forms. It is still
+missing the ISO-specific error constructors, config/rewrite/audit plumbing, and
+ISO/lax builtin variants that the C++ and Elixir targets use.
 
 Current state:
 
 | Component | Python status | Notes |
 | --- | --- | --- |
-| Prolog `catch/3` / `throw/1` | Missing | No side-stack catcher frames or user-level throw unwinding in the packaged runtime. |
+| Prolog `catch/3` / `throw/1` | Present | Packaged runtime has side-stack catcher frames and generated-project E2E coverage. |
 | ISO error constructors | Missing | No runtime builders for `error(type_error(...), _)`, `error(instantiation_error, _)`, etc. |
-| `throw_iso_error` helper | Missing | Depends on `catch/3` / `throw/1` first. |
+| `throw_iso_error` helper | Missing | Now unblocked by `catch/3` / `throw/1`. |
 | `is_iso/2` / `is_lax/2` | Missing | Existing `is/2` catches `WAMError` and fails silently. |
 | ISO/lax arithmetic compares | Missing | Existing compares catch `WAMError` and fail silently. |
 | `succ/2` and ISO/lax variants | Missing | `succ/2` is not part of the current Python builtin baseline. |
@@ -67,25 +68,23 @@ instead of throwing a structured Prolog error. That is a good starting point for
 
 ## Recommended ISO Port Sequence
 
-Porting `is_iso/2` first would be premature because Python currently has
-nowhere for a structured ISO error to go. The safer sequence is:
+Porting `is_iso/2` first was premature before `catch/3` / `throw/1` existed.
+That substrate is now present, so the remaining sequence is:
 
-1. Add Prolog-level `catch/3` and `throw/1` to the packaged runtime, mirroring
-   the C++/Elixir side-stack design.
-2. Add `error/2` constructors plus `make_type_error`,
+1. Add `error/2` constructors plus `make_type_error`,
    `make_instantiation_error`, `make_domain_error`, and
    `make_evaluation_error`.
-3. Add `throw_iso_error` and prove `catch(Goal, error(Pattern, _), Recovery)`
+2. Add `throw_iso_error` and prove `catch(Goal, error(Pattern, _), Recovery)`
    matches the constructed terms.
-4. Add shared-shape ISO config loading, per-predicate rewrite, and
+3. Add shared-shape ISO config loading, per-predicate rewrite, and
    `wam_python_iso_audit/3`.
-5. Add `is_iso/2` / `is_lax/2`, with explicit-lax bypass tests.
-6. Sweep arithmetic comparisons and add `succ/2` / `succ_iso/2` /
+4. Add `is_iso/2` / `is_lax/2`, with explicit-lax bypass tests.
+5. Sweep arithmetic comparisons and add `succ/2` / `succ_iso/2` /
    `succ_lax/2`.
 
-The first PR should therefore be a catch/throw runtime PR, not an arithmetic
-PR. Once that substrate exists, the C++ and Elixir ISO tests provide a direct
-template for Python E2E coverage.
+The next PR should therefore be an ISO error-constructor and `throw_iso_error`
+PR, not an arithmetic PR. The C++ and Elixir ISO tests provide a direct template
+for Python E2E coverage.
 
 ## Runtime Source Of Truth
 

--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -84,6 +84,15 @@ class Environment:
     perm_vars: List        # Y registers
 
 
+@dataclass
+class CatcherFrame:
+    """Side-stack frame for Prolog catch/3."""
+    catcher_term: Term
+    recovery_term: Term
+    saved_cp: Any
+    snapshot: Any
+
+
 class WamState:
     def __init__(self):
         self.regs: List = [None] * 512   # A1->1, X1->101, Y1->201 (1-indexed, same as all targets)
@@ -109,6 +118,9 @@ class WamState:
         self.indexed_atom_fact2: Dict[str, Dict[str, List[str]]] = {}
         # indexed_weighted_edge: pred_key -> { key_atom -> [(value_atom, weight), ...] }
         self.indexed_weighted_edge: Dict[str, Dict[str, List[Tuple[str, float]]]] = {}
+        # Side stack for Prolog catch/3 frames. Python exceptions provide the
+        # unwind mechanism; these frames carry WAM-level state snapshots.
+        self.catcher_frames: List[CatcherFrame] = []
 
     def fresh_var(self) -> Var:
         v = Var(ref=[None], id=self._var_counter)
@@ -476,6 +488,13 @@ def eval_arith(term: Term, state: WamState):
             return ops[fn](*args)
     raise WAMError(f"Cannot evaluate: {term}")
 
+class WAMThrow(Exception):
+    """Internal carrier for Prolog throw/1 terms."""
+    def __init__(self, term: Term):
+        super().__init__("Prolog throw/1")
+        self.term = term
+
+
 class WAMError(Exception):
     pass
 
@@ -735,8 +754,73 @@ def _goal_succeeds_once(goal: 'Term', state: WamState) -> bool:
     return False
 
 
+def _restore_state_from_snapshot(state: WamState, snapshot: WamState) -> None:
+    """Restore a WamState object in place from a catch/3 snapshot."""
+    state.__dict__.clear()
+    state.__dict__.update(snapshot.__dict__)
+
+
+def _execute_goal_in_state(goal: 'Term', state: WamState) -> bool:
+    """Execute a callable Prolog goal term against the current WAM state."""
+    goal = deref(goal, state)
+    if isinstance(goal, Atom):
+        return _execute_builtin(goal.name, 0, state)
+    if not isinstance(goal, Compound):
+        return False
+    functor = goal.functor
+    arity = len(goal.args)
+    pred_key = functor if '/' in functor else f"{functor}/{arity}"
+    for i, arg in enumerate(goal.args, start=1):
+        set_reg(state, i, deref(arg, state))
+    if _execute_builtin(pred_key, arity, state):
+        return True
+    code = getattr(state, '_code', None)
+    labels = getattr(state, '_labels', None)
+    if code is not None and labels is not None and pred_key in labels:
+        return run_wam(code, labels, pred_key, state)
+    return False
+
+
+def _execute_catch(state: WamState) -> bool:
+    """Execute catch(Goal, Catcher, Recovery)."""
+    goal = deref(get_reg(state, 1), state)
+    snapshot = copy.deepcopy(state)
+    frame = CatcherFrame(
+        catcher_term=deref(get_reg(snapshot, 2), snapshot),
+        recovery_term=deref(get_reg(snapshot, 3), snapshot),
+        saved_cp=snapshot.cp,
+        snapshot=snapshot,
+    )
+    state.catcher_frames.append(frame)
+    try:
+        ok = _execute_goal_in_state(goal, state)
+        if state.catcher_frames and state.catcher_frames[-1] is frame:
+            state.catcher_frames.pop()
+        return ok
+    except WAMThrow as thrown:
+        if state.catcher_frames and state.catcher_frames[-1] is frame:
+            state.catcher_frames.pop()
+        _restore_state_from_snapshot(state, frame.snapshot)
+        if unify(frame.catcher_term, thrown.term, state):
+            return _execute_goal_in_state(frame.recovery_term, state)
+        raise
+
+
+def _execute_throw(state: WamState) -> bool:
+    """Execute throw(Term), unwinding to the nearest active catch/3."""
+    thrown = _deep_copy_term(get_reg(state, 1), {}, state)
+    if not state.catcher_frames:
+        print(f"Uncaught Prolog throw: {_format_value(thrown, state)}", file=__import__('sys').stderr)
+        return False
+    raise WAMThrow(thrown)
+
+
 def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int = -1) -> bool:
     """Execute a WAM builtin_call instruction."""
+    if builtin in ('catch/3', 'catch') and arity == 3:
+        return _execute_catch(state)
+    if builtin in ('throw/1', 'throw') and arity == 1:
+        return _execute_throw(state)
     if builtin == '!/0' or builtin == '!':  # cut
         state.cut_b = state.b
         return True
@@ -1240,6 +1324,20 @@ def run_wam(code: list, labels: dict, entry: str, state: WamState) -> bool:
 
         elif op == 'call_pc':
             _, target_ip, _arity, _label = instr
+            if _label == 'catch/3':
+                state.cp = ip
+                if not _execute_catch(state):
+                    if not fail(): return False
+                    continue
+                arg_snapshot = list(state.regs)
+                continue
+            if _label == 'throw/1':
+                state.cp = ip
+                if not _execute_throw(state):
+                    if not fail(): return False
+                    continue
+                arg_snapshot = list(state.regs)
+                continue
             state.cp = ip   # save continuation (current ip = next instr)
             if target_ip >= 0:
                 ip = target_ip
@@ -1250,6 +1348,18 @@ def run_wam(code: list, labels: dict, entry: str, state: WamState) -> bool:
 
         elif op == 'execute_pc':
             _, target_ip, _label = instr
+            if _label == 'catch/3':
+                if not _execute_catch(state):
+                    if not fail(): return False
+                    continue
+                arg_snapshot = list(state.regs)
+                continue
+            if _label == 'throw/1':
+                if not _execute_throw(state):
+                    if not fail(): return False
+                    continue
+                arg_snapshot = list(state.regs)
+                continue
             if target_ip >= 0:
                 ip = target_ip
                 arg_snapshot = list(state.regs)  # snapshot at callee entry
@@ -1260,6 +1370,20 @@ def run_wam(code: list, labels: dict, entry: str, state: WamState) -> bool:
         elif op == 'call':
             # Legacy unresolved call (fallback)
             _, label, _arity = instr
+            if label == 'catch/3':
+                state.cp = ip
+                if not _execute_catch(state):
+                    if not fail(): return False
+                    continue
+                arg_snapshot = list(state.regs)
+                continue
+            if label == 'throw/1':
+                state.cp = ip
+                if not _execute_throw(state):
+                    if not fail(): return False
+                    continue
+                arg_snapshot = list(state.regs)
+                continue
             state.cp = ip
             target = labels.get(label, -1)
             if target >= 0:
@@ -1272,6 +1396,18 @@ def run_wam(code: list, labels: dict, entry: str, state: WamState) -> bool:
         elif op == 'execute':
             # Legacy unresolved execute (fallback)
             _, label = instr
+            if label == 'catch/3':
+                if not _execute_catch(state):
+                    if not fail(): return False
+                    continue
+                arg_snapshot = list(state.regs)
+                continue
+            if label == 'throw/1':
+                if not _execute_throw(state):
+                    if not fail(): return False
+                    continue
+                arg_snapshot = list(state.regs)
+                continue
             target = labels.get(label, -1)
             if target >= 0:
                 ip = target

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -888,16 +888,36 @@ test(generated_project_enumerates_member_builtin) :-
 		),
 		cleanup_tmp_dir(ProjectDir)).
 
+test(generated_project_runs_catch_throw_builtins) :-
+	setup_call_cleanup(
+		unique_tmp_dir('tmp_wam_python_builtin_e2e', ProjectDir),
+		(   write_builtin_project(ProjectDir),
+			run_generated_query(ProjectDir, 'catch_match_demo/0', MatchOutput),
+			once(sub_string(MatchOutput, _, _, _, "caught")),
+			run_generated_query(ProjectDir, 'catch_compound_demo/0', CompoundOutput),
+			once(sub_string(CompoundOutput, _, _, _, "type_error")),
+			run_generated_query(ProjectDir, 'catch_no_throw_demo/0', NoThrowOutput),
+			once(sub_string(NoThrowOutput, _, _, _, "ok")),
+			\+ sub_string(NoThrowOutput, _, _, _, "bad")
+		),
+		cleanup_tmp_dir(ProjectDir)).
+
 write_builtin_project(ProjectDir) :-
 	term_builtin_wam(TermWam),
 	copy_naf_io_wam(CopyNafIoWam),
 	type_compare_wam(TypeCompareWam),
 	member_collect_wam(MemberCollectWam),
+	catch_match_wam(CatchMatchWam),
+	catch_compound_wam(CatchCompoundWam),
+	catch_no_throw_wam(CatchNoThrowWam),
 	wam_python_target:write_wam_python_project(
 		[term_demo/0-TermWam,
 		 copy_naf_io_demo/0-CopyNafIoWam,
 		 type_compare_demo/0-TypeCompareWam,
-		 member_collect_demo/0-MemberCollectWam],
+		 member_collect_demo/0-MemberCollectWam,
+		 catch_match_demo/0-CatchMatchWam,
+		 catch_compound_demo/0-CatchCompoundWam,
+		 catch_no_throw_demo/0-CatchNoThrowWam],
 		[],
 		ProjectDir).
 
@@ -978,6 +998,44 @@ member_collect_wam(
   builtin_call member/2 2
   end_aggregate 1
   proceed').
+
+catch_match_wam(
+'catch_match_demo/0:
+  allocate
+  put_structure throw/1, 1
+  set_constant foo
+  put_constant foo, 2
+  put_structure write/1, 3
+  set_constant caught
+  deallocate
+  execute catch/3').
+
+catch_compound_wam(
+'catch_compound_demo/0:
+  allocate
+  put_structure error/2, 4
+  set_constant type_error
+  set_constant ctx
+  put_structure throw/1, 1
+  set_value 4
+  put_structure error/2, 2
+  set_variable 104
+  set_variable 105
+  put_structure write/1, 3
+  set_value 104
+  deallocate
+  execute catch/3').
+
+catch_no_throw_wam(
+'catch_no_throw_demo/0:
+  allocate
+  put_structure write/1, 1
+  set_constant ok
+  put_constant foo, 2
+  put_structure write/1, 3
+  set_constant bad
+  deallocate
+  execute catch/3').
 
 run_generated_query(ProjectDir, Query, Output) :-
 	process_create(path(python), ['main.py', Query],


### PR DESCRIPTION
## Summary

- add Prolog-level `catch/3` and `throw/1` support to the packaged Python WAM runtime
- implement side-stack catcher frames with Python exception unwinding for thrown Prolog terms
- dispatch `catch/3` and `throw/1` through builtin, `call`, and `execute` paths
- add generated-project E2E coverage for matching catch, compound catcher binding, and no-throw behavior
- update Python and cross-target ISO docs to mark Python's catch/throw substrate as present while keeping ISO-error compatibility as a follow-up

## Validation

- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_python_target.pl`

## Notes

This is the first Python prerequisite for the cross-target ISO-error stack. Python still needs ISO error constructors, `throw_iso_error`, config/rewrite/audit plumbing, and ISO/lax builtin variants before it should be marked ISO-error compatible.
