### PR TITLE
LLVM WAM: display/1 + writeln/1 (M61)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3470,6 +3470,8 @@ entry:
     i32 75, label %builtin_char_type
     i32 76, label %builtin_compare
     i32 77, label %builtin_must_be
+    i32 78, label %builtin_write
+    i32 79, label %builtin_writeln
   ]
 
 builtin_is:
@@ -3714,8 +3716,19 @@ builtin_write:
   ; ``functor(arg1, arg2, ...)`` with recursive nested terms; the
   ; ``[|]/2`` functor special-cases to list notation. The previous
   ; M19 inline dispatch lives on inside the helper.
+  ; M61: display/1 dispatches to this same label since our runtime
+  ; doesn''t (yet) distinguish operator vs canonical print modes.
   %wr.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   call void @wam_write_value(%WamState* %vm, %Value %wr.a1)
+  ret i1 true
+
+builtin_writeln:
+  ; M61: writeln/1 = write/1 + nl/0. Same value-print helper as write,
+  ; followed by a single newline.
+  %wln.a1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  call void @wam_write_value(%WamState* %vm, %Value %wln.a1)
+  %wln.fmt = getelementptr [2 x i8], [2 x i8]* @.fmt_nl, i32 0, i32 0
+  call i32 (i8*, ...) @printf(i8* %wln.fmt)
   ret i1 true
 
 builtin_nl:
@@ -10152,6 +10165,8 @@ builtin_op_to_id('atomic_list_concat/3', 74). % concat with separator atom (atom
 builtin_op_to_id('char_type/2', 75).          % char classification (check mode)
 builtin_op_to_id('compare/3', 76).            % three-way term order (num/atom)
 builtin_op_to_id('must_be/2', 77).            % type guard (fail-instead-of-throw)
+builtin_op_to_id('display/1', 78).            % alias of write/1 (operator-free print)
+builtin_op_to_id('writeln/1', 79).            % write/1 + nl/0 combined
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2219,6 +2219,32 @@ test_mb_boolean_no(_, R) :-
 test_mb_unknown_type(_, R) :-
     ( must_be(bogus, hello) -> R is 1 ; R is 0 ).   % 0
 
+% M61: display/1 and writeln/1 -- alias for write/1 and write+nl.
+
+:- dynamic test_display_succeeds/2.
+test_display_succeeds(_, R) :-
+    ( display(hello) -> R is 1 ; R is 0 ).   % 1 (and prints ``hello'')
+
+:- dynamic test_display_integer/2.
+test_display_integer(_, R) :-
+    ( display(42) -> R is 1 ; R is 0 ).   % 1 (prints ``42'')
+
+:- dynamic test_display_compound/2.
+test_display_compound(_, R) :-
+    ( display(foo(1, 2)) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_writeln_succeeds/2.
+test_writeln_succeeds(_, R) :-
+    ( writeln(hello) -> R is 1 ; R is 0 ).   % 1 (prints ``hello\n'')
+
+:- dynamic test_writeln_integer/2.
+test_writeln_integer(_, R) :-
+    ( writeln(7) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_writeln_list/2.
+test_writeln_list(_, R) :-
+    ( writeln([1, 2, 3]) -> R is 1 ; R is 0 ).   % 1
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -3611,6 +3637,19 @@ test_all :-
                    test_mb_boolean_no, 0, 0),
        run_test_r0('must_be(bogus, hello) -> 0',
                    test_mb_unknown_type, 0, 0),
+       format('--- M61 display/1 + writeln/1 ---~n'),
+       run_test_r0('display(hello) succeeds -> 1',
+                   test_display_succeeds, 0, 1),
+       run_test_r0('display(42) -> 1',
+                   test_display_integer, 0, 1),
+       run_test_r0('display(foo(1, 2)) -> 1',
+                   test_display_compound, 0, 1),
+       run_test_r0('writeln(hello) -> 1',
+                   test_writeln_succeeds, 0, 1),
+       run_test_r0('writeln(7) -> 1',
+                   test_writeln_integer, 0, 1),
+       run_test_r0('writeln([1,2,3]) -> 1',
+                   test_writeln_list, 0, 1),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Two tiny I/O additions that fill out the common output predicate set.

### display/1
The operator-free print mode in SWI. Our runtime doesn't yet
distinguish operator-vs-canonical (`write/1` already prints in
functor form for unrecognized operators), so `display/1` simply
dispatches to the existing `%builtin_write` label. Op id 78.

### writeln/1
The more common "write something and add a newline" convenience.
Implemented as a small new block `%builtin_writeln` that calls
`@wam_write_value` (same helper `write/1` uses) and then
`printf`-s the `@.fmt_nl` string. Op id 79.

### Dispatch
- `builtin_op_to_id('display/1', 78)` → `%builtin_write` (alias).
- `builtin_op_to_id('writeln/1', 79)` → `%builtin_writeln`.
- Both predicates already in `is_builtin_pred` registry.
- Prefix `wln.` for writeln locals.

## Test plan
- [x] 6 new tests:
  - `display` with atom / integer / compound succeeds
  - `writeln` with atom / integer / list succeeds
- [x] All 434 builtin tests pass (was 428, +6)
- [x] Manual llc round-trip clean

Note: the 3 `display` tests print their value inline on the PASS
line (since display doesn't emit a trailing newline) — `^PASS` grep
undercounts but the broader `PASS \(N\)` count confirms 434.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_