### PR TITLE
feat(wam-python): add stream EOF and output helpers

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -1561,6 +1561,49 @@ def _execute_read_string(state: WamState) -> bool:
     return unify(get_reg(state, 5), make_atom(text), state)
 
 
+def _execute_at_end_of_stream(state: WamState) -> bool:
+    stream = deref(get_reg(state, 1), state)
+    raw = _unwrap_stream(stream)
+    if raw is None or not hasattr(raw, 'read'):
+        return False
+    if state.stream_pushback.get(_stream_pushback_key(stream)):
+        return False
+    try:
+        if hasattr(raw, 'tell') and hasattr(raw, 'seek'):
+            pos = raw.tell()
+            ch = raw.read(1)
+            raw.seek(pos)
+            return ch == ''
+        ch = _peek_handle_char(state, stream)
+    except (OSError, ValueError):
+        return False
+    return ch == ''
+
+
+def _execute_write_to_stream(state: WamState) -> bool:
+    stream = deref(get_reg(state, 1), state)
+    raw = _unwrap_stream(stream)
+    if raw is None or not hasattr(raw, 'write'):
+        return False
+    try:
+        raw.write(_format_value(get_reg(state, 2), state))
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def _execute_nl_to_stream(state: WamState) -> bool:
+    stream = deref(get_reg(state, 1), state)
+    raw = _unwrap_stream(stream)
+    if raw is None or not hasattr(raw, 'write'):
+        return False
+    try:
+        raw.write('\n')
+    except (OSError, ValueError):
+        return False
+    return True
+
+
 def _execute_read_from_stream(state: WamState, stream: Any, target: Term,
                               syntax_default: str = 'fail',
                               read_char: Optional[Callable[[], str]] = None) -> bool:
@@ -1827,6 +1870,12 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return _execute_read_line_to_string(state)
     if builtin in ('read_string/5', 'read_string') and arity == 5:
         return _execute_read_string(state)
+    if builtin in ('at_end_of_stream/1', 'at_end_of_stream') and arity == 1:
+        return _execute_at_end_of_stream(state)
+    if builtin in ('write_to_stream/2', 'write_to_stream') and arity == 2:
+        return _execute_write_to_stream(state)
+    if builtin in ('nl_to_stream/1', 'nl_to_stream') and arity == 1:
+        return _execute_nl_to_stream(state)
     if builtin in ('read/1', 'read_lax/1', 'read_term/1', 'read_term_lax/1',
                    'read', 'read_lax', 'read_term', 'read_term_lax') and arity == 1:
         return _execute_read_default_stream(state, 'fail')

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -1104,6 +1104,47 @@ test(runtime_read_string_reads_bounded_chunks) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_stream_eof_and_output_helpers) :-
+	setup_call_cleanup(
+		(   retractall(user:py_stream_helper_demo),
+			user:python_parser_tmp_dir('tmp_wam_python_stream_helpers', ProjectDir),
+			atomic_list_concat([ProjectDir, '/eof.txt'], InFile),
+			atomic_list_concat([ProjectDir, '/stream_out.txt'], OutFile),
+			assertz((user:py_stream_helper_demo :-
+				open(InFile, read, In),
+				\+ at_end_of_stream(In),
+				peek_char(In, C0), C0 = z,
+				\+ at_end_of_stream(In),
+				get_char(In, C1), C1 = z,
+				at_end_of_stream(In),
+				close(In),
+				open(OutFile, write, Out),
+				write_to_stream(Out, alpha),
+				nl_to_stream(Out),
+				write_to_stream(Out, pair(beta, 2)),
+				close(Out)))
+		),
+		(   setup_call_cleanup(open(InFile, write, Input),
+				write(Input, z),
+				close(Input)),
+			wam_python_target:write_wam_python_project([user:py_stream_helper_demo/0],
+				[runtime_parser(off)], ProjectDir),
+			atomic_list_concat([
+				"import pathlib",
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_stream_helper_demo/0', state))",
+				"print(repr(pathlib.Path('stream_out.txt').read_text()))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True")),
+			once(sub_string(Output, _, _, _, "'alpha\\npair(beta, 2)'"))
+		),
+		(   retractall(user:py_stream_helper_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_runs_reverse_term_to_atom) :-
 	setup_call_cleanup(
 		(   retractall(user:py_term_to_atom_demo),
@@ -1615,6 +1656,9 @@ test(static_runtime_has_lua_baseline_builtins, [nondet]) :-
 		"peek_char/2",
 		"read_line_to_string/2",
 		"read_string/5",
+		"at_end_of_stream/1",
+		"write_to_stream/2",
+		"nl_to_stream/1",
 		"nl/0"
 	]), sub_string(Content, _, _, _, Needle)).
 
@@ -1631,6 +1675,9 @@ test(static_runtime_io_emits_output, [nondet]) :-
 	sub_string(Content, _, _, _, "def _execute_put_code"),
 	sub_string(Content, _, _, _, "def _execute_read_line_to_string"),
 	sub_string(Content, _, _, _, "def _execute_read_string"),
+	sub_string(Content, _, _, _, "def _execute_at_end_of_stream"),
+	sub_string(Content, _, _, _, "def _execute_write_to_stream"),
+	sub_string(Content, _, _, _, "def _execute_nl_to_stream"),
 	sub_string(Content, _, _, _, "print()").
 
 :- end_tests(wam_python_builtin_parity_guard).


### PR DESCRIPTION
## Summary

- add Python WAM runtime support for `at_end_of_stream/1`
- add stream output helpers `write_to_stream/2` and `nl_to_stream/1`
- cover generated-project stream EOF probing, pushback preservation, and file output
- extend the Python builtin parity guard for the new common WAM stream helpers

## Notes

`at_end_of_stream/1` uses `tell`/`seek` for seekable host streams so EOF checks do not consume input, including when called under `\+/1` with an isolated WAM state. It still respects existing stream pushback before probing the underlying file cursor.

## Verification

- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode),run_tests(wam_python_builtin_parity_guard)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
