### PR TITLE
bench(wam-rust): R6 — enwiki LMDB matrix bench end-to-end (9.93M edges)

### DIFF
--- a/examples/benchmark/enwiki_post_ingest.py
+++ b/examples/benchmark/enwiki_post_ingest.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Post-process the integer-keyed enwiki LMDB:
+
+- add category_child reverse-edge DUPSORT sub-db
+- synthesize identity s2i + i2s sub-dbs so the Rust LmdbFactSource
+  (which opens all four Phase 1 sub-dbs at startup) can attach without
+  changes.  Strings are the decimal stringifications of the IDs.
+- pick root by graph topology: node with the largest reachable subtree
+  among true-roots (LMDB-cursor BFS, no in-memory adjacency)
+- emit seed_ids.txt, root_ids.txt, root_categories.tsv,
+  article_category.tsv (synthetic id -> id), metadata.json
+
+Memory profile: a single set of unique int32 IDs (~ few million for
+enwiki) + a single Counter mapping parent_id -> child_count.  No full
+adjacency lists in RAM.
+"""
+import collections
+import json
+import struct
+import sys
+import time
+from pathlib import Path
+
+import lmdb
+
+FIXTURE = Path("data/benchmark/enwiki_cats")
+LMDB_DIR = FIXTURE / "lmdb_resident"
+
+if not LMDB_DIR.exists():
+    sys.stderr.write(f"enwiki_post_ingest: {LMDB_DIR} missing — run the ingest first\n")
+    sys.exit(2)
+
+t0 = time.time()
+env = lmdb.open(
+    str(LMDB_DIR),
+    max_dbs=16,
+    map_size=64 * 1024 * 1024 * 1024,  # 64 GB headroom, sparse-allocated
+    subdir=True,
+    readonly=False,
+)
+# The enwiki ingest declaration in examples/streaming/enwiki_category_ingest.pl
+# does NOT set UW_LMDB_DBNAME, so the consumer falls through to sub-db "main"
+# (because UW_LMDB_DUPSORT=1 forces a named sub-db).  The Rust LmdbFactSource
+# expects "category_parent" (matching the simplewiki ingest), so we re-key
+# edges into the canonical name here.  See WAM_LMDB_RESIDENT_INTERNING
+# spec §1.4 for the Phase 1 layout.
+main_db = env.open_db(b"main", dupsort=True)
+cp_db = env.open_db(b"category_parent", dupsort=True, create=True)
+cc_db = env.open_db(b"category_child", dupsort=True, create=True)
+
+
+def i32(b: bytes) -> int:
+    return struct.unpack("<i", b)[0]
+
+
+def le32(i: int) -> bytes:
+    return struct.pack("<i", i)
+
+
+# pass 1: walk "main" (where enwiki ingest wrote edges), copy forward edges
+# into the canonical "category_parent" sub-db, write reversed edges into
+# "category_child", and accumulate unique-id + degree counters.
+cp_count = 0
+unique_ids: set = set()
+out_degree: collections.Counter = collections.Counter()
+in_degree: collections.Counter = collections.Counter()
+
+# Cursor lives on a read txn (stable across many writes); writes go into
+# their own write txn that we commit/restart periodically.  LMDB allows
+# concurrent read+write txns; the read cursor sees the snapshot at the
+# moment it was opened.
+BATCH = 500_000
+write_txn = env.begin(write=True)
+read_txn = env.begin(write=False, buffers=True)
+try:
+    cur = read_txn.cursor(db=main_db)
+    for k, v in cur:
+        # Copy to canonical forward edges, write reverse edges.
+        # k and v are memoryview slices; convert to bytes for put.
+        kb = bytes(k)
+        vb = bytes(v)
+        write_txn.put(kb, vb, db=cp_db, dupdata=True, overwrite=True)
+        write_txn.put(vb, kb, db=cc_db, dupdata=True, overwrite=True)
+        cp_count += 1
+        child_id = i32(kb)
+        parent_id = i32(vb)
+        unique_ids.add(child_id)
+        unique_ids.add(parent_id)
+        out_degree[parent_id] += 1
+        in_degree[child_id] += 1
+        if cp_count % 1_000_000 == 0:
+            sys.stderr.write(
+                f"  ...{cp_count:,} edges, |U|={len(unique_ids):,}, "
+                f"t={time.time() - t0:.1f}s\n"
+            )
+        if cp_count % BATCH == 0:
+            write_txn.commit()
+            write_txn = env.begin(write=True)
+    write_txn.commit()
+    read_txn.abort()
+except Exception:
+    write_txn.abort()
+    read_txn.abort()
+    raise
+
+env.sync()
+sys.stderr.write(
+    f"pass 1 done: {cp_count:,} edges, "
+    f"{len(unique_ids):,} unique ids "
+    f"({len(out_degree):,} parents, {len(in_degree):,} children) "
+    f"in {time.time() - t0:.1f}s\n"
+)
+
+# Roots = nodes that appear as a parent but never as a child.
+true_roots = sorted(set(out_degree.keys()) - set(in_degree.keys()))
+sys.stderr.write(f"true roots (no parents) = {len(true_roots):,}\n")
+
+
+# pass 2: pick root by cursor-BFS subtree size.  Avoid the 5,000-root
+# brute scan we did at simplewiki — at enwiki scale that is O(M^2) edges
+# touched.  Instead, take the top-K candidates by out-degree (cheap
+# proxy for "likely hub") and BFS each.
+def bfs_size_via_lmdb(start: int, max_depth: int = 10) -> int:
+    visited = {start}
+    queue = collections.deque([(start, 0)])
+    with env.begin() as ro:
+        cur = ro.cursor(db=cc_db)
+        while queue:
+            node, depth = queue.popleft()
+            if depth >= max_depth:
+                continue
+            if not cur.set_key(le32(node)):
+                continue
+            for vbytes in cur.iternext_dup():
+                child = i32(vbytes)
+                if child not in visited:
+                    visited.add(child)
+                    queue.append((child, depth + 1))
+    return len(visited)
+
+
+TOP_K = 32
+candidates = [r for r, _ in sorted(out_degree.items(), key=lambda kv: -kv[1])[:TOP_K]]
+candidates = [c for c in candidates if c in set(true_roots) or in_degree[c] == 0]
+if not candidates:
+    candidates = sorted(true_roots, key=lambda r: -out_degree.get(r, 0))[:TOP_K]
+sys.stderr.write(
+    f"top-{TOP_K} candidate roots (by out-degree): {candidates[:5]}...\n"
+)
+
+best_root = None
+best_size = 0
+results = []
+for r in candidates:
+    s = bfs_size_via_lmdb(r, max_depth=10)
+    results.append((s, r))
+    if s > best_size:
+        best_size = s
+        best_root = r
+results.sort(reverse=True)
+sys.stderr.write(
+    f"best root: id={best_root} subtree_size={best_size:,}  "
+    f"(top 5: {[(s, r) for s, r in results[:5]]})\n"
+)
+
+
+# pass 3: write identity s2i + i2s sub-dbs.
+sys.stderr.write(f"writing identity s2i + i2s for {len(unique_ids):,} ids...\n")
+s2i_db = env.open_db(b"s2i", create=True)
+i2s_db = env.open_db(b"i2s", create=True)
+written = 0
+with env.begin(write=True) as txn:
+    for nid in unique_ids:
+        nstr = str(nid)
+        txn.put(nstr.encode("utf-8"), le32(nid), db=s2i_db, overwrite=True)
+        txn.put(le32(nid), nstr.encode("utf-8"), db=i2s_db, overwrite=True)
+        written += 1
+        if written % 1_000_000 == 0:
+            sys.stderr.write(f"  ...{written:,}/{len(unique_ids):,} s2i+i2s pairs\n")
+env.sync()
+sys.stderr.write(f"identity intern table written\n")
+
+env.close()
+
+# pass 4: emit fixture files (small)
+with open(FIXTURE / "seed_ids.txt", "w") as f:
+    for sid in sorted(in_degree.keys()):
+        f.write(f"{sid}\n")
+
+with open(FIXTURE / "root_ids.txt", "w") as f:
+    f.write(f"{best_root}\n")
+
+with open(FIXTURE / "article_category.tsv", "w") as f:
+    f.write("article\tcategory\n")
+    for nid in sorted(unique_ids):
+        s = str(nid)
+        f.write(f"{s}\t{s}\n")
+
+with open(FIXTURE / "root_categories.tsv", "w") as f:
+    f.write("root_category\n")
+    f.write(f"{best_root}\n")
+
+with open(FIXTURE / "metadata.json", "w") as f:
+    json.dump(
+        {
+            "name": "enwiki_cats",
+            "source": "enwiki-latest-categorylinks.sql.gz",
+            "schema_note": (
+                "newer MediaWiki schema (cl_target_id linktarget reference). "
+                "Nodes are page_id / linktarget_id; identity intern table is "
+                "synthetic for Rust LmdbFactSource compatibility."
+            ),
+            "subcat_edges": cp_count,
+            "unique_ids": len(unique_ids),
+            "unique_children": len(in_degree),
+            "unique_parents": len(out_degree),
+            "true_roots": len(true_roots),
+            "best_root_id": best_root,
+            "best_root_subtree_size": best_size,
+            "best_root_out_degree": out_degree.get(best_root, 0),
+            "root_selection": (
+                f"top-{TOP_K} candidates by out-degree, "
+                f"BFS subtree size at max_depth=10"
+            ),
+            "post_ingest_seconds": round(time.time() - t0, 2),
+        },
+        f,
+        indent=2,
+    )
+
+sys.stderr.write(f"post-ingest done in {time.time() - t0:.1f}s\n")


### PR DESCRIPTION
### Summary

- Closes out the Rust-LMDB arc end-to-end at enwiki scale (**9,932,244 subcat edges**) on the same WSL2 / 5 GB / 8-CPU box.
- Post-ingest tooling adapts the existing enwiki ingest LMDB (which writes edges into the unnamed-default `main` sub-db) onto the canonical Phase 1 layout the Rust `LmdbFactSource` expects (`category_parent`, `category_child`, `s2i`, `i2s`).
- 5-trial median **`total_ms = 188,816`** at single-threaded -N1, deterministic correctness (`tuple_count = 796,694` across all 5 trials).

### What this PR adds

`examples/benchmark/enwiki_post_ingest.py` — runs after the existing `examples/streaming/enwiki_category_ingest.pl` ingest:

1. **Re-keys edges into the canonical sub-db.** The enwiki ingest declaration does not set `UW_LMDB_DBNAME`, so the consumer falls through to writing edges into `main` (because `UW_LMDB_DUPSORT=1` forces a named sub-db). The Rust bench expects `category_parent`. The post-ingest tool copies `main → category_parent` in-place, using a separate read txn for the cursor and batched write txns for the puts.
2. **Builds the reverse-edge `category_child` DUPSORT sub-db** in the same pass.
3. **Synthesises identity `s2i` + `i2s` sub-dbs.** The strings are decimal stringifications of the IDs themselves — the "export-id" interning regime per `WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md` §"Two regimes". The Rust `LmdbFactSource::open` eagerly opens all four Phase 1 sub-dbs at startup, so a stub i2s is needed even when human-readable names aren't required.
4. **Selects a root by topology** — at enwiki scale, scanning all 1.15M true-roots would be O(N²) edge touches. The tool takes the top-K-by-out-degree candidate roots (K=32, cheap proxy for "hub") and runs LMDB-cursor BFS to compute the `max_depth=10` subtree size for each. Result: best root `id=97688913` with **796,695 descendants** (next four: 353k, 327k, 238k, 179k).
5. **Emits fixture files** that the matrix bench consumes (`seed_ids.txt`, `root_ids.txt`, `root_categories.tsv`, `article_category.tsv`, `metadata.json`).

### R6 bench results (5 trials, Rust LMDB cursor, lmdb_zero, -N1)

| Metric | T1 | T2 | T3 | T4 | T5 | **Median** |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `load_ms` | 154,187 | 133,962 | 157,628 | 158,478 | 158,540 | **157,628** |
| `query_ms` | 12,382 | 12,555 | 12,909 | 12,920 | 12,789 | **12,789** |
| `aggregation_ms` | 3,496 | 3,564 | 3,314 | 3,895 | 4,185 | **3,564** |
| `total_ms` | 181,153 | 161,395 | 188,816 | 192,376 | 191,954 | **188,816** |
| RSS | 3.86 GB | 3.41 GB | 3.77 GB | 3.39 GB | 3.84 GB | **3.77 GB** |
| wall | 181.8 s | 165.7 s | 189.5 s | 195.9 s | 195.6 s | **189.5 s** |

- `seed_count` = 3,783,423 (deterministic across all 5 trials)
- `demand_set_size` = 796,695 (deterministic)
- `tuple_count` = 796,694 (deterministic — kernel correctness signal: every reachable node except the root itself produces a path)
- `root_id` = 97,688,913

### Cross-scale shape vs R5 simplewiki

| | Simplewiki (R5) | Enwiki (R6) | Ratio |
| --- | ---: | ---: | ---: |
| edges | 297,283 | 9,932,244 | 33× |
| seeds | 134,692 | 3,783,423 | 28× |
| demand_set | 14,680 | 796,695 | 54× |
| `query_ms` | 370 | 12,789 | 35× |
| **per-seed** | **2.75 µs** | **3.38 µs** | **flat** |
| `total_ms` | 462 | 188,816 | 409× |

Per-seed cost is essentially flat across the two scales — the LMDB cursor BFS path is the same shape regardless of edge count. The 409× scaling in `total_ms` is dominated by `load_ms` (3-orders-of-magnitude growth), not by query work.

### Where `load_ms` goes (84% of total)

The Rust bench's `load_ms` measures everything from `LmdbFactSource::open` through `let load_ms = started.elapsed()` — that includes:

1. LMDB open + sub-db opens (microseconds)
2. `load_i2s` — 3.78M HashMap entries with UTF-8 decode
3. `load_tsv_pairs` — 3.78M lines of `article_category.tsv` parsed
4. `reachable_to_root` cursor BFS — walks 796k reachable nodes
5. `runtime_category_parents` build — for each of 796k reachable nodes, `lookup_parents` and intersect with `reachable_ids` (the actual cost concentration)

Step 5 is the dominant cost at this scale. Known optimisation targets for follow-ups:

- Skip eager `load_i2s` when output rendering is not required (e.g. when only timings matter).
- Stream `runtime_category_parents` lazily from LMDB during query iteration instead of materialising up front.
- Pre-compute and persist `runtime_category_parents` for a given root in the LMDB itself (one-time cost amortised across query workloads on the same root).

These are scoped out of R6, which is intentionally "make the bench work at enwiki scale and capture the numbers."

### Follow-up tickets (not in this PR)

- **R6.5 — fix the enwiki ingest sub-db name.** Update `examples/streaming/enwiki_category_ingest.pl` to set `UW_LMDB_DBNAME='category_parent'` so future ingests skip the `main → category_parent` copy entirely. Matches the simplewiki ingest pattern.
- **R5.5 / R6.5b — linktarget join.** Optional second-pass ingest of `*-latest-linktarget.sql.gz` to map `linktarget_id → category title` for human-readable output. Currently both simplewiki and enwiki carry page_id / linktarget_id strings in the synthetic intern table; fine for perf, not for narrative.
- **R3 — Rust sharded L2 cache.** Was deferred until R5/R6 profiles surfaced hot reads; the profile shows the hot path is `runtime_category_parents` build (step 5 above), not the query loop's edge lookups. The cache work should follow whichever optimisation tackles step 5.
- **R4.5 — DRY matrix bench templates.** Pre-existing tech debt from R4.

### Test plan

- [x] Existing enwiki ingest runs cleanly (~3-4 min wall, 9.93M edges written, no errors)
- [x] Post-ingest copies `main → category_parent`, writes `category_child`, synthesises `s2i` + `i2s` (~126 s total)
- [x] Post-ingest `metadata.json` reports the expected counts and selected root
- [x] Generated Rust LMDB-mode matrix bench builds with `cargo build --release` in 7 s
- [x] 5 trials run end-to-end with deterministic `tuple_count`
- [x] RSS stays under WSL's 5 GB allocation (peak 3.86 GB)
- [x] Per-seed query cost matches R5 simplewiki (~3 µs/seed) — no quadratic blowup at scale

### Files changed

| File | Change |
| --- | --- |
| `examples/benchmark/enwiki_post_ingest.py` | New (231 lines). Three-pass tool: re-key `main`→`category_parent` + write `category_child`, top-K-by-out-degree root selection via LMDB-cursor BFS, identity `s2i`/`i2s` synthesis. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)