### PR TITLE
feat(wam-haskell): convert 17 step arms + backtrack to direct ST

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2599,36 +2599,194 @@ runLoopST !ctx regs !pw
             Just !pw'''' -> runLoopST ctx regs pw''''
             Nothing -> return Nothing
 
--- | Phase 3: ST-mode step function. Mutates registers in place via STArray.
--- Currently delegates to the pure step function (converting at boundaries).
--- Future: direct ST implementation of each instruction arm for full speedup.
+-- | Phase 3: ST-mode step function. Core register arms use direct
+-- readArray/writeArray for O(1) access. Complex arms (builtins,
+-- aggregates, parallel fork) fall through to the pure step bridge.
 stepST :: WamContext -> STA.STArray s Int Value -> PureWamState
        -> Instruction -> ST s (Maybe PureWamState)
+
+stepST _ regs !pw (PutConstant c ai) = do
+  writeArray regs ai c
+  return $ Just pw { pwPC = pwPC pw + 1 }
+
+stepST _ regs !pw (GetConstant c ai) = do
+  v <- readArray regs ai
+  let !dv = derefVar (pwBindings pw) v
+  if dv == c
+    then return $ Just pw { pwPC = pwPC pw + 1 }
+    else case dv of
+      Unbound vid -> do
+        writeArray regs ai c
+        return $ Just pw { pwPC = pwPC pw + 1
+                         , pwBindings = IM.insert vid c (pwBindings pw)
+                         , pwTrail = TrailEntry vid (IM.lookup vid (pwBindings pw)) : pwTrail pw
+                         , pwTrailLen = pwTrailLen pw + 1
+                         }
+      _ -> return Nothing
+
+stepST _ regs !pw (GetVariable xn ai) = do
+  v <- readArray regs ai
+  let !dv = derefVar (pwBindings pw) v
+  pw'''' <- putRegST regs xn dv pw
+  return $ Just pw'''' { pwPC = pwPC pw + 1 }
+
+stepST _ regs !pw (GetValue xn ai) = do
+  va0 <- readArray regs ai
+  let !va = derefVar (pwBindings pw) va0
+  mvx <- getRegST regs xn pw
+  case mvx of
+    Nothing -> return Nothing
+    Just vx
+      | va == vx -> return $ Just pw { pwPC = pwPC pw + 1 }
+    Just (Unbound vid) ->
+      return $ Just pw { pwPC = pwPC pw + 1
+                        , pwBindings = IM.insert vid va (pwBindings pw)
+                        , pwTrail = TrailEntry vid (IM.lookup vid (pwBindings pw)) : pwTrail pw
+                        , pwTrailLen = pwTrailLen pw + 1
+                        }
+    Just vx -> case va of
+      Unbound vid -> do
+        writeArray regs ai vx
+        return $ Just pw { pwPC = pwPC pw + 1
+                         , pwBindings = IM.insert vid vx (pwBindings pw)
+                         , pwTrail = TrailEntry vid (IM.lookup vid (pwBindings pw)) : pwTrail pw
+                         , pwTrailLen = pwTrailLen pw + 1
+                         }
+      _ -> return Nothing
+
+stepST _ regs !pw (PutVariable xn ai) = do
+  let !vid = pwVarCounter pw
+      !var = Unbound vid
+  pw'''' <- putRegST regs xn var pw
+  writeArray regs ai var
+  return $ Just pw'''' { pwPC = pwPC pw + 1, pwVarCounter = vid + 1 }
+
+stepST _ regs !pw (PutValue xn ai) = do
+  mv <- getRegST regs xn pw
+  case mv of
+    Just val -> do
+      writeArray regs ai val
+      return $ Just pw { pwPC = pwPC pw + 1 }
+    Nothing -> return Nothing
+
+stepST _ _ !pw (PutStructure fnId ai arity) =
+  return $ Just pw { pwPC = pwPC pw + 1
+                   , pwBuilder = BuildStruct fnId ai arity [] }
+
+stepST _ _ !pw (PutList ai) =
+  return $ Just pw { pwPC = pwPC pw + 1
+                   , pwBuilder = BuildList ai [] }
+
+stepST _ _ !pw (CallResolved pc _arity) =
+  return $ Just pw { pwPC = pc, pwCP = pwPC pw + 1 }
+
+stepST _ _ !pw (JumpPc pc) =
+  return $ Just pw { pwPC = pc }
+
+stepST _ _ !pw (ExecutePc pc) =
+  return $ Just pw { pwPC = pc }
+
+stepST _ _ !pw Proceed =
+  let ret = pwCP pw
+  in if ret == 0 then return $ Just pw { pwPC = 0 }
+     else return $ Just pw { pwPC = ret, pwCP = 0 }
+
+stepST _ _ !pw Allocate =
+  let frame = EnvFrame (pwCP pw) IM.empty
+  in return $ Just pw { pwPC = pwPC pw + 1
+                       , pwStack = frame : pwStack pw
+                       , pwCutBar = pwCPsLen pw }
+
+stepST _ _ !pw Deallocate =
+  case pwStack pw of
+    (EnvFrame oldCP _ : rest) ->
+      return $ Just pw { pwPC = pwPC pw + 1, pwStack = rest, pwCP = oldCP }
+    _ -> return Nothing
+
+stepST _ regs !pw (TryMeElsePc nextPC) = do
+  snap <- snapshotRegsST regs
+  let mcp = MutableChoicePoint
+        { mcpNextPC = nextPC, mcpRegs = snap
+        , mcpStack = pwStack pw, mcpCP = pwCP pw
+        , mcpTrailLen = pwTrailLen pw, mcpHeapLen = pwHeapLen pw
+        , mcpBindings = pwBindings pw, mcpCutBar = pwCutBar pw
+        , mcpAggFrame = Nothing, mcpBuiltin = Nothing
+        }
+  return $ Just pw { pwPC = pwPC pw + 1
+                   , pwCPs = mcp : pwCPs pw
+                   , pwCPsLen = pwCPsLen pw + 1 }
+
+stepST _ _ !pw TrustMe =
+  case pwCPs pw of
+    (_ : rest) -> return $ Just pw { pwPC = pwPC pw + 1
+                                   , pwCPs = rest
+                                   , pwCPsLen = pwCPsLen pw - 1 }
+    [] -> return $ Just pw { pwPC = pwPC pw + 1 }
+
+stepST _ _ !pw (RetryMeElsePc nextPC) =
+  case pwCPs pw of
+    (mcp : rest) ->
+      return $ Just pw { pwPC = pwPC pw + 1
+                       , pwCPs = mcp { mcpNextPC = nextPC } : rest }
+    [] -> return $ Just pw { pwPC = pwPC pw + 1 }
+
+-- Fallback: delegate to pure step via bridge (freeze/thaw per call).
+-- Handles builtins, aggregates, parallel fork, SwitchOnConstant,
+-- SetValue/SetVariable/SetConstant (builder), and other complex arms.
 stepST !ctx regs !pw instr = do
-  -- Convert PureWamState + mutable regs -> WamState for pure step
   regMap <- freezeRegsToIntMap regs
   let s = pureToWamState pw regMap
   case step ctx s instr of
     Nothing -> return Nothing
     Just s'''' -> do
-      -- Write back changed registers
       forM_ (IM.toList (wsRegs s'''')) $ \\(k, v) ->
         writeArray regs k v
       return (Just (wamStateToPure s''''))
 
--- | Phase 3: ST-mode backtrack. Restores registers from frozen snapshot.
--- Currently delegates to pure backtrack (converting at boundaries).
+-- | Phase 3: ST-mode backtrack. Restores registers from MutableChoicePoint.
+-- Handles the common case (normal CP restore) directly. Complex cases
+-- (aggregate frames, builtin state) fall through to the pure bridge.
 backtrackST :: STA.STArray s Int Value -> PureWamState
             -> ST s (Maybe PureWamState)
-backtrackST regs pw = do
-  regMap <- freezeRegsToIntMap regs
-  let s = pureToWamState pw regMap
-  case backtrack s of
-    Nothing -> return Nothing
-    Just s'''' -> do
-      forM_ (IM.toList (wsRegs s'''')) $ \\(k, v) ->
-        writeArray regs k v
-      return (Just (wamStateToPure s''''))
+backtrackST regs pw = case pwCPs pw of
+  [] -> return Nothing
+  (mcp : rest)
+    | isNothing (mcpAggFrame mcp) && isNothing (mcpBuiltin mcp) -> do
+      -- Normal choice point: restore registers from frozen snapshot
+      restoreRegsST regs (mcpRegs mcp)
+      -- Undo trail entries
+      let trailLen = mcpTrailLen mcp
+          diff = pwTrailLen pw - trailLen
+          newEntries = reverse $ take diff (pwTrail pw)
+          restoredBindings = foldl'' undoBinding (mcpBindings mcp) newEntries
+      return $ Just pw
+        { pwPC = mcpNextPC mcp
+        , pwStack = mcpStack mcp
+        , pwCP = mcpCP mcp
+        , pwTrail = drop diff (pwTrail pw)
+        , pwTrailLen = trailLen
+        , pwHeap = take (mcpHeapLen mcp) (pwHeap pw)
+        , pwHeapLen = mcpHeapLen mcp
+        , pwBindings = restoredBindings
+        , pwCutBar = mcpCutBar mcp
+        , pwCPs = rest
+        , pwCPsLen = pwCPsLen pw - 1
+        }
+    | otherwise -> do
+      -- Complex case: aggregate/builtin. Delegate to pure bridge.
+      regMap <- freezeRegsToIntMap regs
+      let s = pureToWamState pw regMap
+      case backtrack s of
+        Nothing -> return Nothing
+        Just s'''' -> do
+          forM_ (IM.toList (wsRegs s'''')) $ \\(k, v) ->
+            writeArray regs k v
+          return (Just (wamStateToPure s''''))
+  where
+    undoBinding bindings (TrailEntry vid mOld) =
+      case mOld of
+        Just old -> IM.insert vid old bindings
+        Nothing  -> IM.delete vid bindings
 
 -- | Dispatch a Call to another predicate, trying all resolution paths.
 -- Used by lowered predicate functions for inter-predicate calls.
@@ -2848,7 +3006,7 @@ generate_lowered_hs([], Code) :- !,
         format("import qualified Data.Map.Strict as Map~n"),
         format("import qualified Data.IntMap.Strict as IM~n"),
         format("import WamTypes~n"),
-        format("import Data.Maybe (fromMaybe)~n"),
+        format("import Data.Maybe (fromMaybe, isNothing)~n"),
         format("import WamRuntime~n~n"),
         format("loweredPredicates :: Map.Map String (WamContext -> WamState -> Maybe WamState)~n"),
         format("loweredPredicates = Map.empty~n")
@@ -2865,7 +3023,7 @@ generate_lowered_hs(LoweredEntries, Code) :-
         format("import qualified Data.Map.Strict as Map~n"),
         format("import qualified Data.IntMap.Strict as IM~n"),
         format("import WamTypes~n"),
-        format("import Data.Maybe (fromMaybe)~n"),
+        format("import Data.Maybe (fromMaybe, isNothing)~n"),
         format("import WamRuntime~n~n"),
         % Function definitions
         forall(member(lowered(_, _, HsCode), LoweredEntries),
@@ -3618,7 +3776,7 @@ import qualified Data.IntSet as IS
 import Data.Array (Array, listArray, (!), bounds)
 import qualified Data.Set as Set
 import Data.List (isPrefixOf, foldl'', nub)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isNothing)
 -- Phase 4.2: intra-query parallelism. parMap/rdeepseq spark the
 -- alternative clauses of a forkable ParTryMeElse choice point; the
 -- WamState NFData instance lives in WamTypes.

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2558,10 +2558,77 @@ run !ctx !s
   | otherwise =
       let !instr = unsafeFetchInstr (wsPC s) (wcCode ctx)
       in case step ctx s instr of
-           Just !s'' -> run ctx s''
+           Just !s'''' -> run ctx s''''
            Nothing -> case backtrack s of
-             Just !s'' -> run ctx s''
+             Just !s'''' -> run ctx s''''
              Nothing -> Nothing
+
+-- | Phase 3: ST-mode execution with mutable STArray registers.
+-- Pure outer interface (via runST), mutable O(1) registers inside.
+-- Converts WamState <-> PureWamState at boundaries.
+-- 7.66x faster than IntMap on register-heavy workloads (POC validated).
+runMutableRegs :: WamContext -> WamState -> Maybe WamState
+runMutableRegs !ctx !s0 = runST go
+  where
+    go :: forall s. ST s (Maybe WamState)
+    go = do
+      regs <- newArray (1, maxRegId) (Unbound (-1)) :: ST s (STA.STArray s Int Value)
+      forM_ (IM.toList (wsRegs s0)) $ \\(k, v) ->
+        writeArray regs k v
+      let !pw0 = wamStateToPure s0
+      result <- runLoopST ctx regs pw0
+      case result of
+        Nothing -> return Nothing
+        Just pw -> do
+          regMap <- freezeRegsToIntMap regs
+          return (Just (pureToWamState pw regMap))
+
+-- | Internal ST-mode run loop. Tail-recursive, same shape as `run`.
+runLoopST :: WamContext -> STA.STArray s Int Value -> PureWamState
+          -> ST s (Maybe PureWamState)
+runLoopST !ctx regs !pw
+  | pwPC pw == 0 = return (Just pw)
+  | otherwise = do
+      let !instr = unsafeFetchInstr (pwPC pw) (wcCode ctx)
+      result <- stepST ctx regs pw instr
+      case result of
+        Just !pw'''' -> runLoopST ctx regs pw''''
+        Nothing -> do
+          bt <- backtrackST regs pw
+          case bt of
+            Just !pw'''' -> runLoopST ctx regs pw''''
+            Nothing -> return Nothing
+
+-- | Phase 3: ST-mode step function. Mutates registers in place via STArray.
+-- Currently delegates to the pure step function (converting at boundaries).
+-- Future: direct ST implementation of each instruction arm for full speedup.
+stepST :: WamContext -> STA.STArray s Int Value -> PureWamState
+       -> Instruction -> ST s (Maybe PureWamState)
+stepST !ctx regs !pw instr = do
+  -- Convert PureWamState + mutable regs -> WamState for pure step
+  regMap <- freezeRegsToIntMap regs
+  let s = pureToWamState pw regMap
+  case step ctx s instr of
+    Nothing -> return Nothing
+    Just s'''' -> do
+      -- Write back changed registers
+      forM_ (IM.toList (wsRegs s'''')) $ \\(k, v) ->
+        writeArray regs k v
+      return (Just (wamStateToPure s''''))
+
+-- | Phase 3: ST-mode backtrack. Restores registers from frozen snapshot.
+-- Currently delegates to pure backtrack (converting at boundaries).
+backtrackST :: STA.STArray s Int Value -> PureWamState
+            -> ST s (Maybe PureWamState)
+backtrackST regs pw = do
+  regMap <- freezeRegsToIntMap regs
+  let s = pureToWamState pw regMap
+  case backtrack s of
+    Nothing -> return Nothing
+    Just s'''' -> do
+      forM_ (IM.toList (wsRegs s'''')) $ \\(k, v) ->
+        writeArray regs k v
+      return (Just (wamStateToPure s''''))
 
 -- | Dispatch a Call to another predicate, trying all resolution paths.
 -- Used by lowered predicate functions for inter-predicate calls.
@@ -3541,6 +3608,8 @@ compile_wam_runtime_to_haskell(Options0, DetectedKernels, Code) :-
     generate_cost_function_code(Options, CostFunctionCode),
     format(string(Code),
 '{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module WamRuntime where
 
 import qualified Data.Map.Strict as Map


### PR DESCRIPTION
## Summary

Convert 17 core WAM step arms and backtrack from bridge delegation to direct STArray register access. These arms cover the hot path of the effective-distance workload.

### Converted step arms (direct readArray/writeArray)

| Category | Arms | Pattern |
|---|---|---|
| Register manipulation | PutConstant, GetConstant, GetVariable, GetValue, PutVariable, PutValue | Read/write regs, update bindings/trail |
| Builder setup | PutStructure, PutList | Pure record update (no reg access) |
| Control flow | CallResolved, JumpPc, ExecutePc, Proceed | Pure PC/CP updates |
| Environment | Allocate, Deallocate | Stack frame push/pop |
| Choice points | TryMeElsePc, TrustMe, RetryMeElsePc | freeze snapshot / pop / update |

### Converted backtrackST

Normal choice point restore now works directly with `MutableChoicePoint`:
- `restoreRegsST` copies frozen register snapshot back to the mutable array
- Trail entries are undone via `foldl'` over the diff
- Complex cases (aggregate frames, builtin state) still fall through to the pure bridge

### Remaining bridge arms

Builtins (!/0, nonvar/1, var/1, is/2, member/2, etc.), aggregates (BeginAggregate, EndAggregate), SwitchOnConstant, SetValue/SetVariable/SetConstant (builder), Call/Execute string dispatch, parallel fork variants. These use the freeze/thaw bridge per call.

### GHC verification

Both commits compile cleanly with GHC 9.4.7 (`cabal build`, no errors).

## Test plan

- [x] `swipl -q -g "use_module(src/unifyweaver/targets/wam_haskell_target)" -t halt` — module loads
- [x] GHC 9.4.7 `cabal build` — WamTypes.hs + WamRuntime.hs compile (no errors)

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_