### PR TITLE
feat(wam-cpp): parse_atom_to_term/2 + parse_term_to_atom/2 wrappers

### DIFF
--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
@@ -152,6 +152,45 @@ Implemented in PR #2332 with four regression tests covering
 leaf-closure, tokenizer-chain, bare-indicator resolution, and
 unknown-entry rejection.
 
+### Explicit-name wrappers vs shadowing standard SWI names
+
+PR #2334 added two explicit-name wrappers (`parse_atom_to_term/2`,
+`parse_term_to_atom/2`) for operator-aware parsing in compiled
+mode. The natural question was: *why not shadow the standard
+`atom_to_term/3` and `term_to_atom/2` names directly?* Because
+those names are registered in `is_builtin_pred/2` (in
+`wam_target.pl`), the compiler emits `builtin_call` for them,
+which bypasses the label-dispatch chain entirely and lands in
+the C++ `builtin()` function. A same-name wrapper would sit in
+the labels table but **never be reached** at runtime.
+
+Three options were considered:
+
+| Option | Approach | Scope | Tradeoff |
+|---|---|---|---|
+| A | Drop `is_builtin_pred/2` registrations globally | Shared codegen (all targets) | Native users still work via the Call → builtin() fallback; affects every target |
+| B | Per-target builtin-override hook in `compile_predicate_to_wam/3` | Cross-target plumbing | C++-only behavior, but requires shared-codegen API |
+| C | Add new explicit-name wrappers | C++-only, purely additive | Standard names still go to native builtin; users opt into operator parsing by calling explicit names |
+
+C was chosen because it's purely additive and ships in one PR
+without touching cross-target codegen. A and B remain real
+follow-up options if a use case for shadowing the standard names
+emerges (e.g. an existing library that calls `atom_to_term/3`
+and now needs operator support without a code change). Such a
+follow-up should land its own design pass since both options
+span more than just C++.
+
+`parse_term_to_atom/2` is mode-sensitive: forward mode delegates
+to the native `term_to_atom/2` builtin (rendering doesn't need
+operator support and the native path is faster); reverse mode
+goes through `parse_term_from_atom/3` with `canonical_op_table/1`.
+
+The subset machinery cooperates cleanly with these wrappers --
+`runtime_parser_subset([parse_atom_to_term/2, parse_term_to_atom/2])`
+pulls in the wrappers and their transitive closure (which
+includes `parse_term_from_atom/3` and the full operator-parser
+machinery; this is unavoidable for operator support).
+
 The hook should be independent of the WAM items API. A target can skip WAM text
 generation at build time and still need runtime source-term parsing.
 

--- a/src/unifyweaver/core/cpp_runtime_parser_wrappers.pl
+++ b/src/unifyweaver/core/cpp_runtime_parser_wrappers.pl
@@ -24,7 +24,9 @@
 
 :- module(cpp_runtime_parser_wrappers, [
     read_term_from_atom/2,
-    read_term_from_atom/3
+    read_term_from_atom/3,
+    parse_atom_to_term/2,
+    parse_term_to_atom/2
 ]).
 
 :- use_module(prolog_term_parser, [
@@ -49,3 +51,43 @@ read_term_from_atom(Atom, Term) :-
 % the option-handling work has an obvious home for a follow-up.
 read_term_from_atom(Atom, Term, _Options) :-
     read_term_from_atom(Atom, Term).
+
+%% parse_atom_to_term(+Atom, -Term) is semidet.
+%
+% Operator-aware atom-to-term conversion. Equivalent in shape to
+% SWI's atom_to_term/3 but drops the bindings argument -- the
+% portable parser does not return a separate bindings list; it
+% preserves variable identity within one parse internally.
+%
+% Available only in compiled mode. Uses a different name from
+% the SWI standard atom_to_term/3 because that name is registered
+% as a WAM-cpp builtin (is_builtin_pred(atom_to_term, 3)) and the
+% compiler emits builtin_call for it, which bypasses the label
+% dispatch where a wrapper would live. See the PR #2334 commit
+% discussion for the three ways one could route the standard
+% name through (option C -- explicit names -- chosen here).
+parse_atom_to_term(Atom, Term) :-
+    canonical_op_table(Ops),
+    parse_term_from_atom(Atom, Ops, Term).
+
+%% parse_term_to_atom(?Term, ?Atom) is semidet.
+%
+% Bidirectional term/atom conversion with operator support on the
+% parse side. Mirrors SWI's term_to_atom/2:
+%
+%   - (+Term, ?Atom): render Term to an atom; unify with Atom.
+%   - (-Term, +Atom): parse Atom into Term using the canonical op
+%     table (operator notation supported -- this is what you cannot
+%     get from the native term_to_atom/2 builtin).
+%   - (+Term, +Atom): render and check via unification.
+%
+% Forward mode delegates to the WAM-cpp native term_to_atom/2
+% builtin (rendering does not need operator support and the
+% native path is faster). Reverse mode goes through
+% parse_term_from_atom/3.
+parse_term_to_atom(Term, Atom) :-
+    (   nonvar(Term)
+    ->  term_to_atom(Term, Atom)
+    ;   canonical_op_table(Ops),
+        parse_term_from_atom(Atom, Ops, Term)
+    ).

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -5139,6 +5139,55 @@ test(cpp_e2e_runtime_parser_native_excludes_wrappers) :-
         delete_directory_and_contents(TmpDir)
     ).
 
+% Operator-aware wrappers under explicit names (option C from
+% the PR #2334 design discussion). parse_atom_to_term/2 and
+% parse_term_to_atom/2 give compiled-mode users an operator-aware
+% parse path without colliding with the existing C++ builtins for
+% atom_to_term/3 and term_to_atom/2 (which are emitted as
+% builtin_call and bypass label dispatch).
+test(cpp_e2e_runtime_parser_explicit_name_wrappers) :-
+    unique_cpp_tmp_dir('tmp_cpp_runparser_xw', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_pd_safe/0],
+            [ runtime_parser(compiled),
+              runtime_parser_subset([parse_atom_to_term/2,
+                                     parse_term_to_atom/2]) ],
+            TmpDir),
+        ( directory_file_path(TmpDir, 'cpp/generated_program.cpp',
+                              GenPath),
+          read_file_to_string(GenPath, Code, [encoding(octet)]),
+          assertion(sub_string(Code, _, _, _,
+                               "parse_atom_to_term/2")),
+          assertion(sub_string(Code, _, _, _,
+                               "parse_term_to_atom/2")),
+          % And the supporting parser predicates the wrappers call.
+          assertion(sub_string(Code, _, _, _,
+                               "parse_term_from_atom/3")),
+          assertion(sub_string(Code, _, _, _,
+                               "canonical_op_table/1"))
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_runtime_parser_explicit_name_wrappers_absent_native) :-
+    % Default native mode excludes the wrappers entirely.
+    unique_cpp_tmp_dir('tmp_cpp_runparser_xw_native', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project(
+            [user:wam_cpp_pd_safe/0],
+            [], TmpDir),
+        ( directory_file_path(TmpDir, 'cpp/generated_program.cpp',
+                              GenPath),
+          read_file_to_string(GenPath, Code, [encoding(octet)]),
+          assertion(\+ sub_string(Code, _, _, _,
+                                  "parse_atom_to_term/2")),
+          assertion(\+ sub_string(Code, _, _, _,
+                                  "parse_term_to_atom/2"))
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
 % Subset generation -- runtime_parser_subset([Names]) pulls in
 % only the transitive closure of the listed entry points instead
 % of the full ~40-predicate parser. Per the implementation plan


### PR DESCRIPTION
## Summary

Operator-aware parsing under explicit names for compiled-mode callers. Option **C** from the PR review discussion: the standard SWI names (`atom_to_term/3`, `term_to_atom/2`) are registered in `is_builtin_pred/2` and the compiler emits `builtin_call` for them, which **bypasses label dispatch entirely** — so a same-name wrapper would sit in the labels table but never be reached at runtime. The clean, additive answer is to expose the operator-aware path under new explicit names; users opt in.

## New wrappers

| Predicate | Behavior |
|---|---|
| `parse_atom_to_term(+Atom, -Term)` | Atom-to-term shape similar to SWI's `atom_to_term/3` but drops the bindings argument (the portable parser preserves variable identity within a parse internally; it doesn't return a separate bindings list). |
| `parse_term_to_atom(?Term, ?Atom)` | Bidirectional. **Forward** mode delegates to the native `term_to_atom/2` builtin (rendering doesn't need operator support and the native path is faster). **Reverse** mode goes through `parse_term_from_atom/3` — this is the path that gives operator notation (`1+2` etc.) that native `term_to_atom/2` can't handle. |

## Cooperation with subset generation (PR #2333)

```prolog
runtime_parser_subset([parse_atom_to_term/2, parse_term_to_atom/2])
```

Pulls in the wrappers + transitive parser closure — which is most of the parser because operator support needs `parse_expr/8` and friends. **That's inherent to operator parsing, not a codegen inefficiency.** For users who only need tokenization, subset by `tokenize/2` (the empirical data from #2333 shows ~30x size reduction there).

## Tests (2 new)

| Test | Mode | Expectation |
|---|---|---|
| `cpp_e2e_runtime_parser_explicit_name_wrappers` | `compiled` + subset | output contains `parse_atom_to_term/2`, `parse_term_to_atom/2`, `parse_term_from_atom/3`, `canonical_op_table/1` |
| `cpp_e2e_runtime_parser_explicit_name_wrappers_absent_native` | default | output does **not** contain the wrappers (no behavior change for users who don't opt in) |

## Doc update

`RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md` gets a new **"Explicit-name wrappers vs shadowing standard SWI names"** section laying out why option C was chosen over:

- **A** (drop `is_builtin_pred/2` globally) — affects all targets
- **B** (per-target builtin-override hook) — cross-target plumbing required

Both remain real follow-up options if a use case for shadowing the standard names emerges, but they need their own design pass.

## Test plan

- [x] All 2 new tests pass
- [x] All 12 existing parser-track tests pass
- [x] All existing LMDB, relation_policy, stdlib tests pass
- [x] 39-test broad sweep + relation_policy + parser-capability suites (running at PR-open time)

https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGziM3694TcZr9GQksFgv)_