### PR TITLE
feat(wam-fsharp): forkParBranches + MergeStrategy machinery (Phase J-β — parallel aggregate WAM)

### DIFF
--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -103,12 +103,32 @@ fsharp_wam_trail_entry_type :-
 "type TrailEntry = { TrailVarId: int; TrailOldVal: Value option }").
 
 % ============================================================================
-% AggregateFrame — mirrors Haskell `AggFrame`
+% MergeStrategy + AggregateFrame — mirrors Haskell `MergeStrategy` + `AggFrame`
 % ============================================================================
+%
+% AggMergeStrategy classifies an aggregate's combine semantics so the WAM
+% runtime can decide whether to evaluate branches in parallel (forkable
+% strategies: sum/count/bag/set/findall) or fall back to sequential
+% choice-point backtracking (everything else).  Computed at BeginAggregate
+% time from the aggType string via inferMergeStrategy (defined in
+% WamRuntime).
 
 fsharp_wam_agg_frame_type :-
     writeln(
-"type AggFrame = { AggType: string; AggValReg: int; AggResReg: int; AggReturnPC: int }").
+"type MergeStrategy =
+    | MergeSum
+    | MergeCount
+    | MergeBag
+    | MergeSet
+    | MergeFindall
+    | MergeSequential   // not forkable: fall back to sequential backtrack
+
+type AggFrame =
+    { AggType:           string
+      AggValReg:         int
+      AggResReg:         int
+      AggReturnPC:       int
+      AggMergeStrategy:  MergeStrategy }").
 
 % ============================================================================
 % BuiltinState — mirrors Haskell `BuiltinState`

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -976,11 +976,17 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         | cp :: rest -> Some { s with WsPC = s.WsPC + 1; WsCPs = { cp with CpNextPC = nextPC } :: rest }
         | []         -> None
 
-    // Phase 4.1 parallel stubs — alias to sequential counterparts
-    | ParTryMeElse label    -> step ctx s (TryMeElse label)
+    // Phase 4.1 / Phase J — parallel WAM. ParTryMeElse dispatches through
+    // forkOrSequential, which forks all branches in parallel when inside a
+    // forkable aggregate frame (sum/count/bag/set/findall with enough
+    // branches), otherwise falls back to the sequential TryMeElse step.
+    // The Retry/Trust variants always alias to sequential since they
+    // appear inside the chain that the fork enumerates wholesale — only
+    // the leading ParTryMeElse triggers the fork decision.
+    | ParTryMeElse label    -> forkOrSequential ctx s (Choice1Of2 label)
+    | ParTryMeElsePc pc     -> forkOrSequential ctx s (Choice2Of2 pc)
     | ParRetryMeElse label  -> step ctx s (RetryMeElse label)
     | ParTrustMe            -> step ctx s TrustMe
-    | ParTryMeElsePc pc     -> step ctx s (TryMeElsePc pc)
     | ParRetryMeElsePc pc   -> step ctx s (RetryMeElsePc pc)
 
     | SwitchOnConstantPc table ->
@@ -1610,8 +1616,11 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                    CpHeapLen  = s.WsHeapLen
                    CpBindings = s.WsBindings
                    CpCutBar   = s.WsCutBar
-                   CpAggFrame = Some { AggType = aggType; AggValReg = valReg
-                                       AggResReg = resReg; AggReturnPC = 0 }
+                   CpAggFrame = Some { AggType          = aggType
+                                       AggValReg        = valReg
+                                       AggResReg        = resReg
+                                       AggReturnPC      = 0
+                                       AggMergeStrategy = inferMergeStrategy aggType }
                    CpBuiltin  = None }
         Some { s with
                  WsPC       = s.WsPC + 1
@@ -2061,6 +2070,205 @@ and runNegationParallel (ctx: WamContext) (s: WamState) (entryPC: int) (elsePC: 
         match run ctx { s with WsPC = entryPC; WsCP = 0; WsCutBar = 0 } with
         | Some _ -> true
         | None   -> false
+
+/// Classify an aggregate type string as a MergeStrategy.  Sum / count /
+/// bag / set / findall are forkable — their per-branch results combine
+/// associatively, so parallel evaluation is safe.  Everything else falls
+/// back to sequential.  Mirrors wam_haskell_target.pl inferMergeStrategy.
+and inferMergeStrategy (aggType: string) : MergeStrategy =
+    match aggType with
+    | "sum"     -> MergeSum
+    | "count"   -> MergeCount
+    | "bag"     -> MergeBag
+    | "set"     -> MergeSet
+    | "findall" -> MergeFindall
+    | "collect" -> MergeFindall   // alias
+    | _         -> MergeSequential
+
+/// True iff the strategy can be evaluated by forking branches in parallel.
+and isForkableStrategy (ms: MergeStrategy) : bool =
+    match ms with
+    | MergeSum | MergeCount | MergeBag | MergeSet | MergeFindall -> true
+    | MergeSequential -> false
+
+/// Walk WsCPs to find the nearest aggregate frame''s merge strategy, if any.
+and currentAggMergeStrategy (s: WamState) : MergeStrategy option =
+    let rec go cps =
+        match cps with
+        | [] -> None
+        | cp :: rest ->
+            match cp.CpAggFrame with
+            | Some af -> Some af.AggMergeStrategy
+            | None    -> go rest
+    go s.WsCPs
+
+/// Walk WsCPs to find the nearest aggregate frame, returning the whole frame.
+and currentAggFrame (s: WamState) : AggFrame option =
+    let rec go cps =
+        match cps with
+        | [] -> None
+        | cp :: rest ->
+            match cp.CpAggFrame with
+            | Some af -> Some af
+            | None    -> go rest
+    go s.WsCPs
+
+/// Remove the nearest aggregate-frame CP from a CP list.  Used after
+/// forkParBranches consumes the aggregate to drop the frame so subsequent
+/// backtracking doesn''t try to re-finalize it.
+and removeNearestAggFrame (cps: ChoicePoint list) : ChoicePoint list =
+    let rec go cps =
+        match cps with
+        | [] -> []
+        | cp :: rest ->
+            match cp.CpAggFrame with
+            | Some _ -> rest                   // drop it
+            | None   -> cp :: go rest
+    go cps
+
+/// Scan WcCode forward from a Par* instruction to find the matching
+/// EndAggregate''s return PC (one past the EndAggregate).  Returns 0
+/// (treated as halt by run) on overrun so a malformed chain fails gracefully
+/// rather than indexing out of bounds.  Mirrors wam_haskell_target.pl
+/// findOuterEndAggregate.
+and findOuterEndAggregate (ctx: WamContext) (startPC: int) : int =
+    let lo, hi = 0, ctx.WcCode.Length - 1
+    let rec go pc =
+        if pc < lo || pc > hi then 0
+        else
+            match ctx.WcCode.[pc] with
+            | EndAggregate _ -> pc + 1
+            | _              -> go (pc + 1)
+    go (startPC + 1)
+
+/// Combine per-branch aggregate results from forkParBranches into a single
+/// final Value, applying the merge strategy at the cross-branch level.
+/// Each input is one branch''s already-aggregated value (computed by its
+/// own finalizeAggregate from a single-element WsAggAccum), so we are
+/// folding aggregates of aggregates here.  Semantics chosen to keep the
+/// fork equivalent to the sequential version:
+///   sum     : numeric sum of per-branch sums
+///   count   : sum of per-branch counts (each branch counts its hits)
+///   bag     : concat of per-branch VLists
+///   set     : Set.ofList over the flattened bag, back to VList (dedup)
+///   findall : same as bag — findall preserves duplicates and order
+///   other   : fallback to VList of the raw per-branch results
+and combineParBranchResults (ms: MergeStrategy) (results: Value list) : Value =
+    match ms with
+    | MergeSum ->
+        let toNum v =
+            match v with
+            | Integer n -> float n
+            | Float f   -> f
+            | _         -> 0.0
+        let total = results |> List.sumBy toNum
+        if float (int total) = total then Integer (int total) else Float total
+    | MergeCount ->
+        let toInt v = match v with Integer n -> n | _ -> 0
+        Integer (results |> List.sumBy toInt)
+    | MergeBag | MergeFindall ->
+        let extract v = match v with VList items -> items | _ -> [v]
+        VList (results |> List.collect extract)
+    | MergeSet ->
+        let extract v = match v with VList items -> items | _ -> [v]
+        let allItems = results |> List.collect extract
+        VList (List.distinct allItems)
+    | MergeSequential ->
+        VList results
+
+/// Fork all branches of a Par*-chain inside a forkable aggregate frame.
+/// Each branch runs to completion (including its own EndAggregate +
+/// finalizeAggregate) in parallel via Async.Parallel; we then read the
+/// per-branch result from the response register and merge them.
+///
+/// After fork: returns a state with WsPC = retPC (one past the outer
+/// EndAggregate), WsRegs[ResReg] bound to the merged value, and the
+/// aggregate frame removed from WsCPs.  Mirrors wam_haskell_target.pl
+/// forkParBranches.
+and forkParBranches (ctx: WamContext) (s: WamState) (af: AggFrame)
+                    (parPC: int) (elsePC: int) : WamState option =
+    let branchPCs = enumerateParBranches ctx parPC elsePC
+    let runBranch pc =
+        async {
+            // Each branch inherits the aggregate frame in WsCPs so its own
+            // EndAggregate can finalize via the standard path, binding the
+            // per-branch aggregate to AggResReg.  WsCP = 0 makes proceed
+            // halt the branch.  WsAggAccum starts empty so the branch only
+            // accumulates its own contribution.
+            let snapshot = { s with
+                               WsPC       = pc
+                               WsCP       = 0
+                               WsCutBar   = 0
+                               WsAggAccum = [] }
+            return run ctx snapshot
+        }
+    let results =
+        branchPCs
+        |> List.map runBranch
+        |> Async.Parallel
+        |> Async.RunSynchronously
+    // Extract per-branch aggregate result from AggResReg of each successful branch.
+    let perBranchValues =
+        results
+        |> Array.choose (fun rOpt ->
+            rOpt |> Option.bind (fun final ->
+                if af.AggResReg >= 0 && af.AggResReg < final.WsRegs.Length then
+                    let raw = final.WsRegs.[af.AggResReg]
+                    match raw with
+                    | Unbound -1 -> None   // sentinel: branch didn''t finalize
+                    | v -> Some (derefVar final.WsBindings v)
+                else None))
+        |> Array.toList
+    let combined = combineParBranchResults af.AggMergeStrategy perBranchValues
+    let retPC = findOuterEndAggregate ctx parPC
+    // Drop the consumed aggregate frame from WsCPs and bind combined to AggResReg.
+    let outerCPs = removeNearestAggFrame s.WsCPs
+    let regs = Array.copy s.WsRegs
+    if af.AggResReg >= 0 && af.AggResReg < regs.Length then
+        regs.[af.AggResReg] <- combined
+    // Thread through bindings + trail if the outer register slot was Unbound.
+    let preBindings, preTrail, preTrailLen =
+        if af.AggResReg >= 0 && af.AggResReg < s.WsRegs.Length then
+            match derefVar s.WsBindings s.WsRegs.[af.AggResReg] with
+            | Unbound vid ->
+                (Map.add vid combined s.WsBindings,
+                 { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail,
+                 s.WsTrailLen + 1)
+            | _ -> (s.WsBindings, s.WsTrail, s.WsTrailLen)
+        else (s.WsBindings, s.WsTrail, s.WsTrailLen)
+    Some { s with
+             WsPC       = retPC
+             WsRegs     = regs
+             WsBindings = preBindings
+             WsTrail    = preTrail
+             WsTrailLen = preTrailLen
+             WsCPs      = outerCPs
+             WsCPsLen   = List.length outerCPs
+             WsAggAccum = [] }
+
+/// Dispatcher for ParTryMeElse / ParTryMeElsePc.  Checks if we''re inside
+/// a forkable aggregate frame with enough branches; if so, fork.  Otherwise
+/// fall back to the sequential TryMeElse step semantics (a choice point
+/// is pushed, the first branch runs, backtracking will explore the rest).
+and forkOrSequential (ctx: WamContext) (s: WamState)
+                     (elseTarget: Choice<string, int>) : WamState option =
+    let fallback () =
+        match elseTarget with
+        | Choice1Of2 lbl -> step ctx s (TryMeElse lbl)
+        | Choice2Of2 pc  -> step ctx s (TryMeElsePc pc)
+    match currentAggFrame s with
+    | Some af when isForkableStrategy af.AggMergeStrategy ->
+        let elsePC =
+            match elseTarget with
+            | Choice2Of2 pc  -> pc
+            | Choice1Of2 lbl -> Map.tryFind lbl ctx.WcLabels |> Option.defaultValue -1
+        if elsePC <= 0 then fallback ()
+        else
+            let branches = enumerateParBranches ctx s.WsPC elsePC
+            if List.length branches >= forkMinBranches then
+                forkParBranches ctx s af s.WsPC elsePC
+            else fallback ()
+    | _ -> fallback ()
 
 /// Indexed fact dispatch for 2-arg facts via BuiltinState CP.
 /// O(1) Map lookup; first match returned, FactRetry CP for the rest.

--- a/tests/fixtures/wam_fsharp_smoke/Smoke.fs
+++ b/tests/fixtures/wam_fsharp_smoke/Smoke.fs
@@ -543,12 +543,11 @@ let scenario_run_negation_parallel_one_succeeds () =
     assertTrue "runNegationParallel: one-Proceed branch => true (negation fails)"
                (anySucceeded = true)
 
-// -- Scenario 15: Par* step arms still alias to sequential ----------------
+// -- Scenario 15: ParTryMeElsePc OUTSIDE an aggregate aliases to sequential
 //
-// PR #2340 deliberately kept the ParTryMeElse step arms as sequential
-// aliases (the fork path lights up only via \+/1's goal-entry peek for
-// runNegationParallel).  This scenario locks in that contract: a
-// ParTryMeElsePc still pushes a choice point exactly as TryMeElsePc would.
+// forkOrSequential checks for a forkable aggregate frame in WsCPs; absent
+// one, it falls back to the sequential TryMeElse step.  This scenario
+// locks in that contract.
 
 let scenario_par_step_aliases_to_sequential () =
     let code = [| ParTryMeElsePc 99 |]
@@ -556,18 +555,143 @@ let scenario_par_step_aliases_to_sequential () =
     let s0 = mkEmptyState ()
     match step ctx s0 code.[0] with
     | Some s ->
-        assertTrue "ParTryMeElsePc: PC advanced past the instruction"
+        assertTrue "ParTryMeElsePc (no agg frame): PC advanced"
                    (s.WsPC = 1)
-        assertTrue "ParTryMeElsePc: one choice point pushed"
+        assertTrue "ParTryMeElsePc (no agg frame): one CP pushed"
                    (s.WsCPsLen = 1)
         match s.WsCPs with
         | cp :: _ ->
-            assertTrue "ParTryMeElsePc: CP next PC = else target"
+            assertTrue "ParTryMeElsePc (no agg frame): CP next PC = else target"
                        (cp.CpNextPC = 99)
         | [] ->
             assertTrue "ParTryMeElsePc: CP list should be non-empty" false
     | None ->
         assertTrue "ParTryMeElsePc should succeed" false
+
+// -- Scenario 16: inferMergeStrategy + isForkableStrategy ------------------
+
+let scenario_merge_strategy_helpers () =
+    assertTrue "inferMergeStrategy: \"sum\" -> MergeSum"
+               (inferMergeStrategy "sum" = MergeSum)
+    assertTrue "inferMergeStrategy: \"count\" -> MergeCount"
+               (inferMergeStrategy "count" = MergeCount)
+    assertTrue "inferMergeStrategy: \"bag\" -> MergeBag"
+               (inferMergeStrategy "bag" = MergeBag)
+    assertTrue "inferMergeStrategy: \"set\" -> MergeSet"
+               (inferMergeStrategy "set" = MergeSet)
+    assertTrue "inferMergeStrategy: \"findall\" -> MergeFindall"
+               (inferMergeStrategy "findall" = MergeFindall)
+    assertTrue "inferMergeStrategy: \"collect\" -> MergeFindall (alias)"
+               (inferMergeStrategy "collect" = MergeFindall)
+    assertTrue "inferMergeStrategy: unknown -> MergeSequential"
+               (inferMergeStrategy "unknown_strategy" = MergeSequential)
+    assertTrue "isForkableStrategy: MergeSum"     (isForkableStrategy MergeSum)
+    assertTrue "isForkableStrategy: MergeCount"   (isForkableStrategy MergeCount)
+    assertTrue "isForkableStrategy: MergeBag"     (isForkableStrategy MergeBag)
+    assertTrue "isForkableStrategy: MergeSet"     (isForkableStrategy MergeSet)
+    assertTrue "isForkableStrategy: MergeFindall" (isForkableStrategy MergeFindall)
+    assertTrue "isForkableStrategy: MergeSequential -> false"
+               (not (isForkableStrategy MergeSequential))
+
+// -- Scenario 17: combineParBranchResults per-strategy semantics ----------
+
+let scenario_combine_par_branch_results () =
+    // Sum: numeric sum, demotes to Integer when whole.
+    let sumResult = combineParBranchResults MergeSum [Integer 1; Integer 2; Integer 3]
+    assertTrue "combineParBranchResults sum [1; 2; 3] = Integer 6"
+               (sumResult = Integer 6)
+    // Count: sum of per-branch counts.
+    let countResult = combineParBranchResults MergeCount [Integer 1; Integer 1; Integer 1]
+    assertTrue "combineParBranchResults count [1; 1; 1] = Integer 3"
+               (countResult = Integer 3)
+    // Bag: concat of per-branch VLists.
+    let bagResult =
+        combineParBranchResults MergeBag
+            [VList [Atom "a"; Atom "b"]; VList [Atom "c"]]
+    let bagExpected = VList [Atom "a"; Atom "b"; Atom "c"]
+    assertTrue "combineParBranchResults bag [[a;b]; [c]] = VList [a;b;c]"
+               (bagResult = bagExpected)
+    // Set: dedup'd concat.
+    let setResult =
+        combineParBranchResults MergeSet
+            [VList [Atom "a"; Atom "b"]; VList [Atom "b"; Atom "c"]]
+    let setExpected = VList [Atom "a"; Atom "b"; Atom "c"]
+    assertTrue "combineParBranchResults set [[a;b]; [b;c]] = VList [a;b;c] (dedup)"
+               (setResult = setExpected)
+    // Findall: same as bag (preserves order + duplicates).
+    let findallResult =
+        combineParBranchResults MergeFindall
+            [VList [Atom "a"]; VList [Atom "a"]; VList [Atom "b"]]
+    let findallExpected = VList [Atom "a"; Atom "a"; Atom "b"]
+    assertTrue "combineParBranchResults findall [[a]; [a]; [b]] = VList [a;a;b]"
+               (findallResult = findallExpected)
+
+// -- Scenario 18: findOuterEndAggregate scans forward to EndAggregate -----
+
+let scenario_find_outer_end_aggregate () =
+    let code = [|
+        BeginAggregate ("sum", 2, 1)   // PC 0
+        ParTryMeElsePc 3               // PC 1
+        Proceed                         // PC 2
+        ParTrustMe                      // PC 3
+        Proceed                         // PC 4
+        EndAggregate 2                  // PC 5
+        Proceed                         // PC 6 — retPC
+    |]
+    let ctx = mkContext code Map.empty
+    let retPC = findOuterEndAggregate ctx 1   // scan from ParTryMeElsePc
+    assertTrue "findOuterEndAggregate: scans forward to EndAggregate's next PC"
+               (retPC = 6)
+    // Overrun: scan from past-the-end => 0 (halt).
+    let retOverrun = findOuterEndAggregate ctx 100
+    assertTrue "findOuterEndAggregate: overrun returns 0"
+               (retOverrun = 0)
+
+// -- Scenario 19: removeNearestAggFrame drops the nearest agg-frame CP ----
+
+let scenario_remove_nearest_agg_frame () =
+    let plainCP : ChoicePoint = {
+        CpNextPC = 10; CpRegs = Array.empty; CpStack = []
+        CpCP = 0; CpTrailLen = 0; CpHeapLen = 0
+        CpBindings = Map.empty; CpCutBar = 0
+        CpAggFrame = None; CpBuiltin = None }
+    let aggCP : ChoicePoint = {
+        plainCP with CpAggFrame = Some { AggType = "sum"; AggValReg = 2
+                                         AggResReg = 1; AggReturnPC = 0
+                                         AggMergeStrategy = MergeSum } }
+    let cps = [plainCP; aggCP; plainCP]
+    let trimmed = removeNearestAggFrame cps
+    assertTrue "removeNearestAggFrame: drops the aggregate-frame CP"
+               (List.length trimmed = 2)
+    assertTrue "removeNearestAggFrame: neither remaining CP has an AggFrame"
+               (trimmed |> List.forall (fun cp -> cp.CpAggFrame.IsNone))
+
+// -- Scenario 20: forkOrSequential dispatches forkable vs sequential -----
+//
+// Inside a non-forkable (MergeSequential) aggregate frame, ParTryMeElsePc
+// must still fall back to sequential TryMeElse semantics (a CP gets pushed,
+// PC advances past the Par* instruction).  No aggregate frame at all =>
+// same fallback.  Inside a forkable aggregate, the fallback only kicks in
+// if branch count < forkMinBranches (= 3).
+
+let scenario_par_step_inside_sequential_aggregate () =
+    let code = [| ParTryMeElsePc 99 |]
+    let ctx = mkContext code Map.empty
+    let aggCP : ChoicePoint = {
+        CpNextPC = 0; CpRegs = Array.empty; CpStack = []
+        CpCP = 0; CpTrailLen = 0; CpHeapLen = 0
+        CpBindings = Map.empty; CpCutBar = 0
+        CpAggFrame = Some { AggType = "unknown"; AggValReg = 2
+                            AggResReg = 1; AggReturnPC = 0
+                            AggMergeStrategy = MergeSequential }
+        CpBuiltin = None }
+    let s0 = { mkEmptyState () with WsCPs = [aggCP]; WsCPsLen = 1 }
+    match step ctx s0 code.[0] with
+    | Some s ->
+        assertTrue "ParTryMeElsePc (MergeSequential agg): fallback adds 1 CP"
+                   (s.WsCPsLen = 2)
+    | None ->
+        assertTrue "ParTryMeElsePc inside agg should succeed" false
 
 [<EntryPoint>]
 let main _argv =
@@ -588,6 +712,11 @@ let main _argv =
     scenario_run_negation_parallel_all_fail ()
     scenario_run_negation_parallel_one_succeeds ()
     scenario_par_step_aliases_to_sequential ()
+    scenario_merge_strategy_helpers ()
+    scenario_combine_par_branch_results ()
+    scenario_find_outer_end_aggregate ()
+    scenario_remove_nearest_agg_frame ()
+    scenario_par_step_inside_sequential_aggregate ()
     let total = passes + fails
     printfn "RESULT %d/%d" passes total
     if fails > 0 then 1 else 0

--- a/tests/test_wam_fsharp_target.pl
+++ b/tests/test_wam_fsharp_target.pl
@@ -951,6 +951,111 @@ test_fsharp_lowered_emitter_phase_i_pc_offsets :-
     ).
 
 %% ----------------------------------------------------------------------
+%% Phase J-β — forkParBranches + MergeStrategy machinery.  Mirrors the
+%% Haskell baseline''s forkable-aggregate fork path.  Per-branch
+%% aggregation is computed normally (via finalizeAggregate in each
+%% branch), then the per-branch results are merged by
+%% combineParBranchResults at the cross-branch level.  Sum / count /
+%% bag / set / findall are forkable; anything else falls back to
+%% sequential TryMeElse semantics.
+%% ----------------------------------------------------------------------
+
+test_fsharp_merge_strategy_du :-
+    Test = 'WAM-FSharp: MergeStrategy DU + AggFrame.AggMergeStrategy',
+    (   fsharp_wam_type_header(Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "type MergeStrategy ="),
+        sub_string(S, _, _, _, "| MergeSum"),
+        sub_string(S, _, _, _, "| MergeCount"),
+        sub_string(S, _, _, _, "| MergeBag"),
+        sub_string(S, _, _, _, "| MergeSet"),
+        sub_string(S, _, _, _, "| MergeFindall"),
+        sub_string(S, _, _, _, "| MergeSequential"),
+        sub_string(S, _, _, _, "AggMergeStrategy:  MergeStrategy")
+    ->  pass(Test)
+    ;   fail_test(Test, 'MergeStrategy DU or AggFrame field missing')
+    ).
+
+test_fsharp_infer_merge_strategy :-
+    Test = 'WAM-FSharp: inferMergeStrategy helper',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "and inferMergeStrategy (aggType: string) : MergeStrategy ="),
+        sub_string(S, _, _, _, "| \"sum\"     -> MergeSum"),
+        sub_string(S, _, _, _, "| \"count\"   -> MergeCount"),
+        sub_string(S, _, _, _, "| \"bag\"     -> MergeBag"),
+        sub_string(S, _, _, _, "| \"set\"     -> MergeSet"),
+        sub_string(S, _, _, _, "| \"findall\" -> MergeFindall"),
+        sub_string(S, _, _, _, "| \"collect\" -> MergeFindall"),
+        sub_string(S, _, _, _, "| _         -> MergeSequential")
+    ->  pass(Test)
+    ;   fail_test(Test, 'inferMergeStrategy patterns missing')
+    ).
+
+test_fsharp_begin_aggregate_records_strategy :-
+    %% BeginAggregate must thread inferMergeStrategy(aggType) into the
+    %% new AggMergeStrategy field on the pushed AggFrame.
+    Test = 'WAM-FSharp: BeginAggregate stores AggMergeStrategy',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "AggMergeStrategy = inferMergeStrategy aggType")
+    ->  pass(Test)
+    ;   fail_test(Test, 'BeginAggregate does not record AggMergeStrategy')
+    ).
+
+test_fsharp_forkable_strategy_helpers :-
+    Test = 'WAM-FSharp: isForkableStrategy / currentAggMergeStrategy / currentAggFrame helpers',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "and isForkableStrategy (ms: MergeStrategy) : bool ="),
+        sub_string(S, _, _, _, "| MergeSum | MergeCount | MergeBag | MergeSet | MergeFindall -> true"),
+        sub_string(S, _, _, _, "| MergeSequential -> false"),
+        sub_string(S, _, _, _, "and currentAggMergeStrategy (s: WamState) : MergeStrategy option ="),
+        sub_string(S, _, _, _, "and currentAggFrame (s: WamState) : AggFrame option =")
+    ->  pass(Test)
+    ;   fail_test(Test, 'forkable-strategy helpers missing')
+    ).
+
+test_fsharp_fork_par_branches_helpers :-
+    Test = 'WAM-FSharp: removeNearestAggFrame / findOuterEndAggregate / combineParBranchResults / forkParBranches',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "and removeNearestAggFrame (cps: ChoicePoint list) : ChoicePoint list ="),
+        sub_string(S, _, _, _, "and findOuterEndAggregate (ctx: WamContext) (startPC: int) : int ="),
+        sub_string(S, _, _, _, "| EndAggregate _ -> pc + 1"),
+        sub_string(S, _, _, _, "and combineParBranchResults (ms: MergeStrategy) (results: Value list) : Value ="),
+        %% Per-strategy combiners.
+        sub_string(S, _, _, _, "| MergeSum ->"),
+        sub_string(S, _, _, _, "| MergeCount ->"),
+        sub_string(S, _, _, _, "| MergeBag | MergeFindall ->"),
+        sub_string(S, _, _, _, "| MergeSet ->"),
+        sub_string(S, _, _, _, "List.distinct allItems"),
+        sub_string(S, _, _, _, "and forkParBranches (ctx: WamContext) (s: WamState) (af: AggFrame)"),
+        sub_string(S, _, _, _, "|> Async.Parallel"),
+        sub_string(S, _, _, _, "combineParBranchResults af.AggMergeStrategy perBranchValues")
+    ->  pass(Test)
+    ;   fail_test(Test, 'forkParBranches helpers missing or incomplete')
+    ).
+
+test_fsharp_fork_or_sequential_dispatcher :-
+    Test = 'WAM-FSharp: forkOrSequential dispatcher + Par*MeElse routing',
+    (   compile_wam_runtime_to_fsharp([], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, "and forkOrSequential (ctx: WamContext) (s: WamState)"),
+        %% Forkable + enough branches => fork.
+        sub_string(S, _, _, _, "isForkableStrategy af.AggMergeStrategy"),
+        sub_string(S, _, _, _, "forkParBranches ctx s af s.WsPC elsePC"),
+        %% Otherwise fall back to sequential TryMeElse semantics.
+        sub_string(S, _, _, _, "step ctx s (TryMeElse lbl)"),
+        sub_string(S, _, _, _, "step ctx s (TryMeElsePc pc)"),
+        %% Par*MeElse step arms dispatch through forkOrSequential.
+        sub_string(S, _, _, _, "| ParTryMeElse label    -> forkOrSequential ctx s (Choice1Of2 label)"),
+        sub_string(S, _, _, _, "| ParTryMeElsePc pc     -> forkOrSequential ctx s (Choice2Of2 pc)")
+    ->  pass(Test)
+    ;   fail_test(Test, 'forkOrSequential dispatcher or ParTryMeElse routing missing')
+    ).
+
+%% ----------------------------------------------------------------------
 %% Project generation smoke: exercise write_wam_fsharp_project/3 in a
 %% throwaway directory with no kernels and assert the expected files
 %% are produced. Does not invoke `dotnet build`.
@@ -1073,6 +1178,13 @@ run_tests :-
     test_fsharp_lowered_emitter_phase_i_accepted,
     test_fsharp_lowered_emitter_phase_i_emits_step_delegation,
     test_fsharp_lowered_emitter_phase_i_pc_offsets,
+    %% Phase J-β — forkParBranches + MergeStrategy
+    test_fsharp_merge_strategy_du,
+    test_fsharp_infer_merge_strategy,
+    test_fsharp_begin_aggregate_records_strategy,
+    test_fsharp_forkable_strategy_helpers,
+    test_fsharp_fork_par_branches_helpers,
+    test_fsharp_fork_or_sequential_dispatcher,
     test_fsharp_project_generation_smoke,
     format('~n========================================~n'),
     (   test_failed


### PR DESCRIPTION
## Summary

Closes the last remaining Phase-J item. F# now **forks branches in parallel** when `ParTryMeElse` fires inside a forkable aggregate (sum / count / bag / set / findall), instead of always falling back to sequential choice-point backtracking.

After this PR, the F# WAM target matches the Haskell baseline on parallel-WAM features: `\+/1` negation (PR #2340) **and** aggregate fork (this PR).

Single commit (`dadc197`).

## Architecture

```
ParTryMeElse / ParTryMeElsePc
        ↓
forkOrSequential ctx s elseTarget
        ↓
currentAggFrame s    →  None  →  fallback to sequential step
        ↓ Some af
isForkableStrategy af.AggMergeStrategy → false  →  fallback
        ↓ true
enumerate branches; |branches| ≥ forkMinBranches → false  →  fallback
        ↓ true
forkParBranches ctx s af parPC elsePC
        ↓
Async.Parallel each branch via `run ctx snapshot`
        ↓
Extract AggResReg from each successful branch
        ↓
combineParBranchResults af.AggMergeStrategy perBranchValues
        ↓
Bind combined to AggResReg; remove agg frame from WsCPs; PC = retPC
```

## Type machinery (`WamTypes.fs`)

- **`MergeStrategy` DU**: `MergeSum | MergeCount | MergeBag | MergeSet | MergeFindall | MergeSequential`.
- **`AggFrame`** gains `AggMergeStrategy: MergeStrategy` field. Existing consumers (`finalizeAggregate`, `updateNearestAggFrame`) use F# record-update syntax that preserves the new field automatically.

## Runtime helpers (`WamRuntime.fs`)

Seven new mutually-recursive functions:

| Helper | Purpose |
|---|---|
| `inferMergeStrategy : string -> MergeStrategy` | Maps `"sum" -> MergeSum`, etc. `"collect"` aliases to `MergeFindall`. |
| `isForkableStrategy : MergeStrategy -> bool` | True for sum/count/bag/set/findall. |
| `currentAggMergeStrategy` / `currentAggFrame` | Walk `WsCPs` to find the nearest aggregate frame. |
| `removeNearestAggFrame` | Drops the consumed aggregate frame from a CP list after fork completes. |
| `findOuterEndAggregate ctx startPC` | Scans `WcCode` forward to find the matching `EndAggregate`'s return PC. Returns 0 on overrun. |
| `combineParBranchResults ms results` | Combines per-branch aggregates: sum-of-sums; sum of counts; concat of bags; dedup'd concat for set; same as bag for findall. |
| `forkParBranches ctx s af parPC elsePC` | The actual fork: `Async.Parallel` over branches via `run`, then merge. |
| `forkOrSequential ctx s elseTarget` | Dispatcher invoked by the `Par*MeElse` step arms. |

## Step arm updates

`ParTryMeElse` / `ParTryMeElsePc` now dispatch through `forkOrSequential` instead of aliasing directly to `TryMeElse` / `TryMeElsePc`. The `Retry` / `Trust` variants stay aliased — only the leading `ParTryMeElse` triggers the fork decision; the `Retry` / `Trust` opcodes inside the chain are enumerated wholesale by `enumerateParBranches`.

## F# vs Haskell adaptation

The Haskell `forkParBranches` extracts each branch's `wsAggAccum` list pre-finalization — that's tricky to do cleanly because `EndAggregate` calls `finalizeAggregate` synchronously, which clears the accumulator.

The F# port takes a simpler approach: **let each branch's own `EndAggregate` finalize normally**, binding `AggResReg` to the per-branch aggregate. Then `forkParBranches` reads `AggResReg` from each branch's final state and combines them at the cross-branch level via `combineParBranchResults`.

This works because the combiners are associative:
- **sum-of-sums** = total sum
- **count-of-counts** = total count (each branch counts 1)
- **bag-of-bags** = concat of bags
- **set-of-sets** = union (`List.distinct` over concat)
- **findall-of-findalls** = concat (preserves order + duplicates)

Avoids the documented Haskell forkParBranches data-flow questions and is easier to reason about.

## Tests

### Codegen (`tests/test_wam_fsharp_target.pl`) — 6 new assertions (64 / 64 total)

- `test_fsharp_merge_strategy_du` — DU + AggFrame field
- `test_fsharp_infer_merge_strategy` — all match arms
- `test_fsharp_begin_aggregate_records_strategy` — strategy stored at BeginAggregate
- `test_fsharp_forkable_strategy_helpers` — isForkable + currentAgg* helpers
- `test_fsharp_fork_par_branches_helpers` — fork machinery + per-strategy combiners
- `test_fsharp_fork_or_sequential_dispatcher` — dispatcher routing

### Runtime (`tests/fixtures/wam_fsharp_smoke/Smoke.fs`) — 5 new scenarios, 23 new assertions (72 / 72 total)

- `scenario_merge_strategy_helpers` — `inferMergeStrategy` for sum/count/bag/set/findall/collect/unknown + `isForkableStrategy` classification (12 assertions)
- `scenario_combine_par_branch_results` — per-strategy semantics on representative inputs (5 assertions)
- `scenario_find_outer_end_aggregate` — forward scan + overrun safety (2)
- `scenario_remove_nearest_agg_frame` — drops exactly one frame, leaves others (2)
- `scenario_par_step_inside_sequential_aggregate` — `MergeSequential` aggregate falls back to sequential `TryMeElsePc` (1)

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl` — **64 / 64 pass** (+6 over PR #2344's 58).
- `swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_dotnet_smoke.pl` — **5 / 5 pass**. Runtime smoke now reports **`RESULT 72/72`** (was 49 — +23 new Phase J-β assertions). Build clean, **0 FS0025 warnings**.
- Phase-I lowered build smoke (PR #2343) + Phase-I lowered runtime smoke (PR #2344) still pass unchanged.
- `tests/core/test_fsharp_native_lowering.pl` — unchanged.

## Scope deliberately NOT in this PR

- **`runBranchForFork`'s specialized branch executor** (Haskell uses one for `wsAggAccum` extraction): the F# implementation reuses `run` + per-branch `EndAggregate` finalize, then combines via `combineParBranchResults`. See "F# vs Haskell adaptation" above.
- **Race-to-cancel** for `runNegationParallel`: would shave wasted work on first successful branch. Needs `CancellationToken` plumbing through `step` — out of scope.

## Status after this PR

The F# WAM target is now at **full Haskell parity** on parallel-WAM features:

| Phase | Feature | Status |
|---|---|---|
| Phase J-α | `runNegationParallel` for `\+/1` | ✓ PR #2340 |
| Phase J-α | `runNegationParallel` off-by-one fix | ✓ PR #2342 (Haskell upstream still TODO) |
| Phase J-β | `forkParBranches` for aggregates | ✓ **This PR** |

Remaining known follow-ups across the F# WAM track:

- Mirror the `runNegationParallel` off-by-one fix upstream in Haskell.
- Race-to-cancel for `runNegationParallel`.
- (potentially) `wam_to_fsharp/2` legacy dead-code cleanup.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_