### PR TITLE
bench(csharp-query): fail on actionable policy diffs

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -172,7 +172,8 @@ mode. Use `policy-actionable-tsv` or `policy-actionable-markdown` to suppress
 matching rows and show only policy differences or missing policy modes, with
 the policy-selected value and policy-vs-best ratio included for triage. Add
 `--policy-action-threshold` to ignore small measured diffs while still always
-showing missing policy modes:
+showing missing policy modes. Add `--fail-on-policy-actions` when scripted
+calibration should exit non-zero if thresholded actionable rows remain:
 
 ```bash
 python examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py \
@@ -182,6 +183,7 @@ python examples/benchmark/benchmark_csharp_query_effective_distance_artifact_bac
   --repetitions 1 \
   --summary-output output/csharp-query-effective-distance-summary.tsv \
   --policy-action-threshold 1.10 \
+  --fail-on-policy-actions \
   --format policy-actionable-markdown
 ```
 

--- a/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
+++ b/examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py
@@ -891,6 +891,16 @@ def render_summary_based_format(format_name: str, summaries: list[SummaryRow], p
     raise ValueError(f"{format_name} is not a summary-based format")
 
 
+def actionable_policy_rows_from_summaries(
+    summaries: list[SummaryRow],
+    policy_action_threshold: float = 1.0,
+) -> list[PolicyCompareRow]:
+    return policy_actionable_rows(
+        policy_compare_rows_from_summaries(summaries),
+        threshold=policy_action_threshold,
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Compare C# query artifact backends on real effective-distance support relations."
@@ -1014,6 +1024,11 @@ def main(argv: list[str] | None = None) -> int:
             "missing policy modes are always included"
         ),
     )
+    parser.add_argument(
+        "--fail-on-policy-actions",
+        action="store_true",
+        help="exit non-zero when thresholded actionable policy rows remain",
+    )
     parser.add_argument("--keep-temp", action="store_true", help="keep the generated C# benchmark project")
     args = parser.parse_args(argv)
 
@@ -1048,6 +1063,11 @@ def main(argv: list[str] | None = None) -> int:
                 policy_action_threshold=args.policy_action_threshold,
             )
         )
+        if args.fail_on_policy_actions and actionable_policy_rows_from_summaries(
+            summaries,
+            policy_action_threshold=args.policy_action_threshold,
+        ):
+            return 2
         return 0
 
     scales = [scale.strip() for scale in args.scales.split(",") if scale.strip()]
@@ -1140,6 +1160,14 @@ def main(argv: list[str] | None = None) -> int:
         print(render_markdown(rows))
     else:
         print(render_tsv(rows))
+    if args.fail_on_policy_actions:
+        if not summaries:
+            summaries = summarize(rows)
+        if actionable_policy_rows_from_summaries(
+            summaries,
+            policy_action_threshold=args.policy_action_threshold,
+        ):
+            return 2
     return 0
 
 

--- a/tests/test_csharp_query_effective_distance_artifact_backends.py
+++ b/tests/test_csharp_query_effective_distance_artifact_backends.py
@@ -145,6 +145,40 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
                 stderr=subprocess.PIPE,
                 timeout=60,
             )
+            gated = subprocess.run(
+                [
+                    "python3",
+                    str(SCRIPT),
+                    "--summary-input",
+                    str(path),
+                    "--format",
+                    "policy-actionable-markdown",
+                    "--fail-on-policy-actions",
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=60,
+            )
+            gated_thresholded = subprocess.run(
+                [
+                    "python3",
+                    str(SCRIPT),
+                    "--summary-input",
+                    str(path),
+                    "--format",
+                    "policy-actionable-markdown",
+                    "--policy-action-threshold",
+                    "1.20",
+                    "--fail-on-policy-actions",
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=60,
+            )
 
         self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
         self.assertIn("| Policy mode | Policy artifact value | Policy vs best |", result.stdout)
@@ -152,6 +186,13 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
         self.assertNotIn("| lookup_c0 | ms | lmdb | 3.251 | 1.000x | lmdb | 3.251 | match |", result.stdout)
         self.assertEqual(thresholded.returncode, 0, msg=f"stdout:\n{thresholded.stdout}\nstderr:\n{thresholded.stderr}")
         self.assertNotIn("| bucket_c0 | ms | delimited-artifact | 400.000 | 1.143x | mmap-array | 350.000 | diff |", thresholded.stdout)
+        self.assertEqual(gated.returncode, 2, msg=f"stdout:\n{gated.stdout}\nstderr:\n{gated.stderr}")
+        self.assertIn("| bucket_c0 | ms | delimited-artifact | 400.000 | 1.143x | mmap-array | 350.000 | diff |", gated.stdout)
+        self.assertEqual(
+            gated_thresholded.returncode,
+            0,
+            msg=f"stdout:\n{gated_thresholded.stdout}\nstderr:\n{gated_thresholded.stderr}",
+        )
 
     def test_summary_input_rejects_raw_formats(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -193,6 +234,38 @@ class CSharpQueryEffectiveDistanceArtifactBackendTests(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("--policy-action-threshold must be at least 1.0", result.stderr)
+
+    def test_fail_on_policy_actions_live_benchmark_exits_nonzero(self) -> None:
+        if shutil.which("dotnet") is None:
+            self.skipTest("dotnet is not available")
+        if not LIGHTNINGDB_PACKAGE.exists():
+            self.skipTest("LightningDB 0.21.0 package is not available in the local NuGet cache")
+
+        result = subprocess.run(
+            [
+                "python3",
+                str(SCRIPT),
+                "--scales",
+                "dev",
+                "--lookup-keys",
+                "4",
+                "--lookup-repetitions",
+                "1",
+                "--repetitions",
+                "1",
+                "--format",
+                "policy-actionable-markdown",
+                "--fail-on-policy-actions",
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=180,
+        )
+
+        self.assertEqual(result.returncode, 2, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        self.assertIn("| Policy mode | Policy artifact value | Policy vs best |", result.stdout)
 
     def test_summary_input_rejects_summary_output(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
  ## Summary

  - Adds `--fail-on-policy-actions` to the effective-distance artifact backend benchmark.
  - Returns exit code `2` when thresholded actionable policy rows remain.
  - Supports both live benchmark runs and offline `--summary-input` policy checks.
  - Reuses the same threshold logic as `policy-actionable-*` rendering.
  - Documents the fail-gate workflow for scripted calibration checks.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py tests/test_csharp_query_lmdb_provider_smoke.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `python3 -m py_compile examples/benchmark/benchmark_csharp_query_effective_distance_artifact_backends.py tests/
  test_csharp_query_effective_distance_artifact_backends.py`
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime_lmdb/UnifyWeaver.QueryRuntime.Lmdb.csproj`
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
  - `git diff --check`