### PR TITLE
fix(wam-clojure): materialize sub-atom offsets

### DIFF
--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1494,6 +1494,9 @@
     (string? value) (parse-number-text value)
     :else nil))
 
+(defn sub-atom-count-term [state n]
+  (normalize-literal-term (:intern-context state) (str n)))
+
 (defn sub-atom-solution-results [state text before length after sub]
   (let [n (count text)
         before-spec (if-let [n* (sub-atom-int-value state before)]
@@ -1520,9 +1523,9 @@
                :let [a (- n b l)
                      piece (subs text b (+ b l))
                      bindings (cond-> {}
-                                (= before-spec ::var) (assoc 2 b)
-                                (= length-spec ::var) (assoc 3 l)
-                                (= after-spec ::var) (assoc 4 a)
+                                (= before-spec ::var) (assoc 2 (sub-atom-count-term state b))
+                                (= length-spec ::var) (assoc 3 (sub-atom-count-term state l))
+                                (= after-spec ::var) (assoc 4 (sub-atom-count-term state a))
                                 (= sub-text ::var) (assoc 5 piece))]
                :when (and (or (= after-spec ::var) (= after-spec a))
                           (or (= sub-text ::var) (= sub-text piece)))]
@@ -1541,7 +1544,7 @@
                (or (logic-var? length) (= length ::unbound) (some? length-n)))
       [(cond-> {:bindings {1 sub-text}}
          (or (logic-var? length) (= length ::unbound))
-         (assoc-in [:bindings 3] (count sub-text)))])))
+         (assoc-in [:bindings 3] (sub-atom-count-term state (count sub-text))))])))
 
 (defn apply-sub-atom-solution [base-state resume-pc]
   (let [source (deref-value (:bindings base-state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -249,6 +249,12 @@
 :- dynamic user:wam_sub_atom_suffix/0.
 :- dynamic user:wam_sub_atom_backtrack_later_before/0.
 :- dynamic user:wam_sub_atom_length_bound_later_before/0.
+:- dynamic user:wam_sub_atom_before_unify/0.
+:- dynamic user:wam_sub_atom_before_unify_mismatch/0.
+:- dynamic user:wam_sub_atom_length_unify/0.
+:- dynamic user:wam_sub_atom_length_unify_mismatch/0.
+:- dynamic user:wam_sub_atom_after_unify/0.
+:- dynamic user:wam_sub_atom_after_unify_mismatch/0.
 :- dynamic user:wam_sub_atom_no_match/0.
 :- dynamic user:wam_sub_atom_numeric_source_arg/1.
 :- dynamic user:wam_sub_atom_numeric_sub_arg/1.
@@ -525,6 +531,12 @@ user:wam_sub_atom_prefix :- sub_atom(hello, 0, 3, _, hel).
 user:wam_sub_atom_suffix :- sub_atom(hello, _, 3, 0, llo).
 user:wam_sub_atom_backtrack_later_before :- sub_atom(abcabc, B, _, _, b), B =:= 4.
 user:wam_sub_atom_length_bound_later_before :- sub_atom(abcabc, B, 1, _, b), B =:= 4.
+user:wam_sub_atom_before_unify :- sub_atom(hello, B, _, _, ell), B = 1.
+user:wam_sub_atom_before_unify_mismatch :- sub_atom(hello, B, _, _, ell), B = 2.
+user:wam_sub_atom_length_unify :- sub_atom(hello, _, L, _, ell), L = 3.
+user:wam_sub_atom_length_unify_mismatch :- sub_atom(hello, _, L, _, ell), L = 2.
+user:wam_sub_atom_after_unify :- sub_atom(hello, _, _, A, ell), A = 1.
+user:wam_sub_atom_after_unify_mismatch :- sub_atom(hello, _, _, A, ell), A = 2.
 user:wam_sub_atom_no_match :- sub_atom(abc, _, _, _, xyz).
 user:wam_sub_atom_numeric_source_arg(A) :- sub_atom(A, 1, 3, 1, 234).
 user:wam_sub_atom_numeric_sub_arg(S) :- sub_atom(12345, 1, 2, _, S).
@@ -806,6 +818,12 @@ run_smoke :-
           user:wam_sub_atom_suffix/0,
           user:wam_sub_atom_backtrack_later_before/0,
           user:wam_sub_atom_length_bound_later_before/0,
+          user:wam_sub_atom_before_unify/0,
+          user:wam_sub_atom_before_unify_mismatch/0,
+          user:wam_sub_atom_length_unify/0,
+          user:wam_sub_atom_length_unify_mismatch/0,
+          user:wam_sub_atom_after_unify/0,
+          user:wam_sub_atom_after_unify_mismatch/0,
           user:wam_sub_atom_no_match/0,
           user:wam_sub_atom_numeric_source_arg/1,
           user:wam_sub_atom_numeric_sub_arg/1,
@@ -1269,6 +1287,12 @@ smoke_cases([
     case('wam_sub_atom_suffix/0', no_args, "true"),
     case('wam_sub_atom_backtrack_later_before/0', no_args, "true"),
     case('wam_sub_atom_length_bound_later_before/0', no_args, "true"),
+    case('wam_sub_atom_before_unify/0', no_args, "true"),
+    case('wam_sub_atom_before_unify_mismatch/0', no_args, "false"),
+    case('wam_sub_atom_length_unify/0', no_args, "true"),
+    case('wam_sub_atom_length_unify_mismatch/0', no_args, "false"),
+    case('wam_sub_atom_after_unify/0', no_args, "true"),
+    case('wam_sub_atom_after_unify_mismatch/0', no_args, "false"),
     case('wam_sub_atom_no_match/0', no_args, "false"),
     case('wam_sub_atom_numeric_source_arg/1', 12345, "true"),
     case('wam_sub_atom_numeric_sub_arg/1', 23, "true"),


### PR DESCRIPTION
## Summary

- Update Clojure WAM `sub_atom/5` result materialization so produced `Before`, `Length`, and `After` values use lowered numeric literal terms.
- Preserve existing integer parsing for bound `sub_atom/5` numeric arguments.
- Add runtime smoke coverage for successful and mismatching unification of produced `Before`, `Length`, and `After` outputs.

## Why

The lowered Clojure WAM path represents numeric literals as interned terms. `sub_atom/5` previously returned produced offset values as raw JVM integers through the foreign-result path, which works for arithmetic comparisons but can fail when the generated code later unifies the output with a lowered numeric literal.

This change aligns `sub_atom/5` output materialization with the numeric representation used by lowered WAM code, continuing the representation-hardening work from text, numeric text, and length materialization.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
