### PR TITLE
Support WAM-C reverse CSR buffered pread drop policy

### DIFF
--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -135,6 +135,7 @@ typedef struct {
 typedef struct {
     int index_fd;
     int values_fd;
+    bool drop_after_read;
     WamReverseCsrRow *rows;
     int row_count;
 #ifdef WAM_C_ENABLE_LMDB
@@ -345,10 +346,17 @@ void wam_reverse_csr_close(WamReverseCsrArtifact *artifact);
 bool wam_reverse_csr_load(WamReverseCsrArtifact *artifact,
                           const char *index_path,
                           const char *values_path);
+bool wam_reverse_csr_load_pread_drop(WamReverseCsrArtifact *artifact,
+                                     const char *index_path,
+                                     const char *values_path);
 bool wam_reverse_csr_load_lmdb_offset(WamReverseCsrArtifact *artifact,
                                       const char *values_path,
                                       const char *offset_env_path,
                                       const char *db_name);
+bool wam_reverse_csr_load_lmdb_offset_pread_drop(WamReverseCsrArtifact *artifact,
+                                                const char *values_path,
+                                                const char *offset_env_path,
+                                                const char *db_name);
 int wam_reverse_csr_lookup_children(WamReverseCsrArtifact *artifact,
                                     int parent,
                                     int *out_children,

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -57,32 +57,35 @@ wam_c_reverse_index_capabilities(artifact(Opts), [
     runtime_child_lookup(available),
     runtime_api(wam_reverse_csr_lookup_children),
     runtime_index_backend(sorted_array),
-    runtime_io(pread)
+    runtime_io(RuntimeIo)
 ]) :-
     memberchk(storage_kind(csr_pread_artifact), Opts),
     memberchk(index_backend(sorted_array), Opts),
     wam_c_reverse_index_runtime_io_policy_supported(artifact(Opts)),
+    wam_c_reverse_index_runtime_io_capability(artifact(Opts), RuntimeIo),
     !.
 wam_c_reverse_index_capabilities(csr(Opts), [
     planning(accepted),
     runtime_child_lookup(available_after_artifact_build),
     runtime_api(wam_reverse_csr_lookup_children),
     runtime_index_backend(sorted_array),
-    runtime_io(pread)
+    runtime_io(RuntimeIo)
 ]) :-
     memberchk(index_backend(sorted_array), Opts),
     wam_c_reverse_index_runtime_io_policy_supported(csr(Opts)),
+    wam_c_reverse_index_runtime_io_capability(csr(Opts), RuntimeIo),
     !.
 wam_c_reverse_index_capabilities(ReverseIndex, [
     planning(accepted),
     runtime_child_lookup(available),
     runtime_api(wam_reverse_csr_lookup_children),
     runtime_index_backend(lmdb_offset),
-    runtime_io(pread),
+    runtime_io(RuntimeIo),
     runtime_requires(wam_c_enable_lmdb)
 ]) :-
     wam_c_reverse_index_uses_lmdb_offset(ReverseIndex),
     wam_c_reverse_index_runtime_io_policy_supported(ReverseIndex),
+    wam_c_reverse_index_runtime_io_capability(ReverseIndex, RuntimeIo),
     !.
 wam_c_reverse_index_capabilities(ReverseIndex, [
     planning(accepted),
@@ -113,7 +116,18 @@ wam_c_reverse_index_runtime_io_policy(artifact(Opts), Policy) :-
     memberchk(phase(runtime_available), Opts),
     memberchk(io_policy(Policy), Opts).
 
+wam_c_reverse_index_declared_io_policy(csr(Opts), Policy) :-
+    memberchk(io_policy(Policy), Opts).
+wam_c_reverse_index_declared_io_policy(artifact(Opts), Policy) :-
+    memberchk(io_policy(Policy), Opts).
+
 wam_c_supported_reverse_index_runtime_io_policy(buffered_pread).
+wam_c_supported_reverse_index_runtime_io_policy(buffered_pread_drop).
+
+wam_c_reverse_index_runtime_io_capability(ReverseIndex, pread_drop) :-
+    wam_c_reverse_index_declared_io_policy(ReverseIndex, buffered_pread_drop),
+    !.
+wam_c_reverse_index_runtime_io_capability(_ReverseIndex, pread).
 
 wam_c_reverse_index_runtime_io_policy_supported(ReverseIndex) :-
     (   wam_c_reverse_index_runtime_io_policy(ReverseIndex, Policy)
@@ -262,9 +276,10 @@ wam_c_reverse_index_setup_plan(Options, Plan) :-
     wam_c_require_reverse_index_runtime_io_policy(ReverseIndex),
     wam_c_reverse_index_runtime_available(ReverseIndex, Capabilities),
     wam_c_reverse_index_setup_backend(ReverseIndex, Backend),
+    wam_c_reverse_index_setup_policy(ReverseIndex, IoPolicy),
     wam_c_reverse_index_setup_paths(Backend, Options, Paths),
     option(category_id_map(CategoryIdMap), Options, []),
-    Plan = wam_c_reverse_index_setup(Backend, Paths, CategoryIdMap).
+    Plan = wam_c_reverse_index_setup(Backend, IoPolicy, Paths, CategoryIdMap).
 
 wam_c_reverse_index_runtime_available(artifact(Opts), Capabilities) :-
     memberchk(phase(runtime_available), Opts),
@@ -279,6 +294,11 @@ wam_c_reverse_index_setup_backend(ReverseIndex, lmdb_offset) :-
     wam_c_reverse_index_uses_lmdb_offset(ReverseIndex),
     !.
 wam_c_reverse_index_setup_backend(_ReverseIndex, sorted_array).
+
+wam_c_reverse_index_setup_policy(ReverseIndex, Policy) :-
+    wam_c_reverse_index_runtime_io_policy(ReverseIndex, Policy),
+    !.
+wam_c_reverse_index_setup_policy(_ReverseIndex, buffered_pread).
 
 wam_c_reverse_index_setup_paths(sorted_array, Options,
                                 sorted_array(IndexPath, ValuesPath)) :-
@@ -306,9 +326,9 @@ void teardown_wam_c_reverse_index_artifacts(WamState* state,
 ').
 
 wam_c_reverse_index_setup_code(
-        wam_c_reverse_index_setup(Backend, Paths, CategoryIdMap),
+        wam_c_reverse_index_setup(Backend, IoPolicy, Paths, CategoryIdMap),
         Code) :-
-    wam_c_reverse_index_load_call(Backend, Paths, LoadCall),
+    wam_c_reverse_index_load_call(Backend, IoPolicy, Paths, LoadCall),
     wam_c_category_id_setup_lines(CategoryIdMap, IdLines),
     format(atom(Code),
 'bool setup_wam_c_reverse_index_artifacts(WamState* state,
@@ -331,6 +351,7 @@ void teardown_wam_c_reverse_index_artifacts(WamState* state,
 ', [LoadCall, IdLines]).
 
 wam_c_reverse_index_load_call(sorted_array,
+                              buffered_pread,
                               sorted_array(IndexPath, ValuesPath),
                               LoadCall) :-
     c_string_literal(IndexPath, IndexLit),
@@ -338,7 +359,17 @@ wam_c_reverse_index_load_call(sorted_array,
     format(atom(LoadCall),
            'wam_reverse_csr_load(bidirectional_child_csr, ~w, ~w)',
            [IndexLit, ValuesLit]).
+wam_c_reverse_index_load_call(sorted_array,
+                              buffered_pread_drop,
+                              sorted_array(IndexPath, ValuesPath),
+                              LoadCall) :-
+    c_string_literal(IndexPath, IndexLit),
+    c_string_literal(ValuesPath, ValuesLit),
+    format(atom(LoadCall),
+           'wam_reverse_csr_load_pread_drop(bidirectional_child_csr, ~w, ~w)',
+           [IndexLit, ValuesLit]).
 wam_c_reverse_index_load_call(lmdb_offset,
+                              buffered_pread,
                               lmdb_offset(OffsetPath, ValuesPath, DbiName),
                               LoadCall) :-
     c_string_literal(OffsetPath, OffsetLit),
@@ -346,6 +377,16 @@ wam_c_reverse_index_load_call(lmdb_offset,
     c_string_literal(DbiName, DbiLit),
     format(atom(LoadCall),
            'wam_reverse_csr_load_lmdb_offset(bidirectional_child_csr, ~w, ~w, ~w)',
+           [ValuesLit, OffsetLit, DbiLit]).
+wam_c_reverse_index_load_call(lmdb_offset,
+                              buffered_pread_drop,
+                              lmdb_offset(OffsetPath, ValuesPath, DbiName),
+                              LoadCall) :-
+    c_string_literal(OffsetPath, OffsetLit),
+    c_string_literal(ValuesPath, ValuesLit),
+    c_string_literal(DbiName, DbiLit),
+    format(atom(LoadCall),
+           'wam_reverse_csr_load_lmdb_offset_pread_drop(bidirectional_child_csr, ~w, ~w, ~w)',
            [ValuesLit, OffsetLit, DbiLit]).
 
 wam_c_category_id_setup_lines([], '').
@@ -2801,6 +2842,18 @@ static bool wam_pread_exact(int fd, void *buffer, size_t bytes, off_t offset) {
     return true;
 }
 
+static void wam_drop_fd_range(int fd, off_t offset, off_t bytes) {
+#if defined(POSIX_FADV_DONTNEED)
+    if (fd >= 0 && bytes > 0) {
+        (void)posix_fadvise(fd, offset, bytes, POSIX_FADV_DONTNEED);
+    }
+#else
+    (void)fd;
+    (void)offset;
+    (void)bytes;
+#endif
+}
+
 void wam_reverse_csr_init(WamReverseCsrArtifact *artifact) {
     memset(artifact, 0, sizeof(WamReverseCsrArtifact));
     artifact->index_fd = -1;
@@ -2827,10 +2880,12 @@ bool wam_reverse_csr_load(WamReverseCsrArtifact *artifact,
                           const char *values_path) {
     const size_t record_bytes = 16;
     unsigned char *raw = NULL;
+    bool drop_after_read = artifact->drop_after_read;
     bool ok = false;
     off_t index_size = 0;
 
     wam_reverse_csr_close(artifact);
+    artifact->drop_after_read = drop_after_read;
     artifact->index_fd = open(index_path, O_RDONLY);
     if (artifact->index_fd < 0) goto done;
     artifact->values_fd = open(values_path, O_RDONLY);
@@ -2848,6 +2903,9 @@ bool wam_reverse_csr_load(WamReverseCsrArtifact *artifact,
         raw = malloc((size_t)index_size);
         if (!artifact->rows || !raw) goto done;
         if (!wam_pread_exact(artifact->index_fd, raw, (size_t)index_size, 0)) goto done;
+        if (artifact->drop_after_read) {
+            wam_drop_fd_range(artifact->index_fd, 0, index_size);
+        }
         for (int i = 0; i < artifact->row_count; i++) {
             const unsigned char *record = raw + ((size_t)i * record_bytes);
             int parent = (int)wam_read_i32_le(record);
@@ -2866,6 +2924,16 @@ done:
     return ok;
 }
 
+bool wam_reverse_csr_load_pread_drop(WamReverseCsrArtifact *artifact,
+                                     const char *index_path,
+                                     const char *values_path) {
+    bool ok = false;
+    artifact->drop_after_read = true;
+    ok = wam_reverse_csr_load(artifact, index_path, values_path);
+    if (ok) artifact->drop_after_read = true;
+    return ok;
+}
+
 bool wam_reverse_csr_load_lmdb_offset(WamReverseCsrArtifact *artifact,
                                       const char *values_path,
                                       const char *offset_env_path,
@@ -2879,9 +2947,11 @@ bool wam_reverse_csr_load_lmdb_offset(WamReverseCsrArtifact *artifact,
 #else
     MDB_txn *txn = NULL;
     int rc = 0;
+    bool drop_after_read = artifact->drop_after_read;
     bool ok = false;
 
     wam_reverse_csr_close(artifact);
+    artifact->drop_after_read = drop_after_read;
     artifact->values_fd = open(values_path, O_RDONLY);
     if (artifact->values_fd < 0) goto done;
 
@@ -2908,6 +2978,17 @@ done:
     if (!ok) wam_reverse_csr_close(artifact);
     return ok;
 #endif
+}
+
+bool wam_reverse_csr_load_lmdb_offset_pread_drop(WamReverseCsrArtifact *artifact,
+                                                const char *values_path,
+                                                const char *offset_env_path,
+                                                const char *db_name) {
+    bool ok = false;
+    artifact->drop_after_read = true;
+    ok = wam_reverse_csr_load_lmdb_offset(artifact, values_path, offset_env_path, db_name);
+    if (ok) artifact->drop_after_read = true;
+    return ok;
 }
 
 static WamReverseCsrRow *wam_reverse_csr_find_row(WamReverseCsrArtifact *artifact,
@@ -2995,6 +3076,13 @@ int wam_reverse_csr_lookup_children(WamReverseCsrArtifact *artifact,
             return -1;
         }
         out_children[i] = (int)wam_read_i32_le(encoded);
+    }
+    if (artifact->drop_after_read && to_read > 0) {
+        uint64_t first_byte = offset_edges * 4ULL;
+        uint64_t byte_count = (uint64_t)to_read * 4ULL;
+        if (first_byte <= (uint64_t)LLONG_MAX && byte_count <= (uint64_t)LLONG_MAX) {
+            wam_drop_fd_range(artifact->values_fd, (off_t)first_byte, (off_t)byte_count);
+        }
     }
     return total;
 }

--- a/tests/test_wam_c_effective_distance_benchmark.pl
+++ b/tests/test_wam_c_effective_distance_benchmark.pl
@@ -167,6 +167,34 @@ test_child_search_builds_reverse_csr :-
     ;   fail_test(Test, 'reverse_index csr child-search output mismatch')
     ).
 
+test_child_search_builds_pread_drop_reverse_csr :-
+    Test = 'WAM-C effective-distance: reverse_index csr supports buffered_pread_drop',
+    (   unique_tmp_dir(child_search_pread_drop_csr, OutputDir),
+        write_child_search_facts(OutputDir, FactsPath),
+        generate_wam_c_effective_distance_benchmark:generate(
+            FactsPath,
+            OutputDir,
+            kernels_on,
+            [ fact_storage(facts_tsv),
+              child_search(bounded),
+              max_child_expansions(4),
+              child_search_depth(1),
+              reverse_index(csr([
+                  phase(runtime_available),
+                  index_backend(sorted_array),
+                  io_policy(buffered_pread_drop)
+              ]))
+            ]),
+        directory_file_path(OutputDir, 'lib.c', LibPath),
+        read_file_to_string(LibPath, Lib, []),
+        sub_string(Lib, _, _, _, 'wam_reverse_csr_load_pread_drop(bidirectional_child_csr, "category_child.csr.idx", "category_child.csr.val")'),
+        compile_generated_project(OutputDir, facts_tsv),
+        run_generated_project(OutputDir, Output),
+        sub_string(Output, _, _, _, "article_a\troot\t3.000000")
+    ->  pass(Test)
+    ;   fail_test(Test, 'buffered_pread_drop reverse_index csr output mismatch')
+    ).
+
 test_child_search_builds_lmdb_offset_reverse_csr :-
     Test = 'WAM-C effective-distance: reverse_index csr can emit LMDB-offset CSR',
     (   unique_tmp_dir(child_search_lmdb_offset_csr, OutputDir),
@@ -482,6 +510,7 @@ run_tests_once :-
     test_generate_and_run_bounded_child_search,
     test_child_search_uses_bidirectional_kernel,
     test_child_search_builds_reverse_csr,
+    test_child_search_builds_pread_drop_reverse_csr,
     test_child_search_builds_lmdb_offset_reverse_csr,
     test_child_search_rejects_runtime_direct_io_reverse_csr,
     test_generate_and_run_bounded_child_search_kernels_off,

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -367,9 +367,12 @@ test_reverse_csr_generation :-
         atom_string(RuntimeCode, S),
         sub_string(S, _, _, _, 'void wam_reverse_csr_init'),
         sub_string(S, _, _, _, 'bool wam_reverse_csr_load'),
+        sub_string(S, _, _, _, 'bool wam_reverse_csr_load_pread_drop'),
         sub_string(S, _, _, _, 'bool wam_reverse_csr_load_lmdb_offset'),
+        sub_string(S, _, _, _, 'bool wam_reverse_csr_load_lmdb_offset_pread_drop'),
         sub_string(S, _, _, _, 'int wam_reverse_csr_lookup_children'),
         sub_string(S, _, _, _, 'pread('),
+        sub_string(S, _, _, _, 'posix_fadvise'),
         sub_string(S, _, _, _, 'wam_read_i32_le')
     ->  pass(Test)
     ;   fail_test(Test, 'reverse CSR helpers missing')
@@ -408,6 +411,7 @@ test_reverse_index_plan_csr_cost_model :-
         memberchk(runtime_child_lookup(available), Capabilities),
         memberchk(runtime_api(wam_reverse_csr_lookup_children), Capabilities),
         memberchk(runtime_index_backend(lmdb_offset), Capabilities),
+        memberchk(runtime_io(pread_drop), Capabilities),
         memberchk(runtime_requires(wam_c_enable_lmdb), Capabilities)
     ->  pass(Test)
     ;   fail_test(Test, 'CSR options were not normalized through the cost model')
@@ -473,6 +477,24 @@ test_reverse_index_plan_runtime_direct_io_unsupported :-
     ;   fail_test(Test, 'runtime direct_io CSR artifact should not be marked available')
     ).
 
+test_reverse_index_plan_runtime_buffered_pread_drop_available :-
+    Test = 'WAM-C: runtime buffered_pread_drop CSR artifact is available',
+    (   resolve_wam_c_reverse_index_plan(
+            [reverse_index(artifact([
+                storage_kind(csr_pread_artifact),
+                phase(runtime_available),
+                index_backend(sorted_array),
+                io_policy(buffered_pread_drop)
+            ]))],
+            wam_c_reverse_index_plan(artifact(Resolved), Capabilities)
+        ),
+        memberchk(io_policy(buffered_pread_drop), Resolved),
+        memberchk(runtime_child_lookup(available), Capabilities),
+        memberchk(runtime_io(pread_drop), Capabilities)
+    ->  pass(Test)
+    ;   fail_test(Test, 'runtime buffered_pread_drop CSR artifact should be marked available')
+    ).
+
 test_reverse_index_setup_generation :-
     Test = 'WAM-C: reverse_index artifact emits CSR setup lifecycle',
     (   generate_setup_reverse_index_c(
@@ -518,6 +540,26 @@ test_reverse_index_setup_lmdb_offset_generation :-
     ;   fail_test(Test, 'LMDB-offset CSR setup load order changed')
     ).
 
+test_reverse_index_setup_lmdb_offset_pread_drop_generation :-
+    Test = 'WAM-C: reverse_index lmdb-offset setup emits buffered_pread_drop loader',
+    (   generate_setup_reverse_index_c(
+            [reverse_index(artifact([
+                storage_kind(csr_pread_artifact),
+                phase(runtime_available),
+                index_backend(lmdb_offset),
+                io_policy(buffered_pread_drop)
+            ])),
+             reverse_csr_offset_lmdb_path('/tmp/category_child.offsets.lmdb'),
+             reverse_csr_values_path('/tmp/category_child.csr.val'),
+             reverse_csr_offset_lmdb_dbi(offsets)],
+            Code
+        ),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'wam_reverse_csr_load_lmdb_offset_pread_drop(bidirectional_child_csr, "/tmp/category_child.csr.val", "/tmp/category_child.offsets.lmdb", "offsets")')
+    ->  pass(Test)
+    ;   fail_test(Test, 'LMDB-offset buffered_pread_drop CSR setup loader missing')
+    ).
+
 test_reverse_index_setup_rejects_runtime_direct_io :-
     Test = 'WAM-C: reverse_index setup rejects unimplemented direct_io runtime policy',
     (   catch((generate_setup_reverse_index_c(
@@ -537,23 +579,23 @@ test_reverse_index_setup_rejects_runtime_direct_io :-
     ;   fail_test(Test, 'expected permission_error(use, csr_io_policy, direct_io)')
     ).
 
-test_reverse_index_setup_rejects_runtime_buffered_pread_drop :-
-    Test = 'WAM-C: reverse_index setup rejects unimplemented buffered_pread_drop runtime policy',
-    (   catch((generate_setup_reverse_index_c(
-                   [reverse_index(artifact([
-                       storage_kind(csr_pread_artifact),
-                       phase(runtime_available),
-                       index_backend(sorted_array),
-                       io_policy(buffered_pread_drop)
-                   ])),
-                    reverse_csr_index_path('/tmp/category_child.csr.idx'),
-                    reverse_csr_values_path('/tmp/category_child.csr.val')],
-                   _Code
-               ), fail),
-              error(permission_error(use, csr_io_policy, buffered_pread_drop), _),
-              true)
+test_reverse_index_setup_buffered_pread_drop_generation :-
+    Test = 'WAM-C: reverse_index setup emits buffered_pread_drop loader',
+    (   generate_setup_reverse_index_c(
+            [reverse_index(artifact([
+                storage_kind(csr_pread_artifact),
+                phase(runtime_available),
+                index_backend(sorted_array),
+                io_policy(buffered_pread_drop)
+            ])),
+             reverse_csr_index_path('/tmp/category_child.csr.idx'),
+             reverse_csr_values_path('/tmp/category_child.csr.val')],
+            Code
+        ),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'wam_reverse_csr_load_pread_drop(bidirectional_child_csr, "/tmp/category_child.csr.idx", "/tmp/category_child.csr.val")')
     ->  pass(Test)
-    ;   fail_test(Test, 'expected permission_error(use, csr_io_policy, buffered_pread_drop)')
+    ;   fail_test(Test, 'buffered_pread_drop CSR setup loader missing')
     ).
 
 test_streaming_foreign_results_generation :-
@@ -5134,10 +5176,12 @@ run_tests_once :-
     test_reverse_index_plan_runtime_available_sorted_array,
     test_reverse_index_plan_runtime_available_lmdb_offset,
     test_reverse_index_plan_runtime_direct_io_unsupported,
+    test_reverse_index_plan_runtime_buffered_pread_drop_available,
     test_reverse_index_setup_generation,
     test_reverse_index_setup_lmdb_offset_generation,
+    test_reverse_index_setup_lmdb_offset_pread_drop_generation,
     test_reverse_index_setup_rejects_runtime_direct_io,
-    test_reverse_index_setup_rejects_runtime_buffered_pread_drop,
+    test_reverse_index_setup_buffered_pread_drop_generation,
     test_streaming_foreign_results_generation,
     test_kernel_detector_setup_generation,
     test_bidirectional_ancestor_setup_generation,


### PR DESCRIPTION
  ## Summary

  Implements `io_policy(buffered_pread_drop)` for WAM-C reverse CSR artifacts.

  Changes:
  - adds `drop_after_read` tracking to `WamReverseCsrArtifact`
  - adds sorted-array and LMDB-offset `*_pread_drop` CSR loaders
  - uses `posix_fadvise(..., POSIX_FADV_DONTNEED)` after reading CSR index/value ranges when supported
  - reports `runtime_io(pread_drop)` for `buffered_pread_drop`
  - keeps `direct_io` rejected as unsupported
  - adds generated effective-distance coverage for `buffered_pread_drop`

  ## Verification

  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
  - `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
  - `swipl -q -t halt -s examples/benchmark/generate_wam_c_effective_distance_benchmark.pl`
  - `git diff --check`