### PR TITLE
wam-fsharp: ISO arithmetic-compare sweep + succ/2 family

### DIFF
--- a/docs/WAM_FSHARP_TARGET.md
+++ b/docs/WAM_FSHARP_TARGET.md
@@ -89,7 +89,7 @@ let mkState () : WamState =
       WsTrail = []; WsTrailLen = 0; WsCP = 0; WsCPs = []; WsCPsLen = 0
       WsBindings = Map.empty; WsCutBar = 0; WsVarCounter = 0
       WsBuilder = None; WsBuilderStack = []; WsAggAccum = []
-      WsB0Stack = [] }
+      WsB0Stack = []; WsCatchers = [] }
 
 [<EntryPoint>]
 let main _argv =
@@ -456,15 +456,15 @@ defines step branches for:
 **Control:** `true/0`, `fail/0`, `!/0` (cut), `\+/1` (negation),
 `call/1+`, `throw/1`, `catch/3`.
 
-**ISO error variants:** `is_iso/2` (throws structured `error(_, _)`
-on bad eval), `is_lax/2` (alias of `is/2`, fails silently). The
-default `is/2` can be rewritten per-predicate via the
-`iso_errors_config(File)` / `iso_errors(Bool)` /
+**ISO error variants:** Each of `is/2`, the six arithmetic comparisons
+(`>`, `<`, `>=`, `=<`, `=:=`, `=\\=`), and `succ/2` ships in three
+forms: the default (rewritten per-predicate by the iso_errors config),
+an explicit `_iso/2` (always throws structured `error(_, _)` on bad
+input), and an explicit `_lax/2` (always silent-fails). Configure via
+the `iso_errors_config(File)` / `iso_errors(Bool)` /
 `iso_errors(PI, Bool)` options; `wam_fsharp_iso_audit/3` reports
-what each call site resolves to. Arithmetic-comparison variants
-(`>_iso/2`, `<_iso/2`, ...) and `succ_iso/2` are planned follow-ups
--- see `design/WAM_FSHARP_PARITY_AUDIT.md`. Cross-target ISO
-contract: `design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`.
+what each call site resolves to. Cross-target ISO contract:
+`design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`.
 
 **Arithmetic:** `is/2` (full expression evaluator: `+`, `-`, `*`, `/`,
 `//`, `mod`, `rem`, `**`, `abs`, `min`, `max`, `gcd`, `truncate`,

--- a/docs/design/WAM_FSHARP_PARITY_AUDIT.md
+++ b/docs/design/WAM_FSHARP_PARITY_AUDIT.md
@@ -68,8 +68,8 @@ are follow-up work.
 | ISO error constructors | Present | `makeInstantiationError`, `makeTypeError`, `makeDomainError`, `makeEvaluationError`, `makePredIndicator` in `fsharp_wam_bindings.pl`. |
 | `throw_iso_error` helper | Present | Wraps the inner error term in `error(ErrorTerm, _)` (with a fresh unbound `Context`) and raises `WamException`. |
 | `is_iso/2` / `is_lax/2` | Present | `is/2` and `is_lax/2` share the lax body; `is_iso/2` does three-step classification (unbound -> instantiation_error, zero divide -> evaluation_error(zero_divisor), otherwise -> type_error(evaluable, Name/Arity)). |
-| ISO/lax arithmetic compares | **Missing** | Six comparison variants (`>`, `<`, `>=`, `=<`, `=:=`, `=\\=`) still need ISO/lax three-form dispatch. Follow-up PR. |
-| `succ/2` and ISO/lax variants | **Missing** | F# does not currently expose `succ/2` at all. Follow-up PR. |
+| ISO/lax arithmetic compares | Present | All six variants (`>`, `<`, `>=`, `=<`, `=:=`, `=\\=`) ship with `_iso/2` and `_lax/2` aliases. The lax aliases share the existing lax body via OR-pattern dispatch; the ISO variants classify failures as `instantiation_error` (unbound side) or `type_error(evaluable, X/N)`. |
+| `succ/2` and ISO/lax variants | Present | `succ/2` (bidirectional successor with lax silent-fail) plus `succ_iso/2` (raises `instantiation_error` / `type_error(integer, _)` / `type_error(not_less_than_zero, X)` / `domain_error(not_less_than_zero, Y)` per Aït-Kaci spec §6) and `succ_lax/2`. |
 | Lax IEEE-754 float divide | Partial | F# `is/2` already returns `nan`/`inf`/`-inf` for float zero division (CLR default). Integer divide-by-zero in lax mode fails silently because `evalArith` returns `None` (no exception escapes), matching the documented lax contract. |
 | Per-predicate ISO config loader | Present | `iso_errors_config(File)`, inline `iso_errors(Default)` / `iso_errors(PI, Mode)`, file-vs-inline precedence per spec. Copied from Python target; future extraction into `src/unifyweaver/core/iso_errors.pl` is appropriate now that F# is the third adopter. |
 | Per-predicate default rewrite | Present | `iso_errors_rewrite_text/4` walks WAM text, rewriting `is/2` -> `is_iso/2` / `is_lax/2` according to the predicate's resolved mode. Wired into `compile_predicates_to_fsharp` so generated F# uses the ISO-mode key. |
@@ -77,22 +77,20 @@ are follow-up work.
 
 ### Remaining F# ISO Work
 
-Steps 1-5 and 7-8 of the original minimum-useful-adoption list (now
-matched against `WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` § "What Counts
-As Adoption") shipped together. The remaining items:
+The arithmetic-compare sweep and `succ/2` family shipped in a
+follow-up PR alongside the substrate work. F# now matches the full
+"minimum useful adoption unit" in
+`WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` § "What Counts As Adoption"
+plus the C++/Elixir/Python reference key tables (minus `read/*` /
+`read_term*/*`, which are runtime-parser-dependent and live on the
+F# runtime-parser side).
 
-- **Arithmetic-compare ISO/lax variants**: `>_iso/2`, `<_iso/2`,
-  `>=_iso/2`, `=<_iso/2`, `=:=_iso/2`, `=\\=_iso/2` plus matching
-  `*_lax/2` aliases. Each needs a step branch alongside the existing
-  lax branch, an entry in both `iso_errors_default_to_iso/2` and
-  `iso_errors_default_to_lax/2`, and a regression test case.
-- **`succ/2` family**: F# does not currently support `succ/2` at
-  all. Adding it adds three keys (default, `_iso`, `_lax`) per the
-  three-form pattern.
-- **Shared helper extraction**: F# is now the third adopter (after
-  Elixir and Python -- C++ is its own reference). Extracting the
-  `iso_errors_*` predicates into `src/unifyweaver/core/iso_errors.pl`
-  is appropriate next, as called out in
+Remaining cross-cutting work:
+
+- **Shared helper extraction**: F# is the third adopter of the
+  copy-pasted `iso_errors_*` block (after Elixir and Python).
+  Extracting these helpers into `src/unifyweaver/core/iso_errors.pl`
+  is appropriate next per
   `WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` § "Remaining Work".
 
 ## LMDB Fact-Source Readiness

--- a/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
+++ b/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
@@ -65,8 +65,8 @@ Survey columns: shipped means code and tests exist in the target today.
 | `catch/3` + `throw/1` substrate | shipped | shipped | Python and F# shipped; others mostly missing/partial |
 | Error constructors and `throw_iso_error` helper | shipped | shipped | Python and F# shipped; others not adopted |
 | `is_iso/2` / `is_lax/2` | shipped | shipped | Python and F# shipped; others not adopted |
-| ISO/lax arithmetic compares | shipped | shipped | Python shipped; F# follow-up; others not adopted |
-| `succ_iso/2` / `succ_lax/2` | shipped | shipped | Python shipped; F# follow-up (succ/2 not yet wired); others not adopted |
+| ISO/lax arithmetic compares | shipped | shipped | Python and F# shipped; others not adopted |
+| `succ_iso/2` / `succ_lax/2` | shipped | shipped | Python and F# shipped; others not adopted |
 | Lax IEEE-754 float divide behavior | shipped | shipped | Python shipped; F# partial (float div by zero returns nan/inf via CLR; integer div by zero fails silently); others not adopted |
 
 The C++ and Elixir targets are therefore the current reference consumers. C++
@@ -74,9 +74,9 @@ was the first implementation; Elixir proves the design is not C++-specific.
 Python adopted the catch/throw substrate, ISO error constructors,
 `throw_iso_error`, per-predicate config/rewrite/audit plumbing, arithmetic
 assignment variants, arithmetic comparison variants, and successor variants. F#
-is now the third broad adopter (substrate + config/rewrite/audit +
-`is_iso/2` / `is_lax/2`); arithmetic comparison and successor variants are
-follow-up work for F#. Neither Python nor F# should be described as fully
+now matches that adoption surface (substrate + config/rewrite/audit +
+`is_iso/2` / `is_lax/2` + six arithmetic-compare ISO/lax variants +
+`succ/2` family). Neither Python nor F# should be described as fully
 ISO-error compatible until remaining concrete builtins also adopt three-form
 keys. R, Lua, Haskell, Rust, and the remaining targets are still mostly missing
 or partial on this stack.

--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -587,6 +587,48 @@ let throwIsoError (s: WamState) (errTerm: Value) : 'a =
 let makePredIndicator (name: string) (arity: int) : Value =
     Str (\"/\", [Atom name; Integer arity])
 
+/// True iff any subterm in v dereferences to an unbound variable.
+/// Used by is_iso/2 and the ISO arithmetic-compare variants to
+/// detect instantiation_error before evaluating.
+let rec hasUnboundDeep (bindings: Map<int, Value>) (v: Value) : bool =
+    match derefVar bindings v with
+    | Unbound _      -> true
+    | Str (_, args)  -> args  |> List.exists (hasUnboundDeep bindings)
+    | VList items    -> items |> List.exists (hasUnboundDeep bindings)
+    | _              -> false
+
+/// Build the Name/Arity culprit term used by type_error(evaluable, ...).
+/// Walks one level: Atom 'foo' -> foo/0; Str (f, args) -> f/(length args);
+/// anything else -> unknown/0.  Mirrors Python iso_arith_culprit.
+let arithCulprit (bindings: Map<int, Value>) (expr: Value) : Value =
+    match derefVar bindings expr with
+    | Atom name      -> makePredIndicator name 0
+    | Str (fn, args) -> makePredIndicator fn (List.length args)
+    | _              -> makePredIndicator \"unknown\" 0
+
+/// True for predicate names the WAM compiler emits as Call/Execute
+/// (meta-call shape) but that the F# step function handles as ISO
+/// builtins.  The Call/Execute step arms check this to route through
+/// BuiltinCall dispatch.
+let isIsoMetaBuiltin (pred: string) : bool =
+    match pred with
+    | \"catch/3\" | \"throw/1\"
+    | \"is_iso/2\" | \"is_lax/2\"
+    | \"<_iso/2\" | \">_iso/2\" | \">=_iso/2\" | \"=<_iso/2\"
+    | \"=:=_iso/2\" | \"=\\\\=_iso/2\"
+    | \"<_lax/2\" | \">_lax/2\" | \">=_lax/2\" | \"=<_lax/2\"
+    | \"=:=_lax/2\" | \"=\\\\=_lax/2\"
+    | \"succ/2\" | \"succ_iso/2\" | \"succ_lax/2\" -> true
+    | _ -> false
+
+/// Arity of an ISO meta-builtin.  Used by the Execute step arm to
+/// reconstruct the BuiltinCall instruction.
+let isoMetaBuiltinArity (pred: string) : int =
+    match pred with
+    | \"throw/1\" -> 1
+    | \"catch/3\" -> 3
+    | _ -> 2  // is_*, comparison ops, succ all arity 2
+
 /// Append a value to the current builder (PutStructure / PutList).
 // popBuilderStack: when an inner builder is finished (BuildStruct/List
 // arity filled, or ReadArgs exhausted), restore the outer builder

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -892,8 +892,7 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
     // lookup -- which would fail since these aren''t labelled
     // predicates.  Routing through BuiltinCall here picks up the F#
     // step arms for ISO catch/throw/is_iso/is_lax.
-    | Call (pred, arity) when pred = \"catch/3\" || pred = \"throw/1\"
-                            || pred = \"is_iso/2\" || pred = \"is_lax/2\" ->
+    | Call (pred, arity) when isIsoMetaBuiltin pred ->
         let sc = { s with WsCP      = s.WsPC + 1
                           WsB0Stack = s.WsCutBar :: s.WsB0Stack
                           WsCutBar  = s.WsCPsLen }
@@ -913,17 +912,13 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
         | Some pc -> Some { sc with WsPC = pc }
         | None    -> None
 
-    | Execute pred when pred = \"catch/3\" || pred = \"throw/1\"
-                      || pred = \"is_iso/2\" || pred = \"is_lax/2\" ->
+    | Execute pred when isIsoMetaBuiltin pred ->
         // Tail-call meta-builtin: dispatch through BuiltinCall, then
         // convert the PC+1 advance (past the Execute slot) to WsCP so
         // control returns to the outer caller as a normal Proceed
         // would.  Execute itself does not push WsB0Stack, so there''s
         // nothing to pop here.
-        let arity =
-            if pred = \"throw/1\" then 1
-            elif pred = \"catch/3\" then 3
-            else 2
+        let arity = isoMetaBuiltinArity pred
         match step ctx s (BuiltinCall (pred, arity)) with
         | Some sNext -> Some { sNext with WsPC = sNext.WsCP }
         | None -> None
@@ -1374,14 +1369,9 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
     // nearest catch/3 try/with (set up by the catch/3 builtin).
     | BuiltinCall ("is_iso/2", _) ->
         let expr = s.WsRegs.[2] |> derefVar s.WsBindings
-        // Step 1: instantiation check.
-        let rec hasUnbound v =
-            match derefVar s.WsBindings v with
-            | Unbound _      -> true
-            | Str (_, args)  -> List.exists hasUnbound args
-            | VList items    -> List.exists hasUnbound items
-            | _              -> false
-        if hasUnbound expr then throwIsoError s (makeInstantiationError ())
+        // Step 1: instantiation check (helper in fsharp_wam_bindings).
+        if hasUnboundDeep s.WsBindings expr then
+            throwIsoError s (makeInstantiationError ())
         // Step 2: zero-divide check.  Parens around the inner match
         // are mandatory in F# so subsequent `| Str ...` arms attach to
         // the outer match, not the inner.
@@ -1424,6 +1414,44 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
             | Some (Integer n) when float n = r -> Some { s with WsPC = s.WsPC + 1 }
             | _ -> None
 
+    // ISO arithmetic-compare variants.  Each iso_arithCompare branch
+    // classifies a failed eval as either instantiation_error (any
+    // side has unbound) or type_error(evaluable, X/N).  Lax variants
+    // share the existing op/2 body via the alias match below.
+    | BuiltinCall (\"<_iso/2\", _) | BuiltinCall (\">_iso/2\", _)
+    | BuiltinCall (\">=_iso/2\", _) | BuiltinCall (\"=<_iso/2\", _)
+    | BuiltinCall (\"=:=_iso/2\", _) | BuiltinCall (\"=\\\\=_iso/2\", _) ->
+        let op = match instr with
+                 | BuiltinCall (k, _) -> k
+                 | _ -> \"<_iso/2\"
+        let a1 = getReg 1 s
+        let a2 = getReg 2 s
+        // ISO instantiation check fires on either side.
+        let unboundA = match a1 with Some v -> hasUnboundDeep s.WsBindings v | None -> true
+        let unboundB = match a2 with Some v -> hasUnboundDeep s.WsBindings v | None -> true
+        if unboundA || unboundB then
+            throwIsoError s (makeInstantiationError ())
+        let r1 = a1 |> Option.bind (evalArith s.WsBindings)
+        let r2 = a2 |> Option.bind (evalArith s.WsBindings)
+        match r1, r2 with
+        | None, _ ->
+            let culprit = match a1 with Some v -> arithCulprit s.WsBindings v | None -> makePredIndicator \"unknown\" 0
+            throwIsoError s (makeTypeError \"evaluable\" culprit)
+        | _, None ->
+            let culprit = match a2 with Some v -> arithCulprit s.WsBindings v | None -> makePredIndicator \"unknown\" 0
+            throwIsoError s (makeTypeError \"evaluable\" culprit)
+        | Some a, Some b ->
+            let ok =
+                match op with
+                | \"<_iso/2\"   -> a < b
+                | \">_iso/2\"   -> a > b
+                | \">=_iso/2\"  -> a >= b
+                | \"=<_iso/2\"  -> a <= b
+                | \"=:=_iso/2\" -> abs (a - b) < System.Double.Epsilon
+                | \"=\\\\=_iso/2\" -> abs (a - b) >= System.Double.Epsilon
+                | _ -> false
+            if ok then Some { s with WsPC = s.WsPC + 1 } else None
+
     | BuiltinCall ("length/2", _) ->
         match flattenList s s.WsRegs.[1] with
         | Some items ->
@@ -1443,14 +1471,18 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
             | _ -> None
         | _ -> None
 
-    | BuiltinCall ("</2", _) ->
+    // Lax arithmetic comparisons: silent failure on bad eval.  Each
+    // op/2 also matches op_lax/2 so user code can write the explicit
+    // form to bypass an ISO-mode rewrite.  See is_iso/is_lax above
+    // for the three-form contract.
+    | BuiltinCall ("</2", _) | BuiltinCall (\"<_lax/2\", _) ->
         let v1 = getReg 1 s |> Option.bind (evalArith s.WsBindings)
         let v2 = getReg 2 s |> Option.bind (evalArith s.WsBindings)
         match v1, v2 with
         | Some a, Some b when a < b -> Some { s with WsPC = s.WsPC + 1 }
         | _ -> None
 
-    | BuiltinCall (">/2", _) ->
+    | BuiltinCall (">/2", _) | BuiltinCall (\">_lax/2\", _) ->
         let v1 = getReg 1 s |> Option.bind (evalArith s.WsBindings)
         let v2 = getReg 2 s |> Option.bind (evalArith s.WsBindings)
         match v1, v2 with
@@ -1461,21 +1493,21 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
     // C++ comparison builtins). Each evaluates both sides via evalArith and
     // dispatches on the operator. =:=/2 and =\\=/2 use EPSILON tolerance to
     // bridge integer / float comparisons (mirrors the Rust implementation).
-    | BuiltinCall (">=/2", _) ->
+    | BuiltinCall (">=/2", _) | BuiltinCall (\">=_lax/2\", _) ->
         let v1 = getReg 1 s |> Option.bind (evalArith s.WsBindings)
         let v2 = getReg 2 s |> Option.bind (evalArith s.WsBindings)
         match v1, v2 with
         | Some a, Some b when a >= b -> Some { s with WsPC = s.WsPC + 1 }
         | _ -> None
 
-    | BuiltinCall ("=</2", _) ->
+    | BuiltinCall ("=</2", _) | BuiltinCall (\"=<_lax/2\", _) ->
         let v1 = getReg 1 s |> Option.bind (evalArith s.WsBindings)
         let v2 = getReg 2 s |> Option.bind (evalArith s.WsBindings)
         match v1, v2 with
         | Some a, Some b when a <= b -> Some { s with WsPC = s.WsPC + 1 }
         | _ -> None
 
-    | BuiltinCall ("=:=/2", _) ->
+    | BuiltinCall ("=:=/2", _) | BuiltinCall (\"=:=_lax/2\", _) ->
         let v1 = getReg 1 s |> Option.bind (evalArith s.WsBindings)
         let v2 = getReg 2 s |> Option.bind (evalArith s.WsBindings)
         match v1, v2 with
@@ -1483,12 +1515,100 @@ let rec step (ctx: WamContext) (s: WamState) (instr: Instruction) : WamState opt
             Some { s with WsPC = s.WsPC + 1 }
         | _ -> None
 
-    | BuiltinCall ("=\\\\=/2", _) ->
+    | BuiltinCall ("=\\\\=/2", _) | BuiltinCall (\"=\\\\=_lax/2\", _) ->
         let v1 = getReg 1 s |> Option.bind (evalArith s.WsBindings)
         let v2 = getReg 2 s |> Option.bind (evalArith s.WsBindings)
         match v1, v2 with
         | Some a, Some b when abs (a - b) >= System.Double.Epsilon ->
             Some { s with WsPC = s.WsPC + 1 }
+        | _ -> None
+
+    // succ/2 + succ_lax/2 - bidirectional successor.  Lax semantics:
+    // X bound non-negative integer -> Y = X+1; Y bound positive
+    // integer -> X = Y-1; both unbound, or X negative, or Y zero/
+    // negative -> silent fail.  Mirrors Python _execute_succ_lax.
+    | BuiltinCall (\"succ/2\", _) | BuiltinCall (\"succ_lax/2\", _) ->
+        let a = getReg 1 s
+        let b = getReg 2 s
+        let bindReg reg value =
+            match getReg reg s with
+            | Some (Unbound vid) ->
+                let regs = Array.copy s.WsRegs
+                regs.[reg] <- value
+                Some { s with
+                         WsPC      = s.WsPC + 1
+                         WsRegs    = regs
+                         WsBindings= Map.add vid value s.WsBindings
+                         WsTrail   = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
+                         WsTrailLen= s.WsTrailLen + 1 }
+            | Some bound when bound = value -> Some { s with WsPC = s.WsPC + 1 }
+            | _ -> None
+        match a, b with
+        | Some (Integer n), _ when n >= 0 -> bindReg 2 (Integer (n + 1))
+        | _, Some (Integer m) when m > 0  -> bindReg 1 (Integer (m - 1))
+        | _ -> None
+
+    // succ_iso/2 - bidirectional successor with ISO error throws.
+    // Mirrors Python _execute_succ_iso and Aït-Kaci spec §6:
+    //   both unbound          -> instantiation_error
+    //   X not integer         -> type_error(integer, X)
+    //   Y not integer         -> type_error(integer, Y)
+    //   X negative            -> type_error(not_less_than_zero, X)
+    //   Y zero or negative    -> domain_error(not_less_than_zero, Y)
+    | BuiltinCall (\"succ_iso/2\", _) ->
+        let a = getReg 1 s
+        let b = getReg 2 s
+        let aUnbound = match a with Some (Unbound _) -> true | None -> true | _ -> false
+        let bUnbound = match b with Some (Unbound _) -> true | None -> true | _ -> false
+        if aUnbound && bUnbound then
+            throwIsoError s (makeInstantiationError ())
+        // Type check non-unbound args.
+        (match a with
+         | Some v when not aUnbound ->
+            (match v with
+             | Integer _ -> ()
+             | _ -> throwIsoError s (makeTypeError \"integer\" v))
+         | _ -> ())
+        (match b with
+         | Some v when not bUnbound ->
+            (match v with
+             | Integer _ -> ()
+             | _ -> throwIsoError s (makeTypeError \"integer\" v))
+         | _ -> ())
+        // Negativity / domain checks.
+        match a, b with
+        | Some (Integer n), _ when n < 0 ->
+            throwIsoError s (makeTypeError \"not_less_than_zero\" (Integer n))
+        | _, Some (Integer m) when m <= 0 ->
+            throwIsoError s (makeDomainError \"not_less_than_zero\" (Integer m))
+        | Some (Integer n), _ ->
+            let v = Integer (n + 1)
+            match getReg 2 s with
+            | Some (Unbound vid) ->
+                let regs = Array.copy s.WsRegs
+                regs.[2] <- v
+                Some { s with
+                         WsPC      = s.WsPC + 1
+                         WsRegs    = regs
+                         WsBindings= Map.add vid v s.WsBindings
+                         WsTrail   = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
+                         WsTrailLen= s.WsTrailLen + 1 }
+            | Some bound when bound = v -> Some { s with WsPC = s.WsPC + 1 }
+            | _ -> None
+        | _, Some (Integer m) ->
+            let v = Integer (m - 1)
+            match getReg 1 s with
+            | Some (Unbound vid) ->
+                let regs = Array.copy s.WsRegs
+                regs.[1] <- v
+                Some { s with
+                         WsPC      = s.WsPC + 1
+                         WsRegs    = regs
+                         WsBindings= Map.add vid v s.WsBindings
+                         WsTrail   = { TrailVarId = vid; TrailOldVal = Map.tryFind vid s.WsBindings } :: s.WsTrail
+                         WsTrailLen= s.WsTrailLen + 1 }
+            | Some bound when bound = v -> Some { s with WsPC = s.WsPC + 1 }
+            | _ -> None
         | _ -> None
 
     // ==/2, \\==/2 — structural term equality (no unification, no binding).
@@ -4305,7 +4425,22 @@ fsharp_predicate_clause(Name/Arity, Head, Body) :-
 :- dynamic iso_errors_default_to_lax/2.
 
 iso_errors_default_to_iso("is/2", "is_iso/2").
+iso_errors_default_to_iso(">/2", ">_iso/2").
+iso_errors_default_to_iso("</2", "<_iso/2").
+iso_errors_default_to_iso(">=/2", ">=_iso/2").
+iso_errors_default_to_iso("=</2", "=<_iso/2").
+iso_errors_default_to_iso("=:=/2", "=:=_iso/2").
+iso_errors_default_to_iso("=\\=/2", "=\\=_iso/2").
+iso_errors_default_to_iso("succ/2", "succ_iso/2").
+
 iso_errors_default_to_lax("is/2", "is_lax/2").
+iso_errors_default_to_lax(">/2", ">_lax/2").
+iso_errors_default_to_lax("</2", "<_lax/2").
+iso_errors_default_to_lax(">=/2", ">=_lax/2").
+iso_errors_default_to_lax("=</2", "=<_lax/2").
+iso_errors_default_to_lax("=:=/2", "=:=_lax/2").
+iso_errors_default_to_lax("=\\=/2", "=\\=_lax/2").
+iso_errors_default_to_lax("succ/2", "succ_lax/2").
 
 %% iso_errors_resolve_options(+Options, -Config)
 %  Merges optional file config with inline options into iso_config(Default,

--- a/tests/core/test_wam_fsharp_iso_smoke.pl
+++ b/tests/core/test_wam_fsharp_iso_smoke.pl
@@ -27,8 +27,22 @@
 :- dynamic user:fs_iso_is_iso_type_err/0.
 :- dynamic user:fs_iso_is_iso_zero_div/0.
 :- dynamic user:fs_iso_is_lax_silent/0.
-:- dynamic user:fs_iso_default_rewrite_is_iso/0.
-:- dynamic user:fs_iso_per_pred_override_lax/0.
+
+%% Comparison ISO variants
+:- dynamic user:fs_iso_lt_iso_inst/0.
+:- dynamic user:fs_iso_lt_iso_type/0.
+:- dynamic user:fs_iso_gt_iso_inst/0.
+:- dynamic user:fs_iso_eq_iso_type/0.
+:- dynamic user:fs_iso_lt_lax_silent/0.
+:- dynamic user:fs_iso_gt_lax_silent/0.
+
+%% Successor ISO variants
+:- dynamic user:fs_iso_succ_forward/0.
+:- dynamic user:fs_iso_succ_reverse/0.
+:- dynamic user:fs_iso_succ_iso_both_unbound/0.
+:- dynamic user:fs_iso_succ_iso_x_negative/0.
+:- dynamic user:fs_iso_succ_iso_y_zero/0.
+:- dynamic user:fs_iso_succ_lax_silent/0.
 
 :- dynamic user:throwing_pred/0.
 :- dynamic user:simple_recovery/0.
@@ -37,6 +51,18 @@
 :- dynamic user:eval_is_iso_unbound/1.
 :- dynamic user:eval_is_iso_zerodiv/1.
 :- dynamic user:eval_is_lax_bad/1.
+:- dynamic user:lt_iso_unbound/1.
+:- dynamic user:lt_iso_bad/0.
+:- dynamic user:gt_iso_unbound/1.
+:- dynamic user:eq_iso_bad/0.
+:- dynamic user:lt_lax_bad/0.
+:- dynamic user:gt_lax_bad/0.
+:- dynamic user:succ_lax_bad/0.
+:- dynamic user:succ_iso_neg/0.
+:- dynamic user:succ_iso_zero/0.
+:- dynamic user:succ_iso_unbound/0.
+:- dynamic user:succ_forward/1.
+:- dynamic user:succ_reverse/1.
 
 run_dotnet(Args, Dir, ExitCode, OutText) :-
     setup_call_cleanup(
@@ -120,6 +146,78 @@ main :-
     assertz((user:fs_iso_is_lax_silent :-
         \+ eval_is_lax_bad(_X))),
 
+    %% ----- ISO arithmetic comparison variants -----
+    %% Helpers that issue the explicit *_iso / *_lax forms.
+    assertz((user:lt_iso_unbound(X) :- '<_iso'(X, 3))),
+    assertz((user:lt_iso_bad      :- '<_iso'(foo, 3))),
+    assertz((user:gt_iso_unbound(X) :- '>_iso'(X, 3))),
+    assertz((user:eq_iso_bad      :- '=:=_iso'(foo, 3))),
+    assertz((user:lt_lax_bad      :- '<_lax'(foo, 3))),
+    assertz((user:gt_lax_bad      :- '>_lax'(foo, bar))),
+
+    %% 8. <_iso with unbound LHS -> instantiation_error.
+    assertz((user:fs_iso_lt_iso_inst :-
+        catch(lt_iso_unbound(_X),
+              error(instantiation_error, _),
+              true))),
+
+    %% 9. <_iso with non-evaluable -> type_error(evaluable, ...).
+    assertz((user:fs_iso_lt_iso_type :-
+        catch(lt_iso_bad,
+              error(type_error(evaluable, _), _),
+              true))),
+
+    %% 10. >_iso with unbound -> instantiation_error.
+    assertz((user:fs_iso_gt_iso_inst :-
+        catch(gt_iso_unbound(_X),
+              error(instantiation_error, _),
+              true))),
+
+    %% 11. =:=_iso with non-evaluable -> type_error.
+    assertz((user:fs_iso_eq_iso_type :-
+        catch(eq_iso_bad,
+              error(type_error(evaluable, _), _),
+              true))),
+
+    %% 12, 13: lax comparisons fail silently on bad eval.
+    assertz((user:fs_iso_lt_lax_silent :- \+ lt_lax_bad)),
+    assertz((user:fs_iso_gt_lax_silent :- \+ gt_lax_bad)),
+
+    %% ----- succ/2 variants -----
+    assertz((user:succ_forward(Y) :- succ(2, Y))),
+    assertz((user:succ_reverse(X) :- succ(X, 5))),
+    assertz((user:succ_iso_neg     :- succ_iso(-1, _Y))),
+    assertz((user:succ_iso_zero    :- succ_iso(_X, 0))),
+    assertz((user:succ_iso_unbound :- succ_iso(_X, _Y))),
+    assertz((user:succ_lax_bad     :- succ_lax(-3, _Y))),
+
+    %% 14, 15: succ/2 bidirectional.
+    assertz((user:fs_iso_succ_forward :-
+        succ_forward(Y), Y == 3)),
+    assertz((user:fs_iso_succ_reverse :-
+        succ_reverse(X), X == 4)),
+
+    %% 16: succ_iso both unbound -> instantiation_error.
+    assertz((user:fs_iso_succ_iso_both_unbound :-
+        catch(succ_iso_unbound,
+              error(instantiation_error, _),
+              true))),
+
+    %% 17: succ_iso negative X -> type_error(not_less_than_zero, X).
+    assertz((user:fs_iso_succ_iso_x_negative :-
+        catch(succ_iso_neg,
+              error(type_error(not_less_than_zero, _), _),
+              true))),
+
+    %% 18: succ_iso Y = 0 -> domain_error(not_less_than_zero, Y).
+    assertz((user:fs_iso_succ_iso_y_zero :-
+        catch(succ_iso_zero,
+              error(domain_error(not_less_than_zero, _), _),
+              true))),
+
+    %% 19: succ_lax with bad arg fails silently.
+    assertz((user:fs_iso_succ_lax_silent :- \+ succ_lax_bad)),
+
     %% Setup: project dir.
     Dir = '/tmp/uw_fsharp_iso_repro',
     catch(delete_directory_and_contents(Dir), _, true),
@@ -136,13 +234,40 @@ main :-
          user:fs_iso_is_iso_type_err/0,
          user:fs_iso_is_iso_zero_div/0,
          user:fs_iso_is_lax_silent/0,
+         %% Comparison ISO/lax tests
+         user:fs_iso_lt_iso_inst/0,
+         user:fs_iso_lt_iso_type/0,
+         user:fs_iso_gt_iso_inst/0,
+         user:fs_iso_eq_iso_type/0,
+         user:fs_iso_lt_lax_silent/0,
+         user:fs_iso_gt_lax_silent/0,
+         %% succ/2 + variants
+         user:fs_iso_succ_forward/0,
+         user:fs_iso_succ_reverse/0,
+         user:fs_iso_succ_iso_both_unbound/0,
+         user:fs_iso_succ_iso_x_negative/0,
+         user:fs_iso_succ_iso_y_zero/0,
+         user:fs_iso_succ_lax_silent/0,
+         %% Helpers
          user:throwing_pred/0,
          user:simple_recovery/0,
          user:bind_to_42/1,
          user:eval_is_iso/1,
          user:eval_is_iso_unbound/1,
          user:eval_is_iso_zerodiv/1,
-         user:eval_is_lax_bad/1],
+         user:eval_is_lax_bad/1,
+         user:lt_iso_unbound/1,
+         user:lt_iso_bad/0,
+         user:gt_iso_unbound/1,
+         user:eq_iso_bad/0,
+         user:lt_lax_bad/0,
+         user:gt_lax_bad/0,
+         user:succ_forward/1,
+         user:succ_reverse/1,
+         user:succ_iso_neg/0,
+         user:succ_iso_zero/0,
+         user:succ_iso_unbound/0,
+         user:succ_lax_bad/0],
         [no_kernels(true),
          module_name('uw_fs_iso_repro')],
         Dir),
@@ -221,6 +346,20 @@ let main _argv =
     assertTrue \"catch(is_iso(X, foo), error(type_error(evaluable, _), _), _)\" (runPredicate \"fs_iso_is_iso_type_err/0\")
     assertTrue \"catch(is_iso(X, 1/0), error(evaluation_error(zero_divisor), _), _)\" (runPredicate \"fs_iso_is_iso_zero_div/0\")
     assertTrue \"\\\\+ is_lax(X, foo)\"                                    (runPredicate \"fs_iso_is_lax_silent/0\")
+    // Comparison ISO/lax variants
+    assertTrue \"catch(<_iso(X, 3), error(instantiation_error, _), _)\"   (runPredicate \"fs_iso_lt_iso_inst/0\")
+    assertTrue \"catch(<_iso(foo, 3), error(type_error(evaluable, _), _), _)\" (runPredicate \"fs_iso_lt_iso_type/0\")
+    assertTrue \"catch(>_iso(X, 3), error(instantiation_error, _), _)\"   (runPredicate \"fs_iso_gt_iso_inst/0\")
+    assertTrue \"catch(=:=_iso(foo, 3), error(type_error(evaluable, _), _), _)\" (runPredicate \"fs_iso_eq_iso_type/0\")
+    assertTrue \"\\\\+ <_lax(foo, 3)\"                                     (runPredicate \"fs_iso_lt_lax_silent/0\")
+    assertTrue \"\\\\+ >_lax(foo, bar)\"                                   (runPredicate \"fs_iso_gt_lax_silent/0\")
+    // succ/2 + variants
+    assertTrue \"succ(2, 3)\"                                              (runPredicate \"fs_iso_succ_forward/0\")
+    assertTrue \"succ(4, 5)\"                                              (runPredicate \"fs_iso_succ_reverse/0\")
+    assertTrue \"catch(succ_iso(_,_), error(instantiation_error,_), _)\"  (runPredicate \"fs_iso_succ_iso_both_unbound/0\")
+    assertTrue \"catch(succ_iso(-1,_), error(type_error(not_less_than_zero,_),_), _)\" (runPredicate \"fs_iso_succ_iso_x_negative/0\")
+    assertTrue \"catch(succ_iso(_,0), error(domain_error(not_less_than_zero,_),_), _)\" (runPredicate \"fs_iso_succ_iso_y_zero/0\")
+    assertTrue \"\\\\+ succ_lax(-3, _)\"                                    (runPredicate \"fs_iso_succ_lax_silent/0\")
 
     printfn \"RESULT %d/%d\" passes (passes + fails)
     if fails > 0 then 1 else 0

--- a/tests/test_wam_fsharp_iso_unit.pl
+++ b/tests/test_wam_fsharp_iso_unit.pl
@@ -103,6 +103,32 @@ test(iso_errors_text_rewrite_explicit_iso_survives) :-
     % Lax mode shouldn''t touch the explicit iso form either.
     assertion(sub_string(LaxWam, _, _, _, "builtin_call is_iso/2 2")).
 
+test(iso_errors_text_rewrite_comparison_iso) :-
+    % Arithmetic-compare sweep: each of the 6 ops rewrites to its
+    % _iso variant under iso_config(true, []).
+    Wam0 = 'cmp/0:\n  builtin_call </2 2\n  builtin_call >/2 2\n  builtin_call >=/2 2\n  builtin_call =</2 2\n  builtin_call =:=/2 2\n  builtin_call =\\=/2 2',
+    iso_errors_rewrite_text(iso_config(true, []), cmp/0, Wam0, IsoWam),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call <_iso/2 2")),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call >_iso/2 2")),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call >=_iso/2 2")),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call =<_iso/2 2")),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call =:=_iso/2 2")),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call =\\=_iso/2 2")).
+
+test(iso_errors_text_rewrite_comparison_lax) :-
+    Wam0 = 'cmp/0:\n  builtin_call </2 2\n  builtin_call >/2 2\n  builtin_call =:=/2 2',
+    iso_errors_rewrite_text(iso_config(false, []), cmp/0, Wam0, LaxWam),
+    assertion(sub_string(LaxWam, _, _, _, "builtin_call <_lax/2 2")),
+    assertion(sub_string(LaxWam, _, _, _, "builtin_call >_lax/2 2")),
+    assertion(sub_string(LaxWam, _, _, _, "builtin_call =:=_lax/2 2")).
+
+test(iso_errors_text_rewrite_succ) :-
+    Wam0 = 'succ_demo/0:\n  builtin_call succ/2 2',
+    iso_errors_rewrite_text(iso_config(true, []), succ_demo/0, Wam0, IsoWam),
+    assertion(sub_string(IsoWam, _, _, _, "builtin_call succ_iso/2 2")),
+    iso_errors_rewrite_text(iso_config(false, []), succ_demo/0, Wam0, LaxWam),
+    assertion(sub_string(LaxWam, _, _, _, "builtin_call succ_lax/2 2")).
+
 test(iso_errors_text_rewrite_per_pred_override) :-
     % Default ISO, override demo/0 to lax.
     Config = iso_config(true, [demo/0-false]),


### PR DESCRIPTION
## Summary

Follow-up to #2452 (ISO substrate). Completes the F# ISO key-table coverage to match the C++/Elixir/Python references in `WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`.

## Arithmetic-compare sweep (12 new builtins)

- `<_iso/2`, `>_iso/2`, `>=_iso/2`, `=<_iso/2`, `=:=_iso/2`, `=\=_iso/2` throw `instantiation_error` when either side has any unbound subterm and `type_error(evaluable, Name/Arity)` on otherwise-failed eval
- `<_lax/2` ... `=\=_lax/2` share the existing `op/2` lax bodies via OR-pattern dispatch so user code can write the explicit form to bypass an `iso_errors_default(true)` rewrite
- `iso_errors_default_to_iso/2` and `iso_errors_default_to_lax/2` tables extended for all six ops

## succ/2 family (3 new builtins, F# didn't have succ before)

- `succ/2` alias of `succ_lax/2` — bidirectional successor (X bound non-negative → Y = X+1; Y bound positive → X = Y-1) with silent fail on bad input
- `succ_iso/2` raises per Aït-Kaci spec §6:
  - both unbound → `error(instantiation_error, _)`
  - X not integer → `error(type_error(integer, X), _)`
  - Y not integer → `error(type_error(integer, Y), _)`
  - X < 0 → `error(type_error(not_less_than_zero, X), _)`
  - Y ≤ 0 → `error(domain_error(not_less_than_zero, Y), _)`

## Helper extraction in `fsharp_wam_bindings.pl`

- `hasUnboundDeep` / `arithCulprit` factored out of the `is_iso/2` branch so the six new ISO comparison arms can share them
- `isIsoMetaBuiltin` / `isoMetaBuiltinArity` centralise the meta-builtin list that `Call`/`Execute` routes through `BuiltinCall` (replaces the growing when-clause chain)

## Docs

- `WAM_FSHARP_PARITY_AUDIT.md`: ISO/lax arithmetic compares and succ/2 family move from **Missing** to **Present**
- `WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md`: F# now matches Python's adoption surface
- `WAM_FSHARP_TARGET.md`: Control section updated; **Quick Start `mkState` gets the missing `WsCatchers = []`** field (regression from the substrate PR — users following the doc would have gotten a compile error)

## Test plan

- [x] `tests/test_wam_fsharp_target.pl` — 53/53 generator unit
- [x] `tests/test_wam_fsharp_iso_unit.pl` — **11/11** (was 8; +3 for compare/succ rewrite text)
- [x] `tests/core/test_wam_fsharp_iso_smoke.pl` — **19/19** dotnet E2E (was 7; +12 for ISO comparison errors, lax silent, succ bidirectional, succ_iso errors, succ_lax silent)
- [x] `tests/core/test_wam_fsharp_runtime_smoke.pl` — 19/19
- [x] `tests/core/test_wam_fsharp_parser_smoke.pl` — 42/42
- [x] `tests/core/test_wam_fsharp_lowered_smoke.pl` — 19/19
- [x] `tests/core/test_wam_fsharp_lowered_parser_smoke.pl` — 8/8

## Remaining ISO follow-up

The audit doc now lists only one remaining item:

- Extract `iso_errors_*` into `src/unifyweaver/core/iso_errors.pl` (refactor across Python, Elixir, F# — separate PR)

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_