### PR TITLE
perf(wam-fsharp): putReg in-place mutation — ~2-3x speedup across all workloads

### DIFF
--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -460,26 +460,29 @@ let getReg (n: int) (s: WamState) : Value option =
         | v -> Some (derefVar s.WsBindings v)
     else None
 
-/// Set a register value (copy-on-write for snapshot semantics).
+/// Set a register value.  Mutates WsRegs in place for X-regs and the WsRegs
+/// mirror of Y-regs; the env-frame EfYRegs Map is updated via the normal
+/// record-with allocation.
+///
+/// In-place mutation is safe because WAM state ownership is single-threaded
+/// in this runtime: each step returns the new state, the caller uses it,
+/// and the previous reference is dead.  CPs snapshot WsRegs via an explicit
+/// Array.copy at TryMeElse / BeginAggregate / FactRetry / etc., so any
+/// subsequent in-place write doesn't bleed back into the CP's saved regs.
+/// Removing the previous per-write Array.copy of the 512-entry MaxRegs
+/// array dropped putReg from ~32% of CPU time (per dotnet-trace on the
+/// parser-heavy benchmark) to near zero.
 let putReg (n: int) (v: Value) (s: WamState) : WamState =
-    // Y register write -- update BOTH the env frame''s EfYRegs (so
-    // values survive being clobbered by a called predicate writing
-    // to the same numeric slot) AND WsRegs (so direct-array reads
-    // in code that hasn''t been audited still see the value).  Read
-    // path prefers the frame, then falls back to WsRegs.
     if n >= 201 then
-        let r = Array.copy s.WsRegs
-        if n < r.Length then r.[n] <- v
+        if n < s.WsRegs.Length then s.WsRegs.[n] <- v
         match s.WsStack with
         | frame :: rest ->
             let newFrame = { frame with EfYRegs = Map.add (n - 200) v frame.EfYRegs }
-            { s with WsRegs = r; WsStack = newFrame :: rest }
-        | [] ->
-            { s with WsRegs = r }
+            { s with WsStack = newFrame :: rest }
+        | [] -> s
     else
-        let r = Array.copy s.WsRegs
-        r.[n] <- v
-        { s with WsRegs = r }
+        if n >= 0 && n < s.WsRegs.Length then s.WsRegs.[n] <- v
+        s
 
 /// Set a register value in-place (use only when no snapshot is needed).
 let setReg (n: int) (v: Value) (regs: Value array) : Value array =

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -385,7 +385,11 @@ and backtrack (s: WamState) : WamState option =
         // surfaced this.
         Some { s with
                  WsPC       = cp.CpNextPC
-                 WsRegs     = cp.CpRegs
+                 // Array.copy: cp stays on the stack across backtracks (so
+                 // RetryMeElse can modify it), and putReg now mutates
+                 // WsRegs in place.  Without copying here, in-place writes
+                 // after a restore would corrupt the CP''s saved registers.
+                 WsRegs     = Array.copy cp.CpRegs
                  WsStack    = cp.CpStack
                  WsCP       = cp.CpCP
                  WsTrail    = List.skip diff s.WsTrail
@@ -593,7 +597,9 @@ and finalizeAggregate (returnPC: int) (s: WamState) : WamState option =
                         , Map.add vid result cp.CpBindings
                         , { TrailVarId = vid; TrailOldVal = Map.tryFind vid cp.CpBindings } :: restoredTrail
                         , cp.CpTrailLen + 1 )
-                    | _ -> (cp.CpRegs, cp.CpBindings, restoredTrail, cp.CpTrailLen)
+                    // Array.copy: putReg now mutates WsRegs in place, so the
+                    // finalize''d state must not alias cp.CpRegs.
+                    | _ -> (Array.copy cp.CpRegs, cp.CpBindings, restoredTrail, cp.CpTrailLen)
                 Some { s with
                          WsPC       = returnPC
                          WsRegs     = finalRegs


### PR DESCRIPTION
## Summary

Profiled the parser-heavy benchmark from #2426 with `dotnet-trace`.  **`putReg` was consuming ~32% of total CPU time** (33 s of 105 s) — almost entirely from the unconditional `Array.copy` of the 512-entry `MaxRegs` array on every register write.

Switched `putReg` to mutate `WsRegs` in place, with a compensating `Array.copy` moved into `backtrack` (a much rarer event).  **~2-3x runtime speedup across all workloads.**

## Why in-place mutation is safe here

WAM state ownership in this runtime is single-threaded: each `step` returns the new state, the caller uses it, and the previous reference is dead by the time the next `putReg` fires.  CPs snapshot `WsRegs` via an explicit `Array.copy` at creation time (`TryMeElse`, `BeginAggregate`, `FactRetry`, `SelectRetry`, `MemberRetry`), so subsequent in-place writes don't bleed into a CP's saved registers.

There was one aliasing hole I had to plug: `backtrack`'s restore set `WsRegs = cp.CpRegs` directly, so after the restore the live state's `WsRegs` was the CP's saved array.  Per #2350 the CP stays on the stack across backtracks (so `RetryMeElse` can mutate its `CpNextPC`), which means an in-place `putReg` after restore would corrupt the CP and break the next backtrack.  Fix: moved the `Array.copy` from `putReg` to `backtrack` (and `finalizeAggregate`'s non-bind fallback).

## Benchmark results

Numbers from `tests/core/test_wam_fsharp_lowered_bench.pl` (the benchmark added in #2426), two stable runs each:

| workload | iter | mode | before | after | speedup |
| --- | ---: | --- | ---: | ---: | ---: |
| `parser_heavy` | 10k | interpreter | 43–62 s | 22–23 s | **~2x** |
| `parser_heavy` | 10k | functions | 44–60 s | 22 s | **~2x** |
| `fully_lowered` | 200k | interpreter | 5.3–7.1 s | 2.1 s | **~3x** |
| `fully_lowered` | 200k | functions | 5.0–6.4 s | 1.8–1.9 s | **~3x** |

Note the speedup benefits **both** `emit_mode(interpreter)` and `emit_mode(functions)` equally — which means the original choice to keep `interpreter` as the default still stands (see #2426).  Everyone just gets faster.

## Where the new top of the profile sits

After this fix, `putReg` dropped out of the top-20 hot functions.  The new hot spot (per re-profile) is the `backtrack` body itself (~25% of CPU) — specifically the trail-undo path (`List.take` + `List.rev` + `List.fold` over `s.WsTrail`) plus the `Array.copy` I added on restore.  Those would be the next thing to optimise; I'm leaving them for a follow-up so this PR stays focused.

## Test plan

- [x] `test_wam_fsharp_lowered_smoke.pl` → 19/19
- [x] `test_wam_fsharp_lowered_parser_smoke.pl` → 8/8
- [x] `test_wam_fsharp_runtime_smoke.pl` → 19/19
- [x] `test_wam_fsharp_parser_smoke.pl` → 42/42
- [x] `test_wam_fsharp_target.pl` unit tests → all pass
- [x] Bench re-run after the fix: stable ~2x faster (parser) and ~3x faster (fully-lowered) across both emit modes
- [ ] CI green on `claude/wam-fsharp-putreg-mutate-in-place`

## Relationship to #2426

#2426 was supposed to be a "negative finding" PR — we couldn't justify flipping the default to `emit_mode(functions)` because the speedup was tiny (~6%).  After this PR, **the relative speedup of `functions` over `interpreter` is still tiny (~6%)** — but **the absolute baseline is ~2-3x faster**.  Recommendation in #2426 stands: don't flip the default.  This PR is the actual win the benchmark was originally trying to find.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_