### PR TITLE
fix(csharp-dispatch): unify non-recursive csharp through query-plan backend

### DIFF
--- a/src/unifyweaver/core/recursive_compiler.pl
+++ b/src/unifyweaver/core/recursive_compiler.pl
@@ -125,13 +125,19 @@ compile_dispatch(Pred/Arity, FinalOptions, Target, GeneratedCode) :-
     ),
     format('Classification: ~w~n', [Classification]),
 
-    (   Classification = non_recursive ->
-        compile_non_recursive(Target, Pred/Arity, FinalOptions, GeneratedCode)
-    ;   Target == csharp ->
+    (   Target == csharp ->
+        % Unified csharp dispatch: query-plan backend by default,
+        % procedural opt-in via mode(procedural).  Hoisted above the
+        % non_recursive branch so simple fact predicates still get
+        % the query-plan form (RelationScanNode etc.) instead of
+        % falling through to procedural — matching the dispatch the
+        % test_recursive_csharp_target tests assume.
         (   option(mode(procedural), FinalOptions) ->
             csharp_native_target:compile_predicate_to_csharp(Pred/Arity, FinalOptions, GeneratedCode)
         ;   compile_recursive_csharp_query(Pred/Arity, FinalOptions, GeneratedCode)
         )
+    ;   Classification = non_recursive ->
+        compile_non_recursive(Target, Pred/Arity, FinalOptions, GeneratedCode)
     ;   Classification = transitive_closure(BasePred) ->
         format('Detected transitive closure over ~w~n', [BasePred]),
         compile_transitive_closure(Target, Pred, Arity, BasePred, FinalOptions, GeneratedCode)

--- a/tests/core/test_recursive_csharp_target.pl
+++ b/tests/core/test_recursive_csharp_target.pl
@@ -29,19 +29,31 @@ cleanup_test_data :-
 
 test_non_recursive_facts_to_csharp :-
     compile_recursive(test_cf_fact/2, [target(csharp)], Code),
+    % Non-recursive csharp now routes through the query-plan backend
+    % (same path as recursive csharp); facts compile to a QueryPlan
+    % wrapping a RelationScanNode.  Distinct() only appears in
+    % aggregation/set-recursion contexts — not for plain fact lookup —
+    % so check for the distinctive query-plan markers instead.
     (   sub_string(Code, _, _, _, "namespace UnifyWeaver.Generated"),
-        sub_string(Code, _, _, _, "Distinct()") ->
-        format('  ✓ Non-recursive predicate compiled to C# stream~n')
-    ;   format('  ✗ FAILED: Expected C# stream output~n'),
+        sub_string(Code, _, _, _, "RelationScanNode"),
+        sub_string(Code, _, _, _, "QueryPlan") ->
+        format('  ✓ Non-recursive predicate compiled to C# query plan~n')
+    ;   format('  ✗ FAILED: Expected C# query-plan output~n'),
         fail
     ).
 
 test_recursive_tail_to_csharp :-
     compile_recursive(test_cf_rec/2, [target(csharp)], Code),
-    (   sub_string(Code, _, _, _, "FixpointNode"),
-        sub_string(Code, _, _, _, "RecursiveRefNode"),
-        sub_string(Code, _, _, _, "RecursiveRefKind.Delta") ->
-        format('  ✓ Tail recursion compiled to C# query plan~n')
-    ;   format('  ✗ FAILED: Expected C# fixpoint plan output~n'),
+    % test_cf_rec/2 is classified as transitive_closure(test_cf_fact),
+    % so it lowers to the specialized TransitiveClosureNode rather
+    % than the general FixpointNode + RecursiveRefNode + Delta form
+    % (which the classifier only picks for predicates that aren't
+    % shape-matched to transitive closure).  Check the markers the
+    % renderer actually emits for this shape.
+    (   sub_string(Code, _, _, _, "namespace UnifyWeaver.Generated"),
+        sub_string(Code, _, _, _, "TransitiveClosureNode"),
+        sub_string(Code, _, _, _, "QueryPlan") ->
+        format('  ✓ Recursive predicate compiled to C# query plan~n')
+    ;   format('  ✗ FAILED: Expected C# transitive-closure plan output~n'),
         fail
     ).


### PR DESCRIPTION
## Summary

Hoists the csharp branch in `compile_dispatch/4` above the `non_recursive` classification check, so simple fact predicates take the same query-plan path that recursive csharp already takes (unless `mode(procedural)` is explicitly set). Also corrects `test_recursive_csharp_target`'s expected substrings to match the markers the renderer actually emits.

## Why the dispatch needed fixing

Before this change, `recursive_compiler:compile_dispatch/4` had:

```prolog
(   Classification = non_recursive ->
    compile_non_recursive(Target, ...)
;   Target == csharp ->
    ( mode(procedural) -> csharp_native_target ; compile_recursive_csharp_query )
;   Classification = transitive_closure(_) -> ...
; ...
)
```

So for `compile_recursive(test_cf_fact/2, [target(csharp)], _)`: `non_recursive` matched first, the call fell through to `compile_non_recursive(csharp, ...)` which dispatched to `csharp_native_target:compile_predicate_to_csharp` (procedural form). Recursive csharp went through `compile_recursive_csharp_query` (query-plan form), so the two paths produced structurally different output for the same target choice — inconsistent.

After hoisting the csharp branch above `non_recursive`, the dispatch is uniform: `target(csharp)` always goes through the query-plan backend by default, with `mode(procedural)` as the opt-in override.

## `test_recursive_csharp_target`: match the real markers

The two subtests had assertions that didn't match either backend's actual output:

- **`test_non_recursive_facts_to_csharp`** expected `Distinct()` — but `Distinct()` only appears in aggregation/set contexts inside `csharp_target.pl` (`aggQuery`, group-by selectors), not in plain fact-scan plans. Updated to check for `RelationScanNode` and `QueryPlan`, which are the distinctive markers the renderer emits for a fact predicate's plan.

- **`test_recursive_tail_to_csharp`** expected `FixpointNode` + `RecursiveRefNode` + `RecursiveRefKind.Delta` — those are the general fixpoint-plan markers used when the classifier can't shape-match a more specific recursion pattern. But `test_cf_rec/2` is a textbook right-recursive forward transitive closure, so the classifier picks the specialized `transitive_closure(test_cf_fact)` classification and the renderer emits a `TransitiveClosureNode`. Updated to check that marker.

## Verified end-to-end with actual C# compilation

`dotnet 8.0.126` was already installed in the environment. Generated `test_cf_fact` and `test_cf_rec` C# modules, dropped them into a small console project alongside the canonical `QueryRuntime.cs`, and ran them through `QueryExecutor.Execute`:

```
== test_cf_fact ==
  Root node type: RelationScanNode
  IsRecursive: False
== test_cf_rec ==
  Root node type: TransitiveClosureNode
  IsRecursive: True
== executing test_cf_fact ==
  a,b
  b,c
== executing test_cf_rec ==
  a,b
  b,c
  a,c       ← transitive closure correctly computed
```

So the generated code not only compiles, it produces the right results.

## Test plan

- [x] `swipl ... -g main -t halt run_all_tests.pl` now exits 0 (was failing at this test after PRs #2361 + #2362). `Progress: 243/243 tests complete. --- Control Plane Test Suite Finished ---`
- [x] `test_recursive_csharp_target` both subtests pass: ✓ Non-recursive predicate compiled to C# query plan / ✓ Recursive predicate compiled to C# query plan
- [x] End-to-end smoke: generated C# builds clean with `dotnet build` and executes correctly under `QueryExecutor`.

## Closes the test-runner cleanup thread

This is the third (and final) PR in the `run_all_tests.pl` cleanup sequence started after PR #2360's test plan noted out-of-scope failures: PR #2361 (template renderer), PR #2362 (left-recursive TC classifier + format-arg fix), and now this one.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_