### PR TITLE
feat(wam-python): support stdout char output builtins

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -1392,6 +1392,28 @@ def _execute_get_code(state: WamState) -> bool:
     return unify(get_reg(state, 1), value, state)
 
 
+def _execute_put_char(state: WamState) -> bool:
+    value = deref(get_reg(state, 1), state)
+    if not isinstance(value, Atom):
+        return False
+    text = _runtime_atom_text(value.name)
+    if len(text) != 1:
+        return False
+    sys.stdout.write(text)
+    return True
+
+
+def _execute_put_code(state: WamState) -> bool:
+    value = deref(get_reg(state, 1), state)
+    if not isinstance(value, Int) or value.n < 0:
+        return False
+    try:
+        sys.stdout.write(chr(value.n))
+    except (OverflowError, ValueError):
+        return False
+    return True
+
+
 def _execute_read_from_stream(state: WamState, stream: Any, target: Term,
                               syntax_default: str = 'fail',
                               read_char: Optional[Callable[[], str]] = None) -> bool:
@@ -1635,6 +1657,10 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return _execute_peek_char(state)
     if builtin in ('get_code/1', 'get_code') and arity == 1:
         return _execute_get_code(state)
+    if builtin in ('put_char/1', 'put_char') and arity == 1:
+        return _execute_put_char(state)
+    if builtin in ('put_code/1', 'put_code') and arity == 1:
+        return _execute_put_code(state)
     if builtin in ('read/1', 'read_lax/1', 'read_term/1', 'read_term_lax/1',
                    'read', 'read_lax', 'read_term', 'read_term_lax') and arity == 1:
         return _execute_read_default_stream(state, 'fail')

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -882,6 +882,40 @@ test(runtime_char_input_reads_from_stdin) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_char_output_writes_to_stdout) :-
+	setup_call_cleanup(
+		(   retractall(user:py_char_output_demo),
+			assertz((user:py_char_output_demo :-
+				put_char(a),
+				put_code(98),
+				put_code(10))),
+			user:python_parser_tmp_dir('tmp_wam_python_char_output', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_char_output_demo/0],
+				[runtime_parser(off)], ProjectDir),
+			atomic_list_concat([
+				"import io, sys",
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"old_stdout = sys.stdout",
+				"capture = io.StringIO()",
+				"sys.stdout = capture",
+				"try:",
+				"    ok = wr.run_wam(code, labels, 'py_char_output_demo/0', state)",
+				"finally:",
+				"    sys.stdout = old_stdout",
+				"print(repr(capture.getvalue()))",
+				"print(ok)"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "'ab\\n'")),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_char_output_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_runs_reverse_term_to_atom) :-
 	setup_call_cleanup(
 		(   retractall(user:py_term_to_atom_demo),
@@ -1384,6 +1418,8 @@ test(static_runtime_has_lua_baseline_builtins, [nondet]) :-
 		"\\\\+/1",
 		"write/1",
 		"display/1",
+		"put_char/1",
+		"put_code/1",
 		"nl/0"
 	]), sub_string(Content, _, _, _, Needle)).
 
@@ -1396,6 +1432,8 @@ test(static_runtime_naf_uses_isolated_goal_execution, [nondet]) :-
 test(static_runtime_io_emits_output, [nondet]) :-
 	runtime_py_path(P), read_file_to_string(P, Content, []),
 	sub_string(Content, _, _, _, "print(_format_value(get_reg(state, 1), state), end='')"),
+	sub_string(Content, _, _, _, "def _execute_put_char"),
+	sub_string(Content, _, _, _, "def _execute_put_code"),
 	sub_string(Content, _, _, _, "print()").
 
 :- end_tests(wam_python_builtin_parity_guard).


### PR DESCRIPTION
## Summary

- Add WAM-Python runtime support for `put_char/1` and `put_code/1` over `sys.stdout`.
- Validate `put_char/1` against one-character atoms and `put_code/1` against non-negative integer code points.
- Extend Python builtin parity guards for the new output predicates.
- Add a generated Python WAM test that captures stdout and verifies `put_char(a), put_code(98), put_code(10)` emits `ab\n`.

## Notes

This completes the default char/code I/O pair added after `get_char/1`, `peek_char/1`, and `get_code/1`. The implementation intentionally covers default stdout only; stream-argument variants remain a later stream API pass.

Invalid terms fail quietly, consistent with the current lax Python WAM builtin behavior.

## Verification

- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode),run_tests(wam_python_builtin_parity_guard)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
