### PR TITLE
refactor(iso-errors): extract shared helpers into core/iso_errors.pl

### DIFF
--- a/docs/design/WAM_FSHARP_PARITY_AUDIT.md
+++ b/docs/design/WAM_FSHARP_PARITY_AUDIT.md
@@ -87,11 +87,14 @@ F# runtime-parser side).
 
 Remaining cross-cutting work:
 
-- **Shared helper extraction**: F# is the third adopter of the
-  copy-pasted `iso_errors_*` block (after Elixir and Python).
-  Extracting these helpers into `src/unifyweaver/core/iso_errors.pl`
-  is appropriate next per
-  `WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` § "Remaining Work".
+- _None at this layer._  The shared helper extraction landed once F#
+  became the third adopter -- `src/unifyweaver/core/iso_errors.pl`
+  now hosts the config loader, mode resolver, multi-module warning,
+  item-level rewrite, and audit-walker primitives.  Python, Elixir,
+  and F# all `use_module` from there and only keep their key-table
+  assertions, `iso_errors_rewrite_text` parser, and target-specific
+  audit wrapper.  Shared-module tests live in
+  `tests/test_iso_errors.pl`.
 
 ## LMDB Fact-Source Readiness
 

--- a/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
+++ b/docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
@@ -125,7 +125,12 @@ reporting, but neither depends on the other.
 
 ## Remaining Work
 
-- Extract shared ISO config/audit helpers once a third target adopts the design.
+- Shared ISO config/audit helpers were extracted into
+  `src/unifyweaver/core/iso_errors.pl` once F# became the third adopter.
+  Python, Elixir, and F# all `use_module` from there now and only keep
+  the target-specific parts (key-table assertions, `iso_errors_rewrite_text`
+  variants, target audit wrapper).  C++ has its own implementation in C++
+  source and is intentionally separate.  Tests in `tests/test_iso_errors.pl`.
 - Decide which target should be the next adopter based on real `catch/3` /
   arithmetic-error users, not just target popularity.
 - Keep C++ and Elixir docs in sync with the shipped state; older parity plans

--- a/src/unifyweaver/core/iso_errors.pl
+++ b/src/unifyweaver/core/iso_errors.pl
@@ -1,0 +1,290 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (@s243a)
+%
+% iso_errors.pl - Shared ISO error config, mode resolution, and audit
+% helpers for WAM targets.
+%
+% Cross-target ISO contract:
+%   docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md
+%   docs/design/WAM_CPP_ISO_ERRORS_SPECIFICATION.md
+%
+% Background
+% ----------
+% C++, Elixir, Python, and F# all adopted near-identical Prolog
+% plumbing for ISO error config loading, per-predicate mode
+% resolution, and audit. Each target was carrying its own ~340-line
+% copy of the same code. This module extracts the parts that are
+% byte-identical (mod whitespace and comments) so target files can
+% import them.
+%
+% What lives here vs. per-target
+% ------------------------------
+% Shared (this module):
+%   - Config schema parsing: iso_errors_load_config/2,
+%     iso_errors_extract_terms/5, iso_errors_read_terms/2.
+%   - Option resolution: iso_errors_resolve_options/2 and its
+%     iso_errors_inline_* / iso_errors_merge_overrides helpers.
+%   - PI matching: iso_errors_valid_pi/1, iso_errors_pi_matches/2,
+%     iso_errors_shadowed/2.
+%   - Mode resolution: iso_errors_mode_for/3.
+%   - Multi-module warning: iso_errors_warn_multi_module/2,
+%     iso_errors_check_override_scope/2, iso_errors_pi_module/4.
+%   - Item-level rewrite: iso_errors_rewrite/4, iso_errors_rewrite_item/3.
+%   - Audit walker helpers shared across targets:
+%     iso_errors_audit_normalise_pi/2, iso_errors_audit_walk/5,
+%     iso_errors_audit_classify/5, iso_errors_resolve_default/3,
+%     iso_errors_other_mode/2, iso_errors_key_has_suffix/2.
+%
+% Per-target (stays in wam_<target>_target.pl):
+%   - iso_errors_default_to_iso/2 and iso_errors_default_to_lax/2
+%     facts -- these are declared :- multifile here so each target
+%     adds its own table entries.  A target should NOT add an entry
+%     before its runtime has a matching builtin branch; otherwise the
+%     rewrite silently routes calls to dead keys.
+%   - iso_errors_rewrite_text/4 and friends: Python/F# and Elixir use
+%     slightly different WAM-text parsing strategies; reconciliation
+%     is a separate concern from extracting the shared parts.
+%   - The audit predicate itself (wam_<target>_iso_audit/3) and its
+%     pretty-printer -- they consume the shared walker helpers.
+
+:- module(iso_errors, [
+    iso_errors_resolve_options/2,        % +Options, -Config
+    iso_errors_load_config/2,            % +File, -Config
+    iso_errors_mode_for/3,               % +Config, +PI, -Mode
+    iso_errors_warn_multi_module/2,      % +Config, +Predicates
+    iso_errors_rewrite/4,                % +Config, +PI, +Items0, -Items
+    iso_errors_valid_pi/1,               % +PI
+    iso_errors_pi_matches/2,             % +PatternPI, +TargetPI
+    iso_errors_audit_normalise_pi/2,     % +PI, -NormPI
+    iso_errors_audit_walk/5,             % +Items, +PC, +Mode, +Acc, -Sites
+    iso_errors_resolve_default/3,        % +Key, +Mode, -ResolvedKey
+    iso_errors_other_mode/2,             % +Mode, -OtherMode
+    iso_errors_key_has_suffix/2,         % +Key, +Suffix
+    % Multifile tables -- each target asserts its own entries.
+    iso_errors_default_to_iso/2,         % +DefaultKey, -IsoKey
+    iso_errors_default_to_lax/2          % +DefaultKey, -LaxKey
+]).
+
+:- use_module(library(lists)).
+:- use_module(library(option)).
+
+% Each WAM target asserts its own entries; this module ships none.
+% Targets typically include is/2, the six arithmetic comparisons, and
+% succ/2.  Python additionally maps read_term_from_atom/2,3, read/1,2,
+% and read_term/1 because it has the runtime-parser substrate; F# and
+% Elixir do not (yet).
+:- multifile iso_errors_default_to_iso/2.
+:- multifile iso_errors_default_to_lax/2.
+:- dynamic   iso_errors_default_to_iso/2.
+:- dynamic   iso_errors_default_to_lax/2.
+
+% ============================================================================
+% Option resolution
+% ============================================================================
+
+%% iso_errors_resolve_options(+Options, -Config)
+%  Merges optional file config with inline options into
+%  iso_config(Default, Overrides).  Inline options override file
+%  entries for the same PI.
+iso_errors_resolve_options(Options, iso_config(Default, Overrides)) :-
+    (   option(iso_errors_config(File), Options)
+    ->  iso_errors_load_config(File, iso_config(FileDefault, FileOv))
+    ;   FileDefault = false, FileOv = []
+    ),
+    iso_errors_inline_default(Options, FileDefault, Default),
+    iso_errors_inline_overrides(Options, InlineOv),
+    iso_errors_merge_overrides(FileOv, InlineOv, Overrides).
+
+iso_errors_inline_default(Options, FileDefault, Default) :-
+    (   member(iso_errors(M), Options),
+        (M == true ; M == false)
+    ->  Default = M
+    ;   Default = FileDefault
+    ).
+
+iso_errors_inline_overrides(Options, InlineOv) :-
+    findall(PI-Mode,
+        ( member(iso_errors(PI, Mode), Options),
+          (Mode == true ; Mode == false),
+          iso_errors_valid_pi(PI)
+        ),
+        InlineOv).
+
+iso_errors_valid_pi(Name/Arity) :- atom(Name), integer(Arity), Arity >= 0, !.
+iso_errors_valid_pi(Module:Name/Arity) :-
+    atom(Module), atom(Name), integer(Arity), Arity >= 0.
+
+iso_errors_merge_overrides(FileOv, InlineOv, Merged) :-
+    exclude(iso_errors_shadowed(InlineOv), FileOv, Kept),
+    append(Kept, InlineOv, Merged).
+
+iso_errors_shadowed(InlineOv, PI-_) :-
+    member(InlinePI-_, InlineOv),
+    iso_errors_pi_matches(InlinePI, PI), !.
+
+% Bare Name/Arity matches Module:Name/Arity in any module, and vice
+% versa.  Same-shape PIs match by unification.
+iso_errors_pi_matches(PI, PI) :- !.
+iso_errors_pi_matches(Name/Arity, _:Name/Arity) :-
+    atom(Name), integer(Arity), !.
+iso_errors_pi_matches(_:Name/Arity, Name/Arity) :-
+    atom(Name), integer(Arity), !.
+
+% ============================================================================
+% Config-file loader
+% ============================================================================
+
+%% iso_errors_load_config(+File, -Config)
+%  Reads iso_errors_default/1 and iso_errors_override/2 facts.
+%  Unknown facts and I/O failures are ignored, yielding
+%  iso_config(false, []).
+iso_errors_load_config(File, iso_config(Default, Overrides)) :-
+    catch(
+        setup_call_cleanup(
+            open(File, read, Stream),
+            iso_errors_read_terms(Stream, RawTerms),
+            close(Stream)),
+        _,
+        RawTerms = []),
+    iso_errors_extract_terms(RawTerms, false, [], Default, RevOv),
+    reverse(RevOv, Overrides).
+
+iso_errors_read_terms(Stream, Terms) :-
+    read_term(Stream, T, []),
+    (   T == end_of_file
+    ->  Terms = []
+    ;   Terms = [T|Rest],
+        iso_errors_read_terms(Stream, Rest)
+    ).
+
+iso_errors_extract_terms([], D, Ov, D, Ov).
+iso_errors_extract_terms([T|Rest], D0, Ov0, D, Ov) :-
+    (   T = iso_errors_default(NewD), (NewD == true ; NewD == false)
+    ->  iso_errors_extract_terms(Rest, NewD, Ov0, D, Ov)
+    ;   T = iso_errors_override(PI, Mode),
+        (Mode == true ; Mode == false),
+        iso_errors_valid_pi(PI)
+    ->  iso_errors_extract_terms(Rest, D0, [PI-Mode|Ov0], D, Ov)
+    ;   iso_errors_extract_terms(Rest, D0, Ov0, D, Ov)
+    ).
+
+% ============================================================================
+% Mode resolution
+% ============================================================================
+
+%% iso_errors_mode_for(+Config, +PI, -Mode)
+iso_errors_mode_for(iso_config(Default, Overrides), PI, Mode) :-
+    (   member(OvPI-OvMode, Overrides),
+        iso_errors_pi_matches(OvPI, PI)
+    ->  Mode = OvMode
+    ;   Mode = Default
+    ).
+
+% ============================================================================
+% Multi-module bare-PI warning
+% ============================================================================
+
+%% iso_errors_warn_multi_module(+Config, +Predicates)
+%  Warns when a bare override matches predicates from multiple modules.
+iso_errors_warn_multi_module(iso_config(_, Overrides), Predicates) :-
+    forall(member(OvPI-_, Overrides),
+           iso_errors_check_override_scope(OvPI, Predicates)).
+
+iso_errors_check_override_scope(Name/Arity, Predicates) :-
+    atom(Name), integer(Arity), !,
+    findall(M, ( member(P, Predicates),
+                 iso_errors_pi_module(P, Name, Arity, M)
+               ), Modules),
+    list_to_set(Modules, Unique),
+    (   Unique = [_, _ | _]
+    ->  length(Unique, N),
+        format(user_error,
+               'Warning: iso_errors_override(~w/~w, _) matches ~w predicates~n         in different modules (~w).~n         Qualify with `mod:~w/~w` for module-scoped overrides.~n',
+               [Name, Arity, N, Unique, Name, Arity])
+    ;   true
+    ).
+iso_errors_check_override_scope(_, _).
+
+iso_errors_pi_module(Module:Name/Arity, Name, Arity, Module) :- !.
+iso_errors_pi_module(Name/Arity, Name, Arity, user).
+iso_errors_pi_module(Pred/Arity-_, Name, Arity, user) :-
+    atom(Pred), Pred = Name, !.
+
+% ============================================================================
+% Item-level rewrite
+% ============================================================================
+
+%% iso_errors_rewrite(+Config, +PI, +Items0, -Items)
+%  Item-level rewrite API.  Some targets prefer text-level rewrite
+%  (Python/F#/Elixir) and keep their own iso_errors_rewrite_text/4
+%  alongside this; both are equivalent in semantics.
+iso_errors_rewrite(Config, PI, Items0, Items) :-
+    iso_errors_mode_for(Config, PI, Mode),
+    maplist(iso_errors_rewrite_item(Mode), Items0, Items).
+
+iso_errors_rewrite_item(true, builtin_call(Key, N), builtin_call(IsoKey, N)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(true, put_structure(Key, Reg), put_structure(IsoKey, Reg)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(true, call(Key, N), call(IsoKey, N)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(true, execute(Key), execute(IsoKey)) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_rewrite_item(false, builtin_call(Key, N), builtin_call(LaxKey, N)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(false, put_structure(Key, Reg), put_structure(LaxKey, Reg)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(false, call(Key, N), call(LaxKey, N)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(false, execute(Key), execute(LaxKey)) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_rewrite_item(_, Item, Item).
+
+% ============================================================================
+% Audit walker helpers
+% ============================================================================
+%
+% These helpers do the per-call-site bookkeeping shared by every
+% target's wam_<target>_iso_audit/3.  The target predicate is
+% responsible for compiling the predicate to WAM text, parsing the
+% lines into items the walker accepts, and rendering the result;
+% the walking + classification + flip-detection happens here.
+
+iso_errors_audit_normalise_pi(Pred/Arity-_, Pred/Arity) :- !.
+iso_errors_audit_normalise_pi(Module:Pred/Arity, Module:Pred/Arity) :- !.
+iso_errors_audit_normalise_pi(PI, PI).
+
+iso_errors_audit_walk([], _, _, Acc, Acc).
+iso_errors_audit_walk([label|Rest], PC, Mode, Acc, Out) :- !,
+    iso_errors_audit_walk(Rest, PC, Mode, Acc, Out).
+iso_errors_audit_walk([builtin_call(Key, _)|Rest], PC, Mode, Acc, Out) :- !,
+    iso_errors_audit_classify(Key, Mode, Source, Resolved, Flip),
+    PC1 is PC + 1,
+    iso_errors_audit_walk(Rest, PC1, Mode, [site(PC, Key, Resolved, Source, Flip)|Acc], Out).
+iso_errors_audit_walk([_|Rest], PC, Mode, Acc, Out) :-
+    PC1 is PC + 1,
+    iso_errors_audit_walk(Rest, PC1, Mode, Acc, Out).
+
+iso_errors_audit_classify(Key, _Mode, explicit_iso, Key, false) :-
+    iso_errors_key_has_suffix(Key, "_iso"), !.
+iso_errors_audit_classify(Key, _Mode, explicit_lax, Key, false) :-
+    iso_errors_key_has_suffix(Key, "_lax"), !.
+iso_errors_audit_classify(Key, Mode, default, Resolved, Flip) :-
+    iso_errors_resolve_default(Key, Mode, Resolved),
+    iso_errors_other_mode(Mode, OtherMode),
+    iso_errors_resolve_default(Key, OtherMode, OtherResolved),
+    ( Resolved == OtherResolved -> Flip = false ; Flip = true ).
+
+iso_errors_resolve_default(Key, true, IsoKey) :-
+    iso_errors_default_to_iso(Key, IsoKey), !.
+iso_errors_resolve_default(Key, false, LaxKey) :-
+    iso_errors_default_to_lax(Key, LaxKey), !.
+iso_errors_resolve_default(Key, _, Key).
+
+iso_errors_other_mode(true, false).
+iso_errors_other_mode(false, true).
+
+iso_errors_key_has_suffix(Key, Suffix) :-
+    ( atom(Key) -> atom_string(Key, KS) ; KS = Key ),
+    split_string(KS, "/", "", [Name | _]),
+    string_concat(_, Suffix, Name).

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -39,6 +39,15 @@
 :- use_module('../core/template_system').
 :- use_module('../bindings/elixir_wam_bindings').
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../core/iso_errors',
+              [ iso_errors_resolve_options/2,
+                iso_errors_load_config/2,
+                iso_errors_mode_for/3,
+                iso_errors_warn_multi_module/2,
+                iso_errors_rewrite/4,
+                iso_errors_audit_normalise_pi/2,
+                iso_errors_audit_walk/5
+              ]).
 :- use_module('../targets/wam_elixir_utils', [camel_case/2]).
 :- use_module('../core/recursive_kernel_detection',
               [detect_recursive_kernel/4, kernel_config/2]).
@@ -6037,206 +6046,28 @@ end', [CasesStr]).
 % PR #3 ships: API + audit predicate + runtime helpers, all as
 % standalone exports. Behaviour is identical to pre-PR-#3.
 
-%% iso_errors_default_to_iso(+DefaultKey, -IsoKey)
-%  Maps a default builtin key (e.g. "is/2") to its ISO flavour
-%  ("is_iso/2"). Empty in this PR. Declared `dynamic` so calls
-%  with no clauses simply fail (rather than throwing
-%  existence_error) and so PR #4 can populate it either as
-%  asserted facts or as ordinary static clauses below this line.
-:- dynamic iso_errors_default_to_iso/2.
-:- dynamic iso_errors_default_to_lax/2.
-:- discontiguous iso_errors_default_to_iso/2.
-:- discontiguous iso_errors_default_to_lax/2.
+%% Multifile dispatch tables -- assert into the shared iso_errors
+%% module so the shared mode/audit helpers see our entries.  Each
+%% (DefaultKey -> IsoKey or LaxKey) entry needs a matching runtime
+%% builtin branch; adding an entry without a runtime branch silently
+%% rewrites default calls to dead keys.
+iso_errors:iso_errors_default_to_iso("is/2", "is_iso/2").
+iso_errors:iso_errors_default_to_lax("is/2", "is_lax/2").
 
-% PR #4: is/2 — first ISO-aware builtin. ISO-mode predicates get
-% their default is/2 calls rewritten to is_iso/2 (which throws on
-% bad RHS); lax-mode predicates rewrite to is_lax/2 (a no-op rename
-% since is/2 and is_lax/2 share the runtime body). Explicit
-% is_iso/2 or is_lax/2 in user source survives the rewrite — see
-% iso_errors_rewrite_item/3.
-iso_errors_default_to_iso("is/2", "is_iso/2").
-iso_errors_default_to_lax("is/2", "is_lax/2").
-
-% PR #5: arithmetic comparisons — six ops, each with iso/lax
-% variants. ISO body classifies args + throws via the same
-% machinery is_iso/2 uses; lax body shares with default.
-iso_errors_default_to_iso(">/2",   ">_iso/2").
-iso_errors_default_to_lax(">/2",   ">_lax/2").
-iso_errors_default_to_iso("</2",   "<_iso/2").
-iso_errors_default_to_lax("</2",   "<_lax/2").
-iso_errors_default_to_iso(">=/2",  ">=_iso/2").
-iso_errors_default_to_lax(">=/2",  ">=_lax/2").
-iso_errors_default_to_iso("=</2",  "=<_iso/2").
-iso_errors_default_to_lax("=</2",  "=<_lax/2").
-iso_errors_default_to_iso("=:=/2", "=:=_iso/2").
-iso_errors_default_to_lax("=:=/2", "=:=_lax/2").
-iso_errors_default_to_iso("=\\=/2", "=\\=_iso/2").
-iso_errors_default_to_lax("=\\=/2", "=\\=_lax/2").
-% PR #5: succ/2 — bidirectional successor with proper ISO error throws.
-iso_errors_default_to_iso("succ/2", "succ_iso/2").
-iso_errors_default_to_lax("succ/2", "succ_lax/2").
-
-%% iso_errors_resolve_options(+Options, -Config)
-%  Merges the (optional) file config with inline options into one
-%  iso_config(Default, Overrides) struct. Inline options override
-%  file entries for the same PI.
-iso_errors_resolve_options(Options, iso_config(Default, Overrides)) :-
-    (   option(iso_errors_config(File), Options)
-    ->  iso_errors_load_config(File, iso_config(FileDefault, FileOv))
-    ;   FileDefault = false, FileOv = []
-    ),
-    iso_errors_inline_default(Options, FileDefault, Default),
-    iso_errors_inline_overrides(Options, InlineOv),
-    iso_errors_merge_overrides(FileOv, InlineOv, Overrides).
-
-iso_errors_inline_default(Options, FileDefault, Default) :-
-    (   member(iso_errors(M), Options),
-        (M == true ; M == false)
-    ->  Default = M
-    ;   Default = FileDefault
-    ).
-
-iso_errors_inline_overrides(Options, InlineOv) :-
-    findall(PI-Mode,
-            ( member(iso_errors(PI, Mode), Options),
-              (Mode == true ; Mode == false),
-              iso_errors_valid_pi(PI)
-            ),
-            InlineOv).
-
-% Accepts both bare Name/Arity and Module:Name/Arity.
-iso_errors_valid_pi(Name/Arity) :- atom(Name), integer(Arity), Arity >= 0, !.
-iso_errors_valid_pi(Module:Name/Arity) :-
-    atom(Module), atom(Name), integer(Arity), Arity >= 0.
-
-iso_errors_merge_overrides(FileOv, InlineOv, Merged) :-
-    exclude(iso_errors_shadowed(InlineOv), FileOv, Kept),
-    append(Kept, InlineOv, Merged).
-
-iso_errors_shadowed(InlineOv, PI-_) :-
-    member(InlinePI-_, InlineOv),
-    iso_errors_pi_matches(InlinePI, PI), !.
-
-% PI matching: bare Name/Arity matches Module:Name/Arity in any
-% module; Module:Name/Arity matches only its own module.
-iso_errors_pi_matches(PI, PI) :- !.
-iso_errors_pi_matches(Name/Arity, _:Name/Arity) :-
-    atom(Name), integer(Arity), !.
-iso_errors_pi_matches(_:Name/Arity, Name/Arity) :-
-    atom(Name), integer(Arity), !.
-
-%% iso_errors_load_config(+File, -Config)
-%  Reads a Prolog facts file and extracts iso_errors_default/1 +
-%  iso_errors_override/2 terms. Unrecognised terms are silently
-%  ignored. Returns iso_config(false, []) on I/O error.
-iso_errors_load_config(File, iso_config(Default, Overrides)) :-
-    catch(
-        setup_call_cleanup(
-            open(File, read, Stream),
-            iso_errors_read_terms(Stream, RawTerms),
-            close(Stream)),
-        _,
-        RawTerms = []),
-    iso_errors_extract_terms(RawTerms, false, [], Default, RevOv),
-    reverse(RevOv, Overrides).
-
-iso_errors_read_terms(Stream, Terms) :-
-    read_term(Stream, T, []),
-    ( T == end_of_file
-    -> Terms = []
-    ; Terms = [T|Rest],
-      iso_errors_read_terms(Stream, Rest)
-    ).
-
-iso_errors_extract_terms([], D, Ov, D, Ov).
-iso_errors_extract_terms([T|Rest], D0, Ov0, D, Ov) :-
-    (   T = iso_errors_default(NewD), (NewD == true ; NewD == false)
-    ->  iso_errors_extract_terms(Rest, NewD, Ov0, D, Ov)
-    ;   T = iso_errors_override(PI, Mode),
-        (Mode == true ; Mode == false),
-        iso_errors_valid_pi(PI)
-    ->  iso_errors_extract_terms(Rest, D0, [PI-Mode|Ov0], D, Ov)
-    ;   iso_errors_extract_terms(Rest, D0, Ov0, D, Ov)
-    ).
-
-%% iso_errors_mode_for(+Config, +PI, -Mode)
-%  Resolves a predicate's ISO mode. Bare Name/Arity in overrides
-%  matches Module:Name/Arity in any module and vice versa. Falls
-%  back to the config's default when no override matches.
-iso_errors_mode_for(iso_config(Default, Overrides), PI, Mode) :-
-    (   member(OvPI-OvMode, Overrides),
-        iso_errors_pi_matches(OvPI, PI)
-    ->  Mode = OvMode
-    ;   Mode = Default
-    ).
-
-%% iso_errors_warn_multi_module(+Config, +Predicates)
-%  Emits a user_error warning for each bare override that matches
-%  predicates from more than one module in the input list. Catches
-%  the safe_div/2-in-two-modules footgun (SPEC §1).
-iso_errors_warn_multi_module(iso_config(_, Overrides), Predicates) :-
-    forall(member(OvPI-_, Overrides),
-           iso_errors_check_override_scope(OvPI, Predicates)).
-
-iso_errors_check_override_scope(Name/Arity, Predicates) :-
-    atom(Name), integer(Arity), !,
-    findall(M, ( member(P, Predicates),
-                 iso_errors_pi_module(P, Name, Arity, M)
-               ), Modules),
-    list_to_set(Modules, Unique),
-    (   Unique = [_, _ | _]
-    ->  length(Unique, N),
-        format(user_error,
-               'Warning: iso_errors_override(~w/~w, _) matches ~w predicates~n         in different modules (~w).~n         Qualify with `mod:~w/~w` for module-scoped overrides.~n',
-               [Name, Arity, N, Unique, Name, Arity])
-    ;   true
-    ).
-iso_errors_check_override_scope(_, _).
-
-iso_errors_pi_module(Module:Name/Arity, Name, Arity, Module) :- !.
-iso_errors_pi_module(Name/Arity,         Name, Arity, user).
-% Predicates list arrives as Pred/Arity-WamCode pairs in this target;
-% extract the PI for module checking.
-iso_errors_pi_module(Pred/Arity-_, Name, Arity, user) :-
-    atom(Pred), Pred = Name, !.
-
-%% iso_errors_rewrite(+Config, +PI, +Items0, -Items)
-%  Rewrites the default-form builtin_call keys for one predicate.
-%  Explicit *_iso / *_lax keys pass through unchanged. With empty
-%  key tables (this PR), the rewrite is a no-op.
-%
-%  Item shape: matches the de-facto items vocabulary the WAM
-%  compiler emits (mirrors C++; see WAM_ITEMS_API_SPECIFICATION.md
-%  §2 for the canonical list). Targets that haven't migrated to the
-%  Items API yet can still call this on their own ad-hoc item form
-%  as long as the keyed shapes (builtin_call/2, put_structure/2,
-%  call/2, execute/1) match.
-iso_errors_rewrite(Config, PI, Items0, Items) :-
-    iso_errors_mode_for(Config, PI, Mode),
-    maplist(iso_errors_rewrite_item(Mode), Items0, Items).
-
-% Two surfaces to rewrite for an ISO-relevant builtin:
-% - builtin_call("is/2", _) — direct call form.
-% - put_structure("is/2", _) — data form when `is/2` appears inside
-%   a meta-goal (catch(Goal, ...) builds is(X, Expr) into A1).
-% Plus call/execute for completeness.
-iso_errors_rewrite_item(true, builtin_call(Key, N), builtin_call(IsoKey, N)) :-
-    iso_errors_default_to_iso(Key, IsoKey), !.
-iso_errors_rewrite_item(true, put_structure(Key, Reg), put_structure(IsoKey, Reg)) :-
-    iso_errors_default_to_iso(Key, IsoKey), !.
-iso_errors_rewrite_item(true, call(Key, N), call(IsoKey, N)) :-
-    iso_errors_default_to_iso(Key, IsoKey), !.
-iso_errors_rewrite_item(true, execute(Key), execute(IsoKey)) :-
-    iso_errors_default_to_iso(Key, IsoKey), !.
-iso_errors_rewrite_item(false, builtin_call(Key, N), builtin_call(LaxKey, N)) :-
-    iso_errors_default_to_lax(Key, LaxKey), !.
-iso_errors_rewrite_item(false, put_structure(Key, Reg), put_structure(LaxKey, Reg)) :-
-    iso_errors_default_to_lax(Key, LaxKey), !.
-iso_errors_rewrite_item(false, call(Key, N), call(LaxKey, N)) :-
-    iso_errors_default_to_lax(Key, LaxKey), !.
-iso_errors_rewrite_item(false, execute(Key), execute(LaxKey)) :-
-    iso_errors_default_to_lax(Key, LaxKey), !.
-iso_errors_rewrite_item(_, Item, Item).
+iso_errors:iso_errors_default_to_iso(">/2",   ">_iso/2").
+iso_errors:iso_errors_default_to_lax(">/2",   ">_lax/2").
+iso_errors:iso_errors_default_to_iso("</2",   "<_iso/2").
+iso_errors:iso_errors_default_to_lax("</2",   "<_lax/2").
+iso_errors:iso_errors_default_to_iso(">=/2",  ">=_iso/2").
+iso_errors:iso_errors_default_to_lax(">=/2",  ">=_lax/2").
+iso_errors:iso_errors_default_to_iso("=</2",  "=<_iso/2").
+iso_errors:iso_errors_default_to_lax("=</2",  "=<_lax/2").
+iso_errors:iso_errors_default_to_iso("=:=/2", "=:=_iso/2").
+iso_errors:iso_errors_default_to_lax("=:=/2", "=:=_lax/2").
+iso_errors:iso_errors_default_to_iso("=\\=/2", "=\\=_iso/2").
+iso_errors:iso_errors_default_to_lax("=\\=/2", "=\\=_lax/2").
+iso_errors:iso_errors_default_to_iso("succ/2", "succ_iso/2").
+iso_errors:iso_errors_default_to_lax("succ/2", "succ_lax/2").
 
 %% wam_elixir_iso_audit(+Predicates, +Options, -Audit)
 %  Read-only inspection of how each predicate's builtin_call sites
@@ -6257,9 +6088,6 @@ wam_elixir_iso_audit(Predicates, Options, Audit) :-
         iso_errors_audit_predicate(PI, Mode, Sites)
     ), Audit).
 
-iso_errors_audit_normalise_pi(Pred/Arity-_, Pred/Arity) :- !.
-iso_errors_audit_normalise_pi(PI, PI).
-
 iso_errors_audit_predicate(PI, Mode, Sites) :-
     (   catch(
             ( wam_target:compile_predicate_to_wam(PI, [], WamText),
@@ -6274,6 +6102,9 @@ iso_errors_audit_predicate(PI, Mode, Sites) :-
 % Light-weight WAM-text parser for the audit. Only recognises the
 % builtin_call shape that the audit cares about — everything else
 % becomes an opaque `other` item that the walker advances past.
+% Elixir-specific: the audit_classify_line has a 3-element pattern
+% (the third slot is the arity string).  The shared audit walker
+% normalises this away.
 iso_errors_audit_parse_lines(WamText, Items) :-
     atom_string(WamText, S),
     split_string(S, "\n", "", Lines),
@@ -6295,46 +6126,6 @@ iso_errors_audit_classify_line(["builtin_call", KeyComma, _ArityStr], Item) :- !
 iso_errors_audit_classify_line(["builtin_call", Key, _ArityStr], Item) :- !,
     Item = builtin_call(Key, 0).
 iso_errors_audit_classify_line(_, other).
-
-iso_errors_audit_walk([], _, _, Acc, Acc).
-iso_errors_audit_walk([label|Rest], PC, Mode, Acc, Out) :- !,
-    iso_errors_audit_walk(Rest, PC, Mode, Acc, Out).
-iso_errors_audit_walk([builtin_call(Key, _)|Rest], PC, Mode, Acc, Out) :- !,
-    iso_errors_audit_classify(Key, Mode, Source, Resolved, Flip),
-    Site = site(PC, Key, Resolved, Source, Flip),
-    PC1 is PC + 1,
-    iso_errors_audit_walk(Rest, PC1, Mode, [Site|Acc], Out).
-iso_errors_audit_walk([_|Rest], PC, Mode, Acc, Out) :-
-    PC1 is PC + 1,
-    iso_errors_audit_walk(Rest, PC1, Mode, Acc, Out).
-
-% Classify a builtin_call key. Explicit *_iso/N or *_lax/N suffix
-% always wins; otherwise it's a default site whose resolution
-% depends on Mode and the (currently empty) swap tables.
-iso_errors_audit_classify(Key, _Mode, explicit_iso, Key, false) :-
-    iso_errors_key_has_suffix(Key, "_iso"), !.
-iso_errors_audit_classify(Key, _Mode, explicit_lax, Key, false) :-
-    iso_errors_key_has_suffix(Key, "_lax"), !.
-iso_errors_audit_classify(Key, Mode, default, Resolved, Flip) :-
-    iso_errors_resolve_default(Key, Mode, Resolved),
-    iso_errors_other_mode(Mode, OtherMode),
-    iso_errors_resolve_default(Key, OtherMode, OtherResolved),
-    ( Resolved == OtherResolved -> Flip = false ; Flip = true ).
-
-iso_errors_resolve_default(Key, true, IsoKey) :-
-    iso_errors_default_to_iso(Key, IsoKey), !.
-iso_errors_resolve_default(Key, false, LaxKey) :-
-    iso_errors_default_to_lax(Key, LaxKey), !.
-iso_errors_resolve_default(Key, _, Key).
-
-iso_errors_other_mode(true,  false).
-iso_errors_other_mode(false, true).
-
-iso_errors_key_has_suffix(Key, Suffix) :-
-    ( atom(Key) -> atom_string(Key, KS) ; KS = Key ),
-    split_string(KS, "/", "", Parts),
-    Parts = [Name | _],
-    string_concat(_, Suffix, Name).
 
 %% iso_errors_rewrite_text(+Config, +PI, +WamText, -RewrittenText)
 %  Token-aware text-level rewrite of WAM text for one predicate.
@@ -6367,7 +6158,7 @@ iso_errors_rewrite_text(Config, PI, WamText, RewrittenText) :-
         atomic_list_concat(RewrittenLines, '\n', RewrittenText)
     ).
 
-iso_errors_has_lax_entries :- iso_errors_default_to_lax(_, _), !.
+iso_errors_has_lax_entries :- iso_errors:iso_errors_default_to_lax(_, _), !.
 
 % Rewrite one line. Token-split, classify head, look up key in the
 % mode-appropriate table, splice the new key back in. Lines we
@@ -6418,9 +6209,9 @@ iso_errors_rewrite_parts(_, _, _, _) :- fail.
 % itself when no entry exists (the common case while tables are
 % sparse).
 iso_errors_lookup(true, Key, NewKey) :-
-    iso_errors_default_to_iso(Key, NewKey), !.
+    iso_errors:iso_errors_default_to_iso(Key, NewKey), !.
 iso_errors_lookup(false, Key, NewKey) :-
-    iso_errors_default_to_lax(Key, NewKey), !.
+    iso_errors:iso_errors_default_to_lax(Key, NewKey), !.
 iso_errors_lookup(_, Key, Key).
 
 % Replace the FIRST occurrence of Key in Line with NewKey. Both are

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -73,6 +73,15 @@
 :- use_module('../core/template_system', [render_template/3]).
 :- use_module('../core/purity_certificate', [analyze_predicate_purity/2]).
 :- use_module('../bindings/fsharp_wam_bindings').
+:- use_module('../core/iso_errors',
+              [ iso_errors_resolve_options/2,
+                iso_errors_load_config/2,
+                iso_errors_mode_for/3,
+                iso_errors_warn_multi_module/2,
+                iso_errors_rewrite/4,
+                iso_errors_audit_normalise_pi/2,
+                iso_errors_audit_walk/5
+              ]).
 :- use_module('../core/prolog_term_parser').
 :- use_module('../core/cpp_runtime_parser_wrappers').
 :- use_module(wam_runtime_parser_capability, [
@@ -4405,180 +4414,39 @@ fsharp_predicate_clause(Name/Arity, Head, Body) :-
 % Shared contract: docs/design/WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md +
 %                   docs/design/WAM_CPP_ISO_ERRORS_SPECIFICATION.md
 %
-% This block is a copy of the Python/Elixir iso_errors_* implementation
-% (which themselves descend from the C++ reference shape).  The three
-% targets all carry near-identical Prolog plumbing today; a future
-% refactor may extract this into src/unifyweaver/core/iso_errors.pl once
-% a fourth adopter motivates the move (note in
-% WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md §"Remaining Work").
+% The reusable helpers (option resolution, mode lookup, config-file
+% loader, multi-module warning, item-level rewrite, audit walker)
+% live in src/unifyweaver/core/iso_errors.pl and are re-exported by
+% the use_module at the top of this file.  What stays here:
+%   - F# key tables (multifile facts asserted into iso_errors).
+%   - Text-level rewrite (Python/F# parse style; Elixir uses a
+%     slightly different parser that hasn''t been reconciled yet).
+%   - wam_fsharp_iso_audit/3 itself plus its parse-lines helpers.
 %
-% F# v1 ships only is/2 ↔ is_iso/2 / is_lax/2 in the key tables.  The
-% arithmetic-comparison sweep (>, <, >=, =<, =:=, =\=) and succ/2 are
-% follow-up PRs; adding them to the tables before the runtime branches
-% exist would silently rewrite default calls to dead keys.
+% Adding an entry to the key tables without a matching runtime
+% branch in step_function_fsharp silently rewrites default calls to
+% dead keys.  F# currently ships is/2, the six arithmetic-compare
+% ops, and succ/2.
 
-% Per-predicate ISO/lax dispatch tables.  Each (DefaultKey -> IsoKey
-% or LaxKey) entry needs a matching runtime branch in
-% step_function_fsharp -- adding to the table without the runtime
-% support silently drops calls.
-:- dynamic iso_errors_default_to_iso/2.
-:- dynamic iso_errors_default_to_lax/2.
+% Multifile dispatch tables -- assert into iso_errors so the shared
+% mode/audit helpers see our entries.
+iso_errors:iso_errors_default_to_iso("is/2", "is_iso/2").
+iso_errors:iso_errors_default_to_iso(">/2", ">_iso/2").
+iso_errors:iso_errors_default_to_iso("</2", "<_iso/2").
+iso_errors:iso_errors_default_to_iso(">=/2", ">=_iso/2").
+iso_errors:iso_errors_default_to_iso("=</2", "=<_iso/2").
+iso_errors:iso_errors_default_to_iso("=:=/2", "=:=_iso/2").
+iso_errors:iso_errors_default_to_iso("=\\=/2", "=\\=_iso/2").
+iso_errors:iso_errors_default_to_iso("succ/2", "succ_iso/2").
 
-iso_errors_default_to_iso("is/2", "is_iso/2").
-iso_errors_default_to_iso(">/2", ">_iso/2").
-iso_errors_default_to_iso("</2", "<_iso/2").
-iso_errors_default_to_iso(">=/2", ">=_iso/2").
-iso_errors_default_to_iso("=</2", "=<_iso/2").
-iso_errors_default_to_iso("=:=/2", "=:=_iso/2").
-iso_errors_default_to_iso("=\\=/2", "=\\=_iso/2").
-iso_errors_default_to_iso("succ/2", "succ_iso/2").
-
-iso_errors_default_to_lax("is/2", "is_lax/2").
-iso_errors_default_to_lax(">/2", ">_lax/2").
-iso_errors_default_to_lax("</2", "<_lax/2").
-iso_errors_default_to_lax(">=/2", ">=_lax/2").
-iso_errors_default_to_lax("=</2", "=<_lax/2").
-iso_errors_default_to_lax("=:=/2", "=:=_lax/2").
-iso_errors_default_to_lax("=\\=/2", "=\\=_lax/2").
-iso_errors_default_to_lax("succ/2", "succ_lax/2").
-
-%% iso_errors_resolve_options(+Options, -Config)
-%  Merges optional file config with inline options into iso_config(Default,
-%  Overrides).  Inline options override file entries for the same PI.
-iso_errors_resolve_options(Options, iso_config(Default, Overrides)) :-
-    (   option(iso_errors_config(File), Options)
-    ->  iso_errors_load_config(File, iso_config(FileDefault, FileOv))
-    ;   FileDefault = false, FileOv = []
-    ),
-    iso_errors_inline_default(Options, FileDefault, Default),
-    iso_errors_inline_overrides(Options, InlineOv),
-    iso_errors_merge_overrides(FileOv, InlineOv, Overrides).
-
-iso_errors_inline_default(Options, FileDefault, Default) :-
-    (   member(iso_errors(M), Options),
-        (M == true ; M == false)
-    ->  Default = M
-    ;   Default = FileDefault
-    ).
-
-iso_errors_inline_overrides(Options, InlineOv) :-
-    findall(PI-Mode,
-        ( member(iso_errors(PI, Mode), Options),
-          (Mode == true ; Mode == false),
-          iso_errors_valid_pi(PI)
-        ),
-        InlineOv).
-
-iso_errors_valid_pi(Name/Arity) :- atom(Name), integer(Arity), Arity >= 0, !.
-iso_errors_valid_pi(Module:Name/Arity) :-
-    atom(Module), atom(Name), integer(Arity), Arity >= 0.
-
-iso_errors_merge_overrides(FileOv, InlineOv, Merged) :-
-    exclude(iso_errors_shadowed(InlineOv), FileOv, Kept),
-    append(Kept, InlineOv, Merged).
-
-iso_errors_shadowed(InlineOv, PI-_) :-
-    member(InlinePI-_, InlineOv),
-    iso_errors_pi_matches(InlinePI, PI), !.
-
-iso_errors_pi_matches(PI, PI) :- !.
-iso_errors_pi_matches(Name/Arity, _:Name/Arity) :-
-    atom(Name), integer(Arity), !.
-iso_errors_pi_matches(_:Name/Arity, Name/Arity) :-
-    atom(Name), integer(Arity), !.
-
-%% iso_errors_load_config(+File, -Config)
-%  Reads iso_errors_default/1 and iso_errors_override/2 facts.  Unknown
-%  facts and I/O failures are ignored, yielding iso_config(false, []).
-iso_errors_load_config(File, iso_config(Default, Overrides)) :-
-    catch(
-        setup_call_cleanup(
-            open(File, read, Stream),
-            iso_errors_read_terms(Stream, RawTerms),
-            close(Stream)),
-        _,
-        RawTerms = []),
-    iso_errors_extract_terms(RawTerms, false, [], Default, RevOv),
-    reverse(RevOv, Overrides).
-
-iso_errors_read_terms(Stream, Terms) :-
-    read_term(Stream, T, []),
-    (   T == end_of_file
-    ->  Terms = []
-    ;   Terms = [T|Rest],
-        iso_errors_read_terms(Stream, Rest)
-    ).
-
-iso_errors_extract_terms([], D, Ov, D, Ov).
-iso_errors_extract_terms([T|Rest], D0, Ov0, D, Ov) :-
-    (   T = iso_errors_default(NewD), (NewD == true ; NewD == false)
-    ->  iso_errors_extract_terms(Rest, NewD, Ov0, D, Ov)
-    ;   T = iso_errors_override(PI, Mode),
-        (Mode == true ; Mode == false),
-        iso_errors_valid_pi(PI)
-    ->  iso_errors_extract_terms(Rest, D0, [PI-Mode|Ov0], D, Ov)
-    ;   iso_errors_extract_terms(Rest, D0, Ov0, D, Ov)
-    ).
-
-%% iso_errors_mode_for(+Config, +PI, -Mode)
-iso_errors_mode_for(iso_config(Default, Overrides), PI, Mode) :-
-    (   member(OvPI-OvMode, Overrides),
-        iso_errors_pi_matches(OvPI, PI)
-    ->  Mode = OvMode
-    ;   Mode = Default
-    ).
-
-%% iso_errors_warn_multi_module(+Config, +Predicates)
-%  Warns when a bare override matches predicates from multiple modules.
-iso_errors_warn_multi_module(iso_config(_, Overrides), Predicates) :-
-    forall(member(OvPI-_, Overrides),
-           iso_errors_check_override_scope(OvPI, Predicates)).
-
-iso_errors_check_override_scope(Name/Arity, Predicates) :-
-    atom(Name), integer(Arity), !,
-    findall(M, ( member(P, Predicates),
-                 iso_errors_pi_module(P, Name, Arity, M)
-               ), Modules),
-    list_to_set(Modules, Unique),
-    (   Unique = [_, _ | _]
-    ->  length(Unique, N),
-        format(user_error,
-               'Warning: iso_errors_override(~w/~w, _) matches ~w predicates~n         in different modules (~w).~n         Qualify with `mod:~w/~w` for module-scoped overrides.~n',
-               [Name, Arity, N, Unique, Name, Arity])
-    ;   true
-    ).
-iso_errors_check_override_scope(_, _).
-
-iso_errors_pi_module(Module:Name/Arity, Name, Arity, Module) :- !.
-iso_errors_pi_module(Name/Arity, Name, Arity, user).
-iso_errors_pi_module(Pred/Arity-_, Name, Arity, user) :-
-    atom(Pred), Pred = Name, !.
-
-%% iso_errors_rewrite(+Config, +PI, +Items0, -Items)
-%  Item-level rewrite API shared with C++/Elixir/Python.  F# (like
-%  Python) currently uses the text-level wrapper below because both
-%  interpreter and lowered emitter paths start from WAM text.
-iso_errors_rewrite(Config, PI, Items0, Items) :-
-    iso_errors_mode_for(Config, PI, Mode),
-    maplist(iso_errors_rewrite_item(Mode), Items0, Items).
-
-iso_errors_rewrite_item(true, builtin_call(Key, N), builtin_call(IsoKey, N)) :-
-    iso_errors_default_to_iso(Key, IsoKey), !.
-iso_errors_rewrite_item(true, put_structure(Key, Reg), put_structure(IsoKey, Reg)) :-
-    iso_errors_default_to_iso(Key, IsoKey), !.
-iso_errors_rewrite_item(true, call(Key, N), call(IsoKey, N)) :-
-    iso_errors_default_to_iso(Key, IsoKey), !.
-iso_errors_rewrite_item(true, execute(Key), execute(IsoKey)) :-
-    iso_errors_default_to_iso(Key, IsoKey), !.
-iso_errors_rewrite_item(false, builtin_call(Key, N), builtin_call(LaxKey, N)) :-
-    iso_errors_default_to_lax(Key, LaxKey), !.
-iso_errors_rewrite_item(false, put_structure(Key, Reg), put_structure(LaxKey, Reg)) :-
-    iso_errors_default_to_lax(Key, LaxKey), !.
-iso_errors_rewrite_item(false, call(Key, N), call(LaxKey, N)) :-
-    iso_errors_default_to_lax(Key, LaxKey), !.
-iso_errors_rewrite_item(false, execute(Key), execute(LaxKey)) :-
-    iso_errors_default_to_lax(Key, LaxKey), !.
-iso_errors_rewrite_item(_, Item, Item).
+iso_errors:iso_errors_default_to_lax("is/2", "is_lax/2").
+iso_errors:iso_errors_default_to_lax(">/2", ">_lax/2").
+iso_errors:iso_errors_default_to_lax("</2", "<_lax/2").
+iso_errors:iso_errors_default_to_lax(">=/2", ">=_lax/2").
+iso_errors:iso_errors_default_to_lax("=</2", "=<_lax/2").
+iso_errors:iso_errors_default_to_lax("=:=/2", "=:=_lax/2").
+iso_errors:iso_errors_default_to_lax("=\\=/2", "=\\=_lax/2").
+iso_errors:iso_errors_default_to_lax("succ/2", "succ_lax/2").
 
 %% iso_errors_rewrite_text(+Config, +PI, +WamText, -RewrittenText)
 %  Text-level rewrite that walks the WAM text line-by-line, splicing
@@ -4595,7 +4463,7 @@ iso_errors_rewrite_text(Config, PI, WamText, RewrittenText) :-
         atomic_list_concat(RewrittenLines, '\n', RewrittenText)
     ).
 
-iso_errors_has_lax_entries :- iso_errors_default_to_lax(_, _), !.
+iso_errors_has_lax_entries :- iso_errors:iso_errors_default_to_lax(_, _), !.
 
 iso_errors_rewrite_line(Mode, Line, OutLine) :-
     split_string(Line, " \t", " \t", Parts0),
@@ -4633,9 +4501,9 @@ iso_errors_clean_key_token(Token0, Token) :-
     ).
 
 iso_errors_lookup(true, Key, NewKey) :-
-    iso_errors_default_to_iso(Key, NewKey), !.
+    iso_errors:iso_errors_default_to_iso(Key, NewKey), !.
 iso_errors_lookup(false, Key, NewKey) :-
-    iso_errors_default_to_lax(Key, NewKey), !.
+    iso_errors:iso_errors_default_to_lax(Key, NewKey), !.
 iso_errors_lookup(_, Key, Key).
 
 iso_errors_splice_line(Line, Key, NewKey, OutLine) :-
@@ -4660,10 +4528,6 @@ wam_fsharp_iso_audit(Predicates, Options, Audit) :-
         iso_errors_mode_for(Config, PI, Mode),
         iso_errors_audit_predicate(PI, Mode, Sites)
     ), Audit).
-
-iso_errors_audit_normalise_pi(Pred/Arity-_, Pred/Arity) :- !.
-iso_errors_audit_normalise_pi(Module:Pred/Arity, Module:Pred/Arity) :- !.
-iso_errors_audit_normalise_pi(PI, PI).
 
 iso_errors_audit_predicate(PI, Mode, Sites) :-
     (   catch(
@@ -4698,41 +4562,6 @@ iso_errors_audit_classify_line([Tok], label) :-
 iso_errors_audit_classify_line(["builtin_call", Key0 | _], builtin_call(Key, 0)) :- !,
     iso_errors_clean_key_token(Key0, Key).
 iso_errors_audit_classify_line(_, other).
-
-iso_errors_audit_walk([], _, _, Acc, Acc).
-iso_errors_audit_walk([label|Rest], PC, Mode, Acc, Out) :- !,
-    iso_errors_audit_walk(Rest, PC, Mode, Acc, Out).
-iso_errors_audit_walk([builtin_call(Key, _)|Rest], PC, Mode, Acc, Out) :- !,
-    iso_errors_audit_classify(Key, Mode, Source, Resolved, Flip),
-    PC1 is PC + 1,
-    iso_errors_audit_walk(Rest, PC1, Mode, [site(PC, Key, Resolved, Source, Flip)|Acc], Out).
-iso_errors_audit_walk([_|Rest], PC, Mode, Acc, Out) :-
-    PC1 is PC + 1,
-    iso_errors_audit_walk(Rest, PC1, Mode, Acc, Out).
-
-iso_errors_audit_classify(Key, _Mode, explicit_iso, Key, false) :-
-    iso_errors_key_has_suffix(Key, "_iso"), !.
-iso_errors_audit_classify(Key, _Mode, explicit_lax, Key, false) :-
-    iso_errors_key_has_suffix(Key, "_lax"), !.
-iso_errors_audit_classify(Key, Mode, default, Resolved, Flip) :-
-    iso_errors_resolve_default(Key, Mode, Resolved),
-    iso_errors_other_mode(Mode, OtherMode),
-    iso_errors_resolve_default(Key, OtherMode, OtherResolved),
-    ( Resolved == OtherResolved -> Flip = false ; Flip = true ).
-
-iso_errors_resolve_default(Key, true, IsoKey) :-
-    iso_errors_default_to_iso(Key, IsoKey), !.
-iso_errors_resolve_default(Key, false, LaxKey) :-
-    iso_errors_default_to_lax(Key, LaxKey), !.
-iso_errors_resolve_default(Key, _, Key).
-
-iso_errors_other_mode(true, false).
-iso_errors_other_mode(false, true).
-
-iso_errors_key_has_suffix(Key, Suffix) :-
-    ( atom(Key) -> atom_string(Key, KS) ; KS = Key ),
-    split_string(KS, "/", "", [Name | _]),
-    string_concat(_, Suffix, Name).
 
 wam_fsharp_iso_audit_report([]).
 wam_fsharp_iso_audit_report([audit(PI, Mode, Sites)|Rest]) :-

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -45,6 +45,15 @@
 :- use_module('../core/prolog_term_parser').
 :- use_module('../bindings/python_wam_bindings').
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../core/iso_errors',
+              [ iso_errors_resolve_options/2,
+                iso_errors_load_config/2,
+                iso_errors_mode_for/3,
+                iso_errors_warn_multi_module/2,
+                iso_errors_rewrite/4,
+                iso_errors_audit_normalise_pi/2,
+                iso_errors_audit_walk/5
+              ]).
 :- use_module('../targets/wam_python_lowered_emitter', [
 	emit_lowered_python/4,
 	is_deterministic_pred_py/1,
@@ -1388,179 +1397,50 @@ compile_wam_runtime_to_python(_Options, PythonCode) :-
 % ============================================================================
 % ISO Error Configuration And Rewrite Plumbing
 % ============================================================================
+%
+% The reusable helpers (option resolution, mode lookup, config-file
+% loader, multi-module warning, item-level rewrite, audit walker)
+% live in src/unifyweaver/core/iso_errors.pl and are imported via
+% use_module at the top of this file.  What stays here:
+%   - Python key tables (multifile facts asserted into iso_errors),
+%     including read/read_term/read_term_from_atom which only Python
+%     supports via the runtime-parser substrate.
+%   - Text-level rewrite + plans wrapper.
+%   - wam_python_iso_audit/3 itself plus its parse-lines helpers.
 
-% Python has catch/throw plus ISO error constructors. The config and rewrite
-% layer is wired now, while key tables remain empty until the first Python
-% ISO/lax builtin variants land.
-:- dynamic iso_errors_default_to_iso/2.
-:- dynamic iso_errors_default_to_lax/2.
+% Multifile dispatch tables -- assert into iso_errors so the shared
+% mode/audit helpers see our entries.
+iso_errors:iso_errors_default_to_iso("is/2", "is_iso/2").
+iso_errors:iso_errors_default_to_iso(">/2", ">_iso/2").
+iso_errors:iso_errors_default_to_iso("</2", "<_iso/2").
+iso_errors:iso_errors_default_to_iso(">=/2", ">=_iso/2").
+iso_errors:iso_errors_default_to_iso("=</2", "=<_iso/2").
+iso_errors:iso_errors_default_to_iso("=:=/2", "=:=_iso/2").
+iso_errors:iso_errors_default_to_iso("=\\=/2", "=\\=_iso/2").
+iso_errors:iso_errors_default_to_iso("succ/2", "succ_iso/2").
+iso_errors:iso_errors_default_to_iso("read_term_from_atom/2", "read_term_from_atom_iso/2").
+iso_errors:iso_errors_default_to_iso("read_term_from_atom/3", "read_term_from_atom_iso/3").
+iso_errors:iso_errors_default_to_iso("read/1", "read_iso/1").
+iso_errors:iso_errors_default_to_iso("read_term/1", "read_term_iso/1").
+iso_errors:iso_errors_default_to_iso("read/2", "read_iso/2").
 
-iso_errors_default_to_iso("is/2", "is_iso/2").
-iso_errors_default_to_iso(">/2", ">_iso/2").
-iso_errors_default_to_iso("</2", "<_iso/2").
-iso_errors_default_to_iso(">=/2", ">=_iso/2").
-iso_errors_default_to_iso("=</2", "=<_iso/2").
-iso_errors_default_to_iso("=:=/2", "=:=_iso/2").
-iso_errors_default_to_iso("=\\=/2", "=\\=_iso/2").
-iso_errors_default_to_iso("succ/2", "succ_iso/2").
-iso_errors_default_to_iso("read_term_from_atom/2", "read_term_from_atom_iso/2").
-iso_errors_default_to_iso("read_term_from_atom/3", "read_term_from_atom_iso/3").
-iso_errors_default_to_iso("read/1", "read_iso/1").
-iso_errors_default_to_iso("read_term/1", "read_term_iso/1").
-iso_errors_default_to_iso("read/2", "read_iso/2").
+iso_errors:iso_errors_default_to_lax("is/2", "is_lax/2").
+iso_errors:iso_errors_default_to_lax(">/2", ">_lax/2").
+iso_errors:iso_errors_default_to_lax("</2", "<_lax/2").
+iso_errors:iso_errors_default_to_lax(">=/2", ">=_lax/2").
+iso_errors:iso_errors_default_to_lax("=</2", "=<_lax/2").
+iso_errors:iso_errors_default_to_lax("=:=/2", "=:=_lax/2").
+iso_errors:iso_errors_default_to_lax("=\\=/2", "=\\=_lax/2").
+iso_errors:iso_errors_default_to_lax("succ/2", "succ_lax/2").
+iso_errors:iso_errors_default_to_lax("read_term_from_atom/2", "read_term_from_atom_lax/2").
+iso_errors:iso_errors_default_to_lax("read_term_from_atom/3", "read_term_from_atom_lax/3").
+iso_errors:iso_errors_default_to_lax("read/1", "read_lax/1").
+iso_errors:iso_errors_default_to_lax("read_term/1", "read_term_lax/1").
+iso_errors:iso_errors_default_to_lax("read/2", "read_lax/2").
 
-iso_errors_default_to_lax("is/2", "is_lax/2").
-iso_errors_default_to_lax(">/2", ">_lax/2").
-iso_errors_default_to_lax("</2", "<_lax/2").
-iso_errors_default_to_lax(">=/2", ">=_lax/2").
-iso_errors_default_to_lax("=</2", "=<_lax/2").
-iso_errors_default_to_lax("=:=/2", "=:=_lax/2").
-iso_errors_default_to_lax("=\\=/2", "=\\=_lax/2").
-iso_errors_default_to_lax("succ/2", "succ_lax/2").
-iso_errors_default_to_lax("read_term_from_atom/2", "read_term_from_atom_lax/2").
-iso_errors_default_to_lax("read_term_from_atom/3", "read_term_from_atom_lax/3").
-iso_errors_default_to_lax("read/1", "read_lax/1").
-iso_errors_default_to_lax("read_term/1", "read_term_lax/1").
-iso_errors_default_to_lax("read/2", "read_lax/2").
-
-%% iso_errors_resolve_options(+Options, -Config)
-%  Merges optional file config with inline options into iso_config(Default,
-%  Overrides). Inline options override file entries for the same PI.
-iso_errors_resolve_options(Options, iso_config(Default, Overrides)) :-
-	(   option(iso_errors_config(File), Options)
-	->  iso_errors_load_config(File, iso_config(FileDefault, FileOv))
-	;   FileDefault = false, FileOv = []
-	),
-	iso_errors_inline_default(Options, FileDefault, Default),
-	iso_errors_inline_overrides(Options, InlineOv),
-	iso_errors_merge_overrides(FileOv, InlineOv, Overrides).
-
-iso_errors_inline_default(Options, FileDefault, Default) :-
-	(   member(iso_errors(M), Options),
-		(M == true ; M == false)
-	->  Default = M
-	;   Default = FileDefault
-	).
-
-iso_errors_inline_overrides(Options, InlineOv) :-
-	findall(PI-Mode,
-		( member(iso_errors(PI, Mode), Options),
-		  (Mode == true ; Mode == false),
-		  iso_errors_valid_pi(PI)
-		),
-		InlineOv).
-
-iso_errors_valid_pi(Name/Arity) :- atom(Name), integer(Arity), Arity >= 0, !.
-iso_errors_valid_pi(Module:Name/Arity) :-
-	atom(Module), atom(Name), integer(Arity), Arity >= 0.
-
-iso_errors_merge_overrides(FileOv, InlineOv, Merged) :-
-	exclude(iso_errors_shadowed(InlineOv), FileOv, Kept),
-	append(Kept, InlineOv, Merged).
-
-iso_errors_shadowed(InlineOv, PI-_) :-
-	member(InlinePI-_, InlineOv),
-	iso_errors_pi_matches(InlinePI, PI), !.
-
-iso_errors_pi_matches(PI, PI) :- !.
-iso_errors_pi_matches(Name/Arity, _:Name/Arity) :-
-	atom(Name), integer(Arity), !.
-iso_errors_pi_matches(_:Name/Arity, Name/Arity) :-
-	atom(Name), integer(Arity), !.
-
-%% iso_errors_load_config(+File, -Config)
-%  Reads iso_errors_default/1 and iso_errors_override/2 facts. Unknown facts
-%  and I/O failures are ignored, yielding iso_config(false, []).
-iso_errors_load_config(File, iso_config(Default, Overrides)) :-
-	catch(
-		setup_call_cleanup(
-			open(File, read, Stream),
-			iso_errors_read_terms(Stream, RawTerms),
-			close(Stream)),
-		_,
-		RawTerms = []),
-	iso_errors_extract_terms(RawTerms, false, [], Default, RevOv),
-	reverse(RevOv, Overrides).
-
-iso_errors_read_terms(Stream, Terms) :-
-	read_term(Stream, T, []),
-	(   T == end_of_file
-	->  Terms = []
-	;   Terms = [T|Rest],
-		iso_errors_read_terms(Stream, Rest)
-	).
-
-iso_errors_extract_terms([], D, Ov, D, Ov).
-iso_errors_extract_terms([T|Rest], D0, Ov0, D, Ov) :-
-	(   T = iso_errors_default(NewD), (NewD == true ; NewD == false)
-	->  iso_errors_extract_terms(Rest, NewD, Ov0, D, Ov)
-	;   T = iso_errors_override(PI, Mode),
-		(Mode == true ; Mode == false),
-		iso_errors_valid_pi(PI)
-	->  iso_errors_extract_terms(Rest, D0, [PI-Mode|Ov0], D, Ov)
-	;   iso_errors_extract_terms(Rest, D0, Ov0, D, Ov)
-	).
-
-%% iso_errors_mode_for(+Config, +PI, -Mode)
-iso_errors_mode_for(iso_config(Default, Overrides), PI, Mode) :-
-	(   member(OvPI-OvMode, Overrides),
-		iso_errors_pi_matches(OvPI, PI)
-	->  Mode = OvMode
-	;   Mode = Default
-	).
-
-%% iso_errors_warn_multi_module(+Config, +Predicates)
-%  Warns when a bare override matches predicates from multiple modules.
-iso_errors_warn_multi_module(iso_config(_, Overrides), Predicates) :-
-	forall(member(OvPI-_, Overrides),
-	       iso_errors_check_override_scope(OvPI, Predicates)).
-
-iso_errors_check_override_scope(Name/Arity, Predicates) :-
-	atom(Name), integer(Arity), !,
-	findall(M, ( member(P, Predicates),
-	             iso_errors_pi_module(P, Name, Arity, M)
-	           ), Modules),
-	list_to_set(Modules, Unique),
-	(   Unique = [_, _ | _]
-	->  length(Unique, N),
-		format(user_error,
-		       'Warning: iso_errors_override(~w/~w, _) matches ~w predicates~n         in different modules (~w).~n         Qualify with `mod:~w/~w` for module-scoped overrides.~n',
-		       [Name, Arity, N, Unique, Name, Arity])
-	;   true
-	).
-iso_errors_check_override_scope(_, _).
-
-iso_errors_pi_module(Module:Name/Arity, Name, Arity, Module) :- !.
-iso_errors_pi_module(Name/Arity, Name, Arity, user).
-iso_errors_pi_module(Pred/Arity-_, Name, Arity, user) :-
-	atom(Pred), Pred = Name, !.
-
-%% iso_errors_rewrite(+Config, +PI, +Items0, -Items)
-%  Item-level rewrite API shared with C++/Elixir. Python currently uses the
-%  text-level wrapper below because both interpreter and lowered paths start
-%  from WAM text.
-iso_errors_rewrite(Config, PI, Items0, Items) :-
-	iso_errors_mode_for(Config, PI, Mode),
-	maplist(iso_errors_rewrite_item(Mode), Items0, Items).
-
-iso_errors_rewrite_item(true, builtin_call(Key, N), builtin_call(IsoKey, N)) :-
-	iso_errors_default_to_iso(Key, IsoKey), !.
-iso_errors_rewrite_item(true, put_structure(Key, Reg), put_structure(IsoKey, Reg)) :-
-	iso_errors_default_to_iso(Key, IsoKey), !.
-iso_errors_rewrite_item(true, call(Key, N), call(IsoKey, N)) :-
-	iso_errors_default_to_iso(Key, IsoKey), !.
-iso_errors_rewrite_item(true, execute(Key), execute(IsoKey)) :-
-	iso_errors_default_to_iso(Key, IsoKey), !.
-iso_errors_rewrite_item(false, builtin_call(Key, N), builtin_call(LaxKey, N)) :-
-	iso_errors_default_to_lax(Key, LaxKey), !.
-iso_errors_rewrite_item(false, put_structure(Key, Reg), put_structure(LaxKey, Reg)) :-
-	iso_errors_default_to_lax(Key, LaxKey), !.
-iso_errors_rewrite_item(false, call(Key, N), call(LaxKey, N)) :-
-	iso_errors_default_to_lax(Key, LaxKey), !.
-iso_errors_rewrite_item(false, execute(Key), execute(LaxKey)) :-
-	iso_errors_default_to_lax(Key, LaxKey), !.
-iso_errors_rewrite_item(_, Item, Item).
-
+%% iso_errors_rewrite_plans(+Config, +Plans0, -Plans)
+%  Python-specific pred_plan wrapper: applies iso_errors_rewrite_text
+%  to each pred_plan(Pred, Arity, Wam, wam) plan's WAM text.
 iso_errors_rewrite_plans(Config, Plans0, Plans) :-
 	maplist(iso_errors_rewrite_plan(Config), Plans0, Plans).
 
@@ -1581,7 +1461,7 @@ iso_errors_rewrite_text(Config, PI, WamText, RewrittenText) :-
 		atomic_list_concat(RewrittenLines, '\n', RewrittenText)
 	).
 
-iso_errors_has_lax_entries :- iso_errors_default_to_lax(_, _), !.
+iso_errors_has_lax_entries :- iso_errors:iso_errors_default_to_lax(_, _), !.
 
 iso_errors_rewrite_line(Mode, Line, OutLine) :-
 	split_string(Line, " \t", " \t", Parts0),
@@ -1619,9 +1499,9 @@ iso_errors_clean_key_token(Token0, Token) :-
 	).
 
 iso_errors_lookup(true, Key, NewKey) :-
-	iso_errors_default_to_iso(Key, NewKey), !.
+	iso_errors:iso_errors_default_to_iso(Key, NewKey), !.
 iso_errors_lookup(false, Key, NewKey) :-
-	iso_errors_default_to_lax(Key, NewKey), !.
+	iso_errors:iso_errors_default_to_lax(Key, NewKey), !.
 iso_errors_lookup(_, Key, Key).
 
 iso_errors_splice_line(Line, Key, NewKey, OutLine) :-
@@ -1642,10 +1522,6 @@ wam_python_iso_audit(Predicates, Options, Audit) :-
 		iso_errors_mode_for(Config, PI, Mode),
 		iso_errors_audit_predicate(PI, Mode, Sites)
 	), Audit).
-
-iso_errors_audit_normalise_pi(Pred/Arity-_, Pred/Arity) :- !.
-iso_errors_audit_normalise_pi(Module:Pred/Arity, Module:Pred/Arity) :- !.
-iso_errors_audit_normalise_pi(PI, PI).
 
 iso_errors_audit_predicate(PI, Mode, Sites) :-
 	(   catch(
@@ -1680,41 +1556,6 @@ iso_errors_audit_classify_line([Tok], label) :-
 iso_errors_audit_classify_line(["builtin_call", Key0 | _], builtin_call(Key, 0)) :- !,
 	iso_errors_clean_key_token(Key0, Key).
 iso_errors_audit_classify_line(_, other).
-
-iso_errors_audit_walk([], _, _, Acc, Acc).
-iso_errors_audit_walk([label|Rest], PC, Mode, Acc, Out) :- !,
-	iso_errors_audit_walk(Rest, PC, Mode, Acc, Out).
-iso_errors_audit_walk([builtin_call(Key, _)|Rest], PC, Mode, Acc, Out) :- !,
-	iso_errors_audit_classify(Key, Mode, Source, Resolved, Flip),
-	PC1 is PC + 1,
-	iso_errors_audit_walk(Rest, PC1, Mode, [site(PC, Key, Resolved, Source, Flip)|Acc], Out).
-iso_errors_audit_walk([_|Rest], PC, Mode, Acc, Out) :-
-	PC1 is PC + 1,
-	iso_errors_audit_walk(Rest, PC1, Mode, Acc, Out).
-
-iso_errors_audit_classify(Key, _Mode, explicit_iso, Key, false) :-
-	iso_errors_key_has_suffix(Key, "_iso"), !.
-iso_errors_audit_classify(Key, _Mode, explicit_lax, Key, false) :-
-	iso_errors_key_has_suffix(Key, "_lax"), !.
-iso_errors_audit_classify(Key, Mode, default, Resolved, Flip) :-
-	iso_errors_resolve_default(Key, Mode, Resolved),
-	iso_errors_other_mode(Mode, OtherMode),
-	iso_errors_resolve_default(Key, OtherMode, OtherResolved),
-	( Resolved == OtherResolved -> Flip = false ; Flip = true ).
-
-iso_errors_resolve_default(Key, true, IsoKey) :-
-	iso_errors_default_to_iso(Key, IsoKey), !.
-iso_errors_resolve_default(Key, false, LaxKey) :-
-	iso_errors_default_to_lax(Key, LaxKey), !.
-iso_errors_resolve_default(Key, _, Key).
-
-iso_errors_other_mode(true, false).
-iso_errors_other_mode(false, true).
-
-iso_errors_key_has_suffix(Key, Suffix) :-
-	( atom(Key) -> atom_string(Key, KS) ; KS = Key ),
-	split_string(KS, "/", "", [Name | _]),
-	string_concat(_, Suffix, Name).
 
 wam_python_iso_audit_report([]).
 wam_python_iso_audit_report([audit(PI, Mode, Sites)|Rest]) :-

--- a/tests/test_iso_errors.pl
+++ b/tests/test_iso_errors.pl
@@ -1,0 +1,212 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% test_iso_errors.pl - Unit tests for the shared ISO errors module
+% at src/unifyweaver/core/iso_errors.pl.
+%
+% These tests verify the helpers in isolation -- no target dependency.
+% Per-target wrappers (rewrite_text, audit predicates) have their own
+% target-specific test files.
+
+:- encoding(utf8).
+:- use_module(library(plunit)).
+:- use_module('../src/unifyweaver/core/iso_errors').
+
+:- begin_tests(iso_errors).
+
+iso_errors_temp_config_file(Path, Lines) :-
+    tmp_file('tmp_shared_iso_cfg', Path),
+    setup_call_cleanup(
+        open(Path, write, Out),
+        forall(member(L, Lines), format(Out, '~w~n', [L])),
+        close(Out)).
+
+%% ----- valid_pi and pi_matches -----
+
+test(valid_pi_bare) :-
+    assertion(iso_errors_valid_pi(foo/2)),
+    assertion(iso_errors_valid_pi(foo/0)),
+    assertion(\+ iso_errors_valid_pi(foo/(-1))),
+    assertion(\+ iso_errors_valid_pi(foo)),
+    assertion(\+ iso_errors_valid_pi(123/2)).
+
+test(valid_pi_module_qualified) :-
+    assertion(iso_errors_valid_pi(mymod:foo/2)),
+    assertion(\+ iso_errors_valid_pi(mymod:foo)),
+    assertion(\+ iso_errors_valid_pi(mymod:123/2)).
+
+test(pi_matches_same) :-
+    assertion(iso_errors_pi_matches(foo/2, foo/2)),
+    assertion(iso_errors_pi_matches(mymod:foo/2, mymod:foo/2)).
+
+test(pi_matches_bare_to_qualified) :-
+    %% Bare Name/Arity in overrides matches Module:Name/Arity in any
+    %% module.  This is the common case for the multi-module warning.
+    assertion(iso_errors_pi_matches(foo/2, mymod:foo/2)),
+    assertion(iso_errors_pi_matches(foo/2, othermod:foo/2)).
+
+test(pi_matches_qualified_to_bare) :-
+    %% Symmetric: a Module:Name/Arity override matches a bare PI in
+    %% that module.  Used when the predicate list contains bare PIs.
+    assertion(iso_errors_pi_matches(mymod:foo/2, foo/2)).
+
+test(pi_matches_negative_cases) :-
+    assertion(\+ iso_errors_pi_matches(foo/2, bar/2)),
+    assertion(\+ iso_errors_pi_matches(foo/2, foo/3)),
+    assertion(\+ iso_errors_pi_matches(mymod:foo/2, othermod:foo/2)).
+
+%% ----- Config-file loader -----
+
+test(load_config_basic) :-
+    iso_errors_temp_config_file(Path, [
+        'iso_errors_default(true).',
+        'iso_errors_override(legacy_lookup/3, false).',
+        'iso_errors_override(experimental:my_pred/2, true).'
+    ]),
+    setup_call_cleanup(
+        true,
+        (   iso_errors_load_config(Path, Config),
+            assertion(Config == iso_config(true,
+                [legacy_lookup/3-false,
+                 (experimental:my_pred/2)-true]))
+        ),
+        delete_file(Path)).
+
+test(load_config_missing_returns_defaults) :-
+    %% Non-existent file -> iso_config(false, []) (silent failure
+    %% per spec; lets callers run unconfigured without erroring).
+    iso_errors_load_config('/tmp/no_such_iso_config_file_zzz.pl',
+                           iso_config(Default, Overrides)),
+    assertion(Default == false),
+    assertion(Overrides == []).
+
+test(load_config_ignores_unknown_facts) :-
+    iso_errors_temp_config_file(Path, [
+        'iso_errors_default(true).',
+        'iso_errors_override(foo/0, false).',
+        'unrelated_fact(blah).',
+        'iso_errors_default(bad_value).'  % bad mode value -> ignored
+    ]),
+    setup_call_cleanup(
+        true,
+        (   iso_errors_load_config(Path, iso_config(Default, Overrides)),
+            assertion(Default == true),
+            assertion(Overrides == [foo/0-false])
+        ),
+        delete_file(Path)).
+
+%% ----- Option resolution and inline-wins -----
+
+test(resolve_options_inline_only) :-
+    iso_errors_resolve_options(
+        [iso_errors(true), iso_errors(foo/0, false)],
+        iso_config(Default, Overrides)),
+    assertion(Default == true),
+    assertion(Overrides == [foo/0-false]).
+
+test(resolve_options_inline_wins_over_file) :-
+    iso_errors_temp_config_file(Path, [
+        'iso_errors_default(false).',
+        'iso_errors_override(legacy_lookup/3, false).'
+    ]),
+    setup_call_cleanup(
+        true,
+        (   iso_errors_resolve_options(
+                [iso_errors_config(Path),
+                 iso_errors(true),
+                 iso_errors(legacy_lookup/3, true)],
+                Config),
+            iso_errors_mode_for(Config, user:legacy_lookup/3, M1),
+            assertion(M1 == true),
+            iso_errors_mode_for(Config, user:never_listed/2, M2),
+            assertion(M2 == true)
+        ),
+        delete_file(Path)).
+
+%% ----- Mode resolution -----
+
+test(mode_for_bare_override_matches_qualified_pi) :-
+    Config = iso_config(true, [legacy/2-false]),
+    iso_errors_mode_for(Config, user:legacy/2, M1),
+    assertion(M1 == false),
+    iso_errors_mode_for(Config, other_module:legacy/2, M2),
+    assertion(M2 == false),
+    iso_errors_mode_for(Config, user:unrelated/3, M3),
+    assertion(M3 == true).
+
+test(mode_for_qualified_override_module_scoped) :-
+    Config = iso_config(true, [(mymod:scoped/1)-false]),
+    iso_errors_mode_for(Config, mymod:scoped/1, M1),
+    assertion(M1 == false),
+    %% Should NOT match a different module per pi_matches semantics.
+    iso_errors_mode_for(Config, othermod:scoped/1, M2),
+    assertion(M2 == true).
+
+%% ----- Multi-module warning (smoke) -----
+
+test(warn_multi_module_does_not_fail_on_clean_input) :-
+    Config = iso_config(true, []),
+    iso_errors_warn_multi_module(Config, [user:foo/0, mymod:bar/1]),
+    %% Just verifying no exception/failure.
+    true.
+
+%% ----- Item-level rewrite (uses multifile tables) -----
+
+test(rewrite_item_uses_iso_table_in_iso_mode) :-
+    %% Assert a test entry, run rewrite, then retract.
+    setup_call_cleanup(
+        ( assertz(iso_errors:iso_errors_default_to_iso("testkey/1", "testkey_iso/1")),
+          assertz(iso_errors:iso_errors_default_to_lax("testkey/1", "testkey_lax/1")) ),
+        (   iso_errors_rewrite(iso_config(true, []), demo/0,
+                               [builtin_call("testkey/1", 1)],
+                               Out1),
+            assertion(Out1 == [builtin_call("testkey_iso/1", 1)]),
+            iso_errors_rewrite(iso_config(false, []), demo/0,
+                               [builtin_call("testkey/1", 1)],
+                               Out2),
+            assertion(Out2 == [builtin_call("testkey_lax/1", 1)])
+        ),
+        ( retract(iso_errors:iso_errors_default_to_iso("testkey/1", "testkey_iso/1")),
+          retract(iso_errors:iso_errors_default_to_lax("testkey/1", "testkey_lax/1")) )).
+
+test(rewrite_item_passes_through_unknown_keys) :-
+    %% Keys not in the tables survive unchanged.
+    iso_errors_rewrite(iso_config(true, []), demo/0,
+                       [builtin_call("not_in_tables/2", 2)],
+                       Out),
+    assertion(Out == [builtin_call("not_in_tables/2", 2)]).
+
+%% ----- Audit walker primitives -----
+
+test(audit_normalise_pi) :-
+    iso_errors_audit_normalise_pi(foo/2, P1),
+    assertion(P1 == foo/2),
+    iso_errors_audit_normalise_pi(foo/2-stuff, P2),
+    assertion(P2 == foo/2),
+    iso_errors_audit_normalise_pi(mymod:foo/2, P3),
+    assertion(P3 == mymod:foo/2).
+
+test(audit_walk_advances_pc_for_other_items) :-
+    iso_errors_audit_walk([other, other, other], 0, true, [], Out),
+    assertion(Out == []).
+
+test(audit_walk_records_builtin_call_sites) :-
+    setup_call_cleanup(
+        assertz(iso_errors:iso_errors_default_to_iso("foo/0", "foo_iso/0")),
+        (   iso_errors_audit_walk([builtin_call("foo/0", 0)], 0, true, [], OutRev),
+            reverse(OutRev, Out),
+            assertion(Out == [site(0, "foo/0", "foo_iso/0", default, true)])
+        ),
+        retract(iso_errors:iso_errors_default_to_iso("foo/0", "foo_iso/0"))).
+
+%% ----- key_has_suffix -----
+
+test(key_has_suffix) :-
+    assertion(iso_errors_key_has_suffix("foo_iso/2", "_iso")),
+    assertion(iso_errors_key_has_suffix("foo_lax/2", "_lax")),
+    assertion(\+ iso_errors_key_has_suffix("foo/2", "_iso")),
+    assertion(\+ iso_errors_key_has_suffix("foo/2", "_lax")),
+    %% Verify the suffix check looks at the Name portion before the
+    %% slash, not the whole string.
+    assertion(\+ iso_errors_key_has_suffix("foo/0", "_0")).
+
+:- end_tests(iso_errors).

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -479,8 +479,12 @@ test_iso_errors_audit_is_resolves_to_lax :-
 
 test_iso_errors_is_table_populated :-
     Test = 'WAM-Elixir: PR #4 populates is/2 entries in iso/lax tables',
-    (   wam_elixir_target:iso_errors_default_to_iso("is/2", "is_iso/2"),
-        wam_elixir_target:iso_errors_default_to_lax("is/2", "is_lax/2")
+    %% After shared-module extraction, the key tables live as
+    %% multifile facts on iso_errors:iso_errors_default_to_iso/2
+    %% (and _lax/2) -- Elixir's wam_elixir_target.pl asserts into
+    %% that module rather than maintaining its own dynamic facts.
+    (   iso_errors:iso_errors_default_to_iso("is/2", "is_iso/2"),
+        iso_errors:iso_errors_default_to_lax("is/2", "is_lax/2")
     ->  pass(Test)
     ;   fail_test(Test, 'is/2 table entries missing')
     ).
@@ -489,11 +493,11 @@ test_iso_errors_sweep_table_populated :-
     Test = 'WAM-Elixir: PR #5 populates 6 compares + succ/2 in iso/lax tables',
     Compares = [">/2", "</2", ">=/2", "=</2", "=:=/2", "=\\=/2"],
     (   forall(member(K, Compares),
-               (   wam_elixir_target:iso_errors_default_to_iso(K, _),
-                   wam_elixir_target:iso_errors_default_to_lax(K, _)
+               (   iso_errors:iso_errors_default_to_iso(K, _),
+                   iso_errors:iso_errors_default_to_lax(K, _)
                )),
-        wam_elixir_target:iso_errors_default_to_iso("succ/2", "succ_iso/2"),
-        wam_elixir_target:iso_errors_default_to_lax("succ/2", "succ_lax/2")
+        iso_errors:iso_errors_default_to_iso("succ/2", "succ_iso/2"),
+        iso_errors:iso_errors_default_to_lax("succ/2", "succ_lax/2")
     ->  pass(Test)
     ;   fail_test(Test, 'one or more PR #5 table entries missing')
     ).


### PR DESCRIPTION
## Summary

Third and final follow-up to #2452 (ISO substrate) and #2454 (compare sweep + succ). Per the "third adopter" rule in `WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` § Remaining Work — triggered now that F# joins Elixir and Python as a broad ISO-errors adopter — the duplicated `iso_errors_*` helpers move into `src/unifyweaver/core/iso_errors.pl`.

## What's now shared

`src/unifyweaver/core/iso_errors.pl` (~290 LOC) hosts:

- **Option resolution**: `iso_errors_resolve_options/2`, `iso_errors_inline_*`, `iso_errors_merge_overrides/3`
- **Config-file loader**: `iso_errors_load_config/2` + read/extract terms helpers
- **PI matching**: `iso_errors_valid_pi/1`, `iso_errors_pi_matches/2`, `iso_errors_shadowed/2`
- **Mode resolution**: `iso_errors_mode_for/3`
- **Multi-module warning**: `iso_errors_warn_multi_module/2`, `iso_errors_check_override_scope/2`, `iso_errors_pi_module/4`
- **Item-level rewrite**: `iso_errors_rewrite/4`, `iso_errors_rewrite_item/3`
- **Audit walker primitives**: `iso_errors_audit_normalise_pi/2`, `iso_errors_audit_walk/5`, `iso_errors_audit_classify/5`, `iso_errors_resolve_default/3`, `iso_errors_other_mode/2`, `iso_errors_key_has_suffix/2`
- `iso_errors_default_to_iso/2` and `_lax/2` declared `:- multifile` so each target asserts its own table entries

## What stays target-local

Semantic differences make full sharing premature:

- `iso_errors_rewrite_text/4` family — Python/F# use `clean_key_token` + `" \t"` padding; Elixir uses `KeyComma` matching + `""` padding. Both produce equivalent output but the parsers differ in detail.
- `wam_<target>_iso_audit/3` + parse-lines helpers — Elixir's `classify_line` uses a 3-element arity-aware pattern; Python/F# use the simpler 2+rest pattern.
- Key-table entries are per-target (Python adds `read/read_term/read_term_from_atom` variants; F#/Elixir share the `is`/comparisons/succ set).

## Numbers

- ~640 LOC removed from target files
- ~290 LOC added to shared module
- ~230 LOC of new unit tests
- Net: ~120 LOC reduction + a single source of truth for the helpers

## Test plan

- [x] `tests/test_iso_errors.pl` — **20/20** new unit tests covering valid_pi, pi_matches (bare/qualified/symmetric), load_config (basic + missing-file + ignored-facts), resolve_options inline-wins, mode_for bare/qualified, warn_multi_module smoke, item-level rewrite (uses test multifile entries, retracts on exit), audit walker primitives, key_has_suffix
- [x] `tests/test_wam_fsharp_iso_unit.pl` — 11/11 (unchanged)
- [x] `tests/test_wam_fsharp_target.pl` — 53/53 (unchanged)
- [x] `tests/test_wam_python_target.pl` — full suite passes
- [x] `tests/test_wam_elixir_target.pl` — all 8 ISO unit tests pass (one test updated to query `iso_errors:iso_errors_default_to_iso/2` instead of `wam_elixir_target:`; pre-existing Phase A fact-classification failures are unrelated)
- [x] `tests/core/test_wam_fsharp_iso_smoke.pl` — 19/19 dotnet E2E
- [x] `tests/core/test_wam_fsharp_runtime_smoke.pl` — 19/19
- [x] `tests/core/test_wam_fsharp_parser_smoke.pl` — 42/42

## Docs

- `WAM_ISO_ERRORS_CROSS_TARGET_STATUS.md` § "Remaining Work" updated to note the extraction shipped
- `WAM_FSHARP_PARITY_AUDIT.md` § "Remaining F# ISO Work" reduced to "None at this layer" — F# ISO is now feature-complete against the cross-target reference

## Follow-ups

The audit doc still lists future cross-target work that isn't strictly ISO-related (LMDB, CSR). Those are separate concerns.

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_