### PR TITLE
Fix module qualifier stripping that broke parser-bundled project generation

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -268,10 +268,7 @@ wam_haskell_indicator_in_list(_Mod:Pred/Arity, HotPreds) :-
 
 % Compile WAM code on demand for the lowerability check and emission.
 wam_haskell_predicate_wamcode(PredIndicator, WamCode) :-
-    (   PredIndicator = _Module:Pred/Arity -> true
-    ;   PredIndicator = Pred/Arity
-    ),
-    wam_target:compile_predicate_to_wam(Pred/Arity, [], WamCode).
+    wam_target:compile_predicate_to_wam(PredIndicator, [], WamCode).
 
 % ============================================================================
 % PHASE F1: FACT PREDICATE CLASSIFICATION


### PR DESCRIPTION
## Summary

- Fix `wam_haskell_predicate_wamcode/2` to preserve module qualifiers when calling `compile_predicate_to_wam`, unblocking `runtime_parser(compiled)` for end-to-end project generation and GHC compilation

## Root cause

`wam_haskell_predicate_wamcode/2` stripped the module qualifier from predicate indicators before calling `compile_predicate_to_wam`:

```prolog
% Before (broken):
wam_haskell_predicate_wamcode(PredIndicator, WamCode) :-
    (   PredIndicator = _Module:Pred/Arity -> true
    ;   PredIndicator = Pred/Arity
    ),
    wam_target:compile_predicate_to_wam(Pred/Arity, [], WamCode).
```

For module-qualified predicates like `cpp_runtime_parser_wrappers:parse_atom_to_term/2`, this looked up `user:parse_atom_to_term/2` which doesn't exist. `compute_base_pcs` then failed, triggering infinite Prolog backtracking through the codegen pipeline.

## Fix

```prolog
% After (fixed):
wam_haskell_predicate_wamcode(PredIndicator, WamCode) :-
    wam_target:compile_predicate_to_wam(PredIndicator, [], WamCode).
```

The WAM compiler already handles module-qualified indicators correctly (line 51 of `wam_target.pl`).

## End-to-end verification

Parser-bundled project (`runtime_parser(compiled)`, 50 predicates):
- [x] Project generates successfully (~60s)
- [x] GHC 9.4.7 compiles all 4 modules (WamTypes, WamRuntime, Predicates, Lowered) clean
- [x] Predicates.hs contains 2304 lines of WAM instructions for 45 parser + 4 wrapper + 1 user predicates
- [x] All test suites pass (Phase 1, 3, ISO, parser capability 39/39)
- [x] Non-parser projects unaffected

https://claude.ai/code/session_01NMTuARifW7HDSMhiu7JG5g

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMTuARifW7HDSMhiu7JG5g)_