### PR TITLE
feat(wam-python): add item-driven predicate compiler

### DIFF
--- a/docs/design/WAM_PYTHON_PARITY_AUDIT.md
+++ b/docs/design/WAM_PYTHON_PARITY_AUDIT.md
@@ -115,6 +115,8 @@ Items-mode bridge now present:
 - `wam_items_to_python_instructions/4` consumes `label(Name)` plus standard WAM
   instruction items and emits the same Python instruction literals as the text
   path.
+- `compile_wam_predicate_items_to_python/4` wraps that adapter in the same
+  registrar function shape as `compile_wam_predicate_to_python/4`.
 - The adapter preserves typed direct-item constants, so an atom like `'42'` is
   emitted as `Atom("42")` while integer `42` is emitted as `Int(42)`.
 - Current tests compare the adapter against `wam_text_to_items/2` output for a
@@ -122,14 +124,12 @@ Items-mode bridge now present:
 
 Remaining migration target:
 
-1. Add an item-driven predicate compiler parallel to `compile_wam_predicate_to_python/4`,
-   for example `compile_wam_predicate_items_to_python/4`, using
-   `wam_items_to_python_instructions/4` internally.
-2. Change planning to store WAM items once `compile_predicate_to_wam_items/3` is
-   available as a real generator API.
-3. Teach the lowered emitter to consume the same item list directly, or add one
+1. Change planning to store WAM items once `compile_predicate_to_wam_items/3` is
+   available as a real generator API, then route interpreter-mode predicates
+   through `compile_wam_predicate_items_to_python/4`.
+2. Teach the lowered emitter to consume the same item list directly, or add one
    shared adapter from items to the lowered-emitter instruction representation.
-4. Keep the text parser only for external WAM text/debug migration paths, not
+3. Keep the text parser only for external WAM text/debug migration paths, not
    for WAM text generated inside the same process.
 
 Until that migration lands, `tests/test_wam_python_target.pl` includes
@@ -159,7 +159,7 @@ Completed follow-up:
 ## Verification Commands
 
 Use these checks after touching Python WAM runtime parity. On current `main`,
-`tests/test_wam_python_target.pl` passes 170/170 without choicepoint warnings:
+`tests/test_wam_python_target.pl` passes 172/172 without choicepoint warnings:
 
 ```sh
 swipl -q -g run_tests -t halt tests/test_wam_python_target.pl

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -25,6 +25,7 @@
 	compile_wam_helpers_to_python/2,       % +Options, -PythonCode
 	compile_wam_runtime_to_python/2,       % +Options, -PythonCode
 	compile_wam_predicate_to_python/4,     % +Pred/Arity, +WamCode, +Options, -PythonCode
+	compile_wam_predicate_items_to_python/4, % +Pred/Arity, +Items, +Options, -PythonCode
 	wam_instruction_to_python_literal/2,   % +WamInstr, -PyLiteral
 	wam_line_to_python_literal/2,          % +Parts, -PyLit
 	wam_items_to_python_instructions/4,  % +Items, +PredIndicator, -InstrLits, -LabelLits
@@ -1257,7 +1258,8 @@ wam_item_to_line_parts(trust(Label), ["trust", Label]).
 wam_item_to_line_parts(neck_cut, ["neck_cut"]).
 wam_item_to_line_parts(get_level(Yn), ["get_level", Yn]).
 wam_item_to_line_parts(cut(Yn), ["cut", Yn]).
-wam_item_to_line_parts(switch_on_term(Args), ["switch_on_term"|Args]).
+wam_item_to_line_parts(switch_on_term(Args), Parts) :-
+	append(["switch_on_term"], Args, Parts).
 wam_item_to_line_parts(is(Target, Expr), ["is", Target, Expr]).
 wam_item_to_line_parts(builtin_call(Op, Arity), ["builtin_call", Op, Arity]).
 wam_item_to_line_parts(call_foreign(Pred, Arity), ["call_foreign", Pred, Arity]).
@@ -1570,13 +1572,23 @@ sub_string_replace(Str, From, To, Result) :-
 %  Emits a register_predicate(raw_program) call so the flat program can be
 %  built by load_program in main.py.
 compile_wam_predicate_to_python(Pred/Arity, WamCode, Options, PythonCode) :-
+	wam_code_to_python_instructions(WamCode, Pred/Arity, InstrLiterals, _LabelLiterals),
+	format_python_wam_registrar(Pred/Arity, Options, InstrLiterals, PythonCode).
+
+%% compile_wam_predicate_items_to_python(+Pred/Arity, +Items, +Options, -PythonCode)
+%  Converts structured WAM items for a predicate to Python code.
+%  This is the item-driven counterpart to compile_wam_predicate_to_python/4;
+%  callers can bypass WAM text when they already have label/instruction items.
+compile_wam_predicate_items_to_python(Pred/Arity, Items, Options, PythonCode) :-
+	wam_items_to_python_instructions(Items, Pred/Arity, InstrLiterals, _LabelLiterals),
+	format_python_wam_registrar(Pred/Arity, Options, InstrLiterals, PythonCode).
+
+format_python_wam_registrar(Pred/Arity, Options, InstrLiterals, PythonCode) :-
 	atom_string(Pred, PredStr),
 	python_func_name(Pred/Arity, FuncName),
 	option(registrar_prefix(RegistrarPrefix), Options, ''),
 	atom_concat(RegistrarPrefix, FuncName, RegistrarName),
-	% Build the label key: "Pred/Arity"
 	format(atom(LabelKey), '~w/~w', [PredStr, Arity]),
-	wam_code_to_python_instructions(WamCode, Pred/Arity, InstrLiterals, _LabelLiterals),
 	format(string(PythonCode),
 'def ~w(raw_program):
     """Register WAM code for ~w/~w into raw_program dict."""

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2706,8 +2706,14 @@ is_ground_atom_list(L, Atoms) :-
     maplist(atom, Items),
     Atoms = Items.
 
-proper_list(T, []) :- T == [], !.
-proper_list([H|T], [H|R]) :- proper_list(T, R).
+proper_list(T, Items) :-
+    nonvar(T),
+    proper_list_(T, Items).
+
+proper_list_(T, []) :- T == [], !.
+proper_list_([H|T], [H|R]) :-
+    nonvar(T),
+    proper_list_(T, R).
 
 %% emit_not_member_const_atoms_lowering(+X, +Atoms, +V0, -Vf, -Code)
 %

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -319,11 +319,12 @@ test(python_target_still_uses_text_wam_generation) :-
     sub_string(Content, _, _, _, "wam_code_to_python_instructions(WamCode"),
     !.
 
-test(python_items_mode_migration_target_not_yet_present) :-
+test(python_items_mode_planning_still_uses_text_wam) :-
     once(source_file(wam_python_target:compile_wam_predicate_to_python(_, _, _, _), Path)),
     read_file_to_string(Path, Content, []),
+    sub_string(Content, _, _, _, "compile_wam_predicate_items_to_python"),
     \+ sub_string(Content, _, _, _, "compile_predicate_to_wam_items"),
-    \+ sub_string(Content, _, _, _, "compile_wam_predicate_items_to_python").
+    !.
 
 
 test(items_adapter_matches_text_adapter_for_standard_items) :-
@@ -347,6 +348,24 @@ test(items_adapter_preserves_typed_atom_constants) :-
     wam_python_target:wam_items_to_python_instructions(Items, typed/1, Instrs, _Labels),
     sub_string(Instrs, _, _, _, '("put_constant", Atom("42"), A1)'),
     sub_string(Instrs, _, _, _, '("put_constant", Int(42), A2)'),
+    !.
+
+
+test(items_predicate_compiler_matches_text_compiler) :-
+    WamText = 'demo/1:
+    put_constant foo, A1
+    proceed',
+    wam_text_to_items(WamText, Items),
+    wam_python_target:compile_wam_predicate_to_python(demo/1, WamText, [], TextCode),
+    wam_python_target:compile_wam_predicate_items_to_python(demo/1, Items, [], ItemsCode),
+    assertion(ItemsCode == TextCode).
+
+test(items_predicate_compiler_honors_registrar_prefix) :-
+    Items = [label("demo/1"), put_constant(foo, "A1"), proceed],
+    wam_python_target:compile_wam_predicate_items_to_python(demo/1, Items,
+        [registrar_prefix(register_)], Code),
+    sub_string(Code, _, _, _, 'def register_pred_demo_1(raw_program):'),
+    sub_string(Code, _, _, _, 'raw_program["demo/1"] = ('),
     !.
 :- end_tests(wam_python_items_mode_audit).
 


### PR DESCRIPTION
## Summary

- adds `compile_wam_predicate_items_to_python/4` so Python WAM predicates can be registered from structured WAM items without re-tokenizing generated WAM text
- shares registrar formatting between the existing text path and the new item path
- keeps the Python parity audit aligned with the new migration state
- hardens the WAM compiler proper-list recognizer so open-list parser clauses fail the proper-list check instead of expanding indefinitely during runtime-parser bundling

## Verification

- `swipl -q -g "run_tests(wam_python_items_mode_audit),run_tests(wam_python_phase_a)" -t halt tests/test_wam_python_target.pl`
- `swipl --stack_limit=2g -q -g "run_tests(wam_python_runtime_parser_mode)" -t halt tests/test_wam_python_target.pl`
- `swipl --stack_limit=2g -q -g "run_tests" -t halt tests/test_wam_python_target.pl`
- `git diff --check`
