### PR TITLE
perf(wam-rust): category_ancestor kernel optimizations — Haskell parity on identical data

### DIFF
--- a/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
+++ b/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
@@ -763,12 +763,16 @@ fn main() {
             let root_id = vm.intern_atom(&root);
             let mut visited_ids = vec![cat_id];
             let mut hops = Vec::new();
+            // Resolve the constant edge predicate once per seed (not per
+            // recursive call) — the interning principle applied to the
+            // predicate name.
+            let acc = vm.resolve_edge_accessor("category_parent");
             vm.collect_native_category_ancestor_hops(
                 cat_id,
                 root_id,
                 &mut visited_ids,
                 max_depth_limit,
-                "category_parent",
+                &acc,
                 0,
                 &mut hops,
             );
@@ -1389,12 +1393,16 @@ fn main() {
             let root_id = vm.intern_atom(&root);
             let mut visited_ids = vec![cat_id];
             let mut hops = Vec::new();
+            // Resolve the constant edge predicate once per seed (not per
+            // recursive call) — the interning principle applied to the
+            // predicate name.
+            let acc = vm.resolve_edge_accessor("category_parent");
             vm.collect_native_category_ancestor_hops(
                 cat_id,
                 root_id,
                 &mut visited_ids,
                 max_depth_limit,
-                "category_parent",
+                &acc,
                 0,
                 &mut hops,
             );

--- a/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
+++ b/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
@@ -761,14 +761,15 @@ fn main() {
         if vm.foreign_predicates.contains("category_ancestor/4") {
             let cat_id = vm.intern_atom(cat);
             let root_id = vm.intern_atom(&root);
-            let visited_ids = vec![cat_id];
+            let mut visited_ids = vec![cat_id];
             let mut hops = Vec::new();
             vm.collect_native_category_ancestor_hops(
                 cat_id,
                 root_id,
-                &visited_ids,
+                &mut visited_ids,
                 max_depth_limit,
                 "category_parent",
+                0,
                 &mut hops,
             );
             for hop in hops.iter().take(10001) {
@@ -1386,14 +1387,15 @@ fn main() {
         if vm.foreign_predicates.contains("category_ancestor/4") {
             let cat_id = vm.intern_atom(cat);
             let root_id = vm.intern_atom(&root);
-            let visited_ids = vec![cat_id];
+            let mut visited_ids = vec![cat_id];
             let mut hops = Vec::new();
             vm.collect_native_category_ancestor_hops(
                 cat_id,
                 root_id,
-                &visited_ids,
+                &mut visited_ids,
                 max_depth_limit,
                 "category_parent",
+                0,
                 &mut hops,
             );
             for hop in hops.iter().take(10001) {

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1402,14 +1402,14 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                 };
                 let cat_id = self.intern_atom(&cat);
                 let root_id = self.intern_atom(&root);
-                let visited_ids: Vec<u32> = visited.iter().filter_map(|item| {
+                let mut visited_ids: Vec<u32> = visited.iter().filter_map(|item| {
                     match self.deref_var(item) {
                         Value::Atom(s) => Some(self.intern_atom(&s)),
                         _ => None,
                     }
                 }).collect();
                 let mut hops: Vec<i64> = Vec::new();
-                self.collect_native_category_ancestor_hops(cat_id, root_id, &visited_ids, max_depth, &edge_pred, &mut hops);
+                self.collect_native_category_ancestor_hops(cat_id, root_id, &mut visited_ids, max_depth, &edge_pred, 0, &mut hops);
                 if hops.is_empty() {
                     return false;
                 }
@@ -1854,19 +1854,30 @@ compile_collect_native_category_ancestor_to_rust(Code) :-
         &self,
         cat_id: u32,
         root_id: u32,
-        visited: &[u32],
+        visited: &mut Vec<u32>,
         max_depth: usize,
         edge_pred: &str,
+        depth: i64,
         out: &mut Vec<i64>,
     ) {
         // R7: route through self.edge_parents so lazy_lookups is
         // consulted before ffi_facts. This keeps the kernels_on
         // native path working under lmdb_materialisation(lazy).
+        //
+        // Accumulator-passing (ported from the Haskell kernel, perf-log
+        // #16/#207): thread the hop count DOWN as `depth` and emit the
+        // final distance (depth + 1) when the root is reached, instead of
+        // pushing 1 and incrementing every emitted result on the way back
+        // up. Eliminates the O(sum-of-path-depths) re-increment pass
+        // (~57M ops at simplewiki). Output is byte-identical: at a level
+        // with visited.len() == L the old code yielded L (push 1 + L-1
+        // increments) and this yields depth + 1 == L, in the same DFS
+        // emission order.
         let parents = self.edge_parents(cat_id, edge_pred);
         let root_seen = visited.contains(&root_id);
         if !root_seen {
             if parents.contains(&root_id) {
-                out.push(1);
+                out.push(depth + 1);
             }
         }
 
@@ -1874,18 +1885,18 @@ compile_collect_native_category_ancestor_to_rust(Code) :-
             return;
         }
 
+        // Single reused `visited` Vec with DFS push/pop instead of a fresh
+        // per-branch allocation (was ~64M Vec allocs at simplewiki). The
+        // path-so-far is restored by pop() on the way back up, so contents
+        // at every level are identical to the old `[parent | visited]`
+        // copy — output is byte-identical.
         for parent_id in &parents {
             if visited.contains(parent_id) {
                 continue;
             }
-            let mut next_visited: Vec<u32> = Vec::with_capacity(visited.len() + 1);
-            next_visited.push(*parent_id);
-            next_visited.extend_from_slice(visited);
-            let before = out.len();
-            self.collect_native_category_ancestor_hops(*parent_id, root_id, &next_visited, max_depth, edge_pred, out);
-            for hop in out.iter_mut().skip(before) {
-                *hop += 1;
-            }
+            visited.push(*parent_id);
+            self.collect_native_category_ancestor_hops(*parent_id, root_id, visited, max_depth, edge_pred, depth + 1, out);
+            visited.pop();
         }
     }'.
 

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1409,7 +1409,8 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                     }
                 }).collect();
                 let mut hops: Vec<i64> = Vec::new();
-                self.collect_native_category_ancestor_hops(cat_id, root_id, &mut visited_ids, max_depth, &edge_pred, 0, &mut hops);
+                let acc = self.resolve_edge_accessor(&edge_pred);
+                self.collect_native_category_ancestor_hops(cat_id, root_id, &mut visited_ids, max_depth, &acc, 0, &mut hops);
                 if hops.is_empty() {
                     return false;
                 }
@@ -1856,7 +1857,7 @@ compile_collect_native_category_ancestor_to_rust(Code) :-
         root_id: u32,
         visited: &mut Vec<u32>,
         max_depth: usize,
-        edge_pred: &str,
+        acc: &EdgeAccessor,
         depth: i64,
         out: &mut Vec<i64>,
     ) {
@@ -1873,7 +1874,7 @@ compile_collect_native_category_ancestor_to_rust(Code) :-
         // with visited.len() == L the old code yielded L (push 1 + L-1
         // increments) and this yields depth + 1 == L, in the same DFS
         // emission order.
-        let parents = self.edge_parents(cat_id, edge_pred);
+        let parents = self.edge_parents_via(cat_id, acc);
         let root_seen = visited.contains(&root_id);
         if !root_seen {
             if parents.contains(&root_id) {
@@ -1895,7 +1896,7 @@ compile_collect_native_category_ancestor_to_rust(Code) :-
                 continue;
             }
             visited.push(*parent_id);
-            self.collect_native_category_ancestor_hops(*parent_id, root_id, visited, max_depth, edge_pred, depth + 1, out);
+            self.collect_native_category_ancestor_hops(*parent_id, root_id, visited, max_depth, acc, depth + 1, out);
             visited.pop();
         }
     }'.

--- a/templates/targets/rust_wam/materialisation_setup.rs.mustache
+++ b/templates/targets/rust_wam/materialisation_setup.rs.mustache
@@ -84,7 +84,7 @@
     vm.build_lazy_int_maps(&s2i);
     // Prune the lazy edge path to the reachable demand set, matching the
     // eager materialisation's edge filter (avoids 220× over-exploration).
-    vm.set_demand_set(reachable_ids.clone());
+    vm.set_demand_set(&reachable_ids);
     setup_foreign_predicates(&mut vm);
 {{default}}
     // Cached: lazy with a sharded bounded cache layered in front.
@@ -144,6 +144,6 @@
     vm.build_lazy_int_maps(&s2i);
     // Prune the lazy edge path to the reachable demand set, matching the
     // eager materialisation's edge filter (avoids 220× over-exploration).
-    vm.set_demand_set(reachable_ids.clone());
+    vm.set_demand_set(&reachable_ids);
     setup_foreign_predicates(&mut vm);
 {{/match}}

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -382,6 +382,21 @@ pub struct WamState {
     pub aggregate_return_pc: usize,
 }
 
+/// Resolved edge accessor. The category-edge predicate is a CONSTANT for a
+/// whole query, so it is resolved ONCE (`resolve_edge_accessor`) and the
+/// handle threaded through the recursion — instead of re-`format!`-ing and
+/// re-hashing the constant key `"<pred>/2"` on every one of the ~64M kernel
+/// edge lookups. This is the interning principle applied to the predicate
+/// name: resolve once, then per-call work is pure integer access.
+pub enum EdgeAccessor<'a> {
+    /// Eager: borrow the materialised `ffi_facts` adjacency (int -> ints).
+    Eager(&'a HashMap<u32, Vec<u32>>),
+    /// Lazy/cached: borrow the registered on-demand lookup source.
+    Lazy(&'a Arc<dyn LookupSource>),
+    /// Predicate not registered in either path.
+    Empty,
+}
+
 impl WamState {
     /// Create a new WAM state with the given code and labels.
     pub fn new(code: Vec<Instruction>, labels: HashMap<String, usize>) -> Self {
@@ -617,38 +632,56 @@ impl WamState {
     /// "/arity" suffix) as stored in ffi_facts; the lazy lookup key
     /// is constructed by appending "/2" (the convention for edge
     /// predicates).
-    pub fn edge_parents(&self, cat_id: u32, edge_pred: &str) -> Vec<u32> {
-        // Lazy path: pure-integer via the precomputed WAM↔LMDB int maps
-        // (built once by build_lazy_int_maps). No per-call string alloc,
-        // string clone, or string-hashed lookup — that round-trip was the
-        // ~445× gap vs the eager integer path at simplewiki scale.
+    /// Resolve the (constant) edge predicate to a borrowed accessor ONCE,
+    /// before the kernel recursion. Does the single `format!` + string-hash
+    /// per query instead of per call. Lazy/cached takes priority over the
+    /// eager `ffi_facts` fallback, matching the old `edge_parents` order.
+    pub fn resolve_edge_accessor<'a>(&'a self, edge_pred: &str) -> EdgeAccessor<'a> {
         let lazy_key = format!("{}/2", edge_pred);
         if let Some(source) = self.lazy_lookups.get(&lazy_key) {
-            let Some(&int_key) = self.wam_to_lmdb.get(&cat_id) else {
-                // Lazy registered but this atom isn't in s2i; treat as miss.
-                return Vec::new();
-            };
-            let parent_ints = source.lookup_parents(int_key);
-            let mut out = Vec::with_capacity(parent_ints.len());
-            for pid in parent_ints {
-                // Demand-set pruning: eager only materialises edges whose
-                // parent is reachable; the lazy path must match or the
-                // kernel over-explores non-reachable ancestor branches.
-                if !self.demand_set.is_empty() && !self.demand_set.contains(&pid) {
-                    continue;
-                }
-                if let Some(&wam) = self.lmdb_to_wam.get(&pid) {
-                    out.push(wam);
-                }
-            }
-            return out;
+            EdgeAccessor::Lazy(source)
+        } else if let Some(table) = self.ffi_facts.get(edge_pred) {
+            EdgeAccessor::Eager(table)
+        } else {
+            EdgeAccessor::Empty
         }
-        // Eager fallback.
-        self.ffi_facts
-            .get(edge_pred)
-            .and_then(|table| table.get(&cat_id))
-            .cloned()
-            .unwrap_or_default()
+    }
+
+    /// Per-call edge lookup against a pre-resolved accessor — pure-integer,
+    /// no string work. Used by the category_ancestor kernel hot path.
+    pub fn edge_parents_via(&self, cat_id: u32, acc: &EdgeAccessor) -> Vec<u32> {
+        match acc {
+            EdgeAccessor::Eager(table) => {
+                table.get(&cat_id).cloned().unwrap_or_default()
+            }
+            EdgeAccessor::Lazy(source) => {
+                let Some(&int_key) = self.wam_to_lmdb.get(&cat_id) else {
+                    return Vec::new();
+                };
+                let parent_ints = source.lookup_parents(int_key);
+                let mut out = Vec::with_capacity(parent_ints.len());
+                for pid in parent_ints {
+                    // Demand-set pruning: eager only materialises edges whose
+                    // parent is reachable; the lazy path must match or the
+                    // kernel over-explores non-reachable ancestor branches.
+                    if !self.demand_set.is_empty() && !self.demand_set.contains(&pid) {
+                        continue;
+                    }
+                    if let Some(&wam) = self.lmdb_to_wam.get(&pid) {
+                        out.push(wam);
+                    }
+                }
+                out
+            }
+            EdgeAccessor::Empty => Vec::new(),
+        }
+    }
+
+    /// Back-compat single-shot lookup (resolve + dispatch). Kept for callers
+    /// off the hot path; the kernel uses resolve_edge_accessor + edge_parents_via.
+    pub fn edge_parents(&self, cat_id: u32, edge_pred: &str) -> Vec<u32> {
+        let acc = self.resolve_edge_accessor(edge_pred);
+        self.edge_parents_via(cat_id, &acc)
     }
 
     /// Dereference an Unbound variable through the binding table.

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -2,6 +2,42 @@
 // Date: {{date}}
 
 use std::collections::{HashMap, HashSet};
+
+/// Fast non-cryptographic hasher (FxHash-style) for the hot integer-keyed
+/// maps on the category_ancestor kernel path. Interning already turns atoms
+/// into dense ints; this keeps each of the ~64M+ per-query lookups off the
+/// std default SipHash (DoS-resistant but ~5-10x slower for int keys).
+/// Not collision-DoS-resistant — fine for batch graph workloads.
+#[derive(Default)]
+pub struct FxHasher {
+    hash: u64,
+}
+impl std::hash::Hasher for FxHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        const K: u64 = 0x51_7c_c1_b7_27_22_0a_95;
+        for &b in bytes {
+            self.hash = (self.hash.rotate_left(5) ^ (b as u64)).wrapping_mul(K);
+        }
+    }
+    #[inline]
+    fn write_u32(&mut self, i: u32) {
+        const K: u64 = 0x51_7c_c1_b7_27_22_0a_95;
+        self.hash = (self.hash.rotate_left(5) ^ (i as u64)).wrapping_mul(K);
+    }
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        const K: u64 = 0x51_7c_c1_b7_27_22_0a_95;
+        self.hash = (self.hash.rotate_left(5) ^ i).wrapping_mul(K);
+    }
+}
+pub type FxBuildHasher = std::hash::BuildHasherDefault<FxHasher>;
+pub type FxMap<K, V> = std::collections::HashMap<K, V, FxBuildHasher>;
+pub type FxSet<K> = std::collections::HashSet<K, FxBuildHasher>;
 use std::sync::{Arc, Mutex};
 use crate::value::Value;
 use crate::instructions::Instruction;
@@ -49,7 +85,7 @@ pub struct CachedLookup<S: LookupSource> {
 }
 
 struct CacheShard {
-    map: HashMap<i32, Vec<i32>>,
+    map: FxMap<i32, Vec<i32>>,
     /// Insertion order, for FIFO eviction once the shard hits cap.
     order: Vec<i32>,
 }
@@ -63,7 +99,7 @@ impl<S: LookupSource> CachedLookup<S> {
         let cap_per_shard = (capacity / num_shards).max(1);
         let shards = (0..num_shards)
             .map(|_| Mutex::new(CacheShard {
-                map: HashMap::with_capacity(cap_per_shard),
+                map: FxMap::with_capacity_and_hasher(cap_per_shard, Default::default()),
                 order: Vec::with_capacity(cap_per_shard),
             }))
             .collect();
@@ -318,13 +354,13 @@ pub struct WamState {
     /// — no per-call WAM-atom→string→LMDB-int→string→WAM-atom round-trip.
     /// `wam_to_lmdb`: WAM intern id → LMDB int key (for the lookup key).
     /// `lmdb_to_wam`: LMDB int → WAM intern id (for mapping results back).
-    pub wam_to_lmdb: HashMap<u32, i32>,
-    pub lmdb_to_wam: HashMap<i32, u32>,
+    pub wam_to_lmdb: FxMap<u32, i32>,
+    pub lmdb_to_wam: FxMap<i32, u32>,
     /// Reachable demand set (LMDB int ids) for the lazy/cached edge path.
     /// Eager only materialises edges whose parent is in this set; the lazy
     /// path must filter identically or the kernel over-explores
     /// non-reachable ancestor branches. Empty = no filter (eager/other).
-    pub demand_set: HashSet<i32>,
+    pub demand_set: FxSet<i32>,
     /// Variable binding table: maps Unbound variable names to their bound values.
     /// This simulates the WAM heap's shared binding semantics when PutVariable
     /// creates a variable that's stored in both a Y-register and an A-register.
@@ -371,9 +407,9 @@ impl WamState {
             foreign_result_layouts: HashMap::new(),
             foreign_result_modes: HashMap::new(),
             lazy_lookups: HashMap::new(),
-            wam_to_lmdb: HashMap::new(),
-            lmdb_to_wam: HashMap::new(),
-            demand_set: HashSet::new(),
+            wam_to_lmdb: FxMap::default(),
+            lmdb_to_wam: FxMap::default(),
+            demand_set: FxSet::default(),
             bindings: HashMap::new(),
             var_counter: 0,
             cut_barrier: 0,
@@ -561,8 +597,11 @@ impl WamState {
 
     /// Set the reachable demand set (LMDB int ids) used to prune the
     /// lazy/cached edge path to the same edges eager materialises.
-    pub fn set_demand_set(&mut self, demand: HashSet<i32>) {
-        self.demand_set = demand;
+    pub fn set_demand_set(&mut self, demand: &HashSet<i32>) {
+        // reachable_to_root returns a std HashSet; collect into the
+        // FxHash-backed demand_set so the hot `contains` on the kernel
+        // path avoids SipHash.
+        self.demand_set = demand.iter().copied().collect();
     }
 
     /// Fetch a lazy edge-lookup backend by "name/arity".

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -1894,14 +1894,19 @@ test_r7_lazy_lmdb_lookup_handler_arm :-
     ;   fail_test(Test, 'execute_foreign_predicate is missing the lazy_lmdb_lookup arm or its key calls')
     ).
 
-%% R7: native category_ancestor routes through edge_parents (lazy_lookups-aware).
+%% R7: native category_ancestor routes through the resolved edge accessor
+%% (lazy_lookups-aware), resolving the constant predicate ONCE rather than
+%% re-hashing it per call (interning principle).
 test_r7_native_category_ancestor_uses_edge_parents :-
-    Test = 'WAM-Rust R7: native category_ancestor uses edge_parents (not raw ffi_facts)',
+    Test = 'WAM-Rust R7: native category_ancestor uses resolved edge accessor (not per-call ffi_facts string lookup)',
     (   wam_rust_target:compile_collect_native_category_ancestor_to_rust(Code),
-        sub_string(Code, _, _, _, "self.edge_parents(cat_id, edge_pred)"),
+        % Hot path consults the pre-resolved accessor, not a per-call
+        % string-keyed map lookup.
+        sub_string(Code, _, _, _, "self.edge_parents_via(cat_id, acc)"),
+        \+ sub_string(Code, _, _, _, "self.edge_parents(cat_id, edge_pred)"),
         \+ sub_string(Code, _, _, _, "self.ffi_facts.get(edge_pred)")
     ->  pass(Test)
-    ;   fail_test(Test, 'collect_native_category_ancestor_hops still reads ffi_facts directly; should call edge_parents')
+    ;   fail_test(Test, 'kernel should call edge_parents_via(cat_id, acc) against the resolved accessor, not a per-call predicate lookup')
     ).
 
 %% Regression: rust_val_literal must strip outer quotes from atom tokens


### PR DESCRIPTION
  ## Summary

  Three byte-identical optimizations to the WAM-Rust `category_ancestor` kernel,
  each profiled and ported from / aligned with the Haskell kernel. Closes the
  ~3× Rust-vs-Haskell gap that appendix #16 attributed to the un-optimised Rust
  kernel (not the LMDB access layer).

  ## Changes (each verified byte-identical: eager == cached, tuple_count=38,555)

  1. **Accumulator-passing** (`17e3b46d`, Haskell #207) — thread the hop count
     down and emit `depth+1` at the root, instead of pushing 1 and
     re-incrementing every emitted result on the way up (~57M ops removed).
  2. **push/pop visited** (`17e3b46d`) — one reused `Vec` with DFS backtracking
     instead of ~64M per-branch `[parent|visited]` allocations.
  3. **FxHash int maps** (`6a9cbcb0`) — inline FxHash-style hasher (no dep) for
     the hot int-keyed maps (`wam_to_lmdb`, `lmdb_to_wam`, `demand_set`, cache
     shards), off std SipHash.
  4. **Resolve-predicate-once / interning** (`62610b8d`) — the constant edge
     predicate was `format!`-ed + string-hashed on every one of ~64M calls.
     New `EdgeAccessor` (Eager | Lazy | Empty) resolved **once** per query via
     `resolve_edge_accessor`, threaded through the recursion;
     `edge_parents_via(cat_id, acc)` is the per-call hot path (pure-integer, no
     string work). The largest single win.

  ## Result (simplewiki Articles subgraph, query_ms, 3-trial stable)

  | | baseline | this PR | speedup |
  | --- | ---: | ---: | ---: |
  | eager  | 11,700 | ~3,300 | ~3.5× |
  | cached | 19,200 | ~5,600 | ~3.4× |

  vs Haskell `resident_cursor` -N1 (~5,100 ms): **Rust eager now beats Haskell;
  Rust cached is at parity (~1.1×)** on identical data.

  ## Tests
  `tests/test_wam_rust_target.pl` updated for the resolved-accessor structure;
  all pass. `edge_parents` kept as a back-compat resolve+dispatch shim for
  off-hot-path callers.

  ## Out of scope
  FxHash `ffi_facts` (would help eager's last bit), seed-loop parallelism
  (`rayon`), and a perf-log appendix #17 recording the parity conclusion.

  Two small optional follow-ups whenever you want them (not now): a perf-log appendix #17 to record the "both languages
  can be fast / kernel-not-language" conclusion alongside #16 (so the 3× claim in #16 isn't left as the last word), and
  the deferred ffi_facts FxHash / seed-loop parallelism. But as you said — not the highest-value work right now.

  Nice arc: from "is Rust→LMDB lazy even viable?" to a fair cross-target benchmark, a corrected methodology, and a
  kernel that holds its own against Haskell. Want me to do the appendix #17 before you PR, or just go with the PR as-is?
