### PR TITLE
chore(wam-clojure): drop dead clj_strip_quoted_numeric_marker

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_target.pl
+++ b/src/unifyweaver/targets/wam_clojure_target.pl
@@ -507,8 +507,7 @@ switch_case_atom_values(CasesText, AtomSeeds) :-
 
 wam_atom_token_text("''", "") :- !.
 wam_atom_token_text(Token, AtomText) :-
-    clj_unquote_wam_atom_token(Token, Unquoted),
-    clj_strip_quoted_numeric_marker(Unquoted, AtomText).
+    clj_unquote_wam_atom_token(Token, AtomText).
 
 wam_atom_token_literal(Token, Literal) :-
     wam_atom_token_text(Token, AtomText),
@@ -801,9 +800,3 @@ clj_unescape_wam_codes([92, C|Rest], [C|More]) :- !,
     clj_unescape_wam_codes(Rest, More).
 clj_unescape_wam_codes([C|Rest], [C|More]) :-
     clj_unescape_wam_codes(Rest, More).
-
-clj_strip_quoted_numeric_marker(S0, S) :-
-    string_codes(S0, [1|Rest]),
-    !,
-    string_codes(S, Rest).
-clj_strip_quoted_numeric_marker(S, S).


### PR DESCRIPTION
## Summary

Follow-up cleanup to #2389. The Clojure target had `clj_strip_quoted_numeric_marker/2` that stripped the SOH (`\x01`) byte from atom names — a workaround for the in-band atom-vs-number marker that #2389 removed. With SOH gone, the helper became dead code.

## Why a separate PR

Clojure's runtime collapses atom-vs-number distinction at the type level — `templates/targets/clojure_wam/runtime.clj.mustache:75` normalizes every string constant to an atom via `(string? term) (normalize-literal-atom ctx term)`. So the proper atom-vs-number fix would require touching the Clojure runtime template, not just the Prolog emitter — out of scope for "remove the SOH leftover".

## Change

```diff
 wam_atom_token_text("''", "") :- !.
 wam_atom_token_text(Token, AtomText) :-
-    clj_unquote_wam_atom_token(Token, Unquoted),
-    clj_strip_quoted_numeric_marker(Unquoted, AtomText).
+    clj_unquote_wam_atom_token(Token, AtomText).

-clj_strip_quoted_numeric_marker(S0, S) :-
-    string_codes(S0, [1|Rest]),
-    !,
-    string_codes(S, Rest).
-clj_strip_quoted_numeric_marker(S, S).
```

No semantic change. The `clj_strip_quoted_numeric_marker` predicate is a no-op now that no input contains SOH bytes — removing it just stops the call from happening.

## Test plan

- [x] `git diff` reviewed — only the dead helper + its one call are removed.
- [x] `grep -rPl $'\x01' .` returns nothing (no SOH anywhere in repo).
- [x] Clojure generator suite errors on baseline are pre-existing (missing `lmdb.h` headers, `format/3` encoding issues) and unrelated — confirmed by running the same tests on `main` before the cleanup. No new failures introduced.

## Out of scope

The deeper atom-vs-number fix for Clojure (so `'5'` the atom round-trips distinctly from `5` the integer through the Clojure runtime) needs runtime-template changes and per-target follow-up across Python, Scala, R, Go, Haskell, Elixir-lowered. Tracking separately.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_