### PR TITLE
fix(classifier): accept left-recursive transitive-closure ordering + fix no_dedup format args

### DIFF
--- a/src/unifyweaver/core/compiler_driver.pl
+++ b/src/unifyweaver/core/compiler_driver.pl
@@ -175,9 +175,21 @@ is_recursive_clause(Pred, Body) :-
     functor(Goal, Pred, _).
 
 %% Check for transitive closure pattern
-% Two patterns supported:
-% 1. Forward: pred(X,Z) :- base(X,Y), pred(Y,Z).  [e.g., ancestor]
-% 2. Reverse: pred(X,Z) :- base(Y,X), pred(Y,Z).  [e.g., descendant]
+% Four patterns supported, distinguished by goal order in the body
+% (right- vs left-recursive) and by the direction the linkage variable
+% flows between the base and recursive calls.
+%
+% Right-recursive (base goal first, recursive second):
+%   1. Forward:  pred(X,Z) :- base(X,Y), pred(Y,Z).   [e.g. ancestor]
+%   2. Reverse:  pred(X,Z) :- base(Y,X), pred(Y,Z).   [e.g. descendant]
+%
+% Left-recursive (recursive goal first, base second) — semantically
+% equivalent for transitive closure, and the bash BFS compiler
+% doesn't care about goal order:
+%   3. Forward:  pred(X,Z) :- pred(X,Y), base(Y,Z).
+%   4. Reverse:  pred(X,Z) :- pred(X,Y), base(Z,Y).
+%
+% Mirrors the same logic in recursive_compiler.pl:is_transitive_closure/5.
 is_transitive_closure(Pred, 2, BaseClauses, RecClauses, BasePred) :-
     % Check base case is a single predicate call
     member(BaseBody, BaseClauses),
@@ -187,21 +199,36 @@ is_transitive_closure(Pred, 2, BaseClauses, RecClauses, BasePred) :-
 
     % Check recursive case matches pattern
     member(RecBody, RecClauses),
-    RecBody = (BaseCall, RecCall),
-    functor(BaseCall, BasePred, 2),
-    functor(RecCall, Pred, 2),
+    RecBody = (G1, G2),
 
-    % Try both forward and reverse patterns
-    (   % Pattern 1: Forward transitive closure
-        % base(X,Y), recursive(Y,Z) - Y flows from base to recursive
-        BaseCall =.. [BasePred, _X, Y],
-        RecCall =.. [Pred, Y2, _Z],
-        Y == Y2
-    ;   % Pattern 2: Reverse transitive closure
-        % base(Y,X), recursive(Y,Z) - Y flows from base to recursive (reversed args)
-        BaseCall =.. [BasePred, Y, _X],
-        RecCall =.. [Pred, Y2, _Z],
-        Y == Y2
+    % Identify ordering: which body goal is the base call and which is
+    % the recursive call.  Both orderings are accepted.
+    (   functor(G1, BasePred, 2),
+        functor(G2, Pred, 2)
+    ->  % Right-recursive ordering: BaseCall, RecCall
+        BaseCall = G1, RecCall = G2,
+        (   % Pattern 1: Forward — base(X,Y), rec(Y,Z)
+            BaseCall =.. [BasePred, _X, Y],
+            RecCall =.. [Pred, Y2, _Z],
+            Y == Y2
+        ;   % Pattern 2: Reverse — base(Y,X), rec(Y,Z)
+            BaseCall =.. [BasePred, Y, _X],
+            RecCall =.. [Pred, Y2, _Z],
+            Y == Y2
+        )
+    ;   functor(G1, Pred, 2),
+        functor(G2, BasePred, 2)
+    ->  % Left-recursive ordering: RecCall, BaseCall
+        RecCall = G1, BaseCall = G2,
+        (   % Pattern 3: Forward — rec(X,Y), base(Y,Z)
+            RecCall =.. [Pred, _X, Y],
+            BaseCall =.. [BasePred, Y2, _Z],
+            Y == Y2
+        ;   % Pattern 4: Reverse — rec(X,Y), base(Z,Y)
+            RecCall =.. [Pred, _X, Y],
+            BaseCall =.. [BasePred, _Z, Y2],
+            Y == Y2
+        )
     ).
 
 is_transitive_closure(_, _, _, _, _) :- fail.

--- a/src/unifyweaver/core/recursive_compiler.pl
+++ b/src/unifyweaver/core/recursive_compiler.pl
@@ -345,9 +345,24 @@ is_recursive_clause(Pred, Body) :-
     functor(Goal, Pred, _).
 
 %% Check for transitive closure pattern
-% Two patterns supported:
-% 1. Forward: pred(X,Z) :- base(X,Y), pred(Y,Z).  [e.g., ancestor]
-% 2. Reverse: pred(X,Z) :- base(Y,X), pred(Y,Z).  [e.g., descendant]
+% Four patterns supported, distinguished by goal order in the body
+% (right- vs left-recursive) and by the direction the linkage variable
+% flows between the base and recursive calls.
+%
+% Right-recursive (base goal first, recursive second):
+%   1. Forward:  pred(X,Z) :- base(X,Y), pred(Y,Z).   [e.g. ancestor]
+%   2. Reverse:  pred(X,Z) :- base(Y,X), pred(Y,Z).   [e.g. descendant]
+%
+% Left-recursive (recursive goal first, base second) — semantically
+% equivalent for transitive closure, and the bash BFS compiler
+% doesn''t care about goal order:
+%   3. Forward:  pred(X,Z) :- pred(X,Y), base(Y,Z).
+%   4. Reverse:  pred(X,Z) :- pred(X,Y), base(Z,Y).
+%
+% Without patterns 3-4 the classifier fell through to linear_recursion
+% (which has no bash backend) on naturally-phrased predicates like
+% tests/core/test_recursive_constraints.pl''s test_rec_default/2 —
+% halting run_all_tests.pl mid-suite.
 is_transitive_closure(Pred, 2, BaseClauses, RecClauses, BasePred) :-
     % Check base case is a single predicate call
     member(BaseBody, BaseClauses),
@@ -357,21 +372,36 @@ is_transitive_closure(Pred, 2, BaseClauses, RecClauses, BasePred) :-
 
     % Check recursive case matches pattern
     member(RecBody, RecClauses),
-    RecBody = (BaseCall, RecCall),
-    functor(BaseCall, BasePred, 2),
-    functor(RecCall, Pred, 2),
+    RecBody = (G1, G2),
 
-    % Try both forward and reverse patterns
-    (   % Pattern 1: Forward transitive closure
-        % base(X,Y), recursive(Y,Z) - Y flows from base to recursive
-        BaseCall =.. [BasePred, _X, Y],
-        RecCall =.. [Pred, Y2, _Z],
-        Y == Y2
-    ;   % Pattern 2: Reverse transitive closure
-        % base(Y,X), recursive(Y,Z) - Y flows from base to recursive (reversed args)
-        BaseCall =.. [BasePred, Y, _X],
-        RecCall =.. [Pred, Y2, _Z],
-        Y == Y2
+    % Identify ordering: which body goal is the base call and which is
+    % the recursive call.  Both orderings are accepted.
+    (   functor(G1, BasePred, 2),
+        functor(G2, Pred, 2)
+    ->  % Right-recursive ordering: BaseCall, RecCall
+        BaseCall = G1, RecCall = G2,
+        (   % Pattern 1: Forward — base(X,Y), rec(Y,Z)
+            BaseCall =.. [BasePred, _X, Y],
+            RecCall =.. [Pred, Y2, _Z],
+            Y == Y2
+        ;   % Pattern 2: Reverse — base(Y,X), rec(Y,Z)
+            BaseCall =.. [BasePred, Y, _X],
+            RecCall =.. [Pred, Y2, _Z],
+            Y == Y2
+        )
+    ;   functor(G1, Pred, 2),
+        functor(G2, BasePred, 2)
+    ->  % Left-recursive ordering: RecCall, BaseCall
+        RecCall = G1, BaseCall = G2,
+        (   % Pattern 3: Forward — rec(X,Y), base(Y,Z)
+            RecCall =.. [Pred, _X, Y],
+            BaseCall =.. [BasePred, Y2, _Z],
+            Y == Y2
+        ;   % Pattern 4: Reverse — rec(X,Y), base(Z,Y)
+            RecCall =.. [Pred, _X, Y],
+            BaseCall =.. [BasePred, _Z, Y2],
+            Y == Y2
+        )
     ).
 
 is_transitive_closure(_, _, _, _, _) :- fail.

--- a/src/unifyweaver/core/stream_compiler.pl
+++ b/src/unifyweaver/core/stream_compiler.pl
@@ -180,7 +180,10 @@ compile_facts_no_dedup(_Pred, Arity, Facts, PredStr, BashCode) :-
             '~s_stream'
         ],
         atomic_list_concat(Template, '\n', TemplateStr),
-        format(string(BashCode), TemplateStr, [PredStr, PredStr, EntriesStr, PredStr, PredStr, PredStr, PredStr])
+        % 8 ~s placeholders: comment, data-array decl, entries, fn name,
+        % array-ref in lookup loop, stream-fn name, array-ref in stream
+        % loop, and the trailing direct invocation of <pred>_stream.
+        format(string(BashCode), TemplateStr, [PredStr, PredStr, EntriesStr, PredStr, PredStr, PredStr, PredStr, PredStr])
     ;   Arity = 2 ->
         Template = [
             '#!/bin/bash',
@@ -217,7 +220,12 @@ compile_facts_no_dedup(_Pred, Arity, Facts, PredStr, BashCode) :-
             '~s_stream'
         ],
         atomic_list_concat(Template, '\n', TemplateStr),
-        format(string(BashCode), TemplateStr, [PredStr, PredStr, EntriesStr, PredStr, PredStr, PredStr, PredStr, PredStr, PredStr, PredStr])
+        % 11 ~s placeholders: comment, data-array decl, entries, fn name,
+        % array-ref in $2-branch, array-ref in else-branch, stream-fn
+        % name, array-ref in stream-fn, reverse-stream-fn name,
+        % array-ref in reverse-stream-fn, and the trailing direct
+        % invocation of <pred>_stream.
+        format(string(BashCode), TemplateStr, [PredStr, PredStr, EntriesStr, PredStr, PredStr, PredStr, PredStr, PredStr, PredStr, PredStr, PredStr])
     ;   % For higher arities, use a generic approach
         Template = [
             '#!/bin/bash',


### PR DESCRIPTION
## Summary

Extends `is_transitive_closure/5` to recognize the natural left-recursive phrasing of transitive closure, plus an off-by-one `format/3` arg fix in `compile_facts_no_dedup/5` that was masking success on the same test path. Together these get `run_all_tests.pl` past `test_recursive_constraints` (the gap left by PR #2361).

## Classifier: left-recursive transitive closure now recognized

The existing classifier only matched two right-recursive forms:

```prolog
pred(X,Z) :- base(X,Y), pred(Y,Z).   % Forward (e.g. ancestor)
pred(X,Z) :- base(Y,X), pred(Y,Z).   % Reverse (e.g. descendant)
```

But Prolog programmers naturally write the equivalent left-recursive forms too:

```prolog
pred(X,Z) :- pred(X,Y), base(Y,Z).   % Forward
pred(X,Z) :- pred(X,Y), base(Z,Y).   % Reverse
```

Semantically these encode the same transitive closure, and the bash BFS compiler doesn't care about goal order. Previously they fell through to `is_linear_recursive/2`, which has no bash `compile_linear_pattern/8` — causing `test_rec_default/2` in `tests/core/test_recursive_constraints.pl` (a left-recursive forward closure) to crash `run_all_tests.pl` with `Error: No linear recursion support for target bash`.

**Fix:** identify which body goal is the base call vs the recursive call by checking the functor (instead of assuming positional ordering), then check the linkage variable in both possible arg-flow directions. Applied identically to both copies of `is_transitive_closure/5` in `compiler_driver.pl` and `recursive_compiler.pl` (they're duplicated in the codebase).

## stream_compiler: off-by-one `format/3` args in `compile_facts_no_dedup`

While verifying the classifier fix, hit a second bug. `compile_facts_no_dedup/5` emits a bash script with a trailing `<pred>_stream` invocation (so the script does something useful when sourced). Both the `Arity=1` and `Arity=2` branches had 8 and 11 `~s` placeholders respectively but only 7 and 10 args in their `format/3` calls — the trailing invocation's `~s` had no corresponding `PredStr`, triggering `format/3: Format error: not enough arguments` at codegen time.

This path is only hit when the predicate has `unique(false)` set (no deduplication), which is rare — that's why the bug had been latent. Added the missing `PredStr` to both calls and a comment counting the placeholders explicitly.

## Test plan

- [x] `swipl -q -g main -t halt run_all_tests.pl` now passes the `test_compiler_driver` + `test_recursive_constraints` block (previously halted at `linear_recursion / no bash backend`). Next failing test downstream is the unrelated `test_recursive_csharp_target` (C# target doesn't handle non-recursive predicates) — out of scope here.
- [x] `swipl -q -g run_tests -t halt tests/test_wam_haskell_target.pl` — all tests pass (classifier-dependent codegen still works).
- [x] `swipl -q -g run_tests -t halt tests/test_wam_rust_target.pl` — all tests pass.
- [x] `test_wam_c_target` failure is pre-existing on `main` (unrelated `switch_on_constant_fallthrough` instruction gap).

## Continuation of

PR #2361 fixed the original `test_compiler_driver` `halt(1)` (template-renderer single-pass substitution). This PR closes the next failure surface in `run_all_tests.pl`.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_