### PR TITLE
LLVM WAM: sort/2 standard order + dedup (M63)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3473,6 +3473,7 @@ entry:
     i32 78, label %builtin_write
     i32 79, label %builtin_writeln
     i32 80, label %builtin_keysort
+    i32 81, label %builtin_sort
   ]
 
 builtin_is:
@@ -3944,6 +3945,215 @@ ks.b_bind:
   %ks.b_raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
   %ks.b_ok = call i1 @wam_unify_value(%WamState* %vm, %Value %ks.b_raw2, %Value %ks.b_acc)
   ret i1 %ks.b_ok
+
+builtin_sort:
+  ; M63: sort(+List, ?Sorted) -- insertion sort by standard term order
+  ; plus dedup. Supports Integer, Float, Atom elements. Compound
+  ; elements are treated as equal in the comparator (no shift) so
+  ; they retain input order; dedup uses @value_equals which is fine
+  ; for atoms/numbers.
+  %srt.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  call void @wam_arena_ensure()
+  br label %srt.c_loop
+srt.fail:
+  ret i1 false
+srt.c_loop:
+  %srt.c_cur = phi %Value [ %srt.a1, %builtin_sort ], [ %srt.c_next, %srt.c_step ]
+  %srt.c_cnt = phi i32 [ 0, %builtin_sort ], [ %srt.c_cnt1, %srt.c_step ]
+  %srt.c_d = call %Value @wam_deref_value(%WamState* %vm, %Value %srt.c_cur)
+  %srt.c_tag = extractvalue %Value %srt.c_d, 0
+  %srt.c_is_cmp = icmp eq i32 %srt.c_tag, 3
+  br i1 %srt.c_is_cmp, label %srt.c_step, label %srt.c_done
+srt.c_step:
+  %srt.c_cp = extractvalue %Value %srt.c_d, 1
+  %srt.c_cp_ptr = inttoptr i64 %srt.c_cp to %Compound*
+  %srt.c_args_slot = getelementptr %Compound, %Compound* %srt.c_cp_ptr, i32 0, i32 2
+  %srt.c_args = load %Value*, %Value** %srt.c_args_slot
+  %srt.c_t_ptr = getelementptr %Value, %Value* %srt.c_args, i32 1
+  %srt.c_next = load %Value, %Value* %srt.c_t_ptr
+  %srt.c_cnt1 = add i32 %srt.c_cnt, 1
+  br label %srt.c_loop
+srt.c_done:
+  %srt.cnt64 = sext i32 %srt.c_cnt to i64
+  %srt.arr_bytes = shl i64 %srt.cnt64, 4
+  %srt.arr_mem = call i8* @wam_arena_alloc(i64 %srt.arr_bytes)
+  %srt.arr = bitcast i8* %srt.arr_mem to %Value*
+  br label %srt.f_loop
+srt.f_loop:
+  %srt.f_cur = phi %Value [ %srt.a1, %srt.c_done ], [ %srt.f_next, %srt.f_step ]
+  %srt.f_idx = phi i32 [ 0, %srt.c_done ], [ %srt.f_idx1, %srt.f_step ]
+  %srt.f_done_b = icmp sge i32 %srt.f_idx, %srt.c_cnt
+  br i1 %srt.f_done_b, label %srt.sort_init, label %srt.f_step
+srt.f_step:
+  %srt.f_d = call %Value @wam_deref_value(%WamState* %vm, %Value %srt.f_cur)
+  %srt.f_cp = extractvalue %Value %srt.f_d, 1
+  %srt.f_cp_ptr = inttoptr i64 %srt.f_cp to %Compound*
+  %srt.f_args_slot = getelementptr %Compound, %Compound* %srt.f_cp_ptr, i32 0, i32 2
+  %srt.f_args = load %Value*, %Value** %srt.f_args_slot
+  %srt.f_h_ptr = getelementptr %Value, %Value* %srt.f_args, i32 0
+  %srt.f_h_raw = load %Value, %Value* %srt.f_h_ptr
+  %srt.f_h = call %Value @wam_deref_value(%WamState* %vm, %Value %srt.f_h_raw)
+  %srt.f_slot = getelementptr %Value, %Value* %srt.arr, i32 %srt.f_idx
+  store %Value %srt.f_h, %Value* %srt.f_slot
+  %srt.f_t_ptr = getelementptr %Value, %Value* %srt.f_args, i32 1
+  %srt.f_next = load %Value, %Value* %srt.f_t_ptr
+  %srt.f_idx1 = add i32 %srt.f_idx, 1
+  br label %srt.f_loop
+
+  ; ---- Insertion sort (inline term compare) ----
+srt.sort_init:
+  br label %srt.so_loop
+srt.so_loop:
+  %srt.so_i = phi i32 [ 1, %srt.sort_init ], [ %srt.so_i1, %srt.si_done ]
+  %srt.so_more = icmp slt i32 %srt.so_i, %srt.c_cnt
+  br i1 %srt.so_more, label %srt.so_pick, label %srt.dedup_init
+srt.so_pick:
+  %srt.so_key_slot = getelementptr %Value, %Value* %srt.arr, i32 %srt.so_i
+  %srt.so_key = load %Value, %Value* %srt.so_key_slot
+  br label %srt.si_loop
+srt.si_loop:
+  %srt.si_j = phi i32 [ %srt.so_i, %srt.so_pick ], [ %srt.si_j_dec, %srt.si_shift ]
+  %srt.si_j_dec = sub i32 %srt.si_j, 1
+  %srt.si_j_pos = icmp sge i32 %srt.si_j_dec, 0
+  br i1 %srt.si_j_pos, label %srt.si_cmp, label %srt.si_done
+srt.si_cmp:
+  %srt.si_prev_slot = getelementptr %Value, %Value* %srt.arr, i32 %srt.si_j_dec
+  %srt.si_prev = load %Value, %Value* %srt.si_prev_slot
+  ; Inline compare: prev > key ?  (same cat map / atom strcmp /
+  ; int icmp / float fcmp as M59 / keysort).
+  %srt.si_pt = extractvalue %Value %srt.si_prev, 0
+  %srt.si_kt = extractvalue %Value %srt.so_key, 0
+  %srt.si_pcat_atom = icmp eq i32 %srt.si_pt, 0
+  %srt.si_pcat_cmp = icmp eq i32 %srt.si_pt, 3
+  %srt.si_pcat_mid = select i1 %srt.si_pcat_cmp, i32 2, i32 0
+  %srt.si_pcat = select i1 %srt.si_pcat_atom, i32 1, i32 %srt.si_pcat_mid
+  %srt.si_kcat_atom = icmp eq i32 %srt.si_kt, 0
+  %srt.si_kcat_cmp = icmp eq i32 %srt.si_kt, 3
+  %srt.si_kcat_mid = select i1 %srt.si_kcat_cmp, i32 2, i32 0
+  %srt.si_kcat = select i1 %srt.si_kcat_atom, i32 1, i32 %srt.si_kcat_mid
+  %srt.si_cat_eq = icmp eq i32 %srt.si_pcat, %srt.si_kcat
+  br i1 %srt.si_cat_eq, label %srt.si_same_cat, label %srt.si_diff_cat
+srt.si_diff_cat:
+  %srt.si_diff_gt = icmp sgt i32 %srt.si_pcat, %srt.si_kcat
+  br i1 %srt.si_diff_gt, label %srt.si_shift, label %srt.si_done
+srt.si_same_cat:
+  %srt.si_cat_is_atom = icmp eq i32 %srt.si_pcat, 1
+  br i1 %srt.si_cat_is_atom, label %srt.si_atom_cmp, label %srt.si_num_or_cmp
+srt.si_num_or_cmp:
+  %srt.si_cat_is_cmp = icmp eq i32 %srt.si_pcat, 2
+  br i1 %srt.si_cat_is_cmp, label %srt.si_done, label %srt.si_num_cmp
+srt.si_atom_cmp:
+  %srt.si_p_aid = extractvalue %Value %srt.si_prev, 1
+  %srt.si_k_aid = extractvalue %Value %srt.so_key, 1
+  %srt.si_p_str = call i8* @wam_atom_to_string(i64 %srt.si_p_aid)
+  %srt.si_k_str = call i8* @wam_atom_to_string(i64 %srt.si_k_aid)
+  %srt.si_strcmp = call i32 @strcmp(i8* %srt.si_p_str, i8* %srt.si_k_str)
+  %srt.si_atom_gt = icmp sgt i32 %srt.si_strcmp, 0
+  br i1 %srt.si_atom_gt, label %srt.si_shift, label %srt.si_done
+srt.si_num_cmp:
+  %srt.si_p_int = icmp eq i32 %srt.si_pt, 1
+  %srt.si_k_int = icmp eq i32 %srt.si_kt, 1
+  %srt.si_both_int = and i1 %srt.si_p_int, %srt.si_k_int
+  br i1 %srt.si_both_int, label %srt.si_int_cmp, label %srt.si_flt_cmp
+srt.si_int_cmp:
+  %srt.si_p_iv = extractvalue %Value %srt.si_prev, 1
+  %srt.si_k_iv = extractvalue %Value %srt.so_key, 1
+  %srt.si_int_gt = icmp sgt i64 %srt.si_p_iv, %srt.si_k_iv
+  br i1 %srt.si_int_gt, label %srt.si_shift, label %srt.si_done
+srt.si_flt_cmp:
+  %srt.si_p_bits = extractvalue %Value %srt.si_prev, 1
+  %srt.si_k_bits = extractvalue %Value %srt.so_key, 1
+  %srt.si_p_is_flt = icmp eq i32 %srt.si_pt, 2
+  %srt.si_k_is_flt = icmp eq i32 %srt.si_kt, 2
+  %srt.si_p_dflt = bitcast i64 %srt.si_p_bits to double
+  %srt.si_p_dint = sitofp i64 %srt.si_p_bits to double
+  %srt.si_p_d = select i1 %srt.si_p_is_flt, double %srt.si_p_dflt, double %srt.si_p_dint
+  %srt.si_k_dflt = bitcast i64 %srt.si_k_bits to double
+  %srt.si_k_dint = sitofp i64 %srt.si_k_bits to double
+  %srt.si_k_d = select i1 %srt.si_k_is_flt, double %srt.si_k_dflt, double %srt.si_k_dint
+  %srt.si_flt_gt = fcmp ogt double %srt.si_p_d, %srt.si_k_d
+  br i1 %srt.si_flt_gt, label %srt.si_shift, label %srt.si_done
+srt.si_shift:
+  %srt.si_shift_dst = getelementptr %Value, %Value* %srt.arr, i32 %srt.si_j
+  store %Value %srt.si_prev, %Value* %srt.si_shift_dst
+  br label %srt.si_loop
+srt.si_done:
+  %srt.si_place_dst = getelementptr %Value, %Value* %srt.arr, i32 %srt.si_j
+  store %Value %srt.so_key, %Value* %srt.si_place_dst
+  %srt.so_i1 = add i32 %srt.so_i, 1
+  br label %srt.so_loop
+
+  ; ---- Dedup: compact arr in-place, removing consecutive equals ----
+srt.dedup_init:
+  ; If empty list, jump straight to build with out_cnt = 0.
+  %srt.d_empty = icmp eq i32 %srt.c_cnt, 0
+  br i1 %srt.d_empty, label %srt.build_init, label %srt.d_loop
+srt.d_loop:
+  ; in_idx runs 1..cnt-1; out_idx starts at 1 (arr[0] is always kept).
+  %srt.d_in = phi i32 [ 1, %srt.dedup_init ], [ %srt.d_in1, %srt.d_after ]
+  %srt.d_out = phi i32 [ 1, %srt.dedup_init ], [ %srt.d_out_next, %srt.d_after ]
+  %srt.d_more = icmp slt i32 %srt.d_in, %srt.c_cnt
+  br i1 %srt.d_more, label %srt.d_step, label %srt.d_done
+srt.d_step:
+  %srt.d_in_slot = getelementptr %Value, %Value* %srt.arr, i32 %srt.d_in
+  %srt.d_in_val = load %Value, %Value* %srt.d_in_slot
+  %srt.d_out_prev_idx = sub i32 %srt.d_out, 1
+  %srt.d_out_prev_slot = getelementptr %Value, %Value* %srt.arr, i32 %srt.d_out_prev_idx
+  %srt.d_out_prev = load %Value, %Value* %srt.d_out_prev_slot
+  %srt.d_eq = call i1 @value_equals(%Value %srt.d_in_val, %Value %srt.d_out_prev)
+  br i1 %srt.d_eq, label %srt.d_after, label %srt.d_keep
+srt.d_keep:
+  %srt.d_out_slot = getelementptr %Value, %Value* %srt.arr, i32 %srt.d_out
+  store %Value %srt.d_in_val, %Value* %srt.d_out_slot
+  %srt.d_out_kept = add i32 %srt.d_out, 1
+  br label %srt.d_after
+srt.d_after:
+  %srt.d_out_next = phi i32 [ %srt.d_out, %srt.d_step ], [ %srt.d_out_kept, %srt.d_keep ]
+  %srt.d_in1 = add i32 %srt.d_in, 1
+  br label %srt.d_loop
+srt.d_done:
+  br label %srt.build_init
+
+  ; ---- Build cons chain from arr[0..out_cnt) ----
+srt.build_init:
+  %srt.out_cnt = phi i32 [ 0, %srt.dedup_init ], [ %srt.d_out, %srt.d_done ]
+  %srt.b_empty_id = load i64, i64* @wam_empty_list_atom_id
+  %srt.b_empty_v0 = insertvalue %Value undef, i32 0, 0
+  %srt.b_empty_v  = insertvalue %Value %srt.b_empty_v0, i64 %srt.b_empty_id, 1
+  br label %srt.b_loop
+srt.b_loop:
+  %srt.b_i = phi i32 [ %srt.out_cnt, %srt.build_init ], [ %srt.b_i_prev, %srt.b_step ]
+  %srt.b_acc = phi %Value [ %srt.b_empty_v, %srt.build_init ], [ %srt.b_new_cons, %srt.b_step ]
+  %srt.b_done = icmp sle i32 %srt.b_i, 0
+  br i1 %srt.b_done, label %srt.b_bind, label %srt.b_step
+srt.b_step:
+  %srt.b_i_prev = sub i32 %srt.b_i, 1
+  %srt.b_slot = getelementptr %Value, %Value* %srt.arr, i32 %srt.b_i_prev
+  %srt.b_head = load %Value, %Value* %srt.b_slot
+  %srt.b_cp_size = ptrtoint %Compound* getelementptr (%Compound, %Compound* null, i32 1) to i64
+  %srt.b_cp_mem = call i8* @wam_arena_alloc(i64 %srt.b_cp_size)
+  %srt.b_cp = bitcast i8* %srt.b_cp_mem to %Compound*
+  %srt.b_fn_slot = getelementptr %Compound, %Compound* %srt.b_cp, i32 0, i32 0
+  %srt.b_fn_ptr = getelementptr [4 x i8], [4 x i8]* @.fn__5B_7C_5D, i32 0, i32 0
+  store i8* %srt.b_fn_ptr, i8** %srt.b_fn_slot
+  %srt.b_ar_slot = getelementptr %Compound, %Compound* %srt.b_cp, i32 0, i32 1
+  store i32 2, i32* %srt.b_ar_slot
+  %srt.b_args_mem = call i8* @wam_arena_alloc(i64 32)
+  %srt.b_args = bitcast i8* %srt.b_args_mem to %Value*
+  %srt.b_args_slot = getelementptr %Compound, %Compound* %srt.b_cp, i32 0, i32 2
+  store %Value* %srt.b_args, %Value** %srt.b_args_slot
+  %srt.b_h_ptr = getelementptr %Value, %Value* %srt.b_args, i32 0
+  store %Value %srt.b_head, %Value* %srt.b_h_ptr
+  %srt.b_t_ptr = getelementptr %Value, %Value* %srt.b_args, i32 1
+  store %Value %srt.b_acc, %Value* %srt.b_t_ptr
+  %srt.b_cp_i64 = ptrtoint %Compound* %srt.b_cp to i64
+  %srt.b_nc0 = insertvalue %Value undef, i32 3, 0
+  %srt.b_new_cons = insertvalue %Value %srt.b_nc0, i64 %srt.b_cp_i64, 1
+  br label %srt.b_loop
+srt.b_bind:
+  %srt.b_raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %srt.b_ok = call i1 @wam_unify_value(%WamState* %vm, %Value %srt.b_raw2, %Value %srt.b_acc)
+  ret i1 %srt.b_ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -10382,6 +10592,7 @@ builtin_op_to_id('must_be/2', 77).            % type guard (fail-instead-of-thro
 builtin_op_to_id('display/1', 78).            % alias of write/1 (operator-free print)
 builtin_op_to_id('writeln/1', 79).            % write/1 + nl/0 combined
 builtin_op_to_id('keysort/2', 80).            % stable sort of K-V pairs by Key
+builtin_op_to_id('sort/2', 81).               % sort + dedup under standard term order
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2314,6 +2314,76 @@ test_ks_mixed_num_keys(_, R) :-
     keysort([2-a, 1.5-b, 1-c, 2.5-d], [K-_|_]),
     R is K.   % 1
 
+% M63: sort/2 -- standard term order with dedup.
+
+:- dynamic test_sort_int_unique/2.
+test_sort_int_unique(_, R) :-
+    sort([3, 1, 2], L),
+    length(L, N),
+    R is N.   % 3
+
+:- dynamic test_sort_int_first/2.
+test_sort_int_first(_, R) :-
+    sort([5, 2, 8, 1, 3], [F|_]),
+    R is F.   % 1
+
+:- dynamic test_sort_int_last/2.
+test_sort_int_last(_, R) :-
+    sort([5, 2, 8, 1, 3], L),
+    last(L, E),
+    R is E.   % 8
+
+:- dynamic test_sort_dedup/2.
+test_sort_dedup(_, R) :-
+    sort([3, 1, 2, 1, 3, 2], L),
+    length(L, N),
+    R is N.   % 3 (dedup removes duplicates)
+
+:- dynamic test_sort_all_same/2.
+test_sort_all_same(_, R) :-
+    sort([7, 7, 7, 7], L),
+    length(L, N),
+    R is N.   % 1
+
+:- dynamic test_sort_empty/2.
+test_sort_empty(_, R) :-
+    sort([], L),
+    length(L, N),
+    R is N + 23.   % 23
+
+:- dynamic test_sort_singleton/2.
+test_sort_singleton(_, R) :-
+    sort([42], [E]),
+    R is E.   % 42
+
+:- dynamic test_sort_atom_keys/2.
+test_sort_atom_keys(_, R) :-
+    sort([banana, apple, cherry], [F|_]),
+    atom_length(F, L),
+    R is L.   % 5 (apple)
+
+:- dynamic test_sort_atom_dedup/2.
+test_sort_atom_dedup(_, R) :-
+    sort([b, a, c, a, b], L),
+    length(L, N),
+    R is N.   % 3
+
+:- dynamic test_sort_float/2.
+test_sort_float(_, R) :-
+    sort([3.5, 1.5, 2.5], [F|_]),
+    R is truncate(F * 10).   % 15
+
+:- dynamic test_sort_mixed_num/2.
+test_sort_mixed_num(_, R) :-
+    sort([3, 1.5, 2, 1], [F|_]),
+    R is F.   % 1
+
+:- dynamic test_sort_already_sorted/2.
+test_sort_already_sorted(_, R) :-
+    sort([1, 2, 3, 4, 5], L),
+    length(L, N),
+    R is N.   % 5 (no dedup, already sorted)
+
 % M20: transcendentals -- sin, cos, tan, log, exp. All lower to LLVM
 % intrinsics that the M18 -lm rollout already links. Verified via
 % truncate(... * scale) so the shell exit code can carry an integer
@@ -3744,6 +3814,31 @@ test_all :-
                    test_ks_float_keys, 0, 15),
        run_test_r0('keysort mixed num keys first -> 1',
                    test_ks_mixed_num_keys, 0, 1),
+       format('--- M63 sort/2 (standard order + dedup) ---~n'),
+       run_test_r0('sort([3,1,2]) length -> 3',
+                   test_sort_int_unique, 0, 3),
+       run_test_r0('sort([5,2,8,1,3]) first -> 1',
+                   test_sort_int_first, 0, 1),
+       run_test_r0('sort([5,2,8,1,3]) last -> 8',
+                   test_sort_int_last, 0, 8),
+       run_test_r0('sort([3,1,2,1,3,2]) dedup length -> 3',
+                   test_sort_dedup, 0, 3),
+       run_test_r0('sort([7,7,7,7]) length -> 1',
+                   test_sort_all_same, 0, 1),
+       run_test_r0('sort([]) + 23 -> 23',
+                   test_sort_empty, 0, 23),
+       run_test_r0('sort([42], [E]) -> 42',
+                   test_sort_singleton, 0, 42),
+       run_test_r0('sort atom keys first length -> 5 (apple)',
+                   test_sort_atom_keys, 0, 5),
+       run_test_r0('sort atom dedup length -> 3',
+                   test_sort_atom_dedup, 0, 3),
+       run_test_r0('sort float first*10 -> 15',
+                   test_sort_float, 0, 15),
+       run_test_r0('sort mixed num first -> 1',
+                   test_sort_mixed_num, 0, 1),
+       run_test_r0('sort already-sorted length -> 5',
+                   test_sort_already_sorted, 0, 5),
        format('--- M20 transcendentals -- sin / cos / tan / log / exp ---~n'),
        run_test_r0('truncate(sin(22/7/2) * 100) -> ~99',
                    test_sin_pi_half, 0, 99),


### PR DESCRIPTION
## Summary

Adds `sort(+List, ?Sorted)` — standard term-order sort with adjacent
duplicate removal. Insertion sort (stable) on whole list elements,
followed by in-place compaction that drops a value when it equals the
previous kept value (via `@value_equals` on the dereffed Values).

Mirrors M62 `keysort`'s structure but compares the **whole** element
instead of `args[0]` (no pair extraction), plus a dedup pass between
sort and build.

Supported element types: Integer, Float, Atom (compare via the M59-
style cat-map + atom `strcmp` / int `icmp` / float `fcmp` inline).
Compound elements are treated as equal by the comparator (no shift) so
they retain input order; the dedup pass uses `@value_equals` which
compares by Compound pointer, so equal-shaped compounds at different
arena addresses won't be deduped — close enough for now.

### Algorithm
1. Count A1 → `n`.
2. Allocate `arr` of `n` `%Values`; walk A1 again, dereffing each head
   and storing into `arr[i]`.
3. Insertion sort with strict-`>` shift (stable on equal).
4. Dedup: `out_idx = 1`; for `in_idx` in `1..n-1`: if `arr[in_idx]`
   equal to `arr[out_idx-1]`, skip; else copy + increment `out_idx`.
   Final `%srt.out_cnt` is the kept length.
5. Build cons chain from `arr[0..out_cnt)` back-to-front and unify A2.

Empty-list edge case takes the `dedup_init` branch straight to
`build_init` with `out_cnt = 0`; the build loop sees `i = 0` and
goes directly to bind with `[]`.

### Variable hygiene
- Prefix `srt.` with sub-prefixes `c.` (count), `f.` (fill),
  `so.` / `si.` (sort outer/inner), `d.` (dedup), `b.` (build).
- Manual `llc -filetype=obj` round-trip clean.

### Dispatch
- `builtin_op_to_id('sort/2', 81)` → `%builtin_sort`.
- `sort/2` already in `is_builtin_pred` registry.

## Test plan
- [x] 12 new tests:
  - Integer: unique length, first, last; with dupes length; all-same
    → 1; empty + 23; singleton
  - Atom: alphabetical first + dedup length
  - Float: `3.5` / `1.5` / `2.5` → first `1.5`; truncated `*10` → 15
  - Mixed int+float: `3` / `1.5` / `2` / `1` → first 1
  - Already-sorted: length unchanged
- [x] All 458 builtin tests pass (was 446, +12)
- [x] Manual llc round-trip clean


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_