### PR TITLE
fix(wam-fsharp): backtrack keeps CP on stack (Bug B from PR #2350)

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -558,6 +558,18 @@ and backtrack (s: WamState) : WamState option =
         let diff      = s.WsTrailLen - trailLen
         let newEntries= s.WsTrail |> List.take diff |> List.rev
         let restoredBindings = List.fold undoBinding cp.CpBindings newEntries
+        // Bug B fix from PR #2350: keep the CP on the stack.  Standard
+        // WAM convention is that backtrack RESTORES from the top CP
+        // without popping it; only TrustMe pops.  Between successive
+        // backtracks, RetryMeElse modifies the top CP''s CpNextPC to
+        // point to the next clause''s entry — so the CP MUST remain on
+        // the stack for the next-clause logic to work.  Previously
+        // WsCPs was set to `rest` here, popping the CP; that
+        // accidentally worked for chains of length ≤ 2 (the only CP
+        // was needed once) but failed for 3+ when RetryMeElse arrived
+        // at an empty stack.  See PR #2350''s query smoke
+        // `query_X_parent_eve_BUG` for the regression test that
+        // surfaced this.
         Some { s with
                  WsPC       = cp.CpNextPC
                  WsRegs     = cp.CpRegs
@@ -569,8 +581,9 @@ and backtrack (s: WamState) : WamState option =
                  WsHeapLen  = cp.CpHeapLen
                  WsBindings = restoredBindings
                  WsCutBar   = cp.CpCutBar
-                 WsCPs      = rest
-                 WsCPsLen   = s.WsCPsLen - 1 }
+                 // WsCPs intentionally unchanged: keep CP on stack so
+                 // RetryMeElse can modify it (or TrustMe can pop it later).
+               }
 
 and resumeBuiltin (bs: BuiltinState) (cp: ChoicePoint) (rest: ChoicePoint list) (s: WamState) : WamState option =
     match bs with

--- a/tests/fixtures/wam_fsharp_query_smoke/Driver.fs
+++ b/tests/fixtures/wam_fsharp_query_smoke/Driver.fs
@@ -206,21 +206,23 @@ let query_parent_ann_eve () =
     | None ->
         assertTrue "parent(ann, eve) should succeed" false
 
-let query_X_parent_eve_BUG () =
+let query_X_parent_eve () =
     // A1 Unbound, A2 ground.  No indexed dispatch (A1 unbound → falls
-    // through), so we walk the chain.  Match is in clause 3 (X = ann),
-    // but reaching clause 3 needs 2 backtracks — Bug B means the
-    // second backtrack finds an empty CP stack.  Still [KNOWN BUG].
+    // through to the linear chain).  Match is in clause 3 (X = ann),
+    // reached via 2 backtracks: clause 1 (tom, bob) fails on A2,
+    // clause 2 (bob, ann) fails on A2, clause 3 (ann, eve) matches.
+    // Now works after Bug B fix (PR follow-up to #2351): backtrack
+    // keeps the CP on the stack, so RetryMeElse can modify and
+    // TrustMe can pop normally.
     let ctx = mkContext ()
     let s = mkQueryState (Unbound 1000) (Atom "eve") 1001
     match dispatchCall ctx "parent_query_smoke/2" s with
-    | None ->
-        assertTrue "[KNOWN BUG] parent(X, eve): currently None (Bug B — chain pop after 2 backtracks)"
-                   true
     | Some result ->
         let answer = derefVar result.WsBindings result.WsRegs.[1]
-        assertTrue (sprintf "[BUG B FIXED?] parent(X, eve): now returns A1 = %A (was None — update smoke)" answer)
-                   false
+        assertTrue "parent(X, eve): X = Atom \"ann\" (clause 3 via 2 backtracks)"
+                   (answer = Atom "ann")
+    | None ->
+        assertTrue "parent(X, eve) should succeed via clause-3 chain walk" false
 
 [<EntryPoint>]
 let main _argv =
@@ -235,7 +237,7 @@ let main _argv =
     // Currently-broken scenarios (clause 3 unreachable):
     query_parent_ann_X ()
     query_parent_ann_eve ()
-    query_X_parent_eve_BUG ()
+    query_X_parent_eve ()
     let total = passes + fails
     printfn "RESULT %d/%d" passes total
     if fails > 0 then 1 else 0


### PR DESCRIPTION
## Summary

Closes the final multi-clause dispatch bug surfaced by PR #2350's query smoke. After this fix, F# WAM correctly dispatches **ALL** multi-clause queries — ground or unbound first arg, match in any clause — through the standard try/retry/trust chain.

Single commit (`4394834`).

## What Bug B was

The F# `backtrack` popped the choice point from `WsCPs` after restoring from it:

```fsharp
Some { s with ...; WsCPs = rest; WsCPsLen = s.WsCPsLen - 1 }
```

But the F# `RetryMeElse` / `RetryMeElsePc` step arms **modify** the top CP's `CpNextPC` without pushing a new one — they assume the CP is still on the stack. For chains of 3+ clauses, the second backtrack arrived at an **empty stack**, RetryMeElse had nothing to modify, and the chain dead-ended.

**Standard WAM semantics** has `backtrack` restore from the top CP without popping; only `TrustMe` pops. Between successive backtracks `RetryMeElse` just updates the CP's next-clause pointer for the next round.

F# (and Haskell) had `backtrack` popping plus `RetryMeElse` modifying — internally inconsistent.

## Why we hadn't noticed

The inconsistency was masked by an off-by-one in array indexing (Bug A from PR #2350), which sent labels to clause **bodies** instead of `Retry`/`Trust`. After Bug A was fixed in PR #2351, the off-by-one stopped covering for Bug B, and `parent(X, eve)` (clause 3 via 2 backtracks) became reliably broken.

## Fix

`src/unifyweaver/targets/wam_fsharp_target.pl`, `backtrack`:

```diff
 Some { s with
          WsPC       = cp.CpNextPC
          WsRegs     = cp.CpRegs
          ...
-         WsCPs      = rest
-         WsCPsLen   = s.WsCPsLen - 1 }
+         // WsCPs intentionally unchanged: keep CP on stack so
+         // RetryMeElse can modify it (or TrustMe can pop it later).
+       }
```

One-line semantic change. The restored state inherits the CP stack unchanged from `s`, matching standard WAM.

## Why this doesn't break other tests

Three concerns to address:

1. **`backtrackInner` / `finalizeAggregate` paths.** These have their own logic and don't go through the patched code path. Aggregate smokes (`RESULT 81/81`) still pass — confirmed.

2. **`resumeBuiltin` (`FactRetry`/`HopsRetry`/`FFIStreamRetry`/`SelectRetry`) paths.** These also have their own pop/keep logic and bypass the patched code path. Existing builtin tests pass.

3. **Choice-point accumulation.** Could CPs build up over many backtracks? No — `TryMeElse` pushes once per use, `RetryMeElse` modifies top (no push), `TrustMe` pops. Stack size is bounded by live choice points, not by backtrack count.

## Query smoke update

| Scenario | Before | After |
|---|---|---|
| `query_X_parent_eve` | `[KNOWN BUG]` → `None` | `X = Atom "ann"` (clause 3 via 2 backtracks) |

All 10 query scenarios now pass with **zero `[KNOWN BUG]` markers**.

## Verification

- `swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_dotnet_smoke.pl` — **6 / 6 pass**. Query smoke `RESULT 10/10` (all green).
- `swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl` — **64 / 64** (codegen layer unchanged).
- Phase-I lowered runtime smoke: still `RESULT 16/16`.
- Pre-existing interpreter runtime smoke (PR #2347): still `RESULT 81/81` — confirms the change doesn't break aggregate forking, NAF parallel, or any other Par* path.
- `tests/core/test_fsharp_native_lowering.pl` — unchanged.

## Net effect of the 3-PR sequence

Three PRs to fully fix multi-clause dispatch in F# WAM:

| PR | Scope |
|---|---|
| #2350 | Surfaced both bugs via runtime query smoke (`[KNOWN BUG]` markers for 3 scenarios). |
| #2351 | Fixed Bug A (indexed dispatch unreachable) — three coordinated changes (sentinel + `SwitchOnConstantPc` fall-through-on-miss + `Retry`/`Trust` no-op-advance on empty CPs). |
| **this PR** | Fixed Bug B (backtrack-pops vs `RetryMeElse`-modifies-top inconsistency) — single-line change to `backtrack`. |

After this PR the F# WAM correctly executes any standard multi-clause Prolog predicate end-to-end through the runtime. The remaining known follow-up items from the broader F# parity track:

- Race-to-cancel for `runNegationParallel` (needs `CancellationToken` plumbing through `step` — deferred).
- Mirror these dispatch fixes upstream in the Haskell baseline (same `backtrack` pops + `RetryMeElse` modifies-top inconsistency).
- `wam_to_fsharp/2` legacy dead-code cleanup.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_