### PR TITLE
fix(wam-target): findall nested compound templates

### DIFF
--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1058,8 +1058,8 @@ witness_var_regs([_|Vs], Varmap, Rest) :-
 
 %% compile_compound_template(+Template, +V0, -Vf, -InitCode, -ConstructionCode)
 %  For findall(Functor(Arg1, Arg2, ...), Goal, L) with compound Template:
-%  - Each Arg is either a variable or a constant
-%  - Variables get Y-regs allocated (via allocate_var) and initialized
+%  - Each Arg is a variable, an atomic, or a NESTED compound. Variable
+%    leaves get Y-regs allocated (via allocate_var) and initialized
 %    directly so they have stable slots across the inner-goal call.
 %    Do not initialize through A-registers: those are scratch argument
 %    registers for the inner goal, and aliasing a template variable
@@ -1067,49 +1067,102 @@ witness_var_regs([_|Vs], Varmap, Rest) :-
 %    (for example findall(Y-L, bagof(X, p(X,Y), L), Groups)).
 %  - ConstructionCode emits put_structure + set_value/set_constant
 %    after the inner goal returns; A1 holds the heap ref to the
-%    constructed Template
-%  - Compound args within the Template (e.g., `findall(p(f(X)), ...)`)
-%    are not yet supported — would need recursive heap construction.
+%    constructed Template.
+%  - Nested compound args (e.g. findall(K-V-B, ...) where the template
+%    is -/2(-/2(K,V), B)) use the WAM set_variable trick: the outer
+%    put_structure starts in A1, set_variable X_subN allocates a
+%    fresh cell into the parent''s arg slot, then put_structure on
+%    X_subN mutates the same cell to the sub-compound — visible
+%    through the parent because cells are shared by pointer.
 compile_compound_template(Template, V0, Vf, InitCode, ConstructionCode) :-
-    Template =.. [Functor | Args],
-    length(Args, Arity),
-    compile_template_arg_init(Args, 1, V0, V1, InitLines),
+    init_template_leaf_vars(Template, V0, V1, InitLines),
     (   InitLines == []
     ->  InitCode = ""
     ;   atomic_list_concat(InitLines, '\n', InitCode)
     ),
-    format(string(PutStrucCode), "    put_structure ~w/~w, A1", [Functor, Arity]),
-    compile_template_arg_set(Args, V1, Vf, SetLines),
-    atomic_list_concat([PutStrucCode | SetLines], '\n', ConstructionCode).
+    % Construct the structure top-down, root first into A1; sub-
+    % compounds get fresh X-regs (named "_XT<N>") that the outer
+    % parent''s set_variable allocates and the inner put_structure
+    % mutates in place.
+    construct_template(Template, 'A1', 0, _, V1, Vf, Lines),
+    atomic_list_concat(Lines, '\n', ConstructionCode).
 
-compile_template_arg_init([], _, V, V, []).
-compile_template_arg_init([Arg | Rest], I, V0, Vf, Lines) :-
-    (   var(Arg)
-    ->  allocate_var(Arg, V0, V1, Reg),
+%% init_template_leaf_vars(+Template, +V0, -Vf, -Lines)
+%  Walks Template recursively and allocates a Y-register per variable
+%  leaf, emitting put_variable lines so each Y-reg starts as a fresh
+%  unbound cell on every aggregate iteration.
+init_template_leaf_vars(T, V0, Vf, Lines) :-
+    (   var(T)
+    ->  allocate_var(T, V0, Vf, Reg),
         format(string(Line), "    put_variable ~w, ~w", [Reg, Reg]),
-        Lines = [Line | RestLines]
-    ;   atomic(Arg)
-    ->  V1 = V0,
-        Lines = RestLines
-    ;   % Compound or other — not yet supported
-        throw(error(unsupported_template_arg(Arg), compile_compound_template/5))
-    ),
-    NI is I + 1,
-    compile_template_arg_init(Rest, NI, V1, Vf, RestLines).
+        Lines = [Line]
+    ;   atomic(T)
+    ->  Vf = V0,
+        Lines = []
+    ;   T =.. [_|Args],
+        init_template_leaf_vars_list(Args, V0, Vf, Lines)
+    ).
+init_template_leaf_vars_list([], V, V, []).
+init_template_leaf_vars_list([H|T], V0, Vf, Lines) :-
+    init_template_leaf_vars(H, V0, V1, HLines),
+    init_template_leaf_vars_list(T, V1, Vf, TLines),
+    append(HLines, TLines, Lines).
 
-compile_template_arg_set([], V, V, []).
-compile_template_arg_set([Arg | Rest], V0, Vf, [Line | Lines]) :-
-    (   var(Arg)
-    ->  get_var_reg(Arg, V0, Reg),
-        format(string(Line), "    set_value ~w", [Reg]),
-        V1 = V0
-    ;   atomic(Arg)
-    ->  V1 = V0,
-        quote_wam_constant(Arg, ArgStr),
-        format(string(Line), "    set_constant ~w", [ArgStr])
-    ;   throw(error(unsupported_template_arg(Arg), compile_compound_template/5))
+%% construct_template(+Template, +TargetReg, +T0, -Tf, +V0, -Vf, -Lines)
+%  Emits WAM instructions that build Template into TargetReg. T0/Tf
+%  is a counter for naming fresh "_XT<N>" sub-compound registers so
+%  nested compounds each get their own scratch slot. Lines is a flat
+%  list in correct emission order.
+construct_template(T, TargetReg, T0, Tf, V0, Vf, Lines) :-
+    T =.. [Functor|Args],
+    length(Args, Arity),
+    format(string(HeadLine), "    put_structure ~w/~w, ~w",
+           [Functor, Arity, TargetReg]),
+    % Pass over the args: for each, emit a fill line (set_value /
+    % set_constant / set_variable + record a pending sub-compound)
+    % and collect any pending sub-compound construction tasks.
+    construct_template_args(Args, T0, T1, V0, V1, FillLines, Pending),
+    % Sub-compounds are constructed AFTER the outer put_structure +
+    % its fill lines, in left-to-right order.
+    construct_pending(Pending, T1, Tf, V1, Vf, PendingLines),
+    append([HeadLine | FillLines], PendingLines, Lines).
+
+% Wrapper: emit fill lines for the outer compound''s args, and
+% collect (SubReg, SubTemplate) tasks for sub-compounds.
+construct_template_args([], T, T, V, V, [], []).
+construct_template_args([A|Rest], T0, Tf, V0, Vf,
+                       [FillLine|FillTail], Pending) :-
+    (   var(A)
+    ->  get_var_reg(A, V0, Reg),
+        format(string(FillLine), "    set_value ~w", [Reg]),
+        T1 = T0, V1 = V0, ThisPending = []
+    ;   atomic(A)
+    ->  quote_wam_constant(A, AStr),
+        format(string(FillLine), "    set_constant ~w", [AStr]),
+        T1 = T0, V1 = V0, ThisPending = []
+    ;   % Compound — allocate a fresh sub-reg, emit set_variable
+        % which attaches a fresh cell to the parent''s arg slot AND
+        % binds the X-reg to it. The pending entry holds the X-reg
+        % and the sub-template for later put_structure-based
+        % mutation of that same cell.
+        format(atom(SubReg), "_XT~w", [T0]),
+        T1 is T0 + 1,
+        format(string(FillLine), "    set_variable ~w", [SubReg]),
+        V1 = V0,
+        ThisPending = [SubReg-A]
     ),
-    compile_template_arg_set(Rest, V1, Vf, Lines).
+    construct_template_args(Rest, T1, Tf, V1, Vf, FillTail, RestPending),
+    append(ThisPending, RestPending, Pending).
+
+% Construct each pending sub-compound into its allocated reg.
+construct_pending([], T, T, V, V, []).
+construct_pending([Reg-Sub|Rest], T0, Tf, V0, Vf, Lines) :-
+    construct_template(Sub, Reg, T0, T1, V0, V1, SubLines),
+    construct_pending(Rest, T1, Tf, V1, Vf, RestLines),
+    append(SubLines, RestLines, Lines).
+
+flatten_once([], []).
+flatten_once([L|Ls], Out) :- append(L, Rest, Out), flatten_once(Ls, Rest).
 
 %% compile_findall(+Template, +InnerGoal, +Result, +V0, -Vf, -Code)
 compile_findall(Template, InnerGoal, Result, V0, Vf, Code) :-

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -307,6 +307,10 @@
 :- dynamic user:wam_cpp_test_clause_missing/0.
 :- dynamic user:wam_cpp_test_clause_unknown/0.
 :- dynamic user:wam_cpp_test_clause_after_assertz/0.
+:- dynamic user:wam_cpp_test_nested_dash/0.
+:- dynamic user:wam_cpp_test_nested_f_g/0.
+:- dynamic user:wam_cpp_test_nested_right/0.
+:- dynamic user:wam_cpp_test_nested_constant/0.
 :- dynamic user:wam_cpp_test_enum_member/0.
 
 user:wam_cpp_test_member_yes   :- member(b, [a, b, c]).
@@ -817,6 +821,34 @@ user:wam_cpp_test_clause_after_assertz :-
     assertz(wam_cpp_clause_p(4)),
     findall(X, clause(wam_cpp_clause_p(X), _), L),
     L = [1, 2, 3, 4].
+% findall with nested compound templates. Previously compile_compound_template
+% threw on any compound arg, which got caught + swallowed by the per-
+% predicate try-catch in compile_predicates_for_project, silently
+% dropping the affected predicate from the output. The fix recurses
+% into nested compounds using set_variable + put_structure on the
+% sub-reg so the parent''s arg slot sees the sub-compound. Each test
+% asserts ground facts and findalls them through a nested template.
+:- dynamic user:wam_cpp_nest_emit/3.
+user:wam_cpp_nest_setup :-
+    retractall(wam_cpp_nest_emit(_, _, _)),
+    assertz(wam_cpp_nest_emit(a, 10, true)),
+    assertz(wam_cpp_nest_emit(b, 20, false)).
+user:wam_cpp_test_nested_dash :-
+    wam_cpp_nest_setup,
+    findall(K-V-B, wam_cpp_nest_emit(K, V, B), L),
+    L = [a-10-true, b-20-false].
+user:wam_cpp_test_nested_f_g :-
+    wam_cpp_nest_setup,
+    findall(f(g(K, V), B), wam_cpp_nest_emit(K, V, B), L),
+    L = [f(g(a, 10), true), f(g(b, 20), false)].
+user:wam_cpp_test_nested_right :-
+    wam_cpp_nest_setup,
+    findall(g(K, f(V, B)), wam_cpp_nest_emit(K, V, B), L),
+    L = [g(a, f(10, true)), g(b, f(20, false))].
+user:wam_cpp_test_nested_constant :-
+    wam_cpp_nest_setup,
+    findall(g(K, f(V, marker)), wam_cpp_nest_emit(K, V, _), L),
+    L = [g(a, f(10, marker)), g(b, f(20, marker))].
 user:wam_cpp_test_enum_member  :- findall(X, member(X, [a, b, c]), L),
                                   L = [a, b, c].
 
@@ -4032,6 +4064,35 @@ test(cpp_e2e_clause_runtime, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_clause_missing/0',       [], true),
           run_query(BinPath, 'wam_cpp_test_clause_unknown/0',       [], true),
           run_query(BinPath, 'wam_cpp_test_clause_after_assertz/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_findall_nested_template, [condition(cpp_compiler_available)]) :-
+    % Regression for the findall nested compound template bug
+    % uncovered during PR #2286 development. The compile path used
+    % to throw unsupported_template_arg on any compound arg of a
+    % findall template, and the surrounding catch silently dropped
+    % the predicate from the output. The fix in compile_compound_
+    % template recurses into nested compounds using set_variable
+    % at the parent level + put_structure on the sub-reg. Tests
+    % cover left-nested (-/2-2x), right-nested, mixed-functor
+    % nests, and templates containing a literal atom inside the
+    % nested compound.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_nest', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_test_nested_dash/0,
+                               user:wam_cpp_test_nested_f_g/0,
+                               user:wam_cpp_test_nested_right/0,
+                               user:wam_cpp_test_nested_constant/0,
+                               user:wam_cpp_nest_setup/0,
+                               user:wam_cpp_nest_emit/3],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_nested_dash/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_nested_f_g/0',      [], true),
+          run_query(BinPath, 'wam_cpp_test_nested_right/0',    [], true),
+          run_query(BinPath, 'wam_cpp_test_nested_constant/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Fixes the pre-existing bug surfaced during PR #2286: `findall` with a nested compound template (e.g. `K-V-B`, `f(g(K, V), B)`) silently dropped the calling predicate from the generated output. Now nested templates compile and produce correct results.

## Root cause

`compile_compound_template`'s helpers checked each `Arg` as `var | atomic | otherwise` and threw `unsupported_template_arg/2` on compound. `compile_predicates_for_project` wraps each per-predicate compile in `catch(_, _, fail)` so the throw became a **silent skip** — the affected predicate just disappeared from the project, and calls to it later failed at runtime with no diagnostic.

## Fix

Replace the flat init/set pair with two recursive helpers:

- **`init_template_leaf_vars`** walks the template tree and allocates a Y-register per variable leaf, regardless of nesting depth.
- **`construct_template`** walks top-down, emitting `put_structure` at the root + a fill line per arg.
  - Variable / atomic args use `set_value` / `set_constant` as before.
  - Compound args allocate a fresh `_XT<N>` sub-register, emit `set_variable` for it (which attaches a new cell to the parent's arg slot **and** binds the sub-reg to it), and record a pending `(SubReg, SubTemplate)` task.
  - After the outer compound's fill lines, pending tasks build each sub-compound via `put_structure` on the sub-reg. Because the parent's arg slot shares the cell via shared_ptr, mutating in place propagates the sub-compound up to the parent transparently.

### Example bytecode

```
?- findall(f(g(K, V), B), goal(K, V, B), L).

% init phase (per-iteration):
put_variable Y1, Y1      ; K
put_variable Y2, Y2      ; V
put_variable Y3, Y3      ; B

% construction (after inner goal binds K, V, B):
put_structure f/2, A1    ; outer compound
set_variable _XT0        ; arg 0 = fresh cell shared with sub-reg
set_value Y3             ; arg 1 = B
put_structure g/2, _XT0  ; mutates _XT0''s cell to g(...)
set_value Y1             ; g''s arg 0 = K
set_value Y2             ; g''s arg 1 = V
```

After this sequence A1 holds `f(g(K, V), B)` with bindings flowing correctly.

## Tests

One new `cpp_e2e_findall_nested_template` bundle with **4 cases**:

- Left-nested `-/2` (`K-V-B`).
- Arbitrary-functor nesting (`f(g(K, V), B)`).
- Right-nesting (`g(K, f(V, B))`).
- Mixed variable + atom inside a sub-compound (`g(K, f(V, marker))`).

Each setup asserts two ground facts at startup and `findall`s through the template; the expected lists are exact-match.

Full `test_wam_cpp_generator` suite passes; `test_wam_target` unchanged and green.

## Test plan

- [x] Smoke test `/tmp` — all 6 cases (including 3 previously-failing nesting variants).
- [x] `test_wam_target` regression — all green.
- [x] Full `test_wam_cpp_generator` — all green.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_