### PR TITLE
fix(wam-clojure): escape quoted atom constants in generated code

### DIFF
--- a/PR_WAM_CLOJURE_QUOTED_ATOM_ESCAPING.md
+++ b/PR_WAM_CLOJURE_QUOTED_ATOM_ESCAPING.md
@@ -1,0 +1,23 @@
+# PR Title
+
+fix(wam-clojure): escape quoted atom constants in generated code
+
+# PR Description
+
+## Summary
+
+- Normalizes WAM single-quoted atom tokens before emitting Clojure literals.
+- Strips the WAM quoted-numeric atom marker so atoms like `'4'` become the runtime atom text `4`, not an invalid generated Clojure escape sequence.
+- Hardens Clojure string literal emission for backslashes, quotes, and control characters.
+- Restores the `number_chars/2` reverse smoke fixture to use quoted digit atoms directly instead of the `char_code/2` workaround.
+
+## Why
+
+The Clojure lowered emitter previously rendered Prolog `~q` output into Clojure source. For quoted numeric atoms this could produce invalid Clojure such as `"'\x1\4'"`-style syntax. This PR makes quoted atom normalization explicit and keeps generated source valid.
+
+## Testing
+
+- `git diff --check`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
+- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -992,18 +992,59 @@ emit_lowered_expr(_Instr, S, Expr) :-
 clj_lowered_literal(Value, Literal) :-
     (   number(Value)
     ->  format(atom(Literal), '~w', [Value])
-    ;   Value == ''
-    ->  Literal = '""'
-    ;   format(atom(Literal), '~q', [Value])
+    ;   clj_lowered_atom_text(Value, Text),
+        clj_lowered_string_literal(Text, Literal)
     ).
+
+clj_lowered_atom_text(Value, Text) :-
+    (   string(Value) -> S0 = Value ; atom_string(Value, S0) ),
+    clj_unquote_wam_atom_token(S0, S1),
+    clj_strip_quoted_numeric_marker(S1, Text).
+
+clj_unquote_wam_atom_token("''", "") :- !.
+clj_unquote_wam_atom_token(S0, S) :-
+    sub_string(S0, 0, 1, _, "'"),
+    sub_string(S0, _, 1, 0, "'"),
+    !,
+    sub_string(S0, 1, _, 1, Inner),
+    string_codes(Inner, Codes0),
+    clj_unescape_wam_codes(Codes0, Codes),
+    string_codes(S, Codes).
+clj_unquote_wam_atom_token(S, S).
+
+clj_unescape_wam_codes([], []).
+clj_unescape_wam_codes([92, C|Rest], [C|More]) :- !,
+    clj_unescape_wam_codes(Rest, More).
+clj_unescape_wam_codes([C|Rest], [C|More]) :-
+    clj_unescape_wam_codes(Rest, More).
+
+clj_strip_quoted_numeric_marker(S0, S) :-
+    string_codes(S0, [1|Rest]),
+    !,
+    string_codes(S, Rest).
+clj_strip_quoted_numeric_marker(S, S).
 
 clj_lowered_string_literal(Value, Literal) :-
     (   string(Value) -> S0 = Value ; atom_string(Value, S0) ),
-    split_string(S0, "\\", "", BackslashParts),
-    atomics_to_string(BackslashParts, "\\\\", S1),
-    split_string(S1, "\"", "", QuoteParts),
-    atomics_to_string(QuoteParts, "\\\"", Escaped),
+    clj_escape_string(S0, Escaped),
     format(atom(Literal), '"~w"', [Escaped]).
+
+clj_escape_string(S0, Escaped) :-
+    string_codes(S0, Codes),
+    maplist(clj_escape_code, Codes, Parts),
+    atomics_to_string(Parts, "", Escaped).
+
+clj_escape_code(92, "\\\\") :- !.
+clj_escape_code(34, "\\\"") :- !.
+clj_escape_code(10, "\\n") :- !.
+clj_escape_code(13, "\\r") :- !.
+clj_escape_code(9, "\\t") :- !.
+clj_escape_code(Code, Escaped) :-
+    (   Code < 32
+    ->  format(string(Escaped), '\\u~|~`0t~16r~4+', [Code])
+    ;   char_code(Char, Code),
+        string_chars(Escaped, [Char])
+    ).
 
 instr_comment(proceed, "proceed").
 instr_comment(fail, "fail").

--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -506,7 +506,9 @@ switch_case_atom_values(CasesText, AtomSeeds) :-
             AtomSeeds).
 
 wam_atom_token_text("''", "") :- !.
-wam_atom_token_text(Token, Token).
+wam_atom_token_text(Token, AtomText) :-
+    clj_unquote_wam_atom_token(Token, Unquoted),
+    clj_strip_quoted_numeric_marker(Unquoted, AtomText).
 
 wam_atom_token_literal(Token, Literal) :-
     wam_atom_token_text(Token, AtomText),
@@ -761,13 +763,47 @@ run_shell_command_or_throw(Cwd, Command, ErrorFunctor) :-
     ).
 
 clj_string_literal(In, Literal) :-
-    atom_string(InAtom, In),
-    atom_string(InAtom, InStr0),
+    (   string(In) -> InStr0 = In ; atom_string(In, InStr0) ),
     escape_clj_string(InStr0, Escaped),
     format(atom(Literal), '"~w"', [Escaped]).
 
 escape_clj_string(In, Out) :-
-    split_string(In, "\\", "", Parts1),
-    atomic_list_concat(Parts1, "\\\\", Tmp1),
-    split_string(Tmp1, "\"", "", Parts2),
-    atomic_list_concat(Parts2, "\\\"", Out).
+    string_codes(In, Codes),
+    maplist(escape_clj_code, Codes, Parts),
+    atomics_to_string(Parts, "", Out).
+
+escape_clj_code(92, "\\\\") :- !.
+escape_clj_code(34, "\\\"") :- !.
+escape_clj_code(10, "\\n") :- !.
+escape_clj_code(13, "\\r") :- !.
+escape_clj_code(9, "\\t") :- !.
+escape_clj_code(Code, Escaped) :-
+    (   Code < 32
+    ->  format(string(Escaped), '\\u~|~`0t~16r~4+', [Code])
+    ;   char_code(Char, Code),
+        string_chars(Escaped, [Char])
+    ).
+
+clj_unquote_wam_atom_token(Token, S) :-
+    (   string(Token) -> S0 = Token ; atom_string(Token, S0) ),
+    sub_string(S0, 0, 1, _, "'"),
+    sub_string(S0, _, 1, 0, "'"),
+    !,
+    sub_string(S0, 1, _, 1, Inner),
+    string_codes(Inner, Codes0),
+    clj_unescape_wam_codes(Codes0, Codes),
+    string_codes(S, Codes).
+clj_unquote_wam_atom_token(Token, S) :-
+    (   string(Token) -> S = Token ; atom_string(Token, S) ).
+
+clj_unescape_wam_codes([], []).
+clj_unescape_wam_codes([92, C|Rest], [C|More]) :- !,
+    clj_unescape_wam_codes(Rest, More).
+clj_unescape_wam_codes([C|Rest], [C|More]) :-
+    clj_unescape_wam_codes(Rest, More).
+
+clj_strip_quoted_numeric_marker(S0, S) :-
+    string_codes(S0, [1|Rest]),
+    !,
+    string_codes(S, Rest).
+clj_strip_quoted_numeric_marker(S, S).

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -418,7 +418,7 @@ user:wam_char_type_lower_fail :- char_type('A', lower).
 user:wam_number_codes_guard(N, C) :- number_codes(N, C).
 user:wam_number_codes_reverse :- number_codes(N, [52,50]), N =:= 42.
 user:wam_number_chars_guard(N, C) :- number_chars(N, C).
-user:wam_number_chars_reverse :- char_code(C4, 52), char_code(C2, 50), number_chars(N, [C4,C2]), N =:= 42.
+user:wam_number_chars_reverse :- number_chars(N, ['4','2']), N =:= 42.
 user:wam_number_chars_bad_chars :- number_chars(_, [f,o,o]).
 user:wam_text_conversion_unbound_pair(_) :- user:wam_unbound_arg(A), user:wam_unbound_arg(C), atom_codes(A, C).
 user:wam_atom_concat_guard(A, B, C) :- atom_concat(A, B, C).


### PR DESCRIPTION
## Summary

- Normalizes WAM single-quoted atom tokens before emitting Clojure literals.
- Strips the WAM quoted-numeric atom marker so atoms like `'4'` become the runtime atom text `4`, not an invalid generated Clojure escape sequence.
- Hardens Clojure string literal emission for backslashes, quotes, and control characters.
- Restores the `number_chars/2` reverse smoke fixture to use quoted digit atoms directly instead of the `char_code/2` workaround.

## Why

The Clojure lowered emitter previously rendered Prolog `~q` output into Clojure source. For quoted numeric atoms this could produce invalid Clojure such as `"'\x1\4'"`-style syntax. This PR makes quoted atom normalization explicit and keeps generated source valid.

## Testing

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
