### PR TITLE
Feat/wam go between builtin

### DIFF
--- a/PR_go_wam_between_builtin.md
+++ b/PR_go_wam_between_builtin.md
@@ -1,0 +1,22 @@
+# Title
+
+Add Go WAM between/3 builtin parity
+
+# Description
+
+## Summary
+
+- Adds direct Go WAM lowering for `between/3`.
+- Implements runtime support for deterministic `between(+Low, +High, +Value)` range checks.
+- Implements enumerable `between(+Low, +High, -Value)` via a dedicated choicepoint resume state.
+- Adds generated Go WAM builtin E2E coverage for range success, range failure, invalid bounds, singleton ranges, and `findall/3` enumeration.
+- Updates the Go WAM parity audit to document the R/C++ `between/3` parity surface.
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -13,7 +13,7 @@ current cross-target builtin/runtime baseline.
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
 | Structural builtins | `member/2`, `memberchk/2`, `select/3`, `delete/3`, `permutation/2`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, `msort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++ also cover richer list builtins including `select/3`, `delete/3`, `permutation/2`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sort/2`, and `msort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1`, `ground/1` | Includes `is_list/1` and Clojure direct `ground/1` in the current baseline | Present for current baseline type and groundness checks |
-| Arithmetic builtins | `is/2`, `succ/2` | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir | Present for current baseline arithmetic checks, with expanded successor coverage |
+| Arithmetic builtins | `is/2`, `succ/2`, `between/3` | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir; R/C++ also cover `between/3` | Present for current baseline arithmetic checks, with expanded successor and integer-range coverage |
 | Atom/text conversion | `atom_number/2`, `atom_codes/2`, `atom_chars/2`, `string_codes/2`, `string_chars/2`, `number_codes/2`, `number_chars/2`, `atom_string/2`, `string_to_atom/2`, `upcase_atom/2`, `downcase_atom/2`, `atom_concat/3`, `atom_length/2`, `string_length/2`, `char_code/2`, `sub_atom/5` forward mode, `char_type/2` forward mode, `string_code/3` forward mode, `split_string/4` forward mode | Clojure direct builtin surface includes bidirectional `atom_number/2`, atom/string/number code-list and char-list conversion, atom/string conversion, atom case conversion, deterministic atom concatenation, text length checks, and char-code conversion | Present for current atom-number, atom/string/number code-list, atom/string/number char-list, atom/string, atom-case, atom-concat, text-length, char-code, forward sub-atom, forward char-type, forward string-code, and forward split-string checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` | Includes `=</2`; Haskell mode analysis and Clojure lowering also cover term-order comparisons | Present for current baseline comparisons, with expanded term-order coverage |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
@@ -59,6 +59,9 @@ current cross-target builtin/runtime baseline.
 - Deterministic `numlist/3` is now covered by the generated Go WAM builtin E2E
   test for closed integer range construction and `Low > High` failure,
   matching the Clojure/R range-list surface.
+- `between/3` is now covered by the generated Go WAM builtin E2E test for
+  deterministic `(+,+,+)` range checks and enumerable `(+,+,-)` integer
+  generation through `findall/3`, matching the bounded R/C++ range surface.
 - Deterministic `sort/2` and `msort/2` are now covered by the generated Go WAM
   builtin E2E test for standard ordered sorting, duplicate removal in
   `sort/2`, duplicate preservation in `msort/2`, mixed atom/integer ordering,

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -466,6 +466,9 @@ wam_go_direct_builtin("nth1/3", 3, 'nth1/3').
 wam_go_direct_builtin(numlist/3, 3, 'numlist/3').
 wam_go_direct_builtin('numlist/3', 3, 'numlist/3').
 wam_go_direct_builtin("numlist/3", 3, 'numlist/3').
+wam_go_direct_builtin(between/3, 3, 'between/3').
+wam_go_direct_builtin('between/3', 3, 'between/3').
+wam_go_direct_builtin("between/3", 3, 'between/3').
 wam_go_direct_builtin(sort/2, 2, 'sort/2').
 wam_go_direct_builtin('sort/2', 2, 'sort/2').
 wam_go_direct_builtin("sort/2", 2, 'sort/2').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -66,6 +66,10 @@ type ChoicePoint struct {
 	ForeignResults   []Value
 	MemberTail       Value
 	SelectResults    []SelectSolution
+	BetweenActive    bool
+	BetweenCurrent   int64
+	BetweenHigh      int64
+	BetweenReg       int
 }
 
 type EnvFrame struct {
@@ -1305,6 +1309,35 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 			return vm.Unify(arg1, &Integer{Val: bInt.Val - 1})
 		}
 		return false
+	case "between/3":
+		lo, ok1 := vm.deref(arg1).(*Integer)
+		hi, ok2 := vm.deref(arg2).(*Integer)
+		if !ok1 || !ok2 || lo.Val > hi.Val {
+			return false
+		}
+		v := vm.deref(arg3)
+		if n, ok := v.(*Integer); ok {
+			return n.Val >= lo.Val && n.Val <= hi.Val
+		}
+		if !isUnbound(v) {
+			return false
+		}
+		if lo.Val < hi.Val {
+			vm.ChoicePoints = append(vm.ChoicePoints, ChoicePoint{
+				ResumePC:       vm.PC + 1,
+				CP:             vm.CP,
+				E:              vm.E,
+				StackLen:       len(vm.Stack),
+				SavedRegs:      vm.snapshotAllRegs(),
+				HeapTop:        vm.HeapLen,
+				TrailMark:      vm.TrailLen,
+				BetweenActive:  true,
+				BetweenCurrent: lo.Val + 1,
+				BetweenHigh:    hi.Val,
+				BetweenReg:     2,
+			})
+		}
+		return vm.Unify(arg3, &Integer{Val: lo.Val})
 	case "atom_number/2":
 		atomVal := vm.deref(arg1)
 		numberVal := vm.deref(arg2)
@@ -2181,6 +2214,36 @@ func (vm *WamState) backtrack() bool {
                 vm.ChoicePoints = vm.ChoicePoints[:topIdx]
             }
             if !vm.applySelectSolution(solution) {
+                continue
+            }
+            vm.PC = resumePC
+            return true
+        }
+        return vm.backtrack()
+    }
+    if cp.BetweenActive {
+        for cp.BetweenCurrent <= cp.BetweenHigh {
+            vm.unwindTrailTo(cp.TrailMark)
+            vm.restoreSavedRegs(cp.SavedRegs)
+            if cp.StackLen <= len(vm.Stack) {
+                vm.Stack = vm.Stack[:cp.StackLen]
+            }
+            if cp.HeapTop <= vm.HeapLen {
+                vm.heapTrimTo(cp.HeapTop)
+            }
+            vm.PC = cp.ResumePC
+            vm.CP = cp.CP
+            vm.E = cp.E
+            vm.Halted = false
+            vm.CurrentStruct = nil
+            vm.CurrentList = nil
+            n := cp.BetweenCurrent
+            cp.BetweenCurrent++
+            resumePC := cp.ResumePC
+            if cp.BetweenCurrent > cp.BetweenHigh {
+                vm.ChoicePoints = vm.ChoicePoints[:topIdx]
+            }
+            if !vm.Unify(vm.getReg(cp.BetweenReg), &Integer{Val: n}) {
                 continue
             }
             vm.PC = resumePC

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -25,6 +25,7 @@
 :- dynamic user:test_split_string_builtin/0.
 :- dynamic user:test_tab_builtin/0.
 :- dynamic user:test_succ_builtin/0.
+:- dynamic user:test_between_builtin/0.
 :- dynamic user:test_atom_number_builtin/0.
 :- dynamic user:test_atom_case_builtin/0.
 :- dynamic user:test_atom_concat_builtin/0.
@@ -154,6 +155,16 @@ test(builtins_execution) :-
                 numlist(3, 3, S),
                 S = [3],
                 \+ numlist(5, 2, _)
+            )),
+          assertz(user:test_between_builtin :-
+            (   between(1, 3, 1),
+                between(1, 3, 3),
+                \+ between(1, 3, 4),
+                \+ between(5, 2, _),
+                findall(N, between(2, 5, N), Ns),
+                Ns = [2,3,4,5],
+                findall(One, between(7, 7, One), Ones),
+                Ones = [7]
             )),
           assertz(user:test_sort_builtin :-
             (   sort([3,1,2,1,3], S),
@@ -482,6 +493,7 @@ test(builtins_execution) :-
           retractall(user:test_split_string_builtin),
           retractall(user:test_tab_builtin),
           retractall(user:test_succ_builtin),
+          retractall(user:test_between_builtin),
           retractall(user:test_atom_number_builtin),
           retractall(user:test_atom_case_builtin),
           retractall(user:test_atom_concat_builtin),
@@ -501,7 +513,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_tab_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_sort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_tab_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -542,6 +554,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "nth0/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "nth1/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "numlist/3"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "between/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "sort/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "msort/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "@</2"')),
@@ -752,6 +765,14 @@ func main() {
 		fmt.Println("SUCC_FAILURE")
 	}
 
+	betweenVM := wam.NewWamState(wam.Test_between_builtinCode, wam.Test_between_builtinLabels)
+	betweenVM.PC = wam.Test_between_builtinStartPC
+	if betweenVM.Run() {
+		fmt.Println("BETWEEN_SUCCESS")
+	} else {
+		fmt.Println("BETWEEN_FAILURE")
+	}
+
 	atomNumberVM := wam.NewWamState(wam.Test_atom_number_builtinCode, wam.Test_atom_number_builtinLabels)
 	atomNumberVM.PC = wam.Test_atom_number_builtinStartPC
 	if atomNumberVM.Run() {
@@ -901,6 +922,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "SPLIT_STRING_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "   tabbedTAB_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SUCC_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "BETWEEN_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_NUMBER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_CASE_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_CONCAT_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM between/3 builtin parity

## Summary

- Adds direct Go WAM lowering for `between/3`.
- Implements runtime support for deterministic `between(+Low, +High, +Value)` range checks.
- Implements enumerable `between(+Low, +High, -Value)` via a dedicated choicepoint resume state.
- Adds generated Go WAM builtin E2E coverage for range success, range failure, invalid bounds, singleton ranges, and `findall/3` enumeration.
- Updates the Go WAM parity audit to document the R/C++ `between/3` parity surface.

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
