### PR TITLE
feat(wam-python): add list ordering helpers

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -294,6 +294,64 @@ def _term_ground(term: 'Term', state: WamState) -> bool:
     return True
 
 
+def _standard_order_key(term: 'Term', state: WamState) -> Tuple:
+    term = deref(term, state)
+    if isinstance(term, Var):
+        return (0, term.id)
+    if isinstance(term, Float):
+        return (1, term.f)
+    if isinstance(term, Int):
+        return (1, term.n)
+    if isinstance(term, Atom):
+        return (2, _runtime_atom_text(term.name))
+    if isinstance(term, Compound):
+        functor = _display_functor_name(term.functor, len(term.args))
+        return (3, len(term.args), functor, tuple(_standard_order_key(arg, state) for arg in term.args))
+    if isinstance(term, Ref):
+        return _standard_order_key(deref(term, state), state)
+    return (4, repr(term))
+
+
+def _execute_sort_like(state: WamState, dedup: bool) -> bool:
+    items = _term_to_list(get_reg(state, 1), state)
+    if items is None:
+        return False
+    sorted_items = sorted(items, key=lambda item: _standard_order_key(item, state))
+    if dedup:
+        unique: List[Term] = []
+        previous_key = None
+        have_previous = False
+        for item in sorted_items:
+            key = _standard_order_key(item, state)
+            if not have_previous or key != previous_key:
+                unique.append(item)
+                previous_key = key
+                have_previous = True
+        sorted_items = unique
+    return unify(get_reg(state, 2), _list_from_terms(sorted_items), state)
+
+
+def _pair_key(term: 'Term', state: WamState) -> Optional[Tuple]:
+    term = deref(term, state)
+    if not isinstance(term, Compound) or _display_functor_name(term.functor, len(term.args)) != '-' or len(term.args) != 2:
+        return None
+    return _standard_order_key(term.args[0], state)
+
+
+def _execute_keysort(state: WamState) -> bool:
+    items = _term_to_list(get_reg(state, 1), state)
+    if items is None:
+        return False
+    keyed: List[Tuple[Tuple, Term]] = []
+    for item in items:
+        key = _pair_key(item, state)
+        if key is None:
+            return False
+        keyed.append((key, item))
+    keyed.sort(key=lambda pair: pair[0])
+    return unify(get_reg(state, 2), _list_from_terms([item for _, item in keyed]), state)
+
+
 def _make_cons(head: 'Term', tail: 'Term') -> 'Compound':
     """Construct a cons cell Compound('.', [head, tail])."""
     return Compound('.', [head, tail])
@@ -2421,6 +2479,12 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
         if items is None:
             return False
         return _execute_member_from_index(get_reg(state, 1), items, 0, resume_ip, state)
+    if builtin in ('sort/2', 'sort') and arity == 2:
+        return _execute_sort_like(state, dedup=True)
+    if builtin in ('msort/2', 'msort') and arity == 2:
+        return _execute_sort_like(state, dedup=False)
+    if builtin in ('keysort/2', 'keysort') and arity == 2:
+        return _execute_keysort(state)
     if builtin in ('functor/3', 'functor') and arity == 3:
         term = deref(get_reg(state, 1), state)
         name = deref(get_reg(state, 2), state)

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -1080,6 +1080,40 @@ test(runtime_format_helpers) :-
 			user:python_parser_cleanup_tmp_dir(ProjectDir)
 		)).
 
+test(runtime_list_ordering_helpers) :-
+	setup_call_cleanup(
+		(   retractall(user:py_list_ordering_demo),
+			assertz((user:py_list_ordering_demo :-
+				sort([3, 1, 2, 1, 3], Sorted),
+				Sorted = [1, 2, 3],
+				msort([3, 1, 2, 1, 3], MSorted),
+				MSorted = [1, 1, 2, 3, 3],
+				sort([foo, 1, bar, 2], Mixed),
+				Mixed = [1, 2, bar, foo],
+				keysort([b-1, a-2, b-3, a-4], KeySorted),
+				KeySorted = [a-2, a-4, b-1, b-3],
+				sort([], EmptySorted),
+				EmptySorted = [],
+				keysort([], EmptyKeys),
+				EmptyKeys = [],
+				\+ keysort([bad], _))),
+			user:python_parser_tmp_dir('tmp_wam_python_list_ordering', ProjectDir)
+		),
+		(   wam_python_target:write_wam_python_project([user:py_list_ordering_demo/0],
+				[runtime_parser(off)], ProjectDir),
+			atomic_list_concat([
+				"import predicates as p, wam_runtime as wr",
+				"code, labels = wr.load_program(p.build_program())",
+				"state = wr.WamState()",
+				"print(wr.run_wam(code, labels, 'py_list_ordering_demo/0', state))"
+			], '\n', Script),
+			user:python_parser_run_snippet(ProjectDir, Script, Output),
+			once(sub_string(Output, _, _, _, "True"))
+		),
+		(   retractall(user:py_list_ordering_demo),
+			user:python_parser_cleanup_tmp_dir(ProjectDir)
+		)).
+
 test(runtime_with_output_to_helpers) :-
 	setup_call_cleanup(
 		(   retractall(user:py_with_output_to_demo),
@@ -1970,6 +2004,9 @@ test(static_runtime_has_lua_baseline_builtins, [nondet]) :-
 		"format/2",
 		"format/3",
 		"with_output_to/2",
+		"sort/2",
+		"msort/2",
+		"keysort/2",
 		"put_char/1",
 		"put_char/2",
 		"put_code/1",
@@ -2004,6 +2041,11 @@ test(static_runtime_io_emits_output, [nondet]) :-
 	sub_string(Content, _, _, _, "'format/3'"),
 	sub_string(Content, _, _, _, "def _execute_with_output_to"),
 	sub_string(Content, _, _, _, "'with_output_to/2'"),
+	sub_string(Content, _, _, _, "def _execute_sort_like"),
+	sub_string(Content, _, _, _, "def _execute_keysort"),
+	sub_string(Content, _, _, _, "'sort/2'"),
+	sub_string(Content, _, _, _, "'msort/2'"),
+	sub_string(Content, _, _, _, "'keysort/2'"),
 	sub_string(Content, _, _, _, "def _execute_put_char"),
 	sub_string(Content, _, _, _, "def _execute_put_code"),
 	sub_string(Content, _, _, _, "def _execute_read_line_to_string"),


### PR DESCRIPTION
## Summary
- Add Python WAM runtime support for `sort/2`, `msort/2`, and `keysort/2`.
- Implement a scoped standard-order key for runtime terms covering variables, numbers, atoms, and compounds.
- Preserve duplicates for `msort/2`, deduplicate adjacent equal sort keys for `sort/2`, and keep `keysort/2` stable over `Key-Value` pairs.
- Fail `keysort/2` cleanly for malformed input elements.
- Add generated-project coverage plus static guard checks so the helpers stay wired into the Python target.

## Tests
- `python -m py_compile src/unifyweaver/targets/wam_python_runtime/WamRuntime.py`
- `swipl -q -g "run_tests(wam_python_runtime_parser_mode),run_tests(wam_python_builtin_parity_guard)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`

## Notes
- The full Python target suite passes locally: `166/166`.
- Existing choicepoint warnings still appear in the full suite, but they are unrelated to this change.
