### PR TITLE
feat(wam-clojure): support generated lists for length

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -765,9 +765,7 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "length/2" ; Op == 'length/2'),
     !,
-    format(atom(Expr),
-           '(let [list-value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A1") ::lowered-unbound)) len (runtime/proper-list-length ~w list-value) out (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound))] (if (some? len) (let [[ok next-state] (runtime/unify-values ~w out len)] (if ok (runtime/advance next-state) (runtime/backtrack ~w))) (runtime/backtrack ~w)))',
-           [S, S, S, S, S, S, S, S]).
+    format(atom(Expr), '(runtime/apply-length-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "member/2" ; Op == 'member/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -709,6 +709,7 @@
 (declare apply-append-solution)
 (declare apply-first-foreign-solution)
 (declare list->term)
+(declare fresh-var)
 
 (defn push-member-choice-point [state base-state resume-pc elem rest-list]
   (let [rest* (deref-value (:bindings base-state) rest-list)
@@ -1445,6 +1446,52 @@
           (normalize-literal-atom ctx "[]")
           (reverse items)))
 
+(defn length-count-value [state value]
+  (cond
+    (integer? value) value
+    (string? value) (parse-number-text value)
+    (atom-term? value) (parse-number-text (atom-text state value))
+    :else nil))
+
+(defn generated-list-term [state n]
+  (when (and (integer? n) (not (neg? n)))
+    (loop [s state
+           remaining n
+           items []]
+      (if (zero? remaining)
+        [(list->term (:intern-context s) items) s]
+        (let [[fresh s*] (fresh-var s)]
+          (recur s* (dec remaining) (conj items fresh)))))))
+
+(defn apply-length-solution [state]
+  (let [list-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A2") ::unbound))
+        len (proper-list-length state list-value)
+        out-count (length-count-value state out)]
+    (cond
+      (some? len)
+      (if (logic-var? out)
+        (let [[ok next-state] (unify-values state out len)]
+          (if ok
+            (advance next-state)
+            (backtrack state)))
+        (if (= out-count len)
+          (advance state)
+          (backtrack state)))
+
+      (and (logic-var? list-value) (integer? out-count) (not (neg? out-count)))
+      (if-let [[list-term generated-state] (generated-list-term state out-count)]
+        (let [[ok next-state] (unify-values generated-state list-value list-term)]
+          (if ok
+            (advance next-state)
+            (backtrack state)))
+        (backtrack state))
+
+      :else
+      (backtrack state))))
+
 (defn univ-decompose-term [state term]
   (let [term* (deref-value (:bindings state) term)
         ctx (:intern-context state)]
@@ -2108,17 +2155,7 @@
               (backtrack state)))
 
           "length/2"
-          (let [list-value (deref-value (:bindings state)
-                                        (or (reg-get-raw state "A1") ::unbound))
-                len (proper-list-length state list-value)
-                out (deref-value (:bindings state)
-                                 (or (reg-get-raw state "A2") ::unbound))]
-            (if (some? len)
-              (let [[ok next-state] (unify-values state out len)]
-                (if ok
-                  (advance next-state)
-                  (backtrack state)))
-              (backtrack state)))
+          (apply-length-solution state)
 
           "member/2"
           (let [elem (deref-value (:bindings state)

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -524,11 +524,8 @@ test(simple_builtin_length_is_direct_lowered_in_prefix) :-
         WamCode = "test_length/2:\nbuiltin_call length/2, 2\nproceed\n",
         wam_clojure_lowerable(test_length/2, WamCode, deterministic),
         lower_predicate_to_clojure(test_length/2, WamCode, [], Code),
-        has(Code, "runtime/deref-value"),
-        has(Code, "runtime/proper-list-length"),
-        has(Code, "runtime/unify-values"),
-        has(Code, "runtime/advance"),
-        has(Code, "runtime/backtrack")
+        has(Code, "runtime/apply-length-solution"),
+        assertion(\+ has(Code, "runtime/proper-list-length"))
     )).
 
 test(simple_builtin_member_is_direct_lowered_in_prefix) :-

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -77,6 +77,8 @@
 :- dynamic user:wam_length_guard/2.
 :- dynamic user:wam_length_bad_list/1.
 :- dynamic user:wam_length_unbound_list/1.
+:- dynamic user:wam_length_generate_list/0.
+:- dynamic user:wam_length_negative_generate/0.
 :- dynamic user:wam_member_guard/2.
 :- dynamic user:wam_member_backtrack_b/0.
 :- dynamic user:wam_member_unbound_list/1.
@@ -321,6 +323,8 @@ user:wam_is_list_unbound(_) :- user:wam_unbound_arg(Y), is_list(Y).
 user:wam_length_guard(L, N) :- length(L, N).
 user:wam_length_bad_list(N) :- length([a|b], N).
 user:wam_length_unbound_list(N) :- user:wam_unbound_arg(Y), length(Y, N).
+user:wam_length_generate_list :- user:wam_unbound_arg(Y), length(Y, 2), Y = [_,_].
+user:wam_length_negative_generate :- user:wam_unbound_arg(Y), length(Y, -1).
 user:wam_member_guard(X, L) :- member(X, L).
 user:wam_member_backtrack_b :- member(X, [a,b]), X = b.
 user:wam_member_unbound_list(X) :- user:wam_unbound_arg(Y), member(X, Y).
@@ -570,6 +574,8 @@ run_smoke :-
           user:wam_length_guard/2,
           user:wam_length_bad_list/1,
           user:wam_length_unbound_list/1,
+          user:wam_length_generate_list/0,
+          user:wam_length_negative_generate/0,
           user:wam_member_guard/2,
           user:wam_member_backtrack_b/0,
           user:wam_member_unbound_list/1,
@@ -920,7 +926,9 @@ smoke_cases([
     case('wam_length_guard/2', args('[a,b]', 1), "false"),
     case('wam_length_guard/2', args('[]', 0), "true"),
     case('wam_length_bad_list/1', 1, "false"),
-    case('wam_length_unbound_list/1', 0, "false"),
+    case('wam_length_unbound_list/1', 0, "true"),
+    case('wam_length_generate_list/0', no_args, "true"),
+    case('wam_length_negative_generate/0', no_args, "false"),
     case('wam_member_guard/2', args(a, '[a,b]'), "true"),
     case('wam_member_guard/2', args(b, '[a,b]'), "true"),
     case('wam_member_guard/2', args(c, '[a,b]'), "false"),
@@ -1323,7 +1331,9 @@ assert_lowered_length_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-length-guard-2"),
     has(CoreCode, "defn lowered-wam-length-bad-list-1"),
     has(CoreCode, "defn lowered-wam-length-unbound-list-1"),
-    has(CoreCode, "runtime/proper-list-length").
+    has(CoreCode, "defn lowered-wam-length-generate-list-0"),
+    has(CoreCode, "defn lowered-wam-length-negative-generate-0"),
+    has(CoreCode, "runtime/apply-length-solution").
 
 assert_lowered_member_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary
- Adds bounded generated-list support for Clojure WAM `length/2` when the list side is unbound and the length side is a non-negative integer.
- Routes both shared runtime dispatch and lowered `length/2` emission through `runtime/apply-length-solution`.
- Normalizes compiled integer constants for `length/2`, so generated WAM constants like `"2"` behave as integer lengths in this helper.
- Adds runtime smoke coverage for `length(Y, 0)`, `length(Y, 2), Y = [_,_]`, and negative length failure.

## Why
Clojure WAM previously failed conservatively whenever the list side of `length/2` was unbound. Supporting the bounded integer-length mode brings it closer to Prolog semantics without opening infinite generation for `length(L, N)` when both sides are unbound.

## Validation
- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
