### PR TITLE
Support WAM-C reverse CSR direct I/O

### DIFF
--- a/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
@@ -186,16 +186,18 @@ effective_distance_reverse_index_options(Options, OutputDir, CategoryParents,
     !,
     effective_distance_csr_index_backend(CsrOptions0, IndexBackend),
     effective_distance_csr_io_policy(CsrOptions0, IoPolicy),
+    effective_distance_csr_block_size_options(CsrOptions0, BlockSizeOptions),
     write_effective_distance_reverse_csr(OutputDir, CategoryParents,
                                          ArticleCategories, RootCategories,
-                                         IndexBackend, CategoryIdMap),
+                                         IndexBackend, IoPolicy, CategoryIdMap),
+    append([
+        storage_kind(csr_pread_artifact),
+        phase(runtime_available),
+        index_backend(IndexBackend),
+        io_policy(IoPolicy)
+    ], BlockSizeOptions, ArtifactOptions),
     ReverseIndexOptions = [
-        reverse_index(artifact([
-            storage_kind(csr_pread_artifact),
-            phase(runtime_available),
-            index_backend(IndexBackend),
-            io_policy(IoPolicy)
-        ])),
+        reverse_index(artifact(ArtifactOptions)),
         reverse_csr_values_path('category_child.csr.val'),
         category_id_map(CategoryIdMap)
     | ReverseIndexPathOptions],
@@ -225,6 +227,11 @@ parse_effective_distance_csr_index_backend(Backend, _) :-
 effective_distance_csr_io_policy(Options, IoPolicy) :-
     must_be(list, Options),
     resolve_csr_io_policy(Options, IoPolicy).
+
+effective_distance_csr_block_size_options(Options, [block_size_edges(BlockSizeEdges)]) :-
+    memberchk(block_size_edges(BlockSizeEdges), Options),
+    !.
+effective_distance_csr_block_size_options(_, []).
 
 effective_distance_reverse_index_path_options(sorted_array,
                                              [reverse_csr_index_path('category_child.csr.idx')]).
@@ -316,7 +323,7 @@ category_parent_tsv_line(Child-Parent, Line) :-
 
 write_effective_distance_reverse_csr(OutputDir, CategoryParents,
                                      ArticleCategories, RootCategories,
-                                     IndexBackend, CategoryIdMap) :-
+                                     IndexBackend, IoPolicy, CategoryIdMap) :-
     effective_distance_category_id_map(CategoryParents, ArticleCategories,
                                        RootCategories, CategoryIdMap),
     directory_file_path(OutputDir, 'category_child.csr.idx', IndexPath),
@@ -330,6 +337,7 @@ write_effective_distance_reverse_csr(OutputDir, CategoryParents,
     sort(ChildPairs0, ChildPairs),
     group_children_by_parent(ChildPairs, Rows),
     write_reverse_csr_files(IndexPath, ValuesPath, Rows),
+    maybe_pad_reverse_csr_values(IoPolicy, ValuesPath),
     maybe_write_reverse_csr_offset_lmdb_seeder(IndexBackend, OutputDir, Rows).
 
 effective_distance_category_id_map(CategoryParents, ArticleCategories,
@@ -383,6 +391,23 @@ write_reverse_csr_rows([csr_row(ParentId, Children)|Rows], Offset,
     forall(member(ChildId, Children), put_i32_le(ValuesStream, ChildId)),
     NextOffset is Offset + Count,
     write_reverse_csr_rows(Rows, NextOffset, IndexStream, ValuesStream).
+
+maybe_pad_reverse_csr_values(direct_io, ValuesPath) :-
+    !,
+    pad_file_to_alignment(ValuesPath, 4096).
+maybe_pad_reverse_csr_values(_, _).
+
+pad_file_to_alignment(Path, Alignment) :-
+    size_file(Path, Size),
+    Pad is (Alignment - (Size mod Alignment)) mod Alignment,
+    (   Pad =:= 0
+    ->  true
+    ;   setup_call_cleanup(
+            open(Path, append, Stream, [type(binary)]),
+            forall(between(1, Pad, _), put_byte(Stream, 0)),
+            close(Stream)
+        )
+    ).
 
 maybe_write_reverse_csr_offset_lmdb_seeder(sorted_array, _OutputDir, _Rows).
 maybe_write_reverse_csr_offset_lmdb_seeder(lmdb_offset, OutputDir, Rows) :-

--- a/src/unifyweaver/core/cost_model.pl
+++ b/src/unifyweaver/core/cost_model.pl
@@ -322,13 +322,16 @@ normalize_kind_options(artifact, Opts0, Opts) :-
     validate_reverse_ordering(Ordering),
     option(cache_bytes(CacheBytes), Opts0, 0),
     validate_nonnegative_integer(cache_bytes, CacheBytes),
+    option(block_size_edges(BlockSizeEdges), Opts0, 0),
+    validate_nonnegative_integer(block_size_edges, BlockSizeEdges),
     artifact_index_options(StorageKind, Opts0, IndexOpt),
     artifact_io_options(StorageKind, Opts0, IoOpt),
     append([
         relation(Relation),
         storage_kind(StorageKind),
         ordering(Ordering),
-        cache_bytes(CacheBytes)
+        cache_bytes(CacheBytes),
+        block_size_edges(BlockSizeEdges)
     ], IndexOpt, PrefixOpts),
     append(PrefixOpts, IoOpt, Opts).
 

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -136,6 +136,9 @@ typedef struct {
     int index_fd;
     int values_fd;
     bool drop_after_read;
+    bool direct_io;
+    size_t direct_io_alignment;
+    off_t values_size;
     WamReverseCsrRow *rows;
     int row_count;
 #ifdef WAM_C_ENABLE_LMDB
@@ -349,6 +352,10 @@ bool wam_reverse_csr_load(WamReverseCsrArtifact *artifact,
 bool wam_reverse_csr_load_pread_drop(WamReverseCsrArtifact *artifact,
                                      const char *index_path,
                                      const char *values_path);
+bool wam_reverse_csr_load_direct_io(WamReverseCsrArtifact *artifact,
+                                    const char *index_path,
+                                    const char *values_path,
+                                    int block_size_edges);
 bool wam_reverse_csr_load_lmdb_offset(WamReverseCsrArtifact *artifact,
                                       const char *values_path,
                                       const char *offset_env_path,
@@ -357,6 +364,11 @@ bool wam_reverse_csr_load_lmdb_offset_pread_drop(WamReverseCsrArtifact *artifact
                                                 const char *values_path,
                                                 const char *offset_env_path,
                                                 const char *db_name);
+bool wam_reverse_csr_load_lmdb_offset_direct_io(WamReverseCsrArtifact *artifact,
+                                                const char *values_path,
+                                                const char *offset_env_path,
+                                                const char *db_name,
+                                                int block_size_edges);
 int wam_reverse_csr_lookup_children(WamReverseCsrArtifact *artifact,
                                     int parent,
                                     int *out_children,

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -123,9 +123,13 @@ wam_c_reverse_index_declared_io_policy(artifact(Opts), Policy) :-
 
 wam_c_supported_reverse_index_runtime_io_policy(buffered_pread).
 wam_c_supported_reverse_index_runtime_io_policy(buffered_pread_drop).
+wam_c_supported_reverse_index_runtime_io_policy(direct_io).
 
 wam_c_reverse_index_runtime_io_capability(ReverseIndex, pread_drop) :-
     wam_c_reverse_index_declared_io_policy(ReverseIndex, buffered_pread_drop),
+    !.
+wam_c_reverse_index_runtime_io_capability(ReverseIndex, direct_io) :-
+    wam_c_reverse_index_declared_io_policy(ReverseIndex, direct_io),
     !.
 wam_c_reverse_index_runtime_io_capability(_ReverseIndex, pread).
 
@@ -139,8 +143,20 @@ wam_c_require_reverse_index_runtime_io_policy(ReverseIndex) :-
     (   wam_c_reverse_index_runtime_io_policy(ReverseIndex, Policy),
         \+ wam_c_supported_reverse_index_runtime_io_policy(Policy)
     ->  throw(error(permission_error(use, csr_io_policy, Policy), _))
+    ;   wam_c_reverse_index_runtime_io_policy(ReverseIndex, direct_io),
+        \+ wam_c_reverse_index_direct_io_preconditions(ReverseIndex)
+    ->  throw(error(permission_error(use, csr_io_policy, direct_io), _))
     ;   true
     ).
+
+wam_c_reverse_index_direct_io_preconditions(csr(Opts)) :-
+    memberchk(block_size_edges(BlockSizeEdges), Opts),
+    integer(BlockSizeEdges),
+    BlockSizeEdges > 0.
+wam_c_reverse_index_direct_io_preconditions(artifact(Opts)) :-
+    memberchk(block_size_edges(BlockSizeEdges), Opts),
+    integer(BlockSizeEdges),
+    BlockSizeEdges > 0.
 
 % ============================================================================
 % PHASE 4: Hybrid Module Assembly
@@ -277,9 +293,10 @@ wam_c_reverse_index_setup_plan(Options, Plan) :-
     wam_c_reverse_index_runtime_available(ReverseIndex, Capabilities),
     wam_c_reverse_index_setup_backend(ReverseIndex, Backend),
     wam_c_reverse_index_setup_policy(ReverseIndex, IoPolicy),
+    wam_c_reverse_index_setup_block_size_edges(ReverseIndex, BlockSizeEdges),
     wam_c_reverse_index_setup_paths(Backend, Options, Paths),
     option(category_id_map(CategoryIdMap), Options, []),
-    Plan = wam_c_reverse_index_setup(Backend, IoPolicy, Paths, CategoryIdMap).
+    Plan = wam_c_reverse_index_setup(Backend, IoPolicy, BlockSizeEdges, Paths, CategoryIdMap).
 
 wam_c_reverse_index_runtime_available(artifact(Opts), Capabilities) :-
     memberchk(phase(runtime_available), Opts),
@@ -299,6 +316,14 @@ wam_c_reverse_index_setup_policy(ReverseIndex, Policy) :-
     wam_c_reverse_index_runtime_io_policy(ReverseIndex, Policy),
     !.
 wam_c_reverse_index_setup_policy(_ReverseIndex, buffered_pread).
+
+wam_c_reverse_index_setup_block_size_edges(csr(Opts), BlockSizeEdges) :-
+    memberchk(block_size_edges(BlockSizeEdges), Opts),
+    !.
+wam_c_reverse_index_setup_block_size_edges(artifact(Opts), BlockSizeEdges) :-
+    memberchk(block_size_edges(BlockSizeEdges), Opts),
+    !.
+wam_c_reverse_index_setup_block_size_edges(_ReverseIndex, 0).
 
 wam_c_reverse_index_setup_paths(sorted_array, Options,
                                 sorted_array(IndexPath, ValuesPath)) :-
@@ -326,9 +351,9 @@ void teardown_wam_c_reverse_index_artifacts(WamState* state,
 ').
 
 wam_c_reverse_index_setup_code(
-        wam_c_reverse_index_setup(Backend, IoPolicy, Paths, CategoryIdMap),
+        wam_c_reverse_index_setup(Backend, IoPolicy, BlockSizeEdges, Paths, CategoryIdMap),
         Code) :-
-    wam_c_reverse_index_load_call(Backend, IoPolicy, Paths, LoadCall),
+    wam_c_reverse_index_load_call(Backend, IoPolicy, BlockSizeEdges, Paths, LoadCall),
     wam_c_category_id_setup_lines(CategoryIdMap, IdLines),
     format(atom(Code),
 'bool setup_wam_c_reverse_index_artifacts(WamState* state,
@@ -352,6 +377,7 @@ void teardown_wam_c_reverse_index_artifacts(WamState* state,
 
 wam_c_reverse_index_load_call(sorted_array,
                               buffered_pread,
+                              _BlockSizeEdges,
                               sorted_array(IndexPath, ValuesPath),
                               LoadCall) :-
     c_string_literal(IndexPath, IndexLit),
@@ -361,6 +387,7 @@ wam_c_reverse_index_load_call(sorted_array,
            [IndexLit, ValuesLit]).
 wam_c_reverse_index_load_call(sorted_array,
                               buffered_pread_drop,
+                              _BlockSizeEdges,
                               sorted_array(IndexPath, ValuesPath),
                               LoadCall) :-
     c_string_literal(IndexPath, IndexLit),
@@ -368,8 +395,19 @@ wam_c_reverse_index_load_call(sorted_array,
     format(atom(LoadCall),
            'wam_reverse_csr_load_pread_drop(bidirectional_child_csr, ~w, ~w)',
            [IndexLit, ValuesLit]).
+wam_c_reverse_index_load_call(sorted_array,
+                              direct_io,
+                              BlockSizeEdges,
+                              sorted_array(IndexPath, ValuesPath),
+                              LoadCall) :-
+    c_string_literal(IndexPath, IndexLit),
+    c_string_literal(ValuesPath, ValuesLit),
+    format(atom(LoadCall),
+           'wam_reverse_csr_load_direct_io(bidirectional_child_csr, ~w, ~w, ~w)',
+           [IndexLit, ValuesLit, BlockSizeEdges]).
 wam_c_reverse_index_load_call(lmdb_offset,
                               buffered_pread,
+                              _BlockSizeEdges,
                               lmdb_offset(OffsetPath, ValuesPath, DbiName),
                               LoadCall) :-
     c_string_literal(OffsetPath, OffsetLit),
@@ -380,6 +418,7 @@ wam_c_reverse_index_load_call(lmdb_offset,
            [ValuesLit, OffsetLit, DbiLit]).
 wam_c_reverse_index_load_call(lmdb_offset,
                               buffered_pread_drop,
+                              _BlockSizeEdges,
                               lmdb_offset(OffsetPath, ValuesPath, DbiName),
                               LoadCall) :-
     c_string_literal(OffsetPath, OffsetLit),
@@ -388,6 +427,17 @@ wam_c_reverse_index_load_call(lmdb_offset,
     format(atom(LoadCall),
            'wam_reverse_csr_load_lmdb_offset_pread_drop(bidirectional_child_csr, ~w, ~w, ~w)',
            [ValuesLit, OffsetLit, DbiLit]).
+wam_c_reverse_index_load_call(lmdb_offset,
+                              direct_io,
+                              BlockSizeEdges,
+                              lmdb_offset(OffsetPath, ValuesPath, DbiName),
+                              LoadCall) :-
+    c_string_literal(OffsetPath, OffsetLit),
+    c_string_literal(ValuesPath, ValuesLit),
+    c_string_literal(DbiName, DbiLit),
+    format(atom(LoadCall),
+           'wam_reverse_csr_load_lmdb_offset_direct_io(bidirectional_child_csr, ~w, ~w, ~w, ~w)',
+           [ValuesLit, OffsetLit, DbiLit, BlockSizeEdges]).
 
 wam_c_category_id_setup_lines([], '').
 wam_c_category_id_setup_lines(CategoryIdMap, Lines) :-
@@ -2279,7 +2329,8 @@ compile_step_wam_to_c(_Options, CCode) :-
 
 compile_wam_helpers_to_c(_Options, CCode) :-
     CCode =
-'#define _POSIX_C_SOURCE 200809L
+'#define _GNU_SOURCE
+#define _POSIX_C_SOURCE 200809L
 #include "wam_runtime.h"
 #include <errno.h>
 #include <fcntl.h>
@@ -2842,6 +2893,37 @@ static bool wam_pread_exact(int fd, void *buffer, size_t bytes, off_t offset) {
     return true;
 }
 
+static bool wam_direct_read_exact(WamReverseCsrArtifact *artifact,
+                                  void *buffer,
+                                  size_t bytes,
+                                  off_t offset) {
+    if (!artifact->direct_io) {
+        return wam_pread_exact(artifact->values_fd, buffer, bytes, offset);
+    }
+    if (artifact->direct_io_alignment == 0 || artifact->values_size < 0) return false;
+
+    size_t alignment = artifact->direct_io_alignment;
+    uint64_t start = (uint64_t)offset;
+    uint64_t end = start + (uint64_t)bytes;
+    if (end < start || end > (uint64_t)artifact->values_size) return false;
+    uint64_t aligned_start = start - (start % (uint64_t)alignment);
+    uint64_t aligned_end = ((end + (uint64_t)alignment - 1ULL) / (uint64_t)alignment) *
+                           (uint64_t)alignment;
+    if (aligned_end < aligned_start) return false;
+    if (aligned_end > (uint64_t)artifact->values_size) return false;
+    size_t read_bytes = (size_t)(aligned_end - aligned_start);
+    if (read_bytes == 0 || ((uint64_t)read_bytes != aligned_end - aligned_start)) return false;
+
+    void *scratch = NULL;
+    if (posix_memalign(&scratch, alignment, read_bytes) != 0) return false;
+    bool ok = wam_pread_exact(artifact->values_fd, scratch, read_bytes, (off_t)aligned_start);
+    if (ok) {
+        memcpy(buffer, ((unsigned char *)scratch) + (start - aligned_start), bytes);
+    }
+    free(scratch);
+    return ok;
+}
+
 static void wam_drop_fd_range(int fd, off_t offset, off_t bytes) {
 #if defined(POSIX_FADV_DONTNEED)
     if (fd >= 0 && bytes > 0) {
@@ -2881,15 +2963,27 @@ bool wam_reverse_csr_load(WamReverseCsrArtifact *artifact,
     const size_t record_bytes = 16;
     unsigned char *raw = NULL;
     bool drop_after_read = artifact->drop_after_read;
+    bool direct_io = artifact->direct_io;
+    size_t direct_io_alignment = artifact->direct_io_alignment;
     bool ok = false;
     off_t index_size = 0;
 
     wam_reverse_csr_close(artifact);
     artifact->drop_after_read = drop_after_read;
+    artifact->direct_io = direct_io;
+    artifact->direct_io_alignment = direct_io_alignment;
     artifact->index_fd = open(index_path, O_RDONLY);
     if (artifact->index_fd < 0) goto done;
-    artifact->values_fd = open(values_path, O_RDONLY);
+    int values_flags = O_RDONLY;
+#ifdef O_DIRECT
+    if (artifact->direct_io) values_flags |= O_DIRECT;
+#else
+    if (artifact->direct_io) goto done;
+#endif
+    artifact->values_fd = open(values_path, values_flags);
     if (artifact->values_fd < 0) goto done;
+    artifact->values_size = lseek(artifact->values_fd, 0, SEEK_END);
+    if (artifact->values_size < 0) goto done;
 
     index_size = lseek(artifact->index_fd, 0, SEEK_END);
     if (index_size < 0 || (index_size % (off_t)record_bytes) != 0) goto done;
@@ -2934,6 +3028,20 @@ bool wam_reverse_csr_load_pread_drop(WamReverseCsrArtifact *artifact,
     return ok;
 }
 
+bool wam_reverse_csr_load_direct_io(WamReverseCsrArtifact *artifact,
+                                    const char *index_path,
+                                    const char *values_path,
+                                    int block_size_edges) {
+    if (block_size_edges <= 0) return false;
+    artifact->direct_io = true;
+    artifact->direct_io_alignment = 4096;
+    bool ok = wam_reverse_csr_load(artifact, index_path, values_path);
+    if (ok) {
+        artifact->direct_io = true;
+    }
+    return ok;
+}
+
 bool wam_reverse_csr_load_lmdb_offset(WamReverseCsrArtifact *artifact,
                                       const char *values_path,
                                       const char *offset_env_path,
@@ -2948,12 +3056,24 @@ bool wam_reverse_csr_load_lmdb_offset(WamReverseCsrArtifact *artifact,
     MDB_txn *txn = NULL;
     int rc = 0;
     bool drop_after_read = artifact->drop_after_read;
+    bool direct_io = artifact->direct_io;
+    size_t direct_io_alignment = artifact->direct_io_alignment;
     bool ok = false;
 
     wam_reverse_csr_close(artifact);
     artifact->drop_after_read = drop_after_read;
-    artifact->values_fd = open(values_path, O_RDONLY);
+    artifact->direct_io = direct_io;
+    artifact->direct_io_alignment = direct_io_alignment;
+    int values_flags = O_RDONLY;
+#ifdef O_DIRECT
+    if (artifact->direct_io) values_flags |= O_DIRECT;
+#else
+    if (artifact->direct_io) goto done;
+#endif
+    artifact->values_fd = open(values_path, values_flags);
     if (artifact->values_fd < 0) goto done;
+    artifact->values_size = lseek(artifact->values_fd, 0, SEEK_END);
+    if (artifact->values_size < 0) goto done;
 
     rc = mdb_env_create(&artifact->offset_env);
     if (rc != MDB_SUCCESS) goto done;
@@ -2988,6 +3108,21 @@ bool wam_reverse_csr_load_lmdb_offset_pread_drop(WamReverseCsrArtifact *artifact
     artifact->drop_after_read = true;
     ok = wam_reverse_csr_load_lmdb_offset(artifact, values_path, offset_env_path, db_name);
     if (ok) artifact->drop_after_read = true;
+    return ok;
+}
+
+bool wam_reverse_csr_load_lmdb_offset_direct_io(WamReverseCsrArtifact *artifact,
+                                                const char *values_path,
+                                                const char *offset_env_path,
+                                                const char *db_name,
+                                                int block_size_edges) {
+    if (block_size_edges <= 0) return false;
+    artifact->direct_io = true;
+    artifact->direct_io_alignment = 4096;
+    bool ok = wam_reverse_csr_load_lmdb_offset(artifact, values_path, offset_env_path, db_name);
+    if (ok) {
+        artifact->direct_io = true;
+    }
     return ok;
 }
 
@@ -3072,7 +3207,7 @@ int wam_reverse_csr_lookup_children(WamReverseCsrArtifact *artifact,
         unsigned char encoded[4];
         uint64_t edge_offset = offset_edges + (uint64_t)i;
         if (edge_offset > (UINT64_MAX / 4ULL)) return -1;
-        if (!wam_pread_exact(artifact->values_fd, encoded, sizeof(encoded), (off_t)(edge_offset * 4ULL))) {
+        if (!wam_direct_read_exact(artifact, encoded, sizeof(encoded), (off_t)(edge_offset * 4ULL))) {
             return -1;
         }
         out_children[i] = (int)wam_read_i32_le(encoded);

--- a/tests/core/test_cost_model.pl
+++ b/tests/core/test_cost_model.pl
@@ -659,6 +659,7 @@ test_reverse_index_artifact_normalizes_storage_kind :-
         storage_kind(csr_pread_artifact),
         ordering(root_bfs),
         cache_bytes(1024),
+        block_size_edges(0),
         index_backend(lmdb_offset),
         io_policy(buffered_pread)
     ]),

--- a/tests/test_wam_c_effective_distance_benchmark.pl
+++ b/tests/test_wam_c_effective_distance_benchmark.pl
@@ -264,6 +264,36 @@ test_child_search_rejects_runtime_direct_io_reverse_csr :-
     ;   fail_test(Test, 'expected permission_error(use, csr_io_policy, direct_io)')
     ).
 
+test_child_search_builds_direct_io_reverse_csr :-
+    Test = 'WAM-C effective-distance: reverse_index csr emits direct_io loader',
+    (   unique_tmp_dir(child_search_direct_io_csr_enabled, OutputDir),
+        write_child_search_facts(OutputDir, FactsPath),
+        generate_wam_c_effective_distance_benchmark:generate(
+            FactsPath,
+            OutputDir,
+            kernels_on,
+            [ fact_storage(facts_tsv),
+              child_search(bounded),
+              max_child_expansions(4),
+              child_search_depth(1),
+              reverse_index(csr([
+                  phase(runtime_available),
+                  index_backend(sorted_array),
+                  io_policy(direct_io),
+                  block_size_edges(1024)
+              ]))
+            ]),
+        directory_file_path(OutputDir, 'lib.c', LibPath),
+        directory_file_path(OutputDir, 'category_child.csr.val', ValuesPath),
+        read_file_to_string(LibPath, Lib, []),
+        sub_string(Lib, _, _, _, 'wam_reverse_csr_load_direct_io(bidirectional_child_csr, "category_child.csr.idx", "category_child.csr.val", 1024)'),
+        size_file(ValuesPath, ValuesBytes),
+        0 is ValuesBytes mod 4096,
+        compile_generated_project(OutputDir, facts_tsv)
+    ->  pass(Test)
+    ;   fail_test(Test, 'direct_io reverse_index csr generated files mismatch')
+    ).
+
 test_generate_and_run_bounded_child_search_kernels_off :-
     Test = 'WAM-C effective-distance: kernels_off child search matches reference path',
     (   unique_tmp_dir(child_search_kernels_off, OutputDir),
@@ -513,6 +543,7 @@ run_tests_once :-
     test_child_search_builds_pread_drop_reverse_csr,
     test_child_search_builds_lmdb_offset_reverse_csr,
     test_child_search_rejects_runtime_direct_io_reverse_csr,
+    test_child_search_builds_direct_io_reverse_csr,
     test_generate_and_run_bounded_child_search_kernels_off,
     test_generate_and_run_weighted_child_search,
     test_generate_and_run_child_search_budget_pruning,

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -368,10 +368,13 @@ test_reverse_csr_generation :-
         sub_string(S, _, _, _, 'void wam_reverse_csr_init'),
         sub_string(S, _, _, _, 'bool wam_reverse_csr_load'),
         sub_string(S, _, _, _, 'bool wam_reverse_csr_load_pread_drop'),
+        sub_string(S, _, _, _, 'bool wam_reverse_csr_load_direct_io'),
         sub_string(S, _, _, _, 'bool wam_reverse_csr_load_lmdb_offset'),
         sub_string(S, _, _, _, 'bool wam_reverse_csr_load_lmdb_offset_pread_drop'),
+        sub_string(S, _, _, _, 'bool wam_reverse_csr_load_lmdb_offset_direct_io'),
         sub_string(S, _, _, _, 'int wam_reverse_csr_lookup_children'),
         sub_string(S, _, _, _, 'pread('),
+        sub_string(S, _, _, _, 'O_DIRECT'),
         sub_string(S, _, _, _, 'posix_fadvise'),
         sub_string(S, _, _, _, 'wam_read_i32_le')
     ->  pass(Test)
@@ -459,22 +462,23 @@ test_reverse_index_plan_runtime_available_lmdb_offset :-
     ;   fail_test(Test, 'runtime lmdb-offset CSR artifact was not marked available')
     ).
 
-test_reverse_index_plan_runtime_direct_io_unsupported :-
-    Test = 'WAM-C: runtime direct_io CSR artifact is rejected as unsupported',
+test_reverse_index_plan_runtime_direct_io_available :-
+    Test = 'WAM-C: runtime direct_io CSR artifact is available when block size is declared',
     (   resolve_wam_c_reverse_index_plan(
             [reverse_index(artifact([
                 storage_kind(csr_pread_artifact),
                 phase(runtime_available),
                 index_backend(sorted_array),
-                io_policy(direct_io)
+                io_policy(direct_io),
+                block_size_edges(1024)
             ]))],
             wam_c_reverse_index_plan(artifact(Resolved), Capabilities)
         ),
         memberchk(io_policy(direct_io), Resolved),
-        memberchk(runtime_child_lookup(unsupported), Capabilities),
-        memberchk(runtime_reason(csr_io_policy_not_implemented(direct_io)), Capabilities)
+        memberchk(runtime_child_lookup(available), Capabilities),
+        memberchk(runtime_io(direct_io), Capabilities)
     ->  pass(Test)
-    ;   fail_test(Test, 'runtime direct_io CSR artifact should not be marked available')
+    ;   fail_test(Test, 'runtime direct_io CSR artifact should be marked available')
     ).
 
 test_reverse_index_plan_runtime_buffered_pread_drop_available :-
@@ -560,8 +564,8 @@ test_reverse_index_setup_lmdb_offset_pread_drop_generation :-
     ;   fail_test(Test, 'LMDB-offset buffered_pread_drop CSR setup loader missing')
     ).
 
-test_reverse_index_setup_rejects_runtime_direct_io :-
-    Test = 'WAM-C: reverse_index setup rejects unimplemented direct_io runtime policy',
+test_reverse_index_setup_rejects_runtime_direct_io_without_block_size :-
+    Test = 'WAM-C: reverse_index setup rejects direct_io without block size',
     (   catch((generate_setup_reverse_index_c(
                    [reverse_index(artifact([
                        storage_kind(csr_pread_artifact),
@@ -577,6 +581,26 @@ test_reverse_index_setup_rejects_runtime_direct_io :-
               true)
     ->  pass(Test)
     ;   fail_test(Test, 'expected permission_error(use, csr_io_policy, direct_io)')
+    ).
+
+test_reverse_index_setup_direct_io_generation :-
+    Test = 'WAM-C: reverse_index setup emits direct_io loader',
+    (   generate_setup_reverse_index_c(
+            [reverse_index(artifact([
+                storage_kind(csr_pread_artifact),
+                phase(runtime_available),
+                index_backend(sorted_array),
+                io_policy(direct_io),
+                block_size_edges(1024)
+            ])),
+             reverse_csr_index_path('/tmp/category_child.csr.idx'),
+             reverse_csr_values_path('/tmp/category_child.csr.val')],
+            Code
+        ),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'wam_reverse_csr_load_direct_io(bidirectional_child_csr, "/tmp/category_child.csr.idx", "/tmp/category_child.csr.val", 1024)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'direct_io CSR setup loader missing')
     ).
 
 test_reverse_index_setup_buffered_pread_drop_generation :-
@@ -5175,12 +5199,13 @@ run_tests_once :-
     test_reverse_index_plan_csr_cost_model,
     test_reverse_index_plan_runtime_available_sorted_array,
     test_reverse_index_plan_runtime_available_lmdb_offset,
-    test_reverse_index_plan_runtime_direct_io_unsupported,
+    test_reverse_index_plan_runtime_direct_io_available,
     test_reverse_index_plan_runtime_buffered_pread_drop_available,
     test_reverse_index_setup_generation,
     test_reverse_index_setup_lmdb_offset_generation,
     test_reverse_index_setup_lmdb_offset_pread_drop_generation,
-    test_reverse_index_setup_rejects_runtime_direct_io,
+    test_reverse_index_setup_rejects_runtime_direct_io_without_block_size,
+    test_reverse_index_setup_direct_io_generation,
     test_reverse_index_setup_buffered_pread_drop_generation,
     test_streaming_foreign_results_generation,
     test_kernel_detector_setup_generation,


### PR DESCRIPTION
  ## Summary

  - Add guarded `io_policy(direct_io)` support for WAM-C reverse CSR artifacts.
  - Require `block_size_edges` before enabling direct-I/O CSR setup.
  - Emit direct-I/O loaders for sorted-array and LMDB-offset CSR layouts.
  - Preserve effective-distance CSR direct-I/O metadata through artifact generation.
  - Pad generated direct-I/O CSR value files to 4096-byte alignment.

  ## Verification

  - `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
  - `swipl -q -t halt -s examples/benchmark/generate_wam_c_effective_distance_benchmark.pl`
  - `git diff --check`