### PR TITLE
Integrate direction-weighted metric into codegen pipeline

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -5039,11 +5039,20 @@ generate_program_fs(_Predicates, DetectedKernels, Options, Code) :-
     ->  atom_number(L2CapStr, L2Cap)
     ;   L2CapStr = L2Cap
     ),
+    (   option(kernel_mode(bidirectional), Options)
+    ->  HasBidir = true,
+        option(child_branch_factor(BranchFactor), Options, 15.0),
+        option(graph_dimensionality(Dimensionality), Options, 5.0)
+    ;   HasBidir = false, BranchFactor = 15.0, Dimensionality = 5.0
+    ),
     Dict = [
         foreign_preds = ForeignPredsStr,
         lookup_sources_expr = LookupSourcesExpr,
         has_csr = HasCsr,
         has_lmdb = HasLmdb,
+        has_bidirectional = HasBidir,
+        branch_factor = BranchFactor,
+        dimensionality = Dimensionality,
         materialisation = Materialisation,
         l2_capacity = L2CapStr
     ],

--- a/templates/targets/fsharp_wam/program.fs.mustache
+++ b/templates/targets/fsharp_wam/program.fs.mustache
@@ -62,6 +62,28 @@ let extractDouble (v: Value) : float option =
     | Integer n -> Some (float n)
     | _         -> None
 
+{{#has_bidirectional}}
+// -- Direction-weighted effective distance metric -------------------------
+//
+// Each path is weighted by direction: w = (1/D)^N * (1/(b*D))^M
+// where N = parent hops, M = child hops, D = dimensionality, b = branch factor.
+// Normalized power-mean: d = (Σ(w * (h+1)^(-n)) / Σw)^(-1/n)
+
+let private parentWeight = 1.0 / {{dimensionality}}
+let private childWeight  = 1.0 / ({{branch_factor}} * {{dimensionality}})
+
+let effectiveDistanceWeighted (results: (int * int * int) list) (n: float) : float =
+    if List.isEmpty results then infinity
+    else
+        let mutable sumWF = 0.0
+        let mutable sumW = 0.0
+        for (totalHops, parentHops, childHops) in results do
+            let w = (parentWeight ** float parentHops) * (childWeight ** float childHops)
+            sumWF <- sumWF + w * (float (totalHops + 1)) ** (-n)
+            sumW <- sumW + w
+        (sumWF / sumW) ** (-1.0 / n)
+{{/has_bidirectional}}
+
 [<EntryPoint>]
 let main argv =
     let factsDir = if argv.Length > 0 then argv.[0] else "."


### PR DESCRIPTION
## Summary

- Adds `effectiveDistanceWeighted` function to the Program.fs template inside a `{{#has_bidirectional}}` conditional section
- Uses the kernel's `(totalHops, parentHops, childHops)` return type from PR #2503 to compute direction-weighted effective distance
- Metric: `d = (Σ(w * (h+1)^(-n)) / Σw)^(-1/n)` where `w = (1/D)^N * (1/(b*D))^M`
- Parameters `branch_factor` (default 15.0) and `dimensionality` (default 5.0) passed through template from `child_branch_factor` and `graph_dimensionality` codegen options
- When `kernel_mode(bidirectional)` is not set, the metric code is omitted entirely

Completes the end-to-end pipeline: kernel returns direction-split hop counts → metric computes convergent weighted distance (0.1% delta at childCost=3, vs 72% for uniform).

## Test plan

- [x] 19/19 cost analyzer tests pass
- [x] Template renders correctly with has_bidirectional=true (metric present, parameters substituted)
- [x] Template renders correctly with has_bidirectional=false (metric absent)
- [x] Prolog target loads without errors

https://claude.ai/code/session_01G2ZvZyzkhUL5MtUihXeCkH

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2ZvZyzkhUL5MtUihXeCkH)_