### PR TITLE
Feat/wam go string code builtin

### DIFF
--- a/PR_go_wam_string_code_builtin.md
+++ b/PR_go_wam_string_code_builtin.md
@@ -1,0 +1,30 @@
+# PR Title
+
+Add Go WAM string_code/3 builtin parity
+
+# PR Description
+
+## Summary
+
+- Adds direct Go WAM lowering for `string_code/3`.
+- Implements deterministic generated Go runtime support for `string_code(+Index,+String,?Code)` with 1-based indexing.
+- Extends the generated Go WAM builtin E2E test with code lookup, code unification, invalid index failure, unbound argument failure, non-text source failure, and bound-code mismatch failure.
+- Updates the Go WAM parity audit to record forward-mode `string_code/3` coverage against the R/C++ deterministic text-code lookup surface.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(string_code/3,3), G), writeln(G), halt"`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`
+
+## Push
+
+```sh
+git push -u origin feat/wam-go-string-code-builtin
+```

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -14,7 +14,7 @@ current cross-target builtin/runtime baseline.
 | Structural builtins | `member/2`, `memberchk/2`, `select/3`, `delete/3`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `select/3`, `delete/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1`, `ground/1` | Includes `is_list/1` and Clojure direct `ground/1` in the current baseline | Present for current baseline type and groundness checks |
 | Arithmetic builtins | `is/2`, `succ/2` | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir | Present for current baseline arithmetic checks, with expanded successor coverage |
-| Atom/text conversion | `atom_number/2`, `atom_codes/2`, `atom_chars/2`, `string_codes/2`, `string_chars/2`, `number_codes/2`, `number_chars/2`, `atom_string/2`, `string_to_atom/2`, `upcase_atom/2`, `downcase_atom/2`, `atom_concat/3`, `atom_length/2`, `string_length/2`, `char_code/2`, `sub_atom/5` forward mode, `char_type/2` forward mode | Clojure direct builtin surface includes bidirectional `atom_number/2`, atom/string/number code-list and char-list conversion, atom/string conversion, atom case conversion, deterministic atom concatenation, text length checks, and char-code conversion | Present for current atom-number, atom/string/number code-list, atom/string/number char-list, atom/string, atom-case, atom-concat, text-length, char-code, forward sub-atom, and forward char-type checks |
+| Atom/text conversion | `atom_number/2`, `atom_codes/2`, `atom_chars/2`, `string_codes/2`, `string_chars/2`, `number_codes/2`, `number_chars/2`, `atom_string/2`, `string_to_atom/2`, `upcase_atom/2`, `downcase_atom/2`, `atom_concat/3`, `atom_length/2`, `string_length/2`, `char_code/2`, `sub_atom/5` forward mode, `char_type/2` forward mode, `string_code/3` forward mode | Clojure direct builtin surface includes bidirectional `atom_number/2`, atom/string/number code-list and char-list conversion, atom/string conversion, atom case conversion, deterministic atom concatenation, text length checks, and char-code conversion | Present for current atom-number, atom/string/number code-list, atom/string/number char-list, atom/string, atom-case, atom-concat, text-length, char-code, forward sub-atom, forward char-type, and forward string-code checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` | Includes `=</2`; Haskell mode analysis and Clojure lowering also cover term-order comparisons | Present for current baseline comparisons, with expanded term-order coverage |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
 | Term inspection | `functor/3`, `arg/3` | `functor/3`, `arg/3` | Present |
@@ -79,6 +79,10 @@ current cross-target builtin/runtime baseline.
   punct, ascii, csym, csymf, newline, multi-character failure, unbound
   argument failure, and unknown category failure, matching the R/Clojure
   atom-category surface.
+- Forward-mode `string_code/3` is now covered by the generated Go WAM
+  builtin E2E test for 1-based code lookup, code unification, invalid index failure, unbound argument failure, non-text source
+  failure, and bound-code mismatch failure, matching the R/C++
+  deterministic text-code lookup surface.
 - Bidirectional `succ/2` is now covered by the generated Go WAM builtin E2E
   test for forward binding, reverse binding, matching integer pairs, mismatch
   failure, negative predecessor failure, non-positive successor failure, and

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -469,6 +469,9 @@ wam_go_direct_builtin("sub_atom/5", 5, 'sub_atom/5').
 wam_go_direct_builtin(char_type/2, 2, 'char_type/2').
 wam_go_direct_builtin('char_type/2', 2, 'char_type/2').
 wam_go_direct_builtin("char_type/2", 2, 'char_type/2').
+wam_go_direct_builtin(string_code/3, 3, 'string_code/3').
+wam_go_direct_builtin('string_code/3', 3, 'string_code/3').
+wam_go_direct_builtin("string_code/3", 3, 'string_code/3').
 wam_go_direct_builtin(succ/2, 2, 'succ/2').
 wam_go_direct_builtin('succ/2', 2, 'succ/2').
 wam_go_direct_builtin("succ/2", 2, 'succ/2').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1495,6 +1495,17 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 		default:
 			return false
 		}
+	case "string_code/3":
+		index, okIndex := vm.deref(arg1).(*Integer)
+		text, okText := vm.deref(arg2).(*Atom)
+		if !okIndex || !okText || index.Val < 1 {
+			return false
+		}
+		runes := []rune(text.Name)
+		if index.Val > int64(len(runes)) {
+			return false
+		}
+		return vm.Unify(arg3, &Integer{Val: int64(runes[index.Val-1])})
 
 	case "var/1": return isUnbound(vm.deref(arg1))
 	case "nonvar/1": return !isUnbound(vm.deref(arg1))

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -20,6 +20,7 @@
 :- dynamic user:test_ground_builtin/0.
 :- dynamic user:test_sub_atom_builtin/0.
 :- dynamic user:test_char_type_builtin/0.
+:- dynamic user:test_string_code_builtin/0.
 :- dynamic user:test_succ_builtin/0.
 :- dynamic user:test_atom_number_builtin/0.
 :- dynamic user:test_atom_case_builtin/0.
@@ -212,6 +213,20 @@ test(builtins_execution) :-
                 \+ char_type(_, alpha),
                 \+ char_type(a, _),
                 \+ char_type(a, unknown)
+            )),
+          assertz(user:test_string_code_builtin :-
+            (   string_code(1, abc, C1),
+                C1 =:= 97,
+                string_code(2, abc, 98),
+                string_code(3, abc, C3),
+                C3 =:= 99,
+                \+ string_code(0, abc, _),
+                \+ string_code(4, abc, _),
+                \+ string_code(-1, abc, _),
+                \+ string_code(_, abc, _),
+                \+ string_code(1, _, _),
+                \+ string_code(1, 42, _),
+                \+ string_code(1, abc, 98)
             )),
           assertz(user:test_succ_builtin :-
             (   succ(0, 1),
@@ -414,6 +429,7 @@ test(builtins_execution) :-
           retractall(user:test_ground_builtin),
           retractall(user:test_sub_atom_builtin),
           retractall(user:test_char_type_builtin),
+          retractall(user:test_string_code_builtin),
           retractall(user:test_succ_builtin),
           retractall(user:test_atom_number_builtin),
           retractall(user:test_atom_case_builtin),
@@ -434,7 +450,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -484,6 +500,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "ground/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "sub_atom/5"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "char_type/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "string_code/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "succ/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "atom_number/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "upcase_atom/2"')),
@@ -641,6 +658,14 @@ func main() {
 		fmt.Println("CHAR_TYPE_FAILURE")
 	}
 
+	stringCodeVM := wam.NewWamState(wam.Test_string_code_builtinCode, wam.Test_string_code_builtinLabels)
+	stringCodeVM.PC = wam.Test_string_code_builtinStartPC
+	if stringCodeVM.Run() {
+		fmt.Println("STRING_CODE_SUCCESS")
+	} else {
+		fmt.Println("STRING_CODE_FAILURE")
+	}
+
 	succVM := wam.NewWamState(wam.Test_succ_builtinCode, wam.Test_succ_builtinLabels)
 	succVM.PC = wam.Test_succ_builtinStartPC
 	if succVM.Run() {
@@ -793,6 +818,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "GROUND_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SUB_ATOM_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "CHAR_TYPE_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "STRING_CODE_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SUCC_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_NUMBER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_CASE_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM string_code/3 builtin parity

## Summary

- Adds direct Go WAM lowering for `string_code/3`.
- Implements deterministic generated Go runtime support for `string_code(+Index,+String,?Code)` with 1-based indexing.
- Extends the generated Go WAM builtin E2E test with code lookup, code unification, invalid index failure, unbound argument failure, non-text source failure, and bound-code mismatch failure.
- Updates the Go WAM parity audit to record forward-mode `string_code/3` coverage against the R/C++ deterministic text-code lookup surface.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(string_code/3,3), G), writeln(G), halt"`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`

## Push

```sh
git push -u origin feat/wam-go-string-code-builtin
```
