### PR TITLE
Add WAM-C reverse CSR planning and pread reader

### DIFF
--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -7,6 +7,8 @@
 #include <string.h>
 #include <stdbool.h>
 #include <assert.h>
+#include <stdint.h>
+#include <sys/types.h>
 #ifdef WAM_C_ENABLE_LMDB
 #include <lmdb.h>
 #endif
@@ -123,6 +125,19 @@ typedef struct {
     int edge_count;
     int edge_cap;
 } WamFactSource;
+
+typedef struct {
+    int parent;
+    uint64_t offset_edges;
+    uint32_t child_count;
+} WamReverseCsrRow;
+
+typedef struct {
+    int index_fd;
+    int values_fd;
+    WamReverseCsrRow *rows;
+    int row_count;
+} WamReverseCsrArtifact;
 
 typedef struct {
     int *values;
@@ -286,6 +301,15 @@ bool wam_fact_source_load_lmdb(WamState *state, WamFactSource *source,
 int wam_fact_source_lookup_arg1(WamFactSource *source, const char *arg1,
                                 CategoryEdge *out_edges, int max_edges);
 bool wam_register_category_parent_fact_source(WamState *state, WamFactSource *source);
+void wam_reverse_csr_init(WamReverseCsrArtifact *artifact);
+void wam_reverse_csr_close(WamReverseCsrArtifact *artifact);
+bool wam_reverse_csr_load(WamReverseCsrArtifact *artifact,
+                          const char *index_path,
+                          const char *values_path);
+int wam_reverse_csr_lookup_children(WamReverseCsrArtifact *artifact,
+                                    int parent,
+                                    int *out_children,
+                                    int max_children);
 void wam_int_results_init(WamIntResults *results);
 void wam_int_results_close(WamIntResults *results);
 bool wam_int_results_push(WamIntResults *results, int value);

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -21,6 +21,7 @@
     wam_instruction_to_c_literal/3,   % +WamInstr, +LabelMap, -CCode
     detect_kernels/2,                 % +Predicates, -DetectedKernels
     generate_setup_detected_kernels_c/2, % +DetectedKernels, -CCode
+    resolve_wam_c_reverse_index_plan/2, % +Options, -Plan
     plan_wam_c_lowered_helpers/4,     % +Predicates, +Options, +DetectedKeys, -Plans
     write_wam_c_project/3             % +Predicates, +Options, +ProjectDir
 ]).
@@ -33,9 +34,31 @@
 :- use_module('../core/template_system').
 :- use_module('../bindings/c_wam_bindings').
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../core/cost_model', [resolve_reverse_index/2]).
 :- use_module('../core/recursive_kernel_detection', [
     detect_recursive_kernel/4
 ]).
+
+%% resolve_wam_c_reverse_index_plan(+Options, -Plan)
+%  Normalizes reverse-index options for WAM-C without claiming runtime child-edge
+%  lookup support. The generated C runtime currently has parent fact-source
+%  loading and ancestor kernels; CSR reverse indexes are planning/build inputs
+%  until a C reader and lookup API are added.
+resolve_wam_c_reverse_index_plan(Options, Plan) :-
+    resolve_reverse_index(Options, ReverseIndex),
+    wam_c_reverse_index_capabilities(ReverseIndex, Capabilities),
+    Plan = wam_c_reverse_index_plan(ReverseIndex, Capabilities).
+
+wam_c_reverse_index_capabilities(none, [
+    planning(unneeded),
+    runtime_child_lookup(unavailable)
+]) :- !.
+wam_c_reverse_index_capabilities(ReverseIndex, [
+    planning(accepted),
+    runtime_child_lookup(unsupported),
+    runtime_reason(no_c_reverse_index_reader)
+]) :-
+    ReverseIndex \= none.
 
 % ============================================================================
 % PHASE 4: Hybrid Module Assembly

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -40,10 +40,8 @@
 ]).
 
 %% resolve_wam_c_reverse_index_plan(+Options, -Plan)
-%  Normalizes reverse-index options for WAM-C without claiming runtime child-edge
-%  lookup support. The generated C runtime currently has parent fact-source
-%  loading and ancestor kernels; CSR reverse indexes are planning/build inputs
-%  until a C reader and lookup API are added.
+%  Normalizes reverse-index options for WAM-C and reports which normalized
+%  variants the generated C runtime can currently consume.
 resolve_wam_c_reverse_index_plan(Options, Plan) :-
     resolve_reverse_index(Options, ReverseIndex),
     wam_c_reverse_index_capabilities(ReverseIndex, Capabilities),
@@ -53,12 +51,44 @@ wam_c_reverse_index_capabilities(none, [
     planning(unneeded),
     runtime_child_lookup(unavailable)
 ]) :- !.
+wam_c_reverse_index_capabilities(artifact(Opts), [
+    planning(accepted),
+    runtime_child_lookup(available),
+    runtime_api(wam_reverse_csr_lookup_children),
+    runtime_index_backend(sorted_array),
+    runtime_io(pread)
+]) :-
+    memberchk(storage_kind(csr_pread_artifact), Opts),
+    memberchk(index_backend(sorted_array), Opts),
+    !.
+wam_c_reverse_index_capabilities(csr(Opts), [
+    planning(accepted),
+    runtime_child_lookup(available_after_artifact_build),
+    runtime_api(wam_reverse_csr_lookup_children),
+    runtime_index_backend(sorted_array),
+    runtime_io(pread)
+]) :-
+    memberchk(index_backend(sorted_array), Opts),
+    !.
 wam_c_reverse_index_capabilities(ReverseIndex, [
     planning(accepted),
     runtime_child_lookup(unsupported),
-    runtime_reason(no_c_reverse_index_reader)
+    runtime_reason(lmdb_offset_index_not_implemented)
+]) :-
+    wam_c_reverse_index_uses_lmdb_offset(ReverseIndex),
+    !.
+wam_c_reverse_index_capabilities(ReverseIndex, [
+    planning(accepted),
+    runtime_child_lookup(unsupported),
+    runtime_reason(reverse_index_kind_not_implemented)
 ]) :-
     ReverseIndex \= none.
+
+wam_c_reverse_index_uses_lmdb_offset(csr(Opts)) :-
+    memberchk(index_backend(lmdb_offset), Opts).
+wam_c_reverse_index_uses_lmdb_offset(artifact(Opts)) :-
+    memberchk(storage_kind(csr_pread_artifact), Opts),
+    memberchk(index_backend(lmdb_offset), Opts).
 
 % ============================================================================
 % PHASE 4: Hybrid Module Assembly

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -1992,7 +1992,12 @@ compile_step_wam_to_c(_Options, CCode) :-
 
 compile_wam_helpers_to_c(_Options, CCode) :-
     CCode =
-'#include "wam_runtime.h"
+'#define _POSIX_C_SOURCE 200809L
+#include "wam_runtime.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <unistd.h>
 
 void wam_state_init(WamState *state) {
     memset(state, 0, sizeof(WamState));
@@ -2488,6 +2493,140 @@ bool wam_register_category_parent_fact_source(WamState *state, WamFactSource *so
         wam_register_category_parent(state, source->edges[i].child, source->edges[i].parent);
     }
     return true;
+}
+
+static int32_t wam_read_i32_le(const unsigned char *p) {
+    uint32_t v = ((uint32_t)p[0]) |
+                 ((uint32_t)p[1] << 8) |
+                 ((uint32_t)p[2] << 16) |
+                 ((uint32_t)p[3] << 24);
+    return (int32_t)v;
+}
+
+static uint32_t wam_read_u32_le(const unsigned char *p) {
+    return ((uint32_t)p[0]) |
+           ((uint32_t)p[1] << 8) |
+           ((uint32_t)p[2] << 16) |
+           ((uint32_t)p[3] << 24);
+}
+
+static uint64_t wam_read_u64_le(const unsigned char *p) {
+    uint64_t v = 0;
+    for (int i = 7; i >= 0; i--) {
+        v = (v << 8) | (uint64_t)p[i];
+    }
+    return v;
+}
+
+static bool wam_pread_exact(int fd, void *buffer, size_t bytes, off_t offset) {
+    unsigned char *out = (unsigned char *)buffer;
+    size_t done = 0;
+    while (done < bytes) {
+        ssize_t n = pread(fd, out + done, bytes - done, offset + (off_t)done);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (n == 0) return false;
+        done += (size_t)n;
+    }
+    return true;
+}
+
+void wam_reverse_csr_init(WamReverseCsrArtifact *artifact) {
+    memset(artifact, 0, sizeof(WamReverseCsrArtifact));
+    artifact->index_fd = -1;
+    artifact->values_fd = -1;
+}
+
+void wam_reverse_csr_close(WamReverseCsrArtifact *artifact) {
+    if (artifact->index_fd >= 0) close(artifact->index_fd);
+    if (artifact->values_fd >= 0) close(artifact->values_fd);
+    free(artifact->rows);
+    wam_reverse_csr_init(artifact);
+}
+
+bool wam_reverse_csr_load(WamReverseCsrArtifact *artifact,
+                          const char *index_path,
+                          const char *values_path) {
+    const size_t record_bytes = 16;
+    unsigned char *raw = NULL;
+    bool ok = false;
+    off_t index_size = 0;
+
+    wam_reverse_csr_close(artifact);
+    artifact->index_fd = open(index_path, O_RDONLY);
+    if (artifact->index_fd < 0) goto done;
+    artifact->values_fd = open(values_path, O_RDONLY);
+    if (artifact->values_fd < 0) goto done;
+
+    index_size = lseek(artifact->index_fd, 0, SEEK_END);
+    if (index_size < 0 || (index_size % (off_t)record_bytes) != 0) goto done;
+    if (lseek(artifact->index_fd, 0, SEEK_SET) < 0) goto done;
+    if ((index_size / (off_t)record_bytes) > INT_MAX) goto done;
+    artifact->row_count = (int)(index_size / (off_t)record_bytes);
+    if ((off_t)artifact->row_count * (off_t)record_bytes != index_size) goto done;
+
+    if (artifact->row_count > 0) {
+        artifact->rows = calloc((size_t)artifact->row_count, sizeof(WamReverseCsrRow));
+        raw = malloc((size_t)index_size);
+        if (!artifact->rows || !raw) goto done;
+        if (!wam_pread_exact(artifact->index_fd, raw, (size_t)index_size, 0)) goto done;
+        for (int i = 0; i < artifact->row_count; i++) {
+            const unsigned char *record = raw + ((size_t)i * record_bytes);
+            int parent = (int)wam_read_i32_le(record);
+            if (i > 0 && parent <= artifact->rows[i - 1].parent) goto done;
+            artifact->rows[i].parent = parent;
+            artifact->rows[i].offset_edges = wam_read_u64_le(record + 4);
+            artifact->rows[i].child_count = wam_read_u32_le(record + 12);
+        }
+    }
+
+    ok = true;
+
+done:
+    free(raw);
+    if (!ok) wam_reverse_csr_close(artifact);
+    return ok;
+}
+
+static WamReverseCsrRow *wam_reverse_csr_find_row(WamReverseCsrArtifact *artifact,
+                                                  int parent) {
+    int lo = 0;
+    int hi = artifact->row_count;
+    while (lo < hi) {
+        int mid = lo + (hi - lo) / 2;
+        int mid_parent = artifact->rows[mid].parent;
+        if (mid_parent < parent) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    if (lo >= artifact->row_count || artifact->rows[lo].parent != parent) return NULL;
+    return &artifact->rows[lo];
+}
+
+int wam_reverse_csr_lookup_children(WamReverseCsrArtifact *artifact,
+                                    int parent,
+                                    int *out_children,
+                                    int max_children) {
+    WamReverseCsrRow *row = wam_reverse_csr_find_row(artifact, parent);
+    if (!row) return 0;
+    if (max_children < 0) max_children = 0;
+    if (row->child_count > (uint32_t)INT_MAX) return -1;
+    int total = (int)row->child_count;
+    int to_read = total < max_children ? total : max_children;
+    for (int i = 0; i < to_read; i++) {
+        unsigned char encoded[4];
+        uint64_t edge_offset = row->offset_edges + (uint64_t)i;
+        if (edge_offset > (UINT64_MAX / 4ULL)) return -1;
+        if (!wam_pread_exact(artifact->values_fd, encoded, sizeof(encoded), (off_t)(edge_offset * 4ULL))) {
+            return -1;
+        }
+        out_children[i] = (int)wam_read_i32_le(encoded);
+    }
+    return total;
 }
 
 void wam_int_results_init(WamIntResults *results) {

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -347,6 +347,61 @@ test_fact_source_generation :-
     ;   fail_test(Test, 'file FactSource helpers missing')
     ).
 
+test_reverse_index_plan_none :-
+    Test = 'WAM-C: reverse_index none plans no runtime child lookup',
+    (   resolve_wam_c_reverse_index_plan(
+            [reverse_index(none)],
+            wam_c_reverse_index_plan(none, Capabilities)
+        ),
+        memberchk(planning(unneeded), Capabilities),
+        memberchk(runtime_child_lookup(unavailable), Capabilities)
+    ->  pass(Test)
+    ;   fail_test(Test, 'reverse_index(none) did not plan as unavailable')
+    ).
+
+test_reverse_index_plan_csr_cost_model :-
+    Test = 'WAM-C: reverse_index csr uses shared CSR cost model',
+    (   resolve_wam_c_reverse_index_plan(
+            [reverse_index(csr([
+                index_backend(auto),
+                expected_child_lookups_per_query(500),
+                expected_query_count_per_artifact(100),
+                sorted_array_lookup_ms_per_1000(4.418097),
+                lmdb_offset_lookup_ms_per_1000(2.961144),
+                sorted_array_build_seconds(0.331824),
+                lmdb_offset_build_seconds(0.381317),
+                lmdb_offset_bytes(2113536),
+                available_memory_bytes(1073741824)
+            ]))],
+            wam_c_reverse_index_plan(csr(Resolved), Capabilities)
+        ),
+        memberchk(index_backend(lmdb_offset), Resolved),
+        memberchk(io_policy(buffered_pread_drop), Resolved),
+        memberchk(runtime_child_lookup(unsupported), Capabilities),
+        memberchk(runtime_reason(no_c_reverse_index_reader), Capabilities)
+    ->  pass(Test)
+    ;   fail_test(Test, 'CSR options were not normalized through the cost model')
+    ).
+
+test_reverse_index_plan_runtime_available_marks_unsupported :-
+    Test = 'WAM-C: runtime reverse_index request is accepted as unsupported plan',
+    (   resolve_wam_c_reverse_index_plan(
+            [reverse_index(artifact([
+                storage_kind(csr_pread_artifact),
+                phase(runtime_available),
+                index_backend(lmdb_offset),
+                io_policy(buffered_pread)
+            ]))],
+            wam_c_reverse_index_plan(artifact(Resolved), Capabilities)
+        ),
+        memberchk(phase(runtime_available), Resolved),
+        memberchk(storage_kind(csr_pread_artifact), Resolved),
+        memberchk(index_backend(lmdb_offset), Resolved),
+        memberchk(runtime_child_lookup(unsupported), Capabilities)
+    ->  pass(Test)
+    ;   fail_test(Test, 'runtime reverse index request did not stay explicit')
+    ).
+
 test_streaming_foreign_results_generation :-
     Test = 'WAM-C: streaming foreign result helpers generated',
     (   compile_wam_runtime_to_c([], RuntimeCode),
@@ -4363,6 +4418,9 @@ run_tests_once :-
     test_weighted_shortest_path_kernel_generation,
     test_astar_shortest_path_kernel_generation,
     test_fact_source_generation,
+    test_reverse_index_plan_none,
+    test_reverse_index_plan_csr_cost_model,
+    test_reverse_index_plan_runtime_available_marks_unsupported,
     test_streaming_foreign_results_generation,
     test_kernel_detector_setup_generation,
     test_transitive_closure_detector_setup_generation,

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -347,6 +347,19 @@ test_fact_source_generation :-
     ;   fail_test(Test, 'file FactSource helpers missing')
     ).
 
+test_reverse_csr_generation :-
+    Test = 'WAM-C: reverse CSR pread helpers generated',
+    (   compile_wam_runtime_to_c([], RuntimeCode),
+        atom_string(RuntimeCode, S),
+        sub_string(S, _, _, _, 'void wam_reverse_csr_init'),
+        sub_string(S, _, _, _, 'bool wam_reverse_csr_load'),
+        sub_string(S, _, _, _, 'int wam_reverse_csr_lookup_children'),
+        sub_string(S, _, _, _, 'pread('),
+        sub_string(S, _, _, _, 'wam_read_i32_le')
+    ->  pass(Test)
+    ;   fail_test(Test, 'reverse CSR helpers missing')
+    ).
+
 test_reverse_index_plan_none :-
     Test = 'WAM-C: reverse_index none plans no runtime child lookup',
     (   resolve_wam_c_reverse_index_plan(
@@ -1163,6 +1176,16 @@ test_lmdb_fact_source_executable_smoke :-
     ;   format('[PASS] ~w (gcc or lmdb unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_reverse_csr_executable_smoke :-
+    Test = 'WAM-C: reverse CSR executable smoke',
+    (   gcc_available
+    ->  (   run_reverse_csr_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'reverse CSR executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_streaming_foreign_results_executable_smoke :-
     Test = 'WAM-C: streaming category_ancestor result executable smoke',
     (   gcc_available
@@ -1674,6 +1697,34 @@ run_lmdb_fact_source_executable_smoke :-
     wam_c_lmdb_fact_source_smoke_main(EnvPath, MainCode),
     write_text_file(MainPath, MainCode),
     compile_c_smoke_lmdb(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
+run_reverse_csr_executable_smoke :-
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_reverse_csr_smoke', Stamp, TmpBase),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(IndexPath), '~w.csr.idx', [TmpBase]),
+    format(atom(ValuesPath), '~w.csr.val', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(RuntimePath, RuntimeCode),
+    write_text_file(PredPath, '#include "wam_runtime.h"\n'),
+    write_binary_file(IndexPath, [
+        20,0,0,0, 0,0,0,0,0,0,0,0, 3,0,0,0,
+        30,0,0,0, 3,0,0,0,0,0,0,0, 1,0,0,0
+    ]),
+    write_binary_file(ValuesPath, [
+        10,0,0,0,
+        12,0,0,0,
+        13,0,0,0,
+        11,0,0,0
+    ]),
+    wam_c_reverse_csr_smoke_main(IndexPath, ValuesPath, MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
 
 run_kernel_detector_executable_smoke :-
@@ -2220,6 +2271,13 @@ write_text_file(Path, Content) :-
     setup_call_cleanup(
         open(Path, write, Stream),
         format(Stream, '~w', [Content]),
+        close(Stream)
+    ).
+
+write_binary_file(Path, Bytes) :-
+    setup_call_cleanup(
+        open(Path, write, Stream, [type(binary)]),
+        forall(member(Byte, Bytes), put_byte(Stream, Byte)),
         close(Stream)
     ).
 
@@ -3601,6 +3659,51 @@ int main(void) {
 }
 ', [EnvPath, EnvPath]).
 
+wam_c_reverse_csr_smoke_main(IndexPath, ValuesPath, MainCode) :-
+    format(atom(MainCode),
+'#include "wam_runtime.h"
+
+int main(void) {
+    WamReverseCsrArtifact csr;
+    int children[4] = {0, 0, 0, 0};
+    int count = 0;
+
+    wam_reverse_csr_init(&csr);
+    if (!wam_reverse_csr_load(&csr, "~w", "~w")) {
+        return 10;
+    }
+
+    count = wam_reverse_csr_lookup_children(&csr, 20, children, 4);
+    if (count != 3 || children[0] != 10 || children[1] != 12 || children[2] != 13) {
+        wam_reverse_csr_close(&csr);
+        return 20;
+    }
+
+    children[0] = 0;
+    children[1] = 0;
+    count = wam_reverse_csr_lookup_children(&csr, 20, children, 2);
+    if (count != 3 || children[0] != 10 || children[1] != 12) {
+        wam_reverse_csr_close(&csr);
+        return 30;
+    }
+
+    count = wam_reverse_csr_lookup_children(&csr, 30, children, 4);
+    if (count != 1 || children[0] != 11) {
+        wam_reverse_csr_close(&csr);
+        return 40;
+    }
+
+    count = wam_reverse_csr_lookup_children(&csr, 99, children, 4);
+    if (count != 0) {
+        wam_reverse_csr_close(&csr);
+        return 50;
+    }
+
+    wam_reverse_csr_close(&csr);
+    return 0;
+}
+', [IndexPath, ValuesPath]).
+
 wam_c_streaming_foreign_smoke_main(
 '#include "wam_runtime.h"
 
@@ -4418,6 +4521,7 @@ run_tests_once :-
     test_weighted_shortest_path_kernel_generation,
     test_astar_shortest_path_kernel_generation,
     test_fact_source_generation,
+    test_reverse_csr_generation,
     test_reverse_index_plan_none,
     test_reverse_index_plan_csr_cost_model,
     test_reverse_index_plan_runtime_available_marks_unsupported,
@@ -4458,6 +4562,7 @@ run_tests_once :-
     test_astar_shortest_path_kernel_executable_smoke,
     test_fact_source_executable_smoke,
     test_lmdb_fact_source_executable_smoke,
+    test_reverse_csr_executable_smoke,
     test_kernel_detector_executable_smoke,
     test_transitive_closure_detector_executable_smoke,
     test_transitive_distance_detector_executable_smoke,

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -391,13 +391,34 @@ test_reverse_index_plan_csr_cost_model :-
         memberchk(index_backend(lmdb_offset), Resolved),
         memberchk(io_policy(buffered_pread_drop), Resolved),
         memberchk(runtime_child_lookup(unsupported), Capabilities),
-        memberchk(runtime_reason(no_c_reverse_index_reader), Capabilities)
+        memberchk(runtime_reason(lmdb_offset_index_not_implemented), Capabilities)
     ->  pass(Test)
     ;   fail_test(Test, 'CSR options were not normalized through the cost model')
     ).
 
-test_reverse_index_plan_runtime_available_marks_unsupported :-
-    Test = 'WAM-C: runtime reverse_index request is accepted as unsupported plan',
+test_reverse_index_plan_runtime_available_sorted_array :-
+    Test = 'WAM-C: runtime sorted-array CSR artifact is available',
+    (   resolve_wam_c_reverse_index_plan(
+            [reverse_index(artifact([
+                storage_kind(csr_pread_artifact),
+                phase(runtime_available),
+                index_backend(sorted_array),
+                io_policy(buffered_pread)
+            ]))],
+            wam_c_reverse_index_plan(artifact(Resolved), Capabilities)
+        ),
+        memberchk(phase(runtime_available), Resolved),
+        memberchk(storage_kind(csr_pread_artifact), Resolved),
+        memberchk(index_backend(sorted_array), Resolved),
+        memberchk(runtime_child_lookup(available), Capabilities),
+        memberchk(runtime_api(wam_reverse_csr_lookup_children), Capabilities),
+        memberchk(runtime_io(pread), Capabilities)
+    ->  pass(Test)
+    ;   fail_test(Test, 'runtime sorted-array CSR artifact was not marked available')
+    ).
+
+test_reverse_index_plan_runtime_available_lmdb_offset_unsupported :-
+    Test = 'WAM-C: runtime lmdb-offset CSR artifact is still unsupported',
     (   resolve_wam_c_reverse_index_plan(
             [reverse_index(artifact([
                 storage_kind(csr_pread_artifact),
@@ -410,9 +431,10 @@ test_reverse_index_plan_runtime_available_marks_unsupported :-
         memberchk(phase(runtime_available), Resolved),
         memberchk(storage_kind(csr_pread_artifact), Resolved),
         memberchk(index_backend(lmdb_offset), Resolved),
-        memberchk(runtime_child_lookup(unsupported), Capabilities)
+        memberchk(runtime_child_lookup(unsupported), Capabilities),
+        memberchk(runtime_reason(lmdb_offset_index_not_implemented), Capabilities)
     ->  pass(Test)
-    ;   fail_test(Test, 'runtime reverse index request did not stay explicit')
+    ;   fail_test(Test, 'runtime lmdb-offset CSR artifact did not stay unsupported')
     ).
 
 test_streaming_foreign_results_generation :-
@@ -4524,7 +4546,8 @@ run_tests_once :-
     test_reverse_csr_generation,
     test_reverse_index_plan_none,
     test_reverse_index_plan_csr_cost_model,
-    test_reverse_index_plan_runtime_available_marks_unsupported,
+    test_reverse_index_plan_runtime_available_sorted_array,
+    test_reverse_index_plan_runtime_available_lmdb_offset_unsupported,
     test_streaming_foreign_results_generation,
     test_kernel_detector_setup_generation,
     test_transitive_closure_detector_setup_generation,


### PR DESCRIPTION
  Adds the first WAM-C runtime surface for reverse CSR child-edge lookup.

  ### Changes

  - Adds `resolve_wam_c_reverse_index_plan/2` for C-specific reverse-index capability planning.
  - Normalizes reverse-index options through the shared cost model.
  - Adds `WamReverseCsrArtifact` and a sorted-array CSR `pread` reader to the C runtime.
  - Exposes `wam_reverse_csr_load` and `wam_reverse_csr_lookup_children`.
  - Marks sorted-array `csr_pread_artifact` lookup as available in WAM-C planning.
  - Keeps `lmdb_offset` CSR indexes explicitly unsupported for WAM-C for now.

  ### Verification

  - Focused WAM-C CSR/planning tests pass.
  - `tests/core/test_cost_model.pl` passes.
  - `git diff --check` passes.

  Note: the broader WAM-C suite still has pre-existing later real-Prolog smoke failures unrelated to this branch.