### PR TITLE
LLVM WAM: M27 — atom_chars/2 forward mode

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3397,6 +3397,7 @@ entry:
     i32 35, label %builtin_atom_length
     i32 36, label %builtin_atom_codes
     i32 37, label %builtin_char_code
+    i32 38, label %builtin_atom_chars
   ]
 
 builtin_is:
@@ -4791,6 +4792,93 @@ chc.forward_cmp:
 chc.fail:
   ret i1 false
 
+builtin_atom_chars:
+  ; M27: atom_chars/2 forward mode -- A1 = atom, A2 = list of
+  ; single-char atoms. Walks A1''s C string twice: first to measure
+  ; the length, then backwards from index n-1 to 0 emitting cons
+  ; cells whose heads are single-char Atom values pulled from the
+  ; M26 @wam_char_to_atom_id table. Non-printable bytes (outside
+  ; 32..126) get an atom id of 0 -- the head still emits as
+  ; Atom(0), which @wam_write_value renders as ``?``. Reverse mode
+  ; (list of chars -> atom) needs runtime interning and is deferred.
+  %ach.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %ach.t1 = extractvalue %Value %ach.a1, 0
+  %ach.is_atom = icmp eq i32 %ach.t1, 0
+  br i1 %ach.is_atom, label %ach.lookup, label %ach.fail
+ach.fail:
+  ret i1 false
+ach.lookup:
+  %ach.aid = extractvalue %Value %ach.a1, 1
+  %ach.str = call i8* @wam_atom_to_string(i64 %ach.aid)
+  %ach.str_null = icmp eq i8* %ach.str, null
+  br i1 %ach.str_null, label %ach.fail, label %ach.measure
+ach.measure:
+  br label %ach.measure_loop
+ach.measure_loop:
+  %ach.mp = phi i8* [ %ach.str, %ach.measure ], [ %ach.mpn, %ach.measure_step ]
+  %ach.mn = phi i32 [ 0, %ach.measure ], [ %ach.mn1, %ach.measure_step ]
+  %ach.mc = load i8, i8* %ach.mp
+  %ach.mzero = icmp eq i8 %ach.mc, 0
+  br i1 %ach.mzero, label %ach.build_init, label %ach.measure_step
+ach.measure_step:
+  %ach.mpn = getelementptr i8, i8* %ach.mp, i32 1
+  %ach.mn1 = add i32 %ach.mn, 1
+  br label %ach.measure_loop
+ach.build_init:
+  %ach.empty_id = load i64, i64* @wam_empty_list_atom_id
+  %ach.empty_v0 = insertvalue %Value undef, i32 0, 0
+  %ach.empty_v  = insertvalue %Value %ach.empty_v0, i64 %ach.empty_id, 1
+  call void @wam_arena_ensure()
+  br label %ach.build_loop
+ach.build_loop:
+  %ach.bi = phi i32 [ %ach.mn, %ach.build_init ], [ %ach.bi_prev, %ach.build_step ]
+  %ach.btail = phi %Value [ %ach.empty_v, %ach.build_init ], [ %ach.new_cons, %ach.build_step ]
+  %ach.done_b = icmp sle i32 %ach.bi, 0
+  br i1 %ach.done_b, label %ach.bind_out, label %ach.build_step
+ach.build_step:
+  %ach.bi_prev = sub i32 %ach.bi, 1
+  %ach.cp_b = getelementptr i8, i8* %ach.str, i32 %ach.bi_prev
+  %ach.ch_b = load i8, i8* %ach.cp_b
+  %ach.ch_b64 = zext i8 %ach.ch_b to i64
+  ; Look up the char''s atom id via @wam_char_to_atom. Out-of-range
+  ; or non-printable bytes return 0, which renders as ``?``.
+  %ach.char_aid = call i64 @wam_char_to_atom(i64 %ach.ch_b64)
+  %ach.char_v0 = insertvalue %Value undef, i32 0, 0
+  %ach.char_v = insertvalue %Value %ach.char_v0, i64 %ach.char_aid, 1
+  ; Allocate a [|]/2 Compound on the arena.
+  %ach.cp_size = ptrtoint %Compound* getelementptr (%Compound, %Compound* null, i32 1) to i64
+  %ach.cp_mem = call i8* @wam_arena_alloc(i64 %ach.cp_size)
+  %ach.cp = bitcast i8* %ach.cp_mem to %Compound*
+  %ach.fn_slot = getelementptr %Compound, %Compound* %ach.cp, i32 0, i32 0
+  %ach.fn_ptr = getelementptr [4 x i8], [4 x i8]* @.fn__5B_7C_5D, i32 0, i32 0
+  store i8* %ach.fn_ptr, i8** %ach.fn_slot
+  %ach.ar_slot = getelementptr %Compound, %Compound* %ach.cp, i32 0, i32 1
+  store i32 2, i32* %ach.ar_slot
+  %ach.args_mem = call i8* @wam_arena_alloc(i64 32)
+  %ach.args = bitcast i8* %ach.args_mem to %Value*
+  %ach.args_slot = getelementptr %Compound, %Compound* %ach.cp, i32 0, i32 2
+  store %Value* %ach.args, %Value** %ach.args_slot
+  %ach.h_ptr = getelementptr %Value, %Value* %ach.args, i32 0
+  store %Value %ach.char_v, %Value* %ach.h_ptr
+  %ach.t_ptr = getelementptr %Value, %Value* %ach.args, i32 1
+  store %Value %ach.btail, %Value* %ach.t_ptr
+  %ach.cp_i64 = ptrtoint %Compound* %ach.cp to i64
+  %ach.nc0 = insertvalue %Value undef, i32 3, 0
+  %ach.new_cons = insertvalue %Value %ach.nc0, i64 %ach.cp_i64, 1
+  br label %ach.build_loop
+ach.bind_out:
+  %ach.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %ach.a2_unb = call i1 @value_is_unbound(%Value %ach.a2)
+  br i1 %ach.a2_unb, label %ach.bind, label %ach.unify
+ach.bind:
+  call void @wam_trail_binding(%WamState* %vm, i32 1)
+  call void @wam_bind_reg(%WamState* %vm, i32 1, %Value %ach.btail)
+  ret i1 true
+ach.unify:
+  %ach.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %ach.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %ach.raw2, %Value %ach.btail)
+  ret i1 %ach.uok
+
 unknown:
   ret i1 false
 }'.
@@ -6048,6 +6136,7 @@ builtin_op_to_id('format/1', 33).
 builtin_op_to_id('atom_length/2', 35).
 builtin_op_to_id('atom_codes/2', 36).
 builtin_op_to_id('char_code/2', 37).
+builtin_op_to_id('atom_chars/2', 38).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -377,6 +377,37 @@ test_char_code_check(_, R) :-
     char_code(a, 97),
     R is 1.
 
+% M27: atom_chars/2 forward mode -- walks atom string, maps each byte
+% to a single-char atom via the M26 char-id table, builds a cons chain.
+% Reverse mode (chars -> atom) needs runtime interning and is deferred.
+:- dynamic test_atom_chars_head/2.
+test_atom_chars_head(_, R) :-
+    atom_chars(hello, Cs),
+    Cs = [C|_],
+    char_code(C, X),    % round-trip the single-char atom back to a code
+    R is X.             % ''h'' = 104
+
+:- dynamic test_atom_chars_third/2.
+test_atom_chars_third(_, R) :-
+    atom_chars(hello, Cs),
+    Cs = [_, _, C|_],
+    char_code(C, X),
+    R is X.             % ''l'' = 108
+
+:- dynamic test_atom_chars_length/2.
+test_atom_chars_length(_, R) :-
+    atom_chars(world, Cs),
+    length(Cs, N),
+    R is N.             % 5
+
+% Round-trip through both atom_chars and write/1 to verify the
+% printer renders the list of single-char atoms correctly.
+:- dynamic test_atom_chars_print/2.
+test_atom_chars_print(_, R) :-
+    atom_chars(hi, Cs),
+    format('~w', [Cs]),
+    R is 1.
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -1115,6 +1146,15 @@ test_all :-
                    test_char_code_reverse_h, 0, 104),
        run_test_r0('char_code(a, 97) (check mode) -> 1',
                    test_char_code_check, 0, 1),
+       format('--- M27 atom_chars/2 forward mode ---~n'),
+       run_test_r0('atom_chars(hello)[0] code -> 104',
+                   test_atom_chars_head, 0, 104),
+       run_test_r0('atom_chars(hello)[2] code -> 108',
+                   test_atom_chars_third, 0, 108),
+       run_test_r0('length(atom_chars(world)) -> 5',
+                   test_atom_chars_length, 0, 5),
+       run_fmt_test('write atom_chars(hi) -> "[h, i]"',
+                    test_atom_chars_print, "[h, i]"),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Adds `atom_chars/2` (op id 38), forward mode only. Same arena-allocation pattern as `atom_codes/2` from M19, just with single-char Atom heads instead of Integer-code heads.

**Algorithm:**
1. Walk A1's C string to measure the length `N`.
2. Walk backward from index `N-1` to `0`, emitting `[|]/2` cons cells whose heads are single-char `Atom` values pulled from the M26 `@wam_char_to_atom_id` table.
3. Bind A2 to the chain head (or unify via `wam_unify_value` if A2 was already bound).

Non-printable bytes (outside `32..126`) get atom id `0` — the head still emits as `Atom(0)`, which `@wam_write_value` renders as `?`.

Reverse mode (`chars → atom`) needs runtime atom interning to construct novel atoms not in the static table, so it's deferred.

Local-name hygiene: the new builtin block uses `ach.` prefix — `ac.` is claimed by `builtin_atom_check`, `aco.` by `builtin_atom_codes`.

## Test plan

- [x] `tests/core/test_wam_llvm_builtin_execution.pl` — 122 cases pass (was 118). New:
  - `atom_chars(hello)[0]` code → 104 (round-trip via `char_code`)
  - `atom_chars(hello)[2]` code → 108
  - `length(atom_chars(world))` → 5
  - `write(atom_chars(hi))` → `"[h, i]"` (pretty-print round-trip, exercises the M26 lookup and the M21 list printer together)
- [x] `tests/core/test_wam_llvm_findall_execution.pl` — M9 still passes.
- [x] `tests/core/test_wam_llvm_realdata_benchmark.pl` — 31 ancestors, per-iter ~0.060ms, no regression.
- [x] `tests/core/test_wam_llvm_bfs_execution.pl` — 4 cases pass.
- [x] `tests/core/test_wam_llvm_astar_execution.pl` — A*(a,d) → distance 12.0.

Run with `LC_ALL=C.UTF-8`.

## Out of scope

- **Reverse mode `atom_chars(A, [h, i])` → `A = hi`**: needs runtime atom interning to construct novel atoms not in the static table.
- **`atom_concat/3`**: similar — bound + bound is easy (concat two strings, intern result) but reverse decomposition is harder.
- **`sub_atom/5`**: substring extraction; needs interning for the output atom.

Forward-mode atom inspection is now solid:
- `atom_length/2` (M19) — count bytes
- `atom_codes/2` (M19) — emit integer-code list
- `char_code/2` (M26) — single-char bidirectional
- `atom_chars/2` (M27) — emit single-char-atom list

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_