### PR TITLE
feat(wam-clojure): support char_type code form

### DIFF
--- a/PR_WAM_CLOJURE_CHAR_TYPE_CODE.md
+++ b/PR_WAM_CLOJURE_CHAR_TYPE_CODE.md
@@ -1,0 +1,18 @@
+# PR Title
+
+feat(wam-clojure): support char_type code form
+
+# PR Description
+
+## Summary
+
+- Adds Clojure WAM runtime handling for `char_type(Char, code(Code))`.
+- Supports both forward validation from a known character to a code and reverse construction from a valid code to a character atom.
+- Adds smoke coverage for forward, reverse, and mismatch cases in the generated Clojure runtime fixture.
+
+## Testing
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1230,17 +1230,47 @@
                  (not (Character/isWhitespace ch)))
     false))
 
+(defn char-type-code-arg [state type-value]
+  (when (and (structure-term? type-value)
+             (= "code/1" (functor-key (:intern-context state) (:functor type-value)))
+             (= 1 (count (:args type-value))))
+    (first (:args type-value))))
+
 (defn apply-char-type-solution [state]
   (let [char-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A1") ::unbound))
         type-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A2") ::unbound))
         char-text (char-code-text state char-value)
-        type-text (atom-text state type-value)]
-    (if (and (some? char-text)
-             (some? type-text)
-             (char-type-class? (first char-text) type-text))
+        type-text (atom-text state type-value)
+        code-arg (char-type-code-arg state type-value)]
+    (cond
+      (and (some? char-text)
+           (some? type-text)
+           (char-type-class? (first char-text) type-text))
       (advance state)
+
+      (some? code-arg)
+      (let [code-value (deref-value (:bindings state) code-arg)
+            code (code-point-value state code-value)]
+        (cond
+          (some? char-text)
+          (let [[ok unified-state] (unify-values state code-value (int (first char-text)))]
+            (if ok
+              (advance unified-state)
+              (backtrack state)))
+
+          (valid-char-code? code)
+          (let [[next-state atom-term] (intern-text-atom state (str (char code)))
+                [ok unified-state] (unify-values next-state char-value atom-term)]
+            (if ok
+              (advance unified-state)
+              (backtrack state)))
+
+          :else
+          (backtrack state)))
+
+      :else
       (backtrack state))))
 
 (defn apply-atom-concat-solution [state]

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -180,6 +180,9 @@
 :- dynamic user:wam_char_type_alpha/0.
 :- dynamic user:wam_char_type_digit/0.
 :- dynamic user:wam_char_type_space/0.
+:- dynamic user:wam_char_type_code_forward/0.
+:- dynamic user:wam_char_type_code_reverse/0.
+:- dynamic user:wam_char_type_code_mismatch/0.
 :- dynamic user:wam_char_type_lower_fail/0.
 :- dynamic user:wam_number_codes_guard/2.
 :- dynamic user:wam_number_codes_reverse/0.
@@ -406,6 +409,9 @@ user:wam_char_code_unbound_pair(_) :- user:wam_unbound_arg(C), user:wam_unbound_
 user:wam_char_type_alpha :- char_type(a, alpha).
 user:wam_char_type_digit :- char_code(C, 0'5), char_type(C, digit), char_type(C, alnum).
 user:wam_char_type_space :- char_code(C, 32), char_type(C, space), char_type(C, whitespace).
+user:wam_char_type_code_forward :- char_type('A', code(C)), C =:= 65.
+user:wam_char_type_code_reverse :- char_type(C, code(97)), C = a.
+user:wam_char_type_code_mismatch :- char_type('A', code(66)).
 user:wam_char_type_lower_fail :- char_type('A', lower).
 user:wam_number_codes_guard(N, C) :- number_codes(N, C).
 user:wam_number_codes_reverse :- number_codes(N, [52,50]), N =:= 42.
@@ -637,6 +643,9 @@ run_smoke :-
           user:wam_char_type_alpha/0,
           user:wam_char_type_digit/0,
           user:wam_char_type_space/0,
+          user:wam_char_type_code_forward/0,
+          user:wam_char_type_code_reverse/0,
+          user:wam_char_type_code_mismatch/0,
           user:wam_char_type_lower_fail/0,
           user:wam_number_codes_guard/2,
           user:wam_number_codes_reverse/0,
@@ -1029,6 +1038,9 @@ smoke_cases([
     case('wam_char_type_alpha/0', no_args, "true"),
     case('wam_char_type_digit/0', no_args, "true"),
     case('wam_char_type_space/0', no_args, "true"),
+    case('wam_char_type_code_forward/0', no_args, "true"),
+    case('wam_char_type_code_reverse/0', no_args, "true"),
+    case('wam_char_type_code_mismatch/0', no_args, "false"),
     case('wam_char_type_lower_fail/0', no_args, "false"),
     case('wam_number_codes_guard/2', args(42, '[52,50]'), "true"),
     case('wam_number_codes_guard/2', args(42, '[52]'), "false"),
@@ -1409,6 +1421,7 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-string-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-char-code-guard-2"),
     has(CoreCode, "defn lowered-wam-char-type-alpha-0"),
+    has(CoreCode, "defn lowered-wam-char-type-code-forward-0"),
     has(CoreCode, "defn lowered-wam-number-codes-guard-2"),
     has(CoreCode, "defn lowered-wam-number-chars-guard-2"),
     has(CoreCode, "defn lowered-wam-atom-concat-guard-3"),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM runtime handling for `char_type(Char, code(Code))`.
- Supports both forward validation from a known character to a code and reverse construction from a valid code to a character atom.
- Adds smoke coverage for forward, reverse, and mismatch cases in the generated Clojure runtime fixture.

## Testing

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
