### PR TITLE
Add reverse CSR artifact builder prototype

### DIFF
--- a/docs/design/WAM_REVERSE_INDEX_ARTIFACTS.md
+++ b/docs/design/WAM_REVERSE_INDEX_ARTIFACTS.md
@@ -581,7 +581,8 @@ Phase B - baseline builder:
 Phase C - CSR prototype:
 
 - Build `parent_sort` CSR from `category_parent/2` with
-  `id_encoding(int32_le)`.
+  `id_encoding(int32_le)`. Prototype script:
+  `examples/benchmark/build_reverse_csr_artifact.py`.
 - Add a small Rust reader, co-located with the Rust LMDB sink/build path,
   with direct-index or binary-search lookup. C# binding can follow once
   the format and policy are stable.

--- a/examples/benchmark/build_reverse_csr_artifact.py
+++ b/examples/benchmark/build_reverse_csr_artifact.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""
+build_reverse_csr_artifact.py — build a parent-sorted CSR reverse index
+from a Phase 1 LMDB category_parent sub-db.
+
+Input:
+  category_parent  int32_le child -> int32_le parent (DUPSORT)
+
+Output:
+  category_child.csr.idx   records: int32 parent, uint64 offset_edges, uint32 count
+  category_child.csr.val   records: int32 child
+  category_child.csr.meta  JSON manifest
+
+The output relation is category_child(parent, child). The prototype is
+intentionally parent_sort only and uses ordinary buffered reads on the
+reader side; direct I/O policy is deferred until the format is stable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import struct
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+try:
+    import lmdb
+except ImportError:
+    sys.stderr.write("build_reverse_csr_artifact: 'lmdb' Python package required\n")
+    sys.exit(1)
+
+
+IDX_RECORD = struct.Struct("<iQI")
+I32 = struct.Struct("<i")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build a parent-sorted CSR category_child reverse artifact from Phase 1 LMDB.",
+    )
+    parser.add_argument("phase1_lmdb_dir", type=Path)
+    parser.add_argument("out_dir", type=Path)
+    parser.add_argument("--refresh", action="store_true", help="replace an existing output directory")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    src_dir: Path = args.phase1_lmdb_dir
+    out_dir: Path = args.out_dir
+    started_at = time.time()
+
+    if not (src_dir / "data.mdb").exists():
+        sys.stderr.write(f"missing {src_dir}/data.mdb\n")
+        return 2
+    if out_dir.exists():
+        if not args.refresh:
+            sys.stderr.write(f"output directory exists; pass --refresh to rebuild: {out_dir}\n")
+            return 3
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    children_by_parent: dict[int, list[int]] = defaultdict(list)
+    edge_count = 0
+    max_id = 0
+
+    env = lmdb.open(str(src_dir), readonly=True, max_dbs=8, lock=False, subdir=True)
+    try:
+        with env.begin() as txn:
+            cp_db = env.open_db(b"category_parent", txn=txn, dupsort=True, create=False)
+            cursor = txn.cursor(db=cp_db)
+            for key, value in cursor:
+                if len(key) != 4 or len(value) != 4:
+                    continue
+                child = I32.unpack(key)[0]
+                parent = I32.unpack(value)[0]
+                children_by_parent[parent].append(child)
+                edge_count += 1
+                max_id = max(max_id, child, parent)
+    finally:
+        env.close()
+
+    idx_path = out_dir / "category_child.csr.idx"
+    val_path = out_dir / "category_child.csr.val"
+    meta_path = out_dir / "category_child.csr.meta"
+
+    offset_edges = 0
+    parent_count = 0
+    with idx_path.open("wb") as idx_file, val_path.open("wb") as val_file:
+        for parent in sorted(children_by_parent):
+            children = sorted(children_by_parent[parent])
+            idx_file.write(IDX_RECORD.pack(parent, offset_edges, len(children)))
+            for child in children:
+                val_file.write(I32.pack(child))
+            offset_edges += len(children)
+            parent_count += 1
+
+    elapsed_seconds = time.time() - started_at
+    manifest = {
+        "format": "unifyweaver.reverse_csr.v1",
+        "schema_version": 1,
+        "relation": "category_child/2",
+        "source_relation": "category_parent/2",
+        "source_environment_path": str(src_dir),
+        "storage_kind": "csr_pread_artifact",
+        "id_encoding": "int32_le",
+        "ordering": "parent_sort",
+        "io_policy": "buffered_pread",
+        "index_path": idx_path.name,
+        "values_path": val_path.name,
+        "index_record_format": "int32_le parent, uint64_le offset_edges, uint32_le count_edges",
+        "value_record_format": "int32_le child",
+        "index_record_bytes": IDX_RECORD.size,
+        "value_record_bytes": I32.size,
+        "parent_count": parent_count,
+        "edge_count": edge_count,
+        "max_id": max_id,
+        "build": {
+            "tool": "build_reverse_csr_artifact.py",
+            "elapsed_seconds": round(elapsed_seconds, 6),
+        },
+    }
+    meta_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    sys.stderr.write(
+        f"build_reverse_csr_artifact: parents={parent_count} edges={edge_count} "
+        f"max_id={max_id} -> {out_dir}\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_build_reverse_csr_artifact.py
+++ b/tests/test_build_reverse_csr_artifact.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import lmdb
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER = ROOT / "examples" / "benchmark" / "build_reverse_csr_artifact.py"
+I32 = struct.Struct("<i")
+IDX_RECORD = struct.Struct("<iQI")
+
+
+def i32(value: int) -> bytes:
+    return I32.pack(value)
+
+
+def read_idx(path: Path) -> list[tuple[int, int, int]]:
+    data = path.read_bytes()
+    return [
+        IDX_RECORD.unpack_from(data, offset)
+        for offset in range(0, len(data), IDX_RECORD.size)
+    ]
+
+
+def read_i32_values(path: Path) -> list[int]:
+    data = path.read_bytes()
+    return [
+        I32.unpack_from(data, offset)[0]
+        for offset in range(0, len(data), I32.size)
+    ]
+
+
+class BuildReverseCsrArtifactTest(unittest.TestCase):
+    def test_builder_writes_parent_sorted_csr(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            phase1 = tmp_path / "phase1.lmdb"
+            out_dir = tmp_path / "category_child_csr"
+
+            phase1.mkdir()
+            env = lmdb.open(str(phase1), map_size=1 << 20, max_dbs=8, subdir=True)
+            cp_db = env.open_db(b"category_parent", dupsort=True)
+            with env.begin(write=True) as txn:
+                txn.put(i32(10), i32(20), db=cp_db)
+                txn.put(i32(12), i32(20), db=cp_db)
+                txn.put(i32(11), i32(30), db=cp_db)
+                txn.put(i32(13), i32(20), db=cp_db)
+            env.close()
+
+            result = subprocess.run(
+                [sys.executable, str(BUILDER), str(phase1), str(out_dir)],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            meta = json.loads((out_dir / "category_child.csr.meta").read_text(encoding="utf-8"))
+            self.assertEqual(meta["format"], "unifyweaver.reverse_csr.v1")
+            self.assertEqual(meta["relation"], "category_child/2")
+            self.assertEqual(meta["source_relation"], "category_parent/2")
+            self.assertEqual(meta["storage_kind"], "csr_pread_artifact")
+            self.assertEqual(meta["id_encoding"], "int32_le")
+            self.assertEqual(meta["ordering"], "parent_sort")
+            self.assertEqual(meta["io_policy"], "buffered_pread")
+            self.assertEqual(meta["parent_count"], 2)
+            self.assertEqual(meta["edge_count"], 4)
+            self.assertEqual(meta["index_record_bytes"], IDX_RECORD.size)
+            self.assertEqual(meta["value_record_bytes"], I32.size)
+
+            self.assertEqual(
+                read_idx(out_dir / "category_child.csr.idx"),
+                [
+                    (20, 0, 3),
+                    (30, 3, 1),
+                ],
+            )
+            self.assertEqual(
+                read_i32_values(out_dir / "category_child.csr.val"),
+                [10, 12, 13, 11],
+            )
+
+    def test_builder_refuses_existing_output_without_refresh(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            phase1 = tmp_path / "phase1.lmdb"
+            out_dir = tmp_path / "category_child_csr"
+
+            phase1.mkdir()
+            out_dir.mkdir()
+            env = lmdb.open(str(phase1), map_size=1 << 20, max_dbs=8, subdir=True)
+            env.open_db(b"category_parent", dupsort=True)
+            env.close()
+
+            result = subprocess.run(
+                [sys.executable, str(BUILDER), str(phase1), str(out_dir)],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 3)
+            self.assertIn("pass --refresh", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  - Add a `parent_sort` CSR builder for Phase 1 LMDB `category_parent/2`.
  - Emit `category_child.csr.idx`, `category_child.csr.val`, and `category_child.csr.meta`.
  - Use `id_encoding(int32_le)`, `storage_kind(csr_pread_artifact)`, and `io_policy(buffered_pread)`.
  - Add tests for CSR layout, metadata, and output-directory overwrite protection.
  - Link the prototype builder from the reverse-index design doc.

  ## Validation

  - `python3 tests/test_build_reverse_csr_artifact.py`
  - `python3 tests/test_convert_lmdb_to_phase1_layout.py`
  - `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
  - `python3 -m py_compile examples/benchmark/build_reverse_csr_artifact.py tests/test_build_reverse_csr_artifact.py
  examples/benchmark/convert_lmdb_to_phase1_layout.py tests/test_convert_lmdb_to_phase1_layout.py`
  - `git diff --check`