### PR TITLE
feat(wam-rust): lmdb_materialisation(auto) cost-model resolver + §3.1 runtime cache sizing (R8b)

### DIFF
--- a/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
+++ b/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
@@ -3,6 +3,8 @@
 :- use_module('../../src/unifyweaver/targets/wam_rust_target').
 :- use_module('../../src/unifyweaver/targets/prolog_target').
 :- use_module('../../src/unifyweaver/core/template_system', [render_template/3]).
+:- use_module('../../src/unifyweaver/core/cost_model',
+              [resolve_auto_lmdb_materialisation/2, resolve_lmdb_cache_capacity/2]).
 
 %% generate_wam_rust_matrix_benchmark.pl
 %%
@@ -21,27 +23,29 @@ benchmark_workload_path(Path) :-
 
 main :-
     current_prolog_flag(argv, Argv),
-    (   Argv = [_FactsPath, OutputDir, VariantAtom, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbCrateAtom, LmdbMaterialisationAtom]
+    (   Argv = [_FactsPath, OutputDir, VariantAtom, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbCrateAtom, LmdbMaterialisationAtom, FactCountAtom]
     ->  true
+    ;   Argv = [_FactsPath, OutputDir, VariantAtom, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbCrateAtom, LmdbMaterialisationAtom]
+    ->  FactCountAtom = '0'
     ;   Argv = [_FactsPath, OutputDir, VariantAtom, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbCrateAtom]
-    ->  LmdbMaterialisationAtom = eager
+    ->  LmdbMaterialisationAtom = eager, FactCountAtom = '0'
     ;   Argv = [_FactsPath, OutputDir, VariantAtom, EmitModeAtom, KernelModeAtom, LmdbModeAtom]
-    ->  LmdbCrateAtom = auto, LmdbMaterialisationAtom = eager
+    ->  LmdbCrateAtom = auto, LmdbMaterialisationAtom = eager, FactCountAtom = '0'
     ;   Argv = [_FactsPath, OutputDir, VariantAtom, EmitModeAtom, KernelModeAtom]
-    ->  LmdbModeAtom = none, LmdbCrateAtom = auto, LmdbMaterialisationAtom = eager
+    ->  LmdbModeAtom = none, LmdbCrateAtom = auto, LmdbMaterialisationAtom = eager, FactCountAtom = '0'
     ;   format(user_error,
-            'Usage: ... -- <facts.pl> <output-dir> <seeded|accumulated> <interpreter|functions> <kernels_on|kernels_off> [<none|cursor>] [<lmdb_zero|heed|auto>] [<eager|lazy|cached|auto>]~n',
+            'Usage: ... -- <facts.pl> <output-dir> <seeded|accumulated> <interpreter|functions> <kernels_on|kernels_off> [<none|cursor>] [<lmdb_zero|heed|auto>] [<eager|lazy|cached|auto>] [<fact-count>]~n',
             []),
         halt(1)
     ),
-    generate(VariantAtom, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbCrateAtom, LmdbMaterialisationAtom, OutputDir),
+    generate(VariantAtom, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbCrateAtom, LmdbMaterialisationAtom, FactCountAtom, OutputDir),
     halt(0).
 
 main :-
     format(user_error, 'Error: generation failed~n', []),
     halt(1).
 
-generate(VariantAtom, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbCrateAtom, LmdbMaterialisationAtom, OutputDir) :-
+generate(VariantAtom, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbCrateAtom, LmdbMaterialisationAtom, FactCountAtom, OutputDir) :-
     benchmark_workload_path(WorkloadPath),
     load_files(WorkloadPath, [silent(true)]),
     retractall(user:mode(category_ancestor(_, _, _, _))),
@@ -51,7 +55,10 @@ generate(VariantAtom, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbCrateAtom,
     parse_kernel_mode(KernelModeAtom, KernelOptions),
     parse_lmdb_mode(LmdbModeAtom, LmdbOptions),
     parse_lmdb_crate(LmdbCrateAtom, LmdbCrateOptions),
-    parse_lmdb_materialisation(LmdbMaterialisationAtom, LmdbMaterialisation, LmdbMaterialisationOptions),
+    materialisation_metadata(FactCountAtom, Metadata),
+    resolve_lmdb_materialisation(LmdbMaterialisationAtom, Metadata,
+                                 LmdbMaterialisation, LmdbMaterialisationOptions),
+    resolve_lmdb_cache_capacity(Metadata, CacheCapacity),
     validate_lmdb_materialisation_combo(LmdbMaterialisation, LmdbModeAtom),
     BasePreds = [dimension_n/1, max_depth/1, category_ancestor/4],
     prolog_target:generate_prolog_script(BasePreds, OptimizationOptions, ScriptCode),
@@ -64,10 +71,10 @@ generate(VariantAtom, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbCrateAtom,
     append([[module_name(wam_rust_matrix_bench), wam_fallback(true), emit_mode(EmitMode), parallel(true)],
             KernelOptions, LmdbOptions, LmdbCrateOptions, LmdbMaterialisationOptions], Options),
     write_wam_rust_project(Predicates, Options, OutputDir),
-    write_matrix_main(OutputDir, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbMaterialisation),
+    write_matrix_main(OutputDir, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbMaterialisation, CacheCapacity),
     format(user_error,
-           '[WAM-Rust-Matrix] variant=~w emit_mode=~w kernels=~w lmdb=~w lmdb_crate=~w materialisation=~w output=~w~n',
-           [VariantAtom, EmitMode, KernelModeAtom, LmdbModeAtom, LmdbCrateAtom, LmdbMaterialisation, OutputDir]).
+           '[WAM-Rust-Matrix] variant=~w emit_mode=~w kernels=~w lmdb=~w lmdb_crate=~w materialisation=~w(from ~w) cache_capacity=~w output=~w~n',
+           [VariantAtom, EmitMode, KernelModeAtom, LmdbModeAtom, LmdbCrateAtom, LmdbMaterialisation, LmdbMaterialisationAtom, CacheCapacity, OutputDir]).
 
 parse_lmdb_mode(none, []).
 parse_lmdb_mode(cursor, [lmdb_mode(cursor)]).
@@ -76,15 +83,29 @@ parse_lmdb_crate(auto, [lmdb_crate(auto)]).
 parse_lmdb_crate(lmdb_zero, [lmdb_crate(lmdb_zero)]).
 parse_lmdb_crate(heed, [lmdb_crate(heed)]).
 
-% Phase R7: lmdb_materialisation option (eager | lazy | cached | auto).
-% - eager: current behaviour — build runtime_category_parents Vec at startup.
+% lmdb_materialisation option (eager | lazy | cached | auto).
+% - eager: build runtime_category_parents Vec at startup.
 % - lazy:  parent edges read on-demand via LookupSource trait + LMDB cursor.
-% - cached: not yet implemented (R8); errors here.
-% - auto: R7 returns eager; R8 will wire the cost-model resolver.
-parse_lmdb_materialisation(eager,  eager,  [lmdb_materialisation(eager)]).
-parse_lmdb_materialisation(auto,   eager,  [lmdb_materialisation(eager)]).
-parse_lmdb_materialisation(lazy,   lazy,   [lmdb_materialisation(lazy)]).
-parse_lmdb_materialisation(cached, cached, [lmdb_materialisation(cached)]).
+% - cached: lazy + a sharded bounded cache (CachedLookup decorator).
+% - auto (R8b): the cost-model resolver picks eager/lazy/cached from
+%   fixture metadata (fact_count, workload_segregated, ...). Mode
+%   selection is codegen-time and static — MemAvailable is read at
+%   *runtime* for the cache-capacity clamp, never baked in here.
+%
+% The matrix bench regenerates one project per fixture scale, so
+% fact_count is a legitimate generation-time parameter. When omitted
+% (FactCountAtom = '0') the resolver's safe default is eager.
+materialisation_metadata(FactCountAtom, Metadata) :-
+    ( atom_number(FactCountAtom, FactCount0) -> true ; FactCount0 = 0 ),
+    FactCount is max(0, FactCount0),
+    Metadata = [fact_count(FactCount)].
+
+% Resolve the requested materialisation atom against fixture metadata.
+% Explicit eager/lazy/cached pass through unchanged; auto runs the
+% cost-model decision tree. Always re-derives the option list from the
+% resolved mode so downstream codegen sees the concrete mode.
+resolve_lmdb_materialisation(RequestedAtom, Metadata, Mode, [lmdb_materialisation(Mode)]) :-
+    resolve_auto_lmdb_materialisation([lmdb_materialisation(RequestedAtom) | Metadata], Mode).
 
 % Lazy / cached modes only make sense when the LMDB is opened at
 % runtime (i.e., lmdb_mode == cursor). Without it there is no
@@ -140,7 +161,7 @@ collect_wam_predicates(accumulated, [
     user:'category_ancestor$effective_distance_sum_bound'/3
 ]).
 
-write_matrix_main(OutputDir, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbMaterialisation) :-
+write_matrix_main(OutputDir, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbMaterialisation, CacheCapacity) :-
     directory_file_path(OutputDir, 'src', SrcDir),
     directory_file_path(SrcDir, 'main.rs', MainPath),
     format(string(ModeMetric), 'wam_rust_matrix_~w_~w', [EmitModeAtom, KernelModeAtom]),
@@ -149,7 +170,7 @@ write_matrix_main(OutputDir, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbMat
     ;   rust_main_template(Template)
     ),
     format(string(BaseCode), Template, [ModeMetric]),
-    apply_lmdb_materialisation_transform(LmdbMaterialisation, BaseCode, Code),
+    apply_lmdb_materialisation_transform(LmdbMaterialisation, CacheCapacity, BaseCode, Code),
     setup_call_cleanup(
         open(MainPath, write, Stream, [encoding(utf8)]),
         format(Stream, '~w', [Code]),
@@ -163,11 +184,11 @@ write_matrix_main(OutputDir, EmitModeAtom, KernelModeAtom, LmdbModeAtom, LmdbMat
 % by lazy and cached) is injected after the LmdbFactSource use
 % statement. Eager mode is a pass-through (the base template
 % already has the eager setup inline).
-apply_lmdb_materialisation_transform(eager, Code, Code).
-apply_lmdb_materialisation_transform(lazy, BaseCode, Code) :-
-    rewrite_for_lookup_source_mode(lazy, BaseCode, Code).
-apply_lmdb_materialisation_transform(cached, BaseCode, Code) :-
-    rewrite_for_lookup_source_mode(cached, BaseCode, Code).
+apply_lmdb_materialisation_transform(eager, _CacheCapacity, Code, Code).
+apply_lmdb_materialisation_transform(lazy, CacheCapacity, BaseCode, Code) :-
+    rewrite_for_lookup_source_mode(lazy, CacheCapacity, BaseCode, Code).
+apply_lmdb_materialisation_transform(cached, CacheCapacity, BaseCode, Code) :-
+    rewrite_for_lookup_source_mode(cached, CacheCapacity, BaseCode, Code).
 
 % --- R8a lookup-source-mode rewrite (lazy + cached) ---
 %
@@ -177,8 +198,8 @@ apply_lmdb_materialisation_transform(cached, BaseCode, Code) :-
 % the rendered base main.rs at the eager-block anchors. Also injects
 % the LazyCategoryParents struct (shared between lazy and cached) at
 % module scope.
-rewrite_for_lookup_source_mode(Mode, BaseCode, Code) :-
-    materialisation_setup_dict(Mode, Dict),
+rewrite_for_lookup_source_mode(Mode, CacheCapacity, BaseCode, Code) :-
+    materialisation_setup_dict(Mode, CacheCapacity, Dict),
     materialisation_setup_template(SetupTemplate),
     render_template(SetupTemplate, Dict, RenderedSetup),
     lazy_struct_template(StructTemplate),
@@ -187,12 +208,17 @@ rewrite_for_lookup_source_mode(Mode, BaseCode, Code) :-
     replace_eager_setup_block(Code1, RenderedSetup, Code).
 
 % Build the Dict passed to render_template for the materialisation
-% setup template. Cache-capacity / shard defaults are R8a placeholders;
-% R8b's auto-resolver will compute these from /proc/meminfo.
-materialisation_setup_dict(Mode, [
+% setup template. cache_capacity_default is the §3.1
+% `unrestricted_working_set` clamp computed by R8b's resolver
+% (resolve_lmdb_cache_capacity/2); the generated Rust applies the
+% MemAvailable-dependent clamp on top of it at runtime. cache_cap_pct
+% and cache_floor_bytes parameterise that runtime clamp (§3.1).
+materialisation_setup_dict(Mode, CacheCapacity, [
     materialisation = Mode,
-    cache_capacity_default = 1024,
-    cache_shards_default = 4
+    cache_capacity_default = CacheCapacity,
+    cache_shards_default = 4,
+    cache_cap_pct = '0.5',
+    cache_floor_bytes = 536870912
 ]).
 
 % Locate + read the materialisation-setup mustache template.
@@ -217,7 +243,7 @@ rust_wam_template_path(Filename, Path) :-
                         '/templates/targets/rust_wam/', Filename], Path).
 
 inject_lazy_struct(Source, RenderedStruct, Result) :-
-    StructAnchor = "use wam_rust_matrix_bench::lmdb_fact_source::LmdbFactSource;",
+    StructAnchor = "use wam_lib::lmdb_fact_source::LmdbFactSource;",
     find_and_split_once(Source, StructAnchor, Prefix, Suffix),
     atomics_to_string([Prefix, StructAnchor, "\n", RenderedStruct, Suffix], Result).
 
@@ -246,12 +272,12 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::time::Instant;
 
-use wam_rust_matrix_bench::foreign_pred_keys;
-use wam_rust_matrix_bench::setup_foreign_predicates;
-use wam_rust_matrix_bench::shared_wam_program;
-use wam_rust_matrix_bench::instructions::Instruction;
-use wam_rust_matrix_bench::state::WamState;
-use wam_rust_matrix_bench::value::Value;
+use wam_lib::foreign_pred_keys;
+use wam_lib::setup_foreign_predicates;
+use wam_lib::shared_wam_program;
+use wam_lib::instructions::Instruction;
+use wam_lib::state::WamState;
+use wam_lib::value::Value;
 
 fn load_tsv_pairs(path: &Path) -> Vec<(String, String)> {
     let file = File::open(path).unwrap_or_else(|e| panic!("cannot open {}: {}", path.display(), e));
@@ -843,13 +869,13 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::time::Instant;
 
-use wam_rust_matrix_bench::foreign_pred_keys;
-use wam_rust_matrix_bench::setup_foreign_predicates;
-use wam_rust_matrix_bench::shared_wam_program;
-use wam_rust_matrix_bench::instructions::Instruction;
-use wam_rust_matrix_bench::state::WamState;
-use wam_rust_matrix_bench::value::Value;
-use wam_rust_matrix_bench::lmdb_fact_source::LmdbFactSource;
+use wam_lib::foreign_pred_keys;
+use wam_lib::setup_foreign_predicates;
+use wam_lib::shared_wam_program;
+use wam_lib::instructions::Instruction;
+use wam_lib::state::WamState;
+use wam_lib::value::Value;
+use wam_lib::lmdb_fact_source::LmdbFactSource;
 
 fn load_tsv_pairs(path: &Path) -> Vec<(String, String)> {
     let file = File::open(path).unwrap_or_else(|e| panic!("cannot open {}: {}", path.display(), e));

--- a/src/unifyweaver/core/cost_model.pl
+++ b/src/unifyweaver/core/cost_model.pl
@@ -37,6 +37,14 @@
     recommend_access_pattern/5, % +KKeys, +WBytes, +RFreeBytes, +Constants, -Pattern
     resolve_reverse_index/2,    % +Options, -ReverseIndex
     validate_reverse_index_option/2, % +Spec, -Normalized
+
+    %% LMDB materialisation-mode resolver (eager | lazy | cached)
+    resolve_auto_lmdb_materialisation/2, % +Options, -Mode
+    resolve_lmdb_cache_capacity/2,       % +Options, -CapacityEntries
+    lmdb_cache_capacity_free_pct/2,      % +Options, -Fraction
+    lmdb_cache_capacity_floor_bytes/2,   % +Options, -Bytes
+    lmdb_edge_size_bytes/1,              % -Bytes
+
     resolve_csr_io_policy/2,    % +Options, -Policy
     resolve_csr_index_backend/2, % +Options, -Backend
     csr_index_backend_options_from_benchmark_tsv/3,
@@ -615,6 +623,165 @@ validate_nonnegative_integer(_Name, Value) :-
     !.
 validate_nonnegative_integer(Name, Value) :-
     throw(error(domain_error(nonnegative_integer(Name), Value), _)).
+
+%% =====================================================================
+%% LMDB materialisation-mode resolver
+%% =====================================================================
+%%
+%% `lmdb_materialisation(auto | eager | lazy | cached)` is a codegen
+%% option (WAM-Rust today; target-agnostic so Haskell/C# can reuse it).
+%% This resolver implements the `auto` decision per
+%% docs/design/WAM_LMDB_LAZY_SPECIFICATION.md §7.2 and the cache-sizing
+%% rule in WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md §3.1.
+%%
+%% IMPORTANT: mode selection is a *codegen-time* decision driven purely
+%% by static fixture metadata. It must NOT read `/proc/meminfo` —
+%% MemAvailable is a runtime quantity, and baking a codegen-time
+%% reading into the emitted binary would be wrong on any machine other
+%% than the build host. The MemAvailable-dependent cache-capacity clamp
+%% (§3.1) is therefore applied at *runtime* in the generated target
+%% code; this resolver only emits the static `unrestricted_working_set`
+%% default plus the clamp parameters (cap_pct, headroom floor).
+
+%! lmdb_edge_size_bytes(-Bytes) is det.
+%
+%  Approximate in-cache cost of one parent edge: an i32 child key plus
+%  an i32 parent value plus container/hashing overhead. Used to turn a
+%  demand-set *edge count* into a memory footprint for the §3.1 clamp.
+lmdb_edge_size_bytes(12).
+
+%! resolve_auto_lmdb_materialisation(+Options, -Mode) is det.
+%
+%  Pick `eager` | `lazy` | `cached` from workload metadata. Explicit
+%  callers pass `lmdb_materialisation(eager|lazy|cached)` and get it
+%  back unchanged; `auto` (or an unset option) runs the decision tree.
+%
+%  Decision tree (spec §7.2):
+%    1. If an explicit `memory_budget(Bytes)` is *declared* and the
+%       demand set doesn't fit in it, the demand set can't be held
+%       resident → use a lazy form (`lazy` if the workload is
+%       segregated, else `cached`). No live MemAvailable read here —
+%       only a caller-declared budget triggers this branch.
+%    2. Otherwise the demand set fits. Choose `eager` iff the one-shot
+%       up-front materialisation is cheap (estimated cold build time
+%       within the per-process build budget, scaled by the expected
+%       query count so a long-lived process tolerates a bigger build).
+%       Else fall to the lazy form (`lazy` if segregated, else
+%       `cached`).
+%
+%  Recognised metadata options (all optional, conservative defaults):
+%    - fact_count(F)                        total edges in the source
+%    - demand_set_estimate(D)               edges the queries will touch
+%                                           (defaults to fact_count)
+%    - workload_segregated(Bool)            default false
+%    - expected_query_count_per_process(NQ) default 1
+%    - memory_budget(Bytes)                 declared cap; absent = unbounded
+%    - eager_build_budget_ms(Ms)            default 1000
+%    - constants(C)                         hardware constants list
+resolve_auto_lmdb_materialisation(Options, Mode) :-
+    option(lmdb_materialisation(Requested), Options, auto),
+    resolve_lmdb_materialisation_value(Requested, Options, Mode).
+
+resolve_lmdb_materialisation_value(eager,  _Options, eager) :- !.
+resolve_lmdb_materialisation_value(lazy,   _Options, lazy) :- !.
+resolve_lmdb_materialisation_value(cached, _Options, cached) :- !.
+resolve_lmdb_materialisation_value(auto, Options, Mode) :-
+    !,
+    lmdb_demand_set_estimate(Options, D),
+    (   lmdb_demand_set_overflows_budget(D, Options)
+    ->  lmdb_lazy_form(Options, Mode)
+    ;   lmdb_eager_build_is_cheap(D, Options)
+    ->  Mode = eager
+    ;   lmdb_lazy_form(Options, Mode)
+    ).
+resolve_lmdb_materialisation_value(Other, _Options, _) :-
+    throw(error(domain_error(lmdb_materialisation, Other), _)).
+
+%  When the demand set can't live in RAM we still need on-demand
+%  access; segregated workloads prefer bare `lazy` (no cross-query
+%  reuse to exploit), everything else prefers `cached`.
+lmdb_lazy_form(Options, Mode) :-
+    option(workload_segregated(WS), Options, false),
+    (   WS == true
+    ->  Mode = lazy
+    ;   Mode = cached
+    ).
+
+%  Demand-set edge estimate, defaulting to fact_count, then to 0.
+lmdb_demand_set_estimate(Options, D) :-
+    option(fact_count(F), Options, 0),
+    option(demand_set_estimate(D0), Options, F),
+    (   number(D0), D0 > 0
+    ->  D = D0
+    ;   D = F
+    ).
+
+%  True only when an explicit budget is declared AND the demand set's
+%  footprint exceeds it. No `memory_budget` option => never fires
+%  (codegen does not read MemAvailable).
+lmdb_demand_set_overflows_budget(D, Options) :-
+    option(memory_budget(Budget), Options),
+    number(Budget),
+    lmdb_edge_size_bytes(EdgeBytes),
+    Footprint is D * EdgeBytes,
+    Footprint > Budget.
+
+%  Eager wins when the up-front demand-set build is cheap. Estimate the
+%  build as D cold parent-edge seeks; tolerate up to
+%  eager_build_budget_ms × max(1, NQ) (a long-lived process amortises a
+%  bigger one-time build). With the default 1 s budget and 100 µs cold
+%  seek the eager↔cached crossover lands at ~10k edges — so 1k → eager,
+%  simplewiki/enwiki → cached, matching plan §3.
+lmdb_eager_build_is_cheap(D, Options) :-
+    option(eager_build_budget_ms(Budget0), Options, 1000),
+    option(expected_query_count_per_process(NQ), Options, 1),
+    resolve_cost_constants(Options, C),
+    seek_time_ms(D, 0.0, C, BuildMs),
+    Budget is Budget0 * max(1, NQ),
+    BuildMs =< Budget.
+
+resolve_cost_constants(Options, C) :-
+    (   option(constants(C0), Options), is_list(C0)
+    ->  C = C0
+    ;   default_constants(C)
+    ).
+
+%! resolve_lmdb_cache_capacity(+Options, -CapacityEntries) is det.
+%
+%  Codegen-time *default* cache capacity in entries (distinct child
+%  keys). This is the `unrestricted_working_set` term of §3.1 — the
+%  capacity that would serve the workload with no evictions, derived
+%  from the demand-set estimate. The MemAvailable clamp of §3.1 is NOT
+%  applied here; the generated target applies it at runtime. Floored at
+%  1024 so tiny fixtures still get a usable cache.
+%
+%  An explicit `cache_capacity(N)` option overrides the estimate.
+resolve_lmdb_cache_capacity(Options, Capacity) :-
+    (   option(cache_capacity(Explicit), Options), integer(Explicit), Explicit > 0
+    ->  Capacity = Explicit
+    ;   lmdb_demand_set_estimate(Options, D),
+        Capacity is max(1024, D)
+    ).
+
+%! lmdb_cache_capacity_free_pct(+Options, -Fraction) is det.
+%
+%  `cap_pct` from §3.1 — the fraction of (MemAvailable − headroom) the
+%  runtime cache may claim. Override per-predicate with
+%  `cache_capacity_free_pct(F)`.
+lmdb_cache_capacity_free_pct(Options, Fraction) :-
+    option(cache_capacity_free_pct(Fraction0), Options, 0.5),
+    validate_fraction(cache_capacity_free_pct, Fraction0),
+    Fraction = Fraction0.
+
+%! lmdb_cache_capacity_floor_bytes(+Options, -Bytes) is det.
+%
+%  Fixed component of the §3.1 `headroom_floor`
+%  (`max(512 MB, 0.10 × MemTotal)`). The runtime takes the max of this
+%  and 10% of MemTotal. Override with `cache_capacity_floor_bytes(B)`.
+lmdb_cache_capacity_floor_bytes(Options, Bytes) :-
+    option(cache_capacity_floor_bytes(Bytes0), Options, 536870912), % 512 MiB
+    validate_nonnegative_integer(cache_capacity_floor_bytes, Bytes0),
+    Bytes = Bytes0.
 
 %% =====================================================================
 %% System probe

--- a/templates/targets/rust_wam/lazy_category_parents.rs.mustache
+++ b/templates/targets/rust_wam/lazy_category_parents.rs.mustache
@@ -10,7 +10,7 @@ struct LazyCategoryParents {
     i2s: HashMap<i32, String>,
 }
 
-impl wam_rust_matrix_bench::state::LookupSource for LazyCategoryParents {
+impl wam_lib::state::LookupSource for LazyCategoryParents {
     fn lookup_key_for_atom(&self, atom: &str) -> Option<i32> {
         self.s2i.get(atom).copied()
     }

--- a/templates/targets/rust_wam/materialisation_setup.rs.mustache
+++ b/templates/targets/rust_wam/materialisation_setup.rs.mustache
@@ -86,10 +86,10 @@
     // Cached: lazy with a sharded bounded cache layered in front.
     // Decorator pattern — CachedLookup<LazyCategoryParents> implements
     // LookupSource itself, so the kernel can't tell whether it's
-    // hitting a cache. Mirrors Haskell's lmdbL2EdgeLookup. Capacity
-    // is set explicitly here (R8a); R8b's auto-resolver will compute
-    // it from MemAvailable per WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md
-    // §3.1.
+    // hitting a cache. Mirrors Haskell's lmdbL2EdgeLookup. Capacity is
+    // the §3.1 working-set default ({{cache_capacity_default}} entries)
+    // computed by the cost-model resolver at codegen time, clamped at
+    // runtime against MemAvailable (read here, never baked in).
     let s2i = lmdb.load_s2i().expect("load_s2i");
     let load_ms = started.elapsed().as_millis();
 
@@ -109,16 +109,25 @@
         s2i: s2i.clone(),
         i2s: i2s.clone(),
     };
+    // WAM_CACHE_CAPACITY overrides everything; otherwise apply the
+    // §3.1 runtime clamp of the codegen working-set default by the
+    // host's MemAvailable (read now, at runtime).
     let cache_capacity: usize = std::env::var("WAM_CACHE_CAPACITY")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or({{cache_capacity_default}});
+        .unwrap_or_else(|| {
+            wam_lib::state::resolve_runtime_cache_capacity(
+                {{cache_capacity_default}},
+                {{cache_cap_pct}},
+                {{cache_floor_bytes}},
+            )
+        });
     let cache_shards: usize = std::env::var("WAM_CACHE_SHARDS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or({{cache_shards_default}});
     let cached_source = std::sync::Arc::new(
-        wam_rust_matrix_bench::state::CachedLookup::new(inner, cache_capacity, cache_shards)
+        wam_lib::state::CachedLookup::new(inner, cache_capacity, cache_shards)
     );
     vm.register_lazy_lookup("category_parent/2", cached_source);
     vm.register_foreign_predicate("category_parent/2");

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -118,6 +118,73 @@ impl<S: LookupSource> LookupSource for CachedLookup<S> {
     }
 }
 
+/// R8b: §3.1 cache-capacity resolution, applied at *runtime*.
+///
+/// The codegen layer emits `working_set` (the §3.1
+/// `unrestricted_working_set` — the demand-set size, i.e. the capacity
+/// that serves the workload with zero evictions) plus the clamp
+/// parameters. This function applies the MemAvailable-dependent clamp
+/// when the binary actually runs, so cache sizing adapts to the host
+/// rather than to the build machine (MemAvailable must never be baked
+/// in at codegen time):
+///
+///   capacity = min(working_set,
+///                  cap_pct * (MemAvailable - max(floor_bytes, 0.10*MemTotal))
+///                    / edge_bytes)
+///
+/// For the small demand sets typical of the category graph the
+/// `working_set` term wins and the memory math is irrelevant; the clamp
+/// only bites for very large fan-out workloads on memory-constrained
+/// hosts. On non-Linux hosts (`/proc/meminfo` absent) the working set is
+/// used unclamped — the conservative cross-platform default. Floored at
+/// 1024 entries so even a tight machine keeps a usable cache.
+pub fn resolve_runtime_cache_capacity(
+    working_set: usize,
+    cap_pct: f64,
+    floor_bytes: u64,
+) -> usize {
+    const EDGE_BYTES: u64 = 12; // i32 key + i32 val + container overhead
+    match read_meminfo_available_total() {
+        Some((avail, total)) => {
+            let headroom_floor = floor_bytes.max((total as f64 * 0.10) as u64);
+            let budget_bytes = if avail > headroom_floor {
+                (cap_pct * (avail - headroom_floor) as f64) as u64
+            } else {
+                0
+            };
+            let budget_entries = (budget_bytes / EDGE_BYTES) as usize;
+            working_set.min(budget_entries.max(1024))
+        }
+        None => working_set,
+    }
+}
+
+/// Read `MemAvailable` and `MemTotal` (in bytes) from `/proc/meminfo`.
+/// Returns `None` on any platform/parse failure (e.g. non-Linux hosts).
+fn read_meminfo_available_total() -> Option<(u64, u64)> {
+    let text = std::fs::read_to_string("/proc/meminfo").ok()?;
+    let mut avail: Option<u64> = None;
+    let mut total: Option<u64> = None;
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix("MemAvailable:") {
+            avail = parse_meminfo_kib(rest);
+        } else if let Some(rest) = line.strip_prefix("MemTotal:") {
+            total = parse_meminfo_kib(rest);
+        }
+    }
+    match (avail, total) {
+        (Some(a), Some(t)) => Some((a, t)),
+        _ => None,
+    }
+}
+
+/// Parse the leading kibibyte count of a `/proc/meminfo` value line
+/// (e.g. `"  16384256 kB"`) and convert to bytes.
+fn parse_meminfo_kib(rest: &str) -> Option<u64> {
+    let kib: u64 = rest.split_whitespace().next()?.parse().ok()?;
+    Some(kib * 1024)
+}
+
 /// Trail entry: records the old value of a register before mutation.
 #[derive(Clone, Debug)]
 pub struct TrailEntry {

--- a/tests/core/test_cost_model.pl
+++ b/tests/core/test_cost_model.pl
@@ -103,6 +103,24 @@ test(test_reverse_index_artifact_normalizes_storage_kind).
 
 test(test_read_mem_available_returns_positive).
 
+test(test_materialisation_explicit_eager_passthrough).
+test(test_materialisation_explicit_lazy_passthrough).
+test(test_materialisation_explicit_cached_passthrough).
+test(test_materialisation_auto_1k_picks_eager).
+test(test_materialisation_auto_simplewiki_picks_cached).
+test(test_materialisation_auto_enwiki_picks_cached).
+test(test_materialisation_auto_segregated_picks_lazy).
+test(test_materialisation_auto_budget_overflow_picks_cached).
+test(test_materialisation_auto_budget_overflow_segregated_picks_lazy).
+test(test_materialisation_auto_high_query_count_amortises_eager).
+test(test_materialisation_auto_default_no_metadata).
+test(test_materialisation_rejects_unknown_mode).
+test(test_cache_capacity_uses_working_set).
+test(test_cache_capacity_floored).
+test(test_cache_capacity_explicit_override).
+test(test_cache_capacity_free_pct_default_and_override).
+test(test_cache_capacity_floor_bytes_default_and_override).
+
 %% ========================================================================
 %% Default constants
 %% ========================================================================
@@ -661,6 +679,144 @@ test_read_mem_available_returns_positive :-
     ->  pass(Test)
     ;   %% Skip on non-Linux platforms
         format("[SKIP] ~w (no /proc/meminfo)~n", [Test])
+    ).
+
+%% ========================================================================
+%% LMDB materialisation-mode resolver
+%% ========================================================================
+
+%% Helper: assert resolve_auto_lmdb_materialisation picks Expected.
+expect_materialisation(Test, Options, Expected) :-
+    (   resolve_auto_lmdb_materialisation(Options, Mode),
+        Mode == Expected
+    ->  pass(Test)
+    ;   ( resolve_auto_lmdb_materialisation(Options, Got) -> true ; Got = '<failed>' ),
+        fail_test(Test, format_atom("got ~w (expected ~w)", [Got, Expected]))
+    ).
+
+test_materialisation_explicit_eager_passthrough :-
+    %% Explicit modes are returned verbatim even at huge scale.
+    expect_materialisation(
+        'explicit eager passes through regardless of scale',
+        [lmdb_materialisation(eager), fact_count(9_930_000)], eager).
+
+test_materialisation_explicit_lazy_passthrough :-
+    expect_materialisation(
+        'explicit lazy passes through',
+        [lmdb_materialisation(lazy), fact_count(1000)], lazy).
+
+test_materialisation_explicit_cached_passthrough :-
+    expect_materialisation(
+        'explicit cached passes through',
+        [lmdb_materialisation(cached), fact_count(1000)], cached).
+
+test_materialisation_auto_1k_picks_eager :-
+    %% Build of ~1000 cold seeds is ~100 ms < 1 s budget → eager.
+    expect_materialisation(
+        'auto at 1k picks eager (cheap up-front build)',
+        [lmdb_materialisation(auto), fact_count(1000)], eager).
+
+test_materialisation_auto_simplewiki_picks_cached :-
+    %% ~297k cold seeds is ~30 s >> 1 s budget → cached.
+    expect_materialisation(
+        'auto at simplewiki scale picks cached',
+        [lmdb_materialisation(auto), fact_count(297_000)], cached).
+
+test_materialisation_auto_enwiki_picks_cached :-
+    expect_materialisation(
+        'auto at enwiki scale picks cached',
+        [lmdb_materialisation(auto), fact_count(9_930_000)], cached).
+
+test_materialisation_auto_segregated_picks_lazy :-
+    %% Same scale, but a segregated workload has no cross-query reuse
+    %% to exploit → bare lazy beats cached.
+    expect_materialisation(
+        'auto + workload_segregated picks lazy over cached',
+        [lmdb_materialisation(auto), fact_count(9_930_000),
+         workload_segregated(true)], lazy).
+
+test_materialisation_auto_budget_overflow_picks_cached :-
+    %% Demand set (2000 edges × 12 B = 24 kB) exceeds the declared 1 kB
+    %% budget → can't hold resident → cached.
+    expect_materialisation(
+        'auto with declared budget overflow picks cached',
+        [lmdb_materialisation(auto), fact_count(2000), memory_budget(1000)],
+        cached).
+
+test_materialisation_auto_budget_overflow_segregated_picks_lazy :-
+    expect_materialisation(
+        'auto budget overflow + segregated picks lazy',
+        [lmdb_materialisation(auto), fact_count(2000), memory_budget(1000),
+         workload_segregated(true)],
+        lazy).
+
+test_materialisation_auto_high_query_count_amortises_eager :-
+    %% A long-lived process (many queries) tolerates a bigger one-time
+    %% build, so even 1M edges can amortise to eager.
+    expect_materialisation(
+        'auto with high query count amortises a large eager build',
+        [lmdb_materialisation(auto), fact_count(1_000_000),
+         expected_query_count_per_process(100_000)],
+        eager).
+
+test_materialisation_auto_default_no_metadata :-
+    %% No metadata + no explicit option: demand set defaults to 0,
+    %% build is free → eager (matches R7's safe default).
+    expect_materialisation(
+        'auto with no metadata defaults to eager',
+        [], eager).
+
+test_materialisation_rejects_unknown_mode :-
+    Test = 'resolve_auto_lmdb_materialisation rejects an unknown mode',
+    (   catch(resolve_auto_lmdb_materialisation([lmdb_materialisation(bogus)], _),
+              error(domain_error(lmdb_materialisation, bogus), _),
+              true)
+    ->  pass(Test)
+    ;   fail_test(Test, 'expected domain_error(lmdb_materialisation, bogus)')
+    ).
+
+test_cache_capacity_uses_working_set :-
+    Test = 'resolve_lmdb_cache_capacity uses the demand-set working set',
+    (   resolve_lmdb_cache_capacity([fact_count(9_930_000)], Cap),
+        Cap =:= 9_930_000
+    ->  pass(Test)
+    ;   fail_test(Test, 'expected capacity = fact_count')
+    ).
+
+test_cache_capacity_floored :-
+    Test = 'resolve_lmdb_cache_capacity floors tiny fixtures at 1024',
+    (   resolve_lmdb_cache_capacity([fact_count(100)], Cap),
+        Cap =:= 1024
+    ->  pass(Test)
+    ;   fail_test(Test, 'expected capacity floored to 1024')
+    ).
+
+test_cache_capacity_explicit_override :-
+    Test = 'resolve_lmdb_cache_capacity honours explicit cache_capacity',
+    (   resolve_lmdb_cache_capacity(
+            [fact_count(9_930_000), cache_capacity(50_000)], Cap),
+        Cap =:= 50_000
+    ->  pass(Test)
+    ;   fail_test(Test, 'expected explicit cache_capacity to win')
+    ).
+
+test_cache_capacity_free_pct_default_and_override :-
+    Test = 'lmdb_cache_capacity_free_pct default 0.5 + override',
+    (   lmdb_cache_capacity_free_pct([], P0), P0 =:= 0.5,
+        lmdb_cache_capacity_free_pct([cache_capacity_free_pct(0.3)], P1),
+        P1 =:= 0.3
+    ->  pass(Test)
+    ;   fail_test(Test, 'free_pct default/override mismatch')
+    ).
+
+test_cache_capacity_floor_bytes_default_and_override :-
+    Test = 'lmdb_cache_capacity_floor_bytes default 512 MiB + override',
+    (   lmdb_cache_capacity_floor_bytes([], B0), B0 =:= 536870912,
+        lmdb_cache_capacity_floor_bytes(
+            [cache_capacity_floor_bytes(1073741824)], B1),
+        B1 =:= 1073741824
+    ->  pass(Test)
+    ;   fail_test(Test, 'floor_bytes default/override mismatch')
     ).
 
 csr_benchmark_rows([


### PR DESCRIPTION
  ## Summary

  Turns the R7/R8a `lmdb_materialisation(auto)` stub (which always returned
  `eager`) into a real cost-model decision, and makes the §3.1 cache-capacity
  sizing live. Target-agnostic resolver lives in `core/cost_model.pl`; the
  MemAvailable-dependent clamp is applied at **runtime** in the generated Rust,
  never baked in at codegen.

  Builds on #2552 (R8a `cached` decorator + template migration, merged).
  Implements Phase R8b of `docs/design/WAM_LMDB_LAZY_IMPLEMENTATION_PLAN.md`
  (§3 + §3.1; spec §7.2).

  ## What's in this PR

  **Resolver — `src/unifyweaver/core/cost_model.pl` (target-agnostic)**
  - `resolve_auto_lmdb_materialisation/2` picks `eager | lazy | cached` from
    static fixture metadata (`fact_count`, `demand_set_estimate`,
    `workload_segregated`, `expected_query_count_per_process`, optional declared
    `memory_budget`). Explicit modes pass through unchanged.
    - Mode selection is **codegen-time** and never reads `/proc/meminfo`.
    - Eager is chosen iff the estimated cold demand-set build is within the
      per-process budget (`seek_time_ms(D, cold) ≤ eager_build_budget_ms × NQ`).
      With the 1 s default the eager↔cached crossover lands at ~10k edges →
      **1k → eager, simplewiki (297k) → cached, enwiki (9.9M) → cached,
      segregated → lazy** (matches plan §3).
  - `resolve_lmdb_cache_capacity/2` emits the §3.1 `unrestricted_working_set`
    default (demand set, floored at 1024; explicit `cache_capacity(N)` wins).
  - `lmdb_cache_capacity_free_pct/2` + `lmdb_cache_capacity_floor_bytes/2`
    expose the runtime clamp params (`cap_pct = 0.5`, floor = 512 MiB).
  - 18 new resolver tests → `test_cost_model.pl` **38 → 56 pass**.

  **Runtime MemAvailable clamp — `state.rs.mustache`**
  - New `resolve_runtime_cache_capacity()` + `/proc/meminfo` reader. The cached
    branch clamps the codegen working-set default at startup:
    `min(working_set, cap_pct × (MemAvailable − max(floor, 0.10×MemTotal)) / edge_bytes)`.
    `WAM_CACHE_CAPACITY` still overrides; non-Linux hosts fall back to the
    working-set default.

  **Matrix-bench wiring — `generate_wam_rust_matrix_benchmark.pl`**
  - New optional `<fact-count>` generation arg; `auto` resolves against it (the
    bench regenerates per fixture scale, so fact_count is a legitimate codegen
    parameter). Resolved capacity flows into the materialisation-setup template,
    replacing R8a's hardcoded `1024`.

  ## Bundled pre-existing build fix

  The matrix bench's `main.rs` templates referenced the **package** name
  `wam_rust_matrix_bench::`, but the emitted library crate is `wam_lib`, so
  generated Rust projects **never compiled**. R7's and R8a's "smoke tests" were
  generation + byte-diff only — never a `cargo build`. Renamed all
  `wam_rust_matrix_bench::` path references to `wam_lib::`. Bundled here because
  the same files carry the R8b wiring and this fix is what unblocked end-to-end
  validation.

  ## Validation (1k_cats / 20 seeds / cursor)

  - `eager`, `lazy`, `cached` all `cargo build` clean and produce
    **byte-identical** output (`demand_set_size=1003`, `tuple_count=48`) — the
    first real build + run of the lazy/cached Rust paths.
  - Non-cursor path builds; `auto` resolves 1k → eager, 500k → cached.
  - `cost_model` 56/56, `wam_rust` target 158/158 pass.

  ## Out of scope (follow-ups)

  - **R9**: move the `CallIndexedAtomFact2 → CallForeign` rewrite into the WAM
    compiler (still `TODO(R9)` in `materialisation_setup.rs.mustache`).
  - **R7-bench cross-scale sweep**: now unblocked by the build fix — measure
    whether lazy/cached collapses the ~148 s enwiki `eager` time at simplewiki
    (297k) and enwiki (9.9M).
  - macOS/Windows MemAvailable readers (Linux-only today; non-Linux uses the
    working-set default, per plan §3.1 cross-platform note).