### PR TITLE
tool(csharp-query): add effective-distance policy review wrapper

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,8 @@ jobs:
           python3 examples/benchmark/refresh_csharp_query_scan_source_mode_calibration.py --dry-run
           python3 -m unittest tests/test_csharp_query_calibration_ci_contract.py
           python3 -m unittest tests/test_csharp_query_policy_report_ci_contract.py
+          python3 -m unittest tests/test_csharp_query_policy_review_wrapper.py
+          python3 examples/benchmark/review_csharp_query_effective_distance_policy.py --dry-run
 
       - name: Generate and run inference test runner
         run: |

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -197,6 +197,19 @@ python examples/benchmark/benchmark_csharp_query_effective_distance_artifact_bac
   --format policy-actionable-markdown
 ```
 
+For scripted policy review, use the wrapper so the summary artifact,
+threshold, fail gate, artifact reuse, and report format stay consistent:
+
+```bash
+python examples/benchmark/review_csharp_query_effective_distance_policy.py \
+  --scales dev \
+  --dry-run
+```
+
+Pass `--summary-input output/csharp-query-effective-distance-policy-summary.tsv`
+to re-render a saved summary without rerunning the benchmark, or
+`--no-fail-on-policy-actions` when you want a report-only invocation.
+
 At the checked-in 300-10k scales this is expected to favor preload or
 mmap-array; LMDB is primarily retained as the larger-data comparison point for
 future 50k+ style runs where memory pressure matters.

--- a/examples/benchmark/review_csharp_query_effective_distance_policy.py
+++ b/examples/benchmark/review_csharp_query_effective_distance_policy.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Run or re-render the C# query effective-distance backend policy review.
+
+This is a thin wrapper around
+benchmark_csharp_query_effective_distance_artifact_backends.py that keeps the
+scripted policy-actionable invocation in one place.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCHMARK_DIR = ROOT / "examples" / "benchmark"
+BENCHMARK_SCRIPT = BENCHMARK_DIR / "benchmark_csharp_query_effective_distance_artifact_backends.py"
+OUTPUT_DIR = ROOT / "output"
+DEFAULT_SUMMARY_OUTPUT = OUTPUT_DIR / "csharp-query-effective-distance-policy-summary.tsv"
+DEFAULT_ARTIFACT_ROOT = OUTPUT_DIR / "csharp-query-effective-distance-artifacts"
+POLICY_FORMATS = (
+    "policy-tsv",
+    "policy-markdown",
+    "policy-compare-tsv",
+    "policy-compare-markdown",
+    "policy-actionable-tsv",
+    "policy-actionable-markdown",
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="dev", help="comma-separated scales for a live benchmark run")
+    parser.add_argument(
+        "--relation",
+        choices=("category_parent", "article_category"),
+        default="category_parent",
+        help="support relation to benchmark during live runs",
+    )
+    parser.add_argument("--lookup-keys", type=int, default=4)
+    parser.add_argument("--lookup-repetitions", type=int, default=1)
+    parser.add_argument("--repetitions", type=int, default=1)
+    parser.add_argument(
+        "--artifact-root",
+        type=Path,
+        default=DEFAULT_ARTIFACT_ROOT,
+        help="persistent artifact directory for live runs",
+    )
+    parser.add_argument(
+        "--summary-output",
+        type=Path,
+        default=DEFAULT_SUMMARY_OUTPUT,
+        help="summary TSV written during live runs",
+    )
+    parser.add_argument(
+        "--summary-input",
+        type=Path,
+        default=None,
+        help="existing summary TSV to render offline instead of running benchmarks",
+    )
+    parser.add_argument(
+        "--format",
+        choices=POLICY_FORMATS,
+        default="policy-actionable-markdown",
+        help="policy report format to render",
+    )
+    parser.add_argument(
+        "--policy-action-threshold",
+        type=float,
+        default=1.10,
+        help="minimum policy-vs-best ratio included by actionable policy reports",
+    )
+    parser.add_argument(
+        "--no-fail-on-policy-actions",
+        action="store_true",
+        help="do not fail when actionable policy rows remain",
+    )
+    parser.add_argument(
+        "--no-require-idle",
+        action="store_true",
+        help="do not pass --require-idle to the underlying live benchmark",
+    )
+    parser.add_argument(
+        "--skip-resource-check",
+        action="store_true",
+        help="forward --skip-resource-check to the underlying live benchmark",
+    )
+    parser.add_argument(
+        "--skip-missing-scales",
+        action="store_true",
+        help="forward --skip-missing-scales to the underlying live benchmark",
+    )
+    parser.add_argument(
+        "--refresh-artifacts",
+        action="store_true",
+        help="rebuild artifacts under --artifact-root instead of reusing manifests",
+    )
+    parser.add_argument(
+        "--no-use-scale-lmdb-artifact",
+        action="store_true",
+        help="do not prefer scale-local LMDB manifests during live runs",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the underlying command without running it",
+    )
+    args = parser.parse_args(argv)
+
+    if args.lookup_keys <= 0:
+        parser.error("--lookup-keys must be positive")
+    if args.lookup_repetitions <= 0:
+        parser.error("--lookup-repetitions must be positive")
+    if args.repetitions <= 0:
+        parser.error("--repetitions must be positive")
+    if args.policy_action_threshold < 1.0:
+        parser.error("--policy-action-threshold must be at least 1.0")
+    if args.summary_input is not None and args.summary_output != DEFAULT_SUMMARY_OUTPUT:
+        parser.error("--summary-output cannot be used with --summary-input")
+    return args
+
+
+def build_review_command(args: argparse.Namespace) -> list[str]:
+    command = [
+        sys.executable,
+        str(BENCHMARK_SCRIPT),
+    ]
+
+    if args.summary_input is not None:
+        command.extend(["--summary-input", str(args.summary_input)])
+    else:
+        command.extend(
+            [
+                "--scales",
+                args.scales,
+                "--relation",
+                args.relation,
+                "--lookup-keys",
+                str(args.lookup_keys),
+                "--lookup-repetitions",
+                str(args.lookup_repetitions),
+                "--repetitions",
+                str(args.repetitions),
+                "--artifact-root",
+                str(args.artifact_root),
+                "--summary-output",
+                str(args.summary_output),
+            ]
+        )
+        if not args.no_require_idle:
+            command.append("--require-idle")
+        if args.skip_resource_check:
+            command.append("--skip-resource-check")
+        if args.skip_missing_scales:
+            command.append("--skip-missing-scales")
+        if args.refresh_artifacts:
+            command.append("--refresh-artifacts")
+        if not args.no_use_scale_lmdb_artifact:
+            command.append("--use-scale-lmdb-artifact")
+
+    command.extend(
+        [
+            "--policy-action-threshold",
+            f"{args.policy_action_threshold:g}",
+            "--format",
+            args.format,
+        ]
+    )
+    if not args.no_fail_on_policy_actions:
+        command.append("--fail-on-policy-actions")
+    return command
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    command = build_review_command(args)
+    if args.dry_run:
+        print(shlex.join(command))
+        return 0
+    return subprocess.run(command, cwd=ROOT).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_csharp_query_policy_report_ci_contract.py
+++ b/tests/test_csharp_query_policy_report_ci_contract.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "examples" / "benchmark" / "benchmark_csharp_query_effective_distance_artifact_backends.py"
+WRAPPER_SCRIPT = ROOT / "examples" / "benchmark" / "review_csharp_query_effective_distance_policy.py"
 SUMMARY_HEADERS = [
     "scale",
     "relation",
@@ -48,6 +49,36 @@ class CSharpQueryPolicyReportCiContractTests(unittest.TestCase):
             "--policy-action-threshold",
             "--fail-on-policy-actions",
             "policy-actionable-markdown",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, result.stdout)
+
+    def test_policy_review_wrapper_is_in_ci_contract(self) -> None:
+        workflow = (ROOT / ".github" / "workflows" / "test.yml").read_text()
+
+        self.assertIn("python3 -m unittest tests/test_csharp_query_policy_review_wrapper.py", workflow)
+        self.assertIn(
+            "python3 examples/benchmark/review_csharp_query_effective_distance_policy.py --dry-run",
+            workflow,
+        )
+
+    def test_policy_review_wrapper_help_exposes_safe_contract(self) -> None:
+        result = subprocess.run(
+            ["python3", str(WRAPPER_SCRIPT), "--help"],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=60,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        for expected in (
+            "--summary-input",
+            "--summary-output",
+            "--policy-action-threshold",
+            "--no-fail-on-policy-actions",
+            "--dry-run",
         ):
             with self.subTest(expected=expected):
                 self.assertIn(expected, result.stdout)

--- a/tests/test_csharp_query_policy_review_wrapper.py
+++ b/tests/test_csharp_query_policy_review_wrapper.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
+
+from review_csharp_query_effective_distance_policy import (  # noqa: E402
+    BENCHMARK_SCRIPT,
+    DEFAULT_ARTIFACT_ROOT,
+    DEFAULT_SUMMARY_OUTPUT,
+    build_review_command,
+    main,
+    parse_args,
+)
+
+
+class CSharpQueryPolicyReviewWrapperTests(unittest.TestCase):
+    def test_default_command_uses_small_guarded_policy_actionable_run(self) -> None:
+        command = build_review_command(parse_args([]))
+
+        self.assertEqual(command[0], sys.executable)
+        self.assertEqual(command[1], str(BENCHMARK_SCRIPT))
+        self.assertEqual(self._option_value(command, "--scales"), "dev")
+        self.assertEqual(self._option_value(command, "--relation"), "category_parent")
+        self.assertEqual(self._option_value(command, "--lookup-keys"), "4")
+        self.assertEqual(self._option_value(command, "--lookup-repetitions"), "1")
+        self.assertEqual(self._option_value(command, "--repetitions"), "1")
+        self.assertEqual(self._option_value(command, "--artifact-root"), str(DEFAULT_ARTIFACT_ROOT))
+        self.assertEqual(self._option_value(command, "--summary-output"), str(DEFAULT_SUMMARY_OUTPUT))
+        self.assertEqual(self._option_value(command, "--policy-action-threshold"), "1.1")
+        self.assertEqual(self._option_value(command, "--format"), "policy-actionable-markdown")
+        self.assertIn("--require-idle", command)
+        self.assertIn("--use-scale-lmdb-artifact", command)
+        self.assertIn("--fail-on-policy-actions", command)
+
+    def test_offline_summary_input_renders_without_live_benchmark_options(self) -> None:
+        summary = ROOT / "output" / "summary.tsv"
+        command = build_review_command(parse_args(["--summary-input", str(summary)]))
+
+        self.assertEqual(self._option_value(command, "--summary-input"), str(summary))
+        self.assertNotIn("--scales", command)
+        self.assertNotIn("--artifact-root", command)
+        self.assertNotIn("--summary-output", command)
+        self.assertNotIn("--require-idle", command)
+        self.assertEqual(self._option_value(command, "--format"), "policy-actionable-markdown")
+        self.assertIn("--fail-on-policy-actions", command)
+
+    def test_live_run_options_are_forwarded(self) -> None:
+        command = build_review_command(
+            parse_args(
+                [
+                    "--scales",
+                    "300,1k",
+                    "--relation",
+                    "article_category",
+                    "--lookup-keys",
+                    "8",
+                    "--lookup-repetitions",
+                    "2",
+                    "--repetitions",
+                    "3",
+                    "--policy-action-threshold",
+                    "1.25",
+                    "--format",
+                    "policy-compare-tsv",
+                    "--no-require-idle",
+                    "--skip-resource-check",
+                    "--skip-missing-scales",
+                    "--refresh-artifacts",
+                    "--no-use-scale-lmdb-artifact",
+                    "--no-fail-on-policy-actions",
+                ]
+            )
+        )
+
+        self.assertEqual(self._option_value(command, "--scales"), "300,1k")
+        self.assertEqual(self._option_value(command, "--relation"), "article_category")
+        self.assertEqual(self._option_value(command, "--lookup-keys"), "8")
+        self.assertEqual(self._option_value(command, "--lookup-repetitions"), "2")
+        self.assertEqual(self._option_value(command, "--repetitions"), "3")
+        self.assertEqual(self._option_value(command, "--policy-action-threshold"), "1.25")
+        self.assertEqual(self._option_value(command, "--format"), "policy-compare-tsv")
+        self.assertIn("--skip-resource-check", command)
+        self.assertIn("--skip-missing-scales", command)
+        self.assertIn("--refresh-artifacts", command)
+        self.assertNotIn("--require-idle", command)
+        self.assertNotIn("--use-scale-lmdb-artifact", command)
+        self.assertNotIn("--fail-on-policy-actions", command)
+
+    def test_summary_input_rejects_custom_summary_output(self) -> None:
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit):
+                parse_args(
+                    [
+                        "--summary-input",
+                        "output/summary.tsv",
+                        "--summary-output",
+                        "output/other.tsv",
+                    ]
+                )
+
+        self.assertIn("--summary-output cannot be used with --summary-input", stderr.getvalue())
+
+    def test_dry_run_prints_command_without_running(self) -> None:
+        stdout = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout):
+            result = main(["--dry-run", "--no-require-idle"])
+
+        self.assertEqual(result, 0)
+        output = stdout.getvalue()
+        self.assertIn(str(BENCHMARK_SCRIPT), output)
+        self.assertIn("--summary-output", output)
+        self.assertIn("--policy-action-threshold 1.1", output)
+        self.assertIn("--format policy-actionable-markdown", output)
+
+    @staticmethod
+    def _option_value(command: list[str], option: str) -> str:
+        return command[command.index(option) + 1]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  - Add `review_csharp_query_effective_distance_policy.py` as a stable wrapper around the C# query effective-distance artifact
  backend policy report.
  - Default the wrapper to a small guarded `policy-actionable-markdown` run with summary output, artifact reuse, thresholding,
  and fail-on-action behavior.
  - Support offline `--summary-input` rendering so saved summary TSVs can be reviewed without rerunning benchmarks.
  - Add wrapper unit tests, CI dry-run coverage, and README usage notes.

  ## Verification

  - `python3 -m unittest tests/test_csharp_query_policy_review_wrapper.py tests/
  test_csharp_query_policy_report_ci_contract.py`
  - `python3 examples/benchmark/review_csharp_query_effective_distance_policy.py --dry-run`
  - `python3 -m py_compile examples/benchmark/review_csharp_query_effective_distance_policy.py tests/
  test_csharp_query_policy_review_wrapper.py tests/test_csharp_query_policy_report_ci_contract.py`
  - `git diff --check`
  - `python3 -m unittest tests/test_csharp_query_effective_distance_artifact_backends.py tests/
  test_csharp_query_policy_review_wrapper.py tests/test_csharp_query_policy_report_ci_contract.py tests/
  test_csharp_query_calibration_ci_contract.py`