### PR TITLE
feat(wam-clojure): reverse materialized output

### DIFF
--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -822,7 +822,15 @@
         (if ok
           (advance next-state)
           (backtrack state)))
-      (backtrack state))))
+      (if-let [out-items (proper-list-items state out)]
+        (if (logic-var? list-value)
+          (let [input-term (list->term (:intern-context state) (reverse out-items))
+                [ok next-state] (unify-values state list-value input-term)]
+            (if ok
+              (advance next-state)
+              (backtrack state)))
+          (backtrack state))
+        (backtrack state)))))
 
 (defn apply-last-solution [state]
   (let [list-value (deref-value (:bindings state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -337,7 +337,7 @@ user:wam_append_unbound_left(C) :- user:wam_unbound_arg(A), append(A, [b], C).
 user:wam_append_split(A, B) :- append(A, B, [a,b,c]).
 user:wam_reverse_guard(L, R) :- reverse(L, R).
 user:wam_reverse_bad_list(R) :- reverse([a|b], R).
-user:wam_reverse_unbound_list(R) :- user:wam_unbound_arg(L), reverse(L, R).
+user:wam_reverse_unbound_list(R) :- reverse(L, R), is_list(L).
 user:wam_last_guard(L, X) :- last(L, X).
 user:wam_last_empty(X) :- last([], X).
 user:wam_last_bad_list(X) :- last([a|b], X).
@@ -954,7 +954,8 @@ smoke_cases([
     case('wam_reverse_guard/2', args('[]', '[]'), "true"),
     case('wam_reverse_guard/2', args('[a,b,c]', '[a,b,c]'), "false"),
     case('wam_reverse_bad_list/1', '[b,a]', "false"),
-    case('wam_reverse_unbound_list/1', '[b,a]', "false"),
+    case('wam_reverse_unbound_list/1', '[b,a]', "true"),
+    case('wam_reverse_unbound_list/1', '[a,b]', "true"),
     case('wam_last_guard/2', args('[a,b,c]', c), "true"),
     case('wam_last_guard/2', args('[a]', a), "true"),
     case('wam_last_guard/2', args('[a,b,c]', b), "false"),


### PR DESCRIPTION
## Summary
- Adds bounded materialized-output support for Clojure WAM `reverse/2`.
- Allows `reverse(L, R)` to bind unbound `L` when `R` is already a proper finite list.
- Extends runtime smoke coverage for direct lowerable reverse calls with materialized outputs.

## Why
The Clojure WAM runtime previously handled only forward `reverse/2` from a bound input list. This PR adds the safe reverse direction without introducing unbounded generation: the output must already be a proper materialized list, so the runtime can derive exactly one input list.

## Notes
- This intentionally does not generate arbitrary output lists when both sides are unbound.
- Bad-list behavior remains conservative and unchanged.

## Validation
- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
