### PR TITLE
feat(wam-rust): cursor BFS on LmdbFactSource + LMDB codegen tests (R2)

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -19,7 +19,8 @@
     cargo_check_project/2,               % +ProjectDir, -Result
     detect_kernels/2,                    % +Predicates, -DetectedKernels
     generate_setup_foreign_predicates_rust/2, % +DetectedKernels, -RustCode
-    escape_rust_string/2
+    escape_rust_string/2,
+    resolve_lmdb_crate/2                 % +Spec, -Crate  (lmdb_zero|heed|auto -> concrete)
 ]).
 
 :- use_module(library(lists)).

--- a/templates/targets/rust_wam/lmdb_fact_source_heed.rs.mustache
+++ b/templates/targets/rust_wam/lmdb_fact_source_heed.rs.mustache
@@ -132,6 +132,36 @@ impl LmdbFactSource {
         }
         Ok(out)
     }
+
+    /// Cursor-based demand-set BFS — R2 of the Rust-LMDB arc.
+    /// Same semantics as the lmdb-zero implementation: walk down from
+    /// `root_id` through `category_child` edges up to `max_depth` hops,
+    /// returning every reachable int ID (including the root itself).
+    ///
+    /// Sequential; parallel frontier-split is deferred to a future phase.
+    /// Each `lookup_children` call opens its own short-lived RoTxn.
+    pub fn reachable_to_root(
+        &self,
+        root_id: i32,
+        max_depth: usize,
+    ) -> Result<std::collections::HashSet<i32>, heed::Error> {
+        use std::collections::{HashSet, VecDeque};
+        let mut reachable: HashSet<i32> = HashSet::new();
+        reachable.insert(root_id);
+        let mut queue: VecDeque<(i32, usize)> = VecDeque::from([(root_id, 0)]);
+        while let Some((current, depth)) = queue.pop_front() {
+            if depth >= max_depth {
+                continue;
+            }
+            let children = self.lookup_children(current)?;
+            for child in children {
+                if reachable.insert(child) {
+                    queue.push_back((child, depth + 1));
+                }
+            }
+        }
+        Ok(reachable)
+    }
 }
 
 fn decode_i32(bytes: &[u8]) -> i32 {

--- a/templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache
+++ b/templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache
@@ -141,6 +141,40 @@ impl LmdbFactSource {
         }
         Ok(out)
     }
+
+    /// Cursor-based demand-set BFS — R2 of the Rust-LMDB arc.
+    /// Walks down from `root_id` through `category_child` edges (reverse
+    /// adjacency direction stored at ingest time) up to `max_depth` hops.
+    /// Returns every reachable int ID including the root itself.
+    ///
+    /// Sequential; parallel frontier-split is deferred to a future phase
+    /// (mirrors Haskell Phase L#9's evolution from sequential to parallel
+    /// `computeDemandSetCursorBFS`).
+    ///
+    /// Each `lookup_children` call opens its own short-lived txn + cursor;
+    /// no cross-call cursor reuse yet (cache work is R3, deferred).
+    pub fn reachable_to_root(
+        &self,
+        root_id: i32,
+        max_depth: usize,
+    ) -> Result<std::collections::HashSet<i32>, lmdb::Error> {
+        use std::collections::{HashSet, VecDeque};
+        let mut reachable: HashSet<i32> = HashSet::new();
+        reachable.insert(root_id);
+        let mut queue: VecDeque<(i32, usize)> = VecDeque::from([(root_id, 0)]);
+        while let Some((current, depth)) = queue.pop_front() {
+            if depth >= max_depth {
+                continue;
+            }
+            let children = self.lookup_children(current)?;
+            for child in children {
+                if reachable.insert(child) {
+                    queue.push_back((child, depth + 1));
+                }
+            }
+        }
+        Ok(reachable)
+    }
 }
 
 fn decode_i32(bytes: &[u8]) -> i32 {

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -1376,6 +1376,156 @@ test_project_cargo_content :-
     ;   fail_test(Test, 'Cargo.toml template rendering failed')
     ).
 
+%% LMDB codegen tests (R1 + R1.5 of the Rust-LMDB arc).
+%% Verify conditional emission of LmdbFactSource module + Cargo.toml deps
+%% across lmdb_mode(none|cursor) x lmdb_crate(lmdb_zero|heed|auto).
+
+test_resolve_lmdb_crate_auto_defaults_lmdb_zero :-
+    Test = 'WAM-Rust: resolve_lmdb_crate(auto) -> lmdb_zero',
+    (   resolve_lmdb_crate(auto, lmdb_zero)
+    ->  pass(Test)
+    ;   fail_test(Test, 'auto should resolve to lmdb_zero (current default)')
+    ).
+
+test_resolve_lmdb_crate_explicit_lmdb_zero :-
+    Test = 'WAM-Rust: resolve_lmdb_crate(lmdb_zero) -> lmdb_zero',
+    (   resolve_lmdb_crate(lmdb_zero, lmdb_zero)
+    ->  pass(Test)
+    ;   fail_test(Test, 'explicit lmdb_zero should resolve to lmdb_zero')
+    ).
+
+test_resolve_lmdb_crate_explicit_heed :-
+    Test = 'WAM-Rust: resolve_lmdb_crate(heed) -> heed',
+    (   resolve_lmdb_crate(heed, heed)
+    ->  pass(Test)
+    ;   fail_test(Test, 'explicit heed should resolve to heed')
+    ).
+
+test_lmdb_mode_none_omits_module :-
+    Test = 'WAM-Rust: lmdb_mode(none) emits no lmdb_fact_source.rs and no lmdb deps',
+    TmpDir = 'output/test_wam_rust_lmdb_none',
+    (   (   exists_directory(TmpDir)
+        ->  catch(delete_directory_and_contents(TmpDir), _, true)
+        ;   true
+        ),
+        write_wam_rust_project(
+            [user:test_simple_fact/2],
+            [module_name('lmdb_none_test'), lmdb_mode(none)],
+            TmpDir),
+        directory_file_path(TmpDir, 'src', SrcDir),
+        directory_file_path(SrcDir, 'lmdb_fact_source.rs', LmdbPath),
+        \+ exists_file(LmdbPath),
+        directory_file_path(TmpDir, 'Cargo.toml', CargoPath),
+        read_file_to_string(CargoPath, CargoStr, []),
+        \+ sub_string(CargoStr, _, _, _, 'lmdb-zero'),
+        \+ sub_string(CargoStr, _, _, _, 'heed ='),
+        directory_file_path(SrcDir, 'lib.rs', LibPath),
+        read_file_to_string(LibPath, LibStr, []),
+        \+ sub_string(LibStr, _, _, _, 'pub mod lmdb_fact_source'),
+        catch(delete_directory_and_contents(TmpDir), _, true)
+    ->  pass(Test)
+    ;   catch(delete_directory_and_contents(TmpDir), _, true),
+        fail_test(Test, 'lmdb_mode(none) regression: file or deps unexpectedly present')
+    ).
+
+test_lmdb_mode_cursor_auto_uses_lmdb_zero :-
+    Test = 'WAM-Rust: lmdb_mode(cursor) + lmdb_crate(auto) -> lmdb-zero',
+    TmpDir = 'output/test_wam_rust_lmdb_auto',
+    (   (   exists_directory(TmpDir)
+        ->  catch(delete_directory_and_contents(TmpDir), _, true)
+        ;   true
+        ),
+        write_wam_rust_project(
+            [user:test_simple_fact/2],
+            [module_name('lmdb_auto_test'),
+             lmdb_mode(cursor), lmdb_crate(auto)],
+            TmpDir),
+        directory_file_path(TmpDir, 'Cargo.toml', CargoPath),
+        read_file_to_string(CargoPath, CargoStr, []),
+        sub_string(CargoStr, _, _, _, 'lmdb-zero = "0.4"'),
+        \+ sub_string(CargoStr, _, _, _, 'heed ='),
+        directory_file_path(TmpDir, 'src', SrcDir),
+        directory_file_path(SrcDir, 'lmdb_fact_source.rs', LmdbPath),
+        exists_file(LmdbPath),
+        read_file_to_string(LmdbPath, LmdbStr, []),
+        sub_string(LmdbStr, _, _, _, 'lmdb_zero'),
+        sub_string(LmdbStr, _, _, _, 'pub struct LmdbFactSource'),
+        sub_string(LmdbStr, _, _, _, 'pub fn reachable_to_root'),
+        directory_file_path(SrcDir, 'lib.rs', LibPath),
+        read_file_to_string(LibPath, LibStr, []),
+        sub_string(LibStr, _, _, _, 'pub mod lmdb_fact_source'),
+        catch(delete_directory_and_contents(TmpDir), _, true)
+    ->  pass(Test)
+    ;   catch(delete_directory_and_contents(TmpDir), _, true),
+        fail_test(Test, 'lmdb_mode(cursor) + auto failed to emit lmdb-zero variant')
+    ).
+
+test_lmdb_mode_cursor_heed :-
+    Test = 'WAM-Rust: lmdb_mode(cursor) + lmdb_crate(heed) -> heed',
+    TmpDir = 'output/test_wam_rust_lmdb_heed',
+    (   (   exists_directory(TmpDir)
+        ->  catch(delete_directory_and_contents(TmpDir), _, true)
+        ;   true
+        ),
+        write_wam_rust_project(
+            [user:test_simple_fact/2],
+            [module_name('lmdb_heed_test'),
+             lmdb_mode(cursor), lmdb_crate(heed)],
+            TmpDir),
+        directory_file_path(TmpDir, 'Cargo.toml', CargoPath),
+        read_file_to_string(CargoPath, CargoStr, []),
+        sub_string(CargoStr, _, _, _, 'heed = "0.20"'),
+        \+ sub_string(CargoStr, _, _, _, 'lmdb-zero'),
+        directory_file_path(TmpDir, 'src', SrcDir),
+        directory_file_path(SrcDir, 'lmdb_fact_source.rs', LmdbPath),
+        exists_file(LmdbPath),
+        read_file_to_string(LmdbPath, LmdbStr, []),
+        sub_string(LmdbStr, _, _, _, 'use heed::'),
+        sub_string(LmdbStr, _, _, _, 'pub struct LmdbFactSource'),
+        sub_string(LmdbStr, _, _, _, 'pub fn reachable_to_root'),
+        sub_string(LmdbStr, _, _, _, 'env.write_txn'),  % bootstrap requirement
+        catch(delete_directory_and_contents(TmpDir), _, true)
+    ->  pass(Test)
+    ;   catch(delete_directory_and_contents(TmpDir), _, true),
+        fail_test(Test, 'lmdb_mode(cursor) + heed failed to emit heed variant')
+    ).
+
+test_lmdb_crate_mutual_exclusion :-
+    Test = 'WAM-Rust: Cargo.toml never lists both lmdb-zero and heed',
+    TmpDirA = 'output/test_wam_rust_lmdb_mut_a',
+    TmpDirB = 'output/test_wam_rust_lmdb_mut_b',
+    (   (   exists_directory(TmpDirA)
+        ->  catch(delete_directory_and_contents(TmpDirA), _, true)
+        ;   true
+        ),
+        (   exists_directory(TmpDirB)
+        ->  catch(delete_directory_and_contents(TmpDirB), _, true)
+        ;   true
+        ),
+        write_wam_rust_project([user:test_simple_fact/2],
+            [module_name('mut_a'), lmdb_mode(cursor), lmdb_crate(lmdb_zero)],
+            TmpDirA),
+        write_wam_rust_project([user:test_simple_fact/2],
+            [module_name('mut_b'), lmdb_mode(cursor), lmdb_crate(heed)],
+            TmpDirB),
+        directory_file_path(TmpDirA, 'Cargo.toml', CargoA),
+        directory_file_path(TmpDirB, 'Cargo.toml', CargoB),
+        read_file_to_string(CargoA, StrA, []),
+        read_file_to_string(CargoB, StrB, []),
+        % A contains lmdb-zero and NOT heed
+        sub_string(StrA, _, _, _, 'lmdb-zero'),
+        \+ sub_string(StrA, _, _, _, 'heed ='),
+        % B contains heed and NOT lmdb-zero
+        sub_string(StrB, _, _, _, 'heed = "0.20"'),
+        \+ sub_string(StrB, _, _, _, 'lmdb-zero'),
+        catch(delete_directory_and_contents(TmpDirA), _, true),
+        catch(delete_directory_and_contents(TmpDirB), _, true)
+    ->  pass(Test)
+    ;   catch(delete_directory_and_contents(TmpDirA), _, true),
+        catch(delete_directory_and_contents(TmpDirB), _, true),
+        fail_test(Test, 'Cargo.toml leaked both lmdb crates or wrong one')
+    ).
+
 test_project_with_wam_fallback :-
     Test = 'WAM-Rust: project includes WAM-compiled predicates',
     TmpDir = 'output/test_wam_rust_fallback',
@@ -1772,6 +1922,13 @@ run_tests :-
     test_compile_wam_runtime_output,
     test_write_wam_rust_project,
     test_project_cargo_content,
+    test_resolve_lmdb_crate_auto_defaults_lmdb_zero,
+    test_resolve_lmdb_crate_explicit_lmdb_zero,
+    test_resolve_lmdb_crate_explicit_heed,
+    test_lmdb_mode_none_omits_module,
+    test_lmdb_mode_cursor_auto_uses_lmdb_zero,
+    test_lmdb_mode_cursor_heed,
+    test_lmdb_crate_mutual_exclusion,
     test_project_with_wam_fallback,
     test_instruction_parser,
     test_instruction_parser_labels,


### PR DESCRIPTION
  ## Summary

  R2 of the Rust-LMDB arc — adds the cursor-based demand-set BFS method
  to both `LmdbFactSource` templates, plus the codegen tests for R1+R1.5
  that were called out as outstanding in PR #2258. Both halves land together
  so the BFS is properly covered from day one.

  Builds on PR #2258 (R1 + R1.5: `LmdbFactSource` module + configurable
  `lmdb_crate` option). The BFS is still dead code in the binary at the
  end of this PR — wiring it into the matrix bench's `main.rs` is R4.

  ## What changed

  | File | Change |
  | --- | --- |
  | `templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache` | New `reachable_to_root` method (+34 lines) |
  | `templates/targets/rust_wam/lmdb_fact_source_heed.rs.mustache` | New `reachable_to_root` method (+30 lines) |
  | `src/unifyweaver/targets/wam_rust_target.pl` | Export `resolve_lmdb_crate/2` so tests can verify the resolver
  directly |
  | `tests/test_wam_rust_target.pl` | 7 new codegen tests (+157 lines) |

  ## The BFS

  ```rust
  pub fn reachable_to_root(
      &self,
      root_id: i32,
      max_depth: usize,
  ) -> Result<HashSet<i32>, _>
  ```
  Walks down from root_id through the category_child dupsort sub-db
  (reverse-adjacency stored at ingest time) up to max_depth hops.
  Returns every reachable int ID including the root itself.

  Sequential. Parallel frontier-split is deferred to a future phase
  (mirrors Haskell's Phase L#8 → L#9 evolution). Each lookup_children
  call opens its own short-lived cursor; no cross-call cursor reuse yet
  (L2 cache is R3, also deferred).

  Both crate templates expose identical API and semantics. They differ
  only in transaction mechanics:

| Crate     | Per-call txn                                                       |
|-----------|-------------------------------------------------------------------|
| lmdb-zero | `ReadTransaction::new(&*self.env)`                                |
| heed      | `self.env.read_txn()` against the WriteTxn-bootstrap'd dbi handles |

  New codegen tests

  Test: test_resolve_lmdb_crate_auto_defaults_lmdb_zero
  Verifies: auto → lmdb_zero
  ────────────────────────────────────────
  Test: test_resolve_lmdb_crate_explicit_lmdb_zero
  Verifies: lmdb_zero → lmdb_zero
  ────────────────────────────────────────
  Test: test_resolve_lmdb_crate_explicit_heed
  Verifies: heed → heed
  ────────────────────────────────────────
  Test: test_lmdb_mode_none_omits_module
  Verifies: lmdb_mode(none): no Cargo dep, no module file, no pub mod line in lib.rs
  ────────────────────────────────────────
  Test: test_lmdb_mode_cursor_auto_uses_lmdb_zero
  Verifies: lmdb_mode(cursor) + lmdb_crate(auto): Cargo has lmdb-zero = "0.4", module emitted, LmdbFactSource struct +
    reachable_to_root present, pub mod in lib.rs
  ────────────────────────────────────────
  Test: test_lmdb_mode_cursor_heed
  Verifies: lmdb_crate(heed): Cargo has heed = "0.20", module uses use heed::, contains env.write_txn bootstrap +
    reachable_to_root
  ────────────────────────────────────────
  Test: test_lmdb_crate_mutual_exclusion
  Verifies: Cargo.toml never lists both crates simultaneously

  Verification

  Check: Full Rust-target test suite (run_tests -t halt tests/test_wam_rust_target.pl)
  Result: All pass — 7 new + ~70 existing, no regressions
  ────────────────────────────────────────
  Check: Smoke regenerate at 100k_cats, lmdb_crate=lmdb_zero, cargo build --release
  Result: Finished in 6.84s, clean
  ────────────────────────────────────────
  Check: Smoke regenerate at 100k_cats, lmdb_crate=heed, cargo build --release
  Result: Finished in 11.33s, clean
  ────────────────────────────────────────
  Check: reachable_to_root present in both generated modules
  Result: Confirmed by codegen tests + manual grep

  What's intentionally not in this PR

  Phase: R4
  Description: Wire LmdbFactSource::reachable_to_root into the matrix bench's main.rs (replacing the TSV
    compute_reachable_to_root) + WAM_ROOT_ID env var for principled root selection
  Lands in: next PR
  ────────────────────────────────────────
  Phase: R5
  Description: Re-ingest simplewiki_cats Phase-1 LMDB + bench Rust at simplewiki, head-to-head with Haskell Phase L#7
  Lands in: after R4
  ────────────────────────────────────────
  Phase: R6
  Description: Same for enwiki_cats (9.93 M edges)
  Lands in: after R5
  ────────────────────────────────────────
  Phase: R3
  Description: Sharded L2 cache (if profiling at enwiki shows hot read paths)
  Lands in: deferred to last

  End-to-end runtime validation of reachable_to_root (against the 1k
  LMDB fixture, comparing BFS output against ground truth from
  category_parent.tsv) will land alongside R4 when the BFS is actually
  called by the bench.

  Test plan

  - CI: swipl -g run_tests -t halt tests/test_wam_rust_target.pl passes
  - Manual: cargo build --release on regenerated 100k_cats with both lmdb_crate=lmdb_zero and lmdb_crate=heed

  🤖 Generated with Claude Code (https://claude.com/claude-code)