### PR TITLE
Add WAM-C child CSR scale sweep wrapper

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,18 +4,21 @@ Status date: 2026-05-31
 
 Latest branch verification:
 
-- `investigate/wam-c-larger-artifact-layouts` based on `main` at `982c82f0`
-  (`Merge pull request #2652 from s243a/feat/wam-c-native-kernel-float-output`)
+- `investigate/wam-c-child-csr-scale-sweep` based on `main` at `05de16c8`
+  (`Merge pull request #2662 from s243a/investigate/wam-c-larger-artifact-layouts`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py`
 - `python3 tests/test_benchmark_target_matrix.py`
+- `python3 -m py_compile examples/benchmark/benchmark_wam_c_child_csr_scale_sweep.py tests/test_wam_c_child_csr_scale_sweep.py`
+- `python3 tests/test_wam_c_child_csr_scale_sweep.py`
 - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets c-wam-child-search-layouts --repetitions 1 --baseline-target c-wam-accumulated-child-scan --run-timeout-seconds 180`
 - `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10x --target-sets c-wam-child-csr-layouts --compile-only-targets c-wam-accumulated-child-csr,c-wam-accumulated-child-csr-drop,c-wam-accumulated-child-csr-lmdb-offset --baseline-target c-wam-accumulated-child-csr`
+- `python3 examples/benchmark/benchmark_wam_c_child_csr_scale_sweep.py`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-larger-artifact-layouts`
+- `investigate/wam-c-child-csr-scale-sweep`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -203,6 +206,8 @@ Implemented so far:
   `c-wam-child-csr-layouts` for larger CSR-only comparisons.
 - Compile-only matrix rows now report WAM-C artifact byte sizes for TSV, LMDB,
   CSR index/values, and LMDB-offset stores.
+- Added `benchmark_wam_c_child_csr_scale_sweep.py` as the routine compile-only
+  scale-sweep wrapper for CSR layout artifacts.
 - `dev` layout smoke shows output parity across scan, sorted-array CSR,
   buffered-pread-drop CSR, and LMDB-offset CSR; runtimes were about
   `0.130-0.145s` for the four variants.
@@ -210,6 +215,10 @@ Implemented so far:
   `0.735-0.811s`; the generated parent TSV is `167,698` bytes, the reverse
   CSR index is `22,528` bytes, reverse CSR values are `15,728` bytes, and the
   LMDB-offset store adds `77,824` bytes.
+- The default compile-only scale sweep now covers `10x,1k,5k,10k` and finishes
+  locally in roughly half a minute. At `10k`, parent TSV is `1,266,946` bytes,
+  reverse CSR index is `118,672` bytes, reverse CSR values are `100,908` bytes,
+  and the LMDB-offset store adds `327,680` bytes.
 
 Open measurement:
 
@@ -218,6 +227,8 @@ Open measurement:
 - Use compile-only rows for routine larger-scale artifact-size comparisons,
   then schedule runtime rows separately for scales where child-search query
   execution is acceptable.
+- `50k_cats` and `100k_cats` are explicit opt-in scales for the wrapper because
+  generated-project build time is no longer a routine local gate there.
 - Parent-only TSV and LMDB targets remain the priority memory structures for
   current effective-distance workloads. Reverse CSR targets are now available
   for future child-path variants and artifact-layout measurements.
@@ -411,9 +422,8 @@ After hash-bucket row dispatch but before compact row tables:
 
 ## Suggested Immediate Next Step
 
-Use `c-wam-child-search-layouts` at `dev` as the fast correctness gate and
-`c-wam-child-csr-layouts` in compile-only mode for routine larger-scale
-artifact-size comparisons. Run full child-search runtime rows only in explicit
-longer benchmark windows, and do not promote in-memory compressed CSR work
-until those measurements show that the current file-backed CSR layout is the
-limiting factor.
+Use `benchmark_wam_c_child_csr_scale_sweep.py` for routine compile-only
+artifact-size comparisons through `10k`. Run `50k_cats`, `100k_cats`, and full
+child-search runtime rows only in explicit longer benchmark windows, and do not
+promote in-memory compressed CSR work until those measurements show that the
+current file-backed CSR layout is the limiting factor.

--- a/examples/benchmark/benchmark_wam_c_child_csr_scale_sweep.py
+++ b/examples/benchmark/benchmark_wam_c_child_csr_scale_sweep.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Run the WAM-C child-search CSR layout scale sweep.
+
+This wrapper keeps the routine sweep compile-only: it builds the generated C
+projects and reports artifact byte sizes without executing the expensive
+child-search query body. Use the underlying matrix directly for full runtime
+rows when a longer benchmark window is intentional.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "examples" / "benchmark" / "benchmark_effective_distance_matrix.py"
+CSR_TARGETS = [
+    "c-wam-accumulated-child-csr",
+    "c-wam-accumulated-child-csr-drop",
+    "c-wam-accumulated-child-csr-lmdb-offset",
+]
+DEFAULT_SCALES = "10x,1k,5k,10k"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scales",
+        default=DEFAULT_SCALES,
+        help=(
+            f"Comma-separated benchmark scales. Default: {DEFAULT_SCALES}. "
+            "Use --scales 50k_cats,100k_cats explicitly for the largest local artifacts."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the matrix command without running it.",
+    )
+    parser.add_argument(
+        "matrix_args",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments passed after -- to the matrix runner.",
+    )
+    return parser.parse_args()
+
+
+def matrix_command(scales: str, extra_args: list[str] | None = None) -> list[str]:
+    command = [
+        sys.executable,
+        str(MATRIX),
+        "--scales",
+        scales,
+        "--target-sets",
+        "c-wam-child-csr-layouts",
+        "--compile-only-targets",
+        ",".join(CSR_TARGETS),
+        "--baseline-target",
+        "c-wam-accumulated-child-csr",
+    ]
+    if extra_args:
+        command.extend(extra_args)
+    return command
+
+
+def main() -> int:
+    args = parse_args()
+    extra_args = args.matrix_args
+    if extra_args and extra_args[0] == "--":
+        extra_args = extra_args[1:]
+    command = matrix_command(args.scales, extra_args)
+    if args.dry_run:
+        print(" ".join(command))
+        return 0
+    return subprocess.run(command, cwd=ROOT, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_wam_c_child_csr_scale_sweep.py
+++ b/tests/test_wam_c_child_csr_scale_sweep.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
+
+from benchmark_wam_c_child_csr_scale_sweep import (  # noqa: E402
+    CSR_TARGETS,
+    DEFAULT_SCALES,
+    matrix_command,
+)
+
+
+class WamCChildCsrScaleSweepTests(unittest.TestCase):
+    def test_matrix_command_uses_compile_only_csr_layout_targets(self) -> None:
+        command = matrix_command("10x,1k")
+
+        self.assertEqual(command[0], sys.executable)
+        self.assertIn("benchmark_effective_distance_matrix.py", command[1])
+        self.assertIn("--target-sets", command)
+        self.assertEqual(command[command.index("--target-sets") + 1], "c-wam-child-csr-layouts")
+        self.assertIn("--compile-only-targets", command)
+        self.assertEqual(command[command.index("--compile-only-targets") + 1], ",".join(CSR_TARGETS))
+        self.assertEqual(command[command.index("--baseline-target") + 1], "c-wam-accumulated-child-csr")
+
+    def test_matrix_command_accepts_extra_matrix_args(self) -> None:
+        command = matrix_command(DEFAULT_SCALES, ["--keep-temp"])
+
+        self.assertEqual(command[-1], "--keep-temp")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  - Adds `benchmark_wam_c_child_csr_scale_sweep.py` as a routine compile-only sweep for WAM-C child-search CSR artifact
  layouts.
  - Defaults the sweep to `10x,1k,5k,10k`, keeping `50k_cats` and `100k_cats` as explicit opt-in scales.
  - Adds tests for the wrapper command shape.
  - Updates `WAM_C_TARGET_NEXT_STEPS.md` with the new sweep workflow and `10k` artifact-size evidence.

  ## Verification

  - `python3 -m py_compile examples/benchmark/benchmark_wam_c_child_csr_scale_sweep.py tests/
  test_wam_c_child_csr_scale_sweep.py examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/
  benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py`
  - `python3 tests/test_wam_c_child_csr_scale_sweep.py`
  - `python3 tests/test_benchmark_target_matrix.py`
  - `python3 examples/benchmark/benchmark_wam_c_child_csr_scale_sweep.py`
  - `git diff --check`

  ## Notes

  The sweep is compile-only by design: it builds the generated C projects and reports artifact sizes without running the
  expensive child-search query body.