### PR TITLE
LLVM WAM: M24 — word-like operator notation (is / mod / xor / rem / div)

### DIFF
--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -1904,11 +1904,55 @@ wv.maybe_op2:
   br i1 %wv.b2, label %wv.check_2char, label %wv.canonical
 
 wv.check_2char:
-  ; fn[2] must be 0 -- ops are exactly 2 bytes.
+  ; fn[2] == 0 -> exactly 2 bytes (M23 path).
+  ; fn[2] != 0 -> maybe a 3-byte word op (M24 path).
   %wv.fn2_ptr = getelementptr i8, i8* %wv.fn_ptr, i32 2
   %wv.fn2 = load i8, i8* %wv.fn2_ptr
   %wv.fn2_zero = icmp eq i8 %wv.fn2, 0
-  br i1 %wv.fn2_zero, label %wv.binary_op2, label %wv.canonical
+  br i1 %wv.fn2_zero, label %wv.binary_op2, label %wv.check_3char
+
+wv.check_3char:
+  ; fn[3] must be 0 -- only handle exactly 3-byte ops.
+  %wv.fn3_ptr = getelementptr i8, i8* %wv.fn_ptr, i32 3
+  %wv.fn3 = load i8, i8* %wv.fn3_ptr
+  %wv.fn3_zero = icmp eq i8 %wv.fn3, 0
+  br i1 %wv.fn3_zero, label %wv.binary_op3, label %wv.canonical
+
+wv.binary_op3:
+  ; Pack (fn[0], fn[1], fn[2]) into i32:
+  ;   (fn[0] << 16) | (fn[1] << 8) | fn[2]
+  %wv.fn0_c3 = load i8, i8* %wv.fn_ptr
+  %wv.fn0_z3 = zext i8 %wv.fn0_c3 to i32
+  %wv.fn1_z3 = zext i8 %wv.fn1 to i32
+  %wv.fn2_z3 = zext i8 %wv.fn2 to i32
+  %wv.fn0_s3 = shl i32 %wv.fn0_z3, 16
+  %wv.fn1_s3 = shl i32 %wv.fn1_z3, 8
+  %wv.packed3_a = or i32 %wv.fn0_s3, %wv.fn1_s3
+  %wv.packed3 = or i32 %wv.packed3_a, %wv.fn2_z3
+  switch i32 %wv.packed3, label %wv.canonical [
+    i32 7171940, label %wv.infix_word3  ; ''m'' ''o'' ''d'' (109,111,100)
+    i32 7892850, label %wv.infix_word3  ; ''x'' ''o'' ''r'' (120,111,114)
+    i32 7497069, label %wv.infix_word3  ; ''r'' ''e'' ''m'' (114,101,109)
+    i32 6580598, label %wv.infix_word3  ; ''d'' ''i'' ''v'' (100,105,118)
+  ]
+
+wv.infix_word3:
+  ; Print: arg0 + '' '' + fn[0..2] + '' '' + arg1.
+  %wv.w3_a0_ptr = getelementptr %Value, %Value* %wv.args, i32 0
+  %wv.w3_a0 = load %Value, %Value* %wv.w3_a0_ptr
+  call void @wam_write_value(%WamState* %vm, %Value %wv.w3_a0)
+  call i32 @putchar(i32 32)
+  %wv.w3_fn0_i32 = zext i8 %wv.fn0_c3 to i32
+  call i32 @putchar(i32 %wv.w3_fn0_i32)
+  %wv.w3_fn1_i32 = zext i8 %wv.fn1 to i32
+  call i32 @putchar(i32 %wv.w3_fn1_i32)
+  %wv.w3_fn2_i32 = zext i8 %wv.fn2 to i32
+  call i32 @putchar(i32 %wv.w3_fn2_i32)
+  call i32 @putchar(i32 32)
+  %wv.w3_a1_ptr = getelementptr %Value, %Value* %wv.args, i32 1
+  %wv.w3_a1 = load %Value, %Value* %wv.w3_a1_ptr
+  call void @wam_write_value(%WamState* %vm, %Value %wv.w3_a1)
+  ret void
 
 wv.binary_op2:
   ; Pack (fn[0], fn[1]) into i16: (fn[0] << 8) | fn[1].
@@ -1918,14 +1962,15 @@ wv.binary_op2:
   %wv.fn0_shift = shl i16 %wv.fn0_z16, 8
   %wv.packed = or i16 %wv.fn0_shift, %wv.fn1_z16
   switch i16 %wv.packed, label %wv.canonical [
-    i16 11582, label %wv.infix2  ; ''-'' ''>'' -> ``->``
-    i16 14893, label %wv.infix2  ; '':'' ''-'' -> ``:-``
-    i16 15677, label %wv.infix2  ; ''='' ''='' -> ``==``
-    i16 23613, label %wv.infix2  ; ''\\'' ''='' -> ``\\=``
-    i16 15676, label %wv.infix2  ; ''='' ''<'' -> ``=<``
-    i16 15933, label %wv.infix2  ; ''>'' ''='' -> ``>=``
-    i16 12079, label %wv.infix2  ; ''/'' ''/'' -> ``//``
-    i16 10794, label %wv.infix2  ; ''*'' ''*'' -> ``**``
+    i16 11582, label %wv.infix2       ; ''-'' ''>'' -> ``->``
+    i16 14893, label %wv.infix2       ; '':'' ''-'' -> ``:-``
+    i16 15677, label %wv.infix2       ; ''='' ''='' -> ``==``
+    i16 23613, label %wv.infix2       ; ''\\'' ''='' -> ``\\=``
+    i16 15676, label %wv.infix2       ; ''='' ''<'' -> ``=<``
+    i16 15933, label %wv.infix2       ; ''>'' ''='' -> ``>=``
+    i16 12079, label %wv.infix2       ; ''/'' ''/'' -> ``//``
+    i16 10794, label %wv.infix2       ; ''*'' ''*'' -> ``**``
+    i16 26995, label %wv.infix_word2  ; ''i'' ''s'' -> `` is `` (word-spaced)
   ]
 
 wv.infix2:
@@ -1940,6 +1985,25 @@ wv.infix2:
   %wv.i2_a1_ptr = getelementptr %Value, %Value* %wv.args, i32 1
   %wv.i2_a1 = load %Value, %Value* %wv.i2_a1_ptr
   call void @wam_write_value(%WamState* %vm, %Value %wv.i2_a1)
+  ret void
+
+wv.infix_word2:
+  ; Word-like 2-char op (``is``) -- emit `` is `` with surrounding
+  ; spaces so adjacent atoms / numbers don''t collide with the op
+  ; name. Same arg flow as wv.infix2.
+  %wv.w2_a0_ptr = getelementptr %Value, %Value* %wv.args, i32 0
+  %wv.w2_a0 = load %Value, %Value* %wv.w2_a0_ptr
+  call void @wam_write_value(%WamState* %vm, %Value %wv.w2_a0)
+  call i32 @putchar(i32 32)
+  %wv.w2_fn0_c = load i8, i8* %wv.fn_ptr
+  %wv.w2_fn0_i32 = zext i8 %wv.w2_fn0_c to i32
+  call i32 @putchar(i32 %wv.w2_fn0_i32)
+  %wv.w2_fn1_i32 = zext i8 %wv.fn1 to i32
+  call i32 @putchar(i32 %wv.w2_fn1_i32)
+  call i32 @putchar(i32 32)
+  %wv.w2_a1_ptr = getelementptr %Value, %Value* %wv.args, i32 1
+  %wv.w2_a1 = load %Value, %Value* %wv.w2_a1_ptr
+  call void @wam_write_value(%WamState* %vm, %Value %wv.w2_a1)
   ret void
 
 wv.binary_op:

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -546,6 +546,42 @@ test_write_int_div(_, R) :- T = (7//2), format('~w', [T]), R is 1.
 :- dynamic test_write_pow/2.
 test_write_pow(_, R) :- T = (2**8), format('~w', [T]), R is 1.
 
+% M24: word-like operators in the pretty-printer. ``is`` (2-char) and
+% ``mod`` / ``xor`` / ``rem`` / ``div`` (3-char) are printed with
+% surrounding spaces so they don''t collide with adjacent atoms /
+% numbers (``Xis5`` is ambiguous; ``X is 5`` reads cleanly).
+:- dynamic test_write_is/2.
+test_write_is(_, R) :-
+    % Build the ``is/2`` compound explicitly so we exercise the
+    % pretty-printer rather than just evaluating with the runtime.
+    T = is(x, 5),
+    format('~w', [T]),
+    R is 1.
+
+:- dynamic test_write_mod/2.
+test_write_mod(_, R) :-
+    T = mod(7, 3),
+    format('~w', [T]),
+    R is 1.
+
+:- dynamic test_write_xor/2.
+test_write_xor(_, R) :-
+    T = xor(5, 3),
+    format('~w', [T]),
+    R is 1.
+
+:- dynamic test_write_rem/2.
+test_write_rem(_, R) :-
+    T = rem(10, 4),
+    format('~w', [T]),
+    R is 1.
+
+:- dynamic test_write_div/2.
+test_write_div(_, R) :-
+    T = div(8, 3),
+    format('~w', [T]),
+    R is 1.
+
 % M15: precision directives ~Nf (fixed-point) and ~Ne (scientific).
 % Parses the digit run between ~ and f/e at runtime, then routes the
 % next arg through printf "%.*f" / "%.*e" with the parsed precision.
@@ -1061,6 +1097,12 @@ test_all :-
        run_fmt_test('~w of (5>=4)', test_write_ge, "5>=4"),
        run_fmt_test('~w of (7//2)', test_write_int_div, "7//2"),
        run_fmt_test('~w of (2**8)', test_write_pow, "2**8"),
+       format('--- M24 word-like operators (is / mod / xor / rem / div) ---~n'),
+       run_fmt_test('~w of is(x, 5)', test_write_is, "x is 5"),
+       run_fmt_test('~w of mod(7, 3)', test_write_mod, "7 mod 3"),
+       run_fmt_test('~w of xor(5, 3)', test_write_xor, "5 xor 3"),
+       run_fmt_test('~w of rem(10, 4)', test_write_rem, "10 rem 4"),
+       run_fmt_test('~w of div(8, 3)', test_write_div, "8 div 3"),
        format('--- M15 precision directives (~~Nf / ~~Ne) ---~n'),
        run_fmt_test('"~6f~n" with 0.25', test_fmt_6f,
                     "0.250000\n"),


### PR DESCRIPTION
## Summary

Extends the pretty-printer with word-like operators that need space padding so they don't collide with adjacent atoms / numbers (`Xis5` is ambiguous; `X is 5` reads cleanly).

- **`is`** (2 chars) joins the M23 switch but routes to a new `wv.infix_word2` label that emits ` is ` (leading + trailing space).
- **`mod`, `xor`, `rem`, `div`** (3 chars) get a brand-new 3-byte dispatch: when `fn[2] != 0` we check `fn[3] == 0` (strict 3-byte), pack `(fn[0], fn[1], fn[2])` into an `i32`, and switch into `wv.infix_word3`. Same ` op ` spacing as the 2-char word path.

**Packed i32 values** (`(fn[0]<<16) | (fn[1]<<8) | fn[2]`):

| Op | Packed | Bytes |
|----|--------|-------|
| `mod` | 7171940 | 109, 111, 100 |
| `xor` | 7892850 | 120, 111, 114 |
| `rem` | 7497069 | 114, 101, 109 |
| `div` | 6580598 | 100, 105, 118 |

(Aside: I initially had wrong values for `mod`/`xor`/`div` from doing the byte arithmetic by hand. A quick sanity check during testing caught the mismatch — output was the canonical `mod(7, 3)` instead of the expected `7 mod 3`. Fixed values verified against the shift formula before commit.)

## Test plan

- [x] `tests/core/test_wam_llvm_builtin_execution.pl` — 108 cases pass (was 103). New:
  - `is(x, 5)` → `"x is 5"`
  - `mod(7, 3)` → `"7 mod 3"`
  - `xor(5, 3)` → `"5 xor 3"`
  - `rem(10, 4)` → `"10 rem 4"`
  - `div(8, 3)` → `"8 div 3"`
- [x] `tests/core/test_wam_llvm_findall_execution.pl` — M9 still passes.
- [x] `tests/core/test_wam_llvm_realdata_benchmark.pl` — 31 ancestors, per-iter ~0.068ms, within noise.
- [x] `tests/core/test_wam_llvm_bfs_execution.pl` — 4 cases pass.
- [x] `tests/core/test_wam_llvm_astar_execution.pl` — A*(a,d) → distance 12.0.

Run with `LC_ALL=C.UTF-8`.

## Out of scope

- **3-char symbolic operators**: `=:=`, `=\=`, `=..`, `\==`, `@<=`, `@>=`. Same packed-i32 dispatch path, routed to `wv.infix2`-style printing (no spaces).
- **Precedence-aware parens**: `1 + 2 * 3` still prints flat. Would need a runtime op priority/associativity table and a "context priority" recursion through the printer.
- **`~q` quoted print**: needs atom-needs-quoting detection.

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_