### PR TITLE
feat(wam-python): add atomic list concat and split string helpers

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -875,6 +875,57 @@ def _execute_string_code(state: WamState) -> bool:
     return unify(get_reg(state, 3), Int(ord(text[index.n - 1])), state)
 
 
+def _execute_atomic_list_concat(state: WamState, arity: int) -> bool:
+    if arity == 2:
+        items = _term_to_list(get_reg(state, 1), state)
+        if items is None:
+            return False
+        parts: List[str] = []
+        for item in items:
+            text = _text_coerce(item, state)
+            if text is None:
+                return False
+            parts.append(text)
+        return unify(get_reg(state, 2), make_atom(''.join(parts)), state)
+
+    separator = _text_coerce(get_reg(state, 2), state, allow_float=False)
+    if separator is None:
+        return False
+    items = _term_to_list(get_reg(state, 1), state)
+    if items is not None:
+        parts: List[str] = []
+        for item in items:
+            text = _text_coerce(item, state)
+            if text is None:
+                return False
+            parts.append(text)
+        return unify(get_reg(state, 3), make_atom(separator.join(parts)), state)
+
+    source = _text_coerce(get_reg(state, 3), state, allow_float=False)
+    if source is None or separator == '':
+        return False
+    return unify(get_reg(state, 1), _list_from_terms([make_atom(part) for part in source.split(separator)]), state)
+
+
+def _execute_split_string(state: WamState) -> bool:
+    text = _text_coerce(get_reg(state, 1), state)
+    separators = _text_coerce(get_reg(state, 2), state, allow_float=False)
+    pads = _text_coerce(get_reg(state, 3), state, allow_float=False)
+    if text is None or separators is None or pads is None:
+        return False
+
+    parts: List[str] = []
+    current: List[str] = []
+    for ch in text:
+        if ch in separators:
+            parts.append(''.join(current).strip(pads))
+            current = []
+        else:
+            current.append(ch)
+    parts.append(''.join(current).strip(pads))
+    return unify(get_reg(state, 4), _list_from_terms([make_atom(part) for part in parts]), state)
+
+
 def _execute_append(state: WamState) -> bool:
     left = _term_to_list(get_reg(state, 1), state)
     right = _term_to_list(get_reg(state, 2), state)
@@ -1983,6 +2034,12 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return _execute_char_code(state)
     if builtin in ('string_code/3', 'string_code') and arity == 3:
         return _execute_string_code(state)
+    if builtin in ('atomic_list_concat/2', 'atomic_list_concat') and arity == 2:
+        return _execute_atomic_list_concat(state, 2)
+    if builtin in ('atomic_list_concat/3',) and arity == 3:
+        return _execute_atomic_list_concat(state, 3)
+    if builtin in ('split_string/4', 'split_string') and arity == 4:
+        return _execute_split_string(state)
     if builtin in ('read_term_from_atom/2', 'read_term_from_atom_lax/2',
                    'read_term_from_atom', 'read_term_from_atom_lax') and arity == 2:
         return _execute_read_term_from_atom(state, 2, 'fail')

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -1208,6 +1208,33 @@ test(runtime_number_char_helpers) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_atomic_split_string_helpers) :-
+	setup_call_cleanup(
+		(   retractall(user:py_atomic_split_helper_demo),
+			assertz((user:py_atomic_split_helper_demo :-
+				atomic_list_concat([a, 2, b], Joined), Joined = 'a2b',
+				atomic_list_concat([a, b, c], '-', Hyphen), Hyphen = 'a-b-c',
+				atomic_list_concat(Parts, '-', 'x-y-z'), Parts = [x, y, z],
+				split_string(' a, b,,c ', ',', ' ', Split), Split = [a, b, '', c],
+				\+ atomic_list_concat(_, '', abc),
+				\+ split_string(f(1), ',', '', _))),
+			user:python_parser_tmp_dir('tmp_wam_python_atomic_split_helpers', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_atomic_split_helper_demo/0],
+				[runtime_parser(off)], ProjectDir),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_atomic_split_helper_demo/0', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_atomic_split_helper_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_runs_reverse_term_to_atom) :-
 	setup_call_cleanup(
 		(   retractall(user:py_term_to_atom_demo),
@@ -1699,6 +1726,9 @@ test(static_runtime_has_lua_baseline_builtins, [nondet]) :-
 		"atom_number/2",
 		"char_code/2",
 		"string_code/3",
+		"atomic_list_concat/2",
+		"atomic_list_concat/3",
+		"split_string/4",
 		"var/1",
 		"nonvar/1",
 		"is_list/1",
@@ -1758,6 +1788,8 @@ test(static_runtime_io_emits_output, [nondet]) :-
 	sub_string(Content, _, _, _, "def _execute_atom_number"),
 	sub_string(Content, _, _, _, "def _execute_char_code"),
 	sub_string(Content, _, _, _, "def _execute_string_code"),
+	sub_string(Content, _, _, _, "def _execute_atomic_list_concat"),
+	sub_string(Content, _, _, _, "def _execute_split_string"),
 	sub_string(Content, _, _, _, "print()").
 
 :- end_tests(wam_python_builtin_parity_guard).


### PR DESCRIPTION
## Summary

- add Python WAM runtime support for `atomic_list_concat/2`
- add `atomic_list_concat/3` join and split modes
- add `split_string/4` with separator and pad-character handling
- cover generated-project behavior for joins, splits, adjacent separators, padding, and failure cases
- extend the Python builtin parity guard for these common text helpers

## Notes

This mirrors the current C++ target behavior: `atomic_list_concat/3` joins when the list is bound and splits when the list is unbound and the source atom is bound; empty separators fail in split mode. `split_string/4` splits on any separator character and strips leading/trailing pad characters from each part.

## Verification

- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode),run_tests(wam_python_builtin_parity_guard)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
