### PR TITLE
fix(wam-rust): lowered emitter strips quotes from atom tokens (backport of F# #2422)

### DIFF
--- a/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
@@ -23,6 +23,7 @@
 
 :- use_module(library(lists)).
 :- use_module(wam_rust_target, [escape_rust_string/2]).
+:- use_module(wam_text_parser, [wam_classify_constant_token/2]).
 
 % =====================================================================
 % Parsing
@@ -432,12 +433,20 @@ rust_reg_name(RegStr, Name) :-
 
 %% rust_val_literal(+Str, -RustLiteral)
 %  Convert a WAM constant to a Rust value literal.
+%
+%  Uses the shared wam_classify_constant_token/2 so quoted atoms like
+%  `'42'` are classified as atoms (with the outer quotes stripped to
+%  `42`) instead of being formatted verbatim with the quote characters
+%  baked into the F# string.  This mirrors the F# target's #2422 fix
+%  and the existing approach in the Haskell / Go / C++ / Elixir /
+%  Python lowered emitters, all of which already delegate to this
+%  classifier.
 rust_val_literal(Str, RustVal) :-
-    (   number_string(N, Str), integer(N)
+    wam_classify_constant_token(Str, Class),
+    (   Class = integer(N)
     ->  format(atom(RustVal), 'Value::Integer(~w)', [N])
-    ;   number_string(F, Str), float(F)
+    ;   Class = float(F)
     ->  format(atom(RustVal), 'Value::Float(~w)', [F])
-    ;   Str == "[]"
-    ->  RustVal = 'Value::Atom("[]".to_string())'
-    ;   format(atom(RustVal), 'Value::Atom("~w".to_string())', [Str])
+    ;   Class = atom(Name),
+        format(atom(RustVal), 'Value::Atom("~w".to_string())', [Name])
     ).

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -1866,6 +1866,45 @@ test_lowered_calls_detected_kernel_via_callforeign :-
     ;   fail_test(Test, 'Lowered helper did not emit CallForeign for detected kernel')
     ).
 
+%% Regression: rust_val_literal must strip outer quotes from atom tokens
+%% so a Prolog source-level `'42'` (numeric-looking quoted atom) becomes
+%% Value::Atom("42") rather than Value::Atom("'42'").  The naive
+%% number_string-first path emitted the literal-with-quotes verbatim and
+%% broke any predicate that bound a quoted-numeric atom.  Same fix as F#
+%% PR #2422 -- the Rust lowered emitter was the last target with this bug.
+test_lowered_quoted_numeric_atom_strips_quotes :-
+    Test = 'WAM-Rust: lowered put_constant on quoted-numeric atom strips outer quotes',
+    %% `put_constant '42', A1` -> the WAM tokenizer hands the lowered
+    %% emitter the literal string `'42'` (with quotes).  Rendering
+    %% should produce Value::Atom("42"), not Value::Atom("'42'").
+    WamCode = 'put_constant \'42\' A1\nproceed\n',
+    (   lower_predicate_to_rust(test_quoted_numeric/1, WamCode, [], Lines),
+        atomic_list_concat(Lines, '\n', RustCode),
+        %% Must contain the quote-stripped form...
+        sub_string(RustCode, _, _, _, 'Value::Atom("42".to_string())'),
+        %% ...and must NOT contain the buggy verbatim-with-quotes form.
+        \+ sub_string(RustCode, _, _, _, 'Value::Atom("\'42\'".to_string())')
+    ->  pass(Test)
+    ;   fail_test(Test,
+            'Lowered emitter rendered quoted-numeric atom with quotes baked into the Rust string literal')
+    ).
+
+%% Companion: a normal (unquoted) numeric token must still classify as
+%% Integer, not Atom -- catches the symmetric regression where the
+%% quote-stripping pass might over-strip and accidentally turn an
+%% integer literal into an atom.
+test_lowered_unquoted_integer_stays_integer :-
+    Test = 'WAM-Rust: lowered put_constant on unquoted integer renders Value::Integer',
+    WamCode = 'put_constant 42 A1\nproceed\n',
+    (   lower_predicate_to_rust(test_unquoted_integer/1, WamCode, [], Lines),
+        atomic_list_concat(Lines, '\n', RustCode),
+        sub_string(RustCode, _, _, _, 'Value::Integer(42)'),
+        \+ sub_string(RustCode, _, _, _, 'Value::Atom("42".to_string())')
+    ->  pass(Test)
+    ;   fail_test(Test,
+            'Lowered emitter mis-classified an unquoted integer as an atom')
+    ).
+
 %% Run all tests
 run_tests :-
     format('~n========================================~n'),
@@ -1946,6 +1985,8 @@ run_tests :-
     test_native_wam_mixed_project,
     test_rust_wam_lib_imports_hashset,
     test_lowered_calls_detected_kernel_via_callforeign,
+    test_lowered_quoted_numeric_atom_strips_quotes,
+    test_lowered_unquoted_integer_stays_integer,
 
     format('~n========================================~n'),
     (   test_failed


### PR DESCRIPTION
## Summary

Backport of the F# #2422 fix to the Rust lowered emitter.  An audit during the F# documentation pass (#2430) surfaced that `wam_rust_lowered_emitter.pl` was the last target whose value renderer still tried `number_string` first and fell through to a verbatim `Atom("...")` format when the token had outer single quotes.

## The bug

For a source-level quoted-numeric atom like `'42'`, the WAM tokenizer hands the lowered emitter the literal string `'42'` (with the quotes intact).  `rust_val_literal/2`'s `number_string("'42'", N)` would fail (the leading quote isn't a digit), so it fell through to the atom case and emitted

```rust
Value::Atom("'42'".to_string())   // 4-char atom; wrong
```

After this PR it emits

```rust
Value::Atom("42".to_string())     // 2-char atom; correct
```

## The fix

Switch `rust_val_literal/2` to delegate to the shared `wam_text_parser:wam_classify_constant_token/2` -- the same classifier that the Haskell, Go, C++, Elixir, Python, Lua, and R lowered emitters / target helpers already use.  That classifier strips a pair of outer single quotes from the token and classifies the inner as `atom(Name)`, even when the inner content reparses as a number.

This brings Rust in line with the other targets:

| target | uses shared `wam_classify_constant_token` |
| --- | --- |
| Haskell | ✅ (via `val_hs`) |
| C++ | ✅ |
| Go | ✅ |
| Elixir | ✅ |
| Python | ✅ |
| Lua | ✅ (via target's `constant_to_lua_term`) |
| R | ✅ (via target's `constant_to_r_term`) |
| F# | ✅ since #2422 (local copy of the same logic) |
| Clojure | ✅ (own classifier `clj_unquote_wam_atom_token` does the same thing) |
| **Rust** | **❌ -- this PR fixes** |

## Why this matters even without a parser library

The Rust target doesn't integrate the runtime parser library (no `runtime_parser` option, no `prolog_term_parser` references), so most users wouldn't have hit this via `read_term_from_atom`.  But any user predicate like

```prolog
foo :- X = '42', atom(X).
```

compiles to `put_constant '42', A1` and would have triggered the bug at lowering time.

## Regression tests

`tests/test_wam_rust_target.pl` gets two new tests:

1. **`test_lowered_quoted_numeric_atom_strips_quotes`** -- confirms a `put_constant` on the literal `'42'` renders `Value::Atom("42".to_string())` and NOT `Value::Atom("'42'".to_string())`.

2. **`test_lowered_unquoted_integer_stays_integer`** -- companion test confirming an unquoted `42` still renders `Value::Integer(42)` (catches the symmetric over-stripping regression).

Both pass with the fix.

## Test plan

- [x] `swipl tests/test_wam_rust_target.pl` → all PASS (4 lowered-emitter tests including the 2 new regression tests)
- [x] `swipl` load of `src/unifyweaver/targets/wam_rust_lowered_emitter.pl` → no new warnings
- [ ] CI green on `claude/wam-rust-quoted-atom-fix`

## Out of scope

- `tests/test_wam_rust_runtime.pl` has pre-existing `cargo build` failures (unresolved `tc_ancestor` / `weighted_path` imports in the test fixture) that are present on main before this PR -- not caused or fixed by this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_