### PR TITLE
feat(wam-fsharp): comparison / type / I/O parity with Rust + atom / string parity with Go

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -1056,6 +1056,99 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         | Some a, Some b when a > b -> Some { s with WsPC = s.WsPC + 1 }
         | _ -> None
 
+    // >=/2, =</2, =:=/2, =\\=/2 — arithmetic comparisons (parity with Rust /
+    // C++ comparison builtins). Each evaluates both sides via evalArith and
+    // dispatches on the operator. =:=/2 and =\\=/2 use EPSILON tolerance to
+    // bridge integer / float comparisons (mirrors the Rust implementation).
+    | BuiltinCall (">=/2", _) ->
+        let v1 = getReg 1 s |> Option.bind (evalArith s.WsBindings)
+        let v2 = getReg 2 s |> Option.bind (evalArith s.WsBindings)
+        match v1, v2 with
+        | Some a, Some b when a >= b -> Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
+    | BuiltinCall ("=</2", _) ->
+        let v1 = getReg 1 s |> Option.bind (evalArith s.WsBindings)
+        let v2 = getReg 2 s |> Option.bind (evalArith s.WsBindings)
+        match v1, v2 with
+        | Some a, Some b when a <= b -> Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
+    | BuiltinCall ("=:=/2", _) ->
+        let v1 = getReg 1 s |> Option.bind (evalArith s.WsBindings)
+        let v2 = getReg 2 s |> Option.bind (evalArith s.WsBindings)
+        match v1, v2 with
+        | Some a, Some b when abs (a - b) < System.Double.Epsilon ->
+            Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
+    | BuiltinCall ("=\\\\=/2", _) ->
+        let v1 = getReg 1 s |> Option.bind (evalArith s.WsBindings)
+        let v2 = getReg 2 s |> Option.bind (evalArith s.WsBindings)
+        match v1, v2 with
+        | Some a, Some b when abs (a - b) >= System.Double.Epsilon ->
+            Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
+    // ==/2, \\==/2 — structural term equality (no unification, no binding).
+    // Both sides are dereferenced through the binding chain, then compared
+    // by F# structural equality on the Value DU. Mirrors the Rust ==/2 +
+    // C++ ==/2 / \\==/2 step cases.
+    | BuiltinCall ("==/2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some a, Some b when a = b -> Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
+    | BuiltinCall ("\\\\==/2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some a, Some b when a <> b -> Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
+    // true/0 / fail/0 — trivial control. Mirrors the Rust execute_control
+    // dispatch (true succeeds and advances, fail short-circuits).
+    | BuiltinCall ("true/0", _) -> Some { s with WsPC = s.WsPC + 1 }
+    | BuiltinCall ("fail/0", _) -> None
+
+    // compound/1 — type check matching Str (any) and non-empty VList.
+    // F# VList is a flat list (not cons-cells), so a non-empty VList is
+    // exactly the compound case.
+    | BuiltinCall ("compound/1", _) ->
+        match getReg 1 s with
+        | Some (Str _)        -> Some { s with WsPC = s.WsPC + 1 }
+        | Some (VList (_::_)) -> Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
+    // float/1 — type check for Float values.
+    | BuiltinCall ("float/1", _) ->
+        match getReg 1 s with
+        | Some (Float _) -> Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
+    // is_list/1 — type check for proper lists. Since F# VList is a flat
+    // Value list (head/tail items, not cons cells), VList _ already means
+    // a proper list (empty or non-empty). Atom "[]" also counts as the
+    // empty list per Prolog convention.
+    | BuiltinCall ("is_list/1", _) ->
+        match getReg 1 s with
+        | Some (VList _)      -> Some { s with WsPC = s.WsPC + 1 }
+        | Some (Atom "[]")    -> Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
+    // write/1 / display/1 — print the dereferenced value to stdout.
+    // Mirrors the Rust write/1 + display/1 fast-path (both use Display
+    // for now; standard Prolog differentiates quoting between them).
+    | BuiltinCall ("write/1", _) | BuiltinCall ("display/1", _) ->
+        match getReg 1 s with
+        | Some v ->
+            printf "%s" (sprintf "%A" v)
+            Some { s with WsPC = s.WsPC + 1 }
+        | None -> None
+
+    // nl/0 — newline to stdout.
+    | BuiltinCall ("nl/0", _) ->
+        printfn ""
+        Some { s with WsPC = s.WsPC + 1 }
+
     | BuiltinCall ("member/2", _) ->
         let elem_ = s.WsRegs.[1] |> derefVar s.WsBindings
         let list_ = s.WsRegs.[2] |> derefVar s.WsBindings

--- a/tests/test_wam_fsharp_target.pl
+++ b/tests/test_wam_fsharp_target.pl
@@ -162,6 +162,100 @@ test_fsharp_no_regressions :-
     ).
 
 %% ----------------------------------------------------------------------
+%% Phase B parity: arithmetic comparison operators (>=, =<, =:=, =\=)
+%% present in the Rust target. The Haskell baseline currently has only
+%% < and >, so this brings the F# target one step further toward the
+%% Rust/C++ comparison-builtin coverage.
+%% ----------------------------------------------------------------------
+
+test_fsharp_arith_comparison_builtins :-
+    Test = 'WAM-FSharp: arithmetic comparisons (>=, =<, =:=, =\\=)',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\">=/2\""),
+        sub_string(S, _, _, _, "BuiltinCall (\"=</2\""),
+        sub_string(S, _, _, _, "BuiltinCall (\"=:=/2\""),
+        %% =\=/2 emits as F# pattern "=\\=/2" (one backslash at F# runtime).
+        sub_string(S, _, _, _, "BuiltinCall (\"=\\\\=/2\""),
+        %% EPSILON tolerance bridges integer/float comparisons.
+        sub_string(S, _, _, _, "System.Double.Epsilon")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing arithmetic comparison step cases')
+    ).
+
+%% ----------------------------------------------------------------------
+%% Term equality (==, \\==): structural equality on the dereferenced
+%% value, no unification or binding. Mirrors the Rust execute_arith ==/2
+%% case and the C++ ==/2 / \\==/2 fused case.
+%% ----------------------------------------------------------------------
+
+test_fsharp_term_equality_builtins :-
+    Test = 'WAM-FSharp: term equality (==/2, \\==/2)',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"==/2\""),
+        sub_string(S, _, _, _, "BuiltinCall (\"\\\\==/2\"")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing term equality / inequality step cases')
+    ).
+
+%% ----------------------------------------------------------------------
+%% Trivial control: true/0 (succeed + advance) and fail/0 (always fail).
+%% These show up in source Prolog programs as call(true) / call(fail)
+%% and via aggregate-clause guards.  Rust has them as the first arms of
+%% execute_control.
+%% ----------------------------------------------------------------------
+
+test_fsharp_trivial_control_builtins :-
+    Test = 'WAM-FSharp: trivial control (true/0, fail/0)',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"true/0\""),
+        sub_string(S, _, _, _, "BuiltinCall (\"fail/0\"")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing trivial control step cases')
+    ).
+
+%% ----------------------------------------------------------------------
+%% Type checks: compound/1, float/1, is_list/1. Brings the F# type-check
+%% set to parity with the Rust execute_type_builtin coverage. atom/1,
+%% integer/1, number/1, var/1, nonvar/1 were already present.
+%% ----------------------------------------------------------------------
+
+test_fsharp_type_check_builtins :-
+    Test = 'WAM-FSharp: type checks (compound/1, float/1, is_list/1)',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"compound/1\""),
+        %% compound matches Str OR non-empty VList.
+        sub_string(S, _, _, _, "Some (Str _)"),
+        sub_string(S, _, _, _, "Some (VList (_::_))"),
+        sub_string(S, _, _, _, "BuiltinCall (\"float/1\""),
+        sub_string(S, _, _, _, "BuiltinCall (\"is_list/1\""),
+        %% is_list accepts the empty-list atom convention too.
+        sub_string(S, _, _, _, "Some (Atom \"[]\")")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing type check step cases')
+    ).
+
+%% ----------------------------------------------------------------------
+%% I/O builtins: write/1, display/1, nl/0. F# uses sprintf / printfn for
+%% Display output. Mirrors the Rust execute_io_builtin set.
+%% ----------------------------------------------------------------------
+
+test_fsharp_io_builtins :-
+    Test = 'WAM-FSharp: I/O (write/1, display/1, nl/0)',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"write/1\""),
+        sub_string(S, _, _, _, "BuiltinCall (\"display/1\""),
+        sub_string(S, _, _, _, "BuiltinCall (\"nl/0\""),
+        sub_string(S, _, _, _, "printfn \"\"")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing I/O step cases')
+    ).
+
+%% ----------------------------------------------------------------------
 %% Phase F parity smoke: fact-shape classification helpers exposed by
 %% the F# target (parity infra used by Haskell / Elixir hybrid targets).
 %% ----------------------------------------------------------------------
@@ -304,6 +398,11 @@ run_tests :-
     test_fsharp_copy_term_builtin_present,
     test_fsharp_negation_step_handler_present,
     test_fsharp_no_regressions,
+    test_fsharp_arith_comparison_builtins,
+    test_fsharp_term_equality_builtins,
+    test_fsharp_trivial_control_builtins,
+    test_fsharp_type_check_builtins,
+    test_fsharp_io_builtins,
     test_fsharp_fact_shape_helpers_exported,
     test_fsharp_emit_mode_resolution,
     test_fsharp_lowerable_single_clause_proceed,


### PR DESCRIPTION
## Summary

Two rounds of F# hybrid WAM parity additions (squashed into one PR because the work happens on the same dev branch `claude/f-sharp-hybrid-wam-FCoQx`). Follows PR #2335 which added the term-inspection + NAF builtins.

| Commit | Scope |
|---|---|
| `5738d3e` | Comparison + type-check + I/O builtin parity with Rust |
| `9340d08` | Atom / string builtin parity with Go |

Together they bring the F# step function to **26 builtins** beyond the `!/0`, `is/2`, `nonvar/1`, `var/1`, `atom/1`, `integer/1`, `number/1`, `length/2`, `</2`, `>/2`, `member/2`, `functor/3`, `copy_term/2`, `arg/3`, `=../2`, `\+/1` baseline already present.

## Audit

### Round 1 — comparison / type / I/O / control (parity with Rust)

| Builtin family | Operator | Rust | C++ | F# before | F# after |
|---|---|---|---|---|---|
| Arithmetic comparison | `>=/2`, `=</2`, `=:=/2`, `=\=/2` | ✓ | ✓ | ✗ | ✓ |
| Term equality | `==/2`, `\==/2` | ~ / ✓ | ✓ | ✗ | ✓ |
| Trivial control | `true/0`, `fail/0` | ✓ | ✓ | ✗ | ✓ |
| Type check | `compound/1`, `float/1`, `is_list/1` | ✓ | ✓ | ✗ | ✓ |
| I/O | `write/1`, `display/1`, `nl/0` | ✓ | ✓ | ✗ | ✓ |

### Round 2 — atom / string builtins (parity with Go)

| Builtin | Go | F# before | F# after | Notes |
|---|---|---|---|---|
| `atom_concat/3` | ✓ | ✗ | ✓ | F# `a + b` for two Atoms |
| `atom_length/2` / `string_length/2` | ✓ | ✗ | ✓ | OR-aliased to single arm |
| `char_code/2` | ✓ | ✗ | ✓ | Bidirectional, 0..65535 BMP guard |
| `atom_codes/2` | ✓ | ✗ | ✓ | StringBuilder fold for reverse direction |
| `atom_chars/2` | ✓ | ✗ | ✓ | Same fold pattern |
| `atom_string/2` / `string_to_atom/2` | ✓ | ✗ | ✓ | Identity (F# Atom is string-based) |
| `upcase_atom/2`, `downcase_atom/2` | ✓ | ✗ | ✓ | `.NET ToUpperInvariant` / `ToLowerInvariant` |
| `atom_number/2` | ✓ | ✗ | ✓ | `Int64.TryParse` → `Double.TryParse` (invariant culture) |
| `succ/2` | ✓ | ✗ | ✓ | Bidirectional, non-negative |

## Implementation notes

- **Comparison `=:=/2` / `=\=/2`** use `System.Double.Epsilon` for the integer / float bridge, mirroring Rust's EPSILON pattern.
- **`compound/1`** matches `Str _` *or* non-empty `VList`. F# `VList` is a flat `Value list`, so a non-empty VList is exactly the compound case.
- **`is_list/1`** accepts both `VList _` and `Atom "[]"` (the empty-list atom convention).
- **`atom_codes/2`** and **`atom_chars/2`** use `System.Text.StringBuilder` in the reverse direction (list-of-codes → Atom) for O(n) construction, replacing repeated `String.concat`.
- **`atom_number/2`** uses `CultureInfo.InvariantCulture` for the float form and `ToString("G", invariant)` for the reverse, keeping round-trip stable across locales.
- **`succ/2`** enforces both directions are non-negative (`x >= 0` forward, `y > 0` reverse to allow `succ(_, 0)` to fail).

## Files changed

- `src/unifyweaver/targets/wam_fsharp_target.pl` — 24 new `BuiltinCall` step arms total (13 from round 1, 11 from round 2).
- `tests/test_wam_fsharp_target.pl` — 14 new codegen parity assertions (5 round 1 + 9 round 2). Total assertions now 26 (was 12 in PR #2335).

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl` — **26 / 26 pass**.
- `swipl -q -g run_benchmarks -t halt tests/bench_wam_fsharp.pl` — pre-existing benchmark still runs, lowered-vs-interpreter speedup steady at ~1.7×.
- `swipl -q -g run_tests -t halt tests/core/test_fsharp_native_lowering.pl` — pre-existing native-lowering tests still pass.
- Codegen spot check: confirmed all 24 new builtins are emitted in `WamRuntime.fs`.

## Test plan

- [x] All 26 codegen parity tests pass.
- [x] Pre-existing F# WAM benchmark + native-lowering tests still pass.
- [x] Codegen string-pattern spot check matches Rust + Go baselines.
- [ ] _(Out of scope: full `dotnet build` of a generated project — same constraint as PR #2335 and the Haskell target test suite, which document GHC-per-test as prohibitively slow.)_

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP