### PR TITLE
feat(wam-cpp): assoc library as a stdlib feature

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -552,6 +552,58 @@ static const int _wam_cpp_setup_register = []() {
            ;  throw(error(assertion_failed, G))
            )))
    ).
+% assoc/2 stdlib: unbalanced BST keyed by standard order. The empty
+% tree is the atom `t`; non-empty nodes are t(Key, Value, Left, Right).
+% Unbalanced keeps the asserted source tiny; can be upgraded to AVL
+% in a follow-up. Re-uses compare/3 (already in the runtime) for
+% standard-order key comparison.
+:- (   current_predicate(user:put_assoc/4)
+   ->  true
+   ;   assertz((user:empty_assoc(t))),
+       assertz((user:get_assoc(Key, t(K, V, L, R), Value) :-
+           compare(Order, Key, K),
+           wam_cpp_get_assoc_(Order, Key, V, L, R, Value))),
+       assertz((user:wam_cpp_get_assoc_(=, _, Value, _, _, Value))),
+       assertz((user:wam_cpp_get_assoc_(<, Key, _, L, _, Value) :-
+           get_assoc(Key, L, Value))),
+       assertz((user:wam_cpp_get_assoc_(>, Key, _, _, R, Value) :-
+           get_assoc(Key, R, Value))),
+       assertz((user:put_assoc(Key, t, Val, t(Key, Val, t, t)) :- !)),
+       assertz((user:put_assoc(Key, t(K, V, L, R), Val, NewTree) :-
+           compare(Order, Key, K),
+           wam_cpp_put_assoc_(Order, Key, K, V, L, R, Val, NewTree))),
+       assertz((user:wam_cpp_put_assoc_(=, Key, _, _, L, R, Val,
+                                       t(Key, Val, L, R)))),
+       assertz((user:wam_cpp_put_assoc_(<, Key, K, V, L, R, Val,
+                                       t(K, V, NewL, R)) :-
+           put_assoc(Key, L, Val, NewL))),
+       assertz((user:wam_cpp_put_assoc_(>, Key, K, V, L, R, Val,
+                                       t(K, V, L, NewR)) :-
+           put_assoc(Key, R, Val, NewR))),
+       assertz((user:list_to_assoc(List, Assoc) :-
+           wam_cpp_list_to_assoc_(List, t, Assoc))),
+       assertz((user:wam_cpp_list_to_assoc_([], A, A))),
+       assertz((user:wam_cpp_list_to_assoc_([K-V|T], A0, A) :-
+           put_assoc(K, A0, V, A1),
+           wam_cpp_list_to_assoc_(T, A1, A))),
+       assertz((user:assoc_to_list(t, []))),
+       assertz((user:assoc_to_list(t(K, V, L, R), Pairs) :-
+           assoc_to_list(L, LP),
+           assoc_to_list(R, RP),
+           append(LP, [K-V|RP], Pairs))),
+       assertz((user:assoc_to_keys(Assoc, Keys) :-
+           assoc_to_list(Assoc, Pairs),
+           wam_cpp_pairs_keys(Pairs, Keys))),
+       assertz((user:assoc_to_values(Assoc, Values) :-
+           assoc_to_list(Assoc, Pairs),
+           wam_cpp_pairs_values(Pairs, Values))),
+       assertz((user:wam_cpp_pairs_keys([], []))),
+       assertz((user:wam_cpp_pairs_keys([K-_|T], [K|KT]) :-
+           wam_cpp_pairs_keys(T, KT))),
+       assertz((user:wam_cpp_pairs_values([], []))),
+       assertz((user:wam_cpp_pairs_values([_-V|T], [V|VT]) :-
+           wam_cpp_pairs_values(T, VT)))
+   ).
 
 %% stdlib_feature_predicates(+Feature, -Predicates)
 %  Registry mapping a stdlib feature name to its predicate
@@ -568,11 +620,25 @@ stdlib_feature_predicates(predsort, [
 stdlib_feature_predicates(assertion, [
     user:assertion/1
 ]).
+stdlib_feature_predicates(assoc, [
+    user:empty_assoc/1,
+    user:get_assoc/3,
+    user:wam_cpp_get_assoc_/6,
+    user:put_assoc/4,
+    user:wam_cpp_put_assoc_/8,
+    user:list_to_assoc/2,
+    user:wam_cpp_list_to_assoc_/3,
+    user:assoc_to_list/2,
+    user:assoc_to_keys/2,
+    user:assoc_to_values/2,
+    user:wam_cpp_pairs_keys/2,
+    user:wam_cpp_pairs_values/2
+]).
 
 %% all_stdlib_features(-Features)
 %  List of every known stdlib feature, in a stable order. Used when
 %  the caller passes include_stdlib(true).
-all_stdlib_features([predsort, assertion]).
+all_stdlib_features([predsort, assertion, assoc]).
 
 % is/2 — first ISO-aware builtin. ISO-mode predicates get their
 % default is/2 calls rewritten to is_iso/2 (which throws on bad

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -230,6 +230,14 @@
 :- dynamic user:wam_cpp_test_assertion_ok/0.
 :- dynamic user:wam_cpp_test_assertion_fail/0.
 :- dynamic user:wam_cpp_test_assertion_expr/0.
+:- dynamic user:wam_cpp_test_assoc_empty/0.
+:- dynamic user:wam_cpp_test_assoc_put_get/0.
+:- dynamic user:wam_cpp_test_assoc_missing/0.
+:- dynamic user:wam_cpp_test_assoc_overwrite/0.
+:- dynamic user:wam_cpp_test_assoc_list_sorted/0.
+:- dynamic user:wam_cpp_test_assoc_keys/0.
+:- dynamic user:wam_cpp_test_assoc_values/0.
+:- dynamic user:wam_cpp_test_assoc_compound_keys/0.
 :- dynamic user:wam_cpp_test_enum_member/0.
 
 user:wam_cpp_test_member_yes   :- member(b, [a, b, c]).
@@ -439,6 +447,39 @@ user:wam_cpp_test_assertion_expr    :-
     catch(assertion(1 =:= 2),
           error(assertion_failed, _),
           true).
+% assoc library (BST keyed by standard order, asserted as user-module
+% Prolog and exposed via the stdlib `assoc` feature):
+user:wam_cpp_test_assoc_empty         :- empty_assoc(t).
+user:wam_cpp_test_assoc_put_get       :-
+    empty_assoc(A0),
+    put_assoc(name, A0, alice, A1),
+    put_assoc(age, A1, 30, A2),
+    get_assoc(name, A2, alice),
+    get_assoc(age, A2, 30).
+user:wam_cpp_test_assoc_missing       :-
+    empty_assoc(A0),
+    put_assoc(x, A0, 1, A1),
+    \+ get_assoc(missing, A1, _).
+user:wam_cpp_test_assoc_overwrite     :-
+    empty_assoc(A0),
+    put_assoc(k, A0, 1, A1),
+    put_assoc(k, A1, 2, A2),
+    get_assoc(k, A2, 2).
+user:wam_cpp_test_assoc_list_sorted   :-
+    list_to_assoc([c-3, a-1, b-2], A),
+    assoc_to_list(A, [a-1, b-2, c-3]).
+user:wam_cpp_test_assoc_keys          :-
+    list_to_assoc([c-3, a-1, b-2], A),
+    assoc_to_keys(A, [a, b, c]).
+user:wam_cpp_test_assoc_values        :-
+    list_to_assoc([c-3, a-1, b-2], A),
+    assoc_to_values(A, [1, 2, 3]).
+user:wam_cpp_test_assoc_compound_keys :-
+    empty_assoc(A0),
+    put_assoc(pt(1, 2), A0, north, A1),
+    put_assoc(pt(3, 4), A1, south, A2),
+    get_assoc(pt(1, 2), A2, north),
+    get_assoc(pt(3, 4), A2, south).
 user:wam_cpp_test_enum_member  :- findall(X, member(X, [a, b, c]), L),
                                   L = [a, b, c].
 
@@ -3348,6 +3389,40 @@ test(cpp_e2e_stdlib_autoinclude_and_assertion,
           run_query(BinPath, 'wam_cpp_test_assertion_ok/0',   [], true),
           run_query(BinPath, 'wam_cpp_test_assertion_fail/0', [], true),
           run_query(BinPath, 'wam_cpp_test_assertion_expr/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_assoc_library, [condition(cpp_compiler_available)]) :-
+    % assoc library: empty_assoc/1, put_assoc/4, get_assoc/3,
+    % list_to_assoc/2, assoc_to_list/2, assoc_to_keys/2,
+    % assoc_to_values/2. Backing rep is an unbalanced BST keyed by
+    % standard order (compare/3). All clauses + helpers asserted in
+    % the user module at wam_cpp_target.pl load time; pulled in by
+    % include_stdlib(assoc). Tests cover empty + insert + lookup +
+    % missing-key fail + overwrite + list round-trip (which
+    % implicitly checks sorted in-order traversal) + compound keys.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_assoc', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_assoc_empty/0,
+                               user:wam_cpp_test_assoc_put_get/0,
+                               user:wam_cpp_test_assoc_missing/0,
+                               user:wam_cpp_test_assoc_overwrite/0,
+                               user:wam_cpp_test_assoc_list_sorted/0,
+                               user:wam_cpp_test_assoc_keys/0,
+                               user:wam_cpp_test_assoc_values/0,
+                               user:wam_cpp_test_assoc_compound_keys/0],
+                              [emit_main(true), include_stdlib(assoc)],
+                              TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_assoc_empty/0',         [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_put_get/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_missing/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_overwrite/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_list_sorted/0',   [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_keys/0',          [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_values/0',        [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_compound_keys/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Adds the SWI `library(assoc)` surface as ordinary user-module Prolog clauses asserted at module-load time, registered as a stdlib feature so callers can pull it in via `include_stdlib(assoc)` or `include_stdlib(true)`.

### Backing representation

Unbalanced BST keyed by standard order. Empty tree is the atom `t`; non-empty nodes are `t(Key, Value, Left, Right)`. Keeps the asserted source tiny and uses `compare/3` (already in the runtime). Worst-case `O(N)` per op on degenerate insert order; can be upgraded to AVL in a follow-up if perf matters.

### Predicates

| Name | Shape |
|---|---|
| `empty_assoc/1` | `empty_assoc(-Assoc)` |
| `put_assoc/4` | `put_assoc(+Key, +Assoc0, +Value, -Assoc)` |
| `get_assoc/3` | `get_assoc(+Key, +Assoc, -Value)` (fails on miss) |
| `list_to_assoc/2` | `list_to_assoc(+Pairs, -Assoc)` (Pairs are `Key-Value`) |
| `assoc_to_list/2` | `assoc_to_list(+Assoc, -Pairs)` (in-order ⇒ sorted) |
| `assoc_to_keys/2` | `assoc_to_keys(+Assoc, -Keys)` |
| `assoc_to_values/2` | `assoc_to_values(+Assoc, -Values)` |

Internal helpers (`wam_cpp_get_assoc_/6`, `wam_cpp_put_assoc_/8`, `wam_cpp_list_to_assoc_/3`, `wam_cpp_pairs_keys/2`, `wam_cpp_pairs_values/2`) are auto-included by the stdlib_feature registry so callers don't have to spell them out.

### Usage

```prolog
?- empty_assoc(A0), put_assoc(name, A0, alice, A1), put_assoc(age, A1, 30, A),
   get_assoc(age, A, V).
V = 30.

?- list_to_assoc([c-3, a-1, b-2], A), assoc_to_list(A, Pairs).
Pairs = [a-1, b-2, c-3].
```

```prolog
write_wam_cpp_project(MyPreds, [emit_main(true), include_stdlib(assoc)], Dir).
```

### Tests

One new `cpp_e2e_assoc_library` bundle with **8 cases**:

- Empty tree (`empty_assoc/1` ↔ atom `t`).
- Insert + lookup pair (with two different keys).
- Missing key fails.
- Overwrite (second `put_assoc` on the same key wins).
- List round-trip (`list_to_assoc` then `assoc_to_list` returns sorted pairs even when input was unsorted — implicit sorted-traversal check).
- Keys projection and values projection.
- Compound keys: `pt(1, 2)` → north, `pt(3, 4)` → south.

Full `test_wam_cpp_generator` suite (351 tests) passes; `test_wam_target` unchanged and green.

## Test plan

- [x] Smoke test `/tmp` — all 10 cases pass.
- [x] `test_wam_target` regression — all green.
- [x] Full `test_wam_cpp_generator` (351 tests) — all green.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_