### PR TITLE
feat(wam-fsharp): lowered-emitter coverage for Phase-I specialized instructions

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
@@ -151,6 +151,29 @@ supported_fs(proceed).
 supported_fs(fail).
 supported_fs(execute(_)).
 
+% ----------------------------------------------------------------------
+% Phase I — Haskell-only specialized instructions.  Emitted by the WAM
+% compiler's binding-analysis pass; previously the lowered emitter
+% silently fell back to interpreter mode when it saw any of these.
+% Each clause below mirrors the matching wam_instr_to_fsharp text parse
+% rule (src/unifyweaver/targets/wam_fsharp_target.pl Phase I block) so
+% the lowered F# function emits the same Instruction constructor the
+% interpreter codegen does.
+% ----------------------------------------------------------------------
+supported_fs(put_structure_dyn(_, _, _)).
+supported_fs(arg(_, _, _)).
+supported_fs(not_member_list(_, _)).
+supported_fs(build_empty_set(_)).
+supported_fs(set_insert(_, _, _)).
+supported_fs(not_member_set(_, _)).
+%% not_member_const_atoms is variable-arity:
+%%   not_member_const_atoms(XReg, Atom1, Atom2, ..., AtomN)  (N >= 1)
+%% The compound term arity is therefore >= 2 (one XReg + one or more atoms).
+supported_fs(T) :-
+    compound(T),
+    functor(T, not_member_const_atoms, N),
+    N >= 2.
+
 % ============================================================================
 % Emission
 % ============================================================================
@@ -272,6 +295,19 @@ is_match_instr_fs(retry_me_else(_)).
 is_match_instr_fs(trust_me).
 is_match_instr_fs(begin_aggregate(_, _, _)).
 is_match_instr_fs(end_aggregate(_)).
+%% Phase I — all delegate to `step` via a match arm, so they need the
+%% `| Some SVout ->` continuation indent like every other match-emitting
+%% instruction.
+is_match_instr_fs(put_structure_dyn(_, _, _)).
+is_match_instr_fs(arg(_, _, _)).
+is_match_instr_fs(not_member_list(_, _)).
+is_match_instr_fs(build_empty_set(_)).
+is_match_instr_fs(set_insert(_, _, _)).
+is_match_instr_fs(not_member_set(_, _)).
+is_match_instr_fs(T) :-
+    compound(T),
+    functor(T, not_member_const_atoms, N),
+    N >= 2.
 
 %% emit_instrs_lm_fs(+PCInstrs, +SV, +Indent, +FP, +LabelMap)
 %  LabelMap-aware entry point called from emit_func_fs.
@@ -763,6 +799,96 @@ emit_one_fs(execute(PredStr), _PC, SV, SV, I, FP) :-
     ->  format("~wcallForeign ctx \"~w\" ~w~n", [I, EscPred, SV])
     ;   format("~wdispatchCall ctx \"~w\" ~w~n", [I, EscPred, SV])
     ).
+
+% ============================================================================
+% Phase I — Haskell-only specialized instructions: delegate to step.
+%
+% Each clause emits exactly the same shape as the BuiltinCall delegation
+% above: open a `match step ctx { s with WsPC = PC } (Constructor ...) with`
+% block with a `| Some SVout ->` arm that the next instruction continues
+% into.  The matching is_match_instr_fs/1 entries above make sure the
+% emit_instrs_lm_fs chain places the continuation at the right indent.
+% ============================================================================
+
+% PutStructureDyn — runtime-parsed functor (name+arity from registers).
+emit_one_fs(put_structure_dyn(NameRegStr, ArityRegStr, TargetRegStr),
+            PC, SV, SVout, I, _FP) :-
+    reg_to_int_fs(NameRegStr, NameReg),
+    reg_to_int_fs(ArityRegStr, ArityReg),
+    reg_to_int_fs(TargetRegStr, TargetReg),
+    fresh_sv_fs(SV, SVout),
+    format("~wmatch step ctx { ~w with WsPC = ~w } (PutStructureDyn (~w, ~w, ~w)) with~n",
+           [I, SV, PC, NameReg, ArityReg, TargetReg]),
+    format("~w| Some ~w ->~n", [I, SVout]).
+
+% Arg — specialized arg/3 with compile-time N.
+emit_one_fs(arg(NStr, TRegStr, ARegStr), PC, SV, SVout, I, _FP) :-
+    (   number_string(N, NStr) -> true
+    ;   atom_number(NStr, N) -> true
+    ;   throw(error(domain_error(arg_specialization_n, NStr), emit_one_fs/6))
+    ),
+    reg_to_int_fs(TRegStr, TReg),
+    reg_to_int_fs(ARegStr, AReg),
+    fresh_sv_fs(SV, SVout),
+    format("~wmatch step ctx { ~w with WsPC = ~w } (Arg (~w, ~w, ~w)) with~n",
+           [I, SV, PC, N, TReg, AReg]),
+    format("~w| Some ~w ->~n", [I, SVout]).
+
+% NotMemberList — \\+ member(X, L) on a bound VList L.
+emit_one_fs(not_member_list(XRegStr, LRegStr), PC, SV, SVout, I, _FP) :-
+    reg_to_int_fs(XRegStr, XReg),
+    reg_to_int_fs(LRegStr, LReg),
+    fresh_sv_fs(SV, SVout),
+    format("~wmatch step ctx { ~w with WsPC = ~w } (NotMemberList (~w, ~w)) with~n",
+           [I, SV, PC, XReg, LReg]),
+    format("~w| Some ~w ->~n", [I, SVout]).
+
+% NotMemberConstAtoms — variable-arity: not_member_const_atoms(XReg, A1, ..., An).
+emit_one_fs(NotMemConstAtoms, PC, SV, SVout, I, _FP) :-
+    compound(NotMemConstAtoms),
+    functor(NotMemConstAtoms, not_member_const_atoms, N),
+    N >= 2,
+    arg(1, NotMemConstAtoms, XRegStr),
+    reg_to_int_fs(XRegStr, XReg),
+    findall(AtomTok,
+            (between(2, N, K), arg(K, NotMemConstAtoms, AtomTok)),
+            AtomTokens),
+    maplist([Tok, Quoted]>>(
+        escape_dq_fs(Tok, EscTok),
+        format(atom(Quoted), '"~w"', [EscTok])
+    ), AtomTokens, QuotedAtoms),
+    atomic_list_concat(QuotedAtoms, '; ', AtomsList),
+    fresh_sv_fs(SV, SVout),
+    format("~wmatch step ctx { ~w with WsPC = ~w } (NotMemberConstAtoms (~w, [~w])) with~n",
+           [I, SV, PC, XReg, AtomsList]),
+    format("~w| Some ~w ->~n", [I, SVout]).
+
+% BuildEmptySet — write VSet Set.empty into the target register.
+emit_one_fs(build_empty_set(RegStr), PC, SV, SVout, I, _FP) :-
+    reg_to_int_fs(RegStr, Reg),
+    fresh_sv_fs(SV, SVout),
+    format("~wmatch step ctx { ~w with WsPC = ~w } (BuildEmptySet ~w) with~n",
+           [I, SV, PC, Reg]),
+    format("~w| Some ~w ->~n", [I, SVout]).
+
+% SetInsert — Atom + VSet -> VSet (with Set.add).
+emit_one_fs(set_insert(ERegStr, InRegStr, OutRegStr), PC, SV, SVout, I, _FP) :-
+    reg_to_int_fs(ERegStr, EReg),
+    reg_to_int_fs(InRegStr, InReg),
+    reg_to_int_fs(OutRegStr, OutReg),
+    fresh_sv_fs(SV, SVout),
+    format("~wmatch step ctx { ~w with WsPC = ~w } (SetInsert (~w, ~w, ~w)) with~n",
+           [I, SV, PC, EReg, InReg, OutReg]),
+    format("~w| Some ~w ->~n", [I, SVout]).
+
+% NotMemberSet — O(log N) visited-set membership check.
+emit_one_fs(not_member_set(ERegStr, SRegStr), PC, SV, SVout, I, _FP) :-
+    reg_to_int_fs(ERegStr, EReg),
+    reg_to_int_fs(SRegStr, SReg),
+    fresh_sv_fs(SV, SVout),
+    format("~wmatch step ctx { ~w with WsPC = ~w } (NotMemberSet (~w, ~w)) with~n",
+           [I, SV, PC, EReg, SReg]),
+    format("~w| Some ~w ->~n", [I, SVout]).
 
 % BeginAggregate — delegate to step
 emit_one_fs(begin_aggregate(TypeStr, ValRegStr, ResRegStr), PC, SV, SVout, I, _FP) :-

--- a/tests/core/test_wam_fsharp_dotnet_smoke.pl
+++ b/tests/core/test_wam_fsharp_dotnet_smoke.pl
@@ -308,6 +308,64 @@ test_dotnet_run_smoke :-
         fail_test(Test, 'no RESULT line in smoke stdout')
     ).
 
+%% ------------------------------------------------------------------------
+%% Phase-I lowered emitter build smoke: hand-roll a WAM body containing
+%% every Phase-I instruction, drive lower_predicate_to_fsharp/4 to emit
+%% an F# function, splice it into Lowered.fs, and confirm the project
+%% builds.  Without lowered-emitter coverage these instructions would
+%% silently fall back to interpreter; with coverage they emit step-
+%% delegation chains that must compile clean F#.
+%% ------------------------------------------------------------------------
+
+test_dotnet_build_phase_i_lowered :-
+    Test = 'WAM-FSharp dotnet: Phase-I lowered emitter compiles',
+    smoke_root(Root),
+    directory_file_path(Root, phase_i, Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    %% Generate the empty-predicates project as a base.
+    write_wam_fsharp_project([],
+        [no_kernels(true), module_name('uw_fsharp_phase_i_lowered')],
+        Dir),
+    %% Drive the lowered emitter on a body exercising every Phase-I op.
+    Wam = 'p_phase_i/3:\n  build_empty_set A1\n  put_structure_dyn A1 A2 A3\n  arg 2 A1 A3\n  not_member_list A1 A2\n  set_insert A1 A2 A3\n  not_member_set A1 A2\n  not_member_const_atoms A1 foo bar baz\n  proceed',
+    catch(
+        wam_fsharp_target:lower_predicate_to_fsharp(p_phase_i/3, Wam,
+            [base_pc(1), foreign_preds([])],
+            lowered(_, FuncName, Code)),
+        LowerErr,
+        (   format('  lower_predicate_to_fsharp error: ~q~n', [LowerErr]),
+            fail_test(Test, 'lower_predicate_to_fsharp failed'), !, fail
+        )
+    ),
+    %% Splice into Lowered.fs (overwrites the auto-generated empty stub).
+    format(atom(LoweredContent),
+'module Lowered
+
+open WamTypes
+open WamRuntime
+
+~w
+
+let loweredPredicates : Map<string, WamContext -> WamState -> WamState option> =
+    Map.ofList [ ("p_phase_i/3", ~w) ]
+', [Code, FuncName]),
+    directory_file_path(Dir, 'Lowered.fs', LoweredPath),
+    setup_call_cleanup(
+        open(LoweredPath, write, S, [encoding(utf8)]),
+        write(S, LoweredContent),
+        close(S)
+    ),
+    run_dotnet_build(Dir, ExitCode, Output),
+    (   ExitCode == 0,
+        sub_string(Output, _, _, _, "Build succeeded")
+    ->  pass(Test),
+        maybe_clean(Dir)
+    ;   format('---- dotnet build output ----~n~w~n----~n', [Output]),
+        fail_test(Test,
+            format_atom('dotnet build failed (exit ~w) for Phase-I lowered', [ExitCode]))
+    ).
+
 %% ========================================================================
 %% Runner
 %% ========================================================================
@@ -319,7 +377,8 @@ run_tests :-
     (   dotnet_available
     ->  test_dotnet_build_empty_project,
         test_dotnet_build_multi_fact_project,
-        test_dotnet_run_smoke
+        test_dotnet_run_smoke,
+        test_dotnet_build_phase_i_lowered
     ;   skip('WAM-FSharp dotnet smoke', 'dotnet not on PATH — install .NET SDK to run')
     ),
     format('~n========================================~n'),

--- a/tests/test_wam_fsharp_target.pl
+++ b/tests/test_wam_fsharp_target.pl
@@ -894,6 +894,63 @@ test_fsharp_lowerable_multi_clause :-
     ).
 
 %% ----------------------------------------------------------------------
+%% Phase I — lowered-emitter coverage for the Haskell-only specialized
+%% instructions.  Before this round these instructions were missing from
+%% supported_fs/1 / is_match_instr_fs/1 / emit_one_fs/6, so any
+%% predicate whose WAM-text body contained PutStructureDyn / Arg /
+%% NotMember* / VSet-family ops silently fell back to the interpreter.
+%% These tests assert (a) the lowered emitter now accepts them, and
+%% (b) the emitted F# code matches the expected step-delegation shape.
+%% ----------------------------------------------------------------------
+
+test_fsharp_lowered_emitter_phase_i_accepted :-
+    Test = 'WAM-FSharp lowered: Phase-I body is lowerable',
+    Wam = 'p_phase_i/3:\n  build_empty_set A1\n  put_structure_dyn A1 A2 A3\n  arg 2 A1 A3\n  not_member_list A1 A2\n  set_insert A1 A2 A3\n  not_member_set A1 A2\n  not_member_const_atoms A1 foo bar baz\n  proceed',
+    (   wam_fsharp_lowerable(p_phase_i/3, Wam, _Reason)
+    ->  pass(Test)
+    ;   fail_test(Test, 'Phase-I body should be lowerable')
+    ).
+
+test_fsharp_lowered_emitter_phase_i_emits_step_delegation :-
+    Test = 'WAM-FSharp lowered: Phase-I instructions delegate to step',
+    Wam = 'p_phase_i/3:\n  build_empty_set A1\n  put_structure_dyn A1 A2 A3\n  arg 2 A1 A3\n  not_member_list A1 A2\n  set_insert A1 A2 A3\n  not_member_set A1 A2\n  not_member_const_atoms A1 foo bar baz\n  proceed',
+    (   wam_fsharp_target:lower_predicate_to_fsharp(p_phase_i/3, Wam,
+            [base_pc(1), foreign_preds([])],
+            lowered(_, _FuncName, Code)),
+        %% Every Phase-I instruction must delegate to `step` with the
+        %% correct constructor; the |> Some sv -> continuation chain
+        %% must be present.
+        sub_string(Code, _, _, _, "(BuildEmptySet 1)"),
+        sub_string(Code, _, _, _, "(PutStructureDyn (1, 2, 3))"),
+        sub_string(Code, _, _, _, "(Arg (2, 1, 3))"),
+        sub_string(Code, _, _, _, "(NotMemberList (1, 2))"),
+        sub_string(Code, _, _, _, "(SetInsert (1, 2, 3))"),
+        sub_string(Code, _, _, _, "(NotMemberSet (1, 2))"),
+        sub_string(Code, _, _, _, "(NotMemberConstAtoms (1, [\"foo\"; \"bar\"; \"baz\"]))"),
+        %% Step-delegation chain shape: match step ctx { ... } (Instr) with | Some _ ->
+        sub_string(Code, _, _, _, "match step ctx { s_init with WsPC = 1 } (BuildEmptySet 1) with")
+    ->  pass(Test)
+    ;   fail_test(Test, 'Missing Phase-I step-delegation patterns')
+    ).
+
+test_fsharp_lowered_emitter_phase_i_pc_offsets :-
+    %% base_pc(N) offsets the local PCs so they match the global merged
+    %% instruction array.  With base_pc(10), the first instruction''s
+    %% WsPC should be 10 (not 1).
+    Test = 'WAM-FSharp lowered: Phase-I respects base_pc offset',
+    Wam = 'p_phase_i_off/2:\n  build_empty_set A1\n  not_member_set A1 A2\n  proceed',
+    (   wam_fsharp_target:lower_predicate_to_fsharp(p_phase_i_off/2, Wam,
+            [base_pc(10), foreign_preds([])],
+            lowered(_, _, Code)),
+        %% First instruction at offset 10.
+        sub_string(Code, _, _, _, "WsPC = 10 } (BuildEmptySet 1)"),
+        %% Second at 11.
+        sub_string(Code, _, _, _, "WsPC = 11 } (NotMemberSet (1, 2))")
+    ->  pass(Test)
+    ;   fail_test(Test, 'base_pc offset not threaded through Phase-I emitters')
+    ).
+
+%% ----------------------------------------------------------------------
 %% Project generation smoke: exercise write_wam_fsharp_project/3 in a
 %% throwaway directory with no kernels and assert the expected files
 %% are produced. Does not invoke `dotnet build`.
@@ -1012,6 +1069,10 @@ run_tests :-
     test_fsharp_lowerable_single_clause_proceed,
     test_fsharp_lowerable_rejects_aggregate,
     test_fsharp_lowerable_multi_clause,
+    %% Phase I — lowered emitter
+    test_fsharp_lowered_emitter_phase_i_accepted,
+    test_fsharp_lowered_emitter_phase_i_emits_step_delegation,
+    test_fsharp_lowered_emitter_phase_i_pc_offsets,
     test_fsharp_project_generation_smoke,
     format('~n========================================~n'),
     (   test_failed


### PR DESCRIPTION
## Summary

Closes the quiet correctness hole flagged at the end of PR #2342: the WAM-to-F# **lowered emitter** (`src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl`) didn't know about any of the Phase-I specialized instructions added in PR #2339.  If the WAM compiler's binding-analysis pass emitted `PutStructureDyn` / `Arg` / `NotMember*` / `BuildEmptySet` / `SetInsert` / `NotMemberSet` / `NotMemberConstAtoms` inside a lowerable predicate body, the whole predicate **silently fell back to interpreter mode** — losing the lowering speedup that's the entire reason for emitting those instructions in the first place.

Single commit (`5d31710`).

## What was missing

The lowered emitter has three points that gate which instructions can be lowered:

1. **`supported_fs/1`** — whitelist of instructions accepted in a lowerable body.  Without an entry, `wam_fsharp_lowerable/3` fails and the whole predicate stays interpreted.
2. **`is_match_instr_fs/1`** — declares which instructions emit a `match ... with | Some SVout -> ...` pattern (vs an inline `let` binding).  Drives indentation in `emit_instrs_lm_fs`.
3. **`emit_one_fs/6`** — the actual codegen clause that emits the F# code for each instruction in a lowered function body.

None of the seven Phase-I instructions had any of the three.  This PR adds all of them.

## Changes

### `src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl`

- **7 new `supported_fs/1` clauses**, including a variable-arity matcher for `not_member_const_atoms` (any compound with functor `not_member_const_atoms` and arity ≥ 2 — one register + one or more atoms).
- **7 matching `is_match_instr_fs/1` entries** — all Phase-I instructions delegate to `step` via the match-arm pattern.
- **7 new `emit_one_fs/6` clauses**, all following the existing `BuiltinCall` delegation pattern:

  ```fsharp
  match step ctx { s with WsPC = PC } (Constructor args) with
  | Some SVout -> ...
  ```

  The variable-arity `not_member_const_atoms` uses `findall` + `maplist` to build the F# string-list literal:

  ```fsharp
  (NotMemberConstAtoms (1, ["foo"; "bar"; "baz"]))
  ```

### `tests/test_wam_fsharp_target.pl` (58 tests total now, was 55)

Three new codegen parity assertions:

- **`test_fsharp_lowered_emitter_phase_i_accepted`** — `wam_fsharp_lowerable/3` succeeds on a body containing every Phase-I op.
- **`test_fsharp_lowered_emitter_phase_i_emits_step_delegation`** — the emitted F# function contains the expected step-delegation chain for each instruction with the correct constructor arguments.
- **`test_fsharp_lowered_emitter_phase_i_pc_offsets`** — `base_pc(N)` threading works: first instruction's `WsPC = N`, second = `N+1`.

### `tests/core/test_wam_fsharp_dotnet_smoke.pl` (4 dotnet smokes total now, was 3)

New **`test_dotnet_build_phase_i_lowered`**:

1. Generate the empty-predicates project as a base.
2. Drive `lower_predicate_to_fsharp/4` on a hand-rolled WAM body containing every Phase-I op.
3. **Splice the emitted F# function into `Lowered.fs`** (overwriting the auto-generated empty stub).
4. Confirm `dotnet build` succeeds.

This catches the case where the codegen parity tests would pass but the emitted F# wouldn't actually compile (e.g., a missing constructor arg, a type mismatch, etc.) — same posture as the runtime smoke from PR #2342.

## Sample emitted output

Driving the lowered emitter on:

```
p_phase_i/3:
  build_empty_set A1
  put_structure_dyn A1 A2 A3
  arg 2 A1 A3
  not_member_list A1 A2
  set_insert A1 A2 A3
  not_member_set A1 A2
  not_member_const_atoms A1 foo bar baz
  proceed
```

produces:

```fsharp
let lowered_p_phase_i_3 (ctx: WamContext) (s_init: WamState) : WamState option =
    match step ctx { s_init with WsPC = 1 } (BuildEmptySet 1) with
    | Some s_0 ->
        match step ctx { s_0 with WsPC = 2 } (PutStructureDyn (1, 2, 3)) with
        | Some s_1 ->
            match step ctx { s_1 with WsPC = 3 } (Arg (2, 1, 3)) with
            | Some s_2 ->
                match step ctx { s_2 with WsPC = 4 } (NotMemberList (1, 2)) with
                | Some s_3 ->
                    match step ctx { s_3 with WsPC = 5 } (SetInsert (1, 2, 3)) with
                    | Some s_4 ->
                        match step ctx { s_4 with WsPC = 6 } (NotMemberSet (1, 2)) with
                        | Some s_5 ->
                            match step ctx { s_5 with WsPC = 7 }
                                  (NotMemberConstAtoms (1, ["foo"; "bar"; "baz"])) with
                            | Some s_6 ->
                                let ret_ = s_6.WsCP
                                if ret_ = 0 then Some { s_6 with WsPC = 0 }
                                else Some { s_6 with WsPC = ret_; WsCP = 0 }
```

## Known: pre-existing emitter warnings

The lowered emitter's `match step ... with | Some SVout -> ...` pattern triggers F# `FS0025` (incomplete pattern matches — no explicit `| None -> ...` arm).  This is **not new** — `BuiltinCall`, `CutIte`, `Jump`, and every other match-style instruction emit the same shape.  Cleaning these warnings up across the emitter is a separate follow-up.

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl` — **58 / 58 pass** (+3 over PR #2342's 55).
- `swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_dotnet_smoke.pl` — **4 / 4 pass** (+1 over PR #2342's 3).  All smokes including the new Phase-I lowered build smoke.
- `swipl -q -g run_tests -t halt tests/core/test_fsharp_native_lowering.pl` — pre-existing native-lowering tests still pass.

## Status after this PR

The F# WAM lowered emitter is now fully aware of the Phase-I instruction set.  Coverage matrix:

| Layer | Pre-PR #2339 baseline | PR #2339 added | This PR adds |
|---|---|---|---|
| `Value` DU (incl. `VSet`) | ✓ | — | — |
| `Instruction` DU | ✓ | ✓ (Phase-I) | — |
| Runtime `step` function | ✓ | ✓ | — |
| Codegen text parse (`wam_instr_to_fsharp`) | ✓ | ✓ | — |
| **Lowered emitter** (`supported_fs` + `emit_one_fs`) | ✓ | ✗ | ✓ |

Remaining future work (not in this PR):

- **`forkParBranches` for aggregates** — completes Phase-J parallel-WAM by extending `BeginAggregate` frames with a `MergeStrategy` field.
- **Mirror the `runNegationParallel` off-by-one fix upstream in Haskell** (`wam_haskell_target.pl:1581`).
- **Lowered emitter `Par*` variants** — currently the WAM compiler doesn't emit `par_try_me_else` etc. as text mnemonics (the Par* variants are post-tokenization rewrites in Haskell), so there's no immediate need.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_