### PR TITLE
Fix nested match blocks and add match/case edge case tests

### DIFF
--- a/src/unifyweaver/core/template_system.pl
+++ b/src/unifyweaver/core/template_system.pl
@@ -431,7 +431,8 @@ expand_match_blocks(Template, Dict, Result) :-
     ).
 
 %% find_match_block(+Str, -Key, -Before, -Body, -After)
-%  Locate the first {{match key}} in Str and its matching {{/match}}.
+%  Locate the first {{match key}} in Str and its balanced {{/match}}.
+%  Handles nested match blocks via depth counting.
 find_match_block(Str, Key, Before, Body, After) :-
     sub_string(Str, OpenIdx, 8, _, "{{match "),
     AfterOpen is OpenIdx + 8,
@@ -442,11 +443,45 @@ find_match_block(Str, Key, Before, Body, After) :-
     atom_string(Key, KeyStr),
     BodyStart is AfterOpen + EndRel + 2,
     sub_string(Str, BodyStart, _, 0, BodyAndAfter),
-    sub_string(BodyAndAfter, CloseRel, 10, _, "{{/match}}"),
+    find_balanced_match_close(BodyAndAfter, 1, 0, CloseRel),
     sub_string(BodyAndAfter, 0, CloseRel, _, Body),
     CloseEnd is CloseRel + 10,
     sub_string(BodyAndAfter, CloseEnd, _, 0, After),
     sub_string(Str, 0, OpenIdx, _, Before).
+
+%% find_balanced_match_close(+Str, +Depth, +Pos, -ClosePos)
+%  Scan Str from Pos looking for the balanced {{/match}} at Depth=0.
+%  Depth starts at 1 (for the already-opened outer match block).
+find_balanced_match_close(Str, Depth, Pos, ClosePos) :-
+    sub_string(Str, Pos, _, 0, Rest),
+    (   Depth =:= 0
+    ->  ClosePos = Pos
+    ;   Rest \= "",
+        next_match_event(Rest, EventType, EventOffset, EventLen),
+        AbsOffset is Pos + EventOffset,
+        NextPos is AbsOffset + EventLen,
+        (   EventType = open
+        ->  Depth1 is Depth + 1,
+            find_balanced_match_close(Str, Depth1, NextPos, ClosePos)
+        ;   EventType = close,
+            Depth1 is Depth - 1,
+            (   Depth1 =:= 0
+            ->  ClosePos = AbsOffset
+            ;   find_balanced_match_close(Str, Depth1, NextPos, ClosePos)
+            )
+        )
+    ).
+
+%% next_match_event(+Str, -Type, -Offset, -Len)
+%  Find the nearest {{match ...}} (open) or {{/match}} (close) in Str.
+next_match_event(Str, Type, Offset, Len) :-
+    (   sub_string(Str, OpenIdx, 8, _, "{{match ") -> true ; OpenIdx = 999999999 ),
+    (   sub_string(Str, CloseIdx, 10, _, "{{/match}}") -> true ; CloseIdx = 999999999 ),
+    OpenIdx + CloseIdx < 1999999998,  % at least one must exist
+    (   OpenIdx < CloseIdx
+    ->  Type = open, Offset = OpenIdx, Len = 8
+    ;   Type = close, Offset = CloseIdx, Len = 10
+    ).
 
 %% parse_match_cases(+Body, -Cases, -Default)
 %  Parse the body of a match block into a list of case(Value, CaseBody)
@@ -486,27 +521,67 @@ split_match_segments_(Body, Acc, Segments) :-
     ).
 
 %% find_next_case_marker(+Str, -Type, -Value, -Before, -After)
-%  Find the next {{case value}} or {{default}} in Str.
+%  Find the next top-level {{case value}} or {{default}} in Str,
+%  skipping any that are inside nested {{match}}...{{/match}} blocks.
 find_next_case_marker(Str, Type, Value, Before, After) :-
-    (   find_case_at(Str, CaseIdx, CaseVal, CaseAfterIdx),
-        find_default_at(Str, DefIdx, DefAfterIdx)
-    ->  (   CaseIdx < DefIdx
-        ->  Type = case_seg, Value = CaseVal,
-            sub_string(Str, 0, CaseIdx, _, Before),
-            sub_string(Str, CaseAfterIdx, _, 0, After)
-        ;   Type = default_seg, Value = '',
-            sub_string(Str, 0, DefIdx, _, Before),
-            sub_string(Str, DefAfterIdx, _, 0, After)
+    find_next_case_marker_(Str, 0, 0, Type, Value, MarkerIdx, AfterIdx),
+    sub_string(Str, 0, MarkerIdx, _, Before),
+    sub_string(Str, AfterIdx, _, 0, After).
+
+%% find_next_case_marker_(+Str, +Pos, +Depth, -Type, -Value, -MarkerIdx, -AfterIdx)
+%  Scan from Pos at match nesting Depth for the next depth-0 case/default.
+find_next_case_marker_(Str, Pos, Depth, Type, Value, MarkerIdx, AfterIdx) :-
+    sub_string(Str, Pos, _, 0, Rest),
+    Rest \= "",
+    find_earliest_tag(Rest, TagType, TagOffset, TagVal, TagAfterRel),
+    AbsIdx is Pos + TagOffset,
+    AbsAfter is Pos + TagAfterRel,
+    (   TagType = match_open
+    ->  Depth1 is Depth + 1,
+        find_next_case_marker_(Str, AbsAfter, Depth1, Type, Value, MarkerIdx, AfterIdx)
+    ;   TagType = match_close
+    ->  Depth1 is Depth - 1,
+        (   Depth1 >= 0
+        ->  find_next_case_marker_(Str, AbsAfter, Depth1, Type, Value, MarkerIdx, AfterIdx)
+        ;   fail
         )
-    ;   find_case_at(Str, CaseIdx, CaseVal, CaseAfterIdx)
-    ->  Type = case_seg, Value = CaseVal,
-        sub_string(Str, 0, CaseIdx, _, Before),
-        sub_string(Str, CaseAfterIdx, _, 0, After)
-    ;   find_default_at(Str, DefIdx, DefAfterIdx)
-    ->  Type = default_seg, Value = '',
-        sub_string(Str, 0, DefIdx, _, Before),
-        sub_string(Str, DefAfterIdx, _, 0, After)
+    ;   (TagType = case_tag ; TagType = default_tag),
+        (   Depth =:= 0
+        ->  (TagType = case_tag -> Type = case_seg ; Type = default_seg),
+            Value = TagVal, MarkerIdx = AbsIdx, AfterIdx = AbsAfter
+        ;   find_next_case_marker_(Str, AbsAfter, Depth, Type, Value, MarkerIdx, AfterIdx)
+        )
     ).
+
+%% find_earliest_tag(+Str, -TagType, -Offset, -Value, -AfterOffset)
+%  Find the earliest of {{match }}, {{/match}}, {{case }}, {{default}} in Str.
+find_earliest_tag(Str, TagType, Offset, Value, AfterOffset) :-
+    findall(Idx-Type-Val-After,
+            ( tag_candidate(Str, Idx, Type, Val, After) ),
+            Candidates),
+    Candidates \= [],
+    sort(Candidates, [Offset-TagType-Value-AfterOffset|_]).
+
+tag_candidate(Str, Idx, match_open, '', After) :-
+    sub_string(Str, Idx, 8, _, "{{match "),
+    Start is Idx + 8,
+    sub_string(Str, Start, _, 0, Tail),
+    sub_string(Tail, EndRel, 2, _, "}}"),
+    After is Start + EndRel + 2.
+tag_candidate(Str, Idx, match_close, '', After) :-
+    sub_string(Str, Idx, 10, _, "{{/match}}"),
+    After is Idx + 10.
+tag_candidate(Str, Idx, case_tag, Val, After) :-
+    sub_string(Str, Idx, 7, _, "{{case "),
+    Start is Idx + 7,
+    sub_string(Str, Start, _, 0, Tail),
+    sub_string(Tail, EndRel, 2, _, "}}"),
+    sub_string(Tail, 0, EndRel, _, ValStr),
+    atom_string(Val, ValStr),
+    After is Start + EndRel + 2.
+tag_candidate(Str, Idx, default_tag, '', After) :-
+    sub_string(Str, Idx, 11, _, "{{default}}"),
+    After is Idx + 11.
 
 find_case_at(Str, Idx, Value, AfterIdx) :-
     sub_string(Str, Idx, 7, _, "{{case "),
@@ -1113,6 +1188,111 @@ test_template_system :-
     render_template('plain {{x}} plain {{y}} plain', [x='X', y='Y'], R16),
     (sub_string(R16, _, _, _, 'plain X plain Y plain')
      -> writeln('PASS') ; (format('FAIL: got ~w~n', [R16]), fail)),
+
+    % === Match/Case Edge Case Tests (sections 3.1-3.8) ===
+
+    % Test 17: Section inside case body (3.1)
+    write('Test 17 - Section inside case body: '),
+    render_template("{{match mode}}{{case cached}}{{#has_l2}}L2 on{{/has_l2}}{{^has_l2}}L2 off{{/has_l2}}{{case eager}}no cache{{/match}}",
+                    [mode=cached, has_l2=true], R17),
+    (   sub_string(R17, _, _, _, "L2 on"), \+ sub_string(R17, _, _, _, "L2 off")
+    ->  writeln('PASS')
+    ;   (format('FAIL: got ~w~n', [R17]), fail)
+    ),
+
+    % Test 18: Nested match blocks (3.2)
+    write('Test 18 - Nested match blocks: '),
+    render_template("{{match outer}}{{case a}}{{match inner}}{{case x}}AX{{case y}}AY{{/match}}{{case b}}B{{/match}}",
+                    [outer=a, inner=y], R18),
+    (   sub_string(R18, _, _, _, "AY")
+    ->  writeln('PASS')
+    ;   (format('FAIL: got ~w~n', [R18]), fail)
+    ),
+
+    % Test 19: Nested match, outer selects non-nested case (3.2 variant)
+    write('Test 19 - Nested match, outer=b: '),
+    render_template("{{match outer}}{{case a}}{{match inner}}{{case x}}AX{{/match}}{{case b}}B{{/match}}",
+                    [outer=b], R19),
+    (   sub_string(R19, _, _, _, "B"), \+ sub_string(R19, _, _, _, "AX")
+    ->  writeln('PASS')
+    ;   (format('FAIL: got ~w~n', [R19]), fail)
+    ),
+
+    % Test 20: Underscores in case values (3.3)
+    write('Test 20 - Underscores in case values: '),
+    render_template("{{match backend}}{{case lmdb_offset}}LMDB{{case sorted_array}}SORTED{{/match}}",
+                    [backend=lmdb_offset], R20),
+    (   sub_string(R20, _, _, _, "LMDB")
+    ->  writeln('PASS')
+    ;   (format('FAIL: got ~w~n', [R20]), fail)
+    ),
+
+    % Test 21: Hyphens in case values (3.4)
+    write('Test 21 - Hyphens in case values: '),
+    render_template("{{match target}}{{case wam-fsharp}}Fsharp{{case wam-haskell}}Haskell{{/match}}",
+                    [target='wam-fsharp'], R21),
+    (   sub_string(R21, _, _, _, "Fsharp")
+    ->  writeln('PASS')
+    ;   (format('FAIL: got ~w~n', [R21]), fail)
+    ),
+
+    % Test 22: Empty case body (3.5)
+    write('Test 22 - Empty case body: '),
+    render_template("{{match mode}}{{case skip}}{{case keep}}KEPT{{/match}}", [mode=skip], R22a),
+    render_template("{{match mode}}{{case skip}}{{case keep}}KEPT{{/match}}", [mode=keep], R22b),
+    (   R22a = "", sub_string(R22b, _, _, _, "KEPT")
+    ->  writeln('PASS')
+    ;   (format('FAIL: skip=~w keep=~w~n', [R22a, R22b]), fail)
+    ),
+
+    % Test 23: Match with only default (3.6)
+    write('Test 23 - Only default: '),
+    render_template("{{match anything}}{{default}}ALWAYS{{/match}}", [anything=whatever], R23),
+    (   sub_string(R23, _, _, _, "ALWAYS")
+    ->  writeln('PASS')
+    ;   (format('FAIL: got ~w~n', [R23]), fail)
+    ),
+
+    % Test 24: Whitespace handling (3.7)
+    write('Test 24 - Whitespace preserved: '),
+    render_template("{{match mode}}\n  {{case eager}}\n    EAGER\n  {{case lazy}}\n    LAZY\n{{/match}}", [mode=eager], R24),
+    (   sub_string(R24, _, _, _, "EAGER"), sub_string(R24, _, _, _, "\n")
+    ->  writeln('PASS')
+    ;   (format('FAIL: got ~w~n', [R24]), fail)
+    ),
+
+    % Test 25: Malformed - no closing {{/match}} (3.8)
+    write('Test 25 - Malformed no /match: '),
+    render_template("{{match key}}{{case a}}body", [key=a], R25),
+    (   sub_string(R25, _, _, _, "{{match key}}")
+    ->  writeln('PASS')
+    ;   (format('FAIL: got ~w~n', [R25]), fail)
+    ),
+
+    % Test 26: Malformed - no key in {{match}} (3.8)
+    write('Test 26 - Malformed no key: '),
+    render_template("{{match}}{{case a}}body{{/match}}", [key=a], R26),
+    (   sub_string(R26, _, _, _, "{{match}}")
+    ->  writeln('PASS')
+    ;   (format('FAIL: got ~w~n', [R26]), fail)
+    ),
+
+    % Test 27: Orphan {{/match}} (3.8)
+    write('Test 27 - Orphan /match: '),
+    render_template("hello{{/match}}world", [], R27),
+    (   sub_string(R27, _, _, _, "hello"), sub_string(R27, _, _, _, "world")
+    ->  writeln('PASS')
+    ;   (format('FAIL: got ~w~n', [R27]), fail)
+    ),
+
+    % Test 28: Variable substitution inside matched case body
+    write('Test 28 - Var substitution in case: '),
+    render_template("{{match mode}}{{case cached}}cache={{size}}{{default}}none{{/match}}",
+                    [mode=cached, size='64'], R28),
+    (   sub_string(R28, _, _, _, "cache=64")
+    ->  writeln('PASS')
+    ;   (format('FAIL: got ~w~n', [R28]), fail)
+    ),
 
     % Clean up
     clear_template_cache(test_cached),

--- a/tests/test_template_match_case.pl
+++ b/tests/test_template_match_case.pl
@@ -1,0 +1,142 @@
+:- encoding(utf8).
+% Isolated edge case tests for match/case template feature.
+% Run: swipl -q -g run_tests -t halt tests/test_template_match_case.pl
+
+:- use_module('../src/unifyweaver/core/template_system').
+
+:- dynamic test_count/2.  % test_count(pass, N), test_count(fail, N)
+
+run_tests :-
+    retractall(test_count(_, _)),
+    assertz(test_count(pass, 0)),
+    assertz(test_count(fail, 0)),
+    writeln('=== Match/Case Edge Case Tests ==='),
+
+    run_test("Nested match: outer=a inner=y",
+        render_template("{{match outer}}{{case a}}[{{match inner}}{{case x}}AX{{case y}}AY{{/match}}]{{case b}}B{{/match}}",
+                         [outer=a, inner=y], R1),
+        sub_string(R1, _, _, _, "[AY]")),
+
+    run_test("Nested match: outer=a inner=x",
+        render_template("{{match outer}}{{case a}}[{{match inner}}{{case x}}AX{{case y}}AY{{/match}}]{{case b}}B{{/match}}",
+                         [outer=a, inner=x], R2),
+        sub_string(R2, _, _, _, "[AX]")),
+
+    run_test("Nested match: outer=b (skip nested)",
+        render_template("{{match outer}}{{case a}}{{match inner}}{{case x}}AX{{/match}}{{case b}}B{{/match}}",
+                         [outer=b], R3),
+        sub_string(R3, _, _, _, "B")),
+
+    run_test("Nested match: outer=a inner unmatched -> default",
+        render_template("{{match outer}}{{case a}}{{match inner}}{{case x}}X{{default}}DEF{{/match}}{{case b}}B{{/match}}",
+                         [outer=a, inner=z], R4),
+        sub_string(R4, _, _, _, "DEF")),
+
+    run_test("Double nested match",
+        render_template("{{match l1}}{{case a}}{{match l2}}{{case p}}{{match l3}}{{case q}}DEEP{{/match}}{{/match}}{{/match}}",
+                         [l1=a, l2=p, l3=q], R5),
+        sub_string(R5, _, _, _, "DEEP")),
+
+    run_test("Section inside case body (truthy)",
+        render_template("{{match mode}}{{case cached}}{{#l2}}L2{{/l2}}{{^l2}}noL2{{/l2}}{{/match}}",
+                         [mode=cached, l2=true], R6),
+        (sub_string(R6, _, _, _, "L2"), \+ sub_string(R6, _, _, _, "noL2"))),
+
+    run_test("Section inside case body (falsy)",
+        render_template("{{match mode}}{{case cached}}{{#l2}}L2{{/l2}}{{^l2}}noL2{{/l2}}{{/match}}",
+                         [mode=cached, l2=false], R7),
+        (sub_string(R7, _, _, _, "noL2"))),
+
+    run_test("Hyphens in case value",
+        render_template("{{match t}}{{case wam-fsharp}}FS{{case wam-haskell}}HS{{/match}}",
+                         [t='wam-fsharp'], R8),
+        sub_string(R8, _, _, _, "FS")),
+
+    run_test("Dots in case value",
+        render_template("{{match ver}}{{case 3.11}}old{{case 3.12}}new{{/match}}",
+                         [ver='3.12'], R9),
+        sub_string(R9, _, _, _, "new")),
+
+    run_test("Underscores in case value",
+        render_template("{{match b}}{{case lmdb_offset}}LMDB{{case sorted_array}}SA{{/match}}",
+                         [b=sorted_array], R10),
+        sub_string(R10, _, _, _, "SA")),
+
+    run_test("Empty case body (skip)",
+        render_template("{{match m}}{{case skip}}{{case keep}}K{{/match}}", [m=skip], R11),
+        R11 = ""),
+
+    run_test("Empty case body (keep)",
+        render_template("{{match m}}{{case skip}}{{case keep}}K{{/match}}", [m=keep], R12),
+        sub_string(R12, _, _, _, "K")),
+
+    run_test("Only default",
+        render_template("{{match any}}{{default}}ALWAYS{{/match}}", [any=whatever], R13),
+        sub_string(R13, _, _, _, "ALWAYS")),
+
+    run_test("Only default, key missing from dict",
+        render_template("{{match missing}}{{default}}FALLBACK{{/match}}", [], R14),
+        sub_string(R14, _, _, _, "FALLBACK")),
+
+    run_test("No match no default -> empty",
+        render_template("{{match m}}{{case a}}A{{case b}}B{{/match}}", [m=c], R15),
+        R15 = ""),
+
+    run_test("Whitespace preserved around case body",
+        render_template("{{match m}}\n{{case a}}\n  BODY\n{{/match}}", [m=a], R16),
+        sub_string(R16, _, _, _, "\n  BODY\n")),
+
+    run_test("Variable substitution inside case",
+        render_template("{{match m}}{{case x}}val={{v}}{{/match}}", [m=x, v='42'], R17),
+        sub_string(R17, _, _, _, "val=42")),
+
+    run_test("Multiple match blocks in one template",
+        render_template("{{match a}}{{case x}}AX{{/match}}-{{match b}}{{case y}}BY{{/match}}",
+                         [a=x, b=y], R18),
+        sub_string(R18, _, _, _, "AX-BY")),
+
+    run_test("Malformed: no closing /match",
+        render_template("{{match k}}{{case a}}body", [k=a], R19),
+        sub_string(R19, _, _, _, "{{match k}}")),
+
+    run_test("Malformed: no key in match tag",
+        render_template("{{match}}{{case a}}body{{/match}}", [], R20),
+        sub_string(R20, _, _, _, "{{match}}")),
+
+    run_test("Malformed: orphan /match",
+        render_template("X{{/match}}Y", [], R21),
+        (sub_string(R21, _, _, _, "X"), sub_string(R21, _, _, _, "Y"))),
+
+    run_test("Malformed: empty case value",
+        render_template("{{match k}}{{case }}body{{/match}}", [k=a], _R22),
+        true),  % should not crash
+
+    % Summary
+    test_count(pass, P),
+    test_count(fail, F),
+    Total is P + F,
+    format('~n=== Results: ~w/~w passed ===~n', [P, Total]),
+    (F > 0 -> halt(1) ; true).
+
+run_test(Name, Setup, Check) :-
+    write(Name), write(': '),
+    (   catch(
+            (call(Setup), (call(Check) -> true ; fail)),
+            Err,
+            (format('ERROR: ~w~n', [Err]), record_fail, fail)
+        )
+    ->  writeln('PASS'), record_pass
+    ;   writeln('FAIL'), record_fail
+    ).
+
+record_pass :-
+    test_count(pass, N),
+    retract(test_count(pass, N)),
+    N1 is N + 1,
+    assertz(test_count(pass, N1)).
+
+record_fail :-
+    test_count(fail, N),
+    retract(test_count(fail, N)),
+    N1 is N + 1,
+    assertz(test_count(fail, N1)).


### PR DESCRIPTION
## Summary

- **Fix nested `{{match}}`/`{{/match}}` blocks**: `find_match_block` and `find_next_case_marker` now use balanced depth-counting so nested match blocks resolve correctly instead of closing at the first inner `{{/match}}`. Previously, a template like `{{match outer}}{{case a}}{{match inner}}{{case x}}AX{{/match}}{{case b}}B{{/match}}` would break because the parser grabbed the inner `{{/match}}` as the outer block's close.
- **Add 12 inline tests** (Tests 17–28) to `test_template_system/0` covering sections 3.1–3.8 of the testing plan in `WAM_TEMPLATE_MATCH_CASE_TESTING.md`.
- **Add 22-test isolated suite** at `tests/test_template_match_case.pl` for deeper edge cases: triple-nested matches, hyphens/dots/underscores in case values, empty case bodies, default-only blocks, whitespace preservation, variable substitution inside cases, and malformed blocks.

## Test plan

- [x] `swipl -q -g "use_module('src/unifyweaver/core/constraint_analyzer'), test_template_system" -t halt src/unifyweaver/core/template_system.pl` — 28/28 pass
- [x] `swipl -q -g run_tests -t halt tests/test_template_match_case.pl` — 22/22 pass
- [x] `swipl -q -g run_tests -t halt tests/core/test_template_sections.pl` — 18/18 pass (no regressions)

https://claude.ai/code/session_016wXe6qSH2bYpcgN9kKMS7x

---
_Generated by [Claude Code](https://claude.ai/code/session_016wXe6qSH2bYpcgN9kKMS7x)_