### PR TITLE
fix(wam-clojure): materialize numeric text lists

### DIFF
--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1093,15 +1093,19 @@
     (symbol? value) (name value)
     :else nil))
 
-(defn number-text [value]
-  (when (number? value)
-    (str value)))
-
 (declare parse-number-text)
+
+(defn number-text [state value]
+  (cond
+    (number? value) (str value)
+    (string? value) (when (some? (parse-number-text value)) value)
+    (atom-term? value) (let [text (atom-text state value)]
+                         (when (some? (parse-number-text text)) text))
+    :else nil))
 
 (defn atom-number-text [state value]
   (or (atom-text state value)
-      (number-text value)))
+      (number-text state value)))
 
 (defn atom-number-value [state value]
   (cond
@@ -1164,7 +1168,7 @@
         codes? (or (= pred "atom_codes/2") (= pred "string_codes/2") (= pred "number_codes/2"))
         atom? (or (= pred "atom_codes/2") (= pred "atom_chars/2")
                   (= pred "string_codes/2") (= pred "string_chars/2"))
-        value-text (if atom? (atom-text state left) (number-text left))
+        value-text (if atom? (atom-text state left) (number-text state left))
         list-text (if codes? (code-list-text state right) (char-list-text state right))]
     (cond
       (and (some? value-text) (some? list-text))
@@ -1272,7 +1276,7 @@
 
 (defn atomic-concat-text [state value]
   (or (atom-text state value)
-      (number-text value)))
+      (number-text state value)))
 
 (defn atomic-concat-list-term [state texts]
   (loop [s state

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -218,8 +218,12 @@
 :- dynamic user:wam_char_type_code_mismatch/0.
 :- dynamic user:wam_char_type_lower_fail/0.
 :- dynamic user:wam_number_codes_guard/2.
+:- dynamic user:wam_number_codes_forward/0.
+:- dynamic user:wam_number_codes_forward_mismatch/0.
 :- dynamic user:wam_number_codes_reverse/0.
 :- dynamic user:wam_number_chars_guard/2.
+:- dynamic user:wam_number_chars_forward/0.
+:- dynamic user:wam_number_chars_forward_mismatch/0.
 :- dynamic user:wam_number_chars_reverse/0.
 :- dynamic user:wam_number_chars_bad_chars/0.
 :- dynamic user:wam_text_conversion_unbound_pair/1.
@@ -486,8 +490,12 @@ user:wam_char_type_code_reverse :- char_type(C, code(97)), C = a.
 user:wam_char_type_code_mismatch :- char_type('A', code(66)).
 user:wam_char_type_lower_fail :- char_type('A', lower).
 user:wam_number_codes_guard(N, C) :- number_codes(N, C).
+user:wam_number_codes_forward :- number_codes(42, C), C = [52,50].
+user:wam_number_codes_forward_mismatch :- number_codes(42, C), C = [52].
 user:wam_number_codes_reverse :- number_codes(N, [52,50]), N =:= 42.
 user:wam_number_chars_guard(N, C) :- number_chars(N, C).
+user:wam_number_chars_forward :- number_chars(42, C), C = ['4','2'].
+user:wam_number_chars_forward_mismatch :- number_chars(42, C), C = ['4'].
 user:wam_number_chars_reverse :- number_chars(N, ['4','2']), N =:= 42.
 user:wam_number_chars_bad_chars :- number_chars(_, [f,o,o]).
 user:wam_text_conversion_unbound_pair(_) :- user:wam_unbound_arg(A), user:wam_unbound_arg(C), atom_codes(A, C).
@@ -759,8 +767,12 @@ run_smoke :-
           user:wam_char_type_code_mismatch/0,
           user:wam_char_type_lower_fail/0,
           user:wam_number_codes_guard/2,
+          user:wam_number_codes_forward/0,
+          user:wam_number_codes_forward_mismatch/0,
           user:wam_number_codes_reverse/0,
           user:wam_number_chars_guard/2,
+          user:wam_number_chars_forward/0,
+          user:wam_number_chars_forward_mismatch/0,
           user:wam_number_chars_reverse/0,
           user:wam_number_chars_bad_chars/0,
           user:wam_text_conversion_unbound_pair/1,
@@ -1209,9 +1221,13 @@ smoke_cases([
     case('wam_char_type_lower_fail/0', no_args, "false"),
     case('wam_number_codes_guard/2', args(42, '[52,50]'), "true"),
     case('wam_number_codes_guard/2', args(42, '[52]'), "false"),
+    case('wam_number_codes_forward/0', no_args, "true"),
+    case('wam_number_codes_forward_mismatch/0', no_args, "false"),
     case('wam_number_codes_reverse/0', no_args, "true"),
     case('wam_number_chars_guard/2', args(42, '[''4'',''2'']'), "true"),
     case('wam_number_chars_guard/2', args(42, '[''4'']'), "false"),
+    case('wam_number_chars_forward/0', no_args, "true"),
+    case('wam_number_chars_forward_mismatch/0', no_args, "false"),
     case('wam_number_chars_reverse/0', no_args, "true"),
     case('wam_number_chars_bad_chars/0', no_args, "false"),
     case('wam_text_conversion_unbound_pair/1', a, "false"),


### PR DESCRIPTION
## Summary

- Extend Clojure WAM numeric text conversion so `number_codes/2` and `number_chars/2` can materialize output lists from bound numeric inputs represented as lowered WAM literals.
- Teach `number-text` to accept raw JVM numbers, parseable strings, and parseable interned atom terms while rejecting non-numeric atoms.
- Add runtime smoke coverage for forward and mismatch cases for `number_codes/2` and `number_chars/2`.

## Why

The previous text-list materialization work aligned code-list output with lowered WAM list literals, but numeric forward conversion still only recognized raw JVM numeric values. Lowered WAM constants such as `42` are represented as interned literal terms, so `number_codes(42, C), C = [52,50]` failed even though the logical mode is finite and should succeed.

This change makes numeric text conversion consume the same representation emitted by the lowered Clojure WAM path, without making non-numeric atoms look numeric.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
