### PR TITLE
feat(wam): flip args_first_emission to default-on

### DIFF
--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -95,25 +95,32 @@ compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code) :-
     ->  b_setval(wam_inline_bagof_setof, true)
     ;   b_setval(wam_inline_bagof_setof, false)
     ),
-    % args_first_emission: opt-in flag that reorders nested-compound
-    % construction. By default, compile_set_arguments emits each
-    % nested compound INLINE — `set_variable Xn ; put_structure F/N,
-    % Xn ; <nested args>` — which interleaves nested struct bodies
-    % with the outer compound's arg slots. On a flat-heap runtime
-    % (Elixir's lowered model), this puts the outer's later arg slots
-    % AT addresses already occupied by the nested struct's tag,
-    % breaking the addr+1..addr+arity contiguity assumption.
+    % args_first_emission: emit set_variable for ALL outer-compound
+    % args BEFORE any nested put_structure. The legacy emit
+    % interleaved `set_variable Xn ; put_structure F/N, Xn ;
+    % <nested args>` — fine for runtimes that store compound args
+    % in a Value-internal vector (C++), wrong for flat-heap runtimes
+    % (Elixir, and likely Rust/Haskell when they hit the same case)
+    % because nested put_structure grows heap_len past the outer's
+    % later arg slots.
     %
-    % With this flag, all set_variable's for the outer's args are
-    % emitted FIRST (reserving contiguous heap slots), then all
-    % nested put_structures emit AFTER. Same instruction count, same
-    % per-instruction semantics — pure reordering. Opt-in so targets
-    % that don't rely on heap-contiguous args (e.g., C++ which stores
-    % args in a Value-internal vector) are unaffected. Elixir target
-    % opts in; Rust/Haskell can opt in if they hit the same issue.
-    (   option(args_first_emission(true), Options)
-    ->  b_setval(wam_args_first_emission, true)
-    ;   b_setval(wam_args_first_emission, false)
+    % New emit: same instruction count, same per-instruction semantics
+    % — pure reordering. Tested ON via the audit-against-baseline
+    % methodology in PR-2278 (test_wam_target, test_wam_c_target,
+    % test_wam_clojure_generator, test_wam_cpp_generator, test_wam_e2e,
+    % test_wam_go_generator, test_wam_haskell_target,
+    % test_wam_ilasm_target, test_wam_jvm_target, test_wam_lua_generator,
+    % test_wam_python_target, test_wam_r_generator, test_wam_rust_target,
+    % test_wam_cross_target_consistency, test_wam_dict,
+    % test_wam_fact_table, test_wam_rule_index): zero new failures
+    % attributable to the flip; pre-existing main-branch failures
+    % preserved.
+    %
+    % Now the DEFAULT. Opt out via args_first_emission(false) if you
+    % need byte-identical bytecode against a legacy snapshot.
+    (   option(args_first_emission(false), Options)
+    ->  b_setval(wam_args_first_emission, false)
+    ;   b_setval(wam_args_first_emission, true)
     ),
     (   length(Clauses, 1)
     ->  Clauses = [Clause],
@@ -1647,22 +1654,26 @@ compile_put_argument(Arg, I, V0, V1, Code) :-
 %% compile_set_arguments(+Args, +VIn, -VOut, -Code)
 %  Emits set_value/set_variable instructions for put_structure sub-arguments.
 %
-%  When the `wam_args_first_emission` flag is set (via
-%  compile_clauses_to_wam reading args_first_emission(true) from
-%  options), nested compound emissions are DEFERRED until after all
-%  immediate set_*'s for the current compound — see
-%  compile_set_arguments_split/5 below. This preserves heap
-%  contiguity of addr+1..addr+arity, required by flat-heap targets.
+%  Default behaviour (args-first): defers nested put_structure emit
+%  until after all immediate set_*'s for the current compound — see
+%  compile_set_arguments_split/5. This preserves heap contiguity of
+%  addr+1..addr+arity, which flat-heap target runtimes assume.
+%
+%  Legacy interleaved behaviour preserved as
+%  compile_set_arguments_inline/4 for the
+%  args_first_emission(false) opt-out — used when callers need
+%  byte-identical bytecode against a pre-flip snapshot.
 compile_set_arguments(Args, V0, Vf, Code) :-
-    ( catch(b_getval(wam_args_first_emission, true), _, fail)
-    -> compile_set_arguments_split(Args, V0, Vf, ImmCode, DeferredCode),
+    catch(b_getval(wam_args_first_emission, FlagVal), _, FlagVal = true),
+    ( FlagVal == false
+    -> compile_set_arguments_inline(Args, V0, Vf, Code)
+    ;  compile_set_arguments_split(Args, V0, Vf, ImmCode, DeferredCode),
        ( DeferredCode == ""
        -> Code = ImmCode
        ;  ImmCode == ""
        -> Code = DeferredCode
        ;  format(string(Code), "~w~n~w", [ImmCode, DeferredCode])
        )
-    ;  compile_set_arguments_inline(Args, V0, Vf, Code)
     ).
 
 % Original interleaved emission — preserved for targets that don't

--- a/tests/test_wam_elixir_classic_programs.pl
+++ b/tests/test_wam_elixir_classic_programs.pl
@@ -719,13 +719,12 @@ test(bagof_with_quantifier) :-
     % Tests ^/2 transparency through the inlined dispatch path
     % combined with nested compound args. Previously blocked because
     % the WAM compiler's interleaved nested-put_structure emission
-    % broke heap-contiguity of em/2's args (see the args_first_emission
-    % flag in wam_target.pl). With that flag on, em(-(X,Y), [...])
-    % has its args at addr+1, addr+2 contiguous; dispatch_call_meta
-    % reads them correctly; the goal enumerates over [a-1, b-2, c-3].
+    % broke heap-contiguity of em/2's args. Now passes by default
+    % because args-first emission is the WAM compiler's default
+    % (see args_first_emission in wam_target.pl).
     with_elixir_project(
         [user:elx_bagof_with_quantifier/1, user:em/2],
-        [inline_bagof_setof(true), args_first_emission(true)],
+        [inline_bagof_setof(true)],
         TmpDir,
         verify_elixir_args(TmpDir, 'elx_bagof_with_quantifier/1',
                            ['[a,b,c]'], "true")).


### PR DESCRIPTION
  ## Summary

  [PR #2259](https://github.com/s243a/UnifyWeaver/pull/2259) shipped `args_first_emission` as opt-in. After auditing
  every WAM target test suite — and verifying **NO new failures attributable to flipping the default** — this PR makes
  it the default.

  ## Audit methodology

  Ran each WAM target test suite individually on:

  1. `main` (baseline)
  2. this branch with flag default-**OFF** (verify no regression vs main)
  3. this branch with flag default-**ON** (look for NEW failures)

  ### Suites audited

  `test_wam_target`, `test_wam_c_target`, `test_wam_clojure_generator`, `test_wam_cpp_generator`, `test_wam_e2e`,
  `test_wam_go_generator`, `test_wam_haskell_target`, `test_wam_ilasm_target`, `test_wam_jvm_target`,
  `test_wam_lua_generator`, `test_wam_python_target`, `test_wam_r_generator`, `test_wam_rust_target`,
  `test_wam_cross_target_consistency`, `test_wam_dict`, `test_wam_fact_table`, `test_wam_rule_index`.

  ### Findings

  | Test | On main | Flag OFF | Flag ON | Notes |
  | --- | --- | --- | --- | --- |
  | test_wam_target | ✅ | ✅ | ✅ | |
  | test_wam_c_target | ✅ | ✅ | ✅ | |
  | test_wam_clojure_generator | ✅ | ✅ | ✅ | |
  | test_wam_e2e | ⚠️ | ⚠️ | ⚠️ | `atom/1` check — **pre-existing on main** |
  | test_wam_go_generator | ✅ | ✅ | ✅ | |
  | test_wam_haskell_target | ✅ | ✅ | ✅ | |
  | test_wam_ilasm_target | ✅ | ✅ | ✅ | |
  | test_wam_jvm_target | ✅ | ✅ | ✅ | |
  | test_wam_lua_generator | ✅ | ✅ | ✅ | |
  | test_wam_python_target | ⚠️ | ⚠️ | ⚠️ | 5 e2e tests — **pre-existing on main** (likely env/subprocess) |
  | test_wam_r_generator | ✅ | ✅ | ✅ | |
  | test_wam_rust_target | ✅ | ✅ | ✅ | |
  | test_wam_cross_target_consistency | ⚠️ | ⚠️ | ⚠️ | `llvm_has_read_write_mode` — **pre-existing on main** |
  | test_wam_dict | ✅ | ✅ | ✅ | |
  | test_wam_fact_table | ✅ | ✅ | ✅ | |

  **Zero new failures attributable to flipping the default.**

  The Rust compile-time bench (already verified in PR #2259) shows the args-first emit is well within natural variance —
   no perf regression.

  ## Why this matters

  - Removes the opt-in flag from every Elixir `bagof_with_quantifier`-style test. Lower friction for future Elixir tests
   that hit the same nested-compound pattern.
  - Rust and Haskell likely have the SAME latent bug (heap-flat representation) but their existing tests don't exercise
  the pattern. The new default protects them prospectively without requiring any per-target opt-in.
  - Opt-out via `args_first_emission(false)` preserved for any caller that needs byte-identical bytecode against a
  pre-flip snapshot.

  ## Wiring changes

  - `compile_clauses_to_wam`: default flipped (opt-out via `args_first_emission(false)`).
  - `compile_set_arguments` wrapper: dispatch logic inverted — defaults to `compile_set_arguments_split` (the new
  args-first path); inline path triggered by `FlagVal == false`.
  - `bagof_with_quantifier` test in `tests/test_wam_elixir_classic_programs.pl`: removed the now-redundant
  `args_first_emission(true)` option.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)