### PR TITLE
fix(wam-clojure): materialize functor and arg numeric outputs

### DIFF
--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -652,6 +652,8 @@
       (subs key 0 slash)
       key)))
 
+(declare parse-number-text atom-text)
+
 (defn functor-read-pair [state value]
   (let [value* (deref-value (:bindings state) value)
         ctx (:intern-context state)]
@@ -670,6 +672,16 @@
       :else
       nil)))
 
+(defn functor-arity-value [state value]
+  (cond
+    (integer? value) value
+    (string? value) (parse-number-text value)
+    (atom-term? value) (parse-number-text (atom-text state value))
+    :else nil))
+
+(defn functor-arity-term [state arity]
+  (normalize-literal-term (:intern-context state) (str arity)))
+
 (defn apply-functor-solution [state]
   (let [term (deref-value (:bindings state)
                           (or (reg-get-raw state "A1") ::unbound))]
@@ -680,12 +692,21 @@
                                    (or (reg-get-raw state "A3") ::unbound))
             [ok-name name-state] (unify-values state name-out name)]
         (if ok-name
-          (let [[ok-arity arity-state] (unify-values name-state arity-out arity)]
+          (let [[ok-arity arity-state] (if (logic-var? arity-out)
+                                         (unify-values name-state arity-out (functor-arity-term state arity))
+                                         [(= (functor-arity-value state arity-out) arity) name-state])]
             (if ok-arity
               (advance arity-state)
               (backtrack state)))
           (backtrack state)))
       (backtrack state))))
+
+(defn arg-index-value [state value]
+  (cond
+    (integer? value) value
+    (string? value) (parse-number-text value)
+    (atom-term? value) (parse-number-text (atom-text state value))
+    :else nil))
 
 (defn apply-arg-solution [state]
   (let [index (deref-value (:bindings state)
@@ -693,12 +714,13 @@
         term (deref-value (:bindings state)
                           (or (reg-get-raw state "A2") ::unbound))
         out (deref-value (:bindings state)
-                         (or (reg-get-raw state "A3") ::unbound))]
-    (if (and (integer? index)
-             (pos? index)
+                         (or (reg-get-raw state "A3") ::unbound))
+        index-count (arg-index-value state index)]
+    (if (and (integer? index-count)
+             (pos? index-count)
              (structure-term? term)
-             (<= index (count (:args term))))
-      (let [arg-value (nth (:args term) (dec index))
+             (<= index-count (count (:args term))))
+      (let [arg-value (nth (:args term) (dec index-count))
             [ok next-state] (unify-values state out arg-value)]
         (if ok
           (advance next-state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -135,7 +135,11 @@
 :- dynamic user:wam_copy_term_sharing_fail/0.
 :- dynamic user:wam_copy_term_independent_ok/0.
 :- dynamic user:wam_functor_guard/3.
+:- dynamic user:wam_functor_arity_unify/0.
+:- dynamic user:wam_functor_arity_unify_mismatch/0.
 :- dynamic user:wam_arg_guard/3.
+:- dynamic user:wam_arg_numeric_arg_unify/0.
+:- dynamic user:wam_arg_numeric_arg_unify_mismatch/0.
 :- dynamic user:wam_univ_guard/2.
 :- dynamic user:wam_univ_decompose_struct/0.
 :- dynamic user:wam_univ_decompose_atom/0.
@@ -431,7 +435,11 @@ user:wam_copy_term_guard(A, B) :- copy_term(A, B).
 user:wam_copy_term_sharing_fail :- user:wam_unbound_arg(X), copy_term(f(X, X), f(a, b)).
 user:wam_copy_term_independent_ok :- copy_term(f(_, _), f(a, b)).
 user:wam_functor_guard(Term, Name, Arity) :- functor(Term, Name, Arity).
+user:wam_functor_arity_unify :- functor(f(a,b), f, Arity), Arity = 2.
+user:wam_functor_arity_unify_mismatch :- functor(f(a,b), f, Arity), Arity = 1.
 user:wam_arg_guard(Index, Term, Arg) :- arg(Index, Term, Arg).
+user:wam_arg_numeric_arg_unify :- arg(1, f(42), Arg), Arg = 42.
+user:wam_arg_numeric_arg_unify_mismatch :- arg(1, f(42), Arg), Arg = 43.
 user:wam_univ_guard(Term, List) :- Term =.. List.
 user:wam_univ_decompose_struct :- f(a, b) =.. [f, a, b].
 user:wam_univ_decompose_atom :- a =.. [a].
@@ -732,7 +740,11 @@ run_smoke :-
           user:wam_copy_term_sharing_fail/0,
           user:wam_copy_term_independent_ok/0,
           user:wam_functor_guard/3,
+          user:wam_functor_arity_unify/0,
+          user:wam_functor_arity_unify_mismatch/0,
           user:wam_arg_guard/3,
+          user:wam_arg_numeric_arg_unify/0,
+          user:wam_arg_numeric_arg_unify_mismatch/0,
           user:wam_univ_guard/2,
           user:wam_univ_decompose_struct/0,
           user:wam_univ_decompose_atom/0,
@@ -1189,11 +1201,15 @@ smoke_cases([
     case('wam_functor_guard/3', args('f(a)', a, 1), "false"),
     case('wam_functor_guard/3', args(a, a, 0), "true"),
     case('wam_functor_guard/3', args(42, 42, 0), "true"),
+    case('wam_functor_arity_unify/0', no_args, "true"),
+    case('wam_functor_arity_unify_mismatch/0', no_args, "false"),
     case('wam_arg_guard/3', args(1, 'f(a,b)', a), "true"),
     case('wam_arg_guard/3', args(2, 'f(a,b)', b), "true"),
     case('wam_arg_guard/3', args(1, '[a,b]', a), "true"),
     case('wam_arg_guard/3', args(3, 'f(a,b)', a), "false"),
     case('wam_arg_guard/3', args(1, a, a), "false"),
+    case('wam_arg_numeric_arg_unify/0', no_args, "true"),
+    case('wam_arg_numeric_arg_unify_mismatch/0', no_args, "false"),
     case('wam_univ_guard/2', args('f(a,b)', '[f,a,b]'), "true"),
     case('wam_univ_guard/2', args(a, '[a]'), "true"),
     case('wam_univ_guard/2', args(42, '[42]'), "true"),


### PR DESCRIPTION
## Summary

- Normalize generated `functor/3` arity outputs before binding logic variables, while preserving bound-arity guard behavior.
- Teach `arg/3` to accept normalized numeric index terms emitted by lowered Clojure WAM code.
- Add runtime smoke coverage for generated numeric-output unification and mismatch paths for `functor/3` and `arg/3`.

## Why

The lowered Clojure WAM path represents numeric constants as normalized runtime terms. `functor/3` previously bound generated arity outputs as raw integers, and `arg/3` accepted only raw integer indexes. That made compiled predicates fail when generated numeric outputs were later unified against lowered numeric constants.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

## Commit

- `610bf800 fix(wam-clojure): materialize functor and arg numeric outputs`
