### PR TITLE
fix(wam-python): two parser regressions surfaced by F# audit backport

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -898,10 +898,17 @@ def _parse_constant(name: str) -> 'Term':
 
 
 def _constant_term(atom_arg: 'Term') -> 'Term':
-    if isinstance(atom_arg, (Int, Float)):
+    # Preserve already-typed terms verbatim.  The previous behaviour
+    # was to re-parse Atom("42").name through _parse_constant which
+    # promotes any numeric-looking string to Int / Float -- so a
+    # source-level quoted-numeric atom like `'42'` (correctly emitted
+    # by the codegen as Atom("42")) silently became Int(42) at
+    # put_constant time, breaking read_term_from_atom('42', _) and
+    # related uses of quoted-numeric atoms.  The _parse_constant
+    # fallback below is reserved for the WAM-text load path where
+    # atom_arg arrives as a raw string with no type information.
+    if isinstance(atom_arg, (Int, Float, Atom)):
         return atom_arg
-    if isinstance(atom_arg, Atom):
-        return _parse_constant(atom_arg.name)
     return _parse_constant(str(atom_arg))
 
 

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -51,7 +51,9 @@
 	parse_wam_text_py/2,
 	python_func_name/2
 ]).
-:- use_module('../targets/wam_text_parser', [wam_classify_constant_token/2]).
+:- use_module('../targets/wam_text_parser',
+              [wam_classify_constant_token/2,
+               wam_tokenize_line/2]).
 :- use_module(wam_runtime_parser_capability, [
 	parser_dependent_body_goal/2,
 	wam_target_runtime_parser/3
@@ -1333,8 +1335,13 @@ wam_code_to_python_instructions(WamCode, _PredIndicator, InstrLiterals, LabelLit
 
 wam_lines_to_python([], _, [], []).
 wam_lines_to_python([Line|Rest], PC, Instrs, Labels) :-
-	split_string(Line, " \t", " \t", Parts),
-	delete(Parts, "", CleanParts),
+	%% Quote-respecting tokeniser: the naive `split_string` on whitespace
+	%% broke any atom token containing a space (e.g. `':- p'`), splitting
+	%% it across multiple parts and causing wam_line_to_python_literal/2
+	%% to silently emit `# SKIP: ...` instead of the real put_constant.
+	%% wam_text_parser:wam_tokenize_line/2 honours the WAM-text
+	%% single-quote convention.
+	wam_tokenize_line(Line, CleanParts),
 	(   CleanParts == []
 	->  wam_lines_to_python(Rest, PC, Instrs, Labels)
 	;   CleanParts = [First|_],

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -720,6 +720,88 @@ test(runtime_parser_compiled_read_term_singletons) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+% Regression: read_term_from_atom on a bare numeric-looking atom (`'42'`).
+% Two bugs collided to break this:
+%   (1) _constant_term in WamRuntime.py re-parsed Atom("42").name through
+%       _parse_constant, which promotes numeric-looking strings to Int.
+%       So put_constant Atom("42") silently became Int(42) at runtime,
+%       and read_term_from_atom rejects non-Atom input (returns False).
+%   (2) wam_lines_to_python used a naive whitespace split that broke any
+%       atom token containing a space (`':- p'`), splitting it across
+%       multiple parts and emitting a `# SKIP:` comment instead of the
+%       real put_constant -- so even after (1) was fixed, a directive-
+%       shaped atom never made it into A1.
+% Both fixes verified by this test: bare integer-shaped quoted atoms,
+% prefix-directive atoms, prefix-NaF atoms.
+test(runtime_parser_compiled_read_term_integer_shaped_atom) :-
+	setup_call_cleanup(
+		(   retractall(user:py_read_int_shape),
+			assertz((user:py_read_int_shape :-
+				read_term_from_atom('42', T),
+				T == 42)),
+			user:python_parser_tmp_dir('tmp_wam_python_parser_int_shape', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_read_int_shape/0],
+				[runtime_parser(compiled)], ProjectDir),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_read_int_shape/0', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_read_int_shape),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
+test(runtime_parser_compiled_read_term_prefix_directive) :-
+	setup_call_cleanup(
+		(   retractall(user:py_read_prefix_directive),
+			assertz((user:py_read_prefix_directive :-
+				read_term_from_atom(':- p', T),
+				T == ':-'(p))),
+			user:python_parser_tmp_dir('tmp_wam_python_parser_prefix_dir', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_read_prefix_directive/0],
+				[runtime_parser(compiled)], ProjectDir),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_read_prefix_directive/0', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_read_prefix_directive),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
+test(runtime_parser_compiled_read_term_prefix_naf) :-
+	setup_call_cleanup(
+		(   retractall(user:py_read_prefix_naf),
+			assertz((user:py_read_prefix_naf :-
+				read_term_from_atom('\\+ foo', T),
+				T == '\\+'(foo))),
+			user:python_parser_tmp_dir('tmp_wam_python_parser_prefix_naf', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_read_prefix_naf/0],
+				[runtime_parser(compiled)], ProjectDir),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_read_prefix_naf/0', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_read_prefix_naf),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_read_term_syntax_errors_policy) :-
 	setup_call_cleanup(
 		(   retractall(user:py_read_term_syntax_lax),


### PR DESCRIPTION
## Summary

Backporting the F# parser smoke (`:- p` / `?- p` / `\+ foo` shapes) to the Python WAM target found **two distinct bugs** in Python that conspired to break `read_term_from_atom` for inputs the F# target now handles cleanly. Both bugs fired off source-level atoms whose textual content happens to collide with WAM-text syntax conventions.

## Bug 1 — `_constant_term` re-parses Atom names through `_parse_constant`

`WamRuntime.py:_constant_term` did:

```python
if isinstance(atom_arg, Atom):
    return _parse_constant(atom_arg.name)
```

That re-parses the atom's name as if it were a raw WAM-text string and promotes any numeric-looking content to `Int` / `Float`. So `put_constant` on the source-level quoted-numeric atom `'42'` (correctly emitted by the codegen as `Atom("42")`) silently became `Int(42)` at runtime, and `read_term_from_atom(_, _)` rejects non-Atom first arguments outright.

**Net effect:** `read_term_from_atom('42', _)`, `read_term_from_atom('1', _)`, `read_term_from_atom('12', _)`, and every other bare-integer-shaped quoted atom returned `False`. `read_term_from_atom('p(1)', _)` worked because the integer is buried inside a compound that arrives as `Atom("p(1)")` and goes straight to the parser without `_parse_constant` intervention.

**Fix:** preserve already-typed terms verbatim:

```python
if isinstance(atom_arg, (Int, Float, Atom)):
    return atom_arg
return _parse_constant(str(atom_arg))   # reserved for the WAM-text load path
```

## Bug 2 — `wam_lines_to_python` used naive whitespace split

The Python target's WAM-text-to-Python-literal pipeline used:

```prolog
split_string(Line, " \t", " \t", Parts)
```

That splits on whitespace without honouring single-quote boundaries. So an atom token containing a space (e.g. `':- p'` from `read_term_from_atom(':- p', _)`) was split across multiple parts (`"':-"`, `"p',"`, ...), `wam_line_to_python_literal/2` failed to recognise the malformed pattern, and the codegen silently emitted:

```python
# SKIP: put_constant ':- p', A1
```

instead of the real `put_constant`. `A1` was never set, `read_term_from_atom` saw a stale register, and the predicate failed.

**Fix:** switch to `wam_text_parser:wam_tokenize_line/2` which already honours the WAM-text single-quote convention. This is the same tokeniser the other targets use via `wam_text_to_items/2` — brings the Python target's text-parse path into line.

## Regression tests added

Three new tests in the `wam_python_runtime_parser_mode` block of `test_wam_python_target.pl`:

| test | covers |
| --- | --- |
| `runtime_parser_compiled_read_term_integer_shaped_atom` | `read_term_from_atom('42', T), T == 42` (Bug 1) |
| `runtime_parser_compiled_read_term_prefix_directive` | `read_term_from_atom(':- p', T), T == ':-'(p)` (Bug 2) |
| `runtime_parser_compiled_read_term_prefix_naf` | `read_term_from_atom('\\+ foo', T), T == '\\+'(foo)` (Bug 2) |

All three failed before this PR and pass after. Existing 21 tests in the block continue to pass.

## How this was found

Doing the F# parser-smoke backport for other WAM targets meant porting the test shape to each. Python's parser library compilation is already exercised by the existing `runtime_parser_compiled_runs_read_term_*` tests with inputs like `'p(a)'`, `'p(a,b)'`, `'[1,2,3]'`, `'1+2'`, `'2*3+4'`. None of those happen to hit either bug — the bare-integer atom and the space-containing-atom shapes are the missing coverage. Adding the F# `:- p` case made both bugs visible.

## Test plan

- [x] All 24 tests in `wam_python_runtime_parser_mode` pass (was 21 before, +3 new)
- [x] No code changes outside `wam_python_target.pl`, `wam_python_runtime/WamRuntime.py`, `test_wam_python_target.pl`
- [ ] CI green on `claude/wam-python-quoted-atom-and-spaces-fix`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_