### PR TITLE
fix(wam-cpp): synthesize CP at indexed sub-chain entry

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -625,20 +625,20 @@ static const int _wam_cpp_setup_register = []() {
        assertz((user:drop(_, [], []) :- !)),
        assertz((user:drop(N, [_|T], R) :-
            N > 0, N1 is N - 1, drop(N1, T, R))),
-       % intersection/union written as two-clause if-then-else to
-       % side-step a pre-existing indexing limitation: when three
-       % clauses share a [H|T] first arg, the SwitchOnTerm short-
-       % circuits past the initial TryMeElse and the third clause
-       % never gets a choice point. The if-then-else form has only
-       % one [H|T] clause, so backtracking isn't needed.
+       % Standard three-clause intersection/union. Earlier the
+       % runtime couldn''t synthesize a CP at an indexed sub-chain
+       % entry, so 3+-clause predicates with overlapping compound
+       % heads lost choices. With the SwitchOnTerm + RetryMeElse
+       % CP-synthesis path in place (this PR''s runtime change),
+       % three clauses backtrack normally.
        assertz((user:intersection([], _, []))),
-       assertz((user:intersection([H|T], L, R) :-
-           ( member(H, L) -> R = [H|R1] ; R = R1 ),
-           intersection(T, L, R1))),
+       assertz((user:intersection([H|T], L, [H|R]) :-
+           member(H, L), !, intersection(T, L, R))),
+       assertz((user:intersection([_|T], L, R) :- intersection(T, L, R))),
        assertz((user:union([], L, L))),
        assertz((user:union([H|T], L, R) :-
-           ( member(H, L) -> R = R1 ; R = [H|R1] ),
-           union(T, L, R1))),
+           member(H, L), !, union(T, L, R))),
+       assertz((user:union([H|T], L, [H|R]) :- union(T, L, R))),
        assertz((user:permutation([], []))),
        assertz((user:permutation(L, [H|T]) :-
            select(H, L, Rest), permutation(Rest, T)))
@@ -2660,6 +2660,12 @@ struct WamState {
     std::size_t cut_barrier = 0;
     std::uint64_t var_counter = 0;
     bool halt = false;
+    // True iff SwitchOnTerm just jumped directly into the middle/end
+    // of a clause chain, bypassing the chain''s entry TryMeElse. The
+    // subsequent RetryMeElse / TrustMe consults this flag to decide
+    // whether to synthesize a fresh CP (RetryMeElse) or skip the pop
+    // (TrustMe), then clears it. Reset on query entry.
+    bool indexed_entry = false;
 
     // Cell-aware accessors. get_reg/put_reg keep their Value-shaped API
     // so existing lowered code keeps compiling; get_cell exposes the cell
@@ -6428,6 +6434,12 @@ bool WamState::step(const Instruction& instr) {
 
         // ---- Choice points -----------------------------------------
         case Instruction::Op::TryMeElse: {
+            // A normal entry to a clause chain. Clear any
+            // indexed_entry flag in case SwitchOnTerm pointed here
+            // (defensive -- our current compiler points indexed
+            // jumps at RetryMeElse / TrustMe rather than TryMeElse,
+            // but the flag should be local to a single dispatch).
+            indexed_entry = false;
             ChoicePoint cp_;
             cp_.alt_pc = instr.target;
             cp_.saved_cp = cp;
@@ -6441,17 +6453,39 @@ bool WamState::step(const Instruction& instr) {
             pc += 1; return true;
         }
         case Instruction::Op::RetryMeElse: {
-            // No-op if no CP exists (e.g. when an indexing instruction
-            // jumped past the originating try_me_else). Classic WAM:
-            // retry_me_else updates the top CP''s alt; if there is no
-            // top CP we simply continue with no alt to manage.
-            if (!choice_points.empty()) {
+            // Normal failure-driven retry path: update top CP''s alt.
+            // Indexed-entry path (set by SwitchOnTerm bypassing the
+            // chain''s entry TryMeElse): synthesize a fresh CP so this
+            // predicate level has its own backtrack handle, even if
+            // an outer level''s CP is already on the stack.
+            if (!choice_points.empty() && !indexed_entry) {
                 choice_points.back().alt_pc = instr.target;
+            } else {
+                indexed_entry = false;
+                ChoicePoint cp_;
+                cp_.alt_pc = instr.target;
+                cp_.saved_cp = cp;
+                cp_.trail_mark = trail.size();
+                cp_.cut_barrier = cut_barrier;
+                cp_.saved_regs = regs;
+                cp_.saved_mode_stack = mode_stack;
+                cp_.saved_env_stack = env_stack;
+                cp_.saved_body_frames = body_frames;
+                choice_points.push_back(std::move(cp_));
             }
             pc += 1; return true;
         }
         case Instruction::Op::TrustMe: {
-            if (!choice_points.empty()) choice_points.pop_back();
+            // Normally pops the top CP (the one TryMeElse/RetryMeElse
+            // installed for this chain). When SwitchOnTerm jumped
+            // directly to a TrustMe (last clause), no CP was installed
+            // and indexed_entry flags this -- nothing to pop, just
+            // clear the flag and continue.
+            if (indexed_entry) {
+                indexed_entry = false;
+            } else if (!choice_points.empty()) {
+                choice_points.pop_back();
+            }
             pc += 1; return true;
         }
         case Instruction::Op::CutIte: {
@@ -6598,32 +6632,39 @@ bool WamState::step(const Instruction& instr) {
             return false;
         }
         case Instruction::Op::SwitchOnTerm: {
+            // Direct-jump branches (pc = target) bypass the entry
+            // TryMeElse of the clause chain, so we flag them via
+            // indexed_entry. The receiving RetryMeElse/TrustMe sees
+            // the flag and synthesizes a CP (or skips a pop) so the
+            // current predicate level gets its own backtrack handle
+            // even when an outer level''s CP is on the stack.
             CellPtr ac = get_cell("A1");
             const Value& a = *ac;
             if (a.is_unbound()) { pc += 1; return true; }
-            // Atom / integer / float → const_table.
             if (a.tag == Value::Tag::Atom || a.tag == Value::Tag::Integer
                 || a.tag == Value::Tag::Float) {
                 for (auto& kv : instr.const_table) {
                     if (kv.first == a) {
                         if (kv.second == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
                         if (kv.second == Instruction::SWITCH_NONE)    return false;
+                        indexed_entry = true;
                         pc = kv.second; return true;
                     }
                 }
                 return false;
             }
-            // Compound → list_pc for cons cells, otherwise struct_table.
             if (a.tag == Value::Tag::Compound) {
                 if (a.s == "[|]/2") {
                     if (instr.target == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
                     if (instr.target == Instruction::SWITCH_NONE)    return false;
+                    indexed_entry = true;
                     pc = instr.target; return true;
                 }
                 for (auto& kv : instr.struct_table) {
                     if (kv.first == a.s) {
                         if (kv.second == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
                         if (kv.second == Instruction::SWITCH_NONE)    return false;
+                        indexed_entry = true;
                         pc = kv.second; return true;
                     }
                 }
@@ -8441,6 +8482,7 @@ bool WamState::query(const std::string& pred_key, const std::vector<Value>& args
     pc = it->second;
     cp = 0;
     cut_barrier = 0;
+    indexed_entry = false;
     halt = false;
     return run();
 }

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -268,6 +268,11 @@
 :- dynamic user:wam_cpp_test_union/0.
 :- dynamic user:wam_cpp_test_permutation_check/0.
 :- dynamic user:wam_cpp_test_permutation_no/0.
+:- dynamic user:wam_cpp_test_idx_flat/0.
+:- dynamic user:wam_cpp_test_idx_keep/0.
+:- dynamic user:wam_cpp_test_idx_drop_first/0.
+:- dynamic user:wam_cpp_test_idx_keep_first/0.
+:- dynamic user:wam_cpp_test_idx_mixed/0.
 :- dynamic user:wam_cpp_test_enum_member/0.
 
 user:wam_cpp_test_member_yes   :- member(b, [a, b, c]).
@@ -582,6 +587,19 @@ user:wam_cpp_test_intersection_empty :- intersection([1, 2], [3, 4], []).
 user:wam_cpp_test_union          :- union([1, 2, 3], [3, 4, 5], [1, 2, 3, 4, 5]).
 user:wam_cpp_test_permutation_check :- permutation([a, b, c], [c, a, b]).
 user:wam_cpp_test_permutation_no    :- \+ permutation([a, b, c], [a, b, d]).
+% Indexing-bug regression tests. Three-clause predicate with first
+% arg [] / [H|T] / [H|T] used to lose backtracking when SwitchOnTerm
+% jumped past the chain's entry TryMeElse. Both flat and recursive
+% backtracking are exercised.
+user:wam_cpp_idx_bar([], []).
+user:wam_cpp_idx_bar([H|T], [H|R]) :- H > 10, wam_cpp_idx_bar(T, R).
+user:wam_cpp_idx_bar([_|T], R) :- wam_cpp_idx_bar(T, R).
+user:wam_cpp_test_idx_flat        :- wam_cpp_idx_bar([5], R), R = [].
+user:wam_cpp_test_idx_keep        :- wam_cpp_idx_bar([15], R), R = [15].
+user:wam_cpp_test_idx_drop_first  :- wam_cpp_idx_bar([5, 15], R), R = [15].
+user:wam_cpp_test_idx_keep_first  :- wam_cpp_idx_bar([15, 5], R), R = [15].
+user:wam_cpp_test_idx_mixed       :- wam_cpp_idx_bar([5, 15, 7, 20], R),
+                                     R = [15, 20].
 user:wam_cpp_test_enum_member  :- findall(X, member(X, [a, b, c]), L),
                                   L = [a, b, c].
 
@@ -3643,6 +3661,33 @@ test(cpp_e2e_lists_extra, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_union/0',              [], true),
           run_query(BinPath, 'wam_cpp_test_permutation_check/0',  [], true),
           run_query(BinPath, 'wam_cpp_test_permutation_no/0',     [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_indexing_backtrack, [condition(cpp_compiler_available)]) :-
+    % Regression for the SwitchOnTerm-vs-CP-sub-chain bug uncovered
+    % by PR #2264. Three-clause predicate with []/[H|T]/[H|T] first
+    % args used to lose backtracking when the indexed jump for the
+    % compound case skipped the chain's entry TryMeElse. The runtime
+    % now flags indexed entries (SwitchOn{Term,Constant,Structure}
+    % direct jumps) and the next RetryMeElse synthesizes a fresh CP
+    % so the predicate level has its own backtrack handle.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_idx', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_idx_flat/0,
+                               user:wam_cpp_test_idx_keep/0,
+                               user:wam_cpp_test_idx_drop_first/0,
+                               user:wam_cpp_test_idx_keep_first/0,
+                               user:wam_cpp_test_idx_mixed/0,
+                               user:wam_cpp_idx_bar/2],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_idx_flat/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_idx_keep/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_idx_drop_first/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_idx_keep_first/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_idx_mixed/0',      [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Fixes the WAM indexing bug uncovered in PR #2264. **Three-clause (or more) predicates whose clauses share a `[H|T]` first arg used to lose backtracking**: `SwitchOnTerm` jumped directly to the `RetryMeElse` / `TrustMe` at the indexed sub-chain entry, bypassing the chain's entry `TryMeElse`, and the level had no choice point of its own. The third clause was unreachable on backtrack.

The bug was visible whenever clause 2's head matched but its body failed — you'd expect backtracking to try clause 3, but instead control would either fall out of the predicate (and propagate failure to the caller) or, worse, **reuse an outer level's CP as if it belonged to the inner call** (mis-restoring outer registers, which is what gave wrong answers like `bar3([15, 5], R) → R = []` instead of `[15]`).

PR #2264 worked around this by rewriting `intersection/3` and `union/3` in two-clause if-then-else form. **The workaround is reverted here in favour of the standard three-clause form.**

## Mechanism

- New `WamState::indexed_entry` bool field. Reset at query entry and at every normal `TryMeElse`.
- **`SwitchOnTerm`** (and the constant / structure indexing variants) set the flag whenever they directly jump to a target (i.e. bypass the chain's entry `TryMeElse`). The fall-through case — `SWITCH_DEFAULT` advancing to `pc+1` — leaves the flag alone since the next instruction is the entry `TryMeElse`.
- **`RetryMeElse`** with `indexed_entry=true` (or empty CP stack) now synthesizes a fresh CP capturing the current state (pre-head-match `regs` / `env` / `mode` / `body_frames` / `trail_mark` / `saved_cp` / `cut_barrier`). Without the flag it behaves as before — update the existing CP's alt.
- **`TrustMe`** with `indexed_entry=true` skips its usual CP pop — when `SwitchOnTerm` jumped directly to the last clause, no CP was installed for this level so there's nothing to pop. Both ops clear the flag after consuming it.

## Tests

One new `cpp_e2e_indexing_backtrack` bundle with **5 cases** covering the regression — three-clause predicate `idx_bar/2` that keeps elements `> 10` and drops the rest:

| Case | Input | Expected |
|---|---|---|
| `idx_flat` | `[5]` | `[]` (clause 3 only) |
| `idx_keep` | `[15]` | `[15]` (clause 2 straight) |
| `idx_drop_first` | `[5, 15]` | `[15]` (clause 3 then clause 2) |
| `idx_keep_first` | `[15, 5]` | `[15]` (clause 2 then clause 3 — **previously-broken**) |
| `idx_mixed` | `[5, 15, 7, 20]` | `[15, 20]` (multiple alternations) |

Pre-fix, `idx_keep_first` returned `[]` because the inner level's failed clause-2 backtracked into the OUTER level's CP, restoring outer A1/A2 and re-running outer's clause 3.

Full `test_wam_cpp_generator` suite (355 tests) passes; `test_wam_target` unchanged and green.

## Test plan

- [x] Smoke tests for direct + recursive 3-clause backtracking — all green.
- [x] `intersection/3` and `union/3` reverted to standard 3-clause form — still passing.
- [x] Full `test_wam_cpp_generator` (355 tests) — all green.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_