### PR TITLE
Feat/wam go ground builtin

### DIFF
--- a/PR_go_wam_ground_builtin.md
+++ b/PR_go_wam_ground_builtin.md
@@ -1,0 +1,30 @@
+# PR Title
+
+Add Go WAM ground/1 builtin parity
+
+# PR Description
+
+## Summary
+
+- Adds direct Go WAM lowering for `ground/1`.
+- Implements generated Go runtime groundness checks for atoms, numbers, compounds, structures, lists, and empty lists.
+- Extends the Go WAM builtin E2E test with positive and negative `ground/1` cases, including nested unbound variables and list placeholders.
+- Updates the Go WAM parity audit to record `ground/1` coverage against the current cross-target baseline.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(ground/1,1), G), writeln(G), halt"`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`
+
+## Push
+
+```sh
+git push -u origin feat/wam-go-ground-builtin
+```

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -12,7 +12,7 @@ current cross-target builtin/runtime baseline.
 | Direct fact dispatch | `call_indexed_atom_fact2`, `AtomFact2Source` registry, TSV-backed and LMDB-artifact atom fact loading, foreign/native kernel registration, indexed atom/weighted fact tables | `call_indexed_atom_fact2`, inline/external fact stream paths | Present for current external atom fact-source baseline |
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
 | Structural builtins | `member/2`, `memberchk/2`, `select/3`, `delete/3`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `select/3`, `delete/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
-| Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1` | Includes `is_list/1` in the current baseline | Present for current baseline type checks |
+| Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1`, `ground/1` | Includes `is_list/1` and Clojure direct `ground/1` in the current baseline | Present for current baseline type and groundness checks |
 | Arithmetic builtins | `is/2`, `succ/2` | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir | Present for current baseline arithmetic checks, with expanded successor coverage |
 | Atom/text conversion | `atom_number/2`, `atom_codes/2`, `atom_chars/2`, `string_codes/2`, `string_chars/2`, `number_codes/2`, `number_chars/2`, `atom_string/2`, `string_to_atom/2`, `upcase_atom/2`, `downcase_atom/2`, `atom_concat/3`, `atom_length/2`, `string_length/2`, `char_code/2` | Clojure direct builtin surface includes bidirectional `atom_number/2`, atom/string/number code-list and char-list conversion, atom/string conversion, atom case conversion, deterministic atom concatenation, text length checks, and char-code conversion | Present for current atom-number, atom/string/number code-list, atom/string/number char-list, atom/string, atom-case, atom-concat, text-length, and char-code checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` | Includes `=</2`; Haskell mode analysis and Clojure lowering also cover term-order comparisons | Present for current baseline comparisons, with expanded term-order coverage |
@@ -64,6 +64,10 @@ current cross-target builtin/runtime baseline.
   atom/integer ordering used by Go WAM sort and indexed-switch ordering,
   matching the Clojure term-order lowering surface and the Haskell mode
   analysis baseline.
+- `ground/1` is now covered by the generated Go WAM builtin E2E test for
+  ground atoms, numbers, compounds, lists, empty lists, fresh variables,
+  nested unbound compound arguments, and list elements with unbound variables,
+  matching the current Clojure groundness surface.
 - Bidirectional `succ/2` is now covered by the generated Go WAM builtin E2E
   test for forward binding, reverse binding, matching integer pairs, mismatch
   failure, negative predecessor failure, non-positive successor failure, and

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -460,6 +460,9 @@ wam_go_direct_builtin("@>=/2", 2, '@>=/2').
 wam_go_direct_builtin(compare/3, 3, 'compare/3').
 wam_go_direct_builtin('compare/3', 3, 'compare/3').
 wam_go_direct_builtin("compare/3", 3, 'compare/3').
+wam_go_direct_builtin(ground/1, 1, 'ground/1').
+wam_go_direct_builtin('ground/1', 1, 'ground/1').
+wam_go_direct_builtin("ground/1", 1, 'ground/1').
 wam_go_direct_builtin(succ/2, 2, 'succ/2').
 wam_go_direct_builtin('succ/2', 2, 'succ/2').
 wam_go_direct_builtin("succ/2", 2, 'succ/2').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -674,6 +674,34 @@ func (vm *WamState) heapConsAfterUnbound(v *Unbound) (Value, bool) {
 	return nil, false
 }
 
+func (vm *WamState) heapListAfterUnbound(v *Unbound) (Value, bool) {
+	found := false
+	for i := 0; i < vm.HeapLen; i++ {
+		cell := vm.Heap[i]
+		if cell == v {
+			found = true
+			continue
+		}
+		if !found {
+			continue
+		}
+		next := vm.deref(cell)
+		switch t := next.(type) {
+		case *List:
+			return next, true
+		case *Compound:
+			if isConsFunctor(t.Functor) && len(t.Args) == 2 {
+				return next, true
+			}
+		case *Structure:
+			if isConsFunctor(t.Functor) && len(t.Args) == 2 {
+				return next, true
+			}
+		}
+	}
+	return nil, false
+}
+
 func (vm *WamState) listHeadTail(list *List) (Value, Value, bool) {
 	switch len(list.Elements) {
 	case 0:
@@ -904,6 +932,64 @@ func (vm *WamState) copyTermValue(v Value, seen map[int]*Unbound) Value {
 		return &List{Elements: items}
 	default:
 		return t
+	}
+}
+
+func (vm *WamState) groundTerm(v Value, seen map[Value]bool) bool {
+	v = vm.deref(v)
+	switch t := v.(type) {
+	case *Unbound:
+		if next, ok := vm.heapConsAfterUnbound(t); ok {
+			return vm.groundTerm(next, seen)
+		}
+		if next, ok := vm.heapListAfterUnbound(t); ok {
+			return vm.groundTerm(next, seen)
+		}
+		return false
+	case *Atom, *Integer, *Float:
+		return true
+	case *Compound:
+		if seen[t] {
+			return true
+		}
+		seen[t] = true
+		for _, arg := range t.Args {
+			if !vm.groundTerm(arg, seen) {
+				return false
+			}
+		}
+		return true
+	case *Structure:
+		if seen[t] {
+			return true
+		}
+		seen[t] = true
+		for _, arg := range t.Args {
+			if !vm.groundTerm(arg, seen) {
+				return false
+			}
+		}
+		return true
+	case *List:
+		if isEmptyListValue(t) {
+			return true
+		}
+		if seen[t] {
+			return true
+		}
+		seen[t] = true
+		items, ok := vm.listToSlice(t)
+		if !ok {
+			return false
+		}
+		for _, item := range items {
+			if !vm.groundTerm(item, seen) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
 	}
 }
 
@@ -1349,6 +1435,7 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 	case "number/1": return isNumber(vm.deref(arg1))
 	case "compound/1": return isCompound(vm.deref(arg1))
 	case "atomic/1": return isAtomic(vm.deref(arg1))
+	case "ground/1": return vm.groundTerm(arg1, make(map[Value]bool))
 	case "is_list/1": return isList(vm.deref(arg1))
 
 	case "==/2": return valueEquals(vm.deref(arg1), vm.deref(arg2))

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -17,6 +17,7 @@
 :- dynamic user:test_numlist_builtin/0.
 :- dynamic user:test_sort_builtin/0.
 :- dynamic user:test_term_order_builtin/0.
+:- dynamic user:test_ground_builtin/0.
 :- dynamic user:test_succ_builtin/0.
 :- dynamic user:test_atom_number_builtin/0.
 :- dynamic user:test_atom_case_builtin/0.
@@ -157,6 +158,17 @@ test(builtins_execution) :-
                 compare(<, bar, foo),
                 compare(=, foo, foo),
                 compare(>, 2, 1)
+            )),
+          assertz(user:test_ground_builtin :-
+            (   ground(hello),
+                ground(42),
+                ground(foo(1, [2, 3], bar)),
+                ground([a,b,c]),
+                ground([]),
+                \+ ground(_),
+                \+ (Scratch = [z], ground(_), Scratch = [z]),
+                \+ ground(foo(1, _, 3)),
+                \+ ground([a, _])
             )),
           assertz(user:test_succ_builtin :-
             (   succ(0, 1),
@@ -356,6 +368,7 @@ test(builtins_execution) :-
           retractall(user:test_numlist_builtin),
           retractall(user:test_sort_builtin),
           retractall(user:test_term_order_builtin),
+          retractall(user:test_ground_builtin),
           retractall(user:test_succ_builtin),
           retractall(user:test_atom_number_builtin),
           retractall(user:test_atom_case_builtin),
@@ -376,7 +389,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -423,6 +436,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "@>/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "@>=/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "compare/3"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "ground/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "succ/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "atom_number/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "upcase_atom/2"')),
@@ -554,6 +568,14 @@ func main() {
 		fmt.Println("TERM_ORDER_SUCCESS")
 	} else {
 		fmt.Println("TERM_ORDER_FAILURE")
+	}
+
+	groundVM := wam.NewWamState(wam.Test_ground_builtinCode, wam.Test_ground_builtinLabels)
+	groundVM.PC = wam.Test_ground_builtinStartPC
+	if groundVM.Run() {
+		fmt.Println("GROUND_SUCCESS")
+	} else {
+		fmt.Println("GROUND_FAILURE")
 	}
 
 	succVM := wam.NewWamState(wam.Test_succ_builtinCode, wam.Test_succ_builtinLabels)
@@ -705,6 +727,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "NUMLIST_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SORT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "TERM_ORDER_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "GROUND_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SUCC_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_NUMBER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_CASE_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM ground/1 builtin parity

## Summary

- Adds direct Go WAM lowering for `ground/1`.
- Implements generated Go runtime groundness checks for atoms, numbers, compounds, structures, lists, and empty lists.
- Extends the Go WAM builtin E2E test with positive and negative `ground/1` cases, including nested unbound variables and list placeholders.
- Updates the Go WAM parity audit to record `ground/1` coverage against the current cross-target baseline.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(ground/1,1), G), writeln(G), halt"`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`

## Push

```sh
git push -u origin feat/wam-go-ground-builtin
```
