### PR TITLE
feat(wam-fsharp): atom / list / sort / order / unification builtins (Go parity)

### DIFF
--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -466,7 +466,65 @@ and copyTermArgs (c: int) (m: Map<int, int>) (xs: Value list)
     | x :: rest ->
         let x1, c1, m1 = copyTermWalk c m x
         let rest1, c2, m2 = copyTermArgs c1 m1 rest
-        x1 :: rest1, c2, m2").
+        x1 :: rest1, c2, m2
+
+/// Standard-order comparison on Value terms.  Mirrors the Go target's
+/// compareValues helper (templates/targets/go_wam/state.go.mustache) and
+/// the Prolog/ISO standard ordering of terms:
+///
+///   Var < Number < Atom < String < Compound (incl. VList)
+///
+/// Numbers (Integer / Float) are compared by numeric value, bridging int
+/// and float via float-promotion.  Atoms compare by ordinal string order.
+/// Compound terms (Str / VList) compare first by arity, then by functor
+/// name, then element-wise.  VList behaves like a compound with functor
+/// '.' and arity matching the list length.
+///
+/// This helper is independent of the Value type's CustomComparison
+/// override — that override's `compare this other` recurses through
+/// `IComparable.CompareTo` and is not used by the runtime hot path.
+/// Built-ins that need standard order (compare/3, @</2, @=</2, @>/2,
+/// @>=/2, sort/2, msort/2) call compareValue directly.
+let rec compareValue (a: Value) (b: Value) : int =
+    let rankOf v =
+        match v with
+        | Unbound _           -> 0
+        | Integer _ | Float _ -> 1
+        | Atom _              -> 2
+        | Str _ | VList _     -> 3
+        | Ref _               -> 4
+    match a, b with
+    | Unbound x, Unbound y -> compare x y
+    | Integer x, Integer y -> compare x y
+    | Float x,   Float y   -> compare x y
+    | Integer x, Float y   -> compare (float x) y
+    | Float x,   Integer y -> compare x (float y)
+    | Atom x,    Atom y    -> System.String.Compare(x, y, System.StringComparison.Ordinal)
+    | Ref x,     Ref y     -> compare x y
+    | Str (fx, ax), Str (fy, ay) ->
+        let ca = compare (List.length ax) (List.length ay)
+        if ca <> 0 then ca
+        else
+            let cf = System.String.Compare(fx, fy, System.StringComparison.Ordinal)
+            if cf <> 0 then cf
+            else compareValueList ax ay
+    | VList xs, VList ys -> compareValueList xs ys
+    | Str (_, ax), VList ys ->
+        let ca = compare (List.length ax) (List.length ys)
+        if ca <> 0 then ca else compareValueList ax ys
+    | VList xs, Str (_, ay) ->
+        let ca = compare (List.length xs) (List.length ay)
+        if ca <> 0 then ca else compareValueList xs ay
+    | _ -> compare (rankOf a) (rankOf b)
+
+and compareValueList (xs: Value list) (ys: Value list) : int =
+    match xs, ys with
+    | [], []           -> 0
+    | [], _            -> -1
+    | _, []            -> 1
+    | x :: xt, y :: yt ->
+        let c = compareValue x y
+        if c <> 0 then c else compareValueList xt yt").
 
 % ============================================================================
 % Combined preamble emitter

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -1149,6 +1149,186 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         printfn ""
         Some { s with WsPC = s.WsPC + 1 }
 
+    // ========================================================================
+    // Phase G — atom / string builtins (parity with Go target)
+    // ========================================================================
+    // F# Atom is string-based, so most of these collapse to direct .NET
+    // string operations. The list-of-codes / list-of-chars conversions
+    // use the F# Value DU shape: VList of Value list (a flat list).
+    //
+    // Reference: templates/targets/go_wam/state.go.mustache case arms
+    // for atom_concat/3, atom_length/2, char_code/2, atom_codes/2,
+    // atom_string/2, upcase_atom/2, downcase_atom/2, atom_number/2,
+    // succ/2.
+
+    | BuiltinCall ("atom_concat/3", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some (Atom a), Some (Atom b) ->
+            match bindOutput 3 (Atom (a + b)) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    | BuiltinCall ("atom_length/2", _) | BuiltinCall ("string_length/2", _) ->
+        match getReg 1 s with
+        | Some (Atom a) ->
+            match bindOutput 2 (Integer a.Length) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    // char_code/2 — single-char atom <-> Unicode code point. Bidirectional.
+    | BuiltinCall ("char_code/2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some (Atom a), _ when a.Length = 1 ->
+            match bindOutput 2 (Integer (int a.[0])) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | Some (Unbound _), Some (Integer c) when c >= 0 && c <= 65535 ->
+            match bindOutput 1 (Atom (string (char c))) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    // atom_codes/2 — atom <-> list of Integer code points. Bidirectional.
+    | BuiltinCall ("atom_codes/2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some (Atom a), _ ->
+            let codes = a |> Seq.map (fun c -> Integer (int c)) |> List.ofSeq
+            match bindOutput 2 (VList codes) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | Some (Unbound _), Some (VList items) ->
+            let folder acc v =
+                match acc, derefVar s.WsBindings v with
+                | Some (sb: System.Text.StringBuilder), Integer c when c >= 0 && c <= 65535 ->
+                    Some (sb.Append(char c))
+                | _ -> None
+            match List.fold folder (Some (System.Text.StringBuilder())) items with
+            | Some sb ->
+                match bindOutput 1 (Atom (sb.ToString())) s with
+                | None    -> None
+                | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+            | None -> None
+        | _ -> None
+
+    // atom_chars/2 — atom <-> list of single-char atoms. Bidirectional.
+    | BuiltinCall ("atom_chars/2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some (Atom a), _ ->
+            let chars = a |> Seq.map (fun c -> Atom (string c)) |> List.ofSeq
+            match bindOutput 2 (VList chars) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | Some (Unbound _), Some (VList items) ->
+            let folder acc v =
+                match acc, derefVar s.WsBindings v with
+                | Some (sb: System.Text.StringBuilder), Atom c when c.Length = 1 ->
+                    Some (sb.Append(c))
+                | _ -> None
+            match List.fold folder (Some (System.Text.StringBuilder())) items with
+            | Some sb ->
+                match bindOutput 1 (Atom (sb.ToString())) s with
+                | None    -> None
+                | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+            | None -> None
+        | _ -> None
+
+    // atom_string/2 — atom <-> "string". F# Atom is already string-based,
+    // so this is essentially an identity reinterpretation. Mirrors the
+    // Go target''s atom_string/2 + string_to_atom/2 unified case (where
+    // both directions succeed when either side is an Atom).
+    | BuiltinCall ("atom_string/2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some (Atom a), _ ->
+            match bindOutput 2 (Atom a) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _, Some (Atom a) ->
+            match bindOutput 1 (Atom a) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    // string_to_atom/2 — String in A1, Atom in A2 (reversed arg order
+    // relative to atom_string/2 per SWI convention).
+    | BuiltinCall ("string_to_atom/2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some (Atom a), _ ->
+            match bindOutput 2 (Atom a) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _, Some (Atom a) ->
+            match bindOutput 1 (Atom a) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    // upcase_atom/2, downcase_atom/2 — Unicode-aware ASCII-safe case
+    // conversion using .NET''s invariant-culture transforms.
+    | BuiltinCall ("upcase_atom/2", _) ->
+        match getReg 1 s with
+        | Some (Atom a) ->
+            match bindOutput 2 (Atom (a.ToUpperInvariant())) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    | BuiltinCall ("downcase_atom/2", _) ->
+        match getReg 1 s with
+        | Some (Atom a) ->
+            match bindOutput 2 (Atom (a.ToLowerInvariant())) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    // atom_number/2 — atom <-> Integer / Float. Tries integer parse first,
+    // then float parse (invariant culture for the float form). Reverse
+    // direction emits the canonical %d (Integer) or %g (Float) format.
+    | BuiltinCall ("atom_number/2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some (Atom a), _ ->
+            let asInt = System.Int64.TryParse(a)
+            match asInt with
+            | true, n ->
+                match bindOutput 2 (Integer (int n)) s with
+                | None    -> None
+                | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+            | _ ->
+                let asFloat = System.Double.TryParse(a,
+                                System.Globalization.NumberStyles.Float,
+                                System.Globalization.CultureInfo.InvariantCulture)
+                match asFloat with
+                | true, f ->
+                    match bindOutput 2 (Float f) s with
+                    | None    -> None
+                    | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+                | _ -> None
+        | _, Some (Integer n) ->
+            match bindOutput 1 (Atom (string n)) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _, Some (Float f) ->
+            let txt = f.ToString("G", System.Globalization.CultureInfo.InvariantCulture)
+            match bindOutput 1 (Atom txt) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    // succ/2 — Integer successor. succ(X, Y) iff Y = X + 1 and both are
+    // non-negative. Bidirectional. Mirrors the Go target''s succ/2.
+    | BuiltinCall ("succ/2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some (Integer x), _ when x >= 0 ->
+            match bindOutput 2 (Integer (x + 1)) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _, Some (Integer y) when y > 0 ->
+            match bindOutput 1 (Integer (y - 1)) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
     | BuiltinCall ("member/2", _) ->
         let elem_ = s.WsRegs.[1] |> derefVar s.WsBindings
         let list_ = s.WsRegs.[2] |> derefVar s.WsBindings

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -1329,6 +1329,201 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
             | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
         | _ -> None
 
+    // ========================================================================
+    // Phase H — list / sort / order / unification builtins (Go parity)
+    // ========================================================================
+    // Reference: templates/targets/go_wam/state.go.mustache.  These all
+    // operate on F#''s VList shape (a flat Value list).  Standard-order
+    // comparisons use the runtime compareValue helper (defined in
+    // WamTypes.fs alongside copyTermWalk and friends) rather than the
+    // Value type''s CustomComparison override, which has a recursive
+    // CompareTo implementation that is not safe for the hot path.
+
+    // append/3 — concat two ground lists. Reverse / partial modes are
+    // intentionally not supported here (parity with Go''s listToSlice +
+    // slice concat: both A1 and A2 must be VList).
+    | BuiltinCall ("append/3", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some (VList xs), Some (VList ys) ->
+            match bindOutput 3 (VList (xs @ ys)) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    // reverse/2 — list reverse. Bidirectional: whichever side is bound
+    // becomes the source, the other becomes the output.
+    | BuiltinCall ("reverse/2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some (VList items), _ ->
+            match bindOutput 2 (VList (List.rev items)) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _, Some (VList items) ->
+            match bindOutput 1 (VList (List.rev items)) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    // last/2 — extract the last element of a non-empty list.
+    | BuiltinCall ("last/2", _) ->
+        match getReg 1 s with
+        | Some (VList items) when not (List.isEmpty items) ->
+            match bindOutput 2 (List.last items) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    // nth0/3, nth1/3 — index access. nth0 is 0-based, nth1 is 1-based.
+    | BuiltinCall ("nth0/3", _) | BuiltinCall ("nth1/3", _) ->
+        let base_ =
+            match instr with
+            | BuiltinCall ("nth1/3", _) -> 1
+            | _ -> 0
+        match getReg 1 s, getReg 2 s with
+        | Some (Integer i), Some (VList items) ->
+            let idx = i - base_
+            if idx >= 0 && idx < List.length items then
+                match bindOutput 3 (List.item idx items) s with
+                | None    -> None
+                | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+            else None
+        | _ -> None
+
+    // memberchk/2 — deterministic membership check: succeed once on the
+    // first match, no choice points. Mirrors the Go memberchk/2 fast
+    // path that just walks the list and returns true on first Unify.
+    | BuiltinCall ("memberchk/2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some elem_, Some (VList items) ->
+            if items |> List.exists (fun v -> derefVar s.WsBindings v = elem_) then
+                Some { s with WsPC = s.WsPC + 1 }
+            else None
+        | _ -> None
+
+    // delete/3 — remove ALL occurrences of A2 from list A1, produce A3.
+    | BuiltinCall ("delete/3", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some (VList items), Some target ->
+            let kept = items |> List.filter (fun v -> derefVar s.WsBindings v <> target)
+            match bindOutput 3 (VList kept) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    // select/3 — choose one element to remove. Deterministic first-
+    // solution semantics: returns the first selection that unifies with
+    // A1, with the remaining list in A3.  Full backtracking via choice
+    // points is left for a follow-up (parity with the Go select/3 that
+    // does enumerate all solutions via ChoicePoint records).
+    | BuiltinCall ("select/3", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some elem_, Some (VList items) ->
+            let rec findSplit prefix rest =
+                match rest with
+                | [] -> None
+                | x :: xs ->
+                    let dx = derefVar s.WsBindings x
+                    if dx = elem_ then Some (List.rev prefix @ xs)
+                    else findSplit (x :: prefix) xs
+            match findSplit [] items with
+            | None      -> None
+            | Some rest ->
+                match bindOutput 3 (VList rest) s with
+                | None    -> None
+                | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    // numlist/3 — generate the inclusive integer range [Lo..Hi] into A3.
+    | BuiltinCall ("numlist/3", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some (Integer lo), Some (Integer hi) when lo <= hi ->
+            let items = [ for n in lo .. hi -> Integer n ]
+            match bindOutput 3 (VList items) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    // sort/2 — standard-order sort with dedup. msort/2 — same sort
+    // without dedup. Both use compareValue (the runtime helper) for the
+    // sort key.
+    | BuiltinCall ("sort/2", _) ->
+        match getReg 1 s with
+        | Some (VList items) ->
+            let deref_ = items |> List.map (derefVar s.WsBindings)
+            let sorted = deref_ |> List.sortWith compareValue
+            let rec dedup xs =
+                match xs with
+                | []                              -> []
+                | [x]                             -> [x]
+                | x :: y :: rest when compareValue x y = 0 -> dedup (x :: rest)
+                | x :: rest                       -> x :: dedup rest
+            match bindOutput 2 (VList (dedup sorted)) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    | BuiltinCall ("msort/2", _) ->
+        match getReg 1 s with
+        | Some (VList items) ->
+            let sorted = items |> List.map (derefVar s.WsBindings) |> List.sortWith compareValue
+            match bindOutput 2 (VList sorted) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    // compare/3 — three-way compare: bind A1 to ''<'', ''='', or ''>'' based
+    // on the standard-order comparison of A2 vs A3.
+    | BuiltinCall ("compare/3", _) ->
+        match getReg 2 s, getReg 3 s with
+        | Some a, Some b ->
+            let c = compareValue a b
+            let order = if c < 0 then Atom "<" elif c > 0 then Atom ">" else Atom "="
+            match bindOutput 1 order s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | _ -> None
+
+    // @</2, @=</2, @>/2, @>=/2 — standard-order comparison predicates.
+    | BuiltinCall ("@</2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some a, Some b when compareValue a b < 0 -> Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
+    | BuiltinCall ("@=</2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some a, Some b when compareValue a b <= 0 -> Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
+    | BuiltinCall ("@>/2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some a, Some b when compareValue a b > 0 -> Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
+    | BuiltinCall ("@>=/2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some a, Some b when compareValue a b >= 0 -> Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
+    // =/2 — explicit unification. Delegates to the local unifyVal helper
+    // that lives at the end of the step function (binding-trail aware).
+    | BuiltinCall ("=/2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some a, Some b -> unifyVal a b s
+        | _ -> None
+
+    // \\=/2 — non-unifiable check. Succeeds when A1 and A2 cannot unify
+    // under the current binding state.  Implemented by attempting
+    // unification on a copy of the state and inverting the result; if
+    // the trial unifies, \\=/2 fails (bindings are discarded since we
+    // never thread the trial state out).
+    | BuiltinCall ("\\\\=/2", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some a, Some b ->
+            match unifyVal a b s with
+            | Some _ -> None
+            | None   -> Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
     | BuiltinCall ("member/2", _) ->
         let elem_ = s.WsRegs.[1] |> derefVar s.WsBindings
         let list_ = s.WsRegs.[2] |> derefVar s.WsBindings

--- a/tests/test_wam_fsharp_target.pl
+++ b/tests/test_wam_fsharp_target.pl
@@ -378,6 +378,190 @@ test_fsharp_succ_builtin :-
     ).
 
 %% ----------------------------------------------------------------------
+%% Phase H parity: list / sort / order / unification builtins.  Brings
+%% the F# target to the remaining Go-target builtin coverage (append/3,
+%% reverse/2, last/2, nth0/3, nth1/3, memberchk/2, delete/3, select/3,
+%% numlist/3, sort/2, msort/2, compare/3, @</2 family, =/2, \\=/2).
+%% Reference: templates/targets/go_wam/state.go.mustache.
+%% ----------------------------------------------------------------------
+
+test_fsharp_compare_value_helper_present :-
+    %% compareValue + compareValueList live in WamTypes.fs (the type
+    %% header preamble), invoked by compare/3, the @ comparisons, and
+    %% sort/2 / msort/2. The helper avoids the Value type''s recursive
+    %% CustomComparison override.
+    Test = 'WAM-FSharp: compareValue helper present in type header',
+    (   fsharp_wam_type_header(Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "let rec compareValue"),
+        sub_string(S, _, _, _, "compareValueList"),
+        %% Standard ordering: Var < Number < Atom < Compound.
+        sub_string(S, _, _, _, "| Unbound _           -> 0"),
+        sub_string(S, _, _, _, "| Atom _              -> 2"),
+        %% Numeric mixing via float-promotion.
+        sub_string(S, _, _, _, "| Integer x, Float y   -> compare (float x) y")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing compareValue / compareValueList helpers')
+    ).
+
+test_fsharp_append_builtin :-
+    Test = 'WAM-FSharp: append/3',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"append/3\""),
+        %% F# list concatenation operator on the two VList contents.
+        sub_string(S, _, _, _, "VList (xs @ ys)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing append/3 step case')
+    ).
+
+test_fsharp_reverse_builtin :-
+    Test = 'WAM-FSharp: reverse/2 (bidirectional)',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"reverse/2\""),
+        sub_string(S, _, _, _, "List.rev items")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing reverse/2 step case')
+    ).
+
+test_fsharp_last_builtin :-
+    Test = 'WAM-FSharp: last/2',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"last/2\""),
+        %% Non-empty list guard.
+        sub_string(S, _, _, _, "not (List.isEmpty items)"),
+        sub_string(S, _, _, _, "List.last items")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing last/2 step case')
+    ).
+
+test_fsharp_nth_builtins :-
+    Test = 'WAM-FSharp: nth0/3 + nth1/3',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"nth0/3\""),
+        sub_string(S, _, _, _, "BuiltinCall (\"nth1/3\""),
+        %% Shared dispatch with a base offset derived from the op name.
+        sub_string(S, _, _, _, "List.item idx items")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing nth0/3 / nth1/3 step case')
+    ).
+
+test_fsharp_memberchk_builtin :-
+    Test = 'WAM-FSharp: memberchk/2',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"memberchk/2\""),
+        %% Deterministic: no choice point, just List.exists.
+        sub_string(S, _, _, _, "items |> List.exists"),
+        sub_string(S, _, _, _, "derefVar s.WsBindings v = elem_")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing memberchk/2 step case')
+    ).
+
+test_fsharp_delete_builtin :-
+    Test = 'WAM-FSharp: delete/3',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"delete/3\""),
+        %% Removes ALL occurrences via List.filter.
+        sub_string(S, _, _, _, "List.filter")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing delete/3 step case')
+    ).
+
+test_fsharp_select_builtin :-
+    Test = 'WAM-FSharp: select/3 (deterministic first-solution)',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"select/3\""),
+        %% Linear split-by-element implementation.
+        sub_string(S, _, _, _, "findSplit")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing select/3 step case')
+    ).
+
+test_fsharp_numlist_builtin :-
+    Test = 'WAM-FSharp: numlist/3',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"numlist/3\""),
+        %% Range comprehension generates the Integer list.
+        sub_string(S, _, _, _, "for n in lo .. hi -> Integer n")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing numlist/3 step case')
+    ).
+
+test_fsharp_sort_msort_builtins :-
+    Test = 'WAM-FSharp: sort/2 + msort/2',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"sort/2\""),
+        sub_string(S, _, _, _, "BuiltinCall (\"msort/2\""),
+        %% Both call List.sortWith compareValue.
+        sub_string(S, _, _, _, "List.sortWith compareValue"),
+        %% sort/2 has a dedup pass; msort/2 does not.
+        sub_string(S, _, _, _, "let rec dedup")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing sort/2 / msort/2 step cases')
+    ).
+
+test_fsharp_compare_builtin :-
+    Test = 'WAM-FSharp: compare/3',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"compare/3\""),
+        %% Result is an Atom dispatching on the sign of compareValue.
+        sub_string(S, _, _, _, "if c < 0 then Atom \"<\" elif c > 0 then Atom \">\" else Atom \"=\"")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing compare/3 step case')
+    ).
+
+test_fsharp_standard_order_comparison :-
+    Test = 'WAM-FSharp: @</2, @=</2, @>/2, @>=/2',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"@</2\""),
+        sub_string(S, _, _, _, "BuiltinCall (\"@=</2\""),
+        sub_string(S, _, _, _, "BuiltinCall (\"@>/2\""),
+        sub_string(S, _, _, _, "BuiltinCall (\"@>=/2\""),
+        %% All four call compareValue.
+        sub_string(S, _, _, _, "compareValue a b < 0"),
+        sub_string(S, _, _, _, "compareValue a b <= 0"),
+        sub_string(S, _, _, _, "compareValue a b > 0"),
+        sub_string(S, _, _, _, "compareValue a b >= 0")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing @ comparison step cases')
+    ).
+
+test_fsharp_unify_builtin :-
+    Test = 'WAM-FSharp: =/2 (explicit unification)',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"=/2\""),
+        %% Delegates to the local unifyVal helper that lives at the
+        %% end of the step function (binding-trail aware).
+        sub_string(S, _, _, _, "unifyVal a b s")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing =/2 step case')
+    ).
+
+test_fsharp_not_unifiable_builtin :-
+    Test = 'WAM-FSharp: \\=/2 (non-unifiable)',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        %% F# pattern emits "\\=/2" (one backslash at runtime),
+        %% matching the WAM op name.
+        sub_string(S, _, _, _, "BuiltinCall (\"\\\\=/2\""),
+        %% Inverted-unify pattern: Some _ (unified) => None (fail).
+        sub_string(S, _, _, _, "| Some _ -> None")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing \\=/2 step case')
+    ).
+
+%% ----------------------------------------------------------------------
 %% Phase F parity smoke: fact-shape classification helpers exposed by
 %% the F# target (parity infra used by Haskell / Elixir hybrid targets).
 %% ----------------------------------------------------------------------
@@ -534,6 +718,21 @@ run_tests :-
     test_fsharp_case_conversion_builtins,
     test_fsharp_atom_number_builtin,
     test_fsharp_succ_builtin,
+    %% Phase H — list / sort / order / unification (Go parity)
+    test_fsharp_compare_value_helper_present,
+    test_fsharp_append_builtin,
+    test_fsharp_reverse_builtin,
+    test_fsharp_last_builtin,
+    test_fsharp_nth_builtins,
+    test_fsharp_memberchk_builtin,
+    test_fsharp_delete_builtin,
+    test_fsharp_select_builtin,
+    test_fsharp_numlist_builtin,
+    test_fsharp_sort_msort_builtins,
+    test_fsharp_compare_builtin,
+    test_fsharp_standard_order_comparison,
+    test_fsharp_unify_builtin,
+    test_fsharp_not_unifiable_builtin,
     test_fsharp_fact_shape_helpers_exported,
     test_fsharp_emit_mode_resolution,
     test_fsharp_lowerable_single_clause_proceed,

--- a/tests/test_wam_fsharp_target.pl
+++ b/tests/test_wam_fsharp_target.pl
@@ -256,6 +256,128 @@ test_fsharp_io_builtins :-
     ).
 
 %% ----------------------------------------------------------------------
+%% Phase G parity: atom / string builtins (parity with the Go target).
+%% Brings the F# step function to coverage parity with the Go target''s
+%% atom_*, char_code, upcase_atom, downcase_atom, atom_string,
+%% string_to_atom, atom_number, and succ builtins.
+%% Reference: templates/targets/go_wam/state.go.mustache.
+%% ----------------------------------------------------------------------
+
+test_fsharp_atom_concat_builtin :-
+    Test = 'WAM-FSharp: atom_concat/3',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"atom_concat/3\""),
+        %% .NET string concatenation, both A1 and A2 must be Atoms.
+        sub_string(S, _, _, _, "Atom (a + b)"),
+        sub_string(S, _, _, _, "bindOutput 3 (Atom (a + b))")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing atom_concat/3 step case')
+    ).
+
+test_fsharp_atom_length_builtin :-
+    Test = 'WAM-FSharp: atom_length/2 + string_length/2',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        %% Both names alias to the same OR-pattern arm in the step case.
+        sub_string(S, _, _, _, "BuiltinCall (\"atom_length/2\""),
+        sub_string(S, _, _, _, "BuiltinCall (\"string_length/2\""),
+        sub_string(S, _, _, _, "Integer a.Length")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing atom_length/2 / string_length/2 step case')
+    ).
+
+test_fsharp_char_code_builtin :-
+    Test = 'WAM-FSharp: char_code/2',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"char_code/2\""),
+        %% Forward: single-char Atom -> Integer code via int a.[0].
+        sub_string(S, _, _, _, "Integer (int a.[0])"),
+        %% Reverse: Integer code -> single-char Atom via string (char c).
+        sub_string(S, _, _, _, "Atom (string (char c))"),
+        %% BMP guard to keep parity with the Go target''s 0..65535 range.
+        sub_string(S, _, _, _, "c >= 0 && c <= 65535")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing char_code/2 step case patterns')
+    ).
+
+test_fsharp_atom_codes_builtin :-
+    Test = 'WAM-FSharp: atom_codes/2',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"atom_codes/2\""),
+        %% Forward: Atom -> VList of Integer code points.
+        sub_string(S, _, _, _, "Integer (int c)"),
+        sub_string(S, _, _, _, "VList codes"),
+        %% Reverse: VList of Integer -> Atom via StringBuilder fold.
+        sub_string(S, _, _, _, "System.Text.StringBuilder")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing atom_codes/2 step case patterns')
+    ).
+
+test_fsharp_atom_chars_builtin :-
+    Test = 'WAM-FSharp: atom_chars/2',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"atom_chars/2\""),
+        %% Forward: Atom -> VList of single-char Atom values.
+        sub_string(S, _, _, _, "Atom (string c)"),
+        sub_string(S, _, _, _, "VList chars")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing atom_chars/2 step case patterns')
+    ).
+
+test_fsharp_atom_string_aliases :-
+    Test = 'WAM-FSharp: atom_string/2 + string_to_atom/2',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"atom_string/2\""),
+        sub_string(S, _, _, _, "BuiltinCall (\"string_to_atom/2\"")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing atom_string/2 / string_to_atom/2 step cases')
+    ).
+
+test_fsharp_case_conversion_builtins :-
+    Test = 'WAM-FSharp: upcase_atom/2 + downcase_atom/2',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"upcase_atom/2\""),
+        sub_string(S, _, _, _, "BuiltinCall (\"downcase_atom/2\""),
+        %% .NET invariant-culture transforms (Unicode-safe).
+        sub_string(S, _, _, _, "a.ToUpperInvariant()"),
+        sub_string(S, _, _, _, "a.ToLowerInvariant()")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing upcase / downcase step cases')
+    ).
+
+test_fsharp_atom_number_builtin :-
+    Test = 'WAM-FSharp: atom_number/2',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"atom_number/2\""),
+        %% Integer parse first, then Float fallback (invariant culture).
+        sub_string(S, _, _, _, "System.Int64.TryParse"),
+        sub_string(S, _, _, _, "System.Double.TryParse"),
+        sub_string(S, _, _, _, "System.Globalization.CultureInfo.InvariantCulture")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing atom_number/2 step case patterns')
+    ).
+
+test_fsharp_succ_builtin :-
+    Test = 'WAM-FSharp: succ/2',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "BuiltinCall (\"succ/2\""),
+        %% Forward: Integer x (x >= 0) -> Integer (x + 1).
+        sub_string(S, _, _, _, "Integer (x + 1)"),
+        %% Reverse: Integer y (y > 0) -> Integer (y - 1).
+        sub_string(S, _, _, _, "Integer (y - 1)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing succ/2 step case patterns')
+    ).
+
+%% ----------------------------------------------------------------------
 %% Phase F parity smoke: fact-shape classification helpers exposed by
 %% the F# target (parity infra used by Haskell / Elixir hybrid targets).
 %% ----------------------------------------------------------------------
@@ -403,6 +525,15 @@ run_tests :-
     test_fsharp_trivial_control_builtins,
     test_fsharp_type_check_builtins,
     test_fsharp_io_builtins,
+    test_fsharp_atom_concat_builtin,
+    test_fsharp_atom_length_builtin,
+    test_fsharp_char_code_builtin,
+    test_fsharp_atom_codes_builtin,
+    test_fsharp_atom_chars_builtin,
+    test_fsharp_atom_string_aliases,
+    test_fsharp_case_conversion_builtins,
+    test_fsharp_atom_number_builtin,
+    test_fsharp_succ_builtin,
     test_fsharp_fact_shape_helpers_exported,
     test_fsharp_emit_mode_resolution,
     test_fsharp_lowerable_single_clause_proceed,


### PR DESCRIPTION
## Summary

Two commits on the F# hybrid WAM parity branch:

| Commit | Scope | Status |
|---|---|---|
| `a8b5ab7` | Atom / string builtins (Go parity) | **Re-applied** — these were lost from the previous PR #2336 merge (only the round-1 commit got merged; this one was orphaned) |
| `fb527bd` | List / sort / order / unification builtins (Go parity) | New |

Together they close the "remaining Go-style gaps" enumerated at the end of PR #2336.

## Recovered work (commit `a8b5ab7`)

Identical content to the originally-pushed `9340d08` on PR #2336 — cherry-picked from reflog after noticing the merge of PR #2336 only included round 1. Brings the F# step function to atom/string-builtin coverage parity with Go: `atom_concat/3`, `atom_length/2`, `string_length/2`, `char_code/2`, `atom_codes/2`, `atom_chars/2`, `atom_string/2`, `string_to_atom/2`, `upcase_atom/2`, `downcase_atom/2`, `atom_number/2`, `succ/2`. (11 BuiltinCall arms, 12 op keys including the OR-aliased `atom_length/2` + `string_length/2`.)

## New work (commit `fb527bd`)

### Audit

| Family | Builtin | Go | F# before | F# after |
|---|---|---|---|---|
| List ops | `append/3` | ✓ | ✗ | ✓ |
| List ops | `reverse/2` | ✓ | ✗ | ✓ (bidirectional) |
| List ops | `last/2` | ✓ | ✗ | ✓ |
| List ops | `nth0/3`, `nth1/3` | ✓ | ✗ | ✓ (shared dispatch) |
| List ops | `memberchk/2` | ✓ | ✗ | ✓ (deterministic) |
| List ops | `delete/3` | ✓ | ✗ | ✓ |
| List ops | `select/3` | ✓ | ✗ | ✓ (first-solution¹) |
| List ops | `numlist/3` | ✓ | ✗ | ✓ |
| Sort / order | `sort/2`, `msort/2` | ✓ | ✗ | ✓ |
| Sort / order | `compare/3` | ✓ | ✗ | ✓ |
| Sort / order | `@</2`, `@=</2`, `@>/2`, `@>=/2` | ✓ | ✗ | ✓ |
| Unification | `=/2` | ✓ | ✗ | ✓ |
| Unification | `\=/2` | ✓ | ✗ | ✓ |

¹ The Go target's `select/3` enumerates all solutions via `ChoicePoint` records; the F# port lands the deterministic first-solution shape for this round. Full backtracking enumeration is intentionally left as follow-up (it needs the same `BuiltinState` / `FactRetry`-style choice-point machinery the existing `member/2` setup uses).

### Implementation notes

- **`compareValue` / `compareValueList`** (new helpers in `WamTypes.fs`): explicit pattern-match standard term ordering — `Var < Number < Atom < Compound (incl. VList)` — with float-promotion for mixed `Integer` / `Float` numeric comparisons. Compounds compare by arity first, then functor name, then element-wise. Independent of the `Value` DU's `CustomComparison` override, whose `IComparable.CompareTo` implementation has a self-recursive `compare this other` call that would stack-overflow under the hot path. The helper is the source of truth for `compare/3`, `@</2` and friends, `sort/2`, and `msort/2`.

- **`sort/2`** uses `List.sortWith compareValue` plus a tail-recursive `dedup` pass; `msort/2` is the same sort without dedup.

- **`memberchk/2`** is deterministic (no choice point) — just a `List.exists` walk.

- **`delete/3`** removes all occurrences of A2, matching the Go target's `valueEquals` filter loop.

- **`select/3`** uses an explicit `findSplit` helper that walks the list with a prefix accumulator, returning the first split where the head unifies with A1.

- **`=/2`** delegates to the existing `unifyVal` helper that lives at the end of the step function (binding-trail aware).

- **`\=/2`** runs `unifyVal` on the live state and inverts the result; if the trial unifies, `\=/2` fails. The trial's bindings are never threaded out, so this is non-destructive at the Prolog level (the failed unification's trail entries are discarded along with the `Some _` result).

### Files changed

- `src/unifyweaver/bindings/fsharp_wam_bindings.pl` — adds the `compareValue` / `compareValueList` helpers to the type-header preamble (emitted as part of `WamTypes.fs`).
- `src/unifyweaver/targets/wam_fsharp_target.pl` — 18 new `BuiltinCall` step arms.
- `tests/test_wam_fsharp_target.pl` — 14 new codegen parity assertions (40 tests total now).

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl` — **40 / 40 pass**.
- `swipl -q -g run_benchmarks -t halt tests/bench_wam_fsharp.pl` — pre-existing benchmark steady at ~1.75-1.85× lowered-vs-interpreter speedup.
- `swipl -q -g run_tests -t halt tests/core/test_fsharp_native_lowering.pl` — pre-existing native-lowering tests still pass.

## Test plan

- [x] All 40 codegen parity tests pass.
- [x] Pre-existing F# WAM benchmark + native-lowering tests still pass.
- [x] Codegen spot check: all 18 new patterns plus `compareValue` are present in `WamRuntime.fs` / `WamTypes.fs`.
- [ ] _(Out of scope: full `dotnet build` of a generated project — same constraint as PR #2335 / #2336 and the Haskell target test suite.)_

## Remaining gaps (future work)

After this PR, the F# WAM target's step function covers the full Rust + Go builtin baselines for the common-case Prolog source surface. Known remaining work for full Haskell-target parity:

- **Specialized lowered instructions** (Haskell-only, not in Rust / Go / C++): `PutStructureDyn`, `Arg n tReg aReg`, `NotMemberList`, `NotMemberConstAtoms`, `VSet` + `BuildEmptySet` / `SetInsert` / `NotMemberSet`. These are perf optimizations rather than new functionality.
- **`select/3` full backtracking** via `BuiltinState`-style choice points (parity with the Go `select/3` enumeration).
- **Parallel WAM** — full Task-Parallel-Library wiring for `ParTryMeElse` (F# already has the alias stubs).
- **Value DU `CustomComparison` fix** — the existing override is buggy but unused on the hot path; `compareValue` works around it. Removing the broken attributes and letting F# auto-generate structural comparison would be a clean follow-up.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_