### PR TITLE
Wire WAM-C reverse CSR setup from options

### DIFF
--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -21,6 +21,7 @@
     wam_instruction_to_c_literal/3,   % +WamInstr, +LabelMap, -CCode
     detect_kernels/2,                 % +Predicates, -DetectedKernels
     generate_setup_detected_kernels_c/2, % +DetectedKernels, -CCode
+    generate_setup_reverse_index_c/2, % +Options, -CCode
     resolve_wam_c_reverse_index_plan/2, % +Options, -Plan
     plan_wam_c_lowered_helpers/4,     % +Predicates, +Options, +DetectedKeys, -Plans
     write_wam_c_project/3             % +Predicates, +Options, +ProjectDir
@@ -114,12 +115,14 @@ write_wam_c_project(Predicates, Options, ProjectDir) :-
     compile_lowered_helpers_for_project(LoweredPlans, LoweredKeys, LoweredCode, SetupLoweredCode),
     render_wam_c_lowered_helper_plan(LoweredPlans, LoweredPlanCode),
     generate_setup_detected_kernels_c(DetectedKernels, SetupKernelCode),
+    generate_setup_reverse_index_c(Options, SetupReverseIndexCode),
     compile_predicates_for_project(Predicates,
                                    [detected_kernel_keys(DetectedKeys),
                                     lowered_helper_keys(LoweredKeys)|Options],
                                    PredicatesCode),
-    format(atom(LibCode), '#include "wam_runtime.h"~n~n~w~n~n~w~n~n~w~n~n~w',
-           [LoweredPlanCode, SetupKernelCode, LoweredCode, SetupLoweredCode]),
+    format(atom(LibCode), '#include "wam_runtime.h"~n~n~w~n~n~w~n~n~w~n~n~w~n~n~w',
+           [LoweredPlanCode, SetupKernelCode, SetupReverseIndexCode,
+            LoweredCode, SetupLoweredCode]),
     format(atom(LibCodeWithPredicates), '~w~n~n~w', [LibCode, PredicatesCode]),
     directory_file_path(ProjectDir, 'lib.c', LibPath),
     write_file(LibPath, LibCodeWithPredicates),
@@ -207,6 +210,147 @@ generate_setup_detected_kernels_c(DetectedKernels, Code) :-
     format(atom(Code),
            'void setup_detected_wam_c_kernels(WamState* state) {\n~w\n}',
            [Body]).
+
+%% generate_setup_reverse_index_c(+Options, -CCode)
+%  Emit project-level lifecycle hooks for a declaratively configured
+%  runtime reverse CSR. The generated setup function only attaches an
+%  artifact when the normalized reverse_index phase is runtime_available
+%  and the caller provided the concrete artifact paths.
+generate_setup_reverse_index_c(Options, Code) :-
+    (   wam_c_reverse_index_setup_plan(Options, Plan)
+    ->  wam_c_reverse_index_setup_code(Plan, Code)
+    ;   wam_c_reverse_index_noop_setup_code(Code)
+    ).
+
+wam_c_reverse_index_setup_plan(Options, Plan) :-
+    resolve_wam_c_reverse_index_plan(Options,
+        wam_c_reverse_index_plan(ReverseIndex, Capabilities)),
+    wam_c_reverse_index_runtime_available(ReverseIndex, Capabilities),
+    wam_c_reverse_index_setup_backend(ReverseIndex, Backend),
+    wam_c_reverse_index_setup_paths(Backend, Options, Paths),
+    option(category_id_map(CategoryIdMap), Options, []),
+    Plan = wam_c_reverse_index_setup(Backend, Paths, CategoryIdMap).
+
+wam_c_reverse_index_runtime_available(artifact(Opts), Capabilities) :-
+    memberchk(phase(runtime_available), Opts),
+    memberchk(runtime_child_lookup(available), Capabilities).
+wam_c_reverse_index_runtime_available(csr(Opts), Capabilities) :-
+    memberchk(phase(runtime_available), Opts),
+    (   memberchk(runtime_child_lookup(available), Capabilities)
+    ;   memberchk(runtime_child_lookup(available_after_artifact_build), Capabilities)
+    ).
+
+wam_c_reverse_index_setup_backend(ReverseIndex, lmdb_offset) :-
+    wam_c_reverse_index_uses_lmdb_offset(ReverseIndex),
+    !.
+wam_c_reverse_index_setup_backend(_ReverseIndex, sorted_array).
+
+wam_c_reverse_index_setup_paths(sorted_array, Options,
+                                sorted_array(IndexPath, ValuesPath)) :-
+    option(reverse_csr_index_path(IndexPath), Options),
+    option(reverse_csr_values_path(ValuesPath), Options).
+wam_c_reverse_index_setup_paths(lmdb_offset, Options,
+                                lmdb_offset(OffsetPath, ValuesPath, DbiName)) :-
+    option(reverse_csr_offset_lmdb_path(OffsetPath), Options),
+    option(reverse_csr_values_path(ValuesPath), Options),
+    option(reverse_csr_offset_lmdb_dbi(DbiName), Options, offsets).
+
+wam_c_reverse_index_noop_setup_code(
+'bool setup_wam_c_reverse_index_artifacts(WamState* state,
+                                         WamReverseCsrArtifact* bidirectional_child_csr) {
+    (void)state;
+    (void)bidirectional_child_csr;
+    return true;
+}
+
+void teardown_wam_c_reverse_index_artifacts(WamState* state,
+                                           WamReverseCsrArtifact* bidirectional_child_csr) {
+    (void)state;
+    (void)bidirectional_child_csr;
+}
+').
+
+wam_c_reverse_index_setup_code(
+        wam_c_reverse_index_setup(Backend, Paths, CategoryIdMap),
+        Code) :-
+    wam_c_reverse_index_load_call(Backend, Paths, LoadCall),
+    wam_c_category_id_setup_lines(CategoryIdMap, IdLines),
+    format(atom(Code),
+'bool setup_wam_c_reverse_index_artifacts(WamState* state,
+                                         WamReverseCsrArtifact* bidirectional_child_csr) {
+    wam_reverse_csr_init(bidirectional_child_csr);
+    if (!(~w)) {
+        wam_reverse_csr_close(bidirectional_child_csr);
+        return false;
+    }
+~w
+    wam_attach_bidirectional_child_csr(state, bidirectional_child_csr);
+    return true;
+}
+
+void teardown_wam_c_reverse_index_artifacts(WamState* state,
+                                           WamReverseCsrArtifact* bidirectional_child_csr) {
+    wam_attach_bidirectional_child_csr(state, NULL);
+    wam_reverse_csr_close(bidirectional_child_csr);
+}
+', [LoadCall, IdLines]).
+
+wam_c_reverse_index_load_call(sorted_array,
+                              sorted_array(IndexPath, ValuesPath),
+                              LoadCall) :-
+    c_string_literal(IndexPath, IndexLit),
+    c_string_literal(ValuesPath, ValuesLit),
+    format(atom(LoadCall),
+           'wam_reverse_csr_load(bidirectional_child_csr, ~w, ~w)',
+           [IndexLit, ValuesLit]).
+wam_c_reverse_index_load_call(lmdb_offset,
+                              lmdb_offset(OffsetPath, ValuesPath, DbiName),
+                              LoadCall) :-
+    c_string_literal(OffsetPath, OffsetLit),
+    c_string_literal(ValuesPath, ValuesLit),
+    c_string_literal(DbiName, DbiLit),
+    format(atom(LoadCall),
+           'wam_reverse_csr_load_lmdb_offset(bidirectional_child_csr, ~w, ~w, ~w)',
+           [ValuesLit, OffsetLit, DbiLit]).
+
+wam_c_category_id_setup_lines([], '').
+wam_c_category_id_setup_lines(CategoryIdMap, Lines) :-
+    CategoryIdMap \= [],
+    maplist(wam_c_category_id_setup_line, CategoryIdMap, LineList),
+    atomic_list_concat(LineList, '\n', Body),
+    format(atom(Lines), '~w\n', [Body]).
+
+wam_c_category_id_setup_line(Atom-Id, Line) :-
+    !,
+    wam_c_category_id_setup_line_(Atom, Id, Line).
+wam_c_category_id_setup_line(category_id(Atom, Id), Line) :-
+    !,
+    wam_c_category_id_setup_line_(Atom, Id, Line).
+wam_c_category_id_setup_line(id(Atom, Id), Line) :-
+    !,
+    wam_c_category_id_setup_line_(Atom, Id, Line).
+
+wam_c_category_id_setup_line_(Atom, Id, Line) :-
+    integer(Id),
+    c_string_literal(Atom, AtomLit),
+    format(atom(Line),
+           '    wam_register_category_id(state, ~w, ~w);',
+           [AtomLit, Id]).
+
+c_string_literal(Value, Literal) :-
+    format(atom(Raw), '~w', [Value]),
+    atom_codes(Raw, Codes),
+    phrase(c_string_literal_codes(Codes), EscapedCodes),
+    atom_codes(Escaped, EscapedCodes),
+    format(atom(Literal), '"~w"', [Escaped]).
+
+c_string_literal_codes([]) --> [].
+c_string_literal_codes([0'\\|Rest]) --> "\\\\", c_string_literal_codes(Rest).
+c_string_literal_codes([0'"|Rest]) --> "\\\"", c_string_literal_codes(Rest).
+c_string_literal_codes([10|Rest]) --> "\\n", c_string_literal_codes(Rest).
+c_string_literal_codes([13|Rest]) --> "\\r", c_string_literal_codes(Rest).
+c_string_literal_codes([9|Rest]) --> "\\t", c_string_literal_codes(Rest).
+c_string_literal_codes([Code|Rest]) --> [Code], c_string_literal_codes(Rest).
 
 wam_c_kernel_registration_line(Key-recursive_kernel(category_ancestor, _Pred, ConfigOps), Line) :-
     wam_c_kernel_max_depth(ConfigOps, MaxDepth),

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -455,6 +455,51 @@ test_reverse_index_plan_runtime_available_lmdb_offset :-
     ;   fail_test(Test, 'runtime lmdb-offset CSR artifact was not marked available')
     ).
 
+test_reverse_index_setup_generation :-
+    Test = 'WAM-C: reverse_index artifact emits CSR setup lifecycle',
+    (   generate_setup_reverse_index_c(
+            [reverse_index(artifact([
+                storage_kind(csr_pread_artifact),
+                phase(runtime_available),
+                index_backend(sorted_array),
+                io_policy(buffered_pread)
+            ])),
+             reverse_csr_index_path('/tmp/category_child.csr.idx'),
+             reverse_csr_values_path('/tmp/category_child.csr.val'),
+             category_id_map([orphan-20, child-30])],
+            Code
+        ),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'bool setup_wam_c_reverse_index_artifacts'),
+        sub_string(S, _, _, _, 'wam_reverse_csr_load(bidirectional_child_csr, "/tmp/category_child.csr.idx", "/tmp/category_child.csr.val")'),
+        sub_string(S, _, _, _, 'wam_register_category_id(state, "orphan", 20)'),
+        sub_string(S, _, _, _, 'wam_register_category_id(state, "child", 30)'),
+        sub_string(S, _, _, _, 'wam_attach_bidirectional_child_csr(state, bidirectional_child_csr)'),
+        sub_string(S, _, _, _, 'void teardown_wam_c_reverse_index_artifacts')
+    ->  pass(Test)
+    ;   fail_test(Test, 'reverse_index artifact setup lifecycle missing')
+    ).
+
+test_reverse_index_setup_lmdb_offset_generation :-
+    Test = 'WAM-C: reverse_index lmdb-offset setup preserves CSR load order',
+    (   generate_setup_reverse_index_c(
+            [reverse_index(artifact([
+                storage_kind(csr_pread_artifact),
+                phase(runtime_available),
+                index_backend(lmdb_offset),
+                io_policy(buffered_pread)
+            ])),
+             reverse_csr_offset_lmdb_path('/tmp/category_child.offsets.lmdb'),
+             reverse_csr_values_path('/tmp/category_child.csr.val'),
+             reverse_csr_offset_lmdb_dbi(offsets)],
+            Code
+        ),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'wam_reverse_csr_load_lmdb_offset(bidirectional_child_csr, "/tmp/category_child.csr.val", "/tmp/category_child.offsets.lmdb", "offsets")')
+    ->  pass(Test)
+    ;   fail_test(Test, 'LMDB-offset CSR setup load order changed')
+    ).
+
 test_streaming_foreign_results_generation :-
     Test = 'WAM-C: streaming foreign result helpers generated',
     (   compile_wam_runtime_to_c([], RuntimeCode),
@@ -1168,6 +1213,16 @@ test_bidirectional_ancestor_csr_child_lookup_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_reverse_index_setup_executable_smoke :-
+    Test = 'WAM-C: generated reverse_index CSR setup executable smoke',
+    (   gcc_available
+    ->  (   run_reverse_index_setup_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'generated reverse_index CSR setup executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_transitive_closure_kernel_executable_smoke :-
     Test = 'WAM-C: transitive_closure2 native kernel executable smoke',
     (   gcc_available
@@ -1670,6 +1725,46 @@ run_bidirectional_ancestor_csr_child_lookup_executable_smoke :-
         30,0,0,0
     ]),
     wam_c_bidirectional_ancestor_csr_smoke_main(IndexPath, ValuesPath, MainCode),
+    write_text_file(MainPath, MainCode),
+    compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+    run_c_smoke_plain(ExePath).
+
+run_reverse_index_setup_executable_smoke :-
+    WamCode = 'bidirectional_ancestor/5:\n    call_foreign bidirectional_ancestor/5, 5\n    proceed',
+    compile_wam_predicate_to_c(user:bidirectional_ancestor/5, WamCode, [], PredCode),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    get_time(Now),
+    Stamp is round(Now * 1000000),
+    wam_c_temp_path('unifyweaver_wam_c_reverse_index_setup_smoke', Stamp, TmpBase),
+    format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+    format(atom(PredPath), '~w_pred.c', [TmpBase]),
+    format(atom(MainPath), '~w_main.c', [TmpBase]),
+    format(atom(IndexPath), '~w.csr.idx', [TmpBase]),
+    format(atom(ValuesPath), '~w.csr.val', [TmpBase]),
+    format(atom(ExePath), '~w_bin', [TmpBase]),
+    generate_setup_reverse_index_c(
+        [reverse_index(artifact([
+            storage_kind(csr_pread_artifact),
+            phase(runtime_available),
+            index_backend(sorted_array),
+            io_policy(buffered_pread)
+        ])),
+         reverse_csr_index_path(IndexPath),
+         reverse_csr_values_path(ValuesPath),
+         category_id_map([orphan-20, child-30, root-40])],
+        SetupCode
+    ),
+    write_text_file(RuntimePath, RuntimeCode),
+    format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w~n~n~w',
+           [SetupCode, PredCode]),
+    write_text_file(PredPath, PredTranslationUnit),
+    write_binary_file(IndexPath, [
+        20,0,0,0, 0,0,0,0,0,0,0,0, 1,0,0,0
+    ]),
+    write_binary_file(ValuesPath, [
+        30,0,0,0
+    ]),
+    wam_c_reverse_index_setup_smoke_main(MainCode),
     write_text_file(MainPath, MainCode),
     compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
     run_c_smoke_plain(ExePath).
@@ -3102,6 +3197,66 @@ int main(void) {
     return 0;
 }
 ', [IndexPath, ValuesPath]).
+
+wam_c_reverse_index_setup_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_bidirectional_ancestor_5(WamState* state);
+bool setup_wam_c_reverse_index_artifacts(WamState* state,
+                                         WamReverseCsrArtifact* bidirectional_child_csr);
+void teardown_wam_c_reverse_index_artifacts(WamState* state,
+                                            WamReverseCsrArtifact* bidirectional_child_csr);
+
+int main(void) {
+    WamState state;
+    WamReverseCsrArtifact csr;
+    wam_state_init(&state);
+    setup_bidirectional_ancestor_5(&state);
+
+    if (!setup_wam_c_reverse_index_artifacts(&state, &csr)) {
+        wam_free_state(&state);
+        return 5;
+    }
+
+    wam_register_category_parent(&state, "child", "root");
+    wam_register_bidirectional_ancestor_kernel(&state, "bidirectional_ancestor/5",
+                                               4, 1.0, 2.0, 10.0);
+
+    WamValue args[5] = {
+        val_atom("orphan"),
+        val_atom("root"),
+        val_unbound("Total"),
+        val_unbound("Parents"),
+        val_unbound("Children")
+    };
+    int rc = wam_run_predicate(&state, "bidirectional_ancestor/5", args, 5);
+    if (rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_INT || state.A[2].data.integer != 2 ||
+        state.A[3].tag != VAL_INT || state.A[3].data.integer != 1 ||
+        state.A[4].tag != VAL_INT || state.A[4].data.integer != 1) {
+        teardown_wam_c_reverse_index_artifacts(&state, &csr);
+        wam_free_state(&state);
+        return 10;
+    }
+
+    teardown_wam_c_reverse_index_artifacts(&state, &csr);
+    WamValue fallback_args[5] = {
+        val_atom("orphan"),
+        val_atom("root"),
+        val_unbound("Total"),
+        val_unbound("Parents"),
+        val_unbound("Children")
+    };
+    int fallback_rc = wam_run_predicate(&state, "bidirectional_ancestor/5", fallback_args, 5);
+    if (fallback_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
 
 wam_c_transitive_closure_smoke_main(
 '#include "wam_runtime.h"
@@ -4922,6 +5077,8 @@ run_tests_once :-
     test_reverse_index_plan_csr_cost_model,
     test_reverse_index_plan_runtime_available_sorted_array,
     test_reverse_index_plan_runtime_available_lmdb_offset,
+    test_reverse_index_setup_generation,
+    test_reverse_index_setup_lmdb_offset_generation,
     test_streaming_foreign_results_generation,
     test_kernel_detector_setup_generation,
     test_bidirectional_ancestor_setup_generation,
@@ -4954,6 +5111,7 @@ run_tests_once :-
     test_category_ancestor_kernel_executable_smoke,
     test_bidirectional_ancestor_kernel_executable_smoke,
     test_bidirectional_ancestor_csr_child_lookup_executable_smoke,
+    test_reverse_index_setup_executable_smoke,
     test_transitive_closure_kernel_executable_smoke,
     test_transitive_distance_kernel_executable_smoke,
     test_transitive_parent_distance_kernel_executable_smoke,


### PR DESCRIPTION
  ## Summary
  - Add generated WAM-C setup/teardown hooks for runtime reverse CSR artifacts.
  - Support declarative sorted-array and LMDB-offset CSR setup from `reverse_index(artifact(...))` options.
  - Add `category_id_map(...)` handling so generated setup registers atom IDs before attaching CSR.
  - Add generation and executable smoke coverage for the CSR setup lifecycle.

  ## Verification
  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
  - `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
  - `git diff --check`