### PR TITLE
feat(wam-python): support read_term_from_atom variable_names

### DIFF
--- a/src/unifyweaver/core/prolog_term_parser.pl
+++ b/src/unifyweaver/core/prolog_term_parser.pl
@@ -15,7 +15,9 @@
 %
 % API
 %   parse_term_from_codes(+Codes, +OpTable, -Term).
+%   parse_term_from_codes(+Codes, +OpTable, -Term, -VarEnv).
 %   parse_term_from_atom (+Atom,  +OpTable, -Term).
+%   parse_term_from_atom (+Atom,  +OpTable, -Term, -VarEnv).
 %   canonical_op_table(-OpTable).
 %
 % OpTable is a list of op(Name, Prec, Type) facts; Type is one of
@@ -43,7 +45,9 @@
 
 :- module(prolog_term_parser, [
     parse_term_from_codes/3,
+    parse_term_from_codes/4,
     parse_term_from_atom/3,
+    parse_term_from_atom/4,
     canonical_op_table/1
 ]).
 
@@ -55,10 +59,17 @@ parse_term_from_atom(Atom, OpTable, Term) :-
     atom_codes(Atom, Codes),
     parse_term_from_codes(Codes, OpTable, Term).
 
+parse_term_from_atom(Atom, OpTable, Term, VarEnv) :-
+    atom_codes(Atom, Codes),
+    parse_term_from_codes(Codes, OpTable, Term, VarEnv).
+
 parse_term_from_codes(Codes, OpTable, Term) :-
+    parse_term_from_codes(Codes, OpTable, Term, _VarEnv).
+
+parse_term_from_codes(Codes, OpTable, Term, VarEnv) :-
     tokenize(Codes, Tokens),
     !,
-    parse_expr(Tokens, OpTable, 1200, Term, _Prec, [], _Env, Rest),
+    parse_expr(Tokens, OpTable, 1200, Term, _Prec, [], VarEnv, Rest),
     Rest == [].
 
 % -----------------------------------------------------------------------------

--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -1023,7 +1023,7 @@ def _list_from_terms(items: List['Term']) -> 'Term':
 
 def _runtime_functor_name(functor: str, arity: int) -> str:
     if functor in ('.', './2', '[|]/2'):
-        return functor
+        return '.'
     if '/' in functor:
         return functor
     return f"{functor}/{arity}"
@@ -1092,12 +1092,59 @@ def _copy_term_between_states(val: 'Term', source: WamState, target: WamState,
     return val
 
 
-def _execute_compiled_parse_atom(state: WamState, atom_text: str, target: 'Term') -> bool:
+def _runtime_atom_text(atom_text: str) -> str:
+    if len(atom_text) >= 2 and atom_text[0] == "'" and atom_text[-1] == "'":
+        inner = atom_text[1:-1]
+        return inner.replace("\\'", "'").replace("\\\\", "\\")
+    return atom_text
+
+
+def _read_option_arg(options: 'Term', name: str, state: WamState) -> Optional['Term']:
+    items = _term_to_list(options, state)
+    if items is None:
+        return None
+    wanted = f"{name}/1"
+    for item in items:
+        item = deref(item, state)
+        if isinstance(item, Compound) and len(item.args) == 1:
+            if item.functor == wanted or item.functor == name:
+                return item.args[0]
+    return None
+
+
+def _variable_names_from_env(env_term: 'Term', source: WamState, target: WamState,
+                             var_map: Dict[int, Var]) -> 'Term':
+    pairs: List[Term] = []
+    for pair in _term_to_list(env_term, source) or []:
+        pair = deref(pair, source)
+        if not isinstance(pair, Compound) or len(pair.args) != 2:
+            continue
+        name = deref(pair.args[0], source)
+        if not isinstance(name, Atom) or name.name == '_':
+            continue
+        var = _copy_term_between_states(pair.args[1], source, target, var_map)
+        pairs.append(Compound('=/2', [make_atom(name.name), var]))
+    return _list_from_terms(list(reversed(pairs)))
+
+
+def _execute_compiled_parse_atom(state: WamState, atom_text: str, target: 'Term',
+                                 options: Optional['Term'] = None) -> bool:
+    atom_text = _runtime_atom_text(atom_text)
     code = getattr(state, '_code', None)
     labels = getattr(state, '_labels', None)
     if not code or not labels:
         return False
-    if 'canonical_op_table/1' not in labels or 'parse_term_from_atom/3' not in labels:
+    if 'canonical_op_table/1' not in labels:
+        return False
+
+    want_var_names = None
+    if options is not None:
+        want_var_names = _read_option_arg(options, 'variable_names', state)
+
+    parser_entry = 'parse_term_from_atom/3'
+    if want_var_names is not None and 'parse_term_from_atom/4' in labels:
+        parser_entry = 'parse_term_from_atom/4'
+    elif parser_entry not in labels:
         return False
 
     parser_state = WamState()
@@ -1107,21 +1154,32 @@ def _execute_compiled_parse_atom(state: WamState, atom_text: str, target: 'Term'
         return False
 
     parsed = parser_state.fresh_var()
+    var_env = parser_state.fresh_var()
     set_reg(parser_state, 1, make_atom(atom_text))
     set_reg(parser_state, 2, deref(ops, parser_state))
     set_reg(parser_state, 3, parsed)
-    if not run_wam(code, labels, 'parse_term_from_atom/3', parser_state):
+    if parser_entry == 'parse_term_from_atom/4':
+        set_reg(parser_state, 4, var_env)
+    if not run_wam(code, labels, parser_entry, parser_state):
         return False
 
-    copied = _copy_term_between_states(parsed, parser_state, state, {})
-    return unify(target, copied, state)
+    var_map: Dict[int, Var] = {}
+    copied = _copy_term_between_states(parsed, parser_state, state, var_map)
+    if not unify(target, copied, state):
+        return False
+    if want_var_names is not None:
+        names = _variable_names_from_env(var_env, parser_state, state, var_map)
+        if not unify(want_var_names, names, state):
+            return False
+    return True
 
 
-def _execute_read_term_from_atom(state: WamState) -> bool:
+def _execute_read_term_from_atom(state: WamState, arity: int = 2) -> bool:
     atom_term = deref(get_reg(state, 1), state)
     if not isinstance(atom_term, Atom):
         return False
-    return _execute_compiled_parse_atom(state, atom_term.name, get_reg(state, 2))
+    options = get_reg(state, 3) if arity == 3 else None
+    return _execute_compiled_parse_atom(state, atom_term.name, get_reg(state, 2), options)
 
 
 def _execute_term_to_atom(state: WamState) -> bool:
@@ -1303,9 +1361,9 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
     if builtin in ('number_codes/2', 'number_codes') and arity == 2:
         return _execute_number_codes(state)
     if builtin in ('read_term_from_atom/2', 'read_term_from_atom') and arity == 2:
-        return _execute_read_term_from_atom(state)
+        return _execute_read_term_from_atom(state, 2)
     if builtin in ('read_term_from_atom/3',) and arity == 3:
-        return _execute_read_term_from_atom(state)
+        return _execute_read_term_from_atom(state, 3)
     if builtin in ('term_to_atom/2', 'term_to_atom') and arity == 2:
         return _execute_term_to_atom(state)
     if builtin in ('append/3', 'append') and arity == 3:
@@ -1495,6 +1553,7 @@ def run_wam(code: list, labels: dict, entry: str, state: WamState) -> bool:
 
         elif op == 'put_structure':
             _, functor, arity, reg = instr
+            functor = _runtime_functor_name(functor, arity)
             old = deref(get_reg(state, reg), state)
             c = Compound(functor, [None]*arity)
             addr = heap_put(state, c)
@@ -1566,6 +1625,7 @@ def run_wam(code: list, labels: dict, entry: str, state: WamState) -> bool:
 
         elif op == 'get_structure':
             _, functor, arity, reg = instr
+            functor = _runtime_functor_name(functor, arity)
             snap_val = arg_snapshot[reg] if (reg < len(arg_snapshot) and reg <= _A_MAX) else get_reg(state, reg)
             val = deref(snap_val, state)
             if isinstance(val, Var):

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -833,7 +833,8 @@ def _deep_copy_term(val, var_map, state):
 %% python_value_literal(+PrologTerm, -PyLiteral)
 %  Convert a Prolog term to a Python value literal.
 python_value_literal(atom(A), PyVal) :- !,
-	format(atom(PyVal), 'Atom("~w")', [A]).
+	escape_python_string(A, Esc),
+	format(atom(PyVal), 'Atom("~w")', [Esc]).
 python_value_literal(integer(I), PyVal) :- !,
 	format(atom(PyVal), 'Int(~w)', [I]).
 python_value_literal(N, PyVal) :- integer(N), !,
@@ -841,9 +842,11 @@ python_value_literal(N, PyVal) :- integer(N), !,
 python_value_literal(N, PyVal) :- float(N), !,
 	format(atom(PyVal), 'Float(~w)', [N]).
 python_value_literal(A, PyVal) :- atom(A), !,
-	format(atom(PyVal), 'Atom("~w")', [A]).
+	escape_python_string(A, Esc),
+	format(atom(PyVal), 'Atom("~w")', [Esc]).
 python_value_literal(S, PyVal) :- string(S), !,
-	format(atom(PyVal), 'Atom("~w")', [S]).
+	escape_python_string(S, Esc),
+	format(atom(PyVal), 'Atom("~w")', [Esc]).
 
 %% wam_instruction_to_python_literal(+WamInstr, -PyLiteral)
 %  Convert WAM instruction term to Python tuple literal.
@@ -985,7 +988,12 @@ clean_comma(S, Clean) :-
 %% escape_python_string(+In, -Out)
 %  Escape a string for Python string literal.
 escape_python_string(In, Out) :-
-	atom_string(In, S),
+	(   atom(In)
+	->  atom_string(In, S)
+	;   string(In)
+	->  S = In
+	;   term_string(In, S)
+	),
 	split_string(S, "\\", "", Parts),
 	atomic_list_concat(Parts, "\\\\", S1),
 	split_string(S1, "\"", "", Parts2),

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -584,6 +584,30 @@ test(runtime_parser_compiled_runs_read_term_from_atom) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_parser_compiled_read_term_variable_names) :-
+	setup_call_cleanup(
+		(   retractall(user:py_read_term_vars_demo),
+			assertz((user:py_read_term_vars_demo :-
+				read_term_from_atom('p(A,B,A)', T, [variable_names(Vs)]),
+				T = p(X, Y, X),
+				Vs = ['A'=X, 'B'=Y])),
+			user:python_parser_tmp_dir('tmp_wam_python_parser_read_vars', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_read_term_vars_demo/0],
+				[runtime_parser(compiled)], ProjectDir),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_read_term_vars_demo/0', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_read_term_vars_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_runs_reverse_term_to_atom) :-
 	setup_call_cleanup(
 		(   retractall(user:py_term_to_atom_demo),


### PR DESCRIPTION
## Summary
- add `/4` portable parser entry points that return the parse variable environment
- wire WAM-Python `read_term_from_atom/3` to support `variable_names/1` through the compiled runtime parser
- normalize Python runtime cons functors so `.` and `[|]/2` list cells unify consistently
- fix Python atom literal emission to escape atom text without relying on Prolog write syntax

## Notes
- `read_term_from_atom/2` continues to use the existing compiled parser path.
- `read_term_from_atom/3` currently handles `variable_names/1`; unsupported options are ignored as before.
- The list-cell normalization closes a runtime mismatch exposed by comparing generated `Name=Var` pairs.

## Tests
- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
