### PR TITLE
Add artifact-only WAM-C CSR scale sweep

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -190,10 +190,12 @@ Reason:
 - Weighted/A* native kernels previously covered only integer results, while
   Haskell and Rust had broader numeric-result surfaces.
 
-### Active: `investigate/wam-c-larger-artifact-layouts`
+### Active: `investigate/wam-c-csr-artifact-only-large-scales`
 
 Goal: measure whether the newer parent-only LMDB and reverse CSR artifact
-layouts remain the right defaults at larger category scales.
+layouts remain the right defaults at larger category scales, without forcing
+full WAM-C query-runner generation and C compilation when only artifact bytes
+are needed.
 
 Implemented so far:
 
@@ -208,6 +210,11 @@ Implemented so far:
   CSR index/values, and LMDB-offset stores.
 - Added `benchmark_wam_c_child_csr_scale_sweep.py` as the routine compile-only
   scale-sweep wrapper for CSR layout artifacts.
+- Added an `--artifact-only` path to that wrapper. It reads the benchmark TSVs,
+  assigns the same sorted category IDs as the WAM-C generator, writes the
+  parent-sorted reverse CSR index/value files, and optionally writes the
+  LMDB-offset lookup store. This keeps `50k_cats` and `100k_cats` artifact
+  measurements out of the expensive generated-C compile path.
 - `dev` layout smoke shows output parity across scan, sorted-array CSR,
   buffered-pread-drop CSR, and LMDB-offset CSR; runtimes were about
   `0.130-0.145s` for the four variants.
@@ -219,16 +226,25 @@ Implemented so far:
   locally in roughly half a minute. At `10k`, parent TSV is `1,266,946` bytes,
   reverse CSR index is `118,672` bytes, reverse CSR values are `100,908` bytes,
   and the LMDB-offset store adds `327,680` bytes.
+- The artifact-only path reproduces the `10k` generated parent TSV, CSR index,
+  and CSR value byte counts without compiling C. Its Python-created LMDB-offset
+  directory reports `335,872` bytes including `lock.mdb`, while the data file
+  alone is consistent with the prior `327,680` byte observation.
+- `50k_cats` and `100k_cats` artifact-only rows currently share the same local
+  category-parent graph: generated parent TSV `10,126,909` bytes, reverse CSR
+  index `678,752` bytes, reverse CSR values `787,600` bytes, LMDB-offset store
+  `1,687,552` bytes, `42,422` parent rows, `196,900` child-parent edges, and
+  `84,136` category IDs. Build time was about `0.11s` for sorted-array rows
+  and about `0.15s` for LMDB-offset rows.
 
 Open measurement:
 
 - `10x` child-search layout runs are not a routine local gate even with a small
   child-expansion cap; run them only as an explicit longer benchmark window.
-- Use compile-only rows for routine larger-scale artifact-size comparisons,
-  then schedule runtime rows separately for scales where child-search query
+- Use compile-only rows for routine generated-project comparisons through
+  `10k`, use `--artifact-only` for `50k_cats` and `100k_cats` size checks, then
+  schedule runtime rows separately for scales where child-search query
   execution is acceptable.
-- `50k_cats` and `100k_cats` are explicit opt-in scales for the wrapper because
-  generated-project build time is no longer a routine local gate there.
 - Parent-only TSV and LMDB targets remain the priority memory structures for
   current effective-distance workloads. Reverse CSR targets are now available
   for future child-path variants and artifact-layout measurements.
@@ -423,7 +439,8 @@ After hash-bucket row dispatch but before compact row tables:
 ## Suggested Immediate Next Step
 
 Use `benchmark_wam_c_child_csr_scale_sweep.py` for routine compile-only
-artifact-size comparisons through `10k`. Run `50k_cats`, `100k_cats`, and full
-child-search runtime rows only in explicit longer benchmark windows, and do not
-promote in-memory compressed CSR work until those measurements show that the
-current file-backed CSR layout is the limiting factor.
+generated-project artifact comparisons through `10k`, and use
+`benchmark_wam_c_child_csr_scale_sweep.py --artifact-only --scales
+50k_cats,100k_cats` for large category-graph artifact bytes. Next, decide
+whether to add a small cold/warm CSR lookup microbenchmark for the file-backed
+reader before spending implementation time on in-memory compressed CSR.

--- a/examples/benchmark/benchmark_wam_c_child_csr_scale_sweep.py
+++ b/examples/benchmark/benchmark_wam_c_child_csr_scale_sweep.py
@@ -6,24 +6,58 @@ This wrapper keeps the routine sweep compile-only: it builds the generated C
 projects and reports artifact byte sizes without executing the expensive
 child-search query body. Use the underlying matrix directly for full runtime
 rows when a longer benchmark window is intentional.
+
+Use --artifact-only for large category scales where generating and compiling the
+full WAM-C query runner is not needed. That path builds only the reverse CSR
+artifacts from the benchmark TSV inputs and reports their byte sizes.
 """
 
 from __future__ import annotations
 
 import argparse
+import shutil
+import struct
 import subprocess
 import sys
+import tempfile
+import time
+from collections import defaultdict
+from dataclasses import dataclass
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
 MATRIX = ROOT / "examples" / "benchmark" / "benchmark_effective_distance_matrix.py"
+BENCH_DIR = ROOT / "data" / "benchmark"
 CSR_TARGETS = [
     "c-wam-accumulated-child-csr",
     "c-wam-accumulated-child-csr-drop",
     "c-wam-accumulated-child-csr-lmdb-offset",
 ]
 DEFAULT_SCALES = "10x,1k,5k,10k"
+ARTIFACT_ONLY_TARGETS = [
+    ("c-wam-accumulated-child-csr", "sorted_array"),
+    ("c-wam-accumulated-child-csr-drop", "sorted_array"),
+    ("c-wam-accumulated-child-csr-lmdb-offset", "lmdb_offset"),
+]
+IDX_RECORD = struct.Struct("<iQI")
+OFFSET_RECORD = struct.Struct("<QI")
+I32 = struct.Struct("<i")
+
+
+@dataclass(frozen=True)
+class ArtifactOnlyRow:
+    scale: str
+    target: str
+    status: str
+    build_s: float
+    category_parent_tsv_bytes: int
+    reverse_csr_index_bytes: int
+    reverse_csr_values_bytes: int
+    reverse_csr_offsets_lmdb_bytes: int
+    parent_count: int
+    edge_count: int
+    category_count: int
 
 
 def parse_args() -> argparse.Namespace:
@@ -39,7 +73,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Print the matrix command without running it.",
+        help="Print the matrix command or artifact-only plan without running it.",
+    )
+    parser.add_argument(
+        "--artifact-only",
+        action="store_true",
+        help="Build only reverse CSR artifacts from benchmark TSVs; skip WAM-C generation and C compilation.",
+    )
+    parser.add_argument(
+        "--artifact-root",
+        type=Path,
+        help="Directory for artifact-only outputs. Defaults to a temporary directory that is removed after the run.",
     )
     parser.add_argument(
         "matrix_args",
@@ -67,8 +111,228 @@ def matrix_command(scales: str, extra_args: list[str] | None = None) -> list[str
     return command
 
 
+def scale_names(scales: str) -> list[str]:
+    return [part.strip() for part in scales.split(",") if part.strip()]
+
+
+def read_tsv_pairs(path: Path) -> list[tuple[str, str]]:
+    rows: list[tuple[str, str]] = []
+    if not path.exists():
+        return rows
+    with path.open("r", encoding="utf-8") as stream:
+        next(stream, None)
+        for line in stream:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            parts = line.split("\t")
+            if len(parts) >= 2:
+                rows.append((parts[0], parts[1]))
+    return rows
+
+
+def read_tsv_column(path: Path) -> list[str]:
+    values: list[str] = []
+    if not path.exists():
+        return values
+    with path.open("r", encoding="utf-8") as stream:
+        next(stream, None)
+        for line in stream:
+            value = line.rstrip("\n")
+            if value:
+                values.append(value.split("\t", 1)[0])
+    return values
+
+
+def category_id_map(
+    category_parents: list[tuple[str, str]],
+    article_categories: list[tuple[str, str]],
+    root_categories: list[str],
+) -> dict[str, int]:
+    categories: set[str] = set(root_categories)
+    for child, parent in category_parents:
+        categories.add(child)
+        categories.add(parent)
+    for _article, category in article_categories:
+        categories.add(category)
+    return {category: index for index, category in enumerate(sorted(categories), start=1)}
+
+
+def generated_category_parent_tsv_bytes(category_parents: list[tuple[str, str]]) -> int:
+    return sum(len(f"{child}\t{parent}\n".encode("utf-8")) for child, parent in category_parents)
+
+
+def file_tree_size_bytes(path: Path) -> int:
+    if path.is_file():
+        return path.stat().st_size
+    if path.is_dir():
+        return sum(child.stat().st_size for child in path.rglob("*") if child.is_file())
+    return 0
+
+
+def write_reverse_csr_artifact(
+    category_parents: list[tuple[str, str]],
+    ids: dict[str, int],
+    out_dir: Path,
+    index_backend: str,
+) -> tuple[int, int, int]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    children_by_parent: dict[int, list[int]] = defaultdict(list)
+    edge_count = 0
+    for child, parent in category_parents:
+        children_by_parent[ids[parent]].append(ids[child])
+        edge_count += 1
+
+    idx_path = out_dir / "category_child.csr.idx"
+    val_path = out_dir / "category_child.csr.val"
+    offset_edges = 0
+    with idx_path.open("wb") as idx_file, val_path.open("wb") as val_file:
+        for parent_id in sorted(children_by_parent):
+            children = sorted(children_by_parent[parent_id])
+            idx_file.write(IDX_RECORD.pack(parent_id, offset_edges, len(children)))
+            for child_id in children:
+                val_file.write(I32.pack(child_id))
+            offset_edges += len(children)
+
+    if index_backend == "lmdb_offset":
+        write_lmdb_offset_index(idx_path, out_dir / "category_child.csr.offsets.lmdb")
+    elif index_backend != "sorted_array":
+        raise ValueError(f"unknown index backend: {index_backend}")
+    return len(children_by_parent), edge_count, len(ids)
+
+
+def write_lmdb_offset_index(idx_path: Path, offset_lmdb_path: Path) -> None:
+    try:
+        import lmdb
+    except ImportError as exc:
+        raise RuntimeError("artifact-only LMDB offset rows require the 'lmdb' Python package") from exc
+
+    row_count = idx_path.stat().st_size // IDX_RECORD.size
+    env = lmdb.open(
+        str(offset_lmdb_path),
+        map_size=max(row_count * 128, 1 << 20),
+        max_dbs=2,
+        subdir=True,
+    )
+    try:
+        offsets_db = env.open_db(b"offsets")
+        with env.begin(write=True) as txn:
+            data = idx_path.read_bytes()
+            for offset in range(0, len(data), IDX_RECORD.size):
+                parent_id, offset_edges, count = IDX_RECORD.unpack_from(data, offset)
+                txn.put(I32.pack(parent_id), OFFSET_RECORD.pack(offset_edges, count), db=offsets_db)
+    finally:
+        env.sync()
+        env.close()
+
+
+def build_artifact_only_rows(scales: list[str], artifact_root: Path) -> list[ArtifactOnlyRow]:
+    rows: list[ArtifactOnlyRow] = []
+    for scale in scales:
+        scale_dir = BENCH_DIR / scale
+        category_parent_path = scale_dir / "category_parent.tsv"
+        if not category_parent_path.exists():
+            raise FileNotFoundError(category_parent_path)
+
+        category_parents = read_tsv_pairs(category_parent_path)
+        article_categories = read_tsv_pairs(scale_dir / "article_category.tsv")
+        root_categories = read_tsv_column(scale_dir / "root_categories.tsv")
+        ids = category_id_map(category_parents, article_categories, root_categories)
+
+        for target, index_backend in ARTIFACT_ONLY_TARGETS:
+            started_at = time.perf_counter()
+            out_dir = artifact_root / scale / target
+            if out_dir.exists():
+                shutil.rmtree(out_dir)
+            parent_count, edge_count, category_count = write_reverse_csr_artifact(
+                category_parents,
+                ids,
+                out_dir,
+                index_backend,
+            )
+            build_s = time.perf_counter() - started_at
+            rows.append(
+                ArtifactOnlyRow(
+                    scale=scale,
+                    target=target,
+                    status="artifact_only",
+                    build_s=build_s,
+                    category_parent_tsv_bytes=generated_category_parent_tsv_bytes(category_parents),
+                    reverse_csr_index_bytes=file_tree_size_bytes(out_dir / "category_child.csr.idx"),
+                    reverse_csr_values_bytes=file_tree_size_bytes(out_dir / "category_child.csr.val"),
+                    reverse_csr_offsets_lmdb_bytes=file_tree_size_bytes(out_dir / "category_child.csr.offsets.lmdb"),
+                    parent_count=parent_count,
+                    edge_count=edge_count,
+                    category_count=category_count,
+                )
+            )
+    return rows
+
+
+def print_artifact_only_rows(rows: list[ArtifactOnlyRow]) -> None:
+    print(
+        "\t".join(
+            [
+                "scale",
+                "target",
+                "status",
+                "build_s",
+                "category_parent_tsv_bytes",
+                "reverse_csr_index_bytes",
+                "reverse_csr_values_bytes",
+                "reverse_csr_offsets_lmdb_bytes",
+                "parent_count",
+                "edge_count",
+                "category_count",
+            ]
+        )
+    )
+    for row in rows:
+        print(
+            "\t".join(
+                [
+                    row.scale,
+                    row.target,
+                    row.status,
+                    f"{row.build_s:.3f}",
+                    str(row.category_parent_tsv_bytes),
+                    str(row.reverse_csr_index_bytes),
+                    str(row.reverse_csr_values_bytes),
+                    str(row.reverse_csr_offsets_lmdb_bytes),
+                    str(row.parent_count),
+                    str(row.edge_count),
+                    str(row.category_count),
+                ]
+            )
+        )
+
+
+def run_artifact_only(scales: str, artifact_root: Path | None, dry_run: bool) -> int:
+    names = scale_names(scales)
+    if dry_run:
+        root = artifact_root or Path("<temporary artifact root>")
+        for scale in names:
+            for target, index_backend in ARTIFACT_ONLY_TARGETS:
+                print(f"artifact-only {scale} {target} index_backend={index_backend} root={root}")
+        return 0
+
+    if artifact_root is not None:
+        artifact_root.mkdir(parents=True, exist_ok=True)
+        rows = build_artifact_only_rows(names, artifact_root)
+        print_artifact_only_rows(rows)
+        return 0
+
+    with tempfile.TemporaryDirectory(prefix="wam-c-child-csr-artifacts-") as tmp:
+        rows = build_artifact_only_rows(names, Path(tmp))
+        print_artifact_only_rows(rows)
+    return 0
+
+
 def main() -> int:
     args = parse_args()
+    if args.artifact_only:
+        return run_artifact_only(args.scales, args.artifact_root, args.dry_run)
+
     extra_args = args.matrix_args
     if extra_args and extra_args[0] == "--":
         extra_args = extra_args[1:]

--- a/tests/test_wam_c_child_csr_scale_sweep.py
+++ b/tests/test_wam_c_child_csr_scale_sweep.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import struct
 import sys
+import tempfile
 import unittest
 from pathlib import Path
+
+import lmdb
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -12,7 +16,15 @@ sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
 from benchmark_wam_c_child_csr_scale_sweep import (  # noqa: E402
     CSR_TARGETS,
     DEFAULT_SCALES,
+    I32,
+    IDX_RECORD,
+    build_artifact_only_rows,
+    category_id_map,
+    generated_category_parent_tsv_bytes,
     matrix_command,
+    read_tsv_column,
+    read_tsv_pairs,
+    write_reverse_csr_artifact,
 )
 
 
@@ -32,6 +44,119 @@ class WamCChildCsrScaleSweepTests(unittest.TestCase):
         command = matrix_command(DEFAULT_SCALES, ["--keep-temp"])
 
         self.assertEqual(command[-1], "--keep-temp")
+
+    def test_category_id_map_matches_generator_sorting_surface(self) -> None:
+        ids = category_id_map(
+            [("ChildB", "Parent"), ("ChildA", "Parent")],
+            [("Article", "ArticleOnly")],
+            ["RootOnly"],
+        )
+
+        self.assertEqual(
+            ids,
+            {
+                "ArticleOnly": 1,
+                "ChildA": 2,
+                "ChildB": 3,
+                "Parent": 4,
+                "RootOnly": 5,
+            },
+        )
+
+    def test_artifact_only_csr_records_are_parent_sorted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp) / "out"
+            ids = {"child_b": 1, "child_a": 2, "parent": 3, "other_parent": 4}
+
+            parent_count, edge_count, category_count = write_reverse_csr_artifact(
+                [("child_b", "parent"), ("child_a", "parent"), ("child_b", "other_parent")],
+                ids,
+                out_dir,
+                "sorted_array",
+            )
+
+            self.assertEqual(parent_count, 2)
+            self.assertEqual(edge_count, 3)
+            self.assertEqual(category_count, 4)
+            self.assertEqual(
+                read_idx(out_dir / "category_child.csr.idx"),
+                [
+                    (3, 0, 2),
+                    (4, 2, 1),
+                ],
+            )
+            self.assertEqual(read_i32_values(out_dir / "category_child.csr.val"), [1, 2, 1])
+
+    def test_artifact_only_lmdb_offsets_match_idx_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp) / "out"
+            ids = {"child_b": 1, "child_a": 2, "parent": 3}
+
+            write_reverse_csr_artifact(
+                [("child_b", "parent"), ("child_a", "parent")],
+                ids,
+                out_dir,
+                "lmdb_offset",
+            )
+
+            offset_env = lmdb.open(
+                str(out_dir / "category_child.csr.offsets.lmdb"),
+                readonly=True,
+                max_dbs=2,
+                lock=False,
+                subdir=True,
+            )
+            try:
+                with offset_env.begin() as txn:
+                    offsets_db = offset_env.open_db(b"offsets", txn=txn, create=False)
+                    self.assertEqual(struct.unpack("<QI", txn.get(I32.pack(3), db=offsets_db)), (0, 2))
+            finally:
+                offset_env.close()
+
+    def test_build_artifact_only_rows_reads_benchmark_tsvs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact_root = Path(tmp) / "artifacts"
+            scale = "dev"
+
+            rows = build_artifact_only_rows([scale], artifact_root)
+
+            self.assertEqual([row.target for row in rows], CSR_TARGETS)
+            self.assertTrue(all(row.scale == scale for row in rows))
+            self.assertTrue(all(row.edge_count > 0 for row in rows))
+            self.assertTrue(all(row.reverse_csr_index_bytes > 0 for row in rows))
+            self.assertTrue(all(row.reverse_csr_values_bytes > 0 for row in rows))
+            self.assertEqual(rows[0].reverse_csr_offsets_lmdb_bytes, 0)
+            self.assertGreater(rows[-1].reverse_csr_offsets_lmdb_bytes, 0)
+
+    def test_tsv_readers_skip_headers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pair_path = tmp_path / "pairs.tsv"
+            column_path = tmp_path / "column.tsv"
+            pair_path.write_text("left\tright\nA\tB\nC\tD\n", encoding="utf-8")
+            column_path.write_text("value\nRoot\n", encoding="utf-8")
+
+            self.assertEqual(read_tsv_pairs(pair_path), [("A", "B"), ("C", "D")])
+            self.assertEqual(read_tsv_column(column_path), ["Root"])
+
+    def test_generated_parent_tsv_size_excludes_source_header(self) -> None:
+        self.assertEqual(generated_category_parent_tsv_bytes([("A", "B"), ("C", "D")]), 8)
+
+
+def read_idx(path: Path) -> list[tuple[int, int, int]]:
+    data = path.read_bytes()
+    return [
+        IDX_RECORD.unpack_from(data, offset)
+        for offset in range(0, len(data), IDX_RECORD.size)
+    ]
+
+
+def read_i32_values(path: Path) -> list[int]:
+    data = path.read_bytes()
+    return [
+        I32.unpack_from(data, offset)[0]
+        for offset in range(0, len(data), I32.size)
+    ]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary

  - add `--artifact-only` mode to the WAM-C child CSR scale sweep wrapper
  - build reverse CSR index/value artifacts directly from benchmark TSVs without generating or compiling the full WAM-C
  query runner
  - report large-scale CSR artifact sizes for sorted-array and LMDB-offset layouts
  - update WAM-C target notes with the `50k_cats` / `100k_cats` artifact-only measurements

  ## Verification

  - `python3 -m py_compile examples/benchmark/benchmark_wam_c_child_csr_scale_sweep.py tests/
  test_wam_c_child_csr_scale_sweep.py`
  - `python3 tests/test_wam_c_child_csr_scale_sweep.py`
  - `python3 examples/benchmark/benchmark_wam_c_child_csr_scale_sweep.py --artifact-only --scales 50k_cats,100k_cats`
  - `git diff --check`