### PR TITLE
fix(wam-r,scala,elixir-lowered): atom-vs-number via shared wam_classify_constant_token

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -36,6 +36,7 @@
 :- use_module(library(option)).
 :- use_module(library(pairs), [group_pairs_by_key/2]).
 :- use_module('wam_elixir_utils', [reg_id/2, is_label_part/1, camel_case/2, parse_arity/2]).
+:- use_module('../targets/wam_text_parser', [wam_classify_constant_token/2]).
 :- use_module('../core/purity_certificate', [analyze_predicate_purity/2]).
 :- use_module('../core/predicate_preprocessing',
               [declared_preprocess_metadata/4]).
@@ -711,12 +712,21 @@ render_index_entry(Key-Tuples, Entry) :-
 %  default ~1M atom table limit. See the experiment writeup for
 %  measurements.
 elixir_constant_literal(TokenStr, ElixirLiteral) :-
-    (   number_string(_, TokenStr)
-    ->  ElixirLiteral = TokenStr
-    ;   intern_atoms_enabled,
-        valid_elixir_atom_name(TokenStr)
-    ->  format(string(ElixirLiteral), ':~w', [TokenStr])
-    ;   format(string(ElixirLiteral), '"~w"', [TokenStr])
+    %% Atom-vs-number disambiguation via wam_text_parser. A bare
+    %% token `5` is the integer 5 (emit as bare); a quoted token
+    %% `'5'` is the atom whose name is "5" (emit as :5 or "5" per
+    %% the intern_atoms_enabled toggle).
+    wam_classify_constant_token(TokenStr, Class),
+    (   Class = integer(N)
+    ->  format(string(ElixirLiteral), "~w", [N])
+    ;   Class = float(F)
+    ->  format(string(ElixirLiteral), "~w", [F])
+    ;   Class = atom(Name),
+        intern_atoms_enabled,
+        valid_elixir_atom_name(Name)
+    ->  format(string(ElixirLiteral), ':~w', [Name])
+    ;   Class = atom(Name),
+        format(string(ElixirLiteral), '"~w"', [Name])
     ).
 
 %% intern_atoms_enabled is asserted by write_wam_elixir_project/3
@@ -758,7 +768,11 @@ tokenize_chars([C | Rest], Tokens) :-
     ->  tokenize_chars(Rest, Tokens)
     ;   C == '\''
     ->  read_quoted_chars(Rest, TokenChars, Remainder),
-        string_chars(Token, TokenChars),
+        % Preserve the outer single quotes attached to the token so
+        % atom-vs-number is recoverable downstream via
+        % wam_text_parser:wam_classify_constant_token/2 (bare `5`
+        % is the integer 5; quoted `'5'` is the atom whose name is "5").
+        string_chars(Token, ['\''|TokenChars]),
         Tokens = [Token | RestTokens],
         tokenize_chars(Remainder, RestTokens)
     ;   read_unquoted_chars([C | Rest], TokenChars, Remainder),
@@ -771,8 +785,11 @@ wam_separator_char(' ').
 wam_separator_char('\t').
 wam_separator_char(',').
 
+% read_quoted_chars/3: returns the inner unescaped chars WITH the
+% trailing closing quote appended. The caller prepends the opening
+% quote so the produced token has both outer quotes preserved.
 read_quoted_chars([], [], []).             % unterminated quote — yield what we have
-read_quoted_chars(['\'' | Rest], [], Rest).
+read_quoted_chars(['\'' | Rest], ['\''], Rest).
 read_quoted_chars(['\\', Escaped | Rest], [Real | More], Remainder) :-
     !,
     unescape_wam_char(Escaped, Real),

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -55,6 +55,7 @@
 :- use_module(library(option)).
 :- use_module(library(filesex), [make_directory_path/1, directory_file_path/3]).
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../targets/wam_text_parser', [wam_classify_constant_token/2]).
 :- use_module('../core/template_system', [render_template/3]).
 % Lowered emitter: real Phase-2 implementation lives there. We keep the
 % module load lazy via catch/3 so the file remains usable even if the
@@ -219,7 +220,11 @@ tokenize_wam_chars([C|Rest], CurR, Acc, outside, Tokens) :-
         )
     ;   C == '\''
     ->  (   CurR == []
-        ->  tokenize_wam_chars(Rest, [], Acc, inside, Tokens)
+        ->  % Enter quoted region — keep the opening quote attached
+            % to the token so atom-vs-number is recoverable
+            % downstream via wam_text_parser:wam_classify_constant_token/2.
+            % A bare `5` is the integer 5; a quoted `'5'` is the atom.
+            tokenize_wam_chars(Rest, ['\''], Acc, inside, Tokens)
         ;   tokenize_wam_chars(Rest, [C|CurR], Acc, outside, Tokens)
         )
     ;   tokenize_wam_chars(Rest, [C|CurR], Acc, outside, Tokens)
@@ -229,7 +234,9 @@ tokenize_wam_chars([C|Rest], CurR, Acc, inside, Tokens) :-
         Rest = [Escaped|More]
     ->  tokenize_wam_chars(More, [Escaped|CurR], Acc, inside, Tokens)
     ;   C == '\''
-    ->  reverse(CurR, CurC), string_chars(T, CurC),
+    ->  % Closing quote — keep it attached to the token so the
+        % outer quotes survive to the constant classifier.
+        reverse(['\''|CurR], CurC), string_chars(T, CurC),
         tokenize_wam_chars(Rest, [], [T|Acc], outside, Tokens)
     ;   tokenize_wam_chars(Rest, [C|CurR], Acc, inside, Tokens)
     ).
@@ -466,15 +473,22 @@ strip_arity_suffix(Pred, Name) :-
     ).
 
 %% constant_to_r_term(+ConstStr, -RTermLit)
-%  Numbers become Integer(N) / FloatTerm(N); everything else interns as Atom.
+%  Numbers become IntTerm(N) / FloatTerm(N); everything else interns as Atom.
+%
+%  Atom-vs-number disambiguation goes through
+%  wam_text_parser:wam_classify_constant_token/2: a bare token `5`
+%  is the integer 5, a quoted token `'5'` is the atom whose name
+%  is "5". tokenize_wam_chars/5 above preserves outer quotes
+%  attached to the token; this is what makes the discriminator
+%  reach this predicate.
 constant_to_r_term(C, Lit) :-
-    (   number_string(N, C),
-        integer(N)
+    wam_classify_constant_token(C, Class),
+    (   Class = integer(N)
     ->  format(string(Lit), 'IntTerm(~w)', [N])
-    ;   number_string(F, C),
-        float(F)
+    ;   Class = float(F)
     ->  format(string(Lit), 'FloatTerm(~w)', [F])
-    ;   intern_r_atom(C, AtomId),
+    ;   Class = atom(Name),
+        intern_r_atom(Name, AtomId),
         format(string(Lit), 'Atom(~w)', [AtomId])
     ).
 

--- a/src/unifyweaver/targets/wam_scala_target.pl
+++ b/src/unifyweaver/targets/wam_scala_target.pl
@@ -28,6 +28,7 @@
 :- use_module(library(filesex), [make_directory_path/1, directory_file_path/3]).
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
 :- use_module('../core/template_system', [render_template/3]).
+:- use_module('../targets/wam_text_parser', [wam_classify_constant_token/2]).
 
 % ============================================================================
 % ATOM INTERNING TABLE (compile-time)
@@ -139,7 +140,10 @@ tokenize_wam_chars([C|Rest], CurR, Acc, outside, Tokens) :-
         )
     ;   C == '\''
     ->  (   CurR == []
-        ->  tokenize_wam_chars(Rest, [], Acc, inside, Tokens)
+        ->  % Enter quoted region — keep the opening quote attached
+            % to the token so atom-vs-number is recoverable
+            % downstream via wam_classify_constant_token/2.
+            tokenize_wam_chars(Rest, ['\''], Acc, inside, Tokens)
         ;   % Stray quote in the middle of an unquoted token — keep it.
             tokenize_wam_chars(Rest, [C|CurR], Acc, outside, Tokens)
         )
@@ -150,7 +154,9 @@ tokenize_wam_chars([C|Rest], CurR, Acc, inside, Tokens) :-
         Rest = [Escaped|More]
     ->  tokenize_wam_chars(More, [Escaped|CurR], Acc, inside, Tokens)
     ;   C == '\''
-    ->  reverse(CurR, CurC), string_chars(T, CurC),
+    ->  % Closing quote — keep it attached so the outer quotes
+        % survive to the constant classifier.
+        reverse(['\''|CurR], CurC), string_chars(T, CurC),
         tokenize_wam_chars(Rest, [], [T|Acc], outside, Tokens)
     ;   tokenize_wam_chars(Rest, [C|CurR], Acc, inside, Tokens)
     ).
@@ -379,14 +385,20 @@ strip_arity_suffix(Pred, Name) :-
 %  Converts a WAM constant token to its Scala-source-literal form.
 %  Integer tokens become IntTerm(N); float tokens become FloatTerm(N);
 %  everything else is interned as an atom.
+%
+%  Atom-vs-number disambiguation goes through
+%  wam_text_parser:wam_classify_constant_token/2: a bare token `5`
+%  is the integer 5, a quoted token `'5'` is the atom whose name is
+%  "5". tokenize_wam_chars/5 above preserves outer quotes attached
+%  to the token so the discriminator reaches this predicate.
 constant_to_scala_term(C, Lit) :-
-    (   number_string(N, C),
-        integer(N)
+    wam_classify_constant_token(C, Class),
+    (   Class = integer(N)
     ->  format(string(Lit), 'IntTerm(~w)', [N])
-    ;   number_string(F, C),
-        float(F)
+    ;   Class = float(F)
     ->  format(string(Lit), 'FloatTerm(~w)', [F])
-    ;   intern_scala_atom(C, AtomId),
+    ;   Class = atom(Name),
+        intern_scala_atom(Name, AtomId),
         format(string(Lit), 'Atom(~w)', [AtomId])
     ).
 

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -848,7 +848,10 @@ test_tokenize_unquoted :-
 test_tokenize_quoted_atom_with_comma :-
     Test = 'Tokenizer: quoted atom containing comma stays one token',
     wam_elixir_lowered_emitter:tokenize_wam_line("    get_constant 'Has,comma', A1", Tokens),
-    (   Tokens == ["get_constant", "Has,comma", "A1"]
+    %% Quote-preserving convention (post SOH-removal): outer quotes
+    %% stay attached so atom-vs-number is recoverable via
+    %% wam_text_parser:wam_classify_constant_token/2.
+    (   Tokens == ["get_constant", "'Has,comma'", "A1"]
     ->  pass(Test)
     ;   fail_test(Test, Tokens)
     ).
@@ -856,7 +859,9 @@ test_tokenize_quoted_atom_with_comma :-
 test_tokenize_quoted_atom_with_escape :-
     Test = 'Tokenizer: quoted atom with \\\' escape unquotes to literal',
     wam_elixir_lowered_emitter:tokenize_wam_line("    get_constant 'it\\'s', A1", Tokens),
-    (   Tokens == ["get_constant", "it's", "A1"]
+    %% Inner backslash-escape is still resolved (\\' -> '); outer
+    %% quotes are preserved so the token round-trips as a quoted atom.
+    (   Tokens == ["get_constant", "'it's'", "A1"]
     ->  pass(Test)
     ;   fail_test(Test, Tokens)
     ).


### PR DESCRIPTION
## Summary

Final batch in the SOH-removal follow-up series — propagates `wam_text_parser:wam_classify_constant_token/2` to the remaining targets: **R**, **Scala**, and **Elixir-lowered**.

Each of these targets had its own tokenizer that stripped outer quotes, and a constant emitter that did blind `number_string/2` → `intern_*_atom/2`. After #2389 the WAM-text producer emits `'5'` (quoted) for the atom whose name is "5"; with quotes stripped at tokenizer time, the discriminator is lost and both `'5'` and `5` reduce to the bare string `"5"` → emitted as integer. Wrong type for the atom.

Same fix pattern in each: tokenizer keeps the outer quotes attached to the token (matching the convention used by `wam_text_parser`, F#, and Lua), and the constant emitter dispatches on the shared classifier.

## Per-target changes

| File | Change |
|---|---|
| `wam_r_target.pl` | `tokenize_wam_chars/5` keeps the opening quote when entering inside-mode and the closing quote when flushing. `constant_to_r_term/2` uses the classifier — `intern_r_atom` now sees the unquoted name. |
| `wam_scala_target.pl` | Same tokenizer pattern (both outer quotes preserved). `constant_to_scala_term/2` refactored to dispatch on Class. |
| `wam_elixir_lowered_emitter.pl` | `tokenize_chars/2` prepends the opening quote; `read_quoted_chars/3` keeps the closing quote. `elixir_constant_literal/2` dispatches on the classifier — integers/floats emit bare (`5`, `-3.14`); atoms emit as `:name` (`intern_atoms_enabled`) or `"name"` (default) with outer quotes correctly stripped. |
| `tests/test_wam_elixir_target.pl` | `test_tokenize_quoted_atom_with_comma` and `test_tokenize_quoted_atom_with_escape` expectations updated to the new quote-preserving form. Same pattern as the Lua test update in #2389. |

## Verified

- **Per-target classifier smoke** (3 targets, 4-6 cases each):
  - Bare `5` → `IntTerm(5)` / `IntTerm(5)` / `5`
  - Quoted `'5'` → `Atom(<id>)` / `Atom(<id>)` / `"5"`
  - Bare `-3.14` → `FloatTerm(...)` / `FloatTerm(...)` / `-3.14`
  - Quoted `'-3.14'` → `Atom(...)` / `Atom(...)` / `"-3.14"`
  - Bare identifier → `Atom(...)`
- **Intern-name verification**: confirmed `intern_*_atom` now sees the unquoted name `"5"`, not `"'5'"`.
- **Elixir tokenizer tests** (3 cases): plain, quoted-with-comma, quoted-with-escape — all pass with the new expectations.
- **R generator suite**: 89 dots, 0 failures.
- **Scala generator suite**: 14 failures on baseline, 14 failures on this branch — no regression. All are pre-existing 'Encoding cannot represent character' template issues plus two `switch_on_constant` tests that fail on baseline too because they depend on `scala_atom_intern_table` being pre-initialized.

## Runtime testing

R, Scala, and Elixir toolchains aren't installed in this environment, so no E2E runtime test. Pattern is identical to the C++/F#/Lua/Python/Go/Haskell fixes that DID get runtime coverage (PR #2389, #2394, #2395, #2396), so confidence is high.

## Series complete

After this PR lands, every WAM target in the repo correctly honors atom-vs-number distinction:
- C++ / F# / Lua: #2389
- Clojure cleanup: #2392
- Python: #2394
- Go: #2395
- Haskell: #2396
- R / Scala / Elixir-lowered: **this PR**

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_