### PR TITLE
Feat/wam go atom case builtins

### DIFF
--- a/PR_go_wam_atom_case_builtins.md
+++ b/PR_go_wam_atom_case_builtins.md
@@ -1,0 +1,24 @@
+# PR Title
+
+Add Go WAM atom case builtin parity
+
+# PR Description
+
+## Summary
+
+- Add direct Go WAM lowering for `upcase_atom/2` and `downcase_atom/2`.
+- Implement deterministic runtime execution for atom case conversion.
+- Cover converted-output binding, bound-output success, mismatch failure, unbound-source failure, and non-atom source failure in the generated Go WAM builtin E2E test.
+- Update the Go WAM parity audit to record the atom-case conversion surface alongside `atom_number/2`.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(upcase_atom/2,2), U), wam_go_target:wam_instruction_to_go_literal(call(downcase_atom/2,2), D), writeln(U), writeln(D), halt"`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -14,7 +14,7 @@ current cross-target builtin/runtime baseline.
 | Structural builtins | `member/2`, `memberchk/2`, `select/3`, `delete/3`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `select/3`, `delete/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Arithmetic builtins | `is/2`, `succ/2` | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir | Present for current baseline arithmetic checks, with expanded successor coverage |
-| Atom/number conversion | `atom_number/2` | Clojure direct builtin surface includes bidirectional `atom_number/2` | Present for current atom-number conversion checks |
+| Atom/text conversion | `atom_number/2`, `upcase_atom/2`, `downcase_atom/2` | Clojure direct builtin surface includes bidirectional `atom_number/2` and atom case conversion | Present for current atom-number and atom-case checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` | Includes `=</2`; Haskell mode analysis and Clojure lowering also cover term-order comparisons | Present for current baseline comparisons, with expanded term-order coverage |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
 | Term inspection | `functor/3`, `arg/3` | `functor/3`, `arg/3` | Present |
@@ -72,6 +72,10 @@ current cross-target builtin/runtime baseline.
   E2E test for atom-to-integer, integer-to-atom, atom-to-float, float-to-atom,
   numeric first-argument compatibility, bad atom failure, and both-unbound
   failure, matching the Clojure atom-number surface.
+- Deterministic `upcase_atom/2` and `downcase_atom/2` are now covered by the
+  generated Go WAM builtin E2E test for converted output binding, bound-output
+  success, mismatch failure, unbound-source failure, and non-atom source
+  failure, matching the Clojure atom-case surface.
 - Go WAM choice points now have explicit generated-runtime coverage for normal
   clause retries, indexed alternatives, foreign stream retries, indexed atom
   fact streams, and `member/2` builtin retries.

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -466,6 +466,12 @@ wam_go_direct_builtin("succ/2", 2, 'succ/2').
 wam_go_direct_builtin(atom_number/2, 2, 'atom_number/2').
 wam_go_direct_builtin('atom_number/2', 2, 'atom_number/2').
 wam_go_direct_builtin("atom_number/2", 2, 'atom_number/2').
+wam_go_direct_builtin(upcase_atom/2, 2, 'upcase_atom/2').
+wam_go_direct_builtin('upcase_atom/2', 2, 'upcase_atom/2').
+wam_go_direct_builtin("upcase_atom/2", 2, 'upcase_atom/2').
+wam_go_direct_builtin(downcase_atom/2, 2, 'downcase_atom/2').
+wam_go_direct_builtin('downcase_atom/2', 2, 'downcase_atom/2').
+wam_go_direct_builtin("downcase_atom/2", 2, 'downcase_atom/2').
 
 wam_instruction_to_go_literal(get_constant(C, Ai), GoLiteral) :-
     go_value_literal(C, GoVal),

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1153,6 +1153,18 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			return vm.Unify(arg1, internAtom(quotedNumericAtomPrefix+text))
 		}
 		return false
+	case "upcase_atom/2":
+		atom, ok := vm.deref(arg1).(*Atom)
+		if !ok {
+			return false
+		}
+		return vm.Unify(arg2, internAtom(strings.ToUpper(atom.Name)))
+	case "downcase_atom/2":
+		atom, ok := vm.deref(arg1).(*Atom)
+		if !ok {
+			return false
+		}
+		return vm.Unify(arg2, internAtom(strings.ToLower(atom.Name)))
 
 	case "var/1": return isUnbound(vm.deref(arg1))
 	case "nonvar/1": return !isUnbound(vm.deref(arg1))

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -19,6 +19,7 @@
 :- dynamic user:test_term_order_builtin/0.
 :- dynamic user:test_succ_builtin/0.
 :- dynamic user:test_atom_number_builtin/0.
+:- dynamic user:test_atom_case_builtin/0.
 :- dynamic user:test_set_aggregate/0.
 :- dynamic user:test_unify_builtin/0.
 :- dynamic user:test_neg_fact/1.
@@ -175,6 +176,18 @@ test(builtins_execution) :-
                 \+ atom_number(foo, _),
                 \+ atom_number(_, _)
             )),
+          assertz(user:test_atom_case_builtin :-
+            (   upcase_atom(hello, U),
+                U == 'HELLO',
+                upcase_atom(hello, 'HELLO'),
+                \+ upcase_atom(hello, hello),
+                downcase_atom('HELLO', D),
+                D == hello,
+                downcase_atom('HELLO', hello),
+                \+ downcase_atom('HELLO', 'HELLO'),
+                \+ upcase_atom(_, _),
+                \+ upcase_atom(42, _)
+            )),
           assertz(user:test_set_aggregate :-
             (   aggregate_all(set(X), member(X, [a,b,a]), S),
                 length(S, 2),
@@ -210,6 +223,7 @@ test(builtins_execution) :-
           retractall(user:test_term_order_builtin),
           retractall(user:test_succ_builtin),
           retractall(user:test_atom_number_builtin),
+          retractall(user:test_atom_case_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
           retractall(user:test_neg_fact(_)),
@@ -219,7 +233,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -268,6 +282,8 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "compare/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "succ/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "atom_number/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "upcase_atom/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "downcase_atom/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "\\\\+/1"')),
     assertion(sub_string(LibCode, _, _, _, 'AggType: "set"')),
 
@@ -401,6 +417,14 @@ func main() {
 		fmt.Println("ATOM_NUMBER_FAILURE")
 	}
 
+	atomCaseVM := wam.NewWamState(wam.Test_atom_case_builtinCode, wam.Test_atom_case_builtinLabels)
+	atomCaseVM.PC = wam.Test_atom_case_builtinStartPC
+	if atomCaseVM.Run() {
+		fmt.Println("ATOM_CASE_SUCCESS")
+	} else {
+		fmt.Println("ATOM_CASE_FAILURE")
+	}
+
 	setVM := wam.NewWamState(wam.Test_set_aggregateCode, wam.Test_set_aggregateLabels)
 	setVM.PC = wam.Test_set_aggregateStartPC
 	if setVM.Run() {
@@ -464,6 +488,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "TERM_ORDER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SUCC_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_NUMBER_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "ATOM_CASE_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NEG_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM atom case builtin parity

## Summary

- Add direct Go WAM lowering for `upcase_atom/2` and `downcase_atom/2`.
- Implement deterministic runtime execution for atom case conversion.
- Cover converted-output binding, bound-output success, mismatch failure, unbound-source failure, and non-atom source failure in the generated Go WAM builtin E2E test.
- Update the Go WAM parity audit to record the atom-case conversion surface alongside `atom_number/2`.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(upcase_atom/2,2), U), wam_go_target:wam_instruction_to_go_literal(call(downcase_atom/2,2), D), writeln(U), writeln(D), halt"`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`
