### PR TITLE
fix+test(wam-fsharp): lowered emitter missed | None -> None arms — runtime smoke caught it

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
@@ -376,11 +376,13 @@ emit_instrs_lm_fs([pc(PC, Instr)|Rest], SV, Ind, FP, LM) :-
     atom_concat(Ind, "    ", IndInner),
     (   Rest = []
     ->  (   is_match_instr_fs(Instr)
-        ->  format("~wSome ~w~n", [IndInner, SVout])
+        ->  format("~wSome ~w~n", [IndInner, SVout]),
+            format("~w| None -> None~n", [Ind])
         ;   true
         )
     ;   (   is_match_instr_fs(Instr)
-        ->  emit_instrs_lm_fs(Rest, SVout, IndInner, FP, LM)
+        ->  emit_instrs_lm_fs(Rest, SVout, IndInner, FP, LM),
+            format("~w| None -> None~n", [Ind])
         ;   emit_instrs_lm_fs(Rest, SVout, Ind, FP, LM)
         )
     ).
@@ -430,19 +432,24 @@ emit_instrs_fs([pc(PC, Instr)|Rest], SV, Ind, FP) :-
     (   Rest = []
     ->  % Last instruction.
         %   - match-emitting instructions leave an open "| Some SVout ->" arm;
-        %     we must emit "Some SVout" indented one level deeper as its body.
+        %     we must emit "Some SVout" indented one level deeper as its body,
+        %     and close the match with "| None -> None" at Ind level so the
+        %     resulting F# pattern match is exhaustive (FS0025 closure).
         %   - let-binding instructions (allocate, put_*, get_variable, proceed)
         %     already closed their output, so nothing more is needed.
         (   is_match_instr_fs(Instr)
-        ->  format("~wSome ~w~n", [IndInner, SVout])
+        ->  format("~wSome ~w~n", [IndInner, SVout]),
+            format("~w| None -> None~n", [Ind])
         ;   true
         )
     ;   % Intermediate instruction: continue chain.
         %   match-emitting instructions opened a "| Some SVout ->" arm;
         %   remaining instructions become its body at IndInner.
+        %   After the body, close the match with "| None -> None" at Ind level.
         %   let-binding instructions stay at the same indent level.
         (   is_match_instr_fs(Instr)
-        ->  emit_instrs_fs(Rest, SVout, IndInner, FP)
+        ->  emit_instrs_fs(Rest, SVout, IndInner, FP),
+            format("~w| None -> None~n", [Ind])
         ;   emit_instrs_fs(Rest, SVout, Ind, FP)
         )
     ).
@@ -477,9 +484,12 @@ emit_ite_block_fs([pc(PC, Instr)|Rest], SV, Ind, FP) :-
     emit_one_fs(Instr, PC, SV, SVout, Ind, FP),
     % Mirror emit_instrs_lm_fs: match-emitting instructions open a
     % '| Some SVout ->' arm, so remaining code becomes its body at IndInner.
+    % After the body, close the match with '| None -> None' at Ind level so
+    % the F# pattern match is exhaustive (FS0025 closure).
     atom_concat(Ind, "    ", IndInner),
     (   is_match_instr_fs(Instr)
-    ->  emit_ite_block_fs(Rest, SVout, IndInner, FP)
+    ->  emit_ite_block_fs(Rest, SVout, IndInner, FP),
+        format("~w| None -> None~n", [Ind])
     ;   emit_ite_block_fs(Rest, SVout, Ind, FP)
     ).
 

--- a/tests/core/test_wam_fsharp_dotnet_smoke.pl
+++ b/tests/core/test_wam_fsharp_dotnet_smoke.pl
@@ -366,6 +366,100 @@ let loweredPredicates : Map<string, WamContext -> WamState -> WamState option> =
             format_atom('dotnet build failed (exit ~w) for Phase-I lowered', [ExitCode]))
     ).
 
+%% ------------------------------------------------------------------------
+%% Phase-I lowered emitter RUNTIME smoke.  Extends the build smoke above
+%% with an actual `dotnet run` step that drives each lowered function
+%% with crafted register inputs and asserts on the resulting WamState.
+%% Closes the loop on PR #2343 (which only verified the lowered code
+%% compiles, not that it runs correctly).
+%%
+%% Predicate naming convention (matches lower_predicate_to_fsharp''s
+%% sanitizer): phase_i_arg/3 -> lowered_phase_i_arg_3, etc.  The fixture
+%% Driver.fs (tests/fixtures/wam_fsharp_phase_i_lowered_smoke/) calls
+%% these functions by their predictable names.
+%% ------------------------------------------------------------------------
+
+phase_i_lowered_scenarios([
+    phase_i_arg/3   - 'phase_i_arg/3:\n  arg 2 A1 X1\n  proceed',
+    phase_i_nml/2   - 'phase_i_nml/2:\n  not_member_list A1 A2\n  proceed',
+    phase_i_vset/2  - 'phase_i_vset/2:\n  build_empty_set X1\n  set_insert A1 X1 X2\n  not_member_set A2 X2\n  proceed',
+    phase_i_nmca/1  - 'phase_i_nmca/1:\n  not_member_const_atoms A1 foo bar baz\n  proceed',
+    phase_i_psd/3   - 'phase_i_psd/3:\n  put_structure_dyn A1 A2 A3\n  proceed'
+]).
+
+phase_i_driver_fixture(Path) :-
+    repo_root_for_smoke(Root),
+    directory_file_path(Root,
+        'tests/fixtures/wam_fsharp_phase_i_lowered_smoke/Driver.fs', Path).
+
+test_dotnet_run_phase_i_lowered :-
+    Test = 'WAM-FSharp dotnet: Phase-I lowered runtime smoke (build + run + assert)',
+    smoke_root(Root),
+    directory_file_path(Root, phase_i_run, Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    write_wam_fsharp_project([],
+        [no_kernels(true), module_name('uw_fsharp_phase_i_run')],
+        Dir),
+    %% Lower each scenario and concatenate the emitted F# functions.
+    phase_i_lowered_scenarios(Scenarios),
+    findall(Code,
+            (   member(PI - Wam, Scenarios),
+                wam_fsharp_target:lower_predicate_to_fsharp(PI, Wam,
+                    [base_pc(1), foreign_preds([])],
+                    lowered(_, _, Code))
+            ),
+            Codes),
+    atomic_list_concat(Codes, '\n\n', AllCode),
+    format(atom(LoweredContent),
+'module Lowered
+
+open WamTypes
+open WamRuntime
+
+~w
+
+let loweredPredicates : Map<string, WamContext -> WamState -> WamState option> =
+    Map.empty
+', [AllCode]),
+    directory_file_path(Dir, 'Lowered.fs', LoweredPath),
+    setup_call_cleanup(
+        open(LoweredPath, write, S, [encoding(utf8)]),
+        write(S, LoweredContent),
+        close(S)
+    ),
+    %% Overwrite Program.fs with the runtime driver fixture.
+    phase_i_driver_fixture(FixturePath),
+    (   exists_file(FixturePath)
+    ->  true
+    ;   fail_test(Test,
+            format_atom('Driver fixture not found: ~w', [FixturePath])), !, fail
+    ),
+    directory_file_path(Dir, 'Program.fs', ProgPath),
+    copy_file_overwrite(FixturePath, ProgPath),
+    %% Build + run.
+    run_dotnet_build(Dir, BuildExit, BuildOutput),
+    (   BuildExit == 0
+    ->  true
+    ;   format('---- dotnet build output ----~n~w~n----~n', [BuildOutput]),
+        fail_test(Test, 'Phase-I lowered runtime build failed'), !, fail
+    ),
+    run_dotnet_run(Dir, RunExit, RunOutput),
+    (   parse_smoke_result(RunOutput, Passes, Total)
+    ->  (   RunExit == 0,
+            Passes =:= Total,
+            Passes > 0
+        ->  format('  RESULT ~w/~w~n', [Passes, Total]),
+            pass(Test),
+            maybe_clean(Dir)
+        ;   format('---- dotnet run output ----~n~w~n----~n', [RunOutput]),
+            fail_test(Test,
+                format_atom('Phase-I lowered runtime failed: ~w/~w pass, exit ~w', [Passes, Total, RunExit]))
+        )
+    ;   format('---- dotnet run output ----~n~w~n----~n', [RunOutput]),
+        fail_test(Test, 'no RESULT line in Phase-I lowered run output')
+    ).
+
 %% ========================================================================
 %% Runner
 %% ========================================================================
@@ -378,7 +472,8 @@ run_tests :-
     ->  test_dotnet_build_empty_project,
         test_dotnet_build_multi_fact_project,
         test_dotnet_run_smoke,
-        test_dotnet_build_phase_i_lowered
+        test_dotnet_build_phase_i_lowered,
+        test_dotnet_run_phase_i_lowered
     ;   skip('WAM-FSharp dotnet smoke', 'dotnet not on PATH — install .NET SDK to run')
     ),
     format('~n========================================~n'),

--- a/tests/fixtures/wam_fsharp_phase_i_lowered_smoke/Driver.fs
+++ b/tests/fixtures/wam_fsharp_phase_i_lowered_smoke/Driver.fs
@@ -1,0 +1,246 @@
+module Program
+
+// Runtime smoke for the Phase-I lowered emitter.
+//
+// Replaces the default Program.fs (the category-ancestor benchmark
+// driver) and drives lowered functions that were emitted by
+// lower_predicate_to_fsharp/4 from hand-rolled WAM bodies containing
+// Phase-I specialized instructions.
+//
+// The test driver (tests/core/test_wam_fsharp_dotnet_smoke.pl) splices
+// the lowered functions into Lowered.fs at the predictable names below,
+// then runs this Program.fs to call each one with crafted register
+// inputs and assert on the resulting WamState.
+//
+// Predicate-name → lowered-function-name convention (from
+// lower_predicate_to_fsharp's sanitizer):
+//   phase_i_arg/3   -> lowered_phase_i_arg_3
+//   phase_i_nml/2   -> lowered_phase_i_nml_2
+//   phase_i_vset/2  -> lowered_phase_i_vset_2
+//   phase_i_nmca/1  -> lowered_phase_i_nmca_1
+//   phase_i_psd/3   -> lowered_phase_i_psd_3
+
+open WamTypes
+open WamRuntime
+open Lowered
+
+let mutable passes = 0
+let mutable fails = 0
+
+let assertTrue (name: string) (cond: bool) =
+    if cond then
+        passes <- passes + 1
+        printfn "[PASS] %s" name
+    else
+        fails <- fails + 1
+        printfn "[FAIL] %s" name
+
+let mkContext () =
+    { WcCode              = [||]
+      WcLabels            = Map.empty
+      WcForeignFacts      = Map.empty
+      WcFfiFacts          = Map.empty
+      WcFfiWeightedFacts  = Map.empty
+      WcAtomIntern        = Map.empty
+      WcAtomDeintern      = Map.empty
+      WcForeignConfig     = Map.empty
+      WcLoweredPredicates = Map.empty }
+
+let mkState (regs: (int * Value) list) =
+    let r = Array.create MaxRegs (Unbound -1)
+    for (i, v) in regs do
+        r.[i] <- v
+    { WsPC         = 0
+      WsRegs       = r
+      WsStack      = []
+      WsHeap       = []
+      WsHeapLen    = 0
+      WsTrail      = []
+      WsTrailLen   = 0
+      WsCP         = 0
+      WsCPs        = []
+      WsCPsLen     = 0
+      WsBindings   = Map.empty
+      WsCutBar     = 0
+      WsVarCounter = 0
+      WsBuilder    = None
+      WsAggAccum   = [] }
+
+// -- arg/3 specialized ----------------------------------------------------
+
+let scenario_arg () =
+    // phase_i_arg/3 body: `arg 2 A1 X1\n  proceed`
+    // With A1 = Str("foo", [Atom "x"; Atom "y"; Atom "z"]),
+    // X1 (reg 101) should be set to Atom "y" (2nd subterm).
+    let ctx = mkContext ()
+    let s = mkState [
+        (1, Str ("foo", [Atom "x"; Atom "y"; Atom "z"]))
+    ]
+    match lowered_phase_i_arg_3 ctx s with
+    | Some final ->
+        assertTrue "lowered arg(2, A1, X1): X1 = Atom \"y\""
+                   (final.WsRegs.[101] = Atom "y")
+    | None ->
+        assertTrue "lowered arg should succeed on a 3-arg Str" false
+
+    // Mismatch case: N=2 on a 1-arg Str -> should fail (returns None).
+    let sMiss = mkState [
+        (1, Str ("foo", [Atom "x"]))
+    ]
+    match lowered_phase_i_arg_3 ctx sMiss with
+    | Some _ ->
+        assertTrue "lowered arg out-of-range should fail" false
+    | None ->
+        assertTrue "lowered arg out-of-range: returns None" true
+
+// -- not_member_list ------------------------------------------------------
+
+let scenario_nml () =
+    // phase_i_nml/2 body: `not_member_list A1 A2\n  proceed`
+    // A1 = Atom "z" (not in list), A2 = VList [a; b; c] -> succeed.
+    let ctx = mkContext ()
+    let s = mkState [
+        (1, Atom "z")
+        (2, VList [Atom "a"; Atom "b"; Atom "c"])
+    ]
+    match lowered_phase_i_nml_2 ctx s with
+    | Some _ ->
+        assertTrue "lowered not_member_list: z notin [a,b,c] -> success" true
+    | None ->
+        assertTrue "lowered not_member_list should succeed" false
+
+    // A1 = Atom "b" (in list) -> fail.
+    let sBad = mkState [
+        (1, Atom "b")
+        (2, VList [Atom "a"; Atom "b"; Atom "c"])
+    ]
+    match lowered_phase_i_nml_2 ctx sBad with
+    | Some _ ->
+        assertTrue "lowered not_member_list: b in list should fail" false
+    | None ->
+        assertTrue "lowered not_member_list: returns None when X in list" true
+
+// -- VSet family: build_empty_set + set_insert + not_member_set -----------
+
+let scenario_vset () =
+    // phase_i_vset/2 body:
+    //   build_empty_set X1
+    //   set_insert A1 X1 X2
+    //   not_member_set A2 X2
+    //   proceed
+    //
+    // With A1 = Atom "a", A2 = Atom "b":
+    //   X1 = VSet {}
+    //   X2 = VSet {"a"}
+    //   not_member_set "b" {"a"} -> success.
+    let ctx = mkContext ()
+    let s = mkState [
+        (1, Atom "a")
+        (2, Atom "b")
+    ]
+    match lowered_phase_i_vset_2 ctx s with
+    | Some final ->
+        assertTrue "lowered vset chain: succeeds"
+                   true
+        assertTrue "lowered vset chain: X1 (reg 101) = VSet Set.empty"
+                   (final.WsRegs.[101] = VSet Set.empty)
+        assertTrue "lowered vset chain: X2 (reg 102) = VSet {\"a\"}"
+                   (final.WsRegs.[102] = VSet (Set.ofList ["a"]))
+    | None ->
+        assertTrue "lowered vset chain should succeed" false
+
+    // With A2 = Atom "a" (same as inserted) -> not_member_set fails.
+    let sBad = mkState [
+        (1, Atom "a")
+        (2, Atom "a")
+    ]
+    match lowered_phase_i_vset_2 ctx sBad with
+    | Some _ ->
+        assertTrue "lowered vset chain: A2 in set should fail" false
+    | None ->
+        assertTrue "lowered vset chain: returns None on hit" true
+
+// -- not_member_const_atoms (variable-arity) -------------------------------
+
+let scenario_nmca () =
+    // phase_i_nmca/1 body: `not_member_const_atoms A1 foo bar baz\n  proceed`
+    // A1 = Atom "qux" (not in {foo, bar, baz}) -> succeed.
+    let ctx = mkContext ()
+    let s = mkState [
+        (1, Atom "qux")
+    ]
+    match lowered_phase_i_nmca_1 ctx s with
+    | Some _ ->
+        assertTrue "lowered not_member_const_atoms: qux notin {foo,bar,baz}" true
+    | None ->
+        assertTrue "lowered not_member_const_atoms should succeed" false
+
+    // A1 = Atom "bar" (in list) -> fail.
+    let sBad = mkState [
+        (1, Atom "bar")
+    ]
+    match lowered_phase_i_nmca_1 ctx sBad with
+    | Some _ ->
+        assertTrue "lowered not_member_const_atoms: bar in list should fail" false
+    | None ->
+        assertTrue "lowered not_member_const_atoms: returns None on hit" true
+
+    // A1 = Integer 42 (non-atom ground) -> succeed (can't unify with atoms).
+    let sInt = mkState [
+        (1, Integer 42)
+    ]
+    match lowered_phase_i_nmca_1 ctx sInt with
+    | Some _ ->
+        assertTrue "lowered not_member_const_atoms: Integer can't unify with atoms" true
+    | None ->
+        assertTrue "lowered not_member_const_atoms (Integer): should succeed" false
+
+// -- PutStructureDyn ------------------------------------------------------
+
+let scenario_psd () =
+    // phase_i_psd/3 body: `put_structure_dyn A1 A2 A3\n  proceed`
+    // With A1 = Atom "foo", A2 = Integer 2 (arity), A3 = target reg.
+    // Effect: WsBuilder = BuildStruct("foo", 3, 2, [])
+    let ctx = mkContext ()
+    let s = mkState [
+        (1, Atom "foo")
+        (2, Integer 2)
+    ]
+    match lowered_phase_i_psd_3 ctx s with
+    | Some final ->
+        match final.WsBuilder with
+        | Some (BuildStruct (fn, reg, arity, args)) ->
+            assertTrue "lowered put_structure_dyn: builder functor = \"foo\""
+                       (fn = "foo")
+            assertTrue "lowered put_structure_dyn: builder target reg = 3"
+                       (reg = 3)
+            assertTrue "lowered put_structure_dyn: builder arity = 2"
+                       (arity = 2)
+            assertTrue "lowered put_structure_dyn: builder args = []"
+                       (args = [])
+        | _ ->
+            assertTrue "lowered put_structure_dyn: builder should be BuildStruct" false
+    | None ->
+        assertTrue "lowered put_structure_dyn should succeed" false
+
+    // Non-Atom name -> failure.
+    let sBad = mkState [
+        (1, Integer 42)
+        (2, Integer 0)
+    ]
+    match lowered_phase_i_psd_3 ctx sBad with
+    | Some _ ->
+        assertTrue "lowered put_structure_dyn: non-Atom name should fail" false
+    | None ->
+        assertTrue "lowered put_structure_dyn (non-Atom): returns None" true
+
+[<EntryPoint>]
+let main _argv =
+    scenario_arg ()
+    scenario_nml ()
+    scenario_vset ()
+    scenario_nmca ()
+    scenario_psd ()
+    let total = passes + fails
+    printfn "RESULT %d/%d" passes total
+    if fails > 0 then 1 else 0


### PR DESCRIPTION
## Summary

Adds a runtime smoke for the Phase-I lowered path — which **immediately surfaced a serious latent bug** in the lowered emitter affecting every step-delegating instruction it has ever emitted.

Single commit (`8279ecd`).

## The bug

PR #2343 added Phase-I lowered-emitter coverage with codegen tests and a *build* smoke.  The build smoke proved the lowered F# code compiles (modulo `FS0025` incomplete-match warnings I dismissed as non-fatal).

**The FS0025 warnings were not cosmetic** — they were `MatchFailureException` traps at runtime.  Every lowered function that uses the `match step ctx ... with | Some sv -> ...` pattern (which is virtually all of them) crashes the moment `step` returns `None`.

The pattern affects every step-delegating instruction the lowered emitter emits, not just the Phase-I additions:

- `BuiltinCall`, `CutIte`, `Jump`
- `Deallocate`, `GetConstant`, `GetValue`, `GetStructure`, `GetList`
- the `Unify*` family, the `Set*` family
- `BeginAggregate`, `EndAggregate`
- and the seven Phase-I additions from PR #2343

Earlier lowered code never tripped because no test ever drove a lowered function through `dotnet run`.  The runtime smoke this PR adds exposed it immediately because some Phase-I scenarios exercise the failure path (e.g. `arg 2 A1 X1` on a 1-arg Str returns `None`).

### Repro

```fsharp
match step ctx { s_init with WsPC = 1 } (Arg (2, 1, 101)) with
| Some s_0 ->
    let ret_ = s_0.WsCP
    if ret_ = 0 then Some { s_0 with WsPC = 0 }
    else Some { s_0 with WsPC = ret_; WsCP = 0 }
// <-- no `| None -> None` here. When step returns None, MatchFailureException.
```

```
Unhandled exception. Microsoft.FSharp.Core.MatchFailureException: The match cases were incomplete
   at Lowered.lowered_phase_i_arg_3(WamContext ctx, WamState s_init) in Lowered.fs:line 11
```

## The fix

`src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl`: emit a `| None -> None` arm after every match-style step delegation in **three** places that compose the lowered output:

1. **`emit_instrs_lm_fs`** (5-arg, LabelMap-aware path used by `emit_func_fs`) — both the empty-`Rest` final-instruction case and the recursive intermediate case.
2. **`emit_instrs_fs`** (4-arg legacy path used inside ITE blocks) — same two cases.
3. **`emit_ite_block_fs`** continuation case (`[pc(_, Instr) | Rest]` with `Rest \= []`) — the empty-Rest case in the same predicate already had the closure, so the partial fix was there since the file's first commit but the chained variant slipped through.

After the fix:
- FS0025 warnings disappear from the build output (`7 Warning(s)` → `0 Warning(s)`).
- Runtime no longer crashes on None-returns — the match falls through cleanly to `None`.

## The runtime smoke

### `tests/fixtures/wam_fsharp_phase_i_lowered_smoke/Driver.fs` (new)

Replaces the auto-generated `Program.fs`.  Drives five lowered functions (one per Phase-I instruction class) with crafted register inputs across **16 assertions** covering both success and failure paths:

| Scenario | Sub-assertions |
|---|---|
| `arg(2, A1, X1)` | success (extracts 2nd subterm); out-of-range N → `None` |
| `not_member_list(A1, A2)` | success (X not in list); fail (X in list) |
| VSet chain (`build_empty_set` + `set_insert` + `not_member_set`) | success with `WsRegs` snapshot verification (X1 = `VSet Set.empty`, X2 = `VSet {"a"}`); fail on hit |
| `not_member_const_atoms(A1, foo, bar, baz)` | success (miss); fail (hit); succeed (non-atom ground Integer) |
| `put_structure_dyn(A1, A2, A3)` | success with `WsBuilder` snapshot verification (functor / target reg / arity / args); fail on non-Atom name |

### `tests/core/test_wam_fsharp_dotnet_smoke.pl` gains `test_dotnet_run_phase_i_lowered`

1. Generates the empty-predicates project as a base.
2. Drives `lower_predicate_to_fsharp/4` on five hand-rolled WAM bodies (`phase_i_arg/3`, `phase_i_nml/2`, `phase_i_vset/2`, `phase_i_nmca/1`, `phase_i_psd/3` — predicate names chosen so the sanitizer yields predictable function names the Driver fixture calls by name).
3. Splices the emitted F# functions into `Lowered.fs`.
4. Overwrites `Program.fs` with the Driver fixture.
5. `dotnet build` + `dotnet run`, parses `RESULT N/M` from stdout.

The build smoke from PR #2343 stays — it covers a slightly different shape (single 8-instruction body with every Phase-I op interleaved) and catches a different failure class (codegen string issues that wouldn't necessarily surface in the runtime smoke's smaller per-scenario bodies).

## Verification

- `swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_dotnet_smoke.pl` — **5 / 5 pass** (+1 over PR #2343's 4).  Phase-I runtime smoke reports `RESULT 16/16`.  Build output now has **0 warnings** (previously 7 FS0025).
- `swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl` — **58 / 58** (codegen tests unchanged — the fix is in the emitter's match-closing logic, codegen patterns are still detectable).
- `test_dotnet_run_smoke` (the Phase-Y interpreter runtime smoke from PR #2342): still `RESULT 49/49`.
- `tests/core/test_fsharp_native_lowering.pl`: pre-existing tests unchanged.

## Test plan

- [x] All five dotnet smokes pass.
- [x] Runtime smoke reports `RESULT 16/16` for the Phase-I lowered path.
- [x] Build now has 0 warnings (previously 7 FS0025).
- [x] All 58 codegen tests still pass.
- [x] Pre-existing interpreter runtime smoke still passes (`RESULT 49/49`).

## What this enables next

The runtime smoke pattern (build + run + assert) is now established for both:

1. **Interpreter path** (`tests/fixtures/wam_fsharp_smoke/Smoke.fs`, 49 assertions from PR #2342) — drives `step` directly with hand-constructed instructions.
2. **Lowered path** (this PR's `Driver.fs`, 16 assertions) — drives lowered F# functions emitted by `lower_predicate_to_fsharp/4`.

Future smokes for additional features can follow either pattern.  The `| None -> None` closure fix means lowered output is now safe to call on any input, including failing paths — unblocking real-world use of the lowered emitter.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_