### PR TITLE
feat(wam-cpp): A2 structure + term indexing

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -1831,10 +1831,20 @@ instr_to_setup_line(switch_on_structure(Entries), Labels, Line) :- !,
     format(atom(Line),
            '    vm.instrs.push_back(Instruction::SwitchOnStructure({~w}));',
            [EntriesCpp]).
+instr_to_setup_line(switch_on_structure_a2(Entries), Labels, Line) :- !,
+    parse_switch_struct_entries(Entries, Labels, EntriesCpp),
+    format(atom(Line),
+           '    vm.instrs.push_back(Instruction::SwitchOnStructureA2({~w}));',
+           [EntriesCpp]).
 instr_to_setup_line(switch_on_term(Tokens), Labels, Line) :- !,
     parse_switch_term(Tokens, Labels, ConstsCpp, StructsCpp, ListPC),
     format(atom(Line),
            '    vm.instrs.push_back(Instruction::SwitchOnTerm({~w}, {~w}, ~w));',
+           [ConstsCpp, StructsCpp, ListPC]).
+instr_to_setup_line(switch_on_term_a2(Tokens), Labels, Line) :- !,
+    parse_switch_term(Tokens, Labels, ConstsCpp, StructsCpp, ListPC),
+    format(atom(Line),
+           '    vm.instrs.push_back(Instruction::SwitchOnTermA2({~w}, {~w}, ~w));',
            [ConstsCpp, StructsCpp, ListPC]).
 instr_to_setup_line(catch_return, _Labels, Line) :- !,
     Line = '    vm.instrs.push_back(Instruction::CatchReturn());'.
@@ -2303,7 +2313,9 @@ struct Instruction {
         BuiltinCall, CallForeign,
         TryMeElse, RetryMeElse, TrustMe, Jump, CutIte,
         BeginAggregate, EndAggregate,
-        SwitchOnConstant, SwitchOnConstantA2, SwitchOnStructure, SwitchOnTerm,
+        SwitchOnConstant, SwitchOnConstantA2,
+        SwitchOnStructure, SwitchOnStructureA2,
+        SwitchOnTerm, SwitchOnTermA2,
         CatchReturn, NegationReturn, FindallCollect, ConjReturn, DisjAlt,
         IfThenCommit, IfThenElse, AggregateNextGroup, DynamicNextClause,
         SubAtomNext, BodyNext, RetractNext, OutputCaptureReturn,
@@ -2402,10 +2414,20 @@ struct Instruction {
         { Instruction i; i.op = Op::SwitchOnConstantA2; i.const_table = std::move(table); return i; }
     static Instruction SwitchOnStructure(std::vector<std::pair<std::string, std::size_t>> table)
         { Instruction i; i.op = Op::SwitchOnStructure; i.struct_table = std::move(table); return i; }
+    static Instruction SwitchOnStructureA2(std::vector<std::pair<std::string, std::size_t>> table)
+        { Instruction i; i.op = Op::SwitchOnStructureA2; i.struct_table = std::move(table); return i; }
     static Instruction SwitchOnTerm(std::vector<std::pair<Value, std::size_t>> consts,
                                     std::vector<std::pair<std::string, std::size_t>> structs,
                                     std::size_t list_pc)
         { Instruction i; i.op = Op::SwitchOnTerm;
+          i.const_table = std::move(consts);
+          i.struct_table = std::move(structs);
+          i.target = list_pc;
+          return i; }
+    static Instruction SwitchOnTermA2(std::vector<std::pair<Value, std::size_t>> consts,
+                                      std::vector<std::pair<std::string, std::size_t>> structs,
+                                      std::size_t list_pc)
+        { Instruction i; i.op = Op::SwitchOnTermA2;
           i.const_table = std::move(consts);
           i.struct_table = std::move(structs);
           i.target = list_pc;
@@ -7249,6 +7271,22 @@ bool WamState::step(const Instruction& instr) {
             }
             return false;
         }
+        case Instruction::Op::SwitchOnStructureA2: {
+            // A2 mirror of SwitchOnStructure.
+            CellPtr ac = get_cell("A2");
+            const Value& a = *ac;
+            if (a.is_unbound()) { pc += 1; return true; }
+            if (a.tag != Value::Tag::Compound) { pc += 1; return true; }
+            for (auto& kv : instr.struct_table) {
+                if (kv.first == a.s) {
+                    if (kv.second == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
+                    if (kv.second == Instruction::SWITCH_NONE)    return false;
+                    indexed_entry = true;
+                    pc = kv.second; return true;
+                }
+            }
+            return false;
+        }
         case Instruction::Op::SwitchOnTerm: {
             // Direct-jump branches (pc = target) bypass the entry
             // TryMeElse of the clause chain, so we flag them via
@@ -7257,6 +7295,42 @@ bool WamState::step(const Instruction& instr) {
             // current predicate level gets its own backtrack handle
             // even when an outer level''s CP is on the stack.
             CellPtr ac = get_cell("A1");
+            const Value& a = *ac;
+            if (a.is_unbound()) { pc += 1; return true; }
+            if (a.tag == Value::Tag::Atom || a.tag == Value::Tag::Integer
+                || a.tag == Value::Tag::Float) {
+                for (auto& kv : instr.const_table) {
+                    if (kv.first == a) {
+                        if (kv.second == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
+                        if (kv.second == Instruction::SWITCH_NONE)    return false;
+                        indexed_entry = true;
+                        pc = kv.second; return true;
+                    }
+                }
+                return false;
+            }
+            if (a.tag == Value::Tag::Compound) {
+                if (a.s == "[|]/2") {
+                    if (instr.target == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
+                    if (instr.target == Instruction::SWITCH_NONE)    return false;
+                    indexed_entry = true;
+                    pc = instr.target; return true;
+                }
+                for (auto& kv : instr.struct_table) {
+                    if (kv.first == a.s) {
+                        if (kv.second == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
+                        if (kv.second == Instruction::SWITCH_NONE)    return false;
+                        indexed_entry = true;
+                        pc = kv.second; return true;
+                    }
+                }
+                return false;
+            }
+            pc += 1; return true;
+        }
+        case Instruction::Op::SwitchOnTermA2: {
+            // A2 mirror of SwitchOnTerm.
+            CellPtr ac = get_cell("A2");
             const Value& a = *ac;
             if (a.is_unbound()) { pc += 1; return true; }
             if (a.tag == Value::Tag::Atom || a.tag == Value::Tag::Integer

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -244,15 +244,32 @@ format_switch_on_term(ConstEntries, StructEntries, ListLabel, IndexCode) :-
 
 %% build_second_arg_index(+Pred, +Arity, +Clauses, -IndexCode)
 %  When first-arg indexing fails (e.g., all variable first args),
-%  try indexing on the second argument instead.
+%  try indexing on the second argument instead. Mirrors the A1
+%  decision: all atomic → switch_on_constant_a2; all compound →
+%  switch_on_structure_a2; mixed atomic/compound → switch_on_term_a2.
+%  Any variable A2 disqualifies indexing entirely.
 build_second_arg_index(Pred, Arity, Clauses, IndexCode) :-
     classify_second_args(Clauses, Types),
     \+ member(variable, Types),
-    forall(member(T, Types), T = constant),
-    build_constant_index_on(Clauses, 2, 1, Pred, Arity, Entries),
-    Entries \= [],
-    format_index_entries(Entries, EntriesStr),
-    format(string(IndexCode), "    switch_on_constant_a2 ~w", [EntriesStr]).
+    (   forall(member(T, Types), T = constant)
+    ->  build_constant_index_on(Clauses, 2, 1, Pred, Arity, Entries),
+        Entries \= [],
+        format_index_entries(Entries, EntriesStr),
+        format(string(IndexCode), "    switch_on_constant_a2 ~w", [EntriesStr])
+    ;   forall(member(T, Types), T = structure),
+        \+ second_args_contain_list(Clauses)
+    ->  build_structure_index_on(Clauses, 2, 1, Pred, Arity, Entries),
+        Entries \= [],
+        format_index_entries(Entries, EntriesStr),
+        format(string(IndexCode), "    switch_on_structure_a2 ~w", [EntriesStr])
+    ;   % Mixed atomic/compound (possibly including lists) — emit
+        % switch_on_term_a2 with type-based dispatch, same shape as
+        % the A1 switch_on_term.
+        build_term_index_on(Clauses, 2, 1, Pred, Arity, Types,
+                            ConstEntries, StructEntries, ListLabel),
+        format_switch_on_term_a2(ConstEntries, StructEntries, ListLabel,
+                                 IndexCode)
+    ).
 
 classify_second_args([], []).
 classify_second_args([Head-_|Rest], [Type|RestTypes]) :-
@@ -260,11 +277,76 @@ classify_second_args([Head-_|Rest], [Type|RestTypes]) :-
     (   length(Args, L), L >= 2, nth1(2, Args, SecondArg)
     ->  (   var(SecondArg) -> Type = variable
         ;   atomic(SecondArg) -> Type = constant
+        ;   is_list_term(SecondArg) -> Type = structure
+        ;   compound(SecondArg) -> Type = structure
         ;   Type = variable
         )
     ;   Type = variable
     ),
     classify_second_args(Rest, RestTypes).
+
+second_args_contain_list([Head-_|_]) :-
+    Head =.. [_|Args],
+    nth1(2, Args, SecondArg),
+    is_list_term(SecondArg), !.
+second_args_contain_list([_|Rest]) :-
+    second_args_contain_list(Rest).
+
+build_structure_index_on([], _, _, _, _, []).
+build_structure_index_on([Head-_|Rest], ArgPos, I, Pred, Arity,
+                         [FN-Label|RestEntries]) :-
+    Head =.. [_|Args],
+    nth1(ArgPos, Args, ArgVal),
+    ArgVal =.. [F|SubArgs],
+    length(SubArgs, SArity),
+    format(atom(FN), "~w/~w", [F, SArity]),
+    (   I == 1 -> Label = default
+    ;   format(atom(Label), "L_~w_~w_~w", [Pred, Arity, I])
+    ),
+    NextI is I + 1,
+    build_structure_index_on(Rest, ArgPos, NextI, Pred, Arity, RestEntries).
+
+build_term_index_on([], _, _, _, _, _, [], [], none).
+build_term_index_on([Head-_|Rest], ArgPos, I, Pred, Arity,
+                    [Type|RestTypes],
+                    ConstEntries, StructEntries, ListLabel) :-
+    Head =.. [_|Args],
+    nth1(ArgPos, Args, ArgVal),
+    (   I == 1 -> Label = default
+    ;   format(atom(Label), "L_~w_~w_~w", [Pred, Arity, I])
+    ),
+    NextI is I + 1,
+    build_term_index_on(Rest, ArgPos, NextI, Pred, Arity, RestTypes,
+                        RestConst, RestStruct, RestListLabel),
+    (   Type = constant
+    ->  ConstEntries = [ArgVal-Label|RestConst],
+        StructEntries = RestStruct,
+        ListLabel = RestListLabel
+    ;   Type = structure,
+        is_list_term(ArgVal)
+    ->  ConstEntries = RestConst,
+        StructEntries = RestStruct,
+        ListLabel = Label
+    ;   Type = structure
+    ->  ArgVal =.. [F|SubArgs],
+        length(SubArgs, SArity),
+        format(atom(FN), "~w/~w", [F, SArity]),
+        ConstEntries = RestConst,
+        StructEntries = [FN-Label|RestStruct],
+        ListLabel = RestListLabel
+    ;   ConstEntries = RestConst,
+        StructEntries = RestStruct,
+        ListLabel = RestListLabel
+    ).
+
+format_switch_on_term_a2(ConstEntries, StructEntries, ListLabel, IndexCode) :-
+    length(ConstEntries, CLen),
+    length(StructEntries, SLen),
+    format_index_entries(ConstEntries, CStr),
+    format_index_entries(StructEntries, SStr),
+    format(string(IndexCode),
+           "    switch_on_term_a2 ~w ~w ~w ~w ~w",
+           [CLen, CStr, SLen, SStr, ListLabel]).
 
 build_constant_index_on([], _, _, _, _, []).
 build_constant_index_on([Head-_|Rest], ArgPos, I, Pred, Arity, [Val-Label|RestEntries]) :-

--- a/src/unifyweaver/targets/wam_text_parser.pl
+++ b/src/unifyweaver/targets/wam_text_parser.pl
@@ -182,4 +182,6 @@ wam_recognise_instruction(["end_aggregate", R],        end_aggregate(R)).
 wam_recognise_instruction(["switch_on_constant"     | Es], switch_on_constant(Es)).
 wam_recognise_instruction(["switch_on_constant_a2"  | Es], switch_on_constant_a2(Es)).
 wam_recognise_instruction(["switch_on_structure"    | Es], switch_on_structure(Es)).
+wam_recognise_instruction(["switch_on_structure_a2" | Es], switch_on_structure_a2(Es)).
 wam_recognise_instruction(["switch_on_term"         | Ts], switch_on_term(Ts)).
+wam_recognise_instruction(["switch_on_term_a2"      | Ts], switch_on_term_a2(Ts)).

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -2969,6 +2969,57 @@ user:wam_cpp_test_a2_shared_key_backtracks :-
     findall(T, wam_cpp_a2tag(_, T, red), L),
     L = [error, fatal].
 
+% A2 = all-compound (different functors). Exercises switch_on_structure_a2.
+% A1 is variable in every clause, so first-arg indexing is skipped.
+:- dynamic user:wam_cpp_a2struct/2.
+:- dynamic user:wam_cpp_test_a2_structure_direct/0.
+:- dynamic user:wam_cpp_test_a2_structure_miss/0.
+:- dynamic user:wam_cpp_test_a2_structure_unbound/0.
+
+user:wam_cpp_a2struct(_, foo(red)).
+user:wam_cpp_a2struct(_, bar(green, leaf)).
+user:wam_cpp_a2struct(_, baz(blue, 1, ok)).
+
+user:wam_cpp_test_a2_structure_direct :-
+    wam_cpp_a2struct(any, foo(red)),
+    wam_cpp_a2struct(any, bar(green, leaf)),
+    wam_cpp_a2struct(any, baz(blue, 1, ok)).
+user:wam_cpp_test_a2_structure_miss :-
+    % qux/1 is not in the table; bound A2 with no functor match
+    % fails fast at the switch.
+    \+ wam_cpp_a2struct(any, qux(1)),
+    % Wrong arity for foo also fails (foo/2 doesn't exist).
+    \+ wam_cpp_a2struct(any, foo(1, 2)).
+user:wam_cpp_test_a2_structure_unbound :-
+    % Unbound A2 → switch falls through to chain; findall sees all.
+    findall(F, ( wam_cpp_a2struct(_, S), functor(S, F, _) ), L),
+    L = [foo, bar, baz].
+
+% A2 = mixed atom + compound. Exercises switch_on_term_a2 — the most
+% common shape (atom for "empty" plus compound for non-empty). Mirrors
+% the assoc tree-recur predicate that's now indexed by this opcode.
+:- dynamic user:wam_cpp_a2term/3.
+:- dynamic user:wam_cpp_test_a2_term_atom_clause/0.
+:- dynamic user:wam_cpp_test_a2_term_compound_clause/0.
+:- dynamic user:wam_cpp_test_a2_term_list_clauses/0.
+:- dynamic user:wam_cpp_test_a2_term_unbound/0.
+
+user:wam_cpp_a2term(_, empty,     leaf).
+user:wam_cpp_a2term(_, node(_, _), branch).
+user:wam_cpp_a2term(_, [],        nil_list).
+user:wam_cpp_a2term(_, [_|_],     cons_list).
+
+user:wam_cpp_test_a2_term_atom_clause :-
+    wam_cpp_a2term(any, empty, R), R = leaf.
+user:wam_cpp_test_a2_term_compound_clause :-
+    wam_cpp_a2term(any, node(1, 2), R), R = branch.
+user:wam_cpp_test_a2_term_list_clauses :-
+    wam_cpp_a2term(any, [],         R1), R1 = nil_list,
+    wam_cpp_a2term(any, [a, b, c],  R2), R2 = cons_list.
+user:wam_cpp_test_a2_term_unbound :-
+    findall(R, wam_cpp_a2term(_, _, R), L),
+    L = [leaf, branch, nil_list, cons_list].
+
 user:wam_cpp_test_write :- write(hello), nl.
 % Y-reg isolation: both helpers use Y1/Y2 internally. Caller relies on
 % preserved Y1 across the two calls.
@@ -8785,6 +8836,38 @@ test(cpp_e2e_switch_on_constant_a2, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_a2_no_match_fails/0',        [], true),
           run_query(BinPath, 'wam_cpp_test_a2_unbound_enumerates/0',    [], true),
           run_query(BinPath, 'wam_cpp_test_a2_shared_key_backtracks/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% A2 structure + term indexing. Predicates whose A1 is variable in
+% every clause currently get NO A1 indexing (correct: a variable
+% head matches anything). Previously they also got no A2 indexing
+% unless A2 was all atomic constants. With switch_on_structure_a2
+% and switch_on_term_a2, multi-clause predicates with compound or
+% mixed A2 also get O(1) dispatch.
+test(cpp_e2e_switch_on_structure_and_term_a2,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_sta2', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_a2struct/2,
+                               user:wam_cpp_test_a2_structure_direct/0,
+                               user:wam_cpp_test_a2_structure_miss/0,
+                               user:wam_cpp_test_a2_structure_unbound/0,
+                               user:wam_cpp_a2term/3,
+                               user:wam_cpp_test_a2_term_atom_clause/0,
+                               user:wam_cpp_test_a2_term_compound_clause/0,
+                               user:wam_cpp_test_a2_term_list_clauses/0,
+                               user:wam_cpp_test_a2_term_unbound/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_a2_structure_direct/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_a2_structure_miss/0',       [], true),
+          run_query(BinPath, 'wam_cpp_test_a2_structure_unbound/0',    [], true),
+          run_query(BinPath, 'wam_cpp_test_a2_term_atom_clause/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_a2_term_compound_clause/0', [], true),
+          run_query(BinPath, 'wam_cpp_test_a2_term_list_clauses/0',    [], true),
+          run_query(BinPath, 'wam_cpp_test_a2_term_unbound/0',         [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).

--- a/tests/test_wam_target.pl
+++ b/tests/test_wam_target.pl
@@ -187,6 +187,41 @@ aggsubs_count(S, Sub, N) :-
     findall(_, sub_string(S, _, _, _, Sub), Occurrences),
     length(Occurrences, N).
 
+%% A2 indexing: when A1 is variable in every clause, the compiler
+%% falls back to A2-based indexing. Three flavours, mirroring A1:
+%%   all constants  → switch_on_constant_a2
+%%   all compounds  → switch_on_structure_a2 (no lists)
+%%   mixed types    → switch_on_term_a2
+:- dynamic test_a2_const/2, test_a2_struct/2, test_a2_term/2.
+test_a2_const(_, alpha).
+test_a2_const(_, beta).
+test_a2_const(_, gamma).
+
+test_a2_struct(_, foo(_)).
+test_a2_struct(_, bar(_, _)).
+test_a2_struct(_, baz(_, _, _)).
+
+test_a2_term(_, t).
+test_a2_term(_, t(_, _)).
+test_a2_term(_, []).
+test_a2_term(_, [_|_]).
+
+test_wam_a2_indexing :-
+    Test = 'WAM: A2-arg indexing emits constant/structure/term variants',
+    (   wam_target:compile_predicate_to_wam(user:test_a2_const/2, [], C1),
+        wam_target:compile_predicate_to_wam(user:test_a2_struct/2, [], C2),
+        wam_target:compile_predicate_to_wam(user:test_a2_term/2, [], C3),
+        atom_string(C1, S1), atom_string(C2, S2), atom_string(C3, S3),
+        sub_string(S1, _, _, _, 'switch_on_constant_a2'),
+        sub_string(S2, _, _, _, 'switch_on_structure_a2'),
+        sub_string(S3, _, _, _, 'switch_on_term_a2'),
+        % Term-form should not be a degenerate structure/constant emit.
+        \+ sub_string(S3, _, _, _, 'switch_on_structure_a2'),
+        \+ sub_string(S3, _, _, _, 'switch_on_constant_a2 ')
+    ->  pass(Test)
+    ;   fail_test(Test, 'A2 indexing did not emit the expected pseudo-instruction')
+    ).
+
 %% Run all tests
 run_tests :-
     format('~n========================================~n'),
@@ -201,7 +236,8 @@ run_tests :-
     test_wam_compound_head,
     test_wam_module,
     test_wam_multi_clause_findall_emits_allocate,
-    
+    test_wam_a2_indexing,
+
     format('~n========================================~n'),
     (   test_failed
     ->  format('Some tests FAILED~n'),


### PR DESCRIPTION
## Summary

Extends A2 indexing to cover structure and term (mixed) dispatch — completing the three-way decision that A1 already had. Previously the only A2 path was `switch_on_constant_a2` (all-atomic), so a predicate whose A1 was variable and A2 was compound or mixed got no indexing at all and walked the `try_me_else` chain linearly.

A1 → A2 mirroring:

| A1                                | A2 (new)                       |
|-----------------------------------|--------------------------------|
| `switch_on_constant`              | `switch_on_constant_a2` ✓ (#2297) |
| `switch_on_structure`             | `switch_on_structure_a2`       |
| `switch_on_term`                  | `switch_on_term_a2`            |

The new opcodes (`Op::SwitchOnStructureA2`, `Op::SwitchOnTermA2`) are mechanical clones of their A1 counterparts with `get_cell("A1")` swapped for `"A2"`. Same dispatch semantics: jump to first matching entry, set `indexed_entry` so the receiving `RetryMeElse` synthesizes a CP at this predicate level; unbound A2 falls through to the chain.

## WAM compiler changes

- `classify_second_args` now detects `structure` type (was constant-only)
- `second_args_contain_list/1` (mirrors `first_args_contain_list/1`)
- `build_structure_index_on/6` and `build_term_index_on/9` — argument-position-parameterised generalisations
- `build_second_arg_index/4` branches on the three-way classification

## Direct beneficiary

`wam_cpp_put_assoc_recur/5` (the AVL insert recursor): A1 is the key (variable), A2 is the tree node (`t` vs `t(K,V,B,L,R)`). Previously zero indexing; now `switch_on_term_a2` dispatches empty/non-empty in O(1).

Generated WAM-asm before this PR (no index at all):

```
wam_cpp_put_assoc_recur/5:
    try_me_else L_..._5_2
    ...
```

After:

```
wam_cpp_put_assoc_recur/5:
    switch_on_term_a2 1 t:default 1 t/5:L_..._5_2 none
    try_me_else L_..._5_2
    ...
```

## Test plan

- [x] `cpp_e2e_switch_on_structure_and_term_a2` — new e2e test, 7 sub-assertions covering structure direct-jump, miss, unbound, plus term atom-clause, compound-clause, list-clauses (cons + nil), unbound
- [x] `test_wam_a2_indexing` in `test_wam_target.pl` — locks in the compile-level emission shape for all three A2 flavours
- [x] All existing wam_target tests still pass (9/9)
- [x] All text-parser tests still pass
- [x] 31-test broad sweep across indexing/dispatch/list/assoc/sort/dcg/dynamic-pred paths — 33+ assertions, 0 failures
- [x] Manual verification: generated `Instruction::SwitchOnTermA2(...)` and `Instruction::SwitchOnStructureA2(...)` push_backs appear in the right places
- [x] Existing `cpp_e2e_assoc_library` (now driven by `switch_on_term_a2` on the recursor) still passes including the AVL balance assertions

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_