### PR TITLE
Feat/wam go atom concat builtin

### DIFF
--- a/PR_go_wam_atom_concat_builtin.md
+++ b/PR_go_wam_atom_concat_builtin.md
@@ -1,0 +1,24 @@
+# PR Title
+
+Add Go WAM atom_concat/3 builtin parity
+
+# PR Description
+
+## Summary
+
+- Add direct Go WAM lowering for `atom_concat/3`.
+- Implement deterministic runtime support when both input arguments are atoms.
+- Cover output binding, bound-output success, mismatch failure, unbound-input failure, and non-atom input failure in the generated Go WAM builtin E2E test.
+- Update the Go WAM parity audit to record the atom-concat conversion surface alongside the existing atom-number and atom-case builtins.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(atom_concat/3,3), X), writeln(X), halt"`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -14,7 +14,7 @@ current cross-target builtin/runtime baseline.
 | Structural builtins | `member/2`, `memberchk/2`, `select/3`, `delete/3`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `select/3`, `delete/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Arithmetic builtins | `is/2`, `succ/2` | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir | Present for current baseline arithmetic checks, with expanded successor coverage |
-| Atom/text conversion | `atom_number/2`, `upcase_atom/2`, `downcase_atom/2` | Clojure direct builtin surface includes bidirectional `atom_number/2` and atom case conversion | Present for current atom-number and atom-case checks |
+| Atom/text conversion | `atom_number/2`, `upcase_atom/2`, `downcase_atom/2`, `atom_concat/3` | Clojure direct builtin surface includes bidirectional `atom_number/2`, atom case conversion, and deterministic atom concatenation | Present for current atom-number, atom-case, and atom-concat checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` | Includes `=</2`; Haskell mode analysis and Clojure lowering also cover term-order comparisons | Present for current baseline comparisons, with expanded term-order coverage |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
 | Term inspection | `functor/3`, `arg/3` | `functor/3`, `arg/3` | Present |
@@ -76,6 +76,10 @@ current cross-target builtin/runtime baseline.
   generated Go WAM builtin E2E test for converted output binding, bound-output
   success, mismatch failure, unbound-source failure, and non-atom source
   failure, matching the Clojure atom-case surface.
+- Deterministic `atom_concat/3` is now covered by the generated Go WAM builtin
+  E2E test for output binding, bound-output success, mismatch failure, unbound
+  input failure, and non-atom input failure, matching the current Clojure
+  atom-concat surface.
 - Go WAM choice points now have explicit generated-runtime coverage for normal
   clause retries, indexed alternatives, foreign stream retries, indexed atom
   fact streams, and `member/2` builtin retries.

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -472,6 +472,9 @@ wam_go_direct_builtin("upcase_atom/2", 2, 'upcase_atom/2').
 wam_go_direct_builtin(downcase_atom/2, 2, 'downcase_atom/2').
 wam_go_direct_builtin('downcase_atom/2', 2, 'downcase_atom/2').
 wam_go_direct_builtin("downcase_atom/2", 2, 'downcase_atom/2').
+wam_go_direct_builtin(atom_concat/3, 3, 'atom_concat/3').
+wam_go_direct_builtin('atom_concat/3', 3, 'atom_concat/3').
+wam_go_direct_builtin("atom_concat/3", 3, 'atom_concat/3').
 
 wam_instruction_to_go_literal(get_constant(C, Ai), GoLiteral) :-
     go_value_literal(C, GoVal),

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1165,6 +1165,13 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			return false
 		}
 		return vm.Unify(arg2, internAtom(strings.ToLower(atom.Name)))
+	case "atom_concat/3":
+		left, okLeft := vm.deref(arg1).(*Atom)
+		right, okRight := vm.deref(arg2).(*Atom)
+		if !okLeft || !okRight {
+			return false
+		}
+		return vm.Unify(arg3, internAtom(left.Name+right.Name))
 
 	case "var/1": return isUnbound(vm.deref(arg1))
 	case "nonvar/1": return !isUnbound(vm.deref(arg1))

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -20,6 +20,7 @@
 :- dynamic user:test_succ_builtin/0.
 :- dynamic user:test_atom_number_builtin/0.
 :- dynamic user:test_atom_case_builtin/0.
+:- dynamic user:test_atom_concat_builtin/0.
 :- dynamic user:test_set_aggregate/0.
 :- dynamic user:test_unify_builtin/0.
 :- dynamic user:test_neg_fact/1.
@@ -188,6 +189,16 @@ test(builtins_execution) :-
                 \+ upcase_atom(_, _),
                 \+ upcase_atom(42, _)
             )),
+          assertz(user:test_atom_concat_builtin :-
+            (   atom_concat(fo, o, A),
+                A == foo,
+                atom_concat(fo, o, foo),
+                \+ atom_concat(fo, o, bar),
+                \+ atom_concat(_, o, foo),
+                \+ atom_concat(fo, _, foo),
+                \+ atom_concat(42, o, _),
+                \+ atom_concat(fo, 42, _)
+            )),
           assertz(user:test_set_aggregate :-
             (   aggregate_all(set(X), member(X, [a,b,a]), S),
                 length(S, 2),
@@ -224,6 +235,7 @@ test(builtins_execution) :-
           retractall(user:test_succ_builtin),
           retractall(user:test_atom_number_builtin),
           retractall(user:test_atom_case_builtin),
+          retractall(user:test_atom_concat_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
           retractall(user:test_neg_fact(_)),
@@ -233,7 +245,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -284,6 +296,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "atom_number/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "upcase_atom/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "downcase_atom/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "atom_concat/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "\\\\+/1"')),
     assertion(sub_string(LibCode, _, _, _, 'AggType: "set"')),
 
@@ -425,6 +438,14 @@ func main() {
 		fmt.Println("ATOM_CASE_FAILURE")
 	}
 
+	atomConcatVM := wam.NewWamState(wam.Test_atom_concat_builtinCode, wam.Test_atom_concat_builtinLabels)
+	atomConcatVM.PC = wam.Test_atom_concat_builtinStartPC
+	if atomConcatVM.Run() {
+		fmt.Println("ATOM_CONCAT_SUCCESS")
+	} else {
+		fmt.Println("ATOM_CONCAT_FAILURE")
+	}
+
 	setVM := wam.NewWamState(wam.Test_set_aggregateCode, wam.Test_set_aggregateLabels)
 	setVM.PC = wam.Test_set_aggregateStartPC
 	if setVM.Run() {
@@ -489,6 +510,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "SUCC_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_NUMBER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_CASE_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "ATOM_CONCAT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NEG_SUCCESS")),


### PR DESCRIPTION
#Add Go WAM atom_concat/3 builtin parity

## Summary

- Add direct Go WAM lowering for `atom_concat/3`.
- Implement deterministic runtime support when both input arguments are atoms.
- Cover output binding, bound-output success, mismatch failure, unbound-input failure, and non-atom input failure in the generated Go WAM builtin E2E test.
- Update the Go WAM parity audit to record the atom-concat conversion surface alongside the existing atom-number and atom-case builtins.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(atom_concat/3,3), X), writeln(X), halt"`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`
