### PR TITLE
fix(wam-python): use typing.Union for Term so generated runtime imports on Python 3.8+

### DIFF
--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -8,7 +8,7 @@ import copy
 import os
 import sys
 from dataclasses import dataclass, field
-from typing import Any, Optional, Callable, Dict, List, Tuple
+from typing import Any, Optional, Callable, Dict, List, Tuple, Union
 
 
 # -- Term representation ----------------------------------------------------
@@ -54,7 +54,12 @@ class StreamHandle:
     handle: Any
     def __deepcopy__(self, memo): return self
 
-Term = Atom | Compound | Var | Int | Float | Ref | StreamHandle
+# NB: a runtime assignment, not an annotation — `from __future__ import
+# annotations` does NOT defer it, so PEP-604 `X | Y` union syntax would
+# evaluate eagerly and raise TypeError on Python < 3.10. Use typing.Union
+# so the generated runtime imports cleanly on 3.8+ (the rest of the file
+# already targets old Python via Optional/List/Dict).
+Term = Union[Atom, Compound, Var, Int, Float, Ref, StreamHandle]
 
 # -- Atom interning cache -----------------------------------------------------
 # Ensures `make_atom("foo") is make_atom("foo")` — pointer-equality for equal


### PR DESCRIPTION
  ## Summary

  The generated WAM Python runtime — `wam_python_runtime/WamRuntime.py`, copied verbatim into every generated project —
  defined the `Term` type alias with PEP-604 `X | Y` union syntax:

  ```python
  Term = Atom | Compound | Var | Int | Float | Ref | StreamHandle
  ```

  This is a **runtime assignment, not an annotation**, so the file's `from __future__ import annotations` does **not** defer
  it — the `|` evaluates eagerly at import time and raises:

  ```
  TypeError: unsupported operand type(s) for |: 'type' and 'type'
  ```

  on **Python < 3.10**. Every test that executes generated Python died on `from wam_runtime import *`. The rest of the file
  already targets old Python (`Optional` / `List` / `Dict` from `typing`), so this one line was an inconsistency, not an
  intended 3.10 floor.

  ## Fix

  Switch to `typing.Union` (and add `Union` to the existing `typing` import). No behaviour change on 3.10+; the runtime now
  imports cleanly on **3.8+**.

  ```python
  Term = Union[Atom, Compound, Var, Int, Float, Ref, StreamHandle]
  ```
  ## Fix

  Switch to `typing.Union` (and add `Union` to the existing `typing` import). No behaviour change on 3.10+; the runtime now
  imports cleanly on **3.8+**.

  ```python
  Term = Union[Atom, Compound, Var, Int, Float, Ref, StreamHandle]
  ```

  ## Impact

  Fixes **37 pre-existing failures** in `test_wam_python_target.pl` (the `wam_python_runtime_parser_mode` and
  `wam_python_compile` units — everything that runs generated Python). Suite goes **129/166 → 166/166**.

  Confirmed single root cause: no other generated `.py` in the tree carries the `X | Y` pattern.

  ## Test plan

  - [x] `python3 -c "import ast; ast.parse(...)"` — syntax validates
  - [x] `test_wam_python_target.pl`: **166/166** (was 129/166), local Python 3.8.10
  - [x] Grep swept all `src/unifyweaver/**/*.py` for other runtime-evaluated `X | Y` unions — none found

  ## Note

  These failures were previously assumed to be an environmental gap (generated code needing a newer Python). They are not —
  it's a real latent bug in the committed runtime, reproducible on any Python < 3.10.