### PR TITLE
test(wam-clojure): cover downcase unbound source

### DIFF
--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -163,6 +163,7 @@
 :- dynamic user:wam_upcase_atom_guard/2.
 :- dynamic user:wam_downcase_atom_guard/2.
 :- dynamic user:wam_upcase_atom_unbound_source/1.
+:- dynamic user:wam_downcase_atom_unbound_source/1.
 :- dynamic user:wam_atomic_list_concat_2_guard/1.
 :- dynamic user:wam_atomic_list_concat_3_guard/1.
 :- dynamic user:wam_atomic_list_concat_3_split/0.
@@ -405,6 +406,7 @@ user:wam_atom_number_unbound_pair(_) :- user:wam_unbound_arg(A), user:wam_unboun
 user:wam_upcase_atom_guard(A, U) :- upcase_atom(A, U).
 user:wam_downcase_atom_guard(A, L) :- downcase_atom(A, L).
 user:wam_upcase_atom_unbound_source(_) :- user:wam_unbound_arg(A), upcase_atom(A, _).
+user:wam_downcase_atom_unbound_source(_) :- user:wam_unbound_arg(A), downcase_atom(A, _).
 user:wam_atomic_list_concat_2_guard(A) :- atomic_list_concat([f,o,o], A).
 user:wam_atomic_list_concat_3_guard(A) :- atomic_list_concat([f,o], o, A).
 user:wam_atomic_list_concat_3_split :- user:wam_unbound_arg(L), atomic_list_concat(L, b, abcbd), L = [a,c,d].
@@ -652,6 +654,7 @@ run_smoke :-
           user:wam_upcase_atom_guard/2,
           user:wam_downcase_atom_guard/2,
           user:wam_upcase_atom_unbound_source/1,
+          user:wam_downcase_atom_unbound_source/1,
           user:wam_atomic_list_concat_2_guard/1,
           user:wam_atomic_list_concat_3_guard/1,
           user:wam_atomic_list_concat_3_split/0,
@@ -1056,6 +1059,7 @@ smoke_cases([
     case('wam_downcase_atom_guard/2', args('HELLO', hello), "true"),
     case('wam_downcase_atom_guard/2', args('HELLO', 'HELLO'), "false"),
     case('wam_upcase_atom_unbound_source/1', a, "false"),
+    case('wam_downcase_atom_unbound_source/1', a, "false"),
     case('wam_atomic_list_concat_2_guard/1', foo, "true"),
     case('wam_atomic_list_concat_3_guard/1', foo, "true"),
     case('wam_atomic_list_concat_3_split/0', no_args, "true"),
@@ -1469,6 +1473,7 @@ assert_lowered_ground_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-atom-number-reverse-mismatch-0"),
     has(CoreCode, "defn lowered-wam-upcase-atom-guard-2"),
     has(CoreCode, "defn lowered-wam-downcase-atom-guard-2"),
+    has(CoreCode, "defn lowered-wam-downcase-atom-unbound-source-1"),
     has(CoreCode, "defn lowered-wam-atomic-list-concat-2-guard-1"),
     has(CoreCode, "defn lowered-wam-atomic-list-concat-3-guard-1"),
     has(CoreCode, "defn lowered-wam-atomic-list-concat-3-split-0"),


### PR DESCRIPTION
## Summary

- Adds a Clojure WAM runtime smoke regression for `downcase_atom/2` with an unbound source argument.
- Mirrors the existing `upcase_atom/2` unbound-source negative fixture.
- Asserts that the lowered Clojure core emits the new fixture function.

## Why

The smoke suite already covered guard success/failure for both `upcase_atom/2` and `downcase_atom/2`, but only `upcase_atom/2` had explicit unbound-source coverage. This keeps case-conversion builtin coverage symmetric and documents the conservative failure behavior for an unbound source.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
