### PR TITLE
LLVM WAM lowered emitter: multi-clause via hybrid dispatcher (M3)

### DIFF
--- a/docs/LLVM_TARGET.md
+++ b/docs/LLVM_TARGET.md
@@ -280,10 +280,11 @@ per WAM instruction.
 
 Mirrors `wam_fsharp_lowered_emitter.pl` / `wam_rust_lowered_emitter.pl`:
 
-1. **Single-clause only** — predicates with `try_me_else` /
-   `retry_me_else` / `trust_me` in the bytecode (multi-clause + WAM
-   indexing) are rejected. They stay on the bytecode path where the
-   choice-point machinery handles backtracking.
+1. **Clause-1 body must be deterministic** — `wam_llvm_lowerable/3`
+   strips any `try_me_else` prefix and the leading `switch_on_constant`
+   indexing, then takes the body through the first `proceed`/`fail`
+   as "clause 1". That body must contain no choice-point instructions
+   (`try_me_else` / `retry_me_else` / `trust_me`).
 2. **Supported instructions only** — the supported set is
    `get_constant`, `get_variable`, `get_value`, `get_structure`,
    `get_list`, `unify_variable`, `unify_value`, `unify_constant`,
@@ -292,6 +293,19 @@ Mirrors `wam_fsharp_lowered_emitter.pl` / `wam_rust_lowered_emitter.pl`:
    `deallocate`, `builtin_call`, `proceed`, `fail`. Anything else
    (`call`, `execute`, `jump`, `cut_ite`, etc.) makes the gate fail
    silently and the predicate falls back to the bytecode path.
+
+The lowerability check returns a *shape* the pipeline acts on:
+
+- `single_clause` — bytecode contains no choice-point instrs anywhere;
+  the lowered fn IS the whole predicate. Emitted as a `native` record
+  plus a thin `@<pred>` wrapper that just delegates to
+  `@lowered_<pred>_<arity>`.
+- `multi_clause_c1` — clause 1 is lowerable but the bytecode contains
+  `try_me_else` / `retry_me_else` / `trust_me` for additional clauses.
+  Emitted as a `hybrid` record: the lowered clause-1 fast path AND the
+  full bytecode (all clauses) ship in the module, and `@<pred>` is a
+  dispatcher that tries the fast path first; on failure it falls back
+  to running the full bytecode through `@run_loop`.
 
 Predicates that fail the gate emit a `<pred>/<arity>: WAM fallback`
 log line instead of `<pred>/<arity>: lowered LLVM emission`, and the
@@ -309,19 +323,33 @@ predicate took.
 
 ### Status
 
-- M1: single-clause deterministic predicates over simple
+- **M1**: single-clause deterministic predicates over simple
   register/arithmetic ops.
-- M2 (this release): pattern matching — `get_structure`, `get_list`,
+- **M2**: pattern matching — `get_structure`, `get_list`,
   `unify_variable`, `unify_value`, `unify_constant`. Read-mode
   (matching against a bound compound from the caller) and write-mode
   (allocating a fresh compound on the arena) both supported, mirroring
   the bytecode `@step` cases. `get_list` read-mode currently returns
   the same failure sentinel the bytecode interpreter does — once the
   interpreter gains ground-list read support, this path follows.
-- Future: multi-clause via "lowered clause-1 + bytecode clause-2+"
-  (mirrors the F# emit-mode pattern), `call`/`execute` lowered to
-  direct `call i1 @<other_pred>`, indirect dispatch through a
-  caller-supplied `%WamState*` to avoid the per-call state alloc.
+- **M3 (this release): multi-clause via lowered clause-1 + bytecode
+  fallback**. Predicates whose clause 1 is deterministic + supported
+  but whose full body has additional clauses with `try_me_else` /
+  `retry_me_else` / `trust_me` now lower as a `hybrid` record. The
+  emitted module contains BOTH `@lowered_<pred>_<arity>` (the
+  clause-1 fast path) AND `@<pred>` (a dispatcher that tries the fast
+  path first, then on failure runs the full bytecode through
+  `@run_loop` at the predicate's `StartPC` in `@module_code`).
+  Mirrors the F# target's `dispatchCall` semantics:
+  the lowered clause-1 is a hint, not a replacement — the slow path
+  always handles the full backtracking behaviour. Single-clause
+  predicates also gain a `@<pred>` wrapper around their lowered
+  function so external callers can use the same name across emit
+  modes.
+- Future: `call`/`execute` lowered to direct `call i1 @<other_pred>`
+  so cross-predicate calls within lowered code stay native;
+  caller-supplied `%WamState*` to avoid per-call state alloc when a
+  lowered predicate calls another lowered predicate.
 
 ### Tests
 

--- a/src/unifyweaver/targets/wam_llvm_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_llvm_lowered_emitter.pl
@@ -54,10 +54,14 @@
 %   - proceed, fail
 
 :- module(wam_llvm_lowered_emitter, [
-    wam_llvm_lowerable/3,            % +Pred/Arity, +WamCode, -Reason
+    wam_llvm_lowerable/3,            % +Pred/Arity, +WamCode, -Shape
     lower_predicate_to_llvm/4,       % +Pred/Arity, +WamCode, +Options, -LLVMCode
     is_deterministic_pred_llvm/1,    % +Instrs
-    llvm_lowered_func_name/2         % +Pred/Arity, -LLVMFuncName
+    llvm_lowered_func_name/2,        % +Pred/Arity, -LLVMFuncName
+    clause1_instrs/2,                % +Instrs, -Clause1Body (exported for tests)
+    emit_native_wrapper/2,           % +Pred/Arity, -WrapperCode (M3)
+    emit_hybrid_dispatcher/5         % +Pred/Arity, +StartPC, +InstrCount,
+                                     % +LabelArraySize, -DispatcherCode (M3)
 ]).
 
 :- use_module(library(lists)).
@@ -130,23 +134,88 @@ instr_from_parts(["cut_ite"], cut_ite).
 % Lowerability gate
 % ============================================================================
 
-%% wam_llvm_lowerable(+PI, +WamCode, -Reason) is semidet.
+%% wam_llvm_lowerable(+PI, +WamCode, -Shape) is semidet.
 %
-%  Succeeds iff the predicate is safe to lower to a standalone LLVM
-%  function. Reason is bound to a short tag for logging.
-wam_llvm_lowerable(_PI, WamCode, Reason) :-
+%  Succeeds iff the predicate's *clause-1 body* is safe to lower to a
+%  standalone LLVM function. Shape distinguishes how the dispatcher
+%  should wire it up:
+%
+%    single_clause    — the bytecode has no try_me_else / retry_me_else
+%                       / trust_me anywhere; the lowered function is
+%                       the whole predicate. No bytecode fallback
+%                       needed; the caller's @<pred> wrapper just
+%                       delegates to @lowered_<pred>_<arity>.
+%
+%    multi_clause_c1  — clause 1 is deterministic + supported, but the
+%                       bytecode has try_me_else / retry_me_else /
+%                       trust_me for additional clauses. The lowered
+%                       function is the *fast path*; on failure the
+%                       dispatcher falls back to running the full
+%                       bytecode (all clauses) through @run_loop.
+%                       Mirrors the F# emitter's multi-clause
+%                       approach (see wam_fsharp_lowered_emitter.pl).
+wam_llvm_lowerable(_PI, WamCode, Shape) :-
     (   is_list(WamCode) -> Instrs = WamCode
     ;   atom(WamCode) -> parse_wam_text(WamCode, Instrs)
     ;   parse_wam_text(WamCode, Instrs)
     ),
-    is_deterministic_pred_llvm(Instrs),
-    forall(member(I, Instrs), supported(I)),
-    Reason = deterministic.
+    clause1_instrs(Instrs, C1),
+    is_deterministic_pred_llvm(C1),
+    forall(member(I, C1), supported(I)),
+    ( has_choice_point_instrs(Instrs)
+    -> Shape = multi_clause_c1
+    ;  Shape = single_clause
+    ).
 
 is_deterministic_pred_llvm(Instrs) :-
     \+ member(try_me_else(_), Instrs),
     \+ member(retry_me_else(_), Instrs),
     \+ member(trust_me, Instrs).
+
+%% has_choice_point_instrs(+Instrs) is semidet.
+%
+%  Predicate-level check: does the bytecode contain any choice-point
+%  instructions across all clauses? Used to distinguish single-clause
+%  from multi-clause predicates after clause-1 lowerability passes.
+has_choice_point_instrs(Instrs) :-
+    member(I, Instrs),
+    ( I = try_me_else(_)
+    ; I = retry_me_else(_)
+    ; I = trust_me
+    ), !.
+
+%% clause1_instrs(+Instrs, -Clause1Body) is det.
+%
+%  Extract clause 1's instruction body from a full predicate's parsed
+%  instruction list, mirroring wam_fsharp_lowered_emitter.pl /
+%  wam_rust_lowered_emitter.pl. Strips any switch_on_constant prefix
+%  (multi-clause indexing) and the `try_me_else` first-clause marker;
+%  the body extends through the first `proceed` or `fail` terminator.
+%
+%  For single-clause predicates with no try_me_else, returns the full
+%  instruction list as-is (it IS clause 1).
+clause1_instrs(Instrs0, C1) :-
+    % NB: switch_on_constant / switch_on_constant_a2 instructions are
+    % silently ignored by parse_wam_text/2 (the parser doesn't have an
+    % instr_from_parts/2 clause for them), so the head of Instrs0 here
+    % is whatever follows the switch prefix. The strip_* clauses below
+    % are belt-and-braces in case a future parser change emits these.
+    strip_switch_prefix(Instrs0, Instrs),
+    ( Instrs = [try_me_else(_)|Rest]
+    -> take_to_proceed(Rest, C1)
+    ;  C1 = Instrs
+    ).
+
+strip_switch_prefix([switch_on_constant(_,_,_)|Rest], Out) :- !,
+    strip_switch_prefix(Rest, Out).
+strip_switch_prefix([switch_on_constant_a2(_,_,_)|Rest], Out) :- !,
+    strip_switch_prefix(Rest, Out).
+strip_switch_prefix(L, L).
+
+take_to_proceed([], []).
+take_to_proceed([proceed|_], [proceed]) :- !.
+take_to_proceed([fail|_], [fail]) :- !.
+take_to_proceed([I|Rest], [I|Out]) :- take_to_proceed(Rest, Out).
 
 supported(get_constant(_, _)).
 supported(get_variable(_, _)).
@@ -205,18 +274,24 @@ llvm_safe_code(_, 0'_).
 %% lower_predicate_to_llvm(+PI, +WamCode, +Options, -LLVMCode) is det.
 %
 %  Caller must have already verified wam_llvm_lowerable/3.
+%  Emits a function for *clause 1 only* — for multi-clause predicates,
+%  clauses 2+ are reached via dispatcher fallback to the bytecode path.
 lower_predicate_to_llvm(PI, WamCode, _Options, LLVMCode) :-
     ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     llvm_lowered_func_name(Pred/Arity, FuncName),
     (   is_list(WamCode) -> Instrs = WamCode
     ;   parse_wam_text(WamCode, Instrs)
     ),
+    % Lower the clause-1 body only. For single-clause preds this is
+    % the whole instruction list; for multi-clause preds it's the body
+    % between try_me_else and the first proceed/fail.
+    clause1_instrs(Instrs, C1Instrs),
     % Build the parameter list and the entry-block "copy %a<i> into reg i-1".
     build_param_list(Arity, ParamList),
     build_arg_setup(Arity, ArgSetup),
     % Emit one basic block per instruction, then the shared
     % succeed/fail epilogue blocks.
-    emit_all_instrs(Instrs, 0, BodyBlocks),
+    emit_all_instrs(C1Instrs, 0, BodyBlocks),
     atomic_list_concat(BodyBlocks, '\n', BodyStr),
     format(atom(LLVMCode),
 '; === lowered predicate: ~w/~w ===
@@ -1315,3 +1390,131 @@ parse_functor(FStr, Name, Arity) :-
     split_string(S, "/", "", [NameStr, ArityStr]),
     Name = NameStr,
     number_string(Arity, ArityStr).
+
+% ============================================================================
+% M3: Public-entry wrappers + multi-clause dispatchers
+% ============================================================================
+
+%% emit_native_wrapper(+Pred/Arity, -WrapperCode) is det.
+%
+%  Emits `define i1 @<pred>(%Value %a1, ...)` as a thin wrapper around
+%  the lowered function. Single-clause lowered predicates use this so
+%  external callers can invoke `@<pred>` regardless of emit mode
+%  (unifies the API between emit_mode(interpreter) and
+%  emit_mode(functions) for the same predicate).
+%
+%  Single-arg form (the lowered function returns success/failure with
+%  no extra dispatch logic needed) — at -O2 the wrapper inlines into
+%  the caller's call site.
+emit_native_wrapper(Pred/Arity, WrapperCode) :-
+    atom_string(Pred, PredStr),
+    llvm_lowered_func_name(Pred/Arity, LoweredName),
+    build_param_list(Arity, ParamList),
+    build_arg_list(Arity, ArgList),
+    format(atom(WrapperCode),
+'; Public entry for ~w/~w (M3 native wrapper around the lowered fn).
+; At -O2 this collapses into the caller via inlining.
+define i1 @~w(~w) {
+entry:
+  %r = call i1 @~w(~w)
+  ret i1 %r
+}',
+        [PredStr, Arity,
+         PredStr, ParamList,
+         LoweredName, ArgList]).
+
+%% emit_hybrid_dispatcher(+Pred/Arity, +StartPC, +InstrCount,
+%%                        +LabelArraySize, -DispatcherCode) is det.
+%
+%  Emits the M3 multi-clause dispatcher entry `@<pred>` for predicates
+%  whose clause 1 is lowerable but whose full body contains
+%  try_me_else / retry_me_else / trust_me (so additional clauses need
+%  the bytecode interpreter for backtrack).
+%
+%  Fast path: invoke `@lowered_<pred>_<arity>` first; if it returns
+%  true, return true immediately.
+%
+%  Slow path: on failure, allocate a fresh %WamState, set the input
+%  registers, set the start PC to the predicate's offset in
+%  @module_code, and call @run_loop. This runs the FULL bytecode for
+%  the predicate (all clauses, with proper choice-point management),
+%  matching the F# target's dispatchCall semantics:
+%  the lowered clause-1 is a hint, not a replacement.
+%
+%  Limitation accepted in M3: the fast path doesn't share its
+%  %WamState with the slow path. If clause 1 binds an A-register via
+%  the lowered code and then fails, the slow path starts clean — it
+%  doesn't see clause 1's intermediate bindings. That matches the F#
+%  target's behaviour and is correct for first-arg-indexed predicates
+%  where clause 1 either succeeds deterministically or fails before
+%  any side-effecting binding. Predicates that don't fit that shape
+%  still benefit from the slow path; they just pay a small redundant
+%  cost on the fast-path attempt.
+emit_hybrid_dispatcher(Pred/Arity, StartPC, InstrCount, LabelArraySize,
+                       DispatcherCode) :-
+    atom_string(Pred, PredStr),
+    llvm_lowered_func_name(Pred/Arity, LoweredName),
+    build_param_list(Arity, ParamList),
+    build_arg_list(Arity, ArgList),
+    build_arg_setup_slow(Arity, ArgSetupSlow),
+    format(atom(DispatcherCode),
+'; Public entry for ~w/~w (M3 hybrid dispatcher).
+; Fast path: lowered clause 1 (deterministic + supported instr subset).
+; Slow path on fast-path failure: full bytecode via @run_loop, which
+; handles try_me_else / retry_me_else / trust_me for clauses 2+.
+define i1 @~w(~w) {
+entry:
+  %fast = call i1 @~w(~w)
+  br i1 %fast, label %success, label %slow_path
+
+success:
+  ret i1 true
+
+slow_path:
+  %vm = call %WamState* @wam_state_new(
+    %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @module_code, i32 0, i32 0),
+    i32 ~w,
+    i32* getelementptr ([~w x i32], [~w x i32]* @module_labels, i32 0, i32 0),
+    i32 ~w)
+~w
+  call void @wam_set_pc(%WamState* %vm, i32 ~w)
+  %slow = call i1 @run_loop(%WamState* %vm)
+  call void @wam_state_free(%WamState* %vm)
+  ret i1 %slow
+}',
+        [PredStr, Arity,
+         PredStr, ParamList,
+         LoweredName, ArgList,
+         InstrCount, InstrCount,
+         InstrCount,
+         LabelArraySize, LabelArraySize,
+         LabelArraySize,
+         ArgSetupSlow,
+         StartPC]).
+
+%% build_arg_list(+Arity, -ArgList)
+%
+%  Comma-separated list "%Value %a1, %Value %a2, ..." used at the
+%  call sites in the native wrapper and hybrid dispatcher (where the
+%  callee expects the same %Value parameters the entry received).
+build_arg_list(0, "") :- !.
+build_arg_list(Arity, ArgList) :-
+    numlist(1, Arity, Indices),
+    maplist([I, S]>>format(atom(S), "%Value %a~w", [I]), Indices, Parts),
+    atomic_list_concat(Parts, ', ', ArgList).
+
+%% build_arg_setup_slow(+Arity, -SetupIR)
+%
+%  Mirror of build_arg_setup/2 but emitted into the hybrid dispatcher's
+%  slow_path block — copies each %Value %a<i> into the fresh
+%  %WamState's argument register i-1 before calling @run_loop.
+build_arg_setup_slow(0, "") :- !.
+build_arg_setup_slow(Arity, Setup) :-
+    numlist(1, Arity, Indices),
+    maplist([I, S]>>(
+        RegIdx is I - 1,
+        format(atom(S),
+            '  call void @wam_set_reg(%WamState* %vm, i32 ~w, %Value %a~w)',
+            [RegIdx, I])
+    ), Indices, Parts),
+    atomic_list_concat(Parts, '\n', Setup).

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -53,7 +53,9 @@
 :- use_module(wam_llvm_lowered_emitter, [
     wam_llvm_lowerable/3,
     lower_predicate_to_llvm/4,
-    llvm_lowered_func_name/2
+    llvm_lowered_func_name/2,
+    emit_native_wrapper/2,
+    emit_hybrid_dispatcher/5
 ]).
 
 :- discontiguous wam_llvm_case/2.
@@ -1494,14 +1496,25 @@ compile_predicates_for_llvm(Predicates, Options, NativeCode, WamCode) :-
 %
 %  Classified is a list of records (in input order):
 %    native(PredIndicator, Arity, PredCode)
-%       — native-lowered; emit PredCode as-is.
+%       — native-lowered (legacy llvm_target.pl or single-clause
+%         wam_llvm_lowered_emitter); emit PredCode as-is. PredCode
+%         already includes the `@<pred>` public-entry wrapper.
 %    wam(PredIndicator, Arity, RawInstrs, LocalLabels, StartPC, NumInstrs)
 %       — wam-fallback or foreign-kernel; goes into merged code.
+%         Public entry `@<pred>` is emitted by emit_one_entry_func.
+%    hybrid(PredIndicator, Arity, LoweredCode, RawInstrs, LocalLabels,
+%           StartPC, NumInstrs)
+%       — multi-clause predicate whose clause 1 is lowerable (M3).
+%         LoweredCode is the `@lowered_<pred>_<arity>` clause-1 fast
+%         path. The full bytecode (all clauses) goes into merged
+%         @module_code at StartPC. Public entry `@<pred>` is emitted
+%         by emit_hybrid_dispatcher and tries the fast path first,
+%         then falls back to @run_loop at StartPC on failure.
 %    failed(PredIndicator, Arity)
 %       — both native + wam failed; emit a comment.
 %
-%  StartPC threads through wam/foreign records only; native/failed do
-%  not consume code slots.
+%  StartPC threads through wam/foreign/hybrid records only; native
+%  and failed do not consume code slots.
 pass1_classify_predicates([], _, _, []).
 pass1_classify_predicates([PredIndicator|Rest], Options, StartPC,
                           [Record | RestRecs]) :-
@@ -1519,24 +1532,28 @@ pass1_classify_predicates([PredIndicator|Rest], Options, StartPC,
     ->  format(user_error, '  ~w/~w: native lowering~n', [Pred, Arity]),
         Record = native(PredIndicator, Arity, PredCode),
         NextPC = StartPC
-    ;   % WAM-lowered LLVM emission (PR #N — wam_llvm_lowered_emitter).
+    ;   % WAM-lowered LLVM emission (wam_llvm_lowered_emitter).
         %
         % Gate: opt-in via emit_mode(Mode), where Mode is one of:
         %   functions          — try to lower every predicate
         %   mixed([P/A, ...])  — try to lower only the listed predicates
         %   interpreter        — never lower (default; matches prior behaviour)
         %
-        % If lowering succeeds, the predicate ships as a standalone
-        % LLVM function with the WAM instruction sequence inlined as
-        % straight-line basic blocks. No %Instruction array, no @step
-        % switch dispatch, no @run_loop trampoline for this predicate.
+        % Shape (returned by wam_llvm_lowerable/3):
+        %   single_clause   — full body is the lowered fn; no bytecode
+        %                     needed. Classify as Native; PredCode
+        %                     bundles the lowered fn + @<pred> wrapper.
+        %   multi_clause_c1 — clause 1 lowered as a fast path; full
+        %                     bytecode also emitted into @module_code
+        %                     so the dispatcher's slow path can run
+        %                     all clauses. Classify as Hybrid.
         emit_mode_allows_lowering(Module:Pred/Arity, Options),
         catch(
             wam_target:compile_predicate_to_wam(Module:Pred/Arity,
                 Options, LowerWamRaw),
             _, fail),
         catch(
-            wam_llvm_lowerable(Pred/Arity, LowerWamRaw, _LowerReason),
+            wam_llvm_lowerable(Pred/Arity, LowerWamRaw, LowerShape),
             _, fail)
     ->  catch(
             lower_predicate_to_llvm(Pred/Arity, LowerWamRaw,
@@ -1547,10 +1564,35 @@ pass1_classify_predicates([PredIndicator|Rest], Options, StartPC,
                 [Pred, Arity, LowerErr]),
               fail
             )),
-        format(user_error, '  ~w/~w: lowered LLVM emission~n',
+        ( LowerShape == single_clause
+        -> format(user_error,
+            '  ~w/~w: lowered LLVM emission (single-clause)~n',
             [Pred, Arity]),
-        Record = native(PredIndicator, Arity, LoweredCode),
-        NextPC = StartPC
+           % Pack the lowered fn + thin @<pred> wrapper into one PredCode
+           % blob so the existing Native record path emits everything.
+           emit_native_wrapper(Pred/Arity, NativeWrapper),
+           atomic_list_concat([LoweredCode, '\n\n', NativeWrapper],
+               BundledCode),
+           Record = native(PredIndicator, Arity, BundledCode),
+           NextPC = StartPC
+        ;  LowerShape == multi_clause_c1
+        -> format(user_error,
+            '  ~w/~w: lowered LLVM emission (hybrid clause-1 + bytecode)~n',
+            [Pred, Arity]),
+           % Parse the WAM bytecode (all clauses) into the merge so the
+           % dispatcher's slow path can run it. The dispatcher entry
+           % is emitted in pass2 via emit_hybrid_dispatcher.
+           %
+           % Hybrid records use the bare Pred/Arity form (matching the
+           % wam-record convention) so partition / resolve / dispatch
+           % helpers can pattern-match the indicator uniformly.
+           parse_wam_to_pass1(Pred/Arity, LowerWamRaw, Arity, StartPC,
+               wam(Pred/Arity, _, RawInstrs, LocalLabels, StartPC, NumInstrs),
+               NumInstrs),
+           Record = hybrid(Pred/Arity, Arity, LoweredCode,
+               RawInstrs, LocalLabels, StartPC, NumInstrs),
+           NextPC is StartPC + NumInstrs
+        )
     ;   option(wam_fallback(WamFB), Options, true),
         WamFB \== false,
         catch(
@@ -1624,6 +1666,11 @@ build_merged_labels_entries([wam(_, _, _, LocalLabels, StartPC, _)|Rest],
     shift_labels(LocalLabels, StartPC, Shifted),
     build_merged_labels_entries(Rest, RestEntries),
     append(Shifted, RestEntries, Entries).
+build_merged_labels_entries([hybrid(_, _, _, _, LocalLabels, StartPC, _)|Rest],
+                            Entries) :- !,
+    shift_labels(LocalLabels, StartPC, Shifted),
+    build_merged_labels_entries(Rest, RestEntries),
+    append(Shifted, RestEntries, Entries).
 build_merged_labels_entries([_|Rest], Entries) :-
     build_merged_labels_entries(Rest, Entries).
 
@@ -1643,11 +1690,25 @@ shift_labels([Name-LocalPC|Rest], Shift, [Name-GlobalPC|RestShifted]) :-
 %  All of these go into WamParts.
 pass2_emit_merged(Classified, LabelMap, NamePCPairs, Options,
                   NativeParts, WamParts) :-
-    partition_classified(Classified, NativeRecords, WamRecords, FailedRecords),
-    maplist([native(_,_,Code), Code]>>true, NativeRecords, NativeParts),
-    (   WamRecords == []
+    partition_classified(Classified,
+        NativeRecords, WamRecords, HybridRecords, FailedRecords),
+    % Native records' PredCode already includes both the lowered
+    % function AND the @<pred> wrapper. Hybrid records contribute
+    % their LoweredCode (just the @lowered_*_* fn); the matching
+    % @<pred> dispatcher is emitted in the WAM entry-funcs section
+    % because it needs InstrCount/LabelCount/StartPC.
+    maplist([native(_,_,Code), Code]>>true, NativeRecords, NativeCodes),
+    maplist([hybrid(_,_,LC,_,_,_,_), LC]>>true,
+            HybridRecords, HybridLowered),
+    append(NativeCodes, HybridLowered, NativeParts),
+    % WAM-like records (wam + hybrid) all participate in the merged
+    % @module_code. Their entry funcs differ — emit_one_entry_func
+    % vs emit_hybrid_dispatcher — dispatched on record type by
+    % emit_one_record_entry_func/5 inside emit_all_entry_funcs.
+    append(WamRecords, HybridRecords, WamLikeRecords),
+    (   WamLikeRecords == []
     ->  MergedCode = '', EntryFuncs = '', SwitchDefs = ''
-    ;   emit_merged_wam_section(WamRecords, LabelMap, NamePCPairs, Options,
+    ;   emit_merged_wam_section(WamLikeRecords, LabelMap, NamePCPairs, Options,
                                 MergedCode, EntryFuncs, SwitchDefs)
     ),
     maplist([failed(PI,A), C]>>format(atom(C),
@@ -1656,13 +1717,16 @@ pass2_emit_merged(Classified, LabelMap, NamePCPairs, Options,
     WamParts0 = [SwitchDefs, MergedCode, EntryFuncs | FailedComments],
     exclude(==(''), WamParts0, WamParts).
 
-partition_classified([], [], [], []).
-partition_classified([native(PI,A,C)|Rest], [native(PI,A,C)|RN], RW, RF) :- !,
-    partition_classified(Rest, RN, RW, RF).
-partition_classified([wam(P,A,I,L,S,N)|Rest], RN, [wam(P,A,I,L,S,N)|RW], RF) :- !,
-    partition_classified(Rest, RN, RW, RF).
-partition_classified([failed(PI,A)|Rest], RN, RW, [failed(PI,A)|RF]) :-
-    partition_classified(Rest, RN, RW, RF).
+partition_classified([], [], [], [], []).
+partition_classified([native(PI,A,C)|Rest], [native(PI,A,C)|RN], RW, RH, RF) :- !,
+    partition_classified(Rest, RN, RW, RH, RF).
+partition_classified([wam(P,A,I,L,S,N)|Rest], RN, [wam(P,A,I,L,S,N)|RW], RH, RF) :- !,
+    partition_classified(Rest, RN, RW, RH, RF).
+partition_classified([hybrid(P,A,LC,I,L,S,N)|Rest], RN, RW,
+                     [hybrid(P,A,LC,I,L,S,N)|RH], RF) :- !,
+    partition_classified(Rest, RN, RW, RH, RF).
+partition_classified([failed(PI,A)|Rest], RN, RW, RH, [failed(PI,A)|RF]) :-
+    partition_classified(Rest, RN, RW, RH, RF).
 
 %% emit_merged_wam_section(+WamRecords, +GlobalLabels, +Options,
 %%                         -CodeGlobal, -EntryFuncs, -SwitchDefs)
@@ -1719,7 +1783,20 @@ emit_merged_wam_section(WamRecords, LabelMap, NamePCPairs, Options,
 %  names are predicate-qualified so flattening doesn't collide.
 resolve_all_wam_records([], _, [], []).
 resolve_all_wam_records([wam(Pred/_Arity, _, RawInstrs, _, _, _)|Rest],
-                        GlobalLabels, AllLiterals, AllSwitchDefs) :-
+                        GlobalLabels, AllLiterals, AllSwitchDefs) :- !,
+    atom_string(Pred, PredStr),
+    maplist(resolve_llvm_literal(GlobalLabels), RawInstrs, Literals0),
+    resolve_switch_tables(Literals0, PredStr, 0, ResolvedLits, SwitchDefs),
+    resolve_all_wam_records(Rest, GlobalLabels, RestLits, RestDefs),
+    append(ResolvedLits, RestLits, AllLiterals),
+    append(SwitchDefs, RestDefs, AllSwitchDefs).
+resolve_all_wam_records([hybrid(Pred/_Arity, _, _, RawInstrs, _, _, _)|Rest],
+                        GlobalLabels, AllLiterals, AllSwitchDefs) :- !,
+    % Hybrid records (M3) participate in the merged @module_code on
+    % equal footing with pure wam records — same resolution pass over
+    % their RawInstrs, same per-predicate switch-table namespace.
+    % The dispatcher entry (which uses the merged PC) is emitted by
+    % emit_one_record_entry_func/5, not here.
     atom_string(Pred, PredStr),
     maplist(resolve_llvm_literal(GlobalLabels), RawInstrs, Literals0),
     resolve_switch_tables(Literals0, PredStr, 0, ResolvedLits, SwitchDefs),
@@ -1733,11 +1810,28 @@ resolve_all_wam_records([wam(Pred/_Arity, _, RawInstrs, _, _, _)|Rest],
 %  One `define i1 @<pred>(...)` per wam/foreign predicate. All share
 %  @module_code and @module_labels, setting PC = StartPC before
 %  invoking the run loop.
-emit_all_entry_funcs(WamRecords, _Options, InstrCount, LabelCount,
+emit_all_entry_funcs(WamLikeRecords, _Options, InstrCount, LabelCount,
                      LabelArraySize, EntryFuncs) :-
-    maplist(emit_one_entry_func(InstrCount, LabelCount, LabelArraySize),
-            WamRecords, Funcs),
+    maplist(emit_one_record_entry_func(InstrCount, LabelCount, LabelArraySize),
+            WamLikeRecords, Funcs),
     atomic_list_concat(Funcs, '\n\n', EntryFuncs).
+
+%% emit_one_record_entry_func(+IC, +LC, +LAS, +Record, -Func)
+%
+%  Dispatcher: wam records use the standard entry-func shape;
+%  hybrid records (M3) get the fast-path-plus-slow-path dispatcher
+%  from the lowered emitter.
+emit_one_record_entry_func(InstrCount, LabelCount, LabelArraySize,
+                           wam(Pred/Arity, _, _, _, StartPC, _),
+                           Func) :- !,
+    emit_one_entry_func(InstrCount, LabelCount, LabelArraySize,
+                        wam(Pred/Arity, _, _, _, StartPC, _),
+                        Func).
+emit_one_record_entry_func(InstrCount, _LabelCount, LabelArraySize,
+                           hybrid(Pred/Arity, _, _, _, _, StartPC, _),
+                           Func) :- !,
+    emit_hybrid_dispatcher(Pred/Arity, StartPC,
+                           InstrCount, LabelArraySize, Func).
 
 emit_one_entry_func(InstrCount, LabelCount, LabelArraySize,
                     wam(Pred/Arity, _, _, _, StartPC, _),

--- a/tests/core/test_wam_llvm_lowered_emitter.pl
+++ b/tests/core/test_wam_llvm_lowered_emitter.pl
@@ -86,26 +86,38 @@ host_target_triple(Triple) :-
 
 test_lowerability :-
     format('--- lowerability gate ---~n'),
-    % Single-clause deterministic predicates should lower. The first 4
-    % are simple register/builtin shapes (added in PR M1); the latter 3
-    % exercise the pattern-matching extension (get_structure / get_list
-    % / unify_variable / unify_constant).
+    % Single-clause deterministic predicates lower as single_clause.
+    % The first 4 are simple register/builtin shapes (M1); the latter
+    % 3 exercise the pattern-matching extension (M2 — get_structure /
+    % get_list / unify_variable / unify_constant).
     forall(member(PI,
                   [lw_const/2, lw_unify/2, lw_add/2, lw_multi/2,
                    lw_pair_first/2, lw_head/2, lw_lit_pair/1]),
         ( compile_predicate_to_wam(user:PI, [], Wam),
-          ( wam_llvm_lowerable(PI, Wam, R)
-          -> format('  PASS: ~w lowerable (~w)~n', [PI, R])
+          ( wam_llvm_lowerable(PI, Wam, Shape)
+          -> ( Shape == single_clause
+             -> format('  PASS: ~w lowerable (single_clause)~n', [PI])
+             ;  format('  FAIL: ~w expected single_clause shape, got ~w~n',
+                       [PI, Shape]),
+                throw(unexpected_shape(PI, Shape))
+             )
           ;  format('  FAIL: ~w should be lowerable~n', [PI]),
              throw(unexpected_unlowerable(PI))
           )
         )),
-    % Multi-clause should NOT lower (try_me_else present).
+    % Multi-clause first-arg-indexed predicates are now lowerable as
+    % multi_clause_c1 (M3) — clause 1 becomes the fast path, the full
+    % bytecode handles clauses 2+ via the dispatcher's slow path.
     compile_predicate_to_wam(user:lw_choice/2, [], MultiWam),
-    ( wam_llvm_lowerable(lw_choice/2, MultiWam, _)
-    -> format('  FAIL: lw_choice/2 should NOT be lowerable (multi-clause)~n'),
-       throw(unexpected_lowerable(lw_choice/2))
-    ;  format('  PASS: lw_choice/2 correctly rejected (multi-clause)~n')
+    ( wam_llvm_lowerable(lw_choice/2, MultiWam, MultiShape)
+    -> ( MultiShape == multi_clause_c1
+       -> format('  PASS: lw_choice/2 lowerable (multi_clause_c1)~n')
+       ;  format('  FAIL: lw_choice/2 expected multi_clause_c1, got ~w~n',
+                 [MultiShape]),
+          throw(unexpected_shape(lw_choice/2, MultiShape))
+       )
+    ;  format('  FAIL: lw_choice/2 should be lowerable as multi_clause_c1~n'),
+       throw(unexpected_unlowerable(lw_choice/2))
     ).
 
 % ============================================================================
@@ -151,12 +163,19 @@ test_ir_structure :-
     -> format('  PASS: lowered lw_lit_pair_1 (unify_constant path)~n')
     ;  throw(missing_lowered(lw_lit_pair_1))
     ),
-    % lw_choice/2 is multi-clause → must fall back to WAM bytecode path,
-    % so its `@lw_choice` entry is the WAM entry func, NOT a lowered one.
+    % lw_choice/2 is multi-clause → under M3 it gets BOTH a lowered
+    % clause-1 fast path AND a hybrid dispatcher @lw_choice that
+    % falls back to the full bytecode on failure. Verify both
+    % symbols are present.
     ( sub_string(Src, _, _, _, "define i1 @lowered_lw_choice_2")
-    -> format('  FAIL: lw_choice/2 should NOT have lowered emission~n'),
-       throw(unexpected_lowered_emission(lw_choice_2))
-    ;  format('  PASS: lw_choice_2 correctly stays on bytecode path~n')
+    -> format('  PASS: hybrid lowered_lw_choice_2 fast-path present~n')
+    ;  format('  FAIL: hybrid lowered_lw_choice_2 missing~n'),
+       throw(missing_hybrid_fast(lw_choice_2))
+    ),
+    ( sub_string(Src, _, _, _, "M3 hybrid dispatcher")
+    -> format('  PASS: hybrid dispatcher @lw_choice present~n')
+    ;  format('  FAIL: hybrid dispatcher @lw_choice missing~n'),
+       throw(missing_hybrid_dispatcher(lw_choice_2))
     ),
     catch(delete_file(LLPath), _, true),
     clear_llvm_foreign_kernel_specs.
@@ -276,7 +295,78 @@ test_execution :-
     % which is already covered indirectly by the wider regression suite.
     run_exec_test(lw_pair_first, 6, 0),
     run_exec_test(lw_head, 6, 0),
-    test_exec_unary(lw_lit_pair, 6, 0).
+    test_exec_unary(lw_lit_pair, 6, 0),
+    % --- M3 hybrid dispatcher coverage ---
+    %
+    % lw_choice/2 has 3 clauses indexed on A1. Calling the dispatcher
+    % `@lw_choice` (the public entry) with each A1 value verifies:
+    %
+    %   A1 = 1 → fast path (lowered clause 1) hits, returns true.
+    %   A1 = 2 → fast path fails on `get_constant 1, A1` mismatch;
+    %            slow path runs full bytecode, clause 2 succeeds.
+    %   A1 = 3 → same as A1=2 but clause 3 succeeds in the slow path.
+    %   A1 = 9 → both paths fail (no matching clause), returns false.
+    %
+    % `run_exec_test_pred/4` calls the public entry `@<pred>` directly
+    % (not @lowered_*), which is what external WAM users do.
+    test_hybrid_dispatch(lw_choice, 1, 1, success),
+    test_hybrid_dispatch(lw_choice, 2, 1, success),
+    test_hybrid_dispatch(lw_choice, 3, 1, success),
+    test_hybrid_dispatch(lw_choice, 9, 1, failure).
+
+%% test_hybrid_dispatch(+Pred, +A1Value, +A1Tag, +Expected)
+%
+%  Compile a hybrid predicate and call its public entry `@<pred>` with
+%  the given A1 (passing A2 as unbound). Expected ∈ {success, failure}.
+test_hybrid_dispatch(Pred, A1Val, A1Tag, Expected) :-
+    format('  hybrid dispatch ~w(~w, _) → ~w...~n', [Pred, A1Val, Expected]),
+    clear_llvm_foreign_kernel_specs,
+    tmp_file_stream(text, LLPath, S0), close(S0),
+    host_target_triple(Triple),
+    write_wam_llvm_project(
+        [user:Pred/2],
+        [ module_name('lwhybrid'),
+          target_triple(Triple),
+          target_datalayout(''),
+          emit_mode(functions)
+        ],
+        LLPath),
+    atom_string(Pred, PredStr),
+    ( Expected == success -> ExpectedExit = 0 ; ExpectedExit = 1 ),
+    format(atom(DriverIR),
+'define i32 @main() {
+entry:
+  %a1_0 = insertvalue %Value undef, i32 ~w, 0
+  %a1 = insertvalue %Value %a1_0, i64 ~w, 1
+  %a2_0 = insertvalue %Value undef, i32 6, 0
+  %a2 = insertvalue %Value %a2_0, i64 0, 1
+  %ok = call i1 @~w(%Value %a1, %Value %a2)
+  %ret = select i1 %ok, i32 0, i32 1
+  ret i32 %ret
+}
+', [A1Tag, A1Val, PredStr]),
+    setup_call_cleanup(open(LLPath, append, Out),
+        ( write(Out, '\n'), write(Out, DriverIR) ), close(Out)),
+    atom_concat(LLPath, '.o', OPath),
+    atom_concat(LLPath, '.out', BinPath),
+    format(atom(LlcCmd),
+        'llc -O2 -filetype=obj -relocation-model=pic ~w -o ~w 2>/dev/null',
+        [LLPath, OPath]),
+    shell(LlcCmd, _),
+    format(atom(ClangCmd), 'clang -O2 ~w -o ~w 2>/dev/null', [OPath, BinPath]),
+    shell(ClangCmd, _),
+    shell(BinPath, RunExit),
+    ( RunExit =:= ExpectedExit
+    -> format('    PASS: @~w(~w, _) → ~w (exit=~w)~n',
+              [Pred, A1Val, Expected, RunExit])
+    ;  format('    FAIL: @~w(~w, _) expected exit=~w, got ~w~n',
+              [Pred, A1Val, ExpectedExit, RunExit]),
+       throw(hybrid_dispatch_failed(Pred, A1Val, Expected, RunExit))
+    ),
+    catch(delete_file(LLPath), _, true),
+    catch(delete_file(OPath), _, true),
+    catch(delete_file(BinPath), _, true),
+    clear_llvm_foreign_kernel_specs.
 
 % Same as run_exec_test but for 1-arity preds.
 test_exec_unary(PredAtom, A1Tag, A1Pay) :-


### PR DESCRIPTION
## Summary

Predicates whose clause 1 is deterministic + supported but whose full body has additional clauses (`try_me_else` / `retry_me_else` / `trust_me`) now lower as a **hybrid record**. The emitted module contains BOTH:

- `@lowered_<pred>_<arity>` — the **clause-1 fast path** (straight-line basic blocks, no `@step` switch dispatch)
- `@<pred>` — a **dispatcher** that tries the fast path first; on failure runs the full bytecode (all clauses) through `@run_loop` at the predicate's `StartPC` in `@module_code`

Mirrors the F# target's `dispatchCall` semantics: the lowered clause 1 is a hint, not a replacement — the slow path always handles full backtracking.

Single-clause lowered predicates also gain a `@<pred>` thin wrapper around their `@lowered_*_*` function so external callers can use the same name across emit modes.

### Why this matters

Closes the second-largest gap between the WAM-LLVM target and the other WAM targets' lowered emitters (F#, Haskell, Lua, Rust). Real-world predicates are usually multi-clause for first-arg indexing (`lookup(1,a). lookup(2,b). lookup(3,c).`); before this PR those fell through the gate entirely. Now they get the fast-path benefit on the common clause-1 hit.

## Implementation

### `wam_llvm_lowered_emitter.pl`

| Change | Purpose |
| --- | --- |
| `wam_llvm_lowerable/3` returns a *Shape* (`single_clause` \| `multi_clause_c1`) | The pipeline acts on shape, not just lowerable-yes/no. |
| `clause1_instrs/2` (exported) | Strips `switch_on_constant` prefix and `try_me_else` marker, takes body through first `proceed`/`fail`. Mirrors `wam_fsharp_lowered_emitter`. |
| `lower_predicate_to_llvm/4` emits clause-1 body only | Was the whole instruction list. |
| `emit_native_wrapper/2` (new) | Thin `@<pred>` → `@lowered_*_*` wrapper for single-clause records. |
| `emit_hybrid_dispatcher/5` (new) | Fast-path-plus-slow-path dispatcher for `multi_clause_c1` records. |

### `wam_llvm_target.pl`

- New 7-arg record type: `hybrid(PI, Arity, LoweredCode, RawInstrs, LocalLabels, StartPC, NumInstrs)`.
- `pass1_classify_predicates` routes:
  - `single_clause` → `native` record (lowered fn + thin wrapper bundled into PredCode)
  - `multi_clause_c1` → `hybrid` record (lowered fn + full bytecode in @module_code + dispatcher in entry-funcs section)
- `partition_classified/5` (was `/4`) separates hybrid records.
- `build_merged_labels_entries`, `resolve_all_wam_records` handle hybrid records (their labels and raw instrs join the merge on equal footing with wam records).
- `emit_one_record_entry_func/5` dispatches on record type — wam → `emit_one_entry_func` (existing), hybrid → `emit_hybrid_dispatcher`.

## Test plan

- [x] **Lowerability gate** — 7 single-clause preds correctly classified as `single_clause`; `lw_choice/2` (3-clause first-arg-indexed) correctly classified as `multi_clause_c1`.
- [x] **IR structure** — `lw_choice/2` produces BOTH `@lowered_lw_choice_2` AND a `M3 hybrid dispatcher` `@lw_choice` in the emitted module.
- [x] **`llvm-as` validation** — accepts the 7-predicate combined module (`lw_const`/`lw_unify`/`lw_add`/`lw_multi`/`lw_pair_first`/`lw_head`/`lw_lit_pair`).
- [x] **End-to-end execution (single-clause)** — each of the 7 single-clause preds compiles via `llc -O2 + clang -O2` and returns success at runtime.
- [x] **NEW: hybrid dispatcher execution** — for `lw_choice/2`:

  | call | route | exit | result |
  | --- | --- | ---: | --- |
  | `@lw_choice(1, _)` | fast path hits | 0 | success |
  | `@lw_choice(2, _)` | fast path fails (`get_constant 1, A1` mismatch); slow path runs full bytecode, clause 2 succeeds | 0 | success |
  | `@lw_choice(3, _)` | same as above, clause 3 succeeds | 0 | success |
  | `@lw_choice(9, _)` | both paths fail | 1 | failure |

- [x] **Full LLVM regression sweep** (15 core tests) — all stay green; default-mode codegen unchanged.

## Status flow

- M1 (#2540): register/arithmetic ops
- M2 (#2542): compound-term + list pattern matching
- **M3 (this PR): multi-clause via hybrid dispatcher**
- Future: direct `call`/`execute` lowering with shared `%WamState*` to avoid per-call state alloc when a lowered predicate calls another lowered predicate.

## File summary

| File | Δ | Purpose |
| --- | ---: | --- |
| `src/unifyweaver/targets/wam_llvm_lowered_emitter.pl` | +223 | Shape return, `clause1_instrs`, native wrapper + hybrid dispatcher emitters |
| `src/unifyweaver/targets/wam_llvm_target.pl` | +120/-30 | Hybrid record type, classification routing, partition + label-merge + entry-func dispatch |
| `tests/core/test_wam_llvm_lowered_emitter.pl` | +124 | Shape-aware gate test, hybrid IR check, M3 dispatcher execution coverage |
| `docs/LLVM_TARGET.md` | +38/-15 | Updated gate explanation, status |

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_