### PR TITLE
fix(template-system): render check_body before nested placeholder keys

### DIFF
--- a/src/unifyweaver/core/template_system.pl
+++ b/src/unifyweaver/core/template_system.pl
@@ -694,13 +694,24 @@ generate_transitive_closure(PredName, BaseName, Options, Code) :-
     fi
 }',
 
+    % NOTE on key order: `check_body` is a string built above that
+    % itself contains `{{pred}}` and `{{tmp_suffix}}` placeholders.
+    % render_template_string/3 is a single-pass iterator over this
+    % dict — once a key is substituted, its inserted content is not
+    % re-scanned for later keys.  Keeping `check_body` FIRST means the
+    % inner placeholders it introduces are still present when `pred`
+    % and `tmp_suffix` come around in the same pass.  Without this
+    % ordering the generated `_check()` body literally calls
+    % `{{pred}}_all` and creates `/tmp/{{pred}}_found_{{tmp_suffix}}`,
+    % causing tests/core/test_compiler_driver.pl to fail because the
+    % generated bash script bombs out at `{{pred}}_all`.
     render_template(Template, [
+        check_body = CheckBody,
         pred = PredStr,
         base = BaseStr,
         strategy = Strategy,
         tmp_suffix = TempSuffixStr,
-        trap_signals = TrapSignalsStr,
-        check_body = CheckBody
+        trap_signals = TrapSignalsStr
     ], Code).
 
 %% Deduplication wrapper template


### PR DESCRIPTION
## Summary

Fixes the `test_compiler_driver` `halt(1)` that PR #2360's test plan flagged as out-of-scope. Root cause was a single-pass-substitution bug in the Mustache-style template renderer.

## What was wrong

`generate_transitive_closure/4` builds a `CheckBody` string from the shell capabilities (`no_processes` vs default) that itself contains nested `{{pred}}` and `{{tmp_suffix}}` placeholders:

```prolog
CheckBody = '
    local tmpflag="/tmp/{{pred}}_found_{{tmp_suffix}}"
    {{pred}}_all "$start" 2>/dev/null | ...
```

When this was passed to `render_template/3` alongside `pred`, `tmp_suffix`, etc., the substitution order mattered. `render_template_string/3` is a single-pass iterator that does **not** re-scan inserted content for later keys. Previously `check_body` was the **last** entry in the dict, so by the time it was substituted in, the iterator had already moved past `pred` and `tmp_suffix` — leaving the inner placeholders intact.

The resulting `ancestor.sh` contained:

```bash
ancestor_check() {
    local tmpflag="/tmp/{{pred}}_found_{{tmp_suffix}}"
    {{pred}}_all "$start" 2>/dev/null | ...
}
```

When sourced and executed by the test runner this bombed out with `command not found: {{pred}}_all` → bash exit 1. `tests/core/test_compiler_driver.pl` propagated that as `halt(1)`, which terminated `run_all_tests.pl` mid-suite (the failure noted in PR #2360's test plan as out-of-scope).

## Fix

Reorder the dict so `check_body` is the **first** key. The `CheckBody` string's `{{pred}}` and `{{tmp_suffix}}` placeholders are then still present in the template when the subsequent passes for those keys run, and they get substituted normally. Added a comment at the call site explaining why the key order matters.

## Test plan

- [x] `tests/core/test_compiler_driver.pl` in isolation: both `PASS` lines appear, exit 0.
- [x] Regenerated `output/core_tests/ancestor.sh`: `_check()` body now contains fully-resolved `ancestor_all` and `/tmp/ancestor_found_$$` — no more `{{...}}` literals.
- [x] Generated bash test runner executes cleanly: `ancestor a c` succeeds, `! ancestor d a` succeeds.

## Still failing downstream (out of scope)

`run_all_tests.pl` still exits non-zero after this fix because `test_recursive_constraints` hits a **separate** issue:

> Its test predicates are written as `(RecCall, BaseCall)` but `is_transitive_closure/5` in `recursive_compiler.pl` only matches `(BaseCall, RecCall)`, so the predicate is classified as `linear_recursion` — which has no bash backend.

That's a different root cause: either the classifier should accept both goal orders, or the test should be re-phrased. Filed for follow-up.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_