### PR TITLE
Add edge store and LMDB materialisation auto-resolvers

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -4328,14 +4328,112 @@ resolve_auto_csr_index_backend_hs(Options0, Options) :-
     ;   Options = Options0
     ).
 
+%% resolve_auto_edge_store_hs(+Options0, -Options)
+%  Resolve edge_store(auto) into a concrete store selection.
+%  Decides between lmdb_cached, lmdb_eager, csr, or dual_csr based on
+%  workload metadata. When edge_store is not auto (or absent), pass through.
+%  Mirrors F#'s resolve_auto_edge_store_fs/2.
+resolve_auto_edge_store_hs(Options0, Options) :-
+    (   option(edge_store(auto), Options0)
+    ->  compute_edge_store_hs(Options0, Store),
+        exclude(=(edge_store(_)), Options0, Rest),
+        apply_edge_store_hs(Store, Rest, Options)
+    ;   Options = Options0
+    ).
+
+compute_edge_store_hs(Options, Store) :-
+    option(expected_query_count(Q), Options, 1),
+    option(expected_lookups_per_query(L), Options, 50),
+    option(edge_count(E), Options, 0),
+    option(graph_mutability(Mut), Options, 'static'),
+    option(needs_reverse(NeedsRev), Options, false),
+    TotalLookups is Q * L,
+    %% Cost model (milliseconds):
+    %%   LMDB eager: one-time load E*0.005ms, per-lookup ~0.5us (IntMap.lookup)
+    %%   LMDB cached: no load, per-lookup ~2us warm (cursor + L2 cache)
+    %%   CSR: build E*0.01ms, per-lookup ~1.5us (binary search on index)
+    EagerLoadMs is E * 0.005,
+    EagerPerLookupUs is 0.5,
+    CachedPerLookupUs is 2.0,
+    CsrBuildMs is E * 0.01,
+    CsrPerLookupUs is 1.5,
+    %% Total wall time per mode (ms):
+    EagerTotalMs is EagerLoadMs + TotalLookups * EagerPerLookupUs / 1000,
+    CachedTotalMs is TotalLookups * CachedPerLookupUs / 1000,
+    CsrTotalMs is CsrBuildMs + TotalLookups * CsrPerLookupUs / 1000,
+    (   Mut == 'dynamic'
+    ->  Store = lmdb_cached
+    ;   NeedsRev == true, CsrTotalMs =< CachedTotalMs
+    ->  Store = dual_csr
+    ;   (   CsrTotalMs =< EagerTotalMs, CsrTotalMs =< CachedTotalMs
+        ->  Store = csr
+        ;   EagerTotalMs =< CachedTotalMs
+        ->  Store = lmdb_eager
+        ;   Store = lmdb_cached
+        )
+    ),
+    (   option(edge_store_verbose(true), Options)
+    ->  format(user_error,
+               '[WAM-Haskell] edge_store(auto): Q=~w L=~w E=~w eager=~2fms cached=~2fms csr=~2fms -> ~w~n',
+               [Q, L, E, EagerTotalMs, CachedTotalMs, CsrTotalMs, Store])
+    ;   true
+    ).
+
+apply_edge_store_hs(lmdb_cached, Opts, [lmdb_materialisation(cached) | Opts]).
+apply_edge_store_hs(lmdb_eager, Opts, [lmdb_materialisation(eager) | Opts]).
+apply_edge_store_hs(csr, Opts, Opts).
+apply_edge_store_hs(dual_csr, Opts, Opts).
+
+%% resolve_auto_lmdb_materialisation_hs(+Options0, -Options)
+%  Resolve lmdb_materialisation(auto) into eager/lazy/cached using
+%  the shared cost model. When not auto, pass through.
+%  Mirrors F#'s resolve_auto_lmdb_materialisation_fs/2.
+resolve_auto_lmdb_materialisation_hs(Options0, Options) :-
+    (   option(lmdb_materialisation(auto), Options0)
+    ->  compute_lmdb_materialisation_hs(Options0, Mode),
+        exclude(=(lmdb_materialisation(_)), Options0, Rest),
+        Options = [lmdb_materialisation(Mode) | Rest]
+    ;   Options = Options0
+    ).
+
+compute_lmdb_materialisation_hs(Options, Mode) :-
+    option(fact_count(F), Options, 0),
+    option(demand_set_estimate(D), Options, F),
+    option(expected_query_count(NQ), Options, 1),
+    option(workload_segregated(WS), Options, false),
+    option(working_set_fraction(WSF), Options, 0.05),
+    EdgeBytes is D * 50,
+    (   option(memory_budget(B), Options)
+    ->  true
+    ;   catch(read_mem_available_bytes(B), _, B = 1_000_000_000)
+    ),
+    (   EdgeBytes > B
+    ->  (WS == true -> Mode = lazy ; Mode = cached)
+    ;   KKeys is integer(F * WSF),
+        option(cost_model_constants(Constants), Options, []),
+        recommend_access_pattern(KKeys, EdgeBytes, B, Constants, Pattern),
+        (   Pattern = sort
+        ->  (NQ >= 10, F =< 100_000 -> Mode = eager ; Mode = cached)
+        ;   (EdgeBytes > B -> Mode = cached ; Mode = eager)
+        )
+    ),
+    (   option(materialisation_verbose(true), Options)
+    ->  format(user_error,
+               '[WAM-Haskell] lmdb_materialisation(auto): F=~w D=~w B=~w NQ=~w WS=~w -> ~w~n',
+               [F, D, B, NQ, WS, Mode])
+    ;   true
+    ).
+
 %% resolve_haskell_cost_options(+Options0, -Options)
 %  Composed resolver chain: runs all auto-resolvers in sequence.
 %  Mirrors F#'s resolve_fsharp_cost_options/2.
 resolve_haskell_cost_options(Options0, Options) :-
-    resolve_auto_use_lmdb(Options0, Options1),
-    resolve_auto_cache_strategy(Options1, Options2),
-    resolve_auto_lmdb_cache_mode(Options2, Options3),
-    resolve_auto_csr_index_backend_hs(Options3, Options).
+    resolve_auto_edge_store_hs(Options0, Options1),
+    resolve_auto_use_lmdb(Options1, Options2),
+    resolve_auto_cache_strategy(Options2, Options3),
+    resolve_auto_lmdb_materialisation_hs(Options3, Options4),
+    resolve_auto_lmdb_cache_mode(Options4, Options5),
+    resolve_auto_csr_index_backend_hs(Options5, Options).
 
 %% resolve_demand_filter_spec(+Options, -SpecHs)
 %  Pick the DemandFilterSpec literal to emit into Main.hs.


### PR DESCRIPTION
## Summary

- Add edge store auto-resolver (`resolve_auto_edge_store_hs/2`) that selects between lmdb_cached, lmdb_eager, csr, or dual_csr based on workload cost model
- Add LMDB materialisation auto-resolver (`resolve_auto_lmdb_materialisation_hs/2`) that selects eager/lazy/cached using the shared cost model
- Extend the composed resolver chain to 6 resolvers, completing F# cost-based auto-resolution parity

## Edge store auto-resolver

Resolves `edge_store(auto)` using a cost model that estimates total wall time per mode:

| Mode | Load cost | Per-lookup cost | When selected |
|------|-----------|----------------|---------------|
| `lmdb_eager` | E × 0.005ms | ~0.5μs (IntMap.lookup) | Low edge count, high query volume |
| `lmdb_cached` | 0 | ~2μs (cursor + L2 cache) | Dynamic graphs, or default fallback |
| `csr` | E × 0.01ms | ~1.5μs (binary search) | Static graph, CSR cheapest overall |
| `dual_csr` | E × 0.01ms | ~1.5μs | Needs reverse-index AND CSR is cheapest |

Decision tree: dynamic → `lmdb_cached`; needs_reverse + CSR cheapest → `dual_csr`; CSR cheapest overall → `csr`; eager cheapest → `lmdb_eager`; else → `lmdb_cached`.

## LMDB materialisation auto-resolver

Resolves `lmdb_materialisation(auto)` using `cost_model:recommend_access_pattern/5`:
- Memory-constrained: segregated workload → `lazy`, else → `cached`
- Fits in memory: sort pattern + ≥10 queries + ≤100K facts → `eager`, else → `cached`

## Composed chain

`resolve_haskell_cost_options/2` now runs 6 resolvers in order:
1. `resolve_auto_edge_store_hs` (new)
2. `resolve_auto_use_lmdb`
3. `resolve_auto_cache_strategy`
4. `resolve_auto_lmdb_materialisation_hs` (new)
5. `resolve_auto_lmdb_cache_mode`
6. `resolve_auto_csr_index_backend_hs`

## Test plan

- [x] Phase 1, 3, ISO test suites: all pass
- [x] Edge store resolver: dynamic → cached, static high-volume → lmdb_cached, pass-through when no edge_store option
- [x] LMDB materialisation resolver: auto → eager for small graph with high query count
- [x] GHC 9.4.7 compilation: clean

https://claude.ai/code/session_01NMTuARifW7HDSMhiu7JG5g

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMTuARifW7HDSMhiu7JG5g)_