### PR TITLE
bench(csharp-query): threshold actionable policy diffs

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -170,7 +170,9 @@ Use `policy-compare-tsv` or `policy-compare-markdown` to compare the current
 effective-distance source policy against the measured best artifact-backed
 mode. Use `policy-actionable-tsv` or `policy-actionable-markdown` to suppress
 matching rows and show only policy differences or missing policy modes, with
-the policy-selected value and policy-vs-best ratio included for triage:
+the policy-selected value and policy-vs-best ratio included for triage. Add
+`--policy-action-threshold` to ignore small measured diffs while still always
+showing missing policy modes:
 
 ```bash
 python examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py \
@@ -179,6 +181,7 @@ python examples/benchmark/benchmark_csharp_query_effective_distance_artifact_bac
   --lookup-repetitions 1 \
   --repetitions 1 \
   --summary-output output/csharp-query-effective-distance-summary.tsv \
+  --policy-action-threshold 1.10 \
   --format policy-actionable-markdown
 ```
 

--- a/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
+++ b/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
@@ -748,8 +748,25 @@ def policy_compare_rows_from_summaries(rows: list[SummaryRow]) -> list[PolicyCom
     return compare_rows
 
 
-def policy_actionable_rows(rows: list[PolicyCompareRow]) -> list[PolicyCompareRow]:
-    return [row for row in rows if row.values["status"] != "match"]
+def parse_policy_vs_best_ratio(value: str) -> float | None:
+    if not value:
+        return None
+    return float(value[:-1] if value.endswith("x") else value)
+
+
+def policy_actionable_rows(rows: list[PolicyCompareRow], threshold: float = 1.0) -> list[PolicyCompareRow]:
+    actionable: list[PolicyCompareRow] = []
+    for row in rows:
+        status = row.values["status"]
+        if status == "match":
+            continue
+        if status == "missing-policy-mode":
+            actionable.append(row)
+            continue
+        ratio = parse_policy_vs_best_ratio(row.values["policy_vs_best"])
+        if ratio is None or ratio >= threshold:
+            actionable.append(row)
+    return actionable
 
 
 def render_summary_tsv(rows: list[SummaryRow]) -> str:
@@ -838,15 +855,15 @@ def render_policy_compare_markdown(rows: list[PolicyCompareRow]) -> str:
     return "\n".join(lines)
 
 
-def render_policy_actionable_tsv(rows: list[PolicyCompareRow]) -> str:
-    return render_policy_compare_tsv(policy_actionable_rows(rows))
+def render_policy_actionable_tsv(rows: list[PolicyCompareRow], threshold: float = 1.0) -> str:
+    return render_policy_compare_tsv(policy_actionable_rows(rows, threshold=threshold))
 
 
-def render_policy_actionable_markdown(rows: list[PolicyCompareRow]) -> str:
-    return render_policy_compare_markdown(policy_actionable_rows(rows))
+def render_policy_actionable_markdown(rows: list[PolicyCompareRow], threshold: float = 1.0) -> str:
+    return render_policy_compare_markdown(policy_actionable_rows(rows, threshold=threshold))
 
 
-def render_summary_based_format(format_name: str, summaries: list[SummaryRow]) -> str:
+def render_summary_based_format(format_name: str, summaries: list[SummaryRow], policy_action_threshold: float = 1.0) -> str:
     if format_name == "summary-tsv":
         return render_summary_tsv(summaries)
     if format_name == "summary-full-markdown":
@@ -862,9 +879,15 @@ def render_summary_based_format(format_name: str, summaries: list[SummaryRow]) -
     if format_name == "policy-compare-markdown":
         return render_policy_compare_markdown(policy_compare_rows_from_summaries(summaries))
     if format_name == "policy-actionable-tsv":
-        return render_policy_actionable_tsv(policy_compare_rows_from_summaries(summaries))
+        return render_policy_actionable_tsv(
+            policy_compare_rows_from_summaries(summaries),
+            threshold=policy_action_threshold,
+        )
     if format_name == "policy-actionable-markdown":
-        return render_policy_actionable_markdown(policy_compare_rows_from_summaries(summaries))
+        return render_policy_actionable_markdown(
+            policy_compare_rows_from_summaries(summaries),
+            threshold=policy_action_threshold,
+        )
     raise ValueError(f"{format_name} is not a summary-based format")
 
 
@@ -982,6 +1005,15 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="write the computed summary-tsv artifact while still printing the requested report",
     )
+    parser.add_argument(
+        "--policy-action-threshold",
+        type=float,
+        default=1.0,
+        help=(
+            "minimum policy-vs-best ratio included by policy-actionable formats; "
+            "missing policy modes are always included"
+        ),
+    )
     parser.add_argument("--keep-temp", action="store_true", help="keep the generated C# benchmark project")
     args = parser.parse_args(argv)
 
@@ -995,6 +1027,8 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--min-free-memory-mib must be positive")
     if args.max_competing_cpu_percent < 0:
         parser.error("--max-competing-cpu-percent must be non-negative")
+    if args.policy_action_threshold < 1.0:
+        parser.error("--policy-action-threshold must be at least 1.0")
 
     if args.summary_input is not None:
         if args.summary_output is not None:
@@ -1007,7 +1041,13 @@ def main(argv: list[str] | None = None) -> int:
             parser.error(str(error))
         except ValueError as error:
             parser.error(str(error))
-        print(render_summary_based_format(args.format, summaries))
+        print(
+            render_summary_based_format(
+                args.format,
+                summaries,
+                policy_action_threshold=args.policy_action_threshold,
+            )
+        )
         return 0
 
     scales = [scale.strip() for scale in args.scales.split(",") if scale.strip()]
@@ -1089,7 +1129,13 @@ def main(argv: list[str] | None = None) -> int:
         summaries = []
 
     if args.format in SUMMARY_INPUT_FORMATS:
-        print(render_summary_based_format(args.format, summaries))
+        print(
+            render_summary_based_format(
+                args.format,
+                summaries,
+                policy_action_threshold=args.policy_action_threshold,
+            )
+        )
     elif args.format == "markdown":
         print(render_markdown(rows))
     else:

--- a/tests/test_csharp_query_effective_distance_artifact_backends.py
+++ b/tests/test_csharp_query_effective_distance_artifact_backends.py
@@ -128,11 +128,30 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
                 stderr=subprocess.PIPE,
                 timeout=60,
             )
+            thresholded = subprocess.run(
+                [
+                    "python3",
+                    str(SCRIPT),
+                    "--summary-input",
+                    str(path),
+                    "--format",
+                    "policy-actionable-markdown",
+                    "--policy-action-threshold",
+                    "1.20",
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=60,
+            )
 
         self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
         self.assertIn("| Policy mode | Policy artifact value | Policy vs best |", result.stdout)
         self.assertIn("| bucket_c0 | ms | delimited-artifact | 400.000 | 1.143x | mmap-array | 350.000 | diff |", result.stdout)
         self.assertNotIn("| lookup_c0 | ms | lmdb | 3.251 | 1.000x | lmdb | 3.251 | match |", result.stdout)
+        self.assertEqual(thresholded.returncode, 0, msg=f"stdout:\n{thresholded.stdout}\nstderr:\n{thresholded.stderr}")
+        self.assertNotIn("| bucket_c0 | ms | delimited-artifact | 400.000 | 1.143x | mmap-array | 350.000 | diff |", thresholded.stdout)
 
     def test_summary_input_rejects_raw_formats(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -156,6 +175,24 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("--summary-input requires a summary-* or policy-* --format", result.stderr)
+
+    def test_policy_action_threshold_must_be_at_least_one(self) -> None:
+        result = subprocess.run(
+            [
+                "python3",
+                str(SCRIPT),
+                "--policy-action-threshold",
+                "0.99",
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=60,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--policy-action-threshold must be at least 1.0", result.stderr)
 
     def test_summary_input_rejects_summary_output(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -629,7 +666,7 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
         self.assertEqual(by_shape["lookup_c0"]["policy_vs_best"], "")
         self.assertEqual(by_shape["lookup_c0"]["status"], "missing-policy-mode")
 
-    def test_policy_actionable_rows_filter_matches(self) -> None:
+    def test_policy_actionable_rows_filter_matches_and_small_diffs(self) -> None:
         rows = [
             MODULE.PolicyCompareRow(
                 {
@@ -659,6 +696,24 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
                     "access_shape": "bucket_c0",
                     "metric": "ms",
                     "policy_mode": "mmap-array",
+                    "policy_artifact_value": "1.300",
+                    "policy_vs_best": "1.040x",
+                    "best_artifact_mode": "lmdb",
+                    "best_artifact_value": "1.250",
+                    "status": "diff",
+                    "values_by_mode": "lmdb:1.250|mmap-array:1.300",
+                }
+            ),
+            MODULE.PolicyCompareRow(
+                {
+                    "scale": "dev",
+                    "relation": "category_parent",
+                    "rows": "6",
+                    "distinct_categories": "4",
+                    "lookup_keys": "2",
+                    "access_shape": "bucket_c1",
+                    "metric": "ms",
+                    "policy_mode": "mmap-array",
                     "policy_artifact_value": "2.000",
                     "policy_vs_best": "1.600x",
                     "best_artifact_mode": "lmdb",
@@ -667,12 +722,33 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
                     "values_by_mode": "lmdb:1.250|mmap-array:2.000",
                 }
             ),
+            MODULE.PolicyCompareRow(
+                {
+                    "scale": "dev",
+                    "relation": "category_parent",
+                    "rows": "6",
+                    "distinct_categories": "4",
+                    "lookup_keys": "2",
+                    "access_shape": "scan",
+                    "metric": "ms",
+                    "policy_mode": "mmap-array",
+                    "policy_artifact_value": "",
+                    "policy_vs_best": "",
+                    "best_artifact_mode": "lmdb",
+                    "best_artifact_value": "1.250",
+                    "status": "missing-policy-mode",
+                    "values_by_mode": "lmdb:1.250",
+                }
+            ),
         ]
 
-        actionable = MODULE.policy_actionable_rows(rows)
-        self.assertEqual([row.values["access_shape"] for row in actionable], ["bucket_c0"])
+        actionable = MODULE.policy_actionable_rows(rows, threshold=1.10)
+        self.assertEqual([row.values["access_shape"] for row in actionable], ["bucket_c1", "scan"])
         self.assertNotIn("lookup_c0", MODULE.render_policy_actionable_tsv(rows))
-        self.assertIn("bucket_c0", MODULE.render_policy_actionable_markdown(rows))
+        thresholded = MODULE.render_policy_actionable_markdown(rows, threshold=1.10)
+        self.assertNotIn("bucket_c0", thresholded)
+        self.assertIn("bucket_c1", thresholded)
+        self.assertIn("scan", thresholded)
 
     def test_artifact_root_reuses_existing_manifests(self) -> None:
         if shutil.which("dotnet") is None:


### PR DESCRIPTION
  ## Summary

  - Adds `--policy-action-threshold` for `policy-actionable-*` reports.
  - Filters measured `diff` rows below the configured policy-vs-best ratio.
  - Keeps `missing-policy-mode` rows visible regardless of threshold.
  - Documents thresholded actionable reports in the benchmark README.
  - Covers threshold validation, summary-input thresholding, small-diff suppression, and missing-policy-mode retention in
  tests.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py tests/test_csharp_query_lmdb_provider_smoke.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime_lmdb/UnifyWeaver.QueryRuntime.Lmdb.csproj`
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
  - `git diff --check`