### PR TITLE
Feat/wam go tab builtin

### DIFF
--- a/PR_go_wam_tab_builtin.md
+++ b/PR_go_wam_tab_builtin.md
@@ -1,0 +1,30 @@
+# PR Title
+
+Add Go WAM tab/1 builtin parity
+
+# PR Description
+
+## Summary
+
+- Adds direct Go WAM lowering for `tab/1`.
+- Implements generated Go runtime support for `tab(+N)`, writing `N` spaces for nonnegative integer arguments.
+- Extends the generated Go WAM builtin E2E test with nonnegative space output, zero-width success, negative integer failure, unbound argument failure, and non-integer failure.
+- Updates the Go WAM parity audit I/O row to record `tab/1` coverage against the R/C++ I/O polish surface.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(tab/1,1), G), writeln(G), halt"`
+- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
+- `git diff --check`
+
+## Push
+
+```sh
+git push -u origin feat/wam-go-tab-builtin
+```

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -21,7 +21,7 @@ current cross-target builtin/runtime baseline.
 | Univ | `=../2` compose/decompose | `=../2` compose/decompose | Present |
 | Copying | `copy_term/2` with fresh variables and preserved sharing | `copy_term/2` with fresh variables and preserved sharing | Present |
 | Control | `true/0`, `fail/0`, `!/0`, `\+/1`, `CutIte` | Same baseline, with broader isolated-goal NAF in Haskell/Python | Present for current baseline, including isolated user-goal NAF and race-to-true over multi-clause WAM targets |
-| IO | `write/1`, `display/1`, `nl/0` | `write/1`, `display/1`, `nl/0` | Present |
+| IO | `write/1`, `display/1`, `nl/0`, `tab/1` | `write/1`, `display/1`, `nl/0`; R/C++ also cover `tab/1` | Present for current baseline plus tab output |
 
 ## Immediate Findings
 
@@ -88,6 +88,10 @@ current cross-target builtin/runtime baseline.
   no-separator padding, separator plus pad trimming, multiple separators,
   numeric source conversion, unbound input failure, and bound-output mismatch
   failure, matching the R/C++ deterministic split-string surface.
+- `tab/1` is now covered by the generated Go WAM builtin E2E test for
+  nonnegative space output, zero-width success, negative integer failure,
+  unbound argument failure, and non-integer failure, matching the R/C++
+  basic I/O polish surface.
 - Bidirectional `succ/2` is now covered by the generated Go WAM builtin E2E
   test for forward binding, reverse binding, matching integer pairs, mismatch
   failure, negative predecessor failure, non-positive successor failure, and

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -475,6 +475,9 @@ wam_go_direct_builtin("string_code/3", 3, 'string_code/3').
 wam_go_direct_builtin(split_string/4, 4, 'split_string/4').
 wam_go_direct_builtin('split_string/4', 4, 'split_string/4').
 wam_go_direct_builtin("split_string/4", 4, 'split_string/4').
+wam_go_direct_builtin(tab/1, 1, 'tab/1').
+wam_go_direct_builtin('tab/1', 1, 'tab/1').
+wam_go_direct_builtin("tab/1", 1, 'tab/1').
 wam_go_direct_builtin(succ/2, 2, 'succ/2').
 wam_go_direct_builtin('succ/2', 2, 'succ/2').
 wam_go_direct_builtin("succ/2", 2, 'succ/2').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1227,6 +1227,13 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 	case "nl/0":
 		fmt.Println()
 		return true
+	case "tab/1":
+		count, ok := vm.deref(arg1).(*Integer)
+		if !ok || count.Val < 0 {
+			return false
+		}
+		fmt.Print(strings.Repeat(" ", int(count.Val)))
+		return true
 	case "true/0":
 		return true
 	case "fail/0":

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -22,6 +22,7 @@
 :- dynamic user:test_char_type_builtin/0.
 :- dynamic user:test_string_code_builtin/0.
 :- dynamic user:test_split_string_builtin/0.
+:- dynamic user:test_tab_builtin/0.
 :- dynamic user:test_succ_builtin/0.
 :- dynamic user:test_atom_number_builtin/0.
 :- dynamic user:test_atom_case_builtin/0.
@@ -255,6 +256,14 @@ test(builtins_execution) :-
                 \+ split_string('a,b', Comma, _, _),
                 \+ split_string('a,b', Comma, '', [a,b,c])
             )),
+          assertz(user:test_tab_builtin :-
+            (   tab(3),
+                write(tabbed),
+                tab(0),
+                \+ tab(-1),
+                \+ tab(_),
+                \+ tab(foo)
+            )),
           assertz(user:test_succ_builtin :-
             (   succ(0, 1),
                 succ(2, X),
@@ -458,6 +467,7 @@ test(builtins_execution) :-
           retractall(user:test_char_type_builtin),
           retractall(user:test_string_code_builtin),
           retractall(user:test_split_string_builtin),
+          retractall(user:test_tab_builtin),
           retractall(user:test_succ_builtin),
           retractall(user:test_atom_number_builtin),
           retractall(user:test_atom_case_builtin),
@@ -478,7 +488,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_tab_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -530,6 +540,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "char_type/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "string_code/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "split_string/4"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "tab/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "succ/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "atom_number/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "upcase_atom/2"')),
@@ -703,6 +714,14 @@ func main() {
 		fmt.Println("SPLIT_STRING_FAILURE")
 	}
 
+	tabVM := wam.NewWamState(wam.Test_tab_builtinCode, wam.Test_tab_builtinLabels)
+	tabVM.PC = wam.Test_tab_builtinStartPC
+	if tabVM.Run() {
+		fmt.Println("TAB_SUCCESS")
+	} else {
+		fmt.Println("TAB_FAILURE")
+	}
+
 	succVM := wam.NewWamState(wam.Test_succ_builtinCode, wam.Test_succ_builtinLabels)
 	succVM.PC = wam.Test_succ_builtinStartPC
 	if succVM.Run() {
@@ -857,6 +876,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "CHAR_TYPE_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "STRING_CODE_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SPLIT_STRING_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "   tabbedTAB_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SUCC_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_NUMBER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_CASE_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM tab/1 builtin parity

## Summary

- Adds direct Go WAM lowering for `tab/1`.
- Implements generated Go runtime support for `tab(+N)`, writing `N` spaces for nonnegative integer arguments.
- Extends the generated Go WAM builtin E2E test with nonnegative space output, zero-width success, negative integer failure, unbound argument failure, and non-integer failure.
- Updates the Go WAM parity audit I/O row to record `tab/1` coverage against the R/C++ I/O polish surface.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), wam_go_target:wam_instruction_to_go_literal(call(tab/1,1), G), writeln(G), halt"`
- `swipl -q -g "use_module(src/unifyweaver/targets/wam_go_target), halt"`
- `git diff --check`

## Push

```sh
git push -u origin feat/wam-go-tab-builtin
```
