### PR TITLE
Add WAM-C bidirectional ancestor kernel

### DIFF
--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -152,6 +152,18 @@ typedef struct {
 } WamIntResults;
 
 typedef struct {
+    int total_hops;
+    int parent_hops;
+    int child_hops;
+} WamBidirectionalAncestorResult;
+
+typedef struct {
+    WamBidirectionalAncestorResult *values;
+    int count;
+    int cap;
+} WamBidirectionalAncestorResults;
+
+typedef struct {
     int reg;
     int is_y_reg;
     WamValue val;
@@ -192,6 +204,7 @@ typedef struct {
     HashEntry *s_hash_table;
     int s_hash_size;
     int list_target_pc;
+    bool no_match_fallthrough;
 } WamSwitchInstr;
 
 typedef union {
@@ -264,6 +277,9 @@ struct WamState {
     int category_edge_count;
     int category_edge_cap;
     int category_max_depth;
+    double bidirectional_parent_step_cost;
+    double bidirectional_child_step_cost;
+    double bidirectional_cost_budget;
 
     /* Native weighted_shortest_path3 kernel data */
     WeightedEdge *weighted_edges;
@@ -286,6 +302,11 @@ void wam_register_transitive_edge(WamState *state, const char *child, const char
 void wam_register_weighted_edge(WamState *state, const char *source, const char *target, int weight);
 void wam_register_direct_distance_edge(WamState *state, const char *source, const char *target, int distance);
 void wam_register_category_ancestor_kernel(WamState *state, const char *pred, int max_depth);
+void wam_register_bidirectional_ancestor_kernel(WamState *state, const char *pred,
+                                                int max_depth,
+                                                double parent_step_cost,
+                                                double child_step_cost,
+                                                double cost_budget);
 void wam_register_transitive_closure_kernel(WamState *state, const char *pred);
 void wam_register_transitive_distance_kernel(WamState *state, const char *pred);
 void wam_register_transitive_parent_distance_kernel(WamState *state, const char *pred);
@@ -293,6 +314,7 @@ void wam_register_transitive_step_parent_distance_kernel(WamState *state, const 
 void wam_register_weighted_shortest_path_kernel(WamState *state, const char *pred);
 void wam_register_astar_shortest_path_kernel(WamState *state, const char *pred);
 bool wam_category_ancestor_handler(WamState *state, const char *pred, int arity);
+bool wam_bidirectional_ancestor_handler(WamState *state, const char *pred, int arity);
 bool wam_transitive_closure_handler(WamState *state, const char *pred, int arity);
 bool wam_transitive_distance_handler(WamState *state, const char *pred, int arity);
 bool wam_transitive_parent_distance_handler(WamState *state, const char *pred, int arity);
@@ -323,7 +345,15 @@ int wam_reverse_csr_lookup_children(WamReverseCsrArtifact *artifact,
 void wam_int_results_init(WamIntResults *results);
 void wam_int_results_close(WamIntResults *results);
 bool wam_int_results_push(WamIntResults *results, int value);
+void wam_bidirectional_ancestor_results_init(WamBidirectionalAncestorResults *results);
+void wam_bidirectional_ancestor_results_close(WamBidirectionalAncestorResults *results);
+bool wam_bidirectional_ancestor_results_push(WamBidirectionalAncestorResults *results,
+                                             int total_hops,
+                                             int parent_hops,
+                                             int child_hops);
 bool wam_collect_category_ancestor_hops(WamState *state, WamIntResults *results);
+bool wam_collect_bidirectional_ancestor_hops(WamState *state,
+                                             WamBidirectionalAncestorResults *results);
 
 /* Helpers */
 static inline WamValue val_atom(const char *s) {

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -188,6 +188,7 @@ detect_kernels([PI|Rest], Kernels) :-
     detect_kernels(Rest, RestKernels).
 
 wam_c_supported_kernel(recursive_kernel(category_ancestor, _Pred, _ConfigOps)).
+wam_c_supported_kernel(recursive_kernel(bidirectional_ancestor, _Pred, _ConfigOps)).
 wam_c_supported_kernel(recursive_kernel(transitive_closure2, _Pred, _ConfigOps)).
 wam_c_supported_kernel(recursive_kernel(transitive_distance3, _Pred, _ConfigOps)).
 wam_c_supported_kernel(recursive_kernel(transitive_parent_distance4, _Pred, _ConfigOps)).
@@ -212,6 +213,14 @@ wam_c_kernel_registration_line(Key-recursive_kernel(category_ancestor, _Pred, Co
     format(atom(Line),
            '    wam_register_category_ancestor_kernel(state, "~w", ~w);',
            [Key, MaxDepth]).
+wam_c_kernel_registration_line(Key-recursive_kernel(bidirectional_ancestor, _Pred, ConfigOps), Line) :-
+    wam_c_kernel_max_depth(ConfigOps, MaxDepth),
+    wam_c_kernel_float_config(ConfigOps, parent_step_cost, 1.0, ParentCost),
+    wam_c_kernel_float_config(ConfigOps, child_step_cost, 3.0, ChildCost),
+    wam_c_kernel_float_config(ConfigOps, cost_budget, 10.0, Budget),
+    format(atom(Line),
+           '    wam_register_bidirectional_ancestor_kernel(state, "~w", ~w, ~w, ~w, ~w);',
+           [Key, MaxDepth, ParentCost, ChildCost, Budget]).
 wam_c_kernel_registration_line(Key-recursive_kernel(transitive_closure2, _Pred, _ConfigOps), Line) :-
     format(atom(Line),
            '    wam_register_transitive_closure_kernel(state, "~w");',
@@ -243,6 +252,15 @@ wam_c_kernel_max_depth(ConfigOps, MaxDepth) :-
         MaxDepth0 > 0
     ->  MaxDepth = MaxDepth0
     ;   MaxDepth = 10
+    ).
+
+wam_c_kernel_float_config(ConfigOps, Key, Default, Value) :-
+    Term =.. [Key, Value0],
+    (   member(Term, ConfigOps),
+        number(Value0),
+        Value0 > 0
+    ->  Value = Value0
+    ;   Value = Default
     ).
 
 % ============================================================================
@@ -1525,12 +1543,20 @@ wam_lines_to_c_pass2([Line|Rest], PC, LabelMap, Arity, OffsetVar, CodeSize, Inst
 wam_generate_c_instruction(PC, Parts, LabelMap, Arity, OffsetVar, CodeLines) :-
     c_pc_expr(OffsetVar, PC, PCExpr),
     (   (   Parts = ["switch_on_constant" | Entries],
-            SwitchReg = 0
+            SwitchReg = 0,
+            Fallthrough = false
         ;   Parts = ["switch_on_constant_a2" | Entries],
-            SwitchReg = 1
+            SwitchReg = 1,
+            Fallthrough = false
+        ;   Parts = ["switch_on_constant_fallthrough" | Entries],
+            SwitchReg = 0,
+            Fallthrough = true
+        ;   Parts = ["switch_on_constant_a2_fallthrough" | Entries],
+            SwitchReg = 1,
+            Fallthrough = true
         )
     ->  length(Entries, HashSize),
-        format(atom(L0), '    state->code[~w] = (Instruction){ .tag = INSTR_SWITCH_ON_CONSTANT, .as.switch_index = { .reg = ~w, .hash_size = ~w } };', [PCExpr, SwitchReg, HashSize]),
+        format(atom(L0), '    state->code[~w] = (Instruction){ .tag = INSTR_SWITCH_ON_CONSTANT, .as.switch_index = { .reg = ~w, .hash_size = ~w, .no_match_fallthrough = ~w } };', [PCExpr, SwitchReg, HashSize, Fallthrough]),
         format(atom(L1), '    state->code[~w].as.switch_index.hash_table = malloc(sizeof(HashEntry) * ~w);', [PCExpr, HashSize]),
         generate_hash_table_entries(PC, PCExpr, "as.switch_index.hash_table", Entries, 0, LabelMap, OffsetVar, HashLines),
         append([L0, L1], HashLines, CodeLines)
@@ -1767,6 +1793,10 @@ compile_step_wam_to_c(_Options, CCode) :-
                     return true; // Unbound variable falls through to the sequential try_me_else chain
                 }
                 if (cell->tag != VAL_ATOM && cell->tag != VAL_INT) {
+                    if (instr->as.switch_index.no_match_fallthrough) {
+                        state->P++;
+                        return true;
+                    }
                     return false; // Type mismatch, fail
                 }
                 for (int i = 0; i < instr->as.switch_index.hash_size; i++) {
@@ -1774,6 +1804,10 @@ compile_step_wam_to_c(_Options, CCode) :-
                         state->P = instr->as.switch_index.hash_table[i].target_pc;
                         return true;
                     }
+                }
+                if (instr->as.switch_index.no_match_fallthrough) {
+                    state->P++;
+                    return true;
                 }
                 return false; // Not found in index, fail
             }
@@ -2787,9 +2821,54 @@ bool wam_int_results_push(WamIntResults *results, int value) {
     return true;
 }
 
+void wam_bidirectional_ancestor_results_init(WamBidirectionalAncestorResults *results) {
+    memset(results, 0, sizeof(WamBidirectionalAncestorResults));
+}
+
+void wam_bidirectional_ancestor_results_close(WamBidirectionalAncestorResults *results) {
+    free(results->values);
+    memset(results, 0, sizeof(WamBidirectionalAncestorResults));
+}
+
+bool wam_bidirectional_ancestor_results_push(WamBidirectionalAncestorResults *results,
+                                             int total_hops,
+                                             int parent_hops,
+                                             int child_hops) {
+    if (results->count >= results->cap) {
+        results->cap = results->cap ? results->cap * 2 : WAM_INITIAL_CAP;
+        results->values = realloc(results->values,
+                                  sizeof(WamBidirectionalAncestorResult) * results->cap);
+        if (!results->values) {
+            results->count = 0;
+            results->cap = 0;
+            return false;
+        }
+    }
+    results->values[results->count].total_hops = total_hops;
+    results->values[results->count].parent_hops = parent_hops;
+    results->values[results->count].child_hops = child_hops;
+    results->count++;
+    return true;
+}
+
 void wam_register_category_ancestor_kernel(WamState *state, const char *pred, int max_depth) {
     state->category_max_depth = max_depth > 0 ? max_depth : 10;
     wam_register_foreign_predicate(state, pred, 4, wam_category_ancestor_handler);
+}
+
+void wam_register_bidirectional_ancestor_kernel(WamState *state, const char *pred,
+                                                int max_depth,
+                                                double parent_step_cost,
+                                                double child_step_cost,
+                                                double cost_budget) {
+    state->category_max_depth = max_depth > 0 ? max_depth : 10;
+    state->bidirectional_parent_step_cost =
+        parent_step_cost > 0.0 ? parent_step_cost : 1.0;
+    state->bidirectional_child_step_cost =
+        child_step_cost > 0.0 ? child_step_cost : 3.0;
+    state->bidirectional_cost_budget =
+        cost_budget > 0.0 ? cost_budget : 10.0;
+    wam_register_foreign_predicate(state, pred, 5, wam_bidirectional_ancestor_handler);
 }
 
 void wam_register_transitive_closure_kernel(WamState *state, const char *pred) {
@@ -2943,6 +3022,137 @@ bool wam_category_ancestor_handler(WamState *state, const char *pred, int arity)
     WamValue result = val_int(results.values[0]);
     bool ok = wam_unify(state, &state->A[2], &result);
     wam_int_results_close(&results);
+    return ok;
+}
+
+static bool wam_bidirectional_ancestor_dfs(WamState *state,
+                                           const char *node,
+                                           const char *root,
+                                           int depth,
+                                           int max_depth,
+                                           const char **visited,
+                                           int visited_len,
+                                           int parent_hops,
+                                           int child_hops,
+                                           double cost,
+                                           WamBidirectionalAncestorResults *results) {
+    bool found = false;
+    double parent_cost = state->bidirectional_parent_step_cost > 0.0
+        ? state->bidirectional_parent_step_cost
+        : 1.0;
+    double child_cost = state->bidirectional_child_step_cost > 0.0
+        ? state->bidirectional_child_step_cost
+        : 3.0;
+    double budget = state->bidirectional_cost_budget > 0.0
+        ? state->bidirectional_cost_budget
+        : 10.0;
+
+    for (int i = 0; i < state->category_edge_count; i++) {
+        CategoryEdge *edge = &state->category_edges[i];
+        if (strcmp(edge->child, node) != 0) continue;
+        if (wam_visited_array_contains(visited, visited_len, edge->parent)) continue;
+        double next_cost = cost + parent_cost;
+        if (next_cost > budget) continue;
+        int next_parent_hops = parent_hops + 1;
+        if (strcmp(edge->parent, root) == 0) {
+            if (!wam_bidirectional_ancestor_results_push(
+                    results, next_parent_hops + child_hops,
+                    next_parent_hops, child_hops)) {
+                return false;
+            }
+            found = true;
+            continue;
+        }
+        if (depth + 1 >= max_depth || visited_len >= 64) continue;
+        visited[visited_len] = edge->parent;
+        if (wam_bidirectional_ancestor_dfs(state, edge->parent, root,
+                                           depth + 1, max_depth,
+                                           visited, visited_len + 1,
+                                           next_parent_hops, child_hops,
+                                           next_cost, results)) {
+            found = true;
+        }
+    }
+
+    for (int i = 0; i < state->category_edge_count; i++) {
+        CategoryEdge *edge = &state->category_edges[i];
+        if (strcmp(edge->parent, node) != 0) continue;
+        if (wam_visited_array_contains(visited, visited_len, edge->child)) continue;
+        double next_cost = cost + child_cost;
+        if (next_cost > budget) continue;
+        int next_child_hops = child_hops + 1;
+        if (strcmp(edge->child, root) == 0) {
+            if (!wam_bidirectional_ancestor_results_push(
+                    results, parent_hops + next_child_hops,
+                    parent_hops, next_child_hops)) {
+                return false;
+            }
+            found = true;
+            continue;
+        }
+        if (depth + 1 >= max_depth || visited_len >= 64) continue;
+        visited[visited_len] = edge->child;
+        if (wam_bidirectional_ancestor_dfs(state, edge->child, root,
+                                           depth + 1, max_depth,
+                                           visited, visited_len + 1,
+                                           parent_hops, next_child_hops,
+                                           next_cost, results)) {
+            found = true;
+        }
+    }
+
+    return found;
+}
+
+bool wam_collect_bidirectional_ancestor_hops(WamState *state,
+                                             WamBidirectionalAncestorResults *results) {
+    const char *cat = NULL;
+    const char *root = NULL;
+    const char *visited[64];
+    int visited_len = 0;
+    if (!wam_value_as_atom(state, state->A[0], &cat)) return false;
+    if (!wam_value_as_atom(state, state->A[1], &root)) return false;
+    if (strcmp(cat, root) == 0) {
+        return wam_bidirectional_ancestor_results_push(results, 0, 0, 0);
+    }
+
+    visited[visited_len++] = cat;
+    int max_depth = state->category_max_depth > 0 ? state->category_max_depth : 10;
+    return wam_bidirectional_ancestor_dfs(state, cat, root, 0, max_depth,
+                                          visited, visited_len, 0, 0, 0.0,
+                                          results);
+}
+
+static bool wam_unify_bidirectional_ancestor_result(
+        WamState *state,
+        WamBidirectionalAncestorResult *result) {
+    WamValue total_value = val_int(result->total_hops);
+    WamValue parent_value = val_int(result->parent_hops);
+    WamValue child_value = val_int(result->child_hops);
+    return wam_unify(state, &state->A[2], &total_value) &&
+           wam_unify(state, &state->A[3], &parent_value) &&
+           wam_unify(state, &state->A[4], &child_value);
+}
+
+bool wam_bidirectional_ancestor_handler(WamState *state, const char *pred, int arity) {
+    (void)pred;
+    if (arity != 5) return false;
+
+    WamBidirectionalAncestorResults results;
+    wam_bidirectional_ancestor_results_init(&results);
+    if (!wam_collect_bidirectional_ancestor_hops(state, &results) || results.count == 0) {
+        wam_bidirectional_ancestor_results_close(&results);
+        return false;
+    }
+
+    bool ok = false;
+    for (int i = 0; i < results.count; i++) {
+        if (wam_unify_bidirectional_ancestor_result(state, &results.values[i])) {
+            ok = true;
+            break;
+        }
+    }
+    wam_bidirectional_ancestor_results_close(&results);
     return ok;
 }
 

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -265,6 +265,18 @@ test_category_ancestor_kernel_generation :-
     ;   fail_test(Test, 'category_ancestor native kernel helpers missing')
     ).
 
+test_bidirectional_ancestor_kernel_generation :-
+    Test = 'WAM-C: bidirectional_ancestor native kernel helpers generated',
+    (   compile_wam_runtime_to_c([], RuntimeCode),
+        atom_string(RuntimeCode, S),
+        sub_string(S, _, _, _, 'void wam_register_bidirectional_ancestor_kernel'),
+        sub_string(S, _, _, _, 'bool wam_bidirectional_ancestor_handler'),
+        sub_string(S, _, _, _, 'wam_bidirectional_ancestor_dfs'),
+        sub_string(S, _, _, _, 'bidirectional_parent_step_cost')
+    ->  pass(Test)
+    ;   fail_test(Test, 'bidirectional_ancestor native kernel helpers missing')
+    ).
+
 test_transitive_closure_kernel_generation :-
     Test = 'WAM-C: transitive_closure2 native kernel helpers generated',
     (   compile_wam_runtime_to_c([], RuntimeCode),
@@ -465,6 +477,19 @@ test_kernel_detector_setup_generation :-
         pass(Test)
     ;   cleanup_wam_c_detector_category_ancestor,
         fail_test(Test, 'detected kernel setup missing')
+    ).
+
+test_bidirectional_ancestor_setup_generation :-
+    Test = 'WAM-C: bidirectional_ancestor setup preserves direction costs',
+    Kernel = 'bidirectional_ancestor/5'-recursive_kernel(
+        bidirectional_ancestor,
+        bidirectional_ancestor/5,
+        [max_depth(7), parent_step_cost(1.5), child_step_cost(4.0), cost_budget(12.0)]),
+    (   generate_setup_detected_kernels_c([Kernel], SetupCode),
+        sub_atom(SetupCode, _, _, _, 'setup_detected_wam_c_kernels'),
+        sub_atom(SetupCode, _, _, _, 'wam_register_bidirectional_ancestor_kernel(state, "bidirectional_ancestor/5", 7, 1.5, 4.0, 12.0)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'bidirectional_ancestor setup missing direction costs')
     ).
 
 test_transitive_closure_detector_setup_generation :-
@@ -1121,6 +1146,16 @@ test_category_ancestor_kernel_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_bidirectional_ancestor_kernel_executable_smoke :-
+    Test = 'WAM-C: bidirectional_ancestor native kernel executable smoke',
+    (   gcc_available
+    ->  (   run_bidirectional_ancestor_kernel_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'bidirectional_ancestor native kernel executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_transitive_closure_kernel_executable_smoke :-
     Test = 'WAM-C: transitive_closure2 native kernel executable smoke',
     (   gcc_available
@@ -1581,6 +1616,25 @@ run_category_ancestor_kernel_executable_smoke :-
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
 
+run_bidirectional_ancestor_kernel_executable_smoke :-
+    WamCode = 'bidirectional_ancestor/5:\n    call_foreign bidirectional_ancestor/5, 5\n    proceed',
+    compile_wam_predicate_to_c(user:bidirectional_ancestor/5, WamCode, [], PredCode),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_bidirectional_ancestor_smoke', Stamp, TmpBase),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(RuntimePath, RuntimeCode),
+    format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+    write_text_file(PredPath, PredTranslationUnit),
+    wam_c_bidirectional_ancestor_smoke_main(MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
 run_transitive_closure_kernel_executable_smoke :-
     WamCode = 'tc_ancestor/2:\n    call_foreign tc_ancestor/2, 2\n    proceed',
     compile_wam_predicate_to_c(user:tc_ancestor/2, WamCode, [], PredCode),
@@ -2004,7 +2058,7 @@ run_real_prolog_multiclause_executable_smoke :-
     assertz((user:wam_c_real_multi(X, int) :- integer(X))),
     assertz((user:wam_c_real_multi([_|_], list) :- true)),
     (   compile_predicate_to_wam(user:wam_c_real_multi/2, [], WamCode),
-        sub_string(WamCode, _, _, _, 'switch_on_constant_a2'),
+        sub_string(WamCode, _, _, _, 'switch_on_constant_fallthrough'),
         sub_string(WamCode, _, _, _, 'retry_me_else'),
         sub_string(WamCode, _, _, _, 'builtin_call integer/1, 1'),
         compile_wam_predicate_to_c(user:wam_c_real_multi/2, WamCode, [], PredCode),
@@ -2868,6 +2922,76 @@ int main(void) {
     if (fail_rc != WAM_HALT) {
         wam_free_state(&state);
         return 30;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
+wam_c_bidirectional_ancestor_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_bidirectional_ancestor_5(WamState* state);
+
+static int run_query(WamState *state,
+                     const char *cat,
+                     const char *root,
+                     int *total,
+                     int *parents,
+                     int *children) {
+    WamValue args[5] = {
+        val_atom(cat),
+        val_atom(root),
+        val_unbound("Total"),
+        val_unbound("Parents"),
+        val_unbound("Children")
+    };
+    int rc = wam_run_predicate(state, "bidirectional_ancestor/5", args, 5);
+    if (rc != 0 || state->P != WAM_HALT) return 0;
+    if (state->A[2].tag != VAL_INT ||
+        state->A[3].tag != VAL_INT ||
+        state->A[4].tag != VAL_INT) {
+        return 0;
+    }
+    *total = state->A[2].data.integer;
+    *parents = state->A[3].data.integer;
+    *children = state->A[4].data.integer;
+    return 1;
+}
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_bidirectional_ancestor_5(&state);
+    wam_register_category_parent(&state, "orphan", "side");
+    wam_register_category_parent(&state, "child", "orphan");
+    wam_register_category_parent(&state, "child", "root");
+    wam_register_bidirectional_ancestor_kernel(&state, "bidirectional_ancestor/5",
+                                               4, 1.0, 2.0, 10.0);
+
+    int total = -1;
+    int parents = -1;
+    int children = -1;
+    if (!run_query(&state, "orphan", "root", &total, &parents, &children) ||
+        total != 2 || parents != 1 || children != 1) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    wam_register_bidirectional_ancestor_kernel(&state, "bidirectional_ancestor/5",
+                                               4, 1.0, 2.0, 2.5);
+    WamValue pruned_args[5] = {
+        val_atom("orphan"),
+        val_atom("root"),
+        val_unbound("Total"),
+        val_unbound("Parents"),
+        val_unbound("Children")
+    };
+    int pruned_rc = wam_run_predicate(&state, "bidirectional_ancestor/5", pruned_args, 5);
+    if (pruned_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
     }
 
     wam_free_state(&state);
@@ -4681,6 +4805,7 @@ run_tests_once :-
     test_builtin_call_generation,
     test_call_foreign_generation,
     test_category_ancestor_kernel_generation,
+    test_bidirectional_ancestor_kernel_generation,
     test_transitive_closure_kernel_generation,
     test_transitive_distance_kernel_generation,
     test_transitive_parent_distance_kernel_generation,
@@ -4695,6 +4820,7 @@ run_tests_once :-
     test_reverse_index_plan_runtime_available_lmdb_offset,
     test_streaming_foreign_results_generation,
     test_kernel_detector_setup_generation,
+    test_bidirectional_ancestor_setup_generation,
     test_transitive_closure_detector_setup_generation,
     test_transitive_distance_detector_setup_generation,
     test_transitive_parent_distance_detector_setup_generation,
@@ -4722,6 +4848,7 @@ run_tests_once :-
     test_builtin_call_executable_smoke,
     test_call_foreign_executable_smoke,
     test_category_ancestor_kernel_executable_smoke,
+    test_bidirectional_ancestor_kernel_executable_smoke,
     test_transitive_closure_kernel_executable_smoke,
     test_transitive_distance_kernel_executable_smoke,
     test_transitive_parent_distance_kernel_executable_smoke,


### PR DESCRIPTION
  ## Summary
  - Add native WAM-C support for `bidirectional_ancestor/5`, returning `total_hops`, `parent_hops`, and `child_hops`.
  - Preserve direction-aware costs through kernel setup via `parent_step_cost`, `child_step_cost`, and `cost_budget`.
  - Add bounded bidirectional traversal in the C runtime with budget pruning.
  - Teach WAM-C to parse and execute `switch_on_constant_fallthrough` / A2 fallthrough switches.
  - Add generation and executable smoke coverage for the new bidirectional kernel.

  ## Verification
  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
  - `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
  - `git diff --check`