### PR TITLE
test(csharp-query): cover policy report CI contract

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
           python3 -m unittest tests/test_csharp_query_scan_calibration_refresh_wrapper.py
           python3 examples/benchmark/refresh_csharp_query_scan_source_mode_calibration.py --dry-run
           python3 -m unittest tests/test_csharp_query_calibration_ci_contract.py
+          python3 -m unittest tests/test_csharp_query_policy_report_ci_contract.py
 
       - name: Generate and run inference test runner
         run: |

--- a/tests/test_csharp_query_calibration_ci_contract.py
+++ b/tests/test_csharp_query_calibration_ci_contract.py
@@ -20,6 +20,7 @@ class CSharpQueryCalibrationCiContractTests(unittest.TestCase):
             "python3 -m unittest tests/test_csharp_query_scan_calibration_refresh_wrapper.py",
             "python3 examples/benchmark/refresh_csharp_query_scan_source_mode_calibration.py --dry-run",
             "python3 -m unittest tests/test_csharp_query_calibration_ci_contract.py",
+            "python3 -m unittest tests/test_csharp_query_policy_report_ci_contract.py",
         ]
 
         for command in required_commands:

--- a/tests/test_csharp_query_policy_report_ci_contract.py
+++ b/tests/test_csharp_query_policy_report_ci_contract.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "examples" / "benchmark" / "benchmark_csharp_query_effective_distance_artifact_backends.py"
+SUMMARY_HEADERS = [
+    "scale",
+    "relation",
+    "rows",
+    "distinct_categories",
+    "lookup_keys",
+    "best_lookup_mode",
+    "best_lookup_col1_mode",
+    "best_bucket_mode",
+    "best_bucket_col1_mode",
+    "best_scan_mode",
+    "smallest_artifact_mode",
+    "lookup_ms_by_mode",
+    "lookup_col1_ms_by_mode",
+    "bucket_ms_by_mode",
+    "bucket_col1_ms_by_mode",
+    "scan_ms_by_mode",
+    "artifact_bytes_by_mode",
+]
+
+
+class CSharpQueryPolicyReportCiContractTests(unittest.TestCase):
+    def test_help_exposes_policy_report_contract_flags(self) -> None:
+        result = subprocess.run(
+            ["python3", str(SCRIPT), "--help"],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=60,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        for expected in (
+            "--summary-input",
+            "--summary-output",
+            "--policy-action-threshold",
+            "--fail-on-policy-actions",
+            "policy-actionable-markdown",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, result.stdout)
+
+    def test_summary_input_fail_gate_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            summary_path = Path(tmp) / "summary.tsv"
+            summary_path.write_text(
+                "\t".join(SUMMARY_HEADERS)
+                + "\n"
+                + "\t".join(
+                    [
+                        "enwiki_page_5m",
+                        "article_category",
+                        "5000000",
+                        "1918305",
+                        "128",
+                        "lmdb",
+                        "mmap-array",
+                        "mmap-array",
+                        "mmap-array",
+                        "mmap-array",
+                        "mmap-array",
+                        "lmdb:3.251|mmap-array:3.288",
+                        "lmdb:1219.110|mmap-array:236.382",
+                        "delimited-artifact:400.000|mmap-array:350.000",
+                        "mmap-array:350.000",
+                        "mmap-array:850.000",
+                        "lmdb:142443019|mmap-array:80000643",
+                    ]
+                )
+                + "\n"
+            )
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(SCRIPT),
+                    "--summary-input",
+                    str(summary_path),
+                    "--format",
+                    "policy-actionable-markdown",
+                    "--policy-action-threshold",
+                    "1.10",
+                    "--fail-on-policy-actions",
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=60,
+            )
+
+        self.assertEqual(result.returncode, 2, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        self.assertIn("| Policy mode | Policy artifact value | Policy vs best |", result.stdout)
+        self.assertIn("| bucket_c0 | ms | delimited-artifact | 400.000 | 1.143x | mmap-array | 350.000 | diff |", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  - Adds a lightweight CI contract test for C# query policy report command shape.
  - Verifies `--summary-input`, `--summary-output`, `--policy-action-threshold`, `--fail-on-policy-actions`, and `policy-
  actionable-markdown` remain exposed.
  - Adds a fast synthetic `--summary-input ... --fail-on-policy-actions` contract check.
  - Wires the new test into GitHub Actions.
  - Extends the existing calibration CI contract to assert this new test remains in the workflow.

  ## Validation

  - `python3 -m unittest tests/test_csharp_query_policy_report_ci_contract.py tests/
  test_csharp_query_calibration_ci_contract.py`
  - `python3 -m unittest tests/test_csharp_query_source_mode_policy.py tests/test_csharp_query_lmdb_provider_smoke.py tests/
  test_csharp_query_effective_distance_artifact_backends.py tests/test_csharp_query_policy_report_ci_contract.py tests/
  test_csharp_query_calibration_ci_contract.py`
  - `python3 -m py_compile tests/test_csharp_query_policy_report_ci_contract.py tests/
  test_csharp_query_calibration_ci_contract.py`
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime_lmdb/UnifyWeaver.QueryRuntime.Lmdb.csproj`
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
  - `git diff --check`