### PR TITLE
Add synthetic reverse CSR benchmark fixture

### DIFF
--- a/docs/reports/reverse_csr_lookup_synthetic.md
+++ b/docs/reports/reverse_csr_lookup_synthetic.md
@@ -1,0 +1,46 @@
+# Reverse CSR Lookup Synthetic Benchmark
+
+**Snapshot date**: 2026-05-22.
+
+This report records the first repeatable CSR-vs-LMDB measurement using a
+generated Phase 1 LMDB fixture. The goal is not to claim final
+performance; it is to make the measurement path reproducible without
+depending on local simplewiki/enwiki artifacts.
+
+## Command
+
+```sh
+tmpdir=$(mktemp -d /tmp/uw-csr-bench-XXXXXX)
+python3 examples/benchmark/generate_synthetic_phase1_lmdb.py \
+  "$tmpdir/phase1.lmdb" \
+  --parents 10000 \
+  --children-per-parent 8
+python3 examples/benchmark/benchmark_reverse_csr_lookup.py \
+  "$tmpdir/phase1.lmdb" \
+  --csr-dir "$tmpdir/csr" \
+  --sample-parents 1000 \
+  --iterations 5 \
+  --seed 7
+```
+
+## Result
+
+| backend | sample_parents | iterations | total_children | median_ms | min_ms | max_ms | artifact_bytes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| csr | 1000 | 5 | 8000 | 12.104892 | 11.941214 | 12.224214 | 480780 |
+| lmdb | 1000 | 5 | 8000 | 3.613239 | 3.578186 | 3.852191 | 4579328 |
+
+## Interpretation
+
+The prototype CSR artifact is much smaller than the Phase 1 LMDB file
+for this synthetic graph, but the current Python CSR reader is slower
+than LMDB lookup. That is expected for the first reader: every lookup
+opens, seeks, and reads from the values file.
+
+The next optimization target is therefore the reader path, not the CSR
+layout:
+
+- keep the values file open across lookup batches;
+- optionally cache recently used child slices or blocks;
+- then rerun the same benchmark before considering WAM runtime
+  integration.

--- a/examples/benchmark/generate_synthetic_phase1_lmdb.py
+++ b/examples/benchmark/generate_synthetic_phase1_lmdb.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""
+generate_synthetic_phase1_lmdb.py — create a synthetic Phase 1 LMDB
+fixture with category_parent and category_child sub-dbs.
+
+The fixture is intentionally simple and deterministic. It exists to make
+reverse CSR lookup measurements reproducible without depending on local
+simplewiki/enwiki artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import struct
+import sys
+import time
+from pathlib import Path
+
+try:
+    import lmdb
+except ImportError:
+    sys.stderr.write("generate_synthetic_phase1_lmdb: 'lmdb' Python package required\n")
+    sys.exit(1)
+
+
+I32 = struct.Struct("<i")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate a synthetic Phase 1 LMDB category graph fixture.")
+    parser.add_argument("out_lmdb_dir", type=Path)
+    parser.add_argument("--parents", type=int, default=1000)
+    parser.add_argument("--children-per-parent", type=int, default=8)
+    parser.add_argument("--map-size", type=int, default=1 << 30)
+    parser.add_argument("--refresh", action="store_true", help="replace an existing output directory")
+    return parser.parse_args(argv)
+
+
+def i32(value: int) -> bytes:
+    return I32.pack(value)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    out_dir: Path = args.out_lmdb_dir
+    if args.parents <= 0:
+        sys.stderr.write("--parents must be positive\n")
+        return 2
+    if args.children_per_parent <= 0:
+        sys.stderr.write("--children-per-parent must be positive\n")
+        return 2
+    if out_dir.exists():
+        if not args.refresh:
+            sys.stderr.write(f"output directory exists; pass --refresh to rebuild: {out_dir}\n")
+            return 3
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    started_at = time.time()
+    edge_count = args.parents * args.children_per_parent
+    first_parent_id = 1
+    first_child_id = args.parents + 1
+    max_id = first_child_id + edge_count - 1
+
+    env = lmdb.open(str(out_dir), map_size=args.map_size, max_dbs=8, subdir=True)
+    try:
+        s2i_db = env.open_db(b"s2i")
+        i2s_db = env.open_db(b"i2s")
+        meta_db = env.open_db(b"meta")
+        cp_db = env.open_db(b"category_parent", dupsort=True)
+        cc_db = env.open_db(b"category_child", dupsort=True)
+        ac_db = env.open_db(b"article_category", dupsort=True)
+
+        with env.begin(write=True) as txn:
+            child_id = first_child_id
+            for parent_offset in range(args.parents):
+                parent_id = first_parent_id + parent_offset
+                for _ in range(args.children_per_parent):
+                    txn.put(i32(child_id), i32(parent_id), db=cp_db)
+                    txn.put(i32(parent_id), i32(child_id), db=cc_db)
+                    child_id += 1
+
+            txn.put(b"schema_version", b"1", db=meta_db)
+            txn.put(b"next_id", i32(max_id + 1), db=meta_db)
+            txn.put(b"compile_time_atoms_count", i32(0), db=meta_db)
+            txn.put(b"id_encoding", b"int32_le", db=meta_db)
+            txn.put(b"category_parent_edge_count", str(edge_count).encode("ascii"), db=meta_db)
+            txn.put(b"category_child_edge_count", str(edge_count).encode("ascii"), db=meta_db)
+            txn.put(b"reverse_index_relation", b"category_child/2", db=meta_db)
+            txn.put(b"reverse_index_storage_kind", b"phase1_lmdb_subdb", db=meta_db)
+
+            # Touch stub dbs so the Phase 1 shape is explicit.
+            _ = (s2i_db, i2s_db, ac_db)
+    finally:
+        env.sync()
+        env.close()
+
+    manifest = {
+        "format": "unifyweaver.synthetic_phase1_lmdb.v1",
+        "id_encoding": "int32_le",
+        "parents": args.parents,
+        "children_per_parent": args.children_per_parent,
+        "edge_count": edge_count,
+        "max_id": max_id,
+        "relations": {
+            "category_parent/2": {
+                "database": "category_parent",
+                "dupsort": True,
+                "edge_count": edge_count,
+            },
+            "category_child/2": {
+                "database": "category_child",
+                "dupsort": True,
+                "edge_count": edge_count,
+                "derived_from": "category_parent/2",
+            },
+        },
+        "build": {
+            "tool": "generate_synthetic_phase1_lmdb.py",
+            "elapsed_seconds": round(time.time() - started_at, 6),
+        },
+    }
+    (out_dir / "phase1_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    sys.stderr.write(
+        f"generate_synthetic_phase1_lmdb: parents={args.parents} "
+        f"children_per_parent={args.children_per_parent} edges={edge_count} -> {out_dir}\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_generate_synthetic_phase1_lmdb.py
+++ b/tests/test_generate_synthetic_phase1_lmdb.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import lmdb
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GENERATOR = ROOT / "examples" / "benchmark" / "generate_synthetic_phase1_lmdb.py"
+BENCHMARK = ROOT / "examples" / "benchmark" / "benchmark_reverse_csr_lookup.py"
+I32 = struct.Struct("<i")
+
+
+class GenerateSyntheticPhase1LmdbTest(unittest.TestCase):
+    def test_generator_writes_phase1_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp) / "phase1.lmdb"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(GENERATOR),
+                    str(out_dir),
+                    "--parents",
+                    "3",
+                    "--children-per-parent",
+                    "2",
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            manifest = json.loads((out_dir / "phase1_manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["format"], "unifyweaver.synthetic_phase1_lmdb.v1")
+            self.assertEqual(manifest["id_encoding"], "int32_le")
+            self.assertEqual(manifest["parents"], 3)
+            self.assertEqual(manifest["children_per_parent"], 2)
+            self.assertEqual(manifest["edge_count"], 6)
+
+            env = lmdb.open(str(out_dir), readonly=True, max_dbs=8, lock=False, subdir=True)
+            try:
+                with env.begin() as txn:
+                    cc_db = env.open_db(b"category_child", txn=txn, dupsort=True, create=False)
+                    cursor = txn.cursor(db=cc_db)
+                    rows = [
+                        (I32.unpack(k)[0], I32.unpack(v)[0])
+                        for k, v in cursor
+                    ]
+                    self.assertEqual(rows, [(1, 4), (1, 5), (2, 6), (2, 7), (3, 8), (3, 9)])
+            finally:
+                env.close()
+
+    def test_generated_fixture_runs_reverse_csr_benchmark(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            phase1 = tmp_path / "phase1.lmdb"
+            csr_dir = tmp_path / "csr"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(GENERATOR),
+                    str(phase1),
+                    "--parents",
+                    "8",
+                    "--children-per-parent",
+                    "4",
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(BENCHMARK),
+                    str(phase1),
+                    "--csr-dir",
+                    str(csr_dir),
+                    "--sample-parents",
+                    "5",
+                    "--iterations",
+                    "2",
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("backend\tsample_parents\titerations", result.stdout)
+            self.assertIn("csr\t5\t2\t20\t", result.stdout)
+            self.assertIn("lmdb\t5\t2\t20\t", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  - Add a deterministic synthetic Phase 1 LMDB fixture generator.
  - Generate category_parent and category_child sub-dbs with configurable parent/child fanout.
  - Add tests verifying the generated Phase 1 layout and CSR-vs-LMDB benchmark compatibility.
  - Record the first repeatable synthetic CSR lookup benchmark result.

  ## Key Result

  For a synthetic fixture with 10000 parents, 8 children per parent, and 80000 edges:

| backend | median_ms | artifact_bytes |
| ------- | --------- | -------------- |
| CSR     | 12.104892 | 480780         |
| LMDB    | 3.613239  | 4579328        |

  CSR is much smaller, but the current Python reader is slower. The next optimization target is keeping the CSR values
  file open across lookup batches.

  ## Validation

  - python3 tests/test_generate_synthetic_phase1_lmdb.py
  - python3 tests/test_benchmark_reverse_csr_lookup.py
  - python3 tests/test_read_reverse_csr_artifact.py
  - python3 tests/test_build_reverse_csr_artifact.py
  - python3 tests/test_convert_lmdb_to_phase1_layout.py
  - swipl -q -g run_tests -t halt tests/core/test_cost_model.pl
  - python3 -m py_compile examples/benchmark/generate_synthetic_phase1_lmdb.py tests/
    test_generate_synthetic_phase1_lmdb.py examples/benchmark/benchmark_reverse_csr_lookup.py tests/
    test_benchmark_reverse_csr_lookup.py examples/benchmark/read_reverse_csr_artifact.py tests/
    test_read_reverse_csr_artifact.py examples/benchmark/build_reverse_csr_artifact.py tests/
    test_build_reverse_csr_artifact.py examples/benchmark/convert_lmdb_to_phase1_layout.py tests/
    test_convert_lmdb_to_phase1_layout.py
  - git diff --check