### PR TITLE
Keep reverse CSR values file open during lookup

### DIFF
--- a/docs/design/WAM_REVERSE_INDEX_ARTIFACTS.md
+++ b/docs/design/WAM_REVERSE_INDEX_ARTIFACTS.md
@@ -319,6 +319,15 @@ same conceptual family as `binary_artifact`, `lmdb_artifact`, and
 `mmap_array_artifact`, rather than as a replacement for the existing C#
 artifact framework.
 
+One concrete effective-distance use is a staged search for workloads
+that allow non-carrot-shaped paths. The runtime can first run the hot
+ancestor kernel over the parent-edge store, preserving the current
+ancestor-first reuse path. Only after that search is exhausted should it
+open the reverse CSR path to add child nodes and widen the frontier. In
+that shape, CSR is not competing with the parent-edge LMDB as the primary
+resident structure; it is a deferred expansion artifact used when the
+query semantics justify leaving the ancestor-only search space.
+
 ### 3.4.1 CSR I/O policy
 
 CSR access should expose an explicit I/O policy:

--- a/docs/reports/reverse_csr_lookup_synthetic.md
+++ b/docs/reports/reverse_csr_lookup_synthetic.md
@@ -27,8 +27,8 @@ python3 examples/benchmark/benchmark_reverse_csr_lookup.py \
 
 | backend | sample_parents | iterations | total_children | median_ms | min_ms | max_ms | csr_artifact_bytes | phase1_lmdb_env_bytes |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| csr | 1000 | 5 | 8000 | 12.104892 | 11.941214 | 12.224214 | 480780 | 4579328 |
-| lmdb | 1000 | 5 | 8000 | 3.613239 | 3.578186 | 3.852191 | 480780 | 4579328 |
+| csr | 1000 | 5 | 8000 | 3.188616 | 3.180329 | 3.430460 | 480780 | 4579328 |
+| lmdb | 1000 | 5 | 8000 | 3.690326 | 3.581263 | 3.842682 | 480780 | 4579328 |
 
 `phase1_lmdb_env_bytes` is the size of the whole Phase 1 LMDB
 environment file (`data.mdb`), not the size of only the parent-edge or
@@ -47,14 +47,14 @@ artifact may become memory-resident only when memory budget allows, and
 that in-memory representation should preserve the compact typed-array /
 CSR shape rather than expanding into Python-style object lists.
 
-The current Python CSR reader is slower than LMDB lookup. That is
-expected for the first reader: every lookup opens, seeks, and reads from
-the values file.
+The original Python CSR reader was slower than LMDB lookup because every
+lookup opened, sought, and read from the values file. The reader now
+keeps the values file open across lookup batches, which makes this
+synthetic fixture measure positional lookup cost more directly.
 
-The next optimization target is therefore the reader path, not the CSR
-layout:
+The next optimization target is therefore no longer file-handle churn:
 
-- keep the values file open across lookup batches;
 - optionally cache recently used child slices or blocks;
-- then rerun the same benchmark before considering WAM runtime
-  integration.
+- compare parent-edge-only LMDB memory pressure against CSR residency;
+- then consider WAM runtime integration for workloads that need deferred
+  child expansion.

--- a/examples/benchmark/benchmark_reverse_csr_lookup.py
+++ b/examples/benchmark/benchmark_reverse_csr_lookup.py
@@ -167,45 +167,45 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         ensure_csr_artifact(phase1_lmdb_dir, csr_dir, refresh_csr)
-        csr = ReverseCsrArtifact(csr_dir)
-        lmdb_lookup = LmdbCategoryChildLookup(phase1_lmdb_dir)
-        try:
-            parent_ids = sample_parent_ids(lmdb_lookup.parents(), args.sample_parents, args.seed)
-            if not parent_ids:
-                sys.stderr.write("no parent ids found in category_child\n")
-                return 4
+        with ReverseCsrArtifact(csr_dir) as csr:
+            lmdb_lookup = LmdbCategoryChildLookup(phase1_lmdb_dir)
+            try:
+                parent_ids = sample_parent_ids(lmdb_lookup.parents(), args.sample_parents, args.seed)
+                if not parent_ids:
+                    sys.stderr.write("no parent ids found in category_child\n")
+                    return 4
 
-            for parent in parent_ids:
-                csr_children = csr.lookup(parent)
-                lmdb_children = lmdb_lookup.lookup(parent)
-                if csr_children != lmdb_children:
-                    sys.stderr.write(
-                        f"parity mismatch for parent={parent}: "
-                        f"csr={csr_children[:10]} lmdb={lmdb_children[:10]}\n"
-                    )
-                    return 5
+                for parent in parent_ids:
+                    csr_children = csr.lookup(parent)
+                    lmdb_children = lmdb_lookup.lookup(parent)
+                    if csr_children != lmdb_children:
+                        sys.stderr.write(
+                            f"parity mismatch for parent={parent}: "
+                            f"csr={csr_children[:10]} lmdb={lmdb_children[:10]}\n"
+                        )
+                        return 5
 
-            timed = [
-                time_lookup_loop("csr", csr.lookup, parent_ids, args.iterations),
-                time_lookup_loop("lmdb", lmdb_lookup.lookup, parent_ids, args.iterations),
-            ]
-            rows: list[dict[str, str]] = []
-            for backend, times_ms, total_children in timed:
-                rows.append({
-                    "backend": backend,
-                    "sample_parents": str(len(parent_ids)),
-                    "iterations": str(args.iterations),
-                    "total_children": str(total_children),
-                    "median_ms": f"{statistics.median(times_ms):.6f}",
-                    "min_ms": f"{min(times_ms):.6f}",
-                    "max_ms": f"{max(times_ms):.6f}",
-                    "csr_artifact_bytes": str(artifact_bytes(csr_dir)),
-                    "phase1_lmdb_env_bytes": str((phase1_lmdb_dir / "data.mdb").stat().st_size),
-                })
-            print_tsv(rows)
-            return 0
-        finally:
-            lmdb_lookup.close()
+                timed = [
+                    time_lookup_loop("csr", csr.lookup, parent_ids, args.iterations),
+                    time_lookup_loop("lmdb", lmdb_lookup.lookup, parent_ids, args.iterations),
+                ]
+                rows: list[dict[str, str]] = []
+                for backend, times_ms, total_children in timed:
+                    rows.append({
+                        "backend": backend,
+                        "sample_parents": str(len(parent_ids)),
+                        "iterations": str(args.iterations),
+                        "total_children": str(total_children),
+                        "median_ms": f"{statistics.median(times_ms):.6f}",
+                        "min_ms": f"{min(times_ms):.6f}",
+                        "max_ms": f"{max(times_ms):.6f}",
+                        "csr_artifact_bytes": str(artifact_bytes(csr_dir)),
+                        "phase1_lmdb_env_bytes": str((phase1_lmdb_dir / "data.mdb").stat().st_size),
+                    })
+                print_tsv(rows)
+                return 0
+            finally:
+                lmdb_lookup.close()
     finally:
         if temp_dir is not None:
             temp_dir.cleanup()

--- a/examples/benchmark/read_reverse_csr_artifact.py
+++ b/examples/benchmark/read_reverse_csr_artifact.py
@@ -17,6 +17,7 @@ import json
 import struct
 import sys
 from pathlib import Path
+from types import TracebackType
 
 try:
     import lmdb
@@ -38,6 +39,22 @@ class ReverseCsrArtifact:
         self.idx_path = artifact_dir / self.meta["index_path"]
         self.val_path = artifact_dir / self.meta["values_path"]
         self.index = self._load_index(self.idx_path)
+        self._values = self.val_path.open("rb")
+
+    def close(self) -> None:
+        if not self._values.closed:
+            self._values.close()
+
+    def __enter__(self) -> "ReverseCsrArtifact":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()
 
     @staticmethod
     def _load_meta(path: Path) -> dict:
@@ -91,9 +108,10 @@ class ReverseCsrArtifact:
         _parent, offset_edges, count = self.index[lo]
         byte_offset = offset_edges * I32.size
         byte_count = count * I32.size
-        with self.val_path.open("rb") as values:
-            values.seek(byte_offset)
-            data = values.read(byte_count)
+        if self._values.closed:
+            raise ValueError("CSR values file is closed")
+        self._values.seek(byte_offset)
+        data = self._values.read(byte_count)
         if len(data) != byte_count:
             raise ValueError("CSR values file ended before requested child slice")
         return [I32.unpack_from(data, offset)[0] for offset in range(0, len(data), I32.size)]
@@ -139,33 +157,36 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
     artifact = ReverseCsrArtifact(args.artifact_dir)
 
-    if args.command == "lookup":
-        for child in artifact.lookup(args.parent_id):
-            print(child)
-        return 0
+    try:
+        if args.command == "lookup":
+            for child in artifact.lookup(args.parent_id):
+                print(child)
+            return 0
 
-    if args.command == "validate":
-        expected = lmdb_children_by_parent(args.phase1_lmdb_dir)
-        csr_parents = set(artifact.parents())
-        expected_parents = set(expected)
-        if csr_parents != expected_parents:
-            missing = sorted(expected_parents - csr_parents)[:10]
-            extra = sorted(csr_parents - expected_parents)[:10]
-            sys.stderr.write(f"parent key mismatch: missing={missing} extra={extra}\n")
-            return 4
-        for parent in sorted(expected):
-            actual_children = artifact.lookup(parent)
-            expected_children = expected[parent]
-            if actual_children != expected_children:
-                sys.stderr.write(
-                    f"children mismatch for parent={parent}: "
-                    f"actual={actual_children[:10]} expected={expected_children[:10]}\n"
-                )
-                return 5
-        print(f"validated parents={len(expected)} edges={sum(len(v) for v in expected.values())}")
-        return 0
+        if args.command == "validate":
+            expected = lmdb_children_by_parent(args.phase1_lmdb_dir)
+            csr_parents = set(artifact.parents())
+            expected_parents = set(expected)
+            if csr_parents != expected_parents:
+                missing = sorted(expected_parents - csr_parents)[:10]
+                extra = sorted(csr_parents - expected_parents)[:10]
+                sys.stderr.write(f"parent key mismatch: missing={missing} extra={extra}\n")
+                return 4
+            for parent in sorted(expected):
+                actual_children = artifact.lookup(parent)
+                expected_children = expected[parent]
+                if actual_children != expected_children:
+                    sys.stderr.write(
+                        f"children mismatch for parent={parent}: "
+                        f"actual={actual_children[:10]} expected={expected_children[:10]}\n"
+                    )
+                    return 5
+            print(f"validated parents={len(expected)} edges={sum(len(v) for v in expected.values())}")
+            return 0
 
-    raise AssertionError(args.command)
+        raise AssertionError(args.command)
+    finally:
+        artifact.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_read_reverse_csr_artifact.py
+++ b/tests/test_read_reverse_csr_artifact.py
@@ -13,6 +13,8 @@ from test_build_reverse_csr_artifact import BUILDER, ROOT, i32
 
 
 READER = ROOT / "examples" / "benchmark" / "read_reverse_csr_artifact.py"
+sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
+from read_reverse_csr_artifact import ReverseCsrArtifact  # noqa: E402
 
 
 def make_phase1_lmdb(path: Path) -> None:
@@ -94,6 +96,31 @@ class ReadReverseCsrArtifactTest(unittest.TestCase):
             )
             self.assertEqual(validate.returncode, 0, validate.stderr)
             self.assertEqual(validate.stdout.strip(), "validated parents=2 edges=4")
+
+    def test_artifact_keeps_values_file_open_until_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            phase1 = tmp_path / "phase1.lmdb"
+            out_dir = tmp_path / "category_child_csr"
+            make_phase1_lmdb(phase1)
+
+            build = subprocess.run(
+                [sys.executable, str(BUILDER), str(phase1), str(out_dir)],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(build.returncode, 0, build.stderr)
+
+            with ReverseCsrArtifact(out_dir) as artifact:
+                self.assertFalse(artifact._values.closed)
+                self.assertEqual(artifact.lookup(20), [10, 12, 13])
+
+            self.assertTrue(artifact._values.closed)
+            with self.assertRaisesRegex(ValueError, "CSR values file is closed"):
+                artifact.lookup(20)
 
     def test_reader_rejects_unsupported_id_encoding(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
  ## Summary

  - Keep `category_child.csr.val` open for the lifetime of `ReverseCsrArtifact`.
  - Add explicit `close()` and context-manager support to the CSR reader.
  - Update the lookup benchmark to use the CSR reader as a context manager.
  - Add test coverage for persistent values-file handle behavior.
  - Refresh the synthetic CSR-vs-LMDB benchmark report with the updated reader results.
  - Document a staged effective-distance use case where reverse CSR is used for deferred child expansion after the
  ancestor kernel is exhausted.

  ## Validation

  - `python3 tests/test_read_reverse_csr_artifact.py`
  - `python3 tests/test_benchmark_reverse_csr_lookup.py`
  - `python3 tests/test_build_reverse_csr_artifact.py`
  - `python3 tests/test_generate_synthetic_phase1_lmdb.py`
  - `python3 tests/test_convert_lmdb_to_phase1_layout.py`
  - `python3 -m py_compile examples/benchmark/read_reverse_csr_artifact.py examples/benchmark/
  benchmark_reverse_csr_lookup.py tests/test_read_reverse_csr_artifact.py tests/test_benchmark_reverse_csr_lookup.py`
  - `git diff --check`