### PR TITLE
feat(wam-cpp): current_predicate/1 + predicate_property/2

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -5706,6 +5706,97 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         pc += 1; return true;
     }
 
+    // ---- current_predicate/1 ---------------------------------------
+    // current_predicate(?PredSpec). PredSpec is Name/Arity. Check
+    // mode: both Name and Arity bound -- succeeds iff the predicate
+    // exists in the WAM (either as a static label or in the dynamic
+    // database). Enum mode (partial spec) is deferred -- callers can
+    // use findall + a known-name list for now.
+    if (op == "current_predicate/1") {
+        Value spec = *get_cell("A1");
+        if (spec.is_unbound())
+            return throw_iso_error(make_instantiation_error());
+        if (spec.tag != Value::Tag::Compound || spec.s != "//2"
+            || spec.args.size() != 2)
+            return throw_iso_error(make_type_error("predicate_indicator", spec));
+        Value name = *spec.args[0];
+        Value arity = *spec.args[1];
+        if (name.is_unbound() || arity.is_unbound())
+            return throw_iso_error(make_instantiation_error());
+        if (name.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", name));
+        if (arity.tag != Value::Tag::Integer)
+            return throw_iso_error(make_type_error("integer", arity));
+        std::string key = name.s + "/" + std::to_string(arity.i);
+        if (labels.find(key) != labels.end()) { pc += 1; return true; }
+        if (dynamic_db.find(key) != dynamic_db.end()) { pc += 1; return true; }
+        return false;
+    }
+
+    // ---- predicate_property/2 --------------------------------------
+    // predicate_property(+Head, +Property). Property is checked
+    // against the predicate''s status:
+    //   defined        -- in labels OR dynamic_db.
+    //   dynamic        -- in dynamic_db (asserted at runtime).
+    //   static         -- in labels but not dynamic_db.
+    //   number_of_clauses(?N) -- N is the number of clauses (for
+    //                    dynamic preds; for static preds we report
+    //                    1 since we can''t introspect the clause list).
+    // Head must be bound to an atom or compound term. Multi-clause
+    // ranking of properties (per ISO) is not supported in this
+    // minimal impl -- just check-mode against the current property.
+    if (op == "predicate_property/2") {
+        Value head = *get_cell("A1");
+        if (head.is_unbound())
+            return throw_iso_error(make_instantiation_error());
+        std::string key;
+        if (head.tag == Value::Tag::Atom) {
+            key = head.s + "/0";
+        } else if (head.tag == Value::Tag::Compound) {
+            // head.s is "name/arity" already.
+            key = head.s;
+        } else {
+            return throw_iso_error(make_type_error("callable", head));
+        }
+        bool in_labels = (labels.find(key) != labels.end());
+        bool in_dynamic = (dynamic_db.find(key) != dynamic_db.end());
+        Value prop = *get_cell("A2");
+        if (prop.is_unbound())
+            return throw_iso_error(make_instantiation_error());
+        if (prop.tag == Value::Tag::Atom) {
+            if (prop.s == "defined") {
+                if (in_labels || in_dynamic) { pc += 1; return true; }
+                return false;
+            }
+            if (prop.s == "dynamic") {
+                if (in_dynamic) { pc += 1; return true; }
+                return false;
+            }
+            if (prop.s == "static") {
+                if (in_labels && !in_dynamic) { pc += 1; return true; }
+                return false;
+            }
+            return throw_iso_error(make_domain_error("predicate_property", prop));
+        }
+        if (prop.tag == Value::Tag::Compound
+            && prop.s == "number_of_clauses/1" && prop.args.size() == 1) {
+            std::int64_t n;
+            if (in_dynamic) {
+                n = (std::int64_t)dynamic_db[key].size();
+            } else if (in_labels) {
+                n = 1; // best-effort: can''t introspect static clause list.
+            } else {
+                return false;
+            }
+            Value nv = Value::Integer(n);
+            CellPtr tgt = prop.args[0];
+            if (tgt->is_unbound()) { bind_cell(tgt, nv); pc += 1; return true; }
+            if (!unify_cells(tgt, std::make_shared<Cell>(nv))) return false;
+            pc += 1; return true;
+        }
+        return throw_iso_error(make_domain_error("predicate_property", prop));
+    }
+
     // ---- I/O -------------------------------------------------------
     // All write paths route through emit_output / emit_output_char so
     // with_output_to/2 can intercept them into a capture buffer.

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1518,6 +1518,8 @@ is_builtin_pred(read_string, 5).        % read_string(+S, +L, ?L, _, -String).
 is_builtin_pred(at_end_of_stream, 1).   % at_end_of_stream(+Stream).
 is_builtin_pred(write_to_stream, 2).    % write_to_stream(+S, +Term).
 is_builtin_pred(nl_to_stream, 1).       % nl_to_stream(+S).
+is_builtin_pred(current_predicate, 1).  % current_predicate(?Name/Arity).
+is_builtin_pred(predicate_property, 2). % predicate_property(+Head, +Prop).
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -279,6 +279,17 @@
 :- dynamic user:wam_cpp_test_stream_at_end/0.
 :- dynamic user:wam_cpp_test_stream_missing_file/0.
 :- dynamic user:wam_cpp_test_stream_close_unknown/0.
+:- dynamic user:wam_cpp_test_intro_static_yes/0.
+:- dynamic user:wam_cpp_test_intro_static_no/0.
+:- dynamic user:wam_cpp_test_intro_arity_no/0.
+:- dynamic user:wam_cpp_test_intro_builtin_yes/0.
+:- dynamic user:wam_cpp_test_intro_prop_defined/0.
+:- dynamic user:wam_cpp_test_intro_prop_static/0.
+:- dynamic user:wam_cpp_test_intro_prop_dynamic/0.
+:- dynamic user:wam_cpp_test_intro_prop_static_not_dynamic/0.
+:- dynamic user:wam_cpp_test_intro_prop_count/0.
+:- dynamic user:wam_cpp_test_intro_inst_throw/0.
+:- dynamic user:wam_cpp_test_intro_indicator_throw/0.
 :- dynamic user:wam_cpp_test_enum_member/0.
 
 user:wam_cpp_test_member_yes   :- member(b, [a, b, c]).
@@ -659,6 +670,47 @@ user:wam_cpp_test_stream_missing_file :-
 user:wam_cpp_test_stream_close_unknown :-
     catch(close(no_such_handle),
           error(existence_error(stream, _), _),
+          true).
+% Introspection: current_predicate/1 (check mode) and
+% predicate_property/2. Cover static lookups, dynamic-db lookups,
+% preloaded-bytecode (e.g. append/3), property atoms (defined,
+% static, dynamic), number_of_clauses/1, and the type/instantiation
+% error paths.
+:- dynamic user:wam_cpp_intro_dyn/1.
+user:wam_cpp_intro_dyn(initial).
+user:wam_cpp_intro_static(a).
+user:wam_cpp_intro_static(b).
+user:wam_cpp_test_intro_static_yes :-
+    current_predicate(wam_cpp_intro_static/1).
+user:wam_cpp_test_intro_static_no :-
+    \+ current_predicate(wam_cpp_no_such_pred/3).
+user:wam_cpp_test_intro_arity_no :-
+    \+ current_predicate(wam_cpp_intro_static/2).
+user:wam_cpp_test_intro_builtin_yes :-
+    current_predicate(append/3).
+user:wam_cpp_test_intro_prop_defined :-
+    predicate_property(wam_cpp_intro_static(_), defined).
+user:wam_cpp_test_intro_prop_static :-
+    predicate_property(wam_cpp_intro_static(_), static).
+user:wam_cpp_test_intro_prop_dynamic :-
+    assertz(wam_cpp_intro_dyn(more)),
+    predicate_property(wam_cpp_intro_dyn(_), dynamic).
+user:wam_cpp_test_intro_prop_static_not_dynamic :-
+    \+ predicate_property(wam_cpp_intro_static(_), dynamic).
+user:wam_cpp_test_intro_prop_count :-
+    retractall(wam_cpp_intro_dyn(_)),
+    assertz(wam_cpp_intro_dyn(a)),
+    assertz(wam_cpp_intro_dyn(b)),
+    assertz(wam_cpp_intro_dyn(c)),
+    predicate_property(wam_cpp_intro_dyn(_), number_of_clauses(N)),
+    N = 3.
+user:wam_cpp_test_intro_inst_throw :-
+    catch(current_predicate(_),
+          error(instantiation_error, _),
+          true).
+user:wam_cpp_test_intro_indicator_throw :-
+    catch(current_predicate(foo),
+          error(type_error(predicate_indicator, _), _),
           true).
 user:wam_cpp_test_enum_member  :- findall(X, member(X, [a, b, c]), L),
                                   L = [a, b, c].
@@ -3773,6 +3825,42 @@ test(cpp_e2e_stream_io, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_stream_at_end/0',        [], true),
           run_query(BinPath, 'wam_cpp_test_stream_missing_file/0',  [], true),
           run_query(BinPath, 'wam_cpp_test_stream_close_unknown/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_introspection, [condition(cpp_compiler_available)]) :-
+    % current_predicate/1 (check mode) + predicate_property/2:
+    % static / dynamic / defined / number_of_clauses(N), plus the
+    % expected throws on missing instantiation and bad-shape PI.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_intro', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_intro_static_yes/0,
+                               user:wam_cpp_test_intro_static_no/0,
+                               user:wam_cpp_test_intro_arity_no/0,
+                               user:wam_cpp_test_intro_builtin_yes/0,
+                               user:wam_cpp_test_intro_prop_defined/0,
+                               user:wam_cpp_test_intro_prop_static/0,
+                               user:wam_cpp_test_intro_prop_dynamic/0,
+                               user:wam_cpp_test_intro_prop_static_not_dynamic/0,
+                               user:wam_cpp_test_intro_prop_count/0,
+                               user:wam_cpp_test_intro_inst_throw/0,
+                               user:wam_cpp_test_intro_indicator_throw/0,
+                               user:wam_cpp_intro_static/1,
+                               user:wam_cpp_intro_dyn/1],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_intro_static_yes/0',           [], true),
+          run_query(BinPath, 'wam_cpp_test_intro_static_no/0',            [], true),
+          run_query(BinPath, 'wam_cpp_test_intro_arity_no/0',             [], true),
+          run_query(BinPath, 'wam_cpp_test_intro_builtin_yes/0',          [], true),
+          run_query(BinPath, 'wam_cpp_test_intro_prop_defined/0',         [], true),
+          run_query(BinPath, 'wam_cpp_test_intro_prop_static/0',          [], true),
+          run_query(BinPath, 'wam_cpp_test_intro_prop_dynamic/0',         [], true),
+          run_query(BinPath, 'wam_cpp_test_intro_prop_static_not_dynamic/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_intro_prop_count/0',           [], true),
+          run_query(BinPath, 'wam_cpp_test_intro_inst_throw/0',           [], true),
+          run_query(BinPath, 'wam_cpp_test_intro_indicator_throw/0',      [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Adds two introspection builtins for meta-programming. Both operate in **check mode**; full nondet enumeration over the labels map / dynamic_db is deferred — callers can use `findall` over a known-name list for now, and `clause/2` (runtime form) is a separate follow-up that needs a `ClauseIterator` similar to the existing `RetractIterator`.

### `current_predicate/1`

```prolog
current_predicate(?PredSpec)
```

`PredSpec` must be `Name/Arity` with both fully bound — succeeds iff the predicate exists either as a static label or as a `dynamic_db` entry. Detects pre-loaded bytecode predicates (`append/3`, `member/2`, `between/3`, etc.) the same way since they live in the labels map.

**Errors:**
- `type_error(predicate_indicator, _)` for non-`/2` specs.
- `instantiation_error` for unbound subterms (`current_predicate(_)`, `current_predicate(foo/_)`).

### `predicate_property/2`

```prolog
predicate_property(+Head, +Property)
```

`Head` must be bound to an atom or compound; its name + arity becomes the lookup key. Recognized properties:

| Property | Meaning |
|---|---|
| `defined` | in labels OR dynamic_db |
| `dynamic` | in dynamic_db (asserted at runtime) |
| `static` | in labels but not dynamic_db |
| `number_of_clauses(?N)` | dynamic: actual count; static: `1` (best-effort) |

Unknown property atoms throw `domain_error(predicate_property, _)`.

### Tests

One new `cpp_e2e_introspection` bundle with **11 cases**:

- Static predicate lookup (positive + arity-mismatch negative).
- Non-existent predicate (negative).
- Preloaded bytecode predicate (`append/3` exists via the labels map).
- Property atoms: `defined`, `static`, `dynamic`, plus a negative-direction check (static pred isn't dynamic).
- `number_of_clauses(N)` for a dynamic pred after three `assertz` calls.
- Two throw paths: instantiation error and bad-shape PI.

### Deferred

- **Nondet enumeration**: `current_predicate(Name/_)` enumerating all arities, or `current_predicate(_/Arity)` enumerating all names. Needs a CP-iterator pattern.
- **`clause/2` runtime form**: would let callers walk a dynamic predicate's body terms. Needs a `ClauseIterator` paralleling the existing `RetractIterator`.

Full `test_wam_cpp_generator` suite (357 tests) passes; `test_wam_target` unchanged and green.

## Test plan

- [x] Smoke test `/tmp` — all 11 cases pass.
- [x] `test_wam_target` regression — all green.
- [x] Full `test_wam_cpp_generator` (357 tests) — all green.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_