### PR TITLE
fix(wam-fsharp): lazy LMDB — kernel lookup function + cached default + scale sweep

### DIFF
--- a/src/unifyweaver/bindings/fsharp_wam_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_wam_bindings.pl
@@ -458,18 +458,31 @@ fsharp_wam_helpers :-
 // Helper functions
 // ============================================================================
 
-/// Resolve a fact Map for kernel dispatch.  Checks WcLookupSources
-/// first (preferred path after LMDB Phase 2); extracts the inner Map
-/// from EagerLookupSource for zero-cost access, or builds a Map from
-/// DictLookupSource on demand.  Falls back to WcFfiFacts for legacy
-/// compatibility.
+/// Resolve a fact lookup function for kernel dispatch.  Returns
+/// int -> int list, which kernels call directly instead of
+/// Map.tryFind.  This avoids materialising the entire relation
+/// into a Map — critical for lazy/cached modes at large scale
+/// (enwiki 10M edges: Map.add would take ~140s).
+///
+/// Dispatch order:
+///   1. WcLookupSources (ILookupSource.Lookup — works for eager,
+///      lazy cursor, cached two-level, dict)
+///   2. WcFfiFacts (legacy Map<int, int list> path)
+///   3. empty (returns [] for any key)
+let resolveFactLookup (pred: string) (ctx: WamContext) : (int -> int list) =
+    match Map.tryFind pred ctx.WcLookupSources with
+    | Some src -> src.Lookup
+    | None ->
+        match Map.tryFind pred ctx.WcFfiFacts with
+        | Some factMap -> fun key -> Map.tryFind key factMap |> Option.defaultValue []
+        | None -> fun _ -> []
+
+/// Legacy: resolve a fact Map for callers that still need Map<int, int list>.
+/// Prefer resolveFactLookup for new code.
 let resolveFactMap (pred: string) (ctx: WamContext) : Map<int, int list> =
     match Map.tryFind pred ctx.WcLookupSources with
     | Some (:? EagerLookupSource as eager) -> eager.Data
     | Some (:? DictLookupSource as dict) ->
-        // Convert Dictionary to Map for kernel consumption.
-        // One-time cost; callers that only need ILookupSource should
-        // use the Dict path directly for O(1) lookup.
         dict.Dict |> Seq.fold (fun acc kv ->
             Map.add kv.Key kv.Value acc) Map.empty
     | Some _ ->

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -3526,7 +3526,7 @@ reg_var_name_fs(N, Name) :- format(atom(Name), 'r~w', [N]).
 
 emit_config_let_bindings_fs([]).
 emit_config_let_bindings_fs([config_facts(FactKey)|Rest]) :-
-    format('        let ~w_facts = resolveFactMap "~w" ctx~n',
+    format('        let ~w_facts = resolveFactLookup "~w" ctx~n',
            [FactKey, FactKey]),
     emit_config_let_bindings_fs(Rest).
 emit_config_let_bindings_fs([config_weighted_facts(FactKey)|Rest]) :-
@@ -4652,7 +4652,7 @@ write_wam_fsharp_project(Predicates, Options, ProjectDir) :-
     ->  fsharp_lmdb_template_source(LmdbTemplateCode),
         directory_file_path(ProjectDir, 'LmdbFactSource.fs', LmdbPath),
         write_fs_file(LmdbPath, LmdbTemplateCode),
-        option(lmdb_materialisation(LmdbMode), Options, eager),
+        option(lmdb_materialisation(LmdbMode), Options, cached),
         format(user_error, '[WAM-FSharp] LMDB fact source included (materialisation=~w)~n', [LmdbMode])
     ;   true
     ),

--- a/templates/targets/fsharp_wam/kernel_category_ancestor.fs.mustache
+++ b/templates/targets/fsharp_wam/kernel_category_ancestor.fs.mustache
@@ -1,12 +1,17 @@
 /// Native depth-bounded DFS for the category_ancestor kernel.
 /// Auto-generated from kernel detection. Edge predicate: {{edge_pred}}.
-/// Atoms are interned at the FFI boundary so the hot loop uses Map<int,int list>
-/// with integer comparison instead of string hashing.
+///
+/// Takes a lookup function (int -> int list) instead of a concrete
+/// Map so it works with any ILookupSource implementation: eager Map,
+/// lazy LMDB cursor, or cached two-level.  This avoids materialising
+/// the entire edge relation into a Map at kernel entry, which is
+/// catastrophic at large scale (e.g. enwiki 10M edges → 140s for
+/// Map.add; see WAM_LMDB_LAZY_PHILOSOPHY.md §1).
 let rec nativeKernel_category_ancestor
-    (parents: Map<int, int list>)
+    (lookupParents: int -> int list)
     (cat: int) (root: int) (maxDepth: int)
     (depth: int) (visited: int list) : int list =
-    let directParents = Map.tryFind cat parents |> Option.defaultValue []
+    let directParents = lookupParents cat
     let baseHits = directParents |> List.choose (fun p -> if p = root then Some 1 else None)
     let recHits =
         if depth >= maxDepth then []
@@ -14,6 +19,6 @@ let rec nativeKernel_category_ancestor
             directParents |> List.collect (fun mid ->
                 if List.contains mid visited then []
                 else
-                    nativeKernel_category_ancestor parents mid root maxDepth (depth + 1) (mid :: visited)
+                    nativeKernel_category_ancestor lookupParents mid root maxDepth (depth + 1) (mid :: visited)
                     |> List.map (fun h -> h + 1))
     baseHits @ recHits

--- a/tests/core/test_wam_fsharp_lmdb_scale_sweep.pl
+++ b/tests/core/test_wam_fsharp_lmdb_scale_sweep.pl
@@ -1,0 +1,162 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% test_wam_fsharp_lmdb_scale_sweep.pl - Scale sweep across fixture sizes
+%
+% Runs the LMDB materialisation mode benchmark at multiple fixture sizes
+% to find the lazy↔eager crossover point and measure how each mode
+% scales. Feeds the lmdb_materialisation(auto) cost-model resolver.
+%
+% Prerequisites: python3 + lmdb, .NET 8 SDK, LANG=C.UTF-8
+
+:- encoding(utf8).
+:- use_module('../../src/unifyweaver/targets/wam_fsharp_target',
+              [write_wam_fsharp_project/3]).
+:- use_module(library(filesex), [delete_directory_and_contents/1,
+                                  make_directory_path/1,
+                                  directory_file_path/3]).
+:- use_module(library(process)).
+
+run_cmd(Prog, Args, Dir, ExitCode, OutText) :-
+    setup_call_cleanup(
+        process_create(path(Prog), Args,
+                       [cwd(Dir),
+                        stdout(pipe(Out)),
+                        stderr(pipe(Err)),
+                        process(PID)]),
+        ( read_string(Out, _, OutStr),
+          read_string(Err, _, ErrStr),
+          process_wait(PID, exit(ExitCode)),
+          string_concat(OutStr, ErrStr, OutText)
+        ),
+        ( catch(close(Out), _, true), catch(close(Err), _, true) )).
+
+main :-
+    LmdbDir = '/tmp/uw_fsharp_lmdb_sweep_fixture',
+    ProjectDir = '/tmp/uw_fsharp_lmdb_sweep',
+    catch(delete_directory_and_contents(ProjectDir), _, true),
+
+    %% Build the F# project once (first fixture size).
+    %% Subsequent runs only rewrite Program.fs and do incremental build.
+    Scales = [50, 200, 500, 1000, 2000, 5000],
+    ChildrenPerParent = 8,
+
+    format('~n========================================~n'),
+    format('F# LMDB Scale Sweep (children_per_parent=~w)~n', [ChildrenPerParent]),
+    format('========================================~n~n'),
+    format('~w ~w ~w ~w ~w ~w ~w ~w ~w~n',
+           ['Parents', 'Edges', 'DictLoad', 'DictQ', 'EagerLoad', 'EagerQ',
+            'LazyQ', '2LvlCold', '2LvlWarm']),
+    format('------- ----- -------- ----- --------- ------ ----- -------- --------~n'),
+
+    forall(member(NParents, Scales),
+           run_one_scale(NParents, ChildrenPerParent, LmdbDir, ProjectDir)).
+
+run_one_scale(NParents, CPP, LmdbDir, ProjectDir) :-
+    NEdges is NParents * CPP,
+    FirstChild is NParents + 1,
+    LastChild is NParents + NEdges,
+    atom_number(NParentsA, NParents),
+    atom_number(CPPA, CPP),
+
+    %% Generate fixture
+    catch(delete_directory_and_contents(LmdbDir), _, true),
+    run_cmd(python3,
+            ['examples/benchmark/generate_synthetic_phase1_lmdb.py',
+             LmdbDir, '--parents', NParentsA,
+             '--children-per-parent', CPPA, '--refresh'],
+            '.', PyExit, _),
+    (PyExit == 0 -> true ; format('LMDB gen failed for ~w~n', [NParents]), halt(1)),
+
+    %% Generate or update F# project
+    (   \+ exists_directory(ProjectDir)
+    ->  make_directory_path(ProjectDir),
+        write_wam_fsharp_project([], [no_kernels(true), module_name('uw_fs_lmdb_sweep'), lmdb_path(LmdbDir)], ProjectDir)
+    ;   true
+    ),
+
+    %% Write Program.fs with this fixture's path and seed range
+    atom_string(LmdbDir, LmdbDirStr),
+    atom_number(FirstChildA, FirstChild),
+    atom_number(LastChildA, LastChild),
+    atom_string(FirstChildA, FirstChildS),
+    atom_string(LastChildA, LastChildS),
+
+    string_concat(LmdbDirStr, "\"
+    let env = openEnv lmdbPath
+    let seeds = [| ", Seg1),
+    string_concat(Seg1, FirstChildS, Seg2),
+    string_concat(Seg2, " .. ", Seg3),
+    string_concat(Seg3, LastChildS, Seg4),
+    string_concat(Seg4, " |]
+
+    let sw = Diagnostics.Stopwatch.StartNew()
+    let dictData = loadDupsortRelationDict env \"category_parent\"
+    let dictLoadMs = sw.Elapsed.TotalMilliseconds
+    let dictSrc = WamTypes.DictLookupSource(dictData) :> WamTypes.ILookupSource
+    let swQ = Diagnostics.Stopwatch.StartNew()
+    for seed in seeds do dictSrc.Lookup(seed) |> ignore
+    swQ.Stop()
+    let dictQMs = swQ.Elapsed.TotalMilliseconds
+
+    let sw2 = Diagnostics.Stopwatch.StartNew()
+    let eagerMap = loadCategoryParent env
+    let eagerLoadMs = sw2.Elapsed.TotalMilliseconds
+    let eagerSrc = WamTypes.EagerLookupSource(eagerMap) :> WamTypes.ILookupSource
+    let swQ2 = Diagnostics.Stopwatch.StartNew()
+    for seed in seeds do eagerSrc.Lookup(seed) |> ignore
+    swQ2.Stop()
+    let eagerQMs = swQ2.Elapsed.TotalMilliseconds
+
+    let lazySrc = LmdbCursorLookup(env, \"category_parent\") :> WamTypes.ILookupSource
+    let swQ3 = Diagnostics.Stopwatch.StartNew()
+    for seed in seeds do lazySrc.Lookup(seed) |> ignore
+    swQ3.Stop()
+    let lazyQMs = swQ3.Elapsed.TotalMilliseconds
+
+    let tlSrc = TwoLevelCachedLookupSource(LmdbCursorLookup(env, \"category_parent\")) :> WamTypes.ILookupSource
+    let swQ4 = Diagnostics.Stopwatch.StartNew()
+    for seed in seeds do tlSrc.Lookup(seed) |> ignore
+    swQ4.Stop()
+    let tlColdMs = swQ4.Elapsed.TotalMilliseconds
+    let swQ5 = Diagnostics.Stopwatch.StartNew()
+    for seed in seeds do tlSrc.Lookup(seed) |> ignore
+    swQ5.Stop()
+    let tlWarmMs = swQ5.Elapsed.TotalMilliseconds
+
+    env.Dispose()
+    printfn \"%.1f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f\" (float seeds.Length) dictLoadMs dictQMs eagerLoadMs eagerQMs lazyQMs tlColdMs tlWarmMs
+    0
+", DriverTail),
+    string_concat("module Program
+open System
+open LmdbFactSource
+open WamTypes
+[<EntryPoint>]
+let main _argv =
+    let lmdbPath = \"", DriverTail, DriverCode),
+
+    directory_file_path(ProjectDir, 'Program.fs', ProgPath),
+    open(ProgPath, write, OW, [encoding(utf8)]),
+    write(OW, DriverCode),
+    close(OW),
+
+    %% Build (incremental after first)
+    run_cmd(dotnet, ['build', '--nologo', '-v', 'quiet', '-c', 'Release'],
+            ProjectDir, BuildExit, BuildOut),
+    (   BuildExit == 0 -> true
+    ;   format('BUILD FAILED at ~w parents:~n~w~n', [NParents, BuildOut]), halt(1)
+    ),
+
+    %% Run
+    run_cmd(dotnet, ['run', '--no-build', '-c', 'Release'],
+            ProjectDir, _RunExit, RunOut),
+    %% Parse CSV output line
+    split_string(RunOut, "\n", "\r\n ", Lines),
+    include(\=(""), Lines, NonEmpty),
+    last(NonEmpty, CsvLine),
+    split_string(CsvLine, ",", " ", Fields),
+    (   Fields = [EdgesS, DictLoadS, DictQS, EagerLoadS, EagerQS, LazyQS, TlColdS, TlWarmS]
+    ->  format('~7w ~5w ~8w ~5w ~9w ~6w ~5w ~8w ~8w~n',
+               [NParents, NEdges, DictLoadS, DictQS, EagerLoadS, EagerQS, LazyQS, TlColdS, TlWarmS])
+    ;   format('~7w ~5w  (parse error: ~w)~n', [NParents, NEdges, CsvLine])
+    ).

--- a/tests/core/test_wam_fsharp_lmdb_scale_sweep.pl
+++ b/tests/core/test_wam_fsharp_lmdb_scale_sweep.pl
@@ -41,7 +41,7 @@ main :-
     ChildrenPerParent = 8,
 
     format('~n========================================~n'),
-    format('F# LMDB Scale Sweep (children_per_parent=~w)~n', [ChildrenPerParent]),
+    format('F# LMDB Scale Sweep — FULL demand (all edges queried)~n'),
     format('========================================~n~n'),
     format('~w ~w ~w ~w ~w ~w ~w ~w ~w~n',
            ['Parents', 'Edges', 'DictLoad', 'DictQ', 'EagerLoad', 'EagerQ',
@@ -49,12 +49,39 @@ main :-
     format('------- ----- -------- ----- --------- ------ ----- -------- --------~n'),
 
     forall(member(NParents, Scales),
-           run_one_scale(NParents, ChildrenPerParent, LmdbDir, ProjectDir)).
+           run_one_scale(NParents, ChildrenPerParent, LmdbDir, ProjectDir, full)),
 
-run_one_scale(NParents, CPP, LmdbDir, ProjectDir) :-
+    format('~n========================================~n'),
+    format('F# LMDB Scale Sweep — PARTIAL demand (100 seeds, varying graph)~n'),
+    format('This shows the lazy/cached advantage at large scale.~n'),
+    format('========================================~n~n'),
+    format('~w ~w ~w ~w ~w ~w ~w ~w ~w~n',
+           ['Parents', 'Edges', 'DictLoad', 'DictQ', 'EagerLoad', 'EagerQ',
+            'LazyQ', '2LvlCold', '2LvlWarm']),
+    format('------- ----- -------- ----- --------- ------ ----- -------- --------~n'),
+
+    forall(member(NParents, Scales),
+           run_one_scale(NParents, ChildrenPerParent, LmdbDir, ProjectDir, partial)).
+
+run_one_scale(NParents, CPP, LmdbDir, ProjectDir, DemandMode) :-
     NEdges is NParents * CPP,
     FirstChild is NParents + 1,
-    LastChild is NParents + NEdges,
+    (   DemandMode = full
+    ->  LastChild is NParents + NEdges
+    ;   % partial: query only 100 seeds from the middle of the range
+        NSeedsPartial is min(100, NEdges),
+        MidStart is NParents + 1 + (NEdges - NSeedsPartial) // 2,
+        FirstChild2 is MidStart,
+        LastChild is FirstChild2 + NSeedsPartial - 1
+    ),
+    (   DemandMode = partial, NEdges >= 100
+    ->  true  % use partial range
+    ;   true
+    ),
+    (   DemandMode = partial
+    ->  SeedFirst = FirstChild2
+    ;   SeedFirst = FirstChild
+    ),
     atom_number(NParentsA, NParents),
     atom_number(CPPA, CPP),
 
@@ -76,7 +103,7 @@ run_one_scale(NParents, CPP, LmdbDir, ProjectDir) :-
 
     %% Write Program.fs with this fixture's path and seed range
     atom_string(LmdbDir, LmdbDirStr),
-    atom_number(FirstChildA, FirstChild),
+    atom_number(FirstChildA, SeedFirst),
     atom_number(LastChildA, LastChild),
     atom_string(FirstChildA, FirstChildS),
     atom_string(LastChildA, LastChildS),


### PR DESCRIPTION
## Summary

Fixes F#'s LMDB architecture so lazy/cached modes work correctly at scale, motivated by profiling that revealed the same problem Rust had at enwiki: eager materialisation dominates total time when the query touches a small fraction of the graph.

Three commits:

1. **`f508e7e` bench**: Scale sweep at 400-40k edges (full demand)
2. **`420cbd2` bench**: Partial-demand sweep (100 seeds, varying graph) — shows the real lazy advantage
3. **`981444c` fix**: Kernel accepts lookup function, default changed to cached

## The problem

The F# kernel template took `Map<int, int list>` as its edge-lookup parameter. At kernel entry, `resolveFactMap` materialised the entire relation into a Map — even for lazy/cached modes. This defeated the purpose of lazy mode:

- At 40k edges with 100 seeds: **eager Map 137 ms** (136 ms materialising edges the query never touches + 1.5 ms query)
- This matches the Rust enwiki pattern from `WAM_LMDB_LAZY_PHILOSOPHY.md` §1: Rust eager paid 140s to build `Vec<(String, String)>` for 10M edges before any kernel work

## The fix

**Kernel template** (`kernel_category_ancestor.fs.mustache`):
```fsharp
// Before: takes Map, does Map.tryFind
let rec nativeKernel_category_ancestor (parents: Map<int, int list>) ...
    let directParents = Map.tryFind cat parents |> Option.defaultValue []

// After: takes lookup function, works with any ILookupSource
let rec nativeKernel_category_ancestor (lookupParents: int -> int list) ...
    let directParents = lookupParents cat
```

**`resolveFactLookup`** (new helper): returns `int -> int list` dispatching through `ILookupSource.Lookup` or `WcFfiFacts`. Kernel codegen uses this instead of `resolveFactMap`. No materialisation step.

**Default mode**: `lmdb_materialisation` default changed from `eager` to `cached` (two-level L1/L2). Cached gives the best tradeoff at any scale: zero startup, sub-ms warm hits, bounded memory.

## Scale sweep results (100 seeds, .NET 8 Release)

| Edges | Eager Map (ms) | Dict (ms) | Lazy (ms) | 2Lvl warm (ms) |
|---|---|---|---|---|
| 400 | 7.6 | 7.2 | 1.3 | 0.01 |
| 4,000 | 14.4 | 9.3 | 1.5 | 0.01 |
| 8,000 | 21.7 | 10.8 | 1.4 | 0.01 |
| 40,000 | **137.5** | 31.5 | **1.6** | **0.01** |

**Lazy is 86× faster than eager Map** at 40k edges with partial demand. This matches the Haskell-vs-Rust reversal: when materialisation cost M >> query cost N×p, lazy wins by orders of magnitude.

## Test plan

- [x] `tests/test_wam_fsharp_target.pl` — 53/53
- [x] `tests/core/test_wam_fsharp_runtime_smoke.pl` — 19/19
- [x] `tests/core/test_wam_fsharp_lmdb_smoke.pl` — 21/21
- [x] `tests/core/test_wam_fsharp_lmdb_bench.pl` — all modes agree
- [x] `tests/core/test_wam_fsharp_lmdb_scale_sweep.pl` — full + partial demand sweeps

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_