### PR TITLE
feat(wam-cpp): AVL-balanced assoc + fix switch-dispatch off-by-one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,11 @@ packages-microsoft-prod.deb
 
 # Temporary directories
 tmp/
+# Test scratch dirs created by the WAM C++ e2e suite (setup_call_cleanup
+# normally removes them, but a long-running suite can leave one
+# visible mid-run).
+tests/tmp_cpp_*/
+tests/tmp_*/
 
 
 # Downloaded libraries (use setup scripts to install)

--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -556,15 +556,21 @@ static const int _wam_cpp_setup_register = []() {
            ;  throw(error(assertion_failed, G))
            )))
    ).
-% assoc/2 stdlib: unbalanced BST keyed by standard order. The empty
-% tree is the atom `t`; non-empty nodes are t(Key, Value, Left, Right).
-% Unbalanced keeps the asserted source tiny; can be upgraded to AVL
-% in a follow-up. Re-uses compare/3 (already in the runtime) for
+% assoc/2 stdlib: AVL tree keyed by standard order. The empty
+% tree is the atom `t`; non-empty nodes are
+% t(Key, Value, Balance, Left, Right) where Balance is one of:
+%   <   left subtree is one taller
+%   =   subtrees are equal height
+%   >   right subtree is one taller
+% This is the standard SWI library(assoc) AVL representation. Insert
+% tracks a height-change flag (same / grew) up the spine; once a
+% node would tip to imbalance, a single or double rotation restores
+% the invariant. Re-uses compare/3 (already in the runtime) for
 % standard-order key comparison.
 :- (   current_predicate(user:put_assoc/4)
    ->  true
    ;   assertz((user:empty_assoc(t))),
-       assertz((user:get_assoc(Key, t(K, V, L, R), Value) :-
+       assertz((user:get_assoc(Key, t(K, V, _, L, R), Value) :-
            compare(Order, Key, K),
            wam_cpp_get_assoc_(Order, Key, V, L, R, Value))),
        assertz((user:wam_cpp_get_assoc_(=, _, Value, _, _, Value))),
@@ -572,18 +578,100 @@ static const int _wam_cpp_setup_register = []() {
            get_assoc(Key, L, Value))),
        assertz((user:wam_cpp_get_assoc_(>, Key, _, _, R, Value) :-
            get_assoc(Key, R, Value))),
-       assertz((user:put_assoc(Key, t, Val, t(Key, Val, t, t)) :- !)),
-       assertz((user:put_assoc(Key, t(K, V, L, R), Val, NewTree) :-
+       % put_assoc/4: drop the height-change flag from the worker.
+       assertz((user:put_assoc(Key, Tree, Val, NewTree) :-
+           wam_cpp_put_assoc_recur(Key, Tree, Val, NewTree, _))),
+       % Insert into empty subtree — the new node grew the tree.
+       assertz((user:wam_cpp_put_assoc_recur(Key, t, Val,
+                                            t(Key, Val, =, t, t), grew))),
+       % Insert into a non-empty node — compare + dispatch.
+       assertz((user:wam_cpp_put_assoc_recur(Key, t(K, V, B, L, R), Val,
+                                            NewTree, Change) :-
            compare(Order, Key, K),
-           wam_cpp_put_assoc_(Order, Key, K, V, L, R, Val, NewTree))),
-       assertz((user:wam_cpp_put_assoc_(=, Key, _, _, L, R, Val,
-                                       t(Key, Val, L, R)))),
-       assertz((user:wam_cpp_put_assoc_(<, Key, K, V, L, R, Val,
-                                       t(K, V, NewL, R)) :-
-           put_assoc(Key, L, Val, NewL))),
-       assertz((user:wam_cpp_put_assoc_(>, Key, K, V, L, R, Val,
-                                       t(K, V, L, NewR)) :-
-           put_assoc(Key, R, Val, NewR))),
+           wam_cpp_put_assoc_dispatch(Order, Key, Val, K, V, B,
+                                      L, R, NewTree, Change))),
+       % =: replace value, balance preserved.
+       assertz((user:wam_cpp_put_assoc_dispatch(=, Key, Val, _, _, B,
+                                               L, R,
+                                               t(Key, Val, B, L, R),
+                                               same))),
+       % <: recurse into L, then ask wam_cpp_rebalance_left to decide
+       % whether the subtree got taller and whether to rotate.
+       assertz((user:wam_cpp_put_assoc_dispatch(<, Key, Val, K, V, B,
+                                               L, R, NewTree, Change) :-
+           wam_cpp_put_assoc_recur(Key, L, Val, L1, LChange),
+           wam_cpp_rebalance_left(LChange, B, K, V, L1, R,
+                                  NewTree, Change))),
+       % >: symmetric — recurse into R, then rebalance from the right.
+       assertz((user:wam_cpp_put_assoc_dispatch(>, Key, Val, K, V, B,
+                                               L, R, NewTree, Change) :-
+           wam_cpp_put_assoc_recur(Key, R, Val, R1, RChange),
+           wam_cpp_rebalance_right(RChange, B, K, V, L, R1,
+                                   NewTree, Change))),
+       % wam_cpp_rebalance_left(LChange, B, K, V, L, R, NewTree,
+       %                       Change)
+       % LChange=same — copy through.
+       assertz((user:wam_cpp_rebalance_left(same, B, K, V, L, R,
+                                           t(K, V, B, L, R), same))),
+       % LChange=grew, was right-heavy — now balanced, height same.
+       assertz((user:wam_cpp_rebalance_left(grew, >, K, V, L, R,
+                                           t(K, V, =, L, R), same))),
+       % LChange=grew, was balanced — now left-heavy, height grew.
+       assertz((user:wam_cpp_rebalance_left(grew, =, K, V, L, R,
+                                           t(K, V, <, L, R), grew))),
+       % LChange=grew, was left-heavy — rotate. Look at L''s balance.
+       assertz((user:wam_cpp_rebalance_left(grew, <, K, V, L, R,
+                                           NewTree, same) :-
+           wam_cpp_rotate_left_heavy(L, K, V, R, NewTree))),
+       % LL case — single right rotation. L''s left grew.
+       assertz((user:wam_cpp_rotate_left_heavy(t(LK, LV, <, LL, LR),
+                                              K, V, R,
+                                              t(LK, LV, =, LL,
+                                                t(K, V, =, LR, R))))),
+       % LR case — double rotation. L''s right grew. New balances
+       % depend on the inner node''s balance.
+       assertz((user:wam_cpp_rotate_left_heavy(
+                   t(LK, LV, >, LL, t(LRK, LRV, LRB, LRL, LRR)),
+                   K, V, R,
+                   t(LRK, LRV, =,
+                     t(LK, LV, NLB, LL, LRL),
+                     t(K,  V,  NRB, LRR, R))) :-
+           wam_cpp_lr_balance(LRB, NLB, NRB))),
+       % wam_cpp_rebalance_right(RChange, B, K, V, L, R, NewTree,
+       %                        Change) — mirror of left.
+       assertz((user:wam_cpp_rebalance_right(same, B, K, V, L, R,
+                                            t(K, V, B, L, R), same))),
+       assertz((user:wam_cpp_rebalance_right(grew, <, K, V, L, R,
+                                            t(K, V, =, L, R), same))),
+       assertz((user:wam_cpp_rebalance_right(grew, =, K, V, L, R,
+                                            t(K, V, >, L, R), grew))),
+       assertz((user:wam_cpp_rebalance_right(grew, >, K, V, L, R,
+                                            NewTree, same) :-
+           wam_cpp_rotate_right_heavy(L, K, V, R, NewTree))),
+       % RR case — single left rotation.
+       assertz((user:wam_cpp_rotate_right_heavy(L, K, V,
+                                               t(RK, RV, >, RL, RR),
+                                               t(RK, RV, =,
+                                                 t(K, V, =, L, RL),
+                                                 RR)))),
+       % RL case — double rotation. New balances depend on inner.
+       assertz((user:wam_cpp_rotate_right_heavy(
+                   L, K, V,
+                   t(RK, RV, <, t(RLK, RLV, RLB, RLL, RLR), RR),
+                   t(RLK, RLV, =,
+                     t(K,  V,  NLB, L,   RLL),
+                     t(RK, RV, NRB, RLR, RR))) :-
+           wam_cpp_rl_balance(RLB, NLB, NRB))),
+       % Balance-factor tables for the double-rotation cases:
+       %   LR rotation: the inner node (LR) had balance LRB; afterwards
+       %   the new left child gets NLB and the new right child gets NRB.
+       assertz((user:wam_cpp_lr_balance(<, =, >))),
+       assertz((user:wam_cpp_lr_balance(=, =, =))),
+       assertz((user:wam_cpp_lr_balance(>, <, =))),
+       %   RL rotation (mirror image):
+       assertz((user:wam_cpp_rl_balance(<, =, >))),
+       assertz((user:wam_cpp_rl_balance(=, =, =))),
+       assertz((user:wam_cpp_rl_balance(>, <, =))),
        assertz((user:list_to_assoc(List, Assoc) :-
            wam_cpp_list_to_assoc_(List, t, Assoc))),
        assertz((user:wam_cpp_list_to_assoc_([], A, A))),
@@ -591,7 +679,7 @@ static const int _wam_cpp_setup_register = []() {
            put_assoc(K, A0, V, A1),
            wam_cpp_list_to_assoc_(T, A1, A))),
        assertz((user:assoc_to_list(t, []))),
-       assertz((user:assoc_to_list(t(K, V, L, R), Pairs) :-
+       assertz((user:assoc_to_list(t(K, V, _, L, R), Pairs) :-
            assoc_to_list(L, LP),
            assoc_to_list(R, RP),
            append(LP, [K-V|RP], Pairs))),
@@ -668,7 +756,14 @@ stdlib_feature_predicates(assoc, [
     user:get_assoc/3,
     user:wam_cpp_get_assoc_/6,
     user:put_assoc/4,
-    user:wam_cpp_put_assoc_/8,
+    user:wam_cpp_put_assoc_recur/5,
+    user:wam_cpp_put_assoc_dispatch/10,
+    user:wam_cpp_rebalance_left/8,
+    user:wam_cpp_rebalance_right/8,
+    user:wam_cpp_rotate_left_heavy/5,
+    user:wam_cpp_rotate_right_heavy/5,
+    user:wam_cpp_lr_balance/3,
+    user:wam_cpp_rl_balance/3,
     user:list_to_assoc/2,
     user:wam_cpp_list_to_assoc_/3,
     user:assoc_to_list/2,
@@ -1722,11 +1817,14 @@ instr_to_setup_line(switch_on_constant(Entries), Labels, Line) :- !,
            '    vm.instrs.push_back(Instruction::SwitchOnConstant({~w}));',
            [EntriesCpp]).
 instr_to_setup_line(switch_on_constant_a2(Entries), Labels, Line) :- !,
-    % Treated as a no-op for now (interpreter falls through to the
-    % try_me_else chain on A2 dispatch). Emit as a comment.
+    % Treated as a runtime no-op for now (interpreter falls through to
+    % the try_me_else chain on A2 dispatch). Emit a real Nop push_back
+    % so vm.instrs.size() matches the PC count used for label resolution
+    % — otherwise every label after this point would be off-by-one.
     parse_switch_entries(Entries, Labels, _EntriesCpp),
     format(atom(Line),
-           '    // switch_on_constant_a2 ~w (no-op; falls through)', [Entries]).
+           '    vm.instrs.push_back(Instruction::Nop()); // switch_on_constant_a2 ~w',
+           [Entries]).
 instr_to_setup_line(switch_on_structure(Entries), Labels, Line) :- !,
     parse_switch_struct_entries(Entries, Labels, EntriesCpp),
     format(atom(Line),
@@ -2208,7 +2306,8 @@ struct Instruction {
         CatchReturn, NegationReturn, FindallCollect, ConjReturn, DisjAlt,
         IfThenCommit, IfThenElse, AggregateNextGroup, DynamicNextClause,
         SubAtomNext, BodyNext, RetractNext, OutputCaptureReturn,
-        CurrentPredNext
+        CurrentPredNext,
+        Nop
     };
     // Sentinel pc values for switch-table entries that should not jump.
     static constexpr std::size_t SWITCH_DEFAULT = static_cast<std::size_t>(-1);
@@ -2336,6 +2435,8 @@ struct Instruction {
         { Instruction i; i.op = Op::OutputCaptureReturn; return i; }
     static Instruction CurrentPredNext()
         { Instruction i; i.op = Op::CurrentPredNext; return i; }
+    static Instruction Nop()
+        { Instruction i; i.op = Op::Nop; return i; }
 };
 
 struct TrailEntry {
@@ -6907,6 +7008,13 @@ bool WamState::step(const Instruction& instr) {
         case Instruction::Op::Jump:
             pc = instr.target;
             return true;
+        case Instruction::Op::Nop:
+            // Placeholder emitted for WAM-asm pseudo-instructions that
+            // currently have no runtime semantics (e.g.
+            // switch_on_constant_a2). Counted in PC accounting so labels
+            // resolve correctly; behaves as a fall-through.
+            pc += 1;
+            return true;
 
         // ---- Choice points -----------------------------------------
         case Instruction::Op::TryMeElse: {
@@ -7076,7 +7184,14 @@ bool WamState::step(const Instruction& instr) {
 
         // ---- Indexing ----------------------------------------------
         case Instruction::Op::SwitchOnConstant: {
-            // Dispatch on A1''s atom/integer value.
+            // Dispatch on A1''s atom/integer value. When the table has
+            // multiple entries for the same key (e.g. several clauses
+            // sharing A1=grew), only the first is the jump target; the
+            // rest are reached via the RetryMeElse chain at that label.
+            // Setting indexed_entry tells the receiving RetryMeElse to
+            // synthesize a fresh CP at this predicate level (otherwise
+            // it would mutate an outer level''s CP). Symmetric to
+            // SwitchOnTerm.
             CellPtr ac = get_cell("A1");
             const Value& a = *ac;
             if (a.is_unbound()) { pc += 1; return true; }
@@ -7088,6 +7203,7 @@ bool WamState::step(const Instruction& instr) {
                 if (kv.first == a) {
                     if (kv.second == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
                     if (kv.second == Instruction::SWITCH_NONE)    return false;
+                    indexed_entry = true;
                     pc = kv.second; return true;
                 }
             }
@@ -7102,6 +7218,7 @@ bool WamState::step(const Instruction& instr) {
                 if (kv.first == a.s) {
                     if (kv.second == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
                     if (kv.second == Instruction::SWITCH_NONE)    return false;
+                    indexed_entry = true;
                     pc = kv.second; return true;
                 }
             }

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -238,6 +238,10 @@
 :- dynamic user:wam_cpp_test_assoc_keys/0.
 :- dynamic user:wam_cpp_test_assoc_values/0.
 :- dynamic user:wam_cpp_test_assoc_compound_keys/0.
+:- dynamic user:wam_cpp_assoc_depth/2.
+:- dynamic user:wam_cpp_test_assoc_avl_balance_sorted/0.
+:- dynamic user:wam_cpp_test_assoc_avl_balance_descending/0.
+:- dynamic user:wam_cpp_test_assoc_avl_balance_zigzag/0.
 :- dynamic user:wam_cpp_test_get_time_positive/0.
 :- dynamic user:wam_cpp_test_stamp_utc/0.
 :- dynamic user:wam_cpp_test_stamp_subsec/0.
@@ -561,6 +565,85 @@ user:wam_cpp_test_assoc_compound_keys :-
     put_assoc(pt(3, 4), A1, south, A2),
     get_assoc(pt(1, 2), A2, north),
     get_assoc(pt(3, 4), A2, south).
+% AVL balance: insert keys in ascending order — a plain BST would be
+% a 16-deep chain, but the AVL must stay roughly log2(16) ≈ 4-5 deep.
+% Tree-depth probe uses the t(K,V,B,L,R) node shape.
+user:wam_cpp_assoc_depth(t, 0).
+user:wam_cpp_assoc_depth(t(_, _, _, L, R), D) :-
+    wam_cpp_assoc_depth(L, DL),
+    wam_cpp_assoc_depth(R, DR),
+    ( DL >= DR -> D is DL + 1 ; D is DR + 1 ).
+user:wam_cpp_test_assoc_avl_balance_sorted :-
+    empty_assoc(A0),
+    put_assoc(1,  A0,  v1,  A1),
+    put_assoc(2,  A1,  v2,  A2),
+    put_assoc(3,  A2,  v3,  A3),
+    put_assoc(4,  A3,  v4,  A4),
+    put_assoc(5,  A4,  v5,  A5),
+    put_assoc(6,  A5,  v6,  A6),
+    put_assoc(7,  A6,  v7,  A7),
+    put_assoc(8,  A7,  v8,  A8),
+    put_assoc(9,  A8,  v9,  A9),
+    put_assoc(10, A9,  v10, A10),
+    put_assoc(11, A10, v11, A11),
+    put_assoc(12, A11, v12, A12),
+    put_assoc(13, A12, v13, A13),
+    put_assoc(14, A13, v14, A14),
+    put_assoc(15, A14, v15, A15),
+    put_assoc(16, A15, v16, A16),
+    wam_cpp_assoc_depth(A16, D),
+    D =< 6,
+    get_assoc(1,  A16, v1),
+    get_assoc(8,  A16, v8),
+    get_assoc(16, A16, v16),
+    \+ get_assoc(0,  A16, _),
+    \+ get_assoc(17, A16, _).
+user:wam_cpp_test_assoc_avl_balance_descending :-
+    % Mirror case — keys descending forces left-side rotations.
+    empty_assoc(A0),
+    put_assoc(16, A0,  v16, A1),
+    put_assoc(15, A1,  v15, A2),
+    put_assoc(14, A2,  v14, A3),
+    put_assoc(13, A3,  v13, A4),
+    put_assoc(12, A4,  v12, A5),
+    put_assoc(11, A5,  v11, A6),
+    put_assoc(10, A6,  v10, A7),
+    put_assoc(9,  A7,  v9,  A8),
+    put_assoc(8,  A8,  v8,  A9),
+    put_assoc(7,  A9,  v7,  A10),
+    put_assoc(6,  A10, v6,  A11),
+    put_assoc(5,  A11, v5,  A12),
+    put_assoc(4,  A12, v4,  A13),
+    put_assoc(3,  A13, v3,  A14),
+    put_assoc(2,  A14, v2,  A15),
+    put_assoc(1,  A15, v1,  A16),
+    wam_cpp_assoc_depth(A16, D),
+    D =< 6,
+    get_assoc(1,  A16, v1),
+    get_assoc(16, A16, v16).
+user:wam_cpp_test_assoc_avl_balance_zigzag :-
+    % Insert in zigzag order — exercises both LR and RL rotations.
+    empty_assoc(A0),
+    put_assoc(8,  A0,  v8,  A1),
+    put_assoc(4,  A1,  v4,  A2),
+    put_assoc(12, A2,  v12, A3),
+    put_assoc(6,  A3,  v6,  A4),
+    put_assoc(10, A4,  v10, A5),
+    put_assoc(2,  A5,  v2,  A6),
+    put_assoc(14, A6,  v14, A7),
+    put_assoc(5,  A7,  v5,  A8),
+    put_assoc(7,  A8,  v7,  A9),
+    put_assoc(9,  A9,  v9,  A10),
+    put_assoc(11, A10, v11, A11),
+    put_assoc(1,  A11, v1,  A12),
+    put_assoc(3,  A12, v3,  A13),
+    put_assoc(13, A13, v13, A14),
+    put_assoc(15, A14, v15, A15),
+    wam_cpp_assoc_depth(A15, D),
+    D =< 5,
+    get_assoc(7,  A15, v7),
+    get_assoc(15, A15, v15),
+    assoc_to_keys(A15, [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]).
 % Date/time: get_time/1 (Float seconds since epoch),
 % stamp_date_time/3 (decompose + TZ), date_time_stamp/2 (compose),
 % format_time/3 (strftime-style atom output). Tests use the canonical
@@ -2824,6 +2907,35 @@ user:wam_cpp_mixed(foo(x)).
 user:wam_cpp_listy([]).
 user:wam_cpp_listy([_|_]).
 
+% A2-dispatch fixture — multi-clause predicate where the dispatch
+% constant lives in A2, not A1. The compiler emits
+% switch_on_constant_a2 (a runtime no-op that historically was
+% emitted as a C++ comment instead of a real push_back, leaving
+% downstream labels off-by-one). The downstream predicate
+% wam_cpp_after_a2/0 catches that regression: if its label PC is
+% off, calling it crashes or jumps mid-predicate.
+:- dynamic user:wam_cpp_a2dispatch/4.
+:- dynamic user:wam_cpp_after_a2/0.
+:- dynamic user:wam_cpp_test_a2_all_clauses/0.
+:- dynamic user:wam_cpp_test_a2_downstream_label/0.
+
+user:wam_cpp_a2dispatch(B, same, K, t(same, B, K)).
+user:wam_cpp_a2dispatch(=, grew, K, t(grew_eq, K)).
+user:wam_cpp_a2dispatch(<, grew, K, t(grew_lt, K)).
+user:wam_cpp_a2dispatch(>, grew, K, t(grew_gt, K)).
+
+user:wam_cpp_after_a2 :- true.
+
+user:wam_cpp_test_a2_all_clauses :-
+    user:wam_cpp_a2dispatch(=, same, k1, T1), T1 = t(same, =, k1),
+    user:wam_cpp_a2dispatch(=, grew, k2, T2), T2 = t(grew_eq, k2),
+    user:wam_cpp_a2dispatch(<, grew, k3, T3), T3 = t(grew_lt, k3),
+    user:wam_cpp_a2dispatch(>, grew, k4, T4), T4 = t(grew_gt, k4).
+
+user:wam_cpp_test_a2_downstream_label :-
+    user:wam_cpp_a2dispatch(=, same, k, _),
+    user:wam_cpp_after_a2.
+
 user:wam_cpp_test_write :- write(hello), nl.
 % Y-reg isolation: both helpers use Y1/Y2 internally. Caller relies on
 % preserved Y1 across the two calls.
@@ -3820,18 +3932,25 @@ test(cpp_e2e_assoc_library, [condition(cpp_compiler_available)]) :-
                                user:wam_cpp_test_assoc_list_sorted/0,
                                user:wam_cpp_test_assoc_keys/0,
                                user:wam_cpp_test_assoc_values/0,
-                               user:wam_cpp_test_assoc_compound_keys/0],
+                               user:wam_cpp_test_assoc_compound_keys/0,
+                               user:wam_cpp_assoc_depth/2,
+                               user:wam_cpp_test_assoc_avl_balance_sorted/0,
+                               user:wam_cpp_test_assoc_avl_balance_descending/0,
+                               user:wam_cpp_test_assoc_avl_balance_zigzag/0],
                               [emit_main(true), include_stdlib(assoc)],
                               TmpDir),
         ( build_e2e_binary(TmpDir, BinPath),
-          run_query(BinPath, 'wam_cpp_test_assoc_empty/0',         [], true),
-          run_query(BinPath, 'wam_cpp_test_assoc_put_get/0',       [], true),
-          run_query(BinPath, 'wam_cpp_test_assoc_missing/0',       [], true),
-          run_query(BinPath, 'wam_cpp_test_assoc_overwrite/0',     [], true),
-          run_query(BinPath, 'wam_cpp_test_assoc_list_sorted/0',   [], true),
-          run_query(BinPath, 'wam_cpp_test_assoc_keys/0',          [], true),
-          run_query(BinPath, 'wam_cpp_test_assoc_values/0',        [], true),
-          run_query(BinPath, 'wam_cpp_test_assoc_compound_keys/0', [], true)
+          run_query(BinPath, 'wam_cpp_test_assoc_empty/0',                  [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_put_get/0',                [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_missing/0',                [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_overwrite/0',              [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_list_sorted/0',            [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_keys/0',                   [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_values/0',                 [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_compound_keys/0',          [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_avl_balance_sorted/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_avl_balance_descending/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_avl_balance_zigzag/0',     [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).
@@ -8600,6 +8719,30 @@ test(cpp_e2e_switch_on_term, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_listy/1', ['[]'],       true),
           run_query(BinPath, 'wam_cpp_listy/1', ['[a,b]'],    true),
           run_query(BinPath, 'wam_cpp_listy/1', [foo],        false)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% Regression for the switch_on_constant_a2 off-by-one bug. The WAM-asm
+% layer emits switch_on_constant_a2 at the head of any multi-clause
+% predicate that dispatches on A2 (rather than A1). Before the fix the
+% C++ emitter rendered it as a /comment/, but the PC-counter still
+% advanced — so every label after the first such predicate pointed
+% one instruction past its real entry. The downstream check
+% (wam_cpp_test_a2_downstream_label) catches that: if
+% wam_cpp_after_a2's label is wrong, the call lands inside the prior
+% predicate's frame and either crashes or returns false.
+test(cpp_e2e_switch_on_constant_a2, [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_swa2', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_a2dispatch/4,
+                               user:wam_cpp_after_a2/0,
+                               user:wam_cpp_test_a2_all_clauses/0,
+                               user:wam_cpp_test_a2_downstream_label/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_a2_all_clauses/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_a2_downstream_label/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Two related compiler/runtime fixes that together unlock an AVL upgrade for the assoc stdlib.

### 1. `switch_on_constant_a2` was emitted as a C++ comment

The WAM-asm layer emits `switch_on_constant_a2` at the head of any multi-clause predicate that dispatches on A2 (not A1). The C++ emitter rendered it as a `// ...` source comment, but the PC counter still advanced past it — so every label after the first such predicate pointed one instruction past its real entry. Multi-clause predicates with A2-dispatched heads worked by luck, but downstream predicates' labels were silently wrong.

Fix: a new `Op::Nop` opcode (a fall-through that just advances PC), and emit `Instruction::Nop()` `push_back` for `switch_on_constant_a2` so `vm.instrs.size()` matches the PC count used to resolve labels.

### 2. `SwitchOnConstant` / `SwitchOnStructure` didn't set `indexed_entry`

When the constant table has multiple entries sharing a key (e.g. several clauses with `A1 = grew`), only the first is the jump target; the rest are reached via the `RetryMeElse` chain at that label. Without `indexed_entry`, `RetryMeElse` mutated an outer level's choice point instead of synthesizing a fresh one for this dispatch — overwriting the caller's backtrack handle with a pointer into the dispatched predicate's body.

Fix mirrors what `SwitchOnTerm` already does: set `indexed_entry = true` on a successful indexed jump, so `RetryMeElse` synthesizes a CP at the right level.

### 3. AVL assoc

With those in place, the previous unbalanced-BST assoc stdlib is replaced with a full AVL implementation following the standard SWI `library(assoc)` layout: `t(Key, Value, Balance, Left, Right)` where `Balance ∈ {<, =, >}`. Insert tracks a `same`/`grew` height-change flag up the spine and falls into single (LL/RR) or double (LR/RL) rotations when a node would tip beyond balance.

Cross-checked against `library(assoc)` on ascending, descending, and zigzag inputs — all in-order traversals match.

### Regression tests

- `cpp_e2e_switch_on_constant_a2` — 4-clause A2-dispatched predicate plus a downstream predicate whose label was previously off-by-one.
- AVL balance assertions inside `cpp_e2e_assoc_library`: insert 16 keys in ascending, descending, and zigzag order; check that the resulting tree depth is bounded (≤ 6 instead of 16).

Existing assoc tests are agnostic about the tree representation (they only exercise `put`/`get`/`list` behaviour), so they continue to pass.

## Test plan

- [x] `cpp_e2e_switch_on_constant_a2` (new regression for fix #1)
- [x] `cpp_e2e_assoc_library` with three new AVL-balance assertions
- [x] All `switch_on_*` / `indexing_backtrack` / `sort*` tests (verify fix #2 doesn't regress single-key dispatch)
- [x] Sampled ~30 indexing-sensitive tests: `lists_extra`, `dcg`, `msort`, `keysort`, `include`/`exclude`/`partition`, `foldl`, `pairs_kv`, `member`/`length`/`append`/`reverse`/`last`/`nth0`, `maplist*`, `findall*`, `bagof_setof`, `fact`, `clause_runtime`, `recursive_arithmetic`, `retract*`, `assertz_query` — all pass
- [x] 139 of the 365 full-suite tests ran in a single timed pass — 0 failures, 0 errors
- [x] Cross-check our AVL output vs `library(assoc)` on asc/desc/zigzag inputs — in-order lists match

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_