### PR TITLE
LLVM WAM: get_time/1 wall-clock as Float seconds (M72)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1453,7 +1453,8 @@ declare void @free(i8*)
 declare i32 @snprintf(i8*, i64, i8*, ...)
 declare i32 @strcmp(i8*, i8*)
 declare i32 @printf(i8*, ...)
-declare i32 @putchar(i32)'
+declare i32 @putchar(i32)
+declare i64 @time(i64*)'
     ).
 
 %% generate_wasm_exports(+Predicates, -ExportCode)
@@ -3486,6 +3487,7 @@ entry:
     i32 87, label %builtin_at_le
     i32 88, label %builtin_at_gt
     i32 89, label %builtin_at_ge
+    i32 90, label %builtin_get_time
   ]
 
 builtin_is:
@@ -4334,6 +4336,20 @@ builtin_at_ge:
   %atge.r = call i32 @wam_term_cmp(%WamState* %vm, %Value %atge.a1, %Value %atge.a2)
   %atge.ok = icmp sge i32 %atge.r, 0
   ret i1 %atge.ok
+
+builtin_get_time:
+  ; M72: get_time(?Time) -- wall-clock seconds since the epoch, as
+  ; Float. Calls libc time(NULL) so resolution is whole-second;
+  ; gettimeofday / clock_gettime can replace this for sub-second
+  ; precision in a follow-up. Unifies A1 with the resulting Float.
+  %gt.t_i64 = call i64 @time(i64* null)
+  %gt.t_d = sitofp i64 %gt.t_i64 to double
+  %gt.t_bits = bitcast double %gt.t_d to i64
+  %gt.v0 = insertvalue %Value undef, i32 2, 0
+  %gt.v = insertvalue %Value %gt.v0, i64 %gt.t_bits, 1
+  %gt.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %gt.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %gt.raw1, %Value %gt.v)
+  ret i1 %gt.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -10905,6 +10921,7 @@ builtin_op_to_id('@</2', 86).                 % standard order: less than.
 builtin_op_to_id('@=</2', 87).                % standard order: less or equal.
 builtin_op_to_id('@>/2', 88).                 % standard order: greater than.
 builtin_op_to_id('@>=/2', 89).                % standard order: greater or equal.
+builtin_op_to_id('get_time/1', 90).           % wall-clock time as Float seconds since epoch.
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,29 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M72: get_time/1 -- wall-clock seconds since the epoch as Float.
+
+:- dynamic test_get_time_succeeds/2.
+test_get_time_succeeds(_, R) :- ( get_time(_) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_get_time_positive/2.
+test_get_time_positive(_, R) :-
+    get_time(T),
+    ( T > 0.0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_get_time_recent/2.
+test_get_time_recent(_, R) :-
+    % UNIX time should be past 2020 (1577836800 epoch).
+    get_time(T),
+    ( T > 1577836800.0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_get_time_monotonic/2.
+test_get_time_monotonic(_, R) :-
+    % Two get_time calls -- second should be >= first.
+    get_time(T1),
+    get_time(T2),
+    ( T2 >= T1 -> R is 1 ; R is 0 ).   % 1
+
 % M71: forall/2 -- compile-time rewrite to \+ (Cond, \+ Action).
 
 :- dynamic positive/1.
@@ -4154,6 +4177,15 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M72 get_time/1 ---~n'),
+       run_test_r0('get_time(_) succeeds -> 1',
+                   test_get_time_succeeds, 0, 1),
+       run_test_r0('get_time(T), T > 0.0 -> 1',
+                   test_get_time_positive, 0, 1),
+       run_test_r0('get_time(T) > 2020 epoch -> 1',
+                   test_get_time_recent, 0, 1),
+       run_test_r0('get_time monotonic -> 1',
+                   test_get_time_monotonic, 0, 1),
        format('--- M71 forall/2 (compile-time \\+ (Cond, \\+ Action) rewrite) ---~n'),
        run_test_r0('forall manual soft-cut rewrite -> 1',
                    test_forall_manual + [positive/1], 0, 1),


### PR DESCRIPTION
## Summary

Adds `get_time(?Time)` — whole-second wall-clock time as Float seconds
since the UNIX epoch. Calls libc `time(NULL)`, converts the i64 result
to double, bitcasts to i64 for the Float payload, and unifies A1.

Whole-second resolution is the floor; sub-second precision would need
`gettimeofday` / `clock_gettime` and a `struct timespec` local;
deferred to keep this PR small.

### Declarations
New: `declare i64 @time(i64*)` added alongside the existing
malloc / realloc / etc set.

### Dispatch
- `builtin_op_to_id('get_time/1', 90)` → `%builtin_get_time`.
- `get_time/1` already in `is_builtin_pred` registry.
- Prefix `gt.`.

## Test plan
- [x] 4 new tests:
  - `get_time(_)` succeeds
  - `T > 0.0` (basic positive check)
  - `T > 1577836800.0` (after 2020 epoch — catches obvious garbage)
  - two `get_time` calls in a row: `T2 >= T1` (monotonic at
    whole-second resolution)
- [x] All 483 builtin tests pass (was 479, +4)
- [x] Manual llc round-trip clean


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_