### PR TITLE
feat(wam-python): plan predicates with WAM items

### DIFF
--- a/docs/design/WAM_PYTHON_PARITY_AUDIT.md
+++ b/docs/design/WAM_PYTHON_PARITY_AUDIT.md
@@ -97,16 +97,17 @@ Python is a good candidate for the WAM items-mode migration because generated
 projects already use one packaged runtime surface, but the generator still has a
 text-first compile pipeline.
 
-Current load-bearing text path:
+Current load-bearing items path:
 
-- `plan_python_predicate/3` calls `compile_predicate_to_wam(..., WamCode)` and
-  stores canonical WAM text in `pred_plan/4`.
-- `compile_wam_predicate_to_python/4` converts that text through
-  `wam_code_to_python_instructions/4`, which tokenizes each line and calls
-  `wam_line_to_python_literal/2`.
-- lowered mode calls `parse_wam_text_py/2` in `compile_lowered_wam_predicate_to_python/4`,
-  `lowered_candidate_wam/1`, and `lowered_route_supported/4` before emitting
-  lowered Python functions.
+- `plan_python_predicate/3` still calls `compile_predicate_to_wam(..., WamText)`
+  when compiling Prolog predicates, but immediately normalizes that text through
+  `wam_text_to_items/2` and stores `wam_items(WamText, Items)` in `pred_plan/4`.
+- interpreter-mode predicate emission routes planned predicates through
+  `compile_wam_predicate_items_to_python/4`, so generated Python no longer
+  reparses planned WAM text during interpreter registration.
+- lowered mode still unwraps the stored text and calls `parse_wam_text_py/2` in
+  `compile_lowered_wam_predicate_to_python/4`, `lowered_candidate_wam/1`, and
+  `lowered_route_supported/4` before emitting lowered Python functions.
 - `wam_python_iso_audit/3` still recompiles predicates to WAM text and parses
   lines for audit reporting.
 
@@ -120,21 +121,23 @@ Items-mode bridge now present:
 - The adapter preserves typed direct-item constants, so an atom like `'42'` is
   emitted as `Atom("42")` while integer `42` is emitted as `Int(42)`.
 - Current tests compare the adapter against `wam_text_to_items/2` output for a
-  standard WAM-text fixture and cover typed atom/integer constant separation.
+  standard WAM-text fixture, cover typed atom/integer constant separation, and
+  assert that `compile_all_predicates/3` uses the items-backed plan for
+  interpreter-mode predicate registration.
 
 Remaining migration target:
 
-1. Change planning to store WAM items once `compile_predicate_to_wam_items/3` is
-   available as a real generator API, then route interpreter-mode predicates
-   through `compile_wam_predicate_items_to_python/4`.
+1. Replace the temporary `compile_predicate_to_wam/3` plus `wam_text_to_items/2`
+   normalization step with `compile_predicate_to_wam_items/3` once that common
+   generator API exists.
 2. Teach the lowered emitter to consume the same item list directly, or add one
    shared adapter from items to the lowered-emitter instruction representation.
 3. Keep the text parser only for external WAM text/debug migration paths, not
    for WAM text generated inside the same process.
 
-Until that migration lands, `tests/test_wam_python_target.pl` includes
-items-mode audit tests that record the remaining text-first planning path and
-protect the new items adapter.
+Until the native generator API lands, `tests/test_wam_python_target.pl` includes
+items-mode audit tests that record the remaining text-to-items normalization
+bridge and protect the item-driven Python emitter.
 
 ## Remaining Follow-Up
 
@@ -159,7 +162,7 @@ Completed follow-up:
 ## Verification Commands
 
 Use these checks after touching Python WAM runtime parity. On current `main`,
-`tests/test_wam_python_target.pl` passes 172/172 without choicepoint warnings:
+`tests/test_wam_python_target.pl` passes 173/173 without choicepoint warnings:
 
 ```sh
 swipl -q -g run_tests -t halt tests/test_wam_python_target.pl

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -66,7 +66,8 @@
 :- use_module('../targets/wam_text_parser',
               [wam_classify_constant_token/2,
                wam_tokenize_line/2,
-               wam_recognise_instruction/2]).
+               wam_recognise_instruction/2,
+               wam_text_to_items/2]).
 :- use_module(wam_runtime_parser_capability, [
 	parser_dependent_body_goal/2,
 	wam_target_runtime_parser/3
@@ -1743,13 +1744,16 @@ iso_errors:iso_errors_default_to_lax("read/2", "read_lax/2").
 
 %% iso_errors_rewrite_plans(+Config, +Plans0, -Plans)
 %  Python-specific pred_plan wrapper: applies iso_errors_rewrite_text
-%  to each pred_plan(Pred, Arity, Wam, wam) plan's WAM text.
+%  to each pred_plan(Pred, Arity, WamRepr, wam) plan's WAM text, then
+%  refreshes the structured items used by interpreter-mode codegen.
 iso_errors_rewrite_plans(Config, Plans0, Plans) :-
 	maplist(iso_errors_rewrite_plan(Config), Plans0, Plans).
 
 iso_errors_rewrite_plan(Config, pred_plan(Pred, Arity, Wam0, wam), pred_plan(Pred, Arity, Wam, wam)) :-
 	!,
-	iso_errors_rewrite_text(Config, Pred/Arity, Wam0, Wam).
+	wam_plan_text(Wam0, WamText0),
+	iso_errors_rewrite_text(Config, Pred/Arity, WamText0, WamText),
+	python_wam_text_plan(WamText, Wam).
 iso_errors_rewrite_plan(_, Plan, Plan).
 
 %% iso_errors_rewrite_text(+Config, +PI, +WamText, -RewrittenText)
@@ -2030,44 +2034,58 @@ python_predicate_clause(Name/Arity, Head, Body) :-
 plan_python_predicates(Predicates, Options, Plans) :-
 	maplist(plan_python_predicate(Options), Predicates, Plans).
 
-plan_python_predicate(Options, Module:Pred/Arity-WamCode,
-                      pred_plan(Pred, Arity, WamCode, Kind)) :- !,
+plan_python_predicate(Options, _Module:Pred/Arity-WamText,
+                      pred_plan(Pred, Arity, Wam, Kind)) :- !,
 	(   is_ffi_predicate(Pred, Arity, Options)
-	->  Kind = ffi
-	;   Module == user
-	->  Kind = wam
-	;   Kind = wam
+	->  Kind = ffi,
+	    Wam = ''
+	;   python_wam_text_plan(WamText, Wam),
+	    Kind = wam
 	).
 plan_python_predicate(Options, Module:Pred/Arity,
-                      pred_plan(Pred, Arity, WamCode, Kind)) :- !,
+                      pred_plan(Pred, Arity, Wam, Kind)) :- !,
 	(   is_ffi_predicate(Pred, Arity, Options)
 	->  Kind = ffi,
-	    WamCode = ''
-	;   compile_predicate_to_wam(Module:Pred/Arity, [], WamCode)
-	->  Kind = wam
-	;   WamCode = '',
+	    Wam = ''
+	;   compile_predicate_to_wam(Module:Pred/Arity, [], WamText)
+	->  python_wam_text_plan(WamText, Wam),
+	    Kind = wam
+	;   Wam = '',
 	    Kind = missing
 	).
-plan_python_predicate(Options, Pred/Arity-WamCode, pred_plan(Pred, Arity, WamCode, Kind)) :- !,
-	(   is_ffi_predicate(Pred, Arity, Options)
-	->  Kind = ffi
-	;   Kind = wam
-	).
-plan_python_predicate(Options, Pred/Arity, pred_plan(Pred, Arity, WamCode, Kind)) :-
+plan_python_predicate(Options, Pred/Arity-WamText, pred_plan(Pred, Arity, Wam, Kind)) :- !,
 	(   is_ffi_predicate(Pred, Arity, Options)
 	->  Kind = ffi,
-	    WamCode = ''
-	;   compile_predicate_to_wam(Pred/Arity, [], WamCode)
-	->  Kind = wam
-	;   WamCode = '',
+	    Wam = ''
+	;   python_wam_text_plan(WamText, Wam),
+	    Kind = wam
+	).
+plan_python_predicate(Options, Pred/Arity, pred_plan(Pred, Arity, Wam, Kind)) :-
+	(   is_ffi_predicate(Pred, Arity, Options)
+	->  Kind = ffi,
+	    Wam = ''
+	;   compile_predicate_to_wam(Pred/Arity, [], WamText)
+	->  python_wam_text_plan(WamText, Wam),
+	    Kind = wam
+	;   Wam = '',
 	    Kind = missing
 	).
+
+python_wam_text_plan(WamText, wam_items(WamText, Items)) :-
+	wam_text_to_items(WamText, Items).
+
+wam_plan_text(wam_items(WamText, _Items), WamText) :- !.
+wam_plan_text(WamText, WamText).
+
+wam_plan_items(wam_items(_WamText, Items), Items) :- !.
+wam_plan_items(WamText, Items) :-
+	wam_text_to_items(WamText, Items).
 
 lowered_route_set(Plans, Options, LoweredSet) :-
 	(   option(emit_mode(lowered), Options)
 	->  findall(Pred/Arity,
-	        ( member(pred_plan(Pred, Arity, WamCode, wam), Plans),
-	          lowered_candidate_wam(WamCode)
+	        ( member(pred_plan(Pred, Arity, Wam, wam), Plans),
+	          lowered_candidate_wam(Wam)
 	        ),
 	        Candidates0),
 	    sort(Candidates0, Candidates),
@@ -2075,8 +2093,9 @@ lowered_route_set(Plans, Options, LoweredSet) :-
 	;   LoweredSet = []
 	).
 
-lowered_candidate_wam(WamCode) :-
-	parse_wam_text_py(WamCode, Instrs),
+lowered_candidate_wam(Wam) :-
+	wam_plan_text(Wam, WamText),
+	parse_wam_text_py(WamText, Instrs),
 	is_deterministic_pred_py(Instrs).
 
 fix_lowered_route_set(Current, Plans, Options, Final) :-
@@ -2088,8 +2107,9 @@ fix_lowered_route_set(Current, Plans, Options, Final) :-
 	).
 
 lowered_route_supported(Plans, Options, Current, Pred/Arity) :-
-	member(pred_plan(Pred, Arity, WamCode, wam), Plans),
-	parse_wam_text_py(WamCode, Instrs),
+	member(pred_plan(Pred, Arity, Wam, wam), Plans),
+	wam_plan_text(Wam, WamText),
+	parse_wam_text_py(WamText, Instrs),
 	findall(CalleePred/CalleeArity, direct_wam_call(Instrs, CalleePred/CalleeArity), Calls0),
 	sort(Calls0, Calls),
 	forall(member(CalleePred/CalleeArity, Calls),
@@ -2124,17 +2144,20 @@ pred_string_indicator(PredStr, ArityStr, Pred/Arity) :-
 	    atom_number(ArityAtom0, Arity)
 	).
 
-compile_planned_predicate(Options, LoweredSet, pred_plan(Pred, Arity, WamCode, Kind), PredCode) :-
+compile_planned_predicate(Options, LoweredSet, pred_plan(Pred, Arity, Wam, Kind), PredCode) :-
 	(   Kind = ffi
 	->  compile_ffi_stub_predicate(Pred, Arity, Options, PredCode)
 	;   Kind = missing
 	->  atom_string(Pred, PredStr),
 	    format(string(PredCode), '# Could not compile ~w/~w to WAM\n', [PredStr, Arity])
 	;   member(Pred/Arity, LoweredSet)
-	->  compile_lowered_wam_predicate_to_python(Pred/Arity, WamCode, Options, PredCode)
+	->  wam_plan_text(Wam, WamText),
+	    compile_lowered_wam_predicate_to_python(Pred/Arity, WamText, Options, PredCode)
 	;   option(emit_mode(lowered), Options)
-	->  compile_wam_predicate_to_python(Pred/Arity, WamCode, [registrar_prefix(register_)|Options], PredCode)
-	;   compile_wam_predicate_to_python(Pred/Arity, WamCode, Options, PredCode)
+	->  wam_plan_items(Wam, Items),
+	    compile_wam_predicate_items_to_python(Pred/Arity, Items, [registrar_prefix(register_)|Options], PredCode)
+	;   wam_plan_items(Wam, Items),
+	    compile_wam_predicate_items_to_python(Pred/Arity, Items, Options, PredCode)
 	).
 
 %% pred_func_name(+Options, +PredSpec, -FuncName)

--- a/src/unifyweaver/targets/wam_text_parser.pl
+++ b/src/unifyweaver/targets/wam_text_parser.pl
@@ -197,17 +197,28 @@ wam_recognise_instruction(["get_structure", F, Ai],    get_structure(F, Ai)).
 wam_recognise_instruction(["get_list", Ai],            get_list(Ai)).
 wam_recognise_instruction(["get_nil", Ai],             get_nil(Ai)).
 wam_recognise_instruction(["get_integer", N, Ai],      get_integer(N, Ai)).
+wam_recognise_instruction(["get_float", F, Ai],        get_float(F, Ai)).
 wam_recognise_instruction(["unify_variable", Xn],      unify_variable(Xn)).
 wam_recognise_instruction(["unify_value", Xn],         unify_value(Xn)).
 wam_recognise_instruction(["unify_constant", C],       unify_constant(C)).
+wam_recognise_instruction(["unify_nil"],               unify_nil).
+wam_recognise_instruction(["unify_void", N],           unify_void(N)).
 wam_recognise_instruction(["put_variable", Xn, Ai],    put_variable(Xn, Ai)).
 wam_recognise_instruction(["put_value", Xn, Ai],       put_value(Xn, Ai)).
+wam_recognise_instruction(["put_unsafe_value", Yn, Ai], put_unsafe_value(Yn, Ai)).
 wam_recognise_instruction(["put_constant", C, Ai],     put_constant(C, Ai)).
+wam_recognise_instruction(["put_nil", Ai],             put_nil(Ai)).
+wam_recognise_instruction(["put_integer", N, Ai],      put_integer(N, Ai)).
+wam_recognise_instruction(["put_float", F, Ai],        put_float(F, Ai)).
 wam_recognise_instruction(["put_structure", F, Ai],    put_structure(F, Ai)).
 wam_recognise_instruction(["put_list", Ai],            put_list(Ai)).
 wam_recognise_instruction(["set_variable", Xn],        set_variable(Xn)).
 wam_recognise_instruction(["set_value", Xn],           set_value(Xn)).
+wam_recognise_instruction(["set_local_value", Xn],     set_local_value(Xn)).
 wam_recognise_instruction(["set_constant", C],         set_constant(C)).
+wam_recognise_instruction(["set_nil"],                 set_nil).
+wam_recognise_instruction(["set_integer", N],          set_integer(N)).
+wam_recognise_instruction(["set_void", N],             set_void(N)).
 wam_recognise_instruction(["call", P, N],              call(P, N)).
 wam_recognise_instruction(["execute", P],              execute(P)).
 wam_recognise_instruction(["proceed"],                 proceed).

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -310,19 +310,18 @@ test(compile_runtime_reads_static_runtime_source) :-
 
 :- begin_tests(wam_python_items_mode_audit).
 
-test(python_target_still_uses_text_wam_generation) :-
+test(python_planning_normalizes_wam_text_to_items) :-
     once(source_file(wam_python_target:compile_wam_predicate_to_python(_, _, _, _), Path)),
     read_file_to_string(Path, Content, []),
-    sub_string(Content, _, _, _, "compile_predicate_to_wam(Pred/Arity, [], WamCode)"),
-    sub_string(Content, _, _, _, "compile_predicate_to_wam(Module:Pred/Arity, [], WamText)"),
-    sub_string(Content, _, _, _, "parse_wam_text_py(WamCode, Instrs)"),
-    sub_string(Content, _, _, _, "wam_code_to_python_instructions(WamCode"),
+    sub_string(Content, _, _, _, "python_wam_text_plan(WamText, wam_items(WamText, Items))"),
+    sub_string(Content, _, _, _, "compile_wam_predicate_items_to_python(Pred/Arity, Items, Options, PredCode)"),
+    sub_string(Content, _, _, _, "wam_plan_text(Wam, WamText)"),
     !.
 
-test(python_items_mode_planning_still_uses_text_wam) :-
+test(python_items_mode_still_waits_on_native_item_generator) :-
     once(source_file(wam_python_target:compile_wam_predicate_to_python(_, _, _, _), Path)),
     read_file_to_string(Path, Content, []),
-    sub_string(Content, _, _, _, "compile_wam_predicate_items_to_python"),
+    sub_string(Content, _, _, _, "wam_text_to_items(WamText, Items)"),
     \+ sub_string(Content, _, _, _, "compile_predicate_to_wam_items"),
     !.
 
@@ -366,6 +365,16 @@ test(items_predicate_compiler_honors_registrar_prefix) :-
         [registrar_prefix(register_)], Code),
     sub_string(Code, _, _, _, 'def register_pred_demo_1(raw_program):'),
     sub_string(Code, _, _, _, 'raw_program["demo/1"] = ('),
+    !.
+
+test(compile_all_interpreter_uses_items_plan) :-
+    WamText = 'demo/1:
+    put_constant foo, A1
+    proceed',
+    wam_python_target:compile_all_predicates([demo/1-WamText], [], Code),
+    sub_string(Code, _, _, _, 'def pred_demo_1(raw_program):'),
+    sub_string(Code, _, _, _, 'raw_program["demo/1"] = ('),
+    sub_string(Code, _, _, _, '("put_constant", Atom("foo"), A1)'),
     !.
 :- end_tests(wam_python_items_mode_audit).
 

--- a/tests/test_wam_text_parser.pl
+++ b/tests/test_wam_text_parser.pl
@@ -32,19 +32,19 @@ test(tokenize_quoted_atom_with_spaces) :-
     % PR #2076 regression: format strings must survive tokenization
     % as a single token.
     wam_tokenize_line("    put_constant 'plain text~n', A1", T),
-    assertion(T == ["put_constant", "plain text~n", "A1"]).
+    assertion(T == ["put_constant", "'plain text~n'", "A1"]).
 
 test(tokenize_quoted_atom_with_internal_commas) :-
     wam_tokenize_line("    put_constant 'a, b, c', A1", T),
-    assertion(T == ["put_constant", "a, b, c", "A1"]).
+    assertion(T == ["put_constant", "'a, b, c'", "A1"]).
 
 test(tokenize_quoted_atom_with_escaped_quote) :-
     wam_tokenize_line("    put_constant 'it\\'s', A1", T),
-    assertion(T == ["put_constant", "it's", "A1"]).
+    assertion(T == ["put_constant", "'it's'", "A1"]).
 
 test(tokenize_quoted_atom_with_escaped_backslash) :-
     wam_tokenize_line("    put_constant 'a\\\\b', A1", T),
-    assertion(T == ["put_constant", "a\\b", "A1"]).
+    assertion(T == ["put_constant", "'a\\b'", "A1"]).
 
 test(tokenize_conjunction_functor_preserved) :-
     % PR #2084 regression: ",/2" must be one token; bare comma
@@ -114,6 +114,24 @@ test(recognise_builtin_call) :-
     wam_recognise_instruction(["builtin_call", "is/2", "2"], I),
     assertion(I == builtin_call("is/2", "2")).
 
+test(recognise_numeric_and_nil_instructions) :-
+    Pairs = [
+        ["get_float", "3.5", "A1"]-get_float("3.5", "A1"),
+        ["unify_nil"]-unify_nil,
+        ["unify_void", "2"]-unify_void("2"),
+        ["put_unsafe_value", "Y1", "A2"]-put_unsafe_value("Y1", "A2"),
+        ["put_nil", "A1"]-put_nil("A1"),
+        ["put_integer", "7", "A1"]-put_integer("7", "A1"),
+        ["put_float", "3.5", "A1"]-put_float("3.5", "A1"),
+        ["set_local_value", "Y1"]-set_local_value("Y1"),
+        ["set_nil"]-set_nil,
+        ["set_integer", "7"]-set_integer("7"),
+        ["set_void", "2"]-set_void("2")
+    ],
+    forall(member(Tokens-Expected, Pairs),
+           ( wam_recognise_instruction(Tokens, Item),
+             assertion(Item == Expected) )).
+
 test(recognise_try_me_else) :-
     wam_recognise_instruction(["try_me_else", "L_clause_2"], I),
     assertion(I == try_me_else("L_clause_2")).
@@ -166,7 +184,7 @@ test(text_to_items_with_quoted_atom) :-
     Text = "tp/0:\n    put_constant 'hello world', A1\n    execute write/1\n",
     wam_text_to_items(Text, Items),
     assertion(Items == [label("tp/0"),
-                        put_constant("hello world", "A1"),
+                        put_constant("'hello world'", "A1"),
                         execute("write/1")]).
 
 test(text_to_items_with_conjunction_functor) :-


### PR DESCRIPTION
## Summary

- normalizes Python WAM predicate plans into `wam_items(WamText, Items)` using the shared `wam_text_to_items/2` parser
- routes interpreter-mode planned predicates through `compile_wam_predicate_items_to_python/4`
- keeps lowered mode on the existing text-backed analysis and lowered emitter path
- extends the shared WAM text parser to recognize standard numeric, nil, void, and unsafe-value instructions needed by items-backed planning
- updates the Python parity audit to describe the remaining bridge until `compile_predicate_to_wam_items/3` exists

## Verification

- `swipl --stack_limit=2g -q -g "run_tests" -t halt tests/test_wam_text_parser.pl tests/test_wam_python_target.pl`
- `git diff --check`
