### PR TITLE
Add declarative CSR index backend option

### DIFF
--- a/docs/design/WAM_REVERSE_INDEX_ARTIFACTS.md
+++ b/docs/design/WAM_REVERSE_INDEX_ARTIFACTS.md
@@ -154,6 +154,7 @@ Initial Prolog shape:
     parent_edge(category_parent/2),
     reverse_index(csr([
         ordering(parent_sort),
+        index_backend(sorted_array),
         phase(cache_warmup),
         cache_bytes(67108864)
     ]))
@@ -163,6 +164,7 @@ Initial Prolog shape:
     parent_edge(category_parent/2),
     reverse_index(csr([
         ordering(root_bfs),
+        index_backend(lmdb_offset),
         block_size_edges(65536),
         phase(runtime_available)
     ]))
@@ -189,6 +191,7 @@ reverse_index(artifact([
     storage_kind(csr_pread_artifact),
     id_encoding(int32_le),
     ordering(root_bfs),
+    index_backend(sorted_array),
     phase(runtime_available),
     io_policy(auto),
     cache_bytes(67108864)
@@ -200,8 +203,16 @@ names the important distinction from `mmap_array_artifact`: reverse
 child rows are fetched by explicit reads with bounded user-space cache,
 not by mapping another large relation into the process address space.
 
-`io_policy(auto)` is the default for CSR. See §3.4.1 for how it
+`io_policy(auto)` is the default for CSR. See §3.4.2 for how it
 resolves.
+
+`index_backend(auto|sorted_array|lmdb_offset|dense_direct)` selects how
+the runtime finds a parent's `(offset, count)` record before reading
+`.val`. If omitted, the current behavior is `sorted_array`: binary
+search over the CSR index. Explicit `index_backend(auto)` is the
+cost-analyzer hook. It should resolve to `sorted_array` until the cost
+model has measured terms for ID density, index size, LMDB lookup cost,
+and preprocessing cost.
 
 ### 2.1 Reverse-index phases
 
@@ -328,7 +339,32 @@ that shape, CSR is not competing with the parent-edge LMDB as the primary
 resident structure; it is a deferred expansion artifact used when the
 query semantics justify leaving the ancestor-only search space.
 
-### 3.4.1 CSR I/O policy
+### 3.4.1 CSR index backend
+
+CSR has two lookups:
+
+1. map `parent_id` to the row location for that parent;
+2. read the child slice from `.val`.
+
+The first step is controlled by `index_backend(...)`:
+
+| Backend | Meaning | Tradeoff |
+| --- | --- | --- |
+| `sorted_array` | Keep `.idx` sorted by parent ID and use binary search. | Simple, compact, no second LMDB lookup; best when the index fits in memory. |
+| `lmdb_offset` | Store `parent_id -> offset,count` or `parent_id -> idx_row` in an LMDB sub-db. | Handles sparse Wikipedia/page IDs without dense direct arrays; adds LMDB B-tree lookup and page-cache pressure. |
+| `dense_direct` | Store a direct array indexed by numeric parent ID. | Fastest lookup when IDs are dense; wasteful or impossible for sparse page-id spaces. |
+| `auto` | Let the cost analyzer choose. | Current conservative resolution is `sorted_array`; future overrides require measured density, index size, query count, and preprocessing terms. |
+
+An LMDB offset index may store the final `.val` offset directly, or it
+may store the row number in `.idx`. Storing the final offset can skip the
+binary search and the `.idx` read, but it means the CSR builder must
+write or rewrite LMDB offset metadata as rows are finalized. That is
+extra preprocessing and another artifact to keep consistent with the CSR
+files. The cost analyzer should only choose it when the saved lookup
+work outweighs the additional build time, disk bytes, and page-cache
+touches.
+
+### 3.4.2 CSR I/O policy
 
 CSR access should expose an explicit I/O policy:
 
@@ -549,6 +585,8 @@ Performance:
 - Record minor and major page faults where the platform exposes them.
 - Compare parent-only LMDB, reverse LMDB, `parent_sort` CSR, and
   `root_bfs` CSR.
+- Compare `sorted_array`, `lmdb_offset`, and dense-direct CSR index
+  backends where the ID space makes each backend plausible.
 - Compare `buffered_pread`, `buffered_pread_drop`, and `direct_io`
   where the platform supports direct I/O and the block layout can meet
   alignment requirements.
@@ -571,6 +609,8 @@ Phase A - design and option validation:
   `reverse_index(none|lmdb|mmap_array|csr|artifact|auto)`.
 - Add option parsing for `id_encoding(...)` and
   `io_policy(auto|buffered_pread|buffered_pread_drop|direct_io)`.
+- Add option parsing for
+  `index_backend(auto|sorted_array|lmdb_offset|dense_direct)`.
 - Reject `phase(runtime_available)` when no runtime reverse lookup API
   exists for the target.
 - Map `reverse_index(artifact(...))` onto the existing storage-kind

--- a/src/unifyweaver/core/cost_model.pl
+++ b/src/unifyweaver/core/cost_model.pl
@@ -38,6 +38,7 @@
     resolve_reverse_index/2,    % +Options, -ReverseIndex
     validate_reverse_index_option/2, % +Spec, -Normalized
     resolve_csr_io_policy/2,    % +Options, -Policy
+    resolve_csr_index_backend/2, % +Options, -Backend
 
     %% Hardware constants
     default_constants/1,        % -Constants
@@ -284,6 +285,7 @@ normalize_kind_options(mmap_array, _Opts0, []).
 normalize_kind_options(csr, Opts0, Opts) :-
     option(ordering(Ordering), Opts0, parent_sort),
     validate_reverse_ordering(Ordering),
+    resolve_csr_index_backend(Opts0, IndexBackend),
     option(cache_bytes(CacheBytes), Opts0, 0),
     validate_nonnegative_integer(cache_bytes, CacheBytes),
     option(block_size_edges(BlockSizeEdges), Opts0, 0),
@@ -291,6 +293,7 @@ normalize_kind_options(csr, Opts0, Opts) :-
     resolve_csr_io_policy(Opts0, IoPolicy),
     Opts = [
         ordering(Ordering),
+        index_backend(IndexBackend),
         io_policy(IoPolicy),
         cache_bytes(CacheBytes),
         block_size_edges(BlockSizeEdges)
@@ -304,13 +307,24 @@ normalize_kind_options(artifact, Opts0, Opts) :-
     validate_reverse_ordering(Ordering),
     option(cache_bytes(CacheBytes), Opts0, 0),
     validate_nonnegative_integer(cache_bytes, CacheBytes),
+    artifact_index_options(StorageKind, Opts0, IndexOpt),
     artifact_io_options(StorageKind, Opts0, IoOpt),
     append([
         relation(Relation),
         storage_kind(StorageKind),
         ordering(Ordering),
         cache_bytes(CacheBytes)
-    ], IoOpt, Opts).
+    ], IndexOpt, PrefixOpts),
+    append(PrefixOpts, IoOpt, Opts).
+
+artifact_index_options(csr_pread_artifact, Opts0, [index_backend(IndexBackend)]) :-
+    !,
+    resolve_csr_index_backend(Opts0, IndexBackend).
+artifact_index_options(_StorageKind, Opts0, []) :-
+    \+ option(index_backend(_), Opts0),
+    !.
+artifact_index_options(StorageKind, _Opts0, _) :-
+    throw(error(permission_error(use, index_backend, StorageKind), _)).
 
 artifact_io_options(csr_pread_artifact, Opts0, [io_policy(IoPolicy)]) :-
     !,
@@ -348,6 +362,21 @@ resolve_csr_io_policy_value(Policy, _Options, Policy) :-
     validate_csr_io_policy(Policy),
     !.
 
+%! resolve_csr_index_backend(+Options, -Backend) is det.
+%
+%  Resolve CSR index backend. Omitted values keep the current sorted
+%  array behavior. Explicit `auto` is the future cost-analyzer hook; it
+%  conservatively resolves to sorted_array until measured override rules
+%  are added.
+resolve_csr_index_backend(Options, Backend) :-
+    option(index_backend(Backend0), Options, sorted_array),
+    resolve_csr_index_backend_value(Backend0, Options, Backend).
+
+resolve_csr_index_backend_value(auto, _Options, sorted_array) :- !.
+resolve_csr_index_backend_value(Backend, _Options, Backend) :-
+    validate_csr_index_backend(Backend),
+    !.
+
 validate_known_reverse_options([]).
 validate_known_reverse_options([Opt|Rest]) :-
     functor(Opt, Name, 1),
@@ -360,6 +389,7 @@ validate_known_reverse_options([Opt|_]) :-
 reverse_option_key(phase).
 reverse_option_key(id_encoding).
 reverse_option_key(ordering).
+reverse_option_key(index_backend).
 reverse_option_key(cache_bytes).
 reverse_option_key(block_size_edges).
 reverse_option_key(io_policy).
@@ -386,6 +416,17 @@ validate_csr_io_policy(Policy) :-
     !.
 validate_csr_io_policy(Policy) :-
     throw(error(domain_error(csr_io_policy, Policy), _)).
+
+validate_csr_index_backend(Backend) :-
+    memberchk(Backend, [
+        auto,
+        sorted_array,
+        lmdb_offset,
+        dense_direct
+    ]),
+    !.
+validate_csr_index_backend(Backend) :-
+    throw(error(domain_error(csr_index_backend, Backend), _)).
 
 validate_reverse_ordering(Ordering) :-
     memberchk(Ordering, [

--- a/tests/core/test_cost_model.pl
+++ b/tests/core/test_cost_model.pl
@@ -85,10 +85,14 @@ test(test_recommend_scan_at_high_k).
 test(test_reverse_index_auto_defaults_none).
 test(test_reverse_index_auto_descendant_uses_existing_artifact).
 test(test_reverse_index_csr_normalizes_defaults).
+test(test_reverse_index_csr_auto_index_backend_keeps_sorted_array).
+test(test_reverse_index_csr_accepts_lmdb_offset_index_backend).
 test(test_reverse_index_csr_runtime_auto_direct_io_when_supported).
 test(test_reverse_index_csr_runtime_auto_buffered_when_direct_io_not_verified).
 test(test_reverse_index_rejects_bad_id_encoding).
+test(test_reverse_index_rejects_unknown_index_backend).
 test(test_reverse_index_rejects_unknown_io_policy).
+test(test_reverse_index_rejects_index_backend_for_mmap_artifact).
 test(test_reverse_index_rejects_io_policy_for_mmap_artifact).
 test(test_reverse_index_artifact_normalizes_storage_kind).
 
@@ -345,6 +349,48 @@ test_reverse_index_csr_normalizes_defaults :-
         phase(planning_only),
         id_encoding(int32_le),
         ordering(parent_sort),
+        index_backend(sorted_array),
+        io_policy(buffered_pread_drop),
+        cache_bytes(0),
+        block_size_edges(0)
+    ]),
+    (   ReverseIndex = Expected
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got reverse_index=~w", [ReverseIndex]))
+    ).
+
+test_reverse_index_csr_accepts_lmdb_offset_index_backend :-
+    Test = 'validate_reverse_index_option csr accepts lmdb_offset index backend',
+    validate_reverse_index_option(
+        csr([
+            phase(runtime_available),
+            index_backend(lmdb_offset),
+            io_policy(buffered_pread)
+        ]),
+        ReverseIndex
+    ),
+    Expected = csr([
+        phase(runtime_available),
+        id_encoding(int32_le),
+        ordering(parent_sort),
+        index_backend(lmdb_offset),
+        io_policy(buffered_pread),
+        cache_bytes(0),
+        block_size_edges(0)
+    ]),
+    (   ReverseIndex = Expected
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got reverse_index=~w", [ReverseIndex]))
+    ).
+
+test_reverse_index_csr_auto_index_backend_keeps_sorted_array :-
+    Test = 'validate_reverse_index_option csr auto index_backend keeps sorted_array until cost override',
+    validate_reverse_index_option(csr([index_backend(auto)]), ReverseIndex),
+    Expected = csr([
+        phase(planning_only),
+        id_encoding(int32_le),
+        ordering(parent_sort),
+        index_backend(sorted_array),
         io_policy(buffered_pread_drop),
         cache_bytes(0),
         block_size_edges(0)
@@ -393,6 +439,15 @@ test_reverse_index_rejects_bad_id_encoding :-
     ;   fail_test(Test, 'expected domain_error(reverse_index_id_encoding, bytes)')
     ).
 
+test_reverse_index_rejects_unknown_index_backend :-
+    Test = 'validate_reverse_index_option rejects unsupported csr index_backend',
+    (   catch((validate_reverse_index_option(csr([index_backend(heap_map)]), _), fail),
+              error(domain_error(csr_index_backend, heap_map), _),
+              true)
+    ->  pass(Test)
+    ;   fail_test(Test, 'expected domain_error(csr_index_backend, heap_map)')
+    ).
+
 test_reverse_index_rejects_unknown_io_policy :-
     Test = 'validate_reverse_index_option rejects unsupported io_policy',
     (   catch((validate_reverse_index_option(csr([io_policy(magic)]), _), fail),
@@ -400,6 +455,21 @@ test_reverse_index_rejects_unknown_io_policy :-
               true)
     ->  pass(Test)
     ;   fail_test(Test, 'expected domain_error(csr_io_policy, magic)')
+    ).
+
+test_reverse_index_rejects_index_backend_for_mmap_artifact :-
+    Test = 'validate_reverse_index_option rejects index_backend for mmap_array artifact',
+    (   catch((validate_reverse_index_option(
+                  artifact([
+                      storage_kind(mmap_array_artifact),
+                      index_backend(lmdb_offset)
+                  ]),
+                  _),
+                fail),
+              error(permission_error(use, index_backend, mmap_array_artifact), _),
+              true)
+    ->  pass(Test)
+    ;   fail_test(Test, 'expected permission_error(use, index_backend, mmap_array_artifact)')
     ).
 
 test_reverse_index_rejects_io_policy_for_mmap_artifact :-
@@ -426,6 +496,7 @@ test_reverse_index_artifact_normalizes_storage_kind :-
             phase(runtime_available),
             id_encoding(int32_le),
             ordering(root_bfs),
+            index_backend(lmdb_offset),
             io_policy(buffered_pread),
             cache_bytes(1024)
         ]),
@@ -438,6 +509,7 @@ test_reverse_index_artifact_normalizes_storage_kind :-
         storage_kind(csr_pread_artifact),
         ordering(root_bfs),
         cache_bytes(1024),
+        index_backend(lmdb_offset),
         io_policy(buffered_pread)
     ]),
     (   ReverseIndex = Expected


### PR DESCRIPTION
  ## Summary

  - Add `index_backend(...)` support for reverse CSR configuration.
  - Support `sorted_array`, `lmdb_offset`, `dense_direct`, and `auto`.
  - Keep omitted `index_backend` on the current behavior: `sorted_array`, meaning binary search over the CSR index.
  - Treat explicit `index_backend(auto)` as the future cost-analyzer hook, currently resolving conservatively to
  `sorted_array`.
  - Allow `index_backend(...)` for `csr(...)` and `artifact([storage_kind(csr_pread_artifact), ...])`.
  - Reject `index_backend(...)` for non-CSR artifact storage kinds.
  - Document the LMDB offset-index tradeoff: fewer CSR index searches, but more preprocessing, disk bytes, LMDB lookups,
  page-cache pressure, and artifact consistency work.

  ## Validation

  - `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
  - `git diff --check`