### PR TITLE
Add WAM-C child-search artifact layout matrix targets

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -1,22 +1,20 @@
 # WAM C Target - Status And Next Steps
 
-Status date: 2026-05-29
+Status date: 2026-05-31
 
 Latest branch verification:
 
-- `feat/wam-c-native-kernel-float-output` based on `main` at `7e4b70d5`
-  (`Merge pull request #2582 from s243a/feat/wam-haskell-iso-items-rewrite`)
-- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
+- `investigate/wam-c-larger-artifact-layouts` based on `main` at `982c82f0`
+  (`Merge pull request #2652 from s243a/feat/wam-c-native-kernel-float-output`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
-- `swipl -q -g run_tests -t halt tests/core/test_cost_model.pl`
-- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py tests/test_wam_c_lowered_helper_scale_regression.py`
-- `swipl -q -t halt -s examples/benchmark/generate_wam_c_effective_distance_benchmark.pl`
-- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10x --targets prolog-accumulated,c-wam-accumulated,c-wam-accumulated-no-kernels,c-wam-accumulated-lmdb,c-wam-accumulated-no-kernels-lmdb --repetitions 1 --baseline-target prolog-accumulated --run-timeout-seconds 180`
+- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py`
+- `python3 tests/test_benchmark_target_matrix.py`
+- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets c-wam-child-search-layouts --repetitions 1 --baseline-target c-wam-accumulated-child-scan --run-timeout-seconds 180`
 - `git diff --check`
 
 Active branch:
 
-- `feat/wam-c-native-kernel-float-output`
+- `investigate/wam-c-larger-artifact-layouts`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -158,8 +156,8 @@ missing important target features; `Missing` = no comparable C path yet.
 | Shared kernel detector integration | Partial/Done | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`, `transitive_closure2`, `transitive_distance3`, `transitive_parent_distance4`, `transitive_step_parent_distance5`, `weighted_shortest_path3`, and `astar_shortest_path4`; Haskell and Rust still have broader wrapper/fact-layout integration. |
 | Lowered/native helper functions | Partial/Done | Done | Done | C has constant fact-only native helpers, planner metadata, interpreted-vs-lowered matrix wiring, body-call helpers, filtered-fact helpers, comparison-filter helpers, rejection metadata, repeated-variable filter hardening, empty-result rejection metadata, and projected body-call helper expansion. |
 | FactSource abstraction | Partial | Partial/less central | Done | C has TSV category-parent loading; generalize beyond category edges as needed. |
-| LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts and generated effective-distance LMDB wiring; larger artifact layout support remains. |
-| Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB `kernels_on`/`kernels_off`; next gap is larger artifact layouts. |
+| LMDB-backed facts | Partial/Done | Not primary | Done | C has optional eager LMDB loading for UTF-8 key/value category-parent facts, generated effective-distance LMDB wiring, and a matrix path for LMDB-offset reverse CSR row lookup. |
+| Effective-distance benchmark harness | Partial/Done | Done | Done | C is wired into the shared matrix for TSV and LMDB parent-only targets plus bounded child-search scan, sorted-array CSR, buffered-pread-drop CSR, and LMDB-offset CSR layout targets. |
 | Classic-program e2e suite | Partial/Done | Partial/Done | Partial/Done | C now covers generated Fibonacci-style recursion with arithmetic; add Ackermann-style depth only if routine runtime stays acceptable. |
 | Memory lifecycle | Partial/Done | Runtime-managed | Runtime-managed | C has ASAN lifecycle smoke coverage for repeated setup, indexed clauses, fact-source loading, native kernel dispatch, and repeated top-level calls. |
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
@@ -188,22 +186,31 @@ Reason:
 - Weighted/A* native kernels previously covered only integer results, while
   Haskell and Rust had broader numeric-result surfaces.
 
-### 1. `investigate/wam-c-larger-artifact-layouts`
+### Active: `investigate/wam-c-larger-artifact-layouts`
 
 Goal: measure whether the newer parent-only LMDB and reverse CSR artifact
 layouts remain the right defaults at larger category scales.
 
-Scope:
+Implemented so far:
 
-- Reuse the existing effective-distance matrix before adding new benchmark
-  surfaces.
-- Compare TSV, LMDB, CSR, and direct-I/O CSR modes where the current generator
-  can already emit them.
-- Keep any in-memory compressed CSR work out of this branch unless measurement
-  shows the current layout is the limiting factor.
+- Reused the existing effective-distance matrix instead of adding a separate
+  benchmark script.
+- Added WAM-C generator layout profiles for bounded child search over loaded
+  parent facts, sorted-array reverse CSR, buffered-pread-drop reverse CSR, and
+  LMDB-offset reverse CSR.
+- Added `c-wam-child-search-layouts` for scan-vs-CSR smoke comparisons and
+  `c-wam-child-csr-layouts` for larger CSR-only comparisons.
+- `dev` layout smoke shows output parity across scan, sorted-array CSR,
+  buffered-pread-drop CSR, and LMDB-offset CSR; runtimes were about
+  `0.130-0.145s` for the four variants.
 
-Status: recommended after the runtime-cost investigation, or sooner if a
-concrete generated benchmark requires float output.
+Open measurement:
+
+- `10x` child-search layout runs are not a routine local gate even with a small
+  child-expansion cap; run them only as an explicit longer benchmark window.
+- Parent-only TSV and LMDB targets remain the priority memory structures for
+  current effective-distance workloads. Reverse CSR targets are now available
+  for future child-path variants and artifact-layout measurements.
 
 ### Completed Investigation: `investigate/wam-c-next-benchmark-demand`
 
@@ -394,8 +401,7 @@ After hash-bucket row dispatch but before compact row tables:
 
 ## Suggested Immediate Next Step
 
-Proceed with `investigate/wam-c-larger-artifact-layouts` unless the next round
-of work is explicitly generated-program parity focused. The accumulated runtime
-investigation found and fixed the dominant `10x` cost: repeated full-edge scans
-inside recursive ancestor traversal, and the weighted/A* native kernels now
-preserve fractional results.
+Use `c-wam-child-search-layouts` at `dev` as the fast correctness gate and
+`c-wam-child-csr-layouts` for explicit longer larger-scale measurement. Do not
+promote in-memory compressed CSR work until those measurements show that the
+current file-backed CSR layout is the limiting factor.

--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -10,6 +10,7 @@ Latest branch verification:
 - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py`
 - `python3 tests/test_benchmark_target_matrix.py`
 - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets c-wam-child-search-layouts --repetitions 1 --baseline-target c-wam-accumulated-child-scan --run-timeout-seconds 180`
+- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10x --target-sets c-wam-child-csr-layouts --compile-only-targets c-wam-accumulated-child-csr,c-wam-accumulated-child-csr-drop,c-wam-accumulated-child-csr-lmdb-offset --baseline-target c-wam-accumulated-child-csr`
 - `git diff --check`
 
 Active branch:
@@ -200,14 +201,23 @@ Implemented so far:
   LMDB-offset reverse CSR.
 - Added `c-wam-child-search-layouts` for scan-vs-CSR smoke comparisons and
   `c-wam-child-csr-layouts` for larger CSR-only comparisons.
+- Compile-only matrix rows now report WAM-C artifact byte sizes for TSV, LMDB,
+  CSR index/values, and LMDB-offset stores.
 - `dev` layout smoke shows output parity across scan, sorted-array CSR,
   buffered-pread-drop CSR, and LMDB-offset CSR; runtimes were about
   `0.130-0.145s` for the four variants.
+- `10x` CSR compile-only smoke builds all three CSR layouts in about
+  `0.735-0.811s`; the generated parent TSV is `167,698` bytes, the reverse
+  CSR index is `22,528` bytes, reverse CSR values are `15,728` bytes, and the
+  LMDB-offset store adds `77,824` bytes.
 
 Open measurement:
 
 - `10x` child-search layout runs are not a routine local gate even with a small
   child-expansion cap; run them only as an explicit longer benchmark window.
+- Use compile-only rows for routine larger-scale artifact-size comparisons,
+  then schedule runtime rows separately for scales where child-search query
+  execution is acceptable.
 - Parent-only TSV and LMDB targets remain the priority memory structures for
   current effective-distance workloads. Reverse CSR targets are now available
   for future child-path variants and artifact-layout measurements.
@@ -402,6 +412,8 @@ After hash-bucket row dispatch but before compact row tables:
 ## Suggested Immediate Next Step
 
 Use `c-wam-child-search-layouts` at `dev` as the fast correctness gate and
-`c-wam-child-csr-layouts` for explicit longer larger-scale measurement. Do not
-promote in-memory compressed CSR work until those measurements show that the
-current file-backed CSR layout is the limiting factor.
+`c-wam-child-csr-layouts` in compile-only mode for routine larger-scale
+artifact-size comparisons. Run full child-search runtime rows only in explicit
+longer benchmark windows, and do not promote in-memory compressed CSR work
+until those measurements show that the current file-backed CSR layout is the
+limiting factor.

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -155,12 +155,16 @@ def available_targets(requested: list[str]) -> list[str]:
     c_wam_targets = {
         "c-wam-accumulated",
         "c-wam-accumulated-no-kernels",
+        "c-wam-accumulated-child-scan",
+        "c-wam-accumulated-child-csr",
+        "c-wam-accumulated-child-csr-drop",
         "c-wam-lowered-helper",
         "c-wam-lowered-helper-interpreted",
     }
     c_wam_lmdb_targets = {
         "c-wam-accumulated-lmdb",
         "c-wam-accumulated-no-kernels-lmdb",
+        "c-wam-accumulated-child-csr-lmdb-offset",
     }
     for target in requested:
         if target.startswith("csharp-") and shutil.which("dotnet") is None:

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -841,7 +841,7 @@ def should_timeout_target(target: str, timeout_targets: set[str]) -> bool:
     return not timeout_targets or target in timeout_targets
 
 
-def compile_only_result(target: str, scale: str, build_seconds: float) -> RunResult:
+def compile_only_result(target: str, scale: str, build_seconds: float, message: str = "") -> RunResult:
     return RunResult(
         target=target,
         scale=scale,
@@ -850,8 +850,59 @@ def compile_only_result(target: str, scale: str, build_seconds: float) -> RunRes
         row_count=0,
         stderr="",
         status="compile_only",
-        message="generated/built but not executed",
+        message=message or "generated/built but not executed",
     )
+
+
+def file_tree_size_bytes(path: Path) -> int:
+    if path.is_file():
+        return path.stat().st_size
+    if path.is_dir():
+        return sum(child.stat().st_size for child in path.rglob("*") if child.is_file())
+    return 0
+
+
+def wam_c_project_dir(root: Path, scale: str, target: str) -> Path | None:
+    profiles = {
+        "c-wam-accumulated": ("kernels_on", "facts_tsv", "parent_only"),
+        "c-wam-accumulated-no-kernels": ("kernels_off", "facts_tsv", "parent_only"),
+        "c-wam-accumulated-lmdb": ("kernels_on", "facts_lmdb", "parent_only"),
+        "c-wam-accumulated-no-kernels-lmdb": ("kernels_off", "facts_lmdb", "parent_only"),
+        "c-wam-accumulated-child-scan": ("kernels_on", "facts_tsv", "child_scan"),
+        "c-wam-accumulated-child-csr": ("kernels_on", "facts_tsv", "child_csr_sorted"),
+        "c-wam-accumulated-child-csr-drop": ("kernels_on", "facts_tsv", "child_csr_buffered_drop"),
+        "c-wam-accumulated-child-csr-lmdb-offset": (
+            "kernels_on",
+            "facts_tsv",
+            "child_csr_lmdb_offset",
+        ),
+    }
+    profile = profiles.get(target)
+    if profile is None:
+        return None
+    kernel_mode, fact_storage, layout_profile = profile
+    return root / f"wam_c_{kernel_mode}_{fact_storage}_{layout_profile}" / scale
+
+
+def wam_c_artifact_size_message(root: Path, scale: str, target: str) -> str:
+    project_dir = wam_c_project_dir(root, scale, target)
+    if project_dir is None:
+        return ""
+    artifacts = [
+        ("category_parent_tsv", project_dir / "category_parent.tsv"),
+        ("category_parent_lmdb", project_dir / "category_parent.lmdb"),
+        ("reverse_csr_index", project_dir / "category_child.csr.idx"),
+        ("reverse_csr_values", project_dir / "category_child.csr.val"),
+        ("reverse_csr_offsets_lmdb", project_dir / "category_child.csr.offsets.lmdb"),
+    ]
+    parts = []
+    for label, path in artifacts:
+        size = file_tree_size_bytes(path)
+        if size > 0:
+            parts.append(f"{label}_bytes={size}")
+    if not parts:
+        return "generated/built but not executed"
+    return "generated/built but not executed; " + " ".join(parts)
 
 
 def failed_result(
@@ -1151,7 +1202,8 @@ def main() -> int:
                     command = commands[target]
                 build_seconds = time.perf_counter() - build_started
                 if target in compile_only_targets:
-                    results.append(compile_only_result(target, scale, build_seconds))
+                    message = wam_c_artifact_size_message(temp_root, scale, target)
+                    results.append(compile_only_result(target, scale, build_seconds, message))
                     continue
                 results.append(
                     benchmark_target(

--- a/examples/benchmark/benchmark_effective_distance_matrix.py
+++ b/examples/benchmark/benchmark_effective_distance_matrix.py
@@ -280,31 +280,36 @@ def build_wam_go_effective_distance(root: Path, scale: str, kernel_mode: str) ->
 
 
 def build_wam_c_effective_distance(
-    root: Path, scale: str, kernel_mode: str, fact_storage: str = "facts_tsv"
+    root: Path,
+    scale: str,
+    kernel_mode: str,
+    fact_storage: str = "facts_tsv",
+    layout_profile: str = "parent_only",
 ) -> list[str]:
     facts_path = require_file(BENCH_DIR / scale / "facts.pl")
-    project_dir = root / f"wam_c_{kernel_mode}_{fact_storage}" / scale
+    project_dir = root / f"wam_c_{kernel_mode}_{fact_storage}_{layout_profile}" / scale
     project_dir.mkdir(parents=True, exist_ok=True)
-    run_command(
-        [
-            "swipl",
-            "-q",
-            "-s",
-            str(WAM_C_GENERATOR),
-            "--",
-            str(facts_path),
-            str(project_dir),
-            kernel_mode,
-            fact_storage,
-        ],
-        cwd=ROOT,
-    )
+    generator_command = [
+        "swipl",
+        "-q",
+        "-s",
+        str(WAM_C_GENERATOR),
+        "--",
+        str(facts_path),
+        str(project_dir),
+        kernel_mode,
+        fact_storage,
+    ]
+    if layout_profile != "parent_only":
+        generator_command.append(layout_profile)
+    run_command(generator_command, cwd=ROOT)
     runtime_path = project_dir / "wam_runtime.c"
     lib_path = project_dir / "lib.c"
     main_path = project_dir / "main.c"
     binary_path = project_dir / "wam_c_effective_distance"
     compile_flags = ["-std=c11", "-Wall", "-Wextra"]
     link_flags = ["-lm"]
+    uses_lmdb_runtime = False
     if fact_storage == "facts_lmdb":
         seeder_path = project_dir / "seed_category_parent_lmdb.c"
         seeder_binary = project_dir / "seed_category_parent_lmdb"
@@ -320,10 +325,28 @@ def build_wam_c_effective_distance(
             cwd=ROOT,
         )
         run_command([str(seeder_binary)], cwd=project_dir)
-        compile_flags.append("-DWAM_C_ENABLE_LMDB")
-        link_flags.append("-llmdb")
+        uses_lmdb_runtime = True
     elif fact_storage != "facts_tsv":
         raise ValueError(f"unknown WAM-C fact storage mode: {fact_storage}")
+    reverse_csr_offset_seeder_path = project_dir / "seed_category_child_csr_offsets_lmdb.c"
+    if reverse_csr_offset_seeder_path.exists():
+        reverse_csr_offset_seeder_binary = project_dir / "seed_category_child_csr_offsets_lmdb"
+        run_command(
+            [
+                "gcc",
+                *compile_flags,
+                str(reverse_csr_offset_seeder_path),
+                "-llmdb",
+                "-o",
+                str(reverse_csr_offset_seeder_binary),
+            ],
+            cwd=ROOT,
+        )
+        run_command([str(reverse_csr_offset_seeder_binary)], cwd=project_dir)
+        uses_lmdb_runtime = True
+    if uses_lmdb_runtime:
+        compile_flags.append("-DWAM_C_ENABLE_LMDB")
+        link_flags.append("-llmdb")
     run_command(
         [
             "gcc",
@@ -1064,6 +1087,22 @@ def main() -> int:
                     command = build_wam_c_effective_distance(temp_root, scale, "kernels_on", "facts_lmdb")
                 elif target == "c-wam-accumulated-no-kernels-lmdb":
                     command = build_wam_c_effective_distance(temp_root, scale, "kernels_off", "facts_lmdb")
+                elif target == "c-wam-accumulated-child-scan":
+                    command = build_wam_c_effective_distance(
+                        temp_root, scale, "kernels_on", "facts_tsv", "child_scan"
+                    )
+                elif target == "c-wam-accumulated-child-csr":
+                    command = build_wam_c_effective_distance(
+                        temp_root, scale, "kernels_on", "facts_tsv", "child_csr_sorted"
+                    )
+                elif target == "c-wam-accumulated-child-csr-drop":
+                    command = build_wam_c_effective_distance(
+                        temp_root, scale, "kernels_on", "facts_tsv", "child_csr_buffered_drop"
+                    )
+                elif target == "c-wam-accumulated-child-csr-lmdb-offset":
+                    command = build_wam_c_effective_distance(
+                        temp_root, scale, "kernels_on", "facts_tsv", "child_csr_lmdb_offset"
+                    )
                 elif target == "c-wam-lowered-helper":
                     command = build_wam_c_lowered_helper_benchmark(temp_root, scale, "lowered")
                 elif target == "c-wam-lowered-helper-interpreted":

--- a/examples/benchmark/benchmark_target_matrix.py
+++ b/examples/benchmark/benchmark_target_matrix.py
@@ -102,6 +102,26 @@ TARGETS: dict[str, TargetInfo] = {
         "hybrid-wam",
         "Hybrid WAM C effective-distance runner with reference DFS, kernels disabled, and LMDB fact storage",
     ),
+    "c-wam-accumulated-child-scan": TargetInfo(
+        "c-wam-accumulated-child-scan",
+        "hybrid-wam-child-search",
+        "Hybrid WAM C effective-distance runner with bounded child search over loaded parent facts",
+    ),
+    "c-wam-accumulated-child-csr": TargetInfo(
+        "c-wam-accumulated-child-csr",
+        "hybrid-wam-child-search",
+        "Hybrid WAM C effective-distance runner with bounded child search over sorted-array reverse CSR",
+    ),
+    "c-wam-accumulated-child-csr-drop": TargetInfo(
+        "c-wam-accumulated-child-csr-drop",
+        "hybrid-wam-child-search",
+        "Hybrid WAM C effective-distance runner with bounded child search over buffered-pread-drop reverse CSR",
+    ),
+    "c-wam-accumulated-child-csr-lmdb-offset": TargetInfo(
+        "c-wam-accumulated-child-csr-lmdb-offset",
+        "hybrid-wam-child-search",
+        "Hybrid WAM C effective-distance runner with bounded child search over reverse CSR and LMDB row offsets",
+    ),
     "c-wam-lowered-helper": TargetInfo(
         "c-wam-lowered-helper",
         "hybrid-wam-lowered-helper",
@@ -378,6 +398,17 @@ TARGET_SETS: dict[str, list[str]] = {
     "c-wam-lowered-helper": [
         "c-wam-lowered-helper-interpreted",
         "c-wam-lowered-helper",
+    ],
+    "c-wam-child-search-layouts": [
+        "c-wam-accumulated-child-scan",
+        "c-wam-accumulated-child-csr",
+        "c-wam-accumulated-child-csr-drop",
+        "c-wam-accumulated-child-csr-lmdb-offset",
+    ],
+    "c-wam-child-csr-layouts": [
+        "c-wam-accumulated-child-csr",
+        "c-wam-accumulated-child-csr-drop",
+        "c-wam-accumulated-child-csr-lmdb-offset",
     ],
     "scala-wam-artifact": [
         "scala-wam-seeded",

--- a/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
@@ -20,7 +20,14 @@
 %%
 %% Usage:
 %%   swipl -q -s examples/benchmark/generate_wam_c_effective_distance_benchmark.pl -- \
-%%       <facts.pl> <output-dir> [kernels_on|kernels_off] [facts_tsv|facts_lmdb]
+%%       <facts.pl> <output-dir> [kernels_on|kernels_off] [facts_tsv|facts_lmdb] [layout_profile]
+%%
+%% Layout profiles:
+%%   parent_only                - parent-path query only (default)
+%%   child_scan                 - bounded child search over the loaded parent facts
+%%   child_csr_sorted           - bounded child search using sorted-array reverse CSR
+%%   child_csr_buffered_drop    - sorted-array reverse CSR with buffered pread/drop
+%%   child_csr_lmdb_offset      - reverse CSR values plus LMDB row-offset lookup
 
 benchmark_workload_path(Path) :-
     source_file(benchmark_workload_path(_), ThisFile),
@@ -31,6 +38,11 @@ main :-
     current_prolog_flag(argv, Argv),
     (   Argv == []
     ->  true
+    ;   Argv = [FactsPath, OutputDir, KernelModeAtom, FactStorageAtom, LayoutProfileAtom]
+    ->  parse_layout_profile(LayoutProfileAtom, LayoutProfileOptions),
+        generate(FactsPath, OutputDir, KernelModeAtom,
+                 [fact_storage(FactStorageAtom)|LayoutProfileOptions]),
+        halt(0)
     ;   Argv = [FactsPath, OutputDir, KernelModeAtom, FactStorageAtom]
     ->  generate(FactsPath, OutputDir, KernelModeAtom, FactStorageAtom),
         halt(0)
@@ -41,7 +53,7 @@ main :-
     ->  generate(FactsPath, OutputDir, kernels_on),
         halt(0)
     ;   format(user_error,
-               'Usage: ... -- <facts.pl> <output-dir> [kernels_on|kernels_off] [facts_tsv|facts_lmdb]~n',
+               'Usage: ... -- <facts.pl> <output-dir> [kernels_on|kernels_off] [facts_tsv|facts_lmdb] [layout_profile]~n',
                []),
         halt(1)
     ).
@@ -145,6 +157,53 @@ parse_fact_storage(Atom, Mode) :-
     parse_fact_storage(String, Mode), !.
 parse_fact_storage(Atom, _) :-
     throw(error(domain_error(wam_c_fact_storage, Atom), _)).
+
+parse_layout_profile(parent_only, []).
+parse_layout_profile(child_scan, Options) :-
+    child_search_layout_options(Options).
+parse_layout_profile(child_csr_sorted, Options) :-
+    child_search_layout_options(ChildOptions),
+    append(ChildOptions,
+           [reverse_index(csr([index_backend(sorted_array),
+                               io_policy(buffered_pread)]))],
+           Options).
+parse_layout_profile(child_csr_buffered_drop, Options) :-
+    child_search_layout_options(ChildOptions),
+    append(ChildOptions,
+           [reverse_index(csr([index_backend(sorted_array),
+                               io_policy(buffered_pread_drop)]))],
+           Options).
+parse_layout_profile(child_csr_lmdb_offset, Options) :-
+    child_search_layout_options(ChildOptions),
+    append(ChildOptions,
+           [reverse_index(csr([index_backend(lmdb_offset),
+                               io_policy(buffered_pread)]))],
+           Options).
+parse_layout_profile("parent_only", Options) :-
+    parse_layout_profile(parent_only, Options).
+parse_layout_profile("child_scan", Options) :-
+    parse_layout_profile(child_scan, Options).
+parse_layout_profile("child_csr_sorted", Options) :-
+    parse_layout_profile(child_csr_sorted, Options).
+parse_layout_profile("child_csr_buffered_drop", Options) :-
+    parse_layout_profile(child_csr_buffered_drop, Options).
+parse_layout_profile("child_csr_lmdb_offset", Options) :-
+    parse_layout_profile(child_csr_lmdb_offset, Options).
+parse_layout_profile(Atom, Options) :-
+    atom(Atom),
+    atom_string(Atom, String),
+    parse_layout_profile(String, Options), !.
+parse_layout_profile(Atom, _) :-
+    throw(error(domain_error(wam_c_layout_profile, Atom), _)).
+
+child_search_layout_options([
+    child_search(bounded),
+    max_child_expansions(8),
+    child_search_depth(1),
+    parent_step_cost(1.0),
+    child_step_cost(2.0),
+    child_search_budget(1.0e100)
+]).
 
 parse_child_search_options(Options, ChildSearch) :-
     is_list(Options),

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
 from benchmark_effective_distance_matrix import (  # noqa: E402
     RunResult,
     benchmark_target,
+    build_wam_c_effective_distance,
     kernel_pair_delta_rows,
     parse_args,
     print_kernel_pair_deltas,
@@ -118,6 +119,41 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
             "hybrid-wam-lowered-helper",
         )
 
+    def test_c_child_search_layout_targets_are_registered_separately(self) -> None:
+        targets = resolve_targets(
+            explicit_targets=None,
+            target_set_names=["c-wam-child-search-layouts"],
+        )
+
+        self.assertEqual(
+            targets,
+            [
+                "c-wam-accumulated-child-scan",
+                "c-wam-accumulated-child-csr",
+                "c-wam-accumulated-child-csr-drop",
+                "c-wam-accumulated-child-csr-lmdb-offset",
+            ],
+        )
+        for target in targets:
+            self.assertEqual(TARGETS[target].category, "hybrid-wam-child-search")
+
+    def test_c_child_csr_layout_targets_are_registered_separately(self) -> None:
+        targets = resolve_targets(
+            explicit_targets=None,
+            target_set_names=["c-wam-child-csr-layouts"],
+        )
+
+        self.assertEqual(
+            targets,
+            [
+                "c-wam-accumulated-child-csr",
+                "c-wam-accumulated-child-csr-drop",
+                "c-wam-accumulated-child-csr-lmdb-offset",
+            ],
+        )
+        for target in targets:
+            self.assertEqual(TARGETS[target].category, "hybrid-wam-child-search")
+
     def test_scala_targets_are_registered(self) -> None:
         targets = resolve_targets(
             explicit_targets=None,
@@ -178,6 +214,17 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
             "scala-wam-accumulated,scala-wam-accumulated-artifact",
             text,
         )
+        self.assertIn(
+            "c-wam-child-search-layouts\tc-wam-accumulated-child-scan,"
+            "c-wam-accumulated-child-csr,c-wam-accumulated-child-csr-drop,"
+            "c-wam-accumulated-child-csr-lmdb-offset",
+            text,
+        )
+        self.assertIn(
+            "c-wam-child-csr-layouts\tc-wam-accumulated-child-csr,"
+            "c-wam-accumulated-child-csr-drop,c-wam-accumulated-child-csr-lmdb-offset",
+            text,
+        )
         self.assertIn("clojure-wam-scaffold\t", text)
 
     def test_effective_distance_runner_resolves_seeded_clojure_targets(self) -> None:
@@ -213,6 +260,29 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
         self.assertEqual(result.row_count, 1)
         run_command_mock.assert_called_once()
         self.assertEqual(run_command_mock.call_args.args[0], ["lowered-helper-benchmark"])
+
+    def test_c_child_csr_layout_build_passes_profile_to_generator(self) -> None:
+        with patch("benchmark_effective_distance_matrix.require_file") as require_file_mock, \
+             patch("benchmark_effective_distance_matrix.run_command") as run_command_mock, \
+             patch.object(Path, "exists", return_value=False):
+            require_file_mock.return_value = ROOT / "data" / "benchmark" / "dev" / "facts.pl"
+            run_command_mock.return_value = subprocess.CompletedProcess(
+                args=["wam-c-benchmark"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+
+            build_wam_c_effective_distance(
+                ROOT / "output" / "matrix-test",
+                "dev",
+                "kernels_on",
+                "facts_tsv",
+                "child_csr_sorted",
+            )
+
+        generator_command = run_command_mock.call_args_list[0].args[0]
+        self.assertEqual(generator_command[-1], "child_csr_sorted")
 
     def test_kernel_pair_registry_covers_registered_wam_pairs(self) -> None:
         pairs = {(pair.family, pair.mode): pair for pair in KERNEL_TARGET_PAIRS}

--- a/tests/test_benchmark_target_matrix.py
+++ b/tests/test_benchmark_target_matrix.py
@@ -17,6 +17,8 @@ from benchmark_effective_distance_matrix import (  # noqa: E402
     RunResult,
     benchmark_target,
     build_wam_c_effective_distance,
+    compile_only_result,
+    wam_c_artifact_size_message,
     kernel_pair_delta_rows,
     parse_args,
     print_kernel_pair_deltas,
@@ -283,6 +285,42 @@ class BenchmarkTargetMatrixTests(unittest.TestCase):
 
         generator_command = run_command_mock.call_args_list[0].args[0]
         self.assertEqual(generator_command[-1], "child_csr_sorted")
+
+    def test_wam_c_artifact_size_message_reports_generated_layout_files(self) -> None:
+        project_dir = (
+            ROOT
+            / "output"
+            / "matrix-test"
+            / "wam_c_kernels_on_facts_tsv_child_csr_sorted"
+            / "dev"
+        )
+        with patch("benchmark_effective_distance_matrix.file_tree_size_bytes") as size_mock:
+            size_mock.side_effect = lambda path: {
+                project_dir / "category_parent.tsv": 100,
+                project_dir / "category_child.csr.idx": 32,
+                project_dir / "category_child.csr.val": 64,
+            }.get(path, 0)
+
+            message = wam_c_artifact_size_message(
+                ROOT / "output" / "matrix-test",
+                "dev",
+                "c-wam-accumulated-child-csr",
+            )
+
+        self.assertIn("category_parent_tsv_bytes=100", message)
+        self.assertIn("reverse_csr_index_bytes=32", message)
+        self.assertIn("reverse_csr_values_bytes=64", message)
+
+    def test_compile_only_result_preserves_artifact_message(self) -> None:
+        result = compile_only_result(
+            "c-wam-accumulated-child-csr",
+            "dev",
+            1.25,
+            "generated/built but not executed; reverse_csr_values_bytes=64",
+        )
+
+        self.assertEqual(result.status, "compile_only")
+        self.assertEqual(result.message, "generated/built but not executed; reverse_csr_values_bytes=64")
 
     def test_kernel_pair_registry_covers_registered_wam_pairs(self) -> None:
         pairs = {(pair.family, pair.mode): pair for pair in KERNEL_TARGET_PAIRS}


### PR DESCRIPTION
  ## Summary

  - Adds WAM-C effective-distance matrix targets for bounded child-search layouts:
    - scan over loaded parent facts
    - sorted-array reverse CSR
    - buffered-pread-drop reverse CSR
    - LMDB-offset reverse CSR
  - Adds generator layout profiles for those child-search artifact modes.
  - Reports WAM-C artifact byte sizes in compile-only matrix rows.
  - Updates `WAM_C_TARGET_NEXT_STEPS.md` with dev parity results and 10x compile-only artifact-size evidence.

  ## Verification

  - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
  - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/
  benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py`
  - `python3 tests/test_benchmark_target_matrix.py`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets c-wam-child-search-
  layouts --repetitions 1 --baseline-target c-wam-accumulated-child-scan --run-timeout-seconds 180`
  - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10x --target-sets c-wam-child-csr-
  layouts --compile-only-targets c-wam-accumulated-child-csr,c-wam-accumulated-child-csr-drop,c-wam-accumulated-child-
  csr-lmdb-offset --baseline-target c-wam-accumulated-child-csr`
  - `git diff --check`

  ## Notes

  The dev child-search layout run matched outputs across all layouts. Full 10x child-search runtime rows are
  intentionally left as a longer benchmark window; this PR makes those layouts measurable and adds compile-only
  artifact-size reporting for routine larger-scale checks.