### PR TITLE
LLVM WAM: append/3 deterministic forward mode (M39)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3414,6 +3414,7 @@ entry:
     i32 52, label %builtin_nth1
     i32 53, label %builtin_last
     i32 54, label %builtin_reverse
+    i32 55, label %builtin_append
   ]
 
 builtin_is:
@@ -6031,6 +6032,97 @@ rev.done:
   %rev.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %rev.raw2, %Value %rev.acc)
   ret i1 %rev.ok
 
+builtin_append:
+  ; M39: append(+List1, +List2, ?List3) -- deterministic mode (A1 and
+  ; A2 both bound lists). Two-pass: count A1, allocate a Value array,
+  ; copy each head, then build the result by walking the array
+  ; back-to-front prepending each head onto A2 as the seed tail.
+  ; append([], L, L) handled as the count=0 degenerate case (the
+  ; build loop never runs, acc stays equal to A2).
+  %app.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %app.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  call void @wam_arena_ensure()
+  br label %app.c_loop
+app.c_loop:
+  %app.c_cur = phi %Value [ %app.a1, %builtin_append ], [ %app.c_next, %app.c_step ]
+  %app.c_cnt = phi i32 [ 0, %builtin_append ], [ %app.c_cnt1, %app.c_step ]
+  %app.c_d = call %Value @wam_deref_value(%WamState* %vm, %Value %app.c_cur)
+  %app.c_tag = extractvalue %Value %app.c_d, 0
+  %app.c_is_cmp = icmp eq i32 %app.c_tag, 3
+  br i1 %app.c_is_cmp, label %app.c_step, label %app.c_done
+app.c_step:
+  %app.c_cp = extractvalue %Value %app.c_d, 1
+  %app.c_cp_ptr = inttoptr i64 %app.c_cp to %Compound*
+  %app.c_args_slot = getelementptr %Compound, %Compound* %app.c_cp_ptr, i32 0, i32 2
+  %app.c_args = load %Value*, %Value** %app.c_args_slot
+  %app.c_tail_ptr = getelementptr %Value, %Value* %app.c_args, i32 1
+  %app.c_next = load %Value, %Value* %app.c_tail_ptr
+  %app.c_cnt1 = add i32 %app.c_cnt, 1
+  br label %app.c_loop
+app.c_done:
+  ; Allocate an arr of %Value (16 bytes each); skip alloc if empty.
+  %app.cnt64 = sext i32 %app.c_cnt to i64
+  %app.arr_bytes = shl i64 %app.cnt64, 4
+  %app.arr_mem = call i8* @wam_arena_alloc(i64 %app.arr_bytes)
+  %app.arr = bitcast i8* %app.arr_mem to %Value*
+  br label %app.f_loop
+app.f_loop:
+  %app.f_cur = phi %Value [ %app.a1, %app.c_done ], [ %app.f_next, %app.f_step ]
+  %app.f_idx = phi i32 [ 0, %app.c_done ], [ %app.f_idx1, %app.f_step ]
+  %app.f_done_b = icmp sge i32 %app.f_idx, %app.c_cnt
+  br i1 %app.f_done_b, label %app.b_init, label %app.f_step
+app.f_step:
+  %app.f_d = call %Value @wam_deref_value(%WamState* %vm, %Value %app.f_cur)
+  %app.f_cp = extractvalue %Value %app.f_d, 1
+  %app.f_cp_ptr = inttoptr i64 %app.f_cp to %Compound*
+  %app.f_args_slot = getelementptr %Compound, %Compound* %app.f_cp_ptr, i32 0, i32 2
+  %app.f_args = load %Value*, %Value** %app.f_args_slot
+  %app.f_head_ptr = getelementptr %Value, %Value* %app.f_args, i32 0
+  %app.f_head = load %Value, %Value* %app.f_head_ptr
+  %app.f_tail_ptr = getelementptr %Value, %Value* %app.f_args, i32 1
+  %app.f_next = load %Value, %Value* %app.f_tail_ptr
+  %app.f_slot = getelementptr %Value, %Value* %app.arr, i32 %app.f_idx
+  store %Value %app.f_head, %Value* %app.f_slot
+  %app.f_idx1 = add i32 %app.f_idx, 1
+  br label %app.f_loop
+app.b_init:
+  br label %app.b_loop
+app.b_loop:
+  ; Walk back-to-front: i from cnt-1 down to 0, prepending arr[i]
+  ; onto acc; initial acc seed is A2 (preserves the second list).
+  %app.b_i = phi i32 [ %app.c_cnt, %app.b_init ], [ %app.b_i_prev, %app.b_step ]
+  %app.b_acc = phi %Value [ %app.a2, %app.b_init ], [ %app.b_new_cons, %app.b_step ]
+  %app.b_done_b = icmp sle i32 %app.b_i, 0
+  br i1 %app.b_done_b, label %app.b_bind, label %app.b_step
+app.b_step:
+  %app.b_i_prev = sub i32 %app.b_i, 1
+  %app.b_slot = getelementptr %Value, %Value* %app.arr, i32 %app.b_i_prev
+  %app.b_head = load %Value, %Value* %app.b_slot
+  %app.b_cp_size = ptrtoint %Compound* getelementptr (%Compound, %Compound* null, i32 1) to i64
+  %app.b_cp_mem = call i8* @wam_arena_alloc(i64 %app.b_cp_size)
+  %app.b_cp = bitcast i8* %app.b_cp_mem to %Compound*
+  %app.b_fn_slot = getelementptr %Compound, %Compound* %app.b_cp, i32 0, i32 0
+  %app.b_fn_ptr = getelementptr [4 x i8], [4 x i8]* @.fn__5B_7C_5D, i32 0, i32 0
+  store i8* %app.b_fn_ptr, i8** %app.b_fn_slot
+  %app.b_ar_slot = getelementptr %Compound, %Compound* %app.b_cp, i32 0, i32 1
+  store i32 2, i32* %app.b_ar_slot
+  %app.b_args_mem = call i8* @wam_arena_alloc(i64 32)
+  %app.b_args = bitcast i8* %app.b_args_mem to %Value*
+  %app.b_args_slot = getelementptr %Compound, %Compound* %app.b_cp, i32 0, i32 2
+  store %Value* %app.b_args, %Value** %app.b_args_slot
+  %app.b_h_ptr = getelementptr %Value, %Value* %app.b_args, i32 0
+  store %Value %app.b_head, %Value* %app.b_h_ptr
+  %app.b_t_ptr = getelementptr %Value, %Value* %app.b_args, i32 1
+  store %Value %app.b_acc, %Value* %app.b_t_ptr
+  %app.b_cp_i64 = ptrtoint %Compound* %app.b_cp to i64
+  %app.b_nc0 = insertvalue %Value undef, i32 3, 0
+  %app.b_new_cons = insertvalue %Value %app.b_nc0, i64 %app.b_cp_i64, 1
+  br label %app.b_loop
+app.b_bind:
+  %app.b_raw3 = call %Value @wam_get_reg(%WamState* %vm, i32 2)
+  %app.b_ok = call i1 @wam_unify_value(%WamState* %vm, %Value %app.b_raw3, %Value %app.b_acc)
+  ret i1 %app.b_ok
+
 unknown:
   ret i1 false
 }'.
@@ -7458,6 +7550,7 @@ builtin_op_to_id('nth0/3', 51).
 builtin_op_to_id('nth1/3', 52).
 builtin_op_to_id('last/2', 53).
 builtin_op_to_id('reverse/2', 54).
+builtin_op_to_id('append/3', 55).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -922,6 +922,57 @@ test_reverse_idempotent(_, R) :-
     nth0(0, L2, E),
     R is E.   % 1 (reverse twice -> original)
 
+% M39: append/3 deterministic (A1 and A2 both bound lists).
+
+:- dynamic test_append_length/2.
+test_append_length(_, R) :-
+    append([1, 2, 3], [4, 5], L),
+    length(L, N),
+    R is N.   % 5
+
+:- dynamic test_append_first/2.
+test_append_first(_, R) :-
+    append([10, 20], [30, 40], L),
+    nth0(0, L, E),
+    R is E.   % 10 (head from A1)
+
+:- dynamic test_append_seam/2.
+test_append_seam(_, R) :-
+    append([10, 20], [30, 40], L),
+    nth0(2, L, E),
+    R is E.   % 30 (first elem of A2)
+
+:- dynamic test_append_last/2.
+test_append_last(_, R) :-
+    append([10, 20], [30, 40], L),
+    last(L, E),
+    R is E.   % 40
+
+:- dynamic test_append_left_empty/2.
+test_append_left_empty(_, R) :-
+    append([], [7, 8], L),
+    length(L, N),
+    R is N.   % 2
+
+:- dynamic test_append_right_empty/2.
+test_append_right_empty(_, R) :-
+    append([7, 8], [], L),
+    length(L, N),
+    R is N.   % 2
+
+:- dynamic test_append_both_empty/2.
+test_append_both_empty(_, R) :-
+    append([], [], L),
+    length(L, N),
+    R is N + 9.   % 9
+
+:- dynamic test_append_roundtrip/2.
+test_append_roundtrip(_, R) :-
+    append([1, 2], [3, 4], L),
+    reverse(L, L2),
+    nth0(0, L2, E),
+    R is E.   % 4 (last of L becomes first after reverse)
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -1842,6 +1893,23 @@ test_all :-
                    test_reverse_singleton, 0, 42),
        run_test_r0('reverse twice idempotent -> 1',
                    test_reverse_idempotent, 0, 1),
+       format('--- M39 append/3 deterministic ---~n'),
+       run_test_r0('append([1,2,3], [4,5], L), length -> 5',
+                   test_append_length, 0, 5),
+       run_test_r0('append([10,20], [30,40], L), nth0(0) -> 10',
+                   test_append_first, 0, 10),
+       run_test_r0('append([10,20], [30,40], L), nth0(2) -> 30 (seam)',
+                   test_append_seam, 0, 30),
+       run_test_r0('append([10,20], [30,40], L), last -> 40',
+                   test_append_last, 0, 40),
+       run_test_r0('append([], [7,8], L), length -> 2',
+                   test_append_left_empty, 0, 2),
+       run_test_r0('append([7,8], [], L), length -> 2',
+                   test_append_right_empty, 0, 2),
+       run_test_r0('append([], [], L), length + 9 -> 9',
+                   test_append_both_empty, 0, 9),
+       run_test_r0('append + reverse roundtrip -> last becomes first -> 4',
+                   test_append_roundtrip, 0, 4),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Two-pass list concatenation. First pass walks A1 counting elements
into a buffer of `n %Value` slots; second pass copies each head into
`arr[i]`. The build pass walks the array back-to-front prepending each
head onto an accumulator initially seeded with A2, so the result has
A1's elements in order followed by A2's entire chain.

### Steps
- **Count**: deref each `[|]/2` cell, advance through the tail. Falls
  out of the loop on the first non-compound (so `A1 = []` gives
  `count = 0`).
- **Allocate** `arr = arena_alloc(count * sizeof(%Value))`.
- **Fill**: re-walk A1, store each loaded head at `arr[i]`.
- **Build**: phi-loop from `i = count` down to 0; each iteration
  arena-allocates a fresh `[|]/2` Compound (`head = arr[i-1]`,
  `tail = acc`) and sets `acc` to the new cons `Value`.
- `wam_unify_value` binds `A3 = final acc`; handles both unbound and
  already-bound A3 uniformly.

The empty-left case (`append([], L, R)`) walks the count loop zero
times, the build loop sees `i_done` immediately, and `acc` stays
`= A2` unchanged — so R unifies with L correctly. The 0-byte
`arena_alloc` is a no-op since the array is never indexed.

### Dispatch
- `builtin_op_to_id('append/3', 55)` → `%builtin_append`.
- `append/3` was already in `is_builtin_pred` (pre-M19 stub) so the
  compiler already emits `builtin_call`.
- Prefix `app.` with sub-prefixes `c.` (count), `f.` (fill), `b.` (build).

## Test plan
- [x] 8 new builtin tests covering length, head, seam, tail, left/right/
      both empty, and append+reverse roundtrip
- [x] All 211 builtin tests pass (was 203, +8)
- [x] bfs execution 4/4 PASS, astar execution PASS


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_