### PR TITLE
docs: template testing plan + Program.fs migration design

### DIFF
--- a/docs/design/PROMPT_FSHARP_PROGRAM_TEMPLATE.md
+++ b/docs/design/PROMPT_FSHARP_PROGRAM_TEMPLATE.md
@@ -1,0 +1,73 @@
+# Prompt: Migrate F# Program.fs to Mustache Template
+
+## Context
+
+The F# WAM target generates `Program.fs` as a ~200-line Prolog
+format string embedded in `generate_program_fs/4` in
+`src/unifyweaver/targets/wam_fsharp_target.pl` (lines 4843-5049).
+
+The template system (`src/unifyweaver/core/template_system.pl`)
+now supports `{{match key}}{{case val}}...{{/match}}` blocks
+for multi-valued dispatch, plus the existing `{{#flag}}`/`{{^flag}}`
+sections and `{{name}}` substitution.
+
+## Task
+
+Extract Program.fs from the inline Prolog format string into
+`templates/targets/fsharp_wam/program.fs.mustache`, using template
+constructs for conditional logic.
+
+### Prerequisite check
+
+Before starting, verify template match/case tests pass:
+```
+swipl -q -g test_template_system -t halt src/unifyweaver/core/template_system.pl
+```
+
+If the match/case edge case tests have not been added yet, see
+`docs/design/PROMPT_TEMPLATE_MATCH_TESTING.md` and do that first.
+
+### Specific deliverables
+
+1. **Create `templates/targets/fsharp_wam/program.fs.mustache`**
+   with the Program.fs content, replacing:
+   - `~w` format variables with `{{name}}` template variables
+   - Prolog conditional logic with `{{#flag}}` and `{{match key}}`
+   - See design doc `WAM_FSHARP_PROGRAM_TEMPLATE_MIGRATION.md`
+     for the full variable table and match block examples
+
+2. **Update `generate_program_fs/4`** in `wam_fsharp_target.pl` to:
+   - Compute a Dict of template variables
+   - Load the template via a new `fsharp_program_template_source/1`
+   - Call `render_template/3`
+   - The predicate should be ~20 lines, not ~200
+
+3. **Add `fsharp_program_template_source/1`** following the pattern
+   of `fsharp_lmdb_template_source/1` (line 4690+)
+
+4. **Verify all existing tests pass**:
+   ```
+   swipl -g main tests/core/test_wam_fsharp_csr_smoke.pl
+   swipl -g main tests/core/test_wam_fsharp_csr_bench.pl
+   ```
+
+5. **Verify generated output is equivalent** to pre-migration by
+   diff-comparing generated Program.fs with both old and new paths
+
+### Key files
+
+- `src/unifyweaver/targets/wam_fsharp_target.pl` -- current
+  `generate_program_fs/4` (lines 4843-5049), template loaders
+  (lines 4690-4710)
+- `src/unifyweaver/core/template_system.pl` -- `render_template/3`
+- `templates/targets/fsharp_wam/*.mustache` -- existing templates
+- `docs/design/WAM_FSHARP_PROGRAM_TEMPLATE_MIGRATION.md` -- design
+
+### Watch out for
+
+- Single quotes in F# code (e.g., `'\t'`) -- these are fine in
+  template files but were `''\\t''` in the Prolog format string
+- The template's `{{` delimiters don't conflict with F# syntax
+  (F# uses `{ }` for records but not `{{ }}`)
+- The format string has exactly 4 `~w` placeholders matching
+  `[LmdbOpen, CsrOpen, ForeignPredsStr, LookupSourcesExpr]`

--- a/docs/design/PROMPT_TEMPLATE_MATCH_TESTING.md
+++ b/docs/design/PROMPT_TEMPLATE_MATCH_TESTING.md
@@ -1,0 +1,59 @@
+# Prompt: Template System Match/Case Testing
+
+## Context
+
+The template system (`src/unifyweaver/core/template_system.pl`) was
+extended with `{{match key}}{{case val}}...{{default}}...{{/match}}`
+blocks for multi-valued option dispatch. The feature is implemented
+and happy-path tested (7 cases) but edge cases are untested.
+
+## Task
+
+Add comprehensive tests for the match/case feature. Follow the
+testing plan in `docs/design/WAM_TEMPLATE_MATCH_CASE_TESTING.md`.
+
+### Specific deliverables
+
+1. **Add tests to `test_template_system/0`** in
+   `src/unifyweaver/core/template_system.pl` (around line 850+).
+   Cover sections 3.1 through 3.8 of the testing plan.
+
+2. **Create `tests/test_template_match_case.pl`** for isolated
+   edge case tests (nested matches, malformed blocks) that might
+   fail and need fixes.
+
+3. **Fix any bugs found** -- particularly:
+   - Nested match blocks (section 3.2) likely fail because
+     `find_match_block` finds the first `{{/match}}` instead of
+     the balanced closing one. Fix with depth-counting or
+     recursive parsing if needed.
+   - Case values with hyphens (section 3.4) may fail atom parsing.
+   - Malformed blocks (section 3.8) should not crash.
+
+4. **Run `swipl -q -g test_template_system -t halt`** to verify
+   all existing + new tests pass.
+
+### Key files
+
+- `src/unifyweaver/core/template_system.pl` -- implementation +
+  existing tests (search for `expand_match_blocks`, `case_matches`,
+  `test_template_system`)
+- `docs/design/WAM_TEMPLATE_MATCH_CASE_TESTING.md` -- full testing
+  plan with expected results for each case
+
+### Architecture notes
+
+- `render_template/3` pipeline: match blocks -> sections -> substitution
+- Match expansion runs first so case bodies can contain `{{#flag}}`
+  sections and `{{name}}` variables
+- `case_matches/2` is the extensibility point for future glob/regex
+  support (currently exact string match only)
+- The template system is used by both Haskell and F# WAM targets
+  for kernel templates, and will soon be used for Program.fs/Main.hs
+
+### What NOT to change
+
+- Don't change the `render_template/3` signature or pipeline order
+- Don't change existing section (`{{#flag}}`) behavior
+- Don't add glob/regex to `case_matches/2` yet (document as future)
+- Don't modify any WAM target files -- this is template-system only

--- a/docs/design/WAM_FSHARP_PROGRAM_TEMPLATE_MIGRATION.md
+++ b/docs/design/WAM_FSHARP_PROGRAM_TEMPLATE_MIGRATION.md
@@ -1,0 +1,121 @@
+# F# Program.fs Template Migration: Design
+
+**Status**: Design. Depends on template match/case testing.
+**Date**: 2026-05-25
+**Prerequisite**: `WAM_TEMPLATE_MATCH_CASE_TESTING.md` edge cases pass
+
+## 1. Problem
+
+The F# WAM target generates `Program.fs` as a ~200-line Prolog
+format string inside `generate_program_fs/4` in
+`src/unifyweaver/targets/wam_fsharp_target.pl` (lines 4843-5049).
+
+Issues:
+- Hard to read and edit (F# code inside single-quoted Prolog atom)
+- Quoting hell (`''` for literal single quotes, `~w` for variables)
+- No syntax highlighting in editors
+- Conditional code uses Prolog `format` arguments (`~w`) computed
+  before the format call, not template-level conditionals
+
+## 2. Proposed solution
+
+Move Program.fs to `templates/targets/fsharp_wam/program.fs.mustache`
+using the template system's `{{name}}`, `{{#flag}}`, and
+`{{match key}}` constructs.
+
+### Template variables
+
+| Variable | Source | Example |
+|---|---|---|
+| `{{foreign_preds}}` | `format_foreign_preds_fs/2` | `"category_ancestor/4"` |
+| `{{lookup_sources_expr}}` | `generate_lookup_sources_expr_fs/2` | `Map.ofList [...]` |
+| `{{module_opens}}` | conditional on options | `open CsrReader` |
+
+### Template conditionals
+
+```
+{{#has_csr}}
+open CsrReader
+{{/has_csr}}
+
+{{#has_lmdb}}
+open LmdbFactSource
+{{/has_lmdb}}
+```
+
+### Template match blocks
+
+```
+{{match materialisation}}
+{{case eager}}
+    let parentsInterned = loadCategoryParent env |> ...
+{{case cached}}
+    let cachedSrc = TwoLevelCachedLookupSource(...)
+{{case lazy}}
+    let lazySrc = LmdbCursorLookup(env, "category_parent")
+{{/match}}
+```
+
+## 3. Migration steps
+
+1. Extract the format string content to a new file:
+   `templates/targets/fsharp_wam/program.fs.mustache`
+
+2. Replace `~w` format variables with `{{name}}` template variables
+
+3. Replace conditional Prolog logic with `{{#flag}}` sections
+   and `{{match key}}` blocks
+
+4. Update `generate_program_fs/4` to:
+   - Compute template variables into a Dict
+   - Load the template file
+   - Call `render_template/3`
+
+5. Follow the pattern of `fsharp_lmdb_template_source/1` and
+   `fsharp_csr_template_source/1` for loading templates
+
+## 4. Template variable computation
+
+```prolog
+generate_program_fs(Predicates, DetectedKernels, Options, Code) :-
+    pairs_keys(DetectedKernels, ForeignKeys),
+    format_foreign_preds_fs(ForeignKeys, ForeignPredsStr),
+    generate_lookup_sources_expr_fs(Options, LookupSourcesExpr),
+    (option(csr_path(_), Options) -> HasCsr = true ; HasCsr = false),
+    (option(lmdb_path(_), Options) -> HasLmdb = true ; HasLmdb = false),
+    option(lmdb_materialisation(Materialisation), Options, cached),
+    Dict = [
+        foreign_preds = ForeignPredsStr,
+        lookup_sources_expr = LookupSourcesExpr,
+        has_csr = HasCsr,
+        has_lmdb = HasLmdb,
+        materialisation = Materialisation
+    ],
+    fsharp_program_template_source(Template),
+    render_template(Template, Dict, Code).
+```
+
+## 5. Risk
+
+- The template system's match/case has untested edge cases
+  (nested matches, special chars in values). Run the testing
+  plan in `WAM_TEMPLATE_MATCH_CASE_TESTING.md` first.
+- The existing format string works. Migration is a refactor,
+  not a feature. Don't break working tests.
+- Some F# code in the template contains `'` characters (e.g.,
+  `foldl'`) which might interact with template parsing.
+
+## 6. Testing
+
+After migration:
+- `swipl -g main tests/core/test_wam_fsharp_csr_smoke.pl` must pass
+- `swipl -g main tests/core/test_wam_fsharp_lmdb_smoke.pl` must pass
+- Generate a project with various option combinations and verify
+  the Program.fs content is identical to the pre-migration output
+
+## 7. References
+
+- Current implementation: `wam_fsharp_target.pl` lines 4843-5049
+- Template system: `src/unifyweaver/core/template_system.pl`
+- Existing template files: `templates/targets/fsharp_wam/*.mustache`
+- Template match/case testing: `WAM_TEMPLATE_MATCH_CASE_TESTING.md`

--- a/docs/design/WAM_TEMPLATE_MATCH_CASE_TESTING.md
+++ b/docs/design/WAM_TEMPLATE_MATCH_CASE_TESTING.md
@@ -1,0 +1,191 @@
+# Template System Match/Case: Testing Plan
+
+**Status**: Feature implemented, happy-path tested. Edge cases pending.
+**Date**: 2026-05-25
+**Feature location**: `src/unifyweaver/core/template_system.pl`
+**Predicates**: `expand_match_blocks/3`, `case_matches/2`,
+`find_match_block/5`, `parse_match_cases/3`, `resolve_match/5`
+
+## 1. What was implemented
+
+The template system was extended with `{{match key}}...{{/match}}`
+blocks for multi-valued option dispatch:
+
+```
+{{match mode}}
+{{case eager}}eager code
+{{case cached}}cached code
+{{default}}fallback
+{{/match}}
+```
+
+Processing order in `render_template/3`:
+1. `expand_match_blocks` (new) -- resolve match/case blocks
+2. `expand_sections` (existing) -- resolve `{{#flag}}`/`{{^flag}}`
+3. `render_template_string` (existing) -- substitute `{{name}}`
+
+The `case_matches/2` predicate currently does exact string match.
+It is factored out for future extension to glob/regex patterns.
+
+## 2. What was tested (happy path)
+
+Seven ad-hoc tests run via `swipl -q -g "..."`:
+
+1. Basic exact match: `mode=cached` matches `{{case cached}}`
+2. Default fallback: `mode=lazy` with no lazy case -> default
+3. No match, no default: produces empty string
+4. Variable substitution inside case body: `{{name}}` works
+5. Key not in dict: falls through to default
+6. Match inside section: `{{#enabled}}...{{match}}...{{/enabled}}`
+7. Multiple match blocks in one template
+
+## 3. What needs testing (edge cases)
+
+### 3.1 Nesting: section inside case body
+
+```
+{{match mode}}
+{{case cached}}
+{{#has_l2}}L2 enabled{{/has_l2}}
+{{^has_l2}}L2 disabled{{/has_l2}}
+{{case eager}}
+no cache
+{{/match}}
+```
+
+Expected: when `mode=cached, has_l2=true`, renders "L2 enabled".
+This tests that match expansion happens before section expansion
+(the current processing order).
+
+### 3.2 Nested match blocks
+
+```
+{{match outer}}
+{{case a}}
+  {{match inner}}
+  {{case x}}AX{{case y}}AY
+  {{/match}}
+{{case b}}B
+{{/match}}
+```
+
+Expected: when `outer=a, inner=y`, renders "AY".
+Risk: the `find_match_block` parser finds the first `{{match`
+and the first `{{/match}}` -- nested matches would close at the
+wrong `{{/match}}`. This likely FAILS with the current
+implementation and needs a fix (balanced-bracket parsing).
+
+### 3.3 Case values with special characters
+
+```
+{{match backend}}
+{{case lmdb_offset}}LMDB{{case sorted_array}}SORTED{{/match}}
+```
+
+Expected: `backend=lmdb_offset` renders "LMDB".
+The `valid_tag_name` check requires alphanumeric + underscore for
+section tags, but match keys go through `atom_string` -- verify
+underscores work in case values.
+
+### 3.4 Case values with hyphens/dots
+
+```
+{{match target}}
+{{case wam-fsharp}}F#{{case wam-haskell}}Haskell{{/match}}
+```
+
+Expected: `target=wam-fsharp` renders "F#".
+Risk: hyphens in case values may fail `atom_string` or the
+`find_case_at` parser if `}}` is not found correctly.
+
+### 3.5 Empty case body
+
+```
+{{match mode}}{{case skip}}{{case keep}}KEPT{{/match}}
+```
+
+Expected: `mode=skip` renders empty string; `mode=keep` renders "KEPT".
+
+### 3.6 Match with only default
+
+```
+{{match anything}}{{default}}ALWAYS{{/match}}
+```
+
+Expected: always renders "ALWAYS" regardless of dict.
+
+### 3.7 Whitespace handling
+
+```
+{{match mode}}
+  {{case eager}}
+    EAGER
+  {{case lazy}}
+    LAZY
+{{/match}}
+```
+
+Expected: rendered output includes the whitespace/newlines around
+the case body. Verify no spurious trimming.
+
+### 3.8 Malformed blocks
+
+- `{{match key}}` without `{{/match}}` -- should not crash
+  (ideally passes through unchanged or produces empty)
+- `{{match}}` without a key -- should not match
+- `{{case}}` without a value -- should not match
+- `{{/match}}` without opening -- should pass through
+
+### 3.9 Real template file
+
+Load a `.fs.mustache` or `.hs.mustache` file from disk that
+contains match blocks. Verify `render_template/3` works on
+file-loaded content (not just inline strings).
+
+### 3.10 Integration with codegen
+
+Generate an actual F# or Haskell project where the template
+uses `{{match register_mode}}` to select between `run` and
+`runMutableRegs`. Build with GHC/dotnet to verify the rendered
+code compiles.
+
+## 4. Where to add tests
+
+Add test cases to `test_template_system/0` in
+`src/unifyweaver/core/template_system.pl` (around line 850+).
+Follow the existing pattern:
+
+```prolog
+write('Test N - Match/case description: '),
+render_template(Template, Dict, Result),
+(   expected_check(Result)
+->  writeln('PASS')
+;   format('FAIL: got ~w~n', [Result])
+),
+```
+
+Also add a separate test file:
+`tests/test_template_match_case.pl` for the edge cases that
+might fail (nested matches, malformed blocks) -- these should
+be isolated so failures don't block the main test suite.
+
+## 5. Known limitations
+
+- **Nested match blocks**: likely broken (first `{{/match}}`
+  closes the outer block). Needs balanced-bracket parsing if
+  we want to support this. Low priority -- codegen rarely
+  needs nested match.
+- **Same-key multiple matches**: if two `{{match mode}}` blocks
+  appear in the same template, both are expanded independently.
+  This works correctly (tested as "multiple match blocks").
+- **Case ordering**: first matching case wins. No fall-through.
+- **No pattern matching**: only exact string equality. Future
+  extension via `case_matches/2` (documented in code).
+
+## 6. References
+
+- Implementation: `src/unifyweaver/core/template_system.pl`
+  lines 400-555 (expand_match_blocks and helpers)
+- Existing tests: `test_template_system/0` in same file
+- Philosophy: comments in `case_matches/2` (line 550+)
+  document future glob/regex extension points


### PR DESCRIPTION
## Summary

Design docs and session prompts for two follow-up tasks:

### 1. Template match/case testing (can run in parallel)
- **Testing plan** (`WAM_TEMPLATE_MATCH_CASE_TESTING.md`): 10 edge cases including nested match blocks, special chars, malformed blocks, whitespace handling
- **Session prompt** (`PROMPT_TEMPLATE_MATCH_TESTING.md`): self-contained instructions for a fresh session to implement tests and fix bugs
- Known issue: nested `{{match}}` blocks likely fail (first `{{/match}}` closes outer block)

### 2. Program.fs template migration (depends on #1)
- **Design doc** (`WAM_FSHARP_PROGRAM_TEMPLATE_MIGRATION.md`): plan to move 200-line Prolog format string to `.fs.mustache` file using `{{match}}`, `{{#flag}}`, and `{{name}}`
- **Session prompt** (`PROMPT_FSHARP_PROGRAM_TEMPLATE.md`): self-contained instructions with variable table, watch-out notes, and verification steps

### Sequencing
Template testing should run first (or in parallel). Program.fs migration depends on match/case working correctly for edge cases like hyphens in values and sections inside case bodies.

## Test plan

- [x] Design docs are self-contained and reference correct file paths/line numbers
- [x] Prompts include prerequisite checks and verification commands

https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjPz2RS2SGvs4er87nypP)_