### PR TITLE
feat(wam-cpp): stream I/O foundation

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -2108,6 +2108,7 @@ compile_wam_runtime_header_to_cpp(_Options,
 
 #include <cstddef>
 #include <cstdint>
+#include <fstream>
 #include <functional>
 #include <memory>
 #include <set>
@@ -2667,6 +2668,18 @@ struct WamState {
     // (TrustMe), then clears it. Reset on query entry.
     bool indexed_entry = false;
 
+    // File-stream registry. open/3 inserts; close/1 erases; the read
+    // / write builtins look up by atom handle. Each entry owns its
+    // underlying fstream so RAII closes it if the user forgets. The
+    // handle atom is "$stream_N" with a per-WamState monotonically
+    // increasing counter.
+    struct StreamEntry {
+        std::unique_ptr<std::fstream> file;
+        bool is_read = false;
+    };
+    std::unordered_map<std::string, StreamEntry> streams;
+    std::uint64_t stream_counter = 0;
+
     // Cell-aware accessors. get_reg/put_reg keep their Value-shaped API
     // so existing lowered code keeps compiling; get_cell exposes the cell
     // for instructions that need sharing semantics.
@@ -2883,6 +2896,7 @@ compile_wam_runtime_to_cpp(_Options,
 #include <cmath>
 #include <cstdio>
 #include <ctime>
+#include <fstream>
 #include <limits>
 #include <random>
 #include <sstream>
@@ -5507,6 +5521,188 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         CellPtr tgt = get_cell("A1");
         if (tgt->is_unbound()) { bind_cell(tgt, out); pc += 1; return true; }
         if (!unify_cells(tgt, std::make_shared<Cell>(out))) return false;
+        pc += 1; return true;
+    }
+
+    // ---- open/3 ----------------------------------------------------
+    // open(+File, +Mode, -Stream). Mode: read | write | append.
+    // Stream unifies with a freshly minted atom handle "$stream_N"
+    // that the read/write builtins look up in the streams registry.
+    // Throws existence_error(source_sink, File) if the file can''t
+    // be opened (mostly for read mode where the file must exist).
+    if (op == "open/3") {
+        Value fv = *get_cell("A1");
+        Value mv = *get_cell("A2");
+        if (fv.is_unbound() || mv.is_unbound())
+            return throw_iso_error(make_instantiation_error());
+        if (fv.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", fv));
+        if (mv.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", mv));
+        std::ios_base::openmode m;
+        bool is_read = false;
+        if      (mv.s == "read")   { m = std::ios::in;  is_read = true; }
+        else if (mv.s == "write")  { m = std::ios::out | std::ios::trunc; }
+        else if (mv.s == "append") { m = std::ios::out | std::ios::app; }
+        else return throw_iso_error(make_domain_error("io_mode", mv));
+        auto fs = std::make_unique<std::fstream>(fv.s, m);
+        if (!fs->is_open())
+            return throw_iso_error(Value::Compound("existence_error/2", {
+                std::make_shared<Cell>(Value::Atom("source_sink")),
+                std::make_shared<Cell>(fv)
+            }));
+        std::string handle = "$stream_" + std::to_string(stream_counter++);
+        StreamEntry entry;
+        entry.file = std::move(fs);
+        entry.is_read = is_read;
+        streams.emplace(handle, std::move(entry));
+        Value sv = Value::Atom(handle);
+        CellPtr tgt = get_cell("A3");
+        if (tgt->is_unbound()) { bind_cell(tgt, sv); pc += 1; return true; }
+        if (!unify_cells(tgt, std::make_shared<Cell>(sv))) return false;
+        pc += 1; return true;
+    }
+
+    // ---- close/1 ---------------------------------------------------
+    // close(+Stream). Closes and erases the handle. Throws
+    // existence_error(stream, Stream) if the handle isn''t known.
+    if (op == "close/1") {
+        Value sv = *get_cell("A1");
+        if (sv.is_unbound())
+            return throw_iso_error(make_instantiation_error());
+        if (sv.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", sv));
+        auto it = streams.find(sv.s);
+        if (it == streams.end())
+            return throw_iso_error(Value::Compound("existence_error/2", {
+                std::make_shared<Cell>(Value::Atom("stream")),
+                std::make_shared<Cell>(sv)
+            }));
+        it->second.file->close();
+        streams.erase(it);
+        pc += 1; return true;
+    }
+
+    // ---- read_line_to_string/2 -------------------------------------
+    // read_line_to_string(+Stream, -Line). Reads up to but not
+    // including the next newline. On EOF, Line unifies with the atom
+    // end_of_file. Trailing CR (Windows CRLF) is stripped.
+    if (op == "read_line_to_string/2") {
+        Value sv = *get_cell("A1");
+        if (sv.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", sv));
+        auto it = streams.find(sv.s);
+        if (it == streams.end())
+            return throw_iso_error(Value::Compound("existence_error/2", {
+                std::make_shared<Cell>(Value::Atom("stream")),
+                std::make_shared<Cell>(sv)
+            }));
+        if (!it->second.is_read) return false;
+        std::string line;
+        if (!std::getline(*it->second.file, line)) {
+            Value eof = Value::Atom("end_of_file");
+            CellPtr tgt = get_cell("A2");
+            if (tgt->is_unbound()) { bind_cell(tgt, eof); pc += 1; return true; }
+            if (!unify_cells(tgt, std::make_shared<Cell>(eof))) return false;
+            pc += 1; return true;
+        }
+        if (!line.empty() && line.back() == ''\\r'') line.pop_back();
+        Value lv = Value::Atom(line);
+        CellPtr tgt = get_cell("A2");
+        if (tgt->is_unbound()) { bind_cell(tgt, lv); pc += 1; return true; }
+        if (!unify_cells(tgt, std::make_shared<Cell>(lv))) return false;
+        pc += 1; return true;
+    }
+
+    // ---- read_string/5 ---------------------------------------------
+    // read_string(+Stream, +Length, ?Length, -String) -- a subset
+    // of SWI''s 5-arg form. With +Length, reads up to Length chars
+    // (less if EOF reached); the third arg unifies with the actual
+    // count read. The fourth arg (PadEnd in SWI; sometimes used as
+    // a sentinel) is accepted but ignored in our minimal impl.
+    if (op == "read_string/5") {
+        Value sv = *get_cell("A1");
+        Value lv = *get_cell("A2");
+        if (sv.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", sv));
+        if (lv.tag != Value::Tag::Integer)
+            return throw_iso_error(make_type_error("integer", lv));
+        auto it = streams.find(sv.s);
+        if (it == streams.end())
+            return throw_iso_error(Value::Compound("existence_error/2", {
+                std::make_shared<Cell>(Value::Atom("stream")),
+                std::make_shared<Cell>(sv)
+            }));
+        if (!it->second.is_read) return false;
+        std::string buf;
+        buf.resize((std::size_t)lv.i);
+        it->second.file->read(&buf[0], lv.i);
+        std::streamsize got = it->second.file->gcount();
+        buf.resize((std::size_t)got);
+        Value count_v = Value::Integer((std::int64_t)got);
+        Value str_v = Value::Atom(buf);
+        CellPtr tgt3 = get_cell("A3");
+        if (tgt3->is_unbound()) bind_cell(tgt3, count_v);
+        else if (!unify_cells(tgt3, std::make_shared<Cell>(count_v))) return false;
+        CellPtr tgt5 = get_cell("A5");
+        if (tgt5->is_unbound()) bind_cell(tgt5, str_v);
+        else if (!unify_cells(tgt5, std::make_shared<Cell>(str_v))) return false;
+        pc += 1; return true;
+    }
+
+    // ---- at_end_of_stream/1 ----------------------------------------
+    // at_end_of_stream(+Stream). Succeeds when the next read on
+    // Stream would yield EOF.
+    if (op == "at_end_of_stream/1") {
+        Value sv = *get_cell("A1");
+        if (sv.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", sv));
+        auto it = streams.find(sv.s);
+        if (it == streams.end())
+            return throw_iso_error(Value::Compound("existence_error/2", {
+                std::make_shared<Cell>(Value::Atom("stream")),
+                std::make_shared<Cell>(sv)
+            }));
+        if (!it->second.is_read) return false;
+        std::fstream& f = *it->second.file;
+        if (f.eof()) { pc += 1; return true; }
+        int c = f.peek();
+        if (c == EOF) { pc += 1; return true; }
+        return false;
+    }
+
+    // ---- write_to_stream/2 -----------------------------------------
+    // write_to_stream(+Stream, +Term). Renders Term and writes it
+    // (no newline). Companion: nl_to_stream/1 writes one newline.
+    // Not standard SWI; convenient before with_output_to(stream(_),...)
+    // lands.
+    if (op == "write_to_stream/2") {
+        Value sv = *get_cell("A1");
+        if (sv.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", sv));
+        auto it = streams.find(sv.s);
+        if (it == streams.end())
+            return throw_iso_error(Value::Compound("existence_error/2", {
+                std::make_shared<Cell>(Value::Atom("stream")),
+                std::make_shared<Cell>(sv)
+            }));
+        if (it->second.is_read) return false;
+        Value v = *get_cell("A2");
+        *it->second.file << render(v);
+        pc += 1; return true;
+    }
+    if (op == "nl_to_stream/1") {
+        Value sv = *get_cell("A1");
+        if (sv.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", sv));
+        auto it = streams.find(sv.s);
+        if (it == streams.end())
+            return throw_iso_error(Value::Compound("existence_error/2", {
+                std::make_shared<Cell>(Value::Atom("stream")),
+                std::make_shared<Cell>(sv)
+            }));
+        if (it->second.is_read) return false;
+        *it->second.file << ''\\n'';
         pc += 1; return true;
     }
 

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1511,6 +1511,13 @@ is_builtin_pred(get_time, 1).           % get_time(-Stamp), Float since epoch.
 is_builtin_pred(stamp_date_time, 3).    % stamp_date_time(+Stamp, -DT, +TZ).
 is_builtin_pred(date_time_stamp, 2).    % date_time_stamp(+DT, -Stamp).
 is_builtin_pred(format_time, 3).        % format_time(-Atom, +Fmt, +Stamp).
+is_builtin_pred(open, 3).               % open(+File, +Mode, -Stream).
+is_builtin_pred(close, 1).              % close(+Stream).
+is_builtin_pred(read_line_to_string, 2). % read_line_to_string(+Stream, -Line).
+is_builtin_pred(read_string, 5).        % read_string(+S, +L, ?L, _, -String).
+is_builtin_pred(at_end_of_stream, 1).   % at_end_of_stream(+Stream).
+is_builtin_pred(write_to_stream, 2).    % write_to_stream(+S, +Term).
+is_builtin_pred(nl_to_stream, 1).       % nl_to_stream(+S).
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -273,6 +273,12 @@
 :- dynamic user:wam_cpp_test_idx_drop_first/0.
 :- dynamic user:wam_cpp_test_idx_keep_first/0.
 :- dynamic user:wam_cpp_test_idx_mixed/0.
+:- dynamic user:wam_cpp_test_stream_roundtrip/0.
+:- dynamic user:wam_cpp_test_stream_read_string/0.
+:- dynamic user:wam_cpp_test_stream_append/0.
+:- dynamic user:wam_cpp_test_stream_at_end/0.
+:- dynamic user:wam_cpp_test_stream_missing_file/0.
+:- dynamic user:wam_cpp_test_stream_close_unknown/0.
 :- dynamic user:wam_cpp_test_enum_member/0.
 
 user:wam_cpp_test_member_yes   :- member(b, [a, b, c]).
@@ -600,6 +606,60 @@ user:wam_cpp_test_idx_drop_first  :- wam_cpp_idx_bar([5, 15], R), R = [15].
 user:wam_cpp_test_idx_keep_first  :- wam_cpp_idx_bar([15, 5], R), R = [15].
 user:wam_cpp_test_idx_mixed       :- wam_cpp_idx_bar([5, 15, 7, 20], R),
                                      R = [15, 20].
+% Stream I/O: open/close + read_line_to_string + read_string +
+% at_end_of_stream + write_to_stream/nl_to_stream. Each test
+% creates a temp file in /tmp, exercises the path, then cleans up
+% (we just leave the file -- /tmp is ephemeral).
+user:wam_cpp_test_stream_roundtrip :-
+    open('/tmp/wam_stream_t1.txt', write, W),
+    write_to_stream(W, 'line one'), nl_to_stream(W),
+    write_to_stream(W, 'line two'), nl_to_stream(W),
+    close(W),
+    open('/tmp/wam_stream_t1.txt', read, R),
+    read_line_to_string(R, L1),
+    read_line_to_string(R, L2),
+    read_line_to_string(R, EOF),
+    close(R),
+    L1 = 'line one', L2 = 'line two', EOF = end_of_file.
+user:wam_cpp_test_stream_read_string :-
+    open('/tmp/wam_stream_t2.txt', write, W),
+    write_to_stream(W, 'hello world'),
+    close(W),
+    open('/tmp/wam_stream_t2.txt', read, R),
+    read_string(R, 5, N1, _, S1),
+    read_string(R, 100, N2, _, S2),
+    close(R),
+    S1 = 'hello', N1 = 5,
+    S2 = ' world', N2 = 6.
+user:wam_cpp_test_stream_append :-
+    open('/tmp/wam_stream_t3.txt', write, W1),
+    write_to_stream(W1, 'first'), nl_to_stream(W1),
+    close(W1),
+    open('/tmp/wam_stream_t3.txt', append, W2),
+    write_to_stream(W2, 'second'), nl_to_stream(W2),
+    close(W2),
+    open('/tmp/wam_stream_t3.txt', read, R),
+    read_line_to_string(R, L1),
+    read_line_to_string(R, L2),
+    close(R),
+    L1 = 'first', L2 = 'second'.
+user:wam_cpp_test_stream_at_end :-
+    open('/tmp/wam_stream_t4.txt', write, W),
+    write_to_stream(W, 'one'), nl_to_stream(W),
+    close(W),
+    open('/tmp/wam_stream_t4.txt', read, R),
+    \+ at_end_of_stream(R),
+    read_line_to_string(R, _),
+    at_end_of_stream(R),
+    close(R).
+user:wam_cpp_test_stream_missing_file :-
+    catch(open('/tmp/wam_stream_does_not_exist.xyz', read, _),
+          error(existence_error(source_sink, _), _),
+          true).
+user:wam_cpp_test_stream_close_unknown :-
+    catch(close(no_such_handle),
+          error(existence_error(stream, _), _),
+          true).
 user:wam_cpp_test_enum_member  :- findall(X, member(X, [a, b, c]), L),
                                   L = [a, b, c].
 
@@ -3688,6 +3748,31 @@ test(cpp_e2e_indexing_backtrack, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_idx_drop_first/0', [], true),
           run_query(BinPath, 'wam_cpp_test_idx_keep_first/0', [], true),
           run_query(BinPath, 'wam_cpp_test_idx_mixed/0',      [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_stream_io, [condition(cpp_compiler_available)]) :-
+    % Stream I/O foundation: open/3, close/1, read_line_to_string/2,
+    % read_string/5, at_end_of_stream/1, write_to_stream/2,
+    % nl_to_stream/1. Each test creates a temp file in /tmp and
+    % exercises one path. Files are left in place; /tmp is ephemeral.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_stream', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_stream_roundtrip/0,
+                               user:wam_cpp_test_stream_read_string/0,
+                               user:wam_cpp_test_stream_append/0,
+                               user:wam_cpp_test_stream_at_end/0,
+                               user:wam_cpp_test_stream_missing_file/0,
+                               user:wam_cpp_test_stream_close_unknown/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_stream_roundtrip/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_stream_read_string/0',   [], true),
+          run_query(BinPath, 'wam_cpp_test_stream_append/0',        [], true),
+          run_query(BinPath, 'wam_cpp_test_stream_at_end/0',        [], true),
+          run_query(BinPath, 'wam_cpp_test_stream_missing_file/0',  [], true),
+          run_query(BinPath, 'wam_cpp_test_stream_close_unknown/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

First cut at **file-based stream I/O**. Adds a stream registry to `WamState` and seven builtins covering the read + write paths so generated programs can read config / log files / parse input without going through stdin or environment vars.

### Stream representation

`WamState` gains a `streams` map (`string → StreamEntry`) and a `stream_counter` for handle minting. `StreamEntry` owns a `std::unique_ptr<std::fstream>` so RAII closes the file even if the user forgets `close/1`. Handles are atoms of the form `'$stream_N'` returned from `open/3` and consumed by read/write builtins.

### New builtins

| Builtin | Shape |
|---|---|
| `open/3` | `open(+File, +Mode, -Stream)`. Modes: `read` \| `write` \| `append` |
| `close/1` | `close(+Stream)` — closes + erases the handle |
| `read_line_to_string/2` | reads up to next newline; CRLF stripped; EOF binds `end_of_file` |
| `read_string/5` | `read_string(+S, +Len, ?Got, _Pad, -Str)` — reads up to `Len` chars |
| `at_end_of_stream/1` | succeeds when next read would yield EOF |
| `write_to_stream/2` | renders Term and writes (no newline) |
| `nl_to_stream/1` | writes one newline |

### Error shapes

ISO-style via the existing `throw_iso_error` path:

- `error(existence_error(source_sink, File), _)` — missing file on read.
- `error(existence_error(stream, Stream), _)` — unknown handle.
- `error(type_error(atom, X), _)` — non-atom Stream/File.
- `error(domain_error(io_mode, Mode), _)` — bad mode atom.
- `error(instantiation_error, _)` — unbound File or Mode.

### Implementation notes

- `<fstream>` added to both the runtime header and the runtime source. The header needs it because `StreamEntry` holds `std::unique_ptr<std::fstream>` — the unique_ptr destructor needs the complete type at the point of `WamState` destruction.
- All ops route lookups through the streams map. Failed reads surface as fail or EOF binding (whichever is more idiomatic per builtin); existence + type errors throw ISO.

### Tests

One new `cpp_e2e_stream_io` bundle with **6 cases**:

- **Roundtrip**: write 2 lines + read back + verify EOF marker on third read.
- **read_string**: split file content into 5-char prefix + remainder, verify both `Got` count and string match.
- **Append**: append mode adds to existing file rather than truncating.
- **at_end_of_stream**: transitions from `false` to `true` after reading the file's one line.
- **Missing file**: open with read mode throws `existence_error(source_sink, _)`.
- **Unknown handle**: close on garbage handle throws `existence_error(stream, _)`.

### Deferred

`with_output_to(stream(_), Goal)` is deferred — it needs integration with the existing `emit_output` / output-capture-frame machinery and is bigger than the rest of this PR. The `write_to_stream/2` + `nl_to_stream/1` pair covers the immediate need without that infra.

Full `test_wam_cpp_generator` suite (356 tests) passes; `test_wam_target` unchanged and green.

## Test plan

- [x] Smoke test `/tmp` — all 6 cases pass.
- [x] `test_wam_target` regression — all green.
- [x] Full `test_wam_cpp_generator` (356 tests) — all green.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_