### PR TITLE
feat(wam-clojure): materialize singleton last

### DIFF
--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -844,7 +844,15 @@
             (advance next-state)
             (backtrack state)))
         (backtrack state))
-      (backtrack state))))
+      (if (and (logic-var? list-value)
+               (not= out ::unbound)
+               (not (logic-var? out)))
+        (let [singleton-term (list->term (:intern-context state) [out])
+              [ok next-state] (unify-values state list-value singleton-term)]
+          (if ok
+            (advance next-state)
+            (backtrack state)))
+        (backtrack state)))))
 
 (defn nth-index-value [state value]
   (cond

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -341,7 +341,7 @@ user:wam_reverse_unbound_list(R) :- reverse(L, R), is_list(L).
 user:wam_last_guard(L, X) :- last(L, X).
 user:wam_last_empty(X) :- last([], X).
 user:wam_last_bad_list(X) :- last([a|b], X).
-user:wam_last_unbound_list(X) :- user:wam_unbound_arg(L), last(L, X).
+user:wam_last_unbound_list(X) :- last(L, X), L = [X].
 user:wam_nth0_guard(N, L, X) :- nth0(N, L, X).
 user:wam_nth0_negative(X) :- nth0(-1, [a,b,c], X).
 user:wam_nth0_out_of_range(X) :- nth0(3, [a,b,c], X).
@@ -961,7 +961,8 @@ smoke_cases([
     case('wam_last_guard/2', args('[a,b,c]', b), "false"),
     case('wam_last_empty/1', a, "false"),
     case('wam_last_bad_list/1', a, "false"),
-    case('wam_last_unbound_list/1', a, "false"),
+    case('wam_last_unbound_list/1', a, "true"),
+    case('wam_last_unbound_list/1', b, "true"),
     case('wam_nth0_guard/3', args(0, '[a,b,c]', a), "true"),
     case('wam_nth0_guard/3', args(1, '[a,b,c]', b), "true"),
     case('wam_nth0_guard/3', args(2, '[a,b,c]', c), "true"),


### PR DESCRIPTION
## Summary
- Adds a conservative singleton materialization mode for Clojure WAM `last/2`.
- Allows `last(L, X)` to bind unbound `L` to `[X]` when `X` is already bound.
- Extends runtime smoke coverage for direct lowerable singleton `last/2` materialization.

## Why
The Clojure WAM runtime previously handled only bound-list `last/2`. This PR adds one bounded reverse case that has exactly one minimal solution and does not require generating arbitrary longer lists.

## Notes
- This intentionally does not enumerate all possible lists ending in `X`.
- Empty-list and bad-list behavior remains unchanged.
- The smoke predicate asserts the singleton mode directly with `last(L, X), L = [X]`.

## Validation
- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
