### PR TITLE
fix(simplewiki-ingest): use cl_target_id at col 6, not cl_timestamp at col 2 (R5)

### DIFF
--- a/docs/handoff/wam_rust_simplewiki_blocker.md
+++ b/docs/handoff/wam_rust_simplewiki_blocker.md
@@ -1,0 +1,168 @@
+# R5 simplewiki handoff: ingest column-mapping blocker (RESOLVED)
+
+**Status**: R5 complete. The ingest column-mapping fix landed (`UW_VAL_COL = 2 → 6`), simplewiki LMDB re-ingested with real `cl_target_id` edges, post-ingest selected a 14,680-node root subtree, and the Rust LMDB-mode matrix bench produced deterministic results across 5 trials.
+
+## TL;DR — the fix that was applied
+
+In `examples/streaming/simplewiki_category_ingest_text.pl`, changed:
+
+```prolog
+'UW_VAL_COL'        = 2,    % WRONG — col 2 is cl_timestamp
+```
+
+to:
+
+```prolog
+'UW_VAL_COL'        = 6,    % cl_target_id (newer MediaWiki schema replaces cl_to varchar)
+```
+
+Confirmed against the CREATE TABLE in the dump: col 0 = `cl_from`, col 4 = `cl_type`, col 6 = `cl_target_id` (bigint, the linktarget reference). Older docs/comments saying "cl_to (column 2)" reflected a pre-linktarget MediaWiki schema.
+
+## R5 results (5 trials, median, simplewiki, Rust LMDB cursor, lmdb_zero, -N1)
+
+| Metric | Median |
+| --- | ---: |
+| `load_ms` (open LMDB + i2s load + reach-root cursor BFS) | 43 |
+| `query_ms` (134,692 seed iterations through the kernel) | 370 |
+| `aggregation_ms` | 29 |
+| `total_ms` | 462 |
+| `seed_count` | 134,692 |
+| `demand_set_size` | 14,680 (root_id=2 subtree) |
+| `tuple_count` | 126 (paths within max_depth=10) |
+| peak RSS | ~80 MB |
+| wall | ~0.48 s |
+
+`tuple_count` is deterministic across all 5 trials — correctness signal.
+
+### Comparison to Haskell Phase L#7
+
+Haskell `resident_cursor` at simplewiki: 226 ms -N1 / 207 ms -N2 / 234 ms -N4 (root id 265340 with 14,661 descendants, **5,000 seeds**).
+
+Rust ran the same per-seed workload but across **134,692 seeds** (the full demand-graph seed set) — 27× more seeds. At ~3.4 µs/seed, the Rust cursor path is competitive on a per-seed basis; total time is higher because the seed denominator differs. For a true head-to-head comparison, both runs would need to use the same seed cardinality.
+
+## What's staged but uncommitted on this branch
+
+`feat/wam-rust-bench-simplewiki` is **zero commits ahead of main**. These two files are staged:
+
+```
+A  docs/handoff/wam_rust_simplewiki_blocker.md         (this file)
+A  examples/benchmark/simplewiki_post_ingest.py
+```
+
+Plus the untracked LMDB fixture at `data/benchmark/simplewiki_cats/` (gitignored, but the LMDB content is currently the BROKEN version with timestamps as edges — should be re-ingested after applying the fix).
+
+## How I confirmed the column mapping
+
+Inspecting the actual mysql_stream output for subcat rows with the same `cl_from=4985`:
+
+```
+col0: 4985                                                          ← cl_from
+col1: .FBHRP2L\x04N.:2D.2\x01\x14\x01\xdc\x13                       ← cl_sortkey (binary)
+col2: 2025-02-17 19:20:03                                           ← cl_timestamp
+col3:                                                               ← cl_sortkey_prefix
+col4: subcat                                                        ← cl_type
+col5: 1                                                             ← cl_collation
+col6: 664772 / 1886545 / 2377498  (varies per row)                  ← cl_to (linktarget_id)
+```
+
+Three subcat rows with `cl_from=4985` had three different col-6 values — that's the shape of an outgoing edge list, which is what `cl_to` should look like. Column 6 it is.
+
+## What the post-ingest script (`examples/benchmark/simplewiki_post_ingest.py`) does
+
+Already saved and ready to use. After running the (fixed) ingest pipeline:
+
+1. Walks `category_parent` (DUPSORT), writes reversed edges into a new `category_child` DUPSORT sub-db on the same LMDB env (idempotent — safe to rerun)
+2. Scans all true-roots (nodes with no parents) for the largest reachable subtree at `max_depth=10`
+3. Emits `seed_ids.txt`, `root_ids.txt`, `root_categories.tsv`, `article_category.tsv` (using `i2s`-decoded names from the same env to avoid the readonly-cursor quirk), `metadata.json`
+
+The article_category fix: reads i2s from the same RW env in one session — Python lmdb's `open_db` on a readonly env over a never-opened-named-subdb fails with EINVAL.
+
+## Recovery procedure for next session
+
+```bash
+# 0. confirm we're on the right branch (or recreate it)
+git checkout feat/wam-rust-bench-simplewiki 2>/dev/null || git checkout -b feat/wam-rust-bench-simplewiki
+
+# 1. apply the column fix to the ingest declaration
+#    (edit examples/streaming/simplewiki_category_ingest_text.pl
+#     change UW_VAL_COL = 2 to UW_VAL_COL = 6)
+
+# 2. wipe and re-ingest the simplewiki LMDB
+rm -rf data/benchmark/simplewiki_cats/lmdb_resident
+mkdir -p data/benchmark/simplewiki_cats/lmdb_resident
+swipl -q -g "process_dump('context/gemini/UnifyWeaver/data/simplewiki/simplewiki-latest-categorylinks.sql.gz', 'data/benchmark/simplewiki_cats/lmdb_resident')." \
+    -t halt examples/streaming/simplewiki_category_ingest_text.pl
+
+# 3. run post-ingest (adds category_child + picks root + emits fixture files)
+python3 examples/benchmark/simplewiki_post_ingest.py
+
+# 4. sanity check: best_root_subtree_size should be much larger than 1222
+#    (with correct edges we expect a deep hierarchy — Phase L#7 Haskell
+#    had a root with 14,661 descendants)
+cat data/benchmark/simplewiki_cats/metadata.json
+
+# 5. regen the Rust LMDB-mode bench (R4's wiring is already on main)
+rm -rf /tmp/uw_swiki_bench
+swipl -q -s examples/benchmark/generate_wam_rust_matrix_benchmark.pl -- \
+    data/benchmark/1k/facts.pl /tmp/uw_swiki_bench accumulated interpreter kernels_on cursor lmdb_zero
+(cd /tmp/uw_swiki_bench && cargo build --release)
+
+# 6. run the 5-trial sweep
+BIN=/tmp/uw_swiki_bench/target/release/wam_rust_matrix_bench
+FIXTURE=$PWD/data/benchmark/simplewiki_cats
+for T in 1 2 3 4 5; do
+    /usr/bin/time -f "wall=%es rss=%MkB" "$BIN" "$FIXTURE" 2>&1 \
+        | grep -E "(load_ms|query_ms|total_ms|seed_count|demand_set_size|tuple_count|wall|rss)" \
+        | tr '\n' ' '; echo
+done
+
+# 7. compare to Haskell Phase L#7 numbers in WAM_PERF_OPTIMIZATION_LOG.md:
+#    resident_cursor at simplewiki: 226 ms -N1 / 207 ms -N2 / 234 ms -N4
+#    (Haskell used root id 265340 with 14,661 descendants, 5000 seeds)
+#    With corrected ingest, our Rust numbers should be in the same regime.
+
+# 8. commit + open PR with R5 results
+```
+
+## Caveat that survives the fix
+
+`cl_to` in the newer schema is a `linktarget_id`, not a category name. The graph topology will be correct (real subcat edges connecting categories), but the node STRINGS in s2i/i2s will be `cl_from` page_id-strings (children) and `cl_to` linktarget_id-strings (parents) — different namespaces.
+
+For PERF measurement this is fine (wall-clock, demand_set_size, kernel throughput are all valid). For human-readable output (knowing the root is "Physics"), we'd need a second-pass ingest of `simplewiki-latest-linktarget.sql.gz` to map linktarget_id → category title. That's a separate enhancement — file as R5.5 if/when needed.
+
+## Negative-baseline bench numbers (with broken topology)
+
+For the record, the BROKEN simplewiki LMDB (page_id→timestamp edges) gave us these numbers — useful as a "kernel-fail throughput" reference:
+
+| Metric | Median (5 trials) |
+| --- | ---: |
+| `load_ms` | 20 |
+| `query_ms` | 322 |
+| `aggregation_ms` | 24 |
+| `total_ms` | 380 |
+| `seed_count` | 118,697 |
+| `demand_set_size` | 1,222 |
+| `tuple_count` | 0 (kernel finds no paths) |
+| peak RSS | 64 MB |
+
+Single-threaded Rust, lmdb-zero crate, cursor BFS. The 322 ms query_ms is dominated by iterating 118k seeds where every kernel call fails fast (no edges → empty result). With the column fix, query_ms should *decrease* (fewer dead-end iterations) AND `tuple_count` should go up (real paths exist).
+
+## What's on main (unaffected by this blocker)
+
+R1–R4 of the Rust-LMDB arc are merged. Specifically:
+
+| PR | Commit | What |
+| --- | --- | --- |
+| #2258 | `21b65f31` + `181b72ab` | `LmdbFactSource` + configurable lmdb_crate (lmdb_zero default, heed opt-in) |
+| #2260 | `005f5dfc` | Cursor `reachable_to_root` BFS + LMDB codegen tests |
+| #2278 | `aa126442` | Matrix bench main.rs wired to LmdbFactSource (R4) |
+
+These run end-to-end at 1k_cats with `total_ms=12`, `tuple_count=48` — proving the infrastructure works. R5's job was to validate at 297k-edge scale, which is what this blocker is about.
+
+## Reference points
+
+- Haskell Phase L#7 (simplewiki resident_cursor): `docs/design/WAM_PERF_OPTIMIZATION_LOG.md`
+- Haskell Phase L#8/9 (enwiki — also needs the same ingest fix when we get to R6): same doc
+- ingest pipeline source: `examples/streaming/simplewiki_category_ingest_text.pl`
+- mysql_stream binary: `src/unifyweaver/runtime/rust/mysql_stream/target/release/mysql_stream`
+- SQL dumps: `context/gemini/UnifyWeaver/data/simplewiki/` (gitignored)

--- a/examples/benchmark/simplewiki_post_ingest.py
+++ b/examples/benchmark/simplewiki_post_ingest.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Post-process the text-keyed simplewiki LMDB:
+- add category_child reverse-edge DUPSORT sub-db
+- pick root by graph topology: node with the largest reachable subtree
+  (since simplewiki's newer schema makes 'Physics' un-resolvable without
+   joining page+linktarget tables — see ingest notes)
+- emit seed_ids.txt (all category int IDs that appear as children)
+- emit root_ids.txt
+- emit synthetic article_category.tsv (category -> category)
+- emit metadata.json
+"""
+import collections
+import json
+import struct
+import sys
+import time
+from pathlib import Path
+
+import lmdb
+
+FIXTURE = Path("data/benchmark/simplewiki_cats")
+LMDB_DIR = FIXTURE / "lmdb_resident"
+
+t0 = time.time()
+env = lmdb.open(
+    str(LMDB_DIR),
+    max_dbs=16,
+    map_size=2 * 1024 * 1024 * 1024,
+    subdir=True,
+    readonly=False,
+)
+cp_db = env.open_db(b"category_parent", dupsort=True)
+cc_db = env.open_db(b"category_child", dupsort=True, create=True)
+
+# pass 1: walk category_parent, write reversed edges to category_child,
+# build adjacency in memory for root selection
+cp_count = 0
+children_of = collections.defaultdict(list)
+parents_of = collections.defaultdict(list)
+with env.begin(write=True) as txn:
+    cur = txn.cursor(db=cp_db)
+    for k, v in cur:
+        txn.put(v, k, db=cc_db, dupdata=True, overwrite=True)
+        cp_count += 1
+        child_id = struct.unpack("<i", k)[0]
+        parent_id = struct.unpack("<i", v)[0]
+        children_of[parent_id].append(child_id)
+        parents_of[child_id].append(parent_id)
+        if cp_count % 100_000 == 0:
+            sys.stderr.write(f"  ...{cp_count} reverse-edges written\n")
+
+env.sync()
+
+# pass 2: pick root by largest descendant subtree
+# Candidates: nodes with no parents (true roots) — typically a handful
+candidate_roots = sorted(set(children_of.keys()) - set(parents_of.keys()))
+sys.stderr.write(
+    f"category_parent edges = {cp_count}, "
+    f"unique children = {len(parents_of)}, "
+    f"unique parents = {len(children_of)}, "
+    f"true roots (no parents) = {len(candidate_roots)}\n"
+)
+
+
+def bfs_size(start, adj, max_depth=10):
+    visited = {start}
+    queue = collections.deque([(start, 0)])
+    while queue:
+        node, depth = queue.popleft()
+        if depth >= max_depth:
+            continue
+        for child in adj.get(node, []):
+            if child not in visited:
+                visited.add(child)
+                queue.append((child, depth + 1))
+    return len(visited)
+
+
+# Scan ALL true roots to find the largest subtree. With 27k candidates
+# this is still <1s in practice (most roots have tiny subtrees).
+best_root = None
+best_size = 0
+scanned = 0
+top5 = []
+for r in candidate_roots:
+    s = bfs_size(r, children_of, max_depth=10)
+    if s > best_size:
+        best_size = s
+        best_root = r
+    top5.append((s, r))
+    scanned += 1
+    if scanned % 5000 == 0:
+        sys.stderr.write(f"  ...scanned {scanned}/{len(candidate_roots)} roots\n")
+top5.sort(reverse=True)
+sys.stderr.write(
+    f"best root: id={best_root} subtree_size={best_size}  "
+    f"(top 5: {[(s, r) for s, r in top5[:5]]})\n"
+)
+env.close()
+
+# pass 3: emit fixture files
+seed_ids_path = FIXTURE / "seed_ids.txt"
+with open(seed_ids_path, "w") as f:
+    for sid in sorted(parents_of.keys()):
+        f.write(f"{sid}\n")
+
+with open(FIXTURE / "root_ids.txt", "w") as f:
+    f.write(f"{best_root}\n")
+
+# Synthetic article_category.tsv using the real i2s-decoded names
+# (original page_id strings like "1000114").  Critical: these must
+# match the strings the Rust LMDB-mode bench inserts into
+# runtime_category_parents via lmdb.load_i2s(); otherwise tuple_count
+# will be 0 (kernel can't match "node_<id>" seeds against "<page_id>"
+# edges).  Read i2s from the SAME env we already have open above.
+all_nodes = sorted(set(parents_of.keys()) | set(children_of.keys()))
+env_rw = lmdb.open(str(LMDB_DIR), max_dbs=16, map_size=2 * 1024 * 1024 * 1024, subdir=True, readonly=False)
+i2s_db_rw = env_rw.open_db(b"i2s")
+nid_to_str = {}
+with env_rw.begin() as txn:
+    cur = txn.cursor(db=i2s_db_rw)
+    for k, v in cur:
+        nid_to_str[struct.unpack("<i", k)[0]] = v.decode("utf-8", "replace")
+env_rw.close()
+with open(FIXTURE / "article_category.tsv", "w") as f:
+    f.write("article\tcategory\n")
+    for nid in all_nodes:
+        name = nid_to_str.get(nid, f"unknown_{nid}")
+        f.write(f"{name}\t{name}\n")
+sys.stderr.write(f"article_category.tsv: {len(all_nodes)} rows, sample name = '{nid_to_str.get(all_nodes[0], '?')}'\n")
+
+# root_categories.tsv: emit one synthetic name matching best_root
+with open(FIXTURE / "root_categories.tsv", "w") as f:
+    f.write("root_category\n")
+    f.write(f"node_{best_root}\n")
+
+# metadata.json
+with open(FIXTURE / "metadata.json", "w") as f:
+    json.dump(
+        {
+            "name": "simplewiki_cats",
+            "source": "simplewiki-latest-categorylinks.sql.gz",
+            "schema_note": "newer MediaWiki schema (cl_to via linktarget); "
+                            "nodes are page_id / linktarget_id, not category names. "
+                            "Graph topology is valid for perf measurement.",
+            "subcat_edges": cp_count,
+            "unique_children": len(parents_of),
+            "unique_parents": len(children_of),
+            "true_roots": len(candidate_roots),
+            "best_root_id": best_root,
+            "best_root_subtree_size": best_size,
+            "article_category_tsv": "synthetic (node_<id> -> node_<id>)",
+            "post_ingest_seconds": round(time.time() - t0, 2),
+        },
+        f,
+        indent=2,
+    )
+
+sys.stderr.write(f"post-ingest done in {time.time() - t0:.2f}s\n")

--- a/examples/streaming/simplewiki_category_ingest_text.pl
+++ b/examples/streaming/simplewiki_category_ingest_text.pl
@@ -72,8 +72,10 @@ process_dump(DumpPath, LmdbPath, Options) :-
     make_directory_if_missing(LmdbPath),
     % cl_from is column 0 (numeric in MediaWiki, but we read its TSV
     % representation as a string and intern it — see SPECIFICATION §7.1
-    % regime "Text-keyed").  cl_to (column 2) is the parent category
-    % name as a string.  cl_type (column 4) filters to subcat rows.
+    % regime "Text-keyed").  cl_target_id (column 6) is the parent
+    % category reference (newer MediaWiki schema replaces the legacy
+    % cl_to varchar at column 2 with a linktarget id).  cl_type
+    % (column 4) filters to subcat rows.
     BaseEnv = [
         'UW_LMDB_PATH'      = LmdbPath,
         'UW_LMDB_DBNAME'    = 'category_parent',
@@ -81,7 +83,7 @@ process_dump(DumpPath, LmdbPath, Options) :-
         'UW_FILTER_COL'     = 4,
         'UW_FILTER_VAL'     = subcat,
         'UW_KEY_COL'        = 0,
-        'UW_VAL_COL'        = 2,
+        'UW_VAL_COL'        = 6,
         'UW_INTERN_KEY'     = 1,
         'UW_INTERN_VAL'     = 1,
         'UW_LMDB_S2I_DB'    = s2i,


### PR DESCRIPTION
### Summary

- **Bug**: `examples/streaming/simplewiki_category_ingest_text.pl` was reading column 2 of the `mysql_stream` output as the parent reference, but in the newer MediaWiki schema column 2 is `cl_timestamp` and the real parent reference (`cl_target_id`) is at column 6. As a result the LMDB at `data/benchmark/simplewiki_cats/lmdb_resident/` contained `(page_id, timestamp)` pairs as edges and the WAM-Rust LMDB-mode bench reported `tuple_count=0` (the kernel could never find a path).
- **Fix**: change `UW_VAL_COL = 2` to `UW_VAL_COL = 6` in the ingest declaration. Confirmed against the dump's CREATE TABLE.
- **Result**: R5 (Rust-LMDB simplewiki bench) is unblocked. Cursor BFS picks a 14,680-node root subtree and the bench produces deterministic real results across 5 trials.

### The schema check

```
$ zcat simplewiki-latest-categorylinks.sql.gz | head -200 | grep -A 10 CREATE
CREATE TABLE `categorylinks` (
  `cl_from` int(8) unsigned NOT NULL DEFAULT 0,
  `cl_sortkey` varbinary(230) NOT NULL DEFAULT '',
  `cl_timestamp` timestamp NOT NULL DEFAULT current_timestamp() ...,
  `cl_sortkey_prefix` varbinary(255) NOT NULL DEFAULT '',
  `cl_type` enum('page','subcat','file') NOT NULL DEFAULT 'page',
  `cl_collation_id` smallint(5) unsigned NOT NULL DEFAULT 0,
  `cl_target_id` bigint(20) unsigned NOT NULL,
```

| col | field | type | role |
| --- | --- | --- | --- |
| 0 | `cl_from` | int | child page id |
| 1 | `cl_sortkey` | varbinary | sort blob |
| 2 | `cl_timestamp` | timestamp | _was wrongly used as parent_ |
| 3 | `cl_sortkey_prefix` | varbinary | — |
| 4 | `cl_type` | enum | filter (`subcat`) |
| 5 | `cl_collation_id` | smallint | — |
| 6 | `cl_target_id` | bigint | parent reference (linktarget id) — **correct UW_VAL_COL** |

The older MediaWiki schema kept the parent as a `cl_to` varchar; the newer dumps replace it with a `cl_target_id` bigint that points into the `linktarget` table. The ingest declaration was written for the old schema.

### R5 bench results (5 trials, median, Rust LMDB cursor, lmdb_zero, -N1)

| Metric | Median |
| --- | ---: |
| `load_ms` (LMDB open + i2s load + reach-root cursor BFS) | 43 |
| `query_ms` (134,692 seed iterations through the kernel) | 370 |
| `aggregation_ms` | 29 |
| **`total_ms`** | **462** |
| `seed_count` | 134,692 |
| `demand_set_size` | 14,680 (root_id=2 subtree) |
| `tuple_count` | 126 (deterministic across all 5 trials) |
| peak RSS | ~80 MB |
| wall | ~0.48 s |

For comparison, Haskell Phase L#7 at simplewiki `resident_cursor` measured 226 / 207 / 234 ms at -N1 / -N2 / -N4 — but Haskell ran 5,000 seeds while Rust ran 134,692 (27× more). Per-seed: Rust ≈ 3.4 µs, Haskell ≈ 45 µs. For a true head-to-head we'd run both with matching seed cardinality (deferred — outside this PR's scope).

### Files changed

| File | Change |
| --- | --- |
| `examples/streaming/simplewiki_category_ingest_text.pl` | `UW_VAL_COL = 2` → `UW_VAL_COL = 6` + comment update describing the linktarget schema change (5 lines diff) |
| `examples/benchmark/simplewiki_post_ingest.py` | New post-ingest tool. Walks `category_parent`, writes the reversed `category_child` DUPSORT sub-db, scans all true-roots for the largest reachable subtree at `max_depth=10`, emits `seed_ids.txt` / `root_ids.txt` / `root_categories.tsv` / `article_category.tsv` (using i2s-decoded names from the same RW env to dodge the readonly-cursor EINVAL) and `metadata.json`. |
| `docs/handoff/wam_rust_simplewiki_blocker.md` | Full record: the bug, the fix, the recovery procedure, the schema evidence, and the R5 results. |

### Caveat that survives the fix

`cl_target_id` is a linktarget id, not a category name string. Graph topology is correct (real subcat edges) but the node strings in `s2i`/`i2s` are `cl_from` page_id-strings (children) and `cl_target_id` linktarget_id-strings (parents) — different namespaces. For perf measurement that's fine; for human-readable output (knowing the root is "Physics"), we'd need a second-pass ingest of `simplewiki-latest-linktarget.sql.gz` to map `linktarget_id` → category title. Filed as a possible R5.5 follow-up; not blocking R6 (enwiki) or further perf work.

### Test plan

- [x] CREATE TABLE in `simplewiki-latest-categorylinks.sql.gz` shows `cl_target_id` at col 6
- [x] Re-ingest emits `interned=134692` (vs `118697` from the broken timestamp ingest — more unique parent IDs is the signature of real `cl_target_id` data)
- [x] Post-ingest reports `subcat_edges=297283`, `true_roots=43178`, `best_root_id=2`, `best_root_subtree_size=14680`
- [x] Generated Rust LMDB-mode matrix-bench project builds with `cargo build --release` in ~7 s
- [x] 5-trial sweep produces deterministic `tuple_count=126` (correctness signal — kernel finds the same paths every run)
- [x] `total_ms` stable around 462 ms across all 5 trials (range 455–494 ms)

### What follows

- **R6 (enwiki)**: same fix likely applies to `examples/streaming/enwiki_category_ingest.pl` — investigate before re-ingesting the 2.4 GB dump.
- **R5.5 (linktarget join)**: if human-readable category names are needed, add a second-pass ingest from `simplewiki-latest-linktarget.sql.gz` to populate a `linktarget_id` → title map.
- **R4.5**: DRY the matrix-bench `main.rs` templates (TSV mode and LMDB mode share ~400 lines of helpers in duplicated form right now — acknowledged tech debt from R4 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)