### PR TITLE
feat(wam-clojure): split atom_concat outputs

### DIFF
--- a/PR_WAM_CLOJURE_ATOM_CONCAT_SPLIT.md
+++ b/PR_WAM_CLOJURE_ATOM_CONCAT_SPLIT.md
@@ -1,0 +1,32 @@
+# PR Title
+
+feat(wam-clojure): split atom_concat outputs
+
+# PR Description
+
+## Summary
+
+- Extend the lowered Clojure WAM runtime handling for `atom_concat/3` and `string_concat/3` beyond fully-bound concatenation.
+- Add deterministic one-sided split support for cases where exactly one input side is unbound and the output text is bound.
+- Keep both-inputs-unbound split mode conservative because SWI-Prolog produces multiple possible splits.
+- Add runtime smoke coverage and generated-code assertions for the new atom and string split paths.
+
+## Behavior
+
+Supported deterministic modes now include:
+
+- `atom_concat(A, o, foo)` deriving `A = fo`
+- `atom_concat(fo, B, foo)` deriving `B = o`
+- `string_concat(A, o, foo)` deriving `A = fo`
+- `string_concat(fo, B, foo)` deriving `B = o`
+
+The ambiguous mode remains unsupported by the lowered fast path:
+
+- `atom_concat(A, B, foo)` still fails conservatively because it has multiple valid splits.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1223,13 +1223,33 @@
         out (deref-value (:bindings state)
                          (or (reg-get-raw state "A3") ::unbound))
         left-text (atom-text state left)
-        right-text (atom-text state right)]
-    (if (and (some? left-text) (some? right-text))
+        right-text (atom-text state right)
+        out-text (atom-text state out)]
+    (cond
+      (and (some? left-text) (some? right-text))
       (let [[next-state atom] (intern-text-atom state (str left-text right-text))
             [ok unified-state] (unify-values next-state out atom)]
         (if ok
           (advance unified-state)
           (backtrack state)))
+
+      (and (nil? left-text) (some? right-text) (some? out-text)
+           (str/ends-with? out-text right-text))
+      (let [prefix (subs out-text 0 (- (count out-text) (count right-text)))
+            [ok unified-state] (unify-text-atom-value state left prefix)]
+        (if ok
+          (advance unified-state)
+          (backtrack state)))
+
+      (and (some? left-text) (nil? right-text) (some? out-text)
+           (str/starts-with? out-text left-text))
+      (let [suffix (subs out-text (count left-text))
+            [ok unified-state] (unify-text-atom-value state right suffix)]
+        (if ok
+          (advance unified-state)
+          (backtrack state)))
+
+      :else
       (backtrack state))))
 
 (defn apply-atom-length-solution [state]

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -184,7 +184,11 @@
 :- dynamic user:wam_atom_concat_guard/3.
 :- dynamic user:wam_atom_concat_new_atom/0.
 :- dynamic user:wam_atom_concat_unbound_left/1.
+:- dynamic user:wam_atom_concat_unbound_right/1.
+:- dynamic user:wam_atom_concat_unbound_both/1.
 :- dynamic user:wam_string_concat_guard/3.
+:- dynamic user:wam_string_concat_unbound_left/1.
+:- dynamic user:wam_string_concat_unbound_right/1.
 :- dynamic user:wam_atom_length_guard/2.
 :- dynamic user:wam_atom_length_unbound/1.
 :- dynamic user:wam_string_length_guard/2.
@@ -399,8 +403,12 @@ user:wam_number_chars_guard(N, C) :- number_chars(N, C).
 user:wam_text_conversion_unbound_pair(_) :- user:wam_unbound_arg(A), user:wam_unbound_arg(C), atom_codes(A, C).
 user:wam_atom_concat_guard(A, B, C) :- atom_concat(A, B, C).
 user:wam_atom_concat_new_atom :- atom_concat(fo, o, X), X = foo.
-user:wam_atom_concat_unbound_left(C) :- user:wam_unbound_arg(A), atom_concat(A, o, C).
+user:wam_atom_concat_unbound_left(C) :- user:wam_unbound_arg(A), atom_concat(A, o, C), A = fo.
+user:wam_atom_concat_unbound_right(C) :- user:wam_unbound_arg(B), atom_concat(fo, B, C), B = o.
+user:wam_atom_concat_unbound_both(C) :- user:wam_unbound_arg(A), user:wam_unbound_arg(B), atom_concat(A, B, C).
 user:wam_string_concat_guard(A, B, C) :- string_concat(A, B, C).
+user:wam_string_concat_unbound_left(C) :- user:wam_unbound_arg(A), string_concat(A, o, C), A = fo.
+user:wam_string_concat_unbound_right(C) :- user:wam_unbound_arg(B), string_concat(fo, B, C), B = o.
 user:wam_atom_length_guard(A, N) :- atom_length(A, N).
 user:wam_atom_length_unbound(N) :- user:wam_unbound_arg(A), atom_length(A, N).
 user:wam_string_length_guard(A, N) :- string_length(A, N).
@@ -621,7 +629,11 @@ run_smoke :-
           user:wam_atom_concat_guard/3,
           user:wam_atom_concat_new_atom/0,
           user:wam_atom_concat_unbound_left/1,
+          user:wam_atom_concat_unbound_right/1,
+          user:wam_atom_concat_unbound_both/1,
           user:wam_string_concat_guard/3,
+          user:wam_string_concat_unbound_left/1,
+          user:wam_string_concat_unbound_right/1,
           user:wam_atom_length_guard/2,
           user:wam_atom_length_unbound/1,
           user:wam_string_length_guard/2,
@@ -1005,8 +1017,14 @@ smoke_cases([
     case('wam_atom_concat_guard/3', args(fo, o, foo), "true"),
     case('wam_atom_concat_guard/3', args(fo, o, bar), "false"),
     case('wam_atom_concat_new_atom/0', no_args, "true"),
-    case('wam_atom_concat_unbound_left/1', foo, "false"),
+    case('wam_atom_concat_unbound_left/1', foo, "true"),
+    case('wam_atom_concat_unbound_left/1', bar, "false"),
+    case('wam_atom_concat_unbound_right/1', foo, "true"),
+    case('wam_atom_concat_unbound_right/1', bar, "false"),
+    case('wam_atom_concat_unbound_both/1', foo, "false"),
     case('wam_string_concat_guard/3', args(fo, o, foo), "true"),
+    case('wam_string_concat_unbound_left/1', foo, "true"),
+    case('wam_string_concat_unbound_right/1', foo, "true"),
     case('wam_atom_length_guard/2', args(foo, 3), "true"),
     case('wam_atom_length_guard/2', args(foo, 2), "false"),
     case('wam_atom_length_unbound/1', 0, "false"),
@@ -1369,6 +1387,10 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-number-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-number-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-atom-concat-guard-3"),
+    has(CoreCode, "defn lowered-wam-atom-concat-unbound-left-1"),
+    has(CoreCode, "defn lowered-wam-atom-concat-unbound-right-1"),
+    has(CoreCode, "defn lowered-wam-string-concat-unbound-left-1"),
+    has(CoreCode, "defn lowered-wam-string-concat-unbound-right-1"),
     has(CoreCode, "defn lowered-wam-atom-length-guard-2"),
     has(CoreCode, "defn lowered-wam-sub-atom-extract-0"),
     has(CoreCode, "runtime/ground-term?"),


### PR DESCRIPTION
## Summary

- Extend the lowered Clojure WAM runtime handling for `atom_concat/3` and `string_concat/3` beyond fully-bound concatenation.
- Add deterministic one-sided split support for cases where exactly one input side is unbound and the output text is bound.
- Keep both-inputs-unbound split mode conservative because SWI-Prolog produces multiple possible splits.
- Add runtime smoke coverage and generated-code assertions for the new atom and string split paths.

## Behavior

Supported deterministic modes now include:

- `atom_concat(A, o, foo)` deriving `A = fo`
- `atom_concat(fo, B, foo)` deriving `B = o`
- `string_concat(A, o, foo)` deriving `A = fo`
- `string_concat(fo, B, foo)` deriving `B = o`

The ambiguous mode remains unsupported by the lowered fast path:

- `atom_concat(A, B, foo)` still fails conservatively because it has multiple valid splits.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
