### PR TITLE
feat(wam-clojure): lower atomic_list_concat builtins

### DIFF
--- a/PR_WAM_CLOJURE_ATOMIC_LIST_CONCAT.md
+++ b/PR_WAM_CLOJURE_ATOMIC_LIST_CONCAT.md
@@ -1,0 +1,22 @@
+# PR Title
+
+feat(wam-clojure): lower atomic_list_concat builtins
+
+# PR Description
+
+## Summary
+
+- Adds direct lowered Clojure WAM support for `atomic_list_concat/2` and `atomic_list_concat/3`.
+- Implements a runtime helper that handles the bound-list concatenation direction and unifies the joined atom output.
+- Adds lowered-emitter assertions and runtime smoke coverage for success, mismatch, improper-list, and unsupported unbound-list cases.
+
+## Scope
+
+This is a conservative parity step for the Clojure lowered WAM tier. It supports deterministic list-bound uses such as `atomic_list_concat([f,o,o], A)` and `atomic_list_concat([f,o], o, A)`. Modes requiring splitting an atom/string back into list parts remain unsupported and fail through the existing backtracking path.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -476,6 +476,14 @@ clojure_direct_builtin("downcase_atom/2", "2").
 clojure_direct_builtin("downcase_atom/2", 2).
 clojure_direct_builtin('downcase_atom/2', "2").
 clojure_direct_builtin('downcase_atom/2', 2).
+clojure_direct_builtin("atomic_list_concat/2", "2").
+clojure_direct_builtin("atomic_list_concat/2", 2).
+clojure_direct_builtin('atomic_list_concat/2', "2").
+clojure_direct_builtin('atomic_list_concat/2', 2).
+clojure_direct_builtin("atomic_list_concat/3", "3").
+clojure_direct_builtin("atomic_list_concat/3", 3).
+clojure_direct_builtin('atomic_list_concat/3', "3").
+clojure_direct_builtin('atomic_list_concat/3', 3).
 clojure_direct_builtin("string_to_atom/2", "2").
 clojure_direct_builtin("string_to_atom/2", 2).
 clojure_direct_builtin('string_to_atom/2', "2").
@@ -881,6 +889,13 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     ),
     !,
     format(atom(Expr), '(runtime/apply-atom-case-solution ~w "~w")', [S, Op]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (   Op == "atomic_list_concat/2" ; Op == 'atomic_list_concat/2'
+    ;   Op == "atomic_list_concat/3" ; Op == 'atomic_list_concat/3'
+    ),
+    !,
+    format(atom(Expr), '(runtime/apply-atomic-list-concat-solution ~w "~w")', [S, Op]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "char_code/2" ; Op == 'char_code/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1129,6 +1129,33 @@
           (backtrack state)))
       (backtrack state))))
 
+(defn atomic-concat-text [state value]
+  (or (atom-text state value)
+      (number-text value)))
+
+(defn apply-atomic-list-concat-solution [state pred]
+  (let [list-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        separator-value (when (= pred "atomic_list_concat/3")
+                          (deref-value (:bindings state)
+                                       (or (reg-get-raw state "A2") ::unbound)))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state (if (= pred "atomic_list_concat/3") "A3" "A2")) ::unbound))
+        items (proper-list-items state list-value)
+        separator-text (if (= pred "atomic_list_concat/3")
+                         (atomic-concat-text state separator-value)
+                         "")]
+    (if (and (some? items) (some? separator-text))
+      (let [texts (map #(atomic-concat-text state %) items)]
+        (if (every? some? texts)
+          (let [joined (str/join separator-text texts)
+                [ok unified-state] (unify-text-atom-value state out joined)]
+            (if ok
+              (advance unified-state)
+              (backtrack state)))
+          (backtrack state)))
+      (backtrack state))))
+
 (defn char-code-text [state value]
   (let [text (atom-text state value)]
     (when (and (string? text) (= 1 (count text)))
@@ -2077,6 +2104,12 @@
 
           "downcase_atom/2"
           (apply-atom-case-solution state (:pred instr))
+
+          "atomic_list_concat/2"
+          (apply-atomic-list-concat-solution state (:pred instr))
+
+          "atomic_list_concat/3"
+          (apply-atomic-list-concat-solution state (:pred instr))
 
           "string_to_atom/2"
           (apply-atom-string-solution state (:pred instr))

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -744,6 +744,26 @@ test(simple_builtin_downcase_atom_is_direct_lowered_in_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
+test(simple_builtin_atomic_list_concat_2_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_atomic_list_concat_2/2:\nbuiltin_call atomic_list_concat/2, 2\nproceed\n",
+        wam_clojure_lowerable(test_atomic_list_concat_2/2, WamCode, deterministic),
+        lower_predicate_to_clojure(test_atomic_list_concat_2/2, WamCode, [], Code),
+        has(Code, "runtime/apply-atomic-list-concat-solution"),
+        has(Code, "atomic_list_concat/2"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
+test(simple_builtin_atomic_list_concat_3_is_direct_lowered_in_prefix) :-
+    once((
+        WamCode = "test_atomic_list_concat_3/3:\nbuiltin_call atomic_list_concat/3, 3\nproceed\n",
+        wam_clojure_lowerable(test_atomic_list_concat_3/3, WamCode, deterministic),
+        lower_predicate_to_clojure(test_atomic_list_concat_3/3, WamCode, [], Code),
+        has(Code, "runtime/apply-atomic-list-concat-solution"),
+        has(Code, "atomic_list_concat/3"),
+        assertion(\+ has(Code, "runtime/step"))
+    )).
+
 test(simple_builtin_string_to_atom_is_direct_lowered_in_prefix) :-
     once((
         WamCode = "test_string_to_atom/2:\nbuiltin_call string_to_atom/2, 2\nproceed\n",

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -157,6 +157,11 @@
 :- dynamic user:wam_upcase_atom_guard/2.
 :- dynamic user:wam_downcase_atom_guard/2.
 :- dynamic user:wam_upcase_atom_unbound_source/1.
+:- dynamic user:wam_atomic_list_concat_2_guard/1.
+:- dynamic user:wam_atomic_list_concat_3_guard/1.
+:- dynamic user:wam_atomic_list_concat_mismatch/0.
+:- dynamic user:wam_atomic_list_concat_bad_list/0.
+:- dynamic user:wam_atomic_list_concat_unbound_list/1.
 :- dynamic user:wam_string_to_atom_guard/2.
 :- dynamic user:wam_string_to_atom_reverse/0.
 :- dynamic user:wam_string_to_atom_unbound_pair/1.
@@ -364,6 +369,11 @@ user:wam_atom_number_unbound_pair(_) :- user:wam_unbound_arg(A), user:wam_unboun
 user:wam_upcase_atom_guard(A, U) :- upcase_atom(A, U).
 user:wam_downcase_atom_guard(A, L) :- downcase_atom(A, L).
 user:wam_upcase_atom_unbound_source(_) :- user:wam_unbound_arg(A), upcase_atom(A, _).
+user:wam_atomic_list_concat_2_guard(A) :- atomic_list_concat([f,o,o], A).
+user:wam_atomic_list_concat_3_guard(A) :- atomic_list_concat([f,o], o, A).
+user:wam_atomic_list_concat_mismatch :- atomic_list_concat([f,o], a, foo).
+user:wam_atomic_list_concat_bad_list :- atomic_list_concat([a|b], _).
+user:wam_atomic_list_concat_unbound_list(_) :- user:wam_unbound_arg(L), atomic_list_concat(L, _).
 user:wam_string_to_atom_guard(S, A) :- string_to_atom(S, A).
 user:wam_string_to_atom_reverse :- string_to_atom(world, A), A = world.
 user:wam_string_to_atom_unbound_pair(_) :- user:wam_unbound_arg(S), user:wam_unbound_arg(A), string_to_atom(S, A).
@@ -576,6 +586,11 @@ run_smoke :-
           user:wam_upcase_atom_guard/2,
           user:wam_downcase_atom_guard/2,
           user:wam_upcase_atom_unbound_source/1,
+          user:wam_atomic_list_concat_2_guard/1,
+          user:wam_atomic_list_concat_3_guard/1,
+          user:wam_atomic_list_concat_mismatch/0,
+          user:wam_atomic_list_concat_bad_list/0,
+          user:wam_atomic_list_concat_unbound_list/1,
           user:wam_string_to_atom_guard/2,
           user:wam_string_to_atom_reverse/0,
           user:wam_string_to_atom_unbound_pair/1,
@@ -945,6 +960,11 @@ smoke_cases([
     case('wam_downcase_atom_guard/2', args('HELLO', hello), "true"),
     case('wam_downcase_atom_guard/2', args('HELLO', 'HELLO'), "false"),
     case('wam_upcase_atom_unbound_source/1', a, "false"),
+    case('wam_atomic_list_concat_2_guard/1', foo, "true"),
+    case('wam_atomic_list_concat_3_guard/1', foo, "true"),
+    case('wam_atomic_list_concat_mismatch/0', no_args, "false"),
+    case('wam_atomic_list_concat_bad_list/0', no_args, "false"),
+    case('wam_atomic_list_concat_unbound_list/1', a, "false"),
     case('wam_string_to_atom_guard/2', args(hello, hello), "true"),
     case('wam_string_to_atom_guard/2', args(hello, world), "false"),
     case('wam_string_to_atom_reverse/0', no_args, "true"),
@@ -1321,6 +1341,8 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-atom-number-guard-2"),
     has(CoreCode, "defn lowered-wam-upcase-atom-guard-2"),
     has(CoreCode, "defn lowered-wam-downcase-atom-guard-2"),
+    has(CoreCode, "defn lowered-wam-atomic-list-concat-2-guard-1"),
+    has(CoreCode, "defn lowered-wam-atomic-list-concat-3-guard-1"),
     has(CoreCode, "defn lowered-wam-string-to-atom-guard-2"),
     has(CoreCode, "defn lowered-wam-string-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-string-chars-guard-2"),
@@ -1335,6 +1357,7 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "runtime/apply-atom-string-solution"),
     has(CoreCode, "runtime/apply-atom-number-solution"),
     has(CoreCode, "runtime/apply-atom-case-solution"),
+    has(CoreCode, "runtime/apply-atomic-list-concat-solution"),
     has(CoreCode, "runtime/apply-char-code-solution"),
     has(CoreCode, "runtime/apply-atom-concat-solution"),
     has(CoreCode, "runtime/apply-atom-length-solution"),


### PR DESCRIPTION
## Summary

- Adds direct lowered Clojure WAM support for `atomic_list_concat/2` and `atomic_list_concat/3`.
- Implements a runtime helper that handles the bound-list concatenation direction and unifies the joined atom output.
- Adds lowered-emitter assertions and runtime smoke coverage for success, mismatch, improper-list, and unsupported unbound-list cases.

## Scope

This is a conservative parity step for the Clojure lowered WAM tier. It supports deterministic list-bound uses such as `atomic_list_concat([f,o,o], A)` and `atomic_list_concat([f,o], o, A)`. Modes requiring splitting an atom/string back into list parts remain unsupported and fail through the existing backtracking path.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
