### PR TITLE
LLVM WAM: compare/3 for Integer / Float / Atom (M59)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3454,6 +3454,7 @@ entry:
     i32 73, label %builtin_atomic_list_concat
     i32 74, label %builtin_atomic_list_concat3
     i32 75, label %builtin_char_type
+    i32 76, label %builtin_compare
   ]
 
 builtin_is:
@@ -8380,6 +8381,110 @@ ctp.do_newline:
   %ctp.n_any = or i1 %ctp.n_lf, %ctp.n_cr
   ret i1 %ctp.n_any
 
+builtin_compare:
+  ; M59: compare(?Order, @T1, @T2). Order is bound to ''<'', ''='', or ''>''
+  ; per the standard order of terms. Supported: Integer, Float, Atom.
+  ; Compound term comparison is deferred -- fails for now.
+  ; Cross-category order: Number < Atom < Compound (matches ISO).
+  %cmp.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %cmp.a3 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 2)
+  %cmp.t2 = extractvalue %Value %cmp.a2, 0
+  %cmp.t3 = extractvalue %Value %cmp.a3, 0
+  ; Map tag (0=Atom, 1=Integer, 2=Float, 3=Compound) to category
+  ; (0=Number, 1=Atom, 2=Compound). Numbers come first, atoms middle,
+  ; compounds last. Unknown tags fall to category 2 which mostly
+  ; means ``unsupported'' here.
+  %cmp.t2_is_atom = icmp eq i32 %cmp.t2, 0
+  %cmp.t2_is_cmp = icmp eq i32 %cmp.t2, 3
+  %cmp.cat2_mid = select i1 %cmp.t2_is_cmp, i32 2, i32 0
+  %cmp.cat2 = select i1 %cmp.t2_is_atom, i32 1, i32 %cmp.cat2_mid
+  %cmp.t3_is_atom = icmp eq i32 %cmp.t3, 0
+  %cmp.t3_is_cmp = icmp eq i32 %cmp.t3, 3
+  %cmp.cat3_mid = select i1 %cmp.t3_is_cmp, i32 2, i32 0
+  %cmp.cat3 = select i1 %cmp.t3_is_atom, i32 1, i32 %cmp.cat3_mid
+  ; Look up the three result atoms via the char-to-atom table (M26).
+  %cmp.lt_id = call i64 @wam_char_to_atom(i64 60)   ; ''<''
+  %cmp.eq_id = call i64 @wam_char_to_atom(i64 61)   ; ''=''
+  %cmp.gt_id = call i64 @wam_char_to_atom(i64 62)   ; ''>''
+  %cmp.cat_eq = icmp eq i32 %cmp.cat2, %cmp.cat3
+  br i1 %cmp.cat_eq, label %cmp.same_cat, label %cmp.diff_cat
+cmp.diff_cat:
+  ; Result is determined purely by category order.
+  %cmp.cat_lt = icmp slt i32 %cmp.cat2, %cmp.cat3
+  %cmp.diff_id = select i1 %cmp.cat_lt, i64 %cmp.lt_id, i64 %cmp.gt_id
+  br label %cmp.bind
+cmp.same_cat:
+  ; Same category. Compound (cat 2) is unsupported -> fail.
+  %cmp.cat_is_cmp = icmp eq i32 %cmp.cat2, 2
+  br i1 %cmp.cat_is_cmp, label %cmp.fail, label %cmp.same_not_cmp
+cmp.fail:
+  ret i1 false
+cmp.same_not_cmp:
+  %cmp.cat_is_atom = icmp eq i32 %cmp.cat2, 1
+  br i1 %cmp.cat_is_atom, label %cmp.same_atoms, label %cmp.same_nums
+cmp.same_atoms:
+  %cmp.aid2 = extractvalue %Value %cmp.a2, 1
+  %cmp.aid3 = extractvalue %Value %cmp.a3, 1
+  %cmp.str2 = call i8* @wam_atom_to_string(i64 %cmp.aid2)
+  %cmp.str3 = call i8* @wam_atom_to_string(i64 %cmp.aid3)
+  %cmp.s_a_null2 = icmp eq i8* %cmp.str2, null
+  %cmp.s_a_null3 = icmp eq i8* %cmp.str3, null
+  %cmp.s_a_any_null = or i1 %cmp.s_a_null2, %cmp.s_a_null3
+  br i1 %cmp.s_a_any_null, label %cmp.fail, label %cmp.same_atoms_cmp
+cmp.same_atoms_cmp:
+  %cmp.s_a_r = call i32 @strcmp(i8* %cmp.str2, i8* %cmp.str3)
+  %cmp.s_a_lt = icmp slt i32 %cmp.s_a_r, 0
+  %cmp.s_a_gt = icmp sgt i32 %cmp.s_a_r, 0
+  %cmp.s_a_mid = select i1 %cmp.s_a_gt, i64 %cmp.gt_id, i64 %cmp.eq_id
+  %cmp.s_a_id = select i1 %cmp.s_a_lt, i64 %cmp.lt_id, i64 %cmp.s_a_mid
+  br label %cmp.bind_via_atom
+cmp.same_nums:
+  ; Both numbers. If both Integer, compare as i64. Otherwise convert to
+  ; double and use fcmp (handles Int-Float and Float-Float).
+  %cmp.t2_is_int = icmp eq i32 %cmp.t2, 1
+  %cmp.t3_is_int = icmp eq i32 %cmp.t3, 1
+  %cmp.both_int = and i1 %cmp.t2_is_int, %cmp.t3_is_int
+  br i1 %cmp.both_int, label %cmp.cmp_int, label %cmp.cmp_float
+cmp.cmp_int:
+  %cmp.iv2 = extractvalue %Value %cmp.a2, 1
+  %cmp.iv3 = extractvalue %Value %cmp.a3, 1
+  %cmp.i_lt = icmp slt i64 %cmp.iv2, %cmp.iv3
+  %cmp.i_gt = icmp sgt i64 %cmp.iv2, %cmp.iv3
+  %cmp.i_mid = select i1 %cmp.i_gt, i64 %cmp.gt_id, i64 %cmp.eq_id
+  %cmp.i_id = select i1 %cmp.i_lt, i64 %cmp.lt_id, i64 %cmp.i_mid
+  br label %cmp.bind_via_int
+cmp.cmp_float:
+  ; Widen both to double. If tag == 2, bitcast i64 to double.
+  ; Otherwise (tag == 1, Integer) sitofp.
+  %cmp.bits2 = extractvalue %Value %cmp.a2, 1
+  %cmp.bits3 = extractvalue %Value %cmp.a3, 1
+  %cmp.t2_is_flt = icmp eq i32 %cmp.t2, 2
+  %cmp.t3_is_flt = icmp eq i32 %cmp.t3, 2
+  %cmp.d2_flt = bitcast i64 %cmp.bits2 to double
+  %cmp.d2_int = sitofp i64 %cmp.bits2 to double
+  %cmp.d2 = select i1 %cmp.t2_is_flt, double %cmp.d2_flt, double %cmp.d2_int
+  %cmp.d3_flt = bitcast i64 %cmp.bits3 to double
+  %cmp.d3_int = sitofp i64 %cmp.bits3 to double
+  %cmp.d3 = select i1 %cmp.t3_is_flt, double %cmp.d3_flt, double %cmp.d3_int
+  %cmp.f_lt = fcmp olt double %cmp.d2, %cmp.d3
+  %cmp.f_gt = fcmp ogt double %cmp.d2, %cmp.d3
+  %cmp.f_mid = select i1 %cmp.f_gt, i64 %cmp.gt_id, i64 %cmp.eq_id
+  %cmp.f_id = select i1 %cmp.f_lt, i64 %cmp.lt_id, i64 %cmp.f_mid
+  br label %cmp.bind_via_float
+cmp.bind_via_atom:
+  br label %cmp.bind
+cmp.bind_via_int:
+  br label %cmp.bind
+cmp.bind_via_float:
+  br label %cmp.bind
+cmp.bind:
+  %cmp.id = phi i64 [ %cmp.diff_id, %cmp.diff_cat ], [ %cmp.s_a_id, %cmp.bind_via_atom ], [ %cmp.i_id, %cmp.bind_via_int ], [ %cmp.f_id, %cmp.bind_via_float ]
+  %cmp.v0 = insertvalue %Value undef, i32 0, 0
+  %cmp.v = insertvalue %Value %cmp.v0, i64 %cmp.id, 1
+  %cmp.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %cmp.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %cmp.raw1, %Value %cmp.v)
+  ret i1 %cmp.ok
+
 unknown:
   ret i1 false
 }'.
@@ -9828,6 +9933,7 @@ builtin_op_to_id('pairs_keys_values/3', 72). % forward only: split pairs -> keys
 builtin_op_to_id('atomic_list_concat/2', 73). % concat list of atoms (atoms only mode)
 builtin_op_to_id('atomic_list_concat/3', 74). % concat with separator atom (atoms-only forward)
 builtin_op_to_id('char_type/2', 75).          % char classification (check mode)
+builtin_op_to_id('compare/3', 76).            % three-way term order (num/atom)
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2020,6 +2020,95 @@ test_ct_unknown_type(_, R) :-
 test_ct_multichar_atom(_, R) :-
     ( char_type(ab, alpha) -> R is 1 ; R is 0 ).   % 0 -- not single-char
 
+% M59: compare/3 -- three-way standard order (Integer / Float / Atom).
+
+:- dynamic test_cmp_int_lt/2.
+test_cmp_int_lt(_, R) :-
+    compare(O, 1, 5),
+    char_code(O, C),
+    R is C.   % '<' = 60
+
+:- dynamic test_cmp_int_eq/2.
+test_cmp_int_eq(_, R) :-
+    compare(O, 7, 7),
+    char_code(O, C),
+    R is C.   % '=' = 61
+
+:- dynamic test_cmp_int_gt/2.
+test_cmp_int_gt(_, R) :-
+    compare(O, 10, 3),
+    char_code(O, C),
+    R is C.   % '>' = 62
+
+:- dynamic test_cmp_neg/2.
+test_cmp_neg(_, R) :-
+    compare(O, -5, 5),
+    char_code(O, C),
+    R is C.   % '<'
+
+:- dynamic test_cmp_float_lt/2.
+test_cmp_float_lt(_, R) :-
+    compare(O, 1.5, 2.5),
+    char_code(O, C),
+    R is C.   % '<'
+
+:- dynamic test_cmp_float_eq/2.
+test_cmp_float_eq(_, R) :-
+    compare(O, 3.14, 3.14),
+    char_code(O, C),
+    R is C.   % '='
+
+:- dynamic test_cmp_int_float_mixed/2.
+test_cmp_int_float_mixed(_, R) :-
+    % Numbers compared by value: 2 < 2.5
+    compare(O, 2, 2.5),
+    char_code(O, C),
+    R is C.   % '<'
+
+:- dynamic test_cmp_atom_lt/2.
+test_cmp_atom_lt(_, R) :-
+    compare(O, apple, banana),
+    char_code(O, C),
+    R is C.   % '<'
+
+:- dynamic test_cmp_atom_eq/2.
+test_cmp_atom_eq(_, R) :-
+    compare(O, hello, hello),
+    char_code(O, C),
+    R is C.   % '='
+
+:- dynamic test_cmp_atom_gt/2.
+test_cmp_atom_gt(_, R) :-
+    compare(O, zebra, apple),
+    char_code(O, C),
+    R is C.   % '>'
+
+:- dynamic test_cmp_num_atom/2.
+test_cmp_num_atom(_, R) :-
+    % Numbers come before atoms in ISO standard order.
+    compare(O, 42, foo),
+    char_code(O, C),
+    R is C.   % '<'
+
+:- dynamic test_cmp_atom_num/2.
+test_cmp_atom_num(_, R) :-
+    compare(O, foo, 42),
+    char_code(O, C),
+    R is C.   % '>'
+
+:- dynamic test_cmp_check_mode_lt/2.
+test_cmp_check_mode_lt(_, R) :-
+    % Order bound in advance -- compare just unifies.
+    ( compare(<, 1, 2) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_cmp_check_mode_eq/2.
+test_cmp_check_mode_eq(_, R) :-
+    ( compare(=, foo, foo) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_cmp_check_mode_wrong/2.
+test_cmp_check_mode_wrong(_, R) :-
+    ( compare(>, 1, 5) -> R is 1 ; R is 0 ).   % 0 -- 1 > 5 is false
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -3326,6 +3415,37 @@ test_all :-
                    test_ct_unknown_type, 0, 0),
        run_test_r0('char_type(ab, alpha) multichar -> 0',
                    test_ct_multichar_atom, 0, 0),
+       format('--- M59 compare/3 (Integer / Float / Atom) ---~n'),
+       run_test_r0('compare(O, 1, 5) -> 60 (<)',
+                   test_cmp_int_lt, 0, 60),
+       run_test_r0('compare(O, 7, 7) -> 61 (=)',
+                   test_cmp_int_eq, 0, 61),
+       run_test_r0('compare(O, 10, 3) -> 62 (>)',
+                   test_cmp_int_gt, 0, 62),
+       run_test_r0('compare(O, -5, 5) -> 60 (<)',
+                   test_cmp_neg, 0, 60),
+       run_test_r0('compare(O, 1.5, 2.5) -> 60 (<)',
+                   test_cmp_float_lt, 0, 60),
+       run_test_r0('compare(O, 3.14, 3.14) -> 61 (=)',
+                   test_cmp_float_eq, 0, 61),
+       run_test_r0('compare(O, 2, 2.5) mixed -> 60 (<)',
+                   test_cmp_int_float_mixed, 0, 60),
+       run_test_r0('compare(O, apple, banana) -> 60 (<)',
+                   test_cmp_atom_lt, 0, 60),
+       run_test_r0('compare(O, hello, hello) -> 61 (=)',
+                   test_cmp_atom_eq, 0, 61),
+       run_test_r0('compare(O, zebra, apple) -> 62 (>)',
+                   test_cmp_atom_gt, 0, 62),
+       run_test_r0('compare(O, 42, foo) cross-cat -> 60',
+                   test_cmp_num_atom, 0, 60),
+       run_test_r0('compare(O, foo, 42) cross-cat -> 62',
+                   test_cmp_atom_num, 0, 62),
+       run_test_r0('compare(<, 1, 2) check mode -> 1',
+                   test_cmp_check_mode_lt, 0, 1),
+       run_test_r0('compare(=, foo, foo) check mode -> 1',
+                   test_cmp_check_mode_eq, 0, 1),
+       run_test_r0('compare(>, 1, 5) check mode wrong -> 0',
+                   test_cmp_check_mode_wrong, 0, 0),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2052,8 +2052,8 @@ test_cmp_float_lt(_, R) :-
     char_code(O, C),
     R is C.   % '<'
 
-:- dynamic test_cmp_float_eq/2.
-test_cmp_float_eq(_, R) :-
+:- dynamic test_cmp_order_float_eq/2.
+test_cmp_order_float_eq(_, R) :-
     compare(O, 3.14, 3.14),
     char_code(O, C),
     R is C.   % '='
@@ -3427,7 +3427,7 @@ test_all :-
        run_test_r0('compare(O, 1.5, 2.5) -> 60 (<)',
                    test_cmp_float_lt, 0, 60),
        run_test_r0('compare(O, 3.14, 3.14) -> 61 (=)',
-                   test_cmp_float_eq, 0, 61),
+                   test_cmp_order_float_eq, 0, 61),
        run_test_r0('compare(O, 2, 2.5) mixed -> 60 (<)',
                    test_cmp_int_float_mixed, 0, 60),
        run_test_r0('compare(O, apple, banana) -> 60 (<)',


### PR DESCRIPTION
## Summary

Adds `compare(?Order, @T1, @T2)` — three-way standard term order for
the three supported categories. Compound terms are NOT yet supported;
attempting to compare two compounds fails. Mixed-category compares
(e.g. integer vs atom) work via the ISO category order:

  **Number < Atom < Compound**

Result is bound to the single-char atom `<`, `=`, or `>` looked up
via `@wam_char_to_atom` (the M26 char-to-atom table; ASCII codes 60,
61, 62). The result also works in check mode (`compare(<, 1, 2)`)
because `wam_unify_value` handles the bound-arg side uniformly.

### Tag-to-category mapping
Computed twice, once for T1 once for T2:
- tag 0 (Atom) → cat 1
- tag 1 (Integer) → cat 0
- tag 2 (Float) → cat 0
- tag 3 (Compound) → cat 2

### Category-different path
Just `select cat2 < cat3, '<', '>'`.

### Category-same paths
- **Compound** (cat 2): fail (deferred).
- **Atom**: `strcmp` the two interned strings, map sign → `<` / `=` / `>`.
- **Number**: if both Integer use `icmp s{lt,gt}` on i64; otherwise
  widen to double (`bitcast` for Float, `sitofp` for Integer) and
  `fcmp`.

Final bind goes through a single phi merging the four result-source
blocks (`diff_cat`, `bind_via_atom`, `bind_via_int`, `bind_via_float`)
into `%cmp.id`, then wraps it as Atom and unifies A1.

### Dispatch
- `builtin_op_to_id('compare/3', 76)` → `%builtin_compare`.
- `compare/3` already in `is_builtin_pred`.
- Prefix `cmp.`; sub-prefix `s_a` (same atoms), `i` (same ints), `f`
  (same floats) for the cmp helpers.

## Test plan
- [x] 15 new tests: int `<`, `=`, `>` (including negative); float
      `<`, `=`; mixed int/float (`2 < 2.5`); atom `<`, `=`, `>`;
      cross-category Number/Atom both directions; check mode (Order
      bound) for `<`, `=`, and a wrong-Order case
- [x] All 401 builtin tests pass (was 386, +15)
- [x] Manual llc round-trip clean

### Follow-up fix
First test run hit a name collision — `test_cmp_float_eq` was already
in use for an unrelated arithmetic test (`1/2 =:= 0.5 -> 1`). Last
definition wins for dynamic predicates, so the arithmetic test was
getting the new compare-order body and returning the atom code
instead of `1`. Renamed my version to `test_cmp_order_float_eq`.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_