### PR TITLE
feat(wam-python): support read_line_to_string/2

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -1510,6 +1510,33 @@ def _execute_put_code_stream(state: WamState) -> bool:
     return _write_stream_char(deref(get_reg(state, 1), state), text)
 
 
+def _execute_read_line_to_string(state: WamState) -> bool:
+    stream = deref(get_reg(state, 1), state)
+    raw = _unwrap_stream(stream)
+    if raw is None or not hasattr(raw, 'read'):
+        return False
+
+    chars: List[str] = []
+    while True:
+        ch = _read_handle_char(state, stream)
+        if ch is None:
+            return False
+        if ch == '':
+            if not chars:
+                return unify(get_reg(state, 2), make_atom('end_of_file'), state)
+            return unify(get_reg(state, 2), make_atom(''.join(chars)), state)
+        if ch == '\n':
+            return unify(get_reg(state, 2), make_atom(''.join(chars)), state)
+        if ch == '\r':
+            next_ch = _read_handle_char(state, stream)
+            if next_ch is None:
+                return False
+            if next_ch not in ('', '\n'):
+                state.stream_pushback.setdefault(_stream_pushback_key(stream), []).append(next_ch)
+            return unify(get_reg(state, 2), make_atom(''.join(chars)), state)
+        chars.append(ch)
+
+
 def _execute_read_from_stream(state: WamState, stream: Any, target: Term,
                               syntax_default: str = 'fail',
                               read_char: Optional[Callable[[], str]] = None) -> bool:
@@ -1772,6 +1799,8 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return _execute_put_code(state)
     if builtin in ('put_code/2',) and arity == 2:
         return _execute_put_code_stream(state)
+    if builtin in ('read_line_to_string/2', 'read_line_to_string') and arity == 2:
+        return _execute_read_line_to_string(state)
     if builtin in ('read/1', 'read_lax/1', 'read_term/1', 'read_term_lax/1',
                    'read', 'read_lax', 'read_term', 'read_term_lax') and arity == 1:
         return _execute_read_default_stream(state, 'fail')

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -1041,6 +1041,38 @@ test(runtime_stream_char_io_reads_and_writes_files) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_read_line_to_string_reads_file_lines) :-
+	setup_call_cleanup(
+		(   retractall(user:py_read_line_demo),
+			user:python_parser_tmp_dir('tmp_wam_python_read_line', ProjectDir),
+			atomic_list_concat([ProjectDir, '/lines.txt'], InFile),
+			assertz((user:py_read_line_demo :-
+				open(InFile, read, S),
+				peek_char(S, C0), C0 = f,
+				read_line_to_string(S, L1), L1 = foo,
+				read_line_to_string(S, L2), L2 = '',
+				read_line_to_string(S, L3), L3 = bar,
+				read_line_to_string(S, L4), L4 = end_of_file,
+				close(S)))
+		),
+		(   setup_call_cleanup(open(InFile, write, Input),
+				format(Input, "foo~n~nbar", []),
+				close(Input)),
+			wam_python_target:write_wam_python_project([user:py_read_line_demo/0],
+				[runtime_parser(off)], ProjectDir),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_read_line_demo/0', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_read_line_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_runs_reverse_term_to_atom) :-
 	setup_call_cleanup(
 		(   retractall(user:py_term_to_atom_demo),
@@ -1550,6 +1582,7 @@ test(static_runtime_has_lua_baseline_builtins, [nondet]) :-
 		"get_char/2",
 		"get_code/2",
 		"peek_char/2",
+		"read_line_to_string/2",
 		"nl/0"
 	]), sub_string(Content, _, _, _, Needle)).
 
@@ -1564,6 +1597,7 @@ test(static_runtime_io_emits_output, [nondet]) :-
 	sub_string(Content, _, _, _, "print(_format_value(get_reg(state, 1), state), end='')"),
 	sub_string(Content, _, _, _, "def _execute_put_char"),
 	sub_string(Content, _, _, _, "def _execute_put_code"),
+	sub_string(Content, _, _, _, "def _execute_read_line_to_string"),
 	sub_string(Content, _, _, _, "print()").
 
 :- end_tests(wam_python_builtin_parity_guard).


### PR DESCRIPTION
## Summary

- Add WAM-Python runtime support for `read_line_to_string/2` on opened text streams.
- Reuse the existing per-stream pushback path, so `peek_char/2` and line reads interact correctly.
- Return line text without line terminators, and return `end_of_file` when no characters remain.
- Add a generated Python WAM file-stream test covering normal lines, an empty line, EOF, and a preceding `peek_char/2`.

## Notes

This provides a parser-independent line-reading primitive for generated Python WAM programs, complementing the recent `open/3` and stream char/code I/O support.

Line endings handle `\n`, `\r`, and `\r\n` by returning the accumulated line text without the terminator. Invalid stream terms fail quietly, consistent with the current lax Python WAM builtin behavior.

## Verification

- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode),run_tests(wam_python_builtin_parity_guard)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
