### PR TITLE
Feat/wam go atom codes builtin

### DIFF
--- a/PR_go_wam_atom_codes_builtin.md
+++ b/PR_go_wam_atom_codes_builtin.md
@@ -1,0 +1,25 @@
+# PR Title
+
+Add Go WAM atom_codes/2 parity
+
+# PR Description
+
+## Summary
+
+- Add direct Go WAM lowering for `atom_codes/2`.
+- Implement runtime atom/code-list conversion for atom-to-codes and codes-to-atom modes.
+- Handle bound code-list comparison through decoded text, including lists materialized through heap cons cells inside `\+/1`.
+- Cover forward, reverse, empty-atom, mismatch, both-unbound, and invalid-code cases in the generated Go WAM builtin E2E test.
+- Update the Go WAM parity audit to record atom/code-list conversion parity with the Clojure text conversion surface.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(atom_codes/2,2), G), writeln(G), halt"`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -14,7 +14,7 @@ current cross-target builtin/runtime baseline.
 | Structural builtins | `member/2`, `memberchk/2`, `select/3`, `delete/3`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `select/3`, `delete/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Arithmetic builtins | `is/2`, `succ/2` | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir | Present for current baseline arithmetic checks, with expanded successor coverage |
-| Atom/text conversion | `atom_number/2`, `atom_string/2`, `string_to_atom/2`, `upcase_atom/2`, `downcase_atom/2`, `atom_concat/3`, `atom_length/2`, `string_length/2`, `char_code/2` | Clojure direct builtin surface includes bidirectional `atom_number/2`, atom/string conversion, atom case conversion, deterministic atom concatenation, text length checks, and char-code conversion | Present for current atom-number, atom/string, atom-case, atom-concat, text-length, and char-code checks |
+| Atom/text conversion | `atom_number/2`, `atom_codes/2`, `atom_string/2`, `string_to_atom/2`, `upcase_atom/2`, `downcase_atom/2`, `atom_concat/3`, `atom_length/2`, `string_length/2`, `char_code/2` | Clojure direct builtin surface includes bidirectional `atom_number/2`, atom/code-list conversion, atom/string conversion, atom case conversion, deterministic atom concatenation, text length checks, and char-code conversion | Present for current atom-number, atom-code-list, atom/string, atom-case, atom-concat, text-length, and char-code checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` | Includes `=</2`; Haskell mode analysis and Clojure lowering also cover term-order comparisons | Present for current baseline comparisons, with expanded term-order coverage |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
 | Term inspection | `functor/3`, `arg/3` | `functor/3`, `arg/3` | Present |
@@ -88,6 +88,11 @@ current cross-target builtin/runtime baseline.
   E2E test for char-to-code binding, bound-code success, mismatch failure,
   code-to-char binding, multi-character atom failure, both-unbound failure,
   and invalid-code failure, matching the current Clojure char-code surface.
+- Bidirectional `atom_codes/2` is now covered by the generated Go WAM builtin
+  E2E test for atom-to-code-list binding, bound-list success, mismatch failure,
+  code-list-to-atom binding, empty-atom conversion, both-unbound failure, and
+  invalid-code failure, matching the current Clojure atom/code-list conversion
+  surface.
 - Bidirectional `atom_string/2` and `string_to_atom/2` are now covered by the
   generated Go WAM builtin E2E test for atom-to-text binding, bound-text
   success, mismatch failure, text-to-atom binding, and both-unbound failure,

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -484,6 +484,9 @@ wam_go_direct_builtin("string_length/2", 2, 'string_length/2').
 wam_go_direct_builtin(char_code/2, 2, 'char_code/2').
 wam_go_direct_builtin('char_code/2', 2, 'char_code/2').
 wam_go_direct_builtin("char_code/2", 2, 'char_code/2').
+wam_go_direct_builtin(atom_codes/2, 2, 'atom_codes/2').
+wam_go_direct_builtin('atom_codes/2', 2, 'atom_codes/2').
+wam_go_direct_builtin("atom_codes/2", 2, 'atom_codes/2').
 wam_go_direct_builtin(atom_string/2, 2, 'atom_string/2').
 wam_go_direct_builtin('atom_string/2', 2, 'atom_string/2').
 wam_go_direct_builtin("atom_string/2", 2, 'atom_string/2').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -948,6 +948,52 @@ func atomNumberValue(v Value) (Value, bool) {
 	}
 }
 
+func atomCodeList(text string) *List {
+	items := make([]Value, 0, len([]rune(text)))
+	for _, r := range text {
+		items = append(items, &Integer{Val: int64(r)})
+	}
+	return &List{Elements: items}
+}
+
+func codePointValue(v Value) (rune, bool) {
+	switch t := v.(type) {
+	case *Integer:
+		if t.Val < 0 || t.Val > 65535 {
+			return 0, false
+		}
+		return rune(t.Val), true
+	case *Atom:
+		parsed, ok := parseAtomNumberText(strings.TrimPrefix(t.Name, quotedNumericAtomPrefix))
+		if !ok {
+			return 0, false
+		}
+		integer, ok := parsed.(*Integer)
+		if !ok || integer.Val < 0 || integer.Val > 65535 {
+			return 0, false
+		}
+		return rune(integer.Val), true
+	default:
+		return 0, false
+	}
+}
+
+func (vm *WamState) codeListText(v Value) (string, bool) {
+	items, ok := vm.listToSlice(v)
+	if !ok {
+		return "", false
+	}
+	runes := make([]rune, 0, len(items))
+	for _, item := range items {
+		code, ok := codePointValue(vm.deref(item))
+		if !ok {
+			return "", false
+		}
+		runes = append(runes, code)
+	}
+	return string(runes), true
+}
+
 func (vm *WamState) Deref(v Value) Value {
 	return vm.deref(v)
 }
@@ -1193,6 +1239,25 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 				return false
 			}
 			return vm.Unify(arg1, internAtom(string(rune(code.Val))))
+		}
+		return false
+	case "atom_codes/2":
+		atomVal := vm.deref(arg1)
+		codeListVal := vm.deref(arg2)
+		if u, ok := codeListVal.(*Unbound); ok {
+			if next, ok := vm.heapConsAfterUnbound(u); ok {
+				codeListVal = vm.deref(next)
+			}
+		}
+		if atom, ok := atomVal.(*Atom); ok {
+			if _, unbound := codeListVal.(*Unbound); unbound {
+				return vm.Unify(arg2, atomCodeList(atom.Name))
+			}
+			text, ok := vm.codeListText(codeListVal)
+			return ok && atom.Name == text
+		}
+		if text, ok := vm.codeListText(codeListVal); ok {
+			return vm.Unify(arg1, internAtom(text))
 		}
 		return false
 	case "atom_string/2", "string_to_atom/2":

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -23,6 +23,7 @@
 :- dynamic user:test_atom_concat_builtin/0.
 :- dynamic user:test_atom_string_length_builtin/0.
 :- dynamic user:test_char_code_builtin/0.
+:- dynamic user:test_atom_codes_builtin/0.
 :- dynamic user:test_atom_string_builtin/0.
 :- dynamic user:test_set_aggregate/0.
 :- dynamic user:test_unify_builtin/0.
@@ -228,6 +229,21 @@ test(builtins_execution) :-
                 \+ char_code(_, -1),
                 \+ char_code(_, 65536)
             )),
+          assertz(user:test_atom_codes_builtin :-
+            (   atom_codes(foo, Codes),
+                Codes = [102,111,111],
+                atom_codes(foo, [102,111,111]),
+                \+ atom_codes(foo, [102,111]),
+                atom_codes(A2, [98,97,114]),
+                A2 == bar,
+                atom_codes('', Empty),
+                Empty = [],
+                \+ atom_codes(_, _),
+                \+ atom_codes(_, [-1]),
+                \+ atom_codes(_, [65536]),
+                \+ atom_codes(_, [foo]),
+                \+ atom_codes(_, [1.5])
+            )),
           assertz(user:test_atom_string_builtin :-
             (   atom_string(hello, S),
                 S == hello,
@@ -281,6 +297,7 @@ test(builtins_execution) :-
           retractall(user:test_atom_concat_builtin),
           retractall(user:test_atom_string_length_builtin),
           retractall(user:test_char_code_builtin),
+          retractall(user:test_atom_codes_builtin),
           retractall(user:test_atom_string_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
@@ -291,7 +308,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -346,6 +363,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "atom_length/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "string_length/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "char_code/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "atom_codes/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "atom_string/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "string_to_atom/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "\\\\+/1"')),
@@ -513,6 +531,14 @@ func main() {
 		fmt.Println("CHAR_CODE_FAILURE")
 	}
 
+	atomCodesVM := wam.NewWamState(wam.Test_atom_codes_builtinCode, wam.Test_atom_codes_builtinLabels)
+	atomCodesVM.PC = wam.Test_atom_codes_builtinStartPC
+	if atomCodesVM.Run() {
+		fmt.Println("ATOM_CODES_SUCCESS")
+	} else {
+		fmt.Println("ATOM_CODES_FAILURE")
+	}
+
 	atomStringVM := wam.NewWamState(wam.Test_atom_string_builtinCode, wam.Test_atom_string_builtinLabels)
 	atomStringVM.PC = wam.Test_atom_string_builtinStartPC
 	if atomStringVM.Run() {
@@ -588,6 +614,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "ATOM_CONCAT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_STRING_LENGTH_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "CHAR_CODE_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "ATOM_CODES_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_STRING_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM atom_codes/2 parity

## Summary

- Add direct Go WAM lowering for `atom_codes/2`.
- Implement runtime atom/code-list conversion for atom-to-codes and codes-to-atom modes.
- Handle bound code-list comparison through decoded text, including lists materialized through heap cons cells inside `\+/1`.
- Cover forward, reverse, empty-atom, mismatch, both-unbound, and invalid-code cases in the generated Go WAM builtin E2E test.
- Update the Go WAM parity audit to record atom/code-list conversion parity with the Clojure text conversion surface.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(atom_codes/2,2), G), writeln(G), halt"`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`
