### PR TITLE
feat(wam-python): add succ ISO and lax variants

### DIFF
--- a/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
+++ b/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
@@ -66,18 +66,17 @@ Survey columns: shipped means code and tests exist in the target today.
 | Error constructors and `throw_iso_error` helper | shipped | shipped | Python shipped; others not adopted |
 | `is_iso/2` / `is_lax/2` | shipped | shipped | Python shipped; others not adopted |
 | ISO/lax arithmetic compares | shipped | shipped | Python shipped; others not adopted |
-| `succ_iso/2` / `succ_lax/2` | shipped | shipped | not adopted |
+| `succ_iso/2` / `succ_lax/2` | shipped | shipped | Python shipped; others not adopted |
 | Lax IEEE-754 float divide behavior | shipped | shipped | not adopted |
 
 The C++ and Elixir targets are therefore the current reference consumers. C++
 was the first implementation; Elixir proves the design is not C++-specific.
 Python has now adopted the catch/throw substrate, ISO error constructors,
 `throw_iso_error`, per-predicate config/rewrite/audit plumbing, arithmetic
-assignment variants, and arithmetic comparison variants. It should not be
-described as fully ISO-error compatible until remaining concrete builtins also
-adopt three-form keys. R, Lua,
-Haskell, Rust, and the remaining targets are still mostly missing or partial on
-this stack.
+assignment variants, arithmetic comparison variants, and successor variants. It
+should not be described as fully ISO-error compatible until remaining concrete
+builtins also adopt three-form keys. R, Lua, Haskell, Rust, and the remaining
+targets are still mostly missing or partial on this stack.
 
 ## What Counts As Adoption
 

--- a/docs/design/WAM_PYTHON_PARITY_AUDIT.md
+++ b/docs/design/WAM_PYTHON_PARITY_AUDIT.md
@@ -29,12 +29,12 @@ matters for parity.
 
 ## ISO Error Readiness
 
-Python is **not yet an ISO-error adopter**. It now has the Prolog-level
+Python is now a partial ISO-error adopter. It has the Prolog-level
 `catch/3` and `throw/1` substrate, ISO error-term constructors,
-`throw_iso_error`, and the arithmetic/comparison builtin surface that would
-eventually receive `_iso` and `_lax` forms. It is still missing the
-config/rewrite/audit plumbing and ISO/lax builtin variants that the C++ and
-Elixir targets use.
+`throw_iso_error`, the config/rewrite/audit plumbing, and ISO/lax variants for
+arithmetic assignment, arithmetic comparison, and successor builtins. It should
+not yet be described as fully ISO-error compatible until any remaining concrete
+builtins with ISO/lax behavior are swept.
 
 Current state:
 
@@ -45,7 +45,7 @@ Current state:
 | `throw_iso_error` helper | Present | Wraps `error(ErrorTerm, Context)` and routes through `throw/1`. |
 | `is_iso/2` / `is_lax/2` | Present | ISO mode throws structured errors; `is/2` and `is_lax/2` preserve lax failure. |
 | ISO/lax arithmetic compares | Present | Six comparison variants now follow ISO/lax three-form dispatch. |
-| `succ/2` and ISO/lax variants | Missing | `succ/2` is not part of the current Python builtin baseline. |
+| `succ/2` and ISO/lax variants | Present | Lax `succ/2`/`succ_lax/2` fail silently; `succ_iso/2` throws structured instantiation, type, and domain errors. |
 | Per-predicate ISO config loader | Present | Supports `iso_errors_config(File)`, `iso_errors(Default)`, and `iso_errors(PI, Mode)` options. |
 | Per-predicate default rewrite | Present | `is/2` now rewrites to `is_iso/2` or `is_lax/2`; text-level rewrite feeds interpreter and lowered emission. |
 | ISO audit predicate | Present | `wam_python_iso_audit/3` reports builtin call sites using the shared audit shape. |
@@ -73,12 +73,12 @@ Porting `is_iso/2` first was premature before `catch/3` / `throw/1` existed.
 That substrate and the ISO error helpers are now present, so the remaining
 sequence is:
 
-1. Add `succ/2` / `succ_iso/2` / `succ_lax/2`.
-2. Sweep any remaining arithmetic builtins that need ISO/lax behavior.
+1. Sweep any remaining arithmetic builtins that need ISO/lax behavior.
+2. Extend the same three-form pattern to the next concrete builtin family that
+   needs ISO-mode errors.
 
-The next PR should therefore port the successor variants and add explicit-lax
-bypass coverage for that operator. The C++ and Elixir ISO tests provide a direct
-template for Python E2E coverage.
+The successor variants now have explicit-lax bypass coverage. The C++ and
+Elixir ISO tests remain the direct template for any next Python E2E coverage.
 
 ## Runtime Source Of Truth
 

--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -613,6 +613,42 @@ def _execute_compare_iso(state: WamState, op: str) -> bool:
     return _compare_arith(op, a, b)
 
 
+def _execute_succ_lax(state: WamState) -> bool:
+    a = deref(get_reg(state, 1), state)
+    b = deref(get_reg(state, 2), state)
+    if isinstance(a, Int):
+        if a.n < 0:
+            return False
+        return unify(get_reg(state, 2), Int(a.n + 1), state)
+    if isinstance(b, Int):
+        if b.n <= 0:
+            return False
+        return unify(get_reg(state, 1), Int(b.n - 1), state)
+    return False
+
+
+def _execute_succ_iso(state: WamState) -> bool:
+    a = deref(get_reg(state, 1), state)
+    b = deref(get_reg(state, 2), state)
+    a_unbound = isinstance(a, Var)
+    b_unbound = isinstance(b, Var)
+    if a_unbound and b_unbound:
+        return throw_iso_error(state, make_instantiation_error(state))
+    if not a_unbound and not isinstance(a, Int):
+        return throw_iso_error(state, make_type_error(state, 'integer', a))
+    if not b_unbound and not isinstance(b, Int):
+        return throw_iso_error(state, make_type_error(state, 'integer', b))
+    if isinstance(a, Int):
+        if a.n < 0:
+            return throw_iso_error(state, make_type_error(state, 'not_less_than_zero', a))
+        return unify(get_reg(state, 2), Int(a.n + 1), state)
+    if isinstance(b, Int):
+        if b.n <= 0:
+            return throw_iso_error(state, make_domain_error(state, 'not_less_than_zero', b))
+        return unify(get_reg(state, 1), Int(b.n - 1), state)
+    return False
+
+
 class WAMThrow(Exception):
     """Internal carrier for Prolog throw/1 terms."""
     def __init__(self, term: Term):
@@ -1008,6 +1044,10 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
     for op, keys in compare_iso.items():
         if builtin in keys and arity == 2:
             return _execute_compare_iso(state, op)
+    if builtin in ('succ/2', 'succ_lax/2', 'succ', 'succ_lax') and arity == 2:
+        return _execute_succ_lax(state)
+    if builtin in ('succ_iso/2', 'succ_iso') and arity == 2:
+        return _execute_succ_iso(state)
     if builtin in ('\\+/1', '\\+'):  # negation as failure
         goal = deref(get_reg(state, 1), state)
         return not _goal_succeeds_once(goal, state)

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -1351,6 +1351,7 @@ iso_errors_default_to_iso(">=/2", ">=_iso/2").
 iso_errors_default_to_iso("=</2", "=<_iso/2").
 iso_errors_default_to_iso("=:=/2", "=:=_iso/2").
 iso_errors_default_to_iso("=\\=/2", "=\\=_iso/2").
+iso_errors_default_to_iso("succ/2", "succ_iso/2").
 
 iso_errors_default_to_lax("is/2", "is_lax/2").
 iso_errors_default_to_lax(">/2", ">_lax/2").
@@ -1359,6 +1360,7 @@ iso_errors_default_to_lax(">=/2", ">=_lax/2").
 iso_errors_default_to_lax("=</2", "=<_lax/2").
 iso_errors_default_to_lax("=:=/2", "=:=_lax/2").
 iso_errors_default_to_lax("=\\=/2", "=\\=_lax/2").
+iso_errors_default_to_lax("succ/2", "succ_lax/2").
 
 %% iso_errors_resolve_options(+Options, -Config)
 %  Merges optional file config with inline options into iso_config(Default,

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -450,7 +450,12 @@ test(iso_errors_text_rewrite_uses_is_key_tables) :-
 	assertion(sub_string(CmpIso, _, _, _, "builtin_call =:=_iso/2 2")),
 	wam_python_target:iso_errors_rewrite_text(iso_config(false, []), cmp/0, Cmp0, CmpLax),
 	assertion(sub_string(CmpLax, _, _, _, "builtin_call >_lax/2 2")),
-	assertion(sub_string(CmpLax, _, _, _, "builtin_call =:=_lax/2 2")).
+	assertion(sub_string(CmpLax, _, _, _, "builtin_call =:=_lax/2 2")),
+	Succ0 = 'succ_demo/0:\n  builtin_call succ/2 2',
+	wam_python_target:iso_errors_rewrite_text(iso_config(true, []), succ_demo/0, Succ0, SuccIso),
+	assertion(sub_string(SuccIso, _, _, _, "builtin_call succ_iso/2 2")),
+	wam_python_target:iso_errors_rewrite_text(iso_config(false, []), succ_demo/0, Succ0, SuccLax),
+	assertion(sub_string(SuccLax, _, _, _, "builtin_call succ_lax/2 2")).
 
 test(iso_errors_project_generation_rewrites_wam_text) :-
 	setup_call_cleanup(
@@ -1032,8 +1037,14 @@ test(generated_runtime_runs_is_iso_and_lax_variants) :-
 			once(sub_string(Output, _, _, _, "cmp_inst")),
 			once(sub_string(Output, _, _, _, "cmp_type")),
 			once(sub_string(Output, _, _, _, "cmp_zero")),
+			once(sub_string(Output, _, _, _, "succ_inst")),
+			once(sub_string(Output, _, _, _, "succ_type")),
+			once(sub_string(Output, _, _, _, "succ_domain")),
+			once(sub_string(Output, _, _, _, "succ_forward")),
+			once(sub_string(Output, _, _, _, "succ_backward")),
 			once(sub_string(Output, _, _, _, "lax_false")),
-			once(sub_string(Output, _, _, _, "cmp_lax_false"))
+			once(sub_string(Output, _, _, _, "cmp_lax_false")),
+			once(sub_string(Output, _, _, _, "succ_lax_false"))
 		),
 		cleanup_tmp_dir(ProjectDir)).
 
@@ -1236,6 +1247,24 @@ is_iso_lax_script(Script) :-
 		"expr = wr.Compound('//2', [wr.Int(1), wr.Int(0)])",
 		"catch_is(wr.Compound('=:=_iso/2', [expr, wr.Int(0)]), wr.Compound('error/2', [wr.Compound('evaluation_error/1', [wr.make_atom('zero_divisor')]), wr.Var([None], 504)]), wr.Compound('write/1', [wr.make_atom('cmp_zero')]))",
 		"print()",
+		"catch_is(wr.Compound('succ_iso/2', [wr.Var([None], 700), wr.Var([None], 701)]), wr.Compound('error/2', [wr.make_atom('instantiation_error'), wr.Var([None], 702)]), wr.Compound('write/1', [wr.make_atom('succ_inst')]))",
+		"print()",
+		"catch_is(wr.Compound('succ_iso/2', [wr.make_atom('foo'), wr.Var([None], 703)]), wr.Compound('error/2', [wr.Compound('type_error/2', [wr.make_atom('integer'), wr.Var([None], 704)]), wr.Var([None], 705)]), wr.Compound('write/1', [wr.make_atom('succ_type')]))",
+		"print()",
+		"catch_is(wr.Compound('succ_iso/2', [wr.Var([None], 706), wr.Int(0)]), wr.Compound('error/2', [wr.Compound('domain_error/2', [wr.make_atom('not_less_than_zero'), wr.Var([None], 707)]), wr.Var([None], 708)]), wr.Compound('write/1', [wr.make_atom('succ_domain')]))",
+		"print()",
+		"s = wr.WamState()",
+		"v = wr.Var([None], 710)",
+		"wr.set_reg(s, 1, wr.Int(2))",
+		"wr.set_reg(s, 2, v)",
+		"ok = wr._execute_builtin('succ/2', 2, s) and isinstance(wr.deref(v, s), wr.Int) and wr.deref(v, s).n == 3",
+		"print('succ_forward' if ok else 'bad')",
+		"s = wr.WamState()",
+		"v = wr.Var([None], 711)",
+		"wr.set_reg(s, 1, v)",
+		"wr.set_reg(s, 2, wr.Int(3))",
+		"ok = wr._execute_builtin('succ/2', 2, s) and isinstance(wr.deref(v, s), wr.Int) and wr.deref(v, s).n == 2",
+		"print('succ_backward' if ok else 'bad')",
 		"s = wr.WamState()",
 		"wr.set_reg(s, 1, wr.Var([None], 400))",
 		"wr.set_reg(s, 2, wr.make_atom('foo'))",
@@ -1244,6 +1273,10 @@ is_iso_lax_script(Script) :-
 		"wr.set_reg(s, 1, wr.Var([None], 600))",
 		"wr.set_reg(s, 2, wr.Int(5))",
 		"print('cmp_lax_false' if not wr._execute_builtin('>_lax/2', 2, s) else 'bad')",
+		"s = wr.WamState()",
+		"wr.set_reg(s, 1, wr.Int(-1))",
+		"wr.set_reg(s, 2, wr.Var([None], 800))",
+		"print('succ_lax_false' if not wr._execute_builtin('succ_lax/2', 2, s) else 'bad')",
 		""
 	], '\n', Script).
 


### PR DESCRIPTION
## Summary

- add Python WAM runtime support for `succ/2`, `succ_lax/2`, and `succ_iso/2`
- wire `succ/2` into Python's ISO-error rewrite tables for default ISO/lax modes
- extend generated-project E2E coverage for successor success, lax failure, and structured ISO errors
- update Python parity and cross-target ISO-error status docs

## Verification

- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_python_target.pl`

## Notes

The focused Python target suite passes. Existing choicepoint warnings remain in unrelated tests and were present during this run.
