### PR TITLE
feat(wam-clojure): lower compound name builtins

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -444,6 +444,14 @@ clojure_direct_builtin("arg/3", "3").
 clojure_direct_builtin("arg/3", 3).
 clojure_direct_builtin('arg/3', "3").
 clojure_direct_builtin('arg/3', 3).
+clojure_direct_builtin("compound_name_arity/3", "3").
+clojure_direct_builtin("compound_name_arity/3", 3).
+clojure_direct_builtin('compound_name_arity/3', "3").
+clojure_direct_builtin('compound_name_arity/3', 3).
+clojure_direct_builtin("compound_name_arguments/3", "3").
+clojure_direct_builtin("compound_name_arguments/3", 3).
+clojure_direct_builtin('compound_name_arguments/3', "3").
+clojure_direct_builtin('compound_name_arguments/3', 3).
 clojure_direct_builtin("=../2", "2").
 clojure_direct_builtin("=../2", 2).
 clojure_direct_builtin('=../2', "2").
@@ -847,6 +855,16 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "arg/3" ; Op == 'arg/3'),
     !,
     format(atom(Expr), '(runtime/apply-arg-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "compound_name_arity/3" ; Op == 'compound_name_arity/3'),
+    !,
+    format(atom(Expr), '(runtime/apply-compound-name-arity-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "compound_name_arguments/3" ; Op == 'compound_name_arguments/3'),
+    !,
+    format(atom(Expr), '(runtime/apply-compound-name-arguments-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "=../2" ; Op == '=../2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -652,7 +652,7 @@
       (subs key 0 slash)
       key)))
 
-(declare parse-number-text atom-text)
+(declare parse-number-text atom-text fresh-var list->term)
 
 (defn functor-read-pair [state value]
   (let [value* (deref-value (:bindings state) value)
@@ -681,6 +681,25 @@
 
 (defn functor-arity-term [state arity]
   (normalize-literal-term (:intern-context state) (str arity)))
+
+(defn compound-name-text [state value]
+  (when (atom-term? value)
+    (atom-text state value)))
+
+(defn fresh-compound-args [state arity]
+  (loop [s state
+         remaining arity
+         args []]
+    (if (zero? remaining)
+      [s args]
+      (let [[fresh s*] (fresh-var s)]
+        (recur s* (dec remaining) (conj args fresh))))))
+
+(defn build-compound-term [state name-text args]
+  (let [functor-key (str name-text "/" (count args))
+        [ctx* functor-id] (intern-atom (:intern-context state) functor-key)
+        state* (assoc state :intern-context ctx*)]
+    [state* (structure-term (atom-term functor-id) args)]))
 
 (defn apply-functor-solution [state]
   (let [term (deref-value (:bindings state)
@@ -725,6 +744,77 @@
         (if ok
           (advance next-state)
           (backtrack state)))
+      (backtrack state))))
+
+(defn apply-compound-name-arity-solution [state]
+  (let [raw-term (or (reg-get-raw state "A1") ::unbound)
+        term (deref-value (:bindings state) raw-term)
+        name-out (deref-value (:bindings state)
+                              (or (reg-get-raw state "A2") ::unbound))
+        arity-out (deref-value (:bindings state)
+                               (or (reg-get-raw state "A3") ::unbound))]
+    (cond
+      (structure-term? term)
+      (let [key (functor-key (:intern-context state) (:functor term))
+            name (normalize-literal-atom (:intern-context state) (functor-name-from-key key))
+            arity (count (:args term))
+            [ok-name name-state] (unify-values state name-out name)]
+        (if ok-name
+          (let [[ok-arity arity-state] (if (logic-var? arity-out)
+                                         (unify-values name-state arity-out (functor-arity-term state arity))
+                                         [(= (functor-arity-value state arity-out) arity) name-state])]
+            (if ok-arity
+              (advance arity-state)
+              (backtrack state)))
+          (backtrack state)))
+
+      (logic-var? term)
+      (let [name-text (compound-name-text state name-out)
+            arity (functor-arity-value state arity-out)]
+        (if (and (string? name-text) (integer? arity) (not (neg? arity)))
+          (let [[args-state args] (fresh-compound-args state arity)
+                [compound-state built] (build-compound-term args-state name-text args)
+                [ok next-state] (unify-values compound-state raw-term built)]
+            (if ok
+              (advance next-state)
+              (backtrack state)))
+          (backtrack state)))
+
+      :else
+      (backtrack state))))
+
+(defn apply-compound-name-arguments-solution [state]
+  (let [raw-term (or (reg-get-raw state "A1") ::unbound)
+        term (deref-value (:bindings state) raw-term)
+        name-out (deref-value (:bindings state)
+                              (or (reg-get-raw state "A2") ::unbound))
+        args-out (deref-value (:bindings state)
+                              (or (reg-get-raw state "A3") ::unbound))]
+    (cond
+      (structure-term? term)
+      (let [key (functor-key (:intern-context state) (:functor term))
+            name (normalize-literal-atom (:intern-context state) (functor-name-from-key key))
+            args-list (list->term (:intern-context state) (:args term))
+            [ok-name name-state] (unify-values state name-out name)]
+        (if ok-name
+          (let [[ok-args args-state] (unify-values name-state args-out args-list)]
+            (if ok-args
+              (advance args-state)
+              (backtrack state)))
+          (backtrack state)))
+
+      (logic-var? term)
+      (let [name-text (compound-name-text state name-out)
+            args (proper-list-items state args-out)]
+        (if (and (string? name-text) (some? args))
+          (let [[compound-state built] (build-compound-term state name-text args)
+                [ok next-state] (unify-values compound-state raw-term built)]
+            (if ok
+              (advance next-state)
+              (backtrack state)))
+          (backtrack state)))
+
+      :else
       (backtrack state))))
 
 (declare apply-member-solution)
@@ -2426,6 +2516,12 @@
 
           "arg/3"
           (apply-arg-solution state)
+
+          "compound_name_arity/3"
+          (apply-compound-name-arity-solution state)
+
+          "compound_name_arguments/3"
+          (apply-compound-name-arguments-solution state)
 
           "=../2"
           (apply-univ-solution state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -140,6 +140,15 @@
 :- dynamic user:wam_arg_guard/3.
 :- dynamic user:wam_arg_numeric_arg_unify/0.
 :- dynamic user:wam_arg_numeric_arg_unify_mismatch/0.
+:- dynamic user:wam_compound_name_arity_guard/3.
+:- dynamic user:wam_compound_name_arity_decompose/0.
+:- dynamic user:wam_compound_name_arity_compose/0.
+:- dynamic user:wam_compound_name_arity_compose_zero/0.
+:- dynamic user:wam_compound_name_arity_mismatch/0.
+:- dynamic user:wam_compound_name_arguments_guard/3.
+:- dynamic user:wam_compound_name_arguments_decompose/0.
+:- dynamic user:wam_compound_name_arguments_compose/0.
+:- dynamic user:wam_compound_name_arguments_mismatch/0.
 :- dynamic user:wam_univ_guard/2.
 :- dynamic user:wam_univ_decompose_struct/0.
 :- dynamic user:wam_univ_decompose_atom/0.
@@ -440,6 +449,15 @@ user:wam_functor_arity_unify_mismatch :- functor(f(a,b), f, Arity), Arity = 1.
 user:wam_arg_guard(Index, Term, Arg) :- arg(Index, Term, Arg).
 user:wam_arg_numeric_arg_unify :- arg(1, f(42), Arg), Arg = 42.
 user:wam_arg_numeric_arg_unify_mismatch :- arg(1, f(42), Arg), Arg = 43.
+user:wam_compound_name_arity_guard(Term, Name, Arity) :- compound_name_arity(Term, Name, Arity).
+user:wam_compound_name_arity_decompose :- compound_name_arity(f(a,b), Name, Arity), Name = f, Arity = 2.
+user:wam_compound_name_arity_compose :- compound_name_arity(Term, f, 2), Term = f(_,_).
+user:wam_compound_name_arity_compose_zero :- compound_name_arity(_Term, f, 0).
+user:wam_compound_name_arity_mismatch :- compound_name_arity(f(a,b), f, 1).
+user:wam_compound_name_arguments_guard(Term, Name, Args) :- compound_name_arguments(Term, Name, Args).
+user:wam_compound_name_arguments_decompose :- compound_name_arguments(f(a,42), Name, Args), Name = f, Args = [a,42].
+user:wam_compound_name_arguments_compose :- compound_name_arguments(Term, f, [a,42]), Term = f(a,42).
+user:wam_compound_name_arguments_mismatch :- compound_name_arguments(f(a,42), f, [a,43]).
 user:wam_univ_guard(Term, List) :- Term =.. List.
 user:wam_univ_decompose_struct :- f(a, b) =.. [f, a, b].
 user:wam_univ_decompose_atom :- a =.. [a].
@@ -745,6 +763,15 @@ run_smoke :-
           user:wam_arg_guard/3,
           user:wam_arg_numeric_arg_unify/0,
           user:wam_arg_numeric_arg_unify_mismatch/0,
+          user:wam_compound_name_arity_guard/3,
+          user:wam_compound_name_arity_decompose/0,
+          user:wam_compound_name_arity_compose/0,
+          user:wam_compound_name_arity_compose_zero/0,
+          user:wam_compound_name_arity_mismatch/0,
+          user:wam_compound_name_arguments_guard/3,
+          user:wam_compound_name_arguments_decompose/0,
+          user:wam_compound_name_arguments_compose/0,
+          user:wam_compound_name_arguments_mismatch/0,
           user:wam_univ_guard/2,
           user:wam_univ_decompose_struct/0,
           user:wam_univ_decompose_atom/0,
@@ -950,6 +977,7 @@ run_smoke :-
     assert_lowered_copy_term_builtin_emitted(TmpDir),
     assert_lowered_functor_builtin_emitted(TmpDir),
     assert_lowered_arg_builtin_emitted(TmpDir),
+    assert_lowered_compound_name_builtin_emitted(TmpDir),
     assert_lowered_univ_builtin_emitted(TmpDir),
     assert_lowered_ground_builtin_emitted(TmpDir),
     assert_lowered_arithmetic_comparison_builtin_emitted(TmpDir),
@@ -1210,6 +1238,16 @@ smoke_cases([
     case('wam_arg_guard/3', args(1, a, a), "false"),
     case('wam_arg_numeric_arg_unify/0', no_args, "true"),
     case('wam_arg_numeric_arg_unify_mismatch/0', no_args, "false"),
+    case('wam_compound_name_arity_guard/3', args('f(a,b)', f, 2), "true"),
+    case('wam_compound_name_arity_guard/3', args(a, a, 0), "false"),
+    case('wam_compound_name_arity_decompose/0', no_args, "true"),
+    case('wam_compound_name_arity_compose/0', no_args, "true"),
+    case('wam_compound_name_arity_compose_zero/0', no_args, "true"),
+    case('wam_compound_name_arity_mismatch/0', no_args, "false"),
+    case('wam_compound_name_arguments_guard/3', args('f(a,b)', f, '[a,b]'), "true"),
+    case('wam_compound_name_arguments_decompose/0', no_args, "true"),
+    case('wam_compound_name_arguments_compose/0', no_args, "true"),
+    case('wam_compound_name_arguments_mismatch/0', no_args, "false"),
     case('wam_univ_guard/2', args('f(a,b)', '[f,a,b]'), "true"),
     case('wam_univ_guard/2', args(a, '[a]'), "true"),
     case('wam_univ_guard/2', args(42, '[42]'), "true"),
@@ -1693,6 +1731,14 @@ assert_lowered_arg_builtin_emitted(ProjectDir) :-
     read_file_to_string(CorePath, CoreCode, []),
     has(CoreCode, "defn lowered-wam-arg-guard-3"),
     has(CoreCode, "runtime/apply-arg-solution").
+
+assert_lowered_compound_name_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-compound-name-arity-guard-3"),
+    has(CoreCode, "defn lowered-wam-compound-name-arguments-guard-3"),
+    has(CoreCode, "runtime/apply-compound-name-arity-solution"),
+    has(CoreCode, "runtime/apply-compound-name-arguments-solution").
 
 assert_lowered_univ_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Add lowered Clojure WAM support for `compound_name_arity/3`.
- Add lowered Clojure WAM support for `compound_name_arguments/3`.
- Implement conservative runtime decomposition and composition helpers for compound structures.
- Add runtime smoke coverage for guard, decomposition, composition, zero-arity composition, mismatch, and numeric argument-list cases.
- Assert that generated Clojure routes these predicates through the new runtime helpers instead of falling back silently.

## Why

This extends the Clojure lowered structural builtin tier after the existing `functor/3`, `arg/3`, and `=../2` work. These builtins reuse the same runtime representation concerns: interned functor names, normalized numeric arities, proper-list argument materialization, and generated compound construction.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

## Commit

- `941a7049 feat(wam-clojure): lower compound name builtins`
