### PR TITLE
LLVM WAM: M22 — single-char operator notation in pretty-printer

### DIFF
--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -1880,13 +1880,74 @@ wv.list_done:
   ret void
 
 wv.term:
+  ; M22: detect simple infix / prefix operator notation before
+  ; falling through to the canonical functor(args) form. Only
+  ; single-char operators are recognised here -- 2-char operators
+  ; like ``->`` / ``:-`` / ``=:=`` need a small lookup and are
+  ; deferred to a follow-up.
+  %wv.fn1_ptr = getelementptr i8, i8* %wv.fn_ptr, i32 1
+  %wv.fn1 = load i8, i8* %wv.fn1_ptr
+  %wv.fn1_zero = icmp eq i8 %wv.fn1, 0
+  br i1 %wv.fn1_zero, label %wv.maybe_op, label %wv.canonical
+
+wv.maybe_op:
+  %wv.fn0_char = load i8, i8* %wv.fn_ptr
+  %wv.is_binary = icmp eq i32 %wv.arity, 2
+  %wv.is_unary = icmp eq i32 %wv.arity, 1
+  br i1 %wv.is_binary, label %wv.binary_op, label %wv.unary_check
+
+wv.binary_op:
+  ; Single-byte binary operators that print as infix without parens.
+  ; Precedence is not modelled yet -- a child operator with lower
+  ; priority than its parent should be parenthesised, but the
+  ; runtime doesn''t have an op-priority table yet.
+  switch i8 %wv.fn0_char, label %wv.canonical [
+    i8 43, label %wv.infix  ; ''+''
+    i8 45, label %wv.infix  ; ''-''
+    i8 42, label %wv.infix  ; ''*''
+    i8 47, label %wv.infix  ; ''/''
+    i8 61, label %wv.infix  ; ''=''
+    i8 60, label %wv.infix  ; ''<''
+    i8 62, label %wv.infix  ; ''>''
+    i8 58, label %wv.infix  ; '':''
+    i8 94, label %wv.infix  ; ''^''
+  ]
+
+wv.infix:
+  %wv.iarg0_ptr = getelementptr %Value, %Value* %wv.args, i32 0
+  %wv.iarg0 = load %Value, %Value* %wv.iarg0_ptr
+  call void @wam_write_value(%WamState* %vm, %Value %wv.iarg0)
+  %wv.fn0_i32 = zext i8 %wv.fn0_char to i32
+  call i32 @putchar(i32 %wv.fn0_i32)
+  %wv.iarg1_ptr = getelementptr %Value, %Value* %wv.args, i32 1
+  %wv.iarg1 = load %Value, %Value* %wv.iarg1_ptr
+  call void @wam_write_value(%WamState* %vm, %Value %wv.iarg1)
+  ret void
+
+wv.unary_check:
+  br i1 %wv.is_unary, label %wv.maybe_prefix, label %wv.canonical
+
+wv.maybe_prefix:
+  ; Only ``-`` is a meaningful single-char prefix op; ``+`` is a no-op
+  ; that real code never writes out. ``\+`` is two characters.
+  %wv.is_neg = icmp eq i8 %wv.fn0_char, 45
+  br i1 %wv.is_neg, label %wv.prefix, label %wv.canonical
+
+wv.prefix:
+  call i32 @putchar(i32 45)
+  %wv.parg_ptr = getelementptr %Value, %Value* %wv.args, i32 0
+  %wv.parg = load %Value, %Value* %wv.parg_ptr
+  call void @wam_write_value(%WamState* %vm, %Value %wv.parg)
+  ret void
+
+wv.canonical:
   %wv.fmt_str2 = getelementptr [3 x i8], [3 x i8]* @.fmt_str, i32 0, i32 0
   call i32 (i8*, ...) @printf(i8* %wv.fmt_str2, i8* %wv.fn_ptr)
   call i32 @putchar(i32 40)
   br label %wv.term_loop
 
 wv.term_loop:
-  %wv.ti = phi i32 [ 0, %wv.term ], [ %wv.ti_next, %wv.term_after ]
+  %wv.ti = phi i32 [ 0, %wv.canonical ], [ %wv.ti_next, %wv.term_after ]
   %wv.done_t = icmp sge i32 %wv.ti, %wv.arity
   br i1 %wv.done_t, label %wv.term_done, label %wv.term_iter
 

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -491,6 +491,33 @@ test_write_compound(_, R) :-
     format('~w', [T]),
     R is 1.
 
+% M22: operator notation in pretty-printer. Single-char binary ops
+% print as ``arg1 op arg2``; unary ``-`` prints as ``-arg``.
+% Precedence isn''t modelled, so ``1+2*3`` will round-trip with all
+% operators flat (no parens) -- enough to read but not strictly
+% re-parseable for compound expressions.
+:- dynamic test_write_add/2.
+test_write_add(_, R) :- T = 1+2, format('~w', [T]), R is 1.
+
+:- dynamic test_write_mul_add/2.
+test_write_mul_add(_, R) :-
+    T = 1+2*3, format('~w', [T]), R is 1.
+
+:- dynamic test_write_eq/2.
+test_write_eq(_, R) :- T = (x=y), format('~w', [T]), R is 1.
+
+:- dynamic test_write_colon/2.
+test_write_colon(_, R) :- T = a:b, format('~w', [T]), R is 1.
+
+:- dynamic test_write_neg/2.
+test_write_neg(_, R) :- T = -(x), format('~w', [T]), R is 1.
+
+:- dynamic test_write_list_of_pairs/2.
+test_write_list_of_pairs(_, R) :-
+    L = [a-1, b-2],
+    format('~w', [L]),
+    R is 1.
+
 % M15: precision directives ~Nf (fixed-point) and ~Ne (scientific).
 % Parses the digit run between ~ and f/e at runtime, then routes the
 % next arg through printf "%.*f" / "%.*e" with the parsed precision.
@@ -983,11 +1010,20 @@ test_all :-
                     "about ~w\n"),
        format('--- M21 compound pretty-printing through write/1 ---~n'),
        run_fmt_test('~w of [1,2,3]', test_write_list3, "[1, 2, 3]"),
-       run_fmt_test('~w of a-b', test_write_pair, "-(a, b)"),
+       run_fmt_test('~w of a-b (M22 infix notation)',
+                    test_write_pair, "a-b"),
        run_fmt_test('~w of []', test_write_empty, "[]"),
        run_fmt_test('~w of [1,[2,3],4]', test_write_nested, "[1, [2, 3], 4]"),
        run_fmt_test('~w of foo(1, hello, 3.5)', test_write_compound,
                     "foo(1, hello, 3.5)"),
+       format('--- M22 infix / prefix operator notation ---~n'),
+       run_fmt_test('~w of 1+2', test_write_add, "1+2"),
+       run_fmt_test('~w of 1+2*3', test_write_mul_add, "1+2*3"),
+       run_fmt_test('~w of x=y', test_write_eq, "x=y"),
+       run_fmt_test('~w of a:b', test_write_colon, "a:b"),
+       run_fmt_test('~w of -(x)', test_write_neg, "-x"),
+       run_fmt_test('~w of [a-1, b-2]',
+                    test_write_list_of_pairs, "[a-1, b-2]"),
        format('--- M15 precision directives (~~Nf / ~~Ne) ---~n'),
        run_fmt_test('"~6f~n" with 0.25', test_fmt_6f,
                     "0.250000\n"),


### PR DESCRIPTION
## Summary

`@wam_write_value` now detects simple infix and prefix operators before falling through to the canonical `functor(args)` form. Direct follow-up to M21.

**Recognised operators** (single-char functors, detected via direct byte comparison — no runtime string compare):

| Arity | Op chars | Output |
|-------|----------|--------|
| 2 | `+`, `-`, `*`, `/`, `=`, `<`, `>`, `:`, `^` | `arg1 op arg2` |
| 1 | `-` | `-arg` |

Detection is shallow on purpose: only operators whose functor is exactly 1 byte (`fn[1] == 0`). Two-char operators (`->`, `:-`, `=:=`, etc.) need a small lookup and are deferred. Precedence is also not modelled — a child operator with lower priority than its parent should be parenthesised, but `1+2*3` round-trips without parens (still readable, just not strictly re-parseable for compound expressions).

## Test plan

The M21 test for `~w of a-b` previously expected `-(a, b)` (canonical form); it now expects `a-b` — that's the whole point of this change.

- [x] `tests/core/test_wam_llvm_builtin_execution.pl` — 95 cases pass (was 89). New:
  - `1+2` → `"1+2"`
  - `1+2*3` → `"1+2*3"` (no precedence parens)
  - `(x = y)` → `"x=y"`
  - `a:b` → `"a:b"`
  - `-(x)` → `"-x"` (prefix)
  - `[a-1, b-2]` → `"[a-1, b-2]"` (op notation composes with list)
- [x] `tests/core/test_wam_llvm_findall_execution.pl` — M9 still passes.
- [x] `tests/core/test_wam_llvm_realdata_benchmark.pl` — 31 ancestors, per-iter ~0.051ms, no regression.
- [x] `tests/core/test_wam_llvm_bfs_execution.pl` — 4 cases pass.
- [x] `tests/core/test_wam_llvm_astar_execution.pl` — A*(a,d) → distance 12.0.

Run with `LC_ALL=C.UTF-8`.

## Out of scope

- **Two-char operators**: `->`, `:-`, `=:=`, `==`, `\=`, `=<`, `>=`, `//`, `**`, etc. Would need a small lookup keyed off `fn[0]`/`fn[1]` and printing the op as a 2-byte string. Natural follow-up.
- **Precedence-aware parens**: requires an op priority/associativity table at runtime and a "context priority" recursion through the printer. Substantial.
- **Spaces around binary ops**: SWI prints `1 + 2` (with spaces) for the canonical reader path but `1+2` (no spaces) for `~w`. Current choice matches `~w` convention.

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_