### PR TITLE
LLVM WAM: reverse/2 deterministic forward mode (M38)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3413,6 +3413,7 @@ entry:
     i32 51, label %builtin_nth0
     i32 52, label %builtin_nth1
     i32 53, label %builtin_last
+    i32 54, label %builtin_reverse
   ]
 
 builtin_is:
@@ -5974,6 +5975,62 @@ lst.done:
   %lst.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %lst.raw2, %Value %lst.head)
   ret i1 %lst.ok
 
+builtin_reverse:
+  ; M38: reverse(+List, ?Reversed) -- deterministic forward mode.
+  ; Single-pass walk of A1: for each cons cell, prepend the head onto
+  ; an accumulator initially seeded with the [] atom. The final
+  ; accumulator is the reversed list. Walking stops at the first
+  ; non-compound cell (matches length/2 semantics on improper lists:
+  ; reverse(non_list) -> succeeds with []).
+  %rev.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  call void @wam_arena_ensure()
+  %rev.empty_id = load i64, i64* @wam_empty_list_atom_id
+  %rev.empty_v0 = insertvalue %Value undef, i32 0, 0
+  %rev.empty_v  = insertvalue %Value %rev.empty_v0, i64 %rev.empty_id, 1
+  br label %rev.loop
+rev.loop:
+  %rev.cur = phi %Value [ %rev.a1, %builtin_reverse ], [ %rev.tail, %rev.step ]
+  %rev.acc = phi %Value [ %rev.empty_v, %builtin_reverse ], [ %rev.new_cons, %rev.step ]
+  %rev.d = call %Value @wam_deref_value(%WamState* %vm, %Value %rev.cur)
+  %rev.tag = extractvalue %Value %rev.d, 0
+  %rev.is_cmp = icmp eq i32 %rev.tag, 3
+  br i1 %rev.is_cmp, label %rev.step, label %rev.done
+rev.step:
+  %rev.cp = extractvalue %Value %rev.d, 1
+  %rev.cp_ptr = inttoptr i64 %rev.cp to %Compound*
+  %rev.args_slot = getelementptr %Compound, %Compound* %rev.cp_ptr, i32 0, i32 2
+  %rev.args = load %Value*, %Value** %rev.args_slot
+  %rev.head_ptr = getelementptr %Value, %Value* %rev.args, i32 0
+  %rev.head = load %Value, %Value* %rev.head_ptr
+  %rev.tail_ptr = getelementptr %Value, %Value* %rev.args, i32 1
+  %rev.tail = load %Value, %Value* %rev.tail_ptr
+  ; Allocate a fresh [|]/2 Compound on the arena: head = current head,
+  ; tail = accumulator.
+  %rev.new_cp_size = ptrtoint %Compound* getelementptr (%Compound, %Compound* null, i32 1) to i64
+  %rev.new_cp_mem = call i8* @wam_arena_alloc(i64 %rev.new_cp_size)
+  %rev.new_cp = bitcast i8* %rev.new_cp_mem to %Compound*
+  %rev.new_fn_slot = getelementptr %Compound, %Compound* %rev.new_cp, i32 0, i32 0
+  %rev.new_fn_ptr = getelementptr [4 x i8], [4 x i8]* @.fn__5B_7C_5D, i32 0, i32 0
+  store i8* %rev.new_fn_ptr, i8** %rev.new_fn_slot
+  %rev.new_ar_slot = getelementptr %Compound, %Compound* %rev.new_cp, i32 0, i32 1
+  store i32 2, i32* %rev.new_ar_slot
+  %rev.new_args_mem = call i8* @wam_arena_alloc(i64 32)
+  %rev.new_args = bitcast i8* %rev.new_args_mem to %Value*
+  %rev.new_args_slot = getelementptr %Compound, %Compound* %rev.new_cp, i32 0, i32 2
+  store %Value* %rev.new_args, %Value** %rev.new_args_slot
+  %rev.new_h_ptr = getelementptr %Value, %Value* %rev.new_args, i32 0
+  store %Value %rev.head, %Value* %rev.new_h_ptr
+  %rev.new_t_ptr = getelementptr %Value, %Value* %rev.new_args, i32 1
+  store %Value %rev.acc, %Value* %rev.new_t_ptr
+  %rev.new_cp_i64 = ptrtoint %Compound* %rev.new_cp to i64
+  %rev.new_cons_v0 = insertvalue %Value undef, i32 3, 0
+  %rev.new_cons = insertvalue %Value %rev.new_cons_v0, i64 %rev.new_cp_i64, 1
+  br label %rev.loop
+rev.done:
+  %rev.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %rev.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %rev.raw2, %Value %rev.acc)
+  ret i1 %rev.ok
+
 unknown:
   ret i1 false
 }'.
@@ -7400,6 +7457,7 @@ builtin_op_to_id('string_to_atom/2', 50). % string_to_atom(?S, ?A) -- same as at
 builtin_op_to_id('nth0/3', 51).
 builtin_op_to_id('nth1/3', 52).
 builtin_op_to_id('last/2', 53).
+builtin_op_to_id('reverse/2', 54).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -884,6 +884,44 @@ test_last_singleton(_, R) :-
 test_last_empty(_, R) :-
     ( last([], _) -> R is 1 ; R is 0 ).   % 0
 
+% M38: reverse/2 deterministic forward mode.
+
+:- dynamic test_reverse_first/2.
+test_reverse_first(_, R) :-
+    reverse([10, 20, 30], L),
+    nth0(0, L, E),
+    R is E.   % 30 (originally last)
+
+:- dynamic test_reverse_last/2.
+test_reverse_last(_, R) :-
+    reverse([10, 20, 30], L),
+    last(L, E),
+    R is E.   % 10 (originally first)
+
+:- dynamic test_reverse_length/2.
+test_reverse_length(_, R) :-
+    reverse([1, 2, 3, 4, 5], L),
+    length(L, N),
+    R is N.   % 5
+
+:- dynamic test_reverse_empty/2.
+test_reverse_empty(_, R) :-
+    reverse([], L),
+    length(L, N),
+    R is N + 7.   % 7
+
+:- dynamic test_reverse_singleton/2.
+test_reverse_singleton(_, R) :-
+    reverse([42], [E]),
+    R is E.   % 42
+
+:- dynamic test_reverse_idempotent/2.
+test_reverse_idempotent(_, R) :-
+    reverse([1, 2, 3], L1),
+    reverse(L1, L2),
+    nth0(0, L2, E),
+    R is E.   % 1 (reverse twice -> original)
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -1791,6 +1829,19 @@ test_all :-
                    test_last_singleton, 0, 99),
        run_test_r0('last([], _) -> 0',
                    test_last_empty, 0, 0),
+       format('--- M38 reverse/2 deterministic ---~n'),
+       run_test_r0('reverse([10,20,30], L), nth0(0, L) -> 30',
+                   test_reverse_first, 0, 30),
+       run_test_r0('reverse([10,20,30], L), last(L) -> 10',
+                   test_reverse_last, 0, 10),
+       run_test_r0('reverse([1..5], L), length(L) -> 5',
+                   test_reverse_length, 0, 5),
+       run_test_r0('reverse([], L) + 7 -> 7',
+                   test_reverse_empty, 0, 7),
+       run_test_r0('reverse([42], [E]) -> 42',
+                   test_reverse_singleton, 0, 42),
+       run_test_r0('reverse twice idempotent -> 1',
+                   test_reverse_idempotent, 0, 1),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Single-pass list reversal. Walks the input's `[|]/2` chain; for each
cons cell, prepends the head onto an accumulator initially seeded
with the `[]` atom, so the final accumulator is the reversed list.
`wam_unify_value` binds (or checks) A2 against the result.

### Loop body each iteration
- Deref the current cell; fall out of the loop the moment we hit a
  non-compound (matches `length/2` semantics on improper lists —
  `reverse(non_list)` cleanly returns `[]`).
- Load head + tail from the args array.
- Arena-allocate a fresh `[|]/2` Compound whose head is the loaded
  head and whose tail is the current accumulator; phi the new cons
  back as the next acc.

### Dispatch
- `builtin_op_to_id('reverse/2', 54)` → `%builtin_reverse`.
- `reverse/2` was already in `is_builtin_pred` (pre-M19 stub) so the
  compiler already emits `builtin_call`.
- Prefix `rev.` to stay clear of `re.` / `rs.` neighbours.

## Test plan
- [x] 6 new builtin tests: first-element after reverse, last-after-
      reverse, length preservation, empty list, singleton fixed-point,
      twice-idempotent roundtrip
- [x] All 203 builtin tests pass (was 197, +6)
- [x] bfs execution 4/4 PASS, astar execution PASS


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_