### PR TITLE
test(wam-elixir): add compiled-mode-rejection regression + correct doc

### DIFF
--- a/docs/WAM_RUNTIME_PARSER_STATUS.md
+++ b/docs/WAM_RUNTIME_PARSER_STATUS.md
@@ -70,7 +70,7 @@ each WAM instruction).
 | **Python**   | ✅ | — | ✅ | `none` * | yes — `test_wam_python_target.pl` `wam_python_runtime_parser_mode` block |
 | **C++**      | ✅ | ✅ | ✅ | `native(parse_term)` | partial — codegen tests in `test_wam_cpp_generator.pl`, one `'42'` parse verified end-to-end during the audit |
 | **R**        | ✅ | ✅ | ✅ | `native(parse_term)` | codegen tests; runtime end-to-end via the R smoke harness |
-| **Elixir**   | ✅ | — | (advertised but **stub**) | `none` | n/a — `compiled` option exists but the parser predicates aren't actually bundled |
+| **Elixir**   | ✅ | — | — | `none` | n/a — `runtime_parser(compiled)` correctly throws `domain_error` (since Elixir isn't in the capability table); guarded by `test_runtime_parser_compiled_request_errors` |
 | **Rust**     | ✅ | — | — | `none` | n/a (no parser-mode wiring) |
 | **Haskell**  | ✅ | — | — | `none` | n/a (no parser-mode wiring) |
 | **Go**       | ✅ | — | — | `none` | n/a (no parser-mode wiring) |
@@ -143,20 +143,28 @@ someone writes one).
 
 Three threads, roughly in order of impact:
 
-### 1. Close the Elixir stub
+### 1. Elixir parser bundling (if a user appears)
 
-Elixir advertises `runtime_parser(compiled)` in
-`elixir_runtime_parser_mode_literal/2` but doesn't actually prepend the
-parser predicates to the project list.  At minimum: change the option
-to throw `domain_error` like the targets that genuinely don't support
-it, so users don't think they have a parser they don't have.  Better:
-implement the bundling (mirror Python's
-`wam_python_target.pl:expand_python_runtime_parser_predicates/3`).
+Elixir is not in the capability table for any parser mode, so
+`runtime_parser(compiled)` and `runtime_parser(native)` both
+correctly throw `domain_error` at codegen.  Regression-protected
+by `test_runtime_parser_compiled_request_errors` in
+`tests/test_wam_elixir_target.pl` (added alongside the existing
+`test_runtime_parser_native_request_errors`).
 
-The Elixir runtime would also need atom-codes / number-codes / WAM-text
-plumbing equivalent to what Python has — significant work.  Worth it
-if there's a real user for `read_term_from_atom` in Elixir; not
-otherwise.
+(An earlier version of this doc described Elixir as having an
+"advertised but stub" compiled mode -- that was inaccurate; the
+capability resolver rejects before reaching the unreachable
+`elixir_runtime_parser_mode_literal(compiled(_), _)` clause.  The
+clause itself is dead forward-compat code; left in place in case a
+later implementation needs it.)
+
+If someone wants Elixir to actually support `runtime_parser(compiled)`,
+the work is: add Elixir to the capability table, port Python's
+`expand_python_runtime_parser_predicates/3` to prepend the parser
+predicates to the project list, and add atom-codes / number-codes /
+WAM-text plumbing to the Elixir runtime equivalent to Python's.
+Significant work; worth it if there's a real user, not otherwise.
 
 ### 2. Add `compiled` to one more target with a real use case
 

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -101,6 +101,34 @@ test_runtime_parser_native_request_errors :-
         elixir_parser_cleanup_tmp_dir(TmpDir)
     ).
 
+%% Regression: runtime_parser(compiled) must reject for Elixir.  The
+%% Elixir target doesn't actually bundle the portable parser predicates
+%% (unlike Python/F#/C++ which do), so silently accepting `compiled`
+%% would produce a project that throws "predicate not found" at run
+%% time when read_term_from_atom is finally called -- worse than
+%% rejecting cleanly at codegen.  The check belongs to
+%% wam_runtime_parser_capability:resolve_runtime_parser_request/3
+%% (wam_elixir isn't in the capability table for compiled), so this
+%% test guards against accidentally adding it there without
+%% implementing bundling on the Elixir side.
+test_runtime_parser_compiled_request_errors :-
+    Test = 'Runtime parser mode: compiled request is rejected for WAM-Elixir',
+    WamCode = 'parser_compiled/0:\n  proceed',
+    setup_call_cleanup(
+        elixir_parser_tmp_dir('tmp_wam_elixir_parser_compiled_err', TmpDir),
+        (   catch((write_wam_elixir_project([parser_compiled/0-WamCode],
+                                            [runtime_parser(compiled)],
+                                            TmpDir),
+                   Caught = false),
+                  error(domain_error(runtime_parser_mode(wam_elixir), compiled), _),
+                  Caught = true),
+            Caught == true
+        ->  pass(Test)
+        ;   fail_test(Test, 'expected compiled runtime parser mode domain_error')
+        ),
+        elixir_parser_cleanup_tmp_dir(TmpDir)
+    ).
+
 test_runtime_parser_none_rejects_parser_dependent_builtin :-
     Test = 'Runtime parser mode: disabled parser rejects read_term_from_atom/2',
     WamCode = 'elixir_parser_dep/0:\n  proceed',
@@ -3207,6 +3235,7 @@ run_tests :-
     test_runtime_assembly,
     test_runtime_parser_mode_metadata,
     test_runtime_parser_native_request_errors,
+    test_runtime_parser_compiled_request_errors,
     test_runtime_parser_none_rejects_parser_dependent_builtin,
     test_runtime_parser_none_allows_term_to_atom_forward,
     test_instruction_count,


### PR DESCRIPTION
## Summary

Picking up plan-forward thread (1) from #2437 (close the Elixir `runtime_parser(compiled)` stub), it turned out **Elixir is already correctly rejecting** `runtime_parser(compiled)` AND `runtime_parser(native)` — both throw `domain_error` at codegen because `wam_elixir` isn't in the capability table for either mode.

My earlier doc characterised Elixir's compiled mode as "advertised but stub", based on seeing the `elixir_runtime_parser_mode_literal(compiled(SourceModule), _)` clause in `wam_elixir_target.pl`. That clause IS dead code, but it's **not reachable** through the user-facing `runtime_parser(compiled)` option — the capability resolver rejects before getting there. So the user-facing failure mode is already honest (clean codegen-time `domain_error` instead of a runtime "predicate not found").

This PR locks in that correct behaviour and fixes the doc:

## Changes

### 1. New regression test

`tests/test_wam_elixir_target.pl :: test_runtime_parser_compiled_request_errors`, added alongside the existing `test_runtime_parser_native_request_errors`. Same shape:

```prolog
write_wam_elixir_project([_], [runtime_parser(compiled)], _)
```

must throw `error(domain_error(runtime_parser_mode(wam_elixir), compiled), _)`.

This regression-protects against accidentally adding `wam_elixir` to `wam_runtime_parser_capability:target_runtime_parser_mode_/2` without first implementing parser-predicate bundling on the Elixir side.

### 2. Doc correction

`docs/WAM_RUNTIME_PARSER_STATUS.md`:

- Elixir row in the capability table: dropped the "advertised but stub" claim (it was wrong).
- Plan-forward section (1) rewritten to describe the actual state — Elixir is not in the capability table, both `compiled` and `native` correctly reject — and noting that the unreachable `elixir_runtime_parser_mode_literal(compiled(_), _)` clause is dead forward-compat code, left in place in case a later implementation needs it.

### 3. Test runner wired up

`test_runtime_parser_compiled_request_errors` added to `run_tests/0` right after `test_runtime_parser_native_request_errors`.

## Verification

All 5 parser-related Elixir tests pass:

- `generated runtime records parser disabled`
- `native request is rejected for WAM-Elixir`
- `compiled request is rejected for WAM-Elixir`  **(NEW)**
- `disabled parser rejects read_term_from_atom/2`
- `disabled parser allows forward term_to_atom/2`

No production code change — pure test + doc work. The thing I originally promised to "close" turned out to already be closed; this PR documents that accurately and locks the behaviour in with a test.

## Test plan

- [x] New `test_runtime_parser_compiled_request_errors` passes
- [x] Existing `test_runtime_parser_native_request_errors` still passes (same shape, regression-protected)
- [x] All 5 parser-related Elixir tests pass together
- [ ] CI green on `claude/wam-elixir-runtime-parser-compiled-reject`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_