### PR TITLE
LLVM WAM: atomic_list_concat Float widening for /2 and /3 (M57)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -7646,7 +7646,10 @@ alc.c_step:
   br i1 %alc.c_h_is_atom, label %alc.c_measure, label %alc.c_try_int
 alc.c_try_int:
   %alc.c_h_is_int = icmp eq i32 %alc.c_h_tag, 1
-  br i1 %alc.c_h_is_int, label %alc.c_int_measure, label %alc.fail
+  br i1 %alc.c_h_is_int, label %alc.c_int_measure, label %alc.c_try_float
+alc.c_try_float:
+  %alc.c_h_is_float = icmp eq i32 %alc.c_h_tag, 2
+  br i1 %alc.c_h_is_float, label %alc.c_float_measure, label %alc.fail
 alc.c_int_measure:
   ; snprintf the integer into the scratch buffer; return value is the
   ; rendered length (excluding null).
@@ -7654,6 +7657,14 @@ alc.c_int_measure:
   %alc.c_int_fmt = getelementptr [5 x i8], [5 x i8]* @.fmt_lld, i32 0, i32 0
   %alc.c_int_n32 = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %alc.iscratch, i64 32, i8* %alc.c_int_fmt, i64 %alc.c_int_v)
   %alc.c_int_len = sext i32 %alc.c_int_n32 to i64
+  br label %alc.c_advance
+alc.c_float_measure:
+  ; M57: extract i64 payload, bitcast to double, snprintf %g.
+  %alc.c_flt_bits = extractvalue %Value %alc.c_h_d, 1
+  %alc.c_flt_v = bitcast i64 %alc.c_flt_bits to double
+  %alc.c_flt_fmt = getelementptr [3 x i8], [3 x i8]* @.fmt_dbl, i32 0, i32 0
+  %alc.c_flt_n32 = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %alc.iscratch, i64 32, i8* %alc.c_flt_fmt, double %alc.c_flt_v)
+  %alc.c_flt_len = sext i32 %alc.c_flt_n32 to i64
   br label %alc.c_advance
 alc.c_measure:
   %alc.c_aid = extractvalue %Value %alc.c_h_d, 1
@@ -7671,7 +7682,7 @@ alc.c_m_step:
   %alc.c_mn1 = add i64 %alc.c_mn, 1
   br label %alc.c_m_loop
 alc.c_advance:
-  %alc.c_elem_len = phi i64 [ %alc.c_mn, %alc.c_m_loop ], [ %alc.c_int_len, %alc.c_int_measure ]
+  %alc.c_elem_len = phi i64 [ %alc.c_mn, %alc.c_m_loop ], [ %alc.c_int_len, %alc.c_int_measure ], [ %alc.c_flt_len, %alc.c_float_measure ]
   %alc.c_total1 = add i64 %alc.c_total, %alc.c_elem_len
   %alc.c_t_ptr = getelementptr %Value, %Value* %alc.c_args, i32 1
   %alc.c_next = load %Value, %Value* %alc.c_t_ptr
@@ -7697,7 +7708,10 @@ alc.f_step:
   %alc.f_h_d = call %Value @wam_deref_value(%WamState* %vm, %Value %alc.f_head)
   %alc.f_h_tag = extractvalue %Value %alc.f_h_d, 0
   %alc.f_is_atom = icmp eq i32 %alc.f_h_tag, 0
-  br i1 %alc.f_is_atom, label %alc.f_load_atom, label %alc.f_int_write
+  br i1 %alc.f_is_atom, label %alc.f_load_atom, label %alc.f_try_int
+alc.f_try_int:
+  %alc.f_is_int = icmp eq i32 %alc.f_h_tag, 1
+  br i1 %alc.f_is_int, label %alc.f_int_write, label %alc.f_float_write
 alc.f_load_atom:
   %alc.f_aid = extractvalue %Value %alc.f_h_d, 1
   %alc.f_str = call i8* @wam_atom_to_string(i64 %alc.f_aid)
@@ -7713,10 +7727,25 @@ alc.f_int_write:
   %alc.f_int_n32 = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %alc.f_int_dst, i64 %alc.f_int_avail, i8* %alc.f_int_fmt, i64 %alc.f_int_v)
   %alc.f_int_len = sext i32 %alc.f_int_n32 to i64
   br label %alc.f_copy_int
+alc.f_float_write:
+  ; M57: snprintf %g directly into the output buffer.
+  %alc.f_flt_bits = extractvalue %Value %alc.f_h_d, 1
+  %alc.f_flt_v = bitcast i64 %alc.f_flt_bits to double
+  %alc.f_flt_dst = getelementptr i8, i8* %alc.buf, i64 %alc.f_off
+  %alc.f_flt_avail = sub i64 %alc.bufsz, %alc.f_off
+  %alc.f_flt_fmt = getelementptr [3 x i8], [3 x i8]* @.fmt_dbl, i32 0, i32 0
+  %alc.f_flt_n32 = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %alc.f_flt_dst, i64 %alc.f_flt_avail, i8* %alc.f_flt_fmt, double %alc.f_flt_v)
+  %alc.f_flt_len = sext i32 %alc.f_flt_n32 to i64
+  br label %alc.f_copy_flt
 alc.f_copy_int:
   %alc.f_off_int = add i64 %alc.f_off, %alc.f_int_len
   %alc.f_t_ptr_int = getelementptr %Value, %Value* %alc.f_args, i32 1
   %alc.f_next_int = load %Value, %Value* %alc.f_t_ptr_int
+  br label %alc.f_after
+alc.f_copy_flt:
+  %alc.f_off_flt = add i64 %alc.f_off, %alc.f_flt_len
+  %alc.f_t_ptr_flt = getelementptr %Value, %Value* %alc.f_args, i32 1
+  %alc.f_next_flt = load %Value, %Value* %alc.f_t_ptr_flt
   br label %alc.f_after
 alc.f_m_loop:
   %alc.f_mp = phi i8* [ %alc.f_str, %alc.f_load_atom ], [ %alc.f_mpn, %alc.f_m_step ]
@@ -7736,8 +7765,8 @@ alc.f_copy:
   %alc.f_next_atom = load %Value, %Value* %alc.f_t_ptr_atom
   br label %alc.f_after
 alc.f_after:
-  %alc.f_off1 = phi i64 [ %alc.f_off_atom, %alc.f_copy ], [ %alc.f_off_int, %alc.f_copy_int ]
-  %alc.f_next = phi %Value [ %alc.f_next_atom, %alc.f_copy ], [ %alc.f_next_int, %alc.f_copy_int ]
+  %alc.f_off1 = phi i64 [ %alc.f_off_atom, %alc.f_copy ], [ %alc.f_off_int, %alc.f_copy_int ], [ %alc.f_off_flt, %alc.f_copy_flt ]
+  %alc.f_next = phi %Value [ %alc.f_next_atom, %alc.f_copy ], [ %alc.f_next_int, %alc.f_copy_int ], [ %alc.f_next_flt, %alc.f_copy_flt ]
   br label %alc.f_loop
 alc.f_done:
   %alc.term_dst = getelementptr i8, i8* %alc.buf, i64 %alc.c_total
@@ -7808,12 +7837,22 @@ alc3.c_step:
   br i1 %alc3.c_h_is_atom, label %alc3.c_measure, label %alc3.c_try_int
 alc3.c_try_int:
   %alc3.c_h_is_int = icmp eq i32 %alc3.c_h_tag, 1
-  br i1 %alc3.c_h_is_int, label %alc3.c_int_measure, label %alc3.fail
+  br i1 %alc3.c_h_is_int, label %alc3.c_int_measure, label %alc3.c_try_float
+alc3.c_try_float:
+  %alc3.c_h_is_float = icmp eq i32 %alc3.c_h_tag, 2
+  br i1 %alc3.c_h_is_float, label %alc3.c_float_measure, label %alc3.fail
 alc3.c_int_measure:
   %alc3.c_int_v = extractvalue %Value %alc3.c_h_d, 1
   %alc3.c_int_fmt = getelementptr [5 x i8], [5 x i8]* @.fmt_lld, i32 0, i32 0
   %alc3.c_int_n32 = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %alc3.iscratch, i64 32, i8* %alc3.c_int_fmt, i64 %alc3.c_int_v)
   %alc3.c_int_len = sext i32 %alc3.c_int_n32 to i64
+  br label %alc3.c_advance
+alc3.c_float_measure:
+  %alc3.c_flt_bits = extractvalue %Value %alc3.c_h_d, 1
+  %alc3.c_flt_v = bitcast i64 %alc3.c_flt_bits to double
+  %alc3.c_flt_fmt = getelementptr [3 x i8], [3 x i8]* @.fmt_dbl, i32 0, i32 0
+  %alc3.c_flt_n32 = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %alc3.iscratch, i64 32, i8* %alc3.c_flt_fmt, double %alc3.c_flt_v)
+  %alc3.c_flt_len = sext i32 %alc3.c_flt_n32 to i64
   br label %alc3.c_advance
 alc3.c_measure:
   %alc3.c_aid = extractvalue %Value %alc3.c_h_d, 1
@@ -7831,8 +7870,8 @@ alc3.c_m_step:
   %alc3.c_mn1 = add i64 %alc3.c_mn, 1
   br label %alc3.c_m_loop
 alc3.c_advance:
-  ; Add element length (atom or int), plus separator length for every element after the first.
-  %alc3.c_elem_len = phi i64 [ %alc3.c_mn, %alc3.c_m_loop ], [ %alc3.c_int_len, %alc3.c_int_measure ]
+  ; Add element length (atom / int / float), plus separator length for every element after the first.
+  %alc3.c_elem_len = phi i64 [ %alc3.c_mn, %alc3.c_m_loop ], [ %alc3.c_int_len, %alc3.c_int_measure ], [ %alc3.c_flt_len, %alc3.c_float_measure ]
   %alc3.c_not_first = icmp ne i32 %alc3.c_n, 0
   %alc3.c_sep_add = select i1 %alc3.c_not_first, i64 %alc3.smn, i64 0
   %alc3.c_with_sep = add i64 %alc3.c_total, %alc3.c_sep_add
@@ -7873,7 +7912,10 @@ alc3.f_dispatch:
   %alc3.f_h_d = call %Value @wam_deref_value(%WamState* %vm, %Value %alc3.f_head)
   %alc3.f_h_tag = extractvalue %Value %alc3.f_h_d, 0
   %alc3.f_is_atom = icmp eq i32 %alc3.f_h_tag, 0
-  br i1 %alc3.f_is_atom, label %alc3.f_load_atom, label %alc3.f_int_write
+  br i1 %alc3.f_is_atom, label %alc3.f_load_atom, label %alc3.f_try_int
+alc3.f_try_int:
+  %alc3.f_is_int = icmp eq i32 %alc3.f_h_tag, 1
+  br i1 %alc3.f_is_int, label %alc3.f_int_write, label %alc3.f_float_write
 alc3.f_load_atom:
   %alc3.f_aid = extractvalue %Value %alc3.f_h_d, 1
   %alc3.f_str = call i8* @wam_atom_to_string(i64 %alc3.f_aid)
@@ -7886,6 +7928,16 @@ alc3.f_int_write:
   %alc3.f_int_n32 = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %alc3.f_int_dst, i64 %alc3.f_int_avail, i8* %alc3.f_int_fmt, i64 %alc3.f_int_v)
   %alc3.f_int_len = sext i32 %alc3.f_int_n32 to i64
   %alc3.f_off_after_int = add i64 %alc3.f_off_after_sep, %alc3.f_int_len
+  br label %alc3.f_after
+alc3.f_float_write:
+  %alc3.f_flt_bits = extractvalue %Value %alc3.f_h_d, 1
+  %alc3.f_flt_v = bitcast i64 %alc3.f_flt_bits to double
+  %alc3.f_flt_dst = getelementptr i8, i8* %alc3.buf, i64 %alc3.f_off_after_sep
+  %alc3.f_flt_avail = sub i64 %alc3.bufsz, %alc3.f_off_after_sep
+  %alc3.f_flt_fmt = getelementptr [3 x i8], [3 x i8]* @.fmt_dbl, i32 0, i32 0
+  %alc3.f_flt_n32 = call i32 (i8*, i64, i8*, ...) @snprintf(i8* %alc3.f_flt_dst, i64 %alc3.f_flt_avail, i8* %alc3.f_flt_fmt, double %alc3.f_flt_v)
+  %alc3.f_flt_len = sext i32 %alc3.f_flt_n32 to i64
+  %alc3.f_off_after_flt = add i64 %alc3.f_off_after_sep, %alc3.f_flt_len
   br label %alc3.f_after
 alc3.f_m_loop:
   %alc3.f_mp = phi i8* [ %alc3.f_str, %alc3.f_load_atom ], [ %alc3.f_mpn, %alc3.f_m_step ]
@@ -7903,7 +7955,7 @@ alc3.f_copy_atom:
   %alc3.f_off_after_atom = add i64 %alc3.f_off_after_sep, %alc3.f_mn
   br label %alc3.f_after
 alc3.f_after:
-  %alc3.f_off_next = phi i64 [ %alc3.f_off_after_atom, %alc3.f_copy_atom ], [ %alc3.f_off_after_int, %alc3.f_int_write ]
+  %alc3.f_off_next = phi i64 [ %alc3.f_off_after_atom, %alc3.f_copy_atom ], [ %alc3.f_off_after_int, %alc3.f_int_write ], [ %alc3.f_off_after_flt, %alc3.f_float_write ]
   %alc3.f_idx1 = add i32 %alc3.f_idx, 1
   %alc3.f_t_ptr = getelementptr %Value, %Value* %alc3.f_args, i32 1
   %alc3.f_next = load %Value, %Value* %alc3.f_t_ptr

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -1906,6 +1906,38 @@ test_alc3_int_split_count(_, R) :-
     length(Parts, N),
     R is N.   % 3
 
+% M57: Float widening for atomic_list_concat/2 and /3.
+
+:- dynamic test_alc_float_singleton/2.
+test_alc_float_singleton(_, R) :-
+    atomic_list_concat([3.5], A),
+    atom_codes(A, [C|_]),
+    R is C.   % '3' = 51
+
+:- dynamic test_alc_float_with_atom/2.
+test_alc_float_with_atom(_, R) :-
+    atomic_list_concat([pi, '=', 3.14], A),
+    atom_codes(A, [C|_]),
+    R is C.   % 'p' = 112
+
+:- dynamic test_alc_float_with_int/2.
+test_alc_float_with_int(_, R) :-
+    atomic_list_concat([1, 2.5, 3], A),
+    atom_codes(A, [_, _, C|_]),
+    R is C.   % '.' = 46 (position 2 is the decimal point of 2.5)
+
+:- dynamic test_alc3_float_only/2.
+test_alc3_float_only(_, R) :-
+    atomic_list_concat([1.5, 2.5], '+', A),
+    atom_codes(A, [_, _, _, C|_]),    % position 3 is the '+'
+    R is C.   % 43
+
+:- dynamic test_alc3_float_mixed/2.
+test_alc3_float_mixed(_, R) :-
+    atomic_list_concat([x, 1.5, y], ',', A),
+    atom_codes(A, [C|_]),
+    R is C.   % 'x' = 120
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -3160,6 +3192,17 @@ test_all :-
                    test_alc3_int_multi_char_sep, 0, 7),
        run_test_r0('alc/3 int + split roundtrip count -> 3',
                    test_alc3_int_split_count, 0, 3),
+       format('--- M57 atomic_list_concat Float widening ---~n'),
+       run_test_r0('alc([3.5]) first -> 51 (\'3\')',
+                   test_alc_float_singleton, 0, 51),
+       run_test_r0('alc([pi, \'=\', 3.14]) first -> 112 (p)',
+                   test_alc_float_with_atom, 0, 112),
+       run_test_r0('alc([1, 2.5, 3]) pos 2 -> 46 (.)',
+                   test_alc_float_with_int, 0, 46),
+       run_test_r0('alc/3 [1.5, 2.5] / \'+\' pos 3 -> 43',
+                   test_alc3_float_only, 0, 43),
+       run_test_r0('alc/3 [x, 1.5, y] / \',\' first -> 120 (x)',
+                   test_alc3_float_mixed, 0, 120),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Adds Float head support to both `atomic_list_concat/2` and `/3`'s
forward modes. Third arm of the existing atom / int tag dispatch:
when `head_tag == 2` (Float), extract i64 payload, bitcast to double,
and snprintf `%g` via `@.fmt_dbl` (already declared by
`state.ll.mustache` for `format/2`).

### Pass 1 changes (count)
- `alc.c_try_int` / `alc3.c_try_int` now branch to `c_try_float` on
  non-integer (instead of fail).
- New `c_try_float` → `c_float_measure` or fail.
- `c_advance` phi-merges 3 sources for `elem_len`: atom (`c_m_loop`),
  int (`c_int_measure`), float (`c_float_measure`).

### Pass 2 changes (fill)
- `f_try_int` branches to `f_int_write` on int, `f_float_write` on
  float.
- New `f_float_write`: snprintf `%g` directly into output buffer at
  the running offset; returns rendered length.
- alc/2: `f_after` phi-merges 3 paths (atom / int / float) for both
  `off_next` and `next`.
- alc/3: `f_after` phi-merges 3 paths for `off_next`; `idx` and `next`
  loaded once after the join since `f_dispatch` dominates `f_after`
  through all paths.

`%g` formatting gives the standard 6-significant-figure Prolog
default; larger values switch to scientific notation automatically.
Buffer is already sized accurately by pass 1's snprintf-based
measurement.

## Test plan
- [x] 5 new tests:
  - `alc([3.5])` first code → 51 (`'3'`)
  - `alc([pi, '=', 3.14])` first code → 112 (atom-first composition)
  - `alc([1, 2.5, 3])` pos 2 → 46 (decimal point in middle)
  - `alc/3 [1.5, 2.5] / '+'` pos 3 → 43 (sep between floats)
  - `alc/3 [x, 1.5, y] / ','` first → 120 (atom-float-atom with sep)
- [x] All 366 builtin tests pass (was 361, +5)
- [x] Manual llc round-trip clean


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_