### PR TITLE
LLVM WAM: M28 — between/3 + foreign-iter fixes for aggregator interop

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3398,6 +3398,7 @@ entry:
     i32 36, label %builtin_atom_codes
     i32 37, label %builtin_char_code
     i32 38, label %builtin_atom_chars
+    i32 39, label %builtin_between
   ]
 
 builtin_is:
@@ -4879,6 +4880,98 @@ ach.unify:
   %ach.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %ach.raw2, %Value %ach.btail)
   ret i1 %ach.uok
 
+builtin_between:
+  ; M28: between(Low, High, X) -- A1 = Low, A2 = High, A3 = X.
+  ; Two modes:
+  ;   check (X bound to Integer):
+  ;     succeeds iff Low <= X <= High. Single result.
+  ;   enumerate (X unbound):
+  ;     allocates an Integer[High - Low + 1] array on the arena,
+  ;     binds A3 to Integer(Low), and pushes a foreign-iter choice
+  ;     point so backtrack walks the rest. Result count capped at
+  ;     1,000,000 to keep the arena from exploding -- larger ranges
+  ;     fail and the user should use a tighter loop.
+  ;
+  ; Low or High not bound to Integer -> fail.
+  %bet.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %bet.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %bet.t1 = extractvalue %Value %bet.a1, 0
+  %bet.t2 = extractvalue %Value %bet.a2, 0
+  %bet.int1 = icmp eq i32 %bet.t1, 1
+  %bet.int2 = icmp eq i32 %bet.t2, 1
+  %bet.both_int = and i1 %bet.int1, %bet.int2
+  br i1 %bet.both_int, label %bet.go, label %bet.fail
+bet.fail:
+  ret i1 false
+bet.go:
+  %bet.lo = extractvalue %Value %bet.a1, 1
+  %bet.hi = extractvalue %Value %bet.a2, 1
+  %bet.a3 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 2)
+  %bet.a3_unb = call i1 @value_is_unbound(%Value %bet.a3)
+  br i1 %bet.a3_unb, label %bet.enum, label %bet.check
+bet.check:
+  ; A3 already bound. Must be Integer and within [Low, High].
+  %bet.t3 = extractvalue %Value %bet.a3, 0
+  %bet.int3 = icmp eq i32 %bet.t3, 1
+  br i1 %bet.int3, label %bet.range, label %bet.fail
+bet.range:
+  %bet.x = extractvalue %Value %bet.a3, 1
+  %bet.cmp_lo = icmp sle i64 %bet.lo, %bet.x
+  %bet.cmp_hi = icmp sle i64 %bet.x, %bet.hi
+  %bet.in_range = and i1 %bet.cmp_lo, %bet.cmp_hi
+  ret i1 %bet.in_range
+bet.enum:
+  ; Compute count = High - Low + 1. Fail if non-positive.
+  %bet.diff = sub i64 %bet.hi, %bet.lo
+  %bet.count64 = add i64 %bet.diff, 1
+  %bet.empty = icmp sle i64 %bet.count64, 0
+  br i1 %bet.empty, label %bet.fail, label %bet.size_check
+bet.size_check:
+  ; Cap result-array size: 1,000,000 ints = 16 MB on the arena.
+  ; Larger ranges fail rather than blow up memory; user code can
+  ; do its own incremental loop in that case.
+  %bet.too_big = icmp ugt i64 %bet.count64, 1000000
+  br i1 %bet.too_big, label %bet.fail, label %bet.alloc
+bet.alloc:
+  ; malloc not arena: the foreign-iter pop_cp path calls free() on
+  ; the result array when exhausted, so we need an owned heap
+  ; allocation rather than an arena bump.
+  %bet.bytes = shl i64 %bet.count64, 4  ; count * sizeof(%Value) = count * 16
+  %bet.mem = call i8* @malloc(i64 %bet.bytes)
+  %bet.mem_null = icmp eq i8* %bet.mem, null
+  br i1 %bet.mem_null, label %bet.fail, label %bet.alloc_ok
+bet.alloc_ok:
+  %bet.arr = bitcast i8* %bet.mem to %Value*
+  %bet.count = trunc i64 %bet.count64 to i32
+  br label %bet.fill_loop
+bet.fill_loop:
+  %bet.fi = phi i32 [ 0, %bet.alloc_ok ], [ %bet.fi_next, %bet.fill_step ]
+  %bet.fi_done = icmp sge i32 %bet.fi, %bet.count
+  br i1 %bet.fi_done, label %bet.bind_first, label %bet.fill_step
+bet.fill_step:
+  %bet.fi_64 = sext i32 %bet.fi to i64
+  %bet.val_i = add i64 %bet.lo, %bet.fi_64
+  %bet.v0 = insertvalue %Value undef, i32 1, 0
+  %bet.v = insertvalue %Value %bet.v0, i64 %bet.val_i, 1
+  %bet.slot = getelementptr %Value, %Value* %bet.arr, i32 %bet.fi
+  store %Value %bet.v, %Value* %bet.slot
+  %bet.fi_next = add i32 %bet.fi, 1
+  br label %bet.fill_loop
+bet.bind_first:
+  ; Bind A3 = Integer(Low) and push the foreign-iter CP so subsequent
+  ; backtracks walk arr[1..count-1].
+  %bet.first_ptr = getelementptr %Value, %Value* %bet.arr, i32 0
+  %bet.first = load %Value, %Value* %bet.first_ptr
+  call void @wam_trail_binding(%WamState* %vm, i32 2)
+  call void @wam_bind_reg(%WamState* %vm, i32 2, %Value %bet.first)
+  ; return_pc = current_pc + 1 -- where execution will resume on each yield.
+  %bet.pc = call i32 @wam_get_pc(%WamState* %vm)
+  %bet.return_pc = add i32 %bet.pc, 1
+  %bet.arr_i8 = bitcast %Value* %bet.arr to i8*
+  call void @wam_push_foreign_choice_point(%WamState* %vm,
+      i8* %bet.arr_i8, i32 %bet.count, i32 2, i32 %bet.return_pc)
+  ret i1 true
+
 unknown:
   ret i1 false
 }'.
@@ -6137,6 +6230,7 @@ builtin_op_to_id('atom_length/2', 35).
 builtin_op_to_id('atom_codes/2', 36).
 builtin_op_to_id('char_code/2', 37).
 builtin_op_to_id('atom_chars/2', 38).
+builtin_op_to_id('between/3', 39).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -814,6 +814,11 @@ is_builtin_goal(length).
 is_builtin_goal(is_list).
 is_builtin_goal(append).
 is_builtin_goal((\+)).
+is_builtin_goal(atom_length).
+is_builtin_goal(atom_codes).
+is_builtin_goal(atom_chars).
+is_builtin_goal(char_code).
+is_builtin_goal(between).
 
 %% expand_aggregate_goals_for_perm_vars(+Goals, -Expanded)
 %  For permanent-variable detection, expand aggregate_all/findall/
@@ -2083,6 +2088,7 @@ is_builtin_pred(string_length, 2).      % alias for atom_length/2.
 is_builtin_pred(number_chars, 2).       % number ↔ list of single-char atoms.
 is_builtin_pred(atom_to_term, 3).       % parse atom + return [] bindings.
 is_builtin_pred(char_code, 2).    % char-atom ↔ integer code.
+is_builtin_pred(between, 3).      % between(+Low, +High, ?X) -- nondet enumeration.
 is_builtin_pred(assertz, 1).      % dynamic db: append fact.
 is_builtin_pred(asserta, 1).      % dynamic db: prepend fact.
 % retract/1 is nondeterministic — dispatched via the Call/Execute

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -4486,31 +4486,40 @@ yield:
   br i1 %is_paired, label %yield_paired, label %yield_single
 
 yield_single:
-  ; Read result[cursor], write to result_reg
+  ; Read result[cursor], write to result_reg. M28: route through
+  ; trail_binding + bind_reg instead of set_reg so a result_reg
+  ; that holds a Ref into the heap (e.g. the put_value Y_var, A_n
+  ; pattern that aggregate_all uses for its value reg) gets the
+  ; underlying heap cell bound. Without this, the next iteration''s
+  ; deref of the Y-aliased reg sees Unbound and the aggregator
+  ; collects a sentinel instead of the yielded value.
   %fr_ptr_s = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 8
   %results_raw_s = load i8*, i8** %fr_ptr_s
   %results_s = bitcast i8* %results_raw_s to %Value*
   %cursor_64_s = zext i32 %cursor to i64
   %val_ptr_s = getelementptr %Value, %Value* %results_s, i64 %cursor_64_s
   %val_s = load %Value, %Value* %val_ptr_s
-  call void @wam_set_reg(%WamState* %vm, i32 %result_reg, %Value %val_s)
+  call void @wam_trail_binding(%WamState* %vm, i32 %result_reg)
+  call void @wam_bind_reg(%WamState* %vm, i32 %result_reg, %Value %val_s)
   %next_cursor_s = add i32 %cursor, 1
   br label %yield_done
 
 yield_paired:
   ; Paired mode: result[cursor] → reg 1 (A2), result[cursor+1] → reg 2 (A3).
-  ; Cursor advances by 2.
+  ; Cursor advances by 2. M28: same trail + bind change as yield_single.
   %fr_ptr_p = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 8
   %results_raw_p = load i8*, i8** %fr_ptr_p
   %results_p = bitcast i8* %results_raw_p to %Value*
   %cursor_64_p = zext i32 %cursor to i64
   %val1_ptr = getelementptr %Value, %Value* %results_p, i64 %cursor_64_p
   %val1 = load %Value, %Value* %val1_ptr
-  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %val1)
+  call void @wam_trail_binding(%WamState* %vm, i32 1)
+  call void @wam_bind_reg(%WamState* %vm, i32 1, %Value %val1)
   %cursor_64_p1 = add i64 %cursor_64_p, 1
   %val2_ptr = getelementptr %Value, %Value* %results_p, i64 %cursor_64_p1
   %val2 = load %Value, %Value* %val2_ptr
-  call void @wam_set_reg(%WamState* %vm, i32 2, %Value %val2)
+  call void @wam_trail_binding(%WamState* %vm, i32 2)
+  call void @wam_bind_reg(%WamState* %vm, i32 2, %Value %val2)
   %next_cursor_p = add i32 %cursor, 2
   br label %yield_done
 
@@ -4557,5 +4566,11 @@ pop_restore:
   %pop_scp = load i32, i32* %pop_scp_ptr
   call void @wam_set_cp(%WamState* %vm, i32 %pop_scp)
 
-  ret i1 false
+  ; M28: after popping the exhausted foreign-iter CP, retry backtrack
+  ; on the now-exposed CP underneath. Without this, an aggregate
+  ; sitting below a between/3 iterator never finalises -- foreign_
+  ; iter_next''s false return goes straight back to run_loop which
+  ; reads it as "no more solutions" and fails the whole goal.
+  %pop_retry = call i1 @backtrack(%WamState* %vm)
+  ret i1 %pop_retry
 }

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -408,6 +408,42 @@ test_atom_chars_print(_, R) :-
     format('~w', [Cs]),
     R is 1.
 
+% M28: between/3 multi-result iterator. Three patterns:
+%   bind + use (one solution, fail on next): runs to completion
+%   accumulate via findall (consume the iterator)
+%   check (both ends + bound X): no iterator, just range check.
+:- dynamic test_between_bind_first/2.
+test_between_bind_first(_, R) :-
+    between(3, 5, X),    % binds X = 3 on first solution
+    R is X.
+
+:- dynamic test_between_check_in/2.
+test_between_check_in(_, R) :-
+    % X already bound, both ends bound, X in range -> succeeds.
+    X = 5,
+    between(1, 10, X),
+    R is 1.
+
+:- dynamic test_between_check_out/2.
+test_between_check_out(_, R) :-
+    % X already bound, X out of range -> fails. run_test_r0 maps
+    % the failure to exit 255.
+    X = 99,
+    between(1, 10, X),
+    R is 1.
+
+:- dynamic test_between_sum/2.
+test_between_sum(_, R) :-
+    % Sum 1..10 = 55. Exercises full iterator drain via
+    % aggregate_all + between.
+    aggregate_all(sum(X), between(1, 10, X), S),
+    R is S.
+
+:- dynamic test_between_count/2.
+test_between_count(_, R) :-
+    aggregate_all(count, between(1, 7, _), N),
+    R is N.   % 7 -- route through is/2 so the result lands in A1
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -1155,6 +1191,17 @@ test_all :-
                    test_atom_chars_length, 0, 5),
        run_fmt_test('write atom_chars(hi) -> "[h, i]"',
                     test_atom_chars_print, "[h, i]"),
+       format('--- M28 between/3 ---~n'),
+       run_test_r0('between(3, 5, X) bind first -> 3',
+                   test_between_bind_first, 0, 3),
+       run_test_r0('between(1, 10, 5) in range -> 1',
+                   test_between_check_in, 0, 1),
+       run_test_r0('between(1, 10, 99) out of range -> 255',
+                   test_between_check_out, 0, 255),
+       run_test_r0('aggregate_all(sum(X), between(1, 10, X)) -> 55',
+                   test_between_sum, 0, 55),
+       run_test_r0('aggregate_all(count, between(1, 7, _)) -> 7',
+                   test_between_count, 0, 7),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Adds `builtin_between` (op id 39). Three modes:

| Mode | Args | Behaviour |
|------|------|-----------|
| enumerate | X unbound | mallocs a `count * sizeof(%Value)` buffer, fills with `Integer(Low..High)`, binds `X = Integer(Low)`, pushes a foreign-result iterator CP so backtracks walk the rest |
| check | X bound Integer | succeeds iff `Low <= X <= High` |
| fail | Low or High not Integer | fails |

Result-array size is capped at 1M entries (16 MB) — larger ranges fail rather than blow up memory. Compile-time registration in `is_builtin_pred(between, 3)` makes the WAM compiler emit `builtin_call between/3, 3` rather than a regular `call`.

## Two latent foreign-iter bugs fixed

These surfaced once `between` was used inside `aggregate_all` — the existing single foreign-iter consumer (category_ancestor) didn't exercise these paths.

**(1) `wam_foreign_iter_next` yielded via `wam_set_reg`**, which overwrites the register slot but leaves any Ref-into-heap that the caller put there unchanged. The bytecode for `aggregate_all(sum(X), between(1, 10, X), S)` does `put_value Y1, A3` so A3 holds a Ref into Y1's heap cell — between binds the heap cell on first call, but on every subsequent yield `wam_set_reg` overwrote A3 to Integer directly, leaving Y1's heap cell at the stale prior value. The aggregator's `end_aggregate` deref of Y1 then saw Unbound (after trail unwind) instead of the yielded value.

Both `yield_single` and `yield_paired` now do `wam_trail_binding + wam_bind_reg` instead, which writes through to the heap cell and trails the heap binding so the NEXT yield's unwind correctly clears it.

**(2) `pop_cp` returned false directly** when the iterator exhausted. `backtrack` relayed that to `run_loop` which read it as "no more solutions" and failed the whole goal — even if an aggregate frame was waiting underneath to be finalized. `pop_cp` now recursively calls `@backtrack` on the now-exposed CP so the aggregator (or any other outer choice point) gets its turn.

Category_ancestor (`tests/core/test_wam_llvm_realdata_benchmark.pl`) and the existing paired iterators (`astar`, `dijkstra`) were verified against the broader suite — both unchanged.

## Test plan

- [x] `tests/core/test_wam_llvm_builtin_execution.pl` — 127 cases pass (was 122). New:
  - `between(3, 5, X)` bind first → 3
  - `between(1, 10, 5)` in range → 1 (check mode)
  - `between(1, 10, 99)` out of range → 255 (correctly fails)
  - `aggregate_all(sum(X), between(1, 10, X))` → 55 (exercises fix #1: heap-write through Ref)
  - `aggregate_all(count, between(1, 7, _))` → 7 (exercises fix #2: pop_cp recursive backtrack)
- [x] `tests/core/test_wam_llvm_findall_execution.pl` — M9 still passes.
- [x] `tests/core/test_wam_llvm_realdata_benchmark.pl` — 31 ancestors, per-iter ~0.046ms, no regression.
- [x] `tests/core/test_wam_llvm_bfs_execution.pl` — 4 cases pass.
- [x] `tests/core/test_wam_llvm_astar_execution.pl` — A*(a,d) → distance 12.0.

Run with `LC_ALL=C.UTF-8`.

## Out of scope

- **Reverse modes for `between/3`**: `between(L, H, X)` with L or H unbound. Not a standard Prolog form.
- **Lazy iteration without pre-computed array**: for huge ranges (> 1M elements), a custom CP type that computes on demand would avoid the malloc. Current cap fails on those.
- **Other multi-result builtins**: with the foreign-iter pattern now correctly handling Ref-aliased result regs and exhaustion cascade, things like `nth0/3` / `nth1/3` / `last/2` enumeration are easier to add.

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_