### PR TITLE
fix(wam-clojure): materialize length outputs

### DIFF
--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1460,15 +1460,23 @@
                            (or (reg-get-raw state "A1") ::unbound))
         out (deref-value (:bindings state)
                          (or (reg-get-raw state "A2") ::unbound))
-        text (atom-text state value)]
+        text (atom-text state value)
+        out-count (cond
+                    (integer? out) out
+                    (string? out) (parse-number-text out)
+                    (atom-term? out) (parse-number-text (atom-text state out))
+                    :else nil)]
     (cond
       (some? text)
-      (let [[ok next-state] (unify-values state out (count text))]
+      (let [len (count text)
+            [ok next-state] (if (logic-var? out)
+                              (unify-values state out (normalize-literal-term (:intern-context state) (str len)))
+                              [(= out-count len) state])]
         (if ok
           (advance next-state)
           (backtrack state)))
 
-      (and (logic-var? value) (= out 0))
+      (and (logic-var? value) (= out-count 0))
       (let [[ok next-state] (unify-text-atom-value state value "")]
         (if ok
           (advance next-state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -237,8 +237,12 @@
 :- dynamic user:wam_string_concat_unbound_left/1.
 :- dynamic user:wam_string_concat_unbound_right/1.
 :- dynamic user:wam_atom_length_guard/2.
+:- dynamic user:wam_atom_length_forward/0.
+:- dynamic user:wam_atom_length_forward_mismatch/0.
 :- dynamic user:wam_atom_length_unbound/1.
 :- dynamic user:wam_string_length_guard/2.
+:- dynamic user:wam_string_length_forward/0.
+:- dynamic user:wam_string_length_forward_mismatch/0.
 :- dynamic user:wam_string_length_unbound/1.
 :- dynamic user:wam_sub_atom_extract/0.
 :- dynamic user:wam_sub_atom_prefix/0.
@@ -509,8 +513,12 @@ user:wam_string_concat_new_string :- string_concat(fo, o, X), X = foo.
 user:wam_string_concat_unbound_left(C) :- user:wam_unbound_arg(A), string_concat(A, o, C), A = fo.
 user:wam_string_concat_unbound_right(C) :- user:wam_unbound_arg(B), string_concat(fo, B, C), B = o.
 user:wam_atom_length_guard(A, N) :- atom_length(A, N).
+user:wam_atom_length_forward :- atom_length(foo, N), N =:= 3.
+user:wam_atom_length_forward_mismatch :- atom_length(foo, N), N =:= 2.
 user:wam_atom_length_unbound(N) :- atom_length(_A, N).
 user:wam_string_length_guard(A, N) :- string_length(A, N).
+user:wam_string_length_forward :- string_length(foo, N), N =:= 3.
+user:wam_string_length_forward_mismatch :- string_length(foo, N), N =:= 2.
 user:wam_string_length_unbound(N) :- string_length(_A, N).
 user:wam_sub_atom_extract :- sub_atom(hello, 1, 3, A, S), A =:= 1, S = ell.
 user:wam_sub_atom_prefix :- sub_atom(hello, 0, 3, _, hel).
@@ -786,8 +794,12 @@ run_smoke :-
           user:wam_string_concat_unbound_left/1,
           user:wam_string_concat_unbound_right/1,
           user:wam_atom_length_guard/2,
+          user:wam_atom_length_forward/0,
+          user:wam_atom_length_forward_mismatch/0,
           user:wam_atom_length_unbound/1,
           user:wam_string_length_guard/2,
+          user:wam_string_length_forward/0,
+          user:wam_string_length_forward_mismatch/0,
           user:wam_string_length_unbound/1,
           user:wam_sub_atom_extract/0,
           user:wam_sub_atom_prefix/0,
@@ -1245,8 +1257,12 @@ smoke_cases([
     case('wam_string_concat_unbound_right/1', foo, "true"),
     case('wam_atom_length_guard/2', args(foo, 3), "true"),
     case('wam_atom_length_guard/2', args(foo, 2), "false"),
+    case('wam_atom_length_forward/0', no_args, "true"),
+    case('wam_atom_length_forward_mismatch/0', no_args, "false"),
     case('wam_atom_length_unbound/1', 0, "true"),
     case('wam_string_length_guard/2', args(foo, 3), "true"),
+    case('wam_string_length_forward/0', no_args, "true"),
+    case('wam_string_length_forward_mismatch/0', no_args, "false"),
     case('wam_string_length_unbound/1', 0, "true"),
     case('wam_sub_atom_extract/0', no_args, "true"),
     case('wam_sub_atom_prefix/0', no_args, "true"),


### PR DESCRIPTION
## Summary

- Update Clojure WAM `atom_length/2` and `string_length/2` so output variables are bound to interned numeric literal terms when running through the lowered path.
- Preserve guard behavior for raw numeric, string, and interned numeric output values.
- Add runtime smoke coverage for forward and mismatch cases for both `atom_length/2` and `string_length/2`.

## Why

Lowered WAM predicates compare numeric values through the same interned literal representation used by generated code. The previous length implementation unified output variables with raw JVM integers, which worked for direct guard calls but could fail when the result was later compared to a lowered numeric literal.

This change aligns length output materialization with the rest of the lowered Clojure WAM numeric representation while keeping direct API guard checks compatible.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
