### PR TITLE
fix(wam-fsharp): dispatchCall must reset WsCP when entering run for non-lowered predicates

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -2846,7 +2846,20 @@ and dispatchCall (ctx: WamContext) (pred: string) (sc: WamState) : WamState opti
     | Some sr -> Some sr
     | None ->
     match Map.tryFind pred ctx.WcLabels with
-    | Some pc -> run ctx { sc with WsPC = pc }
+    | Some pc ->
+        // Save the caller''s intended return PC and set WsCP = 0 before
+        // entering run.  Without this, the called predicate''s outermost
+        // Proceed sets WsPC = WsCP (the caller''s post-call PC), so the
+        // interpreter loop keeps executing the CALLER''s WAM continuation
+        // -- which is wrong when the caller is a lowered function that
+        // intends to handle its own continuation in F#.  Resetting WsCP
+        // to 0 makes Proceed stop the run loop (run returns on WsPC = 0);
+        // we restore WsCP before handing control back so the lowered
+        // caller''s subsequent Allocate sees the right value.
+        let savedCP = sc.WsCP
+        match run ctx { sc with WsPC = pc; WsCP = 0 } with
+        | Some sf -> Some { sf with WsCP = savedCP }
+        | None    -> None
     | None    -> None
 
 /// Foreign call for lowered functions.

--- a/tests/core/test_wam_fsharp_lowered_parser_smoke.pl
+++ b/tests/core/test_wam_fsharp_lowered_parser_smoke.pl
@@ -1,0 +1,177 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% test_wam_fsharp_lowered_parser_smoke.pl
+% F# WAM lowered emitter + compiled-parser end-to-end test.
+%
+% Exercises a focused subset of `read_term_from_atom/2` cases under
+% emit_mode(functions) with runtime_parser(compiled).  Companion to
+% test_wam_fsharp_lowered_smoke.pl (which covers runtime builtins under
+% lowered mode); this one specifically catches regressions in the
+% interaction between lowered predicates and the WAM interpreter's
+% `run` loop when calling non-lowered helpers (e.g. tokenize_loop/3,
+% take_digits/3) through dispatchCall.
+%
+% The cases below are deliberately the simple-shape parser inputs
+% (`'42'`, `'foo'`, `'a'`, `'(a)'`, `'-3'`) -- these are the ones that
+% surfaced the dispatchCall WsCP-propagation bug: when a lowered
+% predicate calls dispatchCall to enter an interpreted helper, the
+% helper's Proceed otherwise propagated WsCP into WsPC and the
+% interpreter loop kept running the LOWERED caller's WAM continuation
+% in addition to the F# continuation -- producing double-execution
+% state corruption.
+
+:- encoding(utf8).
+:- use_module('../../src/unifyweaver/targets/wam_fsharp_target',
+              [write_wam_fsharp_project/3]).
+:- use_module(library(filesex), [delete_directory_and_contents/1,
+                                  make_directory_path/1,
+                                  directory_file_path/3]).
+:- use_module(library(process)).
+:- use_module(library(readutil), [read_string/5]).
+
+:- dynamic user:fs_lp_int/0.
+:- dynamic user:fs_lp_foo/0.
+:- dynamic user:fs_lp_a/0.
+:- dynamic user:fs_lp_paren/0.
+:- dynamic user:fs_lp_minus/0.
+:- dynamic user:fs_lp_p_a/0.
+:- dynamic user:fs_lp_list/0.
+:- dynamic user:fs_lp_plus/0.
+
+run_dotnet(Args, Dir, ExitCode, Out) :-
+    process_create(path(dotnet), Args,
+        [cwd(Dir), stdout(pipe(O)), stderr(pipe(E)), process(Pid)]),
+    read_string(O, _, OS),
+    read_string(E, _, ES),
+    close(O), close(E),
+    process_wait(Pid, exit(ExitCode)),
+    atomic_list_concat([OS, '\n', ES], Out).
+
+main :-
+    retractall(user:fs_lp_int),
+    retractall(user:fs_lp_foo),
+    retractall(user:fs_lp_a),
+    retractall(user:fs_lp_paren),
+    retractall(user:fs_lp_minus),
+    retractall(user:fs_lp_p_a),
+    retractall(user:fs_lp_list),
+    retractall(user:fs_lp_plus),
+
+    assertz((user:fs_lp_int   :- read_term_from_atom('42', _T))),
+    assertz((user:fs_lp_foo   :- read_term_from_atom('foo', _T))),
+    assertz((user:fs_lp_a     :- read_term_from_atom('a', _T))),
+    assertz((user:fs_lp_paren :- read_term_from_atom('(a)', _T))),
+    assertz((user:fs_lp_minus :- read_term_from_atom('-3', _T))),
+    assertz((user:fs_lp_p_a   :- read_term_from_atom('p(a)', _T))),
+    assertz((user:fs_lp_list  :- read_term_from_atom('[1,2,3]', _T))),
+    assertz((user:fs_lp_plus  :- read_term_from_atom('1+2', _T))),
+
+    Dir = '/tmp/uw_fsharp_lowered_parser_repro',
+    catch(delete_directory_and_contents(Dir), _, true),
+    make_directory_path(Dir),
+
+    write_wam_fsharp_project(
+        [user:fs_lp_int/0, user:fs_lp_foo/0, user:fs_lp_a/0,
+         user:fs_lp_paren/0, user:fs_lp_minus/0, user:fs_lp_p_a/0,
+         user:fs_lp_list/0, user:fs_lp_plus/0],
+        [no_kernels(true),
+         emit_mode(functions),
+         runtime_parser(compiled),
+         module_name('uw_fs_lowered_parser_repro')],
+        Dir),
+    format('Project generated at ~w~n', [Dir]),
+
+    directory_file_path(Dir, 'Program.fs', ProgPath),
+    DriverCode = "module Program
+
+open WamTypes
+open WamRuntime
+open Predicates
+open Lowered
+
+let mutable passes = 0
+let mutable fails = 0
+
+let assertTrue (name: string) (cond: bool) =
+    if cond then
+        passes <- passes + 1
+        printfn \"[PASS] %s\" name
+    else
+        fails <- fails + 1
+        printfn \"[FAIL] %s\" name
+
+let mkContext () =
+    let foreignPreds : string list = []
+    let resolvedCode =
+        resolveCallInstrs allLabels foreignPreds (Array.toList allCode)
+        |> List.toArray
+    { WcCode              = resolvedCode
+      WcLabels            = allLabels
+      WcForeignFacts      = Map.empty
+      WcFfiFacts          = Map.empty
+      WcFfiWeightedFacts  = Map.empty
+      WcAtomIntern        = Map.empty
+      WcAtomDeintern      = Map.empty
+      WcForeignConfig     = Map.empty
+      WcLoweredPredicates = loweredPredicates
+      WcCancellationToken = None }
+
+let mkState () : WamState =
+    { WsPC         = 0
+      WsRegs       = Array.create MaxRegs (Unbound -1)
+      WsStack      = []
+      WsHeap       = []
+      WsHeapLen    = 0
+      WsTrail      = []
+      WsTrailLen   = 0
+      WsCP         = 0
+      WsCPs        = []
+      WsCPsLen     = 0
+      WsBindings   = Map.empty
+      WsCutBar     = 0
+      WsVarCounter = 0
+      WsBuilder    = None
+      WsBuilderStack = []
+      WsAggAccum   = []
+      WsB0Stack    = [] }
+
+let runPredicate (predKey: string) =
+    let ctx = mkContext ()
+    let s = mkState ()
+    match dispatchCall ctx predKey s with
+    | Some s1 ->
+        match run ctx s1 with
+        | Some _ -> true
+        | None   -> false
+    | None -> false
+
+[<EntryPoint>]
+let main _argv =
+    assertTrue \"read_term_from_atom('42', T)\"      (runPredicate \"fs_lp_int/0\")
+    assertTrue \"read_term_from_atom('foo', T)\"     (runPredicate \"fs_lp_foo/0\")
+    assertTrue \"read_term_from_atom('a', T)\"       (runPredicate \"fs_lp_a/0\")
+    assertTrue \"read_term_from_atom('(a)', T)\"     (runPredicate \"fs_lp_paren/0\")
+    assertTrue \"read_term_from_atom('-3', T)\"      (runPredicate \"fs_lp_minus/0\")
+    assertTrue \"read_term_from_atom('p(a)', T)\"    (runPredicate \"fs_lp_p_a/0\")
+    assertTrue \"read_term_from_atom('[1,2,3]', T)\" (runPredicate \"fs_lp_list/0\")
+    assertTrue \"read_term_from_atom('1+2', T)\"     (runPredicate \"fs_lp_plus/0\")
+
+    printfn \"RESULT %d/%d\" passes (passes + fails)
+    if fails > 0 then 1 else 0
+",
+    open(ProgPath, write, OW, [encoding(utf8)]),
+    write(OW, DriverCode),
+    close(OW),
+
+    format('Building...~n'),
+    run_dotnet(['build', '--nologo', '-v', 'minimal'], Dir, BuildExit, BuildOut),
+    (   BuildExit == 0
+    ->  format('Build OK.~n')
+    ;   format('--- build output ---~n~w~n----~n', [BuildOut]),
+        format('BUILD FAILED~n'),
+        halt(1)
+    ),
+
+    format('Running...~n'),
+    run_dotnet(['run', '--no-build', '--nologo'], Dir, RunExit, RunOut),
+    format('--- run output (exit=~w) ---~n~w~n----~n', [RunExit, RunOut]).


### PR DESCRIPTION
## Summary

Fixes the parser-smoke-in-lowered-mode regressions noted in #2422.  Previously the parser smoke test passed 18/42 under `emit_mode(functions)` (vs 42/42 under the default interpreter mode).  After this PR it passes **42/42** in both modes.

## Root cause

When a lowered F# function called `dispatchCall` for a predicate that wasn't itself lowered, `dispatchCall` fell through to the interpreter's labels case:

```fsharp
| Some pc -> run ctx { sc with WsPC = pc }
```

But `sc.WsCP` was whatever the lowered caller had stashed there — the caller's intended post-call F# continuation, often a WAM PC pointing into the caller's lowered-from-WAM body (e.g. `PC 1627`).  So when the called predicate's outermost `Proceed` fired:

1. It set `WsPC = WsCP = 1627`
2. `run` happily kept going at PC 1627
3. That was the caller's WAM continuation — `run` executed it in the interpreter
4. Then control returned to the F# lowered caller, which executed its OWN F# continuation
5. Same WAM instructions ran twice; state corrupted

So calling a non-lowered helper from a lowered predicate didn't return at the call boundary — it bled into the caller's WAM body inside `run` before returning to the F# caller.

### Curiously: long inputs passed, short ones failed

A weird symptom of this bug: parser inputs that exercised many of `dispatchCall` paths (`'a + b * c'`, `':- p'`, `'X is 1+2'`) all passed in lowered mode, while the short ones (`'42'`, `'foo'`, `'a'`, `'(a)'`) all failed.  Reason: the long ones corrupted state in a way that still produced a "success" termination by accident (the extra interpreter runs eventually hit a `WsPC = 0`).  The short paths failed cleanly.

## Fix

In `dispatchCall`, snapshot `sc.WsCP`, set it to `0` before `run`, then restore on return:

```fsharp
| Some pc ->
    let savedCP = sc.WsCP
    match run ctx { sc with WsPC = pc; WsCP = 0 } with
    | Some sf -> Some { sf with WsCP = savedCP }
    | None    -> None
```

This matches the expected boundary semantics: when the callee's outermost `Proceed` fires, `WsPC = WsCP = 0`, `run` returns at the line `if s.WsPC = 0 then Some s` — and only then does the lowered caller resume its F# continuation.

## Regression test

Adds `tests/core/test_wam_fsharp_lowered_parser_smoke.pl` — a focused 8-case parser smoke under `emit_mode(functions)` + `runtime_parser(compiled)`, covering the simple-shape inputs (`'42'`, `'foo'`, `'a'`, `'(a)'`, `'-3'`, `'p(a)'`, `'[1,2,3]'`, `'1+2'`) that surfaced the bug.

| Test | Before this PR | After |
| --- | --- | --- |
| `test_wam_fsharp_lowered_parser_smoke.pl` (new) | 0/8 | **8/8** |
| `test_wam_fsharp_parser_smoke.pl` (full, under `emit_mode(functions)`, manually verified) | 18/42 | **42/42** |
| `test_wam_fsharp_parser_smoke.pl` (default interpreter mode) | 42/42 | 42/42 (no regression) |
| `test_wam_fsharp_lowered_smoke.pl` (runtime preds in lowered mode) | 19/19 | 19/19 (no regression) |
| `test_wam_fsharp_runtime_smoke.pl` (interpreter mode) | 19/19 | 19/19 (no regression) |
| `test_wam_fsharp_target.pl` (unit tests) | all pass | all pass |

## Test plan

- [x] Reproduced the original bug with a minimal isolated test (`fs_int :- read_term_from_atom('42', _T)` under `emit_mode(functions)` failed)
- [x] Instrumented the generated `Lowered.fs` chain step-by-step until the failure surfaced inside `dispatchCall` -> `run` -> `tokenize_loop/3`'s Proceed bleeding into the caller's WAM continuation
- [x] After fix: 8/8 on the new focused smoke; 42/42 on the full parser smoke run in `emit_mode(functions)` mode
- [x] No regressions in any existing smoke or unit test (parallel run)
- [ ] CI green on `claude/wam-fsharp-lowered-parser-fix`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_