### PR TITLE
feat(wam-fsharp): number_codes/2 builtin + strip atom-vs-number SOH marker

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -1250,6 +1250,65 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                 | None -> None
         | _ -> None
 
+    // number_codes/2 — number <-> list of decimal code points.
+    // Bidirectional like atom_codes/2.  Without this, the parser
+    // library''s `codes_to_number(Cs, N) :- number_codes(N, Cs).`
+    // failed silently, so tokenize/2 on \"42\" never produced a
+    // tk_num token and every numeric / compound / list input
+    // bottomed out as None.  Accept both VList and Str(\"[|]\",_)
+    // shapes for the code list (the parser builds the latter
+    // via take_digits accumulators).
+    | BuiltinCall (\"number_codes/2\", _) ->
+        match getReg 1 s, getReg 2 s with
+        | Some (Integer n), _ ->
+            let codes =
+                (string n) |> Seq.map (fun c -> Integer (int c)) |> List.ofSeq
+            match bindOutput 2 (VList codes) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | Some (Float f), _ ->
+            let codes =
+                (sprintf \"%g\" f) |> Seq.map (fun c -> Integer (int c)) |> List.ofSeq
+            match bindOutput 2 (VList codes) s with
+            | None    -> None
+            | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+        | Some (Unbound _), Some listVal ->
+            match valueToProperList s.WsBindings listVal with
+            | None       -> None
+            | Some items ->
+                let folder acc v =
+                    match acc, derefVar s.WsBindings v with
+                    | Some (sb: System.Text.StringBuilder), Integer c when c >= 0 && c <= 65535 ->
+                        Some (sb.Append(char c))
+                    | _ -> None
+                match List.fold folder (Some (System.Text.StringBuilder())) items with
+                | Some sb ->
+                    let str = sb.ToString()
+                    // Prefer Integer (matches Prolog''s number_codes
+                    // forward semantics for integral input); fall back
+                    // to Float when there''s a decimal point or
+                    // scientific notation.  Bail out on garbage so
+                    // number_codes(N, \"abc\") fails rather than
+                    // binding N to NaN.
+                    let parsed =
+                        match System.Int64.TryParse(str) with
+                        | true, n -> Some (Integer (int n))
+                        | false, _ ->
+                            match System.Double.TryParse(
+                                    str,
+                                    System.Globalization.NumberStyles.Float,
+                                    System.Globalization.CultureInfo.InvariantCulture) with
+                            | true, f -> Some (Float f)
+                            | false, _ -> None
+                    match parsed with
+                    | Some numVal ->
+                        match bindOutput 1 numVal s with
+                        | None    -> None
+                        | Some s1 -> Some { s1 with WsPC = s1.WsPC + 1 }
+                    | None -> None
+                | None -> None
+        | _ -> None
+
     // atom_chars/2 — atom <-> list of single-char atoms. Bidirectional.
     | BuiltinCall ("atom_chars/2", _) ->
         match getReg 1 s, getReg 2 s with
@@ -2921,8 +2980,19 @@ fs_wam_value(Val0, Fs) :-
     %% collapse to one.  fs_split_wam_line preserves the outer
     %% quotes so we can distinguish `'+'` (atom) from `+`
     %% (unquoted symbol) downstream; here we drop them.
-    fs_strip_quoted_atom(Val1, Val),
-    (   number_string(N, Val), integer(N)
+    %%
+    %% ForceAtom = true when the quoted form carried the
+    %% wam_target:quote_wam_constant SOH marker (`'5'`,
+    %% `'42'`), which means the source had a quoted-atom
+    %% whose textual form re-parses as a number.  Without this
+    %% flag we''d collapse `'42'` to "42" and the number_string
+    %% check below would emit `Integer 42` -- exactly the
+    %% atom-vs-number confusion the marker is there to prevent.
+    fs_strip_quoted_atom(Val1, Val, ForceAtom),
+    (   ForceAtom == true
+    ->  fs_escape_string_for_fsharp(Val, Escaped),
+        format(string(Fs), 'Atom "~w"', [Escaped])
+    ;   number_string(N, Val), integer(N)
     ->  format(string(Fs), 'Integer ~w', [N])
     ;   number_string(F, Val), float(F)
     ->  format(string(Fs), 'Float ~w', [F])
@@ -2932,13 +3002,30 @@ fs_wam_value(Val0, Fs) :-
         format(string(Fs), 'Atom "~w"', [Escaped])
     ).
 
-fs_strip_quoted_atom(S0, S) :-
+%% fs_strip_quoted_atom(+S0, -S, -ForceAtom)
+%
+%  Strip surrounding single quotes, returning the inner atom name.
+%  ForceAtom = true when the inner content begins with the SOH (\1)
+%  marker -- wam_target:quote_wam_constant/2 prefixes atoms whose
+%  textual form re-parses as a number (, , )
+%  with this marker so the WAM TEXT layer round-trips atom-vs-number
+%  unambiguously.  The marker is stripped from the returned name.
+%  Without this flag the F# emitter would collapse  to "42",
+%  match number_string, and emit  -- exactly the
+%  atom-vs-number confusion the marker exists to prevent.
+fs_strip_quoted_atom(S0, S, ForceAtom) :-
     string_chars(S0, Chars0),
     (   Chars0 = [''''|Rest], append(Inner, [''''], Rest)
     ->  fs_unescape_quoted(Inner, InnerU),
-        string_chars(S, InnerU)
-    ;   S = S0
+        fs_strip_number_atom_marker(InnerU, InnerStripped, ForceAtom),
+        string_chars(S, InnerStripped)
+    ;   ForceAtom = false,
+        S = S0
     ).
+
+fs_strip_number_atom_marker([C|Rest], Rest, true) :-
+    char_code(C, 1), !.
+fs_strip_number_atom_marker(Chars, Chars, false).
 
 fs_unescape_quoted([], []).
 fs_unescape_quoted([''''|[''''|Rest]], [''''|Out]) :-


### PR DESCRIPTION
## Summary

Two F#-target fixes that unblock `read_term_from_atom/2` for atoms and numbers. The previous PR (#2382) had ALL FOUR layered probes returning `Some` but with bogus output values — this digs in and finds the parser-correctness gaps that were causing the bogus output.

| Input via `read_term_from_atom('X', _T)` | Before | After |
|---|---|---|
| `'foo'` | `Atom "foo"` ✓ | `Atom "foo"` ✓ |
| `'42'` (wrapper) | None | **Some, `_T = Integer 42`** |
| numeric tokens via `tokenize` | code list malformed (`Integer 1` prefixed) | proper code list ✓ |
| `foo(bar)`, `[1,2,3]`, `1+2` | None | None (downstream, see below) |

## Changes

### 1. `number_codes/2` builtin handler

`is_builtin_pred(number_codes, 2)` was in the shared compiler's recognized-builtin list (`wam_target.pl:1746`), so the WAM compiler emitted `BuiltinCall ("number_codes/2", 2)` for the parser library's `codes_to_number(Cs, N) :- number_codes(N, Cs).` — but the F# runtime had no handler. Every `BuiltinCall ("number_codes/2", _)` returned None and `take_number_after_sign/4` silently dropped numeric tokens.

Fix: a bidirectional handler mirroring `atom_codes/2`'s shape, using `valueToProperList` so the code list can arrive as either `VList` or `Str ("[|]", _)`. Forward direction renders integer/float via `string n` / `sprintf "%g"`; reverse direction parses with `Int64.TryParse` first, then `Double.TryParse`, bailing out on garbage so `number_codes(N, "abc")` properly fails.

### 2. Strip `quote_wam_constant` SOH marker

`wam_target:quote_wam_constant/2` prefixes atoms whose textual form re-parses as a number (`'42'`, `'5'`, `'-3.14'`) with a literal `` (SOH) byte INSIDE the quotes — so the WAM TEXT for `'42'` is actually `'<SOH>42'` (5 chars). The F# emitter wasn't stripping it: `Atom "42"` was actually being emitted as `Atom "<SOH>42"` (a 3-char F# string), and `atom_codes` on the wrapper's input produced a 3-element code list `[Integer 1; Integer 52; Integer 50]` — that extra `Integer 1` broke every numeric-via-atom parse downstream.

Fix: `fs_strip_quoted_atom/3` (new arity) returns a `ForceAtom` flag that's true when the inner content begins with the SOH marker. `fs_wam_value/2` consults the flag: when set, emit `Atom "..."` unconditionally and skip the `number_string` check that would otherwise collapse `'42'` back to `Integer 42`.

## Encoding note — known wart

The SOH marker **is** valid UTF-8 (single-byte ASCII control char), but using an invisible control character as an in-band atom-vs-number discriminator is awkward: source files contain literal control chars, `grep`/`cat`/`Edit` choke on them, etc. The WAM TEXT format already carries the same information via quoting (`'42'` vs `42`).

**Only 2 files in the codebase reference the SOH byte today**: `wam_target.pl` (which injects it) and `wam_fsharp_target.pl` (the stripper added here). Every other target is blind to it and likely has a *latent* atom-that-looks-like-number bug for the same reason F# did — they're just not tested for it.

A follow-up PR will drop the SOH entirely by having `wam_text_parser` tag tokens with their quote-state and each target's emitter branch on the tag. Out of scope here.

## Surfaced next gaps (out of scope here)

- **Compounds / lists / operators still parse to None** under `read_term_from_atom`. Tokenization succeeds in isolation when invoked directly with the right shape, but the end-to-end parse fails. Tracing shows `tokenize` correctly produces `[tk_atom(foo); tk_lparen; tk_atom(bar); tk_rparen]` from `Str ("[|]", _)` input but FAILS on the same content in `VList` shape once the input has >3 codes with mixed ident / non-ident chars. Looks like a `take_ident` clause-3 backtracking interaction with the cut that surfaces only at the ident/non-ident boundary.
- **Remove SOH marker entirely** (the follow-up described above).

## Test plan

- [x] Direct `dispatchCall ctx "read_term_from_atom/2"` for atoms and numbers binds the output Var correctly: `foo → Atom "foo"`, `42 → Integer 42`, `bar → Atom "bar"`.
- [x] Wrapper-based call (`p_pte_int :- read_term_from_atom('42', _T)`) returns Some (was None before the SOH strip).
- [x] F# WAM suite (`tests/run_wam_fsharp_tests.pl`): 2/2 passes. Phase-I lowered 16/16, query smoke 10/10, category-ancestor benchmark `solutions=21`, NAF micro-benchmark.
- [x] Capability hook tests (`tests/test_wam_runtime_parser_capability.pl`): 38/38 pass.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_