### PR TITLE
feat(wam): add representation mode policy

### DIFF
--- a/docs/design/WAM_ITEMS_API_SPECIFICATION.md
+++ b/docs/design/WAM_ITEMS_API_SPECIFICATION.md
@@ -3,7 +3,8 @@
 The concrete shape of the structured-items API we're adding to
 `wam_target.pl`. For *why* each decision, see
 `WAM_ITEMS_API_PHILOSOPHY.md`. For per-target migration plans, see
-the per-target section in §6 below.
+the per-target section in §6 below. For target-level representation mode names,
+see `WAM_REPRESENTATION_MODES.md`.
 
 ## 0. Implementation Status
 

--- a/docs/design/WAM_PYTHON_PARITY_AUDIT.md
+++ b/docs/design/WAM_PYTHON_PARITY_AUDIT.md
@@ -99,6 +99,8 @@ text-first compile pipeline.
 
 Current load-bearing items path:
 
+- WAM representation mode is resolved through `wam_ir_mode/4`; Python defaults
+  to `wam_items_bridge` for interpreter mode and `wam_text` for lowered mode.
 - `plan_python_predicate/3` calls `compile_predicate_to_wam_items/3` for
   internally compiled interpreter-mode predicates and stores `wam_items(items_only,
   Items)` in `pred_plan/4`.
@@ -165,7 +167,7 @@ Completed follow-up:
 ## Verification Commands
 
 Use these checks after touching Python WAM runtime parity. On current `main`,
-`tests/test_wam_python_target.pl` passes 174/174 without choicepoint warnings:
+`tests/test_wam_python_target.pl` passes 177/177 without choicepoint warnings:
 
 ```sh
 swipl -q -g run_tests -t halt tests/test_wam_python_target.pl

--- a/docs/design/WAM_REPRESENTATION_MODES.md
+++ b/docs/design/WAM_REPRESENTATION_MODES.md
@@ -1,0 +1,45 @@
+# WAM Representation Modes
+
+This document names the representation choices between Prolog clause
+compilation and target code generation. These modes describe what representation
+is produced and consumed; they do not by themselves choose whether a target uses
+an interpreter loop, lowered functions, or mixed emission.
+
+## Modes
+
+| Mode | Pipeline | Notes |
+|---|---|---|
+| `wam_text` | Prolog clauses -> WAM text -> target path | Historical default for most WAM targets. |
+| `wam_items_bridge` | Prolog clauses -> WAM text -> shared parser -> WAM items -> target path | Low-risk migration bridge; still pays the text round trip. |
+| `wam_items_native` | Prolog clauses -> WAM items -> target path | Skips WAM text, but still executes WAM represented in the target language. |
+| `direct_target` | Prolog clauses -> target-native code | Alias for the existing non-WAM target path where a target supports it. |
+
+`wam_items_native` does not skip WAM. It skips only the serialized WAM-text
+form. The target still receives a WAM instruction stream, usually materialized
+as target-language data and executed by that target's WAM runtime. This can be
+more optimizable than idiomatic target code because the instruction vocabulary is
+compact, regular, and easy to rewrite or partially lower through kernels/FFI.
+
+`direct_target` is the name for the existing non-WAM generation path. It is a
+separate backend strategy, not a WAM representation mode in the strict sense.
+
+## Resolution
+
+Targets should resolve representation policy through
+`wam_ir_mode:wam_ir_mode/4`:
+
+```prolog
+wam_ir_mode(Target, EmitMode, Options, Mode).
+```
+
+An explicit `wam_ir(Mode)` option overrides the target default. Without an
+override, defaults are per target and per emit mode. Current defaults are
+conservative:
+
+- Python interpreter mode: `wam_items_bridge`
+- Python lowered mode: `wam_text`
+- Lua/R interpreter mode: `wam_items_bridge` as the intended migration default
+- Unknown WAM targets: `wam_text`
+
+WAM-specific targets may reject `direct_target`; callers should use the ordinary
+non-WAM target when they want direct target-native code.

--- a/src/unifyweaver/targets/wam_ir_mode.pl
+++ b/src/unifyweaver/targets/wam_ir_mode.pl
@@ -1,0 +1,69 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% WAM representation-mode policy shared by WAM targets.
+
+:- module(wam_ir_mode, [
+    wam_ir_mode/4,             % +Target, +EmitMode, +Options, -Mode
+    wam_ir_mode_supported/1,   % ?Mode
+    wam_ir_mode_uses_wam/1,    % +Mode
+    wam_ir_mode_skips_text/1   % +Mode
+]).
+
+:- use_module(library(option)).
+
+%% wam_ir_mode_supported(?Mode) is semidet.
+%
+%  Supported representation modes:
+%
+%    wam_text          Prolog clauses -> WAM text -> target path
+%    wam_items_bridge  Prolog clauses -> WAM text -> WAM items -> target path
+%    wam_items_native  Prolog clauses -> WAM items -> target path
+%    direct_target     Existing non-WAM target-native codegen path
+%
+%  `direct_target` is an alias for a target's non-WAM emitter. It is not a WAM
+%  path and WAM-specific targets may reject it even though the shared resolver
+%  recognizes the name.
+wam_ir_mode_supported(wam_text).
+wam_ir_mode_supported(wam_items_bridge).
+wam_ir_mode_supported(wam_items_native).
+wam_ir_mode_supported(direct_target).
+
+%% wam_ir_mode(+Target, +EmitMode, +Options, -Mode) is det.
+%
+%  Resolve the WAM representation mode for Target and EmitMode. Explicit
+%  `wam_ir(Mode)` options win; otherwise the per-target default is used.
+wam_ir_mode(Target, EmitMode, Options, Mode) :-
+    (   option(wam_ir(Explicit), Options)
+    ->  validate_wam_ir_mode(Explicit, Mode)
+    ;   wam_ir_mode_default(Target, EmitMode, Mode)
+    ).
+
+validate_wam_ir_mode(Mode, Mode) :-
+    wam_ir_mode_supported(Mode),
+    !.
+validate_wam_ir_mode(Other, _) :-
+    throw(error(domain_error(wam_ir_mode, Other), wam_ir_mode/4)).
+
+%% wam_ir_mode_uses_wam(+Mode) is semidet.
+wam_ir_mode_uses_wam(wam_text).
+wam_ir_mode_uses_wam(wam_items_bridge).
+wam_ir_mode_uses_wam(wam_items_native).
+
+%% wam_ir_mode_skips_text(+Mode) is semidet.
+wam_ir_mode_skips_text(wam_items_native).
+wam_ir_mode_skips_text(direct_target).
+
+% Conservative current defaults. Interpreter-mode Python already consumes the
+% common items bridge; lowered Python still needs WAM text for its analyzer and
+% lowered emitter. Lua/R are marked as likely bridge consumers for their
+% interpreter paths, but their target code has not been migrated yet.
+wam_ir_mode_default(wam_python, interpreter, wam_items_bridge) :- !.
+wam_ir_mode_default(wam_python, lowered, wam_text) :- !.
+wam_ir_mode_default(wam_python, functions, wam_text) :- !.
+wam_ir_mode_default(wam_python, mixed(_), wam_text) :- !.
+wam_ir_mode_default(wam_lua, interpreter, wam_items_bridge) :- !.
+wam_ir_mode_default(wam_r, interpreter, wam_items_bridge) :- !.
+wam_ir_mode_default(_, direct_target, direct_target) :- !.
+wam_ir_mode_default(_, _, wam_text).

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -51,6 +51,7 @@
 	compile_predicate_to_wam_text/3,
 	compile_predicate_to_wam_items/3
 ]).
+:- use_module('../targets/wam_ir_mode', [wam_ir_mode/4]).
 :- use_module('../core/iso_errors',
               [ iso_errors_resolve_options/2,
                 iso_errors_load_config/2,
@@ -2081,11 +2082,28 @@ plan_python_predicate(Options, Pred/Arity, pred_plan(Pred, Arity, Wam, Kind)) :-
 	).
 
 python_plan_compile_predicate(Options, PredIndicator, Wam) :-
-	(   option(emit_mode(lowered), Options)
+	python_wam_emit_ir_mode(Options, IrMode),
+	(   IrMode = wam_text
 	->  compile_predicate_to_wam_text(PredIndicator, [], WamText),
 	    python_wam_text_plan(WamText, Wam)
-	;   compile_predicate_to_wam_items(PredIndicator, [], Items),
+	;   IrMode = wam_items_bridge
+	->  compile_predicate_to_wam_items(PredIndicator, [], Items),
 	    python_wam_items_plan(Items, Wam)
+	).
+
+python_wam_emit_ir_mode(Options, IrMode) :-
+	(   option(emit_mode(lowered), Options)
+	->  EmitMode = lowered
+	;   EmitMode = interpreter
+	),
+	wam_ir_mode(wam_python, EmitMode, Options, IrMode),
+	(   IrMode == direct_target
+	->  throw(error(domain_error(wam_python_ir_mode, direct_target),
+	                python_plan_compile_predicate/3))
+	;   IrMode == wam_items_native
+	->  throw(error(existence_error(wam_ir_mode, wam_items_native),
+	                python_plan_compile_predicate/3))
+	;   true
 	).
 
 python_wam_text_plan(WamText, wam_items(text(WamText), Items)) :-

--- a/tests/test_wam_ir_mode.pl
+++ b/tests/test_wam_ir_mode.pl
@@ -1,0 +1,42 @@
+:- encoding(utf8).
+
+:- use_module('../src/unifyweaver/targets/wam_ir_mode').
+:- use_module(library(plunit)).
+
+:- begin_tests(wam_ir_mode).
+
+test(python_interpreter_defaults_to_items_bridge) :-
+    wam_ir_mode(wam_python, interpreter, [], Mode),
+    assertion(Mode == wam_items_bridge).
+
+test(python_lowered_defaults_to_text) :-
+    wam_ir_mode(wam_python, lowered, [], Mode),
+    assertion(Mode == wam_text).
+
+test(lua_and_r_interpreter_defaults_to_items_bridge) :-
+    wam_ir_mode(wam_lua, interpreter, [], LuaMode),
+    wam_ir_mode(wam_r, interpreter, [], RMode),
+    assertion(LuaMode == wam_items_bridge),
+    assertion(RMode == wam_items_bridge).
+
+test(unknown_target_defaults_to_text) :-
+    wam_ir_mode(wam_unknown, interpreter, [], Mode),
+    assertion(Mode == wam_text).
+
+test(explicit_option_overrides_default) :-
+    wam_ir_mode(wam_python, interpreter, [wam_ir(wam_text)], Mode),
+    assertion(Mode == wam_text).
+
+test(rejects_unknown_mode, [throws(error(domain_error(wam_ir_mode, nonsense), _))]) :-
+    wam_ir_mode(wam_python, interpreter, [wam_ir(nonsense)], _).
+
+test(mode_predicates_classify_wam_and_text_skip) :-
+    assertion(wam_ir_mode_uses_wam(wam_text)),
+    assertion(wam_ir_mode_uses_wam(wam_items_bridge)),
+    assertion(wam_ir_mode_uses_wam(wam_items_native)),
+    assertion(\+ wam_ir_mode_uses_wam(direct_target)),
+    assertion(wam_ir_mode_skips_text(wam_items_native)),
+    assertion(wam_ir_mode_skips_text(direct_target)),
+    assertion(\+ wam_ir_mode_skips_text(wam_items_bridge)).
+
+:- end_tests(wam_ir_mode).

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -324,7 +324,8 @@ test(python_planning_uses_common_items_api) :-
 test(python_lowered_mode_keeps_text_plan) :-
     once(source_file(wam_python_target:compile_wam_predicate_to_python(_, _, _, _), Path)),
     read_file_to_string(Path, Content, []),
-    sub_string(Content, _, _, _, "option(emit_mode(lowered), Options)"),
+    sub_string(Content, _, _, _, "python_wam_emit_ir_mode(Options, IrMode)"),
+    sub_string(Content, _, _, _, "wam_ir_mode(wam_python, EmitMode, Options, IrMode)"),
     sub_string(Content, _, _, _, "compile_predicate_to_wam_text(PredIndicator, [], WamText)"),
     sub_string(Content, _, _, _, "wam_plan_text(Wam, WamText)"),
     !.
@@ -387,6 +388,24 @@ test(compile_all_generated_predicate_uses_items_api) :-
     sub_string(Code, _, _, _, 'raw_program["py_items_api_demo/0"] = ('),
     sub_string(Code, _, _, _, '("proceed",)'),
     !.
+
+test(compile_all_generated_predicate_allows_text_ir_override) :-
+    wam_python_target:compile_all_predicates([user:py_items_api_demo/0],
+        [wam_ir(wam_text)], Code),
+    sub_string(Code, _, _, _, 'def pred_py_items_api_demo_0(raw_program):'),
+    sub_string(Code, _, _, _, 'raw_program["py_items_api_demo/0"] = ('),
+    sub_string(Code, _, _, _, '("proceed",)'),
+    !.
+
+test(compile_all_generated_predicate_rejects_direct_target_ir,
+     [throws(error(domain_error(wam_python_ir_mode, direct_target), _))]) :-
+    wam_python_target:compile_all_predicates([user:py_items_api_demo/0],
+        [wam_ir(direct_target)], _).
+
+test(compile_all_generated_predicate_rejects_native_items_until_available,
+     [throws(error(existence_error(wam_ir_mode, wam_items_native), _))]) :-
+    wam_python_target:compile_all_predicates([user:py_items_api_demo/0],
+        [wam_ir(wam_items_native)], _).
 :- end_tests(wam_python_items_mode_audit).
 
 % ============================================================================


### PR DESCRIPTION
## Summary

- adds shared `wam_ir_mode/4` policy for target WAM representation choices
- defines the representation modes `wam_text`, `wam_items_bridge`, `wam_items_native`, and `direct_target`
- documents that `wam_items_native` skips WAM text but still executes WAM represented in the target language
- wires Python WAM planning through the shared resolver
- keeps Python interpreter mode defaulting to `wam_items_bridge` and lowered mode defaulting to `wam_text`
- adds tests for resolver defaults, overrides, and Python rejection of unsupported `direct_target` / `wam_items_native` modes

## Verification

- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
- `swipl -q -g "run_tests(wam_ir_mode),run_tests(wam_text_parser),run_tests(wam_python_items_mode_audit),run_tests(wam_python_builtin_e2e)" -t halt tests/test_wam_ir_mode.pl tests/test_wam_text_parser.pl tests/test_wam_python_target.pl`
- `swipl --stack_limit=2g -q -g "run_tests" -t halt tests/test_wam_ir_mode.pl tests/test_wam_text_parser.pl tests/test_wam_python_target.pl`
- `git diff --check`
