### PR TITLE
feat(wam-python): support format output helpers

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -1322,6 +1322,121 @@ def _format_canonical_value(val: 'Term', state: WamState) -> str:
     return str(val)
 
 
+def _emit_output(text: str, stream: Any = None) -> bool:
+    out = sys.stdout if stream is None else stream
+    try:
+        out.write(text)
+        out.flush()
+    except OSError:
+        return False
+    return True
+
+
+def _format_string_text(term: 'Term', state: WamState) -> Optional[str]:
+    term = deref(term, state)
+    if isinstance(term, Atom):
+        return _runtime_atom_text(term.name)
+    if isinstance(term, Int):
+        return str(term.n)
+    return None
+
+
+def _format_s_arg(term: 'Term', state: WamState) -> Optional[str]:
+    term = deref(term, state)
+    if isinstance(term, Atom):
+        return _runtime_atom_text(term.name)
+    codes = _codes_from_list(term, state)
+    if codes is not None:
+        try:
+            return ''.join(chr(code) for code in codes)
+        except (OverflowError, ValueError):
+            return None
+    return _format_value(term, state)
+
+
+def _render_format_buffer(fmt: str, args: List['Term'], state: WamState) -> Optional[str]:
+    out: List[str] = []
+    arg_index = 0
+    i = 0
+    while i < len(fmt):
+        ch = fmt[i]
+        if ch != '~' or i + 1 >= len(fmt):
+            out.append(ch)
+            i += 1
+            continue
+        i += 1
+        directive = fmt[i]
+        if directive == 'n':
+            out.append('\n')
+        elif directive == 't':
+            out.append('\t')
+        elif directive == '~':
+            out.append('~')
+        elif directive in ('w', 'p'):
+            if arg_index >= len(args):
+                return None
+            out.append(_format_value(args[arg_index], state))
+            arg_index += 1
+        elif directive == 'a':
+            if arg_index >= len(args):
+                return None
+            value = deref(args[arg_index], state)
+            out.append(_runtime_atom_text(value.name) if isinstance(value, Atom) else _format_value(value, state))
+            arg_index += 1
+        elif directive == 'd':
+            if arg_index >= len(args):
+                return None
+            value = deref(args[arg_index], state)
+            out.append(str(value.n) if isinstance(value, Int) else _format_value(value, state))
+            arg_index += 1
+        elif directive == 's':
+            if arg_index >= len(args):
+                return None
+            text = _format_s_arg(args[arg_index], state)
+            if text is None:
+                return None
+            out.append(text)
+            arg_index += 1
+        else:
+            out.append('~')
+            out.append(directive)
+        i += 1
+    return ''.join(out)
+
+
+def _execute_format_builtin(arity: int, state: WamState) -> bool:
+    fmt_reg = 2 if arity == 3 else 1
+    fmt = _format_string_text(get_reg(state, fmt_reg), state)
+    if fmt is None:
+        return False
+    if arity == 1:
+        args: List[Term] = []
+    else:
+        args = _term_to_list(get_reg(state, 3 if arity == 3 else 2), state)
+        if args is None:
+            return False
+    rendered = _render_format_buffer(fmt, args, state)
+    if rendered is None:
+        return False
+    if arity != 3:
+        return _emit_output(rendered)
+    dest = deref(get_reg(state, 1), state)
+    if isinstance(dest, Atom):
+        name = _runtime_atom_text(dest.name)
+        if name == 'user_output':
+            return _emit_output(rendered)
+        if name == 'user_error':
+            return _emit_output(rendered, sys.stderr)
+        return False
+    if isinstance(dest, Compound) and len(dest.args) == 1:
+        functor = _display_functor_name(dest.functor, len(dest.args))
+        if functor in ('atom', 'string'):
+            return unify(dest.args[0], make_atom(rendered), state)
+        if functor == 'codes':
+            return unify(dest.args[0], _list_from_codes([ord(ch) for ch in rendered]), state)
+    return False
+
+
 def _deep_copy_term(val: 'Term', var_map: Dict[int, Var], state: WamState) -> 'Term':
     """Copy a term, giving each source variable one fresh target variable."""
     val = deref(val, state)
@@ -2308,23 +2423,20 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         target = get_reg(state, 2)
         return unify(target, _deep_copy_term(original, {}, state), state)
     if builtin in ('write/1', 'display/1', 'print/1'):
-        print(_format_value(get_reg(state, 1), state), end='')
-        return True
+        return _emit_output(_format_value(get_reg(state, 1), state))
     if builtin in ('write_canonical/1',):
-        print(_format_canonical_value(get_reg(state, 1), state), end='')
-        return True
+        return _emit_output(_format_canonical_value(get_reg(state, 1), state))
     if builtin in ('writeln/1',):
-        print(_format_value(get_reg(state, 1), state))
-        return True
+        return _emit_output(_format_value(get_reg(state, 1), state) + '\n')
     if builtin in ('tab/1',):
         n = deref(get_reg(state, 1), state)
         if not isinstance(n, Int) or n.n < 0:
             return False
-        print(' ' * n.n, end='')
-        return True
+        return _emit_output(' ' * n.n)
+    if builtin in ('format/1', 'format/2', 'format/3'):
+        return _execute_format_builtin(arity, state)
     if builtin in ('nl/0', 'nl'):
-        print()
-        return True
+        return _emit_output('\n')
     return False
 
 

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -753,6 +753,8 @@ compile_execute_builtin_to_python(Code) :-
                 return False
             print(\" \" * d.n, end=\"\")
             return True
+        if op == \"format\" and arity in (1, 2, 3):
+            return _execute_format_builtin(self, arity)
         if op == \"nl\" and arity == 0:
             print()
             return True
@@ -873,6 +875,115 @@ def _format_list(val, formatter):
         return \", \".join(items)
     items.append(\"|\" + formatter(current))
     return \", \".join(items)
+
+def _legacy_term_to_list(val):
+    items = []
+    current = val
+    while isinstance(current, Var) and current.ref is not None:
+        current = current.ref
+    while isinstance(current, Compound) and current.functor == \".\" and len(current.args) == 2:
+        head = current.args[0]
+        while isinstance(head, Var) and head.ref is not None:
+            head = head.ref
+        items.append(head)
+        current = current.args[1]
+        while isinstance(current, Var) and current.ref is not None:
+            current = current.ref
+    if isinstance(current, Atom) and current.name == \"[]\":
+        return items
+    return None
+
+def _legacy_list_from_codes(codes):
+    result = Atom(\"[]\")
+    for code in reversed(codes):
+        result = Compound(\".\", [Int(code), result])
+    return result
+
+def _legacy_render_format(fmt, args):
+    out = []
+    ai = 0
+    i = 0
+    while i < len(fmt):
+        ch = fmt[i]
+        if ch != \"~\" or i + 1 >= len(fmt):
+            out.append(ch)
+            i += 1
+            continue
+        i += 1
+        d = fmt[i]
+        if d == \"n\":
+            out.append(\"\\n\")
+        elif d == \"t\":
+            out.append(\"\\t\")
+        elif d == \"~\":
+            out.append(\"~\")
+        elif d in (\"w\", \"p\"):
+            if ai >= len(args):
+                return None
+            out.append(_format_value(args[ai]))
+            ai += 1
+        elif d == \"a\":
+            if ai >= len(args):
+                return None
+            v = args[ai]
+            out.append(v.name if isinstance(v, Atom) else _format_value(v))
+            ai += 1
+        elif d == \"d\":
+            if ai >= len(args):
+                return None
+            v = args[ai]
+            out.append(str(v.n) if isinstance(v, Int) else _format_value(v))
+            ai += 1
+        elif d == \"s\":
+            if ai >= len(args):
+                return None
+            v = args[ai]
+            if isinstance(v, Atom):
+                out.append(v.name)
+            else:
+                codes = _legacy_term_to_list(v)
+                if codes is not None and all(isinstance(c, Int) for c in codes):
+                    out.append(\"\".join(chr(c.n) for c in codes))
+                else:
+                    out.append(_format_value(v))
+            ai += 1
+        else:
+            out.append(\"~\" + d)
+        i += 1
+    return \"\".join(out)
+
+def _execute_format_builtin(state, arity):
+    fmt = deref(get_reg(state, 2 if arity == 3 else 1), state)
+    if isinstance(fmt, Atom):
+        fmt_text = fmt.name
+    elif isinstance(fmt, Int):
+        fmt_text = str(fmt.n)
+    else:
+        return False
+    args = [] if arity == 1 else _legacy_term_to_list(deref(get_reg(state, 3 if arity == 3 else 2), state))
+    if args is None:
+        return False
+    rendered = _legacy_render_format(fmt_text, args)
+    if rendered is None:
+        return False
+    if arity != 3:
+        print(rendered, end=\"\")
+        return True
+    dest = deref(get_reg(state, 1), state)
+    if isinstance(dest, Atom):
+        if dest.name == \"user_output\":
+            print(rendered, end=\"\")
+            return True
+        if dest.name == \"user_error\":
+            print(rendered, end=\"\", file=__import__(\"sys\").stderr)
+            return True
+        return False
+    if isinstance(dest, Compound) and len(dest.args) == 1:
+        if dest.functor in (\"atom\", \"atom/1\", \"string\", \"string/1\"):
+            return unify(dest.args[0], Atom(rendered), state)
+        if dest.functor in (\"codes\", \"codes/1\"):
+            return unify(dest.args[0], _legacy_list_from_codes([ord(ch) for ch in rendered]), state)
+    return False
 
 def _deep_copy_term(val, var_map, state):
     """Deep copy a term, renaming variables."""

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -1034,6 +1034,52 @@ test(runtime_output_canonical_helpers) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_format_helpers) :-
+	setup_call_cleanup(
+		(   retractall(user:py_format_stdout_demo),
+			retractall(user:py_format_dest_demo),
+			assertz((user:py_format_stdout_demo :-
+				format('plain~n'),
+				format('X=~w D=~d A=~a S=~s T=~~~n', [foo(1), 42, hello, [111, 107]]))),
+			assertz((user:py_format_dest_demo :-
+				format(atom(A), 'n=~d', [42]),
+				A = 'n=42',
+				format(string(S), 's=~a', [hello]),
+				S = 's=hello',
+				format(codes(C), 'ab', []),
+				C = [97, 98])),
+			user:python_parser_tmp_dir('tmp_wam_python_format_helpers', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project(
+				[user:py_format_stdout_demo/0, user:py_format_dest_demo/0],
+				[runtime_parser(off)], ProjectDir),
+			atomic_list_concat([
+				"import io, sys",
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"old_stdout = sys.stdout",
+				"capture = io.StringIO()",
+				"sys.stdout = capture",
+				"try:",
+				"    ok_stdout = wr.run_wam(code, labels, 'py_format_stdout_demo/0', state)",
+				"finally:",
+				"    sys.stdout = old_stdout",
+				"state2 = wr.WamState()",
+				"ok_dest = wr.run_wam(code, labels, 'py_format_dest_demo/0', state2)",
+				"print(repr(capture.getvalue()))",
+				"print(ok_stdout)",
+				"print(ok_dest)"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "plain\\nX=foo(1) D=42 A=hello S=ok T=~\\n")),
+			once(sub_string(Output, _, _, _, "True\nTrue"))
+		),
+		(   retractall(user:py_format_stdout_demo),
+			retractall(user:py_format_dest_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_stream_char_io_reads_and_writes_files) :-
 	setup_call_cleanup(
 		(   retractall(user:py_stream_char_io_demo),
@@ -1859,6 +1905,9 @@ test(static_runtime_has_lua_baseline_builtins, [nondet]) :-
 		"display/1",
 		"tab/1",
 		"write_canonical/1",
+		"format/1",
+		"format/2",
+		"format/3",
 		"put_char/1",
 		"put_char/2",
 		"put_code/1",
@@ -1882,10 +1931,15 @@ test(static_runtime_naf_uses_isolated_goal_execution, [nondet]) :-
 
 test(static_runtime_io_emits_output, [nondet]) :-
 	runtime_py_path(P), read_file_to_string(P, Content, []),
-	sub_string(Content, _, _, _, "print(_format_value(get_reg(state, 1), state), end='')"),
+	sub_string(Content, _, _, _, "def _emit_output"),
+	sub_string(Content, _, _, _, "return _emit_output(_format_value(get_reg(state, 1), state))"),
 	sub_string(Content, _, _, _, "def _format_canonical_value"),
 	sub_string(Content, _, _, _, "'write_canonical/1'"),
 	sub_string(Content, _, _, _, "'tab/1'"),
+	sub_string(Content, _, _, _, "def _execute_format_builtin"),
+	sub_string(Content, _, _, _, "'format/1'"),
+	sub_string(Content, _, _, _, "'format/2'"),
+	sub_string(Content, _, _, _, "'format/3'"),
 	sub_string(Content, _, _, _, "def _execute_put_char"),
 	sub_string(Content, _, _, _, "def _execute_put_code"),
 	sub_string(Content, _, _, _, "def _execute_read_line_to_string"),
@@ -1908,7 +1962,7 @@ test(static_runtime_io_emits_output, [nondet]) :-
 	sub_string(Content, _, _, _, "def _term_ground"),
 	sub_string(Content, _, _, _, "'atomic/1'"),
 	sub_string(Content, _, _, _, "'\\\\==/2'"),
-	sub_string(Content, _, _, _, "print()").
+	sub_string(Content, _, _, _, "return _emit_output('\\n')").
 
 :- end_tests(wam_python_builtin_parity_guard).
 


### PR DESCRIPTION
## Summary
- add Python WAM runtime support for `format/1`, `format/2`, and `format/3`
- support the C++-matching directive subset: `~w`, `~p`, `~a`, `~d`, `~s`, `~n`, `~t`, and `~~`
- route existing Python WAM output builtins through a shared `_emit_output` helper
- support `format/3` destinations `user_output`, `user_error`, `atom(V)`, `string(V)`, and `codes(V)`
- keep the legacy direct Python text-generation path aligned with packaged `WamRuntime.py`
- add generated-project coverage for stdout formatting and atom/string/codes destinations

## Tests
- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_python_target.pl`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode),run_tests(wam_python_builtin_parity_guard),run_tests(wam_python_builtin_e2e)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
