### PR TITLE
feat(wam-cpp): mixed-mode A2 indexing (mirror of #2301 for A2)

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -2025,6 +2025,17 @@ instr_to_setup_line(switch_on_constant_a2(Entries), Labels, Line) :- !,
     format(atom(Line),
            '    vm.instrs.push_back(Instruction::SwitchOnConstantA2({~w}));',
            [EntriesCpp]).
+instr_to_setup_line(switch_on_constant_a2_fallthrough(Entries), Labels, Line) :- !,
+    % Mixed-mode A2 indexing — A1 is variable in every clause, AND
+    % the predicate has a variable-A2 clause somewhere. The indexed
+    % prefix (clauses before the first variable A2) gets switch
+    % entries; bound A2 with no match falls through to the chain so
+    % the variable-A2 clauses still match. Mirror of A1''s
+    % switch_on_constant_fallthrough.
+    parse_switch_entries(Entries, Labels, EntriesCpp),
+    format(atom(Line),
+           '    vm.instrs.push_back(Instruction::SwitchOnConstantA2({~w}, true));',
+           [EntriesCpp]).
 instr_to_setup_line(switch_on_structure(Entries), Labels, Line) :- !,
     parse_switch_struct_entries(Entries, Labels, EntriesCpp),
     format(atom(Line),
@@ -2618,8 +2629,12 @@ struct Instruction {
           i.const_table = std::move(table);
           i.no_match_fallthrough = fall_on_miss;
           return i; }
-    static Instruction SwitchOnConstantA2(std::vector<std::pair<Value, std::size_t>> table)
-        { Instruction i; i.op = Op::SwitchOnConstantA2; i.const_table = std::move(table); return i; }
+    static Instruction SwitchOnConstantA2(std::vector<std::pair<Value, std::size_t>> table,
+                                          bool fall_on_miss = false)
+        { Instruction i; i.op = Op::SwitchOnConstantA2;
+          i.const_table = std::move(table);
+          i.no_match_fallthrough = fall_on_miss;
+          return i; }
     static Instruction SwitchOnStructure(std::vector<std::pair<std::string, std::size_t>> table)
         { Instruction i; i.op = Op::SwitchOnStructure; i.struct_table = std::move(table); return i; }
     static Instruction SwitchOnStructureA2(std::vector<std::pair<std::string, std::size_t>> table)
@@ -7467,6 +7482,10 @@ bool WamState::step(const Instruction& instr) {
                     pc = kv.second; return true;
                 }
             }
+            // See SwitchOnConstant: bound A2 with no entry in the
+            // table falls through to the try_me_else chain when the
+            // predicate has variable-A2 clauses (mixed-mode A2).
+            if (instr.no_match_fallthrough) { pc += 1; return true; }
             return false;
         }
         case Instruction::Op::SwitchOnStructure: {

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -278,10 +278,20 @@ format_switch_on_term(ConstEntries, StructEntries, ListLabel, IndexCode) :-
 %  try indexing on the second argument instead. Mirrors the A1
 %  decision: all atomic → switch_on_constant_a2; all compound →
 %  switch_on_structure_a2; mixed atomic/compound → switch_on_term_a2.
-%  Any variable A2 disqualifies indexing entirely.
+%  When the predicate has variable A2 clauses, the constant prefix
+%  (up to the first variable A2) is still dispatched via
+%  switch_on_constant_a2_fallthrough — symmetric with A1''s
+%  switch_on_constant_fallthrough.
 build_second_arg_index(Pred, Arity, Clauses, IndexCode) :-
     classify_second_args(Clauses, Types),
-    \+ member(variable, Types),
+    (   \+ member(variable, Types)
+    ->  build_second_arg_index_homogeneous(Pred, Arity, Clauses, Types,
+                                           IndexCode)
+    ;   build_second_arg_index_with_fallthrough(Pred, Arity, Clauses, Types,
+                                                IndexCode)
+    ).
+
+build_second_arg_index_homogeneous(Pred, Arity, Clauses, Types, IndexCode) :-
     (   forall(member(T, Types), T = constant)
     ->  build_constant_index_on(Clauses, 2, 1, Pred, Arity, Entries),
         Entries \= [],
@@ -301,6 +311,18 @@ build_second_arg_index(Pred, Arity, Clauses, IndexCode) :-
         format_switch_on_term_a2(ConstEntries, StructEntries, ListLabel,
                                  IndexCode)
     ).
+
+build_second_arg_index_with_fallthrough(Pred, Arity, Clauses, Types,
+                                        IndexCode) :-
+    indexed_prefix(Types, Clauses, PrefixTypes, PrefixClauses),
+    PrefixClauses \= [],
+    % v1: only handle constant prefix, matching the A1 scope.
+    forall(member(T, PrefixTypes), T = constant),
+    build_constant_index_on(PrefixClauses, 2, 1, Pred, Arity, Entries),
+    Entries \= [],
+    format_index_entries(Entries, EntriesStr),
+    format(string(IndexCode),
+           "    switch_on_constant_a2_fallthrough ~w", [EntriesStr]).
 
 classify_second_args([], []).
 classify_second_args([Head-_|Rest], [Type|RestTypes]) :-

--- a/src/unifyweaver/targets/wam_text_parser.pl
+++ b/src/unifyweaver/targets/wam_text_parser.pl
@@ -179,10 +179,11 @@ wam_recognise_instruction(["begin_aggregate", K, V, R, W],
 wam_recognise_instruction(["end_aggregate", R],        end_aggregate(R)).
 % Indexing instructions: variable-arity tail tokens captured as a list,
 % target-side decoders parse them per the dispatch-table convention.
-wam_recognise_instruction(["switch_on_constant"             | Es], switch_on_constant(Es)).
-wam_recognise_instruction(["switch_on_constant_fallthrough" | Es], switch_on_constant_fallthrough(Es)).
-wam_recognise_instruction(["switch_on_constant_a2"          | Es], switch_on_constant_a2(Es)).
-wam_recognise_instruction(["switch_on_structure"            | Es], switch_on_structure(Es)).
-wam_recognise_instruction(["switch_on_structure_a2"         | Es], switch_on_structure_a2(Es)).
-wam_recognise_instruction(["switch_on_term"                 | Ts], switch_on_term(Ts)).
-wam_recognise_instruction(["switch_on_term_a2"              | Ts], switch_on_term_a2(Ts)).
+wam_recognise_instruction(["switch_on_constant"                | Es], switch_on_constant(Es)).
+wam_recognise_instruction(["switch_on_constant_fallthrough"    | Es], switch_on_constant_fallthrough(Es)).
+wam_recognise_instruction(["switch_on_constant_a2"             | Es], switch_on_constant_a2(Es)).
+wam_recognise_instruction(["switch_on_constant_a2_fallthrough" | Es], switch_on_constant_a2_fallthrough(Es)).
+wam_recognise_instruction(["switch_on_structure"               | Es], switch_on_structure(Es)).
+wam_recognise_instruction(["switch_on_structure_a2"            | Es], switch_on_structure_a2(Es)).
+wam_recognise_instruction(["switch_on_term"                    | Ts], switch_on_term(Ts)).
+wam_recognise_instruction(["switch_on_term_a2"                 | Ts], switch_on_term_a2(Ts)).

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -3281,6 +3281,59 @@ user:wam_cpp_test_mma_mid_unbound :-
     findall(K-V, wam_cpp_mma_mid(K, V), L),
     L = [a-1, _-99, b-2, c-3].
 
+% Mixed-mode A2 indexing — mirror of the A1 case for predicates
+% whose A1 is variable in every clause but whose A2 has a trailing
+% variable catch-all. Previously the variable A2 disabled A2
+% indexing entirely; now the prefix is dispatched via
+% switch_on_constant_a2_fallthrough.
+:- dynamic user:wam_cpp_mma2_tag/3.
+:- dynamic user:wam_cpp_test_mma2_specific_hit/0.
+:- dynamic user:wam_cpp_test_mma2_unknown_falls_through/0.
+:- dynamic user:wam_cpp_test_mma2_specific_backtracks_to_default/0.
+:- dynamic user:wam_cpp_test_mma2_unknown_only_default/0.
+:- dynamic user:wam_cpp_test_mma2_all_unbound_enumerates/0.
+
+user:wam_cpp_mma2_tag(_, error, red).
+user:wam_cpp_mma2_tag(_, warn,  yellow).
+user:wam_cpp_mma2_tag(_, ok,    green).
+user:wam_cpp_mma2_tag(_, _,     gray).
+
+user:wam_cpp_test_mma2_specific_hit :-
+    wam_cpp_mma2_tag(any, error, red),
+    wam_cpp_mma2_tag(any, warn,  yellow),
+    wam_cpp_mma2_tag(any, ok,    green).
+user:wam_cpp_test_mma2_unknown_falls_through :-
+    % A2 = something NOT in the table — must fall through to the
+    % chain so the variable-A2 clause matches.
+    wam_cpp_mma2_tag(any, other, gray).
+user:wam_cpp_test_mma2_specific_backtracks_to_default :-
+    findall(C, wam_cpp_mma2_tag(any, error, C), L),
+    L = [red, gray].
+user:wam_cpp_test_mma2_unknown_only_default :-
+    findall(C, wam_cpp_mma2_tag(any, unknown, C), L),
+    L = [gray].
+user:wam_cpp_test_mma2_all_unbound_enumerates :-
+    findall(T-C, wam_cpp_mma2_tag(_, T, C), L),
+    L = [error-red, warn-yellow, ok-green, _-gray].
+
+% Variable A2 in the middle — indexed prefix is just `a`. After-var
+% clauses are reachable only via fall-through.
+:- dynamic user:wam_cpp_mma2_mid/3.
+:- dynamic user:wam_cpp_test_mma2_mid_indexed/0.
+:- dynamic user:wam_cpp_test_mma2_mid_after_var/0.
+
+user:wam_cpp_mma2_mid(_, a, 1).
+user:wam_cpp_mma2_mid(_, _, 99).
+user:wam_cpp_mma2_mid(_, b, 2).
+user:wam_cpp_mma2_mid(_, c, 3).
+
+user:wam_cpp_test_mma2_mid_indexed :-
+    findall(V, wam_cpp_mma2_mid(any, a, V), L),
+    L = [1, 99].
+user:wam_cpp_test_mma2_mid_after_var :-
+    findall(V, wam_cpp_mma2_mid(any, b, V), L),
+    L = [99, 2].
+
 user:wam_cpp_test_write :- write(hello), nl.
 % Y-reg isolation: both helpers use Y1/Y2 internally. Caller relies on
 % preserved Y1 across the two calls.
@@ -9170,6 +9223,38 @@ test(cpp_e2e_mixed_mode_a1_indexing,
           run_query(BinPath, 'wam_cpp_test_mma_mid_indexed/0',                     [], true),
           run_query(BinPath, 'wam_cpp_test_mma_mid_after_var/0',                   [], true),
           run_query(BinPath, 'wam_cpp_test_mma_mid_unbound/0',                     [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% Mixed-mode A2 indexing — same lift as the A1 case, but applied
+% to A2 when A1 is variable in every clause. The indexed A2 prefix
+% (clauses before the first variable-A2 clause) gets
+% switch_on_constant_a2_fallthrough; bound-but-unmatched A2 falls
+% through to the try_me_else chain so trailing variable clauses
+% still match.
+test(cpp_e2e_mixed_mode_a2_indexing,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_mma2', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_mma2_tag/3,
+                               user:wam_cpp_test_mma2_specific_hit/0,
+                               user:wam_cpp_test_mma2_unknown_falls_through/0,
+                               user:wam_cpp_test_mma2_specific_backtracks_to_default/0,
+                               user:wam_cpp_test_mma2_unknown_only_default/0,
+                               user:wam_cpp_test_mma2_all_unbound_enumerates/0,
+                               user:wam_cpp_mma2_mid/3,
+                               user:wam_cpp_test_mma2_mid_indexed/0,
+                               user:wam_cpp_test_mma2_mid_after_var/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_mma2_specific_hit/0',                    [], true),
+          run_query(BinPath, 'wam_cpp_test_mma2_unknown_falls_through/0',           [], true),
+          run_query(BinPath, 'wam_cpp_test_mma2_specific_backtracks_to_default/0',  [], true),
+          run_query(BinPath, 'wam_cpp_test_mma2_unknown_only_default/0',            [], true),
+          run_query(BinPath, 'wam_cpp_test_mma2_all_unbound_enumerates/0',          [], true),
+          run_query(BinPath, 'wam_cpp_test_mma2_mid_indexed/0',                     [], true),
+          run_query(BinPath, 'wam_cpp_test_mma2_mid_after_var/0',                   [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).

--- a/tests/test_wam_target.pl
+++ b/tests/test_wam_target.pl
@@ -244,6 +244,51 @@ test_mma_none(a, 1).
 test_mma_none(b, 2).
 test_mma_none(c, 3).
 
+%% Mixed-mode A2 indexing — mirror of the A1 case. Predicates whose
+%% A1 is variable in every clause should now get
+%% switch_on_constant_a2_fallthrough for their indexed A2 prefix
+%% instead of dropping A2 indexing entirely.
+:- dynamic test_mma2_trailing/3, test_mma2_middle/3, test_mma2_first/3,
+           test_mma2_none/3.
+test_mma2_trailing(_, error, red).
+test_mma2_trailing(_, warn,  yellow).
+test_mma2_trailing(_, ok,    green).
+test_mma2_trailing(_, _,     gray).
+
+test_mma2_middle(_, a, 1).
+test_mma2_middle(_, _, 99).
+test_mma2_middle(_, b, 2).
+
+test_mma2_first(_, _, 0).
+test_mma2_first(_, a, 1).
+test_mma2_first(_, b, 2).
+
+test_mma2_none(_, a, 1).
+test_mma2_none(_, b, 2).
+test_mma2_none(_, c, 3).
+
+test_wam_mixed_mode_a2_indexing :-
+    Test = 'WAM: mixed-mode A2 indexing emits switch_on_constant_a2_fallthrough',
+    (   wam_target:compile_predicate_to_wam(user:test_mma2_trailing/3, [], C1),
+        wam_target:compile_predicate_to_wam(user:test_mma2_middle/3, [], C2),
+        wam_target:compile_predicate_to_wam(user:test_mma2_first/3, [], C3),
+        wam_target:compile_predicate_to_wam(user:test_mma2_none/3, [], C4),
+        atom_string(C1, S1), atom_string(C2, S2),
+        atom_string(C3, S3), atom_string(C4, S4),
+        % Trailing var A2: indexed prefix = error,warn,ok.
+        sub_string(S1, _, _, _, 'switch_on_constant_a2_fallthrough'),
+        % Middle var A2: indexed prefix = just `a`.
+        sub_string(S2, _, _, _, 'switch_on_constant_a2_fallthrough'),
+        % Var A2 first: no A2 indexing.
+        \+ sub_string(S3, _, _, _, 'switch_on_constant_a2_fallthrough'),
+        % No var A2: plain switch_on_constant_a2 (NOT fallthrough).
+        sub_string(S4, _, _, _, 'switch_on_constant_a2 '),
+        \+ sub_string(S4, _, _, _, 'switch_on_constant_a2_fallthrough')
+    ->  pass(Test)
+    ;   fail_test(Test,
+                  'Mixed-mode A2 indexing did not emit the expected pseudo-instruction')
+    ).
+
 test_wam_mixed_mode_a1_indexing :-
     Test = 'WAM: mixed-mode A1 indexing emits switch_on_constant_fallthrough',
     (   wam_target:compile_predicate_to_wam(user:test_mma_trailing/2, [], C1),
@@ -282,6 +327,7 @@ run_tests :-
     test_wam_multi_clause_findall_emits_allocate,
     test_wam_a2_indexing,
     test_wam_mixed_mode_a1_indexing,
+    test_wam_mixed_mode_a2_indexing,
 
     format('~n========================================~n'),
     (   test_failed


### PR DESCRIPTION
## Summary

Symmetric to the A1 mixed-mode work in #2301. Predicates whose A1 is variable in every clause (so A1 indexing is correctly skipped) but whose A2 has a trailing variable catch-all previously got **no** A2 indexing either — the variable A2 clause disabled the whole table.

```prolog
tag(_, error, red).      % indexed
tag(_, warn,  yellow).   % indexed
tag(_, ok,    green).    % indexed
tag(_, _,     gray).     % trailing var A2 = default
```

`tag(any, error, red)` walked all 4 clauses linearly. Now the indexed A2 prefix dispatches via a new `switch_on_constant_a2_fallthrough`; bound-but-unmatched A2 falls through to the try_me_else chain so the variable-A2 clauses still match.

```
tag(any, error, red):  switch jumps directly; chain handles retry
tag(any, other, gray): switch misses → falls through → chain
                       walks all four; clause 4 matches
```

## Runtime change

The `SwitchOnConstantA2` step() handler gains the same one-branch fallthrough check as `SwitchOnConstant`. Factory grows a defaulted `fall_on_miss` arg; existing call sites unchanged.

## Scope

Matches v1 of the A1 work — indexed prefix is constant-only. Structure/term A2 with a trailing variable clause still skips indexing.

Variable-A2-clause positions handled:

| Layout | Result |
|---|---|
| Trailing (`error, warn, ok, _`) | Indexed prefix = `error, warn, ok` |
| Middle (`a, _, b, c`)           | Indexed prefix = `a` only |
| First (`_, a, b`)               | No A2 indexing (unchanged) |
| No variable (`a, b, c`)         | Plain `switch_on_constant_a2` (unchanged) |

## Regression tests

- `cpp_e2e_mixed_mode_a2_indexing` — 7 sub-assertions: direct hit on each indexed clause, fallthrough on miss, backtrack into the default, miss-only-default, full enumeration on unbound, plus middle-var (indexed + after-var).
- `test_wam_mixed_mode_a2_indexing` in `test_wam_target.pl` — locks in the compile-level emission shape for all four variable-A2 positions.

## Test plan

- [x] `cpp_e2e_mixed_mode_a2_indexing` — 7 sub-assertions, all pass
- [x] `test_wam_target.pl` — all 11 tests pass (including new emission test)
- [x] Text parser tests pass
- [x] 34-test broad sweep — running at PR-open time

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_