### PR TITLE
feat(wam-cpp): filesystem helpers + with_output_to(stream(_))

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -2896,6 +2896,7 @@ compile_wam_runtime_to_cpp(_Options,
 #include <cmath>
 #include <cstdio>
 #include <ctime>
+#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <random>
@@ -5706,6 +5707,95 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         pc += 1; return true;
     }
 
+    // ---- Filesystem helpers ----------------------------------------
+    // Thin wrappers over std::filesystem. Path arguments must be
+    // bound atoms; non-atom paths throw type_error(atom, _).
+    if (op == "exists_file/1") {
+        Value p = *get_cell("A1");
+        if (p.is_unbound())
+            return throw_iso_error(make_instantiation_error());
+        if (p.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", p));
+        std::error_code ec;
+        bool ok = std::filesystem::is_regular_file(p.s, ec);
+        if (!ok) return false;
+        pc += 1; return true;
+    }
+    if (op == "exists_directory/1") {
+        Value p = *get_cell("A1");
+        if (p.is_unbound())
+            return throw_iso_error(make_instantiation_error());
+        if (p.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", p));
+        std::error_code ec;
+        bool ok = std::filesystem::is_directory(p.s, ec);
+        if (!ok) return false;
+        pc += 1; return true;
+    }
+    if (op == "directory_files/2") {
+        Value p = *get_cell("A1");
+        if (p.is_unbound())
+            return throw_iso_error(make_instantiation_error());
+        if (p.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", p));
+        std::error_code ec;
+        if (!std::filesystem::is_directory(p.s, ec))
+            return throw_iso_error(Value::Compound("existence_error/2", {
+                std::make_shared<Cell>(Value::Atom("directory")),
+                std::make_shared<Cell>(p)
+            }));
+        std::vector<std::string> names;
+        names.push_back(".");
+        names.push_back("..");
+        for (auto& entry : std::filesystem::directory_iterator(p.s, ec)) {
+            names.push_back(entry.path().filename().string());
+        }
+        // Standard ordering: SWI returns names in unspecified order;
+        // we sort lexically for deterministic test output.
+        std::sort(names.begin() + 2, names.end());
+        CellPtr list = std::make_shared<Cell>(Value::Atom("[]"));
+        for (auto it = names.rbegin(); it != names.rend(); ++it) {
+            std::vector<CellPtr> ca;
+            ca.push_back(std::make_shared<Cell>(Value::Atom(*it)));
+            ca.push_back(list);
+            list = std::make_shared<Cell>(
+                Value::Compound("[|]/2", std::move(ca)));
+        }
+        if (!unify_cells(get_cell("A2"), list)) return false;
+        pc += 1; return true;
+    }
+    if (op == "make_directory/1") {
+        Value p = *get_cell("A1");
+        if (p.is_unbound())
+            return throw_iso_error(make_instantiation_error());
+        if (p.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", p));
+        std::error_code ec;
+        std::filesystem::create_directory(p.s, ec);
+        if (ec)
+            return throw_iso_error(Value::Compound("permission_error/3", {
+                std::make_shared<Cell>(Value::Atom("create")),
+                std::make_shared<Cell>(Value::Atom("directory")),
+                std::make_shared<Cell>(p)
+            }));
+        pc += 1; return true;
+    }
+    if (op == "delete_file/1") {
+        Value p = *get_cell("A1");
+        if (p.is_unbound())
+            return throw_iso_error(make_instantiation_error());
+        if (p.tag != Value::Tag::Atom)
+            return throw_iso_error(make_type_error("atom", p));
+        std::error_code ec;
+        bool ok = std::filesystem::remove(p.s, ec);
+        if (!ok || ec)
+            return throw_iso_error(Value::Compound("existence_error/2", {
+                std::make_shared<Cell>(Value::Atom("source_sink")),
+                std::make_shared<Cell>(p)
+            }));
+        pc += 1; return true;
+    }
+
     // ---- current_predicate/1 ---------------------------------------
     // current_predicate(?PredSpec). PredSpec is Name/Arity. Check
     // mode: both Name and Arity bound -- succeeds iff the predicate
@@ -5890,15 +5980,17 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
     }
     // ---- with_output_to/2 -------------------------------------------
     // with_output_to(+Sink, :Goal): capture Goal''s output into Sink.
-    // Sink is atom(V) / string(V) / codes(V). The I/O builtins write
-    // to the top OutputCaptureFrame''s buffer while it''s active; when
-    // Goal proceeds normally, control lands at output_capture_return_pc
-    // which pops the frame and unifies the buffer with Sink.
+    // Sink is atom(V) / string(V) / codes(V) / stream(Handle).
+    // The I/O builtins write to the top OutputCaptureFrame''s buffer
+    // while it''s active; when Goal proceeds normally, control lands
+    // at output_capture_return_pc which pops the frame and either
+    // unifies the buffer with the sink''s arg (atom/string/codes) or
+    // writes the buffer to the stream (stream(Handle)).
     if (op == "with_output_to/2") {
         Value sv = deref(*get_cell("A1"));
         if (sv.tag != Value::Tag::Compound || sv.args.size() != 1
             || (sv.s != "atom/1" && sv.s != "string/1"
-                && sv.s != "codes/1")) return false;
+                && sv.s != "codes/1" && sv.s != "stream/1")) return false;
         OutputCaptureFrame f;
         f.sink = get_cell("A1");
         // saved_cp: for the direct BuiltinCall instr path, pc + 1
@@ -6677,6 +6769,21 @@ bool WamState::step(const Instruction& instr) {
             Value sink = deref(*f.sink);
             if (sink.tag != Value::Tag::Compound
                 || sink.args.size() != 1) return false;
+            // stream/1 sink: write the buffer to the stream and skip
+            // unification entirely. Stream must already be open in
+            // write or append mode.
+            if (sink.s == "stream/1") {
+                Value sh = *sink.args[0];
+                if (sh.tag != Value::Tag::Atom) return false;
+                auto sit = streams.find(sh.s);
+                if (sit == streams.end()) return false;
+                if (sit->second.is_read) return false;
+                *sit->second.file << f.buffer;
+                if (f.saved_cp == 0) { halt = true; return true; }
+                pc = f.saved_cp;
+                cp = 0;
+                return true;
+            }
             CellPtr tgt = sink.args[0];
             Value out_v;
             if (sink.s == "atom/1" || sink.s == "string/1") {

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1520,6 +1520,11 @@ is_builtin_pred(write_to_stream, 2).    % write_to_stream(+S, +Term).
 is_builtin_pred(nl_to_stream, 1).       % nl_to_stream(+S).
 is_builtin_pred(current_predicate, 1).  % current_predicate(?Name/Arity).
 is_builtin_pred(predicate_property, 2). % predicate_property(+Head, +Prop).
+is_builtin_pred(exists_file, 1).        % exists_file(+Path).
+is_builtin_pred(exists_directory, 1).   % exists_directory(+Path).
+is_builtin_pred(directory_files, 2).    % directory_files(+Dir, -Files).
+is_builtin_pred(make_directory, 1).     % make_directory(+Path).
+is_builtin_pred(delete_file, 1).        % delete_file(+Path).
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -290,6 +290,16 @@
 :- dynamic user:wam_cpp_test_intro_prop_count/0.
 :- dynamic user:wam_cpp_test_intro_inst_throw/0.
 :- dynamic user:wam_cpp_test_intro_indicator_throw/0.
+:- dynamic user:wam_cpp_test_fs_exists_file_yes/0.
+:- dynamic user:wam_cpp_test_fs_exists_file_no/0.
+:- dynamic user:wam_cpp_test_fs_exists_dir_yes/0.
+:- dynamic user:wam_cpp_test_fs_exists_dir_no/0.
+:- dynamic user:wam_cpp_test_fs_make_check/0.
+:- dynamic user:wam_cpp_test_fs_dir_files/0.
+:- dynamic user:wam_cpp_test_fs_delete/0.
+:- dynamic user:wam_cpp_test_fs_delete_missing/0.
+:- dynamic user:wam_cpp_test_wos_stream/0.
+:- dynamic user:wam_cpp_test_wos_format/0.
 :- dynamic user:wam_cpp_test_enum_member/0.
 
 user:wam_cpp_test_member_yes   :- member(b, [a, b, c]).
@@ -712,6 +722,52 @@ user:wam_cpp_test_intro_indicator_throw :-
     catch(current_predicate(foo),
           error(type_error(predicate_indicator, _), _),
           true).
+% Filesystem helpers + with_output_to(stream(_), G). Each test
+% sets up its own temp file/dir in /tmp. Tests are sequenced so
+% they don't collide on shared paths.
+user:wam_cpp_test_fs_exists_file_yes :- exists_file('/etc/hostname').
+user:wam_cpp_test_fs_exists_file_no  :- \+ exists_file('/no/such/x.zzz').
+user:wam_cpp_test_fs_exists_dir_yes  :- exists_directory('/tmp').
+user:wam_cpp_test_fs_exists_dir_no   :- \+ exists_directory('/no/such/dir').
+user:wam_cpp_test_fs_make_check :-
+    catch(delete_file('/tmp/wam_e2e_makedir/.keep'), _, true),
+    catch(delete_file('/tmp/wam_e2e_makedir'), _, true),
+    make_directory('/tmp/wam_e2e_makedir'),
+    exists_directory('/tmp/wam_e2e_makedir').
+user:wam_cpp_test_fs_dir_files :-
+    catch(make_directory('/tmp/wam_e2e_dir'), _, true),
+    open('/tmp/wam_e2e_dir/file_a.txt', write, W1), close(W1),
+    open('/tmp/wam_e2e_dir/file_b.txt', write, W2), close(W2),
+    directory_files('/tmp/wam_e2e_dir', Files),
+    member('file_a.txt', Files),
+    member('file_b.txt', Files),
+    member('.', Files),
+    member('..', Files).
+user:wam_cpp_test_fs_delete :-
+    open('/tmp/wam_e2e_to_delete.txt', write, W), close(W),
+    exists_file('/tmp/wam_e2e_to_delete.txt'),
+    delete_file('/tmp/wam_e2e_to_delete.txt'),
+    \+ exists_file('/tmp/wam_e2e_to_delete.txt').
+user:wam_cpp_test_fs_delete_missing :-
+    catch(delete_file('/no/such/file.zzz'),
+          error(existence_error(source_sink, _), _),
+          true).
+user:wam_cpp_test_wos_stream :-
+    open('/tmp/wam_e2e_wos.txt', write, S),
+    with_output_to(stream(S), (write(hello), write(' '), write(world))),
+    close(S),
+    open('/tmp/wam_e2e_wos.txt', read, R),
+    read_line_to_string(R, Line),
+    close(R),
+    Line = 'hello world'.
+user:wam_cpp_test_wos_format :-
+    open('/tmp/wam_e2e_wos2.txt', write, S),
+    with_output_to(stream(S), format("~w-~w", [42, ok])),
+    close(S),
+    open('/tmp/wam_e2e_wos2.txt', read, R),
+    read_line_to_string(R, Line),
+    close(R),
+    Line = '42-ok'.
 user:wam_cpp_test_enum_member  :- findall(X, member(X, [a, b, c]), L),
                                   L = [a, b, c].
 
@@ -3861,6 +3917,39 @@ test(cpp_e2e_introspection, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_intro_prop_count/0',           [], true),
           run_query(BinPath, 'wam_cpp_test_intro_inst_throw/0',           [], true),
           run_query(BinPath, 'wam_cpp_test_intro_indicator_throw/0',      [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_fs_and_wos, [condition(cpp_compiler_available)]) :-
+    % Filesystem helpers (exists_file/1, exists_directory/1,
+    % directory_files/2, make_directory/1, delete_file/1) plus
+    % with_output_to(stream(_), Goal) which completes the stream PR
+    % by routing the existing output-capture frame to a stream sink.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_fsws', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_fs_exists_file_yes/0,
+                               user:wam_cpp_test_fs_exists_file_no/0,
+                               user:wam_cpp_test_fs_exists_dir_yes/0,
+                               user:wam_cpp_test_fs_exists_dir_no/0,
+                               user:wam_cpp_test_fs_make_check/0,
+                               user:wam_cpp_test_fs_dir_files/0,
+                               user:wam_cpp_test_fs_delete/0,
+                               user:wam_cpp_test_fs_delete_missing/0,
+                               user:wam_cpp_test_wos_stream/0,
+                               user:wam_cpp_test_wos_format/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_fs_exists_file_yes/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_fs_exists_file_no/0',  [], true),
+          run_query(BinPath, 'wam_cpp_test_fs_exists_dir_yes/0',  [], true),
+          run_query(BinPath, 'wam_cpp_test_fs_exists_dir_no/0',   [], true),
+          run_query(BinPath, 'wam_cpp_test_fs_make_check/0',      [], true),
+          run_query(BinPath, 'wam_cpp_test_fs_dir_files/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_fs_delete/0',          [], true),
+          run_query(BinPath, 'wam_cpp_test_fs_delete_missing/0',  [], true),
+          run_query(BinPath, 'wam_cpp_test_wos_stream/0',         [], true),
+          run_query(BinPath, 'wam_cpp_test_wos_format/0',         [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Two complementary additions that round out the file-IO surface from PR #2275.

### Filesystem helpers

Thin wrappers over `std::filesystem`:

| Builtin | Behavior |
|---|---|
| `exists_file/1` | regular-file existence check |
| `exists_directory/1` | directory existence check |
| `directory_files/2` | `directory_files(+Dir, -Files)`. Returns `"."`/`".."` plus lexically-sorted entry names. Throws `existence_error(directory, _)` if Dir isn't a directory |
| `make_directory/1` | create a directory; throws `permission_error(create, directory, _)` on failure |
| `delete_file/1` | remove a file; throws `existence_error(source_sink, _)` when the path doesn't exist |

All take an atom path; non-atom throws `type_error(atom, _)`; unbound throws `instantiation_error`.

### `with_output_to(stream(Handle), Goal)`

Completes the deferred item from PR #2275. Adds a `stream/1` sink shape to the existing `OutputCaptureFrame` machinery. When the captured Goal proceeds, the buffer is written to the stream rather than unified with the sink's arg. Stream must already be open in write or append mode.

Lets generated code redirect the standard `write/1`, `format/2`, `nl/0` family to a file without sprinkling `write_to_stream/2` calls:

```prolog
?- open('/tmp/log.txt', write, S),
   with_output_to(stream(S), format("count=~w~n", [42])),
   close(S).
```

### Implementation notes

- `<filesystem>` added to the runtime source includes.
- The `stream/1` branch in `Op::OutputCaptureReturn` looks up the stream handle in the existing `streams` map (from PR #2275); a read-mode stream fails. The branch short-circuits before the atom/string/codes unification path so no sink-unify happens for stream sinks.
- `with_output_to/2`'s dispatch was extended to accept `stream/1` in its sink-shape filter.

### Tests

One new `cpp_e2e_fs_and_wos` bundle with **10 cases**:

- `exists_file` / `exists_directory` positive + negative.
- `make_directory` + `exists_directory` roundtrip.
- `directory_files` lists files plus the `./..` entries.
- `delete_file` plus the `existence_error` throw on a missing path.
- `with_output_to(stream(S), write/3)` writes `"hello world"`.
- `with_output_to(stream(S), format(...))` writes formatted text.

Full `test_wam_cpp_generator` suite (358 tests) passes; `test_wam_target` unchanged and green.

## Test plan

- [x] Smoke test `/tmp` — all 10 cases pass.
- [x] `test_wam_target` regression — all green.
- [x] Full `test_wam_cpp_generator` (358 tests) — all green.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_