### PR TITLE
LLVM WAM: atom_number/2 integer mode (M32)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3401,6 +3401,7 @@ entry:
     i32 39, label %builtin_between
     i32 40, label %builtin_atom_concat
     i32 41, label %builtin_sub_atom
+    i32 42, label %builtin_atom_number
   ]
 
 builtin_is:
@@ -5270,6 +5271,90 @@ sba.unify5:
   %sba.u5 = call i1 @wam_unify_value(%WamState* %vm, %Value %sba.raw5, %Value %sba.new_v)
   ret i1 %sba.u5
 
+builtin_atom_number:
+  ; M32: atom_number(?Atom, ?Number) -- integer mode only.
+  ;   A1 bound atom: parse digits (with optional leading ''-''), unify
+  ;     A2 with Integer(value). Empty / sign-only / non-digit input
+  ;     fails cleanly.
+  ;   A1 unbound + A2 bound Integer: snprintf the value with %lld,
+  ;     intern it, unify A1 with the resulting atom.
+  ;   Other combinations fail. Float parsing / formatting is deferred.
+  %anu.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %anu.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %anu.t1 = extractvalue %Value %anu.a1, 0
+  %anu.is_atom = icmp eq i32 %anu.t1, 0
+  br i1 %anu.is_atom, label %anu.fwd_lookup, label %anu.try_reverse
+anu.try_reverse:
+  %anu.t2 = extractvalue %Value %anu.a2, 0
+  %anu.is_int2 = icmp eq i32 %anu.t2, 1
+  br i1 %anu.is_int2, label %anu.reverse, label %anu.fail
+anu.fail:
+  ret i1 false
+anu.fwd_lookup:
+  %anu.aid = extractvalue %Value %anu.a1, 1
+  %anu.str = call i8* @wam_atom_to_string(i64 %anu.aid)
+  %anu.str_null = icmp eq i8* %anu.str, null
+  br i1 %anu.str_null, label %anu.fail, label %anu.parse_init
+anu.parse_init:
+  ; Inspect first byte to decide sign.
+  %anu.c0 = load i8, i8* %anu.str
+  %anu.is_neg = icmp eq i8 %anu.c0, 45   ; ASCII ''-''
+  br i1 %anu.is_neg, label %anu.sel_neg, label %anu.sel_pos
+anu.sel_neg:
+  %anu.pn0 = getelementptr i8, i8* %anu.str, i32 1
+  br label %anu.first_check
+anu.sel_pos:
+  br label %anu.first_check
+anu.first_check:
+  %anu.p_start = phi i8* [ %anu.pn0, %anu.sel_neg ], [ %anu.str, %anu.sel_pos ]
+  %anu.sign = phi i64 [ -1, %anu.sel_neg ], [ 1, %anu.sel_pos ]
+  ; Require at least one digit after the optional sign.
+  %anu.fc = load i8, i8* %anu.p_start
+  %anu.fc_ge0 = icmp uge i8 %anu.fc, 48
+  %anu.fc_le9 = icmp ule i8 %anu.fc, 57
+  %anu.fc_dig = and i1 %anu.fc_ge0, %anu.fc_le9
+  br i1 %anu.fc_dig, label %anu.parse_loop, label %anu.fail
+anu.parse_loop:
+  %anu.p = phi i8* [ %anu.p_start, %anu.first_check ], [ %anu.pn, %anu.parse_step ]
+  %anu.acc = phi i64 [ 0, %anu.first_check ], [ %anu.acc1, %anu.parse_step ]
+  %anu.lc = load i8, i8* %anu.p
+  %anu.lc_zero = icmp eq i8 %anu.lc, 0
+  br i1 %anu.lc_zero, label %anu.parse_done, label %anu.parse_check
+anu.parse_check:
+  %anu.lc_ge0 = icmp uge i8 %anu.lc, 48
+  %anu.lc_le9 = icmp ule i8 %anu.lc, 57
+  %anu.lc_dig = and i1 %anu.lc_ge0, %anu.lc_le9
+  br i1 %anu.lc_dig, label %anu.parse_step, label %anu.fail
+anu.parse_step:
+  %anu.dig8 = sub i8 %anu.lc, 48
+  %anu.dig64 = zext i8 %anu.dig8 to i64
+  %anu.mul = mul i64 %anu.acc, 10
+  %anu.acc1 = add i64 %anu.mul, %anu.dig64
+  %anu.pn = getelementptr i8, i8* %anu.p, i32 1
+  br label %anu.parse_loop
+anu.parse_done:
+  %anu.signed = mul i64 %anu.acc, %anu.sign
+  %anu.fwd_v0 = insertvalue %Value undef, i32 1, 0
+  %anu.fwd_v = insertvalue %Value %anu.fwd_v0, i64 %anu.signed, 1
+  %anu.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %anu.fwd_u = call i1 @wam_unify_value(%WamState* %vm, %Value %anu.raw2, %Value %anu.fwd_v)
+  ret i1 %anu.fwd_u
+anu.reverse:
+  ; A2 bound Integer; format ``%lld`` into a 32-byte arena buffer and
+  ; intern.
+  %anu.n = extractvalue %Value %anu.a2, 1
+  call void @wam_arena_ensure()
+  %anu.rbuf = call i8* @wam_arena_alloc(i64 32)
+  %anu.rfmt = getelementptr [5 x i8], [5 x i8]* @.fmt_lld, i32 0, i32 0
+  %anu.rlen = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %anu.rbuf, i64 32, i8* %anu.rfmt, i64 %anu.n)
+  %anu.rlen64 = sext i32 %anu.rlen to i64
+  %anu.rev_id = call i64 @wam_intern_atom(i8* %anu.rbuf, i64 %anu.rlen64)
+  %anu.rev_v0 = insertvalue %Value undef, i32 0, 0
+  %anu.rev_v = insertvalue %Value %anu.rev_v0, i64 %anu.rev_id, 1
+  %anu.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %anu.rev_u = call i1 @wam_unify_value(%WamState* %vm, %Value %anu.raw1, %Value %anu.rev_v)
+  ret i1 %anu.rev_u
+
 unknown:
   ret i1 false
 }'.
@@ -6684,6 +6769,7 @@ builtin_op_to_id('atom_chars/2', 38).
 builtin_op_to_id('between/3', 39).
 builtin_op_to_id('atom_concat/3', 40).
 builtin_op_to_id('sub_atom/5', 41).
+builtin_op_to_id('atom_number/2', 42).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2091,6 +2091,7 @@ is_builtin_pred(char_code, 2).    % char-atom ↔ integer code.
 is_builtin_pred(between, 3).      % between(+Low, +High, ?X) -- nondet enumeration.
 is_builtin_pred(atom_concat, 3).  % atom_concat(+A1, +A2, -A12) -- forward concat.
 is_builtin_pred(sub_atom, 5).     % sub_atom(+A, +B, +L, ?After, ?Sub) -- deterministic extraction.
+is_builtin_pred(atom_number, 2).  % atom_number(?A, ?N) -- integer mode only.
 is_builtin_pred(assertz, 1).      % dynamic db: append fact.
 is_builtin_pred(asserta, 1).      % dynamic db: prepend fact.
 % retract/1 is nondeterministic — dispatched via the Call/Execute

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -585,6 +585,55 @@ test_sub_atom_overflow(_, R) :-
     -> R is 1
     ;  R is 0 ).   % 0 -- length exceeds source
 
+% M32: atom_number/2 integer mode -- forward (atom -> int) + reverse
+% (int -> atom). Float parsing / formatting deferred.
+
+:- dynamic test_atom_number_fwd/2.
+test_atom_number_fwd(_, R) :-
+    atom_number('42', N),
+    R is N.   % 42
+
+:- dynamic test_atom_number_fwd_neg/2.
+test_atom_number_fwd_neg(_, R) :-
+    atom_number('-17', N),
+    R is N + 100.   % 83
+
+:- dynamic test_atom_number_fwd_zero/2.
+test_atom_number_fwd_zero(_, R) :-
+    atom_number('0', N),
+    R is N + 7.   % 7
+
+:- dynamic test_atom_number_fwd_bad/2.
+test_atom_number_fwd_bad(_, R) :-
+    ( atom_number('12abc', _)
+    -> R is 1
+    ;  R is 0 ).   % 0 -- trailing junk fails
+
+:- dynamic test_atom_number_fwd_empty/2.
+test_atom_number_fwd_empty(_, R) :-
+    ( atom_number('', _)
+    -> R is 1
+    ;  R is 0 ).   % 0 -- empty atom fails
+
+:- dynamic test_atom_number_rev/2.
+test_atom_number_rev(_, R) :-
+    atom_number(A, 42),
+    atom_length(A, N),
+    R is N.   % 2
+
+:- dynamic test_atom_number_rev_neg/2.
+test_atom_number_rev_neg(_, R) :-
+    atom_number(A, -17),
+    atom_length(A, N),
+    R is N.   % 3
+
+% Roundtrip: number -> atom -> back to same number.
+:- dynamic test_atom_number_roundtrip/2.
+test_atom_number_roundtrip(_, R) :-
+    atom_number(A, 99),
+    atom_number(A, N),
+    R is N.   % 99 (kept <256 for bash exit-code carry)
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -1384,6 +1433,23 @@ test_all :-
                    test_sub_atom_full, 0, 5),
        run_test_r0('sub_atom(hi,0,99,_,_) overflow -> 0',
                    test_sub_atom_overflow, 0, 0),
+       format('--- M32 atom_number/2 integer forward + reverse ---~n'),
+       run_test_r0('atom_number(\'42\', N) -> 42',
+                   test_atom_number_fwd, 0, 42),
+       run_test_r0('atom_number(\'-17\', N) -> N + 100 = 83',
+                   test_atom_number_fwd_neg, 0, 83),
+       run_test_r0('atom_number(\'0\', N) -> N + 7 = 7',
+                   test_atom_number_fwd_zero, 0, 7),
+       run_test_r0('atom_number(\'12abc\', _) trailing junk -> 0',
+                   test_atom_number_fwd_bad, 0, 0),
+       run_test_r0('atom_number(\'\', _) empty -> 0',
+                   test_atom_number_fwd_empty, 0, 0),
+       run_test_r0('atom_number(A, 42), atom_length(A) -> 2',
+                   test_atom_number_rev, 0, 2),
+       run_test_r0('atom_number(A, -17), atom_length(A) -> 3',
+                   test_atom_number_rev_neg, 0, 3),
+       run_test_r0('roundtrip atom_number(A,99) twice -> 99',
+                   test_atom_number_roundtrip, 0, 99),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Adds `atom_number(?Atom, ?Number)` as a bidirectional integer builtin.
Forward parses digits (with optional leading minus) into an `Integer`
`Value`; reverse formats an `Integer` via `snprintf %lld`, interns the
result, and binds the atom. Float parsing / formatting is deferred to
a later milestone.

### Forward mode (A1 bound atom)
- Look up A1's C string. Inspect first byte: if `-` (45), set
  `sign = -1` and advance; otherwise `sign = +1`.
- Require at least one digit at the post-sign position (rejects `''`
  and `'-'`); each subsequent byte must also be a digit (48..57) up
  to the null terminator. Any non-digit fails — `'12abc'` and `''`
  cleanly return false.
- Accumulate as `i64`, multiply by sign, wrap in `Integer`, unify with
  A2 (handles both unbound and already-bound A2 via `wam_unify_value`).

### Reverse mode (A1 unbound, A2 bound Integer)
- `arena_alloc` 32 bytes, `snprintf` with `@.fmt_lld` (already declared
  by `state.ll.mustache` for `format/2`), grab `snprintf`'s return
  value as the string length, intern, unify A1 with the new atom.

### Dispatch
- `builtin_op_to_id('atom_number/2', 42)` → `i32 42, label %builtin_atom_number`.
- `is_builtin_pred(atom_number, 2)` in `wam_target.pl`.
- Variable prefix `anu.` to stay clear of `an.` / `am.` neighbours.

## Test plan
- [x] 8 new builtin tests: signed forward, zero, malformed (trailing
      junk + empty), reverse signed, atom_length of result, and a
      roundtrip (kept `<256` for bash exit-code carry)
- [x] All 154 builtin tests pass (was 146, +8)
- [x] bfs execution 4/4 PASS, astar execution PASS


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_