### PR TITLE
feat(wam-cpp): structure / term mixed-mode indexing

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -2041,20 +2041,47 @@ instr_to_setup_line(switch_on_structure(Entries), Labels, Line) :- !,
     format(atom(Line),
            '    vm.instrs.push_back(Instruction::SwitchOnStructure({~w}));',
            [EntriesCpp]).
+instr_to_setup_line(switch_on_structure_fallthrough(Entries), Labels, Line) :- !,
+    % Mixed-mode A1 indexing for compound prefixes — see
+    % switch_on_constant_fallthrough for the rationale. Bound A1
+    % whose functor isn''t in the table falls through to the chain
+    % so the trailing variable-A1 clauses still match.
+    parse_switch_struct_entries(Entries, Labels, EntriesCpp),
+    format(atom(Line),
+           '    vm.instrs.push_back(Instruction::SwitchOnStructure({~w}, true));',
+           [EntriesCpp]).
 instr_to_setup_line(switch_on_structure_a2(Entries), Labels, Line) :- !,
     parse_switch_struct_entries(Entries, Labels, EntriesCpp),
     format(atom(Line),
            '    vm.instrs.push_back(Instruction::SwitchOnStructureA2({~w}));',
+           [EntriesCpp]).
+instr_to_setup_line(switch_on_structure_a2_fallthrough(Entries), Labels, Line) :- !,
+    parse_switch_struct_entries(Entries, Labels, EntriesCpp),
+    format(atom(Line),
+           '    vm.instrs.push_back(Instruction::SwitchOnStructureA2({~w}, true));',
            [EntriesCpp]).
 instr_to_setup_line(switch_on_term(Tokens), Labels, Line) :- !,
     parse_switch_term(Tokens, Labels, ConstsCpp, StructsCpp, ListPC),
     format(atom(Line),
            '    vm.instrs.push_back(Instruction::SwitchOnTerm({~w}, {~w}, ~w));',
            [ConstsCpp, StructsCpp, ListPC]).
+instr_to_setup_line(switch_on_term_fallthrough(Tokens), Labels, Line) :- !,
+    % Mixed-mode for prefixes that mix constants and structures
+    % (including lists). Reads/writes both const_table and
+    % struct_table; bound A1 with no match in either falls through.
+    parse_switch_term(Tokens, Labels, ConstsCpp, StructsCpp, ListPC),
+    format(atom(Line),
+           '    vm.instrs.push_back(Instruction::SwitchOnTerm({~w}, {~w}, ~w, true));',
+           [ConstsCpp, StructsCpp, ListPC]).
 instr_to_setup_line(switch_on_term_a2(Tokens), Labels, Line) :- !,
     parse_switch_term(Tokens, Labels, ConstsCpp, StructsCpp, ListPC),
     format(atom(Line),
            '    vm.instrs.push_back(Instruction::SwitchOnTermA2({~w}, {~w}, ~w));',
+           [ConstsCpp, StructsCpp, ListPC]).
+instr_to_setup_line(switch_on_term_a2_fallthrough(Tokens), Labels, Line) :- !,
+    parse_switch_term(Tokens, Labels, ConstsCpp, StructsCpp, ListPC),
+    format(atom(Line),
+           '    vm.instrs.push_back(Instruction::SwitchOnTermA2({~w}, {~w}, ~w, true));',
            [ConstsCpp, StructsCpp, ListPC]).
 instr_to_setup_line(catch_return, _Labels, Line) :- !,
     Line = '    vm.instrs.push_back(Instruction::CatchReturn());'.
@@ -2683,25 +2710,37 @@ private:
         for (auto& kv : i.const_table) i.const_map.try_emplace(kv.first, kv.second);
     }
 public:
-    static Instruction SwitchOnStructure(std::vector<std::pair<std::string, std::size_t>> table)
-        { Instruction i; i.op = Op::SwitchOnStructure; i.struct_table = std::move(table); return i; }
-    static Instruction SwitchOnStructureA2(std::vector<std::pair<std::string, std::size_t>> table)
-        { Instruction i; i.op = Op::SwitchOnStructureA2; i.struct_table = std::move(table); return i; }
+    static Instruction SwitchOnStructure(std::vector<std::pair<std::string, std::size_t>> table,
+                                         bool fall_on_miss = false)
+        { Instruction i; i.op = Op::SwitchOnStructure;
+          i.struct_table = std::move(table);
+          i.no_match_fallthrough = fall_on_miss;
+          return i; }
+    static Instruction SwitchOnStructureA2(std::vector<std::pair<std::string, std::size_t>> table,
+                                           bool fall_on_miss = false)
+        { Instruction i; i.op = Op::SwitchOnStructureA2;
+          i.struct_table = std::move(table);
+          i.no_match_fallthrough = fall_on_miss;
+          return i; }
     static Instruction SwitchOnTerm(std::vector<std::pair<Value, std::size_t>> consts,
                                     std::vector<std::pair<std::string, std::size_t>> structs,
-                                    std::size_t list_pc)
+                                    std::size_t list_pc,
+                                    bool fall_on_miss = false)
         { Instruction i; i.op = Op::SwitchOnTerm;
           i.const_table = std::move(consts);
           i.struct_table = std::move(structs);
           i.target = list_pc;
+          i.no_match_fallthrough = fall_on_miss;
           return i; }
     static Instruction SwitchOnTermA2(std::vector<std::pair<Value, std::size_t>> consts,
                                       std::vector<std::pair<std::string, std::size_t>> structs,
-                                      std::size_t list_pc)
+                                      std::size_t list_pc,
+                                      bool fall_on_miss = false)
         { Instruction i; i.op = Op::SwitchOnTermA2;
           i.const_table = std::move(consts);
           i.struct_table = std::move(structs);
           i.target = list_pc;
+          i.no_match_fallthrough = fall_on_miss;
           return i; }
     static Instruction CatchReturn()
         { Instruction i; i.op = Op::CatchReturn; return i; }
@@ -7542,11 +7581,18 @@ bool WamState::step(const Instruction& instr) {
             for (auto& kv : instr.struct_table) {
                 if (kv.first == a.s) {
                     if (kv.second == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
-                    if (kv.second == Instruction::SWITCH_NONE)    return false;
+                    if (kv.second == Instruction::SWITCH_NONE) {
+                        if (instr.no_match_fallthrough) { pc += 1; return true; }
+                        return false;
+                    }
                     indexed_entry = true;
                     pc = kv.second; return true;
                 }
             }
+            // Bound compound with no matching functor entry. Mixed-mode
+            // mirror of SwitchOnConstant: fall through to the chain if
+            // the predicate has variable-headed clauses.
+            if (instr.no_match_fallthrough) { pc += 1; return true; }
             return false;
         }
         case Instruction::Op::SwitchOnStructureA2: {
@@ -7558,11 +7604,15 @@ bool WamState::step(const Instruction& instr) {
             for (auto& kv : instr.struct_table) {
                 if (kv.first == a.s) {
                     if (kv.second == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
-                    if (kv.second == Instruction::SWITCH_NONE)    return false;
+                    if (kv.second == Instruction::SWITCH_NONE) {
+                        if (instr.no_match_fallthrough) { pc += 1; return true; }
+                        return false;
+                    }
                     indexed_entry = true;
                     pc = kv.second; return true;
                 }
             }
+            if (instr.no_match_fallthrough) { pc += 1; return true; }
             return false;
         }
         case Instruction::Op::SwitchOnTerm: {
@@ -7580,28 +7630,39 @@ bool WamState::step(const Instruction& instr) {
                 for (auto& kv : instr.const_table) {
                     if (kv.first == a) {
                         if (kv.second == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
-                        if (kv.second == Instruction::SWITCH_NONE)    return false;
+                        if (kv.second == Instruction::SWITCH_NONE) {
+                            if (instr.no_match_fallthrough) { pc += 1; return true; }
+                            return false;
+                        }
                         indexed_entry = true;
                         pc = kv.second; return true;
                     }
                 }
+                if (instr.no_match_fallthrough) { pc += 1; return true; }
                 return false;
             }
             if (a.tag == Value::Tag::Compound) {
                 if (a.s == "[|]/2") {
                     if (instr.target == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
-                    if (instr.target == Instruction::SWITCH_NONE)    return false;
+                    if (instr.target == Instruction::SWITCH_NONE) {
+                        if (instr.no_match_fallthrough) { pc += 1; return true; }
+                        return false;
+                    }
                     indexed_entry = true;
                     pc = instr.target; return true;
                 }
                 for (auto& kv : instr.struct_table) {
                     if (kv.first == a.s) {
                         if (kv.second == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
-                        if (kv.second == Instruction::SWITCH_NONE)    return false;
+                        if (kv.second == Instruction::SWITCH_NONE) {
+                            if (instr.no_match_fallthrough) { pc += 1; return true; }
+                            return false;
+                        }
                         indexed_entry = true;
                         pc = kv.second; return true;
                     }
                 }
+                if (instr.no_match_fallthrough) { pc += 1; return true; }
                 return false;
             }
             pc += 1; return true;
@@ -7616,28 +7677,39 @@ bool WamState::step(const Instruction& instr) {
                 for (auto& kv : instr.const_table) {
                     if (kv.first == a) {
                         if (kv.second == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
-                        if (kv.second == Instruction::SWITCH_NONE)    return false;
+                        if (kv.second == Instruction::SWITCH_NONE) {
+                            if (instr.no_match_fallthrough) { pc += 1; return true; }
+                            return false;
+                        }
                         indexed_entry = true;
                         pc = kv.second; return true;
                     }
                 }
+                if (instr.no_match_fallthrough) { pc += 1; return true; }
                 return false;
             }
             if (a.tag == Value::Tag::Compound) {
                 if (a.s == "[|]/2") {
                     if (instr.target == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
-                    if (instr.target == Instruction::SWITCH_NONE)    return false;
+                    if (instr.target == Instruction::SWITCH_NONE) {
+                        if (instr.no_match_fallthrough) { pc += 1; return true; }
+                        return false;
+                    }
                     indexed_entry = true;
                     pc = instr.target; return true;
                 }
                 for (auto& kv : instr.struct_table) {
                     if (kv.first == a.s) {
                         if (kv.second == Instruction::SWITCH_DEFAULT) { pc += 1; return true; }
-                        if (kv.second == Instruction::SWITCH_NONE)    return false;
+                        if (kv.second == Instruction::SWITCH_NONE) {
+                            if (instr.no_match_fallthrough) { pc += 1; return true; }
+                            return false;
+                        }
                         indexed_entry = true;
                         pc = kv.second; return true;
                     }
                 }
+                if (instr.no_match_fallthrough) { pc += 1; return true; }
                 return false;
             }
             pc += 1; return true;

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -179,13 +179,36 @@ build_first_arg_index_homogeneous(Pred, Arity, Clauses, Types, IndexCode) :-
 build_first_arg_index_with_fallthrough(Pred, Arity, Clauses, Types, IndexCode) :-
     indexed_prefix(Types, Clauses, PrefixTypes, PrefixClauses),
     PrefixClauses \= [],
-    % v1: only handle constant prefix.
-    forall(member(T, PrefixTypes), T = constant),
-    build_constant_index(PrefixClauses, 1, Pred, Arity, Entries),
-    Entries \= [],
-    format_index_entries(Entries, EntriesStr),
+    (   forall(member(T, PrefixTypes), T = constant)
+    ->  build_constant_index(PrefixClauses, 1, Pred, Arity, Entries),
+        Entries \= [],
+        format_index_entries(Entries, EntriesStr),
+        format(string(IndexCode),
+               "    switch_on_constant_fallthrough ~w", [EntriesStr])
+    ;   forall(member(T, PrefixTypes), T = structure),
+        \+ first_args_contain_list(PrefixClauses)
+    ->  build_structure_index(PrefixClauses, 1, Pred, Arity, Entries),
+        Entries \= [],
+        format_index_entries(Entries, EntriesStr),
+        format(string(IndexCode),
+               "    switch_on_structure_fallthrough ~w", [EntriesStr])
+    ;   % Mixed atomic/compound (including lists) — switch_on_term
+        % with fallthrough semantics on every miss path.
+        build_term_index(PrefixClauses, 1, Pred, Arity, PrefixTypes,
+                         ConstEntries, StructEntries, ListLabel),
+        format_switch_on_term_fallthrough(ConstEntries, StructEntries,
+                                          ListLabel, IndexCode)
+    ).
+
+format_switch_on_term_fallthrough(ConstEntries, StructEntries, ListLabel,
+                                  IndexCode) :-
+    length(ConstEntries, CLen),
+    length(StructEntries, SLen),
+    format_index_entries(ConstEntries, CStr),
+    format_index_entries(StructEntries, SStr),
     format(string(IndexCode),
-           "    switch_on_constant_fallthrough ~w", [EntriesStr]).
+           "    switch_on_term_fallthrough ~w ~w ~w ~w ~w",
+           [CLen, CStr, SLen, SStr, ListLabel]).
 
 %% indexed_prefix(+Types, +Clauses, -PrefixTypes, -PrefixClauses)
 %  Take clauses up to (but not including) the first one whose A1 is
@@ -316,13 +339,34 @@ build_second_arg_index_with_fallthrough(Pred, Arity, Clauses, Types,
                                         IndexCode) :-
     indexed_prefix(Types, Clauses, PrefixTypes, PrefixClauses),
     PrefixClauses \= [],
-    % v1: only handle constant prefix, matching the A1 scope.
-    forall(member(T, PrefixTypes), T = constant),
-    build_constant_index_on(PrefixClauses, 2, 1, Pred, Arity, Entries),
-    Entries \= [],
-    format_index_entries(Entries, EntriesStr),
+    (   forall(member(T, PrefixTypes), T = constant)
+    ->  build_constant_index_on(PrefixClauses, 2, 1, Pred, Arity, Entries),
+        Entries \= [],
+        format_index_entries(Entries, EntriesStr),
+        format(string(IndexCode),
+               "    switch_on_constant_a2_fallthrough ~w", [EntriesStr])
+    ;   forall(member(T, PrefixTypes), T = structure),
+        \+ second_args_contain_list(PrefixClauses)
+    ->  build_structure_index_on(PrefixClauses, 2, 1, Pred, Arity, Entries),
+        Entries \= [],
+        format_index_entries(Entries, EntriesStr),
+        format(string(IndexCode),
+               "    switch_on_structure_a2_fallthrough ~w", [EntriesStr])
+    ;   build_term_index_on(PrefixClauses, 2, 1, Pred, Arity, PrefixTypes,
+                            ConstEntries, StructEntries, ListLabel),
+        format_switch_on_term_a2_fallthrough(ConstEntries, StructEntries,
+                                             ListLabel, IndexCode)
+    ).
+
+format_switch_on_term_a2_fallthrough(ConstEntries, StructEntries, ListLabel,
+                                     IndexCode) :-
+    length(ConstEntries, CLen),
+    length(StructEntries, SLen),
+    format_index_entries(ConstEntries, CStr),
+    format_index_entries(StructEntries, SStr),
     format(string(IndexCode),
-           "    switch_on_constant_a2_fallthrough ~w", [EntriesStr]).
+           "    switch_on_term_a2_fallthrough ~w ~w ~w ~w ~w",
+           [CLen, CStr, SLen, SStr, ListLabel]).
 
 classify_second_args([], []).
 classify_second_args([Head-_|Rest], [Type|RestTypes]) :-

--- a/src/unifyweaver/targets/wam_text_parser.pl
+++ b/src/unifyweaver/targets/wam_text_parser.pl
@@ -179,11 +179,15 @@ wam_recognise_instruction(["begin_aggregate", K, V, R, W],
 wam_recognise_instruction(["end_aggregate", R],        end_aggregate(R)).
 % Indexing instructions: variable-arity tail tokens captured as a list,
 % target-side decoders parse them per the dispatch-table convention.
-wam_recognise_instruction(["switch_on_constant"                | Es], switch_on_constant(Es)).
-wam_recognise_instruction(["switch_on_constant_fallthrough"    | Es], switch_on_constant_fallthrough(Es)).
-wam_recognise_instruction(["switch_on_constant_a2"             | Es], switch_on_constant_a2(Es)).
-wam_recognise_instruction(["switch_on_constant_a2_fallthrough" | Es], switch_on_constant_a2_fallthrough(Es)).
-wam_recognise_instruction(["switch_on_structure"               | Es], switch_on_structure(Es)).
-wam_recognise_instruction(["switch_on_structure_a2"            | Es], switch_on_structure_a2(Es)).
-wam_recognise_instruction(["switch_on_term"                    | Ts], switch_on_term(Ts)).
-wam_recognise_instruction(["switch_on_term_a2"                 | Ts], switch_on_term_a2(Ts)).
+wam_recognise_instruction(["switch_on_constant"                 | Es], switch_on_constant(Es)).
+wam_recognise_instruction(["switch_on_constant_fallthrough"     | Es], switch_on_constant_fallthrough(Es)).
+wam_recognise_instruction(["switch_on_constant_a2"              | Es], switch_on_constant_a2(Es)).
+wam_recognise_instruction(["switch_on_constant_a2_fallthrough"  | Es], switch_on_constant_a2_fallthrough(Es)).
+wam_recognise_instruction(["switch_on_structure"                | Es], switch_on_structure(Es)).
+wam_recognise_instruction(["switch_on_structure_fallthrough"    | Es], switch_on_structure_fallthrough(Es)).
+wam_recognise_instruction(["switch_on_structure_a2"             | Es], switch_on_structure_a2(Es)).
+wam_recognise_instruction(["switch_on_structure_a2_fallthrough" | Es], switch_on_structure_a2_fallthrough(Es)).
+wam_recognise_instruction(["switch_on_term"                     | Ts], switch_on_term(Ts)).
+wam_recognise_instruction(["switch_on_term_fallthrough"         | Ts], switch_on_term_fallthrough(Ts)).
+wam_recognise_instruction(["switch_on_term_a2"                  | Ts], switch_on_term_a2(Ts)).
+wam_recognise_instruction(["switch_on_term_a2_fallthrough"      | Ts], switch_on_term_a2_fallthrough(Ts)).

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -3334,6 +3334,105 @@ user:wam_cpp_test_mma2_mid_after_var :-
     findall(V, wam_cpp_mma2_mid(any, b, V), L),
     L = [99, 2].
 
+% Mixed-mode for STRUCTURE-only A1 prefix — closes the v1 limit
+% from #2301. Predicates like the canonical tree-recursive shape
+% (all-compound clauses + a trailing catch-all) now get
+% switch_on_structure_fallthrough instead of dropping A1 indexing.
+:- dynamic user:wam_cpp_mma_struct/2.
+:- dynamic user:wam_cpp_test_mma_struct_hit/0.
+:- dynamic user:wam_cpp_test_mma_struct_unknown_functor/0.
+:- dynamic user:wam_cpp_test_mma_struct_backtracks_to_default/0.
+:- dynamic user:wam_cpp_test_mma_struct_unknown_only_default/0.
+
+user:wam_cpp_mma_struct(circle(_),       round).
+user:wam_cpp_mma_struct(square(_),       angular).
+user:wam_cpp_mma_struct(triangle(_,_,_), pointy).
+user:wam_cpp_mma_struct(_,               unknown).
+
+user:wam_cpp_test_mma_struct_hit :-
+    wam_cpp_mma_struct(circle(1),         round),
+    wam_cpp_mma_struct(square(2),         angular),
+    wam_cpp_mma_struct(triangle(1, 2, 3), pointy).
+user:wam_cpp_test_mma_struct_unknown_functor :-
+    % A1 functor isn''t in the table — must fall through to the chain.
+    wam_cpp_mma_struct(rhombus(4), unknown).
+user:wam_cpp_test_mma_struct_backtracks_to_default :-
+    findall(R, wam_cpp_mma_struct(circle(1), R), L),
+    L = [round, unknown].
+user:wam_cpp_test_mma_struct_unknown_only_default :-
+    findall(R, wam_cpp_mma_struct(hexagon(_), R), L),
+    L = [unknown].
+
+% Mixed-mode for MIXED A1 prefix (atoms + structures) — closes the
+% other v1 limit. Pattern: arithmetic-style head with `zero` atom
+% plus `succ(_)` / `plus(_,_)` structures and a catch-all.
+:- dynamic user:wam_cpp_mma_term/2.
+:- dynamic user:wam_cpp_test_mma_term_hit_atom/0.
+:- dynamic user:wam_cpp_test_mma_term_hit_struct/0.
+:- dynamic user:wam_cpp_test_mma_term_unknown_atom/0.
+:- dynamic user:wam_cpp_test_mma_term_unknown_struct/0.
+:- dynamic user:wam_cpp_test_mma_term_backtracks/0.
+
+user:wam_cpp_mma_term(zero,         leaf).
+user:wam_cpp_mma_term(succ(_),      unary).
+user:wam_cpp_mma_term(plus(_, _),   binary).
+user:wam_cpp_mma_term(_,            other).
+
+user:wam_cpp_test_mma_term_hit_atom :-
+    wam_cpp_mma_term(zero, leaf).
+user:wam_cpp_test_mma_term_hit_struct :-
+    wam_cpp_mma_term(succ(7), unary),
+    wam_cpp_mma_term(plus(1, 2), binary).
+user:wam_cpp_test_mma_term_unknown_atom :-
+    % Bound atom NOT in the table — fall through.
+    wam_cpp_mma_term(unknown_atom, other).
+user:wam_cpp_test_mma_term_unknown_struct :-
+    % Bound compound whose functor isn''t in the table — fall through.
+    wam_cpp_mma_term(times(1, 2), other).
+user:wam_cpp_test_mma_term_backtracks :-
+    findall(R, wam_cpp_mma_term(zero, R), L),
+    L = [leaf, other].
+
+% Same lift on A2: structure-only prefix when A1 is variable.
+:- dynamic user:wam_cpp_mma_struct_a2/3.
+:- dynamic user:wam_cpp_test_mma_struct_a2_hit/0.
+:- dynamic user:wam_cpp_test_mma_struct_a2_unknown/0.
+:- dynamic user:wam_cpp_test_mma_struct_a2_backtracks/0.
+
+user:wam_cpp_mma_struct_a2(_, circle(_),       round).
+user:wam_cpp_mma_struct_a2(_, square(_),       angular).
+user:wam_cpp_mma_struct_a2(_, triangle(_,_,_), pointy).
+user:wam_cpp_mma_struct_a2(_, _,               unknown).
+
+user:wam_cpp_test_mma_struct_a2_hit :-
+    wam_cpp_mma_struct_a2(any, circle(1), round),
+    wam_cpp_mma_struct_a2(any, square(2), angular).
+user:wam_cpp_test_mma_struct_a2_unknown :-
+    wam_cpp_mma_struct_a2(any, hexagon(6), unknown).
+user:wam_cpp_test_mma_struct_a2_backtracks :-
+    findall(R, wam_cpp_mma_struct_a2(any, circle(1), R), L),
+    L = [round, unknown].
+
+% Same lift on A2: mixed prefix when A1 is variable.
+:- dynamic user:wam_cpp_mma_term_a2/3.
+:- dynamic user:wam_cpp_test_mma_term_a2_hit_atom/0.
+:- dynamic user:wam_cpp_test_mma_term_a2_hit_struct/0.
+:- dynamic user:wam_cpp_test_mma_term_a2_unknown/0.
+
+user:wam_cpp_mma_term_a2(_, zero,       leaf).
+user:wam_cpp_mma_term_a2(_, succ(_),    unary).
+user:wam_cpp_mma_term_a2(_, plus(_, _), binary).
+user:wam_cpp_mma_term_a2(_, _,          other).
+
+user:wam_cpp_test_mma_term_a2_hit_atom :-
+    wam_cpp_mma_term_a2(any, zero, leaf).
+user:wam_cpp_test_mma_term_a2_hit_struct :-
+    wam_cpp_mma_term_a2(any, succ(1), unary),
+    wam_cpp_mma_term_a2(any, plus(2, 3), binary).
+user:wam_cpp_test_mma_term_a2_unknown :-
+    wam_cpp_mma_term_a2(any, times(1, 2), other),
+    wam_cpp_mma_term_a2(any, unknown_atom, other).
+
 user:wam_cpp_test_write :- write(hello), nl.
 % Y-reg isolation: both helpers use Y1/Y2 internally. Caller relies on
 % preserved Y1 across the two calls.
@@ -9223,6 +9322,56 @@ test(cpp_e2e_mixed_mode_a1_indexing,
           run_query(BinPath, 'wam_cpp_test_mma_mid_indexed/0',                     [], true),
           run_query(BinPath, 'wam_cpp_test_mma_mid_after_var/0',                   [], true),
           run_query(BinPath, 'wam_cpp_test_mma_mid_unbound/0',                     [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+% Mixed-mode for structure / mixed (term) A1 prefixes — closes the
+% v1 limits from #2301 and #2303. The "indexed prefix" lift now
+% extends past constant-only: pure-structure prefix (tree-recursive
+% pattern) gets switch_on_structure_fallthrough, and mixed atom +
+% structure prefix (arithmetic-style with `zero` + `succ`/`plus`)
+% gets switch_on_term_fallthrough.
+test(cpp_e2e_mixed_mode_struct_term_indexing,
+     [condition(cpp_compiler_available)]) :-
+    unique_cpp_tmp_dir('tmp_cpp_e2e_mma_st', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_mma_struct/2,
+                               user:wam_cpp_test_mma_struct_hit/0,
+                               user:wam_cpp_test_mma_struct_unknown_functor/0,
+                               user:wam_cpp_test_mma_struct_backtracks_to_default/0,
+                               user:wam_cpp_test_mma_struct_unknown_only_default/0,
+                               user:wam_cpp_mma_term/2,
+                               user:wam_cpp_test_mma_term_hit_atom/0,
+                               user:wam_cpp_test_mma_term_hit_struct/0,
+                               user:wam_cpp_test_mma_term_unknown_atom/0,
+                               user:wam_cpp_test_mma_term_unknown_struct/0,
+                               user:wam_cpp_test_mma_term_backtracks/0,
+                               user:wam_cpp_mma_struct_a2/3,
+                               user:wam_cpp_test_mma_struct_a2_hit/0,
+                               user:wam_cpp_test_mma_struct_a2_unknown/0,
+                               user:wam_cpp_test_mma_struct_a2_backtracks/0,
+                               user:wam_cpp_mma_term_a2/3,
+                               user:wam_cpp_test_mma_term_a2_hit_atom/0,
+                               user:wam_cpp_test_mma_term_a2_hit_struct/0,
+                               user:wam_cpp_test_mma_term_a2_unknown/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_mma_struct_hit/0',                    [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_struct_unknown_functor/0',        [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_struct_backtracks_to_default/0',  [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_struct_unknown_only_default/0',   [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_term_hit_atom/0',                 [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_term_hit_struct/0',               [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_term_unknown_atom/0',             [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_term_unknown_struct/0',           [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_term_backtracks/0',               [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_struct_a2_hit/0',                 [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_struct_a2_unknown/0',             [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_struct_a2_backtracks/0',          [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_term_a2_hit_atom/0',              [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_term_a2_hit_struct/0',            [], true),
+          run_query(BinPath, 'wam_cpp_test_mma_term_a2_unknown/0',               [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).

--- a/tests/test_wam_target.pl
+++ b/tests/test_wam_target.pl
@@ -267,6 +267,42 @@ test_mma2_none(_, a, 1).
 test_mma2_none(_, b, 2).
 test_mma2_none(_, c, 3).
 
+%% Mixed-mode A1 indexing for structure-only and mixed (term)
+%% prefixes — the v1 limits from #2301 / #2303.
+:- dynamic test_mma_struct/2, test_mma_term/2,
+           test_mma_struct_a2/3, test_mma_term_a2/3.
+test_mma_struct(circle(_), 1).
+test_mma_struct(square(_), 2).
+test_mma_struct(_,         0).
+
+test_mma_term(zero,        1).
+test_mma_term(succ(_),     2).
+test_mma_term(_,           0).
+
+test_mma_struct_a2(_, circle(_), 1).
+test_mma_struct_a2(_, square(_), 2).
+test_mma_struct_a2(_, _,         0).
+
+test_mma_term_a2(_, zero,    1).
+test_mma_term_a2(_, succ(_), 2).
+test_mma_term_a2(_, _,       0).
+
+test_wam_mixed_mode_struct_term_indexing :-
+    Test = 'WAM: mixed-mode struct/term indexing emits new fallthrough opcodes',
+    (   wam_target:compile_predicate_to_wam(user:test_mma_struct/2, [], C1),
+        wam_target:compile_predicate_to_wam(user:test_mma_term/2, [], C2),
+        wam_target:compile_predicate_to_wam(user:test_mma_struct_a2/3, [], C3),
+        wam_target:compile_predicate_to_wam(user:test_mma_term_a2/3, [], C4),
+        atom_string(C1, S1), atom_string(C2, S2),
+        atom_string(C3, S3), atom_string(C4, S4),
+        sub_string(S1, _, _, _, 'switch_on_structure_fallthrough'),
+        sub_string(S2, _, _, _, 'switch_on_term_fallthrough'),
+        sub_string(S3, _, _, _, 'switch_on_structure_a2_fallthrough'),
+        sub_string(S4, _, _, _, 'switch_on_term_a2_fallthrough')
+    ->  pass(Test)
+    ;   fail_test(Test, 'struct/term mixed-mode did not emit the expected pseudo-instruction')
+    ).
+
 test_wam_mixed_mode_a2_indexing :-
     Test = 'WAM: mixed-mode A2 indexing emits switch_on_constant_a2_fallthrough',
     (   wam_target:compile_predicate_to_wam(user:test_mma2_trailing/3, [], C1),
@@ -328,6 +364,7 @@ run_tests :-
     test_wam_a2_indexing,
     test_wam_mixed_mode_a1_indexing,
     test_wam_mixed_mode_a2_indexing,
+    test_wam_mixed_mode_struct_term_indexing,
 
     format('~n========================================~n'),
     (   test_failed


### PR DESCRIPTION
## Summary

Closes the v1 limit explicitly noted in #2301 and #2303: when the indexed prefix is all-structure or mixed atom+structure, predicates with a trailing variable-A1 clause now get O(1) dispatch instead of dropping A1 indexing entirely.

Common patterns this newly indexes:

```prolog
shape(circle(_), round).        % switch_on_structure_fallthrough
shape(square(_), angular).
shape(triangle(_,_,_), pointy).
shape(_, unknown).

eval(zero, leaf).               % switch_on_term_fallthrough
eval(succ(_), unary).           %   (atom + structure prefix)
eval(plus(_,_), binary).
eval(_, other).
```

Both have A2 mirrors for predicates whose A1 is variable in every clause.

## New pseudo-instructions

```
switch_on_structure_fallthrough
switch_on_structure_a2_fallthrough
switch_on_term_fallthrough
switch_on_term_a2_fallthrough
```

## Runtime change

The four affected factories (`SwitchOnStructure{,A2}`, `SwitchOnTerm{,A2}`) grow a defaulted `fall_on_miss` arg. Existing call sites unchanged. Step handlers honour `no_match_fallthrough` on every "bound but no indexed match" path, including the `SWITCH_NONE` sentinel branches:

- no entry for the bound atom/integer/float in `const_table`
- no entry for the bound compound functor in `struct_table`
- `[|]/2` with list-pc == `SWITCH_NONE`
- `SWITCH_NONE` on a `struct_table` entry

## WAM compiler change

The existing `build_first_arg_index_with_fallthrough` (and A2 variant) relaxed their constant-only check. They now also handle:

- pure-structure prefix → `switch_on_structure_fallthrough`
- mixed atom+structure prefix → `switch_on_term_fallthrough`

Same shape as the existing homogeneous emit (`build_structure_index` / `build_term_index` reused on the prefix instead of the whole clause list), with a fallthrough opcode name instead.

Variable-A1-clause positions handled (now uniform across constant / structure / term prefixes):

| Layout            | Result                                       |
| ----------------- | -------------------------------------------- |
| Trailing default  | Indexed prefix = all non-variable clauses    |
| Middle variable   | Indexed prefix = clauses before the variable |
| First variable    | No A1 indexing (unchanged)                   |
| No variable       | Plain `switch_on_*` (unchanged)              |

## Regression tests

- `cpp_e2e_mixed_mode_struct_term_indexing` — **15 sub-assertions** covering struct-only and mixed prefix shapes, A1 and A2, hit on each indexed clause, fallthrough on unknown functor / unknown atom, backtrack into the default, miss-only-default.
- `test_wam_mixed_mode_struct_term_indexing` in `test_wam_target.pl` — locks in the compile-level emission shape for all four new pseudo-instructions.

## Stacking

This PR is **stacked on #2306** (hash const_table). Base branch is set to `feat/wam-cpp-hash-const-table`. After #2306 merges, GitHub will auto-rebase the base to `main`.

## Test plan

- [x] `cpp_e2e_mixed_mode_struct_term_indexing` — 15 sub-assertions, all pass
- [x] `test_wam_target.pl` — all 12 tests pass (incl. new emission test)
- [x] Text parser tests pass
- [x] Existing indexing tests (8 e2e) — all pass
- [x] 26-test broad sweep clean — 40 dots, zero errors

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_