### PR TITLE
feat(wam-clojure): materialize minimal delete/3 source mode

### DIFF
--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1011,14 +1011,29 @@
         elem (deref-value (:bindings state)
                           (or (reg-get-raw state "A2") ::unbound))
         out (deref-value (:bindings state)
-                         (or (reg-get-raw state "A3") ::unbound))]
-    (if-let [items (proper-list-items state list-value)]
-      (let [kept (remove #(term-identical? state % elem) items)
+                         (or (reg-get-raw state "A3") ::unbound))
+        out-items (proper-list-items state out)]
+    (cond
+      (proper-list-items state list-value)
+      (let [kept (remove #(term-identical? state % elem)
+                         (proper-list-items state list-value))
             result-term (list->term (:intern-context state) kept)
             [ok next-state] (unify-values state out result-term)]
         (if ok
           (advance next-state)
           (backtrack state)))
+
+      (and (logic-var? list-value)
+           (not (logic-var? elem))
+           (not= elem ::unbound)
+           (some? out-items)
+           (not-any? #(term-identical? state % elem) out-items))
+      (let [[ok next-state] (unify-values state list-value out)]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+
+      :else
       (backtrack state))))
 
 (defn sorted-unique-list? [state items]

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -366,7 +366,7 @@ user:wam_numlist_high_before_low(List) :- numlist(3, 1, List).
 user:wam_numlist_unbound_low(List) :- numlist(Low, 3, List), integer(Low).
 user:wam_delete_guard(L, Elem, Rest) :- delete(L, Elem, Rest).
 user:wam_delete_bad_list(Rest) :- delete([a|b], a, Rest).
-user:wam_delete_unbound_list(Rest) :- user:wam_unbound_arg(L), delete(L, a, Rest).
+user:wam_delete_unbound_list(Rest) :- delete(L, a, Rest), is_list(L).
 user:wam_sort_guard(L, S) :- sort(L, S).
 user:wam_sort_bad_list(S) :- sort([a|b], S).
 user:wam_sort_unbound_list(S) :- sort(L, S), is_list(L).
@@ -1014,7 +1014,9 @@ smoke_cases([
     case('wam_delete_guard/3', args('[f(a),f(b),f(a)]', 'f(a)', '[f(b)]'), "true"),
     case('wam_delete_guard/3', args('[a,b,a,c]', a, '[a,b,c]'), "false"),
     case('wam_delete_bad_list/1', '[]', "false"),
-    case('wam_delete_unbound_list/1', '[]', "false"),
+    case('wam_delete_unbound_list/1', '[]', "true"),
+    case('wam_delete_unbound_list/1', '[b,c]', "true"),
+    case('wam_delete_unbound_list/1', '[a]', "false"),
     case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b,c]'), "true"),
     case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b]'), "false"),
     case('wam_sort_guard/2', args('[f(b),f(a),a]', '[a,f(a),f(b)]'), "true"),


### PR DESCRIPTION
## Summary

- Add a conservative Clojure WAM inverse mode for `delete/3` when the input list is unbound and the rest list is materialized.
- Bind the input list to the rest list only when the rest list contains no element identical to the deleted element.
- Update runtime smoke coverage for empty and non-empty minimal-source cases while preserving rejection when the rest list still contains the deleted element.

## Why

The full inverse of `delete(List, Elem, Rest)` can be infinite because deleted elements may be inserted back into the input list at arbitrary positions. This PR intentionally implements only one finite, sound minimal source candidate: `List = Rest`, valid when `Rest` contains no `Elem`.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
