### PR TITLE
LLVM WAM: atomic_list_concat/2 atoms-only (M52)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3436,6 +3436,7 @@ entry:
     i32 70, label %builtin_pairs_keys
     i32 71, label %builtin_pairs_values
     i32 72, label %builtin_pairs_keys_values
+    i32 73, label %builtin_atomic_list_concat
   ]
 
 builtin_is:
@@ -7610,6 +7611,107 @@ pkv.r_bind:
   %pkv.r_ok = call i1 @wam_unify_value(%WamState* %vm, %Value %pkv.r_raw1, %Value %pkv.r_b_acc)
   ret i1 %pkv.r_ok
 
+builtin_atomic_list_concat:
+  ; M52: atomic_list_concat(+List, ?Atom) -- atoms-only mode.
+  ; Walks A1 summing each Atom head''s string length, allocates a
+  ; single buffer, walks again memcpy''ing each string, interns the
+  ; result. Non-atom heads (Integer, Float, etc.) fail; that case
+  ; needs snprintf per element and is deferred.
+  %alc.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  call void @wam_arena_ensure()
+  br label %alc.c_loop
+alc.fail:
+  ret i1 false
+alc.c_loop:
+  %alc.c_cur = phi %Value [ %alc.a1, %builtin_atomic_list_concat ], [ %alc.c_next, %alc.c_advance ]
+  %alc.c_total = phi i64 [ 0, %builtin_atomic_list_concat ], [ %alc.c_total1, %alc.c_advance ]
+  %alc.c_d = call %Value @wam_deref_value(%WamState* %vm, %Value %alc.c_cur)
+  %alc.c_tag = extractvalue %Value %alc.c_d, 0
+  %alc.c_is_cmp = icmp eq i32 %alc.c_tag, 3
+  br i1 %alc.c_is_cmp, label %alc.c_step, label %alc.c_done
+alc.c_step:
+  %alc.c_cp = extractvalue %Value %alc.c_d, 1
+  %alc.c_cp_ptr = inttoptr i64 %alc.c_cp to %Compound*
+  %alc.c_args_slot = getelementptr %Compound, %Compound* %alc.c_cp_ptr, i32 0, i32 2
+  %alc.c_args = load %Value*, %Value** %alc.c_args_slot
+  %alc.c_h_ptr = getelementptr %Value, %Value* %alc.c_args, i32 0
+  %alc.c_head = load %Value, %Value* %alc.c_h_ptr
+  %alc.c_h_d = call %Value @wam_deref_value(%WamState* %vm, %Value %alc.c_head)
+  %alc.c_h_tag = extractvalue %Value %alc.c_h_d, 0
+  %alc.c_h_is_atom = icmp eq i32 %alc.c_h_tag, 0
+  br i1 %alc.c_h_is_atom, label %alc.c_measure, label %alc.fail
+alc.c_measure:
+  %alc.c_aid = extractvalue %Value %alc.c_h_d, 1
+  %alc.c_str = call i8* @wam_atom_to_string(i64 %alc.c_aid)
+  %alc.c_str_null = icmp eq i8* %alc.c_str, null
+  br i1 %alc.c_str_null, label %alc.fail, label %alc.c_m_loop
+alc.c_m_loop:
+  %alc.c_mp = phi i8* [ %alc.c_str, %alc.c_measure ], [ %alc.c_mpn, %alc.c_m_step ]
+  %alc.c_mn = phi i64 [ 0, %alc.c_measure ], [ %alc.c_mn1, %alc.c_m_step ]
+  %alc.c_mc = load i8, i8* %alc.c_mp
+  %alc.c_mz = icmp eq i8 %alc.c_mc, 0
+  br i1 %alc.c_mz, label %alc.c_advance, label %alc.c_m_step
+alc.c_m_step:
+  %alc.c_mpn = getelementptr i8, i8* %alc.c_mp, i32 1
+  %alc.c_mn1 = add i64 %alc.c_mn, 1
+  br label %alc.c_m_loop
+alc.c_advance:
+  %alc.c_total1 = add i64 %alc.c_total, %alc.c_mn
+  %alc.c_t_ptr = getelementptr %Value, %Value* %alc.c_args, i32 1
+  %alc.c_next = load %Value, %Value* %alc.c_t_ptr
+  br label %alc.c_loop
+alc.c_done:
+  %alc.bufsz = add i64 %alc.c_total, 1
+  %alc.buf = call i8* @wam_arena_alloc(i64 %alc.bufsz)
+  br label %alc.f_loop
+alc.f_loop:
+  %alc.f_cur = phi %Value [ %alc.a1, %alc.c_done ], [ %alc.f_next, %alc.f_after ]
+  %alc.f_off = phi i64 [ 0, %alc.c_done ], [ %alc.f_off1, %alc.f_after ]
+  %alc.f_d = call %Value @wam_deref_value(%WamState* %vm, %Value %alc.f_cur)
+  %alc.f_tag = extractvalue %Value %alc.f_d, 0
+  %alc.f_is_cmp = icmp eq i32 %alc.f_tag, 3
+  br i1 %alc.f_is_cmp, label %alc.f_step, label %alc.f_done
+alc.f_step:
+  %alc.f_cp = extractvalue %Value %alc.f_d, 1
+  %alc.f_cp_ptr = inttoptr i64 %alc.f_cp to %Compound*
+  %alc.f_args_slot = getelementptr %Compound, %Compound* %alc.f_cp_ptr, i32 0, i32 2
+  %alc.f_args = load %Value*, %Value** %alc.f_args_slot
+  %alc.f_h_ptr = getelementptr %Value, %Value* %alc.f_args, i32 0
+  %alc.f_head = load %Value, %Value* %alc.f_h_ptr
+  %alc.f_h_d = call %Value @wam_deref_value(%WamState* %vm, %Value %alc.f_head)
+  %alc.f_aid = extractvalue %Value %alc.f_h_d, 1
+  %alc.f_str = call i8* @wam_atom_to_string(i64 %alc.f_aid)
+  ; Measure this atom''s length again (second pass).
+  br label %alc.f_m_loop
+alc.f_m_loop:
+  %alc.f_mp = phi i8* [ %alc.f_str, %alc.f_step ], [ %alc.f_mpn, %alc.f_m_step ]
+  %alc.f_mn = phi i64 [ 0, %alc.f_step ], [ %alc.f_mn1, %alc.f_m_step ]
+  %alc.f_mc = load i8, i8* %alc.f_mp
+  %alc.f_mz = icmp eq i8 %alc.f_mc, 0
+  br i1 %alc.f_mz, label %alc.f_copy, label %alc.f_m_step
+alc.f_m_step:
+  %alc.f_mpn = getelementptr i8, i8* %alc.f_mp, i32 1
+  %alc.f_mn1 = add i64 %alc.f_mn, 1
+  br label %alc.f_m_loop
+alc.f_copy:
+  %alc.f_dst = getelementptr i8, i8* %alc.buf, i64 %alc.f_off
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %alc.f_dst, i8* %alc.f_str, i64 %alc.f_mn, i1 false)
+  %alc.f_off1 = add i64 %alc.f_off, %alc.f_mn
+  %alc.f_t_ptr = getelementptr %Value, %Value* %alc.f_args, i32 1
+  %alc.f_next = load %Value, %Value* %alc.f_t_ptr
+  br label %alc.f_after
+alc.f_after:
+  br label %alc.f_loop
+alc.f_done:
+  %alc.term_dst = getelementptr i8, i8* %alc.buf, i64 %alc.c_total
+  store i8 0, i8* %alc.term_dst
+  %alc.new_id = call i64 @wam_intern_atom(i8* %alc.buf, i64 %alc.c_total)
+  %alc.new_v0 = insertvalue %Value undef, i32 0, 0
+  %alc.new_v = insertvalue %Value %alc.new_v0, i64 %alc.new_id, 1
+  %alc.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %alc.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %alc.raw2, %Value %alc.new_v)
+  ret i1 %alc.ok
+
 unknown:
   ret i1 false
 }'.
@@ -9055,6 +9157,7 @@ builtin_op_to_id('string_code/3', 69).   % string_code(+Idx, +Str, -Code) 1-base
 builtin_op_to_id('pairs_keys/2', 70).    % extract keys from K-V pair list
 builtin_op_to_id('pairs_values/2', 71).  % extract values
 builtin_op_to_id('pairs_keys_values/3', 72). % forward only: split pairs -> keys + values
+builtin_op_to_id('atomic_list_concat/2', 73). % concat list of atoms (atoms only mode)
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -1635,6 +1635,56 @@ test_pkv_forward_then_reverse(_, R) :-
     sum_list(Ks2, S),
     R is S.   % 60
 
+% M52: atomic_list_concat/2 (atoms-only mode).
+
+:- dynamic test_alc_simple_length/2.
+test_alc_simple_length(_, R) :-
+    atomic_list_concat([hello, world], A),
+    atom_length(A, N),
+    R is N.   % 10
+
+:- dynamic test_alc_first_code/2.
+test_alc_first_code(_, R) :-
+    atomic_list_concat([hello, world], A),
+    atom_codes(A, [C|_]),
+    R is C.   % 'h' = 104
+
+:- dynamic test_alc_seam_code/2.
+test_alc_seam_code(_, R) :-
+    atomic_list_concat([ab, cd], A),
+    atom_codes(A, [_, _, C, _]),
+    R is C.   % 'c' = 99
+
+:- dynamic test_alc_empty_list/2.
+test_alc_empty_list(_, R) :-
+    atomic_list_concat([], A),
+    atom_length(A, N),
+    R is N + 31.   % 31 -- empty atom
+
+:- dynamic test_alc_singleton/2.
+test_alc_singleton(_, R) :-
+    atomic_list_concat([only], A),
+    atom_length(A, N),
+    R is N.   % 4
+
+:- dynamic test_alc_many/2.
+test_alc_many(_, R) :-
+    atomic_list_concat([a, b, c, d, e], A),
+    atom_length(A, N),
+    R is N.   % 5
+
+:- dynamic test_alc_with_empties/2.
+test_alc_with_empties(_, R) :-
+    atomic_list_concat(['', hi, ''], A),
+    atom_length(A, N),
+    R is N.   % 2
+
+:- dynamic test_alc_dedup/2.
+test_alc_dedup(_, R) :-
+    atomic_list_concat([hi, there], A),
+    atomic_list_concat([hi, there], B),
+    ( A == B -> R is 1 ; R is 0 ).   % 1 -- intern dedupes
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -2800,6 +2850,23 @@ test_all :-
                    test_pkv_rev_mismatch_values_longer, 0, 0),
        run_test_r0('pkv forward then reverse roundtrip sum -> 60',
                    test_pkv_forward_then_reverse, 0, 60),
+       format('--- M52 atomic_list_concat/2 (atoms-only) ---~n'),
+       run_test_r0('atomic_list_concat([hello, world]) length -> 10',
+                   test_alc_simple_length, 0, 10),
+       run_test_r0('atomic_list_concat([hello, world]) first -> 104',
+                   test_alc_first_code, 0, 104),
+       run_test_r0('atomic_list_concat([ab, cd]) seam -> 99 (c)',
+                   test_alc_seam_code, 0, 99),
+       run_test_r0('atomic_list_concat([]) + 31 -> 31',
+                   test_alc_empty_list, 0, 31),
+       run_test_r0('atomic_list_concat([only]) length -> 4',
+                   test_alc_singleton, 0, 4),
+       run_test_r0('atomic_list_concat([a,b,c,d,e]) length -> 5',
+                   test_alc_many, 0, 5),
+       run_test_r0('atomic_list_concat([\'\', hi, \'\']) length -> 2',
+                   test_alc_with_empties, 0, 2),
+       run_test_r0('atomic_list_concat dedup -> 1',
+                   test_alc_dedup, 0, 1),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Adds `atomic_list_concat(+List, ?Atom)` in the atoms-only mode.

### Two-pass shape
1. **Count**: walk A1, for each Atom head measure its interned-string
   length and accumulate total; non-atom head fails the call
   (`Integer` / `Float` / `Compound` aliases need `snprintf`-based
   widening and are deferred).
2. **Allocate** buffer of `(total + 1)` bytes; walk A1 again, `memcpy`
   each atom's C string into the buffer at the current write offset.
   Null-terminate, intern, unify A2 with the resulting Atom.

Empty list → the empty atom (length 0). Empty atom heads (`['']`) are
allowed and contribute nothing to the result. The intern call dedupes
identical concatenations (`test_alc_dedup` verifies).

### phi predecessor note
The count loop back-edge to `alc.c_loop` comes from `alc.c_advance`
(where `%alc.c_next` and `%alc.c_total1` are computed), not
`alc.c_step`. llc verifier caught the mismatch the first time around.

### Dispatch
- `builtin_op_to_id('atomic_list_concat/2', 73)` → `%builtin_atomic_list_concat`.
- `atomic_list_concat/2` already in `is_builtin_pred` registry.
- Prefix `alc.` with sub-prefixes `c.` (count) and `f.` (fill); stays
  clear of `al.` (atom_length) and existing neighbours.
- Manual `llc -filetype=obj` round-trip clean.

## Test plan
- [x] 8 new tests: length, first code, seam code (concat boundary),
      empty list, singleton, many elements, includes empty atoms, dedup
- [x] All 327 builtin tests pass (was 319, +8)
- [x] Manual llc round-trip clean


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_