### PR TITLE
LLVM WAM: M21 — compound pretty-printing in write/1 and format/2 ~w

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3624,48 +3624,13 @@ builtin_neq:
   ret i1 %neq.r
 
 builtin_write:
-  ; M19: dispatch on tag so write/1 prints Integers, Floats and
-  ; Atoms (via the M12 atom-string table). Compounds and other tags
-  ; print a placeholder `_` -- full term pretty-printing is deferred.
-  %wr.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
-  %wr.tag = call i32 @value_tag(%Value %wr.a1)
-  switch i32 %wr.tag, label %wr.print_anon [
-    i32 0, label %wr.print_atom
-    i32 1, label %wr.print_int
-    i32 2, label %wr.print_float
-  ]
-
-wr.print_int:
-  %wr.pay = call i64 @value_payload(%Value %wr.a1)
-  %wr.fmt_lld = getelementptr [5 x i8], [5 x i8]* @.fmt_lld, i32 0, i32 0
-  call i32 (i8*, ...) @printf(i8* %wr.fmt_lld, i64 %wr.pay)
-  br label %wr.done
-
-wr.print_float:
-  %wr.fbits = call i64 @value_payload(%Value %wr.a1)
-  %wr.fval = bitcast i64 %wr.fbits to double
-  %wr.fmt_dbl = getelementptr [3 x i8], [3 x i8]* @.fmt_dbl, i32 0, i32 0
-  call i32 (i8*, ...) @printf(i8* %wr.fmt_dbl, double %wr.fval)
-  br label %wr.done
-
-wr.print_atom:
-  %wr.aid = call i64 @value_payload(%Value %wr.a1)
-  %wr.astr = call i8* @wam_atom_to_string(i64 %wr.aid)
-  %wr.astr_null = icmp eq i8* %wr.astr, null
-  br i1 %wr.astr_null, label %wr.done, label %wr.print_atom_go
-wr.print_atom_go:
-  %wr.fmt_str = getelementptr [3 x i8], [3 x i8]* @.fmt_str, i32 0, i32 0
-  call i32 (i8*, ...) @printf(i8* %wr.fmt_str, i8* %wr.astr)
-  br label %wr.done
-
-wr.print_anon:
-  ; Compound / Ref / Unbound / Bool -- placeholder. Full pretty-
-  ; printing of compounds (with parens + args) is deferred; format/2
-  ; with ~w handles the more common per-arg printing.
-  call i32 @putchar(i32 95)
-  br label %wr.done
-
-wr.done:
+  ; M21: route through @wam_write_value which handles all tags
+  ; (Integer, Float, Atom, Compound, Unbound). Compounds print as
+  ; ``functor(arg1, arg2, ...)`` with recursive nested terms; the
+  ; ``[|]/2`` functor special-cases to list notation. The previous
+  ; M19 inline dispatch lives on inside the helper.
+  %wr.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  call void @wam_write_value(%WamState* %vm, %Value %wr.a1)
   ret i1 true
 
 builtin_nl:
@@ -4576,50 +4541,19 @@ f2.directive_w:
   br i1 %f2.has_arg, label %f2.read_arg, label %f2.no_arg
 
 f2.read_arg:
+  ; M21: route ~w through @wam_write_value so the per-tag dispatch
+  ; (including compound pretty-printing as ``functor(...)`` and list
+  ; notation for [|]/2 chains) is shared with write/1. Pre-M21 the
+  ; inline switch printed Compounds as ``_``.
   %f2.cp_bits = extractvalue %Value %f2.args_d, 1
   %f2.cp = inttoptr i64 %f2.cp_bits to %Compound*
   %f2.cargs_slot = getelementptr %Compound, %Compound* %f2.cp, i32 0, i32 2
   %f2.cargs = load %Value*, %Value** %f2.cargs_slot
   %f2.head_ptr = getelementptr %Value, %Value* %f2.cargs, i32 0
   %f2.head_raw = load %Value, %Value* %f2.head_ptr
-  %f2.head = call %Value @wam_deref_value(%WamState* %vm, %Value %f2.head_raw)
   %f2.tail_ptr = getelementptr %Value, %Value* %f2.cargs, i32 1
   %f2.tail = load %Value, %Value* %f2.tail_ptr
-  %f2.head_tag = extractvalue %Value %f2.head, 0
-  switch i32 %f2.head_tag, label %f2.print_anon [
-    i32 0, label %f2.print_atom
-    i32 1, label %f2.print_int
-    i32 2, label %f2.print_float
-  ]
-
-f2.print_int:
-  %f2.iv = extractvalue %Value %f2.head, 1
-  %f2.fmt_lld = getelementptr [5 x i8], [5 x i8]* @.fmt_lld, i32 0, i32 0
-  call i32 (i8*, ...) @printf(i8* %f2.fmt_lld, i64 %f2.iv)
-  br label %f2.after_w
-
-f2.print_float:
-  %f2.fbits = extractvalue %Value %f2.head, 1
-  %f2.fval = bitcast i64 %f2.fbits to double
-  %f2.fmt_dbl = getelementptr [3 x i8], [3 x i8]* @.fmt_dbl, i32 0, i32 0
-  call i32 (i8*, ...) @printf(i8* %f2.fmt_dbl, double %f2.fval)
-  br label %f2.after_w
-
-f2.print_atom:
-  %f2.aid = extractvalue %Value %f2.head, 1
-  %f2.astr = call i8* @wam_atom_to_string(i64 %f2.aid)
-  %f2.astr_null = icmp eq i8* %f2.astr, null
-  br i1 %f2.astr_null, label %f2.after_w, label %f2.print_atom_go
-f2.print_atom_go:
-  %f2.fmt_str = getelementptr [3 x i8], [3 x i8]* @.fmt_str, i32 0, i32 0
-  call i32 (i8*, ...) @printf(i8* %f2.fmt_str, i8* %f2.astr)
-  br label %f2.after_w
-
-f2.print_anon:
-  ; Compound and other tags: print underscore placeholder. Full
-  ; pretty-printing is deferred; effective_distance''s format strings
-  ; only use atoms, integers, and floats.
-  call i32 @putchar(i32 95)
+  call void @wam_write_value(%WamState* %vm, %Value %f2.head_raw)
   br label %f2.after_w
 
 f2.after_w:

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -1744,6 +1744,176 @@ default_case:
 ; "sort a flat list of ints" case; structural ordering is M11 work.
 ; Returns the new list's head Value (Compound, or the [] Atom when
 ; the input is empty).
+
+; M21: recursive pretty-printer used by write/1 and friends.
+; Prints Integers, Floats, Atoms via existing format strings, and
+; Compounds as either list notation ([a, b, c] when the functor is
+; [|]/2) or term notation (functor(arg, ...)) otherwise. Unbound
+; cells render as `_`; unknown atoms (id out of range) render as
+; `?`. Recurses into compound args -- no depth limit, so a cyclic
+; term would loop, but the rest of the runtime never produces
+; cycles.
+define void @wam_write_value(%WamState* %vm, %Value %v) {
+entry:
+  %wv.d = call %Value @wam_deref_value(%WamState* %vm, %Value %v)
+  %wv.tag = extractvalue %Value %wv.d, 0
+  switch i32 %wv.tag, label %wv.unbound [
+    i32 0, label %wv.atom
+    i32 1, label %wv.int
+    i32 2, label %wv.float
+    i32 3, label %wv.compound
+  ]
+
+wv.int:
+  %wv.iv = extractvalue %Value %wv.d, 1
+  %wv.fmt_lld = getelementptr [5 x i8], [5 x i8]* @.fmt_lld, i32 0, i32 0
+  call i32 (i8*, ...) @printf(i8* %wv.fmt_lld, i64 %wv.iv)
+  ret void
+
+wv.float:
+  %wv.fb = extractvalue %Value %wv.d, 1
+  %wv.fv = bitcast i64 %wv.fb to double
+  %wv.fmt_dbl = getelementptr [3 x i8], [3 x i8]* @.fmt_dbl, i32 0, i32 0
+  call i32 (i8*, ...) @printf(i8* %wv.fmt_dbl, double %wv.fv)
+  ret void
+
+wv.atom:
+  %wv.aid = extractvalue %Value %wv.d, 1
+  %wv.eid = load i64, i64* @wam_empty_list_atom_id
+  %wv.is_empty = icmp eq i64 %wv.aid, %wv.eid
+  br i1 %wv.is_empty, label %wv.empty_list, label %wv.atom_str
+
+wv.empty_list:
+  call i32 @putchar(i32 91)
+  call i32 @putchar(i32 93)
+  ret void
+
+wv.atom_str:
+  %wv.str = call i8* @wam_atom_to_string(i64 %wv.aid)
+  %wv.null = icmp eq i8* %wv.str, null
+  br i1 %wv.null, label %wv.atom_unknown, label %wv.atom_go
+
+wv.atom_go:
+  %wv.fmt_str = getelementptr [3 x i8], [3 x i8]* @.fmt_str, i32 0, i32 0
+  call i32 (i8*, ...) @printf(i8* %wv.fmt_str, i8* %wv.str)
+  ret void
+
+wv.atom_unknown:
+  call i32 @putchar(i32 63)
+  ret void
+
+wv.unbound:
+  call i32 @putchar(i32 95)
+  ret void
+
+wv.compound:
+  %wv.cp_bits = extractvalue %Value %wv.d, 1
+  %wv.cp = inttoptr i64 %wv.cp_bits to %Compound*
+  %wv.fn_slot = getelementptr %Compound, %Compound* %wv.cp, i32 0, i32 0
+  %wv.fn_ptr = load i8*, i8** %wv.fn_slot
+  %wv.ar_slot = getelementptr %Compound, %Compound* %wv.cp, i32 0, i32 1
+  %wv.arity = load i32, i32* %wv.ar_slot
+  %wv.args_slot = getelementptr %Compound, %Compound* %wv.cp, i32 0, i32 2
+  %wv.args = load %Value*, %Value** %wv.args_slot
+  ; Detect list notation by comparing the functor ptr to @.fn__5B_7C_5D
+  ; (the eager-registered [|]/2 string). Compound args of [|] are
+  ; (Head, Tail) where Tail recurses through more [|] cells or
+  ; terminates in the [] Atom.
+  %wv.bracket = getelementptr [4 x i8], [4 x i8]* @.fn__5B_7C_5D, i32 0, i32 0
+  %wv.is_list = icmp eq i8* %wv.fn_ptr, %wv.bracket
+  br i1 %wv.is_list, label %wv.list, label %wv.term
+
+wv.list:
+  call i32 @putchar(i32 91)
+  %wv.h0_ptr = getelementptr %Value, %Value* %wv.args, i32 0
+  %wv.h0 = load %Value, %Value* %wv.h0_ptr
+  call void @wam_write_value(%WamState* %vm, %Value %wv.h0)
+  %wv.t0_ptr = getelementptr %Value, %Value* %wv.args, i32 1
+  %wv.t0 = load %Value, %Value* %wv.t0_ptr
+  br label %wv.list_walk
+
+wv.list_walk:
+  %wv.cur = phi %Value [ %wv.t0, %wv.list ], [ %wv.cur_next, %wv.list_step ]
+  %wv.cur_d = call %Value @wam_deref_value(%WamState* %vm, %Value %wv.cur)
+  %wv.cur_tag = extractvalue %Value %wv.cur_d, 0
+  %wv.cur_is_atom = icmp eq i32 %wv.cur_tag, 0
+  br i1 %wv.cur_is_atom, label %wv.list_check_end, label %wv.list_check_cons
+
+wv.list_check_end:
+  %wv.cur_aid = extractvalue %Value %wv.cur_d, 1
+  %wv.eid2 = load i64, i64* @wam_empty_list_atom_id
+  %wv.cur_is_end = icmp eq i64 %wv.cur_aid, %wv.eid2
+  br i1 %wv.cur_is_end, label %wv.list_done, label %wv.list_improper
+
+wv.list_check_cons:
+  %wv.cur_is_cmp = icmp eq i32 %wv.cur_tag, 3
+  br i1 %wv.cur_is_cmp, label %wv.list_check_cons2, label %wv.list_improper
+
+wv.list_check_cons2:
+  %wv.cur_cp_bits = extractvalue %Value %wv.cur_d, 1
+  %wv.cur_cp = inttoptr i64 %wv.cur_cp_bits to %Compound*
+  %wv.cur_fn_slot = getelementptr %Compound, %Compound* %wv.cur_cp, i32 0, i32 0
+  %wv.cur_fn_ptr = load i8*, i8** %wv.cur_fn_slot
+  %wv.bracket2 = getelementptr [4 x i8], [4 x i8]* @.fn__5B_7C_5D, i32 0, i32 0
+  %wv.cur_is_list = icmp eq i8* %wv.cur_fn_ptr, %wv.bracket2
+  br i1 %wv.cur_is_list, label %wv.list_step, label %wv.list_improper
+
+wv.list_step:
+  call i32 @putchar(i32 44)
+  call i32 @putchar(i32 32)
+  %wv.cur_args_slot = getelementptr %Compound, %Compound* %wv.cur_cp, i32 0, i32 2
+  %wv.cur_args = load %Value*, %Value** %wv.cur_args_slot
+  %wv.cur_h_ptr = getelementptr %Value, %Value* %wv.cur_args, i32 0
+  %wv.cur_h = load %Value, %Value* %wv.cur_h_ptr
+  call void @wam_write_value(%WamState* %vm, %Value %wv.cur_h)
+  %wv.cur_t_ptr = getelementptr %Value, %Value* %wv.cur_args, i32 1
+  %wv.cur_next = load %Value, %Value* %wv.cur_t_ptr
+  br label %wv.list_walk
+
+wv.list_improper:
+  call i32 @putchar(i32 124)
+  call void @wam_write_value(%WamState* %vm, %Value %wv.cur_d)
+  br label %wv.list_done
+
+wv.list_done:
+  call i32 @putchar(i32 93)
+  ret void
+
+wv.term:
+  %wv.fmt_str2 = getelementptr [3 x i8], [3 x i8]* @.fmt_str, i32 0, i32 0
+  call i32 (i8*, ...) @printf(i8* %wv.fmt_str2, i8* %wv.fn_ptr)
+  call i32 @putchar(i32 40)
+  br label %wv.term_loop
+
+wv.term_loop:
+  %wv.ti = phi i32 [ 0, %wv.term ], [ %wv.ti_next, %wv.term_after ]
+  %wv.done_t = icmp sge i32 %wv.ti, %wv.arity
+  br i1 %wv.done_t, label %wv.term_done, label %wv.term_iter
+
+wv.term_iter:
+  %wv.first = icmp eq i32 %wv.ti, 0
+  br i1 %wv.first, label %wv.term_arg, label %wv.term_sep
+
+wv.term_sep:
+  call i32 @putchar(i32 44)
+  call i32 @putchar(i32 32)
+  br label %wv.term_arg
+
+wv.term_arg:
+  %wv.arg_ptr = getelementptr %Value, %Value* %wv.args, i32 %wv.ti
+  %wv.arg = load %Value, %Value* %wv.arg_ptr
+  call void @wam_write_value(%WamState* %vm, %Value %wv.arg)
+  br label %wv.term_after
+
+wv.term_after:
+  %wv.ti_next = add i32 %wv.ti, 1
+  br label %wv.term_loop
+
+wv.term_done:
+  call i32 @putchar(i32 41)
+  ret void
+}
+
 define %Value @wam_msort_list(%WamState* %vm, %Value %head_in) inlinehint nounwind {
 entry:
   call void @wam_arena_ensure()

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -459,6 +459,38 @@ test_fmt_tilde_escape(_, R) :-
     format('about ~~w~n', []),
     R is 1.
 
+% M21: compound pretty-printing through write/1. The runtime helper
+% @wam_write_value walks Compounds recursively, printing them as
+% functor(arg, ...) or list notation for [|]/2 chains. Tested via
+% format/2 ~w which now routes through the same helper -- the test
+% predicates use format() so stdout capture works.
+:- dynamic test_write_list3/2.
+test_write_list3(_, R) :-
+    L = [1, 2, 3],
+    format('~w', [L]),
+    R is 1.
+
+:- dynamic test_write_pair/2.
+test_write_pair(_, R) :-
+    format('~w', [a-b]),
+    R is 1.
+
+:- dynamic test_write_empty/2.
+test_write_empty(_, R) :-
+    format('~w', [[]]),
+    R is 1.
+
+:- dynamic test_write_nested/2.
+test_write_nested(_, R) :-
+    format('~w', [[1, [2, 3], 4]]),
+    R is 1.
+
+:- dynamic test_write_compound/2.
+test_write_compound(_, R) :-
+    T = foo(1, hello, 3.5),
+    format('~w', [T]),
+    R is 1.
+
 % M15: precision directives ~Nf (fixed-point) and ~Ne (scientific).
 % Parses the digit run between ~ and f/e at runtime, then routes the
 % next arg through printf "%.*f" / "%.*e" with the parsed precision.
@@ -949,6 +981,13 @@ test_all :-
                     "color=red\n"),
        run_fmt_test('"about ~~w~n" tilde escape', test_fmt_tilde_escape,
                     "about ~w\n"),
+       format('--- M21 compound pretty-printing through write/1 ---~n'),
+       run_fmt_test('~w of [1,2,3]', test_write_list3, "[1, 2, 3]"),
+       run_fmt_test('~w of a-b', test_write_pair, "-(a, b)"),
+       run_fmt_test('~w of []', test_write_empty, "[]"),
+       run_fmt_test('~w of [1,[2,3],4]', test_write_nested, "[1, [2, 3], 4]"),
+       run_fmt_test('~w of foo(1, hello, 3.5)', test_write_compound,
+                    "foo(1, hello, 3.5)"),
        format('--- M15 precision directives (~~Nf / ~~Ne) ---~n'),
        run_fmt_test('"~6f~n" with 0.25', test_fmt_6f,
                     "0.250000\n"),


### PR DESCRIPTION
## Summary

Adds `@wam_write_value` — a recursive pretty-printer that walks Compounds and emits either list notation (`[a, b, c]`) or term notation (`foo(arg, ...)`).

Both `write/1` and `format/2`'s `~w` route through it. Pre-M21 anything compound printed as just `_`, which made `format("~w", [List])` give useless output even though the rest of the runtime built the list correctly.

## Implementation

- **List detection** uses a functor-pointer equality test against `@.fn__5B_7C_5D` (the M9 eager-registered `[|]/2` string). No string compare needed at runtime.
- **`[]`** is detected via atom-id equality against `@wam_empty_list_atom_id`, so a bare `[]` (not just a list terminator) renders correctly.
- **Improper lists** like `[1|X]` emit `|<tail>` and close with `]`.
- **Recursion** is direct (no depth cap) — runtime never produces cyclic terms, so this is safe in practice.

Per-tag behaviour:

| Tag | Output |
|-----|--------|
| Integer | `printf("%lld", payload)` |
| Float | `printf("%g", bitcast bits to double)` |
| Atom | `wam_atom_to_string` + `printf("%s", ...)` (or `[]` for the empty-list atom) |
| Compound | list notation if functor == `@.fn__5B_7C_5D`, else `functor(arg, ...)` |
| Unbound | `putchar('_')` |
| Unknown atom id (out of table range) | `putchar('?')` |

## Test plan

- [x] `tests/core/test_wam_llvm_builtin_execution.pl` — 89 cases pass (was 84). New (captured via stdout):
  - `~w of [1, 2, 3]` → `"[1, 2, 3]"`
  - `~w of a-b` → `"-(a, b)"` (no operator notation yet — full op-aware printing is a follow-up)
  - `~w of []` → `"[]"`
  - `~w of [1, [2, 3], 4]` → `"[1, [2, 3], 4]"` (nested list recursion)
  - `~w of foo(1, hello, 3.5)` → `"foo(1, hello, 3.5)"`
- [x] `tests/core/test_wam_llvm_findall_execution.pl` — M9 still passes.
- [x] `tests/core/test_wam_llvm_realdata_benchmark.pl` — 31 ancestors, per-iter ~0.061ms, no regression.
- [x] `tests/core/test_wam_llvm_bfs_execution.pl` — 4 cases pass.
- [x] `tests/core/test_wam_llvm_astar_execution.pl` — A*(a,d) → distance 12.0.

Run with `LC_ALL=C.UTF-8`.

## Out of scope

- **Operator notation**: `a-b` currently prints as `-(a, b)`. Making it `a-b` requires an operator priority/associativity table at runtime and would change the output of many programs — natural follow-up but a separate PR.
- **`~q` (quoted print)**: needs atom-needs-quoting detection (whitespace, special chars, leading uppercase). Builds on the same printer plumbing.
- **Cyclic term protection**: if a term cycles through the heap, the recursion loops. The current runtime never produces cycles so it's safe in practice.

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_