### PR TITLE
Benchmark reverse CSR LMDB offset index

### DIFF
--- a/docs/reports/reverse_csr_lookup_synthetic.md
+++ b/docs/reports/reverse_csr_lookup_synthetic.md
@@ -19,6 +19,7 @@ python3 examples/benchmark/benchmark_reverse_csr_lookup.py \
   "$tmpdir/phase1.lmdb" \
   --csr-dir "$tmpdir/csr" \
   --parent-lmdb-dir "$tmpdir/parent_only.lmdb" \
+  --csr-index-backends sorted_array,lmdb_offset \
   --sample-parents 1000 \
   --iterations 5 \
   --seed 7
@@ -26,10 +27,11 @@ python3 examples/benchmark/benchmark_reverse_csr_lookup.py \
 
 ## Result
 
-| backend | sample_parents | iterations | total_children | median_ms | min_ms | max_ms | csr_artifact_bytes | parent_lmdb_env_bytes | phase1_lmdb_env_bytes |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| csr | 1000 | 5 | 8000 | 3.136484 | 3.076236 | 3.269940 | 480780 | 1507328 | 4579328 |
-| lmdb | 1000 | 5 | 8000 | 3.525135 | 3.490397 | 3.926229 | 480780 | 1507328 | 4579328 |
+| backend | index_backend | sample_parents | iterations | total_children | median_ms | min_ms | max_ms | csr_artifact_bytes | csr_build_seconds | offset_index_bytes | parent_lmdb_env_bytes | phase1_lmdb_env_bytes |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| csr_sorted_array | sorted_array | 1000 | 5 | 8000 | 3.413093 | 3.299319 | 3.427612 | 481020 | 0.060911 | 0 | 1507328 | 4579328 |
+| csr_lmdb_offset | lmdb_offset | 1000 | 5 | 8000 | 2.649246 | 2.543666 | 2.820476 | 943906 | 0.075248 | 454656 | 1507328 | 4579328 |
+| lmdb | n/a | 1000 | 5 | 8000 | 3.514109 | 3.445555 | 3.775466 | 481020 | 0.060911 | 0 | 1507328 | 4579328 |
 
 `phase1_lmdb_env_bytes` is the size of the whole Phase 1 LMDB
 environment file (`data.mdb`), not the size of only the parent-edge or
@@ -55,6 +57,14 @@ only when memory budget allows, and that in-memory representation should
 preserve the compact typed-array / CSR shape rather than expanding into
 Python-style object lists.
 
+The `lmdb_offset` CSR index backend is slightly faster than binary
+search over the sorted `.idx` file in this run, but it pays for that with
+extra preprocessing and bytes: build time rises from 0.060911s to
+0.075248s, and artifact size rises from 481020 bytes to 943906 bytes.
+That is the cost-analyzer tradeoff. At Wikipedia scale, the sorted CSR
+index is expected to fit in memory, so lookup savings must be large
+enough to justify the additional LMDB offset artifact and build work.
+
 The original Python CSR reader was slower than LMDB lookup because every
 lookup opened, sought, and read from the values file. The reader now
 keeps the values file open across lookup batches, which makes this
@@ -63,6 +73,6 @@ synthetic fixture measure positional lookup cost more directly.
 The next optimization target is therefore no longer file-handle churn:
 
 - optionally cache recently used child slices or blocks;
-- compare parent-edge-only LMDB memory pressure against CSR residency;
+- sweep CSR index backends across larger scales and fanout shapes;
 - then consider WAM runtime integration for workloads that need deferred
   child expansion.

--- a/examples/benchmark/benchmark_reverse_csr_lookup.py
+++ b/examples/benchmark/benchmark_reverse_csr_lookup.py
@@ -13,6 +13,7 @@ both backends. It is a measurement hook, not runtime integration.
 from __future__ import annotations
 
 import argparse
+import json
 import random
 import shutil
 import statistics
@@ -45,6 +46,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("phase1_lmdb_dir", type=Path)
     parser.add_argument("--csr-dir", type=Path, default=None, help="existing or output CSR artifact directory")
     parser.add_argument("--refresh-csr", action="store_true", help="rebuild CSR artifact when --csr-dir exists")
+    parser.add_argument(
+        "--csr-index-backends",
+        default="sorted_array",
+        help="comma-separated CSR index backends to benchmark: sorted_array,lmdb_offset",
+    )
     parser.add_argument(
         "--parent-lmdb-dir",
         type=Path,
@@ -101,10 +107,28 @@ class LmdbCategoryChildLookup:
         return sorted(children)
 
 
-def ensure_csr_artifact(phase1_lmdb_dir: Path, csr_dir: Path, refresh: bool) -> None:
+def parse_csr_index_backends(value: str) -> list[str]:
+    backends = [part.strip() for part in value.split(",") if part.strip()]
+    if not backends:
+        raise ValueError("--csr-index-backends must list at least one backend")
+    allowed = {"sorted_array", "lmdb_offset"}
+    unknown = sorted(set(backends) - allowed)
+    if unknown:
+        raise ValueError(f"unsupported CSR index backend(s): {', '.join(unknown)}")
+    return backends
+
+
+def ensure_csr_artifact(phase1_lmdb_dir: Path, csr_dir: Path, refresh: bool, index_backend: str) -> None:
     if csr_dir.exists() and not refresh:
         return
-    command = [sys.executable, str(BUILDER), str(phase1_lmdb_dir), str(csr_dir)]
+    command = [
+        sys.executable,
+        str(BUILDER),
+        str(phase1_lmdb_dir),
+        str(csr_dir),
+        "--index-backend",
+        index_backend,
+    ]
     if refresh:
         command.append("--refresh")
     result = subprocess.run(
@@ -186,12 +210,17 @@ def time_lookup_loop(label: str, lookup, parent_ids: list[int], iterations: int)
 
 
 def artifact_bytes(path: Path) -> int:
-    return sum(p.stat().st_size for p in path.iterdir() if p.is_file())
+    return sum(p.stat().st_size for p in path.rglob("*") if p.is_file())
+
+
+def csr_manifest(path: Path) -> dict:
+    return json.loads((path / "category_child.csr.meta").read_text(encoding="utf-8"))
 
 
 def print_tsv(rows: list[dict[str, str]]) -> None:
     headers = [
         "backend",
+        "index_backend",
         "sample_parents",
         "iterations",
         "total_children",
@@ -199,6 +228,8 @@ def print_tsv(rows: list[dict[str, str]]) -> None:
         "min_ms",
         "max_ms",
         "csr_artifact_bytes",
+        "csr_build_seconds",
+        "offset_index_bytes",
         "parent_lmdb_env_bytes",
         "phase1_lmdb_env_bytes",
     ]
@@ -212,6 +243,11 @@ def main(argv: list[str] | None = None) -> int:
     phase1_lmdb_dir: Path = args.phase1_lmdb_dir
     if not (phase1_lmdb_dir / "data.mdb").exists():
         sys.stderr.write(f"missing {phase1_lmdb_dir}/data.mdb\n")
+        return 2
+    try:
+        csr_index_backends = parse_csr_index_backends(args.csr_index_backends)
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
         return 2
 
     temp_dir: tempfile.TemporaryDirectory[str] | None = None
@@ -231,11 +267,17 @@ def main(argv: list[str] | None = None) -> int:
         if temp_dir is None:
             temp_dir = tempfile.TemporaryDirectory()
         parent_lmdb_dir = Path(temp_dir.name) / "category_parent_only.lmdb"
+    csr_dirs = {
+        index_backend: csr_dir if len(csr_index_backends) == 1 else csr_dir / index_backend
+        for index_backend in csr_index_backends
+    }
 
     try:
-        ensure_csr_artifact(phase1_lmdb_dir, csr_dir, refresh_csr)
+        for index_backend, one_csr_dir in csr_dirs.items():
+            ensure_csr_artifact(phase1_lmdb_dir, one_csr_dir, refresh_csr, index_backend)
         ensure_parent_only_lmdb(phase1_lmdb_dir, parent_lmdb_dir, refresh_parent_lmdb)
-        with ReverseCsrArtifact(csr_dir) as csr:
+        csrs = {index_backend: ReverseCsrArtifact(one_csr_dir) for index_backend, one_csr_dir in csr_dirs.items()}
+        try:
             lmdb_lookup = LmdbCategoryChildLookup(phase1_lmdb_dir)
             try:
                 parent_ids = sample_parent_ids(lmdb_lookup.parents(), args.sample_parents, args.seed)
@@ -244,30 +286,42 @@ def main(argv: list[str] | None = None) -> int:
                     return 4
 
                 for parent in parent_ids:
-                    csr_children = csr.lookup(parent)
                     lmdb_children = lmdb_lookup.lookup(parent)
-                    if csr_children != lmdb_children:
-                        sys.stderr.write(
-                            f"parity mismatch for parent={parent}: "
-                            f"csr={csr_children[:10]} lmdb={lmdb_children[:10]}\n"
-                        )
-                        return 5
+                    for index_backend, csr in csrs.items():
+                        csr_children = csr.lookup(parent)
+                        if csr_children != lmdb_children:
+                            sys.stderr.write(
+                                f"parity mismatch for parent={parent} index_backend={index_backend}: "
+                                f"csr={csr_children[:10]} lmdb={lmdb_children[:10]}\n"
+                            )
+                            return 5
 
-                timed = [
-                    time_lookup_loop("csr", csr.lookup, parent_ids, args.iterations),
-                    time_lookup_loop("lmdb", lmdb_lookup.lookup, parent_ids, args.iterations),
-                ]
+                timed = []
+                for index_backend, csr in csrs.items():
+                    timed.append((
+                        index_backend,
+                        *time_lookup_loop(f"csr_{index_backend}", csr.lookup, parent_ids, args.iterations),
+                    ))
+                timed.append((
+                    "n/a",
+                    *time_lookup_loop("lmdb", lmdb_lookup.lookup, parent_ids, args.iterations),
+                ))
                 rows: list[dict[str, str]] = []
-                for backend, times_ms, total_children in timed:
+                for index_backend, backend, times_ms, total_children in timed:
+                    one_csr_dir = csr_dirs[csr_index_backends[0]] if index_backend == "n/a" else csr_dirs[index_backend]
+                    manifest = csr_manifest(one_csr_dir)
                     rows.append({
                         "backend": backend,
+                        "index_backend": index_backend,
                         "sample_parents": str(len(parent_ids)),
                         "iterations": str(args.iterations),
                         "total_children": str(total_children),
                         "median_ms": f"{statistics.median(times_ms):.6f}",
                         "min_ms": f"{min(times_ms):.6f}",
                         "max_ms": f"{max(times_ms):.6f}",
-                        "csr_artifact_bytes": str(artifact_bytes(csr_dir)),
+                        "csr_artifact_bytes": str(artifact_bytes(one_csr_dir)),
+                        "csr_build_seconds": f"{manifest['build']['elapsed_seconds']:.6f}",
+                        "offset_index_bytes": str(manifest.get("offset_index_bytes", 0)),
                         "parent_lmdb_env_bytes": str((parent_lmdb_dir / "data.mdb").stat().st_size),
                         "phase1_lmdb_env_bytes": str((phase1_lmdb_dir / "data.mdb").stat().st_size),
                     })
@@ -275,6 +329,9 @@ def main(argv: list[str] | None = None) -> int:
                 return 0
             finally:
                 lmdb_lookup.close()
+        finally:
+            for csr in csrs.values():
+                csr.close()
     finally:
         if temp_dir is not None:
             temp_dir.cleanup()

--- a/examples/benchmark/build_reverse_csr_artifact.py
+++ b/examples/benchmark/build_reverse_csr_artifact.py
@@ -11,6 +11,7 @@ Input:
 Output:
   category_child.csr.idx   records: int32 parent, uint64 offset_edges, uint32 count
   category_child.csr.val   records: int32 child
+  category_child.csr.offsets.lmdb optional parent -> offset/count lookup
   category_child.csr.meta  JSON manifest
 
 The output relation is category_child(parent, child). The prototype is
@@ -37,6 +38,7 @@ except ImportError:
 
 
 IDX_RECORD = struct.Struct("<iQI")
+OFFSET_RECORD = struct.Struct("<QI")
 I32 = struct.Struct("<i")
 
 
@@ -47,6 +49,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("phase1_lmdb_dir", type=Path)
     parser.add_argument("out_dir", type=Path)
     parser.add_argument("--refresh", action="store_true", help="replace an existing output directory")
+    parser.add_argument(
+        "--index-backend",
+        choices=["sorted_array", "lmdb_offset"],
+        default="sorted_array",
+        help="parent -> offset/count lookup backend to emit",
+    )
     return parser.parse_args(argv)
 
 
@@ -88,18 +96,38 @@ def main(argv: list[str] | None = None) -> int:
 
     idx_path = out_dir / "category_child.csr.idx"
     val_path = out_dir / "category_child.csr.val"
+    offset_lmdb_path = out_dir / "category_child.csr.offsets.lmdb"
     meta_path = out_dir / "category_child.csr.meta"
 
     offset_edges = 0
     parent_count = 0
+    sorted_parents = sorted(children_by_parent)
     with idx_path.open("wb") as idx_file, val_path.open("wb") as val_file:
-        for parent in sorted(children_by_parent):
+        for parent in sorted_parents:
             children = sorted(children_by_parent[parent])
             idx_file.write(IDX_RECORD.pack(parent, offset_edges, len(children)))
             for child in children:
                 val_file.write(I32.pack(child))
             offset_edges += len(children)
             parent_count += 1
+
+    offset_index_bytes = 0
+    if args.index_backend == "lmdb_offset":
+        offset_env = lmdb.open(
+            str(offset_lmdb_path),
+            map_size=max(parent_count * 64, 1 << 20),
+            max_dbs=2,
+            subdir=True,
+        )
+        try:
+            offset_db = offset_env.open_db(b"offsets")
+            with offset_env.begin(write=True) as txn:
+                for parent, offset_edges, count in read_idx_records(idx_path):
+                    txn.put(I32.pack(parent), OFFSET_RECORD.pack(offset_edges, count), db=offset_db)
+        finally:
+            offset_env.sync()
+            offset_env.close()
+        offset_index_bytes = (offset_lmdb_path / "data.mdb").stat().st_size
 
     elapsed_seconds = time.time() - started_at
     manifest = {
@@ -111,16 +139,22 @@ def main(argv: list[str] | None = None) -> int:
         "storage_kind": "csr_pread_artifact",
         "id_encoding": "int32_le",
         "ordering": "parent_sort",
+        "index_backend": args.index_backend,
         "io_policy": "buffered_pread",
         "index_path": idx_path.name,
         "values_path": val_path.name,
+        "offset_index_path": offset_lmdb_path.name if args.index_backend == "lmdb_offset" else None,
+        "offset_index_database": "offsets" if args.index_backend == "lmdb_offset" else None,
         "index_record_format": "int32_le parent, uint64_le offset_edges, uint32_le count_edges",
+        "offset_index_record_format": "uint64_le offset_edges, uint32_le count_edges",
         "value_record_format": "int32_le child",
         "index_record_bytes": IDX_RECORD.size,
+        "offset_index_record_bytes": OFFSET_RECORD.size,
         "value_record_bytes": I32.size,
         "parent_count": parent_count,
         "edge_count": edge_count,
         "max_id": max_id,
+        "offset_index_bytes": offset_index_bytes,
         "build": {
             "tool": "build_reverse_csr_artifact.py",
             "elapsed_seconds": round(elapsed_seconds, 6),
@@ -133,6 +167,14 @@ def main(argv: list[str] | None = None) -> int:
         f"max_id={max_id} -> {out_dir}\n"
     )
     return 0
+
+
+def read_idx_records(path: Path) -> list[tuple[int, int, int]]:
+    data = path.read_bytes()
+    return [
+        IDX_RECORD.unpack_from(data, offset)
+        for offset in range(0, len(data), IDX_RECORD.size)
+    ]
 
 
 if __name__ == "__main__":

--- a/examples/benchmark/read_reverse_csr_artifact.py
+++ b/examples/benchmark/read_reverse_csr_artifact.py
@@ -27,6 +27,7 @@ except ImportError:
 
 
 IDX_RECORD = struct.Struct("<iQI")
+OFFSET_RECORD = struct.Struct("<QI")
 I32 = struct.Struct("<i")
 EXPECTED_FORMAT = "unifyweaver.reverse_csr.v1"
 
@@ -38,12 +39,24 @@ class ReverseCsrArtifact:
         self.meta = self._load_meta(self.meta_path)
         self.idx_path = artifact_dir / self.meta["index_path"]
         self.val_path = artifact_dir / self.meta["values_path"]
+        self.index_backend = self.meta.get("index_backend", "sorted_array")
+        self.offset_index_path = (
+            artifact_dir / self.meta["offset_index_path"]
+            if self.index_backend == "lmdb_offset"
+            else None
+        )
         self.index = self._load_index(self.idx_path)
         self._values = self.val_path.open("rb")
+        self._offset_db = None
+        self._offset_env = self._open_offset_index()
 
     def close(self) -> None:
         if not self._values.closed:
             self._values.close()
+        if self._offset_env is not None:
+            self._offset_env.close()
+            self._offset_env = None
+            self._offset_db = None
 
     def __enter__(self) -> "ReverseCsrArtifact":
         return self
@@ -71,11 +84,31 @@ class ReverseCsrArtifact:
             raise ValueError(f"unsupported CSR id_encoding: {meta.get('id_encoding')!r}")
         if meta.get("ordering") != "parent_sort":
             raise ValueError(f"unsupported CSR ordering: {meta.get('ordering')!r}")
+        if meta.get("index_backend", "sorted_array") not in {"sorted_array", "lmdb_offset"}:
+            raise ValueError(f"unsupported CSR index_backend: {meta.get('index_backend')!r}")
         if meta.get("index_record_bytes") != IDX_RECORD.size:
             raise ValueError("CSR index_record_bytes does not match reader format")
+        if meta.get("index_backend", "sorted_array") == "lmdb_offset":
+            if meta.get("offset_index_record_bytes") != OFFSET_RECORD.size:
+                raise ValueError("CSR offset_index_record_bytes does not match reader format")
+            if not meta.get("offset_index_path"):
+                raise ValueError("CSR lmdb_offset backend missing offset_index_path")
         if meta.get("value_record_bytes") != I32.size:
             raise ValueError("CSR value_record_bytes does not match reader format")
         return meta
+
+    def _open_offset_index(self) -> lmdb.Environment | None:
+        if self.index_backend != "lmdb_offset":
+            return None
+        assert self.offset_index_path is not None
+        if not (self.offset_index_path / "data.mdb").exists():
+            raise FileNotFoundError(f"missing CSR offset index LMDB: {self.offset_index_path}")
+        env = lmdb.open(str(self.offset_index_path), readonly=True, max_dbs=2, lock=False, subdir=True)
+        self._offset_db = env.open_db(
+            self.meta.get("offset_index_database", "offsets").encode("ascii"),
+            create=False,
+        )
+        return env
 
     def _load_index(self, path: Path) -> list[tuple[int, int, int]]:
         data = path.read_bytes()
@@ -93,6 +126,33 @@ class ReverseCsrArtifact:
         return records
 
     def lookup(self, parent: int) -> list[int]:
+        offset_count = self._lookup_offset_count(parent)
+        if offset_count is None:
+            return []
+
+        offset_edges, count = offset_count
+        byte_offset = offset_edges * I32.size
+        byte_count = count * I32.size
+        if self._values.closed:
+            raise ValueError("CSR values file is closed")
+        self._values.seek(byte_offset)
+        data = self._values.read(byte_count)
+        if len(data) != byte_count:
+            raise ValueError("CSR values file ended before requested child slice")
+        return [I32.unpack_from(data, offset)[0] for offset in range(0, len(data), I32.size)]
+
+    def _lookup_offset_count(self, parent: int) -> tuple[int, int] | None:
+        if self.index_backend == "lmdb_offset":
+            assert self._offset_env is not None
+            assert self._offset_db is not None
+            with self._offset_env.begin() as txn:
+                value = txn.get(I32.pack(parent), db=self._offset_db)
+            if value is None:
+                return None
+            if len(value) != OFFSET_RECORD.size:
+                raise ValueError("CSR offset index record has unexpected size")
+            return OFFSET_RECORD.unpack(value)
+
         lo = 0
         hi = len(self.index)
         while lo < hi:
@@ -103,18 +163,9 @@ class ReverseCsrArtifact:
             else:
                 hi = mid
         if lo >= len(self.index) or self.index[lo][0] != parent:
-            return []
-
+            return None
         _parent, offset_edges, count = self.index[lo]
-        byte_offset = offset_edges * I32.size
-        byte_count = count * I32.size
-        if self._values.closed:
-            raise ValueError("CSR values file is closed")
-        self._values.seek(byte_offset)
-        data = self._values.read(byte_count)
-        if len(data) != byte_count:
-            raise ValueError("CSR values file ended before requested child slice")
-        return [I32.unpack_from(data, offset)[0] for offset in range(0, len(data), I32.size)]
+        return offset_edges, count
 
     def parents(self) -> list[int]:
         return [parent for parent, _offset_edges, _count in self.index]

--- a/tests/test_benchmark_reverse_csr_lookup.py
+++ b/tests/test_benchmark_reverse_csr_lookup.py
@@ -45,15 +45,60 @@ class BenchmarkReverseCsrLookupTest(unittest.TestCase):
             )
             self.assertEqual(result.returncode, 0, result.stderr)
             rows = list(csv.DictReader(result.stdout.splitlines(), delimiter="\t"))
-            self.assertEqual([row["backend"] for row in rows], ["csr", "lmdb"])
+            self.assertEqual([row["backend"] for row in rows], ["csr_sorted_array", "lmdb"])
+            self.assertEqual([row["index_backend"] for row in rows], ["sorted_array", "n/a"])
             for row in rows:
                 self.assertEqual(row["sample_parents"], "2")
                 self.assertEqual(row["iterations"], "2")
                 self.assertEqual(row["total_children"], "4")
                 self.assertGreater(float(row["median_ms"]), 0.0)
                 self.assertGreater(int(row["csr_artifact_bytes"]), 0)
+                self.assertGreaterEqual(float(row["csr_build_seconds"]), 0.0)
+                self.assertEqual(int(row["offset_index_bytes"]), 0)
                 self.assertGreater(int(row["parent_lmdb_env_bytes"]), 0)
                 self.assertGreater(int(row["phase1_lmdb_env_bytes"]), 0)
+
+    def test_benchmark_compares_csr_index_backends(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            phase1 = tmp_path / "phase1.lmdb"
+            csr_dir = tmp_path / "category_child_csr"
+            make_phase1_lmdb(phase1)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(BENCHMARK),
+                    str(phase1),
+                    "--csr-dir",
+                    str(csr_dir),
+                    "--csr-index-backends",
+                    "sorted_array,lmdb_offset",
+                    "--sample-parents",
+                    "2",
+                    "--iterations",
+                    "2",
+                    "--seed",
+                    "7",
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            rows = list(csv.DictReader(result.stdout.splitlines(), delimiter="\t"))
+            self.assertEqual(
+                [row["backend"] for row in rows],
+                ["csr_sorted_array", "csr_lmdb_offset", "lmdb"],
+            )
+            self.assertEqual(
+                [row["index_backend"] for row in rows],
+                ["sorted_array", "lmdb_offset", "n/a"],
+            )
+            self.assertEqual(int(rows[0]["offset_index_bytes"]), 0)
+            self.assertGreater(int(rows[1]["offset_index_bytes"]), 0)
 
     def test_benchmark_detects_missing_phase1_lmdb(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_build_reverse_csr_artifact.py
+++ b/tests/test_build_reverse_csr_artifact.py
@@ -72,6 +72,7 @@ class BuildReverseCsrArtifactTest(unittest.TestCase):
             self.assertEqual(meta["storage_kind"], "csr_pread_artifact")
             self.assertEqual(meta["id_encoding"], "int32_le")
             self.assertEqual(meta["ordering"], "parent_sort")
+            self.assertEqual(meta["index_backend"], "sorted_array")
             self.assertEqual(meta["io_policy"], "buffered_pread")
             self.assertEqual(meta["parent_count"], 2)
             self.assertEqual(meta["edge_count"], 4)
@@ -89,6 +90,52 @@ class BuildReverseCsrArtifactTest(unittest.TestCase):
                 read_i32_values(out_dir / "category_child.csr.val"),
                 [10, 12, 13, 11],
             )
+
+    def test_builder_writes_lmdb_offset_index(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            phase1 = tmp_path / "phase1.lmdb"
+            out_dir = tmp_path / "category_child_csr"
+
+            phase1.mkdir()
+            env = lmdb.open(str(phase1), map_size=1 << 20, max_dbs=8, subdir=True)
+            cp_db = env.open_db(b"category_parent", dupsort=True)
+            with env.begin(write=True) as txn:
+                txn.put(i32(10), i32(20), db=cp_db)
+                txn.put(i32(12), i32(20), db=cp_db)
+                txn.put(i32(11), i32(30), db=cp_db)
+            env.close()
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(BUILDER),
+                    str(phase1),
+                    str(out_dir),
+                    "--index-backend",
+                    "lmdb_offset",
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            meta = json.loads((out_dir / "category_child.csr.meta").read_text(encoding="utf-8"))
+            self.assertEqual(meta["index_backend"], "lmdb_offset")
+            self.assertEqual(meta["offset_index_path"], "category_child.csr.offsets.lmdb")
+            self.assertGreater(meta["offset_index_bytes"], 0)
+
+            offset_env = lmdb.open(str(out_dir / "category_child.csr.offsets.lmdb"), readonly=True, max_dbs=2, lock=False, subdir=True)
+            try:
+                with offset_env.begin() as txn:
+                    offsets_db = offset_env.open_db(b"offsets", txn=txn, create=False)
+                    self.assertEqual(struct.unpack("<QI", txn.get(i32(20), db=offsets_db)), (0, 2))
+                    self.assertEqual(struct.unpack("<QI", txn.get(i32(30), db=offsets_db)), (2, 1))
+            finally:
+                offset_env.close()
 
     def test_builder_refuses_existing_output_without_refresh(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_generate_synthetic_phase1_lmdb.py
+++ b/tests/test_generate_synthetic_phase1_lmdb.py
@@ -100,10 +100,10 @@ class GenerateSyntheticPhase1LmdbTest(unittest.TestCase):
                 check=False,
             )
             self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertIn("backend\tsample_parents\titerations", result.stdout)
-            self.assertIn("csr_artifact_bytes\tparent_lmdb_env_bytes\tphase1_lmdb_env_bytes", result.stdout)
-            self.assertIn("csr\t5\t2\t20\t", result.stdout)
-            self.assertIn("lmdb\t5\t2\t20\t", result.stdout)
+            self.assertIn("backend\tindex_backend\tsample_parents\titerations", result.stdout)
+            self.assertIn("csr_build_seconds\toffset_index_bytes\tparent_lmdb_env_bytes", result.stdout)
+            self.assertIn("csr_sorted_array\tsorted_array\t5\t2\t20\t", result.stdout)
+            self.assertIn("lmdb\tn/a\t5\t2\t20\t", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_read_reverse_csr_artifact.py
+++ b/tests/test_read_reverse_csr_artifact.py
@@ -97,6 +97,41 @@ class ReadReverseCsrArtifactTest(unittest.TestCase):
             self.assertEqual(validate.returncode, 0, validate.stderr)
             self.assertEqual(validate.stdout.strip(), "validated parents=2 edges=4")
 
+    def test_lookup_reads_lmdb_offset_index_backend(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            phase1 = tmp_path / "phase1.lmdb"
+            out_dir = tmp_path / "category_child_csr"
+            make_phase1_lmdb(phase1)
+
+            build = subprocess.run(
+                [
+                    sys.executable,
+                    str(BUILDER),
+                    str(phase1),
+                    str(out_dir),
+                    "--index-backend",
+                    "lmdb_offset",
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(build.returncode, 0, build.stderr)
+
+            lookup = subprocess.run(
+                [sys.executable, str(READER), "lookup", str(out_dir), "20"],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(lookup.returncode, 0, lookup.stderr)
+            self.assertEqual(lookup.stdout.splitlines(), ["10", "12", "13"])
+
     def test_artifact_keeps_values_file_open_until_closed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)


### PR DESCRIPTION
  ## Summary

  - Add --index-backend lmdb_offset support to the reverse CSR builder.
  - Emit an optional LMDB offset index storing parent_id -> offset_edges,count.
  - Teach the CSR reader to use either:
      - sorted_array: binary search over .idx
      - lmdb_offset: LMDB lookup for offset/count, then .val read
  - Extend the reverse CSR lookup benchmark to compare multiple CSR index backends with --csr-index-backends.
  - Report CSR build time and offset-index bytes.
  - Refresh the synthetic benchmark report with sorted-array vs LMDB-offset results.

  ## Results

  For the current synthetic fixture:

| backend | median_ms | csr_bytes | build_s | offset_bytes |
|---|---|---|---|---|
| csr_sorted_array | 3.413093 | 481020 | 0.060911 | 0 |
| csr_lmdb_offset | 2.649246 | 943906 | 0.075248 | 454656 |
| lmdb | 3.514109 | 481020 | 0.060911 | 0 |

  lmdb_offset improves lookup time on this fixture, but increases build time and nearly doubles the CSR artifact bytes.
  At Wikipedia scale, where the sorted CSR index may fit in memory, the cost analyzer needs to weigh lookup savings
  against preprocessing and artifact-size cost.

  ## Validation

  - python3 tests/test_build_reverse_csr_artifact.py
  - python3 tests/test_read_reverse_csr_artifact.py
  - python3 tests/test_benchmark_reverse_csr_lookup.py
  - python3 tests/test_generate_synthetic_phase1_lmdb.py
  - python3 -m py_compile examples/benchmark/build_reverse_csr_artifact.py examples/benchmark/
    read_reverse_csr_artifact.py examples/benchmark/benchmark_reverse_csr_lookup.py tests/
    test_build_reverse_csr_artifact.py tests/test_read_reverse_csr_artifact.py tests/
    test_benchmark_reverse_csr_lookup.py tests/test_generate_synthetic_phase1_lmdb.py
  - git diff --check