### PR TITLE
Add reverse-index artifact policy and Phase 1 manifest metadata

### DIFF
--- a/docs/design/WAM_REVERSE_INDEX_ARTIFACTS.md
+++ b/docs/design/WAM_REVERSE_INDEX_ARTIFACTS.md
@@ -24,8 +24,8 @@ The short version:
   backing stores compete for the OS page cache, even if they are in
   separate files.
 - A CSR-style reverse artifact can keep child lookup out of the
-  memory-mapped path by using explicit `pread` slices and a bounded
-  user-space cache.
+  memory-mapped path by using explicit read policy, bounded user-space
+  cache, and optional OS-cache bypass when the platform supports it.
 
 This is not a fourth lazy/eager mode. It is an artifact and lifecycle
 choice that composes with the L0/L1/L2 parent-edge tier.
@@ -73,6 +73,20 @@ framework?" The current question is:
 2. when should the planner allow that artifact to be touched;
 3. whether we need a new non-mmap CSR storage kind for reverse lookup
    when page-cache competition matters.
+
+Every reverse artifact MUST declare the ID convention it stores. A
+target reader may translate between conventions before opening the
+artifact, but it must not silently interpret one encoding as another.
+
+```prolog
+id_encoding(int32_le).       % Phase 1 resident IDs
+id_encoding(decimal_utf8).   % C# query LMDB artifact IDs today
+```
+
+For CSR, the preferred implementation encoding is `int32_le`, because
+CSR is an integer layout. A C# query workload that still uses decimal
+UTF-8 IDs needs either a companion mapping table or a build step that
+emits an artifact in the reader's declared convention.
 
 ## 1. Problem
 
@@ -164,6 +178,7 @@ resolved option should include a storage kind:
 reverse_index(artifact([
     relation(category_child/2),
     storage_kind(mmap_array_artifact),
+    id_encoding(int32_le),
     ordering(parent_sort),
     phase(cache_warmup)
 ])).
@@ -171,8 +186,10 @@ reverse_index(artifact([
 reverse_index(artifact([
     relation(category_child/2),
     storage_kind(csr_pread_artifact),
+    id_encoding(int32_le),
     ordering(root_bfs),
     phase(runtime_available),
+    io_policy(auto),
     cache_bytes(67108864)
 ])).
 ```
@@ -181,6 +198,9 @@ reverse_index(artifact([
 names the important distinction from `mmap_array_artifact`: reverse
 child rows are fetched by explicit reads with bounded user-space cache,
 not by mapping another large relation into the process address space.
+
+`io_policy(auto)` is the default for CSR. See §3.4.1 for how it
+resolves.
 
 ### 2.1 Reverse-index phases
 
@@ -282,18 +302,62 @@ small in-memory key index.
 Lookup is:
 
 1. find the parent's `(offset, count)` record;
-2. `pread` exactly `count * sizeof(child_id)` bytes from `.val`;
+2. read exactly `count * sizeof(child_id)` bytes from `.val` using the
+   configured `io_policy`;
 3. optionally cache that slice in a bounded user-space cache.
 
 The important property is that the CSR files do not have to be
-memory-mapped. The runtime can use ordinary reads or `pread`, keeping
-reverse-edge caching explicit and bounded instead of letting the OS page
-cache make the trade-off implicitly.
+memory-mapped. Avoiding mmap removes a second reverse-edge virtual
+address mapping from the hot path. It does not, by itself, eliminate OS
+page-cache pressure: ordinary `read` and `pread` still populate the
+kernel page cache. True page-cache bypass requires platform-specific
+direct I/O, and that comes with alignment and portability costs.
 
 This proposed artifact should be treated as a new storage kind in the
 same conceptual family as `binary_artifact`, `lmdb_artifact`, and
 `mmap_array_artifact`, rather than as a replacement for the existing C#
 artifact framework.
+
+### 3.4.1 CSR I/O policy
+
+CSR access should expose an explicit I/O policy:
+
+```prolog
+io_policy(auto).
+io_policy(buffered_pread).
+io_policy(buffered_pread_drop).
+io_policy(direct_io).
+```
+
+| Policy | Meaning | Default use |
+| --- | --- | --- |
+| `buffered_pread` | Use `pread` or equivalent positional reads. No mmap, but OS page cache is allowed. | Safe portable baseline. |
+| `buffered_pread_drop` | Use `pread`, then ask the OS to drop consumed reverse blocks where supported, e.g. `posix_fadvise(..., DONTNEED)`. | Planning/warmup phases that should not leave reverse pages resident. |
+| `direct_io` | Use direct I/O, e.g. Linux `O_DIRECT`, when the filesystem, alignment, block size, and runtime bindings support it. | Large aligned runtime reads where page-cache isolation beats direct-I/O overhead. |
+| `auto` | Choose from phase, platform support, block size, and measurements. | Default. |
+
+`direct_io` should not be the unconditional default. It can avoid page
+cache competition, but it requires aligned buffers, aligned offsets and
+sizes, platform-specific open flags, and careful handling of short or
+small reads. It may also defeat useful kernel readahead. The initial
+resolver should be conservative:
+
+```prolog
+resolve_csr_io_policy(Options, buffered_pread_drop) :-
+    option(phase(Phase), Options),
+    memberchk(Phase, [planning_only, cache_warmup]).
+resolve_csr_io_policy(Options, direct_io) :-
+    option(phase(runtime_available), Options),
+    option(block_size_edges(B), Options),
+    B >= 65536,
+    option(platform_supports_direct_io(true), Options),
+    option(alignment_verified(true), Options),
+    option(measured_direct_io_win(true), Options).
+resolve_csr_io_policy(_Options, buffered_pread).
+```
+
+This is pseudocode using `option/3` in the `library(option)` style. The
+actual resolver should live beside the other cost-model predicates.
 
 ### 3.5 `reverse_index(csr([block_size_edges(N), ...]))`
 
@@ -307,7 +371,7 @@ category_child.blocks.00001
 ...
 ```
 
-or kept as one `.val` file with block metadata:
+The default should be one `.val` file with block metadata:
 
 ```
 block_id, file_offset, edge_count, parent_min, parent_max, checksum
@@ -316,6 +380,10 @@ block_id, file_offset, edge_count, parent_min, parent_max, checksum
 Block CSR lets the builder group parents whose child lists are likely to
 be queried together. It also gives the runtime a natural cache unit:
 cache or drop one block at a time, rather than caching arbitrary slices.
+Separate block files are a future option for platforms where operational
+constraints make a single large file awkward. They should not be the
+first implementation because they increase file-descriptor management
+and manifest complexity.
 
 ## 4. Ordering strategies
 
@@ -333,7 +401,7 @@ free, and it only pays when the same dataset sees enough queries.
 | `graph_partition` | near-linear practical cost, high constants | blocks with low cross-block traffic | METIS-style partitioning; valuable only for large reusable corpora. |
 | `spectral` | expensive eigensolver iterations | global bandwidth reduction | Mostly completeness; likely too costly for ordinary benchmarks. |
 | `bandwidth_heuristic` | NP-hard exact problem; heuristic cost varies | block diagonal shape | Use only when query volume is massive. |
-| `embedding_cluster` | expensive unless embeddings already exist | semantic locality | Useful if topic embeddings are already part of the corpus. |
+| `embedding_cluster` | expensive unless embeddings already exist | semantic locality | Out of scope unless a separate embedding pipeline is integrated. |
 
 The cheap and moderate options are close enough to linear that they are
 reasonable for corpora that will be queried repeatedly. The high-cost
@@ -362,6 +430,10 @@ If the caller expects only a few queries, parent-only LMDB usually wins
 because `reverse_preprocess_wall_seconds` is not amortised. If the same
 dataset will support thousands or millions of queries, even a linear
 preprocessing pass can become cheap.
+
+If `per_query_savings <= 0`, the artifact is contraindicated regardless
+of expected query count. Benchmark reports should flag that case
+explicitly instead of producing a negative break-even query count.
 
 The cost model needs these inputs:
 
@@ -392,6 +464,7 @@ otherwise:
 
 ```prolog
 resolve_reverse_index(Options, none) :-
+    % option/3 is SWI-Prolog library(option) style pseudocode.
     option(expected_query_count_per_artifact(Q), Options, 1),
     Q < 100,
     \+ option(needs_descendant_lookup(true), Options).
@@ -425,6 +498,9 @@ reverse_index_phase(cache_warmup).
 reverse_index_runtime_access(disabled).
 ```
 
+These predicates are design stubs. Phase D planner integration defines
+where they live and how target runtimes enforce them.
+
 If a workload genuinely needs both directions during runtime, the target
 should prefer CSR with explicit cache sizing over a second mmap source:
 
@@ -444,6 +520,16 @@ Correctness:
 - Verify identical descendant sets for sampled parents.
 - Verify identical demand sets and effective-distance outputs when a
   reverse artifact is used only for planning or warmup.
+- Verify artifact readers reject mismatched `id_encoding` declarations
+  instead of silently interpreting decimal UTF-8 IDs as int32 or the
+  reverse.
+
+Phase enforcement:
+
+- Verify `planning_only` and `cache_warmup` reverse artifacts are closed
+  or flagged inaccessible before the hot kernel's first WAM instruction.
+- Verify the "reverse artifact touched during hot kernel" telemetry is
+  zero for every phase except `runtime_available`.
 
 Performance:
 
@@ -453,6 +539,9 @@ Performance:
 - Record minor and major page faults where the platform exposes them.
 - Compare parent-only LMDB, reverse LMDB, `parent_sort` CSR, and
   `root_bfs` CSR.
+- Compare `buffered_pread`, `buffered_pread_drop`, and `direct_io`
+  where the platform supports direct I/O and the block layout can meet
+  alignment requirements.
 - Compute break-even query counts from observed preprocessing cost and
   per-query savings.
 
@@ -460,6 +549,8 @@ Regression guard:
 
 - Add a telemetry field for "reverse artifact touched during hot
   kernel". It should be zero for `planning_only` and `cache_warmup`.
+- Add telemetry for resolved CSR `io_policy`, direct-I/O support,
+  alignment fallback, and any `DONTNEED` advisory calls.
 
 ## 9. Implementation plan
 
@@ -468,10 +559,14 @@ Phase A - design and option validation:
 - Land this design doc.
 - Add Prolog option parsing tests for
   `reverse_index(none|lmdb|mmap_array|csr|artifact|auto)`.
+- Add option parsing for `id_encoding(...)` and
+  `io_policy(auto|buffered_pread|buffered_pread_drop|direct_io)`.
 - Reject `phase(runtime_available)` when no runtime reverse lookup API
   exists for the target.
 - Map `reverse_index(artifact(...))` onto the existing storage-kind
   vocabulary where a target already supports relation artifacts.
+- Define the minimum benchmark criteria before `reverse_index(auto)` can
+  choose anything other than `none` or an existing target artifact.
 
 Phase B - baseline builder:
 
@@ -485,9 +580,15 @@ Phase B - baseline builder:
 
 Phase C - CSR prototype:
 
-- Build `parent_sort` CSR from `category_parent/2`.
-- Add a small reader with direct-index or binary-search lookup.
-- Use `pread` instead of mmap by default.
+- Build `parent_sort` CSR from `category_parent/2` with
+  `id_encoding(int32_le)`.
+- Add a small Rust reader, co-located with the Rust LMDB sink/build path,
+  with direct-index or binary-search lookup. C# binding can follow once
+  the format and policy are stable.
+- Implement `io_policy(buffered_pread)` and
+  `io_policy(buffered_pread_drop)` first.
+- Prototype `io_policy(direct_io)` only after block alignment and
+  platform support are verified.
 - Add bounded slice/block cache.
 
 Phase D - planner integration:

--- a/examples/benchmark/convert_lmdb_to_phase1_layout.py
+++ b/examples/benchmark/convert_lmdb_to_phase1_layout.py
@@ -31,8 +31,10 @@ has a populated meta sub-db.
 """
 
 import os
+import json
 import struct
 import sys
+import time
 from pathlib import Path
 
 try:
@@ -43,6 +45,7 @@ except ImportError:
 
 
 def main() -> int:
+    started_at = time.time()
     if len(sys.argv) != 3:
         sys.stderr.write(
             "Usage: convert_lmdb_to_phase1_layout.py <src_lmdb_dir> <dst_lmdb_dir>\n"
@@ -121,17 +124,86 @@ def main() -> int:
                 dst_txn.put(b"compile_time_atoms_count", struct.pack("<i", 0), db=meta_db)
                 dst_txn.put(b"cli_args", " ".join(sys.argv).encode("utf-8"), db=meta_db)
                 dst_txn.put(b"converted_from", str(src_dir).encode("utf-8"), db=meta_db)
+                dst_txn.put(b"id_encoding", b"int32_le", db=meta_db)
+                dst_txn.put(b"category_parent_edge_count", str(cp_count).encode("ascii"), db=meta_db)
+                dst_txn.put(b"category_child_edge_count", str(cp_count).encode("ascii"), db=meta_db)
+                dst_txn.put(b"reverse_index_relation", b"category_child/2", db=meta_db)
+                dst_txn.put(b"reverse_index_storage_kind", b"phase1_lmdb_subdb", db=meta_db)
 
     finally:
         src_env.close()
         dst_env.sync()
         dst_env.close()
 
+    elapsed_seconds = time.time() - started_at
+    write_phase1_manifest(
+        dst_dir,
+        src_dir,
+        cp_count,
+        max_id,
+        elapsed_seconds,
+    )
+
     sys.stderr.write(
         f"convert_lmdb_to_phase1_layout: cp_edges={cp_count} "
         f"cc_edges={cp_count} max_id={max_id} -> {dst_dir}\n"
     )
     return 0
+
+
+def write_phase1_manifest(
+    dst_dir: Path,
+    src_dir: Path,
+    edge_count: int,
+    max_id: int,
+    elapsed_seconds: float,
+) -> None:
+    manifest = {
+        "format": "unifyweaver.phase1_lmdb_manifest.v1",
+        "schema_version": 1,
+        "environment_path": str(dst_dir),
+        "source_environment_path": str(src_dir),
+        "id_encoding": "int32_le",
+        "max_id": max_id,
+        "relations": {
+            "category_parent/2": {
+                "database": "category_parent",
+                "dupsort": True,
+                "edge_count": edge_count,
+                "key": "child",
+                "value": "parent",
+            },
+            "category_child/2": {
+                "database": "category_child",
+                "dupsort": True,
+                "edge_count": edge_count,
+                "key": "parent",
+                "value": "child",
+                "derived_from": "category_parent/2",
+                "storage_kind": "phase1_lmdb_subdb",
+            },
+            "article_category/2": {
+                "database": "article_category",
+                "dupsort": True,
+                "edge_count": 0,
+            },
+        },
+        "reverse_indexes": [
+            {
+                "relation": "category_child/2",
+                "source_relation": "category_parent/2",
+                "storage_kind": "phase1_lmdb_subdb",
+                "id_encoding": "int32_le",
+                "edge_count": edge_count,
+            }
+        ],
+        "build": {
+            "tool": "convert_lmdb_to_phase1_layout.py",
+            "elapsed_seconds": round(elapsed_seconds, 6),
+        },
+    }
+    manifest_path = dst_dir / "phase1_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/src/unifyweaver/core/cost_model.pl
+++ b/src/unifyweaver/core/cost_model.pl
@@ -35,6 +35,9 @@
     crossover_k/4,              % +WBytes, +FHot, +Constants, -KCross
     warming_payoff_m/5,         % +WWarmBytes, +KPerQuery, +FHot, +Constants, -MMin
     recommend_access_pattern/5, % +KKeys, +WBytes, +RFreeBytes, +Constants, -Pattern
+    resolve_reverse_index/2,    % +Options, -ReverseIndex
+    validate_reverse_index_option/2, % +Spec, -Normalized
+    resolve_csr_io_policy/2,    % +Options, -Policy
 
     %% Hardware constants
     default_constants/1,        % -Constants
@@ -43,6 +46,8 @@
     %% System probes (impure)
     read_mem_available_bytes/1  % -Bytes
 ]).
+
+:- use_module(library(option)).
 
 %% =====================================================================
 %% Hardware constants
@@ -209,6 +214,220 @@ recommend_access_pattern(KKeys, WBytes, RFreeBytes, Constants, Pattern) :-
     ->  Pattern = sort
     ;   Pattern = scan
     ).
+
+%% =====================================================================
+%% Reverse-index artifact policy
+%% =====================================================================
+
+%! resolve_reverse_index(+Options, -ReverseIndex) is det.
+%
+%  Resolve the reverse-index artifact request from workload metadata.
+%  The current `auto` policy is deliberately conservative: it returns
+%  `none` unless descendant lookup is semantically required. Explicit
+%  reverse_index(...) terms are normalized and validated.
+resolve_reverse_index(Options, ReverseIndex) :-
+    option(reverse_index(Spec0), Options, auto),
+    resolve_reverse_index_spec(Spec0, Options, ReverseIndex).
+
+resolve_reverse_index_spec(auto, Options, ReverseIndex) :-
+    !,
+    option(needs_descendant_lookup(NeedsDesc), Options, false),
+    option(expected_query_count_per_artifact(QueryCount), Options, 1),
+    (   NeedsDesc == true
+    ->  ReverseIndex = artifact([
+            relation(category_child/2),
+            storage_kind(mmap_array_artifact),
+            phase(planning_only),
+            id_encoding(int32_le)
+        ])
+    ;   QueryCount < 100
+    ->  ReverseIndex = none
+    ;   ReverseIndex = none
+    ).
+resolve_reverse_index_spec(Spec, _Options, ReverseIndex) :-
+    validate_reverse_index_option(Spec, ReverseIndex).
+
+%! validate_reverse_index_option(+Spec, -Normalized) is det.
+%
+%  Validate the user-facing reverse_index(...) spec and fill in
+%  conservative defaults. Throws domain_error/2 for unsupported
+%  values.
+validate_reverse_index_option(none, none) :- !.
+validate_reverse_index_option(auto, auto) :- !.
+validate_reverse_index_option(lmdb(Opts0), lmdb(Opts)) :-
+    !,
+    normalize_reverse_options(lmdb, Opts0, Opts).
+validate_reverse_index_option(mmap_array(Opts0), mmap_array(Opts)) :-
+    !,
+    normalize_reverse_options(mmap_array, Opts0, Opts).
+validate_reverse_index_option(csr(Opts0), csr(Opts)) :-
+    !,
+    normalize_reverse_options(csr, Opts0, Opts).
+validate_reverse_index_option(artifact(Opts0), artifact(Opts)) :-
+    !,
+    normalize_reverse_options(artifact, Opts0, Opts).
+validate_reverse_index_option(Spec, _) :-
+    throw(error(domain_error(reverse_index_option, Spec), _)).
+
+normalize_reverse_options(Kind, Opts0, Opts) :-
+    must_be(list, Opts0),
+    validate_known_reverse_options(Opts0),
+    option(phase(Phase), Opts0, planning_only),
+    validate_reverse_phase(Phase),
+    option(id_encoding(IdEncoding), Opts0, int32_le),
+    validate_id_encoding(IdEncoding),
+    normalize_kind_options(Kind, Opts0, KindOpts),
+    append([phase(Phase), id_encoding(IdEncoding)], KindOpts, Opts).
+
+normalize_kind_options(lmdb, _Opts0, []).
+normalize_kind_options(mmap_array, _Opts0, []).
+normalize_kind_options(csr, Opts0, Opts) :-
+    option(ordering(Ordering), Opts0, parent_sort),
+    validate_reverse_ordering(Ordering),
+    option(cache_bytes(CacheBytes), Opts0, 0),
+    validate_nonnegative_integer(cache_bytes, CacheBytes),
+    option(block_size_edges(BlockSizeEdges), Opts0, 0),
+    validate_nonnegative_integer(block_size_edges, BlockSizeEdges),
+    resolve_csr_io_policy(Opts0, IoPolicy),
+    Opts = [
+        ordering(Ordering),
+        io_policy(IoPolicy),
+        cache_bytes(CacheBytes),
+        block_size_edges(BlockSizeEdges)
+    ].
+normalize_kind_options(artifact, Opts0, Opts) :-
+    option(relation(Relation), Opts0, category_child/2),
+    validate_predicate_indicator(Relation),
+    option(storage_kind(StorageKind), Opts0, mmap_array_artifact),
+    validate_storage_kind(StorageKind),
+    option(ordering(Ordering), Opts0, parent_sort),
+    validate_reverse_ordering(Ordering),
+    option(cache_bytes(CacheBytes), Opts0, 0),
+    validate_nonnegative_integer(cache_bytes, CacheBytes),
+    artifact_io_options(StorageKind, Opts0, IoOpt),
+    append([
+        relation(Relation),
+        storage_kind(StorageKind),
+        ordering(Ordering),
+        cache_bytes(CacheBytes)
+    ], IoOpt, Opts).
+
+artifact_io_options(csr_pread_artifact, Opts0, [io_policy(IoPolicy)]) :-
+    !,
+    resolve_csr_io_policy(Opts0, IoPolicy).
+artifact_io_options(_StorageKind, Opts0, []) :-
+    \+ option(io_policy(_), Opts0),
+    !.
+artifact_io_options(StorageKind, _Opts0, _) :-
+    throw(error(permission_error(use, io_policy, StorageKind), _)).
+
+%! resolve_csr_io_policy(+Options, -Policy) is det.
+%
+%  Resolve CSR I/O policy. Explicit non-auto values are validated and
+%  preserved. `auto` picks buffered_pread_drop for planning/warmup,
+%  direct_io only when all direct-I/O preconditions are declared and
+%  measured to win, and buffered_pread otherwise.
+resolve_csr_io_policy(Options, Policy) :-
+    option(io_policy(Policy0), Options, auto),
+    resolve_csr_io_policy_value(Policy0, Options, Policy).
+
+resolve_csr_io_policy_value(auto, Options, buffered_pread_drop) :-
+    option(phase(Phase), Options, planning_only),
+    memberchk(Phase, [planning_only, cache_warmup]),
+    !.
+resolve_csr_io_policy_value(auto, Options, direct_io) :-
+    option(phase(runtime_available), Options),
+    option(block_size_edges(BlockSizeEdges), Options),
+    BlockSizeEdges >= 65536,
+    option(platform_supports_direct_io(true), Options),
+    option(alignment_verified(true), Options),
+    option(measured_direct_io_win(true), Options),
+    !.
+resolve_csr_io_policy_value(auto, _Options, buffered_pread) :- !.
+resolve_csr_io_policy_value(Policy, _Options, Policy) :-
+    validate_csr_io_policy(Policy),
+    !.
+
+validate_known_reverse_options([]).
+validate_known_reverse_options([Opt|Rest]) :-
+    functor(Opt, Name, 1),
+    reverse_option_key(Name),
+    !,
+    validate_known_reverse_options(Rest).
+validate_known_reverse_options([Opt|_]) :-
+    throw(error(domain_error(reverse_index_option_key, Opt), _)).
+
+reverse_option_key(phase).
+reverse_option_key(id_encoding).
+reverse_option_key(ordering).
+reverse_option_key(cache_bytes).
+reverse_option_key(block_size_edges).
+reverse_option_key(io_policy).
+reverse_option_key(platform_supports_direct_io).
+reverse_option_key(alignment_verified).
+reverse_option_key(measured_direct_io_win).
+reverse_option_key(relation).
+reverse_option_key(storage_kind).
+
+validate_reverse_phase(Phase) :-
+    memberchk(Phase, [planning_only, cache_warmup, runtime_available]),
+    !.
+validate_reverse_phase(Phase) :-
+    throw(error(domain_error(reverse_index_phase, Phase), _)).
+
+validate_id_encoding(Encoding) :-
+    memberchk(Encoding, [int32_le, decimal_utf8]),
+    !.
+validate_id_encoding(Encoding) :-
+    throw(error(domain_error(reverse_index_id_encoding, Encoding), _)).
+
+validate_csr_io_policy(Policy) :-
+    memberchk(Policy, [auto, buffered_pread, buffered_pread_drop, direct_io]),
+    !.
+validate_csr_io_policy(Policy) :-
+    throw(error(domain_error(csr_io_policy, Policy), _)).
+
+validate_reverse_ordering(Ordering) :-
+    memberchk(Ordering, [
+        parent_sort,
+        root_bfs,
+        component_degree,
+        multi_root_bfs,
+        graph_partition,
+        spectral,
+        bandwidth_heuristic,
+        embedding_cluster
+    ]),
+    !.
+validate_reverse_ordering(Ordering) :-
+    throw(error(domain_error(reverse_index_ordering, Ordering), _)).
+
+validate_storage_kind(StorageKind) :-
+    memberchk(StorageKind, [
+        binary_artifact,
+        delimited_artifact,
+        lmdb_artifact,
+        mmap_array_artifact,
+        csr_pread_artifact
+    ]),
+    !.
+validate_storage_kind(StorageKind) :-
+    throw(error(domain_error(reverse_index_storage_kind, StorageKind), _)).
+
+validate_predicate_indicator(Name/Arity) :-
+    atom(Name),
+    integer(Arity),
+    Arity >= 0,
+    !.
+validate_predicate_indicator(PI) :-
+    throw(error(domain_error(predicate_indicator, PI), _)).
+
+validate_nonnegative_integer(_Name, Value) :-
+    integer(Value),
+    Value >= 0,
+    !.
+validate_nonnegative_integer(Name, Value) :-
+    throw(error(domain_error(nonnegative_integer(Name), Value), _)).
 
 %% =====================================================================
 %% System probe

--- a/tests/core/test_cost_model.pl
+++ b/tests/core/test_cost_model.pl
@@ -82,6 +82,16 @@ test(test_warming_pays_off_when_all_cold).
 test(test_recommend_sort_at_low_k).
 test(test_recommend_scan_at_high_k).
 
+test(test_reverse_index_auto_defaults_none).
+test(test_reverse_index_auto_descendant_uses_existing_artifact).
+test(test_reverse_index_csr_normalizes_defaults).
+test(test_reverse_index_csr_runtime_auto_direct_io_when_supported).
+test(test_reverse_index_csr_runtime_auto_buffered_when_direct_io_not_verified).
+test(test_reverse_index_rejects_bad_id_encoding).
+test(test_reverse_index_rejects_unknown_io_policy).
+test(test_reverse_index_rejects_io_policy_for_mmap_artifact).
+test(test_reverse_index_artifact_normalizes_storage_kind).
+
 test(test_read_mem_available_returns_positive).
 
 %% ========================================================================
@@ -300,6 +310,139 @@ test_recommend_scan_at_high_k :-
     (   Pattern = scan
     ->  pass(Test)
     ;   fail_test(Test, format_atom("got pattern=~w (expected scan)", [Pattern]))
+    ).
+
+%% ========================================================================
+%% Reverse-index artifact policy
+%% ========================================================================
+
+test_reverse_index_auto_defaults_none :-
+    Test = 'resolve_reverse_index auto defaults to none for low-query no-descendant workloads',
+    resolve_reverse_index([], ReverseIndex),
+    (   ReverseIndex = none
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got reverse_index=~w (expected none)", [ReverseIndex]))
+    ).
+
+test_reverse_index_auto_descendant_uses_existing_artifact :-
+    Test = 'resolve_reverse_index auto uses existing artifact when descendants are required',
+    resolve_reverse_index([needs_descendant_lookup(true)], ReverseIndex),
+    Expected = artifact([
+        relation(category_child/2),
+        storage_kind(mmap_array_artifact),
+        phase(planning_only),
+        id_encoding(int32_le)
+    ]),
+    (   ReverseIndex = Expected
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got reverse_index=~w", [ReverseIndex]))
+    ).
+
+test_reverse_index_csr_normalizes_defaults :-
+    Test = 'validate_reverse_index_option csr normalizes defaults',
+    validate_reverse_index_option(csr([]), ReverseIndex),
+    Expected = csr([
+        phase(planning_only),
+        id_encoding(int32_le),
+        ordering(parent_sort),
+        io_policy(buffered_pread_drop),
+        cache_bytes(0),
+        block_size_edges(0)
+    ]),
+    (   ReverseIndex = Expected
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got reverse_index=~w", [ReverseIndex]))
+    ).
+
+test_reverse_index_csr_runtime_auto_direct_io_when_supported :-
+    Test = 'resolve_csr_io_policy auto selects direct_io only when runtime support is verified',
+    Options = [
+        phase(runtime_available),
+        block_size_edges(65536),
+        platform_supports_direct_io(true),
+        alignment_verified(true),
+        measured_direct_io_win(true)
+    ],
+    resolve_csr_io_policy(Options, Policy),
+    (   Policy = direct_io
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got policy=~w (expected direct_io)", [Policy]))
+    ).
+
+test_reverse_index_csr_runtime_auto_buffered_when_direct_io_not_verified :-
+    Test = 'resolve_csr_io_policy auto falls back to buffered_pread without direct_io proof',
+    Options = [
+        phase(runtime_available),
+        block_size_edges(65536),
+        platform_supports_direct_io(true),
+        alignment_verified(false),
+        measured_direct_io_win(true)
+    ],
+    resolve_csr_io_policy(Options, Policy),
+    (   Policy = buffered_pread
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got policy=~w (expected buffered_pread)", [Policy]))
+    ).
+
+test_reverse_index_rejects_bad_id_encoding :-
+    Test = 'validate_reverse_index_option rejects unsupported id_encoding',
+    (   catch((validate_reverse_index_option(csr([id_encoding(bytes)]), _), fail),
+              error(domain_error(reverse_index_id_encoding, bytes), _),
+              true)
+    ->  pass(Test)
+    ;   fail_test(Test, 'expected domain_error(reverse_index_id_encoding, bytes)')
+    ).
+
+test_reverse_index_rejects_unknown_io_policy :-
+    Test = 'validate_reverse_index_option rejects unsupported io_policy',
+    (   catch((validate_reverse_index_option(csr([io_policy(magic)]), _), fail),
+              error(domain_error(csr_io_policy, magic), _),
+              true)
+    ->  pass(Test)
+    ;   fail_test(Test, 'expected domain_error(csr_io_policy, magic)')
+    ).
+
+test_reverse_index_rejects_io_policy_for_mmap_artifact :-
+    Test = 'validate_reverse_index_option rejects io_policy for mmap_array artifact',
+    (   catch((validate_reverse_index_option(
+                  artifact([
+                      storage_kind(mmap_array_artifact),
+                      io_policy(direct_io)
+                  ]),
+                  _),
+                fail),
+              error(permission_error(use, io_policy, mmap_array_artifact), _),
+              true)
+    ->  pass(Test)
+    ;   fail_test(Test, 'expected permission_error(use, io_policy, mmap_array_artifact)')
+    ).
+
+test_reverse_index_artifact_normalizes_storage_kind :-
+    Test = 'validate_reverse_index_option artifact normalizes storage_kind and relation',
+    validate_reverse_index_option(
+        artifact([
+            relation(category_child/2),
+            storage_kind(csr_pread_artifact),
+            phase(runtime_available),
+            id_encoding(int32_le),
+            ordering(root_bfs),
+            io_policy(buffered_pread),
+            cache_bytes(1024)
+        ]),
+        ReverseIndex
+    ),
+    Expected = artifact([
+        phase(runtime_available),
+        id_encoding(int32_le),
+        relation(category_child/2),
+        storage_kind(csr_pread_artifact),
+        ordering(root_bfs),
+        cache_bytes(1024),
+        io_policy(buffered_pread)
+    ]),
+    (   ReverseIndex = Expected
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got reverse_index=~w", [ReverseIndex]))
     ).
 
 %% ========================================================================

--- a/tests/test_convert_lmdb_to_phase1_layout.py
+++ b/tests/test_convert_lmdb_to_phase1_layout.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import lmdb
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONVERTER = ROOT / "examples" / "benchmark" / "convert_lmdb_to_phase1_layout.py"
+
+
+def i32(value: int) -> bytes:
+    return struct.pack("<i", value)
+
+
+class ConvertLmdbToPhase1LayoutTest(unittest.TestCase):
+    def test_converter_writes_reverse_index_manifest_and_meta(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            src = tmp_path / "src.lmdb"
+            dst = tmp_path / "dst.lmdb"
+
+            src.mkdir()
+            env = lmdb.open(str(src), map_size=1 << 20, max_dbs=4, subdir=True)
+            main_db = env.open_db(b"main", dupsort=True)
+            with env.begin(write=True) as txn:
+                txn.put(i32(10), i32(20), db=main_db)
+                txn.put(i32(10), i32(30), db=main_db)
+                txn.put(i32(11), i32(20), db=main_db)
+            env.close()
+
+            result = subprocess.run(
+                [sys.executable, str(CONVERTER), str(src), str(dst)],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            manifest = json.loads((dst / "phase1_manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["format"], "unifyweaver.phase1_lmdb_manifest.v1")
+            self.assertEqual(manifest["id_encoding"], "int32_le")
+            self.assertEqual(manifest["relations"]["category_parent/2"]["edge_count"], 3)
+            self.assertEqual(manifest["relations"]["category_child/2"]["storage_kind"], "phase1_lmdb_subdb")
+            self.assertEqual(manifest["reverse_indexes"][0]["relation"], "category_child/2")
+            self.assertEqual(manifest["reverse_indexes"][0]["edge_count"], 3)
+
+            dst_env = lmdb.open(str(dst), readonly=True, max_dbs=8, lock=False)
+            try:
+                with dst_env.begin() as txn:
+                    meta_db = dst_env.open_db(b"meta", txn=txn, create=False)
+                    cc_db = dst_env.open_db(b"category_child", txn=txn, dupsort=True, create=False)
+                    self.assertEqual(txn.get(b"id_encoding", db=meta_db), b"int32_le")
+                    self.assertEqual(txn.get(b"category_child_edge_count", db=meta_db), b"3")
+                    self.assertEqual(txn.get(b"reverse_index_relation", db=meta_db), b"category_child/2")
+                    cursor = txn.cursor(db=cc_db)
+                    self.assertEqual(
+                        sorted((struct.unpack("<i", k)[0], struct.unpack("<i", v)[0]) for k, v in cursor),
+                        [(20, 10), (20, 11), (30, 10)],
+                    )
+            finally:
+                dst_env.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  - Clarify reverse CSR I/O policy in the design docs, including `buffered_pread`, `buffered_pread_drop`, and gated
  `direct_io`.
  - Add target-neutral reverse-index option validation/resolution in the cost model.
  - Support `reverse_index(...)`, `id_encoding(...)`, and CSR `io_policy(...)` configuration contracts.
  - Emit Phase 1 LMDB manifest metadata for the derived `category_child/2` reverse index.
  - Add tests for reverse-index policy resolution and Phase 1 manifest output.

  ## Validation

  - `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
  - `python3 tests/test_convert_lmdb_to_phase1_layout.py`
  - `python3 -m py_compile examples/benchmark/convert_lmdb_to_phase1_layout.py tests/
  test_convert_lmdb_to_phase1_layout.py`
  - `git diff --check`