### PR TITLE
fix(wam-haskell): atom-vs-number via shared wam_classify_constant_token

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
@@ -21,6 +21,7 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(wam_text_parser, [wam_classify_constant_token/2]).
 
 %% =====================================================================
 %% Parsing
@@ -435,11 +436,13 @@ fresh_sv(Cur, Next) :-
 
 val_hs(Str, Hs) :-
     atom_string(Str, StrS),
-    (   number_string(N, StrS), integer(N)
+    wam_classify_constant_token(StrS, Class),
+    (   Class = integer(N)
     ->  format(atom(Hs), 'Integer ~w', [N])
-    ;   number_string(F, StrS), float(F)
+    ;   Class = float(F)
     ->  format(atom(Hs), 'Float ~w', [F])
-    ;   wam_haskell_target:intern_atom(Str, AtomId),
+    ;   Class = atom(Name),
+        wam_haskell_target:intern_atom(Name, AtomId),
         format(atom(Hs), 'Atom ~w', [AtomId])
     ).
 

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -63,6 +63,7 @@
              [recommend_access_pattern/5, read_mem_available_bytes/1]).
 :- use_module('../core/algorithm_manifest',
              [load_algorithm_manifest/2]).
+:- use_module('../targets/wam_text_parser', [wam_classify_constant_token/2]).
 :- use_module('../core/cost_function',
              [validate_cost_function/1, cost_function_with_defaults/2]).
 
@@ -4914,21 +4915,29 @@ parse_functor_arity(FN, Arity) :-
 
 %% wam_value_to_haskell(+WamVal, -HaskellExpr)
 %  Converts a WAM constant to a Haskell Value constructor.
+%
+%  Atom-vs-number disambiguation goes through
+%  wam_text_parser:wam_classify_constant_token/2: a bare token `5`
+%  is the integer 5, a quoted token `'5'` is the atom whose name
+%  is "5". Without the classifier, intern_atom would intern the
+%  atom with the outer quotes attached.
 wam_value_to_haskell(Val, Hs) :-
     atom_string(Val, ValStr),
-    (   number_string(N, ValStr), integer(N)
+    wam_classify_constant_token(ValStr, Class),
+    (   Class = integer(N)
     ->  % Wrap negative integers in parens so Haskell parses correctly:
         % Integer (-5) not Integer -5
         (   N < 0
         ->  format(string(Hs), 'Integer (~w)', [N])
         ;   format(string(Hs), 'Integer ~w', [N])
         )
-    ;   number_string(F, ValStr), float(F)
+    ;   Class = float(F)
     ->  (   F < 0
         ->  format(string(Hs), 'Float (~w)', [F])
         ;   format(string(Hs), 'Float ~w', [F])
         )
-    ;   intern_atom(Val, AtomId),
+    ;   Class = atom(Name),
+        intern_atom(Name, AtomId),
         format(string(Hs), 'Atom ~w', [AtomId])
     ).
 


### PR DESCRIPTION
## Summary

`wam_value_to_haskell/2` in `wam_haskell_target.pl` and `val_hs/2` in `wam_haskell_lowered_emitter.pl` were atom-vs-number blind: both tried `number_string/2` on the raw token and fell through to `intern_atom/2` when that failed. After #2389, the WAM-text producer emits `'5'` (quoted) for the atom whose name is `5`. The Haskell tokenizer (`split_string` based, line 300) happens to preserve outer quotes in simple cases, so `intern_atom("'5'", ...)` was interning the atom with literal quotes in its name.

This routes both emit paths through `wam_text_parser:wam_classify_constant_token/2`, matching what C++, F#, Lua, Python, and Go now use.

## Changes

| File | Change |
|---|---|
| `wam_haskell_target.pl` | Import `wam_classify_constant_token/2`. Rewrite `wam_value_to_haskell/2` to dispatch on `integer/float/atom` Class. Negative-number paren-wrapping preserved. |
| `wam_haskell_lowered_emitter.pl` | Import the classifier. Rewrite `val_hs/2` to dispatch on Class. `intern_atom` now sees the unquoted atom name. |

## Verified

- **Direct smoke**: `5` → `Integer 5`; `'5'` → `Atom 5` with atom id 5 mapped to name `"5"` (not `"'5'"`) in the intern table; `foo` → `Atom 6` (name "foo"); `-3.14` → `Float (-3.14)`; `'-3.14'` → `Atom 7` (name "-3.14").
- **End-to-end Haskell**: Generated literals embedded into `Main.hs` with a minimal `data Value = Atom Int | Integer Int | Float Double` plus an atom-name lookup table; `runghc Main.hs` confirms `Atom id` resolves to name "5" for `'5'` and `Integer 5` for bare `5`. Output:
  ```
  atom-side: Atom 5
  int-side:  Integer 5
  foo-side:  Atom 6
  PASS atom-side has name 5
  PASS int-side is Integer 5
  PASS foo-side has name foo
  ```
- **Phase 1 suite**: 6/6 pass.
- **Phase 2/3 suites**: hit a pre-existing infrastructure encoding error (`format/3: I/O error ... Encoding cannot represent character`) seen on baseline before this change. Same pattern as Clojure/Python suites — unrelated to the classifier migration.

## Out of scope

R, Scala, Elixir-lowered — runtimes not installed in this environment; getting their own batched PR with Prolog-level tests only.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_