### PR TITLE
LLVM WAM: forall/2 compile-time soft-cut rewrite (M71)

### DIFF
--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1193,6 +1193,14 @@ compile_goals([Goal|Rest], V0, HasEnv, Vf, Code) :-
         wam_inline_not_enabled
     ->  compile_goals([((NotGoal, !, fail) ; true) | Rest],
                       V0, HasEnv, Vf, Code)
+    % M71: forall(Cond, Action) inlines to \+ (Cond, \+ Action) --
+    % the standard rewrite. Falls into the \+ rewrite above for both
+    % the outer and inner negations.
+    ;   nonvar(Goal),
+        Goal = forall(ForallCond, ForallAction),
+        wam_inline_not_enabled
+    ->  compile_goals([\+ (ForallCond, \+ ForallAction) | Rest],
+                      V0, HasEnv, Vf, Code)
     % Bare if-then: (Cond -> Then) without an Else clause. Reuses the
     % if-then-else compiler with Else=fail — semantically identical
     % for the success path; Cond-failure just falls through to fail

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1242,14 +1242,11 @@ compile_goals([Goal|Rest], V0, HasEnv, Vf, Code) :-
     % normal dispatch (including if-then-else inlining).
     ;   Goal = once(OnceGoal)
     ->  compile_goals([(OnceGoal -> true) | Rest], V0, HasEnv, Vf, Code)
-    % forall(G, T) — for every solution of G, T must succeed.
-    % Desugars to \+ (G, \+ T): negation-as-failure over the
-    % conjunction of generator + negated test. Recursion routes
-    % through compile_goal_call, which emits `call \+/1, 1` and the
-    % runtime handles negation via the builtin path.
-    ;   Goal = forall(GenGoal, TestGoal)
-    ->  compile_goals([\+ (GenGoal, \+ TestGoal) | Rest],
-                      V0, HasEnv, Vf, Code)
+    % M71: forall/2 now handled by the earlier M71 clause that uses
+    % the soft-cut rewrite. This stale clause used \+ (G, \+ T) which
+    % was broken for nested negation (both cuts hit the same barrier);
+    % the earlier clause takes precedence so this would never fire,
+    % but remove it to avoid confusion if the earlier clause ever moves.
     ;   Rest == []
     ->  % Last goal: execute (Tail Call Optimization)
         (   %% Term-construction builtins (=../2 and functor/3) only
@@ -1754,9 +1751,14 @@ compile_inner_call_goals([Goal|Rest], V0, Vf, Code) :-
     % machinery picks it up.
     ;   Goal = once(OnceGoal)
     ->  compile_inner_call_goals([(OnceGoal -> true) | Rest], V0, Vf, Code)
+    % M71: forall rewrites to soft-cut form (matches the compile_goals
+    % clause). The old \+ (G, \+ T) form fails for nested negation
+    % because both ! cuts hit the clause''s single cut_barrier.
     ;   Goal = forall(GenGoal, TestGoal)
-    ->  compile_inner_call_goals([\+ (GenGoal, \+ TestGoal) | Rest],
-                                 V0, Vf, Code)
+    ->  compile_inner_call_goals(
+            [((GenGoal, (TestGoal -> fail ; true)) -> fail ; true)
+             | Rest],
+            V0, Vf, Code)
     ;   compile_goal_call(Goal, V0, V1, GoalCode),
         compile_inner_call_goals(Rest, V1, Vf, RestCode),
         join_goal_codes(GoalCode, RestCode, Code)

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1193,14 +1193,20 @@ compile_goals([Goal|Rest], V0, HasEnv, Vf, Code) :-
         wam_inline_not_enabled
     ->  compile_goals([((NotGoal, !, fail) ; true) | Rest],
                       V0, HasEnv, Vf, Code)
-    % M71: forall(Cond, Action) inlines to \+ (Cond, \+ Action) --
-    % the standard rewrite. Falls into the \+ rewrite above for both
-    % the outer and inner negations.
+    % M71: forall(Cond, Action) inlines as
+    %   ((Cond, (Action -> fail ; true)) -> fail ; true)
+    % i.e., \+ (Cond, \+ Action) using soft-cut (-> form) for BOTH
+    % negations. The cut-based ((G, !, fail) ; true) rewrite that \+
+    % uses by default doesn''t nest correctly here: the inner ! and
+    % outer ! both target the clause''s single cut_barrier, so the
+    % inner cut wipes the outer disjunction''s CP and forall always
+    % fails. Soft-cut (-> ; ) gives proper local-scope cuts.
     ;   nonvar(Goal),
-        Goal = forall(ForallCond, ForallAction),
-        wam_inline_not_enabled
-    ->  compile_goals([\+ (ForallCond, \+ ForallAction) | Rest],
-                      V0, HasEnv, Vf, Code)
+        Goal = forall(ForallCond, ForallAction)
+    ->  compile_goals(
+            [((ForallCond, (ForallAction -> fail ; true)) -> fail ; true)
+             | Rest],
+            V0, HasEnv, Vf, Code)
     % Bare if-then: (Cond -> Then) without an Else clause. Reuses the
     % if-then-else compiler with Else=fail — semantically identical
     % for the success path; Cond-failure just falls through to fail

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2452,6 +2452,38 @@ test_cmp_lists_diff(_, R) :-
     char_code(O, C),
     R is C.   % '<'
 
+% M71: forall/2 -- compile-time rewrite to \+ (Cond, \+ Action).
+
+:- dynamic positive/1.
+positive(1).
+positive(2).
+positive(3).
+
+:- dynamic small/1.
+small(1).
+small(2).
+small(3).
+small(4).
+small(5).
+
+:- dynamic test_forall_all_pos/2.
+test_forall_all_pos(_, R) :-
+    ( forall(positive(X), X > 0) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_forall_one_fails/2.
+test_forall_one_fails(_, R) :-
+    ( forall(positive(X), X > 1) -> R is 1 ; R is 0 ).   % 0 (1 fails)
+
+:- dynamic test_forall_subset/2.
+test_forall_subset(_, R) :-
+    % Every X in positive/1 is also in small/1.
+    ( forall(positive(X), small(X)) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_forall_empty/2.
+test_forall_empty(_, R) :-
+    % No solutions for false_pred -> forall vacuously true.
+    ( forall(member(X, []), X > 0) -> R is 1 ; R is 0 ).   % 1
+
 % M70: msort/2 + aggregate_all(set, ...) migrated to @wam_term_cmp.
 % Integer-only sorting unchanged; atom sorting now alphabetical (was
 % previously by intern atom_id which is allocation order).
@@ -4115,6 +4147,15 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M71 forall/2 (compile-time \\+ (Cond, \\+ Action) rewrite) ---~n'),
+       run_test_r0('forall(positive(X), X > 0) -> 1',
+                   test_forall_all_pos + [positive/1], 0, 1),
+       run_test_r0('forall(positive(X), X > 1) -> 0 (1 fails)',
+                   test_forall_one_fails + [positive/1], 0, 0),
+       run_test_r0('forall(positive(X), small(X)) subset -> 1',
+                   test_forall_subset + [positive/1, small/1], 0, 1),
+       run_test_r0('forall over empty solutions -> 1 (vacuous)',
+                   test_forall_empty, 0, 1),
        format('--- M70 msort/2 + setof migrated to @wam_term_cmp ---~n'),
        run_test_r0('msort([d,b,a,c]) first -> 97 (a)',
                    test_msort_atoms_alpha, 0, 97),

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2452,6 +2452,13 @@ test_cmp_lists_diff(_, R) :-
     char_code(O, C),
     R is C.   % '<'
 
+% M71 manual-rewrite check: does the soft-cut form work when written
+% directly (without forall)?
+
+:- dynamic test_forall_manual/2.
+test_forall_manual(_, R) :-
+    ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
+
 % M71: forall/2 -- compile-time rewrite to \+ (Cond, \+ Action).
 
 :- dynamic positive/1.
@@ -4148,6 +4155,8 @@ test_all :-
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
        format('--- M71 forall/2 (compile-time \\+ (Cond, \\+ Action) rewrite) ---~n'),
+       run_test_r0('forall manual soft-cut rewrite -> 1',
+                   test_forall_manual + [positive/1], 0, 1),
        run_test_r0('forall(positive(X), X > 0) -> 1',
                    test_forall_all_pos + [positive/1], 0, 1),
        run_test_r0('forall(positive(X), X > 1) -> 0 (1 fails)',


### PR DESCRIPTION
## Summary

Adds `forall(Cond, Action)` as a compile-time rewrite. Body inlines to:

```prolog
((Cond, (Action -> fail ; true)) -> fail ; true)
```

This is `\+ (Cond, \+ Action)` expanded with **soft-cut** (`->`) for
**both** negations. No new builtin / dispatch needed.

### Why not the existing `\+` cut-based inline?
The repo already has a `forall(G, T) → \+ (G, \+ T)` rewrite that
recursively expands via the `\+` inline. But `\+ G → ((G, !, fail) ;
true)` uses `!` which targets the clause's single `cut_barrier`.
When `\+` nests, both cuts hit that same barrier — the inner cut
wipes the outer disjunction's CP and `forall` always fails.

Soft-cut (`->`) emits `get_level Y_n` / `cut Y_n` (M17) with a fresh
permanent Y per `->`, so each branch has a locally-scoped cut barrier.
The inner cut now prunes only the inner disjunction's CP; the outer's
`; true` fallback survives. `forall` succeeds correctly when all
`Cond` solutions satisfy `Action`.

### Two rewrite sites updated
- `compile_goals` (line ~1204): handles `forall` as the next goal in
  a clause body or after a `,`.
- `compile_inner_call_goals` (line ~1755): handles `forall` when it
  appears inside an if-then-else condition (which routes through this
  separate dispatch). The first run of this PR missed this site —
  `test_forall_all_pos` wraps `forall` in `( forall(...) -> ... ; ... )`,
  so the inner dispatch was the actual code path.

The stale `forall` clause in `compile_goals` that used the broken
`\+ (G, \+ T)` form is removed (it was already unreachable due to the
new M71 clause coming earlier, but worth deleting to avoid confusing
future readers).

## Test plan
- [x] 5 new tests:
  - `forall(positive(X), X > 0)` over `[1,2,3]` → 1 (all positive)
  - `forall(positive(X), X > 1)` → 0 (X=1 fails)
  - `forall(positive(X), small(X))` subset check
  - `forall(member(X, []), _)` vacuously true over empty
  - manual soft-cut rewrite probe (`((Cond, (Action -> fail ; true))
    -> fail ; true)` written by hand, confirms the rewrite shape
    works independently)
- [x] All 479 builtin tests pass (was 474, +5)
- [x] Manual standalone repro: forall(positive(X), X > 0) returns 1


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_