### PR TITLE
LLVM WAM: string_chars/string_codes aliases + string_code/3 (M48)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3426,6 +3426,9 @@ entry:
     i32 64, label %builtin_intersection
     i32 65, label %builtin_union
     i32 66, label %builtin_list_to_set
+    i32 67, label %builtin_atom_chars
+    i32 68, label %builtin_atom_codes
+    i32 69, label %builtin_string_code
   ]
 
 builtin_is:
@@ -7046,6 +7049,55 @@ l2s.b_bind:
   %l2s.b_ok = call i1 @wam_unify_value(%WamState* %vm, %Value %l2s.b_raw2, %Value %l2s.b_acc)
   ret i1 %l2s.b_ok
 
+builtin_string_code:
+  ; M48: string_code(+Index, +String, ?Code) -- 1-based byte access.
+  ; Atoms are strings in this runtime, so A2 is just an Atom.
+  ; Validates A1 is Integer, A2 is Atom, Index in [1, length]. Returns
+  ; the byte at position Index-1 as an Integer code. Failing the
+  ; bounds check or types simply returns false (no type_error throw).
+  %stc.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %stc.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %stc.t1 = extractvalue %Value %stc.a1, 0
+  %stc.t2 = extractvalue %Value %stc.a2, 0
+  %stc.is_int = icmp eq i32 %stc.t1, 1
+  %stc.is_atom = icmp eq i32 %stc.t2, 0
+  %stc.both = and i1 %stc.is_int, %stc.is_atom
+  br i1 %stc.both, label %stc.lookup, label %stc.fail
+stc.fail:
+  ret i1 false
+stc.lookup:
+  %stc.aid = extractvalue %Value %stc.a2, 1
+  %stc.str = call i8* @wam_atom_to_string(i64 %stc.aid)
+  %stc.str_null = icmp eq i8* %stc.str, null
+  br i1 %stc.str_null, label %stc.fail, label %stc.measure
+stc.measure:
+  br label %stc.m_loop
+stc.m_loop:
+  %stc.mp = phi i8* [ %stc.str, %stc.measure ], [ %stc.mpn, %stc.m_step ]
+  %stc.mn = phi i64 [ 0, %stc.measure ], [ %stc.mn1, %stc.m_step ]
+  %stc.mc = load i8, i8* %stc.mp
+  %stc.mz = icmp eq i8 %stc.mc, 0
+  br i1 %stc.mz, label %stc.bounds, label %stc.m_step
+stc.m_step:
+  %stc.mpn = getelementptr i8, i8* %stc.mp, i32 1
+  %stc.mn1 = add i64 %stc.mn, 1
+  br label %stc.m_loop
+stc.bounds:
+  %stc.idx = extractvalue %Value %stc.a1, 1
+  %stc.lo_bad = icmp slt i64 %stc.idx, 1
+  %stc.hi_bad = icmp sgt i64 %stc.idx, %stc.mn
+  %stc.bad = or i1 %stc.lo_bad, %stc.hi_bad
+  br i1 %stc.bad, label %stc.fail, label %stc.read
+stc.read:
+  %stc.pos = sub i64 %stc.idx, 1
+  %stc.byte_ptr = getelementptr i8, i8* %stc.str, i64 %stc.pos
+  %stc.byte = load i8, i8* %stc.byte_ptr
+  %stc.byte64 = zext i8 %stc.byte to i64
+  %stc.code_v = call %Value @value_integer(i64 %stc.byte64)
+  %stc.raw3 = call %Value @wam_get_reg(%WamState* %vm, i32 2)
+  %stc.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %stc.raw3, %Value %stc.code_v)
+  ret i1 %stc.ok
+
 unknown:
   ret i1 false
 }'.
@@ -8485,6 +8537,9 @@ builtin_op_to_id('subtract/3', 63).
 builtin_op_to_id('intersection/3', 64).
 builtin_op_to_id('union/3', 65).
 builtin_op_to_id('list_to_set/2', 66).
+builtin_op_to_id('string_chars/2', 67).  % alias of atom_chars/2
+builtin_op_to_id('string_codes/2', 68).  % alias of atom_codes/2
+builtin_op_to_id('string_code/3', 69).   % string_code(+Idx, +Str, -Code) 1-based
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -1410,6 +1410,54 @@ test_l2s_idempotent(_, R) :-
     length(L2, N),
     R is N.   % 3 -- already a set
 
+% M48: string_chars/2, string_codes/2 aliases + string_code/3.
+
+:- dynamic test_string_chars_first/2.
+test_string_chars_first(_, R) :-
+    string_chars(hello, [H|_]),
+    char_code(H, C),
+    R is C.   % 'h' = 104
+
+:- dynamic test_string_chars_length/2.
+test_string_chars_length(_, R) :-
+    string_chars(abc, L),
+    length(L, N),
+    R is N.   % 3
+
+:- dynamic test_string_codes_first/2.
+test_string_codes_first(_, R) :-
+    string_codes(hello, [C|_]),
+    R is C.   % 104
+
+:- dynamic test_string_codes_length/2.
+test_string_codes_length(_, R) :-
+    string_codes(abcde, L),
+    length(L, N),
+    R is N.   % 5
+
+:- dynamic test_string_code_first/2.
+test_string_code_first(_, R) :-
+    string_code(1, hello, C),
+    R is C.   % 'h' = 104
+
+:- dynamic test_string_code_middle/2.
+test_string_code_middle(_, R) :-
+    string_code(3, abcdef, C),
+    R is C.   % 'c' = 99
+
+:- dynamic test_string_code_last/2.
+test_string_code_last(_, R) :-
+    string_code(5, hello, C),
+    R is C.   % 'o' = 111
+
+:- dynamic test_string_code_oob_low/2.
+test_string_code_oob_low(_, R) :-
+    ( string_code(0, hello, _) -> R is 1 ; R is 0 ).   % 0 -- 1-based
+
+:- dynamic test_string_code_oob_high/2.
+test_string_code_oob_high(_, R) :-
+    ( string_code(99, hello, _) -> R is 1 ; R is 0 ).   % 0
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -2499,6 +2547,25 @@ test_all :-
                    test_l2s_atom_dupes, 0, 3),
        run_test_r0('list_to_set idempotent on already-a-set -> 3',
                    test_l2s_idempotent, 0, 3),
+       format('--- M48 string_chars/2 + string_codes/2 aliases + string_code/3 ---~n'),
+       run_test_r0('string_chars(hello, [H|_]) char_code -> 104',
+                   test_string_chars_first, 0, 104),
+       run_test_r0('string_chars(abc, L) length -> 3',
+                   test_string_chars_length, 0, 3),
+       run_test_r0('string_codes(hello, [C|_]) -> 104',
+                   test_string_codes_first, 0, 104),
+       run_test_r0('string_codes(abcde, L) length -> 5',
+                   test_string_codes_length, 0, 5),
+       run_test_r0('string_code(1, hello, C) -> 104 (h)',
+                   test_string_code_first, 0, 104),
+       run_test_r0('string_code(3, abcdef, C) -> 99 (c)',
+                   test_string_code_middle, 0, 99),
+       run_test_r0('string_code(5, hello, C) -> 111 (o)',
+                   test_string_code_last, 0, 111),
+       run_test_r0('string_code(0, hello, _) -> 0 (1-based)',
+                   test_string_code_oob_low, 0, 0),
+       run_test_r0('string_code(99, hello, _) -> 0 (overflow)',
+                   test_string_code_oob_high, 0, 0),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Routes `string_chars/2` and `string_codes/2` to the existing
`atom_chars` and `atom_codes` dispatch labels respectively — the
runtime has no distinct string type, so SWI's string predicates are
atom variants. Adds `string_code/3` as a new tiny block for 1-based
byte access.

### string_code(+Index, +String, ?Code)
- Validates A1 is `Integer`, A2 is `Atom`; looks up A2's string and
  measures null-terminated length.
- Bounds check: `Index in [1, length]`; failing returns false (no
  `type_error` throw — `catch/throw` deferred).
- Reads byte at position `Index - 1`, zext to i64, wraps in `Integer`,
  unifies A3 (handles bound + unbound modes via `wam_unify_value`).

### Dispatch
- `string_chars/2` op id 67 → `%builtin_atom_chars` (alias).
- `string_codes/2` op id 68 → `%builtin_atom_codes` (alias).
- `string_code/3` op id 69 → `%builtin_string_code` (new block).
- All three already in `is_builtin_pred` registry.
- Prefix `stc.` for string_code locals.
- Manual `llc -filetype=obj` clean.

## Test plan
- [x] 9 new tests: string_chars + char_code composition, length;
      string_codes head code + length; string_code first/middle/last
      positions; bounds 0 (1-based rejects) and overflow
- [x] All 292 builtin tests pass (was 283, +9)
- [x] Manual llc round-trip clean


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_