### PR TITLE
docs(wam-python): refresh parity audit

### DIFF
--- a/docs/design/WAM_PYTHON_PARITY_AUDIT.md
+++ b/docs/design/WAM_PYTHON_PARITY_AUDIT.md
@@ -17,9 +17,10 @@ matters for parity.
 | --- | --- | --- | --- |
 | Direct fact dispatch | `call_indexed_atom_fact2`, category ancestor helpers | Indexed fact paths | Present |
 | Aggregates | `begin_aggregate`, `end_aggregate` runtime paths | `findall/3`, `aggregate_all/3` families | Present, covered by generated-project E2E |
-| Structural builtins | `member/2`, `length/2` | `member/2`, `length/2` | Present: `member/2` enumerates via builtin choice points |
+| Structural builtins | `member/2`, `length/2` | `member/2`, `length/2` | Present: `member/2` enumerates via builtin choice points; `length/2` covers fixed and generative modes |
 | Type builtins | `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `var/1`, `nonvar/1`, `is_list/1` | Same baseline set | Present |
 | Comparison builtins | `==/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2` | Same baseline set | Present |
+| List ordering | `sort/2`, `msort/2`, `keysort/2` | Same baseline set where present | Present: generated-project E2E covers numeric, atom, duplicate, empty-list, and keyed-pair cases |
 | Unification builtins | `=/2`, `\=/2` | `=/2`, `\=/2` in comparable runtimes | Present |
 | Term inspection | `functor/3`, `arg/3` | `functor/3`, `arg/3` | Present |
 | Univ | `=../2` compose and decompose | `=../2` compose and decompose | Present |
@@ -92,7 +93,9 @@ now share one Python WAM runtime surface.
 ## Remaining Follow-Up
 
 The packaged static runtime now carries the Lua/Rust/Haskell builtin baseline.
-No Python WAM builtin parity gaps are currently tracked here.
+No Python WAM builtin parity gaps are currently tracked here. The current
+Python WAM target file also runs without the earlier plunit choicepoint-warning
+noise in the registry and ITE detection tests.
 
 Completed follow-up:
 
@@ -100,12 +103,17 @@ Completed follow-up:
   type/comparison builtins through the packaged static runtime.
 - Generated-project E2E tests now verify `member/2` enumeration through
   aggregate collection.
+- Generated-project E2E tests now verify `sort/2`, `msort/2`, and `keysort/2`
+  through the packaged static runtime.
+- Python WAM registry and ITE tests now use deterministic assertions where the
+  test only needs the first valid proof, keeping full-suite output warning-free.
 - `compile_wam_runtime_to_python/2` now returns the packaged static runtime,
   removing the separate fallback runtime surface.
 
 ## Verification Commands
 
-Use these checks after touching Python WAM runtime parity:
+Use these checks after touching Python WAM runtime parity. On current `main`,
+`tests/test_wam_python_target.pl` passes 166/166 without choicepoint warnings:
 
 ```sh
 swipl -q -g run_tests -t halt tests/test_wam_python_target.pl


### PR DESCRIPTION
## Summary
- Update the Python WAM parity audit to reflect recently merged runtime support for `sort/2`, `msort/2`, and `keysort/2`.
- Note `length/2` generative-mode coverage in the packaged runtime surface table.
- Record that the full Python WAM target suite now runs without the earlier registry/ITE choicepoint-warning noise.
- Keep the audit's current status explicit: no tracked Python WAM builtin parity gaps remain.

## Tests
- `git diff --check`

## Notes
- Documentation-only change.
- Runtime and test verification referenced in the doc was already run on current `main`: `tests/test_wam_python_target.pl` passes `166/166`.
