### PR TITLE
feat: register C++ in runtime-parser capability hook

### DIFF
--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
@@ -93,8 +93,15 @@ than emitting parser stubs.
 
 Status: this hook is implemented and covered by
 `tests/test_wam_runtime_parser_capability.pl`, with R and Lua as the initial
-consumers. The remaining work is target-by-target adoption, not inventing the
-contract.
+consumers. C++ is now also registered (default
+`native(parse_term)`; `compiled(prolog_term_parser)` available
+opt-in) -- it ships a hand-written canonical-form parser used by
+`atom_to_term/3`, `term_to_atom/2`'s reverse mode, and
+`read_term/1`. The C++ native parser does not yet support
+operator notation, so callers requiring `1+2`-style input would
+need `runtime_parser(compiled)` once the project writer is wired
+through the hook (Phase 6+ work). The remaining work is
+target-by-target adoption, not inventing the contract.
 
 The hook should be independent of the WAM items API. A target can skip WAM text
 generation at build time and still need runtime source-term parsing.

--- a/src/unifyweaver/targets/wam_runtime_parser_capability.pl
+++ b/src/unifyweaver/targets/wam_runtime_parser_capability.pl
@@ -107,12 +107,24 @@ resolve_runtime_parser_request(Request, _Target, _Mode) :-
     domain_error(runtime_parser_request, Request).
 
 target_runtime_parser_default(wam_r, native(parse_term)).
+% C++ has a hand-written canonical-form parser in the runtime
+% (LmdbFactSource lives next to it). It powers atom_to_term/3,
+% term_to_atom/2's reverse mode, and read_term/1. It does NOT
+% currently support operator notation -- 1+2 must be written
+% as +(1, 2). Compiling the portable parser in would lift that
+% restriction; we register both modes here and leave native as
+% the default since it ships today.
+target_runtime_parser_default(wam_cpp, native(parse_term)).
 
 target_runtime_parser_mode_(wam_r, native(parse_term)).
 target_runtime_parser_mode_(wam_r, compiled(prolog_term_parser)).
+target_runtime_parser_mode_(wam_cpp, native(parse_term)).
+target_runtime_parser_mode_(wam_cpp, compiled(prolog_term_parser)).
 
 normalize_runtime_parser_target(r, wam_r) :- !.
 normalize_runtime_parser_target(wam_r, wam_r) :- !.
+normalize_runtime_parser_target(cpp, wam_cpp) :- !.
+normalize_runtime_parser_target(wam_cpp, wam_cpp) :- !.
 normalize_runtime_parser_target(Target, Target).
 
 strip_module_qualifier(Module:Goal, Stripped) :-

--- a/tests/test_wam_runtime_parser_capability.pl
+++ b/tests/test_wam_runtime_parser_capability.pl
@@ -20,6 +20,23 @@ test(r_can_opt_into_compiled_parser) :-
     wam_target_runtime_parser(wam_r, [runtime_parser(compiled)],
                               compiled(prolog_term_parser)).
 
+test(cpp_defaults_to_native_parser) :-
+    wam_target_runtime_parser(wam_cpp, [], native(parse_term)).
+
+test(cpp_alias_defaults_to_native_parser) :-
+    wam_target_runtime_parser(cpp, [], native(parse_term)).
+
+test(cpp_off_disables_parser) :-
+    wam_target_runtime_parser(wam_cpp, [runtime_parser(off)], none).
+
+test(cpp_can_require_native_parser) :-
+    wam_target_runtime_parser(wam_cpp, [runtime_parser(native)],
+                              native(parse_term)).
+
+test(cpp_can_opt_into_compiled_parser) :-
+    wam_target_runtime_parser(wam_cpp, [runtime_parser(compiled)],
+                              compiled(prolog_term_parser)).
+
 test(unknown_target_defaults_to_none) :-
     wam_target_runtime_parser(wam_lua, [], none).
 


### PR DESCRIPTION
## Summary

Small first step into the runtime-parser track (#7 from the menu). Registers `wam_cpp` in the shared `src/unifyweaver/targets/wam_runtime_parser_capability.pl` registry, matching the pattern R already follows.

C++ already ships a hand-written canonical-form parser in the runtime (used by `atom_to_term/3`, `term_to_atom/2` reverse mode, and `read_term/1`) but wasn't declared in the registry, so callers asking `wam_target_runtime_parser(cpp, [], Mode)` used to get `Mode = none` even though the parser was right there.

## Changes

```prolog
target_runtime_parser_default(wam_cpp, native(parse_term)).
target_runtime_parser_mode_(wam_cpp, native(parse_term)).
target_runtime_parser_mode_(wam_cpp, compiled(prolog_term_parser)).
```

Plus the `cpp ↔ wam_cpp` alias clause for the normalisation helper (mirrors how `r ↔ wam_r` already worked).

## Capability matrix after this PR

| Target | Default | Native? | Compiled? |
|---|---|---|---|
| `wam_r` | `native(parse_term)` | yes (inline) | yes |
| **`wam_cpp`** | **`native(parse_term)`** | **yes (canonical-form only)** | **yes** |
| `wam_lua` | `none` | no | no |
| others | `none` (fallback) | no | no |

## What's deferred

Per the implementation plan's Phase 5 guidance (*"Do not immediately wire every target's `write_wam_*_project/3` through the new hook"*), this PR only documents C++'s posture in the registry. **Wiring `write_wam_cpp_project` through the hook** — so resolution actually changes generated code — is the natural follow-up.

The C++ native parser doesn't yet support operator notation (`1+2` must be written as `+(1, 2)`). That gap is the motivation for the follow-up: opting into `runtime_parser(compiled)` would compile the portable `prolog_term_parser.pl` into the C++ output and unlock operator parsing.

## Tests

**5 new tests** in `tests/test_wam_runtime_parser_capability.pl`:

- `cpp_defaults_to_native_parser`
- `cpp_alias_defaults_to_native_parser` (the `cpp ↔ wam_cpp` alias)
- `cpp_off_disables_parser`
- `cpp_can_require_native_parser`
- `cpp_can_opt_into_compiled_parser`

**31 tests total** in the suite, all passing.

## Doc update

Implementation plan Phase 5 status now records the C++ adoption, including the caveat about the missing operator support and the natural follow-up direction.

## Test plan

- [x] All 31 hook tests pass (5 new + 26 existing)
- [x] No existing test affected (pure-additive registration)

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_