### PR TITLE
Fix detect_kernels and compile flow for module-qualified predicates

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -957,9 +957,12 @@ result_wrap_expr(float, 'Float rv').
 %  full recursive_kernel(Kind, Pred/Arity, ConfigOps) term.
 detect_kernels([], []).
 detect_kernels([PI|Rest], Kernels) :-
-    (   PI = _Mod:Pred/Arity -> true ; PI = Pred/Arity ),
+    (   PI = Mod:Pred/Arity -> true ; PI = Pred/Arity, Mod = user ),
     functor(Head, Pred, Arity),
-    findall(Head-Body, user:clause(Head, Body), Clauses),
+    (   catch(findall(Head-Body, clause(Mod:Head, Body), Clauses), _, Clauses = [])
+    ->  true
+    ;   Clauses = []
+    ),
     (   Clauses \= [],
         detect_recursive_kernel(Pred, Arity, Clauses, Kernel)
     ->  format(atom(Key), '~w/~w', [Pred, Arity]),
@@ -3695,7 +3698,7 @@ write_wam_haskell_project(Predicates, Options0, ProjectDir) :-
     % lowered ones — so backtrack can land on alternate clauses that the
     % lowered function doesn't handle. Phase 4+ lowered functions only
     % inline clause 1; clause 2+ runs through the interpreter on backtrack.
-    compile_predicates_to_haskell(Predicates, Options, PredsCode0, InlineDefs),
+    compile_predicates_to_haskell(InternalPreds, Options, PredsCode0, InlineDefs),
     % Append compile-time atom table to Predicates.hs
     emit_atom_table_haskell(AtomTableCode),
     format(string(PredsCode0WithAtoms), "~w~n~n~w", [PredsCode0, AtomTableCode]),
@@ -3722,7 +3725,7 @@ write_wam_haskell_project(Predicates, Options0, ProjectDir) :-
     write_hs_file(CabalPath, CabalCode),
 
     % Generate Main.hs (InlineDefs from F3 → wcInlineFacts wiring)
-    generate_main_hs(Predicates, DetectedKernels, InlineDefs, Options, MainCode0),
+    generate_main_hs(InternalPreds, DetectedKernels, InlineDefs, Options, MainCode0),
     apply_hashmap_rewrite(UseHM, main, MainCode0, MainCode),
     directory_file_path(SrcDir, 'Main.hs', MainPath),
     write_hs_file(MainPath, MainCode),


### PR DESCRIPTION
## Summary

- Fix `detect_kernels/2` to handle module-qualified predicates safely (catches `permission_error` on built-in/private predicates instead of crashing)
- Fix predicate compilation and Main.hs generation to use `InternalPreds` (which includes parser predicates after expansion) instead of the original `Predicates` argument

## Context

These fixes were discovered while testing the runtime parser integration (#2522). When `runtime_parser(compiled)` appends 50 parser predicates (module-qualified as `prolog_term_parser:Name/Arity` and `cpp_runtime_parser_wrappers:Name/Arity`), the existing code had three issues:

1. **`detect_kernels/2`** called `user:clause(Head, Body)` for all predicates regardless of module qualification. For module-qualified predicates that shadow SWI built-ins (like `read_term_from_atom/3`), this triggered `permission_error(access, private_procedure, ...)`. Fixed by using `clause(Mod:Head, Body)` with a `catch/3` guard.

2. **`compile_predicates_to_haskell`** was called with the original `Predicates` argument instead of `InternalPreds` (the expanded set that includes parser predicates). Fixed by passing `InternalPreds`.

3. **`generate_main_hs`** was similarly called with `Predicates` instead of `InternalPreds`. Fixed to match.

## Test plan

- [x] Phase 1, 3, ISO test suites: all pass
- [x] Runtime parser capability tests: 39/39 pass
- [x] Non-parser projects: GHC 9.4.7 compilation clean
- [x] Parser predicate WAM compilation: all 45 predicates compile individually

Note: end-to-end GHC compilation of parser-bundled projects hits a pre-existing codegen limitation (SWI built-in name collision causes `wam_instr_to_haskell` loop for `parse_atom_to_term`). This affects F# equally — F# parser tests use `assertz`-based predicates to work around it. A follow-up PR should address the name collision in the codegen pipeline.

https://claude.ai/code/session_01NMTuARifW7HDSMhiu7JG5g

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMTuARifW7HDSMhiu7JG5g)_