### PR TITLE
feat(wam-lua): use shared items ir policy

### DIFF
--- a/docs/design/WAM_REPRESENTATION_MODES.md
+++ b/docs/design/WAM_REPRESENTATION_MODES.md
@@ -38,8 +38,15 @@ conservative:
 
 - Python interpreter mode: `wam_items_bridge`
 - Python lowered mode: `wam_text`
-- Lua/R interpreter mode: `wam_items_bridge` as the intended migration default
+- Lua interpreter mode: `wam_items_bridge`
+- Lua lowered/functions mode: `wam_text`
+- R interpreter mode: `wam_items_bridge` as the intended migration default
 - Unknown WAM targets: `wam_text`
 
 WAM-specific targets may reject `direct_target`; callers should use the ordinary
 non-WAM target when they want direct target-native code.
+
+Lua follows the same partial migration shape as Python: interpreter-mode
+generated predicates consume common WAM items through the bridge, while lowered
+Lua emission keeps the text path because its lowerability analysis still works
+over tokenized WAM text.

--- a/src/unifyweaver/targets/wam_ir_mode.pl
+++ b/src/unifyweaver/targets/wam_ir_mode.pl
@@ -55,10 +55,10 @@ wam_ir_mode_uses_wam(wam_items_native).
 wam_ir_mode_skips_text(wam_items_native).
 wam_ir_mode_skips_text(direct_target).
 
-% Conservative current defaults. Interpreter-mode Python already consumes the
-% common items bridge; lowered Python still needs WAM text for its analyzer and
-% lowered emitter. Lua/R are marked as likely bridge consumers for their
-% interpreter paths, but their target code has not been migrated yet.
+% Conservative current defaults. Interpreter-mode Python and Lua already
+% consume the common items bridge; their lowered paths still need WAM text for
+% analyzers and lowered emitters. R is marked as a likely bridge consumer for
+% its interpreter path, but its target code has not been migrated yet.
 wam_ir_mode_default(wam_python, interpreter, wam_items_bridge) :- !.
 wam_ir_mode_default(wam_python, lowered, wam_text) :- !.
 wam_ir_mode_default(wam_python, functions, wam_text) :- !.

--- a/src/unifyweaver/targets/wam_lua_target.pl
+++ b/src/unifyweaver/targets/wam_lua_target.pl
@@ -27,8 +27,12 @@
 :- use_module(library(lists)).
 :- use_module(library(option)).
 :- use_module(library(filesex), [make_directory_path/1, directory_file_path/3]).
-:- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../targets/wam_target', [
+    compile_predicate_to_wam_text/3,
+    compile_predicate_to_wam_items/3
+]).
 :- use_module('../core/template_system', [render_template/3]).
+:- use_module(wam_ir_mode, [wam_ir_mode/4]).
 :- use_module(wam_text_parser, [
     wam_tokenize_line/2,
     wam_recognise_label/2,
@@ -60,6 +64,17 @@ validate_emit_mode(mixed(L), mixed(L)) :- is_list(L), !.
 validate_emit_mode(Other, _) :-
     throw(error(domain_error(wam_lua_emit_mode, Other),
                 wam_lua_resolve_emit_mode/2)).
+
+wam_lua_emit_ir_mode(Options, EmitMode, IrMode) :-
+    wam_ir_mode(wam_lua, EmitMode, Options, IrMode),
+    (   IrMode == direct_target
+    ->  throw(error(domain_error(wam_lua_ir_mode, direct_target),
+                    wam_lua_emit_ir_mode/3))
+    ;   IrMode == wam_items_native
+    ->  throw(error(existence_error(wam_ir_mode, wam_items_native),
+                    wam_lua_emit_ir_mode/3))
+    ;   true
+    ).
 
 should_try_lower(functions, _, _) :- !.
 should_try_lower(mixed(HotPreds), P, A) :-
@@ -427,8 +442,9 @@ compile_predicates_for_project(Predicates, Options,
     forall(member(A, ExtraAtoms), (atom_string(A, S), intern_lua_atom(S, _))),
     option(foreign_predicates(ForeignPredicates), Options, []),
     append_missing_foreign_predicates(Predicates, ForeignPredicates, CompilePreds),
-    wam_lua_resolve_emit_mode(Options, Mode),
-    compile_all_predicates(CompilePreds, Options, Mode, 1,
+    wam_lua_resolve_emit_mode(Options, EmitMode),
+    wam_lua_emit_ir_mode(Options, EmitMode, IrMode),
+    compile_all_predicates(CompilePreds, Options, EmitMode, IrMode, 1,
         [], [], [], [], [], [], [],
         AllInstrs, TopLabels, AllLabels, Wrappers, LoweredEntries, InlineFacts, FactSources),
     atomic_list_concat(Wrappers, '\n', WrapperCode),
@@ -444,9 +460,9 @@ same_pi(P0, P1) :- pi_key(P0, K), pi_key(P1, K).
 pi_key(_:P/A, P/A) :- !.
 pi_key(P/A, P/A).
 
-compile_all_predicates([], _, _, _, Instrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts, FactSources,
+compile_all_predicates([], _, _, _, _, Instrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts, FactSources,
                        Instrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts, FactSources).
-compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
+compile_all_predicates([Pred|Rest], Options, EmitMode, IrMode, BasePC,
                        InstrAcc, TopLabelAcc, AllLabelAcc, WrapperAcc, LoweredAcc, InlineFactAcc, FactSourceAcc,
                        AllInstrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts, FactSources) :-
     (Pred = _M:P/Arity -> true ; Pred = P/Arity),
@@ -455,7 +471,7 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
         lua_string_literal(Key, KeyQ),
         format(string(FLit), 'I.CallFactStream(~w, ~w)', [KeyQ, Arity]),
         PredInstrs = [FLit, 'I.Proceed()'],
-        WamForLower = "",
+        WamCode = "",
         PredSubLabelEntries0 = [],
         InlineFactEntry = none,
         lua_fact_source_entry(Key, SourceSpec, FactSourceEntry)
@@ -463,13 +479,13 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
     ->  lua_string_literal(P, PQ),
         format(string(FLit), 'I.CallForeign(~w, ~w)', [PQ, Arity]),
         PredInstrs = [FLit, 'I.Proceed()'],
-        WamForLower = "",
+        WamCode = "",
         PredSubLabelEntries0 = [],
         InlineFactEntry = none,
         FactSourceEntry = none
-    ;   compile_predicate_to_wam(P/Arity, [], WamForLower),
+    ;   compile_lua_predicate_wam(P/Arity, IrMode, WamCode),
         (   Arity == 2,
-            lua_inline_fact_tuples(WamForLower, Tuples),
+            lua_inline_fact_tuples(WamCode, Tuples),
             Tuples \= []
         ->  format(string(Key), '~w/~w', [P, Arity]),
             lua_string_literal(Key, KeyQ),
@@ -478,7 +494,7 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
             PredSubLabelEntries0 = [],
             lua_inline_fact_entry(Key, Tuples, InlineFactEntry),
             FactSourceEntry = none
-        ;   wam_code_to_lua_data(WamForLower, Options, PredInstrs, PredSubLabelEntries0),
+        ;   wam_code_to_lua_data(WamCode, Options, PredInstrs, PredSubLabelEntries0),
             InlineFactEntry = none,
             FactSourceEntry = none
         )
@@ -498,11 +514,11 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
     format(string(MainEntry), '  [~w] = ~w', [KeyQ, BasePC]),
     NewTopLabels = [MainEntry|TopLabelAcc],
     append([MainEntry|PredSubLabelEntries], AllLabelAcc, NewAllLabels),
-    (   should_try_lower(Mode, P, Arity),
-        WamForLower \= "",
+    (   should_try_lower(EmitMode, P, Arity),
+        WamCode \= "",
         InlineFactEntry == none,
-        catch(wam_lua_lowerable(Pred, WamForLower, _), _, fail),
-        catch(lower_predicate_to_lua(Pred, WamForLower, [],
+        catch(wam_lua_lowerable(Pred, WamCode, _), _, fail),
+        catch(lower_predicate_to_lua(Pred, WamCode, [],
                                      lowered(_, FuncName, LoweredLua)), _, fail)
     ->  NewLoweredAcc = [LoweredLua|LoweredAcc],
         emit_lua_lowered_wrapper(P, Arity, FuncName, Wrapper)
@@ -511,9 +527,14 @@ compile_all_predicates([Pred|Rest], Options, Mode, BasePC,
     ),
     (InlineFactEntry == none -> NewInlineFactAcc = InlineFactAcc ; NewInlineFactAcc = [InlineFactEntry|InlineFactAcc]),
     (FactSourceEntry == none -> NewFactSourceAcc = FactSourceAcc ; NewFactSourceAcc = [FactSourceEntry|FactSourceAcc]),
-    compile_all_predicates(Rest, Options, Mode, NewPC,
+    compile_all_predicates(Rest, Options, EmitMode, IrMode, NewPC,
         NewInstrs, NewTopLabels, NewAllLabels, [Wrapper|WrapperAcc], NewLoweredAcc, NewInlineFactAcc, NewFactSourceAcc,
         AllInstrs, TopLabels, AllLabels, Wrappers, Lowered, InlineFacts, FactSources).
+
+compile_lua_predicate_wam(PredIndicator, wam_text, WamCode) :-
+    compile_predicate_to_wam_text(PredIndicator, [], WamCode).
+compile_lua_predicate_wam(PredIndicator, wam_items_bridge, WamCode) :-
+    compile_predicate_to_wam_items(PredIndicator, [], WamCode).
 
 lua_fact_source_spec(P, Arity, Options, Spec) :-
     Arity =:= 2,

--- a/src/unifyweaver/targets/wam_text_parser.pl
+++ b/src/unifyweaver/targets/wam_text_parser.pl
@@ -227,6 +227,7 @@ wam_recognise_instruction(["allocate"],                allocate).
 wam_recognise_instruction(["deallocate"],              deallocate).
 wam_recognise_instruction(["builtin_call", Op, Ar],    builtin_call(Op, Ar)).
 wam_recognise_instruction(["call_foreign", Pred, Ar],  call_foreign(Pred, Ar)).
+wam_recognise_instruction(["arg", N, Reg, OutReg],     arg(N, Reg, OutReg)).
 wam_recognise_instruction(["try_me_else", L],          try_me_else(L)).
 wam_recognise_instruction(["retry_me_else", L],        retry_me_else(L)).
 wam_recognise_instruction(["trust_me"],                trust_me).

--- a/tests/test_wam_lua_generator.pl
+++ b/tests/test_wam_lua_generator.pl
@@ -209,6 +209,45 @@ test(shared_wam_parser_keeps_lua_extensions) :-
     assertion(Labels == ["  [\"p/0\"] = 1"]),
     assertion(Instrs == ["I.ArgInstr(1, 201, 103)", 'I.Proceed()']).
 
+test(lua_interpreter_uses_items_ir_policy) :-
+    once(source_file(wam_lua_target:write_wam_lua_project(_, _, _), Path)),
+    read_file_to_string(Path, Content, []),
+    sub_string(Content, _, _, _, "wam_lua_emit_ir_mode(Options, EmitMode, IrMode)"),
+    sub_string(Content, _, _, _, "wam_ir_mode(wam_lua, EmitMode, Options, IrMode)"),
+    sub_string(Content, _, _, _, "compile_predicate_to_wam_items(PredIndicator, [], WamCode)"),
+    sub_string(Content, _, _, _, "compile_predicate_to_wam_text(PredIndicator, [], WamCode)"),
+    !.
+
+test(lua_generated_predicate_allows_text_ir_override) :-
+    unique_lua_tmp_dir('tmp_lua_text_ir_override', TmpDir),
+    setup_call_cleanup(
+        write_wam_lua_project([user:wam_lua_fact/1], [wam_ir(wam_text)], TmpDir),
+        ( directory_file_path(TmpDir, 'lua/generated_program.lua', Program),
+          read_file_to_string(Program, Code, []),
+          assertion(sub_string(Code, _, _, _, 'I.GetConstant(V.Atom(')),
+          assertion(sub_string(Code, _, _, _, '["wam_lua_fact/1"] = 1'))
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(lua_generated_predicate_rejects_direct_target_ir,
+     [throws(error(domain_error(wam_lua_ir_mode, direct_target), _))]) :-
+    unique_lua_tmp_dir('tmp_lua_direct_ir_err', TmpDir),
+    call_cleanup(
+        write_wam_lua_project([user:wam_lua_fact/1],
+                              [wam_ir(direct_target)],
+                              TmpDir),
+        (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true)).
+
+test(lua_generated_predicate_rejects_native_items_until_available,
+     [throws(error(existence_error(wam_ir_mode, wam_items_native), _))]) :-
+    unique_lua_tmp_dir('tmp_lua_native_ir_err', TmpDir),
+    call_cleanup(
+        write_wam_lua_project([user:wam_lua_fact/1],
+                              [wam_ir(wam_items_native)],
+                              TmpDir),
+        (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true)).
+
 test(lua_parity_guard) :-
     read_file_to_string('templates/targets/lua_wam/runtime.lua.mustache', Runtime, []),
     read_file_to_string('tests/test_wam_lua_generator.pl', Tests, []),

--- a/tests/test_wam_text_parser.pl
+++ b/tests/test_wam_text_parser.pl
@@ -114,6 +114,10 @@ test(recognise_builtin_call) :-
     wam_recognise_instruction(["builtin_call", "is/2", "2"], I),
     assertion(I == builtin_call("is/2", "2")).
 
+test(recognise_arg_instruction) :-
+    wam_recognise_instruction(["arg", "1", "Y1", "X3"], I),
+    assertion(I == arg("1", "Y1", "X3")).
+
 test(recognise_numeric_and_nil_instructions) :-
     Pairs = [
         ["get_float", "3.5", "A1"]-get_float("3.5", "A1"),


### PR DESCRIPTION
## Summary
- Wire WAM-Lua project generation through `wam_ir_mode/4` so interpreter mode uses the shared `wam_items_bridge` by default.
- Keep Lua lowered/functions mode on WAM text because the lowered emitter still analyzes tokenized WAM text.
- Teach the shared WAM text parser to preserve `arg` instructions so Lua items-bridge generation does not drop term-inspection instructions.
- Add Lua IR-policy override/rejection tests and update representation-mode docs.

## Tests
- `swipl -q -g "run_tests(wam_text_parser),run_tests(wam_ir_mode),run_tests(wam_lua_generator)" -t halt tests/test_wam_text_parser.pl tests/test_wam_ir_mode.pl tests/test_wam_lua_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_target.pl`
- `swipl -q -g "run_tests(wam_python_items_mode_audit),run_tests(wam_python_builtin_e2e)" -t halt tests/test_wam_python_target.pl`
