### PR TITLE
feat(wam-elixir): meta-call dispatch for findall/bagof/setof

### DIFF
--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -1601,14 +1601,13 @@ compile_utility_helpers_to_elixir(Code) :-
         goal_term = deref_var(state, get_reg(state, 2))
         prepared = %{state | regs: Map.put(state.regs, 1, goal_term)}
         dispatch_call_meta(prepared, 1, state.cp)
+      {"findall/3", 3} ->
+        execute_aggregate_meta(state, :collect)
+      {"bagof/3", 3} ->
+        execute_aggregate_meta(state, :bagof)
+      {"setof/3", 3} ->
+        execute_aggregate_meta(state, :setof)
       {"throw/1", 1} ->
-        # throw(Term). Deep-copy the term (independent of catch
-        # boundary), then BEAM-throw {:wam_throw, copy} so the
-        # nearest enclosing execute_catch unwinds the BEAM stack
-        # back to itself. If catcher_frames is empty, no enclosing
-        # catch exists at the WAM level — convert to :fail + stderr
-        # diagnostic so the lowered run(args) wrapper sees a clean
-        # failure rather than a crash.
         execute_throw(state)
       _ ->
         # Hardening: surface unimplemented builtins instead of silently
@@ -1644,6 +1643,140 @@ compile_utility_helpers_to_elixir(Code) :-
   # `defp`: only invoked from within WamRuntime (execute_builtin
   # arm + the :call/:execute step arms via the same module). Not
   # part of the runtime''s external API.
+  # Meta-call dispatch for findall/3, bagof/3, setof/3.
+  # A1=Template, A2=Goal, A3=Result. Pushes an aggregate frame,
+  # sets cp to a collector closure, then dispatches Goal via
+  # dispatch_call_meta. Each time Goal succeeds the collector
+  # captures the template value and throws fail to drive the next
+  # solution. When Goal exhausts, backtrack finds the aggregate
+  # frame and finalise_aggregate groups + binds the result.
+  defp execute_aggregate_meta(state, kind) do
+    template_ref = get_reg_raw(state, 1)
+    goal = deref_var(state, get_reg(state, 2))
+    result_reg_val = get_reg_raw(state, 3)
+
+    # For bagof/setof: walk Goal to find witness vars not in Template
+    # and not under ^/2. In the meta-call path we track witness
+    # bindings by storing the derefed unbound refs directly (not
+    # register IDs, since meta-call args are heap-allocated, not in
+    # fixed registers).
+    witness_refs =
+      if kind in [:bagof, :setof] do
+        template_vars = collect_term_vars(state, template_ref, MapSet.new())
+        {goal_vars, _} = collect_goal_witnesses(state, goal, template_vars)
+        goal_vars
+      else
+        []
+      end
+
+    # Push aggregate frame. value_reg and result_reg are register
+    # indices in the inline path, but here we store a sentinel (-1)
+    # and use the saved refs directly.
+    state = push_aggregate_frame(state, kind, -1, -1, [])
+    # Stash template_ref, result_reg_val, and witness_refs in the
+    # aggregate CP so the collector and finaliser can read them.
+    {updated_cps, _} =
+      Enum.map_reduce(state.choice_points, false, fn cp, done ->
+        cond do
+          done -> {cp, done}
+          Map.has_key?(cp, :agg_type) ->
+            cp = cp
+            |> Map.put(:meta_template_ref, template_ref)
+            |> Map.put(:meta_result_ref, result_reg_val)
+            |> Map.put(:meta_witness_refs, witness_refs)
+            {cp, true}
+          true -> {cp, done}
+        end
+      end)
+    state = %{state | choice_points: updated_cps}
+
+    # Collector closure: on each Goal success, capture template
+    # value and witness values, then fail to drive the next solution.
+    collector = fn(s) ->
+      val = deep_copy_value(s, deref_var(s, template_ref))
+      {updated, _} =
+        Enum.map_reduce(s.choice_points, false, fn cp, done ->
+          cond do
+            done -> {cp, done}
+            Map.has_key?(cp, :agg_type) ->
+              cp = Map.put(cp, :agg_accum, [val | Map.get(cp, :agg_accum, [])])
+              w_refs = Map.get(cp, :meta_witness_refs, [])
+              cp =
+                if w_refs != [] do
+                  wvals = Enum.map(w_refs, fn wr ->
+                    deep_copy_value(s, deref_var(s, wr))
+                  end)
+                  Map.put(cp, :agg_witness_accum, [wvals | Map.get(cp, :agg_witness_accum, [])])
+                else
+                  cp
+                end
+              {cp, true}
+            true -> {cp, done}
+          end
+        end)
+      throw({:fail, %{s | choice_points: updated}})
+    end
+
+    # Load Goal into A1 and dispatch as 1-arity meta-call with
+    # cp = collector so Goal proceeds into collection.
+    state = %{state | regs: Map.put(state.regs, 1, goal)}
+    dispatch_call_meta(state, 1, collector)
+  end
+
+  # Walk a term collecting unbound variable refs.
+  defp collect_term_vars(_state, {:unbound, _} = ref, seen) do
+    if MapSet.member?(seen, ref), do: seen, else: MapSet.put(seen, ref)
+  end
+  defp collect_term_vars(state, {:ref, addr}, seen) do
+    case Map.get(state.heap, addr) do
+      {:str, fn_name} ->
+        arity = parse_functor_arity(fn_name)
+        Enum.reduce(1..max(arity, 1), seen, fn i, acc ->
+          if arity == 0, do: acc,
+          else: collect_term_vars(state, deref_var(state, Map.get(state.heap, addr + i)), acc)
+        end)
+      _ -> seen
+    end
+  end
+  defp collect_term_vars(state, val, seen) do
+    derefed = deref_var(state, val)
+    if derefed != val, do: collect_term_vars(state, derefed, seen), else: seen
+  end
+
+  # Walk Goal collecting witness vars: vars not in exclude set and
+  # not under ^/2 LHS. Returns {witness_list, seen_set}.
+  defp collect_goal_witnesses(state, {:unbound, _} = ref, exclude) do
+    if MapSet.member?(exclude, ref), do: {[], exclude},
+    else: {[ref], MapSet.put(exclude, ref)}
+  end
+  defp collect_goal_witnesses(state, {:ref, addr}, exclude) do
+    case Map.get(state.heap, addr) do
+      {:str, "^/2"} ->
+        lhs = deref_var(state, Map.get(state.heap, addr + 1))
+        lhs_vars = collect_term_vars(state, lhs, MapSet.new())
+        exclude2 = MapSet.union(exclude, lhs_vars)
+        rhs = deref_var(state, Map.get(state.heap, addr + 2))
+        collect_goal_witnesses(state, rhs, exclude2)
+      {:str, fn_name} ->
+        arity = parse_functor_arity(fn_name)
+        if arity > 0 do
+          Enum.reduce(1..arity, {[], exclude}, fn i, {acc, exc} ->
+            arg = deref_var(state, Map.get(state.heap, addr + i))
+            {new_vars, new_exc} = collect_goal_witnesses(state, arg, exc)
+            {acc ++ new_vars, new_exc}
+          end)
+        else
+          {[], exclude}
+        end
+      _ -> {[], exclude}
+    end
+  end
+  defp collect_goal_witnesses(state, val, exclude) do
+    derefed = deref_var(state, val)
+    if derefed != val, do: collect_goal_witnesses(state, derefed, exclude),
+    else: {[], exclude}
+  end
+
   defp dispatch_call_meta(state, total_arity, after_pc) do
     goal = deref_var(state, get_reg(state, 1))
     # Elixir descending-range trap: `for i <- 2..1` would raise
@@ -2831,10 +2964,13 @@ compile_aggregate_helpers_to_elixir(Code) :-
   def finalise_aggregate(state, agg_cp, rest_cps, agg_type) do
     accum_rev = Enum.reverse(agg_cp.agg_accum)
     witness_regs = Map.get(agg_cp, :agg_witness_regs, [])
+    meta_witness_refs = Map.get(agg_cp, :meta_witness_refs, [])
     witness_accum_rev = Enum.reverse(Map.get(agg_cp, :agg_witness_accum, []))
+    has_witnesses = (witness_regs != [] or meta_witness_refs != []) and
+                    witness_accum_rev != []
 
     # Witness-group path for bagof/setof with free witnesses.
-    if agg_type in [:bagof, :setof] and witness_regs != [] do
+    if agg_type in [:bagof, :setof] and has_witnesses do
       if accum_rev == [], do: throw({:fail, state})
       groups = group_by_witness(accum_rev, witness_accum_rev, agg_type)
       if groups == [], do: throw({:fail, state})
@@ -2865,16 +3001,26 @@ compile_aggregate_helpers_to_elixir(Code) :-
           :min ->
             if accum_rev == [], do: throw({:fail, state}), else: Enum.min(accum_rev)
         end
-      # Bind the result through the trail when result_reg holds an
-      # unbound ref.
+      # Bind the result. Meta-call path stores result ref in the CP
+      # (agg_result_reg == -1); inline path uses a register index.
+      meta_result_ref = Map.get(agg_cp, :meta_result_ref)
       bound_regs =
-        case Map.get(agg_cp.regs, agg_cp.agg_result_reg) do
-          {:unbound, id} ->
-            agg_cp.regs
-            |> Map.put(id, result)
-            |> Map.put(agg_cp.agg_result_reg, result)
-          _ ->
-            Map.put(agg_cp.regs, agg_cp.agg_result_reg, result)
+        if meta_result_ref != nil and agg_cp.agg_result_reg == -1 do
+          case meta_result_ref do
+            {:unbound, id} ->
+              agg_cp.regs |> Map.put(id, result)
+            _ ->
+              agg_cp.regs
+          end
+        else
+          case Map.get(agg_cp.regs, agg_cp.agg_result_reg) do
+            {:unbound, id} ->
+              agg_cp.regs
+              |> Map.put(id, result)
+              |> Map.put(agg_cp.agg_result_reg, result)
+            _ ->
+              Map.put(agg_cp.regs, agg_cp.agg_result_reg, result)
+          end
         end
       restored = %{state |
         regs: bound_regs,

--- a/tests/test_wam_elixir_classic_programs.pl
+++ b/tests/test_wam_elixir_classic_programs.pl
@@ -266,6 +266,17 @@ user:bs_pair(c, 3).
 :- dynamic user:bs_none/1.
 user:bs_none(_) :- fail.
 
+% --- Meta-call aggregate tests (NO inline_bagof_setof) ---
+% These exercise the runtime dispatch path for findall/3 and bagof/3
+% where the WAM compiler emits `execute findall/3` instead of
+% begin_aggregate/end_aggregate. Uses bs_int/1 facts (1,2,3) which
+% are defined above.
+:- dynamic user:elx_findall_meta/1.
+user:elx_findall_meta(L) :- findall(X, bs_int(X), L).
+
+:- dynamic user:elx_bagof_meta/1.
+user:elx_bagof_meta(L) :- bagof(X, bs_int(X), L).
+
 :- dynamic user:elx_bagof_basic/1.
 :- dynamic user:elx_bagof_fails_empty/0.
 :- dynamic user:elx_setof_basic/1.
@@ -684,11 +695,33 @@ test(compound_eq_mismatch_arity) :-
                            [], "false")).
 
 % --- bagof/setof tests ---
+% --- Meta-call aggregate tests (NO inline_bagof_setof) ---
+% These use the runtime execute_aggregate_meta path where the WAM
+% compiler emits `execute findall/3` / `execute bagof/3` instead of
+% begin_aggregate/end_aggregate.
+
+test(findall_meta) :-
+    % findall(X, bs_int(X), L) via meta-call dispatch. No inline.
+    with_elixir_project(
+        [user:elx_findall_meta/1, user:bs_int/1],
+        _Opts,
+        TmpDir,
+        verify_elixir_args(TmpDir, 'elx_findall_meta/1',
+                           ['[1,2,3]'], "true")).
+
+test(bagof_meta) :-
+    % bagof(X, bs_int(X), L) via meta-call dispatch. No witness
+    % vars (X is both template and goal arg). Should give [1,2,3].
+    with_elixir_project(
+        [user:elx_bagof_meta/1, user:bs_int/1],
+        _Opts,
+        TmpDir,
+        verify_elixir_args(TmpDir, 'elx_bagof_meta/1',
+                           ['[1,2,3]'], "true")).
+
+% --- Inline bagof/setof tests (with inline_bagof_setof(true)) ---
 % All pass inline_bagof_setof(true) so the WAM compiler inlines
-% bagof/setof into begin_aggregate / end_aggregate (which the Elixir
-% runtime already supports). Without this option the compiler emits
-% `execute bagof/3` which the Elixir runtime cannot dispatch (no
-% meta-call findall/bagof/setof; deferred to a separate PR).
+% bagof/setof into begin_aggregate / end_aggregate.
 
 test(bagof_basic) :-
     with_elixir_project(


### PR DESCRIPTION
  ## Summary

  Removes the `inline_bagof_setof(true)` requirement. The Elixir runtime now handles `findall/3`, `bagof/3`, and
  `setof/3` as builtins in `execute_builtin`, dispatching the Goal via `dispatch_call_meta`. This lets goals constructed
   at runtime via `call/N` use aggregates.

  Previously, the WAM compiler had to inline aggregates as `begin_aggregate`/`end_aggregate` instructions (requiring the
   `inline_bagof_setof(true)` option). Without it, the compiler emitted `execute findall/3` which hit the
  `{:unknown_builtin, ...}` fallback. Now both paths work — inline for the common case, meta-call for
  runtime-constructed goals.

  ## Implementation

  ### `execute_aggregate_meta/2`

  New helper in `WamRuntime` that handles the meta-call dispatch path:

  1. **Saves template ref** (A1) and result ref (A3) in the aggregate CP — A1 gets overwritten when dispatching Goal, so
   the original unbound refs are stashed as `:meta_template_ref` and `:meta_result_ref` in the CP frame.

  2. **Witness computation** (bagof/setof only): walks the Goal term on the heap to find free witness vars via
  `collect_goal_witnesses/3` — vars present in Goal but not in Template and not under `^/2`. Uses `collect_term_vars/3`
  to build the Template exclude set.

  3. **Collector closure**: sets `state.cp` to a function that, on each Goal success:
     - Derefs and deep-copies the template value from the saved ref
     - Snapshots witness values (for bagof/setof)
     - Appends to the aggregate accumulator
     - Throws `{:fail, state}` to drive the next solution

  4. **Dispatches Goal** via `dispatch_call_meta(state, 1, collector)`.

  ### `finalise_aggregate` update

  When the aggregate frame has `meta_result_ref` (meta-call path, `agg_result_reg == -1`), binds the result through the
  saved unbound ref instead of a register index.

  ## New tests

  | Test | What it verifies |
  |---|---|
  | `findall_meta` | `findall(X, bs_int(X), L)` without `inline_bagof_setof(true)` — exercises the `execute findall/3` →
   `execute_aggregate_meta` path |
  | `bagof_meta` | `bagof(X, bs_int(X), L)` without `inline_bagof_setof(true)` — same path for bagof (no witness vars in
   this case since X is both template and goal arg) |

  Both use `bs_int/1` facts `{1, 2, 3}` from existing test fixtures.

  ## Verification

  | Metric | Before (PR #2492) | This PR |
  |---|---|---|
  | Tests passing | 36/48 | **38/50** |
  | Tests failing | 12/48 | 12/50 |
  | New tests | — | +2 (findall_meta, bagof_meta) |

  12 pre-existing failures unchanged (`switch_on_term_a2` TODO).

  ## What this unblocks

  - Runtime-constructed aggregate goals via `call/N` (e.g., `call(findall, X, Goal, L)`)
  - Nested aggregates where the inner is not statically visible to the WAM compiler
  - Removes the need to document `inline_bagof_setof(true)` as a prerequisite for every aggregate test

  🤖 Generated with [Claude Code](https://claude.com/claude-code)