### PR TITLE
feat(wam-python): add filesystem builtins

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -5,6 +5,7 @@ Trail-based mutable state. No external dependencies.
 
 from __future__ import annotations
 import copy
+import os
 import sys
 from dataclasses import dataclass, field
 from typing import Any, Optional, Callable, Dict, List, Tuple
@@ -1537,6 +1538,49 @@ def _execute_open(state: WamState) -> bool:
     return True
 
 
+def _execute_exists_file(state: WamState) -> bool:
+    path = _stream_path_text(get_reg(state, 1), state)
+    return path is not None and os.path.isfile(path)
+
+
+def _execute_exists_directory(state: WamState) -> bool:
+    path = _stream_path_text(get_reg(state, 1), state)
+    return path is not None and os.path.isdir(path)
+
+
+def _execute_directory_files(state: WamState) -> bool:
+    path = _stream_path_text(get_reg(state, 1), state)
+    if path is None or not os.path.isdir(path):
+        return False
+    try:
+        names = ['.', '..'] + sorted(os.listdir(path))
+    except OSError:
+        return False
+    return unify(get_reg(state, 2), _list_from_terms([make_atom(name) for name in names]), state)
+
+
+def _execute_make_directory(state: WamState) -> bool:
+    path = _stream_path_text(get_reg(state, 1), state)
+    if path is None:
+        return False
+    try:
+        os.mkdir(path)
+    except OSError:
+        return False
+    return True
+
+
+def _execute_delete_file(state: WamState) -> bool:
+    path = _stream_path_text(get_reg(state, 1), state)
+    if path is None:
+        return False
+    try:
+        os.remove(path)
+    except OSError:
+        return False
+    return True
+
+
 def _execute_close(state: WamState) -> bool:
     stream = _unwrap_stream(deref(get_reg(state, 1), state))
     if stream is None or not hasattr(stream, 'close'):
@@ -2051,6 +2095,16 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return _execute_read_term_from_atom(state, 3, 'error')
     if builtin in ('open/3', 'open') and arity == 3:
         return _execute_open(state)
+    if builtin in ('exists_file/1', 'exists_file') and arity == 1:
+        return _execute_exists_file(state)
+    if builtin in ('exists_directory/1', 'exists_directory') and arity == 1:
+        return _execute_exists_directory(state)
+    if builtin in ('directory_files/2', 'directory_files') and arity == 2:
+        return _execute_directory_files(state)
+    if builtin in ('make_directory/1', 'make_directory') and arity == 1:
+        return _execute_make_directory(state)
+    if builtin in ('delete_file/1', 'delete_file') and arity == 1:
+        return _execute_delete_file(state)
     if builtin in ('close/1', 'close') and arity == 1:
         return _execute_close(state)
     if builtin in ('get_char/1', 'get_char') and arity == 1:

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -1235,6 +1235,44 @@ test(runtime_atomic_split_string_helpers) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_filesystem_helpers) :-
+	setup_call_cleanup(
+		(   retractall(user:py_filesystem_helper_demo),
+			user:python_parser_tmp_dir('tmp_wam_python_filesystem_helpers', ProjectDir),
+			atomic_list_concat([ProjectDir, '/fs_dir'], Dir),
+			atomic_list_concat([Dir, '/data.txt'], File),
+			assertz((user:py_filesystem_helper_demo :-
+				\+ exists_directory(Dir),
+				make_directory(Dir),
+				exists_directory(Dir),
+				\+ exists_file(File),
+				open(File, write, Out),
+				write_to_stream(Out, payload),
+				close(Out),
+				exists_file(File),
+				directory_files(Dir, Files),
+				member('.', Files),
+				member('..', Files),
+				member('data.txt', Files),
+				delete_file(File),
+				\+ exists_file(File),
+				\+ delete_file(File)))
+		),
+		(   wam_python_target:write_wam_python_project([user:py_filesystem_helper_demo/0],
+				[runtime_parser(off)], ProjectDir),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_filesystem_helper_demo/0', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_filesystem_helper_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_runs_reverse_term_to_atom) :-
 	setup_call_cleanup(
 		(   retractall(user:py_term_to_atom_demo),
@@ -1729,6 +1767,11 @@ test(static_runtime_has_lua_baseline_builtins, [nondet]) :-
 		"atomic_list_concat/2",
 		"atomic_list_concat/3",
 		"split_string/4",
+		"exists_file/1",
+		"exists_directory/1",
+		"directory_files/2",
+		"make_directory/1",
+		"delete_file/1",
 		"var/1",
 		"nonvar/1",
 		"is_list/1",
@@ -1790,6 +1833,9 @@ test(static_runtime_io_emits_output, [nondet]) :-
 	sub_string(Content, _, _, _, "def _execute_string_code"),
 	sub_string(Content, _, _, _, "def _execute_atomic_list_concat"),
 	sub_string(Content, _, _, _, "def _execute_split_string"),
+	sub_string(Content, _, _, _, "def _execute_exists_file"),
+	sub_string(Content, _, _, _, "def _execute_directory_files"),
+	sub_string(Content, _, _, _, "def _execute_delete_file"),
 	sub_string(Content, _, _, _, "print()").
 
 :- end_tests(wam_python_builtin_parity_guard).


### PR DESCRIPTION
## Summary

- add Python WAM runtime support for `exists_file/1`
- add `exists_directory/1`, `directory_files/2`, and `make_directory/1`
- add `delete_file/1`
- cover generated-project filesystem behavior for directory creation, file creation/deletion, directory listing, and missing-file failure
- extend the Python builtin parity guard for the filesystem helper cluster

## Notes

The implementation follows the existing Python WAM runtime convention for I/O helpers: invalid path terms or OS errors fail quietly instead of throwing ISO-style errors. Directory listings include `.` and `..`, then sorted directory entries for deterministic test output.

## Verification

- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode),run_tests(wam_python_builtin_parity_guard)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
