### PR TITLE
fix(csharp-smoke): drop hardcoded net9.0 from runtime smoke + pin CI framework

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,13 @@ jobs:
       CSHARP_QUERY_SMOKE_JSON_SUMMARY_PATH: tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.json
       CSHARP_QUERY_SMOKE_FAILURE_ARTIFACT_NAME: csharp-query-smoke-artifacts
       CSHARP_QUERY_SMOKE_JSON_ARTIFACT_NAME: csharp-query-smoke-summary-json
+      # Pin the Prolog harness's TargetFramework probe to the SDK installed
+      # by the setup-dotnet step below, so generated .csproj's land their
+      # build output in a predictable bin/Debug/<framework>/ directory.
+      # The PS smoke runner now discovers the framework dir at runtime
+      # too, but pinning makes it deterministic regardless of which
+      # SDKs the runner has pre-installed.
+      UNIFYWEAVER_DOTNET_FRAMEWORK: net9.0
 
     steps:
       - name: Checkout code

--- a/scripts/testing/generate_csharp_manual.pl
+++ b/scripts/testing/generate_csharp_manual.pl
@@ -27,9 +27,13 @@ main :-
     (exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true),
     make_directory(Dir),
 
-    % Create dotnet project
+    % Create dotnet project.  Probe `dotnet --list-sdks` for the highest
+    % installed major so this works on hosts without net9.0 (e.g. an SDK 8
+    % container).  Override with UNIFYWEAVER_DOTNET_FRAMEWORK if needed.
     writeln('Creating dotnet console project...'),
-    process_create(path(dotnet), ['new', 'console', '--force', '--framework', 'net9.0'],
+    detect_target_framework(Framework),
+    format('Using target framework: ~w~n', [Framework]),
+    process_create(path(dotnet), ['new', 'console', '--force', '--framework', Framework],
                    [cwd(Dir), stdout(null), stderr(null)]),
 
     % Copy QueryRuntime.cs
@@ -73,3 +77,31 @@ class Program {
     format('  dotnet run~n'),
     format('~nExpected output: 0, 2, 4~n~n'),
     halt(0).
+
+detect_target_framework(Framework) :-
+    (   getenv('UNIFYWEAVER_DOTNET_FRAMEWORK', Env), Env \== ''
+    ->  atom_string(Framework, Env)
+    ;   probe_target_framework(Framework)
+    ->  true
+    ;   Framework = 'net9.0'
+    ).
+
+probe_target_framework(Framework) :-
+    catch(
+        setup_call_cleanup(
+            process_create(path(dotnet), ['--list-sdks'],
+                           [stdout(pipe(Out)), stderr(null), process(PID)]),
+            read_string(Out, _, Output),
+            (close(Out), process_wait(PID, _))
+        ),
+        _, fail
+    ),
+    split_string(Output, "\n", "\r \t", Lines),
+    findall(Major,
+            ( member(Line, Lines), Line \== "",
+              split_string(Line, ".", "", [MajorStr|_]),
+              number_string(Major, MajorStr)
+            ), Majors),
+    Majors \= [],
+    max_list(Majors, Highest),
+    format(atom(Framework), 'net~w.0', [Highest]).

--- a/scripts/testing/run_csharp_query_runtime_smoke.ps1
+++ b/scripts/testing/run_csharp_query_runtime_smoke.ps1
@@ -12,7 +12,10 @@
 #   pwsh -File .\scripts\testing\run_csharp_query_runtime_smoke.ps1 -CacheSlice lru
 #
 # Notes:
-# - Requires SWI-Prolog and dotnet (net9.0 SDK) on PATH (or in common SWI locations).
+# - Requires SWI-Prolog and dotnet on PATH (or in common SWI locations).  The
+#   target framework is detected from the generated .csproj's TargetFramework
+#   element, so net8.0 / net9.0 / etc. all work as long as the installed SDK
+#   matches what the Prolog harness picks at codegen time.
 # - Generated bin/obj artifacts should be git-ignored.
 
 [CmdletBinding()]
@@ -273,9 +276,21 @@ foreach ($project in $projects) {
         continue
     }
 
-    $binDir = Join-PathMany -Base $dir -Parts @("bin", "Debug", "net9.0")
-    if (-not (Test-Path $binDir)) {
-        throw "Build output dir not found: $binDir"
+    # Locate bin/Debug/<framework>/ without hardcoding the framework — the
+    # Prolog harness picks the TargetFramework dynamically from the host's
+    # installed SDKs (UNIFYWEAVER_DOTNET_FRAMEWORK > `dotnet --list-sdks`
+    # highest > 'net9.0' fallback), so the directory name varies by runner.
+    $debugDir = Join-PathMany -Base $dir -Parts @("bin", "Debug")
+    if (-not (Test-Path $debugDir)) {
+        throw "Build output dir not found: $debugDir (no bin/Debug)"
+    }
+    $binDir = Get-ChildItem -Path $debugDir -Directory -Filter "net*" -ErrorAction SilentlyContinue |
+        Select-Object -First 1 |
+        ForEach-Object FullName
+    if (-not $binDir) {
+        $candidates = (Get-ChildItem -Path $debugDir -Directory -ErrorAction SilentlyContinue |
+            ForEach-Object Name) -join ", "
+        throw "Build output dir not found: $debugDir/net* (found subdirs: $candidates)"
     }
 
     $dll = Get-ChildItem -Path $binDir -File -Filter "*.dll" | Where-Object { $_.Name -notlike "*.deps.dll" } | Select-Object -First 1


### PR DESCRIPTION
## Summary

Fixes the `csharp_query_runtime_smoke` CI job, which started failing after #2366 with:

```
Failure detail: "Build output dir not found:
  /home/runner/work/UnifyWeaver/UnifyWeaver/tmp/csharp_query_smoke_ci/.../bin/Debug/net9.0"
```

#2366 introduced framework auto-detection in the Prolog harness so the `.csproj`'s `<TargetFramework>` is picked from `dotnet --list-sdks`. The PowerShell smoke runner that drives the CI job still hardcoded `bin/Debug/net9.0` in its post-build lookup, so when the harness probe landed anywhere other than `net9.0` (which can happen on a runner with multiple SDKs pre-installed even after `setup-dotnet@v4` adds 9.0.x), the script crashed before it could find the built binary.

## Changes

1. **`scripts/testing/run_csharp_query_runtime_smoke.ps1`** — replace the hardcoded `bin/Debug/net9.0` path with `Get-ChildItem -Path bin/Debug -Directory -Filter "net*"` and take the first match. Now finds whichever `bin/Debug/<framework>/` directory `dotnet build` actually emits. Diagnostic on miss lists candidate subdirs.

2. **`scripts/testing/generate_csharp_manual.pl`** — same `dotnet --list-sdks` probe (plus `UNIFYWEAVER_DOTNET_FRAMEWORK` override) as the test harness uses, so the manual demo script also runs on hosts without `net9.0`.

3. **`.github/workflows/test.yml`** — pin `UNIFYWEAVER_DOTNET_FRAMEWORK: net9.0` for the smoke job, matching the `setup-dotnet@v4` install. The PS-side discovery is robust either way; the pin just makes CI deterministic regardless of which other SDKs the runner image has pre-installed.

## Test plan

- [x] Visually verified `Get-ChildItem -Directory -Filter "net*"` returns `DirectoryInfo` objects; `Select-Object -First 1 | ForEach-Object FullName` produces the absolute path the rest of the script expects.
- [x] Diagnostic miss-case (`debugDir` exists but no `net*` subdir) lists the actual subdirs present so future failures self-explain.
- [x] CI workflow change is additive (one new env var); no step semantics altered.
- [ ] Awaiting CI run on this PR to confirm the smoke job goes green.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_