### PR TITLE
feat(wam): args_first_emission flag — unblock bagof_with_quantifier

### DIFF
--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -95,6 +95,26 @@ compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code) :-
     ->  b_setval(wam_inline_bagof_setof, true)
     ;   b_setval(wam_inline_bagof_setof, false)
     ),
+    % args_first_emission: opt-in flag that reorders nested-compound
+    % construction. By default, compile_set_arguments emits each
+    % nested compound INLINE — `set_variable Xn ; put_structure F/N,
+    % Xn ; <nested args>` — which interleaves nested struct bodies
+    % with the outer compound's arg slots. On a flat-heap runtime
+    % (Elixir's lowered model), this puts the outer's later arg slots
+    % AT addresses already occupied by the nested struct's tag,
+    % breaking the addr+1..addr+arity contiguity assumption.
+    %
+    % With this flag, all set_variable's for the outer's args are
+    % emitted FIRST (reserving contiguous heap slots), then all
+    % nested put_structures emit AFTER. Same instruction count, same
+    % per-instruction semantics — pure reordering. Opt-in so targets
+    % that don't rely on heap-contiguous args (e.g., C++ which stores
+    % args in a Value-internal vector) are unaffected. Elixir target
+    % opts in; Rust/Haskell can opt in if they hit the same issue.
+    (   option(args_first_emission(true), Options)
+    ->  b_setval(wam_args_first_emission, true)
+    ;   b_setval(wam_args_first_emission, false)
+    ),
     (   length(Clauses, 1)
     ->  Clauses = [Clause],
         compile_single_clause_wam(Clause, Options, ClausesCode0)
@@ -1604,8 +1624,30 @@ compile_put_argument(Arg, I, V0, V1, Code) :-
 
 %% compile_set_arguments(+Args, +VIn, -VOut, -Code)
 %  Emits set_value/set_variable instructions for put_structure sub-arguments.
-compile_set_arguments([], V, V, "").
-compile_set_arguments([Arg|Rest], V0, Vf, Code) :-
+%
+%  When the `wam_args_first_emission` flag is set (via
+%  compile_clauses_to_wam reading args_first_emission(true) from
+%  options), nested compound emissions are DEFERRED until after all
+%  immediate set_*'s for the current compound — see
+%  compile_set_arguments_split/5 below. This preserves heap
+%  contiguity of addr+1..addr+arity, required by flat-heap targets.
+compile_set_arguments(Args, V0, Vf, Code) :-
+    ( catch(b_getval(wam_args_first_emission, true), _, fail)
+    -> compile_set_arguments_split(Args, V0, Vf, ImmCode, DeferredCode),
+       ( DeferredCode == ""
+       -> Code = ImmCode
+       ;  ImmCode == ""
+       -> Code = DeferredCode
+       ;  format(string(Code), "~w~n~w", [ImmCode, DeferredCode])
+       )
+    ;  compile_set_arguments_inline(Args, V0, Vf, Code)
+    ).
+
+% Original interleaved emission — preserved for targets that don't
+% opt in to args_first_emission. Behaviour unchanged from pre-flag
+% baseline.
+compile_set_arguments_inline([], V, V, "").
+compile_set_arguments_inline([Arg|Rest], V0, Vf, Code) :-
     (   var(Arg)
     ->  (   get_var_reg(Arg, V0, Reg)
         ->  format(string(ArgCode), "    set_value ~w", [Reg]),
@@ -1629,7 +1671,7 @@ compile_set_arguments([Arg|Rest], V0, Vf, Code) :-
         bind_var(Arg, XReg, V_temp, V1a),
         format(string(SetCode), "    set_variable ~w", [XReg]),
         format(string(PutCode), "    put_structure ~w/~w, ~w", [F, NArity, XReg]),
-        compile_set_arguments(NestedArgs, V1a, V1, NestedCode),
+        compile_set_arguments_inline(NestedArgs, V1a, V1, NestedCode),
         (   NestedCode == ""
         ->  format(string(ArgCode), "~w~n~w", [SetCode, PutCode])
         ;   format(string(ArgCode), "~w~n~w~n~w", [SetCode, PutCode, NestedCode])
@@ -1639,11 +1681,73 @@ compile_set_arguments([Arg|Rest], V0, Vf, Code) :-
         bind_var(Arg, XReg, V_temp, V1),
         format(string(ArgCode), "    set_variable ~w", [XReg])
     ),
-    compile_set_arguments(Rest, V1, Vf, RestCode),
+    compile_set_arguments_inline(Rest, V1, Vf, RestCode),
     (   RestCode == ""
     ->  Code = ArgCode
     ;   format(string(Code), "~w~n~w", [ArgCode, RestCode])
     ).
+
+% Args-first emission: returns Immediate (set_value/set_variable
+% /set_constant for each outer arg) AND Deferred (put_structure +
+% nested args bodies, recursively args-first). All immediate
+% emissions complete BEFORE any deferred — that way the outer
+% compound's args are at contiguous heap slots before any nested
+% structure body grows the heap.
+compile_set_arguments_split([], V, V, "", "").
+compile_set_arguments_split([Arg|Rest], V0, Vf, Code, Deferred) :-
+    arg_split(Arg, V0, V1, ImmArg, DefArg),
+    compile_set_arguments_split(Rest, V1, Vf, ImmRest, DefRest),
+    join_lines(ImmArg, ImmRest, Code),
+    join_lines(DefArg, DefRest, Deferred).
+
+% Per-arg classification. Returns the immediate emit (Imm) and any
+% deferred emit (Def, possibly empty). For nested compounds, the
+% deferred emit is the put_structure for the compound + its
+% (recursively-split) args.
+arg_split(Arg, V0, V1, Imm, "") :-
+    var(Arg),
+    !,
+    (   get_var_reg(Arg, V0, Reg)
+    ->  format(string(Imm), "    set_value ~w", [Reg]),
+        V1 = V0
+    ;   get_yi_alloc(Arg, V0, YReg, V1)
+    ->  format(string(Imm), "    set_variable ~w", [YReg])
+    ;   next_x_reg(V0, XReg, V_temp),
+        bind_var(Arg, XReg, V_temp, V1),
+        format(string(Imm), "    set_variable ~w", [XReg])
+    ).
+arg_split(Arg, V0, V0, Imm, "") :-
+    atomic(Arg),
+    !,
+    quote_wam_constant(Arg, ArgStr),
+    format(string(Imm), "    set_constant ~w", [ArgStr]).
+arg_split(Arg, V0, V1, Imm, Def) :-
+    compound(Arg),
+    !,
+    Arg =.. [F|NestedArgs],
+    length(NestedArgs, NArity),
+    next_x_reg(V0, XReg, V_temp),
+    bind_var(Arg, XReg, V_temp, V1a),
+    format(string(Imm), "    set_variable ~w", [XReg]),
+    % Recurse into nested args using the same args-first scheme.
+    compile_set_arguments_split(NestedArgs, V1a, V1,
+                                 NestedImm, NestedDef),
+    format(string(StructLine),
+           "    put_structure ~w/~w, ~w", [F, NArity, XReg]),
+    % Build the deferred chunk: put_structure for THIS compound,
+    % then its immediate args, then any further deferreds.
+    join_lines(StructLine, NestedImm, ThisStructWithImm),
+    join_lines(ThisStructWithImm, NestedDef, Def).
+arg_split(Arg, V0, V1, Imm, "") :-
+    % Fallback (rarely reached — covers unknown shapes).
+    next_x_reg(V0, XReg, V_temp),
+    bind_var(Arg, XReg, V_temp, V1),
+    format(string(Imm), "    set_variable ~w", [XReg]).
+
+% Join two code strings with a newline, handling empty-string cases.
+join_lines("", B, B) :- !.
+join_lines(A, "", A) :- !.
+join_lines(A, B, Out) :- format(string(Out), "~w~n~w", [A, B]).
 
 %% Variable Mapping Helpers
 %  Bindings use b(Var, Reg) for seen variables, and

--- a/tests/test_wam_elixir_classic_programs.pl
+++ b/tests/test_wam_elixir_classic_programs.pl
@@ -715,18 +715,17 @@ test(setof_sorts_ints) :-
         verify_elixir_args(TmpDir, 'elx_setof_sorts_ints/1',
                            ['[1,2,3]'], "true")).
 
-test(bagof_with_quantifier,
-     [blocked('^/2 transparency through inlined bagof body interacts with heap layout of nested compounds — separate fix; not introduced by member-enumerator follow-up')]) :-
-    % Tests ^/2 transparency through the inlined dispatch path.
-    % Currently FAILS: the goal Y^em(X-Y, [a-1,...]) doesn't enumerate
-    % because the em compound on the heap has its first arg (the -/2)
-    % laid out in a way my dispatch_call_meta picks up as a {:str, ...}
-    % instead of a {:ref, ...}. Reproducible with the bagof_setof PR's
-    % version too — pre-existing, not caused by this PR. Filed as
-    % follow-up alongside witness-group backtracking.
+test(bagof_with_quantifier) :-
+    % Tests ^/2 transparency through the inlined dispatch path
+    % combined with nested compound args. Previously blocked because
+    % the WAM compiler's interleaved nested-put_structure emission
+    % broke heap-contiguity of em/2's args (see the args_first_emission
+    % flag in wam_target.pl). With that flag on, em(-(X,Y), [...])
+    % has its args at addr+1, addr+2 contiguous; dispatch_call_meta
+    % reads them correctly; the goal enumerates over [a-1, b-2, c-3].
     with_elixir_project(
         [user:elx_bagof_with_quantifier/1, user:em/2],
-        [inline_bagof_setof(true)],
+        [inline_bagof_setof(true), args_first_emission(true)],
         TmpDir,
         verify_elixir_args(TmpDir, 'elx_bagof_with_quantifier/1',
                            ['[a,b,c]'], "true")).
@@ -826,6 +825,7 @@ wam_compile_opts(ExtraOpts, WamOpts) :-
                ), WamOpts).
 
 forwardable_wam_opt(inline_bagof_setof(_)).
+forwardable_wam_opt(args_first_emission(_)).
 
 %% verify_elixir_args(+ProjectDir, +PredKey, +Args, +Expected)
 %


### PR DESCRIPTION
## Summary

Closes the heap-layout limitation that left `bagof_with_quantifier` blocked in [PR #2235](https://github.com/s243a/UnifyWeaver/pull/2235) (member-enumerator follow-up).

### Background

`compile_set_arguments` in `wam_target.pl` emits nested compound args **INLINE**: `set_variable Xn ; put_structure F/N, Xn ; <nested args>` for each nested compound. On a flat-heap runtime (Elixir's lowered model) this puts the outer compound's later arg slots AT addresses already occupied by the nested struct's tag, breaking the `addr+1..addr+arity` contiguity assumption.

Concrete: `bagof(X, Y^em(X-Y, [a-1,...]), R)` builds `em(-(Y2,Y1), [...])` on the heap. The compiler emitted:

```
put_structure em/2, A2
set_variable X5          ← em arg 1 slot at heap[N+1]
put_structure -/2, X5    ← writes -/2 at heap[N+2] (CLOBBERS em's arg 2!)
set_value Y2 / Y1        ← writes to heap[N+3..N+4]
set_variable X6          ← em arg 2 slot at heap[N+5] — non-contiguous
put_structure [|]/2, X6
...
```

`dispatch_call_meta` in the Elixir runtime read em's args via `heap_slice(addr+1, 2)` and got `[{:ref, N+2}, {:str, "-/2"}]` — the second arg was the `-/2` tag, not the list ref.

### Fix (opt-in via `args_first_emission(true)` option)

New emit order — `set_variable` for ALL outer args first, then nested `put_structure`s after:

```
put_structure em/2, A2
set_variable X5      ← em arg 1 slot at heap[N+1]
set_variable X6      ← em arg 2 slot at heap[N+2] CONTIGUOUS
put_structure -/2, X5   ← writes -/2 at heap[N+3]
set_value Y2 / Y1
put_structure [|]/2, X6 ← writes list elsewhere
...
```

**Same instruction count, same per-instruction semantics — pure reordering.** New emission lives in `compile_set_arguments_split/5` (args-first); original interleaved emission preserved verbatim in `compile_set_arguments_inline/4`. The `compile_set_arguments` wrapper dispatches based on the `b_setval` flag.

### Why opt-in

Minimizes blast radius. C++ doesn't need it (stores compound args in a `Value`-internal vector, not on the flat heap). Rust/Haskell likely have the same latent bug but their existing tests don't surface it; they can opt in later if needed.

## Test plan

### Compile-time perf (`tests/bench_wam_rust.pl`)

| Predicate | Main (baseline) | This branch | Delta |
| --- | --- | --- | --- |
| `append/3` (compile) | 467ms | 444ms | -4.9% (faster) |
| `append/3` (lowerable) | 290ms | 267ms | -7.9% (faster) |
| `fibonacci/2` (compile) | 402ms | 357ms | -11.2% (faster) |
| `fibonacci/2` (lowerable) | 313ms | 288ms | -8.0% (faster) |
| `member/2` (compile) | 370ms | 342ms | -7.6% (faster) |
| `member/2` (lowerable) | 202ms | 205ms | +1.5% (within noise) |

10,000-iteration loops on each bench. All deltas are within natural variance for these workloads; "faster" is likely just timing noise on tight loops, not a real speedup. **No regression.** Flag is OFF for these benches (Rust target doesn't opt in).

### Target test suites (existing)

- [x] `test_wam_target.pl` — core WAM compiler tests pass
- [x] `test_wam_rust_target.pl` — Rust target tests pass
- [x] `test_wam_haskell_target.pl` — Haskell target tests pass

(All three exercise the **preserved inline path** since they don't pass `args_first_emission(true)`.)

### Elixir e2e

- [x] All 47 e2e tests pass, including the previously-blocked `bagof_with_quantifier` (flag on for that test)

## Wiring

- `compile_clauses_to_wam` reads option `args_first_emission/1` and sets `b_setval(wam_args_first_emission, true|false)`. Same pattern as the existing `inline_bagof_setof` flag.
- Elixir test harness's `wam_compile_opts/2` forwards `args_first_emission(_)` alongside `inline_bagof_setof(_)`.
- The `bagof_with_quantifier` test passes both flags (the latter to inline bagof itself).

## Limitations / next steps

- This PR doesn't change the Elixir runtime — only the WAM compiler. The runtime fix would be to store compound args in a Value-internal vector (like C++), eliminating the contiguity assumption entirely. That's a larger refactor; opt-in flag is the bounded fix.
- Rust and Haskell targets COULD opt in if their dispatch_call_meta equivalents have the same heap-contiguity assumption. Worth investigating in a separate audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)