### PR TITLE
LLVM WAM: string-type aliases (M36)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3406,6 +3406,10 @@ entry:
     i32 44, label %builtin_number_chars
     i32 45, label %builtin_upcase_atom
     i32 46, label %builtin_downcase_atom
+    i32 47, label %builtin_atom_concat
+    i32 48, label %builtin_atom_length
+    i32 49, label %builtin_atom_string_alias
+    i32 50, label %builtin_atom_string_alias
   ]
 
 builtin_is:
@@ -5827,6 +5831,17 @@ dca.x_term:
   %dca.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %dca.raw2, %Value %dca.new_v)
   ret i1 %dca.uok
 
+builtin_atom_string_alias:
+  ; M36: atom_string(?Atom, ?String) and string_to_atom(?String, ?Atom)
+  ; -- the runtime has no distinct string type, so both reduce to
+  ; unifying A1 with A2 (handles bind, check, and both-unbound modes
+  ; uniformly). string_concat/3 and string_length/2 share dispatch
+  ; labels with atom_concat / atom_length directly (no block needed).
+  %asa.r1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %asa.r2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %asa.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %asa.r1, %Value %asa.r2)
+  ret i1 %asa.ok
+
 unknown:
   ret i1 false
 }'.
@@ -7246,6 +7261,10 @@ builtin_op_to_id('number_codes/2', 43).
 builtin_op_to_id('number_chars/2', 44).
 builtin_op_to_id('upcase_atom/2', 45).
 builtin_op_to_id('downcase_atom/2', 46).
+builtin_op_to_id('string_concat/3', 47).  % alias of atom_concat/3
+builtin_op_to_id('string_length/2', 48).  % alias of atom_length/2
+builtin_op_to_id('atom_string/2', 49).    % atom <-> string (runtime treats both as atoms)
+builtin_op_to_id('string_to_atom/2', 50). % string_to_atom(?S, ?A) -- same as atom_string but swapped
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -788,6 +788,48 @@ test_upcase_downcase_roundtrip(_, R) :-
     downcase_atom(U, D),
     ( D == hello -> R is 1 ; R is 0 ).   % 1
 
+% M36: string-type aliases. Runtime has no distinct string type, so
+% atom_string / string_to_atom reduce to unify, and string_concat /
+% string_length share dispatch labels with atom_concat / atom_length.
+
+:- dynamic test_atom_string_fwd/2.
+test_atom_string_fwd(_, R) :-
+    atom_string(hello, S),
+    atom_length(S, N),
+    R is N.   % 5
+
+:- dynamic test_atom_string_check/2.
+test_atom_string_check(_, R) :-
+    ( atom_string(hello, hello) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_string_to_atom_fwd/2.
+test_string_to_atom_fwd(_, R) :-
+    string_to_atom(world, A),
+    atom_length(A, N),
+    R is N.   % 5
+
+:- dynamic test_string_concat_length/2.
+test_string_concat_length(_, R) :-
+    string_concat(hi, there, S),
+    atom_length(S, N),
+    R is N.   % 7
+
+:- dynamic test_string_concat_first_code/2.
+test_string_concat_first_code(_, R) :-
+    string_concat(ab, cd, S),
+    atom_codes(S, [C|_]),
+    R is C.   % 'a' = 97
+
+:- dynamic test_string_length_simple/2.
+test_string_length_simple(_, R) :-
+    string_length(hello, N),
+    R is N.   % 5
+
+:- dynamic test_string_length_empty/2.
+test_string_length_empty(_, R) :-
+    string_length('', N),
+    R is N + 42.   % 42
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -1657,6 +1699,21 @@ test_all :-
                    test_downcase_mixed, 0, 98),
        run_test_r0('upcase then downcase roundtrip -> hello -> 1',
                    test_upcase_downcase_roundtrip, 0, 1),
+       format('--- M36 string-type aliases (atom_string/string_concat/string_length/string_to_atom) ---~n'),
+       run_test_r0('atom_string(hello, S), atom_length(S) -> 5',
+                   test_atom_string_fwd, 0, 5),
+       run_test_r0('atom_string(hello, hello) check -> 1',
+                   test_atom_string_check, 0, 1),
+       run_test_r0('string_to_atom(world, A), atom_length(A) -> 5',
+                   test_string_to_atom_fwd, 0, 5),
+       run_test_r0('string_concat(hi, there, S), atom_length(S) -> 7',
+                   test_string_concat_length, 0, 7),
+       run_test_r0('string_concat(ab, cd, S) first code -> 97',
+                   test_string_concat_first_code, 0, 97),
+       run_test_r0('string_length(hello, N) -> 5',
+                   test_string_length_simple, 0, 5),
+       run_test_r0('string_length(\'\', N) + 42 -> 42',
+                   test_string_length_empty, 0, 42),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Routes the four SWI string-API predicates to existing atom-builtin
labels. The runtime has no distinct string type — strings are atoms —
so `atom_string` / `string_to_atom` reduce to
`wam_unify_value(A1, A2)`, and `string_concat` / `string_length` share
dispatch labels with `atom_concat` / `atom_length` directly.

### Dispatch
- `string_concat/3`   op id 47 → label `%builtin_atom_concat`
- `string_length/2`   op id 48 → label `%builtin_atom_length`
- `atom_string/2`     op id 49 → label `%builtin_atom_string_alias`
- `string_to_atom/2`  op id 50 → label `%builtin_atom_string_alias`
  (arg order doesn't matter since the block just unifies A1 with A2)

### New IR
- One tiny block `builtin_atom_string_alias` (prefix `asa.`) that does
  `wam_unify_value` on the two raw register slots; handles bind +
  check + both-unbound modes uniformly.

All four predicates were already registered in `wam_target.pl`'s
`is_builtin_pred` table.

## Test plan
- [x] 7 new builtin tests: forward bind, equality check, swapped-arg
      forward, concat length + composition with `atom_codes`, length
      simple + empty
- [x] All 186 builtin tests pass (was 179, +7)
- [x] bfs execution 4/4 PASS, astar execution PASS


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_