### PR TITLE
feat(wam-clojure): render numeric sub_atom text

### DIFF
--- a/PR_WAM_CLOJURE_SUB_ATOM_NUMERIC_TEXT.md
+++ b/PR_WAM_CLOJURE_SUB_ATOM_NUMERIC_TEXT.md
@@ -1,0 +1,27 @@
+# PR Title
+
+feat(wam-clojure): render numeric sub_atom text
+
+# PR Description
+
+## Summary
+
+- Extend the Clojure WAM `sub_atom/5` runtime helper to render numeric source values through `atom-number-text`.
+- Extend bound `Sub` matching to accept numeric runtime values through the same text-rendering path.
+- Add smoke coverage for numeric source and numeric sub arguments without widening unsupported source-unbound behavior.
+
+## Behavior
+
+This brings Clojure WAM `sub_atom/5` closer to the C++ WAM runtime behavior for rendered atomic text values:
+
+- `sub_atom(A, 1, 3, 1, 234)` succeeds for runtime argument `A = 12345`.
+- `sub_atom(12345, 1, 2, _, S)` succeeds for runtime argument `S = 23`.
+
+Existing atom/string `sub_atom/5` modes remain unchanged, including conservative failure for unbound source values.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1286,9 +1286,8 @@
                      (when (and (integer? n*) (not (neg? n*)) (<= n* n)) n*)
                      (when (or (= after ::unbound) (logic-var? after)) ::var))
         sub-text (cond
-                   (atom-term? sub) (atom-text state sub)
                    (or (= sub ::unbound) (logic-var? sub)) ::var
-                   :else nil)]
+                   :else (atom-number-text state sub))]
     (when (and (some? before-spec)
                (some? length-spec)
                (some? after-spec)
@@ -1320,7 +1319,7 @@
                            (or (reg-get-raw base-state "A4") ::unbound))
         sub (deref-value (:bindings base-state)
                          (or (reg-get-raw base-state "A5") ::unbound))
-        text (atom-text base-state source)]
+        text (atom-number-text base-state source)]
     (if-let [results (and (some? text)
                           (sub-atom-solution-results base-state text before length after sub))]
       (apply-first-foreign-solution base-state resume-pc results)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -198,6 +198,8 @@
 :- dynamic user:wam_sub_atom_backtrack_later_before/0.
 :- dynamic user:wam_sub_atom_length_bound_later_before/0.
 :- dynamic user:wam_sub_atom_no_match/0.
+:- dynamic user:wam_sub_atom_numeric_source_arg/1.
+:- dynamic user:wam_sub_atom_numeric_sub_arg/1.
 :- dynamic user:wam_sub_atom_unbound_source/1.
 :- dynamic user:wam_arith_eq_42/1.
 :- dynamic user:wam_arith_eq_float/1.
@@ -418,6 +420,8 @@ user:wam_sub_atom_suffix :- sub_atom(hello, _, 3, 0, llo).
 user:wam_sub_atom_backtrack_later_before :- sub_atom(abcabc, B, _, _, b), B =:= 4.
 user:wam_sub_atom_length_bound_later_before :- sub_atom(abcabc, B, 1, _, b), B =:= 4.
 user:wam_sub_atom_no_match :- sub_atom(abc, _, _, _, xyz).
+user:wam_sub_atom_numeric_source_arg(A) :- sub_atom(A, 1, 3, 1, 234).
+user:wam_sub_atom_numeric_sub_arg(S) :- sub_atom(12345, 1, 2, _, S).
 user:wam_sub_atom_unbound_source(_) :- user:wam_unbound_arg(A), sub_atom(A, 0, 1, _, _).
 user:wam_arith_eq_42(X) :- X =:= 42.
 user:wam_arith_eq_float(X) :- X =:= 3.5.
@@ -643,6 +647,8 @@ run_smoke :-
           user:wam_sub_atom_backtrack_later_before/0,
           user:wam_sub_atom_length_bound_later_before/0,
           user:wam_sub_atom_no_match/0,
+          user:wam_sub_atom_numeric_source_arg/1,
+          user:wam_sub_atom_numeric_sub_arg/1,
           user:wam_sub_atom_unbound_source/1,
           user:wam_arith_eq_42/1,
           user:wam_arith_eq_float/1,
@@ -1035,6 +1041,8 @@ smoke_cases([
     case('wam_sub_atom_backtrack_later_before/0', no_args, "true"),
     case('wam_sub_atom_length_bound_later_before/0', no_args, "true"),
     case('wam_sub_atom_no_match/0', no_args, "false"),
+    case('wam_sub_atom_numeric_source_arg/1', 12345, "true"),
+    case('wam_sub_atom_numeric_sub_arg/1', 23, "true"),
     case('wam_sub_atom_unbound_source/1', a, "false"),
     case('wam_arith_eq_42/1', 42, "true"),
     case('wam_arith_eq_42/1', 3.5, "false"),


### PR DESCRIPTION
## Summary

- Extend the Clojure WAM `sub_atom/5` runtime helper to render numeric source values through `atom-number-text`.
- Extend bound `Sub` matching to accept numeric runtime values through the same text-rendering path.
- Add smoke coverage for numeric source and numeric sub arguments without widening unsupported source-unbound behavior.

## Behavior

This brings Clojure WAM `sub_atom/5` closer to the C++ WAM runtime behavior for rendered atomic text values:

- `sub_atom(A, 1, 3, 1, 234)` succeeds for runtime argument `A = 12345`.
- `sub_atom(12345, 1, 2, _, S)` succeeds for runtime argument `S = 23`.

Existing atom/string `sub_atom/5` modes remain unchanged, including conservative failure for unbound source values.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
