### PR TITLE
feat(wam-python): add ISO arithmetic comparisons

### DIFF
--- a/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
+++ b/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
@@ -65,17 +65,17 @@ Survey columns: shipped means code and tests exist in the target today.
 | `catch/3` + `throw/1` substrate | shipped | shipped | Python shipped; others mostly missing/partial |
 | Error constructors and `throw_iso_error` helper | shipped | shipped | Python shipped; others not adopted |
 | `is_iso/2` / `is_lax/2` | shipped | shipped | Python shipped; others not adopted |
-| ISO/lax arithmetic compares | shipped | shipped | not adopted |
+| ISO/lax arithmetic compares | shipped | shipped | Python shipped; others not adopted |
 | `succ_iso/2` / `succ_lax/2` | shipped | shipped | not adopted |
 | Lax IEEE-754 float divide behavior | shipped | shipped | not adopted |
 
 The C++ and Elixir targets are therefore the current reference consumers. C++
 was the first implementation; Elixir proves the design is not C++-specific.
 Python has now adopted the catch/throw substrate, ISO error constructors,
-`throw_iso_error`, per-predicate config/rewrite/audit plumbing, and the
-`is_iso/2` / `is_lax/2` arithmetic assignment variants. It should not be
-described as fully ISO-error compatible until comparisons and remaining concrete
-builtins also adopt three-form keys. R, Lua,
+`throw_iso_error`, per-predicate config/rewrite/audit plumbing, arithmetic
+assignment variants, and arithmetic comparison variants. It should not be
+described as fully ISO-error compatible until remaining concrete builtins also
+adopt three-form keys. R, Lua,
 Haskell, Rust, and the remaining targets are still mostly missing or partial on
 this stack.
 

--- a/docs/design/WAM_PYTHON_PARITY_AUDIT.md
+++ b/docs/design/WAM_PYTHON_PARITY_AUDIT.md
@@ -44,7 +44,7 @@ Current state:
 | ISO error constructors | Present | Runtime builders exist for `instantiation_error`, `type_error/2`, `domain_error/2`, and `evaluation_error/1`. |
 | `throw_iso_error` helper | Present | Wraps `error(ErrorTerm, Context)` and routes through `throw/1`. |
 | `is_iso/2` / `is_lax/2` | Present | ISO mode throws structured errors; `is/2` and `is_lax/2` preserve lax failure. |
-| ISO/lax arithmetic compares | Missing | Existing compares catch `WAMError` and fail silently. |
+| ISO/lax arithmetic compares | Present | Six comparison variants now follow ISO/lax three-form dispatch. |
 | `succ/2` and ISO/lax variants | Missing | `succ/2` is not part of the current Python builtin baseline. |
 | Per-predicate ISO config loader | Present | Supports `iso_errors_config(File)`, `iso_errors(Default)`, and `iso_errors(PI, Mode)` options. |
 | Per-predicate default rewrite | Present | `is/2` now rewrites to `is_iso/2` or `is_lax/2`; text-level rewrite feeds interpreter and lowered emission. |
@@ -73,13 +73,12 @@ Porting `is_iso/2` first was premature before `catch/3` / `throw/1` existed.
 That substrate and the ISO error helpers are now present, so the remaining
 sequence is:
 
-1. Sweep arithmetic comparisons into ISO/lax variants using the same
-   classification helpers as `is_iso/2`.
-2. Add `succ/2` / `succ_iso/2` / `succ_lax/2`.
+1. Add `succ/2` / `succ_iso/2` / `succ_lax/2`.
+2. Sweep any remaining arithmetic builtins that need ISO/lax behavior.
 
-The next PR should therefore port the arithmetic comparison variants and add
-explicit-lax bypass coverage for those operators. The C++ and Elixir ISO tests
-provide a direct template for Python E2E coverage.
+The next PR should therefore port the successor variants and add explicit-lax
+bypass coverage for that operator. The C++ and Elixir ISO tests provide a direct
+template for Python E2E coverage.
 
 ## Runtime Source Of Truth
 

--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -554,18 +554,63 @@ def _execute_is_lax(state: WamState) -> bool:
 def _execute_is_iso(state: WamState) -> bool:
     dst = deref(get_reg(state, 1), state)
     expr = get_reg(state, 2)
+    result = _eval_arith_iso(state, expr)
+    if isinstance(result, bool):
+        return result
+    r = Int(result) if isinstance(result, int) else Float(result)
+    return unify(dst, r, state)
+
+
+def _eval_arith_iso(state: WamState, expr: Term):
     if iso_term_contains_unbound(state, expr):
         return throw_iso_error(state, make_instantiation_error(state))
     if iso_term_has_zero_divide(state, expr):
         return throw_iso_error(state, make_evaluation_error(state, 'zero_divisor'))
     try:
-        result = eval_arith(expr, state)
+        return eval_arith(expr, state)
     except WAMThrow:
         raise
     except Exception:
         return throw_iso_error(state, make_type_error(state, 'evaluable', iso_arith_culprit(state, expr)))
-    r = Int(result) if isinstance(result, int) else Float(result)
-    return unify(dst, r, state)
+
+
+def _compare_arith(op: str, a, b) -> bool:
+    if op == '<':
+        return a < b
+    if op == '>':
+        return a > b
+    if op == '=<':
+        return a <= b
+    if op == '>=':
+        return a >= b
+    if op == '=:=':
+        return a == b
+    if op == '=\\=':
+        return a != b
+    return False
+
+
+def _execute_compare_lax(state: WamState, op: str) -> bool:
+    a = deref(get_reg(state, 1), state)
+    b = deref(get_reg(state, 2), state)
+    try:
+        return _compare_arith(op, eval_arith(a, state), eval_arith(b, state))
+    except WAMError:
+        return False
+    except (ZeroDivisionError, ValueError, TypeError, OverflowError):
+        return False
+
+
+def _execute_compare_iso(state: WamState, op: str) -> bool:
+    a_expr = get_reg(state, 1)
+    b_expr = get_reg(state, 2)
+    a = _eval_arith_iso(state, a_expr)
+    if isinstance(a, bool):
+        return a
+    b = _eval_arith_iso(state, b_expr)
+    if isinstance(b, bool):
+        return b
+    return _compare_arith(op, a, b)
 
 
 class WAMThrow(Exception):
@@ -941,48 +986,28 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return _execute_is_lax(state)
     if builtin in ('is_iso/2', 'is_iso') and arity == 2:
         return _execute_is_iso(state)
-    if builtin in ('<//2', '</2', '<'):
-        a = deref(get_reg(state, 1), state)
-        b = deref(get_reg(state, 2), state)
-        try:
-            return eval_arith(a, state) < eval_arith(b, state)
-        except WAMError:
-            return False
-    if builtin in ('>/2', '>'):
-        a = deref(get_reg(state, 1), state)
-        b = deref(get_reg(state, 2), state)
-        try:
-            return eval_arith(a, state) > eval_arith(b, state)
-        except WAMError:
-            return False
-    if builtin in ('=</2', '=<'):
-        a = deref(get_reg(state, 1), state)
-        b = deref(get_reg(state, 2), state)
-        try:
-            return eval_arith(a, state) <= eval_arith(b, state)
-        except WAMError:
-            return False
-    if builtin in ('>=/2', '>='):
-        a = deref(get_reg(state, 1), state)
-        b = deref(get_reg(state, 2), state)
-        try:
-            return eval_arith(a, state) >= eval_arith(b, state)
-        except WAMError:
-            return False
-    if builtin in ('=:=/2', '=:='):
-        a = deref(get_reg(state, 1), state)
-        b = deref(get_reg(state, 2), state)
-        try:
-            return eval_arith(a, state) == eval_arith(b, state)
-        except WAMError:
-            return False
-    if builtin in ('=\\=/2', '=\\='):
-        a = deref(get_reg(state, 1), state)
-        b = deref(get_reg(state, 2), state)
-        try:
-            return eval_arith(a, state) != eval_arith(b, state)
-        except WAMError:
-            return False
+    compare_lax = {
+        '<': ('<//2', '</2', '<_lax/2', '<_lax'),
+        '>': ('>/2', '>_lax/2', '>', '>_lax'),
+        '=<': ('=</2', '=<_lax/2', '=<', '=<_lax'),
+        '>=': ('>=/2', '>=_lax/2', '>=', '>=_lax'),
+        '=:=': ('=:=/2', '=:=_lax/2', '=:=', '=:=_lax'),
+        '=\\=': ('=\\=/2', '=\\=_lax/2', '=\\=', '=\\=_lax'),
+    }
+    for op, keys in compare_lax.items():
+        if builtin in keys and arity == 2:
+            return _execute_compare_lax(state, op)
+    compare_iso = {
+        '<': ('<_iso/2', '<_iso'),
+        '>': ('>_iso/2', '>_iso'),
+        '=<': ('=<_iso/2', '=<_iso'),
+        '>=': ('>=_iso/2', '>=_iso'),
+        '=:=': ('=:=_iso/2', '=:=_iso'),
+        '=\\=': ('=\\=_iso/2', '=\\=_iso'),
+    }
+    for op, keys in compare_iso.items():
+        if builtin in keys and arity == 2:
+            return _execute_compare_iso(state, op)
     if builtin in ('\\+/1', '\\+'):  # negation as failure
         goal = deref(get_reg(state, 1), state)
         return not _goal_succeeds_once(goal, state)

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -1345,7 +1345,20 @@ compile_wam_runtime_to_python(_Options, PythonCode) :-
 :- dynamic iso_errors_default_to_lax/2.
 
 iso_errors_default_to_iso("is/2", "is_iso/2").
+iso_errors_default_to_iso(">/2", ">_iso/2").
+iso_errors_default_to_iso("</2", "<_iso/2").
+iso_errors_default_to_iso(">=/2", ">=_iso/2").
+iso_errors_default_to_iso("=</2", "=<_iso/2").
+iso_errors_default_to_iso("=:=/2", "=:=_iso/2").
+iso_errors_default_to_iso("=\\=/2", "=\\=_iso/2").
+
 iso_errors_default_to_lax("is/2", "is_lax/2").
+iso_errors_default_to_lax(">/2", ">_lax/2").
+iso_errors_default_to_lax("</2", "<_lax/2").
+iso_errors_default_to_lax(">=/2", ">=_lax/2").
+iso_errors_default_to_lax("=</2", "=<_lax/2").
+iso_errors_default_to_lax("=:=/2", "=:=_lax/2").
+iso_errors_default_to_lax("=\\=/2", "=\\=_lax/2").
 
 %% iso_errors_resolve_options(+Options, -Config)
 %  Merges optional file config with inline options into iso_config(Default,

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -443,7 +443,14 @@ test(iso_errors_text_rewrite_uses_is_key_tables) :-
 	assertion(sub_string(IsoWam, _, _, _, "call is_iso/2, 2")),
 	assertion(sub_string(IsoWam, _, _, _, "execute is_iso/2")),
 	wam_python_target:iso_errors_rewrite_text(iso_config(false, []), demo/0, Wam0, LaxWam),
-	assertion(sub_string(LaxWam, _, _, _, "builtin_call is_lax/2 2")).
+	assertion(sub_string(LaxWam, _, _, _, "builtin_call is_lax/2 2")),
+	Cmp0 = 'cmp/0:\n  builtin_call >/2 2\n  builtin_call =:=/2 2',
+	wam_python_target:iso_errors_rewrite_text(iso_config(true, []), cmp/0, Cmp0, CmpIso),
+	assertion(sub_string(CmpIso, _, _, _, "builtin_call >_iso/2 2")),
+	assertion(sub_string(CmpIso, _, _, _, "builtin_call =:=_iso/2 2")),
+	wam_python_target:iso_errors_rewrite_text(iso_config(false, []), cmp/0, Cmp0, CmpLax),
+	assertion(sub_string(CmpLax, _, _, _, "builtin_call >_lax/2 2")),
+	assertion(sub_string(CmpLax, _, _, _, "builtin_call =:=_lax/2 2")).
 
 test(iso_errors_project_generation_rewrites_wam_text) :-
 	setup_call_cleanup(
@@ -1022,7 +1029,11 @@ test(generated_runtime_runs_is_iso_and_lax_variants) :-
 			once(sub_string(Output, _, _, _, "type")),
 			once(sub_string(Output, _, _, _, "inst")),
 			once(sub_string(Output, _, _, _, "zero")),
-			once(sub_string(Output, _, _, _, "lax_false"))
+			once(sub_string(Output, _, _, _, "cmp_inst")),
+			once(sub_string(Output, _, _, _, "cmp_type")),
+			once(sub_string(Output, _, _, _, "cmp_zero")),
+			once(sub_string(Output, _, _, _, "lax_false")),
+			once(sub_string(Output, _, _, _, "cmp_lax_false"))
 		),
 		cleanup_tmp_dir(ProjectDir)).
 
@@ -1218,10 +1229,21 @@ is_iso_lax_script(Script) :-
 		"expr = wr.Compound('//2', [wr.Int(1), wr.Int(0)])",
 		"catch_is(wr.Compound('is_iso/2', [v, expr]), wr.Compound('error/2', [wr.Compound('evaluation_error/1', [wr.make_atom('zero_divisor')]), wr.Var([None], 301)]), wr.Compound('write/1', [wr.make_atom('zero')]))",
 		"print()",
+		"catch_is(wr.Compound('>_iso/2', [wr.Var([None], 500), wr.Int(5)]), wr.Compound('error/2', [wr.make_atom('instantiation_error'), wr.Var([None], 501)]), wr.Compound('write/1', [wr.make_atom('cmp_inst')]))",
+		"print()",
+		"catch_is(wr.Compound('<_iso/2', [wr.make_atom('foo'), wr.Int(5)]), wr.Compound('error/2', [wr.Compound('type_error/2', [wr.make_atom('evaluable'), wr.Var([None], 502)]), wr.Var([None], 503)]), wr.Compound('write/1', [wr.make_atom('cmp_type')]))",
+		"print()",
+		"expr = wr.Compound('//2', [wr.Int(1), wr.Int(0)])",
+		"catch_is(wr.Compound('=:=_iso/2', [expr, wr.Int(0)]), wr.Compound('error/2', [wr.Compound('evaluation_error/1', [wr.make_atom('zero_divisor')]), wr.Var([None], 504)]), wr.Compound('write/1', [wr.make_atom('cmp_zero')]))",
+		"print()",
 		"s = wr.WamState()",
 		"wr.set_reg(s, 1, wr.Var([None], 400))",
 		"wr.set_reg(s, 2, wr.make_atom('foo'))",
 		"print('lax_false' if not wr._execute_builtin('is_lax/2', 2, s) else 'bad')",
+		"s = wr.WamState()",
+		"wr.set_reg(s, 1, wr.Var([None], 600))",
+		"wr.set_reg(s, 2, wr.Int(5))",
+		"print('cmp_lax_false' if not wr._execute_builtin('>_lax/2', 2, s) else 'bad')",
 		""
 	], '\n', Script).
 


### PR DESCRIPTION
## Summary

Adds Python WAM ISO/lax variants for the six arithmetic comparison builtins, building on the existing Python `is_iso/2`, `is_lax/2`, ISO error helpers, and per-predicate rewrite plumbing.

## Changes

- Add ISO/lax runtime dispatch for:
  - `>/2` -> `>_iso/2` / `>_lax/2`
  - `</2` -> `<_iso/2` / `<_lax/2`
  - `>=/2` -> `>=_iso/2` / `>=_lax/2`
  - `=</2` -> `=<_iso/2` / `=<_lax/2`
  - `=:=/2` -> `=:=_iso/2` / `=:=_lax/2`
  - `=\=/2` -> `=\=_iso/2` / `=\=_lax/2`
- Reuse the `is_iso/2` arithmetic classification path for comparison ISO errors:
  - `error(instantiation_error, _)` for unbound expression terms.
  - `error(evaluation_error(zero_divisor), _)` for division by zero.
  - `error(type_error(evaluable, Culprit), _)` for non-evaluable terms.
- Populate the Python ISO rewrite table for all six comparison operators.
- Extend Python target tests for comparison rewrite behavior, ISO comparison error catching, and explicit-lax comparison behavior.
- Update Python parity and cross-target ISO status docs.
- Keep the ISO rewrite table clauses contiguous and remove the Python invalid escape warning.

## Validation

- `swipl -q -g run_tests -t halt tests/test_wam_python_target.pl`
- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `git diff --check`

## Notes

Python still should not be described as fully ISO-error compatible. The next ISO slice should likely port `succ/2`, `succ_iso/2`, and `succ_lax/2` with explicit-lax bypass coverage.
