### PR TITLE
feat(wam-python): support read/2 over Python streams

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -1291,6 +1291,39 @@ def _execute_read_term_from_atom(state: WamState, arity: int = 2,
                                         options, syntax_default)
 
 
+def _read_stream_char(stream: Any) -> str:
+    if hasattr(stream, 'read'):
+        chunk = stream.read(1)
+        return chunk or ''
+    return ''
+
+
+def _execute_read(state: WamState, syntax_default: str = 'fail') -> bool:
+    stream = deref(get_reg(state, 1), state)
+    target = get_reg(state, 2)
+    if stream is None or isinstance(stream, (Atom, Compound, Var, Int, Float, Ref)):
+        return False
+
+    buffer = ''
+    while True:
+        ch = _read_stream_char(stream)
+        if ch == '':
+            if not buffer.strip():
+                return unify(target, make_atom('end_of_file'), state)
+            return _execute_compiled_parse_atom(state, buffer.strip(), target, None, syntax_default)
+
+        buffer += ch
+        stripped = buffer.strip()
+        if not stripped.endswith('.'):
+            continue
+
+        candidate = stripped[:-1].strip()
+        if not candidate:
+            continue
+        if _execute_compiled_parse_atom(state, candidate, target, None, 'fail'):
+            return True
+
+
 def _execute_term_to_atom(state: WamState) -> bool:
     term = deref(get_reg(state, 1), state)
     atom_term = deref(get_reg(state, 2), state)
@@ -1478,6 +1511,10 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return _execute_read_term_from_atom(state, 3, 'fail')
     if builtin in ('read_term_from_atom_iso/3',) and arity == 3:
         return _execute_read_term_from_atom(state, 3, 'error')
+    if builtin in ('read/2', 'read_lax/2', 'read', 'read_lax') and arity == 2:
+        return _execute_read(state, 'fail')
+    if builtin in ('read_iso/2', 'read_iso') and arity == 2:
+        return _execute_read(state, 'error')
     if builtin in ('term_to_atom/2', 'term_to_atom') and arity == 2:
         return _execute_term_to_atom(state)
     if builtin in ('append/3', 'append') and arity == 3:

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -1398,6 +1398,7 @@ iso_errors_default_to_iso("=\\=/2", "=\\=_iso/2").
 iso_errors_default_to_iso("succ/2", "succ_iso/2").
 iso_errors_default_to_iso("read_term_from_atom/2", "read_term_from_atom_iso/2").
 iso_errors_default_to_iso("read_term_from_atom/3", "read_term_from_atom_iso/3").
+iso_errors_default_to_iso("read/2", "read_iso/2").
 
 iso_errors_default_to_lax("is/2", "is_lax/2").
 iso_errors_default_to_lax(">/2", ">_lax/2").
@@ -1409,6 +1410,7 @@ iso_errors_default_to_lax("=\\=/2", "=\\=_lax/2").
 iso_errors_default_to_lax("succ/2", "succ_lax/2").
 iso_errors_default_to_lax("read_term_from_atom/2", "read_term_from_atom_lax/2").
 iso_errors_default_to_lax("read_term_from_atom/3", "read_term_from_atom_lax/3").
+iso_errors_default_to_lax("read/2", "read_lax/2").
 
 %% iso_errors_resolve_options(+Options, -Config)
 %  Merges optional file config with inline options into iso_config(Default,

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -463,7 +463,12 @@ test(iso_errors_text_rewrite_uses_is_key_tables) :-
 	assertion(sub_string(ReadIso, _, _, _, "builtin_call read_term_from_atom_iso/3 3")),
 	wam_python_target:iso_errors_rewrite_text(iso_config(false, []), read_demo/0, Read0, ReadLax),
 	assertion(sub_string(ReadLax, _, _, _, "call read_term_from_atom_lax/2, 2")),
-	assertion(sub_string(ReadLax, _, _, _, "builtin_call read_term_from_atom_lax/3 3")).
+	assertion(sub_string(ReadLax, _, _, _, "builtin_call read_term_from_atom_lax/3 3")),
+	ReadStream0 = 'read_stream_demo/0:\n  builtin_call read/2 2',
+	wam_python_target:iso_errors_rewrite_text(iso_config(true, []), read_stream_demo/0, ReadStream0, ReadStreamIso),
+	assertion(sub_string(ReadStreamIso, _, _, _, "builtin_call read_iso/2 2")),
+	wam_python_target:iso_errors_rewrite_text(iso_config(false, []), read_stream_demo/0, ReadStream0, ReadStreamLax),
+	assertion(sub_string(ReadStreamLax, _, _, _, "builtin_call read_lax/2 2")).
 
 test(iso_errors_project_generation_rewrites_wam_text) :-
 	setup_call_cleanup(
@@ -745,6 +750,33 @@ test(runtime_parser_compiled_read_term_syntax_errors_policy) :-
 		(   retractall(user:py_read_term_syntax_lax),
 			retractall(user:py_read_term_syntax_iso),
 			retractall(user:py_read_term_syntax_override),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
+test(runtime_parser_compiled_runs_read2_from_python_stream) :-
+	setup_call_cleanup(
+		(   retractall(user:py_read2_demo),
+			assertz((user:py_read2_demo(S) :-
+				read(S, T1), T1 = fact(1),
+				read(S, T2), T2 = fact(2),
+				read(S, T3), T3 = expr(1 + 2 * 3),
+				read(S, T4), T4 = end_of_file)),
+			user:python_parser_tmp_dir('tmp_wam_python_parser_read2', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_read2_demo/1],
+				[runtime_parser(compiled)], ProjectDir),
+			atomic_list_concat([
+				"import io",
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"wr.set_reg(state, 1, io.StringIO('fact(1).\\nfact(2).\\nexpr(1+2*3).\\n'))",
+				"print(wr.run_wam(code, labels, 'py_read2_demo/1', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_read2_demo),
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 


### PR DESCRIPTION
## Summary
- add WAM-Python runtime support for `read/2` when the stream argument is a Python text stream-like object with `.read(1)`
- reuse the compiled runtime parser to parse one dotted term at a time
- bind `end_of_file` when reading from an empty stream at EOF
- add ISO/lax rewrite keys for `read/2` as `read_iso/2` and `read_lax/2`
- add generated WAM-Python coverage using `io.StringIO`

## Scope
- This does not add a full WAM-Python stream subsystem (`open/3`, `close/1`, stream aliases, etc.).
- It provides the runtime `read/2` parser path for callers that already pass a Python stream object.

## Tests
- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_iso_errors_config)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
