### PR TITLE
fix(wam-fsharp): unblock indexed dispatch (Bug A from PR #2350)

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -959,22 +959,28 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                    CpBuiltin  = None }
         Some { s with WsPC = s.WsPC + 1; WsCPs = cp :: s.WsCPs; WsCPsLen = s.WsCPsLen + 1 }
 
+    // TrustMe / RetryMeElse: when an indexed SwitchOnConstantPc jumps
+    // directly to a clause that begins with one of these (the WAM
+    // emitter places labels just before Retry/Trust), there''s no
+    // choice point to pop or modify — we''re committing deterministically
+    // to that clause.  Treat the empty-CP case as a no-op advance
+    // instead of failing, so indexed dispatch works (Bug A from PR #2350).
     | TrustMe ->
         match s.WsCPs with
         | _ :: rest -> Some { s with WsPC = s.WsPC + 1; WsCPs = rest; WsCPsLen = s.WsCPsLen - 1 }
-        | []        -> None
+        | []        -> Some { s with WsPC = s.WsPC + 1 }
 
     | RetryMeElse label ->
         match s.WsCPs with
         | cp :: rest ->
             let nextPC = Map.tryFind label ctx.WcLabels |> Option.defaultValue 0
             Some { s with WsPC = s.WsPC + 1; WsCPs = { cp with CpNextPC = nextPC } :: rest }
-        | [] -> None
+        | [] -> Some { s with WsPC = s.WsPC + 1 }
 
     | RetryMeElsePc nextPC ->
         match s.WsCPs with
         | cp :: rest -> Some { s with WsPC = s.WsPC + 1; WsCPs = { cp with CpNextPC = nextPC } :: rest }
-        | []         -> None
+        | []         -> Some { s with WsPC = s.WsPC + 1 }
 
     // Phase 4.1 / Phase J — parallel WAM. ParTryMeElse dispatches through
     // forkOrSequential, which forks all branches in parallel when inside a
@@ -989,6 +995,15 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
     | ParTrustMe            -> step ctx s TrustMe
     | ParRetryMeElsePc pc   -> step ctx s (RetryMeElsePc pc)
 
+    // SwitchOnConstantPc / SwitchOnConstant: indexed dispatch on A1.
+    // Hits jump to the matching clause; misses fall through to the
+    // next instruction (typically TryMeElse) which then runs the linear
+    // chain.  Falling through on miss (rather than returning None)
+    // mirrors the WAM compiler''s `tom:default` semantics — `default`
+    // labels get dropped by resolveCallInstrs, so the table just lacks
+    // an entry, and falling through is the right behavior.  Without
+    // this, indexed dispatch fails outright on any A1 not explicitly
+    // listed in the table.
     | SwitchOnConstantPc table ->
         let valOpt = getReg 1 s
         match valOpt with
@@ -996,12 +1011,12 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         | Some (Atom key) ->
             match binarySearchStr table key with
             | Some pc -> Some { s with WsPC = pc }
-            | None    -> None
+            | None    -> Some { s with WsPC = s.WsPC + 1 }
         | Some (Integer n) ->
             match binarySearchStr table (string n) with
             | Some pc -> Some { s with WsPC = pc }
-            | None    -> None
-        | _ -> None
+            | None    -> Some { s with WsPC = s.WsPC + 1 }
+        | _ -> Some { s with WsPC = s.WsPC + 1 }
 
     | SwitchOnConstant table ->
         let valOpt = getReg 1 s
@@ -1012,9 +1027,9 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
             | Some label ->
                 match Map.tryFind label ctx.WcLabels with
                 | Some pc -> Some { s with WsPC = pc }
-                | None    -> None
-            | None -> None
-        | None -> None
+                | None    -> Some { s with WsPC = s.WsPC + 1 }
+            | None -> Some { s with WsPC = s.WsPC + 1 }
+        | None -> Some { s with WsPC = s.WsPC + 1 }
 
     | BuiltinCall ("!/0", _) ->
         Some { s with
@@ -3160,15 +3175,30 @@ pred_func_name_fs(PI, FN) :-
     format(atom(FN), '~w_~w', [PSafe, A]).
 
 emit_merged_code_build_fs([], Code) :-
-    Code = 'let allCode : Instruction array = [||]\nlet allLabels : Map<string, int> = Map.empty'.
+    %% Even the empty case must reserve index 0 as a halt sentinel:
+    %% `run`'s loop short-circuits on `s.WsPC = 0` before fetching from
+    %% WcCode, so we never actually execute index 0.  Having it present
+    %% means PC numbering (1-based per the WAM compiler / labels) aligns
+    %% with array indexing.  Without the sentinel, the first real
+    %% instruction lands at index 0 (unreachable) and label "pred/N" → 1
+    %% points to the SECOND emitted instruction — the cause of Bug A in
+    %% PR #2350's query smoke.
+    Code = 'let allCode : Instruction array = [| Fail |]\nlet allLabels : Map<string, int> = Map.empty'.
 emit_merged_code_build_fs(FuncNames, Code) :-
     FuncNames \= [],
     maplist([FN, Expr]>>(format(atom(Expr), '~w_code', [FN])), FuncNames, CodeExprs),
     atomic_list_concat(CodeExprs, ' @ ', CodeConcat),
     maplist([FN, Expr]>>(format(atom(Expr), '~w_labels', [FN])), FuncNames, LabelExprs),
     atomic_list_concat(LabelExprs, ' |> mapUnion ', LabelUnion),
+    %% Prepend a Fail sentinel at index 0 so WAM-PC 1 (the first real
+    %% instruction emitted by the WAM compiler) maps to array index 1.
+    %% Closes the off-by-one (Bug A from PR #2350): without the
+    %% sentinel, SwitchOnConstantPc — emitted as the first instruction
+    %% by the WAM compiler — lands at array index 0 where `run`'s halt
+    %% sentinel `if s.WsPC = 0 then Some s` short-circuits before
+    %% fetching, making indexed dispatch unreachable.
     format(string(Code),
-'let allCode : Instruction array = (~w) |> List.toArray
+'let allCode : Instruction array = (Fail :: (~w)) |> List.toArray
 let allLabels : Map<string, int> = ~w', [CodeConcat, LabelUnion]).
 
 %% generate_lowered_fs(+LoweredEntries, -Code)

--- a/tests/fixtures/wam_fsharp_query_smoke/Driver.fs
+++ b/tests/fixtures/wam_fsharp_query_smoke/Driver.fs
@@ -169,58 +169,57 @@ let query_X_parent_ann () =
     | None ->
         assertTrue "parent(X, ann) should succeed" false
 
-// -- Currently-broken queries: clause 3 unreachable ------------------------
+// -- Clause-3 queries: now reachable via indexed dispatch for ground A1
+//                       (Bug A fixed in this PR), still broken for unbound
+//                       A1 because of Bug B (chain pop bug).
 //
-// These assert the CURRENT (buggy) behavior — `None` — so the smoke
-// passes.  When the dispatch bugs are fixed in a follow-up PR, the
-// expected results below will flip to actual matches and these
-// assertions will fail, prompting test updates.
+// Bug A (sentinel + Retry/Trust no-op-on-empty + SwitchOnConstantPc
+// fall-through-on-miss) lets ground A1 reach any clause via the indexed
+// dispatch table.  parent(ann, X) and parent(ann, eve) now succeed.
+//
+// Bug B (backtrack pops CP, RetryMeElse expects to modify it) still bites
+// when A1 is Unbound and we need to walk past clause 2 — there's no
+// indexed path available, the chain runs out after the first backtrack.
+// parent(X, eve) still asserts [KNOWN BUG].
 
-let query_parent_ann_X_BUG () =
-    // Bug A (SwitchOnConstantPc unreachable) + Bug B (chain breaks):
-    // ground A1 = ann should land in clause 3 either via indexed
-    // dispatch (Bug A blocks) or via 2 backtracks through the chain
-    // (Bug B blocks).  Currently returns None.
-    //
-    // Expected after fixes: Some result with A2 = Atom "eve".
+let query_parent_ann_X () =
+    // Ground A1 = ann: indexed dispatch via SwitchOnConstantPc jumps
+    // directly to clause 3.  Should now succeed with X = eve.
     let ctx = mkContext ()
     let s = mkQueryState (Atom "ann") (Unbound 800) 801
     match dispatchCall ctx "parent_query_smoke/2" s with
-    | None ->
-        assertTrue "[KNOWN BUG] parent(ann, X): currently None (clause 3 unreachable)"
-                   true
     | Some result ->
         let answer = derefVar result.WsBindings result.WsRegs.[2]
-        // If the bug gets fixed, surface that clearly:
-        assertTrue (sprintf "[BUG FIXED?] parent(ann, X): now returns A2 = %A (was None — update smoke)" answer)
-                   false
+        assertTrue "parent(ann, X): X = Atom \"eve\" (clause 3 via indexed dispatch)"
+                   (answer = Atom "eve")
+    | None ->
+        assertTrue "parent(ann, X) should succeed (clause 3 indexed)" false
 
-let query_parent_ann_eve_BUG () =
-    // Same bug class: clause-3 match unreachable.  Currently None.
+let query_parent_ann_eve () =
+    // Both ground, clause 3 exact match via indexed dispatch.
     let ctx = mkContext ()
     let s = mkQueryState (Atom "ann") (Atom "eve") 900
     match dispatchCall ctx "parent_query_smoke/2" s with
-    | None ->
-        assertTrue "[KNOWN BUG] parent(ann, eve): currently None (clause 3 unreachable)"
-                   true
     | Some _ ->
-        assertTrue "[BUG FIXED?] parent(ann, eve): now succeeds (was None — update smoke)"
-                   false
+        assertTrue "parent(ann, eve) succeeds (clause 3 exact match via indexed dispatch)"
+                   true
+    | None ->
+        assertTrue "parent(ann, eve) should succeed" false
 
 let query_X_parent_eve_BUG () =
-    // A1 Unbound, A2 ground.  Match is in clause 3 (X = ann), but
-    // reaching clause 3 needs 2 backtracks through the chain — Bug B
-    // means the second backtrack finds an empty CP stack.  Currently
-    // None.
+    // A1 Unbound, A2 ground.  No indexed dispatch (A1 unbound → falls
+    // through), so we walk the chain.  Match is in clause 3 (X = ann),
+    // but reaching clause 3 needs 2 backtracks — Bug B means the
+    // second backtrack finds an empty CP stack.  Still [KNOWN BUG].
     let ctx = mkContext ()
     let s = mkQueryState (Unbound 1000) (Atom "eve") 1001
     match dispatchCall ctx "parent_query_smoke/2" s with
     | None ->
-        assertTrue "[KNOWN BUG] parent(X, eve): currently None (clause 3 via 2 backtracks)"
+        assertTrue "[KNOWN BUG] parent(X, eve): currently None (Bug B — chain pop after 2 backtracks)"
                    true
     | Some result ->
         let answer = derefVar result.WsBindings result.WsRegs.[1]
-        assertTrue (sprintf "[BUG FIXED?] parent(X, eve): now returns A1 = %A (was None — update smoke)" answer)
+        assertTrue (sprintf "[BUG B FIXED?] parent(X, eve): now returns A1 = %A (was None — update smoke)" answer)
                    false
 
 [<EntryPoint>]
@@ -234,8 +233,8 @@ let main _argv =
     query_X_parent_bob ()
     query_X_parent_ann ()
     // Currently-broken scenarios (clause 3 unreachable):
-    query_parent_ann_X_BUG ()
-    query_parent_ann_eve_BUG ()
+    query_parent_ann_X ()
+    query_parent_ann_eve ()
     query_X_parent_eve_BUG ()
     let total = passes + fails
     printfn "RESULT %d/%d" passes total


### PR DESCRIPTION
## Summary

Fixes Bug A from PR #2350 — unblocks **indexed dispatch** for ground first-argument queries. F# WAM can now correctly route any clause (1, 2, or 3+) via the `SwitchOnConstantPc` indexed path. Bug B (the chain-pop bug for unbound A1 with match in clause 3+) remains as `[KNOWN BUG]` for a follow-up PR.

Single commit (`0c71b6f`).

## What Bug A actually was

The "SwitchOnConstantPc at array index 0 unreachable" framing in PR #2350 was incomplete — it was an *accidentally-self-consistent* triple. Patching just the array indexing alone broke the existing workaround, so the smoke immediately failed scenarios that previously passed:

```
Before:  parent(tom, X) → "bob"  ✓ (linear chain bypassing the dead SwitchOnConstantPc)
After A-only fix:  parent(tom, X) → None  ✗ (SwitchOnConstantPc misses "tom", returns None)
```

Three coordinated changes are required for indexed dispatch to work end-to-end:

### 1. Prepend Fail sentinel to `allCode` at index 0

`PC 0` is `run`'s halt sentinel — `if s.WsPC = 0 then Some s` short-circuits before fetching. Without padding, the first real WAM instruction lands at `array[0]` (unreachable), and labels emitted with PC values 1+ resolve to `array[i]` where `i` is off by 1 from what the WAM compiler intended.

### 2. `SwitchOnConstantPc` / `SwitchOnConstant` fall through on miss

The WAM compiler emits `tom:default` entries that `resolveCallInstrs` drops (because `"default"` is not a real label), leaving an unindexed atom. Previously the step returned `None` on miss, killing the query. Now we fall through to the next instruction (the linear `TryMeElse` chain), matching the WAM compiler's intent.

### 3. `TrustMe` / `RetryMeElse` / `RetryMeElsePc` no-op-advance on empty CPs

When the now-reachable `SwitchOnConstantPc` jumps directly to a clause body that's labeled with a `RetryMeElse` or `TrustMe` instruction (the WAM emitter places labels just before these), there's no choice point yet — we're committing deterministically to that clause via indexed dispatch. Previously the step returned `None` when `WsCPs` was empty; now it advances PC. Behavior unchanged for the chain case (CP is present, normal modify-or-pop happens).

## Why these three together

The original off-by-one in array indexing accidentally aligned label PCs to clause **bodies** (skipping Retry/Trust by 1). When indexed dispatch was unreachable, this self-cancellation worked for chains of length ≤ 2. Fixing the indexing alone makes indexed dispatch land precisely at Retry/Trust — which then fail on the empty CP stack. The three fixes together make both code paths (indexed and chain) behave correctly for any clause reachable in at most one backtrack; clauses needing 2+ backtracks via the chain still hit Bug B.

## Query smoke updates

`tests/fixtures/wam_fsharp_query_smoke/Driver.fs`:

| Scenario | Before this PR | After this PR |
|---|---|---|
| `query_parent_ann_X` | `[KNOWN BUG]` asserting `None` | Asserts `X = Atom "eve"` (clause 3 via indexed dispatch) |
| `query_parent_ann_eve` | `[KNOWN BUG]` asserting `None` | Asserts exact-match success (clause 3 via indexed dispatch) |
| `query_X_parent_eve_BUG` | `[KNOWN BUG]` asserting `None` | Still `[KNOWN BUG]` — Bug B: A1 Unbound, no indexed path, chain pops on first backtrack |

## Verification

- `swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_dotnet_smoke.pl` — **6 / 6 pass**. Query smoke `RESULT 10/10` (7 working + 2 newly-fixed via Bug A + 1 still-known-bug for Bug B).
- `swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl` — **64 / 64** (codegen layer unchanged).
- Phase-I lowered runtime smoke: still `RESULT 16/16`.
- Pre-existing interpreter runtime smoke (PR #2347): still `RESULT 81/81`.
- `tests/core/test_fsharp_native_lowering.pl` — unchanged.

## Net effect

F# WAM can now correctly dispatch ground first-argument queries to ANY clause (1, 2, or 3+) via the indexed path. **Bug B is the only remaining barrier** for multi-clause dispatch where indexed dispatch doesn't apply (typically: A1 unbound, match in clause 3+).

## Next-PR scope

Bug B fix: `backtrack` pops the CP and restores from it, but `RetryMeElse` expects to modify the top CP — leaving the second backtrack with an empty CP stack. Two fix options:
- **(a)** Change `backtrack` to leave the CP on the stack (standard WAM convention); `TrustMe` is the only thing that pops.
- **(b)** Have `RetryMeElse` re-push the CP after modifying its `CpNextPC`.

Option (a) is closer to standard WAM. Either way it touches the core dispatch semantics and may surface further bugs — worth a separate focused PR.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_