### PR TITLE
fix(wam-clojure): materialize char code outputs

### DIFF
--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1336,6 +1336,9 @@
 (defn valid-char-code? [value]
   (and (integer? value) (not (neg? value)) (<= value 65535)))
 
+(defn char-code-count-term [state code]
+  (normalize-literal-term (:intern-context state) (str code)))
+
 (defn apply-char-code-solution [state]
   (let [char-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A1") ::unbound))
@@ -1345,7 +1348,10 @@
         code (code-point-value state code-value)]
     (cond
       (some? char-text)
-      (let [[ok unified-state] (unify-values state code-value (int (first char-text)))]
+      (let [char-code (int (first char-text))
+            [ok unified-state] (if (logic-var? code-value)
+                                 (unify-values state code-value (char-code-count-term state char-code))
+                                 [(= code char-code) state])]
         (if ok
           (advance unified-state)
           (backtrack state)))
@@ -1400,7 +1406,10 @@
             code (code-point-value state code-value)]
         (cond
           (some? char-text)
-          (let [[ok unified-state] (unify-values state code-value (int (first char-text)))]
+          (let [char-code (int (first char-text))
+                [ok unified-state] (if (logic-var? code-value)
+                                     (unify-values state code-value (char-code-count-term state char-code))
+                                     [(= code char-code) state])]
             (if ok
               (advance unified-state)
               (backtrack state)))

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -208,12 +208,16 @@
 :- dynamic user:wam_char_code_reverse/0.
 :- dynamic user:wam_char_code_forward/0.
 :- dynamic user:wam_char_code_forward_mismatch/0.
+:- dynamic user:wam_char_code_forward_unify/0.
+:- dynamic user:wam_char_code_forward_unify_mismatch/0.
 :- dynamic user:wam_char_code_bad_char/0.
 :- dynamic user:wam_char_code_unbound_pair/1.
 :- dynamic user:wam_char_type_alpha/0.
 :- dynamic user:wam_char_type_digit/0.
 :- dynamic user:wam_char_type_space/0.
 :- dynamic user:wam_char_type_code_forward/0.
+:- dynamic user:wam_char_type_code_forward_unify/0.
+:- dynamic user:wam_char_type_code_forward_unify_mismatch/0.
 :- dynamic user:wam_char_type_code_reverse/0.
 :- dynamic user:wam_char_type_code_mismatch/0.
 :- dynamic user:wam_char_type_lower_fail/0.
@@ -494,12 +498,16 @@ user:wam_char_code_guard(C, N) :- char_code(C, N).
 user:wam_char_code_reverse :- char_code(C, 65), C = 'A'.
 user:wam_char_code_forward :- char_code(a, N), N =:= 97.
 user:wam_char_code_forward_mismatch :- char_code(a, N), N =:= 98.
+user:wam_char_code_forward_unify :- char_code(a, N), N = 97.
+user:wam_char_code_forward_unify_mismatch :- char_code(a, N), N = 98.
 user:wam_char_code_bad_char :- char_code(ab, _).
 user:wam_char_code_unbound_pair(_) :- user:wam_unbound_arg(C), user:wam_unbound_arg(N), char_code(C, N).
 user:wam_char_type_alpha :- char_type(a, alpha).
 user:wam_char_type_digit :- char_code(C, 0'5), char_type(C, digit), char_type(C, alnum).
 user:wam_char_type_space :- char_code(C, 32), char_type(C, space), char_type(C, whitespace).
 user:wam_char_type_code_forward :- char_type('A', code(C)), C =:= 65.
+user:wam_char_type_code_forward_unify :- char_type('A', code(C)), C = 65.
+user:wam_char_type_code_forward_unify_mismatch :- char_type('A', code(C)), C = 66.
 user:wam_char_type_code_reverse :- char_type(C, code(97)), C = a.
 user:wam_char_type_code_mismatch :- char_type('A', code(66)).
 user:wam_char_type_lower_fail :- char_type('A', lower).
@@ -785,12 +793,16 @@ run_smoke :-
           user:wam_char_code_reverse/0,
           user:wam_char_code_forward/0,
           user:wam_char_code_forward_mismatch/0,
+          user:wam_char_code_forward_unify/0,
+          user:wam_char_code_forward_unify_mismatch/0,
           user:wam_char_code_bad_char/0,
           user:wam_char_code_unbound_pair/1,
           user:wam_char_type_alpha/0,
           user:wam_char_type_digit/0,
           user:wam_char_type_space/0,
           user:wam_char_type_code_forward/0,
+          user:wam_char_type_code_forward_unify/0,
+          user:wam_char_type_code_forward_unify_mismatch/0,
           user:wam_char_type_code_reverse/0,
           user:wam_char_type_code_mismatch/0,
           user:wam_char_type_lower_fail/0,
@@ -1252,12 +1264,16 @@ smoke_cases([
     case('wam_char_code_reverse/0', no_args, "true"),
     case('wam_char_code_forward/0', no_args, "true"),
     case('wam_char_code_forward_mismatch/0', no_args, "false"),
+    case('wam_char_code_forward_unify/0', no_args, "true"),
+    case('wam_char_code_forward_unify_mismatch/0', no_args, "false"),
     case('wam_char_code_bad_char/0', no_args, "false"),
     case('wam_char_code_unbound_pair/1', a, "false"),
     case('wam_char_type_alpha/0', no_args, "true"),
     case('wam_char_type_digit/0', no_args, "true"),
     case('wam_char_type_space/0', no_args, "true"),
     case('wam_char_type_code_forward/0', no_args, "true"),
+    case('wam_char_type_code_forward_unify/0', no_args, "true"),
+    case('wam_char_type_code_forward_unify_mismatch/0', no_args, "false"),
     case('wam_char_type_code_reverse/0', no_args, "true"),
     case('wam_char_type_code_mismatch/0', no_args, "false"),
     case('wam_char_type_lower_fail/0', no_args, "false"),


### PR DESCRIPTION
## Summary

- Update Clojure WAM `char_code/2` output materialization so generated code values bind as lowered numeric literal terms.
- Apply the same representation fix to `char_type/2` `code(C)` generated code outputs.
- Preserve existing raw numeric guard behavior for bound code arguments.
- Add runtime smoke coverage for unification-based success and mismatch cases for generated code outputs.

## Why

The lowered Clojure WAM path represents numeric literals as interned terms. `char_code/2` and `char_type/2` previously produced raw JVM integers when the code argument was an output variable. That worked for arithmetic comparisons but could fail when generated code later unified the result with a lowered numeric literal.

This change aligns char-code output materialization with the numeric representation used by lowered WAM code while keeping direct guard calls compatible.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
