### PR TITLE
feat(wam-python): support stream char builtins

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -133,6 +133,7 @@ class WamState:
         self.catcher_frames: List[CatcherFrame] = []
         self.temp_y_regs: Optional[List] = None
         self.input_pushback: List[str] = []
+        self.stream_pushback: Dict[int, List[str]] = {}
 
     def fresh_var(self) -> Var:
         v = Var(ref=[None], id=self._var_counter)
@@ -1374,44 +1375,132 @@ def _peek_default_char(state: WamState) -> str:
     return ch
 
 
+def _stream_pushback_key(stream: Any) -> int:
+    return id(_unwrap_stream(stream))
+
+
+def _read_handle_char(state: WamState, stream: Any) -> Optional[str]:
+    raw = _unwrap_stream(stream)
+    if raw is None or not hasattr(raw, 'read'):
+        return None
+    key = id(raw)
+    chars = state.stream_pushback.get(key)
+    if chars:
+        return chars.pop()
+    return _read_stream_char(raw)
+
+
+def _peek_handle_char(state: WamState, stream: Any) -> Optional[str]:
+    ch = _read_handle_char(state, stream)
+    if ch is not None and ch != '':
+        state.stream_pushback.setdefault(_stream_pushback_key(stream), []).append(ch)
+    return ch
+
+
+def _char_atom_value(ch: str) -> Atom:
+    return make_atom('end_of_file') if ch == '' else make_atom(ch)
+
+
+def _code_value(ch: str) -> Int:
+    return Int(-1) if ch == '' else Int(ord(ch))
+
+
+def _output_atom_char_text(value: Term, state: WamState) -> Optional[str]:
+    value = deref(value, state)
+    if not isinstance(value, Atom):
+        return None
+    text = _runtime_atom_text(value.name)
+    return text if len(text) == 1 else None
+
+
+def _output_code_text(value: Term, state: WamState) -> Optional[str]:
+    value = deref(value, state)
+    if not isinstance(value, Int) or value.n < 0:
+        return None
+    try:
+        return chr(value.n)
+    except (OverflowError, ValueError):
+        return None
+
+
+def _write_stream_char(stream: Any, text: str) -> bool:
+    stream = _unwrap_stream(stream)
+    if stream is None or not hasattr(stream, 'write'):
+        return False
+    try:
+        stream.write(text)
+    except OSError:
+        return False
+    return True
+
+
 def _execute_get_char(state: WamState) -> bool:
     ch = _read_default_char(state)
-    value = make_atom('end_of_file') if ch == '' else make_atom(ch)
-    return unify(get_reg(state, 1), value, state)
+    return unify(get_reg(state, 1), _char_atom_value(ch), state)
 
 
 def _execute_peek_char(state: WamState) -> bool:
     ch = _peek_default_char(state)
-    value = make_atom('end_of_file') if ch == '' else make_atom(ch)
-    return unify(get_reg(state, 1), value, state)
+    return unify(get_reg(state, 1), _char_atom_value(ch), state)
 
 
 def _execute_get_code(state: WamState) -> bool:
     ch = _read_default_char(state)
-    value = Int(-1) if ch == '' else Int(ord(ch))
-    return unify(get_reg(state, 1), value, state)
+    return unify(get_reg(state, 1), _code_value(ch), state)
+
+
+def _execute_get_char_stream(state: WamState) -> bool:
+    stream = deref(get_reg(state, 1), state)
+    ch = _read_handle_char(state, stream)
+    if ch is None:
+        return False
+    return unify(get_reg(state, 2), _char_atom_value(ch), state)
+
+
+def _execute_peek_char_stream(state: WamState) -> bool:
+    stream = deref(get_reg(state, 1), state)
+    ch = _peek_handle_char(state, stream)
+    if ch is None:
+        return False
+    return unify(get_reg(state, 2), _char_atom_value(ch), state)
+
+
+def _execute_get_code_stream(state: WamState) -> bool:
+    stream = deref(get_reg(state, 1), state)
+    ch = _read_handle_char(state, stream)
+    if ch is None:
+        return False
+    return unify(get_reg(state, 2), _code_value(ch), state)
 
 
 def _execute_put_char(state: WamState) -> bool:
-    value = deref(get_reg(state, 1), state)
-    if not isinstance(value, Atom):
-        return False
-    text = _runtime_atom_text(value.name)
-    if len(text) != 1:
+    text = _output_atom_char_text(get_reg(state, 1), state)
+    if text is None:
         return False
     sys.stdout.write(text)
     return True
 
 
 def _execute_put_code(state: WamState) -> bool:
-    value = deref(get_reg(state, 1), state)
-    if not isinstance(value, Int) or value.n < 0:
+    text = _output_code_text(get_reg(state, 1), state)
+    if text is None:
         return False
-    try:
-        sys.stdout.write(chr(value.n))
-    except (OverflowError, ValueError):
-        return False
+    sys.stdout.write(text)
     return True
+
+
+def _execute_put_char_stream(state: WamState) -> bool:
+    text = _output_atom_char_text(get_reg(state, 2), state)
+    if text is None:
+        return False
+    return _write_stream_char(deref(get_reg(state, 1), state), text)
+
+
+def _execute_put_code_stream(state: WamState) -> bool:
+    text = _output_code_text(get_reg(state, 2), state)
+    if text is None:
+        return False
+    return _write_stream_char(deref(get_reg(state, 1), state), text)
 
 
 def _execute_read_from_stream(state: WamState, stream: Any, target: Term,
@@ -1441,11 +1530,16 @@ def _execute_read_from_stream(state: WamState, stream: Any, target: Term,
 
 
 def _execute_read(state: WamState, syntax_default: str = 'fail') -> bool:
+    stream = deref(get_reg(state, 1), state)
+    raw = _unwrap_stream(stream)
+    if raw is None or not hasattr(raw, 'read'):
+        return False
     return _execute_read_from_stream(
         state,
-        deref(get_reg(state, 1), state),
+        stream,
         get_reg(state, 2),
         syntax_default,
+        lambda: _read_handle_char(state, stream) or '',
     )
 
 
@@ -1653,14 +1747,24 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return _execute_close(state)
     if builtin in ('get_char/1', 'get_char') and arity == 1:
         return _execute_get_char(state)
+    if builtin in ('get_char/2',) and arity == 2:
+        return _execute_get_char_stream(state)
     if builtin in ('peek_char/1', 'peek_char') and arity == 1:
         return _execute_peek_char(state)
+    if builtin in ('peek_char/2',) and arity == 2:
+        return _execute_peek_char_stream(state)
     if builtin in ('get_code/1', 'get_code') and arity == 1:
         return _execute_get_code(state)
+    if builtin in ('get_code/2',) and arity == 2:
+        return _execute_get_code_stream(state)
     if builtin in ('put_char/1', 'put_char') and arity == 1:
         return _execute_put_char(state)
+    if builtin in ('put_char/2',) and arity == 2:
+        return _execute_put_char_stream(state)
     if builtin in ('put_code/1', 'put_code') and arity == 1:
         return _execute_put_code(state)
+    if builtin in ('put_code/2',) and arity == 2:
+        return _execute_put_code_stream(state)
     if builtin in ('read/1', 'read_lax/1', 'read_term/1', 'read_term_lax/1',
                    'read', 'read_lax', 'read_term', 'read_term_lax') and arity == 1:
         return _execute_read_default_stream(state, 'fail')

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2003,10 +2003,15 @@ is_builtin_pred(term_to_atom, 2). % bidirectional canonical-form term ↔ atom.
 is_builtin_pred(read, 1).         % stdin: read a term terminated by `.`.
 is_builtin_pred(read_term, 1).    % alias for read/1.
 is_builtin_pred(get_char, 1).     % stdin: read one char as atom.
+is_builtin_pred(get_char, 2).     % stream: read one char as atom.
 is_builtin_pred(get_code, 1).     % stdin: read one char as int code.
+is_builtin_pred(get_code, 2).     % stream: read one char as int code.
 is_builtin_pred(peek_char, 1).    % stdin: peek one char (un-consumed).
+is_builtin_pred(peek_char, 2).    % stream: peek one char (un-consumed).
 is_builtin_pred(put_char, 1).     % stdout: write one single-char atom.
+is_builtin_pred(put_char, 2).     % stream: write one single-char atom.
 is_builtin_pred(put_code, 1).     % stdout: write one int code as char.
+is_builtin_pred(put_code, 2).     % stream: write one int code as char.
 is_builtin_pred(atomic_list_concat, 2). % concatenate list of atomics.
 is_builtin_pred(atomic_list_concat, 3). % concat with separator (or split).
 is_builtin_pred(atom_string, 2).        % atom ↔ string (interchangeable).

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -916,6 +916,49 @@ test(runtime_char_output_writes_to_stdout) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_stream_char_io_reads_and_writes_files) :-
+	setup_call_cleanup(
+		(   retractall(user:py_stream_char_io_demo),
+			user:python_parser_tmp_dir('tmp_wam_python_stream_char_io', ProjectDir),
+			atomic_list_concat([ProjectDir, '/chars_in.txt'], InFile),
+			atomic_list_concat([ProjectDir, '/chars_out.txt'], OutFile),
+			assertz((user:py_stream_char_io_demo :-
+				open(InFile, read, In),
+				peek_char(In, C0), C0 = a,
+				get_char(In, C1), C1 = a,
+				get_code(In, Code), Code = 98,
+				peek_char(In, E0), E0 = end_of_file,
+				get_char(In, E1), E1 = end_of_file,
+				get_code(In, ECode), ECode = -1,
+				close(In),
+				open(OutFile, write, Out),
+				put_char(Out, x),
+				put_code(Out, 121),
+				put_code(Out, 10),
+				close(Out)))
+		),
+		(   setup_call_cleanup(open(InFile, write, Input),
+				write(Input, ab),
+				close(Input)),
+			wam_python_target:write_wam_python_project([user:py_stream_char_io_demo/0],
+				[runtime_parser(off)], ProjectDir),
+			atomic_list_concat([
+				"import pathlib",
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"ok = wr.run_wam(code, labels, 'py_stream_char_io_demo/0', state)",
+				"print(ok)",
+				"print(repr(pathlib.Path('chars_out.txt').read_text()))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True")),
+			once(sub_string(Output, _, _, _, "'xy\\n'"))
+		),
+		(   retractall(user:py_stream_char_io_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_runs_reverse_term_to_atom) :-
 	setup_call_cleanup(
 		(   retractall(user:py_term_to_atom_demo),
@@ -1419,7 +1462,12 @@ test(static_runtime_has_lua_baseline_builtins, [nondet]) :-
 		"write/1",
 		"display/1",
 		"put_char/1",
+		"put_char/2",
 		"put_code/1",
+		"put_code/2",
+		"get_char/2",
+		"get_code/2",
+		"peek_char/2",
 		"nl/0"
 	]), sub_string(Content, _, _, _, Needle)).
 


### PR DESCRIPTION
## Summary

- Add WAM-Python runtime support for stream-argument char/code I/O: `get_char/2`, `peek_char/2`, `get_code/2`, `put_char/2`, and `put_code/2`.
- Register those arity-2 predicates in the shared WAM builtin catalog.
- Add per-stream pushback keyed by host stream identity so `peek_char/2` does not consume input.
- Route `read/2` through the same stream pushback path so a peeked character remains visible to later term reads.
- Add a generated Python WAM test that reads and writes characters through files opened by `open/3`.

## Notes

EOF behavior matches the default-stream variants: char predicates return `end_of_file`; code predicates return `-1`.

`put_char/2` accepts one-character atoms. `put_code/2` accepts non-negative integer code points. Invalid stream or value terms fail quietly, matching the current lax Python WAM builtin behavior.

## Verification

- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode),run_tests(wam_python_builtin_parity_guard)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
