### PR TITLE
feat(wam-clojure): lower forward char_type checks

### DIFF
--- a/PR_WAM_CLOJURE_CHAR_TYPE_FORWARD.md
+++ b/PR_WAM_CLOJURE_CHAR_TYPE_FORWARD.md
@@ -1,0 +1,41 @@
+# PR Title
+
+feat(wam-clojure): lower forward char_type checks
+
+# PR Description
+
+## Summary
+
+- Add `char_type/2` to the Clojure WAM direct builtin set.
+- Add a conservative Clojure runtime helper for forward character classification when both arguments are bound.
+- Add runtime smoke coverage for alpha, digit/alnum, space/whitespace, and a negative lower-case check.
+
+## Behavior
+
+The Clojure WAM runtime now handles deterministic forward checks such as:
+
+- `char_type(a, alpha)`
+- `char_type(C, digit)` after deriving `C` with `char_code(C, 0'5)`
+- `char_type(C, space)` and `char_type(C, whitespace)` after deriving `C` with `char_code(C, 32)`
+- `char_type('A', lower)` correctly fails
+
+Supported class atoms in this slice:
+
+- `alpha`
+- `alnum`
+- `digit`
+- `upper`
+- `lower`
+- `space`
+- `whitespace`
+- `ascii`
+- `punct`
+
+Compound `char_type/2` forms such as `upper(Lower)`, `lower(Upper)`, `to_upper/1`, `to_lower/1`, `digit/1`, and `code/1` remain follow-up work.
+
+## Validation
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -508,6 +508,10 @@ clojure_direct_builtin("char_code/2", "2").
 clojure_direct_builtin("char_code/2", 2).
 clojure_direct_builtin('char_code/2', "2").
 clojure_direct_builtin('char_code/2', 2).
+clojure_direct_builtin("char_type/2", "2").
+clojure_direct_builtin("char_type/2", 2).
+clojure_direct_builtin('char_type/2', "2").
+clojure_direct_builtin('char_type/2', 2).
 clojure_direct_builtin("atom_concat/3", "3").
 clojure_direct_builtin("atom_concat/3", 3).
 clojure_direct_builtin('atom_concat/3', "3").
@@ -901,6 +905,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "char_code/2" ; Op == 'char_code/2'),
     !,
     format(atom(Expr), '(runtime/apply-char-code-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "char_type/2" ; Op == 'char_type/2'),
+    !,
+    format(atom(Expr), '(runtime/apply-char-type-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (   Op == "atom_concat/3" ; Op == 'atom_concat/3'

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1215,6 +1215,34 @@
       :else
       (backtrack state))))
 
+(defn char-type-class? [ch class-name]
+  (case class-name
+    "alpha" (Character/isLetter ch)
+    "alnum" (Character/isLetterOrDigit ch)
+    "digit" (Character/isDigit ch)
+    "upper" (Character/isUpperCase ch)
+    "lower" (Character/isLowerCase ch)
+    "whitespace" (Character/isWhitespace ch)
+    "space" (Character/isWhitespace ch)
+    "ascii" (<= (int ch) 127)
+    "punct" (and (<= (int ch) 127)
+                 (not (Character/isLetterOrDigit ch))
+                 (not (Character/isWhitespace ch)))
+    false))
+
+(defn apply-char-type-solution [state]
+  (let [char-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        type-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A2") ::unbound))
+        char-text (char-code-text state char-value)
+        type-text (atom-text state type-value)]
+    (if (and (some? char-text)
+             (some? type-text)
+             (char-type-class? (first char-text) type-text))
+      (advance state)
+      (backtrack state))))
+
 (defn apply-atom-concat-solution [state]
   (let [left (deref-value (:bindings state)
                           (or (reg-get-raw state "A1") ::unbound))
@@ -2174,6 +2202,9 @@
 
           "char_code/2"
           (apply-char-code-solution state)
+
+          "char_type/2"
+          (apply-char-type-solution state)
 
           "atom_concat/3"
           (apply-atom-concat-solution state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -177,6 +177,10 @@
 :- dynamic user:wam_char_code_reverse/0.
 :- dynamic user:wam_char_code_bad_char/0.
 :- dynamic user:wam_char_code_unbound_pair/1.
+:- dynamic user:wam_char_type_alpha/0.
+:- dynamic user:wam_char_type_digit/0.
+:- dynamic user:wam_char_type_space/0.
+:- dynamic user:wam_char_type_lower_fail/0.
 :- dynamic user:wam_number_codes_guard/2.
 :- dynamic user:wam_number_codes_reverse/0.
 :- dynamic user:wam_number_chars_guard/2.
@@ -399,6 +403,10 @@ user:wam_char_code_guard(C, N) :- char_code(C, N).
 user:wam_char_code_reverse :- char_code(C, 65), C = 'A'.
 user:wam_char_code_bad_char :- char_code(ab, _).
 user:wam_char_code_unbound_pair(_) :- user:wam_unbound_arg(C), user:wam_unbound_arg(N), char_code(C, N).
+user:wam_char_type_alpha :- char_type(a, alpha).
+user:wam_char_type_digit :- char_code(C, 0'5), char_type(C, digit), char_type(C, alnum).
+user:wam_char_type_space :- char_code(C, 32), char_type(C, space), char_type(C, whitespace).
+user:wam_char_type_lower_fail :- char_type('A', lower).
 user:wam_number_codes_guard(N, C) :- number_codes(N, C).
 user:wam_number_codes_reverse :- number_codes(N, [52,50]), N =:= 42.
 user:wam_number_chars_guard(N, C) :- number_chars(N, C).
@@ -626,6 +634,10 @@ run_smoke :-
           user:wam_char_code_reverse/0,
           user:wam_char_code_bad_char/0,
           user:wam_char_code_unbound_pair/1,
+          user:wam_char_type_alpha/0,
+          user:wam_char_type_digit/0,
+          user:wam_char_type_space/0,
+          user:wam_char_type_lower_fail/0,
           user:wam_number_codes_guard/2,
           user:wam_number_codes_reverse/0,
           user:wam_number_chars_guard/2,
@@ -1014,6 +1026,10 @@ smoke_cases([
     case('wam_char_code_reverse/0', no_args, "true"),
     case('wam_char_code_bad_char/0', no_args, "false"),
     case('wam_char_code_unbound_pair/1', a, "false"),
+    case('wam_char_type_alpha/0', no_args, "true"),
+    case('wam_char_type_digit/0', no_args, "true"),
+    case('wam_char_type_space/0', no_args, "true"),
+    case('wam_char_type_lower_fail/0', no_args, "false"),
     case('wam_number_codes_guard/2', args(42, '[52,50]'), "true"),
     case('wam_number_codes_guard/2', args(42, '[52]'), "false"),
     case('wam_number_codes_reverse/0', no_args, "true"),
@@ -1392,6 +1408,7 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-string-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-string-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-char-code-guard-2"),
+    has(CoreCode, "defn lowered-wam-char-type-alpha-0"),
     has(CoreCode, "defn lowered-wam-number-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-number-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-atom-concat-guard-3"),
@@ -1408,6 +1425,7 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "runtime/apply-atom-case-solution"),
     has(CoreCode, "runtime/apply-atomic-list-concat-solution"),
     has(CoreCode, "runtime/apply-char-code-solution"),
+    has(CoreCode, "runtime/apply-char-type-solution"),
     has(CoreCode, "runtime/apply-atom-concat-solution"),
     has(CoreCode, "runtime/apply-atom-length-solution"),
     has(CoreCode, "runtime/apply-sub-atom-solution").


### PR DESCRIPTION
## Summary

- Add `char_type/2` to the Clojure WAM direct builtin set.
- Add a conservative Clojure runtime helper for forward character classification when both arguments are bound.
- Add runtime smoke coverage for alpha, digit/alnum, space/whitespace, and a negative lower-case check.

## Behavior

The Clojure WAM runtime now handles deterministic forward checks such as:

- `char_type(a, alpha)`
- `char_type(C, digit)` after deriving `C` with `char_code(C, 0'5)`
- `char_type(C, space)` and `char_type(C, whitespace)` after deriving `C` with `char_code(C, 32)`
- `char_type('A', lower)` correctly fails

Supported class atoms in this slice:

- `alpha`
- `alnum`
- `digit`
- `upper`
- `lower`
- `space`
- `whitespace`
- `ascii`
- `punct`

Compound `char_type/2` forms such as `upper(Lower)`, `lower(Upper)`, `to_upper/1`, `to_lower/1`, `digit/1`, and `code/1` remain follow-up work.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
