### PR TITLE
Feat/wam go number list builtins

### DIFF
--- a/PR_go_wam_number_list_builtins.md
+++ b/PR_go_wam_number_list_builtins.md
@@ -1,0 +1,24 @@
+# PR Title
+
+Add Go WAM number_codes/2 and number_chars/2 parity
+
+# PR Description
+
+## Summary
+
+- Add direct Go WAM lowering for `number_codes/2` and `number_chars/2`.
+- Implement runtime number/list conversion using the existing code-list and char-list text helpers plus the `atom_number/2` numeric parsing/formatting path.
+- Cover number-to-list binding, bound-list success, mismatch failure, list-to-number binding for integer, negative, and float text, both-unbound failure, and invalid-list failure in the generated Go WAM builtin E2E test.
+- Update the Go WAM parity audit to record number code-list and char-list conversion parity with the Clojure text conversion surface.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(number_codes/2,2), C), wam_go_target:wam_instruction_to_go_literal(call(number_chars/2,2), H), writeln(C), writeln(H), halt"`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -14,7 +14,7 @@ current cross-target builtin/runtime baseline.
 | Structural builtins | `member/2`, `memberchk/2`, `select/3`, `delete/3`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `select/3`, `delete/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
 | Arithmetic builtins | `is/2`, `succ/2` | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir | Present for current baseline arithmetic checks, with expanded successor coverage |
-| Atom/text conversion | `atom_number/2`, `atom_codes/2`, `atom_chars/2`, `string_codes/2`, `string_chars/2`, `atom_string/2`, `string_to_atom/2`, `upcase_atom/2`, `downcase_atom/2`, `atom_concat/3`, `atom_length/2`, `string_length/2`, `char_code/2` | Clojure direct builtin surface includes bidirectional `atom_number/2`, atom/string code-list and char-list conversion, atom/string conversion, atom case conversion, deterministic atom concatenation, text length checks, and char-code conversion | Present for current atom-number, atom/string code-list, atom/string char-list, atom/string, atom-case, atom-concat, text-length, and char-code checks |
+| Atom/text conversion | `atom_number/2`, `atom_codes/2`, `atom_chars/2`, `string_codes/2`, `string_chars/2`, `number_codes/2`, `number_chars/2`, `atom_string/2`, `string_to_atom/2`, `upcase_atom/2`, `downcase_atom/2`, `atom_concat/3`, `atom_length/2`, `string_length/2`, `char_code/2` | Clojure direct builtin surface includes bidirectional `atom_number/2`, atom/string/number code-list and char-list conversion, atom/string conversion, atom case conversion, deterministic atom concatenation, text length checks, and char-code conversion | Present for current atom-number, atom/string/number code-list, atom/string/number char-list, atom/string, atom-case, atom-concat, text-length, and char-code checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` | Includes `=</2`; Haskell mode analysis and Clojure lowering also cover term-order comparisons | Present for current baseline comparisons, with expanded term-order coverage |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
 | Term inspection | `functor/3`, `arg/3` | `functor/3`, `arg/3` | Present |
@@ -103,6 +103,11 @@ current cross-target builtin/runtime baseline.
   success, mismatch failure, list-to-string binding, empty-string conversion,
   both-unbound failure, and invalid-list failure, matching the current Clojure
   string list-conversion aliases.
+- Bidirectional `number_codes/2` and `number_chars/2` are now covered by the
+  generated Go WAM builtin E2E test for number-to-list binding, bound-list
+  success, mismatch failure, list-to-number binding for integer, negative, and
+  float text, both-unbound failure, and invalid-list failure, matching the
+  current Clojure number list-conversion surface.
 - Bidirectional `atom_string/2` and `string_to_atom/2` are now covered by the
   generated Go WAM builtin E2E test for atom-to-text binding, bound-text
   success, mismatch failure, text-to-atom binding, and both-unbound failure,

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -496,6 +496,12 @@ wam_go_direct_builtin("string_codes/2", 2, 'string_codes/2').
 wam_go_direct_builtin(string_chars/2, 2, 'string_chars/2').
 wam_go_direct_builtin('string_chars/2', 2, 'string_chars/2').
 wam_go_direct_builtin("string_chars/2", 2, 'string_chars/2').
+wam_go_direct_builtin(number_codes/2, 2, 'number_codes/2').
+wam_go_direct_builtin('number_codes/2', 2, 'number_codes/2').
+wam_go_direct_builtin("number_codes/2", 2, 'number_codes/2').
+wam_go_direct_builtin(number_chars/2, 2, 'number_chars/2').
+wam_go_direct_builtin('number_chars/2', 2, 'number_chars/2').
+wam_go_direct_builtin("number_chars/2", 2, 'number_chars/2').
 wam_go_direct_builtin(atom_string/2, 2, 'atom_string/2').
 wam_go_direct_builtin('atom_string/2', 2, 'atom_string/2').
 wam_go_direct_builtin("atom_string/2", 2, 'atom_string/2').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1294,6 +1294,36 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			return vm.Unify(arg1, internAtom(text))
 		}
 		return false
+	case "number_codes/2", "number_chars/2":
+		numberVal := vm.deref(arg1)
+		listVal := vm.deref(arg2)
+		if u, ok := listVal.(*Unbound); ok {
+			if next, ok := vm.heapConsAfterUnbound(u); ok {
+				listVal = vm.deref(next)
+			}
+		}
+		textFromList := vm.codeListText
+		listFromText := func(text string) *List { return atomCodeList(text) }
+		if op == "number_chars/2" {
+			textFromList = vm.charListText
+			listFromText = func(text string) *List { return atomCharList(text) }
+		}
+		if number, ok := atomNumberValue(numberVal); ok {
+			text, ok := atomNumberText(number)
+			if !ok {
+				return false
+			}
+			if _, unbound := listVal.(*Unbound); unbound {
+				return vm.Unify(arg2, listFromText(text))
+			}
+			listText, ok := textFromList(listVal)
+			return ok && text == listText
+		}
+		if text, ok := textFromList(listVal); ok {
+			parsed, ok := parseAtomNumberText(text)
+			return ok && vm.Unify(arg1, parsed)
+		}
+		return false
 	case "atom_string/2", "string_to_atom/2":
 		atomArg := arg1
 		stringArg := arg2

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -26,6 +26,7 @@
 :- dynamic user:test_atom_codes_builtin/0.
 :- dynamic user:test_atom_chars_builtin/0.
 :- dynamic user:test_string_list_builtin/0.
+:- dynamic user:test_number_list_builtin/0.
 :- dynamic user:test_atom_string_builtin/0.
 :- dynamic user:test_set_aggregate/0.
 :- dynamic user:test_unify_builtin/0.
@@ -283,6 +284,31 @@ test(builtins_execution) :-
                 \+ string_chars(_, [ab]),
                 \+ string_chars(_, [1])
             )),
+          assertz(user:test_number_list_builtin :-
+            (   number_codes(42, Codes),
+                Codes = [52,50],
+                number_codes(42, [52,50]),
+                \+ number_codes(42, [52]),
+                number_codes(N2, [45,51]),
+                N2 =:= -3,
+                number_codes(F2, [51,46,53]),
+                F2 =:= 3.5,
+                \+ number_codes(_, _),
+                \+ number_codes(_, [foo]),
+                \+ number_codes(_, [65536]),
+                \+ number_codes(_, [97,98,99]),
+                number_chars(42, Chars),
+                Chars = ['4','2'],
+                number_chars(42, ['4','2']),
+                \+ number_chars(42, ['4']),
+                number_chars(N3, ['-','3']),
+                N3 =:= -3,
+                number_chars(F3, ['3','.','5']),
+                F3 =:= 3.5,
+                \+ number_chars(_, _),
+                \+ number_chars(_, [ab]),
+                \+ number_chars(_, [a,b,c])
+            )),
           assertz(user:test_atom_string_builtin :-
             (   atom_string(hello, S),
                 S == hello,
@@ -339,6 +365,7 @@ test(builtins_execution) :-
           retractall(user:test_atom_codes_builtin),
           retractall(user:test_atom_chars_builtin),
           retractall(user:test_string_list_builtin),
+          retractall(user:test_number_list_builtin),
           retractall(user:test_atom_string_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
@@ -349,7 +376,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -408,6 +435,8 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "atom_chars/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "string_codes/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "string_chars/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "number_codes/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "number_chars/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "atom_string/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "string_to_atom/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "\\\\+/1"')),
@@ -599,6 +628,14 @@ func main() {
 		fmt.Println("STRING_LIST_FAILURE")
 	}
 
+	numberListVM := wam.NewWamState(wam.Test_number_list_builtinCode, wam.Test_number_list_builtinLabels)
+	numberListVM.PC = wam.Test_number_list_builtinStartPC
+	if numberListVM.Run() {
+		fmt.Println("NUMBER_LIST_SUCCESS")
+	} else {
+		fmt.Println("NUMBER_LIST_FAILURE")
+	}
+
 	atomStringVM := wam.NewWamState(wam.Test_atom_string_builtinCode, wam.Test_atom_string_builtinLabels)
 	atomStringVM.PC = wam.Test_atom_string_builtinStartPC
 	if atomStringVM.Run() {
@@ -677,6 +714,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "ATOM_CODES_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_CHARS_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "STRING_LIST_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "NUMBER_LIST_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_STRING_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM number_codes/2 and number_chars/2 parity

## Summary

- Add direct Go WAM lowering for `number_codes/2` and `number_chars/2`.
- Implement runtime number/list conversion using the existing code-list and char-list text helpers plus the `atom_number/2` numeric parsing/formatting path.
- Cover number-to-list binding, bound-list success, mismatch failure, list-to-number binding for integer, negative, and float text, both-unbound failure, and invalid-list failure in the generated Go WAM builtin E2E test.
- Update the Go WAM parity audit to record number code-list and char-list conversion parity with the Clojure text conversion surface.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(number_codes/2,2), C), wam_go_target:wam_instruction_to_go_literal(call(number_chars/2,2), H), writeln(C), writeln(H), halt"`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`
