### PR TITLE
feat(wam-python): honor read term syntax error mode

### DIFF
--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
@@ -114,6 +114,32 @@ generation-time diagnostic. Silent runtime stubs are not acceptable for new
 targets because parser failure is otherwise hard to distinguish from ordinary
 predicate failure.
 
+## Syntax Error Policy
+
+The parser entry point itself reports invalid source text as ordinary predicate
+failure. Builtin-facing consumers decide whether that failure remains quiet or
+becomes an ISO-style syntax error. This keeps the portable parser pure and lets
+each target integrate with its existing ISO-error dispatch.
+
+For `read_term_from_atom/2,3`, the default behavior is selected by the enclosing
+predicate's ISO mode when the target has adopted the three-form ISO/lax builtin
+contract:
+
+- lax/default-lax call sites fail quietly on invalid syntax;
+- ISO-mode default call sites throw `error(syntax_error(_), _)`;
+- explicit ISO and explicit lax builtin keys keep their meaning regardless of
+  the enclosing predicate's mode.
+
+The `syntax_errors/1` option is an explicit local override and takes precedence
+over the enclosing predicate mode:
+
+- `syntax_errors(error)` throws on invalid syntax even from a lax call site;
+- `syntax_errors(fail)` and `syntax_errors(quiet)` fail quietly even from an
+  ISO call site.
+
+Targets that have not adopted ISO-error dispatch may keep invalid syntax as
+failure, but should document that `syntax_errors(error)` is not yet supported.
+
 ## Stream Read Semantics
 
 `read/2` must read from a target stream until it can parse one complete dotted

--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -1198,14 +1198,34 @@ def _singletons_from_term(term: 'Term', env_term: 'Term', source: WamState,
     return _list_from_terms(pairs)
 
 
+def _syntax_errors_mode(options: Optional['Term'], state: WamState, default: str) -> str:
+    if options is None:
+        return default
+    opt = _read_option_arg(options, 'syntax_errors', state)
+    opt = deref(opt, state) if opt is not None else None
+    if isinstance(opt, Atom) and opt.name in ('error', 'fail', 'quiet'):
+        return opt.name
+    return default
+
+
+def make_syntax_error(state: WamState, kind: str = 'end_of_clause') -> Term:
+    return Compound('syntax_error/1', [make_atom(kind)])
+
+
 def _execute_compiled_parse_atom(state: WamState, atom_text: str, target: 'Term',
-                                 options: Optional['Term'] = None) -> bool:
+                                 options: Optional['Term'] = None,
+                                 syntax_default: str = 'fail') -> bool:
     atom_text = _runtime_atom_text(atom_text)
     code = getattr(state, '_code', None)
     labels = getattr(state, '_labels', None)
+    syntax_mode = _syntax_errors_mode(options, state, syntax_default)
     if not code or not labels:
+        if syntax_mode == 'error':
+            return throw_iso_error(state, make_syntax_error(state))
         return False
     if 'canonical_op_table/1' not in labels:
+        if syntax_mode == 'error':
+            return throw_iso_error(state, make_syntax_error(state))
         return False
 
     want_var_names = None
@@ -1238,6 +1258,8 @@ def _execute_compiled_parse_atom(state: WamState, atom_text: str, target: 'Term'
     if parser_entry == 'parse_term_from_atom/4':
         set_reg(parser_state, 4, var_env)
     if not run_wam(code, labels, parser_entry, parser_state):
+        if syntax_mode == 'error':
+            return throw_iso_error(state, make_syntax_error(state))
         return False
 
     var_map: Dict[int, Var] = {}
@@ -1259,12 +1281,14 @@ def _execute_compiled_parse_atom(state: WamState, atom_text: str, target: 'Term'
     return True
 
 
-def _execute_read_term_from_atom(state: WamState, arity: int = 2) -> bool:
+def _execute_read_term_from_atom(state: WamState, arity: int = 2,
+                                 syntax_default: str = 'fail') -> bool:
     atom_term = deref(get_reg(state, 1), state)
     if not isinstance(atom_term, Atom):
         return False
     options = get_reg(state, 3) if arity == 3 else None
-    return _execute_compiled_parse_atom(state, atom_term.name, get_reg(state, 2), options)
+    return _execute_compiled_parse_atom(state, atom_term.name, get_reg(state, 2),
+                                        options, syntax_default)
 
 
 def _execute_term_to_atom(state: WamState) -> bool:
@@ -1445,10 +1469,15 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return _execute_atom_codes(state)
     if builtin in ('number_codes/2', 'number_codes') and arity == 2:
         return _execute_number_codes(state)
-    if builtin in ('read_term_from_atom/2', 'read_term_from_atom') and arity == 2:
-        return _execute_read_term_from_atom(state, 2)
-    if builtin in ('read_term_from_atom/3',) and arity == 3:
-        return _execute_read_term_from_atom(state, 3)
+    if builtin in ('read_term_from_atom/2', 'read_term_from_atom_lax/2',
+                   'read_term_from_atom', 'read_term_from_atom_lax') and arity == 2:
+        return _execute_read_term_from_atom(state, 2, 'fail')
+    if builtin in ('read_term_from_atom_iso/2', 'read_term_from_atom_iso') and arity == 2:
+        return _execute_read_term_from_atom(state, 2, 'error')
+    if builtin in ('read_term_from_atom/3', 'read_term_from_atom_lax/3') and arity == 3:
+        return _execute_read_term_from_atom(state, 3, 'fail')
+    if builtin in ('read_term_from_atom_iso/3',) and arity == 3:
+        return _execute_read_term_from_atom(state, 3, 'error')
     if builtin in ('term_to_atom/2', 'term_to_atom') and arity == 2:
         return _execute_term_to_atom(state)
     if builtin in ('append/3', 'append') and arity == 3:

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -1381,6 +1381,8 @@ iso_errors_default_to_iso("=</2", "=<_iso/2").
 iso_errors_default_to_iso("=:=/2", "=:=_iso/2").
 iso_errors_default_to_iso("=\\=/2", "=\\=_iso/2").
 iso_errors_default_to_iso("succ/2", "succ_iso/2").
+iso_errors_default_to_iso("read_term_from_atom/2", "read_term_from_atom_iso/2").
+iso_errors_default_to_iso("read_term_from_atom/3", "read_term_from_atom_iso/3").
 
 iso_errors_default_to_lax("is/2", "is_lax/2").
 iso_errors_default_to_lax(">/2", ">_lax/2").
@@ -1390,6 +1392,8 @@ iso_errors_default_to_lax("=</2", "=<_lax/2").
 iso_errors_default_to_lax("=:=/2", "=:=_lax/2").
 iso_errors_default_to_lax("=\\=/2", "=\\=_lax/2").
 iso_errors_default_to_lax("succ/2", "succ_lax/2").
+iso_errors_default_to_lax("read_term_from_atom/2", "read_term_from_atom_lax/2").
+iso_errors_default_to_lax("read_term_from_atom/3", "read_term_from_atom_lax/3").
 
 %% iso_errors_resolve_options(+Options, -Config)
 %  Merges optional file config with inline options into iso_config(Default,

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -456,7 +456,14 @@ test(iso_errors_text_rewrite_uses_is_key_tables) :-
 	wam_python_target:iso_errors_rewrite_text(iso_config(true, []), succ_demo/0, Succ0, SuccIso),
 	assertion(sub_string(SuccIso, _, _, _, "builtin_call succ_iso/2 2")),
 	wam_python_target:iso_errors_rewrite_text(iso_config(false, []), succ_demo/0, Succ0, SuccLax),
-	assertion(sub_string(SuccLax, _, _, _, "builtin_call succ_lax/2 2")).
+	assertion(sub_string(SuccLax, _, _, _, "builtin_call succ_lax/2 2")),
+	Read0 = 'read_demo/0:\n  call read_term_from_atom/2, 2\n  builtin_call read_term_from_atom/3 3',
+	wam_python_target:iso_errors_rewrite_text(iso_config(true, []), read_demo/0, Read0, ReadIso),
+	assertion(sub_string(ReadIso, _, _, _, "call read_term_from_atom_iso/2, 2")),
+	assertion(sub_string(ReadIso, _, _, _, "builtin_call read_term_from_atom_iso/3 3")),
+	wam_python_target:iso_errors_rewrite_text(iso_config(false, []), read_demo/0, Read0, ReadLax),
+	assertion(sub_string(ReadLax, _, _, _, "call read_term_from_atom_lax/2, 2")),
+	assertion(sub_string(ReadLax, _, _, _, "builtin_call read_term_from_atom_lax/3 3")).
 
 test(iso_errors_project_generation_rewrites_wam_text) :-
 	setup_call_cleanup(
@@ -658,6 +665,46 @@ test(runtime_parser_compiled_read_term_singletons) :-
 			once(sub_string(Output, _, _, _, "True"))
 		),
 		(   retractall(user:py_read_term_singletons_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
+test(runtime_parser_compiled_read_term_syntax_errors_policy) :-
+	setup_call_cleanup(
+		(   retractall(user:py_read_term_syntax_lax),
+			retractall(user:py_read_term_syntax_iso),
+			retractall(user:py_read_term_syntax_override),
+			assertz((user:py_read_term_syntax_lax :-
+				\+ read_term_from_atom('p(', _))),
+			assertz((user:py_read_term_syntax_iso :-
+				catch(read_term_from_atom('p(', _),
+					error(syntax_error(_), _),
+					true))),
+			assertz((user:py_read_term_syntax_override :-
+				\+ read_term_from_atom('p(', _, [syntax_errors(fail)]))),
+			user:python_parser_tmp_dir('tmp_wam_python_parser_syntax_errors', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([
+				user:py_read_term_syntax_lax/0,
+				user:py_read_term_syntax_iso/0,
+				user:py_read_term_syntax_override/0
+			], [runtime_parser(compiled),
+				iso_errors(user:py_read_term_syntax_iso/0, true),
+				iso_errors(user:py_read_term_syntax_override/0, true)], ProjectDir),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"for entry in ('py_read_term_syntax_lax/0', 'py_read_term_syntax_iso/0', 'py_read_term_syntax_override/0'):",
+				"    state = wr.WamState()",
+				"    print(entry, wr.run_wam(code, labels, entry, state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "py_read_term_syntax_lax/0 True")),
+			once(sub_string(Output, _, _, _, "py_read_term_syntax_iso/0 True")),
+			once(sub_string(Output, _, _, _, "py_read_term_syntax_override/0 True"))
+		),
+		(   retractall(user:py_read_term_syntax_lax),
+			retractall(user:py_read_term_syntax_iso),
+			retractall(user:py_read_term_syntax_override),
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 


### PR DESCRIPTION
## Summary
- add WAM-Python ISO/lax builtin rewrite keys for `read_term_from_atom/2` and `read_term_from_atom/3`
- make invalid syntax fail quietly in lax mode and throw `error(syntax_error(_), _)` in ISO mode
- honor `syntax_errors(error)`, `syntax_errors(fail)`, and `syntax_errors(quiet)` as local overrides for `read_term_from_atom/3`
- document the runtime parser syntax-error policy in the runtime parser transpilation spec
- add generated WAM-Python coverage for lax default, ISO default, and ISO mode overridden by `syntax_errors(fail)`

## Tests
- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_iso_errors_config)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`

## Notes
- Parser entry points still report invalid source text as failure; builtin-facing consumers decide whether that becomes an ISO error.
- The thrown syntax error currently uses `syntax_error(end_of_clause)` as the concrete inner term.
