### PR TITLE
LLVM WAM: M14 — float-aware comparisons + float aggregate sum

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3357,52 +3357,141 @@ is.check_eq:
   ret i1 %is.eq
 
 builtin_gt:
-  %gt.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
-  %gt.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
-  %gt.v1 = call i64 @value_payload(%Value %gt.a1)
-  %gt.v2 = call i64 @value_payload(%Value %gt.a2)
-  %gt.r = icmp sgt i64 %gt.v1, %gt.v2
-  ret i1 %gt.r
+  ; M14: arithmetic compare. Evaluate both args via eval_arith_value
+  ; so a Compound operand (e.g. `X > Y * 2`) is reduced to a numeric
+  ; Value rather than treated as a pointer payload. Dispatch on tag:
+  ; if either operand is Float, promote both to double and use fcmp;
+  ; otherwise compare integer payloads with icmp.
+  %gt.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %gt.a2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %gt.e1 = call %Value @eval_arith_value(%WamState* %vm, %Value %gt.a1)
+  %gt.e2 = call %Value @eval_arith_value(%WamState* %vm, %Value %gt.a2)
+  %gt.t1 = extractvalue %Value %gt.e1, 0
+  %gt.t2 = extractvalue %Value %gt.e2, 0
+  %gt.f1 = icmp eq i32 %gt.t1, 2
+  %gt.f2 = icmp eq i32 %gt.t2, 2
+  %gt.eitherf = or i1 %gt.f1, %gt.f2
+  br i1 %gt.eitherf, label %gt.float, label %gt.int
+gt.int:
+  %gt.iv1 = extractvalue %Value %gt.e1, 1
+  %gt.iv2 = extractvalue %Value %gt.e2, 1
+  %gt.ir = icmp sgt i64 %gt.iv1, %gt.iv2
+  ret i1 %gt.ir
+gt.float:
+  %gt.d1 = call double @value_to_double(%Value %gt.e1)
+  %gt.d2 = call double @value_to_double(%Value %gt.e2)
+  %gt.fr = fcmp ogt double %gt.d1, %gt.d2
+  ret i1 %gt.fr
 
 builtin_lt:
-  %lt.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
-  %lt.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
-  %lt.v1 = call i64 @value_payload(%Value %lt.a1)
-  %lt.v2 = call i64 @value_payload(%Value %lt.a2)
-  %lt.r = icmp slt i64 %lt.v1, %lt.v2
-  ret i1 %lt.r
+  %lt.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %lt.a2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %lt.e1 = call %Value @eval_arith_value(%WamState* %vm, %Value %lt.a1)
+  %lt.e2 = call %Value @eval_arith_value(%WamState* %vm, %Value %lt.a2)
+  %lt.t1 = extractvalue %Value %lt.e1, 0
+  %lt.t2 = extractvalue %Value %lt.e2, 0
+  %lt.f1 = icmp eq i32 %lt.t1, 2
+  %lt.f2 = icmp eq i32 %lt.t2, 2
+  %lt.eitherf = or i1 %lt.f1, %lt.f2
+  br i1 %lt.eitherf, label %lt.float, label %lt.int
+lt.int:
+  %lt.iv1 = extractvalue %Value %lt.e1, 1
+  %lt.iv2 = extractvalue %Value %lt.e2, 1
+  %lt.ir = icmp slt i64 %lt.iv1, %lt.iv2
+  ret i1 %lt.ir
+lt.float:
+  %lt.d1 = call double @value_to_double(%Value %lt.e1)
+  %lt.d2 = call double @value_to_double(%Value %lt.e2)
+  %lt.fr = fcmp olt double %lt.d1, %lt.d2
+  ret i1 %lt.fr
 
 builtin_ge:
-  %ge.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
-  %ge.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
-  %ge.v1 = call i64 @value_payload(%Value %ge.a1)
-  %ge.v2 = call i64 @value_payload(%Value %ge.a2)
-  %ge.r = icmp sge i64 %ge.v1, %ge.v2
-  ret i1 %ge.r
+  %ge.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %ge.a2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %ge.e1 = call %Value @eval_arith_value(%WamState* %vm, %Value %ge.a1)
+  %ge.e2 = call %Value @eval_arith_value(%WamState* %vm, %Value %ge.a2)
+  %ge.t1 = extractvalue %Value %ge.e1, 0
+  %ge.t2 = extractvalue %Value %ge.e2, 0
+  %ge.f1 = icmp eq i32 %ge.t1, 2
+  %ge.f2 = icmp eq i32 %ge.t2, 2
+  %ge.eitherf = or i1 %ge.f1, %ge.f2
+  br i1 %ge.eitherf, label %ge.float, label %ge.int
+ge.int:
+  %ge.iv1 = extractvalue %Value %ge.e1, 1
+  %ge.iv2 = extractvalue %Value %ge.e2, 1
+  %ge.ir = icmp sge i64 %ge.iv1, %ge.iv2
+  ret i1 %ge.ir
+ge.float:
+  %ge.d1 = call double @value_to_double(%Value %ge.e1)
+  %ge.d2 = call double @value_to_double(%Value %ge.e2)
+  %ge.fr = fcmp oge double %ge.d1, %ge.d2
+  ret i1 %ge.fr
 
 builtin_le:
-  %le.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
-  %le.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
-  %le.v1 = call i64 @value_payload(%Value %le.a1)
-  %le.v2 = call i64 @value_payload(%Value %le.a2)
-  %le.r = icmp sle i64 %le.v1, %le.v2
-  ret i1 %le.r
+  %le.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %le.a2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %le.e1 = call %Value @eval_arith_value(%WamState* %vm, %Value %le.a1)
+  %le.e2 = call %Value @eval_arith_value(%WamState* %vm, %Value %le.a2)
+  %le.t1 = extractvalue %Value %le.e1, 0
+  %le.t2 = extractvalue %Value %le.e2, 0
+  %le.f1 = icmp eq i32 %le.t1, 2
+  %le.f2 = icmp eq i32 %le.t2, 2
+  %le.eitherf = or i1 %le.f1, %le.f2
+  br i1 %le.eitherf, label %le.float, label %le.int
+le.int:
+  %le.iv1 = extractvalue %Value %le.e1, 1
+  %le.iv2 = extractvalue %Value %le.e2, 1
+  %le.ir = icmp sle i64 %le.iv1, %le.iv2
+  ret i1 %le.ir
+le.float:
+  %le.d1 = call double @value_to_double(%Value %le.e1)
+  %le.d2 = call double @value_to_double(%Value %le.e2)
+  %le.fr = fcmp ole double %le.d1, %le.d2
+  ret i1 %le.fr
 
 builtin_arith_eq:
-  %aeq.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
-  %aeq.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
-  %aeq.v1 = call i64 @value_payload(%Value %aeq.a1)
-  %aeq.v2 = call i64 @value_payload(%Value %aeq.a2)
-  %aeq.r = icmp eq i64 %aeq.v1, %aeq.v2
-  ret i1 %aeq.r
+  %aeq.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %aeq.a2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %aeq.e1 = call %Value @eval_arith_value(%WamState* %vm, %Value %aeq.a1)
+  %aeq.e2 = call %Value @eval_arith_value(%WamState* %vm, %Value %aeq.a2)
+  %aeq.t1 = extractvalue %Value %aeq.e1, 0
+  %aeq.t2 = extractvalue %Value %aeq.e2, 0
+  %aeq.f1 = icmp eq i32 %aeq.t1, 2
+  %aeq.f2 = icmp eq i32 %aeq.t2, 2
+  %aeq.eitherf = or i1 %aeq.f1, %aeq.f2
+  br i1 %aeq.eitherf, label %aeq.float, label %aeq.int
+aeq.int:
+  %aeq.iv1 = extractvalue %Value %aeq.e1, 1
+  %aeq.iv2 = extractvalue %Value %aeq.e2, 1
+  %aeq.ir = icmp eq i64 %aeq.iv1, %aeq.iv2
+  ret i1 %aeq.ir
+aeq.float:
+  %aeq.d1 = call double @value_to_double(%Value %aeq.e1)
+  %aeq.d2 = call double @value_to_double(%Value %aeq.e2)
+  %aeq.fr = fcmp oeq double %aeq.d1, %aeq.d2
+  ret i1 %aeq.fr
 
 builtin_arith_ne:
-  %ane.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
-  %ane.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
-  %ane.v1 = call i64 @value_payload(%Value %ane.a1)
-  %ane.v2 = call i64 @value_payload(%Value %ane.a2)
-  %ane.r = icmp ne i64 %ane.v1, %ane.v2
-  ret i1 %ane.r
+  %ane.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %ane.a2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %ane.e1 = call %Value @eval_arith_value(%WamState* %vm, %Value %ane.a1)
+  %ane.e2 = call %Value @eval_arith_value(%WamState* %vm, %Value %ane.a2)
+  %ane.t1 = extractvalue %Value %ane.e1, 0
+  %ane.t2 = extractvalue %Value %ane.e2, 0
+  %ane.f1 = icmp eq i32 %ane.t1, 2
+  %ane.f2 = icmp eq i32 %ane.t2, 2
+  %ane.eitherf = or i1 %ane.f1, %ane.f2
+  br i1 %ane.eitherf, label %ane.float, label %ane.int
+ane.int:
+  %ane.iv1 = extractvalue %Value %ane.e1, 1
+  %ane.iv2 = extractvalue %Value %ane.e2, 1
+  %ane.ir = icmp ne i64 %ane.iv1, %ane.iv2
+  ret i1 %ane.ir
+ane.float:
+  %ane.d1 = call double @value_to_double(%Value %ane.e1)
+  %ane.d2 = call double @value_to_double(%Value %ane.e2)
+  %ane.fr = fcmp one double %ane.d1, %ane.d2
+  ret i1 %ane.fr
 
 builtin_eq:
   %eq.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -1413,10 +1413,31 @@ count_case:
   ret %Value %c_final
 
 sum_case:
-  br label %sum_loop
+  ; M14: scan once for any Float entry. If all entries are Integer
+  ; we use the integer path (preserves precision; the original
+  ; behaviour). If any entry is a Float we use a double accumulator
+  ; -- previously the integer loop just added raw payload bits which
+  ; gave junk for Float entries (Float bits != the underlying value).
+  br label %sum_scan
+sum_scan:
+  %scan_i = phi i32 [0, %sum_case], [%scan_inext, %sum_scan_step]
+  %had_float = phi i1 [false, %sum_case], [%scan_new_hadf, %sum_scan_step]
+  %scan_done = icmp sge i32 %scan_i, %count
+  br i1 %scan_done, label %sum_dispatch, label %sum_scan_step
+sum_scan_step:
+  %scan_slot = getelementptr %Value, %Value* %accum, i32 %scan_i
+  %scan_val = load %Value, %Value* %scan_slot
+  %scan_tag = extractvalue %Value %scan_val, 0
+  %scan_is_f = icmp eq i32 %scan_tag, 2
+  %scan_new_hadf = or i1 %had_float, %scan_is_f
+  %scan_inext = add i32 %scan_i, 1
+  br label %sum_scan
+sum_dispatch:
+  br i1 %had_float, label %sum_float, label %sum_loop
+
 sum_loop:
-  %i_s = phi i32 [0, %sum_case], [%next_s, %sum_body]
-  %acc_s = phi i64 [0, %sum_case], [%new_acc_s, %sum_body]
+  %i_s = phi i32 [0, %sum_dispatch], [%next_s, %sum_body]
+  %acc_s = phi i64 [0, %sum_dispatch], [%new_acc_s, %sum_body]
   %done_s = icmp sge i32 %i_s, %count
   br i1 %done_s, label %sum_done, label %sum_body
 sum_body:
@@ -1427,11 +1448,29 @@ sum_body:
   %next_s = add i32 %i_s, 1
   br label %sum_loop
 sum_done:
-  ; PHI value %acc_s is valid here as %sum_done is a direct successor
-  ; of the loop block and the edge carries the final iteration state.
   %s_val = insertvalue %Value undef, i32 1, 0    ; Integer tag
   %s_final = insertvalue %Value %s_val, i64 %acc_s, 1
   ret %Value %s_final
+
+sum_float:
+  br label %sum_floop
+sum_floop:
+  %i_sf = phi i32 [0, %sum_float], [%next_sf, %sum_fbody]
+  %acc_sf = phi double [0.0, %sum_float], [%new_acc_sf, %sum_fbody]
+  %done_sf = icmp sge i32 %i_sf, %count
+  br i1 %done_sf, label %sum_fdone, label %sum_fbody
+sum_fbody:
+  %slot_sf = getelementptr %Value, %Value* %accum, i32 %i_sf
+  %val_sf = load %Value, %Value* %slot_sf
+  ; Promote each entry to double -- Integers go via sitofp, Floats
+  ; reinterpret their payload bits.
+  %term_d = call double @value_to_double(%Value %val_sf)
+  %new_acc_sf = fadd double %acc_sf, %term_d
+  %next_sf = add i32 %i_sf, 1
+  br label %sum_floop
+sum_fdone:
+  %sf_val = call %Value @value_float(double %acc_sf)
+  ret %Value %sf_val
 
 min_case:
   ; Initial value: take first element if count > 0, else 0

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -227,6 +227,51 @@ test_float_chain(_, R) :- R is (1 / 2) + (1 / 4). % 0.5 + 0.25 = 0.75
 :- dynamic test_float_pow_chain/2.
 test_float_pow_chain(_, R) :- R is (2 ** -2) + 0.5. % 0.25 + 0.5 = 0.75
 
+% M14: float-aware comparison ops. Pre-M14, builtin_gt/lt/etc read
+% the register payload as raw i64 -- meaningless when one operand
+% is a Float because float bits aren''t the numeric value. Also,
+% comparisons over a Compound expression like `X > Y * 2` mis-fed
+% the unmaterialised Compound pointer to icmp.
+:- dynamic test_cmp_float_gt/2.
+test_cmp_float_gt(_, R) :-
+    X is 1 / 4,        % Float 0.25
+    ( X > 0 -> R is 1 ; R is 0 ).   % expect 1
+
+:- dynamic test_cmp_float_gt_neg/2.
+test_cmp_float_gt_neg(_, R) :-
+    X is -1 / 4,       % Float -0.25
+    ( X > 0 -> R is 1 ; R is 0 ).   % expect 0
+
+:- dynamic test_cmp_float_eq/2.
+test_cmp_float_eq(_, R) :-
+    X is 1 / 2,        % Float 0.5
+    ( X =:= 0.5 -> R is 1 ; R is 0 ). % expect 1
+
+:- dynamic test_cmp_compound_expr/2.
+test_cmp_compound_expr(_, R) :-
+    Y = 3,
+    % Direct comparison of Y * 2 against 5 -- arithmetic eval on both sides.
+    ( Y * 2 > 5 -> R is 1 ; R is 0 ).   % 6 > 5 -> 1
+
+% M14: aggregate_all(sum(F), ...) over Float-producing inner goal.
+% The sum_case now scans for any Float entry and switches to a
+% double accumulator instead of integer add-of-bits.
+:- dynamic node/1.
+node(2).
+node(4).
+node(8).
+
+:- dynamic test_sum_int/2.
+test_sum_int(_, R) :-
+    aggregate_all(sum(N), node(N), S),   % 2 + 4 + 8 = 14, stays Integer
+    R is S.                              % route through is/2 -> A1
+
+:- dynamic test_sum_float/2.
+test_sum_float(_, R) :-
+    aggregate_all(sum(W), (node(N), W is 1 / N), Sum),
+    % Sum = 1/2 + 1/4 + 1/8 = 0.875
+    R is Sum.
+
 % M12: format/2 -- prints to stdout. Tested by capturing the shell
 % stdout and comparing against expected string. Each predicate
 % does ONE format call and then succeeds (no R binding -- the
@@ -648,6 +693,14 @@ test_all :-
                     [], test_float_chain, 100, 75),
        run_pow_test('(2**-2)+0.5 -> Float 0.75, *100 -> 75',
                     [], test_float_pow_chain, 100, 75),
+       format('--- M14 float-aware comparisons + float sum ---~n'),
+       run_test_r0('1/4 > 0 -> 1', test_cmp_float_gt, 0, 1),
+       run_test_r0('-1/4 > 0 -> 0', test_cmp_float_gt_neg, 0, 0),
+       run_test_r0('1/2 =:= 0.5 -> 1', test_cmp_float_eq, 0, 1),
+       run_test_r0('Y*2 > 5 when Y=3 -> 1', test_cmp_compound_expr, 0, 1),
+       run_test_r0('sum(node) int -> 14', test_sum_int + [node/1], 0, 14),
+       run_pow_test('sum(1/N) -> 0.875, *100 -> 87',
+                    [node/1], test_sum_float, 100, 87),
        format('--- M12 format/2 stdout printing ---~n'),
        run_fmt_test('literal "hello world"', test_fmt_literal,
                     "hello world\n"),


### PR DESCRIPTION
## Summary

Two coupled fixes targeting effective_distance.pl's remaining arithmetic failure modes after M13.

**Comparison ops (`>/2`, `</2`, `>=/2`, `=</2`, `=:=/2`, `=\=/2`)** previously read register payloads as raw `i64` and dispatched `icmp` directly. That worked when both operands were already-evaluated Integers, but mis-compared bits when either was a Float (the IEEE-754 bit pattern is **not** the numeric value, and Float bit ordering is non-monotonic across sign) and silently fed Compound pointers into `icmp` when an operand was an arithmetic expression like `Y * 2`.

Each op now reads the raw register, routes through `eval_arith_value` to fully reduce the operand, then dispatches on tag: if either side is Float, promote both to `double` via `value_to_double` and use `fcmp`; otherwise compare integer payloads with `icmp` (preserves precision for int-only comparisons).

**`sum_case` in `wam_apply_aggregation`** used to always accumulate as `i64` by summing raw payload bits. For `aggregate_all(sum(W), ...)` where the inner `W` was a Float (e.g. `W is Hops ** NegN`), each Float's payload was its IEEE bit pattern, so the integer sum produced garbage. The case now scans the accumulator for any Float entry first; if found, the loop accumulates via `double` through `value_to_double` and boxes the result as Float. Pure-Integer accumulators keep the original integer-only path (preserves precision).

## Test plan

- [x] `tests/core/test_wam_llvm_builtin_execution.pl` — 53 cases pass (was 47 pre-M14). New:
  - **Comparisons** (4): `1/4 > 0 → 1`, `-1/4 > 0 → 0`, `1/2 =:= 0.5 → 1`, `Y * 2 > 5 when Y=3 → 1` (the last exercises Compound-operand evaluation through eval_arith_value).
  - **Sums** (2): `aggregate_all(sum(N), node(N), R)` over int facts {2, 4, 8} → 14 (Integer path); `aggregate_all(sum(W), (node(N), W is 1/N), R)` → Float 0.875 (Float path).
- [x] `tests/core/test_wam_llvm_findall_execution.pl` — M9 still passes.
- [x] `tests/core/test_wam_llvm_realdata_benchmark.pl` — 31 ancestors, per-iter ~0.057ms, no regression.
- [x] `tests/core/test_wam_llvm_bfs_execution.pl` — 4 cases pass.
- [x] `tests/core/test_wam_llvm_astar_execution.pl` — A*(a,d) → distance 12.0.

Run with `LC_ALL=C.UTF-8`.

## Out of scope / next

With M14 in place, effective_distance.pl's arithmetic should round-trip end-to-end (float `**`, mixed-tag `+/-/*///`, sum aggregation, and `> 0` comparison all working).

Remaining unrelated items:
- Proper `get_level` / `cut Y_n` for soft cut (`(Cond -> Then ; Else)` with multi-clause Cond). The M10 cb fix made hard `!` work; soft `cut_ite` is still naive-decrement.
- Reverse-mode `length/2` (`length(L, 3)` generates a fresh list).
- Wider `format/2` directive coverage (`~Nf` fixed-point floats, `~e` scientific).

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_