### PR TITLE
feat(wam-cpp): on_compile_error policy for compile_predicates_for_project

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -2020,16 +2020,43 @@ compile_predicates_for_project(Predicates, Options, PredicatesCode) :-
     ->  Options1 = Options
     ;   Options1 = [foreign_pred_keys(ForeignKeys)|Options]
     ),
+    % on_compile_error policy: warn (default) | throw | skip.
+    %   warn  -- print "WAM C++: ... <Err>" to stderr and drop pred
+    %   throw -- re-throw, surfacing the error at the caller
+    %   skip  -- old silent-skip behavior (pre-#2293)
+    (   member(on_compile_error(Policy0), Options)
+    ->  Policy = Policy0
+    ;   Policy = warn
+    ),
     findall(Code, (
         member(PI, Predicates),
         catch(
             ( compile_predicate_to_wam(PI, [inline_bagof_setof(true)], WamCode),
               compile_wam_predicate_to_cpp(PI, WamCode, Options1, Code)
             ),
-            _Err,
-            fail)
+            Err,
+            handle_compile_error(Policy, PI, Err)
+        )
     ), Codes),
     atomic_list_concat(Codes, '\n\n', PredicatesCode).
+
+%% handle_compile_error(+Policy, +PI, +Err)
+%  Per-predicate compile failure handler. Logs / re-throws / drops
+%  based on Policy. Always fails after warn/skip so findall just
+%  omits the predicate''s Code entry; throw policy propagates the
+%  original exception so the caller can react.
+handle_compile_error(throw, PI, Err) :- !,
+    format(user_error,
+           "WAM C++: re-throwing compile error for ~w: ~w~n",
+           [PI, Err]),
+    throw(Err).
+handle_compile_error(skip, _PI, _Err) :- !, fail.
+handle_compile_error(_, PI, Err) :-
+    % default + explicit "warn"
+    format(user_error,
+           "WAM C++: failed to compile ~w: ~w~n",
+           [PI, Err]),
+    fail.
 
 foreign_pred_keys_from_options(Options, Keys) :-
     (   member(foreign_pred_keys(Keys0), Options)

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -8706,6 +8706,34 @@ iso_errors_temp_config_file(Path, Lines) :-
         forall(member(L, Lines), format(Out, '~w~n', [L])),
         close(Out)).
 
+% Unit tests for compile_predicates_for_project''s on_compile_error
+% diagnostic policy. The handler logs / re-throws / drops based on
+% Policy. Verified by calling handle_compile_error/3 directly and
+% inspecting the failure / exception path.
+
+test(compile_error_throw_policy_rethrows) :-
+    catch(
+        wam_cpp_target:handle_compile_error(throw, foo/1,
+                                            error(test_marker, _)),
+        Caught,
+        Caught = error(test_marker, _)
+    ),
+    assertion(nonvar(Caught)).
+
+test(compile_error_warn_policy_fails) :-
+    \+ wam_cpp_target:handle_compile_error(warn, foo/1,
+                                          error(test_marker, _)).
+
+test(compile_error_skip_policy_fails) :-
+    \+ wam_cpp_target:handle_compile_error(skip, foo/1,
+                                          error(test_marker, _)).
+
+test(compile_error_default_is_warn) :-
+    % Anything that isn''t throw/skip falls through to the warn
+    % handler. Using `unknown_policy` here exercises that branch.
+    \+ wam_cpp_target:handle_compile_error(unknown_policy, foo/1,
+                                          error(test_marker, _)).
+
 :- end_tests(wam_cpp_generator).
 
 % --------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Surfaces per-predicate compile failures that were previously silently dropped. Direct lesson from PR #2291: the findall nested-template bug threw `unsupported_template_arg/2` inside `compile_compound_template`, but the surrounding `catch(_, _, fail)` swallowed it, dropping the affected predicate from the project with no diagnostic. The user just saw a missing predicate at runtime.

## New option

`on_compile_error(Policy)` on `write_wam_cpp_project/3`:

| Policy | Behavior |
|---|---|
| `warn` (default) | Print `"WAM C++: failed to compile <PI>: <Err>"` to stderr and drop the predicate. Trades silence for visibility |
| `throw` | Print `"WAM C++: re-throwing compile error for <PI>: <Err>"` to stderr and re-throw. For callers that want fail-fast |
| `skip` | The old behavior. Silently drop the predicate. For callers that intentionally feed optional predicates |

The Policy only affects **exceptions** thrown from `compile_predicate_to_wam` / `compile_wam_predicate_to_cpp`. The existing "no clauses for ..." path in `compile_predicate_to_wam` still prints its own message and `fail`s (no exception thrown), so existing noisy "WAM target: no clauses" lines in test output are unchanged.

## Behavior change

Default behavior moves from silent skip to verbose warn. This means:
- ✅ Future compile-time bugs surface immediately as build warnings instead of confusing runtime failures.
- ⚠️ Callers that intentionally relied on silent skipping (passing optional predicates that might not exist) need to add `on_compile_error(skip)`.

## Tests

4 new plunit tests calling `handle_compile_error/3` directly:

- `throw` policy re-throws the original exception.
- `warn` policy fails (drops the predicate).
- `skip` policy fails silently.
- Unknown policy atom falls through to the warn handler (unrecognized policies don't silently skip).

Full `test_wam_cpp_generator` suite passes; `test_wam_target` unchanged and green.

## Test plan

- [x] Smoke test in `/tmp` — handler does the right thing for `throw` and `warn` policies.
- [x] `test_wam_target` regression — all green.
- [x] Full `test_wam_cpp_generator` suite (including the 4 new unit tests) — all green.

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_