### PR TITLE
Gate runDemandBFSCursor behind demand_bfs_mode_cursor conditional

### DIFF
--- a/docs/SESSION_HASKELL_PARITY_SUMMARY.md
+++ b/docs/SESSION_HASKELL_PARITY_SUMMARY.md
@@ -1,0 +1,42 @@
+# Haskell Hybrid WAM Feature Parity — Session Summary
+
+## Branch: claude/haskell-hybrid-wam-features-Qih27
+
+## PRs shipped (17 total)
+
+| PR | Feature |
+|----|---------|
+| #2509 | Lowered emitter: inline optimizations (get_constant, get_value, put_structure, put_list, set_*, deallocate, cut) + Phase I instructions (PutStructureDyn, Arg, NotMemberList, etc.) |
+| #2510 | ISO error handling: WamException, throw/1, catch/3, is_iso/2, 6 ISO comparison variants, succ variants, isIsoMetaBuiltin routing |
+| #2512 | WAM instructions: GetStructure, GetList, UnifyVariable, UnifyValue, UnifyConstant + ReadArgs builder + pushBuilderIfActive |
+| #2514 | Bidirectional ancestor kernel template (A*-pruned frontier search) |
+| #2517 | CSR reverse-index reader template + codegen wiring (csr_path option) |
+| #2518 | Bidirectional kernel upgrade + CSR auto-resolution |
+| #2519 | Edge store + LMDB materialisation auto-resolvers (6-resolver composed chain) |
+| #2521 | stepST handlers for GetStructure/GetList/Unify* |
+| #2522 | Runtime parser support (compiled prolog_term_parser, 50 predicates) |
+| #2523 | Fix detect_kernels for module-qualified predicates |
+| #2524 | Fix module qualifier stripping in wam_haskell_predicate_wamcode |
+| #2526 | stepST handlers for ISO builtins (15 of 18 native, 3 on pure bridge) |
+| #2527 | CSR benchmark validation test suite (15 tests) |
+| #2528 | Cross-target benchmark script |
+
+## Key technical decisions
+
+- **ISO exceptions**: Haskell uses lazy `throw` (works in pure/ST) + `unsafePerformIO` + `try` for catch/3
+- **Builder state**: Added `ReadArgs ![Value]` + `wsBuilderStack :: ![Builder]` for nested get_structure
+- **CSR reader**: Binary search on in-memory .idx ByteString, positioned Handle reads for .val
+- **Runtime parser**: 45 parser + 4 wrapper predicates appended via haskell_project_predicates/3
+- **stepST ISO**: `throwIsoErrorPure` uses PureWamState bindings; `succLaxST` reads registers directly
+
+## Known issues
+
+- Main.hs always includes LMDB types (MDB_env) even when LMDB isn't used — blocks GHC compilation without lmdb package
+- Runtime parser end-to-end: works but generation takes ~60s for 50 predicates
+- succ_iso/2, throw/1, catch/3 still use pure bridge in stepST (appropriate due to exception semantics)
+
+## Testing verified with
+
+- SWI-Prolog 9.0.4
+- GHC 9.4.7
+- Test suites: Phase 1 (11), Phase 3 (8), Phase 4 (31), ISO (9), CSR (15), parser capability (39)

--- a/templates/targets/haskell_wam/main.hs.mustache
+++ b/templates/targets/haskell_wam/main.hs.mustache
@@ -505,6 +505,7 @@ runDemandBFS spec parents rootId = case spec of
       , dfrFluxScores  = Nothing
       }
 
+{{#demand_bfs_mode_cursor}}
 -- | Phase 2b.3 cursor-mode counterpart of runDemandBFS. Same dispatch
 -- shape but the demand set is computed via LMDB cursor on the
 -- category_child sub-db instead of an in-memory IntMap. No 5M-edge
@@ -529,6 +530,7 @@ runDemandBFSCursor spec env childDbName rootId = case spec of
       , dfrSortedSeeds = Nothing
       , dfrFluxScores  = Nothing
       }
+{{/demand_bfs_mode_cursor}}
 
 -- | Compute the backward-reachable demand set from a root node, with an
 -- optional hop limit. Nothing = unbounded (legacy behaviour). The bound


### PR DESCRIPTION
## Summary

- Wrap `runDemandBFSCursor` function in `main.hs.mustache` with `{{#demand_bfs_mode_cursor}}` conditional so its `MDB_env` type signature is only emitted when LMDB cursor mode is active
- Previously, generated Haskell projects always included this function even with `use_lmdb(false)`, causing GHC compilation to fail due to the missing `MDB_env` type

## Test plan

- [x] Generated project without `use_lmdb`: no `MDB_env` references, compiles clean
- [x] Generated project with `use_lmdb(true)` + `demand_bfs_mode(in_memory)`: `runDemandBFSCursor` correctly omitted
- [x] Generated project with `use_lmdb(true)` + `demand_bfs_mode(cursor)`: `runDemandBFSCursor` correctly present
- [x] Benchmark at 300 scale: generates, compiles with -O2, runs with correct output (272 rows match reference)
- [x] All existing test suites pass: CSR (15/15), ISO (9/9), Phase 4 (31/31)

https://claude.ai/code/session_01NMTuARifW7HDSMhiu7JG5g

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMTuARifW7HDSMhiu7JG5g)_