### PR TITLE
feat(wam-python): add number and char conversion helpers

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -705,6 +705,48 @@ def _list_from_codes(codes: List[int]) -> 'Term':
     return _list_from_terms([Int(code) for code in codes])
 
 
+def _chars_from_list(term: 'Term', state: WamState) -> Optional[List[str]]:
+    items = _term_to_list(term, state)
+    if items is None:
+        return None
+    chars: List[str] = []
+    for item in items:
+        value = deref(item, state)
+        if not isinstance(value, Atom):
+            return None
+        text = _runtime_atom_text(value.name)
+        if len(text) != 1:
+            return None
+        chars.append(text)
+    return chars
+
+
+def _list_from_chars(chars: List[str]) -> 'Term':
+    return _list_from_terms([make_atom(ch) for ch in chars])
+
+
+def _parse_number_text(text: str) -> Optional[Term]:
+    if text == '':
+        return None
+    try:
+        return Int(int(text, 10))
+    except ValueError:
+        pass
+    try:
+        return Float(float(text))
+    except ValueError:
+        return None
+
+
+def _number_text(value: Term, state: WamState) -> Optional[str]:
+    value = deref(value, state)
+    if isinstance(value, Int):
+        return str(value.n)
+    if isinstance(value, Float):
+        return _format_value(value, state)
+    return None
+
+
 def _execute_atom_codes(state: WamState) -> bool:
     atom_term = deref(get_reg(state, 1), state)
     codes_term = deref(get_reg(state, 2), state)
@@ -779,6 +821,58 @@ def _execute_atom_string(state: WamState) -> bool:
     if text is None:
         return False
     return unify(get_reg(state, 1), make_atom(text), state)
+
+
+def _execute_number_chars(state: WamState) -> bool:
+    number_text = _number_text(get_reg(state, 1), state)
+    if number_text is not None:
+        return unify(get_reg(state, 2), _list_from_chars(list(number_text)), state)
+    chars = _chars_from_list(get_reg(state, 2), state)
+    if chars is None:
+        return False
+    parsed = _parse_number_text(''.join(chars))
+    if parsed is None:
+        return False
+    return unify(get_reg(state, 1), parsed, state)
+
+
+def _execute_atom_number(state: WamState) -> bool:
+    atom_term = deref(get_reg(state, 1), state)
+    if not isinstance(atom_term, Var):
+        if not isinstance(atom_term, Atom):
+            return False
+        parsed = _parse_number_text(_runtime_atom_text(atom_term.name))
+        if parsed is None:
+            return False
+        return unify(get_reg(state, 2), parsed, state)
+    text = _number_text(get_reg(state, 2), state)
+    if text is None:
+        return False
+    return unify(get_reg(state, 1), make_atom(text), state)
+
+
+def _execute_char_code(state: WamState) -> bool:
+    char_term = deref(get_reg(state, 1), state)
+    code_term = deref(get_reg(state, 2), state)
+    if isinstance(char_term, Atom):
+        text = _runtime_atom_text(char_term.name)
+        if len(text) != 1:
+            return False
+        return unify(get_reg(state, 2), Int(ord(text)), state)
+    if isinstance(code_term, Int) and 0 <= code_term.n <= 255:
+        return unify(get_reg(state, 1), make_atom(chr(code_term.n)), state)
+    return False
+
+
+def _execute_string_code(state: WamState) -> bool:
+    index = deref(get_reg(state, 1), state)
+    text_term = deref(get_reg(state, 2), state)
+    if not isinstance(index, Int) or not isinstance(text_term, Atom):
+        return False
+    text = _runtime_atom_text(text_term.name)
+    if index.n < 1 or index.n > len(text):
+        return False
+    return unify(get_reg(state, 3), Int(ord(text[index.n - 1])), state)
 
 
 def _execute_append(state: WamState) -> bool:
@@ -1881,6 +1975,14 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return _execute_atom_length(state)
     if builtin in ('atom_string/2', 'atom_string', 'string_to_atom/2', 'string_to_atom') and arity == 2:
         return _execute_atom_string(state)
+    if builtin in ('number_chars/2', 'number_chars') and arity == 2:
+        return _execute_number_chars(state)
+    if builtin in ('atom_number/2', 'atom_number') and arity == 2:
+        return _execute_atom_number(state)
+    if builtin in ('char_code/2', 'char_code') and arity == 2:
+        return _execute_char_code(state)
+    if builtin in ('string_code/3', 'string_code') and arity == 3:
+        return _execute_string_code(state)
     if builtin in ('read_term_from_atom/2', 'read_term_from_atom_lax/2',
                    'read_term_from_atom', 'read_term_from_atom_lax') and arity == 2:
         return _execute_read_term_from_atom(state, 2, 'fail')

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -1175,6 +1175,39 @@ test(runtime_atom_string_helpers) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_number_char_helpers) :-
+	setup_call_cleanup(
+		(   retractall(user:py_number_char_helper_demo),
+			assertz((user:py_number_char_helper_demo :-
+				number_chars(120, Chars), Chars = ['1', '2', '0'],
+				number_chars(N, ['-', '4', '2']), N = -42,
+				number_chars(F, ['3', '.', '5']), F = 3.5,
+				atom_number('17', AN), AN = 17,
+				atom_number(Atom, 2.5), Atom = '2.5',
+				char_code(a, Code), Code = 97,
+				char_code(Char, 98), Char = b,
+				string_code(2, abc, BCode), BCode = 98,
+				\+ number_chars(_, []),
+				\+ atom_number(not_a_number, _),
+				\+ char_code(ab, _),
+				\+ string_code(4, abc, _))),
+			user:python_parser_tmp_dir('tmp_wam_python_number_char_helpers', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_number_char_helper_demo/0],
+				[runtime_parser(off)], ProjectDir),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_number_char_helper_demo/0', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_number_char_helper_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_runs_reverse_term_to_atom) :-
 	setup_call_cleanup(
 		(   retractall(user:py_term_to_atom_demo),
@@ -1662,6 +1695,10 @@ test(static_runtime_has_lua_baseline_builtins, [nondet]) :-
 		"string_concat/3",
 		"string_length/2",
 		"string_to_atom/2",
+		"number_chars/2",
+		"atom_number/2",
+		"char_code/2",
+		"string_code/3",
 		"var/1",
 		"nonvar/1",
 		"is_list/1",
@@ -1717,6 +1754,10 @@ test(static_runtime_io_emits_output, [nondet]) :-
 	sub_string(Content, _, _, _, "def _execute_atom_concat"),
 	sub_string(Content, _, _, _, "def _execute_atom_length"),
 	sub_string(Content, _, _, _, "def _execute_atom_string"),
+	sub_string(Content, _, _, _, "def _execute_number_chars"),
+	sub_string(Content, _, _, _, "def _execute_atom_number"),
+	sub_string(Content, _, _, _, "def _execute_char_code"),
+	sub_string(Content, _, _, _, "def _execute_string_code"),
 	sub_string(Content, _, _, _, "print()").
 
 :- end_tests(wam_python_builtin_parity_guard).


### PR DESCRIPTION
## Summary

- add Python WAM runtime support for `number_chars/2`
- add bidirectional `atom_number/2`
- add `char_code/2` and `string_code/3`
- add shared helpers for char-list conversion and numeric text parsing
- cover generated-project success and failure cases for the new builtins
- extend the Python builtin parity guard for these common conversion helpers

## Notes

The implementation mirrors the current C++ target scope: conversions are deterministic, invalid numeric text fails quietly, `char_code/2` accepts byte-range codes, and `string_code/3` uses 1-based indexing.

## Verification

- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode),run_tests(wam_python_builtin_parity_guard)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
