### PR TITLE
wam-fsharp: LMDB Phase 1 — LmdbFactSource template + codegen option

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -4647,6 +4647,15 @@ write_wam_fsharp_project(Predicates, Options, ProjectDir) :-
     directory_file_path(ProjectDir, 'Lowered.fs', LoweredPath),
     write_fs_file(LoweredPath, LoweredCode),
 
+    % Generate LmdbFactSource.fs when lmdb_path is set.
+    (   option(lmdb_path(_), Options)
+    ->  fsharp_lmdb_template_source(LmdbTemplateCode),
+        directory_file_path(ProjectDir, 'LmdbFactSource.fs', LmdbPath),
+        write_fs_file(LmdbPath, LmdbTemplateCode),
+        format(user_error, '[WAM-FSharp] LMDB fact source included~n', [])
+    ;   true
+    ),
+
     % Generate Program.fs (benchmark driver).  The driver calls into
     % USER predicates only -- portable-parser predicates are library
     % code, not entry points -- so this stays on the original list.
@@ -4662,6 +4671,19 @@ write_wam_fsharp_project(Predicates, Options, ProjectDir) :-
     write_fs_file(FsprojPath, FsprojCode),
 
     format(user_error, '[WAM-FSharp] Generated project at: ~w~n', [ProjectDir]).
+
+%% fsharp_lmdb_template_source(-Code)
+%  Reads the LmdbFactSource.fs.mustache template and returns it
+%  as a string.  The template is a plain F# module with no mustache
+%  variables (the LMDB path is passed at runtime, not baked in).
+fsharp_lmdb_template_source(Code) :-
+    source_file(wam_fsharp_target:_, SrcFile),
+    file_directory_name(SrcFile, SrcDir),
+    file_directory_name(SrcDir, TargetsDir),
+    file_directory_name(TargetsDir, UnifyWeaverDir),
+    file_directory_name(UnifyWeaverDir, ProjectRoot),
+    atom_concat(ProjectRoot, '/templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache', TemplatePath),
+    read_file_to_string(TemplatePath, Code, []).
 
 %% write_fs_file(+Path, +Content)
 write_fs_file(Path, Content) :-
@@ -5010,7 +5032,13 @@ format_foreign_preds_fs(Keys, Str) :-
     atomic_list_concat(Quoted, '; ', Str).
 
 %% generate_fsproj(+ModName, +Options, -Code)
-generate_fsproj(ModName, _Options, Code) :-
+generate_fsproj(ModName, Options, Code) :-
+    (   option(lmdb_path(_), Options)
+    ->  LmdbCompile  = '\n    <Compile Include="LmdbFactSource.fs" />',
+        LmdbPackage  = '\n  <ItemGroup>\n    <PackageReference Include="LightningDB" Version="0.21.0" />\n  </ItemGroup>\n'
+    ;   LmdbCompile  = '',
+        LmdbPackage  = ''
+    ),
     format(string(Code),
 '<Project Sdk="Microsoft.NET.Sdk">
 
@@ -5023,13 +5051,13 @@ generate_fsproj(ModName, _Options, Code) :-
     <Deterministic>true</Deterministic>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup>~w
     <Compile Include="WamTypes.fs" />
     <Compile Include="WamRuntime.fs" />
     <Compile Include="Predicates.fs" />
     <Compile Include="Lowered.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
-
+~w
 </Project>
-', [ModName]).
+', [ModName, LmdbCompile, LmdbPackage]).

--- a/templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache
+++ b/templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache
@@ -1,0 +1,116 @@
+// LMDB-backed edge lookup for the wam-fsharp runtime.
+//
+// Mirrors the Rust lmdb_fact_source for the Phase 1 sub-db layout:
+//
+//   s2i              (string -> int32)   intern table forward
+//   i2s              (int32  -> string)  intern table reverse
+//   category_parent  (int32 child  -> int32 parent)  DUPSORT
+//   category_child   (int32 parent -> int32 child)   DUPSORT
+//
+// Uses the LightningDB NuGet package (same CLR binding used by the
+// C# lmdb_ingest tool at src/unifyweaver/runtime/csharp/lmdb_ingest).
+//
+// Endianness: int32 keys/values are stored little-endian, matching
+// the streaming ingest pipeline and Phase 1 converter.
+
+module LmdbFactSource
+
+open System
+open LightningDB
+
+/// Decode a 4-byte little-endian int32 from LMDB key/value bytes.
+let private decodeI32 (bytes: ReadOnlySpan<byte>) : int =
+    if bytes.Length >= 4 then
+        BitConverter.ToInt32(bytes)
+    else
+        let buf = Array.zeroCreate<byte> 4
+        bytes.CopyTo(Span<byte>(buf))
+        BitConverter.ToInt32(buf, 0)
+
+/// Encode an int32 as 4-byte little-endian (for LMDB key lookup).
+let encodeI32 (value: int) : byte[] =
+    BitConverter.GetBytes(value)
+
+/// Open the Phase 1 LMDB environment at `lmdbPath`.  Returns the
+/// environment handle; callers use it with the load* helpers below
+/// to materialise facts into the WAM context.
+let openEnv (lmdbPath: string) : LightningEnvironment =
+    let env = new LightningEnvironment(lmdbPath)
+    env.MaxDatabases <- 8
+    env.Open(EnvironmentOpenFlags.ReadOnly ||| EnvironmentOpenFlags.NoLock)
+    env
+
+/// Load the s2i (string->int) intern table into a Map.
+let loadS2I (env: LightningEnvironment) : Map<string, int> =
+    use tx = env.BeginTransaction(TransactionBeginFlags.ReadOnly)
+    let db = tx.OpenDatabase("s2i", new DatabaseConfiguration(Flags = DatabaseOpenFlags.None))
+    use cursor = tx.CreateCursor(db)
+    let mutable result = Map.empty
+    let struct (rc, _, _) = cursor.First()
+    if rc = MDBResultCode.Success then
+        let struct (_, k, v) = cursor.GetCurrent()
+        result <- Map.add (Text.Encoding.UTF8.GetString(k.CopyToNewArray())) (decodeI32 (v.AsSpan())) result
+        let mutable ok = true
+        while ok do
+            let struct (rc2, _, _) = cursor.Next()
+            if rc2 = MDBResultCode.Success then
+                let struct (_, k2, v2) = cursor.GetCurrent()
+                result <- Map.add (Text.Encoding.UTF8.GetString(k2.CopyToNewArray())) (decodeI32 (v2.AsSpan())) result
+            else
+                ok <- false
+    result
+
+/// Load the i2s (int->string) reverse intern table.
+let loadI2S (env: LightningEnvironment) : Map<int, string> =
+    use tx = env.BeginTransaction(TransactionBeginFlags.ReadOnly)
+    let db = tx.OpenDatabase("i2s", new DatabaseConfiguration(Flags = DatabaseOpenFlags.None))
+    use cursor = tx.CreateCursor(db)
+    let mutable result = Map.empty
+    let struct (rc, _, _) = cursor.First()
+    if rc = MDBResultCode.Success then
+        let struct (_, k, v) = cursor.GetCurrent()
+        result <- Map.add (decodeI32 (k.AsSpan())) (Text.Encoding.UTF8.GetString(v.CopyToNewArray())) result
+        let mutable ok = true
+        while ok do
+            let struct (rc2, _, _) = cursor.Next()
+            if rc2 = MDBResultCode.Success then
+                let struct (_, k2, v2) = cursor.GetCurrent()
+                result <- Map.add (decodeI32 (k2.AsSpan())) (Text.Encoding.UTF8.GetString(v2.CopyToNewArray())) result
+            else
+                ok <- false
+    result
+
+/// Load a DUPSORT database (e.g. category_parent) into a Map<int, int list>.
+/// Each key may have multiple values (duplicates); all are collected.
+let loadDupsortRelation (env: LightningEnvironment) (dbName: string) : Map<int, int list> =
+    use tx = env.BeginTransaction(TransactionBeginFlags.ReadOnly)
+    let db = tx.OpenDatabase(dbName, new DatabaseConfiguration(Flags = DatabaseOpenFlags.DuplicatesSort))
+    use cursor = tx.CreateCursor(db)
+    let mutable result : Map<int, int list> = Map.empty
+    let struct (rc, _, _) = cursor.First()
+    if rc = MDBResultCode.Success then
+        let addEntry () =
+            let struct (_, k, v) = cursor.GetCurrent()
+            let key = decodeI32 (k.AsSpan())
+            let value = decodeI32 (v.AsSpan())
+            result <-
+                match Map.tryFind key result with
+                | Some vs -> Map.add key (vs @ [value]) result
+                | None    -> Map.add key [value] result
+        addEntry ()
+        let mutable ok = true
+        while ok do
+            let struct (rc2, _, _) = cursor.Next()
+            if rc2 = MDBResultCode.Success then
+                addEntry ()
+            else
+                ok <- false
+    result
+
+/// Convenience: load category_parent(child->parents) for WcFfiFacts.
+let loadCategoryParent (env: LightningEnvironment) : Map<int, int list> =
+    loadDupsortRelation env "category_parent"
+
+/// Convenience: load category_child(parent->children) for reverse lookup.
+let loadCategoryChild (env: LightningEnvironment) : Map<int, int list> =
+    loadDupsortRelation env "category_child"

--- a/tests/core/test_wam_fsharp_lmdb_smoke.pl
+++ b/tests/core/test_wam_fsharp_lmdb_smoke.pl
@@ -1,0 +1,153 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% test_wam_fsharp_lmdb_smoke.pl - F# WAM LMDB fact-source end-to-end smoke test
+%
+% Creates a small synthetic Phase 1 LMDB fixture (via Python), generates
+% an F# project with lmdb_path(LmdbDir), builds with dotnet, and
+% verifies that the generated code can read facts from the LMDB and
+% dispatch WAM predicates against them.
+%
+% Prerequisites:
+%   - python3 with the 'lmdb' package (pip3 install lmdb)
+%   - .NET 8 SDK on PATH
+%   - LANG=C.UTF-8
+
+:- encoding(utf8).
+:- use_module('../../src/unifyweaver/targets/wam_fsharp_target',
+              [write_wam_fsharp_project/3]).
+:- use_module(library(filesex), [delete_directory_and_contents/1,
+                                  make_directory_path/1,
+                                  directory_file_path/3]).
+:- use_module(library(process)).
+
+run_dotnet(Args, Dir, ExitCode, OutText) :-
+    setup_call_cleanup(
+        process_create(path(dotnet), Args,
+                       [cwd(Dir),
+                        stdout(pipe(Out)),
+                        stderr(pipe(Err)),
+                        process(PID)]),
+        ( read_string(Out, _, OutStr),
+          read_string(Err, _, ErrStr),
+          process_wait(PID, exit(ExitCode)),
+          string_concat(OutStr, ErrStr, OutText)
+        ),
+        ( catch(close(Out), _, true), catch(close(Err), _, true) )).
+
+main :-
+    LmdbDir = '/tmp/uw_fsharp_lmdb_fixture',
+    ProjectDir = '/tmp/uw_fsharp_lmdb_smoke',
+    catch(delete_directory_and_contents(LmdbDir), _, true),
+    catch(delete_directory_and_contents(ProjectDir), _, true),
+
+    %% Step 1: Generate synthetic Phase 1 LMDB (10 parents, 3 children each)
+    format('Generating LMDB fixture...~n'),
+    setup_call_cleanup(
+        process_create(path(python3),
+                       ['examples/benchmark/generate_synthetic_phase1_lmdb.py',
+                        LmdbDir,
+                        '--parents', '5',
+                        '--children-per-parent', '2',
+                        '--refresh'],
+                       [stdout(pipe(PyOut)),
+                        stderr(pipe(PyErr)),
+                        process(PyPID)]),
+        ( read_string(PyOut, _, _PyOutS),
+          read_string(PyErr, _, PyErrS),
+          process_wait(PyPID, exit(PyExit))
+        ),
+        ( catch(close(PyOut), _, true), catch(close(PyErr), _, true) )),
+    (   PyExit == 0
+    ->  format('LMDB fixture generated.~n')
+    ;   format('LMDB generation failed (exit ~w): ~w~n', [PyExit, PyErrS]),
+        halt(1)
+    ),
+
+    %% Step 2: Generate F# project with lmdb_path.
+    %% The test predicate: load category_parent from LMDB, check that
+    %% parent of child 6 is parent 1 (per the synthetic fixture pattern:
+    %% parents 1..5, children 6..15, each parent gets 2 children).
+    %% Child 6 -> parent 1, child 7 -> parent 1, child 8 -> parent 2, etc.
+    make_directory_path(ProjectDir),
+    write_wam_fsharp_project(
+        [],
+        [no_kernels(true),
+         module_name('uw_fs_lmdb_smoke'),
+         lmdb_path(LmdbDir)],
+        ProjectDir),
+    format('Project generated at ~w~n', [ProjectDir]),
+
+    %% Step 3: Write a custom Program.fs that:
+    %%   - Opens the LMDB
+    %%   - Loads category_parent into a Map<int, int list>
+    %%   - Verifies expected edges exist
+    directory_file_path(ProjectDir, 'Program.fs', ProgPath),
+    atom_string(LmdbDir, LmdbDirStr),
+    atom_string(LmdbDir, LmdbDirStr),
+    string_concat(LmdbDirStr, "\"
+    eprintfn \"Opening LMDB at: %s\" lmdbPath
+    let env = openEnv lmdbPath
+    let cp = loadCategoryParent env
+
+    let totalEdges = cp |> Map.fold (fun acc _ vs -> acc + List.length vs) 0
+    assertTrue \"total edges = 10\" (totalEdges = 10)
+
+    assertTrue \"child 6 -> parent 1\" (Map.tryFind 6 cp = Some [1])
+    assertTrue \"child 7 -> parent 1\" (Map.tryFind 7 cp = Some [1])
+    assertTrue \"child 8 -> parent 2\" (Map.tryFind 8 cp = Some [2])
+    assertTrue \"child 14 -> parent 5\" (Map.tryFind 14 cp = Some [5])
+
+    assertTrue \"child 99 -> None\" (Map.tryFind 99 cp = None)
+    assertTrue \"parent 1 not a child\" (Map.tryFind 1 cp = None)
+
+    let cc = loadCategoryChild env
+    let ccTotalEdges = cc |> Map.fold (fun acc _ vs -> acc + List.length vs) 0
+    assertTrue \"reverse total edges = 10\" (ccTotalEdges = 10)
+    assertTrue \"parent 1 -> [6; 7]\" (Map.tryFind 1 cc = Some [6; 7])
+
+    env.Dispose()
+
+    printfn \"RESULT %d/%d\" passes (passes + fails)
+    if fails > 0 then 1 else 0
+", DriverTail),
+    string_concat("module Program
+
+open System
+open LmdbFactSource
+
+let mutable passes = 0
+let mutable fails = 0
+
+let assertTrue (name: string) (cond: bool) =
+    if cond then
+        passes <- passes + 1
+        printfn \"[PASS] %s\" name
+    else
+        fails <- fails + 1
+        printfn \"[FAIL] %s\" name
+
+[<EntryPoint>]
+let main _argv =
+    let lmdbPath = \"", DriverTail, DriverCode),
+    open(ProgPath, write, OW, [encoding(utf8)]),
+    write(OW, DriverCode),
+    close(OW),
+
+    %% Step 4: Build
+    format('Building...~n'),
+    run_dotnet(['build', '--nologo', '-v', 'minimal'], ProjectDir, BuildExit, BuildOut),
+    (   BuildExit == 0
+    ->  format('Build OK.~n')
+    ;   format('--- build output ---~n~w~n----~n', [BuildOut]),
+        format('BUILD FAILED~n'),
+        halt(1)
+    ),
+
+    %% Step 5: Run
+    format('Running...~n'),
+    run_dotnet(['run', '--no-build', '-c', 'Debug'], ProjectDir, RunExit, RunOut),
+    format('--- run output (exit=~w) ---~n~w~n----~n', [RunExit, RunOut]),
+    (   RunExit == 0
+    ->  halt(0)
+    ;   halt(1)
+    ).


### PR DESCRIPTION
## Summary

Adds the first LMDB fact-source capability to the F# WAM target, closing the "F# has no LMDB plumbing at all" gap noted in `docs/design/WAM_FSHARP_PARITY_AUDIT.md`.

## New template

`templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache` — standalone F# module using the [LightningDB](https://www.nuget.org/packages/LightningDB) NuGet package (same CLR binding the C# `lmdb_ingest` tool uses). Reads the Phase 1 resident layout:

- `openEnv(path)` — opens the LMDB environment read-only
- `loadS2I` / `loadI2S` — string↔int intern tables into `Map<string,int>` / `Map<int,string>`
- `loadDupsortRelation(env, dbName)` — generic DUPSORT reader returning `Map<int, int list>`
- `loadCategoryParent` / `loadCategoryChild` — convenience wrappers

This is **eager materialisation** per the LMDB lazy specification: the entire relation is loaded into an F# Map at startup. Lazy and cached modes (LookupSource trait, cursor-based on-demand reads, bounded LRU) are future phases.

## Codegen wiring

`write_wam_fsharp_project/3` now accepts `lmdb_path(Path)`:
- Copies `LmdbFactSource.fs` into the generated project
- Adds `<PackageReference Include="LightningDB" Version="0.21.0"/>` to the `.fsproj`
- Adds `<Compile Include="LmdbFactSource.fs"/>` before `WamTypes.fs`

When `lmdb_path` is not set, no LMDB code is generated (zero overhead).

## Test plan

- [x] `tests/core/test_wam_fsharp_lmdb_smoke.pl` — **9/9** new E2E tests: generates a synthetic Phase 1 LMDB (5 parents × 2 children = 10 edges) via the Python fixture builder, generates an F# project with `lmdb_path`, builds with dotnet, verifies edge count + specific edges + absent keys + reverse relation
- [x] `tests/test_wam_fsharp_target.pl` — 53/53 (no regressions)
- [x] `tests/core/test_wam_fsharp_runtime_smoke.pl` — 19/19 (unchanged)

## Future phases

Per the LMDB lazy specification (`WAM_LMDB_LAZY_SPECIFICATION.md`):

| Phase | Status | Description |
|---|---|---|
| Eager materialisation | ✅ this PR | Full `Map<int, int list>` built at startup |
| `LookupSource` interface | next | Trait/interface abstracting fact access for lazy/cached dispatch |
| Lazy cursor-based lookup | next | `LmdbCursorLookup` reads on-demand, no cache |
| Cached + LRU | later | `CachedLookup` decorator with bounded user-space cache |

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_