### PR TITLE
test(wam): cover haskell runtime parser alias

### DIFF
--- a/tests/test_wam_runtime_parser_capability.pl
+++ b/tests/test_wam_runtime_parser_capability.pl
@@ -156,6 +156,13 @@ test(fsharp_off_explicit_none) :-
 test(haskell_defaults_to_none) :-
     wam_target_runtime_parser(wam_haskell, [], none).
 
+test(haskell_alias_defaults_to_none) :-
+    wam_target_runtime_parser(haskell, [], none).
+
+test(haskell_alias_can_opt_into_compiled_parser) :-
+    wam_target_runtime_parser(haskell, [runtime_parser(compiled)],
+                              compiled(prolog_term_parser)).
+
 test(haskell_can_opt_into_compiled_parser) :-
     wam_target_runtime_parser(wam_haskell, [runtime_parser(compiled)],
                               compiled(prolog_term_parser)).


### PR DESCRIPTION
## Summary
- Add runtime parser capability tests for the existing `haskell` target alias.
- Verify `haskell` defaults to parser mode `none`, matching `wam_haskell`.
- Verify `haskell` can opt into `compiled(prolog_term_parser)`, matching `wam_haskell`.
- Keep this test-only; no resolver behavior changed.

## Tests
- `swipl -q -g "run_tests" -t halt tests/test_wam_runtime_parser_capability.pl`
- `git diff --check`

## Notes
- Runtime parser capability suite passes `45/45`.
- No warning suppression or discontiguous directives were added.
