### PR TITLE
feat(wam-clojure): materialize unbound list mode for select/3

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -811,9 +811,7 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "select/3" ; Op == 'select/3'),
     !,
-    format(atom(Expr),
-           '(let [list-value (runtime/deref-value (:bindings ~w) (or (runtime/reg-get-raw ~w "A2") ::lowered-unbound))] (runtime/apply-select-solution ~w (inc (:pc ~w)) list-value))',
-           [S, S, S, S]).
+    format(atom(Expr), '(runtime/apply-select-solution ~w (inc (:pc ~w)))', [S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "numlist/3" ; Op == 'numlist/3'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -928,11 +928,38 @@
                                                   (subvec indexed-items (inc idx))))}})
           (range (count indexed-items)))))
 
-(defn apply-select-solution [base-state resume-pc list-value]
-  (if-let [items (proper-list-items base-state list-value)]
-    (apply-first-foreign-solution base-state resume-pc
-                                  (select-solution-results base-state items))
-    (backtrack base-state)))
+(defn select-insert-results [state elem rest-items]
+  (let [ctx (:intern-context state)
+        indexed-rest (vec rest-items)]
+    (mapv (fn [idx]
+            {:bindings {2 (list->term ctx (concat (subvec indexed-rest 0 idx)
+                                                  [elem]
+                                                  (subvec indexed-rest idx)))}})
+          (range (inc (count indexed-rest))))))
+
+(defn apply-select-solution [base-state resume-pc]
+  (let [elem (deref-value (:bindings base-state)
+                          (or (reg-get-raw base-state "A1") ::unbound))
+        list-value (deref-value (:bindings base-state)
+                                (or (reg-get-raw base-state "A2") ::unbound))
+        rest-value (deref-value (:bindings base-state)
+                                (or (reg-get-raw base-state "A3") ::unbound))
+        list-items (proper-list-items base-state list-value)
+        rest-items (proper-list-items base-state rest-value)]
+    (cond
+      (some? list-items)
+      (apply-first-foreign-solution base-state resume-pc
+                                    (select-solution-results base-state list-items))
+
+      (and (logic-var? list-value)
+           (not (logic-var? elem))
+           (not= elem ::unbound)
+           (some? rest-items))
+      (apply-first-foreign-solution base-state resume-pc
+                                    (select-insert-results base-state elem rest-items))
+
+      :else
+      (backtrack base-state))))
 
 (defn numlist-int-value [state value]
   (cond
@@ -2290,9 +2317,7 @@
           (apply-nth1-solution state (inc (:pc state)))
 
           "select/3"
-          (let [list-value (deref-value (:bindings state)
-                                        (or (reg-get-raw state "A2") ::unbound))]
-            (apply-select-solution state (inc (:pc state)) list-value))
+          (apply-select-solution state (inc (:pc state)))
 
           "numlist/3"
           (apply-numlist-solution state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -358,7 +358,7 @@ user:wam_nth1_unbound_list(X) :- user:wam_unbound_arg(L), nth1(1, L, X).
 user:wam_select_guard(Elem, List, Rest) :- select(Elem, List, Rest).
 user:wam_select_backtrack(Elem, Rest) :- select(Elem, [a,b,c], Rest), Elem = b.
 user:wam_select_bad_list(Rest) :- select(a, [a|b], Rest).
-user:wam_select_unbound_list(Rest) :- user:wam_unbound_arg(L), select(a, L, Rest).
+user:wam_select_unbound_list(Rest) :- select(a, L, Rest), is_list(L).
 user:wam_numlist_guard(Low, High, List) :- numlist(Low, High, List).
 user:wam_numlist_high_before_low(List) :- numlist(3, 1, List).
 user:wam_numlist_unbound_low(List) :- numlist(Low, 3, List), integer(Low).
@@ -994,7 +994,7 @@ smoke_cases([
     case('wam_select_guard/3', args(a, '[a,b,c]', '[a,c]'), "false"),
     case('wam_select_backtrack/2', args(b, '[a,c]'), "true"),
     case('wam_select_bad_list/1', '[b,c]', "false"),
-    case('wam_select_unbound_list/1', '[b,c]', "false"),
+    case('wam_select_unbound_list/1', '[b,c]', "true"),
     case('wam_numlist_guard/3', args(1, 3, '[1,2,3]'), "true"),
     case('wam_numlist_guard/3', args(2, 2, '[2]'), "true"),
     case('wam_numlist_guard/3', args(1, 3, '[1,3]'), "false"),


### PR DESCRIPTION
## Summary

- Add bounded reverse-mode materialization for Clojure WAM `select/3` when the list argument is unbound and the rest list is materialized.
- Move `select/3` argument inspection into the Clojure runtime helper so lowered and runtime-dispatch paths share the same behavior.
- Update the Clojure runtime smoke fixture so `select(a, L, [b,c]), is_list(L)` succeeds through finite insertion candidates.

## Why

This continues the Clojure WAM materialization work by covering another finite, scale-safe reverse mode. For `select(Elem, List, Rest)`, when `Elem` is bound and `Rest` is a proper list, the possible `List` values are bounded to `length(Rest) + 1` insertions.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
