### PR TITLE
Feat/wam go delete builtin

### DIFF
--- a/PR_go_wam_delete_builtin.md
+++ b/PR_go_wam_delete_builtin.md
@@ -1,0 +1,24 @@
+# PR Title
+
+Add Go WAM delete builtin
+
+# PR Description
+
+## Summary
+
+- Adds generated Go WAM runtime support for deterministic `delete/3` over proper lists.
+- Registers `delete/3` as a direct Go WAM builtin so compiled calls emit `BuiltinCall` instructions.
+- Extends the generated Go builtin E2E test to cover removing one matching atom, removing no matches, removing all matches, and malformed-list failure.
+- Updates the Go WAM parity audit to record the structural-list parity closure against the Clojure/C++ surface.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- direct emitter check for `delete/3`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -11,7 +11,7 @@ current cross-target builtin/runtime baseline.
 | Choice points and backtracking | `try_me_else`, `retry_me_else`, `trust_me`, indexed alternatives, foreign stream retries, indexed atom fact streams, `member/2` builtin retries | Choice point stack with normal, builtin, and fact-stream resume states | Present for current resume-state baseline |
 | Direct fact dispatch | `call_indexed_atom_fact2`, `AtomFact2Source` registry, TSV-backed and LMDB-artifact atom fact loading, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Present for current external atom fact-source baseline |
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
-| Structural builtins | `member/2`, `memberchk/2`, `select/3`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `select/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
+| Structural builtins | `member/2`, `memberchk/2`, `select/3`, `delete/3`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `select/3`, `delete/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Arithmetic builtins | `is/2`, `succ/2` | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir | Present for current baseline arithmetic checks, with expanded successor coverage |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` | Includes `=</2`; Haskell mode analysis and Clojure lowering also cover term-order comparisons | Present for current baseline comparisons, with expanded term-order coverage |
@@ -39,6 +39,9 @@ current cross-target builtin/runtime baseline.
   E2E test for first-match selection, missing/empty/malformed-list failure,
   and `findall/3` enumeration of every selected element/rest pair, matching
   the Clojure/C++ structural-list surface.
+- Deterministic `delete/3` is now covered by the generated Go WAM builtin E2E
+  test for removing one, none, or all matching atom elements and malformed-list
+  failure, matching the Clojure/C++ structural-list surface for proper lists.
 - Deterministic `reverse/2` is now covered by the generated Go WAM builtin E2E
   test for both forward and reverse-list binding modes, closing one richer
   Clojure/R/C++ list-builtin parity gap.

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -425,6 +425,9 @@ wam_go_direct_builtin("memberchk/2", 2, 'memberchk/2').
 wam_go_direct_builtin(select/3, 3, 'select/3').
 wam_go_direct_builtin('select/3', 3, 'select/3').
 wam_go_direct_builtin("select/3", 3, 'select/3').
+wam_go_direct_builtin(delete/3, 3, 'delete/3').
+wam_go_direct_builtin('delete/3', 3, 'delete/3').
+wam_go_direct_builtin("delete/3", 3, 'delete/3').
 wam_go_direct_builtin(reverse/2, 2, 'reverse/2').
 wam_go_direct_builtin('reverse/2', 2, 'reverse/2').
 wam_go_direct_builtin("reverse/2", 2, 'reverse/2').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1275,6 +1275,19 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			return true
 		}
 		return false
+	case "delete/3":
+		items, ok := vm.listToSlice(arg1)
+		if !ok {
+			return false
+		}
+		target := vm.deref(arg2)
+		kept := make([]Value, 0, len(items))
+		for _, item := range items {
+			if !valueEquals(vm.deref(item), target) {
+				kept = append(kept, item)
+			}
+		}
+		return vm.Unify(arg3, &List{Elements: kept})
 	case "append/3":
 		l1, ok1 := vm.listToSlice(arg1)
 		l2, ok2 := vm.listToSlice(arg2)

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -10,6 +10,7 @@
 :- dynamic user:test_member_collect/0.
 :- dynamic user:test_memberchk_builtin/0.
 :- dynamic user:test_select_builtin/0.
+:- dynamic user:test_delete_builtin/0.
 :- dynamic user:test_reverse_builtin/0.
 :- dynamic user:test_last_builtin/0.
 :- dynamic user:test_nth_builtin/0.
@@ -82,6 +83,15 @@ test(builtins_execution) :-
                 \+ select(z, [a,b,c], _),
                 \+ select(_, [], _),
                 \+ select(_, [a|b], _)
+            )),
+          assertz(user:test_delete_builtin :-
+            (   delete([a,b,c,b], b, R),
+                R = [a,c],
+                delete([a,b,c], z, Same),
+                Same = [a,b,c],
+                delete([a,a,a], a, Empty),
+                Empty = [],
+                \+ delete([a|b], a, _)
             )),
           assertz(user:test_reverse_builtin :-
             (   reverse([a,b,c], R),
@@ -175,6 +185,7 @@ test(builtins_execution) :-
           retractall(user:test_member_collect),
           retractall(user:test_memberchk_builtin),
           retractall(user:test_select_builtin),
+          retractall(user:test_delete_builtin),
           retractall(user:test_reverse_builtin),
           retractall(user:test_last_builtin),
           retractall(user:test_nth_builtin),
@@ -191,7 +202,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -225,6 +236,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "=/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "memberchk/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "select/3"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "delete/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "reverse/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "last/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "nth0/3"')),
@@ -297,6 +309,14 @@ func main() {
 		fmt.Println("SELECT_SUCCESS")
 	} else {
 		fmt.Println("SELECT_FAILURE")
+	}
+
+	deleteVM := wam.NewWamState(wam.Test_delete_builtinCode, wam.Test_delete_builtinLabels)
+	deleteVM.PC = wam.Test_delete_builtinStartPC
+	if deleteVM.Run() {
+		fmt.Println("DELETE_SUCCESS")
+	} else {
+		fmt.Println("DELETE_FAILURE")
 	}
 
 	reverseVM := wam.NewWamState(wam.Test_reverse_builtinCode, wam.Test_reverse_builtinLabels)
@@ -409,6 +429,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "MEMBER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "MEMBERCHK_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SELECT_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "DELETE_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "REVERSE_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "LAST_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NTH_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM delete builtin

## Summary

- Adds generated Go WAM runtime support for deterministic `delete/3` over proper lists.
- Registers `delete/3` as a direct Go WAM builtin so compiled calls emit `BuiltinCall` instructions.
- Extends the generated Go builtin E2E test to cover removing one matching atom, removing no matches, removing all matches, and malformed-list failure.
- Updates the Go WAM parity audit to record the structural-list parity closure against the Clojure/C++ surface.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- direct emitter check for `delete/3`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`
