### PR TITLE
Clarify reverse CSR benchmark size reporting

### DIFF
--- a/docs/reports/reverse_csr_lookup_synthetic.md
+++ b/docs/reports/reverse_csr_lookup_synthetic.md
@@ -25,17 +25,31 @@ python3 examples/benchmark/benchmark_reverse_csr_lookup.py \
 
 ## Result
 
-| backend | sample_parents | iterations | total_children | median_ms | min_ms | max_ms | artifact_bytes |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| csr | 1000 | 5 | 8000 | 12.104892 | 11.941214 | 12.224214 | 480780 |
-| lmdb | 1000 | 5 | 8000 | 3.613239 | 3.578186 | 3.852191 | 4579328 |
+| backend | sample_parents | iterations | total_children | median_ms | min_ms | max_ms | csr_artifact_bytes | phase1_lmdb_env_bytes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| csr | 1000 | 5 | 8000 | 12.104892 | 11.941214 | 12.224214 | 480780 | 4579328 |
+| lmdb | 1000 | 5 | 8000 | 3.613239 | 3.578186 | 3.852191 | 480780 | 4579328 |
+
+`phase1_lmdb_env_bytes` is the size of the whole Phase 1 LMDB
+environment file (`data.mdb`), not the size of only the parent-edge or
+child-edge relation. It includes `category_parent`, `category_child`,
+`meta`, stub sub-dbs, LMDB B-tree pages, and LMDB allocation overhead.
+LMDB does not expose an exact per-subdb byte count through this
+benchmark.
 
 ## Interpretation
 
-The prototype CSR artifact is much smaller than the Phase 1 LMDB file
-for this synthetic graph, but the current Python CSR reader is slower
-than LMDB lookup. That is expected for the first reader: every lookup
-opens, seeks, and reads from the values file.
+The prototype CSR artifact is much smaller than the full Phase 1 LMDB
+environment for this synthetic graph, but this is not a parent-only
+LMDB comparison. In a memory-budgeted runtime, the priority resident or
+memory-mapped structure remains the hot parent-edge store. A reverse CSR
+artifact may become memory-resident only when memory budget allows, and
+that in-memory representation should preserve the compact typed-array /
+CSR shape rather than expanding into Python-style object lists.
+
+The current Python CSR reader is slower than LMDB lookup. That is
+expected for the first reader: every lookup opens, seeks, and reads from
+the values file.
 
 The next optimization target is therefore the reader path, not the CSR
 layout:

--- a/examples/benchmark/benchmark_reverse_csr_lookup.py
+++ b/examples/benchmark/benchmark_reverse_csr_lookup.py
@@ -141,7 +141,8 @@ def print_tsv(rows: list[dict[str, str]]) -> None:
         "median_ms",
         "min_ms",
         "max_ms",
-        "artifact_bytes",
+        "csr_artifact_bytes",
+        "phase1_lmdb_env_bytes",
     ]
     print("\t".join(headers))
     for row in rows:
@@ -198,7 +199,8 @@ def main(argv: list[str] | None = None) -> int:
                     "median_ms": f"{statistics.median(times_ms):.6f}",
                     "min_ms": f"{min(times_ms):.6f}",
                     "max_ms": f"{max(times_ms):.6f}",
-                    "artifact_bytes": str(artifact_bytes(csr_dir) if backend == "csr" else (phase1_lmdb_dir / "data.mdb").stat().st_size),
+                    "csr_artifact_bytes": str(artifact_bytes(csr_dir)),
+                    "phase1_lmdb_env_bytes": str((phase1_lmdb_dir / "data.mdb").stat().st_size),
                 })
             print_tsv(rows)
             return 0

--- a/tests/test_benchmark_reverse_csr_lookup.py
+++ b/tests/test_benchmark_reverse_csr_lookup.py
@@ -51,7 +51,8 @@ class BenchmarkReverseCsrLookupTest(unittest.TestCase):
                 self.assertEqual(row["iterations"], "2")
                 self.assertEqual(row["total_children"], "4")
                 self.assertGreater(float(row["median_ms"]), 0.0)
-                self.assertGreater(int(row["artifact_bytes"]), 0)
+                self.assertGreater(int(row["csr_artifact_bytes"]), 0)
+                self.assertGreater(int(row["phase1_lmdb_env_bytes"]), 0)
 
     def test_benchmark_detects_missing_phase1_lmdb(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_generate_synthetic_phase1_lmdb.py
+++ b/tests/test_generate_synthetic_phase1_lmdb.py
@@ -101,6 +101,7 @@ class GenerateSyntheticPhase1LmdbTest(unittest.TestCase):
             )
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("backend\tsample_parents\titerations", result.stdout)
+            self.assertIn("csr_artifact_bytes\tphase1_lmdb_env_bytes", result.stdout)
             self.assertIn("csr\t5\t2\t20\t", result.stdout)
             self.assertIn("lmdb\t5\t2\t20\t", result.stdout)
 


### PR DESCRIPTION
  ## Summary

  - Rename benchmark size output from `artifact_bytes` to explicit size columns.
  - Report `csr_artifact_bytes` and `phase1_lmdb_env_bytes` for both benchmark rows.
  - Clarify that the LMDB size is the whole Phase 1 `data.mdb` environment, not a parent-edge-only or relation-only byte
  count.
  - Update the synthetic benchmark report to reflect the corrected interpretation.
  - Note that parent-edge LMDB remains the priority hot memory structure, while reverse CSR can be considered for memory
  residency only when memory budget allows.

  ## Validation

  - `python3 tests/test_benchmark_reverse_csr_lookup.py`
  - `python3 tests/test_generate_synthetic_phase1_lmdb.py`
  - `python3 tests/test_read_reverse_csr_artifact.py`
  - `python3 tests/test_build_reverse_csr_artifact.py`
  - `python3 tests/test_convert_lmdb_to_phase1_layout.py`
  - `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
  - `python3 -m py_compile examples/benchmark/generate_synthetic_phase1_lmdb.py tests/
  test_generate_synthetic_phase1_lmdb.py examples/benchmark/benchmark_reverse_csr_lookup.py tests/
  test_benchmark_reverse_csr_lookup.py examples/benchmark/read_reverse_csr_artifact.py tests/
  test_read_reverse_csr_artifact.py examples/benchmark/build_reverse_csr_artifact.py tests/
  test_build_reverse_csr_artifact.py examples/benchmark/convert_lmdb_to_phase1_layout.py tests/
  test_convert_lmdb_to_phase1_layout.py`
  - `git diff --check`

  Verified locally: working directory is /home/s243a/Projects/UnifyWeaver/context/gemini/UnifyWeaver, branch is docs/
  reverse-csr-size-caveat, and HEAD matches origin/docs/reverse-csr-size-caveat at 5df1188a.