### PR TITLE
feat(wam-haskell): make STArray (runMutableRegs) the default

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -3997,10 +3997,11 @@ generate_merged_code_build(DetectedKernels, Options, Code) :-
     ).
 
 generate_query_body(Options, QueryBody) :-
-    % Phase 3: select run function based on register_mode option
-    (   member(register_mode(st_array), Options)
-    ->  RunFn = 'runMutableRegs'
-    ;   RunFn = 'run'
+    % Phase 3: select run function. Default is runMutableRegs (STArray,
+    % 7.66x faster). Override with register_mode(intmap) for pure path.
+    (   member(register_mode(intmap), Options)
+    ->  RunFn = 'run'
+    ;   RunFn = 'runMutableRegs'
     ),
     % Emit a PURE expression so the seed loop can use `parMap rdeepseq`.
     % We use explicit braces and semicolons on the `let` to avoid Haskell's
@@ -4019,9 +4020,16 @@ generate_query_body(Options, QueryBody) :-
         % collectForeignSolutions which calls the native kernel directly.
         QueryBody =
 'let { hopsVarId = 1000000 ; s0 = emptyState { wsRegs = IM.fromList [ (1, Atom (iAtom cat)), (2, Atom (iAtom root)), (3, Unbound hopsVarId), (4, VList [Atom (iAtom cat)]) ], wsCP = 0 } ; !solutions = collectForeignSolutions ctx "category_ancestor/4" s0 hopsVarId ; !weightSum = sum [((hops + 1) ** negN) | hops <- solutions] } in (cat, weightSum)'
-    ;   % Default: collectSolutions loop for category_ancestor/4
-        QueryBody =
-'let { hopsVarId = 1000000 ; s0 = emptyState { wsPC = fromMaybe 1 $ Map.lookup "category_ancestor/4" mergedLabels, wsRegs = IM.fromList [ (1, Atom (iAtom cat)), (2, Atom (iAtom root)), (3, Unbound hopsVarId), (4, VList [Atom (iAtom cat)]) ], wsCP = 0 } ; !solutions = collectSolutions ctx s0 hopsVarId ; !weightSum = sum [((hops + 1) ** negN) | hops <- solutions] } in (cat, weightSum)'
+    ;   % Default: collectSolutions loop for category_ancestor/4.
+        % Phase 3: use collectSolutionsST (STArray mutable regs) by default.
+        % Override with register_mode(intmap) to use the pure IntMap path.
+        (   member(register_mode(intmap), Options)
+        ->  CollectFn = 'collectSolutions'
+        ;   CollectFn = 'collectSolutionsST'
+        ),
+        format(atom(QueryBody),
+'let { hopsVarId = 1000000 ; s0 = emptyState { wsPC = fromMaybe 1 $ Map.lookup "category_ancestor/4" mergedLabels, wsRegs = IM.fromList [ (1, Atom (iAtom cat)), (2, Atom (iAtom root)), (3, Unbound hopsVarId), (4, VList [Atom (iAtom cat)]) ], wsCP = 0 } ; !solutions = ~w ctx s0 hopsVarId ; !weightSum = sum [((hops + 1) ** negN) | hops <- solutions] } in (cat, weightSum)',
+            [CollectFn])
     ).
 
 %% detected_kernel_keys(+DetectedKernels, -Keys)

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -400,6 +400,25 @@ collectSolutions !ctx s0 hopsVarId =
           Just _ -> hops : rest
           Nothing -> rest
 
+-- | Phase 3: ST-mode collectSolutions using runMutableRegs.
+-- Same semantics as collectSolutions but uses mutable STArray registers
+-- for O(1) register access (7.66x faster on register-heavy workloads).
+collectSolutionsST :: WamContext -> WamState -> Int -> [Double]
+collectSolutionsST !ctx s0 hopsVarId =
+    case runMutableRegs ctx s0 of
+      Nothing -> []
+      Just s1 ->
+        let hopsVal = case IM.lookup hopsVarId (wsBindings s1) of
+              Just v -> extractDouble (wcInternTable ctx) (derefVar (wsBindings s1) v)
+              Nothing -> Nothing
+            hops = fromMaybe 0 hopsVal
+            rest = case backtrack s1 of
+              Just s2 -> collectSolutionsST ctx s2 hopsVarId
+              Nothing -> []
+        in case hopsVal of
+          Just _ -> hops : rest
+          Nothing -> rest
+
 -- | Collect all Hops solutions via executeForeign dispatch.
 -- Used when the query predicate has an FFI kernel — bypasses WAM
 -- code and calls the native kernel directly. The first result comes


### PR DESCRIPTION
## Summary

Make `runMutableRegs` (STArray) the default run function for all generated Haskell WAM projects. Previously, generated projects used `run` (IntMap) by default.

### Changes

- **Query body template**: `collectSolutionsST` replaces `collectSolutions` as the default for the WAM interpreter path
- **Aggregation path**: `runMutableRegs` replaces `run` for the `query_pred` optimized path
- **Override**: `register_mode(intmap)` codegen option restores the pure IntMap path
- **Main.hs template**: adds `collectSolutionsST` function (calls `runMutableRegs` internally, same solution-collection semantics)

### Correctness

Tested on the dev fixture (198 edges, 21 seeds): **0 mismatches** between IntMap and STArray paths. Both produce bit-identical effective-distance values.

### Expected impact

Based on the POC prototype benchmark (7.66x on synthetic WAM workload with similar instruction mix), the default ST path should bring the Haskell WAM from ~107ms to ~15-25ms on the effective-distance workload, approaching F#'s 11ms. A simplewiki-scale fixture would be needed to measure this precisely.

## Test plan

- [x] `swipl -q -g "use_module(src/unifyweaver/targets/wam_haskell_target)" -t halt` -- module loads
- [x] Generated project uses `collectSolutionsST` and `runMutableRegs` by default
- [x] GHC 9.4.7 build passes
- [x] `LANG=C.UTF-8 swipl -g main tests/core/test_wam_haskell_st_regs_bench.pl` -- 0 mismatches

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_