### PR TITLE
fix(wam-python): retry older CPs when FFI continuation is exhausted

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -1582,27 +1582,38 @@ def run_wam(code: list, labels: dict, entry: str, state: WamState) -> bool:
     arg_snapshot: list = list(state.regs)  # snapshot at initial entry
 
     def fail():
+        # An exhausted FFI continuation (result < 0) means the builtin
+        # whose CP this is has no more solutions — but the WAM might still
+        # have OLDER choice points stacked behind it that we need to try
+        # before reporting "no more". The continuation has typically
+        # already shrunk state.b to the next fallback CP; loop and retry
+        # so we don't drop those by returning False outright.
         nonlocal ip
-        if state.b < 0:
-            return False
-        cp = state.stack[state.b]
-        restore_choice_point(state)
-        # next_clause is now a pre-resolved PC int, string label, or callable
-        next_ip = cp.next_clause
-        if callable(next_ip):
-            # Callable: FFI continuation — call with state, returns new IP
-            result = next_ip(state)
-            if result < 0:
+        while True:
+            if state.b < 0:
                 return False
-            ip = result
-        elif isinstance(next_ip, int) and next_ip >= 0:
-            ip = next_ip
-        else:
-            # Fallback: try string label resolution
-            ip = labels.get(cp.next_clause, -1)
-            if ip < 0:
-                return False
-        return True
+            cp = state.stack[state.b]
+            restore_choice_point(state)
+            next_ip = cp.next_clause
+            if callable(next_ip):
+                # Callable: FFI continuation — call with state, returns new IP.
+                result = next_ip(state)
+                if result < 0:
+                    # Exhausted; the continuation updated state.b. Try again.
+                    continue
+                ip = result
+                return True
+            elif isinstance(next_ip, int) and next_ip >= 0:
+                ip = next_ip
+                return True
+            else:
+                # Fallback: try string label resolution.
+                resolved = labels.get(cp.next_clause, -1)
+                if resolved < 0:
+                    # Unresolved label; pop this CP and try the next one.
+                    continue
+                ip = resolved
+                return True
 
     while ip < code_len:
         instr = code[ip]

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -584,6 +584,46 @@ test(runtime_parser_compiled_runs_read_term_from_atom) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+% Regression for the run_wam fail() FFI-continuation-exhaustion bug:
+% `read_term_from_atom` failed to parse any term whose grammar required
+% backtracking through a builtin's choice-point continuation (e.g. the
+% member/2 driving resolve_infix/4 inside parse_op_loop/10). Symptom:
+% `'p(a)'` worked, but `'p(a,b)'`, `'[1,2,3]'`, `'1+2'` all returned
+% None — the wrapper goal `read_term_from_atom(_, T), T = ...` failed.
+%
+% Root cause: when an FFI continuation returned -1 (no more solutions),
+% fail() in WamRuntime.py returned False outright instead of letting
+% older choice-points on the stack run. The continuation had already
+% updated state.b to its fallback; fail() just dropped that fallback.
+% Fix: wrap the body of fail() in a `while True:` loop so an
+% exhausted-continuation result restarts the loop, picking up whatever
+% CP state.b now points at.
+test(runtime_parser_compiled_runs_read_term_multi_arg) :-
+	setup_call_cleanup(
+		(   retractall(user:py_read_term_multi_arg_demo),
+			assertz((user:py_read_term_multi_arg_demo :-
+				read_term_from_atom('p(a,b)', T1), T1 = p(a, b),
+				read_term_from_atom('foo(bar,baz)', T2), T2 = foo(bar, baz),
+				read_term_from_atom('[1,2,3]', T3), T3 = [1, 2, 3],
+				read_term_from_atom('1+2', T4), T4 = 1 + 2,
+				read_term_from_atom('2*3+4', T5), T5 = 2 * 3 + 4)),
+			user:python_parser_tmp_dir('tmp_wam_python_parser_multi_arg', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_read_term_multi_arg_demo/0],
+				[runtime_parser(compiled)], ProjectDir),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_read_term_multi_arg_demo/0', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_read_term_multi_arg_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_read_term_variable_names) :-
 	setup_call_cleanup(
 		(   retractall(user:py_read_term_vars_demo),


### PR DESCRIPTION
## Summary

`read_term_from_atom` in the Python WAM runtime parsed simple inputs (`'foo'`, `'p(a)'`, `'[]'`, `'[1]'`, `'[1|X]'`) but failed on **anything whose grammar required backtracking through a builtin's choice-point continuation** — including all of the user-reported blockers:

| Input | Before | After |
|---|---|---|
| `'foo(bar)'` | None | `foo(bar)` ✓ |
| `'p(a,b)'` | None | `p(a, b)` ✓ |
| `'[1,2,3]'` | None | `[1, 2, 3]` ✓ |
| `'[a,b,c]'` | None | `[a, b, c]` ✓ |
| `'1+2'` | None | `1 + 2` ✓ |
| `'2*3+4'` | None | `2 * 3 + 4` ✓ |
| `'foo(bar,baz)'` | None | `foo(bar, baz)` ✓ |

Single-element lists and 1-arg compounds happened to dodge the bug because they never recursed into `parse_args` / `parse_list_elems` with a `tk_comma` boundary token. Anything with a comma-separated body hit it.

## Root cause

`run_wam`'s inner `fail()` returned `False` outright when an FFI continuation (e.g. `_execute_member_from_index`'s continuation, used to drive `member/2` across the operator table inside `resolve_infix/4` inside `parse_op_loop/10`) reported "no more solutions" with `result < 0`.

But by that point the continuation has typically already shrunk `state.b` to point at the *next older CP* it wants the runtime to fall back to. By returning `False` instead of trying that older CP, `fail()` silently dropped the fallback — so `parse_op_loop`'s clause-4 fallback (which handles "this token is not an operator, just leave it in `Rest`") never ran.

Traced via instrumented `fail()` print debug:

```
[fail: CP next_clause=<_execute_member_from_index continuation>]
                                                       ← here it returned False
                                                       ← should have continued to parse_op_loop_10_4
```

## Fix

`src/unifyweaver/targets/wam_python_runtime/WamRuntime.py` — wrap `fail()`'s body in `while True:`. When a continuation returns `-1`, `continue` instead of `return False`, picking up whatever CP `state.b` now points at. Same treatment for the unresolved-label fallback branch, for symmetry. Net diff is ~25 lines.

## Verified

- **Manual reproduction**: 12/12 inputs (7 previously-broken multi-arg / list / arithmetic + 5 regression for previously-working singletons) now round-trip via `read_term_from_atom`.
- **New regression test**: `runtime_parser_compiled_runs_read_term_multi_arg` in `test_wam_python_target.pl` bundles all the multi-arg cases as a single guard against this exact bug.
- **Full Python WAM suite**: 0 failures, 0 encoding errors under a UTF-8 locale (whole suite runs through cleanly).

## Why this only surfaced now

The SOH-removal series (#2389 → #2397) was the prerequisite for this parser work — before SOH was removed, `read_term_from_atom('42', _)` was failing for a different reason (the atom-vs-number marker collapsed atoms). Once that was clean, `'p(a)'` started working. The next layer of bugs (this PR) only became visible after the easy cases stopped masking the harder ones.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_