### PR TITLE
feat(wam-clojure): materialize zero-length atom and string length modes

### DIFF
--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1441,11 +1441,20 @@
         out (deref-value (:bindings state)
                          (or (reg-get-raw state "A2") ::unbound))
         text (atom-text state value)]
-    (if (some? text)
+    (cond
+      (some? text)
       (let [[ok next-state] (unify-values state out (count text))]
         (if ok
           (advance next-state)
           (backtrack state)))
+
+      (and (logic-var? value) (= out 0))
+      (let [[ok next-state] (unify-text-atom-value state value "")]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+
+      :else
       (backtrack state))))
 
 (declare apply-first-foreign-solution)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -459,9 +459,9 @@ user:wam_string_concat_new_string :- string_concat(fo, o, X), X = foo.
 user:wam_string_concat_unbound_left(C) :- user:wam_unbound_arg(A), string_concat(A, o, C), A = fo.
 user:wam_string_concat_unbound_right(C) :- user:wam_unbound_arg(B), string_concat(fo, B, C), B = o.
 user:wam_atom_length_guard(A, N) :- atom_length(A, N).
-user:wam_atom_length_unbound(N) :- user:wam_unbound_arg(A), atom_length(A, N).
+user:wam_atom_length_unbound(N) :- atom_length(_A, N).
 user:wam_string_length_guard(A, N) :- string_length(A, N).
-user:wam_string_length_unbound(N) :- user:wam_unbound_arg(A), string_length(A, N).
+user:wam_string_length_unbound(N) :- string_length(_A, N).
 user:wam_sub_atom_extract :- sub_atom(hello, 1, 3, A, S), A =:= 1, S = ell.
 user:wam_sub_atom_prefix :- sub_atom(hello, 0, 3, _, hel).
 user:wam_sub_atom_suffix :- sub_atom(hello, _, 3, 0, llo).
@@ -1141,9 +1141,9 @@ smoke_cases([
     case('wam_string_concat_unbound_right/1', foo, "true"),
     case('wam_atom_length_guard/2', args(foo, 3), "true"),
     case('wam_atom_length_guard/2', args(foo, 2), "false"),
-    case('wam_atom_length_unbound/1', 0, "false"),
+    case('wam_atom_length_unbound/1', 0, "true"),
     case('wam_string_length_guard/2', args(foo, 3), "true"),
-    case('wam_string_length_unbound/1', 0, "false"),
+    case('wam_string_length_unbound/1', 0, "true"),
     case('wam_sub_atom_extract/0', no_args, "true"),
     case('wam_sub_atom_prefix/0', no_args, "true"),
     case('wam_sub_atom_suffix/0', no_args, "true"),


### PR DESCRIPTION
## Summary

- Add bounded reverse-mode materialization for Clojure WAM `atom_length/2` when the atom argument is unbound and the requested length is `0`.
- Reuse the same shared text-length runtime helper for `string_length/2`, enabling the equivalent empty-string materialization case.
- Update the Clojure runtime smoke fixtures so the lowered builtin path directly validates these zero-length reverse modes.

## Why

This closes two conservative Clojure WAM materialization gaps without introducing unbounded text generation. Nonzero unbound text lengths remain unsupported because they would require generating arbitrary text values, while length `0` has exactly one bounded candidate: the empty text value.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
