### PR TITLE
feat(wam-python): support file stream open and close

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -46,7 +46,13 @@ class Ref:
     """Heap address reference."""
     addr: int
 
-Term = Atom | Compound | Var | Int | Float | Ref
+@dataclass
+class StreamHandle:
+    """Host stream wrapper that survives WAM state snapshots by identity."""
+    handle: Any
+    def __deepcopy__(self, memo): return self
+
+Term = Atom | Compound | Var | Int | Float | Ref | StreamHandle
 
 # -- Atom interning cache -----------------------------------------------------
 # Ensures `make_atom("foo") is make_atom("foo")` — pointer-equality for equal
@@ -1291,7 +1297,62 @@ def _execute_read_term_from_atom(state: WamState, arity: int = 2,
                                         options, syntax_default)
 
 
+def _unwrap_stream(stream: Any) -> Any:
+    return stream.handle if isinstance(stream, StreamHandle) else stream
+
+
+def _stream_open_mode(mode_term: Term, state: WamState) -> Optional[str]:
+    mode_term = deref(mode_term, state)
+    if not isinstance(mode_term, Atom):
+        return None
+    mode = _runtime_atom_text(mode_term.name)
+    if mode == 'read':
+        return 'r'
+    if mode == 'write':
+        return 'w'
+    if mode == 'append':
+        return 'a'
+    return None
+
+
+def _stream_path_text(path_term: Term, state: WamState) -> Optional[str]:
+    path_term = deref(path_term, state)
+    if not isinstance(path_term, Atom):
+        return None
+    return _runtime_atom_text(path_term.name)
+
+
+def _execute_open(state: WamState) -> bool:
+    path = _stream_path_text(get_reg(state, 1), state)
+    mode = _stream_open_mode(get_reg(state, 2), state)
+    if path is None or mode is None:
+        return False
+    try:
+        handle = open(path, mode, encoding='utf-8')
+    except OSError:
+        return False
+    if not unify(get_reg(state, 3), StreamHandle(handle), state):
+        try:
+            handle.close()
+        except OSError:
+            pass
+        return False
+    return True
+
+
+def _execute_close(state: WamState) -> bool:
+    stream = _unwrap_stream(deref(get_reg(state, 1), state))
+    if stream is None or not hasattr(stream, 'close'):
+        return False
+    try:
+        stream.close()
+    except OSError:
+        return False
+    return True
+
+
 def _read_stream_char(stream: Any) -> str:
+    stream = _unwrap_stream(stream)
     if hasattr(stream, 'read'):
         chunk = stream.read(1)
         return chunk or ''
@@ -1511,6 +1572,10 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return _execute_read_term_from_atom(state, 3, 'fail')
     if builtin in ('read_term_from_atom_iso/3',) and arity == 3:
         return _execute_read_term_from_atom(state, 3, 'error')
+    if builtin in ('open/3', 'open') and arity == 3:
+        return _execute_open(state)
+    if builtin in ('close/1', 'close') and arity == 1:
+        return _execute_close(state)
     if builtin in ('read/2', 'read_lax/2', 'read', 'read_lax') and arity == 2:
         return _execute_read(state, 'fail')
     if builtin in ('read_iso/2', 'read_iso') and arity == 2:

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -780,6 +780,38 @@ test(runtime_parser_compiled_runs_read2_from_python_stream) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_parser_compiled_runs_read2_from_opened_file) :-
+	setup_call_cleanup(
+		(   retractall(user:py_read2_file_demo),
+			user:python_parser_tmp_dir('tmp_wam_python_parser_read2_file', ProjectDir),
+			atomic_list_concat([ProjectDir, '/read_terms.pl'], DataFile),
+			assertz((user:py_read2_file_demo :-
+				open(DataFile, read, S),
+				read(S, T1), T1 = fact(1),
+				read(S, T2), T2 = fact(2),
+				read(S, T3), T3 = expr(1 + 2 * 3),
+				read(S, T4), T4 = end_of_file,
+				close(S)))
+		),
+		(   wam_python_target:write_wam_python_project([user:py_read2_file_demo/0],
+				[runtime_parser(compiled)], ProjectDir),
+			setup_call_cleanup(
+				open(DataFile, write, Out),
+				format(Out, "fact(1).~nfact(2).~nexpr(1+2*3).~n", []),
+				close(Out)),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_read2_file_demo/0', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_read2_file_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_runs_reverse_term_to_atom) :-
 	setup_call_cleanup(
 		(   retractall(user:py_term_to_atom_demo),


### PR DESCRIPTION
## Summary

- Add WAM-Python runtime support for `open/3` and `close/1` over UTF-8 text files.
- Wrap opened Python file objects in a `StreamHandle` so WAM state snapshots do not deep-copy host file handles.
- Cover `open/3 -> read/2 -> close/1` with a generated Python WAM runtime-parser test.

## Notes

This builds on the existing Python `read/2` runtime-parser path. The generated program can now open a Prolog source-like file directly instead of relying on a host-injected `io.StringIO`.

The initial scope supports `read`, `write`, and `append` modes as text streams. Invalid paths, modes, or stream terms fail quietly, matching the current lax Python WAM builtin behavior.

## Verification

- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
