### PR TITLE
perf(test-cpp): cache wam_runtime.o across cpp_e2e_* tests + document parser-bundle bottleneck

### DIFF
--- a/docs/WAM_RUNTIME_PARSER_STATUS.md
+++ b/docs/WAM_RUNTIME_PARSER_STATUS.md
@@ -185,15 +185,84 @@ The Python target now has end-to-end tests in
 `tests/test_wam_python_target.pl` for bare-integer atoms,
 prefix-directive atoms, and prefix-NaF atoms.  The C++ target has
 end-to-end tests for parser-label presence in the generated source but
-nothing that actually builds + runs.  Building C++ projects with the
-~45-predicate parser library takes ~12 minutes per case unoptimised,
-which is the blocker.
+nothing that actually builds + runs the parser library.
 
-A cheap improvement: pre-compile the C++ runtime once into a static
-library at fixture setup, then each per-case build only links the
-generated-program against it.  Order-of-magnitude faster, and unlocks
-end-to-end coverage of `:- p` / `\+ foo` / numeric quoted atoms for
-C++ — bringing it to parity with Python's coverage.
+#### What the C++ build time actually looks like
+
+Two distinct cost paths:
+
+| project shape                            | files                              | g++ -O0 wall time |
+| ---------------------------------------- | ---------------------------------- | ----------------- |
+| **fact-shaped** (no `runtime_parser`)    | `main.cpp` + `wam_runtime.cpp` + small `generated_program.cpp` | ~6-7 s            |
+| **parser-bundled** (`runtime_parser(compiled)`) | same files, but `generated_program.cpp` is now ~42k lines / 2.8 MB carrying the WAM-compiled parser predicates | **~11 min**       |
+
+The 11 min figure for the parser-bundled case lands almost entirely on
+`generated_program.cpp` -- I measured the breakdown after the cache
+landed:
+
+|                          | g++ default flags | g++ minimal safety flags | clang++ default      |
+| ------------------------ | ----------------- | ------------------------ | -------------------- |
+| `wam_runtime.cpp`        | 4.4 s             | -                        | -                    |
+| `generated_program.cpp`  | ~11 min           | 3 min (segfaults at run) | 1.5 min (segfaults at run) |
+
+So `wam_runtime.cpp` is ~4 s of an 11-minute total -- pre-compiling
+just it isn't enough.  The minimal-flag g++ / clang variants are
+~4-8x faster but the resulting binaries crash at the first line of
+`wam_cpp_setup` -- looks like deep-stack UB driven by ~40k consecutive
+`vm.instrs.push_back(...)` temporaries that g++'s default stack
+protections happen to mask.  Fixing that UB would unlock the
+fast-compile path but is significant debugging work in the codegen.
+
+#### What landed
+
+Added a `wam_runtime.o` cache to `build_e2e_binary/2` (in
+`tests/test_wam_cpp_generator.pl`).  First call per unique runtime
+content compiles `wam_runtime.cpp` to a content-hashed .o under
+`/tmp/uw_cpp_runtime_cache/`; subsequent C++ e2e tests in the same
+session reuse it.
+
+Measured impact on the existing `cpp_e2e_fact / cpp_e2e_choice_backtracking
+/ cpp_e2e_caller` suite (small fact-shaped projects, no parser bundling):
+
+- cold cache: 12.0 s for the 3 tests
+- warm cache:  7.6 s for the 3 tests
+- 4.4 s saved (≈ 1.5 s / test, ≈ 36 % faster overall)
+
+The full C++ generator suite has ~30+ `cpp_e2e_*` tests, so the cache
+saves around 30 s per full test run -- modest but real, and it scales
+with the number of C++ e2e tests added later.
+
+For parser-bundled projects the cache saves the same 4.4 s, which is
+noise against the 11 min `generated_program.cpp` compile -- so the
+infrastructure exists but a true end-to-end parser test would still
+need either the UB fix (so clang/minimal-flag g++ can be used) or a
+codegen split.
+
+#### What's left
+
+The actual order-of-magnitude speedup the original plan suggested
+needs **codegen-level work**.  Two routes:
+
+- **Fix the UB so clang / minimal-flag g++ work.**  Investigate the
+  `wam_cpp_setup` stack-usage pattern in the C++ codegen (~40k
+  consecutive `Instruction::Foo(...)` temporaries inside a single
+  function) and either factor it into per-predicate setup functions or
+  switch to a static-array-of-Instruction-structs initialisation.
+  Either restructuring should also make clang's faster compile path
+  produce a working binary.
+
+- **Split the parser library into a separately-compiled file.**  The
+  `wam_cpp_setup` function currently registers labels and emits
+  instructions for parser + user predicates in one giant body.  If the
+  parser portion went into its own translation unit, it could be
+  cached the same way `wam_runtime.cpp` now is.  Bigger codegen
+  refactor; the per-test compile would still need to know the parser
+  library's instruction count to compute absolute label offsets for
+  the user predicates.
+
+Either approach unlocks per-case parser-bundled tests in the seconds
+range and brings C++ to parity with Python's end-to-end coverage of
+the `:- p` / `\+ foo` / numeric-quoted-atom shapes.
 
 ### Not on the plan
 

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -10371,11 +10371,48 @@ build_e2e_binary(TmpDir, BinPath) :-
     directory_file_path(CppDir, 'generated_program.cpp', Prog),
     directory_file_path(CppDir, 'main.cpp', Main),
     directory_file_path(CppDir, 'cpp_test', BinPath),
+    %% Pre-compile wam_runtime.cpp to a content-hashed cache directory
+    %% the first time we see this version of the runtime, then reuse
+    %% the .o file across every cpp_e2e_* test in the suite.  Saves the
+    %% ~4-5 second wam_runtime.cpp compile per case (was ~6-7s total
+    %% for fact-shaped projects).  The generated_program.cpp + main.cpp
+    %% still recompile per case since their content is test-specific.
+    %% See docs/WAM_RUNTIME_PARSER_STATUS.md for the bottleneck analysis
+    %% of why parser-bundled (runtime_parser(compiled)) projects still
+    %% take 11+ min/case even with this cache (the bulk is in
+    %% generated_program.cpp, not wam_runtime.cpp).
+    cached_wam_runtime_object(Rt, RuntimeObj),
     process_create(path('g++'),
-                   ['-std=c++17', '-O0', '-o', BinPath, Rt, Prog, Main],
+                   ['-std=c++17', '-O0', '-o', BinPath, RuntimeObj, Prog, Main],
                    [stderr(null), process(PID)]),
     process_wait(PID, Status),
     assertion(Status == exit(0)).
+
+%% cached_wam_runtime_object(+RuntimeCpp, -CachedObj)
+%
+%  Compile RuntimeCpp to a .o file in a content-hashed cache directory.
+%  First call per unique RuntimeCpp content does the compile; subsequent
+%  calls reuse the existing .o.  Compile uses the same flags as the
+%  non-cached build_e2e_binary so behaviour is preserved.
+cached_wam_runtime_object(RuntimeCpp, CachedObj) :-
+    use_module(library(crypto)),
+    crypto_file_hash(RuntimeCpp, Hash, [algorithm(sha256)]),
+    %% Per-suite cache directory under /tmp.  Sharing across suites is
+    %% intentional -- wam_runtime.cpp is the same content for every
+    %% C++ test in this repo's lifetime, so one compile per Prolog
+    %% release of the project is plenty.
+    CacheDir = '/tmp/uw_cpp_runtime_cache',
+    catch(make_directory_path(CacheDir), _, true),
+    format(atom(CachedObj), '~w/wam_runtime_~w.o', [CacheDir, Hash]),
+    (   exists_file(CachedObj)
+    ->  true
+    ;   process_create(path('g++'),
+                       ['-std=c++17', '-O0', '-c',
+                        '-o', CachedObj, RuntimeCpp],
+                       [stderr(null), process(PID)]),
+        process_wait(PID, Status),
+        assertion(Status == exit(0))
+    ).
 
 run_query(BinPath, PredKey, Args, Expected) :-
     maplist(atom_string, Args, ArgStrs),


### PR DESCRIPTION
## Summary

Picks up plan-forward thread (2) from #2437: speed up the C++ end-to-end test path.

## What landed

`build_e2e_binary/2` (in `tests/test_wam_cpp_generator.pl`) now pre-compiles `wam_runtime.cpp` to a content-hashed `.o` file under `/tmp/uw_cpp_runtime_cache/` and reuses it across every subsequent `cpp_e2e_*` test in the session.  Helper `cached_wam_runtime_object/2` keys the cache by SHA-256 of the runtime source so the `.o` is rebuilt automatically whenever `wam_runtime.cpp` changes.

## Measured impact (existing `cpp_e2e_*` suite, fact-shaped projects)

| state | time | per-test save |
| --- | ---: | ---: |
| cold cache (3 tests: fact, choice, caller) | 12.0 s | — |
| warm cache (same 3 tests) | 7.6 s | **1.5 s / test, ≈ 36% faster** |

The full C++ generator suite has ~30+ `cpp_e2e_*` tests; scaling the save linearly gives **~30 s per full test run**.  Modest but real, and the saving compounds as more C++ e2e tests are added.

## What didn't land, and why

The plan-forward language in #2437 said this should "drop test time from ~12 min/case to seconds."  That was based on the assumption that `wam_runtime.cpp` dominated the per-case build cost.  Profiling found otherwise:

| file | g++ -O0 (default flags) |
| --- | ---: |
| `wam_runtime.cpp` | 4.4 s |
| `generated_program.cpp` (parser-bundled, 42k lines / 2.8 MB) | **11+ min** |
| `main.cpp` | 1 s |

So caching `wam_runtime.o` saves 4.4 s of an 11-min total — a real win for the existing fact-shaped tests but barely a dent for parser-bundled (`runtime_parser(compiled)`) projects.

### Faster-compile paths explored but blocked by UB

Two alternative compile paths each ~4-8x faster on `generated_program.cpp`:

| path | wall time | binary status |
| --- | ---: | --- |
| g++ -O0 with safety flags off | 3 min | **segfaults at run time** |
| clang++ -O0 (any flag combo) | 1.5 min | **segfaults at run time** |

Both crash at the first line of `wam_cpp_setup` (`vm.instrs.clear()`), which looks like deep-stack UB driven by the ~40k consecutive `vm.instrs.push_back(Instruction::Foo(...))` temporaries inside a single function body.  g++'s default stack-protection flags happen to mask the problem.  Fixing the UB unlocks the fast-compile path but is significant codegen-level debugging — outside this PR's scope.

## Doc

Updated `docs/WAM_RUNTIME_PARSER_STATUS.md` section 3 ("cross-target test for the compiled path"):

- **"What the C++ build time actually looks like"** — two tables (project shape vs per-file/per-compiler breakdown).
- **"What landed"** — this PR's cache, with measured numbers.
- **"What's left"** — two concrete follow-up routes:
  1. Fix the UB in `wam_cpp_setup`'s stack pattern so clang / minimal-flag g++ produce working binaries (8x speedup).
  2. Split the parser library into a separately-compiled translation unit so its `.o` can be cached the same way `wam_runtime.o` now is (parser-bundled tests drop from minutes to seconds).

Either unlocks per-case parser-bundled tests in the seconds range and brings C++ to parity with Python's end-to-end coverage of the `:- p` / `\+ foo` / numeric-quoted-atom shapes.

## Test plan

- [x] `cpp_e2e_fact`, `cpp_e2e_choice_backtracking`, `cpp_e2e_caller` all pass with the new cache (3 dots, exit 0)
- [x] Cache file lands at `/tmp/uw_cpp_runtime_cache/wam_runtime_<sha256>.o` and is reused across calls
- [x] Cold-vs-warm cache wall-clock measurement matches the expected 4.4 s save
- [ ] CI green on `claude/wam-cpp-parser-test-speedup`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_