### PR TITLE
Support WAM-C native kernel float results

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -1,24 +1,22 @@
 # WAM C Target - Status And Next Steps
 
-Status date: 2026-05-28
+Status date: 2026-05-29
 
-Base verified locally:
+Latest branch verification:
 
-- `main` at `9f805888` (`Merge pull request #2566 from s243a/feat/wam-c-direct-io-csr`)
+- `feat/wam-c-native-kernel-float-output` based on `main` at `7e4b70d5`
+  (`Merge pull request #2582 from s243a/feat/wam-haskell-iso-items-rewrite`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
-- `python3 tests/test_benchmark_target_matrix.py`
-- `python3 tests/test_wam_c_lowered_helper_scale_regression.py`
 - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/test_wam_c_lowered_helper_scale_regression.py`
-- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev,10x --target-sets c-wam-lowered-helper --repetitions 1 --baseline-target c-wam-lowered-helper-interpreted`
-- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 1 --baseline-target prolog-accumulated`
+- `swipl -q -t halt -s examples/benchmark/generate_wam_c_effective_distance_benchmark.pl`
 - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10x --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 1 --baseline-target prolog-accumulated --run-timeout-seconds 180`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-accumulated-runtime-cost`
+- `feat/wam-c-native-kernel-float-output`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -78,9 +76,10 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | `transitive_distance3` native kernel | Done | C shared-kernel detector accepts `transitive_distance3`, emits detected setup, registers a native arity-3 foreign handler, and covers direct plus detected-project executable smokes |
 | `transitive_parent_distance4` native kernel | Done | C shared-kernel detector accepts `transitive_parent_distance4`, emits detected setup, registers a native arity-4 foreign handler, and covers direct plus detected-project executable smokes |
 | `transitive_step_parent_distance5` native kernel | Done | C shared-kernel detector accepts `transitive_step_parent_distance5`, emits detected setup, registers a native arity-5 foreign handler, and covers direct plus detected-project executable smokes |
-| `weighted_shortest_path3` native kernel | Done | C shared-kernel detector accepts `weighted_shortest_path3`, emits detected setup, registers a native arity-3 foreign handler, and covers direct plus detected-project executable smokes over integer weighted edges |
-| `astar_shortest_path4` native kernel | Done | C shared-kernel detector accepts `astar_shortest_path4`, emits detected setup, registers a native arity-4 foreign handler, and covers direct plus detected-project executable smokes over integer weighted and direct-distance edges |
-| Accumulated runtime edge-index fix | Done | Lazy child indexes for `WamState` and `WamFactSource` remove repeated full-edge scans; `10x` accumulated C targets now run around 0.066-0.069s with output parity versus Prolog at 0.204s |
+| `weighted_shortest_path3` native kernel | Done | C shared-kernel detector accepts `weighted_shortest_path3`, emits detected setup, registers a native arity-3 foreign handler, and covers direct plus detected-project executable smokes over weighted edges |
+| `astar_shortest_path4` native kernel | Done | C shared-kernel detector accepts `astar_shortest_path4`, emits detected setup, registers a native arity-4 foreign handler, and covers direct plus detected-project executable smokes over weighted and direct-distance edges |
+| Accumulated runtime edge-index fix | Done | Lazy child indexes for `WamState` and `WamFactSource` remove repeated full-edge scans; `10x` accumulated C targets now run around 0.065-0.071s with output parity versus Prolog at 0.202s |
+| Native weighted-kernel float output | Done | C runtime has `VAL_FLOAT`, numeric unification, double weighted/direct edge storage, and executable weighted/A* smokes for fractional 1.5 results while preserving exact-integer outputs as `VAL_INT` |
 
 ## Current C Target Baseline
 
@@ -109,7 +108,8 @@ The C target is now a credible small WAM backend:
   `transitive_distance3`, `transitive_parent_distance4`, and
   `transitive_step_parent_distance5` handlers over an in-memory edge table,
   plus `weighted_shortest_path3` and `astar_shortest_path4` over in-memory
-  integer weighted edges.
+  weighted edges with exact-integer results kept as `VAL_INT` and fractional
+  results returned as `VAL_FLOAT`.
 - Supports loading category-parent facts from TSV through a small
   `WamFactSource` interface.
 - Supports collecting all integer hop results for native `category_ancestor/4`
@@ -154,7 +154,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
 | Negation / control builtins | Partial | Broader | Broader | C likely needs explicit tests for `\+/1`, cut interactions, and if-then-else lowering. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
-| Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, integer-weighted shortest path, and integer A* shortest path; remaining parity gaps are broader integration details. |
+| Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
 | Shared kernel detector integration | Partial/Done | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`, `transitive_closure2`, `transitive_distance3`, `transitive_parent_distance4`, `transitive_step_parent_distance5`, `weighted_shortest_path3`, and `astar_shortest_path4`; Haskell and Rust still have broader wrapper/fact-layout integration. |
 | Lowered/native helper functions | Partial/Done | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, comparison-filter helpers, rejection metadata, repeated-variable filter hardening, empty-result rejection metadata, and projected body-call helper expansion. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
@@ -166,28 +166,29 @@ missing important target features; `Missing` = no comparable C path yet.
 
 ## Recommended Next Branches
 
-### 1. `feat/wam-c-native-kernel-float-output`
+### Completed: `feat/wam-c-native-kernel-float-output`
 
 Goal: close the output-type parity gap for weighted/A* native kernels by adding
 a C runtime representation for floating-point results.
 
-Scope:
+Evidence:
 
-- Add a `VAL_FLOAT` or equivalent runtime value representation.
-- Extend foreign-handler unification and smoke assertions for weighted/A*
-  results that are not exact integers.
-- Keep benchmark integration separate unless the value representation itself
-  proves stable.
+- `VAL_FLOAT`, `val_float`, and `val_number_from_double` are available in
+  the C runtime.
+- Weighted and direct-distance edges store `double` weights.
+- Weighted shortest path and A* emit exact integers as `VAL_INT` and fractional
+  weights as `VAL_FLOAT`.
+- Executable smokes cover fractional weighted and A* results.
 
 Reason:
 
 - The accumulated effective-distance runtime blocker is resolved at `10x`; the
   dominant cost was repeated full-edge scans in ancestor traversal, not WAM
   dispatch or native-kernel call overhead.
-- Weighted/A* native kernels currently cover integer results, while Haskell and
-  Rust have broader numeric-result surfaces.
+- Weighted/A* native kernels previously covered only integer results, while
+  Haskell and Rust had broader numeric-result surfaces.
 
-### 2. `investigate/wam-c-larger-artifact-layouts`
+### 1. `investigate/wam-c-larger-artifact-layouts`
 
 Goal: measure whether the newer parent-only LMDB and reverse CSR artifact
 layouts remain the right defaults at larger category scales.
@@ -393,7 +394,8 @@ After hash-bucket row dispatch but before compact row tables:
 
 ## Suggested Immediate Next Step
 
-Proceed with `feat/wam-c-native-kernel-float-output` unless the next round of
-work is explicitly benchmark-scale focused. The accumulated runtime
+Proceed with `investigate/wam-c-larger-artifact-layouts` unless the next round
+of work is explicitly generated-program parity focused. The accumulated runtime
 investigation found and fixed the dominant `10x` cost: repeated full-edge scans
-inside recursive ancestor traversal.
+inside recursive ancestor traversal, and the weighted/A* native kernels now
+preserve fractional results.

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 #include <assert.h>
 #include <stdint.h>
+#include <limits.h>
 #include <sys/types.h>
 #ifdef WAM_C_ENABLE_LMDB
 #include <lmdb.h>
@@ -27,7 +28,7 @@ typedef bool (*WamForeignHandler)(WamState *state, const char *pred, int arity);
 
 /* Value tag enum */
 typedef enum {
-    VAL_ATOM, VAL_INT, VAL_REF, VAL_STR, VAL_UNBOUND, VAL_LIST
+    VAL_ATOM, VAL_INT, VAL_FLOAT, VAL_REF, VAL_STR, VAL_UNBOUND, VAL_LIST
 } WamValueTag;
 
 typedef struct {
@@ -35,6 +36,7 @@ typedef struct {
     union {
         const char *atom;
         int integer;
+        double floating;
         int ref_addr;
         const char *str_functor;
         const char *unbound_name;
@@ -117,7 +119,7 @@ typedef struct {
 typedef struct {
     const char *source;
     const char *target;
-    int weight;
+    double weight;
 } WeightedEdge;
 
 typedef struct {
@@ -318,8 +320,8 @@ bool wam_execute_builtin(WamState *state, const char *op, int arity);
 bool wam_execute_foreign_predicate(WamState *state, const char *pred, int arity);
 void wam_register_category_parent(WamState *state, const char *child, const char *parent);
 void wam_register_transitive_edge(WamState *state, const char *child, const char *parent);
-void wam_register_weighted_edge(WamState *state, const char *source, const char *target, int weight);
-void wam_register_direct_distance_edge(WamState *state, const char *source, const char *target, int distance);
+void wam_register_weighted_edge(WamState *state, const char *source, const char *target, double weight);
+void wam_register_direct_distance_edge(WamState *state, const char *source, const char *target, double distance);
 void wam_register_category_ancestor_kernel(WamState *state, const char *pred, int max_depth);
 void wam_register_bidirectional_ancestor_kernel(WamState *state, const char *pred,
                                                 int max_depth,
@@ -402,6 +404,15 @@ static inline WamValue val_atom(const char *s) {
 }
 static inline WamValue val_int(int n) {
     WamValue v; v.tag = VAL_INT; v.data.integer = n; return v;
+}
+static inline WamValue val_float(double n) {
+    WamValue v; v.tag = VAL_FLOAT; v.data.floating = n; return v;
+}
+static inline WamValue val_number_from_double(double n) {
+    if (n >= (double)INT_MIN && n <= (double)INT_MAX && n == (double)((int)n)) {
+        return val_int((int)n);
+    }
+    return val_float(n);
 }
 static inline WamValue val_unbound(const char *name) {
     WamValue v; v.tag = VAL_UNBOUND; v.data.unbound_name = name; return v;
@@ -536,6 +547,7 @@ static inline bool val_is_unbound(WamValue v) {
 static inline bool val_equal(WamValue v1, WamValue v2) {
     if (v1.tag != v2.tag) return false;
     if (v1.tag == VAL_INT) return v1.data.integer == v2.data.integer;
+    if (v1.tag == VAL_FLOAT) return v1.data.floating == v2.data.floating;
     if (v1.tag == VAL_ATOM) return strcmp(v1.data.atom, v2.data.atom) == 0;
     // simplify for demonstration
     return false;
@@ -596,6 +608,8 @@ static inline bool wam_unify(WamState *state, WamValue *v1, WamValue *v2) {
         
         if (d1->tag == VAL_INT) {
             if (d1->data.integer != d2->data.integer) return false;
+        } else if (d1->tag == VAL_FLOAT) {
+            if (d1->data.floating != d2->data.floating) return false;
         } else if (d1->tag == VAL_ATOM) {
             if (strcmp(d1->data.atom, d2->data.atom) != 0) return false;
         } else if (d1->tag == VAL_LIST) {

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -893,7 +893,11 @@ c_static_value_literal(Atom, Lit) :-
     format(atom(Lit), '{ .tag = VAL_ATOM, .data.atom = "~w" }', [Atom]).
 c_static_value_literal(Int, Lit) :-
     integer(Int),
+    !,
     format(atom(Lit), '{ .tag = VAL_INT, .data.integer = ~w }', [Int]).
+c_static_value_literal(Float, Lit) :-
+    float(Float),
+    format(atom(Lit), '{ .tag = VAL_FLOAT, .data.floating = ~16g }', [Float]).
 
 lowered_fact_bucket_arrays(Symbol, Rows, ArraysCode, CasesCode, BucketCount) :-
     findall(First, member([First|_], Rows), FirstValues0),
@@ -1635,14 +1639,14 @@ wam_instruction_to_c_literal(Instr, _, Code) :- wam_instruction_to_c_literal(Ins
 
 c_value_literal(Str, Lit) :-
     string(Str),
-    (   number_string(Int, Str),
-        integer(Int)
-    ->  c_value_literal(Int, Lit)
+    (   number_string(Number, Str)
+    ->  c_value_literal(Number, Lit)
     ;   atom_string(Atom, Str),
         c_value_literal(Atom, Lit)
     ).
 c_value_literal(Atom, Lit) :- atom(Atom), format(atom(Lit), 'val_atom("~w")', [Atom]).
-c_value_literal(Int, Lit) :- integer(Int), format(atom(Lit), 'val_int(~w)', [Int]).
+c_value_literal(Int, Lit) :- integer(Int), !, format(atom(Lit), 'val_int(~w)', [Int]).
+c_value_literal(Float, Lit) :- float(Float), format(atom(Lit), 'val_float(~16g)', [Float]).
 
 c_reg_index(RegStr, IsY, Idx) :-
     string(RegStr),
@@ -2446,6 +2450,11 @@ static bool wam_term_functor(WamState *state, WamValue term,
         *arity_out = 0;
         return true;
     }
+    if (cell->tag == VAL_FLOAT) {
+        *name_out = *cell;
+        *arity_out = 0;
+        return true;
+    }
     if (cell->tag == VAL_LIST) {
         *name_out = val_atom(".");
         *arity_out = 2;
@@ -2585,8 +2594,8 @@ bool wam_execute_builtin(WamState *state, const char *op, int arity) {
         WamValue *a1 = wam_deref_ptr(state, &state->A[0]);
         if (strcmp(op, "atom/1") == 0) return a1->tag == VAL_ATOM;
         if (strcmp(op, "integer/1") == 0) return a1->tag == VAL_INT;
-        if (strcmp(op, "number/1") == 0) return a1->tag == VAL_INT;
-        if (strcmp(op, "float/1") == 0) return false;
+        if (strcmp(op, "number/1") == 0) return a1->tag == VAL_INT || a1->tag == VAL_FLOAT;
+        if (strcmp(op, "float/1") == 0) return a1->tag == VAL_FLOAT;
         if (strcmp(op, "var/1") == 0) return val_is_unbound(*a1);
         if (strcmp(op, "nonvar/1") == 0) return !val_is_unbound(*a1);
         if (strcmp(op, "compound/1") == 0) return a1->tag == VAL_STR || a1->tag == VAL_LIST;
@@ -2615,7 +2624,7 @@ bool wam_execute_builtin(WamState *state, const char *op, int arity) {
         WamValue *arity_cell = wam_deref_ptr(state, &state->A[2]);
         if (arity_cell->tag != VAL_INT || arity_cell->data.integer < 0) return false;
         if (arity_cell->data.integer == 0) {
-            if (name->tag != VAL_ATOM && name->tag != VAL_INT) return false;
+            if (name->tag != VAL_ATOM && name->tag != VAL_INT && name->tag != VAL_FLOAT) return false;
             return wam_unify(state, &state->A[0], name);
         }
         if (name->tag != VAL_ATOM) return false;
@@ -2674,7 +2683,7 @@ void wam_register_transitive_edge(WamState *state, const char *child, const char
     wam_register_category_parent(state, child, parent);
 }
 
-void wam_register_weighted_edge(WamState *state, const char *source, const char *target, int weight) {
+void wam_register_weighted_edge(WamState *state, const char *source, const char *target, double weight) {
     if (state->weighted_edge_count >= state->weighted_edge_cap) {
         state->weighted_edge_cap = state->weighted_edge_cap ? state->weighted_edge_cap * 2 : WAM_INITIAL_CAP;
         state->weighted_edges = realloc(state->weighted_edges, sizeof(WeightedEdge) * state->weighted_edge_cap);
@@ -2685,7 +2694,7 @@ void wam_register_weighted_edge(WamState *state, const char *source, const char 
     state->weighted_edge_count++;
 }
 
-void wam_register_direct_distance_edge(WamState *state, const char *source, const char *target, int distance) {
+void wam_register_direct_distance_edge(WamState *state, const char *source, const char *target, double distance) {
     if (state->direct_distance_edge_count >= state->direct_distance_edge_cap) {
         state->direct_distance_edge_cap = state->direct_distance_edge_cap ? state->direct_distance_edge_cap * 2 : WAM_INITIAL_CAP;
         state->direct_distance_edges = realloc(state->direct_distance_edges, sizeof(WeightedEdge) * state->direct_distance_edge_cap);
@@ -4100,12 +4109,12 @@ static bool wam_weighted_shortest_path_dijkstra(WamState *state,
                                                 const char *start,
                                                 const char *target,
                                                 const char **target_out,
-                                                int *weight_out) {
+                                                double *weight_out) {
     const char *nodes[256];
-    int distances[256];
+    double distances[256];
     bool done[256];
     int node_count = 0;
-    const int inf = 1073741823;
+    const double inf = 1.0e100;
 
     nodes[node_count] = start;
     distances[node_count] = 0;
@@ -4114,7 +4123,7 @@ static bool wam_weighted_shortest_path_dijkstra(WamState *state,
 
     while (true) {
         int best_idx = -1;
-        int best_distance = inf;
+        double best_distance = inf;
         for (int i = 0; i < node_count; i++) {
             if (!done[i] && distances[i] < best_distance) {
                 best_idx = i;
@@ -4159,7 +4168,7 @@ static bool wam_weighted_shortest_path_dijkstra(WamState *state,
 
     if (!target) {
         int best_idx = -1;
-        int best_distance = inf;
+        double best_distance = inf;
         for (int i = 0; i < node_count; i++) {
             if (strcmp(nodes[i], start) != 0 && distances[i] < best_distance) {
                 best_idx = i;
@@ -4191,19 +4200,19 @@ bool wam_weighted_shortest_path_handler(WamState *state, const char *pred, int a
     }
 
     const char *result_target = NULL;
-    int result_weight = 0;
+    double result_weight = 0.0;
     if (!wam_weighted_shortest_path_dijkstra(state, start, target,
                                              &result_target, &result_weight)) {
         return false;
     }
 
     WamValue target_value = val_atom(result_target);
-    WamValue weight_value = val_int(result_weight);
+    WamValue weight_value = val_number_from_double(result_weight);
     return wam_unify(state, &state->A[1], &target_value) &&
            wam_unify(state, &state->A[2], &weight_value);
 }
 
-static int wam_astar_heuristic(WamState *state, const char *node, const char *target) {
+static double wam_astar_heuristic(WamState *state, const char *node, const char *target) {
     for (int i = 0; i < state->direct_distance_edge_count; i++) {
         WeightedEdge *edge = &state->direct_distance_edges[i];
         if (strcmp(edge->source, node) == 0 && strcmp(edge->target, target) == 0) {
@@ -4217,12 +4226,12 @@ static bool wam_astar_shortest_path_search(WamState *state,
                                            const char *start,
                                            const char *target,
                                            int dimensionality,
-                                           int *weight_out) {
+                                           double *weight_out) {
     const char *nodes[256];
-    int distances[256];
+    double distances[256];
     bool done[256];
     int node_count = 0;
-    const int inf = 1073741823;
+    const double inf = 1.0e100;
     (void)dimensionality;
 
     nodes[node_count] = start;
@@ -4232,12 +4241,12 @@ static bool wam_astar_shortest_path_search(WamState *state,
 
     while (true) {
         int best_idx = -1;
-        int best_score = inf;
-        int best_distance = inf;
+        double best_score = inf;
+        double best_distance = inf;
         for (int i = 0; i < node_count; i++) {
             if (done[i]) continue;
-            int heuristic = wam_astar_heuristic(state, nodes[i], target);
-            int score = distances[i] <= inf - heuristic ? distances[i] + heuristic : inf;
+            double heuristic = wam_astar_heuristic(state, nodes[i], target);
+            double score = distances[i] <= inf - heuristic ? distances[i] + heuristic : inf;
             if (score < best_score || (score == best_score && distances[i] < best_distance)) {
                 best_idx = i;
                 best_score = score;
@@ -4293,14 +4302,14 @@ bool wam_astar_shortest_path_handler(WamState *state, const char *pred, int arit
     WamValue *dim_cell = wam_deref_ptr(state, &state->A[2]);
     if (dim_cell->tag != VAL_INT) return false;
 
-    int result_weight = 0;
+    double result_weight = 0.0;
     if (!wam_astar_shortest_path_search(state, start, target,
                                         dim_cell->data.integer,
                                         &result_weight)) {
         return false;
     }
 
-    WamValue weight_value = val_int(result_weight);
+    WamValue weight_value = val_number_from_double(result_weight);
     return wam_unify(state, &state->A[3], &weight_value);
 }
 '.

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -3679,6 +3679,8 @@ int main(void) {
     wam_register_weighted_edge(&state, "tom", "eve", 1);
     wam_register_weighted_edge(&state, "eve", "ann", 1);
     wam_register_weighted_edge(&state, "bob", "ann", 1);
+    wam_register_weighted_edge(&state, "flo", "mid", 0.5);
+    wam_register_weighted_edge(&state, "mid", "fin", 1.0);
     wam_register_weighted_shortest_path_kernel(&state, "weighted_path/3");
 
     WamValue shortest_args[3] = {
@@ -3717,6 +3719,29 @@ int main(void) {
         return 30;
     }
 
+    WamValue float_args[3] = {
+        val_atom("flo"),
+        val_atom("fin"),
+        val_unbound("Weight")
+    };
+    int float_rc = wam_run_predicate(&state, "weighted_path/3", float_args, 3);
+    if (float_rc != 0 || state.P != WAM_HALT ||
+        state.A[2].tag != VAL_FLOAT || state.A[2].data.floating != 1.5) {
+        wam_free_state(&state);
+        return 35;
+    }
+
+    WamValue float_direct_args[3] = {
+        val_atom("flo"),
+        val_atom("fin"),
+        val_float(1.5)
+    };
+    int float_direct_rc = wam_run_predicate(&state, "weighted_path/3", float_direct_args, 3);
+    if (float_direct_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 36;
+    }
+
     WamValue fail_args[3] = {
         val_atom("ann"),
         val_atom("tom"),
@@ -3743,9 +3768,12 @@ static void register_astar_edges(WamState *state) {
     wam_register_weighted_edge(state, "tom", "eve", 1);
     wam_register_weighted_edge(state, "eve", "ann", 1);
     wam_register_weighted_edge(state, "bob", "ann", 1);
+    wam_register_weighted_edge(state, "flo", "mid", 0.5);
+    wam_register_weighted_edge(state, "mid", "fin", 1.0);
     wam_register_direct_distance_edge(state, "tom", "ann", 2);
     wam_register_direct_distance_edge(state, "eve", "ann", 1);
     wam_register_direct_distance_edge(state, "bob", "ann", 1);
+    wam_register_direct_distance_edge(state, "flo", "fin", 1.5);
 }
 
 int main(void) {
@@ -3778,6 +3806,19 @@ int main(void) {
     if (direct_rc != 0 || state.P != WAM_HALT) {
         wam_free_state(&state);
         return 20;
+    }
+
+    WamValue float_args[4] = {
+        val_atom("flo"),
+        val_atom("fin"),
+        val_int(5),
+        val_unbound("Weight")
+    };
+    int float_rc = wam_run_predicate(&state, "astar_path/4", float_args, 4);
+    if (float_rc != 0 || state.P != WAM_HALT ||
+        state.A[3].tag != VAL_FLOAT || state.A[3].data.floating != 1.5) {
+        wam_free_state(&state);
+        return 25;
     }
 
     WamValue bad_dim_args[4] = {


### PR DESCRIPTION
  ## Summary

  - Adds `VAL_FLOAT` support to the WAM-C runtime.
  - Stores weighted and direct-distance kernel edges as `double`.
  - Updates weighted shortest path and A* native kernels to return exact integer results as `VAL_INT` and fractional
  results as `VAL_FLOAT`.
  - Adds executable smoke coverage for fractional `1.5` weighted/A* results.
  - Updates `WAM_C_TARGET_NEXT_STEPS.md` to mark this branch complete and identify larger artifact-layout measurement as
  the next recommended WAM-C branch.

  ## Verification

  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
  - `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
  - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/
  benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/
  test_wam_c_lowered_helper_scale_regression.py`
  - `swipl -q -t halt -s examples/benchmark/generate_wam_c_effective_distance_benchmark.pl`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10x --targets prolog-accumulated,c-wam-
  accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 1
  --baseline-target prolog-accumulated --run-timeout-seconds 180`
  - `git diff --check`