### PR TITLE
test(wam-clojure): expect switch body labels

### DIFF
--- a/tests/test_wam_clojure_generator.pl
+++ b/tests/test_wam_clojure_generator.pl
@@ -430,8 +430,8 @@ test(switch_on_constant_preserves_default_fallthrough) :-
         read_file_to_string(CorePath, CoreCode, []),
         read_file_to_string(RuntimePath, RuntimeCode, []),
         assertion(sub_string(CoreCode, _, _, _, '{:value "a" :label "default"}')),
-        assertion(sub_string(CoreCode, _, _, _, '{:value "b" :label "L_wam_choice_fact_1_2"}')),
-        assertion(sub_string(CoreCode, _, _, _, '{:value "c" :label "L_wam_choice_fact_1_3"}')),
+        assertion(sub_string(CoreCode, _, _, _, '{:value "b" :label "L_wam_choice_fact_1_2_body"}')),
+        assertion(sub_string(CoreCode, _, _, _, '{:value "c" :label "L_wam_choice_fact_1_3_body"}')),
         assertion(sub_string(RuntimeCode, _, _, _, ':default-fallthrough?')),
         assertion(sub_string(RuntimeCode, _, _, _, '(advance state)')),
         delete_directory_and_contents(TmpDir)


### PR DESCRIPTION
## Summary

- Updates the Clojure WAM `switch_on_constant` generator test to expect `_body` switch targets.
- Keeps the default fallthrough assertion unchanged.
- Restores the full Clojure generator test suite after switch lowering began targeting clause body labels.

## Why

The generated Clojure WAM switch table now routes non-default constants to clause body labels such as `L_wam_choice_fact_1_2_body`. The test still expected older wrapper labels like `L_wam_choice_fact_1_2`, causing `switch_on_constant_preserves_default_fallthrough` to fail on current `main` even though runtime smoke still passed.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
