### PR TITLE
feat(wam-python): add canonical output helpers

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -1274,6 +1274,54 @@ def _format_value(val: 'Term', state: WamState) -> str:
     return str(val)
 
 
+def _atom_needs_canonical_quote(name: str) -> bool:
+    if name == '[]':
+        return False
+    if not name:
+        return True
+    try:
+        int(name)
+        return True
+    except ValueError:
+        try:
+            float(name)
+            return True
+        except ValueError:
+            pass
+    if not name[0].islower():
+        return True
+    return any(not (ch.isalnum() or ch == '_') for ch in name)
+
+
+def _canonical_atom_text(name: str) -> str:
+    if not _atom_needs_canonical_quote(name):
+        return name
+    return "'" + name.replace('\\', '\\\\').replace("'", "\\'") + "'"
+
+
+def _format_canonical_value(val: 'Term', state: WamState) -> str:
+    """Format a WAM term for write_canonical/1."""
+    val = deref(val, state)
+    if isinstance(val, Atom):
+        return _canonical_atom_text(val.name)
+    if isinstance(val, Int):
+        return str(val.n)
+    if isinstance(val, Float):
+        return str(val.f)
+    if isinstance(val, Var):
+        return f"_V{val.id}"
+    if isinstance(val, Compound):
+        if _is_cons_functor(val.functor) and len(val.args) == 2:
+            items = _term_to_list(val, state)
+            if items is not None:
+                return '[' + ', '.join(_format_canonical_value(item, state) for item in items) + ']'
+        functor = _canonical_atom_text(_display_functor_name(val.functor, len(val.args)))
+        return f"{functor}(" + ', '.join(_format_canonical_value(arg, state) for arg in val.args) + ')'
+    if isinstance(val, Ref):
+        return _format_canonical_value(deref(val, state), state)
+    return str(val)
+
+
 def _deep_copy_term(val: 'Term', var_map: Dict[int, Var], state: WamState) -> 'Term':
     """Copy a term, giving each source variable one fresh target variable."""
     val = deref(val, state)
@@ -2262,8 +2310,17 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
     if builtin in ('write/1', 'display/1', 'print/1'):
         print(_format_value(get_reg(state, 1), state), end='')
         return True
+    if builtin in ('write_canonical/1',):
+        print(_format_canonical_value(get_reg(state, 1), state), end='')
+        return True
     if builtin in ('writeln/1',):
         print(_format_value(get_reg(state, 1), state))
+        return True
+    if builtin in ('tab/1',):
+        n = deref(get_reg(state, 1), state)
+        if not isinstance(n, Int) or n.n < 0:
+            return False
+        print(' ' * n.n, end='')
         return True
     if builtin in ('nl/0', 'nl'):
         print()

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -739,9 +739,19 @@ compile_execute_builtin_to_python(Code) :-
             d = deref(get_reg(self, 1), self)
             print(_format_value(d), end=\"\")
             return True
+        if op == \"write_canonical\" and arity == 1:
+            d = deref(get_reg(self, 1), self)
+            print(_format_canonical_value(d), end=\"\")
+            return True
         if op == \"writeln\" and arity == 1:
             d = deref(get_reg(self, 1), self)
             print(_format_value(d))
+            return True
+        if op == \"tab\" and arity == 1:
+            d = deref(get_reg(self, 1), self)
+            if not isinstance(d, Int) or d.n < 0:
+                return False
+            print(\" \" * d.n, end=\"\")
             return True
         if op == \"nl\" and arity == 0:
             print()
@@ -801,7 +811,7 @@ def _format_value(val):
         return str(val.f)
     if isinstance(val, Compound):
         if val.functor == \".\" and len(val.args) == 2:
-            return \"[\" + _format_list(val) + \"]\"
+            return \"[\" + _format_list(val, _format_value) + \"]\"
         args_str = \", \".join(_format_value(a) for a in val.args)
         return f\"{val.functor}({args_str})\"
     if isinstance(val, Var):
@@ -810,16 +820,58 @@ def _format_value(val):
         return f\"ref({val.addr})\"
     return str(val)
 
-def _format_list(val):
+def _atom_needs_canonical_quote(name):
+    if name == \"[]\":
+        return False
+    if not name:
+        return True
+    try:
+        int(name)
+        return True
+    except ValueError:
+        try:
+            float(name)
+            return True
+        except ValueError:
+            pass
+    if not name[0].islower():
+        return True
+    return any(not (ch.isalnum() or ch == \"_\") for ch in name)
+
+def _canonical_atom_text(name):
+    if not _atom_needs_canonical_quote(name):
+        return name
+    return \"''\" + name.replace(\"\\\\\", \"\\\\\\\\\").replace(\"''\", \"\\\\''\") + \"''\"
+
+def _format_canonical_value(val):
+    """Format a Value for write_canonical/1."""
+    if isinstance(val, Atom):
+        return _canonical_atom_text(val.name)
+    if isinstance(val, Int):
+        return str(val.n)
+    if isinstance(val, Float):
+        return str(val.f)
+    if isinstance(val, Compound):
+        if val.functor == \".\" and len(val.args) == 2:
+            return \"[\" + _format_list(val, _format_canonical_value) + \"]\"
+        args_str = \", \".join(_format_canonical_value(a) for a in val.args)
+        return f\"{_canonical_atom_text(val.functor)}({args_str})\"
+    if isinstance(val, Var):
+        return \"_\" if val.ref is None else _format_canonical_value(val.ref)
+    if isinstance(val, Ref):
+        return f\"ref({val.addr})\"
+    return str(val)
+
+def _format_list(val, formatter):
     """Format a ./2 cons-cell chain as a Prolog list."""
     items = []
     current = val
     while isinstance(current, Compound) and current.functor == \".\" and len(current.args) == 2:
-        items.append(_format_value(current.args[0]))
+        items.append(formatter(current.args[0]))
         current = current.args[1]
     if isinstance(current, Atom) and current.name == \"[]\":
         return \", \".join(items)
-    items.append(\"|\" + _format_value(current))
+    items.append(\"|\" + formatter(current))
     return \", \".join(items)
 
 def _deep_copy_term(val, var_map, state):

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -998,6 +998,42 @@ test(runtime_char_output_writes_to_stdout) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_output_canonical_helpers) :-
+	setup_call_cleanup(
+		(   retractall(user:py_output_canonical_demo),
+			assertz((user:py_output_canonical_demo :-
+				write_canonical('hello world'),
+				tab(2),
+				write_canonical(f('two words', [a, 2])),
+				nl,
+				\+ tab(-1))),
+			user:python_parser_tmp_dir('tmp_wam_python_output_canonical', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_output_canonical_demo/0],
+				[runtime_parser(off)], ProjectDir),
+			atomic_list_concat([
+				"import io, sys",
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"old_stdout = sys.stdout",
+				"capture = io.StringIO()",
+				"sys.stdout = capture",
+				"try:",
+				"    ok = wr.run_wam(code, labels, 'py_output_canonical_demo/0', state)",
+				"finally:",
+				"    sys.stdout = old_stdout",
+				"print(repr(capture.getvalue()))",
+				"print(ok)"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "'hello world'  f('two words', [a, 2])\\n")),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_output_canonical_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_stream_char_io_reads_and_writes_files) :-
 	setup_call_cleanup(
 		(   retractall(user:py_stream_char_io_demo),
@@ -1821,6 +1857,8 @@ test(static_runtime_has_lua_baseline_builtins, [nondet]) :-
 		"\\\\+/1",
 		"write/1",
 		"display/1",
+		"tab/1",
+		"write_canonical/1",
 		"put_char/1",
 		"put_char/2",
 		"put_code/1",
@@ -1845,6 +1883,9 @@ test(static_runtime_naf_uses_isolated_goal_execution, [nondet]) :-
 test(static_runtime_io_emits_output, [nondet]) :-
 	runtime_py_path(P), read_file_to_string(P, Content, []),
 	sub_string(Content, _, _, _, "print(_format_value(get_reg(state, 1), state), end='')"),
+	sub_string(Content, _, _, _, "def _format_canonical_value"),
+	sub_string(Content, _, _, _, "'write_canonical/1'"),
+	sub_string(Content, _, _, _, "'tab/1'"),
 	sub_string(Content, _, _, _, "def _execute_put_char"),
 	sub_string(Content, _, _, _, "def _execute_put_code"),
 	sub_string(Content, _, _, _, "def _execute_read_line_to_string"),


### PR DESCRIPTION
## Summary
- add Python WAM runtime support for `tab/1` and `write_canonical/1`
- render canonical output with quoted atoms where needed, including nested compound/list terms
- keep the legacy inline Python generator aligned with the packaged static runtime
- add generated-project coverage for canonical quoting, tab spacing, and negative `tab/1` failure

## Tests
- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_python_target.pl`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode),run_tests(wam_python_builtin_parity_guard),run_tests(wam_python_builtin_e2e)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
