### PR TITLE
Derive CSR index costs from benchmark telemetry

### DIFF
--- a/docs/design/WAM_REVERSE_INDEX_ARTIFACTS.md
+++ b/docs/design/WAM_REVERSE_INDEX_ARTIFACTS.md
@@ -414,6 +414,27 @@ the terms from local benchmark telemetry, artifact manifests, or
 platform probes, while omitted or incomplete measurements keep the
 current `sorted_array` behavior.
 
+The cost model exposes a small telemetry adapter for benchmark output:
+
+```prolog
+csr_index_backend_options_from_benchmark_tsv(
+    "reverse_csr_lookup.tsv",
+    [
+        expected_child_lookups_per_query(500),
+        expected_query_count_per_artifact(100),
+        available_memory_bytes(1073741824)
+    ],
+    Options
+),
+resolve_csr_index_backend(Options, Backend).
+```
+
+The adapter extracts `median_ms`, `csr_build_seconds`, and
+`offset_index_bytes` from the `sorted_array` and `lmdb_offset` rows
+emitted by `benchmark_reverse_csr_lookup.py`. Workload expectations and
+memory policy remain caller-provided because they are query- and
+deployment-specific.
+
 ### 3.4.2 CSR I/O policy
 
 CSR access should expose an explicit I/O policy:

--- a/src/unifyweaver/core/cost_model.pl
+++ b/src/unifyweaver/core/cost_model.pl
@@ -39,6 +39,10 @@
     validate_reverse_index_option/2, % +Spec, -Normalized
     resolve_csr_io_policy/2,    % +Options, -Policy
     resolve_csr_index_backend/2, % +Options, -Backend
+    csr_index_backend_options_from_benchmark_tsv/3,
+                                % +Path, +WorkloadOptions, -Options
+    csr_index_backend_options_from_benchmark_rows/3,
+                                % +Rows, +WorkloadOptions, -Options
 
     %% Hardware constants
     default_constants/1,        % -Constants
@@ -49,6 +53,9 @@
 ]).
 
 :- use_module(library(option)).
+:- use_module(library(apply)).
+:- use_module(library(pairs)).
+:- use_module(library(readutil)).
 
 %% =====================================================================
 %% Hardware constants
@@ -380,6 +387,80 @@ resolve_csr_index_backend_value(auto, _Options, sorted_array) :- !.
 resolve_csr_index_backend_value(Backend, _Options, Backend) :-
     validate_csr_index_backend(Backend),
     !.
+
+%! csr_index_backend_options_from_benchmark_tsv(+Path, +WorkloadOptions, -Options) is det.
+%
+%  Read benchmark_reverse_csr_lookup.py TSV output and produce the
+%  measured option terms consumed by resolve_csr_index_backend/2.
+%  WorkloadOptions should provide expected_child_lookups_per_query/1 and
+%  expected_query_count_per_artifact/1. It may also provide
+%  available_memory_bytes/1 or lmdb_offset_memory_fits(true).
+csr_index_backend_options_from_benchmark_tsv(Path, WorkloadOptions, Options) :-
+    read_file_to_string(Path, Text, []),
+    tsv_rows(Text, Rows),
+    csr_index_backend_options_from_benchmark_rows(Rows, WorkloadOptions, Options).
+
+%! csr_index_backend_options_from_benchmark_rows(+Rows, +WorkloadOptions, -Options) is det.
+%
+%  Rows is a list of Field-ValueString pairs as produced by tsv_rows/2.
+csr_index_backend_options_from_benchmark_rows(Rows, WorkloadOptions, Options) :-
+    must_be(list, WorkloadOptions),
+    memberchk(expected_child_lookups_per_query(LookupsPerQuery), WorkloadOptions),
+    memberchk(expected_query_count_per_artifact(QueryCount), WorkloadOptions),
+    benchmark_row_for_index_backend(Rows, sorted_array, SortedRow),
+    benchmark_row_for_index_backend(Rows, lmdb_offset, LmdbRow),
+    row_number(SortedRow, median_ms, SortedMsPer1000),
+    row_number(LmdbRow, median_ms, LmdbMsPer1000),
+    row_number(SortedRow, csr_build_seconds, SortedBuildSeconds),
+    row_number(LmdbRow, csr_build_seconds, LmdbBuildSeconds),
+    row_number(LmdbRow, offset_index_bytes, LmdbOffsetBytes),
+    BaseOptions = [
+        index_backend(auto),
+        expected_child_lookups_per_query(LookupsPerQuery),
+        expected_query_count_per_artifact(QueryCount),
+        sorted_array_lookup_ms_per_1000(SortedMsPer1000),
+        lmdb_offset_lookup_ms_per_1000(LmdbMsPer1000),
+        sorted_array_build_seconds(SortedBuildSeconds),
+        lmdb_offset_build_seconds(LmdbBuildSeconds),
+        lmdb_offset_bytes(LmdbOffsetBytes)
+    ],
+    include(csr_index_passthrough_workload_option, WorkloadOptions, PassThrough),
+    append(BaseOptions, PassThrough, Options).
+
+tsv_rows(Text, Rows) :-
+    split_string(Text, "\n", "\n\r", RawLines),
+    exclude(=(""), RawLines, Lines),
+    Lines = [HeaderLine|DataLines],
+    split_string(HeaderLine, "\t", "", HeaderStrings),
+    maplist(atom_string, Headers, HeaderStrings),
+    maplist(tsv_row(Headers), DataLines, Rows).
+
+tsv_row(Headers, Line, Row) :-
+    split_string(Line, "\t", "\r", Values),
+    same_length(Headers, Values),
+    pairs_keys_values(Row, Headers, Values).
+
+benchmark_row_for_index_backend(Rows, Backend, Row) :-
+    atom_string(Backend, BackendString),
+    member(Row, Rows),
+    memberchk(index_backend-BackendString, Row),
+    !.
+benchmark_row_for_index_backend(_Rows, Backend, _Row) :-
+    throw(error(existence_error(csr_benchmark_row, Backend), _)).
+
+row_number(Row, Field, Number) :-
+    memberchk(Field-String, Row),
+    number_string(Number, String),
+    !.
+row_number(Row, Field, _Number) :-
+    (   memberchk(Field-String, Row)
+    ->  throw(error(type_error(number_string(Field), String), _))
+    ;   throw(error(existence_error(csr_benchmark_field, Field), _))
+    ).
+
+csr_index_passthrough_workload_option(available_memory_bytes(_)).
+csr_index_passthrough_workload_option(csr_index_memory_fraction(_)).
+csr_index_passthrough_workload_option(lmdb_offset_memory_fits(true)).
 
 csr_lmdb_offset_pays_off(Options) :-
     option(expected_child_lookups_per_query(LookupsPerQuery), Options),

--- a/tests/core/test_cost_model.pl
+++ b/tests/core/test_cost_model.pl
@@ -89,6 +89,8 @@ test(test_reverse_index_csr_auto_index_backend_keeps_sorted_array).
 test(test_reverse_index_csr_auto_index_backend_selects_lmdb_offset_when_amortized).
 test(test_reverse_index_csr_auto_index_backend_keeps_sorted_array_when_build_not_amortized).
 test(test_reverse_index_csr_auto_index_backend_keeps_sorted_array_when_memory_does_not_fit).
+test(test_csr_index_backend_options_from_benchmark_rows).
+test(test_csr_index_backend_options_from_benchmark_tsv).
 test(test_reverse_index_csr_accepts_lmdb_offset_index_backend).
 test(test_reverse_index_csr_runtime_auto_direct_io_when_supported).
 test(test_reverse_index_csr_runtime_auto_buffered_when_direct_io_not_verified).
@@ -477,6 +479,59 @@ test_reverse_index_csr_auto_index_backend_keeps_sorted_array_when_memory_does_no
     ;   fail_test(Test, format_atom("got reverse_index=~w", [ReverseIndex]))
     ).
 
+test_csr_index_backend_options_from_benchmark_rows :-
+    Test = 'csr_index_backend_options_from_benchmark_rows extracts measured cost terms',
+    csr_benchmark_rows(Rows),
+    csr_index_backend_options_from_benchmark_rows(
+        Rows,
+        [
+            expected_child_lookups_per_query(500),
+            expected_query_count_per_artifact(100),
+            available_memory_bytes(1073741824)
+        ],
+        Options
+    ),
+    resolve_csr_index_backend(Options, Backend),
+    (   Backend = lmdb_offset,
+        memberchk(sorted_array_lookup_ms_per_1000(4.418097), Options),
+        memberchk(lmdb_offset_lookup_ms_per_1000(2.961144), Options),
+        memberchk(sorted_array_build_seconds(0.331824), Options),
+        memberchk(lmdb_offset_build_seconds(0.381317), Options),
+        memberchk(lmdb_offset_bytes(2113536), Options),
+        memberchk(available_memory_bytes(1073741824), Options)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("options=~w backend=~w", [Options, Backend]))
+    ).
+
+test_csr_index_backend_options_from_benchmark_tsv :-
+    Test = 'csr_index_backend_options_from_benchmark_tsv reads lookup benchmark TSV',
+    csr_benchmark_tsv(Text),
+    setup_call_cleanup(
+        tmp_file_stream(text, Path, Stream),
+        (   write(Stream, Text),
+            close(Stream),
+            csr_index_backend_options_from_benchmark_tsv(
+                Path,
+                [
+                    expected_child_lookups_per_query(100),
+                    expected_query_count_per_artifact(1),
+                    lmdb_offset_memory_fits(true)
+                ],
+                Options
+            ),
+            resolve_csr_index_backend(Options, Backend)
+        ),
+        (   exists_file(Path)
+        ->  delete_file(Path)
+        ;   true
+        )
+    ),
+    (   Backend = sorted_array,
+        memberchk(lmdb_offset_memory_fits(true), Options)
+    ->  pass(Test)
+    ;   fail_test(Test, format_atom("options=~w backend=~w", [Options, Backend]))
+    ).
+
 test_reverse_index_csr_runtime_auto_direct_io_when_supported :-
     Test = 'resolve_csr_io_policy auto selects direct_io only when runtime support is verified',
     Options = [
@@ -607,6 +662,49 @@ test_read_mem_available_returns_positive :-
     ;   %% Skip on non-Linux platforms
         format("[SKIP] ~w (no /proc/meminfo)~n", [Test])
     ).
+
+csr_benchmark_rows([
+    [
+        backend-"csr_sorted_array",
+        index_backend-"sorted_array",
+        sample_parents-"1000",
+        iterations-"5",
+        total_children-"8000",
+        median_ms-"4.418097",
+        csr_artifact_bytes-"2401022",
+        csr_build_seconds-"0.331824",
+        offset_index_bytes-"0"
+    ],
+    [
+        backend-"csr_lmdb_offset",
+        index_backend-"lmdb_offset",
+        sample_parents-"1000",
+        iterations-"5",
+        total_children-"8000",
+        median_ms-"2.961144",
+        csr_artifact_bytes-"4522789",
+        csr_build_seconds-"0.381317",
+        offset_index_bytes-"2113536"
+    ],
+    [
+        backend-"lmdb",
+        index_backend-"n/a",
+        sample_parents-"1000",
+        iterations-"5",
+        total_children-"8000",
+        median_ms-"3.812495",
+        csr_artifact_bytes-"2401022",
+        csr_build_seconds-"0.331824",
+        offset_index_bytes-"0"
+    ]
+]).
+
+csr_benchmark_tsv(
+"backend\tindex_backend\tsample_parents\titerations\ttotal_children\tmedian_ms\tcsr_artifact_bytes\tcsr_build_seconds\toffset_index_bytes
+csr_sorted_array\tsorted_array\t1000\t5\t8000\t4.418097\t2401022\t0.331824\t0
+csr_lmdb_offset\tlmdb_offset\t1000\t5\t8000\t2.961144\t4522789\t0.381317\t2113536
+lmdb\tn/a\t1000\t5\t8000\t3.812495\t2401022\t0.331824\t0
+").
 
 %% ========================================================================
 %% Helper: format an atom for fail_test reasons


### PR DESCRIPTION
  ## Summary

  - Add `csr_index_backend_options_from_benchmark_tsv/3`.
  - Add `csr_index_backend_options_from_benchmark_rows/3`.
  - Extract measured CSR index terms from benchmark output:
    - `median_ms`
    - `csr_build_seconds`
    - `offset_index_bytes`
  - Combine measured terms with workload expectations:
    - `expected_child_lookups_per_query(...)`
    - `expected_query_count_per_artifact(...)`
    - `available_memory_bytes(...)` or `lmdb_offset_memory_fits(true)`
  - Produce the option list consumed by `resolve_csr_index_backend/2`.
  - Document the benchmark-telemetry-to-resolver flow in the reverse-index design doc.

  ## Validation

  - `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
  - `git diff --check`