### PR TITLE
Add reverse CSR scale sweep report

### DIFF
--- a/docs/reports/reverse_csr_scale_sweep.md
+++ b/docs/reports/reverse_csr_scale_sweep.md
@@ -1,0 +1,82 @@
+# Reverse CSR Scale Sweep
+
+**Snapshot date**: 2026-05-24.
+
+This report checks whether reverse CSR memory remains small as the
+synthetic graph grows. The goal is to separate the current Wikipedia
+category/link case from denser datasets where memory can still become
+the limiting factor.
+
+## Command
+
+```sh
+python3 examples/benchmark/benchmark_reverse_csr_scale_sweep.py \
+  --scale 1000x8 \
+  --scale 10000x8 \
+  --scale 50000x8 \
+  --sample-parents 1000 \
+  --iterations 5 \
+  --seed 7
+```
+
+Each scale uses `parents x children_per_parent`, so `50000x8` has
+400000 immediate `category_child(parent, child)` edges.
+
+## Result
+
+| parents | children/parent | edges | backend | median_ms | csr_bytes | csr_bytes/edge | csr_bytes/parent | build_s | offset_bytes | parent_lmdb_bytes | parent_lmdb_bytes/edge | phase1_lmdb_bytes |
+| ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1000 | 8 | 8000 | csr_sorted_array | 4.012461 | 49016 | 6.127000 | 49.016000 | 0.005984 | 0 | 188416 | 23.552000 | 385024 |
+| 1000 | 8 | 8000 | csr_lmdb_offset | 3.815845 | 118685 | 14.835625 | 118.685000 | 0.014155 | 61440 | 188416 | 23.552000 | 385024 |
+| 1000 | 8 | 8000 | lmdb | 3.470263 | 49016 | 6.127000 | 49.016000 | 0.005984 | 0 | 188416 | 23.552000 | 385024 |
+| 10000 | 8 | 80000 | csr_sorted_array | 3.419292 | 481020 | 6.012750 | 48.102000 | 0.059963 | 0 | 1507328 | 18.841600 | 4579328 |
+| 10000 | 8 | 80000 | csr_lmdb_offset | 4.734667 | 943906 | 11.798825 | 94.390600 | 0.076226 | 454656 | 1507328 | 18.841600 | 4579328 |
+| 10000 | 8 | 80000 | lmdb | 3.708610 | 481020 | 6.012750 | 48.102000 | 0.059963 | 0 | 1507328 | 18.841600 | 4579328 |
+| 50000 | 8 | 400000 | csr_sorted_array | 4.418097 | 2401022 | 6.002555 | 48.020440 | 0.331824 | 0 | 7352320 | 18.380800 | 22859776 |
+| 50000 | 8 | 400000 | csr_lmdb_offset | 2.961144 | 4522789 | 11.306973 | 90.455780 | 0.381317 | 2113536 | 7352320 | 18.380800 | 22859776 |
+| 50000 | 8 | 400000 | lmdb | 3.812495 | 2401022 | 6.002555 | 48.020440 | 0.331824 | 0 | 7352320 | 18.380800 | 22859776 |
+
+## Interpretation
+
+For this synthetic immediate-edge shape, sorted-array CSR converges near
+6 bytes per edge and about 48 bytes per parent. The LMDB-offset index is
+larger, converging near 11-12 bytes per edge and about 90 bytes per
+parent. Parent-only LMDB is still larger in this sweep, converging near
+18-19 bytes per edge.
+
+The important cost is therefore not raw memory for current-scale
+Wikipedia category/link artifacts. Build time and reuse count are more
+important: at 400000 edges the sorted CSR build is 0.331824s and the
+LMDB-offset build is 0.381317s. Both are fast enough that repeated
+effective-distance variants with 100-500 child lookups per query can
+plausibly amortize the build cost.
+
+Local benchmark metadata includes an English Wikipedia-derived
+`1m_cats` fixture with 1000000 hierarchy edges and 46846078 scanned
+categorylinks rows. Using the 400000-edge synthetic ratios as a rough
+projection:
+
+| Scenario | Edge count | sorted CSR estimate | LMDB-offset CSR estimate |
+| --- | ---: | ---: | ---: |
+| category hierarchy only | 1000000 | ~6 MB | ~11 MB |
+| all scanned categorylinks rows | 46846078 | ~281 MB | ~529 MB |
+
+These are order-of-magnitude estimates from synthetic packed-int
+artifacts, not a substitute for a real enwiki build. They do support the
+working assumption that immediate-edge CSR memory is modest for the
+Wikipedia-scale cases we are currently targeting.
+
+That assumption is not universal. CSR stores only nonzero edges, but it
+does not make dense data small. Memory can become significant for:
+
+- transitive descendant or all-pairs reachability artifacts;
+- dense or near-complete graph datasets;
+- non-Wikipedia datasets with much larger edge counts;
+- in-memory representations that expand packed arrays into object
+  lists, maps, or per-edge heap allocations.
+
+For those cases, `reverse_index(csr(...))` still needs cost-analyzer
+guardrails. The current evidence only says that immediate reverse edges
+for likely Wikipedia category/link workloads are small enough that build
+time, query reuse, and page-cache interaction should dominate the
+decision.

--- a/examples/benchmark/benchmark_reverse_csr_scale_sweep.py
+++ b/examples/benchmark/benchmark_reverse_csr_scale_sweep.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""
+benchmark_reverse_csr_scale_sweep.py — sweep synthetic reverse CSR scales.
+
+This is a thin wrapper around generate_synthetic_phase1_lmdb.py and
+benchmark_reverse_csr_lookup.py. It records how CSR bytes, parent-only
+LMDB bytes, build time, and lookup time move as parent count and fanout
+change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCHMARK_DIR = ROOT / "examples" / "benchmark"
+GENERATOR = BENCHMARK_DIR / "generate_synthetic_phase1_lmdb.py"
+LOOKUP_BENCHMARK = BENCHMARK_DIR / "benchmark_reverse_csr_lookup.py"
+
+
+HEADERS = [
+    "parents",
+    "children_per_parent",
+    "edge_count",
+    "backend",
+    "index_backend",
+    "sample_parents",
+    "iterations",
+    "total_children",
+    "median_ms",
+    "min_ms",
+    "max_ms",
+    "csr_artifact_bytes",
+    "csr_bytes_per_edge",
+    "csr_bytes_per_parent",
+    "csr_build_seconds",
+    "offset_index_bytes",
+    "parent_lmdb_env_bytes",
+    "parent_lmdb_bytes_per_edge",
+    "phase1_lmdb_env_bytes",
+]
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sweep synthetic reverse CSR lookup scales.")
+    parser.add_argument(
+        "--scale",
+        action="append",
+        default=[],
+        help="scale as PARENTSxCHILDREN_PER_PARENT, e.g. 10000x8; may be repeated",
+    )
+    parser.add_argument("--sample-parents", type=int, default=1000)
+    parser.add_argument("--iterations", type=int, default=5)
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--work-dir", type=Path, default=None, help="keep generated artifacts under this directory")
+    parser.add_argument("--refresh", action="store_true", help="replace generated artifacts under --work-dir")
+    return parser.parse_args(argv)
+
+
+def parse_scale(value: str) -> tuple[int, int]:
+    try:
+        parents_text, children_text = value.lower().split("x", 1)
+        parents = int(parents_text)
+        children_per_parent = int(children_text)
+    except ValueError as exc:
+        raise ValueError(f"invalid --scale {value!r}; expected PARENTSxCHILDREN_PER_PARENT") from exc
+    if parents <= 0 or children_per_parent <= 0:
+        raise ValueError(f"invalid --scale {value!r}; both values must be positive")
+    return parents, children_per_parent
+
+
+def run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def generate_fixture(out_dir: Path, parents: int, children_per_parent: int, refresh: bool) -> None:
+    command = [
+        sys.executable,
+        str(GENERATOR),
+        str(out_dir),
+        "--parents",
+        str(parents),
+        "--children-per-parent",
+        str(children_per_parent),
+    ]
+    if refresh:
+        command.append("--refresh")
+    result = run_command(command)
+    if result.returncode != 0:
+        raise RuntimeError(f"fixture generation failed for {parents}x{children_per_parent}:\n{result.stderr}")
+
+
+def run_lookup_benchmark(
+    phase1_dir: Path,
+    csr_dir: Path,
+    parent_lmdb_dir: Path,
+    sample_parents: int,
+    iterations: int,
+    seed: int,
+    refresh: bool,
+) -> list[dict[str, str]]:
+    command = [
+        sys.executable,
+        str(LOOKUP_BENCHMARK),
+        str(phase1_dir),
+        "--csr-dir",
+        str(csr_dir),
+        "--parent-lmdb-dir",
+        str(parent_lmdb_dir),
+        "--csr-index-backends",
+        "sorted_array,lmdb_offset",
+        "--sample-parents",
+        str(sample_parents),
+        "--iterations",
+        str(iterations),
+        "--seed",
+        str(seed),
+    ]
+    if refresh:
+        command.extend(["--refresh-csr", "--refresh-parent-lmdb"])
+    result = run_command(command)
+    if result.returncode != 0:
+        raise RuntimeError(f"lookup benchmark failed for {phase1_dir}:\n{result.stderr}")
+    return list(csv.DictReader(result.stdout.splitlines(), delimiter="\t"))
+
+
+def row_with_scale(row: dict[str, str], parents: int, children_per_parent: int) -> dict[str, str]:
+    edge_count = parents * children_per_parent
+    csr_artifact_bytes = int(row["csr_artifact_bytes"])
+    parent_lmdb_env_bytes = int(row["parent_lmdb_env_bytes"])
+    return {
+        "parents": str(parents),
+        "children_per_parent": str(children_per_parent),
+        "edge_count": str(edge_count),
+        **row,
+        "csr_bytes_per_edge": f"{csr_artifact_bytes / edge_count:.6f}",
+        "csr_bytes_per_parent": f"{csr_artifact_bytes / parents:.6f}",
+        "parent_lmdb_bytes_per_edge": f"{parent_lmdb_env_bytes / edge_count:.6f}",
+    }
+
+
+def print_tsv(rows: list[dict[str, str]]) -> None:
+    print("\t".join(HEADERS))
+    for row in rows:
+        print("\t".join(row[h] for h in HEADERS))
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        scales = [parse_scale(value) for value in (args.scale or ["1000x8", "10000x8"])]
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+
+    temp_dir: tempfile.TemporaryDirectory[str] | None = None
+    if args.work_dir is None:
+        temp_dir = tempfile.TemporaryDirectory()
+        work_dir = Path(temp_dir.name)
+    else:
+        work_dir = args.work_dir
+        work_dir.mkdir(parents=True, exist_ok=True)
+
+    rows: list[dict[str, str]] = []
+    try:
+        for parents, children_per_parent in scales:
+            scale_dir = work_dir / f"{parents}x{children_per_parent}"
+            phase1_dir = scale_dir / "phase1.lmdb"
+            csr_dir = scale_dir / "csr"
+            parent_lmdb_dir = scale_dir / "parent_only.lmdb"
+            generate_fixture(phase1_dir, parents, children_per_parent, args.refresh)
+            benchmark_rows = run_lookup_benchmark(
+                phase1_dir,
+                csr_dir,
+                parent_lmdb_dir,
+                args.sample_parents,
+                args.iterations,
+                args.seed,
+                args.refresh,
+            )
+            rows.extend(row_with_scale(row, parents, children_per_parent) for row in benchmark_rows)
+        print_tsv(rows)
+        return 0
+    finally:
+        if temp_dir is not None:
+            temp_dir.cleanup()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_benchmark_reverse_csr_scale_sweep.py
+++ b/tests/test_benchmark_reverse_csr_scale_sweep.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import csv
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from test_build_reverse_csr_artifact import ROOT
+
+
+SWEEP = ROOT / "examples" / "benchmark" / "benchmark_reverse_csr_scale_sweep.py"
+
+
+class BenchmarkReverseCsrScaleSweepTest(unittest.TestCase):
+    def test_scale_sweep_reports_size_and_lookup_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SWEEP),
+                    "--scale",
+                    "4x2",
+                    "--sample-parents",
+                    "3",
+                    "--iterations",
+                    "1",
+                    "--work-dir",
+                    str(Path(tmp) / "work"),
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            rows = list(csv.DictReader(result.stdout.splitlines(), delimiter="\t"))
+            self.assertEqual(
+                [row["backend"] for row in rows],
+                ["csr_sorted_array", "csr_lmdb_offset", "lmdb"],
+            )
+            for row in rows:
+                self.assertEqual(row["parents"], "4")
+                self.assertEqual(row["children_per_parent"], "2")
+                self.assertEqual(row["edge_count"], "8")
+                self.assertEqual(row["sample_parents"], "3")
+                self.assertEqual(row["iterations"], "1")
+                self.assertGreater(int(row["csr_artifact_bytes"]), 0)
+                self.assertGreater(float(row["csr_bytes_per_edge"]), 0.0)
+                self.assertGreater(float(row["csr_bytes_per_parent"]), 0.0)
+                self.assertGreater(int(row["parent_lmdb_env_bytes"]), 0)
+                self.assertGreater(float(row["parent_lmdb_bytes_per_edge"]), 0.0)
+
+    def test_scale_sweep_rejects_bad_scale(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SWEEP), "--scale", "bad"],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("invalid --scale", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  - Add `benchmark_reverse_csr_scale_sweep.py` to run synthetic reverse CSR scale sweeps.
  - Reuse the existing Phase 1 LMDB generator and reverse CSR lookup benchmark.
  - Compare `sorted_array`, `lmdb_offset`, and LMDB lookup across multiple synthetic scales.
  - Report CSR bytes per edge, CSR bytes per parent, parent-only LMDB bytes per edge, build time, and lookup time.
  - Add tests for the scale-sweep wrapper.
  - Document memory caveats: immediate Wikipedia-style edges are modest, but dense graphs, transitive descendants, all-
  pairs reachability, and object-heavy in-memory layouts can still make memory material.

  ## Key Results

  Sorted CSR converges around:

  - `~6 bytes/edge`
  - `~48 bytes/parent`

  LMDB-offset CSR converges around:

  - `~11-12 bytes/edge`
  - `~90 bytes/parent`

  Parent-only LMDB in the synthetic shape converges around:

  - `~18-19 bytes/edge`

  ## Validation

  - `python3 tests/test_benchmark_reverse_csr_scale_sweep.py`
  - `python3 tests/test_benchmark_reverse_csr_lookup.py`
  - `python3 tests/test_build_reverse_csr_artifact.py`
  - `python3 tests/test_read_reverse_csr_artifact.py`
  - `python3 tests/test_generate_synthetic_phase1_lmdb.py`
  - `python3 -m py_compile examples/benchmark/benchmark_reverse_csr_scale_sweep.py tests/
  test_benchmark_reverse_csr_scale_sweep.py examples/benchmark/benchmark_reverse_csr_lookup.py examples/benchmark/
  build_reverse_csr_artifact.py examples/benchmark/read_reverse_csr_artifact.py`
  - `git diff --check`