### PR TITLE
Extract Program.fs from inline format string to Mustache template

### DIFF
--- a/docs/design/WAM_FSHARP_PROGRAM_TEMPLATE_MIGRATION.md
+++ b/docs/design/WAM_FSHARP_PROGRAM_TEMPLATE_MIGRATION.md
@@ -1,6 +1,6 @@
 # F# Program.fs Template Migration: Design
 
-**Status**: Design. Depends on template match/case testing.
+**Status**: Implemented. Template created, generate_program_fs/4 refactored.
 **Date**: 2026-05-25
 **Prerequisite**: `WAM_TEMPLATE_MATCH_CASE_TESTING.md` edge cases pass
 

--- a/src/unifyweaver/core/template_system.pl
+++ b/src/unifyweaver/core/template_system.pl
@@ -29,6 +29,7 @@
 :- discontiguous template/2.
 
 :- use_module(library(lists)).
+:- use_module(constraint_analyzer, [get_dedup_strategy/2]).
 
 %% ============================================
 %% DYNAMIC PREDICATES (Configuration & Cache)

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -4707,6 +4707,17 @@ fsharp_csr_template_source(Code) :-
     atom_concat(ProjectRoot, '/templates/targets/fsharp_wam/csr_reader.fs.mustache', TemplatePath),
     read_file_to_string(TemplatePath, Code, []).
 
+%% fsharp_program_template_source(-Code)
+%  Reads the program.fs.mustache template for the main Program.fs file.
+fsharp_program_template_source(Code) :-
+    source_file(wam_fsharp_target:_, SrcFile),
+    file_directory_name(SrcFile, SrcDir),
+    file_directory_name(SrcDir, TargetsDir),
+    file_directory_name(TargetsDir, UnifyWeaverDir),
+    file_directory_name(UnifyWeaverDir, ProjectRoot),
+    atom_concat(ProjectRoot, '/templates/targets/fsharp_wam/program.fs.mustache', TemplatePath),
+    read_file_to_string(TemplatePath, Code, []).
+
 %% write_fs_file(+Path, +Content)
 write_fs_file(Path, Content) :-
     open(Path, write, Stream, [encoding(utf8)]),
@@ -4844,214 +4855,17 @@ emit_lowered_entries_rest_fs([lowered(PredName, FuncName, _)|Rest]) :-
 generate_program_fs(_Predicates, DetectedKernels, Options, Code) :-
     pairs_keys(DetectedKernels, ForeignKeys),
     format_foreign_preds_fs(ForeignKeys, ForeignPredsStr),
-    option(module_name(_ModName), Options, 'wam-fsharp-bench'),
-    %% Phase 3: generate WcLookupSources expression
     generate_lookup_sources_expr_fs(Options, LookupSourcesExpr),
-    %% Conditional module opens
-    (   option(csr_path(_), Options) -> CsrOpen = '\nopen CsrReader' ; CsrOpen = '' ),
-    (   option(lmdb_path(_), Options) -> LmdbOpen = '\nopen LmdbFactSource' ; LmdbOpen = '' ),
-    format(string(Code),
-'module Program
-
-open System
-open System.Diagnostics
-open WamTypes
-open WamRuntime
-open Predicates
-open Lowered~w~w
-
-// -- TSV loading helpers --------------------------------------------------
-
-let loadTsvPairs (path: string) : (string * string) array =
-    System.IO.File.ReadAllLines(path)
-    |> Array.skip 1
-    |> Array.filter (fun l -> l.Trim().Length > 0 && not (l.StartsWith("#")))
-    |> Array.choose (fun l ->
-        let parts = l.Split(''\\t'')
-        if parts.Length >= 2 then Some (parts.[0].Trim(), parts.[1].Trim())
-        else None)
-
-let loadSingleColumn (path: string) : string array =
-    System.IO.File.ReadAllLines(path)
-    |> Array.skip 1
-    |> Array.filter (fun l -> l.Trim().Length > 0 && not (l.StartsWith("#")))
-    |> Array.map (fun l -> l.Trim())
-
-// -- Atom interning from all string sources --------------------------------
-
-let buildFullAtomInternTable (code: Instruction array) (extraAtoms: string seq) : Map<string, int> * Map<int, string> =
-    let atoms = System.Collections.Generic.HashSet<string>()
-    for instr in code do
-        match instr with
-        | GetConstant (Atom a, _) -> atoms.Add(a) |> ignore
-        | PutConstant (Atom a, _) -> atoms.Add(a) |> ignore
-        | SwitchOnConstantPc table -> for (k, _) in table do atoms.Add(k) |> ignore
-        | _ -> ()
-    for a in extraAtoms do atoms.Add(a) |> ignore
-    let sorted = atoms |> Seq.sort |> Seq.toArray
-    let intern   = sorted |> Array.mapi (fun i a -> (a, i)) |> Map.ofArray
-    let deintern = sorted |> Array.mapi (fun i a -> (i, a)) |> Map.ofArray
-    intern, deintern
-
-// -- Build interned FFI facts map -----------------------------------------
-
-let buildFfiFacts (pairs: (string * string) array) (intern: Map<string, int>) : Map<int, int list> =
-    let mutable m : Map<int, int list> = Map.empty
-    for (child, parent) in pairs do
-        match Map.tryFind child intern, Map.tryFind parent intern with
-        | Some cid, Some pid ->
-            let existing = Map.tryFind cid m |> Option.defaultValue []
-            m <- Map.add cid (pid :: existing) m
-        | _ -> ()
-    m
-
-// -- Extract double from WAM Value ----------------------------------------
-
-let extractDouble (v: Value) : float option =
-    match v with
-    | Float f   -> Some f
-    | Integer n -> Some (float n)
-    | _         -> None
-
-[<EntryPoint>]
-let main argv =
-    let factsDir = if argv.Length > 0 then argv.[0] else "."
-    let numReps  = if argv.Length > 1 then (try int argv.[1] with _ -> 3) else 3
-
-    let sw = Stopwatch.StartNew()
-
-    // Load TSV facts
-    let categoryParents  = loadTsvPairs (System.IO.Path.Combine(factsDir, "category_parent.tsv"))
-    let articleCategories = loadTsvPairs (System.IO.Path.Combine(factsDir, "article_category.tsv"))
-    let roots            = loadSingleColumn (System.IO.Path.Combine(factsDir, "root_categories.tsv"))
-    let root = if roots.Length > 0 then roots.[0] else "Physics"
-
-    let loadMs = sw.ElapsedMilliseconds
-    eprintfn "load_ms=%d" loadMs
-
-    // Resolve call instructions
-    let foreignPreds = [ ~w ]
-    let resolvedCode = resolveCallInstrs allLabels foreignPreds (Array.toList allCode) |> List.toArray
-
-    // Build atom intern table from instructions + all TSV atoms
-    let extraAtoms = seq {
-        for (c, p) in categoryParents do yield c; yield p
-        for (_, c) in articleCategories do yield c
-        for r in roots do yield r
-    }
-    let atomIntern, atomDeintern = buildFullAtomInternTable resolvedCode extraAtoms
-
-    // Build interned FFI facts: category_parent child -> [parent ids]
-    let parentsInterned = buildFfiFacts categoryParents atomIntern
-
-    // Seed categories (distinct second column of article_category)
-    let seedCats =
-        articleCategories
-        |> Array.map snd
-        |> Array.distinct
-        |> Array.sort
-
-    // Build WamContext
-    let ctx =
-        { WcCode             = resolvedCode
-          WcLabels            = allLabels
-          WcForeignFacts      = Map.empty
-          WcFfiFacts          = Map.ofList [ ("category_parent", parentsInterned) ]
-          WcFfiWeightedFacts  = Map.empty
-          WcAtomIntern        = atomIntern
-          WcAtomDeintern      = atomDeintern
-          WcForeignConfig     = Map.ofList [ ("max_depth", 10) ]
-          WcLoweredPredicates = loweredPredicates
-          WcLookupSources   = ~w
-      WcCancellationToken = None }
-
-    let emptyState =
-        { WsPC         = 0
-          WsRegs       = Array.create MaxRegs (Unbound -1)
-          WsStack      = []
-          WsHeap       = []
-          WsHeapLen    = 0
-          WsTrail      = []
-          WsTrailLen   = 0
-          WsCP         = 0
-          WsCPs        = []
-          WsCPsLen     = 0
-          WsBindings   = Map.empty
-          WsCutBar     = 0
-          WsVarCounter = 0
-          WsBuilder    = None
-          WsBuilderStack = []
-          WsAggAccum   = []
-          WsB0Stack    = []
-          WsCatchers   = [] }
-
-    // Find entry point: prefer lowered predicates, fall back to code array
-    let queryPred =
-        let candidates = [
-            "category_ancestor$effective_distance_sum_selected/3"
-            "category_ancestor$effective_distance_sum_bound/3"
-            "category_ancestor/4"
-        ]
-        candidates
-        |> List.tryFind (fun p ->
-            Map.containsKey p ctx.WcLoweredPredicates ||
-            Map.containsKey p ctx.WcLabels)
-        |> Option.defaultValue "category_ancestor/4"
-
-    let setupMs = sw.ElapsedMilliseconds
-    eprintfn "setup_ms=%d queryPred=%s" setupMs queryPred
-
-    // Benchmark loop: numReps repetitions
-    let mutable totalSolutions = 0
-    let mutable lastQueryMs = 0L
-
-    for rep = 1 to numReps do
-        let querySw = Stopwatch.StartNew()
-        let mutable repSolutions = 0
-
-        for cat in seedCats do
-            let varId = 1000000
-            let regs = Array.create MaxRegs (Unbound -1)
-            // Register layout depends on which queryPred resolved.  The /3
-            // candidates are lowered aggregate variants whose semantics fold
-            // a target root into the call shape, so A2 is the root and A3
-            // accumulates the result.  The /4 variant is the raw
-            // category_ancestor(+Cat, -Ancestor, -Hops, +Visited) — A2 and
-            // A3 are outputs (Unbound), and A4 must be a list-valued input
-            // seeded with [Cat] so that the cycle-detection guard (negation
-            // over member/2) sees a real list rather than an unbound
-            // variable.  Without the seeded A4 the predicate fails
-            // unconditionally and the benchmark reports solutions=0.
-            if queryPred.EndsWith "/4" then
-                regs.[1] <- Atom cat
-                regs.[2] <- Unbound varId
-                regs.[3] <- Unbound (varId + 1)
-                regs.[4] <- VList [ Atom cat ]
-            else
-                regs.[1] <- Atom cat
-                regs.[2] <- Atom root
-                regs.[3] <- Unbound varId
-            let s0 = { emptyState with WsPC = 0; WsRegs = regs; WsCP = 0 }
-            match dispatchCall ctx queryPred s0 with
-            | Some s1 ->
-                repSolutions <- repSolutions + 1
-            | None -> ()
-
-        querySw.Stop()
-        lastQueryMs <- querySw.ElapsedMilliseconds
-        totalSolutions <- totalSolutions + repSolutions
-        eprintfn "rep=%d query_ms=%d seeds=%d solutions=%d"
-            rep lastQueryMs seedCats.Length repSolutions
-
-    sw.Stop()
-    let totalMs = sw.ElapsedMilliseconds
-
-    // Summary output
-    printfn "query_ms=%d seeds=%d solutions=%d reps=%d"
-        lastQueryMs seedCats.Length (totalSolutions / numReps) numReps
-    printfn "total_ms=%d" totalMs
-    0
-', [LmdbOpen, CsrOpen, ForeignPredsStr, LookupSourcesExpr]).
+    (option(csr_path(_), Options) -> HasCsr = true ; HasCsr = false),
+    (option(lmdb_path(_), Options) -> HasLmdb = true ; HasLmdb = false),
+    Dict = [
+        foreign_preds = ForeignPredsStr,
+        lookup_sources_expr = LookupSourcesExpr,
+        has_csr = HasCsr,
+        has_lmdb = HasLmdb
+    ],
+    fsharp_program_template_source(Template),
+    render_template(Template, Dict, Code).
 
 format_foreign_preds_fs([], '').
 format_foreign_preds_fs(Keys, Str) :-

--- a/templates/targets/fsharp_wam/program.fs.mustache
+++ b/templates/targets/fsharp_wam/program.fs.mustache
@@ -1,0 +1,202 @@
+module Program
+
+open System
+open System.Diagnostics
+open WamTypes
+open WamRuntime
+open Predicates
+open Lowered
+{{#has_lmdb}}open LmdbFactSource
+{{/has_lmdb}}{{#has_csr}}open CsrReader
+{{/has_csr}}
+// -- TSV loading helpers --------------------------------------------------
+
+let loadTsvPairs (path: string) : (string * string) array =
+    System.IO.File.ReadAllLines(path)
+    |> Array.skip 1
+    |> Array.filter (fun l -> l.Trim().Length > 0 && not (l.StartsWith("#")))
+    |> Array.choose (fun l ->
+        let parts = l.Split('\t')
+        if parts.Length >= 2 then Some (parts.[0].Trim(), parts.[1].Trim())
+        else None)
+
+let loadSingleColumn (path: string) : string array =
+    System.IO.File.ReadAllLines(path)
+    |> Array.skip 1
+    |> Array.filter (fun l -> l.Trim().Length > 0 && not (l.StartsWith("#")))
+    |> Array.map (fun l -> l.Trim())
+
+// -- Atom interning from all string sources --------------------------------
+
+let buildFullAtomInternTable (code: Instruction array) (extraAtoms: string seq) : Map<string, int> * Map<int, string> =
+    let atoms = System.Collections.Generic.HashSet<string>()
+    for instr in code do
+        match instr with
+        | GetConstant (Atom a, _) -> atoms.Add(a) |> ignore
+        | PutConstant (Atom a, _) -> atoms.Add(a) |> ignore
+        | SwitchOnConstantPc table -> for (k, _) in table do atoms.Add(k) |> ignore
+        | _ -> ()
+    for a in extraAtoms do atoms.Add(a) |> ignore
+    let sorted = atoms |> Seq.sort |> Seq.toArray
+    let intern   = sorted |> Array.mapi (fun i a -> (a, i)) |> Map.ofArray
+    let deintern = sorted |> Array.mapi (fun i a -> (i, a)) |> Map.ofArray
+    intern, deintern
+
+// -- Build interned FFI facts map -----------------------------------------
+
+let buildFfiFacts (pairs: (string * string) array) (intern: Map<string, int>) : Map<int, int list> =
+    let mutable m : Map<int, int list> = Map.empty
+    for (child, parent) in pairs do
+        match Map.tryFind child intern, Map.tryFind parent intern with
+        | Some cid, Some pid ->
+            let existing = Map.tryFind cid m |> Option.defaultValue []
+            m <- Map.add cid (pid :: existing) m
+        | _ -> ()
+    m
+
+// -- Extract double from WAM Value ----------------------------------------
+
+let extractDouble (v: Value) : float option =
+    match v with
+    | Float f   -> Some f
+    | Integer n -> Some (float n)
+    | _         -> None
+
+[<EntryPoint>]
+let main argv =
+    let factsDir = if argv.Length > 0 then argv.[0] else "."
+    let numReps  = if argv.Length > 1 then (try int argv.[1] with _ -> 3) else 3
+
+    let sw = Stopwatch.StartNew()
+
+    // Load TSV facts
+    let categoryParents  = loadTsvPairs (System.IO.Path.Combine(factsDir, "category_parent.tsv"))
+    let articleCategories = loadTsvPairs (System.IO.Path.Combine(factsDir, "article_category.tsv"))
+    let roots            = loadSingleColumn (System.IO.Path.Combine(factsDir, "root_categories.tsv"))
+    let root = if roots.Length > 0 then roots.[0] else "Physics"
+
+    let loadMs = sw.ElapsedMilliseconds
+    eprintfn "load_ms=%d" loadMs
+
+    // Resolve call instructions
+    let foreignPreds = [ {{foreign_preds}} ]
+    let resolvedCode = resolveCallInstrs allLabels foreignPreds (Array.toList allCode) |> List.toArray
+
+    // Build atom intern table from instructions + all TSV atoms
+    let extraAtoms = seq {
+        for (c, p) in categoryParents do yield c; yield p
+        for (_, c) in articleCategories do yield c
+        for r in roots do yield r
+    }
+    let atomIntern, atomDeintern = buildFullAtomInternTable resolvedCode extraAtoms
+
+    // Build interned FFI facts: category_parent child -> [parent ids]
+    let parentsInterned = buildFfiFacts categoryParents atomIntern
+
+    // Seed categories (distinct second column of article_category)
+    let seedCats =
+        articleCategories
+        |> Array.map snd
+        |> Array.distinct
+        |> Array.sort
+
+    // Build WamContext
+    let ctx =
+        { WcCode             = resolvedCode
+          WcLabels            = allLabels
+          WcForeignFacts      = Map.empty
+          WcFfiFacts          = Map.ofList [ ("category_parent", parentsInterned) ]
+          WcFfiWeightedFacts  = Map.empty
+          WcAtomIntern        = atomIntern
+          WcAtomDeintern      = atomDeintern
+          WcForeignConfig     = Map.ofList [ ("max_depth", 10) ]
+          WcLoweredPredicates = loweredPredicates
+          WcLookupSources   = {{lookup_sources_expr}}
+      WcCancellationToken = None }
+
+    let emptyState =
+        { WsPC         = 0
+          WsRegs       = Array.create MaxRegs (Unbound -1)
+          WsStack      = []
+          WsHeap       = []
+          WsHeapLen    = 0
+          WsTrail      = []
+          WsTrailLen   = 0
+          WsCP         = 0
+          WsCPs        = []
+          WsCPsLen     = 0
+          WsBindings   = Map.empty
+          WsCutBar     = 0
+          WsVarCounter = 0
+          WsBuilder    = None
+          WsBuilderStack = []
+          WsAggAccum   = []
+          WsB0Stack    = []
+          WsCatchers   = [] }
+
+    // Find entry point: prefer lowered predicates, fall back to code array
+    let queryPred =
+        let candidates = [
+            "category_ancestor$effective_distance_sum_selected/3"
+            "category_ancestor$effective_distance_sum_bound/3"
+            "category_ancestor/4"
+        ]
+        candidates
+        |> List.tryFind (fun p ->
+            Map.containsKey p ctx.WcLoweredPredicates ||
+            Map.containsKey p ctx.WcLabels)
+        |> Option.defaultValue "category_ancestor/4"
+
+    let setupMs = sw.ElapsedMilliseconds
+    eprintfn "setup_ms=%d queryPred=%s" setupMs queryPred
+
+    // Benchmark loop: numReps repetitions
+    let mutable totalSolutions = 0
+    let mutable lastQueryMs = 0L
+
+    for rep = 1 to numReps do
+        let querySw = Stopwatch.StartNew()
+        let mutable repSolutions = 0
+
+        for cat in seedCats do
+            let varId = 1000000
+            let regs = Array.create MaxRegs (Unbound -1)
+            // Register layout depends on which queryPred resolved.  The /3
+            // candidates are lowered aggregate variants whose semantics fold
+            // a target root into the call shape, so A2 is the root and A3
+            // accumulates the result.  The /4 variant is the raw
+            // category_ancestor(+Cat, -Ancestor, -Hops, +Visited) — A2 and
+            // A3 are outputs (Unbound), and A4 must be a list-valued input
+            // seeded with [Cat] so that the cycle-detection guard (negation
+            // over member/2) sees a real list rather than an unbound
+            // variable.  Without the seeded A4 the predicate fails
+            // unconditionally and the benchmark reports solutions=0.
+            if queryPred.EndsWith "/4" then
+                regs.[1] <- Atom cat
+                regs.[2] <- Unbound varId
+                regs.[3] <- Unbound (varId + 1)
+                regs.[4] <- VList [ Atom cat ]
+            else
+                regs.[1] <- Atom cat
+                regs.[2] <- Atom root
+                regs.[3] <- Unbound varId
+            let s0 = { emptyState with WsPC = 0; WsRegs = regs; WsCP = 0 }
+            match dispatchCall ctx queryPred s0 with
+            | Some s1 ->
+                repSolutions <- repSolutions + 1
+            | None -> ()
+
+        querySw.Stop()
+        lastQueryMs <- querySw.ElapsedMilliseconds
+        totalSolutions <- totalSolutions + repSolutions
+        eprintfn "rep=%d query_ms=%d seeds=%d solutions=%d"
+            rep lastQueryMs seedCats.Length repSolutions
+
+    sw.Stop()
+    let totalMs = sw.ElapsedMilliseconds
+
+    // Summary output
+    printfn "query_ms=%d seeds=%d solutions=%d reps=%d"
+        lastQueryMs seedCats.Length (totalSolutions / numReps) numReps
+    printfn "total_ms=%d" totalMs
+    0

--- a/templates/targets/fsharp_wam/program.fs.mustache
+++ b/templates/targets/fsharp_wam/program.fs.mustache
@@ -165,7 +165,7 @@ let main argv =
             // candidates are lowered aggregate variants whose semantics fold
             // a target root into the call shape, so A2 is the root and A3
             // accumulates the result.  The /4 variant is the raw
-            // category_ancestor(+Cat, -Ancestor, -Hops, +Visited) — A2 and
+            // category_ancestor(+Cat, -Ancestor, -Hops, +Visited) -- A2 and
             // A3 are outputs (Unbound), and A4 must be a list-valued input
             // seeded with [Cat] so that the cycle-detection guard (negation
             // over member/2) sees a real list rather than an unbound


### PR DESCRIPTION
## Summary

- **Extracts the ~200-line Prolog format string** in `generate_program_fs/4` into `templates/targets/fsharp_wam/program.fs.mustache`, reducing the predicate to ~14 lines that compute a Dict and call `render_template/3`
- **Adds `fsharp_program_template_source/1`** template loader following the existing pattern of `fsharp_lmdb_template_source/1` and `fsharp_csr_template_source/1`
- **Fixes a missing `use_module` for `constraint_analyzer`** in `template_system.pl`, which caused `test_template_system` to fail when run standalone

The template uses `{{#has_lmdb}}`/`{{#has_csr}}` conditional sections for module opens, and `{{foreign_preds}}`/`{{lookup_sources_expr}}` for variable substitution. The Prolog quoting issues (`''\\t''` → `'\t'`) and an em-dash encoding warning are also resolved.

Depends on #2486 (merged).

## Test plan

- [x] All 28 `test_template_system` tests pass: `swipl -q -g test_template_system -t halt src/unifyweaver/core/template_system.pl`
- [x] All 22 match/case edge case tests pass: `swipl -q -g run_tests -t halt tests/test_template_match_case.pl`
- [x] Template rendering verified for all 4 conditional combos (both/lmdb-only/csr-only/neither)
- [ ] E2E smoke/bench tests (`test_wam_fsharp_csr_smoke.pl`, `test_wam_fsharp_csr_bench.pl`) need python3+lmdb and .NET 8 SDK — not available in this environment

https://claude.ai/code/session_01G2ZvZyzkhUL5MtUihXeCkH

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2ZvZyzkhUL5MtUihXeCkH)_