### PR TITLE
refactor(wam-haskell): complete cross-target items-level ISO rewrite

### DIFF
--- a/docs/design/WAM_ITEMS_API_SPECIFICATION.md
+++ b/docs/design/WAM_ITEMS_API_SPECIFICATION.md
@@ -488,25 +488,31 @@ items natively: `wam_cpp_target.pl` calls the shared
 it never carried the per-shape text-rewrite duplication. (An earlier draft of
 this section claimed it did — that was inaccurate.)
 
-**Elixir, F#, and Python have been migrated off the per-shape text rules.** Each
-target's `iso_errors_rewrite_line/3` now tokenizes a WAM line with the shared
+**All text-rewrite targets — Elixir, F#, Python, and Haskell — have been
+migrated off their bespoke per-line rewrites.** Each target's
+`iso_errors_rewrite_line/3` now tokenizes a WAM line with the shared
 `wam_tokenize_line/2`, recognises it to a structured item via
 `wam_recognise_instruction/2`, and applies the shared
 `iso_errors_rewrite_item/3` (exported from `core/iso_errors`) — a single
 `arg(1)`-based key swap that covers all four shapes at once. The swapped key is
 spliced back into the original line so text output stays byte-identical. The
-four duplicated `iso_errors_rewrite_parts` clauses and the local
-`iso_errors_lookup/3` are gone from all three. This is the
+duplicated `iso_errors_rewrite_parts` clauses and the local
+`iso_errors_lookup/3` / `iso_errors_rewrite_key/3` helpers are gone. This is the
 `swap_key_in_item/3`-style pass the note below anticipated, realised without yet
-requiring a full items-first emitter. (Elixir: PR #2559. F# + Python: this PR.)
+requiring a full items-first emitter. (Elixir: PR #2559. F# + Python: PR #2570.
+Haskell: this PR.)
 
-**Haskell still carries its own text-rewrite path** — a narrower
-`builtin_call`-only `sub_string` rewrite (it never had the four-shape
-duplication). Migrating it to the shared item pass is a straightforward
-follow-up. In all targets, ISO mode stays per-predicate — resolved by
-`iso_errors_mode_for(Config, PI, Mode)`, honouring `iso_errors_override` per
-`Pred/Arity`; this refactor does not change that.
+Haskell was the last and slightly different case: it had only ever rewritten
+`builtin_call` (not the four shapes) and used a three-valued mode (`iso` / `lax`
+/ `default` atoms). The shared pass broadens it to all four shapes, but since the
+only keys in the ISO/lax tables are arithmetic builtins (`is/2`, the six
+comparisons, `succ/2`) — which the WAM compiler always emits as `builtin_call` —
+the extra coverage never matches in practice and simply makes Haskell consistent.
+The `default` mode now passes through the shared rewriter's catch-all unchanged.
 
-The interaction remains important for the remaining targets' future migrations.
-Once a target consumes structured WAM items directly, ISO rewrites collapse to
-this same single shared pass instead of several text-shape rules per key.
+C++ never had a text-rewrite path: `wam_cpp_target.pl` already consumes
+structured items and calls `iso_errors_rewrite/4` directly. So every WAM target
+now routes ISO rewriting through the single shared item pass. In all targets, ISO
+mode stays per-predicate — resolved by `iso_errors_mode_for(Config, PI, Mode)`,
+honouring `iso_errors_override` per `Pred/Arity`; this refactor does not change
+that.

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -71,7 +71,11 @@
               resolve_csr_index_backend/2]).
 :- use_module('../core/algorithm_manifest',
              [load_algorithm_manifest/2]).
-:- use_module('../targets/wam_text_parser', [wam_classify_constant_token/2]).
+:- use_module('../targets/wam_text_parser',
+              [ wam_classify_constant_token/2,
+                wam_tokenize_line/2,
+                wam_recognise_instruction/2
+              ]).
 :- use_module('../targets/wam_runtime_parser_capability',
              [parser_dependent_body_goal/2, wam_target_runtime_parser/3]).
 :- use_module('../core/prolog_term_parser').
@@ -84,6 +88,7 @@
                 iso_errors_mode_for/3,
                 iso_errors_warn_multi_module/2,
                 iso_errors_rewrite/4,
+                iso_errors_rewrite_item/3,
                 iso_errors_audit_normalise_pi/2,
                 iso_errors_audit_walk/5
               ]).
@@ -6684,52 +6689,62 @@ iso_errors:iso_errors_default_to_lax("=\\=/2", "=\\=_lax/2").
 iso_errors:iso_errors_default_to_lax("succ/2", "succ_lax/2").
 
 %% iso_errors_rewrite_text(+Config, +PI, +WamText, -RewrittenText)
-%  Text-level ISO rewrite: replaces BuiltinCall keys per the ISO config.
-%  Mirrors the F# and Python iso_errors_rewrite_text/4.
+%  Text-level ISO rewrite routed through the shared items pipeline.
+%  Mirrors the Elixir / F# / Python migration: each line is tokenized
+%  with the shared quote-aware tokenizer, recognised to a structured
+%  item, rewritten by the shared iso_errors_rewrite_item/3, and the
+%  swapped key is spliced back into the original line (whitespace
+%  preserved byte-for-byte).
+%
+%  iso_errors_mode_for/3 may yield the atom `default` (the third-valued
+%  config default the Haskell target supports) in addition to
+%  true/false; only true/false drive a rewrite, anything else passes
+%  the text through unchanged.
+%
+%  Previously this target only rewrote `builtin_call` keys. The shared
+%  iso_errors_rewrite_item/3 also covers put_structure / call / execute,
+%  but the only keys in the ISO/lax tables are arithmetic builtins
+%  (is/2, the six comparisons, succ/2) which the WAM compiler always
+%  emits as builtin_call — so the broader coverage is a harmless
+%  superset that keeps Haskell consistent with the other targets.
 iso_errors_rewrite_text(Config, PI, WamText, RewrittenText) :-
     iso_errors_mode_for(Config, PI, Mode),
-    (   Mode == true  -> RMode = iso
-    ;   Mode == false -> RMode = lax
-    ;   RMode = default
-    ),
-    (   RMode == default
-    ->  RewrittenText = WamText
-    ;   atom_string(WamText, WamStr),
+    (   ( Mode == true ; Mode == false )
+    ->  atom_string(WamText, WamStr),
         split_string(WamStr, "\n", "", Lines),
-        maplist(iso_errors_rewrite_line(RMode), Lines, NewLines),
+        maplist(iso_errors_rewrite_line(Mode), Lines, NewLines),
         atomic_list_concat(NewLines, "\n", RewrittenText)
+    ;   RewrittenText = WamText
     ).
 
-iso_errors_rewrite_line(Mode, Line, NewLine) :-
-    (   sub_string(Line, Before, _, _, "builtin_call "),
-        sub_string(Line, Before, 13, _, "builtin_call ")
-    ->  sub_string(Line, 0, Before, _, Prefix),
-        Offset is Before + 13,
-        sub_string(Line, Offset, _, 0, Rest),
-        split_string(Rest, " ", "", [KeyRaw|Tail]),
-        % Strip trailing comma from key token (e.g. "is/2," -> "is/2")
-        (   string_concat(Key, ",", KeyRaw) -> true ; Key = KeyRaw ),
-        iso_errors_rewrite_key(Mode, Key, NewKey),
-        % Reattach comma if it was there
-        (   string_concat(_, ",", KeyRaw)
-        ->  string_concat(NewKey, ",", NewKeyTok)
-        ;   NewKeyTok = NewKey
-        ),
-        atomic_list_concat([NewKeyTok|Tail], " ", NewRest),
-        atom_concat(Prefix, "builtin_call ", P2),
-        atom_concat(P2, NewRest, NewLine)
-    ;   NewLine = Line
+% Rewrite one line via the shared items pipeline. Any failure along the
+% chain (unrecognised line, key not in the ISO/lax tables, splice miss)
+% falls through to OutLine = Line. All four rewritable shapes carry the
+% key as their first argument, so arg(1, ...) extracts old/new keys
+% generically.
+iso_errors_rewrite_line(Mode, Line, OutLine) :-
+    (   wam_tokenize_line(Line, Tokens),
+        wam_recognise_instruction(Tokens, Item0),
+        iso_errors_rewrite_item(Mode, Item0, Item1),
+        Item0 \== Item1,
+        arg(1, Item0, OldKey),
+        arg(1, Item1, NewKey),
+        iso_errors_splice_line(Line, OldKey, NewKey, OutLine)
+    ->  true
+    ;   OutLine = Line
     ).
 
-iso_errors_rewrite_key(iso, Key, NewKey) :-
-    (   iso_errors:iso_errors_default_to_iso(Key, NewKey) -> true
-    ;   NewKey = Key
-    ).
-iso_errors_rewrite_key(lax, Key, NewKey) :-
-    (   iso_errors:iso_errors_default_to_lax(Key, NewKey) -> true
-    ;   NewKey = Key
-    ).
-iso_errors_rewrite_key(default, Key, Key).
+% Replace the first occurrence of Key in Line with NewKey, preserving
+% surrounding whitespace. Same helper the other targets use.
+iso_errors_splice_line(Line, Key, NewKey, OutLine) :-
+    sub_string(Line, Before, KLen, _After, Key),
+    string_length(Key, KLen),
+    sub_string(Line, 0, Before, _, Pre),
+    PostStart is Before + KLen,
+    sub_string(Line, PostStart, _, 0, Post),
+    string_concat(Pre, NewKey, T1),
+    string_concat(T1, Post, OutLine),
+    !.
 
 %% write_hs_file(+Path, +Content)
 write_hs_file(Path, Content) :-


### PR DESCRIPTION
  ## Summary

  Migrates the Haskell WAM target off its bespoke `builtin_call`-only `sub_string` ISO rewrite, routing it through the
  shared `iso_errors_rewrite_item/3` in `core/iso_errors`. This is the **last** text-rewrite target — completing the
  cross-target sweep started with Elixir (#2559) and continued with F# + Python (#2570).

  Haskell's `iso_errors_rewrite_text/4` now:

  1. tokenizes each WAM line with the shared `wam_tokenize_line/2`
  2. recognises it to a structured item via `wam_recognise_instruction/2`
  3. applies the shared `iso_errors_rewrite_item/3` (one `arg(1)`-based key swap covering all four shapes — `builtin_call`,
  `put_structure`, `call`, `execute`)
  4. splices the swapped key back into the original line (whitespace preserved byte-for-byte)

  **Deleted:** the local `iso_errors_rewrite_key/3`. **Added:** `iso_errors_splice_line/4` (the same helper the other
  targets use).

  ## Haskell-specific details preserved

  - **Three-valued mode.** `iso_errors_mode_for/3` may return the atom `default` (the third-valued config default this
  target supports) in addition to `true`/`false`. Only `true`/`false` drive a rewrite; anything else passes the text through
  unchanged — matching the prior default-passthrough behaviour.
  - **Broadened shape coverage is harmless.** The migration goes from `builtin_call`-only to all four shapes. Since the only
  keys in the ISO/lax tables are arithmetic builtins (`is/2`, the six comparisons, `succ/2`) — which the WAM compiler
  always emits as `builtin_call` — the extra shapes never match in practice. It just makes Haskell consistent with the other
  targets.

  ## Cross-target status after this PR

  Every WAM target now routes ISO rewriting through the single shared `iso_errors_rewrite_item/3` pass:

  - **C++** — consumes structured items and calls `iso_errors_rewrite/4` directly (never had a text path)
  - **Elixir / F# / Python / Haskell** — tokenize → recognise → swap → splice

  ## Invariants preserved

  - **Per-predicate ISO optionality unchanged:** mode is still resolved by `iso_errors_mode_for(Config, PI, Mode)`,
  honouring `iso_errors_override(Pred/Arity, Mode)`.
  - **Byte-identical output:** splicing the key into the original line, not re-printing.

  ## Test plan

  - [x] `test_wam_haskell_iso_smoke.pl`: all pass — `is`→`iso`/`lax`, explicit-`is_iso/2` survival, the 6-comparison-op
  sweep, and the codegen-helper checks
  - [x] Shared `core/iso_errors`: **20/20** (`test_iso_errors.pl`)

  ## Not in scope

  The full items-first emitter refactor (`WAM_ITEMS_API_SPECIFICATION.md` Phase 1) — this only completes the ISO-rewrite
  path migration.