### PR TITLE
feat(wam-fsharp): wire compiled-parser mode + surface emitter gaps

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -61,6 +61,12 @@
 :- use_module('../core/template_system', [render_template/3]).
 :- use_module('../core/purity_certificate', [analyze_predicate_purity/2]).
 :- use_module('../bindings/fsharp_wam_bindings').
+:- use_module('../core/prolog_term_parser').
+:- use_module('../core/cpp_runtime_parser_wrappers').
+:- use_module(wam_runtime_parser_capability, [
+    parser_dependent_body_goal/2,
+    wam_target_runtime_parser/3
+]).
 
 % Phase 3 lowered emitter lives in wam_fsharp_lowered_emitter.
 :- reexport('wam_fsharp_lowered_emitter',
@@ -149,8 +155,19 @@ wam_fsharp_indicator_in_list(_Mod:Pred/Arity, HotPreds) :-
     member(Pred/Arity, HotPreds), !.
 
 wam_fsharp_predicate_wamcode(PI, WamCode) :-
-    (   PI = _Module:Pred/Arity -> true ; PI = Pred/Arity ),
-    wam_target:compile_predicate_to_wam(Pred/Arity, [], WamCode).
+    %% Module-qualified indicators (e.g. prolog_term_parser:foo/2 from
+    %% the compiled runtime parser library) are passed through to the
+    %% WAM compiler verbatim so it looks clauses up in the right
+    %% module.  Stripping to the bare Name/Arity, the previous
+    %% behaviour, defaulted lookup to `user:` and produced
+    %% "WAM target: no clauses for user:foo/2" for library
+    %% predicates.
+    (   PI = user:Pred/Arity
+    ->  wam_target:compile_predicate_to_wam(Pred/Arity, [], WamCode)
+    ;   PI = _Module:_Pred/_Arity
+    ->  wam_target:compile_predicate_to_wam(PI, [], WamCode)
+    ;   wam_target:compile_predicate_to_wam(PI, [], WamCode)
+    ).
 
 % ============================================================================
 % FFI-owned fact detection (Phase D: skip WAM-compilation for pure FFI facts)
@@ -2874,9 +2891,40 @@ wam_instr_to_fsharp(["not_member_set", EReg, SReg], Fs) :-
     fs_reg_name_to_int(CE, EI), fs_reg_name_to_int(CS, SI),
     format(string(Fs), 'NotMemberSet (~w, ~w)', [EI, SI]).
 
-% Fallback for unknown instructions
+% Fallback for unknown instructions.
+%
+% The F# WAM emitter doesn't recognize every WAM instruction the
+% shared compiler can produce -- specifically `get_structure`,
+% certain `unify_constant`/`get_constant` forms, and the
+% `switch_on_term` / `switch_on_constant_fallthrough` variants
+% used by indexed dispatch -- and silently replaced them with
+% `Proceed`, which lets the predicate "compile" but breaks runtime
+% semantics (predicate returns immediately without doing the
+% work).  This was found while wiring the compiled portable Prolog
+% parser through F# (`runtime_parser(compiled)`): the parser's WAM
+% has ~120 lines emitted as `Proceed` stubs across `get_structure`
+% (op/3, [|]/2, tk_atom/1, tk_num/1, tk_sym/1, tk_var/1, -/2),
+% `get_constant ' '`, `unify_constant ' '`, and four
+% `switch_on_*` variants.
+%
+% Until the emitter learns these instructions, surface the gap on
+% stderr at codegen time rather than letting it pretend to compile
+% cleanly.  Deduplicated per (head-token, arity) so a noisy
+% predicate doesn't drown the output.
+:- dynamic wam_fsharp_unknown_seen/2.
+
 wam_instr_to_fsharp(Parts, Fs) :-
     atomic_list_concat(Parts, ' ', Joined),
+    (   Parts = [Head|_], length(Parts, Len)
+    ->  (   wam_fsharp_unknown_seen(Head, Len)
+        ->  true
+        ;   assertz(wam_fsharp_unknown_seen(Head, Len)),
+            format(user_error,
+                   '[WAM-FSharp] WARNING: instruction not supported by emitter -> emitting Proceed stub: ~w~n',
+                   [Joined])
+        )
+    ;   true
+    ),
     format(string(Fs), '(* UNKNOWN: ~w *) Proceed', [Joined]).
 
 %% fs_parse_switch_entries(+Entries, -FSharpPairs)
@@ -2897,6 +2945,92 @@ fs_parse_switch_entries([Entry|Rest], [FsPair|FsRest]) :-
 % write_wam_fsharp_project/3 — Project Generation
 % ============================================================================
 
+%% Runtime parser integration helpers ---------------------------------------
+%
+% F# adopts the `compiled(prolog_term_parser)` runtime-parser mode
+% from `wam_runtime_parser_capability.pl`, mirroring Python's
+% approach.  When that mode is selected, the portable parser
+% predicates (defined in `src/unifyweaver/core/prolog_term_parser.pl`)
+% and the target-agnostic wrappers (`read_term_from_atom/2,3` etc.,
+% from `src/unifyweaver/core/cpp_runtime_parser_wrappers.pl`) are
+% appended to the user's predicate list so they're compiled to WAM
+% and emitted into `Predicates.fs`.  When `none` is selected, any
+% predicate whose body has a statically visible parser-dependent
+% call is rejected here rather than silently producing a runtime
+% that lacks the underlying parsing capability.
+
+%% fsharp_project_predicates(+UserPreds, +Mode, -ProjectPreds)
+%
+%  In `compiled` mode, append the portable parser + wrapper
+%  predicate indicators.  In other modes, leave the list untouched.
+fsharp_project_predicates(Predicates, compiled(prolog_term_parser), ProjectPredicates) :-
+    !,
+    fsharp_runtime_parser_predicates(ParserPreds),
+    fsharp_runtime_parser_wrapper_predicates(WrapperPreds),
+    append([Predicates, ParserPreds, WrapperPreds], Combined),
+    sort(Combined, ProjectPredicates).
+fsharp_project_predicates(Predicates, _RuntimeParserMode, Predicates).
+
+%% fsharp_runtime_parser_predicates(-Predicates)
+%
+%  Enumerate non-imported predicates of `prolog_term_parser` as
+%  `prolog_term_parser:Name/Arity` indicators.  Matches Python's
+%  approach in `python_runtime_parser_predicates/1`.
+fsharp_runtime_parser_predicates(Predicates) :-
+    findall(prolog_term_parser:Name/Arity,
+            ( current_predicate(prolog_term_parser:Name/Arity),
+              functor(Head, Name, Arity),
+              once(clause(prolog_term_parser:Head, _)),
+              \+ predicate_property(prolog_term_parser:Head, imported_from(_))
+            ),
+            Raw),
+    sort(Raw, Predicates).
+
+%% fsharp_runtime_parser_wrapper_predicates(-Predicates)
+%
+%  Enumerate non-imported predicates of `cpp_runtime_parser_wrappers`
+%  (the module name is C++-historical but the wrappers themselves are
+%  target-agnostic per the module-header comment).
+fsharp_runtime_parser_wrapper_predicates(Predicates) :-
+    findall(cpp_runtime_parser_wrappers:Name/Arity,
+            ( current_predicate(cpp_runtime_parser_wrappers:Name/Arity),
+              functor(Head, Name, Arity),
+              once(clause(cpp_runtime_parser_wrappers:Head, _)),
+              \+ predicate_property(cpp_runtime_parser_wrappers:Head,
+                                    imported_from(_))
+            ),
+            Raw),
+    sort(Raw, Predicates).
+
+%% fsharp_validate_runtime_parser_mode(+Predicates, +Mode)
+%
+%  When the mode is `none`, reject any user predicate whose body
+%  statically calls a parser-dependent builtin.  Mirrors
+%  `validate_python_runtime_parser_mode/2`.
+fsharp_validate_runtime_parser_mode(Predicates, none) :-
+    !,
+    (   fsharp_predicates_parser_dependency(Predicates, Pred, Builtin)
+    ->  throw(error(permission_error(use, runtime_parser, Builtin),
+                    context(write_wam_fsharp_project/3,
+                            parser_disabled_for_predicate(Pred))))
+    ;   true
+    ).
+fsharp_validate_runtime_parser_mode(_Predicates, _Mode).
+
+fsharp_predicates_parser_dependency(Predicates, Pred, Builtin) :-
+    member(Pred, Predicates),
+    fsharp_predicate_clause(Pred, _Head, Body),
+    parser_dependent_body_goal(Body, Builtin),
+    !.
+
+fsharp_predicate_clause(Module:Name/Arity, Head, Body) :-
+    !,
+    functor(Head, Name, Arity),
+    clause(Module:Head, Body).
+fsharp_predicate_clause(Name/Arity, Head, Body) :-
+    functor(Head, Name, Arity),
+    clause(user:Head, Body).
+
 %% write_wam_fsharp_project(+Predicates, +Options, +ProjectDir)
 %  Generates a complete F# project with:
 %  - WamTypes.fs:   Value DU, WamState, WamContext, helpers
@@ -2908,11 +3042,29 @@ fs_parse_switch_entries([Entry|Rest], [FsPair|FsRest]) :-
 write_wam_fsharp_project(Predicates, Options, ProjectDir) :-
     make_directory_path(ProjectDir),
 
-    % Kernel detection (skip with no_kernels(true))
+    % Resolve runtime parser mode (capability hook).  When `compiled`
+    % is selected, the portable parser predicates + the target-agnostic
+    % `read_term_from_atom`/`parse_*` wrappers are appended to the
+    % user's predicate list so the F# WAM compiler emits them too.
+    % When `none`, statically visible parser-dependent bodies are
+    % rejected at codegen time (Lua-style) rather than silently
+    % producing a stubbed runtime.
+    wam_target_runtime_parser(wam_fsharp, Options, RuntimeParserMode),
+    fsharp_validate_runtime_parser_mode(Predicates, RuntimeParserMode),
+    fsharp_project_predicates(Predicates, RuntimeParserMode, ProjectPredicates),
+    length(Predicates, NUserPreds),
+    length(ProjectPredicates, NAllPreds),
+    format(user_error,
+           '[WAM-FSharp] runtime_parser=~w (user=~w total=~w)~n',
+           [RuntimeParserMode, NUserPreds, NAllPreds]),
+
+    % Kernel detection (skip with no_kernels(true)).  Kernel detection
+    % runs on ProjectPredicates so portable-parser predicates can also
+    % be considered, but in practice they're not recursive kernels.
     (   option(no_kernels(true), Options)
     ->  DetectedKernels = [],
         format(user_error, '[WAM-FSharp] kernel detection suppressed~n', [])
-    ;   detect_kernels_fs(Predicates, DetectedKernels),
+    ;   detect_kernels_fs(ProjectPredicates, DetectedKernels),
         (   DetectedKernels \= []
         ->  pairs_keys(DetectedKernels, DetectedKeys),
             format(user_error, '[WAM-FSharp] detected kernels: ~w~n', [DetectedKeys])
@@ -2922,7 +3074,7 @@ write_wam_fsharp_project(Predicates, Options, ProjectDir) :-
 
     % Resolve emit mode and partition
     wam_fsharp_resolve_emit_mode(Options, EmitMode),
-    wam_fsharp_partition_predicates(EmitMode, Predicates, DetectedKernels, InterpList, LoweredList),
+    wam_fsharp_partition_predicates(EmitMode, ProjectPredicates, DetectedKernels, InterpList, LoweredList),
     length(InterpList, NInterp),
     length(LoweredList, NLower),
     format(user_error, '[WAM-FSharp] emit_mode=~w  interpreted=~w  lowered=~w~n',
@@ -2939,10 +3091,10 @@ write_wam_fsharp_project(Predicates, Options, ProjectDir) :-
     write_fs_file(RuntimePath, RuntimeCode),
 
     % Compute base PCs for all predicates (shared between Predicates.fs and Lowered.fs)
-    compute_base_pcs_fs(Predicates, BasePCMap),
+    compute_base_pcs_fs(ProjectPredicates, BasePCMap),
 
     % Generate Predicates.fs (skip FFI-owned facts — Phase D: -70%)
-    compile_predicates_to_fsharp(Predicates, Options, DetectedKernels, BasePCMap, PredsCode),
+    compile_predicates_to_fsharp(ProjectPredicates, Options, DetectedKernels, BasePCMap, PredsCode),
     directory_file_path(ProjectDir, 'Predicates.fs', PredsPath),
     write_fs_file(PredsPath, PredsCode),
 
@@ -2952,7 +3104,9 @@ write_wam_fsharp_project(Predicates, Options, ProjectDir) :-
     directory_file_path(ProjectDir, 'Lowered.fs', LoweredPath),
     write_fs_file(LoweredPath, LoweredCode),
 
-    % Generate Program.fs (benchmark driver)
+    % Generate Program.fs (benchmark driver).  The driver calls into
+    % USER predicates only -- portable-parser predicates are library
+    % code, not entry points -- so this stays on the original list.
     option(module_name(ModName), Options, 'wam-fsharp-bench'),
     generate_program_fs(Predicates, DetectedKernels, Options, ProgramCode),
     directory_file_path(ProjectDir, 'Program.fs', ProgramPath),

--- a/src/unifyweaver/targets/wam_runtime_parser_capability.pl
+++ b/src/unifyweaver/targets/wam_runtime_parser_capability.pl
@@ -115,17 +115,33 @@ target_runtime_parser_default(wam_r, native(parse_term)).
 % restriction; we register both modes here and leave native as
 % the default since it ships today.
 target_runtime_parser_default(wam_cpp, native(parse_term)).
+% F# has no native runtime parser today; the F# target compiles
+% Prolog through WAM and can host the portable parser like Python
+% does, but several WAM instructions the parser needs are not yet
+% supported by the F# emitter (`get_structure`, certain
+% `unify_constant`/`get_constant` forms, the `switch_on_term` /
+% `switch_on_constant_fallthrough` variants) and are emitted as
+% `Proceed` stubs.  As a result, parser predicates COMPILE but
+% don't EXECUTE correctly today.  Default is therefore `none` so
+% existing F# projects don't silently pull the parser library in;
+% `runtime_parser(compiled)` is opt-in and primarily useful for
+% stress-testing the emitter while the missing instructions are
+% being filled in.
+target_runtime_parser_default(wam_fsharp, none).
 
 target_runtime_parser_mode_(wam_r, native(parse_term)).
 target_runtime_parser_mode_(wam_r, compiled(prolog_term_parser)).
 target_runtime_parser_mode_(wam_cpp, native(parse_term)).
 target_runtime_parser_mode_(wam_cpp, compiled(prolog_term_parser)).
 target_runtime_parser_mode_(wam_python, compiled(prolog_term_parser)).
+target_runtime_parser_mode_(wam_fsharp, compiled(prolog_term_parser)).
 
 normalize_runtime_parser_target(r, wam_r) :- !.
 normalize_runtime_parser_target(wam_r, wam_r) :- !.
 normalize_runtime_parser_target(cpp, wam_cpp) :- !.
 normalize_runtime_parser_target(wam_cpp, wam_cpp) :- !.
+normalize_runtime_parser_target(fsharp, wam_fsharp) :- !.
+normalize_runtime_parser_target(wam_fsharp, wam_fsharp) :- !.
 normalize_runtime_parser_target(Target, Target).
 
 strip_module_qualifier(Module:Goal, Stripped) :-

--- a/tests/test_wam_runtime_parser_capability.pl
+++ b/tests/test_wam_runtime_parser_capability.pl
@@ -122,4 +122,31 @@ test(parser_dependent_body_goal_forward_term_to_atom_ignored, [fail]) :-
 test(parser_dependent_body_goal_module_qualified_body) :-
     once(parser_dependent_body_goal(user:(true, read(_, _)), read/2)).
 
+% --- F# WAM target (compiled mode opt-in only) ----------------------------
+%
+% Default is `none` because the F# WAM instruction emitter is
+% missing several instructions the portable parser needs
+% (`get_structure`, certain `unify_constant`/`get_constant` forms,
+% `switch_on_term`, `switch_on_constant_fallthrough`).  They're
+% emitted as `Proceed` stubs today, so parser predicates compile
+% but don't execute correctly.  `runtime_parser(compiled)` makes
+% the wiring exercise itself a stress test for the F# emitter.
+
+test(fsharp_defaults_to_none) :-
+    wam_target_runtime_parser(wam_fsharp, [], none).
+
+test(fsharp_alias_defaults_to_none) :-
+    wam_target_runtime_parser(fsharp, [], none).
+
+test(fsharp_can_opt_into_compiled_parser) :-
+    wam_target_runtime_parser(wam_fsharp, [runtime_parser(compiled)],
+                              compiled(prolog_term_parser)).
+
+test(fsharp_cannot_require_native_parser_yet,
+     [throws(error(domain_error(runtime_parser_mode(wam_fsharp), native), _))]) :-
+    wam_target_runtime_parser(wam_fsharp, [runtime_parser(native)], _).
+
+test(fsharp_off_explicit_none) :-
+    wam_target_runtime_parser(wam_fsharp, [runtime_parser(off)], none).
+
 :- end_tests(wam_runtime_parser_capability).


### PR DESCRIPTION
## Summary

Wires the F# WAM target into `wam_runtime_parser_capability.pl`'s `compiled(prolog_term_parser)` mode (opt-in only), and uses that wiring as a stress test to surface concrete gaps in the F# WAM instruction emitter. Bottom line:

- ✅ **Capability hook is wired** — `wam_target_runtime_parser(wam_fsharp, _, _)` resolves correctly for `auto`/`off`/`native`/`compiled`.
- ✅ **Project generation works** — with `runtime_parser(compiled)`, every non-imported `prolog_term_parser:` predicate plus the four target-agnostic wrappers (`read_term_from_atom/2,3`, `parse_atom_to_term/2`, `parse_term_to_atom/2`) are appended to the project predicate list.
- ✅ **Dotnet build passes clean** — a 50-predicate F# project compiles with zero warnings/errors.
- ❌ **Runtime execution fails** — even trivial `canonical_op_table/1` returns `None` because the F# WAM emitter is missing several instructions the parser needs and silently writes them as `Proceed` stubs.

Default is `none` so existing F# projects don't pull the parser library in. `runtime_parser(compiled)` is opt-in and acts as the emitter stress test.

## What's in the diff

**`wam_runtime_parser_capability.pl`** — add `wam_fsharp` rows for default + supported modes, plus `fsharp`/`wam_fsharp` aliases.

**`wam_fsharp_target.pl`**:

- Route `write_wam_fsharp_project/3` through `wam_target_runtime_parser/3`. In `compiled` mode, append parser + wrapper predicates and run kernel detection / partition / compile on the merged list. In `none` mode, reject any user predicate whose body statically calls a parser-dependent builtin (Lua-style validation).
- Stop stripping module qualifiers in `wam_fsharp_predicate_wamcode/2`. Without this, library predicates like `prolog_term_parser:canonical_op_table/1` were resolved against `user:` and the WAM compiler errored "no clauses for user:canonical_op_table/1". The shared `compile_predicate_to_wam/3` already accepts qualified indicators, so this is the minimal fix.
- Replace the silent `(* UNKNOWN: ... *) Proceed` fallback with a deduplicated stderr warning, so the emitter gap stops hiding.

**`tests/test_wam_runtime_parser_capability.pl`** — 5 capability-hook tests covering the F# default (`none`), the alias resolution (`fsharp` → `wam_fsharp`), the `compiled` opt-in, the `native` rejection (no native parser yet), and explicit `off`.

## Surfaced limitations (the deliverable)

Running `runtime_parser(compiled)` against the F# emitter produces ~7 distinct warnings — instructions the F# emitter doesn't recognize and silently turns into no-op `Proceed`:

| Missing instruction | Where the parser uses it |
|---|---|
| `get_structure op/3` | Building the canonical operator table |
| `get_structure [|]/2` | Every cons cell in the op table (~43 entries) |
| `get_structure -/2` | Number-handling `can_lead_negative` |
| `get_structure tk_atom/1` / `tk_num/1` / `tk_sym/1` / `tk_var/1` | Tokenizer token-shape dispatch |
| `unify_constant ' '` / `get_constant ' '` | Whitespace handling in tokenizer |
| `switch_on_term 0/1/2 ...` | Var/constant/compound dispatch (indexing) |
| `switch_on_constant_fallthrough _:default` (+ `fy`/`yf`/`yfx`/`[]` variants) | Operator-type dispatch in `is_prefix_type` / `is_postfix_type` / `is_infix_type` |

These were entirely silent before — the emitter had a catch-all fallback that wrote a comment and a `Proceed`. The new stderr warning surfaces each missing instruction kind once per run, named concretely, so the follow-up work has a clear punch list.

## Test plan

- [x] `swipl -g run_tests -t halt tests/test_wam_runtime_parser_capability.pl` — all 33 pre-existing + 5 new tests pass.
- [x] `swipl -g main -t halt tests/run_wam_fsharp_tests.pl` — F# WAM suite still 2/2 passes (codegen + dotnet runtime smokes). Zero new emitter warnings because default is `none`.
- [x] Opt-in compiled smoke: generated F# project with `runtime_parser(compiled)`, 50 predicates, `dotnet build` succeeds in ~17s with 0 errors/warnings.
- [x] Runtime probe of `canonical_op_table/1`, `tokenize/2`, `parse_term_from_atom/3`, and `read_term_from_atom/2` all return `None` at runtime — confirms the gap is real and not a wiring issue.

## Follow-ups (not in this PR)

1. Teach the F# emitter the seven missing instructions. The warning lines name each one and the parser library exercises all of them, so the test loop is just "request `runtime_parser(compiled)`, build, watch warnings go to zero, then test runtime."
2. Once instructions land, add a dotnet runtime smoke that asserts `read_term_from_atom('foo(bar)', T), T = foo(bar)` succeeds end-to-end. Pattern is identical to the Python compiled-parser tests in `tests/test_wam_python_target.pl:564-585`.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_