### PR TITLE
feat(wam-fsharp): write-mode unify_* + builder stack (parser predicates now execute)

### DIFF
--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -207,6 +207,14 @@ type WamState =
       WsCutBar    : int                  // cut barrier depth
       WsVarCounter: int                  // fresh variable id counter
       WsBuilder   : BuilderState option  // PutStructure / PutList accumulator
+      // Stack of outer build / read contexts saved when a GetStructure
+      // or GetList nests into the active context (e.g. `[op(:-,1200,xfx)|T]`
+      // needs the outer BuildList active while the inner BuildStruct
+      // fills, then restores on inner materialization).  Both R
+      // (templates/targets/r_wam/runtime.R.mustache build_stack) and
+      // Python (src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+      // write_stack/read_stack) maintain the same stack discipline.
+      WsBuilderStack : BuilderState list
       WsAggAccum  : Value list           // aggregate accumulator
     }
 
@@ -414,6 +422,31 @@ let bindOutput (reg: int) (value: Value) (s: WamState) : WamState option =
         | _ -> None
 
 /// Append a value to the current builder (PutStructure / PutList).
+// popBuilderStack: when an inner builder is finished (BuildStruct/List
+// arity filled, or ReadArgs exhausted), restore the outer builder
+// from WsBuilderStack so the parent structure can keep filling.
+// Both R (build_stack pop in append_build_arg) and Python (write_stack
+// pop in _finish_write_ctx) do this on every fill completion -- not
+// just the final one -- in case the parent is also at its limit.
+// We don''t cascade-fill here (the parent already holds an Unbound
+// var bound to the inner struct via its register, so derefVar
+// resolves it transparently); we just unwind the saved contexts.
+let popBuilderStack (s: WamState) : WamState =
+    match s.WsBuilderStack with
+    | outer :: rest -> { s with WsBuilder = Some outer; WsBuilderStack = rest }
+    | []            -> { s with WsBuilder = None }
+
+// pushBuilderIfActive: when starting a new inner build/read context
+// (GetStructure / GetList on a register that produces nesting), save
+// the current builder onto the stack so the inner can use WsBuilder
+// without clobbering the outer.  No-op when there''s no active
+// builder.  Returns the modified state; callers then set the new
+// WsBuilder on the returned state.
+let pushBuilderIfActive (s: WamState) : WamState =
+    match s.WsBuilder with
+    | Some b -> { s with WsBuilderStack = b :: s.WsBuilderStack }
+    | None   -> s
+
 let addToBuilder (value: Value) (s: WamState) : WamState option =
     match s.WsBuilder with
     | None -> None
@@ -424,20 +457,18 @@ let addToBuilder (value: Value) (s: WamState) : WamState option =
             let r = Array.copy s.WsRegs
             let regVal = if reg >= 0 && reg < s.WsRegs.Length then s.WsRegs.[reg] else Unbound -1
             r.[reg] <- str
-            match derefVar s.WsBindings regVal with
-            | Unbound vid ->
-                Some { s with
-                         WsPC      = s.WsPC + 1
+            let s0 =
+                match derefVar s.WsBindings regVal with
+                | Unbound vid ->
+                    { s with
                          WsRegs    = r
                          WsBindings= Map.add vid str s.WsBindings
                          WsTrail   = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
-                         WsTrailLen= s.WsTrailLen + 1
-                         WsBuilder = None }
-            | _ ->
-                Some { s with
-                         WsPC      = s.WsPC + 1
-                         WsRegs    = r
-                         WsBuilder = None }
+                         WsTrailLen= s.WsTrailLen + 1 }
+                | _ ->
+                    { s with WsRegs = r }
+            let s1 = popBuilderStack s0
+            Some { s1 with WsPC = s.WsPC + 1 }
         else
             Some { s with WsPC = s.WsPC + 1; WsBuilder = Some (BuildStruct (fn, reg, arity, args')) }
     | Some (BuildList (reg, items)) ->
@@ -452,20 +483,18 @@ let addToBuilder (value: Value) (s: WamState) : WamState option =
             let r = Array.copy s.WsRegs
             let regVal = if reg >= 0 && reg < s.WsRegs.Length then s.WsRegs.[reg] else Unbound -1
             r.[reg] <- listVal
-            match derefVar s.WsBindings regVal with
-            | Unbound vid ->
-                Some { s with
-                         WsPC      = s.WsPC + 1
+            let s0 =
+                match derefVar s.WsBindings regVal with
+                | Unbound vid ->
+                    { s with
                          WsRegs    = r
                          WsBindings= Map.add vid listVal s.WsBindings
                          WsTrail   = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
-                         WsTrailLen= s.WsTrailLen + 1
-                         WsBuilder = None }
-            | _ ->
-                Some { s with
-                         WsPC      = s.WsPC + 1
-                         WsRegs    = r
-                         WsBuilder = None }
+                         WsTrailLen= s.WsTrailLen + 1 }
+                | _ ->
+                    { s with WsRegs = r }
+            let s1 = popBuilderStack s0
+            Some { s1 with WsPC = s.WsPC + 1 }
         else
             Some { s with WsPC = s.WsPC + 1; WsBuilder = Some (BuildList (reg, items')) }
     | Some (ReadArgs _) -> None
@@ -473,8 +502,10 @@ let addToBuilder (value: Value) (s: WamState) : WamState option =
 let readNextArg (s: WamState) : (Value * WamState) option =
     match s.WsBuilder with
     | Some (ReadArgs (v :: rest)) ->
-        let nextBuilder = match rest with [] -> None | _ -> Some (ReadArgs rest)
-        Some (derefVar s.WsBindings v, { s with WsBuilder = nextBuilder })
+        let s' =
+            if List.isEmpty rest then popBuilderStack s
+            else { s with WsBuilder = Some (ReadArgs rest) }
+        Some (derefVar s.WsBindings v, s')
     | _ -> None
 
 /// Arithmetic evaluator over Value terms.

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -616,11 +616,23 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         | _ -> None
 
     | GetStructure (fn, arity, ai) ->
+        // If we''re already inside a build/read context, push it so the
+        // parent structure can resume filling once this inner one
+        // materializes / is exhausted.  Without this push, nested
+        // patterns like `[op(:-,1200,xfx) | Rest]` overwrite the outer
+        // BuildList and lose track of where to return.
         match getReg ai s with
         | Some (Str (fn0, args)) when fn0 = fn && List.length args = arity ->
-            if arity = 0 then Some { s with WsPC = s.WsPC + 1; WsBuilder = None }
-            else Some { s with WsPC = s.WsPC + 1; WsBuilder = Some (ReadArgs args) }
+            // arity = 0: no args to read, outer builder (if any) keeps running.
+            if arity = 0 then Some { s with WsPC = s.WsPC + 1 }
+            else
+                let push = pushBuilderIfActive s
+                Some { push with WsPC = s.WsPC + 1; WsBuilder = Some (ReadArgs args) }
         | Some (Unbound vid) when arity = 0 ->
+            // Atom-arity struct write: bind reg to Str(fn, []).  Outer
+            // builder''s arg slot, if any, already holds the Unbound var
+            // we just bound to the atom -- no append needed, outer
+            // continues.
             let str = Str (fn, [])
             let r = Array.copy s.WsRegs
             r.[ai] <- str
@@ -629,34 +641,57 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                      WsRegs    = r
                      WsBindings= Map.add vid str s.WsBindings
                      WsTrail   = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
-                     WsTrailLen= s.WsTrailLen + 1
-                     WsBuilder = None }
+                     WsTrailLen= s.WsTrailLen + 1 }
         | Some (Unbound _) ->
-            Some { s with WsPC = s.WsPC + 1; WsBuilder = Some (BuildStruct (fn, ai, arity, [])) }
+            let push = pushBuilderIfActive s
+            Some { push with WsPC = s.WsPC + 1; WsBuilder = Some (BuildStruct (fn, ai, arity, [])) }
         | _ -> None
 
     | GetList ai ->
+        let push = pushBuilderIfActive s
         match getReg ai s with
         | Some (VList (h :: t)) ->
-            Some { s with WsPC = s.WsPC + 1; WsBuilder = Some (ReadArgs [h; VList t]) }
+            Some { push with WsPC = s.WsPC + 1; WsBuilder = Some (ReadArgs [h; VList t]) }
         | Some (Unbound _) ->
-            Some { s with WsPC = s.WsPC + 1; WsBuilder = Some (BuildList (ai, [])) }
+            Some { push with WsPC = s.WsPC + 1; WsBuilder = Some (BuildList (ai, [])) }
         | _ -> None
 
     | UnifyVariable xn ->
         match readNextArg s with
         | Some (v, s1) -> Some (putReg xn v { s1 with WsPC = s.WsPC + 1 })
-        | None         -> None
+        | None ->
+            // Write mode: GetList / GetStructure on an unbound register
+            // sets WsBuilder = Some (BuildList _) | Some (BuildStruct _),
+            // and the following Unify* instructions must APPEND a fresh
+            // var to the structure being constructed.  The R and Python
+            // runtimes both do the same (templates/targets/r_wam/runtime.R.mustache
+            // around UnifyVariable, src/unifyweaver/targets/wam_python_runtime
+            // /WamRuntime.py:1760).  addToBuilder advances PC and
+            // materializes the struct/list once arity is reached, so
+            // PC is NOT advanced here directly.
+            let vid = s.WsVarCounter
+            let var = Unbound vid
+            let s1 = putReg xn var { s with WsVarCounter = s.WsVarCounter + 1 }
+            addToBuilder var s1
 
     | UnifyValue xn ->
-        match readNextArg s, getReg xn s with
-        | Some (v, s1), Some x -> unifyVal v x s1
-        | _                    -> None
+        match readNextArg s with
+        | Some (v, s1) ->
+            match getReg xn s with
+            | Some x -> unifyVal v x s1
+            | None   -> None
+        | None ->
+            // Write mode: append value-of-xn to builder.
+            match getReg xn s with
+            | Some v -> addToBuilder v s
+            | None   -> None
 
     | UnifyConstant c ->
         match readNextArg s with
         | Some (v, s1) -> unifyVal v c s1
-        | None         -> None
+        | None ->
+            // Write mode: append constant to builder.
+            addToBuilder c s
 
     | PutConstant (c, ai) ->
         let r = Array.copy s.WsRegs
@@ -683,10 +718,15 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         | None   -> None
 
     | PutStructure (fn, ai, arity) ->
-        Some { s with WsPC = s.WsPC + 1; WsBuilder = Some (BuildStruct (fn, ai, arity, [])) }
+        // PutStructure starts a fresh build context.  If we''re already
+        // inside one (nested PutStructure for compound subterms in a
+        // body call), push the outer so it can resume.
+        let push = pushBuilderIfActive s
+        Some { push with WsPC = s.WsPC + 1; WsBuilder = Some (BuildStruct (fn, ai, arity, [])) }
 
     | PutList ai ->
-        Some { s with WsPC = s.WsPC + 1; WsBuilder = Some (BuildList (ai, [])) }
+        let push = pushBuilderIfActive s
+        Some { push with WsPC = s.WsPC + 1; WsBuilder = Some (BuildList (ai, [])) }
 
     | SetValue xn ->
         match getReg xn s with
@@ -1713,7 +1753,8 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         let mArity = getReg arityReg s
         match mName, mArity with
         | Some (Atom fname), Some (Integer arity) when arity >= 0 ->
-            Some { s with
+            let push = pushBuilderIfActive s
+            Some { push with
                      WsPC      = s.WsPC + 1
                      WsBuilder = Some (BuildStruct (fname, targetReg, arity, [])) }
         | _ -> None  // name must be Atom, arity a non-negative Integer
@@ -3605,6 +3646,7 @@ let main argv =
           WsCutBar     = 0
           WsVarCounter = 0
           WsBuilder    = None
+          WsBuilderStack = []
           WsAggAccum   = [] }
 
     // Find entry point: prefer lowered predicates, fall back to code array

--- a/tests/fixtures/wam_fsharp_naf_microbench/Driver.fs
+++ b/tests/fixtures/wam_fsharp_naf_microbench/Driver.fs
@@ -109,6 +109,7 @@ let mkState () =
       WsCutBar     = 0
       WsVarCounter = 1000
       WsBuilder    = None
+      WsBuilderStack = []
       WsAggAccum   = [] }
 
 let runScenario (name: string) (branch1: Instruction list) (expectTrue: bool) (slowSize: int) : int64 * int64 * bool =

--- a/tests/fixtures/wam_fsharp_phase_i_lowered_smoke/Driver.fs
+++ b/tests/fixtures/wam_fsharp_phase_i_lowered_smoke/Driver.fs
@@ -65,6 +65,7 @@ let mkState (regs: (int * Value) list) =
       WsCutBar     = 0
       WsVarCounter = 0
       WsBuilder    = None
+      WsBuilderStack = []
       WsAggAccum   = [] }
 
 // -- arg/3 specialized ----------------------------------------------------

--- a/tests/fixtures/wam_fsharp_query_smoke/Driver.fs
+++ b/tests/fixtures/wam_fsharp_query_smoke/Driver.fs
@@ -87,6 +87,7 @@ let mkQueryState (a1: Value) (a2: Value) (vidStart: int) =
       WsCutBar     = 0
       WsVarCounter = vidStart
       WsBuilder    = None
+      WsBuilderStack = []
       WsAggAccum   = [] }
 
 // -- Working queries: clauses 1-2 reachable --------------------------------

--- a/tests/fixtures/wam_fsharp_smoke/Smoke.fs
+++ b/tests/fixtures/wam_fsharp_smoke/Smoke.fs
@@ -54,6 +54,7 @@ let mkEmptyState () =
       WsCutBar     = 0
       WsVarCounter = 0
       WsBuilder    = None
+      WsBuilderStack = []
       WsAggAccum   = [] }
 
 let mkContext (code: Instruction array) (labels: Map<string, int>) =


### PR DESCRIPTION
## Summary

Fixes the runtime gap surfaced by PR #2378: parser-library predicates returning `None` even though the emitter produced clean WAM. After this PR, **`canonical_op_table/1`** — the parser library's most structure-heavy predicate (builds a 30-element list of `op/3` facts) — **now executes successfully** under the F# runtime.

The user pointed out C++ and R already work; both R (`templates/targets/r_wam/runtime.R.mustache:1784`) and Python (`src/unifyweaver/targets/wam_python_runtime/WamRuntime.py:1760`) confirmed the canonical design, which this PR ports to F#.

## Changes

### Gap 1: `Unify_*` instructions only handled READ mode

`UnifyVariable`, `UnifyValue`, `UnifyConstant` all called `readNextArg` and returned `None` on failure — wrong when the active builder is a `BuildList` / `BuildStruct` (write mode) rather than `ReadArgs`. In write mode they must **append** to the structure under construction (fresh var, register value, or constant). Without this, even `canonical_op_table([op(...)|...])` failed on its second instruction: `GetList 1` enters write mode, and the immediately following `UnifyVariable 101` saw no read args and returned `None`.

**Fix**: each `Unify_*` arm now falls back to `addToBuilder` when `readNextArg` returns `None`. `addToBuilder` already correctly handles both `BuildList` and `BuildStruct` accumulation + materialization, so the routing change is one branch per instruction.

### Gap 2: `WsBuilder` was a single Option, not a stack

Nested structures (`[op(:-,1200,xfx) | Rest]` — outer list, first element is an `op/3`, both built concurrently) need to remember the outer build context while the inner fills. Before this PR, the inner `GetStructure` overwrote the outer `WsBuilder` and lost track of where to return when the inner materialized.

**Fix**: added `WsBuilderStack : BuilderState list` to `WamState` plus two helpers:
- `pushBuilderIfActive` saves the current builder onto the stack when a new `GetStructure` / `GetList` / `PutStructure` / `PutList` / `PutStructureDyn` would otherwise clobber it.
- `popBuilderStack` restores the outer when the inner fills (called from `addToBuilder` on materialization and from `readNextArg` when `ReadArgs` is exhausted).

The pop-on-fill cascade does **not** re-append the materialized inner to the outer: the outer's arg slot already holds the `Unbound` var that was bound to the inner during materialization, so `derefVar` resolves transparently. This matches the F# value model (immutable `Value` DU; bindings carry the actual struct, arg slots carry the `Unbound` that points to it). R / Python can mutate compounds in place so they don't need this indirection — but the discipline (stack push on begin, pop on fill) is identical.

### Test fixture updates

Four `tests/fixtures/wam_fsharp_*/Driver.fs` (+ `Smoke.fs`) files initialize `WamState` records explicitly and needed `WsBuilderStack = []` added to keep F# record-init syntax happy. Mechanical one-line additions.

## Verification

| | Before | After |
|---|---|---|
| `p_canonical_op_table/0` runtime probe | None | **Some** |
| Existing F# WAM suite (`tests/run_wam_fsharp_tests.pl`) | 2/2 pass | 2/2 pass |
| Capability hook tests (`tests/test_wam_runtime_parser_capability.pl`) | 38/38 pass | 38/38 pass |
| Parser-library `dotnet build` | 0 errors, 0 warnings | 0 errors, 0 warnings |

The other three layered probes (`p_tokenize/0`, `p_parse_term_from_atom_lowlevel/0`, `p_read_term_from_atom_wrapper/0`) still return `None`, but for an **unrelated downstream reason**: `tokenize/2` calls `Execute "reverse/2"` and `reverse/2` isn't included in the generated parser-library code (a separate "which stdlib predicates ship with the parser bundle" gap). See "Next gap" below.

## Next gap (out of scope here)

- **`reverse/2`, `append/3`, etc. missing from compiled parser bundles.** The WAM compiler doesn't include these when generating the parser library, and they aren't recognized as builtins at WAM-compile time. Adding them — either by including the source or wiring them as `BuiltinCall` — would unblock `tokenize/2` and the `parse_term` predicates.
- **Static stub sync.** `src/unifyweaver/targets/fsharp_runtime/WamRuntime.fs` is documented as a hand-maintained reference copy of the generated runtime; it still has the older single-Option `WsBuilder` shape. Updating it is a sync-bookkeeping task, separate from this functional change.

## Test plan

- [x] Layered parser probe: `canonical_op_table/1` returns `Some` (was `None`).
- [x] `tests/run_wam_fsharp_tests.pl`: 2/2 passes (codegen + dotnet runtime smokes; Phase-I lowered 16/16, query smoke 10/10, category-ancestor `solutions=21`, NAF parallel benchmark). Zero new warnings.
- [x] `tests/test_wam_runtime_parser_capability.pl`: 38/38 plunit tests pass.
- [x] Build clean: parser-library `dotnet build` succeeds in ~6s, 0 errors, 0 warnings.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_