### PR TITLE
feat(wam-python): support stdin char input builtins

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -132,6 +132,7 @@ class WamState:
         # unwind mechanism; these frames carry WAM-level state snapshots.
         self.catcher_frames: List[CatcherFrame] = []
         self.temp_y_regs: Optional[List] = None
+        self.input_pushback: List[str] = []
 
     def fresh_var(self) -> Var:
         v = Var(ref=[None], id=self._var_counter)
@@ -1360,14 +1361,46 @@ def _read_stream_char(stream: Any) -> str:
     return ''
 
 
+def _read_default_char(state: WamState) -> str:
+    if state.input_pushback:
+        return state.input_pushback.pop()
+    return _read_stream_char(sys.stdin)
+
+
+def _peek_default_char(state: WamState) -> str:
+    ch = _read_default_char(state)
+    if ch != '':
+        state.input_pushback.append(ch)
+    return ch
+
+
+def _execute_get_char(state: WamState) -> bool:
+    ch = _read_default_char(state)
+    value = make_atom('end_of_file') if ch == '' else make_atom(ch)
+    return unify(get_reg(state, 1), value, state)
+
+
+def _execute_peek_char(state: WamState) -> bool:
+    ch = _peek_default_char(state)
+    value = make_atom('end_of_file') if ch == '' else make_atom(ch)
+    return unify(get_reg(state, 1), value, state)
+
+
+def _execute_get_code(state: WamState) -> bool:
+    ch = _read_default_char(state)
+    value = Int(-1) if ch == '' else Int(ord(ch))
+    return unify(get_reg(state, 1), value, state)
+
+
 def _execute_read_from_stream(state: WamState, stream: Any, target: Term,
-                              syntax_default: str = 'fail') -> bool:
+                              syntax_default: str = 'fail',
+                              read_char: Optional[Callable[[], str]] = None) -> bool:
     if stream is None or isinstance(stream, (Atom, Compound, Var, Int, Float, Ref)):
         return False
 
     buffer = ''
     while True:
-        ch = _read_stream_char(stream)
+        ch = read_char() if read_char is not None else _read_stream_char(stream)
         if ch == '':
             if not buffer.strip():
                 return unify(target, make_atom('end_of_file'), state)
@@ -1401,6 +1434,7 @@ def _execute_read_default_stream(state: WamState,
         sys.stdin,
         get_reg(state, 1),
         syntax_default,
+        lambda: _read_default_char(state),
     )
 
 
@@ -1595,6 +1629,12 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return _execute_open(state)
     if builtin in ('close/1', 'close') and arity == 1:
         return _execute_close(state)
+    if builtin in ('get_char/1', 'get_char') and arity == 1:
+        return _execute_get_char(state)
+    if builtin in ('peek_char/1', 'peek_char') and arity == 1:
+        return _execute_peek_char(state)
+    if builtin in ('get_code/1', 'get_code') and arity == 1:
+        return _execute_get_code(state)
     if builtin in ('read/1', 'read_lax/1', 'read_term/1', 'read_term_lax/1',
                    'read', 'read_lax', 'read_term', 'read_term_lax') and arity == 1:
         return _execute_read_default_stream(state, 'fail')

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -849,6 +849,39 @@ test(runtime_parser_compiled_runs_read1_from_stdin) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_char_input_reads_from_stdin) :-
+	setup_call_cleanup(
+		(   retractall(user:py_char_input_demo),
+			assertz((user:py_char_input_demo :-
+				peek_char(C0), C0 = a,
+				get_char(C1), C1 = a,
+				get_code(Code), Code = 98,
+				peek_char(E0), E0 = end_of_file,
+				get_char(E1), E1 = end_of_file,
+				get_code(ECode), ECode = -1)),
+			user:python_parser_tmp_dir('tmp_wam_python_char_input', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_char_input_demo/0],
+				[runtime_parser(compiled)], ProjectDir),
+			atomic_list_concat([
+				"import io, sys",
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"old_stdin = sys.stdin",
+				"sys.stdin = io.StringIO('ab')",
+				"try:",
+				"    print(wr.run_wam(code, labels, 'py_char_input_demo/0', state))",
+				"finally:",
+				"    sys.stdin = old_stdin"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_char_input_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_runs_reverse_term_to_atom) :-
 	setup_call_cleanup(
 		(   retractall(user:py_term_to_atom_demo),


### PR DESCRIPTION
## Summary

- Add WAM-Python runtime support for `get_char/1`, `peek_char/1`, and `get_code/1` over `sys.stdin`.
- Add a per-state input pushback buffer so `peek_char/1` does not consume input and still works for non-seekable stdin-like streams.
- Reuse the same pushback path from `read/1`, so a peeked character remains visible to later term reads.
- Add a generated Python WAM test covering peek, char/code reads, and EOF behavior.

## Notes

EOF follows the common Prolog convention used by the existing builtin declarations: `get_char/1` and `peek_char/1` return `end_of_file`; `get_code/1` returns `-1`.

This intentionally covers the default input stream only. Stream-argument variants such as `get_char/2` are left for a later, broader stream API pass.

## Verification

- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
