### PR TITLE
test(wam-clojure): cover string concat output mode

### DIFF
--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -198,6 +198,7 @@
 :- dynamic user:wam_atom_concat_unbound_right/1.
 :- dynamic user:wam_atom_concat_unbound_both/1.
 :- dynamic user:wam_string_concat_guard/3.
+:- dynamic user:wam_string_concat_new_string/0.
 :- dynamic user:wam_string_concat_unbound_left/1.
 :- dynamic user:wam_string_concat_unbound_right/1.
 :- dynamic user:wam_atom_length_guard/2.
@@ -431,6 +432,7 @@ user:wam_atom_concat_unbound_left(C) :- user:wam_unbound_arg(A), atom_concat(A, 
 user:wam_atom_concat_unbound_right(C) :- user:wam_unbound_arg(B), atom_concat(fo, B, C), B = o.
 user:wam_atom_concat_unbound_both(C) :- user:wam_unbound_arg(A), user:wam_unbound_arg(B), atom_concat(A, B, C).
 user:wam_string_concat_guard(A, B, C) :- string_concat(A, B, C).
+user:wam_string_concat_new_string :- string_concat(fo, o, X), X = foo.
 user:wam_string_concat_unbound_left(C) :- user:wam_unbound_arg(A), string_concat(A, o, C), A = fo.
 user:wam_string_concat_unbound_right(C) :- user:wam_unbound_arg(B), string_concat(fo, B, C), B = o.
 user:wam_atom_length_guard(A, N) :- atom_length(A, N).
@@ -669,6 +671,7 @@ run_smoke :-
           user:wam_atom_concat_unbound_right/1,
           user:wam_atom_concat_unbound_both/1,
           user:wam_string_concat_guard/3,
+          user:wam_string_concat_new_string/0,
           user:wam_string_concat_unbound_left/1,
           user:wam_string_concat_unbound_right/1,
           user:wam_atom_length_guard/2,
@@ -1073,6 +1076,7 @@ smoke_cases([
     case('wam_atom_concat_unbound_right/1', bar, "false"),
     case('wam_atom_concat_unbound_both/1', foo, "false"),
     case('wam_string_concat_guard/3', args(fo, o, foo), "true"),
+    case('wam_string_concat_new_string/0', no_args, "true"),
     case('wam_string_concat_unbound_left/1', foo, "true"),
     case('wam_string_concat_unbound_right/1', foo, "true"),
     case('wam_atom_length_guard/2', args(foo, 3), "true"),
@@ -1446,6 +1450,7 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-atom-concat-guard-3"),
     has(CoreCode, "defn lowered-wam-atom-concat-unbound-left-1"),
     has(CoreCode, "defn lowered-wam-atom-concat-unbound-right-1"),
+    has(CoreCode, "defn lowered-wam-string-concat-new-string-0"),
     has(CoreCode, "defn lowered-wam-string-concat-unbound-left-1"),
     has(CoreCode, "defn lowered-wam-string-concat-unbound-right-1"),
     has(CoreCode, "defn lowered-wam-atom-length-guard-2"),


### PR DESCRIPTION
## Summary

- Adds a Clojure WAM runtime smoke regression for `string_concat(fo, o, X), X = foo`.
- Registers the new `wam_string_concat_new_string/0` fixture alongside the existing `string_concat/3` guard and split-binding cases.
- Asserts that the generated lowered Clojure core includes the new fixture function.

## Why

The Clojure WAM smoke suite already covered `string_concat/3` guard mode and unbound-left/right split modes, but it lacked the common output-variable mode where both inputs are bound and the result is produced into a fresh variable. This mirrors the existing `atom_concat_new_atom/0` coverage and tightens text builtin parity.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
