### PR TITLE
feat(wam-clojure): lower atom case builtins

### DIFF
--- a/PR_WAM_CLOJURE_ATOM_CASE_BUILTINS.md
+++ b/PR_WAM_CLOJURE_ATOM_CASE_BUILTINS.md
@@ -1,0 +1,19 @@
+# PR Title
+
+feat(wam-clojure): lower atom case builtins
+
+# PR Description
+
+## Summary
+
+- Adds direct lowered Clojure support for `upcase_atom/2` and `downcase_atom/2`.
+- Implements a shared `runtime/apply-atom-case-solution` helper using existing atom text/interning semantics.
+- Adds lowered-emitter coverage for both builtins.
+- Extends the Clojure runtime smoke suite with success, mismatch, unbound-source, and generated-code assertions.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -468,6 +468,14 @@ clojure_direct_builtin("atom_number/2", "2").
 clojure_direct_builtin("atom_number/2", 2).
 clojure_direct_builtin('atom_number/2', "2").
 clojure_direct_builtin('atom_number/2', 2).
+clojure_direct_builtin("upcase_atom/2", "2").
+clojure_direct_builtin("upcase_atom/2", 2).
+clojure_direct_builtin('upcase_atom/2', "2").
+clojure_direct_builtin('upcase_atom/2', 2).
+clojure_direct_builtin("downcase_atom/2", "2").
+clojure_direct_builtin("downcase_atom/2", 2).
+clojure_direct_builtin('downcase_atom/2', "2").
+clojure_direct_builtin('downcase_atom/2', 2).
 clojure_direct_builtin("string_to_atom/2", "2").
 clojure_direct_builtin("string_to_atom/2", 2).
 clojure_direct_builtin('string_to_atom/2', "2").
@@ -866,6 +874,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "atom_number/2" ; Op == 'atom_number/2'),
     !,
     format(atom(Expr), '(runtime/apply-atom-number-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (   Op == "upcase_atom/2" ; Op == 'upcase_atom/2'
+    ;   Op == "downcase_atom/2" ; Op == 'downcase_atom/2'
+    ),
+    !,
+    format(atom(Expr), '(runtime/apply-atom-case-solution ~w "~w")', [S, Op]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "char_code/2" ; Op == 'char_code/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1113,6 +1113,22 @@
       :else
       (backtrack state))))
 
+(defn apply-atom-case-solution [state pred]
+  (let [source (deref-value (:bindings state)
+                            (or (reg-get-raw state "A1") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A2") ::unbound))
+        source-text (atom-text state source)]
+    (if (some? source-text)
+      (let [converted (if (= pred "upcase_atom/2")
+                        (str/upper-case source-text)
+                        (str/lower-case source-text))
+            [ok unified-state] (unify-text-atom-value state out converted)]
+        (if ok
+          (advance unified-state)
+          (backtrack state)))
+      (backtrack state))))
+
 (defn char-code-text [state value]
   (let [text (atom-text state value)]
     (when (and (string? text) (= 1 (count text)))
@@ -2055,6 +2071,12 @@
 
           "atom_number/2"
           (apply-atom-number-solution state)
+
+          "upcase_atom/2"
+          (apply-atom-case-solution state (:pred instr))
+
+          "downcase_atom/2"
+          (apply-atom-case-solution state (:pred instr))
 
           "string_to_atom/2"
           (apply-atom-string-solution state (:pred instr))

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -724,6 +724,26 @@ test(simple_builtin_atom_number_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_upcase_atom_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_upcase_atom/2:\nbuiltin_call upcase_atom/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_upcase_atom/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_upcase_atom/2, WamCode, [], Code),
+        has(Code, "runtime/apply-atom-case-solution"),
+        has(Code, "upcase_atom/2"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
+test(simple_builtin_downcase_atom_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_downcase_atom/2:\nbuiltin_call downcase_atom/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_downcase_atom/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_downcase_atom/2, WamCode, [], Code),
+        has(Code, "runtime/apply-atom-case-solution"),
+        has(Code, "downcase_atom/2"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_string_to_atom_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_string_to_atom/2:\nbuiltin_call string_to_atom/2, 2\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -154,6 +154,9 @@
 :- dynamic user:wam_atom_number_reverse/0.
 :- dynamic user:wam_atom_number_bad_atom/0.
 :- dynamic user:wam_atom_number_unbound_pair/1.
+:- dynamic user:wam_upcase_atom_guard/2.
+:- dynamic user:wam_downcase_atom_guard/2.
+:- dynamic user:wam_upcase_atom_unbound_source/1.
 :- dynamic user:wam_string_to_atom_guard/2.
 :- dynamic user:wam_string_to_atom_reverse/0.
 :- dynamic user:wam_string_to_atom_unbound_pair/1.
@@ -358,6 +361,9 @@ user:wam_atom_number_guard(A, N) :- atom_number(A, N).
 user:wam_atom_number_reverse :- atom_number(A, 42), atom_codes(A, [52,50]).
 user:wam_atom_number_bad_atom :- atom_number(foo, _).
 user:wam_atom_number_unbound_pair(_) :- user:wam_unbound_arg(A), user:wam_unbound_arg(N), atom_number(A, N).
+user:wam_upcase_atom_guard(A, U) :- upcase_atom(A, U).
+user:wam_downcase_atom_guard(A, L) :- downcase_atom(A, L).
+user:wam_upcase_atom_unbound_source(_) :- user:wam_unbound_arg(A), upcase_atom(A, _).
 user:wam_string_to_atom_guard(S, A) :- string_to_atom(S, A).
 user:wam_string_to_atom_reverse :- string_to_atom(world, A), A = world.
 user:wam_string_to_atom_unbound_pair(_) :- user:wam_unbound_arg(S), user:wam_unbound_arg(A), string_to_atom(S, A).
@@ -567,6 +573,9 @@ run_smoke :-
           user:wam_atom_number_reverse/0,
           user:wam_atom_number_bad_atom/0,
           user:wam_atom_number_unbound_pair/1,
+          user:wam_upcase_atom_guard/2,
+          user:wam_downcase_atom_guard/2,
+          user:wam_upcase_atom_unbound_source/1,
           user:wam_string_to_atom_guard/2,
           user:wam_string_to_atom_reverse/0,
           user:wam_string_to_atom_unbound_pair/1,
@@ -931,6 +940,11 @@ smoke_cases([
     case('wam_atom_number_reverse/0', no_args, "true"),
     case('wam_atom_number_bad_atom/0', no_args, "false"),
     case('wam_atom_number_unbound_pair/1', a, "false"),
+    case('wam_upcase_atom_guard/2', args(hello, 'HELLO'), "true"),
+    case('wam_upcase_atom_guard/2', args(hello, hello), "false"),
+    case('wam_downcase_atom_guard/2', args('HELLO', hello), "true"),
+    case('wam_downcase_atom_guard/2', args('HELLO', 'HELLO'), "false"),
+    case('wam_upcase_atom_unbound_source/1', a, "false"),
     case('wam_string_to_atom_guard/2', args(hello, hello), "true"),
     case('wam_string_to_atom_guard/2', args(hello, world), "false"),
     case('wam_string_to_atom_reverse/0', no_args, "true"),
@@ -1305,6 +1319,8 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-atom-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-atom-string-guard-2"),
     has(CoreCode, "defn lowered-wam-atom-number-guard-2"),
+    has(CoreCode, "defn lowered-wam-upcase-atom-guard-2"),
+    has(CoreCode, "defn lowered-wam-downcase-atom-guard-2"),
     has(CoreCode, "defn lowered-wam-string-to-atom-guard-2"),
     has(CoreCode, "defn lowered-wam-string-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-string-chars-guard-2"),
@@ -1318,6 +1334,7 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "runtime/apply-text-conversion-solution"),
     has(CoreCode, "runtime/apply-atom-string-solution"),
     has(CoreCode, "runtime/apply-atom-number-solution"),
+    has(CoreCode, "runtime/apply-atom-case-solution"),
     has(CoreCode, "runtime/apply-char-code-solution"),
     has(CoreCode, "runtime/apply-atom-concat-solution"),
     has(CoreCode, "runtime/apply-atom-length-solution"),


### PR DESCRIPTION
## Summary

- Adds direct lowered Clojure support for `upcase_atom/2` and `downcase_atom/2`.
- Implements a shared `runtime/apply-atom-case-solution` helper using existing atom text/interning semantics.
- Adds lowered-emitter coverage for both builtins.
- Extends the Clojure runtime smoke suite with success, mismatch, unbound-source, and generated-code assertions.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
