### PR TITLE
LLVM WAM: subtract/3 (M44)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3422,6 +3422,7 @@ entry:
     i32 60, label %builtin_sum_list
     i32 61, label %builtin_max_list
     i32 62, label %builtin_min_list
+    i32 63, label %builtin_subtract
   ]
 
 builtin_is:
@@ -6500,6 +6501,134 @@ mnl.done:
   %mnl.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %mnl.raw2, %Value %mnl.res_v)
   ret i1 %mnl.ok
 
+builtin_subtract:
+  ; M44: subtract(+List1, +List2, ?Difference) -- elements of List1
+  ; that have no unify-match in List2. Three-pass:
+  ;   1. count A1''s elements n;
+  ;   2. allocate arr of n %Values; for each A1 head, inner-walk A2
+  ;      with the trial-unify + rollback pattern (memberchk inline).
+  ;      Match found anywhere in A2: skip the head, keep the binding
+  ;      (matches SWI subtract([a,b,c], [X], R) -> X=a, R=[b,c]).
+  ;      A2 exhausted without match: store head at arr[out_idx++].
+  ;   3. walk arr back-to-front prepending each survivor onto [];
+  ;      unify A3 with the resulting cons chain.
+  %sbt.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %sbt.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  call void @wam_arena_ensure()
+  br label %sbt.c_loop
+sbt.c_loop:
+  %sbt.c_cur = phi %Value [ %sbt.a1, %builtin_subtract ], [ %sbt.c_next, %sbt.c_step ]
+  %sbt.c_cnt = phi i32 [ 0, %builtin_subtract ], [ %sbt.c_cnt1, %sbt.c_step ]
+  %sbt.c_d = call %Value @wam_deref_value(%WamState* %vm, %Value %sbt.c_cur)
+  %sbt.c_tag = extractvalue %Value %sbt.c_d, 0
+  %sbt.c_is_cmp = icmp eq i32 %sbt.c_tag, 3
+  br i1 %sbt.c_is_cmp, label %sbt.c_step, label %sbt.c_done
+sbt.c_step:
+  %sbt.c_cp = extractvalue %Value %sbt.c_d, 1
+  %sbt.c_cp_ptr = inttoptr i64 %sbt.c_cp to %Compound*
+  %sbt.c_args_slot = getelementptr %Compound, %Compound* %sbt.c_cp_ptr, i32 0, i32 2
+  %sbt.c_args = load %Value*, %Value** %sbt.c_args_slot
+  %sbt.c_t_ptr = getelementptr %Value, %Value* %sbt.c_args, i32 1
+  %sbt.c_next = load %Value, %Value* %sbt.c_t_ptr
+  %sbt.c_cnt1 = add i32 %sbt.c_cnt, 1
+  br label %sbt.c_loop
+sbt.c_done:
+  %sbt.cnt64 = sext i32 %sbt.c_cnt to i64
+  %sbt.arr_bytes = shl i64 %sbt.cnt64, 4
+  %sbt.arr_mem = call i8* @wam_arena_alloc(i64 %sbt.arr_bytes)
+  %sbt.arr = bitcast i8* %sbt.arr_mem to %Value*
+  br label %sbt.outer_loop
+sbt.outer_loop:
+  %sbt.o_cur = phi %Value [ %sbt.a1, %sbt.c_done ], [ %sbt.o_next, %sbt.o_after ]
+  %sbt.in_idx = phi i32 [ 0, %sbt.c_done ], [ %sbt.in_idx1, %sbt.o_after ]
+  %sbt.out_idx = phi i32 [ 0, %sbt.c_done ], [ %sbt.out_next, %sbt.o_after ]
+  %sbt.o_done = icmp sge i32 %sbt.in_idx, %sbt.c_cnt
+  br i1 %sbt.o_done, label %sbt.build_init, label %sbt.o_step
+sbt.o_step:
+  %sbt.o_d = call %Value @wam_deref_value(%WamState* %vm, %Value %sbt.o_cur)
+  %sbt.o_cp = extractvalue %Value %sbt.o_d, 1
+  %sbt.o_cp_ptr = inttoptr i64 %sbt.o_cp to %Compound*
+  %sbt.o_args_slot = getelementptr %Compound, %Compound* %sbt.o_cp_ptr, i32 0, i32 2
+  %sbt.o_args = load %Value*, %Value** %sbt.o_args_slot
+  %sbt.o_h_ptr = getelementptr %Value, %Value* %sbt.o_args, i32 0
+  %sbt.o_head = load %Value, %Value* %sbt.o_h_ptr
+  %sbt.o_t_ptr = getelementptr %Value, %Value* %sbt.o_args, i32 1
+  %sbt.o_next = load %Value, %Value* %sbt.o_t_ptr
+  br label %sbt.inner_loop
+sbt.inner_loop:
+  %sbt.i_cur = phi %Value [ %sbt.a2, %sbt.o_step ], [ %sbt.i_next, %sbt.i_rollback ]
+  %sbt.i_d = call %Value @wam_deref_value(%WamState* %vm, %Value %sbt.i_cur)
+  %sbt.i_tag = extractvalue %Value %sbt.i_d, 0
+  %sbt.i_is_cmp = icmp eq i32 %sbt.i_tag, 3
+  br i1 %sbt.i_is_cmp, label %sbt.i_try, label %sbt.no_match
+sbt.i_try:
+  %sbt.i_cp = extractvalue %Value %sbt.i_d, 1
+  %sbt.i_cp_ptr = inttoptr i64 %sbt.i_cp to %Compound*
+  %sbt.i_args_slot = getelementptr %Compound, %Compound* %sbt.i_cp_ptr, i32 0, i32 2
+  %sbt.i_args = load %Value*, %Value** %sbt.i_args_slot
+  %sbt.i_h_ptr = getelementptr %Value, %Value* %sbt.i_args, i32 0
+  %sbt.i_head = load %Value, %Value* %sbt.i_h_ptr
+  %sbt.i_t_ptr = getelementptr %Value, %Value* %sbt.i_args, i32 1
+  %sbt.i_next = load %Value, %Value* %sbt.i_t_ptr
+  %sbt.ts_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 9
+  %sbt.saved_ts = load i32, i32* %sbt.ts_ptr
+  %sbt.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %sbt.o_head, %Value %sbt.i_head)
+  br i1 %sbt.uok, label %sbt.match, label %sbt.i_rollback
+sbt.i_rollback:
+  call void @unwind_trail(%WamState* %vm, i32 %sbt.saved_ts)
+  br label %sbt.inner_loop
+sbt.match:
+  ; Element matched -- skip; binding kept.
+  br label %sbt.o_after
+sbt.no_match:
+  ; A2 exhausted without match -- keep o_head at arr[out_idx].
+  %sbt.no_slot = getelementptr %Value, %Value* %sbt.arr, i32 %sbt.out_idx
+  store %Value %sbt.o_head, %Value* %sbt.no_slot
+  %sbt.out_kept = add i32 %sbt.out_idx, 1
+  br label %sbt.o_after
+sbt.o_after:
+  %sbt.out_next = phi i32 [ %sbt.out_idx, %sbt.match ], [ %sbt.out_kept, %sbt.no_match ]
+  %sbt.in_idx1 = add i32 %sbt.in_idx, 1
+  br label %sbt.outer_loop
+sbt.build_init:
+  %sbt.b_empty_id = load i64, i64* @wam_empty_list_atom_id
+  %sbt.b_empty_v0 = insertvalue %Value undef, i32 0, 0
+  %sbt.b_empty_v  = insertvalue %Value %sbt.b_empty_v0, i64 %sbt.b_empty_id, 1
+  br label %sbt.b_loop
+sbt.b_loop:
+  %sbt.b_i = phi i32 [ %sbt.out_idx, %sbt.build_init ], [ %sbt.b_i_prev, %sbt.b_step ]
+  %sbt.b_acc = phi %Value [ %sbt.b_empty_v, %sbt.build_init ], [ %sbt.b_new_cons, %sbt.b_step ]
+  %sbt.b_done = icmp sle i32 %sbt.b_i, 0
+  br i1 %sbt.b_done, label %sbt.b_bind, label %sbt.b_step
+sbt.b_step:
+  %sbt.b_i_prev = sub i32 %sbt.b_i, 1
+  %sbt.b_slot = getelementptr %Value, %Value* %sbt.arr, i32 %sbt.b_i_prev
+  %sbt.b_head = load %Value, %Value* %sbt.b_slot
+  %sbt.b_cp_size = ptrtoint %Compound* getelementptr (%Compound, %Compound* null, i32 1) to i64
+  %sbt.b_cp_mem = call i8* @wam_arena_alloc(i64 %sbt.b_cp_size)
+  %sbt.b_cp = bitcast i8* %sbt.b_cp_mem to %Compound*
+  %sbt.b_fn_slot = getelementptr %Compound, %Compound* %sbt.b_cp, i32 0, i32 0
+  %sbt.b_fn_ptr = getelementptr [4 x i8], [4 x i8]* @.fn__5B_7C_5D, i32 0, i32 0
+  store i8* %sbt.b_fn_ptr, i8** %sbt.b_fn_slot
+  %sbt.b_ar_slot = getelementptr %Compound, %Compound* %sbt.b_cp, i32 0, i32 1
+  store i32 2, i32* %sbt.b_ar_slot
+  %sbt.b_args_mem = call i8* @wam_arena_alloc(i64 32)
+  %sbt.b_args = bitcast i8* %sbt.b_args_mem to %Value*
+  %sbt.b_args_slot = getelementptr %Compound, %Compound* %sbt.b_cp, i32 0, i32 2
+  store %Value* %sbt.b_args, %Value** %sbt.b_args_slot
+  %sbt.b_h_ptr = getelementptr %Value, %Value* %sbt.b_args, i32 0
+  store %Value %sbt.b_head, %Value* %sbt.b_h_ptr
+  %sbt.b_t_ptr = getelementptr %Value, %Value* %sbt.b_args, i32 1
+  store %Value %sbt.b_acc, %Value* %sbt.b_t_ptr
+  %sbt.b_cp_i64 = ptrtoint %Compound* %sbt.b_cp to i64
+  %sbt.b_nc0 = insertvalue %Value undef, i32 3, 0
+  %sbt.b_new_cons = insertvalue %Value %sbt.b_nc0, i64 %sbt.b_cp_i64, 1
+  br label %sbt.b_loop
+sbt.b_bind:
+  %sbt.b_raw3 = call %Value @wam_get_reg(%WamState* %vm, i32 2)
+  %sbt.b_ok = call i1 @wam_unify_value(%WamState* %vm, %Value %sbt.b_raw3, %Value %sbt.b_acc)
+  ret i1 %sbt.b_ok
+
 unknown:
   ret i1 false
 }'.
@@ -7935,6 +8064,7 @@ builtin_op_to_id('sum_list/2', 59).
 builtin_op_to_id('sumlist/2', 60).   % alias of sum_list/2
 builtin_op_to_id('max_list/2', 61).
 builtin_op_to_id('min_list/2', 62).
+builtin_op_to_id('subtract/3', 63).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -1156,6 +1156,63 @@ test_max_minus_min(_, R) :-
     min_list([4, 7, 1, 9, 3], Mn),
     R is Mx - Mn.   % 9 - 1 = 8
 
+% M44: subtract/3 -- elements of A1 with no unify-match in A2.
+
+:- dynamic test_subtract_disjoint/2.
+test_subtract_disjoint(_, R) :-
+    subtract([1, 2, 3], [4, 5, 6], L),
+    length(L, N),
+    R is N.   % 3 -- all kept
+
+:- dynamic test_subtract_one/2.
+test_subtract_one(_, R) :-
+    subtract([1, 2, 3], [2], L),
+    length(L, N),
+    R is N.   % 2
+
+:- dynamic test_subtract_many/2.
+test_subtract_many(_, R) :-
+    subtract([1, 2, 3, 4, 5], [2, 4], L),
+    length(L, N),
+    R is N.   % 3
+
+:- dynamic test_subtract_all/2.
+test_subtract_all(_, R) :-
+    subtract([1, 2, 3], [3, 2, 1], L),
+    length(L, N),
+    R is N + 7.   % 7 -- empty result
+
+:- dynamic test_subtract_empty_left/2.
+test_subtract_empty_left(_, R) :-
+    subtract([], [1, 2], L),
+    length(L, N),
+    R is N + 8.   % 8
+
+:- dynamic test_subtract_empty_right/2.
+test_subtract_empty_right(_, R) :-
+    subtract([7, 8, 9], [], L),
+    length(L, N),
+    R is N.   % 3 -- nothing to remove
+
+:- dynamic test_subtract_first/2.
+test_subtract_first(_, R) :-
+    subtract([10, 20, 30, 40], [10], L),
+    nth0(0, L, E),
+    R is E.   % 20
+
+:- dynamic test_subtract_preserves_order/2.
+test_subtract_preserves_order(_, R) :-
+    subtract([10, 5, 20, 5, 30], [5], L),
+    nth0(1, L, E),    % L = [10, 20, 30]
+    R is E.   % 20
+
+:- dynamic test_subtract_dupes/2.
+test_subtract_dupes(_, R) :-
+    % All occurrences in A1 are filtered, just like delete/3.
+    subtract([1, 2, 1, 3, 1], [1], L),
+    length(L, N),
+    R is N.   % 2
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -2163,6 +2220,25 @@ test_all :-
                    test_min_list_empty, 0, 0),
        run_test_r0('max_list - min_list of [4,7,1,9,3] -> 8',
                    test_max_minus_min, 0, 8),
+       format('--- M44 subtract/3 ---~n'),
+       run_test_r0('subtract([1,2,3], [4,5,6]) disjoint length -> 3',
+                   test_subtract_disjoint, 0, 3),
+       run_test_r0('subtract([1,2,3], [2]) length -> 2',
+                   test_subtract_one, 0, 2),
+       run_test_r0('subtract([1,2,3,4,5], [2,4]) length -> 3',
+                   test_subtract_many, 0, 3),
+       run_test_r0('subtract([1,2,3], [3,2,1]) empty + 7 -> 7',
+                   test_subtract_all, 0, 7),
+       run_test_r0('subtract([], [1,2]) + 8 -> 8',
+                   test_subtract_empty_left, 0, 8),
+       run_test_r0('subtract([7,8,9], []) length -> 3',
+                   test_subtract_empty_right, 0, 3),
+       run_test_r0('subtract([10,20,30,40], [10]) nth0(0) -> 20',
+                   test_subtract_first, 0, 20),
+       run_test_r0('subtract([10,5,20,5,30], [5]) nth0(1) -> 20',
+                   test_subtract_preserves_order, 0, 20),
+       run_test_r0('subtract([1,2,1,3,1], [1]) length -> 2 (all dupes filtered)',
+                   test_subtract_dupes, 0, 2),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Adds `subtract(+List1, +List2, ?Difference)` — elements of List1 with
no unify-match in List2. Three-pass impl mirroring `delete/3`'s shape
but with an inner walk over List2 instead of a single comparison:

1. **Count** A1's elements `n`.
2. **Filter**: allocate `arr` of `n` `%Value`s. Outer loop over A1: for
   each head, inner-walk A2 using the trial-unify + rollback pattern
   (memberchk inline). Match found anywhere in A2: skip the head, keep
   the binding (matches SWI `subtract([a,b,c], [X], R)` → `X=a,
   R=[b,c]` semantics). A2 exhausted without match: store head at
   `arr[out_idx++]`.
3. **Build**: walk `arr` back-to-front prepending each survivor onto
   the `[]` seed; unify A3 with the chain.

Like `delete/3`, all occurrences of a matching element are filtered
(see `test_subtract_dupes`: `[1,2,1,3,1]` minus `[1]` gives `[2,3]`).

### Variable hygiene
- Prefix `sbt.` with sub-prefixes `c.` (count), `o.` (outer), `i.`
  (inner), `b.` (build). Stays clear of `sb.` / `sub.` neighbours.
- Manual `llc -filetype=obj` round-trip verifies the IR is
  verifier-clean before commit (M42 / M43 pattern).

### Dispatch
- `builtin_op_to_id('subtract/3', 63)` → `%builtin_subtract`.
- `subtract/3` already in `is_builtin_pred` registry (pre-M19 stub).

## Test plan
- [x] 9 new tests: disjoint / one match / many matches / all match /
      both-empty cases / first-survives / middle-survives /
      duplicates-all-filtered
- [x] Manual llc round-trip clean
- [x] Full 253-test suite verifying in background


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_