### PR TITLE
test(wam-fsharp): end-to-end runtime smoke (build + run + assert RESULT N/N)

### DIFF
--- a/tests/core/test_wam_fsharp_dotnet_smoke.pl
+++ b/tests/core/test_wam_fsharp_dotnet_smoke.pl
@@ -2,28 +2,35 @@
 % SPDX-License-Identifier: MIT OR Apache-2.0
 % Copyright (c) 2025 John William Creighton (@s243a)
 %
-% test_wam_fsharp_dotnet_smoke.pl — Real `dotnet build` smoke for the
-% WAM-to-F# transpilation target.
+% test_wam_fsharp_dotnet_smoke.pl — Real `dotnet build` + `dotnet run` smokes
+% for the WAM-to-F# transpilation target.
 %
 % Why this exists
 % ---------------
 % The companion file tests/test_wam_fsharp_target.pl is entirely
 % codegen-pattern-based: it asserts string fragments are present in
 % the emitted F# source but never invokes the F# compiler. That
-% caught zero of the two latent bugs fixed in the parent commit
-% (multi-line record-update syntax in GetList; fs_wam_value/2
-% crashing on atom input from fs_parse_switch_entries).
+% caught zero of the two latent bugs fixed in PR #2340 (multi-line
+% record-update syntax in GetList; fs_wam_value/2 crashing on atom
+% input from fs_parse_switch_entries).
 %
-% This smoke test closes that gap by:
-%   1. Generating a real F# project via write_wam_fsharp_project/3
-%      for two representative shapes:
-%        a. An empty-predicates project (covers WamTypes.fs +
-%           WamRuntime.fs + Predicates.fs + Lowered.fs scaffolding
-%           and the Program.fs benchmark driver).
-%        b. A two-fact predicate (covers the multi-clause /
-%           switch-on-constant codegen path that triggered bug #2).
-%   2. Running `dotnet build` on each and asserting "Build succeeded."
-%      with no errors.
+% This smoke test closes that gap with two layers:
+%
+%   1. Build smokes (test_dotnet_build_*):
+%      - empty-predicates project: scaffolding compiles
+%      - multi-fact predicate: switch-on-constant path compiles
+%
+%   2. Run smoke (test_dotnet_run_smoke):
+%      - generate a project, OVERWRITE Program.fs with the fixture
+%        at tests/fixtures/wam_fsharp_smoke/Smoke.fs
+%      - build, then `dotnet run`
+%      - parse stdout for `RESULT N/M`, assert N == M and N > 0
+%
+% The fixture drives the runtime through a few representative
+% scenarios that exercise step semantics, backtracking, compareValue,
+% derefVar, unifyVal, and the enumerateParBranches helper without
+% depending on the codegen pipeline (Instructions are constructed
+% inline).
 %
 % Skip behaviour
 % --------------
@@ -201,6 +208,106 @@ format_atom(Format, Args, Atom) :-
 format_atom(Format, Args) :-
     format_atom(Format, Args, _).
 
+%% ------------------------------------------------------------------------
+%% Run smoke: overwrite Program.fs with the fixture and exercise the
+%% runtime via `dotnet run`.  The fixture (tests/fixtures/wam_fsharp_smoke
+%% /Smoke.fs) is independent of which predicates were generated — it
+%% constructs Instruction arrays inline — so we can use the empty-
+%% predicates project as the build base.
+%% ------------------------------------------------------------------------
+
+run_dotnet_run(Dir, ExitCode, Output) :-
+    setup_dotnet_env,
+    setup_call_cleanup(
+        process_create(path(dotnet),
+            ['run', '--nologo', '-v', 'quiet', '--no-build'],
+            [cwd(Dir),
+             stdout(pipe(Out)), stderr(pipe(Err)),
+             process(Pid)]),
+        (   read_string(Out, _, OutText),
+            read_string(Err, _, ErrText),
+            process_wait(Pid, exit(ExitCode)),
+            atomic_list_concat([OutText, '\n', ErrText], Output)
+        ),
+        (   catch(close(Out), _, true),
+            catch(close(Err), _, true)
+        )
+    ).
+
+repo_root_for_smoke(Root) :-
+    source_file(repo_root_for_smoke(_), This),
+    file_directory_name(This, CoreDir),
+    file_directory_name(CoreDir, TestsDir),
+    file_directory_name(TestsDir, Root).
+
+smoke_fixture_path(Path) :-
+    repo_root_for_smoke(Root),
+    directory_file_path(Root,
+        'tests/fixtures/wam_fsharp_smoke/Smoke.fs', Path).
+
+copy_file_overwrite(Src, Dst) :-
+    setup_call_cleanup(
+        open(Src, read, In, [type(binary)]),
+        setup_call_cleanup(
+            open(Dst, write, Out, [type(binary)]),
+            copy_stream_data(In, Out),
+            close(Out)
+        ),
+        close(In)
+    ).
+
+%% Parse `RESULT N/M` from the smoke output.  Returns N, M.
+parse_smoke_result(Output, Passes, Total) :-
+    split_string(Output, "\n", "", Lines),
+    member(Line, Lines),
+    string_concat("RESULT ", Rest, Line),
+    split_string(Rest, "/", "", [PStr, TStr|_]),
+    number_string(Passes, PStr),
+    number_string(Total, TStr), !.
+
+test_dotnet_run_smoke :-
+    Test = 'WAM-FSharp dotnet: runtime smoke (build + run + assert RESULT N/N)',
+    smoke_root(Root),
+    directory_file_path(Root, runsmoke, Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    %% Generate the project (use the empty-predicates shape — the fixture
+    %% doesn't depend on Predicates.fs content).
+    write_wam_fsharp_project([],
+        [no_kernels(true), module_name('uw_fsharp_runsmoke')],
+        Dir),
+    %% Overwrite Program.fs with the fixture.
+    smoke_fixture_path(FixturePath),
+    (   exists_file(FixturePath)
+    ->  true
+    ;   fail_test(Test,
+            format_atom('Fixture not found: ~w', [FixturePath])), !, fail
+    ),
+    directory_file_path(Dir, 'Program.fs', ProgPath),
+    copy_file_overwrite(FixturePath, ProgPath),
+    %% Build + run.
+    run_dotnet_build(Dir, BuildExit, BuildOutput),
+    (   BuildExit == 0
+    ->  true
+    ;   format('---- dotnet build output ----~n~w~n----~n', [BuildOutput]),
+        fail_test(Test, 'fixture build failed'), !, fail
+    ),
+    run_dotnet_run(Dir, RunExit, RunOutput),
+    (   parse_smoke_result(RunOutput, Passes, Total)
+    ->  (   RunExit == 0,
+            Passes =:= Total,
+            Passes > 0
+        ->  format('  RESULT ~w/~w~n', [Passes, Total]),
+            pass(Test),
+            maybe_clean(Dir)
+        ;   format('---- dotnet run output ----~n~w~n----~n', [RunOutput]),
+            fail_test(Test,
+                format_atom('runtime smoke failed: ~w/~w pass, exit ~w', [Passes, Total, RunExit]))
+        )
+    ;   format('---- dotnet run output ----~n~w~n----~n', [RunOutput]),
+        fail_test(Test, 'no RESULT line in smoke stdout')
+    ).
+
 %% ========================================================================
 %% Runner
 %% ========================================================================
@@ -211,7 +318,8 @@ run_tests :-
     format('========================================~n~n'),
     (   dotnet_available
     ->  test_dotnet_build_empty_project,
-        test_dotnet_build_multi_fact_project
+        test_dotnet_build_multi_fact_project,
+        test_dotnet_run_smoke
     ;   skip('WAM-FSharp dotnet smoke', 'dotnet not on PATH — install .NET SDK to run')
     ),
     format('~n========================================~n'),

--- a/tests/fixtures/wam_fsharp_smoke/Smoke.fs
+++ b/tests/fixtures/wam_fsharp_smoke/Smoke.fs
@@ -1,0 +1,271 @@
+module Program
+
+// Runtime smoke for the F# WAM target.
+//
+// Replaces the default Program.fs (the category-ancestor benchmark driver)
+// when the test harness wants to actually execute the runtime rather than
+// just verify it builds.  Imports the *real* generated WamTypes +
+// WamRuntime — same build flags, same module structure — and drives a
+// handful of representative scenarios that exercise:
+//   - Basic step instructions (PutConstant, Proceed, GetConstant)
+//   - Backtracking via try_me_else / trust_me
+//   - Standard-order term comparison (compareValue)
+//   - Variable dereferencing through binding chains (derefVar)
+//   - Parallel WAM helpers (enumerateParBranches)
+//
+// The smoke does NOT depend on Predicates.fs or Lowered.fs content —
+// it constructs Instruction arrays inline.  That keeps the test
+// independent of which predicates the project happened to be generated
+// with.  Tests/fixtures uses the same approach as the Haskell GHC
+// smoke (tests/fixtures/wam_put_structure_dyn_smoke/Smoke.hs).
+//
+// Output contract:
+//   - Each scenario prints `[PASS] <name>` or `[FAIL] <name>`.
+//   - A final `RESULT <passes>/<total>` line is parsed by the
+//     Prolog test driver to determine overall outcome.
+//   - Exit code is 0 iff every scenario passes.
+
+open WamTypes
+open WamRuntime
+
+let mutable passes = 0
+let mutable fails = 0
+
+let assertTrue (name: string) (cond: bool) =
+    if cond then
+        passes <- passes + 1
+        printfn "[PASS] %s" name
+    else
+        fails <- fails + 1
+        printfn "[FAIL] %s" name
+
+let mkEmptyState () =
+    { WsPC         = 0
+      WsRegs       = Array.create MaxRegs (Unbound -1)
+      WsStack      = []
+      WsHeap       = []
+      WsHeapLen    = 0
+      WsTrail      = []
+      WsTrailLen   = 0
+      WsCP         = 0
+      WsCPs        = []
+      WsCPsLen     = 0
+      WsBindings   = Map.empty
+      WsCutBar     = 0
+      WsVarCounter = 0
+      WsBuilder    = None
+      WsAggAccum   = [] }
+
+let mkContext (code: Instruction array) (labels: Map<string, int>) =
+    { WcCode              = code
+      WcLabels            = labels
+      WcForeignFacts      = Map.empty
+      WcFfiFacts          = Map.empty
+      WcFfiWeightedFacts  = Map.empty
+      WcAtomIntern        = Map.empty
+      WcAtomDeintern      = Map.empty
+      WcForeignConfig     = Map.empty
+      WcLoweredPredicates = Map.empty }
+
+// -- Scenario 1: PutConstant writes to register and advances PC ------------
+
+let scenario_put_constant () =
+    let code = [| PutConstant (Atom "foo", 1) |]
+    let ctx = mkContext code Map.empty
+    let s0 = mkEmptyState ()
+    match step ctx s0 code.[0] with
+    | Some s ->
+        assertTrue "PutConstant: register 1 = Atom \"foo\""
+                   (s.WsRegs.[1] = Atom "foo")
+        assertTrue "PutConstant: PC advanced by 1"
+                   (s.WsPC = 1)
+    | None ->
+        assertTrue "PutConstant should succeed" false
+
+// -- Scenario 2: GetConstant unifies with bound register --------------------
+
+let scenario_get_constant_match () =
+    let code = [| GetConstant (Atom "foo", 1) |]
+    let ctx = mkContext code Map.empty
+    let regs = Array.create MaxRegs (Unbound -1)
+    regs.[1] <- Atom "foo"
+    let s0 = { mkEmptyState () with WsRegs = regs }
+    match step ctx s0 code.[0] with
+    | Some s ->
+        assertTrue "GetConstant (matched): PC advanced"
+                   (s.WsPC = 1)
+    | None ->
+        assertTrue "GetConstant (matched) should succeed" false
+
+let scenario_get_constant_mismatch () =
+    let code = [| GetConstant (Atom "foo", 1) |]
+    let ctx = mkContext code Map.empty
+    let regs = Array.create MaxRegs (Unbound -1)
+    regs.[1] <- Atom "bar"
+    let s0 = { mkEmptyState () with WsRegs = regs }
+    match step ctx s0 code.[0] with
+    | Some _ ->
+        assertTrue "GetConstant (mismatch) should fail" false
+    | None ->
+        assertTrue "GetConstant (mismatch): returns None" true
+
+// -- Scenario 3: Proceed returns to CP --------------------------------------
+
+let scenario_proceed_returns_to_cp () =
+    let code = [| Proceed |]
+    let ctx = mkContext code Map.empty
+    let s0 = { mkEmptyState () with WsPC = 0; WsCP = 42 }
+    match step ctx s0 code.[0] with
+    | Some s ->
+        assertTrue "Proceed: PC <- CP" (s.WsPC = 42)
+        assertTrue "Proceed: CP cleared" (s.WsCP = 0)
+    | None ->
+        assertTrue "Proceed should succeed" false
+
+// -- Scenario 4: compareValue gives Prolog standard order ------------------
+
+let scenario_compare_value () =
+    assertTrue "compareValue: Unbound < Integer"
+               (compareValue (Unbound 0) (Integer 1) < 0)
+    assertTrue "compareValue: Integer < Atom"
+               (compareValue (Integer 5) (Atom "a") < 0)
+    assertTrue "compareValue: Atom < Str (compound)"
+               (compareValue (Atom "z") (Str ("foo", [])) < 0)
+    assertTrue "compareValue: structural equality on Atoms"
+               (compareValue (Atom "x") (Atom "x") = 0)
+    assertTrue "compareValue: numeric mixing (Integer 1 < Float 2.0)"
+               (compareValue (Integer 1) (Float 2.0) < 0)
+    assertTrue "compareValue: Atom alpha order"
+               (compareValue (Atom "a") (Atom "b") < 0)
+
+// -- Scenario 5: derefVar follows the binding chain ------------------------
+
+let scenario_deref_var () =
+    let bs = Map.ofList [ (1, Unbound 2); (2, Atom "x") ]
+    assertTrue "derefVar: 1 -> 2 -> Atom \"x\""
+               (derefVar bs (Unbound 1) = Atom "x")
+    assertTrue "derefVar: non-Unbound passthrough"
+               (derefVar bs (Atom "y") = Atom "y")
+    assertTrue "derefVar: unbound stays Unbound"
+               (derefVar Map.empty (Unbound 99) = Unbound 99)
+
+// -- Scenario 6: enumerateParBranches walks Par* chains --------------------
+
+let scenario_enumerate_par_branches () =
+    // PC 0: ParTryMeElsePc 3   (branch 1 entry at PC 1)
+    // PC 1: Proceed             (branch 1 body)
+    // PC 2: (unused)
+    // PC 3: ParTrustMe          (last branch entry at PC 4)
+    // PC 4: Proceed             (branch 2 body)
+    let code = [|
+        ParTryMeElsePc 3      // PC 0
+        Proceed                // PC 1
+        Proceed                // PC 2
+        ParTrustMe             // PC 3
+        Proceed                // PC 4
+    |]
+    let ctx = mkContext code Map.empty
+    let branches = enumerateParBranches ctx 0 3
+    assertTrue "enumerateParBranches: yields both branch entry PCs"
+               (branches = [1; 4])
+
+    // 3-branch chain via ParRetryMeElsePc in the middle.
+    let code3 = [|
+        ParTryMeElsePc 3      // PC 0
+        Proceed                // PC 1 (branch 1)
+        Proceed                // PC 2
+        ParRetryMeElsePc 5    // PC 3
+        Proceed                // PC 4 (branch 2)
+        ParTrustMe             // PC 5
+        Proceed                // PC 6 (branch 3)
+    |]
+    let ctx3 = mkContext code3 Map.empty
+    let branches3 = enumerateParBranches ctx3 0 3
+    assertTrue "enumerateParBranches: 3-branch chain via ParRetryMeElsePc"
+               (branches3 = [1; 4; 6])
+
+// -- Scenario 7: Try/Trust backtracking via run ----------------------------
+
+let scenario_backtrack_run () =
+    // Two-clause predicate emulating:
+    //   p(a). p(b).
+    // Layout:
+    //   PC 0: TryMeElsePc 3       — push CP for clause 2
+    //   PC 1: GetConstant (Atom "a", 1)
+    //   PC 2: Proceed
+    //   PC 3: TrustMe             — pop CP (last clause)
+    //   PC 4: GetConstant (Atom "b", 1)
+    //   PC 5: Proceed
+    let code = [|
+        TryMeElsePc 3
+        GetConstant (Atom "a", 1)
+        Proceed
+        TrustMe
+        GetConstant (Atom "b", 1)
+        Proceed
+    |]
+    let ctx = mkContext code Map.empty
+    // Query: p(b) — should succeed on clause 2 via backtrack.
+    let regs = Array.create MaxRegs (Unbound -1)
+    regs.[1] <- Atom "b"
+    let s0 = { mkEmptyState () with WsPC = 1; WsCP = 0; WsRegs = regs }
+    // Drive the first try: GetConstant a fails -> backtrack to clause 2.
+    // Use run to exercise the full backtracking machinery, NOT just one
+    // step.  But run terminates on WsPC = 0, so we'd need a sentinel.
+    // Instead, just check that backtrack works on a single failure:
+    match step ctx s0 (TryMeElsePc 3) with
+    | Some s1 ->
+        // First clause head: GetConstant a vs Atom "b" -> mismatch -> None.
+        let s2 = { s1 with WsPC = 1 }
+        match step ctx s2 code.[1] with
+        | None ->
+            // Now backtrack.
+            match backtrack s2 with
+            | Some s3 ->
+                assertTrue "Backtrack: returns to clause 2 (PC = 3)"
+                           (s3.WsPC = 3)
+                // Restored regs from CP snapshot
+                assertTrue "Backtrack: regs restored"
+                           (s3.WsRegs.[1] = Atom "b")
+            | None ->
+                assertTrue "Backtrack should succeed" false
+        | Some _ ->
+            assertTrue "GetConstant (mismatch) should fail" false
+    | None ->
+        assertTrue "TryMeElsePc should succeed" false
+
+// -- Scenario 8: unifyVal binds and trails ---------------------------------
+
+let scenario_unify_val () =
+    let s0 = mkEmptyState ()
+    // unifyVal (Unbound 1) (Atom "x") s0 should bind 1 -> Atom "x"
+    match unifyVal (Unbound 1) (Atom "x") s0 with
+    | Some s1 ->
+        assertTrue "unifyVal: bindings[1] = Atom \"x\""
+                   (Map.tryFind 1 s1.WsBindings = Some (Atom "x"))
+        assertTrue "unifyVal: trail entry created"
+                   (s1.WsTrailLen = 1)
+    | None ->
+        assertTrue "unifyVal (Unbound, Atom) should succeed" false
+
+    // unifyVal (Atom "x") (Atom "y") s0 should fail
+    match unifyVal (Atom "x") (Atom "y") s0 with
+    | Some _ ->
+        assertTrue "unifyVal (Atom x, Atom y) should fail" false
+    | None ->
+        assertTrue "unifyVal (Atom x, Atom y): returns None" true
+
+[<EntryPoint>]
+let main _argv =
+    scenario_put_constant ()
+    scenario_get_constant_match ()
+    scenario_get_constant_mismatch ()
+    scenario_proceed_returns_to_cp ()
+    scenario_compare_value ()
+    scenario_deref_var ()
+    scenario_enumerate_par_branches ()
+    scenario_backtrack_run ()
+    scenario_unify_val ()
+    let total = passes + fails
+    printfn "RESULT %d/%d" passes total
+    if fails > 0 then 1 else 0


### PR DESCRIPTION
## Summary

Extends `tests/core/test_wam_fsharp_dotnet_smoke.pl` with a third scenario that actually **executes** the generated F# runtime, not just compiles it.  Converts the existing compile-only smoke into a real correctness gate.

Single commit (`acb14ed`).

## What's new

### `tests/fixtures/wam_fsharp_smoke/Smoke.fs`

A self-contained F# module that **replaces** the default `Program.fs` (the category-ancestor benchmark driver) and drives the runtime through 22 assertions:

| Scenario | Assertions |
|---|---|
| `PutConstant` | register write + PC advance |
| `GetConstant` (matched / mismatched) | PC advance vs `None` return |
| `Proceed` | `WsPC ← WsCP`, `WsCP ← 0` |
| `compareValue` | Prolog standard ordering (`Var < Number < Atom < Compound`), `Integer`/`Float` numeric mixing, `Atom` alphabetic order, structural equality |
| `derefVar` | follows binding chain; passthrough for non-`Unbound`; missing-binding stays `Unbound` |
| `enumerateParBranches` | 2-branch `ParTryMeElsePc → ParTrustMe` chain; 3-branch chain via `ParRetryMeElsePc` |
| `backtrack` | restores `CP` snapshot regs and PC |
| `unifyVal` | binds `Unbound` to ground + creates trail entry; mismatched ground/ground returns `None` |

The fixture constructs `Instruction` arrays inline — it does not depend on `Predicates.fs` / `Lowered.fs` content.  Same pattern as the Haskell GHC smoke (`tests/fixtures/wam_put_structure_dyn_smoke/Smoke.hs`).

### `tests/core/test_wam_fsharp_dotnet_smoke.pl`

Gains `test_dotnet_run_smoke` which:

1. Generates a project with the empty-predicates shape.
2. **Overwrites `Program.fs`** with the fixture content.
3. `dotnet build` + `dotnet run --no-build`.
4. Parses stdout for `RESULT N/M`; passes iff `exit == 0`, `N == M`, and `N > 0`.

The Prolog driver parses the summary and asserts all-passed-and-non-empty, so an empty fixture (or a regression that breaks every assertion) is caught.

## Why this matters

PR #2340 added the compile-only smoke as a direct response to "have you been running the code in these tests?" — and it caught the two latent codegen bugs that had been sitting unnoticed.  But it only verifies the generated F# **compiles**.  Scenarios that compile fine but crash at runtime (e.g., off-by-one in a register-index handler, infinite recursion in a helper, structural-comparison bugs on the new `VSet` variant) would slip through.

The runtime smoke closes that gap.  It's the F# equivalent of the Haskell GHC smoke that drives `put_structure_dyn` end-to-end.

## Output contract

The fixture prints one `[PASS]` / `[FAIL]` per assertion plus a final `RESULT <passes>/<total>`:

```
[PASS] PutConstant: register 1 = Atom "foo"
[PASS] PutConstant: PC advanced by 1
[PASS] GetConstant (matched): PC advanced
[PASS] GetConstant (mismatch): returns None
[PASS] Proceed: PC <- CP
[PASS] Proceed: CP cleared
[PASS] compareValue: Unbound < Integer
[PASS] compareValue: Integer < Atom
[PASS] compareValue: Atom < Str (compound)
[PASS] compareValue: structural equality on Atoms
[PASS] compareValue: numeric mixing (Integer 1 < Float 2.0)
[PASS] compareValue: Atom alpha order
[PASS] derefVar: 1 -> 2 -> Atom "x"
[PASS] derefVar: non-Unbound passthrough
[PASS] derefVar: unbound stays Unbound
[PASS] enumerateParBranches: yields both branch entry PCs
[PASS] enumerateParBranches: 3-branch chain via ParRetryMeElsePc
[PASS] Backtrack: returns to clause 2 (PC = 3)
[PASS] Backtrack: regs restored
[PASS] unifyVal: bindings[1] = Atom "x"
[PASS] unifyVal: trail entry created
[PASS] unifyVal (Atom x, Atom y): returns None
RESULT 22/22
```

Exit code is non-zero on any failure.

## Skip behaviour

The skip-without-dotnet path from PR #2340 is unchanged — if `dotnet --version` fails, the entire smoke test suite (build + run) skips with `[SKIP]` and exits 0.

## Verification

- `swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_dotnet_smoke.pl` — **3 / 3 pass** (2 build smokes + new runtime smoke); runtime smoke reports `RESULT 22/22`.
- `swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl` — **55 / 55** (unchanged).
- `swipl -q -g run_tests -t halt tests/core/test_fsharp_native_lowering.pl` — pre-existing native-lowering tests still pass.

## Performance

- Build dominates: ~17s (one-time setup of the test project).
- The actual run is ~0.3s.
- Total wall time for the three-test smoke suite is ~25s.

## Test plan

- [x] Runtime smoke `RESULT 22/22` matches expected fixture assertion count.
- [x] Pre-existing F# codegen tests still pass (55/55).
- [x] Pre-existing dotnet build smokes still pass.
- [x] Native-lowering tests still pass.

## What this enables next

Now that the runtime smoke is in place, future PRs can:

1. **Catch runtime regressions automatically** — any change to a step arm, helper, or type definition that breaks semantics shows up immediately.
2. **Test the harder runtime paths** — `forkParBranches`, parallel aggregation, etc. — by adding scenarios to the fixture rather than building separate test projects.
3. **Provide end-to-end execution coverage** for the Phase-I instructions (`PutStructureDyn`, `Arg`, `VSet` family) — current fixture covers the basics; expansion to those is a follow-up.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_