### PR TITLE
test(wam-cpp): lock in DCG call//N (DCG-body meta-call)

### DIFF
--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -246,6 +246,14 @@
 :- dynamic user:wam_cpp_test_format_basic/0.
 :- dynamic user:wam_cpp_test_format_year/0.
 :- dynamic user:wam_cpp_test_format_from_date9/0.
+:- dynamic user:wam_cpp_test_dcgcall_n0/0.
+:- dynamic user:wam_cpp_test_dcgcall_n0_no/0.
+:- dynamic user:wam_cpp_test_dcgcall_full/0.
+:- dynamic user:wam_cpp_test_dcgcall_partial/0.
+:- dynamic user:wam_cpp_test_dcgcall_partial_no/0.
+:- dynamic user:wam_cpp_test_dcgcall_rep3/0.
+:- dynamic user:wam_cpp_test_dcgcall_rep0/0.
+:- dynamic user:wam_cpp_test_dcgcall_rep_no/0.
 :- dynamic user:wam_cpp_test_enum_member/0.
 
 user:wam_cpp_test_member_yes   :- member(b, [a, b, c]).
@@ -514,6 +522,33 @@ user:wam_cpp_test_format_year       :-
 user:wam_cpp_test_format_from_date9 :-
     stamp_date_time(1704067200, DT, 'UTC'),
     format_time(A, '%Y-%m-%d', DT), A = '2024-01-01'.
+% DCG call//N (DCG-body meta-call) -- works via composition of SWI's
+% --> term_expansion (which rewrites call(P) inside a DCG body to
+% call(P, S0, S)) and the existing dispatch_call_meta. No new runtime
+% code needed; this section documents and locks in the behavior.
+user:dcg_emit_b --> [b].
+user:dcg_emit_two(X, Y) --> [X], [Y].
+user:dcg_emit_a --> [a].
+user:dcg_with_call0 --> [a], call(user:dcg_emit_b), [c].
+user:dcg_with_call_full --> [start], call(user:dcg_emit_two(x, y)), [end].
+user:dcg_with_call_partial --> [start], call(user:dcg_emit_two(x), y), [end].
+user:dcg_rep0(_, 0) --> [].
+user:dcg_rep0(P, N) -->
+    { N > 0, N1 is N - 1 }, call(P), user:dcg_rep0(P, N1).
+user:wam_cpp_test_dcgcall_n0      :- phrase(dcg_with_call0, [a, b, c]).
+user:wam_cpp_test_dcgcall_n0_no   :- \+ phrase(dcg_with_call0, [a, b, d]).
+user:wam_cpp_test_dcgcall_full    :-
+    phrase(dcg_with_call_full, [start, x, y, end]).
+user:wam_cpp_test_dcgcall_partial :-
+    phrase(dcg_with_call_partial, [start, x, y, end]).
+user:wam_cpp_test_dcgcall_partial_no :-
+    \+ phrase(dcg_with_call_partial, [start, x, z, end]).
+user:wam_cpp_test_dcgcall_rep3    :-
+    phrase(dcg_rep0(dcg_emit_a, 3), [a, a, a]).
+user:wam_cpp_test_dcgcall_rep0    :-
+    phrase(dcg_rep0(dcg_emit_a, 0), []).
+user:wam_cpp_test_dcgcall_rep_no  :-
+    \+ phrase(dcg_rep0(dcg_emit_a, 3), [a, a]).
 user:wam_cpp_test_enum_member  :- findall(X, member(X, [a, b, c]), L),
                                   L = [a, b, c].
 
@@ -3488,6 +3523,49 @@ test(cpp_e2e_date_time, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_format_basic/0',      [], true),
           run_query(BinPath, 'wam_cpp_test_format_year/0',       [], true),
           run_query(BinPath, 'wam_cpp_test_format_from_date9/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_dcg_call, [condition(cpp_compiler_available)]) :-
+    % DCG call//N (DCG-body meta-call). Works via composition of
+    % SWI's --> term_expansion (which rewrites call(P) inside a DCG
+    % body to call(P, S0, S)) and our existing dispatch_call_meta.
+    % No new runtime code; these tests document and lock in the
+    % behavior. Covers:
+    %   call//1: nullary DCG via call(P).
+    %   call//1 with full partial application: call(P(x, y)).
+    %   call//2: call(P(x), y) -- one extra arg threaded through.
+    %   Module-qualified DCG meta-call (via user: prefix already
+    %     present on the rules, exercised by phrase indirection).
+    %   Recursive higher-order DCG via call(P) inside rep0/2.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_dcgcall', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_dcgcall_n0/0,
+                               user:wam_cpp_test_dcgcall_n0_no/0,
+                               user:wam_cpp_test_dcgcall_full/0,
+                               user:wam_cpp_test_dcgcall_partial/0,
+                               user:wam_cpp_test_dcgcall_partial_no/0,
+                               user:wam_cpp_test_dcgcall_rep3/0,
+                               user:wam_cpp_test_dcgcall_rep0/0,
+                               user:wam_cpp_test_dcgcall_rep_no/0,
+                               user:dcg_emit_b/2,
+                               user:dcg_emit_two/4,
+                               user:dcg_emit_a/2,
+                               user:dcg_with_call0/2,
+                               user:dcg_with_call_full/2,
+                               user:dcg_with_call_partial/2,
+                               user:dcg_rep0/4],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_dcgcall_n0/0',         [], true),
+          run_query(BinPath, 'wam_cpp_test_dcgcall_n0_no/0',      [], true),
+          run_query(BinPath, 'wam_cpp_test_dcgcall_full/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_dcgcall_partial/0',    [], true),
+          run_query(BinPath, 'wam_cpp_test_dcgcall_partial_no/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_dcgcall_rep3/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_dcgcall_rep0/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_dcgcall_rep_no/0',     [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

DCG-body meta-call (`call//N`) already works through composition of three existing pieces:

1. SWI's `-->` term_expansion (which rewrites `call(P)` inside a DCG body to `call(P, S0, S)` at consult time).
2. The module-qualified meta-call dispatcher landed in PR #2245.
3. The `dispatch_call_meta` helper that powers `call/N`.

**No new runtime code was needed.** This PR adds test coverage that locks in the behavior so a future change can't silently break it.

### What works (now covered by tests)

```prolog
emit_b --> [b].
emit_two(X, Y) --> [X], [Y].
emit_a --> [a].

% call//1 nullary
with_call0 --> [a], call(emit_b), [c].

% call//1 with a partially-applied parametric DCG
with_call_full --> [start], call(emit_two(x, y)), [end].

% call//2 -- one extra arg threaded through
with_call_partial --> [start], call(emit_two(x), y), [end].

% Higher-order recursive DCG
rep0(_, 0) --> [].
rep0(P, N) --> { N > 0, N1 is N - 1 }, call(P), rep0(P, N1).
```

```prolog
?- phrase(with_call0, [a, b, c]).                       % true
?- phrase(with_call_full, [start, x, y, end]).          % true
?- phrase(with_call_partial, [start, x, y, end]).       % true
?- phrase(rep0(emit_a, 3), [a, a, a]).                  % true
```

### Tests

One new `cpp_e2e_dcg_call` bundle with **8 cases**:

- `call//1` nullary: success + fail.
- `call//1` with full partial application: `call(emit_two(x, y))`.
- `call//2` partial form: `call(emit_two(x), y)` — success + fail.
- Recursive higher-order DCG: `rep0(P, N)` at N=3, N=0, and an insufficient-input fail.

Test rules defined as `user:dcg_*` so they end up in `user` module (plunit's test module would otherwise hide them from `clause/2`), matching the convention from the original `cpp_e2e_dcg` bundle in PR #2241.

Full `test_wam_cpp_generator` suite (353 tests) passes; `test_wam_target` unchanged and green.

## Test plan

- [x] Smoke tests `/tmp` — all 9 cases pass with no runtime changes.
- [x] `test_wam_target` regression — all green.
- [x] Full `test_wam_cpp_generator` (353 tests) — all green.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_