### PR TITLE
Add Go WAM forward-mode sub_atom/5 builtin

### DIFF
--- a/PR_go_wam_sub_atom_forward.md
+++ b/PR_go_wam_sub_atom_forward.md
@@ -1,0 +1,31 @@
+# PR Title
+
+Add Go WAM forward-mode sub_atom/5 builtin
+
+# PR Description
+
+## Summary
+
+- Adds direct Go WAM lowering for `sub_atom/5`.
+- Extends the generated Go WAM runtime builtin dispatcher to read A4/A5 for arity-5 builtins.
+- Implements deterministic forward-mode `sub_atom(+Atom,+Before,+Length,?After,?SubAtom)`.
+- Adds generated Go WAM E2E coverage for extraction, empty substring extraction, numeric source conversion, mismatch failure, out-of-range failure, unbound source failure, and unsupported enumerable modes.
+- Updates the Go WAM parity audit to record forward-mode `sub_atom/5` coverage against the R WAM baseline while leaving full nondeterministic enumeration for a later slice.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(sub_atom/5,5), G), writeln(G), halt"`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`
+
+## Push
+
+```sh
+git push -u origin feat/wam-go-sub-atom-forward
+```

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -14,7 +14,7 @@ current cross-target builtin/runtime baseline.
 | Structural builtins | `member/2`, `memberchk/2`, `select/3`, `delete/3`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `select/3`, `delete/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1`, `ground/1` | Includes `is_list/1` and Clojure direct `ground/1` in the current baseline | Present for current baseline type and groundness checks |
 | Arithmetic builtins | `is/2`, `succ/2` | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir | Present for current baseline arithmetic checks, with expanded successor coverage |
-| Atom/text conversion | `atom_number/2`, `atom_codes/2`, `atom_chars/2`, `string_codes/2`, `string_chars/2`, `number_codes/2`, `number_chars/2`, `atom_string/2`, `string_to_atom/2`, `upcase_atom/2`, `downcase_atom/2`, `atom_concat/3`, `atom_length/2`, `string_length/2`, `char_code/2` | Clojure direct builtin surface includes bidirectional `atom_number/2`, atom/string/number code-list and char-list conversion, atom/string conversion, atom case conversion, deterministic atom concatenation, text length checks, and char-code conversion | Present for current atom-number, atom/string/number code-list, atom/string/number char-list, atom/string, atom-case, atom-concat, text-length, and char-code checks |
+| Atom/text conversion | `atom_number/2`, `atom_codes/2`, `atom_chars/2`, `string_codes/2`, `string_chars/2`, `number_codes/2`, `number_chars/2`, `atom_string/2`, `string_to_atom/2`, `upcase_atom/2`, `downcase_atom/2`, `atom_concat/3`, `atom_length/2`, `string_length/2`, `char_code/2`, `sub_atom/5` forward mode | Clojure direct builtin surface includes bidirectional `atom_number/2`, atom/string/number code-list and char-list conversion, atom/string conversion, atom case conversion, deterministic atom concatenation, text length checks, and char-code conversion | Present for current atom-number, atom/string/number code-list, atom/string/number char-list, atom/string, atom-case, atom-concat, text-length, char-code, and forward sub-atom checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` | Includes `=</2`; Haskell mode analysis and Clojure lowering also cover term-order comparisons | Present for current baseline comparisons, with expanded term-order coverage |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
 | Term inspection | `functor/3`, `arg/3` | `functor/3`, `arg/3` | Present |
@@ -68,6 +68,12 @@ current cross-target builtin/runtime baseline.
   ground atoms, numbers, compounds, lists, empty lists, fresh variables,
   nested unbound compound arguments, and list elements with unbound variables,
   matching the current Clojure groundness surface.
+- Deterministic forward-mode `sub_atom/5` is now covered by the generated
+  Go WAM builtin E2E test for bound source, before, and length arguments,
+  after/sub-atom unification, empty substring extraction, numeric source
+  conversion, out-of-range failure, unbound source failure, unsupported
+  enumerable modes, and mismatch failure, matching the R WAM forward-mode
+  baseline while leaving full nondeterministic enumeration for a later slice.
 - Bidirectional `succ/2` is now covered by the generated Go WAM builtin E2E
   test for forward binding, reverse binding, matching integer pairs, mismatch
   failure, negative predecessor failure, non-positive successor failure, and

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -463,6 +463,9 @@ wam_go_direct_builtin("compare/3", 3, 'compare/3').
 wam_go_direct_builtin(ground/1, 1, 'ground/1').
 wam_go_direct_builtin('ground/1', 1, 'ground/1').
 wam_go_direct_builtin("ground/1", 1, 'ground/1').
+wam_go_direct_builtin(sub_atom/5, 5, 'sub_atom/5').
+wam_go_direct_builtin('sub_atom/5', 5, 'sub_atom/5').
+wam_go_direct_builtin("sub_atom/5", 5, 'sub_atom/5').
 wam_go_direct_builtin(succ/2, 2, 'succ/2').
 wam_go_direct_builtin('succ/2', 2, 'succ/2').
 wam_go_direct_builtin("succ/2", 2, 'succ/2').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1210,9 +1210,11 @@ func (vm *WamState) evalArithmetic(v Value) (float64, bool) {
 
 func (vm *WamState) executeBuiltin(op string, arity int) bool {
 	arg1 := vm.getReg(0) // A1
-	var arg2, arg3 Value
+	var arg2, arg3, arg4, arg5 Value
 	if arity >= 2 { arg2 = vm.getReg(1) } // A2
 	if arity >= 3 { arg3 = vm.getReg(2) } // A3
+	if arity >= 4 { arg4 = vm.getReg(3) } // A4
+	if arity >= 5 { arg5 = vm.getReg(4) } // A5
 
 	switch op {
 	case "display/1":
@@ -1426,6 +1428,33 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			return vm.Unify(atomArg, internAtom(text.Name))
 		}
 		return false
+	case "sub_atom/5":
+		source, ok := atomNumberText(vm.deref(arg1))
+		if !ok {
+			return false
+		}
+		before, okBefore := vm.deref(arg2).(*Integer)
+		length, okLength := vm.deref(arg3).(*Integer)
+		if !okBefore || !okLength || before.Val < 0 || length.Val < 0 {
+			return false
+		}
+		runes := []rune(source)
+		start := before.Val
+		end := start + length.Val
+		if end > int64(len(runes)) {
+			return false
+		}
+		after := int64(len(runes)) - end
+		sub := string(runes[start:end])
+		mark := vm.TrailLen
+		if !vm.Unify(arg4, &Integer{Val: after}) {
+			return false
+		}
+		if !vm.Unify(arg5, internAtom(sub)) {
+			vm.unwindTrailTo(mark)
+			return false
+		}
+		return true
 
 	case "var/1": return isUnbound(vm.deref(arg1))
 	case "nonvar/1": return !isUnbound(vm.deref(arg1))

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -18,6 +18,7 @@
 :- dynamic user:test_sort_builtin/0.
 :- dynamic user:test_term_order_builtin/0.
 :- dynamic user:test_ground_builtin/0.
+:- dynamic user:test_sub_atom_builtin/0.
 :- dynamic user:test_succ_builtin/0.
 :- dynamic user:test_atom_number_builtin/0.
 :- dynamic user:test_atom_case_builtin/0.
@@ -169,6 +170,24 @@ test(builtins_execution) :-
                 \+ (Scratch = [z], ground(_), Scratch = [z]),
                 \+ ground(foo(1, _, 3)),
                 \+ ground([a, _])
+            )),
+          assertz(user:test_sub_atom_builtin :-
+            (   sub_atom(hello, 1, 3, A, S),
+                A =:= 1,
+                S == ell,
+                sub_atom(hello, 0, 3, 2, hel),
+                sub_atom(hello, 2, 3, 0, llo),
+                sub_atom(abc, 0, 3, 0, abc),
+                sub_atom(abc, 0, 0, 3, ''),
+                sub_atom(12345, 1, 3, 1, '234'),
+                \+ sub_atom(abc, 1, 99, _, _),
+                \+ sub_atom(abc, -1, 1, _, _),
+                \+ sub_atom(abc, 0, -1, _, _),
+                \+ sub_atom(_, 0, 1, _, _),
+                \+ sub_atom(abc, _, 1, _, _),
+                \+ sub_atom(abc, 0, _, _, _),
+                \+ sub_atom(abc, 0, 2, 0, ab),
+                \+ sub_atom(abc, 0, 2, _, ac)
             )),
           assertz(user:test_succ_builtin :-
             (   succ(0, 1),
@@ -369,6 +388,7 @@ test(builtins_execution) :-
           retractall(user:test_sort_builtin),
           retractall(user:test_term_order_builtin),
           retractall(user:test_ground_builtin),
+          retractall(user:test_sub_atom_builtin),
           retractall(user:test_succ_builtin),
           retractall(user:test_atom_number_builtin),
           retractall(user:test_atom_case_builtin),
@@ -389,7 +409,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -437,6 +457,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "@>=/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "compare/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "ground/1"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "sub_atom/5"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "succ/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "atom_number/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "upcase_atom/2"')),
@@ -576,6 +597,14 @@ func main() {
 		fmt.Println("GROUND_SUCCESS")
 	} else {
 		fmt.Println("GROUND_FAILURE")
+	}
+
+	subAtomVM := wam.NewWamState(wam.Test_sub_atom_builtinCode, wam.Test_sub_atom_builtinLabels)
+	subAtomVM.PC = wam.Test_sub_atom_builtinStartPC
+	if subAtomVM.Run() {
+		fmt.Println("SUB_ATOM_SUCCESS")
+	} else {
+		fmt.Println("SUB_ATOM_FAILURE")
 	}
 
 	succVM := wam.NewWamState(wam.Test_succ_builtinCode, wam.Test_succ_builtinLabels)
@@ -728,6 +757,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "SORT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "TERM_ORDER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "GROUND_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "SUB_ATOM_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SUCC_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_NUMBER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_CASE_SUCCESS")),


### PR DESCRIPTION
## Summary

- Adds direct Go WAM lowering for `sub_atom/5`.
- Extends the generated Go WAM runtime builtin dispatcher to read A4/A5 for arity-5 builtins.
- Implements deterministic forward-mode `sub_atom(+Atom,+Before,+Length,?After,?SubAtom)`.
- Adds generated Go WAM E2E coverage for extraction, empty substring extraction, numeric source conversion, mismatch failure, out-of-range failure, unbound source failure, and unsupported enumerable modes.
- Updates the Go WAM parity audit to record forward-mode `sub_atom/5` coverage against the R WAM baseline while leaving full nondeterministic enumeration for a later slice.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(sub_atom/5,5), G), writeln(G), halt"`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`

## Push

```sh
git push -u origin feat/wam-go-sub-atom-forward
```
