### PR TITLE
feat(wam-python): add term type parity builtins

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -282,6 +282,17 @@ def _term_identical(a: 'Term', b: 'Term', state: WamState) -> bool:
     return False
 
 
+def _term_ground(term: 'Term', state: WamState) -> bool:
+    term = deref(term, state)
+    if isinstance(term, Var):
+        return False
+    if isinstance(term, Compound):
+        return all(_term_ground(arg, state) for arg in term.args)
+    if isinstance(term, Ref):
+        return _term_ground(deref(term, state), state)
+    return True
+
+
 def _make_cons(head: 'Term', tail: 'Term') -> 'Compound':
     """Construct a cons cell Compound('.', [head, tail])."""
     return Compound('.', [head, tail])
@@ -2027,6 +2038,8 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         return not unify(get_reg(sub, 1), get_reg(sub, 2), sub)
     if builtin in ('==/2', '==') and arity == 2:
         return _term_identical(get_reg(state, 1), get_reg(state, 2), state)
+    if builtin in ('\\==/2', '\\==') and arity == 2:
+        return not _term_identical(get_reg(state, 1), get_reg(state, 2), state)
     if builtin in ('is/2', 'is_lax/2', 'is', 'is_lax') and arity == 2:
         return _execute_is_lax(state)
     if builtin in ('is_iso/2', 'is_iso') and arity == 2:
@@ -2182,6 +2195,11 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
     if builtin in ('compound/1', 'compound'):
         val = deref(get_reg(state, 1), state)
         return isinstance(val, Compound)
+    if builtin in ('atomic/1', 'atomic'):
+        val = deref(get_reg(state, 1), state)
+        return isinstance(val, (Atom, Int, Float))
+    if builtin in ('ground/1', 'ground'):
+        return _term_ground(get_reg(state, 1), state)
     if builtin in ('is_list/1', 'is_list'):
         val = deref(get_reg(state, 1), state)
         return _term_to_list(val, state) is not None

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -1273,6 +1273,31 @@ test(runtime_filesystem_helpers) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_term_type_parity_helpers) :-
+	setup_call_cleanup(
+		(   retractall(user:py_term_type_parity_demo),
+			assertz((user:py_term_type_parity_demo :-
+				a \== b,
+				\+ (same \== same),
+				ground(f(a, [1, b])),
+				\+ ground(f(_)))),
+			user:python_parser_tmp_dir('tmp_wam_python_term_type_parity', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_term_type_parity_demo/0],
+				[runtime_parser(off)], ProjectDir),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_term_type_parity_demo/0', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_term_type_parity_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_parser_compiled_runs_reverse_term_to_atom) :-
 	setup_call_cleanup(
 		(   retractall(user:py_term_to_atom_demo),
@@ -1754,6 +1779,9 @@ test(static_runtime_has_lua_baseline_builtins, [nondet]) :-
 		"float/1",
 		"number/1",
 		"compound/1",
+		"atomic/1",
+		"ground/1",
+		"\\==/2",
 		"atom_concat/3",
 		"atom_length/2",
 		"atom_string/2",
@@ -1836,6 +1864,9 @@ test(static_runtime_io_emits_output, [nondet]) :-
 	sub_string(Content, _, _, _, "def _execute_exists_file"),
 	sub_string(Content, _, _, _, "def _execute_directory_files"),
 	sub_string(Content, _, _, _, "def _execute_delete_file"),
+	sub_string(Content, _, _, _, "def _term_ground"),
+	sub_string(Content, _, _, _, "'atomic/1'"),
+	sub_string(Content, _, _, _, "'\\\\==/2'"),
 	sub_string(Content, _, _, _, "print()").
 
 :- end_tests(wam_python_builtin_parity_guard).
@@ -2013,6 +2044,11 @@ type_compare_wam(
   put_constant same, 1
   put_constant same, 2
   builtin_call ==/2 2
+  put_constant left, 1
+  put_constant right, 2
+  builtin_call \\==/2 2
+  put_integer 42, 1
+  builtin_call atomic/1 1
   put_integer 2, 1
   put_integer 2, 2
   builtin_call =:=/2 2


### PR DESCRIPTION
## Summary

- add Python WAM runtime support for `\==/2`
- add `ground/1` recursive term groundness checking
- add `atomic/1` runtime type checking for atoms, integers, and floats
- cover generated-source behavior for `\==/2` and `ground/1`
- cover direct WAM generated-project behavior for `atomic/1`
- extend the Python static parity guard for the new term/type builtins

## Notes

`ground/1` and `\==/2` are already recognized by the WAM compiler guard tables. `atomic/1` is implemented in the Python runtime and covered through direct WAM because it is not currently registered as a shared WAM lowering builtin.

## Verification

- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode),run_tests(wam_python_builtin_parity_guard),run_tests(wam_python_builtin_e2e)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
