### PR TITLE
LLVM WAM: M25 — 3-char symbolic operator notation

### DIFF
--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -1934,7 +1934,29 @@ wv.binary_op3:
     i32 7892850, label %wv.infix_word3  ; ''x'' ''o'' ''r'' (120,111,114)
     i32 7497069, label %wv.infix_word3  ; ''r'' ''e'' ''m'' (114,101,109)
     i32 6580598, label %wv.infix_word3  ; ''d'' ''i'' ''v'' (100,105,118)
+    i32 4012605, label %wv.infix3       ; ''='' '':'' ''='' -> ``=:=``
+    i32 4021309, label %wv.infix3       ; ''='' ''\\'' ''='' -> ``=\\=``
+    i32 4009518, label %wv.infix3       ; ''='' ''.'' ''.'' -> ``=..``
+    i32 6044989, label %wv.infix3       ; ''\\'' ''='' ''='' -> ``\\==``
+    i32 4209980, label %wv.infix3       ; ''@'' ''='' ''<'' -> ``@=<``
+    i32 4210237, label %wv.infix3       ; ''@'' ''>'' ''='' -> ``@>=``
   ]
+
+wv.infix3:
+  ; Print: arg0 + fn[0..2] (no spaces, symbolic 3-byte op) + arg1.
+  %wv.s3_a0_ptr = getelementptr %Value, %Value* %wv.args, i32 0
+  %wv.s3_a0 = load %Value, %Value* %wv.s3_a0_ptr
+  call void @wam_write_value(%WamState* %vm, %Value %wv.s3_a0)
+  %wv.s3_fn0_i32 = zext i8 %wv.fn0_c3 to i32
+  call i32 @putchar(i32 %wv.s3_fn0_i32)
+  %wv.s3_fn1_i32 = zext i8 %wv.fn1 to i32
+  call i32 @putchar(i32 %wv.s3_fn1_i32)
+  %wv.s3_fn2_i32 = zext i8 %wv.fn2 to i32
+  call i32 @putchar(i32 %wv.s3_fn2_i32)
+  %wv.s3_a1_ptr = getelementptr %Value, %Value* %wv.args, i32 1
+  %wv.s3_a1 = load %Value, %Value* %wv.s3_a1_ptr
+  call void @wam_write_value(%WamState* %vm, %Value %wv.s3_a1)
+  ret void
 
 wv.infix_word3:
   ; Print: arg0 + '' '' + fn[0..2] + '' '' + arg1.

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -582,6 +582,44 @@ test_write_div(_, R) :-
     format('~w', [T]),
     R is 1.
 
+% M25: 3-char symbolic operators. Same 3-byte packed-i32 dispatch as
+% the word-like ops, but routed to wv.infix3 (no surrounding spaces).
+:- dynamic test_write_arith_eq/2.
+test_write_arith_eq(_, R) :-
+    T = =:=(x, y),
+    format('~w', [T]),
+    R is 1.
+
+:- dynamic test_write_arith_ne/2.
+test_write_arith_ne(_, R) :-
+    T = =\=(x, y),
+    format('~w', [T]),
+    R is 1.
+
+:- dynamic test_write_univ/2.
+test_write_univ(_, R) :-
+    T = =..(foo, [1, 2]),
+    format('~w', [T]),
+    R is 1.
+
+:- dynamic test_write_struct_ne/2.
+test_write_struct_ne(_, R) :-
+    T = \==(a, b),
+    format('~w', [T]),
+    R is 1.
+
+:- dynamic test_write_term_le/2.
+test_write_term_le(_, R) :-
+    T = @=<(a, b),
+    format('~w', [T]),
+    R is 1.
+
+:- dynamic test_write_term_ge/2.
+test_write_term_ge(_, R) :-
+    T = @>=(b, a),
+    format('~w', [T]),
+    R is 1.
+
 % M15: precision directives ~Nf (fixed-point) and ~Ne (scientific).
 % Parses the digit run between ~ and f/e at runtime, then routes the
 % next arg through printf "%.*f" / "%.*e" with the parsed precision.
@@ -1103,6 +1141,14 @@ test_all :-
        run_fmt_test('~w of xor(5, 3)', test_write_xor, "5 xor 3"),
        run_fmt_test('~w of rem(10, 4)', test_write_rem, "10 rem 4"),
        run_fmt_test('~w of div(8, 3)', test_write_div, "8 div 3"),
+       format('--- M25 three-char symbolic operators ---~n'),
+       run_fmt_test('~w of =:=(x, y)', test_write_arith_eq, "x=:=y"),
+       run_fmt_test('~w of =\\=(x, y)', test_write_arith_ne, "x=\\=y"),
+       run_fmt_test('~w of =..(foo, [1, 2])',
+                    test_write_univ, "foo=..[1, 2]"),
+       run_fmt_test('~w of \\==(a, b)', test_write_struct_ne, "a\\==b"),
+       run_fmt_test('~w of @=<(a, b)', test_write_term_le, "a@=<b"),
+       run_fmt_test('~w of @>=(b, a)', test_write_term_ge, "b@>=a"),
        format('--- M15 precision directives (~~Nf / ~~Ne) ---~n'),
        run_fmt_test('"~6f~n" with 0.25', test_fmt_6f,
                     "0.250000\n"),


### PR DESCRIPTION
## Summary

Six more symbolic operators in the existing 3-byte dispatch, routed to a new `wv.infix3` label (no surrounding spaces, unlike the M24 word-like path).

| Op | Packed `i32` | Bytes | Meaning |
|----|--------------|-------|---------|
| `=:=` | 4012605 | `=`, `:`, `=` | arithmetic equality |
| `=\=` | 4021309 | `=`, `\`, `=` | arithmetic inequality |
| `=..` | 4009518 | `=`, `.`, `.` | univ |
| `\==` | 6044989 | `\`, `=`, `=` | structural inequality |
| `@=<` | 4209980 | `@`, `=`, `<` | term less-or-equal |
| `@>=` | 4210237 | `@`, `>`, `=` | term greater-or-equal |

The 3-char dispatch infrastructure was already in place from M24 (`mod` / `xor` / `rem` / `div` go to `wv.infix_word3` with spaces); this PR just adds the symbolic targets and the `wv.infix3` print routine.

**Operator notation surface now covers:**

| PR | Class | Examples |
|----|-------|----------|
| M22 | 1-char symbolic | `+`, `-`, `*`, `/`, `=`, `<`, `>`, `:`, `^` |
| M23 | 2-char symbolic | `->`, `:-`, `==`, `\=`, `=<`, `>=`, `//`, `**` |
| M24 | word-like (spaced) | `is`, `mod`, `xor`, `rem`, `div` |
| M25 | 3-char symbolic | `=:=`, `=\=`, `=..`, `\==`, `@=<`, `@>=` |

## Test plan

- [x] `tests/core/test_wam_llvm_builtin_execution.pl` — 114 cases pass (was 108). New:
  - `=:=(x, y)` → `"x=:=y"`
  - `=\=(x, y)` → `"x=\=y"`
  - `=..(foo, [1, 2])` → `"foo=..[1, 2]"`
  - `\==(a, b)` → `"a\==b"`
  - `@=<(a, b)` → `"a@=<b"`
  - `@>=(b, a)` → `"b@>=a"`
- [x] `tests/core/test_wam_llvm_findall_execution.pl` — M9 still passes.
- [x] `tests/core/test_wam_llvm_realdata_benchmark.pl` — 31 ancestors, per-iter ~0.063ms, no regression.
- [x] `tests/core/test_wam_llvm_bfs_execution.pl` — 4 cases pass.
- [x] `tests/core/test_wam_llvm_astar_execution.pl` — A*(a,d) → distance 12.0.

Run with `LC_ALL=C.UTF-8`.

## Out of scope

The operator notation work is now pretty thorough for common Prolog. Remaining substantial polish:
- **Precedence-aware parens**: `1 + 2 * 3` still prints flat. Needs a runtime op-priority table.
- **`~q` quoted print**: needs atom-needs-quoting detection (whitespace, special chars, leading uppercase).
- **Runtime atom interning**: unlocks `atom_chars/2`, `char_code/2`, reverse-mode `atom_codes/2`, `atom_concat/3`, `sub_atom/5`. Substantial infrastructure piece.
- **More builtins**: `between/3` (multi-result), `assert`/`retract` (dynamic db).

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_