### PR TITLE
LLVM WAM: nth0/3 + nth1/3 + last/2 list-indexing (M37)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3410,6 +3410,9 @@ entry:
     i32 48, label %builtin_atom_length
     i32 49, label %builtin_atom_string_alias
     i32 50, label %builtin_atom_string_alias
+    i32 51, label %builtin_nth0
+    i32 52, label %builtin_nth1
+    i32 53, label %builtin_last
   ]
 
 builtin_is:
@@ -5842,6 +5845,135 @@ builtin_atom_string_alias:
   %asa.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %asa.r1, %Value %asa.r2)
   ret i1 %asa.ok
 
+builtin_nth0:
+  ; M37: nth0(+Index, +List, ?Elem) -- 0-indexed list access.
+  ; Walks the [|]/2 chain Index times then takes the head; unifies A3
+  ; with that element. Negative Index, non-Integer Index, or running
+  ; off the end of the list all fail cleanly.
+  %n0.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %n0.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %n0.t1 = extractvalue %Value %n0.a1, 0
+  %n0.is_int = icmp eq i32 %n0.t1, 1
+  br i1 %n0.is_int, label %n0.start, label %n0.fail
+n0.fail:
+  ret i1 false
+n0.start:
+  %n0.i0 = extractvalue %Value %n0.a1, 1
+  %n0.i0_neg = icmp slt i64 %n0.i0, 0
+  br i1 %n0.i0_neg, label %n0.fail, label %n0.loop
+n0.loop:
+  %n0.cur = phi %Value [ %n0.a2, %n0.start ], [ %n0.next, %n0.advance ]
+  %n0.i = phi i64 [ %n0.i0, %n0.start ], [ %n0.i_next, %n0.advance ]
+  %n0.d = call %Value @wam_deref_value(%WamState* %vm, %Value %n0.cur)
+  %n0.tag = extractvalue %Value %n0.d, 0
+  %n0.is_cmp = icmp eq i32 %n0.tag, 3
+  br i1 %n0.is_cmp, label %n0.dispatch, label %n0.fail
+n0.dispatch:
+  %n0.i_zero = icmp eq i64 %n0.i, 0
+  br i1 %n0.i_zero, label %n0.take_head, label %n0.advance
+n0.advance:
+  %n0.cp = extractvalue %Value %n0.d, 1
+  %n0.cp_ptr = inttoptr i64 %n0.cp to %Compound*
+  %n0.args_slot = getelementptr %Compound, %Compound* %n0.cp_ptr, i32 0, i32 2
+  %n0.args = load %Value*, %Value** %n0.args_slot
+  %n0.tail_ptr = getelementptr %Value, %Value* %n0.args, i32 1
+  %n0.next = load %Value, %Value* %n0.tail_ptr
+  %n0.i_next = sub i64 %n0.i, 1
+  br label %n0.loop
+n0.take_head:
+  %n0.cp_h = extractvalue %Value %n0.d, 1
+  %n0.cp_h_ptr = inttoptr i64 %n0.cp_h to %Compound*
+  %n0.h_args_slot = getelementptr %Compound, %Compound* %n0.cp_h_ptr, i32 0, i32 2
+  %n0.h_args = load %Value*, %Value** %n0.h_args_slot
+  %n0.head_ptr = getelementptr %Value, %Value* %n0.h_args, i32 0
+  %n0.head = load %Value, %Value* %n0.head_ptr
+  %n0.raw3 = call %Value @wam_get_reg(%WamState* %vm, i32 2)
+  %n0.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %n0.raw3, %Value %n0.head)
+  ret i1 %n0.ok
+
+builtin_nth1:
+  ; M37: nth1(+Index, +List, ?Elem) -- 1-indexed list access. Same
+  ; mechanics as nth0 but the loop starts at Index - 1; Index < 1
+  ; fails.
+  %n1.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %n1.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %n1.t1 = extractvalue %Value %n1.a1, 0
+  %n1.is_int = icmp eq i32 %n1.t1, 1
+  br i1 %n1.is_int, label %n1.start, label %n1.fail
+n1.fail:
+  ret i1 false
+n1.start:
+  %n1.i_raw = extractvalue %Value %n1.a1, 1
+  %n1.i_le0 = icmp sle i64 %n1.i_raw, 0
+  br i1 %n1.i_le0, label %n1.fail, label %n1.adjust
+n1.adjust:
+  %n1.i0 = sub i64 %n1.i_raw, 1
+  br label %n1.loop
+n1.loop:
+  %n1.cur = phi %Value [ %n1.a2, %n1.adjust ], [ %n1.next, %n1.advance ]
+  %n1.i = phi i64 [ %n1.i0, %n1.adjust ], [ %n1.i_next, %n1.advance ]
+  %n1.d = call %Value @wam_deref_value(%WamState* %vm, %Value %n1.cur)
+  %n1.tag = extractvalue %Value %n1.d, 0
+  %n1.is_cmp = icmp eq i32 %n1.tag, 3
+  br i1 %n1.is_cmp, label %n1.dispatch, label %n1.fail
+n1.dispatch:
+  %n1.i_zero = icmp eq i64 %n1.i, 0
+  br i1 %n1.i_zero, label %n1.take_head, label %n1.advance
+n1.advance:
+  %n1.cp = extractvalue %Value %n1.d, 1
+  %n1.cp_ptr = inttoptr i64 %n1.cp to %Compound*
+  %n1.args_slot = getelementptr %Compound, %Compound* %n1.cp_ptr, i32 0, i32 2
+  %n1.args = load %Value*, %Value** %n1.args_slot
+  %n1.tail_ptr = getelementptr %Value, %Value* %n1.args, i32 1
+  %n1.next = load %Value, %Value* %n1.tail_ptr
+  %n1.i_next = sub i64 %n1.i, 1
+  br label %n1.loop
+n1.take_head:
+  %n1.cp_h = extractvalue %Value %n1.d, 1
+  %n1.cp_h_ptr = inttoptr i64 %n1.cp_h to %Compound*
+  %n1.h_args_slot = getelementptr %Compound, %Compound* %n1.cp_h_ptr, i32 0, i32 2
+  %n1.h_args = load %Value*, %Value** %n1.h_args_slot
+  %n1.head_ptr = getelementptr %Value, %Value* %n1.h_args, i32 0
+  %n1.head = load %Value, %Value* %n1.head_ptr
+  %n1.raw3 = call %Value @wam_get_reg(%WamState* %vm, i32 2)
+  %n1.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %n1.raw3, %Value %n1.head)
+  ret i1 %n1.ok
+
+builtin_last:
+  ; M37: last(+List, ?Elem) -- returns the last element of a non-
+  ; empty list. Walks the [|]/2 chain; when the tail of the current
+  ; cons cell is not itself a compound, the current head is the
+  ; answer. Empty list and non-list arguments fail cleanly.
+  %lst.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  br label %lst.loop
+lst.fail:
+  ret i1 false
+lst.loop:
+  %lst.cur = phi %Value [ %lst.a1, %builtin_last ], [ %lst.tail_d, %lst.step ]
+  %lst.d = call %Value @wam_deref_value(%WamState* %vm, %Value %lst.cur)
+  %lst.tag = extractvalue %Value %lst.d, 0
+  %lst.is_cmp = icmp eq i32 %lst.tag, 3
+  br i1 %lst.is_cmp, label %lst.peek, label %lst.fail
+lst.peek:
+  %lst.cp = extractvalue %Value %lst.d, 1
+  %lst.cp_ptr = inttoptr i64 %lst.cp to %Compound*
+  %lst.args_slot = getelementptr %Compound, %Compound* %lst.cp_ptr, i32 0, i32 2
+  %lst.args = load %Value*, %Value** %lst.args_slot
+  %lst.tail_ptr = getelementptr %Value, %Value* %lst.args, i32 1
+  %lst.tail = load %Value, %Value* %lst.tail_ptr
+  %lst.tail_d = call %Value @wam_deref_value(%WamState* %vm, %Value %lst.tail)
+  %lst.tail_tag = extractvalue %Value %lst.tail_d, 0
+  %lst.tail_is_cmp = icmp eq i32 %lst.tail_tag, 3
+  br i1 %lst.tail_is_cmp, label %lst.step, label %lst.done
+lst.step:
+  br label %lst.loop
+lst.done:
+  %lst.head_ptr = getelementptr %Value, %Value* %lst.args, i32 0
+  %lst.head = load %Value, %Value* %lst.head_ptr
+  %lst.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %lst.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %lst.raw2, %Value %lst.head)
+  ret i1 %lst.ok
+
 unknown:
   ret i1 false
 }'.
@@ -7265,6 +7397,9 @@ builtin_op_to_id('string_concat/3', 47).  % alias of atom_concat/3
 builtin_op_to_id('string_length/2', 48).  % alias of atom_length/2
 builtin_op_to_id('atom_string/2', 49).    % atom <-> string (runtime treats both as atoms)
 builtin_op_to_id('string_to_atom/2', 50). % string_to_atom(?S, ?A) -- same as atom_string but swapped
+builtin_op_to_id('nth0/3', 51).
+builtin_op_to_id('nth1/3', 52).
+builtin_op_to_id('last/2', 53).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2111,6 +2111,9 @@ is_builtin_pred(compare, 3).      % standard order: -1 / 0 / +1 as atom.
 is_builtin_pred(char_type, 2).    % char classification + case conv.
 is_builtin_pred(upcase_atom, 2).  % whole-atom case conversion: upper.
 is_builtin_pred(downcase_atom, 2).% whole-atom case conversion: lower.
+is_builtin_pred(nth0, 3).         % nth0(+Index, +List, ?Elem) -- 0-indexed.
+is_builtin_pred(nth1, 3).         % nth1(+Index, +List, ?Elem) -- 1-indexed.
+is_builtin_pred(last, 2).         % last(+List, ?Elem).
 is_builtin_pred(numlist, 3).      % integer range generator: [Lo..Hi].
 is_builtin_pred(sort, 2).         % stable sort + dedup (std order).
 is_builtin_pred(msort, 2).        % stable sort, NO dedup (std order).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -830,6 +830,60 @@ test_string_length_empty(_, R) :-
     string_length('', N),
     R is N + 42.   % 42
 
+% M37: nth0/3, nth1/3, last/2 -- list-indexing trio. Forward modes
+% only (Index + List bound).
+
+:- dynamic test_nth0_first/2.
+test_nth0_first(_, R) :-
+    nth0(0, [10, 20, 30], E),
+    R is E.   % 10
+
+:- dynamic test_nth0_middle/2.
+test_nth0_middle(_, R) :-
+    nth0(2, [10, 20, 30, 40], E),
+    R is E.   % 30
+
+:- dynamic test_nth0_last/2.
+test_nth0_last(_, R) :-
+    nth0(3, [10, 20, 30, 40], E),
+    R is E.   % 40
+
+:- dynamic test_nth0_overflow/2.
+test_nth0_overflow(_, R) :-
+    ( nth0(5, [10, 20], _) -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_nth0_negative/2.
+test_nth0_negative(_, R) :-
+    ( nth0(-1, [10, 20], _) -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_nth1_first/2.
+test_nth1_first(_, R) :-
+    nth1(1, [10, 20, 30], E),
+    R is E.   % 10
+
+:- dynamic test_nth1_third/2.
+test_nth1_third(_, R) :-
+    nth1(3, [10, 20, 30, 40], E),
+    R is E.   % 30
+
+:- dynamic test_nth1_zero/2.
+test_nth1_zero(_, R) :-
+    ( nth1(0, [10, 20], _) -> R is 1 ; R is 0 ).   % 0 -- 1-indexed rejects 0
+
+:- dynamic test_last_simple/2.
+test_last_simple(_, R) :-
+    last([10, 20, 30], E),
+    R is E.   % 30
+
+:- dynamic test_last_singleton/2.
+test_last_singleton(_, R) :-
+    last([99], E),
+    R is E.   % 99
+
+:- dynamic test_last_empty/2.
+test_last_empty(_, R) :-
+    ( last([], _) -> R is 1 ; R is 0 ).   % 0
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -1714,6 +1768,29 @@ test_all :-
                    test_string_length_simple, 0, 5),
        run_test_r0('string_length(\'\', N) + 42 -> 42',
                    test_string_length_empty, 0, 42),
+       format('--- M37 nth0/3 + nth1/3 + last/2 list-indexing ---~n'),
+       run_test_r0('nth0(0, [10,20,30], E) -> 10',
+                   test_nth0_first, 0, 10),
+       run_test_r0('nth0(2, [10,20,30,40], E) -> 30',
+                   test_nth0_middle, 0, 30),
+       run_test_r0('nth0(3, [10,20,30,40], E) -> 40',
+                   test_nth0_last, 0, 40),
+       run_test_r0('nth0(5, [10,20], _) overflow -> 0',
+                   test_nth0_overflow, 0, 0),
+       run_test_r0('nth0(-1, [10,20], _) negative -> 0',
+                   test_nth0_negative, 0, 0),
+       run_test_r0('nth1(1, [10,20,30], E) -> 10',
+                   test_nth1_first, 0, 10),
+       run_test_r0('nth1(3, [10,20,30,40], E) -> 30',
+                   test_nth1_third, 0, 30),
+       run_test_r0('nth1(0, [10,20], _) rejects 0 -> 0',
+                   test_nth1_zero, 0, 0),
+       run_test_r0('last([10,20,30], E) -> 30',
+                   test_last_simple, 0, 30),
+       run_test_r0('last([99], E) -> 99',
+                   test_last_singleton, 0, 99),
+       run_test_r0('last([], _) -> 0',
+                   test_last_empty, 0, 0),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Three deterministic list-access builtins, all walking the `[|]/2` cons
chain. Each follows the same shape pioneered by `length/2`: deref each
cell, treat "not a compound" (e.g., the `[]` atom) as end-of-list,
fail cleanly when the index runs off the end or the input isn't a
list.

### nth0(+Index, +List, ?Elem)
- Validate A1 is `Integer >= 0`; loop A1 times deref'ing the current
  cell as a `Compound` and advancing through the tail slot. When the
  countdown hits zero, take the current cell's head and unify A3.
- Negative index, non-integer index, or running off the end of the
  list all branch into the shared `n0.fail` label.

### nth1(+Index, +List, ?Elem)
- Same mechanics; `Index <= 0` fails (1-indexed semantics), then
  decrements Index by 1 and falls into the nth0-style loop.

### last(+List, ?Elem)
- Walks the chain; at each cons cell, derefs the tail and checks
  whether it's also `Compound`. If yes, step forward. If no, the
  current head is the last element, unify A2 with it. Empty list
  (A1 = `[]` atom) falls through the initial `is_cmp` check and fails.

### Dispatch
- `nth0/3` op id 51, label `%builtin_nth0`, prefix `n0.`
- `nth1/3` op id 52, label `%builtin_nth1`, prefix `n1.`
- `last/2` op id 53, label `%builtin_last`, prefix `lst.`
- All three added to `wam_target.pl`'s `is_builtin_pred` so the WAM
  compiler emits `builtin_call`.

## Test plan
- [x] 11 new builtin tests: nth0 first/middle/last/overflow/negative;
      nth1 first/third + rejects index 0; last simple/singleton/empty
- [x] All 197 builtin tests pass (was 186, +11)
- [x] bfs execution 4/4 PASS, astar execution PASS


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_