### PR TITLE
fix(wam-clojure): normalize empty atom constants

### DIFF
--- a/PR_WAM_CLOJURE_EMPTY_ATOM_NORMALIZATION.md
+++ b/PR_WAM_CLOJURE_EMPTY_ATOM_NORMALIZATION.md
@@ -1,0 +1,23 @@
+# PR Title
+
+fix(wam-clojure): normalize empty atom constants
+
+# PR Description
+
+## Summary
+
+- Normalizes WAM atom constant token `''` to empty atom text `""` in the Clojure WAM generator.
+- Applies the same normalization to compile-time atom seeds and switch-on-constant entries.
+- Updates the lowered emitter literal path so Prolog empty atoms are emitted as empty Clojure strings.
+- Adds runtime smoke coverage for `atomic_list_concat(L, o, foo), L = [f,'','']`.
+
+## Why
+
+The Clojure WAM target previously treated serialized Prolog empty atom tokens as the literal two-character atom text `''`. That broke cases where generated code needed to unify against actual empty atom segments, especially the deterministic `atomic_list_concat/3` split path added in the previous PR.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -983,6 +983,8 @@ emit_lowered_expr(_Instr, S, Expr) :-
 clj_lowered_literal(Value, Literal) :-
     (   number(Value)
     ->  format(atom(Literal), '~w', [Value])
+    ;   Value == ''
+    ->  Literal = '""'
     ;   format(atom(Literal), '~q', [Value])
     ).
 

--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -497,17 +497,25 @@ wam_lines_intern_seeds([Line|Rest], AtomSeeds, FunctorSeeds) :-
 
 switch_case_atom_values(CasesText, AtomSeeds) :-
     split_string(CasesText, " ", " ", RawCases),
-    findall(Const,
+    findall(AtomText,
             ( member(RawCase, RawCases),
               normalize_space(string(Case), RawCase),
-              split_string(Case, ":", "", [Const|_])
+              split_string(Case, ":", "", [Const|_]),
+              wam_atom_token_text(Const, AtomText)
             ),
             AtomSeeds).
 
-wam_op_intern_seeds("get_constant", [Const, _], [Const], []).
-wam_op_intern_seeds("put_constant", [Const, _], [Const], []).
-wam_op_intern_seeds("set_constant", [Const], [Const], []).
-wam_op_intern_seeds("unify_constant", [Const], [Const], []).
+wam_atom_token_text("''", "") :- !.
+wam_atom_token_text(Token, Token).
+
+wam_atom_token_literal(Token, Literal) :-
+    wam_atom_token_text(Token, AtomText),
+    clj_string_literal(AtomText, Literal).
+
+wam_op_intern_seeds("get_constant", [Const, _], [AtomText], []) :- wam_atom_token_text(Const, AtomText).
+wam_op_intern_seeds("put_constant", [Const, _], [AtomText], []) :- wam_atom_token_text(Const, AtomText).
+wam_op_intern_seeds("set_constant", [Const], [AtomText], []) :- wam_atom_token_text(Const, AtomText).
+wam_op_intern_seeds("unify_constant", [Const], [AtomText], []) :- wam_atom_token_text(Const, AtomText).
 wam_op_intern_seeds("put_structure", [Functor, _], [Functor], [Functor]).
 wam_op_intern_seeds("get_structure", [Functor, _], [Functor], [Functor]).
 wam_op_intern_seeds("put_list", [_], ["[|]/2"], ["[|]/2"]).
@@ -573,11 +581,11 @@ wam_op_to_clojure_literal("proceed", [], _, '{:op :proceed}').
 wam_op_to_clojure_literal("allocate", [], _, '{:op :allocate}').
 wam_op_to_clojure_literal("deallocate", [], _, '{:op :deallocate}').
 wam_op_to_clojure_literal("get_constant", [Const, Reg], _, Literal) :-
-    clj_string_literal(Const, ConstLit),
+    wam_atom_token_literal(Const, ConstLit),
     clj_string_literal(Reg, RegLit),
     format(atom(Literal), '{:op :get-constant :constant ~w :reg ~w}', [ConstLit, RegLit]).
 wam_op_to_clojure_literal("put_constant", [Const, Reg], _, Literal) :-
-    clj_string_literal(Const, ConstLit),
+    wam_atom_token_literal(Const, ConstLit),
     clj_string_literal(Reg, RegLit),
     format(atom(Literal), '{:op :put-constant :constant ~w :reg ~w}', [ConstLit, RegLit]).
 wam_op_to_clojure_literal("get_variable", [Var, Reg], _, Literal) :-
@@ -618,7 +626,7 @@ wam_op_to_clojure_literal("set_value", [Var], _, Literal) :-
     clj_string_literal(Var, VarLit),
     format(atom(Literal), '{:op :set-value :var ~w}', [VarLit]).
 wam_op_to_clojure_literal("set_constant", [Const], _, Literal) :-
-    clj_string_literal(Const, ConstLit),
+    wam_atom_token_literal(Const, ConstLit),
     format(atom(Literal), '{:op :set-constant :constant ~w}', [ConstLit]).
 wam_op_to_clojure_literal("unify_variable", [Var], _, Literal) :-
     clj_string_literal(Var, VarLit),
@@ -627,7 +635,7 @@ wam_op_to_clojure_literal("unify_value", [Var], _, Literal) :-
     clj_string_literal(Var, VarLit),
     format(atom(Literal), '{:op :unify-value :var ~w}', [VarLit]).
 wam_op_to_clojure_literal("unify_constant", [Const], _, Literal) :-
-    clj_string_literal(Const, ConstLit),
+    wam_atom_token_literal(Const, ConstLit),
     format(atom(Literal), '{:op :unify-constant :constant ~w}', [ConstLit]).
 wam_op_to_clojure_literal("switch_on_constant", [CasesText], _, Literal) :-
     parse_switch_cases(CasesText, CaseEntries),
@@ -649,7 +657,7 @@ parse_switch_cases(CasesText, CaseEntries) :-
 parse_switch_case(RawCase, Entry) :-
     normalize_space(string(Case), RawCase),
     (   split_string(Case, ":", "", [Const, Label])
-    ->  clj_string_literal(Const, ConstLit),
+    ->  wam_atom_token_literal(Const, ConstLit),
         clj_string_literal(Label, LabelLit),
         format(atom(Entry), '{:value ~w :label ~w}', [ConstLit, LabelLit])
     ;   clj_string_literal("malformed", ConstLit),

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -160,6 +160,7 @@
 :- dynamic user:wam_atomic_list_concat_2_guard/1.
 :- dynamic user:wam_atomic_list_concat_3_guard/1.
 :- dynamic user:wam_atomic_list_concat_3_split/0.
+:- dynamic user:wam_atomic_list_concat_3_split_empty_segments/0.
 :- dynamic user:wam_atomic_list_concat_3_split_mismatch/0.
 :- dynamic user:wam_atomic_list_concat_3_unbound_separator/0.
 :- dynamic user:wam_atomic_list_concat_mismatch/0.
@@ -375,6 +376,7 @@ user:wam_upcase_atom_unbound_source(_) :- user:wam_unbound_arg(A), upcase_atom(A
 user:wam_atomic_list_concat_2_guard(A) :- atomic_list_concat([f,o,o], A).
 user:wam_atomic_list_concat_3_guard(A) :- atomic_list_concat([f,o], o, A).
 user:wam_atomic_list_concat_3_split :- user:wam_unbound_arg(L), atomic_list_concat(L, b, abcbd), L = [a,c,d].
+user:wam_atomic_list_concat_3_split_empty_segments :- user:wam_unbound_arg(L), atomic_list_concat(L, o, foo), L = [f,'',''].
 user:wam_atomic_list_concat_3_split_mismatch :- user:wam_unbound_arg(L), atomic_list_concat(L, o, foo), L = [foo].
 user:wam_atomic_list_concat_3_unbound_separator :- user:wam_unbound_arg(L), user:wam_unbound_arg(S), atomic_list_concat(L, S, abc).
 user:wam_atomic_list_concat_mismatch :- atomic_list_concat([f,o], a, foo).
@@ -595,6 +597,7 @@ run_smoke :-
           user:wam_atomic_list_concat_2_guard/1,
           user:wam_atomic_list_concat_3_guard/1,
           user:wam_atomic_list_concat_3_split/0,
+          user:wam_atomic_list_concat_3_split_empty_segments/0,
           user:wam_atomic_list_concat_3_split_mismatch/0,
           user:wam_atomic_list_concat_3_unbound_separator/0,
           user:wam_atomic_list_concat_mismatch/0,
@@ -972,6 +975,7 @@ smoke_cases([
     case('wam_atomic_list_concat_2_guard/1', foo, "true"),
     case('wam_atomic_list_concat_3_guard/1', foo, "true"),
     case('wam_atomic_list_concat_3_split/0', no_args, "true"),
+    case('wam_atomic_list_concat_3_split_empty_segments/0', no_args, "true"),
     case('wam_atomic_list_concat_3_split_mismatch/0', no_args, "false"),
     case('wam_atomic_list_concat_3_unbound_separator/0', no_args, "false"),
     case('wam_atomic_list_concat_mismatch/0', no_args, "false"),
@@ -1356,6 +1360,7 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-atomic-list-concat-2-guard-1"),
     has(CoreCode, "defn lowered-wam-atomic-list-concat-3-guard-1"),
     has(CoreCode, "defn lowered-wam-atomic-list-concat-3-split-0"),
+    has(CoreCode, "defn lowered-wam-atomic-list-concat-3-split-empty-segments-0"),
     has(CoreCode, "defn lowered-wam-atomic-list-concat-3-split-mismatch-0"),
     has(CoreCode, "defn lowered-wam-string-to-atom-guard-2"),
     has(CoreCode, "defn lowered-wam-string-codes-guard-2"),


### PR DESCRIPTION
## Summary

- Normalizes WAM atom constant token `''` to empty atom text `""` in the Clojure WAM generator.
- Applies the same normalization to compile-time atom seeds and switch-on-constant entries.
- Updates the lowered emitter literal path so Prolog empty atoms are emitted as empty Clojure strings.
- Adds runtime smoke coverage for `atomic_list_concat(L, o, foo), L = [f,'','']`.

## Why

The Clojure WAM target previously treated serialized Prolog empty atom tokens as the literal two-character atom text `''`. That broke cases where generated code needed to unify against actual empty atom segments, especially the deterministic `atomic_list_concat/3` split path added in the previous PR.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
