### PR TITLE
docs(design): WAM LMDB lazy-access design triad (L0/L1/L2 + scan + segregation)

### DIFF
--- a/docs/design/WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,265 @@
+# LMDB Lazy Access: Implementation Plan
+
+**Status**: Phased rollout. Companion to
+[`WAM_LMDB_LAZY_PHILOSOPHY.md`](WAM_LMDB_LAZY_PHILOSOPHY.md) (the
+"why") and [`WAM_LMDB_LAZY_SPECIFICATION.md`](WAM_LMDB_LAZY_SPECIFICATION.md)
+(the "what").
+
+**Snapshot date**: 2026-05-20.
+
+This document sequences the work to bring L1, L2, scan-mode, and the
+workload-segregation contract to each target. Haskell already has L2
+(Phase L#7-9); the heaviest lift is Rust.
+
+## 1. Current state across targets
+
+| Target | L0 | L1 | L2 | Scan | Segregation |
+| --- | :-: | :-: | :-: | :-: | :-: |
+| Haskell | ✅ (`resident` IntMap) | ⚠️ degenerate (L2 with cache size 0) | ✅ (`resident_cursor` + sharded cache) | ❌ | ❌ |
+| Rust | ✅ (R5/R6 matrix bench) | ❌ | ❌ | ❌ | ❌ |
+| C# | ✅ + planner picks at query time | partial via planner | partial via planner | partial via planner | partial via planner |
+| Go | ✅ (channel-pipeline) | ❌ | ❌ | ❌ | ❌ |
+| Elixir | ✅ + `generator_mode(true)` | ❌ | ❌ | ❌ | ❌ |
+| Python | ✅ + `yield from` pipeline | ❌ | ❌ | ❌ | ❌ |
+| Others | ✅ | ❌ | ❌ | ❌ | ❌ |
+
+So the gap matrix is wide. Prioritising Rust (because the R6 enwiki
+result is the public-facing motivator).
+
+## 2. Phase R7 — Rust L1 prototype
+
+**Scope**: Add `lmdb_lazy_tier(l0|l1|l2)` codegen option to the
+matrix-bench generator. Implement L1 path that skips the
+`runtime_category_parents` materialisation block and registers
+`category_parent/2` as a foreign predicate backed by an
+`LmdbCursorLookup` struct.
+
+**Files**:
+
+- `examples/benchmark/generate_wam_rust_matrix_benchmark.pl` — gate
+  the materialisation block on the tier option; emit a different
+  registration call when `l1`.
+- `templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache`
+  — add an `LmdbCursorLookup` struct implementing the
+  `LookupSource` trait (§3 of spec doc).
+- `templates/targets/rust_wam/lmdb_fact_source_heed.rs.mustache` —
+  same for heed.
+- `src/unifyweaver/runtime/rust/wam_rust/state.rs` (or equivalent) —
+  add `register_foreign_lookup` API that accepts `Box<dyn LookupSource>`.
+- `src/unifyweaver/runtime/rust/wam_rust/foreign.rs` (or equivalent) —
+  modify the FFI path for predicates that have a registered
+  foreign lookup, routing edge lookups through the trait instead of
+  through `ffi_facts`.
+- `tests/test_wam_rust_target.pl` — add codegen tests asserting
+  that the lazy variant elides the materialisation block.
+
+**Measurement**:
+
+- Smoke test at 1k_cats: confirm tuple_count + effective_distance
+  match L0.
+- Bench at simplewiki (5,000 demand-set seeds): record cold T1 +
+  warm median for L1 vs L0.
+- Bench at enwiki (1,000 demand-set seeds): same.
+- Update the Reddit report at `examples/more/.../reports/effective_distance_haskell_vs_rust.md`
+  with the new numbers.
+
+**Expected outcome**: L1 at enwiki should drop from ~148 s (L0) to
+~1-10 s (lazy LMDB cursor reads + 1000 seeds × ~10 hops). If L1
+beats L0 at enwiki, we've validated the lazy-streaming hypothesis.
+If not, profiling reveals what's actually dominating cost.
+
+**Estimated effort**: ~1 day. Branch: `feat/wam-rust-lmdb-lazy-l1`.
+
+## 3. Phase R8 — Rust L2 cache layer
+
+**Scope**: Add `CachedLookup<S>` decorator that wraps any
+`LookupSource` with a sharded LRU cache. Add cost-model resolver
+`resolve_lmdb_lookup_tier/2` that picks L0/L1/L2 from workload
+metadata.
+
+**Files**:
+
+- `templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache`
+  — add `CachedLookup` struct.
+- `src/unifyweaver/core/cost_model.pl` — add `resolve_lmdb_lookup_tier/2`
+  per spec §7.2.
+- `examples/benchmark/generate_wam_rust_matrix_benchmark.pl` — wire
+  the resolver into the codegen so `lmdb_lazy_tier(auto)` works.
+- `tests/test_wam_rust_target.pl` — codegen tests for the auto
+  resolver.
+- `tests/core/test_cost_model.pl` — resolver tests covering the
+  decision tree (small fact_count + high seed count → l0; large +
+  any seed count → l2; segregated → l1).
+
+**Measurement**:
+
+- Re-run the bench matrix at all three scales with `lmdb_lazy_tier(auto)`.
+- Verify the resolver picks L0 at 1k, l2 at simplewiki and enwiki.
+- Confirm L2 enwiki numbers match Haskell's `resident_cursor` shape
+  (within an order of magnitude — the cross-language gap should
+  collapse).
+
+**Estimated effort**: ~1-2 days. Branch: `feat/wam-rust-lmdb-lazy-l2`.
+
+## 4. Phase R9 — workload-segregation contract
+
+**Scope**: Add the `workload_segregated(bool)` option to the
+`recursive_kernel` declaration. Update the cost-model resolver to
+prefer L1 when set. Thread the flag through the codegen.
+
+**Files**:
+
+- `src/unifyweaver/core/recursive_kernel_detection.pl` — accept
+  the new option.
+- `src/unifyweaver/core/cost_model.pl` — already covers this in
+  R8's resolver work; verify.
+- `examples/benchmark/effective_distance.pl` — example use of the
+  declaration (does NOT set it by default since simplewiki/enwiki
+  benchmarks aren't necessarily segregated).
+- `tests/test_recursive_kernel_detection.pl` — declaration tests.
+
+**Measurement**:
+
+- Construct a synthetic segregated workload (e.g., 1000 seeds
+  partitioned 100 each into 10 disjoint root-subtrees, run as 10
+  separate process invocations).
+- Verify L1 wins over L2 on the segregated workload.
+- Verify L2 wins over L1 on the original non-segregated workload.
+
+**Estimated effort**: ~1 day. Branch: `feat/wam-segregation-contract`.
+
+## 5. Phase R10 — scan-mode (Rust)
+
+**Scope**: Implement `ScanSource` trait + `scan_range` method on
+`LmdbCursorLookup`. Add cost-model resolver
+`resolve_lmdb_access_mode/2`. Update the ingest pipeline to write
+`layout_strategy` to the LMDB meta sub-db.
+
+**Files**:
+
+- `templates/targets/rust_wam/lmdb_fact_source_*.mustache` — add
+  `ScanSource` trait + impl.
+- `src/unifyweaver/runtime/python/lmdb_ingest/ingest_to_lmdb.py` —
+  optionally pre-process IDs via topological sort if requested;
+  write `layout_strategy` to meta.
+- `examples/streaming/*_category_ingest*.pl` — pass through the
+  optional `layout_strategy` knob.
+- `src/unifyweaver/core/cost_model.pl` — `resolve_lmdb_access_mode/2`.
+- Codegen wires the scan path into the kernel when chosen.
+
+**Measurement**:
+
+- Re-ingest 1k_cats with topological sort; compare seek vs scan at
+  the same scale.
+- If scan wins meaningfully on small fixtures, validate at
+  simplewiki.
+
+**Estimated effort**: ~2 days. Branch: `feat/wam-rust-lmdb-scan-mode`.
+
+## 6. Phase H1 — Haskell L1 (validation only)
+
+**Scope**: Haskell already implements L2 via `resident_cursor` +
+sharded cache. Validate that `lmdb_cache_capacity(0)` produces a
+correct L1 (no cache) behaviour and update the cost-model resolver
+to recognise it.
+
+**Files**:
+
+- `src/unifyweaver/core/cost_model.pl` — extend `resolve_lmdb_lookup_tier/2`
+  to handle the Haskell case: `l1` corresponds to
+  `lmdb_cache_capacity(0)` plus `lmdb_cache_mode(none)`.
+- `tests/test_wam_haskell_target.pl` — codegen tests.
+
+**Measurement**:
+
+- Sanity-check existing Haskell L2 results.
+- Add a measurement at enwiki with cache-capacity 0 (L1) to compare
+  against L2; expect L2 to win unless we contrive a segregated
+  workload.
+
+**Estimated effort**: ~0.5 day. Branch: `feat/wam-haskell-l1-recognition`.
+
+## 7. Phase X — cross-target consolidation
+
+**Scope**: Once Rust + Haskell both have L0/L1/L2 + scan-mode +
+segregation, write a cross-target benchmark report and update the
+Reddit report with all six (3 tiers × 2 access modes) data points
+at simplewiki and enwiki.
+
+**Files**:
+
+- `examples/more/graph/effect_dist/haskell/gen/reports/effective_distance_haskell_vs_rust.md`
+  — update with the post-R10 numbers; refer to this spec as the
+  canonical taxonomy.
+- A new `docs/design/WAM_LMDB_LAZY_BENCHMARK_REPORT.md` (or an
+  appendix in the perf log) capturing the cross-target table.
+
+**Estimated effort**: ~0.5 day. No branch — runs after R10 lands.
+
+## 8. Dependencies
+
+```
+R7 (Rust L1) ──┐
+               ├──► R8 (Rust L2 + resolver) ──┐
+               │                              ├──► X (consolidation)
+H1 (Haskell L1) ─────────────────────────────┤
+                                              │
+R10 (Rust scan) ──────────────────────────────┤
+                                              │
+R9 (segregation) ─────────────────────────────┘
+```
+
+- R7 is the only hard prerequisite for anything; it establishes the
+  `LookupSource` trait that R8, R9, R10 all build on.
+- H1 is independent (no Rust dependency).
+- R10 (scan) is independent of R9 (segregation) but the cost model
+  in R8 anticipates both.
+
+## 9. Out-of-scope (for this plan revision)
+
+- **Other targets (Go, C#, Elixir, Python) L1/L2 implementation**:
+  C# already has substantial planner-level coverage; others are
+  speculative. File separate implementation plans when motivated
+  by a workload.
+- **MST-sort ingest pre-processor**: see philosophy doc §4.2.
+- **Multi-process shared cache**: see spec §11.
+- **Adaptive tier switching mid-run**: see spec §11.
+
+## 10. Open questions before R7 starts
+
+1. **Does the WAM-Rust runtime's `ffi_facts` indirection allow a
+   trait-object swap-in?** Need to read `state.rs` carefully — the
+   `register_foreign_lookup` API might need a refactor of how
+   foreign predicates dispatch.
+2. **Cursor lifetime in Rust**: should L1 hold one shared cursor
+   protected by a mutex (cheap but contended), per-thread cursors
+   (more memory, lock-free), or open-per-call cursors (slow but
+   simplest)? Likely per-thread for the parallel future, single
+   for the L1 prototype.
+3. **What's the right `cache_capacity` default for L2**: matches
+   Haskell's existing default? Or sized by demand-set heuristic?
+4. **Should scan-mode require a separate codegen option, or be
+   chosen by the cost-model resolver automatically once
+   `layout_strategy` is known**? Initial answer: automatic — keeps
+   the user-facing surface small.
+
+## 11. Concrete next step
+
+**This PR (`docs/wam-lmdb-lazy-design`)**: lands the three design
+docs. No code changes.
+
+**Next PR (`feat/wam-rust-lmdb-lazy-l1`)**: implements Phase R7. The
+follow-on PRs for R8/R9/R10 land independently as each phase
+completes.
+
+## 12. References
+
+- `docs/design/WAM_LMDB_LAZY_PHILOSOPHY.md`
+- `docs/design/WAM_LMDB_LAZY_SPECIFICATION.md`
+- `docs/design/CACHE_COST_MODEL_PHILOSOPHY.md`
+- `docs/design/QUERY_PLAN_RUNTIME_PHILOSOPHY.md`
+- `docs/design/WAM_LMDB_RESIDENT_INTERNING_*.md` (existing LMDB layout)
+- `examples/benchmark/generate_wam_rust_matrix_benchmark.pl` — current Rust eager bench
+- `templates/targets/rust_wam/lmdb_fact_source_*.mustache` — current Rust LMDB source
+- `templates/targets/haskell_wam/lmdb_fact_source.hs.mustache` — current Haskell L2
+- `examples/more/graph/effect_dist/haskell/gen/reports/effective_distance_haskell_vs_rust.md` — the public-facing motivator

--- a/docs/design/WAM_LMDB_LAZY_PHILOSOPHY.md
+++ b/docs/design/WAM_LMDB_LAZY_PHILOSOPHY.md
@@ -1,0 +1,309 @@
+# LMDB Lazy Access: Philosophy
+
+**Status**: Design discussion. Captures the architectural vocabulary for
+lazy LMDB access patterns in the WAM targets and how they relate to
+workload-segregation and physical-layout strategies.
+
+**Snapshot date**: 2026-05-20.
+
+**Companions**:
+- [`WAM_LMDB_LAZY_SPECIFICATION.md`](WAM_LMDB_LAZY_SPECIFICATION.md) —
+  cross-target interface specification.
+- [`WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md`](WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md) —
+  phased rollout for Rust (and reference catalogue for Haskell, which
+  already implements much of L2).
+
+This doc sits inside the broader framing of
+[`QUERY_PLAN_RUNTIME_PHILOSOPHY.md`](QUERY_PLAN_RUNTIME_PHILOSOPHY.md)
+(precursor for the runtime planner pattern) and
+[`SCAN_STRATEGY_PHILOSOPHY.md`](SCAN_STRATEGY_PHILOSOPHY.md) (which
+informs how plans get chosen).
+
+## 1. Context — where this came from
+
+The Rust R5/R6 LMDB benchmark arc (PRs #2284 + #2288) measured the
+WAM-Rust target against simplewiki (297 k edges) and enwiki (9.93 M
+edges). The bench eagerly materialises every demand-set
+`(child, parent)` edge into a `Vec<(String, String)>` at startup, then
+walks that Vec inside the seed loop.
+
+At simplewiki this wins (~31 ms warm vs Haskell's 226 ms `-N1`,
+because the materialisation cost `M ≈ 17 ms` is tiny relative to
+Haskell's demand-BFS setup). At enwiki it loses badly — ~148 s
+total, dominated by `M ≈ 140 s` worth of cursor lookups and string
+allocation before any kernel work runs. Haskell's `resident_cursor`
+mode finishes the same workload in 733 ms at `-N4`.
+
+The reversal is a design-choice difference: Rust eager-materialises;
+Haskell lazy-streams from LMDB cursors during the kernel walk. Both
+are native-compiled and both wrap the same C library. The choice of
+*when* to read dominates the choice of *what language* to read with.
+
+This document captures the design vocabulary for lazy LMDB access so
+the same trade-off can be discussed consistently across targets, and
+so future cost-model resolvers can pick between modes from workload
+metadata rather than hand-tuning.
+
+## 2. The lazy/eager spectrum (and the three tiers)
+
+Three modes show up in measurements so far. Naming them up front:
+
+- **L0 — eager materialisation.** Build an in-memory index of every
+  demand-set edge before any kernel iteration runs. The kernel walks
+  the index without touching LMDB after startup.
+- **L1 — pure lazy.** No materialisation. Each kernel walk step does
+  an LMDB cursor lookup on demand. No cache layer above the LMDB.
+- **L2 — lazy with cache.** Each kernel walk step queries a cache
+  first; on miss, does an LMDB cursor lookup and populates the cache.
+  Subsequent lookups for the same key hit the cache.
+
+The Haskell `resident_cursor` mode is **L2** — it's lazy by default
+but the runtime maintains per-HEC L1 + sharded L2 cache tiers above
+the LMDB cursor reads. The Haskell `resident` (IntMap) mode is
+**L0** — eager in-process materialisation, with the same memory wall
+the Rust bench has.
+
+The Rust bench today is **L0**. We have no L1 or L2 variant yet, and
+the cross-target story this doc motivates is to add both.
+
+### 2.1 Where each mode wins
+
+The naive cost model for one process invocation:
+
+```
+L0 wall ≈ M + N × ε         (M = materialisation cost, ε = per-seed kernel)
+L1 wall ≈ N × p             (p = lazy per-seed cost, larger than ε)
+L2 wall ≈ N × q + θ × p     (q = cache-hit cost, θ = cache-miss rate)
+```
+
+`L1 wall ≤ L2 wall` only when `θ × p ≤ N × (p − q)`, which simplifies
+to `θ ≤ N(p−q)/Np` — i.e., when **the cache miss rate is low enough
+that the cache machinery itself isn't worth its overhead**. In a
+single isolated query that's almost always the case (θ ≈ 100%, but
+N ≈ 1 — the cache never gets to amortise). Across many seeds with
+graph locality, θ drops quickly and L2 wins.
+
+The non-obvious result is that **L1 only beats L2 under specific
+workload conditions**: high cache-miss rate due to no locality between
+queries, OR a workload-segregation guarantee that means cache hits
+won't happen anyway. Most real workloads have *some* locality, so L2
+is the right default.
+
+### 2.2 The picture in one table
+
+| Mode | Wins for | Why |
+| --- | --- | --- |
+| **L0** | Batched workloads, demand-set fits in RAM | Pays `M` once, amortises across many seeds |
+| **L1** | Pure one-shot queries, OR segregated batches with provably-disjoint subgraphs | No `M` overhead, no cache machinery overhead |
+| **L2** | Default for everything else | Bounded per-seed cost, locality benefits, scales past the memory wall |
+
+The cost-model resolver should pick **L2 by default**, **L0 when
+demand set is small enough and seed count is high enough** (the
+crossover in [`QUERY_PLAN_RUNTIME_PHILOSOPHY.md`](QUERY_PLAN_RUNTIME_PHILOSOPHY.md)
+§2), and **L1 only when the caller explicitly signals workload
+segregation** (see §3).
+
+## 3. Workload segregation: the enabling condition for L1
+
+L1 has a real niche, but only when the bench harness can guarantee
+that **no two queries in the same process share an LMDB key**. Then
+the cache that L2 would maintain has zero hits, and L1's no-cache
+shape is pure win.
+
+The natural model for this is **node clusters** — group seeds whose
+upward walks touch disjoint subgraphs. The category graph of
+Wikipedia has multiple top-level roots; if a workload is "compute
+effective distances against root R₁ for batch A, then against root
+R₂ for batch B," and R₁ / R₂ have non-overlapping descendant subtrees,
+then within each batch L1 is correct, and across batches the cache
+would never have warmed for the new keys anyway.
+
+Two ways to surface this to the cost model:
+
+1. **User-declared segregation**: caller passes a `cluster_id` or
+   `workload_segregated(true)` flag. The simplest contract. Risk:
+   user lies, L1 burns cycles on uncached repeats.
+2. **Compiler-inferred segregation**: shape analysis proves that the
+   query stream cannot revisit nodes (e.g., the seed set is bounded
+   by the demand set, and `max_depth` limits the walk such that
+   per-seed visited nodes are disjoint with other seeds). Harder but
+   verifiable.
+
+For initial implementation, option 1 is fine — the cost-model
+default is L2, and L1 is opt-in via an explicit annotation.
+
+### 3.1 Where segregation comes from in practice
+
+- **Multi-root workloads**: each root's descendant subtree is one
+  cluster. Easy to detect (the existing post-ingest tools already
+  pick a root).
+- **Topic-partitioned graphs**: if the graph is annotated with
+  topic/community labels, queries restricted to one topic are
+  segregated by construction.
+- **Time-window queries**: in an append-only graph with edges
+  tagged by insertion time, a query restricted to a time window
+  touches a known subgraph.
+
+These are all *application-level* facts the compiler can't infer
+without help. The user-declared signal is the right initial interface.
+
+## 4. Scans vs seeks: a separate axis
+
+Independent of the lazy/eager choice is the question of **how each
+LMDB lookup actually reaches data**. LMDB stores entries as B-tree
+pages on disk:
+
+- **Seek**: point lookup. Walk the B-tree from root to leaf for one
+  key. O(log B) page touches, where B is the branching factor of
+  the B-tree (typically ~256 for LMDB pages of 4 KB with int32 keys).
+- **Scan**: range read. Position a cursor at a starting key, then
+  call `next_key` repeatedly. Each subsequent key in the same B-tree
+  leaf page is essentially free (no extra page walk). Each leaf-page
+  transition costs one page touch.
+
+If a query needs N edges and they're stored in K B-tree pages, then:
+
+- Seek: N × log(B) page touches (one full descent per edge)
+- Scan: K page touches (one descent + K-1 cheap next-key calls)
+
+When N is large and the relevant edges cluster into a few pages,
+scan crushes seek. When edges are scattered uniformly, seek and scan
+are similar.
+
+### 4.1 Scan-friendliness requires physical layout
+
+Scans only beat seeks when **related keys are physically adjacent in
+the B-tree**. LMDB sorts keys lexicographically, so adjacency
+depends on the byte-encoding choice:
+
+- **Random integer IDs (current `cl_target_id`)**: keys are
+  scattered. A demand set of 14 k nodes occupies pages all over the
+  B-tree. Scan offers no advantage.
+- **Topologically-sorted IDs**: assign each node an ID equal to its
+  BFS order from some seed root. Adjacent IDs are likely adjacent in
+  the graph. Scan over an interval reads many edges from few pages.
+- **Semantically-clustered IDs**: assign IDs by topic/community.
+  Queries restricted to one topic scan a contiguous prefix.
+
+### 4.2 Pre-processing strategies
+
+Three physical-layout strategies, ordered by cost:
+
+| Strategy | Pre-processing cost | Scan locality | Notes |
+| --- | --- | --- | --- |
+| **Insertion order (current default)** | 0 | Poor | What LMDB gives you from the existing ingest. |
+| **Topological sort** | O(V + E), one pass | Good for DAG workloads | Trivial for DAGs; falls back to SCC + topological sort of the SCC DAG for cyclic graphs. |
+| **Semantic clustering** | O(V·k) where k = embedding cost | Good if clusters match query patterns | Cluster by embedding distance or pre-computed topic labels. Works best with annotated graphs. |
+| **MST sort** | O(E log V) | Provably good | Compute a minimum spanning tree, then DFS-order the nodes. Optimal in the sense that adjacent IDs minimise tree-edge weight; expensive enough that it only pays off for static benchmarks. |
+
+The scan-friendliness story is **orthogonal** to the lazy/eager
+choice. L1 + scan combines workload segregation with physical
+locality — the strongest configuration for one-shot, no-cache
+workloads. L2 + scan still benefits from physical locality on
+cache misses. L0 doesn't care because it pays for materialisation
+once anyway.
+
+## 5. How the modes compose
+
+The full space of mode choices:
+
+```
+                       physical-layout
+                       quality
+                            │
+                  poor      │      good
+                 ─────────────────────────
+  L0 (eager) │   indifferent (M pays once)
+  L1 (lazy)  │   bad         │  great (workload-seg + scan)
+  L2 (cache) │   ok          │  great (cache hits + scan misses)
+```
+
+The decision tree for the cost-model resolver becomes:
+
+1. *Is demand_set_size × edge_size > available_memory_budget?* → must use lazy (L1 or L2).
+2. *Does the user declare workload_segregated?* → L1.
+3. *Otherwise?* → L2.
+4. *Is physical layout known to be scan-friendly?* → enable scan-mode within the chosen tier.
+
+The existing cost-model resolvers (`cache_strategy(auto)`,
+`lmdb_cache_mode(auto)`, `resident_auto`) already cover parts of this.
+The L1/L2 distinction is what's new here; scan-mode is a related
+axis that would be added per-target.
+
+## 6. Cross-language patterns this maps to
+
+L1 and L2 are general patterns. The iterator-based lookup interface
+maps cleanly across targets:
+
+| Target | Idiomatic lazy lookup return type | Cache layer notes |
+| --- | --- | --- |
+| Haskell | `[Int]` (lazy list) or `ConduitT () Int IO ()` | Already implemented (L2); per-HEC L1 + sharded L2 in `lmdb_cache_mode` |
+| Rust | `impl Iterator<Item=i32> + 'a` | Closure-based foreign predicate; cache via `dashmap` or sharded `HashMap` |
+| Go | `<-chan int` (channel) | Pipeline-chaining already has channel mode; same pattern |
+| C# | `IEnumerable<int>` (LINQ) | Existing C# planner already does this for relations |
+| Python | generator (`def parents(child): yield ...`) | Existing federated_query already uses `yield` for partial results |
+| Elixir | `Stream` lazy enumeration | `generator_mode(true)` option already exists |
+
+So the *interface* is the same shape everywhere; the implementation
+just chooses each language's native iterator equivalent. The cache
+tier layers on top via a Decorator pattern: an L2 cache wraps an L1
+source via the same interface.
+
+## 7. What this rules out
+
+- **Picking lazy vs eager at the language level.** The mode is
+  workload-dependent, not language-dependent. Any target can
+  implement any tier.
+- **A single "best" mode that wins everywhere.** Each tier has a
+  niche; the cost model has to choose.
+- **Hand-tuning per benchmark.** The auto-resolvers exist precisely
+  so that "which tier?" is determined by workload metadata, not
+  by which mode the experimenter happened to remember to set.
+- **Treating scan-mode as a tier of laziness.** It's a separate
+  axis. Any tier can use seeks or scans; the choice is determined
+  by physical layout quality.
+
+## 8. Open questions
+
+1. **What is the workload-segregation contract?** Just a boolean
+   `workload_segregated(true)` flag, or a richer cluster annotation?
+   The richer version lets the resolver size the cache to one
+   cluster at a time.
+2. **Should scan-mode be a target-level option or a per-predicate
+   option?** Target-level is simpler; per-predicate matches the
+   layout-quality question more accurately.
+3. **How does this compose with the runtime planner pattern
+   ([`QUERY_PLAN_RUNTIME_PHILOSOPHY.md`](QUERY_PLAN_RUNTIME_PHILOSOPHY.md))?**
+   The planner is the right place to decide L0/L1/L2 + seek/scan
+   per query rather than per process. Question: is the decision
+   cheap enough to do per query, or does it need to be amortised?
+4. **MST sort + LMDB rewrite for very large graphs**: is the
+   pre-processing cost ever worth it for a one-off benchmark? Or
+   only for production query workloads that hit the same DB
+   thousands of times?
+5. **Cache invalidation under graph mutation**: the current Haskell
+   L2 cache assumes a static LMDB. Mutating workloads need a
+   versioning story.
+6. **Cross-target benchmark methodology**: when we measure L1/L2/
+   scan-mode against L0, we need a workload spec that exercises
+   each mode's niche. The existing matrix-bench is L0-shaped;
+   it'd over-amortise.
+
+## 9. References
+
+- `docs/design/QUERY_PLAN_RUNTIME_PHILOSOPHY.md` — broader runtime
+  planner pattern that this fits inside.
+- `docs/design/SCAN_STRATEGY_PHILOSOPHY.md` + `_SPECIFICATION.md` +
+  `_IMPLEMENTATION_PLAN.md` — scan-strategy triad (warm-build core,
+  cost-function-driven plan selection).
+- `docs/design/CACHE_COST_MODEL_PHILOSOPHY.md` — cost-model framework
+  this work feeds into.
+- `docs/design/WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md` — LMDB
+  layout this lazy work reads from.
+- `docs/design/COST_FUNCTION_PHILOSOPHY.md` — Green's-function and
+  flux cost-functions; the lazy-vs-eager decision is one of the
+  inputs.
+- `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` Phase L#7–9 — Haskell L2
+  measurements at simplewiki and enwiki.
+- `examples/more/graph/effect_dist/haskell/gen/reports/effective_distance_haskell_vs_rust.md` —
+  Haskell-vs-Rust report that motivated this design.

--- a/docs/design/WAM_LMDB_LAZY_SPECIFICATION.md
+++ b/docs/design/WAM_LMDB_LAZY_SPECIFICATION.md
@@ -1,0 +1,384 @@
+# LMDB Lazy Access: Specification
+
+**Status**: Design specification. Companion to
+[`WAM_LMDB_LAZY_PHILOSOPHY.md`](WAM_LMDB_LAZY_PHILOSOPHY.md) (the
+"why") and [`WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md`](WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md)
+(the "when").
+
+**Snapshot date**: 2026-05-20.
+
+This document specifies the cross-target interface for the three
+LMDB-access tiers L0 / L1 / L2 (see philosophy doc §2 for the
+vocabulary), plus the scan-vs-seek axis and the workload-segregation
+contract. The intent is that each target's implementation can be
+audited against the same surface area.
+
+## 1. Tier model
+
+Three modes per target:
+
+| Tier | Materialisation | Cache layer | Per-call cost |
+| --- | --- | --- | ---: |
+| L0 (eager) | Yes — full demand-set Vec/HashMap built at startup | n/a (the materialisation *is* the cache) | O(1) HashMap lookup |
+| L1 (lazy) | No | None | O(log B) LMDB cursor seek |
+| L2 (lazy + cache) | No | Yes — bounded-size LRU or sharded HashMap | O(1) on hit, O(log B) on miss |
+
+A target MUST implement L0 (which most already do). A target SHOULD
+implement L2 for any LMDB-backed fact source whose `fact_count`
+exceeds the existing `use_lmdb(auto)` threshold. A target MAY
+implement L1 for workloads with explicit segregation declarations.
+
+## 2. The canonical lookup interface
+
+All three tiers expose the **same shape** to callers. The contract:
+
+```
+lookup_parents(key) -> Iterator<Edge>
+```
+
+where `Iterator<Edge>` is each language's native lazy-sequence type:
+
+| Target | Concrete type |
+| --- | --- |
+| Haskell | `Int -> [Int]` (lazy list) or `Int -> Conduit Int IO ()` |
+| Rust | `fn lookup_parents(&self, key: i32) -> impl Iterator<Item = i32> + '_` |
+| Go | `func (s *Source) LookupParents(key int32) <-chan int32` |
+| C# | `IEnumerable<int> LookupParents(int key)` |
+| Python | `def lookup_parents(self, key: int): yield ...` |
+| Elixir | `def lookup_parents(source, key), do: Stream.unfold(...)` |
+
+The iterator MUST yield ints (or whatever the canonical ID type is
+for the predicate). String conversion happens at the caller's
+discretion via i2s — this is consistent with the existing LMDB-resident
+interning convention.
+
+The iterator MUST be lazy in the sense that constructing it does no
+LMDB work; only the first `.next()` call triggers the cursor. This
+makes the iterator usable as a return value from a foreign predicate
+without forcing materialisation.
+
+## 3. Source trait / interface
+
+Each target defines a source trait that all three tiers implement:
+
+### Rust
+
+```rust
+pub trait LookupSource {
+    type EdgeIter<'a>: Iterator<Item = i32> + 'a where Self: 'a;
+    fn lookup_parents<'a>(&'a self, child_id: i32) -> Self::EdgeIter<'a>;
+}
+```
+
+Implementations:
+
+```rust
+pub struct EagerVecLookup { ... }
+pub struct LmdbCursorLookup<'env> { ... }  // L1
+pub struct CachedLookup<S: LookupSource> { inner: S, cache: ... }  // L2 decorator
+```
+
+### Haskell
+
+```haskell
+class LookupSource s where
+    lookupParents :: s -> Int -> [Int]
+```
+
+Haskell already has this conceptually inside `EdgeLookup` in
+`lmdb_fact_source.hs.mustache`; the spec confirms the shape.
+
+### Other targets
+
+Same pattern: a trait/interface whose method returns the target's
+native lazy iterator type. Each tier implements the trait.
+
+## 4. Cache-tier spec (L2)
+
+The L2 cache wraps any L1 implementation via the Decorator pattern.
+Spec:
+
+- **Bounded size**: configurable via existing `cache_capacity(...)`
+  option (already in `cache_strategy(auto)`).
+- **Sharded for parallelism**: `cache_shards(...)` already exists in
+  Haskell; the spec confirms it's the canonical knob. Default
+  shards = number of capabilities / threads.
+- **Eviction policy**: LRU on a per-shard basis. The cache contract
+  is "correctness preserved on eviction" — any miss falls through to
+  the inner L1 source.
+- **Composition with L1**: L2 is a Decorator over L1, not a replacement.
+  Same `LookupSource` trait. This means L1 and L2 are interchangeable
+  in calling code — the kernel doesn't know which it has.
+- **Concurrent access**: per-shard locking (Haskell uses `IORef`-protected
+  Maps; Rust uses `dashmap` or sharded `RwLock<HashMap>`).
+
+## 5. Scan vs seek
+
+A second axis, orthogonal to the L0/L1/L2 tier. Some sources can
+expose a *range* read in addition to point lookups.
+
+### 5.1 Scan trait
+
+```rust
+pub trait ScanSource: LookupSource {
+    type RangeIter<'a>: Iterator<Item = (i32, i32)> + 'a where Self: 'a;
+    fn scan_range<'a>(&'a self, start_inclusive: i32, end_exclusive: i32)
+        -> Self::RangeIter<'a>;
+}
+```
+
+The iterator yields `(child, parent)` pairs from the half-open
+range `[start, end)` of child IDs. Only `LmdbCursorLookup`
+implements `ScanSource`; the eager Vec implementation can fall
+through to a filter on its existing data.
+
+### 5.2 When the kernel uses scans
+
+The kernel uses scans when:
+
+- The keys to look up are *contiguous in ID space* (a precondition
+  the cost model checks), AND
+- The number of keys is large enough that the per-call seek cost
+  dominates (call it `scan_threshold_keys`, default ~16).
+
+Otherwise the kernel uses repeated point seeks via `lookup_parents`.
+
+### 5.3 Physical-layout signals
+
+The cost model needs a `physical_layout_quality` signal to decide
+whether scan-mode is worth using. Initial implementation: a manifest
+field on the LMDB written by the ingest pipeline.
+
+```
+meta:
+  layout_strategy:    insertion_order | topological | semantic | mst
+  scan_threshold:     <integer>
+```
+
+Default: `insertion_order` (current state); cost model defaults to
+seeks-only.
+
+## 6. Workload-segregation contract
+
+The signal that allows L1 to be picked over L2.
+
+### 6.1 Caller-side declaration
+
+A new option on the bench harness or the recursive_kernel
+declaration:
+
+```prolog
+:- recursive_kernel(category_ancestor, category_ancestor/4, [
+    max_depth(10),
+    edge_pred(category_parent/2),
+    workload_segregated(true),         % NEW
+    segregation_cluster_id(physics)    % NEW (optional)
+]).
+```
+
+When `workload_segregated(true)`, the cost-model resolver MAY pick
+L1 over L2. When unset (default), the resolver picks L2.
+
+The `segregation_cluster_id` is purely informational at this stage
+— it provides a name for telemetry / cache-eviction-boundary
+purposes. The cost model does not enforce that different cluster
+IDs use different cache scopes; that's a future refinement.
+
+### 6.2 What "segregated" means semantically
+
+A workload is *segregated* iff:
+
+- The query stream issued in a single process invocation does not
+  revisit any LMDB key.
+- OR: the cache hit rate would be effectively zero anyway (e.g., the
+  workload is one query against a cold cache).
+
+If the caller declares `workload_segregated(true)` and the
+guarantee is violated, the result is **slower** L1 execution due
+to repeated LMDB cursor walks — but **not incorrect**. L1 produces
+the same answers as L2 on identical input; the segregation flag is
+strictly a performance hint.
+
+### 6.3 Compiler-inferred segregation (deferred)
+
+Shape analysis could in principle prove segregation:
+
+- If `max_depth × branching_factor < total_seed_count` AND
+- Visited sets between seeds are guaranteed disjoint (rare in
+  general; common when seeds are partitioned by root)
+
+But this requires the cost model to know about visited-set
+intersection, which it doesn't today. Deferred to a future
+revision.
+
+## 7. Cost-model integration
+
+The existing resolver predicates extend to cover the new axes:
+
+### 7.1 New input fields
+
+Added to the workload-metadata vocabulary used by `resolve_*` predicates:
+
+| Field | Type | Default | Source |
+| --- | --- | --- | --- |
+| `workload_segregated` | bool | false | caller-declared |
+| `segregation_cluster_id` | atom | _none_ | caller-declared |
+| `physical_layout_quality` | enum | `insertion_order` | LMDB meta sub-db |
+| `scan_threshold_keys` | int | 16 | LMDB meta sub-db |
+| `cache_miss_rate_estimate` | float | 0.5 | empirical / heuristic |
+| `expected_query_count_per_process` | int | 1 | caller-declared |
+
+### 7.2 Resolver: `resolve_lmdb_lookup_tier/2`
+
+New predicate, sits next to the existing `resolve_auto_lmdb_cache_mode/2`:
+
+```prolog
+resolve_lmdb_lookup_tier(Options, Tier) :-
+    % Tier = l0 | l1 | l2
+    option(fact_count(F), Options),
+    option(demand_set_estimate(D), Options),
+    option(memory_budget(B), Options),
+    option(workload_segregated(WS), Options, false),
+    option(expected_query_count_per_process(NQ), Options, 1),
+    edge_size_bytes(F, EdgeBytes),
+    (   D * EdgeBytes > B
+    ->  % Demand set doesn't fit; must use lazy
+        ( WS == true -> Tier = l1 ; Tier = l2 )
+    ;   % Demand set fits; eager wins if NQ * ε amortises M
+        crossover_eager_lazy(F, D, NQ, ChooseEager),
+        (   ChooseEager == true
+        ->  Tier = l0
+        ;   ( WS == true -> Tier = l1 ; Tier = l2 )
+        )
+    ).
+```
+
+### 7.3 Resolver: `resolve_lmdb_access_mode/2`
+
+For the scan-vs-seek axis:
+
+```prolog
+resolve_lmdb_access_mode(Options, Mode) :-
+    % Mode = seek | scan
+    option(physical_layout_quality(Q), Options, insertion_order),
+    option(expected_keys_per_call(K), Options, 1),
+    option(scan_threshold_keys(T), Options, 16),
+    (   Q \= insertion_order, K >= T
+    ->  Mode = scan
+    ;   Mode = seek
+    ).
+```
+
+The two resolvers compose: `(l0|l1|l2) × (seek|scan)` = 6 combinations,
+but only 4 are meaningful (L0 doesn't use either; L1+scan, L2+seek,
+L2+scan, and L1+seek are the four lazy options).
+
+## 8. Generated-code shape
+
+### 8.1 Rust (per-tier)
+
+For L0 — current behaviour:
+
+```rust
+let runtime_category_parents: Vec<(String, String)> = (...materialisation...);
+vm.register_indexed_atom_fact2("category_parent/2", build_indexed_fact2(&runtime_category_parents));
+```
+
+For L1:
+
+```rust
+let lookup = LmdbCursorLookup::new(&lmdb, &reachable_ids, &i2s);
+vm.register_foreign_lookup("category_parent/2", Box::new(lookup));
+```
+
+For L2:
+
+```rust
+let inner = LmdbCursorLookup::new(&lmdb, &reachable_ids, &i2s);
+let lookup = CachedLookup::new(inner, /* cache_capacity */ 1024, /* shards */ 4);
+vm.register_foreign_lookup("category_parent/2", Box::new(lookup));
+```
+
+`register_foreign_lookup` is the new runtime API the WAM-Rust runtime
+needs. Today the kernel calls into `ffi_facts: HashMap<String,
+HashMap<u32, Vec<u32>>>` for foreign-predicate edge lookups; the L1/L2
+path replaces that with a trait object call.
+
+### 8.2 Haskell (per-tier)
+
+L0 — `resident` (IntMap) mode. Already implemented.
+
+L1 — a hypothetical `lazyCursor` mode (not yet implemented). Would
+remove the per-HEC L1 and sharded L2 caches from the
+`lmdbFactSource.hs.mustache` template.
+
+L2 — `resident_cursor` mode with `lmdb_cache_mode(per_hec |
+sharded | two_level)`. Already implemented.
+
+So in Haskell, L2 is the existing implementation; L1 would be an L2
+instance with cache size = 0, which is a configuration value
+already exposed. **No new Haskell code is required to support L1**;
+the spec just blesses it as a valid configuration.
+
+### 8.3 Scan-mode hooks
+
+Per-target, the scan iterator opens a cursor at `start` and iterates
+until it sees a key ≥ `end`. The contract is the same across all
+targets; the implementation uses each target's native LMDB binding's
+range API.
+
+## 9. Testing contract
+
+For each target and each tier:
+
+1. **Correctness**: a small fixture (`1k_cats`, 5933 edges) yields
+   identical `tuple_count` and per-tuple `effective_distance` under
+   L0, L1, and L2 modes.
+2. **Cache behaviour**: at L2, count cache hits / misses via
+   instrumentation; assert hits > 0 on the test workload.
+3. **Segregation contract**: at L1 with `workload_segregated(true)`,
+   confirm no cross-seed key revisits via instrumentation.
+4. **Scan vs seek**: a smoke test on a topologically-sorted fixture
+   confirms scan yields the same results as repeated seeks.
+
+## 10. Versioning and migration
+
+Adding L1 / L2 / scan-mode is *additive*:
+
+- Existing benchmarks default to L0 (unchanged behaviour).
+- The cost-model resolver opts into L2 only when `lmdb_lazy_tier(auto)`
+  is set; existing call sites without that option remain at L0.
+- The LMDB on-disk format is unchanged. The new `layout_strategy` and
+  `scan_threshold` fields in the meta sub-db are optional reads with
+  documented defaults.
+
+This means each target can adopt the L1/L2 work incrementally without
+breaking existing benchmarks.
+
+## 11. Out of scope (for this spec revision)
+
+- **Multi-process shared cache**: would let L2 share state across
+  process invocations. Out of scope; could be added with the LMDB
+  itself as a shared cache by definition (an L2-as-LMDB-table
+  pattern).
+- **Adaptive tier switching**: the cost model picks once per
+  process. Switching tiers mid-run is more invasive and not
+  motivated by any current measurement.
+- **Compiler-inferred segregation**: see §6.3. Deferred.
+- **MST-sort ingest pre-processor**: see philosophy doc §4.2.
+  Deferred to its own design doc when motivated by a workload.
+
+## 12. References
+
+- `WAM_LMDB_LAZY_PHILOSOPHY.md` — the "why" doc.
+- `WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md` — the "when" doc with
+  phased rollout.
+- `WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md` — LMDB layout this
+  spec reads from.
+- `QUERY_PLAN_RUNTIME_PHILOSOPHY.md` — the broader runtime-planner
+  pattern.
+- `CACHE_COST_MODEL_PHILOSOPHY.md` — cost-model framework.
+- `templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache`
+  — current Rust `LookupSource`-equivalent (eager only).
+- `templates/targets/haskell_wam/lmdb_fact_source.hs.mustache` —
+  current Haskell L2 implementation.


### PR DESCRIPTION
## Description

Lands three new design docs that capture the architectural vocabulary for lazy LMDB access patterns in the WAM targets and their relationship to workload-segregation, scan-vs-seek, and physical-layout strategies. Design-only; no code changes. Sets up the follow-up `feat/wam-rust-lmdb-lazy-l1` PR (Phase R7).

### Why these docs

The Rust R5/R6 LMDB benchmark arc (PRs #2284 / #2288) measured the WAM-Rust matrix bench against simplewiki (297 k edges) and enwiki (9.93 M edges). At simplewiki the Rust bench's eager-materialisation design wins (~31 ms warm vs Haskell's 226 ms `-N1`). At enwiki it loses badly — ~148 s total, dominated by ~140 s of materialising the 796 k-edge demand-set Vec before any kernel iteration runs. Haskell's `resident_cursor` lazy-streaming mode finishes the same workload in 733 ms at `-N4`.

The cross-target benchmark report ([`effective_distance_haskell_vs_rust.md`](https://github.com/s243a/UnifyWeaver_Examples/blob/main/graph/effect_dist/haskell/gen/reports/effective_distance_haskell_vs_rust.md)) and the precursor philosophy doc ([`QUERY_PLAN_RUNTIME_PHILOSOPHY.md`](https://github.com/s243a/UnifyWeaver/blob/main/docs/design/QUERY_PLAN_RUNTIME_PHILOSOPHY.md)) both call out a lazy-cursor Rust variant as the open follow-up. This triad pins down the design vocabulary before implementation begins.

### Three docs as a unit

| Doc | Role | Lines |
| --- | --- | ---: |
| `WAM_LMDB_LAZY_PHILOSOPHY.md` | The "why". Names L0 / L1 / L2 tiers; explains when each wins; introduces workload-segregation and scan-vs-seek as separate axes. | ~280 |
| `WAM_LMDB_LAZY_SPECIFICATION.md` | The "what". Canonical iterator interface, `LookupSource` + `ScanSource` traits, cost-model resolver shape, cross-target type mapping. | ~290 |
| `WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md` | The "when". Phased rollout: R7 (Rust L1), R8 (Rust L2 + resolver), R9 (segregation), R10 (scan), H1 (Haskell L1 validation), X (cross-target consolidation). | ~210 |

### Key architectural points

1. **Three tiers, not two.** L0 (eager materialisation), L1 (pure lazy), L2 (lazy with cache). The Haskell `resident_cursor` mode is L2 — lazy plus per-HEC + sharded cache tiers. The current Rust bench is L0.
2. **L1 only wins under workload segregation.** Without a guarantee that the query stream doesn't revisit LMDB keys, L2's cache amortises repeats and wins. L1 is opt-in via `workload_segregated(true)` on the kernel declaration.
3. **Scans vs seeks is orthogonal.** Any tier can use point seeks or range scans. Scans only beat seeks when related keys are physically adjacent in the LMDB B-tree, which requires a pre-processing step (topological sort, semantic clustering, or MST sort) at ingest time.
4. **Iterator pattern is cross-language.** The canonical lookup interface returns a lazy iterator in each target's native form — Haskell `[Int]`, Rust `impl Iterator<Item=i32>`, Go channel, C# `IEnumerable<int>`, Python generator. Existing UnifyWeaver code already uses each of these patterns elsewhere (enhanced pipeline chaining in particular).
5. **Cost-model integration as the unifier.** Two new resolvers: `resolve_lmdb_lookup_tier/2` picks L0/L1/L2 from workload metadata; `resolve_lmdb_access_mode/2` picks seek/scan from physical-layout signals. These compose with the existing `cache_strategy(auto)`, `lmdb_cache_mode(auto)`, and `resident_auto` resolvers.

### What this enables

After R7 (Rust L1 prototype) lands, we can measure whether the enwiki gap closes. Expected outcome from the cost-model math: Rust L1 at enwiki should run in ~1-10 s (1000 seeds × ~10 hops × ~µs per lookup), down from L0's ~148 s. After R8 (L2 cache) the gap should match Haskell within an order of magnitude.

After R10 (scan-mode) we can validate whether physical-layout pre-processing pays off at the scales we care about.

### Status of existing targets per the spec

- **Haskell**: L2 already implemented (Phase L#7-9 in `WAM_PERF_OPTIMIZATION_LOG.md`). L1 is a degenerate L2 with cache capacity 0 — no new code needed, just resolver recognition (H1).
- **Rust**: L0 only (R5/R6). L1+L2+scan are the R7-R10 phases.
- **C#**: Substantial planner-level coverage already; not explicitly mapped to L0/L1/L2 yet. Audit deferred.
- **Other targets**: L0 only.

### Files changed

| File | Status | Lines |
| --- | --- | ---: |
| `docs/design/WAM_LMDB_LAZY_PHILOSOPHY.md` | new | ~280 |
| `docs/design/WAM_LMDB_LAZY_SPECIFICATION.md` | new | ~290 |
| `docs/design/WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md` | new | ~210 |

### Test plan

- [x] No code changes — design docs only
- [x] Cross-references resolve: each doc points to the other two plus existing design docs (`QUERY_PLAN_RUNTIME_PHILOSOPHY.md`, `CACHE_COST_MODEL_PHILOSOPHY.md`, `SCAN_STRATEGY_*.md`, `WAM_LMDB_RESIDENT_INTERNING_*.md`, the published Reddit-equivalent report)
- [x] Markdown renders correctly in GitHub-flavoured preview
- [x] Vocabulary internally consistent (L0/L1/L2 used consistently; "workload segregation" defined once and referenced)
- [x] Date stamp (2026-05-20) consistent

### Open questions deferred to the spec or to phase R7

- Cursor lifetime in Rust: one shared cursor (cheap, contended) vs per-thread cursors (more memory, lock-free) vs open-per-call (slow, simplest). Spec leaves it to the implementation; R7 will pick per-thread.
- Default cache capacity for L2: match Haskell's existing default or size by demand-set heuristic. Spec leaves it parameterised.
- How `register_foreign_lookup` slots into the existing Rust WAM runtime's `ffi_facts` dispatch. R7's first task is to read the runtime carefully.

### Follow-up PRs sequenced by this doc

- `feat/wam-rust-lmdb-lazy-l1` — Phase R7 implementation (~1 day)
- `feat/wam-rust-lmdb-lazy-l2` — Phase R8 (~1-2 days)
- `feat/wam-segregation-contract` — Phase R9 (~1 day)
- `feat/wam-rust-lmdb-scan-mode` — Phase R10 (~2 days)
- `feat/wam-haskell-l1-recognition` — Phase H1 (~0.5 day)
- Cross-target consolidation report once R10 + H1 land

🤖 Generated with [Claude Code](https://claude.com/claude-code)