### PR TITLE
LLVM WAM: M20 — eval_arith transcendentals (sin/cos/tan/log/exp)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -5235,17 +5235,20 @@ ev_eval_unary:
   %u = call %Value @eval_arith_value(%WamState* %vm, %Value %u_raw)
   %u_tag = extractvalue %Value %u, 0
   %u_is_float = icmp eq i32 %u_tag, 2
-  ; M18: dispatch on the first functor byte. Most unary math ops are
-  ; uniquely identified by their first letter; ceiling/cos and sqrt/
-  ; sign/sin share initials and disambiguate on the second byte.
+  ; M18/M20: dispatch on the first functor byte. Most unary math ops
+  ; are uniquely identified by their first letter; the c / s / t
+  ; prefixes have collisions handled by second-byte dispatch in the
+  ; *_disambig labels.
   switch i8 %fn0, label %ev_zero [
     i8 45,  label %ev_neg       ; ''-''
     i8 97,  label %ev_abs       ; ''a''
-    i8 116, label %ev_trunc     ; ''t''
     i8 114, label %ev_round     ; ''r''
     i8 102, label %ev_floor     ; ''f''
-    i8 99,  label %ev_ceil_cos  ; ''c''
-    i8 115, label %ev_sqrt_sign ; ''s''
+    i8 99,  label %ev_ceil_cos  ; ''c'' -> ceiling | cos
+    i8 115, label %ev_sqrt_sign ; ''s'' -> sqrt | sign | sin
+    i8 116, label %ev_trunc_tan ; ''t'' -> truncate | tan
+    i8 108, label %ev_log       ; ''l''
+    i8 101, label %ev_exp       ; ''e''
   ]
 ev_neg:
   br i1 %u_is_float, label %ev_neg_f, label %ev_neg_i
@@ -5310,6 +5313,38 @@ ev_floor_f:
   %floor_v = call %Value @value_integer(i64 %floor_r_i)
   ret %Value %floor_v
 
+ev_trunc_tan:
+  ; ''t'' -> truncate (second byte ''r'') | tan (second byte ''a'').
+  %tt_fn1_ptr = getelementptr i8, i8* %fn_ptr, i32 1
+  %tt_fn1 = load i8, i8* %tt_fn1_ptr
+  switch i8 %tt_fn1, label %ev_zero [
+    i8 114, label %ev_trunc  ; ''r''
+    i8 97,  label %ev_tan    ; ''a''
+  ]
+
+ev_tan:
+  ; tan(x) = sin(x) / cos(x); always Float.
+  %tan_d = call double @value_to_double(%Value %u)
+  %tan_s = call double @llvm.sin.f64(double %tan_d)
+  %tan_c = call double @llvm.cos.f64(double %tan_d)
+  %tan_r = fdiv double %tan_s, %tan_c
+  %tan_v = call %Value @value_float(double %tan_r)
+  ret %Value %tan_v
+
+ev_log:
+  ; log(x) -> natural log, always Float.
+  %log_d = call double @value_to_double(%Value %u)
+  %log_r = call double @llvm.log.f64(double %log_d)
+  %log_v = call %Value @value_float(double %log_r)
+  ret %Value %log_v
+
+ev_exp:
+  ; exp(x) -> e^x, always Float.
+  %exp_d = call double @value_to_double(%Value %u)
+  %exp_r = call double @llvm.exp.f64(double %exp_d)
+  %exp_v = call %Value @value_float(double %exp_r)
+  ret %Value %exp_v
+
 ev_ceil_cos:
   ; Disambiguate ceiling vs cos on the second byte: ''e'' -> ceiling,
   ; ''o'' -> cos. Anything else falls back to ev_zero.
@@ -5317,7 +5352,15 @@ ev_ceil_cos:
   %cc_fn1 = load i8, i8* %cc_fn1_ptr
   switch i8 %cc_fn1, label %ev_zero [
     i8 101, label %ev_ceil  ; ''e''
+    i8 111, label %ev_cos   ; ''o''
   ]
+
+ev_cos:
+  %cos_d = call double @value_to_double(%Value %u)
+  %cos_r = call double @llvm.cos.f64(double %cos_d)
+  %cos_v = call %Value @value_float(double %cos_r)
+  ret %Value %cos_v
+
 ev_ceil:
   br i1 %u_is_float, label %ev_ceil_f, label %ev_ceil_i
 ev_ceil_i:
@@ -5330,18 +5373,30 @@ ev_ceil_f:
   ret %Value %ceil_v
 
 ev_sqrt_sign:
-  ; Disambiguate sqrt vs sign on the second byte: ''q'' -> sqrt,
-  ; ''i'' -> sign. (sin/cos/log/exp are not implemented; they''d add
-  ; libm dependencies the current target avoids.)
+  ; Disambiguate sqrt | sign | sin. Second byte routes to sqrt
+  ; (``q``) directly; for ``i`` we peek at the third byte to split
+  ; sign (``g``) from sin (``n``).
   %ss_fn1_ptr = getelementptr i8, i8* %fn_ptr, i32 1
   %ss_fn1 = load i8, i8* %ss_fn1_ptr
   switch i8 %ss_fn1, label %ev_zero [
-    i8 113, label %ev_sqrt  ; ''q''
-    i8 105, label %ev_sign  ; ''i'' (sign -- only handle ``si`` -> sign,
-                            ;  sin is omitted to keep the dispatch
-                            ;  shallow; callers wanting sin can use a
-                            ;  Taylor series in user code.)
+    i8 113, label %ev_sqrt        ; ''q''
+    i8 105, label %ev_sign_or_sin ; ''i''
   ]
+
+ev_sign_or_sin:
+  %ssi_fn2_ptr = getelementptr i8, i8* %fn_ptr, i32 2
+  %ssi_fn2 = load i8, i8* %ssi_fn2_ptr
+  switch i8 %ssi_fn2, label %ev_zero [
+    i8 103, label %ev_sign  ; ''g'' (sign)
+    i8 110, label %ev_sin   ; ''n'' (sin)
+  ]
+
+ev_sin:
+  %sin_d = call double @value_to_double(%Value %u)
+  %sin_r = call double @llvm.sin.f64(double %sin_d)
+  %sin_v = call %Value @value_float(double %sin_r)
+  ret %Value %sin_v
+
 ev_sqrt:
   ; sqrt always returns Float (Prolog ``sqrt(4)`` -> 2.0, not 2).
   %sqrt_d = call double @value_to_double(%Value %u)

--- a/templates/targets/llvm_wam/module.ll.mustache
+++ b/templates/targets/llvm_wam/module.ll.mustache
@@ -18,6 +18,10 @@ declare double @llvm.round.f64(double)
 declare double @llvm.floor.f64(double)
 declare double @llvm.ceil.f64(double)
 declare double @llvm.sqrt.f64(double)
+declare double @llvm.sin.f64(double)
+declare double @llvm.cos.f64(double)
+declare double @llvm.log.f64(double)
+declare double @llvm.exp.f64(double)
 
 ; === Value Constructors & Inspectors ===
 {{value_functions}}

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -351,6 +351,40 @@ test_atom_codes_length(_, R) :-
     length(Cs, N),
     R is N.   % 5
 
+% M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
+% intrinsics that the M18 -lm rollout already links. Verified via
+% truncate(... * scale) so the shell exit code can carry an integer
+% close to the expected value (the Prolog-side truncate makes the
+% result int-typed before is/2 boxes it).
+:- dynamic test_sin_pi_half/2.
+test_sin_pi_half(_, R) :-
+    % sin(pi/2) = 1.0; *100 -> 100. We approximate pi as 22/7 to
+    % avoid needing a runtime pi constant (close enough for the
+    % exit-code precision the test driver carries).
+    X is sin(22/7/2),
+    R is truncate(X * 100).   % ~ 99 (22/7 is slightly off pi)
+
+:- dynamic test_cos_zero/2.
+test_cos_zero(_, R) :-
+    X is cos(0),
+    R is truncate(X * 100).   % 100
+
+:- dynamic test_tan_zero/2.
+test_tan_zero(_, R) :-
+    X is tan(0),
+    R is truncate(X * 100).   % 0
+
+:- dynamic test_log_e/2.
+test_log_e(_, R) :-
+    % log(e^2) = 2; emit via exp + log round-trip.
+    X is log(exp(2)),
+    R is truncate(X).   % 2
+
+:- dynamic test_exp_zero/2.
+test_exp_zero(_, R) :-
+    X is exp(0),
+    R is truncate(X).   % 1
+
 % M14: float-aware comparison ops. Pre-M14, builtin_gt/lt/etc read
 % the register payload as raw i64 -- meaningless when one operand
 % is a Float because float bits aren''t the numeric value. Also,
@@ -885,6 +919,17 @@ test_all :-
                    test_atom_codes_second, 0, 101),
        run_test_r0('length(atom_codes(world)) -> 5',
                    test_atom_codes_length, 0, 5),
+       format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
+       run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
+                   test_sin_pi_half, 0, 99),
+       run_test_r0('truncate(cos(0) * 100) -> 100',
+                   test_cos_zero, 0, 100),
+       run_test_r0('truncate(tan(0) * 100) -> 0',
+                   test_tan_zero, 0, 0),
+       run_test_r0('truncate(log(exp(2))) -> 2',
+                   test_log_e, 0, 2),
+       run_test_r0('truncate(exp(0)) -> 1',
+                   test_exp_zero, 0, 1),
        format('--- M14 float-aware comparisons + float sum ---~n'),
        run_test_r0('1/4 > 0 -> 1', test_cmp_float_gt, 0, 1),
        run_test_r0('-1/4 > 0 -> 0', test_cmp_float_gt_neg, 0, 0),


### PR DESCRIPTION
## Summary

Rounds out the unary math op surface with the five common transcendentals.

| Op | Result | Implementation |
|----|--------|----------------|
| `sin(x)` | Float | `llvm.sin.f64` |
| `cos(x)` | Float | `llvm.cos.f64` |
| `log(x)` | Float (natural log) | `llvm.log.f64` |
| `exp(x)` | Float | `llvm.exp.f64` |
| `tan(x)` | Float | `sin(x) / cos(x)` (no `llvm.tan.f64` intrinsic) |

Operand promotion goes through `value_to_double` (Integer is `sitofp`'d, Float bits are bitcast back). All five return Float regardless of operand tag — matches Prolog's usual behaviour.

**Dispatch extension.** The unary `switch` now has cases for `l` (log), `e` (exp), and refined cases for `c` / `s` / `t`:

- `c` → `ev_ceil_cos`: second byte `e` = ceiling, `o` = cos
- `s` → `ev_sqrt_sign`: second `q` = sqrt, `i` = `ev_sign_or_sin` → third `g` = sign, `n` = sin
- `t` → `ev_trunc_tan`: second byte `r` = truncate, `a` = tan

Module template adds the four new intrinsic declarations (`-lm` already rolling out from M18 picks up the symbols).

## Test plan

- [x] `tests/core/test_wam_llvm_builtin_execution.pl` — 84 cases pass (was 79). New:
  - `truncate(sin(22/7/2) * 100) → 99` (22/7 ≈ π, sin(π/2) = 1.0 — 22/7 is slightly off, hence 99 instead of 100)
  - `truncate(cos(0) * 100) → 100`
  - `truncate(tan(0) * 100) → 0`
  - `truncate(log(exp(2))) → 2` (round-trip)
  - `truncate(exp(0)) → 1`
- [x] `tests/core/test_wam_llvm_findall_execution.pl` — M9 still passes.
- [x] `tests/core/test_wam_llvm_realdata_benchmark.pl` — 31 ancestors, per-iter ~0.057ms, no regression.
- [x] `tests/core/test_wam_llvm_bfs_execution.pl` — 4 cases pass.
- [x] `tests/core/test_wam_llvm_astar_execution.pl` — A*(a,d) → distance 12.0.

Run with `LC_ALL=C.UTF-8`.

## Out of scope

- `asin`, `acos`, `atan`, `atan2`, `pow`, `log/2` (base-N log) — niche; deferred.
- `pi` / `e` as constants — would need to recognize 0-ary atoms in eval_arith.
- Runtime atom interning (would unlock `atom_chars/2`, reverse-mode `atom_codes/2`, `char_code/2`).

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_