### PR TITLE
feat(wam): expose items compile bridge

### DIFF
--- a/docs/design/WAM_ITEMS_API_SPECIFICATION.md
+++ b/docs/design/WAM_ITEMS_API_SPECIFICATION.md
@@ -5,6 +5,20 @@ The concrete shape of the structured-items API we're adding to
 `WAM_ITEMS_API_PHILOSOPHY.md`. For per-target migration plans, see
 the per-target section in §6 below.
 
+## 0. Implementation Status
+
+The first implementation step is intentionally conservative:
+
+- `compile_predicate_to_wam_text/3` is now the explicit legacy text API.
+- `compile_predicate_to_wam_items/3` is available as a bridge: it compiles text
+  through the existing generator and normalizes it with `wam_text_to_items/2`.
+- `compile_predicate_to_wam/3` still returns text by default for compatibility
+  with the existing targets. The default-output flip described below remains a
+  later migration step after more callers consume items directly.
+
+The final API shape below is still the target design; current code deliberately
+lands the low-risk bridge first.
+
 ## 1. Public API
 
 Three predicates. The two `_items/3` and `_text/3` predicates are

--- a/docs/design/WAM_PYTHON_PARITY_AUDIT.md
+++ b/docs/design/WAM_PYTHON_PARITY_AUDIT.md
@@ -99,15 +99,19 @@ text-first compile pipeline.
 
 Current load-bearing items path:
 
-- `plan_python_predicate/3` still calls `compile_predicate_to_wam(..., WamText)`
-  when compiling Prolog predicates, but immediately normalizes that text through
-  `wam_text_to_items/2` and stores `wam_items(WamText, Items)` in `pred_plan/4`.
+- `plan_python_predicate/3` calls `compile_predicate_to_wam_items/3` for
+  internally compiled interpreter-mode predicates and stores `wam_items(items_only,
+  Items)` in `pred_plan/4`.
+- Supplied WAM text still normalizes through `wam_text_to_items/2` and stores
+  `wam_items(text(WamText), Items)` so external/debug text input remains
+  supported.
 - interpreter-mode predicate emission routes planned predicates through
   `compile_wam_predicate_items_to_python/4`, so generated Python no longer
-  reparses planned WAM text during interpreter registration.
-- lowered mode still unwraps the stored text and calls `parse_wam_text_py/2` in
-  `compile_lowered_wam_predicate_to_python/4`, `lowered_candidate_wam/1`, and
-  `lowered_route_supported/4` before emitting lowered Python functions.
+  reparses internally generated WAM text during interpreter registration.
+- lowered mode still requests explicit WAM text via `compile_predicate_to_wam_text/3`
+  and calls `parse_wam_text_py/2` in `compile_lowered_wam_predicate_to_python/4`,
+  `lowered_candidate_wam/1`, and `lowered_route_supported/4` before emitting
+  lowered Python functions.
 - `wam_python_iso_audit/3` still recompiles predicates to WAM text and parses
   lines for audit reporting.
 
@@ -122,22 +126,21 @@ Items-mode bridge now present:
   emitted as `Atom("42")` while integer `42` is emitted as `Int(42)`.
 - Current tests compare the adapter against `wam_text_to_items/2` output for a
   standard WAM-text fixture, cover typed atom/integer constant separation, and
-  assert that `compile_all_predicates/3` uses the items-backed plan for
-  interpreter-mode predicate registration.
+  assert that `compile_all_predicates/3` uses the common items API for internally
+  compiled interpreter-mode predicates.
 
 Remaining migration target:
 
-1. Replace the temporary `compile_predicate_to_wam/3` plus `wam_text_to_items/2`
-   normalization step with `compile_predicate_to_wam_items/3` once that common
-   generator API exists.
+1. Replace the current `compile_predicate_to_wam_items/3` bridge implementation
+   with direct item emission once `wam_target.pl` grows native item generation.
 2. Teach the lowered emitter to consume the same item list directly, or add one
    shared adapter from items to the lowered-emitter instruction representation.
 3. Keep the text parser only for external WAM text/debug migration paths, not
    for WAM text generated inside the same process.
 
-Until the native generator API lands, `tests/test_wam_python_target.pl` includes
-items-mode audit tests that record the remaining text-to-items normalization
-bridge and protect the item-driven Python emitter.
+Until native item emission lands, `tests/test_wam_python_target.pl` includes
+items-mode audit tests that record the remaining bridge boundary and protect the
+item-driven Python emitter.
 
 ## Remaining Follow-Up
 
@@ -162,7 +165,7 @@ Completed follow-up:
 ## Verification Commands
 
 Use these checks after touching Python WAM runtime parity. On current `main`,
-`tests/test_wam_python_target.pl` passes 173/173 without choicepoint warnings:
+`tests/test_wam_python_target.pl` passes 174/174 without choicepoint warnings:
 
 ```sh
 swipl -q -g run_tests -t halt tests/test_wam_python_target.pl

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -46,7 +46,11 @@
 :- use_module('../core/template_system').
 :- use_module('../core/prolog_term_parser').
 :- use_module('../bindings/python_wam_bindings').
-:- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../targets/wam_target', [
+	compile_predicate_to_wam/3,
+	compile_predicate_to_wam_text/3,
+	compile_predicate_to_wam_items/3
+]).
 :- use_module('../core/iso_errors',
               [ iso_errors_resolve_options/2,
                 iso_errors_load_config/2,
@@ -1751,9 +1755,16 @@ iso_errors_rewrite_plans(Config, Plans0, Plans) :-
 
 iso_errors_rewrite_plan(Config, pred_plan(Pred, Arity, Wam0, wam), pred_plan(Pred, Arity, Wam, wam)) :-
 	!,
-	wam_plan_text(Wam0, WamText0),
-	iso_errors_rewrite_text(Config, Pred/Arity, WamText0, WamText),
-	python_wam_text_plan(WamText, Wam).
+	(   Wam0 = wam_items(text(WamText0), _Items0)
+	->  iso_errors_rewrite_text(Config, Pred/Arity, WamText0, WamText),
+	    python_wam_text_plan(WamText, Wam)
+	;   Wam0 = wam_items(items_only, Items0)
+	->  iso_errors_rewrite(Config, Pred/Arity, Items0, Items),
+	    python_wam_items_plan(Items, Wam)
+	;   wam_plan_text(Wam0, WamText0)
+	->  iso_errors_rewrite_text(Config, Pred/Arity, WamText0, WamText),
+	    python_wam_text_plan(WamText, Wam)
+	).
 iso_errors_rewrite_plan(_, Plan, Plan).
 
 %% iso_errors_rewrite_text(+Config, +PI, +WamText, -RewrittenText)
@@ -2047,9 +2058,8 @@ plan_python_predicate(Options, Module:Pred/Arity,
 	(   is_ffi_predicate(Pred, Arity, Options)
 	->  Kind = ffi,
 	    Wam = ''
-	;   compile_predicate_to_wam(Module:Pred/Arity, [], WamText)
-	->  python_wam_text_plan(WamText, Wam),
-	    Kind = wam
+	;   python_plan_compile_predicate(Options, Module:Pred/Arity, Wam)
+	->  Kind = wam
 	;   Wam = '',
 	    Kind = missing
 	).
@@ -2064,20 +2074,30 @@ plan_python_predicate(Options, Pred/Arity, pred_plan(Pred, Arity, Wam, Kind)) :-
 	(   is_ffi_predicate(Pred, Arity, Options)
 	->  Kind = ffi,
 	    Wam = ''
-	;   compile_predicate_to_wam(Pred/Arity, [], WamText)
-	->  python_wam_text_plan(WamText, Wam),
-	    Kind = wam
+	;   python_plan_compile_predicate(Options, Pred/Arity, Wam)
+	->  Kind = wam
 	;   Wam = '',
 	    Kind = missing
 	).
 
-python_wam_text_plan(WamText, wam_items(WamText, Items)) :-
+python_plan_compile_predicate(Options, PredIndicator, Wam) :-
+	(   option(emit_mode(lowered), Options)
+	->  compile_predicate_to_wam_text(PredIndicator, [], WamText),
+	    python_wam_text_plan(WamText, Wam)
+	;   compile_predicate_to_wam_items(PredIndicator, [], Items),
+	    python_wam_items_plan(Items, Wam)
+	).
+
+python_wam_text_plan(WamText, wam_items(text(WamText), Items)) :-
 	wam_text_to_items(WamText, Items).
 
-wam_plan_text(wam_items(WamText, _Items), WamText) :- !.
+python_wam_items_plan(Items, wam_items(items_only, Items)).
+
+wam_plan_text(wam_items(text(WamText), _Items), WamText) :- !.
+wam_plan_text(wam_items(items_only, _Items), _) :- !, fail.
 wam_plan_text(WamText, WamText).
 
-wam_plan_items(wam_items(_WamText, Items), Items) :- !.
+wam_plan_items(wam_items(_Source, Items), Items) :- !.
 wam_plan_items(WamText, Items) :-
 	wam_text_to_items(WamText, Items).
 

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -9,6 +9,8 @@
 :- module(wam_target, [
     target_info/1,
     compile_predicate_to_wam/3,          % +PredIndicator, +Options, -WAMCode
+    compile_predicate_to_wam_text/3,     % +PredIndicator, +Options, -WAMCode
+    compile_predicate_to_wam_items/3,    % +PredIndicator, +Options, -Items
     compile_predicate/3,                 % +PredIndicator, +Options, -WAMCode (dispatch alias)
     compile_facts_to_wam/3,              % +Pred, +Arity, -WAMCode
     compile_wam_module/3,                % +Predicates, +Options, -WAMCode
@@ -25,6 +27,7 @@
 :- use_module('../core/clause_body_analysis').
 :- use_module('../core/template_system').
 :- use_module('../core/binding_state_analysis').
+:- use_module('../targets/wam_text_parser', [wam_text_to_items/2]).
 
 %% target_info(-Info)
 target_info(info{
@@ -47,7 +50,15 @@ compile_predicate(PredArity, Options, Code) :-
     compile_predicate_to_wam(PredArity, Options, Code).
 
 %% compile_predicate_to_wam(+PredIndicator, +Options, -Code)
+%  Compatibility wrapper: returns canonical WAM text, matching the historical
+%  API. New callers that want an explicit format should use
+%  compile_predicate_to_wam_text/3 or compile_predicate_to_wam_items/3.
 compile_predicate_to_wam(PredIndicator, Options, Code) :-
+    compile_predicate_to_wam_text(PredIndicator, Options, Code).
+
+%% compile_predicate_to_wam_text(+PredIndicator, +Options, -Code)
+%  Compile a predicate to canonical WAM text.
+compile_predicate_to_wam_text(PredIndicator, Options, Code) :-
     % Handle module qualification
     (   PredIndicator = Module:Pred/Arity -> true
     ;   PredIndicator = Pred/Arity -> option(module(Module), Options, user)
@@ -63,12 +74,21 @@ compile_predicate_to_wam(PredIndicator, Options, Code) :-
     ;   compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code)
     ).
 
+%% compile_predicate_to_wam_items(+PredIndicator, +Options, -Items)
+%  Compile a predicate to structured WAM items. This bridge keeps the legacy
+%  text generator as the source of truth for now, then normalizes through the
+%  shared parser. A later generator pass can replace this with direct item
+%  emission without changing target-facing call sites.
+compile_predicate_to_wam_items(PredIndicator, Options, Items) :-
+    compile_predicate_to_wam_text(PredIndicator, Options, Code),
+    wam_text_to_items(Code, Items).
+
 %% compile_wam_module(+Predicates, +Options, -Code) is det.
 %
 %   Compiles a list of predicates to a single WAM module using templates.
 compile_wam_module(Predicates, Options, Code) :-
     maplist({Options}/[PI, PredCode]>> (
-        compile_predicate_to_wam(PI, Options, PredCode)
+        compile_predicate_to_wam_text(PI, Options, PredCode)
     ), Predicates, PredCodes),
     
     atomic_list_concat(PredCodes, '\n\n', AllPredsCode),

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -308,21 +308,25 @@ test(compile_runtime_reads_static_runtime_source) :-
 % Items-mode migration audit
 % ============================================================================
 
+:- dynamic user:py_items_api_demo/0.
+user:py_items_api_demo.
+
 :- begin_tests(wam_python_items_mode_audit).
 
-test(python_planning_normalizes_wam_text_to_items) :-
+test(python_planning_uses_common_items_api) :-
     once(source_file(wam_python_target:compile_wam_predicate_to_python(_, _, _, _), Path)),
     read_file_to_string(Path, Content, []),
-    sub_string(Content, _, _, _, "python_wam_text_plan(WamText, wam_items(WamText, Items))"),
+    sub_string(Content, _, _, _, "compile_predicate_to_wam_items(PredIndicator, [], Items)"),
+    sub_string(Content, _, _, _, "python_wam_items_plan(Items, Wam)"),
     sub_string(Content, _, _, _, "compile_wam_predicate_items_to_python(Pred/Arity, Items, Options, PredCode)"),
-    sub_string(Content, _, _, _, "wam_plan_text(Wam, WamText)"),
     !.
 
-test(python_items_mode_still_waits_on_native_item_generator) :-
+test(python_lowered_mode_keeps_text_plan) :-
     once(source_file(wam_python_target:compile_wam_predicate_to_python(_, _, _, _), Path)),
     read_file_to_string(Path, Content, []),
-    sub_string(Content, _, _, _, "wam_text_to_items(WamText, Items)"),
-    \+ sub_string(Content, _, _, _, "compile_predicate_to_wam_items"),
+    sub_string(Content, _, _, _, "option(emit_mode(lowered), Options)"),
+    sub_string(Content, _, _, _, "compile_predicate_to_wam_text(PredIndicator, [], WamText)"),
+    sub_string(Content, _, _, _, "wam_plan_text(Wam, WamText)"),
     !.
 
 
@@ -375,6 +379,13 @@ test(compile_all_interpreter_uses_items_plan) :-
     sub_string(Code, _, _, _, 'def pred_demo_1(raw_program):'),
     sub_string(Code, _, _, _, 'raw_program["demo/1"] = ('),
     sub_string(Code, _, _, _, '("put_constant", Atom("foo"), A1)'),
+    !.
+
+test(compile_all_generated_predicate_uses_items_api) :-
+    wam_python_target:compile_all_predicates([user:py_items_api_demo/0], [], Code),
+    sub_string(Code, _, _, _, 'def pred_py_items_api_demo_0(raw_program):'),
+    sub_string(Code, _, _, _, 'raw_program["py_items_api_demo/0"] = ('),
+    sub_string(Code, _, _, _, '("proceed",)'),
     !.
 :- end_tests(wam_python_items_mode_audit).
 

--- a/tests/test_wam_target.pl
+++ b/tests/test_wam_target.pl
@@ -311,6 +311,20 @@ test_wam_mixed_mode_a1_indexing :-
                   'Mixed-mode A1 indexing did not emit the expected pseudo-instruction')
     ).
 
+test_wam_items_api_bridge :-
+    Test = 'WAM: items API bridge',
+    (   wam_target:compile_predicate_to_wam(user:test_grandparent/2, [], LegacyCode),
+        wam_target:compile_predicate_to_wam_text(user:test_grandparent/2, [], TextCode),
+        wam_target:compile_predicate_to_wam_items(user:test_grandparent/2, [], Items),
+        LegacyCode == TextCode,
+        member(label("test_grandparent/2"), Items),
+        member(allocate, Items),
+        member(call("test_parent/2", "2"), Items),
+        member(execute("test_parent/2"), Items)
+    ->  pass(Test)
+    ;   fail_test(Test, 'Explicit text/items APIs do not match legacy WAM output')
+    ).
+
 %% Run all tests
 run_tests :-
     format('~n========================================~n'),
@@ -324,6 +338,7 @@ run_tests :-
     test_wam_nested_put_structure,
     test_wam_compound_head,
     test_wam_module,
+    test_wam_items_api_bridge,
     test_wam_multi_clause_findall_emits_allocate,
     test_wam_a2_indexing,
     test_wam_mixed_mode_a1_indexing,


### PR DESCRIPTION
## Summary

- adds explicit WAM target APIs for `compile_predicate_to_wam_text/3` and `compile_predicate_to_wam_items/3`
- keeps `compile_predicate_to_wam/3` text-compatible for existing callers while the items migration proceeds
- implements `compile_predicate_to_wam_items/3` as a conservative bridge through existing WAM text plus shared `wam_text_to_items/2`
- routes Python interpreter-mode planning for internally compiled predicates through the common items API
- keeps Python lowered mode on explicit WAM text because the lowered analyzer/emitter remains text-backed
- updates the WAM items design status, Python parity audit, and regression tests

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
- `swipl -q -g "run_tests(wam_text_parser),run_tests(wam_python_items_mode_audit),run_tests(wam_python_builtin_e2e)" -t halt tests/test_wam_text_parser.pl tests/test_wam_python_target.pl`
- `swipl --stack_limit=2g -q -g "run_tests" -t halt tests/test_wam_text_parser.pl tests/test_wam_python_target.pl`
- `git diff --check`
