### PR TITLE
Feat/wam go split string builtin

### DIFF
--- a/PR_go_wam_split_string_builtin.md
+++ b/PR_go_wam_split_string_builtin.md
@@ -1,0 +1,31 @@
+# PR Title
+
+Add Go WAM split_string/4 builtin parity
+
+# PR Description
+
+## Summary
+
+- Adds direct Go WAM lowering for `split_string/4`.
+- Implements deterministic generated Go runtime support for `split_string(+String,+Separators,+Pad,?SubStrings)`.
+- Splits on any separator character and trims leading/trailing pad characters from each segment.
+- Extends the generated Go WAM builtin E2E test with separator splitting, empty input, adjacent separators, no-separator padding, separator plus pad trimming, multiple separators, numeric source conversion, unbound input failure, and bound-output mismatch failure.
+- Updates the Go WAM parity audit to record forward-mode `split_string/4` coverage against the R/C++ deterministic split-string surface.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(split_string/4,4), G), writeln(G), halt"`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`
+
+## Push
+
+```sh
+git push -u origin feat/wam-go-split-string-builtin
+```

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -14,7 +14,7 @@ current cross-target builtin/runtime baseline.
 | Structural builtins | `member/2`, `memberchk/2`, `select/3`, `delete/3`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `select/3`, `delete/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1`, `ground/1` | Includes `is_list/1` and Clojure direct `ground/1` in the current baseline | Present for current baseline type and groundness checks |
 | Arithmetic builtins | `is/2`, `succ/2` | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir | Present for current baseline arithmetic checks, with expanded successor coverage |
-| Atom/text conversion | `atom_number/2`, `atom_codes/2`, `atom_chars/2`, `string_codes/2`, `string_chars/2`, `number_codes/2`, `number_chars/2`, `atom_string/2`, `string_to_atom/2`, `upcase_atom/2`, `downcase_atom/2`, `atom_concat/3`, `atom_length/2`, `string_length/2`, `char_code/2`, `sub_atom/5` forward mode, `char_type/2` forward mode, `string_code/3` forward mode | Clojure direct builtin surface includes bidirectional `atom_number/2`, atom/string/number code-list and char-list conversion, atom/string conversion, atom case conversion, deterministic atom concatenation, text length checks, and char-code conversion | Present for current atom-number, atom/string/number code-list, atom/string/number char-list, atom/string, atom-case, atom-concat, text-length, char-code, forward sub-atom, forward char-type, and forward string-code checks |
+| Atom/text conversion | `atom_number/2`, `atom_codes/2`, `atom_chars/2`, `string_codes/2`, `string_chars/2`, `number_codes/2`, `number_chars/2`, `atom_string/2`, `string_to_atom/2`, `upcase_atom/2`, `downcase_atom/2`, `atom_concat/3`, `atom_length/2`, `string_length/2`, `char_code/2`, `sub_atom/5` forward mode, `char_type/2` forward mode, `string_code/3` forward mode, `split_string/4` forward mode | Clojure direct builtin surface includes bidirectional `atom_number/2`, atom/string/number code-list and char-list conversion, atom/string conversion, atom case conversion, deterministic atom concatenation, text length checks, and char-code conversion | Present for current atom-number, atom/string/number code-list, atom/string/number char-list, atom/string, atom-case, atom-concat, text-length, char-code, forward sub-atom, forward char-type, forward string-code, and forward split-string checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` | Includes `=</2`; Haskell mode analysis and Clojure lowering also cover term-order comparisons | Present for current baseline comparisons, with expanded term-order coverage |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
 | Term inspection | `functor/3`, `arg/3` | `functor/3`, `arg/3` | Present |
@@ -80,9 +80,14 @@ current cross-target builtin/runtime baseline.
   argument failure, and unknown category failure, matching the R/Clojure
   atom-category surface.
 - Forward-mode `string_code/3` is now covered by the generated Go WAM
-  builtin E2E test for 1-based code lookup, code unification, invalid index failure, unbound argument failure, non-text source
-  failure, and bound-code mismatch failure, matching the R/C++
-  deterministic text-code lookup surface.
+  builtin E2E test for 1-based code lookup, code unification, invalid index
+  failure, unbound argument failure, non-text source failure, and bound-code
+  mismatch failure, matching the R/C++ deterministic text-code lookup surface.
+- Forward-mode `split_string/4` is now covered by the generated Go WAM
+  builtin E2E test for separator splitting, empty input, adjacent separators,
+  no-separator padding, separator plus pad trimming, multiple separators,
+  numeric source conversion, unbound input failure, and bound-output mismatch
+  failure, matching the R/C++ deterministic split-string surface.
 - Bidirectional `succ/2` is now covered by the generated Go WAM builtin E2E
   test for forward binding, reverse binding, matching integer pairs, mismatch
   failure, negative predecessor failure, non-positive successor failure, and

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -472,6 +472,9 @@ wam_go_direct_builtin("char_type/2", 2, 'char_type/2').
 wam_go_direct_builtin(string_code/3, 3, 'string_code/3').
 wam_go_direct_builtin('string_code/3', 3, 'string_code/3').
 wam_go_direct_builtin("string_code/3", 3, 'string_code/3').
+wam_go_direct_builtin(split_string/4, 4, 'split_string/4').
+wam_go_direct_builtin('split_string/4', 4, 'split_string/4').
+wam_go_direct_builtin("split_string/4", 4, 'split_string/4').
 wam_go_direct_builtin(succ/2, 2, 'succ/2').
 wam_go_direct_builtin('succ/2', 2, 'succ/2').
 wam_go_direct_builtin("succ/2", 2, 'succ/2').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1506,6 +1506,46 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			return false
 		}
 		return vm.Unify(arg3, &Integer{Val: int64(runes[index.Val-1])})
+	case "split_string/4":
+		source, okSource := atomNumberText(vm.deref(arg1))
+		seps, okSeps := atomNumberText(vm.deref(arg2))
+		pads, okPads := atomNumberText(vm.deref(arg3))
+		if !okSource || !okSeps || !okPads {
+			return false
+		}
+		sepSet := make(map[rune]bool)
+		for _, r := range seps {
+			sepSet[r] = true
+		}
+		padSet := make(map[rune]bool)
+		for _, r := range pads {
+			padSet[r] = true
+		}
+		parts := []string{}
+		current := []rune{}
+		for _, r := range source {
+			if sepSet[r] {
+				parts = append(parts, string(current))
+				current = current[:0]
+				continue
+			}
+			current = append(current, r)
+		}
+		parts = append(parts, string(current))
+		items := make([]Value, 0, len(parts))
+		for _, part := range parts {
+			runes := []rune(part)
+			start := 0
+			for start < len(runes) && padSet[runes[start]] {
+				start++
+			}
+			end := len(runes)
+			for end > start && padSet[runes[end-1]] {
+				end--
+			}
+			items = append(items, internAtom(string(runes[start:end])))
+		}
+		return vm.Unify(arg4, &List{Elements: items})
 
 	case "var/1": return isUnbound(vm.deref(arg1))
 	case "nonvar/1": return !isUnbound(vm.deref(arg1))

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -21,6 +21,7 @@
 :- dynamic user:test_sub_atom_builtin/0.
 :- dynamic user:test_char_type_builtin/0.
 :- dynamic user:test_string_code_builtin/0.
+:- dynamic user:test_split_string_builtin/0.
 :- dynamic user:test_succ_builtin/0.
 :- dynamic user:test_atom_number_builtin/0.
 :- dynamic user:test_atom_case_builtin/0.
@@ -228,6 +229,32 @@ test(builtins_execution) :-
                 \+ string_code(1, 42, _),
                 \+ string_code(1, abc, 98)
             )),
+          assertz(user:test_split_string_builtin :-
+            (   char_code(Comma, 44),
+                char_code(Semi, 59),
+                atom_concat(Comma, Semi, CommaSemi),
+                split_string('a,b,c', Comma, '', [a,b,c]),
+                split_string('', Comma, '', ['']),
+                split_string(hello, Comma, '', [hello]),
+                split_string('a,,b', Comma, '', [a,'',b]),
+                char_code(Space, 32),
+                atom_concat(Space, hello, Padded0),
+                atom_concat(Padded0, Space, Padded),
+                split_string(Padded, '', Space, [hello]),
+                atom_concat(a, Comma, SP0),
+                atom_concat(SP0, Space, SP1),
+                atom_concat(SP1, b, SepPadInput),
+                split_string(SepPadInput, Comma, Space, [a,b]),
+                split_string('a,b;c,d', CommaSemi, '', [a,b,c,d]),
+                atom_concat(abc, Space, Trail0),
+                atom_concat(Trail0, Space, Trail),
+                split_string(Trail, '', Space, [abc]),
+                split_string(123, '', '', ['123']),
+                \+ split_string(_, Comma, '', _),
+                \+ split_string('a,b', _, '', _),
+                \+ split_string('a,b', Comma, _, _),
+                \+ split_string('a,b', Comma, '', [a,b,c])
+            )),
           assertz(user:test_succ_builtin :-
             (   succ(0, 1),
                 succ(2, X),
@@ -430,6 +457,7 @@ test(builtins_execution) :-
           retractall(user:test_sub_atom_builtin),
           retractall(user:test_char_type_builtin),
           retractall(user:test_string_code_builtin),
+          retractall(user:test_split_string_builtin),
           retractall(user:test_succ_builtin),
           retractall(user:test_atom_number_builtin),
           retractall(user:test_atom_case_builtin),
@@ -450,7 +478,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -501,6 +529,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "sub_atom/5"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "char_type/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "string_code/3"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "split_string/4"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "succ/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "atom_number/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "upcase_atom/2"')),
@@ -666,6 +695,14 @@ func main() {
 		fmt.Println("STRING_CODE_FAILURE")
 	}
 
+	splitStringVM := wam.NewWamState(wam.Test_split_string_builtinCode, wam.Test_split_string_builtinLabels)
+	splitStringVM.PC = wam.Test_split_string_builtinStartPC
+	if splitStringVM.Run() {
+		fmt.Println("SPLIT_STRING_SUCCESS")
+	} else {
+		fmt.Println("SPLIT_STRING_FAILURE")
+	}
+
 	succVM := wam.NewWamState(wam.Test_succ_builtinCode, wam.Test_succ_builtinLabels)
 	succVM.PC = wam.Test_succ_builtinStartPC
 	if succVM.Run() {
@@ -819,6 +856,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "SUB_ATOM_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "CHAR_TYPE_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "STRING_CODE_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "SPLIT_STRING_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SUCC_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_NUMBER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_CASE_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM split_string/4 builtin parity

## Summary

- Adds direct Go WAM lowering for `split_string/4`.
- Implements deterministic generated Go runtime support for `split_string(+String,+Separators,+Pad,?SubStrings)`.
- Splits on any separator character and trims leading/trailing pad characters from each segment.
- Extends the generated Go WAM builtin E2E test with separator splitting, empty input, adjacent separators, no-separator padding, separator plus pad trimming, multiple separators, numeric source conversion, unbound input failure, and bound-output mismatch failure.
- Updates the Go WAM parity audit to record forward-mode `split_string/4` coverage against the R/C++ deterministic split-string surface.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(split_string/4,4), G), writeln(G), halt"`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`

## Push

```sh
git push -u origin feat/wam-go-split-string-builtin
```
