### PR TITLE
feat(wam-python): capture output to streams

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -1341,7 +1341,7 @@ def _capture_sink_functor(sink: 'Term', state: WamState) -> Optional[Tuple[str, 
     if not isinstance(sink, Compound) or len(sink.args) != 1:
         return None
     functor = _display_functor_name(sink.functor, len(sink.args))
-    if functor in ('atom', 'string', 'codes'):
+    if functor in ('atom', 'string', 'codes', 'stream'):
         return functor, sink.args[0]
     return None
 
@@ -1353,7 +1353,17 @@ def _unify_capture_sink(sink: 'Term', text: str, state: WamState) -> bool:
     kind, target = parsed
     if kind in ('atom', 'string'):
         return unify(target, make_atom(text), state)
-    return unify(target, _list_from_codes([ord(ch) for ch in text]), state)
+    if kind == 'codes':
+        return unify(target, _list_from_codes([ord(ch) for ch in text]), state)
+    raw = _unwrap_stream(deref(target, state))
+    if raw is None or not hasattr(raw, 'write'):
+        return False
+    try:
+        raw.write(text)
+        raw.flush()
+    except (OSError, ValueError):
+        return False
+    return True
 
 
 def _execute_with_output_to(state: WamState) -> bool:

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -1083,6 +1083,9 @@ test(runtime_format_helpers) :-
 test(runtime_with_output_to_helpers) :-
 	setup_call_cleanup(
 		(   retractall(user:py_with_output_to_demo),
+			user:python_parser_tmp_dir('tmp_wam_python_with_output_to', ProjectDir),
+			atomic_list_concat([ProjectDir, '/wot_stream.txt'], StreamOutFile),
+			atomic_list_concat([ProjectDir, '/wot_stream_format.txt'], StreamFmtFile),
 			assertz((user:py_with_output_to_demo :-
 				with_output_to(atom(A), write(hello)),
 				A = hello,
@@ -1107,8 +1110,21 @@ test(runtime_with_output_to_helpers) :-
 				Chars = qR,
 				Seed = keep,
 				\+ with_output_to(atom(Seed), write(changed)),
-				Seed = keep)),
-			user:python_parser_tmp_dir('tmp_wam_python_with_output_to', ProjectDir)
+				Seed = keep,
+				open(StreamOutFile, write, Out),
+				with_output_to(stream(Out), (write(hello), write(' '), write(world))),
+				close(Out),
+				open(StreamOutFile, read, In),
+				read_line_to_string(In, Line),
+				close(In),
+				Line = 'hello world',
+				open(StreamFmtFile, write, FOut),
+				with_output_to(stream(FOut), format('~w-~w', [42, ok])),
+				close(FOut),
+				open(StreamFmtFile, read, FIn),
+				read_line_to_string(FIn, FLine),
+				close(FIn),
+				FLine = '42-ok'))
 		),
 		(   wam_python_target:write_wam_python_project([user:py_with_output_to_demo/0],
 				[runtime_parser(off)], ProjectDir),


### PR DESCRIPTION
## Summary
- extend Python WAM `with_output_to/2` to accept `stream(S)` sinks
- flush captured output into the existing writable stream after the captured goal succeeds
- keep existing atom/string/codes capture behavior unchanged
- add generated-project coverage for stream capture with both `write/1` and `format/2`, reading the file output back through Python WAM stream predicates

## Tests
- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
