### PR TITLE
fix(wam-go-lowered): atom-vs-number via shared wam_classify_constant_token

### DIFF
--- a/src/unifyweaver/targets/wam_go_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_go_lowered_emitter.pl
@@ -23,6 +23,7 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(wam_text_parser, [wam_classify_constant_token/2]).
 :- use_module(wam_go_target, [
     escape_go_string/2,
     intern_atom_go/2
@@ -553,16 +554,25 @@ go_reg_idx(RegStr, Idx) :-
 %  Convert a WAM constant to a Go value literal. Atom literals are
 %  routed through intern_atom_go/2 so identical atoms share a single
 %  package-level *Atom value rather than allocating per call.
+%
+%  Atom-vs-number disambiguation goes through
+%  wam_text_parser:wam_classify_constant_token/2: a bare token `5`
+%  is the integer 5, a quoted token `'5'` is the atom whose name
+%  is "5". Without the classifier, `intern_atom_go` would intern
+%  the atom with the outer quotes attached (`internAtom("'5'")`).
 go_val_literal(Str, GoVal) :-
-    (   number_string(N, Str), integer(N)
+    wam_classify_constant_token(Str, Class),
+    (   Class = integer(N)
     ->  format(atom(GoVal), '&Integer{Val: ~w}', [N])
-    ;   number_string(F, Str), float(F)
+    ;   Class = float(F)
     ->  format(atom(GoVal), '&Float{Val: ~w}', [F])
-    ;   intern_atom_go(Str, AtomVar)
-    ->  GoVal = AtomVar
-    ;   % Defensive fallback if interning is somehow unavailable.
-        escape_go_string(Str, Escaped),
-        format(atom(GoVal), '&Atom{Name: "~w"}', [Escaped])
+    ;   Class = atom(Name),
+        (   intern_atom_go(Name, AtomVar)
+        ->  GoVal = AtomVar
+        ;   % Defensive fallback if interning is somehow unavailable.
+            escape_go_string(Name, Escaped),
+            format(atom(GoVal), '&Atom{Name: "~w"}', [Escaped])
+        )
     ).
 
 %% pred_to_go_call(+PredStr, -CallExpr)


### PR DESCRIPTION
## Summary

The Go lowered emitter's `go_val_literal/2` in `wam_go_lowered_emitter.pl` was atom-vs-number blind: it tried `number_string/2` on the raw token, and when that failed it called `intern_atom_go/2` with the **unstripped** token. After #2389, the WAM-text producer emits `'5'` (with outer quotes) for the atom whose name is `5`. The Go lowered tokenizer is split-string based and happens to preserve outer quotes in simple cases (no embedded separators) — so `intern_atom_go("'5'", ...)` was interning the atom under the name `'5'` (literal quotes baked in).

The non-lowered Go path (`wam_go_target:parse_string_to_go_val/2`) is **already correct** — it uses `term_to_atom/2` as the fallback which round-trips atom-vs-number properly. Verified with a separate smoke; no change needed there.

This routes the lowered path through the same `wam_text_parser:wam_classify_constant_token/2` that C++, F#, Lua, and Python now use.

## Change

```diff
 go_val_literal(Str, GoVal) :-
-    (   number_string(N, Str), integer(N)
-    ->  format(atom(GoVal), '&Integer{Val: ~w}', [N])
-    ;   number_string(F, Str), float(F)
-    ->  format(atom(GoVal), '&Float{Val: ~w}', [F])
-    ;   intern_atom_go(Str, AtomVar)
-    ->  GoVal = AtomVar
-    ;   escape_go_string(Str, Escaped),
-        format(atom(GoVal), '&Atom{Name: "~w"}', [Escaped])
+    wam_classify_constant_token(Str, Class),
+    (   Class = integer(N)
+    ->  format(atom(GoVal), '&Integer{Val: ~w}', [N])
+    ;   Class = float(F)
+    ->  format(atom(GoVal), '&Float{Val: ~w}', [F])
+    ;   Class = atom(Name),
+        (   intern_atom_go(Name, AtomVar)
+        ->  GoVal = AtomVar
+        ;   escape_go_string(Name, Escaped),
+            format(atom(GoVal), '&Atom{Name: "~w"}', [Escaped])
+        )
     ).
```

## Verified

- **Direct classifier smoke**: `'5'` → `&Atom{Name: "5"}` (no literal quotes), `5` → `&Integer{Val: 5}`, `-3.14` → `&Float{Val: -3.14}`, `foo` → `&Atom{Name: "foo"}`.
- **End-to-end Go**: Generated literals embedded into a small `package main`; `go run` confirms `*main.Atom &{Name:5}` for `'5'` and `*main.Integer &{Val:5}` for `5` via runtime type assertions.
- **Pre-existing suites**: `wam_go_lowered_phase2` (6/6) and `wam_go_lowered_phase3` (8/8) pass with the new helper.

## Out of scope

Other targets in the same SOH-blind category — Scala, R, Haskell, Elixir-lowered — getting their own per-target PRs (Python landed in #2394).

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_