### PR TITLE
LLVM WAM: msort/2 + setof migrated to @wam_term_cmp (M70)

### DIFF
--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -1394,7 +1394,7 @@ store:
 ; cons-cell list from the accumulator entries. Both return the same
 ; shape — bag/findall preserves order/duplicates, set goes through a
 ; downstream sort/dedup pass that doesn't change the per-entry shape.
-define %Value @wam_apply_aggregation(i32 %agg_type, %Value* %accum, i32 %count) {
+define %Value @wam_apply_aggregation(%WamState* %vm, i32 %agg_type, %Value* %accum, i32 %count) {
 entry:
   switch i32 %agg_type, label %default_case [
     i32 0, label %sum_case
@@ -1631,13 +1631,11 @@ set_sort_inner:
 set_si_cmp:
   %set_si_left_ptr = getelementptr %Value, %Value* %accum, i32 %set_si_j_dec
   %set_si_left = load %Value, %Value* %set_si_left_ptr
-  %set_si_left_tag = extractvalue %Value %set_si_left, 0
-  %set_si_left_pay = extractvalue %Value %set_si_left, 1
-  %set_tag_gt = icmp sgt i32 %set_si_left_tag, %set_so_key_tag
-  %set_tag_eq = icmp eq i32 %set_si_left_tag, %set_so_key_tag
-  %set_pay_gt = icmp sgt i64 %set_si_left_pay, %set_so_key_pay
-  %set_pay_gt_eq = and i1 %set_tag_eq, %set_pay_gt
-  %set_should_shift = or i1 %set_tag_gt, %set_pay_gt_eq
+  ; M70: delegate to @wam_term_cmp (same migration as the plain msort
+  ; loop above). Same behaviour on integer-only setof; correct
+  ; standard order on atoms / compounds.
+  %set_si_cmp_r = call i32 @wam_term_cmp(%WamState* %vm, %Value %set_si_left, %Value %set_so_key)
+  %set_should_shift = icmp sgt i32 %set_si_cmp_r, 0
   br i1 %set_should_shift, label %set_si_shift, label %set_si_done
 set_si_shift:
   %set_si_dst_ptr = getelementptr %Value, %Value* %accum, i32 %set_si_j
@@ -2189,16 +2187,13 @@ sort_inner:
 si_cmp:
   %si_left_ptr = getelementptr %Value, %Value* %buf, i32 %si_j_dec
   %si_left = load %Value, %Value* %si_left_ptr
-  %si_left_tag = extractvalue %Value %si_left, 0
-  %si_left_pay = extractvalue %Value %si_left, 1
-  ; Compare by (tag, payload). If left_tag > key_tag, shift; if equal,
-  ; compare payloads (signed for ints/etc, raw for pointers -- both
-  ; fine for "consistent ordering").
-  %tag_gt = icmp sgt i32 %si_left_tag, %so_key_tag
-  %tag_eq = icmp eq i32 %si_left_tag, %so_key_tag
-  %pay_gt = icmp sgt i64 %si_left_pay, %so_key_pay
-  %pay_gt_when_eq = and i1 %tag_eq, %pay_gt
-  %should_shift = or i1 %tag_gt, %pay_gt_when_eq
+  ; M70: delegate to @wam_term_cmp -- proper standard term order
+  ; (alphabetic atoms, recursive compound, etc.) replaces the old
+  ; (tag, payload) ordering. Behaviour unchanged for integer-only
+  ; lists (which is what every existing msort test uses) and now
+  ; correct for atoms / floats / compounds.
+  %si_cmp_r = call i32 @wam_term_cmp(%WamState* %vm, %Value %si_left, %Value %so_key)
+  %should_shift = icmp sgt i32 %si_cmp_r, 0
   br i1 %should_shift, label %si_shift, label %si_done
 si_shift:
   %si_dst_ptr = getelementptr %Value, %Value* %buf, i32 %si_j
@@ -4313,7 +4308,7 @@ do_finalize:
   %accum_ptr = load %Value*, %Value** %accum_ptr_ptr
   %count_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 21
   %count = load i32, i32* %count_ptr
-  %result = call %Value @wam_apply_aggregation(i32 %agg_type, %Value* %accum_ptr, i32 %count)
+  %result = call %Value @wam_apply_aggregation(%WamState* %vm, i32 %agg_type, %Value* %accum_ptr, i32 %count)
 
   ; Restore trail (unwind to CP's mark)
   %tm_ptr = getelementptr %ChoicePoint, %ChoicePoint* %top, i32 0, i32 2

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2452,6 +2452,35 @@ test_cmp_lists_diff(_, R) :-
     char_code(O, C),
     R is C.   % '<'
 
+% M70: msort/2 + aggregate_all(set, ...) migrated to @wam_term_cmp.
+% Integer-only sorting unchanged; atom sorting now alphabetical (was
+% previously by intern atom_id which is allocation order).
+
+:- dynamic test_msort_atoms_alpha/2.
+test_msort_atoms_alpha(_, R) :-
+    % b interns before a in this program, but standard order is alpha:
+    % expected sorted: [a, b, c, d].
+    msort([d, b, a, c], [F|_]),
+    char_code(F, C), R is C.   % 97 ('a')
+
+:- dynamic test_msort_atoms_last/2.
+test_msort_atoms_last(_, R) :-
+    msort([d, b, a, c], L),
+    last(L, E),
+    char_code(E, C), R is C.   % 100 ('d')
+
+:- dynamic test_msort_dupes_kept/2.
+test_msort_dupes_kept(_, R) :-
+    % msort keeps duplicates (unlike sort).
+    msort([2, 1, 2, 1, 3], L),
+    length(L, N), R is N.   % 5
+
+:- dynamic test_msort_compound/2.
+test_msort_compound(_, R) :-
+    % Compound sorted via @wam_term_cmp recursion through args.
+    msort([foo(3), foo(1), foo(2)], [F|_]),
+    F = foo(N), R is N.   % 1
+
 % M69: @</2 @=</2 @>/2 @>=/2 standard-order comparison operators.
 
 :- dynamic test_at_lt_yes/2.
@@ -4086,6 +4115,15 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M70 msort/2 + setof migrated to @wam_term_cmp ---~n'),
+       run_test_r0('msort([d,b,a,c]) first -> 97 (a)',
+                   test_msort_atoms_alpha, 0, 97),
+       run_test_r0('msort([d,b,a,c]) last -> 100 (d)',
+                   test_msort_atoms_last, 0, 100),
+       run_test_r0('msort([2,1,2,1,3]) length -> 5 (dupes kept)',
+                   test_msort_dupes_kept, 0, 5),
+       run_test_r0('msort([foo(3), foo(1), foo(2)]) first arg -> 1',
+                   test_msort_compound, 0, 1),
        format('--- M69 standard-order comparison operators ---~n'),
        run_test_r0('1 @< 2 -> 1',
                    test_at_lt_yes, 0, 1),


### PR DESCRIPTION
## Summary

Two sort sites in `state.ll.mustache` previously used `(tag, payload)`
ordering — consistent but not standard. Migrated both to delegate
to `@wam_term_cmp`, which gives:
- integer-only sorting: **identical behaviour**
- atoms: now **alphabetical** (was intern-order)
- floats / compounds: now standard order with recursion

### Sites changed
- `@wam_msort_list`'s `si_cmp` (the plain `msort/2` inner loop).
- `@wam_apply_aggregation`'s `set_si_cmp` (the sort used by
  `aggregate_all(set, ...)` and `setof/3` before dedup).

`@wam_apply_aggregation` got a new `%vm` parameter so it can call
`@wam_term_cmp` (which derefs internally). The single call site in
the same file is updated accordingly.

## Test plan
- [x] 4 new tests:
  - `msort([d,b,a,c])` first/last → `a`/`d` (alphabetical)
  - msort dupes kept (length 5)
  - msort compound `foo(3)`/`foo(1)`/`foo(2)` → `foo(1)` first via
    recursion
- [x] All pre-existing M9 findall/aggregate tests and integer-only
      msort tests still pass through the migrated path
- [x] All 474 builtin tests pass (was 470, +4)
- [x] Manual llc round-trip clean


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_