### PR TITLE
wam-fsharp: ISO error substrate + per-predicate config (is_iso/is_lax)

### DIFF
--- a/docs/WAM_FSHARP_TARGET.md
+++ b/docs/WAM_FSHARP_TARGET.md
@@ -454,7 +454,9 @@ The runtime in `fsharp_wam_bindings.pl` + `wam_fsharp_target.pl`
 defines step branches for:
 
 **Control:** `true/0`, `fail/0`, `!/0` (cut), `\+/1` (negation),
-`call/1+`, `throw/1`, `catch/3`.
+`call/1+`. `throw/1` and `catch/3` are **not yet** wired in the F# WAM
+runtime; see `design/WAM_FSHARP_PARITY_AUDIT.md` for the ISO-error
+adoption plan.
 
 **Arithmetic:** `is/2` (full expression evaluator: `+`, `-`, `*`, `/`,
 `//`, `mod`, `rem`, `**`, `abs`, `min`, `max`, `gcd`, `truncate`,

--- a/docs/WAM_FSHARP_TARGET.md
+++ b/docs/WAM_FSHARP_TARGET.md
@@ -454,9 +454,17 @@ The runtime in `fsharp_wam_bindings.pl` + `wam_fsharp_target.pl`
 defines step branches for:
 
 **Control:** `true/0`, `fail/0`, `!/0` (cut), `\+/1` (negation),
-`call/1+`. `throw/1` and `catch/3` are **not yet** wired in the F# WAM
-runtime; see `design/WAM_FSHARP_PARITY_AUDIT.md` for the ISO-error
-adoption plan.
+`call/1+`, `throw/1`, `catch/3`.
+
+**ISO error variants:** `is_iso/2` (throws structured `error(_, _)`
+on bad eval), `is_lax/2` (alias of `is/2`, fails silently). The
+default `is/2` can be rewritten per-predicate via the
+`iso_errors_config(File)` / `iso_errors(Bool)` /
+`iso_errors(PI, Bool)` options; `wam_fsharp_iso_audit/3` reports
+what each call site resolves to. Arithmetic-comparison variants
+(`>_iso/2`, `<_iso/2`, ...) and `succ_iso/2` are planned follow-ups
+-- see `design/WAM_FSHARP_PARITY_AUDIT.md`. Cross-target ISO
+contract: `design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`.
 
 **Arithmetic:** `is/2` (full expression evaluator: `+`, `-`, `*`, `/`,
 `//`, `mod`, `rem`, `**`, `abs`, `min`, `max`, `gcd`, `truncate`,

--- a/docs/design/WAM_FSHARP_PARITY_AUDIT.md
+++ b/docs/design/WAM_FSHARP_PARITY_AUDIT.md
@@ -40,7 +40,7 @@ binding-level types in
 | Direct fact dispatch | `ForeignFacts` / `FfiFacts` / `FfiWeightedFacts` in-memory maps on `WamContext` | `call_indexed_atom_fact2`, fact-source registry | Present for in-memory facts only - no external fact source |
 | Aggregates | `BeginAggregate`/`EndAggregate` + `MergeStrategy` DU (`MergeSum`/`Count`/`Bag`/`Set`/`Findall`/`Sequential`); accumulator materializes on backtrack | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present |
 | Structural builtins | `member/2`, `memberchk/2`, `append/3`, `length/2`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `delete/3`, `select/3`, `sort/2`, `msort/2`, `compare/3` | Same baseline expanded by Go/Clojure/C++ | Present |
-| Type builtins | `atom/1`, `atomic/1`, `compound/1`, `integer/1`, `number/1`, `float/1`, `var/1`, `nonvar/1` | Same baseline; Lua/Python/Go also have `is_list/1` | Present **except `is_list/1`** (not currently wired) |
+| Type builtins | `atom/1`, `atomic/1`, `compound/1`, `integer/1`, `number/1`, `float/1`, `var/1`, `nonvar/1`, `is_list/1` | Same baseline | Present |
 | Comparison builtins | `==/2`, `\==/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` via Prolog-standard `compareValue` (Var < Number < Atom < Compound) | Same baseline | Present |
 | Unification builtin | `=/2`, `\=/2` | Same | Present |
 | Term inspection | `functor/3`, `arg/3` (both modes); specialized `Arg` opcode for literal-N case | Same | Present |
@@ -56,52 +56,44 @@ binding-level types in
 
 ## ISO Error Readiness
 
-F# is **not yet** an ISO-error adopter. Per
-`WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`, the reference consumers are
-C++ and Elixir (both fully shipped) and Python (substrate + arithmetic
-variants shipped, remaining concrete builtins outstanding). F# has
-none of the components below.
+F# is now a **partial ISO-error adopter**. The substrate
+(catch/throw + error constructors + throw_iso_error), the config
+loader/rewrite/audit plumbing, and `is_iso/2` + `is_lax/2` shipped
+together. The arithmetic-comparison and `succ/2` ISO/lax variants
+are follow-up work.
 
 | Component | F# status | Notes |
 | --- | --- | --- |
-| Prolog `catch/3` / `throw/1` substrate | **Missing** | `WamRuntime.fs` has no `WamException` type and no catcher frames on `WsStack` / `WsCPs`. `docs/WAM_FSHARP_TARGET.md` currently lists `throw/1` and `catch/3` under "Control" - **that line is inaccurate** and should be removed or marked "planned" when this audit lands. The `throw` calls in `wam_fsharp_target.pl` and `wam_fsharp_lowered_emitter.pl` are codegen-time Prolog `throw/1`, not WAM-runtime catch/throw. |
-| ISO error constructors | **Missing** | No runtime builders for `instantiation_error`, `type_error/2`, `domain_error/2`, `evaluation_error/1` in `WamRuntime.fs`. |
-| `throw_iso_error` helper | **Missing** | Depends on the substrate above. |
-| `is_iso/2` / `is_lax/2` | **Missing** | Current `is/2` is lax by construction (arithmetic failures fail silently / return `nan`/`inf` via `Double.NaN` and `Double.PositiveInfinity`, matching the F# CLR float semantics). That is a viable starting point for `*_lax` aliases once the three-form split exists. |
-| ISO/lax arithmetic compares | **Missing** | Six comparison variants would need ISO/lax three-form dispatch. |
-| `succ/2` and ISO/lax variants | **Missing** | F# does not currently expose `succ/2`. |
-| Lax IEEE-754 float divide | Partial | F# `is/2` already returns `nan`/`inf`/`-inf` for float zero division (CLR default). Integer zero division throws `DivideByZeroException` which propagates as a runtime crash rather than failing silently; that needs adjustment for lax mode. |
-| Per-predicate ISO config loader | **Missing** | No `iso_errors_config(File)`, no inline `iso_errors(Default)` / `iso_errors(PI, Mode)` option parsing in `wam_fsharp_target.pl`. |
-| Per-predicate default rewrite | **Missing** | Text-level rewrite from `is/2` to `is_iso/2`/`is_lax/2` would feed both the interpreter and lowered emitter; neither is wired today. |
-| ISO audit predicate | **Missing** | No `wam_fsharp_iso_audit/3`. |
+| Prolog `catch/3` / `throw/1` substrate | Present | `WamException` exception type plus a `WsCatchers : CatcherFrame list` side stack on `WamState`. `dispatchCall` has a top-level try/with that prints "Uncaught Prolog throw" and returns `None`. The WAM compiler emits `catch/3` and `throw/1` as `Call`/`Execute` meta-calls (not `BuiltinCall`); special-case dispatch in the F# step `Call`/`Execute` arms routes them through `BuiltinCall` so the ISO arms fire. |
+| ISO error constructors | Present | `makeInstantiationError`, `makeTypeError`, `makeDomainError`, `makeEvaluationError`, `makePredIndicator` in `fsharp_wam_bindings.pl`. |
+| `throw_iso_error` helper | Present | Wraps the inner error term in `error(ErrorTerm, _)` (with a fresh unbound `Context`) and raises `WamException`. |
+| `is_iso/2` / `is_lax/2` | Present | `is/2` and `is_lax/2` share the lax body; `is_iso/2` does three-step classification (unbound -> instantiation_error, zero divide -> evaluation_error(zero_divisor), otherwise -> type_error(evaluable, Name/Arity)). |
+| ISO/lax arithmetic compares | **Missing** | Six comparison variants (`>`, `<`, `>=`, `=<`, `=:=`, `=\\=`) still need ISO/lax three-form dispatch. Follow-up PR. |
+| `succ/2` and ISO/lax variants | **Missing** | F# does not currently expose `succ/2` at all. Follow-up PR. |
+| Lax IEEE-754 float divide | Partial | F# `is/2` already returns `nan`/`inf`/`-inf` for float zero division (CLR default). Integer divide-by-zero in lax mode fails silently because `evalArith` returns `None` (no exception escapes), matching the documented lax contract. |
+| Per-predicate ISO config loader | Present | `iso_errors_config(File)`, inline `iso_errors(Default)` / `iso_errors(PI, Mode)`, file-vs-inline precedence per spec. Copied from Python target; future extraction into `src/unifyweaver/core/iso_errors.pl` is appropriate now that F# is the third adopter. |
+| Per-predicate default rewrite | Present | `iso_errors_rewrite_text/4` walks WAM text, rewriting `is/2` -> `is_iso/2` / `is_lax/2` according to the predicate's resolved mode. Wired into `compile_predicates_to_fsharp` so generated F# uses the ISO-mode key. |
+| ISO audit predicate | Present | `wam_fsharp_iso_audit/3` reports per-call-site resolution following the shared audit shape. `wam_fsharp_iso_audit_report/1` pretty-prints. |
 
-### Minimum Useful F# ISO Adoption
+### Remaining F# ISO Work
 
-Per the shared contract in `WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` §
-"What Counts As Adoption", the minimum useful unit for F# is:
+Steps 1-5 and 7-8 of the original minimum-useful-adoption list (now
+matched against `WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` § "What Counts
+As Adoption") shipped together. The remaining items:
 
-1. Add a `WamException` exception type (carries the ISO error term).
-2. Add catcher-frame plumbing on `WsCPs` so `step` can unwind on
-   `throw/1` and resume at a matching `catch/3` handler. Pattern:
-   either a new `ChoicePoint` variant with `CpCatcher: Value option`,
-   or a sibling stack on `WamState` for catcher frames. The Elixir
-   target's side-stack pattern is the closest reference.
-3. Add ISO error constructors (`instantiation_error/0`,
-   `type_error/2`, `domain_error/2`, `evaluation_error/1`) and a
-   `throw_iso_error` helper in `WamRuntime.fs`.
-4. Per-predicate config/override parsing in `wam_fsharp_target.pl`,
-   mirroring the option shape already shipped by C++/Elixir/Python.
-5. Default-key rewrite for `is/2`; `is_iso/2` and `is_lax/2`
-   implementations that survive the rewrite.
-6. Six ISO/lax arithmetic-compare aliases (`=:=`, `=\=`, `<`, `>`,
-   `=<`, `>=`).
-7. `wam_fsharp_iso_audit/3` reporting builtin call sites using the
-   shared audit shape.
-8. Tests under `tests/core/test_wam_fsharp_iso_*.pl` matching the
-   shape of the existing Python ISO E2E coverage.
-
-Steps 1-3 form a single self-contained PR; the rest can land in
-follow-ups once the substrate exists.
+- **Arithmetic-compare ISO/lax variants**: `>_iso/2`, `<_iso/2`,
+  `>=_iso/2`, `=<_iso/2`, `=:=_iso/2`, `=\\=_iso/2` plus matching
+  `*_lax/2` aliases. Each needs a step branch alongside the existing
+  lax branch, an entry in both `iso_errors_default_to_iso/2` and
+  `iso_errors_default_to_lax/2`, and a regression test case.
+- **`succ/2` family**: F# does not currently support `succ/2` at
+  all. Adding it adds three keys (default, `_iso`, `_lax`) per the
+  three-form pattern.
+- **Shared helper extraction**: F# is now the third adopter (after
+  Elixir and Python -- C++ is its own reference). Extracting the
+  `iso_errors_*` predicates into `src/unifyweaver/core/iso_errors.pl`
+  is appropriate next, as called out in
+  `WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` § "Remaining Work".
 
 ## LMDB Fact-Source Readiness
 
@@ -206,9 +198,6 @@ then F# CSR.
 
 These are smaller than the three above but worth tracking:
 
-- **`is_list/1`** is in the cross-target baseline (Lua, Python, Go)
-  but not currently wired in F#. Trivial addition - one match clause
-  in `WamRuntime.fs` `step` plus a Prolog dispatch entry.
 - **`succ/2`** is in the Clojure/Elixir baseline but not F#. Would
   land naturally with the ISO `succ_iso/2` / `succ_lax/2` work
   above.
@@ -239,8 +228,8 @@ These are smaller than the three above but worth tracking:
    `lmdb_materialisation(lazy)` codegen option.
 6. **LMDB Phase 3 (cached)**: `CachedLookup` decorator + auto
    resolver.
-7. **`is_list/1` and `succ/2`** small builtins: bundle with whichever
-   ISO PR they fit alongside.
+7. **`succ/2`** small builtin: bundle with the ISO `succ_iso/2` /
+   `succ_lax/2` PR.
 8. **CSR reader**: gated on LMDB work and on Rust CSR Phase C
    stabilising the format.
 

--- a/docs/design/WAM_FSHARP_PARITY_AUDIT.md
+++ b/docs/design/WAM_FSHARP_PARITY_AUDIT.md
@@ -1,0 +1,263 @@
+# WAM F# Parity Audit
+
+This note compares the F# hybrid WAM target against the cross-target
+reference baselines, using Haskell and Rust for WAM runtime/builtin
+behavior, C++/Elixir/Python for ISO-error parity, and Haskell/Rust for
+LMDB lazy-access parity. It also records readiness against the
+in-flight reverse-index/CSR design.
+
+Companion docs:
+
+- [`../WAM_FSHARP_TARGET.md`](../WAM_FSHARP_TARGET.md) - the user-facing
+  F# target reference.
+- [`WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`](WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md) -
+  shared ISO-error contract; the table here mirrors the rows in that
+  status doc.
+- [`WAM_LMDB_LAZY_PHILOSOPHY.md`](WAM_LMDB_LAZY_PHILOSOPHY.md) and the
+  matching `_SPECIFICATION.md` / `_IMPLEMENTATION_PLAN.md` - LMDB
+  `eager`/`lazy`/`cached` taxonomy. F# is not currently named in the
+  phased rollout.
+- [`WAM_REVERSE_INDEX_ARTIFACTS.md`](WAM_REVERSE_INDEX_ARTIFACTS.md) -
+  CSR reverse-index design; Phase C ships a Rust reader first, with C#
+  to follow once the format and policy are stable.
+- [`WAM_GO_PARITY_AUDIT.md`](WAM_GO_PARITY_AUDIT.md),
+  [`WAM_PYTHON_PARITY_AUDIT.md`](WAM_PYTHON_PARITY_AUDIT.md),
+  [`WAM_LUA_PARITY_AUDIT.md`](WAM_LUA_PARITY_AUDIT.md) - sibling
+  per-target audits this one is modelled on.
+
+## Verified Runtime Surface
+
+The F# WAM runtime in
+`src/unifyweaver/targets/fsharp_runtime/WamRuntime.fs`, plus the
+binding-level types in
+`src/unifyweaver/bindings/fsharp_wam_bindings.pl` and the codegen in
+`src/unifyweaver/targets/wam_fsharp_target.pl` /
+`src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl`, supplies:
+
+| Area | F# support | Rust/Haskell baseline | Status |
+| --- | --- | --- | --- |
+| Choice points and backtracking | `TryMeElse`/`RetryMeElse`/`TrustMe`, `Try`/`Retry`/`Trust` for indexed dispatch (issue #2400), `MemberRetry`/`SelectRetry`/`FactRetry`/`HopsRetry`/`FFIStreamRetry` builtin CPs | Choice point stack with normal/builtin/fact-stream resume states | Present |
+| Direct fact dispatch | `ForeignFacts` / `FfiFacts` / `FfiWeightedFacts` in-memory maps on `WamContext` | `call_indexed_atom_fact2`, fact-source registry | Present for in-memory facts only - no external fact source |
+| Aggregates | `BeginAggregate`/`EndAggregate` + `MergeStrategy` DU (`MergeSum`/`Count`/`Bag`/`Set`/`Findall`/`Sequential`); accumulator materializes on backtrack | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present |
+| Structural builtins | `member/2`, `memberchk/2`, `append/3`, `length/2`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `delete/3`, `select/3`, `sort/2`, `msort/2`, `compare/3` | Same baseline expanded by Go/Clojure/C++ | Present |
+| Type builtins | `atom/1`, `atomic/1`, `compound/1`, `integer/1`, `number/1`, `float/1`, `var/1`, `nonvar/1` | Same baseline; Lua/Python/Go also have `is_list/1` | Present **except `is_list/1`** (not currently wired) |
+| Comparison builtins | `==/2`, `\==/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` via Prolog-standard `compareValue` (Var < Number < Atom < Compound) | Same baseline | Present |
+| Unification builtin | `=/2`, `\=/2` | Same | Present |
+| Term inspection | `functor/3`, `arg/3` (both modes); specialized `Arg` opcode for literal-N case | Same | Present |
+| Univ | `=../2` compose and decompose; specialized `PutStructureDyn` opcode for runtime-parsed functor | Same | Present |
+| Copying | `copy_term/2` with fresh variables and preserved sharing | Same | Present |
+| Control | `true/0`, `fail/0`, `!/0` (full B0 cut barrier per Aït-Kaci), `\+/1`, `CutIte`, `runNegationParallel` racing isolated clause bodies | Same baseline; race-to-true also in Haskell/Go | Present |
+| Arithmetic | `is/2` (full evaluator: `+`, `-`, `*`, `/`, `//`, `mod`, `rem`, `**`, `abs`, `min`, `max`, `gcd`, `truncate`, `round`, `ceiling`, `floor`, `sqrt`, `sin`, `cos`, `tan`, `pi`, `e`, bitwise) | Same | Present **without ISO/lax three-form split** - see "ISO Error Readiness" below |
+| Atom / text conversion | `atom_codes/2`, `atom_chars/2`, `atom_length/2`, `atom_concat/3`, `atom_string/2`, `atom_number/2`, `number_codes/2`, `number_chars/2`, `char_code/2`, `upcase_atom/2`, `downcase_atom/2`, `sub_atom/5`, `string_codes/2`, `string_chars/2` | Same baseline | Present |
+| IO | `write/1`, `display/1`, `nl/0` | Same | Present |
+| Database (limited) | `assert/1`, `assertz/1`, `asserta/1`, `retract/1` via `WcLoweredPredicates` mutation - works for facts, not clauses with bodies | C++/Python/Haskell have a richer dynamic-database story | Partial - documented in target doc as "use Python for dynamic-database semantics" |
+| Sets | `BuildEmptySet`, `SetInsert`, `NotMemberSet` for graph-kernel visited sets | Same shape across targets | Present |
+| Runtime parser | `runtime_parser(compiled(prolog_term_parser))` compiles `prolog_term_parser.pl` into WAM and exposes `read_term_from_atom/2,3`, `parse_term_from_atom/3,4`, `parse_term_from_codes/3,4` | Per `WAM_RUNTIME_PARSER_STATUS.md`: F# is fully covered (compiled mode) | Present |
+
+## ISO Error Readiness
+
+F# is **not yet** an ISO-error adopter. Per
+`WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`, the reference consumers are
+C++ and Elixir (both fully shipped) and Python (substrate + arithmetic
+variants shipped, remaining concrete builtins outstanding). F# has
+none of the components below.
+
+| Component | F# status | Notes |
+| --- | --- | --- |
+| Prolog `catch/3` / `throw/1` substrate | **Missing** | `WamRuntime.fs` has no `WamException` type and no catcher frames on `WsStack` / `WsCPs`. `docs/WAM_FSHARP_TARGET.md` currently lists `throw/1` and `catch/3` under "Control" - **that line is inaccurate** and should be removed or marked "planned" when this audit lands. The `throw` calls in `wam_fsharp_target.pl` and `wam_fsharp_lowered_emitter.pl` are codegen-time Prolog `throw/1`, not WAM-runtime catch/throw. |
+| ISO error constructors | **Missing** | No runtime builders for `instantiation_error`, `type_error/2`, `domain_error/2`, `evaluation_error/1` in `WamRuntime.fs`. |
+| `throw_iso_error` helper | **Missing** | Depends on the substrate above. |
+| `is_iso/2` / `is_lax/2` | **Missing** | Current `is/2` is lax by construction (arithmetic failures fail silently / return `nan`/`inf` via `Double.NaN` and `Double.PositiveInfinity`, matching the F# CLR float semantics). That is a viable starting point for `*_lax` aliases once the three-form split exists. |
+| ISO/lax arithmetic compares | **Missing** | Six comparison variants would need ISO/lax three-form dispatch. |
+| `succ/2` and ISO/lax variants | **Missing** | F# does not currently expose `succ/2`. |
+| Lax IEEE-754 float divide | Partial | F# `is/2` already returns `nan`/`inf`/`-inf` for float zero division (CLR default). Integer zero division throws `DivideByZeroException` which propagates as a runtime crash rather than failing silently; that needs adjustment for lax mode. |
+| Per-predicate ISO config loader | **Missing** | No `iso_errors_config(File)`, no inline `iso_errors(Default)` / `iso_errors(PI, Mode)` option parsing in `wam_fsharp_target.pl`. |
+| Per-predicate default rewrite | **Missing** | Text-level rewrite from `is/2` to `is_iso/2`/`is_lax/2` would feed both the interpreter and lowered emitter; neither is wired today. |
+| ISO audit predicate | **Missing** | No `wam_fsharp_iso_audit/3`. |
+
+### Minimum Useful F# ISO Adoption
+
+Per the shared contract in `WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` §
+"What Counts As Adoption", the minimum useful unit for F# is:
+
+1. Add a `WamException` exception type (carries the ISO error term).
+2. Add catcher-frame plumbing on `WsCPs` so `step` can unwind on
+   `throw/1` and resume at a matching `catch/3` handler. Pattern:
+   either a new `ChoicePoint` variant with `CpCatcher: Value option`,
+   or a sibling stack on `WamState` for catcher frames. The Elixir
+   target's side-stack pattern is the closest reference.
+3. Add ISO error constructors (`instantiation_error/0`,
+   `type_error/2`, `domain_error/2`, `evaluation_error/1`) and a
+   `throw_iso_error` helper in `WamRuntime.fs`.
+4. Per-predicate config/override parsing in `wam_fsharp_target.pl`,
+   mirroring the option shape already shipped by C++/Elixir/Python.
+5. Default-key rewrite for `is/2`; `is_iso/2` and `is_lax/2`
+   implementations that survive the rewrite.
+6. Six ISO/lax arithmetic-compare aliases (`=:=`, `=\=`, `<`, `>`,
+   `=<`, `>=`).
+7. `wam_fsharp_iso_audit/3` reporting builtin call sites using the
+   shared audit shape.
+8. Tests under `tests/core/test_wam_fsharp_iso_*.pl` matching the
+   shape of the existing Python ISO E2E coverage.
+
+Steps 1-3 form a single self-contained PR; the rest can land in
+follow-ups once the substrate exists.
+
+## LMDB Fact-Source Readiness
+
+F# is **not yet** named in `WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md`. The
+current state across all WAM targets (from the plan's §1 table) is:
+
+| Target | `eager` | `lazy` | `cached` | Scan | Segregation |
+| --- | :-: | :-: | :-: | :-: | :-: |
+| Haskell | shipped | degenerate (cap 0) | shipped | not yet | not yet |
+| Rust | shipped | planned R7 | planned R8 | planned R10 | planned R9 |
+| C# | shipped + planner | partial | partial | partial | partial |
+| Go | shipped | not yet | not yet | not yet | not yet |
+| Elixir | shipped + generator-mode | not yet | not yet | not yet | not yet |
+| Python | shipped + `yield from` | not yet | not yet | not yet | not yet |
+| **F#** | **none** | **none** | **none** | **none** | **none** |
+
+The `eager` baseline is missing too because F# has no `WcFactSource`
+shape at all - the `WamContext` exposes only in-memory
+`Map<string, Map<string, string list>>` for `WcForeignFacts` and
+`Map<string, Map<int, int list>>` for `WcFfiFacts`. There is no
+fact-source trait, no LMDB template, and no .NET LMDB binding
+selected. The closest precedent in the codebase is the C# ingest at
+`src/unifyweaver/runtime/csharp/lmdb_ingest/` which uses the
+[LightningDB](https://www.nuget.org/packages/LightningDB) NuGet
+package (0.21+) - F# can consume the same package since it shares the
+CLR with C#.
+
+### Minimum Useful F# LMDB Adoption
+
+The path mirrors the Rust R7 plan but is independent of it:
+
+1. **Pick the binding.** LightningDB 0.21+ is the obvious choice
+   (already used by `lmdb_ingest`); a `FSharp.LMDB` wrapper is not
+   needed and would be premature.
+2. **Add a `LookupSource` interface to `WamRuntime.fs`** with one
+   method along the shape `member _.Lookup : int -> seq<int>` (or
+   `seq<Value>` once interning vs raw int IDs is decided). This is
+   the equivalent of the Haskell `FactSource` typeclass and the Rust
+   `LookupSource` trait that R7 introduces.
+3. **Add an `LmdbCursorLookup` implementation** reading the Phase 1
+   resident layout (`int32_le` keys) from
+   `WAM_LMDB_RESIDENT_INTERNING_SPECIFICATION.md`. One shared cursor
+   protected by a mutex is the simplest starting shape.
+4. **Add `WcLookupSources : Map<string, LookupSource>`** to
+   `WamContext` and a `dispatchLookup` path that prefers the
+   registered lookup over `WcFfiFacts` when present.
+5. **Codegen option `lmdb_materialisation(eager|lazy|cached)`** in
+   `wam_fsharp_target.pl`. Initial PR can omit the `auto` token
+   (resolver wiring) and the `cached` decorator; those land in a
+   follow-up.
+6. **Mustache template `templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache`**
+   carrying the LMDB-zero-allocation pattern used by the Rust
+   template at `templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache`.
+7. **Tests** under `tests/test_wam_fsharp_target.pl` for codegen
+   shape; a generated-project smoke test under `tests/core/` for
+   end-to-end behavior against a small fixture LMDB.
+
+`cached` mode (step beyond the minimum) follows the Haskell
+`resident_cursor` pattern: a `CachedLookup` decorator wraps any
+`LookupSource` with a sharded LRU. .NET's
+`System.Collections.Concurrent.ConcurrentDictionary` plus a
+`LinkedList<int>` for LRU ordering is the simplest portable choice;
+`Microsoft.Extensions.Caching.Memory` is heavier than needed.
+
+The plan's §9 "out-of-scope" list does not currently include F#; this
+audit suggests adding F# explicitly so future readers know whether to
+expect it in a given phase.
+
+## CSR Reverse-Index Readiness
+
+F# is **not yet** named in `WAM_REVERSE_INDEX_ARTIFACTS.md`. The
+implementation plan's Phase C calls for "a small Rust reader,
+co-located with the Rust LMDB sink/build path, with direct-index or
+binary-search lookup. C# binding can follow once the format and policy
+are stable." F# is a natural follower of the C# binding step since
+both share the CLR and can consume the same `.csr.idx` / `.csr.val` /
+`.csr.meta` files.
+
+For F#, the minimum useful unit once Phase C has stabilized the
+format is:
+
+1. **Add a CSR-reader module** to the F# runtime tree (likely
+   `src/unifyweaver/targets/fsharp_runtime/CsrReader.fs`) implementing
+   the `io_policy(buffered_pread)` and `io_policy(buffered_pread_drop)`
+   paths. `direct_io` can stay out-of-scope on the first pass.
+2. **Wire the `reverse_index(csr(...))` option** into
+   `wam_fsharp_target.pl`'s option parsing, including
+   `id_encoding(int32_le)` and `phase(planning_only|cache_warmup|runtime_available)`.
+3. **Phase enforcement**: reject `phase(runtime_available)` at codegen
+   time until an F# runtime reverse-lookup API exists - matches the
+   guard already specified in §9 Phase A of the artifacts doc.
+4. **Tests** verifying identical descendant sets for sampled parents
+   against the Rust-built CSR fixture used by the existing
+   `tests/test_benchmark_reverse_csr_lookup.py`.
+
+CSR work is gated on LMDB work because the cost-model resolver
+(`WAM_REVERSE_INDEX_ARTIFACTS.md` §5) needs the parent-edge
+`eager`/`lazy`/`cached` choice as input. Sequencing: F# LMDB first,
+then F# CSR.
+
+## Other Notable Gaps
+
+These are smaller than the three above but worth tracking:
+
+- **`is_list/1`** is in the cross-target baseline (Lua, Python, Go)
+  but not currently wired in F#. Trivial addition - one match clause
+  in `WamRuntime.fs` `step` plus a Prolog dispatch entry.
+- **`succ/2`** is in the Clojure/Elixir baseline but not F#. Would
+  land naturally with the ISO `succ_iso/2` / `succ_lax/2` work
+  above.
+- **`assertz/1` / `retract/1` for clauses with bodies** - currently
+  documented as "use Python WAM target if you need this". A real fix
+  would require a heap-resident clause store rather than
+  `WcLoweredPredicates` mutation. Not gating other work.
+- **`docs/WAM_FSHARP_TARGET.md` "Control" line** incorrectly lists
+  `throw/1` and `catch/3` as supported. Should be corrected when ISO
+  substrate work begins, or sooner as a docs-only fix.
+
+## Recommended Follow-Up Order
+
+1. **Docs accuracy**: drop `throw/1` and `catch/3` from the
+   "Control" line in `docs/WAM_FSHARP_TARGET.md`, or mark them
+   "planned (see WAM_FSHARP_PARITY_AUDIT.md)". One-line PR.
+2. **ISO substrate Phase 1**: `WamException` + catch/throw + ISO
+   error constructors + `throw_iso_error`. Self-contained and
+   unblocks every later ISO-mode builtin. Matches the C++/Elixir
+   "minimum useful adoption unit".
+3. **ISO substrate Phase 2**: per-predicate config loader + default
+   rewrite + `is_iso/2` / `is_lax/2` + comparison aliases +
+   `wam_fsharp_iso_audit/3`. Lands once Phase 1 is in.
+4. **LMDB Phase 1 (eager + LookupSource interface)**: introduces
+   the trait shape without committing to `lazy`/`cached`. Lets later
+   phases land independently.
+5. **LMDB Phase 2 (lazy)**: `LmdbCursorLookup` + the
+   `lmdb_materialisation(lazy)` codegen option.
+6. **LMDB Phase 3 (cached)**: `CachedLookup` decorator + auto
+   resolver.
+7. **`is_list/1` and `succ/2`** small builtins: bundle with whichever
+   ISO PR they fit alongside.
+8. **CSR reader**: gated on LMDB work and on Rust CSR Phase C
+   stabilising the format.
+
+## Verification Commands
+
+Use these checks after touching F# WAM parity:
+
+```sh
+swipl -q -g run_tests -t halt tests/test_wam_fsharp_target.pl
+swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_runtime_smoke.pl
+swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_dotnet_smoke.pl
+swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_parser_smoke.pl
+swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_lowered_smoke.pl
+swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_lowered_parser_smoke.pl
+swipl -q -g "use_module(src/unifyweaver/targets/wam_fsharp_target), halt"
+```
+
+The dotnet smoke tests need the .NET 8 SDK on `PATH` and should be
+run under `LANG=C.UTF-8` (the test files contain em-dashes that the
+default POSIX locale rejects).

--- a/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
+++ b/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
@@ -57,26 +57,29 @@ Survey columns: shipped means code and tests exist in the target today.
 
 | Component | C++ | Elixir | Other WAM targets |
 |---|---|---|---|
-| Prolog config loader (`iso_errors_config/1`, inline overrides) | shipped | shipped | Python plumbing shipped; other targets not adopted |
-| Bare-PI multi-module warning | shipped | shipped | Python plumbing shipped; other targets not adopted |
-| Per-predicate default rewrite | shipped | shipped | Python plumbing shipped; other targets not adopted |
+| Prolog config loader (`iso_errors_config/1`, inline overrides) | shipped | shipped | Python and F# plumbing shipped; other targets not adopted |
+| Bare-PI multi-module warning | shipped | shipped | Python and F# plumbing shipped; other targets not adopted |
+| Per-predicate default rewrite | shipped | shipped | Python and F# plumbing shipped; other targets not adopted |
 | Text-path rewrite coverage (`builtin_call`, `put_structure`, `call`, `execute`) | shipped | shipped | target-specific |
-| Audit predicate and report | `wam_cpp_iso_audit/3` | `wam_elixir_iso_audit/3` | `wam_python_iso_audit/3`; others not adopted |
-| `catch/3` + `throw/1` substrate | shipped | shipped | Python shipped; others mostly missing/partial |
-| Error constructors and `throw_iso_error` helper | shipped | shipped | Python shipped; others not adopted |
-| `is_iso/2` / `is_lax/2` | shipped | shipped | Python shipped; others not adopted |
-| ISO/lax arithmetic compares | shipped | shipped | Python shipped; others not adopted |
-| `succ_iso/2` / `succ_lax/2` | shipped | shipped | Python shipped; others not adopted |
-| Lax IEEE-754 float divide behavior | shipped | shipped | Python shipped; others not adopted |
+| Audit predicate and report | `wam_cpp_iso_audit/3` | `wam_elixir_iso_audit/3` | `wam_python_iso_audit/3`, `wam_fsharp_iso_audit/3`; others not adopted |
+| `catch/3` + `throw/1` substrate | shipped | shipped | Python and F# shipped; others mostly missing/partial |
+| Error constructors and `throw_iso_error` helper | shipped | shipped | Python and F# shipped; others not adopted |
+| `is_iso/2` / `is_lax/2` | shipped | shipped | Python and F# shipped; others not adopted |
+| ISO/lax arithmetic compares | shipped | shipped | Python shipped; F# follow-up; others not adopted |
+| `succ_iso/2` / `succ_lax/2` | shipped | shipped | Python shipped; F# follow-up (succ/2 not yet wired); others not adopted |
+| Lax IEEE-754 float divide behavior | shipped | shipped | Python shipped; F# partial (float div by zero returns nan/inf via CLR; integer div by zero fails silently); others not adopted |
 
 The C++ and Elixir targets are therefore the current reference consumers. C++
 was the first implementation; Elixir proves the design is not C++-specific.
-Python has now adopted the catch/throw substrate, ISO error constructors,
+Python adopted the catch/throw substrate, ISO error constructors,
 `throw_iso_error`, per-predicate config/rewrite/audit plumbing, arithmetic
-assignment variants, arithmetic comparison variants, and successor variants. It
-should not be described as fully ISO-error compatible until remaining concrete
-builtins also adopt three-form keys. R, Lua, Haskell, Rust, and the remaining
-targets are still mostly missing or partial on this stack.
+assignment variants, arithmetic comparison variants, and successor variants. F#
+is now the third broad adopter (substrate + config/rewrite/audit +
+`is_iso/2` / `is_lax/2`); arithmetic comparison and successor variants are
+follow-up work for F#. Neither Python nor F# should be described as fully
+ISO-error compatible until remaining concrete builtins also adopt three-form
+keys. R, Lua, Haskell, Rust, and the remaining targets are still mostly missing
+or partial on this stack.
 
 ## What Counts As Adoption
 

--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -160,7 +160,14 @@ fsharp_wam_builtin_state_type :-
 
 fsharp_wam_env_frame_type :-
     writeln(
-"type EnvFrame = { EfSavedCP: int; EfYRegs: Map<int, Value>; EfSavedCutBar: int }").
+"type EnvFrame = { EfSavedCP: int; EfYRegs: Map<int, Value>; EfSavedCutBar: int }
+
+/// Exception carrier for Prolog throw/1.  The thrown term is
+/// deep-dereferenced before being raised so the catcher sees the
+/// value the thrower intended, not bindings that may have changed
+/// during unwind.  Uncaught throws propagate to the top-level entry
+/// point (dispatchCall / runPredicate).
+exception WamException of Value").
 
 % ============================================================================
 % ChoicePoint — mirrors Haskell `ChoicePoint`
@@ -245,7 +252,25 @@ type WamState =
       // barrier was set AFTER TryMeElse already incremented
       // WsCPsLen — see issue #2400 follow-up.
       WsB0Stack   : int list
+      // ISO catcher stack for catch/3.  Each catch/3 pushes a frame
+      // carrying the catcher pattern, recovery goal, and a snapshot
+      // of state at catch-entry time.  throw/1 raises a WamException
+      // which the nearest catch/3 try/with catches; the catcher
+      // restores its snapshot, unifies catcher with thrown term, and
+      // runs recovery.  Mirrors Python wam_runtime.catcher_frames.
+      WsCatchers  : CatcherFrame list
     }
+
+/// ISO catcher frame for catch/3.  CfSnapshot is the live state at
+/// catch-entry time; on WamException unwind the catcher restores from
+/// it.  CfSnapshotRegs is a defensive Array.copy of the snapshot''s
+/// WsRegs so that putReg''s in-place mutation between catch and throw
+/// can''t corrupt the saved frame (same discipline as ChoicePoint.CpRegs).
+and CatcherFrame =
+    { CfCatcherTerm  : Value
+      CfRecoveryTerm : Value
+      CfSnapshot     : WamState
+      CfSnapshotRegs : Value array }
 
 and BuilderState =
     | BuildStruct of fn: string * reg: int * arity: int * args: Value list
@@ -518,6 +543,49 @@ let bindOutput (reg: int) (value: Value) (s: WamState) : WamState option =
                      WsTrailLen = s.WsTrailLen + 1 }
         | existing when existing = value -> Some s
         | _ -> None
+
+// ============================================================================
+// ISO error-term constructors.  Mirror the Python/Elixir/C++ shapes:
+//   error(ErrorTerm, Context) where Context is an unbound var for v1.
+// throwIsoError wraps an ErrorTerm in the error/2 envelope, deep-derefs
+// it (so the catcher sees what the thrower meant, not stale bindings),
+// then raises WamException for the nearest catch/3 try/with to catch.
+// ============================================================================
+
+/// Build error(instantiation_error, _) inner.
+let makeInstantiationError () : Value = Atom \"instantiation_error\"
+
+/// Build error(type_error(Expected, Culprit), _) inner.
+let makeTypeError (expected: string) (culprit: Value) : Value =
+    Str (\"type_error\", [Atom expected; culprit])
+
+/// Build error(domain_error(Domain, Culprit), _) inner.
+let makeDomainError (domain: string) (culprit: Value) : Value =
+    Str (\"domain_error\", [Atom domain; culprit])
+
+/// Build error(evaluation_error(Kind), _) inner.
+let makeEvaluationError (kind: string) : Value =
+    Str (\"evaluation_error\", [Atom kind])
+
+/// Deep-deref a Value through current bindings so the thrown term is
+/// self-contained.  Mirrors Python _deep_copy_term''s deref pass.
+let rec derefDeep (bindings: Map<int, Value>) (v: Value) : Value =
+    match derefVar bindings v with
+    | Str (fn, args) -> Str (fn, args |> List.map (derefDeep bindings))
+    | VList items    -> VList (items |> List.map (derefDeep bindings))
+    | other          -> other
+
+/// Wrap an ISO error term in error(ErrorTerm, _) and raise WamException.
+/// The fresh unbound Context slot follows the C++ spec §5 decision: the
+/// standard catcher shape `error(Pattern, _)` will unify regardless.
+let throwIsoError (s: WamState) (errTerm: Value) : 'a =
+    let wrapped = Str (\"error\", [derefDeep s.WsBindings errTerm; Unbound s.WsVarCounter])
+    raise (WamException wrapped)
+
+/// Build a predicate-indicator term (Atom/Arity) for ISO error reports.
+/// Used as the Culprit for type_error(evaluable, X/N).
+let makePredIndicator (name: string) (arity: int) : Value =
+    Str (\"/\", [Atom name; Integer arity])
 
 /// Append a value to the current builder (PutStructure / PutList).
 // popBuilderStack: when an inner builder is finished (BuildStruct/List

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -47,7 +47,19 @@
     fsharp_fact_only/2,                  % +Segments, -Bool
     fsharp_first_arg_groundness/3,       % +Segments, +Arity, -Status
     fsharp_pick_layout/5,                % +PredIndicator, +NClauses, +FactOnly, +Options, -Layout
-    split_wam_into_segments_fs/2         % +Lines, -Segments
+    split_wam_into_segments_fs/2,        % +Lines, -Segments
+    % ISO error config + rewrite (parity with C++/Elixir/Python).  See
+    % docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md for the shared
+    % contract.  Initial F# adoption ships is_iso/2 and is_lax/2; the
+    % comparison-op and succ/2 variants are follow-ups.
+    iso_errors_resolve_options/2,        % +Options, -Config
+    iso_errors_load_config/2,            % +File, -Config
+    iso_errors_mode_for/3,               % +Config, +PI, -Mode
+    iso_errors_warn_multi_module/2,      % +Config, +Predicates
+    iso_errors_rewrite/4,                % +Config, +PI, +Items0, -Items
+    iso_errors_rewrite_text/4,           % +Config, +PI, +WamText0, -WamText
+    wam_fsharp_iso_audit/3,              % +Predicates, +Options, -Audit
+    wam_fsharp_iso_audit_report/1        % +Audit
 ]).
 
 :- use_module(library(lists)).
@@ -867,6 +879,26 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                                          WsB0Stack = s.WsCutBar :: s.WsB0Stack
                                          WsCutBar  = s.WsCPsLen }
 
+    // catch/3 and throw/1 are emitted by the WAM compiler as
+    // Call / Execute (meta-call shape) rather than BuiltinCall.
+    // Dispatch them through the BuiltinCall step branch so the ISO
+    // substrate runs.  For Call: BuiltinCall returns PC=WsPC+1 which
+    // matches the natural advance past the Call site.  For Execute:
+    // BuiltinCall returns PC=WsPC+1 (past the Execute itself), then
+    // we convert that to PC=WsCP to honor tail-call return semantics.
+    // ISO meta-builtins emitted as Call by the WAM compiler.  These
+    // are predicate names the shared wam_target.pl does NOT classify
+    // as is_builtin_goal, so they normally fall through to label
+    // lookup -- which would fail since these aren''t labelled
+    // predicates.  Routing through BuiltinCall here picks up the F#
+    // step arms for ISO catch/throw/is_iso/is_lax.
+    | Call (pred, arity) when pred = \"catch/3\" || pred = \"throw/1\"
+                            || pred = \"is_iso/2\" || pred = \"is_lax/2\" ->
+        let sc = { s with WsCP      = s.WsPC + 1
+                          WsB0Stack = s.WsCutBar :: s.WsB0Stack
+                          WsCutBar  = s.WsCPsLen }
+        step ctx sc (BuiltinCall (pred, arity))
+
     | Call (pred, _arity) ->
         let sc = { s with WsCP      = s.WsPC + 1
                           WsB0Stack = s.WsCutBar :: s.WsB0Stack
@@ -880,6 +912,21 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         match Map.tryFind pred ctx.WcLabels with
         | Some pc -> Some { sc with WsPC = pc }
         | None    -> None
+
+    | Execute pred when pred = \"catch/3\" || pred = \"throw/1\"
+                      || pred = \"is_iso/2\" || pred = \"is_lax/2\" ->
+        // Tail-call meta-builtin: dispatch through BuiltinCall, then
+        // convert the PC+1 advance (past the Execute slot) to WsCP so
+        // control returns to the outer caller as a normal Proceed
+        // would.  Execute itself does not push WsB0Stack, so there''s
+        // nothing to pop here.
+        let arity =
+            if pred = \"throw/1\" then 1
+            elif pred = \"catch/3\" then 3
+            else 2
+        match step ctx s (BuiltinCall (pred, arity)) with
+        | Some sNext -> Some { sNext with WsPC = sNext.WsCP }
+        | None -> None
 
     | Execute pred ->
         // Tail call: no return, so no push.  Update barrier in place.
@@ -1295,7 +1342,12 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         | Some (Integer _) | Some (Float _) -> Some { s with WsPC = s.WsPC + 1 }
         | _                                  -> None
 
-    | BuiltinCall ("is/2", _) ->
+    // is/2 and is_lax/2 share the lax body: arithmetic eval that fails
+    // silently on bad input.  is_iso/2 below has its own body that throws
+    // structured ISO error terms instead.  This split implements the
+    // three-form ISO/lax dispatch defined in WAM_CPP_ISO_ERRORS_SPECIFICATION.md
+    // and matches the Python/Elixir/C++ shipped reference shape.
+    | BuiltinCall ("is/2", _) | BuiltinCall ("is_lax/2", _) ->
         let expr   = s.WsRegs.[2] |> derefVar s.WsBindings
         let result = evalArith s.WsBindings expr
         let lhs    = getReg 1 s
@@ -1312,6 +1364,65 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
                      WsTrailLen= s.WsTrailLen + 1 }
         | Some (Integer n), Some r when float n = r -> Some { s with WsPC = s.WsPC + 1 }
         | _ -> None
+
+    // is_iso/2 — same eval semantics as is/2, but on bad eval raise a
+    // structured ISO error via throwIsoError.  Failure classification:
+    //   - unbound var anywhere in RHS -> instantiation_error
+    //   - integer or float zero divide  -> evaluation_error(zero_divisor)
+    //   - non-evaluable atom / unknown functor -> type_error(evaluable, X/N)
+    // The actual unwind is via WamException, which propagates up to the
+    // nearest catch/3 try/with (set up by the catch/3 builtin).
+    | BuiltinCall ("is_iso/2", _) ->
+        let expr = s.WsRegs.[2] |> derefVar s.WsBindings
+        // Step 1: instantiation check.
+        let rec hasUnbound v =
+            match derefVar s.WsBindings v with
+            | Unbound _      -> true
+            | Str (_, args)  -> List.exists hasUnbound args
+            | VList items    -> List.exists hasUnbound items
+            | _              -> false
+        if hasUnbound expr then throwIsoError s (makeInstantiationError ())
+        // Step 2: zero-divide check.  Parens around the inner match
+        // are mandatory in F# so subsequent `| Str ...` arms attach to
+        // the outer match, not the inner.
+        let rec hasZeroDivide v =
+            match derefVar s.WsBindings v with
+            | Str ((\"/\" | \"//\" | \"mod\" | \"rem\"), [_; rhs]) ->
+                (match derefVar s.WsBindings rhs with
+                 | Integer 0 -> true
+                 | Float f when f = 0.0 -> true
+                 | _ -> false)
+            | Str (_, args) -> List.exists hasZeroDivide args
+            | _ -> false
+        if hasZeroDivide expr then
+            throwIsoError s (makeEvaluationError \"zero_divisor\")
+        // Step 3: evaluate, classify any remaining failure as type_error.
+        let result = evalArith s.WsBindings expr
+        match result with
+        | None ->
+            // Build culprit term.  For an Atom ''foo'' use foo/0; for a
+            // Str f(args) use f/arity.  Anything else uses unknown/0.
+            let culprit =
+                match derefVar s.WsBindings expr with
+                | Atom name      -> makePredIndicator name 0
+                | Str (fn, args) -> makePredIndicator fn (List.length args)
+                | _              -> makePredIndicator \"unknown\" 0
+            throwIsoError s (makeTypeError \"evaluable\" culprit)
+        | Some r ->
+            let lhs = getReg 1 s
+            match lhs with
+            | Some (Unbound vid) ->
+                let v = if float (int r) = r then Integer (int r) else Float r
+                let regs = Array.copy s.WsRegs
+                regs.[1] <- v
+                Some { s with
+                         WsPC      = s.WsPC + 1
+                         WsRegs    = regs
+                         WsBindings= Map.add vid v s.WsBindings
+                         WsTrail   = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
+                         WsTrailLen= s.WsTrailLen + 1 }
+            | Some (Integer n) when float n = r -> Some { s with WsPC = s.WsPC + 1 }
+            | _ -> None
 
     | BuiltinCall ("length/2", _) ->
         match flattenList s s.WsRegs.[1] with
@@ -2225,6 +2336,198 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         | _ -> None
 
     // ========================================================================
+    // ISO catch/3 and throw/1 — exception-style non-local control.
+    //
+    // catch(Goal, Catcher, Recovery): pushes a CatcherFrame holding a
+    // snapshot of pre-call state, runs Goal recursively via `run`, pops
+    // the frame on normal return.  If Goal (or any nested goal) executes
+    // throw/1, F# raises WamException with the thrown term; the try/with
+    // here catches it, restores the snapshot, unifies Catcher with the
+    // thrown term, and runs Recovery.  Mirrors Python _execute_catch.
+    //
+    // throw(Term): deep-derefs Term through the current bindings and
+    // raises WamException.  Propagates through the run loop until caught
+    // by a catch/3 try/with or by the top-level runPredicate harness
+    // (which prints \"Uncaught Prolog throw: ...\" and returns None).
+    // ========================================================================
+    | BuiltinCall (\"throw/1\", _) ->
+        // Plain throw/1: pass the user''s term through unchanged.  ISO
+        // wrapping in error(ErrorTerm, Context) is the job of
+        // throwIsoError, which is_iso/2 and friends call directly when
+        // they detect a structured ISO failure.  User code that wants
+        // ISO shape passes error(...) terms explicitly.
+        match getReg 1 s with
+        | Some v ->
+            let thrown = derefDeep s.WsBindings v
+            raise (WamException thrown)
+        | None ->
+            raise (WamException (Atom \"instantiation_error\"))
+
+    | BuiltinCall (\"catch/3\", _) ->
+        let goal = getReg 1 s
+        let catcherTerm  = getReg 2 s |> Option.defaultValue (Unbound -1)
+        let recoveryTerm = getReg 3 s |> Option.defaultValue (Unbound -1)
+        let snapshotRegs = Array.copy s.WsRegs
+        let snapshot = { s with WsRegs = snapshotRegs }
+        let frame =
+            { CfCatcherTerm  = catcherTerm
+              CfRecoveryTerm = recoveryTerm
+              CfSnapshot     = snapshot
+              CfSnapshotRegs = snapshotRegs }
+        // Resolve the goal and build a child state to run.  Two
+        // dispatch paths:
+        //   1. Label lookup (user-defined predicate) -> jump to PC and
+        //      run.  This is the common case.
+        //   2. Builtin call (catch/3, throw/1, is_iso/2, is_lax/2, etc.)
+        //      -- the goal name isn''t a label so we fall through to a
+        //      BuiltinCall step.  Needed so nested catch/3 inside the
+        //      caller''s catch goal works, and so is_iso/2 (which the
+        //      WAM compiler emits as Execute, not BuiltinCall) can fire
+        //      its throw.
+        // true/fail are inlined to avoid round-tripping them through
+        // BuiltinCall.
+        let runGoalInChild (goalVal: Value) : WamState option =
+            let runWithArgs goalKey arity (dArgs: Value list) =
+                let regsCh = Array.create MaxRegs (Unbound -1)
+                dArgs |> List.iteri (fun i v -> regsCh.[i + 1] <- v)
+                let child =
+                    { s with
+                        WsRegs     = regsCh
+                        WsCP       = 0
+                        WsCutBar   = 0
+                        WsB0Stack  = []
+                        WsCatchers = frame :: s.WsCatchers }
+                match Map.tryFind goalKey ctx.WcLabels with
+                | Some pc -> run ctx { child with WsPC = pc }
+                | None ->
+                    // Fall through to BuiltinCall dispatch.  The PC is
+                    // immaterial here -- BuiltinCall doesn''t read WsPC
+                    // for dispatch; we set it to 0 so a recursive run
+                    // halts cleanly when the builtin returns.
+                    step ctx { child with WsPC = 0 } (BuiltinCall (goalKey, arity))
+            match goalVal with
+            | Atom \"true\" -> Some s
+            | Atom \"fail\" -> None
+            | Str (fname, args) ->
+                let arity = List.length args
+                let dArgs = args |> List.map (derefVar s.WsBindings)
+                let goalKey = sprintf \"%s/%d\" fname arity
+                runWithArgs goalKey arity dArgs
+            | Atom fname ->
+                let goalKey = sprintf \"%s/0\" fname
+                runWithArgs goalKey 0 []
+            | _ -> None
+        try
+            match goal with
+            | Some g ->
+                match runGoalInChild g with
+                | Some resultState ->
+                    // Goal succeeded.  Carry bindings/trail/heap forward
+                    // (they belong to the caller now), but revert WsRegs
+                    // to the catch/3 caller''s regs since the child used
+                    // a fresh register array.  Filter our specific
+                    // catcher frame out by reference identity in case
+                    // nested catches pushed their own.
+                    let withoutFrame =
+                        resultState.WsCatchers
+                        |> List.filter (fun f -> not (System.Object.ReferenceEquals(f, frame)))
+                    Some { resultState with
+                             WsRegs     = s.WsRegs
+                             WsCatchers = withoutFrame
+                             WsPC       = s.WsPC + 1 }
+                | None -> None
+            | None -> None
+        with
+        | WamException thrown ->
+            // Restore from snapshot, try to unify Catcher with Thrown,
+            // and on success run Recovery.  On unify failure rethrow so
+            // an outer catcher can try.
+            let regsRestored = Array.copy frame.CfSnapshotRegs
+            let restored = { frame.CfSnapshot with WsRegs = regsRestored }
+            // Unify in-place against the restored state''s bindings.
+            let rec unifyTerms (a: Value) (b: Value) (st: WamState) : WamState option =
+                let da = derefVar st.WsBindings a
+                let db = derefVar st.WsBindings b
+                match da, db with
+                | Unbound va, Unbound vb when va = vb -> Some st
+                | Unbound vid, v | v, Unbound vid ->
+                    Some { st with
+                             WsBindings = Map.add vid v st.WsBindings
+                             WsTrail    = { TrailVarId = vid
+                                            TrailOldVal = Map.tryFind vid st.WsBindings } :: st.WsTrail
+                             WsTrailLen = st.WsTrailLen + 1 }
+                | Atom a1, Atom a2 when a1 = a2 -> Some st
+                | Integer i1, Integer i2 when i1 = i2 -> Some st
+                | Float f1, Float f2 when f1 = f2 -> Some st
+                | Str (f1, a1), Str (f2, a2) when f1 = f2 && List.length a1 = List.length a2 ->
+                    let rec walk xs ys st0 =
+                        match xs, ys with
+                        | [], [] -> Some st0
+                        | x :: xr, y :: yr ->
+                            match unifyTerms x y st0 with
+                            | Some st1 -> walk xr yr st1
+                            | None -> None
+                        | _ -> None
+                    walk a1 a2 st
+                | VList l1, VList l2 when List.length l1 = List.length l2 ->
+                    let rec walk xs ys st0 =
+                        match xs, ys with
+                        | [], [] -> Some st0
+                        | x :: xr, y :: yr ->
+                            match unifyTerms x y st0 with
+                            | Some st1 -> walk xr yr st1
+                            | None -> None
+                        | _ -> None
+                    walk l1 l2 st
+                | _ -> None
+            match unifyTerms frame.CfCatcherTerm thrown restored with
+            | Some unified ->
+                // Run the recovery goal in a child state, similar to the
+                // catch''s goal path.  Recovery success advances PC past
+                // catch/3; failure causes catch to fail.
+                let recoveryRun =
+                    match derefVar unified.WsBindings frame.CfRecoveryTerm with
+                    // Common builtin atoms: handle directly without
+                    // requiring a label/builtin dispatch round-trip.
+                    | Atom \"true\"  -> Some unified
+                    | Atom \"fail\"  -> None
+                    | Str (fname, args) ->
+                        let dArgs = args |> List.map (derefVar unified.WsBindings)
+                        let goalKey = sprintf \"%s/%d\" fname (List.length args)
+                        match Map.tryFind goalKey ctx.WcLabels with
+                        | Some pc ->
+                            let regsCh = Array.create MaxRegs (Unbound -1)
+                            dArgs |> List.iteri (fun i v -> regsCh.[i + 1] <- v)
+                            let child =
+                                { unified with
+                                    WsPC      = pc
+                                    WsRegs    = regsCh
+                                    WsCP      = 0
+                                    WsCutBar  = 0
+                                    WsB0Stack = [] }
+                            run ctx child
+                        | None -> None
+                    | Atom fname ->
+                        let goalKey = sprintf \"%s/0\" fname
+                        match Map.tryFind goalKey ctx.WcLabels with
+                        | Some pc ->
+                            let child =
+                                { unified with
+                                    WsPC      = pc
+                                    WsCP      = 0
+                                    WsCutBar  = 0
+                                    WsB0Stack = [] }
+                            run ctx child
+                        | None -> None
+                    | _ -> None
+                match recoveryRun with
+                | Some _ -> Some { unified with WsPC = s.WsPC + 1 }
+                | None   -> None
+            | None ->
+                // Unify failed -- rethrow for outer catcher.
+                raise (WamException thrown)
+
+    // ========================================================================
     // Phase I — Haskell-only specialized instructions (perf optimizations).
     // ========================================================================
     // Reference: src/unifyweaver/targets/wam_haskell_target.pl. These are
@@ -2720,7 +3023,15 @@ and forkParBranches (ctx: WamContext) (s: WamState) (af: AggFrame)
                                // context.  Branch runs with WsCP=0 so a
                                // mismatched pop would halt; starting empty
                                // keeps Call/Proceed pairing consistent.
-                               WsB0Stack  = [] }
+                               WsB0Stack  = []
+                               // Catchers don''t span forks: a throw in a
+                               // forked branch propagates as uncaught
+                               // within the branch, killing it but not
+                               // the parent (whose catch frame holds a
+                               // snapshot of pre-fork state).  Conservative
+                               // choice for v1 -- distributed catch
+                               // across parallel branches is out of scope.
+                               WsCatchers = [] }
             return run ctx snapshot
         }
     let results =
@@ -2845,28 +3156,38 @@ and callIndexedFact2 (ctx: WamContext) (pred: string) (s: WamState) : WamState o
 
 /// Dispatch a Call to another predicate for use by lowered functions.
 and dispatchCall (ctx: WamContext) (pred: string) (sc: WamState) : WamState option =
-    match Map.tryFind pred ctx.WcLoweredPredicates with
-    | Some fn -> fn ctx sc
-    | None ->
-    match callIndexedFact2 ctx pred sc with
-    | Some sr -> Some sr
-    | None ->
-    match Map.tryFind pred ctx.WcLabels with
-    | Some pc ->
-        // Save the caller''s intended return PC and set WsCP = 0 before
-        // entering run.  Without this, the called predicate''s outermost
-        // Proceed sets WsPC = WsCP (the caller''s post-call PC), so the
-        // interpreter loop keeps executing the CALLER''s WAM continuation
-        // -- which is wrong when the caller is a lowered function that
-        // intends to handle its own continuation in F#.  Resetting WsCP
-        // to 0 makes Proceed stop the run loop (run returns on WsPC = 0);
-        // we restore WsCP before handing control back so the lowered
-        // caller''s subsequent Allocate sees the right value.
-        let savedCP = sc.WsCP
-        match run ctx { sc with WsPC = pc; WsCP = 0 } with
-        | Some sf -> Some { sf with WsCP = savedCP }
+    try
+        match Map.tryFind pred ctx.WcLoweredPredicates with
+        | Some fn -> fn ctx sc
+        | None ->
+        match callIndexedFact2 ctx pred sc with
+        | Some sr -> Some sr
+        | None ->
+        match Map.tryFind pred ctx.WcLabels with
+        | Some pc ->
+            // Save the caller''s intended return PC and set WsCP = 0 before
+            // entering run.  Without this, the called predicate''s outermost
+            // Proceed sets WsPC = WsCP (the caller''s post-call PC), so the
+            // interpreter loop keeps executing the CALLER''s WAM continuation
+            // -- which is wrong when the caller is a lowered function that
+            // intends to handle its own continuation in F#.  Resetting WsCP
+            // to 0 makes Proceed stop the run loop (run returns on WsPC = 0);
+            // we restore WsCP before handing control back so the lowered
+            // caller''s subsequent Allocate sees the right value.
+            let savedCP = sc.WsCP
+            match run ctx { sc with WsPC = pc; WsCP = 0 } with
+            | Some sf -> Some { sf with WsCP = savedCP }
+            | None    -> None
         | None    -> None
-    | None    -> None
+    with
+    | WamException term ->
+        // Uncaught throw at top-level dispatch.  Print a diagnostic on
+        // stderr (matching the Python runtime''s behavior) and return
+        // None so the caller observes a failed predicate rather than a
+        // .NET crash.  Tests that want to assert specific errors should
+        // use catch/3 from the Prolog side.
+        eprintfn \"Uncaught Prolog throw from %s: %A\" pred term
+        None
 
 /// Foreign call for lowered functions.
 and callForeign (ctx: WamContext) (pred: string) (sc: WamState) : WamState option =
@@ -3957,6 +4278,338 @@ fsharp_predicate_clause(Name/Arity, Head, Body) :-
     functor(Head, Name, Arity),
     clause(user:Head, Body).
 
+% ============================================================================
+% PHASE: ISO error configuration, rewrite, and audit
+% ============================================================================
+%
+% Shared contract: docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md +
+%                   docs/design/WAM_CPP_ISO_ERRORS_SPECIFICATION.md
+%
+% This block is a copy of the Python/Elixir iso_errors_* implementation
+% (which themselves descend from the C++ reference shape).  The three
+% targets all carry near-identical Prolog plumbing today; a future
+% refactor may extract this into src/unifyweaver/core/iso_errors.pl once
+% a fourth adopter motivates the move (note in
+% WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md §"Remaining Work").
+%
+% F# v1 ships only is/2 ↔ is_iso/2 / is_lax/2 in the key tables.  The
+% arithmetic-comparison sweep (>, <, >=, =<, =:=, =\=) and succ/2 are
+% follow-up PRs; adding them to the tables before the runtime branches
+% exist would silently rewrite default calls to dead keys.
+
+% Per-predicate ISO/lax dispatch tables.  Each (DefaultKey -> IsoKey
+% or LaxKey) entry needs a matching runtime branch in
+% step_function_fsharp -- adding to the table without the runtime
+% support silently drops calls.
+:- dynamic iso_errors_default_to_iso/2.
+:- dynamic iso_errors_default_to_lax/2.
+
+iso_errors_default_to_iso("is/2", "is_iso/2").
+iso_errors_default_to_lax("is/2", "is_lax/2").
+
+%% iso_errors_resolve_options(+Options, -Config)
+%  Merges optional file config with inline options into iso_config(Default,
+%  Overrides).  Inline options override file entries for the same PI.
+iso_errors_resolve_options(Options, iso_config(Default, Overrides)) :-
+    (   option(iso_errors_config(File), Options)
+    ->  iso_errors_load_config(File, iso_config(FileDefault, FileOv))
+    ;   FileDefault = false, FileOv = []
+    ),
+    iso_errors_inline_default(Options, FileDefault, Default),
+    iso_errors_inline_overrides(Options, InlineOv),
+    iso_errors_merge_overrides(FileOv, InlineOv, Overrides).
+
+iso_errors_inline_default(Options, FileDefault, Default) :-
+    (   member(iso_errors(M), Options),
+        (M == true ; M == false)
+    ->  Default = M
+    ;   Default = FileDefault
+    ).
+
+iso_errors_inline_overrides(Options, InlineOv) :-
+    findall(PI-Mode,
+        ( member(iso_errors(PI, Mode), Options),
+          (Mode == true ; Mode == false),
+          iso_errors_valid_pi(PI)
+        ),
+        InlineOv).
+
+iso_errors_valid_pi(Name/Arity) :- atom(Name), integer(Arity), Arity >= 0, !.
+iso_errors_valid_pi(Module:Name/Arity) :-
+    atom(Module), atom(Name), integer(Arity), Arity >= 0.
+
+iso_errors_merge_overrides(FileOv, InlineOv, Merged) :-
+    exclude(iso_errors_shadowed(InlineOv), FileOv, Kept),
+    append(Kept, InlineOv, Merged).
+
+iso_errors_shadowed(InlineOv, PI-_) :-
+    member(InlinePI-_, InlineOv),
+    iso_errors_pi_matches(InlinePI, PI), !.
+
+iso_errors_pi_matches(PI, PI) :- !.
+iso_errors_pi_matches(Name/Arity, _:Name/Arity) :-
+    atom(Name), integer(Arity), !.
+iso_errors_pi_matches(_:Name/Arity, Name/Arity) :-
+    atom(Name), integer(Arity), !.
+
+%% iso_errors_load_config(+File, -Config)
+%  Reads iso_errors_default/1 and iso_errors_override/2 facts.  Unknown
+%  facts and I/O failures are ignored, yielding iso_config(false, []).
+iso_errors_load_config(File, iso_config(Default, Overrides)) :-
+    catch(
+        setup_call_cleanup(
+            open(File, read, Stream),
+            iso_errors_read_terms(Stream, RawTerms),
+            close(Stream)),
+        _,
+        RawTerms = []),
+    iso_errors_extract_terms(RawTerms, false, [], Default, RevOv),
+    reverse(RevOv, Overrides).
+
+iso_errors_read_terms(Stream, Terms) :-
+    read_term(Stream, T, []),
+    (   T == end_of_file
+    ->  Terms = []
+    ;   Terms = [T|Rest],
+        iso_errors_read_terms(Stream, Rest)
+    ).
+
+iso_errors_extract_terms([], D, Ov, D, Ov).
+iso_errors_extract_terms([T|Rest], D0, Ov0, D, Ov) :-
+    (   T = iso_errors_default(NewD), (NewD == true ; NewD == false)
+    ->  iso_errors_extract_terms(Rest, NewD, Ov0, D, Ov)
+    ;   T = iso_errors_override(PI, Mode),
+        (Mode == true ; Mode == false),
+        iso_errors_valid_pi(PI)
+    ->  iso_errors_extract_terms(Rest, D0, [PI-Mode|Ov0], D, Ov)
+    ;   iso_errors_extract_terms(Rest, D0, Ov0, D, Ov)
+    ).
+
+%% iso_errors_mode_for(+Config, +PI, -Mode)
+iso_errors_mode_for(iso_config(Default, Overrides), PI, Mode) :-
+    (   member(OvPI-OvMode, Overrides),
+        iso_errors_pi_matches(OvPI, PI)
+    ->  Mode = OvMode
+    ;   Mode = Default
+    ).
+
+%% iso_errors_warn_multi_module(+Config, +Predicates)
+%  Warns when a bare override matches predicates from multiple modules.
+iso_errors_warn_multi_module(iso_config(_, Overrides), Predicates) :-
+    forall(member(OvPI-_, Overrides),
+           iso_errors_check_override_scope(OvPI, Predicates)).
+
+iso_errors_check_override_scope(Name/Arity, Predicates) :-
+    atom(Name), integer(Arity), !,
+    findall(M, ( member(P, Predicates),
+                 iso_errors_pi_module(P, Name, Arity, M)
+               ), Modules),
+    list_to_set(Modules, Unique),
+    (   Unique = [_, _ | _]
+    ->  length(Unique, N),
+        format(user_error,
+               'Warning: iso_errors_override(~w/~w, _) matches ~w predicates~n         in different modules (~w).~n         Qualify with `mod:~w/~w` for module-scoped overrides.~n',
+               [Name, Arity, N, Unique, Name, Arity])
+    ;   true
+    ).
+iso_errors_check_override_scope(_, _).
+
+iso_errors_pi_module(Module:Name/Arity, Name, Arity, Module) :- !.
+iso_errors_pi_module(Name/Arity, Name, Arity, user).
+iso_errors_pi_module(Pred/Arity-_, Name, Arity, user) :-
+    atom(Pred), Pred = Name, !.
+
+%% iso_errors_rewrite(+Config, +PI, +Items0, -Items)
+%  Item-level rewrite API shared with C++/Elixir/Python.  F# (like
+%  Python) currently uses the text-level wrapper below because both
+%  interpreter and lowered emitter paths start from WAM text.
+iso_errors_rewrite(Config, PI, Items0, Items) :-
+    iso_errors_mode_for(Config, PI, Mode),
+    maplist(iso_errors_rewrite_item(Mode), Items0, Items).
+
+iso_errors_rewrite_item(true, builtin_call(Key, N), builtin_call(IsoKey, N)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(true, put_structure(Key, Reg), put_structure(IsoKey, Reg)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(true, call(Key, N), call(IsoKey, N)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(true, execute(Key), execute(IsoKey)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(false, builtin_call(Key, N), builtin_call(LaxKey, N)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(false, put_structure(Key, Reg), put_structure(LaxKey, Reg)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(false, call(Key, N), call(LaxKey, N)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(false, execute(Key), execute(LaxKey)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(_, Item, Item).
+
+%% iso_errors_rewrite_text(+Config, +PI, +WamText, -RewrittenText)
+%  Text-level rewrite that walks the WAM text line-by-line, splicing
+%  default-form keys into their resolved ISO/lax forms.  Mirrors
+%  Python wam_python_target:iso_errors_rewrite_text/4.
+iso_errors_rewrite_text(Config, PI, WamText, RewrittenText) :-
+    iso_errors_mode_for(Config, PI, Mode),
+    (   Mode == false,
+        \+ iso_errors_has_lax_entries
+    ->  RewrittenText = WamText
+    ;   atom_string(WamText, S),
+        split_string(S, "\n", "", Lines),
+        maplist(iso_errors_rewrite_line(Mode), Lines, RewrittenLines),
+        atomic_list_concat(RewrittenLines, '\n', RewrittenText)
+    ).
+
+iso_errors_has_lax_entries :- iso_errors_default_to_lax(_, _), !.
+
+iso_errors_rewrite_line(Mode, Line, OutLine) :-
+    split_string(Line, " \t", " \t", Parts0),
+    exclude(==(""), Parts0, Parts),
+    (   iso_errors_rewrite_parts(Mode, Parts, Line, OutLine)
+    ->  true
+    ;   OutLine = Line
+    ).
+
+iso_errors_rewrite_parts(Mode, ["builtin_call", Key0 | _], Line, OutLine) :- !,
+    iso_errors_clean_key_token(Key0, Key),
+    iso_errors_lookup(Mode, Key, NewKey),
+    Key \== NewKey,
+    iso_errors_splice_line(Line, Key, NewKey, OutLine).
+iso_errors_rewrite_parts(Mode, ["put_structure", Key0 | _], Line, OutLine) :- !,
+    iso_errors_clean_key_token(Key0, Key),
+    iso_errors_lookup(Mode, Key, NewKey),
+    Key \== NewKey,
+    iso_errors_splice_line(Line, Key, NewKey, OutLine).
+iso_errors_rewrite_parts(Mode, ["call", Key0 | _], Line, OutLine) :- !,
+    iso_errors_clean_key_token(Key0, Key),
+    iso_errors_lookup(Mode, Key, NewKey),
+    Key \== NewKey,
+    iso_errors_splice_line(Line, Key, NewKey, OutLine).
+iso_errors_rewrite_parts(Mode, ["execute", Key0 | _], Line, OutLine) :- !,
+    iso_errors_clean_key_token(Key0, Key),
+    iso_errors_lookup(Mode, Key, NewKey),
+    Key \== NewKey,
+    iso_errors_splice_line(Line, Key, NewKey, OutLine).
+
+iso_errors_clean_key_token(Token0, Token) :-
+    (   string_concat(Token, ",", Token0)
+    ->  true
+    ;   Token = Token0
+    ).
+
+iso_errors_lookup(true, Key, NewKey) :-
+    iso_errors_default_to_iso(Key, NewKey), !.
+iso_errors_lookup(false, Key, NewKey) :-
+    iso_errors_default_to_lax(Key, NewKey), !.
+iso_errors_lookup(_, Key, Key).
+
+iso_errors_splice_line(Line, Key, NewKey, OutLine) :-
+    sub_string(Line, Before, KLen, _After, Key),
+    string_length(Key, KLen),
+    sub_string(Line, 0, Before, _, Pre),
+    PostStart is Before + KLen,
+    sub_string(Line, PostStart, _, 0, Post),
+    string_concat(Pre, NewKey, T1),
+    string_concat(T1, Post, OutLine), !.
+
+%% wam_fsharp_iso_audit(+Predicates, +Options, -Audit)
+%  Read-only audit pass that reports per-call-site resolution of
+%  default/explicit_iso/explicit_lax keys for each predicate in
+%  Predicates.  Useful for reviewing whether an iso_errors config does
+%  what was intended before generation.  Mirrors C++/Elixir/Python.
+wam_fsharp_iso_audit(Predicates, Options, Audit) :-
+    iso_errors_resolve_options(Options, Config),
+    findall(audit(PI, Mode, Sites), (
+        member(P, Predicates),
+        iso_errors_audit_normalise_pi(P, PI),
+        iso_errors_mode_for(Config, PI, Mode),
+        iso_errors_audit_predicate(PI, Mode, Sites)
+    ), Audit).
+
+iso_errors_audit_normalise_pi(Pred/Arity-_, Pred/Arity) :- !.
+iso_errors_audit_normalise_pi(Module:Pred/Arity, Module:Pred/Arity) :- !.
+iso_errors_audit_normalise_pi(PI, PI).
+
+iso_errors_audit_predicate(PI, Mode, Sites) :-
+    (   catch(
+            ( iso_errors_audit_wam_for_pi(PI, WamText),
+              iso_errors_audit_parse_lines(WamText, Items)
+            ),
+            _, fail)
+    ->  iso_errors_audit_walk(Items, 0, Mode, [], SitesRev),
+        reverse(SitesRev, Sites)
+    ;   Sites = []
+    ).
+
+iso_errors_audit_wam_for_pi(Module:Pred/Arity, WamText) :- !,
+    compile_predicate_to_wam(Module:Pred/Arity, [], WamText).
+iso_errors_audit_wam_for_pi(Pred/Arity, WamText) :-
+    compile_predicate_to_wam(Pred/Arity, [], WamText).
+
+iso_errors_audit_parse_lines(WamText, Items) :-
+    atom_string(WamText, S),
+    split_string(S, "\n", "", Lines),
+    maplist(iso_errors_audit_parse_one, Lines, MaybeItems),
+    exclude(==(skip), MaybeItems, Items).
+
+iso_errors_audit_parse_one(Line, Item) :-
+    split_string(Line, " \t", " \t", Parts0),
+    exclude(==(""), Parts0, Parts),
+    iso_errors_audit_classify_line(Parts, Item).
+
+iso_errors_audit_classify_line([], skip).
+iso_errors_audit_classify_line([Tok], label) :-
+    string_concat(_, ":", Tok), !.
+iso_errors_audit_classify_line(["builtin_call", Key0 | _], builtin_call(Key, 0)) :- !,
+    iso_errors_clean_key_token(Key0, Key).
+iso_errors_audit_classify_line(_, other).
+
+iso_errors_audit_walk([], _, _, Acc, Acc).
+iso_errors_audit_walk([label|Rest], PC, Mode, Acc, Out) :- !,
+    iso_errors_audit_walk(Rest, PC, Mode, Acc, Out).
+iso_errors_audit_walk([builtin_call(Key, _)|Rest], PC, Mode, Acc, Out) :- !,
+    iso_errors_audit_classify(Key, Mode, Source, Resolved, Flip),
+    PC1 is PC + 1,
+    iso_errors_audit_walk(Rest, PC1, Mode, [site(PC, Key, Resolved, Source, Flip)|Acc], Out).
+iso_errors_audit_walk([_|Rest], PC, Mode, Acc, Out) :-
+    PC1 is PC + 1,
+    iso_errors_audit_walk(Rest, PC1, Mode, Acc, Out).
+
+iso_errors_audit_classify(Key, _Mode, explicit_iso, Key, false) :-
+    iso_errors_key_has_suffix(Key, "_iso"), !.
+iso_errors_audit_classify(Key, _Mode, explicit_lax, Key, false) :-
+    iso_errors_key_has_suffix(Key, "_lax"), !.
+iso_errors_audit_classify(Key, Mode, default, Resolved, Flip) :-
+    iso_errors_resolve_default(Key, Mode, Resolved),
+    iso_errors_other_mode(Mode, OtherMode),
+    iso_errors_resolve_default(Key, OtherMode, OtherResolved),
+    ( Resolved == OtherResolved -> Flip = false ; Flip = true ).
+
+iso_errors_resolve_default(Key, true, IsoKey) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_resolve_default(Key, false, LaxKey) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_resolve_default(Key, _, Key).
+
+iso_errors_other_mode(true, false).
+iso_errors_other_mode(false, true).
+
+iso_errors_key_has_suffix(Key, Suffix) :-
+    ( atom(Key) -> atom_string(Key, KS) ; KS = Key ),
+    split_string(KS, "/", "", [Name | _]),
+    string_concat(_, Suffix, Name).
+
+wam_fsharp_iso_audit_report([]).
+wam_fsharp_iso_audit_report([audit(PI, Mode, Sites)|Rest]) :-
+    format('~w [~w]~n', [PI, Mode]),
+    (   Sites == []
+    ->  format('  (no builtin_call sites)~n', [])
+    ;   forall(member(site(PC, Orig, Res, Src, Flip), Sites),
+               format('  pc=~w  ~w -> ~w  (~w)  flip-changes=~w~n',
+                      [PC, Orig, Res, Src, Flip]))
+    ),
+    wam_fsharp_iso_audit_report(Rest).
+
 %% write_wam_fsharp_project(+Predicates, +Options, +ProjectDir)
 %  Generates a complete F# project with:
 %  - WamTypes.fs:   Value DU, WamState, WamContext, helpers
@@ -4061,7 +4714,13 @@ compile_predicates_to_fsharp(Predicates, Options, DetectedKernels, BasePCMap, Co
     ->  format(user_error, '[WAM-FSharp] skipped ~w FFI-owned fact predicates~n', [NSkipped])
     ;   true
     ),
-    maplist(compile_one_predicate_fs(Options, BasePCMap), WamPredicates, PredCodes),
+    % ISO error config: resolve once, warn about ambiguous bare overrides,
+    % pass through compile_one_predicate_fs so each predicate gets its
+    % WAM text rewritten according to its resolved Mode.  Mirrors Python
+    % wam_python_target:compile_all_predicates ISO wiring.
+    iso_errors_resolve_options(Options, IsoConfig),
+    iso_errors_warn_multi_module(IsoConfig, WamPredicates),
+    maplist(compile_one_predicate_fs(Options, BasePCMap, IsoConfig), WamPredicates, PredCodes),
     atomic_list_concat(PredCodes, '\n\n', AllPredCode),
     % Build merged code list and label map
     maplist(pred_func_name_fs, WamPredicates, FuncNames),
@@ -4077,15 +4736,27 @@ open WamRuntime
 ~w
 ', [AllPredCode, MergedCodeBuild]).
 
-compile_one_predicate_fs(Options, BasePCMap, PredIndicator, Code) :-
+compile_one_predicate_fs(Options, BasePCMap, IsoConfig, PredIndicator, Code) :-
     %% Shape check: must be Module:Name/Arity or Name/Arity.  The
     %% destructured Pred/Arity aren't used further (we pass
     %% PredIndicator wholesale to the helpers below); underscore-
     %% prefix the names so SWI doesn't flag them as singletons.
     (   PredIndicator = _M:_Pred/_Arity -> true ; PredIndicator = _Pred/_Arity ),
     wam_fsharp_predicate_wamcode(PredIndicator, WamCode),
+    %% ISO rewrite happens at the text level (matches Python).  Items
+    %% level rewrite is exported for future use but the F# emitter
+    %% currently parses WAM text, so a text-level pass is the natural
+    %% integration point.
+    iso_errors_pi_for_rewrite(PredIndicator, RewritePI),
+    iso_errors_rewrite_text(IsoConfig, RewritePI, WamCode, WamCodeIso),
     predicate_base_pc_fs(PredIndicator, BasePCMap, BasePC),
-    compile_wam_predicate_to_fsharp(PredIndicator, WamCode, [base_pc(BasePC)|Options], Code).
+    compile_wam_predicate_to_fsharp(PredIndicator, WamCodeIso, [base_pc(BasePC)|Options], Code).
+
+% Normalise an F# predicate indicator (possibly module-qualified or
+% paired) to the bare Name/Arity form iso_errors_mode_for expects.
+iso_errors_pi_for_rewrite(_M:Pred/Arity, Pred/Arity) :- !.
+iso_errors_pi_for_rewrite(Pred/Arity-_, Pred/Arity) :- !.
+iso_errors_pi_for_rewrite(PI, PI).
 
 pred_func_name_fs(PI, FN) :-
     (   PI = _M:P/A -> true ; PI = P/A ),
@@ -4297,7 +4968,8 @@ let main argv =
           WsBuilder    = None
           WsBuilderStack = []
           WsAggAccum   = []
-          WsB0Stack    = [] }
+          WsB0Stack    = []
+          WsCatchers   = [] }
 
     // Find entry point: prefer lowered predicates, fall back to code array
     let queryPred =

--- a/tests/core/test_wam_fsharp_iso_smoke.pl
+++ b/tests/core/test_wam_fsharp_iso_smoke.pl
@@ -1,0 +1,247 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% test_wam_fsharp_iso_smoke.pl - F# WAM ISO catch/throw + is_iso/is_lax smoke test
+%
+% Compiles a battery of small predicates that exercise the ISO error
+% substrate (catch/3, throw/1, is_iso/2 with structured errors,
+% is_lax/2 silent failure, per-predicate iso_errors override) to F#,
+% builds with dotnet, then drives each predicate from a hand-written
+% F# driver.  Companion to test_wam_fsharp_runtime_smoke.pl, which
+% covers the non-ISO runtime builtins.
+%
+% Each PASS/FAIL line summarises one input; the final RESULT line is
+% "PASSED/TOTAL".  Exit code 0 if all pass, 1 otherwise.
+
+:- encoding(utf8).
+:- use_module('../../src/unifyweaver/targets/wam_fsharp_target',
+              [write_wam_fsharp_project/3]).
+:- use_module(library(filesex), [delete_directory_and_contents/1,
+                                  make_directory_path/1,
+                                  directory_file_path/3]).
+:- use_module(library(process)).
+
+:- dynamic user:fs_iso_throw_catch_match/0.
+:- dynamic user:fs_iso_throw_catch_nomatch/0.
+:- dynamic user:fs_iso_no_throw_binds/0.
+:- dynamic user:fs_iso_is_iso_inst_err/0.
+:- dynamic user:fs_iso_is_iso_type_err/0.
+:- dynamic user:fs_iso_is_iso_zero_div/0.
+:- dynamic user:fs_iso_is_lax_silent/0.
+:- dynamic user:fs_iso_default_rewrite_is_iso/0.
+:- dynamic user:fs_iso_per_pred_override_lax/0.
+
+:- dynamic user:throwing_pred/0.
+:- dynamic user:simple_recovery/0.
+:- dynamic user:bind_to_42/1.
+:- dynamic user:eval_is_iso/1.
+:- dynamic user:eval_is_iso_unbound/1.
+:- dynamic user:eval_is_iso_zerodiv/1.
+:- dynamic user:eval_is_lax_bad/1.
+
+run_dotnet(Args, Dir, ExitCode, OutText) :-
+    setup_call_cleanup(
+        process_create(path(dotnet), Args,
+                       [cwd(Dir),
+                        stdout(pipe(Out)),
+                        stderr(pipe(Err)),
+                        process(PID)]),
+        ( read_string(Out, _, OutStr),
+          read_string(Err, _, ErrStr),
+          process_wait(PID, exit(ExitCode)),
+          string_concat(OutStr, ErrStr, OutText)
+        ),
+        ( catch(close(Out), _, true), catch(close(Err), _, true) )).
+
+main :-
+    %% ----- Helper predicates the tests call -----
+
+    %% throwing_pred always throws atom 'my_error'.
+    assertz((user:throwing_pred :- throw(my_error))),
+    %% simple_recovery is the recovery goal for catch tests.
+    assertz((user:simple_recovery :- true)),
+    %% bind_to_42 binds its argument to 42 -- used to verify catch
+    %% preserves bindings made by a successful goal.
+    assertz((user:bind_to_42(X) :- X = 42)),
+
+    %% eval_is_iso(X) - explicit is_iso call.  Should throw for bad
+    %% expressions even when iso_errors(false) is set.
+    assertz((user:eval_is_iso(X) :- is_iso(X, foo))),
+    %% eval_is_iso_unbound uses an explicit is_iso with an unbound RHS.
+    assertz((user:eval_is_iso_unbound(X) :- is_iso(X, _Y))),
+    %% eval_is_iso_zerodiv - integer divide by zero in ISO mode.
+    assertz((user:eval_is_iso_zerodiv(X) :- is_iso(X, 1 / 0))),
+    %% eval_is_lax_bad - explicit lax call on a bad expression; must
+    %% fail silently.
+    assertz((user:eval_is_lax_bad(X) :- is_lax(X, foo))),
+
+    %% ----- Tests -----
+
+    %% 1. throw + catch with matching catcher pattern -> recovery runs.
+    assertz((user:fs_iso_throw_catch_match :-
+        catch(throwing_pred, my_error, simple_recovery))),
+
+    %% 2. throw + catch with non-matching catcher -> rethrow.  We wrap
+    %% in OUTER catch so the rethrow is captured; predicate succeeds
+    %% if the outer catches what the inner re-raised.
+    assertz((user:fs_iso_throw_catch_nomatch :-
+        catch(
+            catch(throwing_pred, other_error, fail),
+            my_error,
+            simple_recovery))),
+
+    %% 3. catch + no throw -> goal succeeds, bindings persist.
+    assertz((user:fs_iso_no_throw_binds :-
+        catch(bind_to_42(X), _, fail),
+        X == 42)),
+
+    %% 4. is_iso with unbound RHS -> instantiation_error.
+    assertz((user:fs_iso_is_iso_inst_err :-
+        catch(
+            eval_is_iso_unbound(_X),
+            error(instantiation_error, _),
+            true))),
+
+    %% 5. is_iso with non-evaluable atom -> type_error(evaluable, ...).
+    assertz((user:fs_iso_is_iso_type_err :-
+        catch(
+            eval_is_iso(_X),
+            error(type_error(evaluable, _), _),
+            true))),
+
+    %% 6. is_iso with integer zero divide -> evaluation_error(zero_divisor).
+    assertz((user:fs_iso_is_iso_zero_div :-
+        catch(
+            eval_is_iso_zerodiv(_X),
+            error(evaluation_error(zero_divisor), _),
+            true))),
+
+    %% 7. is_lax with bad RHS -> silently fails (predicate calling
+    %% it via \+ should succeed because the inner failed).
+    assertz((user:fs_iso_is_lax_silent :-
+        \+ eval_is_lax_bad(_X))),
+
+    %% Setup: project dir.
+    Dir = '/tmp/uw_fsharp_iso_repro',
+    catch(delete_directory_and_contents(Dir), _, true),
+    make_directory_path(Dir),
+
+    %% Generate F# project.  Default mode (ISO defaults off in tests
+    %% above use explicit is_iso/is_lax forms, which survive any
+    %% rewrite).
+    write_wam_fsharp_project(
+        [user:fs_iso_throw_catch_match/0,
+         user:fs_iso_throw_catch_nomatch/0,
+         user:fs_iso_no_throw_binds/0,
+         user:fs_iso_is_iso_inst_err/0,
+         user:fs_iso_is_iso_type_err/0,
+         user:fs_iso_is_iso_zero_div/0,
+         user:fs_iso_is_lax_silent/0,
+         user:throwing_pred/0,
+         user:simple_recovery/0,
+         user:bind_to_42/1,
+         user:eval_is_iso/1,
+         user:eval_is_iso_unbound/1,
+         user:eval_is_iso_zerodiv/1,
+         user:eval_is_lax_bad/1],
+        [no_kernels(true),
+         module_name('uw_fs_iso_repro')],
+        Dir),
+    format('Project generated at ~w~n', [Dir]),
+
+    directory_file_path(Dir, 'Program.fs', ProgPath),
+    DriverCode = "module Program
+
+open WamTypes
+open WamRuntime
+open Predicates
+
+let mutable passes = 0
+let mutable fails = 0
+
+let assertTrue (name: string) (cond: bool) =
+    if cond then
+        passes <- passes + 1
+        printfn \"[PASS] %s\" name
+    else
+        fails <- fails + 1
+        printfn \"[FAIL] %s\" name
+
+let mkContext () =
+    let foreignPreds : string list = []
+    let resolvedCode =
+        resolveCallInstrs allLabels foreignPreds (Array.toList allCode)
+        |> List.toArray
+    { WcCode              = resolvedCode
+      WcLabels            = allLabels
+      WcForeignFacts      = Map.empty
+      WcFfiFacts          = Map.empty
+      WcFfiWeightedFacts  = Map.empty
+      WcAtomIntern        = Map.empty
+      WcAtomDeintern      = Map.empty
+      WcForeignConfig     = Map.empty
+      WcLoweredPredicates = Map.empty
+      WcCancellationToken = None }
+
+let mkState () : WamState =
+    { WsPC         = 0
+      WsRegs       = Array.create MaxRegs (Unbound -1)
+      WsStack      = []
+      WsHeap       = []
+      WsHeapLen    = 0
+      WsTrail      = []
+      WsTrailLen   = 0
+      WsCP         = 0
+      WsCPs        = []
+      WsCPsLen     = 0
+      WsBindings   = Map.empty
+      WsCutBar     = 0
+      WsVarCounter = 0
+      WsBuilder    = None
+      WsBuilderStack = []
+      WsAggAccum   = []
+      WsB0Stack    = []
+      WsCatchers   = [] }
+
+let runPredicate (predKey: string) =
+    let ctx = mkContext ()
+    let s = mkState ()
+    match dispatchCall ctx predKey s with
+    | Some s1 ->
+        match run ctx s1 with
+        | Some _ -> true
+        | None   -> false
+    | None -> false
+
+[<EntryPoint>]
+let main _argv =
+    assertTrue \"catch(throw(my_error), my_error, true)\"                  (runPredicate \"fs_iso_throw_catch_match/0\")
+    assertTrue \"catch(catch(throw(my_error), other, _), my_error, true)\" (runPredicate \"fs_iso_throw_catch_nomatch/0\")
+    assertTrue \"catch(X=42, _, fail), X == 42\"                          (runPredicate \"fs_iso_no_throw_binds/0\")
+    assertTrue \"catch(is_iso(X, _Y), error(instantiation_error, _), _)\" (runPredicate \"fs_iso_is_iso_inst_err/0\")
+    assertTrue \"catch(is_iso(X, foo), error(type_error(evaluable, _), _), _)\" (runPredicate \"fs_iso_is_iso_type_err/0\")
+    assertTrue \"catch(is_iso(X, 1/0), error(evaluation_error(zero_divisor), _), _)\" (runPredicate \"fs_iso_is_iso_zero_div/0\")
+    assertTrue \"\\\\+ is_lax(X, foo)\"                                    (runPredicate \"fs_iso_is_lax_silent/0\")
+
+    printfn \"RESULT %d/%d\" passes (passes + fails)
+    if fails > 0 then 1 else 0
+",
+    open(ProgPath, write, OW, [encoding(utf8)]),
+    write(OW, DriverCode),
+    close(OW),
+
+    format('Building...~n'),
+    run_dotnet(['build', '--nologo', '-v', 'minimal'], Dir, BuildExit, BuildOut),
+    (   BuildExit == 0
+    ->  format('Build OK.~n')
+    ;   format('--- build output ---~n~w~n----~n', [BuildOut]),
+        format('BUILD FAILED~n'),
+        halt(1)
+    ),
+
+    format('Running...~n'),
+    run_dotnet(['run', '--no-build', '-c', 'Debug'], Dir, RunExit, RunOut),
+    format('--- run output (exit=~w) ---~n~w~n----~n', [RunExit, RunOut]),
+    (   RunExit == 0
+    ->  halt(0)
+    ;   halt(1)
+    ).

--- a/tests/core/test_wam_fsharp_lowered_bench.pl
+++ b/tests/core/test_wam_fsharp_lowered_bench.pl
@@ -82,7 +82,8 @@ let mkState () : WamState =
       WsBuilder    = None
       WsBuilderStack = []
       WsAggAccum   = []
-      WsB0Stack    = [] }
+      WsB0Stack    = []
+      WsCatchers   = [] }
 
 let runPredicate (ctx: WamContext) (predKey: string) =
     let s = mkState ()

--- a/tests/core/test_wam_fsharp_lowered_parser_smoke.pl
+++ b/tests/core/test_wam_fsharp_lowered_parser_smoke.pl
@@ -133,7 +133,8 @@ let mkState () : WamState =
       WsBuilder    = None
       WsBuilderStack = []
       WsAggAccum   = []
-      WsB0Stack    = [] }
+      WsB0Stack    = []
+      WsCatchers   = [] }
 
 let runPredicate (predKey: string) =
     let ctx = mkContext ()

--- a/tests/core/test_wam_fsharp_lowered_smoke.pl
+++ b/tests/core/test_wam_fsharp_lowered_smoke.pl
@@ -199,7 +199,8 @@ let mkState () : WamState =
       WsBuilder    = None
       WsBuilderStack = []
       WsAggAccum   = []
-      WsB0Stack    = [] }
+      WsB0Stack    = []
+      WsCatchers   = [] }
 
 let runPredicate (predKey: string) =
     let ctx = mkContext ()

--- a/tests/core/test_wam_fsharp_parser_smoke.pl
+++ b/tests/core/test_wam_fsharp_parser_smoke.pl
@@ -290,7 +290,8 @@ let mkState () : WamState =
       WsBuilder    = None
       WsBuilderStack = []
       WsAggAccum   = []
-      WsB0Stack    = [] }
+      WsB0Stack    = []
+      WsCatchers   = [] }
 
 let runPredicate (predKey: string) =
     let ctx = mkContext ()

--- a/tests/core/test_wam_fsharp_runtime_smoke.pl
+++ b/tests/core/test_wam_fsharp_runtime_smoke.pl
@@ -195,7 +195,8 @@ let mkState () : WamState =
       WsBuilder    = None
       WsBuilderStack = []
       WsAggAccum   = []
-      WsB0Stack    = [] }
+      WsB0Stack    = []
+      WsCatchers   = [] }
 
 let runPredicate (predKey: string) =
     let ctx = mkContext ()

--- a/tests/test_wam_fsharp_iso_unit.pl
+++ b/tests/test_wam_fsharp_iso_unit.pl
@@ -1,0 +1,148 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% test_wam_fsharp_iso_unit.pl - Prolog-only unit tests for F# WAM ISO
+% error config loader, rewrite, and audit predicates.
+%
+% These tests don''t invoke dotnet -- they exercise the
+% iso_errors_resolve_options / iso_errors_mode_for /
+% iso_errors_rewrite_text / wam_fsharp_iso_audit helpers directly.
+% End-to-end behaviour (catch/throw + is_iso/is_lax in generated F#)
+% is covered by tests/core/test_wam_fsharp_iso_smoke.pl.
+
+:- encoding(utf8).
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [delete_directory_and_contents/1]).
+:- use_module('../src/unifyweaver/targets/wam_fsharp_target').
+
+:- begin_tests(wam_fsharp_iso_errors_config).
+
+% Helper: write a temp config file with one line per Line atom.
+iso_errors_temp_config_file(Path, Lines) :-
+    tmp_file('tmp_wam_fsharp_iso_cfg', Path),
+    setup_call_cleanup(
+        open(Path, write, Out),
+        forall(member(L, Lines), format(Out, '~w~n', [L])),
+        close(Out)).
+
+test(iso_errors_config_loader_basic) :-
+    iso_errors_temp_config_file(Path, [
+        'iso_errors_default(true).',
+        'iso_errors_override(legacy_lookup/3, false).',
+        'iso_errors_override(experimental:my_pred/2, true).',
+        'ignored_fact(ok).'
+    ]),
+    setup_call_cleanup(
+        true,
+        (   iso_errors_load_config(Path, Config),
+            assertion(Config == iso_config(true,
+                [legacy_lookup/3-false,
+                 (experimental:my_pred/2)-true])),
+            iso_errors_mode_for(Config, user:legacy_lookup/3, M1),
+            assertion(M1 == false),
+            iso_errors_mode_for(Config, user:never_listed/2, M2),
+            assertion(M2 == true),
+            iso_errors_mode_for(Config, experimental:my_pred/2, M3),
+            assertion(M3 == true)
+        ),
+        delete_file(Path)).
+
+test(iso_errors_config_missing_default) :-
+    iso_errors_temp_config_file(Path, [
+        '% no default declared',
+        'iso_errors_override(foo/0, true).'
+    ]),
+    setup_call_cleanup(
+        true,
+        (   iso_errors_load_config(Path, Config),
+            % Absent default -> false per spec.
+            assertion(Config == iso_config(false, [foo/0-true])),
+            iso_errors_mode_for(Config, user:foo/0, M1),
+            assertion(M1 == true),
+            iso_errors_mode_for(Config, user:bar/0, M2),
+            assertion(M2 == false)
+        ),
+        delete_file(Path)).
+
+test(iso_errors_inline_wins_over_file) :-
+    iso_errors_temp_config_file(Path, [
+        'iso_errors_default(false).',
+        'iso_errors_override(legacy_lookup/3, false).'
+    ]),
+    setup_call_cleanup(
+        true,
+        (   iso_errors_resolve_options(
+                [iso_errors_config(Path),
+                 iso_errors(true),
+                 iso_errors(legacy_lookup/3, true)],
+                Config),
+            iso_errors_mode_for(Config, user:legacy_lookup/3, M1),
+            assertion(M1 == true),
+            iso_errors_mode_for(Config, user:never_listed/2, M2),
+            assertion(M2 == true)
+        ),
+        delete_file(Path)).
+
+test(iso_errors_text_rewrite_is_to_is_iso) :-
+    Wam0 = 'demo/0:\n  put_variable 4, 1\n  put_integer 1, 2\n  builtin_call is/2 2\n  proceed',
+    iso_errors_rewrite_text(iso_config(true, []), demo/0, Wam0, IsoWam),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call is_iso/2 2")),
+    \+ sub_string(IsoWam, _, _, _, "builtin_call is/2 2").
+
+test(iso_errors_text_rewrite_is_to_is_lax) :-
+    Wam0 = 'demo/0:\n  builtin_call is/2 2\n  proceed',
+    iso_errors_rewrite_text(iso_config(false, []), demo/0, Wam0, LaxWam),
+    assertion(sub_string(LaxWam, _, _, _, "builtin_call is_lax/2 2")),
+    \+ sub_string(LaxWam, _, _, _, "builtin_call is/2 2").
+
+test(iso_errors_text_rewrite_explicit_iso_survives) :-
+    % Explicit is_iso/2 in source must NOT be rewritten in either mode.
+    Wam0 = 'demo/0:\n  builtin_call is_iso/2 2\n  proceed',
+    iso_errors_rewrite_text(iso_config(true, []), demo/0, Wam0, IsoWam),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call is_iso/2 2")),
+    iso_errors_rewrite_text(iso_config(false, []), demo/0, Wam0, LaxWam),
+    % Lax mode shouldn''t touch the explicit iso form either.
+    assertion(sub_string(LaxWam, _, _, _, "builtin_call is_iso/2 2")).
+
+test(iso_errors_text_rewrite_per_pred_override) :-
+    % Default ISO, override demo/0 to lax.
+    Config = iso_config(true, [demo/0-false]),
+    Wam0 = 'demo/0:\n  builtin_call is/2 2\n  proceed',
+    iso_errors_rewrite_text(Config, demo/0, Wam0, OutWam),
+    assertion(sub_string(OutWam, _, _, _, "builtin_call is_lax/2 2")),
+    % Other predicates default to ISO.
+    Wam2 = 'other/0:\n  builtin_call is/2 2\n  proceed',
+    iso_errors_rewrite_text(Config, other/0, Wam2, OutWam2),
+    assertion(sub_string(OutWam2, _, _, _, "builtin_call is_iso/2 2")).
+
+test(iso_errors_audit_structure) :-
+    setup_call_cleanup(
+        assertz((user:fs_iso_audit_pred :- X is 1 + 2, X = 3)),
+        (   wam_fsharp_iso_audit(
+                [user:fs_iso_audit_pred/0],
+                [iso_errors(fs_iso_audit_pred/0, true)],
+                Audit),
+            assertion(Audit = [audit(user:fs_iso_audit_pred/0, true, _Sites)])
+        ),
+        retractall(user:fs_iso_audit_pred)).
+
+test(iso_errors_project_generation_rewrites_wam_text) :-
+    TmpDir = '/tmp/uw_fs_iso_rewrite_unit',
+    catch(delete_directory_and_contents(TmpDir), _, true),
+    setup_call_cleanup(
+        assertz((user:fs_iso_rewrite_demo :- X is 1 + 2, X == 3)),
+        (   write_wam_fsharp_project(
+                [user:fs_iso_rewrite_demo/0],
+                [iso_errors(true), no_kernels(true)],
+                TmpDir),
+            % Predicates.fs should contain BuiltinCall ("is_iso/2", ...)
+            % rather than BuiltinCall ("is/2", ...).
+            string_concat(TmpDir, '/Predicates.fs', PredsPath),
+            read_file_to_string(PredsPath, Code, []),
+            assertion(sub_string(Code, _, _, _, "is_iso/2")),
+            \+ sub_string(Code, _, _, _, "is/2,")
+        ),
+        once((   retractall(user:fs_iso_rewrite_demo),
+                 catch(delete_directory_and_contents(TmpDir), _, true)
+             ))).
+
+:- end_tests(wam_fsharp_iso_errors_config).


### PR DESCRIPTION
## Summary

Brings the F# WAM target into the cross-target ISO-error adoption set defined in `docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`. F# joins Elixir, Python, and the C++ reference as a broad adopter. Two commits:

1. **`97911ef`** — parity audit doc (`docs/design/WAM_FSHARP_PARITY_AUDIT.md`) inventorying ISO/LMDB/CSR gaps. Also corrects an inaccuracy in `WAM_FSHARP_TARGET.md` that listed `throw/1` and `catch/3` as supported when they weren't yet wired.
2. **`2335e89`** — full ISO substrate + per-predicate config implementation; that doc inaccuracy gets re-flipped to "supported" because it's now true.

## Runtime substrate

`fsharp_wam_bindings.pl` + `wam_fsharp_target.pl`:

- `WamException` exception type carrying the thrown term
- `WsCatchers : CatcherFrame list` side stack on `WamState` with state snapshots for `catch/3` unwind
- ISO error builders: `makeInstantiationError`, `makeTypeError`, `makeDomainError`, `makeEvaluationError`, `makePredIndicator`
- `throwIsoError` wraps inner error term in `error(ErrorTerm, _)` and raises `WamException`
- `derefDeep` walker so thrown terms are bindings-independent

## Builtin dispatch

- `catch/3` snapshots state, pushes a `CatcherFrame`, runs goal in a child state, catches `WamException`, restores+unifies+runs recovery
- `throw/1` deep-derefs and raises `WamException` (no error/2 wrapping — that's `throwIsoError`'s job; user-level `throw/1` passes the term through unchanged)
- `is/2` and `is_lax/2` share the lax body (silent failure on bad eval)
- `is_iso/2` does three-step ISO classification: unbound → `instantiation_error`, zero divide → `evaluation_error(zero_divisor)`, non-evaluable atom / unknown functor → `type_error(evaluable, Name/Arity)`
- `Call`/`Execute` step arms special-case `catch/3`, `throw/1`, `is_iso/2`, `is_lax/2` since the shared WAM compiler emits these as `Call`/`Execute` rather than `BuiltinCall` (matches Elixir's dispatch pattern)
- `dispatchCall` wraps in try/with so uncaught throws print a diagnostic and return `None` rather than crashing dotnet

## Per-predicate ISO config

Copy of Python's `iso_errors_*` block, target-renamed audit predicate. As noted in the cross-target status doc, F# is now the third adopter — extracting these helpers into `src/unifyweaver/core/iso_errors.pl` is appropriate next work but out of scope here.

- `iso_errors_config(File)` loads `iso_errors_default/1` and `iso_errors_override/2` facts
- `iso_errors(Bool)` / `iso_errors(PI, Bool)` inline options override file entries (inline wins)
- `iso_errors_warn_multi_module/2` warns on bare PI overrides matching multiple modules
- `iso_errors_rewrite_text/4` rewrites WAM text per resolved mode; wired into `compile_predicates_to_fsharp`
- `wam_fsharp_iso_audit/3` + `wam_fsharp_iso_audit_report/1`

## Tests

- `tests/test_wam_fsharp_iso_unit.pl` — 8 Prolog-only unit tests for loader, mode resolver, rewrite, audit, and end-to-end project-generation rewrite check
- `tests/core/test_wam_fsharp_iso_smoke.pl` — 7 dotnet E2E tests covering throw+catch (matching catcher, rethrow on non-match, bindings persist on no-throw), `is_iso` with each of the three ISO error shapes, and `is_lax` silent failure

## Test plan

- [x] `tests/test_wam_fsharp_target.pl` — 53/53 (no regressions in generator unit tests)
- [x] `tests/test_wam_fsharp_iso_unit.pl` — 8/8 new ISO unit tests
- [x] `tests/core/test_wam_fsharp_runtime_smoke.pl` — 19/19 (existing runtime smoke unchanged)
- [x] `tests/core/test_wam_fsharp_parser_smoke.pl` — 42/42 (parser smoke unchanged)
- [x] `tests/core/test_wam_fsharp_lowered_smoke.pl` — 19/19
- [x] `tests/core/test_wam_fsharp_lowered_parser_smoke.pl` — 8/8
- [x] `tests/core/test_wam_fsharp_iso_smoke.pl` — 7/7 new ISO E2E

## Follow-ups (called out in the audit doc, not in this PR)

- Arithmetic-compare ISO/lax sweep (`>_iso/2`, `<_iso/2`, `>=_iso/2`, `=<_iso/2`, `=:=_iso/2`, `=\=_iso/2` + matching `_lax` aliases)
- `succ/2` + `succ_iso/2` / `succ_lax/2`
- Extract `iso_errors_*` into `src/unifyweaver/core/iso_errors.pl` (now that three targets carry near-identical copies)

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_