### PR TITLE
chore(gitignore): ignore test scratch dirs at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,12 @@ tmp/
 # visible mid-run).
 tests/tmp_cpp_*/
 tests/tmp_*/
+# Same dirs when a suite is invoked with the repo root as cwd
+# (some test runners use relative paths that resolve to the
+# current working directory).
+tmp_cpp_*/
+tmp_wam_*/
+tmp_scala_*/
 
 
 # Downloaded libraries (use setup scripts to install)


### PR DESCRIPTION
## Summary

`.gitignore` already covers `tests/tmp_cpp_*/` and `tests/tmp_*/`, but several test suites (WAM Clojure, WAM Scala, others) create their scratch directories relative to the current working directory. When the runner is invoked from the repo root — which is how most session-tooling launches it — those dirs land directly under the root and bypass the existing rules.

Found this by accumulating ~130 untracked `tmp_scala_*/` and `tmp_wam_clojure_*/` dirs across a single session.

## Change

```diff
+# Same dirs when a suite is invoked with the repo root as cwd
+# (some test runners use relative paths that resolve to the
+# current working directory).
+tmp_cpp_*/
+tmp_wam_*/
+tmp_scala_*/
```

No code or test changes.

## Verified

- `git status --short` is clean after deleting the orphan dirs.
- Pattern matches every suite-scratch dir I've seen so far this session.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_