### PR TITLE
LLVM WAM: @&lt; @=&lt; @&gt; @&gt;= standard-order operators (M69)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3482,6 +3482,10 @@ entry:
     i32 83, label %builtin_put_char
     i32 84, label %builtin_put_code
     i32 85, label %builtin_split_string
+    i32 86, label %builtin_at_lt
+    i32 87, label %builtin_at_le
+    i32 88, label %builtin_at_gt
+    i32 89, label %builtin_at_ge
   ]
 
 builtin_is:
@@ -4298,6 +4302,38 @@ ssp.b_bind:
   %ssp.b_raw4 = call %Value @wam_get_reg(%WamState* %vm, i32 3)
   %ssp.b_ok = call i1 @wam_unify_value(%WamState* %vm, %Value %ssp.b_raw4, %Value %ssp.b_acc)
   ret i1 %ssp.b_ok
+
+builtin_at_lt:
+  ; M69: @</2 -- standard term order strictly less than.
+  %atlt.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %atlt.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %atlt.r = call i32 @wam_term_cmp(%WamState* %vm, %Value %atlt.a1, %Value %atlt.a2)
+  %atlt.ok = icmp slt i32 %atlt.r, 0
+  ret i1 %atlt.ok
+
+builtin_at_le:
+  ; M69: @=</2 -- standard term order less or equal.
+  %atle.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %atle.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %atle.r = call i32 @wam_term_cmp(%WamState* %vm, %Value %atle.a1, %Value %atle.a2)
+  %atle.ok = icmp sle i32 %atle.r, 0
+  ret i1 %atle.ok
+
+builtin_at_gt:
+  ; M69: @>/2 -- standard term order strictly greater than.
+  %atgt.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %atgt.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %atgt.r = call i32 @wam_term_cmp(%WamState* %vm, %Value %atgt.a1, %Value %atgt.a2)
+  %atgt.ok = icmp sgt i32 %atgt.r, 0
+  ret i1 %atgt.ok
+
+builtin_at_ge:
+  ; M69: @>=/2 -- standard term order greater or equal.
+  %atge.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %atge.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %atge.r = call i32 @wam_term_cmp(%WamState* %vm, %Value %atge.a1, %Value %atge.a2)
+  %atge.ok = icmp sge i32 %atge.r, 0
+  ret i1 %atge.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -10865,6 +10901,10 @@ builtin_op_to_id('tab/1', 82).                % I/O: print N spaces.
 builtin_op_to_id('put_char/1', 83).           % I/O: print first byte of single-char atom.
 builtin_op_to_id('put_code/1', 84).           % I/O: print byte value as char.
 builtin_op_to_id('split_string/4', 85).       % split atom on any char from SepChars; strip pad chars from segments.
+builtin_op_to_id('@</2', 86).                 % standard order: less than.
+builtin_op_to_id('@=</2', 87).                % standard order: less or equal.
+builtin_op_to_id('@>/2', 88).                 % standard order: greater than.
+builtin_op_to_id('@>=/2', 89).                % standard order: greater or equal.
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2452,6 +2452,47 @@ test_cmp_lists_diff(_, R) :-
     char_code(O, C),
     R is C.   % '<'
 
+% M69: @</2 @=</2 @>/2 @>=/2 standard-order comparison operators.
+
+:- dynamic test_at_lt_yes/2.
+test_at_lt_yes(_, R) :- ( 1 @< 2 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_at_lt_no/2.
+test_at_lt_no(_, R) :- ( 5 @< 2 -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_at_lt_eq/2.
+test_at_lt_eq(_, R) :- ( 3 @< 3 -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_at_le_yes/2.
+test_at_le_yes(_, R) :- ( 1 @=< 2 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_at_le_eq/2.
+test_at_le_eq(_, R) :- ( 3 @=< 3 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_at_le_no/2.
+test_at_le_no(_, R) :- ( 5 @=< 2 -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_at_gt_yes/2.
+test_at_gt_yes(_, R) :- ( 5 @> 2 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_at_gt_no/2.
+test_at_gt_no(_, R) :- ( 1 @> 2 -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_at_ge_yes/2.
+test_at_ge_yes(_, R) :- ( 5 @>= 2 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_at_ge_eq/2.
+test_at_ge_eq(_, R) :- ( 3 @>= 3 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_at_atom/2.
+test_at_atom(_, R) :- ( apple @< banana -> R is 1 ; R is 0 ).   % 1 (alpha order)
+
+:- dynamic test_at_cross_cat/2.
+test_at_cross_cat(_, R) :- ( 42 @< foo -> R is 1 ; R is 0 ).   % 1 (numbers < atoms)
+
+:- dynamic test_at_compound/2.
+test_at_compound(_, R) :- ( foo(1) @< foo(2) -> R is 1 ; R is 0 ).   % 1
+
 % M68: split_string/4 -- per-char separators + pad-strip on segments.
 
 :- dynamic test_ss_simple/2.
@@ -4045,6 +4086,33 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M69 standard-order comparison operators ---~n'),
+       run_test_r0('1 @< 2 -> 1',
+                   test_at_lt_yes, 0, 1),
+       run_test_r0('5 @< 2 -> 0',
+                   test_at_lt_no, 0, 0),
+       run_test_r0('3 @< 3 -> 0',
+                   test_at_lt_eq, 0, 0),
+       run_test_r0('1 @=< 2 -> 1',
+                   test_at_le_yes, 0, 1),
+       run_test_r0('3 @=< 3 -> 1',
+                   test_at_le_eq, 0, 1),
+       run_test_r0('5 @=< 2 -> 0',
+                   test_at_le_no, 0, 0),
+       run_test_r0('5 @> 2 -> 1',
+                   test_at_gt_yes, 0, 1),
+       run_test_r0('1 @> 2 -> 0',
+                   test_at_gt_no, 0, 0),
+       run_test_r0('5 @>= 2 -> 1',
+                   test_at_ge_yes, 0, 1),
+       run_test_r0('3 @>= 3 -> 1',
+                   test_at_ge_eq, 0, 1),
+       run_test_r0('apple @< banana -> 1',
+                   test_at_atom, 0, 1),
+       run_test_r0('42 @< foo cross-cat -> 1',
+                   test_at_cross_cat, 0, 1),
+       run_test_r0('foo(1) @< foo(2) -> 1',
+                   test_at_compound, 0, 1),
        format('--- M68 split_string/4 ---~n'),
        run_test_r0('split_string(\'a,b,c\', \',\', \'\') length -> 3',
                    test_ss_simple, 0, 3),


### PR DESCRIPTION
## Summary

Adds the four binary comparison operators for the standard term
order. Each is a 3-line block delegating to the M64 `@wam_term_cmp`
helper and checking the sign of the returned `i32` (-1, 0, +1):

- `@<` : `icmp slt %r, 0`
- `@=<`: `icmp sle %r, 0`
- `@>` : `icmp sgt %r, 0`
- `@>=`: `icmp sge %r, 0`

Result is the i1 returned by the builtin (true on the comparison
holding, false otherwise). All four supported categories from
`@wam_term_cmp` — Integer, Float, Atom, Compound (with recursion
through args) — work uniformly here.

### Dispatch
- `builtin_op_to_id('@</2', 86)` → `%builtin_at_lt`
- `builtin_op_to_id('@=</2', 87)` → `%builtin_at_le`
- `builtin_op_to_id('@>/2', 88)` → `%builtin_at_gt`
- `builtin_op_to_id('@>=/2', 89)` → `%builtin_at_ge`
- All four already in `is_builtin_pred` registry.
- Prefixes `atlt.` / `atle.` / `atgt.` / `atge.`.

## Test plan
- [x] 13 new tests:
  - `@<` : true / false / equal-is-false
  - `@=<`: true / equal / false
  - `@>` : true / false
  - `@>=`: true / equal
  - atom alpha order (`apple @< banana`)
  - cross-category (`42 @< foo`, numbers come first)
  - compound (`foo(1) @< foo(2)` via recursive arg compare)
- [x] All 470 builtin tests pass (was 457, +13)
- [x] Manual llc round-trip clean


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_