### PR TITLE
feat(wam-cpp): runtime clause/2 (nondet over dynamic predicates)

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -2618,6 +2618,12 @@ struct WamState {
         CellPtr pattern;          // the call''s A1 (full match pattern)
         std::size_t next_idx = 0; // next clause index to test
         std::size_t after_pc = 0;
+        // clause/2 reuses this iterator with these set: instead of
+        // removing the matched clause, we keep it; and we unify the
+        // clause''s body half with body_pattern (treating fact-only
+        // entries as having body = true).
+        bool is_clause_only = false;
+        CellPtr body_pattern;     // A2 of clause/2 (when is_clause_only).
     };
     std::vector<RetractIterator> retract_iters;
     std::size_t retract_next_pc = 0;
@@ -2770,6 +2776,10 @@ struct WamState {
     // removes it, leaves the unification bindings in place, pushes
     // a CP if more candidates remain, and proceeds to after_pc.
     bool    dispatch_retract(std::size_t after_pc);
+    // clause/2: dynamic-db iteration without removal, unifying both
+    // Head and Body. Shares the RetractIterator infrastructure via
+    // the is_clause_only flag.
+    bool    dispatch_clause(std::size_t after_pc);
     bool    retract_try_next();
     // body_next — dispatch the top BodyFrame''s next goal, or pop
     // and proceed to outer after_pc when goals are exhausted.
@@ -6506,6 +6516,8 @@ bool WamState::step(const Instruction& instr) {
             if (instr.a == "sub_atom/5") return dispatch_sub_atom(pc + 1);
             // retract/1 — nondeterministic clause removal.
             if (instr.a == "retract/1") return dispatch_retract(pc + 1);
+            // clause/2 — nondet enumeration of dynamic-db clauses.
+            if (instr.a == "clause/2") return dispatch_clause(pc + 1);
             // ^/2 — existential quantification. Transparent for our
             // find-style aggregation: invoke A2 (the goal) with the
             // standard non-tail after-pc.
@@ -6558,6 +6570,7 @@ bool WamState::step(const Instruction& instr) {
             }
             if (instr.a == "sub_atom/5") return dispatch_sub_atom(cp);
             if (instr.a == "retract/1") return dispatch_retract(cp);
+            if (instr.a == "clause/2") return dispatch_clause(cp);
             if (instr.a == "^/2") {
                 return invoke_goal_as_call(get_cell("A2"), cp);
             }
@@ -7438,6 +7451,33 @@ bool WamState::dispatch_retract(std::size_t after_pc) {
     return retract_try_next();
 }
 
+// clause/2 dispatch. Reuses the RetractIterator infrastructure but
+// with is_clause_only=true so retract_try_next unifies both head
+// and body and DOESN''T remove the matched clause.
+bool WamState::dispatch_clause(std::size_t after_pc) {
+    CellPtr head_pat = get_cell("A1");
+    CellPtr body_pat = get_cell("A2");
+    Value hv = deref(*head_pat);
+    if (hv.is_unbound())
+        return throw_iso_error(make_instantiation_error());
+    std::string key;
+    if (hv.tag == Value::Tag::Atom) key = hv.s + "/0";
+    else if (hv.tag == Value::Tag::Compound) key = hv.s;
+    else return throw_iso_error(make_type_error("callable", hv));
+    // clause/2 in our runtime only sees dynamic-db clauses; static
+    // predicates compiled to bytecode aren''t introspectable here.
+    if (dynamic_db.find(key) == dynamic_db.end()) return false;
+    RetractIterator it;
+    it.key = std::move(key);
+    it.pattern = head_pat;
+    it.body_pattern = body_pat;
+    it.is_clause_only = true;
+    it.next_idx = 0;
+    it.after_pc = after_pc;
+    retract_iters.push_back(std::move(it));
+    return retract_try_next();
+}
+
 // Scan dynamic_db[key] from iter.next_idx onward for a clause that
 // unifies with iter.pattern. On match: remove that clause, leave
 // bindings in place (per ISO), push a CP if any clauses remain
@@ -7456,20 +7496,48 @@ bool WamState::retract_try_next() {
     while (i < vec.size()) {
         std::size_t mark = trail.size();
         CellPtr fresh = deep_copy_term(vec[i]);
-        if (unify_cells(it.pattern, fresh)) {
+        // For clause/2: split the stored term into Head / Body. A
+        // bare-fact entry has Body = true; a :-/2 entry uses its
+        // args. We then unify pattern with Head and body_pattern
+        // with Body. retract/1 just unifies the full term with
+        // pattern (no body slot).
+        bool matched = false;
+        if (it.is_clause_only) {
+            CellPtr head_part, body_part;
+            if (fresh->tag == Value::Tag::Compound
+                && fresh->s == ":-/2" && fresh->args.size() == 2) {
+                head_part = fresh->args[0];
+                body_part = fresh->args[1];
+            } else {
+                head_part = fresh;
+                body_part = std::make_shared<Cell>(Value::Atom("true"));
+            }
+            matched = unify_cells(it.pattern, head_part)
+                   && unify_cells(it.body_pattern, body_part);
+        } else {
+            matched = unify_cells(it.pattern, fresh);
+        }
+        if (matched) {
             // Match. We need to:
             // 1) push a CP (if more candidates exist) whose trail
             //    mark is BEFORE the unification, so backtrack undoes
             //    the pattern''s bindings and the pattern is reusable;
-            // 2) remove the matched clause from vec;
+            // 2) for retract: remove the matched clause from vec.
+            //    for clause/2: leave it in place.
             // 3) leave the unification bindings in place (per ISO
-            //    retract) and proceed to after_pc.
+            //    retract / clause-success semantics) and proceed.
             // The CP''s saved regs/etc are the current values — at
             // entry to retract_try_next, before any binding — which
             // match what the caller of dispatch_retract set up.
-            vec.erase(vec.begin() + i);
-            it.next_idx = i;
-            bool has_more = (i < vec.size());
+            if (it.is_clause_only) {
+                // Don''t remove; advance past this index for the
+                // next backtrack iteration.
+                it.next_idx = i + 1;
+            } else {
+                vec.erase(vec.begin() + i);
+                it.next_idx = i;
+            }
+            bool has_more = (it.next_idx < vec.size());
             std::size_t saved_after_pc = it.after_pc;
             if (has_more) {
                 ChoicePoint cp_;

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -300,6 +300,13 @@
 :- dynamic user:wam_cpp_test_fs_delete_missing/0.
 :- dynamic user:wam_cpp_test_wos_stream/0.
 :- dynamic user:wam_cpp_test_wos_format/0.
+:- dynamic user:wam_cpp_test_clause_fact/0.
+:- dynamic user:wam_cpp_test_clause_var/0.
+:- dynamic user:wam_cpp_test_clause_enum/0.
+:- dynamic user:wam_cpp_test_clause_rule_body/0.
+:- dynamic user:wam_cpp_test_clause_missing/0.
+:- dynamic user:wam_cpp_test_clause_unknown/0.
+:- dynamic user:wam_cpp_test_clause_after_assertz/0.
 :- dynamic user:wam_cpp_test_enum_member/0.
 
 user:wam_cpp_test_member_yes   :- member(b, [a, b, c]).
@@ -768,6 +775,48 @@ user:wam_cpp_test_wos_format :-
     read_line_to_string(R, Line),
     close(R),
     Line = '42-ok'.
+% Runtime clause/2 over dynamic predicates. Iterates dynamic_db
+% with backtracking via the shared RetractIterator + is_clause_only
+% flag (no removal, unifies both Head and Body). Body is `true` for
+% bare facts; `Body` from a `:-/2` stored term otherwise.
+:- dynamic user:wam_cpp_clause_p/1.
+:- dynamic user:wam_cpp_clause_q/2.
+user:wam_cpp_clause_setup_p :-
+    retractall(wam_cpp_clause_p(_)),
+    assertz(wam_cpp_clause_p(1)),
+    assertz(wam_cpp_clause_p(2)),
+    assertz(wam_cpp_clause_p(3)).
+user:wam_cpp_clause_setup_q :-
+    retractall(wam_cpp_clause_q(_, _)),
+    assertz(wam_cpp_clause_q(a, 10)),
+    assertz((wam_cpp_clause_q(b, 20) :- write(side_b), nl)),
+    assertz(wam_cpp_clause_q(c, 30)).
+user:wam_cpp_test_clause_fact :-
+    wam_cpp_clause_setup_p,
+    clause(wam_cpp_clause_p(1), B), B = true.
+user:wam_cpp_test_clause_var :-
+    wam_cpp_clause_setup_p,
+    clause(wam_cpp_clause_p(X), B), X = 1, B = true.
+user:wam_cpp_test_clause_enum :-
+    wam_cpp_clause_setup_p,
+    findall(X, clause(wam_cpp_clause_p(X), true), L),
+    L = [1, 2, 3].
+user:wam_cpp_test_clause_rule_body :-
+    wam_cpp_clause_setup_q,
+    findall(triple(K, V, B), clause(wam_cpp_clause_q(K, V), B), L),
+    L = [triple(a, 10, true),
+         triple(b, 20, (write(side_b), nl)),
+         triple(c, 30, true)].
+user:wam_cpp_test_clause_missing :-
+    wam_cpp_clause_setup_p,
+    \+ clause(wam_cpp_clause_p(99), _).
+user:wam_cpp_test_clause_unknown :-
+    \+ clause(wam_cpp_no_such_dyn(_), _).
+user:wam_cpp_test_clause_after_assertz :-
+    wam_cpp_clause_setup_p,
+    assertz(wam_cpp_clause_p(4)),
+    findall(X, clause(wam_cpp_clause_p(X), _), L),
+    L = [1, 2, 3, 4].
 user:wam_cpp_test_enum_member  :- findall(X, member(X, [a, b, c]), L),
                                   L = [a, b, c].
 
@@ -3950,6 +3999,39 @@ test(cpp_e2e_fs_and_wos, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_fs_delete_missing/0',  [], true),
           run_query(BinPath, 'wam_cpp_test_wos_stream/0',         [], true),
           run_query(BinPath, 'wam_cpp_test_wos_format/0',         [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_clause_runtime, [condition(cpp_compiler_available)]) :-
+    % Runtime clause/2 for dynamic predicates. Each test seeds the
+    % dynamic database with assertz at startup (clause/2 only sees
+    % runtime-asserted clauses, not the statically compiled ones)
+    % then enumerates / matches. Covers facts, bound + var heads,
+    % findall over the enumeration, rule clauses with bodies, miss,
+    % unknown predicate, and assertz-then-enumerate.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_clause', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_clause_fact/0,
+                               user:wam_cpp_test_clause_var/0,
+                               user:wam_cpp_test_clause_enum/0,
+                               user:wam_cpp_test_clause_rule_body/0,
+                               user:wam_cpp_test_clause_missing/0,
+                               user:wam_cpp_test_clause_unknown/0,
+                               user:wam_cpp_test_clause_after_assertz/0,
+                               user:wam_cpp_clause_setup_p/0,
+                               user:wam_cpp_clause_setup_q/0,
+                               user:wam_cpp_clause_p/1,
+                               user:wam_cpp_clause_q/2],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_clause_fact/0',          [], true),
+          run_query(BinPath, 'wam_cpp_test_clause_var/0',           [], true),
+          run_query(BinPath, 'wam_cpp_test_clause_enum/0',          [], true),
+          run_query(BinPath, 'wam_cpp_test_clause_rule_body/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_clause_missing/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_clause_unknown/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_clause_after_assertz/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Completes the deferred runtime `clause/2` from PR #2277. Adds nondet enumeration of clauses for **dynamic** predicates by reusing the existing `RetractIterator` + `retract_next_pc` machinery with a flag that disables removal and adds a body-pattern unification.

### `clause(?Head, ?Body)`

Head must be bound to a callable atom or compound. Body may be unbound (typical), partially bound, or fully bound (acts as a filter). On each iteration we deep-copy the next stored clause, split it into `Head'`/`Body'` (taking the args of `:-/2` for rules, or the whole term + atom `true` for facts), unify against the patterns, and — on success — push a CP for the next iteration before proceeding.

The CP's `alt_pc` reuses `retract_next_pc` and `RetractNext` pops it then re-enters `retract_try_next`, picking up at the saved `next_idx`.

### Implementation

- `RetractIterator` gains `is_clause_only` + `body_pattern` fields. When set, `retract_try_next` splits the fresh-copied stored term into `head_part`/`body_part`, unifies both against the patterns, **leaves the clause in the db**, and bumps `next_idx` past the matched index.
- `dispatch_clause(after_pc)` builds the iterator and delegates to `retract_try_next`, mirroring `dispatch_retract`'s shape. Throws `instantiation_error` on unbound Head and `type_error(callable, _)` on non-callable Head.
- The `Call` and `Execute` opcode arms intercept `clause/2` alongside `retract/1`; `clause/2` is **not** registered in `is_builtin_pred` so the compiler emits a regular `Call` (not `BuiltinCall`), letting the intercept fire.

### Limitation

`clause/2` only sees clauses asserted at runtime (via `assertz`/`asserta`). Statically compiled predicates live in the labels map as WAM bytecode and aren't recoverable as source clauses — consistent with how our runtime distinguishes static vs dynamic. Callers wanting `clause/2` access to a predicate must populate it via `assertz` at startup.

### Deferred

Nondet `current_predicate/1` (enumeration over partial spec) needs moving the builtin from the `builtin()` function to the `Call`/`Execute` dispatch arms so it can push an iterator-style CP. That's a larger restructuring — separate PR.

### Tests

One new `cpp_e2e_clause_runtime` bundle with **7 cases**:

- Fact lookup (ground head), var head, findall enumeration.
- Rule-body lookup — `assertz` a `:-/2` clause and `findall` on `triple(K, V, B)` (avoiding the `K-V-B` pair template which trips an unrelated pre-existing findall issue with nested `-/2` templates — separate bug, not introduced here).
- `clause(p(99), _)` misses (fail).
- `clause/2` of an unknown predicate fails cleanly.
- `assertz` then enumerate — new clause appears in the list.

Full `test_wam_cpp_generator` suite passes; `test_wam_target` unchanged and green.

## Test plan

- [x] Smoke test `/tmp` — all 7 cases pass.
- [x] `test_wam_target` regression — all green.
- [x] Full `test_wam_cpp_generator` — all green.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_