### PR TITLE
refactor(wam-elixir): route ISO rewrite through shared items pipeline

### DIFF
--- a/docs/design/WAM_ITEMS_API_SPECIFICATION.md
+++ b/docs/design/WAM_ITEMS_API_SPECIFICATION.md
@@ -484,9 +484,21 @@ Why migrate small targets first:
 
 The C++ ISO sweep (arith compares + `succ_iso/2`) did not stay blocked on this
 refactor; it shipped against the existing text/items compatibility path. That
-means the C++ and Elixir ISO implementations still carry multi-shape rewrite
-logic for `builtin_call`, `put_structure`, `call`, and `execute`.
+means the C++ ISO implementation still carries multi-shape rewrite logic for
+`builtin_call`, `put_structure`, `call`, and `execute`.
 
-The interaction remains important for future target migrations. Once a target
-consumes structured WAM items directly, ISO rewrites become a single
-`swap_key_in_item/3`-style pass instead of several text-shape rules per key.
+**Elixir is the first target migrated off the per-shape text rules.** Its
+`iso_errors_rewrite_line/3` now tokenizes each WAM line with the shared
+`wam_tokenize_line/2`, recognises it to a structured item via
+`wam_recognise_instruction/2`, and applies the shared
+`iso_errors_rewrite_item/3` (exported from `core/iso_errors`) — a single
+`arg(1)`-based key swap that covers all four shapes at once. The swapped key is
+spliced back into the original line so text output stays byte-identical. The
+four duplicated `iso_errors_rewrite_parts` clauses and the local
+`iso_errors_lookup/3` are gone. This is the `swap_key_in_item/3`-style pass the
+note below anticipated, realised without yet requiring a full items-first
+emitter.
+
+The interaction remains important for the other targets' future migrations.
+Once a target consumes structured WAM items directly, ISO rewrites collapse to
+this same single shared pass instead of several text-shape rules per key.

--- a/src/unifyweaver/core/iso_errors.pl
+++ b/src/unifyweaver/core/iso_errors.pl
@@ -53,6 +53,7 @@
     iso_errors_mode_for/3,               % +Config, +PI, -Mode
     iso_errors_warn_multi_module/2,      % +Config, +Predicates
     iso_errors_rewrite/4,                % +Config, +PI, +Items0, -Items
+    iso_errors_rewrite_item/3,           % +Mode, +Item0, -Item
     iso_errors_valid_pi/1,               % +PI
     iso_errors_pi_matches/2,             % +PatternPI, +TargetPI
     iso_errors_audit_normalise_pi/2,     % +PI, -NormPI

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -45,8 +45,13 @@
                 iso_errors_mode_for/3,
                 iso_errors_warn_multi_module/2,
                 iso_errors_rewrite/4,
+                iso_errors_rewrite_item/3,
                 iso_errors_audit_normalise_pi/2,
                 iso_errors_audit_walk/5
+              ]).
+:- use_module('wam_text_parser',
+              [ wam_tokenize_line/2,
+                wam_recognise_instruction/2
               ]).
 :- use_module('../targets/wam_elixir_utils', [camel_case/2]).
 :- use_module('../core/recursive_kernel_detection',
@@ -6480,59 +6485,32 @@ iso_errors_rewrite_text(Config, PI, WamText, RewrittenText) :-
 
 iso_errors_has_lax_entries :- iso_errors:iso_errors_default_to_lax(_, _), !.
 
-% Rewrite one line. Token-split, classify head, look up key in the
-% mode-appropriate table, splice the new key back in. Lines we
-% don't recognise pass through unchanged.
+% Rewrite one line via the shared items pipeline. Tokenize the line
+% with the shared quote-aware tokenizer, recognise it to a structured
+% WAM item, apply the shared item-level ISO rewrite, and splice the
+% new key back into the original line.
+%
+% iso_errors_rewrite_item/3 (in core/iso_errors) is the single source
+% of truth for the builtin_call / put_structure / call / execute key
+% swaps — this target no longer carries its own per-shape text rules.
+% All four rewritable shapes carry the key as their first argument, so
+% arg(1, ...) extracts old/new keys generically.
+%
+% Splicing rather than re-printing the recognised item preserves the
+% original whitespace byte-for-byte, so existing text output is
+% unaffected. Any failure along the chain (unrecognised line, key not
+% in the ISO/lax tables, splice miss) falls through to OutLine = Line.
 iso_errors_rewrite_line(Mode, Line, OutLine) :-
-    split_string(Line, " \t", "", Parts0),
-    exclude(==(""), Parts0, Parts),
-    (   iso_errors_rewrite_parts(Mode, Parts, Line, OutLine)
+    (   wam_tokenize_line(Line, Tokens),
+        wam_recognise_instruction(Tokens, Item0),
+        iso_errors_rewrite_item(Mode, Item0, Item1),
+        Item0 \== Item1,
+        arg(1, Item0, OldKey),
+        arg(1, Item1, NewKey),
+        iso_errors_splice_line(Line, OldKey, NewKey, OutLine)
     ->  true
     ;   OutLine = Line
     ).
-
-% builtin_call <key>, <arity>  (key has trailing comma)
-iso_errors_rewrite_parts(Mode, ["builtin_call", KeyComma | _Rest], Line, OutLine) :-
-    string_concat(Key, ",", KeyComma), !,
-    iso_errors_lookup(Mode, Key, NewKey),
-    Key \== NewKey,
-    iso_errors_splice_line(Line, Key, NewKey, OutLine),
-    !.
-iso_errors_rewrite_parts(_, ["builtin_call", _Key | _], _, _) :- !, fail.
-
-% put_structure <key>, <reg>   (key has trailing comma; key is "name/arity")
-iso_errors_rewrite_parts(Mode, ["put_structure", KeyComma | _], Line, OutLine) :-
-    string_concat(Key, ",", KeyComma), !,
-    iso_errors_lookup(Mode, Key, NewKey),
-    Key \== NewKey,
-    iso_errors_splice_line(Line, Key, NewKey, OutLine),
-    !.
-
-% call <key>, <arity>
-iso_errors_rewrite_parts(Mode, ["call", KeyComma | _], Line, OutLine) :-
-    string_concat(Key, ",", KeyComma), !,
-    iso_errors_lookup(Mode, Key, NewKey),
-    Key \== NewKey,
-    iso_errors_splice_line(Line, Key, NewKey, OutLine),
-    !.
-
-% execute <key>   (no comma — execute carries no arity field)
-iso_errors_rewrite_parts(Mode, ["execute", Key | _], Line, OutLine) :-
-    iso_errors_lookup(Mode, Key, NewKey),
-    Key \== NewKey,
-    iso_errors_splice_line(Line, Key, NewKey, OutLine),
-    !.
-
-iso_errors_rewrite_parts(_, _, _, _) :- fail.
-
-% Look up Key in the mode-appropriate table. Falls through to Key
-% itself when no entry exists (the common case while tables are
-% sparse).
-iso_errors_lookup(true, Key, NewKey) :-
-    iso_errors:iso_errors_default_to_iso(Key, NewKey), !.
-iso_errors_lookup(false, Key, NewKey) :-
-    iso_errors:iso_errors_default_to_lax(Key, NewKey), !.
-iso_errors_lookup(_, Key, Key).
 
 % Replace the FIRST occurrence of Key in Line with NewKey. Both are
 % string. Simple substring replacement — Key is a "name/arity"


### PR DESCRIPTION
##  Summary

  - Elixir's ISO-error rewrite (is/2→is_iso/2 etc.) duplicated logic that already existed, fully implemented, in
  core/iso_errors as iso_errors_rewrite_item/3. This deletes the duplication.
  - iso_errors_rewrite_line/3 now tokenizes each WAM line, recognises it to a structured item, applies the shared
  item-level rewrite, and splices the swapped key back — preserving byte-identical text output.
  - One arg(1)-based clause replaces the four per-shape text rules; iso_errors_lookup/3 is gone.
  - Exports iso_errors_rewrite_item/3 from core/iso_errors. Elixir is the first target migrated off per-shape text
  rewrites (C++ still carries them).

 ## Test plan

  - [x] 50/50 test_wam_elixir_classic_programs (includes 14 ISO-sweep cases)
  - [x] 20/20 test_iso_errors unit suite
  - [x] Output byte-identical — splice preserves original whitespace

##  Scope note

  This migrates only the ISO-rewrite path, not the full items-first emitter refactor (Spec Phase 1, ~1000 LOC), which
  remains deferred.