### PR TITLE
LLVM WAM: atomic_list_concat/3 Integer heads (M56)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -7750,17 +7750,17 @@ alc.f_done:
   ret i1 %alc.ok
 
 builtin_atomic_list_concat3:
-  ; M53: atomic_list_concat(+List, +Sep, ?Atom) -- atoms-only forward.
-  ; A2 must be a bound Atom (the separator). Splits Atom by Sep is
-  ; deferred (reverse mode would need a substring scan).
-  ; Two-pass walk of A1:
-  ;   1. measure sep_len; walk A1 summing atom_len + (sep_len for
-  ;      every element after the first) into total;
-  ;   2. allocate (total+1) byte buffer; walk A1 again, before each
-  ;      element after the first memcpy the separator, then memcpy
-  ;      the atom''s string. Null-terminate, intern, unify A3.
+  ; M53/M54/M56: atomic_list_concat(?List, +Sep, ?Atom).
+  ; Forward (List bound, A2 sep, A3 ?): concat with sep between
+  ; elements. M56 adds Integer support (in addition to Atoms) via
+  ; snprintf widening (same trick as M55 for alc/2).
+  ; Split (List unbound, A2 sep, A3 bound): scan A3 for sep
+  ; occurrences and emit Atoms.
   %alc3.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
   call void @wam_arena_ensure()
+  ; Scratch buffer for measuring integer element lengths during forward
+  ; mode pass 1. Allocated unconditionally; harmless for split mode.
+  %alc3.iscratch = call i8* @wam_arena_alloc(i64 32)
   %alc3.t2 = extractvalue %Value %alc3.a2, 0
   %alc3.is_sep_atom = icmp eq i32 %alc3.t2, 0
   br i1 %alc3.is_sep_atom, label %alc3.sep_lookup, label %alc3.fail
@@ -7805,7 +7805,16 @@ alc3.c_step:
   %alc3.c_h_d = call %Value @wam_deref_value(%WamState* %vm, %Value %alc3.c_head)
   %alc3.c_h_tag = extractvalue %Value %alc3.c_h_d, 0
   %alc3.c_h_is_atom = icmp eq i32 %alc3.c_h_tag, 0
-  br i1 %alc3.c_h_is_atom, label %alc3.c_measure, label %alc3.fail
+  br i1 %alc3.c_h_is_atom, label %alc3.c_measure, label %alc3.c_try_int
+alc3.c_try_int:
+  %alc3.c_h_is_int = icmp eq i32 %alc3.c_h_tag, 1
+  br i1 %alc3.c_h_is_int, label %alc3.c_int_measure, label %alc3.fail
+alc3.c_int_measure:
+  %alc3.c_int_v = extractvalue %Value %alc3.c_h_d, 1
+  %alc3.c_int_fmt = getelementptr [5 x i8], [5 x i8]* @.fmt_lld, i32 0, i32 0
+  %alc3.c_int_n32 = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %alc3.iscratch, i64 32, i8* %alc3.c_int_fmt, i64 %alc3.c_int_v)
+  %alc3.c_int_len = sext i32 %alc3.c_int_n32 to i64
+  br label %alc3.c_advance
 alc3.c_measure:
   %alc3.c_aid = extractvalue %Value %alc3.c_h_d, 1
   %alc3.c_str = call i8* @wam_atom_to_string(i64 %alc3.c_aid)
@@ -7822,11 +7831,12 @@ alc3.c_m_step:
   %alc3.c_mn1 = add i64 %alc3.c_mn, 1
   br label %alc3.c_m_loop
 alc3.c_advance:
-  ; Add atom length, plus separator length for every element after the first.
+  ; Add element length (atom or int), plus separator length for every element after the first.
+  %alc3.c_elem_len = phi i64 [ %alc3.c_mn, %alc3.c_m_loop ], [ %alc3.c_int_len, %alc3.c_int_measure ]
   %alc3.c_not_first = icmp ne i32 %alc3.c_n, 0
   %alc3.c_sep_add = select i1 %alc3.c_not_first, i64 %alc3.smn, i64 0
   %alc3.c_with_sep = add i64 %alc3.c_total, %alc3.c_sep_add
-  %alc3.c_total1 = add i64 %alc3.c_with_sep, %alc3.c_mn
+  %alc3.c_total1 = add i64 %alc3.c_with_sep, %alc3.c_elem_len
   %alc3.c_n1 = add i32 %alc3.c_n, 1
   %alc3.c_t_ptr = getelementptr %Value, %Value* %alc3.c_args, i32 1
   %alc3.c_next = load %Value, %Value* %alc3.c_t_ptr
@@ -7836,9 +7846,9 @@ alc3.c_done:
   %alc3.buf = call i8* @wam_arena_alloc(i64 %alc3.bufsz)
   br label %alc3.f_loop
 alc3.f_loop:
-  %alc3.f_cur = phi %Value [ %alc3.a1, %alc3.c_done ], [ %alc3.f_next, %alc3.f_copy_atom ]
-  %alc3.f_off = phi i64 [ 0, %alc3.c_done ], [ %alc3.f_off2, %alc3.f_copy_atom ]
-  %alc3.f_idx = phi i32 [ 0, %alc3.c_done ], [ %alc3.f_idx1, %alc3.f_copy_atom ]
+  %alc3.f_cur = phi %Value [ %alc3.a1, %alc3.c_done ], [ %alc3.f_next, %alc3.f_after ]
+  %alc3.f_off = phi i64 [ 0, %alc3.c_done ], [ %alc3.f_off_next, %alc3.f_after ]
+  %alc3.f_idx = phi i32 [ 0, %alc3.c_done ], [ %alc3.f_idx1, %alc3.f_after ]
   %alc3.f_d = call %Value @wam_deref_value(%WamState* %vm, %Value %alc3.f_cur)
   %alc3.f_tag = extractvalue %Value %alc3.f_d, 0
   %alc3.f_is_cmp = icmp eq i32 %alc3.f_tag, 3
@@ -7847,12 +7857,13 @@ alc3.f_pre_sep:
   %alc3.f_not_first = icmp ne i32 %alc3.f_idx, 0
   %alc3.f_off_after_sep_if = add i64 %alc3.f_off, %alc3.smn
   %alc3.f_off_after_sep = select i1 %alc3.f_not_first, i64 %alc3.f_off_after_sep_if, i64 %alc3.f_off
-  br i1 %alc3.f_not_first, label %alc3.f_copy_sep, label %alc3.f_load_atom
+  br i1 %alc3.f_not_first, label %alc3.f_copy_sep, label %alc3.f_dispatch
 alc3.f_copy_sep:
   %alc3.f_sep_dst = getelementptr i8, i8* %alc3.buf, i64 %alc3.f_off
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* %alc3.f_sep_dst, i8* %alc3.sep_str, i64 %alc3.smn, i1 false)
-  br label %alc3.f_load_atom
-alc3.f_load_atom:
+  br label %alc3.f_dispatch
+alc3.f_dispatch:
+  ; M56: load head, branch atom vs int.
   %alc3.f_cp = extractvalue %Value %alc3.f_d, 1
   %alc3.f_cp_ptr = inttoptr i64 %alc3.f_cp to %Compound*
   %alc3.f_args_slot = getelementptr %Compound, %Compound* %alc3.f_cp_ptr, i32 0, i32 2
@@ -7860,9 +7871,22 @@ alc3.f_load_atom:
   %alc3.f_h_ptr = getelementptr %Value, %Value* %alc3.f_args, i32 0
   %alc3.f_head = load %Value, %Value* %alc3.f_h_ptr
   %alc3.f_h_d = call %Value @wam_deref_value(%WamState* %vm, %Value %alc3.f_head)
+  %alc3.f_h_tag = extractvalue %Value %alc3.f_h_d, 0
+  %alc3.f_is_atom = icmp eq i32 %alc3.f_h_tag, 0
+  br i1 %alc3.f_is_atom, label %alc3.f_load_atom, label %alc3.f_int_write
+alc3.f_load_atom:
   %alc3.f_aid = extractvalue %Value %alc3.f_h_d, 1
   %alc3.f_str = call i8* @wam_atom_to_string(i64 %alc3.f_aid)
   br label %alc3.f_m_loop
+alc3.f_int_write:
+  %alc3.f_int_v = extractvalue %Value %alc3.f_h_d, 1
+  %alc3.f_int_dst = getelementptr i8, i8* %alc3.buf, i64 %alc3.f_off_after_sep
+  %alc3.f_int_avail = sub i64 %alc3.bufsz, %alc3.f_off_after_sep
+  %alc3.f_int_fmt = getelementptr [5 x i8], [5 x i8]* @.fmt_lld, i32 0, i32 0
+  %alc3.f_int_n32 = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %alc3.f_int_dst, i64 %alc3.f_int_avail, i8* %alc3.f_int_fmt, i64 %alc3.f_int_v)
+  %alc3.f_int_len = sext i32 %alc3.f_int_n32 to i64
+  %alc3.f_off_after_int = add i64 %alc3.f_off_after_sep, %alc3.f_int_len
+  br label %alc3.f_after
 alc3.f_m_loop:
   %alc3.f_mp = phi i8* [ %alc3.f_str, %alc3.f_load_atom ], [ %alc3.f_mpn, %alc3.f_m_step ]
   %alc3.f_mn = phi i64 [ 0, %alc3.f_load_atom ], [ %alc3.f_mn1, %alc3.f_m_step ]
@@ -7876,7 +7900,10 @@ alc3.f_m_step:
 alc3.f_copy_atom:
   %alc3.f_atom_dst = getelementptr i8, i8* %alc3.buf, i64 %alc3.f_off_after_sep
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* %alc3.f_atom_dst, i8* %alc3.f_str, i64 %alc3.f_mn, i1 false)
-  %alc3.f_off2 = add i64 %alc3.f_off_after_sep, %alc3.f_mn
+  %alc3.f_off_after_atom = add i64 %alc3.f_off_after_sep, %alc3.f_mn
+  br label %alc3.f_after
+alc3.f_after:
+  %alc3.f_off_next = phi i64 [ %alc3.f_off_after_atom, %alc3.f_copy_atom ], [ %alc3.f_off_after_int, %alc3.f_int_write ]
   %alc3.f_idx1 = add i32 %alc3.f_idx, 1
   %alc3.f_t_ptr = getelementptr %Value, %Value* %alc3.f_args, i32 1
   %alc3.f_next = load %Value, %Value* %alc3.f_t_ptr

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -1860,6 +1860,52 @@ test_alc_three_ints(_, R) :-
     atom_codes(A, [_, _, C, _, _, _]),    % position 2 is '2' from "20"
     R is C.   % 50
 
+% M56: atomic_list_concat/3 with Integer heads.
+
+:- dynamic test_alc3_int_only_length/2.
+test_alc3_int_only_length(_, R) :-
+    atomic_list_concat([1, 2, 3], '-', A),
+    atom_length(A, N),
+    R is N.   % 5 -- "1-2-3"
+
+:- dynamic test_alc3_int_first/2.
+test_alc3_int_first(_, R) :-
+    atomic_list_concat([42], '-', A),
+    atom_codes(A, [C|_]),
+    R is C.   % '4' = 52
+
+:- dynamic test_alc3_int_seam/2.
+test_alc3_int_seam(_, R) :-
+    atomic_list_concat([10, 20], '/', A),
+    atom_codes(A, [_, _, C, _, _]),  % position 2 is '/'
+    R is C.   % 47
+
+:- dynamic test_alc3_int_with_atom/2.
+test_alc3_int_with_atom(_, R) :-
+    atomic_list_concat([foo, 42, bar], '-', A),
+    atom_length(A, N),
+    R is N.   % 10 = 3 + 1 + 2 + 1 + 3
+
+:- dynamic test_alc3_int_negative/2.
+test_alc3_int_negative(_, R) :-
+    atomic_list_concat([-5, 7], '+', A),
+    atom_length(A, N),
+    R is N.   % 4 ("-5+7")
+
+:- dynamic test_alc3_int_multi_char_sep/2.
+test_alc3_int_multi_char_sep(_, R) :-
+    atomic_list_concat([1, 2, 3], ', ', A),
+    atom_length(A, N),
+    R is N.   % 7 -- "1, 2, 3"
+
+:- dynamic test_alc3_int_split_count/2.
+test_alc3_int_split_count(_, R) :-
+    % Forward int + split round-trip.
+    atomic_list_concat([100, 200, 300], '|', Joined),
+    atomic_list_concat(Parts, '|', Joined),
+    length(Parts, N),
+    R is N.   % 3
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -3099,6 +3145,21 @@ test_all :-
                    test_alc_int_last, 0, 9),
        run_test_r0('alc([10, 20, 30]) pos 2 -> 50',
                    test_alc_three_ints, 0, 50),
+       format('--- M56 atomic_list_concat/3 Integer heads ---~n'),
+       run_test_r0('alc([1,2,3], \'-\') length -> 5',
+                   test_alc3_int_only_length, 0, 5),
+       run_test_r0('alc([42], \'-\') first -> 52',
+                   test_alc3_int_first, 0, 52),
+       run_test_r0('alc([10, 20], \'/\') seam -> 47',
+                   test_alc3_int_seam, 0, 47),
+       run_test_r0('alc([foo, 42, bar], \'-\') length -> 10',
+                   test_alc3_int_with_atom, 0, 10),
+       run_test_r0('alc([-5, 7], \'+\') length -> 4',
+                   test_alc3_int_negative, 0, 4),
+       run_test_r0('alc([1,2,3], \', \') length -> 7',
+                   test_alc3_int_multi_char_sep, 0, 7),
+       run_test_r0('alc/3 int + split roundtrip count -> 3',
+                   test_alc3_int_split_count, 0, 3),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Mirrors M55's extension of `/2` onto `/3`. Forward mode (List bound +
Sep atom) now accepts Integer heads in addition to Atoms; snprintf
`%lld` widens each integer.

### Pass 1 (count) extensions
`alc3.c_step` → `alc3.c_try_int` → `alc3.c_int_measure` work the same
as the `alc/2` variant. `c_advance` now phi-selects the element length
from `%alc3.c_mn` (atom path) or `%alc3.c_int_len` (int path) and adds
it to `total` along with the sep-add. `iscratch` is a 32-byte arena
buffer allocated at the /3 entry; unused in split mode but harmless.

### Pass 2 (fill) restructured
- `f_pre_sep` computes `off_after_sep` and branches to `f_copy_sep`
  (sep memcpy) or `f_dispatch` directly when first.
- `f_copy_sep` falls through to `f_dispatch` via plain `br`.
- New `f_dispatch` loads the head from the cons cell, derefs, checks
  head tag, branches `f_load_atom` or `f_int_write`. (Previously
  `f_load_atom` did both head loading AND `atom_to_string`; now the
  load is hoisted up.)
- New `f_int_write` snprintfs `%lld` directly at
  `buf + off_after_sep` using `bufsz - off_after_sep` as the size.
  Computes `f_off_after_int`.
- `f_copy_atom` now ends in `br label %f_after` rather than
  `br label %f_loop`, computes `f_off_after_atom` locally.
- New `f_after` phi-merges `off_next` from atom and int paths, then
  advances idx and next.

The `f_loop` phi predecessors update from `f_copy_atom` to `f_after`
accordingly. `f_dispatch` dominates `f_after` through both paths, so
`f_args` is visible at `f_after` for the tail load.

Float widening still deferred (same as M55).

## Test plan
- [x] 7 new tests: integer-only `[1,2,3]` with `'-'` sep → length 5
      (`"1-2-3"`); single integer `[42]` first code 52; `[10, 20]` /
      `'/'` seam check → 47 at pos 2; mixed `[foo, 42, bar]` / `'-'`
      → length 10 (3+1+2+1+3); negative `[-5, 7]` / `'+'` → length 4;
      multi-char sep `[1,2,3]` / `', '` → length 7; int-forward +
      split roundtrip count check
- [x] All 361 builtin tests pass (was 354, +7)
- [x] Manual llc round-trip clean


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_