### PR TITLE
feat(wam-python): add ISO error helpers

### DIFF
--- a/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
+++ b/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
@@ -63,7 +63,7 @@ Survey columns: shipped means code and tests exist in the target today.
 | Text-path rewrite coverage (`builtin_call`, `put_structure`, `call`, `execute`) | shipped | shipped | target-specific |
 | Audit predicate and report | `wam_cpp_iso_audit/3` | `wam_elixir_iso_audit/3` | not adopted |
 | `catch/3` + `throw/1` substrate | shipped | shipped | Python shipped; others mostly missing/partial |
-| Error constructors and `throw_iso_error` helper | shipped | shipped | not adopted |
+| Error constructors and `throw_iso_error` helper | shipped | shipped | Python shipped; others not adopted |
 | `is_iso/2` / `is_lax/2` | shipped | shipped | not adopted |
 | ISO/lax arithmetic compares | shipped | shipped | not adopted |
 | `succ_iso/2` / `succ_lax/2` | shipped | shipped | not adopted |
@@ -71,10 +71,11 @@ Survey columns: shipped means code and tests exist in the target today.
 
 The C++ and Elixir targets are therefore the current reference consumers. C++
 was the first implementation; Elixir proves the design is not C++-specific.
-Python has now adopted the catch/throw substrate, but it should not be described
-as ISO-error compatible until it also adopts error constructors, three-form
-builtin keys, and per-predicate rewrite. R, Lua, Haskell, Rust, and the
-remaining targets are still mostly missing or partial on this stack.
+Python has now adopted the catch/throw substrate plus the ISO error constructors
+and `throw_iso_error`, but it should not be described as ISO-error compatible
+until it also adopts three-form builtin keys and per-predicate rewrite. R, Lua,
+Haskell, Rust, and the remaining targets are still mostly missing or partial on
+this stack.
 
 ## What Counts As Adoption
 

--- a/docs/design/WAM_PYTHON_PARITY_AUDIT.md
+++ b/docs/design/WAM_PYTHON_PARITY_AUDIT.md
@@ -30,18 +30,19 @@ matters for parity.
 ## ISO Error Readiness
 
 Python is **not yet an ISO-error adopter**. It now has the Prolog-level
-`catch/3` and `throw/1` substrate plus the arithmetic and comparison builtin
-surface that would eventually receive `_iso` and `_lax` forms. It is still
-missing the ISO-specific error constructors, config/rewrite/audit plumbing, and
-ISO/lax builtin variants that the C++ and Elixir targets use.
+`catch/3` and `throw/1` substrate, ISO error-term constructors,
+`throw_iso_error`, and the arithmetic/comparison builtin surface that would
+eventually receive `_iso` and `_lax` forms. It is still missing the
+config/rewrite/audit plumbing and ISO/lax builtin variants that the C++ and
+Elixir targets use.
 
 Current state:
 
 | Component | Python status | Notes |
 | --- | --- | --- |
 | Prolog `catch/3` / `throw/1` | Present | Packaged runtime has side-stack catcher frames and generated-project E2E coverage. |
-| ISO error constructors | Missing | No runtime builders for `error(type_error(...), _)`, `error(instantiation_error, _)`, etc. |
-| `throw_iso_error` helper | Missing | Now unblocked by `catch/3` / `throw/1`. |
+| ISO error constructors | Present | Runtime builders exist for `instantiation_error`, `type_error/2`, `domain_error/2`, and `evaluation_error/1`. |
+| `throw_iso_error` helper | Present | Wraps `error(ErrorTerm, Context)` and routes through `throw/1`. |
 | `is_iso/2` / `is_lax/2` | Missing | Existing `is/2` catches `WAMError` and fails silently. |
 | ISO/lax arithmetic compares | Missing | Existing compares catch `WAMError` and fail silently. |
 | `succ/2` and ISO/lax variants | Missing | `succ/2` is not part of the current Python builtin baseline. |
@@ -69,22 +70,18 @@ instead of throwing a structured Prolog error. That is a good starting point for
 ## Recommended ISO Port Sequence
 
 Porting `is_iso/2` first was premature before `catch/3` / `throw/1` existed.
-That substrate is now present, so the remaining sequence is:
+That substrate and the ISO error helpers are now present, so the remaining
+sequence is:
 
-1. Add `error/2` constructors plus `make_type_error`,
-   `make_instantiation_error`, `make_domain_error`, and
-   `make_evaluation_error`.
-2. Add `throw_iso_error` and prove `catch(Goal, error(Pattern, _), Recovery)`
-   matches the constructed terms.
-3. Add shared-shape ISO config loading, per-predicate rewrite, and
+1. Add shared-shape ISO config loading, per-predicate rewrite, and
    `wam_python_iso_audit/3`.
-4. Add `is_iso/2` / `is_lax/2`, with explicit-lax bypass tests.
-5. Sweep arithmetic comparisons and add `succ/2` / `succ_iso/2` /
+2. Add `is_iso/2` / `is_lax/2`, with explicit-lax bypass tests.
+3. Sweep arithmetic comparisons and add `succ/2` / `succ_iso/2` /
    `succ_lax/2`.
 
-The next PR should therefore be an ISO error-constructor and `throw_iso_error`
-PR, not an arithmetic PR. The C++ and Elixir ISO tests provide a direct template
-for Python E2E coverage.
+The next PR should therefore be the generator-side ISO config/rewrite/audit
+plumbing, followed by `is_iso/2` / `is_lax/2`. The C++ and Elixir ISO tests
+provide a direct template for Python E2E coverage.
 
 ## Runtime Source Of Truth
 

--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -815,6 +815,32 @@ def _execute_throw(state: WamState) -> bool:
     raise WAMThrow(thrown)
 
 
+def make_instantiation_error(state: WamState) -> Term:
+    """Build the inner ISO instantiation_error term."""
+    return make_atom('instantiation_error')
+
+
+def make_type_error(state: WamState, expected: str, culprit: Term) -> Term:
+    """Build the inner ISO type_error(Expected, Culprit) term."""
+    return Compound('type_error/2', [make_atom(expected), deref(culprit, state)])
+
+
+def make_domain_error(state: WamState, domain: str, culprit: Term) -> Term:
+    """Build the inner ISO domain_error(Domain, Culprit) term."""
+    return Compound('domain_error/2', [make_atom(domain), deref(culprit, state)])
+
+
+def make_evaluation_error(state: WamState, kind: str) -> Term:
+    """Build the inner ISO evaluation_error(Kind) term."""
+    return Compound('evaluation_error/1', [make_atom(kind)])
+
+
+def throw_iso_error(state: WamState, err_term: Term) -> bool:
+    """Wrap an ISO error term as error(ErrorTerm, Context) and throw it."""
+    set_reg(state, 1, Compound('error/2', [err_term, state.fresh_var()]))
+    return _execute_throw(state)
+
+
 def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int = -1) -> bool:
     """Execute a WAM builtin_call instruction."""
     if builtin in ('catch/3', 'catch') and arity == 3:

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -374,6 +374,17 @@ test(static_runtime_run_wam_four_args, [nondet]) :-
 	read_file_to_string(SrcPath, Content, []),
 	sub_string(Content, _, _, _, "def run_wam(code").
 
+test(static_runtime_has_iso_error_helpers, [nondet]) :-
+	source_file(wam_python_target:compile_step_wam_to_python(_,_), ThisFile),
+	file_directory_name(ThisFile, ThisDir),
+	directory_file_path(ThisDir, 'wam_python_runtime/WamRuntime.py', SrcPath),
+	read_file_to_string(SrcPath, Content, []),
+	sub_string(Content, _, _, _, "def make_instantiation_error(state: WamState)"),
+	sub_string(Content, _, _, _, "def make_type_error(state: WamState, expected: str, culprit: Term)"),
+	sub_string(Content, _, _, _, "def make_domain_error(state: WamState, domain: str, culprit: Term)"),
+	sub_string(Content, _, _, _, "def make_evaluation_error(state: WamState, kind: str)"),
+	sub_string(Content, _, _, _, "def throw_iso_error(state: WamState, err_term: Term)").
+
 :- end_tests(wam_python_phase_b).
 
 % ============================================================================
@@ -902,6 +913,17 @@ test(generated_project_runs_catch_throw_builtins) :-
 		),
 		cleanup_tmp_dir(ProjectDir)).
 
+test(generated_runtime_catches_iso_helper_error_terms) :-
+	setup_call_cleanup(
+		unique_tmp_dir('tmp_wam_python_builtin_e2e', ProjectDir),
+		(   write_builtin_project(ProjectDir),
+			iso_helper_catch_script(Script),
+			run_python_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "foo")),
+			once(sub_string(Output, _, _, _, "zero_divisor"))
+		),
+		cleanup_tmp_dir(ProjectDir)).
+
 write_builtin_project(ProjectDir) :-
 	term_builtin_wam(TermWam),
 	copy_naf_io_wam(CopyNafIoWam),
@@ -1037,6 +1059,41 @@ catch_no_throw_wam(
   deallocate
   execute catch/3').
 
+iso_helper_catch_script(Script) :-
+	atomic_list_concat([
+		"import wam_runtime as wr",
+		"",
+		"def run_type_error():",
+		"    s = wr.WamState()",
+		"    wr.set_reg(s, 1, wr.Compound('throw_iso_type', []))",
+		"    wr.set_reg(s, 2, wr.Compound('error/2', [wr.Compound('type_error/2', [wr.make_atom('evaluable'), s.fresh_var()]), s.fresh_var()]))",
+		"    wr.set_reg(s, 3, wr.Compound('write/1', [wr.get_reg(s, 2).args[0].args[1]]))",
+		"    def builtin(name, arity, state, resume_ip=-1):",
+		"        if name in ('throw_iso_type', 'throw_iso_type/0'):",
+		"            return wr.throw_iso_error(state, wr.make_type_error(state, 'evaluable', wr.make_atom('foo')))",
+		"        return old_builtin(name, arity, state, resume_ip)",
+		"    wr._execute_builtin = builtin",
+		"    wr._execute_catch(s)",
+		"",
+		"def run_eval_error():",
+		"    s = wr.WamState()",
+		"    wr.set_reg(s, 1, wr.Compound('throw_iso_eval', []))",
+		"    wr.set_reg(s, 2, wr.Compound('error/2', [wr.Compound('evaluation_error/1', [s.fresh_var()]), s.fresh_var()]))",
+		"    wr.set_reg(s, 3, wr.Compound('write/1', [wr.get_reg(s, 2).args[0].args[0]]))",
+		"    def builtin(name, arity, state, resume_ip=-1):",
+		"        if name in ('throw_iso_eval', 'throw_iso_eval/0'):",
+		"            return wr.throw_iso_error(state, wr.make_evaluation_error(state, 'zero_divisor'))",
+		"        return old_builtin(name, arity, state, resume_ip)",
+		"    wr._execute_builtin = builtin",
+		"    wr._execute_catch(s)",
+		"",
+		"old_builtin = wr._execute_builtin",
+		"run_type_error()",
+		"print()",
+		"run_eval_error()",
+		""
+	], '\n', Script).
+
 run_generated_query(ProjectDir, Query, Output) :-
 	process_create(path(python), ['main.py', Query],
 		[cwd(ProjectDir), stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
@@ -1048,6 +1105,20 @@ run_generated_query(ProjectDir, Query, Output) :-
 	(   Status = exit(0)
 	->  true
 	;   format(user_error, 'generated WAM Python query ~w failed: ~w~n', [Query, ErrText]),
+		fail
+	).
+
+run_python_snippet(ProjectDir, Script, Output) :-
+	process_create(path(python), ['-c', Script],
+		[cwd(ProjectDir), stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+	read_string(Out, _, Output),
+	read_string(Err, _, ErrText),
+	close(Out),
+	close(Err),
+	process_wait(Pid, Status),
+	(   Status = exit(0)
+	->  true
+	;   format(user_error, 'generated WAM Python snippet failed: ~w~n', [ErrText]),
 		fail
 	).
 


### PR DESCRIPTION
## Summary

Adds the Python WAM runtime ISO error-term helper layer now that the `catch/3` and `throw/1` substrate is available.

## Changes

- Add Python runtime constructors for:
  - `instantiation_error`
  - `type_error/2`
  - `domain_error/2`
  - `evaluation_error/1`
- Add `throw_iso_error`, which wraps an inner ISO error term as `error(ErrorTerm, Context)` and routes through the existing WAM `throw/1` path.
- Add Python WAM tests proving the helpers are present in the packaged runtime and that helper-built errors can be caught through `catch/3`.
- Update Python parity and cross-target ISO status docs to mark the helper layer as present while keeping Python classified as not yet fully ISO-error compatible until config/rewrite/audit and ISO/lax builtin variants land.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_python_target.pl`
- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `git diff --check`

## Notes

This is an incremental readiness step. Python now has the runtime pieces needed to throw structured ISO-style errors, but the target still needs generator-side ISO config/rewrite/audit plumbing and ISO/lax builtin variants before it should be described as ISO-error compatible.
