### PR TITLE
feat(wam-fsharp): Haskell-only specialized instructions (PutStructureDyn / Arg / NotMember* / VSet family)

### DIFF
--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -89,7 +89,10 @@ type Value =
     | VList   of Value list
     | Str     of string * Value list   // functor name, args
     | Unbound of int                   // variable id
-    | Ref     of int                   // heap reference").
+    | Ref     of int                   // heap reference
+    | VSet    of Set<string>           // visited-set: Set of atom strings
+                                        // (F# atoms are string-based; Haskell
+                                        //  uses IS.IntSet of interned int IDs)").
 
 % ============================================================================
 % TrailEntry — mirrors Haskell `data TrailEntry`
@@ -275,7 +278,25 @@ fsharp_wam_instruction_type :-
     | CutIte
     // Aggregation
     | BeginAggregate of aggType: string * valReg: int * resReg: int
-    | EndAggregate   of valReg: int").
+    | EndAggregate   of valReg: int
+    // ----------------------------------------------------------------------
+    // Phase I — Haskell-only specialized instructions ported to F#.
+    // These are performance optimizations emitted by the WAM compiler's
+    // analysis passes; their semantics live in step (see wam_fsharp_target.pl).
+    //   PutStructureDyn: runtime-parsed functor (name and arity from registers).
+    //   Arg: specialized arg/3 with literal N.
+    //   NotMemberList: specialized \\+ member(X, L) with L a VList.
+    //   NotMemberConstAtoms: specialized \\+ member(X, [a, b, c]) with the
+    //     atoms baked into the instruction at compile time.
+    //   BuildEmptySet / SetInsert / NotMemberSet: VSet visited-set support
+    //     (uses Set<string>; Haskell uses IS.IntSet of interned atom IDs).
+    | PutStructureDyn       of nameReg: int * arityReg: int * targetReg: int
+    | Arg                   of n: int * tReg: int * aReg: int
+    | NotMemberList         of xReg: int * lReg: int
+    | NotMemberConstAtoms   of xReg: int * atoms: string list
+    | BuildEmptySet         of reg: int
+    | SetInsert             of elemReg: int * inReg: int * outReg: int
+    | NotMemberSet          of elemReg: int * setReg: int").
 
 % ============================================================================
 % Helper functions — derefVar, getReg, putReg, addToBuilder, evalArith
@@ -504,6 +525,7 @@ let rec compareValue (a: Value) (b: Value) : int =
         | Integer _ | Float _ -> 1
         | Atom _              -> 2
         | Str _ | VList _     -> 3
+        | VSet _              -> 3  // VSet is a compound-ish visited set
         | Ref _               -> 4
     match a, b with
     | Unbound x, Unbound y -> compare x y
@@ -513,6 +535,7 @@ let rec compareValue (a: Value) (b: Value) : int =
     | Float x,   Integer y -> compare x (float y)
     | Atom x,    Atom y    -> System.String.Compare(x, y, System.StringComparison.Ordinal)
     | Ref x,     Ref y     -> compare x y
+    | VSet x,    VSet y    -> compare x y  // F# Set has structural comparison
     | Str (fx, ax), Str (fy, ay) ->
         let ca = compare (List.length ax) (List.length ay)
         if ca <> 0 then ca

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -1803,6 +1803,128 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
             | None -> Some { s with WsPC = s.WsPC + 1 }
         | _ -> None
 
+    // ========================================================================
+    // Phase I — Haskell-only specialized instructions (perf optimizations).
+    // ========================================================================
+    // Reference: src/unifyweaver/targets/wam_haskell_target.pl. These are
+    // emitted by the WAM compiler''s binding-analysis pass when it can
+    // prove the operand shapes statically.
+
+    // PutStructureDyn — like PutStructure but the functor name and arity
+    // come from registers at runtime. Used after =../2 / functor/3 with
+    // variable-shaped output.
+    | PutStructureDyn (nameReg, arityReg, targetReg) ->
+        let mName  = getReg nameReg s
+        let mArity = getReg arityReg s
+        match mName, mArity with
+        | Some (Atom fname), Some (Integer arity) when arity >= 0 ->
+            Some { s with
+                     WsPC      = s.WsPC + 1
+                     WsBuilder = Some (BuildStruct (fname, targetReg, arity, [])) }
+        | _ -> None  // name must be Atom, arity a non-negative Integer
+
+    // Arg — specialized arg/3 with literal N (positive integer). Reads T
+    // from tReg, extracts the Nth subterm, unifies with aReg.
+    | Arg (n, tReg, aReg) when n >= 1 ->
+        match getReg tReg s with
+        | Some tVal ->
+            let mElem =
+                match tVal with
+                | Str (_, args) when n <= List.length args -> Some (List.item (n - 1) args)
+                | VList (x :: _)  when n = 1 -> Some x
+                | VList (_ :: xs) when n = 2 -> Some (VList xs)
+                | _ -> None
+            match mElem with
+            | None -> None
+            | Some elem_ ->
+                // Mirror Haskell semantics: if aReg is uninitialized (the
+                // -1 sentinel via getReg = None), insert directly; if it
+                // dereferences to Unbound, also unify by binding; otherwise
+                // require structural equality.
+                if aReg < 0 || aReg >= s.WsRegs.Length then None
+                else
+                    let regSlot = s.WsRegs.[aReg]
+                    match regSlot with
+                    | Unbound -1 ->
+                        // Sentinel = uninitialized — just write the value.
+                        let r = Array.copy s.WsRegs
+                        r.[aReg] <- elem_
+                        Some { s with WsPC = s.WsPC + 1; WsRegs = r }
+                    | _ ->
+                        let dv = derefVar s.WsBindings regSlot
+                        match dv with
+                        | Unbound vid ->
+                            let r = Array.copy s.WsRegs
+                            r.[aReg] <- elem_
+                            Some { s with
+                                     WsPC       = s.WsPC + 1
+                                     WsRegs     = r
+                                     WsBindings = Map.add vid elem_ s.WsBindings
+                                     WsTrail    = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
+                                     WsTrailLen = s.WsTrailLen + 1 }
+                        | existing when existing = elem_ ->
+                            Some { s with WsPC = s.WsPC + 1 }
+                        | _ -> None
+        | None -> None
+    | Arg (_, _, _) -> None
+
+    // NotMemberList — specialized \\+ member(X, L) on a bound VList L.
+    // Walks L inline, succeeds when X cannot unify with any item.
+    | NotMemberList (xReg, lReg) ->
+        match getReg xReg s, getReg lReg s with
+        | Some x, Some (VList items) ->
+            let found =
+                items |> List.exists (fun item -> derefVar s.WsBindings item = x)
+            if found then None else Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
+    // NotMemberConstAtoms — \\+ member(X, [a, b, c, ...]) with the atoms
+    // baked into the instruction. Single-dispatch fast path:
+    //   - X is an Atom: succeed iff X.name is not in the atom set.
+    //   - X is an Unbound or Ref (could-unify): fail (matches Prolog).
+    //   - X is any other ground value: succeed (cannot unify with atoms).
+    | NotMemberConstAtoms (xReg, atoms) ->
+        match getReg xReg s with
+        | Some (Atom name) ->
+            if List.contains name atoms then None
+            else Some { s with WsPC = s.WsPC + 1 }
+        | Some (Unbound _) -> None
+        | Some (Ref _)     -> None
+        | Some _           -> Some { s with WsPC = s.WsPC + 1 }
+        | None             -> None
+
+    // BuildEmptySet — write VSet Set.empty into the target register.
+    // Bootstraps the visited-set argument for category-ancestor-style
+    // recursive predicates.
+    | BuildEmptySet reg ->
+        if reg < 0 || reg >= s.WsRegs.Length then None
+        else
+            let r = Array.copy s.WsRegs
+            r.[reg] <- VSet Set.empty
+            Some { s with WsPC = s.WsPC + 1; WsRegs = r }
+
+    // SetInsert — read Atom from elemReg + VSet from inReg, write the
+    // inserted VSet to outReg. Fails if either register has the wrong shape.
+    | SetInsert (elemReg, inReg, outReg) ->
+        match getReg elemReg s, getReg inReg s with
+        | Some (Atom name), Some (VSet s0) ->
+            if outReg < 0 || outReg >= s.WsRegs.Length then None
+            else
+                let r = Array.copy s.WsRegs
+                r.[outReg] <- VSet (Set.add name s0)
+                Some { s with WsPC = s.WsPC + 1; WsRegs = r }
+        | _ -> None
+
+    // NotMemberSet — O(log N) membership check via Set.contains. Succeeds
+    // when the Atom is NOT in the VSet. Replaces the O(N) NotMemberList
+    // walk on the visited-set hot path.
+    | NotMemberSet (elemReg, setReg) ->
+        match getReg elemReg s, getReg setReg s with
+        | Some (Atom name), Some (VSet s0) ->
+            if Set.contains name s0 then None
+            else Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
     | _ -> None   // fallback for unhandled instructions
 
 and updateNearestAggFrame (rpc: int) (cps: ChoicePoint list) : ChoicePoint list =
@@ -2547,6 +2669,60 @@ wam_instr_to_fsharp(["end_aggregate", ValReg], Fs) :-
     fs_clean_comma(ValReg, CV),
     fs_reg_name_to_int(CV, VI),
     format(string(Fs), 'EndAggregate ~w', [VI]).
+
+% ----------------------------------------------------------------------
+% Phase I — Haskell-only specialized instructions (text parse rules).
+% Match the WAM-text mnemonics emitted by the WAM compiler''s
+% optimization pass, mirroring the Haskell parser rules in
+% wam_haskell_target.pl wam_instr_to_haskell.
+% ----------------------------------------------------------------------
+
+wam_instr_to_fsharp(["put_structure_dyn", NameReg, ArityReg, TargetReg], Fs) :-
+    fs_clean_comma(NameReg, CN), fs_clean_comma(ArityReg, CA), fs_clean_comma(TargetReg, CT),
+    fs_reg_name_to_int(CN, NI), fs_reg_name_to_int(CA, AI), fs_reg_name_to_int(CT, TI),
+    format(string(Fs), 'PutStructureDyn (~w, ~w, ~w)', [NI, AI, TI]).
+
+wam_instr_to_fsharp(["arg", N, TReg, AReg], Fs) :-
+    fs_clean_comma(N, CN), fs_clean_comma(TReg, CT), fs_clean_comma(AReg, CA),
+    (   number_string(NI, CN)
+    ->  true
+    ;   throw(error(domain_error(arg_specialization_n, CN), wam_instr_to_fsharp/2))
+    ),
+    fs_reg_name_to_int(CT, TI), fs_reg_name_to_int(CA, AI),
+    format(string(Fs), 'Arg (~w, ~w, ~w)', [NI, TI, AI]).
+
+wam_instr_to_fsharp(["not_member_list", XReg, LReg], Fs) :-
+    fs_clean_comma(XReg, CX), fs_clean_comma(LReg, CL),
+    fs_reg_name_to_int(CX, XI), fs_reg_name_to_int(CL, LI),
+    format(string(Fs), 'NotMemberList (~w, ~w)', [XI, LI]).
+
+%% Variable-arity: not_member_const_atoms XReg Atom1 Atom2 ... AtomN
+%% Emits an F# list literal of atom strings.
+wam_instr_to_fsharp(["not_member_const_atoms", XReg | AtomTokens], Fs) :-
+    AtomTokens \= [],
+    fs_clean_comma(XReg, CX), fs_reg_name_to_int(CX, XI),
+    maplist([Tok, Quoted]>>(
+        fs_clean_comma(Tok, CTok),
+        fs_escape_string(CTok, EscTok),
+        format(atom(Quoted), '"~w"', [EscTok])
+    ), AtomTokens, QuotedAtoms),
+    atomic_list_concat(QuotedAtoms, '; ', AtomsList),
+    format(string(Fs), 'NotMemberConstAtoms (~w, [~w])', [XI, AtomsList]).
+
+wam_instr_to_fsharp(["build_empty_set", Reg], Fs) :-
+    fs_clean_comma(Reg, CR), fs_reg_name_to_int(CR, RI),
+    format(string(Fs), 'BuildEmptySet ~w', [RI]).
+
+wam_instr_to_fsharp(["set_insert", EReg, InReg, OutReg], Fs) :-
+    fs_clean_comma(EReg, CE), fs_clean_comma(InReg, CI), fs_clean_comma(OutReg, CO),
+    fs_reg_name_to_int(CE, EI), fs_reg_name_to_int(CI, II), fs_reg_name_to_int(CO, OI),
+    format(string(Fs), 'SetInsert (~w, ~w, ~w)', [EI, II, OI]).
+
+wam_instr_to_fsharp(["not_member_set", EReg, SReg], Fs) :-
+    fs_clean_comma(EReg, CE), fs_clean_comma(SReg, CS),
+    fs_reg_name_to_int(CE, EI), fs_reg_name_to_int(CS, SI),
+    format(string(Fs), 'NotMemberSet (~w, ~w)', [EI, SI]).
+
 % Fallback for unknown instructions
 wam_instr_to_fsharp(Parts, Fs) :-
     atomic_list_concat(Parts, ' ', Joined),

--- a/tests/test_wam_fsharp_target.pl
+++ b/tests/test_wam_fsharp_target.pl
@@ -623,6 +623,147 @@ test_fsharp_not_unifiable_builtin :-
     ).
 
 %% ----------------------------------------------------------------------
+%% Phase I parity: Haskell-only specialized instructions ported to F#.
+%% These are performance optimizations emitted by the WAM compiler''s
+%% binding-analysis pass; their semantics live in step (parity with
+%% src/unifyweaver/targets/wam_haskell_target.pl).
+%% ----------------------------------------------------------------------
+
+test_fsharp_vset_value_variant :-
+    %% F# Value DU gains a VSet of Set<string> variant. Haskell uses
+    %% IS.IntSet of interned atom IDs; F# uses Set<string> directly
+    %% because F# atoms are string-based at the runtime level.
+    Test = 'WAM-FSharp: VSet variant on Value DU',
+    (   fsharp_wam_type_header(Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "| VSet    of Set<string>"),
+        %% compareValue treats VSet at compound rank.
+        sub_string(S, _, _, _, "| VSet _              -> 3"),
+        sub_string(S, _, _, _, "| VSet x,    VSet y    -> compare x y")
+    ->  pass(Test)
+    ;   fail_test(Test, 'VSet variant missing or compareValue not extended')
+    ).
+
+test_fsharp_specialized_instructions_declared :-
+    %% The 7 new Phase-I instructions must be declared in the
+    %% Instruction DU.
+    Test = 'WAM-FSharp: Phase-I instructions in Instruction DU',
+    (   fsharp_wam_type_header(Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "| PutStructureDyn       of nameReg: int * arityReg: int * targetReg: int"),
+        sub_string(S, _, _, _, "| Arg                   of n: int * tReg: int * aReg: int"),
+        sub_string(S, _, _, _, "| NotMemberList         of xReg: int * lReg: int"),
+        sub_string(S, _, _, _, "| NotMemberConstAtoms   of xReg: int * atoms: string list"),
+        sub_string(S, _, _, _, "| BuildEmptySet         of reg: int"),
+        sub_string(S, _, _, _, "| SetInsert             of elemReg: int * inReg: int * outReg: int"),
+        sub_string(S, _, _, _, "| NotMemberSet          of elemReg: int * setReg: int")
+    ->  pass(Test)
+    ;   fail_test(Test, 'One or more Phase-I instructions missing from DU')
+    ).
+
+test_fsharp_put_structure_dyn_step :-
+    Test = 'WAM-FSharp: PutStructureDyn step case',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "| PutStructureDyn (nameReg, arityReg, targetReg) ->"),
+        %% Functor name must dereference to Atom; arity to non-neg Integer.
+        sub_string(S, _, _, _, "Some (Atom fname), Some (Integer arity) when arity >= 0"),
+        %% Pushes a BuildStruct into the WamBuilder slot at targetReg.
+        sub_string(S, _, _, _, "BuildStruct (fname, targetReg, arity, [])")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing PutStructureDyn step case')
+    ).
+
+test_fsharp_arg_specialized_step :-
+    Test = 'WAM-FSharp: Arg (specialized arg/3) step case',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "| Arg (n, tReg, aReg) when n >= 1 ->"),
+        %% Pattern-matches Str / VList for the subterm.
+        sub_string(S, _, _, _, "Str (_, args) when n <= List.length args -> Some (List.item (n - 1) args)"),
+        sub_string(S, _, _, _, "VList (x :: _)  when n = 1 -> Some x"),
+        sub_string(S, _, _, _, "VList (_ :: xs) when n = 2 -> Some (VList xs)"),
+        %% Fall-through guard for n < 1 / non-compound T.
+        sub_string(S, _, _, _, "| Arg (_, _, _) -> None")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing Arg specialized step case')
+    ).
+
+test_fsharp_not_member_list_step :-
+    Test = 'WAM-FSharp: NotMemberList step case',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "| NotMemberList (xReg, lReg) ->"),
+        %% Inline list walk via List.exists + derefVar.
+        sub_string(S, _, _, _, "items |> List.exists (fun item -> derefVar s.WsBindings item = x)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing NotMemberList step case')
+    ).
+
+test_fsharp_not_member_const_atoms_step :-
+    Test = 'WAM-FSharp: NotMemberConstAtoms step case',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "| NotMemberConstAtoms (xReg, atoms) ->"),
+        %% Atom case: List.contains on the baked-in atom strings.
+        sub_string(S, _, _, _, "if List.contains name atoms then None"),
+        %% Could-unify cases (Unbound, Ref) fail.
+        sub_string(S, _, _, _, "| Some (Unbound _) -> None"),
+        sub_string(S, _, _, _, "| Some (Ref _)     -> None"),
+        %% Non-atom ground succeeds.
+        sub_string(S, _, _, _, "| Some _           -> Some { s with WsPC = s.WsPC + 1 }")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing NotMemberConstAtoms step case')
+    ).
+
+test_fsharp_vset_step_cases :-
+    Test = 'WAM-FSharp: BuildEmptySet / SetInsert / NotMemberSet step cases',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        %% BuildEmptySet writes VSet Set.empty into the target register.
+        sub_string(S, _, _, _, "| BuildEmptySet reg ->"),
+        sub_string(S, _, _, _, "r.[reg] <- VSet Set.empty"),
+        %% SetInsert reads Atom + VSet, writes VSet with Set.add.
+        sub_string(S, _, _, _, "| SetInsert (elemReg, inReg, outReg) ->"),
+        sub_string(S, _, _, _, "Some (Atom name), Some (VSet s0)"),
+        sub_string(S, _, _, _, "VSet (Set.add name s0)"),
+        %% NotMemberSet uses Set.contains for the O(log N) check.
+        sub_string(S, _, _, _, "| NotMemberSet (elemReg, setReg) ->"),
+        sub_string(S, _, _, _, "Set.contains name s0")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing VSet step case patterns')
+    ).
+
+test_fsharp_specialized_instructions_wam_parse :-
+    %% Round-trip the WAM-text mnemonics through wam_instr_to_fsharp/2
+    %% to make sure they map to the right Instruction constructors.
+    Test = 'WAM-FSharp: WAM-text parse rules for Phase-I instructions',
+    (   wam_fsharp_target:wam_instr_to_fsharp(
+            ["put_structure_dyn", "A1", "A2", "A3"], F1),
+        wam_fsharp_target:wam_instr_to_fsharp(
+            ["arg", "2", "A1", "A3"], F2),
+        wam_fsharp_target:wam_instr_to_fsharp(
+            ["not_member_list", "A1", "A2"], F3),
+        wam_fsharp_target:wam_instr_to_fsharp(
+            ["not_member_const_atoms", "A1", "foo", "bar"], F4),
+        wam_fsharp_target:wam_instr_to_fsharp(
+            ["build_empty_set", "A1"], F5),
+        wam_fsharp_target:wam_instr_to_fsharp(
+            ["set_insert", "A1", "A2", "A3"], F6),
+        wam_fsharp_target:wam_instr_to_fsharp(
+            ["not_member_set", "A1", "A2"], F7),
+        F1 == "PutStructureDyn (1, 2, 3)",
+        F2 == "Arg (2, 1, 3)",
+        F3 == "NotMemberList (1, 2)",
+        F4 == "NotMemberConstAtoms (1, [\"foo\"; \"bar\"])",
+        F5 == "BuildEmptySet 1",
+        F6 == "SetInsert (1, 2, 3)",
+        F7 == "NotMemberSet (1, 2)"
+    ->  pass(Test)
+    ;   fail_test(Test, 'WAM-text parse rules produced unexpected output')
+    ).
+
+%% ----------------------------------------------------------------------
 %% Phase F parity smoke: fact-shape classification helpers exposed by
 %% the F# target (parity infra used by Haskell / Elixir hybrid targets).
 %% ----------------------------------------------------------------------
@@ -797,6 +938,15 @@ run_tests :-
     test_fsharp_standard_order_comparison,
     test_fsharp_unify_builtin,
     test_fsharp_not_unifiable_builtin,
+    %% Phase I — Haskell-only specialized instructions
+    test_fsharp_vset_value_variant,
+    test_fsharp_specialized_instructions_declared,
+    test_fsharp_put_structure_dyn_step,
+    test_fsharp_arg_specialized_step,
+    test_fsharp_not_member_list_step,
+    test_fsharp_not_member_const_atoms_step,
+    test_fsharp_vset_step_cases,
+    test_fsharp_specialized_instructions_wam_parse,
     test_fsharp_fact_shape_helpers_exported,
     test_fsharp_emit_mode_resolution,
     test_fsharp_lowerable_single_clause_proceed,


### PR DESCRIPTION
## Summary

Ports the seven specialized instructions from the Haskell target's optimization pass to F#, making F# the **second** target with this performance-oriented instruction set (no other hybrid WAM target — Rust, C++, Go, etc. — currently has these). These are emitted by the WAM compiler's binding-analysis pass when it can prove operand shapes statically.

The dominant payoff is the visited-set cycle-detection pattern used by `category_ancestor` and similar recursive predicates, which previously had to build a `VList` and walk it linearly (O(N)) for each membership check. With the `VSet` family, that drops to O(log N).

## Audit

| Instruction | Haskell | Rust | C++ | Go | F# before | F# after |
|---|---|---|---|---|---|---|
| `PutStructureDyn` | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ |
| `Arg n tReg aReg` | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ |
| `NotMemberList` | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ |
| `NotMemberConstAtoms` | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ |
| `VSet` (Value variant) | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ |
| `BuildEmptySet` | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ |
| `SetInsert` | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ |
| `NotMemberSet` | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ |

## Adaptations vs the Haskell baseline

The F# port preserves the semantics but adapts the type signatures to F#'s runtime model:

- **F# `Atom of string`** vs Haskell `Atom of int` (interned ID): the F# port uses `Set<string>` for `VSet` rather than `IS.IntSet`. Likewise `NotMemberConstAtoms` carries a `string list` rather than `[Int]`. No atom-intern indirection is needed at this layer; the F# `Map<string, int>` interning that exists in `WamContext` is used at the FFI boundary, not inside `VSet`.

- **F# `VList of Value list`** is a flat list (not cons-cells like Haskell's `[a]`). `NotMemberList` walks it with `List.exists` + `derefVar`.

- **`Set<_>`** in F# is a structurally-comparable persistent set (BST-backed), giving the O(log N) characteristic the Haskell `IS.IntSet` provided.

## Changes

### `src/unifyweaver/bindings/fsharp_wam_bindings.pl`

- New `VSet of Set<string>` arm on `Value`.
- `compareValue` extended: `VSet` ranks at compound level (3); `VSet x, VSet y` compares via F#'s structural `Set` ordering.
- 7 new arms on the `Instruction` DU: `PutStructureDyn`, `Arg`, `NotMemberList`, `NotMemberConstAtoms`, `BuildEmptySet`, `SetInsert`, `NotMemberSet`.

### `src/unifyweaver/targets/wam_fsharp_target.pl`

- 7 new arms in the `step` function:
  - **`PutStructureDyn (nameReg, arityReg, targetReg)`** — deref name as `Atom`, arity as non-negative `Integer`, push a `BuildStruct` into `WsBuilder`.
  - **`Arg (n, tReg, aReg)`** — deref `tReg`, extract Nth subterm from `Str`/`VList` (with `n=1`→head, `n=2`→tail virtualization for VList), then handle the output register via three paths: uninitialized `-1` sentinel (direct write), `Unbound vid` (bind + trail), structural-equality short-circuit.
  - **`NotMemberList (xReg, lReg)`** — inline `List.exists` walk on the bound VList.
  - **`NotMemberConstAtoms (xReg, atoms)`** — `List.contains` over baked-in atom strings; `Atom` hit/miss; `Unbound`/`Ref` fail (could-unify per Prolog `\+ member` semantics); other ground succeed.
  - **`BuildEmptySet reg`** — write `VSet Set.empty` to the target register.
  - **`SetInsert (elemReg, inReg, outReg)`** — `Atom name`, `VSet s0` → `VSet (Set.add name s0)`.
  - **`NotMemberSet (elemReg, setReg)`** — `Set.contains` for the fast hot-path check.

- 7 new `wam_instr_to_fsharp` parse rules (WAM-text → F# `Instruction` constructor): `put_structure_dyn`, `arg`, `not_member_list`, `not_member_const_atoms` (variable-arity, emits an F# string-list literal), `build_empty_set`, `set_insert`, `not_member_set`. Mirrors the Haskell `wam_instr_to_haskell` clauses.

### `tests/test_wam_fsharp_target.pl`

8 new codegen parity assertions (52 tests total):

1. `test_fsharp_vset_value_variant` — checks the `VSet of Set<string>` arm and the `compareValue` extension (rank + structural compare).
2. `test_fsharp_specialized_instructions_declared` — all 7 instruction declarations on the `Instruction` DU.
3. `test_fsharp_put_structure_dyn_step` — the `BuildStruct` push and the `Atom`+non-neg-`Integer` deref guard.
4. `test_fsharp_arg_specialized_step` — `Str`/`VList` subterm extraction patterns plus the `Arg (_, _, _) -> None` fallthrough.
5. `test_fsharp_not_member_list_step` — `List.exists` + `derefVar` inline walk.
6. `test_fsharp_not_member_const_atoms_step` — all four dispatch cases (`Atom`/`Unbound`/`Ref`/other ground).
7. `test_fsharp_vset_step_cases` — `Set.empty` / `Set.add` / `Set.contains` for the three `VSet` instructions.
8. `test_fsharp_specialized_instructions_wam_parse` — round-trip smoke that exercises every new `wam_instr_to_fsharp` clause and asserts the exact emitted F# constructor syntax.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl` — **52 / 52 pass**.
- `swipl -q -g run_benchmarks -t halt tests/bench_wam_fsharp.pl` — pre-existing benchmark steady at ~1.7× lowered-vs-interpreter speedup.
- `swipl -q -g run_tests -t halt tests/core/test_fsharp_native_lowering.pl` — pre-existing native-lowering tests still pass.
- Codegen round-trip smoke: confirmed `put_structure_dyn A1 A2 A3` → `PutStructureDyn (1, 2, 3)`, `arg 2 A1 A3` → `Arg (2, 1, 3)`, `not_member_const_atoms A1 foo bar` → `NotMemberConstAtoms (1, ["foo"; "bar"])`, etc.

## Test plan

- [x] All 52 codegen parity tests pass (44 from prior PRs + 8 new).
- [x] Pre-existing F# benchmark and native-lowering tests still pass.
- [x] WAM-text → F# constructor round-trip verified for all 7 new mnemonics.
- [ ] _(Out of scope: `dotnet build` smoke — same constraint as all prior F# parity PRs in this branch.)_

## Status

After this PR, the F# WAM target matches the Haskell baseline's instruction set for the optimization-emitted specialized instructions, and is at or beyond every other hybrid WAM target (Rust, C++, Go) on the same dimension. The remaining gap from the original audit is **#4 parallel WAM full TPL wiring** — F# already has the `Par*` instruction stubs; the next round would replace them with real Task-Parallel-Library fork points.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_