### PR TITLE
feat(wam-fsharp): two-level L1/L2 cached lookup source

### DIFF
--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -303,6 +303,16 @@ type EagerLookupSource(data: Map<int, int list>) =
         member _.Lookup(key) =
             Map.tryFind key data |> Option.defaultValue []
 
+/// Dictionary-backed eager lookup: O(1) amortized access without the
+/// cost of building an immutable Map. Used when the caller only needs
+/// ILookupSource (not a Map for kernel dispatch).
+type DictLookupSource(data: System.Collections.Generic.Dictionary<int, int list>) =
+    member _.Dict = data
+    interface ILookupSource with
+        member _.Lookup(key) =
+            let ok, vs = data.TryGetValue(key)
+            if ok then vs else []
+
 
 type WamContext =
     { WcCode            : Instruction array    // instruction array (O(1) fetch)
@@ -450,11 +460,18 @@ fsharp_wam_helpers :-
 
 /// Resolve a fact Map for kernel dispatch.  Checks WcLookupSources
 /// first (preferred path after LMDB Phase 2); extracts the inner Map
-/// from EagerLookupSource for zero-cost access.  Falls back to
-/// WcFfiFacts for legacy compatibility.
+/// from EagerLookupSource for zero-cost access, or builds a Map from
+/// DictLookupSource on demand.  Falls back to WcFfiFacts for legacy
+/// compatibility.
 let resolveFactMap (pred: string) (ctx: WamContext) : Map<int, int list> =
     match Map.tryFind pred ctx.WcLookupSources with
     | Some (:? EagerLookupSource as eager) -> eager.Data
+    | Some (:? DictLookupSource as dict) ->
+        // Convert Dictionary to Map for kernel consumption.
+        // One-time cost; callers that only need ILookupSource should
+        // use the Dict path directly for O(1) lookup.
+        dict.Dict |> Seq.fold (fun acc kv ->
+            Map.add kv.Key kv.Value acc) Map.empty
     | Some _ ->
         Map.tryFind pred ctx.WcFfiFacts |> Option.defaultValue Map.empty
     | None ->

--- a/templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache
+++ b/templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache
@@ -172,16 +172,63 @@ let loadDupsortRelationDict (env: LightningEnvironment) (dbName: string)
 /// materialisation cost, but each runtime lookup pays the cursor-open
 /// overhead.  Appropriate when the working set is small relative to
 /// the full database, or when memory is constrained.
-/// Cached decorator over any ILookupSource.  First lookup for a key
-/// delegates to the inner source and memoises the result; subsequent
-/// lookups for the same key return the cached value without touching
-/// the inner source (no cursor open, no LMDB read).
+/// Two-level cached decorator over any ILookupSource.
 ///
-/// Uses ConcurrentDictionary for thread safety (parallel kernels via
-/// runNegationParallel / forkParBranches share the WamContext).
-/// V1 is unbounded; a bounded LRU variant (evicting by recency or
-/// capacity) is a future refinement once benchmark data shows the
-/// cache size matters relative to available memory.
+/// L1: per-thread Dictionary (ThreadLocal) — zero contention, plain
+///     hashtable lookup. Fixed capacity with collision-overwrite
+///     eviction (power-of-two size, hash mod index). Mirrors the
+///     Haskell per-HEC IOArray design. Most useful when work is
+///     grouped by cache hits (e.g. clustered seed batches).
+///
+/// L2: shared ConcurrentDictionary — cross-thread, lock-free CAS.
+///     Bounded by maxL2Entries; once full, new entries are NOT
+///     inserted (read-through to inner source). This prevents
+///     unbounded memory growth on large corpora.
+///
+/// Dispatch: L1 hit -> return.  L1 miss -> L2 hit -> populate L1,
+///           return.  L2 miss -> inner.Lookup -> populate L2 + L1,
+///           return.
+///
+/// Default capacities: L1 = 4096 (per-thread), L2 = 65536 (shared).
+/// Matches Haskell's lmdb_cache_mode(two_level) defaults.
+type TwoLevelCachedLookupSource(inner: WamTypes.ILookupSource,
+                                 ?l1Capacity: int,
+                                 ?maxL2Entries: int) =
+    let l1Cap = defaultArg l1Capacity 4096
+    let l2Max = defaultArg maxL2Entries 65536
+    let l1Mask = l1Cap - 1
+    let l2 = System.Collections.Concurrent.ConcurrentDictionary<int, int list>()
+    let mutable l2Count = 0
+
+    // L1: per-thread fixed-size array of (key, value) slots.
+    // Hash-mod index with collision-overwrite (no chaining).
+    let l1 = new System.Threading.ThreadLocal<_>(fun () ->
+        Array.create l1Cap (struct (System.Int32.MinValue, ([] : int list))))
+
+    interface WamTypes.ILookupSource with
+        member _.Lookup(key: int) : int list =
+            let arr = l1.Value
+            let idx = key &&& l1Mask
+            let struct (k, v) = arr.[idx]
+            if k = key then v  // L1 hit
+            else
+                // L1 miss -> check L2
+                let ok, v2 = l2.TryGetValue(key)
+                if ok then
+                    arr.[idx] <- struct (key, v2)  // populate L1
+                    v2
+                else
+                    // L2 miss -> inner source
+                    let result = inner.Lookup(key)
+                    // Atomic check-and-increment avoids O(n) l2.Count
+                    if System.Threading.Interlocked.Increment(&l2Count) <= l2Max then
+                        l2.TryAdd(key, result) |> ignore
+                    arr.[idx] <- struct (key, result)  // populate L1
+                    result
+
+/// Flat cached decorator (L2 only, unbounded).  Simpler than
+/// TwoLevelCachedLookupSource; appropriate when per-thread locality
+/// doesn't matter and memory is not constrained.
 type CachedLookupSource(inner: WamTypes.ILookupSource) =
     let cache = System.Collections.Concurrent.ConcurrentDictionary<int, int list>()
     interface WamTypes.ILookupSource with

--- a/templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache
+++ b/templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache
@@ -82,21 +82,29 @@ let loadI2S (env: LightningEnvironment) : Map<int, string> =
 
 /// Load a DUPSORT database (e.g. category_parent) into a Map<int, int list>.
 /// Each key may have multiple values (duplicates); all are collected.
+///
+/// Uses a mutable Dictionary + ResizeArray during the cursor scan for
+/// O(1) amortized insert, then converts to immutable Map in one pass.
+/// Previous version used Map.add + list append per entry, which was
+/// O(n log n) with heavy allocation pressure from intermediate Map
+/// nodes — profiling showed this dominated eager load time.
 let loadDupsortRelation (env: LightningEnvironment) (dbName: string) : Map<int, int list> =
     use tx = env.BeginTransaction(TransactionBeginFlags.ReadOnly)
     let db = tx.OpenDatabase(dbName, new DatabaseConfiguration(Flags = DatabaseOpenFlags.DuplicatesSort))
     use cursor = tx.CreateCursor(db)
-    let mutable result : Map<int, int list> = Map.empty
+    let dict = System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<int>>()
     let struct (rc, _, _) = cursor.First()
     if rc = MDBResultCode.Success then
         let addEntry () =
             let struct (_, k, v) = cursor.GetCurrent()
             let key = decodeI32 (k.AsSpan())
             let value = decodeI32 (v.AsSpan())
-            result <-
-                match Map.tryFind key result with
-                | Some vs -> Map.add key (vs @ [value]) result
-                | None    -> Map.add key [value] result
+            let ok, vs = dict.TryGetValue(key)
+            if ok then vs.Add(value)
+            else
+                let vs = System.Collections.Generic.List<int>()
+                vs.Add(value)
+                dict.[key] <- vs
         addEntry ()
         let mutable ok = true
         while ok do
@@ -105,6 +113,10 @@ let loadDupsortRelation (env: LightningEnvironment) (dbName: string) : Map<int, 
                 addEntry ()
             else
                 ok <- false
+    // Single-pass conversion to immutable Map<int, int list>.
+    let mutable result = Map.empty
+    for kv in dict do
+        result <- Map.add kv.Key (Seq.toList kv.Value) result
     result
 
 /// Convenience: load category_parent(child->parents) for WcFfiFacts.
@@ -114,6 +126,42 @@ let loadCategoryParent (env: LightningEnvironment) : Map<int, int list> =
 /// Convenience: load category_child(parent->children) for reverse lookup.
 let loadCategoryChild (env: LightningEnvironment) : Map<int, int list> =
     loadDupsortRelation env "category_child"
+
+/// Load a DUPSORT database directly into a Dictionary (skipping the
+/// Map conversion). Returns O(1) lookup via DictLookupSource. Use
+/// this when the caller only needs ILookupSource access (not a Map
+/// for kernel dispatch that requires Map.tryFind).
+let loadDupsortRelationDict (env: LightningEnvironment) (dbName: string)
+    : System.Collections.Generic.Dictionary<int, int list> =
+    use tx = env.BeginTransaction(TransactionBeginFlags.ReadOnly)
+    let db = tx.OpenDatabase(dbName, new DatabaseConfiguration(Flags = DatabaseOpenFlags.DuplicatesSort))
+    use cursor = tx.CreateCursor(db)
+    let dict = System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<int>>()
+    let struct (rc, _, _) = cursor.First()
+    if rc = MDBResultCode.Success then
+        let addEntry () =
+            let struct (_, k, v) = cursor.GetCurrent()
+            let key = decodeI32 (k.AsSpan())
+            let value = decodeI32 (v.AsSpan())
+            let ok, vs = dict.TryGetValue(key)
+            if ok then vs.Add(value)
+            else
+                let vs = System.Collections.Generic.List<int>()
+                vs.Add(value)
+                dict.[key] <- vs
+        addEntry ()
+        let mutable ok = true
+        while ok do
+            let struct (rc2, _, _) = cursor.Next()
+            if rc2 = MDBResultCode.Success then
+                addEntry ()
+            else
+                ok <- false
+    // Convert List<int> -> int list for F# immutable consumption.
+    let result = System.Collections.Generic.Dictionary<int, int list>()
+    for kv in dict do
+        result.[kv.Key] <- Seq.toList kv.Value
+    result
 
 /// On-demand LMDB cursor lookup — implements ILookupSource from WamTypes.
 /// Each Lookup call opens a short-lived ReadTransaction + cursor, seeks

--- a/tests/core/test_wam_fsharp_lmdb_bench.pl
+++ b/tests/core/test_wam_fsharp_lmdb_bench.pl
@@ -119,6 +119,29 @@ main :-
     swCachedHit.Stop()
     let cachedHitMs = swCachedHit.Elapsed.TotalMilliseconds
 
+    // --- Two-level cache (L1 per-thread + L2 bounded shared) ---
+    let swTwoLevel = Stopwatch.StartNew()
+    let twoLevelSrc = TwoLevelCachedLookupSource(
+                          LmdbCursorLookup(env, \"category_parent\"),
+                          l1Capacity = 4096,
+                          maxL2Entries = 65536) :> WamTypes.ILookupSource
+    let twoLevelLoadMs = swTwoLevel.Elapsed.TotalMilliseconds
+
+    let swTwoLevelQ = Stopwatch.StartNew()
+    let mutable twoLevelTotal = 0
+    for seed in seeds do
+        twoLevelTotal <- twoLevelTotal + List.length (twoLevelSrc.Lookup(seed))
+    swTwoLevelQ.Stop()
+    let twoLevelQueryMs = swTwoLevelQ.Elapsed.TotalMilliseconds
+
+    // Second pass: warm L1+L2
+    let swTwoLevelHit = Stopwatch.StartNew()
+    let mutable twoLevelHitTotal = 0
+    for seed in seeds do
+        twoLevelHitTotal <- twoLevelHitTotal + List.length (twoLevelSrc.Lookup(seed))
+    swTwoLevelHit.Stop()
+    let twoLevelHitMs = swTwoLevelHit.Elapsed.TotalMilliseconds
+
     env.Dispose()
     swTotal.Stop()
 
@@ -131,11 +154,13 @@ main :-
     printfn \"lazy       %7.2f   %8.2f   %8.2f   %d\" lazyLoadMs lazyQueryMs (lazyLoadMs + lazyQueryMs) lazyTotal
     printfn \"cached     %7.2f   %8.2f   %8.2f   %d\" cachedLoadMs cachedQueryMs (cachedLoadMs + cachedQueryMs) cachedTotal
     printfn \"cached-hit %7.2f   %8.2f   %8.2f   %d\" 0.0 cachedHitMs cachedHitMs cachedHitTotal
+    printfn \"2level     %7.2f   %8.2f   %8.2f   %d\" twoLevelLoadMs twoLevelQueryMs (twoLevelLoadMs + twoLevelQueryMs) twoLevelTotal
+    printfn \"2level-hit %7.2f   %8.2f   %8.2f   %d\" 0.0 twoLevelHitMs twoLevelHitMs twoLevelHitTotal
     printfn \"\"
     printfn \"total_wall_ms = %.2f\" swTotal.Elapsed.TotalMilliseconds
 
     // Sanity: all modes should produce same result
-    if dictTotal = eagerTotal && eagerTotal = lazyTotal && lazyTotal = cachedTotal && cachedTotal = cachedHitTotal then
+    if dictTotal = eagerTotal && eagerTotal = lazyTotal && lazyTotal = cachedTotal && cachedTotal = cachedHitTotal && cachedHitTotal = twoLevelTotal && twoLevelTotal = twoLevelHitTotal then
         printfn \"RESULT OK (all modes agree)\"
         0
     else

--- a/tests/core/test_wam_fsharp_lmdb_bench.pl
+++ b/tests/core/test_wam_fsharp_lmdb_bench.pl
@@ -58,7 +58,20 @@ main :-
     // Seeds: all 8000 children (1001..9000)
     let seeds = [| 1001 .. 9000 |]
 
-    // --- Eager mode ---
+    // --- Dict mode (skip Map, O(1) Dictionary) ---
+    let swDict = Stopwatch.StartNew()
+    let dictData = loadDupsortRelationDict env \"category_parent\"
+    let dictLoadMs = swDict.Elapsed.TotalMilliseconds
+    let dictSrc = WamTypes.DictLookupSource(dictData) :> WamTypes.ILookupSource
+
+    let swDictQ = Stopwatch.StartNew()
+    let mutable dictTotal = 0
+    for seed in seeds do
+        dictTotal <- dictTotal + List.length (dictSrc.Lookup(seed))
+    swDictQ.Stop()
+    let dictQueryMs = swDictQ.Elapsed.TotalMilliseconds
+
+    // --- Eager mode (Map) ---
     let swEager = Stopwatch.StartNew()
     let eagerMap = loadCategoryParent env
     let eagerLoadMs = swEager.Elapsed.TotalMilliseconds
@@ -113,6 +126,7 @@ main :-
     printfn \"F# LMDB Benchmark (1000 parents x 8 children = 8000 edges, %d seeds)\" seeds.Length
     printfn \"========================================================================\"
     printfn \"Mode       load_ms   query_ms   total_ms   result\"
+    printfn \"dict       %7.2f   %8.2f   %8.2f   %d\" dictLoadMs dictQueryMs (dictLoadMs + dictQueryMs) dictTotal
     printfn \"eager      %7.2f   %8.2f   %8.2f   %d\" eagerLoadMs eagerQueryMs (eagerLoadMs + eagerQueryMs) eagerTotal
     printfn \"lazy       %7.2f   %8.2f   %8.2f   %d\" lazyLoadMs lazyQueryMs (lazyLoadMs + lazyQueryMs) lazyTotal
     printfn \"cached     %7.2f   %8.2f   %8.2f   %d\" cachedLoadMs cachedQueryMs (cachedLoadMs + cachedQueryMs) cachedTotal
@@ -121,7 +135,7 @@ main :-
     printfn \"total_wall_ms = %.2f\" swTotal.Elapsed.TotalMilliseconds
 
     // Sanity: all modes should produce same result
-    if eagerTotal = lazyTotal && lazyTotal = cachedTotal && cachedTotal = cachedHitTotal then
+    if dictTotal = eagerTotal && eagerTotal = lazyTotal && lazyTotal = cachedTotal && cachedTotal = cachedHitTotal then
         printfn \"RESULT OK (all modes agree)\"
         0
     else

--- a/tests/core/test_wam_fsharp_lmdb_smoke.pl
+++ b/tests/core/test_wam_fsharp_lmdb_smoke.pl
@@ -125,6 +125,12 @@ main :-
     assertTrue \"CachedLookupSource.Lookup(6) cached = [1]\" (cachedSrc.Lookup(6) = [1])
     assertTrue \"CachedLookupSource.Lookup(99) = []\" (cachedSrc.Lookup(99) = [])
 
+    // Test TwoLevelCachedLookupSource (L1 per-thread + L2 bounded).
+    let twoLevelSrc = TwoLevelCachedLookupSource(lazySrc) :> WamTypes.ILookupSource
+    assertTrue \"TwoLevel.Lookup(6) = [1]\" (twoLevelSrc.Lookup(6) = [1])
+    assertTrue \"TwoLevel.Lookup(6) L1 hit = [1]\" (twoLevelSrc.Lookup(6) = [1])
+    assertTrue \"TwoLevel.Lookup(99) = []\" (twoLevelSrc.Lookup(99) = [])
+
     env.Dispose()
 
     printfn \"RESULT %d/%d\" passes (passes + fails)


### PR DESCRIPTION
## Summary

Adds `TwoLevelCachedLookupSource` mirroring Haskell's `lmdb_cache_mode(two_level)` design with per-thread L1 + bounded shared L2.

## Design

| Layer | Backing | Capacity | Contention | Access |
|---|---|---|---|---|
| **L1** | `ThreadLocal<(int * int list) array>` | 4096 (power-of-two) | Zero — per-thread | Hash-mod index, collision-overwrite |
| **L2** | `ConcurrentDictionary<int, int list>` | 65536 (configurable) | Lock-free CAS | `TryGetValue` / `TryAdd` |

**Dispatch**: L1 hit → return. L1 miss → L2 `TryGetValue` → populate L1, return. L2 miss → `inner.Lookup` → populate L2 (if under capacity) + L1, return.

**Capacity bound**: L2 uses `Interlocked.Increment` on an atomic counter for the capacity check. The first implementation used `ConcurrentDictionary.Count` which is O(n) (locks all buckets and sums) — that caused a 115 ms regression on cold pass. The atomic counter brings cold performance in line with the flat cached variant.

## Benchmark results (.NET 8 Release, 8000 edges, 8000 seeds)

| Mode | load_ms | query_ms | total_ms |
|---|---|---|---|
| dict | 11.2 | 1.1 | 12.3 |
| eager (Map) | 18.5 | 5.9 | 24.3 |
| lazy | 0.3 | 12.8 | 13.1 |
| cached (cold) | 1.4 | 20.0 | 21.4 |
| cached (warm) | 0.0 | 1.7 | 1.7 |
| **2level (cold)** | 1.0 | 18.4 | 19.4 |
| **2level (warm)** | **0.0** | **0.76** | **0.76** |

**Two-level warm-hit is 2.2× faster than flat cached-hit** (0.76 ms vs 1.7 ms). The per-thread L1 array avoids `ConcurrentDictionary` overhead on hits. As the user noted, L1 will be most useful when work is grouped by cache hits (clustered seed batches); the current benchmark uses sequential seeds which is the baseline case.

## Test plan

- [x] `tests/core/test_wam_fsharp_lmdb_smoke.pl` — **21/21** (+3 for TwoLevel correctness: first lookup, L1 hit, absent key)
- [x] `tests/core/test_wam_fsharp_lmdb_bench.pl` — all modes agree, 2level + 2level-hit rows added

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_