### PR TITLE
feat(wam-python): add atom and string helper builtins

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -739,6 +739,48 @@ def _execute_number_codes(state: WamState) -> bool:
         return False
 
 
+def _text_coerce(value: Term, state: WamState, allow_float: bool = True) -> Optional[str]:
+    value = deref(value, state)
+    if isinstance(value, Atom):
+        return _runtime_atom_text(value.name)
+    if isinstance(value, Int):
+        return str(value.n)
+    if allow_float and isinstance(value, Float):
+        return _format_value(value, state)
+    return None
+
+
+def _execute_atom_concat(state: WamState) -> bool:
+    left = _text_coerce(get_reg(state, 1), state)
+    right = _text_coerce(get_reg(state, 2), state)
+    if left is None or right is None:
+        return False
+    return unify(get_reg(state, 3), make_atom(left + right), state)
+
+
+def _execute_atom_length(state: WamState) -> bool:
+    text = _text_coerce(get_reg(state, 1), state, allow_float=False)
+    if text is None:
+        return False
+    return unify(get_reg(state, 2), Int(len(text)), state)
+
+
+def _execute_atom_string(state: WamState) -> bool:
+    left = deref(get_reg(state, 1), state)
+    right = deref(get_reg(state, 2), state)
+    if not isinstance(left, Var):
+        text = _text_coerce(left, state)
+        if text is None:
+            return False
+        return unify(get_reg(state, 2), make_atom(text), state)
+    if isinstance(right, Var):
+        return False
+    text = _text_coerce(right, state)
+    if text is None:
+        return False
+    return unify(get_reg(state, 1), make_atom(text), state)
+
+
 def _execute_append(state: WamState) -> bool:
     left = _term_to_list(get_reg(state, 1), state)
     right = _term_to_list(get_reg(state, 2), state)
@@ -1833,6 +1875,12 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return _execute_atom_codes(state)
     if builtin in ('number_codes/2', 'number_codes') and arity == 2:
         return _execute_number_codes(state)
+    if builtin in ('atom_concat/3', 'atom_concat', 'string_concat/3', 'string_concat') and arity == 3:
+        return _execute_atom_concat(state)
+    if builtin in ('atom_length/2', 'atom_length', 'string_length/2', 'string_length') and arity == 2:
+        return _execute_atom_length(state)
+    if builtin in ('atom_string/2', 'atom_string', 'string_to_atom/2', 'string_to_atom') and arity == 2:
+        return _execute_atom_string(state)
     if builtin in ('read_term_from_atom/2', 'read_term_from_atom_lax/2',
                    'read_term_from_atom', 'read_term_from_atom_lax') and arity == 2:
         return _execute_read_term_from_atom(state, 2, 'fail')

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -1145,6 +1145,36 @@ test(runtime_stream_eof_and_output_helpers) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_atom_string_helpers) :-
+	setup_call_cleanup(
+		(   retractall(user:py_atom_string_helper_demo),
+			assertz((user:py_atom_string_helper_demo :-
+				atom_concat(foo, bar, FooBar), FooBar = foobar,
+				string_concat(FooBar, 7, FooBar7), FooBar7 = foobar7,
+				atom_length(FooBar7, 7),
+				string_length(123, 3),
+				atom_string(Atom, baz), Atom = baz,
+				atom_string(99, Text), Text = '99',
+				string_to_atom(qux, Q), Q = qux,
+				\+ atom_concat(_, b, ab),
+				\+ atom_length(f(1), _))),
+			user:python_parser_tmp_dir('tmp_wam_python_atom_string_helpers', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_atom_string_helper_demo/0],
+				[runtime_parser(off)], ProjectDir),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_atom_string_helper_demo/0', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_atom_string_helper_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_runs_reverse_term_to_atom) :-
 	setup_call_cleanup(
 		(   retractall(user:py_term_to_atom_demo),
@@ -1626,6 +1656,12 @@ test(static_runtime_has_lua_baseline_builtins, [nondet]) :-
 		"float/1",
 		"number/1",
 		"compound/1",
+		"atom_concat/3",
+		"atom_length/2",
+		"atom_string/2",
+		"string_concat/3",
+		"string_length/2",
+		"string_to_atom/2",
 		"var/1",
 		"nonvar/1",
 		"is_list/1",
@@ -1678,6 +1714,9 @@ test(static_runtime_io_emits_output, [nondet]) :-
 	sub_string(Content, _, _, _, "def _execute_at_end_of_stream"),
 	sub_string(Content, _, _, _, "def _execute_write_to_stream"),
 	sub_string(Content, _, _, _, "def _execute_nl_to_stream"),
+	sub_string(Content, _, _, _, "def _execute_atom_concat"),
+	sub_string(Content, _, _, _, "def _execute_atom_length"),
+	sub_string(Content, _, _, _, "def _execute_atom_string"),
 	sub_string(Content, _, _, _, "print()").
 
 :- end_tests(wam_python_builtin_parity_guard).


### PR DESCRIPTION
## Summary

- add Python WAM runtime support for `atom_concat/3` and `string_concat/3`
- add deterministic length helpers `atom_length/2` and `string_length/2`
- add atom/string coercion helpers `atom_string/2` and `string_to_atom/2`
- cover generated-project behavior for supported forward/coercion modes and unsupported split/type modes
- extend the Python builtin parity guard for these common text builtins

## Notes

This mirrors the current C++ target scope: concat is deterministic when the first two arguments are available, and the nondeterministic split mode such as `atom_concat(-, -, +)` remains unsupported for now.

## Verification

- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode),run_tests(wam_python_builtin_parity_guard)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
