### PR TITLE
feat(wam-cpp): LMDB sort-warning + compound-key design note

### DIFF
--- a/docs/design/WAM_CPP_LMDB_FACT_SOURCE_DESIGN.md
+++ b/docs/design/WAM_CPP_LMDB_FACT_SOURCE_DESIGN.md
@@ -391,6 +391,52 @@ The C# design should be the C++ design's reference for the MMA
 format, so any future MMA work cross-pollinates between targets
 (and possibly lets one target consume another's artifacts).
 
+## Future work: pre-sorted compound-key schema
+
+When a user declares `order([arg(2)])` (or any non-trivial order),
+the v2 runtime sorts the loaded bucket with `std::sort` — O(n log
+n) at load time. The Phase 2 implementation (PR #2327) emits a
+codegen-time warning advising the user that this cost exists and
+can usually be avoided by designing the LMDB schema so the data
+is already in the desired order.
+
+The technique: encode the sort column directly into the LMDB key.
+Instead of storing `arg1 -> arg2` (sorted by arg1, the LMDB
+default), store `<arg2>-<unique-id> -> arg1`. LMDB then iterates
+in arg2-sorted order natively. The `<unique-id>` discriminator
+avoids LMDB key collisions when multiple rows share the same
+sort-column value.
+
+Tradeoff:
+
+- **Wins**: zero sort cost at load; B-tree locality matches the
+  query pattern; future `lookup_by_arg1` (v1.5) probes the
+  intended column directly.
+- **Costs**: keys are longer (one full atom + delimiter + id) so
+  the LMDB on-disk size grows; intern tables that key on the LMDB
+  key wouldn't deduplicate the prefix portion.
+
+The intern-table cost is mitigated by interning only the
+**discriminator** portion (the unique id), since the sort-column
+prefix repeats across rows that share a sort value and is
+typically a small set of distinct values. The
+`<sort_column>-<id>` shape lets a separate `id -> long_value`
+intern table reuse identifiers across the data DB and the intern
+sub-DB without duplicating the long values.
+
+This is strictly v2 work — it needs:
+
+1. A new `cpp_fact_sources` source spec option (e.g.
+   `lmdb(Path, [compound_key([sort_column, unique_id_column])])`)
+   telling the codegen which delimiter to split on.
+2. Runtime decode of the compound key into the real row columns
+   before pushing to `dynamic_db`.
+3. A migration story for users who already have flat-key LMDB
+   files (probably an explicit reseed step).
+
+The Phase 2 warning is the in-band hint that nudges users toward
+this design before they get there.
+
 ## Cross-references
 
 - C target reference impl: `src/unifyweaver/targets/wam_c_target.pl:2390-2461`

--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -454,8 +454,9 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     % at the end of wam_cpp_setup so dynamic_db is populated before
     % any query runs. Idempotency is enforced runtime-side.
     lmdb_sources_from_options(Options, LmdbSources),
+    warn_runtime_sorts(LmdbSources),
     findall(LoadLine, (
-        member(lmdb_source(Key, Path, DbName, Unique, OnDup, Order),
+        member(lmdb_source(Key, Path, DbName, Unique, OnDup, Order, _),
                LmdbSources),
         emit_lmdb_load_call(Key, Path, DbName, Unique, OnDup,
                             Order, LoadLine)
@@ -2614,7 +2615,7 @@ foreign_pred_keys_from_options(Options, Keys) :-
 %  sources are accepted; other shapes will be added in follow-ups.
 lmdb_sources_from_options(Options, Sources) :-
     (   member(cpp_fact_sources(Specs), Options)
-    ->  findall(lmdb_source(Key, Path, DbName, Unique, OnDup, Order), (
+    ->  findall(lmdb_source(Key, Path, DbName, Unique, OnDup, Order, SrcOpts), (
             member(source(Functor/Arity, SourceSpec), Specs),
             validate_lmdb_v1_arity(Functor, Arity),
             lmdb_source_spec(SourceSpec, Path, DbName, SrcOpts),
@@ -2628,6 +2629,30 @@ lmdb_sources_from_options(Options, Sources) :-
         ), Sources)
     ;   Sources = []
     ).
+
+%% warn_runtime_sorts(+LmdbSources) is det.
+%
+% Walk the resolved sources and emit one user_error warning per
+% source whose declared order requires a runtime sort. Called
+% from emit_setup_function only -- not from the header-generation
+% call site of lmdb_sources_from_options, otherwise the warning
+% would fire twice per project.
+warn_runtime_sorts(Sources) :-
+    forall(member(lmdb_source(_, _, _, _, _, Order, SrcOpts), Sources),
+           maybe_warn_runtime_sort_one(Order, SrcOpts, Sources)).
+
+maybe_warn_runtime_sort_one(_, SrcOpts, _) :-
+    member(quiet_sort(true), SrcOpts), !.
+maybe_warn_runtime_sort_one(Order, _, Sources) :-
+    order_cpp_sort_keys(Order, SortKeysLit),
+    SortKeysLit \== '{}', !,
+    % Recover the PredArity for the message via a reverse-lookup
+    % in Sources; cheap since list is small.
+    member(lmdb_source(Key, _, _, _, _, Order, _), Sources),
+    format(user_error,
+        "[wam-cpp] note: ~w order(~w) requires a runtime sort. LMDB iterates ascending by key; consider a compound-key schema (e.g. <sort_column>-<id>) so the data is already in the desired order at load time. Suppress with quiet_sort(true) in the source options.~n",
+        [Key, Order]).
+maybe_warn_runtime_sort_one(_, _, _).
 
 % v1 supports arity 2 only; loudly reject anything else so the
 % user sees a real codegen-time error rather than a confusing

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -5266,6 +5266,68 @@ test(cpp_e2e_lmdb_policy_order_by_arg2_desc,
         delete_directory_and_contents(TmpDir)
     ).
 
+% relation_policy/2 Phase 2 -- codegen-time warning when the
+% declared order requires a runtime sort. Per #2327's commit
+% discussion: ideally the user designs the LMDB schema so the
+% data is already in the desired order (e.g. compound keys), so
+% we nudge them with a one-line note when sorting actually fires.
+% Suppressible via per-source quiet_sort(true).
+%
+% Tests run the codegen in a subprocess so user_error can be
+% captured cleanly; checking the in-process user_error stream is
+% awkward because plunit owns it.
+test(cpp_e2e_lmdb_sort_warning_emitted,
+     [condition(cpp_lmdb_available)]) :-
+    run_codegen_subprocess(
+        "
+        :- use_module('/home/user/UnifyWeaver/src/unifyweaver/targets/wam_cpp_target').
+        :- use_module('/home/user/UnifyWeaver/src/unifyweaver/core/relation_policy').
+        :- relation_policy(edge/2, [order([arg(2)])]).
+        :- dynamic user:edge/2.
+        user:dummy :- edge(_, _).
+        :- write_wam_cpp_project([user:dummy/0],
+              [cpp_fact_sources([source(edge/2, lmdb('/tmp/x'))])],
+              '/tmp/sw_warn_emit'), halt.
+        ",
+        Stderr),
+    assertion(sub_string(Stderr, _, _, _,
+                         "requires a runtime sort")).
+
+test(cpp_e2e_lmdb_sort_warning_suppressed,
+     [condition(cpp_lmdb_available)]) :-
+    run_codegen_subprocess(
+        "
+        :- use_module('/home/user/UnifyWeaver/src/unifyweaver/targets/wam_cpp_target').
+        :- use_module('/home/user/UnifyWeaver/src/unifyweaver/core/relation_policy').
+        :- relation_policy(edge/2, [order([arg(2)])]).
+        :- dynamic user:edge/2.
+        user:dummy :- edge(_, _).
+        :- write_wam_cpp_project([user:dummy/0],
+              [cpp_fact_sources([source(edge/2,
+                                  lmdb('/tmp/x', [quiet_sort(true)]))])],
+              '/tmp/sw_warn_supp'), halt.
+        ",
+        Stderr),
+    assertion(\+ sub_string(Stderr, _, _, _,
+                            "requires a runtime sort")).
+
+test(cpp_e2e_lmdb_sort_warning_trivial_no_warn,
+     [condition(cpp_lmdb_available)]) :-
+    run_codegen_subprocess(
+        "
+        :- use_module('/home/user/UnifyWeaver/src/unifyweaver/targets/wam_cpp_target').
+        :- use_module('/home/user/UnifyWeaver/src/unifyweaver/core/relation_policy').
+        :- relation_policy(edge/2, [order([arg(1)])]).
+        :- dynamic user:edge/2.
+        user:dummy :- edge(_, _).
+        :- write_wam_cpp_project([user:dummy/0],
+              [cpp_fact_sources([source(edge/2, lmdb('/tmp/x'))])],
+              '/tmp/sw_warn_triv'), halt.
+        ",
+        Stderr),
+    assertion(\+ sub_string(Stderr, _, _, _,
+                            "requires a runtime sort")).
+
 test(cpp_e2e_lmdb_policy_order_arg1_is_noop,
      [ condition(cpp_lmdb_available),
        setup(clear_policies_for_test) ]) :-
@@ -10419,6 +10481,26 @@ lmdb_seed_three_edges(TmpDir, EnvPath, MetaPred, SeedBin) :-
     process_wait(PID, exit(0)),
     process_create(SeedBin, [], [process(PID2)]),
     process_wait(PID2, exit(0)).
+
+% Run a Prolog script in a fresh swipl subprocess and capture
+% its stderr. Used by the sort-warning tests to verify codegen-
+% time messages without interfering with plunit's own
+% user_error.
+run_codegen_subprocess(Source, Stderr) :-
+    tmp_file(codegen_script, ScriptBase),
+    atom_concat(ScriptBase, '.pl', ScriptPath),
+    setup_call_cleanup(
+        open(ScriptPath, write, S),
+        write(S, Source),
+        close(S)),
+    process_create(path('swipl'),
+                   ['-q', '-f', 'none', ScriptPath],
+                   [stdout(null), stderr(pipe(ErrStream)),
+                    process(PID)]),
+    read_string(ErrStream, _, Stderr),
+    close(ErrStream),
+    process_wait(PID, _Status),
+    catch(delete_file(ScriptPath), _, true).
 
 % Build the C++ project at TmpDir with -DWAM_CPP_ENABLE_LMDB and
 % -llmdb. Used by LMDB end-to-end tests; otherwise identical to


### PR DESCRIPTION
## Summary

Implements your suggestion from the #2327 review: warn the user when the declared `order(...)` policy requires a runtime `std::sort`, so they can consider designing their LMDB schema to avoid the cost.

## Warning format

```
[wam-cpp] note: edge/2 order([arg(2)]) requires a runtime sort.
LMDB iterates ascending by key; consider a compound-key schema
(e.g. <sort_column>-<id>) so the data is already in the desired
order at load time. Suppress with quiet_sort(true) in the source
options.
```

One line to `user_error` at codegen time (not runtime — runtime stays quiet).

## Suppression

Per-source:

```prolog
cpp_fact_sources([
    source(edge/2, lmdb('graph.mdb', [quiet_sort(true)]))
])
```

## Implementation notes

- Warning lives in `warn_runtime_sorts/1`, called only from `emit_setup_function`. An early version fired it from inside `lmdb_sources_from_options` too, but that predicate is also called from `compile_wam_runtime_header_to_cpp` (deciding whether to emit `#define WAM_CPP_ENABLE_LMDB`), causing **duplicate messages per source**. Moving the call to a single site fixes that.
- `lmdb_source/6` → `lmdb_source/7` (added SrcOpts so the warning function can check `quiet_sort`).

## Design doc update

Adds a "Future work: pre-sorted compound-key schema" section to `WAM_CPP_LMDB_FACT_SOURCE_DESIGN.md` capturing the technique you described:

> Instead of storing `arg1 → arg2` (sorted by arg1, the LMDB default), store `<arg2>-<unique-id> → arg1`. LMDB then iterates in arg2-sorted order natively.

Tradeoffs explicitly:

- **Wins**: zero sort cost at load; B-tree locality matches the query pattern; future `lookup_by_arg1` (v1.5) probes the intended column directly.
- **Costs**: keys are longer; intern tables that key on the LMDB key wouldn't deduplicate the prefix portion. Mitigated by interning **only the discriminator** — the sort-column prefix repeats across rows and is typically a small set of distinct values.

V2 work needed:
1. New source-spec option (e.g. `compound_key([sort_column, unique_id_column])`)
2. Runtime decode of compound key into row columns
3. Migration story for users with existing flat-key files

The Phase 2 warning is positioned as the in-band hint that nudges users toward this design **before** they get there.

## Tests (3 new)

Run via a `swipl -q -f none <script>` subprocess so `user_error` can be captured cleanly without interfering with plunit's own stream:

| Test | Order | Expectation |
|---|---|---|
| `cpp_e2e_lmdb_sort_warning_emitted` | `[arg(2)]` | stderr contains "requires a runtime sort" |
| `cpp_e2e_lmdb_sort_warning_suppressed` | `[arg(2)]` + `quiet_sort(true)` | stderr does NOT |
| `cpp_e2e_lmdb_sort_warning_trivial_no_warn` | `[arg(1)]` | stderr does NOT (trivial) |

Shared `run_codegen_subprocess/2` helper writes a Prolog source snippet to a temp file, spawns swipl, captures stderr, and cleans up.

## Test plan

- [x] All 3 warning tests pass
- [x] All existing LMDB tests pass (no regression)
- [x] `relation_policy` Phase 1 tests pass
- [x] 38-test broad sweep (running at PR-open time)

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_