### PR TITLE
docs(wam): clarify items mode custom instructions

### DIFF
--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_SPECIFICATION.md
@@ -4,6 +4,17 @@ This document defines the target-runtime contract for parsing Prolog terms from
 text. It is separate from the build-time WAM items parser used by target
 generators.
 
+Do not conflate these layers:
+
+- `output(items)` / `output(text)` selects the build-time representation that
+  target generators consume from the WAM compiler.
+- `runtime_parser(...)` selects whether generated target code can parse Prolog
+  terms from text while the program is running.
+
+A target can and should migrate to build-time items mode even if it has no
+runtime parser. Conversely, a target may expose a runtime parser while still
+using the legacy text-to-items migration path internally.
+
 ## Canonical Source
 
 The portable parser source is:

--- a/docs/design/WAM_ITEMS_API_PHILOSOPHY.md
+++ b/docs/design/WAM_ITEMS_API_PHILOSOPHY.md
@@ -301,6 +301,40 @@ opts into the building blocks and adds its own clauses. Either
 way, the bug-prone tokenizer and the bulk of instruction-shape
 recognition lives in **one** place.
 
+
+## 6.2 Custom symbolic instructions
+
+Items also give us a cleaner extension point for target-specific WAM
+instructions. In the text pipeline, a custom instruction is easy to print but
+hard to preserve: every target parser has to learn its syntax before the item
+can reach the emitter. In the items pipeline, a custom instruction is just a
+structured term from the start.
+
+The important distinction is between **representation** and **execution**:
+
+- representation mode decides whether the generator hands a target structured
+  items or canonical text. The default should be structured items.
+- execution policy decides what a target does with a custom item after it sees
+  it: compile it away, keep it in the interpreter, or preserve symbolic metadata
+  for a target JIT.
+
+That suggests three execution policies for custom symbolic instructions:
+
+| Policy | Meaning | Good fit |
+| --- | --- | --- |
+| `compiled` | Lower the custom item directly into target source or into standard WAM items. This should be the default. | Known target intrinsic, static optimization, kernel hook. |
+| `interpreted` | Keep the custom item in the runtime instruction stream and dispatch it in the VM. | Debug counters, tracing, rare operations where code size matters more than speed. |
+| `jit` | Preserve symbolic metadata so the runtime or host language can specialize later. | Hot-path specialization, data-layout-dependent kernels, host runtimes with real JIT support. |
+
+The policy should be explicit in item metadata rather than inferred from the
+instruction name. That prevents a target from silently treating a JIT-only item
+as interpreted, or compiling away a marker that a profiler expects to observe.
+Unsupported policies should fail at generation time.
+
+This does not require every target to support custom instructions. The baseline
+contract remains the standard item catalogue. Custom items are an extension
+mechanism for targets that already have a reason to go beyond it.
+
 ## 7. What's intentionally out of scope
 
 - **Removing the text API.** Even after every target migrates, the

--- a/docs/design/WAM_ITEMS_API_SPECIFICATION.md
+++ b/docs/design/WAM_ITEMS_API_SPECIFICATION.md
@@ -181,6 +181,81 @@ The bulk of parsing (~80-90% of any target''s parser today) lives
 in the shared building blocks. Targets ship only what's unique to
 them.
 
+### 1.5 Representation modes vs runtime parser modes
+
+`output(items)` / `output(text)` is a **build-time representation choice**.
+It is independent of `runtime_parser(...)`, which controls whether a generated
+program can parse Prolog terms from text at execution time.
+
+The intended target-generator pipeline is:
+
+```text
+Prolog clauses -> compile_predicate_to_wam_items/3 -> target emitter
+```
+
+The legacy compatibility pipeline remains:
+
+```text
+Prolog clauses -> compile_predicate_to_wam_text/3 -> wam_text_to_items/2 -> target emitter
+```
+
+Targets should prefer the first pipeline for in-tree compilation. The second
+pipeline is for debug dumps, external WAM text, snapshot tests, and migration
+periods where a target has not yet been moved to direct items consumption. In
+particular, a target should not require its own compile-time text parser merely
+to consume WAM that this repository just generated.
+
+### 1.6 Custom symbolic instructions
+
+Targets may extend the standard item catalogue with custom symbolic WAM
+instructions. A custom instruction is still an item term; it is not a raw text
+line. The recommended shape is:
+
+```prolog
+custom_wam(Op, Operands, Meta)
+```
+
+where `Op` is an atom, `Operands` is a list of ordinary WAM item operands, and
+`Meta` is a list of options. `Meta` may include an execution policy:
+
+```prolog
+mode(compiled)      % default: lower directly into target source
+mode(interpreted)   % keep as an instruction dispatched by the runtime VM
+mode(jit)           % emit a stable symbolic form that a target JIT may compile later
+```
+
+Policy meaning:
+
+- `compiled` means the target emitter must know how to lower the instruction
+  into ordinary target-language code or into a sequence of standard WAM items.
+  This is the default because it keeps generated projects self-contained.
+- `interpreted` means the item is intentionally preserved in the runtime
+  instruction stream. The target runtime must have a dispatcher case for `Op`,
+  and unsupported targets must reject the item at generation time.
+- `jit` means the item is preserved with enough symbolic metadata for a runtime
+  or host-language JIT to specialize it after profiling or after seeing concrete
+  data layout. Targets without a JIT must either reject the item or downgrade it
+  through an explicit fallback such as `fallback(compiled)` or
+  `fallback(interpreted)` in `Meta`.
+
+Custom items must round-trip through the common text parser only when a target
+registers an extension recogniser/printer. Standard `wam_text_to_items/2` should
+stay strict for the core instruction set; lenient or extension-aware parsing
+belongs in the target composition layer described in §1.4.
+
+A future shared registry can make this explicit:
+
+```prolog
+%% wam_custom_instruction(+Target, +Op, +Modes, +Lowerer)
+%  Declares that Target accepts custom operation Op, supports execution policies
+%  Modes, and lowers or validates through Lowerer.
+```
+
+Until that registry exists, target-specific custom instructions should be
+clearly namespaced in `Op` (for example `llvm_profile_counter` rather than
+`profile_counter`) and covered by target tests proving unsupported modes fail
+loudly.
+
 ## 2. Item term shapes
 
 The shapes match what every target's existing tokenizer + parser


### PR DESCRIPTION
## Summary
- Clarify that WAM `items`/`text` output is a build-time representation choice, separate from runtime parser mode.
- Document the intended direct items pipeline: `compile_predicate_to_wam_items/3 -> target emitter`.
- Keep the legacy text-to-items path scoped to debug dumps, external WAM text, snapshot tests, and migration periods.
- Specify a design shape for custom symbolic WAM instructions via `custom_wam(Op, Operands, Meta)`.
- Define custom instruction execution policies: `mode(compiled)` as default, `mode(interpreted)`, and `mode(jit)`.
- Add guidance that unsupported custom-instruction policies should fail at generation time.

## Tests
- `git diff --check`

## Notes
- Documentation-only change.
- No target runtime or generator behavior changed.
