### PR TITLE
feat(wam-python): add ISO config rewrite plumbing

### DIFF
--- a/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
+++ b/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
@@ -57,11 +57,11 @@ Survey columns: shipped means code and tests exist in the target today.
 
 | Component | C++ | Elixir | Other WAM targets |
 |---|---|---|---|
-| Prolog config loader (`iso_errors_config/1`, inline overrides) | shipped | shipped | not adopted |
-| Bare-PI multi-module warning | shipped | shipped | not adopted |
-| Per-predicate default rewrite | shipped | shipped | not adopted |
+| Prolog config loader (`iso_errors_config/1`, inline overrides) | shipped | shipped | Python plumbing shipped; other targets not adopted |
+| Bare-PI multi-module warning | shipped | shipped | Python plumbing shipped; other targets not adopted |
+| Per-predicate default rewrite | shipped | shipped | Python plumbing shipped; other targets not adopted |
 | Text-path rewrite coverage (`builtin_call`, `put_structure`, `call`, `execute`) | shipped | shipped | target-specific |
-| Audit predicate and report | `wam_cpp_iso_audit/3` | `wam_elixir_iso_audit/3` | not adopted |
+| Audit predicate and report | `wam_cpp_iso_audit/3` | `wam_elixir_iso_audit/3` | `wam_python_iso_audit/3`; others not adopted |
 | `catch/3` + `throw/1` substrate | shipped | shipped | Python shipped; others mostly missing/partial |
 | Error constructors and `throw_iso_error` helper | shipped | shipped | Python shipped; others not adopted |
 | `is_iso/2` / `is_lax/2` | shipped | shipped | not adopted |
@@ -71,9 +71,10 @@ Survey columns: shipped means code and tests exist in the target today.
 
 The C++ and Elixir targets are therefore the current reference consumers. C++
 was the first implementation; Elixir proves the design is not C++-specific.
-Python has now adopted the catch/throw substrate plus the ISO error constructors
-and `throw_iso_error`, but it should not be described as ISO-error compatible
-until it also adopts three-form builtin keys and per-predicate rewrite. R, Lua,
+Python has now adopted the catch/throw substrate, ISO error constructors,
+`throw_iso_error`, and per-predicate config/rewrite/audit plumbing, but it
+should not be described as ISO-error compatible until it also adopts three-form
+builtin keys for concrete builtins. R, Lua,
 Haskell, Rust, and the remaining targets are still mostly missing or partial on
 this stack.
 

--- a/docs/design/WAM_PYTHON_PARITY_AUDIT.md
+++ b/docs/design/WAM_PYTHON_PARITY_AUDIT.md
@@ -46,9 +46,9 @@ Current state:
 | `is_iso/2` / `is_lax/2` | Missing | Existing `is/2` catches `WAMError` and fails silently. |
 | ISO/lax arithmetic compares | Missing | Existing compares catch `WAMError` and fail silently. |
 | `succ/2` and ISO/lax variants | Missing | `succ/2` is not part of the current Python builtin baseline. |
-| Per-predicate ISO config loader | Missing | No `iso_errors_config/1` or inline `iso_errors(PI, Mode)` handling. |
-| Per-predicate default rewrite | Missing | No Python analogue of C++/Elixir `iso_errors_rewrite/4`. |
-| ISO audit predicate | Missing | No `wam_python_iso_audit/3`. |
+| Per-predicate ISO config loader | Present | Supports `iso_errors_config(File)`, `iso_errors(Default)`, and `iso_errors(PI, Mode)` options. |
+| Per-predicate default rewrite | Present | `iso_errors_rewrite/4` plus text-level rewrite are wired before interpreter and lowered emission; key tables remain empty until ISO/lax builtin variants land. |
+| ISO audit predicate | Present | `wam_python_iso_audit/3` reports builtin call sites using the shared audit shape. |
 
 The packaged runtime is the main implementation surface to update:
 
@@ -79,8 +79,9 @@ sequence is:
 3. Sweep arithmetic comparisons and add `succ/2` / `succ_iso/2` /
    `succ_lax/2`.
 
-The next PR should therefore be the generator-side ISO config/rewrite/audit
-plumbing, followed by `is_iso/2` / `is_lax/2`. The C++ and Elixir ISO tests
+The next PR should therefore add `is_iso/2` / `is_lax/2`, populate
+the Python ISO/lax rewrite key table for `is/2`, and keep explicit-lax bypass
+tests. The C++ and Elixir ISO tests
 provide a direct template for Python E2E coverage.
 
 ## Runtime Source Of Truth

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -28,7 +28,15 @@
 	wam_instruction_to_python_literal/2,   % +WamInstr, -PyLiteral
 	wam_line_to_python_literal/2,          % +Parts, -PyLit
 	write_wam_python_project/3,            % +Predicates, +Options, +ProjectDir
-	emit_wam_python/3                      % +Predicates, +Options, +Mode
+	emit_wam_python/3,                     % +Predicates, +Options, +Mode
+	iso_errors_resolve_options/2,          % +Options, -Config
+	iso_errors_load_config/2,              % +File, -Config
+	iso_errors_mode_for/3,                 % +Config, +PI, -Mode
+	iso_errors_warn_multi_module/2,        % +Config, +Predicates
+	iso_errors_rewrite/4,                  % +Config, +PI, +Items0, -Items
+	iso_errors_rewrite_text/4,             % +Config, +PI, +WamText0, -WamText
+	wam_python_iso_audit/3,                % +Predicates, +Options, -Audit
+	wam_python_iso_audit_report/1          % +Audit
 ]).
 
 :- use_module(library(lists)).
@@ -1325,6 +1333,321 @@ compile_wam_runtime_to_python(_Options, PythonCode) :-
 	static_runtime_source_path(SrcPath),
 	read_file_to_string(SrcPath, PythonCode, []).
 
+
+% ============================================================================
+% ISO Error Configuration And Rewrite Plumbing
+% ============================================================================
+
+% Python has catch/throw plus ISO error constructors. The config and rewrite
+% layer is wired now, while key tables remain empty until the first Python
+% ISO/lax builtin variants land.
+:- dynamic iso_errors_default_to_iso/2.
+:- dynamic iso_errors_default_to_lax/2.
+
+%% iso_errors_resolve_options(+Options, -Config)
+%  Merges optional file config with inline options into iso_config(Default,
+%  Overrides). Inline options override file entries for the same PI.
+iso_errors_resolve_options(Options, iso_config(Default, Overrides)) :-
+	(   option(iso_errors_config(File), Options)
+	->  iso_errors_load_config(File, iso_config(FileDefault, FileOv))
+	;   FileDefault = false, FileOv = []
+	),
+	iso_errors_inline_default(Options, FileDefault, Default),
+	iso_errors_inline_overrides(Options, InlineOv),
+	iso_errors_merge_overrides(FileOv, InlineOv, Overrides).
+
+iso_errors_inline_default(Options, FileDefault, Default) :-
+	(   member(iso_errors(M), Options),
+		(M == true ; M == false)
+	->  Default = M
+	;   Default = FileDefault
+	).
+
+iso_errors_inline_overrides(Options, InlineOv) :-
+	findall(PI-Mode,
+		( member(iso_errors(PI, Mode), Options),
+		  (Mode == true ; Mode == false),
+		  iso_errors_valid_pi(PI)
+		),
+		InlineOv).
+
+iso_errors_valid_pi(Name/Arity) :- atom(Name), integer(Arity), Arity >= 0, !.
+iso_errors_valid_pi(Module:Name/Arity) :-
+	atom(Module), atom(Name), integer(Arity), Arity >= 0.
+
+iso_errors_merge_overrides(FileOv, InlineOv, Merged) :-
+	exclude(iso_errors_shadowed(InlineOv), FileOv, Kept),
+	append(Kept, InlineOv, Merged).
+
+iso_errors_shadowed(InlineOv, PI-_) :-
+	member(InlinePI-_, InlineOv),
+	iso_errors_pi_matches(InlinePI, PI), !.
+
+iso_errors_pi_matches(PI, PI) :- !.
+iso_errors_pi_matches(Name/Arity, _:Name/Arity) :-
+	atom(Name), integer(Arity), !.
+iso_errors_pi_matches(_:Name/Arity, Name/Arity) :-
+	atom(Name), integer(Arity), !.
+
+%% iso_errors_load_config(+File, -Config)
+%  Reads iso_errors_default/1 and iso_errors_override/2 facts. Unknown facts
+%  and I/O failures are ignored, yielding iso_config(false, []).
+iso_errors_load_config(File, iso_config(Default, Overrides)) :-
+	catch(
+		setup_call_cleanup(
+			open(File, read, Stream),
+			iso_errors_read_terms(Stream, RawTerms),
+			close(Stream)),
+		_,
+		RawTerms = []),
+	iso_errors_extract_terms(RawTerms, false, [], Default, RevOv),
+	reverse(RevOv, Overrides).
+
+iso_errors_read_terms(Stream, Terms) :-
+	read_term(Stream, T, []),
+	(   T == end_of_file
+	->  Terms = []
+	;   Terms = [T|Rest],
+		iso_errors_read_terms(Stream, Rest)
+	).
+
+iso_errors_extract_terms([], D, Ov, D, Ov).
+iso_errors_extract_terms([T|Rest], D0, Ov0, D, Ov) :-
+	(   T = iso_errors_default(NewD), (NewD == true ; NewD == false)
+	->  iso_errors_extract_terms(Rest, NewD, Ov0, D, Ov)
+	;   T = iso_errors_override(PI, Mode),
+		(Mode == true ; Mode == false),
+		iso_errors_valid_pi(PI)
+	->  iso_errors_extract_terms(Rest, D0, [PI-Mode|Ov0], D, Ov)
+	;   iso_errors_extract_terms(Rest, D0, Ov0, D, Ov)
+	).
+
+%% iso_errors_mode_for(+Config, +PI, -Mode)
+iso_errors_mode_for(iso_config(Default, Overrides), PI, Mode) :-
+	(   member(OvPI-OvMode, Overrides),
+		iso_errors_pi_matches(OvPI, PI)
+	->  Mode = OvMode
+	;   Mode = Default
+	).
+
+%% iso_errors_warn_multi_module(+Config, +Predicates)
+%  Warns when a bare override matches predicates from multiple modules.
+iso_errors_warn_multi_module(iso_config(_, Overrides), Predicates) :-
+	forall(member(OvPI-_, Overrides),
+	       iso_errors_check_override_scope(OvPI, Predicates)).
+
+iso_errors_check_override_scope(Name/Arity, Predicates) :-
+	atom(Name), integer(Arity), !,
+	findall(M, ( member(P, Predicates),
+	             iso_errors_pi_module(P, Name, Arity, M)
+	           ), Modules),
+	list_to_set(Modules, Unique),
+	(   Unique = [_, _ | _]
+	->  length(Unique, N),
+		format(user_error,
+		       'Warning: iso_errors_override(~w/~w, _) matches ~w predicates~n         in different modules (~w).~n         Qualify with `mod:~w/~w` for module-scoped overrides.~n',
+		       [Name, Arity, N, Unique, Name, Arity])
+	;   true
+	).
+iso_errors_check_override_scope(_, _).
+
+iso_errors_pi_module(Module:Name/Arity, Name, Arity, Module) :- !.
+iso_errors_pi_module(Name/Arity, Name, Arity, user).
+iso_errors_pi_module(Pred/Arity-_, Name, Arity, user) :-
+	atom(Pred), Pred = Name, !.
+
+%% iso_errors_rewrite(+Config, +PI, +Items0, -Items)
+%  Item-level rewrite API shared with C++/Elixir. Python currently uses the
+%  text-level wrapper below because both interpreter and lowered paths start
+%  from WAM text.
+iso_errors_rewrite(Config, PI, Items0, Items) :-
+	iso_errors_mode_for(Config, PI, Mode),
+	maplist(iso_errors_rewrite_item(Mode), Items0, Items).
+
+iso_errors_rewrite_item(true, builtin_call(Key, N), builtin_call(IsoKey, N)) :-
+	iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(true, put_structure(Key, Reg), put_structure(IsoKey, Reg)) :-
+	iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(true, call(Key, N), call(IsoKey, N)) :-
+	iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(true, execute(Key), execute(IsoKey)) :-
+	iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(false, builtin_call(Key, N), builtin_call(LaxKey, N)) :-
+	iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(false, put_structure(Key, Reg), put_structure(LaxKey, Reg)) :-
+	iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(false, call(Key, N), call(LaxKey, N)) :-
+	iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(false, execute(Key), execute(LaxKey)) :-
+	iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(_, Item, Item).
+
+iso_errors_rewrite_plans(Config, Plans0, Plans) :-
+	maplist(iso_errors_rewrite_plan(Config), Plans0, Plans).
+
+iso_errors_rewrite_plan(Config, pred_plan(Pred, Arity, Wam0, wam), pred_plan(Pred, Arity, Wam, wam)) :-
+	!,
+	iso_errors_rewrite_text(Config, Pred/Arity, Wam0, Wam).
+iso_errors_rewrite_plan(_, Plan, Plan).
+
+%% iso_errors_rewrite_text(+Config, +PI, +WamText, -RewrittenText)
+iso_errors_rewrite_text(Config, PI, WamText, RewrittenText) :-
+	iso_errors_mode_for(Config, PI, Mode),
+	(   Mode == false,
+	    \+ iso_errors_has_lax_entries
+	->  RewrittenText = WamText
+	;   atom_string(WamText, S),
+		split_string(S, "\n", "", Lines),
+		maplist(iso_errors_rewrite_line(Mode), Lines, RewrittenLines),
+		atomic_list_concat(RewrittenLines, '\n', RewrittenText)
+	).
+
+iso_errors_has_lax_entries :- iso_errors_default_to_lax(_, _), !.
+
+iso_errors_rewrite_line(Mode, Line, OutLine) :-
+	split_string(Line, " \t", " \t", Parts0),
+	exclude(==(""), Parts0, Parts),
+	(   iso_errors_rewrite_parts(Mode, Parts, Line, OutLine)
+	->  true
+	;   OutLine = Line
+	).
+
+iso_errors_rewrite_parts(Mode, ["builtin_call", Key0 | _], Line, OutLine) :- !,
+	iso_errors_clean_key_token(Key0, Key),
+	iso_errors_lookup(Mode, Key, NewKey),
+	Key \== NewKey,
+	iso_errors_splice_line(Line, Key, NewKey, OutLine).
+iso_errors_rewrite_parts(Mode, ["put_structure", Key0 | _], Line, OutLine) :- !,
+	iso_errors_clean_key_token(Key0, Key),
+	iso_errors_lookup(Mode, Key, NewKey),
+	Key \== NewKey,
+	iso_errors_splice_line(Line, Key, NewKey, OutLine).
+iso_errors_rewrite_parts(Mode, ["call", Key0 | _], Line, OutLine) :- !,
+	iso_errors_clean_key_token(Key0, Key),
+	iso_errors_lookup(Mode, Key, NewKey),
+	Key \== NewKey,
+	iso_errors_splice_line(Line, Key, NewKey, OutLine).
+iso_errors_rewrite_parts(Mode, ["execute", Key0 | _], Line, OutLine) :- !,
+	iso_errors_clean_key_token(Key0, Key),
+	iso_errors_lookup(Mode, Key, NewKey),
+	Key \== NewKey,
+	iso_errors_splice_line(Line, Key, NewKey, OutLine).
+
+iso_errors_clean_key_token(Token0, Token) :-
+	(   string_concat(Token, ",", Token0)
+	->  true
+	;   Token = Token0
+	).
+
+iso_errors_lookup(true, Key, NewKey) :-
+	iso_errors_default_to_iso(Key, NewKey), !.
+iso_errors_lookup(false, Key, NewKey) :-
+	iso_errors_default_to_lax(Key, NewKey), !.
+iso_errors_lookup(_, Key, Key).
+
+iso_errors_splice_line(Line, Key, NewKey, OutLine) :-
+	sub_string(Line, Before, KLen, _After, Key),
+	string_length(Key, KLen),
+	sub_string(Line, 0, Before, _, Pre),
+	PostStart is Before + KLen,
+	sub_string(Line, PostStart, _, 0, Post),
+	string_concat(Pre, NewKey, T1),
+	string_concat(T1, Post, OutLine), !.
+
+%% wam_python_iso_audit(+Predicates, +Options, -Audit)
+wam_python_iso_audit(Predicates, Options, Audit) :-
+	iso_errors_resolve_options(Options, Config),
+	findall(audit(PI, Mode, Sites), (
+		member(P, Predicates),
+		iso_errors_audit_normalise_pi(P, PI),
+		iso_errors_mode_for(Config, PI, Mode),
+		iso_errors_audit_predicate(PI, Mode, Sites)
+	), Audit).
+
+iso_errors_audit_normalise_pi(Pred/Arity-_, Pred/Arity) :- !.
+iso_errors_audit_normalise_pi(Module:Pred/Arity, Module:Pred/Arity) :- !.
+iso_errors_audit_normalise_pi(PI, PI).
+
+iso_errors_audit_predicate(PI, Mode, Sites) :-
+	(   catch(
+		    ( iso_errors_audit_wam_for_pi(PI, WamText),
+		      iso_errors_audit_parse_lines(WamText, Items)
+		    ),
+		    _, fail)
+	->  iso_errors_audit_walk(Items, 0, Mode, [], SitesRev),
+		reverse(SitesRev, Sites)
+	;   Sites = []
+	).
+
+iso_errors_audit_wam_for_pi(Module:Pred/Arity, WamText) :- !,
+	compile_predicate_to_wam(Module:Pred/Arity, [], WamText).
+iso_errors_audit_wam_for_pi(Pred/Arity, WamText) :-
+	compile_predicate_to_wam(Pred/Arity, [], WamText).
+
+iso_errors_audit_parse_lines(WamText, Items) :-
+	atom_string(WamText, S),
+	split_string(S, "\n", "", Lines),
+	maplist(iso_errors_audit_parse_one, Lines, MaybeItems),
+	exclude(==(skip), MaybeItems, Items).
+
+iso_errors_audit_parse_one(Line, Item) :-
+	split_string(Line, " \t", " \t", Parts0),
+	exclude(==(""), Parts0, Parts),
+	iso_errors_audit_classify_line(Parts, Item).
+
+iso_errors_audit_classify_line([], skip).
+iso_errors_audit_classify_line([Tok], label) :-
+	string_concat(_, ":", Tok), !.
+iso_errors_audit_classify_line(["builtin_call", Key0 | _], builtin_call(Key, 0)) :- !,
+	iso_errors_clean_key_token(Key0, Key).
+iso_errors_audit_classify_line(_, other).
+
+iso_errors_audit_walk([], _, _, Acc, Acc).
+iso_errors_audit_walk([label|Rest], PC, Mode, Acc, Out) :- !,
+	iso_errors_audit_walk(Rest, PC, Mode, Acc, Out).
+iso_errors_audit_walk([builtin_call(Key, _)|Rest], PC, Mode, Acc, Out) :- !,
+	iso_errors_audit_classify(Key, Mode, Source, Resolved, Flip),
+	PC1 is PC + 1,
+	iso_errors_audit_walk(Rest, PC1, Mode, [site(PC, Key, Resolved, Source, Flip)|Acc], Out).
+iso_errors_audit_walk([_|Rest], PC, Mode, Acc, Out) :-
+	PC1 is PC + 1,
+	iso_errors_audit_walk(Rest, PC1, Mode, Acc, Out).
+
+iso_errors_audit_classify(Key, _Mode, explicit_iso, Key, false) :-
+	iso_errors_key_has_suffix(Key, "_iso"), !.
+iso_errors_audit_classify(Key, _Mode, explicit_lax, Key, false) :-
+	iso_errors_key_has_suffix(Key, "_lax"), !.
+iso_errors_audit_classify(Key, Mode, default, Resolved, Flip) :-
+	iso_errors_resolve_default(Key, Mode, Resolved),
+	iso_errors_other_mode(Mode, OtherMode),
+	iso_errors_resolve_default(Key, OtherMode, OtherResolved),
+	( Resolved == OtherResolved -> Flip = false ; Flip = true ).
+
+iso_errors_resolve_default(Key, true, IsoKey) :-
+	iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_resolve_default(Key, false, LaxKey) :-
+	iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_resolve_default(Key, _, Key).
+
+iso_errors_other_mode(true, false).
+iso_errors_other_mode(false, true).
+
+iso_errors_key_has_suffix(Key, Suffix) :-
+	( atom(Key) -> atom_string(Key, KS) ; KS = Key ),
+	split_string(KS, "/", "", [Name | _]),
+	string_concat(_, Suffix, Name).
+
+wam_python_iso_audit_report([]).
+wam_python_iso_audit_report([audit(PI, Mode, Sites)|Rest]) :-
+	format('~w [~w]~n', [PI, Mode]),
+	(   Sites == []
+	->  format('  (no builtin_call sites)~n', [])
+	;   forall(member(site(PC, Orig, Res, Src, Flip), Sites),
+	           format('  pc=~w  ~w -> ~w  (~w)  flip-changes=~w~n',
+	                  [PC, Orig, Res, Src, Flip]))
+	),
+	wam_python_iso_audit_report(Rest).
+
 % ============================================================================
 % PHASE 7: Project Generation
 % ============================================================================
@@ -1412,7 +1735,10 @@ compile_all_predicates(Predicates, Options, Code) :-
 	python_runtime_parser_mode_literal(RuntimeParserMode, RuntimeParserModeCode),
 	format(string(RuntimeParserLine), 'RUNTIME_PARSER = ~w~n~n',
 	       [RuntimeParserModeCode]),
-	plan_python_predicates(Predicates, Options, Plans),
+	iso_errors_resolve_options(Options, IsoConfig),
+	iso_errors_warn_multi_module(IsoConfig, Predicates),
+	plan_python_predicates(Predicates, Options, Plans0),
+	iso_errors_rewrite_plans(IsoConfig, Plans0, Plans),
 	lowered_route_set(Plans, Options, LoweredSet),
 	maplist(compile_planned_predicate(Options, LoweredSet), Plans, PredCodes),
 	% Collect function names for build_program() registry

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -385,7 +385,105 @@ test(static_runtime_has_iso_error_helpers, [nondet]) :-
 	sub_string(Content, _, _, _, "def make_evaluation_error(state: WamState, kind: str)"),
 	sub_string(Content, _, _, _, "def throw_iso_error(state: WamState, err_term: Term)").
 
+
 :- end_tests(wam_python_phase_b).
+
+% ============================================================================
+% ISO error config/rewrite plumbing
+% ============================================================================
+
+:- begin_tests(wam_python_iso_errors_config).
+
+test(iso_errors_config_loader_basic) :-
+	iso_errors_temp_config_file(Path, [
+		'iso_errors_default(true).',
+		'iso_errors_override(legacy_lookup/3, false).',
+		'iso_errors_override(experimental:my_pred/2, true).',
+		'ignored_fact(ok).'
+	]),
+	setup_call_cleanup(
+		true,
+		(   wam_python_target:iso_errors_load_config(Path, Config),
+			assertion(Config == iso_config(true,
+				[legacy_lookup/3-false,
+				 (experimental:my_pred/2)-true])),
+			wam_python_target:iso_errors_mode_for(Config, user:legacy_lookup/3, M1),
+			assertion(M1 == false),
+			wam_python_target:iso_errors_mode_for(Config, user:never_listed/2, M2),
+			assertion(M2 == true),
+			wam_python_target:iso_errors_mode_for(Config, experimental:my_pred/2, M3),
+			assertion(M3 == true)
+		),
+		delete_file(Path)).
+
+test(iso_errors_inline_wins_over_file) :-
+	iso_errors_temp_config_file(Path, [
+		'iso_errors_default(false).',
+		'iso_errors_override(legacy_lookup/3, false).'
+	]),
+	setup_call_cleanup(
+		true,
+		(   wam_python_target:iso_errors_resolve_options(
+				[iso_errors_config(Path), iso_errors(true), iso_errors(legacy_lookup/3, true)],
+				Config),
+			wam_python_target:iso_errors_mode_for(Config, user:legacy_lookup/3, M1),
+			assertion(M1 == true),
+			wam_python_target:iso_errors_mode_for(Config, user:never_listed/2, M2),
+			assertion(M2 == true)
+		),
+		delete_file(Path)).
+
+test(iso_errors_text_rewrite_uses_dynamic_key_tables) :-
+	setup_call_cleanup(
+		(   assertz(wam_python_target:iso_errors_default_to_iso("is/2", "is_iso/2"), IsoRef),
+			assertz(wam_python_target:iso_errors_default_to_lax("is/2", "is_lax/2"), LaxRef)
+		),
+		(   Config = iso_config(true, []),
+			Wam0 = 'demo/0:\n  put_structure is/2, 1\n  builtin_call is/2 2\n  call is/2, 2\n  execute is/2',
+			wam_python_target:iso_errors_rewrite_text(Config, demo/0, Wam0, Wam),
+			assertion(sub_string(Wam, _, _, _, "put_structure is_iso/2, 1")),
+			assertion(sub_string(Wam, _, _, _, "builtin_call is_iso/2 2")),
+			assertion(sub_string(Wam, _, _, _, "call is_iso/2, 2")),
+			assertion(sub_string(Wam, _, _, _, "execute is_iso/2"))
+		),
+		(   erase(IsoRef),
+			erase(LaxRef)
+		)).
+
+test(iso_errors_project_generation_rewrites_wam_text) :-
+	setup_call_cleanup(
+		(   assertz(wam_python_target:iso_errors_default_to_iso("is/2", "is_iso/2"), IsoRef),
+			user:python_parser_tmp_dir('tmp_wam_python_iso_rewrite', ProjectDir)
+		),
+		(   Wam = 'iso_rewrite_demo/0:\n  put_variable 4, 1\n  put_integer 1, 2\n  builtin_call is/2 2\n  proceed',
+			wam_python_target:write_wam_python_project([iso_rewrite_demo/0-Wam], [iso_errors(true)], ProjectDir),
+			directory_file_path(ProjectDir, 'predicates.py', PredicatesPath),
+			read_file_to_string(PredicatesPath, Code, []),
+			assertion(sub_string(Code, _, _, _, '"is_iso/2", 2')),
+			\+ sub_string(Code, _, _, _, '"is/2", 2')
+		),
+		(   erase(IsoRef),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
+test(iso_errors_audit_structure) :-
+	wam_python_target:wam_python_iso_audit(
+		[user:py_iso_audit_pred/0],
+		[iso_errors(py_iso_audit_pred/0, true)],
+		Audit),
+	assertion(Audit = [audit(user:py_iso_audit_pred/0, true, _Sites)]).
+
+:- dynamic user:py_iso_audit_pred/0.
+user:py_iso_audit_pred :- X is 1 + 2, X = 3.
+
+iso_errors_temp_config_file(Path, Lines) :-
+	tmp_file('tmp_wam_python_iso_cfg', Path),
+	setup_call_cleanup(
+		open(Path, write, Out),
+		forall(member(L, Lines), format(Out, '~w~n', [L])),
+		close(Out)).
+
+:- end_tests(wam_python_iso_errors_config).
 
 % ============================================================================
 % Runtime parser capability metadata and validation


### PR DESCRIPTION
## Summary

Adds the Python WAM generator-side ISO error configuration, rewrite, and audit layer. This ports the shared C++/Elixir ISO plumbing shape to Python while keeping behavior neutral until concrete Python ISO/lax builtin variants are added.

## Changes

- Add Python ISO config APIs:
  - `iso_errors_load_config/2`
  - `iso_errors_resolve_options/2`
  - `iso_errors_mode_for/3`
  - `iso_errors_warn_multi_module/2`
- Add `iso_errors_rewrite/4` and `iso_errors_rewrite_text/4` for the Python target.
- Wire WAM text rewrite before both interpreter emission and lowered emission, so both Python WAM modes use the same resolved builtin keys.
- Add `wam_python_iso_audit/3` and `wam_python_iso_audit_report/1` using the shared audit shape.
- Add tests for config loading, inline override precedence, dynamic key-table rewrite behavior, generated project rewrite wiring, and audit structure.
- Update Python parity and cross-target ISO status docs.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_python_target.pl`
- `git diff --check`

## Notes

This PR intentionally does not make Python fully ISO-error compatible yet. The rewrite key tables remain behavior-neutral until the next slice adds concrete Python ISO/lax builtin variants, starting with `is_iso/2` and `is_lax/2`.
