### PR TITLE
LLVM WAM: restore M65 compound tests + literal-list verification (M67)

### DIFF
--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2452,6 +2452,17 @@ test_cmp_lists_diff(_, R) :-
     char_code(O, C),
     R is C.   % '<'
 
+% M67 verification: literal-list tests with proper R-is-N pattern.
+
+:- dynamic test_lit_3_ints/2.
+test_lit_3_ints(_, R) :- L = [1, 2, 3], length(L, N), R is N.   % 3
+
+:- dynamic test_lit_3_compounds_arity1/2.
+test_lit_3_compounds_arity1(_, R) :- L = [foo(1), foo(2), foo(3)], length(L, N), R is N.   % 3
+
+:- dynamic test_lit_pair_int/2.
+test_lit_pair_int(_, R) :- L = [a-1, b-2, c-3], length(L, N), R is N.   % 3
+
 % M66: tab/1, put_char/1, put_code/1 -- small I/O builtins.
 
 :- dynamic test_tab_3/2.
@@ -3955,6 +3966,12 @@ test_all :-
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
        format('--- M66 tab/1 + put_char/1 + put_code/1 ---~n'),
+       run_test_r0('[1,2,3] length via R is N -> 3',
+                   test_lit_3_ints, 0, 3),
+       run_test_r0('[foo(1), foo(2), foo(3)] length via R is N -> 3',
+                   test_lit_3_compounds_arity1, 0, 3),
+       run_test_r0('[a-1, b-2, c-3] length via R is N -> 3',
+                   test_lit_pair_int, 0, 3),
        run_test_r0('tab(3) -> 1',
                    test_tab_3, 0, 1),
        run_test_r0('tab(0) -> 1',

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2474,7 +2474,7 @@ test_ks_compound_keys_length(_, R) :-
 :- dynamic test_ks_compound_keys_first/2.
 test_ks_compound_keys_first(_, R) :-
     keysort([foo(3)-c, foo(1)-a, foo(2)-b], [_-V|_]),
-    char_code(V, R).   % 97 ('a')
+    char_code(V, C), R is C.   % 97 ('a')
 
 :- dynamic test_sort_compound_elements/2.
 test_sort_compound_elements(_, R) :-

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2463,6 +2463,34 @@ test_lit_3_compounds_arity1(_, R) :- L = [foo(1), foo(2), foo(3)], length(L, N),
 :- dynamic test_lit_pair_int/2.
 test_lit_pair_int(_, R) :- L = [a-1, b-2, c-3], length(L, N), R is N.   % 3
 
+% M67: re-add the deferred M65 compound-key/element tests now that
+% we know the test framework reads R via reg 0 (force via R is N).
+
+:- dynamic test_ks_compound_keys_length/2.
+test_ks_compound_keys_length(_, R) :-
+    keysort([foo(3)-c, foo(1)-a, foo(2)-b], L),
+    length(L, N), R is N.   % 3
+
+:- dynamic test_ks_compound_keys_first/2.
+test_ks_compound_keys_first(_, R) :-
+    keysort([foo(3)-c, foo(1)-a, foo(2)-b], [_-V|_]),
+    char_code(V, R).   % 97 ('a')
+
+:- dynamic test_sort_compound_elements/2.
+test_sort_compound_elements(_, R) :-
+    sort([foo(3), foo(1), foo(2)], [F|_]),
+    F = foo(N), R is N.   % 1
+
+:- dynamic test_sort_compound_dedup/2.
+test_sort_compound_dedup(_, R) :-
+    sort([foo(2), foo(1), foo(3), foo(1)], L),
+    length(L, N), R is N.   % 3
+
+:- dynamic test_sort_lists/2.
+test_sort_lists(_, R) :-
+    sort([[3, 4], [1, 2], [2, 3]], [F|_]),
+    F = [H|_], R is H.   % 1
+
 % M66: tab/1, put_char/1, put_code/1 -- small I/O builtins.
 
 :- dynamic test_tab_3/2.
@@ -3972,6 +4000,16 @@ test_all :-
                    test_lit_3_compounds_arity1, 0, 3),
        run_test_r0('[a-1, b-2, c-3] length via R is N -> 3',
                    test_lit_pair_int, 0, 3),
+       run_test_r0('keysort compound keys length -> 3',
+                   test_ks_compound_keys_length, 0, 3),
+       run_test_r0('keysort compound keys first value -> 97',
+                   test_ks_compound_keys_first, 0, 97),
+       run_test_r0('sort compound elements first arg -> 1',
+                   test_sort_compound_elements, 0, 1),
+       run_test_r0('sort compound dedup length -> 3',
+                   test_sort_compound_dedup, 0, 3),
+       run_test_r0('sort lists first sublist first elem -> 1',
+                   test_sort_lists, 0, 1),
        run_test_r0('tab(3) -> 1',
                    test_tab_3, 0, 1),
        run_test_r0('tab(0) -> 1',


### PR DESCRIPTION
## Summary

Resolves the M65 "literal-list emit bug" mystery: there's no emit
bug. `run_test_r0`'s driver reads the test result from register 0,
and the test framework relies on the conventional `R is N` arithmetic
pattern to coerce the final value into A0 via is/2. Tests that wrote
`length(L, R)` directly left R in A1, and the driver read L (the
list compound) from A0, truncated its pointer payload to i32, and got
junk (`16` was the truncated `arena_offset` value).

### Added
1. Three literal-list length probes confirming `[1,2,3]`,
   `[foo(1), foo(2), foo(3)]`, and `[a-1, b-2, c-3]` all give length
   3 when written with the proper `length(L, N), R is N` pattern.
2. Five restored M65 compound-key/element tests:
   - `keysort` compound keys length + first-value
   - `sort` compound elements + dedup
   - `sort` lists-as-compounds first sublist

### Lessons
- Builtins that bind their result in A2 (`length`, `char_code`,
  `nth0/3`, etc.) require an explicit `R is X` step to route the
  value to A0 where `run_test_r0` reads it.
- The convention has been there since the start (visible in
  `test_ks_int_keys_length` and many others); the deferred M65 tests
  simply used the wrong shape.

## Test plan
- [x] 8 new tests, all pass
- [x] All 448 builtin tests pass (was 440, +8)
- [x] Manual llc round-trip clean

### Follow-up commit
First version of `test_ks_compound_keys_first` used
`char_code(V, R)` directly (binds R = code in A2). Fixed to
`char_code(V, C), R is C` for proper A0 routing.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_