### PR TITLE
test(wam-clojure): cover compare output unification

### DIFF
--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -53,6 +53,12 @@
 :- dynamic user:wam_compare_lt/0.
 :- dynamic user:wam_compare_eq/0.
 :- dynamic user:wam_compare_gt/0.
+:- dynamic user:wam_compare_lt_unify/0.
+:- dynamic user:wam_compare_lt_unify_mismatch/0.
+:- dynamic user:wam_compare_eq_unify/0.
+:- dynamic user:wam_compare_eq_unify_mismatch/0.
+:- dynamic user:wam_compare_gt_unify/0.
+:- dynamic user:wam_compare_gt_unify_mismatch/0.
 :- dynamic user:wam_compare_atom_number/0.
 :- dynamic user:wam_compare_output_guard/1.
 :- dynamic user:wam_compare_does_not_bind/0.
@@ -343,6 +349,12 @@ user:wam_term_order_does_not_bind :- user:wam_unbound_arg(X), X @< a, X == a.
 user:wam_compare_lt :- compare(Order, a, b), Order == '<'.
 user:wam_compare_eq :- compare(Order, f(a), f(a)), Order == '='.
 user:wam_compare_gt :- compare(Order, b, a), Order == '>'.
+user:wam_compare_lt_unify :- compare(Order, a, b), Order = '<'.
+user:wam_compare_lt_unify_mismatch :- compare(Order, a, b), Order = '>'.
+user:wam_compare_eq_unify :- compare(Order, f(a), f(a)), Order = '='.
+user:wam_compare_eq_unify_mismatch :- compare(Order, f(a), f(a)), Order = '<'.
+user:wam_compare_gt_unify :- compare(Order, b, a), Order = '>'.
+user:wam_compare_gt_unify_mismatch :- compare(Order, b, a), Order = '<'.
 user:wam_compare_atom_number :- compare(Order, 42, a), Order == '<'.
 user:wam_compare_output_guard(Order) :- compare(Order, a, b).
 user:wam_compare_does_not_bind :- user:wam_unbound_arg(X), compare('<', X, a), X == a.
@@ -638,6 +650,12 @@ run_smoke :-
           user:wam_compare_lt/0,
           user:wam_compare_eq/0,
           user:wam_compare_gt/0,
+          user:wam_compare_lt_unify/0,
+          user:wam_compare_lt_unify_mismatch/0,
+          user:wam_compare_eq_unify/0,
+          user:wam_compare_eq_unify_mismatch/0,
+          user:wam_compare_gt_unify/0,
+          user:wam_compare_gt_unify_mismatch/0,
           user:wam_compare_atom_number/0,
           user:wam_compare_output_guard/1,
           user:wam_compare_does_not_bind/0,
@@ -1010,6 +1028,12 @@ smoke_cases([
     case('wam_compare_lt/0', no_args, "true"),
     case('wam_compare_eq/0', no_args, "true"),
     case('wam_compare_gt/0', no_args, "true"),
+    case('wam_compare_lt_unify/0', no_args, "true"),
+    case('wam_compare_lt_unify_mismatch/0', no_args, "false"),
+    case('wam_compare_eq_unify/0', no_args, "true"),
+    case('wam_compare_eq_unify_mismatch/0', no_args, "false"),
+    case('wam_compare_gt_unify/0', no_args, "true"),
+    case('wam_compare_gt_unify_mismatch/0', no_args, "false"),
     case('wam_compare_atom_number/0', no_args, "true"),
     case('wam_compare_output_guard/1', '<', "true"),
     case('wam_compare_output_guard/1', '=', "false"),


### PR DESCRIPTION
## Summary

- Add Clojure WAM smoke coverage for direct unification of produced `compare/3` outputs.
- Cover success and mismatch cases for all comparison result atoms: `<`, `=`, and `>`.
- Keep this as a coverage-only change because the runtime already materializes `compare/3` outputs as interned atom terms.

## Why

The recent Clojure WAM representation-hardening work has focused on generated outputs that are later unified with lowered literals. `compare/3` already used the correct interned atom representation, but the smoke suite only checked identity-style comparisons and an external output guard.

These tests lock down plain lowered unification behavior for all three `compare/3` result atoms and protect the runtime path from regressions.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
