### PR TITLE
feat(wam-python): support parser-backed read/1

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -5,6 +5,7 @@ Trail-based mutable state. No external dependencies.
 
 from __future__ import annotations
 import copy
+import sys
 from dataclasses import dataclass, field
 from typing import Any, Optional, Callable, Dict, List, Tuple
 
@@ -1359,9 +1360,8 @@ def _read_stream_char(stream: Any) -> str:
     return ''
 
 
-def _execute_read(state: WamState, syntax_default: str = 'fail') -> bool:
-    stream = deref(get_reg(state, 1), state)
-    target = get_reg(state, 2)
+def _execute_read_from_stream(state: WamState, stream: Any, target: Term,
+                              syntax_default: str = 'fail') -> bool:
     if stream is None or isinstance(stream, (Atom, Compound, Var, Int, Float, Ref)):
         return False
 
@@ -1383,6 +1383,25 @@ def _execute_read(state: WamState, syntax_default: str = 'fail') -> bool:
             continue
         if _execute_compiled_parse_atom(state, candidate, target, None, 'fail'):
             return True
+
+
+def _execute_read(state: WamState, syntax_default: str = 'fail') -> bool:
+    return _execute_read_from_stream(
+        state,
+        deref(get_reg(state, 1), state),
+        get_reg(state, 2),
+        syntax_default,
+    )
+
+
+def _execute_read_default_stream(state: WamState,
+                                 syntax_default: str = 'fail') -> bool:
+    return _execute_read_from_stream(
+        state,
+        sys.stdin,
+        get_reg(state, 1),
+        syntax_default,
+    )
 
 
 def _execute_term_to_atom(state: WamState) -> bool:
@@ -1576,6 +1595,12 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return _execute_open(state)
     if builtin in ('close/1', 'close') and arity == 1:
         return _execute_close(state)
+    if builtin in ('read/1', 'read_lax/1', 'read_term/1', 'read_term_lax/1',
+                   'read', 'read_lax', 'read_term', 'read_term_lax') and arity == 1:
+        return _execute_read_default_stream(state, 'fail')
+    if builtin in ('read_iso/1', 'read_iso',
+                   'read_term_iso/1', 'read_term_iso') and arity == 1:
+        return _execute_read_default_stream(state, 'error')
     if builtin in ('read/2', 'read_lax/2', 'read', 'read_lax') and arity == 2:
         return _execute_read(state, 'fail')
     if builtin in ('read_iso/2', 'read_iso') and arity == 2:

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -1398,6 +1398,8 @@ iso_errors_default_to_iso("=\\=/2", "=\\=_iso/2").
 iso_errors_default_to_iso("succ/2", "succ_iso/2").
 iso_errors_default_to_iso("read_term_from_atom/2", "read_term_from_atom_iso/2").
 iso_errors_default_to_iso("read_term_from_atom/3", "read_term_from_atom_iso/3").
+iso_errors_default_to_iso("read/1", "read_iso/1").
+iso_errors_default_to_iso("read_term/1", "read_term_iso/1").
 iso_errors_default_to_iso("read/2", "read_iso/2").
 
 iso_errors_default_to_lax("is/2", "is_lax/2").
@@ -1410,6 +1412,8 @@ iso_errors_default_to_lax("=\\=/2", "=\\=_lax/2").
 iso_errors_default_to_lax("succ/2", "succ_lax/2").
 iso_errors_default_to_lax("read_term_from_atom/2", "read_term_from_atom_lax/2").
 iso_errors_default_to_lax("read_term_from_atom/3", "read_term_from_atom_lax/3").
+iso_errors_default_to_lax("read/1", "read_lax/1").
+iso_errors_default_to_lax("read_term/1", "read_term_lax/1").
 iso_errors_default_to_lax("read/2", "read_lax/2").
 
 %% iso_errors_resolve_options(+Options, -Config)

--- a/src/unifyweaver/targets/wam_runtime_parser_capability.pl
+++ b/src/unifyweaver/targets/wam_runtime_parser_capability.pl
@@ -32,7 +32,9 @@ wam_target_runtime_parser(Target, Options, Mode) :-
 %% parser_dependent_builtin(?Name/Arity)
 %
 % Builtins/features that need source text parsed into runtime terms.
+parser_dependent_builtin(read/1).
 parser_dependent_builtin(read/2).
+parser_dependent_builtin(read_term/1).
 parser_dependent_builtin(read_term_from_atom/2).
 parser_dependent_builtin(read_term_from_atom/3).
 parser_dependent_builtin(term_to_atom/2).

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -464,6 +464,13 @@ test(iso_errors_text_rewrite_uses_is_key_tables) :-
 	wam_python_target:iso_errors_rewrite_text(iso_config(false, []), read_demo/0, Read0, ReadLax),
 	assertion(sub_string(ReadLax, _, _, _, "call read_term_from_atom_lax/2, 2")),
 	assertion(sub_string(ReadLax, _, _, _, "builtin_call read_term_from_atom_lax/3 3")),
+	ReadDefault0 = 'read_default_demo/0:\n  builtin_call read/1 1\n  call read_term/1, 1',
+	wam_python_target:iso_errors_rewrite_text(iso_config(true, []), read_default_demo/0, ReadDefault0, ReadDefaultIso),
+	assertion(sub_string(ReadDefaultIso, _, _, _, "builtin_call read_iso/1 1")),
+	assertion(sub_string(ReadDefaultIso, _, _, _, "call read_term_iso/1, 1")),
+	wam_python_target:iso_errors_rewrite_text(iso_config(false, []), read_default_demo/0, ReadDefault0, ReadDefaultLax),
+	assertion(sub_string(ReadDefaultLax, _, _, _, "builtin_call read_lax/1 1")),
+	assertion(sub_string(ReadDefaultLax, _, _, _, "call read_term_lax/1, 1")),
 	ReadStream0 = 'read_stream_demo/0:\n  builtin_call read/2 2',
 	wam_python_target:iso_errors_rewrite_text(iso_config(true, []), read_stream_demo/0, ReadStream0, ReadStreamIso),
 	assertion(sub_string(ReadStreamIso, _, _, _, "builtin_call read_iso/2 2")),
@@ -809,6 +816,36 @@ test(runtime_parser_compiled_runs_read2_from_opened_file) :-
 			once(sub_string(Output, _, _, _, "True"))
 		),
 		(   retractall(user:py_read2_file_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
+test(runtime_parser_compiled_runs_read1_from_stdin) :-
+	setup_call_cleanup(
+		(   retractall(user:py_read1_demo),
+			assertz((user:py_read1_demo :-
+				read(T1), T1 = fact(1),
+				read_term(T2), T2 = fact(2),
+				read(T3), T3 = end_of_file)),
+			user:python_parser_tmp_dir('tmp_wam_python_parser_read1', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_read1_demo/0],
+				[runtime_parser(compiled)], ProjectDir),
+			atomic_list_concat([
+				"import io, sys",
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"old_stdin = sys.stdin",
+				"sys.stdin = io.StringIO('fact(1).\\nfact(2).\\n')",
+				"try:",
+				"    print(wr.run_wam(code, labels, 'py_read1_demo/0', state))",
+				"finally:",
+				"    sys.stdin = old_stdin"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_read1_demo),
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 

--- a/tests/test_wam_runtime_parser_capability.pl
+++ b/tests/test_wam_runtime_parser_capability.pl
@@ -76,10 +76,15 @@ test(invalid_request_errors,
 
 test(parser_dependent_builtin_catalogue) :-
     findall(PI, parser_dependent_builtin(PI), PIs),
-    assertion(PIs == [read/2,
+    assertion(PIs == [read/1,
+                      read/2,
+                      read_term/1,
                       read_term_from_atom/2,
                       read_term_from_atom/3,
                       term_to_atom/2]).
+
+test(parser_dependent_goal_read_default_stream) :-
+    once(parser_dependent_goal(read(_), read/1)).
 
 test(parser_dependent_goal_read) :-
     parser_dependent_goal(read(_, _), read/2).


### PR DESCRIPTION
## Summary

- Add WAM-Python runtime support for `read/1` and `read_term/1` using `sys.stdin`.
- Reuse the existing parser-backed `read/2` stream implementation so default-input reads share EOF and syntax-error behavior.
- Add ISO/lax rewrite entries for `read/1` and `read_term/1`.
- Extend the shared runtime-parser dependency catalog so parser-disabled projects reject `read/1` and `read_term/1`.

## Notes

This is a narrow follow-up to file-backed `open/3` / `read/2` support. It lets generated Python WAM code run source-level predicates that call normal Prolog `read(Term)` without requiring an explicit stream argument.

The implementation preserves the current Python target policy: lax mode fails quietly on syntax errors, while ISO-rewritten `read_iso/1` and `read_term_iso/1` throw `syntax_error(_)` through the existing runtime parser path.

## Verification

- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests" -t halt tests/test_wam_runtime_parser_capability.pl`
- `swipl -q -g "run_tests(wam_python_iso_errors_config),run_tests(wam_python_runtime_parser_mode)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
