### PR TITLE
fix(csharp-strategy-trace): record short-form aliases + align mixed-direction test names

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -14633,6 +14633,7 @@ namespace UnifyWeaver.QueryRuntime
         {
             trace?.RecordStrategy(node, $"{nodeStrategyPrefix}MaterializationPlanSelection{selection.DecisionMode}");
             trace?.RecordStrategy(node, $"{nodeStrategyPrefix}MaterializationPlanPairs{selection.Strategy}");
+            trace?.RecordStrategy(node, $"{nodeStrategyPrefix}{selection.Strategy}");
         }
 
         private static int CountClosurePairRequests(IEnumerable<HashSet<object?>> requestSets) =>

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -4388,11 +4388,11 @@ verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed
     csharp_query_target:build_query_plan(test_group_probe_dir_mixed_reach/4, [target(csharp_query)], Plan),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
     Params = [[a, z, red, cat1], [p, q, red, cat1]],
-    harness_source_with_strategy_flag_no_reuse(ModuleClass, Params, 'GroupedTransitiveClosurePairsBatchedSingleProbeMixed', HarnessSource),
+    harness_source_with_strategy_flag_no_reuse(ModuleClass, Params, 'GroupedTransitiveClosurePairsMixedDirection', HarnessSource),
     maybe_run_query_runtime_with_harness(Plan,
         ['a,z,red,cat1',
          'p,q,red,cat1',
-         'STRATEGY_USED:GroupedTransitiveClosurePairsBatchedSingleProbeMixed=true'],
+         'STRATEGY_USED:GroupedTransitiveClosurePairsMixedDirection=true'],
         Params,
         HarnessSource).
 
@@ -4527,11 +4527,11 @@ verify_parameterized_reachability_pairs_batched_single_probe_mixed_strategy_runt
     csharp_query_target:build_query_plan(test_probe_dir_mixed_reach/2, [target(csharp_query)], Plan),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
     Params = [[a, z], [p, q]],
-    harness_source_with_strategy_flag_no_reuse(ModuleClass, Params, 'TransitiveClosurePairsBatchedSingleProbeMixed', HarnessSource),
+    harness_source_with_strategy_flag_no_reuse(ModuleClass, Params, 'TransitiveClosurePairsMixedDirection', HarnessSource),
     maybe_run_query_runtime_with_harness(Plan,
         ['a,z',
          'p,q',
-         'STRATEGY_USED:TransitiveClosurePairsBatchedSingleProbeMixed=true'],
+         'STRATEGY_USED:TransitiveClosurePairsMixedDirection=true'],
         Params,
         HarnessSource).
 


### PR DESCRIPTION
## Summary

Follow-up to #2366. Fixes the 7 `verify_parameterized_*_strategy_runtime` soft-failures that #2366 documented as known issues — the unlock there made the suite actually *run* the tests, which exposed that none of the strategy names the harness asserted on (`STRATEGY_USED:Foo=true`) were ever recorded by the C# runtime trace.

Two complementary fixes per the (a)/(b) options sketched in #2366:

### (b) — Record short-form aliases in `RecordClosurePairStrategy`

The runtime *did* know which `ClosurePairPlanStrategy` variant it picked. It just emitted only the long-form trace label:

| Strategy enum | Was recorded as |
|---|---|
| `Forward` | `GroupedTransitiveClosurePairsMaterializationPlanPairsForward` |
| `SingleProbeForward` | `GroupedTransitiveClosurePairsMaterializationPlanPairsSingleProbeForward` |
| `SingleProbeBackward` | `GroupedTransitiveClosurePairsMaterializationPlanPairsSingleProbeBackward` |
| `MixedDirection` | `GroupedTransitiveClosurePairsMaterializationPlanPairsMixedDirection` |
| *(and the non-grouped `TransitiveClosurePairs*` variants)* | |

The tests assert on a shorter, more natural form (`GroupedTransitiveClosurePairsForward`). Added one additional `trace?.RecordStrategy(node, $"{prefix}{selection.Strategy}")` line to `RecordClosurePairStrategy` so the short form is recorded *alongside* the existing long form. Additive — any code consuming the long-form names keeps working.

This unblocks 5 of the 7 soft-failures (the `Forward` / `SingleProbeForward` / `SingleProbeBackward` cases, grouped and non-grouped).

### (a) — Align two `BatchedSingleProbeMixed` test expectations

The remaining two tests asserted on `*BatchedSingleProbeMixed`, which doesn't correspond to any `ClosurePairPlanStrategy` enum value — there is no "batched single probe mixed" variant in the runtime. The runtime emits `MixedDirection` for the same plan shape (verified by harness-instrumented dump of `trace.SnapshotStrategies()`).

Renamed the test expectations to `*MixedDirection` to match the actual emitted strategy. Underlying execution is identical; the label was simply wrong.

## Verification

- **All 7 target tests PASS individually** via a standalone driver (each prints `(query runtime execution: PASS)`).
- **Full `test_csharp_query_target` suite**: `Progress: 243/243 tests complete`, **234 runtime-execution PASS / 0 FAIL** (up from 227 / 7 soft-FAIL after #2366), exit 0.
- The new strategy trace lines are additive; existing trace consumers reading the long-form names see no change.

## Test plan

- [x] Dumped `trace.SnapshotStrategies()` for each of the 4 grouped + 3 non-grouped failing test fixtures to identify the exact runtime-emitted names — confirmed the 5 cases were a prefix-naming mismatch and the 2 `BatchedSingleProbeMixed` cases were a strategy-name mismatch.
- [x] After the runtime change + test rename: all 7 target tests assert `STRATEGY_USED:...=true` and pass.
- [x] Full C# query test suite: 234 PASS / 0 FAIL on runtime execution, suite exits 0.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_