### PR TITLE
Return direction-split hop counts from bidirectional kernel

### DIFF
--- a/src/unifyweaver/core/recursive_kernel_detection.pl
+++ b/src/unifyweaver/core/recursive_kernel_detection.pl
@@ -100,7 +100,7 @@ kernel_native_kind(astar_shortest_path4, astar_shortest_path4).
 kernel_native_kind(transitive_step_parent_distance5, transitive_step_parent_distance5).
 
 kernel_result_layout(category_ancestor, tuple(1)).
-kernel_result_layout(bidirectional_ancestor, tuple(1)).
+kernel_result_layout(bidirectional_ancestor, tuple(3)).  % (totalHops, parentHops, childHops)
 kernel_result_layout(transitive_closure2, tuple(1)).
 kernel_result_layout(transitive_distance3, tuple(2)).  % (target, distance)
 kernel_result_layout(weighted_shortest_path3, tuple(2)).  % (target, weight)
@@ -118,7 +118,7 @@ kernel_result_mode(astar_shortest_path4, stream).  % stream of at most 1
 kernel_result_mode(transitive_step_parent_distance5, stream).
 
 kernel_expected_arity(category_ancestor, 4).
-kernel_expected_arity(bidirectional_ancestor, 4).
+kernel_expected_arity(bidirectional_ancestor, 5).
 kernel_expected_arity(transitive_closure2, 2).
 kernel_expected_arity(transitive_distance3, 3).
 kernel_expected_arity(weighted_shortest_path3, 3).
@@ -139,7 +139,9 @@ kernel_expected_arity(transitive_step_parent_distance5, 5).
 kernel_register_layout(bidirectional_ancestor, [
     input(1, atom),          % cat
     input(2, atom),          % root
-    output(3, integer)       % hops (result)
+    output(3, integer),      % totalHops (result, tuple element 1)
+    output(4, integer),      % parentHops (result, tuple element 2)
+    output(5, integer)       % childHops (result, tuple element 3)
 ]).
 
 kernel_register_layout(category_ancestor, [

--- a/templates/targets/fsharp_wam/kernel_bidirectional_ancestor.fs.mustache
+++ b/templates/targets/fsharp_wam/kernel_bidirectional_ancestor.fs.mustache
@@ -14,7 +14,9 @@
 /// exceeds the budget is eliminated, since it cannot reach root
 /// within the remaining budget even using only parent hops (cheapest).
 ///
-/// Returns hop counts for all paths that reach root within budget.
+/// Returns (totalHops, parentHops, childHops) for all paths that
+/// reach root within budget. The caller applies the distance metric
+/// using parentHops and childHops for direction-weighted scoring.
 /// With childCost = infinity, degenerates to upward-only search.
 
 let private computeMinDistToRoot
@@ -40,20 +42,20 @@ let nativeKernel_bidirectional_ancestor
     (lookupChildren: int -> int list)
     (cat: int) (root: int)
     (parentCost: float) (childCost: float) (budget: float)
-    : int list =
+    : (int * int * int) list =
     let minDist = computeMinDistToRoot lookupChildren root
     let minCostToRoot nd =
         match minDist.TryGetValue(nd) with
         | true, d -> float d * parentCost
         | _ -> infinity
     let rec explore
-        (frontier: (int * float * int * Set<int>) list)
-        (acc: int list) : int list =
+        (frontier: (int * float * int * int * int * Set<int>) list)
+        (acc: (int * int * int) list) : (int * int * int) list =
         match frontier with
         | [] -> acc
-        | (node, cost, hops, visited) :: rest ->
+        | (node, cost, hops, pHops, cHops, visited) :: rest ->
             let acc' =
-                if node = root && hops > 0 then hops :: acc
+                if node = root && hops > 0 then (hops, pHops, cHops) :: acc
                 else acc
             let parentNext =
                 if cost + parentCost > budget then []
@@ -64,7 +66,7 @@ let nativeKernel_bidirectional_ancestor
                         else
                             let nc = cost + parentCost
                             if nc + minCostToRoot p > budget then None
-                            else Some (p, nc, hops + 1, Set.add p visited))
+                            else Some (p, nc, hops + 1, pHops + 1, cHops, Set.add p visited))
             let childNext =
                 if cost + childCost > budget then []
                 else
@@ -74,6 +76,6 @@ let nativeKernel_bidirectional_ancestor
                         else
                             let nc = cost + childCost
                             if nc + minCostToRoot c > budget then None
-                            else Some (c, nc, hops + 1, Set.add c visited))
+                            else Some (c, nc, hops + 1, pHops, cHops + 1, Set.add c visited))
             explore (parentNext @ childNext @ rest) acc'
-    explore [(cat, 0.0, 0, Set.singleton cat)] []
+    explore [(cat, 0.0, 0, 0, 0, Set.singleton cat)] []


### PR DESCRIPTION
## Summary

- Bidirectional kernel now returns `(totalHops, parentHops, childHops)` per path instead of just hop count
- Enables direction-weighted metrics: `w = (1/D)^N × (1/(bD))^M` where N=parentHops, M=childHops
- Template frontier tracks parentHops and childHops separately through the search
- Kernel metadata updated: `tuple(3)` result layout, 3 output registers, arity 5

This is the missing piece for the direction-weighted metric to work end-to-end in generated code. The convergence results from PR #2502 showed the weighted power-mean stabilizes at 0.1% delta (vs 72% for uniform), but required per-path direction information that the kernel wasn't returning.

## Test plan

- [x] 19/19 cost analyzer tests pass
- [x] Template and metadata load without errors
- [x] Return type matches the metric formula validated in #2502

https://claude.ai/code/session_01G2ZvZyzkhUL5MtUihXeCkH

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2ZvZyzkhUL5MtUihXeCkH)_