### PR TITLE
Report parent-only LMDB size in reverse CSR benchmark

### DIFF
--- a/docs/reports/reverse_csr_lookup_synthetic.md
+++ b/docs/reports/reverse_csr_lookup_synthetic.md
@@ -18,6 +18,7 @@ python3 examples/benchmark/generate_synthetic_phase1_lmdb.py \
 python3 examples/benchmark/benchmark_reverse_csr_lookup.py \
   "$tmpdir/phase1.lmdb" \
   --csr-dir "$tmpdir/csr" \
+  --parent-lmdb-dir "$tmpdir/parent_only.lmdb" \
   --sample-parents 1000 \
   --iterations 5 \
   --seed 7
@@ -25,10 +26,10 @@ python3 examples/benchmark/benchmark_reverse_csr_lookup.py \
 
 ## Result
 
-| backend | sample_parents | iterations | total_children | median_ms | min_ms | max_ms | csr_artifact_bytes | phase1_lmdb_env_bytes |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| csr | 1000 | 5 | 8000 | 3.188616 | 3.180329 | 3.430460 | 480780 | 4579328 |
-| lmdb | 1000 | 5 | 8000 | 3.690326 | 3.581263 | 3.842682 | 480780 | 4579328 |
+| backend | sample_parents | iterations | total_children | median_ms | min_ms | max_ms | csr_artifact_bytes | parent_lmdb_env_bytes | phase1_lmdb_env_bytes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| csr | 1000 | 5 | 8000 | 3.136484 | 3.076236 | 3.269940 | 480780 | 1507328 | 4579328 |
+| lmdb | 1000 | 5 | 8000 | 3.525135 | 3.490397 | 3.926229 | 480780 | 1507328 | 4579328 |
 
 `phase1_lmdb_env_bytes` is the size of the whole Phase 1 LMDB
 environment file (`data.mdb`), not the size of only the parent-edge or
@@ -37,15 +38,22 @@ child-edge relation. It includes `category_parent`, `category_child`,
 LMDB does not expose an exact per-subdb byte count through this
 benchmark.
 
+`parent_lmdb_env_bytes` is a separate size probe built by copying only
+`category_parent` plus minimal Phase 1-compatible metadata/stub sub-dbs
+into its own LMDB environment. It is not a child-lookup backend in this
+benchmark. It exists to approximate the hot parent-edge store that would
+have memory priority in an ancestor-first runtime.
+
 ## Interpretation
 
-The prototype CSR artifact is much smaller than the full Phase 1 LMDB
-environment for this synthetic graph, but this is not a parent-only
-LMDB comparison. In a memory-budgeted runtime, the priority resident or
-memory-mapped structure remains the hot parent-edge store. A reverse CSR
-artifact may become memory-resident only when memory budget allows, and
-that in-memory representation should preserve the compact typed-array /
-CSR shape rather than expanding into Python-style object lists.
+The prototype CSR artifact is smaller than both the full Phase 1 LMDB
+environment and the parent-only LMDB size probe for this synthetic
+graph. The parent-only LMDB remains the right priority resident or
+memory-mapped structure in a memory-budgeted runtime: it is the hot
+ancestor-kernel store. A reverse CSR artifact may become memory-resident
+only when memory budget allows, and that in-memory representation should
+preserve the compact typed-array / CSR shape rather than expanding into
+Python-style object lists.
 
 The original Python CSR reader was slower than LMDB lookup because every
 lookup opened, sought, and read from the values file. The reader now

--- a/examples/benchmark/benchmark_reverse_csr_lookup.py
+++ b/examples/benchmark/benchmark_reverse_csr_lookup.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import random
+import shutil
 import statistics
 import struct
 import subprocess
@@ -44,6 +45,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("phase1_lmdb_dir", type=Path)
     parser.add_argument("--csr-dir", type=Path, default=None, help="existing or output CSR artifact directory")
     parser.add_argument("--refresh-csr", action="store_true", help="rebuild CSR artifact when --csr-dir exists")
+    parser.add_argument(
+        "--parent-lmdb-dir",
+        type=Path,
+        default=None,
+        help="existing or output category_parent-only LMDB directory for size comparison",
+    )
+    parser.add_argument(
+        "--refresh-parent-lmdb",
+        action="store_true",
+        help="rebuild the parent-only LMDB when --parent-lmdb-dir exists",
+    )
     parser.add_argument("--sample-parents", type=int, default=1000)
     parser.add_argument("--iterations", type=int, default=5)
     parser.add_argument("--seed", type=int, default=1)
@@ -107,6 +119,51 @@ def ensure_csr_artifact(phase1_lmdb_dir: Path, csr_dir: Path, refresh: bool) -> 
         raise RuntimeError(f"CSR builder failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}")
 
 
+def ensure_parent_only_lmdb(phase1_lmdb_dir: Path, parent_lmdb_dir: Path, refresh: bool) -> None:
+    if parent_lmdb_dir.resolve() == phase1_lmdb_dir.resolve():
+        raise ValueError("--parent-lmdb-dir must be different from phase1_lmdb_dir")
+    if parent_lmdb_dir.exists() and not refresh:
+        return
+    if parent_lmdb_dir.exists():
+        shutil.rmtree(parent_lmdb_dir)
+    parent_lmdb_dir.mkdir(parents=True, exist_ok=True)
+
+    source_size = (phase1_lmdb_dir / "data.mdb").stat().st_size
+    dst_env = lmdb.open(
+        str(parent_lmdb_dir),
+        map_size=max(source_size, 1 << 20),
+        max_dbs=8,
+        subdir=True,
+    )
+    src_env = lmdb.open(str(phase1_lmdb_dir), readonly=True, max_dbs=8, lock=False, subdir=True)
+    edge_count = 0
+    try:
+        with src_env.begin() as src_txn:
+            src_cp_db = src_env.open_db(b"category_parent", txn=src_txn, dupsort=True, create=False)
+            dst_meta_db = dst_env.open_db(b"meta")
+            dst_cp_db = dst_env.open_db(b"category_parent", dupsort=True)
+            dst_s2i_db = dst_env.open_db(b"s2i")
+            dst_i2s_db = dst_env.open_db(b"i2s")
+            dst_ac_db = dst_env.open_db(b"article_category", dupsort=True)
+            with dst_env.begin(write=True) as dst_txn:
+                cursor = src_txn.cursor(db=src_cp_db)
+                for key, value in cursor:
+                    if len(key) != 4 or len(value) != 4:
+                        continue
+                    dst_txn.put(key, value, db=dst_cp_db)
+                    edge_count += 1
+                dst_txn.put(b"schema_version", b"1", db=dst_meta_db)
+                dst_txn.put(b"id_encoding", b"int32_le", db=dst_meta_db)
+                dst_txn.put(b"category_parent_edge_count", str(edge_count).encode("ascii"), db=dst_meta_db)
+                dst_txn.put(b"hot_relation", b"category_parent/2", db=dst_meta_db)
+                dst_txn.put(b"storage_scope", b"parent_only_size_probe", db=dst_meta_db)
+                _ = (dst_s2i_db, dst_i2s_db, dst_ac_db)
+    finally:
+        src_env.close()
+        dst_env.sync()
+        dst_env.close()
+
+
 def sample_parent_ids(parent_ids: list[int], count: int, seed: int) -> list[int]:
     if count <= 0 or count >= len(parent_ids):
         return list(parent_ids)
@@ -142,6 +199,7 @@ def print_tsv(rows: list[dict[str, str]]) -> None:
         "min_ms",
         "max_ms",
         "csr_artifact_bytes",
+        "parent_lmdb_env_bytes",
         "phase1_lmdb_env_bytes",
     ]
     print("\t".join(headers))
@@ -159,14 +217,24 @@ def main(argv: list[str] | None = None) -> int:
     temp_dir: tempfile.TemporaryDirectory[str] | None = None
     if args.csr_dir is None:
         temp_dir = tempfile.TemporaryDirectory()
-        csr_dir = Path(temp_dir.name) / "category_child_csr"
+        temp_path = Path(temp_dir.name)
+        csr_dir = temp_path / "category_child_csr"
+        parent_lmdb_dir = args.parent_lmdb_dir or temp_path / "category_parent_only.lmdb"
         refresh_csr = False
+        refresh_parent_lmdb = args.refresh_parent_lmdb
     else:
         csr_dir = args.csr_dir
+        parent_lmdb_dir = args.parent_lmdb_dir
         refresh_csr = args.refresh_csr
+        refresh_parent_lmdb = args.refresh_parent_lmdb
+    if parent_lmdb_dir is None:
+        if temp_dir is None:
+            temp_dir = tempfile.TemporaryDirectory()
+        parent_lmdb_dir = Path(temp_dir.name) / "category_parent_only.lmdb"
 
     try:
         ensure_csr_artifact(phase1_lmdb_dir, csr_dir, refresh_csr)
+        ensure_parent_only_lmdb(phase1_lmdb_dir, parent_lmdb_dir, refresh_parent_lmdb)
         with ReverseCsrArtifact(csr_dir) as csr:
             lmdb_lookup = LmdbCategoryChildLookup(phase1_lmdb_dir)
             try:
@@ -200,6 +268,7 @@ def main(argv: list[str] | None = None) -> int:
                         "min_ms": f"{min(times_ms):.6f}",
                         "max_ms": f"{max(times_ms):.6f}",
                         "csr_artifact_bytes": str(artifact_bytes(csr_dir)),
+                        "parent_lmdb_env_bytes": str((parent_lmdb_dir / "data.mdb").stat().st_size),
                         "phase1_lmdb_env_bytes": str((phase1_lmdb_dir / "data.mdb").stat().st_size),
                     })
                 print_tsv(rows)

--- a/tests/test_benchmark_reverse_csr_lookup.py
+++ b/tests/test_benchmark_reverse_csr_lookup.py
@@ -52,6 +52,7 @@ class BenchmarkReverseCsrLookupTest(unittest.TestCase):
                 self.assertEqual(row["total_children"], "4")
                 self.assertGreater(float(row["median_ms"]), 0.0)
                 self.assertGreater(int(row["csr_artifact_bytes"]), 0)
+                self.assertGreater(int(row["parent_lmdb_env_bytes"]), 0)
                 self.assertGreater(int(row["phase1_lmdb_env_bytes"]), 0)
 
     def test_benchmark_detects_missing_phase1_lmdb(self) -> None:

--- a/tests/test_generate_synthetic_phase1_lmdb.py
+++ b/tests/test_generate_synthetic_phase1_lmdb.py
@@ -101,7 +101,7 @@ class GenerateSyntheticPhase1LmdbTest(unittest.TestCase):
             )
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("backend\tsample_parents\titerations", result.stdout)
-            self.assertIn("csr_artifact_bytes\tphase1_lmdb_env_bytes", result.stdout)
+            self.assertIn("csr_artifact_bytes\tparent_lmdb_env_bytes\tphase1_lmdb_env_bytes", result.stdout)
             self.assertIn("csr\t5\t2\t20\t", result.stdout)
             self.assertIn("lmdb\t5\t2\t20\t", result.stdout)
 


### PR DESCRIPTION
  ## Summary

  - Add a parent-only LMDB size probe to benchmark_reverse_csr_lookup.py.
  - Report parent_lmdb_env_bytes alongside csr_artifact_bytes and phase1_lmdb_env_bytes.
  - Add --parent-lmdb-dir and --refresh-parent-lmdb options.
  - Guard against accidentally writing the parent-only LMDB over the source Phase 1 LMDB.
  - Update tests and the synthetic reverse CSR report with the new size comparison.

  ## Notes

  The parent-only LMDB is not used as a child-lookup backend. It exists to approximate the hot category_parent/2 store
  that should get memory priority in an ancestor-first runtime.

  For the current synthetic fixture:

| artifact                | bytes   |
|-------------------------|---------|
| reverse CSR             | 480780  |
| parent-only LMDB probe  | 1507328 |
| full Phase 1 LMDB       | 4579328 |

  ## Validation

  - python3 tests/test_benchmark_reverse_csr_lookup.py
  - python3 tests/test_generate_synthetic_phase1_lmdb.py
  - python3 tests/test_read_reverse_csr_artifact.py
  - python3 -m py_compile examples/benchmark/benchmark_reverse_csr_lookup.py tests/test_benchmark_reverse_csr_lookup.py
    tests/test_generate_synthetic_phase1_lmdb.py
  - git diff --check