### PR TITLE
Fix mysql_stream parser to handle MySQL float columns

### DIFF
--- a/src/unifyweaver/runtime/rust/mysql_stream/src/categorylinks_resolve.rs
+++ b/src/unifyweaver/runtime/rust/mysql_stream/src/categorylinks_resolve.rs
@@ -265,6 +265,9 @@ fn field_i64(field: &Field) -> Option<i64> {
     match field {
         Field::Int(value) => Some(*value),
         Field::Str(bytes) => std::str::from_utf8(bytes).ok()?.parse().ok(),
+        // Float columns (e.g. page_random) are never ID columns in the
+        // tables we care about; treat as unrepresentable.
+        Field::Float(_) => None,
         Field::Null => None,
     }
 }

--- a/src/unifyweaver/runtime/rust/mysql_stream/src/lib.rs
+++ b/src/unifyweaver/runtime/rust/mysql_stream/src/lib.rs
@@ -23,8 +23,14 @@ pub mod categorylinks_resolve;
 /// aren't necessarily valid UTF-8. Consumers decode as needed.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Field {
-    /// Integer literal (unquoted digits, optional minus sign).
+    /// Integer literal (unquoted digits, optional minus sign, no decimal).
     Int(i64),
+    /// Floating-point literal (digits with a decimal point and/or
+    /// exponent). Used by MediaWiki's `page_random` column among others.
+    /// We don't `PartialEq` against bit-equal floats specially —
+    /// downstream consumers should treat this as opaque unless they need
+    /// the value.
+    Float(f64),
     /// Quoted string/bytes literal, with MySQL escape sequences already
     /// decoded. May or may not be valid UTF-8.
     Str(Vec<u8>),
@@ -201,7 +207,15 @@ impl<R: BufRead> MysqlInsertIter<R> {
         }
     }
 
-    /// Parse an integer literal: optional `-`, then decimal digits.
+    /// Parse a numeric literal: optional `-`, decimal digits, and an
+    /// optional fractional part (`.` followed by more digits) and/or
+    /// exponent (`e` or `E` followed by optional sign and digits).
+    ///
+    /// Returns `Field::Int` if the literal has no fractional or
+    /// exponent part (preserves the original Int-only behaviour for
+    /// integer columns), otherwise `Field::Float`. MediaWiki's
+    /// `page_random` column emits values like `0.198981091825` that
+    /// would otherwise terminate tuple parsing at the decimal point.
     fn parse_int(&mut self) -> Option<Field> {
         let start = self.pos;
         if self.buf.get(self.pos)? == &b'-' {
@@ -218,8 +232,40 @@ impl<R: BufRead> MysqlInsertIter<R> {
         if self.pos == digit_start {
             return None;
         }
+        let mut is_float = false;
+        // Optional fractional part.
+        if let Some(&b'.') = self.buf.get(self.pos) {
+            is_float = true;
+            self.pos += 1;
+            while let Some(&c) = self.buf.get(self.pos) {
+                if c.is_ascii_digit() {
+                    self.pos += 1;
+                } else {
+                    break;
+                }
+            }
+        }
+        // Optional exponent: `e`/`E` then optional sign then digits.
+        if matches!(self.buf.get(self.pos), Some(b'e') | Some(b'E')) {
+            is_float = true;
+            self.pos += 1;
+            if matches!(self.buf.get(self.pos), Some(b'+') | Some(b'-')) {
+                self.pos += 1;
+            }
+            while let Some(&c) = self.buf.get(self.pos) {
+                if c.is_ascii_digit() {
+                    self.pos += 1;
+                } else {
+                    break;
+                }
+            }
+        }
         let s = std::str::from_utf8(&self.buf[start..self.pos]).ok()?;
-        Some(Field::Int(s.parse().ok()?))
+        if is_float {
+            Some(Field::Float(s.parse().ok()?))
+        } else {
+            Some(Field::Int(s.parse().ok()?))
+        }
     }
 
     /// Parse a quoted string. Assumes `self.pos` points at the opening `'`.
@@ -336,6 +382,44 @@ mod tests {
         assert_eq!(
             parse(input),
             vec![vec![Field::Int(1), Field::Int(2), Field::Int(3)]]
+        );
+    }
+
+    /// MediaWiki's `page` table has `page_random` (a double like
+    /// `0.198981091825`). Before adding `Field::Float`, the parser would
+    /// halt mid-tuple on the `.` and silently yield zero rows from the
+    /// entire dump.
+    #[test]
+    fn float_column_does_not_break_tuple() {
+        let input = "INSERT INTO `page` VALUES (4985,14,'Computer_science',0,0,0.198981091825,'20240101000000',NULL);\n";
+        assert_eq!(
+            parse(input),
+            vec![vec![
+                Field::Int(4985),
+                Field::Int(14),
+                s(b"Computer_science"),
+                Field::Int(0),
+                Field::Int(0),
+                Field::Float(0.198981091825),
+                s(b"20240101000000"),
+                Field::Null,
+            ]]
+        );
+    }
+
+    /// Negative integers and exponent notation (1e10, -1.5E-3) should
+    /// both round-trip through `Field::Int` or `Field::Float` as
+    /// appropriate.
+    #[test]
+    fn float_with_exponent_and_negative_int() {
+        let input = "INSERT INTO `t` VALUES (-42,1e10,-1.5E-3);\n";
+        assert_eq!(
+            parse(input),
+            vec![vec![
+                Field::Int(-42),
+                Field::Float(1e10),
+                Field::Float(-1.5e-3),
+            ]]
         );
     }
 

--- a/src/unifyweaver/runtime/rust/mysql_stream/src/lmdb_sink.rs
+++ b/src/unifyweaver/runtime/rust/mysql_stream/src/lmdb_sink.rs
@@ -445,7 +445,7 @@ fn field_i64(field: &Field) -> Option<i64> {
     match field {
         Field::Int(value) => Some(*value),
         Field::Str(bytes) => std::str::from_utf8(bytes).ok()?.parse().ok(),
-        Field::Null => None,
+        Field::Float(_) | Field::Null => None,
     }
 }
 

--- a/src/unifyweaver/runtime/rust/mysql_stream/src/main.rs
+++ b/src/unifyweaver/runtime/rust/mysql_stream/src/main.rs
@@ -42,6 +42,7 @@ fn tsv_escape_bytes(bytes: &[u8], out: &mut Vec<u8>) {
 fn write_field<W: Write>(out: &mut W, f: &Field) -> io::Result<()> {
     match f {
         Field::Int(n) => write!(out, "{}", n),
+        Field::Float(x) => write!(out, "{}", x),
         Field::Str(bytes) => {
             let mut buf = Vec::with_capacity(bytes.len());
             tsv_escape_bytes(bytes, &mut buf);


### PR DESCRIPTION
  ## Summary

  The `mysql_stream` parser only recognized `Int` / `Str` / `Null` field types. When it encountered a literal like
  `0.198981091825` (MediaWiki's `page_random` column, present on **every** row of the page-table dump), `parse_int`
  would consume just the leading `0`, return `Field::Int(0)`, and leave the cursor at the `.`. The tuple loop then
  expected `,` or `)`, saw `.`, and returned `None` — terminating the iterator and silently yielding zero rows from
  the whole dump.

  This made `mysql_stream_lmdb --mode correct` (the default after #2568) load **zero** category-namespace rows from
  the page dump, produce an empty `page_title_to_id` map, and emit an empty graph without surfacing an error.

  ## Reproduction

  ```bash
  # Before this PR: produces an empty graph silently.
  mysql_stream_lmdb \
    simplewiki-latest-categorylinks.sql.gz \
    ./out.lmdb \
    --mode correct \
    --linktarget-dump simplewiki-latest-linktarget.sql.gz \
    --page-dump simplewiki-latest-page.sql.gz \
    --refresh
  # mysql_stream_lmdb: linktarget rows kept (ns=14): 340739
  # mysql_stream_lmdb: page rows kept (ns=14): 0       ← bug
  # mysql_stream_lmdb: scanned=2223386 written=0
  ```

  ## Fix

  - Add `Field::Float(f64)` variant to the `Field` enum.
  - Extend `parse_int` to consume an optional fractional part (`.123…`) and an optional exponent (`e+10`, `E-3`),
  returning `Field::Float` when either appears. Pure-integer literals still return `Field::Int` — **backward
  compatible** for every existing caller.
  - Two new parser unit tests:
    - `float_column_does_not_break_tuple` — exercises the actual page-row layout that triggered the bug.
    - `float_with_exponent_and_negative_int` — scientific notation plus negative integers in the same tuple.
  - Add `Field::Float` arms to every existing exhaustive `match`:
    - `categorylinks_resolve::field_i64` — returns `None` (Float columns are never ID columns in the tables we care
  about).
    - `lmdb_sink::field_i64` — same treatment.
    - `mysql_stream::write_field` (TSV producer) — emits the float's `Display` representation, preserving precision
  for downstream consumers that may want it.

  ## Verification

  After this PR, on simplewiki:

  ```
  mysql_stream_lmdb: linktarget rows kept (ns=14): 340739
  mysql_stream_lmdb: page rows kept (ns=14): 92194
  mysql_stream_lmdb: scanned=2223386 written=294773
  ```

  Spot-checked edges resolve to real categories via the MediaWiki API:

  | page_id | title |
  |---|---|
  | 1000033 | Category:Non-profit organizations of Africa |
  | 312433 | Category:Non-profit organizations |
  | 1051053 | Category:Organizations based in Africa by subject |
  | 177384 | Category:Organisations based in the United Kingdom |

  …and one of the emitted edges is `1000033 → 312433` ("Non-profit organizations of Africa" → "Non-profit
  organizations") — semantically sensible. The graph is finally walkable: previously the old broken ingest produced
  25,227 edges keyed by mixed page_id / lt_id namespaces; the now-correct ingest produces **294,773** edges all keyed
  by `page_id`.

  ## Test plan

  - [x] `cargo test --release` — 22 lib tests + 7 binary tests, all passing (the 2 new float-handling tests are in the
   22).
  - [x] `cargo build --release` — clean.
  - [x] End-to-end ingest on simplewiki (~30 MB compressed dumps): page-rows-kept jumps from 0 → 92,194; edges-written
   from 0 → 294,773.
  - [x] Spot-check 4 page_ids via MediaWiki API → all resolve to real category names in ns=14.
  - [x] No changes to `iter_mysql_rows` public signature; existing callers that only handle `Int` / `Str` / `Null`
  still compile (with a new `Float` arm required by exhaustiveness — flagged as a soft API change in the existing
  module's `match` sites that I touched).

  ## Notes for the reviewer

  - I considered making the change "non-breaking" by parsing floats as `Field::Str` (so no new variant), but that
  would silently lose precision and make it harder for future consumers to opt into reading `page_random` or other
  numeric columns. The variant addition is small and exhaustiveness-checked, so all existing callsites are visible in
  this diff.
  - `f64`'s `PartialEq` is fine for the test `assert_eq!` (the values round-trip exactly because they're the result of
   `f64::from_str` on the same byte sequence). No `Eq` requirement is imposed on `Field` anywhere.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)