### PR TITLE
LLVM WAM: growable trail / stack / choice-point allocators (M5)

### DIFF
--- a/docs/LLVM_TARGET.md
+++ b/docs/LLVM_TARGET.md
@@ -368,9 +368,28 @@ predicate took.
   the set of mutually-call-resolvable preds before classification,
   so the emitter can confidently emit direct calls knowing the
   symbols will resolve at link time.
-- Future: trail-rollback between fast and slow paths in the hybrid
-  dispatcher so clause-1 partial bindings don't leak into the slow
-  path; cross-module closure when LTO is available.
+- **M5 (this release): growable trail, stack, and choice-point
+  allocators**. `wam_state_new` still mallocs the initial buffers
+  (trail 65536 entries, CPs 1024, stack 1024) but `wam_trail_binding`,
+  `wam_trail_heap_binding`, the stack push helpers
+  (`wam_push_unify_ctx`, `wam_push_write_ctx`, the `allocate` @step
+  case, the lowered emitter's allocate), and the CP push sites
+  (`try_me_else`, `begin_aggregate`, `wam_push_foreign_choice_point`)
+  now route through `wam_<area>_ensure_capacity` helpers that double
+  the buffer via `realloc` when at cap. Choice points hold trail
+  marks and heap-top as indices (not pointers), so trail / CP grow
+  is transparent to backtrack; stack grow only moves the stack
+  buffer (the heap-pointed-to data in WriteCtx remains valid
+  because this PR does not grow the heap). The pre-M5 code aborted
+  via `exit(4)` on trail overflow and silently wrote past the end
+  of the stack / CP buffers on those — both are now growth events
+  the runtime handles transparently. A 200k-iteration stress test
+  forces the trail to grow from 65k → ~1M entries and completes in
+  ~95 ms.
+- Future: heap grow (requires a WriteCtx `data` field rework so
+  args pointers survive `realloc`); trail-rollback between fast
+  and slow paths in the hybrid dispatcher; cross-module closure
+  when LTO is available.
 
 ### Tests
 

--- a/src/unifyweaver/targets/wam_llvm_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_llvm_lowered_emitter.pl
@@ -773,6 +773,7 @@ emit_instr(set_variable(XnStr), N, Next, Block) :- !,
 emit_instr(allocate, N, Next, Block) :- !,
     format(atom(L0), 'pc_~w:', [N]),
     L1 = '  ; allocate (env frame push: type=0, save CP, snapshot regs[16..63])',
+    L_ensure = '  call void @wam_stack_ensure_capacity(%WamState* %vm)',
     format(atom(L2),
 '  %al.~w.ss_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 3',
         [N]),
@@ -830,7 +831,7 @@ emit_instr(allocate, N, Next, Block) :- !,
         [N, N]),
     format(atom(L21), '  br label %~w', [Next]),
     atomic_list_concat(
-        [L0, L1, L2, L3, L4, L5, L6, L7, L8, L9, L10,
+        [L0, L1, L_ensure, L2, L3, L4, L5, L6, L7, L8, L9, L10,
          L11, L12, L13, L14, L15, L16, L17, L18, L19, L20, L21],
         '\n', Block).
 

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1325,6 +1325,34 @@ define void @free(i8* %ptr) {
   ret void
 }
 
+; Bump-allocator @realloc for WASM: allocate fresh, memcpy old data,
+; return new ptr. Old block is leaked (the bump allocator has no
+; freelist). Used by M5 growable trail/stack/CP allocators.
+;
+; Note: this doesn\'t know the old block\'s size, so it conservatively
+; copies up to %new_size bytes. The bump allocator only ever hands
+; out blocks aligned to 8 bytes, and grows always double, so this
+; over-copies by at most a factor of 2 — within the WASM page budget
+; that callers already accept.
+define i8* @realloc(i8* %old, i64 %new_size) {
+entry:
+  %is_null = icmp eq i8* %old, null
+  br i1 %is_null, label %fresh_alloc, label %do_copy
+
+fresh_alloc:
+  %new0 = call i8* @malloc(i64 %new_size)
+  ret i8* %new0
+
+do_copy:
+  %new1 = call i8* @malloc(i64 %new_size)
+  ; We don\'t know the old block\'s actual size; the WAM grow path
+  ; always doubles, so copying %new_size / 2 is safe (the old block
+  ; was at least that large). Use shr by 1 to avoid sdiv.
+  %half = lshr i64 %new_size, 1
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %new1, i8* %old, i64 %half, i1 false)
+  ret i8* %new1
+}
+
 ; Stub printf for WASM (no-op, returns 0).
 define i32 @printf(i8* %fmt, ...) {
   ret i32 0
@@ -1341,6 +1369,7 @@ define i32 @strcmp(i8* %a, i8* %b) {
 }
 '
     ;  Decls = 'declare i8* @malloc(i64)
+declare i8* @realloc(i8*, i64)
 declare void @free(i8*)
 declare i32 @snprintf(i8*, i64, i8*, ...)
 declare i32 @strcmp(i8*, i8*)
@@ -2469,6 +2498,10 @@ wam_llvm_case('allocate',
   ; Y-regs no longer clobbers the outer caller. Canonical WAM stores
   ; Y-regs in env frames directly; we snapshot instead to keep every
   ; other instruction body unchanged.
+  ;
+  ; M5: ensure the stack has room before reading its pointer (grow
+  ; may realloc the buffer to a new address).
+  call void @wam_stack_ensure_capacity(%WamState* %vm)
   %alloc.ss_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 3
   %alloc.ss = load i32, i32* %alloc.ss_ptr
   %alloc.stack_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 2
@@ -2640,6 +2673,8 @@ wam_llvm_case('try_me_else',
 '  ; op1 = label index for alternative
   %tme.label = trunc i64 %op1 to i32
   %tme.next_pc = call i32 @wam_label_pc(%WamState* %vm, i32 %tme.label)
+  ; M5: ensure CP array has room before reading its pointer.
+  call void @wam_cp_ensure_capacity(%WamState* %vm)
   ; Push choice point
   %tme.cpn_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 13
   %tme.cpn = load i32, i32* %tme.cpn_ptr
@@ -2784,6 +2819,8 @@ wam_llvm_case('begin_aggregate',
   %ba.val_reg = lshr i32 %ba.op2_trunc, 16
   %ba.res_reg = and i32 %ba.op2_trunc, 65535
 
+  ; M5: ensure CP array has room before reading its pointer.
+  call void @wam_cp_ensure_capacity(%WamState* %vm)
   ; Push a choice point
   %ba.cpn_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 13
   %ba.cpn = load i32, i32* %ba.cpn_ptr

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -299,22 +299,44 @@ define void @wam_set_pc(%WamState* %vm, i32 %pc) alwaysinline nounwind {
   ret void
 }
 
-; Push trail entry
-define void @wam_trail_binding(%WamState* %vm, i32 %reg_idx) alwaysinline nounwind {
+; M5: Doubling-realloc grow for the trail. Called by @wam_trail_binding
+; (and @wam_trail_heap_binding) when the size hits the current cap.
+; CPs hold trail indices, not pointers, so post-realloc indices remain
+; valid; nothing else needs to be patched up.
+define void @wam_trail_grow(%WamState* %vm) {
+entry:
+  %tc_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 10
+  %tc = load i32, i32* %tc_ptr
+  %new_tc = mul i32 %tc, 2
+  %new_tc_i64 = zext i32 %new_tc to i64
+  %elem_size = ptrtoint %TrailEntry* getelementptr (%TrailEntry, %TrailEntry* null, i32 1) to i64
+  %new_bytes = mul i64 %new_tc_i64, %elem_size
+  %trail_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 8
+  %old_trail = load %TrailEntry*, %TrailEntry** %trail_ptr
+  %old_i8 = bitcast %TrailEntry* %old_trail to i8*
+  %new_i8 = call i8* @realloc(i8* %old_i8, i64 %new_bytes)
+  %new_trail = bitcast i8* %new_i8 to %TrailEntry*
+  store %TrailEntry* %new_trail, %TrailEntry** %trail_ptr
+  store i32 %new_tc, i32* %tc_ptr
+  ret void
+}
+
+; Push trail entry (M5: grows automatically when at cap).
+define void @wam_trail_binding(%WamState* %vm, i32 %reg_idx) nounwind {
 entry:
   %ts_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 9
   %ts = load i32, i32* %ts_ptr
   %tc_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 10
   %tc = load i32, i32* %tc_ptr
-  %ovf = icmp sge i32 %ts, %tc
-  br i1 %ovf, label %abort, label %store
+  %need_grow = icmp sge i32 %ts, %tc
+  br i1 %need_grow, label %grow, label %store
 
-abort:
-  call i32 (i8*, ...) @printf(i8* getelementptr ([42 x i8], [42 x i8]* @.fmt_trail_oom, i32 0, i32 0), i32 %ts, i32 %tc)
-  call void @exit(i32 4)
-  unreachable
+grow:
+  call void @wam_trail_grow(%WamState* %vm)
+  br label %store
 
 store:
+  ; Reload trail pointer — realloc may have moved it.
   %trail_arr_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 8
   %trail_arr = load %TrailEntry*, %TrailEntry** %trail_arr_ptr
   %entry_ptr = getelementptr %TrailEntry, %TrailEntry* %trail_arr, i32 %ts
@@ -505,21 +527,21 @@ done:
 ; TrailEntry's reg_idx field as a "heap" sentinel to distinguish from
 ; register indices (which are always 0-63). unwind_trail reads that
 ; bit to pick reg_set vs heap_set on restore.
-define void @wam_trail_heap_binding(%WamState* %vm, i32 %addr, %Value %old_val) alwaysinline nounwind {
+define void @wam_trail_heap_binding(%WamState* %vm, i32 %addr, %Value %old_val) nounwind {
 entry:
   %ts_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 9
   %ts = load i32, i32* %ts_ptr
   %tc_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 10
   %tc = load i32, i32* %tc_ptr
-  %ovf = icmp sge i32 %ts, %tc
-  br i1 %ovf, label %abort, label %store
+  %need_grow = icmp sge i32 %ts, %tc
+  br i1 %need_grow, label %grow, label %store
 
-abort:
-  call i32 (i8*, ...) @printf(i8* getelementptr ([42 x i8], [42 x i8]* @.fmt_trail_oom, i32 0, i32 0), i32 %ts, i32 %tc)
-  call void @exit(i32 4)
-  unreachable
+grow:
+  call void @wam_trail_grow(%WamState* %vm)
+  br label %store
 
 store:
+  ; Reload trail pointer — realloc may have moved it.
   %trail_arr_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 8
   %trail_arr = load %TrailEntry*, %TrailEntry** %trail_arr_ptr
   %entry_ptr = getelementptr %TrailEntry, %TrailEntry* %trail_arr, i32 %ts
@@ -729,8 +751,110 @@ not_match:
 
 ; === Stack Context Helpers (for compound term read/write mode) ===
 
-; Push a UnifyCtx (type=1) with args array and arg count
+; ============================================================================
+; M5: Growable stack + choice-point allocators
+; ============================================================================
+;
+; The stack, choice-point array, and trail (above) all start with the
+; modest initial capacity set in @wam_state_new and double via realloc
+; when a push hits the cap. Stack overflow used to silently write past
+; the end of the buffer (no overflow check was present in
+; wam_push_unify_ctx / wam_push_write_ctx / the allocate @step case);
+; CP overflow same. M5 routes every push through an ensure_capacity
+; helper that calls into the doubling-grow path.
+;
+; Pointer-stability invariant: the choice-point struct stores trail
+; marks and heap-top markers as INDICES (i32), not as pointers, so
+; trail-grow / CP-grow is transparent to backtrack. The stack stores
+; %Value* in its UnifyCtx / WriteCtx `data` field — for UnifyCtx those
+; point into the arena (allocated by put_structure), for WriteCtx via
+; @wam_write_ctx_set_args those can point into the WAM heap (get_list
+; write mode). Since this PR does NOT grow the heap (heap overflow
+; still exits via the existing abort path), those pointers remain
+; stable for the duration of any active WriteCtx and stack-grow itself
+; only moves the stack buffer, not the heap. Heap-grow is a follow-up
+; that would require either walking the stack on grow or changing the
+; WriteCtx data field to a heap-relative index.
+
+define void @wam_stack_grow(%WamState* %vm) {
+entry:
+  %sc_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 4
+  %sc = load i32, i32* %sc_ptr
+  %new_sc = mul i32 %sc, 2
+  %new_sc_i64 = zext i32 %new_sc to i64
+  %elem_size = ptrtoint %StackEntry* getelementptr (%StackEntry, %StackEntry* null, i32 1) to i64
+  %new_bytes = mul i64 %new_sc_i64, %elem_size
+  %stack_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 2
+  %old_stack = load %StackEntry*, %StackEntry** %stack_ptr
+  %old_i8 = bitcast %StackEntry* %old_stack to i8*
+  %new_i8 = call i8* @realloc(i8* %old_i8, i64 %new_bytes)
+  %new_stack = bitcast i8* %new_i8 to %StackEntry*
+  store %StackEntry* %new_stack, %StackEntry** %stack_ptr
+  store i32 %new_sc, i32* %sc_ptr
+  ret void
+}
+
+; Ensures there is at least one free slot at the top of the stack.
+; Callers MUST invoke this BEFORE reading the stack pointer (because
+; grow may realloc the buffer to a new address). All push helpers
+; below follow this discipline.
+define void @wam_stack_ensure_capacity(%WamState* %vm) nounwind {
+entry:
+  %ss_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 3
+  %ss = load i32, i32* %ss_ptr
+  %sc_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 4
+  %sc = load i32, i32* %sc_ptr
+  %ovf = icmp sge i32 %ss, %sc
+  br i1 %ovf, label %grow, label %done
+
+grow:
+  call void @wam_stack_grow(%WamState* %vm)
+  br label %done
+
+done:
+  ret void
+}
+
+define void @wam_cp_grow(%WamState* %vm) {
+entry:
+  %cc_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 14
+  %cc = load i32, i32* %cc_ptr
+  %new_cc = mul i32 %cc, 2
+  %new_cc_i64 = zext i32 %new_cc to i64
+  %elem_size = ptrtoint %ChoicePoint* getelementptr (%ChoicePoint, %ChoicePoint* null, i32 1) to i64
+  %new_bytes = mul i64 %new_cc_i64, %elem_size
+  %cps_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 12
+  %old_cps = load %ChoicePoint*, %ChoicePoint** %cps_ptr
+  %old_i8 = bitcast %ChoicePoint* %old_cps to i8*
+  %new_i8 = call i8* @realloc(i8* %old_i8, i64 %new_bytes)
+  %new_cps = bitcast i8* %new_i8 to %ChoicePoint*
+  store %ChoicePoint* %new_cps, %ChoicePoint** %cps_ptr
+  store i32 %new_cc, i32* %cc_ptr
+  ret void
+}
+
+define void @wam_cp_ensure_capacity(%WamState* %vm) nounwind {
+entry:
+  %cn_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 13
+  %cn = load i32, i32* %cn_ptr
+  %cc_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 14
+  %cc = load i32, i32* %cc_ptr
+  %ovf = icmp sge i32 %cn, %cc
+  br i1 %ovf, label %grow, label %done
+
+grow:
+  call void @wam_cp_grow(%WamState* %vm)
+  br label %done
+
+done:
+  ret void
+}
+
+; Push a UnifyCtx (type=1) with args array and arg count.
+; M5: calls @wam_stack_ensure_capacity first so the buffer is grown
+; if at cap; reloads the stack pointer afterward in case realloc moved it.
 define void @wam_push_unify_ctx(%WamState* %vm, %Value* %args, i32 %count) {
+  call void @wam_stack_ensure_capacity(%WamState* %vm)
   %ss_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 3
   %ss = load i32, i32* %ss_ptr
   %stack_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 2
@@ -757,7 +881,9 @@ define void @wam_push_unify_ctx(%WamState* %vm, %Value* %args, i32 %count) {
 ; Push a WriteCtx (type=2) with write count.
 ; For compound terms, data field stores the args %Value* pointer
 ; so set_value/set_constant write directly into the compound's args array.
+; M5: routes through @wam_stack_ensure_capacity first.
 define void @wam_push_write_ctx(%WamState* %vm, i32 %count) {
+  call void @wam_stack_ensure_capacity(%WamState* %vm)
   %ss_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 3
   %ss = load i32, i32* %ss_ptr
   %stack_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 2
@@ -3237,12 +3363,13 @@ define void @wam_push_foreign_choice_point(
     i32 %result_reg,
     i32 %return_pc) {
 entry:
+  ; M5: ensure cap before reading cps pointer (grow may realloc).
+  call void @wam_cp_ensure_capacity(%WamState* %vm)
   %cpn_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 13
   %cpn = load i32, i32* %cpn_ptr
   %cps_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 12
   %cps = load %ChoicePoint*, %ChoicePoint** %cps_ptr
 
-  ; TODO: check capacity and realloc if needed (current cap=64, sufficient for now)
   %cp = getelementptr %ChoicePoint, %ChoicePoint* %cps, i32 %cpn
 
   ; next_pc = 0 (unused for foreign iter — backtrack handler reads cursor instead)

--- a/tests/core/test_wam_llvm_growable_alloc.pl
+++ b/tests/core/test_wam_llvm_growable_alloc.pl
@@ -1,0 +1,202 @@
+:- encoding(utf8).
+% test_wam_llvm_growable_alloc.pl
+%
+% Exercises the M5 doubling-realloc grow paths for the trail, stack,
+% and choice-point array. The wam_state_new initial caps (trail 65536,
+% CPs 1024, stack 1024) are too high for a smoke test to exceed in a
+% reasonable wall-clock budget, so this test:
+%
+%   1. IR-structure check — confirm `@wam_trail_grow`, `@wam_stack_grow`,
+%      and `@wam_cp_grow` are emitted into the module, and that the
+%      push sites (`@wam_trail_binding`, `@wam_push_unify_ctx`,
+%      `@wam_push_write_ctx`, `@wam_push_foreign_choice_point`, and the
+%      try_me_else / allocate @step cases) call the ensure_capacity
+%      helpers.
+%
+%   2. Execution stress — call a simple WAM-fallback predicate ~200k
+%      times against ONE shared %WamState without resetting the trail.
+%      Each invocation trails ~4 register bindings, so 200k iterations
+%      hit ~800k trail entries — well past the 65536 initial cap. The
+%      test verifies the resulting binary runs to completion without
+%      OOM-aborting (which is what the pre-M5 fixed-size code did).
+
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3,
+     clear_llvm_foreign_kernel_specs/0]).
+:- use_module(library(process)).
+:- use_module(library(readutil)).
+:- use_module(library(pcre)).
+
+:- dynamic add1/2.
+add1(X, R) :- R is X + 1.
+
+host_target_triple(Triple) :-
+    ( catch(
+        ( process_create(path(clang), ['-print-target-triple'],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, Raw), close(Out),
+          process_wait(PID, exit(0))
+        ), _, fail)
+    -> split_string(Raw, "", "\n\r\t ", [S]), atom_string(Triple, S)
+    ;  Triple = 'x86_64-pc-linux-gnu'
+    ).
+
+test_ir_structure :-
+    format('--- M5 IR structure: grow helpers + ensure_capacity calls ---~n'),
+    clear_llvm_foreign_kernel_specs,
+    tmp_file_stream(text, LLPath, S0), close(S0),
+    host_target_triple(Triple),
+    write_wam_llvm_project(
+        [user:add1/2],
+        [ module_name('m5_struct'),
+          target_triple(Triple),
+          target_datalayout('')
+        ],
+        LLPath),
+    read_file_to_string(LLPath, Src, []),
+    forall(member(Sym, [
+                'define void @wam_trail_grow',
+                'define void @wam_stack_grow',
+                'define void @wam_cp_grow',
+                'define void @wam_stack_ensure_capacity',
+                'define void @wam_cp_ensure_capacity'
+            ]),
+        ( sub_string(Src, _, _, _, Sym)
+        -> format('  PASS: ~w present~n', [Sym])
+        ;  format('  FAIL: ~w missing~n', [Sym]),
+           throw(missing_symbol(Sym))
+        )),
+    % Trail / stack / CP push sites must route through the grow helpers.
+    forall(member(Pattern-Site, [
+                'call void @wam_trail_grow'             - 'wam_trail_binding',
+                'call void @wam_stack_ensure_capacity'  - 'allocate or push_*',
+                'call void @wam_cp_ensure_capacity'     - 'try_me_else / begin_aggregate / push_foreign_cp'
+            ]),
+        ( sub_string(Src, _, _, _, Pattern)
+        -> format('  PASS: ~w wired at ~w~n', [Pattern, Site])
+        ;  format('  FAIL: ~w not wired (~w)~n', [Pattern, Site]),
+           throw(unwired(Pattern))
+        )),
+    % @realloc declaration must be in the module (or stubbed for WASM).
+    ( sub_string(Src, _, _, _, '@realloc')
+    -> format('  PASS: @realloc declared / stubbed~n')
+    ;  format('  FAIL: @realloc not in module~n'),
+       throw(missing_realloc)
+    ),
+    catch(delete_file(LLPath), _, true),
+    clear_llvm_foreign_kernel_specs.
+
+test_trail_grow_exec :-
+    format('~n--- M5 execution stress: trail grow over 200k iterations ---~n'),
+    clear_llvm_foreign_kernel_specs,
+    tmp_file_stream(text, LLPath, S0), close(S0),
+    host_target_triple(Triple),
+    write_wam_llvm_project(
+        [user:add1/2],
+        [ module_name('m5_stress'),
+          target_triple(Triple),
+          target_datalayout('')
+        ],
+        LLPath),
+    read_file_to_string(LLPath, Src, []),
+    re_matchsub("@module_code = private constant \\[(?<n>\\d+) x %Instruction\\]",
+                Src, M1, []), get_dict(n, M1, IcStr), number_string(IC, IcStr),
+    re_matchsub("@module_labels = private constant \\[(?<n>\\d+) x i32\\]",
+                Src, M2, []), get_dict(n, M2, LcStr), number_string(LC, LcStr),
+    % Driver: allocate ONE %WamState, loop 200k times calling add1's
+    % bytecode WITHOUT resetting trail / heap (only PC + halt flag).
+    % Each iteration trails ~4 entries via get_variable/put_value/is.
+    % At iteration ~16k the initial trail (cap=65536) hits cap and
+    % must grow — repeatedly — to reach the 200k-iter target.
+    %
+    % We also reset arena per-iter via wam_cleanup (the existing M3
+    % path) since put_structure builds a fresh +/2 compound each call.
+    Iterations = 200000,
+    format(atom(DriverIR),
+'define i32 @main() {
+entry:
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @module_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @module_labels, i32 0, i32 0),
+      i32 ~w)
+  %pc_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 0
+  %hs_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 6
+  %cpn_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 13
+  %halt_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 19
+  br label %loop
+loop:
+  %i = phi i32 [0, %entry], [%i_next, %loop_body]
+  %done = icmp uge i32 %i, ~w
+  br i1 %done, label %exit, label %loop_body
+loop_body:
+  ; Reset only what would otherwise OOM each iter: PC, heap, CP count,
+  ; halted. Crucially we do NOT reset the trail size — bindings
+  ; accumulate, forcing the trail to grow past its initial cap.
+  store i32 0, i32* %pc_ptr
+  store i32 0, i32* %hs_ptr
+  store i32 0, i32* %cpn_ptr
+  store i1 false, i1* %halt_ptr
+  %a1_0 = insertvalue %Value undef, i32 1, 0
+  %a1 = insertvalue %Value %a1_0, i64 17, 1
+  %a2_0 = insertvalue %Value undef, i32 6, 0
+  %a2 = insertvalue %Value %a2_0, i64 0, 1
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %a1)
+  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %a2)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  call void @wam_cleanup()
+  %i_next = add i32 %i, 1
+  br label %loop
+exit:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 0
+}
+', [IC, IC, IC, LC, LC, LC, Iterations]),
+    setup_call_cleanup(open(LLPath, append, Out),
+        ( write(Out, '\n'), write(Out, DriverIR) ), close(Out)),
+    atom_concat(LLPath, '.o', OPath),
+    atom_concat(LLPath, '.out', BinPath),
+    format(atom(LlcCmd),
+        'llc -O2 -filetype=obj -relocation-model=pic ~w -o ~w 2>/dev/null',
+        [LLPath, OPath]),
+    shell(LlcCmd, _),
+    format(atom(ClangCmd), 'clang -O2 ~w -o ~w 2>/dev/null', [OPath, BinPath]),
+    shell(ClangCmd, _),
+    get_time(T0),
+    shell(BinPath, ExitCode),
+    get_time(T1),
+    Elapsed is (T1 - T0) * 1000,
+    ( ExitCode =:= 0
+    -> format('  PASS: 200k iter run completed (exit=0, ~3fms wall-clock)~n',
+              [Elapsed])
+    ;  format('  FAIL: 200k iter run exited ~w (expected 0)~n', [ExitCode]),
+       throw(stress_exec_failed(ExitCode))
+    ),
+    catch(delete_file(LLPath), _, true),
+    catch(delete_file(OPath), _, true),
+    catch(delete_file(BinPath), _, true),
+    clear_llvm_foreign_kernel_specs.
+
+test_all :-
+    ( process_which('clang'), process_which('llc')
+    -> catch(
+         ( test_ir_structure,
+           test_trail_grow_exec,
+           format('~n=== All M5 growable-allocator tests passed ===~n')
+         ),
+         E,
+         ( format(user_error, '  ERROR: ~w~n', [E]),
+           halt(1)
+         ))
+    ;  format('  SKIP: clang/llc not all on PATH~n')
+    ).
+
+process_which(Tool) :-
+    catch(
+        ( process_create(path(which), [Tool],
+              [stdout(pipe(Out)), stderr(null), process(PID)]),
+          read_string(Out, _, _), close(Out),
+          process_wait(PID, exit(0))
+        ), _, fail).
+
+:- initialization(test_all, main).


### PR DESCRIPTION
## Summary

Replaces the `exit(4)`-on-overflow path in the trail (and the silent out-of-bounds write that the stack / CP pushes did when the fixed 1024-entry caps were exceeded) with **doubling realloc**. The WAM-LLVM hybrid target now scales from "toy" workloads to production-sized ones without manually bumping any initial capacities.

This is the correctness-fix the LLVM target was missing — any user predicate that accumulated more than ~65k trail entries or ~1k choice points / stack frames would abort or silently corrupt memory before this PR.

### What grows

| Area | Push sites that route through `*_ensure_capacity` |
| --- | --- |
| **trail** | `@wam_trail_binding`, `@wam_trail_heap_binding` |
| **stack** | `@wam_push_unify_ctx`, `@wam_push_write_ctx`, the `allocate` @step case, the lowered emitter's `allocate` emission |
| **CPs** | `try_me_else`, `begin_aggregate`, `@wam_push_foreign_choice_point` |

### Pointer-stability rationale (why this is safe)

- **Trail / CP grow**: choice points hold trail marks and heap-top as INDICES (`i32`), not pointers. After `realloc` the indices still address the right slot in the (new) trail / CP buffer.
- **Stack grow**: only moves the stack buffer. Each stack entry's `data` field is a `%Value*` pointing into the arena (UnifyCtx after `put_structure`) or the heap (WriteCtx after `get_list` write mode), neither of which moves when the stack grows.

### What does NOT grow (deferred)

- **Heap** stays fixed at 1 MiB; `@wam_heap_push` still exits via abort on overflow.
- The WriteCtx `data` field is a `%Value*` that can point into the heap, so growing the heap would invalidate those in-flight pointers.
- Fix requires either walking the stack on grow to fixup args pointers OR changing the WriteCtx `data` field to a heap-relative index. Deferred to a follow-up PR.

### External `@realloc`

- **Native target**: added `declare i8* @realloc(i8*, i64)` alongside `@malloc` / `@free`.
- **WASM target**: added a bump-allocator stub for `@realloc` that over-copies by at most a factor of 2 (the WAM grow path always doubles, so copying `new_size / 2` bytes is safe).

### Inline-attr note

`@wam_trail_binding` / `@wam_trail_heap_binding` dropped `alwaysinline` since the function now has a non-trivial grow branch. The `-O2` inliner still handles the common `store` path; the cold grow path doesn't need inlining.

## Test plan

- [x] **IR-structure** (`tests/core/test_wam_llvm_growable_alloc.pl` — new):
  - `@wam_trail_grow`, `@wam_stack_grow`, `@wam_cp_grow`, `@wam_stack_ensure_capacity`, `@wam_cp_ensure_capacity` all emitted
  - Push sites wired correctly (trail / stack / CP)
  - `@realloc` declared (native) / stubbed (WASM)

- [x] **Execution stress** — 200k iterations of `add1/2` against a single shared `%WamState` *without* resetting the trail. Pre-M5 this would `exit(4)` at ~16k iters (trail cap 65536 / 4 trail entries per call). Post-M5 the trail grows from 65k → ~1M entries transparently; binary completes in **~95 ms**.

- [x] **Full LLVM regression sweep** (16 existing core tests + new M5 test):

  | test | PASS |
  | --- | ---: |
  | `test_wam_llvm_builtin_execution.pl` | 10 |
  | `test_wam_llvm_bfs_execution.pl` | 4 |
  | `test_wam_llvm_reach_execution.pl` | 5 |
  | `test_wam_llvm_dijkstra_execution.pl` | 4 |
  | `test_wam_llvm_tc2_execution.pl` | 3 |
  | `test_wam_llvm_switch.pl` | 7 |
  | `test_wam_llvm_aggregate.pl` | 5 |
  | `test_wam_llvm_list_suffix_execution.pl` | 4 |
  | `test_wam_llvm_countdown_sum_execution.pl` | 4 |
  | `test_wam_llvm_category_ancestor_execution.pl` | 3 |
  | `test_wam_llvm_astar_execution.pl` | 4 |
  | `test_wam_llvm_ffi_bridge.pl` | 7 |
  | `test_wam_llvm_td3_wiring.pl` | 4 |
  | `test_wam_llvm_foreign_dispatch.pl` | 11 |
  | `test_wam_llvm_lowered_emitter.pl` | 31 |
  | **`test_wam_llvm_growable_alloc.pl` (new)** | **10** |

- [x] **Foreign-kernel benchmark** numbers unchanged — those paths don't push CPs or trail entries excessively, so the grow infrastructure doesn't fire and per-iter timings stay in the same range as the M4 baseline.

## File summary

| File | Δ | Purpose |
| --- | ---: | --- |
| `templates/targets/llvm_wam/state.ll.mustache` | +144 | `@wam_trail_grow`, `@wam_stack_grow`, `@wam_cp_grow`, ensure-capacity helpers; rewrote `@wam_trail_binding` + `@wam_trail_heap_binding` to grow instead of `exit(4)`; routed `@wam_push_unify_ctx` / `@wam_push_write_ctx` / `@wam_push_foreign_choice_point` through ensure-capacity |
| `src/unifyweaver/targets/wam_llvm_target.pl` | +37 | Added `@wam_stack_ensure_capacity` / `@wam_cp_ensure_capacity` calls to the `allocate` / `try_me_else` / `begin_aggregate` @step cases; declared `@realloc` for native; WASM `@realloc` bump-stub |
| `src/unifyweaver/targets/wam_llvm_lowered_emitter.pl` | +1 | Lowered `allocate` emission now calls `@wam_stack_ensure_capacity` before reading the stack pointer |
| `tests/core/test_wam_llvm_growable_alloc.pl` | +192 (new) | IR-structure check + 200k-iter trail-grow stress test |
| `docs/LLVM_TARGET.md` | +20 | M5 status entry |

## Status flow

- ✅ M1 (#2540): register/arithmetic ops
- ✅ M2 (#2542): compound + list pattern matching
- ✅ M3 (#2543): multi-clause via hybrid dispatcher
- ✅ M4 (#2544): call/execute with shared state + closure analysis
- ⏳ **M5 (this PR): growable trail / stack / CP allocators**
- ⏭️ Future: heap grow (WriteCtx data-field rework); trail-rollback between hybrid fast and slow paths; branch-weight `!prof` metadata on the `@step` switch

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_