### PR TITLE
Use reverse CSR for WAM-C bidirectional child lookup

### DIFF
--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -146,6 +146,11 @@ typedef struct {
 } WamReverseCsrArtifact;
 
 typedef struct {
+    const char *atom;
+    int id;
+} WamCategoryIdEntry;
+
+typedef struct {
     int *values;
     int count;
     int cap;
@@ -280,6 +285,10 @@ struct WamState {
     double bidirectional_parent_step_cost;
     double bidirectional_child_step_cost;
     double bidirectional_cost_budget;
+    WamReverseCsrArtifact *bidirectional_child_csr;
+    WamCategoryIdEntry *category_ids;
+    int category_id_count;
+    int category_id_cap;
 
     /* Native weighted_shortest_path3 kernel data */
     WeightedEdge *weighted_edges;
@@ -329,6 +338,8 @@ bool wam_fact_source_load_lmdb(WamState *state, WamFactSource *source,
 int wam_fact_source_lookup_arg1(WamFactSource *source, const char *arg1,
                                 CategoryEdge *out_edges, int max_edges);
 bool wam_register_category_parent_fact_source(WamState *state, WamFactSource *source);
+void wam_register_category_id(WamState *state, const char *atom, int id);
+void wam_attach_bidirectional_child_csr(WamState *state, WamReverseCsrArtifact *artifact);
 void wam_reverse_csr_init(WamReverseCsrArtifact *artifact);
 void wam_reverse_csr_close(WamReverseCsrArtifact *artifact);
 bool wam_reverse_csr_load(WamReverseCsrArtifact *artifact,

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -2103,6 +2103,7 @@ void wam_free_state(WamState *state) {
     free(state->B_array);
     free(state->E_array);
     free(state->category_edges);
+    free(state->category_ids);
     free(state->weighted_edges);
     free(state->direct_distance_edges);
     memset(state, 0, sizeof(WamState));
@@ -2562,6 +2563,27 @@ bool wam_register_category_parent_fact_source(WamState *state, WamFactSource *so
     return true;
 }
 
+void wam_register_category_id(WamState *state, const char *atom, int id) {
+    const char *interned = wam_intern_atom(state, atom);
+    for (int i = 0; i < state->category_id_count; i++) {
+        if (strcmp(state->category_ids[i].atom, interned) == 0) {
+            state->category_ids[i].id = id;
+            return;
+        }
+    }
+    if (state->category_id_count >= state->category_id_cap) {
+        state->category_id_cap = state->category_id_cap ? state->category_id_cap * 2 : WAM_INITIAL_CAP;
+        state->category_ids = realloc(state->category_ids, sizeof(WamCategoryIdEntry) * state->category_id_cap);
+    }
+    state->category_ids[state->category_id_count].atom = interned;
+    state->category_ids[state->category_id_count].id = id;
+    state->category_id_count++;
+}
+
+void wam_attach_bidirectional_child_csr(WamState *state, WamReverseCsrArtifact *artifact) {
+    state->bidirectional_child_csr = artifact;
+}
+
 static int32_t wam_read_i32_le(const unsigned char *p) {
     uint32_t v = ((uint32_t)p[0]) |
                  ((uint32_t)p[1] << 8) |
@@ -2940,6 +2962,26 @@ static bool wam_visited_array_contains(const char **visited, int visited_len, co
     return false;
 }
 
+static bool wam_category_atom_to_id(WamState *state, const char *atom, int *id_out) {
+    for (int i = 0; i < state->category_id_count; i++) {
+        if (strcmp(state->category_ids[i].atom, atom) == 0) {
+            *id_out = state->category_ids[i].id;
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool wam_category_id_to_atom(WamState *state, int id, const char **atom_out) {
+    for (int i = 0; i < state->category_id_count; i++) {
+        if (state->category_ids[i].id == id) {
+            *atom_out = state->category_ids[i].atom;
+            return true;
+        }
+    }
+    return false;
+}
+
 static bool wam_category_ancestor_dfs(WamState *state,
                                       const char *cat,
                                       const char *root,
@@ -3035,6 +3077,107 @@ static bool wam_bidirectional_ancestor_dfs(WamState *state,
                                            int parent_hops,
                                            int child_hops,
                                            double cost,
+                                           WamBidirectionalAncestorResults *results);
+
+static bool wam_bidirectional_ancestor_step_child(
+        WamState *state,
+        const char *child,
+        const char *root,
+        int depth,
+        int max_depth,
+        const char **visited,
+        int visited_len,
+        int parent_hops,
+        int child_hops,
+        double cost,
+        double child_cost,
+        double budget,
+        WamBidirectionalAncestorResults *results,
+        bool *found) {
+    if (wam_visited_array_contains(visited, visited_len, child)) return true;
+    double next_cost = cost + child_cost;
+    if (next_cost > budget) return true;
+    int next_child_hops = child_hops + 1;
+    if (strcmp(child, root) == 0) {
+        if (!wam_bidirectional_ancestor_results_push(
+                results, parent_hops + next_child_hops,
+                parent_hops, next_child_hops)) {
+            return false;
+        }
+        *found = true;
+        return true;
+    }
+    if (depth + 1 >= max_depth || visited_len >= 64) return true;
+    visited[visited_len] = child;
+    if (wam_bidirectional_ancestor_dfs(state, child, root,
+                                       depth + 1, max_depth,
+                                       visited, visited_len + 1,
+                                       parent_hops, next_child_hops,
+                                       next_cost, results)) {
+        *found = true;
+    }
+    return true;
+}
+
+static bool wam_bidirectional_ancestor_expand_children(
+        WamState *state,
+        const char *node,
+        const char *root,
+        int depth,
+        int max_depth,
+        const char **visited,
+        int visited_len,
+        int parent_hops,
+        int child_hops,
+        double cost,
+        double child_cost,
+        double budget,
+        WamBidirectionalAncestorResults *results,
+        bool *found) {
+    if (state->bidirectional_child_csr) {
+        int parent_id = 0;
+        if (!wam_category_atom_to_id(state, node, &parent_id)) return true;
+        int child_ids[256];
+        int child_count = wam_reverse_csr_lookup_children(
+            state->bidirectional_child_csr, parent_id, child_ids, 256);
+        if (child_count < 0) return false;
+        int limit = child_count < 256 ? child_count : 256;
+        for (int i = 0; i < limit; i++) {
+            const char *child = NULL;
+            if (!wam_category_id_to_atom(state, child_ids[i], &child)) continue;
+            if (!wam_bidirectional_ancestor_step_child(
+                    state, child, root, depth, max_depth, visited, visited_len,
+                    parent_hops, child_hops, cost, child_cost, budget,
+                    results, found)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    for (int i = 0; i < state->category_edge_count; i++) {
+        CategoryEdge *edge = &state->category_edges[i];
+        if (strcmp(edge->parent, node) != 0) continue;
+        if (!wam_bidirectional_ancestor_step_child(
+                state, edge->child, root, depth, max_depth, visited, visited_len,
+                parent_hops, child_hops, cost, child_cost, budget,
+                results, found)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool wam_bidirectional_ancestor_dfs(WamState *state,
+                                           const char *node,
+                                           const char *root,
+                                           int depth,
+                                           int max_depth,
+                                           const char **visited,
+                                           int visited_len,
+                                           int parent_hops,
+                                           int child_hops,
+                                           double cost,
                                            WamBidirectionalAncestorResults *results) {
     bool found = false;
     double parent_cost = state->bidirectional_parent_step_cost > 0.0
@@ -3074,31 +3217,11 @@ static bool wam_bidirectional_ancestor_dfs(WamState *state,
         }
     }
 
-    for (int i = 0; i < state->category_edge_count; i++) {
-        CategoryEdge *edge = &state->category_edges[i];
-        if (strcmp(edge->parent, node) != 0) continue;
-        if (wam_visited_array_contains(visited, visited_len, edge->child)) continue;
-        double next_cost = cost + child_cost;
-        if (next_cost > budget) continue;
-        int next_child_hops = child_hops + 1;
-        if (strcmp(edge->child, root) == 0) {
-            if (!wam_bidirectional_ancestor_results_push(
-                    results, parent_hops + next_child_hops,
-                    parent_hops, next_child_hops)) {
-                return false;
-            }
-            found = true;
-            continue;
-        }
-        if (depth + 1 >= max_depth || visited_len >= 64) continue;
-        visited[visited_len] = edge->child;
-        if (wam_bidirectional_ancestor_dfs(state, edge->child, root,
-                                           depth + 1, max_depth,
-                                           visited, visited_len + 1,
-                                           parent_hops, next_child_hops,
-                                           next_cost, results)) {
-            found = true;
-        }
+    if (!wam_bidirectional_ancestor_expand_children(
+            state, node, root, depth, max_depth, visited, visited_len,
+            parent_hops, child_hops, cost, child_cost, budget,
+            results, &found)) {
+        return false;
     }
 
     return found;

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -272,6 +272,8 @@ test_bidirectional_ancestor_kernel_generation :-
         sub_string(S, _, _, _, 'void wam_register_bidirectional_ancestor_kernel'),
         sub_string(S, _, _, _, 'bool wam_bidirectional_ancestor_handler'),
         sub_string(S, _, _, _, 'wam_bidirectional_ancestor_dfs'),
+        sub_string(S, _, _, _, 'void wam_attach_bidirectional_child_csr'),
+        sub_string(S, _, _, _, 'void wam_register_category_id'),
         sub_string(S, _, _, _, 'bidirectional_parent_step_cost')
     ->  pass(Test)
     ;   fail_test(Test, 'bidirectional_ancestor native kernel helpers missing')
@@ -1156,6 +1158,16 @@ test_bidirectional_ancestor_kernel_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_bidirectional_ancestor_csr_child_lookup_executable_smoke :-
+    Test = 'WAM-C: bidirectional_ancestor uses reverse CSR child lookup',
+    (   gcc_available
+    ->  (   run_bidirectional_ancestor_csr_child_lookup_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'bidirectional_ancestor reverse CSR child lookup failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_transitive_closure_kernel_executable_smoke :-
     Test = 'WAM-C: transitive_closure2 native kernel executable smoke',
     (   gcc_available
@@ -1631,6 +1643,33 @@ run_bidirectional_ancestor_kernel_executable_smoke :-
     format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
     write_text_file(PredPath, PredTranslationUnit),
     wam_c_bidirectional_ancestor_smoke_main(MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
+run_bidirectional_ancestor_csr_child_lookup_executable_smoke :-
+    WamCode = 'bidirectional_ancestor/5:\n    call_foreign bidirectional_ancestor/5, 5\n    proceed',
+    compile_wam_predicate_to_c(user:bidirectional_ancestor/5, WamCode, [], PredCode),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_bidirectional_ancestor_csr_smoke', Stamp, TmpBase),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(IndexPath), '~w.csr.idx', [TmpBase]),
+    format(atom(ValuesPath), '~w.csr.val', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    write_text_file(RuntimePath, RuntimeCode),
+    format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+    write_text_file(PredPath, PredTranslationUnit),
+    write_binary_file(IndexPath, [
+        20,0,0,0, 0,0,0,0,0,0,0,0, 1,0,0,0
+    ]),
+    write_binary_file(ValuesPath, [
+        30,0,0,0
+    ]),
+    wam_c_bidirectional_ancestor_csr_smoke_main(IndexPath, ValuesPath, MainCode),
     write_text_file(MainPath, MainCode),
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
@@ -2998,6 +3037,71 @@ int main(void) {
     return 0;
 }
 ').
+
+wam_c_bidirectional_ancestor_csr_smoke_main(IndexPath, ValuesPath, MainCode) :-
+    format(atom(MainCode),
+'#include "wam_runtime.h"
+
+void setup_bidirectional_ancestor_5(WamState* state);
+
+int main(void) {
+    WamState state;
+    WamReverseCsrArtifact csr;
+    wam_state_init(&state);
+    wam_reverse_csr_init(&csr);
+    setup_bidirectional_ancestor_5(&state);
+
+    if (!wam_reverse_csr_load(&csr, "~w", "~w")) {
+        wam_reverse_csr_close(&csr);
+        wam_free_state(&state);
+        return 5;
+    }
+
+    wam_register_category_id(&state, "orphan", 20);
+    wam_register_category_id(&state, "child", 30);
+    wam_register_category_id(&state, "root", 40);
+    wam_register_category_parent(&state, "child", "root");
+    wam_attach_bidirectional_child_csr(&state, &csr);
+    wam_register_bidirectional_ancestor_kernel(&state, "bidirectional_ancestor/5",
+                                               4, 1.0, 2.0, 10.0);
+
+    WamValue args[5] = {
+        val_atom("orphan"),
+        val_atom("root"),
+        val_unbound("Total"),
+        val_unbound("Parents"),
+        val_unbound("Children")
+    };
+    int rc = wam_run_predicate(&state, "bidirectional_ancestor/5", args, 5);
+    if (rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 2 ||
+        state.A[3].tag != VAL_INT || state.A[3].data.integer != 1 ||
+        state.A[4].tag != VAL_INT || state.A[4].data.integer != 1) {
+        wam_reverse_csr_close(&csr);
+        wam_free_state(&state);
+        return 10;
+    }
+
+    wam_attach_bidirectional_child_csr(&state, NULL);
+    WamValue fallback_args[5] = {
+        val_atom("orphan"),
+        val_atom("root"),
+        val_unbound("Total"),
+        val_unbound("Parents"),
+        val_unbound("Children")
+    };
+    int fallback_rc = wam_run_predicate(&state, "bidirectional_ancestor/5", fallback_args, 5);
+    if (fallback_rc != WAM_HALT) {
+        wam_reverse_csr_close(&csr);
+        wam_free_state(&state);
+        return 20;
+    }
+
+    wam_reverse_csr_close(&csr);
+    wam_free_state(&state);
+    return 0;
+}
+', [IndexPath, ValuesPath]).
 
 wam_c_transitive_closure_smoke_main(
 '#include "wam_runtime.h"
@@ -4849,6 +4953,7 @@ run_tests_once :-
     test_call_foreign_executable_smoke,
     test_category_ancestor_kernel_executable_smoke,
     test_bidirectional_ancestor_kernel_executable_smoke,
+    test_bidirectional_ancestor_csr_child_lookup_executable_smoke,
     test_transitive_closure_kernel_executable_smoke,
     test_transitive_distance_kernel_executable_smoke,
     test_transitive_parent_distance_kernel_executable_smoke,


### PR DESCRIPTION
  ## Summary
  - Add WAM-C runtime hooks to register category atom IDs and attach a reverse CSR artifact.
  - Teach `bidirectional_ancestor/5` to expand child edges through `wam_reverse_csr_lookup_children` when a CSR is
  attached.
  - Preserve the existing in-memory edge-scan child expansion as the fallback path.
  - Add an executable smoke test proving a child path is found through CSR and disappears when CSR is detached.

  ## Verification
  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
  - `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
  - `git diff --check`