### PR TITLE
Validate WAM-C reverse CSR io policy

### DIFF
--- a/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
@@ -6,6 +6,7 @@
 :- initialization(main, main).
 
 :- use_module('../../src/unifyweaver/targets/wam_c_target').
+:- use_module('../../src/unifyweaver/core/cost_model', [resolve_csr_io_policy/2]).
 :- use_module(library(filesex), [directory_file_path/3, make_directory_path/1]).
 :- use_module(library(lists)).
 :- use_module(library(pairs), [pairs_keys/2, pairs_values/2]).
@@ -184,6 +185,7 @@ effective_distance_reverse_index_options(Options, OutputDir, CategoryParents,
     memberchk(reverse_index(csr(CsrOptions0)), Options),
     !,
     effective_distance_csr_index_backend(CsrOptions0, IndexBackend),
+    effective_distance_csr_io_policy(CsrOptions0, IoPolicy),
     write_effective_distance_reverse_csr(OutputDir, CategoryParents,
                                          ArticleCategories, RootCategories,
                                          IndexBackend, CategoryIdMap),
@@ -192,7 +194,7 @@ effective_distance_reverse_index_options(Options, OutputDir, CategoryParents,
             storage_kind(csr_pread_artifact),
             phase(runtime_available),
             index_backend(IndexBackend),
-            io_policy(buffered_pread)
+            io_policy(IoPolicy)
         ])),
         reverse_csr_values_path('category_child.csr.val'),
         category_id_map(CategoryIdMap)
@@ -219,6 +221,10 @@ parse_effective_distance_csr_index_backend(sorted_array, sorted_array).
 parse_effective_distance_csr_index_backend(lmdb_offset, lmdb_offset).
 parse_effective_distance_csr_index_backend(Backend, _) :-
     throw(error(domain_error(wam_c_effective_distance_csr_index_backend, Backend), _)).
+
+effective_distance_csr_io_policy(Options, IoPolicy) :-
+    must_be(list, Options),
+    resolve_csr_io_policy(Options, IoPolicy).
 
 effective_distance_reverse_index_path_options(sorted_array,
                                              [reverse_csr_index_path('category_child.csr.idx')]).

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -61,6 +61,7 @@ wam_c_reverse_index_capabilities(artifact(Opts), [
 ]) :-
     memberchk(storage_kind(csr_pread_artifact), Opts),
     memberchk(index_backend(sorted_array), Opts),
+    wam_c_reverse_index_runtime_io_policy_supported(artifact(Opts)),
     !.
 wam_c_reverse_index_capabilities(csr(Opts), [
     planning(accepted),
@@ -70,6 +71,7 @@ wam_c_reverse_index_capabilities(csr(Opts), [
     runtime_io(pread)
 ]) :-
     memberchk(index_backend(sorted_array), Opts),
+    wam_c_reverse_index_runtime_io_policy_supported(csr(Opts)),
     !.
 wam_c_reverse_index_capabilities(ReverseIndex, [
     planning(accepted),
@@ -80,6 +82,16 @@ wam_c_reverse_index_capabilities(ReverseIndex, [
     runtime_requires(wam_c_enable_lmdb)
 ]) :-
     wam_c_reverse_index_uses_lmdb_offset(ReverseIndex),
+    wam_c_reverse_index_runtime_io_policy_supported(ReverseIndex),
+    !.
+wam_c_reverse_index_capabilities(ReverseIndex, [
+    planning(accepted),
+    runtime_child_lookup(unsupported),
+    runtime_reason(csr_io_policy_not_implemented(Policy)),
+    runtime_io(Policy)
+]) :-
+    wam_c_reverse_index_runtime_io_policy(ReverseIndex, Policy),
+    \+ wam_c_supported_reverse_index_runtime_io_policy(Policy),
     !.
 wam_c_reverse_index_capabilities(ReverseIndex, [
     planning(accepted),
@@ -93,6 +105,28 @@ wam_c_reverse_index_uses_lmdb_offset(csr(Opts)) :-
 wam_c_reverse_index_uses_lmdb_offset(artifact(Opts)) :-
     memberchk(storage_kind(csr_pread_artifact), Opts),
     memberchk(index_backend(lmdb_offset), Opts).
+
+wam_c_reverse_index_runtime_io_policy(csr(Opts), Policy) :-
+    memberchk(phase(runtime_available), Opts),
+    memberchk(io_policy(Policy), Opts).
+wam_c_reverse_index_runtime_io_policy(artifact(Opts), Policy) :-
+    memberchk(phase(runtime_available), Opts),
+    memberchk(io_policy(Policy), Opts).
+
+wam_c_supported_reverse_index_runtime_io_policy(buffered_pread).
+
+wam_c_reverse_index_runtime_io_policy_supported(ReverseIndex) :-
+    (   wam_c_reverse_index_runtime_io_policy(ReverseIndex, Policy)
+    ->  wam_c_supported_reverse_index_runtime_io_policy(Policy)
+    ;   true
+    ).
+
+wam_c_require_reverse_index_runtime_io_policy(ReverseIndex) :-
+    (   wam_c_reverse_index_runtime_io_policy(ReverseIndex, Policy),
+        \+ wam_c_supported_reverse_index_runtime_io_policy(Policy)
+    ->  throw(error(permission_error(use, csr_io_policy, Policy), _))
+    ;   true
+    ).
 
 % ============================================================================
 % PHASE 4: Hybrid Module Assembly
@@ -225,6 +259,7 @@ generate_setup_reverse_index_c(Options, Code) :-
 wam_c_reverse_index_setup_plan(Options, Plan) :-
     resolve_wam_c_reverse_index_plan(Options,
         wam_c_reverse_index_plan(ReverseIndex, Capabilities)),
+    wam_c_require_reverse_index_runtime_io_policy(ReverseIndex),
     wam_c_reverse_index_runtime_available(ReverseIndex, Capabilities),
     wam_c_reverse_index_setup_backend(ReverseIndex, Backend),
     wam_c_reverse_index_setup_paths(Backend, Options, Paths),

--- a/tests/test_wam_c_effective_distance_benchmark.pl
+++ b/tests/test_wam_c_effective_distance_benchmark.pl
@@ -211,6 +211,31 @@ test_child_search_builds_lmdb_offset_reverse_csr :-
     ;   fail_test(Test, 'LMDB-offset reverse_index csr generated files mismatch')
     ).
 
+test_child_search_rejects_runtime_direct_io_reverse_csr :-
+    Test = 'WAM-C effective-distance: runtime direct_io reverse CSR fails clearly',
+    (   unique_tmp_dir(child_search_direct_io_csr, OutputDir),
+        write_child_search_facts(OutputDir, FactsPath),
+        catch((generate_wam_c_effective_distance_benchmark:generate(
+                   FactsPath,
+                   OutputDir,
+                   kernels_on,
+                   [ fact_storage(facts_tsv),
+                     child_search(bounded),
+                     max_child_expansions(4),
+                     child_search_depth(1),
+                     reverse_index(csr([
+                         phase(runtime_available),
+                         index_backend(sorted_array),
+                         io_policy(direct_io)
+                     ]))
+                   ]),
+               fail),
+              error(permission_error(use, csr_io_policy, direct_io), _),
+              true)
+    ->  pass(Test)
+    ;   fail_test(Test, 'expected permission_error(use, csr_io_policy, direct_io)')
+    ).
+
 test_generate_and_run_bounded_child_search_kernels_off :-
     Test = 'WAM-C effective-distance: kernels_off child search matches reference path',
     (   unique_tmp_dir(child_search_kernels_off, OutputDir),
@@ -458,6 +483,7 @@ run_tests_once :-
     test_child_search_uses_bidirectional_kernel,
     test_child_search_builds_reverse_csr,
     test_child_search_builds_lmdb_offset_reverse_csr,
+    test_child_search_rejects_runtime_direct_io_reverse_csr,
     test_generate_and_run_bounded_child_search_kernels_off,
     test_generate_and_run_weighted_child_search,
     test_generate_and_run_child_search_budget_pruning,

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -455,6 +455,24 @@ test_reverse_index_plan_runtime_available_lmdb_offset :-
     ;   fail_test(Test, 'runtime lmdb-offset CSR artifact was not marked available')
     ).
 
+test_reverse_index_plan_runtime_direct_io_unsupported :-
+    Test = 'WAM-C: runtime direct_io CSR artifact is rejected as unsupported',
+    (   resolve_wam_c_reverse_index_plan(
+            [reverse_index(artifact([
+                storage_kind(csr_pread_artifact),
+                phase(runtime_available),
+                index_backend(sorted_array),
+                io_policy(direct_io)
+            ]))],
+            wam_c_reverse_index_plan(artifact(Resolved), Capabilities)
+        ),
+        memberchk(io_policy(direct_io), Resolved),
+        memberchk(runtime_child_lookup(unsupported), Capabilities),
+        memberchk(runtime_reason(csr_io_policy_not_implemented(direct_io)), Capabilities)
+    ->  pass(Test)
+    ;   fail_test(Test, 'runtime direct_io CSR artifact should not be marked available')
+    ).
+
 test_reverse_index_setup_generation :-
     Test = 'WAM-C: reverse_index artifact emits CSR setup lifecycle',
     (   generate_setup_reverse_index_c(
@@ -498,6 +516,44 @@ test_reverse_index_setup_lmdb_offset_generation :-
         sub_string(S, _, _, _, 'wam_reverse_csr_load_lmdb_offset(bidirectional_child_csr, "/tmp/category_child.csr.val", "/tmp/category_child.offsets.lmdb", "offsets")')
     ->  pass(Test)
     ;   fail_test(Test, 'LMDB-offset CSR setup load order changed')
+    ).
+
+test_reverse_index_setup_rejects_runtime_direct_io :-
+    Test = 'WAM-C: reverse_index setup rejects unimplemented direct_io runtime policy',
+    (   catch((generate_setup_reverse_index_c(
+                   [reverse_index(artifact([
+                       storage_kind(csr_pread_artifact),
+                       phase(runtime_available),
+                       index_backend(sorted_array),
+                       io_policy(direct_io)
+                   ])),
+                    reverse_csr_index_path('/tmp/category_child.csr.idx'),
+                    reverse_csr_values_path('/tmp/category_child.csr.val')],
+                   _Code
+               ), fail),
+              error(permission_error(use, csr_io_policy, direct_io), _),
+              true)
+    ->  pass(Test)
+    ;   fail_test(Test, 'expected permission_error(use, csr_io_policy, direct_io)')
+    ).
+
+test_reverse_index_setup_rejects_runtime_buffered_pread_drop :-
+    Test = 'WAM-C: reverse_index setup rejects unimplemented buffered_pread_drop runtime policy',
+    (   catch((generate_setup_reverse_index_c(
+                   [reverse_index(artifact([
+                       storage_kind(csr_pread_artifact),
+                       phase(runtime_available),
+                       index_backend(sorted_array),
+                       io_policy(buffered_pread_drop)
+                   ])),
+                    reverse_csr_index_path('/tmp/category_child.csr.idx'),
+                    reverse_csr_values_path('/tmp/category_child.csr.val')],
+                   _Code
+               ), fail),
+              error(permission_error(use, csr_io_policy, buffered_pread_drop), _),
+              true)
+    ->  pass(Test)
+    ;   fail_test(Test, 'expected permission_error(use, csr_io_policy, buffered_pread_drop)')
     ).
 
 test_streaming_foreign_results_generation :-
@@ -5077,8 +5133,11 @@ run_tests_once :-
     test_reverse_index_plan_csr_cost_model,
     test_reverse_index_plan_runtime_available_sorted_array,
     test_reverse_index_plan_runtime_available_lmdb_offset,
+    test_reverse_index_plan_runtime_direct_io_unsupported,
     test_reverse_index_setup_generation,
     test_reverse_index_setup_lmdb_offset_generation,
+    test_reverse_index_setup_rejects_runtime_direct_io,
+    test_reverse_index_setup_rejects_runtime_buffered_pread_drop,
     test_streaming_foreign_results_generation,
     test_kernel_detector_setup_generation,
     test_bidirectional_ancestor_setup_generation,


### PR DESCRIPTION
  ## Summary

  Makes WAM-C reverse CSR runtime policy handling explicit instead of silently accepting policies the C runtime does not
  implement yet.

  Changes:
  - preserves normalized CSR `io_policy(...)` in the WAM-C effective-distance generator
  - reports unsupported runtime CSR I/O policies in WAM-C reverse-index capabilities
  - rejects unimplemented runtime `direct_io` and `buffered_pread_drop` setup with a clear `permission_error(use,
  csr_io_policy, Policy)`
  - adds regression coverage for unsupported runtime policy handling

  ## Verification

  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
  - `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
  - `swipl -q -t halt -s examples/benchmark/generate_wam_c_effective_distance_benchmark.pl`
  - `git diff --check`