### PR TITLE
LLVM WAM: atomic_list_concat/2 Integer heads (M55)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -7613,13 +7613,16 @@ pkv.r_bind:
   ret i1 %pkv.r_ok
 
 builtin_atomic_list_concat:
-  ; M52: atomic_list_concat(+List, ?Atom) -- atoms-only mode.
-  ; Walks A1 summing each Atom head''s string length, allocates a
-  ; single buffer, walks again memcpy''ing each string, interns the
-  ; result. Non-atom heads (Integer, Float, etc.) fail; that case
-  ; needs snprintf per element and is deferred.
+  ; M52/M55: atomic_list_concat(+List, ?Atom) -- atoms-and-integers.
+  ; Walks A1 summing each head''s rendered string length (atom-length
+  ; for Atoms, snprintf-return-value for Integers); allocates a
+  ; single buffer; walks again memcpying atoms and re-snprintfing
+  ; Integers at the running offset. Float / Compound / other heads
+  ; fail the call (Float widening deferred).
   %alc.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
   call void @wam_arena_ensure()
+  ; Scratch buffer for measuring integer lengths during pass 1.
+  %alc.iscratch = call i8* @wam_arena_alloc(i64 32)
   br label %alc.c_loop
 alc.fail:
   ret i1 false
@@ -7640,7 +7643,18 @@ alc.c_step:
   %alc.c_h_d = call %Value @wam_deref_value(%WamState* %vm, %Value %alc.c_head)
   %alc.c_h_tag = extractvalue %Value %alc.c_h_d, 0
   %alc.c_h_is_atom = icmp eq i32 %alc.c_h_tag, 0
-  br i1 %alc.c_h_is_atom, label %alc.c_measure, label %alc.fail
+  br i1 %alc.c_h_is_atom, label %alc.c_measure, label %alc.c_try_int
+alc.c_try_int:
+  %alc.c_h_is_int = icmp eq i32 %alc.c_h_tag, 1
+  br i1 %alc.c_h_is_int, label %alc.c_int_measure, label %alc.fail
+alc.c_int_measure:
+  ; snprintf the integer into the scratch buffer; return value is the
+  ; rendered length (excluding null).
+  %alc.c_int_v = extractvalue %Value %alc.c_h_d, 1
+  %alc.c_int_fmt = getelementptr [5 x i8], [5 x i8]* @.fmt_lld, i32 0, i32 0
+  %alc.c_int_n32 = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %alc.iscratch, i64 32, i8* %alc.c_int_fmt, i64 %alc.c_int_v)
+  %alc.c_int_len = sext i32 %alc.c_int_n32 to i64
+  br label %alc.c_advance
 alc.c_measure:
   %alc.c_aid = extractvalue %Value %alc.c_h_d, 1
   %alc.c_str = call i8* @wam_atom_to_string(i64 %alc.c_aid)
@@ -7657,7 +7671,8 @@ alc.c_m_step:
   %alc.c_mn1 = add i64 %alc.c_mn, 1
   br label %alc.c_m_loop
 alc.c_advance:
-  %alc.c_total1 = add i64 %alc.c_total, %alc.c_mn
+  %alc.c_elem_len = phi i64 [ %alc.c_mn, %alc.c_m_loop ], [ %alc.c_int_len, %alc.c_int_measure ]
+  %alc.c_total1 = add i64 %alc.c_total, %alc.c_elem_len
   %alc.c_t_ptr = getelementptr %Value, %Value* %alc.c_args, i32 1
   %alc.c_next = load %Value, %Value* %alc.c_t_ptr
   br label %alc.c_loop
@@ -7680,13 +7695,32 @@ alc.f_step:
   %alc.f_h_ptr = getelementptr %Value, %Value* %alc.f_args, i32 0
   %alc.f_head = load %Value, %Value* %alc.f_h_ptr
   %alc.f_h_d = call %Value @wam_deref_value(%WamState* %vm, %Value %alc.f_head)
+  %alc.f_h_tag = extractvalue %Value %alc.f_h_d, 0
+  %alc.f_is_atom = icmp eq i32 %alc.f_h_tag, 0
+  br i1 %alc.f_is_atom, label %alc.f_load_atom, label %alc.f_int_write
+alc.f_load_atom:
   %alc.f_aid = extractvalue %Value %alc.f_h_d, 1
   %alc.f_str = call i8* @wam_atom_to_string(i64 %alc.f_aid)
   ; Measure this atom''s length again (second pass).
   br label %alc.f_m_loop
+alc.f_int_write:
+  ; snprintf %lld directly into the output buffer at the running offset.
+  %alc.f_int_v = extractvalue %Value %alc.f_h_d, 1
+  %alc.f_int_dst = getelementptr i8, i8* %alc.buf, i64 %alc.f_off
+  ; Remaining buffer size: bufsz - off; we already sized for total + 1.
+  %alc.f_int_avail = sub i64 %alc.bufsz, %alc.f_off
+  %alc.f_int_fmt = getelementptr [5 x i8], [5 x i8]* @.fmt_lld, i32 0, i32 0
+  %alc.f_int_n32 = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %alc.f_int_dst, i64 %alc.f_int_avail, i8* %alc.f_int_fmt, i64 %alc.f_int_v)
+  %alc.f_int_len = sext i32 %alc.f_int_n32 to i64
+  br label %alc.f_copy_int
+alc.f_copy_int:
+  %alc.f_off_int = add i64 %alc.f_off, %alc.f_int_len
+  %alc.f_t_ptr_int = getelementptr %Value, %Value* %alc.f_args, i32 1
+  %alc.f_next_int = load %Value, %Value* %alc.f_t_ptr_int
+  br label %alc.f_after
 alc.f_m_loop:
-  %alc.f_mp = phi i8* [ %alc.f_str, %alc.f_step ], [ %alc.f_mpn, %alc.f_m_step ]
-  %alc.f_mn = phi i64 [ 0, %alc.f_step ], [ %alc.f_mn1, %alc.f_m_step ]
+  %alc.f_mp = phi i8* [ %alc.f_str, %alc.f_load_atom ], [ %alc.f_mpn, %alc.f_m_step ]
+  %alc.f_mn = phi i64 [ 0, %alc.f_load_atom ], [ %alc.f_mn1, %alc.f_m_step ]
   %alc.f_mc = load i8, i8* %alc.f_mp
   %alc.f_mz = icmp eq i8 %alc.f_mc, 0
   br i1 %alc.f_mz, label %alc.f_copy, label %alc.f_m_step
@@ -7697,11 +7731,13 @@ alc.f_m_step:
 alc.f_copy:
   %alc.f_dst = getelementptr i8, i8* %alc.buf, i64 %alc.f_off
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* %alc.f_dst, i8* %alc.f_str, i64 %alc.f_mn, i1 false)
-  %alc.f_off1 = add i64 %alc.f_off, %alc.f_mn
-  %alc.f_t_ptr = getelementptr %Value, %Value* %alc.f_args, i32 1
-  %alc.f_next = load %Value, %Value* %alc.f_t_ptr
+  %alc.f_off_atom = add i64 %alc.f_off, %alc.f_mn
+  %alc.f_t_ptr_atom = getelementptr %Value, %Value* %alc.f_args, i32 1
+  %alc.f_next_atom = load %Value, %Value* %alc.f_t_ptr_atom
   br label %alc.f_after
 alc.f_after:
+  %alc.f_off1 = phi i64 [ %alc.f_off_atom, %alc.f_copy ], [ %alc.f_off_int, %alc.f_copy_int ]
+  %alc.f_next = phi %Value [ %alc.f_next_atom, %alc.f_copy ], [ %alc.f_next_int, %alc.f_copy_int ]
   br label %alc.f_loop
 alc.f_done:
   %alc.term_dst = getelementptr i8, i8* %alc.buf, i64 %alc.c_total

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -1810,6 +1810,56 @@ test_alc3s_roundtrip(_, R) :-
     length(Parts, N),
     R is N.   % 3
 
+% M55: atomic_list_concat/2 with Integer heads (snprintf widening).
+
+:- dynamic test_alc_int_only_length/2.
+test_alc_int_only_length(_, R) :-
+    atomic_list_concat([1, 2, 3], A),
+    atom_length(A, N),
+    R is N.   % 3 -- "123"
+
+:- dynamic test_alc_int_first_code/2.
+test_alc_int_first_code(_, R) :-
+    atomic_list_concat([42], A),
+    atom_codes(A, [C|_]),
+    R is C.   % '4' = 52
+
+:- dynamic test_alc_int_negative/2.
+test_alc_int_negative(_, R) :-
+    atomic_list_concat([-7], A),
+    atom_codes(A, [C|_]),
+    R is C.   % '-' = 45
+
+:- dynamic test_alc_mixed_length/2.
+test_alc_mixed_length(_, R) :-
+    atomic_list_concat([foo, 42, bar], A),
+    atom_length(A, N),
+    R is N.   % 8 ("foo42bar")
+
+:- dynamic test_alc_mixed_seam/2.
+test_alc_mixed_seam(_, R) :-
+    atomic_list_concat([ab, 99, cd], A),
+    atom_codes(A, [_, _, C, _, _, _]),    % position 2 is '9'
+    R is C.   % 57
+
+:- dynamic test_alc_int_zero/2.
+test_alc_int_zero(_, R) :-
+    atomic_list_concat([0], A),
+    atom_codes(A, [C|_]),
+    R is C.   % '0' = 48
+
+:- dynamic test_alc_int_last/2.
+test_alc_int_last(_, R) :-
+    atomic_list_concat([prefix, 200], A),
+    atom_length(A, N),
+    R is N.   % 9 ("prefix200")
+
+:- dynamic test_alc_three_ints/2.
+test_alc_three_ints(_, R) :-
+    atomic_list_concat([10, 20, 30], A),
+    atom_codes(A, [_, _, C, _, _, _]),    % position 2 is '2' from "20"
+    R is C.   % 50
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -3032,6 +3082,23 @@ test_all :-
                    test_alc3s_empty_sep_fails, 0, 0),
        run_test_r0('alc roundtrip count -> 3',
                    test_alc3s_roundtrip, 0, 3),
+       format('--- M55 atomic_list_concat/2 Integer heads ---~n'),
+       run_test_r0('alc([1,2,3]) atom_length -> 3',
+                   test_alc_int_only_length, 0, 3),
+       run_test_r0('alc([42]) first code -> 52',
+                   test_alc_int_first_code, 0, 52),
+       run_test_r0('alc([-7]) first code -> 45',
+                   test_alc_int_negative, 0, 45),
+       run_test_r0('alc([foo, 42, bar]) length -> 8',
+                   test_alc_mixed_length, 0, 8),
+       run_test_r0('alc([ab, 99, cd]) pos 2 -> 57',
+                   test_alc_mixed_seam, 0, 57),
+       run_test_r0('alc([0]) first code -> 48',
+                   test_alc_int_zero, 0, 48),
+       run_test_r0('alc([prefix, 200]) length -> 9',
+                   test_alc_int_last, 0, 9),
+       run_test_r0('alc([10, 20, 30]) pos 2 -> 50',
+                   test_alc_three_ints, 0, 50),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Extends `atomic_list_concat/2` to accept Integer heads in addition to
Atoms. Each Integer is rendered via `snprintf %lld`; the value and a
null terminator are written into the running output buffer at the
current offset.

### Pass 1 (count) extensions
- `alc.c_step` branches atom vs int (via `alc.c_try_int`); non-atom
  non-int heads still fail.
- `alc.c_int_measure` calls `snprintf` into a 32-byte arena scratch
  buffer and uses the return value as the rendered length.
- `alc.c_advance` now phi-selects between `%alc.c_mn` (atom path) and
  `%alc.c_int_len` (int path) for the element length.

### Pass 2 (fill) extensions
- `alc.f_step` branches atom vs int (Integer heads can only appear
  when pass 1 accepted them; other shapes are unreachable, but the
  load still happens through the int code path).
- `alc.f_int_write` snprintfs `%lld` directly into the output buffer
  at `off` (`size = bufsz - off`, which is exactly large enough by
  pass-1 sizing).
- New `alc.f_after` phi handles `off` + `next` from both branches.

The buffer is sized to `total + 1`; for the last element exactly
`int_len + 1` bytes are available, which snprintf can fill (`int_len`
content + null). For earlier elements snprintf's null is overwritten
by the next memcpy or snprintf. The explicit null-terminate at
`total` remains for safety.

Float widening (Float heads, `%g` formatting) is deferred to a later
milestone — needs a different format string and double extraction.

## Test plan
- [x] 8 new tests: integer-only `[1, 2, 3]` length → 3; single
      integer `[42]` first code 52, `[-7]` first code 45, `[0]` → 48;
      mixed `[foo, 42, bar]` length 8 + seam check at pos 2 of
      `[ab, 99, cd]`; `[prefix, 200]` length 9; `[10, 20, 30]` seam
      check at pos 2
- [x] All 354 builtin tests pass (was 346, +8)
- [x] Manual llc round-trip clean


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_