### PR TITLE
feat(wam-python): add is_iso and is_lax

### DIFF
--- a/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
+++ b/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
@@ -64,7 +64,7 @@ Survey columns: shipped means code and tests exist in the target today.
 | Audit predicate and report | `wam_cpp_iso_audit/3` | `wam_elixir_iso_audit/3` | `wam_python_iso_audit/3`; others not adopted |
 | `catch/3` + `throw/1` substrate | shipped | shipped | Python shipped; others mostly missing/partial |
 | Error constructors and `throw_iso_error` helper | shipped | shipped | Python shipped; others not adopted |
-| `is_iso/2` / `is_lax/2` | shipped | shipped | not adopted |
+| `is_iso/2` / `is_lax/2` | shipped | shipped | Python shipped; others not adopted |
 | ISO/lax arithmetic compares | shipped | shipped | not adopted |
 | `succ_iso/2` / `succ_lax/2` | shipped | shipped | not adopted |
 | Lax IEEE-754 float divide behavior | shipped | shipped | not adopted |
@@ -72,9 +72,10 @@ Survey columns: shipped means code and tests exist in the target today.
 The C++ and Elixir targets are therefore the current reference consumers. C++
 was the first implementation; Elixir proves the design is not C++-specific.
 Python has now adopted the catch/throw substrate, ISO error constructors,
-`throw_iso_error`, and per-predicate config/rewrite/audit plumbing, but it
-should not be described as ISO-error compatible until it also adopts three-form
-builtin keys for concrete builtins. R, Lua,
+`throw_iso_error`, per-predicate config/rewrite/audit plumbing, and the
+`is_iso/2` / `is_lax/2` arithmetic assignment variants. It should not be
+described as fully ISO-error compatible until comparisons and remaining concrete
+builtins also adopt three-form keys. R, Lua,
 Haskell, Rust, and the remaining targets are still mostly missing or partial on
 this stack.
 

--- a/docs/design/WAM_PYTHON_PARITY_AUDIT.md
+++ b/docs/design/WAM_PYTHON_PARITY_AUDIT.md
@@ -43,11 +43,11 @@ Current state:
 | Prolog `catch/3` / `throw/1` | Present | Packaged runtime has side-stack catcher frames and generated-project E2E coverage. |
 | ISO error constructors | Present | Runtime builders exist for `instantiation_error`, `type_error/2`, `domain_error/2`, and `evaluation_error/1`. |
 | `throw_iso_error` helper | Present | Wraps `error(ErrorTerm, Context)` and routes through `throw/1`. |
-| `is_iso/2` / `is_lax/2` | Missing | Existing `is/2` catches `WAMError` and fails silently. |
+| `is_iso/2` / `is_lax/2` | Present | ISO mode throws structured errors; `is/2` and `is_lax/2` preserve lax failure. |
 | ISO/lax arithmetic compares | Missing | Existing compares catch `WAMError` and fail silently. |
 | `succ/2` and ISO/lax variants | Missing | `succ/2` is not part of the current Python builtin baseline. |
 | Per-predicate ISO config loader | Present | Supports `iso_errors_config(File)`, `iso_errors(Default)`, and `iso_errors(PI, Mode)` options. |
-| Per-predicate default rewrite | Present | `iso_errors_rewrite/4` plus text-level rewrite are wired before interpreter and lowered emission; key tables remain empty until ISO/lax builtin variants land. |
+| Per-predicate default rewrite | Present | `is/2` now rewrites to `is_iso/2` or `is_lax/2`; text-level rewrite feeds interpreter and lowered emission. |
 | ISO audit predicate | Present | `wam_python_iso_audit/3` reports builtin call sites using the shared audit shape. |
 
 The packaged runtime is the main implementation surface to update:
@@ -73,15 +73,12 @@ Porting `is_iso/2` first was premature before `catch/3` / `throw/1` existed.
 That substrate and the ISO error helpers are now present, so the remaining
 sequence is:
 
-1. Add shared-shape ISO config loading, per-predicate rewrite, and
-   `wam_python_iso_audit/3`.
-2. Add `is_iso/2` / `is_lax/2`, with explicit-lax bypass tests.
-3. Sweep arithmetic comparisons and add `succ/2` / `succ_iso/2` /
-   `succ_lax/2`.
+1. Sweep arithmetic comparisons into ISO/lax variants using the same
+   classification helpers as `is_iso/2`.
+2. Add `succ/2` / `succ_iso/2` / `succ_lax/2`.
 
-The next PR should therefore add `is_iso/2` / `is_lax/2`, populate
-the Python ISO/lax rewrite key table for `is/2`, and keep explicit-lax bypass
-tests. The C++ and Elixir ISO tests
+The next PR should therefore port the arithmetic comparison variants and add
+explicit-lax bypass coverage for those operators. The C++ and Elixir ISO tests
 provide a direct template for Python E2E coverage.
 
 ## Runtime Source Of Truth

--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -432,7 +432,10 @@ def pop_environment(state: WamState) -> None:
 # -- Arithmetic -------------------------------------------------------------
 
 def _strip_arity(functor: str) -> str:
-    """Strip arity suffix from functor name: '+/2' -> '+', 'mod/2' -> 'mod'."""
+    """Strip WAM arity suffix while preserving slash-named arithmetic ops."""
+    slash_ops = {'//2': '/', '///2': '//', '\\//2': '\\/'}
+    if functor in slash_ops:
+        return slash_ops[functor]
     if '/' in functor:
         return functor.rsplit('/', 1)[0]
     return functor
@@ -487,6 +490,83 @@ def eval_arith(term: Term, state: WamState):
         if fn in ops:
             return ops[fn](*args)
     raise WAMError(f"Cannot evaluate: {term}")
+
+
+def iso_term_contains_unbound(state: WamState, term: Term) -> bool:
+    """Return True when an arithmetic expression tree contains an unbound var."""
+    t = deref(term, state)
+    if isinstance(t, Var):
+        return True
+    if isinstance(t, Ref):
+        cell = state.heap.get(t.addr)
+        return cell is not None and iso_term_contains_unbound(state, cell)
+    if isinstance(t, Compound):
+        return any(iso_term_contains_unbound(state, arg) for arg in t.args)
+    return False
+
+
+def iso_term_has_zero_divide(state: WamState, term: Term) -> bool:
+    """Return True for literal /, //, mod, or rem by zero in an expression tree."""
+    t = deref(term, state)
+    if isinstance(t, Ref):
+        cell = state.heap.get(t.addr)
+        return cell is not None and iso_term_has_zero_divide(state, cell)
+    if not isinstance(t, Compound):
+        return False
+    fn = _strip_arity(t.functor)
+    if fn in ('/', '//', 'mod', 'rem') and len(t.args) == 2:
+        rhs = deref(t.args[1], state)
+        if isinstance(rhs, Ref):
+            rhs = state.heap.get(rhs.addr, rhs)
+        if (isinstance(rhs, Int) and rhs.n == 0) or (isinstance(rhs, Float) and rhs.f == 0.0):
+            return True
+    return any(iso_term_has_zero_divide(state, arg) for arg in t.args)
+
+
+def iso_arith_culprit(state: WamState, term: Term) -> Term:
+    """Build the Name/Arity culprit term used by type_error(evaluable, Culprit)."""
+    t = deref(term, state)
+    if isinstance(t, Ref):
+        cell = state.heap.get(t.addr)
+        if cell is not None:
+            t = deref(cell, state)
+    if isinstance(t, Atom):
+        return Compound('//2', [t, Int(0)])
+    if isinstance(t, Compound):
+        name = _strip_arity(t.functor)
+        return Compound('//2', [make_atom(name), Int(len(t.args))])
+    return Compound('//2', [make_atom('unknown'), Int(0)])
+
+
+def _execute_is_lax(state: WamState) -> bool:
+    dst = deref(get_reg(state, 1), state)
+    expr = deref(get_reg(state, 2), state)
+    try:
+        result = eval_arith(expr, state)
+    except WAMError:
+        return False
+    except (ZeroDivisionError, ValueError, TypeError, OverflowError):
+        return False
+    r = Int(result) if isinstance(result, int) else Float(result)
+    return unify(dst, r, state)
+
+
+def _execute_is_iso(state: WamState) -> bool:
+    dst = deref(get_reg(state, 1), state)
+    expr = get_reg(state, 2)
+    if iso_term_contains_unbound(state, expr):
+        return throw_iso_error(state, make_instantiation_error(state))
+    if iso_term_has_zero_divide(state, expr):
+        return throw_iso_error(state, make_evaluation_error(state, 'zero_divisor'))
+    try:
+        result = eval_arith(expr, state)
+    except WAMThrow:
+        raise
+    except Exception:
+        return throw_iso_error(state, make_type_error(state, 'evaluable', iso_arith_culprit(state, expr)))
+    r = Int(result) if isinstance(result, int) else Float(result)
+    return unify(dst, r, state)
+
 
 class WAMThrow(Exception):
     """Internal carrier for Prolog throw/1 terms."""
@@ -857,15 +937,10 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return not unify(get_reg(sub, 1), get_reg(sub, 2), sub)
     if builtin in ('==/2', '==') and arity == 2:
         return _term_identical(get_reg(state, 1), get_reg(state, 2), state)
-    if builtin in ('is/2', 'is'):
-        dst = deref(get_reg(state, 1), state)
-        expr = deref(get_reg(state, 2), state)
-        try:
-            result = eval_arith(expr, state)
-        except WAMError:
-            return False
-        r = Int(result) if isinstance(result, int) else Float(result)
-        return unify(dst, r, state)
+    if builtin in ('is/2', 'is_lax/2', 'is', 'is_lax') and arity == 2:
+        return _execute_is_lax(state)
+    if builtin in ('is_iso/2', 'is_iso') and arity == 2:
+        return _execute_is_iso(state)
     if builtin in ('<//2', '</2', '<'):
         a = deref(get_reg(state, 1), state)
         b = deref(get_reg(state, 2), state)

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -1344,6 +1344,9 @@ compile_wam_runtime_to_python(_Options, PythonCode) :-
 :- dynamic iso_errors_default_to_iso/2.
 :- dynamic iso_errors_default_to_lax/2.
 
+iso_errors_default_to_iso("is/2", "is_iso/2").
+iso_errors_default_to_lax("is/2", "is_lax/2").
+
 %% iso_errors_resolve_options(+Options, -Config)
 %  Merges optional file config with inline options into iso_config(Default,
 %  Overrides). Inline options override file entries for the same PI.

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -383,7 +383,9 @@ test(static_runtime_has_iso_error_helpers, [nondet]) :-
 	sub_string(Content, _, _, _, "def make_type_error(state: WamState, expected: str, culprit: Term)"),
 	sub_string(Content, _, _, _, "def make_domain_error(state: WamState, domain: str, culprit: Term)"),
 	sub_string(Content, _, _, _, "def make_evaluation_error(state: WamState, kind: str)"),
-	sub_string(Content, _, _, _, "def throw_iso_error(state: WamState, err_term: Term)").
+	sub_string(Content, _, _, _, "def throw_iso_error(state: WamState, err_term: Term)"),
+	sub_string(Content, _, _, _, "def _execute_is_lax(state: WamState)"),
+	sub_string(Content, _, _, _, "def _execute_is_iso(state: WamState)").
 
 
 :- end_tests(wam_python_phase_b).
@@ -433,28 +435,19 @@ test(iso_errors_inline_wins_over_file) :-
 		),
 		delete_file(Path)).
 
-test(iso_errors_text_rewrite_uses_dynamic_key_tables) :-
-	setup_call_cleanup(
-		(   assertz(wam_python_target:iso_errors_default_to_iso("is/2", "is_iso/2"), IsoRef),
-			assertz(wam_python_target:iso_errors_default_to_lax("is/2", "is_lax/2"), LaxRef)
-		),
-		(   Config = iso_config(true, []),
-			Wam0 = 'demo/0:\n  put_structure is/2, 1\n  builtin_call is/2 2\n  call is/2, 2\n  execute is/2',
-			wam_python_target:iso_errors_rewrite_text(Config, demo/0, Wam0, Wam),
-			assertion(sub_string(Wam, _, _, _, "put_structure is_iso/2, 1")),
-			assertion(sub_string(Wam, _, _, _, "builtin_call is_iso/2 2")),
-			assertion(sub_string(Wam, _, _, _, "call is_iso/2, 2")),
-			assertion(sub_string(Wam, _, _, _, "execute is_iso/2"))
-		),
-		(   erase(IsoRef),
-			erase(LaxRef)
-		)).
+test(iso_errors_text_rewrite_uses_is_key_tables) :-
+	Wam0 = 'demo/0:\n  put_structure is/2, 1\n  builtin_call is/2 2\n  call is/2, 2\n  execute is/2',
+	wam_python_target:iso_errors_rewrite_text(iso_config(true, []), demo/0, Wam0, IsoWam),
+	assertion(sub_string(IsoWam, _, _, _, "put_structure is_iso/2, 1")),
+	assertion(sub_string(IsoWam, _, _, _, "builtin_call is_iso/2 2")),
+	assertion(sub_string(IsoWam, _, _, _, "call is_iso/2, 2")),
+	assertion(sub_string(IsoWam, _, _, _, "execute is_iso/2")),
+	wam_python_target:iso_errors_rewrite_text(iso_config(false, []), demo/0, Wam0, LaxWam),
+	assertion(sub_string(LaxWam, _, _, _, "builtin_call is_lax/2 2")).
 
 test(iso_errors_project_generation_rewrites_wam_text) :-
 	setup_call_cleanup(
-		(   assertz(wam_python_target:iso_errors_default_to_iso("is/2", "is_iso/2"), IsoRef),
-			user:python_parser_tmp_dir('tmp_wam_python_iso_rewrite', ProjectDir)
-		),
+		user:python_parser_tmp_dir('tmp_wam_python_iso_rewrite', ProjectDir),
 		(   Wam = 'iso_rewrite_demo/0:\n  put_variable 4, 1\n  put_integer 1, 2\n  builtin_call is/2 2\n  proceed',
 			wam_python_target:write_wam_python_project([iso_rewrite_demo/0-Wam], [iso_errors(true)], ProjectDir),
 			directory_file_path(ProjectDir, 'predicates.py', PredicatesPath),
@@ -462,9 +455,7 @@ test(iso_errors_project_generation_rewrites_wam_text) :-
 			assertion(sub_string(Code, _, _, _, '"is_iso/2", 2')),
 			\+ sub_string(Code, _, _, _, '"is/2", 2')
 		),
-		(   erase(IsoRef),
-			user:python_parser_cleanup_tmp_dir(ProjectDir)
-		)).
+		user:python_parser_cleanup_tmp_dir(ProjectDir)).
 
 test(iso_errors_audit_structure) :-
 	wam_python_target:wam_python_iso_audit(
@@ -1022,6 +1013,19 @@ test(generated_runtime_catches_iso_helper_error_terms) :-
 		),
 		cleanup_tmp_dir(ProjectDir)).
 
+test(generated_runtime_runs_is_iso_and_lax_variants) :-
+	setup_call_cleanup(
+		unique_tmp_dir('tmp_wam_python_builtin_e2e', ProjectDir),
+		(   write_builtin_project(ProjectDir),
+			is_iso_lax_script(Script),
+			run_python_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "type")),
+			once(sub_string(Output, _, _, _, "inst")),
+			once(sub_string(Output, _, _, _, "zero")),
+			once(sub_string(Output, _, _, _, "lax_false"))
+		),
+		cleanup_tmp_dir(ProjectDir)).
+
 write_builtin_project(ProjectDir) :-
 	term_builtin_wam(TermWam),
 	copy_naf_io_wam(CopyNafIoWam),
@@ -1189,6 +1193,35 @@ iso_helper_catch_script(Script) :-
 		"run_type_error()",
 		"print()",
 		"run_eval_error()",
+		""
+	], '\n', Script).
+
+is_iso_lax_script(Script) :-
+	atomic_list_concat([
+		"import wam_runtime as wr",
+		"",
+		"def catch_is(goal, catcher, recovery):",
+		"    s = wr.WamState()",
+		"    wr.set_reg(s, 1, goal)",
+		"    wr.set_reg(s, 2, catcher)",
+		"    wr.set_reg(s, 3, recovery)",
+		"    return wr._execute_catch(s)",
+		"",
+		"v = wr.Var([None], 100)",
+		"catch_is(wr.Compound('is_iso/2', [v, wr.make_atom('foo')]), wr.Compound('error/2', [wr.Compound('type_error/2', [wr.make_atom('evaluable'), wr.Var([None], 101)]), wr.Var([None], 102)]), wr.Compound('write/1', [wr.make_atom('type')]))",
+		"print()",
+		"v = wr.Var([None], 200)",
+		"expr = wr.Compound('+/2', [wr.Var([None], 201), wr.Int(1)])",
+		"catch_is(wr.Compound('is_iso/2', [v, expr]), wr.Compound('error/2', [wr.make_atom('instantiation_error'), wr.Var([None], 202)]), wr.Compound('write/1', [wr.make_atom('inst')]))",
+		"print()",
+		"v = wr.Var([None], 300)",
+		"expr = wr.Compound('//2', [wr.Int(1), wr.Int(0)])",
+		"catch_is(wr.Compound('is_iso/2', [v, expr]), wr.Compound('error/2', [wr.Compound('evaluation_error/1', [wr.make_atom('zero_divisor')]), wr.Var([None], 301)]), wr.Compound('write/1', [wr.make_atom('zero')]))",
+		"print()",
+		"s = wr.WamState()",
+		"wr.set_reg(s, 1, wr.Var([None], 400))",
+		"wr.set_reg(s, 2, wr.make_atom('foo'))",
+		"print('lax_false' if not wr._execute_builtin('is_lax/2', 2, s) else 'bad')",
 		""
 	], '\n', Script).
 


### PR DESCRIPTION
## Summary

Adds the first behavior-changing Python WAM ISO arithmetic builtin slice: `is_iso/2` and `is_lax/2`. This builds on the existing Python catch/throw, ISO error helper, and config/rewrite plumbing.

## Changes

- Add explicit `is_lax/2` runtime dispatch as an alias for existing lax `is/2` behavior.
- Add `is_iso/2` runtime dispatch that throws structured ISO errors for arithmetic assignment failures:
  - `error(instantiation_error, _)` when the RHS expression contains an unbound variable.
  - `error(evaluation_error(zero_divisor), _)` for division by zero.
  - `error(type_error(evaluable, Culprit), _)` for non-evaluable RHS terms.
- Add arithmetic-expression helper walkers for ISO classification.
- Fix Python WAM arithmetic functor stripping for slash operators such as `//2` and `///2`.
- Populate the Python ISO rewrite table so default `is/2` resolves to:
  - `is_iso/2` in ISO mode.
  - `is_lax/2` in lax mode.
- Update Python target tests for rewrite behavior, runtime ISO error catching, and explicit lax behavior.
- Update Python parity and cross-target ISO status docs.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_python_target.pl`
- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `git diff --check`

## Notes

Python still should not be described as fully ISO-error compatible. Arithmetic comparisons and remaining concrete builtins still need ISO/lax variants and rewrite-table entries.
