### PR TITLE
feat(wam-clojure): split atomic_list_concat output

### DIFF
--- a/PR_WAM_CLOJURE_ATOMIC_LIST_CONCAT_SPLIT.md
+++ b/PR_WAM_CLOJURE_ATOMIC_LIST_CONCAT_SPLIT.md
@@ -1,0 +1,22 @@
+# PR Title
+
+feat(wam-clojure): split atomic_list_concat output
+
+# PR Description
+
+## Summary
+
+- Extends lowered Clojure WAM `atomic_list_concat/3` support with deterministic output splitting.
+- Adds a runtime helper that turns split text segments into interned atom terms and unifies them with the list argument.
+- Adds smoke coverage for split success, split mismatch, and unsupported unbound-separator fallback.
+
+## Scope
+
+This keeps the implementation conservative. The new supported mode is `atomic_list_concat(List, Separator, Atom)` when `List` is unbound, `Separator` is a bound non-empty atomic value, and `Atom` is bound. Existing bound-list concatenation behavior remains unchanged. Unsupported modes, including unbound separators and `atomic_list_concat/2` with an unbound list, continue to fail through the lowered runtime backtracking path.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1133,6 +1133,15 @@
   (or (atom-text state value)
       (number-text value)))
 
+(defn atomic-concat-list-term [state texts]
+  (loop [s state
+         remaining texts
+         out []]
+    (if-let [text (first remaining)]
+      (let [[next-state atom] (intern-text-atom s text)]
+        (recur next-state (rest remaining) (conj out atom)))
+      [s (list->term (:intern-context s) out)])))
+
 (defn apply-atomic-list-concat-solution [state pred]
   (let [list-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A1") ::unbound))
@@ -1144,8 +1153,10 @@
         items (proper-list-items state list-value)
         separator-text (if (= pred "atomic_list_concat/3")
                          (atomic-concat-text state separator-value)
-                         "")]
-    (if (and (some? items) (some? separator-text))
+                         "")
+        out-text (atomic-concat-text state out)]
+    (cond
+      (and (some? items) (some? separator-text))
       (let [texts (map #(atomic-concat-text state %) items)]
         (if (every? some? texts)
           (let [joined (str/join separator-text texts)
@@ -1154,6 +1165,22 @@
               (advance unified-state)
               (backtrack state)))
           (backtrack state)))
+
+      (and (= pred "atomic_list_concat/3")
+           (or (= list-value ::unbound) (logic-var? list-value))
+           (some? separator-text)
+           (not= "" separator-text)
+           (some? out-text))
+      (let [segments (str/split out-text
+                                (re-pattern (java.util.regex.Pattern/quote separator-text))
+                                -1)
+            [next-state list-term] (atomic-concat-list-term state segments)
+            [ok unified-state] (unify-values next-state list-value list-term)]
+        (if ok
+          (advance unified-state)
+          (backtrack state)))
+
+      :else
       (backtrack state))))
 
 (defn char-code-text [state value]

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -159,6 +159,9 @@
 :- dynamic user:wam_upcase_atom_unbound_source/1.
 :- dynamic user:wam_atomic_list_concat_2_guard/1.
 :- dynamic user:wam_atomic_list_concat_3_guard/1.
+:- dynamic user:wam_atomic_list_concat_3_split/0.
+:- dynamic user:wam_atomic_list_concat_3_split_mismatch/0.
+:- dynamic user:wam_atomic_list_concat_3_unbound_separator/0.
 :- dynamic user:wam_atomic_list_concat_mismatch/0.
 :- dynamic user:wam_atomic_list_concat_bad_list/0.
 :- dynamic user:wam_atomic_list_concat_unbound_list/1.
@@ -371,6 +374,9 @@ user:wam_downcase_atom_guard(A, L) :- downcase_atom(A, L).
 user:wam_upcase_atom_unbound_source(_) :- user:wam_unbound_arg(A), upcase_atom(A, _).
 user:wam_atomic_list_concat_2_guard(A) :- atomic_list_concat([f,o,o], A).
 user:wam_atomic_list_concat_3_guard(A) :- atomic_list_concat([f,o], o, A).
+user:wam_atomic_list_concat_3_split :- user:wam_unbound_arg(L), atomic_list_concat(L, b, abcbd), L = [a,c,d].
+user:wam_atomic_list_concat_3_split_mismatch :- user:wam_unbound_arg(L), atomic_list_concat(L, o, foo), L = [foo].
+user:wam_atomic_list_concat_3_unbound_separator :- user:wam_unbound_arg(L), user:wam_unbound_arg(S), atomic_list_concat(L, S, abc).
 user:wam_atomic_list_concat_mismatch :- atomic_list_concat([f,o], a, foo).
 user:wam_atomic_list_concat_bad_list :- atomic_list_concat([a|b], _).
 user:wam_atomic_list_concat_unbound_list(_) :- user:wam_unbound_arg(L), atomic_list_concat(L, _).
@@ -588,6 +594,9 @@ run_smoke :-
           user:wam_upcase_atom_unbound_source/1,
           user:wam_atomic_list_concat_2_guard/1,
           user:wam_atomic_list_concat_3_guard/1,
+          user:wam_atomic_list_concat_3_split/0,
+          user:wam_atomic_list_concat_3_split_mismatch/0,
+          user:wam_atomic_list_concat_3_unbound_separator/0,
           user:wam_atomic_list_concat_mismatch/0,
           user:wam_atomic_list_concat_bad_list/0,
           user:wam_atomic_list_concat_unbound_list/1,
@@ -962,6 +971,9 @@ smoke_cases([
     case('wam_upcase_atom_unbound_source/1', a, "false"),
     case('wam_atomic_list_concat_2_guard/1', foo, "true"),
     case('wam_atomic_list_concat_3_guard/1', foo, "true"),
+    case('wam_atomic_list_concat_3_split/0', no_args, "true"),
+    case('wam_atomic_list_concat_3_split_mismatch/0', no_args, "false"),
+    case('wam_atomic_list_concat_3_unbound_separator/0', no_args, "false"),
     case('wam_atomic_list_concat_mismatch/0', no_args, "false"),
     case('wam_atomic_list_concat_bad_list/0', no_args, "false"),
     case('wam_atomic_list_concat_unbound_list/1', a, "false"),
@@ -1343,6 +1355,8 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-downcase-atom-guard-2"),
     has(CoreCode, "defn lowered-wam-atomic-list-concat-2-guard-1"),
     has(CoreCode, "defn lowered-wam-atomic-list-concat-3-guard-1"),
+    has(CoreCode, "defn lowered-wam-atomic-list-concat-3-split-0"),
+    has(CoreCode, "defn lowered-wam-atomic-list-concat-3-split-mismatch-0"),
     has(CoreCode, "defn lowered-wam-string-to-atom-guard-2"),
     has(CoreCode, "defn lowered-wam-string-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-string-chars-guard-2"),


### PR DESCRIPTION
## Summary

- Extends lowered Clojure WAM `atomic_list_concat/3` support with deterministic output splitting.
- Adds a runtime helper that turns split text segments into interned atom terms and unifies them with the list argument.
- Adds smoke coverage for split success, split mismatch, and unsupported unbound-separator fallback.

## Scope

This keeps the implementation conservative. The new supported mode is `atomic_list_concat(List, Separator, Atom)` when `List` is unbound, `Separator` is a bound non-empty atomic value, and `Atom` is bound. Existing bound-list concatenation behavior remains unchanged. Unsupported modes, including unbound separators and `atomic_list_concat/2` with an unbound list, continue to fail through the lowered runtime backtracking path.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
