### PR TITLE
LLVM WAM: sub_atom/5 deterministic extraction mode (M31)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3400,6 +3400,7 @@ entry:
     i32 38, label %builtin_atom_chars
     i32 39, label %builtin_between
     i32 40, label %builtin_atom_concat
+    i32 41, label %builtin_sub_atom
   ]
 
 builtin_is:
@@ -5192,6 +5193,83 @@ atc.check:
   %atc.eq = call i1 @value_equals(%Value %atc.a3, %Value %atc.new_v)
   ret i1 %atc.eq
 
+builtin_sub_atom:
+  ; M31: sub_atom(Atom, Before, Length, After, SubAtom) -- deterministic
+  ; extraction mode only. Requires A1 bound atom, A2 + A3 bound
+  ; non-negative Integers. Computes After = n - Before - Length, fails
+  ; if any of Before / Length / After is negative or the span exceeds
+  ; the source atom''s length. Then memcpys the [Before, Before+Length)
+  ; slice into an arena buffer, interns it, and unifies A4 with
+  ; Integer(After) and A5 with the new atom. Full nondeterministic
+  ; enumeration over Before / Length is deferred to a later milestone.
+  %sba.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %sba.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %sba.a3 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 2)
+  %sba.t1 = extractvalue %Value %sba.a1, 0
+  %sba.t2 = extractvalue %Value %sba.a2, 0
+  %sba.t3 = extractvalue %Value %sba.a3, 0
+  %sba.is_atom = icmp eq i32 %sba.t1, 0
+  %sba.is_int2 = icmp eq i32 %sba.t2, 1
+  %sba.is_int3 = icmp eq i32 %sba.t3, 1
+  %sba.ai = and i1 %sba.is_atom, %sba.is_int2
+  %sba.aii = and i1 %sba.ai, %sba.is_int3
+  br i1 %sba.aii, label %sba.lookup, label %sba.fail
+sba.fail:
+  ret i1 false
+sba.lookup:
+  %sba.aid = extractvalue %Value %sba.a1, 1
+  %sba.str = call i8* @wam_atom_to_string(i64 %sba.aid)
+  %sba.str_null = icmp eq i8* %sba.str, null
+  br i1 %sba.str_null, label %sba.fail, label %sba.measure
+sba.measure:
+  br label %sba.m_loop
+sba.m_loop:
+  %sba.mp = phi i8* [ %sba.str, %sba.measure ], [ %sba.mpn, %sba.m_step ]
+  %sba.mn = phi i64 [ 0, %sba.measure ], [ %sba.mn1, %sba.m_step ]
+  %sba.mc = load i8, i8* %sba.mp
+  %sba.mz = icmp eq i8 %sba.mc, 0
+  br i1 %sba.mz, label %sba.bounds, label %sba.m_step
+sba.m_step:
+  %sba.mpn = getelementptr i8, i8* %sba.mp, i32 1
+  %sba.mn1 = add i64 %sba.mn, 1
+  br label %sba.m_loop
+sba.bounds:
+  ; Validate Before >= 0, Length >= 0, Before + Length <= n.
+  %sba.b = extractvalue %Value %sba.a2, 1
+  %sba.l = extractvalue %Value %sba.a3, 1
+  %sba.b_neg = icmp slt i64 %sba.b, 0
+  %sba.l_neg = icmp slt i64 %sba.l, 0
+  %sba.any_neg = or i1 %sba.b_neg, %sba.l_neg
+  br i1 %sba.any_neg, label %sba.fail, label %sba.bounds2
+sba.bounds2:
+  %sba.bl = add i64 %sba.b, %sba.l
+  %sba.over = icmp sgt i64 %sba.bl, %sba.mn
+  br i1 %sba.over, label %sba.fail, label %sba.slice
+sba.slice:
+  ; After = n - (Before + Length); allocate (Length+1) bytes; memcpy
+  ; slice; null-terminate; intern.
+  %sba.after = sub i64 %sba.mn, %sba.bl
+  call void @wam_arena_ensure()
+  %sba.bufsize = add i64 %sba.l, 1
+  %sba.buf = call i8* @wam_arena_alloc(i64 %sba.bufsize)
+  %sba.src = getelementptr i8, i8* %sba.str, i64 %sba.b
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %sba.buf, i8* %sba.src, i64 %sba.l, i1 false)
+  %sba.term = getelementptr i8, i8* %sba.buf, i64 %sba.l
+  store i8 0, i8* %sba.term
+  %sba.new_id = call i64 @wam_intern_atom(i8* %sba.buf, i64 %sba.l)
+  %sba.new_v0 = insertvalue %Value undef, i32 0, 0
+  %sba.new_v = insertvalue %Value %sba.new_v0, i64 %sba.new_id, 1
+  %sba.after_v0 = insertvalue %Value undef, i32 1, 0
+  %sba.after_v = insertvalue %Value %sba.after_v0, i64 %sba.after, 1
+  ; Unify A4 with After.
+  %sba.raw4 = call %Value @wam_get_reg(%WamState* %vm, i32 3)
+  %sba.u4 = call i1 @wam_unify_value(%WamState* %vm, %Value %sba.raw4, %Value %sba.after_v)
+  br i1 %sba.u4, label %sba.unify5, label %sba.fail
+sba.unify5:
+  %sba.raw5 = call %Value @wam_get_reg(%WamState* %vm, i32 4)
+  %sba.u5 = call i1 @wam_unify_value(%WamState* %vm, %Value %sba.raw5, %Value %sba.new_v)
+  ret i1 %sba.u5
+
 unknown:
   ret i1 false
 }'.
@@ -6605,6 +6683,7 @@ builtin_op_to_id('char_code/2', 37).
 builtin_op_to_id('atom_chars/2', 38).
 builtin_op_to_id('between/3', 39).
 builtin_op_to_id('atom_concat/3', 40).
+builtin_op_to_id('sub_atom/5', 41).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2090,6 +2090,7 @@ is_builtin_pred(atom_to_term, 3).       % parse atom + return [] bindings.
 is_builtin_pred(char_code, 2).    % char-atom ↔ integer code.
 is_builtin_pred(between, 3).      % between(+Low, +High, ?X) -- nondet enumeration.
 is_builtin_pred(atom_concat, 3).  % atom_concat(+A1, +A2, -A12) -- forward concat.
+is_builtin_pred(sub_atom, 5).     % sub_atom(+A, +B, +L, ?After, ?Sub) -- deterministic extraction.
 is_builtin_pred(assertz, 1).      % dynamic db: append fact.
 is_builtin_pred(asserta, 1).      % dynamic db: prepend fact.
 % retract/1 is nondeterministic — dispatched via the Call/Execute

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -540,6 +540,51 @@ test_atom_chars_reverse_dedup(_, R) :-
     atom_chars(B, [h, i, j]),
     ( A == B -> R is 1 ; R is 0 ).
 
+% M31: sub_atom/5 deterministic extraction. Requires Atom + Before +
+% Length all bound. Verifies After is computed correctly and the
+% extracted slice is interned (so subsequent forward ops see it).
+
+:- dynamic test_sub_atom_extract_length/2.
+test_sub_atom_extract_length(_, R) :-
+    sub_atom(hello, 1, 3, _, S),    % "ell"
+    atom_length(S, N),
+    R is N.   % 3
+
+:- dynamic test_sub_atom_extract_after/2.
+test_sub_atom_extract_after(_, R) :-
+    sub_atom(hello, 1, 3, A, _),    % After = 5 - 1 - 3 = 1
+    R is A.   % 1
+
+:- dynamic test_sub_atom_extract_first_code/2.
+test_sub_atom_extract_first_code(_, R) :-
+    sub_atom(hello, 1, 3, _, S),    % "ell"
+    atom_codes(S, [C|_]),
+    R is C.   % 'e' = 101
+
+:- dynamic test_sub_atom_dedup/2.
+test_sub_atom_dedup(_, R) :-
+    sub_atom(hello, 1, 3, _, S1),
+    sub_atom(hello, 1, 3, _, S2),
+    ( S1 == S2 -> R is 1 ; R is 0 ).
+
+:- dynamic test_sub_atom_empty/2.
+test_sub_atom_empty(_, R) :-
+    sub_atom(hello, 2, 0, _, S),    % empty slice
+    atom_length(S, N),
+    R is N.   % 0
+
+:- dynamic test_sub_atom_full/2.
+test_sub_atom_full(_, R) :-
+    sub_atom(hello, 0, 5, A, S),    % whole atom, After = 0
+    atom_length(S, N),
+    R is N + A.   % 5 + 0 = 5
+
+:- dynamic test_sub_atom_overflow/2.
+test_sub_atom_overflow(_, R) :-
+    ( sub_atom(hi, 0, 99, _, _)
+    -> R is 1
+    ;  R is 0 ).   % 0 -- length exceeds source
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -1324,6 +1369,21 @@ test_all :-
                    test_atom_chars_reverse_first, 0, 104),
        run_test_r0('atom_chars(A,[h,i,j]) atom_codes(A) twice == 1',
                    test_atom_chars_reverse_dedup, 0, 1),
+       format('--- M31 sub_atom/5 deterministic extraction ---~n'),
+       run_test_r0('sub_atom(hello,1,3,_,S) atom_length(S) -> 3',
+                   test_sub_atom_extract_length, 0, 3),
+       run_test_r0('sub_atom(hello,1,3,A,_) After -> 1',
+                   test_sub_atom_extract_after, 0, 1),
+       run_test_r0('sub_atom(hello,1,3,_,S) first code -> 101 (e)',
+                   test_sub_atom_extract_first_code, 0, 101),
+       run_test_r0('sub_atom(hello,1,3,_,S) twice -> same id -> 1',
+                   test_sub_atom_dedup, 0, 1),
+       run_test_r0('sub_atom(hello,2,0,_,S) atom_length(S) -> 0',
+                   test_sub_atom_empty, 0, 0),
+       run_test_r0('sub_atom(hello,0,5,A,S) N + After -> 5',
+                   test_sub_atom_full, 0, 5),
+       run_test_r0('sub_atom(hi,0,99,_,_) overflow -> 0',
+                   test_sub_atom_overflow, 0, 0),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Implements the most common `sub_atom/5` mode: Atom + Before + Length all
bound → compute After, slice the source atom, intern the result, and
unify A4 + A5. Full nondeterministic enumeration (where Before / Length
are variables) is deferred to a later milestone; it needs a foreign-iter
CP similar to `between/3`.

### Mechanics
- Validate `A1.tag == Atom`, `A2.tag == Integer`, `A3.tag == Integer`.
- Look up A1's string, measure null-terminated length `n`.
- Bounds check: `Before >= 0`, `Length >= 0`, `Before + Length <= n`;
  any violation fails (matches ISO semantics).
- `arena_alloc(Length + 1)`, `memcpy` from `str + Before`, null-terminate,
  call `@wam_intern_atom` to build / dedupe.
- `wam_unify_value` on A4 with `Integer(After)`, then on A5 with the new
  atom; either failing unification returns false.

### Dispatch
- `builtin_op_to_id('sub_atom/5', 41)` → `i32 41, label %builtin_sub_atom`.
- `is_builtin_pred(sub_atom, 5)` in `wam_target.pl` so the WAM compiler
  emits `builtin_call` instead of regular `call`.
- Variable prefix `sba.` to stay clear of `sb.` / `sa.` neighbours.

## Test plan
- [x] 7 new builtin tests added covering atom_length, After, first code,
      dedup, empty slice, whole-atom slice, and overflow failure
- [x] All 146 builtin tests pass (was 139, +7 new)
- [x] bfs execution: 4/4 PASS
- [x] astar execution: PASS


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_