### PR TITLE
fix(wam-fsharp): member/2 backtracks via MemberRetry CP (fixes ':- p' regression)

### DIFF
--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -145,7 +145,14 @@ fsharp_wam_builtin_state_type :-
     /// the CP snapshot, unifies elemReg with `selected`, and binds
     /// outReg to VList rest_items.  Mirrors the Go target's
     /// SelectResults field (templates/targets/go_wam/state.go.mustache).
-    | SelectRetry    of elemReg: int * outReg: int * remaining: (Value * Value list) list * retPC: int").
+    | SelectRetry    of elemReg: int * outReg: int * remaining: (Value * Value list) list * retPC: int
+    /// member/2 backtracking choice point.  `remaining` is the unflattened
+    /// list-tail still to be tried after the current success; on backtrack
+    /// the runtime restores the CP snapshot and walks `remaining` looking
+    /// for the next unifiable element.  Needed because the parser uses
+    /// `member(op(Name, P, T), OpTable), is_op_type(T), !` and depends on
+    /// backtracking into member when the type guard fails.
+    | MemberRetry    of elemReg: int * remaining: Value list * retPC: int").
 
 % ============================================================================
 % EnvFrame — mirrors Haskell `EnvFrame`

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -495,6 +495,50 @@ and resumeBuiltin (bs: BuiltinState) (cp: ChoicePoint) (rest: ChoicePoint list) 
                                      WsCPs      = newCPs
                                      WsCPsLen   = List.length newCPs }
         tryNext candidates
+    | MemberRetry (_, [], _) ->
+        backtrack { s with WsCPs = rest; WsCPsLen = s.WsCPsLen - 1 }
+    | MemberRetry (elemReg, candidates, retPC) ->
+        // Restore from snapshot, then walk remaining list elements with
+        // unifyTerms until one succeeds (or all fail).  Mirrors the
+        // SelectRetry pattern: the snapshot lets unifyTerms attempts be
+        // independent of each other''s trail entries.
+        let diff = s.WsTrailLen - cp.CpTrailLen
+        let restoredS = { s with
+                             WsRegs     = Array.copy cp.CpRegs
+                             WsStack    = cp.CpStack
+                             WsCP       = cp.CpCP
+                             WsTrail    = List.skip diff s.WsTrail
+                             WsTrailLen = cp.CpTrailLen
+                             WsHeap     = List.take cp.CpHeapLen s.WsHeap
+                             WsHeapLen  = cp.CpHeapLen
+                             WsBindings = cp.CpBindings
+                             WsCutBar   = cp.CpCutBar
+                             WsB0Stack  = (let n = List.length s.WsB0Stack - cp.CpB0StackLen in if n > 0 then List.skip n s.WsB0Stack else s.WsB0Stack)
+                             WsPC       = retPC }
+        let rec tryNext cands =
+            match cands with
+            | [] -> backtrack { s with WsCPs = rest; WsCPsLen = s.WsCPsLen - 1 }
+            | x :: more ->
+                match getReg elemReg restoredS with
+                | None -> backtrack { s with WsCPs = rest; WsCPsLen = s.WsCPsLen - 1 }
+                | Some elem_ ->
+                    let xd = derefVar restoredS.WsBindings x
+                    match unifyTerms elem_ xd restoredS with
+                    | None    -> tryNext more
+                    | Some s2 ->
+                        let newCPs =
+                            match more with
+                            | [] -> rest
+                            | _  -> { cp with CpBuiltin = Some (MemberRetry (elemReg, more, retPC)) } :: rest
+                        Some { s2 with
+                                 WsPC      = retPC
+                                 WsStack   = cp.CpStack
+                                 WsCP      = cp.CpCP
+                                 WsCutBar  = cp.CpCutBar
+                                 WsB0Stack = (let n = List.length s.WsB0Stack - cp.CpB0StackLen in if n > 0 then List.skip n s.WsB0Stack else s.WsB0Stack)
+                                 WsCPs     = newCPs
+                                 WsCPsLen  = List.length newCPs }
+        tryNext candidates
     | FFIStreamRetry (_, _, [], _) ->
         backtrack { s with WsCPs = rest; WsCPsLen = s.WsCPsLen - 1 }
     | FFIStreamRetry (outRegs, outVars, tuple :: restTuples, retPC) ->
@@ -1859,39 +1903,53 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         | _ -> None
 
     | BuiltinCall ("member/2", _) ->
-        // member(Elem, List): Elem unifies with some element of List.
-        // Non-deterministic in standard Prolog (backtracks through all
-        // matches), but the previous implementation only tried the
-        // FIRST element of a VList — wrong even for find-first
-        // semantics, and failed against Str-cons list encodings
-        // entirely.  Issue #2400 follow-up: parser library''s
-        // resolve_infix/4 uses `member(op(Name, Prec, Type), OpTable)`
-        // followed by cut, so it needs find-first across the whole
-        // table (and across BOTH list encodings).  Walk the list
-        // explicitly, trying unifyVal on each element with the
-        // current (snapshot) state and committing to the first
-        // success.  Backtracking through alternative members would
-        // require a FactRetry-style CP — left as a follow-up since
-        // the parser path uses `member, !` and never backtracks.
+        // member(Elem, List): non-deterministic — unifies Elem with the
+        // first matching element of List and pushes a MemberRetry CP so
+        // backtracking can try subsequent matches.  The parser uses
+        // `member(op(Name, P, T), OpTable), is_op_type(T), !` and depends
+        // on the backtracking when the first match fails the type guard
+        // (e.g. resolve_prefix on '':-'' must skip the xfx 1200 entry to
+        // find the fx 1200 entry).  Walks both list encodings (VList and
+        // Str ''[|]'' cons cells) so it works against either runtime
+        // representation.
         let elem_ = s.WsRegs.[1] |> derefVar s.WsBindings
-        let rec walk lst st =
-            match derefVar st.WsBindings lst with
-            | VList []               -> None
-            | Atom "[]"              -> None
-            | VList (x :: rest) ->
-                let xd = derefVar st.WsBindings x
-                match unifyTerms elem_ xd st with
-                | Some st1 -> Some st1
-                | None     -> walk (VList rest) st
-            | Str ("[|]", [h; t]) ->
-                let hd = derefVar st.WsBindings h
-                match unifyTerms elem_ hd st with
-                | Some st1 -> Some st1
-                | None     -> walk t st
-            | _ -> None
-        match walk s.WsRegs.[2] s with
-        | Some sN -> Some { sN with WsPC = sN.WsPC + 1 }
-        | None    -> None
+        let retPC = s.WsPC + 1
+        let rec flatten lst =
+            match derefVar s.WsBindings lst with
+            | VList xs            -> xs
+            | Atom "[]"           -> []
+            | Str ("[|]", [h; t]) -> h :: flatten t
+            | _                   -> []
+        let items = flatten s.WsRegs.[2]
+        let rec tryFrom cands =
+            match cands with
+            | [] -> None
+            | x :: rest ->
+                let xd = derefVar s.WsBindings x
+                match unifyTerms elem_ xd s with
+                | None     -> tryFrom rest
+                | Some st1 ->
+                    let newCPs, newCPsLen =
+                        match rest with
+                        | [] -> s.WsCPs, s.WsCPsLen
+                        | _  ->
+                            let cp = { CpNextPC   = retPC
+                                       CpRegs     = Array.copy s.WsRegs
+                                       CpStack    = s.WsStack
+                                       CpCP       = s.WsCP
+                                       CpTrailLen = s.WsTrailLen
+                                       CpHeapLen  = s.WsHeapLen
+                                       CpBindings = s.WsBindings
+                                       CpCutBar   = s.WsCutBar
+                                       CpB0StackLen = List.length s.WsB0Stack
+                                       CpAggFrame = None
+                                       CpBuiltin  = Some (MemberRetry (1, rest, retPC)) }
+                            cp :: s.WsCPs, s.WsCPsLen + 1
+                    Some { st1 with
+                             WsPC     = retPC
+                             WsCPs    = newCPs
+                             WsCPsLen = newCPsLen }
+        tryFrom items
 
     | BeginAggregate (aggType, valReg, resReg) ->
         let cp = { CpNextPC   = s.WsPC

--- a/tests/core/test_wam_fsharp_parser_smoke.pl
+++ b/tests/core/test_wam_fsharp_parser_smoke.pl
@@ -63,6 +63,7 @@
 :- dynamic user:fs_parser_clause_two_vars/0.
 :- dynamic user:fs_parser_clause_append_base/0.
 :- dynamic user:fs_parser_clause_append_rec/0.
+:- dynamic user:fs_parser_clause_directive_compound/0.
 
 run_dotnet(Args, Dir, ExitCode, Out) :-
     process_create(path(dotnet), Args,
@@ -112,6 +113,7 @@ main :-
     retractall(user:fs_parser_clause_two_vars),
     retractall(user:fs_parser_clause_append_base),
     retractall(user:fs_parser_clause_append_rec),
+    retractall(user:fs_parser_clause_directive_compound),
     retractall(user:fs_simple),
     assertz((user:fs_simple :- true)),
     assertz((user:fs_parser_int :-
@@ -186,20 +188,16 @@ main :-
         read_term_from_atom('p(X) :- q(X) -> r(X) ; s(X)', _T))),
     assertz((user:fs_parser_clause_naf_body :-
         read_term_from_atom('p(X) :- \\+ q(X)', _T))),
-    %% NOTE: We use '?- p' here rather than the more natural ':- p'.
-    %% Both are prefix fx 1200 operators, but ':-' also has an infix xfx 1200
-    %% entry in the canonical_op_table that appears earlier. The F# WAM parser
-    %% fails to backtrack through the infix entry to find the prefix entry
-    %% for ':-' (other multi-entry ops like '-' work fine — root cause TBD).
-    %% '?- p' exercises the same prefix-1200 codepath with a single-entry op.
     assertz((user:fs_parser_clause_directive :-
-        read_term_from_atom('?- p', _T))),
+        read_term_from_atom(':- p', _T))),
     assertz((user:fs_parser_clause_two_vars :-
         read_term_from_atom('p(X,Y) :- q(X), r(Y)', _T))),
     assertz((user:fs_parser_clause_append_base :-
         read_term_from_atom('append([], L, L)', _T))),
     assertz((user:fs_parser_clause_append_rec :-
         read_term_from_atom('append([H|T], L, [H|R]) :- append(T, L, R)', _T))),
+    assertz((user:fs_parser_clause_directive_compound :-
+        read_term_from_atom(':- foo(a)', _T))),
 
     Dir = '/tmp/uw_fsharp_parser_repro',
     catch(delete_directory_and_contents(Dir), _, true),
@@ -229,7 +227,8 @@ main :-
          user:fs_parser_clause_naf_body/0, user:fs_parser_clause_directive/0,
          user:fs_parser_clause_two_vars/0,
          user:fs_parser_clause_append_base/0,
-         user:fs_parser_clause_append_rec/0],
+         user:fs_parser_clause_append_rec/0,
+         user:fs_parser_clause_directive_compound/0],
         [no_kernels(true),
          module_name('uw_fs_parser_repro'),
          runtime_parser(compiled)],
@@ -468,9 +467,11 @@ let main _argv =
     assertTrue \"read_term_from_atom('p(X) :- \\\\+ q(X)', T)\"
                (runPredicate \"fs_parser_clause_naf_body/0\")
 
-    // Directive prefix (using '?- p' — see note on the Prolog assertz for
-    // why ':- p' is a known F# WAM regression to fix separately)
-    assertTrue \"read_term_from_atom('?- p', T)\"
+    // Directive (prefix :-) — regression test for the member/2
+    // backtracking fix: ':-' has both xfx 1200 and fx 1200 entries
+    // in the canonical_op_table and resolve_prefix needs to skip the
+    // xfx one to reach the fx one.
+    assertTrue \"read_term_from_atom(':- p', T)\"
                (runPredicate \"fs_parser_clause_directive/0\")
 
     // Two head vars, two body goals
@@ -484,6 +485,10 @@ let main _argv =
     // append recursive clause — shared vars across head + body, list patterns
     assertTrue \"read_term_from_atom('append([H|T], L, [H|R]) :- append(T, L, R)', T)\"
                (runPredicate \"fs_parser_clause_append_rec/0\")
+
+    // Directive with compound arg — second regression for member/2 fix
+    assertTrue \"read_term_from_atom(':- foo(a)', T)\"
+               (runPredicate \"fs_parser_clause_directive_compound/0\")
 
     printfn \"RESULT %d/%d\" passes (passes + fails)
     if fails > 0 then 1 else 0


### PR DESCRIPTION
## Summary

Fixes the `:- p` regression noted in #2413. The F# WAM compiled parser failed on `read_term_from_atom(':- p', T)` because `member/2` committed to the first matching list element with no choice point, leaving the parser's

```prolog
resolve_prefix(Name, OpTable, Prec, Type) :-
    member(op(Name, Prec, Type), OpTable),
    is_prefix_type(Type),
    !.
```

unable to recover when the first match's type guard failed. For `:-`, the op table has both `op(':-', 1200, xfx)` (first) and `op(':-', 1200, fx)` (later); `member` would bind `Type=xfx`, `is_prefix_type(xfx)` would fail, and with no CP to retry, `resolve_prefix` as a whole failed.

The previous code acknowledged this in a comment — _"left as a follow-up since the parser path uses `member, !` and never backtracks"_ — but **the cut comes AFTER the type guard**, so backtracking into member IS on the critical path. The comment was wrong.

### Why other inputs didn't surface this earlier

| Input | Why it worked despite the bug |
| --- | --- |
| `\+ foo` | `op('\\+', 900, fy)` is the only `\\+` entry — no backtracking needed |
| `-3` | Tokenized as a single `tk_num(-3)` via the signed-number tokenizer — never exercises prefix `-` |
| `?- p` | `op('?-', 1200, fx)` is the only `?-` entry |

`:-` is the first operator in the canonical table with both an infix AND a prefix entry that the parser actually has to choose between via member-backtracking.

### Fix

Rewrite `member/2` to push a `MemberRetry` CP holding the unflattened list tail, mirroring `SelectRetry`'s pattern. On backtrack, restore the CP snapshot and walk the remaining elements with `unifyTerms`.

Three coordinated changes:
1. `BuiltinState` gets a new case: `MemberRetry of elemReg: int * remaining: Value list * retPC: int` (`src/unifyweaver/bindings/fsharp_wam_bindings.pl`)
2. `member/2` builtin rewritten to push the CP on first success (`src/unifyweaver/targets/wam_fsharp_target.pl`)
3. `resumeBuiltin` learns to handle `MemberRetry` (same file)

### Regression tests

Two cases added to `tests/core/test_wam_fsharp_parser_smoke.pl`:
- `:- p` (the original regression; atom operand) — restored from the `?- p` workaround
- `:- foo(a)` (compound operand)

42/42 PASS (up from 41/41 in #2413).

## Test plan

- [x] `LANG=C.UTF-8 swipl -q -g main -t halt tests/core/test_wam_fsharp_parser_smoke.pl` → `RESULT 42/42`
- [x] `swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl` → `All tests passed` (no regression in existing F# target tests)
- [ ] CI green on `claude/wam-fsharp-prefix-colon-dash-bug`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_