### PR TITLE
feat(wam-clojure): enumerate nth unbound indexes

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -801,12 +801,12 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "nth0/3" ; Op == 'nth0/3'),
     !,
-    format(atom(Expr), '(runtime/apply-nth0-solution ~w)', [S]).
+    format(atom(Expr), '(runtime/apply-nth0-solution ~w (inc (:pc ~w)))', [S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "nth1/3" ; Op == 'nth1/3'),
     !,
-    format(atom(Expr), '(runtime/apply-nth1-solution ~w)', [S]).
+    format(atom(Expr), '(runtime/apply-nth1-solution ~w (inc (:pc ~w)))', [S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "select/3" ; Op == 'select/3'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -708,6 +708,8 @@
 (declare apply-member-solution)
 (declare apply-append-solution)
 (declare apply-first-foreign-solution)
+(declare parse-number-text)
+(declare atom-text)
 (declare list->term)
 (declare fresh-var)
 
@@ -836,40 +838,68 @@
         (backtrack state))
       (backtrack state))))
 
-(defn apply-nth0-solution [state]
+(defn nth-index-value [state value]
+  (cond
+    (integer? value) value
+    (string? value) (parse-number-text value)
+    (atom-term? value) (parse-number-text (atom-text state value))
+    :else nil))
+
+(defn nth-solution-results [items base-index]
+  (mapv (fn [zero-index item]
+          {:bindings {1 (+ base-index zero-index)
+                      3 item}})
+        (range)
+        items))
+
+(defn apply-nth0-solution [state resume-pc]
   (let [index-value (deref-value (:bindings state)
                                  (or (reg-get-raw state "A1") ::unbound))
         list-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A2") ::unbound))
         out (deref-value (:bindings state)
-                         (or (reg-get-raw state "A3") ::unbound))]
-    (if (and (integer? index-value) (not (neg? index-value)))
-      (if-let [items (proper-list-items state list-value)]
-        (if (< index-value (count items))
-          (let [[ok next-state] (unify-values state out (nth items index-value))]
+                         (or (reg-get-raw state "A3") ::unbound))
+        index-count (nth-index-value state index-value)]
+    (if-let [items (proper-list-items state list-value)]
+      (cond
+        (and (integer? index-count) (not (neg? index-count)))
+        (if (< index-count (count items))
+          (let [[ok next-state] (unify-values state out (nth items index-count))]
             (if ok
               (advance next-state)
               (backtrack state)))
           (backtrack state))
+
+        (logic-var? index-value)
+        (apply-first-foreign-solution state resume-pc (nth-solution-results items 0))
+
+        :else
         (backtrack state))
       (backtrack state))))
 
-(defn apply-nth1-solution [state]
+(defn apply-nth1-solution [state resume-pc]
   (let [index-value (deref-value (:bindings state)
                                  (or (reg-get-raw state "A1") ::unbound))
         list-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A2") ::unbound))
         out (deref-value (:bindings state)
-                         (or (reg-get-raw state "A3") ::unbound))]
-    (if (and (integer? index-value) (pos? index-value))
-      (if-let [items (proper-list-items state list-value)]
-        (let [zero-index (dec index-value)]
+                         (or (reg-get-raw state "A3") ::unbound))
+        index-count (nth-index-value state index-value)]
+    (if-let [items (proper-list-items state list-value)]
+      (cond
+        (and (integer? index-count) (pos? index-count))
+        (let [zero-index (dec index-count)]
           (if (< zero-index (count items))
             (let [[ok next-state] (unify-values state out (nth items zero-index))]
               (if ok
                 (advance next-state)
                 (backtrack state)))
             (backtrack state)))
+
+        (logic-var? index-value)
+        (apply-first-foreign-solution state resume-pc (nth-solution-results items 1))
+
+        :else
         (backtrack state))
       (backtrack state))))
 
@@ -2187,10 +2217,10 @@
           (apply-last-solution state)
 
           "nth0/3"
-          (apply-nth0-solution state)
+          (apply-nth0-solution state (inc (:pc state)))
 
           "nth1/3"
-          (apply-nth1-solution state)
+          (apply-nth1-solution state (inc (:pc state)))
 
           "select/3"
           (let [list-value (deref-value (:bindings state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -346,14 +346,14 @@ user:wam_nth0_guard(N, L, X) :- nth0(N, L, X).
 user:wam_nth0_negative(X) :- nth0(-1, [a,b,c], X).
 user:wam_nth0_out_of_range(X) :- nth0(3, [a,b,c], X).
 user:wam_nth0_bad_list(X) :- nth0(1, [a|b], X).
-user:wam_nth0_unbound_index(X) :- user:wam_unbound_arg(N), nth0(N, [a,b,c], X).
+user:wam_nth0_unbound_index(X) :- nth0(N, [a,b,c], X), integer(N).
 user:wam_nth0_unbound_list(X) :- user:wam_unbound_arg(L), nth0(0, L, X).
 user:wam_nth1_guard(N, L, X) :- nth1(N, L, X).
 user:wam_nth1_zero(X) :- nth1(0, [a,b,c], X).
 user:wam_nth1_negative(X) :- nth1(-1, [a,b,c], X).
 user:wam_nth1_out_of_range(X) :- nth1(4, [a,b,c], X).
 user:wam_nth1_bad_list(X) :- nth1(2, [a|b], X).
-user:wam_nth1_unbound_index(X) :- user:wam_unbound_arg(N), nth1(N, [a,b,c], X).
+user:wam_nth1_unbound_index(X) :- nth1(N, [a,b,c], X), integer(N).
 user:wam_nth1_unbound_list(X) :- user:wam_unbound_arg(L), nth1(1, L, X).
 user:wam_select_guard(Elem, List, Rest) :- select(Elem, List, Rest).
 user:wam_select_backtrack(Elem, Rest) :- select(Elem, [a,b,c], Rest), Elem = b.
@@ -968,7 +968,10 @@ smoke_cases([
     case('wam_nth0_negative/1', a, "false"),
     case('wam_nth0_out_of_range/1', a, "false"),
     case('wam_nth0_bad_list/1', a, "false"),
-    case('wam_nth0_unbound_index/1', a, "false"),
+    case('wam_nth0_unbound_index/1', a, "true"),
+    case('wam_nth0_unbound_index/1', b, "true"),
+    case('wam_nth0_unbound_index/1', c, "true"),
+    case('wam_nth0_unbound_index/1', d, "false"),
     case('wam_nth0_unbound_list/1', a, "false"),
     case('wam_nth1_guard/3', args(1, '[a,b,c]', a), "true"),
     case('wam_nth1_guard/3', args(2, '[a,b,c]', b), "true"),
@@ -978,7 +981,10 @@ smoke_cases([
     case('wam_nth1_negative/1', a, "false"),
     case('wam_nth1_out_of_range/1', a, "false"),
     case('wam_nth1_bad_list/1', a, "false"),
-    case('wam_nth1_unbound_index/1', a, "false"),
+    case('wam_nth1_unbound_index/1', a, "true"),
+    case('wam_nth1_unbound_index/1', b, "true"),
+    case('wam_nth1_unbound_index/1', c, "true"),
+    case('wam_nth1_unbound_index/1', d, "false"),
     case('wam_nth1_unbound_list/1', a, "false"),
     case('wam_select_guard/3', args(a, '[a,b,c]', '[b,c]'), "true"),
     case('wam_select_guard/3', args(b, '[a,b,c]', '[a,c]'), "true"),


### PR DESCRIPTION
## Summary
- Adds finite unbound-index enumeration for Clojure WAM `nth0/3` and `nth1/3` when the list is a proper finite list.
- Threads the resume PC through lowered `nth0/3` and `nth1/3` calls so generated choicepoints can resume after the builtin.
- Normalizes integer-like index constants for the `nth` helpers, matching the compiled WAM constant representation.
- Extends runtime smoke coverage so `nth0(N, [a,b,c], X)` and `nth1(N, [a,b,c], X)` succeed for `a`, `b`, and `c`, while preserving failure for non-members and unbound-list modes.

## Why
The Clojure WAM runtime previously handled only bound-index `nth0/3` and `nth1/3` modes. Unbound-index lookup over a finite proper list is a bounded, deterministic search space for the runtime to enumerate, and fits the same conservative semantic-expansion path as the recent `length/2` generated-list support.

## Notes
- This PR intentionally keeps unbound-list modes conservative; `nth0(0, L, X)` and `nth1(1, L, X)` still fail when `L` is unbound to avoid introducing infinite generation.
- The smoke predicates are direct lowerable clauses so this PR validates the lowered Clojure WAM builtin path. The call/execute interpreter path remains separate follow-up work.

## Validation
- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
