### PR TITLE
feat(wam-fsharp): CSR lmdb_offset backend + philosophy docs

### DIFF
--- a/docs/design/WAM_FSHARP_CSR_PHILOSOPHY.md
+++ b/docs/design/WAM_FSHARP_CSR_PHILOSOPHY.md
@@ -1,0 +1,196 @@
+# F# CSR Reverse-Index: Philosophy
+
+**Status**: Phase 1 reader implemented. Deeper integration pending.
+**Date**: 2026-05-25
+**Companion**: `WAM_REVERSE_INDEX_ARTIFACTS.md` (format spec),
+`WAM_FSHARP_CSR_PARALLEL_PLAN.md` (implementation plan)
+
+## 1. What CSR is for
+
+The effective-distance algorithm currently traverses *upward* only
+(child -> parent via `category_parent`). CSR enables *downward*
+traversal (parent -> children) for:
+
+- **Bidirectional search**: meet-in-the-middle from seed and root
+- **Demand-set expansion**: find all nodes reachable from root within
+  K hops, then compute distances only for those
+- **Non-carrot-shaped paths**: paths that go down before going up
+
+The existing Phase 1 reader (`CsrLookupSource`) provides the
+`ILookupSource` interface for parent -> children lookup from packed
+binary files.
+
+## 2. CSR and LMDB: complementary, not exclusive
+
+There are three relationships between CSR and LMDB:
+
+### 2.1 CSR alongside LMDB (current)
+
+CSR provides reverse (parent -> children) lookup while LMDB provides
+forward (child -> parent) lookup. Both coexist in `WcLookupSources`:
+
+```
+WcLookupSources = {
+    "category_parent" -> TwoLevelCachedLookupSource(LmdbCursorLookup(...)),
+    "category_child"  -> TwoLevelCachedLookupSource(CsrLookupSource(...))
+}
+```
+
+This is the simplest composition. Each direction has its own optimal
+backing store. The cost analyzer doesn't need to choose — both are
+available.
+
+### 2.2 CSR with LMDB offset index (Rust precedent)
+
+The CSR `.idx` file uses binary search (O(log n)) to find a parent's
+offset. For sparse parent ID spaces (e.g., Wikipedia page IDs with
+gaps), an LMDB offset index provides O(1) amortized lookup:
+
+```
+category_child.csr.offsets.lmdb:
+    key: int32_le parent_id
+    value: uint64_le offset_edges, uint32_le count_edges
+```
+
+The Rust `build_reverse_csr_artifact.py` already supports
+`--index-backend lmdb_offset`. The F# reader would open this LMDB
+for the index lookup while reading values from the flat `.val` file.
+
+### 2.3 CSR replacing LMDB for forward lookup
+
+If we build a CSR grouped by children (child -> parents), it could
+replace the `category_parent` LMDB DUPSORT database entirely:
+
+```
+category_parent.csr.idx   child -> (offset, count) records
+category_parent.csr.val   packed int32 parent IDs
+```
+
+**Trade-off**: CSR is read-only and requires preprocessing. LMDB
+supports concurrent writes and dynamic updates. CSR wins when:
+- The graph is static (typical for benchmark/batch workloads)
+- The working set exceeds OS page cache (CSR is more compact)
+- Sequential scan patterns dominate (CSR is contiguous)
+
+## 3. Dual-CSR: both directions as CSR
+
+For static graphs (the common case in effective-distance), we can
+build *both* directions as CSR:
+
+```
+category_parent.csr.idx/val   child -> [parents]   (upward walk)
+category_child.csr.idx/val    parent -> [children]  (downward walk)
+```
+
+This eliminates LMDB entirely for the hot path. The cost model needs:
+
+- **Preprocessing cost**: time to build both CSR artifacts from the
+  raw edge list (O(E log E) for sorting + O(E) for writing)
+- **Per-query savings**: CSR binary search + flat read vs LMDB
+  B-tree cursor traversal
+- **Expected query count**: amortizes preprocessing
+
+### 3.1 When dual-CSR wins
+
+```
+break_even_queries = preprocessing_cost / per_query_savings
+```
+
+For simplewiki (6k edges): preprocessing ~50ms, savings ~0.5ms/query
+-> break-even at ~100 queries. For enwiki (10M edges): preprocessing
+~10s, savings ~1ms/query -> break-even at ~10k queries.
+
+Batch workloads (computing effective distance for all articles)
+easily exceed break-even. Interactive single-query workloads don't.
+
+### 3.2 When LMDB wins
+
+- Dynamic graphs (edges added/removed between queries)
+- Single-query workloads (preprocessing not amortized)
+- Memory-mapped shared access (multiple processes reading same DB)
+- When the working set fits in OS page cache (LMDB B-tree
+  traversal is ~same cost as CSR binary search when pages are hot)
+
+## 4. Cost analyzer integration
+
+The cost analyzer (`src/unifyweaver/core/cost_model.pl`) needs these
+inputs to choose materialization strategy:
+
+| Input | Source | Used for |
+|---|---|---|
+| `expected_query_count` | caller/manifest | Break-even calculation |
+| `expected_lookups_per_query` | workload analysis | Total lookup volume |
+| `edge_count` | corpus manifest | Preprocessing cost estimate |
+| `graph_mutability` | caller declaration | CSR eligibility |
+| `direction_needed` | kernel analysis | Which CSR(s) to build |
+| `working_set_ratio` | demand filter output | Cache effectiveness |
+
+### 4.1 Decision tree
+
+```prolog
+resolve_edge_store(Options, Store) :-
+    option(expected_query_count(Q), Options),
+    option(expected_lookups_per_query(L), Options),
+    option(edge_count(E), Options),
+    TotalLookups is Q * L,
+    PreprocessCost is E * 0.00001,  % ~10us per edge for CSR build
+    PerLookupSavings is 0.000005,   % ~5us saved per lookup (CSR vs LMDB)
+    BreakEven is PreprocessCost / PerLookupSavings,
+    (   TotalLookups > BreakEven
+    ->  Store = csr
+    ;   Store = lmdb_cached
+    ).
+```
+
+### 4.2 Materialization options (resolved by cost analyzer)
+
+| Option | Store | When |
+|---|---|---|
+| `materialisation(lmdb_cached)` | LMDB + L1/L2 cache | Default, dynamic, few queries |
+| `materialisation(csr_parent)` | CSR child->parents | Static, many queries, upward only |
+| `materialisation(csr_child)` | CSR parent->children | Descendant exploration needed |
+| `materialisation(dual_csr)` | Both CSR directions | Bidirectional search, many queries |
+| `materialisation(lmdb_eager)` | LMDB -> IntMap at startup | Small corpus, all edges fit in RAM |
+
+## 5. Implementation roadmap
+
+### Phase 1 (done): F# CSR reader
+- `CsrLookupSource` implementing `ILookupSource`
+- `csr_path(Path)` codegen option
+- Binary search on `.idx`, positioned reads on `.val`
+- Wraps with `TwoLevelCachedLookupSource`
+
+### Phase 2: LMDB offset index backend
+- Add `index_backend(lmdb_offset)` support to `CsrLookupSource`
+- Open companion LMDB for O(1) parent -> (offset, count) lookup
+- Useful for sparse parent ID spaces (Wikipedia page IDs)
+
+### Phase 3: Forward CSR (child -> parents)
+- Build `category_parent.csr.idx/val` from LMDB
+- New `CsrParentLookupSource` or reuse `CsrLookupSource` with
+  different artifact path
+- Register in `WcLookupSources["category_parent"]`
+- Benchmark vs LMDB cached on effective-distance workload
+
+### Phase 4: Kernel integration
+- Wire `CsrLookupSource` (category_child) into the
+  effective-distance kernel for descendant-path exploration
+- Bidirectional search: upward from seed + downward from root,
+  meet in the middle
+- Demand-set expansion: enumerate root's descendants within K hops
+
+### Phase 5: Cost analyzer
+- `resolve_edge_store/2` predicate in `cost_model.pl`
+- Inputs: query count, lookups/query, edge count, mutability
+- Outputs: materialization strategy per relation per direction
+- Wire into `write_wam_fsharp_project/3` option resolution
+
+## 6. References
+
+- Format spec: `docs/design/WAM_REVERSE_INDEX_ARTIFACTS.md`
+- Plan: `docs/design/WAM_FSHARP_CSR_PARALLEL_PLAN.md`
+- Parity audit: `docs/design/WAM_FSHARP_PARITY_AUDIT.md`
+- Cost model: `src/unifyweaver/core/cost_model.pl`
+- Python builder: `examples/benchmark/build_reverse_csr_artifact.py`
+- F# reader: `templates/targets/fsharp_wam/csr_reader.fs.mustache`
+- Benchmark: `tests/core/test_wam_fsharp_csr_bench.pl`

--- a/docs/design/WAM_HASKELL_MUTABLE_REGISTERS_PHILOSOPHY.md
+++ b/docs/design/WAM_HASKELL_MUTABLE_REGISTERS_PHILOSOPHY.md
@@ -1,6 +1,6 @@
 # Haskell WAM Mutable Registers: Philosophy
 
-**Status**: POC validated. Full conversion pending.
+**Status**: Default in generated projects. 52/55 step arms converted.
 **Date**: 2026-05-25
 **POC benchmark**: commit `9889825` (PR #2471) --
 `examples/benchmark/haskell_register_bench/Main.hs`
@@ -106,7 +106,56 @@ The approach: wrap the `run` loop (including `step` and `backtrack`)
 inside `runST`. All register access becomes `readArray`/`writeArray`.
 The outer interface stays pure: `run :: WamContext -> WamState -> Maybe WamState`.
 
-## 6. References
+## 6. Future work
+
+### 6.1 Remaining bridge arms (~7)
+
+The following step arms still use the freeze/thaw bridge (converting
+between STArray and IntMap per call). These are rare in the hot loop
+but would eliminate the last conversion overhead:
+
+- `member/2` (choice point creation inside builtin)
+- `\+/1` (negation-as-failure with parallel fast path)
+- `BeginAggregate` / `EndAggregate` (aggregate frames)
+- `SwitchOnConstant` (label-based, pre-resolution form)
+- `functor/3`, `=../2`, `copy_term/2` (term manipulation)
+- `CallFactStream` (Phase F2 fact iteration)
+
+### 6.2 Lowered emitter (4 sites)
+
+`wam_haskell_lowered_emitter.pl` generates functions that access
+registers directly via `IM.lookup` and `IM.insert`. When a workload
+uses lowered predicates, these bypass `stepST` and miss the ST
+speedup. Converting these 4 sites requires the lowered functions to
+accept an `STArray` parameter or to be called from within the same
+`runST` block.
+
+### 6.3 Simplewiki-scale benchmark
+
+The dev fixture (198 edges) is too small for timing. A benchmark on
+simplewiki (6k+ edges, 300+ seeds) would measure the actual speedup
+on the effective-distance workload. The POC prototype predicts 7.66x;
+the real number depends on how often the bridge arms are hit and on
+the overhead of `freeze` at choice points.
+
+### 6.4 Bindings store
+
+`wsBindings` (also IntMap) is the second-hottest data structure after
+registers. Converting it to a mutable hash table or flat array would
+give additional speedup. The trade-off is more complex: bindings
+grow unboundedly (unlike registers which are fixed at 200), and trail
+undo needs efficient deletion. A segmented approach (mutable array
+for recently-bound variables, IntMap for overflow) may work.
+
+### 6.5 Parallel seed dispatch via runST
+
+Each seed currently runs through `parMap rdeepseq` with `run` (pure).
+With `runMutableRegs` (also pure via `runST`), each seed still gets
+its own isolated mutable register file — the type system prevents
+sharing. The parallel infrastructure (`parMap`, `async`) should work
+unchanged. Testing with `-N4` on a larger fixture would confirm.
+
+## 7. References
 
 - POC benchmark: `examples/benchmark/haskell_register_bench/Main.hs`
   (commit `9889825`, PR #2471)

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -5058,13 +5058,20 @@ format_foreign_preds_fs(Keys, Str) :-
 generate_fsproj(ModName, Options, Code) :-
     (   option(lmdb_path(_), Options)
     ->  LmdbCompile  = '\n    <Compile Include="LmdbFactSource.fs" />',
-        LmdbPackage  = '\n  <ItemGroup>\n    <PackageReference Include="LightningDB" Version="0.21.0" />\n  </ItemGroup>\n'
+        NeedLightningDB = true
     ;   LmdbCompile  = '',
-        LmdbPackage  = ''
+        NeedLightningDB = false
     ),
     (   option(csr_path(_), Options)
-    ->  CsrCompile = '\n    <Compile Include="CsrReader.fs" />'
-    ;   CsrCompile = ''
+    ->  CsrCompile = '\n    <Compile Include="CsrReader.fs" />',
+        NeedLightningDBForCsr = true
+    ;   CsrCompile = '',
+        NeedLightningDBForCsr = false
+    ),
+    %% Include LightningDB if either LMDB or CSR needs it
+    (   (NeedLightningDB = true ; NeedLightningDBForCsr = true)
+    ->  LmdbPackage = '\n  <ItemGroup>\n    <PackageReference Include="LightningDB" Version="0.21.0" />\n  </ItemGroup>\n'
+    ;   LmdbPackage = ''
     ),
     format(string(Code),
 '<Project Sdk="Microsoft.NET.Sdk">

--- a/templates/targets/fsharp_wam/csr_reader.fs.mustache
+++ b/templates/targets/fsharp_wam/csr_reader.fs.mustache
@@ -5,6 +5,10 @@
 //   category_child.csr.val   int32_le child IDs (4 bytes each)
 //   category_child.csr.meta  JSON manifest (format: unifyweaver.reverse_csr.v1)
 //
+// Supports two index backends:
+//   sorted_array: binary search on the .idx file (default)
+//   lmdb_offset: O(1) lookup via companion LMDB offset index
+//
 // Implements ILookupSource for reverse child-edge lookup (parent -> children).
 // Plugs into the same WcLookupSources ecosystem as LmdbCursorLookup and
 // TwoLevelCachedLookupSource.
@@ -36,6 +40,25 @@ let loadIdx (idxPath: string) : CsrIdxRecord array =
           OffsetEdges = int64 (BitConverter.ToUInt64(data, off + 4))
           CountEdges = int (BitConverter.ToUInt32(data, off + 12)) })
 
+/// Read children from the .val file at the given offset.
+let private readChildren (valStream: FileStream) (valLock: obj)
+                         (offsetEdges: int64) (countEdges: int) : int list =
+    if countEdges = 0 then []
+    else
+        let byteOffset = offsetEdges * 4L
+        let byteCount = countEdges * 4
+        let buffer = Array.zeroCreate<byte> byteCount
+        lock valLock (fun () ->
+            valStream.Seek(byteOffset, SeekOrigin.Begin) |> ignore
+            let mutable totalRead = 0
+            while totalRead < byteCount do
+                let n = valStream.Read(buffer, totalRead, byteCount - totalRead)
+                if n = 0 then failwith "CSR values file ended before full child slice"
+                totalRead <- totalRead + n
+        )
+        [ for j in 0 .. countEdges - 1 ->
+            BitConverter.ToInt32(buffer, j * 4) ]
+
 /// CSR-backed child lookup implementing ILookupSource.
 ///
 /// Index: loaded into memory at construction (small -- 16 bytes per parent).
@@ -61,22 +84,27 @@ type CsrLookupSource(artifactDir: string) =
         if enc <> "int32_le" then
             failwithf "unsupported CSR id_encoding: %s" enc
 
+    let indexBackend =
+        if root.TryGetProperty("index_backend") |> fst then
+            root.GetProperty("index_backend").GetString()
+        else "sorted_array"
+
     let idxPath = Path.Combine(artifactDir, root.GetProperty("index_path").GetString())
     let valPath = Path.Combine(artifactDir, root.GetProperty("values_path").GetString())
     let idx = loadIdx idxPath
     let valStream = new FileStream(valPath, FileMode.Open, FileAccess.Read, FileShare.Read)
     let valLock = obj()
 
-    /// Binary search for parent ID in the sorted index. Returns index or -1.
-    let binarySearch (parent: int) : int =
+    /// Binary search for parent ID in the sorted index. Returns (offset, count) or None.
+    let binarySearchLookup (parent: int) : (int64 * int) option =
         let mutable lo = 0
         let mutable hi = idx.Length - 1
-        let mutable result = -1
+        let mutable result = None
         while lo <= hi do
             let mid = lo + (hi - lo) / 2
             let midParent = idx.[mid].Parent
             if midParent = parent then
-                result <- mid
+                result <- Some (idx.[mid].OffsetEdges, idx.[mid].CountEdges)
                 lo <- hi + 1
             elif midParent < parent then
                 lo <- mid + 1
@@ -84,8 +112,65 @@ type CsrLookupSource(artifactDir: string) =
                 hi <- mid - 1
         result
 
+    /// LMDB offset index lookup (when index_backend = "lmdb_offset").
+    /// Opens the companion LMDB and looks up the parent key.
+    /// Value format: uint64_le offset_edges (8) + uint32_le count_edges (4) = 12 bytes.
+    let lmdbOffsetEnv =
+        if indexBackend = "lmdb_offset" then
+            let offsetPath =
+                if root.TryGetProperty("offset_index_path") |> fst then
+                    Path.Combine(artifactDir, root.GetProperty("offset_index_path").GetString())
+                else
+                    Path.Combine(artifactDir, "category_child.csr.offsets.lmdb")
+            if Directory.Exists(offsetPath) then
+                let env = new LightningDB.LightningEnvironment(offsetPath)
+                env.MaxDatabases <- 2
+                env.Open(LightningDB.EnvironmentOpenFlags.ReadOnly ||| LightningDB.EnvironmentOpenFlags.NoLock)
+                Some env
+            else None
+        else None
+
+    let lmdbOffsetDb =
+        match lmdbOffsetEnv with
+        | Some env ->
+            let dbName =
+                if root.TryGetProperty("offset_index_database") |> fst then
+                    root.GetProperty("offset_index_database").GetString()
+                else "offsets"
+            use tx = env.BeginTransaction(LightningDB.TransactionBeginFlags.ReadOnly)
+            let db = tx.OpenDatabase(dbName, new LightningDB.DatabaseConfiguration(Flags = LightningDB.DatabaseOpenFlags.None))
+            tx.Commit()
+            Some db
+        | None -> None
+
+    let lmdbOffsetLookup (parent: int) : (int64 * int) option =
+        match lmdbOffsetEnv, lmdbOffsetDb with
+        | Some env, Some db ->
+            use tx = env.BeginTransaction(LightningDB.TransactionBeginFlags.ReadOnly)
+            use cursor = tx.CreateCursor(db)
+            let keyBytes = BitConverter.GetBytes(parent)
+            let struct (rc, _, _) = cursor.SetKey(keyBytes)
+            if rc <> LightningDB.MDBResultCode.Success then None
+            else
+                let struct (_, _, v) = cursor.GetCurrent()
+                let vBytes = v.CopyToNewArray()
+                if vBytes.Length >= 12 then
+                    let offsetEdges = int64 (BitConverter.ToUInt64(vBytes, 0))
+                    let countEdges = int (BitConverter.ToUInt32(vBytes, 8))
+                    Some (offsetEdges, countEdges)
+                else None
+        | _ -> None
+
+    /// Dispatch to the appropriate index backend.
+    let lookupOffsetCount (parent: int) : (int64 * int) option =
+        if indexBackend = "lmdb_offset" then
+            lmdbOffsetLookup parent
+        else
+            binarySearchLookup parent
+
     member _.ParentCount = root.GetProperty("parent_count").GetInt32()
     member _.EdgeCount = root.GetProperty("edge_count").GetInt32()
+    member _.IndexBackend = indexBackend
 
     /// List all parent IDs in the index (sorted).
     member _.Parents () : int array =
@@ -93,30 +178,18 @@ type CsrLookupSource(artifactDir: string) =
 
     interface WamTypes.ILookupSource with
         member _.Lookup(key: int) : int list =
-            let i = binarySearch key
-            if i < 0 then []
-            else
-                let record = idx.[i]
-                let byteOffset = record.OffsetEdges * 4L
-                let byteCount = record.CountEdges * 4
-                if byteCount = 0 then []
-                else
-                    let buffer = Array.zeroCreate<byte> byteCount
-                    lock valLock (fun () ->
-                        valStream.Seek(byteOffset, SeekOrigin.Begin) |> ignore
-                        let mutable totalRead = 0
-                        while totalRead < byteCount do
-                            let n = valStream.Read(buffer, totalRead, byteCount - totalRead)
-                            if n = 0 then failwith "CSR values file ended before full child slice"
-                            totalRead <- totalRead + n
-                    )
-                    [ for j in 0 .. record.CountEdges - 1 ->
-                        BitConverter.ToInt32(buffer, j * 4) ]
+            match lookupOffsetCount key with
+            | None -> []
+            | Some (offsetEdges, countEdges) ->
+                readChildren valStream valLock offsetEdges countEdges
 
     interface IDisposable with
         member _.Dispose() =
             valStream.Dispose()
             meta.Dispose()
+            match lmdbOffsetEnv with
+            | Some env -> env.Dispose()
+            | None -> ()
 
 /// Open a CSR artifact directory and return a CsrLookupSource.
 let openCsr (artifactDir: string) : CsrLookupSource =


### PR DESCRIPTION
## Summary

- **CSR `lmdb_offset` backend**: `CsrLookupSource` now supports two index backends, auto-detected from the `.csr.meta` manifest:
  - `sorted_array` (default): binary search on the in-memory `.idx` file
  - `lmdb_offset`: O(1) lookup via companion LMDB offset index (`category_child.csr.offsets.lmdb`)

- **F# CSR philosophy doc**: covers dual-CSR concept (both directions as CSR, eliminating LMDB from hot path), cost analyzer integration (break-even from expected queries/lookups/edges), and 5-phase roadmap

- **Haskell future work doc**: remaining bridge arms, lowered emitter, bindings store, parallel seed dispatch

- **.fsproj**: LightningDB now included when CSR is enabled (needed for `lmdb_offset` backend even without `lmdb_path`)

### LMDB offset backend

When `build_reverse_csr_artifact.py --index-backend lmdb_offset` writes a companion LMDB, the F# reader opens it for O(1) parent lookup. Useful for sparse ID spaces (Wikipedia page IDs with gaps) where binary search on 1.5M+ records becomes measurable.

### Tested

- `sorted_array`: existing smoke test passes
- `lmdb_offset`: E2E verified (50 parents, 200 edges, correct results)

## Test plan

- [x] `swipl -g main tests/core/test_wam_fsharp_csr_smoke.pl` -- sorted_array backend passes
- [x] Manual E2E with `--index-backend lmdb_offset` -- correct results
- [x] Prolog module loads without errors

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_