### PR TITLE
feat(wam-python): support read term variables option

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -1127,6 +1127,31 @@ def _variable_names_from_env(env_term: 'Term', source: WamState, target: WamStat
     return _list_from_terms(list(reversed(pairs)))
 
 
+def _variables_from_term(term: 'Term', state: WamState) -> 'Term':
+    seen: set[int] = set()
+    variables: List[Term] = []
+
+    def walk(value: 'Term') -> None:
+        value = deref(value, state)
+        if isinstance(value, Var):
+            key = id(value.ref)
+            if key not in seen:
+                seen.add(key)
+                variables.append(value)
+            return
+        if isinstance(value, Ref):
+            heap_value = state.heap.get(value.addr)
+            if heap_value is not None:
+                walk(heap_value)
+            return
+        if isinstance(value, Compound):
+            for arg in value.args:
+                walk(arg)
+
+    walk(term)
+    return _list_from_terms(variables)
+
+
 def _execute_compiled_parse_atom(state: WamState, atom_text: str, target: 'Term',
                                  options: Optional['Term'] = None) -> bool:
     atom_text = _runtime_atom_text(atom_text)
@@ -1138,11 +1163,13 @@ def _execute_compiled_parse_atom(state: WamState, atom_text: str, target: 'Term'
         return False
 
     want_var_names = None
+    want_variables = None
     if options is not None:
         want_var_names = _read_option_arg(options, 'variable_names', state)
+        want_variables = _read_option_arg(options, 'variables', state)
 
     parser_entry = 'parse_term_from_atom/3'
-    if want_var_names is not None and 'parse_term_from_atom/4' in labels:
+    if (want_var_names is not None or want_variables is not None) and 'parse_term_from_atom/4' in labels:
         parser_entry = 'parse_term_from_atom/4'
     elif parser_entry not in labels:
         return False
@@ -1170,6 +1197,10 @@ def _execute_compiled_parse_atom(state: WamState, atom_text: str, target: 'Term'
     if want_var_names is not None:
         names = _variable_names_from_env(var_env, parser_state, state, var_map)
         if not unify(want_var_names, names, state):
+            return False
+    if want_variables is not None:
+        variables = _variables_from_term(copied, state)
+        if not unify(want_variables, variables, state):
             return False
     return True
 

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -608,6 +608,32 @@ test(runtime_parser_compiled_read_term_variable_names) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_parser_compiled_read_term_variables) :-
+	setup_call_cleanup(
+		(   retractall(user:py_read_term_variables_demo),
+			assertz((user:py_read_term_variables_demo :-
+				read_term_from_atom('p(A,_,B,A)', T,
+					[variables(Vars), variable_names(Vs)]),
+				T = p(X, Anon, Y, X),
+				Vars = [X, Anon, Y],
+				Vs = ['A'=X, 'B'=Y])),
+			user:python_parser_tmp_dir('tmp_wam_python_parser_read_variables', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_read_term_variables_demo/0],
+				[runtime_parser(compiled)], ProjectDir),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_read_term_variables_demo/0', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_read_term_variables_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_runs_reverse_term_to_atom) :-
 	setup_call_cleanup(
 		(   retractall(user:py_term_to_atom_demo),


### PR DESCRIPTION
## Summary
- add WAM-Python compiled runtime parser support for `read_term_from_atom/3` with `variables/1`
- return parsed variables in left-to-right term order while preserving shared-variable identity
- keep `variable_names/1` interoperating with `variables/1` from the same parse result
- add an end-to-end generated WAM-Python test covering named, shared, and anonymous variables

## Tests
- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`

## Notes
- This builds on the merged compiled parser variable-environment support from PR #2367.
- Existing unsupported `read_term_from_atom/3` options remain ignored.
