### PR TITLE
feat(wam-python): support read_string/5

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -1537,6 +1537,30 @@ def _execute_read_line_to_string(state: WamState) -> bool:
         chars.append(ch)
 
 
+def _execute_read_string(state: WamState) -> bool:
+    stream = deref(get_reg(state, 1), state)
+    raw = _unwrap_stream(stream)
+    length = deref(get_reg(state, 2), state)
+    if raw is None or not hasattr(raw, 'read'):
+        return False
+    if not isinstance(length, Int) or length.n < 0:
+        return False
+
+    chars: List[str] = []
+    for _ in range(length.n):
+        ch = _read_handle_char(state, stream)
+        if ch is None:
+            return False
+        if ch == '':
+            break
+        chars.append(ch)
+
+    text = ''.join(chars)
+    if not unify(get_reg(state, 3), Int(len(text)), state):
+        return False
+    return unify(get_reg(state, 5), make_atom(text), state)
+
+
 def _execute_read_from_stream(state: WamState, stream: Any, target: Term,
                               syntax_default: str = 'fail',
                               read_char: Optional[Callable[[], str]] = None) -> bool:
@@ -1801,6 +1825,8 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return _execute_put_code_stream(state)
     if builtin in ('read_line_to_string/2', 'read_line_to_string') and arity == 2:
         return _execute_read_line_to_string(state)
+    if builtin in ('read_string/5', 'read_string') and arity == 5:
+        return _execute_read_string(state)
     if builtin in ('read/1', 'read_lax/1', 'read_term/1', 'read_term_lax/1',
                    'read', 'read_lax', 'read_term', 'read_term_lax') and arity == 1:
         return _execute_read_default_stream(state, 'fail')

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -1073,6 +1073,37 @@ test(runtime_read_line_to_string_reads_file_lines) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_read_string_reads_bounded_chunks) :-
+	setup_call_cleanup(
+		(   retractall(user:py_read_string_demo),
+			user:python_parser_tmp_dir('tmp_wam_python_read_string', ProjectDir),
+			atomic_list_concat([ProjectDir, '/string.txt'], InFile),
+			assertz((user:py_read_string_demo :-
+				open(InFile, read, S),
+				peek_char(S, C0), C0 = h,
+				read_string(S, 5, N1, _, S1), N1 = 5, S1 = hello,
+				read_string(S, 100, N2, _, S2), N2 = 6, S2 = ' world',
+				read_string(S, 3, N3, _, S3), N3 = 0, S3 = '',
+				close(S)))
+		),
+		(   setup_call_cleanup(open(InFile, write, Input),
+				write(Input, 'hello world'),
+				close(Input)),
+			wam_python_target:write_wam_python_project([user:py_read_string_demo/0],
+				[runtime_parser(off)], ProjectDir),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_read_string_demo/0', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_read_string_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_runs_reverse_term_to_atom) :-
 	setup_call_cleanup(
 		(   retractall(user:py_term_to_atom_demo),
@@ -1583,6 +1614,7 @@ test(static_runtime_has_lua_baseline_builtins, [nondet]) :-
 		"get_code/2",
 		"peek_char/2",
 		"read_line_to_string/2",
+		"read_string/5",
 		"nl/0"
 	]), sub_string(Content, _, _, _, Needle)).
 
@@ -1598,6 +1630,7 @@ test(static_runtime_io_emits_output, [nondet]) :-
 	sub_string(Content, _, _, _, "def _execute_put_char"),
 	sub_string(Content, _, _, _, "def _execute_put_code"),
 	sub_string(Content, _, _, _, "def _execute_read_line_to_string"),
+	sub_string(Content, _, _, _, "def _execute_read_string"),
 	sub_string(Content, _, _, _, "print()").
 
 :- end_tests(wam_python_builtin_parity_guard).


### PR DESCRIPTION
## Summary

- Add WAM-Python runtime support for the project subset of `read_string/5`.
- Match the C++ target convention: `read_string(Stream, Length, ActualLength, _, String)`.
- Read up to `Length` characters from an opened text stream, unifying the actual character count and returned text.
- Reuse the existing stream pushback path, so `peek_char/2` and `read_string/5` interact correctly.
- Add a generated Python WAM file-stream test for bounded reads, remainder reads, EOF reads, and preceding `peek_char/2`.

## Notes

This complements `read_line_to_string/2` with a bounded/block read primitive for generated Python WAM programs. The fourth argument is accepted and ignored, following the minimal C++ target subset.

Invalid streams or negative/non-integer lengths fail quietly, consistent with the current lax Python WAM builtin behavior.

## Verification

- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode),run_tests(wam_python_builtin_parity_guard)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
