### PR TITLE
wam-fsharp: wire LookupSource into kernel dispatch via resolveFactMap

### DIFF
--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -298,9 +298,11 @@ type ILookupSource =
 
 /// Eager implementation: wraps a fully-materialised Map built at startup.
 type EagerLookupSource(data: Map<int, int list>) =
+    member _.Data = data
     interface ILookupSource with
         member _.Lookup(key) =
             Map.tryFind key data |> Option.defaultValue []
+
 
 type WamContext =
     { WcCode            : Instruction array    // instruction array (O(1) fetch)
@@ -445,6 +447,18 @@ fsharp_wam_helpers :-
 "// ============================================================================
 // Helper functions
 // ============================================================================
+
+/// Resolve a fact Map for kernel dispatch.  Checks WcLookupSources
+/// first (preferred path after LMDB Phase 2); extracts the inner Map
+/// from EagerLookupSource for zero-cost access.  Falls back to
+/// WcFfiFacts for legacy compatibility.
+let resolveFactMap (pred: string) (ctx: WamContext) : Map<int, int list> =
+    match Map.tryFind pred ctx.WcLookupSources with
+    | Some (:? EagerLookupSource as eager) -> eager.Data
+    | Some _ ->
+        Map.tryFind pred ctx.WcFfiFacts |> Option.defaultValue Map.empty
+    | None ->
+        Map.tryFind pred ctx.WcFfiFacts |> Option.defaultValue Map.empty
 
 /// Merge two maps (right-biased: values from m2 overwrite m1).
 let mapUnion (m1: Map<'k, 'v>) (m2: Map<'k, 'v>) : Map<'k, 'v> =

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -3526,7 +3526,7 @@ reg_var_name_fs(N, Name) :- format(atom(Name), 'r~w', [N]).
 
 emit_config_let_bindings_fs([]).
 emit_config_let_bindings_fs([config_facts(FactKey)|Rest]) :-
-    format('        let ~w_facts = Map.tryFind "~w" ctx.WcFfiFacts |> Option.defaultValue Map.empty~n',
+    format('        let ~w_facts = resolveFactMap "~w" ctx~n',
            [FactKey, FactKey]),
     emit_config_let_bindings_fs(Rest).
 emit_config_let_bindings_fs([config_weighted_facts(FactKey)|Rest]) :-


### PR DESCRIPTION
## Summary

Completes the LMDB Phase 2 wiring: kernel codegen now resolves fact Maps through `WcLookupSources` (the `ILookupSource` interface from #2457) before falling back to the legacy `WcFfiFacts` path.

## What changed

**`resolveFactMap` helper** (`fsharp_wam_bindings.pl` → `WamTypes.fs`):

```fsharp
let resolveFactMap (pred: string) (ctx: WamContext) : Map<int, int list> =
    match Map.tryFind pred ctx.WcLookupSources with
    | Some (:? EagerLookupSource as eager) -> eager.Data  // zero-cost unwrap
    | Some _ -> Map.tryFind pred ctx.WcFfiFacts |> Option.defaultValue Map.empty
    | None   -> Map.tryFind pred ctx.WcFfiFacts |> Option.defaultValue Map.empty
```

For `EagerLookupSource`, `.Data` is a direct property access — no boxing, no interface dispatch. For non-eager sources (lazy cursor), the function falls back to `WcFfiFacts` since kernels need a `Map` for random-access DFS traversal.

**Codegen change** (`wam_fsharp_target.pl`):

`emit_config_let_bindings_fs(config_facts(FactKey))` now emits:
```fsharp
let category_parent_facts = resolveFactMap "category_parent" ctx
```
instead of:
```fsharp
let category_parent_facts = Map.tryFind "category_parent" ctx.WcFfiFacts |> Option.defaultValue Map.empty
```

Generated kernel dispatchers automatically prefer `WcLookupSources` when populated.

## Why this matters

With this wiring:
- `WcFfiFacts` remains the legacy path (backward compatible)
- `WcLookupSources` is the preferred path when populated
- Future `lmdb_materialisation(eager)` codegen populates `WcLookupSources` with `EagerLookupSource` wrapping the LMDB-loaded Map → kernel uses it via `resolveFactMap` at zero extra cost
- Future `lmdb_materialisation(lazy)` codegen populates `WcLookupSources` with `LmdbCursorLookup` → non-kernel WAM predicates use `ILookupSource.Lookup` directly; kernel paths fall back to `WcFfiFacts` (materialise-on-entry for DFS workloads)

## Test plan

- [x] `tests/test_wam_fsharp_target.pl` — 53/53
- [x] `tests/core/test_wam_fsharp_runtime_smoke.pl` — 19/19
- [x] `tests/core/test_wam_fsharp_parser_smoke.pl` — 42/42
- [x] `tests/core/test_wam_fsharp_iso_smoke.pl` — 19/19
- [x] `tests/core/test_wam_fsharp_lmdb_smoke.pl` — 15/15

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_