### PR TITLE
fix(wam-fsharp): category-ancestor register layout + wire F# WAM tests into runner

### DIFF
--- a/run_all_tests.pl
+++ b/run_all_tests.pl
@@ -13,9 +13,42 @@
 :- use_module(library(test_csharp_query_target)).
 :- use_module(library(test_common_generator)).
 :- use_module(library(test_cross_generator)).
+:- use_module(library(process)).
+
+%% The F# WAM target tests use `:- initialization(run_tests, main)` +
+%% `halt(0/1)` and so can't be loaded as control-plane modules.  Spawn
+%% the aggregate runner as a subprocess; it returns 0 iff every F# WAM
+%% test exits 0.  The dotnet smokes inside it skip gracefully when
+%% `dotnet` isn't on PATH.  A non-zero status fails the whole suite.
+run_wam_fsharp_suite :-
+    writeln('--- F# WAM target suite (subprocess) ---'),
+    catch(
+        (   process_create(path(swipl),
+                ['-q', '-g', 'main', '-t', 'halt',
+                 'tests/run_wam_fsharp_tests.pl'],
+                [stdout(std), stderr(std), process(Pid)]),
+            process_wait(Pid, exit(EC))
+        ),
+        Err,
+        (   format('  [orchestrator spawn failed] ~q~n', [Err]),
+            EC = 99
+        )),
+    (   EC == 0
+    ->  writeln('--- F# WAM target suite: OK ---')
+    ;   format('--- F# WAM target suite: FAILED (exit ~w) ---~n', [EC]),
+        fail
+    ).
 
 main :-
     writeln('--- Starting Control Plane Test Suite ---'),
+    %% run_wam_fsharp_suite runs FIRST.  Downstream tests
+    %% (test_compiler_driver in particular) call halt/1 on failure,
+    %% which exits the whole swipl process before later steps can
+    %% run.  Spawning the F# WAM suite up front guarantees it
+    %% executes regardless of what halts later.  The F# suite itself
+    %% is subprocessed, so a failure there returns control to main/0
+    %% rather than aborting.
+    run_wam_fsharp_suite,
     test_policy,
     test_compiler_driver,
     test_recursive_constraints,

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -3240,9 +3240,25 @@ let main argv =
         for cat in seedCats do
             let varId = 1000000
             let regs = Array.create MaxRegs (Unbound -1)
-            regs.[1] <- Atom cat
-            regs.[2] <- Atom root
-            regs.[3] <- Unbound varId
+            // Register layout depends on which queryPred resolved.  The /3
+            // candidates are lowered aggregate variants whose semantics fold
+            // a target root into the call shape, so A2 is the root and A3
+            // accumulates the result.  The /4 variant is the raw
+            // category_ancestor(+Cat, -Ancestor, -Hops, +Visited) — A2 and
+            // A3 are outputs (Unbound), and A4 must be a list-valued input
+            // seeded with [Cat] so that the cycle-detection guard (negation
+            // over member/2) sees a real list rather than an unbound
+            // variable.  Without the seeded A4 the predicate fails
+            // unconditionally and the benchmark reports solutions=0.
+            if queryPred.EndsWith "/4" then
+                regs.[1] <- Atom cat
+                regs.[2] <- Unbound varId
+                regs.[3] <- Unbound (varId + 1)
+                regs.[4] <- VList [ Atom cat ]
+            else
+                regs.[1] <- Atom cat
+                regs.[2] <- Atom root
+                regs.[3] <- Unbound varId
             let s0 = { emptyState with WsPC = 0; WsRegs = regs; WsCP = 0 }
             match dispatchCall ctx queryPred s0 with
             | Some s1 ->

--- a/tests/core/test_wam_fsharp_dotnet_smoke.pl
+++ b/tests/core/test_wam_fsharp_dotnet_smoke.pl
@@ -546,21 +546,23 @@ test_dotnet_run_query_smoke :-
 %% via write_wam_fsharp_project/3, build, then run the auto-generated
 %% Program.fs against the dev fixture's TSV files.
 %%
-%% The auto-generated Program.fs is a category-ancestor benchmark driver
-%% with hard-coded query semantics — it passes (Cat, Root, Distance) as
-%% A1/A2/A3.  The effective_distance.pl category_ancestor/4 signature is
-%% (+Cat, -Ancestor, -Hops, +Visited), so the driver's args don't match
-%% the predicate's expected output mode — solutions=0 is the expected
-%% outcome.  This is fine for our purpose: we're proving the PIPELINE
-%% works, not validating Prolog semantics for this specific query.
+%% The auto-generated Program.fs sets up registers based on the
+%% resolved queryPred''s arity — /4 (the raw category_ancestor) uses
+%% A1=Cat, A2=Unbound, A3=Unbound, A4=VList [Atom cat] (seeded visited
+%% list for the cycle-detection guard); /3 (the lowered aggregate
+%% variants) uses A1=Cat, A2=Atom root, A3=Unbound.  Without the
+%% arity-aware register layout the /4 path produced solutions=0 because
+%% the cycle-detection guard never matched against an unbound A4.
 %%
 %% Assertions:
 %%   - Build succeeds.
 %%   - dotnet run exits 0.
-%%   - stdout contains "total_ms=" (the driver's summary line).
-%%   - stdout contains "RESULT 0/0" not asserted — the driver doesn't
-%%     emit RESULT lines.  We parse out total_ms instead for the smoke
-%%     output.
+%%   - stdout contains "total_ms=" (the driver''s summary line).
+%%   - stderr "rep=N ... solutions=N" reports solutions > 0 — the dev
+%%     fixture has 21 seed categories and every one of them has at
+%%     least one ancestor in the dev category-parent table, so
+%%     solutions = seeds.  We require solutions >= 1 (not exact) so
+%%     the assertion survives minor fixture changes.
 
 bench_dataset_dir(Dir) :-
     repo_root_for_smoke(Root),
@@ -607,6 +609,23 @@ parse_total_ms(Output, Ms) :-
     split_string(Rest, " \t\r", "", [MsStr|_]),
     number_string(Ms, MsStr), !.
 
+%% Parse the last `solutions=N` field from the benchmark output (the
+%% summary line on stdout — `rep=N ... solutions=N` per-rep lines go to
+%% stderr, but our `run_dotnet_run_with_args` concatenates both).
+parse_solutions(Output, N) :-
+    split_string(Output, "\n", "", Lines),
+    findall(K,
+        ( member(Line, Lines),
+          sub_string(Line, B, _, _, "solutions="),
+          B0 is B + 10,
+          sub_string(Line, B0, _, 0, Rest),
+          split_string(Rest, " \t\r", "", [NStr|_]),
+          number_string(K, NStr)
+        ),
+        All),
+    All \== [],
+    last(All, N).
+
 test_dotnet_run_category_ancestor_bench :-
     Test = 'WAM-FSharp dotnet: category-ancestor end-to-end benchmark',
     smoke_root(Root),
@@ -646,9 +665,15 @@ test_dotnet_run_category_ancestor_bench :-
     run_dotnet_run_with_args(Dir, [BenchDir, '3'], RunExit, RunOutput),
     (   RunExit == 0,
         parse_total_ms(RunOutput, Ms)
-    ->  format('  total_ms=~w (dev fixture, 3 reps)~n', [Ms]),
-        pass(Test),
-        maybe_clean(Dir)
+    ->  (   parse_solutions(RunOutput, Solutions), Solutions >= 1
+        ->  format('  total_ms=~w solutions=~w (dev fixture, 3 reps)~n',
+                   [Ms, Solutions]),
+            pass(Test),
+            maybe_clean(Dir)
+        ;   format('---- dotnet run output ----~n~w~n----~n', [RunOutput]),
+            fail_test(Test,
+                'category-ancestor run produced solutions=0 (expected >= 1; register layout regression?)')
+        )
     ;   format('---- dotnet run output ----~n~w~n----~n', [RunOutput]),
         fail_test(Test,
             format_atom('category-ancestor run failed: exit ~w', [RunExit]))

--- a/tests/run_wam_fsharp_tests.pl
+++ b/tests/run_wam_fsharp_tests.pl
@@ -1,0 +1,83 @@
+:- encoding(utf8).
+%% run_wam_fsharp_tests.pl — aggregate runner for the F# WAM target tests.
+%%
+%% Each F# WAM test file uses `:- initialization(run_tests, main)` and
+%% `halt(0/1)` on completion, so they can't be `use_module`'d in-process.
+%% This script spawns each as a subprocess and aggregates pass/fail.
+%%
+%% Tests run:
+%%   tests/test_wam_fsharp_target.pl
+%%     - Source-level codegen assertions.  Runs everywhere swipl is
+%%       available; no external toolchain required.
+%%   tests/core/test_wam_fsharp_dotnet_smoke.pl
+%%     - dotnet build + run smokes (8 cases including category-ancestor
+%%       end-to-end + NAF micro-benchmark).  Each sub-case skips
+%%       gracefully if `dotnet` isn't on PATH.
+%%
+%% Exit code: 0 iff every spawned test exits 0.
+%%
+%% Usage:
+%%   swipl -q -g main -t halt tests/run_wam_fsharp_tests.pl
+%%
+%% Invoked indirectly by the top-level run_all_tests.pl runner.
+
+:- use_module(library(process)).
+
+repo_root(Root) :-
+    source_file(repo_root(_), This),
+    file_directory_name(This, TestsDir),
+    file_directory_name(TestsDir, Root).
+
+%% (RelativePath, HumanLabel).  Order matters — codegen first (fast),
+%% then dotnet smokes (slower, may skip on toolchain-less machines).
+fsharp_test('tests/test_wam_fsharp_target.pl',
+            'F# WAM codegen tests').
+fsharp_test('tests/core/test_wam_fsharp_dotnet_smoke.pl',
+            'F# WAM dotnet runtime smoke').
+
+run_one(RelPath, Label, Status) :-
+    repo_root(Root),
+    atom_concat(Root, '/', Root1),
+    atom_concat(Root1, RelPath, AbsPath),
+    format('~n──── ~w ────~n', [Label]),
+    format('     ~w~n', [RelPath]),
+    catch(
+        (   process_create(path(swipl),
+                ['-q', '-g', 'run_tests', '-t', 'halt', AbsPath],
+                [stdout(std), stderr(std), process(Pid)]),
+            process_wait(Pid, exit(EC))
+        ),
+        Err,
+        (   format('     [orchestrator error] ~q~n', [Err]),
+            EC = 99
+        )),
+    (   EC == 0
+    ->  Status = pass,
+        format('[orchestrator PASS] ~w (exit=0)~n', [Label])
+    ;   Status = fail(EC),
+        format('[orchestrator FAIL] ~w (exit=~w)~n', [Label, EC])
+    ).
+
+main :-
+    format('~n========================================~n', []),
+    format('F# WAM target test suite~n', []),
+    format('========================================~n', []),
+    findall(P-L, fsharp_test(P, L), Tests),
+    length(Tests, Total),
+    run_all(Tests, [], Results),
+    summarize(Results, Total).
+
+run_all([], Acc, Reversed) :-
+    reverse(Acc, Reversed).
+run_all([P-L|Rest], Acc, Out) :-
+    run_one(P, L, Status),
+    run_all(Rest, [Status|Acc], Out).
+
+summarize(Results, Total) :-
+    include(==(pass), Results, Passes),
+    length(Passes, OK),
+    Fails is Total - OK,
+    format('~n========================================~n', []),
+    format('F# WAM suite: ~w/~w passed (~w failed)~n', [OK, Total, Fails]),
+    format('========================================~n', []),
+    (   OK =:= Total -> halt(0) ; halt(1) ).


### PR DESCRIPTION
## Summary

Two follow-ups from the F# parity track (#3 and #1 from the post-PR-#2357 backlog), on a single branch as requested.

### #3 — Category-ancestor benchmark now reports real solutions

The auto-generated `Program.fs` in `write_wam_fsharp_project` hard-coded a 3-argument register setup (`A1=Cat`, `A2=Atom root`, `A3=Unbound`). When the resolved `queryPred` is the raw `category_ancestor/4` (because no lowered aggregate variants are compiled in this benchmark), the predicate signature is `(+Cat, -Ancestor, -Hops, +Visited)`, so:

- `A2` was bound to the root atom instead of left `Unbound`, blocking the output-mode `-Ancestor`.
- `A4` (`Visited`) was missing entirely — the cycle-detection guard inside the clauses needs a real list to walk, so every call failed.

**Before fix:** `solutions=0` on every rep — acknowledged in the prior smoke comment as "the expected outcome, we're proving the PIPELINE works."

**After fix:** `solutions=21` on the dev fixture (every one of 21 seed categories has at least one ancestor).

The fix branches the register setup on `queryPred.EndsWith "/4"`. For `/4`, sets `A2 = Unbound`, `A3 = Unbound`, `A4 = VList [Atom cat]` (seeded visited list with the start node). For `/3`, keeps the prior layout intact.

Smoke test (`test_dotnet_run_category_ancestor_bench`) updated to parse `solutions=N` and assert `N >= 1`. Previously only asserted that the build + run completed without crashing.

### #1 — F# WAM tests now run from `run_all_tests.pl`

`run_all_tests.pl` did not include the F# WAM tests — they ran only as standalone `swipl -g run_tests -t halt <file>` invocations.

New `tests/run_wam_fsharp_tests.pl` is an aggregate runner that subprocesses every F# WAM test file and reports a pass/fail summary. Currently covers:

- `tests/test_wam_fsharp_target.pl` (codegen tests, runs everywhere)
- `tests/core/test_wam_fsharp_dotnet_smoke.pl` (dotnet runtime smokes, skips gracefully without `dotnet`)

Each F# WAM test uses `:- initialization(run_tests, main)` + `halt`, so they can't be `use_module`'d in-process — subprocessing is the correct integration shape.

`run_all_tests.pl` now spawns this aggregate runner as its **first** step. Going-first matters: downstream tests (`test_compiler_driver` in particular) call `halt(1)` on internal failures, which exits the whole `swipl` process and prevents any later step from running. Spawning the F# WAM suite up front guarantees it executes regardless. The F# suite itself is subprocessed, so its own failures return control to `main/0` rather than aborting.

## Test plan

- [x] `swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl` — all codegen tests pass
- [x] `swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_dotnet_smoke.pl` — all 8 smokes pass, category-ancestor reports `solutions=21`
- [x] `swipl -q -g main -t halt tests/run_wam_fsharp_tests.pl` — 2/2 passed
- [x] `swipl -q -g main -t halt run_all_tests.pl` — F# WAM suite executes first, reports `F# WAM suite: 2/2 passed`, then control flows to existing tests (pre-existing `test_compiler_driver` bash-script failure halts the process — out of scope here)

## Context

This closes the post-#2357 follow-up list:

- ✅ #1 (this PR) — wire F# WAM tests into `run_all_tests.pl`
- ✅ #2 (PR #2356) — mirror F# Bug A dispatch fixes to Haskell
- ✅ #3 (this PR) — fix category-ancestor signature mismatch
- ✅ #4 (PR #2357) — Haskell GHC runtime smoke for the dispatch fixes

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_