### PR TITLE
refactor(wam): route F# + Python ISO rewrite through shared items pipeline

### DIFF
--- a/docs/design/WAM_ITEMS_API_SPECIFICATION.md
+++ b/docs/design/WAM_ITEMS_API_SPECIFICATION.md
@@ -488,25 +488,24 @@ items natively: `wam_cpp_target.pl` calls the shared
 it never carried the per-shape text-rewrite duplication. (An earlier draft of
 this section claimed it did — that was inaccurate.)
 
-**Elixir and F# have been migrated off the per-shape text rules.** Each target's
-`iso_errors_rewrite_line/3` now tokenizes a WAM line with the shared
+**Elixir, F#, and Python have been migrated off the per-shape text rules.** Each
+target's `iso_errors_rewrite_line/3` now tokenizes a WAM line with the shared
 `wam_tokenize_line/2`, recognises it to a structured item via
 `wam_recognise_instruction/2`, and applies the shared
 `iso_errors_rewrite_item/3` (exported from `core/iso_errors`) — a single
 `arg(1)`-based key swap that covers all four shapes at once. The swapped key is
 spliced back into the original line so text output stays byte-identical. The
 four duplicated `iso_errors_rewrite_parts` clauses and the local
-`iso_errors_lookup/3` are gone from both. This is the `swap_key_in_item/3`-style
-pass the note below anticipated, realised without yet requiring a full
-items-first emitter. (Elixir: PR #2559. F#: this PR.)
+`iso_errors_lookup/3` are gone from all three. This is the
+`swap_key_in_item/3`-style pass the note below anticipated, realised without yet
+requiring a full items-first emitter. (Elixir: PR #2559. F# + Python: this PR.)
 
-**Python and Haskell still carry their own text-rewrite paths.** Python has the
-same four `iso_errors_rewrite_parts` clauses + `iso_errors_lookup/3`; Haskell
-uses a narrower `builtin_call`-only `sub_string` rewrite. Both are
-straightforward follow-ups along the same pattern. In all targets, ISO mode
-stays per-predicate — resolved by `iso_errors_mode_for(Config, PI, Mode)`,
-honouring `iso_errors_override` per `Pred/Arity`; this refactor does not change
-that.
+**Haskell still carries its own text-rewrite path** — a narrower
+`builtin_call`-only `sub_string` rewrite (it never had the four-shape
+duplication). Migrating it to the shared item pass is a straightforward
+follow-up. In all targets, ISO mode stays per-predicate — resolved by
+`iso_errors_mode_for(Config, PI, Mode)`, honouring `iso_errors_override` per
+`Pred/Arity`; this refactor does not change that.
 
 The interaction remains important for the remaining targets' future migrations.
 Once a target consumes structured WAM items directly, ISO rewrites collapse to

--- a/docs/design/WAM_ITEMS_API_SPECIFICATION.md
+++ b/docs/design/WAM_ITEMS_API_SPECIFICATION.md
@@ -482,23 +482,32 @@ Why migrate small targets first:
 
 ## 9. ISO-Sweep Interaction
 
-The C++ ISO sweep (arith compares + `succ_iso/2`) did not stay blocked on this
-refactor; it shipped against the existing text/items compatibility path. That
-means the C++ ISO implementation still carries multi-shape rewrite logic for
-`builtin_call`, `put_structure`, `call`, and `execute`.
+The C++ ISO sweep (arith compares + `succ_iso/2`) already builds structured WAM
+items natively: `wam_cpp_target.pl` calls the shared
+`iso_errors_rewrite(Config, PI, Items0, Items)` directly on its items list, so
+it never carried the per-shape text-rewrite duplication. (An earlier draft of
+this section claimed it did — that was inaccurate.)
 
-**Elixir is the first target migrated off the per-shape text rules.** Its
-`iso_errors_rewrite_line/3` now tokenizes each WAM line with the shared
+**Elixir and F# have been migrated off the per-shape text rules.** Each target's
+`iso_errors_rewrite_line/3` now tokenizes a WAM line with the shared
 `wam_tokenize_line/2`, recognises it to a structured item via
 `wam_recognise_instruction/2`, and applies the shared
 `iso_errors_rewrite_item/3` (exported from `core/iso_errors`) — a single
 `arg(1)`-based key swap that covers all four shapes at once. The swapped key is
 spliced back into the original line so text output stays byte-identical. The
 four duplicated `iso_errors_rewrite_parts` clauses and the local
-`iso_errors_lookup/3` are gone. This is the `swap_key_in_item/3`-style pass the
-note below anticipated, realised without yet requiring a full items-first
-emitter.
+`iso_errors_lookup/3` are gone from both. This is the `swap_key_in_item/3`-style
+pass the note below anticipated, realised without yet requiring a full
+items-first emitter. (Elixir: PR #2559. F#: this PR.)
 
-The interaction remains important for the other targets' future migrations.
+**Python and Haskell still carry their own text-rewrite paths.** Python has the
+same four `iso_errors_rewrite_parts` clauses + `iso_errors_lookup/3`; Haskell
+uses a narrower `builtin_call`-only `sub_string` rewrite. Both are
+straightforward follow-ups along the same pattern. In all targets, ISO mode
+stays per-predicate — resolved by `iso_errors_mode_for(Config, PI, Mode)`,
+honouring `iso_errors_override` per `Pred/Arity`; this refactor does not change
+that.
+
+The interaction remains important for the remaining targets' future migrations.
 Once a target consumes structured WAM items directly, ISO rewrites collapse to
 this same single shared pass instead of several text-shape rules per key.

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -90,8 +90,13 @@
                 iso_errors_mode_for/3,
                 iso_errors_warn_multi_module/2,
                 iso_errors_rewrite/4,
+                iso_errors_rewrite_item/3,
                 iso_errors_audit_normalise_pi/2,
                 iso_errors_audit_walk/5
+              ]).
+:- use_module('../targets/wam_text_parser',
+              [ wam_tokenize_line/2,
+                wam_recognise_instruction/2
               ]).
 :- use_module('../core/prolog_term_parser').
 :- use_module('../core/cpp_runtime_parser_wrappers').
@@ -4481,46 +4486,40 @@ iso_errors_rewrite_text(Config, PI, WamText, RewrittenText) :-
 
 iso_errors_has_lax_entries :- iso_errors:iso_errors_default_to_lax(_, _), !.
 
+% Rewrite one line via the shared items pipeline. Tokenize the line
+% with the shared quote-aware tokenizer, recognise it to a structured
+% WAM item, apply the shared item-level ISO rewrite, and splice the
+% new key back into the original line.
+%
+% iso_errors_rewrite_item/3 (in core/iso_errors) is the single source
+% of truth for the builtin_call / put_structure / call / execute key
+% swaps — this target no longer carries its own per-shape text rules.
+% All four rewritable shapes carry the key as their first argument, so
+% arg(1, ...) extracts old/new keys generically.
+%
+% Splicing rather than re-printing the recognised item preserves the
+% original whitespace byte-for-byte, so existing text output is
+% unaffected. Any failure along the chain (unrecognised line, key not
+% in the ISO/lax tables, splice miss) falls through to OutLine = Line.
 iso_errors_rewrite_line(Mode, Line, OutLine) :-
-    split_string(Line, " \t", " \t", Parts0),
-    exclude(==(""), Parts0, Parts),
-    (   iso_errors_rewrite_parts(Mode, Parts, Line, OutLine)
+    (   wam_tokenize_line(Line, Tokens),
+        wam_recognise_instruction(Tokens, Item0),
+        iso_errors_rewrite_item(Mode, Item0, Item1),
+        Item0 \== Item1,
+        arg(1, Item0, OldKey),
+        arg(1, Item1, NewKey),
+        iso_errors_splice_line(Line, OldKey, NewKey, OutLine)
     ->  true
     ;   OutLine = Line
     ).
 
-iso_errors_rewrite_parts(Mode, ["builtin_call", Key0 | _], Line, OutLine) :- !,
-    iso_errors_clean_key_token(Key0, Key),
-    iso_errors_lookup(Mode, Key, NewKey),
-    Key \== NewKey,
-    iso_errors_splice_line(Line, Key, NewKey, OutLine).
-iso_errors_rewrite_parts(Mode, ["put_structure", Key0 | _], Line, OutLine) :- !,
-    iso_errors_clean_key_token(Key0, Key),
-    iso_errors_lookup(Mode, Key, NewKey),
-    Key \== NewKey,
-    iso_errors_splice_line(Line, Key, NewKey, OutLine).
-iso_errors_rewrite_parts(Mode, ["call", Key0 | _], Line, OutLine) :- !,
-    iso_errors_clean_key_token(Key0, Key),
-    iso_errors_lookup(Mode, Key, NewKey),
-    Key \== NewKey,
-    iso_errors_splice_line(Line, Key, NewKey, OutLine).
-iso_errors_rewrite_parts(Mode, ["execute", Key0 | _], Line, OutLine) :- !,
-    iso_errors_clean_key_token(Key0, Key),
-    iso_errors_lookup(Mode, Key, NewKey),
-    Key \== NewKey,
-    iso_errors_splice_line(Line, Key, NewKey, OutLine).
-
+% Kept: the audit (iso_errors_audit_classify_line/2) still uses this to
+% strip the trailing comma from a builtin_call key token.
 iso_errors_clean_key_token(Token0, Token) :-
     (   string_concat(Token, ",", Token0)
     ->  true
     ;   Token = Token0
     ).
-
-iso_errors_lookup(true, Key, NewKey) :-
-    iso_errors:iso_errors_default_to_iso(Key, NewKey), !.
-iso_errors_lookup(false, Key, NewKey) :-
-    iso_errors:iso_errors_default_to_lax(Key, NewKey), !.
-iso_errors_lookup(_, Key, Key).
 
 iso_errors_splice_line(Line, Key, NewKey, OutLine) :-
     sub_string(Line, Before, KLen, _After, Key),

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -51,6 +51,7 @@
                 iso_errors_mode_for/3,
                 iso_errors_warn_multi_module/2,
                 iso_errors_rewrite/4,
+                iso_errors_rewrite_item/3,
                 iso_errors_audit_normalise_pi/2,
                 iso_errors_audit_walk/5
               ]).
@@ -62,7 +63,8 @@
 ]).
 :- use_module('../targets/wam_text_parser',
               [wam_classify_constant_token/2,
-               wam_tokenize_line/2]).
+               wam_tokenize_line/2,
+               wam_recognise_instruction/2]).
 :- use_module(wam_runtime_parser_capability, [
 	parser_dependent_body_goal/2,
 	wam_target_runtime_parser/3
@@ -1626,46 +1628,40 @@ iso_errors_rewrite_text(Config, PI, WamText, RewrittenText) :-
 
 iso_errors_has_lax_entries :- iso_errors:iso_errors_default_to_lax(_, _), !.
 
+% Rewrite one line via the shared items pipeline. Tokenize the line
+% with the shared quote-aware tokenizer, recognise it to a structured
+% WAM item, apply the shared item-level ISO rewrite, and splice the
+% new key back into the original line.
+%
+% iso_errors_rewrite_item/3 (in core/iso_errors) is the single source
+% of truth for the builtin_call / put_structure / call / execute key
+% swaps — this target no longer carries its own per-shape text rules.
+% All four rewritable shapes carry the key as their first argument, so
+% arg(1, ...) extracts old/new keys generically.
+%
+% Splicing rather than re-printing the recognised item preserves the
+% original whitespace byte-for-byte, so existing text output is
+% unaffected. Any failure along the chain (unrecognised line, key not
+% in the ISO/lax tables, splice miss) falls through to OutLine = Line.
 iso_errors_rewrite_line(Mode, Line, OutLine) :-
-	split_string(Line, " \t", " \t", Parts0),
-	exclude(==(""), Parts0, Parts),
-	(   iso_errors_rewrite_parts(Mode, Parts, Line, OutLine)
+	(   wam_tokenize_line(Line, Tokens),
+	    wam_recognise_instruction(Tokens, Item0),
+	    iso_errors_rewrite_item(Mode, Item0, Item1),
+	    Item0 \== Item1,
+	    arg(1, Item0, OldKey),
+	    arg(1, Item1, NewKey),
+	    iso_errors_splice_line(Line, OldKey, NewKey, OutLine)
 	->  true
 	;   OutLine = Line
 	).
 
-iso_errors_rewrite_parts(Mode, ["builtin_call", Key0 | _], Line, OutLine) :- !,
-	iso_errors_clean_key_token(Key0, Key),
-	iso_errors_lookup(Mode, Key, NewKey),
-	Key \== NewKey,
-	iso_errors_splice_line(Line, Key, NewKey, OutLine).
-iso_errors_rewrite_parts(Mode, ["put_structure", Key0 | _], Line, OutLine) :- !,
-	iso_errors_clean_key_token(Key0, Key),
-	iso_errors_lookup(Mode, Key, NewKey),
-	Key \== NewKey,
-	iso_errors_splice_line(Line, Key, NewKey, OutLine).
-iso_errors_rewrite_parts(Mode, ["call", Key0 | _], Line, OutLine) :- !,
-	iso_errors_clean_key_token(Key0, Key),
-	iso_errors_lookup(Mode, Key, NewKey),
-	Key \== NewKey,
-	iso_errors_splice_line(Line, Key, NewKey, OutLine).
-iso_errors_rewrite_parts(Mode, ["execute", Key0 | _], Line, OutLine) :- !,
-	iso_errors_clean_key_token(Key0, Key),
-	iso_errors_lookup(Mode, Key, NewKey),
-	Key \== NewKey,
-	iso_errors_splice_line(Line, Key, NewKey, OutLine).
-
+% Kept: the audit (iso_errors_audit_classify_line/2) still uses this to
+% strip the trailing comma from a builtin_call key token.
 iso_errors_clean_key_token(Token0, Token) :-
 	(   string_concat(Token, ",", Token0)
 	->  true
 	;   Token = Token0
 	).
-
-iso_errors_lookup(true, Key, NewKey) :-
-	iso_errors:iso_errors_default_to_iso(Key, NewKey), !.
-iso_errors_lookup(false, Key, NewKey) :-
-	iso_errors:iso_errors_default_to_lax(Key, NewKey), !.
-iso_errors_lookup(_, Key, Key).
 
 iso_errors_splice_line(Line, Key, NewKey, OutLine) :-
 	sub_string(Line, Before, KLen, _After, Key),


### PR DESCRIPTION
  ## Summary

  Migrates the F# and Python WAM targets off their per-shape text-rewrite duplication for ISO-error
  key swapping (`is/2`→`is_iso/2`, the six arithmetic compares, `succ/2`, etc.), routing them through
  the shared `iso_errors_rewrite_item/3` in `core/iso_errors`. Follows the Elixir migration (#2559).

  Each target's `iso_errors_rewrite_line/3` now:

  1. tokenizes the WAM line with the shared `wam_tokenize_line/2`
  2. recognises it to a structured item via `wam_recognise_instruction/2`
  3. applies the shared `iso_errors_rewrite_item/3` (one `arg(1)`-based key swap covering all four
  rewritable shapes — `builtin_call`, `put_structure`, `call`, `execute`)
  4. splices the swapped key back into the original line

  Splicing preserves whitespace byte-for-byte, so generated F#/Python source is unchanged.

  **Deleted from both targets:** the four duplicated `iso_errors_rewrite_parts` clauses and the local
  `iso_errors_lookup/3`. (`iso_errors_clean_key_token/2` is kept — the audit walker still uses it.)

  ## Also in this PR

  - **Spec doc correction (`WAM_ITEMS_API_SPECIFICATION.md` §9):** the prior text claimed C++ "still
  carries multi-shape rewrite logic." That was inaccurate — `wam_cpp_target.pl` calls the shared
  `iso_errors_rewrite/4` on its items list directly and never had the text duplication. Corrected, and
  updated to reflect F#/Python now migrated. Haskell (a narrower `builtin_call`-only `sub_string`
  rewrite) is noted as the last remaining text-rewrite target.

  ## Invariants preserved

  - **Per-predicate ISO optionality unchanged:** mode is still resolved by
  `iso_errors_mode_for(Config, PI, Mode)`, honouring `iso_errors_override(Pred/Arity, Mode)` exactly
  as before.
  - **Byte-identical output:** splicing the key into the original line, not re-printing the item.

  ## Test plan

  - [x] F# ISO unit suite: **12/12** (`test_wam_fsharp_iso_unit.pl`) — includes the compare-op sweep,
  `succ`, explicit-iso survival, per-predicate override, and the real project-generation rewrite test
  - [x] Shared `core/iso_errors`: **20/20** (`test_iso_errors.pl`)
  - [x] Python suite (`test_wam_python_target.pl`): 129 passed / 36 failed — the 36 failures are
  **pre-existing** `runtime_parser_compiled_*` environmental tests; verified byte-identical failure
  set against a clean `main` worktree (`diff` exit 0), so **zero regressions** from this change

  ## Not in scope

  The full items-first emitter refactor (`WAM_ITEMS_API_SPECIFICATION.md` Phase 1) — this PR only
  migrates the ISO-rewrite path. Haskell's migration is a clean follow-up.