### PR TITLE
Select CSR offset index from measured costs

### DIFF
--- a/docs/design/WAM_REVERSE_INDEX_ARTIFACTS.md
+++ b/docs/design/WAM_REVERSE_INDEX_ARTIFACTS.md
@@ -353,7 +353,7 @@ The first step is controlled by `index_backend(...)`:
 | `sorted_array` | Keep `.idx` sorted by parent ID and use binary search. | Simple, compact, no second LMDB lookup; best when the index fits in memory. |
 | `lmdb_offset` | Store `parent_id -> offset,count` or `parent_id -> idx_row` in an LMDB sub-db. | Handles sparse Wikipedia/page IDs without dense direct arrays; adds LMDB B-tree lookup and page-cache pressure. |
 | `dense_direct` | Store a direct array indexed by numeric parent ID. | Fastest lookup when IDs are dense; wasteful or impossible for sparse page-id spaces. |
-| `auto` | Let the cost analyzer choose. | Current conservative resolution is `sorted_array`; future overrides require measured density, index size, query count, and preprocessing terms. |
+| `auto` | Let the cost analyzer choose. | Defaults to `sorted_array`; may select `lmdb_offset` when measured lookup savings amortize extra build cost and the offset index fits the memory budget. |
 
 An LMDB offset index may store the final `.val` offset directly, or it
 may store the row number in `.idx`. Storing the final offset can skip the
@@ -363,6 +363,56 @@ extra preprocessing and another artifact to keep consistent with the CSR
 files. The cost analyzer should only choose it when the saved lookup
 work outweighs the additional build time, disk bytes, and page-cache
 touches.
+
+The first `auto` rule is deliberately narrow. It selects `lmdb_offset`
+only when all of these are known:
+
+```prolog
+expected_child_lookups_per_query(NLookups).
+expected_query_count_per_artifact(NQueries).
+sorted_array_lookup_ms_per_1000(SortedMs).
+lmdb_offset_lookup_ms_per_1000(OffsetMs).
+sorted_array_build_seconds(SortedBuild).
+lmdb_offset_build_seconds(OffsetBuild).
+```
+
+The rule computes:
+
+```text
+total_lookup_savings_seconds =
+  (NLookups * NQueries / 1000) * ((SortedMs - OffsetMs) / 1000)
+
+marginal_build_seconds =
+  max(0, OffsetBuild - SortedBuild)
+```
+
+`lmdb_offset` is eligible only when lookup savings is positive and
+`total_lookup_savings_seconds >= marginal_build_seconds`.
+
+It must also pass a memory guard. The caller can either declare:
+
+```prolog
+lmdb_offset_memory_fits(true).
+```
+
+or provide:
+
+```prolog
+lmdb_offset_bytes(Bytes).
+available_memory_bytes(Available).
+csr_index_memory_fraction(Fraction).  % default 0.05
+```
+
+In the second form, `lmdb_offset` is eligible only when:
+
+```text
+Bytes <= Available * Fraction
+```
+
+This keeps `auto` target-neutral and evidence-driven. Targets can feed
+the terms from local benchmark telemetry, artifact manifests, or
+platform probes, while omitted or incomplete measurements keep the
+current `sorted_array` behavior.
 
 ### 3.4.2 CSR I/O policy
 

--- a/src/unifyweaver/core/cost_model.pl
+++ b/src/unifyweaver/core/cost_model.pl
@@ -365,17 +365,57 @@ resolve_csr_io_policy_value(Policy, _Options, Policy) :-
 %! resolve_csr_index_backend(+Options, -Backend) is det.
 %
 %  Resolve CSR index backend. Omitted values keep the current sorted
-%  array behavior. Explicit `auto` is the future cost-analyzer hook; it
-%  conservatively resolves to sorted_array until measured override rules
-%  are added.
+%  array behavior. Explicit `auto` may select lmdb_offset when measured
+%  lookup savings amortize the marginal build cost and the offset index
+%  fits the configured memory budget.
 resolve_csr_index_backend(Options, Backend) :-
     option(index_backend(Backend0), Options, sorted_array),
     resolve_csr_index_backend_value(Backend0, Options, Backend).
 
+resolve_csr_index_backend_value(auto, Options, lmdb_offset) :-
+    csr_lmdb_offset_pays_off(Options),
+    csr_lmdb_offset_memory_fits(Options),
+    !.
 resolve_csr_index_backend_value(auto, _Options, sorted_array) :- !.
 resolve_csr_index_backend_value(Backend, _Options, Backend) :-
     validate_csr_index_backend(Backend),
     !.
+
+csr_lmdb_offset_pays_off(Options) :-
+    option(expected_child_lookups_per_query(LookupsPerQuery), Options),
+    validate_nonnegative_number(expected_child_lookups_per_query, LookupsPerQuery),
+    LookupsPerQuery > 0,
+    option(expected_query_count_per_artifact(QueryCount), Options),
+    validate_nonnegative_number(expected_query_count_per_artifact, QueryCount),
+    QueryCount > 0,
+    option(sorted_array_lookup_ms_per_1000(SortedMsPer1000), Options),
+    validate_nonnegative_number(sorted_array_lookup_ms_per_1000, SortedMsPer1000),
+    option(lmdb_offset_lookup_ms_per_1000(LmdbMsPer1000), Options),
+    validate_nonnegative_number(lmdb_offset_lookup_ms_per_1000, LmdbMsPer1000),
+    LookupSavingsMsPer1000 is SortedMsPer1000 - LmdbMsPer1000,
+    LookupSavingsMsPer1000 > 0,
+    option(sorted_array_build_seconds(SortedBuildSeconds), Options),
+    validate_nonnegative_number(sorted_array_build_seconds, SortedBuildSeconds),
+    option(lmdb_offset_build_seconds(LmdbBuildSeconds), Options),
+    validate_nonnegative_number(lmdb_offset_build_seconds, LmdbBuildSeconds),
+    MarginalBuildSeconds is max(0, LmdbBuildSeconds - SortedBuildSeconds),
+    TotalLookupSavingsSeconds is
+        (LookupsPerQuery * QueryCount / 1000.0) *
+        (LookupSavingsMsPer1000 / 1000.0),
+    TotalLookupSavingsSeconds >= MarginalBuildSeconds.
+
+csr_lmdb_offset_memory_fits(Options) :-
+    option(lmdb_offset_memory_fits(true), Options),
+    !.
+csr_lmdb_offset_memory_fits(Options) :-
+    option(lmdb_offset_bytes(LmdbOffsetBytes), Options),
+    validate_nonnegative_number(lmdb_offset_bytes, LmdbOffsetBytes),
+    option(available_memory_bytes(AvailableBytes), Options),
+    validate_nonnegative_number(available_memory_bytes, AvailableBytes),
+    AvailableBytes > 0,
+    option(csr_index_memory_fraction(Fraction), Options, 0.05),
+    validate_fraction(csr_index_memory_fraction, Fraction),
+    LmdbOffsetBytes =< AvailableBytes * Fraction.
 
 validate_known_reverse_options([]).
 validate_known_reverse_options([Opt|Rest]) :-
@@ -393,6 +433,16 @@ reverse_option_key(index_backend).
 reverse_option_key(cache_bytes).
 reverse_option_key(block_size_edges).
 reverse_option_key(io_policy).
+reverse_option_key(expected_child_lookups_per_query).
+reverse_option_key(expected_query_count_per_artifact).
+reverse_option_key(sorted_array_lookup_ms_per_1000).
+reverse_option_key(lmdb_offset_lookup_ms_per_1000).
+reverse_option_key(sorted_array_build_seconds).
+reverse_option_key(lmdb_offset_build_seconds).
+reverse_option_key(lmdb_offset_bytes).
+reverse_option_key(available_memory_bytes).
+reverse_option_key(csr_index_memory_fraction).
+reverse_option_key(lmdb_offset_memory_fits).
 reverse_option_key(platform_supports_direct_io).
 reverse_option_key(alignment_verified).
 reverse_option_key(measured_direct_io_win).
@@ -427,6 +477,21 @@ validate_csr_index_backend(Backend) :-
     !.
 validate_csr_index_backend(Backend) :-
     throw(error(domain_error(csr_index_backend, Backend), _)).
+
+validate_nonnegative_number(_Name, Value) :-
+    number(Value),
+    Value >= 0,
+    !.
+validate_nonnegative_number(Name, Value) :-
+    throw(error(domain_error(nonnegative_number(Name), Value), _)).
+
+validate_fraction(_Name, Value) :-
+    number(Value),
+    Value >= 0,
+    Value =< 1,
+    !.
+validate_fraction(Name, Value) :-
+    throw(error(domain_error(fraction(Name), Value), _)).
 
 validate_reverse_ordering(Ordering) :-
     memberchk(Ordering, [

--- a/tests/core/test_cost_model.pl
+++ b/tests/core/test_cost_model.pl
@@ -86,6 +86,9 @@ test(test_reverse_index_auto_defaults_none).
 test(test_reverse_index_auto_descendant_uses_existing_artifact).
 test(test_reverse_index_csr_normalizes_defaults).
 test(test_reverse_index_csr_auto_index_backend_keeps_sorted_array).
+test(test_reverse_index_csr_auto_index_backend_selects_lmdb_offset_when_amortized).
+test(test_reverse_index_csr_auto_index_backend_keeps_sorted_array_when_build_not_amortized).
+test(test_reverse_index_csr_auto_index_backend_keeps_sorted_array_when_memory_does_not_fit).
 test(test_reverse_index_csr_accepts_lmdb_offset_index_backend).
 test(test_reverse_index_csr_runtime_auto_direct_io_when_supported).
 test(test_reverse_index_csr_runtime_auto_buffered_when_direct_io_not_verified).
@@ -396,6 +399,80 @@ test_reverse_index_csr_auto_index_backend_keeps_sorted_array :-
         block_size_edges(0)
     ]),
     (   ReverseIndex = Expected
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got reverse_index=~w", [ReverseIndex]))
+    ).
+
+test_reverse_index_csr_auto_index_backend_selects_lmdb_offset_when_amortized :-
+    Test = 'validate_reverse_index_option csr auto index_backend selects lmdb_offset when savings amortize build cost',
+    validate_reverse_index_option(
+        csr([
+            index_backend(auto),
+            expected_child_lookups_per_query(500),
+            expected_query_count_per_artifact(100),
+            sorted_array_lookup_ms_per_1000(4.418097),
+            lmdb_offset_lookup_ms_per_1000(2.961144),
+            sorted_array_build_seconds(0.331824),
+            lmdb_offset_build_seconds(0.381317),
+            lmdb_offset_bytes(2113536),
+            available_memory_bytes(1073741824)
+        ]),
+        ReverseIndex
+    ),
+    Expected = csr([
+        phase(planning_only),
+        id_encoding(int32_le),
+        ordering(parent_sort),
+        index_backend(lmdb_offset),
+        io_policy(buffered_pread_drop),
+        cache_bytes(0),
+        block_size_edges(0)
+    ]),
+    (   ReverseIndex = Expected
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got reverse_index=~w", [ReverseIndex]))
+    ).
+
+test_reverse_index_csr_auto_index_backend_keeps_sorted_array_when_build_not_amortized :-
+    Test = 'validate_reverse_index_option csr auto index_backend keeps sorted_array when query reuse is too low',
+    validate_reverse_index_option(
+        csr([
+            index_backend(auto),
+            expected_child_lookups_per_query(100),
+            expected_query_count_per_artifact(1),
+            sorted_array_lookup_ms_per_1000(4.418097),
+            lmdb_offset_lookup_ms_per_1000(2.961144),
+            sorted_array_build_seconds(0.331824),
+            lmdb_offset_build_seconds(0.381317),
+            lmdb_offset_bytes(2113536),
+            available_memory_bytes(1073741824)
+        ]),
+        ReverseIndex
+    ),
+    (   ReverseIndex = csr(Opts),
+        memberchk(index_backend(sorted_array), Opts)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("got reverse_index=~w", [ReverseIndex]))
+    ).
+
+test_reverse_index_csr_auto_index_backend_keeps_sorted_array_when_memory_does_not_fit :-
+    Test = 'validate_reverse_index_option csr auto index_backend keeps sorted_array when lmdb_offset exceeds memory budget',
+    validate_reverse_index_option(
+        csr([
+            index_backend(auto),
+            expected_child_lookups_per_query(500),
+            expected_query_count_per_artifact(100),
+            sorted_array_lookup_ms_per_1000(4.418097),
+            lmdb_offset_lookup_ms_per_1000(2.961144),
+            sorted_array_build_seconds(0.331824),
+            lmdb_offset_build_seconds(0.381317),
+            lmdb_offset_bytes(2113536),
+            available_memory_bytes(1048576)
+        ]),
+        ReverseIndex
+    ),
+    (   ReverseIndex = csr(Opts),
+        memberchk(index_backend(sorted_array), Opts)
     ->  pass(Test)
     ;   fail_test(Test, format_atom("got reverse_index=~w", [ReverseIndex]))
     ).


### PR DESCRIPTION
  ## Summary

  - Teach `index_backend(auto)` to select `lmdb_offset` when measured costs justify it.
  - Keep omitted or under-specified `index_backend` on the current default: `sorted_array`.
  - Require `lmdb_offset` to satisfy both:
    - amortized lookup savings >= marginal build cost
    - offset-index memory fits the declared or estimated memory budget
  - Add cost-model tests for:
    - selecting `lmdb_offset` when reuse amortizes build cost
    - staying on `sorted_array` when query reuse is too low
    - staying on `sorted_array` when memory budget is too small
  - Document the auto-selection formula and required telemetry inputs.

  ## Validation

  - `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
  - `git diff --check`