### PR TITLE
chore(tests): silence two SWI warnings in F# WAM smoke tests

### DIFF
--- a/tests/core/test_wam_fsharp_lowered_parser_smoke.pl
+++ b/tests/core/test_wam_fsharp_lowered_parser_smoke.pl
@@ -27,7 +27,7 @@
                                   make_directory_path/1,
                                   directory_file_path/3]).
 :- use_module(library(process)).
-:- use_module(library(readutil), [read_string/5]).
+%% read_string/3 used below is a SWI built-in -- no import needed.
 
 :- dynamic user:fs_lp_int/0.
 :- dynamic user:fs_lp_foo/0.
@@ -57,14 +57,14 @@ main :-
     retractall(user:fs_lp_list),
     retractall(user:fs_lp_plus),
 
-    assertz((user:fs_lp_int   :- read_term_from_atom('42', _T))),
-    assertz((user:fs_lp_foo   :- read_term_from_atom('foo', _T))),
-    assertz((user:fs_lp_a     :- read_term_from_atom('a', _T))),
-    assertz((user:fs_lp_paren :- read_term_from_atom('(a)', _T))),
-    assertz((user:fs_lp_minus :- read_term_from_atom('-3', _T))),
-    assertz((user:fs_lp_p_a   :- read_term_from_atom('p(a)', _T))),
-    assertz((user:fs_lp_list  :- read_term_from_atom('[1,2,3]', _T))),
-    assertz((user:fs_lp_plus  :- read_term_from_atom('1+2', _T))),
+    assertz((user:fs_lp_int   :- read_term_from_atom('42', _))),
+    assertz((user:fs_lp_foo   :- read_term_from_atom('foo', _))),
+    assertz((user:fs_lp_a     :- read_term_from_atom('a', _))),
+    assertz((user:fs_lp_paren :- read_term_from_atom('(a)', _))),
+    assertz((user:fs_lp_minus :- read_term_from_atom('-3', _))),
+    assertz((user:fs_lp_p_a   :- read_term_from_atom('p(a)', _))),
+    assertz((user:fs_lp_list  :- read_term_from_atom('[1,2,3]', _))),
+    assertz((user:fs_lp_plus  :- read_term_from_atom('1+2', _))),
 
     Dir = '/tmp/uw_fsharp_lowered_parser_repro',
     catch(delete_directory_and_contents(Dir), _, true),

--- a/tests/core/test_wam_fsharp_lowered_smoke.pl
+++ b/tests/core/test_wam_fsharp_lowered_smoke.pl
@@ -20,7 +20,7 @@
                                   make_directory_path/1,
                                   directory_file_path/3]).
 :- use_module(library(process)).
-:- use_module(library(readutil), [read_string/5]).
+%% read_string/3 used below is a SWI built-in -- no import needed.
 
 :- dynamic user:fs_rt_append/0.
 :- dynamic user:fs_rt_member_first/0.

--- a/tests/core/test_wam_fsharp_parser_smoke.pl
+++ b/tests/core/test_wam_fsharp_parser_smoke.pl
@@ -20,7 +20,10 @@
                                   make_directory_path/1,
                                   directory_file_path/3]).
 :- use_module(library(process)).
-:- use_module(library(readutil), [read_string/5]).
+%% read_string/3 used below is a SWI built-in (system:read_string/3) -- no
+%% import needed.  The previous `use_module(library(readutil), [read_string/5])`
+%% triggered an "is not exported" warning because library(readutil) doesn't
+%% re-export the system predicate.
 
 :- dynamic user:fs_parser_demo/0.
 :- dynamic user:fs_parser_p_a/0.
@@ -117,87 +120,87 @@ main :-
     retractall(user:fs_simple),
     assertz((user:fs_simple :- true)),
     assertz((user:fs_parser_int :-
-        read_term_from_atom('42', _T))),
+        read_term_from_atom('42', _))),
     assertz((user:fs_parser_foo :-
-        read_term_from_atom('foo', _T))),
+        read_term_from_atom('foo', _))),
     assertz((user:fs_parser_a :-
-        read_term_from_atom('a', _T))),
+        read_term_from_atom('a', _))),
     assertz((user:fs_parser_var :-
-        read_term_from_atom('X', _T))),
+        read_term_from_atom('X', _))),
     assertz((user:fs_parser_paren_a :-
-        read_term_from_atom('(a)', _T))),
+        read_term_from_atom('(a)', _))),
     assertz((user:fs_parser_minus :-
-        read_term_from_atom('-3', _T))),
+        read_term_from_atom('-3', _))),
     assertz((user:fs_parser_demo :-
-        read_term_from_atom('p(a,b)', _T))),
+        read_term_from_atom('p(a,b)', _))),
     assertz((user:fs_parser_p_a :-
-        read_term_from_atom('p(a)', _T))),
+        read_term_from_atom('p(a)', _))),
     assertz((user:fs_parser_list_123 :-
-        read_term_from_atom('[1,2,3]', _T))),
+        read_term_from_atom('[1,2,3]', _))),
     assertz((user:fs_parser_plus :-
-        read_term_from_atom('1+2', _T))),
+        read_term_from_atom('1+2', _))),
     assertz((user:fs_parser_nested :-
-        read_term_from_atom('p(q(a))', _T))),
+        read_term_from_atom('p(q(a))', _))),
     assertz((user:fs_parser_three_args :-
-        read_term_from_atom('foo(a,b,c)', _T))),
+        read_term_from_atom('foo(a,b,c)', _))),
     assertz((user:fs_parser_mul_plus :-
-        read_term_from_atom('2*3+4', _T))),
+        read_term_from_atom('2*3+4', _))),
     assertz((user:fs_parser_list_vars :-
-        read_term_from_atom('[X,Y,Z]', _T))),
+        read_term_from_atom('[X,Y,Z]', _))),
     assertz((user:fs_parser_naf :-
-        read_term_from_atom('\\+ foo', _T))),
+        read_term_from_atom('\\+ foo', _))),
     assertz((user:fs_parser_prec :-
-        read_term_from_atom('a + b * c', _T))),
+        read_term_from_atom('a + b * c', _))),
     assertz((user:fs_parser_op_in_arg :-
-        read_term_from_atom('foo(a, b+c, d)', _T))),
+        read_term_from_atom('foo(a, b+c, d)', _))),
     assertz((user:fs_parser_partial_list :-
-        read_term_from_atom('[1|T]', _T))),
+        read_term_from_atom('[1|T]', _))),
     assertz((user:fs_parser_eq :-
-        read_term_from_atom('a = b', _T))),
+        read_term_from_atom('a = b', _))),
     assertz((user:fs_parser_is :-
-        read_term_from_atom('X is 1+2', _T))),
+        read_term_from_atom('X is 1+2', _))),
     assertz((user:fs_parser_list_tail_list :-
-        read_term_from_atom('[a,b|[c,d]]', _T))),
+        read_term_from_atom('[a,b|[c,d]]', _))),
     assertz((user:fs_parser_disj :-
-        read_term_from_atom('(a;b)', _T))),
+        read_term_from_atom('(a;b)', _))),
     assertz((user:fs_parser_ite :-
-        read_term_from_atom('a->b;c', _T))),
+        read_term_from_atom('a->b;c', _))),
     assertz((user:fs_parser_caret_assoc :-
-        read_term_from_atom('a^b^c', _T))),
+        read_term_from_atom('a^b^c', _))),
     assertz((user:fs_parser_minus_assoc :-
-        read_term_from_atom('1-2-3', _T))),
+        read_term_from_atom('1-2-3', _))),
     assertz((user:fs_parser_pow_assoc :-
-        read_term_from_atom('2^3^4', _T))),
+        read_term_from_atom('2^3^4', _))),
     assertz((user:fs_parser_empty_list :-
-        read_term_from_atom('[]', _T))),
+        read_term_from_atom('[]', _))),
     assertz((user:fs_parser_shared_var :-
-        read_term_from_atom('p(X,X)', _T))),
+        read_term_from_atom('p(X,X)', _))),
     assertz((user:fs_parser_deep_nest :-
-        read_term_from_atom('f(g(h(i)))', _T))),
+        read_term_from_atom('f(g(h(i)))', _))),
     assertz((user:fs_parser_clause_simple :-
-        read_term_from_atom('p :- q', _T))),
+        read_term_from_atom('p :- q', _))),
     assertz((user:fs_parser_clause_var :-
-        read_term_from_atom('p(X) :- q(X)', _T))),
+        read_term_from_atom('p(X) :- q(X)', _))),
     assertz((user:fs_parser_clause_conj :-
-        read_term_from_atom('p(X) :- q(X), r(X)', _T))),
+        read_term_from_atom('p(X) :- q(X), r(X)', _))),
     assertz((user:fs_parser_clause_conj3 :-
-        read_term_from_atom('p(X) :- q(X), r(X), s(X)', _T))),
+        read_term_from_atom('p(X) :- q(X), r(X), s(X)', _))),
     assertz((user:fs_parser_clause_disj_body :-
-        read_term_from_atom('p(X) :- q(X) ; r(X)', _T))),
+        read_term_from_atom('p(X) :- q(X) ; r(X)', _))),
     assertz((user:fs_parser_clause_ite_body :-
-        read_term_from_atom('p(X) :- q(X) -> r(X) ; s(X)', _T))),
+        read_term_from_atom('p(X) :- q(X) -> r(X) ; s(X)', _))),
     assertz((user:fs_parser_clause_naf_body :-
-        read_term_from_atom('p(X) :- \\+ q(X)', _T))),
+        read_term_from_atom('p(X) :- \\+ q(X)', _))),
     assertz((user:fs_parser_clause_directive :-
-        read_term_from_atom(':- p', _T))),
+        read_term_from_atom(':- p', _))),
     assertz((user:fs_parser_clause_two_vars :-
-        read_term_from_atom('p(X,Y) :- q(X), r(Y)', _T))),
+        read_term_from_atom('p(X,Y) :- q(X), r(Y)', _))),
     assertz((user:fs_parser_clause_append_base :-
-        read_term_from_atom('append([], L, L)', _T))),
+        read_term_from_atom('append([], L, L)', _))),
     assertz((user:fs_parser_clause_append_rec :-
-        read_term_from_atom('append([H|T], L, [H|R]) :- append(T, L, R)', _T))),
+        read_term_from_atom('append([H|T], L, [H|R]) :- append(T, L, R)', _))),
     assertz((user:fs_parser_clause_directive_compound :-
-        read_term_from_atom(':- foo(a)', _T))),
+        read_term_from_atom(':- foo(a)', _))),
 
     Dir = '/tmp/uw_fsharp_parser_repro',
     catch(delete_directory_and_contents(Dir), _, true),

--- a/tests/core/test_wam_fsharp_runtime_smoke.pl
+++ b/tests/core/test_wam_fsharp_runtime_smoke.pl
@@ -18,7 +18,7 @@
                                   make_directory_path/1,
                                   directory_file_path/3]).
 :- use_module(library(process)).
-:- use_module(library(readutil), [read_string/5]).
+%% read_string/3 used below is a SWI built-in -- no import needed.
 
 :- dynamic user:fs_rt_append/0.
 :- dynamic user:fs_rt_member_first/0.


### PR DESCRIPTION
## Summary

Cleans up the two test-file SWI warnings that were noted as out-of-scope in #2429.  Together with #2429 (which cleared the F# target-source warnings) and this PR, the F# WAM test suite now loads with **zero warnings**.

## 1. `system:read_string/5 is not exported (still imported into user)`

Four files had:

```prolog
:- use_module(library(readutil), [read_string/5]).
```

But `read_string/5` is a SWI built-in in `system:`, not exported by `library(readutil)`.  And the test files only use `read_string/3` anyway (also a system built-in), which is autoloaded.

Removed the import lines from:
- `tests/core/test_wam_fsharp_parser_smoke.pl`
- `tests/core/test_wam_fsharp_lowered_parser_smoke.pl`
- `tests/core/test_wam_fsharp_runtime_smoke.pl`
- `tests/core/test_wam_fsharp_lowered_smoke.pl`

Each is replaced by a one-line comment noting `read_string/3` is a system built-in.  (`test_wam_fsharp_dotnet_smoke.pl` had a bare `use_module(library(readutil))` with no import list — doesn't trigger the warning — left untouched.)

## 2. `Singleton-marked variable appears more than once: _T`

Two files had ~40 instances of `read_term_from_atom('foo', _T)` inside the same `main/0` clause body:

```prolog
main :-
    ...
    assertz((user:fs_parser_int :- read_term_from_atom('42', _T))),
    assertz((user:fs_parser_foo :- read_term_from_atom('foo', _T))),
    ...
```

Each `_T` is *semantically* captured as the asserted clause's own local var, but at the textual level all the `_T`s are the same identifier within `main/0`, so SWI flags it (the `_` prefix is reserved for "I'm aware this is unused" — appearing more than once usually means a typo).

Renamed every `_T` to anonymous `_`.  Each `_` is now a genuinely fresh anonymous variable, no ambiguity, no warning.  The asserted clause's effect is unchanged (the result is still discarded).

## Verification

- `swipl` load of all four files: no warnings, no errors
- `test_wam_fsharp_lowered_smoke.pl` → 19/19
- `test_wam_fsharp_lowered_parser_smoke.pl` → 8/8
- `test_wam_fsharp_runtime_smoke.pl` → 19/19
- `test_wam_fsharp_parser_smoke.pl` → 42/42

No behaviour change; this is purely cosmetic.

## Test plan

- [x] All four cleaned smoke tests pass with no warnings
- [x] No code changes outside `tests/core/test_wam_fsharp_*_smoke.pl`
- [ ] CI green on `claude/wam-fsharp-test-warning-cleanup`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_