### PR TITLE
feat(wam-haskell): Phase 3 step conversion -- 38/45 arms direct ST

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2844,11 +2844,110 @@ stepST !ctx regs !pw (BuiltinCall ">/2" _) = do
     (Just a, Just b) | a > b -> return $ Just pw { pwPC = pwPC pw + 1 }
     _ -> return Nothing
 
+-- Builder operations: read reg value and pass to addToBuilder (pure helper).
+-- addToBuilder is pure and only touches wsBuilder/wsRegs, so we can
+-- do the reg read in ST and delegate the builder logic to pure.
+stepST _ regs !pw (SetValue xn) = do
+  mv <- getRegST regs xn pw
+  case mv of
+    Nothing -> return Nothing
+    Just val -> do
+      let s0 = PureWamState { pwPC = pwPC pw, pwStack = pwStack pw
+                            , pwHeap = pwHeap pw, pwHeapLen = pwHeapLen pw
+                            , pwTrail = pwTrail pw, pwTrailLen = pwTrailLen pw
+                            , pwCP = pwCP pw, pwCPs = pwCPs pw, pwCPsLen = pwCPsLen pw
+                            , pwBindings = pwBindings pw, pwCutBar = pwCutBar pw
+                            , pwBuilder = pwBuilder pw, pwVarCounter = pwVarCounter pw
+                            , pwAggAccum = pwAggAccum pw }
+      -- addToBuilder is pure: only modifies wsBuilder and wsRegs (for struct/list finalize)
+      regMap <- freezeRegsToIntMap regs
+      let ws = pureToWamState s0 regMap
+      case addToBuilder val ws of
+        Nothing -> return Nothing
+        Just ws'''' -> do
+          forM_ (IM.toList (wsRegs ws'''')) $ \\(k, v) -> writeArray regs k v
+          return (Just (wamStateToPure ws''''))
+
+stepST _ regs !pw (SetVariable xn) = do
+  let !vid = pwVarCounter pw
+      !var = Unbound vid
+  pw'''' <- putRegST regs xn var pw
+  let pw2 = pw'''' { pwVarCounter = vid + 1 }
+  -- Delegate builder logic to pure
+  regMap <- freezeRegsToIntMap regs
+  let ws = pureToWamState pw2 regMap
+  case addToBuilder var ws of
+    Nothing -> return Nothing
+    Just ws2 -> do
+      forM_ (IM.toList (wsRegs ws2)) $ \\(k, v) -> writeArray regs k v
+      return (Just (wamStateToPure ws2))
+
+stepST _ regs !pw (SetConstant c) = do
+  regMap <- freezeRegsToIntMap regs
+  let ws = pureToWamState pw regMap
+  case addToBuilder c ws of
+    Nothing -> return Nothing
+    Just ws'''' -> do
+      forM_ (IM.toList (wsRegs ws'''')) $ \\(k, v) -> writeArray regs k v
+      return (Just (wamStateToPure ws''''))
+
+-- Call/Execute dispatch (string-based, not pre-resolved)
+stepST !ctx regs !pw (Call pred _arity) = do
+  let sc = pw { pwCP = pwPC pw + 1 }
+  case Map.lookup pred (wcLoweredPredicates ctx) of
+    Just fn -> do
+      regMap <- freezeRegsToIntMap regs
+      let ws = pureToWamState sc regMap
+      case fn ctx ws of
+        Nothing -> return Nothing
+        Just ws'''' -> do
+          forM_ (IM.toList (wsRegs ws'''')) $ \\(k, v) -> writeArray regs k v
+          return (Just (wamStateToPure ws''''))
+    Nothing -> do
+      regMap <- freezeRegsToIntMap regs
+      let ws = pureToWamState sc regMap
+      case callIndexedFact2 ctx pred ws of
+        Just sr -> do
+          forM_ (IM.toList (wsRegs sr)) $ \\(k, v) -> writeArray regs k v
+          return (Just (wamStateToPure sr))
+        Nothing -> case Map.lookup pred (wcLabels ctx) of
+          Just pc -> return $ Just sc { pwPC = pc }
+          Nothing -> return Nothing
+
+stepST !ctx regs !pw (Execute pred) = do
+  case Map.lookup pred (wcLoweredPredicates ctx) of
+    Just fn -> do
+      regMap <- freezeRegsToIntMap regs
+      let ws = pureToWamState pw regMap
+      case fn ctx ws of
+        Nothing -> return Nothing
+        Just ws'''' -> do
+          forM_ (IM.toList (wsRegs ws'''')) $ \\(k, v) -> writeArray regs k v
+          return (Just (wamStateToPure ws''''))
+    Nothing -> do
+      regMap <- freezeRegsToIntMap regs
+      let ws = pureToWamState pw regMap
+      case callIndexedFact2 ctx pred ws of
+        Just sr -> do
+          forM_ (IM.toList (wsRegs sr)) $ \\(k, v) -> writeArray regs k v
+          return (Just (wamStateToPure sr))
+        Nothing -> case Map.lookup pred (wcLabels ctx) of
+          Just pc -> return $ Just pw { pwPC = pc }
+          Nothing -> return Nothing
+
+stepST !ctx regs !pw (CallForeign pred _arity) = do
+  regMap <- freezeRegsToIntMap regs
+  let ws = pureToWamState (pw { pwCP = pwPC pw + 1 }) regMap
+  case executeForeign ctx pred ws of
+    Nothing -> return Nothing
+    Just ws'''' -> do
+      forM_ (IM.toList (wsRegs ws'''')) $ \\(k, v) -> writeArray regs k v
+      return (Just (wamStateToPure ws''''))
+
 -- Fallback: delegate to pure step via bridge (freeze/thaw per call).
--- Handles: SetValue/SetVariable/SetConstant (builder), member/2, \\+/1,
--- length/2, aggregates, parallel fork, =../2, copy_term/2, functor/3,
--- arg/3, NotMember*, BuildEmptySet, SetInsert, PutStructureDyn,
--- Call/Execute (string dispatch), CallForeign, CallFactStream.
+-- Handles: member/2, \\+/1, length/2, aggregates, parallel fork,
+-- =../2, copy_term/2, functor/3, arg/3, NotMember*, BuildEmptySet,
+-- SetInsert, PutStructureDyn, CallFactStream.
 stepST !ctx regs !pw instr = do
   regMap <- freezeRegsToIntMap regs
   let s = pureToWamState pw regMap

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2730,9 +2730,125 @@ stepST _ _ !pw (RetryMeElsePc nextPC) =
                        , pwCPs = mcp { mcpNextPC = nextPC } : rest }
     [] -> return $ Just pw { pwPC = pwPC pw + 1 }
 
+-- Label-based variants (lookup label -> PC)
+stepST !ctx regs !pw (TryMeElse label) =
+  let nextPC = fromMaybe 0 $ Map.lookup label (wcLabels ctx)
+  in stepST ctx regs pw (TryMeElsePc nextPC)
+
+stepST !ctx regs !pw (RetryMeElse label) =
+  let nextPC = fromMaybe 0 $ Map.lookup label (wcLabels ctx)
+  in stepST ctx regs pw (RetryMeElsePc nextPC)
+
+stepST !ctx _ !pw (Jump label) =
+  case Map.lookup label (wcLabels ctx) of
+    Just pc -> return $ Just pw { pwPC = pc }
+    Nothing -> return Nothing
+
+-- SwitchOnConstantPc: indexed dispatch on A1 register
+stepST _ regs !pw (SwitchOnConstantPc table) = do
+  v <- readArray regs 1
+  let !dv = derefVar (pwBindings pw) v
+  case dv of
+    Unbound _ -> return $ Just pw { pwPC = pwPC pw + 1 }
+    Atom aid -> case IM.lookup aid table of
+      Just pc -> return $ Just pw { pwPC = pc }
+      Nothing -> return $ Just pw { pwPC = pwPC pw + 1 }
+    Integer n -> case IM.lookup n table of
+      Just pc -> return $ Just pw { pwPC = pc }
+      Nothing -> return $ Just pw { pwPC = pwPC pw + 1 }
+    _ -> return $ Just pw { pwPC = pwPC pw + 1 }
+
+-- Cut: truncate choice point stack
+stepST _ _ !pw (BuiltinCall "!/0" _) =
+  return $ Just pw { pwPC = pwPC pw + 1
+                   , pwCPs = take (pwCutBar pw) (pwCPs pw)
+                   , pwCPsLen = pwCutBar pw }
+
+-- CutIte: soft cut for if-then-else
+stepST _ _ !pw CutIte =
+  case pwCPs pw of
+    (_ : rest) -> return $ Just pw { pwPC = pwPC pw + 1
+                                   , pwCPs = rest, pwCPsLen = pwCPsLen pw - 1 }
+    [] -> return $ Just pw { pwPC = pwPC pw + 1 }
+
+-- Type-checking builtins
+stepST _ regs !pw (BuiltinCall "nonvar/1" _) = do
+  v <- readArray regs 1
+  let !dv = derefVar (pwBindings pw) v
+  case dv of
+    Unbound _ -> return Nothing
+    _         -> return $ Just pw { pwPC = pwPC pw + 1 }
+
+stepST _ regs !pw (BuiltinCall "var/1" _) = do
+  v <- readArray regs 1
+  let !dv = derefVar (pwBindings pw) v
+  case dv of
+    Unbound _ -> return $ Just pw { pwPC = pwPC pw + 1 }
+    _         -> return Nothing
+
+stepST _ regs !pw (BuiltinCall "atom/1" _) = do
+  v <- readArray regs 1
+  let !dv = derefVar (pwBindings pw) v
+  case dv of
+    Atom _ -> return $ Just pw { pwPC = pwPC pw + 1 }
+    _      -> return Nothing
+
+stepST _ regs !pw (BuiltinCall "integer/1" _) = do
+  v <- readArray regs 1
+  let !dv = derefVar (pwBindings pw) v
+  case dv of
+    Integer _ -> return $ Just pw { pwPC = pwPC pw + 1 }
+    _         -> return Nothing
+
+stepST _ regs !pw (BuiltinCall "number/1" _) = do
+  v <- readArray regs 1
+  let !dv = derefVar (pwBindings pw) v
+  case dv of
+    Integer _ -> return $ Just pw { pwPC = pwPC pw + 1 }
+    Float _   -> return $ Just pw { pwPC = pwPC pw + 1 }
+    _         -> return Nothing
+
+stepST !ctx regs !pw (BuiltinCall "is/2" _) = do
+  v2 <- readArray regs 2
+  v1 <- readArray regs 1
+  let !expr = derefVar (pwBindings pw) v2
+      result = evalArith (wcInternTable ctx) (pwBindings pw) expr
+      !lhs = derefVar (pwBindings pw) v1
+  case (lhs, result) of
+    (Unbound vid, Just r) -> do
+      let val = if fromIntegral (round r :: Int) == r then Integer (round r) else Float r
+      writeArray regs 1 val
+      return $ Just pw { pwPC = pwPC pw + 1
+                       , pwBindings = IM.insert vid val (pwBindings pw)
+                       , pwTrail = TrailEntry vid (IM.lookup vid (pwBindings pw)) : pwTrail pw
+                       , pwTrailLen = pwTrailLen pw + 1
+                       }
+    (Integer n, Just r) | fromIntegral n == r -> return $ Just pw { pwPC = pwPC pw + 1 }
+    _ -> return Nothing
+
+stepST !ctx regs !pw (BuiltinCall "</2" _) = do
+  v1 <- readArray regs 1
+  v2 <- readArray regs 2
+  let r1 = evalArith (wcInternTable ctx) (pwBindings pw) (derefVar (pwBindings pw) v1)
+      r2 = evalArith (wcInternTable ctx) (pwBindings pw) (derefVar (pwBindings pw) v2)
+  case (r1, r2) of
+    (Just a, Just b) | a < b -> return $ Just pw { pwPC = pwPC pw + 1 }
+    _ -> return Nothing
+
+stepST !ctx regs !pw (BuiltinCall ">/2" _) = do
+  v1 <- readArray regs 1
+  v2 <- readArray regs 2
+  let r1 = evalArith (wcInternTable ctx) (pwBindings pw) (derefVar (pwBindings pw) v1)
+      r2 = evalArith (wcInternTable ctx) (pwBindings pw) (derefVar (pwBindings pw) v2)
+  case (r1, r2) of
+    (Just a, Just b) | a > b -> return $ Just pw { pwPC = pwPC pw + 1 }
+    _ -> return Nothing
+
 -- Fallback: delegate to pure step via bridge (freeze/thaw per call).
--- Handles builtins, aggregates, parallel fork, SwitchOnConstant,
--- SetValue/SetVariable/SetConstant (builder), and other complex arms.
+-- Handles: SetValue/SetVariable/SetConstant (builder), member/2, \\+/1,
+-- length/2, aggregates, parallel fork, =../2, copy_term/2, functor/3,
+-- arg/3, NotMember*, BuildEmptySet, SetInsert, PutStructureDyn,
+-- Call/Execute (string dispatch), CallForeign, CallFactStream.
 stepST !ctx regs !pw instr = do
   regMap <- freezeRegsToIntMap regs
   let s = pureToWamState pw regMap


### PR DESCRIPTION
## Summary

Continue Phase 3 mutable register conversion: 38 of ~45 step arms now use direct STArray access. The bridge fallback is reduced to rare instructions not in the effective-distance hot loop.

### Converted in this PR

**Commit 1 (15 more arms, 32 total):**
- SwitchOnConstantPc (indexed dispatch on A1)
- TryMeElse/RetryMeElse (label variants)
- Jump (label lookup)
- !/0 (cut), CutIte (soft cut)
- nonvar/1, var/1, atom/1, integer/1, number/1 (type checks)
- is/2 (arithmetic evaluation + binding)
- </2, >/2 (comparison)

**Commit 2 (6 more arms, 38 total):**
- SetValue, SetVariable, SetConstant (builder ops)
- Call, Execute (string-based predicate dispatch)
- CallForeign (direct foreign call)

### Remaining bridge fallback

Only rare/complex instructions still use the freeze/thaw bridge: member/2, `\+/1`, length/2, aggregates (BeginAggregate, EndAggregate), parallel fork, `=../2`, copy_term/2, functor/3, arg/3, NotMember*, BuildEmptySet, SetInsert, PutStructureDyn, CallFactStream.

These are rarely hit in the effective-distance hot loop where the 7.66x speedup was measured.

### Architecture note

Some converted arms (SetValue/SetVariable, Call/Execute, CallForeign) still use `freezeRegsToIntMap` internally because they delegate to pure helper functions (addToBuilder, executeForeign, callIndexedFact2). The full speedup for these arms requires also converting those helpers to ST — follow-up work.

## Test plan

- [x] `swipl -q -g "use_module(src/unifyweaver/targets/wam_haskell_target)" -t halt` — module loads
- [x] GHC 9.4.7 `cabal build` — no errors on regenerated WamRuntime.hs

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_