### PR TITLE
fix(wam-fsharp): standard-WAM B0 protocol — kill predicate's own retry CP on cut

### DIFF
--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -173,6 +173,15 @@ fsharp_wam_choicepoint_type :-
       CpHeapLen  : int
       CpBindings : Map<int, Value>   // O(1) snapshot — immutable tree
       CpCutBar   : int
+      // B0 stack depth at CP creation time (issue #2400 fu).
+      // Call/CallResolved push onto WsB0Stack; Proceed pops.  But
+      // backtrack into this CP must also discard any pushes that
+      // happened after the CP was created (the failed sub-calls'
+      // pushes never reached their Proceed).  CpB0StackLen captures
+      // the depth at TryMeElse time so backtrack can truncate
+      // WsB0Stack back to it — without that the stack grows
+      // unboundedly and subsequent Proceed pops the wrong entry.
+      CpB0StackLen : int
       CpAggFrame : AggFrame option
       CpBuiltin  : BuiltinState option }").
 
@@ -216,6 +225,19 @@ type WamState =
       // write_stack/read_stack) maintain the same stack discipline.
       WsBuilderStack : BuilderState list
       WsAggAccum  : Value list           // aggregate accumulator
+      // Cut-barrier (B0) stack — pushed by Call/CallResolved before
+      // jumping into a callee and popped by Proceed on return.
+      // Execute/ExecutePc (tail call) updates WsCutBar in place but
+      // does NOT push or pop — the caller's frame is gone, so the
+      // stack depth must remain matched with Call/Proceed pairs
+      // only.  Standard-WAM B0 protocol: each Call saves the
+      // caller's cut barrier here and sets WsCutBar = WsCPsLen
+      // (the count BEFORE the callee's leading TryMeElse pushes
+      // CP_self).  Without this, a `:- ..., !.` in the callee
+      // never drops the predicate's own retry CP because the
+      // barrier was set AFTER TryMeElse already incremented
+      // WsCPsLen — see issue #2400 follow-up.
+      WsB0Stack   : int list
     }
 
 and BuilderState =

--- a/src/unifyweaver/targets/fsharp_runtime/WamRuntime.fs
+++ b/src/unifyweaver/targets/fsharp_runtime/WamRuntime.fs
@@ -74,6 +74,7 @@ type ChoicePoint =
       CpHeapLen  : int
       CpBindings : Map<int, Value>   // O(1) snapshot — immutable tree
       CpCutBar   : int
+      CpB0StackLen : int              // issue #2400 fu — see binding source
       CpAggFrame : AggFrame option
       CpBuiltin  : BuiltinState option }
 
@@ -100,7 +101,9 @@ type WamState =
       WsCutBar    : int
       WsVarCounter: int                  // fresh variable id counter
       WsBuilder   : BuilderState option  // PutStructure / PutList accumulator
-      WsAggAccum  : Value list }
+      WsAggAccum  : Value list
+      WsB0Stack   : int list             // Call/Proceed cut-barrier stack (issue #2400 fu)
+    }
 
 and BuilderState =
     | BuildStruct of fn: string * reg: int * arity: int * args: Value list
@@ -513,6 +516,7 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                    CpHeapLen  = s.WsHeapLen
                    CpBindings = s.WsBindings
                    CpCutBar   = s.WsCutBar
+                   CpB0StackLen = List.length s.WsB0Stack
                    CpAggFrame = None
                    CpBuiltin  = None }
         Some { s1 with WsCPs = cp :: s.WsCPs; WsCPsLen = s.WsCPsLen + 1 }
@@ -526,6 +530,7 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                    CpHeapLen  = s.WsHeapLen
                    CpBindings = s.WsBindings
                    CpCutBar   = s.WsCutBar
+                   CpB0StackLen = List.length s.WsB0Stack
                    CpAggFrame = None
                    CpBuiltin  = None }
         Some { s1 with WsCPs = cp :: s.WsCPs; WsCPsLen = s.WsCPsLen + 1 }
@@ -602,6 +607,7 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                    CpHeapLen  = s.WsHeapLen
                    CpBindings = s.WsBindings
                    CpCutBar   = s.WsCutBar
+                   CpB0StackLen = List.length s.WsB0Stack
                    CpAggFrame = Some af
                    CpBuiltin  = None }
         Some { s1 with WsCPs = cp :: s.WsCPs; WsCPsLen = s.WsCPsLen + 1 }
@@ -719,6 +725,7 @@ and callIndexedFact2 (ctx: WamContext) (pred: string) (s: WamState) : WamState o
                                CpHeapLen  = s.WsHeapLen
                                CpBindings = s.WsBindings
                                CpCutBar   = s.WsCutBar
+                               CpB0StackLen = List.length s.WsB0Stack
                                CpAggFrame = None
                                CpBuiltin  = Some (FactRetry (vid, rest, retPC)) }
                     Some { s with

--- a/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
@@ -232,6 +232,7 @@ emit_func_fs(FN, PCInstrs, LabelMap, ForeignPreds) :-
         format("                         CpHeapLen  = s_init.WsHeapLen~n"),
         format("                         CpBindings = s_init.WsBindings~n"),
         format("                         CpCutBar   = s_init.WsCutBar~n"),
+        format("                         CpB0StackLen = List.length s_init.WsB0Stack~n"),
         format("                         CpAggFrame = None~n"),
         format("                         CpBuiltin  = None } :: s_init.WsCPs~n"),
         format("            WsCPsLen = s_init.WsCPsLen + 1 }~n"),

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -394,6 +394,7 @@ and backtrack (s: WamState) : WamState option =
                  WsHeapLen  = cp.CpHeapLen
                  WsBindings = restoredBindings
                  WsCutBar   = cp.CpCutBar
+                 WsB0Stack  = (let n = List.length s.WsB0Stack - cp.CpB0StackLen in if n > 0 then List.skip n s.WsB0Stack else s.WsB0Stack)
                  // WsCPs intentionally unchanged: keep CP on stack so
                  // RetryMeElse can modify it (or TrustMe can pop it later).
                }
@@ -421,6 +422,7 @@ and resumeBuiltin (bs: BuiltinState) (cp: ChoicePoint) (rest: ChoicePoint list) 
                  WsHeapLen  = cp.CpHeapLen
                  WsBindings = newBindings
                  WsCutBar   = cp.CpCutBar
+                 WsB0Stack  = (let n = List.length s.WsB0Stack - cp.CpB0StackLen in if n > 0 then List.skip n s.WsB0Stack else s.WsB0Stack)
                  WsCPs      = newCPs
                  WsCPsLen   = List.length newCPs }
     | HopsRetry (_, [], _) ->
@@ -444,6 +446,7 @@ and resumeBuiltin (bs: BuiltinState) (cp: ChoicePoint) (rest: ChoicePoint list) 
                  WsHeapLen  = cp.CpHeapLen
                  WsBindings = newBindings
                  WsCutBar   = cp.CpCutBar
+                 WsB0Stack  = (let n = List.length s.WsB0Stack - cp.CpB0StackLen in if n > 0 then List.skip n s.WsB0Stack else s.WsB0Stack)
                  WsCPs      = newCPs
                  WsCPsLen   = List.length newCPs }
     | SelectRetry (_, _, [], _) ->
@@ -464,6 +467,7 @@ and resumeBuiltin (bs: BuiltinState) (cp: ChoicePoint) (rest: ChoicePoint list) 
                              WsHeapLen  = cp.CpHeapLen
                              WsBindings = cp.CpBindings
                              WsCutBar   = cp.CpCutBar
+                             WsB0Stack  = (let n = List.length s.WsB0Stack - cp.CpB0StackLen in if n > 0 then List.skip n s.WsB0Stack else s.WsB0Stack)
                              WsPC       = retPC }
         let rec tryNext pairs =
             match pairs with
@@ -487,6 +491,7 @@ and resumeBuiltin (bs: BuiltinState) (cp: ChoicePoint) (rest: ChoicePoint list) 
                                      WsStack    = cp.CpStack
                                      WsCP       = cp.CpCP
                                      WsCutBar   = cp.CpCutBar
+                                     WsB0Stack  = (let n = List.length s.WsB0Stack - cp.CpB0StackLen in if n > 0 then List.skip n s.WsB0Stack else s.WsB0Stack)
                                      WsCPs      = newCPs
                                      WsCPsLen   = List.length newCPs }
         tryNext candidates
@@ -513,6 +518,7 @@ and resumeBuiltin (bs: BuiltinState) (cp: ChoicePoint) (rest: ChoicePoint list) 
                  WsHeapLen  = cp.CpHeapLen
                  WsBindings = newBindings
                  WsCutBar   = cp.CpCutBar
+                 WsB0Stack  = (let n = List.length s.WsB0Stack - cp.CpB0StackLen in if n > 0 then List.skip n s.WsB0Stack else s.WsB0Stack)
                  WsCPs      = newCPs
                  WsCPsLen   = List.length newCPs }
 
@@ -784,14 +790,47 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
 
     | SetConstant c -> addToBuilder c s
 
+    //
+    // Standard-WAM B0 protocol (issue #2400 follow-up).
+    //
+    // Call / CallResolved: save the caller''s WsCutBar onto WsB0Stack
+    // and set WsCutBar = current WsCPsLen.  This is the count BEFORE
+    // the callee''s leading TryMeElse pushes CP_self, so a `!` inside
+    // the callee drops above WsCutBar = correctly kills CP_self.
+    // Without this, Allocate set WsCutBar = post-TryMeElse count and
+    // cut was a no-op against the predicate''s own retry CP.
+    //
+    // Execute / ExecutePc (tail call): update WsCutBar in place but
+    // do NOT push.  The caller''s frame is being replaced — Proceed
+    // pops, so a push here would unbalance the stack.  The pairing
+    // invariant is: WsB0Stack depth changes only via Call/Proceed
+    // pairs.
+    //
+    // Proceed: pop WsB0Stack into WsCutBar to restore the caller''s
+    // barrier.  See the Proceed handler below.
+    //
     | CallResolved (pc, _arity) ->
-        Some { s with WsPC = pc; WsCP = s.WsPC + 1 }
+        Some { s with WsPC      = pc
+                      WsCP      = s.WsPC + 1
+                      WsB0Stack = s.WsCutBar :: s.WsB0Stack
+                      WsCutBar  = s.WsCPsLen }
 
     | CallForeign (pred, _arity) ->
-        executeForeign ctx pred { s with WsCP = s.WsPC + 1 }
+        // Foreign predicates don''t emit Proceed in the F# WAM (they
+        // either succeed via dispatchForeign''s direct return or push
+        // a builtin CP).  Mirror Call''s B0 protocol so any cut inside
+        // the foreign handler sees the correct barrier; if the
+        // foreign handler bypasses Proceed (e.g. via direct WsPC
+        // assignment) the B0 entry stays — that matches existing
+        // semantics where WsCutBar would not be restored either.
+        executeForeign ctx pred { s with WsCP      = s.WsPC + 1
+                                         WsB0Stack = s.WsCutBar :: s.WsB0Stack
+                                         WsCutBar  = s.WsCPsLen }
 
     | Call (pred, _arity) ->
-        let sc = { s with WsCP = s.WsPC + 1 }
+        let sc = { s with WsCP      = s.WsPC + 1
+                          WsB0Stack = s.WsCutBar :: s.WsB0Stack
+                          WsCutBar  = s.WsCPsLen }
         match Map.tryFind pred ctx.WcLoweredPredicates with
         | Some fn -> fn ctx sc
         | None ->
@@ -803,17 +842,22 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         | None    -> None
 
     | Execute pred ->
+        // Tail call: no return, so no push.  Update barrier in place.
+        let st = { s with WsCutBar = s.WsCPsLen }
         match Map.tryFind pred ctx.WcLoweredPredicates with
-        | Some fn -> fn ctx s
+        | Some fn -> fn ctx st
         | None ->
-        match callIndexedFact2 ctx pred s with
+        match callIndexedFact2 ctx pred st with
         | Some sr -> Some sr
         | None ->
         match Map.tryFind pred ctx.WcLabels with
-        | Some pc -> Some { s with WsPC = pc }
+        | Some pc -> Some { st with WsPC = pc }
         | None    -> None
 
-    | ExecutePc pc -> Some { s with WsPC = pc }
+    | ExecutePc pc ->
+        // Tail call (resolved form): no push, update barrier only.
+        Some { s with WsPC     = pc
+                      WsCutBar = s.WsCPsLen }
 
     | Jump label ->
         match Map.tryFind label ctx.WcLabels with
@@ -823,26 +867,52 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
     | JumpPc pc -> Some { s with WsPC = pc }
 
     | Proceed ->
+        // Standard-WAM return: jump to WsCP (caller''s return PC)
+        // and restore the caller''s cut barrier from WsB0Stack.
+        // Call/CallResolved pushed; Proceed pops.  Tail-call
+        // (Execute/ExecutePc) does NOT push, so the pop here matches
+        // the most recent non-tail Call up the chain.  When the
+        // stack is empty (top-level entry), keep WsCutBar at 0.
         let ret = s.WsCP
-        if ret = 0 then Some { s with WsPC = 0 }
-        else Some { s with WsPC = ret; WsCP = 0 }
+        let cutBarR, stackR =
+            match s.WsB0Stack with
+            | top :: rest -> top, rest
+            | []          -> 0,   []
+        if ret = 0 then Some { s with WsPC      = 0
+                                      WsCutBar  = cutBarR
+                                      WsB0Stack = stackR }
+        else Some { s with WsPC      = ret
+                           WsCP      = 0
+                           WsCutBar  = cutBarR
+                           WsB0Stack = stackR }
 
     | Fail -> None
 
     | Allocate ->
         // Save the previous cut barrier in the frame so Deallocate can
-        // restore it.  Without this, a cut inside a nested clause body
-        // (e.g. `take_digits` calling `digit_code/1`) used the wrong
-        // barrier and the cut became a no-op -- exposing every
-        // ancestor''s CPs to backtrack.  The frame already carries
-        // EfSavedCP for the same reason.
+        // restore it for nested intra-clause cuts (e.g. a cut inside
+        // a goal that was itself inside another goal''s environment).
+        //
+        // Issue #2400 follow-up: do NOT overwrite WsCutBar here.  The
+        // cross-call cut barrier (B0) is now managed by Call/Proceed
+        // via WsB0Stack — Call sets WsCutBar = WsCPsLen BEFORE the
+        // callee''s TryMeElse pushes CP_self, which is the value cuts
+        // inside the callee body need.  If Allocate then re-set
+        // WsCutBar = WsCPsLen (the count AFTER TryMeElse), `:- ..., !.`
+        // would never drop the predicate''s own retry CP — exactly the
+        // bug that caused tokenize_one''s CPs to leak past the parser''s
+        // cut and corrupt later bindings.
+        //
+        // EfSavedCutBar still snapshots WsCutBar so Deallocate restores
+        // the right value when a sub-goal inside this clause had its
+        // own Allocate/Deallocate pair (the WsB0Stack handles
+        // call-to-call; this frame field handles intra-clause nesting).
         let frame = { EfSavedCP    = s.WsCP
                       EfYRegs      = Map.empty
                       EfSavedCutBar= s.WsCutBar }
         Some { s with
                  WsPC    = s.WsPC + 1
-                 WsStack = frame :: s.WsStack
-                 WsCutBar= s.WsCPsLen }
+                 WsStack = frame :: s.WsStack }
 
     | Deallocate ->
         match s.WsStack with
@@ -864,6 +934,7 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                    CpHeapLen  = s.WsHeapLen
                    CpBindings = s.WsBindings
                    CpCutBar   = s.WsCutBar
+                   CpB0StackLen = List.length s.WsB0Stack
                    CpAggFrame = None
                    CpBuiltin  = None }
         Some { s with WsPC = s.WsPC + 1; WsCPs = cp :: s.WsCPs; WsCPsLen = s.WsCPsLen + 1 }
@@ -877,6 +948,7 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                    CpHeapLen  = s.WsHeapLen
                    CpBindings = s.WsBindings
                    CpCutBar   = s.WsCutBar
+                   CpB0StackLen = List.length s.WsB0Stack
                    CpAggFrame = None
                    CpBuiltin  = None }
         Some { s with WsPC = s.WsPC + 1; WsCPs = cp :: s.WsCPs; WsCPsLen = s.WsCPsLen + 1 }
@@ -912,6 +984,7 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                        CpHeapLen  = s.WsHeapLen
                        CpBindings = s.WsBindings
                        CpCutBar   = s.WsCutBar
+                       CpB0StackLen = List.length s.WsB0Stack
                        CpAggFrame = None
                        CpBuiltin  = None }
             Some { s with WsPC = s.WsPC + 1; WsCPs = cp :: s.WsCPs; WsCPsLen = s.WsCPsLen + 1 }
@@ -929,6 +1002,7 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                        CpHeapLen  = s.WsHeapLen
                        CpBindings = s.WsBindings
                        CpCutBar   = s.WsCutBar
+                       CpB0StackLen = List.length s.WsB0Stack
                        CpAggFrame = None
                        CpBuiltin  = None }
             Some { s with WsPC = s.WsPC + 1; WsCPs = cp :: s.WsCPs; WsCPsLen = s.WsCPsLen + 1 }
@@ -957,6 +1031,7 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                    CpHeapLen  = s.WsHeapLen
                    CpBindings = s.WsBindings
                    CpCutBar   = s.WsCutBar
+                   CpB0StackLen = List.length s.WsB0Stack
                    CpAggFrame = None
                    CpBuiltin  = None }
         Some { s with WsPC = targetPC
@@ -973,6 +1048,7 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                    CpHeapLen  = s.WsHeapLen
                    CpBindings = s.WsBindings
                    CpCutBar   = s.WsCutBar
+                   CpB0StackLen = List.length s.WsB0Stack
                    CpAggFrame = None
                    CpBuiltin  = None }
         Some { s with WsPC = targetPC
@@ -997,6 +1073,7 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                        CpHeapLen  = s.WsHeapLen
                        CpBindings = s.WsBindings
                        CpCutBar   = s.WsCutBar
+                       CpB0StackLen = List.length s.WsB0Stack
                        CpAggFrame = None
                        CpBuiltin  = None }
             Some { s with WsPC = targetPC
@@ -1018,6 +1095,7 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                        CpHeapLen  = s.WsHeapLen
                        CpBindings = s.WsBindings
                        CpCutBar   = s.WsCutBar
+                       CpB0StackLen = List.length s.WsB0Stack
                        CpAggFrame = None
                        CpBuiltin  = None }
             Some { s with WsPC = targetPC
@@ -1678,6 +1756,7 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                                                CpHeapLen  = s.WsHeapLen
                                                CpBindings = s.WsBindings
                                                CpCutBar   = s.WsCutBar
+                                               CpB0StackLen = List.length s.WsB0Stack
                                                CpAggFrame = None
                                                CpBuiltin  = Some (SelectRetry (1, 3, more, retPC)) }
                                     cp :: s.WsCPs, s.WsCPsLen + 1
@@ -1795,6 +1874,7 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                    CpHeapLen  = s.WsHeapLen
                    CpBindings = s.WsBindings
                    CpCutBar   = s.WsCutBar
+                   CpB0StackLen = List.length s.WsB0Stack
                    CpAggFrame = Some { AggType          = aggType
                                        AggValReg        = valReg
                                        AggResReg        = resReg
@@ -2406,7 +2486,13 @@ and forkParBranches (ctx: WamContext) (s: WamState) (af: AggFrame)
                                WsPC       = pc
                                WsCP       = 0
                                WsCutBar   = 0
-                               WsAggAccum = [] }
+                               WsAggAccum = []
+                               // Fresh B0 stack for each branch — parent''s
+                               // pushes belong to a different execution
+                               // context.  Branch runs with WsCP=0 so a
+                               // mismatched pop would halt; starting empty
+                               // keeps Call/Proceed pairing consistent.
+                               WsB0Stack  = [] }
             return run ctx snapshot
         }
     let results =
@@ -2509,6 +2595,7 @@ and callIndexedFact2 (ctx: WamContext) (pred: string) (s: WamState) : WamState o
                                        CpHeapLen  = s.WsHeapLen
                                        CpBindings = s.WsBindings
                                        CpCutBar   = s.WsCutBar
+                                       CpB0StackLen = List.length s.WsB0Stack
                                        CpAggFrame = None
                                        CpBuiltin  = Some (FactRetry (vid, rest, retPC)) }
                             cp :: s.WsCPs, s.WsCPsLen + 1
@@ -2871,6 +2958,7 @@ emit_stream_binding_multi_fs(OutputRegs, Indent) :-
     format('~w               CpHeapLen  = s.WsHeapLen~n', [Indent]),
     format('~w               CpBindings = s.WsBindings~n', [Indent]),
     format('~w               CpCutBar   = s.WsCutBar~n', [Indent]),
+    format('~w               CpB0StackLen = List.length s.WsB0Stack~n', [Indent]),
     format('~w               CpAggFrame = None~n', [Indent]),
     format('~w               CpBuiltin  = Some (FFIStreamRetry (', [Indent]),
     emit_outregs_list_fs(OutputRegs),
@@ -3959,7 +4047,8 @@ let main argv =
           WsVarCounter = 0
           WsBuilder    = None
           WsBuilderStack = []
-          WsAggAccum   = [] }
+          WsAggAccum   = []
+          WsB0Stack    = [] }
 
     // Find entry point: prefer lowered predicates, fall back to code array
     let queryPred =

--- a/tests/core/test_wam_indexing_bypass.pl
+++ b/tests/core/test_wam_indexing_bypass.pl
@@ -205,7 +205,8 @@ let main _argv =
           WsVarCounter = 0
           WsBuilder = None
           WsBuilderStack = []
-          WsAggAccum = [] }
+          WsAggAccum = []
+          WsB0Stack = [] }
     let ok =
         match dispatchCall ctx \"bypass_demo/0\" s0 with
         | Some _ -> true

--- a/tests/fixtures/wam_fsharp_naf_microbench/Driver.fs
+++ b/tests/fixtures/wam_fsharp_naf_microbench/Driver.fs
@@ -110,7 +110,8 @@ let mkState () =
       WsVarCounter = 1000
       WsBuilder    = None
       WsBuilderStack = []
-      WsAggAccum   = [] }
+      WsAggAccum   = []
+      WsB0Stack    = [] }
 
 let runScenario (name: string) (branch1: Instruction list) (expectTrue: bool) (slowSize: int) : int64 * int64 * bool =
     let ctx, parPC, elsePC = mkContext branch1 slowSize

--- a/tests/fixtures/wam_fsharp_phase_i_lowered_smoke/Driver.fs
+++ b/tests/fixtures/wam_fsharp_phase_i_lowered_smoke/Driver.fs
@@ -66,7 +66,8 @@ let mkState (regs: (int * Value) list) =
       WsVarCounter = 0
       WsBuilder    = None
       WsBuilderStack = []
-      WsAggAccum   = [] }
+      WsAggAccum   = []
+      WsB0Stack    = [] }
 
 // -- arg/3 specialized ----------------------------------------------------
 

--- a/tests/fixtures/wam_fsharp_query_smoke/Driver.fs
+++ b/tests/fixtures/wam_fsharp_query_smoke/Driver.fs
@@ -88,7 +88,8 @@ let mkQueryState (a1: Value) (a2: Value) (vidStart: int) =
       WsVarCounter = vidStart
       WsBuilder    = None
       WsBuilderStack = []
-      WsAggAccum   = [] }
+      WsAggAccum   = []
+      WsB0Stack    = [] }
 
 // -- Working queries: clauses 1-2 reachable --------------------------------
 

--- a/tests/fixtures/wam_fsharp_smoke/Smoke.fs
+++ b/tests/fixtures/wam_fsharp_smoke/Smoke.fs
@@ -55,7 +55,8 @@ let mkEmptyState () =
       WsVarCounter = 0
       WsBuilder    = None
       WsBuilderStack = []
-      WsAggAccum   = [] }
+      WsAggAccum   = []
+      WsB0Stack    = [] }
 
 let mkContext (code: Instruction array) (labels: Map<string, int>) =
     { WcCode              = code
@@ -656,6 +657,7 @@ let scenario_remove_nearest_agg_frame () =
         CpNextPC = 10; CpRegs = Array.empty; CpStack = []
         CpCP = 0; CpTrailLen = 0; CpHeapLen = 0
         CpBindings = Map.empty; CpCutBar = 0
+        CpB0StackLen = 0
         CpAggFrame = None; CpBuiltin = None }
     let aggCP : ChoicePoint = {
         plainCP with CpAggFrame = Some { AggType = "sum"; AggValReg = 2
@@ -683,6 +685,7 @@ let scenario_par_step_inside_sequential_aggregate () =
         CpNextPC = 0; CpRegs = Array.empty; CpStack = []
         CpCP = 0; CpTrailLen = 0; CpHeapLen = 0
         CpBindings = Map.empty; CpCutBar = 0
+        CpB0StackLen = 0
         CpAggFrame = Some { AggType = "unknown"; AggValReg = 2
                             AggResReg = 1; AggReturnPC = 0
                             AggMergeStrategy = MergeSequential }


### PR DESCRIPTION
## Summary

Fixes the F# WAM's cut-barrier handling so `:- ..., !.` correctly drops
the calling predicate's own retry choice point.

Currently `Allocate` sets `WsCutBar = WsCPsLen` **after** the
predicate's leading `TryMeElse` has already pushed `CP_self`. The
barrier ends up *at* the alternative CP, not *below* it — so a cut
inside the body drops `WsCPsLen - WsCutBar = 0` CPs (a no-op), and
the alternative survives. Later, when an outer goal fails and
backtrack walks the stack, it lands on the stale retry CP and undoes
bindings that should have been committed.

Standard-WAM fix (Aït-Kaci §5.5): capture `B0` at **call time**,
before the callee's `TryMeElse` runs. Independent review of the
analysis was done with Perplexity (deep research + a second
independent pass) and confirmed the diagnosis and protocol.

## The protocol

| Instruction | Behavior |
|---|---|
| `Call` / `CallResolved` / `CallForeign` | push `WsCutBar` onto `WsB0Stack`, set `WsCutBar = WsCPsLen` |
| `Execute` / `ExecutePc` (tail call) | set `WsCutBar = WsCPsLen`, **no push, no pop** — caller's frame is gone, so stack depth stays in sync with `Call`/`Proceed` pairs only |
| `Proceed` | pop `WsB0Stack` into `WsCutBar` |
| `Allocate` | stop overwriting `WsCutBar` (the new Call-time value is correct; would be lost otherwise). `EfSavedCutBar` snapshot kept for intra-clause nested cuts |
| `Deallocate` | restore `EfSavedCutBar` (intra-clause nested-cut case — distinct from cross-call) |
| `backtrack` | truncate `WsB0Stack` to `cp.CpB0StackLen` so failed sub-calls' pushes don't leak past the CP they originated in |

`WamState` gains `WsB0Stack: int list`. `ChoicePoint` gains
`CpB0StackLen: int`. Every CP-construction site (11 in the F# step
handler, 1 in the FFI-stream format emitter, 5 in the standalone
reference runtime, plus the lowered emitter) captures the depth at
`TryMeElse` time. Every hand-built CP in the test fixtures
(`wam_fsharp_smoke`, `wam_fsharp_naf_microbench`,
`wam_fsharp_query_smoke`, `wam_fsharp_phase_i_lowered_smoke`,
`tests/core/test_wam_indexing_bypass`) adds the new field.

## Test results

### All existing tests pass
- `tests/test_wam_target.pl` — all
- `tests/test_wam_fsharp_target.pl` — all
- `tests/core/test_wam_indexing_bypass.pl` — F#/Python/C++ pass; others skip with reasons
- `tests/core/test_wam_fsharp_dotnet_smoke.pl` — 8/8 dotnet smokes

### Trace evidence the fix works
Before this commit, the F# parser regression for `p(a)` showed
spurious undo entries for vids 97 and 110 (the two `tk_atom` token
variables built by `tokenize_one`'s clause body after a cut). After
this commit, neither is undone — the cut now drops `tokenize_one`'s
own retry CP and stale backtracks can't reach back into it.

### Parser regression (`tests/repro_fsharp_parser.pl`)
Before: 7/9. After: 7/9. The two failing inputs — `'p(a)'` and
`'p(a,b)'` — still fail, but for a **different** reason now (no
longer the cut-barrier corruption). The remaining failure is in
`parse_atom_head`'s `!, parse_args(...), =..(...)` path and needs
separate investigation. Filed as follow-up scope.

## What's NOT in this PR

- Fix for the remaining `'p(a)'` / `'p(a,b)'` parser failures.
  Those have a different root cause than the cut barrier; this PR's
  trace evidence (the tk_atom bindings now survive) confirms the
  cut-barrier issue is resolved, but the parser still has more bugs
  downstream.
- Port to other targets. C++'s runtime has a different cut model
  (uses an `indexed_entry` flag and explicit pop in `TrustMe`) that
  doesn't have this bug; Scala has its own CP discipline. Only F#
  needed this fix.

## Test plan
- [x] `swipl -q -g run_tests -t halt tests/core/test_wam_indexing_bypass.pl` → 3 PASS, 4 SKIP
- [x] `swipl -q -g run_tests -t halt tests/test_wam_target.pl` → all pass
- [x] `swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl` → all pass
- [x] `swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_dotnet_smoke.pl` → 8/8 PASS
- [x] Parser regression: 7/9 (same numerator; trace shows the
      previously-undone tk_atom bindings now survive)

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_