### PR TITLE
Feat/wam go select builtin

### DIFF
--- a/PR_go_wam_select_builtin.md
+++ b/PR_go_wam_select_builtin.md
@@ -1,0 +1,25 @@
+# PR Title
+
+Add Go WAM select builtin
+
+# PR Description
+
+## Summary
+
+- Adds generated Go WAM runtime support for `select/3`.
+- Registers `select/3` as a direct Go WAM builtin so compiled calls emit `BuiltinCall` instructions.
+- Adds choicepoint-backed `select/3` enumeration so `findall/3` can observe each selected element/rest pair.
+- Extends the generated Go builtin E2E test to cover direct first/middle/last selection, missing-element failure, empty-list failure, malformed-list failure, and `findall/3` enumeration.
+- Updates the Go WAM parity audit to record the structural-list parity closure against the Clojure/C++ surface.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- direct emitter check for `select/3`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -11,7 +11,7 @@ current cross-target builtin/runtime baseline.
 | Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries, indexed atom fact streams, `member/2` builtin retries | Choice point stack with normal, builtin, and fact-stream resume states | Present for current resume-state baseline |
 | Direct fact dispatch | `call_indexed_atom_fact2`, `AtomFact2Source` registry, TSV-backed and LMDB-artifact atom fact loading, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Present for current external atom fact-source baseline |
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
-| Structural builtins | `member/2`, `memberchk/2`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
+| Structural builtins | `member/2`, `memberchk/2`, `select/3`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `select/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Arithmetic builtins | `is/2`, `succ/2` | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir | Present for current baseline arithmetic checks, with expanded successor coverage |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` | Includes `=</2`; Haskell mode analysis and Clojure lowering also cover term-order comparisons | Present for current baseline comparisons, with expanded term-order coverage |
@@ -35,6 +35,10 @@ current cross-target builtin/runtime baseline.
 - Deterministic `memberchk/2` is now covered by the generated Go WAM builtin
   E2E test, committing to the first unifiable list element without adding
   builtin choice points.
+- Nondeterministic `select/3` is now covered by the generated Go WAM builtin
+  E2E test for first-match selection, missing/empty/malformed-list failure,
+  and `findall/3` enumeration of every selected element/rest pair, matching
+  the Clojure/C++ structural-list surface.
 - Deterministic `reverse/2` is now covered by the generated Go WAM builtin E2E
   test for both forward and reverse-list binding modes, closing one richer
   Clojure/R/C++ list-builtin parity gap.

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -422,6 +422,9 @@ wam_go_direct_builtin(Pred, Arity) :-
 wam_go_direct_builtin(memberchk/2, 2, 'memberchk/2').
 wam_go_direct_builtin('memberchk/2', 2, 'memberchk/2').
 wam_go_direct_builtin("memberchk/2", 2, 'memberchk/2').
+wam_go_direct_builtin(select/3, 3, 'select/3').
+wam_go_direct_builtin('select/3', 3, 'select/3').
+wam_go_direct_builtin("select/3", 3, 'select/3').
 wam_go_direct_builtin(reverse/2, 2, 'reverse/2').
 wam_go_direct_builtin('reverse/2', 2, 'reverse/2').
 wam_go_direct_builtin("reverse/2", 2, 'reverse/2').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -32,6 +32,11 @@ type WeightedEdgeTriple struct {
 	Weight float64
 }
 
+type SelectSolution struct {
+	Elem Value
+	Rest Value
+}
+
 type ChoicePoint struct {
 	NextPC    int
 	ResumePC  int
@@ -59,6 +64,7 @@ type ChoicePoint struct {
 	ForeignResultRegs []int
 	ForeignResults   []Value
 	MemberTail       Value
+	SelectResults    []SelectSolution
 }
 
 type EnvFrame struct {
@@ -764,6 +770,33 @@ func (vm *WamState) listToSlice(v Value) ([]Value, bool) {
 	}
 }
 
+func (vm *WamState) selectSolutions(items []Value) []SelectSolution {
+	solutions := make([]SelectSolution, 0, len(items))
+	for idx, item := range items {
+		rest := make([]Value, 0, len(items)-1)
+		rest = append(rest, items[:idx]...)
+		rest = append(rest, items[idx+1:]...)
+		solutions = append(solutions, SelectSolution{
+			Elem: item,
+			Rest: &List{Elements: rest},
+		})
+	}
+	return solutions
+}
+
+func (vm *WamState) applySelectSolution(solution SelectSolution) bool {
+	mark := vm.TrailLen
+	if !vm.Unify(vm.getReg(0), solution.Elem) {
+		vm.unwindTrailTo(mark)
+		return false
+	}
+	if !vm.Unify(vm.getReg(2), solution.Rest) {
+		vm.unwindTrailTo(mark)
+		return false
+	}
+	return true
+}
+
 func decompose(v Value) (string, []Value) {
 	switch t := v.(type) {
 	case *Atom:
@@ -1201,6 +1234,47 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			vm.unwindTrailTo(mark)
 			v = vm.deref(tail)
 		}
+	case "select/3":
+		items, ok := vm.listToSlice(arg2)
+		if !ok {
+			return false
+		}
+		solutions := vm.selectSolutions(items)
+		if len(solutions) == 0 {
+			return false
+		}
+		resumePC := vm.PC + 1
+		trailMark := vm.TrailLen
+		savedRegs := vm.snapshotAllRegs()
+		stackLen := len(vm.Stack)
+		heapTop := vm.HeapLen
+		for idx, solution := range solutions {
+			vm.unwindTrailTo(trailMark)
+			vm.restoreSavedRegs(savedRegs)
+			if stackLen <= len(vm.Stack) {
+				vm.Stack = vm.Stack[:stackLen]
+			}
+			if heapTop <= vm.HeapLen {
+				vm.heapTrimTo(heapTop)
+			}
+			if !vm.applySelectSolution(solution) {
+				continue
+			}
+			if idx+1 < len(solutions) {
+				vm.ChoicePoints = append(vm.ChoicePoints, ChoicePoint{
+					ResumePC:      resumePC,
+					CP:            vm.CP,
+					E:             vm.E,
+					StackLen:      stackLen,
+					SavedRegs:     savedRegs,
+					HeapTop:       heapTop,
+					TrailMark:     trailMark,
+					SelectResults: append([]SelectSolution(nil), solutions[idx+1:]...),
+				})
+			}
+			return true
+		}
+		return false
 	case "append/3":
 		l1, ok1 := vm.listToSlice(arg1)
 		l2, ok2 := vm.listToSlice(arg2)
@@ -1577,6 +1651,36 @@ func (vm *WamState) backtrack() bool {
             }
             if !vm.Unify(vm.getReg(0), item) {
                 vm.unwindTrailTo(cp.TrailMark)
+                continue
+            }
+            vm.PC = resumePC
+            return true
+        }
+        return vm.backtrack()
+    }
+    if len(cp.SelectResults) > 0 {
+        for len(cp.SelectResults) > 0 {
+            vm.unwindTrailTo(cp.TrailMark)
+            vm.restoreSavedRegs(cp.SavedRegs)
+            if cp.StackLen <= len(vm.Stack) {
+                vm.Stack = vm.Stack[:cp.StackLen]
+            }
+            if cp.HeapTop <= vm.HeapLen {
+                vm.heapTrimTo(cp.HeapTop)
+            }
+            vm.PC = cp.ResumePC
+            vm.CP = cp.CP
+            vm.E = cp.E
+            vm.Halted = false
+            vm.CurrentStruct = nil
+            vm.CurrentList = nil
+            solution := cp.SelectResults[0]
+            cp.SelectResults = cp.SelectResults[1:]
+            resumePC := cp.ResumePC
+            if len(cp.SelectResults) == 0 {
+                vm.ChoicePoints = vm.ChoicePoints[:topIdx]
+            }
+            if !vm.applySelectSolution(solution) {
                 continue
             }
             vm.PC = resumePC

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -9,6 +9,7 @@
 :- dynamic user:test_term_builtins/0.
 :- dynamic user:test_member_collect/0.
 :- dynamic user:test_memberchk_builtin/0.
+:- dynamic user:test_select_builtin/0.
 :- dynamic user:test_reverse_builtin/0.
 :- dynamic user:test_last_builtin/0.
 :- dynamic user:test_nth_builtin/0.
@@ -63,6 +64,24 @@ test(builtins_execution) :-
             (   memberchk(X, [a,b,c]),
                 X == a,
                 \+ memberchk(z, [a,b,c])
+            )),
+          assertz(user:test_select_builtin :-
+            (   select(b, [a,b,c], R),
+                R = [a,c],
+                select(X, [a,b], [b]),
+                X == a,
+                select(a, [a,b,c], RA),
+                RA = [b,c],
+                select(c, [a,b,c], RC),
+                RC = [a,b],
+                findall(Y, select(Y, [a,b,c], _), Ys),
+                Ys = [a,b,c],
+                findall(Rest, select(_, [a,b,c], Rest), Rests),
+                member([b,c], Rests),
+                member([a,c], Rests),
+                \+ select(z, [a,b,c], _),
+                \+ select(_, [], _),
+                \+ select(_, [a|b], _)
             )),
           assertz(user:test_reverse_builtin :-
             (   reverse([a,b,c], R),
@@ -155,6 +174,7 @@ test(builtins_execution) :-
           retractall(user:test_term_builtins),
           retractall(user:test_member_collect),
           retractall(user:test_memberchk_builtin),
+          retractall(user:test_select_builtin),
           retractall(user:test_reverse_builtin),
           retractall(user:test_last_builtin),
           retractall(user:test_nth_builtin),
@@ -171,7 +191,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -188,6 +208,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(StateCode, _, _, _, 'func (vm *WamState) backtrack() bool')),
     assertion(sub_string(StateCode, _, _, _, 'if len(cp.IndexedClausePCs) > 0')),
     assertion(sub_string(StateCode, _, _, _, 'if cp.MemberTail != nil')),
+    assertion(sub_string(StateCode, _, _, _, 'if len(cp.SelectResults) > 0')),
     assertion(sub_string(StateCode, _, _, _, 'if len(cp.ForeignResults) > 0')),
     assertion(sub_string(StateCode, _, _, _, 'func (vm *WamState) runNegationParallel(targetPC int, args []Value) bool')),
     assertion(sub_string(StateCode, _, _, _, 'func raceToTrue(tasks []func() bool) bool')),
@@ -203,6 +224,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "copy_term/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "=/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "memberchk/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "select/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "reverse/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "last/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "nth0/3"')),
@@ -267,6 +289,14 @@ func main() {
 		fmt.Println("MEMBERCHK_SUCCESS")
 	} else {
 		fmt.Println("MEMBERCHK_FAILURE")
+	}
+
+	selectVM := wam.NewWamState(wam.Test_select_builtinCode, wam.Test_select_builtinLabels)
+	selectVM.PC = wam.Test_select_builtinStartPC
+	if selectVM.Run() {
+		fmt.Println("SELECT_SUCCESS")
+	} else {
+		fmt.Println("SELECT_FAILURE")
 	}
 
 	reverseVM := wam.NewWamState(wam.Test_reverse_builtinCode, wam.Test_reverse_builtinLabels)
@@ -378,6 +408,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "TERM_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "MEMBER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "MEMBERCHK_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "SELECT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "REVERSE_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "LAST_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NTH_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM select builtin

## Summary

- Adds generated Go WAM runtime support for `select/3`.
- Registers `select/3` as a direct Go WAM builtin so compiled calls emit `BuiltinCall` instructions.
- Adds choicepoint-backed `select/3` enumeration so `findall/3` can observe each selected element/rest pair.
- Extends the generated Go builtin E2E test to cover direct first/middle/last selection, missing-element failure, empty-list failure, malformed-list failure, and `findall/3` enumeration.
- Updates the Go WAM parity audit to record the structural-list parity closure against the Clojure/C++ surface.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- direct emitter check for `select/3`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`
