### PR TITLE
feat(wam-clojure): wire string_to_atom builtin

### DIFF
--- a/PR_WAM_CLOJURE_STRING_TO_ATOM.md
+++ b/PR_WAM_CLOJURE_STRING_TO_ATOM.md
@@ -1,0 +1,20 @@
+# feat(wam-clojure): wire string_to_atom/2
+
+## Summary
+
+- Registers `string_to_atom/2` in the central WAM builtin table.
+- Adds direct lowered Clojure WAM recognition for `string_to_atom/2`.
+- Wires generated Clojure runtime dispatch through the existing atom/string conversion helper.
+- Extends lowered-emitter and runtime smoke coverage for forward, reverse, mismatch, and unbound-pair cases.
+
+## Notes
+
+- `string_to_atom/2` uses the same Clojure runtime helper as `atom_string/2`, with reversed argument roles.
+- This follows the current Clojure WAM scaffold convention where atom-like text and strings collapse to the same runtime representation.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -464,6 +464,10 @@ clojure_direct_builtin("atom_string/2", "2").
 clojure_direct_builtin("atom_string/2", 2).
 clojure_direct_builtin('atom_string/2', "2").
 clojure_direct_builtin('atom_string/2', 2).
+clojure_direct_builtin("string_to_atom/2", "2").
+clojure_direct_builtin("string_to_atom/2", 2).
+clojure_direct_builtin('string_to_atom/2', "2").
+clojure_direct_builtin('string_to_atom/2', 2).
 clojure_direct_builtin("string_codes/2", "2").
 clojure_direct_builtin("string_codes/2", 2).
 clojure_direct_builtin('string_codes/2', "2").
@@ -848,7 +852,9 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     format(atom(Expr), '(runtime/apply-text-conversion-solution ~w "~w")', [S, Op]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
-    (Op == "atom_string/2" ; Op == 'atom_string/2'),
+    (   Op == "atom_string/2" ; Op == 'atom_string/2'
+    ;   Op == "string_to_atom/2" ; Op == 'string_to_atom/2'
+    ),
     !,
     format(atom(Expr), '(runtime/apply-atom-string-solution ~w "~w")', [S, Op]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1515,6 +1515,7 @@ is_builtin_pred(put_code, 1).     % stdout: write one int code as char.
 is_builtin_pred(atomic_list_concat, 2). % concatenate list of atomics.
 is_builtin_pred(atomic_list_concat, 3). % concat with separator (or split).
 is_builtin_pred(atom_string, 2).        % atom ↔ string (interchangeable).
+is_builtin_pred(string_to_atom, 2).     % string ↔ atom (atom_string/2 argument order).
 is_builtin_pred(string_concat, 3).      % alias for atom_concat/3.
 is_builtin_pred(string_length, 2).      % alias for atom_length/2.
 is_builtin_pred(number_chars, 2).       % number ↔ list of single-char atoms.

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -2013,6 +2013,9 @@
           "atom_string/2"
           (apply-atom-string-solution state (:pred instr))
 
+          "string_to_atom/2"
+          (apply-atom-string-solution state (:pred instr))
+
           "string_codes/2"
           (apply-text-conversion-solution state (:pred instr))
 

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -714,6 +714,16 @@ test(simple_builtin_atom_string_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_string_to_atom_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_string_to_atom/2:\nbuiltin_call string_to_atom/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_string_to_atom/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_string_to_atom/2, WamCode, [], Code),
+        has(Code, "runtime/apply-atom-string-solution"),
+        has(Code, "string_to_atom/2"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_number_chars_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_number_chars/2:\nbuiltin_call number_chars/2, 2\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -150,6 +150,9 @@
 :- dynamic user:wam_atom_string_guard/2.
 :- dynamic user:wam_atom_string_reverse/0.
 :- dynamic user:wam_atom_string_unbound_pair/1.
+:- dynamic user:wam_string_to_atom_guard/2.
+:- dynamic user:wam_string_to_atom_reverse/0.
+:- dynamic user:wam_string_to_atom_unbound_pair/1.
 :- dynamic user:wam_string_codes_guard/2.
 :- dynamic user:wam_string_codes_reverse/0.
 :- dynamic user:wam_string_chars_guard/2.
@@ -347,6 +350,9 @@ user:wam_atom_chars_reverse :- atom_chars(A, [f,o,o]), A = foo.
 user:wam_atom_string_guard(A, S) :- atom_string(A, S).
 user:wam_atom_string_reverse :- atom_string(A, world), A = world.
 user:wam_atom_string_unbound_pair(_) :- user:wam_unbound_arg(A), user:wam_unbound_arg(S), atom_string(A, S).
+user:wam_string_to_atom_guard(S, A) :- string_to_atom(S, A).
+user:wam_string_to_atom_reverse :- string_to_atom(world, A), A = world.
+user:wam_string_to_atom_unbound_pair(_) :- user:wam_unbound_arg(S), user:wam_unbound_arg(A), string_to_atom(S, A).
 user:wam_string_codes_guard(A, C) :- string_codes(A, C).
 user:wam_string_codes_reverse :- string_codes(A, [102,111,111]), A = foo.
 user:wam_string_chars_guard(A, C) :- string_chars(A, C).
@@ -549,6 +555,9 @@ run_smoke :-
           user:wam_atom_string_guard/2,
           user:wam_atom_string_reverse/0,
           user:wam_atom_string_unbound_pair/1,
+          user:wam_string_to_atom_guard/2,
+          user:wam_string_to_atom_reverse/0,
+          user:wam_string_to_atom_unbound_pair/1,
           user:wam_string_codes_guard/2,
           user:wam_string_codes_reverse/0,
           user:wam_string_chars_guard/2,
@@ -905,6 +914,10 @@ smoke_cases([
     case('wam_atom_string_guard/2', args(hello, world), "false"),
     case('wam_atom_string_reverse/0', no_args, "true"),
     case('wam_atom_string_unbound_pair/1', a, "false"),
+    case('wam_string_to_atom_guard/2', args(hello, hello), "true"),
+    case('wam_string_to_atom_guard/2', args(hello, world), "false"),
+    case('wam_string_to_atom_reverse/0', no_args, "true"),
+    case('wam_string_to_atom_unbound_pair/1', a, "false"),
     case('wam_string_codes_guard/2', args(foo, '[102,111,111]'), "true"),
     case('wam_string_codes_guard/2', args(foo, '[102,111]'), "false"),
     case('wam_string_codes_reverse/0', no_args, "true"),
@@ -1274,6 +1287,7 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-atom-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-atom-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-atom-string-guard-2"),
+    has(CoreCode, "defn lowered-wam-string-to-atom-guard-2"),
     has(CoreCode, "defn lowered-wam-string-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-string-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-char-code-guard-2"),


### PR DESCRIPTION
## Summary

- Registers `string_to_atom/2` in the central WAM builtin table.
- Adds direct lowered Clojure WAM recognition for `string_to_atom/2`.
- Wires generated Clojure runtime dispatch through the existing atom/string conversion helper.
- Extends lowered-emitter and runtime smoke coverage for forward, reverse, mismatch, and unbound-pair cases.

## Notes

- `string_to_atom/2` uses the same Clojure runtime helper as `atom_string/2`, with reversed argument roles.
- This follows the current Clojure WAM scaffold convention where atom-like text and strings collapse to the same runtime representation.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
