### PR TITLE
LLVM WAM: M23 — 2-char symbolic operator notation in pretty-printer

### DIFF
--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -1880,21 +1880,67 @@ wv.list_done:
   ret void
 
 wv.term:
-  ; M22: detect simple infix / prefix operator notation before
-  ; falling through to the canonical functor(args) form. Only
-  ; single-char operators are recognised here -- 2-char operators
-  ; like ``->`` / ``:-`` / ``=:=`` need a small lookup and are
-  ; deferred to a follow-up.
+  ; M22 / M23: detect infix / prefix operator notation before
+  ; falling through to the canonical functor(args) form.
+  ; Single-char ops (fn[1] == 0): M22 path.
+  ; Two-char ops (fn[1] != 0, fn[2] == 0): M23 path. Symbolic 2-byte
+  ; operators like ``->`` / ``:-`` / ``==`` / ``=<`` print without
+  ; spaces; word-like 2-char ops (``is``, ``mod``, ``xor``) need
+  ; word-boundary spacing and are deferred.
   %wv.fn1_ptr = getelementptr i8, i8* %wv.fn_ptr, i32 1
   %wv.fn1 = load i8, i8* %wv.fn1_ptr
   %wv.fn1_zero = icmp eq i8 %wv.fn1, 0
-  br i1 %wv.fn1_zero, label %wv.maybe_op, label %wv.canonical
+  br i1 %wv.fn1_zero, label %wv.maybe_op, label %wv.maybe_op2
 
 wv.maybe_op:
   %wv.fn0_char = load i8, i8* %wv.fn_ptr
   %wv.is_binary = icmp eq i32 %wv.arity, 2
   %wv.is_unary = icmp eq i32 %wv.arity, 1
   br i1 %wv.is_binary, label %wv.binary_op, label %wv.unary_check
+
+wv.maybe_op2:
+  ; Only consider 2-char ops for arity=2.
+  %wv.b2 = icmp eq i32 %wv.arity, 2
+  br i1 %wv.b2, label %wv.check_2char, label %wv.canonical
+
+wv.check_2char:
+  ; fn[2] must be 0 -- ops are exactly 2 bytes.
+  %wv.fn2_ptr = getelementptr i8, i8* %wv.fn_ptr, i32 2
+  %wv.fn2 = load i8, i8* %wv.fn2_ptr
+  %wv.fn2_zero = icmp eq i8 %wv.fn2, 0
+  br i1 %wv.fn2_zero, label %wv.binary_op2, label %wv.canonical
+
+wv.binary_op2:
+  ; Pack (fn[0], fn[1]) into i16: (fn[0] << 8) | fn[1].
+  %wv.fn0_c2 = load i8, i8* %wv.fn_ptr
+  %wv.fn0_z16 = zext i8 %wv.fn0_c2 to i16
+  %wv.fn1_z16 = zext i8 %wv.fn1 to i16
+  %wv.fn0_shift = shl i16 %wv.fn0_z16, 8
+  %wv.packed = or i16 %wv.fn0_shift, %wv.fn1_z16
+  switch i16 %wv.packed, label %wv.canonical [
+    i16 11582, label %wv.infix2  ; ''-'' ''>'' -> ``->``
+    i16 14893, label %wv.infix2  ; '':'' ''-'' -> ``:-``
+    i16 15677, label %wv.infix2  ; ''='' ''='' -> ``==``
+    i16 23613, label %wv.infix2  ; ''\\'' ''='' -> ``\\=``
+    i16 15676, label %wv.infix2  ; ''='' ''<'' -> ``=<``
+    i16 15933, label %wv.infix2  ; ''>'' ''='' -> ``>=``
+    i16 12079, label %wv.infix2  ; ''/'' ''/'' -> ``//``
+    i16 10794, label %wv.infix2  ; ''*'' ''*'' -> ``**``
+  ]
+
+wv.infix2:
+  %wv.i2_a0_ptr = getelementptr %Value, %Value* %wv.args, i32 0
+  %wv.i2_a0 = load %Value, %Value* %wv.i2_a0_ptr
+  call void @wam_write_value(%WamState* %vm, %Value %wv.i2_a0)
+  %wv.i2_fn0_c = load i8, i8* %wv.fn_ptr
+  %wv.i2_fn0_i32 = zext i8 %wv.i2_fn0_c to i32
+  call i32 @putchar(i32 %wv.i2_fn0_i32)
+  %wv.i2_fn1_i32 = zext i8 %wv.fn1 to i32
+  call i32 @putchar(i32 %wv.i2_fn1_i32)
+  %wv.i2_a1_ptr = getelementptr %Value, %Value* %wv.args, i32 1
+  %wv.i2_a1 = load %Value, %Value* %wv.i2_a1_ptr
+  call void @wam_write_value(%WamState* %vm, %Value %wv.i2_a1)
+  ret void
 
 wv.binary_op:
   ; Single-byte binary operators that print as infix without parens.

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -518,6 +518,34 @@ test_write_list_of_pairs(_, R) :-
     format('~w', [L]),
     R is 1.
 
+% M23: 2-char symbolic operators in pretty-printer. Same arity=2
+% path as M22 but for functors of length 2 with no word boundary
+% (i.e. all-symbolic): ``->``, ``:-``, ``==``, ``\\=``, ``=<``,
+% ``>=``, ``//``, ``**``.
+:- dynamic test_write_arrow/2.
+test_write_arrow(_, R) :- T = (a->b), format('~w', [T]), R is 1.
+
+:- dynamic test_write_neck/2.
+test_write_neck(_, R) :- T = (h :- g), format('~w', [T]), R is 1.
+
+:- dynamic test_write_struct_eq/2.
+test_write_struct_eq(_, R) :- T = (1==2), format('~w', [T]), R is 1.
+
+:- dynamic test_write_not_unify/2.
+test_write_not_unify(_, R) :- T = (a\=b), format('~w', [T]), R is 1.
+
+:- dynamic test_write_le/2.
+test_write_le(_, R) :- T = (3=<4), format('~w', [T]), R is 1.
+
+:- dynamic test_write_ge/2.
+test_write_ge(_, R) :- T = (5>=4), format('~w', [T]), R is 1.
+
+:- dynamic test_write_int_div/2.
+test_write_int_div(_, R) :- T = (7//2), format('~w', [T]), R is 1.
+
+:- dynamic test_write_pow/2.
+test_write_pow(_, R) :- T = (2**8), format('~w', [T]), R is 1.
+
 % M15: precision directives ~Nf (fixed-point) and ~Ne (scientific).
 % Parses the digit run between ~ and f/e at runtime, then routes the
 % next arg through printf "%.*f" / "%.*e" with the parsed precision.
@@ -1024,6 +1052,15 @@ test_all :-
        run_fmt_test('~w of -(x)', test_write_neg, "-x"),
        run_fmt_test('~w of [a-1, b-2]',
                     test_write_list_of_pairs, "[a-1, b-2]"),
+       format('--- M23 two-char symbolic operator notation ---~n'),
+       run_fmt_test('~w of (a->b)', test_write_arrow, "a->b"),
+       run_fmt_test('~w of (h :- g)', test_write_neck, "h:-g"),
+       run_fmt_test('~w of (1==2)', test_write_struct_eq, "1==2"),
+       run_fmt_test('~w of (a\\=b)', test_write_not_unify, "a\\=b"),
+       run_fmt_test('~w of (3=<4)', test_write_le, "3=<4"),
+       run_fmt_test('~w of (5>=4)', test_write_ge, "5>=4"),
+       run_fmt_test('~w of (7//2)', test_write_int_div, "7//2"),
+       run_fmt_test('~w of (2**8)', test_write_pow, "2**8"),
        format('--- M15 precision directives (~~Nf / ~~Ne) ---~n'),
        run_fmt_test('"~6f~n" with 0.25', test_fmt_6f,
                     "0.250000\n"),


### PR DESCRIPTION
## Summary

`@wam_write_value` now also detects 2-byte symbolic operators in `arity=2` compounds. Direct follow-up to M22.

**Implementation.** Functor length is checked by requiring `fn[2] == 0` (strict 2-byte op) so 3+ char functors fall to canonical printing. The `(fn[0], fn[1])` pair packs into an `i16` for a single switch — no runtime string compare.

**Recognised operators:**

| Op | Meaning | Packed (`fn[0]<<8 \| fn[1]`) |
|----|---------|------------------------------|
| `->` | if-then | 11582 |
| `:-` | clause | 14893 |
| `==` | structural equal | 15677 |
| `\=` | cannot unify | 23613 |
| `=<` | less-or-equal | 15676 |
| `>=` | greater-or-equal | 15933 |
| `//` | integer division | 12079 |
| `**` | power | 10794 |

Output is `arg1<op>arg2` with no whitespace — matches SWI's `~w` convention (the canonical reader path prints with spaces; `~w` doesn't).

## Test plan

- [x] `tests/core/test_wam_llvm_builtin_execution.pl` — 103 cases pass (was 95). New:
  - `(a->b)` → `"a->b"`
  - `(h :- g)` → `"h:-g"`
  - `(1==2)` → `"1==2"`
  - `(a\=b)` → `"a\=b"`
  - `(3=<4)` → `"3=<4"`
  - `(5>=4)` → `"5>=4"`
  - `(7//2)` → `"7//2"`
  - `(2**8)` → `"2**8"`
- [x] `tests/core/test_wam_llvm_findall_execution.pl` — M9 still passes.
- [x] `tests/core/test_wam_llvm_realdata_benchmark.pl` — 31 ancestors, per-iter ~0.056ms, no regression.
- [x] `tests/core/test_wam_llvm_bfs_execution.pl` — 4 cases pass.
- [x] `tests/core/test_wam_llvm_astar_execution.pl` — A*(a,d) → distance 12.0.

Run with `LC_ALL=C.UTF-8`.

## Out of scope

- **Word-like 2-char ops**: `is`, `mod`, `xor`, `rem`. These need word-boundary spacing (` is ` not `is`) — the printer has to emit a leading and trailing space around them. Natural follow-up.
- **3-char ops**: `=:=`, `=\=`, `=..`, `@<=`, `@>=`. Same approach extended to `i24` packing.
- **Precedence-aware parens**: `1+2*3` still prints flat without parens. Would need a runtime op priority table.

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_