### PR TITLE
perf(wam-elixir): Y-regs in separate state field — 30-55x bench speedup

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -1091,7 +1091,8 @@ wrap_segment(FuncName, try_me_else(L), BodyCode, Suffix, Code) :-
     segment_func_name(L, Suffix, FallbackFunc),
     format(string(Code),
 '  defp ~w(state) do
-    cp = %{pc: &~w/1, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
+    cp = %{pc: &~w/1, regs: state.regs, y_regs: state.y_regs,
+           heap: state.heap, heap_len: state.heap_len,
            cp: state.cp, trail: state.trail, trail_len: state.trail_len, stack: state.stack}
     state = %{state | choice_points: [cp | state.choice_points]}
     try do
@@ -1109,7 +1110,8 @@ wrap_segment(FuncName, retry_me_else(L), BodyCode, Suffix, Code) :-
     segment_func_name(L, Suffix, FallbackFunc),
     format(string(Code),
 '  defp ~w(state) do
-    cp = %{pc: &~w/1, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
+    cp = %{pc: &~w/1, regs: state.regs, y_regs: state.y_regs,
+           heap: state.heap, heap_len: state.heap_len,
            cp: state.cp, trail: state.trail, trail_len: state.trail_len, stack: state.stack}
     state = %{state | choice_points: [cp | state.choice_points]}
     try do
@@ -1659,22 +1661,21 @@ wam_elixir_lower_instr(trust_me, _PC, _Labels, _FuncName, _Suffix, Code) :-
     Code = '    :ok # Handled by wrap_segment'.
 
 wam_elixir_lower_instr(allocate, _PC, _Labels, _FuncName, _Suffix, Code) :-
-    Code = '    # Save caller\'s Y-regs so the callee can freely overwrite
+    Code = '    # Save caller Y-regs so the callee can freely overwrite
     # slots 201-299 without corrupting the outer frame. Also snapshot
     # the current choice_points as the new cut barrier so `!` inside
     # this predicate truncates only CPs pushed during its own body,
-    # not the caller\'s. Env popped by deallocate restores both.
-    {y_regs_saved, base_regs} = WamRuntime.split_y_regs(state.regs)
-    new_env = %{cp: state.cp, y_regs_saved: y_regs_saved, cut_point: state.cut_point}
-    state = %{state | stack: [new_env | state.stack], regs: base_regs,
+    # not the caller CPs. Env popped by deallocate restores both.
+    # Y-regs live in their own state field so swap is O(1).
+    new_env = %{cp: state.cp, y_regs_saved: state.y_regs, cut_point: state.cut_point}
+    state = %{state | stack: [new_env | state.stack], y_regs: %{},
                       cut_point: state.choice_points}'.
 
 wam_elixir_lower_instr(deallocate, _PC, _Labels, _FuncName, _Suffix, Code) :-
     Code = '    state = case state.stack do
       [env | rest] ->
-        {_callee_ys, base_regs} = WamRuntime.split_y_regs(state.regs)
-        merged = Map.merge(base_regs, Map.get(env, :y_regs_saved, %{}))
-        %{state | cp: env.cp, stack: rest, regs: merged,
+        %{state | cp: env.cp, stack: rest,
+                  y_regs: Map.get(env, :y_regs_saved, %{}),
                   cut_point: Map.get(env, :cut_point, state.cut_point)}
       _ -> state
     end'.

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -301,18 +301,17 @@ wam_elixir_case(allocate,
 '      {:allocate, _n} ->
         # Save caller\'s Y-regs in the new env so the callee can freely
         # use Y-reg slots (ids 201-299) without clobbering the caller.
-        {y_regs_saved, base_regs} = WamRuntime.split_y_regs(state.regs)
-        new_env = %{cp: state.cp, y_regs_saved: y_regs_saved}
-        %{state | stack: [new_env | state.stack], regs: base_regs, pc: state.pc + 1}').
+        # Y-regs live in their own state field, so swap is O(1).
+        new_env = %{cp: state.cp, y_regs_saved: state.y_regs}
+        %{state | stack: [new_env | state.stack], y_regs: %{}, pc: state.pc + 1}').
 
 wam_elixir_case(deallocate,
 '      :deallocate ->
         case state.stack do
           [env | rest] ->
             # Discard current frame\'s Y-regs and restore the caller\'s.
-            {_callee_ys, base_regs} = WamRuntime.split_y_regs(state.regs)
-            merged = Map.merge(base_regs, Map.get(env, :y_regs_saved, %{}))
-            %{state | cp: env.cp, stack: rest, regs: merged, pc: state.pc + 1}
+            %{state | cp: env.cp, stack: rest,
+              y_regs: Map.get(env, :y_regs_saved, %{}), pc: state.pc + 1}
           _ -> %{state | pc: state.pc + 1}
         end').
 
@@ -321,13 +320,15 @@ wam_elixir_case(deallocate,
 wam_elixir_case(try_me_else,
 '      # Fast path: label pre-resolved at codegen to integer PC.
       {:try_me_else, target} when is_integer(target) ->
-        cp = %{pc: target, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
+        cp = %{pc: target, regs: state.regs, y_regs: state.y_regs,
+               heap: state.heap, heap_len: state.heap_len,
                cp: state.cp, trail: state.trail, trail_len: state.trail_len, stack: state.stack}
         %{state | choice_points: [cp | state.choice_points], pc: state.pc + 1}
       # Fallback: unresolved string label.
       {:try_me_else, label} when is_binary(label) ->
         target = resolve_label(state, label)
-        cp = %{pc: target, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
+        cp = %{pc: target, regs: state.regs, y_regs: state.y_regs,
+               heap: state.heap, heap_len: state.heap_len,
                cp: state.cp, trail: state.trail, trail_len: state.trail_len, stack: state.stack}
         %{state | choice_points: [cp | state.choice_points], pc: state.pc + 1}').
 
@@ -336,7 +337,8 @@ wam_elixir_case(retry_me_else,
       {:retry_me_else, target} when is_integer(target) ->
         case state.choice_points do
           [_old | rest] ->
-            cp = %{pc: target, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
+            cp = %{pc: target, regs: state.regs, y_regs: state.y_regs,
+                   heap: state.heap, heap_len: state.heap_len,
                    cp: state.cp, trail: state.trail, trail_len: state.trail_len, stack: state.stack}
             %{state | choice_points: [cp | rest], pc: state.pc + 1}
           _ -> %{state | pc: state.pc + 1}
@@ -346,7 +348,8 @@ wam_elixir_case(retry_me_else,
         target = resolve_label(state, label)
         case state.choice_points do
           [_old | rest] ->
-            cp = %{pc: target, regs: state.regs, heap: state.heap, heap_len: state.heap_len,
+            cp = %{pc: target, regs: state.regs, y_regs: state.y_regs,
+                   heap: state.heap, heap_len: state.heap_len,
                    cp: state.cp, trail: state.trail, trail_len: state.trail_len, stack: state.stack}
             %{state | choice_points: [cp | rest], pc: state.pc + 1}
           _ -> %{state | pc: state.pc + 1}
@@ -450,6 +453,7 @@ compile_backtrack_to_elixir(Code) :-
     |> unwind_trail(cp.trail_len)
     |> Map.put(:pc, cp.pc)
     |> Map.put(:regs, cp.regs)
+    |> Map.put(:y_regs, Map.get(cp, :y_regs, %{}))
     |> Map.put(:heap, cp.heap)
     |> Map.put(:heap_len, cp.heap_len)
     |> Map.put(:cp, cp.cp)
@@ -510,8 +514,13 @@ compile_unwind_trail_to_elixir(Code) :-
              val = if old_val == :not_set, do: {:unbound, {:heap_ref, addr}}, else: old_val
              %{s | heap: Map.put(s.heap, addr, val)}
           _ ->
-             new_regs = if old_val == :not_set, do: Map.delete(s.regs, key), else: Map.put(s.regs, key, old_val)
-             %{s | regs: new_regs}
+             if is_integer(key) and key >= 201 and key < 300 do
+               new_yr = if old_val == :not_set, do: Map.delete(s.y_regs, key), else: Map.put(s.y_regs, key, old_val)
+               %{s | y_regs: new_yr}
+             else
+               new_regs = if old_val == :not_set, do: Map.delete(s.regs, key), else: Map.put(s.regs, key, old_val)
+               %{s | regs: new_regs}
+             end
         end
       end)
     end
@@ -525,16 +534,41 @@ compile_utility_helpers_to_elixir(Code) :-
   end
 
   def trail_binding(state, key) do
-    old = Map.get(state.regs, key, :not_set)
+    old =
+      if is_integer(key) and key >= 201 and key < 300 do
+        Map.get(state.y_regs, key, :not_set)
+      else
+        Map.get(state.regs, key, :not_set)
+      end
     %{state | trail: [{key, old} | state.trail], trail_len: state.trail_len + 1}
   end
 
   def put_reg(state, reg, val) do
-    %{state | regs: Map.put(state.regs, reg, val)}
+    if is_integer(reg) and reg >= 201 and reg < 300 do
+      %{state | y_regs: Map.put(state.y_regs, reg, val)}
+    else
+      %{state | regs: Map.put(state.regs, reg, val)}
+    end
+  end
+
+  # Raw reg lookup without deref. Use when you need the literal slot
+  # value (for instance to pattern-match {:unbound, id} and trail-bind
+  # through id). Routes Y-reg keys to state.y_regs.
+  def get_reg_raw(state, reg) do
+    if is_integer(reg) and reg >= 201 and reg < 300 do
+      Map.get(state.y_regs, reg)
+    else
+      Map.get(state.regs, reg)
+    end
   end
 
   def get_reg(state, reg) do
-    val = Map.get(state.regs, reg, {:unbound, reg})
+    val =
+      if is_integer(reg) and reg >= 201 and reg < 300 do
+        Map.get(state.y_regs, reg, {:unbound, reg})
+      else
+        Map.get(state.regs, reg, {:unbound, reg})
+      end
     deref_var(state, val)
   end
 
@@ -630,6 +664,7 @@ compile_utility_helpers_to_elixir(Code) :-
         cp = %{
           pc: {:fact_stream, rest, arity},
           regs: state.regs,
+          y_regs: state.y_regs,
           heap: state.heap,
           heap_len: state.heap_len,
           cp: state.cp,
@@ -698,7 +733,13 @@ compile_utility_helpers_to_elixir(Code) :-
   end
 
   def deref_var(state, {:unbound, id}) do
-    case Map.get(state.regs, id) do
+    lookup =
+      if is_integer(id) and id >= 201 and id < 300 do
+        Map.get(state.y_regs, id)
+      else
+        Map.get(state.regs, id)
+      end
+    case lookup do
       nil -> {:unbound, id}
       {:unbound, ^id} -> {:unbound, id}
       val -> deref_var(state, val)
@@ -1679,6 +1720,7 @@ compile_utility_helpers_to_elixir(Code) :-
       trail_mark: state.trail_len,
       base_cp_count: length(state.choice_points),
       saved_regs: state.regs,
+      saved_y_regs: state.y_regs,
       saved_stack: state.stack
     }
     state_with_frame = %{state | catcher_frames: [frame | state.catcher_frames]}
@@ -1941,6 +1983,7 @@ compile_utility_helpers_to_elixir(Code) :-
     %{unwound |
       choice_points: new_cps,
       regs: frame.saved_regs,
+      y_regs: Map.get(frame, :saved_y_regs, %{}),
       stack: frame.saved_stack}
   end
 
@@ -2528,6 +2571,7 @@ compile_aggregate_helpers_to_elixir(Code) :-
     cp = %{
       pc: nil,
       regs: state.regs,
+      y_regs: state.y_regs,
       heap: state.heap,
       heap_len: state.heap_len,
       cp: state.cp,
@@ -2567,7 +2611,7 @@ compile_aggregate_helpers_to_elixir(Code) :-
   dominates, separate optimisations can address them.
   """
   def aggregate_collect(state, value_reg) do
-    raw = Map.get(state.regs, value_reg)
+    raw = get_reg_raw(state, value_reg)
     val = deep_copy_value(state, raw)
     {updated_cps, _collected} =
       Enum.map_reduce(state.choice_points, false, fn cp, collected ->
@@ -2807,7 +2851,8 @@ compile_wam_runtime_to_elixir(Options, Code) :-
     # trail_len caches list length to avoid O(n) re-measure on unwind.
     # code is a tuple so fetch is O(1) via elem/2 instead of O(pc) via Enum.at.
     # Phase A perf: O(1) append/read/replace instead of list O(n) operations.
-    defstruct pc: 1, cp: :halt, regs: %{}, heap: %{}, heap_len: 0,
+    defstruct pc: 1, cp: :halt, regs: %{}, y_regs: %{},
+              heap: %{}, heap_len: 0,
               trail: [], trail_len: 0,
               choice_points: [], stack: [], code: {}, labels: %{},
               # arg_vars is the list of {reg_id, unbound_tuple} for each
@@ -4971,7 +5016,7 @@ compile_tc_kernel_dispatch_module(ModuleName, Pred, EdgePred, Code) :-
   end
 
   defp bind_result_reg(state, reg_idx, value) do
-    case Map.get(state.regs, reg_idx) do
+    case WamRuntime.get_reg_raw(state, reg_idx) do
       {:unbound, id} ->
         state |> WamRuntime.trail_binding(id) |> WamRuntime.put_reg(id, value)
       ^value -> state
@@ -5101,7 +5146,7 @@ compile_category_ancestor_dispatch_module(ModuleName, Pred, EdgePred, MaxDepth, 
   end
 
   defp bind_hops_reg(state, reg_idx, value) do
-    case Map.get(state.regs, reg_idx) do
+    case WamRuntime.get_reg_raw(state, reg_idx) do
       {:unbound, id} ->
         state |> WamRuntime.trail_binding(id) |> WamRuntime.put_reg(id, value)
       ^value -> state
@@ -5234,7 +5279,7 @@ compile_transitive_distance_dispatch_module(ModuleName, Pred, EdgePred, Code) :-
   end
 
   defp bind_one(state, reg_idx, value) do
-    case Map.get(state.regs, reg_idx) do
+    case WamRuntime.get_reg_raw(state, reg_idx) do
       {:unbound, id} ->
         {:ok,
          state
@@ -5376,7 +5421,7 @@ compile_transitive_parent_distance_dispatch_module(ModuleName, Pred, EdgePred, C
   end
 
   defp bind_one(state, reg_idx, value) do
-    case Map.get(state.regs, reg_idx) do
+    case WamRuntime.get_reg_raw(state, reg_idx) do
       {:unbound, id} ->
         {:ok,
          state
@@ -5519,7 +5564,7 @@ compile_transitive_step_parent_distance_dispatch_module(ModuleName, Pred, EdgePr
   end
 
   defp bind_one(state, reg_idx, value) do
-    case Map.get(state.regs, reg_idx) do
+    case WamRuntime.get_reg_raw(state, reg_idx) do
       {:unbound, id} ->
         {:ok,
          state
@@ -5657,7 +5702,7 @@ compile_weighted_shortest_path_dispatch_module(ModuleName, Pred, EdgePred, Code)
   end
 
   defp bind_one(state, reg_idx, value) do
-    case Map.get(state.regs, reg_idx) do
+    case WamRuntime.get_reg_raw(state, reg_idx) do
       {:unbound, id} ->
         {:ok,
          state
@@ -5833,7 +5878,7 @@ compile_astar_shortest_path_dispatch_module(ModuleName, Pred, EdgePred, DirectPr
   end
 
   defp bind_one(state, reg_idx, value) do
-    case Map.get(state.regs, reg_idx) do
+    case WamRuntime.get_reg_raw(state, reg_idx) do
       {:unbound, id} ->
         {:ok,
          state

--- a/tests/bench_wam_elixir_atom_lookups.pl
+++ b/tests/bench_wam_elixir_atom_lookups.pl
@@ -1,0 +1,242 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% bench_wam_elixir_atom_lookups.pl
+%
+% Runtime baseline bench for the WAM-Elixir target. Mirrors the
+% shape of the Rust category_ancestor workload that proved out the
+% 7.9x atom-interning win
+% (docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md).
+%
+% Purpose: capture a NUMERIC baseline for atom-keyed fact lookups
+% on Elixir BEFORE deciding whether atom interning is worth
+% implementing. BEAM has small-binary optimization that may give
+% us most of the win for free — only the bench can tell.
+%
+% Workload: chained parent/2 facts (parent(a0,a1), parent(a1,a2),
+% ...) at multiple sizes, plus ancestor/2 recursive query.
+% Reports wallclock per-invocation in microseconds.
+%
+% Usage:
+%   swipl -g run_bench -t halt tests/bench_wam_elixir_atom_lookups.pl
+%
+% Gated on `elixir` being on PATH.
+
+:- module(bench_wam_elixir_atom_lookups, [run_bench/0, run_eprof/0]).
+
+:- use_module(library(lists)).
+:- use_module(library(process)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_elixir_target').
+
+% ============================================================
+% Top-level
+% ============================================================
+
+run_bench :-
+    (   elixir_on_path
+    ->  true
+    ;   format("SKIP: elixir not on PATH~n"), halt(0)
+    ),
+    format("~n================================================~n"),
+    format("  WAM-Elixir atom-lookup baseline bench~n"),
+    format("================================================~n"),
+    % Small sizes first — verify the lowered emitter handles the
+    % clause count before scaling up. If N=100 works, try larger.
+    Sizes = [50, 100, 250, 500, 1000],
+    Reps = 3,
+    forall(member(N, Sizes), run_one(N, Reps)),
+    format("~n================================================~n"),
+    format("  Done~n"),
+    format("================================================~n~n").
+
+elixir_on_path :-
+    catch(
+        process_create(path(elixir), ['--version'],
+                       [stdout(null), stderr(null), process(Pid)]),
+        _, fail),
+    process_wait(Pid, exit(0)).
+
+% ============================================================
+% Per-size run
+% ============================================================
+
+run_one(N, Reps) :-
+    format("~n=== N=~w chain depth, ~w repetitions ===~n", [N, Reps]),
+    setup_facts(N),
+    catch(
+        ( time_compile_and_run(N, Reps, MeanUs),
+          format("  mean_us=~w~n", [MeanUs])
+        ),
+        Err,
+        format("  ERROR: ~w~n", [Err])
+    ),
+    teardown_facts.
+
+setup_facts(N) :-
+    catch(abolish(user:parent/2), _, true),
+    catch(abolish(user:ancestor/2), _, true),
+    N1 is N - 1,
+    forall(
+        between(0, N1, I), (
+            I1 is I + 1,
+            atom_concat(a, I, From),
+            atom_concat(a, I1, To),
+            assertz(user:parent(From, To))
+        )
+    ),
+    % Two-clause ancestor: direct parent + transitive.
+    user:assertz((ancestor(X, Y) :- parent(X, Y))),
+    user:assertz((ancestor(X, Y) :- parent(X, Z), ancestor(Z, Y))).
+
+teardown_facts :-
+    catch(abolish(user:parent/2), _, true),
+    catch(abolish(user:ancestor/2), _, true).
+
+% ============================================================
+% Compile, run, time
+% ============================================================
+
+time_compile_and_run(N, Reps, MeanUs) :-
+    unique_tmp_dir('tmp_elixir_bench', TmpDir),
+    BaseOpts = [ module_name('wam_elixir_bench'),
+                 emit_mode(lowered),
+                 source_module(user) ],
+    Preds = [user:parent/2, user:ancestor/2],
+    compile_preds(Preds, [], PredWamPairs),
+    write_wam_elixir_project(PredWamPairs, BaseOpts, TmpDir),
+    bench_driver_path(DriverSrc),
+    directory_file_path(TmpDir, 'run_bench.exs', DriverDst),
+    copy_file(DriverSrc, DriverDst),
+    % Query: ancestor(a0, a<N>) — succeeds, walks the whole chain.
+    atom_concat(a, N, LastAtom),
+    atom_string(LastAtom, LastAtomStr),
+    setup_call_cleanup(
+        true,
+        run_bench_driver(TmpDir, 'ancestor/2', Reps,
+                         ['a0', LastAtomStr], MeanUs),
+        delete_directory_and_contents(TmpDir)).
+
+compile_preds([], _Opts, []).
+compile_preds([Mod:Name/Arity | Rest], Opts,
+              [Name/Arity-WamCode | RestPairs]) :-
+    (   wam_target:compile_predicate_to_wam(Name/Arity, Opts, WamCode) -> true
+    ;   wam_target:compile_predicate_to_wam(Mod:Name/Arity, Opts, WamCode) -> true
+    ;   throw(error(wam_compile_failed(Mod:Name/Arity), _))
+    ),
+    compile_preds(Rest, Opts, RestPairs).
+
+run_bench_driver(ProjectDir, PredKey, Reps, Args, MeanUs) :-
+    absolute_file_name(ProjectDir, AbsProjectDir),
+    atom_string(PredKey, PredStr),
+    number_string(Reps, RepsStr),
+    maplist([A, S]>>atom_string(A, S), Args, ArgStrs),
+    append(['run_bench.exs', "WamElixirBench", PredStr, RepsStr],
+           ArgStrs, ProcArgs),
+    process_create(path(elixir), ProcArgs,
+                   [cwd(AbsProjectDir),
+                    stdout(pipe(Out)), stderr(pipe(Err)),
+                    process(Pid)]),
+    read_string(Out, _, OutStr),
+    read_string(Err, _, ErrStr),
+    close(Out),
+    close(Err),
+    process_wait(Pid, exit(ExitCode)),
+    (   ExitCode =:= 0
+    ->  parse_mean_us(OutStr, MeanUs)
+    ;   throw(error(elixir_bench_failed(ExitCode, ErrStr), _))
+    ).
+
+parse_mean_us(Out, MeanUs) :-
+    split_string(Out, "\n", " \t", Lines),
+    member(Line, Lines),
+    split_string(Line, " ", "", Tokens),
+    member(Tok, Tokens),
+    string_concat("mean_us=", ValStr, Tok),
+    !,
+    number_string(MeanUs, ValStr).
+
+unique_tmp_dir(Prefix, TmpDir) :-
+    get_time(T),
+    Stamp is floor(T * 1000),
+    (   getenv('TMPDIR', Base) -> true
+    ;   Base = '/tmp'
+    ),
+    format(atom(TmpDir), '~w/~w_~w', [Base, Prefix, Stamp]).
+
+:- (   prolog_load_context(directory, Dir),
+       directory_file_path(Dir, 'elixir_e2e/run_bench.exs', P),
+       assertz(bench_driver_path_fact(P))
+   ;   true
+   ).
+bench_driver_path(P) :- bench_driver_path_fact(P).
+
+:- (   prolog_load_context(directory, Dir2),
+       directory_file_path(Dir2, 'elixir_e2e/run_eprof.exs', P2),
+       assertz(eprof_driver_path_fact(P2))
+   ;   true
+   ).
+eprof_driver_path(P) :- eprof_driver_path_fact(P).
+
+% ============================================================
+% Profiling entry point — captures :eprof per-function breakdown
+% for a single query at fixed N.
+% ============================================================
+
+run_eprof :-
+    (   elixir_on_path
+    ->  true
+    ;   format("SKIP: elixir not on PATH~n"), halt(0)
+    ),
+    N = 500,
+    format("~n================================================~n"),
+    format("  WAM-Elixir :eprof profile, N=~w~n", [N]),
+    format("================================================~n~n"),
+    setup_facts(N),
+    catch(
+        profile_query(N),
+        Err,
+        format("ERROR: ~w~n", [Err])
+    ),
+    teardown_facts.
+
+profile_query(N) :-
+    unique_tmp_dir('tmp_elixir_eprof', TmpDir),
+    BaseOpts = [ module_name('wam_elixir_bench'),
+                 emit_mode(lowered),
+                 source_module(user) ],
+    Preds = [user:parent/2, user:ancestor/2],
+    compile_preds(Preds, [], PredWamPairs),
+    write_wam_elixir_project(PredWamPairs, BaseOpts, TmpDir),
+    eprof_driver_path(DriverSrc),
+    directory_file_path(TmpDir, 'run_eprof.exs', DriverDst),
+    copy_file(DriverSrc, DriverDst),
+    atom_concat(a, N, LastAtom),
+    atom_string(LastAtom, LastAtomStr),
+    setup_call_cleanup(
+        true,
+        run_eprof_driver(TmpDir, 'ancestor/2', ['a0', LastAtomStr]),
+        delete_directory_and_contents(TmpDir)).
+
+run_eprof_driver(ProjectDir, PredKey, Args) :-
+    absolute_file_name(ProjectDir, AbsProjectDir),
+    atom_string(PredKey, PredStr),
+    maplist([A, S]>>atom_string(A, S), Args, ArgStrs),
+    append(['run_eprof.exs', "WamElixirBench", PredStr], ArgStrs, ProcArgs),
+    process_create(path(elixir), ProcArgs,
+                   [cwd(AbsProjectDir),
+                    stdout(pipe(Out)), stderr(pipe(Err)),
+                    process(Pid)]),
+    read_string(Out, _, OutStr),
+    read_string(Err, _, ErrStr),
+    close(Out),
+    close(Err),
+    process_wait(Pid, exit(ExitCode)),
+    format("~w~n", [OutStr]),
+    (   ExitCode =:= 0
+    ->  true
+    ;   format("stderr: ~w~n", [ErrStr]),
+        throw(error(elixir_eprof_failed(ExitCode), _))
+    ).

--- a/tests/elixir_e2e/run_bench.exs
+++ b/tests/elixir_e2e/run_bench.exs
@@ -1,0 +1,82 @@
+# Bench driver for the WAM-Elixir atom-lookup baseline bench.
+#
+# Loads the project (same shape as run_classic.exs), then runs the
+# query N times under :timer.tc/1. Prints two lines on stdout:
+#   N=<reps> total_us=<total> mean_us=<mean>
+#   result=<true|false|other>
+#
+# CLI: elixir run_bench.exs <ModuleCamel> <PredKey> <reps> [<arg> ...]
+#
+# Args parsing mirrors run_classic.exs (integers, floats, [a,b] lists,
+# bare binaries).
+
+Code.require_file("lib/wam_runtime.ex", __DIR__)
+Code.require_file("lib/wam_dispatcher.ex", __DIR__)
+
+[mod_camel, pred_key, reps_str | raw_args] = System.argv()
+reps = String.to_integer(reps_str)
+
+[pred_name, _arity] = String.split(pred_key, "/")
+pred_camel = Macro.camelize(pred_name)
+pred_module = Module.concat([mod_camel, pred_camel])
+
+lib_dir = Path.join(__DIR__, "lib")
+{:ok, lib_files} = File.ls(lib_dir)
+
+lib_files
+|> Enum.filter(&String.ends_with?(&1, ".ex"))
+|> Enum.reject(&(&1 in ["wam_runtime.ex", "wam_dispatcher.ex"]))
+|> Enum.each(fn fname ->
+  Code.require_file("lib/#{fname}", __DIR__)
+end)
+
+defmodule ParseArg do
+  def parse(s) do
+    cond do
+      s == "[]" ->
+        []
+
+      String.starts_with?(s, "[") and String.ends_with?(s, "]") ->
+        s
+        |> String.slice(1..-2//1)
+        |> String.split(",")
+        |> Enum.map(&String.trim/1)
+        |> Enum.map(&parse/1)
+
+      Regex.match?(~r/^-?\d+$/, s) ->
+        String.to_integer(s)
+
+      Regex.match?(~r/^-?\d+\.\d+$/, s) ->
+        String.to_float(s)
+
+      true ->
+        s
+    end
+  end
+end
+
+parsed_args = Enum.map(raw_args, &ParseArg.parse/1)
+
+# Warmup: one untimed invocation so JIT / module loading is amortised.
+_ = apply(pred_module, :run, [parsed_args])
+
+# Timed: reps invocations under :timer.tc/1. Time returned in microseconds.
+{total_us, last} =
+  :timer.tc(fn ->
+    Enum.reduce(1..reps, nil, fn _, _acc ->
+      apply(pred_module, :run, [parsed_args])
+    end)
+  end)
+
+mean_us = total_us / reps
+
+IO.puts("N=#{reps} total_us=#{total_us} mean_us=#{Float.round(mean_us, 2)}")
+
+result_str =
+  case last do
+    {:ok, _} -> "true"
+    :fail -> "false"
+    other -> "other:#{inspect(other)}"
+  end
+
+IO.puts("result=#{result_str}")

--- a/tests/elixir_e2e/run_eprof.exs
+++ b/tests/elixir_e2e/run_eprof.exs
@@ -1,0 +1,67 @@
+# Profiling driver: runs the bench query under :eprof and prints
+# the analysis to stdout. Captures per-function call counts and
+# cumulative time so we can see whether choice-point management,
+# state-map updates, or unification dominates the bench.
+#
+# CLI: elixir run_eprof.exs <ModuleCamel> <PredKey> [<arg> ...]
+#
+# Args parsing mirrors run_classic.exs.
+
+Code.require_file("lib/wam_runtime.ex", __DIR__)
+Code.require_file("lib/wam_dispatcher.ex", __DIR__)
+
+[mod_camel, pred_key | raw_args] = System.argv()
+
+[pred_name, _arity] = String.split(pred_key, "/")
+pred_camel = Macro.camelize(pred_name)
+pred_module = Module.concat([mod_camel, pred_camel])
+
+lib_dir = Path.join(__DIR__, "lib")
+{:ok, lib_files} = File.ls(lib_dir)
+
+lib_files
+|> Enum.filter(&String.ends_with?(&1, ".ex"))
+|> Enum.reject(&(&1 in ["wam_runtime.ex", "wam_dispatcher.ex"]))
+|> Enum.each(fn fname ->
+  Code.require_file("lib/#{fname}", __DIR__)
+end)
+
+defmodule ParseArg do
+  def parse(s) do
+    cond do
+      s == "[]" ->
+        []
+
+      String.starts_with?(s, "[") and String.ends_with?(s, "]") ->
+        s
+        |> String.slice(1..-2//1)
+        |> String.split(",")
+        |> Enum.map(&String.trim/1)
+        |> Enum.map(&parse/1)
+
+      Regex.match?(~r/^-?\d+$/, s) ->
+        String.to_integer(s)
+
+      Regex.match?(~r/^-?\d+\.\d+$/, s) ->
+        String.to_float(s)
+
+      true ->
+        s
+    end
+  end
+end
+
+parsed_args = Enum.map(raw_args, &ParseArg.parse/1)
+
+# Warmup: untimed call so module loading and BEAM JIT settle.
+_ = apply(pred_module, :run, [parsed_args])
+
+# Profile a single invocation.
+:eprof.start()
+:eprof.start_profiling([self()])
+_result = apply(pred_module, :run, [parsed_args])
+:eprof.stop_profiling()
+
+# Analyze prints to stdout (group_leader). Includes per-function
+# call count and cumulative time (microseconds + percentage).
+:eprof.analyze(:total)


### PR DESCRIPTION
  ## Summary

  Profile-driven perf fix for WAM-Elixir runtime. A chain-style fact-lookup bench showed **O(N²) growth** at N=50..1000.
  `:eprof` localized **91% of runtime** to `WamRuntime.split_y_regs/1`, which folded the entire register map every time
  `allocate`/`deallocate` ran — once per env frame. Each fold was O(N) in regs-map size, and N folds gave O(N²) total.

  This PR moves Y-regs into their own `state.y_regs` field so the split is eliminated entirely. `allocate`/`deallocate`
  swap `state.y_regs` in O(1); `put_reg`/`get_reg`/`trail_binding` dispatch by reg-id range (≥201 & <300 → y_regs, else
  regs).

  ## Measured impact

  | N (chain depth) | Before | After | Speedup |
  |---|---|---|---|
  | 50  | 3.02 ms | 1.07 ms | **2.83×** |
  | 250 | 23.83 ms | 1.15 ms | **20.7×** |
  | 500 | 93.55 ms | 3.47 ms | **27.0×** |
  | 1000 | 379.65 ms | 6.96 ms | **54.6×** |

  Growth shape: O(N²) → ~O(N).

  `:eprof` after the fix: top consumers are `Map.get/3` (16%), `trail_binding/2` (11%), `clause_Ancestor2/1` (8%),
  `try_unify_fact_tuple/4` (7%), `put_reg/3` (6%) — work spread healthily across many real-cost functions. `split_y_regs`
  is **gone from the profile entirely**.

  ## How this displaces the atom-interning plan

  The original Item 1 in the WAM-Elixir parity series was atom interning, modeled on the Rust target's 7.9× win on
  `category_ancestor`
  ([`docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md`](docs/design/WAM_CROSS_TARGET_BENCHMARK_RESULTS.md)). Atom
  interning addresses **string-comparison cost**.

  But the `:eprof` profile of this bench showed string comparisons were < 1% of runtime. The dominant cost was a
  fundamentally different bottleneck — env-frame Y-reg folding. Implementing atom interning first would have netted at most
   a few percent improvement; this fix is two orders of magnitude bigger.

  Lesson reinforced: **bench BEFORE implementing**. Cross-target perf wins don't always transfer.

  ## Wiring changes

  **`src/unifyweaver/targets/wam_elixir_target.pl`:**
  - `defstruct` adds `y_regs: %{}` field
  - `put_reg/3`, `get_reg/2`, `trail_binding/2`: range-dispatch by reg-id (≥201 & <300 → y_regs)
  - `deref_var/2` `{:unbound, id}` case: same dispatch (id can be a Y-reg integer)
  - New `get_reg_raw/2` helper: non-dereffing raw lookup with range dispatch
  - `aggregate_collect/2`, kernel-template `bind_*_reg` helpers (6 sites): use `get_reg_raw` instead of
  `Map.get(state.regs, ...)`
  - `unwind_trail` register-case: restore to y_regs or regs based on key range
  - `backtrack_ordinary`: restore both regs and y_regs from CP
  - `allocate`/`deallocate`: swap `state.y_regs` directly, no split
  - CP snapshots in `try_me_else`/`retry_me_else`/`push_aggregate_frame`/`resume_fact_stream`: include `y_regs:
  state.y_regs`
  - Catcher frame: add `saved_y_regs` field; restore in `restore_from_catcher_frame`

  **`src/unifyweaver/targets/wam_elixir_lowered_emitter.pl`:**
  - `wrap_segment` (try_me_else, retry_me_else) inline CP: include `y_regs: state.y_regs`
  - Inline `allocate`/`deallocate` instruction templates: swap `state.y_regs` directly

  **New bench infrastructure:**
  - `tests/bench_wam_elixir_atom_lookups.pl`: runtime baseline bench (chain-style `parent/2` + recursive `ancestor/2`)
  - `tests/elixir_e2e/run_bench.exs`: timed-invocation driver (warmup + `:timer.tc` over N reps)
  - `tests/elixir_e2e/run_eprof.exs`: profiling driver (`:eprof.start_profiling` / `:eprof.analyze`)

  ## Verification

  | Suite | Before (main) | After (this PR) | Notes |
  |---|---|---|---|
  | `test_wam_elixir_classic_programs` | 47/47 | 47/47 | All 47 e2e tests pass |
  | `test_wam_elixir_target` | pass | pass | |
  | `test_wam_elixir_lowered_phase3` | 15 / 1 | 15 / 1 | 1 pre-existing failure on main, unrelated to this PR
  (compound-Template assertion expects integer but gets binary) |
  | `test_wam_elixir_lowered_phase4c` | 5/5 | 5/5 | |
  | `test_wam_elixir_lowered_phase4d` | 1/1 | 1/1 | |

  **Zero regressions.** Pre-existing failure on main is unchanged.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)