### PR TITLE
Add materialisation match/case dispatch to Program.fs template

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -4858,11 +4858,16 @@ generate_program_fs(_Predicates, DetectedKernels, Options, Code) :-
     generate_lookup_sources_expr_fs(Options, LookupSourcesExpr),
     (option(csr_path(_), Options) -> HasCsr = true ; HasCsr = false),
     (option(lmdb_path(_), Options) -> HasLmdb = true ; HasLmdb = false),
+    option(lmdb_materialisation(Materialisation), Options, cached),
+    option(lmdb_l2_capacity(L2Cap), Options, auto),
+    format(atom(L2CapStr), '"~w"', [L2Cap]),
     Dict = [
         foreign_preds = ForeignPredsStr,
         lookup_sources_expr = LookupSourcesExpr,
         has_csr = HasCsr,
-        has_lmdb = HasLmdb
+        has_lmdb = HasLmdb,
+        materialisation = Materialisation,
+        l2_capacity = L2CapStr
     ],
     fsharp_program_template_source(Template),
     render_template(Template, Dict, Code).

--- a/templates/targets/fsharp_wam/program.fs.mustache
+++ b/templates/targets/fsharp_wam/program.fs.mustache
@@ -93,6 +93,24 @@ let main argv =
     // Build interned FFI facts: category_parent child -> [parent ids]
     let parentsInterned = buildFfiFacts categoryParents atomIntern
 
+{{#has_lmdb}}
+    // LMDB fact source setup (materialisation mode dispatch)
+    let lmdbEnv = openLmdbEnv (System.IO.Path.Combine(factsDir, "lmdb"))
+{{match materialisation}}
+{{case eager}}
+    // Eager: load entire LMDB relation into a Dictionary for O(1) lookup
+    let lmdbFactDict = loadDupsortRelationDict lmdbEnv "category_parent"
+    let lmdbFactSource = DictLookupSource(lmdbFactDict) :> ILookupSource
+{{case lazy}}
+    // Lazy: on-demand cursor lookup, no startup materialisation cost
+    let lmdbFactSource = LmdbCursorLookup(lmdbEnv, "category_parent") :> ILookupSource
+{{default}}
+    // Cached (default): two-level L1/L2 cache over cursor lookup
+    let lmdbInner = LmdbCursorLookup(lmdbEnv, "category_parent") :> ILookupSource
+    let lmdbFactSource = TwoLevelCachedLookupSource(lmdbInner, {{l2_capacity}}) :> ILookupSource
+{{/match}}
+{{/has_lmdb}}
+
     // Seed categories (distinct second column of article_category)
     let seedCats =
         articleCategories

--- a/tests/test_template_match_case.pl
+++ b/tests/test_template_match_case.pl
@@ -167,6 +167,77 @@ run_tests :-
             \+ sub_string(R26, _, _, _, "import SortedArraySource")
         )),
 
+    % === Section 3.10: Integration with real codegen template ===
+    % Uses the actual program.fs.mustache from the fsharp_wam target.
+
+    run_test("3.10a Codegen: LMDB cached materialisation",
+        (   load_template_from_file("templates/targets/fsharp_wam/program.fs.mustache", TmplFsCached),
+            render_template(TmplFsCached,
+                [foreign_preds = '"category_ancestor/4"',
+                 lookup_sources_expr = 'Map.empty',
+                 has_csr = false, has_lmdb = true,
+                 materialisation = cached, l2_capacity = '"auto"'], RFsCached)
+        ),
+        (   sub_string(RFsCached, _, _, _, "open LmdbFactSource"),
+            sub_string(RFsCached, _, _, _, "TwoLevelCachedLookupSource"),
+            sub_string(RFsCached, _, _, _, "LmdbCursorLookup"),
+            \+ sub_string(RFsCached, _, _, _, "DictLookupSource"),
+            \+ sub_string(RFsCached, _, _, _, "open CsrReader")
+        )),
+
+    run_test("3.10b Codegen: LMDB eager materialisation",
+        (   load_template_from_file("templates/targets/fsharp_wam/program.fs.mustache", TmplFsEager),
+            render_template(TmplFsEager,
+                [foreign_preds = '"category_ancestor/4"',
+                 lookup_sources_expr = 'Map.empty',
+                 has_csr = false, has_lmdb = true,
+                 materialisation = eager, l2_capacity = '"auto"'], RFsEager)
+        ),
+        (   sub_string(RFsEager, _, _, _, "DictLookupSource"),
+            sub_string(RFsEager, _, _, _, "loadDupsortRelationDict"),
+            \+ sub_string(RFsEager, _, _, _, "TwoLevelCachedLookupSource")
+        )),
+
+    run_test("3.10c Codegen: LMDB lazy materialisation",
+        (   load_template_from_file("templates/targets/fsharp_wam/program.fs.mustache", TmplFsLazy),
+            render_template(TmplFsLazy,
+                [foreign_preds = '"category_ancestor/4"',
+                 lookup_sources_expr = 'Map.empty',
+                 has_csr = false, has_lmdb = true,
+                 materialisation = lazy, l2_capacity = '"auto"'], RFsLazy)
+        ),
+        (   sub_string(RFsLazy, _, _, _, "LmdbCursorLookup"),
+            sub_string(RFsLazy, _, _, _, "Lazy"),
+            \+ sub_string(RFsLazy, _, _, _, "TwoLevelCachedLookupSource"),
+            \+ sub_string(RFsLazy, _, _, _, "DictLookupSource")
+        )),
+
+    run_test("3.10d Codegen: no LMDB (has_lmdb=false), no match block output",
+        (   load_template_from_file("templates/targets/fsharp_wam/program.fs.mustache", TmplFsNoLmdb),
+            render_template(TmplFsNoLmdb,
+                [foreign_preds = '', lookup_sources_expr = 'Map.empty',
+                 has_csr = false, has_lmdb = false,
+                 materialisation = cached, l2_capacity = '"auto"'], RFsNoLmdb)
+        ),
+        (   \+ sub_string(RFsNoLmdb, _, _, _, "open LmdbFactSource"),
+            \+ sub_string(RFsNoLmdb, _, _, _, "lmdbFactSource"),
+            \+ sub_string(RFsNoLmdb, _, _, _, "TwoLevelCachedLookupSource"),
+            sub_string(RFsNoLmdb, _, _, _, "WcLookupSources")
+        )),
+
+    run_test("3.10e Codegen: CSR + LMDB together",
+        (   load_template_from_file("templates/targets/fsharp_wam/program.fs.mustache", TmplFsBoth),
+            render_template(TmplFsBoth,
+                [foreign_preds = '"category_ancestor/4"',
+                 lookup_sources_expr = 'Map.ofList [ ("category_child", csrSrc) ]',
+                 has_csr = true, has_lmdb = true,
+                 materialisation = eager, l2_capacity = '"auto"'], RFsBoth)
+        ),
+        (   sub_string(RFsBoth, _, _, _, "open CsrReader"),
+            sub_string(RFsBoth, _, _, _, "open LmdbFactSource"),
+            sub_string(RFsBoth, _, _, _, "DictLookupSource")
+        )),
+
     % Summary
     test_count(pass, P),
     test_count(fail, F),


### PR DESCRIPTION
## Summary

- **Add `{{match materialisation}}` dispatch to `program.fs.mustache`**: inside `{{#has_lmdb}}`, the template now dispatches on `materialisation` mode to generate the correct LMDB fact source setup code:
  - `eager`: `DictLookupSource` via `loadDupsortRelationDict` (O(1) in-memory lookup)
  - `lazy`: `LmdbCursorLookup` (on-demand cursor, no startup cost)
  - `cached` (default): `TwoLevelCachedLookupSource` wrapping a cursor lookup with L1/L2 cache
- **Wire `materialisation` and `l2_capacity` through `generate_program_fs/4`** Dict, completing step 3 of `WAM_FSHARP_PROGRAM_TEMPLATE_MIGRATION.md`
- **Five integration tests** (3.10a-e) load the real `program.fs.mustache` from disk and verify each materialisation mode renders correct F# code, including the cross-cutting case of CSR + LMDB together and the no-LMDB case where the match block is suppressed by the `{{#has_lmdb}}` section

This is the first real-world use of `{{match}}` blocks in a production template file.

## Test plan

- [x] `swipl -q -g run_tests -t halt tests/test_template_match_case.pl` -- 31/31 pass
- [x] `swipl -q -g "use_module(...constraint_analyzer), test_template_system" -t halt ...template_system.pl` -- 28/28 pass
- [x] `swipl -q -g run_tests -t halt tests/core/test_template_sections.pl` -- 18/18 pass
- [ ] dotnet build (not available in this environment; requires .NET 8 SDK)

https://claude.ai/code/session_016wXe6qSH2bYpcgN9kKMS7x

---
_Generated by [Claude Code](https://claude.ai/code/session_016wXe6qSH2bYpcgN9kKMS7x)_