### PR TITLE
LLVM WAM: tab/1 + put_char/1 + put_code/1 small I/O (M66)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3476,6 +3476,9 @@ entry:
     i32 79, label %builtin_writeln
     i32 80, label %builtin_keysort
     i32 81, label %builtin_sort
+    i32 82, label %builtin_tab
+    i32 83, label %builtin_put_char
+    i32 84, label %builtin_put_code
   ]
 
 builtin_is:
@@ -4057,6 +4060,82 @@ srt.b_bind:
   %srt.b_raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
   %srt.b_ok = call i1 @wam_unify_value(%WamState* %vm, %Value %srt.b_raw2, %Value %srt.b_acc)
   ret i1 %srt.b_ok
+
+builtin_tab:
+  ; M66: tab(+N) -- write N spaces to stdout. N must be a non-negative
+  ; Integer; negative or non-integer N fails. Each space written via
+  ; @putchar(32).
+  %tab.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %tab.t1 = extractvalue %Value %tab.a1, 0
+  %tab.is_int = icmp eq i32 %tab.t1, 1
+  br i1 %tab.is_int, label %tab.start, label %tab.fail
+tab.fail:
+  ret i1 false
+tab.start:
+  %tab.n = extractvalue %Value %tab.a1, 1
+  %tab.neg = icmp slt i64 %tab.n, 0
+  br i1 %tab.neg, label %tab.fail, label %tab.loop
+tab.loop:
+  %tab.i = phi i64 [ 0, %tab.start ], [ %tab.i_next, %tab.step ]
+  %tab.done = icmp sge i64 %tab.i, %tab.n
+  br i1 %tab.done, label %tab.exit, label %tab.step
+tab.step:
+  call i32 @putchar(i32 32)
+  %tab.i_next = add i64 %tab.i, 1
+  br label %tab.loop
+tab.exit:
+  ret i1 true
+
+builtin_put_char:
+  ; M66: put_char(+Char) -- Char is a single-char atom. Writes its
+  ; first byte to stdout. Non-atom or multi-byte atom fails (latter
+  ; via the length check).
+  %pc.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %pc.t1 = extractvalue %Value %pc.a1, 0
+  %pc.is_atom = icmp eq i32 %pc.t1, 0
+  br i1 %pc.is_atom, label %pc.lookup, label %pc.fail
+pc.fail:
+  ret i1 false
+pc.lookup:
+  %pc.aid = extractvalue %Value %pc.a1, 1
+  %pc.str = call i8* @wam_atom_to_string(i64 %pc.aid)
+  %pc.null = icmp eq i8* %pc.str, null
+  br i1 %pc.null, label %pc.fail, label %pc.check
+pc.check:
+  ; First byte must be non-null and second byte must be null (single-
+  ; char atom).
+  %pc.b0 = load i8, i8* %pc.str
+  %pc.b0_zero = icmp eq i8 %pc.b0, 0
+  br i1 %pc.b0_zero, label %pc.fail, label %pc.check2
+pc.check2:
+  %pc.b1_ptr = getelementptr i8, i8* %pc.str, i32 1
+  %pc.b1 = load i8, i8* %pc.b1_ptr
+  %pc.b1_zero = icmp eq i8 %pc.b1, 0
+  br i1 %pc.b1_zero, label %pc.write, label %pc.fail
+pc.write:
+  %pc.b0_32 = zext i8 %pc.b0 to i32
+  call i32 @putchar(i32 %pc.b0_32)
+  ret i1 true
+
+builtin_put_code:
+  ; M66: put_code(+Code) -- Code is an Integer in [0, 255]. Writes the
+  ; byte directly to stdout.
+  %pco.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %pco.t1 = extractvalue %Value %pco.a1, 0
+  %pco.is_int = icmp eq i32 %pco.t1, 1
+  br i1 %pco.is_int, label %pco.range, label %pco.fail
+pco.fail:
+  ret i1 false
+pco.range:
+  %pco.n = extractvalue %Value %pco.a1, 1
+  %pco.lo = icmp slt i64 %pco.n, 0
+  %pco.hi = icmp sgt i64 %pco.n, 255
+  %pco.bad = or i1 %pco.lo, %pco.hi
+  br i1 %pco.bad, label %pco.fail, label %pco.write
+pco.write:
+  %pco.n32 = trunc i64 %pco.n to i32
+  call i32 @putchar(i32 %pco.n32)
+  ret i1 true
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -10548,6 +10627,9 @@ builtin_op_to_id('display/1', 78).            % alias of write/1 (operator-free 
 builtin_op_to_id('writeln/1', 79).            % write/1 + nl/0 combined
 builtin_op_to_id('keysort/2', 80).            % stable sort of K-V pairs by Key
 builtin_op_to_id('sort/2', 81).               % sort + dedup under standard term order
+builtin_op_to_id('tab/1', 82).                % I/O: print N spaces.
+builtin_op_to_id('put_char/1', 83).           % I/O: print first byte of single-char atom.
+builtin_op_to_id('put_code/1', 84).           % I/O: print byte value as char.
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2452,29 +2452,6 @@ test_cmp_lists_diff(_, R) :-
     char_code(O, C),
     R is C.   % '<'
 
-% M66 investigation: scope of literal-list emit bug. Pure Prolog
-% reports length 3 for [foo(1), foo(2), foo(3)] but LLVM emits a
-% list whose length walk returns 16. Suite below maps which list
-% shapes are affected.
-
-:- dynamic test_lit_3_ints/2.
-test_lit_3_ints(_, R) :- L = [1, 2, 3], length(L, R).   % 3
-
-:- dynamic test_lit_3_atoms/2.
-test_lit_3_atoms(_, R) :- L = [a, b, c], length(L, R).   % 3
-
-:- dynamic test_lit_3_compounds_arity1/2.
-test_lit_3_compounds_arity1(_, R) :- L = [foo(1), foo(2), foo(3)], length(L, R).   % 3
-
-:- dynamic test_lit_singleton_compound/2.
-test_lit_singleton_compound(_, R) :- L = [foo(1)], length(L, R).   % 1
-
-:- dynamic test_lit_2_compounds/2.
-test_lit_2_compounds(_, R) :- L = [foo(1), foo(2)], length(L, R).   % 2
-
-:- dynamic test_lit_pair_int/2.
-test_lit_pair_int(_, R) :- L = [a-1, b-2, c-3], length(L, R).   % 3
-
 % M65: keysort/2 + sort/2 migrated to @wam_term_cmp.
 % Compound key / element behavioral tests deferred -- there''s a
 % pre-existing emit bug where literal lists of compound terms in
@@ -3939,19 +3916,6 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
-       format('--- M66 literal-list-of-X length probes ---~n'),
-       run_test_r0('[1,2,3] length -> 3',
-                   test_lit_3_ints, 0, 3),
-       run_test_r0('[a,b,c] length -> 3',
-                   test_lit_3_atoms, 0, 3),
-       run_test_r0('[foo(1)] length -> 1',
-                   test_lit_singleton_compound, 0, 1),
-       run_test_r0('[foo(1), foo(2)] length -> 2',
-                   test_lit_2_compounds, 0, 2),
-       run_test_r0('[foo(1), foo(2), foo(3)] length -> 3',
-                   test_lit_3_compounds_arity1, 0, 3),
-       run_test_r0('[a-1, b-2, c-3] length -> 3',
-                   test_lit_pair_int, 0, 3),
        format('--- M64 compare/3 Compound terms (recursive via helper) ---~n'),
        run_test_r0('compare(O, foo(1,2), foo(1,2)) -> 61 (=)',
                    test_cmp_compound_eq, 0, 61),

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2452,6 +2452,29 @@ test_cmp_lists_diff(_, R) :-
     char_code(O, C),
     R is C.   % '<'
 
+% M66 investigation: scope of literal-list emit bug. Pure Prolog
+% reports length 3 for [foo(1), foo(2), foo(3)] but LLVM emits a
+% list whose length walk returns 16. Suite below maps which list
+% shapes are affected.
+
+:- dynamic test_lit_3_ints/2.
+test_lit_3_ints(_, R) :- L = [1, 2, 3], length(L, R).   % 3
+
+:- dynamic test_lit_3_atoms/2.
+test_lit_3_atoms(_, R) :- L = [a, b, c], length(L, R).   % 3
+
+:- dynamic test_lit_3_compounds_arity1/2.
+test_lit_3_compounds_arity1(_, R) :- L = [foo(1), foo(2), foo(3)], length(L, R).   % 3
+
+:- dynamic test_lit_singleton_compound/2.
+test_lit_singleton_compound(_, R) :- L = [foo(1)], length(L, R).   % 1
+
+:- dynamic test_lit_2_compounds/2.
+test_lit_2_compounds(_, R) :- L = [foo(1), foo(2)], length(L, R).   % 2
+
+:- dynamic test_lit_pair_int/2.
+test_lit_pair_int(_, R) :- L = [a-1, b-2, c-3], length(L, R).   % 3
+
 % M65: keysort/2 + sort/2 migrated to @wam_term_cmp.
 % Compound key / element behavioral tests deferred -- there''s a
 % pre-existing emit bug where literal lists of compound terms in
@@ -3916,6 +3939,19 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M66 literal-list-of-X length probes ---~n'),
+       run_test_r0('[1,2,3] length -> 3',
+                   test_lit_3_ints, 0, 3),
+       run_test_r0('[a,b,c] length -> 3',
+                   test_lit_3_atoms, 0, 3),
+       run_test_r0('[foo(1)] length -> 1',
+                   test_lit_singleton_compound, 0, 1),
+       run_test_r0('[foo(1), foo(2)] length -> 2',
+                   test_lit_2_compounds, 0, 2),
+       run_test_r0('[foo(1), foo(2), foo(3)] length -> 3',
+                   test_lit_3_compounds_arity1, 0, 3),
+       run_test_r0('[a-1, b-2, c-3] length -> 3',
+                   test_lit_pair_int, 0, 3),
        format('--- M64 compare/3 Compound terms (recursive via helper) ---~n'),
        run_test_r0('compare(O, foo(1,2), foo(1,2)) -> 61 (=)',
                    test_cmp_compound_eq, 0, 61),

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2452,6 +2452,44 @@ test_cmp_lists_diff(_, R) :-
     char_code(O, C),
     R is C.   % '<'
 
+% M66: tab/1, put_char/1, put_code/1 -- small I/O builtins.
+
+:- dynamic test_tab_3/2.
+test_tab_3(_, R) :- ( tab(3) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_tab_zero/2.
+test_tab_zero(_, R) :- ( tab(0) -> R is 1 ; R is 0 ).   % 1 (no output, succeeds)
+
+:- dynamic test_tab_neg/2.
+test_tab_neg(_, R) :- ( tab(-1) -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_tab_not_int/2.
+test_tab_not_int(_, R) :- ( tab(hello) -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_put_char_basic/2.
+test_put_char_basic(_, R) :- ( put_char(a) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_put_char_digit/2.
+test_put_char_digit(_, R) :- ( put_char('5') -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_put_char_multi/2.
+test_put_char_multi(_, R) :- ( put_char(abc) -> R is 1 ; R is 0 ).   % 0 (not single-char)
+
+:- dynamic test_put_char_int/2.
+test_put_char_int(_, R) :- ( put_char(7) -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_put_code_basic/2.
+test_put_code_basic(_, R) :- ( put_code(65) -> R is 1 ; R is 0 ).   % 1 (prints 'A')
+
+:- dynamic test_put_code_low/2.
+test_put_code_low(_, R) :- ( put_code(10) -> R is 1 ; R is 0 ).   % 1 (newline)
+
+:- dynamic test_put_code_neg/2.
+test_put_code_neg(_, R) :- ( put_code(-1) -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_put_code_oob/2.
+test_put_code_oob(_, R) :- ( put_code(300) -> R is 1 ; R is 0 ).   % 0
+
 % M65: keysort/2 + sort/2 migrated to @wam_term_cmp.
 % Compound key / element behavioral tests deferred -- there''s a
 % pre-existing emit bug where literal lists of compound terms in
@@ -3916,6 +3954,31 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M66 tab/1 + put_char/1 + put_code/1 ---~n'),
+       run_test_r0('tab(3) -> 1',
+                   test_tab_3, 0, 1),
+       run_test_r0('tab(0) -> 1',
+                   test_tab_zero, 0, 1),
+       run_test_r0('tab(-1) -> 0',
+                   test_tab_neg, 0, 0),
+       run_test_r0('tab(hello) -> 0',
+                   test_tab_not_int, 0, 0),
+       run_test_r0('put_char(a) -> 1',
+                   test_put_char_basic, 0, 1),
+       run_test_r0('put_char(\'5\') -> 1',
+                   test_put_char_digit, 0, 1),
+       run_test_r0('put_char(abc) -> 0',
+                   test_put_char_multi, 0, 0),
+       run_test_r0('put_char(7) -> 0',
+                   test_put_char_int, 0, 0),
+       run_test_r0('put_code(65) -> 1',
+                   test_put_code_basic, 0, 1),
+       run_test_r0('put_code(10) -> 1',
+                   test_put_code_low, 0, 1),
+       run_test_r0('put_code(-1) -> 0',
+                   test_put_code_neg, 0, 0),
+       run_test_r0('put_code(300) -> 0',
+                   test_put_code_oob, 0, 0),
        format('--- M64 compare/3 Compound terms (recursive via helper) ---~n'),
        run_test_r0('compare(O, foo(1,2), foo(1,2)) -> 61 (=)',
                    test_cmp_compound_eq, 0, 61),


### PR DESCRIPTION
## Summary

Three small I/O builtins that round out the basic output set:

### tab/1
Write N spaces. N must be a non-negative Integer; negative or
non-integer N fails. Inner loop calls `@putchar(32)` N times.

### put_char/1
Char is a single-char atom; writes its first byte. Multi-byte atoms
or non-atoms fail. Length check inlined (load byte 0, ensure non-
null; load byte 1, ensure null).

### put_code/1
Code is an Integer in `[0, 255]`. Writes the byte directly via
`@putchar`. Out-of-range or non-integer fails.

### Dispatch
- `builtin_op_to_id('tab/1', 82)` → `%builtin_tab`.
- `builtin_op_to_id('put_char/1', 83)` → `%builtin_put_char`.
- `builtin_op_to_id('put_code/1', 84)` → `%builtin_put_code`.
- All three already in `is_builtin_pred` registry.
- Prefixes `tab.` / `pc.` / `pco.` — all unique.

## Test plan
- [x] 12 new tests:
  - `tab`: 3 spaces, 0 spaces, -1 (fail), non-int (fail)
  - `put_char`: lowercase letter, digit char; multi-char atom (fail),
    integer arg (fail)
  - `put_code`: 65 (`'A'`), 10 (newline); negative (fail), >255 (fail)
- [x] All 440 builtin tests pass (was 428, +12)
- [x] Manual llc round-trip clean


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_