### PR TITLE
LLVM WAM: M17 — proper soft cut via get_level / cut Y_n

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1570,7 +1570,19 @@ compile_predicates_for_llvm(Predicates, Options, NativeCode, WamCode) :-
     -> OptionsWithBS = Options
     ;  OptionsWithBS = [inline_bagof_setof(true) | Options]
     ),
-    OptionsWithClosure = [lowered_closure(ClosureSet)|OptionsWithBS],
+    % M17: emit if-then-else with get_level Y_n / cut Y_n bytecode
+    % rather than the naive cut_ite. The LLVM target''s cut_ite was
+    % a "decrement cp_count by 1" stub, which silently cut the wrong
+    % choice point when the condition pushed inner CPs (e.g. a call
+    % to a multi-clause predicate). With get_level/cut Y_n we snapshot
+    % the cp_count into a permanent Y register before the try_me_else
+    % and restore it at the cut site, so soft cut works correctly
+    % regardless of inner CP pushes.
+    ( memberchk(ite_use_y_level(_), OptionsWithBS)
+    -> OptionsWithLevel = OptionsWithBS
+    ;  OptionsWithLevel = [ite_use_y_level(true) | OptionsWithBS]
+    ),
+    OptionsWithClosure = [lowered_closure(ClosureSet)|OptionsWithLevel],
     pass1_classify_predicates(Predicates, OptionsWithClosure, 0, Classified),
     build_merged_labels(Classified, NamePCPairs, LabelMap),
     pass2_emit_merged(Classified, LabelMap, NamePCPairs, OptionsWithClosure,
@@ -2150,6 +2162,8 @@ entry:
     i32 30, label %call_foreign
     i32 31, label %cut_ite
     i32 32, label %jump
+    i32 33, label %get_level
+    i32 34, label %cut
   ], !prof !99
 
 ~w
@@ -2166,7 +2180,7 @@ default:
 ; Comments inside the operand list aren\'t allowed (the LLVM IR
 ; parser rejects `;` mid-operand), so the per-opcode rationale lives
 ; in the comment block above the @step definition.
-!99 = !{!\"branch_weights\", i32 1, i32 50, i32 80, i32 100, i32 20, i32 20, i32 30, i32 30, i32 10, i32 50, i32 80, i32 100, i32 20, i32 10, i32 20, i32 30, i32 30, i32 50, i32 50, i32 80, i32 50, i32 100, i32 60, i32 30, i32 5, i32 10, i32 10, i32 5, i32 5, i32 5, i32 5, i32 10, i32 5, i32 5}', [CasesCode]).
+!99 = !{!\"branch_weights\", i32 1, i32 50, i32 80, i32 100, i32 20, i32 20, i32 30, i32 30, i32 10, i32 50, i32 80, i32 100, i32 20, i32 10, i32 20, i32 30, i32 30, i32 50, i32 50, i32 80, i32 50, i32 100, i32 60, i32 30, i32 5, i32 10, i32 10, i32 5, i32 5, i32 5, i32 5, i32 10, i32 5, i32 5, i32 5, i32 5}', [CasesCode]).
 
 compile_llvm_step_case(CaseCode) :-
     wam_llvm_case(Label, BodyCode),
@@ -3145,6 +3159,41 @@ j.go:
 
 j.fail:
   ret i1 false').
+
+wam_llvm_case('get_level',
+'  ; M17: snapshot the current cp_count into a Y register so cut Y_n
+  ; can restore it later. Used for proper if-then-else soft cut --
+  ; pre-M17 the LLVM target''s cut_ite just decremented cp_count by 1,
+  ; which silently cut the wrong CP when the condition pushed inner
+  ; multi-clause CPs. op1 = Y register index.
+  %gl.yn = trunc i64 %op1 to i32
+  %gl.cpn_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 13
+  %gl.cpn = load i32, i32* %gl.cpn_ptr
+  %gl.cpn64 = zext i32 %gl.cpn to i64
+  %gl.v = call %Value @value_integer(i64 %gl.cpn64)
+  call void @wam_trail_binding(%WamState* %vm, i32 %gl.yn)
+  call void @wam_set_reg(%WamState* %vm, i32 %gl.yn, %Value %gl.v)
+  call void @wam_inc_pc(%WamState* %vm)
+  ret i1 true').
+
+wam_llvm_case('cut',
+'  ; M17: restore cp_count from the snapshot stored in Y_n by an
+  ; earlier get_level. Cuts the if-then-else CP and any inner CPs
+  ; the condition pushed. op1 = Y register index.
+  %cy.yn = trunc i64 %op1 to i32
+  %cy.v = call %Value @wam_get_reg(%WamState* %vm, i32 %cy.yn)
+  %cy.pay = extractvalue %Value %cy.v, 1
+  %cy.target = trunc i64 %cy.pay to i32
+  %cy.cpn_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 13
+  %cy.cur = load i32, i32* %cy.cpn_ptr
+  %cy.do_cut = icmp sgt i32 %cy.cur, %cy.target
+  br i1 %cy.do_cut, label %cy.go, label %cy.skip
+cy.go:
+  store i32 %cy.target, i32* %cy.cpn_ptr
+  br label %cy.skip
+cy.skip:
+  call void @wam_inc_pc(%WamState* %vm)
+  ret i1 true').
 
 % ============================================================================
 % PHASE 3: Helper predicates → LLVM functions
@@ -6325,6 +6374,18 @@ wam_line_to_llvm_literal(["trust"|_],
 
 wam_line_to_llvm_literal(["cut_ite"],
     '%Instruction { i32 31, i64 0, i64 0 }').
+
+% M17: get_level Y_n / cut Y_n -- proper soft cut for if-then-else.
+wam_line_to_llvm_literal(["get_level", Yn], Lit) :-
+    clean_comma(Yn, CYn),
+    atom_string(CYnAtom, CYn),
+    reg_name_to_index(CYnAtom, YnIdx),
+    format(atom(Lit), '%Instruction { i32 33, i64 ~w, i64 0 }', [YnIdx]).
+wam_line_to_llvm_literal(["cut", Yn], Lit) :-
+    clean_comma(Yn, CYn),
+    atom_string(CYnAtom, CYn),
+    reg_name_to_index(CYnAtom, YnIdx),
+    format(atom(Lit), '%Instruction { i32 34, i64 ~w, i64 0 }', [YnIdx]).
 
 % jump without a label map errors — label-referencing. Text parser that
 % produces label-free literals is only used for the non-resolved path

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -21,6 +21,7 @@
 
 :- use_module(library(lists)).
 :- use_module(library(option)).
+:- use_module(library(gensym)).
 :- use_module('../core/clause_body_analysis').
 :- use_module('../core/template_system').
 :- use_module('../core/binding_state_analysis').
@@ -101,6 +102,15 @@ compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code) :-
     (   option(inline_not_as_failure(false), Options)
     ->  b_setval(wam_inline_not, false)
     ;   b_setval(wam_inline_not, true)
+    ),
+    % M17: emit if-then-else with get_level Y_n / cut Y_n bytecode
+    % instead of the legacy cut_ite. Targets that opt in (currently
+    % LLVM) implement the new instructions properly; others keep the
+    % cut_ite pattern. Default off so existing C++/Go/Lua/etc. paths
+    % don''t see new opcodes they don''t parse.
+    (   option(ite_use_y_level(true), Options)
+    ->  b_setval(wam_ite_use_y_level, true)
+    ;   b_setval(wam_ite_use_y_level, false)
     ),
     % args_first_emission: emit set_variable for ALL outer-compound
     % args BEFORE any nested put_structure. The legacy emit
@@ -780,6 +790,9 @@ wam_inline_bagof_setof_enabled :-
 
 wam_inline_not_enabled :-
     catch(b_getval(wam_inline_not, true), _, fail).
+
+wam_ite_use_y_level_enabled :-
+    catch(b_getval(wam_ite_use_y_level, true), _, fail).
 
 is_builtin_goal(is).
 is_builtin_goal(=).
@@ -1622,26 +1635,49 @@ flatten_conjunction(Goal, [Goal]).
 %  implementation and just fails.
 compile_if_then_else(CondGoal, ThenGoal, ElseGoal, V0, Vf, _HasEnv, Code) :-
     next_ite_label(ElseLabel, ContLabel),
-    % Flatten condition into a goal list
+    ( wam_ite_use_y_level_enabled
+    -> % M17: allocate a fresh permanent Y for the cut barrier.
+       % get_level Y_n snapshots cp_count BEFORE try_me_else; cut Y_n
+       % at the commit site sets cp_count = Y_n. Together they cut
+       % the ITE choice point AND any inner CPs the condition''s
+       % multi-clause calls left behind -- the naive cut_ite (which
+       % decrements cp_count by 1) silently picked the wrong CP in
+       % that case.
+       %
+       % allocate_var falls back to X if no y_alloc reservation
+       % exists for the var; X regs are caller-saved and the inner
+       % call would clobber the snapshot before cut reads it. Reserve
+       % a fresh Y at the top so allocate_var picks it up.
+       V0 = vmap(Bindings0, XCount0),
+       max_yi_index(Bindings0, 0, MaxY),
+       NextY is MaxY + 1,
+       format(atom(BarrierReg), "Y~w", [NextY]),
+       gensym('$ite_barrier_', BarrierVar),
+       V0a = vmap([b(BarrierVar, BarrierReg)|Bindings0], XCount0)
+    ;  V0a = V0,
+       BarrierReg = none
+    ),
     flatten_conjunction(CondGoal, CondGoals),
-    compile_inner_call_goals(CondGoals, V0, V1, CondCode),
+    compile_inner_call_goals(CondGoals, V0a, V1, CondCode),
     % Then and Else can each be themselves a nested if-then-else --
     % compile_ite_branch recurses on those forms. Else starts from
-    % V0 since backtrack restores to before the condition.
+    % V0a since backtrack restores to before the condition (but the
+    % barrier var is already allocated so its slot is reserved).
     compile_ite_branch(ThenGoal, V1, V2, ThenCode),
-    compile_ite_branch(ElseGoal, V0, V3, ElseCode),
-    % Use the wider variable map as output
+    compile_ite_branch(ElseGoal, V0a, V3, ElseCode),
     (   V2 = V3 -> Vf = V2
-    ;   Vf = V2  % prefer then-branch vars (else-branch is alternative)
+    ;   Vf = V2
     ),
-    % Emit: try_me_else ElseLabel / Cond / !/0 / Then / jump ContLabel
-    %        ElseLabel: trust_me / Else / ContLabel:
-    % Use cut_ite (soft cut) instead of !/0 — pops only the if-then-else
-    % CP, preserving aggregate frames and outer choice points.
-    % ContLabel marks the continuation after both branches.
-    format(string(Code),
-        "    try_me_else ~w~n~w~n    cut_ite~n~w~n    jump ~w~n~w:~n    trust_me~n~w~n~w:",
-        [ElseLabel, CondCode, ThenCode, ContLabel, ElseLabel, ElseCode, ContLabel]).
+    ( BarrierReg == none
+    -> format(string(Code),
+          "    try_me_else ~w~n~w~n    cut_ite~n~w~n    jump ~w~n~w:~n    trust_me~n~w~n~w:",
+          [ElseLabel, CondCode, ThenCode, ContLabel,
+           ElseLabel, ElseCode, ContLabel])
+    ;  format(string(Code),
+          "    get_level ~w~n    try_me_else ~w~n~w~n    cut ~w~n~w~n    jump ~w~n~w:~n    trust_me~n~w~n~w:",
+          [BarrierReg, ElseLabel, CondCode, BarrierReg, ThenCode,
+           ContLabel, ElseLabel, ElseCode, ContLabel])
+    ).
 
 %% compile_ite_branch(+Branch, +V0, -Vf, -Code) is det.
 %  Compile a Then- or Else-branch of an if-then-else. If the branch

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -155,6 +155,38 @@ test_length_rev_unify_all(_, R) :-
     L = [_, M, _],
     R is M.
 
+% M17: if-then-else soft cut with a multi-clause condition. Pre-M17
+% cut_ite naively decremented cp_count by 1, which popped the inner
+% retry CP left over from in_basket''s clause dispatch rather than
+% the ITE guard CP -- after `fail` from the then-branch the backtrack
+% landed on the else-branch and produced a wrong answer. M17 emits
+% get_level Y_n before try_me_else and cut Y_n at the commit site so
+% the cut restores cp_count to the pre-ITE level regardless of any
+% CPs the condition pushed.
+:- dynamic ite_basket/1.
+ite_basket(apple).
+ite_basket(bread).
+ite_basket(milk).
+
+:- dynamic test_ite_succ_then_fail/2.
+test_ite_succ_then_fail(_, R) :-
+    % apple IS in the basket -> condition succeeds, commits to "then" branch.
+    ( ite_basket(apple) -> R is 11 ; R is 22 ).
+
+:- dynamic test_ite_fail_to_else/2.
+test_ite_fail_to_else(_, R) :-
+    % soap is NOT in the basket -> condition fails, takes else branch.
+    ( ite_basket(soap) -> R is 11 ; R is 22 ).
+
+% Chained ITE after a multi-clause call (the case cut_ite would mis-handle).
+:- dynamic test_ite_chained_after_call/2.
+test_ite_chained_after_call(_, R) :-
+    ( ite_basket(milk) -> X is 7 ; X is 0 ),
+    % Continuation arithmetic exercises that the ITE returned with
+    % a clean cp_stack -- pre-M17 inner retry CPs would survive and
+    % the wrong branch would be taken on subsequent backtrack.
+    R is X + 1.
+
 % M10: setof/3 via aggregate_all -> sort + dedup. The agg_type_id
 % routes set/setof to id 6, which inserts a sort+dedup pass before
 % building the cons-cell chain. Drives off a small dynamic fact
@@ -718,6 +750,13 @@ test_all :-
                    test_length_rev_unify_head, 0, 11),
        run_test_r0('length(L, 3), L = [4,5,6], middle -> 5',
                    test_length_rev_unify_all, 0, 5),
+       format('--- M17 if-then-else soft cut (get_level/cut Y_n) ---~n'),
+       run_test_r0('(apple -> 11 ; 22) -> 11',
+                   test_ite_succ_then_fail + [ite_basket/1], 0, 11),
+       run_test_r0('(soap -> 11 ; 22) -> 22',
+                   test_ite_fail_to_else + [ite_basket/1], 0, 22),
+       run_test_r0('(milk -> 7 ; 0), R is X+1 -> 8',
+                   test_ite_chained_after_call + [ite_basket/1], 0, 8),
        format('--- M10 setof/3 (sort + dedup) ---~n'),
        run_test_r0('setof color/1 count -> 3',
                    test_setof_count + [color/1], 0, 3),


### PR DESCRIPTION
## Summary

Proper soft cut for if-then-else via the standard WAM `get_level Y_n` / `cut Y_n` pattern.

The legacy `cut_ite` in the LLVM target decremented `cp_count` by 1 — fine when the condition was a deterministic builtin, but silently wrong when the condition pushed inner CPs (e.g. a call to a multi-clause predicate left a retry CP on top of the ITE guard). After `fail` from the then-branch the backtrack landed on the else-branch and produced a wrong answer.

`get_level Y_n` snapshots `cp_count` into a permanent Y register at ITE entry; `cut Y_n` restores it at the commit site. Together they cut the ITE guard AND any inner CPs the condition left behind — independent of how many CPs the condition stacked.

## Changes

- **`wam_target.pl` `compile_if_then_else`** branches on a new `ite_use_y_level(true)` option. When set, reserves a fresh Y reg for the cut barrier (slotted via a `b/2` entry above any existing Y bindings so `allocate_var` picks it up rather than falling back to X) and emits:
  ```
  get_level Y_n
  try_me_else else
  <cond>
  cut Y_n
  <then>
  jump cont
  else: trust_me
  <else>
  cont:
  ```
  instead of the legacy `try_me_else` / `cut_ite` pattern. Other targets default to false and keep emitting `cut_ite` — no breakage.

- **LLVM target** opts into `ite_use_y_level(true)` in `compile_predicates_for_llvm` (alongside the existing `inline_bagof_setof` / `inline_not_as_failure` defaults).

- **LLVM target** adds `get_level` (op 33) and `cut` (op 34) cases in `@step`. `get_level` reads `cp_count`, boxes as Integer, writes to the named Y reg. `cut` reads Y_n's payload and sets `cp_count` (only if lower than current — safety net so cut never grows the CP stack).

- Bytecode parser adds line handlers for `get_level Y_n` and `cut Y_n`. `@step`'s switch and its `!prof !99` branch-weight metadata extend to cover the two new cases.

- `wam_target.pl` adds `wam_ite_use_y_level_enabled`, the option-setter in `compile_predicate_to_wam`, and `library(gensym)` for the barrier-var name.

## Test plan

- [x] `tests/core/test_wam_llvm_builtin_execution.pl` — 63 cases pass (was 60). New ITE cases over the multi-clause `ite_basket/1` fact base:
  - `(ite_basket(apple) -> 11 ; 22) → 11` (condition succeeds via clause 1, commits to then, retry CP for clauses 2/3 must be cut)
  - `(ite_basket(soap) -> 11 ; 22) → 22` (condition fails through all clauses, takes else)
  - `(ite_basket(milk) -> 7 ; 0), R is X + 1 → 8` (continuation arithmetic verifies the cp_stack is clean after the ITE)
- [x] `tests/core/test_wam_llvm_findall_execution.pl` — M9 still passes.
- [x] `tests/core/test_wam_llvm_realdata_benchmark.pl` — 31 ancestors, per-iter ~0.056ms, no regression.
- [x] `tests/core/test_wam_llvm_bfs_execution.pl` — 4 cases pass.
- [x] `tests/core/test_wam_llvm_astar_execution.pl` — A*(a,d) → distance 12.0.

Run with `LC_ALL=C.UTF-8`.

## Out of scope

The major correctness items I'd been tracking are all done now. Remaining items are opportunistic polish — wider `format/2` directives (`~q`, `~p`), more `eval_arith` ops (`sqrt`, `truncate`, `round`, `sign`), runtime arena reset between aggregations, etc.

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_