### PR TITLE
test(wam-python): remove choicepoint warnings

### DIFF
--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -28,10 +28,10 @@ test(wam_python_module) :-
 	target_registry:target_module(wam_python, wam_python_target).
 
 test(wam_python_has_wam_capability) :-
-	target_registry:target_has_capability(wam_python, wam).
+	once(target_registry:target_has_capability(wam_python, wam)).
 
 test(wam_python_has_trail_backtracking) :-
-	target_registry:target_has_capability(wam_python, trail_backtracking).
+	once(target_registry:target_has_capability(wam_python, trail_backtracking)).
 
 :- end_tests(wam_python_registry).
 
@@ -1770,7 +1770,7 @@ test(is_not_match_call) :-
 test(ite_block_detected) :-
 	% Two-clause ITE: foo(a) and foo(b)
 	Instrs = [get_constant(a, "1"), proceed, get_constant(b, "1"), proceed],
-	wam_python_lowered_emitter:is_ite_block_py(Instrs, Blocks),
+	once(wam_python_lowered_emitter:is_ite_block_py(Instrs, Blocks)),
 	length(Blocks, 2).
 
 test(ite_block_three_clauses) :-
@@ -1778,7 +1778,7 @@ test(ite_block_three_clauses) :-
 	Instrs = [get_constant(a, "1"), proceed,
 	          get_constant(b, "1"), proceed,
 	          get_constant(c, "1"), proceed],
-	wam_python_lowered_emitter:is_ite_block_py(Instrs, Blocks),
+	once(wam_python_lowered_emitter:is_ite_block_py(Instrs, Blocks)),
 	length(Blocks, 3).
 
 test(ite_block_not_detected_single_clause) :-
@@ -1791,7 +1791,7 @@ test(ite_block_with_fail_fallthrough) :-
 	Instrs = [get_constant(a, "1"), proceed,
 	          get_constant(b, "1"), proceed,
 	          fail],
-	wam_python_lowered_emitter:is_ite_block_py(Instrs, Blocks),
+	once(wam_python_lowered_emitter:is_ite_block_py(Instrs, Blocks)),
 	length(Blocks, 3).
 
 test(emit_ite_generates_if, [nondet]) :-


### PR DESCRIPTION
## Summary
- Make Python WAM registry capability smoke tests deterministic with `once/1`.
- Make ITE block detection tests deterministic where they assert only the first valid detection shape.
- Remove the existing plunit "Test succeeded with choicepoint" noise without suppressing warnings or changing runtime behavior.

## Tests
- `swipl -q -g "run_tests(wam_python_registry),run_tests(wam_python_ite)" -t halt tests/test_wam_python_target.pl`
- `swipl -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
- `git diff --check`

## Notes
- This is test-only cleanup.
- No discontiguous warning suppression was added.
- Full Python WAM target suite passes locally: `166/166`.
