### PR TITLE
feat(wam-cpp): assoc API completion — min_assoc, max_assoc, del_assoc

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -672,6 +672,130 @@ static const int _wam_cpp_setup_register = []() {
        assertz((user:wam_cpp_rl_balance(<, =, >))),
        assertz((user:wam_cpp_rl_balance(=, =, =))),
        assertz((user:wam_cpp_rl_balance(>, <, =))),
+       % min_assoc/3 — leftmost (smallest-key) node.
+       assertz((user:min_assoc(t(K, V, _, t, _), K, V) :- !)),
+       assertz((user:min_assoc(t(_, _, _, L, _), K, V) :- min_assoc(L, K, V))),
+       % max_assoc/3 — rightmost (largest-key) node.
+       assertz((user:max_assoc(t(K, V, _, _, t), K, V) :- !)),
+       assertz((user:max_assoc(t(_, _, _, _, R), K, V) :- max_assoc(R, K, V))),
+       % del_assoc/4 — fails if Key not in Tree0. Returns the removed
+       % value and a rebalanced tree. Cross-checked against
+       % library(assoc) on ascending/descending bulk deletes.
+       assertz((user:del_assoc(K, T0, V, T) :-
+           wam_cpp_del_assoc_recur(K, T0, V, T, _))),
+       % wam_cpp_del_assoc_recur(+Key, +Tree, -Val, -NewTree, -Change)
+       %   Change ∈ {same, shrunk}.
+       assertz((user:wam_cpp_del_assoc_recur(K, t(K0, V0, B, L, R),
+                                            V, T, Change) :-
+           compare(Order, K, K0),
+           wam_cpp_del_assoc_dispatch(Order, K, K0, V0, B, L, R,
+                                      V, T, Change))),
+       % Found it — replace this node.
+       assertz((user:wam_cpp_del_assoc_dispatch(=, _, _, V, B, L, R,
+                                               V, T, Change) :-
+           wam_cpp_del_assoc_replace(B, L, R, T, Change))),
+       % Recurse left, then rebalance from the left.
+       assertz((user:wam_cpp_del_assoc_dispatch(<, K, K0, V0, B, L, R,
+                                               V, T, Change) :-
+           wam_cpp_del_assoc_recur(K, L, V, L1, LC),
+           wam_cpp_del_rebalance_left(LC, B, K0, V0, L1, R, T, Change))),
+       % Recurse right, then rebalance from the right.
+       assertz((user:wam_cpp_del_assoc_dispatch(>, K, K0, V0, B, L, R,
+                                               V, T, Change) :-
+           wam_cpp_del_assoc_recur(K, R, V, R1, RC),
+           wam_cpp_del_rebalance_right(RC, B, K0, V0, L, R1, T, Change))),
+       % wam_cpp_del_assoc_replace(B, L, R, NewTree, Change)
+       %   Build the replacement tree when the target node is found.
+       % Empty left — collapse to right.
+       assertz((user:wam_cpp_del_assoc_replace(_, t, R, R, shrunk))),
+       % Empty right (and non-empty left) — collapse to left.
+       assertz((user:wam_cpp_del_assoc_replace(_, L, t, L, shrunk) :-
+           L \= t)),
+       % Both sides non-empty — pull the in-order successor from the
+       % right subtree and use its (K, V) as the new root.
+       assertz((user:wam_cpp_del_assoc_replace(B, L, R, T, Change) :-
+           L \= t, R \= t,
+           wam_cpp_del_min_extract(R, SK, SV, R1, RC),
+           wam_cpp_del_rebalance_right(RC, B, SK, SV, L, R1, T, Change))),
+       % wam_cpp_del_min_extract(+Tree, -K, -V, -NewTree, -Change)
+       %   Extract the minimum key/value, returning the rest of the
+       %   tree and a height-change flag.
+       assertz((user:wam_cpp_del_min_extract(t(K, V, _, t, R), K, V, R,
+                                            shrunk))),
+       assertz((user:wam_cpp_del_min_extract(t(K0, V0, B, L, R),
+                                            K, V, T, Change) :-
+           L \= t,
+           wam_cpp_del_min_extract(L, K, V, L1, LC),
+           wam_cpp_del_rebalance_left(LC, B, K0, V0, L1, R, T, Change))),
+       % wam_cpp_del_rebalance_left(LChange, B, K, V, L, R, NewTree,
+       %                           Change)
+       %   Rebalance after the LEFT subtree shrunk by 0 or 1.
+       assertz((user:wam_cpp_del_rebalance_left(same, B, K, V, L, R,
+                                               t(K, V, B, L, R), same))),
+       % Was left-heavy, lost the extra → balanced, height shrunk.
+       assertz((user:wam_cpp_del_rebalance_left(shrunk, <, K, V, L, R,
+                                               t(K, V, =, L, R), shrunk))),
+       % Was balanced → right-heavy, height stayed.
+       assertz((user:wam_cpp_del_rebalance_left(shrunk, =, K, V, L, R,
+                                               t(K, V, >, L, R), same))),
+       % Was right-heavy → now over-tipped right; rotate based on R''s
+       % balance.
+       assertz((user:wam_cpp_del_rebalance_left(shrunk, >, K, V, L, R,
+                                               T, Change) :-
+           wam_cpp_del_rotate_right(L, K, V, R, T, Change))),
+       % Single left rotation (R right-heavy or balanced) + double
+       % rotation via R''s left subtree (R left-heavy). Three RB cases;
+       % only the RB=> case matches the structure of put''s
+       % rotate_right_heavy, the other two are delete-specific.
+       % RB=>: single left rotation, height shrunk.
+       assertz((user:wam_cpp_del_rotate_right(L, K, V,
+                   t(RK, RV, >, RL, RR),
+                   t(RK, RV, =, t(K, V, =, L, RL), RR),
+                   shrunk))),
+       % RB==: single left rotation, height stays (rotation tilts the
+       % outer node to <, inner to >).
+       assertz((user:wam_cpp_del_rotate_right(L, K, V,
+                   t(RK, RV, =, RL, RR),
+                   t(RK, RV, <, t(K, V, >, L, RL), RR),
+                   same))),
+       % RB=<: double rotation via RL — same shape as put''s RL case,
+       % height shrunk.
+       assertz((user:wam_cpp_del_rotate_right(L, K, V,
+                   t(RK, RV, <, t(RLK, RLV, RLB, RLL, RLR), RR),
+                   t(RLK, RLV, =,
+                     t(K,  V,  NLB, L,   RLL),
+                     t(RK, RV, NRB, RLR, RR)),
+                   shrunk) :-
+           wam_cpp_rl_balance(RLB, NLB, NRB))),
+       % wam_cpp_del_rebalance_right(RChange, B, K, V, L, R, NewTree,
+       %                            Change) — mirror of left.
+       assertz((user:wam_cpp_del_rebalance_right(same, B, K, V, L, R,
+                                                t(K, V, B, L, R), same))),
+       assertz((user:wam_cpp_del_rebalance_right(shrunk, >, K, V, L, R,
+                                                t(K, V, =, L, R), shrunk))),
+       assertz((user:wam_cpp_del_rebalance_right(shrunk, =, K, V, L, R,
+                                                t(K, V, <, L, R), same))),
+       assertz((user:wam_cpp_del_rebalance_right(shrunk, <, K, V, L, R,
+                                                T, Change) :-
+           wam_cpp_del_rotate_left(L, K, V, R, T, Change))),
+       % LB=<: single right rotation, height shrunk.
+       assertz((user:wam_cpp_del_rotate_left(
+                   t(LK, LV, <, LL, LR), K, V, R,
+                   t(LK, LV, =, LL, t(K, V, =, LR, R)),
+                   shrunk))),
+       % LB==: single right rotation, height stays.
+       assertz((user:wam_cpp_del_rotate_left(
+                   t(LK, LV, =, LL, LR), K, V, R,
+                   t(LK, LV, >, LL, t(K, V, <, LR, R)),
+                   same))),
+       % LB=>: double rotation via LR — same shape as put''s LR case.
+       assertz((user:wam_cpp_del_rotate_left(
+                   t(LK, LV, >, LL, t(LRK, LRV, LRB, LRL, LRR)), K, V, R,
+                   t(LRK, LRV, =,
+                     t(LK, LV, NLB, LL,  LRL),
+                     t(K,  V,  NRB, LRR, R)),
+                   shrunk) :-
+           wam_cpp_lr_balance(LRB, NLB, NRB))),
        assertz((user:list_to_assoc(List, Assoc) :-
            wam_cpp_list_to_assoc_(List, t, Assoc))),
        assertz((user:wam_cpp_list_to_assoc_([], A, A))),
@@ -764,6 +888,17 @@ stdlib_feature_predicates(assoc, [
     user:wam_cpp_rotate_right_heavy/5,
     user:wam_cpp_lr_balance/3,
     user:wam_cpp_rl_balance/3,
+    user:min_assoc/3,
+    user:max_assoc/3,
+    user:del_assoc/4,
+    user:wam_cpp_del_assoc_recur/5,
+    user:wam_cpp_del_assoc_dispatch/10,
+    user:wam_cpp_del_assoc_replace/5,
+    user:wam_cpp_del_min_extract/5,
+    user:wam_cpp_del_rebalance_left/8,
+    user:wam_cpp_del_rebalance_right/8,
+    user:wam_cpp_del_rotate_right/6,
+    user:wam_cpp_del_rotate_left/6,
     user:list_to_assoc/2,
     user:wam_cpp_list_to_assoc_/3,
     user:assoc_to_list/2,

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -242,6 +242,15 @@
 :- dynamic user:wam_cpp_test_assoc_avl_balance_sorted/0.
 :- dynamic user:wam_cpp_test_assoc_avl_balance_descending/0.
 :- dynamic user:wam_cpp_test_assoc_avl_balance_zigzag/0.
+:- dynamic user:wam_cpp_test_assoc_min/0.
+:- dynamic user:wam_cpp_test_assoc_max/0.
+:- dynamic user:wam_cpp_test_assoc_min_after_inserts/0.
+:- dynamic user:wam_cpp_test_assoc_del_leaf/0.
+:- dynamic user:wam_cpp_test_assoc_del_root/0.
+:- dynamic user:wam_cpp_test_assoc_del_missing_fails/0.
+:- dynamic user:wam_cpp_test_assoc_del_all_back_to_empty/0.
+:- dynamic user:wam_cpp_test_assoc_del_rebalance_sorted/0.
+:- dynamic user:wam_cpp_test_assoc_del_returns_value/0.
 :- dynamic user:wam_cpp_test_get_time_positive/0.
 :- dynamic user:wam_cpp_test_stamp_utc/0.
 :- dynamic user:wam_cpp_test_stamp_subsec/0.
@@ -644,6 +653,102 @@ user:wam_cpp_test_assoc_avl_balance_zigzag :-
     get_assoc(7,  A15, v7),
     get_assoc(15, A15, v15),
     assoc_to_keys(A15, [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]).
+
+% min_assoc / max_assoc / del_assoc — round out the assoc API.
+user:wam_cpp_test_assoc_min :-
+    empty_assoc(A0),
+    put_assoc(5, A0, v5, A1),
+    put_assoc(1, A1, v1, A2),
+    put_assoc(9, A2, v9, A3),
+    min_assoc(A3, 1, v1).
+user:wam_cpp_test_assoc_max :-
+    empty_assoc(A0),
+    put_assoc(5, A0, v5, A1),
+    put_assoc(1, A1, v1, A2),
+    put_assoc(9, A2, v9, A3),
+    max_assoc(A3, 9, v9).
+user:wam_cpp_test_assoc_min_after_inserts :-
+    % Inserting in zigzag order — min stays the leftmost regardless
+    % of rotations.
+    empty_assoc(A0),
+    put_assoc(8,  A0, v8,  A1),
+    put_assoc(4,  A1, v4,  A2),
+    put_assoc(12, A2, v12, A3),
+    put_assoc(2,  A3, v2,  A4),
+    put_assoc(10, A4, v10, A5),
+    put_assoc(1,  A5, v1,  A6),
+    min_assoc(A6, 1, v1),
+    max_assoc(A6, 12, v12).
+user:wam_cpp_test_assoc_del_leaf :-
+    % Build a tree with a leaf, delete it.
+    empty_assoc(A0),
+    put_assoc(2, A0, v2, A1),
+    put_assoc(1, A1, v1, A2),
+    put_assoc(3, A2, v3, A3),
+    del_assoc(1, A3, v1, A4),
+    \+ get_assoc(1, A4, _),
+    get_assoc(2, A4, v2),
+    get_assoc(3, A4, v3).
+user:wam_cpp_test_assoc_del_root :-
+    % Delete the root — exercises the "both children non-empty" path
+    % that pulls the in-order successor.
+    empty_assoc(A0),
+    put_assoc(2, A0, v2, A1),
+    put_assoc(1, A1, v1, A2),
+    put_assoc(3, A2, v3, A3),
+    del_assoc(2, A3, v2, A4),
+    \+ get_assoc(2, A4, _),
+    get_assoc(1, A4, v1),
+    get_assoc(3, A4, v3).
+user:wam_cpp_test_assoc_del_missing_fails :-
+    empty_assoc(A0),
+    put_assoc(a, A0, 1, A1),
+    \+ del_assoc(z, A1, _, _).
+user:wam_cpp_test_assoc_del_all_back_to_empty :-
+    empty_assoc(A0),
+    put_assoc(1, A0, v1, A1),
+    put_assoc(2, A1, v2, A2),
+    put_assoc(3, A2, v3, A3),
+    put_assoc(4, A3, v4, A4),
+    put_assoc(5, A4, v5, A5),
+    del_assoc(3, A5, _, B1),
+    del_assoc(1, B1, _, B2),
+    del_assoc(5, B2, _, B3),
+    del_assoc(2, B3, _, B4),
+    del_assoc(4, B4, _, B5),
+    B5 == t.
+user:wam_cpp_test_assoc_del_rebalance_sorted :-
+    % Insert 16 keys ascending (max-imbalance shape), then delete
+    % the first half. Tree must stay balanced (depth bounded) and
+    % retain the remaining keys.
+    empty_assoc(A0),
+    put_assoc(1,  A0,  _, A1),  put_assoc(2,  A1,  _, A2),
+    put_assoc(3,  A2,  _, A3),  put_assoc(4,  A3,  _, A4),
+    put_assoc(5,  A4,  _, A5),  put_assoc(6,  A5,  _, A6),
+    put_assoc(7,  A6,  _, A7),  put_assoc(8,  A7,  _, A8),
+    put_assoc(9,  A8,  _, A9),  put_assoc(10, A9,  _, A10),
+    put_assoc(11, A10, _, A11), put_assoc(12, A11, _, A12),
+    put_assoc(13, A12, _, A13), put_assoc(14, A13, _, A14),
+    put_assoc(15, A14, _, A15), put_assoc(16, A15, _, A16),
+    del_assoc(1, A16, _, B1),
+    del_assoc(2, B1,  _, B2),
+    del_assoc(3, B2,  _, B3),
+    del_assoc(4, B3,  _, B4),
+    del_assoc(5, B4,  _, B5),
+    del_assoc(6, B5,  _, B6),
+    del_assoc(7, B6,  _, B7),
+    del_assoc(8, B7,  _, B8),
+    wam_cpp_assoc_depth(B8, D),
+    D =< 4,
+    assoc_to_keys(B8, [9, 10, 11, 12, 13, 14, 15, 16]).
+user:wam_cpp_test_assoc_del_returns_value :-
+    % del_assoc/4 returns the deleted value as its 3rd arg.
+    empty_assoc(A0),
+    put_assoc(name,   A0, alice,  A1),
+    put_assoc(age,    A1, 30,     A2),
+    put_assoc(role,   A2, admin,  A3),
+    del_assoc(age, A3, V, _),
+    V = 30.
 % Date/time: get_time/1 (Float seconds since epoch),
 % stamp_date_time/3 (decompose + TZ), date_time_stamp/2 (compose),
 % format_time/3 (strftime-style atom output). Tests use the canonical
@@ -4020,7 +4125,16 @@ test(cpp_e2e_assoc_library, [condition(cpp_compiler_available)]) :-
                                user:wam_cpp_assoc_depth/2,
                                user:wam_cpp_test_assoc_avl_balance_sorted/0,
                                user:wam_cpp_test_assoc_avl_balance_descending/0,
-                               user:wam_cpp_test_assoc_avl_balance_zigzag/0],
+                               user:wam_cpp_test_assoc_avl_balance_zigzag/0,
+                               user:wam_cpp_test_assoc_min/0,
+                               user:wam_cpp_test_assoc_max/0,
+                               user:wam_cpp_test_assoc_min_after_inserts/0,
+                               user:wam_cpp_test_assoc_del_leaf/0,
+                               user:wam_cpp_test_assoc_del_root/0,
+                               user:wam_cpp_test_assoc_del_missing_fails/0,
+                               user:wam_cpp_test_assoc_del_all_back_to_empty/0,
+                               user:wam_cpp_test_assoc_del_rebalance_sorted/0,
+                               user:wam_cpp_test_assoc_del_returns_value/0],
                               [emit_main(true), include_stdlib(assoc)],
                               TmpDir),
         ( build_e2e_binary(TmpDir, BinPath),
@@ -4034,7 +4148,16 @@ test(cpp_e2e_assoc_library, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_assoc_compound_keys/0',          [], true),
           run_query(BinPath, 'wam_cpp_test_assoc_avl_balance_sorted/0',     [], true),
           run_query(BinPath, 'wam_cpp_test_assoc_avl_balance_descending/0', [], true),
-          run_query(BinPath, 'wam_cpp_test_assoc_avl_balance_zigzag/0',     [], true)
+          run_query(BinPath, 'wam_cpp_test_assoc_avl_balance_zigzag/0',     [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_min/0',                    [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_max/0',                    [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_min_after_inserts/0',      [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_del_leaf/0',               [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_del_root/0',               [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_del_missing_fails/0',      [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_del_all_back_to_empty/0',  [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_del_rebalance_sorted/0',   [], true),
+          run_query(BinPath, 'wam_cpp_test_assoc_del_returns_value/0',      [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
## Summary

Builds on the AVL machinery from #2296 to round out the assoc stdlib with three SWI-compatible predicates:

- `min_assoc(+Assoc, ?Key, ?Value)` — leftmost (smallest-key) node
- `max_assoc(+Assoc, ?Key, ?Value)` — rightmost (largest-key) node
- `del_assoc(+Key, +Assoc0, ?Value, -Assoc)` — delete by key; return the removed value; return a rebalanced tree. Fails (no exception) when the key is absent.

## Implementation notes

`min_assoc`/`max_assoc` are simple recursive walks — no rebalance needed.

`del_assoc` needs delete-specific rebalance helpers. The rotation tables and height-change semantics differ from insert: deletion can produce shrunk-by-one subtrees that need different balance updates than the grew-by-one cases from `put_assoc`. New helpers:

| Helper | Role |
|---|---|
| `wam_cpp_del_assoc_recur` / `_dispatch` | Walk by `compare/3`, branch on Order |
| `wam_cpp_del_assoc_replace` | Replace target node with in-order successor (or merged child if one side empty) |
| `wam_cpp_del_min_extract` | Pull leftmost node for the both-children case |
| `wam_cpp_del_rebalance_{left,right}` | Propagate height-change up the spine |
| `wam_cpp_del_rotate_{right,left}` | Three RB/LB cases each — single rot (RB==), single rot (RB=>/LB=<), double rot |

The double-rotation case reuses the existing `wam_cpp_lr_balance` / `wam_cpp_rl_balance` tables from insert — those are the same regardless of which direction triggered the rotation.

## Validation

- Cross-checked against `library(assoc)`: build a 50-element tree ascending then descending, then delete each key in turn — all 100 cases produce identical in-order traversals + returned values
- The implementation was first prototyped in pure SWI and validated before being transcribed into the `assertz` block

## Regression tests (9 new sub-assertions in `cpp_e2e_assoc_library`)

- `min`, `max`, `min/max after rotations`
- `del_leaf`, `del_root` (both children — exercises the in-order successor path)
- `del_missing_fails`
- `del_all_back_to_empty` — final tree literally `== t`
- `del_rebalance_sorted` — insert 16 keys ascending (max-imbalance shape), delete first 8, assert depth ≤ 4 and correct remaining keys
- `del_returns_value` — locks in the 3rd-arg semantics

## Test plan

- [x] `cpp_e2e_assoc_library` now has 20 sub-assertions, all pass
- [x] SWI-side cross-check against `library(assoc)`: 100 delete cases (asc + desc) match
- [x] 32-test broad sweep across indexing/dispatch/list/assoc/sort/dcg/dynamic-pred paths — in progress, 20 dots / 0 errors at PR-open time

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_