### PR TITLE
feat(wam-clojure): derive numlist low from bound list

### DIFF
--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -918,19 +918,48 @@
                                   (select-solution-results base-state items))
     (backtrack base-state)))
 
+(defn numlist-int-value [state value]
+  (cond
+    (integer? value) value
+    (string? value) (parse-number-text value)
+    (atom-term? value) (parse-number-text (atom-text state value))
+    :else nil))
+
+(defn consecutive-ints-ending-at? [ints high]
+  (and (seq ints)
+       (= (last ints) high)
+       (= ints (vec (range (first ints) (inc high))))))
+
 (defn apply-numlist-solution [state]
   (let [low (deref-value (:bindings state)
                          (or (reg-get-raw state "A1") ::unbound))
         high (deref-value (:bindings state)
                           (or (reg-get-raw state "A2") ::unbound))
         out (deref-value (:bindings state)
-                         (or (reg-get-raw state "A3") ::unbound))]
-    (if (and (integer? low) (integer? high) (<= low high))
-      (let [result-term (list->term (:intern-context state) (range low (inc high)))
+                         (or (reg-get-raw state "A3") ::unbound))
+        low-int (numlist-int-value state low)
+        high-int (numlist-int-value state high)]
+    (cond
+      (and (integer? low-int) (integer? high-int) (<= low-int high-int))
+      (let [result-term (list->term (:intern-context state) (range low-int (inc high-int)))
             [ok next-state] (unify-values state out result-term)]
         (if ok
           (advance next-state)
           (backtrack state)))
+
+      (and (logic-var? low) (integer? high-int))
+      (if-let [items (proper-list-items state out)]
+        (let [ints (mapv #(numlist-int-value state %) items)]
+          (if (and (every? integer? ints)
+                   (consecutive-ints-ending-at? ints high-int))
+            (let [[ok next-state] (unify-values state low (first ints))]
+              (if ok
+                (advance next-state)
+                (backtrack state)))
+            (backtrack state)))
+        (backtrack state))
+
+      :else
       (backtrack state))))
 
 (defn apply-delete-solution [state]

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -361,7 +361,7 @@ user:wam_select_bad_list(Rest) :- select(a, [a|b], Rest).
 user:wam_select_unbound_list(Rest) :- user:wam_unbound_arg(L), select(a, L, Rest).
 user:wam_numlist_guard(Low, High, List) :- numlist(Low, High, List).
 user:wam_numlist_high_before_low(List) :- numlist(3, 1, List).
-user:wam_numlist_unbound_low(List) :- user:wam_unbound_arg(Low), numlist(Low, 3, List).
+user:wam_numlist_unbound_low(List) :- numlist(Low, 3, List), integer(Low).
 user:wam_delete_guard(L, Elem, Rest) :- delete(L, Elem, Rest).
 user:wam_delete_bad_list(Rest) :- delete([a|b], a, Rest).
 user:wam_delete_unbound_list(Rest) :- user:wam_unbound_arg(L), delete(L, a, Rest).
@@ -997,7 +997,10 @@ smoke_cases([
     case('wam_numlist_guard/3', args(2, 2, '[2]'), "true"),
     case('wam_numlist_guard/3', args(1, 3, '[1,3]'), "false"),
     case('wam_numlist_high_before_low/1', '[]', "false"),
-    case('wam_numlist_unbound_low/1', '[1,2,3]', "false"),
+    case('wam_numlist_unbound_low/1', '[1,2,3]', "true"),
+    case('wam_numlist_unbound_low/1', '[2,3]', "true"),
+    case('wam_numlist_unbound_low/1', '[1,3]', "false"),
+    case('wam_numlist_unbound_low/1', '[]', "false"),
     case('wam_delete_guard/3', args('[a,b,a,c]', a, '[b,c]'), "true"),
     case('wam_delete_guard/3', args('[a,b,a,c]', z, '[a,b,a,c]'), "true"),
     case('wam_delete_guard/3', args('[f(a),f(b),f(a)]', 'f(a)', '[f(b)]'), "true"),
@@ -1751,6 +1754,7 @@ prolog_term_string_to_edn('[102,111]', "{:tag :struct :functor \"[|]/2\" :args [
 prolog_term_string_to_edn('[102,111,111]', "{:tag :struct :functor \"[|]/2\" :args [102 {:tag :struct :functor \"[|]/2\" :args [111 {:tag :struct :functor \"[|]/2\" :args [111 \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[1,2,3]', "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [2 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[1,3]', "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}") :- !.
+prolog_term_string_to_edn('[2,3]', "{:tag :struct :functor \"[|]/2\" :args [2 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[2]', "{:tag :struct :functor \"[|]/2\" :args [2 \"[]\"]}") :- !.
 prolog_term_string_to_edn('[f,o]', "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"o\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[f,o,o]', "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"o\" {:tag :struct :functor \"[|]/2\" :args [\"o\" \"[]\"]}]}]}") :- !.


### PR DESCRIPTION
## Summary
- Adds conservative reverse-mode support for Clojure WAM `numlist/3` when `Low` is unbound, `High` is bound, and `List` is a proper non-empty consecutive integer list ending at `High`.
- Normalizes integer-like runtime values in the `numlist/3` helper so compiled constants and parsed numeric list items are handled consistently.
- Extends runtime smoke coverage for valid reverse-mode lists (`[1,2,3]`, `[2,3]`) and invalid cases (`[1,3]`, `[]`).

## Why
Clojure WAM previously handled only forward `numlist/3` construction with bound integer `Low` and `High`. This PR adds a bounded reverse-mode case that can infer `Low` from an already-materialized list, without introducing unconstrained list generation.

## Notes
- Empty-list reverse mode remains false here because deriving `Low` from `numlist(Low, High, [])` would require the high-before-low relation and a family of possible `Low` values; this PR keeps that mode conservative.
- Unbound-list generation is still intentionally out of scope.

## Validation
- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
