### PR TITLE
Add Go WAM atom_number/2 builtin parity

### DIFF
--- a/PR_go_wam_atom_number_builtin.md
+++ b/PR_go_wam_atom_number_builtin.md
@@ -1,0 +1,24 @@
+# PR Title
+
+Add Go WAM atom_number/2 builtin parity
+
+# PR Description
+
+## Summary
+
+- Add direct Go WAM lowering for `atom_number/2`.
+- Implement bidirectional `atom_number/2` runtime behavior for atom-to-number and number-to-atom conversion.
+- Cover integer, float, numeric atom, invalid atom, and both-unbound cases in the generated Go WAM builtin E2E test.
+- Update the Go WAM parity audit to record the new atom/number conversion surface.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(atom_number/2,2), X), writeln(X), halt"`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -14,6 +14,7 @@ current cross-target builtin/runtime baseline.
 | Structural builtins | `member/2`, `memberchk/2`, `select/3`, `delete/3`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `select/3`, `delete/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Arithmetic builtins | `is/2`, `succ/2` | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir | Present for current baseline arithmetic checks, with expanded successor coverage |
+| Atom/number conversion | `atom_number/2` | Clojure direct builtin surface includes bidirectional `atom_number/2` | Present for current atom-number conversion checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` | Includes `=</2`; Haskell mode analysis and Clojure lowering also cover term-order comparisons | Present for current baseline comparisons, with expanded term-order coverage |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
 | Term inspection | `functor/3`, `arg/3` | `functor/3`, `arg/3` | Present |
@@ -67,6 +68,10 @@ current cross-target builtin/runtime baseline.
   test for forward binding, reverse binding, matching integer pairs, mismatch
   failure, negative predecessor failure, non-positive successor failure, and
   both-unbound failure, matching the sibling Clojure/Elixir successor surface.
+- Bidirectional `atom_number/2` is now covered by the generated Go WAM builtin
+  E2E test for atom-to-integer, integer-to-atom, atom-to-float, float-to-atom,
+  numeric first-argument compatibility, bad atom failure, and both-unbound
+  failure, matching the Clojure atom-number surface.
 - Go WAM choice points now have explicit generated-runtime coverage for normal
   clause retries, indexed alternatives, foreign stream retries, indexed atom
   fact streams, and `member/2` builtin retries.

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -463,6 +463,9 @@ wam_go_direct_builtin("compare/3", 3, 'compare/3').
 wam_go_direct_builtin(succ/2, 2, 'succ/2').
 wam_go_direct_builtin('succ/2', 2, 'succ/2').
 wam_go_direct_builtin("succ/2", 2, 'succ/2').
+wam_go_direct_builtin(atom_number/2, 2, 'atom_number/2').
+wam_go_direct_builtin('atom_number/2', 2, 'atom_number/2').
+wam_go_direct_builtin("atom_number/2", 2, 'atom_number/2').
 
 wam_instruction_to_go_literal(get_constant(C, Ai), GoLiteral) :-
     go_value_literal(C, GoVal),

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -907,6 +907,47 @@ func (vm *WamState) copyTermValue(v Value, seen map[int]*Unbound) Value {
 	}
 }
 
+const quotedNumericAtomPrefix = "\x01"
+
+func atomNumberText(v Value) (string, bool) {
+	switch t := v.(type) {
+	case *Atom:
+		return strings.TrimPrefix(t.Name, quotedNumericAtomPrefix), true
+	case *Integer:
+		return strconv.FormatInt(t.Val, 10), true
+	case *Float:
+		return strconv.FormatFloat(t.Val, 'g', -1, 64), true
+	default:
+		return "", false
+	}
+}
+
+func parseAtomNumberText(text string) (Value, bool) {
+	if strings.Contains(text, ".") {
+		val, err := strconv.ParseFloat(text, 64)
+		if err != nil {
+			return nil, false
+		}
+		return &Float{Val: val}, true
+	}
+	val, err := strconv.ParseInt(text, 10, 64)
+	if err != nil {
+		return nil, false
+	}
+	return &Integer{Val: val}, true
+}
+
+func atomNumberValue(v Value) (Value, bool) {
+	switch t := v.(type) {
+	case *Integer, *Float:
+		return t, true
+	case *Atom:
+		return parseAtomNumberText(strings.TrimPrefix(t.Name, quotedNumericAtomPrefix))
+	default:
+		return nil, false
+	}
+}
+
 func (vm *WamState) Deref(v Value) Value {
 	return vm.deref(v)
 }
@@ -1092,6 +1133,24 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 		}
 		if bIsInt && bInt.Val > 0 {
 			return vm.Unify(arg1, &Integer{Val: bInt.Val - 1})
+		}
+		return false
+	case "atom_number/2":
+		atomVal := vm.deref(arg1)
+		numberVal := vm.deref(arg2)
+		if text, ok := atomNumberText(atomVal); ok {
+			parsed, ok := parseAtomNumberText(text)
+			if !ok {
+				return false
+			}
+			return vm.Unify(arg2, parsed)
+		}
+		if parsed, ok := atomNumberValue(numberVal); ok {
+			text, ok := atomNumberText(parsed)
+			if !ok {
+				return false
+			}
+			return vm.Unify(arg1, internAtom(quotedNumericAtomPrefix+text))
 		}
 		return false
 

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -18,6 +18,7 @@
 :- dynamic user:test_sort_builtin/0.
 :- dynamic user:test_term_order_builtin/0.
 :- dynamic user:test_succ_builtin/0.
+:- dynamic user:test_atom_number_builtin/0.
 :- dynamic user:test_set_aggregate/0.
 :- dynamic user:test_unify_builtin/0.
 :- dynamic user:test_neg_fact/1.
@@ -159,6 +160,21 @@ test(builtins_execution) :-
                 \+ succ(_, 0),
                 \+ succ(_, _)
             )),
+          assertz(user:test_atom_number_builtin :-
+            (   atom_number('42', N),
+                N =:= 42,
+                atom_number(A, 42),
+                A == '42',
+                atom_number(C, '42'),
+                C == '42',
+                atom_number('3.5', F),
+                F =:= 3.5,
+                atom_number(B, 3.5),
+                B == '3.5',
+                atom_number(42, 42),
+                \+ atom_number(foo, _),
+                \+ atom_number(_, _)
+            )),
           assertz(user:test_set_aggregate :-
             (   aggregate_all(set(X), member(X, [a,b,a]), S),
                 length(S, 2),
@@ -193,6 +209,7 @@ test(builtins_execution) :-
           retractall(user:test_sort_builtin),
           retractall(user:test_term_order_builtin),
           retractall(user:test_succ_builtin),
+          retractall(user:test_atom_number_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
           retractall(user:test_neg_fact(_)),
@@ -202,7 +219,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -250,6 +267,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "@>=/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "compare/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "succ/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "atom_number/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "\\\\+/1"')),
     assertion(sub_string(LibCode, _, _, _, 'AggType: "set"')),
 
@@ -375,6 +393,14 @@ func main() {
 		fmt.Println("SUCC_FAILURE")
 	}
 
+	atomNumberVM := wam.NewWamState(wam.Test_atom_number_builtinCode, wam.Test_atom_number_builtinLabels)
+	atomNumberVM.PC = wam.Test_atom_number_builtinStartPC
+	if atomNumberVM.Run() {
+		fmt.Println("ATOM_NUMBER_SUCCESS")
+	} else {
+		fmt.Println("ATOM_NUMBER_FAILURE")
+	}
+
 	setVM := wam.NewWamState(wam.Test_set_aggregateCode, wam.Test_set_aggregateLabels)
 	setVM.PC = wam.Test_set_aggregateStartPC
 	if setVM.Run() {
@@ -437,6 +463,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "SORT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "TERM_ORDER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SUCC_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "ATOM_NUMBER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NEG_SUCCESS")),


### PR DESCRIPTION
## Summary

- Add direct Go WAM lowering for `atom_number/2`.
- Implement bidirectional `atom_number/2` runtime behavior for atom-to-number and number-to-atom conversion.
- Cover integer, float, numeric atom, invalid atom, and both-unbound cases in the generated Go WAM builtin E2E test.
- Update the Go WAM parity audit to record the new atom/number conversion surface.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(atom_number/2,2), X), writeln(X), halt"`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`
