### PR TITLE
Add WAM-C reverse CSR LMDB offset reader

### DIFF
--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -137,6 +137,12 @@ typedef struct {
     int values_fd;
     WamReverseCsrRow *rows;
     int row_count;
+#ifdef WAM_C_ENABLE_LMDB
+    bool use_lmdb_offset;
+    bool offset_dbi_open;
+    MDB_env *offset_env;
+    MDB_dbi offset_dbi;
+#endif
 } WamReverseCsrArtifact;
 
 typedef struct {
@@ -306,6 +312,10 @@ void wam_reverse_csr_close(WamReverseCsrArtifact *artifact);
 bool wam_reverse_csr_load(WamReverseCsrArtifact *artifact,
                           const char *index_path,
                           const char *values_path);
+bool wam_reverse_csr_load_lmdb_offset(WamReverseCsrArtifact *artifact,
+                                      const char *values_path,
+                                      const char *offset_env_path,
+                                      const char *db_name);
 int wam_reverse_csr_lookup_children(WamReverseCsrArtifact *artifact,
                                     int parent,
                                     int *out_children,

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -72,8 +72,11 @@ wam_c_reverse_index_capabilities(csr(Opts), [
     !.
 wam_c_reverse_index_capabilities(ReverseIndex, [
     planning(accepted),
-    runtime_child_lookup(unsupported),
-    runtime_reason(lmdb_offset_index_not_implemented)
+    runtime_child_lookup(available),
+    runtime_api(wam_reverse_csr_lookup_children),
+    runtime_index_backend(lmdb_offset),
+    runtime_io(pread),
+    runtime_requires(wam_c_enable_lmdb)
 ]) :-
     wam_c_reverse_index_uses_lmdb_offset(ReverseIndex),
     !.
@@ -2572,6 +2575,14 @@ void wam_reverse_csr_init(WamReverseCsrArtifact *artifact) {
 void wam_reverse_csr_close(WamReverseCsrArtifact *artifact) {
     if (artifact->index_fd >= 0) close(artifact->index_fd);
     if (artifact->values_fd >= 0) close(artifact->values_fd);
+#ifdef WAM_C_ENABLE_LMDB
+    if (artifact->offset_env) {
+        if (artifact->offset_dbi_open) {
+            mdb_dbi_close(artifact->offset_env, artifact->offset_dbi);
+        }
+        mdb_env_close(artifact->offset_env);
+    }
+#endif
     free(artifact->rows);
     wam_reverse_csr_init(artifact);
 }
@@ -2620,6 +2631,50 @@ done:
     return ok;
 }
 
+bool wam_reverse_csr_load_lmdb_offset(WamReverseCsrArtifact *artifact,
+                                      const char *values_path,
+                                      const char *offset_env_path,
+                                      const char *db_name) {
+#ifndef WAM_C_ENABLE_LMDB
+    (void)artifact;
+    (void)values_path;
+    (void)offset_env_path;
+    (void)db_name;
+    return false;
+#else
+    MDB_txn *txn = NULL;
+    int rc = 0;
+    bool ok = false;
+
+    wam_reverse_csr_close(artifact);
+    artifact->values_fd = open(values_path, O_RDONLY);
+    if (artifact->values_fd < 0) goto done;
+
+    rc = mdb_env_create(&artifact->offset_env);
+    if (rc != MDB_SUCCESS) goto done;
+    rc = mdb_env_set_maxdbs(artifact->offset_env, 2);
+    if (rc != MDB_SUCCESS) goto done;
+    rc = mdb_env_open(artifact->offset_env, offset_env_path, MDB_RDONLY, 0664);
+    if (rc != MDB_SUCCESS) goto done;
+    rc = mdb_txn_begin(artifact->offset_env, NULL, MDB_RDONLY, &txn);
+    if (rc != MDB_SUCCESS) goto done;
+    rc = mdb_dbi_open(txn, (db_name && db_name[0]) ? db_name : "offsets", 0, &artifact->offset_dbi);
+    if (rc != MDB_SUCCESS) goto done;
+    rc = mdb_txn_commit(txn);
+    txn = NULL;
+    if (rc != MDB_SUCCESS) goto done;
+
+    artifact->offset_dbi_open = true;
+    artifact->use_lmdb_offset = true;
+    ok = true;
+
+done:
+    if (txn) mdb_txn_abort(txn);
+    if (!ok) wam_reverse_csr_close(artifact);
+    return ok;
+#endif
+}
+
 static WamReverseCsrRow *wam_reverse_csr_find_row(WamReverseCsrArtifact *artifact,
                                                   int parent) {
     int lo = 0;
@@ -2637,19 +2692,69 @@ static WamReverseCsrRow *wam_reverse_csr_find_row(WamReverseCsrArtifact *artifac
     return &artifact->rows[lo];
 }
 
+#ifdef WAM_C_ENABLE_LMDB
+static int wam_reverse_csr_find_lmdb_offset(WamReverseCsrArtifact *artifact,
+                                            int parent,
+                                            uint64_t *offset_edges,
+                                            uint32_t *child_count) {
+    unsigned char key_bytes[4];
+    MDB_txn *txn = NULL;
+    MDB_val key;
+    MDB_val data;
+    int rc = 0;
+
+    key_bytes[0] = (unsigned char)((uint32_t)parent & 0xffU);
+    key_bytes[1] = (unsigned char)(((uint32_t)parent >> 8) & 0xffU);
+    key_bytes[2] = (unsigned char)(((uint32_t)parent >> 16) & 0xffU);
+    key_bytes[3] = (unsigned char)(((uint32_t)parent >> 24) & 0xffU);
+    key.mv_size = sizeof(key_bytes);
+    key.mv_data = key_bytes;
+
+    rc = mdb_txn_begin(artifact->offset_env, NULL, MDB_RDONLY, &txn);
+    if (rc != MDB_SUCCESS) return -1;
+    rc = mdb_get(txn, artifact->offset_dbi, &key, &data);
+    if (rc == MDB_NOTFOUND) {
+        mdb_txn_abort(txn);
+        return 0;
+    }
+    if (rc != MDB_SUCCESS || data.mv_size != 12) {
+        mdb_txn_abort(txn);
+        return -1;
+    }
+    *offset_edges = wam_read_u64_le((const unsigned char *)data.mv_data);
+    *child_count = wam_read_u32_le(((const unsigned char *)data.mv_data) + 8);
+    mdb_txn_abort(txn);
+    return 1;
+}
+#endif
+
 int wam_reverse_csr_lookup_children(WamReverseCsrArtifact *artifact,
                                     int parent,
                                     int *out_children,
                                     int max_children) {
-    WamReverseCsrRow *row = wam_reverse_csr_find_row(artifact, parent);
-    if (!row) return 0;
+    uint64_t offset_edges = 0;
+    uint32_t child_count = 0;
+
+#ifdef WAM_C_ENABLE_LMDB
+    if (artifact->use_lmdb_offset) {
+        int status = wam_reverse_csr_find_lmdb_offset(artifact, parent, &offset_edges, &child_count);
+        if (status <= 0) return status;
+    } else
+#endif
+    {
+        WamReverseCsrRow *row = wam_reverse_csr_find_row(artifact, parent);
+        if (!row) return 0;
+        offset_edges = row->offset_edges;
+        child_count = row->child_count;
+    }
+
     if (max_children < 0) max_children = 0;
-    if (row->child_count > (uint32_t)INT_MAX) return -1;
-    int total = (int)row->child_count;
+    if (child_count > (uint32_t)INT_MAX) return -1;
+    int total = (int)child_count;
     int to_read = total < max_children ? total : max_children;
     for (int i = 0; i < to_read; i++) {
         unsigned char encoded[4];
-        uint64_t edge_offset = row->offset_edges + (uint64_t)i;
+        uint64_t edge_offset = offset_edges + (uint64_t)i;
         if (edge_offset > (UINT64_MAX / 4ULL)) return -1;
         if (!wam_pread_exact(artifact->values_fd, encoded, sizeof(encoded), (off_t)(edge_offset * 4ULL))) {
             return -1;

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -353,6 +353,7 @@ test_reverse_csr_generation :-
         atom_string(RuntimeCode, S),
         sub_string(S, _, _, _, 'void wam_reverse_csr_init'),
         sub_string(S, _, _, _, 'bool wam_reverse_csr_load'),
+        sub_string(S, _, _, _, 'bool wam_reverse_csr_load_lmdb_offset'),
         sub_string(S, _, _, _, 'int wam_reverse_csr_lookup_children'),
         sub_string(S, _, _, _, 'pread('),
         sub_string(S, _, _, _, 'wam_read_i32_le')
@@ -390,8 +391,10 @@ test_reverse_index_plan_csr_cost_model :-
         ),
         memberchk(index_backend(lmdb_offset), Resolved),
         memberchk(io_policy(buffered_pread_drop), Resolved),
-        memberchk(runtime_child_lookup(unsupported), Capabilities),
-        memberchk(runtime_reason(lmdb_offset_index_not_implemented), Capabilities)
+        memberchk(runtime_child_lookup(available), Capabilities),
+        memberchk(runtime_api(wam_reverse_csr_lookup_children), Capabilities),
+        memberchk(runtime_index_backend(lmdb_offset), Capabilities),
+        memberchk(runtime_requires(wam_c_enable_lmdb), Capabilities)
     ->  pass(Test)
     ;   fail_test(Test, 'CSR options were not normalized through the cost model')
     ).
@@ -417,8 +420,8 @@ test_reverse_index_plan_runtime_available_sorted_array :-
     ;   fail_test(Test, 'runtime sorted-array CSR artifact was not marked available')
     ).
 
-test_reverse_index_plan_runtime_available_lmdb_offset_unsupported :-
-    Test = 'WAM-C: runtime lmdb-offset CSR artifact is still unsupported',
+test_reverse_index_plan_runtime_available_lmdb_offset :-
+    Test = 'WAM-C: runtime lmdb-offset CSR artifact is available with LMDB',
     (   resolve_wam_c_reverse_index_plan(
             [reverse_index(artifact([
                 storage_kind(csr_pread_artifact),
@@ -431,10 +434,11 @@ test_reverse_index_plan_runtime_available_lmdb_offset_unsupported :-
         memberchk(phase(runtime_available), Resolved),
         memberchk(storage_kind(csr_pread_artifact), Resolved),
         memberchk(index_backend(lmdb_offset), Resolved),
-        memberchk(runtime_child_lookup(unsupported), Capabilities),
-        memberchk(runtime_reason(lmdb_offset_index_not_implemented), Capabilities)
+        memberchk(runtime_child_lookup(available), Capabilities),
+        memberchk(runtime_index_backend(lmdb_offset), Capabilities),
+        memberchk(runtime_requires(wam_c_enable_lmdb), Capabilities)
     ->  pass(Test)
-    ;   fail_test(Test, 'runtime lmdb-offset CSR artifact did not stay unsupported')
+    ;   fail_test(Test, 'runtime lmdb-offset CSR artifact was not marked available')
     ).
 
 test_streaming_foreign_results_generation :-
@@ -1208,6 +1212,17 @@ test_reverse_csr_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_reverse_csr_lmdb_offset_executable_smoke :-
+    Test = 'WAM-C: reverse CSR LMDB offset executable smoke',
+    (   gcc_available,
+        lmdb_available
+    ->  (   run_reverse_csr_lmdb_offset_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'reverse CSR LMDB offset executable failed')
+        )
+    ;   format('[PASS] ~w (gcc or lmdb unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_streaming_foreign_results_executable_smoke :-
     Test = 'WAM-C: streaming category_ancestor result executable smoke',
     (   gcc_available
@@ -1747,6 +1762,30 @@ run_reverse_csr_executable_smoke :-
     wam_c_reverse_csr_smoke_main(IndexPath, ValuesPath, MainCode),
     write_text_file(MainPath, MainCode),
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
+run_reverse_csr_lmdb_offset_executable_smoke :-
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_reverse_csr_lmdb_offset_smoke', Stamp, TmpBase),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(ValuesPath), '~w.csr.val', [TmpBase]),
+    format(atom(OffsetEnvPath), '~w.offsets.lmdb', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(RuntimePath, RuntimeCode),
+    write_text_file(PredPath, '#include "wam_runtime.h"\n'),
+    write_binary_file(ValuesPath, [
+        10,0,0,0,
+        12,0,0,0,
+        13,0,0,0,
+        11,0,0,0
+    ]),
+    wam_c_reverse_csr_lmdb_offset_smoke_main(ValuesPath, OffsetEnvPath, MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_lmdb(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
 
 run_kernel_detector_executable_smoke :-
@@ -3726,6 +3765,112 @@ int main(void) {
 }
 ', [IndexPath, ValuesPath]).
 
+wam_c_reverse_csr_lmdb_offset_smoke_main(ValuesPath, OffsetEnvPath, MainCode) :-
+    format(atom(MainCode),
+'#include "wam_runtime.h"
+#include <sys/stat.h>
+
+static void encode_i32(unsigned char *out, int value) {
+    unsigned int v = (unsigned int)value;
+    out[0] = (unsigned char)(v & 0xffU);
+    out[1] = (unsigned char)((v >> 8) & 0xffU);
+    out[2] = (unsigned char)((v >> 16) & 0xffU);
+    out[3] = (unsigned char)((v >> 24) & 0xffU);
+}
+
+static void encode_offset_record(unsigned char *out, unsigned long long offset_edges, unsigned int child_count) {
+    for (int i = 0; i < 8; i++) {
+        out[i] = (unsigned char)((offset_edges >> (8 * i)) & 0xffULL);
+    }
+    out[8] = (unsigned char)(child_count & 0xffU);
+    out[9] = (unsigned char)((child_count >> 8) & 0xffU);
+    out[10] = (unsigned char)((child_count >> 16) & 0xffU);
+    out[11] = (unsigned char)((child_count >> 24) & 0xffU);
+}
+
+static int put_offset(MDB_txn *txn, MDB_dbi dbi, int parent, unsigned long long offset_edges, unsigned int child_count) {
+    unsigned char key_bytes[4];
+    unsigned char data_bytes[12];
+    MDB_val key;
+    MDB_val data;
+    encode_i32(key_bytes, parent);
+    encode_offset_record(data_bytes, offset_edges, child_count);
+    key.mv_size = sizeof(key_bytes);
+    key.mv_data = key_bytes;
+    data.mv_size = sizeof(data_bytes);
+    data.mv_data = data_bytes;
+    return mdb_put(txn, dbi, &key, &data, 0);
+}
+
+static int seed_offsets(const char *path) {
+    MDB_env *env = NULL;
+    MDB_txn *txn = NULL;
+    MDB_dbi dbi = 0;
+    int rc = mkdir(path, 0777);
+    (void)rc;
+    rc = mdb_env_create(&env);
+    if (rc != MDB_SUCCESS) return rc;
+    rc = mdb_env_set_maxdbs(env, 2);
+    if (rc != MDB_SUCCESS) { mdb_env_close(env); return rc; }
+    rc = mdb_env_set_mapsize(env, 1048576);
+    if (rc != MDB_SUCCESS) { mdb_env_close(env); return rc; }
+    rc = mdb_env_open(env, path, 0, 0664);
+    if (rc != MDB_SUCCESS) { mdb_env_close(env); return rc; }
+    rc = mdb_txn_begin(env, NULL, 0, &txn);
+    if (rc != MDB_SUCCESS) { mdb_env_close(env); return rc; }
+    rc = mdb_dbi_open(txn, "offsets", MDB_CREATE, &dbi);
+    if (rc == MDB_SUCCESS) rc = put_offset(txn, dbi, 20, 0, 3);
+    if (rc == MDB_SUCCESS) rc = put_offset(txn, dbi, 30, 3, 1);
+    if (rc == MDB_SUCCESS) rc = mdb_txn_commit(txn);
+    else mdb_txn_abort(txn);
+    mdb_dbi_close(env, dbi);
+    mdb_env_close(env);
+    return rc;
+}
+
+int main(void) {
+    WamReverseCsrArtifact csr;
+    int children[4] = {0, 0, 0, 0};
+    int count = 0;
+
+    if (seed_offsets("~w") != MDB_SUCCESS) return 5;
+
+    wam_reverse_csr_init(&csr);
+    if (!wam_reverse_csr_load_lmdb_offset(&csr, "~w", "~w", "offsets")) {
+        return 10;
+    }
+
+    count = wam_reverse_csr_lookup_children(&csr, 20, children, 4);
+    if (count != 3 || children[0] != 10 || children[1] != 12 || children[2] != 13) {
+        wam_reverse_csr_close(&csr);
+        return 20;
+    }
+
+    children[0] = 0;
+    children[1] = 0;
+    count = wam_reverse_csr_lookup_children(&csr, 20, children, 2);
+    if (count != 3 || children[0] != 10 || children[1] != 12) {
+        wam_reverse_csr_close(&csr);
+        return 30;
+    }
+
+    count = wam_reverse_csr_lookup_children(&csr, 30, children, 4);
+    if (count != 1 || children[0] != 11) {
+        wam_reverse_csr_close(&csr);
+        return 40;
+    }
+
+    count = wam_reverse_csr_lookup_children(&csr, 99, children, 4);
+    if (count != 0) {
+        wam_reverse_csr_close(&csr);
+        return 50;
+    }
+
+    wam_reverse_csr_close(&csr);
+    return 0;
+}
+', [OffsetEnvPath, ValuesPath, OffsetEnvPath]).
+
 wam_c_streaming_foreign_smoke_main(
 '#include "wam_runtime.h"
 
@@ -4547,7 +4692,7 @@ run_tests_once :-
     test_reverse_index_plan_none,
     test_reverse_index_plan_csr_cost_model,
     test_reverse_index_plan_runtime_available_sorted_array,
-    test_reverse_index_plan_runtime_available_lmdb_offset_unsupported,
+    test_reverse_index_plan_runtime_available_lmdb_offset,
     test_streaming_foreign_results_generation,
     test_kernel_detector_setup_generation,
     test_transitive_closure_detector_setup_generation,
@@ -4586,6 +4731,7 @@ run_tests_once :-
     test_fact_source_executable_smoke,
     test_lmdb_fact_source_executable_smoke,
     test_reverse_csr_executable_smoke,
+    test_reverse_csr_lmdb_offset_executable_smoke,
     test_kernel_detector_executable_smoke,
     test_transitive_closure_detector_executable_smoke,
     test_transitive_distance_detector_executable_smoke,


### PR DESCRIPTION
  Adds WAM-C runtime support for the reverse CSR `lmdb_offset` index backend, making the cost-model-selected high-query
  CSR path executable in C when LMDB support is enabled.

  ### Changes

  - Adds `wam_reverse_csr_load_lmdb_offset(...)`.
  - Extends `WamReverseCsrArtifact` with conditional LMDB offset-index state.
  - Reuses `wam_reverse_csr_lookup_children` for both sorted-array and LMDB-offset CSR indexes.
  - Updates WAM-C reverse-index planning metadata so `lmdb_offset` is reported as available when compiled with
  `WAM_C_ENABLE_LMDB`.
  - Adds an executable WAM-C smoke test that seeds a tiny LMDB offset index and reads CSR child values through it.

  ### Verification

  - Focused WAM-C CSR sorted-array and LMDB-offset tests pass.
  - `tests/core/test_cost_model.pl` passes.
  - `git diff --check` passes.