### PR TITLE
Index WAM-C category ancestor edge scans

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -1,23 +1,24 @@
 # WAM C Target - Status And Next Steps
 
-Status date: 2026-05-17
+Status date: 2026-05-28
 
 Base verified locally:
 
-- `main` at `dba9ab10` (`Merge pull request #2232 from s243a/feat/wam-c-weighted-shortest-path-kernel`)
+- `main` at `9f805888` (`Merge pull request #2566 from s243a/feat/wam-c-direct-io-csr`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
+- `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
 - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/test_wam_c_lowered_helper_scale_regression.py`
 - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev,10x --target-sets c-wam-lowered-helper --repetitions 1 --baseline-target c-wam-lowered-helper-interpreted`
 - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 1 --baseline-target prolog-accumulated`
-- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10x --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 1 --baseline-target prolog-accumulated`
+- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10x --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 1 --baseline-target prolog-accumulated --run-timeout-seconds 180`
 - `git diff --check`
 
 Active branch:
 
-- `feat/wam-c-astar-shortest-path-kernel`
+- `investigate/wam-c-accumulated-runtime-cost`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -79,6 +80,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | `transitive_step_parent_distance5` native kernel | Done | C shared-kernel detector accepts `transitive_step_parent_distance5`, emits detected setup, registers a native arity-5 foreign handler, and covers direct plus detected-project executable smokes |
 | `weighted_shortest_path3` native kernel | Done | C shared-kernel detector accepts `weighted_shortest_path3`, emits detected setup, registers a native arity-3 foreign handler, and covers direct plus detected-project executable smokes over integer weighted edges |
 | `astar_shortest_path4` native kernel | Done | C shared-kernel detector accepts `astar_shortest_path4`, emits detected setup, registers a native arity-4 foreign handler, and covers direct plus detected-project executable smokes over integer weighted and direct-distance edges |
+| Accumulated runtime edge-index fix | Done | Lazy child indexes for `WamState` and `WamFactSource` remove repeated full-edge scans; `10x` accumulated C targets now run around 0.066-0.069s with output parity versus Prolog at 0.204s |
 
 ## Current C Target Baseline
 
@@ -164,34 +166,7 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `investigate/wam-c-accumulated-runtime-cost`
-
-Goal: explain why the accumulated C WAM effective-distance target is much
-slower than optimized Prolog at `10x`.
-
-Scope:
-
-- Profile generated `c-wam-accumulated` and `c-wam-accumulated-no-kernels` runs
-  at `10x`.
-- Identify whether the cost is WAM dispatch, fact lookup, repeated setup,
-  generated query shape, or native-kernel integration overhead.
-- Keep this separate from `transitive_closure2` unless the same root cause
-  blocks the new kernel.
-
-Status: recommended after the next shared-kernel slice, or sooner if runtime
-performance becomes the blocking question.
-
-Reason:
-
-- The measured shared-kernel family is now covered in C through
-  `astar_shortest_path4` at the small in-memory integer-weight level.
-- Previous benchmark-demand evidence showed accumulated C WAM is still about
-  `0.03x` versus optimized Prolog at `10x`, and native kernels barely move the
-  accumulated target relative to no-kernels.
-- Before adding broader fact-storage or wrapper integration, the next useful
-  question is where that runtime cost is coming from.
-
-### 2. `feat/wam-c-native-kernel-float-output`
+### 1. `feat/wam-c-native-kernel-float-output`
 
 Goal: close the output-type parity gap for weighted/A* native kernels by adding
 a C runtime representation for floating-point results.
@@ -203,6 +178,28 @@ Scope:
   results that are not exact integers.
 - Keep benchmark integration separate unless the value representation itself
   proves stable.
+
+Reason:
+
+- The accumulated effective-distance runtime blocker is resolved at `10x`; the
+  dominant cost was repeated full-edge scans in ancestor traversal, not WAM
+  dispatch or native-kernel call overhead.
+- Weighted/A* native kernels currently cover integer results, while Haskell and
+  Rust have broader numeric-result surfaces.
+
+### 2. `investigate/wam-c-larger-artifact-layouts`
+
+Goal: measure whether the newer parent-only LMDB and reverse CSR artifact
+layouts remain the right defaults at larger category scales.
+
+Scope:
+
+- Reuse the existing effective-distance matrix before adding new benchmark
+  surfaces.
+- Compare TSV, LMDB, CSR, and direct-I/O CSR modes where the current generator
+  can already emit them.
+- Keep any in-memory compressed CSR work out of this branch unless measurement
+  shows the current layout is the limiting factor.
 
 Status: recommended after the runtime-cost investigation, or sooner if a
 concrete generated benchmark requires float output.
@@ -396,9 +393,7 @@ After hash-bucket row dispatch but before compact row tables:
 
 ## Suggested Immediate Next Step
 
-Proceed with `investigate/wam-c-accumulated-runtime-cost`.
-
-Keep it narrow: profile the existing accumulated C WAM effective-distance
-targets at `10x`, identify whether the dominant cost is WAM dispatch, fact
-lookup, repeated setup, generated query shape, or native-kernel integration
-overhead, and document a concrete next implementation branch from that evidence.
+Proceed with `feat/wam-c-native-kernel-float-output` unless the next round of
+work is explicitly benchmark-scale focused. The accumulated runtime
+investigation found and fixed the dominant `10x` cost: repeated full-edge scans
+inside recursive ancestor traversal.

--- a/docs/design/WAM_C_ACCUMULATED_RUNTIME_COST_INVESTIGATION.md
+++ b/docs/design/WAM_C_ACCUMULATED_RUNTIME_COST_INVESTIGATION.md
@@ -1,0 +1,88 @@
+# WAM-C Accumulated Runtime Cost Investigation
+
+Date: 2026-05-28
+Branch: `investigate/wam-c-accumulated-runtime-cost`
+
+## Question
+
+The accumulated WAM-C effective-distance targets were correct but much slower
+than optimized Prolog at `10x`. The investigation goal was to identify whether
+the dominant cost came from WAM dispatch, fact loading, repeated setup,
+generated query shape, native-kernel integration, or fact lookup.
+
+## Baseline
+
+Command:
+
+```sh
+python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10x --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 1 --baseline-target prolog-accumulated --keep-temp --run-timeout-seconds 180
+```
+
+Result before the fix:
+
+| Target | Median |
+|---|---:|
+| `prolog-accumulated` | 0.205s |
+| `c-wam-accumulated` | 8.801s |
+| `c-wam-accumulated-lmdb` | 8.255s |
+| `c-wam-accumulated-no-kernels` | 8.849s |
+| `c-wam-accumulated-no-kernels-lmdb` | 9.137s |
+
+All C outputs matched Prolog. The native-kernel target was only 1.006x faster
+than no-kernels for TSV facts, so foreign dispatch was not the primary issue.
+
+## Finding
+
+The generated accumulated runner repeatedly evaluates `category_ancestor/4`
+for article-category/root pairs. Both paths used by that workload had the same
+shape:
+
+- the native WAM-C `category_ancestor` kernel scanned every registered
+  `category_parent` edge for each DFS step;
+- the no-kernel reference DFS scanned every loaded fact-source edge for each
+  DFS step.
+
+At `10x`, the fixture has only hundreds of article-category entries but several
+thousand parent edges. The cost therefore came from repeated full edge-list
+scans inside recursive ancestor traversal, not from fact loading or kernel
+dispatch.
+
+## Fix
+
+The C runtime now builds a lazy sorted child index for category edges:
+
+- `WamState` keeps `category_edges_by_child` for native category traversal.
+- `WamFactSource` keeps `edges_by_child` for generated no-kernel reference
+  traversal.
+- Both indexes are invalidated when edges are appended and rebuilt lazily on the
+  first lookup.
+- `category_ancestor` and the generated reference DFS use child ranges instead
+  of scanning the full edge list.
+
+## Result
+
+Command:
+
+```sh
+python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10x --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 3 --baseline-target prolog-accumulated --run-timeout-seconds 180
+```
+
+Result after the fix:
+
+| Target | Median | Speedup vs Prolog |
+|---|---:|---:|
+| `prolog-accumulated` | 0.204s | 1.00x |
+| `c-wam-accumulated` | 0.066s | 3.08x |
+| `c-wam-accumulated-lmdb` | 0.069s | 2.95x |
+| `c-wam-accumulated-no-kernels` | 0.068s | 3.00x |
+| `c-wam-accumulated-no-kernels-lmdb` | 0.067s | 3.04x |
+
+All outputs still matched. The remaining kernel/no-kernel delta is small, which
+is expected because both now use the same indexed ancestor traversal shape.
+
+## Next Work
+
+The immediate accumulated-runtime blocker is resolved for `10x`. Sensible next
+branches are now feature-parity work, such as adding floating-point WAM values
+for weighted/A* native-kernel results, or a larger-scale artifact-layout sweep
+if the benchmark focus returns to Wikipedia-sized data.

--- a/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
@@ -848,9 +848,11 @@ static int collect_reference_hops(WamFactSource *source,
                                   int visited_len,
                                   WamIntResults *results) {
     int found = 0;
-    for (int i = 0; i < source->edge_count; i++) {
-        CategoryEdge *edge = &source->edges[i];
-        if (strcmp(edge->child, cat) != 0) continue;
+    CategoryEdge *edges = NULL;
+    int edge_count = 0;
+    if (!wam_fact_source_child_range(source, cat, &edges, &edge_count)) return 0;
+    for (int i = 0; i < edge_count; i++) {
+        CategoryEdge *edge = &edges[i];
         if (visited_contains(visited, visited_len, edge->parent)) continue;
         if (strcmp(edge->parent, root) == 0) {
             if (!wam_int_results_push(results, depth + 1)) return 0;
@@ -858,9 +860,8 @@ static int collect_reference_hops(WamFactSource *source,
         }
     }
     if (visited_len >= max_depth || visited_len >= 64) return found;
-    for (int i = 0; i < source->edge_count; i++) {
-        CategoryEdge *edge = &source->edges[i];
-        if (strcmp(edge->child, cat) != 0) continue;
+    for (int i = 0; i < edge_count; i++) {
+        CategoryEdge *edge = &edges[i];
         if (visited_contains(visited, visited_len, edge->parent)) continue;
         visited[visited_len] = edge->parent;
         if (collect_reference_hops(source, edge->parent, root, depth + 1,

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -124,6 +124,9 @@ typedef struct {
     CategoryEdge *edges;
     int edge_count;
     int edge_cap;
+    CategoryEdge *edges_by_child;
+    int child_index_count;
+    bool child_index_dirty;
 } WamFactSource;
 
 typedef struct {
@@ -285,6 +288,9 @@ struct WamState {
     CategoryEdge *category_edges;
     int category_edge_count;
     int category_edge_cap;
+    CategoryEdge *category_edges_by_child;
+    int category_child_index_count;
+    bool category_child_index_dirty;
     int category_max_depth;
     double bidirectional_parent_step_cost;
     double bidirectional_child_step_cost;
@@ -341,6 +347,8 @@ bool wam_fact_source_load_lmdb(WamState *state, WamFactSource *source,
                                const char *env_path, const char *db_name);
 int wam_fact_source_lookup_arg1(WamFactSource *source, const char *arg1,
                                 CategoryEdge *out_edges, int max_edges);
+bool wam_fact_source_child_range(WamFactSource *source, const char *child,
+                                 CategoryEdge **edges_out, int *count_out);
 bool wam_register_category_parent_fact_source(WamState *state, WamFactSource *source);
 void wam_register_category_id(WamState *state, const char *atom, int id);
 void wam_attach_bidirectional_child_csr(WamState *state, WamReverseCsrArtifact *artifact);

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -2374,6 +2374,7 @@ void wam_free_state(WamState *state) {
     free(state->B_array);
     free(state->E_array);
     free(state->category_edges);
+    free(state->category_edges_by_child);
     free(state->category_ids);
     free(state->weighted_edges);
     free(state->direct_distance_edges);
@@ -2666,6 +2667,7 @@ void wam_register_category_parent(WamState *state, const char *child, const char
     state->category_edges[state->category_edge_count].child = wam_intern_atom(state, child);
     state->category_edges[state->category_edge_count].parent = wam_intern_atom(state, parent);
     state->category_edge_count++;
+    state->category_child_index_dirty = true;
 }
 
 void wam_register_transitive_edge(WamState *state, const char *child, const char *parent) {
@@ -2700,6 +2702,7 @@ void wam_fact_source_init(WamFactSource *source) {
 
 void wam_fact_source_close(WamFactSource *source) {
     free(source->edges);
+    free(source->edges_by_child);
     memset(source, 0, sizeof(WamFactSource));
 }
 
@@ -2714,6 +2717,7 @@ static void wam_fact_source_add_edge(WamState *state,
     source->edges[source->edge_count].child = wam_intern_atom(state, child);
     source->edges[source->edge_count].parent = wam_intern_atom(state, parent);
     source->edge_count++;
+    source->child_index_dirty = true;
 }
 
 bool wam_fact_source_load_tsv(WamState *state, WamFactSource *source, const char *path) {
@@ -2816,13 +2820,80 @@ done:
 #endif
 }
 
+static int wam_compare_category_edge_child_parent(const void *left, const void *right) {
+    const CategoryEdge *a = (const CategoryEdge *)left;
+    const CategoryEdge *b = (const CategoryEdge *)right;
+    int child_cmp = strcmp(a->child, b->child);
+    if (child_cmp != 0) return child_cmp;
+    return strcmp(a->parent, b->parent);
+}
+
+static int wam_category_edge_lower_bound(CategoryEdge *edges, int count, const char *child) {
+    int lo = 0;
+    int hi = count;
+    while (lo < hi) {
+        int mid = lo + (hi - lo) / 2;
+        if (strcmp(edges[mid].child, child) < 0) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    return lo;
+}
+
+static bool wam_fact_source_ensure_child_index(WamFactSource *source) {
+    if (!source->child_index_dirty &&
+        source->edges_by_child &&
+        source->child_index_count == source->edge_count) {
+        return true;
+    }
+    free(source->edges_by_child);
+    source->edges_by_child = NULL;
+    source->child_index_count = 0;
+    if (source->edge_count == 0) {
+        source->child_index_dirty = false;
+        return true;
+    }
+    source->edges_by_child = malloc(sizeof(CategoryEdge) * (size_t)source->edge_count);
+    if (!source->edges_by_child) return false;
+    memcpy(source->edges_by_child, source->edges, sizeof(CategoryEdge) * (size_t)source->edge_count);
+    qsort(source->edges_by_child, (size_t)source->edge_count, sizeof(CategoryEdge),
+          wam_compare_category_edge_child_parent);
+    source->child_index_count = source->edge_count;
+    source->child_index_dirty = false;
+    return true;
+}
+
+bool wam_fact_source_child_range(WamFactSource *source, const char *child,
+                                 CategoryEdge **edges_out, int *count_out) {
+    *edges_out = NULL;
+    *count_out = 0;
+    if (!wam_fact_source_ensure_child_index(source)) return false;
+    int start = wam_category_edge_lower_bound(source->edges_by_child,
+                                              source->child_index_count,
+                                              child);
+    if (start >= source->child_index_count ||
+        strcmp(source->edges_by_child[start].child, child) != 0) {
+        return true;
+    }
+    int end = start;
+    while (end < source->child_index_count &&
+           strcmp(source->edges_by_child[end].child, child) == 0) {
+        end++;
+    }
+    *edges_out = source->edges_by_child + start;
+    *count_out = end - start;
+    return true;
+}
+
 int wam_fact_source_lookup_arg1(WamFactSource *source, const char *arg1,
                                 CategoryEdge *out_edges, int max_edges) {
+    CategoryEdge *edges = NULL;
     int count = 0;
-    for (int i = 0; i < source->edge_count; i++) {
-        if (strcmp(source->edges[i].child, arg1) != 0) continue;
-        if (count < max_edges) out_edges[count] = source->edges[i];
-        count++;
+    if (!wam_fact_source_child_range(source, arg1, &edges, &count)) return -1;
+    for (int i = 0; i < count && i < max_edges; i++) {
+        out_edges[i] = edges[i];
     }
     return count;
 }
@@ -2831,6 +2902,53 @@ bool wam_register_category_parent_fact_source(WamState *state, WamFactSource *so
     for (int i = 0; i < source->edge_count; i++) {
         wam_register_category_parent(state, source->edges[i].child, source->edges[i].parent);
     }
+    return true;
+}
+
+static bool wam_state_ensure_category_child_index(WamState *state) {
+    if (!state->category_child_index_dirty &&
+        state->category_edges_by_child &&
+        state->category_child_index_count == state->category_edge_count) {
+        return true;
+    }
+    free(state->category_edges_by_child);
+    state->category_edges_by_child = NULL;
+    state->category_child_index_count = 0;
+    if (state->category_edge_count == 0) {
+        state->category_child_index_dirty = false;
+        return true;
+    }
+    state->category_edges_by_child = malloc(sizeof(CategoryEdge) * (size_t)state->category_edge_count);
+    if (!state->category_edges_by_child) return false;
+    memcpy(state->category_edges_by_child, state->category_edges,
+           sizeof(CategoryEdge) * (size_t)state->category_edge_count);
+    qsort(state->category_edges_by_child, (size_t)state->category_edge_count,
+          sizeof(CategoryEdge), wam_compare_category_edge_child_parent);
+    state->category_child_index_count = state->category_edge_count;
+    state->category_child_index_dirty = false;
+    return true;
+}
+
+static bool wam_state_category_child_range(WamState *state, const char *child,
+                                           CategoryEdge **edges_out,
+                                           int *count_out) {
+    *edges_out = NULL;
+    *count_out = 0;
+    if (!wam_state_ensure_category_child_index(state)) return false;
+    int start = wam_category_edge_lower_bound(state->category_edges_by_child,
+                                              state->category_child_index_count,
+                                              child);
+    if (start >= state->category_child_index_count ||
+        strcmp(state->category_edges_by_child[start].child, child) != 0) {
+        return true;
+    }
+    int end = start;
+    while (end < state->category_child_index_count &&
+           strcmp(state->category_edges_by_child[end].child, child) == 0) {
+        end++;
+    }
+    *edges_out = state->category_edges_by_child + start;
+    *count_out = end - start;
     return true;
 }
 
@@ -3393,9 +3511,11 @@ static bool wam_category_ancestor_dfs(WamState *state,
                                       int visited_len,
                                       WamIntResults *results) {
     bool found = false;
-    for (int i = 0; i < state->category_edge_count; i++) {
-        CategoryEdge *edge = &state->category_edges[i];
-        if (strcmp(edge->child, cat) != 0) continue;
+    CategoryEdge *edges = NULL;
+    int edge_count = 0;
+    if (!wam_state_category_child_range(state, cat, &edges, &edge_count)) return false;
+    for (int i = 0; i < edge_count; i++) {
+        CategoryEdge *edge = &edges[i];
         if (wam_visited_array_contains(visited, visited_len, edge->parent)) continue;
         if (strcmp(edge->parent, root) == 0) {
             if (!wam_int_results_push(results, depth + 1)) return false;
@@ -3405,9 +3525,8 @@ static bool wam_category_ancestor_dfs(WamState *state,
 
     if (visited_len >= max_depth || visited_len >= 64) return found;
 
-    for (int i = 0; i < state->category_edge_count; i++) {
-        CategoryEdge *edge = &state->category_edges[i];
-        if (strcmp(edge->child, cat) != 0) continue;
+    for (int i = 0; i < edge_count; i++) {
+        CategoryEdge *edge = &edges[i];
         if (wam_visited_array_contains(visited, visited_len, edge->parent)) continue;
         visited[visited_len] = edge->parent;
         if (wam_category_ancestor_dfs(state, edge->parent, root, depth + 1,
@@ -3592,9 +3711,11 @@ static bool wam_bidirectional_ancestor_dfs(WamState *state,
         ? state->bidirectional_cost_budget
         : 10.0;
 
-    for (int i = 0; i < state->category_edge_count; i++) {
-        CategoryEdge *edge = &state->category_edges[i];
-        if (strcmp(edge->child, node) != 0) continue;
+    CategoryEdge *edges = NULL;
+    int edge_count = 0;
+    if (!wam_state_category_child_range(state, node, &edges, &edge_count)) return false;
+    for (int i = 0; i < edge_count; i++) {
+        CategoryEdge *edge = &edges[i];
         if (wam_visited_array_contains(visited, visited_len, edge->parent)) continue;
         double next_cost = cost + parent_cost;
         if (next_cost > budget) continue;

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -260,6 +260,7 @@ test_category_ancestor_kernel_generation :-
         sub_string(S, _, _, _, 'void wam_register_category_parent'),
         sub_string(S, _, _, _, 'void wam_register_category_ancestor_kernel'),
         sub_string(S, _, _, _, 'bool wam_category_ancestor_handler'),
+        sub_string(S, _, _, _, 'wam_state_category_child_range'),
         sub_string(S, _, _, _, 'wam_category_ancestor_dfs')
     ->  pass(Test)
     ;   fail_test(Test, 'category_ancestor native kernel helpers missing')
@@ -355,6 +356,7 @@ test_fact_source_generation :-
         sub_string(S, _, _, _, 'void wam_fact_source_init'),
         sub_string(S, _, _, _, 'bool wam_fact_source_load_tsv'),
         sub_string(S, _, _, _, 'bool wam_fact_source_load_lmdb'),
+        sub_string(S, _, _, _, 'bool wam_fact_source_child_range'),
         sub_string(S, _, _, _, 'int wam_fact_source_lookup_arg1'),
         sub_string(S, _, _, _, 'bool wam_register_category_parent_fact_source')
     ->  pass(Test)


### PR DESCRIPTION
  ## Summary

  - Add lazy child-edge indexes for WAM-C `WamState` and `WamFactSource`.
  - Use indexed child ranges in native `category_ancestor` traversal.
  - Use the same indexed lookup in the generated no-kernel effective-distance reference DFS.
  - Document the accumulated runtime investigation and update the WAM-C next-step roadmap.

  ## Results

  At `10x`, accumulated C targets moved from roughly `8.3-9.1s` to `0.066-0.069s`, with output parity against Prolog.
  The optimized Prolog baseline was `0.204s` in the final 3-repetition run.

  ## Verification

  - `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
  - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/
  benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/
  test_wam_c_lowered_helper_scale_regression.py`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10x --targets prolog-accumulated,c-wam-
  accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 3
  --baseline-target prolog-accumulated --run-timeout-seconds 180`
  - `swipl -q -t halt -s examples/benchmark/generate_wam_c_effective_distance_benchmark.pl`
  - `git diff --check`