### PR TITLE
feat(wam-cpp): mixed-mode A1 indexing (catch-all default clauses)

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -2006,6 +2006,15 @@ instr_to_setup_line(switch_on_constant(Entries), Labels, Line) :- !,
     format(atom(Line),
            '    vm.instrs.push_back(Instruction::SwitchOnConstant({~w}));',
            [EntriesCpp]).
+instr_to_setup_line(switch_on_constant_fallthrough(Entries), Labels, Line) :- !,
+    % Mixed-mode A1 indexing: bound A1 with no entry in the table
+    % must NOT fail — fall through to the try_me_else chain so the
+    % variable-A1 clauses get a chance to match. Same opcode as
+    % SwitchOnConstant, just with the no_match_fallthrough flag set.
+    parse_switch_entries(Entries, Labels, EntriesCpp),
+    format(atom(Line),
+           '    vm.instrs.push_back(Instruction::SwitchOnConstant({~w}, true));',
+           [EntriesCpp]).
 instr_to_setup_line(switch_on_constant_a2(Entries), Labels, Line) :- !,
     % Real A2 dispatch — emitted when the WAM compiler decides A1 is
     % too variable to index on but A2 is all constants. Same dispatch
@@ -2531,6 +2540,11 @@ struct Instruction {
     // dispatch; target doubles as the list-pc for SwitchOnTerm.
     std::vector<std::pair<Value, std::size_t>> const_table;
     std::vector<std::pair<std::string, std::size_t>> struct_table;
+    // Mixed-mode indexing flag: when a bound A1/A2 misses every
+    // entry in the switch table, fall through (pc += 1) instead of
+    // failing. Set when the predicate has variable-headed clauses
+    // that act as a default after the indexed prefix.
+    bool no_match_fallthrough = false;
 
     static Instruction GetConstant(Value v, std::string ai)
         { Instruction i; i.op = Op::GetConstant; i.val = std::move(v); i.a = std::move(ai); return i; }
@@ -2598,8 +2612,12 @@ struct Instruction {
           i.c = std::move(wregs); return i; }
     static Instruction EndAggregate(std::string vreg)
         { Instruction i; i.op = Op::EndAggregate; i.a = std::move(vreg); return i; }
-    static Instruction SwitchOnConstant(std::vector<std::pair<Value, std::size_t>> table)
-        { Instruction i; i.op = Op::SwitchOnConstant; i.const_table = std::move(table); return i; }
+    static Instruction SwitchOnConstant(std::vector<std::pair<Value, std::size_t>> table,
+                                        bool fall_on_miss = false)
+        { Instruction i; i.op = Op::SwitchOnConstant;
+          i.const_table = std::move(table);
+          i.no_match_fallthrough = fall_on_miss;
+          return i; }
     static Instruction SwitchOnConstantA2(std::vector<std::pair<Value, std::size_t>> table)
         { Instruction i; i.op = Op::SwitchOnConstantA2; i.const_table = std::move(table); return i; }
     static Instruction SwitchOnStructure(std::vector<std::pair<std::string, std::size_t>> table)
@@ -7422,7 +7440,12 @@ bool WamState::step(const Instruction& instr) {
                     pc = kv.second; return true;
                 }
             }
-            return false; // bound constant with no matching clause
+            // Bound constant with no matching indexed clause. If the
+            // predicate has variable-headed clauses (mixed-mode
+            // indexing), fall through to the try_me_else chain so
+            // those clauses still get a chance. Otherwise fail fast.
+            if (instr.no_match_fallthrough) { pc += 1; return true; }
+            return false;
         }
         case Instruction::Op::SwitchOnConstantA2: {
             // Dispatch on A2''s atom/integer value. Emitted when A1 is

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -144,10 +144,22 @@ compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code) :-
 %  - All atomic first args → switch_on_constant
 %  - All compound first args → switch_on_structure
 %  - Mixed types → switch_on_term (type-based dispatch)
-%  - Any variable first args → no indexing (variable matches anything)
+%  - Mixed with variable A1 clauses: the prefix up to (but not
+%    including) the first variable clause is the "indexed prefix";
+%    if it's all-constant, emit switch_on_constant_fallthrough — the
+%    runtime jumps to a matching indexed entry, otherwise falls
+%    through to the try_me_else chain (which catches the variable
+%    clauses). v1 limits the prefix to constant-only; structure /
+%    mixed prefixes with a trailing variable clause skip indexing.
 build_first_arg_index(Pred, Arity, Clauses, IndexCode) :-
     classify_first_args(Clauses, Types),
-    \+ member(variable, Types),  % can't index if any clause has a variable first arg
+    (   \+ member(variable, Types)
+    ->  build_first_arg_index_homogeneous(Pred, Arity, Clauses, Types, IndexCode)
+    ;   build_first_arg_index_with_fallthrough(Pred, Arity, Clauses, Types,
+                                               IndexCode)
+    ).
+
+build_first_arg_index_homogeneous(Pred, Arity, Clauses, Types, IndexCode) :-
     (   forall(member(T, Types), T = constant)
     ->  build_constant_index(Clauses, 1, Pred, Arity, Entries),
         Entries \= [],
@@ -163,6 +175,25 @@ build_first_arg_index(Pred, Arity, Clauses, IndexCode) :-
         build_term_index(Clauses, 1, Pred, Arity, Types, ConstEntries, StructEntries, ListLabel),
         format_switch_on_term(ConstEntries, StructEntries, ListLabel, IndexCode)
     ).
+
+build_first_arg_index_with_fallthrough(Pred, Arity, Clauses, Types, IndexCode) :-
+    indexed_prefix(Types, Clauses, PrefixTypes, PrefixClauses),
+    PrefixClauses \= [],
+    % v1: only handle constant prefix.
+    forall(member(T, PrefixTypes), T = constant),
+    build_constant_index(PrefixClauses, 1, Pred, Arity, Entries),
+    Entries \= [],
+    format_index_entries(Entries, EntriesStr),
+    format(string(IndexCode),
+           "    switch_on_constant_fallthrough ~w", [EntriesStr]).
+
+%% indexed_prefix(+Types, +Clauses, -PrefixTypes, -PrefixClauses)
+%  Take clauses up to (but not including) the first one whose A1 is
+%  a variable. Used for mixed-mode A1 indexing.
+indexed_prefix([], [], [], []).
+indexed_prefix([variable|_], _, [], []) :- !.
+indexed_prefix([T|Ts], [C|Cs], [T|PT], [C|PC]) :-
+    indexed_prefix(Ts, Cs, PT, PC).
 
 classify_first_args([], []).
 classify_first_args([Head-_|Rest], [Type|RestTypes]) :-

--- a/src/unifyweaver/targets/wam_text_parser.pl
+++ b/src/unifyweaver/targets/wam_text_parser.pl
@@ -179,9 +179,10 @@ wam_recognise_instruction(["begin_aggregate", K, V, R, W],
 wam_recognise_instruction(["end_aggregate", R],        end_aggregate(R)).
 % Indexing instructions: variable-arity tail tokens captured as a list,
 % target-side decoders parse them per the dispatch-table convention.
-wam_recognise_instruction(["switch_on_constant"     | Es], switch_on_constant(Es)).
-wam_recognise_instruction(["switch_on_constant_a2"  | Es], switch_on_constant_a2(Es)).
-wam_recognise_instruction(["switch_on_structure"    | Es], switch_on_structure(Es)).
-wam_recognise_instruction(["switch_on_structure_a2" | Es], switch_on_structure_a2(Es)).
-wam_recognise_instruction(["switch_on_term"         | Ts], switch_on_term(Ts)).
-wam_recognise_instruction(["switch_on_term_a2"      | Ts], switch_on_term_a2(Ts)).
+wam_recognise_instruction(["switch_on_constant"             | Es], switch_on_constant(Es)).
+wam_recognise_instruction(["switch_on_constant_fallthrough" | Es], switch_on_constant_fallthrough(Es)).
+wam_recognise_instruction(["switch_on_constant_a2"          | Es], switch_on_constant_a2(Es)).
+wam_recognise_instruction(["switch_on_structure"            | Es], switch_on_structure(Es)).
+wam_recognise_instruction(["switch_on_structure_a2"         | Es], switch_on_structure_a2(Es)).
+wam_recognise_instruction(["switch_on_term"                 | Ts], switch_on_term(Ts)).
+wam_recognise_instruction(["switch_on_term_a2"              | Ts], switch_on_term_a2(Ts)).

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -3213,6 +3213,74 @@ user:wam_cpp_test_a2_term_unbound :-
     findall(R, wam_cpp_a2term(_, _, R), L),
     L = [leaf, branch, nil_list, cons_list].
 
+% Mixed-mode A1 indexing — predicates with a trailing variable-A1
+% clause acting as the catch-all default. Previously such predicates
+% got NO A1 indexing (the var clause disabled the whole table). Now
+% the indexed prefix (clauses before any variable-A1 clause) gets a
+% switch_on_constant_fallthrough that jumps directly on a hit and
+% falls through to the try_me_else chain on miss.
+:- dynamic user:wam_cpp_mma_tag/2.
+:- dynamic user:wam_cpp_test_mma_specific_hit/0.
+:- dynamic user:wam_cpp_test_mma_unknown_falls_through/0.
+:- dynamic user:wam_cpp_test_mma_specific_backtracks_to_default/0.
+:- dynamic user:wam_cpp_test_mma_unknown_only_default/0.
+:- dynamic user:wam_cpp_test_mma_all_unbound_enumerates/0.
+
+user:wam_cpp_mma_tag(error, red).
+user:wam_cpp_mma_tag(warn,  yellow).
+user:wam_cpp_mma_tag(ok,    green).
+user:wam_cpp_mma_tag(_,     gray).
+
+user:wam_cpp_test_mma_specific_hit :-
+    % Direct switch hit on each indexed clause.
+    wam_cpp_mma_tag(error, red),
+    wam_cpp_mma_tag(warn,  yellow),
+    wam_cpp_mma_tag(ok,    green).
+user:wam_cpp_test_mma_unknown_falls_through :-
+    % A1 = something NOT in the switch table — must fall through
+    % to the chain so the variable-A1 clause matches.
+    wam_cpp_mma_tag(other, gray).
+user:wam_cpp_test_mma_specific_backtracks_to_default :-
+    % A1 = error matches clause 1 (red) AND the trailing var clause
+    % (gray) on backtrack.
+    findall(C, wam_cpp_mma_tag(error, C), L),
+    L = [red, gray].
+user:wam_cpp_test_mma_unknown_only_default :-
+    % A1 = unknown matches ONLY the var clause.
+    findall(C, wam_cpp_mma_tag(unknown, C), L),
+    L = [gray].
+user:wam_cpp_test_mma_all_unbound_enumerates :-
+    % Unbound A1 enumerates every clause in source order.
+    findall(T-C, wam_cpp_mma_tag(T, C), L),
+    L = [error-red, warn-yellow, ok-green, _-gray].
+
+% Same predicate shape with a variable clause in the MIDDLE — the
+% indexed prefix is just the first clause (`a`). Everything after
+% the var clause sits in the try_me_else chain and is only reached
+% via fall-through.
+:- dynamic user:wam_cpp_mma_mid/2.
+:- dynamic user:wam_cpp_test_mma_mid_indexed/0.
+:- dynamic user:wam_cpp_test_mma_mid_after_var/0.
+:- dynamic user:wam_cpp_test_mma_mid_unbound/0.
+
+user:wam_cpp_mma_mid(a, 1).
+user:wam_cpp_mma_mid(_, 99).
+user:wam_cpp_mma_mid(b, 2).
+user:wam_cpp_mma_mid(c, 3).
+
+user:wam_cpp_test_mma_mid_indexed :-
+    % A1=a hits the indexed clause first, then the var clause on retry.
+    findall(V, wam_cpp_mma_mid(a, V), L),
+    L = [1, 99].
+user:wam_cpp_test_mma_mid_after_var :-
+    % A1=b falls through (no entry for b in the indexed prefix),
+    % the chain walks all clauses and clauses 2+3 both match.
+    findall(V, wam_cpp_mma_mid(b, V), L),
+    L = [99, 2].
+user:wam_cpp_test_mma_mid_unbound :-
+    findall(K-V, wam_cpp_mma_mid(K, V), L),
+    L = [a-1, _-99, b-2, c-3].
+
 user:wam_cpp_test_write :- write(hello), nl.
 % Y-reg isolation: both helpers use Y1/Y2 internally. Caller relies on
 % preserved Y1 across the two calls.
@@ -9068,6 +9136,40 @@ test(cpp_e2e_switch_on_constant_a2, [condition(cpp_compiler_available)]) :-
           run_query(BinPath, 'wam_cpp_test_a2_no_match_fails/0',        [], true),
           run_query(BinPath, 'wam_cpp_test_a2_unbound_enumerates/0',    [], true),
           run_query(BinPath, 'wam_cpp_test_a2_shared_key_backtracks/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% Mixed-mode A1 indexing — predicates with variable-A1 clauses no
+% longer disable A1 indexing entirely. Clauses up to (but not
+% including) the first variable-A1 clause get a
+% switch_on_constant_fallthrough table; the bound-but-unmatched
+% case falls through to the try_me_else chain so trailing variable
+% clauses still match.
+test(cpp_e2e_mixed_mode_a1_indexing,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_mma', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_mma_tag/2,
+                               user:wam_cpp_test_mma_specific_hit/0,
+                               user:wam_cpp_test_mma_unknown_falls_through/0,
+                               user:wam_cpp_test_mma_specific_backtracks_to_default/0,
+                               user:wam_cpp_test_mma_unknown_only_default/0,
+                               user:wam_cpp_test_mma_all_unbound_enumerates/0,
+                               user:wam_cpp_mma_mid/2,
+                               user:wam_cpp_test_mma_mid_indexed/0,
+                               user:wam_cpp_test_mma_mid_after_var/0,
+                               user:wam_cpp_test_mma_mid_unbound/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_mma_specific_hit/0',                    [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_unknown_falls_through/0',           [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_specific_backtracks_to_default/0',  [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_unknown_only_default/0',            [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_all_unbound_enumerates/0',          [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_mid_indexed/0',                     [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_mid_after_var/0',                   [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_mid_unbound/0',                     [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).

--- a/tests/test_wam_target.pl
+++ b/tests/test_wam_target.pl
@@ -222,6 +222,50 @@ test_wam_a2_indexing :-
     ;   fail_test(Test, 'A2 indexing did not emit the expected pseudo-instruction')
     ).
 
+%% Mixed-mode A1 indexing: predicates with a variable A1 clause
+%% should now get a switch_on_constant_fallthrough for their indexed
+%% prefix, instead of no A1 indexing.
+:- dynamic test_mma_trailing/2, test_mma_middle/2, test_mma_first/2,
+           test_mma_none/2.
+test_mma_trailing(a, 1).
+test_mma_trailing(b, 2).
+test_mma_trailing(c, 3).
+test_mma_trailing(_, 0).
+
+test_mma_middle(a, 1).
+test_mma_middle(_, 99).
+test_mma_middle(b, 2).
+
+test_mma_first(_, 0).
+test_mma_first(a, 1).
+test_mma_first(b, 2).
+
+test_mma_none(a, 1).
+test_mma_none(b, 2).
+test_mma_none(c, 3).
+
+test_wam_mixed_mode_a1_indexing :-
+    Test = 'WAM: mixed-mode A1 indexing emits switch_on_constant_fallthrough',
+    (   wam_target:compile_predicate_to_wam(user:test_mma_trailing/2, [], C1),
+        wam_target:compile_predicate_to_wam(user:test_mma_middle/2, [], C2),
+        wam_target:compile_predicate_to_wam(user:test_mma_first/2, [], C3),
+        wam_target:compile_predicate_to_wam(user:test_mma_none/2, [], C4),
+        atom_string(C1, S1), atom_string(C2, S2),
+        atom_string(C3, S3), atom_string(C4, S4),
+        % Trailing var: indexed prefix is a,b,c → fallthrough form.
+        sub_string(S1, _, _, _, 'switch_on_constant_fallthrough'),
+        % Middle var: indexed prefix is just `a` → fallthrough form.
+        sub_string(S2, _, _, _, 'switch_on_constant_fallthrough'),
+        % Var first: no A1 indexing (falls back to A2).
+        \+ sub_string(S3, _, _, _, 'switch_on_constant_fallthrough'),
+        % No var clause: plain switch_on_constant (NOT the fallthrough form).
+        sub_string(S4, _, _, _, 'switch_on_constant '),
+        \+ sub_string(S4, _, _, _, 'switch_on_constant_fallthrough')
+    ->  pass(Test)
+    ;   fail_test(Test,
+                  'Mixed-mode A1 indexing did not emit the expected pseudo-instruction')
+    ).
+
 %% Run all tests
 run_tests :-
     format('~n========================================~n'),
@@ -237,6 +281,7 @@ run_tests :-
     test_wam_module,
     test_wam_multi_clause_findall_emits_allocate,
     test_wam_a2_indexing,
+    test_wam_mixed_mode_a1_indexing,
 
     format('~n========================================~n'),
     (   test_failed


### PR DESCRIPTION
## Summary

Previously any variable-A1 clause disabled A1 indexing entirely. The common "specific cases + catch-all default" pattern got no indexing at all:

```prolog
tag(error, red).      % clause 1: indexed
tag(warn,  yellow).   % clause 2: indexed
tag(ok,    green).    % clause 3: indexed
tag(_,     gray).     % clause 4: variable A1 → kills the whole table
```

`tag(error, red)` walked the try_me_else chain through all 4 clauses (3 wasted head-unifications) instead of jumping directly to clause 1.

This change lifts that restriction for the prefix-only case. The WAM compiler now considers the **indexed prefix** — clauses up to (but not including) the first variable-A1 clause — and if that prefix is all-constant, emits a new `switch_on_constant_fallthrough` pseudo-instruction with entries for those clauses. Bound-but-unmatched A1 falls through to the try_me_else chain so the trailing variable clauses still match.

```
tag(error, red):  switch jumps directly to clause 1; retry chain
                  handles backtracking to clause 4
tag(other, gray): switch misses → falls through → chain walks all
                  four clauses, only clause 4 matches
```

## Runtime change

Add a single `bool no_match_fallthrough` field on `Instruction` plus a defaulted-arg overload of the `SwitchOnConstant` factory:

```cpp
static Instruction SwitchOnConstant(table, bool fall_on_miss = false)
    { ... i.no_match_fallthrough = fall_on_miss; ... }
```

The existing `step()` handler gains one branch in the "no match" path. All existing emit sites (which pass `false` implicitly) keep their current behavior.

## Scope (v1)

The indexed-prefix is restricted to **constant-only** types. Mixed types (structure / term) with a trailing variable clause still skip indexing — can be added later when there's a concrete use case (would need `switch_on_structure_fallthrough` and `switch_on_term_fallthrough`).

Variable-clause positions handled:

| Layout | Result |
|---|---|
| Trailing (`a, b, c, _`)   | Indexed prefix = `a, b, c` |
| Middle (`a, _, b, c`)     | Indexed prefix = `a` only |
| First (`_, a, b`)         | No A1 indexing (unchanged) |
| No variable (`a, b, c`)   | Plain `switch_on_constant` (unchanged) |

## Regression tests

- `cpp_e2e_mixed_mode_a1_indexing` — 8 sub-assertions covering: direct hit on each indexed clause, fallthrough on miss, backtrack into the default, miss-only-default, full enumeration on unbound, plus the middle-var variant (indexed + after-var + unbound).
- `test_wam_mixed_mode_a1_indexing` in `test_wam_target.pl` — locks in the compile-level emission shape for all four variable-clause-position cases.

## Test plan

- [x] `cpp_e2e_mixed_mode_a1_indexing` — 8 sub-assertions, all pass
- [x] `test_wam_target.pl` — all 10 tests pass (including new emission test)
- [x] Text parser tests pass
- [x] Existing indexing tests (`switch_on_constant`, `switch_on_term`, `indexing_backtrack`, `switch_on_constant_a2`, `switch_on_structure_and_term_a2`, `assoc_library`) — all 6 pass
- [x] 33-test broad sweep — running at PR-open time

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_