### PR TITLE
LLVM WAM: M11 — compound deep-copy in aggregators + float ** with negative exp

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3051,18 +3051,17 @@ wam_llvm_case('begin_aggregate',
 % op1 = value_reg_idx
 wam_llvm_case('end_aggregate',
 '  %ea.val_reg = trunc i64 %op1 to i32
-  ; M10: deref before push. The per-iteration value reg is typically
-  ; a put_variable-allocated Ref whose heap cell holds the actual
-  ; result. On backtrack the heap rewinds, so the Ref becomes
-  ; dangling -- pushing the Ref unchanged means all accumulated
-  ; entries end up pointing to the same recycled heap address,
-  ; and set/setof dedups them all to one element. Dereferencing
-  ; here captures the atomic value while it is still bound.
-  ; Compound values still need a deep-copy (M11) -- their args
-  ; can hold Refs into the per-iteration heap region; for now
-  ; the typical setof-of-atoms / findall-of-ints case is correct.
+  ; M11: freeze (deref + deep-copy compounds) before push. Per-
+  ; iteration values are typically Refs into the volatile heap
+  ; region; backtrack between iterations rewinds the heap, so a
+  ; raw Ref ends up dangling and every accumulated entry collapses
+  ; to the same recycled address. wam_freeze_value follows the
+  ; Ref, captures atomic values directly, and for Compounds
+  ; recursively copies the args onto the arena so the result is
+  ; self-contained -- enabling findall(p(X,Y), ..., L) of compound
+  ; templates and setof/sort of compound elements.
   %ea.val_raw = call %Value @wam_get_reg(%WamState* %vm, i32 %ea.val_reg)
-  %ea.val = call %Value @wam_deref_value(%WamState* %vm, %Value %ea.val_raw)
+  %ea.val = call %Value @wam_freeze_value(%WamState* %vm, %Value %ea.val_raw)
 
   ; Push value to accumulator
   call void @wam_agg_push(%WamState* %vm, %Value %ea.val)
@@ -4399,6 +4398,80 @@ ct_loop_step:
   br label %ct_loop
 
 ct_done:
+  %new_i64 = ptrtoint %Compound* %new_cp to i64
+  %new_val0 = insertvalue %Value undef, i32 3, 0
+  %new_val = insertvalue %Value %new_val0, i64 %new_i64, 1
+  ret %Value %new_val
+}
+
+; M11: deref-aware deep-copy. Resolves Refs to the heap-stored value,
+; then copies Compounds (recursing on args) so the returned %Value
+; is self-contained -- it survives a heap rewind. Used by
+; end_aggregate to capture per-iteration findall / setof results
+; whose Compound args otherwise point into the per-iteration heap
+; region that backtrack reclaims, silently aliasing every accumulated
+; entry to the LAST iteration''s values.
+;
+; Atoms / Integers / Floats pass through. Unbounds after deref stay
+; unbound (best effort -- typical aggregate templates have all vars
+; bound by the time end_aggregate runs; an unbound template arg
+; indicates a logic bug the caller will see via the spurious
+; unbound in the result list).
+define %Value @wam_freeze_value(%WamState* %vm, %Value %v) {
+entry:
+  %d = call %Value @wam_deref_value(%WamState* %vm, %Value %v)
+  %tag = extractvalue %Value %d, 0
+  %is_cmp = icmp eq i32 %tag, 3
+  br i1 %is_cmp, label %fz_compound, label %fz_atomic
+
+fz_atomic:
+  ; Atom (0), Integer (1), Float (2), Ref-to-unbound (5 derefs to 6),
+  ; Unbound (6), Bool (7) -- all self-contained values; copy nothing.
+  ret %Value %d
+
+fz_compound:
+  %cp_bits = extractvalue %Value %d, 1
+  %cp_ptr = inttoptr i64 %cp_bits to %Compound*
+  %fn_slot = getelementptr %Compound, %Compound* %cp_ptr, i32 0, i32 0
+  %fn_ptr = load i8*, i8** %fn_slot
+  %ar_slot = getelementptr %Compound, %Compound* %cp_ptr, i32 0, i32 1
+  %arity = load i32, i32* %ar_slot
+  %args_slot = getelementptr %Compound, %Compound* %cp_ptr, i32 0, i32 2
+  %src_args = load %Value*, %Value** %args_slot
+
+  call void @wam_arena_ensure()
+  %cp_size = ptrtoint %Compound* getelementptr (%Compound, %Compound* null, i32 1) to i64
+  %new_mem = call i8* @wam_arena_alloc(i64 %cp_size)
+  %new_cp = bitcast i8* %new_mem to %Compound*
+  %new_fn_slot = getelementptr %Compound, %Compound* %new_cp, i32 0, i32 0
+  store i8* %fn_ptr, i8** %new_fn_slot
+  %new_ar_slot = getelementptr %Compound, %Compound* %new_cp, i32 0, i32 1
+  store i32 %arity, i32* %new_ar_slot
+  %ar64 = zext i32 %arity to i64
+  %args_bytes = shl i64 %ar64, 4
+  %new_args_mem = call i8* @wam_arena_alloc(i64 %args_bytes)
+  %new_args = bitcast i8* %new_args_mem to %Value*
+  %new_args_slot = getelementptr %Compound, %Compound* %new_cp, i32 0, i32 2
+  store %Value* %new_args, %Value** %new_args_slot
+
+  %has_args = icmp sgt i32 %arity, 0
+  br i1 %has_args, label %fz_loop, label %fz_done
+
+fz_loop:
+  %i = phi i32 [ 0, %fz_compound ], [ %i_next, %fz_step ]
+  %src_ptr = getelementptr %Value, %Value* %src_args, i32 %i
+  %src_val = load %Value, %Value* %src_ptr
+  %dst_val = call %Value @wam_freeze_value(%WamState* %vm, %Value %src_val)
+  %dst_ptr = getelementptr %Value, %Value* %new_args, i32 %i
+  store %Value %dst_val, %Value* %dst_ptr
+  br label %fz_step
+
+fz_step:
+  %i_next = add i32 %i, 1
+  %more = icmp slt i32 %i_next, %arity
+  br i1 %more, label %fz_loop, label %fz_done
+
+fz_done:
   %new_i64 = ptrtoint %Compound* %new_cp to i64
   %new_val0 = insertvalue %Value undef, i32 3, 0
   %new_val = insertvalue %Value %new_val0, i64 %new_i64, 1

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3323,12 +3323,12 @@ entry:
   ]
 
 builtin_is:
-  ; A1 is result, A2 is expression. Reads dereffed via eval_arith;
-  ; deref A1 to detect Ref-aliased unbound; bind via wam_bind_reg so
-  ; aliased registers update through the shared heap cell.
+  ; A1 is result, A2 is expression. M11: go through eval_arith_value
+  ; so `**` with a negative integer exponent returns a Float instead
+  ; of the integer eval_arith''s 0. Everything else still routes
+  ; through integer eval_arith (boxed via value_integer).
   %is.a2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
-  %is.result = call i64 @eval_arith(%WamState* %vm, %Value %is.a2)
-  %is.result_val = call %Value @value_integer(i64 %is.result)
+  %is.result_val = call %Value @eval_arith_value(%WamState* %vm, %Value %is.a2)
   %is.a1d = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
   %is.a1_unb = call i1 @value_is_unbound(%Value %is.a1d)
   br i1 %is.a1_unb, label %is.do_bind, label %is.check_eq
@@ -4325,6 +4325,108 @@ fail:
   %f.fmt = getelementptr [26 x i8], [26 x i8]* @.fmt_arith_fail, i32 0, i32 0
   call i32 (i8*, ...) @printf(i8* %f.fmt)
   ret i64 0
+}
+
+; M11: Float-aware top-level evaluator. Returns a tagged %Value so
+; is/2 can produce either Integer (tag=1) or Float (tag=2) results.
+; Right now only one case actually returns Float: `Base ** Exp`
+; where the evaluated Exp is negative -- the integer eval_arith
+; returns 0 for negative exp, which silently miscomputes
+; effective_distance''s `Hops ** NegN` (NegN = -5). For everything
+; else this is a thin wrapper that boxes the i64 eval_arith result
+; as an Integer. Full float propagation through `+`/`-`/`*`/`/`
+; with mixed operands is M12 work (requires a full rewrite of
+; eval_arith to return %Value end-to-end).
+define %Value @eval_arith_value(%WamState* %vm, %Value %expr_raw) {
+entry:
+  %expr = call %Value @wam_deref_value(%WamState* %vm, %Value %expr_raw)
+  %tag = extractvalue %Value %expr, 0
+  ; Top-level Compound check -- if it''s a `**`/2 we may want to
+  ; produce a Float instead of the integer eval_arith would return.
+  %is_cmp = icmp eq i32 %tag, 3
+  br i1 %is_cmp, label %check_pow_pattern, label %fallback_int
+
+check_pow_pattern:
+  %cp_bits = extractvalue %Value %expr, 1
+  %cp_ptr = inttoptr i64 %cp_bits to %Compound*
+  %ar_slot = getelementptr %Compound, %Compound* %cp_ptr, i32 0, i32 1
+  %arity = load i32, i32* %ar_slot
+  %is_binary = icmp eq i32 %arity, 2
+  br i1 %is_binary, label %check_pow_fn, label %fallback_int
+
+check_pow_fn:
+  %fn_slot = getelementptr %Compound, %Compound* %cp_ptr, i32 0, i32 0
+  %fn_ptr = load i8*, i8** %fn_slot
+  %fn0 = load i8, i8* %fn_ptr
+  %fn0_is_star = icmp eq i8 %fn0, 42
+  br i1 %fn0_is_star, label %check_pow_fn2, label %fallback_int
+
+check_pow_fn2:
+  %fn1_ptr = getelementptr i8, i8* %fn_ptr, i32 1
+  %fn1 = load i8, i8* %fn1_ptr
+  %fn1_is_star = icmp eq i8 %fn1, 42
+  br i1 %fn1_is_star, label %check_pow_fn3, label %fallback_int
+
+check_pow_fn3:
+  ; Make sure the functor is exactly "**" (length 2): fn[2] must be 0.
+  ; This avoids confusing `***` or anything else hypothetical.
+  %fn2_ptr = getelementptr i8, i8* %fn_ptr, i32 2
+  %fn2 = load i8, i8* %fn2_ptr
+  %fn2_is_zero = icmp eq i8 %fn2, 0
+  br i1 %fn2_is_zero, label %eval_pow_args, label %fallback_int
+
+eval_pow_args:
+  %args_slot = getelementptr %Compound, %Compound* %cp_ptr, i32 0, i32 2
+  %args = load %Value*, %Value** %args_slot
+  %base_ptr = getelementptr %Value, %Value* %args, i32 0
+  %base_v = load %Value, %Value* %base_ptr
+  %exp_ptr = getelementptr %Value, %Value* %args, i32 1
+  %exp_v = load %Value, %Value* %exp_ptr
+  ; Evaluate both as i64; if either was Float, eval_arith truncates --
+  ; the current path covers the integer-base / integer-exp case only.
+  ; Full float-exp / float-base is M12.
+  %base_i = call i64 @eval_arith(%WamState* %vm, %Value %base_v)
+  %exp_i = call i64 @eval_arith(%WamState* %vm, %Value %exp_v)
+  %exp_neg = icmp slt i64 %exp_i, 0
+  br i1 %exp_neg, label %float_pow, label %fallback_int
+
+float_pow:
+  ; base ** -n = 1 / (base ** n) as double. Loop over |exp| iterations.
+  %abs_exp = sub i64 0, %exp_i
+  %base_d = sitofp i64 %base_i to double
+  br label %float_pow_loop
+
+float_pow_loop:
+  %fp_acc = phi double [ 1.0, %float_pow ], [ %fp_new_acc, %float_pow_step ]
+  %fp_n = phi i64 [ %abs_exp, %float_pow ], [ %fp_dec, %float_pow_step ]
+  %fp_done = icmp sle i64 %fp_n, 0
+  br i1 %fp_done, label %float_pow_finish, label %float_pow_step
+
+float_pow_step:
+  %fp_new_acc = fmul double %fp_acc, %base_d
+  %fp_dec = sub i64 %fp_n, 1
+  br label %float_pow_loop
+
+float_pow_finish:
+  ; result = 1 / acc. Handle acc == 0 (base = 0, n > 0) -> 0 by
+  ; checking before dividing -- IEEE division by 0 would give inf.
+  %is_zero = fcmp oeq double %fp_acc, 0.0
+  br i1 %is_zero, label %float_pow_zero, label %float_pow_recip
+
+float_pow_zero:
+  %fz = call %Value @value_float(double 0.0)
+  ret %Value %fz
+
+float_pow_recip:
+  %fp_r = fdiv double 1.0, %fp_acc
+  %fpv = call %Value @value_float(double %fp_r)
+  ret %Value %fpv
+
+fallback_int:
+  ; Default: integer eval, box as Integer.
+  %i_r = call i64 @eval_arith(%WamState* %vm, %Value %expr_raw)
+  %iv = call %Value @value_integer(i64 %i_r)
+  ret %Value %iv
 }'.
 
 compile_copy_term_to_llvm(Code) :-

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -146,6 +146,42 @@ test_setof_count(_, R) :-
     length(Cs, N),
     R is N.
 
+% M11: findall over a Compound template. Pre-M11, end_aggregate
+% only dereferenced atomic values; Compound entries shared args
+% pointers that pointed into the per-iteration heap region, so
+% every accumulated entry collapsed to the LAST iteration's values
+% after backtrack rewound the heap. wam_freeze_value now deep-
+% copies the Compound's args onto the arena so each entry is
+% self-contained.
+:- dynamic pair/2.
+pair(1, 10).
+pair(2, 20).
+pair(3, 30).
+
+:- dynamic test_findall_pair_first_key/2.
+test_findall_pair_first_key(_, R) :-
+    findall(K-V, pair(K, V), Pairs),
+    Pairs = [K1-_|_],
+    R is K1.
+
+:- dynamic test_findall_pair_first_val/2.
+test_findall_pair_first_val(_, R) :-
+    findall(K-V, pair(K, V), Pairs),
+    Pairs = [_-V1|_],
+    R is V1.
+
+:- dynamic test_findall_pair_last_key/2.
+test_findall_pair_last_key(_, R) :-
+    findall(K-V, pair(K, V), Pairs),
+    Pairs = [_, _, K3-_],
+    R is K3.
+
+:- dynamic test_findall_pair_count/2.
+test_findall_pair_count(_, R) :-
+    findall(K-V, pair(K, V), Pairs),
+    length(Pairs, N),
+    R is N.
+
 % M10: \+/1 negation-as-failure via inline (G -> fail ; true) rewrite
 % in the WAM compiler. No runtime metacall: the bytecode goes through
 % the existing if-then-else (try_me_else / cut_ite / trust_me) chain.
@@ -369,6 +405,15 @@ test_all :-
        format('--- M10 setof/3 (sort + dedup) ---~n'),
        run_test_r0('setof color/1 count -> 3',
                    test_setof_count + [color/1], 0, 3),
+       format('--- M11 findall over compound template ---~n'),
+       run_test_r0('findall pair(K,V), first key -> 1',
+                   test_findall_pair_first_key + [pair/2], 0, 1),
+       run_test_r0('findall pair(K,V), first val -> 10',
+                   test_findall_pair_first_val + [pair/2], 0, 10),
+       run_test_r0('findall pair(K,V), third key -> 3',
+                   test_findall_pair_last_key + [pair/2], 0, 3),
+       run_test_r0('findall pair(K,V), count -> 3',
+                   test_findall_pair_count + [pair/2], 0, 3),
        format('--- M10 \\+ negation-as-failure (inline rewrite) ---~n'),
        run_test_r0('\\+ in_basket(soap) -> succeeds, R=7',
                    test_not_absent + [in_basket/1], 0, 7),

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -182,6 +182,97 @@ test_findall_pair_count(_, R) :-
     length(Pairs, N),
     R is N.
 
+% M11: float `**` with negative exponent. Pre-M11, eval_arith was
+% integer-only and returned 0 for negative exp; now eval_arith_value
+% detects the **/2 pattern at the top level and computes via floating
+% point. The test predicates just bind R via is/2; a custom driver
+% (run_pow_test below) reads reg 0''s tag and float bits so we can
+% verify the result type AND value without needing float arithmetic
+% to compose through eval_arith yet (which is M12 work).
+:- dynamic test_pow_neg_eighth/2.
+test_pow_neg_eighth(_, R) :- R is 2 ** -3.   % expect Float(0.125)
+
+:- dynamic test_pow_neg_fifth/2.
+test_pow_neg_fifth(_, R) :- R is 5 ** -1.    % expect Float(0.2)
+
+:- dynamic test_pow_neg_two/2.
+test_pow_neg_two(_, R) :- R is 10 ** -2.     % expect Float(0.01)
+
+% Custom driver: returns 1000 * float_value cast to i32 so the shell
+% exit code carries enough precision to verify the result. Tag is
+% checked separately via the IR -- if it''s not Float (tag=2) we
+% return 254 as a sentinel so a wrong-type result is distinguishable
+% from a "right tag, wrong value" mismatch.
+run_pow_test(Label, Preds, EntryPred, ScaleI, ExpectedI) :-
+    format('  ~w: ', [Label]),
+    clear_llvm_foreign_kernel_specs,
+    tmp_file_stream(text, LLPath, Stream), close(Stream),
+    host_target_triple(Triple),
+    AllPreds = [user:EntryPred/2 | Preds],
+    write_wam_llvm_project(AllPreds,
+        [module_name('pow_t'), target_triple(Triple), target_datalayout('')],
+        LLPath),
+    read_file_to_string(LLPath, Src, []),
+    extract_instr_count(Src, EntryPred, IC),
+    extract_label_count(Src, EntryPred, LC),
+    format(atom(DriverIR),
+'define i32 @main() {
+entry:
+  %a1_0 = insertvalue %Value undef, i32 1, 0
+  %a1 = insertvalue %Value %a1_0, i64 0, 1
+  %a2_0 = insertvalue %Value undef, i32 6, 0
+  %a2 = insertvalue %Value %a2_0, i64 0, 1
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @module_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @module_labels, i32 0, i32 0),
+      i32 ~w)
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %a1)
+  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %a2)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %hit, label %miss
+hit:
+  %r_raw = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %r_d = call %Value @wam_deref_value(%WamState* %vm, %Value %r_raw)
+  %r_tag = extractvalue %Value %r_d, 0
+  %is_float = icmp eq i32 %r_tag, 2
+  br i1 %is_float, label %scale_float, label %wrong_tag
+scale_float:
+  %r_bits = extractvalue %Value %r_d, 1
+  %r_d_val = bitcast i64 %r_bits to double
+  %scale = sitofp i32 ~w to double
+  %scaled = fmul double %r_d_val, %scale
+  %scaled_i = fptosi double %scaled to i32
+  ret i32 %scaled_i
+wrong_tag:
+  ret i32 254
+miss:
+  ret i32 255
+}
+', [IC, IC, IC, LC, LC, LC, ScaleI]),
+    setup_call_cleanup(open(LLPath, append, Out),
+        ( write(Out, '\n'), write(Out, DriverIR) ), close(Out)),
+    atom_concat(LLPath, '.o', OPath),
+    atom_concat(LLPath, '.out', BinPath),
+    format(atom(LlcCmd),
+        'llc -O0 -filetype=obj -relocation-model=pic ~w -o ~w 2>/dev/null',
+        [LLPath, OPath]),
+    shell(LlcCmd, _),
+    format(atom(ClangCmd), 'clang -O0 ~w -o ~w 2>/dev/null', [OPath, BinPath]),
+    shell(ClangCmd, _),
+    shell(BinPath, ExitCode),
+    ( ExitCode =:= ExpectedI
+    -> format('PASS (~w)~n', [ExitCode])
+    ; ExitCode =:= 254
+    -> format('FAIL (result was not a Float -- got non-2 tag)~n')
+    ;  format('FAIL (got ~w, expected ~w)~n', [ExitCode, ExpectedI])
+    ),
+    catch(delete_file(LLPath), _, true),
+    catch(delete_file(OPath), _, true),
+    catch(delete_file(BinPath), _, true),
+    clear_llvm_foreign_kernel_specs,
+    assertion(ExitCode =:= ExpectedI).
+
 % M10: \+/1 negation-as-failure via inline (G -> fail ; true) rewrite
 % in the WAM compiler. No runtime metacall: the bytecode goes through
 % the existing if-then-else (try_me_else / cut_ite / trust_me) chain.
@@ -414,6 +505,13 @@ test_all :-
                    test_findall_pair_last_key + [pair/2], 0, 3),
        run_test_r0('findall pair(K,V), count -> 3',
                    test_findall_pair_count + [pair/2], 0, 3),
+       format('--- M11 float ** with negative exponent ---~n'),
+       run_pow_test('2**-3 -> Float 0.125, *1000 -> 125',
+                    [], test_pow_neg_eighth, 1000, 125),
+       run_pow_test('5**-1 -> Float 0.2, *100 -> 20',
+                    [], test_pow_neg_fifth, 100, 20),
+       run_pow_test('10**-2 -> Float 0.01, *10000 -> 100',
+                    [], test_pow_neg_two, 10000, 100),
        format('--- M10 \\+ negation-as-failure (inline rewrite) ---~n'),
        run_test_r0('\\+ in_basket(soap) -> succeeds, R=7',
                    test_not_absent + [in_basket/1], 0, 7),


### PR DESCRIPTION
## Summary

Two M11 follow-ups from the M10 batch that just merged (#2571).

- **Compound deep-copy in `end_aggregate`.** New `@wam_freeze_value` runtime helper resolves Refs to the heap-stored value, then recursively copies Compound args onto the arena. `end_aggregate` calls it before pushing to the accumulator, so `findall(K-V, ..., L)` and similar aggregations over compound templates produce self-contained results that survive the inter-iteration heap rewind. Pre-M11, every iteration's compound args were Refs into the per-iteration heap region; backtrack reclaimed those addresses and the NEXT iteration's heap pushes reused them, so all N entries in the accumulator silently aliased the LAST iteration's values.

- **Float `**` with negative exponent.** New `@eval_arith_value` wrapper around `eval_arith`. When the top-level expression of an `is/2` is `Base ** Exp` and the evaluated Exp is negative, the result is computed via floating-point repeated-multiply + reciprocal and boxed as a Float `%Value`. Every other expression still goes through the integer `eval_arith` and boxes as Integer. This unblocks `effective_distance.pl`'s `W is Hops ** NegN` (with `NegN = -5`); pre-M11 the integer pow returned 0 for negative exp and the entire weight sum collapsed to zero. Base = 0 with negative exp returns `Float(0)` rather than dividing by zero.

Full float propagation through `+`/`-`/`*`/`/` with mixed int/float operands is M12 — needs a real rewrite of `eval_arith` to return `%Value` end-to-end.

## Test plan

- [x] `tests/core/test_wam_llvm_builtin_execution.pl` — 34 cases pass (was 27 pre-M11). New: 4 compound findall over a K-V pair fact base (`test_findall_pair_first_key`, `_first_val`, `_last_key`, `_count`), and 3 float-pow cases verified through a custom `run_pow_test` driver that reads the result tag (verifies it's Float = 2) and scales the double bits into an integer the shell exit code can carry.
- [x] `tests/core/test_wam_llvm_findall_execution.pl` — M9 still passes.
- [x] `tests/core/test_wam_llvm_realdata_benchmark.pl` — 31 ancestors, per-iter perf unchanged (~0.056ms).
- [x] `tests/core/test_wam_llvm_bfs_execution.pl` — 4 cases pass.
- [x] `tests/core/test_wam_llvm_astar_execution.pl` — A*(a,d) → distance 12.0.

Run with `LC_ALL=C.UTF-8`.

## Out of scope / M12 follow-ups

- `format/2` — needs a runtime atom-id → string lookup table plus format-string parser.
- Full float arithmetic propagation. Requires `eval_arith` to return `%Value` end-to-end and tag-aware dispatch on each binary op. Operands need promotion when mixed: `1 + 1.0 → 2.0`, etc.
- Reverse-mode `length/2` (`length(L, 3)` generates a fresh 3-element list).
- Proper `get_level`/`cut Y_n` for if-then-else (the M10 cb fix made `!`/0 work, but soft cut via `cut_ite` still has the same naive-decrement issue).

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_