### PR TITLE
Implement cost-based auto-resolvers for F# WAM target

### DIFF
--- a/docs/design/WAM_FSHARP_COST_ANALYZER_DESIGN.md
+++ b/docs/design/WAM_FSHARP_COST_ANALYZER_DESIGN.md
@@ -1,6 +1,6 @@
 # F# Edge Store Cost Analyzer: Design
 
-**Status**: Design. Ready for implementation.
+**Status**: Implemented. Resolver chain wired into write_wam_fsharp_project/3.
 **Date**: 2026-05-26
 **Depends on**: CSR reader (done), dual-CSR builder (done),
 `WcLookupSources` auto-wiring (done)

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -59,7 +59,13 @@
     iso_errors_rewrite/4,                % +Config, +PI, +Items0, -Items
     iso_errors_rewrite_text/4,           % +Config, +PI, +WamText0, -WamText
     wam_fsharp_iso_audit/3,              % +Predicates, +Options, -Audit
-    wam_fsharp_iso_audit_report/1        % +Audit
+    wam_fsharp_iso_audit_report/1,       % +Audit
+    % Cost-based auto-resolvers
+    resolve_auto_edge_store_fs/2,        % +Options0, -Options
+    resolve_auto_lmdb_materialisation_fs/2, % +Options0, -Options
+    resolve_auto_lmdb_cache_tier_fs/2,   % +Options0, -Options
+    resolve_auto_csr_index_backend_fs/2, % +Options0, -Options
+    resolve_fsharp_cost_options/2        % +Options0, -Options
 ]).
 
 :- use_module(library(lists)).
@@ -71,6 +77,11 @@
              [detect_recursive_kernel/4, kernel_metadata/4, kernel_config/2,
               kernel_register_layout/2, kernel_native_call/2, kernel_template_file/2]).
 :- use_module('../core/template_system', [render_template/3]).
+:- use_module('../core/cost_model', [
+    recommend_access_pattern/5,
+    read_mem_available_bytes/1,
+    resolve_csr_index_backend/2
+]).
 :- use_module('../core/purity_certificate', [analyze_predicate_purity/2]).
 :- use_module('../bindings/fsharp_wam_bindings').
 :- use_module('../core/iso_errors',
@@ -4574,6 +4585,147 @@ wam_fsharp_iso_audit_report([audit(PI, Mode, Sites)|Rest]) :-
     ),
     wam_fsharp_iso_audit_report(Rest).
 
+%% =====================================================================
+%% Cost-based auto-resolvers for F# WAM target
+%% =====================================================================
+
+%% resolve_auto_edge_store_fs(+Options0, -Options)
+%  Resolve edge_store(auto) into a concrete store selection.
+%  Decides between lmdb_cached, lmdb_eager, csr, or dual_csr based on
+%  workload metadata. When edge_store is not auto (or absent), pass through.
+resolve_auto_edge_store_fs(Options0, Options) :-
+    (   option(edge_store(auto), Options0)
+    ->  compute_edge_store_fs(Options0, Store),
+        exclude(=(edge_store(_)), Options0, Rest),
+        apply_edge_store_fs(Store, Rest, Options)
+    ;   Options = Options0
+    ).
+
+compute_edge_store_fs(Options, Store) :-
+    option(expected_query_count(Q), Options, 1),
+    option(expected_lookups_per_query(L), Options, 50),
+    option(edge_count(E), Options, 0),
+    option(graph_mutability(Mut), Options, 'static'),
+    option(needs_reverse(NeedsRev), Options, false),
+    TotalLookups is Q * L,
+    CsrBuildMs is E * 0.01,
+    PerLookupSavingsUs is 5,
+    (   PerLookupSavingsUs > 0
+    ->  BreakEvenLookups is CsrBuildMs * 1000 / PerLookupSavingsUs
+    ;   BreakEvenLookups is 1.0e12
+    ),
+    (   Mut == 'dynamic'
+    ->  Store = lmdb_cached
+    ;   (   TotalLookups < BreakEvenLookups
+        ->  (   E < 50000
+            ->  Store = lmdb_eager
+            ;   Store = lmdb_cached
+            )
+        ;   (   NeedsRev = true
+            ->  Store = dual_csr
+            ;   Store = csr
+            )
+        )
+    ),
+    (   option(edge_store_verbose(true), Options)
+    ->  format(user_error,
+               '[WAM-FSharp] edge_store(auto): Q=~w L=~w E=~w mut=~w rev=~w -> ~w~n',
+               [Q, L, E, Mut, NeedsRev, Store])
+    ;   true
+    ).
+
+apply_edge_store_fs(lmdb_cached, Opts, [lmdb_materialisation(cached) | Opts]).
+apply_edge_store_fs(lmdb_eager, Opts, [lmdb_materialisation(eager) | Opts]).
+apply_edge_store_fs(csr, Opts, Opts).
+apply_edge_store_fs(dual_csr, Opts, Opts).
+
+%% resolve_auto_lmdb_materialisation_fs(+Options0, -Options)
+%  Resolve lmdb_materialisation(auto) into eager/lazy/cached using
+%  the shared cost model. When not auto, pass through.
+resolve_auto_lmdb_materialisation_fs(Options0, Options) :-
+    (   option(lmdb_materialisation(auto), Options0)
+    ->  compute_lmdb_materialisation_fs(Options0, Mode),
+        exclude(=(lmdb_materialisation(_)), Options0, Rest),
+        Options = [lmdb_materialisation(Mode) | Rest]
+    ;   Options = Options0
+    ).
+
+compute_lmdb_materialisation_fs(Options, Mode) :-
+    option(fact_count(F), Options, 0),
+    option(demand_set_estimate(D), Options, F),
+    option(expected_query_count(NQ), Options, 1),
+    option(workload_segregated(WS), Options, false),
+    option(working_set_fraction(WSF), Options, 0.05),
+    EdgeBytes is D * 50,
+    (   option(memory_budget(B), Options)
+    ->  true
+    ;   catch(read_mem_available_bytes(B), _, B = 1_000_000_000)
+    ),
+    (   EdgeBytes > B
+    ->  (WS == true -> Mode = lazy ; Mode = cached)
+    ;   KKeys is integer(F * WSF),
+        option(cost_model_constants(Constants), Options, []),
+        recommend_access_pattern(KKeys, EdgeBytes, B, Constants, Pattern),
+        (   Pattern = sort
+        ->  (NQ >= 10, F =< 100_000 -> Mode = eager ; Mode = cached)
+        ;   (EdgeBytes > B -> Mode = cached ; Mode = eager)
+        )
+    ),
+    (   option(materialisation_verbose(true), Options)
+    ->  format(user_error,
+               '[WAM-FSharp] lmdb_materialisation(auto): F=~w D=~w B=~w NQ=~w WS=~w -> ~w~n',
+               [F, D, B, NQ, WS, Mode])
+    ;   true
+    ).
+
+%% resolve_auto_lmdb_cache_tier_fs(+Options0, -Options)
+%  Resolve lmdb_l2_capacity(auto) into a concrete cache size.
+%  For eager/lazy modes the capacity is 0 (no cache tier).
+%  For cached mode the capacity scales with demand set size.
+resolve_auto_lmdb_cache_tier_fs(Options0, Options) :-
+    (   option(lmdb_l2_capacity(auto), Options0)
+    ->  compute_l2_capacity_fs(Options0, Cap),
+        exclude(=(lmdb_l2_capacity(_)), Options0, Rest),
+        Options = [lmdb_l2_capacity(Cap) | Rest]
+    ;   Options = Options0
+    ).
+
+compute_l2_capacity_fs(Options, Cap) :-
+    option(lmdb_materialisation(Mode), Options, cached),
+    (   Mode \= cached
+    ->  Cap = 0
+    ;   option(fact_count(F), Options, 0),
+        option(demand_set_estimate(D), Options, F),
+        Target is max(256, min(65536, integer(D * 0.1))),
+        Cap = Target
+    ),
+    (   option(l2_capacity_verbose(true), Options)
+    ->  format(user_error,
+               '[WAM-FSharp] lmdb_l2_capacity(auto): mode=~w -> ~w~n',
+               [Mode, Cap])
+    ;   true
+    ).
+
+%% resolve_auto_csr_index_backend_fs(+Options0, -Options)
+%  Resolve csr_index_backend(auto) by delegating to the shared
+%  cost rule in cost_model.pl.
+resolve_auto_csr_index_backend_fs(Options0, Options) :-
+    (   option(csr_path(_), Options0),
+        option(csr_index_backend(auto), Options0)
+    ->  resolve_csr_index_backend(Options0, Backend),
+        exclude(=(csr_index_backend(_)), Options0, Rest),
+        Options = [csr_index_backend(Backend) | Rest]
+    ;   Options = Options0
+    ).
+
+%% resolve_fsharp_cost_options(+Options0, -Options)
+%  Composed resolver chain: runs all four auto-resolvers in sequence.
+resolve_fsharp_cost_options(Options0, Options) :-
+    resolve_auto_edge_store_fs(Options0, Options1),
+    resolve_auto_lmdb_materialisation_fs(Options1, Options2),
+    resolve_auto_lmdb_cache_tier_fs(Options2, Options3),
+    resolve_auto_csr_index_backend_fs(Options3, Options).
+
 %% write_wam_fsharp_project(+Predicates, +Options, +ProjectDir)
 %  Generates a complete F# project with:
 %  - WamTypes.fs:   Value DU, WamState, WamContext, helpers
@@ -4582,8 +4734,11 @@ wam_fsharp_iso_audit_report([audit(PI, Mode, Sites)|Rest]) :-
 %  - Lowered.fs:    lowered predicate functions (Phase 3+)
 %  - Program.fs:    benchmark driver
 %  - wam-fsharp-bench.fsproj: project file
-write_wam_fsharp_project(Predicates, Options, ProjectDir) :-
+write_wam_fsharp_project(Predicates, Options0, ProjectDir) :-
     make_directory_path(ProjectDir),
+
+    % Phase 0: resolve cost-based auto options
+    resolve_fsharp_cost_options(Options0, Options),
 
     % Resolve runtime parser mode (capability hook).  When `compiled`
     % is selected, the portable parser predicates + the target-agnostic

--- a/tests/core/test_wam_fsharp_cost_analyzer.pl
+++ b/tests/core/test_wam_fsharp_cost_analyzer.pl
@@ -1,0 +1,153 @@
+:- encoding(utf8).
+% Tests for F# WAM cost analyzer resolver chain.
+% Run: swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_cost_analyzer.pl
+
+:- prolog_load_context(directory, Dir),
+   atom_concat(Dir, '/../../src/unifyweaver/targets/wam_fsharp_target', Mod),
+   use_module(Mod, [
+       resolve_auto_edge_store_fs/2,
+       resolve_auto_lmdb_materialisation_fs/2,
+       resolve_auto_lmdb_cache_tier_fs/2,
+       resolve_auto_csr_index_backend_fs/2,
+       resolve_fsharp_cost_options/2
+   ]).
+
+:- dynamic test_count/2.
+
+run_tests :-
+    retractall(test_count(_, _)),
+    assertz(test_count(pass, 0)),
+    assertz(test_count(fail, 0)),
+    writeln('=== F# WAM Cost Analyzer Tests ==='),
+
+    % -- Edge store resolver tests --
+
+    run_test("edge_store(auto): dynamic graph -> lmdb_cached",
+        ( resolve_auto_edge_store_fs(
+            [edge_store(auto), edge_count(1000), graph_mutability('dynamic')], R),
+          member(lmdb_materialisation(cached), R) )),
+
+    run_test("edge_store(auto): small static, few queries -> lmdb_eager",
+        ( resolve_auto_edge_store_fs(
+            [edge_store(auto), edge_count(1000),
+             expected_query_count(10), expected_lookups_per_query(50)], R),
+          member(lmdb_materialisation(eager), R) )),
+
+    run_test("edge_store(auto): large static, many queries -> csr or dual_csr",
+        ( resolve_auto_edge_store_fs(
+            [edge_store(auto), edge_count(100000),
+             expected_query_count(10000), expected_lookups_per_query(50)], R),
+          \+ member(lmdb_materialisation(eager), R) )),
+
+    run_test("edge_store(auto): needs_reverse -> dual_csr",
+        ( resolve_auto_edge_store_fs(
+            [edge_store(auto), edge_count(100000),
+             expected_query_count(10000), expected_lookups_per_query(50),
+             needs_reverse(true)], R),
+          \+ member(lmdb_materialisation(_), R) )),
+
+    run_test("edge_store not auto -> pass through",
+        ( resolve_auto_edge_store_fs(
+            [edge_store(csr), edge_count(1000)], R),
+          member(edge_store(csr), R) )),
+
+    run_test("edge_store absent -> pass through",
+        ( resolve_auto_edge_store_fs([edge_count(1000)], R),
+          \+ member(edge_store(_), R) )),
+
+    % -- LMDB materialisation resolver tests --
+
+    run_test("materialisation(auto): large dataset, constrained memory -> cached",
+        ( resolve_auto_lmdb_materialisation_fs(
+            [lmdb_materialisation(auto), fact_count(500000),
+             demand_set_estimate(500000), memory_budget(1000)], R),
+          member(lmdb_materialisation(cached), R) )),
+
+    run_test("materialisation(auto): small facts, many queries -> eager",
+        ( resolve_auto_lmdb_materialisation_fs(
+            [lmdb_materialisation(auto), fact_count(5000),
+             expected_query_count(100), memory_budget(1000000000)], R),
+          member(lmdb_materialisation(eager), R) )),
+
+    run_test("materialisation(auto): workload_segregated -> lazy when large",
+        ( resolve_auto_lmdb_materialisation_fs(
+            [lmdb_materialisation(auto), fact_count(1000000),
+             demand_set_estimate(1000000),
+             memory_budget(100), workload_segregated(true)], R),
+          member(lmdb_materialisation(lazy), R) )),
+
+    run_test("materialisation explicit cached -> pass through",
+        ( resolve_auto_lmdb_materialisation_fs(
+            [lmdb_materialisation(cached), fact_count(50000)], R),
+          member(lmdb_materialisation(cached), R) )),
+
+    run_test("materialisation explicit eager -> pass through",
+        ( resolve_auto_lmdb_materialisation_fs(
+            [lmdb_materialisation(eager)], R),
+          member(lmdb_materialisation(eager), R) )),
+
+    % -- L2 capacity resolver tests --
+
+    run_test("l2_capacity(auto) with cached -> computed in [256, 65536]",
+        ( resolve_auto_lmdb_cache_tier_fs(
+            [lmdb_l2_capacity(auto), lmdb_materialisation(cached),
+             fact_count(10000)], R),
+          member(lmdb_l2_capacity(Cap), R),
+          Cap >= 256, Cap =< 65536 )),
+
+    run_test("l2_capacity(auto) with eager -> 0",
+        ( resolve_auto_lmdb_cache_tier_fs(
+            [lmdb_l2_capacity(auto), lmdb_materialisation(eager)], R),
+          member(lmdb_l2_capacity(0), R) )),
+
+    run_test("l2_capacity(auto) with lazy -> 0",
+        ( resolve_auto_lmdb_cache_tier_fs(
+            [lmdb_l2_capacity(auto), lmdb_materialisation(lazy)], R),
+          member(lmdb_l2_capacity(0), R) )),
+
+    run_test("l2_capacity explicit 1024 -> pass through",
+        ( resolve_auto_lmdb_cache_tier_fs(
+            [lmdb_l2_capacity(1024), lmdb_materialisation(cached)], R),
+          member(lmdb_l2_capacity(1024), R) )),
+
+    % -- CSR index backend resolver tests --
+
+    run_test("csr_index_backend without csr_path -> pass through",
+        ( resolve_auto_csr_index_backend_fs(
+            [csr_index_backend(auto)], R),
+          member(csr_index_backend(auto), R) )),
+
+    % -- Composed chain tests --
+
+    run_test("full chain: all auto -> all resolved",
+        ( resolve_fsharp_cost_options(
+            [lmdb_materialisation(auto), lmdb_l2_capacity(auto),
+             fact_count(10000), memory_budget(1000000000)], R),
+          member(lmdb_materialisation(Mode), R), Mode \= auto,
+          member(lmdb_l2_capacity(Cap), R), integer(Cap) )),
+
+    run_test("full chain: no auto values -> pass through unchanged",
+        ( resolve_fsharp_cost_options(
+            [lmdb_materialisation(cached), lmdb_l2_capacity(512)], R),
+          member(lmdb_materialisation(cached), R),
+          member(lmdb_l2_capacity(512), R) )),
+
+    % -- Summary --
+    test_count(pass, P),
+    test_count(fail, F),
+    format('~n=== Results: ~w/~w passed ===~n', [P, P + F]),
+    (F > 0 -> halt(1) ; true).
+
+run_test(Name, Goal0) :-
+    copy_term(Goal0, Goal),
+    (   catch(Goal, Err,
+              (format("~w: ERROR: ~w~n", [Name, Err]),
+               retract(test_count(fail, F0)), F1 is F0 + 1,
+               assertz(test_count(fail, F1))))
+    ->  format("~w: PASS~n", [Name]),
+        retract(test_count(pass, P)), P1 is P + 1,
+        assertz(test_count(pass, P1))
+    ;   format("~w: FAIL~n", [Name]),
+        retract(test_count(fail, F)), F1 is F + 1,
+        assertz(test_count(fail, F1))
+    ).


### PR DESCRIPTION
## Summary

- Adds a four-stage resolver chain (`resolve_fsharp_cost_options/2`) that resolves `auto` values for `edge_store`, `lmdb_materialisation`, `lmdb_l2_capacity`, and `csr_index_backend` using the shared cost model
- `resolve_auto_edge_store_fs`: picks `lmdb_cached`/`lmdb_eager`/`csr`/`dual_csr` from workload metadata (query count, edge count, mutability)
- `resolve_auto_lmdb_materialisation_fs`: picks `eager`/`lazy`/`cached` via `recommend_access_pattern/5` + memory budget + segregation flag
- `resolve_auto_lmdb_cache_tier_fs`: sizes L2 cache from demand set (0 for eager/lazy, scaled 10% clamped to [256, 65536] for cached)
- `resolve_auto_csr_index_backend_fs`: delegates to shared `resolve_csr_index_backend/2`
- Wired into `write_wam_fsharp_project/3` as Phase 0 before codegen
- Implements the design in `docs/design/WAM_FSHARP_COST_ANALYZER_DESIGN.md`

## Test plan

- [x] 18/18 cost analyzer resolver tests pass: `swipl -q -g run_tests -t halt tests/core/test_wam_fsharp_cost_analyzer.pl`
- [x] 28/28 template system tests pass: `swipl -q -g test_template_system -t halt src/unifyweaver/core/template_system.pl`
- [x] Explicit option values pass through unchanged (no behavior change for existing callers)
- [x] Edge cases: dynamic graphs, workload-segregated lazy, memory-constrained cached, absent options

https://claude.ai/code/session_01G2ZvZyzkhUL5MtUihXeCkH

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2ZvZyzkhUL5MtUihXeCkH)_