### PR TITLE
feat(wam-cpp): date/time builtins

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -2824,8 +2824,10 @@ compile_wam_runtime_to_cpp(_Options,
 #include "wam_runtime.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstdio>
+#include <ctime>
 #include <limits>
 #include <random>
 #include <sstream>
@@ -5254,6 +5256,202 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         } else {
             return throw_iso_error(make_domain_error("seed_value", sv));
         }
+        pc += 1; return true;
+    }
+
+    // ---- get_time/1 ------------------------------------------------
+    // get_time(-Stamp) -- Float seconds since the Unix epoch with
+    // sub-second precision via std::chrono::system_clock.
+    if (op == "get_time/1") {
+        auto now = std::chrono::system_clock::now();
+        auto dur = now.time_since_epoch();
+        double sec = std::chrono::duration_cast<
+            std::chrono::duration<double>>(dur).count();
+        Value r = Value::Float(sec);
+        CellPtr tgt = get_cell("A1");
+        if (tgt->is_unbound()) { bind_cell(tgt, r); pc += 1; return true; }
+        if (!unify_cells(tgt, std::make_shared<Cell>(r))) return false;
+        pc += 1; return true;
+    }
+
+    // ---- stamp_date_time/3 -----------------------------------------
+    // stamp_date_time(+Stamp, -DateTime, +TZ)
+    //   Stamp:    Integer or Float seconds since the Unix epoch.
+    //   TZ:       atom -- ''local'' or ''UTC''.
+    //   DateTime: date(Y, Mo, D, H, Mi, S, Off, TZ, DST).
+    //     Off is the seconds offset from UTC (0 for UTC; for local
+    //     we fill it in from tm_gmtoff when the platform provides
+    //     it, else 0).
+    //     S is Float (whole second + sub-second remainder of Stamp).
+    //     DST is the integer flag from tm_isdst (-1, 0, or 1).
+    if (op == "stamp_date_time/3") {
+        Value sv = *get_cell("A1");
+        Value tzv = *get_cell("A3");
+        if (sv.is_unbound() || tzv.is_unbound())
+            return throw_iso_error(make_instantiation_error());
+        double stamp;
+        if (sv.tag == Value::Tag::Integer)      stamp = (double)sv.i;
+        else if (sv.tag == Value::Tag::Float)   stamp = sv.f;
+        else return throw_iso_error(make_type_error("number", sv));
+        if (tzv.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", tzv));
+        std::time_t whole = (std::time_t)stamp;
+        double frac = stamp - (double)whole;
+        std::tm tm{};
+        if (tzv.s == "UTC") {
+#if defined(_WIN32)
+            gmtime_s(&tm, &whole);
+#else
+            gmtime_r(&whole, &tm);
+#endif
+        } else if (tzv.s == "local") {
+#if defined(_WIN32)
+            localtime_s(&tm, &whole);
+#else
+            localtime_r(&whole, &tm);
+#endif
+        } else {
+            return throw_iso_error(make_domain_error("timezone", tzv));
+        }
+        std::int64_t off = 0;
+#if !defined(_WIN32)
+        off = (std::int64_t)tm.tm_gmtoff;
+#endif
+        std::vector<CellPtr> dargs;
+        dargs.push_back(std::make_shared<Cell>(Value::Integer(tm.tm_year + 1900)));
+        dargs.push_back(std::make_shared<Cell>(Value::Integer(tm.tm_mon + 1)));
+        dargs.push_back(std::make_shared<Cell>(Value::Integer(tm.tm_mday)));
+        dargs.push_back(std::make_shared<Cell>(Value::Integer(tm.tm_hour)));
+        dargs.push_back(std::make_shared<Cell>(Value::Integer(tm.tm_min)));
+        dargs.push_back(std::make_shared<Cell>(Value::Float((double)tm.tm_sec + frac)));
+        dargs.push_back(std::make_shared<Cell>(Value::Integer(off)));
+        dargs.push_back(std::make_shared<Cell>(Value::Atom(tzv.s)));
+        dargs.push_back(std::make_shared<Cell>(Value::Integer(tm.tm_isdst)));
+        Value dt = Value::Compound("date/9", std::move(dargs));
+        CellPtr tgt = get_cell("A2");
+        if (tgt->is_unbound()) { bind_cell(tgt, dt); pc += 1; return true; }
+        if (!unify_cells(tgt, std::make_shared<Cell>(dt))) return false;
+        pc += 1; return true;
+    }
+
+    // ---- date_time_stamp/2 -----------------------------------------
+    // date_time_stamp(+DateTime, -Stamp). Inverse of stamp_date_time/3.
+    // Accepts date/9 (full form) or date/6 (Y,Mo,D,H,Mi,S -- assumes
+    // local time, ignores DST/off). Returns Float seconds since epoch.
+    if (op == "date_time_stamp/2") {
+        Value dt = *get_cell("A1");
+        if (dt.tag != Value::Tag::Compound)
+            return throw_iso_error(make_type_error("compound", dt));
+        std::tm tm{};
+        double frac = 0.0;
+        bool is_utc = false;
+        if (dt.s == "date/9" && dt.args.size() == 9) {
+            Value y  = *dt.args[0];
+            Value mo = *dt.args[1];
+            Value d  = *dt.args[2];
+            Value h  = *dt.args[3];
+            Value mi = *dt.args[4];
+            Value s  = *dt.args[5];
+            Value tz = *dt.args[7];
+            if (y.tag != Value::Tag::Integer || mo.tag != Value::Tag::Integer
+                || d.tag != Value::Tag::Integer || h.tag != Value::Tag::Integer
+                || mi.tag != Value::Tag::Integer)
+                return throw_iso_error(make_type_error("integer", y));
+            tm.tm_year = (int)y.i - 1900;
+            tm.tm_mon  = (int)mo.i - 1;
+            tm.tm_mday = (int)d.i;
+            tm.tm_hour = (int)h.i;
+            tm.tm_min  = (int)mi.i;
+            if (s.tag == Value::Tag::Integer) { tm.tm_sec = (int)s.i; }
+            else if (s.tag == Value::Tag::Float) {
+                tm.tm_sec = (int)s.f;
+                frac = s.f - (double)tm.tm_sec;
+            } else return throw_iso_error(make_type_error("number", s));
+            tm.tm_isdst = -1;
+            if (tz.tag == Value::Tag::Atom && tz.s == "UTC") is_utc = true;
+        } else if (dt.s == "date/6" && dt.args.size() == 6) {
+            Value y  = *dt.args[0];
+            Value mo = *dt.args[1];
+            Value d  = *dt.args[2];
+            Value h  = *dt.args[3];
+            Value mi = *dt.args[4];
+            Value s  = *dt.args[5];
+            tm.tm_year = (int)y.i - 1900;
+            tm.tm_mon  = (int)mo.i - 1;
+            tm.tm_mday = (int)d.i;
+            tm.tm_hour = (int)h.i;
+            tm.tm_min  = (int)mi.i;
+            if (s.tag == Value::Tag::Integer) tm.tm_sec = (int)s.i;
+            else if (s.tag == Value::Tag::Float) {
+                tm.tm_sec = (int)s.f;
+                frac = s.f - (double)tm.tm_sec;
+            } else return throw_iso_error(make_type_error("number", s));
+            tm.tm_isdst = -1;
+        } else {
+            return throw_iso_error(make_type_error("date", dt));
+        }
+        std::time_t stamp;
+        if (is_utc) {
+#if defined(_WIN32)
+            stamp = _mkgmtime(&tm);
+#else
+            stamp = timegm(&tm);
+#endif
+        } else {
+            stamp = std::mktime(&tm);
+        }
+        if (stamp == (std::time_t)-1)
+            return throw_iso_error(make_domain_error("date", dt));
+        Value r = Value::Float((double)stamp + frac);
+        CellPtr tgt = get_cell("A2");
+        if (tgt->is_unbound()) { bind_cell(tgt, r); pc += 1; return true; }
+        if (!unify_cells(tgt, std::make_shared<Cell>(r))) return false;
+        pc += 1; return true;
+    }
+
+    // ---- format_time/3 ---------------------------------------------
+    // format_time(-Out, +Format, +Stamp). strftime(3)-style format.
+    // Out unifies with the formatted atom. (Variant taking a stream
+    // destination is deferred -- string sinks (atom/string/codes)
+    // are the common case.) Stamp is Float seconds since epoch (UTC
+    // interpretation); pre-decomposed date/9 terms are also accepted.
+    if (op == "format_time/3") {
+        Value fmt = *get_cell("A2");
+        Value sv = *get_cell("A3");
+        if (fmt.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", fmt));
+        std::tm tm{};
+        if (sv.tag == Value::Tag::Integer || sv.tag == Value::Tag::Float) {
+            double d = (sv.tag == Value::Tag::Float) ? sv.f : (double)sv.i;
+            std::time_t whole = (std::time_t)d;
+#if defined(_WIN32)
+            gmtime_s(&tm, &whole);
+#else
+            gmtime_r(&whole, &tm);
+#endif
+        } else if (sv.tag == Value::Tag::Compound
+                   && sv.s == "date/9" && sv.args.size() == 9) {
+            Value y = *sv.args[0]; Value mo = *sv.args[1];
+            Value d = *sv.args[2]; Value h = *sv.args[3];
+            Value mi = *sv.args[4]; Value s = *sv.args[5];
+            tm.tm_year = (int)y.i - 1900;
+            tm.tm_mon  = (int)mo.i - 1;
+            tm.tm_mday = (int)d.i;
+            tm.tm_hour = (int)h.i;
+            tm.tm_min  = (int)mi.i;
+            tm.tm_sec  = (s.tag == Value::Tag::Float)
+                         ? (int)s.f : (int)s.i;
+        } else {
+            return throw_iso_error(make_type_error("date_or_stamp", sv));
+        }
+        char buf[256];
+        std::size_t n = std::strftime(buf, sizeof(buf), fmt.s.c_str(), &tm);
+        if (n == 0 && !fmt.s.empty())
+            return throw_iso_error(make_domain_error("format_time", fmt));
+        Value out = Value::Atom(std::string(buf, n));
+        CellPtr tgt = get_cell("A1");
+        if (tgt->is_unbound()) { bind_cell(tgt, out); pc += 1; return true; }
+        if (!unify_cells(tgt, std::make_shared<Cell>(out))) return false;
         pc += 1; return true;
     }
 

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1487,6 +1487,10 @@ is_builtin_pred(random_member, 2).      % random_member(-X, +List).
 is_builtin_pred(random_permutation, 2). % random_permutation(+List, -Perm).
 is_builtin_pred(set_random, 1).         % set_random(seed(N|random)).
 is_builtin_pred(sort, 4).               % sort(+Key, +Order, +List, -Sorted).
+is_builtin_pred(get_time, 1).           % get_time(-Stamp), Float since epoch.
+is_builtin_pred(stamp_date_time, 3).    % stamp_date_time(+Stamp, -DT, +TZ).
+is_builtin_pred(date_time_stamp, 2).    % date_time_stamp(+DT, -Stamp).
+is_builtin_pred(format_time, 3).        % format_time(-Atom, +Fmt, +Stamp).
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -238,6 +238,14 @@
 :- dynamic user:wam_cpp_test_assoc_keys/0.
 :- dynamic user:wam_cpp_test_assoc_values/0.
 :- dynamic user:wam_cpp_test_assoc_compound_keys/0.
+:- dynamic user:wam_cpp_test_get_time_positive/0.
+:- dynamic user:wam_cpp_test_stamp_utc/0.
+:- dynamic user:wam_cpp_test_stamp_subsec/0.
+:- dynamic user:wam_cpp_test_dt_roundtrip/0.
+:- dynamic user:wam_cpp_test_date6_to_stamp/0.
+:- dynamic user:wam_cpp_test_format_basic/0.
+:- dynamic user:wam_cpp_test_format_year/0.
+:- dynamic user:wam_cpp_test_format_from_date9/0.
 :- dynamic user:wam_cpp_test_enum_member/0.
 
 user:wam_cpp_test_member_yes   :- member(b, [a, b, c]).
@@ -480,6 +488,32 @@ user:wam_cpp_test_assoc_compound_keys :-
     put_assoc(pt(3, 4), A1, south, A2),
     get_assoc(pt(1, 2), A2, north),
     get_assoc(pt(3, 4), A2, south).
+% Date/time: get_time/1 (Float seconds since epoch),
+% stamp_date_time/3 (decompose + TZ), date_time_stamp/2 (compose),
+% format_time/3 (strftime-style atom output). Tests use the canonical
+% 2024-01-01 00:00:00 UTC stamp = 1704067200 as a reference point.
+user:wam_cpp_test_get_time_positive :- get_time(T), T > 1700000000.0.
+user:wam_cpp_test_stamp_utc         :-
+    stamp_date_time(1704067200,
+                    date(Y, Mo, D, H, Mi, S, _, TZ, _), 'UTC'),
+    Y = 2024, Mo = 1, D = 1, H = 0, Mi = 0, S =:= 0.0, TZ = 'UTC'.
+user:wam_cpp_test_stamp_subsec      :-
+    stamp_date_time(1704067200.25, date(_, _, _, _, _, S, _, _, _), 'UTC'),
+    S > 0.24, S < 0.26.
+user:wam_cpp_test_dt_roundtrip      :-
+    stamp_date_time(1704067200, DT, 'UTC'),
+    date_time_stamp(DT, S),
+    S =:= 1704067200.0.
+user:wam_cpp_test_date6_to_stamp    :-
+    date_time_stamp(date(2024, 1, 1, 12, 30, 45), S),
+    S > 1700000000.0.
+user:wam_cpp_test_format_basic      :-
+    format_time(A, '%Y-%m-%d', 1704067200), A = '2024-01-01'.
+user:wam_cpp_test_format_year       :-
+    format_time(A, '%Y', 1704067200), A = '2024'.
+user:wam_cpp_test_format_from_date9 :-
+    stamp_date_time(1704067200, DT, 'UTC'),
+    format_time(A, '%Y-%m-%d', DT), A = '2024-01-01'.
 user:wam_cpp_test_enum_member  :- findall(X, member(X, [a, b, c]), L),
                                   L = [a, b, c].
 
@@ -3423,6 +3457,37 @@ test(cpp_e2e_assoc_library, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_assoc_keys/0',          [], true),
           run_query(BinPath, 'wam_cpp_test_assoc_values/0',        [], true),
           run_query(BinPath, 'wam_cpp_test_assoc_compound_keys/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_date_time, [condition(cpp_compiler_available)]) :-
+    % get_time/1 -> Float seconds since epoch (via chrono).
+    % stamp_date_time/3 -> decompose to date/9 in UTC or local.
+    % date_time_stamp/2 -> compose back (accepts date/9 or date/6).
+    % format_time/3 -> strftime-style atom output (also accepts
+    % pre-decomposed date/9 terms in the time arg).
+    % Reference stamp: 1704067200 = 2024-01-01 00:00:00 UTC.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_dt', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_get_time_positive/0,
+                               user:wam_cpp_test_stamp_utc/0,
+                               user:wam_cpp_test_stamp_subsec/0,
+                               user:wam_cpp_test_dt_roundtrip/0,
+                               user:wam_cpp_test_date6_to_stamp/0,
+                               user:wam_cpp_test_format_basic/0,
+                               user:wam_cpp_test_format_year/0,
+                               user:wam_cpp_test_format_from_date9/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_get_time_positive/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_stamp_utc/0',         [], true),
+          run_query(BinPath, 'wam_cpp_test_stamp_subsec/0',      [], true),
+          run_query(BinPath, 'wam_cpp_test_dt_roundtrip/0',      [], true),
+          run_query(BinPath, 'wam_cpp_test_date6_to_stamp/0',    [], true),
+          run_query(BinPath, 'wam_cpp_test_format_basic/0',      [], true),
+          run_query(BinPath, 'wam_cpp_test_format_year/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_format_from_date9/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Adds the four core date/time primitives — enough surface for logging, benchmarking, and time-sensitive code without pulling in a full clock/calendar library.

### New builtins

- **`get_time/1`** — `get_time(-Stamp)`. Stamp is Float seconds since the Unix epoch with sub-second precision (`std::chrono::system_clock`).
- **`stamp_date_time/3`** — `stamp_date_time(+Stamp, -DateTime, +TZ)`. Stamp is Integer or Float. TZ is the atom `'UTC'` or `'local'` (anything else throws `domain_error(timezone, _)`). DateTime is the SWI-compatible `date(Y, Mo, D, H, Mi, S, Off, TZ, DST)` compound — S is Float so sub-second precision round-trips; Off is the seconds offset from UTC; DST is the integer `tm_isdst` flag.
- **`date_time_stamp/2`** — `date_time_stamp(+DateTime, -Stamp)`. Inverse of the above. Accepts `date/9` (full form — TZ atom in arg 8 selects UTC vs local) or `date/6` (`Y,Mo,D,H,Mi,S` — assumed local). Sub-second Float seconds preserved.
- **`format_time/3`** — `format_time(-Atom, +Format, +StampOrDate)`. `strftime(3)`-style formatting; output unifies with an atom. Time arg may be a numeric Stamp (UTC interpretation) or a pre-decomposed `date/9`. Stream-destination variant deferred — string sinks are the common case for log/debug formatting.

### Implementation details

- Uses `<chrono>` for the high-resolution clock and `<ctime>` for `strftime`/`mktime`/`gmtime`/`localtime`. Both `#include`s added to the runtime preamble.
- Windows fallback paths use `_mkgmtime`, `gmtime_s`, `localtime_s` so the runtime keeps cross-compiling cleanly.

### Tests

One new `cpp_e2e_date_time` bundle with **8 cases** anchored on the `2024-01-01 00:00:00 UTC = 1704067200` reference stamp:

- `get_time/1` positive (any time after early 2023).
- `stamp_date_time/3` UTC decompose — year/month/day/hour/minute/sec all match.
- Sub-second precision: stamp `1704067200.25` gives `S ≈ 0.25`.
- Full round-trip: `Stamp → date/9 → Stamp` is identity.
- `date/6 → Stamp` (local TZ assumed).
- `format_time/3` with `%Y-%m-%d` and `%Y`.
- `format_time/3` accepting a pre-decomposed `date/9` term.

Full `test_wam_cpp_generator` suite (352 tests) passes; `test_wam_target` unchanged and green.

## Test plan

- [x] Smoke test `/tmp` — all 9 cases pass.
- [x] `test_wam_target` regression — all green.
- [x] Full `test_wam_cpp_generator` (352 tests) — all green.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_