### PR TITLE
refactor(wam-fsharp): Value DU cleanup + select/3 full backtracking

### DIFF
--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -66,7 +66,22 @@ init_fsharp_wam_bindings.
 
 fsharp_wam_value_type :-
     writeln(
-"[<CustomEquality; CustomComparison>]
+"/// Discriminated union for runtime Prolog values.
+///
+/// F# auto-generates structural equality and structural comparison for
+/// DUs, so we deliberately do NOT use [<CustomEquality; CustomComparison>]
+/// here.  An earlier version did, with `Equals(obj) = match ... -> this = other`
+/// and `IComparable.CompareTo = compare this other` overrides — both
+/// recurse through the very operator they''re trying to define, which
+/// would stack-overflow if ever exercised on the hot path.  The runtime
+/// hot path matches Value variants pattern-by-pattern anyway, so the
+/// override was unreachable; removing it is a pure cleanup.
+///
+/// For Prolog-standard term order (Var < Number < Atom < Compound) — as
+/// required by compare/3, @</2 and friends, sort/2, msort/2 — call the
+/// runtime helper compareValue (defined below) directly.  F#''s default
+/// structural comparison is NOT Prolog-standard order: it follows the
+/// DU constructor declaration order (Atom < Integer < Float < VList < ...).
 type Value =
     | Atom    of string
     | Integer of int
@@ -74,17 +89,7 @@ type Value =
     | VList   of Value list
     | Str     of string * Value list   // functor name, args
     | Unbound of int                   // variable id
-    | Ref     of int                   // heap reference
-    interface System.IComparable with
-        member this.CompareTo(obj) =
-            match obj with
-            | :? Value as other -> compare this other
-            | _ -> -1
-    override this.Equals(obj) =
-        match obj with
-        | :? Value as other -> this = other
-        | _ -> false
-    override this.GetHashCode() = hash this").
+    | Ref     of int                   // heap reference").
 
 % ============================================================================
 % TrailEntry — mirrors Haskell `data TrailEntry`
@@ -480,11 +485,12 @@ and copyTermArgs (c: int) (m: Map<int, int>) (xs: Value list)
 /// name, then element-wise.  VList behaves like a compound with functor
 /// '.' and arity matching the list length.
 ///
-/// This helper is independent of the Value type's CustomComparison
-/// override — that override's `compare this other` recurses through
-/// `IComparable.CompareTo` and is not used by the runtime hot path.
-/// Built-ins that need standard order (compare/3, @</2, @=</2, @>/2,
-/// @>=/2, sort/2, msort/2) call compareValue directly.
+/// F#''s auto-generated structural comparison for the Value DU follows
+/// the constructor declaration order (Atom < Integer < Float < VList <
+/// Str < Unbound < Ref) — which is NOT Prolog standard order. So
+/// builtins that need standard order (compare/3, @</2, @=</2, @>/2,
+/// @>=/2, sort/2, msort/2) call compareValue directly rather than
+/// relying on the F# `compare` operator on Value.
 let rec compareValue (a: Value) (b: Value) : int =
     let rankOf v =
         match v with

--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -116,7 +116,13 @@ fsharp_wam_builtin_state_type :-
 "type BuiltinState =
     | FactRetry      of varId: int * remaining: string list * retPC: int
     | HopsRetry      of varId: int * remaining: int list   * retPC: int
-    | FFIStreamRetry of outRegs: int list * outVars: int list * remaining: Value list list * retPC: int").
+    | FFIStreamRetry of outRegs: int list * outVars: int list * remaining: Value list list * retPC: int
+    /// select/3 enumeration choice point.  Each remaining candidate is
+    /// a pair (selected, rest_items): on backtrack the runtime restores
+    /// the CP snapshot, unifies elemReg with `selected`, and binds
+    /// outReg to VList rest_items.  Mirrors the Go target's
+    /// SelectResults field (templates/targets/go_wam/state.go.mustache).
+    | SelectRetry    of elemReg: int * outReg: int * remaining: (Value * Value list) list * retPC: int").
 
 % ============================================================================
 % EnvFrame — mirrors Haskell `EnvFrame`

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -620,6 +620,50 @@ and resumeBuiltin (bs: BuiltinState) (cp: ChoicePoint) (rest: ChoicePoint list) 
                  WsCutBar   = cp.CpCutBar
                  WsCPs      = newCPs
                  WsCPsLen   = List.length newCPs }
+    | SelectRetry (_, _, [], _) ->
+        backtrack { s with WsCPs = rest; WsCPsLen = s.WsCPsLen - 1 }
+    | SelectRetry (elemReg, outReg, candidates, retPC) ->
+        // Restore from snapshot ONCE up front, then walk candidates with
+        // unifyVal until one succeeds (or all fail).  unifyVal returns
+        // None on failure without committing trail entries, so iterating
+        // candidates against the restored state is safe.
+        let diff = s.WsTrailLen - cp.CpTrailLen
+        let restoredS = { s with
+                             WsRegs     = Array.copy cp.CpRegs
+                             WsStack    = cp.CpStack
+                             WsCP       = cp.CpCP
+                             WsTrail    = List.skip diff s.WsTrail
+                             WsTrailLen = cp.CpTrailLen
+                             WsHeap     = List.take cp.CpHeapLen s.WsHeap
+                             WsHeapLen  = cp.CpHeapLen
+                             WsBindings = cp.CpBindings
+                             WsCutBar   = cp.CpCutBar
+                             WsPC       = retPC }
+        let rec tryNext pairs =
+            match pairs with
+            | [] -> backtrack { s with WsCPs = rest; WsCPsLen = s.WsCPsLen - 1 }
+            | (sel, restList) :: more ->
+                match getReg elemReg restoredS with
+                | None -> backtrack { s with WsCPs = rest; WsCPsLen = s.WsCPsLen - 1 }
+                | Some elem_ ->
+                    match unifyVal elem_ sel restoredS with
+                    | None    -> tryNext more
+                    | Some s2 ->
+                        match bindOutput outReg (VList restList) s2 with
+                        | None    -> tryNext more
+                        | Some s3 ->
+                            let newCPs =
+                                match more with
+                                | [] -> rest
+                                | _  -> { cp with CpBuiltin = Some (SelectRetry (elemReg, outReg, more, retPC)) } :: rest
+                            Some { s3 with
+                                     WsPC       = retPC
+                                     WsStack    = cp.CpStack
+                                     WsCP       = cp.CpCP
+                                     WsCutBar   = cp.CpCutBar
+                                     WsCPs      = newCPs
+                                     WsCPsLen   = List.length newCPs }
+        tryNext candidates
     | FFIStreamRetry (_, _, [], _) ->
         backtrack { s with WsCPs = rest; WsCPsLen = s.WsCPsLen - 1 }
     | FFIStreamRetry (outRegs, outVars, tuple :: restTuples, retPC) ->
@@ -1410,27 +1454,54 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
             | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
         | _ -> None
 
-    // select/3 — choose one element to remove. Deterministic first-
-    // solution semantics: returns the first selection that unifies with
-    // A1, with the remaining list in A3.  Full backtracking via choice
-    // points is left for a follow-up (parity with the Go select/3 that
-    // does enumerate all solutions via ChoicePoint records).
+    // select/3 — choose one element to remove with full backtracking
+    // semantics (parity with the Go target''s SelectResults ChoicePoint
+    // enumeration).  Computes all (selected, rest) splits upfront, then
+    // attempts unifyVal on each in turn.  The first successful split
+    // commits; if more remain, a SelectRetry CP is pushed so backtrack
+    // resumes through resumeBuiltin (SelectRetry arm above) and tries
+    // the next candidate.
     | BuiltinCall ("select/3", _) ->
         match getReg 1 s, getReg 2 s with
         | Some elem_, Some (VList items) ->
-            let rec findSplit prefix rest =
+            let rec splits prefix rest =
                 match rest with
-                | [] -> None
+                | [] -> []
                 | x :: xs ->
-                    let dx = derefVar s.WsBindings x
-                    if dx = elem_ then Some (List.rev prefix @ xs)
-                    else findSplit (x :: prefix) xs
-            match findSplit [] items with
-            | None      -> None
-            | Some rest ->
-                match bindOutput 3 (VList rest) s with
-                | None    -> None
-                | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+                    (derefVar s.WsBindings x, List.rev prefix @ xs)
+                    :: splits (x :: prefix) xs
+            let allSplits = splits [] items
+            let retPC = s.WsPC + 1
+            let rec tryNext pairs =
+                match pairs with
+                | [] -> None
+                | (sel, restList) :: more ->
+                    match unifyVal elem_ sel s with
+                    | None    -> tryNext more
+                    | Some s2 ->
+                        match bindOutput 3 (VList restList) s2 with
+                        | None    -> tryNext more
+                        | Some s3 ->
+                            let newCPs, newCPsLen =
+                                if List.isEmpty more then
+                                    s.WsCPs, s.WsCPsLen
+                                else
+                                    let cp = { CpNextPC   = retPC
+                                               CpRegs     = Array.copy s.WsRegs
+                                               CpStack    = s.WsStack
+                                               CpCP       = s.WsCP
+                                               CpTrailLen = s.WsTrailLen
+                                               CpHeapLen  = s.WsHeapLen
+                                               CpBindings = s.WsBindings
+                                               CpCutBar   = s.WsCutBar
+                                               CpAggFrame = None
+                                               CpBuiltin  = Some (SelectRetry (1, 3, more, retPC)) }
+                                    cp :: s.WsCPs, s.WsCPsLen + 1
+                            Some { s3 with
+                                     WsPC      = retPC
+                                     WsCPs     = newCPs
+                                     WsCPsLen  = newCPsLen }
+            tryNext allSplits
         | _ -> None
 
     // numlist/3 — generate the inclusive integer range [Lo..Hi] into A3.

--- a/tests/test_wam_fsharp_target.pl
+++ b/tests/test_wam_fsharp_target.pl
@@ -500,14 +500,48 @@ test_fsharp_delete_builtin :-
     ).
 
 test_fsharp_select_builtin :-
-    Test = 'WAM-FSharp: select/3 (deterministic first-solution)',
+    %% select/3 now enumerates all solutions via SelectRetry choice
+    %% points (parity with the Go target's SelectResults).
+    Test = 'WAM-FSharp: select/3 (full backtracking)',
     (   compile_wam_runtime_to_fsharp([], [], Code),
         atom_string(Code, S),
         sub_string(S, _, _, _, "BuiltinCall (\"select/3\""),
-        %% Linear split-by-element implementation.
-        sub_string(S, _, _, _, "findSplit")
+        %% Computes all (selected, rest) splits upfront.
+        sub_string(S, _, _, _, "let rec splits prefix rest ="),
+        %% Pushes SelectRetry CP with the remaining candidates.
+        sub_string(S, _, _, _, "Some (SelectRetry (1, 3, more, retPC))")
     ->  pass(Test)
-    ;   fail_test(Test, 'Missing select/3 step case')
+    ;   fail_test(Test, 'Missing select/3 backtracking patterns')
+    ).
+
+test_fsharp_select_retry_builtin_state :-
+    %% SelectRetry must be declared in the BuiltinState DU alongside
+    %% FactRetry / HopsRetry / FFIStreamRetry.
+    Test = 'WAM-FSharp: SelectRetry arm in BuiltinState DU',
+    (   fsharp_wam_type_header(Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "| SelectRetry"),
+        %% Carries elemReg, outReg, remaining (Value, Value list) pairs,
+        %% and retPC.
+        sub_string(S, _, _, _, "elemReg: int * outReg: int * remaining: (Value * Value list) list * retPC: int")
+    ->  pass(Test)
+    ;   fail_test(Test, 'SelectRetry arm missing from BuiltinState')
+    ).
+
+test_fsharp_select_retry_resume_handler :-
+    %% resumeBuiltin must dispatch on SelectRetry and restore the CP
+    %% snapshot before trying the next candidate.
+    Test = 'WAM-FSharp: resumeBuiltin handles SelectRetry',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "| SelectRetry (_, _, [], _) ->"),
+        sub_string(S, _, _, _, "| SelectRetry (elemReg, outReg, candidates, retPC) ->"),
+        %% Snapshot restoration before unification.
+        sub_string(S, _, _, _, "WsBindings = cp.CpBindings"),
+        %% Iterates candidates and chains via tryNext.
+        sub_string(S, _, _, _, "let rec tryNext pairs =")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing SelectRetry resume handler patterns')
     ).
 
 test_fsharp_numlist_builtin :-
@@ -755,6 +789,8 @@ run_tests :-
     test_fsharp_memberchk_builtin,
     test_fsharp_delete_builtin,
     test_fsharp_select_builtin,
+    test_fsharp_select_retry_builtin_state,
+    test_fsharp_select_retry_resume_handler,
     test_fsharp_numlist_builtin,
     test_fsharp_sort_msort_builtins,
     test_fsharp_compare_builtin,

--- a/tests/test_wam_fsharp_target.pl
+++ b/tests/test_wam_fsharp_target.pl
@@ -388,8 +388,9 @@ test_fsharp_succ_builtin :-
 test_fsharp_compare_value_helper_present :-
     %% compareValue + compareValueList live in WamTypes.fs (the type
     %% header preamble), invoked by compare/3, the @ comparisons, and
-    %% sort/2 / msort/2. The helper avoids the Value type''s recursive
-    %% CustomComparison override.
+    %% sort/2 / msort/2. The helper implements Prolog-standard term
+    %% ordering, which is NOT the same as F#''s default structural
+    %% comparison (F# orders DU variants by declaration position).
     Test = 'WAM-FSharp: compareValue helper present in type header',
     (   fsharp_wam_type_header(Code),
         atom_string(Code, S),
@@ -402,6 +403,32 @@ test_fsharp_compare_value_helper_present :-
         sub_string(S, _, _, _, "| Integer x, Float y   -> compare (float x) y")
     ->  pass(Test)
     ;   fail_test(Test, 'Missing compareValue / compareValueList helpers')
+    ).
+
+test_fsharp_value_du_no_buggy_overrides :-
+    %% Regression guard for the Value DU cleanup. The earlier definition
+    %% carried [<CustomEquality; CustomComparison>] plus an Equals /
+    %% CompareTo override that recursed through `this = other` /
+    %% `compare this other` — both would stack-overflow if exercised on
+    %% the hot path. Removing them lets F# auto-generate proper
+    %% structural equality + comparison for the DU.
+    %%
+    %% Checks for the actual F# syntax that would re-introduce the bug,
+    %% not just keyword mentions (the cleanup commentary in compareValue''s
+    %% docstring intentionally references the removed pattern by name).
+    Test = 'WAM-FSharp: Value DU has no recursive equality / comparison override',
+    (   fsharp_wam_type_header(Code),
+        atom_string(Code, S),
+        %% The interface block opener is gone.
+        \+ sub_string(S, _, _, _, "interface System.IComparable with"),
+        %% The CompareTo / Equals member declarations are gone.
+        \+ sub_string(S, _, _, _, "member this.CompareTo(obj)"),
+        \+ sub_string(S, _, _, _, "override this.Equals(obj)"),
+        \+ sub_string(S, _, _, _, "override this.GetHashCode()"),
+        %% Value DU itself still emitted.
+        sub_string(S, _, _, _, "type Value =")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Buggy override or attribute still present on Value DU')
     ).
 
 test_fsharp_append_builtin :-
@@ -720,6 +747,7 @@ run_tests :-
     test_fsharp_succ_builtin,
     %% Phase H — list / sort / order / unification (Go parity)
     test_fsharp_compare_value_helper_present,
+    test_fsharp_value_du_no_buggy_overrides,
     test_fsharp_append_builtin,
     test_fsharp_reverse_builtin,
     test_fsharp_last_builtin,


### PR DESCRIPTION
## Summary

Two coordinated cleanups + correctness fixes on the F# hybrid WAM target, both on the same branch as requested:

| Commit | Scope |
|---|---|
| `8b5a078` | **Task 1** — Remove buggy `[<CustomEquality; CustomComparison>]` override on `Value` DU |
| `f4c5dee` | **Task 2** — `select/3` full backtracking via new `SelectRetry` `BuiltinState` arm |

## Task 1 — Value DU cleanup

### Problem

The `Value` DU shipped with this override:

```fsharp
[<CustomEquality; CustomComparison>]
type Value =
    | Atom    of string
    ...
    interface System.IComparable with
        member this.CompareTo(obj) =
            match obj with
            | :? Value as other -> compare this other   // <- recurses through CompareTo
            | _ -> -1
    override this.Equals(obj) =
        match obj with
        | :? Value as other -> this = other             // <- recurses through Equals
        | _ -> false
    override this.GetHashCode() = hash this             // <- recurses through GetHashCode
```

`compare this other` dispatches to `IComparable.CompareTo`. `this = other` (with `[<CustomEquality>]`) dispatches to `obj.Equals`. `hash this` dispatches to `GetHashCode`. All three recursive — would stack-overflow on first invocation.

### Why it ran anyway

The runtime hot path always pattern-matches `Value` variants before any equality check (e.g., `Some (Atom a), Some (Atom b) when a = b`, where `a` and `b` are now bound `string`s, not `Value`s). So the override was never reached — but it was a footgun.

### Fix

Drop the attributes and the entire interface/override block. F# auto-generates correct structural equality, structural comparison, and hash for DUs whose components are all comparable types. The runtime hot path is unchanged.

### `compareValue` stays

`compareValue` is still the source of truth for Prolog-standard term ordering (Var < Number < Atom < Compound). F#'s auto-generated structural comparison follows the DU declaration order (`Atom < Integer < Float < VList < Str < Unbound < Ref`), which is **not** Prolog standard order. So `compare/3`, `@</2` family, `sort/2`, `msort/2` still call `compareValue` directly.

Updates `compareValue`'s docstring to reflect the new state (override is gone; the reason `compareValue` exists is the declaration-order-vs-Prolog-standard-order mismatch, not the buggy override).

## Task 2 — select/3 full backtracking

### Problem

The previous `select/3` returned only the first solution; the PR #2337 description called this out as a follow-up.

### Fix

Adds a new `BuiltinState` arm `SelectRetry of elemReg: int * outReg: int * remaining: (Value * Value list) list * retPC: int`. The step case now:

1. Computes **all** `(selected_element, rest_items)` splits upfront.
2. Walks the splits with `unifyVal`; first successful unify + `bindOutput` commits.
3. If more candidates remain, pushes a `SelectRetry` CP with the unused splits.

On backtrack, `resumeBuiltin` picks up the `SelectRetry` arm, restores the CP snapshot (regs / stack / bindings / trail / heap / cut-bar), and walks the candidates from where we left off. Failed `unifyVal` calls leave no trail entries (single-shot bind-or-fail), so iterating candidates against the restored state is safe.

Matches the Go target's `SelectResults` `ChoicePoint` enumeration in `templates/targets/go_wam/state.go.mustache`.

### Verified semantics

For `select(X, [a, b, c], R)`:
- Solution 1: `X = a, R = [b, c]` — first split, `SelectRetry [(b, [a,c]); (c, [a,b])]` pushed.
- Backtrack → solution 2: `X = b, R = [a, c]` — `SelectRetry [(c, [a,b])]` pushed.
- Backtrack → solution 3: `X = c, R = [a, b]` — no more candidates, CP popped.
- Final backtrack → `None` (no more solutions).

For `select(b, [a, b, c], R)` (bound `X`):
- First split tries `unifyVal b a` → None → skip.
- Second split tries `unifyVal b b` → succeed → bind `R = [a, c]`.

## Files changed

- `src/unifyweaver/bindings/fsharp_wam_bindings.pl` — Value DU attribute / override removal, `SelectRetry` added to `BuiltinState`, `compareValue` docstring updated.
- `src/unifyweaver/targets/wam_fsharp_target.pl` — new `SelectRetry` arm in `resumeBuiltin`, `select/3` step case rewritten for backtracking.
- `tests/test_wam_fsharp_target.pl` — 4 new codegen parity assertions: `test_fsharp_value_du_no_buggy_overrides`, `test_fsharp_select_retry_builtin_state`, `test_fsharp_select_retry_resume_handler`, plus the rewritten `test_fsharp_select_builtin`.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl` — **44 / 44 pass**.
- `swipl -q -g run_benchmarks -t halt tests/bench_wam_fsharp.pl` — pre-existing benchmark steady at ~1.7× lowered-vs-interpreter speedup.
- `swipl -q -g run_tests -t halt tests/core/test_fsharp_native_lowering.pl` — pre-existing native-lowering tests still pass.

## Test plan

- [x] All 44 codegen parity tests pass (40 from prior PRs + 4 new).
- [x] Pre-existing F# WAM benchmark + native-lowering tests still pass.
- [x] Manual trace through `select(X, [a, b, c], R)` and `select(b, [a, b, c], R)` semantics matches Prolog standard.
- [ ] _(Out of scope: full `dotnet build` of a generated project — same constraint as prior F# parity PRs.)_

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_