### PR TITLE
LLVM WAM: M15/M16 — format/2 precision (~Nf/~Ne) + reverse-mode length/2

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4206,14 +4206,24 @@ ms.check:
   ret i1 %ms.ok
 
 builtin_length:
-  ; M10: length/2 -- A1 = list, A2 = count. Walks the [|]/2 Compound
-  ; chain counting elements, binds A2 to Integer(count). Same chain
-  ; convention as msort: terminator is the [] Atom; non-list values
-  ; halt the walk at whatever count was accumulated so far. Reverse
-  ; mode (length(L, N) with L unbound) is not implemented -- typical
-  ; benchmark usage has the list bound.
+  ; M10/M16: length/2. Two modes:
+  ;
+  ;   Forward (A1 = bound list, A2 = unbound or Integer):
+  ;     walks the [|]/2 chain counting elements, binds A2 to
+  ;     Integer(count). Same chain convention as msort: terminator
+  ;     is the [] Atom; non-list values halt the walk at whatever
+  ;     count was accumulated so far.
+  ;
+  ;   Reverse (A1 = unbound, A2 = Integer N):
+  ;     allocates N fresh-unbound heap cells and builds an N-element
+  ;     [|]/2 chain on the arena whose head is bound to A1. Each
+  ;     head args[0] is Ref(heap_addr) so the resulting list elements
+  ;     are real logic variables (they can be unified later via the
+  ;     existing wam_unify_value machinery).
   %ln.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
-  br label %ln.loop
+  %ln.a1_unb = call i1 @value_is_unbound(%Value %ln.a1)
+  br i1 %ln.a1_unb, label %ln.reverse, label %ln.loop
+
 ln.loop:
   %ln.cur = phi %Value [ %ln.a1, %builtin_length ], [ %ln.next, %ln.step ]
   %ln.n = phi i32 [ 0, %builtin_length ], [ %ln.n1, %ln.step ]
@@ -4243,6 +4253,66 @@ ln.bind:
 ln.cmp:
   %ln.eq = call i1 @value_equals(%Value %ln.a2d, %Value %ln.r_val)
   ret i1 %ln.eq
+
+ln.reverse:
+  ; A1 is unbound: check that A2 is a known Integer and build a
+  ; fresh N-element list bound to A1.
+  %ln.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %ln.a2_tag = extractvalue %Value %ln.a2, 0
+  %ln.a2_is_int = icmp eq i32 %ln.a2_tag, 1
+  br i1 %ln.a2_is_int, label %ln.r_build_init, label %ln.r_fail
+
+ln.r_fail:
+  ret i1 false
+
+ln.r_build_init:
+  %ln.n_i64 = extractvalue %Value %ln.a2, 1
+  %ln.n_i32 = trunc i64 %ln.n_i64 to i32
+  %ln.empty_id = load i64, i64* @wam_empty_list_atom_id
+  %ln.empty_v0 = insertvalue %Value undef, i32 0, 0
+  %ln.empty_v  = insertvalue %Value %ln.empty_v0, i64 %ln.empty_id, 1
+  call void @wam_arena_ensure()
+  br label %ln.r_build_loop
+
+ln.r_build_loop:
+  %ln.r_i = phi i32 [ 0, %ln.r_build_init ], [ %ln.r_i_next, %ln.r_build_step ]
+  %ln.r_tail = phi %Value [ %ln.empty_v, %ln.r_build_init ], [ %ln.r_new_cons, %ln.r_build_step ]
+  %ln.r_done = icmp sge i32 %ln.r_i, %ln.n_i32
+  br i1 %ln.r_done, label %ln.r_build_done, label %ln.r_build_step
+
+ln.r_build_step:
+  ; Fresh logic variable: push Unbound to the heap and remember its
+  ; addr as a Ref. This is the standard WAM way to make a freshly
+  ; bindable element.
+  %ln.r_unb = call %Value @value_unbound(i8* null)
+  %ln.r_h_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %ln.r_unb)
+  %ln.r_h_ref = call %Value @value_ref(i32 %ln.r_h_addr)
+  %ln.r_cp_size = ptrtoint %Compound* getelementptr (%Compound, %Compound* null, i32 1) to i64
+  %ln.r_cp_mem = call i8* @wam_arena_alloc(i64 %ln.r_cp_size)
+  %ln.r_cp = bitcast i8* %ln.r_cp_mem to %Compound*
+  %ln.r_fn_slot = getelementptr %Compound, %Compound* %ln.r_cp, i32 0, i32 0
+  %ln.r_fn_ptr = getelementptr [4 x i8], [4 x i8]* @.fn__5B_7C_5D, i32 0, i32 0
+  store i8* %ln.r_fn_ptr, i8** %ln.r_fn_slot
+  %ln.r_ar_slot = getelementptr %Compound, %Compound* %ln.r_cp, i32 0, i32 1
+  store i32 2, i32* %ln.r_ar_slot
+  %ln.r_args_mem = call i8* @wam_arena_alloc(i64 32)
+  %ln.r_args = bitcast i8* %ln.r_args_mem to %Value*
+  %ln.r_args_slot = getelementptr %Compound, %Compound* %ln.r_cp, i32 0, i32 2
+  store %Value* %ln.r_args, %Value** %ln.r_args_slot
+  %ln.r_h0_ptr = getelementptr %Value, %Value* %ln.r_args, i32 0
+  store %Value %ln.r_h_ref, %Value* %ln.r_h0_ptr
+  %ln.r_t_ptr = getelementptr %Value, %Value* %ln.r_args, i32 1
+  store %Value %ln.r_tail, %Value* %ln.r_t_ptr
+  %ln.r_cp_i64 = ptrtoint %Compound* %ln.r_cp to i64
+  %ln.r_nc0 = insertvalue %Value undef, i32 3, 0
+  %ln.r_new_cons = insertvalue %Value %ln.r_nc0, i64 %ln.r_cp_i64, 1
+  %ln.r_i_next = add i32 %ln.r_i, 1
+  br label %ln.r_build_loop
+
+ln.r_build_done:
+  call void @wam_trail_binding(%WamState* %vm, i32 0)
+  call void @wam_bind_reg(%WamState* %vm, i32 0, %Value %ln.r_tail)
+  ret i1 true
 
 builtin_format2:
   ; M12: format/2 -- A1 = format string atom, A2 = args list ([|]/2 chain).

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4299,6 +4299,16 @@ f2.print_lit:
 f2.directive:
   %f2.p_dir = getelementptr i8, i8* %f2.p, i32 1
   %f2.d = load i8, i8* %f2.p_dir
+  ; M15: digit -> precision-prefixed directive (~Nf / ~Ne). Parse
+  ; the digit run, then look at the terminator: ``f`` -> fixed-point
+  ; (printf "%.*f"), ``e`` -> scientific (printf "%.*e"), anything
+  ; else -> unknown, print verbatim.
+  %f2.d_ge0 = icmp uge i8 %f2.d, 48
+  %f2.d_le9 = icmp ule i8 %f2.d, 57
+  %f2.d_is_digit = and i1 %f2.d_ge0, %f2.d_le9
+  br i1 %f2.d_is_digit, label %f2.parse_num, label %f2.dispatch_letter
+
+f2.dispatch_letter:
   switch i8 %f2.d, label %f2.unknown_dir [
     i8 119, label %f2.directive_w
     i8 100, label %f2.directive_w
@@ -4306,6 +4316,89 @@ f2.directive:
     i8 110, label %f2.directive_n
     i8 126, label %f2.directive_t
   ]
+
+f2.parse_num:
+  br label %f2.num_loop
+f2.num_loop:
+  %f2.np = phi i8* [ %f2.p_dir, %f2.parse_num ], [ %f2.np_next, %f2.num_step ]
+  %f2.nacc = phi i64 [ 0, %f2.parse_num ], [ %f2.nacc_new, %f2.num_step ]
+  %f2.nc = load i8, i8* %f2.np
+  %f2.nc_ge0 = icmp uge i8 %f2.nc, 48
+  %f2.nc_le9 = icmp ule i8 %f2.nc, 57
+  %f2.nc_is_d = and i1 %f2.nc_ge0, %f2.nc_le9
+  br i1 %f2.nc_is_d, label %f2.num_step, label %f2.num_done
+f2.num_step:
+  %f2.nd_val_i8 = sub i8 %f2.nc, 48
+  %f2.nd_val = zext i8 %f2.nd_val_i8 to i64
+  %f2.nacc_mul = mul i64 %f2.nacc, 10
+  %f2.nacc_new = add i64 %f2.nacc_mul, %f2.nd_val
+  %f2.np_next = getelementptr i8, i8* %f2.np, i32 1
+  br label %f2.num_loop
+f2.num_done:
+  ; %f2.np points to the terminator char (the first non-digit after ~).
+  ; ``f`` and ``e`` both consume one float-promotable arg and use
+  ; printf("%.*<spec>", N, val). The pointer advances past the
+  ; terminator (np + 1).
+  %f2.nc_is_f = icmp eq i8 %f2.nc, 102
+  %f2.nc_is_e = icmp eq i8 %f2.nc, 101
+  %f2.nc_is_fe = or i1 %f2.nc_is_f, %f2.nc_is_e
+  br i1 %f2.nc_is_fe, label %f2.precision_print, label %f2.precision_unknown
+
+f2.precision_unknown:
+  ; Bad ~<digits><non-fe>: print the ~ then fall through to the
+  ; ordinary unknown handler which will print the next char. Drop
+  ; the parsed digits (best-effort -- atypical in practice).
+  call i32 @putchar(i32 126)
+  %f2.nc_i32 = zext i8 %f2.nc to i32
+  call i32 @putchar(i32 %f2.nc_i32)
+  %f2.p_after_punk = getelementptr i8, i8* %f2.np, i32 1
+  br label %f2.iter_end
+
+f2.precision_print:
+  ; Consume one arg from the args list; promote to double via
+  ; value_to_double; call printf with the chosen format ("%.*f" or
+  ; "%.*e") and the parsed precision N.
+  %f2.parg_d = call %Value @wam_deref_value(%WamState* %vm, %Value %f2.args)
+  %f2.parg_tag = extractvalue %Value %f2.parg_d, 0
+  %f2.parg_has = icmp eq i32 %f2.parg_tag, 3
+  br i1 %f2.parg_has, label %f2.precision_read_arg, label %f2.precision_no_arg
+
+f2.precision_no_arg:
+  ; No arg available: silently skip the directive but advance the
+  ; pointer past the terminator so we don''t loop forever.
+  %f2.p_after_pna = getelementptr i8, i8* %f2.np, i32 1
+  br label %f2.iter_end
+
+f2.precision_read_arg:
+  %f2.pcp_bits = extractvalue %Value %f2.parg_d, 1
+  %f2.pcp = inttoptr i64 %f2.pcp_bits to %Compound*
+  %f2.pcargs_slot = getelementptr %Compound, %Compound* %f2.pcp, i32 0, i32 2
+  %f2.pcargs = load %Value*, %Value** %f2.pcargs_slot
+  %f2.phead_ptr = getelementptr %Value, %Value* %f2.pcargs, i32 0
+  %f2.phead_raw = load %Value, %Value* %f2.phead_ptr
+  %f2.phead = call %Value @wam_deref_value(%WamState* %vm, %Value %f2.phead_raw)
+  %f2.ptail_ptr = getelementptr %Value, %Value* %f2.pcargs, i32 1
+  %f2.ptail = load %Value, %Value* %f2.ptail_ptr
+  %f2.pval_d = call double @value_to_double(%Value %f2.phead)
+  %f2.nacc_i32 = trunc i64 %f2.nacc to i32
+  br i1 %f2.nc_is_f, label %f2.do_starf, label %f2.do_stare
+
+f2.do_starf:
+  %f2.fmt_sf = getelementptr [5 x i8], [5 x i8]* @.fmt_starf, i32 0, i32 0
+  call i32 (i8*, ...) @printf(i8* %f2.fmt_sf, i32 %f2.nacc_i32, double %f2.pval_d)
+  br label %f2.precision_after
+
+f2.do_stare:
+  %f2.fmt_se = getelementptr [5 x i8], [5 x i8]* @.fmt_stare, i32 0, i32 0
+  call i32 (i8*, ...) @printf(i8* %f2.fmt_se, i32 %f2.nacc_i32, double %f2.pval_d)
+  br label %f2.precision_after
+
+f2.precision_after:
+  %f2.p_after_pcons = getelementptr i8, i8* %f2.np, i32 1
+  br label %f2.iter_end_precision_consume
+
+f2.iter_end_precision_consume:
+  br label %f2.iter_end
 
 f2.directive_n:
   call i32 @putchar(i32 10)
@@ -4394,21 +4487,26 @@ f2.iter_end_consume:
   br label %f2.iter_end
 
 f2.iter_end:
-  ; Merge all per-iteration paths. The consume path arrives via
-  ; %f2.iter_end_consume and uses %f2.tail; everything else keeps
-  ; %f2.args unchanged.
+  ; Merge all per-iteration paths. Consume paths advance args to
+  ; %f2.tail / %f2.ptail; everything else keeps %f2.args unchanged.
   %f2.p_next = phi i8* [ %f2.p_lit_next, %f2.print_lit ],
                         [ %f2.p_after_n, %f2.directive_n ],
                         [ %f2.p_after_t, %f2.directive_t ],
                         [ %f2.p_after_u, %f2.unknown_dir ],
                         [ %f2.p_no_arg, %f2.no_arg ],
-                        [ %f2.p_after_w, %f2.iter_end_consume ]
+                        [ %f2.p_after_w, %f2.iter_end_consume ],
+                        [ %f2.p_after_punk, %f2.precision_unknown ],
+                        [ %f2.p_after_pna, %f2.precision_no_arg ],
+                        [ %f2.p_after_pcons, %f2.iter_end_precision_consume ]
   %f2.args_next = phi %Value [ %f2.args, %f2.print_lit ],
                               [ %f2.args, %f2.directive_n ],
                               [ %f2.args, %f2.directive_t ],
                               [ %f2.args, %f2.unknown_dir ],
                               [ %f2.args, %f2.no_arg ],
-                              [ %f2.tail, %f2.iter_end_consume ]
+                              [ %f2.tail, %f2.iter_end_consume ],
+                              [ %f2.args, %f2.precision_unknown ],
+                              [ %f2.args, %f2.precision_no_arg ],
+                              [ %f2.ptail, %f2.iter_end_precision_consume ]
   br label %f2.loop
 
 f2.done:

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -3436,6 +3436,11 @@ define %Value @wam_make_list_value(%List* %list_ptr) alwaysinline nounwind readn
 @.fmt_str = private constant [3 x i8] c"%s\00"
 @.fmt_dbl = private constant [3 x i8] c"%g\00"
 @.fmt_chr = private constant [3 x i8] c"%c\00"
+; M15: variable-precision fixed-point. printf "%.*f" reads the
+; precision from the argument list before the double.
+@.fmt_starf = private constant [5 x i8] c"%.*f\00"
+; Scientific notation, variable precision (~Ne directive).
+@.fmt_stare = private constant [5 x i8] c"%.*e\00"
 
 define %Value @wam_make_empty_list_value() alwaysinline nounwind readnone {
   %v0 = insertvalue %Value undef, i32 4, 0

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -129,6 +129,32 @@ test_msort_dups(_, R) :-
     Sorted = [_, X|_],
     R is X.
 
+% M16: reverse-mode length/2 -- length(L, N) with L unbound and N
+% bound to an Integer allocates a fresh N-element list of unbound
+% logic variables and binds L. We then unify the result with a
+% concrete pattern to confirm the structure round-trips.
+:- dynamic test_length_rev_size/2.
+test_length_rev_size(_, R) :-
+    length(L, 4),
+    length(L, N),   % round-trip: forward-mode length on the freshly built list
+    R is N.
+
+:- dynamic test_length_rev_unify_head/2.
+test_length_rev_unify_head(_, R) :-
+    length(L, 3),
+    L = [11, _, _],   % bind the first cell -- exercises that the
+                       % args[0] Ref in the reverse-built cons cell
+                       % is actually a bindable logic variable.
+    L = [H|_],
+    R is H.
+
+:- dynamic test_length_rev_unify_all/2.
+test_length_rev_unify_all(_, R) :-
+    length(L, 3),
+    L = [4, 5, 6],
+    L = [_, M, _],
+    R is M.
+
 % M10: setof/3 via aggregate_all -> sort + dedup. The agg_type_id
 % routes set/setof to id 6, which inserts a sort+dedup pass before
 % building the cons-cell chain. Drives off a small dynamic fact
@@ -685,6 +711,13 @@ test_all :-
        run_test_r0('msort_third [33,11,22] -> 33', test_msort_third, 0, 33),
        run_test_r0('msort_one [42] -> 42', test_msort_one, 0, 42),
        run_test_r0('msort_dups [3,1,3,2,1] -> 1', test_msort_dups, 0, 1),
+       format('--- M16 reverse-mode length/2 ---~n'),
+       run_test_r0('length(L, 4), length(L, N) -> 4',
+                   test_length_rev_size, 0, 4),
+       run_test_r0('length(L, 3), L = [11,_,_], head -> 11',
+                   test_length_rev_unify_head, 0, 11),
+       run_test_r0('length(L, 3), L = [4,5,6], middle -> 5',
+                   test_length_rev_unify_all, 0, 5),
        format('--- M10 setof/3 (sort + dedup) ---~n'),
        run_test_r0('setof color/1 count -> 3',
                    test_setof_count + [color/1], 0, 3),

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -301,6 +301,33 @@ test_fmt_tilde_escape(_, R) :-
     format('about ~~w~n', []),
     R is 1.
 
+% M15: precision directives ~Nf (fixed-point) and ~Ne (scientific).
+% Parses the digit run between ~ and f/e at runtime, then routes the
+% next arg through printf "%.*f" / "%.*e" with the parsed precision.
+:- dynamic test_fmt_6f/2.
+test_fmt_6f(_, R) :-
+    X is 1 / 4,                       % Float 0.25
+    format('~6f~n', [X]),
+    R is 1.
+
+:- dynamic test_fmt_3f/2.
+test_fmt_3f(_, R) :-
+    X is 1 / 8,                       % Float 0.125
+    format('d=~3f~n', [X]),
+    R is 1.
+
+:- dynamic test_fmt_int_via_f/2.
+test_fmt_int_via_f(_, R) :-
+    % Integer arg routed through ~Nf: should promote via sitofp.
+    format('n=~2f~n', [7]),
+    R is 1.
+
+:- dynamic test_fmt_2e/2.
+test_fmt_2e(_, R) :-
+    X is 1 / 4000,                    % Float 0.00025
+    format('e=~2e~n', [X]),
+    R is 1.
+
 % Runner for format/2 tests: captures stdout, compares against an
 % expected string. The test predicate must end with `R is 1` so the
 % module compiles cleanly and the call succeeds.
@@ -712,6 +739,15 @@ test_all :-
                     "color=red\n"),
        run_fmt_test('"about ~~w~n" tilde escape', test_fmt_tilde_escape,
                     "about ~w\n"),
+       format('--- M15 precision directives (~~Nf / ~~Ne) ---~n'),
+       run_fmt_test('"~6f~n" with 0.25', test_fmt_6f,
+                    "0.250000\n"),
+       run_fmt_test('"d=~3f~n" with 0.125', test_fmt_3f,
+                    "d=0.125\n"),
+       run_fmt_test('"n=~2f~n" with integer 7', test_fmt_int_via_f,
+                    "n=7.00\n"),
+       run_fmt_test('"e=~2e~n" with 0.00025', test_fmt_2e,
+                    "e=2.50e-04\n"),
        format('--- M10 \\+ negation-as-failure (inline rewrite) ---~n'),
        run_test_r0('\\+ in_basket(soap) -> succeeds, R=7',
                    test_not_absent + [in_basket/1], 0, 7),


### PR DESCRIPTION
## Summary

Two small additions that round out `format/2` and `length/2`:

### M15: `format/2` precision directives `~Nf` and `~Ne`

The directive parser now special-cases a digit run after `~`. Digits accumulate into an `i64`, then the terminator dispatches:

- `f` → `printf("%.*f", N, val)` — fixed-point
- `e` → `printf("%.*e", N, val)` — scientific
- anything else → print verbatim (`~<digits><c>`)

The next arg is consumed once and promoted to `double` via `value_to_double`, so an Integer like `7` formatted with `~2f` correctly comes out `7.00`. No-arg case advances the pointer past the terminator so we don't loop.

This was the last piece the original M10 punch-list comment about effective_distance.pl's `format("~w\t~w\t~6f~n", ...)` was waiting on — the format printer now handles the `~6f` slot.

### M16: reverse-mode `length/2`

`builtin_length` branches on A1's tag at entry. If A1 derefs to Unbound and A2 is a known Integer `N`, allocate `N` fresh Unbound heap cells and build an `N`-element `[|]/2` chain on the arena whose head is bound to A1. Each element's `args[0]` is `Ref(heap_addr)`, so the list items are real logic variables that participate in subsequent unification through `wam_unify_value`.

Forward mode (A1 bound → walk the chain, bind A2 to the count) is unchanged.

## Test plan

- [x] `tests/core/test_wam_llvm_builtin_execution.pl` — 60 cases pass (was 53 pre-M15/M16). New:
  - **M15 precision directives** (4): `~6f` over `1/4` → `"0.250000\n"`, `~3f` over `1/8` → `"d=0.125\n"`, `~2f` over Integer `7` → `"n=7.00\n"` (sitofp promotion), `~2e` over `1/4000` → `"e=2.50e-04\n"`.
  - **M16 reverse length** (3): `length(L, 4), length(L, N) → 4` (round-trip via forward-mode), `length(L, 3), L = [11, _, _], head → 11` (head Ref is bindable), `length(L, 3), L = [4, 5, 6], middle → 5` (all three Refs unify).
- [x] `tests/core/test_wam_llvm_findall_execution.pl` — M9 still passes.
- [x] `tests/core/test_wam_llvm_realdata_benchmark.pl` — 31 ancestors, per-iter ~0.052ms, no regression.
- [x] `tests/core/test_wam_llvm_bfs_execution.pl` — 4 cases pass.
- [x] `tests/core/test_wam_llvm_astar_execution.pl` — A*(a,d) → distance 12.0.

Run with `LC_ALL=C.UTF-8`.

## Out of scope

The one big item still standing is **proper `get_level` / `cut Y_n` for soft cut**. The M10 cb fix made hard `!` work (which was enough for `\+` and for `(C, !, fail ; T)` patterns), but `cut_ite` is still naive-decrement — soft cut in `(Cond -> Then ; Else)` mishandles a Cond that pushes inner choice points. That's a substantial change (new bytecode instructions + WAM compiler emission + runtime), so it's getting its own follow-up PR.

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_