### PR TITLE
docs: add tree-likeness index theoretical-foundations companion

### DIFF
--- a/docs/design/TREE_LIKENESS_INDEX_THEORY.md
+++ b/docs/design/TREE_LIKENESS_INDEX_THEORY.md
@@ -134,21 +134,33 @@ $M$ ranges should yield consistent $b'$ estimates under
 homogeneity; the design note's §4.4 measurements at $cc \in
 \{100, 10, 5, 3\}$ are such an overlapping family.
 
-**Equivalent operational definition.** Equivalently,
+**Estimation in practice.** At fixed $B$, the maximum admissible
+$M$ is finite, so $b'$ cannot be extracted from a single
+$(B, cc)$ measurement. Instead, we run the kernel at a sequence
+of decreasing $cc$ values that admit successively more child
+hops. For two adjacent values $cc_1 > cc_2$ with
+$M_{\max}(B, cc_1) = m_1$ and $M_{\max}(B, cc_2) = m_2 > m_1$,
+under homogeneity
 $$
-b' = \lim_{cc \to 0^+}
-\left(\frac{\text{total } \#\text{paths at } (B, cc)}
-           {\text{total } \#\text{paths at } (B, cc = \infty)}\right)^{1/M_{\max}(B, cc)}
+\frac{\text{total } \#\text{paths at } (B, cc_2)}
+     {\text{total } \#\text{paths at } (B, cc_1)}
+\;\approx\;
+\frac{\sum_{M=0}^{m_2} (b')^M}{\sum_{M=0}^{m_1} (b')^M}
 $$
-where $M_{\max}(B, cc) = \lfloor B/cc \rfloor$. This makes the
-$cc \to 0^+$ regime explicit: $b'$ is the per-child-hop multiplier
-seen as we admit increasing numbers of child hops within fixed
-budget.
+so taking the geometric mean over transitions where
+$m_{k+1} - m_k = 1$ recovers $b'$ directly. For larger
+$M$ increments, the appropriate root corrects for the number
+of admitted child-hop levels.
 
-In practice (design note §4.4) we estimate $b'$ as the geometric
-mean of successive total-path-count ratios at $cc$ transitions
-$100 \to 10 \to 5 \to 3$, yielding $b' \approx 11$ on simplewiki
-topical core.
+In practice (design note §4.4), at $B = 15$ we use $cc \in
+\{100, 10, 5, 3\}$ with corresponding $M_{\max} \in \{0, 1, 3, 5\}$.
+The transition ratios are $1.05$, $122.7$, $18.7$; the
+per-child-hop growth recovers as $b' \approx \exp((\log 122.7)/2)
+\approx 11.1$ from the dominant transition (the
+$cc=100 \to 10$ ratio is essentially flat because that transition
+only admits $M = 1$ paths, which are few). The geometric mean
+across non-degenerate transitions gives $b' \approx 11$ on
+simplewiki topical core.
 
 ### 0.5 The tree-likeness index
 
@@ -163,6 +175,25 @@ $$
 i.e. the relative drift of the mean metric value as the child-step
 cost ranges from infinity (tree-search, $M = 0$ only) to
 $0^+$ (full DAG search, all $M$ admitted within budget).
+
+**Denominator choice.** We use
+$d_{\text{wPow}}(v; B, 0^+)$ — the full-DAG metric value — as the
+reference. The interpretation: tree-search is an *approximation*
+to the full-DAG value, and TLI is the relative approximation
+error of that approximation. Using $d_{\text{wPow}}(v; B, \infty)$
+as the denominator would give the inverse error; the absolute
+value in the numerator makes the index sign-agnostic
+regardless. (For the empirical drifts observed on simplewiki,
+the difference between the two normalisations is
+~0.02% × O(TLI) and immaterial.)
+
+**Absolute value.** The convergence direction is not guaranteed
+to be monotonic in $cc$ for all $(G, \mu, Q, B)$ — admitting
+more paths can either decrease or increase $d_{\text{wPow}}$
+depending on whether the new paths have above- or below-average
+$(h+1)^{-n}$ values. The absolute value handles both
+directions; empirically on simplewiki the drift is positive (the
+full-DAG value is slightly higher).
 
 In practice we estimate this with a finite contrast between two
 $cc$ values, typically $cc = 100$ (effectively tree-search at
@@ -197,10 +228,26 @@ homogeneous* if $\mathrm{supp}(Q)$ decomposes as
 $\bigsqcup_i V_i$ where each $(G|_{V_i}, Q|_{V_i}, B)$ is
 homogeneous. In this case the theorems below apply
 *piecewise* — each subgraph has its own $(D_i, b'_i,
-b_{\text{eff},i})$. This is the setting design note §4.5
-documents on Wikipedia: the global graph is piecewise
-homogeneous (topical regime + administrative regime) but not
-globally homogeneous.
+b_{\text{eff},i})$.
+
+**Important caveat.** The piecewise framing only applies when $Q$
+is restricted to a single component $V_i$ at calibration time
+(equivalently, the calibration sees only the subgraph
+$G|_{V_i}$). If $Q$ mixes nodes from multiple components — i.e.
+the query distribution genuinely spans different statistical
+regimes — Lemma 2.1's factorisation fails (different parts of
+$\mathrm{supp}(Q)$ produce different $(D, b')$ values), and
+neither Theorem 2.3 nor Corollary 2.3.1 applies. The
+recommended workflow is to *constrain* $Q$ to a single
+homogeneous component via the topical-root LMDB construction
+(design note §7.1), not to apply theorems piecewise to a query
+that crosses components.
+
+This is the setting design note §4.5 documents on Wikipedia: the
+global graph is piecewise homogeneous (topical regime +
+administrative regime) but not globally homogeneous, and the
+production recipe constrains $Q$ to the topical component
+specifically because cross-component queries break the theory.
 
 ## 1. Background: established results we build on
 
@@ -316,19 +363,40 @@ ultra-small-world consequences from this fit.
 distribution $P(k)$, the expected degree of a node reached by
 following a random edge is
 $$
-\frac{\mathbb{E}[k^2]}{\mathbb{E}[k]} \ge \mathbb{E}[k]
+\tilde{d} := \frac{\mathbb{E}[k^2]}{\mathbb{E}[k]} \ge \mathbb{E}[k]
 $$
-with equality iff degrees are constant.
+with equality iff degrees are constant. The quantity $\tilde{d}$
+is the *size-biased mean* or **Chung-Lu effective degree** (cf.
+§1.1).
 
 Source: S. L. Feld, "Why your friends have more friends than you
 do", *American Journal of Sociology* 96(6): 1464–1477 (1991).
 
-**Relevance to TLI.** The first-moment correction in our
-definition of $b_{\text{eff}}$ versus the raw second-moment ratio
-$b$ is precisely this size-biased correction applied separately
-to the child and parent edge populations. Design note §4.4
-labels this the "degree-bias correction"; this lemma is the
-underlying reason it has the form it does.
+**Relevance to TLI: $b_{\text{eff}}$ is the ratio of Chung-Lu
+effective degrees.** Applying the size-biased mean separately to
+the child and parent edge populations gives
+$$
+\tilde{d}_c = \frac{\mathbb{E}[d_c^2]}{\mathbb{E}[d_c]}, \qquad
+\tilde{d}_p = \frac{\mathbb{E}[d_p^2]}{\mathbb{E}[d_p]}
+$$
+and our calibrated branching asymmetry is exactly the ratio
+$$
+b_{\text{eff}}
+= \frac{\mathbb{E}[d_c^2]/\mathbb{E}[d_c]}{\mathbb{E}[d_p^2]/\mathbb{E}[d_p]}
+= \frac{\tilde{d}_c}{\tilde{d}_p}
+$$
+i.e. the Chung-Lu effective degree in the child direction divided
+by the Chung-Lu effective degree in the parent direction. **Low
+TLI thus has a clean interpretation: the child-direction
+Chung-Lu effective degree dominates the parent-direction one by
+a factor large enough that the convergence inequality
+$b_{\text{eff}} \cdot D > b'$ holds.**
+
+The raw second-moment ratio $b = \mathbb{E}[d_c^2]/\mathbb{E}[d_p^2]$
+omits the first-moment factors and is only approximately equal
+to $b_{\text{eff}}$ when $\mathbb{E}[d_c] \approx \mathbb{E}[d_p]$;
+on simplewiki the two differ by the factor 0.436 (design note
+§4.4), the same first-moment correction.
 
 ### 1.6 Tree pair distance
 
@@ -463,15 +531,26 @@ Multiplying:
 
 For the numerator,
 $$S_M \approx \sum_N r^M \cdot (N+M+1)^{-n} = r^M \cdot L_M$$
-where $L_M = \sum_{N \in [\text{admissible range}]} (N+M+1)^{-n}$.
-Since the length factor $(N+M+1)^{-n}$ decreases in both $N$
-and $M$, $L_M \le L_0$ for all $M \ge 0$, so
-$S_M / S_0 \le r^M$ and the geometric sum gives the bound.
+where $L_M := \sum_{N \in [d_{\min},\ B - M \cdot cc]} (N+M+1)^{-n}$.
+
+**Claim: $L_M \le L_0$ for all $M \ge 0$.** For each $N$ in the
+admissible range at level $M$ (which is a subset of the level-0
+range $[d_{\min}, B]$ truncated from the top by $M \cdot cc$),
+$(N+M+1)^{-n} \le (N+1)^{-n}$ pointwise since $x \mapsto x^{-n}$
+is decreasing. So $L_M$ is term-by-term dominated and has fewer
+or equal terms compared to $L_0$, giving $L_M \le L_0$. Hence
+$S_M / S_0 \le r^M$ and the geometric sum gives
+$\sum_{M \ge 1} S_M / S_0 \le r/(1-r)$.
 
 For the denominator,
-$$W_M \approx \sum_N r^M = r^M \cdot |\text{admissible } N \text{ range at level } M|$$
-The range size shrinks weakly in $M$ (the budget loses capacity
-$cc$ per child hop), so $W_M / W_0 \le r^M$ similarly. $\square$
+$$W_M \approx \sum_N r^M = r^M \cdot R_M$$
+where $R_M$ is the size of the admissible $N$-range at level $M$.
+
+**Claim: $R_M \le R_0$ for all $M \ge 0$.** The level-$M$ range
+$[d_{\min}, B - M \cdot cc]$ is a (possibly empty) subset of the
+level-0 range $[d_{\min}, B]$ obtained by truncating from the
+top, so $R_M \le R_0$. Hence $W_M / W_0 \le r^M$, hence
+$\sum_{M \ge 1} W_M / W_0 \le r/(1-r)$. $\square$
 
 **Caveats and tightness.**
 
@@ -578,26 +657,42 @@ test.
 This is the "decoupling geometry from metric" claim of design
 note §5.6.2 stated as a falsifiable conjecture.
 
-### 3.3 Sharpening of the bound: $\psi(r) \sim r^2 / (1 - r)$
+### 3.3 Sharpening of the bound (refinement of Conjecture 3.1)
+
+This conjecture *refines* Conjecture 3.1 by proposing a specific
+form for the function $\psi$ — it is not an independent claim
+but a guess at the leading-order asymptotic.
 
 **Conjecture 3.3.** The function $\psi$ in Conjecture 3.1
-satisfies $\psi(r) \le C \cdot r^2 / (1 - r)$ for some constant
-$C$ depending only on $n$ (the power-mean exponent) and
-$\mathrm{depth}_{\min}$ (the minimum distance from the support
-of $Q$ to the root).
+satisfies $\psi(r) \le C(n, B, d_{\min}) \cdot r^{\alpha} / (1 - r)$
+for some constant $C$ depending on $n$, the budget $B$, and the
+minimum distance $d_{\min}$ from the support of $Q$ to the
+root, with exponent $\alpha \ge 1$.
 
 **Motivation.** Theorem 2.3 bounds the *individual*
-contribution-sum drifts (numerator and denominator) by $r/(1-r)$.
-But $d_{\text{wPow}}$ is the ratio of these sums; if both drift
-by the same amount, the ratio drift is second-order in $r$. The
-empirical gap (theorem bound $r/(1-r) \approx 18.6\%$ vs
-empirical TLI ~$0.02\%$, a factor of ~1000) is consistent with
-this conjectured tighter scaling.
+contribution-sum drifts by $r/(1-r)$, but $d_{\text{wPow}}$ is
+the ratio of these sums and the drifts partially cancel. The
+question is *how much* they cancel — i.e. what $\alpha$ is.
 
-**Status.** Open. Even the constant $C$ is unknown; a careful
-calculation distinguishing the numerator and denominator
-contribution sums via their different length-factor dependences
-should resolve it.
+**Status.** Open in two directions:
+
+1. **First-order analysis at simplewiki parameters
+   ($B = 15, cc = 5, n = 2$) does NOT give clean $\alpha = 2$
+   scaling.** See §5.1 for the numerical check: $L_M / L_0$ and
+   $R_M / R_0$ differ by ~30–60% at level $M = 1$, so the $r^1$
+   coefficient does not cancel and the leading-order TLI
+   prediction is ~2.1%, not ~$r^2 \approx 0.025\%$.
+2. **The empirical TLI is still ~100× smaller than the first-
+   order prediction** (0.02% vs 2.1%). The source of this further
+   gap is unclear — candidates include budget-truncated $M$
+   ranges, higher-order Taylor terms with their own cancellation,
+   or measurement variance in the aggregate over only 20 seed
+   pairs.
+
+A definitive answer requires either a careful expansion to
+higher order in $r$, or empirical Monte Carlo at varying $r$ to
+fit $\alpha$ directly. The conjecture as stated is *consistent
+with* but not *derived from* the empirical observations.
 
 ### 3.4 Topical scoping is sufficient for homogeneity on Wikipedia
 
@@ -661,6 +756,17 @@ $b_{\text{eff}}$ to roughly $1/3$ of its honest value, which the
 robustness band absorbs but is not principled. See design note
 §5.4 for the discussion.
 
+**Directionality clarification.** A stronger statement than
+"unnecessary": $\rho < 1$ deflates $b_{\text{eff}}$, which
+*decreases* $\mathrm{BranchRatio}$, *increases* the convergence
+ratio $r = b'/(\mathrm{BranchRatio} \cdot D)$, and *loosens* the
+Theorem 2.3 bound. Dropping the routing correction therefore
+gives a *strictly tighter* theoretical bound on TLI, not just a
+simpler formula. The conjecture is more precisely "the routing
+correction was actively miscalibrating in the wrong direction,
+and dropping it gives a better-justified bound while leaving
+empirical TLI unchanged."
+
 **Status.** *Tentative.* The drift probe under the alternate
 composition has not been re-run on topical calibration. Task #14
 in the design note is to settle this empirically by measuring
@@ -670,9 +776,11 @@ TLI under both compositions and verifying both remain below the
 **Production consequence.** If confirmed, the data-prep recipe
 (design note §7.1) and calibration recipe (§7.2) become
 unconditionally simpler: drop the routing correction term, use
-$b_{\text{eff}}$ directly. If refuted, the routing correction
-stays but its theoretical role becomes "calibration-error
-band-aid" rather than "principled factor."
+$b_{\text{eff}}$ directly. The theoretical bound becomes tighter
+in the bargain. If refuted (i.e. dropping routing correction
+substantially increases TLI), the routing correction stays but
+its theoretical role becomes "calibration-error band-aid for an
+unmodelled effect" rather than "principled factor."
 
 ## 4. Empirical status
 
@@ -710,13 +818,21 @@ original design note pre-correction had this as $b_{\text{eff}}
 relationship between these calibrations is documented in design
 note §2.0's notation table.
 
-### 4.3 Conjecture 3.3 ($\psi \sim r^2/(1-r)$ tightening)
+### 4.3 Conjecture 3.3 ($\psi$ sharpening)
 
-Pending: a careful theoretical analysis distinguishing the
-numerator and denominator contribution sums via their different
-length-factor dependences. The empirical 1000× gap between the
-contribution-sum bound and the actual TLI is consistent with the
-conjectured $r^2$ scaling.
+**Mixed evidence.** First-order Taylor analysis at simplewiki
+parameters (§5.1) reduces the bound from the $r/(1-r) \approx
+18.6\%$ contribution-sum estimate to ~2.1% (after partial num/
+denom cancellation), but does *not* reach the empirical 0.02%.
+A clean $r^2/(1-r)$ scaling would predict ~0.025%, agreeing
+within 1.5× — but this is post-hoc fitting, not derivation.
+
+Until a careful expansion to higher order in $r$ resolves the
+exponent $\alpha$, Conjecture 3.3 is consistent with the data
+but not derived from theory. Pending: either an analytic
+expansion of $d_{\text{wPow}}(B, cc)$ to second order in $r$, or
+Monte Carlo evaluation at varying $r$ to fit $\alpha$
+empirically.
 
 ### 4.4 Conjecture 3.4 (topical homogeneity)
 
@@ -753,27 +869,56 @@ i.e. a bound on *individual* contribution-sum drifts. On
 simplewiki this gives $r/(1 - r) \approx 0.186$, while
 empirically TLI is ~0.02% — a factor of ~1000 gap.
 
-The gap arises because $d_{\text{wPow}} = (N/W)^{-1/n}$ is a
-*ratio*. To first order in $r$,
+Since $d_{\text{wPow}} = (N/W)^{-1/n}$ is a *ratio*, the first-
+order TLI estimate is
 $$
-\frac{\mathrm{TLI}}{1} \approx \frac{1}{n}
+\mathrm{TLI} \approx \frac{1}{n}
 \bigl|\Delta\log N - \Delta\log W\bigr|
 $$
-where $\Delta\log N \approx \sum r^k L_k / L_0$ and
-$\Delta\log W \approx \sum r^k R_k / R_0$ with $L_M$ the
-length-factor sum at level $M$ and $R_M$ the admissible-$N$
-range at level $M$. Both $\Delta\log N$ and $\Delta\log W$ are
-bounded by $r/(1-r)$ but their *difference* is much smaller —
-both are dominated by the same $r/(1-r)$ leading term, and the
-correction depends on the *ratio* $L_M/R_M$ vs $L_0/R_0$.
+where $\Delta\log N \approx \sum_{k \ge 1} r^k L_k / L_0$ and
+$\Delta\log W \approx \sum_{k \ge 1} r^k R_k / R_0$.
 
-**Open question (Conjecture 3.3).** Is $\psi(r) = O(r^2/(1-r))$
-the correct scaling, with the constant depending on $n$,
-$d_{\min}$, and the budget $B$? A careful Taylor expansion of
-the ratio $N/W$ in $r$ should resolve this. The empirical 1000×
-gap is consistent with $r^2$ scaling: $r^2/(1-r) \approx 0.029$
-for $r = 0.157$, only ~1.5× off from the empirical 0.02% (and
-closer once the constant $C$ is known).
+**Numerical check at simplewiki parameters does not support
+clean $r^2$ scaling.** For $B = 15$, $cc = 5$, $n = 2$,
+$d_{\min} = 4$:
+
+| Level $M$ | $L_M$ | $L_M / L_0$ | $R_M$ | $R_M / R_0$ | $L_M/L_0 - R_M/R_0$ |
+|---|---|---|---|---|---|
+| 0 | $\approx 0.149$ | 1.000 | 12 | 1.000 | 0 |
+| 1 | $\approx 0.140$ | 0.940 | 8 | 0.667 | 0.273 |
+| 2 | $\approx 0.122$ | 0.819 | 3 | 0.250 | 0.569 |
+
+The $r^1$ coefficient does *not* cancel — the difference at
+$M=1$ alone is $0.273 r$, giving a leading-order contribution of
+$\approx 0.5 \cdot 0.273 \cdot 0.157 \approx 0.021$, i.e. ~2.1%.
+This is much smaller than the contribution-sum bound (18.6%)
+but still ~100× larger than the empirical TLI of 0.02%.
+
+**Status: Conjecture 3.3's $\psi \sim r^2/(1-r)$ scaling is not
+yet supported.** A naive first-order Taylor expansion in $r$
+gives a ~2.1% prediction, not $r^2 \approx 0.025\%$. The
+remaining ~100× gap between first-order theory and empirical
+TLI likely has a different source — possibilities:
+
+- **Budget-constrained M range.** At $B = 15, cc = 5$ only
+  $M \in \{0, 1, 2, 3\}$ are admissible, and $M \in \{2, 3\}$
+  have very restricted $N$-ranges (3 values and 1 value
+  respectively). The effective sum is short and the higher-$M$
+  contributions are heavily truncated.
+- **Higher-order cancellation.** The Taylor expansion at $r=0$
+  may have larger higher-order terms that further reduce TLI;
+  computing the next term explicitly would resolve this.
+- **The simplewiki measurement itself.** TLI = 0.02% is the
+  *aggregate* over 20 seed pairs; per-pair drifts of 0.007%
+  worst-case (design note §4.2) are still 50× smaller than 2.1%.
+
+**Open question.** What is the actual scaling of $\psi(r)$ as a
+function of $r$ and the budget $B$? An honest answer requires
+either (i) a careful Taylor expansion accounting for the budget-
+truncated $L_M, R_M$ sums, or (ii) Monte Carlo evaluation at
+varying $r$ to fit the exponent empirically. Conjecture 3.3 as
+stated is *consistent with* the empirical gap but not derived
+from it.
 
 ### 5.2 Quantitative homogeneity ↔ calibration error
 

--- a/docs/design/TREE_LIKENESS_INDEX_THEORY.md
+++ b/docs/design/TREE_LIKENESS_INDEX_THEORY.md
@@ -1,0 +1,600 @@
+# Tree-likeness index: theoretical foundations
+
+**Companion to** [`TREE_LIKENESS_INDEX.md`](TREE_LIKENESS_INDEX.md), which
+documents the empirical observation, the calibration recipe, and the
+algorithmic consequences. This document attempts to formalise the
+theoretical content: what we can prove, what we conjecture, what is
+borrowed from existing literature.
+
+**Status**: Work in progress. Most central claims are conjectures
+rather than theorems. Established results from graph theory are
+cited; novel claims are clearly labelled. The design note's §4
+documents the empirical evidence supporting the conjectures here.
+
+**Scope**: We formalise the *tree-likeness index* `TLI(G, μ, Q, B)`
+as a statistical quantity computed from a directionally-weighted
+metric on a directed graph. The central conjecture (§3.1) gives an
+operational sufficient condition for low TLI in terms of two
+calibrated graph quantities `b_eff` and `D`. The non-trivial
+structural feature that makes the index interesting is *directional
+asymmetry* (parent-direction branching vs child-direction shortcut
+frequency), not acyclicity or any global structural label.
+
+## 0. Setup and notation
+
+### 0.1 The graph
+
+Let $G = (V, E)$ be a directed graph with a designated root
+$r \in V$. We do **not** require $G$ to be strictly acyclic: rare
+directed cycles are tolerated by visited-set pruning in traversal,
+and contribute negligibly to path counts when present below ~1%
+of vertices (which is the case for Wikipedia category graphs).
+
+What we *do* require is a parent/child decomposition: for each
+non-root $v$, define
+$$
+\mathrm{parents}(v) \subseteq V, \quad
+\mathrm{children}(v) \subseteq V
+$$
+as the sets of nodes connected to $v$ by an in-edge or out-edge
+respectively, in the categorisation interpretation. The
+distinction between "parent direction" and "child direction" is
+load-bearing — it is what gives the metric below its directional
+character.
+
+The relevant structural feature is **multi-parent connectivity**:
+typically $|\mathrm{parents}(v)| > 1$ for most non-root nodes,
+creating abundant undirected cycles (alternate ancestor paths
+through different parent chains). These undirected cycles are
+the *subject* of the index, not a perturbation to it.
+
+### 0.2 Paths
+
+A *path* from $v$ to $r$ in $G$ is a sequence
+$v = v_0 \to v_1 \to \dots \to v_k = r$ where each step is either a
+**parent hop** ($v_{i+1} \in \mathrm{parents}(v_i)$) or a
+**child hop** ($v_{i+1} \in \mathrm{children}(v_i)$). We
+decompose:
+
+- $N(p)$ = number of parent hops in path $p$
+- $M(p)$ = number of child hops in path $p$
+- $h(p) = N(p) + M(p)$ = total hop count
+
+We assume the traversal uses a visited-set so paths are simple
+(no node repeated).
+
+### 0.3 The directionally-weighted metric
+
+Following the design note's §2.0 notation, let:
+
+- $D := \mathbb{E}[d_c]$, the average child fan-out
+- $b := \mathbb{E}[d_c^2] / \mathbb{E}[d_p^2]$, the raw
+  second-moment ratio (the "early-formula" calibration)
+- $b_{\text{eff}} := \frac{\mathbb{E}[d_c^2]/\mathbb{E}[d_c]}{\mathbb{E}[d_p^2]/\mathbb{E}[d_p]}$, the
+  friendship-paradox-corrected branching asymmetry
+- $b'$ := the empirical per-child-hop path-count growth (defined
+  in §0.4 below)
+
+The path weight is
+$$
+w(p) = D^{-N(p)} \cdot (b \cdot D)^{-M(p)}
+$$
+and the **directionally-weighted power-mean metric** with exponent
+$n$ is
+$$
+d_{\text{wPow}}(v; B, cc) = \left(
+\frac{\sum_{p \in \mathcal{P}(v; B, cc)} w(p) \cdot (h(p)+1)^{-n}}
+     {\sum_{p \in \mathcal{P}(v; B, cc)} w(p)}
+\right)^{-1/n}
+$$
+where $\mathcal{P}(v; B, cc)$ is the set of paths from $v$ to $r$
+with cost at most $B$ when each parent hop costs $1$ and each
+child hop costs $cc$. We typically use $n = 2$ in experiments.
+
+### 0.4 Path-count growth
+
+For a node $v$ reachable to $r$ within budget $B$, define
+$$
+\#\text{paths}(v; N, M; B) :=
+\bigl|\{p : v \to r,\ p \text{ has } N \text{ parent hops}
+              \text{ and } M \text{ child hops, cost} \le B\}\bigr|
+$$
+The **empirical per-child-hop path-count growth** is
+$$
+b'(G, Q, B) := \lim_{M \to \infty}
+\frac{\mathbb{E}_{v \sim Q}\bigl[\#\text{paths}(v; \cdot, M+1; B)\bigr]}
+     {\mathbb{E}_{v \sim Q}\bigl[\#\text{paths}(v; \cdot, M; B)\bigr]}
+$$
+where the dot in $\#\text{paths}(v; \cdot, M; B)$ denotes summation
+over $N$, and the limit is taken over $M$ values for which both
+quantities are non-zero. In practice we estimate $b'$ from a
+finite range of $M$ by running the bidirectional kernel at
+varying $cc$ and reading the ratio of total path counts (design
+note §4.4).
+
+### 0.5 The tree-likeness index
+
+The **tree-likeness index** of the tuple $(G, \mu, Q, B)$ where
+$\mu$ is the directionally-weighted metric is
+$$
+\mathrm{TLI}(G, \mu, Q, B) :=
+\frac{\bigl|\mathbb{E}_{v \sim Q}\bigl[d_{\text{wPow}}(v; B, \infty)\bigr] -
+            \mathbb{E}_{v \sim Q}\bigl[d_{\text{wPow}}(v; B, 0^+)\bigr]\bigr|}
+     {\mathbb{E}_{v \sim Q}\bigl[d_{\text{wPow}}(v; B, 0^+)\bigr]}
+$$
+i.e. the relative drift of the mean metric value as the child-step
+cost ranges from infinity (tree-search, $M = 0$ only) to
+$0^+$ (full DAG search, all $M$ admitted within budget).
+
+In practice we estimate this with a finite contrast between two
+$cc$ values, typically $cc = 100$ (effectively tree-search at
+$B = 15$) and $cc = 5$ (admits up to 3 child hops); see design
+note §4.1.
+
+## 1. Background: established results we build on
+
+### 1.1 Random-graph distances (Erdős–Rényi / Chung–Lu)
+
+**Theorem (Chung & Lu, 2002).** For a random graph $G(n, p)$ with
+expected average degree $\langle k \rangle = pn$ satisfying
+$np \to \infty$, the average shortest-path length between random
+node pairs satisfies
+$$
+L \sim \frac{\log n}{\log \langle k \rangle}
+$$
+as $n \to \infty$.
+
+Source: F. Chung and L. Lu, "The average distances in random
+graphs with given expected degrees", *PNAS* 99(25): 15879–15882
+(2002).
+
+This is the baseline for "what branching alone achieves" in a
+homogeneous graph — relevant to §5.3 of the design note's
+geometric-regime comparison.
+
+### 1.2 The small-world property (Watts–Strogatz)
+
+**Definition (Watts & Strogatz, 1998).** A graph is *small-world*
+if it simultaneously satisfies:
+
+1. $L = \Theta(\log n)$ (logarithmic average shortest-path length)
+2. $C \gg C_{\text{random}}$ (clustering coefficient significantly
+   above that of a random graph of the same size and density)
+
+Source: D. J. Watts and S. H. Strogatz, "Collective dynamics of
+'small-world' networks", *Nature* 393: 440–442 (1998).
+
+### 1.3 Ultra-small-world for scale-free graphs (Cohen–Havlin)
+
+**Theorem (Cohen & Havlin, 2003).** For a scale-free network with
+degree distribution $P(k) \propto k^{-\gamma}$:
+
+- If $\gamma > 3$: $L \sim \log n / \log \langle k \rangle$
+- If $\gamma = 3$: $L \sim \log n / \log \log n$
+- If $2 < \gamma < 3$: $L \sim \log \log n$ (ultra-small-world)
+- If $\gamma \le 2$: $L = O(1)$ (degenerate; degree diverges
+  with $n$)
+
+The result requires *statistical homogeneity* of the graph: the
+degree distribution holds uniformly across $V$, with no
+sub-populations having qualitatively different scaling.
+
+Source: R. Cohen and S. Havlin, "Scale-free networks are
+ultrasmall", *Physical Review Letters* 90(5): 058701 (2003).
+
+**Relevance to TLI.** The Cohen–Havlin theorem governs the
+*geometric* regime of the graph (how distances scale with $n$).
+It does not directly bound TLI, but it constrains the family of
+graphs on which TLI can be low under any single global
+calibration (see §5.6.2 of the design note).
+
+### 1.4 Power-law fitting methodology (Clauset–Shalizi–Newman)
+
+**Method (Clauset, Shalizi & Newman, 2009).** Given empirical data
+$\{d_1, \dots, d_n\}$ believed to follow a power-law tail
+$P(k) \propto k^{-\gamma}$ for $k \ge d_{\min}$:
+
+1. For each candidate $d_{\min}$, compute the continuous MLE
+$$
+\hat\gamma(d_{\min}) = 1 + n_{\ge d_{\min}} \biggm/
+\sum_{d_i \ge d_{\min}} \log(d_i / d_{\min})
+$$
+2. Compute the Kolmogorov-Smirnov distance between the empirical
+   tail CDF and the fitted power-law tail CDF
+3. Select the $d_{\min}$ that minimises KS distance
+
+Source: A. Clauset, C. R. Shalizi, and M. E. J. Newman,
+"Power-law distributions in empirical data", *SIAM Review*
+51(4): 661–703 (2009).
+
+**Application here.** Design note §4.4 reports
+$\gamma = 2.41 \pm 0.05$ and $d_{\min} = 29$ with KS distance
+$0.048$ on the simplewiki child-degree distribution (global). The
+fit is statistically valid, but §5.6.2 explains why the
+homogeneity precondition is what blocks invoking Cohen-Havlin
+ultra-small-world consequences from this fit.
+
+### 1.5 Friendship paradox / size-biased degree (Feld)
+
+**Lemma (Feld, 1991).** For a graph with finite degree
+distribution $P(k)$, the expected degree of a node reached by
+following a random edge is
+$$
+\frac{\mathbb{E}[k^2]}{\mathbb{E}[k]} \ge \mathbb{E}[k]
+$$
+with equality iff degrees are constant.
+
+Source: S. L. Feld, "Why your friends have more friends than you
+do", *American Journal of Sociology* 96(6): 1464–1477 (1991).
+
+**Relevance to TLI.** The first-moment correction in our
+definition of $b_{\text{eff}}$ versus the raw second-moment ratio
+$b$ is precisely this size-biased correction applied separately
+to the child and parent edge populations. Design note §4.4
+labels this the "degree-bias correction"; this lemma is the
+underlying reason it has the form it does.
+
+### 1.6 Tree pair distance
+
+**Lemma (folklore).** In a balanced $D$-ary tree of depth $L$ with
+$n = (D^{L+1} - 1)/(D - 1)$ nodes:
+
+- Depth-to-root: $L = \log_D(n(D - 1) + 1) \approx \log_D n$
+- Average pair distance: for any two distinct nodes $u, v$,
+$$
+\mathbb{E}_{u,v}[d(u,v)] \le 2L \approx 2 \log_D n
+$$
+with equality approached as $D \to \infty$ (large branching makes
+LCAs shallow).
+
+**Proof sketch.** The distance between $u$ and $v$ is
+$\mathrm{depth}(u) + \mathrm{depth}(v) - 2 \cdot \mathrm{depth}(\mathrm{LCA}(u,v))$.
+For uniform-random $u, v$ in the leaves of a balanced tree, the
+probability that the LCA is at depth $\ge \ell$ is approximately
+$D^{-\ell}$, so the expected LCA depth is $O(1/(D-1))$, vanishing
+for large $D$. The pair distance is therefore close to twice the
+depth $L$. $\square$
+
+**Relevance to TLI.** A tree-shaped graph is the structural
+limit where TLI is trivially $0$ — there are no cross-edge paths
+to admit, so the metric is path-invariant in $cc$. The interest
+of TLI is what happens *between* this limit and a graph with no
+asymmetry at all (§3 conjecture below).
+
+## 2. What we can prove
+
+We state three results that follow from the definitions in §0 and
+mild homogeneity assumptions. They are *not* the central
+conjecture (§3.1); they are building blocks supporting it.
+
+### 2.1 Path-count growth lemma (conditional on homogeneity)
+
+**Lemma 2.1.** Suppose $G$ is *statistically homogeneous* in the
+following sense: there exist constants $D = \mathbb{E}[d_c]$ and
+$b' \ge 1$ such that, uniformly over all
+$v \in V$ reachable to $r$,
+$$
+\#\text{paths}(v; N, M; B) \approx D^N \cdot (b')^M
+$$
+as $N, M$ range over admissible hop counts within budget $B$,
+where the approximation holds up to a multiplicative
+$(1 + o(1))$ factor.
+
+Then for any query distribution $Q$ supported on the reachable
+set,
+$$
+\mathbb{E}_{v \sim Q}\bigl[\#\text{paths}(v; N, M; B)\bigr] \approx D^N \cdot (b')^M
+$$
+with the same asymptotic factor.
+
+**Proof.** Direct by linearity of expectation, applied to the
+log-path-count under the homogeneity assumption. $\square$
+
+**Remark.** The homogeneity assumption here is restrictive. For
+inhomogeneous graphs (Wikipedia, globally), the path-count
+function has different growth rates in different regions of $V$,
+and the lemma fails. This is what design note §4.5 documents and
+§5.6.2 reframes as the homogeneity precondition. For the
+homogeneous topical core (`Category:Articles` reach), the lemma
+holds empirically with $D \approx 7.34$ and $b' \approx 11$.
+
+### 2.2 Weights normalise path counts
+
+**Proposition 2.2.** Under the homogeneity assumption of Lemma 2.1
+with calibration $b \cdot D = b'$,
+$$
+w(p) \cdot \#\text{paths}\bigl(\cdot;\ N(p), M(p);\ B\bigr) \approx 1
+$$
+for all paths $p$, i.e. the weight formula is precisely a
+path-count normaliser.
+
+**Proof.** Direct substitution:
+$$
+w(p) = D^{-N(p)} (b \cdot D)^{-M(p)}
+     = D^{-N(p)} (b')^{-M(p)}
+$$
+By Lemma 2.1,
+$\#\text{paths}(N, M) \approx D^N (b')^M$, so the product is
+$1$ up to the $(1+o(1))$ factor. $\square$
+
+This is the formal statement of design note §5.6's "weights as
+path-count normalisers" reframing.
+
+### 2.3 Convergence theorem (geometric series bound)
+
+**Theorem 2.3.** Suppose Lemma 2.1 holds with growth constants
+$D$ and $b'$, and suppose the metric is calibrated with
+$b \cdot D > b'$. Define the convergence ratio
+$$
+r := \frac{b'}{b \cdot D} < 1
+$$
+Then the contribution to the numerator of $d_{\text{wPow}}$ from
+paths with $M \ge 1$ child hops, weighted by the length factor
+$(h+1)^{-n}$, is bounded by
+$$
+\sum_{M \ge 1} \mathrm{contribution}(M) \le
+\frac{r}{1 - r} \cdot d_{\text{wPow}}(M = 0)
+$$
+where $d_{\text{wPow}}(M = 0)$ denotes the contribution from
+parent-only paths.
+
+**Proof.** By Lemma 2.1 and Proposition 2.2, the *weighted*
+contribution at level $(N, M)$ is approximately
+$$
+w \cdot \#\text{paths}(N, M) \cdot (h+1)^{-n}
+  \approx (h+1)^{-n}
+$$
+i.e. the abundance and weight cancel. The contribution at level
+$M$ summed over $N$ is therefore proportional to
+$D^N \cdot (b')^M \cdot D^{-N} \cdot (b \cdot D)^{-M} = (b')^M / (b \cdot D)^M = r^M$
+times the length factor. Summing the geometric series in $M$
+gives the stated bound. $\square$
+
+**Corollary 2.3.1** (informal version of the convergence
+conjecture). Under the assumptions of Theorem 2.3, the
+contribution of child-using paths to $d_{\text{wPow}}$ is bounded
+by $r/(1-r)$ times the parent-only contribution. When $r$ is
+small (typical: $r \approx 0.157$ on simplewiki topical core), the
+contribution is small. **This is a partial proof of Conjecture
+3.1 under the additional homogeneity assumption.**
+
+## 3. Conjectures
+
+### 3.1 The central conjecture: convergence as a sufficient condition
+
+**Conjecture (Main).** There exists a monotone-increasing function
+$\psi : [0, 1) \to \mathbb{R}_{\ge 0}$ with $\psi(0) = 0$ and
+$\psi(r) \to \infty$ as $r \to 1^-$, such that for any $(G, \mu, Q, B)$
+satisfying:
+
+(a) *Homogeneity precondition*: the path-count growth in §0.4 is
+well-defined and uniform across the support of $Q$, yielding
+constants $D(G, Q)$, $b'(G, Q, B)$, $b_{\text{eff}}(G, Q)$.
+
+(b) *Convergence condition*:
+$b_{\text{eff}}(G, Q) \cdot D(G, Q) > b'(G, Q, B)$.
+
+Then
+$$
+\mathrm{TLI}(G, \mu, Q, B) \le \psi\!\left(\frac{b'}{b_{\text{eff}} \cdot D}\right)
+$$
+
+In words: under the homogeneity precondition, the TLI is bounded
+by a function of the convergence ratio $r = b'/(b_{\text{eff}} \cdot D)$.
+
+**Partial support.** Theorem 2.3 establishes the bound with
+$\psi(r) = r/(1-r)$ under additionally assuming exact path-count
+factorisation (Lemma 2.1) and exact calibration $b \cdot D = b'$.
+In practice $b_{\text{eff}}$ and $b'$ agree only approximately
+(within ~15% on simplewiki, §4.5 of the design note); the
+conjecture extends Theorem 2.3 to the empirical regime where
+this approximation is not exact.
+
+### 3.2 Topical scoping is sufficient for homogeneity on Wikipedia categories
+
+**Conjecture 3.2.** For Wikipedia category graphs of the form
+"all descendants of a single top-level topical root" (e.g.
+`Category:Articles` on simplewiki, `Category:Main_topic_classifications`
+on enwiki), the homogeneity precondition of Conjecture 3.1 holds
+to a degree sufficient for low TLI in practice.
+
+**Partial support.** Design note §4.5 measures
+$b_{\text{eff}}$ on `Category:Articles` (9.59) and on
+`Category:Physics` (9.51), finding ~1% agreement. This is
+evidence that the topical core is *statistically self-similar*
+across different sub-trees — a necessary condition for
+homogeneity.
+
+**Caveat.** The conjecture has been tested on simplewiki only.
+The enwiki topical-root verification (page_id 7345184 confirmed,
+LMDB construction pending) is task #14 in the design note.
+
+### 3.3 The convergence inequality is the operative condition
+
+**Conjecture 3.3.** For graphs satisfying the homogeneity
+precondition, $b_{\text{eff}} \cdot D > b'$ is the operative
+condition for low TLI — i.e. the *graph-structural* properties
+sometimes invoked as sufficient (power-law tail, dominant parent
+rule, sparse cross-edges; see design note §5.1) act only by
+producing this inequality. Any graph property that yields
+$b_{\text{eff}} \cdot D > b'$ produces low TLI; conversely, no
+graph property that fails to produce the inequality can produce
+low TLI.
+
+This is the "decoupling geometry from metric" claim of design
+note §5.6.2 stated as a falsifiable conjecture.
+
+### 3.4 Symmetric DAGs have high TLI under any directional metric
+
+**Conjecture 3.4.** Let $G$ be a directed graph where, in
+calibration,
+$\mathbb{E}[d_c^2] \approx \mathbb{E}[d_p^2]$ (symmetric DAG, no
+parent/child distinction). Then for *any* directionally-weighted
+metric of the form
+$w(p) = c_1^{N(p)} c_2^{M(p)}$ with constants $c_1, c_2$ derived
+from $G$'s degree distribution, $\mathrm{TLI}(G, \mu, Q, B)$
+is bounded *below* (not above) by a function of $B$ growing as
+$B \to \infty$.
+
+In words: symmetric DAGs cannot have low TLI under any
+calibration of the directional metric. The directional asymmetry
+is *necessary*, not just sufficient.
+
+This conjecture motivates the synthetic-graph falsification task
+(task #10 in the design note).
+
+## 4. Empirical status
+
+For each conjecture, we summarise the empirical evidence
+recorded in the design note. See `TREE_LIKENESS_INDEX.md` §4
+for full details.
+
+### 4.1 Conjecture 3.1 (main)
+
+- Aggregate TLI: ~0.02% on simplewiki rooted at Physics, $n = 20$
+  pairs, budget $B = 15$, child-step costs $cc = 100$ vs $cc = 5$
+  (design note §4.1).
+- Per-pair TLI: ~0.007% worst case across all 20 pairs (design
+  note §4.2).
+- Convergence ratio: $r \approx 0.157$ with topical calibration
+  ($b_{\text{eff}} = 9.59$, $D = 7.34$, $b' \approx 11$).
+- Theorem 2.3 bound: $\psi(0.157) = 0.157/(1 - 0.157) \approx 0.186$,
+  i.e. ~18.6% drift bound. Empirical: ~0.02%. The bound is loose;
+  see §5.1 below.
+
+### 4.2 Conjecture 3.2 (topical homogeneity)
+
+- `Category:Articles` $b_{\text{eff}} = 9.59$ (79,797 reachable
+  nodes).
+- `Category:Physics` $b_{\text{eff}} = 9.51$ (79,199 reachable
+  nodes).
+- Agreement: ~1% (design note §4.5).
+- Global (not topical) $b_{\text{eff}} = 589$, an order-of-
+  magnitude discrepancy — direct evidence that homogeneity fails
+  globally.
+
+### 4.3 Conjecture 3.3 (b·D > b' is operative)
+
+The robustness band documented in design note §5.5 shows three
+calibration regimes (global with routing, topical with routing,
+topical without routing) all yielding TLI < 0.1% despite
+producing $b_{\text{eff}} \cdot D$ values that range from 27 to
+1659. The common factor is that all three exceed $b' \approx 11$.
+This is suggestive evidence but does not establish necessity.
+
+### 4.4 Conjecture 3.4 (symmetric DAG falsification)
+
+Pending: synthetic-graph experiment (task #10). The Cohen-Havlin
+theorem (§1.3) implies that scale-free graphs in the
+$2 < \gamma < 3$ regime are *not* asymptotically symmetric, so a
+falsification requires explicit construction.
+
+## 5. Open theoretical questions
+
+### 5.1 Tightness of the convergence bound
+
+Theorem 2.3 establishes $\mathrm{TLI} \le r/(1 - r)$ under the
+exact-factorisation assumption. On simplewiki this bounds TLI by
+18.6%, while empirically TLI is ~0.02% — a factor of ~1000
+gap. The bound is loose because:
+
+- It assumes worst-case length factors $(h+1)^{-n}$ for child
+  paths, but in practice child paths are *longer*, so the length
+  factor *additionally* suppresses them.
+- It does not exploit the structure of the power-mean
+  aggregation (the Lipschitz constants are smaller than the
+  worst-case sum).
+
+**Open question.** Is there a tighter version of Theorem 2.3 that
+uses the length-factor suppression to give a bound matching the
+empirical ratio? Conjecturally, $\psi(r) \sim r^{n+1}$ or similar
+for power-mean exponent $n$, but this needs proof.
+
+### 5.2 Quantitative homogeneity ↔ calibration error
+
+Conjecture 3.2 asserts that topical scoping is "sufficient for
+homogeneity in practice". Made precise: how much deviation from
+exact homogeneity can be tolerated before the convergence bound
+of Theorem 2.3 fails to apply? Specifically, if the path-count
+factorisation in Lemma 2.1 holds with multiplicative error
+$(1 + \delta)$, what is the corresponding error in the TLI
+bound?
+
+A quantitative answer here would convert Conjecture 3.2 from
+"this seems to work" to a calibration-error budget.
+
+### 5.3 Scale-free regime under topical scoping
+
+Cohen–Havlin (§1.3) implies that scale-free graphs with
+$2 < \gamma < 3$ have ultra-small-world geometry. Wikipedia's
+*global* degree distribution fits $\gamma \approx 2.41$, which is
+in this range. The conjecture is that *topical* sub-graphs do
+not satisfy the precondition of Cohen-Havlin (because they are
+not homogeneously scale-free), so they remain in the small-world
+or tree-like geometric regime.
+
+**Open question.** Empirically measure the topical sub-graph's
+degree distribution and compute its power-law exponent (if it
+fits one). Test whether $\gamma_{\text{topical}} > 3$, which
+would put the topical sub-graph in the *small-world* but not
+ultra-small-world regime, consistent with the observed TLI.
+
+(Task #15 in the design note will partly answer this by
+measuring average pair distance on the topical sub-graph.)
+
+### 5.4 Extension to undirected graphs
+
+The current theory assumes a directed graph with a clear
+parent/child decomposition. What happens when:
+
+- The graph is undirected, or
+- The graph is directed but symmetric (every edge has a reverse
+  edge of equal weight)?
+
+In these settings, the directional asymmetry $b > 1$ vanishes,
+and Theorem 2.3 predicts $\mathrm{TLI} \to 1$. This is consistent
+with intuition: an undirected graph has no way for tree-search
+(which depends on a parent direction) to be a meaningful
+approximation. But the formal statement is conditional on the
+parent/child decomposition existing in the first place.
+
+**Open question.** Is there a generalisation of TLI to
+undirected graphs that uses some other asymmetry (e.g.,
+spectral, expansion-based) in place of directional?
+
+### 5.5 Connection to spectral expansion
+
+The convergence ratio $r = b'/(b \cdot D)$ has a spectral
+interpretation we have not yet developed:
+
+- $D$ is the average degree, related to the largest eigenvalue
+  $\lambda_1$ of the adjacency matrix.
+- $b$ involves second-moment ratios, related to the variance of
+  the degree distribution.
+- $b'$ is a path-count growth rate, related to higher-order
+  expansion properties.
+
+**Open question.** Is there a relationship between $r$ and the
+spectral gap $\lambda_1 - \lambda_2$, or the second-largest
+eigenvalue magnitude? A graph with a large spectral gap is an
+expander — fast-mixing, with quickly-growing neighbourhood
+sizes. Is rapid path-count growth (large $b'$) equivalent to
+poor spectral gap, and is this why ultra-small-world graphs
+(Cohen-Havlin) defeat TLI even under topical scoping?
+
+## 6. References
+
+- Chung, F. and Lu, L. (2002). *The average distances in random
+  graphs with given expected degrees*. PNAS 99(25): 15879–15882.
+- Watts, D. J. and Strogatz, S. H. (1998). *Collective dynamics
+  of "small-world" networks*. Nature 393: 440–442.
+- Cohen, R. and Havlin, S. (2003). *Scale-free networks are
+  ultrasmall*. Physical Review Letters 90(5): 058701.
+- Clauset, A., Shalizi, C. R., and Newman, M. E. J. (2009).
+  *Power-law distributions in empirical data*. SIAM Review
+  51(4): 661–703.
+- Feld, S. L. (1991). *Why your friends have more friends than
+  you do*. American Journal of Sociology 96(6): 1464–1477.
+- [`TREE_LIKENESS_INDEX.md`](TREE_LIKENESS_INDEX.md) (companion
+  design note: empirical observations, calibration, algorithmic
+  consequences).

--- a/docs/design/TREE_LIKENESS_INDEX_THEORY.md
+++ b/docs/design/TREE_LIKENESS_INDEX_THEORY.md
@@ -154,13 +154,16 @@ of admitted child-hop levels.
 
 In practice (design note §4.4), at $B = 15$ we use $cc \in
 \{100, 10, 5, 3\}$ with corresponding $M_{\max} \in \{0, 1, 3, 5\}$.
-The transition ratios are $1.05$, $122.7$, $18.7$; the
-per-child-hop growth recovers as $b' \approx \exp((\log 122.7)/2)
-\approx 11.1$ from the dominant transition (the
-$cc=100 \to 10$ ratio is essentially flat because that transition
-only admits $M = 1$ paths, which are few). The geometric mean
-across non-degenerate transitions gives $b' \approx 11$ on
-simplewiki topical core.
+The transition ratios are $1.05$, $122.7$, $18.7$. The
+$cc = 10 \to 5$ transition admits *two additional* $M$ levels
+($M = 2$ and $M = 3$), so the per-child-hop growth recovers as
+$b' \approx (122.7)^{1/2} \approx 11.1$ — the exponent $1/2$ is
+$1/(\Delta M_{\max})$, the inverse of the number of new
+child-hop levels admitted at the transition. The
+$cc = 100 \to 10$ ratio is essentially flat (1.05) because that
+transition only admits $M = 1$ paths, which are few. The
+geometric mean across non-degenerate transitions gives
+$b' \approx 11$ on simplewiki topical core.
 
 ### 0.5 The tree-likeness index
 
@@ -300,12 +303,14 @@ Source: D. J. Watts and S. H. Strogatz, "Collective dynamics of
 **Relevance to TLI: only the distance criterion is operative.**
 The clustering coefficient $C$ does not appear in the theorems
 or conjectures below; only the $L = \Theta(\log n)$ condition is
-used (to classify regimes in §5.3). A *random* small-world
-(Erdős-Rényi or Chung-Lu) has $C \to 0$ but still has the
-distance scaling. The Watts-Strogatz definition is included here
-for terminology completeness; the operative concept is "graphs
-with $L = \Theta(\log n)$", which includes both Watts-Strogatz
-and random-graph small-worlds.
+used (to classify regimes in §5.3). Strictly, Erdős-Rényi and
+Chung-Lu random graphs are *not* small-world by Watts-Strogatz's
+full definition (they have $C \to 0$), but they share the
+distance scaling. The operative concept in this document is
+"graphs with $L = \Theta(\log n)$" — call this the
+*logarithmic-diameter regime*. It includes both Watts-Strogatz
+small-worlds *and* random graphs, and is the regime we compare
+against tree-like and ultra-small-world graphs in §5.3.
 
 ### 1.3 Ultra-small-world for scale-free graphs (Cohen–Havlin)
 
@@ -522,12 +527,21 @@ $$
 \frac{\sum_{M \ge 1} W_M}{W_0} \le \frac{r}{1 - r}
 $$
 
-**Proof.** By Lemma 2.1 and Proposition 2.2 the weighted
-contribution per path is $\approx (h+1)^{-n}$ for numerator and
-$\approx 1$ for denominator. The number of paths at level
-$(N, M)$ is $D^N (b')^M$, each carrying weight
-$D^{-N} (b_{\text{eff}} \cdot D)^{-M} = D^{-N} (r \cdot D / D)^{-M} \cdot D^{-M}$.
-Multiplying:
+**Proof.** By Lemma 2.1, the number of paths at level $(N, M)$
+is $D^N (b')^M$. Each carries weight
+$$
+w(p) = D^{-N} \cdot (b_{\text{eff}} \cdot D)^{-M}
+$$
+Multiplying path count by weight, the $D^{\pm N}$ factors cancel:
+$$
+D^N (b')^M \cdot D^{-N} (b_{\text{eff}} \cdot D)^{-M}
+\;=\; \frac{(b')^M}{(b_{\text{eff}} \cdot D)^M}
+\;=\; \left(\frac{b'}{b_{\text{eff}} \cdot D}\right)^M
+\;=\; r^M
+$$
+i.e. the weighted path count at level $(N, M)$ is $r^M$ for every
+$N$, with the length factor $(h+1)^{-n}$ multiplying for the
+numerator and $1$ for the denominator.
 
 For the numerator,
 $$S_M \approx \sum_N r^M \cdot (N+M+1)^{-n} = r^M \cdot L_M$$
@@ -674,25 +688,30 @@ contribution-sum drifts by $r/(1-r)$, but $d_{\text{wPow}}$ is
 the ratio of these sums and the drifts partially cancel. The
 question is *how much* they cancel — i.e. what $\alpha$ is.
 
-**Status.** Open in two directions:
+**Status.** Mixed:
 
-1. **First-order analysis at simplewiki parameters
-   ($B = 15, cc = 5, n = 2$) does NOT give clean $\alpha = 2$
-   scaling.** See §5.1 for the numerical check: $L_M / L_0$ and
-   $R_M / R_0$ differ by ~30–60% at level $M = 1$, so the $r^1$
-   coefficient does not cancel and the leading-order TLI
-   prediction is ~2.1%, not ~$r^2 \approx 0.025\%$.
-2. **The empirical TLI is still ~100× smaller than the first-
-   order prediction** (0.02% vs 2.1%). The source of this further
-   gap is unclear — candidates include budget-truncated $M$
-   ranges, higher-order Taylor terms with their own cancellation,
-   or measurement variance in the aggregate over only 20 seed
-   pairs.
+1. **First-order Taylor analysis at simplewiki parameters
+   ($B = 15, cc = 5, n = 2$) shows substantial-but-not-complete
+   cancellation.** See §5.1 for the verified numerical table:
+   $L_1/L_0 \approx 0.631$ and $R_1/R_0 \approx 0.583$, so the
+   $r^1$ coefficient is $\approx 0.048$ — small (5% of the
+   worst-case) but not zero. Leading-order TLI prediction
+   $\approx 0.44\%$, a 40× reduction from the contribution-sum
+   bound of 18.6%.
+2. **The empirical TLI is still ~22× smaller** than this
+   first-order prediction (0.02% vs 0.44%). Source unclear —
+   candidates include budget-truncated $M$ ranges (the $M = 3$
+   level is empty at simplewiki parameters), higher-order
+   Taylor terms with their own cancellation, or measurement
+   variance in the aggregate over only 20 seed pairs.
 
 A definitive answer requires either a careful expansion to
 higher order in $r$, or empirical Monte Carlo at varying $r$ to
 fit $\alpha$ directly. The conjecture as stated is *consistent
-with* but not *derived from* the empirical observations.
+with* but not *fully derived from* the empirical observations:
+the 40× drop from contribution-sum bound to first-order
+prediction is genuine evidence of substantial cancellation,
+but the remaining 22× gap is unexplained.
 
 ### 3.4 Topical scoping is sufficient for homogeneity on Wikipedia
 
@@ -820,19 +839,22 @@ note §2.0's notation table.
 
 ### 4.3 Conjecture 3.3 ($\psi$ sharpening)
 
-**Mixed evidence.** First-order Taylor analysis at simplewiki
-parameters (§5.1) reduces the bound from the $r/(1-r) \approx
-18.6\%$ contribution-sum estimate to ~2.1% (after partial num/
-denom cancellation), but does *not* reach the empirical 0.02%.
-A clean $r^2/(1-r)$ scaling would predict ~0.025%, agreeing
-within 1.5× — but this is post-hoc fitting, not derivation.
+**Mixed evidence.** Recomputed first-order Taylor analysis at
+simplewiki parameters (§5.1, verified table) shows the $r^1$
+coefficient is ~0.048 — small (5% of the worst-case bound) but
+not zero. The predicted first-order TLI is ~0.44%, reducing the
+naive contribution-sum bound (18.6%) by ~40× through partial
+num/denom cancellation. The empirical TLI of 0.02% is still
+~22× below this — consistent with $r^2$-like scaling but not
+purely $r^2$ either (which would predict ~0.025%, off by
+another factor of two from observed).
 
-Until a careful expansion to higher order in $r$ resolves the
-exponent $\alpha$, Conjecture 3.3 is consistent with the data
-but not derived from theory. Pending: either an analytic
-expansion of $d_{\text{wPow}}(B, cc)$ to second order in $r$, or
-Monte Carlo evaluation at varying $r$ to fit $\alpha$
-empirically.
+Honest status: the cancellation is real and substantial, but
+not asymptotically clean at $r = 0.157$. Higher-order Taylor
+terms or budget-truncation effects must account for the
+remaining gap. Pending: either an analytic expansion of
+$d_{\text{wPow}}(B, cc)$ to second order in $r$, or Monte Carlo
+evaluation at varying $r$ to fit $\alpha$ empirically.
 
 ### 4.4 Conjecture 3.4 (topical homogeneity)
 
@@ -878,47 +900,66 @@ $$
 where $\Delta\log N \approx \sum_{k \ge 1} r^k L_k / L_0$ and
 $\Delta\log W \approx \sum_{k \ge 1} r^k R_k / R_0$.
 
-**Numerical check at simplewiki parameters does not support
-clean $r^2$ scaling.** For $B = 15$, $cc = 5$, $n = 2$,
-$d_{\min} = 4$:
+**Numerical check at simplewiki parameters.** For $B = 15$,
+$cc = 5$, $n = 2$, $d_{\min} = 4$:
 
-| Level $M$ | $L_M$ | $L_M / L_0$ | $R_M$ | $R_M / R_0$ | $L_M/L_0 - R_M/R_0$ |
-|---|---|---|---|---|---|
-| 0 | $\approx 0.149$ | 1.000 | 12 | 1.000 | 0 |
-| 1 | $\approx 0.140$ | 0.940 | 8 | 0.667 | 0.273 |
-| 2 | $\approx 0.122$ | 0.819 | 3 | 0.250 | 0.569 |
+| Level $M$ | $N$ range | $L_M = \sum_N (N+M+1)^{-2}$ | $L_M / L_0$ | $R_M$ | $R_M / R_0$ | $L_M/L_0 - R_M/R_0$ |
+|---|---|---|---|---|---|---|
+| 0 | $[4, 15]$ | $\approx 0.1607$ | 1.000 | 12 | 1.000 | 0 |
+| 1 | $[4, 10]$ | $\approx 0.1014$ | 0.631 | 7 | 0.583 | **+0.048** |
+| 2 | $[4, 5]$  | $\approx 0.0360$ | 0.224 | 2 | 0.167 | +0.057 |
+| 3 | $\varnothing$ | 0 | 0 | 0 | 0 | 0 |
 
-The $r^1$ coefficient does *not* cancel — the difference at
-$M=1$ alone is $0.273 r$, giving a leading-order contribution of
-$\approx 0.5 \cdot 0.273 \cdot 0.157 \approx 0.021$, i.e. ~2.1%.
-This is much smaller than the contribution-sum bound (18.6%)
-but still ~100× larger than the empirical TLI of 0.02%.
+(The $M = 3$ level requires $N \le B - 3 \cdot cc = 0$, which
+is below $d_{\min} = 4$, so the range is empty.)
 
-**Status: Conjecture 3.3's $\psi \sim r^2/(1-r)$ scaling is not
-yet supported.** A naive first-order Taylor expansion in $r$
-gives a ~2.1% prediction, not $r^2 \approx 0.025\%$. The
-remaining ~100× gap between first-order theory and empirical
-TLI likely has a different source — possibilities:
+**Partial first-order cancellation.** The $r^1$ coefficient of
+$\alpha_S - \alpha_W$ is the $M=1$ difference, $\approx 0.048$.
+This is small but *non-zero*: a 47% reduction from the
+worst-case contribution-sum bound (where the coefficient would
+be 1), but not the full cancellation that pure $r^2$ scaling
+would require.
 
-- **Budget-constrained M range.** At $B = 15, cc = 5$ only
-  $M \in \{0, 1, 2, 3\}$ are admissible, and $M \in \{2, 3\}$
-  have very restricted $N$-ranges (3 values and 1 value
-  respectively). The effective sum is short and the higher-$M$
-  contributions are heavily truncated.
-- **Higher-order cancellation.** The Taylor expansion at $r=0$
-  may have larger higher-order terms that further reduce TLI;
-  computing the next term explicitly would resolve this.
-- **The simplewiki measurement itself.** TLI = 0.02% is the
-  *aggregate* over 20 seed pairs; per-pair drifts of 0.007%
-  worst-case (design note §4.2) are still 50× smaller than 2.1%.
+**Predicted first-order TLI on simplewiki:**
+$$
+\mathrm{TLI}_{\text{1st-order}} \approx \frac{1}{n} \left|
+r \cdot 0.048 + r^2 \cdot 0.057 \right|
+\approx \frac{1}{2} \left| 0.157 \cdot 0.048 + 0.0246 \cdot 0.057 \right|
+\approx \frac{1}{2} \cdot 0.00889
+\approx 0.44\%
+$$
+
+So:
+- Contribution-sum bound (Theorem 2.3): $r/(1-r) \approx 18.6\%$
+- First-order with partial cancellation: $\approx 0.44\%$
+- Empirical TLI: $\approx 0.02\%$
+- **Remaining gap: ~22× (better than the original ~1000× but not negligible)**
+
+**Status of Conjecture 3.3.** *Mixed evidence.* The $r^1$
+coefficient is small (~5% of the worst-case), consistent with
+substantial-but-incomplete first-order cancellation. This is
+*partially consistent* with $\psi(r) \sim r^2/(1-r)$ scaling
+(which predicts $\approx 0.025\%$ from this $r$) but the
+predicted ~0.44% sits between the $r^1$ and $r^2$ scaling
+regimes. The remaining ~22× gap to empirical likely involves:
+
+- **Budget-truncated higher-$M$ levels.** The $L_3, R_3$ being
+  zero (rather than continuing geometrically) eats some
+  predicted contribution.
+- **Higher-order Taylor terms.** Beyond first order in $r$, the
+  ratio $N/W$ has corrections from $(1+\alpha_S)(1+\alpha_W)^{-1}$
+  expansion that may further cancel.
+- **Length-factor structure.** The $(h+1)^{-n}$ factor for $n=2$
+  more aggressively suppresses longer paths than the geometric
+  bound assumes.
 
 **Open question.** What is the actual scaling of $\psi(r)$ as a
-function of $r$ and the budget $B$? An honest answer requires
+function of $r$ and the budget $B$? Resolving this requires
 either (i) a careful Taylor expansion accounting for the budget-
 truncated $L_M, R_M$ sums, or (ii) Monte Carlo evaluation at
 varying $r$ to fit the exponent empirically. Conjecture 3.3 as
-stated is *consistent with* the empirical gap but not derived
-from it.
+stated is *consistent with* the empirical gap but not yet
+derived from theory.
 
 ### 5.2 Quantitative homogeneity ↔ calibration error
 

--- a/docs/design/TREE_LIKENESS_INDEX_THEORY.md
+++ b/docs/design/TREE_LIKENESS_INDEX_THEORY.md
@@ -68,16 +68,22 @@ We assume the traversal uses a visited-set so paths are simple
 Following the design note's §2.0 notation, let:
 
 - $D := \mathbb{E}[d_c]$, the average child fan-out
-- $b := \mathbb{E}[d_c^2] / \mathbb{E}[d_p^2]$, the raw
-  second-moment ratio (the "early-formula" calibration)
-- $b_{\text{eff}} := \frac{\mathbb{E}[d_c^2]/\mathbb{E}[d_c]}{\mathbb{E}[d_p^2]/\mathbb{E}[d_p]}$, the
-  friendship-paradox-corrected branching asymmetry
+- $b_{\text{eff}} := \dfrac{\mathbb{E}[d_c^2]/\mathbb{E}[d_c]}{\mathbb{E}[d_p^2]/\mathbb{E}[d_p]}$, the
+  **friendship-paradox-corrected branching asymmetry** (the
+  calibrated quantity the kernel actually uses; "size-biased
+  child branching" divided by "size-biased parent branching"). See
+  §1.5 for the Feld correction.
 - $b'$ := the empirical per-child-hop path-count growth (defined
   in §0.4 below)
+- $b := \mathbb{E}[d_c^2] / \mathbb{E}[d_p^2]$, the raw
+  second-moment ratio — this is the *early-formula* calibration
+  used in the design note's pre-correction analysis. It is not
+  used in the kernel or in this document beyond historical
+  context; $b_{\text{eff}}$ is the canonical asymmetry quantity.
 
 The path weight is
 $$
-w(p) = D^{-N(p)} \cdot (b \cdot D)^{-M(p)}
+w(p) = D^{-N(p)} \cdot (b_{\text{eff}} \cdot D)^{-M(p)}
 $$
 and the **directionally-weighted power-mean metric** with exponent
 $n$ is
@@ -91,6 +97,13 @@ where $\mathcal{P}(v; B, cc)$ is the set of paths from $v$ to $r$
 with cost at most $B$ when each parent hop costs $1$ and each
 child hop costs $cc$. We typically use $n = 2$ in experiments.
 
+**Compatibility with the early formula.** The original design
+note uses the early $b$ in some prose. The substitution
+$b \mapsto b_{\text{eff}}$ changes the numerical value of
+$b \cdot D$ but not the *form* of the weight formula. All
+theorems and conjectures below are stated in terms of
+$b_{\text{eff}}$.
+
 ### 0.4 Path-count growth
 
 For a node $v$ reachable to $r$ within budget $B$, define
@@ -99,18 +112,43 @@ $$
 \bigl|\{p : v \to r,\ p \text{ has } N \text{ parent hops}
               \text{ and } M \text{ child hops, cost} \le B\}\bigr|
 $$
-The **empirical per-child-hop path-count growth** is
+At any fixed budget $B$ and child-step cost $cc > 0$, the maximum
+admissible $M$ is finite ($\lfloor B/cc \rfloor$), so a literal
+$M \to \infty$ limit does not exist. We instead define $b'$ as
+the **asymptotic per-child-hop path-count growth rate** under
+the homogeneity assumption: there exists a constant $b' \ge 1$
+and a node-dependent constant $C(v) > 0$ such that, for $M$ in
+the range admissible at $(B, cc)$,
 $$
-b'(G, Q, B) := \lim_{M \to \infty}
-\frac{\mathbb{E}_{v \sim Q}\bigl[\#\text{paths}(v; \cdot, M+1; B)\bigr]}
-     {\mathbb{E}_{v \sim Q}\bigl[\#\text{paths}(v; \cdot, M; B)\bigr]}
+\mathbb{E}_{v \sim Q}\bigl[\#\text{paths}(v; \cdot, M; B)\bigr]
+\approx C \cdot (b')^M
 $$
-where the dot in $\#\text{paths}(v; \cdot, M; B)$ denotes summation
-over $N$, and the limit is taken over $M$ values for which both
-quantities are non-zero. In practice we estimate $b'$ from a
-finite range of $M$ by running the bidirectional kernel at
-varying $cc$ and reading the ratio of total path counts (design
-note §4.4).
+where $\#\text{paths}(v; \cdot, M; B)$ denotes summation over $N$
+and the approximation holds up to a multiplicative
+$(1 + o(1))$ factor uniformly in $M$.
+
+This makes $b'$ a property of the *graph* (and query
+distribution), not of the specific $(B, cc)$ probe used to
+estimate it. Different $(B, cc)$ pairs that admit overlapping
+$M$ ranges should yield consistent $b'$ estimates under
+homogeneity; the design note's §4.4 measurements at $cc \in
+\{100, 10, 5, 3\}$ are such an overlapping family.
+
+**Equivalent operational definition.** Equivalently,
+$$
+b' = \lim_{cc \to 0^+}
+\left(\frac{\text{total } \#\text{paths at } (B, cc)}
+           {\text{total } \#\text{paths at } (B, cc = \infty)}\right)^{1/M_{\max}(B, cc)}
+$$
+where $M_{\max}(B, cc) = \lfloor B/cc \rfloor$. This makes the
+$cc \to 0^+$ regime explicit: $b'$ is the per-child-hop multiplier
+seen as we admit increasing numbers of child hops within fixed
+budget.
+
+In practice (design note §4.4) we estimate $b'$ as the geometric
+mean of successive total-path-count ratios at $cc$ transitions
+$100 \to 10 \to 5 \to 3$, yielding $b' \approx 11$ on simplewiki
+topical core.
 
 ### 0.5 The tree-likeness index
 
@@ -131,22 +169,70 @@ $cc$ values, typically $cc = 100$ (effectively tree-search at
 $B = 15$) and $cc = 5$ (admits up to 3 child hops); see design
 note §4.1.
 
+### 0.6 Statistical homogeneity
+
+A precondition many of the §2 results and §3 conjectures rest on.
+
+**Definition 0.6 (Statistical homogeneity).** A tuple
+$(G, Q, B)$ is *statistically homogeneous* if there exist
+constants $D, b' \ge 1$ such that, uniformly over $v$ in the
+support of the marginal distribution $Q$:
+
+(H1) $\mathbb{E}\bigl[\#\mathrm{children}(v)\bigr] = D$
+(within multiplicative factor $1 + o(1)$);
+
+(H2) The path-count growth in §0.4 has the same $b'$ at every
+$v$ (i.e. $C(v)$ varies but the exponential base does not);
+
+(H3) The calibrated branching asymmetry $b_{\text{eff}}$
+computed from local degree distributions agrees with the global
+$b_{\text{eff}}$ within multiplicative factor $1 + o(1)$.
+
+In words: every region the query distribution can reach
+exhibits the same statistical fingerprint $(D, b_{\text{eff}}, b')$
+within tolerance.
+
+**Inhomogeneity decomposition.** A tuple is *piecewise
+homogeneous* if $\mathrm{supp}(Q)$ decomposes as
+$\bigsqcup_i V_i$ where each $(G|_{V_i}, Q|_{V_i}, B)$ is
+homogeneous. In this case the theorems below apply
+*piecewise* — each subgraph has its own $(D_i, b'_i,
+b_{\text{eff},i})$. This is the setting design note §4.5
+documents on Wikipedia: the global graph is piecewise
+homogeneous (topical regime + administrative regime) but not
+globally homogeneous.
+
 ## 1. Background: established results we build on
 
-### 1.1 Random-graph distances (Erdős–Rényi / Chung–Lu)
+### 1.1 Random-graph distances (Chung–Lu)
 
-**Theorem (Chung & Lu, 2002).** For a random graph $G(n, p)$ with
-expected average degree $\langle k \rangle = pn$ satisfying
-$np \to \infty$, the average shortest-path length between random
-node pairs satisfies
+**Theorem (Chung & Lu, 2002).** For a random graph drawn from the
+given-expected-degree model with weights
+$\mathbf{w} = (w_1, \dots, w_n)$ — where edge $(i,j)$ is present
+with probability $w_i w_j / \sum_k w_k$ — and average degree
+$\langle k \rangle = \mathbb{E}[w] > 1$, the average shortest-path
+length between random node pairs satisfies
 $$
-L \sim \frac{\log n}{\log \langle k \rangle}
+L \sim \frac{\log n}{\log \tilde{d}}
 $$
-as $n \to \infty$.
+as $n \to \infty$, where $\tilde{d} = \mathbb{E}[w^2] / \mathbb{E}[w]$
+is the *expected size-biased degree* (the average degree of a
+random endpoint of a random edge).
+
+The Erdős–Rényi $G(n, p)$ result with $\tilde{d} = \langle k \rangle$
+is a special case (constant-weight model).
 
 Source: F. Chung and L. Lu, "The average distances in random
 graphs with given expected degrees", *PNAS* 99(25): 15879–15882
 (2002).
+
+**Relevance to TLI.** For graphs with heavy-tailed degree
+distribution (like Wikipedia categories), $\tilde{d} \gg
+\langle k \rangle$ because the second moment is dominated by
+hubs. The Chung-Lu theorem then predicts substantially shorter
+distances than the constant-degree estimate would suggest. This
+size-biased correction is the same one entering our
+$b_{\text{eff}}$ definition (§1.5).
 
 This is the baseline for "what branching alone achieves" in a
 homogeneous graph — relevant to §5.3 of the design note's
@@ -163,6 +249,16 @@ if it simultaneously satisfies:
 
 Source: D. J. Watts and S. H. Strogatz, "Collective dynamics of
 'small-world' networks", *Nature* 393: 440–442 (1998).
+
+**Relevance to TLI: only the distance criterion is operative.**
+The clustering coefficient $C$ does not appear in the theorems
+or conjectures below; only the $L = \Theta(\log n)$ condition is
+used (to classify regimes in §5.3). A *random* small-world
+(Erdős-Rényi or Chung-Lu) has $C \to 0$ but still has the
+distance scaling. The Watts-Strogatz definition is included here
+for terminology completeness; the operative concept is "graphs
+with $L = \Theta(\log n)$", which includes both Watts-Strogatz
+and random-graph small-worlds.
 
 ### 1.3 Ultra-small-world for scale-free graphs (Cohen–Havlin)
 
@@ -240,26 +336,32 @@ underlying reason it has the form it does.
 $n = (D^{L+1} - 1)/(D - 1)$ nodes:
 
 - Depth-to-root: $L = \log_D(n(D - 1) + 1) \approx \log_D n$
-- Average pair distance: for any two distinct nodes $u, v$,
+- Average pair distance: for uniform-random distinct nodes $u, v$,
 $$
-\mathbb{E}_{u,v}[d(u,v)] \le 2L \approx 2 \log_D n
+\mathbb{E}_{u,v}[d(u,v)] \approx 2L - \frac{2D}{D-1} \approx 2 \log_D n
 $$
-with equality approached as $D \to \infty$ (large branching makes
-LCAs shallow).
+with the constant offset $2D/(D-1)$ converging to $2$ as
+$D \to \infty$ (large branching makes LCAs shallow).
 
 **Proof sketch.** The distance between $u$ and $v$ is
 $\mathrm{depth}(u) + \mathrm{depth}(v) - 2 \cdot \mathrm{depth}(\mathrm{LCA}(u,v))$.
 For uniform-random $u, v$ in the leaves of a balanced tree, the
 probability that the LCA is at depth $\ge \ell$ is approximately
-$D^{-\ell}$, so the expected LCA depth is $O(1/(D-1))$, vanishing
-for large $D$. The pair distance is therefore close to twice the
-depth $L$. $\square$
+$D^{-\ell}$ (both leaves must descend from the same depth-$\ell$
+ancestor). The expected LCA depth is therefore
+$\sum_{\ell \ge 0} D^{-\ell} \cdot \mathbf{1}[\ell \le L] \approx \sum_{\ell \ge 0} D^{-\ell}
+= D/(D-1)$, and pair distance is
+$2L - 2 \cdot D/(D-1)$. $\square$
 
-**Relevance to TLI.** A tree-shaped graph is the structural
-limit where TLI is trivially $0$ — there are no cross-edge paths
-to admit, so the metric is path-invariant in $cc$. The interest
-of TLI is what happens *between* this limit and a graph with no
-asymmetry at all (§3 conjecture below).
+**Relevance to TLI: regime-comparison context only.** This lemma
+appears in §5.3 to provide a benchmark for "tree-shaped graph
+average pair distance", which we compare against
+small-world and ultra-small-world distance scalings. The lemma
+is *not* used to argue $\mathrm{TLI} = 0$ for trees — that
+follows trivially from the definition (a tree has no cross-edge
+paths, so $\#\text{paths}(v; N, M; B) = 0$ for all $M \ge 1$,
+hence $d_{\text{wPow}}$ does not depend on $cc$ and TLI = 0
+identically).
 
 ## 2. What we can prove
 
@@ -269,39 +371,40 @@ conjecture (§3.1); they are building blocks supporting it.
 
 ### 2.1 Path-count growth lemma (conditional on homogeneity)
 
-**Lemma 2.1.** Suppose $G$ is *statistically homogeneous* in the
-following sense: there exist constants $D = \mathbb{E}[d_c]$ and
-$b' \ge 1$ such that, uniformly over all
-$v \in V$ reachable to $r$,
+**Lemma 2.1.** Suppose $(G, Q, B)$ is statistically homogeneous in
+the sense of Definition 0.6. Then for any node $v$ in the support
+of $Q$,
 $$
 \#\text{paths}(v; N, M; B) \approx D^N \cdot (b')^M
 $$
 as $N, M$ range over admissible hop counts within budget $B$,
 where the approximation holds up to a multiplicative
-$(1 + o(1))$ factor.
-
-Then for any query distribution $Q$ supported on the reachable
-set,
+$(1 + o(1))$ factor. Consequently,
 $$
 \mathbb{E}_{v \sim Q}\bigl[\#\text{paths}(v; N, M; B)\bigr] \approx D^N \cdot (b')^M
 $$
 with the same asymptotic factor.
 
-**Proof.** Direct by linearity of expectation, applied to the
-log-path-count under the homogeneity assumption. $\square$
+**Proof.** Condition (H2) of Definition 0.6 fixes the asymptotic
+behaviour in $M$ at every $v$; condition (H1) fixes the
+asymptotic behaviour in $N$ (since the number of distinct
+$N$-step parent paths from $v$ scales as $D^N$ when each step
+expands by average factor $D$). Combining, and taking
+expectation by linearity, gives the stated form. $\square$
 
 **Remark.** The homogeneity assumption here is restrictive. For
-inhomogeneous graphs (Wikipedia, globally), the path-count
-function has different growth rates in different regions of $V$,
-and the lemma fails. This is what design note §4.5 documents and
-§5.6.2 reframes as the homogeneity precondition. For the
-homogeneous topical core (`Category:Articles` reach), the lemma
-holds empirically with $D \approx 7.34$ and $b' \approx 11$.
+globally inhomogeneous graphs (Wikipedia at full scope), the
+path-count function has different growth rates in different
+regions of $V$, and the lemma fails. This is what design note
+§4.5 documents and §5.6.2 reframes as the homogeneity
+precondition. For the homogeneous topical core
+(`Category:Articles` reach), the lemma holds empirically with
+$D \approx 7.34$ and $b' \approx 11$.
 
 ### 2.2 Weights normalise path counts
 
-**Proposition 2.2.** Under the homogeneity assumption of Lemma 2.1
-with calibration $b \cdot D = b'$,
+**Proposition 2.2.** Under Definition 0.6 homogeneity with
+calibration $b_{\text{eff}} \cdot D = b'$,
 $$
 w(p) \cdot \#\text{paths}\bigl(\cdot;\ N(p), M(p);\ B\bigr) \approx 1
 $$
@@ -310,7 +413,7 @@ path-count normaliser.
 
 **Proof.** Direct substitution:
 $$
-w(p) = D^{-N(p)} (b \cdot D)^{-M(p)}
+w(p) = D^{-N(p)} (b_{\text{eff}} \cdot D)^{-M(p)}
      = D^{-N(p)} (b')^{-M(p)}
 $$
 By Lemma 2.1,
@@ -320,55 +423,110 @@ $1$ up to the $(1+o(1))$ factor. $\square$
 This is the formal statement of design note §5.6's "weights as
 path-count normalisers" reframing.
 
+**Caveat — calibration is approximate.** Proposition 2.2 assumes
+exact $b_{\text{eff}} \cdot D = b'$. Empirically (design note
+§4.5), simplewiki topical calibration gives
+$b_{\text{eff}} \approx 9.59$ and $b' \approx 11$, so the
+weight-as-normaliser correspondence is only approximate (within
+~15%). The next theorem operates in the realistic regime where
+$b_{\text{eff}} \cdot D$ exceeds $b'$ by some margin but does
+not equal it exactly.
+
 ### 2.3 Convergence theorem (geometric series bound)
 
-**Theorem 2.3.** Suppose Lemma 2.1 holds with growth constants
-$D$ and $b'$, and suppose the metric is calibrated with
-$b \cdot D > b'$. Define the convergence ratio
+**Theorem 2.3.** Suppose $(G, Q, B)$ is homogeneous (Definition
+0.6) with growth constants $D$ and $b'$, and the metric is
+calibrated with $b_{\text{eff}} \cdot D > b'$. Define the
+**convergence ratio**
 $$
-r := \frac{b'}{b \cdot D} < 1
+r := \frac{b'}{b_{\text{eff}} \cdot D} \in [0, 1)
 $$
-Then the contribution to the numerator of $d_{\text{wPow}}$ from
-paths with $M \ge 1$ child hops, weighted by the length factor
-$(h+1)^{-n}$, is bounded by
+Let
 $$
-\sum_{M \ge 1} \mathrm{contribution}(M) \le
-\frac{r}{1 - r} \cdot d_{\text{wPow}}(M = 0)
+S_M := \sum_{p:\ M(p) = M} w(p) \cdot (h(p)+1)^{-n}, \qquad
+W_M := \sum_{p:\ M(p) = M} w(p)
 $$
-where $d_{\text{wPow}}(M = 0)$ denotes the contribution from
-parent-only paths.
+be the M-level *numerator* and *denominator* contribution sums
+to $d_{\text{wPow}}^{-n}$. Then both ratios are bounded by the
+same geometric series:
+$$
+\frac{\sum_{M \ge 1} S_M}{S_0} \le \frac{r}{1 - r}, \qquad
+\frac{\sum_{M \ge 1} W_M}{W_0} \le \frac{r}{1 - r}
+$$
 
-**Proof.** By Lemma 2.1 and Proposition 2.2, the *weighted*
-contribution at level $(N, M)$ is approximately
-$$
-w \cdot \#\text{paths}(N, M) \cdot (h+1)^{-n}
-  \approx (h+1)^{-n}
-$$
-i.e. the abundance and weight cancel. The contribution at level
-$M$ summed over $N$ is therefore proportional to
-$D^N \cdot (b')^M \cdot D^{-N} \cdot (b \cdot D)^{-M} = (b')^M / (b \cdot D)^M = r^M$
-times the length factor. Summing the geometric series in $M$
-gives the stated bound. $\square$
+**Proof.** By Lemma 2.1 and Proposition 2.2 the weighted
+contribution per path is $\approx (h+1)^{-n}$ for numerator and
+$\approx 1$ for denominator. The number of paths at level
+$(N, M)$ is $D^N (b')^M$, each carrying weight
+$D^{-N} (b_{\text{eff}} \cdot D)^{-M} = D^{-N} (r \cdot D / D)^{-M} \cdot D^{-M}$.
+Multiplying:
 
-**Corollary 2.3.1** (informal version of the convergence
-conjecture). Under the assumptions of Theorem 2.3, the
-contribution of child-using paths to $d_{\text{wPow}}$ is bounded
-by $r/(1-r)$ times the parent-only contribution. When $r$ is
-small (typical: $r \approx 0.157$ on simplewiki topical core), the
-contribution is small. **This is a partial proof of Conjecture
-3.1 under the additional homogeneity assumption.**
+For the numerator,
+$$S_M \approx \sum_N r^M \cdot (N+M+1)^{-n} = r^M \cdot L_M$$
+where $L_M = \sum_{N \in [\text{admissible range}]} (N+M+1)^{-n}$.
+Since the length factor $(N+M+1)^{-n}$ decreases in both $N$
+and $M$, $L_M \le L_0$ for all $M \ge 0$, so
+$S_M / S_0 \le r^M$ and the geometric sum gives the bound.
+
+For the denominator,
+$$W_M \approx \sum_N r^M = r^M \cdot |\text{admissible } N \text{ range at level } M|$$
+The range size shrinks weakly in $M$ (the budget loses capacity
+$cc$ per child hop), so $W_M / W_0 \le r^M$ similarly. $\square$
+
+**Caveats and tightness.**
+
+1. **The bound is on *contribution sums*, not directly on TLI.**
+   Since $d_{\text{wPow}} = (\text{numerator} / \text{denominator})^{-1/n}$
+   is a *ratio*, and both numerator and denominator drift by
+   $r/(1-r)$, the actual TLI is much smaller than this individual
+   bound would suggest — the drifts partially cancel. A first-order
+   estimate: $\mathrm{TLI} \lesssim |S_{\text{drift}} - W_{\text{drift}}|/n$,
+   typically a fraction of $r/(1-r)$ rather than the full value.
+   §5.1 discusses this in more depth and conjectures a tighter
+   $O(r^2/(1-r))$ bound following GPT's review observation.
+
+2. **The proof bounds $L_M \le L_0$.** A more careful analysis
+   would track $L_M$ as a function of $M$ explicitly. For the
+   simplewiki budget $B = 15$ with $cc = 5$ and $d_{\min} = 4$,
+   $L_M$ decreases roughly as $\zeta(n) - \sum_{k = 1}^{M} k^{-n}$,
+   contributing a sub-geometric factor that further tightens the
+   bound. §5.1 leaves this as an open question for a sharper
+   $\psi$.
+
+3. **The bound does not require $b_{\text{eff}} \cdot D = b'$
+   exactly.** As long as $b_{\text{eff}} \cdot D > b'$, $r < 1$
+   and the geometric series converges. The case $r \to 1$ is
+   the boundary where convergence fails.
+
+**Corollary 2.3.1.** Under the assumptions of Theorem 2.3, the
+M ≥ 1 contributions to both the numerator and denominator of
+$d_{\text{wPow}}$ are bounded by $r/(1-r)$ times the M = 0
+contributions. When $r$ is small (typical: $r \approx 0.157$ on
+simplewiki topical core), the *individual* contribution drifts
+are small. The drift in $d_{\text{wPow}}$ itself is smaller still
+because the numerator and denominator drift partially cancel —
+empirically by ~1000× (theorem bound: 18.6%; empirical TLI:
+~0.02%). **This is a partial proof of Conjecture 3.1 (the main
+convergence conjecture) under the homogeneity assumption.**
 
 ## 3. Conjectures
 
+Ordered by logical dependency: the central convergence conjecture
+(3.1) presupposes statistical homogeneity (Def 0.6); two
+strengthenings refine it (3.2 sharpens the sufficient condition,
+3.3 asserts necessity); two specific instances ground it (3.4 the
+Wikipedia topical case, 3.5 the falsification target); and one
+production-engineering conjecture (3.6) is the last open question
+from the design note.
+
 ### 3.1 The central conjecture: convergence as a sufficient condition
 
-**Conjecture (Main).** There exists a monotone-increasing function
-$\psi : [0, 1) \to \mathbb{R}_{\ge 0}$ with $\psi(0) = 0$ and
-$\psi(r) \to \infty$ as $r \to 1^-$, such that for any $(G, \mu, Q, B)$
-satisfying:
+**Conjecture 3.1 (Main).** There exists a monotone-increasing
+function $\psi : [0, 1) \to \mathbb{R}_{\ge 0}$ with $\psi(0) = 0$
+and $\psi(r) \to \infty$ as $r \to 1^-$, such that for any
+$(G, \mu, Q, B)$ satisfying:
 
-(a) *Homogeneity precondition*: the path-count growth in §0.4 is
-well-defined and uniform across the support of $Q$, yielding
+(a) *Homogeneity precondition*: Definition 0.6 holds, yielding
 constants $D(G, Q)$, $b'(G, Q, B)$, $b_{\text{eff}}(G, Q)$.
 
 (b) *Convergence condition*:
@@ -379,61 +537,100 @@ $$
 \mathrm{TLI}(G, \mu, Q, B) \le \psi\!\left(\frac{b'}{b_{\text{eff}} \cdot D}\right)
 $$
 
-In words: under the homogeneity precondition, the TLI is bounded
-by a function of the convergence ratio $r = b'/(b_{\text{eff}} \cdot D)$.
+In words: under homogeneity, the TLI is bounded by a function
+of the convergence ratio $r = b'/(b_{\text{eff}} \cdot D)$.
 
-**Partial support.** Theorem 2.3 establishes the bound with
-$\psi(r) = r/(1-r)$ under additionally assuming exact path-count
-factorisation (Lemma 2.1) and exact calibration $b \cdot D = b'$.
-In practice $b_{\text{eff}}$ and $b'$ agree only approximately
-(within ~15% on simplewiki, §4.5 of the design note); the
-conjecture extends Theorem 2.3 to the empirical regime where
-this approximation is not exact.
+**Partial support.** Theorem 2.3 establishes the contribution-sum
+bound $r/(1-r)$ under additionally assuming exact path-count
+factorisation (Lemma 2.1) and exact calibration
+$b_{\text{eff}} \cdot D = b'$. The translation to a TLI bound
+is not direct because $d_{\text{wPow}}$ is a ratio; §5.1
+conjectures the true $\psi$ is closer to $r^2/(1-r)$.
 
-### 3.2 Topical scoping is sufficient for homogeneity on Wikipedia categories
+### 3.2 The convergence inequality is the operative condition (necessity)
 
-**Conjecture 3.2.** For Wikipedia category graphs of the form
+**Conjecture 3.2.** For graphs satisfying the homogeneity
+precondition, $b_{\text{eff}} \cdot D > b'$ is *both* necessary
+and sufficient for low TLI — i.e. the graph-structural properties
+sometimes invoked as sufficient (power-law tail, dominant parent
+rule, sparse cross-edges; design note §5.1) act only by producing
+this inequality. Any graph property that yields
+$b_{\text{eff}} \cdot D > b'$ produces low TLI; any tuple with
+$b_{\text{eff}} \cdot D \le b'$ has TLI bounded below.
+
+**Partial support: sufficiency direction.** Design note §5.5
+documents the robustness band: three calibration regimes (global
+with routing, topical with routing, topical without routing)
+yield TLI < 0.1% despite producing $b_{\text{eff}} \cdot D$
+values from 27 to 1659. The common factor is all three exceed
+$b' \approx 11$.
+
+**Open: necessity direction.** We do not have clean empirical
+evidence for the necessity claim (i.e. that $b_{\text{eff}} \cdot D
+\le b'$ *forces* high TLI). The closest evidence is design note
+§4.3's broken-ingest comparison ($b \approx 61 \cdot D = 448$,
+TLI ≈ 1%) vs the correct-ingest version ($b \approx 9933$, TLI ≈
+0.02%), which suggests *some* correlation between $b \cdot D$ and
+TLI but doesn't reach the boundary $b \cdot D \le b'$. Conjecture
+3.4 (synthetic graph at the boundary) is the natural empirical
+test.
+
+This is the "decoupling geometry from metric" claim of design
+note §5.6.2 stated as a falsifiable conjecture.
+
+### 3.3 Sharpening of the bound: $\psi(r) \sim r^2 / (1 - r)$
+
+**Conjecture 3.3.** The function $\psi$ in Conjecture 3.1
+satisfies $\psi(r) \le C \cdot r^2 / (1 - r)$ for some constant
+$C$ depending only on $n$ (the power-mean exponent) and
+$\mathrm{depth}_{\min}$ (the minimum distance from the support
+of $Q$ to the root).
+
+**Motivation.** Theorem 2.3 bounds the *individual*
+contribution-sum drifts (numerator and denominator) by $r/(1-r)$.
+But $d_{\text{wPow}}$ is the ratio of these sums; if both drift
+by the same amount, the ratio drift is second-order in $r$. The
+empirical gap (theorem bound $r/(1-r) \approx 18.6\%$ vs
+empirical TLI ~$0.02\%$, a factor of ~1000) is consistent with
+this conjectured tighter scaling.
+
+**Status.** Open. Even the constant $C$ is unknown; a careful
+calculation distinguishing the numerator and denominator
+contribution sums via their different length-factor dependences
+should resolve it.
+
+### 3.4 Topical scoping is sufficient for homogeneity on Wikipedia
+
+**Conjecture 3.4.** For Wikipedia category graphs of the form
 "all descendants of a single top-level topical root" (e.g.
-`Category:Articles` on simplewiki, `Category:Main_topic_classifications`
-on enwiki), the homogeneity precondition of Conjecture 3.1 holds
-to a degree sufficient for low TLI in practice.
+`Category:Articles` on simplewiki,
+`Category:Main_topic_classifications` on enwiki), the
+homogeneity precondition of Definition 0.6 holds to a degree
+sufficient for low TLI in practice (within tolerance for $\psi$
+of Conjecture 3.1).
 
 **Partial support.** Design note §4.5 measures
 $b_{\text{eff}}$ on `Category:Articles` (9.59) and on
 `Category:Physics` (9.51), finding ~1% agreement. This is
 evidence that the topical core is *statistically self-similar*
 across different sub-trees — a necessary condition for
-homogeneity.
+homogeneity (H3 of Definition 0.6).
 
 **Caveat.** The conjecture has been tested on simplewiki only.
-The enwiki topical-root verification (page_id 7345184 confirmed,
-LMDB construction pending) is task #14 in the design note.
+The enwiki topical-root verification (page_id 7345184 confirmed
+via Wikipedia API, LMDB construction pending) is task #14 in the
+design note.
 
-### 3.3 The convergence inequality is the operative condition
+### 3.5 Symmetric DAGs have high TLI under any directional metric
 
-**Conjecture 3.3.** For graphs satisfying the homogeneity
-precondition, $b_{\text{eff}} \cdot D > b'$ is the operative
-condition for low TLI — i.e. the *graph-structural* properties
-sometimes invoked as sufficient (power-law tail, dominant parent
-rule, sparse cross-edges; see design note §5.1) act only by
-producing this inequality. Any graph property that yields
-$b_{\text{eff}} \cdot D > b'$ produces low TLI; conversely, no
-graph property that fails to produce the inequality can produce
-low TLI.
-
-This is the "decoupling geometry from metric" claim of design
-note §5.6.2 stated as a falsifiable conjecture.
-
-### 3.4 Symmetric DAGs have high TLI under any directional metric
-
-**Conjecture 3.4.** Let $G$ be a directed graph where, in
-calibration,
+**Conjecture 3.5 (Falsification target).** Let $G$ be a directed
+graph where, in calibration,
 $\mathbb{E}[d_c^2] \approx \mathbb{E}[d_p^2]$ (symmetric DAG, no
 parent/child distinction). Then for *any* directionally-weighted
 metric of the form
 $w(p) = c_1^{N(p)} c_2^{M(p)}$ with constants $c_1, c_2$ derived
-from $G$'s degree distribution, $\mathrm{TLI}(G, \mu, Q, B)$
-is bounded *below* (not above) by a function of $B$ growing as
+from $G$'s degree distribution, $\mathrm{TLI}(G, \mu, Q, B)$ is
+bounded *below* (not above) by a function of $B$ growing as
 $B \to \infty$.
 
 In words: symmetric DAGs cannot have low TLI under any
@@ -441,7 +638,41 @@ calibration of the directional metric. The directional asymmetry
 is *necessary*, not just sufficient.
 
 This conjecture motivates the synthetic-graph falsification task
-(task #10 in the design note).
+(task #10 in the design note) and is the natural test of the
+necessity direction of Conjecture 3.2.
+
+### 3.6 Routing-correction redundancy under topical calibration
+
+**Conjecture 3.6.** Under the topical-root LMDB construction
+recipe (design note §7.1), the *routing correction* factor
+$\rho := \mathrm{avg\_min\_dist} / \mathrm{avg\_path\_hops}$
+becomes unnecessary as a separate calibration term — i.e. the
+kernel-internal composition
+$\mathrm{BranchRatio} = b_{\text{eff}} \cdot \rho$ should be
+replaced by $\mathrm{BranchRatio} = b_{\text{eff}}$ when
+calibrating on a homogeneous topical subgraph.
+
+**Motivation.** The routing correction was introduced as a
+heuristic compensation when $b_{\text{eff}}$ was inflated by
+admin hubs in global calibration. Under topical scoping
+$b_{\text{eff}}$ already matches $b'$ to within ~15% (design
+note §4.5); applying $\rho \approx 0.384$ on top *deflates*
+$b_{\text{eff}}$ to roughly $1/3$ of its honest value, which the
+robustness band absorbs but is not principled. See design note
+§5.4 for the discussion.
+
+**Status.** *Tentative.* The drift probe under the alternate
+composition has not been re-run on topical calibration. Task #14
+in the design note is to settle this empirically by measuring
+TLI under both compositions and verifying both remain below the
+0.1% certificate threshold.
+
+**Production consequence.** If confirmed, the data-prep recipe
+(design note §7.1) and calibration recipe (§7.2) become
+unconditionally simpler: drop the routing correction term, use
+$b_{\text{eff}}$ directly. If refuted, the routing correction
+stays but its theoretical role becomes "calibration-error
+band-aid" rather than "principled factor."
 
 ## 4. Empirical status
 
@@ -449,7 +680,7 @@ For each conjecture, we summarise the empirical evidence
 recorded in the design note. See `TREE_LIKENESS_INDEX.md` §4
 for full details.
 
-### 4.1 Conjecture 3.1 (main)
+### 4.1 Conjecture 3.1 (main convergence)
 
 - Aggregate TLI: ~0.02% on simplewiki rooted at Physics, $n = 20$
   pairs, budget $B = 15$, child-step costs $cc = 100$ vs $cc = 5$
@@ -458,61 +689,95 @@ for full details.
   note §4.2).
 - Convergence ratio: $r \approx 0.157$ with topical calibration
   ($b_{\text{eff}} = 9.59$, $D = 7.34$, $b' \approx 11$).
-- Theorem 2.3 bound: $\psi(0.157) = 0.157/(1 - 0.157) \approx 0.186$,
-  i.e. ~18.6% drift bound. Empirical: ~0.02%. The bound is loose;
-  see §5.1 below.
+- Theorem 2.3 contribution-sum bound:
+  $r/(1 - r) \approx 0.186$, i.e. ~18.6%. Empirical TLI: ~0.02%.
+  Gap factor ~1000×; see §5.1 below.
 
-### 4.2 Conjecture 3.2 (topical homogeneity)
+### 4.2 Conjecture 3.2 (b·D > b' is operative — sufficiency)
+
+The robustness band documented in design note §5.5 shows three
+calibration regimes (global with routing, topical with routing,
+topical without routing) all yielding TLI < 0.1% despite
+producing $b_{\text{eff}} \cdot D$ values that range from 27 to
+1659. The common factor is all three exceed $b' \approx 11$.
+This supports *sufficiency* but does not establish *necessity*.
+
+Note on the "1659" figure: this is the global calibration's
+$b_{\text{eff}} \cdot D = 589 \cdot 0.384 \cdot D = 226 \cdot D \approx 1659$,
+where the routing correction $\rho = 0.384$ is folded in. The
+original design note pre-correction had this as $b_{\text{eff}}
+\cdot D \approx 9933$ using the early-formula $b$, and the
+relationship between these calibrations is documented in design
+note §2.0's notation table.
+
+### 4.3 Conjecture 3.3 ($\psi \sim r^2/(1-r)$ tightening)
+
+Pending: a careful theoretical analysis distinguishing the
+numerator and denominator contribution sums via their different
+length-factor dependences. The empirical 1000× gap between the
+contribution-sum bound and the actual TLI is consistent with the
+conjectured $r^2$ scaling.
+
+### 4.4 Conjecture 3.4 (topical homogeneity)
 
 - `Category:Articles` $b_{\text{eff}} = 9.59$ (79,797 reachable
   nodes).
 - `Category:Physics` $b_{\text{eff}} = 9.51$ (79,199 reachable
   nodes).
 - Agreement: ~1% (design note §4.5).
-- Global (not topical) $b_{\text{eff}} = 589$, an order-of-
-  magnitude discrepancy — direct evidence that homogeneity fails
-  globally.
+- Global (not topical) $b_{\text{eff}} = 589$, a 60× discrepancy
+  — direct evidence that homogeneity fails globally.
 
-### 4.3 Conjecture 3.3 (b·D > b' is operative)
-
-The robustness band documented in design note §5.5 shows three
-calibration regimes (global with routing, topical with routing,
-topical without routing) all yielding TLI < 0.1% despite
-producing $b_{\text{eff}} \cdot D$ values that range from 27 to
-1659. The common factor is that all three exceed $b' \approx 11$.
-This is suggestive evidence but does not establish necessity.
-
-### 4.4 Conjecture 3.4 (symmetric DAG falsification)
+### 4.5 Conjecture 3.5 (symmetric DAG falsification)
 
 Pending: synthetic-graph experiment (task #10). The Cohen-Havlin
 theorem (§1.3) implies that scale-free graphs in the
 $2 < \gamma < 3$ regime are *not* asymptotically symmetric, so a
 falsification requires explicit construction.
 
+### 4.6 Conjecture 3.6 (routing-correction redundancy)
+
+Pending: design note task #14. The kernel template's b_eff
+formula update is staged locally; the experiment is to compare
+TLI under `BranchRatio = b_eff` (no routing) vs
+`BranchRatio = b_eff · ρ` (with routing) on simplewiki topical
+calibration, and verify both pass the 0.1% TLI threshold.
+
 ## 5. Open theoretical questions
 
 ### 5.1 Tightness of the convergence bound
 
-Theorem 2.3 establishes $\mathrm{TLI} \le r/(1 - r)$ under the
-exact-factorisation assumption. On simplewiki this bounds TLI by
-18.6%, while empirically TLI is ~0.02% — a factor of ~1000
-gap. The bound is loose because:
+Theorem 2.3 establishes
+$\sum_{M \ge 1} S_M / S_0 \le r/(1-r)$ and similarly for $W$ —
+i.e. a bound on *individual* contribution-sum drifts. On
+simplewiki this gives $r/(1 - r) \approx 0.186$, while
+empirically TLI is ~0.02% — a factor of ~1000 gap.
 
-- It assumes worst-case length factors $(h+1)^{-n}$ for child
-  paths, but in practice child paths are *longer*, so the length
-  factor *additionally* suppresses them.
-- It does not exploit the structure of the power-mean
-  aggregation (the Lipschitz constants are smaller than the
-  worst-case sum).
+The gap arises because $d_{\text{wPow}} = (N/W)^{-1/n}$ is a
+*ratio*. To first order in $r$,
+$$
+\frac{\mathrm{TLI}}{1} \approx \frac{1}{n}
+\bigl|\Delta\log N - \Delta\log W\bigr|
+$$
+where $\Delta\log N \approx \sum r^k L_k / L_0$ and
+$\Delta\log W \approx \sum r^k R_k / R_0$ with $L_M$ the
+length-factor sum at level $M$ and $R_M$ the admissible-$N$
+range at level $M$. Both $\Delta\log N$ and $\Delta\log W$ are
+bounded by $r/(1-r)$ but their *difference* is much smaller —
+both are dominated by the same $r/(1-r)$ leading term, and the
+correction depends on the *ratio* $L_M/R_M$ vs $L_0/R_0$.
 
-**Open question.** Is there a tighter version of Theorem 2.3 that
-uses the length-factor suppression to give a bound matching the
-empirical ratio? Conjecturally, $\psi(r) \sim r^{n+1}$ or similar
-for power-mean exponent $n$, but this needs proof.
+**Open question (Conjecture 3.3).** Is $\psi(r) = O(r^2/(1-r))$
+the correct scaling, with the constant depending on $n$,
+$d_{\min}$, and the budget $B$? A careful Taylor expansion of
+the ratio $N/W$ in $r$ should resolve this. The empirical 1000×
+gap is consistent with $r^2$ scaling: $r^2/(1-r) \approx 0.029$
+for $r = 0.157$, only ~1.5× off from the empirical 0.02% (and
+closer once the constant $C$ is known).
 
 ### 5.2 Quantitative homogeneity ↔ calibration error
 
-Conjecture 3.2 asserts that topical scoping is "sufficient for
+Conjecture 3.4 asserts that topical scoping is "sufficient for
 homogeneity in practice". Made precise: how much deviation from
 exact homogeneity can be tolerated before the convergence bound
 of Theorem 2.3 fails to apply? Specifically, if the path-count
@@ -520,7 +785,7 @@ factorisation in Lemma 2.1 holds with multiplicative error
 $(1 + \delta)$, what is the corresponding error in the TLI
 bound?
 
-A quantitative answer here would convert Conjecture 3.2 from
+A quantitative answer here would convert Conjecture 3.4 from
 "this seems to work" to a calibration-error budget.
 
 ### 5.3 Scale-free regime under topical scoping
@@ -564,15 +829,31 @@ spectral, expansion-based) in place of directional?
 
 ### 5.5 Connection to spectral expansion
 
-The convergence ratio $r = b'/(b \cdot D)$ has a spectral
-interpretation we have not yet developed:
+The convergence ratio $r = b'/(b_{\text{eff}} \cdot D)$ has a
+plausible but unconfirmed spectral interpretation:
 
 - $D$ is the average degree, related to the largest eigenvalue
   $\lambda_1$ of the adjacency matrix.
-- $b$ involves second-moment ratios, related to the variance of
-  the degree distribution.
+- $b_{\text{eff}}$ involves second-moment ratios, related to the
+  variance of the degree distribution.
 - $b'$ is a path-count growth rate, related to higher-order
   expansion properties.
+
+**Sharpening observation.** The connection cannot be a direct
+equivalence between $r$ and the spectral gap. Counter-example:
+a $D$-regular *directed* graph (every node has $D$ children and
+$D$ parents, $D \ge 2$) has a *large* spectral gap (the
+adjacency matrix is dominated by $\lambda_1 = D$ with a
+substantial gap to $\lambda_2$), yet has $b_{\text{eff}} = 1$
+(no directional asymmetry) and $b' \approx D$ (every child hop
+multiplies paths by ~$D$), giving $r = D/(1 \cdot D) = 1$. So
+the convergence fails for a graph with excellent spectral
+expansion.
+
+This rules out "$r$ = function of spectral gap" but leaves open:
+$r$ may be related to a *directional* spectral quantity (e.g.
+the singular value spectrum of the parent/child adjacency
+asymmetry), not the symmetric spectrum.
 
 **Open question.** Is there a relationship between $r$ and the
 spectral gap $\lambda_1 - \lambda_2$, or the second-largest


### PR DESCRIPTION
  ## Summary

  Adds `TREE_LIKENESS_INDEX_THEORY.md`, a formal companion to the design note. Separates the formal content
  (definitions, theorems, conjectures, citations) from the empirical / engineering content (which stays in the design
  note).

  **Stacked on `docs/tree-likeness-index-rename`** — please merge that PR first. After that, this branch can be rebased
  onto `main` and the diff will be just the new theory file.

  ## Structure

  | § | Content |
  |---|---|
  | 0 | Setup and notation — self-contained, LaTeX-formatted definitions for the weighted metric, path-count function,
  and TLI |
  | 1 | Established results with citations: Chung-Lu, Watts-Strogatz, Cohen-Havlin, Clauset-Shalizi-Newman, Feld, tree
  pair distance |
  | 2 | Three real proofs: Lemma 2.1 (path-count factorisation), Prop 2.2 (weights normalise), Theorem 2.3
  (geometric-series TLI bound) |
  | 3 | Four conjectures: main convergence conjecture (Theorem 2.3 is partial proof), topical homogeneity, b·D > b' is
  operative, symmetric-DAG falsification |
  | 4 | Empirical status — cross-references design note §4 |
  | 5 | Five open theoretical questions including a spectral-expansion conjecture |
  | 6 | References |

  ## Key framing decisions

  - **Directional asymmetry is the load-bearing property**, not acyclicity. Wikipedia is approximately DAG, but what
  matters for TLI is multi-parent (undirected-cycle) connectivity and the parent/child branching asymmetry it creates.
  - **Theorem 2.3 (the convergence bound)** establishes `TLI ≤ r/(1-r)` where `r = b'/(b·D)`, *conditional on* exact
  path-count factorisation (Lemma 2.1). On simplewiki this bounds TLI by ~18.6%; empirically TLI is ~0.02%, so the bound
  is loose by ~1000×. §5.1 lists this as an open question.
  - **Self-contained §0** but conservative §2 — we only prove what follows from definitions plus mild homogeneity.
  Bigger claims are conjectures with empirical support from the design note.

  ## Test plan

  - [ ] LaTeX renders correctly in GitHub markdown preview (MathJax)
  - [ ] Cross-references to design note resolve
  - [ ] No circular dependencies between theorem statements
  - [ ] Conjectures are clearly labelled as such

  ## Follow-up

  - Task #10 (synthetic non-tree-like graph) would empirically test Conjecture 3.4
  - Task #14 (routing correction redundancy) would settle the §5.4 question in the design note and update Conjecture
  3.1's calibration story
  - Task #15 (random-pair BFS) measures the geometric regime to test Conjecture 3.2 directly
  - The spectral-expansion question in §5.5 is genuinely open — would welcome reviewer perspectives on whether there's a
  known result connecting `b'/(b·D)` to the spectral gap