### PR TITLE
chore(wam-fsharp): silence target-source discontiguous + singleton warnings (by moving clauses)

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
@@ -337,18 +337,6 @@ emit_instrs_lm_fs([pc(_PC, try_me_else(ElseLabelStr))|Rest], SV, Ind, FP, LM) :-
         emit_instrs_lm_fs(ContInstrs, SVcont, ContInd, FP, LM),
         format("~w| None -> None~n", [Ind])
     ).
-emit_ite_match_fs(SV, CondInstrs, ThenInstrs, ElseInstrs, Ind, FP) :-
-    format("~wmatch (~n", [Ind]),
-    atom_concat(Ind, "    ", CondInd),
-    emit_ite_block_fs(CondInstrs, SV, CondInd, FP),
-    format("~w) with~n", [Ind]),
-    fresh_sv_fs(SV, SVthen),
-    format("~w| Some ~w ->~n", [Ind, SVthen]),
-    atom_concat(Ind, "    ", ThenInd),
-    emit_ite_block_fs(ThenInstrs, SVthen, ThenInd, FP),
-    format("~w| None ->~n", [Ind]),
-    atom_concat(Ind, "    ", ElseInd),
-    emit_ite_block_fs(ElseInstrs, SV, ElseInd, FP).
 
 % execute/1 is a tail call — it must always be the last instruction.
 % If it isn’t, the chain silently breaks because emit_one_fs emits a bare
@@ -389,6 +377,23 @@ emit_instrs_lm_fs([pc(PC, Instr)|Rest], SV, Ind, FP, LM) :-
         ;   emit_instrs_lm_fs(Rest, SVout, Ind, FP, LM)
         )
     ).
+
+%% emit_ite_match_fs(+SV, +CondInstrs, +ThenInstrs, +ElseInstrs, +Ind, +FP)
+%  Helper for emit_instrs_lm_fs's try_me_else clause: emits the F# nested
+%  match for an if-then-else block.  Placed after the emit_instrs_lm_fs
+%  clause group so the latter is contiguous.
+emit_ite_match_fs(SV, CondInstrs, ThenInstrs, ElseInstrs, Ind, FP) :-
+    format("~wmatch (~n", [Ind]),
+    atom_concat(Ind, "    ", CondInd),
+    emit_ite_block_fs(CondInstrs, SV, CondInd, FP),
+    format("~w) with~n", [Ind]),
+    fresh_sv_fs(SV, SVthen),
+    format("~w| Some ~w ->~n", [Ind, SVthen]),
+    atom_concat(Ind, "    ", ThenInd),
+    emit_ite_block_fs(ThenInstrs, SVthen, ThenInd, FP),
+    format("~w| None ->~n", [Ind]),
+    atom_concat(Ind, "    ", ElseInd),
+    emit_ite_block_fs(ElseInstrs, SV, ElseInd, FP).
 
 %% emit_instrs_fs(+PCInstrs, +CurrentStateVar, +Indent, +ForeignPreds)
 %  Legacy 4-arg version used inside ITE blocks (LabelMap not needed there

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -3726,31 +3726,6 @@ wam_instr_to_fsharp(["switch_on_term_a2", CLenS | Rest], Fs) :-
     format(string(Fs), 'SwitchOnTerm (~w, ~w, "~w")',
            [ConstArr, StructArr, ListLabel]).
 
-%% fs_parse_switch_term_entries(+Entries, -Pairs)
-%
-% Parse "key:label" string entries into (Key, Label) pairs.  Mirrors
-% fs_parse_switch_entries but returns string keys (no value-typing)
-% because SwitchOnTerm always keys by atom-name or "F/N" string.
-fs_parse_switch_term_entries([], []).
-fs_parse_switch_term_entries([E|Rest], [(K, L)|Pairs]) :-
-    fs_clean_comma(E, ECl),
-    atom_string(EA, ECl),
-    (   sub_atom(EA, Before, 1, _, ':')
-    ->  sub_atom(EA, 0, Before, _, KA),
-        After is Before + 1,
-        sub_atom(EA, After, _, 0, LA),
-        atom_string(KA, K),
-        atom_string(LA, L)
-    ;   K = ECl,
-        L = "default"
-    ),
-    fs_parse_switch_term_entries(Rest, Pairs).
-
-fs_term_entries_to_array_literal([], "[||]") :- !.
-fs_term_entries_to_array_literal(Pairs, Literal) :-
-    maplist([(K, L), S]>>format(string(S), '("~w", "~w")', [K, L]), Pairs, Strs),
-    atomic_list_concat(Strs, '; ', Joined),
-    format(string(Literal), '[| ~w |]', [Joined]).
 wam_instr_to_fsharp(["begin_aggregate", Type, ValReg, ResReg], Fs) :-
     fs_clean_comma(Type, CT), fs_clean_comma(ValReg, CV), fs_clean_comma(ResReg, CR),
     fs_reg_name_to_int(CV, VI), fs_reg_name_to_int(CR, RI),
@@ -3848,6 +3823,35 @@ wam_instr_to_fsharp(Parts, Fs) :-
     ;   true
     ),
     format(string(Fs), '(* UNKNOWN: ~w *) Proceed', [Joined]).
+
+%% fs_parse_switch_term_entries(+Entries, -Pairs)
+%
+% Parse "key:label" string entries into (Key, Label) pairs.  Mirrors
+% fs_parse_switch_entries but returns string keys (no value-typing)
+% because SwitchOnTerm always keys by atom-name or "F/N" string.
+% Placed after the wam_instr_to_fsharp clause group so the latter is
+% contiguous; callers are the switch_on_term / switch_on_term_a2
+% clauses above.
+fs_parse_switch_term_entries([], []).
+fs_parse_switch_term_entries([E|Rest], [(K, L)|Pairs]) :-
+    fs_clean_comma(E, ECl),
+    atom_string(EA, ECl),
+    (   sub_atom(EA, Before, 1, _, ':')
+    ->  sub_atom(EA, 0, Before, _, KA),
+        After is Before + 1,
+        sub_atom(EA, After, _, 0, LA),
+        atom_string(KA, K),
+        atom_string(LA, L)
+    ;   K = ECl,
+        L = "default"
+    ),
+    fs_parse_switch_term_entries(Rest, Pairs).
+
+fs_term_entries_to_array_literal([], "[||]") :- !.
+fs_term_entries_to_array_literal(Pairs, Literal) :-
+    maplist([(K, L), S]>>format(string(S), '("~w", "~w")', [K, L]), Pairs, Strs),
+    atomic_list_concat(Strs, '; ', Joined),
+    format(string(Literal), '[| ~w |]', [Joined]).
 
 %% fs_parse_switch_entries(+Entries, -FSharpPairs)
 fs_parse_switch_entries([], []).
@@ -4074,7 +4078,11 @@ open WamRuntime
 ', [AllPredCode, MergedCodeBuild]).
 
 compile_one_predicate_fs(Options, BasePCMap, PredIndicator, Code) :-
-    (   PredIndicator = _M:Pred/Arity -> true ; PredIndicator = Pred/Arity ),
+    %% Shape check: must be Module:Name/Arity or Name/Arity.  The
+    %% destructured Pred/Arity aren't used further (we pass
+    %% PredIndicator wholesale to the helpers below); underscore-
+    %% prefix the names so SWI doesn't flag them as singletons.
+    (   PredIndicator = _M:_Pred/_Arity -> true ; PredIndicator = _Pred/_Arity ),
     wam_fsharp_predicate_wamcode(PredIndicator, WamCode),
     predicate_base_pc_fs(PredIndicator, BasePCMap, BasePC),
     compile_wam_predicate_to_fsharp(PredIndicator, WamCode, [base_pc(BasePC)|Options], Code).


### PR DESCRIPTION
## Summary

Three warnings have been appearing on every `swipl` load of the F# target for the last ~10 PRs.  All three were code-organisation issues, not suppress-with-directive cases — so per your guidance I fixed them by moving clauses rather than adding `:- discontiguous` directives.

## What was fixed

### 1. `emit_instrs_lm_fs/5` discontiguous (`wam_fsharp_lowered_emitter.pl`)

`emit_ite_match_fs/6` was defined between the 2nd and 3rd clauses of `emit_instrs_lm_fs/5`, sandwiching it.  Moved `emit_ite_match_fs/6` out to sit after **all** `emit_instrs_lm_fs/5` clauses; it's only called from inside that group's `try_me_else` clause, so the new location reads naturally as "helper appears right after its caller group."

### 2. `wam_instr_to_fsharp/2` discontiguous (`wam_fsharp_target.pl`)

`fs_parse_switch_term_entries/2` and `fs_term_entries_to_array_literal/2` (two helpers for the `SwitchOnTerm` encoding) sat between the `switch_on_term*` and `begin_aggregate` clauses of `wam_instr_to_fsharp/2`, splitting the predicate.  Moved both helpers to after the `wam_instr_to_fsharp/2` catch-all clause — same rationale: they're only called from the `switch_on_term*` clauses above, so the new location keeps them adjacent to the use-site group.

### 3. `compile_one_predicate_fs/4` singleton `Pred` / `Arity`

The shape-check disjunction
```prolog
( PredIndicator = _M:Pred/Arity -> true ; PredIndicator = Pred/Arity )
```
binds `Pred` and `Arity` but neither is used in the body (which passes `PredIndicator` wholesale to its helpers).  Renamed to `_Pred` / `_Arity` — preserves the shape-check semantics, makes the "intentionally unused" intent explicit, and silences the warning.  Not a clause-move case; the prefix-underscore convention is the idiomatic Prolog fix for this shape of singleton.

## Verification

- `swipl` load of both files now produces **no warnings** (only the pre-existing test-file warnings about `read_string/5` + `_T` singleton remain; those are in `tests/core/`, out of scope here)
- `test_wam_fsharp_lowered_smoke.pl` → 19/19
- `test_wam_fsharp_lowered_parser_smoke.pl` → 8/8
- `test_wam_fsharp_runtime_smoke.pl` → 19/19
- `test_wam_fsharp_parser_smoke.pl` → 42/42
- `test_wam_fsharp_target.pl` unit tests → all pass

## Test plan

- [x] Both target files load without warnings
- [x] Every smoke + unit test passes
- [ ] CI green on `claude/wam-fsharp-fix-warnings`

No behaviour change — this is purely a code-organisation cleanup.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_