### PR TITLE
Preserve improper list arguments in WAM codegen

### DIFF
--- a/PR_wam_preserve_improper_list_arguments.md
+++ b/PR_wam_preserve_improper_list_arguments.md
@@ -1,0 +1,21 @@
+# Title
+
+Preserve improper list arguments in WAM codegen
+
+# Description
+
+## Summary
+
+- Fixes WAM argument codegen so `put_list` is used only for proper list literals.
+- Lets improper lists such as `[a|b]` compile as ordinary `[|]/2` structures, preserving the non-list tail.
+- Restores Go WAM builtin behavior for malformed-list rejection in `select/3`, `delete/3`, `permutation/2`, `sort/2`, and similar list builtins.
+- Refreshes the Go WAM builtin test assertion for the current inlined negation lowering, which emits `fail/0` instead of a direct `\+/1` meta-call.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2156,7 +2156,8 @@ compile_put_argument(Arg, I, V0, V1, Code) :-
     ->  quote_wam_constant(Arg, ArgStr),
         format(string(Code), "    put_constant ~w, A~w", [ArgStr, I]),
         V1 = V0
-    ;   is_list_term(Arg)
+    ;   is_list_term(Arg),
+        proper_list(Arg, _)
     ->  Arg = [H|T],
         next_x_reg(V0, XReg, V_temp),
         bind_var(Arg, XReg, V_temp, V2),

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -571,7 +571,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "number_chars/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "atom_string/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "string_to_atom/2"')),
-    assertion(sub_string(LibCode, _, _, _, 'Op: "\\\\+/1"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "fail/0"')),
     assertion(sub_string(LibCode, _, _, _, 'AggType: "set"')),
 
     % Add a main.go to run the test in a separate cmd directory


### PR DESCRIPTION
## Summary

- Fixes WAM argument codegen so `put_list` is used only for proper list literals.
- Lets improper lists such as `[a|b]` compile as ordinary `[|]/2` structures, preserving the non-list tail.
- Restores Go WAM builtin behavior for malformed-list rejection in `select/3`, `delete/3`, `permutation/2`, `sort/2`, and similar list builtins.
- Refreshes the Go WAM builtin test assertion for the current inlined negation lowering, which emits `fail/0` instead of a direct `\+/1` meta-call.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
