### PR TITLE
fix(wam-fsharp): four cascading bugs behind p(a)/p(a,b) parser regression

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -589,6 +589,14 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         let valOpt = getReg ai s
         match valOpt with
         | Some v when v = c -> Some { s with WsPC = s.WsPC + 1 }
+        // Empty-list equivalence (issue #2400 continuation).
+        // `Atom "[]"` and `VList []` both denote Prolog''s empty
+        // list.  Two materialization paths produce them — `Atom`
+        // when GetNil / a literal `[]` constant was emitted, `VList
+        // []` when an addToBuilder run collapsed a `[H|[]]` to a
+        // singleton then materialized as the empty list at the
+        // tail.  GetConstant Atom "[]" must succeed against either.
+        | Some (VList []) when c = Atom "[]" -> Some { s with WsPC = s.WsPC + 1 }
         | Some (Unbound vid) ->
             let r = Array.copy s.WsRegs
             r.[ai] <- c
@@ -1186,6 +1194,16 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         | Some (Str (fn, args)) ->
             let key = sprintf "%s/%d" fn (List.length args)
             match binarySearchStr structTable key with
+            | Some pc -> Some { s with WsPC = pc }
+            | None    -> Some { s with WsPC = s.WsPC + 1 }
+        // `VList []` IS the empty list — same as Atom "[]" — so it
+        // should look up "[]" in constTable, NOT jump to the cons-cell
+        // list chain.  Issue #2400 follow-up: without this, parse_op_loop''s
+        // base case `parse_op_loop([], ...)` was bypassed for A1=VList []
+        // and routed to the [H|T] chain whose head GetList read [] as
+        // an empty-list-typed cons (no head) and failed.
+        | Some (VList []) ->
+            match binarySearchStr constTable "[]" with
             | Some pc -> Some { s with WsPC = pc }
             | None    -> Some { s with WsPC = s.WsPC + 1 }
         | Some (VList _) when listPc > 0 ->
@@ -1984,10 +2002,31 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         let t = getReg 1 s
         match t with
         | Some (Unbound vid) ->
-            // Compose mode: read proper list from A2.
+            // Compose mode: read a proper list from A2.
+            // The runtime stores proper lists in two equivalent
+            // shapes: `VList [x1; ...; xn]` (compact) and `Str ("[|]",
+            // [head; tail])` cons cells (when the tail had to stay
+            // symbolic at materialization time — e.g. came back from
+            // parse_args bound to a head/tail var pair).  Both are
+            // valid Prolog lists; flatten Str-cons into the same
+            // sequence VList would have before destructuring.
+            let rec flattenCons (v: Value) : Value list option =
+                match derefVar s.WsBindings v with
+                | VList xs               -> Some xs
+                | Atom "[]"              -> Some []
+                | Str ("[|]", [h; tail]) ->
+                    match flattenCons tail with
+                    | Some rest -> Some (derefVar s.WsBindings h :: rest)
+                    | None      -> None
+                | _ -> None
             let l = getReg 2 s
-            match l with
-            | Some (VList items) ->
+            let itemsOpt =
+                match l with
+                | Some lv -> flattenCons lv
+                | None    -> None
+            match itemsOpt with
+            | None -> None
+            | Some items ->
                 let mBuilt =
                     match items with
                     | []                   -> None
@@ -2005,7 +2044,6 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                              WsBindings = Map.add vid built s.WsBindings
                              WsTrail    = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
                              WsTrailLen = s.WsTrailLen + 1 }
-            | _ -> None
         | Some tVal ->
             // Decompose mode: build list from T.
             let mList =
@@ -2218,22 +2256,68 @@ and updateNearestAggFrame (rpc: int) (cps: ChoicePoint list) : ChoicePoint list 
         | Some af -> { cp with CpAggFrame = Some { af with AggReturnPC = rpc } } :: rest
         | None    -> cp :: updateNearestAggFrame rpc rest
 
-and unifyVal (a: Value) (b: Value) (s: WamState) : WamState option =
+// Recursive structural unification — does NOT touch WsPC.  Returns
+// the updated state (with new bindings/trail entries) or None on
+// mismatch.  Handles the VList / Str cons-cell equivalence:
+// `VList [h1; ...; hn]` represents `[h1, ..., hn]` with `[]` tail;
+// `Str ("[|]", [h; t])` represents `[h | t]` where t may be a
+// variable, another structure, or another VList.  Both encodings
+// flow out of GetList / addToBuilder depending on which path
+// materialized them, so a unifier that only does structural F#
+// equality (==) misses the equivalence — that''s exactly the bug
+// that broke parse_args'' `Tokens1 = [tk_rparen|RestOut]` check on
+// the F# parser regression for `p(a)` / `p(a,b)`.
+and unifyTerms (a: Value) (b: Value) (s: WamState) : WamState option =
+    let a = derefVar s.WsBindings a
+    let b = derefVar s.WsBindings b
+    let bindUnbound vid v st =
+        { st with
+            WsBindings = Map.add vid v st.WsBindings
+            WsTrail    = { TrailVarId = vid; TrailOldVal = Map.tryFind vid st.WsBindings } :: st.WsTrail
+            WsTrailLen = st.WsTrailLen + 1 }
     match a, b with
-    | Unbound vid, v ->
-        Some { s with
-                 WsPC      = s.WsPC + 1
-                 WsBindings= Map.add vid v s.WsBindings
-                 WsTrail   = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
-                 WsTrailLen= s.WsTrailLen + 1 }
-    | v, Unbound vid ->
-        Some { s with
-                 WsPC      = s.WsPC + 1
-                 WsBindings= Map.add vid v s.WsBindings
-                 WsTrail   = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
-                 WsTrailLen= s.WsTrailLen + 1 }
-    | x, y when x = y -> Some { s with WsPC = s.WsPC + 1 }
-    | _                -> None'.
+    | Unbound vid, v -> Some (bindUnbound vid v s)
+    | v, Unbound vid -> Some (bindUnbound vid v s)
+    // [] equivalences.
+    | VList [], Atom "[]" -> Some s
+    | Atom "[]", VList [] -> Some s
+    // List ~ list element-wise.
+    | VList (h1 :: t1), VList (h2 :: t2) ->
+        match unifyTerms h1 h2 s with
+        | None    -> None
+        | Some s1 -> unifyTerms (VList t1) (VList t2) s1
+    // List ~ cons-cell.  VList [h; ...] ≡ Str ("[|]", [h; VList [...]]).
+    | VList (h :: t), Str ("[|]", [hb; tb]) ->
+        match unifyTerms h hb s with
+        | None    -> None
+        | Some s1 -> unifyTerms (VList t) tb s1
+    | Str ("[|]", [ha; ta]), VList (h :: t) ->
+        match unifyTerms ha h s with
+        | None    -> None
+        | Some s1 -> unifyTerms ta (VList t) s1
+    // Structural recurse on same-functor compounds.
+    | Str (f1, args1), Str (f2, args2)
+        when f1 = f2 && List.length args1 = List.length args2 ->
+        let rec go xs ys st =
+            match xs, ys with
+            | [], [] -> Some st
+            | x :: xt, y :: yt ->
+                match unifyTerms x y st with
+                | None     -> None
+                | Some st1 -> go xt yt st1
+            | _ -> None
+        go args1 args2 s
+    | x, y when x = y -> Some s
+    | _               -> None
+
+and unifyVal (a: Value) (b: Value) (s: WamState) : WamState option =
+    // Public unification entry — performs the recursive unification
+    // via unifyTerms (which is PC-agnostic) and advances WsPC by 1
+    // on success so the caller (typically the =/2 / unify_value
+    // step handler) doesn''t need to.
+    match unifyTerms a b s with
+    | None    -> None
+    | Some sN -> Some { sN with WsPC = sN.WsPC + 1 }'.
 
 % ============================================================================
 % PHASE 4: Run Loop

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1195,16 +1195,33 @@ compile_goals([Goal|Rest], V0, HasEnv, Vf, Code) :-
                       V0, HasEnv, Vf, Code)
     ;   Rest == []
     ->  % Last goal: execute (Tail Call Optimization)
-        (   %% Term-construction builtins (=../2 and functor/3) compose-mode
-            %% lowering routes through compile_goal_execute which dispatches
-            %% to emit_put_structure_dyn_lowering when the binding-state
-            %% preconditions hold. We add the deallocate here (HasEnv == yes
-            %% case) so the resulting tail-call stays TCO-correct.
+        (   %% Term-construction builtins (=../2 and functor/3) only
+            %% take the `deallocate-before-execute` fast path when the
+            %% compose-mode lowering (emit_put_structure_dyn_lowering)
+            %% actually fires — that path reads from input registers
+            %% rather than Y registers, so the env frame can be popped
+            %% beforehand without consequence.  When the binding-state
+            %% preconditions don''t hold (e.g. `Term =.. [Name|Args]`
+            %% with Args runtime-variable, as in parse_atom_head''s
+            %% functor-call clause), compile_goal_execute falls through
+            %% to the generic builtin path which emits PutList +
+            %% SetValue Y_n reads inline.  Emitting Deallocate before
+            %% that body is the codegen bug behind issue #2400''s
+            %% `p(a)` parser regression: the Y reg reads see a stale
+            %% env frame and the =.. compose builds garbage.
+            %%
+            %% Fix: route the fast path only when the special lowering
+            %% will actually apply.  Otherwise fall through to the
+            %% generic builtin-with-env handling below, which emits
+            %% PutCode + BuiltinCall + Deallocate + Proceed in the
+            %% right order.
             is_term_construction_goal(Goal),
-            HasEnv == yes
+            HasEnv == yes,
+            term_construction_uses_special_lowering(Goal)
         ->  compile_goal_execute(Goal, V0, Vf, ExecCode),
             format(string(Code), "    deallocate~n~w", [ExecCode])
-        ;   is_term_construction_goal(Goal)
+        ;   is_term_construction_goal(Goal),
+            term_construction_uses_special_lowering(Goal)
         ->  compile_goal_execute(Goal, V0, Vf, Code)
         ;   %% Visited-set lowering (Layer 2.5) routes through
             %% compile_goal_execute where the rewrite clause fires.
@@ -2502,6 +2519,38 @@ is_term_construction_goal(Goal) :-
     ;   Goal = arg(_, _, _)
     ;   Goal = (\+ member(_, _))
     ).
+
+%% term_construction_uses_special_lowering(+Goal)
+%
+%   True iff the term-construction goal will actually take the
+%   compose-mode lowering path in compile_goal_execute /
+%   compile_goal_call (emit_put_structure_dyn_lowering).  When this
+%   holds, the body reads from input registers and Deallocate may
+%   safely precede it.  When it fails, compile_goal_execute falls
+%   through to the generic builtin path which emits Y-register reads
+%   inline, so Deallocate must follow them (otherwise Y reads land
+%   on a popped env frame — issue #2400 follow-up).
+term_construction_uses_special_lowering(T =.. L) :-
+    parse_univ_list_pattern(L, NameVar, _FixedArgs),
+    catch(
+        ( current_clause_binding_env(BeforeEnv),
+          binding_state_analysis:binding_state_at_var(BeforeEnv, T, unbound),
+          binding_state_analysis:binding_state_at_var(BeforeEnv, NameVar, bound)
+        ),
+        _, fail),
+    !.
+term_construction_uses_special_lowering(functor(T, NameVar, Arity)) :-
+    integer(Arity), Arity >= 0,
+    var(T), var(NameVar),
+    catch(
+        ( current_clause_binding_env(BeforeEnv),
+          binding_state_analysis:binding_state_at_var(BeforeEnv, T, unbound),
+          binding_state_analysis:binding_state_at_var(BeforeEnv, NameVar, bound)
+        ),
+        _, fail),
+    !.
+term_construction_uses_special_lowering(\+ member(_, _)).
+term_construction_uses_special_lowering(arg(_, _, _)).
 
 %% emit_not_member_list_lowering(+X, +L, +V0, -Vf, -Code)
 %


### PR DESCRIPTION
## Summary

Brings the F# parser regression from **7/9 to 9/9**. Tracing why
`read_term_from_atom('p(a)', T)` still failed after the
cut-barrier fix uncovered four cascading bugs — each is independently
necessary; together they unblock the full parser path.

| # | Bug | Symptom | Fix |
|---|-----|---------|-----|
| 1 | `unifyVal` ignored `VList` ↔ `Str("[|]", _)` equivalence | `parse_args`' `Tokens1 = [tk_rparen\|RestOut]` failed when one side was VList and the other was a Str cons | Replaced inline equality with recursive `unifyTerms` that handles the two cons representations and threads bindings through compound args |
| 2 | `=../2` compose mode only handled `VList` input | `parse_atom_head`'s `Term =.. [Name\|Args]` got `[Unbound\|Unbound]` because Args was a Str cons; compose returned None | Added `flattenCons` to walk Str-cons chains via `derefVar` and normalize into the same item list `VList` would destructure into |
| 3 | `GetConstant Atom "[]"` didn't match `VList []` | `parse_op_loop`'s base case `parse_op_loop([], ...)` rejected `A1 = VList []` | Added VList-empty ↔ Atom "[]" equivalence in the GetConstant arm |
| 4 | `SwitchOnTermPc` dispatched `VList []` to the cons-cell list chain | parse_op_loop's empty-list base case was bypassed; head GetList on an empty VList failed | Route `VList []` to constTable lookup for "[]" first (only non-empty VList goes to listPc) |
| 5 | Codegen: `Deallocate` emitted before Y-register reads in term-construction tail calls | `parse_atom_head` clause 1 read Y206/Y207/Y208 *after* its env frame was popped, building `=..` from corrupted Y regs (which parse_args had clobbered via shared WsRegs slots) | Gated the `deallocate-before-execute` fast path on a new `term_construction_uses_special_lowering/1` check that mirrors `emit_put_structure_dyn_lowering`'s preconditions; when it fails, fall through to the generic builtin-with-env handler |

## Test results

### Parser regression (`tests/repro_fsharp_parser.pl`)
| Input | Before | After |
|---|---|---|
| `'42'`, `'foo'`, `'a'`, `'X'`, `'(a)'`, `'-3'` | PASS | PASS |
| **`'p(a)'`** | **FAIL** | **PASS** |
| **`'p(a,b)'`** | **FAIL** | **PASS** |

### Existing tests still green
- `tests/test_wam_target.pl` — all
- `tests/test_wam_fsharp_target.pl` — all
- `tests/core/test_wam_indexing_bypass.pl` — F#/Python/C++ pass
- `tests/core/test_wam_fsharp_dotnet_smoke.pl` — 8/8 dotnet smokes

## What unblocked this

Each bug masked the next. The dispatch-bypass and cut-barrier fixes
in the earlier PRs were prerequisites — without them, tokenize's
bindings were getting corrupted before parse_atom_head even saw the
right token stream, so the four bugs in this PR couldn't surface.
With the cut barrier set correctly:
1. Token bindings survived parser backtracking → `parse_args` got
   real `[tk_rparen]` tokens to work with.
2. Bug 1 surfaced when `parse_args` tried to unify them with a
   Str-cons template.
3. Bug 2 surfaced when `=..` got the resulting Str-cons.
4. Bug 5 surfaced when the corrupted Y reads built nonsense for `=..`.
5. Bugs 3 and 4 surfaced when the final result flowed into
   `parse_op_loop` with `A1 = VList []`.

The unifying theme is **`VList`/`Str("[|]", _)`/`Atom "[]"` are three
encodings of the same Prolog list shape**, and several runtime
operations only handled one of them. Each fix here aligns one
operation to recognize the other encodings.

## Test plan
- [x] `swipl -q -g main -t halt tests/repro_fsharp_parser.pl` → 9/9 PASS
- [x] `swipl -q -g run_tests -t halt tests/core/test_wam_indexing_bypass.pl` → 3 PASS, 4 SKIP
- [x] `swipl -q -g run_tests -t halt tests/test_wam_target.pl` → all
- [x] `swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl` → all
- [x] `swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_dotnet_smoke.pl` → 8/8 dotnet smokes

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_