### PR TITLE
bench(csharp-query): Write reusable policy summary artifacts

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -178,6 +178,7 @@ python examples/benchmark/benchmark_csharp_query_effective_distance_artifact_bac
   --lookup-keys 4 \
   --lookup-repetitions 1 \
   --repetitions 1 \
+  --summary-output output/csharp-query-effective-distance-summary.tsv \
   --format policy-actionable-markdown
 ```
 

--- a/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
+++ b/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
@@ -586,6 +586,11 @@ def load_summary_tsv(path: Path) -> list[SummaryRow]:
         ]
 
 
+def write_summary_tsv(path: Path, rows: list[SummaryRow]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_summary_tsv(rows) + "\n")
+
+
 def format_mode_values(values: dict[str, float], digits: int = 3) -> str:
     def format_value(value: float) -> str:
         return f"{value:.{digits}f}" if digits > 0 else str(int(value))
@@ -971,6 +976,12 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="read an existing summary-tsv artifact and render summary/policy reports without rerunning benchmarks",
     )
+    parser.add_argument(
+        "--summary-output",
+        type=Path,
+        default=None,
+        help="write the computed summary-tsv artifact while still printing the requested report",
+    )
     parser.add_argument("--keep-temp", action="store_true", help="keep the generated C# benchmark project")
     args = parser.parse_args(argv)
 
@@ -986,6 +997,8 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--max-competing-cpu-percent must be non-negative")
 
     if args.summary_input is not None:
+        if args.summary_output is not None:
+            parser.error("--summary-output cannot be used with --summary-input")
         if args.format not in SUMMARY_INPUT_FORMATS:
             parser.error("--summary-input requires a summary-* or policy-* --format")
         try:
@@ -1065,8 +1078,18 @@ def main(argv: list[str] | None = None) -> int:
                 )
             )
 
+    if args.format in SUMMARY_INPUT_FORMATS or args.summary_output is not None:
+        summaries = summarize(rows)
+        if args.summary_output is not None:
+            try:
+                write_summary_tsv(args.summary_output, summaries)
+            except OSError as error:
+                parser.error(str(error))
+    else:
+        summaries = []
+
     if args.format in SUMMARY_INPUT_FORMATS:
-        print(render_summary_based_format(args.format, summarize(rows)))
+        print(render_summary_based_format(args.format, summaries))
     elif args.format == "markdown":
         print(render_markdown(rows))
     else:

--- a/tests/test_csharp_query_effective_distance_artifact_backends.py
+++ b/tests/test_csharp_query_effective_distance_artifact_backends.py
@@ -53,6 +53,36 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "missing summary column"):
                 MODULE.load_summary_tsv(path)
 
+    def test_write_summary_tsv_creates_parent_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "nested" / "summary.tsv"
+            row = MODULE.SummaryRow(
+                {
+                    "scale": "dev",
+                    "relation": "category_parent",
+                    "rows": "6",
+                    "distinct_categories": "4",
+                    "lookup_keys": "2",
+                    "best_lookup_mode": "mmap-array",
+                    "best_lookup_col1_mode": "mmap-array",
+                    "best_bucket_mode": "mmap-array",
+                    "best_bucket_col1_mode": "mmap-array",
+                    "best_scan_mode": "preload",
+                    "smallest_artifact_mode": "mmap-array",
+                    "lookup_ms_by_mode": "mmap-array:1.250",
+                    "lookup_col1_ms_by_mode": "mmap-array:1.500",
+                    "bucket_ms_by_mode": "mmap-array:2.000",
+                    "bucket_col1_ms_by_mode": "mmap-array:2.500",
+                    "scan_ms_by_mode": "preload:1.000",
+                    "artifact_bytes_by_mode": "mmap-array:4096|preload:0",
+                }
+            )
+
+            MODULE.write_summary_tsv(path, [row])
+            loaded = MODULE.load_summary_tsv(path)
+
+        self.assertEqual([summary.values for summary in loaded], [row.values])
+
     def test_summary_input_policy_actionable_markdown_uses_existing_summary(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "summary.tsv"
@@ -126,6 +156,32 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("--summary-input requires a summary-* or policy-* --format", result.stderr)
+
+    def test_summary_input_rejects_summary_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            input_path = Path(tmp) / "summary.tsv"
+            output_path = Path(tmp) / "copy.tsv"
+            input_path.write_text("\t".join(MODULE.SUMMARY_HEADERS) + "\n")
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(SCRIPT),
+                    "--summary-input",
+                    str(input_path),
+                    "--summary-output",
+                    str(output_path),
+                    "--format",
+                    "summary-tsv",
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=60,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--summary-output cannot be used with --summary-input", result.stderr)
 
     def test_skip_missing_scale_errors_when_nothing_remains(self) -> None:
         result = subprocess.run(
@@ -242,6 +298,62 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
         self.assertIn("| Scale | Relation | Rows | Distinct values | Lookup keys | Best lookup c0 | Best lookup c1 |", result.stdout)
         self.assertIn("| dev |", result.stdout)
         self.assertIn("Smallest artifact", result.stdout)
+
+    def test_summary_output_writes_reusable_summary_artifact(self) -> None:
+        if shutil.which("dotnet") is None:
+            self.skipTest("dotnet is not available")
+        if not LIGHTNINGDB_PACKAGE.exists():
+            self.skipTest("LightningDB 0.21.0 package is not available in the local NuGet cache")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            summary_path = Path(tmp) / "summary" / "effective-distance.tsv"
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(SCRIPT),
+                    "--scales",
+                    "dev",
+                    "--lookup-keys",
+                    "4",
+                    "--lookup-repetitions",
+                    "1",
+                    "--repetitions",
+                    "1",
+                    "--format",
+                    "summary-markdown",
+                    "--summary-output",
+                    str(summary_path),
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=180,
+            )
+            self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+            self.assertTrue(summary_path.exists())
+            summaries = MODULE.load_summary_tsv(summary_path)
+
+            offline = subprocess.run(
+                [
+                    "python3",
+                    str(SCRIPT),
+                    "--summary-input",
+                    str(summary_path),
+                    "--format",
+                    "policy-actionable-markdown",
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=60,
+            )
+
+        self.assertEqual(len(summaries), 1)
+        self.assertEqual(summaries[0].values["scale"], "dev")
+        self.assertEqual(offline.returncode, 0, msg=f"stdout:\n{offline.stdout}\nstderr:\n{offline.stderr}")
+        self.assertIn("| Policy mode | Policy artifact value | Policy vs best |", offline.stdout)
 
     def test_policy_actionable_markdown_cli_reports_policy_diffs(self) -> None:
         if shutil.which("dotnet") is None:


### PR DESCRIPTION
  ## Summary

  - Adds `--summary-output <path>` to the effective-distance artifact backend benchmark.
  - Writes computed `summary-tsv` artifacts while still printing the requested report to stdout.
  - Creates parent directories for summary output paths.
  - Rejects incompatible `--summary-input` plus `--summary-output` usage.
  - Documents the summary-output workflow in the benchmark README.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py tests/test_csharp_query_lmdb_provider_smoke.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime_lmdb/UnifyWeaver.QueryRuntime.Lmdb.csproj`
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
  - `git diff --check`