### PR TITLE
docs(design): rename mode tiers eager/lazy/cached + clarify phase-vs-mode vocab

### DIFF
--- a/docs/design/WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md
@@ -5,17 +5,33 @@
 "why") and [`WAM_LMDB_LAZY_SPECIFICATION.md`](WAM_LMDB_LAZY_SPECIFICATION.md)
 (the "what").
 
-**Snapshot date**: 2026-05-20.
+**Snapshot date**: 2026-05-21.
 
-This document sequences the work to bring L1, L2, scan-mode, and the
-workload-segregation contract to each target. Haskell already has L2
-(Phase L#7-9); the heaviest lift is Rust.
+This document sequences the work to bring `lazy`, `cached`, scan-mode,
+and the workload-segregation contract to each target. Haskell already
+has `cached` (perf log Phase L#7-9); the heaviest lift is Rust.
+
+## Vocabulary
+
+This triad uses three distinct sets of identifiers — keep them separate:
+
+- **Modes** (runtime materialisation behaviour): `eager`, `lazy`, `cached`.
+- **Phases** (project sequencing labels): R7, R8, R9, R10, H1, X.
+  These are *this document's* sequencing labels and are unrelated to
+  the modes.
+- **Cache tiers** (Haskell-internal, *within* `cached` mode):
+  per-HEC L1 cache + sharded L2 cache.
+
+See the Vocabulary block in
+[`WAM_LMDB_LAZY_PHILOSOPHY.md`](WAM_LMDB_LAZY_PHILOSOPHY.md) for the
+full discussion. Earlier drafts used `L0`/`L1`/`L2` as mode names;
+those are stale.
 
 ## 1. Current state across targets
 
-| Target | L0 | L1 | L2 | Scan | Segregation |
+| Target | `eager` | `lazy` | `cached` | Scan | Segregation |
 | --- | :-: | :-: | :-: | :-: | :-: |
-| Haskell | ✅ (`resident` IntMap) | ⚠️ degenerate (L2 with cache size 0) | ✅ (`resident_cursor` + sharded cache) | ❌ | ❌ |
+| Haskell | ✅ (`resident` IntMap) | ⚠️ degenerate (`cached` with capacity 0) | ✅ (`resident_cursor` + sharded cache) | ❌ | ❌ |
 | Rust | ✅ (R5/R6 matrix bench) | ❌ | ❌ | ❌ | ❌ |
 | C# | ✅ + planner picks at query time | partial via planner | partial via planner | partial via planner | partial via planner |
 | Go | ✅ (channel-pipeline) | ❌ | ❌ | ❌ | ❌ |
@@ -26,19 +42,21 @@ workload-segregation contract to each target. Haskell already has L2
 So the gap matrix is wide. Prioritising Rust (because the R6 enwiki
 result is the public-facing motivator).
 
-## 2. Phase R7 — Rust L1 prototype
+## 2. Phase R7 — Rust `lazy` mode prototype
 
-**Scope**: Add `lmdb_lazy_tier(l0|l1|l2)` codegen option to the
-matrix-bench generator. Implement L1 path that skips the
-`runtime_category_parents` materialisation block and registers
-`category_parent/2` as a foreign predicate backed by an
-`LmdbCursorLookup` struct.
+**Scope**: Add `lmdb_materialisation(auto|eager|lazy|cached)`
+codegen option to the matrix-bench generator. Implement the `lazy`
+path that skips the `runtime_category_parents` materialisation block
+and registers `category_parent/2` as a foreign predicate backed by
+an `LmdbCursorLookup` struct. R7 wires the `auto` token but leaves
+the resolver returning `eager` until R8 — meaning callers who want
+`lazy` must set it explicitly in R7.
 
 **Files**:
 
 - `examples/benchmark/generate_wam_rust_matrix_benchmark.pl` — gate
-  the materialisation block on the tier option; emit a different
-  registration call when `l1`.
+  the materialisation block on the mode option; emit a different
+  registration call when `lazy`.
 - `templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache`
   — add an `LmdbCursorLookup` struct implementing the
   `LookupSource` trait (§3 of spec doc).
@@ -51,61 +69,65 @@ matrix-bench generator. Implement L1 path that skips the
   foreign lookup, routing edge lookups through the trait instead of
   through `ffi_facts`.
 - `tests/test_wam_rust_target.pl` — add codegen tests asserting
-  that the lazy variant elides the materialisation block.
+  that the `lazy` variant elides the materialisation block.
 
 **Measurement**:
 
 - Smoke test at 1k_cats: confirm tuple_count + effective_distance
-  match L0.
+  match `eager`.
 - Bench at simplewiki (5,000 demand-set seeds): record cold T1 +
-  warm median for L1 vs L0.
+  warm median for `lazy` vs `eager`.
 - Bench at enwiki (1,000 demand-set seeds): same.
 - Update the Reddit report at `examples/more/.../reports/effective_distance_haskell_vs_rust.md`
   with the new numbers.
 
-**Expected outcome**: L1 at enwiki should drop from ~148 s (L0) to
-~1-10 s (lazy LMDB cursor reads + 1000 seeds × ~10 hops). If L1
-beats L0 at enwiki, we've validated the lazy-streaming hypothesis.
-If not, profiling reveals what's actually dominating cost.
+**Expected outcome**: `lazy` at enwiki should drop from ~148 s
+(`eager`) to ~1-10 s (lazy LMDB cursor reads + 1000 seeds × ~10
+hops). If `lazy` beats `eager` at enwiki, we've validated the
+lazy-streaming hypothesis. If not, profiling reveals what's actually
+dominating cost.
 
-**Estimated effort**: ~1 day. Branch: `feat/wam-rust-lmdb-lazy-l1`.
+**Estimated effort**: ~1 day. Branch: `feat/wam-rust-lmdb-lazy`.
 
-## 3. Phase R8 — Rust L2 cache layer
+## 3. Phase R8 — Rust `cached` mode + auto-resolver
 
 **Scope**: Add `CachedLookup<S>` decorator that wraps any
 `LookupSource` with a sharded LRU cache. Add cost-model resolver
-`resolve_lmdb_lookup_tier/2` that picks L0/L1/L2 from workload
-metadata.
+`resolve_auto_lmdb_materialisation/2` that picks `eager`/`lazy`/
+`cached` from workload metadata. Wire the `auto` token to actually
+call the resolver.
 
 **Files**:
 
 - `templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache`
   — add `CachedLookup` struct.
-- `src/unifyweaver/core/cost_model.pl` — add `resolve_lmdb_lookup_tier/2`
-  per spec §7.2.
+- `src/unifyweaver/core/cost_model.pl` — add
+  `resolve_auto_lmdb_materialisation/2` per spec §7.2.
 - `examples/benchmark/generate_wam_rust_matrix_benchmark.pl` — wire
-  the resolver into the codegen so `lmdb_lazy_tier(auto)` works.
+  the resolver into the codegen so `lmdb_materialisation(auto)` works.
 - `tests/test_wam_rust_target.pl` — codegen tests for the auto
   resolver.
 - `tests/core/test_cost_model.pl` — resolver tests covering the
-  decision tree (small fact_count + high seed count → l0; large +
-  any seed count → l2; segregated → l1).
+  decision tree (small fact_count + high seed count → `eager`;
+  large + any seed count → `cached`; segregated → `lazy`).
 
 **Measurement**:
 
-- Re-run the bench matrix at all three scales with `lmdb_lazy_tier(auto)`.
-- Verify the resolver picks L0 at 1k, l2 at simplewiki and enwiki.
-- Confirm L2 enwiki numbers match Haskell's `resident_cursor` shape
-  (within an order of magnitude — the cross-language gap should
-  collapse).
+- Re-run the bench matrix at all three scales with
+  `lmdb_materialisation(auto)`.
+- Verify the resolver picks `eager` at 1k, `cached` at simplewiki
+  and enwiki.
+- Confirm `cached` enwiki numbers match Haskell's `resident_cursor`
+  shape (within an order of magnitude — the cross-language gap
+  should collapse).
 
-**Estimated effort**: ~1-2 days. Branch: `feat/wam-rust-lmdb-lazy-l2`.
+**Estimated effort**: ~1-2 days. Branch: `feat/wam-rust-lmdb-cached`.
 
 ## 4. Phase R9 — workload-segregation contract
 
 **Scope**: Add the `workload_segregated(bool)` option to the
 `recursive_kernel` declaration. Update the cost-model resolver to
-prefer L1 when set. Thread the flag through the codegen.
+prefer `lazy` when set. Thread the flag through the codegen.
 
 **Files**:
 
@@ -123,8 +145,9 @@ prefer L1 when set. Thread the flag through the codegen.
 - Construct a synthetic segregated workload (e.g., 1000 seeds
   partitioned 100 each into 10 disjoint root-subtrees, run as 10
   separate process invocations).
-- Verify L1 wins over L2 on the segregated workload.
-- Verify L2 wins over L1 on the original non-segregated workload.
+- Verify `lazy` wins over `cached` on the segregated workload.
+- Verify `cached` wins over `lazy` on the original non-segregated
+  workload.
 
 **Estimated effort**: ~1 day. Branch: `feat/wam-segregation-contract`.
 
@@ -132,8 +155,8 @@ prefer L1 when set. Thread the flag through the codegen.
 
 **Scope**: Implement `ScanSource` trait + `scan_range` method on
 `LmdbCursorLookup`. Add cost-model resolver
-`resolve_lmdb_access_mode/2`. Update the ingest pipeline to write
-`layout_strategy` to the LMDB meta sub-db.
+`resolve_auto_lmdb_access_mode/2`. Update the ingest pipeline to
+write `layout_strategy` to the LMDB meta sub-db.
 
 **Files**:
 
@@ -144,7 +167,8 @@ prefer L1 when set. Thread the flag through the codegen.
   write `layout_strategy` to meta.
 - `examples/streaming/*_category_ingest*.pl` — pass through the
   optional `layout_strategy` knob.
-- `src/unifyweaver/core/cost_model.pl` — `resolve_lmdb_access_mode/2`.
+- `src/unifyweaver/core/cost_model.pl` —
+  `resolve_auto_lmdb_access_mode/2`.
 - Codegen wires the scan path into the kernel when chosen.
 
 **Measurement**:
@@ -156,35 +180,36 @@ prefer L1 when set. Thread the flag through the codegen.
 
 **Estimated effort**: ~2 days. Branch: `feat/wam-rust-lmdb-scan-mode`.
 
-## 6. Phase H1 — Haskell L1 (validation only)
+## 6. Phase H1 — Haskell `lazy` mode (validation only)
 
-**Scope**: Haskell already implements L2 via `resident_cursor` +
-sharded cache. Validate that `lmdb_cache_capacity(0)` produces a
-correct L1 (no cache) behaviour and update the cost-model resolver
-to recognise it.
+**Scope**: Haskell already implements `cached` via `resident_cursor`
++ sharded cache. Validate that `lmdb_cache_capacity(0)` produces a
+correct `lazy` behaviour and update the cost-model resolver to
+recognise it.
 
 **Files**:
 
-- `src/unifyweaver/core/cost_model.pl` — extend `resolve_lmdb_lookup_tier/2`
-  to handle the Haskell case: `l1` corresponds to
-  `lmdb_cache_capacity(0)` plus `lmdb_cache_mode(none)`.
+- `src/unifyweaver/core/cost_model.pl` — extend
+  `resolve_auto_lmdb_materialisation/2` to handle the Haskell case:
+  `lazy` corresponds to `lmdb_cache_capacity(0)` plus
+  `lmdb_cache_mode(none)`.
 - `tests/test_wam_haskell_target.pl` — codegen tests.
 
 **Measurement**:
 
-- Sanity-check existing Haskell L2 results.
-- Add a measurement at enwiki with cache-capacity 0 (L1) to compare
-  against L2; expect L2 to win unless we contrive a segregated
-  workload.
+- Sanity-check existing Haskell `cached`-mode results.
+- Add a measurement at enwiki with cache-capacity 0 (i.e., `lazy`)
+  to compare against `cached`; expect `cached` to win unless we
+  contrive a segregated workload.
 
-**Estimated effort**: ~0.5 day. Branch: `feat/wam-haskell-l1-recognition`.
+**Estimated effort**: ~0.5 day. Branch: `feat/wam-haskell-lazy-recognition`.
 
 ## 7. Phase X — cross-target consolidation
 
-**Scope**: Once Rust + Haskell both have L0/L1/L2 + scan-mode +
-segregation, write a cross-target benchmark report and update the
-Reddit report with all six (3 tiers × 2 access modes) data points
-at simplewiki and enwiki.
+**Scope**: Once Rust + Haskell both have `eager`/`lazy`/`cached` +
+scan-mode + segregation, write a cross-target benchmark report and
+update the Reddit report with all six (3 modes × 2 access modes)
+data points at simplewiki and enwiki.
 
 **Files**:
 
@@ -199,14 +224,14 @@ at simplewiki and enwiki.
 ## 8. Dependencies
 
 ```
-R7 (Rust L1) ──┐
-               ├──► R8 (Rust L2 + resolver) ──┐
-               │                              ├──► X (consolidation)
-H1 (Haskell L1) ─────────────────────────────┤
-                                              │
-R10 (Rust scan) ──────────────────────────────┤
-                                              │
-R9 (segregation) ─────────────────────────────┘
+R7 (Rust lazy) ──┐
+                 ├──► R8 (Rust cached + resolver) ──┐
+                 │                                  ├──► X (consolidation)
+H1 (Haskell lazy) ─────────────────────────────────┤
+                                                    │
+R10 (Rust scan) ────────────────────────────────────┤
+                                                    │
+R9 (segregation) ───────────────────────────────────┘
 ```
 
 - R7 is the only hard prerequisite for anything; it establishes the
@@ -217,13 +242,13 @@ R9 (segregation) ─────────────────────
 
 ## 9. Out-of-scope (for this plan revision)
 
-- **Other targets (Go, C#, Elixir, Python) L1/L2 implementation**:
-  C# already has substantial planner-level coverage; others are
-  speculative. File separate implementation plans when motivated
-  by a workload.
+- **Other targets (Go, C#, Elixir, Python) `lazy`/`cached`
+  implementation**: C# already has substantial planner-level
+  coverage; others are speculative. File separate implementation
+  plans when motivated by a workload.
 - **MST-sort ingest pre-processor**: see philosophy doc §4.2.
 - **Multi-process shared cache**: see spec §11.
-- **Adaptive tier switching mid-run**: see spec §11.
+- **Adaptive mode switching mid-run**: see spec §11.
 
 ## 10. Open questions before R7 starts
 
@@ -231,13 +256,14 @@ R9 (segregation) ─────────────────────
    trait-object swap-in?** Need to read `state.rs` carefully — the
    `register_foreign_lookup` API might need a refactor of how
    foreign predicates dispatch.
-2. **Cursor lifetime in Rust**: should L1 hold one shared cursor
+2. **Cursor lifetime in Rust**: should `lazy` hold one shared cursor
    protected by a mutex (cheap but contended), per-thread cursors
    (more memory, lock-free), or open-per-call cursors (slow but
    simplest)? Likely per-thread for the parallel future, single
-   for the L1 prototype.
-3. **What's the right `cache_capacity` default for L2**: matches
-   Haskell's existing default? Or sized by demand-set heuristic?
+   for the `lazy` prototype.
+3. **What's the right `cache_capacity` default for `cached`**:
+   matches Haskell's existing default? Or sized by demand-set
+   heuristic?
 4. **Should scan-mode require a separate codegen option, or be
    chosen by the cost-model resolver automatically once
    `layout_strategy` is known**? Initial answer: automatic — keeps
@@ -245,10 +271,11 @@ R9 (segregation) ─────────────────────
 
 ## 11. Concrete next step
 
-**This PR (`docs/wam-lmdb-lazy-design`)**: lands the three design
+**This PR (`docs/wam-lmdb-lazy-rename`)**: tidies the
+mode-vs-phase-vs-cache-tier vocabulary across the three design
 docs. No code changes.
 
-**Next PR (`feat/wam-rust-lmdb-lazy-l1`)**: implements Phase R7. The
+**Next PR (`feat/wam-rust-lmdb-lazy`)**: implements Phase R7. The
 follow-on PRs for R8/R9/R10 land independently as each phase
 completes.
 
@@ -257,9 +284,10 @@ completes.
 - `docs/design/WAM_LMDB_LAZY_PHILOSOPHY.md`
 - `docs/design/WAM_LMDB_LAZY_SPECIFICATION.md`
 - `docs/design/CACHE_COST_MODEL_PHILOSOPHY.md`
+- `docs/design/COST_FUNCTION_PHILOSOPHY.md`
 - `docs/design/QUERY_PLAN_RUNTIME_PHILOSOPHY.md`
 - `docs/design/WAM_LMDB_RESIDENT_INTERNING_*.md` (existing LMDB layout)
 - `examples/benchmark/generate_wam_rust_matrix_benchmark.pl` — current Rust eager bench
 - `templates/targets/rust_wam/lmdb_fact_source_*.mustache` — current Rust LMDB source
-- `templates/targets/haskell_wam/lmdb_fact_source.hs.mustache` — current Haskell L2
+- `templates/targets/haskell_wam/lmdb_fact_source.hs.mustache` — current Haskell `cached`-mode source
 - `examples/more/graph/effect_dist/haskell/gen/reports/effective_distance_haskell_vs_rust.md` — the public-facing motivator

--- a/docs/design/WAM_LMDB_LAZY_PHILOSOPHY.md
+++ b/docs/design/WAM_LMDB_LAZY_PHILOSOPHY.md
@@ -4,20 +4,45 @@
 lazy LMDB access patterns in the WAM targets and how they relate to
 workload-segregation and physical-layout strategies.
 
-**Snapshot date**: 2026-05-20.
+**Snapshot date**: 2026-05-21.
 
 **Companions**:
 - [`WAM_LMDB_LAZY_SPECIFICATION.md`](WAM_LMDB_LAZY_SPECIFICATION.md) —
   cross-target interface specification.
 - [`WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md`](WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md) —
   phased rollout for Rust (and reference catalogue for Haskell, which
-  already implements much of L2).
+  already implements much of `cached` mode).
 
 This doc sits inside the broader framing of
 [`QUERY_PLAN_RUNTIME_PHILOSOPHY.md`](QUERY_PLAN_RUNTIME_PHILOSOPHY.md)
 (precursor for the runtime planner pattern) and
 [`SCAN_STRATEGY_PHILOSOPHY.md`](SCAN_STRATEGY_PHILOSOPHY.md) (which
 informs how plans get chosen).
+
+## Vocabulary
+
+This triad uses three distinct sets of identifiers — keep them separate:
+
+- **Modes** (runtime materialisation behaviour): `eager`, `lazy`, `cached`.
+  These name *what the runtime does on each lookup*. They are the
+  three runtime behaviours described in §2. Selectable per kernel
+  via the codegen option `lmdb_materialisation(auto|eager|lazy|cached)`.
+- **Phases** (project sequencing labels): R7, R8, R9, R10, H1, X.
+  These appear in
+  [`WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md`](WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md);
+  each implements some subset of the modes for some target.
+- **Cache tiers** (Haskell-internal, *within* `cached` mode):
+  per-HEC L1 cache + sharded L2 cache. These are the existing
+  `lmdb_cache_mode(per_hec|sharded|two_level)` configurations and
+  are *internal* to the `cached` mode — not to be confused with the
+  modes above.
+
+Earlier drafts of this triad named the modes `L0`/`L1`/`L2`, which
+collided with the Haskell internal cache-tier names. The rename to
+`eager`/`lazy`/`cached` removes the collision. If you find any
+lingering `L0`/`L1`/`L2` references to *modes* (rather than to
+Haskell's internal cache tiers), they are stale and should be
+updated.
 
 ## 1. Context — where this came from
 
@@ -44,85 +69,90 @@ the same trade-off can be discussed consistently across targets, and
 so future cost-model resolvers can pick between modes from workload
 metadata rather than hand-tuning.
 
-## 2. The lazy/eager spectrum (and the three tiers)
+## 2. The lazy/eager spectrum (and the three modes)
 
-Three modes show up in measurements so far. Naming them up front:
+Three runtime modes show up in measurements so far. Naming them up
+front:
 
-- **L0 — eager materialisation.** Build an in-memory index of every
-  demand-set edge before any kernel iteration runs. The kernel walks
-  the index without touching LMDB after startup.
-- **L1 — pure lazy.** No materialisation. Each kernel walk step does
-  an LMDB cursor lookup on demand. No cache layer above the LMDB.
-- **L2 — lazy with cache.** Each kernel walk step queries a cache
-  first; on miss, does an LMDB cursor lookup and populates the cache.
-  Subsequent lookups for the same key hit the cache.
+- **`eager`** — eager materialisation. Build an in-memory index of
+  every demand-set edge before any kernel iteration runs. The kernel
+  walks the index without touching LMDB after startup.
+- **`lazy`** — pure lazy. No materialisation. Each kernel walk step
+  does an LMDB cursor lookup on demand. No cache layer above the
+  LMDB.
+- **`cached`** — lazy with cache. Each kernel walk step queries a
+  cache first; on miss, does an LMDB cursor lookup and populates
+  the cache. Subsequent lookups for the same key hit the cache.
 
-The Haskell `resident_cursor` mode is **L2** — it's lazy by default
-but the runtime maintains per-HEC L1 + sharded L2 cache tiers above
-the LMDB cursor reads. The Haskell `resident` (IntMap) mode is
-**L0** — eager in-process materialisation, with the same memory wall
-the Rust bench has.
+The Haskell `resident_cursor` runtime is **`cached` mode** — it's
+lazy by default but the runtime maintains per-HEC L1 + sharded L2
+cache tiers above the LMDB cursor reads. (Those cache tiers are
+internal to `cached`; see Vocabulary above.) The Haskell `resident`
+(IntMap) runtime is **`eager` mode** — eager in-process
+materialisation, with the same memory wall the Rust bench has.
 
-The Rust bench today is **L0**. We have no L1 or L2 variant yet, and
-the cross-target story this doc motivates is to add both.
+The Rust bench today is **`eager`**. We have no `lazy` or `cached`
+variant yet, and the cross-target story this doc motivates is to add
+both.
 
 ### 2.1 Where each mode wins
 
 The naive cost model for one process invocation:
 
 ```
-L0 wall ≈ M + N × ε         (M = materialisation cost, ε = per-seed kernel)
-L1 wall ≈ N × p             (p = lazy per-seed cost, larger than ε)
-L2 wall ≈ N × q + θ × p     (q = cache-hit cost, θ = cache-miss rate)
+eager  wall ≈ M + N × ε     (M = materialisation cost, ε = per-seed kernel)
+lazy   wall ≈ N × p         (p = lazy per-seed cost, larger than ε)
+cached wall ≈ N × q + θ × p (q = cache-hit cost, θ = cache-miss rate)
 ```
 
-`L1 wall ≤ L2 wall` only when `θ × p ≤ N × (p − q)`, which simplifies
-to `θ ≤ N(p−q)/Np` — i.e., when **the cache miss rate is low enough
-that the cache machinery itself isn't worth its overhead**. In a
-single isolated query that's almost always the case (θ ≈ 100%, but
-N ≈ 1 — the cache never gets to amortise). Across many seeds with
-graph locality, θ drops quickly and L2 wins.
+`lazy wall ≤ cached wall` only when `θ × p ≤ N × (p − q)`, which
+simplifies to `θ ≤ N(p−q)/Np` — i.e., when **the cache miss rate is
+low enough that the cache machinery itself isn't worth its
+overhead**. In a single isolated query that's almost always the case
+(θ ≈ 100%, but N ≈ 1 — the cache never gets to amortise). Across
+many seeds with graph locality, θ drops quickly and `cached` wins.
 
-The non-obvious result is that **L1 only beats L2 under specific
-workload conditions**: high cache-miss rate due to no locality between
-queries, OR a workload-segregation guarantee that means cache hits
-won't happen anyway. Most real workloads have *some* locality, so L2
-is the right default.
+The non-obvious result is that **`lazy` only beats `cached` under
+specific workload conditions**: high cache-miss rate due to no
+locality between queries, OR a workload-segregation guarantee that
+means cache hits won't happen anyway. Most real workloads have
+*some* locality, so `cached` is the right default.
 
 ### 2.2 The picture in one table
 
 | Mode | Wins for | Why |
 | --- | --- | --- |
-| **L0** | Batched workloads, demand-set fits in RAM | Pays `M` once, amortises across many seeds |
-| **L1** | Pure one-shot queries, OR segregated batches with provably-disjoint subgraphs | No `M` overhead, no cache machinery overhead |
-| **L2** | Default for everything else | Bounded per-seed cost, locality benefits, scales past the memory wall |
+| **`eager`** | Batched workloads, demand-set fits in RAM | Pays `M` once, amortises across many seeds |
+| **`lazy`** | Pure one-shot queries, OR segregated batches with provably-disjoint subgraphs | No `M` overhead, no cache machinery overhead |
+| **`cached`** | Default for everything else | Bounded per-seed cost, locality benefits, scales past the memory wall |
 
-The cost-model resolver should pick **L2 by default**, **L0 when
-demand set is small enough and seed count is high enough** (the
-crossover in [`QUERY_PLAN_RUNTIME_PHILOSOPHY.md`](QUERY_PLAN_RUNTIME_PHILOSOPHY.md)
-§2), and **L1 only when the caller explicitly signals workload
+The cost-model resolver should pick **`cached` by default**,
+**`eager` when demand set is small enough and seed count is high
+enough** (the crossover in
+[`QUERY_PLAN_RUNTIME_PHILOSOPHY.md`](QUERY_PLAN_RUNTIME_PHILOSOPHY.md)
+§2), and **`lazy` only when the caller explicitly signals workload
 segregation** (see §3).
 
-## 3. Workload segregation: the enabling condition for L1
+## 3. Workload segregation: the enabling condition for `lazy`
 
-L1 has a real niche, but only when the bench harness can guarantee
+`lazy` has a real niche, but only when the bench harness can guarantee
 that **no two queries in the same process share an LMDB key**. Then
-the cache that L2 would maintain has zero hits, and L1's no-cache
-shape is pure win.
+the cache that `cached` would maintain has zero hits, and `lazy`'s
+no-cache shape is pure win.
 
 The natural model for this is **node clusters** — group seeds whose
 upward walks touch disjoint subgraphs. The category graph of
 Wikipedia has multiple top-level roots; if a workload is "compute
 effective distances against root R₁ for batch A, then against root
-R₂ for batch B," and R₁ / R₂ have non-overlapping descendant subtrees,
-then within each batch L1 is correct, and across batches the cache
-would never have warmed for the new keys anyway.
+R₂ for batch B," and R₁ / R₂ have non-overlapping descendant
+subtrees, then within each batch `lazy` is correct, and across
+batches the cache would never have warmed for the new keys anyway.
 
 Two ways to surface this to the cost model:
 
 1. **User-declared segregation**: caller passes a `cluster_id` or
    `workload_segregated(true)` flag. The simplest contract. Risk:
-   user lies, L1 burns cycles on uncached repeats.
+   user lies, `lazy` burns cycles on uncached repeats.
 2. **Compiler-inferred segregation**: shape analysis proves that the
    query stream cannot revisit nodes (e.g., the seed set is bounded
    by the demand set, and `max_depth` limits the walk such that
@@ -130,7 +160,7 @@ Two ways to surface this to the cost model:
    verifiable.
 
 For initial implementation, option 1 is fine — the cost-model
-default is L2, and L1 is opt-in via an explicit annotation.
+default is `cached`, and `lazy` is opt-in via an explicit annotation.
 
 ### 3.1 Where segregation comes from in practice
 
@@ -197,11 +227,11 @@ Three physical-layout strategies, ordered by cost:
 | **MST sort** | O(E log V) | Provably good | Compute a minimum spanning tree, then DFS-order the nodes. Optimal in the sense that adjacent IDs minimise tree-edge weight; expensive enough that it only pays off for static benchmarks. |
 
 The scan-friendliness story is **orthogonal** to the lazy/eager
-choice. L1 + scan combines workload segregation with physical
+choice. `lazy` + scan combines workload segregation with physical
 locality — the strongest configuration for one-shot, no-cache
-workloads. L2 + scan still benefits from physical locality on
-cache misses. L0 doesn't care because it pays for materialisation
-once anyway.
+workloads. `cached` + scan still benefits from physical locality on
+cache misses. `eager` doesn't care because it pays for
+materialisation once anyway.
 
 ## 5. How the modes compose
 
@@ -213,31 +243,38 @@ The full space of mode choices:
                             │
                   poor      │      good
                  ─────────────────────────
-  L0 (eager) │   indifferent (M pays once)
-  L1 (lazy)  │   bad         │  great (workload-seg + scan)
-  L2 (cache) │   ok          │  great (cache hits + scan misses)
+  eager          │   indifferent (M pays once)
+  lazy           │   bad        │  great (workload-seg + scan)
+  cached         │   ok         │  great (cache hits + scan misses)
 ```
 
 The decision tree for the cost-model resolver becomes:
 
-1. *Is demand_set_size × edge_size > available_memory_budget?* → must use lazy (L1 or L2).
-2. *Does the user declare workload_segregated?* → L1.
-3. *Otherwise?* → L2.
-4. *Is physical layout known to be scan-friendly?* → enable scan-mode within the chosen tier.
+1. *Is demand_set_size × edge_size > available_memory_budget?* → must use lazy form (`lazy` or `cached`).
+2. *Does the user declare `workload_segregated`?* → `lazy`.
+3. *Otherwise?* → `cached`.
+4. *Is physical layout known to be scan-friendly?* → enable scan-mode within the chosen mode.
 
 The existing cost-model resolvers (`cache_strategy(auto)`,
-`lmdb_cache_mode(auto)`, `resident_auto`) already cover parts of this.
-The L1/L2 distinction is what's new here; scan-mode is a related
-axis that would be added per-target.
+`lmdb_cache_mode(auto)`, `resident_auto`) already cover parts of
+this. The `lazy` / `cached` distinction is what's new here; scan-mode
+is a related axis that would be added per-target. See
+[`CACHE_COST_MODEL_PHILOSOPHY.md`](CACHE_COST_MODEL_PHILOSOPHY.md)
+and [`COST_FUNCTION_PHILOSOPHY.md`](COST_FUNCTION_PHILOSOPHY.md)
+for the cost-resolver pattern these new resolvers slot into. (That
+pattern is the one we sometimes call "the C# cost analysis", since
+the C# planner already does similar runtime mode selection — but
+the pattern itself is target-agnostic and lives in
+`src/unifyweaver/core/cost_model.pl`.)
 
 ## 6. Cross-language patterns this maps to
 
-L1 and L2 are general patterns. The iterator-based lookup interface
-maps cleanly across targets:
+`lazy` and `cached` are general patterns. The iterator-based lookup
+interface maps cleanly across targets:
 
 | Target | Idiomatic lazy lookup return type | Cache layer notes |
 | --- | --- | --- |
-| Haskell | `[Int]` (lazy list) or `ConduitT () Int IO ()` | Already implemented (L2); per-HEC L1 + sharded L2 in `lmdb_cache_mode` |
+| Haskell | `[Int]` (lazy list) or `ConduitT () Int IO ()` | Already implemented (`cached`); per-HEC L1 + sharded L2 in `lmdb_cache_mode` |
 | Rust | `impl Iterator<Item=i32> + 'a` | Closure-based foreign predicate; cache via `dashmap` or sharded `HashMap` |
 | Go | `<-chan int` (channel) | Pipeline-chaining already has channel mode; same pattern |
 | C# | `IEnumerable<int>` (LINQ) | Existing C# planner already does this for relations |
@@ -246,21 +283,23 @@ maps cleanly across targets:
 
 So the *interface* is the same shape everywhere; the implementation
 just chooses each language's native iterator equivalent. The cache
-tier layers on top via a Decorator pattern: an L2 cache wraps an L1
-source via the same interface.
+layer composes on top via a Decorator pattern: a `cached`
+implementation wraps a `lazy` implementation via the same interface.
 
 ## 7. What this rules out
 
 - **Picking lazy vs eager at the language level.** The mode is
   workload-dependent, not language-dependent. Any target can
-  implement any tier.
-- **A single "best" mode that wins everywhere.** Each tier has a
+  implement any mode.
+- **A single "best" mode that wins everywhere.** Each mode has a
   niche; the cost model has to choose.
 - **Hand-tuning per benchmark.** The auto-resolvers exist precisely
-  so that "which tier?" is determined by workload metadata, not
-  by which mode the experimenter happened to remember to set.
-- **Treating scan-mode as a tier of laziness.** It's a separate
-  axis. Any tier can use seeks or scans; the choice is determined
+  so that "which mode?" is determined by workload metadata, not
+  by which mode the experimenter happened to remember to set. The
+  `lmdb_materialisation(auto)` value triggers the resolver; explicit
+  values (`eager`/`lazy`/`cached`) override it.
+- **Treating scan-mode as a degree of laziness.** It's a separate
+  axis. Any mode can use seeks or scans; the choice is determined
   by physical layout quality.
 
 ## 8. Open questions
@@ -274,20 +313,21 @@ source via the same interface.
    layout-quality question more accurately.
 3. **How does this compose with the runtime planner pattern
    ([`QUERY_PLAN_RUNTIME_PHILOSOPHY.md`](QUERY_PLAN_RUNTIME_PHILOSOPHY.md))?**
-   The planner is the right place to decide L0/L1/L2 + seek/scan
-   per query rather than per process. Question: is the decision
-   cheap enough to do per query, or does it need to be amortised?
+   The planner is the right place to decide `eager`/`lazy`/`cached`
+   + seek/scan per query rather than per process. Question: is the
+   decision cheap enough to do per query, or does it need to be
+   amortised?
 4. **MST sort + LMDB rewrite for very large graphs**: is the
    pre-processing cost ever worth it for a one-off benchmark? Or
    only for production query workloads that hit the same DB
    thousands of times?
 5. **Cache invalidation under graph mutation**: the current Haskell
-   L2 cache assumes a static LMDB. Mutating workloads need a
+   `cached` mode assumes a static LMDB. Mutating workloads need a
    versioning story.
-6. **Cross-target benchmark methodology**: when we measure L1/L2/
-   scan-mode against L0, we need a workload spec that exercises
-   each mode's niche. The existing matrix-bench is L0-shaped;
-   it'd over-amortise.
+6. **Cross-target benchmark methodology**: when we measure
+   `lazy`/`cached`/scan-mode against `eager`, we need a workload
+   spec that exercises each mode's niche. The existing matrix-bench
+   is `eager`-shaped; it'd over-amortise.
 
 ## 9. References
 
@@ -298,12 +338,12 @@ source via the same interface.
   cost-function-driven plan selection).
 - `docs/design/CACHE_COST_MODEL_PHILOSOPHY.md` — cost-model framework
   this work feeds into.
-- `docs/design/WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md` — LMDB
-  layout this lazy work reads from.
 - `docs/design/COST_FUNCTION_PHILOSOPHY.md` — Green's-function and
   flux cost-functions; the lazy-vs-eager decision is one of the
   inputs.
-- `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` Phase L#7–9 — Haskell L2
-  measurements at simplewiki and enwiki.
+- `docs/design/WAM_LMDB_RESIDENT_INTERNING_PHILOSOPHY.md` — LMDB
+  layout this lazy work reads from.
+- `docs/design/WAM_PERF_OPTIMIZATION_LOG.md` Phase L#7–9 — Haskell
+  `cached`-mode measurements at simplewiki and enwiki.
 - `examples/more/graph/effect_dist/haskell/gen/reports/effective_distance_haskell_vs_rust.md` —
   Haskell-vs-Rust report that motivated this design.

--- a/docs/design/WAM_LMDB_LAZY_SPECIFICATION.md
+++ b/docs/design/WAM_LMDB_LAZY_SPECIFICATION.md
@@ -5,32 +5,47 @@
 "why") and [`WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md`](WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md)
 (the "when").
 
-**Snapshot date**: 2026-05-20.
+**Snapshot date**: 2026-05-21.
 
 This document specifies the cross-target interface for the three
-LMDB-access tiers L0 / L1 / L2 (see philosophy doc §2 for the
-vocabulary), plus the scan-vs-seek axis and the workload-segregation
-contract. The intent is that each target's implementation can be
-audited against the same surface area.
+LMDB-access modes `eager` / `lazy` / `cached` (see philosophy doc §2
+for the vocabulary), plus the scan-vs-seek axis and the
+workload-segregation contract. The intent is that each target's
+implementation can be audited against the same surface area.
 
-## 1. Tier model
+## Vocabulary
 
-Three modes per target:
+This triad uses three distinct sets of identifiers — keep them separate:
 
-| Tier | Materialisation | Cache layer | Per-call cost |
+- **Modes** (runtime materialisation behaviour): `eager`, `lazy`, `cached`.
+- **Phases** (project sequencing labels): R7, R8, R9, R10, H1, X.
+- **Cache tiers** (Haskell-internal, *within* `cached` mode):
+  per-HEC L1 cache + sharded L2 cache.
+
+See the Vocabulary block in
+[`WAM_LMDB_LAZY_PHILOSOPHY.md`](WAM_LMDB_LAZY_PHILOSOPHY.md) for the
+full discussion. Earlier drafts used `L0`/`L1`/`L2` as mode names;
+those are stale.
+
+## 1. Mode model
+
+Three runtime modes per target:
+
+| Mode | Materialisation | Cache layer | Per-call cost |
 | --- | --- | --- | ---: |
-| L0 (eager) | Yes — full demand-set Vec/HashMap built at startup | n/a (the materialisation *is* the cache) | O(1) HashMap lookup |
-| L1 (lazy) | No | None | O(log B) LMDB cursor seek |
-| L2 (lazy + cache) | No | Yes — bounded-size LRU or sharded HashMap | O(1) on hit, O(log B) on miss |
+| `eager` | Yes — full demand-set Vec/HashMap built at startup | n/a (the materialisation *is* the cache) | O(1) HashMap lookup |
+| `lazy` | No | None | O(log B) LMDB cursor seek |
+| `cached` | No | Yes — bounded-size LRU or sharded HashMap | O(1) on hit, O(log B) on miss |
 
-A target MUST implement L0 (which most already do). A target SHOULD
-implement L2 for any LMDB-backed fact source whose `fact_count`
-exceeds the existing `use_lmdb(auto)` threshold. A target MAY
-implement L1 for workloads with explicit segregation declarations.
+A target MUST implement `eager` (which most already do). A target
+SHOULD implement `cached` for any LMDB-backed fact source whose
+`fact_count` exceeds the existing `use_lmdb(auto)` threshold. A
+target MAY implement `lazy` for workloads with explicit segregation
+declarations.
 
 ## 2. The canonical lookup interface
 
-All three tiers expose the **same shape** to callers. The contract:
+All three modes expose the **same shape** to callers. The contract:
 
 ```
 lookup_parents(key) -> Iterator<Edge>
@@ -59,7 +74,7 @@ without forcing materialisation.
 
 ## 3. Source trait / interface
 
-Each target defines a source trait that all three tiers implement:
+Each target defines a source trait that all three modes implement:
 
 ### Rust
 
@@ -73,9 +88,12 @@ pub trait LookupSource {
 Implementations:
 
 ```rust
-pub struct EagerVecLookup { ... }
-pub struct LmdbCursorLookup<'env> { ... }  // L1
-pub struct CachedLookup<S: LookupSource> { inner: S, cache: ... }  // L2 decorator
+pub struct EagerVecLookup { ... }                      // `eager`
+pub struct LmdbCursorLookup<'env> { ... }              // `lazy`
+pub struct CachedLookup<S: LookupSource> {             // `cached` (Decorator)
+    inner: S,
+    cache: ...,
+}
 ```
 
 ### Haskell
@@ -91,12 +109,12 @@ Haskell already has this conceptually inside `EdgeLookup` in
 ### Other targets
 
 Same pattern: a trait/interface whose method returns the target's
-native lazy iterator type. Each tier implements the trait.
+native lazy iterator type. Each mode implements the trait.
 
-## 4. Cache-tier spec (L2)
+## 4. Cache-layer spec (`cached` mode)
 
-The L2 cache wraps any L1 implementation via the Decorator pattern.
-Spec:
+The `cached` mode wraps any `lazy` implementation via the Decorator
+pattern. Spec:
 
 - **Bounded size**: configurable via existing `cache_capacity(...)`
   option (already in `cache_strategy(auto)`).
@@ -105,17 +123,22 @@ Spec:
   shards = number of capabilities / threads.
 - **Eviction policy**: LRU on a per-shard basis. The cache contract
   is "correctness preserved on eviction" — any miss falls through to
-  the inner L1 source.
-- **Composition with L1**: L2 is a Decorator over L1, not a replacement.
-  Same `LookupSource` trait. This means L1 and L2 are interchangeable
-  in calling code — the kernel doesn't know which it has.
-- **Concurrent access**: per-shard locking (Haskell uses `IORef`-protected
-  Maps; Rust uses `dashmap` or sharded `RwLock<HashMap>`).
+  the inner `lazy` source.
+- **Composition with `lazy`**: `cached` is a Decorator over `lazy`,
+  not a replacement. Same `LookupSource` trait. This means `lazy`
+  and `cached` are interchangeable in calling code — the kernel
+  doesn't know which it has.
+- **Concurrent access**: per-shard locking (Haskell uses `IORef`-
+  protected Maps; Rust uses `dashmap` or sharded `RwLock<HashMap>`).
+- **Internal cache tiers** (Haskell): inside `cached` mode the
+  Haskell runtime composes a per-HEC L1 cache with a sharded L2
+  cache via `lmdb_cache_mode(per_hec|sharded|two_level)`. These
+  tiers are *internal* to `cached` and not exposed as separate modes.
 
 ## 5. Scan vs seek
 
-A second axis, orthogonal to the L0/L1/L2 tier. Some sources can
-expose a *range* read in addition to point lookups.
+A second axis, orthogonal to the mode (§1). Some sources can expose
+a *range* read in addition to point lookups.
 
 ### 5.1 Scan trait
 
@@ -129,7 +152,7 @@ pub trait ScanSource: LookupSource {
 
 The iterator yields `(child, parent)` pairs from the half-open
 range `[start, end)` of child IDs. Only `LmdbCursorLookup`
-implements `ScanSource`; the eager Vec implementation can fall
+implements `ScanSource`; the `eager` Vec implementation can fall
 through to a filter on its existing data.
 
 ### 5.2 When the kernel uses scans
@@ -160,7 +183,7 @@ seeks-only.
 
 ## 6. Workload-segregation contract
 
-The signal that allows L1 to be picked over L2.
+The signal that allows `lazy` to be picked over `cached`.
 
 ### 6.1 Caller-side declaration
 
@@ -177,7 +200,8 @@ declaration:
 ```
 
 When `workload_segregated(true)`, the cost-model resolver MAY pick
-L1 over L2. When unset (default), the resolver picks L2.
+`lazy` over `cached`. When unset (default), the resolver picks
+`cached`.
 
 The `segregation_cluster_id` is purely informational at this stage
 — it provides a name for telemetry / cache-eviction-boundary
@@ -194,10 +218,10 @@ A workload is *segregated* iff:
   workload is one query against a cold cache).
 
 If the caller declares `workload_segregated(true)` and the
-guarantee is violated, the result is **slower** L1 execution due
-to repeated LMDB cursor walks — but **not incorrect**. L1 produces
-the same answers as L2 on identical input; the segregation flag is
-strictly a performance hint.
+guarantee is violated, the result is **slower** `lazy` execution due
+to repeated LMDB cursor walks — but **not incorrect**. `lazy`
+produces the same answers as `cached` on identical input; the
+segregation flag is strictly a performance hint.
 
 ### 6.3 Compiler-inferred segregation (deferred)
 
@@ -213,7 +237,12 @@ revision.
 
 ## 7. Cost-model integration
 
-The existing resolver predicates extend to cover the new axes:
+The existing resolver predicates extend to cover the new axes. The
+auto-resolver pattern follows the existing convention in
+[`CACHE_COST_MODEL_PHILOSOPHY.md`](CACHE_COST_MODEL_PHILOSOPHY.md)
+and [`COST_FUNCTION_PHILOSOPHY.md`](COST_FUNCTION_PHILOSOPHY.md) —
+the user picks an explicit mode or sets `auto` and the resolver
+chooses from workload metadata.
 
 ### 7.1 New input fields
 
@@ -228,13 +257,25 @@ Added to the workload-metadata vocabulary used by `resolve_*` predicates:
 | `cache_miss_rate_estimate` | float | 0.5 | empirical / heuristic |
 | `expected_query_count_per_process` | int | 1 | caller-declared |
 
-### 7.2 Resolver: `resolve_lmdb_lookup_tier/2`
+### 7.2 Codegen option + resolver
 
-New predicate, sits next to the existing `resolve_auto_lmdb_cache_mode/2`:
+The user-facing codegen option:
 
 ```prolog
-resolve_lmdb_lookup_tier(Options, Tier) :-
-    % Tier = l0 | l1 | l2
+lmdb_materialisation(auto | eager | lazy | cached)
+```
+
+When set explicitly to `eager`/`lazy`/`cached`, the codegen emits
+that mode unconditionally. When set to `auto` (default), the
+resolver picks. This matches the existing pattern for
+`cache_strategy(auto)`, `lmdb_cache_mode(auto)`, and `use_lmdb(auto)`.
+
+The resolver predicate, sitting next to the existing
+`resolve_auto_lmdb_cache_mode/2`:
+
+```prolog
+resolve_auto_lmdb_materialisation(Options, Mode) :-
+    % Mode = eager | lazy | cached
     option(fact_count(F), Options),
     option(demand_set_estimate(D), Options),
     option(memory_budget(B), Options),
@@ -242,56 +283,57 @@ resolve_lmdb_lookup_tier(Options, Tier) :-
     option(expected_query_count_per_process(NQ), Options, 1),
     edge_size_bytes(F, EdgeBytes),
     (   D * EdgeBytes > B
-    ->  % Demand set doesn't fit; must use lazy
-        ( WS == true -> Tier = l1 ; Tier = l2 )
+    ->  % Demand set doesn't fit; must use a lazy form
+        ( WS == true -> Mode = lazy ; Mode = cached )
     ;   % Demand set fits; eager wins if NQ * ε amortises M
         crossover_eager_lazy(F, D, NQ, ChooseEager),
         (   ChooseEager == true
-        ->  Tier = l0
-        ;   ( WS == true -> Tier = l1 ; Tier = l2 )
+        ->  Mode = eager
+        ;   ( WS == true -> Mode = lazy ; Mode = cached )
         )
     ).
 ```
 
-### 7.3 Resolver: `resolve_lmdb_access_mode/2`
+### 7.3 Resolver: `resolve_auto_lmdb_access_mode/2`
 
 For the scan-vs-seek axis:
 
 ```prolog
-resolve_lmdb_access_mode(Options, Mode) :-
-    % Mode = seek | scan
+resolve_auto_lmdb_access_mode(Options, Access) :-
+    % Access = seek | scan
     option(physical_layout_quality(Q), Options, insertion_order),
     option(expected_keys_per_call(K), Options, 1),
     option(scan_threshold_keys(T), Options, 16),
     (   Q \= insertion_order, K >= T
-    ->  Mode = scan
-    ;   Mode = seek
+    ->  Access = scan
+    ;   Access = seek
     ).
 ```
 
-The two resolvers compose: `(l0|l1|l2) × (seek|scan)` = 6 combinations,
-but only 4 are meaningful (L0 doesn't use either; L1+scan, L2+seek,
-L2+scan, and L1+seek are the four lazy options).
+The two resolvers compose: `(eager|lazy|cached) × (seek|scan)` = 6
+combinations, but only 4 are meaningful (`eager` doesn't use either;
+`lazy`+scan, `cached`+seek, `cached`+scan, and `lazy`+seek are the
+four lazy options).
 
 ## 8. Generated-code shape
 
-### 8.1 Rust (per-tier)
+### 8.1 Rust (per mode)
 
-For L0 — current behaviour:
+For `eager` — current behaviour:
 
 ```rust
 let runtime_category_parents: Vec<(String, String)> = (...materialisation...);
 vm.register_indexed_atom_fact2("category_parent/2", build_indexed_fact2(&runtime_category_parents));
 ```
 
-For L1:
+For `lazy`:
 
 ```rust
 let lookup = LmdbCursorLookup::new(&lmdb, &reachable_ids, &i2s);
 vm.register_foreign_lookup("category_parent/2", Box::new(lookup));
 ```
 
-For L2:
+For `cached`:
 
 ```rust
 let inner = LmdbCursorLookup::new(&lmdb, &reachable_ids, &i2s);
@@ -301,24 +343,25 @@ vm.register_foreign_lookup("category_parent/2", Box::new(lookup));
 
 `register_foreign_lookup` is the new runtime API the WAM-Rust runtime
 needs. Today the kernel calls into `ffi_facts: HashMap<String,
-HashMap<u32, Vec<u32>>>` for foreign-predicate edge lookups; the L1/L2
-path replaces that with a trait object call.
+HashMap<u32, Vec<u32>>>` for foreign-predicate edge lookups; the
+`lazy`/`cached` path replaces that with a trait object call.
 
-### 8.2 Haskell (per-tier)
+### 8.2 Haskell (per mode)
 
-L0 — `resident` (IntMap) mode. Already implemented.
+`eager` — `resident` (IntMap) mode. Already implemented.
 
-L1 — a hypothetical `lazyCursor` mode (not yet implemented). Would
-remove the per-HEC L1 and sharded L2 caches from the
-`lmdbFactSource.hs.mustache` template.
+`lazy` — a hypothetical `lazyCursor` mode (not yet implemented).
+Would remove the per-HEC L1 and sharded L2 caches from the
+`lmdb_fact_source.hs.mustache` template.
 
-L2 — `resident_cursor` mode with `lmdb_cache_mode(per_hec |
+`cached` — `resident_cursor` mode with `lmdb_cache_mode(per_hec |
 sharded | two_level)`. Already implemented.
 
-So in Haskell, L2 is the existing implementation; L1 would be an L2
-instance with cache size = 0, which is a configuration value
-already exposed. **No new Haskell code is required to support L1**;
-the spec just blesses it as a valid configuration.
+So in Haskell, `cached` is the existing implementation; `lazy`
+would be a `cached` instance with cache size = 0, which is a
+configuration value already exposed. **No new Haskell code is
+required to support `lazy`**; the spec just blesses it as a valid
+configuration.
 
 ### 8.3 Scan-mode hooks
 
@@ -329,40 +372,42 @@ range API.
 
 ## 9. Testing contract
 
-For each target and each tier:
+For each target and each mode:
 
 1. **Correctness**: a small fixture (`1k_cats`, 5933 edges) yields
    identical `tuple_count` and per-tuple `effective_distance` under
-   L0, L1, and L2 modes.
-2. **Cache behaviour**: at L2, count cache hits / misses via
+   `eager`, `lazy`, and `cached` modes.
+2. **Cache behaviour**: at `cached`, count cache hits / misses via
    instrumentation; assert hits > 0 on the test workload.
-3. **Segregation contract**: at L1 with `workload_segregated(true)`,
-   confirm no cross-seed key revisits via instrumentation.
+3. **Segregation contract**: at `lazy` with
+   `workload_segregated(true)`, confirm no cross-seed key revisits
+   via instrumentation.
 4. **Scan vs seek**: a smoke test on a topologically-sorted fixture
    confirms scan yields the same results as repeated seeks.
 
 ## 10. Versioning and migration
 
-Adding L1 / L2 / scan-mode is *additive*:
+Adding `lazy` / `cached` / scan-mode is *additive*:
 
-- Existing benchmarks default to L0 (unchanged behaviour).
-- The cost-model resolver opts into L2 only when `lmdb_lazy_tier(auto)`
-  is set; existing call sites without that option remain at L0.
-- The LMDB on-disk format is unchanged. The new `layout_strategy` and
-  `scan_threshold` fields in the meta sub-db are optional reads with
-  documented defaults.
+- Existing benchmarks default to `eager` (unchanged behaviour).
+- The cost-model resolver opts into `cached` only when
+  `lmdb_materialisation(auto)` is set; existing call sites without
+  that option remain at `eager`.
+- The LMDB on-disk format is unchanged. The new `layout_strategy`
+  and `scan_threshold` fields in the meta sub-db are optional reads
+  with documented defaults.
 
-This means each target can adopt the L1/L2 work incrementally without
-breaking existing benchmarks.
+This means each target can adopt the `lazy`/`cached` work incrementally
+without breaking existing benchmarks.
 
 ## 11. Out of scope (for this spec revision)
 
-- **Multi-process shared cache**: would let L2 share state across
-  process invocations. Out of scope; could be added with the LMDB
-  itself as a shared cache by definition (an L2-as-LMDB-table
-  pattern).
-- **Adaptive tier switching**: the cost model picks once per
-  process. Switching tiers mid-run is more invasive and not
+- **Multi-process shared cache**: would let `cached` share state
+  across process invocations. Out of scope; could be added with the
+  LMDB itself as a shared cache by definition (a `cached`-as-LMDB-
+  table pattern).
+- **Adaptive mode switching**: the cost model picks once per
+  process. Switching modes mid-run is more invasive and not
   motivated by any current measurement.
 - **Compiler-inferred segregation**: see §6.3. Deferred.
 - **MST-sort ingest pre-processor**: see philosophy doc §4.2.
@@ -377,8 +422,11 @@ breaking existing benchmarks.
   spec reads from.
 - `QUERY_PLAN_RUNTIME_PHILOSOPHY.md` — the broader runtime-planner
   pattern.
-- `CACHE_COST_MODEL_PHILOSOPHY.md` — cost-model framework.
+- `CACHE_COST_MODEL_PHILOSOPHY.md` — cost-model framework + the
+  existing auto-resolver pattern.
+- `COST_FUNCTION_PHILOSOPHY.md` — Green's-function / flux cost
+  functions that compose with the resolver.
 - `templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache`
   — current Rust `LookupSource`-equivalent (eager only).
 - `templates/targets/haskell_wam/lmdb_fact_source.hs.mustache` —
-  current Haskell L2 implementation.
+  current Haskell `cached`-mode implementation.


### PR DESCRIPTION
  Follow-up to PR #2376 (the original WAM LMDB lazy-access design triad).

  The previous PR introduced three runtime materialisation modes for
  LMDB-backed predicates and named them `L0`/`L1`/`L2`. That naming
  collided with Haskell's existing per-HEC L1 and sharded L2 cache-tier
  vocabulary (the cache tiers live *inside* the `cached` mode — not as
  peers to it). A mid-PR rename was applied but only partially.

  This PR finishes the rename across the three docs and adds a
  top-of-doc Vocabulary callout to each so the distinction is hard to
  miss going forward.

  ## What changed

  1. **Top-of-doc Vocabulary callout** in all three docs, distinguishing:
     - **Modes** (runtime materialisation): `eager`, `lazy`, `cached`.
     - **Phases** (project sequencing): R7, R8, R9, R10, H1, X.
     - **Cache tiers** (Haskell-internal, within `cached` mode):
       per-HEC L1, sharded L2.

  2. **Settled on `lmdb_materialisation(auto|eager|lazy|cached)`** as the
     user-facing codegen option, matching the existing
     `cache_strategy(auto)` / `lmdb_cache_mode(auto)` / `use_lmdb(auto)`
     naming convention. The `auto` value triggers the resolver; explicit
     modes (`eager`/`lazy`/`cached`) override it.

  3. **Renamed the resolver** to `resolve_auto_lmdb_materialisation/2`
     to match the rest of the `cost_model.pl` auto-resolver family
     (`resolve_auto_cache_strategy/2`, `resolve_auto_lmdb_cache_mode/2`,
     etc.).

  4. **Updated branch names** in the implementation plan:
     - `feat/wam-rust-lmdb-lazy-l1` → `feat/wam-rust-lmdb-lazy`
     - `feat/wam-rust-lmdb-lazy-l2` → `feat/wam-rust-lmdb-cached`
     - `feat/wam-haskell-l1-recognition` → `feat/wam-haskell-lazy-recognition`

  5. **Cross-references** to `CACHE_COST_MODEL_PHILOSOPHY.md` and
     `COST_FUNCTION_PHILOSOPHY.md` as the auto-resolver design pattern
     (sometimes called "the C# cost analysis" since the C# planner
     already does similar runtime mode selection — but the pattern
     itself is target-agnostic).

  6. **Phase R7 scope clarification**: R7 wires the `auto` token but
     leaves the resolver returning `eager` until R8 actually implements
     the resolver. Callers who want `lazy` in the R7 prototype must set
     it explicitly. (This was implicit before; now stated.)

  ## What didn't change

  - Phase labels (R7, R8, R9, R10, H1, X) are preserved — they are
    project sequencing markers, distinct from the modes.
  - Phase L# references (the perf-log Haskell phase numbers) are
    preserved.
  - The Haskell internal cache-tier vocabulary "per-HEC L1 cache" and
    "sharded L2 cache" is preserved — those are the existing
    `lmdb_cache_mode(per_hec|sharded|two_level)` configurations and
    *internal* to the `cached` mode.

  ## Files changed

  | File | Status | Lines net |
  | --- | --- | ---: |
  | `docs/design/WAM_LMDB_LAZY_PHILOSOPHY.md` | modified | +214 / -177 |
  | `docs/design/WAM_LMDB_LAZY_SPECIFICATION.md` | modified | +236 / -169 |
  | `docs/design/WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md` | modified | +186 / -177 |

  (Large net diff because the modes are referenced pervasively; the
  semantic delta is the rename + a new Vocabulary section per doc.)

  ## Test plan

  - [x] No code changes — design docs only
  - [x] All three docs internally consistent: same Vocabulary block,
        same option name (`lmdb_materialisation`), same resolver name
        (`resolve_auto_lmdb_materialisation`)
  - [x] No stale `L0`/`L1`/`L2` references to *modes* (the only
        remaining `L1`/`L2` references are the legit Haskell cache-tier
        names and `Phase L#…` perf-log references)
  - [x] Branch names in the implementation plan match the convention
  - [x] Markdown renders correctly in GitHub-flavoured preview
  - [x] Cross-references to existing docs resolve

  ## Follow-up

  Unblocks `feat/wam-rust-lmdb-lazy` (Phase R7) starting from a clean
  naming baseline.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)