### PR TITLE
feat(wam-clojure): wire atom_number/2

### DIFF
--- a/PR_WAM_CLOJURE_ATOM_NUMBER.md
+++ b/PR_WAM_CLOJURE_ATOM_NUMBER.md
@@ -1,0 +1,20 @@
+# PR Title
+
+feat(wam-clojure): wire atom_number/2
+
+# PR Description
+
+## Summary
+
+- Registers `atom_number/2` as a WAM builtin.
+- Adds direct lowered Clojure emission for `atom_number/2` through `runtime/apply-atom-number-solution`.
+- Implements Clojure runtime support for atom-to-number and number-to-atom conversion.
+- Tightens bound/bound text-conversion handling so numeric-looking generated WAM literals compare by normalized text instead of accidental host-term shape.
+- Adds lowered-emitter and runtime smoke coverage for forward, reverse, failure, and unbound `atom_number/2` cases.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -464,6 +464,10 @@ clojure_direct_builtin("atom_string/2", "2").
 clojure_direct_builtin("atom_string/2", 2).
 clojure_direct_builtin('atom_string/2', "2").
 clojure_direct_builtin('atom_string/2', 2).
+clojure_direct_builtin("atom_number/2", "2").
+clojure_direct_builtin("atom_number/2", 2).
+clojure_direct_builtin('atom_number/2', "2").
+clojure_direct_builtin('atom_number/2', 2).
 clojure_direct_builtin("string_to_atom/2", "2").
 clojure_direct_builtin("string_to_atom/2", 2).
 clojure_direct_builtin('string_to_atom/2', "2").
@@ -857,6 +861,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     ),
     !,
     format(atom(Expr), '(runtime/apply-atom-string-solution ~w "~w")', [S, Op]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "atom_number/2" ; Op == 'atom_number/2'),
+    !,
+    format(atom(Expr), '(runtime/apply-atom-number-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "char_code/2" ; Op == 'char_code/2'),

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1539,6 +1539,7 @@ is_builtin_pred(put_code, 1).     % stdout: write one int code as char.
 is_builtin_pred(atomic_list_concat, 2). % concatenate list of atomics.
 is_builtin_pred(atomic_list_concat, 3). % concat with separator (or split).
 is_builtin_pred(atom_string, 2).        % atom ↔ string (interchangeable).
+is_builtin_pred(atom_number, 2).        % atom <-> number via decimal text.
 is_builtin_pred(string_to_atom, 2).     % string ↔ atom (atom_string/2 argument order).
 is_builtin_pred(string_concat, 3).      % alias for atom_concat/3.
 is_builtin_pred(string_length, 2).      % alias for atom_length/2.

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -957,6 +957,18 @@
   (when (number? value)
     (str value)))
 
+(declare parse-number-text)
+
+(defn atom-number-text [state value]
+  (or (atom-text state value)
+      (number-text value)))
+
+(defn atom-number-value [state value]
+  (cond
+    (number? value) value
+    :else (when-let [text (atom-text state value)]
+            (parse-number-text text))))
+
 (defn intern-text-atom [state text]
   (let [[ctx id] (intern-atom (:intern-context state) text)]
     [(assoc state :intern-context ctx) (atom-term id)]))
@@ -976,8 +988,6 @@
 (defn char-list-term [state text]
   (let [[next-state chars] (intern-char-terms state text)]
     [next-state (list->term (:intern-context next-state) chars)]))
-
-(declare parse-number-text)
 
 (defn code-point-value [state value]
   (cond
@@ -1016,6 +1026,11 @@
         value-text (if atom? (atom-text state left) (number-text left))
         list-text (if codes? (code-list-text state right) (char-list-text state right))]
     (cond
+      (and (some? value-text) (some? list-text))
+      (if (= value-text list-text)
+        (advance state)
+        (backtrack state))
+
       (some? value-text)
       (let [[next-state list-term] (if codes?
                                      (code-list-term state value-text)
@@ -1066,6 +1081,31 @@
 
       (some? string-text-value)
       (let [[ok unified-state] (unify-text-atom-value state atom-value string-text-value)]
+        (if ok
+          (advance unified-state)
+          (backtrack state)))
+
+      :else
+      (backtrack state))))
+
+(defn apply-atom-number-solution [state]
+  (let [atom-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        number-value (deref-value (:bindings state)
+                                  (or (reg-get-raw state "A2") ::unbound))
+        atom-text-value (atom-number-text state atom-value)
+        parsed-number-value (atom-number-value state number-value)]
+    (cond
+      (some? atom-text-value)
+      (if-let [parsed-number (parse-number-text atom-text-value)]
+        (let [[ok unified-state] (unify-values state number-value parsed-number)]
+          (if ok
+            (advance unified-state)
+            (backtrack state)))
+        (backtrack state))
+
+      (some? parsed-number-value)
+      (let [[ok unified-state] (unify-text-atom-value state atom-value (str parsed-number-value))]
         (if ok
           (advance unified-state)
           (backtrack state)))
@@ -2012,6 +2052,9 @@
 
           "atom_string/2"
           (apply-atom-string-solution state (:pred instr))
+
+          "atom_number/2"
+          (apply-atom-number-solution state)
 
           "string_to_atom/2"
           (apply-atom-string-solution state (:pred instr))

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -714,6 +714,16 @@ test(simple_builtin_atom_string_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_atom_number_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_atom_number/2:\nbuiltin_call atom_number/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_atom_number/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_atom_number/2, WamCode, [], Code),
+        has(Code, "runtime/apply-atom-number-solution"),
+        has(Code, "atom_number/2"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_string_to_atom_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_string_to_atom/2:\nbuiltin_call string_to_atom/2, 2\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -150,6 +150,10 @@
 :- dynamic user:wam_atom_string_guard/2.
 :- dynamic user:wam_atom_string_reverse/0.
 :- dynamic user:wam_atom_string_unbound_pair/1.
+:- dynamic user:wam_atom_number_guard/2.
+:- dynamic user:wam_atom_number_reverse/0.
+:- dynamic user:wam_atom_number_bad_atom/0.
+:- dynamic user:wam_atom_number_unbound_pair/1.
 :- dynamic user:wam_string_to_atom_guard/2.
 :- dynamic user:wam_string_to_atom_reverse/0.
 :- dynamic user:wam_string_to_atom_unbound_pair/1.
@@ -350,6 +354,10 @@ user:wam_atom_chars_reverse :- atom_chars(A, [f,o,o]), A = foo.
 user:wam_atom_string_guard(A, S) :- atom_string(A, S).
 user:wam_atom_string_reverse :- atom_string(A, world), A = world.
 user:wam_atom_string_unbound_pair(_) :- user:wam_unbound_arg(A), user:wam_unbound_arg(S), atom_string(A, S).
+user:wam_atom_number_guard(A, N) :- atom_number(A, N).
+user:wam_atom_number_reverse :- atom_number(A, 42), atom_codes(A, [52,50]).
+user:wam_atom_number_bad_atom :- atom_number(foo, _).
+user:wam_atom_number_unbound_pair(_) :- user:wam_unbound_arg(A), user:wam_unbound_arg(N), atom_number(A, N).
 user:wam_string_to_atom_guard(S, A) :- string_to_atom(S, A).
 user:wam_string_to_atom_reverse :- string_to_atom(world, A), A = world.
 user:wam_string_to_atom_unbound_pair(_) :- user:wam_unbound_arg(S), user:wam_unbound_arg(A), string_to_atom(S, A).
@@ -555,6 +563,10 @@ run_smoke :-
           user:wam_atom_string_guard/2,
           user:wam_atom_string_reverse/0,
           user:wam_atom_string_unbound_pair/1,
+          user:wam_atom_number_guard/2,
+          user:wam_atom_number_reverse/0,
+          user:wam_atom_number_bad_atom/0,
+          user:wam_atom_number_unbound_pair/1,
           user:wam_string_to_atom_guard/2,
           user:wam_string_to_atom_reverse/0,
           user:wam_string_to_atom_unbound_pair/1,
@@ -914,6 +926,11 @@ smoke_cases([
     case('wam_atom_string_guard/2', args(hello, world), "false"),
     case('wam_atom_string_reverse/0', no_args, "true"),
     case('wam_atom_string_unbound_pair/1', a, "false"),
+    case('wam_atom_number_guard/2', args(42, 42), "true"),
+    case('wam_atom_number_guard/2', args(42, 43), "false"),
+    case('wam_atom_number_reverse/0', no_args, "true"),
+    case('wam_atom_number_bad_atom/0', no_args, "false"),
+    case('wam_atom_number_unbound_pair/1', a, "false"),
     case('wam_string_to_atom_guard/2', args(hello, hello), "true"),
     case('wam_string_to_atom_guard/2', args(hello, world), "false"),
     case('wam_string_to_atom_reverse/0', no_args, "true"),
@@ -1287,6 +1304,7 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-atom-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-atom-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-atom-string-guard-2"),
+    has(CoreCode, "defn lowered-wam-atom-number-guard-2"),
     has(CoreCode, "defn lowered-wam-string-to-atom-guard-2"),
     has(CoreCode, "defn lowered-wam-string-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-string-chars-guard-2"),
@@ -1299,6 +1317,7 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "runtime/ground-term?"),
     has(CoreCode, "runtime/apply-text-conversion-solution"),
     has(CoreCode, "runtime/apply-atom-string-solution"),
+    has(CoreCode, "runtime/apply-atom-number-solution"),
     has(CoreCode, "runtime/apply-char-code-solution"),
     has(CoreCode, "runtime/apply-atom-concat-solution"),
     has(CoreCode, "runtime/apply-atom-length-solution"),


### PR DESCRIPTION
## Summary

- Registers `atom_number/2` as a WAM builtin.
- Adds direct lowered Clojure emission for `atom_number/2` through `runtime/apply-atom-number-solution`.
- Implements Clojure runtime support for atom-to-number and number-to-atom conversion.
- Tightens bound/bound text-conversion handling so numeric-looking generated WAM literals compare by normalized text instead of accidental host-term shape.
- Adds lowered-emitter and runtime smoke coverage for forward, reverse, failure, and unbound `atom_number/2` cases.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
