### PR TITLE
feat(wam-clojure): materialize constrained sub_atom/5 source mode

### DIFF
--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1500,6 +1500,21 @@
                           (or (= sub-text ::var) (= sub-text piece)))]
            {:bindings bindings}))))))
 
+(defn sub-atom-source-results [state source before length after sub]
+  (let [before-n (sub-atom-int-value state before)
+        length-n (sub-atom-int-value state length)
+        after-n (sub-atom-int-value state after)
+        sub-text (atom-number-text state sub)]
+    (when (and (logic-var? source)
+               (= before-n 0)
+               (= after-n 0)
+               (some? sub-text)
+               (or (nil? length-n) (= length-n (count sub-text)))
+               (or (logic-var? length) (= length ::unbound) (some? length-n)))
+      [(cond-> {:bindings {1 sub-text}}
+         (or (logic-var? length) (= length ::unbound))
+         (assoc-in [:bindings 3] (count sub-text)))])))
+
 (defn apply-sub-atom-solution [base-state resume-pc]
   (let [source (deref-value (:bindings base-state)
                             (or (reg-get-raw base-state "A1") ::unbound))
@@ -1512,8 +1527,9 @@
         sub (deref-value (:bindings base-state)
                          (or (reg-get-raw base-state "A5") ::unbound))
         text (atom-number-text base-state source)]
-    (if-let [results (and (some? text)
-                          (sub-atom-solution-results base-state text before length after sub))]
+    (if-let [results (or (and (some? text)
+                              (sub-atom-solution-results base-state text before length after sub))
+                         (sub-atom-source-results base-state source before length after sub))]
       (apply-first-foreign-solution base-state resume-pc results)
       (backtrack base-state))))
 

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -225,6 +225,8 @@
 :- dynamic user:wam_sub_atom_numeric_source_arg/1.
 :- dynamic user:wam_sub_atom_numeric_sub_arg/1.
 :- dynamic user:wam_sub_atom_unbound_source/1.
+:- dynamic user:wam_sub_atom_materialize_source/0.
+:- dynamic user:wam_sub_atom_materialize_source_length/1.
 :- dynamic user:wam_arith_eq_42/1.
 :- dynamic user:wam_arith_eq_float/1.
 :- dynamic user:wam_arith_neq_42/1.
@@ -471,6 +473,8 @@ user:wam_sub_atom_no_match :- sub_atom(abc, _, _, _, xyz).
 user:wam_sub_atom_numeric_source_arg(A) :- sub_atom(A, 1, 3, 1, 234).
 user:wam_sub_atom_numeric_sub_arg(S) :- sub_atom(12345, 1, 2, _, S).
 user:wam_sub_atom_unbound_source(_) :- user:wam_unbound_arg(A), sub_atom(A, 0, 1, _, _).
+user:wam_sub_atom_materialize_source :- sub_atom(A, 0, 1, 0, a), A = a.
+user:wam_sub_atom_materialize_source_length(N) :- sub_atom(A, 0, N, 0, abc), A = abc.
 user:wam_arith_eq_42(X) :- X =:= 42.
 user:wam_arith_eq_float(X) :- X =:= 3.5.
 user:wam_arith_neq_42(X) :- X =\= 42.
@@ -722,6 +726,8 @@ run_smoke :-
           user:wam_sub_atom_numeric_source_arg/1,
           user:wam_sub_atom_numeric_sub_arg/1,
           user:wam_sub_atom_unbound_source/1,
+          user:wam_sub_atom_materialize_source/0,
+          user:wam_sub_atom_materialize_source_length/1,
           user:wam_arith_eq_42/1,
           user:wam_arith_eq_float/1,
           user:wam_arith_neq_42/1,
@@ -1153,6 +1159,9 @@ smoke_cases([
     case('wam_sub_atom_numeric_source_arg/1', 12345, "true"),
     case('wam_sub_atom_numeric_sub_arg/1', 23, "true"),
     case('wam_sub_atom_unbound_source/1', a, "false"),
+    case('wam_sub_atom_materialize_source/0', no_args, "true"),
+    case('wam_sub_atom_materialize_source_length/1', 3, "true"),
+    case('wam_sub_atom_materialize_source_length/1', 2, "false"),
     case('wam_arith_eq_42/1', 42, "true"),
     case('wam_arith_eq_42/1', 3.5, "false"),
     case('wam_arith_eq_float/1', 3.5, "true"),


### PR DESCRIPTION
## Summary

- Add bounded source materialization for Clojure WAM `sub_atom/5` when the source is unbound but the substring and exact bounds determine a single source value.
- Support the constrained shape `sub_atom(Source, 0, Length, 0, Sub)` where `Sub` is bound and `Length` is either matching or unbound.
- Add runtime smoke coverage for materializing the source and for binding the inferred length.

## Why

The previous broad unbound-source case remains intentionally unsupported because `sub_atom(Source, 0, 1, _, _)` is unbounded. This PR only enables the finite case where `Before = 0`, `After = 0`, and the bound substring fully determines the source.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
