### PR TITLE
feat(wam-fsharp): Y-registers + cut-barrier + parser executes end-to-end

### DIFF
--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -153,7 +153,7 @@ fsharp_wam_builtin_state_type :-
 
 fsharp_wam_env_frame_type :-
     writeln(
-"type EnvFrame = { EfSavedCP: int; EfYRegs: Map<int, Value> }").
+"type EnvFrame = { EfSavedCP: int; EfYRegs: Map<int, Value>; EfSavedCutBar: int }").
 
 % ============================================================================
 % ChoicePoint — mirrors Haskell `ChoicePoint`
@@ -372,9 +372,47 @@ let rec derefVar (bindings: Map<int, Value>) (v: Value) : Value =
         | None       -> v
     | _ -> v
 
+/// Walk a list-shaped value into a flat F# list of derefd elements.
+/// Lists may be stored as VList (proper, ground-tail) OR as a chain of
+/// Str(\"[|]\", [h; t]) cons cells (when materialized with a non-ground
+/// tail in addToBuilder).  Builtins that consume lists -- atom_codes/2,
+/// length/2, member/2, etc. -- only matched VList before this helper,
+/// so anything built via the cons-cell shape (everything coming out of
+/// take_digits / take_ident / parser accumulators) was opaque.  Returns
+/// None for improper / partial lists.
+let rec valueToProperList (bindings: Map<int, Value>) (v: Value) : Value list option =
+    match derefVar bindings v with
+    | Atom \"[]\"                  -> Some []
+    | VList items                ->
+        // Items may themselves contain Unbound vars or cons-cell tails;
+        // surface them as-is for the caller to deref.
+        Some items
+    | Str (\"[|]\", [h; t])        ->
+        match valueToProperList bindings t with
+        | Some rest -> Some (h :: rest)
+        | None      -> None
+    | _ -> None
+
 /// Look up a register (A/X register), dereference through bindings.
 let getReg (n: int) (s: WamState) : Value option =
-    if n >= 0 && n < s.WsRegs.Length then
+    // Y registers (n >= 201, encoded by fs_reg_name_to_int as Yk -> 200+k)
+    // are mirrored in the current env frame -- prefer the frame copy
+    // since the WsRegs entry may have been clobbered by a called
+    // predicate using the same numeric index for its own temporaries.
+    // R (env$perm_vars) and Python (_Y_BASE = 301) use the same
+    // discipline.
+    if n >= 201 then
+        match s.WsStack with
+        | frame :: _ when Map.containsKey (n - 200) frame.EfYRegs ->
+            Some (derefVar s.WsBindings (Map.find (n - 200) frame.EfYRegs))
+        | _ ->
+            // No frame entry yet -- fall through to WsRegs.
+            if n < s.WsRegs.Length then
+                match s.WsRegs.[n] with
+                | Unbound -1 -> None
+                | v          -> Some (derefVar s.WsBindings v)
+            else None
+    elif n >= 0 && n < s.WsRegs.Length then
         match s.WsRegs.[n] with
         | Unbound -1 -> None   // sentinel = uninitialized
         | v -> Some (derefVar s.WsBindings v)
@@ -382,9 +420,24 @@ let getReg (n: int) (s: WamState) : Value option =
 
 /// Set a register value (copy-on-write for snapshot semantics).
 let putReg (n: int) (v: Value) (s: WamState) : WamState =
-    let r = Array.copy s.WsRegs
-    r.[n] <- v
-    { s with WsRegs = r }
+    // Y register write -- update BOTH the env frame''s EfYRegs (so
+    // values survive being clobbered by a called predicate writing
+    // to the same numeric slot) AND WsRegs (so direct-array reads
+    // in code that hasn''t been audited still see the value).  Read
+    // path prefers the frame, then falls back to WsRegs.
+    if n >= 201 then
+        let r = Array.copy s.WsRegs
+        if n < r.Length then r.[n] <- v
+        match s.WsStack with
+        | frame :: rest ->
+            let newFrame = { frame with EfYRegs = Map.add (n - 200) v frame.EfYRegs }
+            { s with WsRegs = r; WsStack = newFrame :: rest }
+        | [] ->
+            { s with WsRegs = r }
+    else
+        let r = Array.copy s.WsRegs
+        r.[n] <- v
+        { s with WsRegs = r }
 
 /// Set a register value in-place (use only when no snapshot is needed).
 let setReg (n: int) (v: Value) (regs: Value array) : Value array =
@@ -454,20 +507,23 @@ let addToBuilder (value: Value) (s: WamState) : WamState option =
         let args' = args @ [value]
         if List.length args' = arity then
             let str = Str (fn, args')
-            let r = Array.copy s.WsRegs
-            let regVal = if reg >= 0 && reg < s.WsRegs.Length then s.WsRegs.[reg] else Unbound -1
-            r.[reg] <- str
-            let s0 =
+            // Route the destination write through putReg so Y registers
+            // (n >= 201) land in the env frame rather than WsRegs.
+            // Snapshot the previous value first for binding trail.
+            let regVal =
+                match getReg reg s with
+                | Some v -> v
+                | None   -> Unbound -1
+            let s0 = putReg reg str s
+            let s0' =
                 match derefVar s.WsBindings regVal with
                 | Unbound vid ->
-                    { s with
-                         WsRegs    = r
+                    { s0 with
                          WsBindings= Map.add vid str s.WsBindings
                          WsTrail   = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
                          WsTrailLen= s.WsTrailLen + 1 }
-                | _ ->
-                    { s with WsRegs = r }
-            let s1 = popBuilderStack s0
+                | _ -> s0
+            let s1 = popBuilderStack s0'
             Some { s1 with WsPC = s.WsPC + 1 }
         else
             Some { s with WsPC = s.WsPC + 1; WsBuilder = Some (BuildStruct (fn, reg, arity, args')) }
@@ -495,20 +551,21 @@ let addToBuilder (value: Value) (s: WamState) : WamState option =
                 | VList t      -> VList (head :: t)
                 | Atom \"[]\"    -> VList [head]
                 | derefdTail   -> Str (\"[|]\", [head; derefdTail])
-            let r = Array.copy s.WsRegs
-            let regVal = if reg >= 0 && reg < s.WsRegs.Length then s.WsRegs.[reg] else Unbound -1
-            r.[reg] <- listVal
-            let s0 =
+            // Y-aware write of materialized list value to destination reg.
+            let regVal =
+                match getReg reg s with
+                | Some v -> v
+                | None   -> Unbound -1
+            let s0 = putReg reg listVal s
+            let s0' =
                 match derefVar s.WsBindings regVal with
                 | Unbound vid ->
-                    { s with
-                         WsRegs    = r
+                    { s0 with
                          WsBindings= Map.add vid listVal s.WsBindings
                          WsTrail   = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
                          WsTrailLen= s.WsTrailLen + 1 }
-                | _ ->
-                    { s with WsRegs = r }
-            let s1 = popBuilderStack s0
+                | _ -> s0
+            let s1 = popBuilderStack s0'
             Some { s1 with WsPC = s.WsPC + 1 }
         else
             Some { s with WsPC = s.WsPC + 1; WsBuilder = Some (BuildList (reg, items')) }

--- a/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
@@ -582,7 +582,7 @@ emit_one_fs(fail, _, _SV, _SVout, I, _FP) :-
 emit_one_fs(allocate, _, SV, SVout, I, _FP) :-
     fresh_sv_fs(SV, SVout),
     format("~wlet ~w = { ~w with~n", [I, SVout, SV]),
-    format("~w               WsStack = { EfSavedCP = ~w.WsCP; EfYRegs = Map.empty } :: ~w.WsStack~n", [I, SV, SV]),
+    format("~w               WsStack = { EfSavedCP = ~w.WsCP; EfYRegs = Map.empty; EfSavedCutBar = ~w.WsCutBar } :: ~w.WsStack~n", [I, SV, SV, SV]),
     format("~w               WsCutBar = ~w.WsCPsLen }~n", [I, SV]).
 
 % Deallocate — can fail on empty stack, delegate to step

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -645,12 +645,12 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
             // builder''s arg slot, if any, already holds the Unbound var
             // we just bound to the atom -- no append needed, outer
             // continues.
+            // Y-aware write via putReg so Yk registers land in the
+            // env frame rather than the X-register array.
             let str = Str (fn, [])
-            let r = Array.copy s.WsRegs
-            r.[ai] <- str
-            Some { s with
+            let s0 = putReg ai str s
+            Some { s0 with
                      WsPC      = s.WsPC + 1
-                     WsRegs    = r
                      WsBindings= Map.add vid str s.WsBindings
                      WsTrail   = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
                      WsTrailLen= s.WsTrailLen + 1 }
@@ -805,7 +805,15 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
     | Fail -> None
 
     | Allocate ->
-        let frame = { EfSavedCP = s.WsCP; EfYRegs = Map.empty }
+        // Save the previous cut barrier in the frame so Deallocate can
+        // restore it.  Without this, a cut inside a nested clause body
+        // (e.g. `take_digits` calling `digit_code/1`) used the wrong
+        // barrier and the cut became a no-op -- exposing every
+        // ancestor''s CPs to backtrack.  The frame already carries
+        // EfSavedCP for the same reason.
+        let frame = { EfSavedCP    = s.WsCP
+                      EfYRegs      = Map.empty
+                      EfSavedCutBar= s.WsCutBar }
         Some { s with
                  WsPC    = s.WsPC + 1
                  WsStack = frame :: s.WsStack
@@ -813,7 +821,12 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
 
     | Deallocate ->
         match s.WsStack with
-        | ef :: rest -> Some { s with WsPC = s.WsPC + 1; WsStack = rest; WsCP = ef.EfSavedCP }
+        | ef :: rest ->
+            Some { s with
+                     WsPC     = s.WsPC + 1
+                     WsStack  = rest
+                     WsCP     = ef.EfSavedCP
+                     WsCutBar = ef.EfSavedCutBar }
         | []         -> None
 
     | TryMeElse label ->
@@ -855,16 +868,45 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         | []        -> Some { s with WsPC = s.WsPC + 1 }
 
     | RetryMeElse label ->
+        let nextPC = Map.tryFind label ctx.WcLabels |> Option.defaultValue 0
         match s.WsCPs with
         | cp :: rest ->
-            let nextPC = Map.tryFind label ctx.WcLabels |> Option.defaultValue 0
             Some { s with WsPC = s.WsPC + 1; WsCPs = { cp with CpNextPC = nextPC } :: rest }
-        | [] -> Some { s with WsPC = s.WsPC + 1 }
+        | [] ->
+            // Indexing-bypass synthesis: an instruction like
+            // SwitchOnTerm jumped directly to this clause without
+            // running clause 1''s TryMeElse, so no CP exists yet.
+            // Without synthesis the clause becomes deterministic --
+            // its failure can''t fall back to the next clause.
+            // Symmetric with TrustMe''s "empty CP = no-op advance".
+            let cp = { CpNextPC   = nextPC
+                       CpRegs     = Array.copy s.WsRegs
+                       CpStack    = s.WsStack
+                       CpCP       = s.WsCP
+                       CpTrailLen = s.WsTrailLen
+                       CpHeapLen  = s.WsHeapLen
+                       CpBindings = s.WsBindings
+                       CpCutBar   = s.WsCutBar
+                       CpAggFrame = None
+                       CpBuiltin  = None }
+            Some { s with WsPC = s.WsPC + 1; WsCPs = cp :: s.WsCPs; WsCPsLen = s.WsCPsLen + 1 }
 
     | RetryMeElsePc nextPC ->
         match s.WsCPs with
-        | cp :: rest -> Some { s with WsPC = s.WsPC + 1; WsCPs = { cp with CpNextPC = nextPC } :: rest }
-        | []         -> Some { s with WsPC = s.WsPC + 1 }
+        | cp :: rest ->
+            Some { s with WsPC = s.WsPC + 1; WsCPs = { cp with CpNextPC = nextPC } :: rest }
+        | [] ->
+            let cp = { CpNextPC   = nextPC
+                       CpRegs     = Array.copy s.WsRegs
+                       CpStack    = s.WsStack
+                       CpCP       = s.WsCP
+                       CpTrailLen = s.WsTrailLen
+                       CpHeapLen  = s.WsHeapLen
+                       CpBindings = s.WsBindings
+                       CpCutBar   = s.WsCutBar
+                       CpAggFrame = None
+                       CpBuiltin  = None }
+            Some { s with WsPC = s.WsPC + 1; WsCPs = cp :: s.WsCPs; WsCPsLen = s.WsCPsLen + 1 }
 
     // Phase 4.1 / Phase J — parallel WAM. ParTryMeElse dispatches through
     // forkOrSequential, which forks all branches in parallel when inside a
@@ -947,9 +989,20 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         Some { s with WsPC = s.WsPC + 1 }
 
     | BuiltinCall ("!/0", _) ->
+        // Cut: discard CPs created since clause entry.  WsCPs is
+        // stack-with-head-newest, so we DROP the newest
+        // (WsCPsLen - WsCutBar) entries to keep the OLDEST WsCutBar
+        // (the CPs that existed when Allocate set WsCutBar).  The
+        // prior `List.take WsCutBar` kept the NEWEST WsCutBar -- the
+        // exact opposite -- but every previously-tested predicate had
+        // either cut_bar = 0 (top level) or kept fewer CPs by
+        // happenstance, so the bug stayed hidden until the parser
+        // library''s in-clause cuts (every `tokenize_one` arm has
+        // `:- !.`) drove it.
+        let drop = max 0 (s.WsCPsLen - s.WsCutBar)
         Some { s with
                  WsPC    = s.WsPC + 1
-                 WsCPs   = List.take s.WsCutBar s.WsCPs
+                 WsCPs   = List.skip drop s.WsCPs
                  WsCPsLen= s.WsCutBar }
 
     | CutIte ->
@@ -1177,18 +1230,24 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
             match bindOutput 2 (VList codes) s with
             | None    -> None
             | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
-        | Some (Unbound _), Some (VList items) ->
-            let folder acc v =
-                match acc, derefVar s.WsBindings v with
-                | Some (sb: System.Text.StringBuilder), Integer c when c >= 0 && c <= 65535 ->
-                    Some (sb.Append(char c))
-                | _ -> None
-            match List.fold folder (Some (System.Text.StringBuilder())) items with
-            | Some sb ->
-                match bindOutput 1 (Atom (sb.ToString())) s with
-                | None    -> None
-                | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
-            | None -> None
+        | Some (Unbound _), Some listVal ->
+            // Accept both VList (proper-list shape) and Str(\"[|]\",_)
+            // cons-cell chains; the parser library produces the latter
+            // via take_ident / take_digits / take_syms accumulators.
+            match valueToProperList s.WsBindings listVal with
+            | None       -> None
+            | Some items ->
+                let folder acc v =
+                    match acc, derefVar s.WsBindings v with
+                    | Some (sb: System.Text.StringBuilder), Integer c when c >= 0 && c <= 65535 ->
+                        Some (sb.Append(char c))
+                    | _ -> None
+                match List.fold folder (Some (System.Text.StringBuilder())) items with
+                | Some sb ->
+                    match bindOutput 1 (Atom (sb.ToString())) s with
+                    | None    -> None
+                    | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+                | None -> None
         | _ -> None
 
     // atom_chars/2 — atom <-> list of single-char atoms. Bidirectional.


### PR DESCRIPTION
## Summary

**The portable Prolog parser library now executes end-to-end under the F# runtime.** `read_term_from_atom('foo', _T)` -- the API surface this whole series has been chasing -- reaches the end of `dispatchCall` with `Some` instead of failing partway through.

| Layered probe | Before this PR series | After PR #2380 | After **this PR** |
|---|---|---|---|
| `p_canonical_op_table/0` | None | Some | Some |
| `p_tokenize/0` | None | None | **Some** |
| `p_parse_term_from_atom_lowlevel/0` | None | None | **Some** |
| `p_read_term_from_atom_wrapper/0` | None | None | **Some** |

## What this PR fixes

Five intertwined bugs. Tracing `tokenize([0'f,0'o,0'o], _)` end-to-end revealed each one immediately after the previous fix unblocked it.

### 1. Y registers stored in `WsRegs`, clobbered by every `Call`

`fs_reg_name_to_int` maps `Y1..Y99` to indices `201..299`, but `getReg`/`putReg` only touched the `WsRegs` array. A called predicate's `GetVariable (Y201, 1)` overwrote the caller's saved tail. `EfYRegs` existed in the `EnvFrame` type but was never read or written.

**Fix:** dual-store discipline. `putReg n >= 201` writes to *both* `WsRegs` and the current frame's `EfYRegs`. `getReg n >= 201` prefers the frame copy (which survives the call). The dual store keeps the many direct `s.WsRegs.[reg]` accesses that haven't been audited consistent in the steady state -- auditing them is owed work. R (`env$perm_vars`) and Python (`_Y_BASE = 301`) do the same logical dispatch.

### 2. Cut barrier not restored on `Deallocate`

`Allocate` set `WsCutBar = s.WsCPsLen` but threw away the previous value. A cut inside a nested call (`take_digits` calling `digit_code/1`) used the wrong barrier and became a no-op -- exposing every ancestor's CPs to backtrack.

**Fix:** `EfSavedCutBar` field on `EnvFrame`. Allocate saves; Deallocate restores. Symmetric with the existing `EfSavedCP`.

### 3. Cut used `List.take` (keep newest) instead of `List.skip` (drop newest)

`WsCPs` is stack-with-head-newest. Cut needs to drop the newest `(WsCPsLen - WsCutBar)` entries to keep the OLDEST `WsCutBar`. The prior `List.take WsCutBar` did the exact opposite, kept hidden because every previously-tested predicate had `cut_bar = 0` (top level) where take and skip both return `[]`. Surfaced by the parser library's in-clause cuts (every `tokenize_one` arm has `:- !.`).

### 4. `RetryMeElse` with no active CP committed deterministically

When `SwitchOnTerm` / `SwitchOnConstantPc` pre-jumps to clause N bypassing clause 1's `TryMeElse`, no CP exists yet. Reaching `RetryMeElse` with an empty CP stack used to mean "advance silently" -- making the indexed-to clause act deterministic, so its failure could not fall back to clause N+1. `take_digits([97], _, _)` (97 isn't a digit) committed to clause 2, `digit_code(97)` failed, no backtrack to clause 3.

**Fix:** synthesize a fresh CP from current state with `CpNextPC = label`. Symmetric with `TrustMe`'s existing "empty CP = no-op advance" escape.

### 5. `atom_codes/2` only consumed `VList`, not `Str("[|]", _)` cons cells

The cons-cell-tail fix in PR #2380 changed materialization so partial lists land as `Str("[|]", [h; t])`. By the time the recursive call binds the tail, the value is logically a ground proper list -- but still stored as a chain of `Str` cons cells. `atom_codes` matched only `Some (VList items)` and saw nothing.

**Fix:** new `valueToProperList` helper in `WamTypes` that walks either shape into an F# `Value list`; `atom_codes/2` consumes via this helper. Future builtins (`length/2`, `number_codes/2`, `char_code/2`) will need the same routing as their parser call sites surface.

## Surfaced next gaps (out of scope)

- **Parser-correctness:** `read_term_from_atom('foo', _T)` returns `Some` but `_T` binds to `Atom "[]"` rather than `Atom "foo"`. The parser runs end-to-end without crashing, but a downstream parser-correctness gap drops the parsed atom. Likely candidates: another list builtin hitting the VList vs `Str("[|]",_)` shape mismatch silently, or a `parse_expr` / `parse_primary` case producing the wrong term shape on single-token input. Needs another layered probe sweep.
- **Direct `WsRegs` audit:** Many `s.WsRegs.[aReg]` reads and `r.[aReg] <- v` writes remain in the step function (`Arg`, aggregate frames, visited-set kernels). The dual-store keeps these consistent in steady state but auditing-and-routing-through-`putReg` is the proper cleanup before we can drop the `WsRegs` mirror.

## Test plan

- [x] F# WAM suite (`tests/run_wam_fsharp_tests.pl`): 2/2 passes. Phase-I lowered 16/16, query smoke 10/10, category-ancestor benchmark `solutions=21`, NAF micro-benchmark. Zero new warnings.
- [x] Capability hook tests (`tests/test_wam_runtime_parser_capability.pl`): 38/38 pass.
- [x] Parser-layers probe: all four entries return `Some`.
- [x] Parser sub-probes: `take_digits/3`, `take_ident/3`, `take_syms/3`, `tokenize_loop/3`, `tokenize_one/4` execute for letter, digit, and mixed inputs.
- [x] Builds clean: parser-library `dotnet build` succeeds in ~7s, 0 errors, 0 warnings.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_