### PR TITLE
feat(wam-clojure): accept materialized sorted output

### DIFF
--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -978,6 +978,12 @@
           (backtrack state)))
       (backtrack state))))
 
+(defn sorted-unique-list? [state items]
+  (= items (vec (sorted-unique-terms state items))))
+
+(defn sorted-list? [state items]
+  (= items (vec (sorted-terms state items))))
+
 (defn apply-sort-solution [state]
   (let [list-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A1") ::unbound))
@@ -990,7 +996,15 @@
         (if ok
           (advance next-state)
           (backtrack state)))
-      (backtrack state))))
+      (if-let [out-items (proper-list-items state out)]
+        (if (and (logic-var? list-value)
+                 (sorted-unique-list? state out-items))
+          (let [[ok next-state] (unify-values state list-value out)]
+            (if ok
+              (advance next-state)
+              (backtrack state)))
+          (backtrack state))
+        (backtrack state)))))
 
 (defn apply-msort-solution [state]
   (let [list-value (deref-value (:bindings state)
@@ -1004,7 +1018,15 @@
         (if ok
           (advance next-state)
           (backtrack state)))
-      (backtrack state))))
+      (if-let [out-items (proper-list-items state out)]
+        (if (and (logic-var? list-value)
+                 (sorted-list? state out-items))
+          (let [[ok next-state] (unify-values state list-value out)]
+            (if ok
+              (advance next-state)
+              (backtrack state)))
+          (backtrack state))
+        (backtrack state)))))
 
 (defn atom-text [state value]
   (cond

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -367,10 +367,10 @@ user:wam_delete_bad_list(Rest) :- delete([a|b], a, Rest).
 user:wam_delete_unbound_list(Rest) :- user:wam_unbound_arg(L), delete(L, a, Rest).
 user:wam_sort_guard(L, S) :- sort(L, S).
 user:wam_sort_bad_list(S) :- sort([a|b], S).
-user:wam_sort_unbound_list(S) :- user:wam_unbound_arg(L), sort(L, S).
+user:wam_sort_unbound_list(S) :- sort(L, S), is_list(L).
 user:wam_msort_guard(L, S) :- msort(L, S).
 user:wam_msort_bad_list(S) :- msort([a|b], S).
-user:wam_msort_unbound_list(S) :- user:wam_unbound_arg(L), msort(L, S).
+user:wam_msort_unbound_list(S) :- msort(L, S), is_list(L).
 user:wam_copy_term_guard(A, B) :- copy_term(A, B).
 user:wam_copy_term_sharing_fail :- user:wam_unbound_arg(X), copy_term(f(X, X), f(a, b)).
 user:wam_copy_term_independent_ok :- copy_term(f(_, _), f(a, b)).
@@ -1011,12 +1011,14 @@ smoke_cases([
     case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b]'), "false"),
     case('wam_sort_guard/2', args('[f(b),f(a),a]', '[a,f(a),f(b)]'), "true"),
     case('wam_sort_bad_list/1', '[a,b,c]', "false"),
-    case('wam_sort_unbound_list/1', '[a,b,c]', "false"),
+    case('wam_sort_unbound_list/1', '[a,b,c]', "true"),
+    case('wam_sort_unbound_list/1', '[a,a,b,c]', "false"),
     case('wam_msort_guard/2', args('[b,a,a,c]', '[a,a,b,c]'), "true"),
     case('wam_msort_guard/2', args('[b,a,a,c]', '[a,b,c]'), "false"),
     case('wam_msort_guard/2', args('[f(b),f(a),a]', '[a,f(a),f(b)]'), "true"),
     case('wam_msort_bad_list/1', '[a,b,c]', "false"),
-    case('wam_msort_unbound_list/1', '[a,b,c]', "false"),
+    case('wam_msort_unbound_list/1', '[a,b,c]', "true"),
+    case('wam_msort_unbound_list/1', '[a,a,b,c]', "true"),
     case('wam_copy_term_guard/2', args(a, a), "true"),
     case('wam_copy_term_guard/2', args(a, b), "false"),
     case('wam_copy_term_guard/2', args('f(a)', 'f(a)'), "true"),


### PR DESCRIPTION
## Summary
- Adds conservative reverse/materialized-output support for Clojure WAM `sort/2` and `msort/2`.
- Allows `sort(L, Sorted)` to bind `L` to `Sorted` only when `Sorted` is a proper sorted duplicate-free list.
- Allows `msort(L, Sorted)` to bind `L` to `Sorted` when `Sorted` is a proper sorted list, preserving duplicates.
- Extends runtime smoke coverage for sorted materialized outputs and duplicate handling.

## Why
The Clojure WAM runtime previously handled only forward `sort/2` and `msort/2` from a bound input list. This PR adds a bounded reverse check for already-materialized outputs without generating permutations or opening exponential search.

## Notes
- This deliberately does not attempt general reverse sorting. `sort(L, S)` and `msort(L, S)` can have many inputs for one output, so this PR only accepts the safe case where `L` can be bound directly to an already valid sorted output.
- `sort/2` rejects duplicate materialized output, while `msort/2` accepts it.

## Validation
- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
