### PR TITLE
feat(wam-scala): add per-predicate lowered emitter for hybrid WAM parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **WAM Scala target: per-predicate lowered emitter** — brings the Scala
+  hybrid WAM to parity with the Haskell/Rust/C++/F#/Go/Clojure targets,
+  all of which already shipped a `wam_*_lowered_emitter.pl`.
+  - New `src/unifyweaver/targets/wam_scala_lowered_emitter.pl` emits a
+    native Scala `lowered_<pred>_<arity>(s, program): Boolean` function
+    per lowerable predicate (deterministic clause 1; simple register ops
+    inlined, structure/unify ops via new `lo*` `WamRuntime` helpers,
+    deterministic builtins via `loBuiltin`).
+  - New `emit_mode(Mode)` option on `write_wam_scala_project/3`
+    (`interpreter` default / `functions` / `mixed([P/A,...])`), plus a
+    global `user:wam_scala_emit_mode/1` hook. The generated
+    `loweredEntries` map + `runEntry` try the fast path and fall back to a
+    fresh interpreter run on a clause-1 miss, so results are identical to
+    the pure interpreter for any boolean query.
+  - New `tests/test_wam_scala_lowered_emitter.pl` — structural tests
+    (always run) plus gated runtime parity tests that compile the same
+    predicates in both modes and assert identical, correct results.
+  - Fixed first-argument indexing instructions that were silently
+    degrading to `Raw(...)` stubs and breaking the interpreter for some
+    predicate shapes, now handled (matching the F#/C/C++/R targets):
+    `switch_on_constant_fallthrough` (mixed fact+rule predicates such as
+    the factorial/Ackermann/Fibonacci base cases) reuses the
+    `SwitchOnConstant` instruction; `switch_on_term_a2` /
+    `switch_on_constant_a2` (+`_fallthrough`) second-argument indexing
+    (e.g. `member/2`) dispatch on the correct register via a new `reg`
+    field on the `SwitchOnConstant` / `SwitchOnTerm` runtime instructions
+    (defaulting to 1, so A1-indexed codegen is unchanged).
 - **Client-Server Phase 8: Service Tracing** - OpenTelemetry-compatible distributed tracing
   - `tracing(Bool)` option to enable distributed tracing
   - Trace exporters: `otlp`, `jaeger`, `zipkin`, `datadog`, `console`, `none`

--- a/docs/WAM_SCALA_TARGET.md
+++ b/docs/WAM_SCALA_TARGET.md
@@ -83,6 +83,46 @@ calling file.
 | `scala_foreign_handlers([handler(P/A, "<scala expr>"), ...])` | Inline Scala source for each foreign handler. |
 | `scala_fact_sources([source(P/A, Spec), ...])` | Declarative fact-source — auto-expands to `foreign_predicates` + `scala_foreign_handlers` + `intern_atoms`. See below. |
 | `intern_atoms([atom1, atom2, ...])` | Pre-intern atoms whose runtime identity matters but which don't appear in any compiled WAM body. |
+| `emit_mode(Mode)` | Code-generation mode. `interpreter` (default) — every predicate runs in the step-loop interpreter. `functions` — every lowerable predicate *also* gets a native Scala fast-path function. `mixed([P/A, ...])` — only the listed predicates are lowered. See [Lowered functions](#lowered-functions-emit_mode). |
+
+You can also set the mode globally without touching `Options` by asserting
+`user:wam_scala_emit_mode(functions).` before generating.
+
+### Lowered functions (`emit_mode`)
+
+In the default `interpreter` mode the generated program is a pure
+stepping WAM: every predicate is dispatched through `WamRuntime.step`.
+`emit_mode(functions)` brings the Scala target to parity with the
+Haskell / Rust / C++ / F# / Go / Clojure targets, all of which ship a
+per-predicate **lowered emitter**
+([wam_scala_lowered_emitter.pl](../src/unifyweaver/targets/wam_scala_lowered_emitter.pl)).
+
+For every lowerable predicate the codegen emits a native Scala function
+`lowered_<pred>_<arity>(s, program): Boolean` that runs the predicate's
+deterministic clause 1 directly — simple register operations are inlined
+as in-place mutations of the mutable `WamState`; failure-capable head
+unification and structure ops delegate to small `lo*` helpers on
+`WamRuntime`; deterministic builtins (`=/2`, `is/2`, the arithmetic
+comparisons, type checks, `!/0`) route through `loBuiltin`. The generated
+`loweredEntries` map registers an entry wrapper per predicate; `runEntry`
+tries the fast path first and **falls back to a fresh interpreter run
+when clause 1 misses**, so results are identical to the pure interpreter
+for any boolean query (a lowered `true` is always a real solution; a
+lowered `false` defers to the complete step loop, preserving
+first-argument indexing, clause 2+, and backtracking into
+nondeterministic sub-goals).
+
+```prolog
+write_wam_scala_project([user:ancestor/2],
+    [ package('demo.anc'), emit_mode(functions) ], '/tmp/anc').
+```
+
+A predicate is lowered only if its clause 1 is deterministic (no
+`try_me_else` / `retry_me_else` / `trust_me` inside the clause body) and
+every clause-1 instruction is supported; predicates whose clause 1 uses a
+nondeterministic builtin (`member/2`, `between/3`, `sort/2`, `findall/3`,
+…) stay in the interpreter. This mirrors the deterministic-clause-1
+contract of the Rust and Clojure lowered emitters.
 
 ### Fact-source spec forms
 
@@ -161,6 +201,12 @@ Two test suites live in [tests/](../tests/):
   — same gating; runs full Prolog programs (list reverse, naive
   reverse, Ackermann, Fibonacci) end-to-end and verifies known
   answers.
+- [test_wam_scala_lowered_emitter.pl](../tests/test_wam_scala_lowered_emitter.pl)
+  — structural tests for `emit_mode` resolution, predicate
+  partitioning and the generated lowered functions (always run) plus
+  gated runtime *parity* tests that compile the same predicates in both
+  `interpreter` and `functions` mode and assert identical, correct
+  results.
 
 Run them:
 

--- a/docs/WAM_TARGET_ROADMAP.md
+++ b/docs/WAM_TARGET_ROADMAP.md
@@ -106,7 +106,7 @@ on a specific architectural question.
 | **Elixir** | reference baseline | Phase 3/4 + comprehensive builtins | dual: WAM-instr + per-predicate emitter | FactSource facade (ETS/SQLite/TSV); no memory-mapped | none | LMDB integration (high-value for >100k); hot-path graph kernels |
 | **Haskell** | how to make materialisation cheap at scale | broad WAM, parMap parallel | dual: WAM-instr + emitter | LMDB key/value (memory-mapped under the hood); raw-pointer interface abandoned due to crashes | parMap rdeepseq | calibrate fork-min-cost like Elixir; investigate cost-aware probing |
 | **C#** | SQL/LINQ-as-substrate; the optimisation-inspiration target | broadest aggregate/join/negation coverage | LINQ pipeline (not WAM-shaped); split into `csharp_target` + `csharp_query_target` + `csharp_native_target` | source-mode sweeps measure cost; memory-mapped file in flight | n/a (LINQ-inspired lineage) | continue source-mode benchmark sweep; tighten cost model |
-| **Scala** | how aggressive can compile-time atom interning + classic-program coverage be | classic programs (n-queens, Ackermann, Fibonacci) — sets the generalisation upper bound | WAM-instruction lowering only; no `wam_scala_lowered_emitter.pl`; step-loop interpreter | 3 backends (inline / file CSV / grouped TSV); auto-inline ≤128 rows | none | add per-predicate native fast-path emitter (single biggest gap); port classics to other targets to validate generalisation |
+| **Scala** | how aggressive can compile-time atom interning + classic-program coverage be | classic programs (n-queens, Ackermann, Fibonacci) — sets the generalisation upper bound | dual: WAM-instr + per-predicate emitter (`wam_scala_lowered_emitter.pl`, `emit_mode(functions)`) — clause-1 fast path with interpreter fallback | 3 backends (inline / file CSV / grouped TSV); auto-inline ≤128 rows | none | hot-path graph kernels; LMDB sidecar (Phase S8); benchmark the lowered path against Elixir/Haskell |
 | **Clojure** | LMDB JNI integration as a first-class data tier | deterministic-prefix lowering; sequential-only tests | dual: WAM-instr + emitter (deterministic prefix only — no `switch_on_constant` lowering yet) | LMDB only (production-grade JNI loader, delay-wrapped) + cache policies (memoize / shared / two_level) | none | extend lowered emitter to non-deterministic prefixes; add parallelism gates |
 | **Rust** | hand-tuned FFI kernel route | deterministic only in lowered emitter | dual: WAM-instr + emitter (deterministic only) | absent (no FactSource facade); FFI kernels are ad-hoc | effective-distance matrix FFI kernel (concrete demonstration of kernel-based lowering wins) | port the kernel pattern to other targets; add layout policies / FactSource generalisation |
 | **F#** | Haskell-shaped target on the .NET runtime | mirrors Haskell coverage | dual: WAM-instr + emitter | none documented | TPL Parallel.map mentioned, no gating | follow Haskell's LMDB lessons + Elixir's cost-gate calibration |
@@ -146,11 +146,13 @@ haven't yet hit the kernel-or-LMDB inflection point.
    C# explore the LINQ side of the design space while WAM targets
    explore the bytecode side, and we can compare results.
 
-4. **Scala is the breadth-anchor and the dual-mode-emitter outlier.**
-   The classics suite (n-queens, Ackermann, Fibonacci) is the most
-   valuable generalisation test bed in the repo. Scala lacks the
-   per-predicate native fast-path emitter; adding one would let it
-   benchmark against Elixir/Haskell on the same basis.
+4. **Scala is the breadth-anchor.** The classics suite (n-queens,
+   Ackermann, Fibonacci) is the most valuable generalisation test bed in
+   the repo. Scala now has a per-predicate native fast-path emitter
+   (`wam_scala_lowered_emitter.pl`, opt-in via `emit_mode(functions)`),
+   closing the dual-mode-emitter gap and letting it benchmark against
+   Elixir/Haskell on the same basis. The next levers are hot-path graph
+   kernels and an LMDB sidecar.
 
    PR #1827 ports the **discipline** (subprocess invocation +
    true/false verification) to Elixir as a starter classic-programs

--- a/src/unifyweaver/targets/wam_scala_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_scala_lowered_emitter.pl
@@ -1,0 +1,435 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (@s243a)
+%
+% wam_scala_lowered_emitter.pl — WAM-lowered Scala emission
+%
+% Emits one Scala function per deterministic predicate, giving the Scala
+% hybrid WAM target the per-predicate native fast-path that the other
+% hybrid WAM targets (Haskell, Rust, C++, F#, Go, Clojure, Lua, Elixir,
+% R) already ship.  This closes the "single biggest gap" called out in
+% docs/WAM_TARGET_ROADMAP.md:
+%
+%   "Scala ... WAM-instruction lowering only; no wam_scala_lowered_emitter.pl;
+%    step-loop interpreter ... add per-predicate native fast-path emitter
+%    (single biggest gap)".
+%
+% Architecture — modelled on wam_rust_lowered_emitter.pl, because the
+% Scala runtime (like Rust's) is *imperative / mutable*: WamState is
+% mutated in place and `step` returns Unit, unlike the Haskell/F#
+% functional runtimes whose `step` returns an Option.  Each lowered
+% predicate becomes:
+%
+%     def lowered_<pred>_<arity>(s: WamState, program: WamProgram): Boolean
+%
+% Simple register operations (put_constant, put_value, get_variable, ...)
+% are inlined as direct mutations of `s`.  Failure-capable structure and
+% unification operations delegate to small `lo*` helper methods added to
+% WamRuntime (loGetConstant, loGetStructure, loUnifyVariable, ...), each
+% of which returns a Boolean and never calls `backtrack` — the lowered
+% function decides what to do on failure.  Deterministic builtins
+% (=/2, is/2, comparisons, type checks, !/0) route through loBuiltin/2.
+%
+% Determinism contract (identical to Rust/Clojure):
+%   - Only clause 1 of a predicate is lowered.  For a multi-clause
+%     predicate, clause 1 runs inline; on failure the function pushes a
+%     choice point for clause 2+ and backtracks into the interpreter.
+%   - A predicate is lowerable only if clause 1 is deterministic (no
+%     try/retry/trust *inside* clause 1) and every clause-1 instruction
+%     is supported.
+%   - Multi-clause predicates whose clause-1 body calls a *user*
+%     predicate are NOT lowered (keeps the choice-point stack clean for
+%     the backtrack-into-clause-2 fallback).  Single-clause bodies may
+%     call sub-predicates; the sub-call is delegated to the interpreter
+%     and its first solution is taken (deterministic-prefix semantics).
+%
+% See: src/unifyweaver/targets/wam_rust_lowered_emitter.pl  (primary model)
+%      src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl (multi-clause shape)
+
+:- module(wam_scala_lowered_emitter, [
+    wam_scala_lowerable/3,        % +PI, +WamCode, -Reason
+    lower_predicate_to_scala/4,   % +PI, +WamCode, +Options, -lowered(PredName, FuncName, Code)
+    is_deterministic_pred_scala/1,
+    scala_lowered_func_name/2     % +Pred/Arity, -Name
+]).
+
+:- use_module(library(lists)).
+:- use_module('../targets/wam_scala_target', [
+       scala_lowered_constant_term/2,
+       scala_lowered_functor_arity/3,
+       scala_lowered_reg_index/2,
+       scala_lowered_intern_atom/2
+   ]).
+
+% =====================================================================
+% Parsing — WAM text → instruction terms (target-agnostic format)
+% =====================================================================
+
+parse_wam_text_scala(WamText, Instrs) :-
+    atom_string(WamText, S),
+    split_string(S, "\n", "", Lines),
+    parse_lines_scala(Lines, Instrs).
+
+parse_lines_scala([], []).
+parse_lines_scala([Line|Rest], Instrs) :-
+    split_string(Line, " \t,", " \t,", Parts0),
+    delete(Parts0, "", Parts),
+    (   Parts == []
+    ->  parse_lines_scala(Rest, Instrs)
+    ;   Parts = [First|_],
+        sub_string(First, _, 1, 0, ":")
+    ->  parse_lines_scala(Rest, Instrs)      % label line — skip
+    ;   instr_from_parts_scala(Parts, Instr)
+    ->  Instrs = [Instr|More],
+        parse_lines_scala(Rest, More)
+    ;   parse_lines_scala(Rest, Instrs)      % unrecognised — skip
+    ).
+
+% Mirrors the token shapes wam_scala_target.pl already recognises.
+instr_from_parts_scala(["get_constant", C, Ai],   get_constant(C, Ai)).
+instr_from_parts_scala(["get_variable", Xn, Ai],  get_variable(Xn, Ai)).
+instr_from_parts_scala(["get_value", Xn, Ai],     get_value(Xn, Ai)).
+instr_from_parts_scala(["get_structure", F, Ai],  get_structure(F, Ai)).
+instr_from_parts_scala(["get_list", Ai],          get_list(Ai)).
+instr_from_parts_scala(["put_constant", C, Ai],   put_constant(C, Ai)).
+instr_from_parts_scala(["put_variable", Xn, Ai],  put_variable(Xn, Ai)).
+instr_from_parts_scala(["put_value", Xn, Ai],     put_value(Xn, Ai)).
+instr_from_parts_scala(["put_structure", F, Ai],  put_structure(F, Ai)).
+instr_from_parts_scala(["put_list", Ai],          put_list(Ai)).
+instr_from_parts_scala(["set_variable", Xn],      set_variable(Xn)).
+instr_from_parts_scala(["set_value", Xn],         set_value(Xn)).
+instr_from_parts_scala(["set_constant", C],       set_constant(C)).
+instr_from_parts_scala(["unify_variable", Xn],    unify_variable(Xn)).
+instr_from_parts_scala(["unify_value", Xn],       unify_value(Xn)).
+instr_from_parts_scala(["unify_constant", C],     unify_constant(C)).
+instr_from_parts_scala(["allocate"],              allocate).
+instr_from_parts_scala(["deallocate"],            deallocate).
+instr_from_parts_scala(["proceed"],               proceed).
+instr_from_parts_scala(["fail"],                  fail).
+instr_from_parts_scala(["try_me_else", L],        try_me_else(L)).
+instr_from_parts_scala(["retry_me_else", L],      retry_me_else(L)).
+instr_from_parts_scala(["trust_me"],              trust_me).
+instr_from_parts_scala(["jump", L],               jump(L)).
+% call/execute come in 2- or 3-token forms (name/arity in one token, or
+% name and arity split).  Normalise both to call(Name, Arity).
+instr_from_parts_scala(["call", PredArity],       call(Name, Arity)) :-
+    parse_pred_arity(PredArity, Name, Arity).
+instr_from_parts_scala(["call", Pred, ArityStr],  call(Name, Arity)) :-
+    number_string(Arity, ArityStr),
+    strip_arity_suffix_scala(Pred, Name).
+instr_from_parts_scala(["execute", PredArity],    execute(Name, Arity)) :-
+    parse_pred_arity(PredArity, Name, Arity).
+instr_from_parts_scala(["execute", Pred, ArityStr], execute(Name, Arity)) :-
+    number_string(Arity, ArityStr),
+    strip_arity_suffix_scala(Pred, Name).
+instr_from_parts_scala(["builtin_call", Pred, ArityStr], builtin_call(Pred, Arity)) :-
+    number_string(Arity, ArityStr).
+instr_from_parts_scala(["call_foreign", Pred, ArityStr], call_foreign(Pred, Arity)) :-
+    number_string(Arity, ArityStr).
+
+parse_pred_arity(PredArity, Name, Arity) :-
+    ( strip_arity_suffix_scala(PredArity, Name0), Name0 \== PredArity
+    ->  Name = Name0,
+        sub_string(PredArity, B, 1, _, "/"),
+        B1 is B + 1, sub_string(PredArity, B1, _, 0, AS),
+        number_string(Arity, AS)
+    ;   Name = PredArity, Arity = 0
+    ).
+
+strip_arity_suffix_scala(Pred, Name) :-
+    (   sub_string(Pred, B, 1, _, "/")
+    ->  sub_string(Pred, 0, B, _, Name)
+    ;   Name = Pred
+    ).
+
+% =====================================================================
+% Lowerability analysis
+% =====================================================================
+
+%% wam_scala_lowerable(+PI, +WamCode, -Reason) is semidet.
+%  Succeeds if the predicate's clause 1 is a deterministic body composed
+%  entirely of supported instructions.  Reason records whether the
+%  predicate is single- or multi-clause (informational only — the entry
+%  wrapper's interpreter fallback makes both shapes sound for boolean
+%  queries regardless of clause-1 sub-calls).
+wam_scala_lowerable(_PI, WamCode, Reason) :-
+    parse_wam_text_scala(WamCode, Instrs),
+    clause1_instrs_scala(Instrs, C1, MultiClause),
+    is_deterministic_pred_scala(C1),
+    forall(member(I, C1), scala_supported(I)),
+    ( MultiClause == true -> Reason = multi_clause_1 ; Reason = single_clause ).
+
+%% clause1_instrs_scala(+Instrs, -Clause1, -MultiClause)
+%  Extracts clause 1.  MultiClause is `true` when the predicate opens
+%  with a try_me_else chain, `false` otherwise.
+clause1_instrs_scala([try_me_else(_)|Rest], C1, true) :- !,
+    take_to_proceed_scala(Rest, C1).
+clause1_instrs_scala(Instrs, Instrs, false).
+
+take_to_proceed_scala([], []).
+take_to_proceed_scala([proceed|_], [proceed]) :- !.
+take_to_proceed_scala([fail|_], [fail]) :- !.
+take_to_proceed_scala([I|Rest], [I|More]) :- take_to_proceed_scala(Rest, More).
+
+%% is_deterministic_pred_scala(+Instrs)
+%  True if the clause-1 instruction list has no choice-point ops.
+is_deterministic_pred_scala(Instrs) :-
+    \+ member(try_me_else(_), Instrs),
+    \+ member(retry_me_else(_), Instrs),
+    \+ member(trust_me, Instrs).
+
+% Supported clause-1 instruction whitelist.
+scala_supported(get_constant(_, _)).
+scala_supported(get_variable(_, _)).
+scala_supported(get_value(_, _)).
+scala_supported(get_structure(_, _)).
+scala_supported(get_list(_)).
+scala_supported(put_constant(_, _)).
+scala_supported(put_variable(_, _)).
+scala_supported(put_value(_, _)).
+scala_supported(put_structure(_, _)).
+scala_supported(put_list(_)).
+scala_supported(set_variable(_)).
+scala_supported(set_value(_)).
+scala_supported(set_constant(_)).
+scala_supported(unify_variable(_)).
+scala_supported(unify_value(_)).
+scala_supported(unify_constant(_)).
+scala_supported(allocate).
+scala_supported(deallocate).
+scala_supported(proceed).
+scala_supported(fail).
+scala_supported(call(_, _)).
+scala_supported(execute(_, _)).
+% Only deterministic builtins may be lowered.  Nondeterministic builtins
+% (member/2, between/3, sort/2, findall, ...) keep the predicate in the
+% interpreter.
+scala_supported(builtin_call(Op, _)) :-
+    deterministic_builtin(Op).
+
+deterministic_builtin("=/2").
+deterministic_builtin("true/0").
+deterministic_builtin("fail/0").
+deterministic_builtin("!/0").
+deterministic_builtin("is/2").
+deterministic_builtin("=:=/2").
+deterministic_builtin("=\\=/2").
+deterministic_builtin("</2").
+deterministic_builtin(">/2").
+deterministic_builtin("=</2").
+deterministic_builtin(">=/2").
+deterministic_builtin("var/1").
+deterministic_builtin("nonvar/1").
+deterministic_builtin("atom/1").
+deterministic_builtin("number/1").
+deterministic_builtin("integer/1").
+deterministic_builtin("float/1").
+deterministic_builtin("atomic/1").
+
+% =====================================================================
+% Function name generation
+% =====================================================================
+
+%% scala_lowered_func_name(+Functor/Arity, -Name)
+%  foo/2 -> 'lowered_foo_2',  my$pred/3 -> 'lowered_my_pred_3'
+scala_lowered_func_name(Functor/Arity, Name) :-
+    atom_string(Functor, FStr),
+    sanitize_scala_ident(FStr, San),
+    format(atom(Name), 'lowered_~w_~w', [San, Arity]).
+
+sanitize_scala_ident(In, Out) :-
+    string_codes(In, Codes),
+    maplist(scala_safe_code, Codes, OutCodes),
+    string_codes(OutStr, OutCodes),
+    atom_string(Out, OutStr).
+
+scala_safe_code(C, C) :-
+    (   C >= 0'a, C =< 0'z -> true
+    ;   C >= 0'A, C =< 0'Z -> true
+    ;   C >= 0'0, C =< 0'9 -> true
+    ;   C =:= 0'_
+    ), !.
+scala_safe_code(_, 0'_).
+
+% =====================================================================
+% Emission
+% =====================================================================
+
+%% lower_predicate_to_scala(+PI, +WamCode, +Options, -lowered(PredName, FuncName, Code))
+%  PredName is the "pred/arity" key (used to register the lowered entry).
+%  FuncName is the generated Scala identifier.
+%  Code is the Scala source for the function definition(s).
+lower_predicate_to_scala(PI, WamCode, Options, lowered(PredName, FuncName, Code)) :-
+    ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
+    format(atom(PredName), '~w/~w', [Pred, Arity]),
+    scala_lowered_func_name(Pred/Arity, FuncName),
+    parse_wam_text_scala(WamCode, Instrs),
+    clause1_instrs_scala(Instrs, C1, MultiClause),
+    (   member(foreign_pred_keys(FK0), Options)
+    ->  maplist(foreign_key_atom, FK0, ForeignKeys)
+    ;   ForeignKeys = []
+    ),
+    with_output_to(string(Code),
+        emit_function_scala(FuncName, C1, MultiClause, ForeignKeys)).
+
+foreign_key_atom(K, A) :- ( atom(K) -> A = K ; atom_string(A, K) ).
+
+%% emit_function_scala(+FuncName, +Clause1, +MultiClause, +ForeignKeys)
+%  Both single- and multi-clause predicates emit the same shape: the
+%  function runs clause 1 inline on the supplied (already arg-loaded)
+%  state and returns whether clause 1 produced a solution.  The entry
+%  wrapper (generated in wam_scala_target.pl) is responsible for the
+%  interpreter fallback when this returns false:
+%
+%      if (lowered_p_a(s, prog)) true
+%      else WamRuntime.runPredicate(prog, startPc, args)   // fresh state
+%
+%  This is sound for boolean top-level queries: a `true` is always a real
+%  solution (clause 1 genuinely succeeded), and a `false` defers to the
+%  complete step-loop interpreter, so first-argument indexing, clause 2+,
+%  and backtracking into nondeterministic sub-goals are all handled there.
+%  `MultiClause` is accepted for signature symmetry but no longer changes
+%  the emission — the entry-wrapper fallback subsumes the old replay/CP
+%  juggling and is correct regardless of the predicate's indexing prefix.
+emit_function_scala(FuncName, C1, _MultiClause, FK) :-
+    format("  /** ~w — clause-1 fast path (generated); entry wrapper handles fallback. */~n", [FuncName]),
+    format("  def ~w(s: WamState, program: WamProgram): Boolean = {~n", [FuncName]),
+    emit_body_scala(C1, "    ", FK),
+    % Only emit the trailing `true` when control can fall off the end of
+    % the body. An execute (tail call) or fail emits its own `return`, so
+    % a trailing `true` there would be unreachable dead code.
+    (   body_falls_through(C1)
+    ->  format("    true~n", [])
+    ;   true
+    ),
+    format("  }~n", []).
+
+%% body_falls_through(+Clause1Instrs)
+%  False when the clause ends in a return-emitting terminal (execute/fail).
+body_falls_through(Instrs) :-
+    ( last(Instrs, Last) -> true ; Last = proceed ),
+    \+ ( Last = execute(_, _) ),
+    Last \== fail.
+
+%% emit_body_scala(+Instrs, +Indent, +ForeignKeys)
+emit_body_scala([], _, _).
+emit_body_scala([I|Rest], Ind, FK) :-
+    emit_one_scala(I, Ind, FK),
+    emit_body_scala(Rest, Ind, FK).
+
+% --- Terminal ---
+emit_one_scala(proceed, I, _) :-
+    format("~w// proceed (clause complete)~n", [I]).
+emit_one_scala(fail, I, _) :-
+    format("~wreturn false~n", [I]).
+
+% --- Head unification (get_*) ---
+emit_one_scala(get_constant(CStr, AiStr), I, _) :-
+    scala_lowered_reg_index(AiStr, Ai),
+    scala_lowered_constant_term(CStr, Term),
+    format("~wif (!WamRuntime.loGetConstant(s, ~w, ~w)) return false~n", [I, Term, Ai]).
+emit_one_scala(get_variable(XnStr, AiStr), I, _) :-
+    scala_lowered_reg_index(XnStr, Xn), scala_lowered_reg_index(AiStr, Ai),
+    format("~wWamRuntime.setReg(s, ~w, s.regs(~w))~n", [I, Xn, Ai]).
+emit_one_scala(get_value(XnStr, AiStr), I, _) :-
+    scala_lowered_reg_index(XnStr, Xn), scala_lowered_reg_index(AiStr, Ai),
+    format("~wif (!WamRuntime.loGetValue(s, ~w, ~w)) return false~n", [I, Xn, Ai]).
+emit_one_scala(get_structure(FStr, AiStr), I, _) :-
+    scala_lowered_reg_index(AiStr, Ai),
+    scala_lowered_functor_arity(FStr, FName, FArity),
+    scala_lowered_intern_atom(FName, FId),
+    format("~wif (!WamRuntime.loGetStructure(s, program, ~w, ~w, ~w)) return false~n",
+           [I, FId, Ai, FArity]).
+emit_one_scala(get_list(AiStr), I, _) :-
+    scala_lowered_reg_index(AiStr, Ai),
+    scala_lowered_intern_atom("[|]", ConsId),
+    format("~wif (!WamRuntime.loGetList(s, program, ~w, ~w)) return false~n", [I, Ai, ConsId]).
+
+% --- Body construction (put_*) ---
+emit_one_scala(put_constant(CStr, AiStr), I, _) :-
+    scala_lowered_reg_index(AiStr, Ai),
+    scala_lowered_constant_term(CStr, Term),
+    format("~wWamRuntime.setReg(s, ~w, ~w)~n", [I, Ai, Term]).
+emit_one_scala(put_variable(XnStr, AiStr), I, _) :-
+    scala_lowered_reg_index(XnStr, Xn), scala_lowered_reg_index(AiStr, Ai),
+    format("~w{ val v = WamRuntime.freshVar(s); WamRuntime.setReg(s, ~w, v); s.regs(~w) = v }~n",
+           [I, Xn, Ai]).
+emit_one_scala(put_value(XnStr, AiStr), I, _) :-
+    scala_lowered_reg_index(XnStr, Xn), scala_lowered_reg_index(AiStr, Ai),
+    format("~ws.regs(~w) = WamRuntime.deref(s.bindings, WamRuntime.getReg(s, ~w))~n", [I, Ai, Xn]).
+emit_one_scala(put_structure(FStr, AiStr), I, _) :-
+    scala_lowered_reg_index(AiStr, Ai),
+    scala_lowered_functor_arity(FStr, FName, FArity),
+    scala_lowered_intern_atom(FName, FId),
+    format("~wWamRuntime.loPutStructure(s, ~w, ~w, ~w)~n", [I, FId, Ai, FArity]).
+emit_one_scala(put_list(AiStr), I, _) :-
+    scala_lowered_reg_index(AiStr, Ai),
+    scala_lowered_intern_atom("[|]", ConsId),
+    format("~wWamRuntime.loPutList(s, ~w, ~w)~n", [I, Ai, ConsId]).
+
+% --- Set (write-mode, build frame) ---
+emit_one_scala(set_variable(XnStr), I, _) :-
+    scala_lowered_reg_index(XnStr, Xn),
+    format("~wif (!WamRuntime.loSetVariable(s, ~w)) return false~n", [I, Xn]).
+emit_one_scala(set_value(XnStr), I, _) :-
+    scala_lowered_reg_index(XnStr, Xn),
+    format("~wif (!WamRuntime.loSetValue(s, ~w)) return false~n", [I, Xn]).
+emit_one_scala(set_constant(CStr), I, _) :-
+    scala_lowered_constant_term(CStr, Term),
+    format("~wif (!WamRuntime.loSetConstant(s, ~w)) return false~n", [I, Term]).
+
+% --- Unify (read/write-mode) ---
+emit_one_scala(unify_variable(XnStr), I, _) :-
+    scala_lowered_reg_index(XnStr, Xn),
+    format("~wif (!WamRuntime.loUnifyVariable(s, ~w)) return false~n", [I, Xn]).
+emit_one_scala(unify_value(XnStr), I, _) :-
+    scala_lowered_reg_index(XnStr, Xn),
+    format("~wif (!WamRuntime.loUnifyValue(s, ~w)) return false~n", [I, Xn]).
+emit_one_scala(unify_constant(CStr), I, _) :-
+    scala_lowered_constant_term(CStr, Term),
+    format("~wif (!WamRuntime.loUnifyConstant(s, ~w)) return false~n", [I, Term]).
+
+% --- Environment ---
+emit_one_scala(allocate, I, _) :-
+    format("~wWamRuntime.loAllocate(s)~n", [I]).
+emit_one_scala(deallocate, I, _) :-
+    format("~wWamRuntime.loDeallocate(s)~n", [I]).
+
+% --- Builtins (deterministic allowlist) ---
+emit_one_scala(builtin_call(OpStr, _N), I, _) :-
+    scala_string_lit(OpStr, OpLit),
+    format("~wif (!WamRuntime.loBuiltin(s, program, ~w)) return false~n", [I, OpLit]).
+
+% --- Control: sub-calls delegate to the interpreter ---
+% loCall / loExecute resolve the target through program.dispatch and run
+% the interpreter, so they transparently handle both user predicates and
+% foreign-predicate stubs (which also have a dispatch entry).
+emit_one_scala(call(NameStr, Arity), I, _) :-
+    scala_string_lit(NameStr, NameLit),
+    format("~wif (!WamRuntime.loCall(s, program, ~w, ~w)) return false~n", [I, NameLit, Arity]).
+emit_one_scala(execute(NameStr, Arity), I, _) :-
+    scala_string_lit(NameStr, NameLit),
+    format("~wreturn WamRuntime.loExecute(s, program, ~w, ~w)~n", [I, NameLit, Arity]).
+
+% --- Choice/structural markers consumed during clause-1 lowering ---
+emit_one_scala(try_me_else(_), _, _) :- !.
+emit_one_scala(retry_me_else(_), _, _) :- !.
+emit_one_scala(trust_me, _, _) :- !.
+emit_one_scala(jump(_), _, _) :- !.
+
+% --- Fallback (should not be reached for lowerable predicates) ---
+emit_one_scala(Instr, I, _) :-
+    format("~w// TODO: unlowered instruction ~w~n", [I, Instr]).
+
+%% scala_string_lit(+Raw, -Quoted) — Scala double-quoted string literal.
+scala_string_lit(Raw, Quoted) :-
+    atom_string(Raw, S),
+    string_chars(S, Chars),
+    maplist(scala_escape_char, Chars, EscLists),
+    append(EscLists, EscChars),
+    string_chars(Body, EscChars),
+    format(string(Quoted), '"~w"', [Body]).
+
+scala_escape_char('\\', ['\\', '\\']) :- !.
+scala_escape_char('"',  ['\\', '"'])  :- !.
+scala_escape_char(C, [C]).

--- a/src/unifyweaver/targets/wam_scala_target.pl
+++ b/src/unifyweaver/targets/wam_scala_target.pl
@@ -20,7 +20,17 @@
 :- module(wam_scala_target, [
     compile_wam_predicate_to_scala/4,  % +Pred/Arity, +WamCode, +Options, -ScalaCode
     write_wam_scala_project/3,         % +Predicates, +Options, +ProjectDir
-    scala_foreign_predicate/3          % +Pred, +Arity, +Options
+    scala_foreign_predicate/3,         % +Pred, +Arity, +Options
+    % --- Hooks for the lowered emitter (wam_scala_lowered_emitter.pl) ---
+    % These expose the codegen-time atom interning / register / constant /
+    % functor helpers so the lowered emitter produces atom IDs and register
+    % indices that match the shared instruction array exactly.
+    scala_lowered_constant_term/2,     % +ConstTokenStr, -ScalaTermLiteral
+    scala_lowered_functor_arity/3,     % +FunctorTokenStr, -Name, -Arity
+    scala_lowered_reg_index/2,         % +RegNameStr, -IntIndex
+    scala_lowered_intern_atom/2,       % +AtomStr, -IntId
+    scala_resolve_emit_mode/2,         % +Options, -Mode
+    scala_partition_predicates/4       % +Mode, +Predicates, -Interp, -Lowered
 ]).
 
 :- use_module(library(lists)).
@@ -95,6 +105,20 @@ reg_to_int(Reg, Int) :-
     ;   Prefix == 'Y' -> Int is Num + 200
     ;   Int = 0
     ).
+
+% ============================================================================
+% LOWERED-EMITTER HOOKS
+% ============================================================================
+% Thin, exported wrappers around the codegen-time interning / register /
+% constant / functor helpers, so wam_scala_lowered_emitter.pl produces atom
+% IDs and register indices that match the shared instruction array.  They
+% MUST be called within the same intern-table session as the main program
+% emission (see compile_predicates_for_project/6) so the IDs line up.
+
+scala_lowered_reg_index(RegStr, Int)      :- reg_to_int(RegStr, Int).
+scala_lowered_constant_term(CStr, Term)   :- constant_to_scala_term(CStr, Term).
+scala_lowered_functor_arity(FStr, N, A)   :- parse_functor_arity(FStr, N, A).
+scala_lowered_intern_atom(AtomStr, Id)    :- intern_scala_atom(AtomStr, Id).
 
 % ============================================================================
 % WAM LINE → SCALA INSTRUCTION LITERAL
@@ -331,6 +355,17 @@ wam_parts_to_scala(["switch_on_constant" | Cases], Lit) :-
     atomic_list_concat(CaseLits, ', ', CasesStr),
     format(string(Lit), 'SwitchOnConstant(Array(~w))', [CasesStr]).
 
+% switch_on_constant_fallthrough is shape-compatible with switch_on_constant:
+% both match A1 against the listed constants and jump to the matching label
+% on a hit. The runtime's switchTarget already falls through to pc+1 on a
+% miss (or to a "default"-labelled case with targetPc = -1), which is exactly
+% fall-through semantics — so we reuse the SwitchOnConstant instruction.
+% Mirrors wam_fsharp_target.pl. Without this the instruction degraded to a
+% Raw(...) stub and broke first-argument-indexed predicates (e.g. the
+% mixed fact+rule shape of factorial/Ackermann/Fibonacci base cases).
+wam_parts_to_scala(["switch_on_constant_fallthrough" | Cases], Lit) :-
+    wam_parts_to_scala(["switch_on_constant" | Cases], Lit).
+
 % --- Switch on term (type-based dispatch) ---
 % First-arg type indexing emitted by the WAM compiler when a predicate
 % mixes constant, list, and compound first-arg shapes. Format:
@@ -341,7 +376,25 @@ wam_parts_to_scala(["switch_on_constant" | Cases], Lit) :-
 % `<functor>/<arity>:<label>`. ListLabel routes any cons cell ([|]/2).
 wam_parts_to_scala(["switch_on_term" | Rest], Lit) :-
     parse_switch_on_term_tokens(Rest, ConstCases, StructCases, ListLabel),
-    format_switch_on_term_lit(ConstCases, StructCases, ListLabel, Lit).
+    format_switch_on_term_lit(ConstCases, StructCases, ListLabel, 1, Lit).
+
+% A2-indexed variants. The WAM compiler emits the `_a2` family when it
+% indexes on the second argument (e.g. member/2's list arg). Same case
+% layout; only the indexed register differs (regs(2) instead of regs(1)).
+% Without these the instructions degraded to Raw(...) stubs and broke the
+% interpreter for A2-indexed predicates. Mirrors the F#/C/C++ targets.
+wam_parts_to_scala(["switch_on_term_a2" | Rest], Lit) :-
+    parse_switch_on_term_tokens(Rest, ConstCases, StructCases, ListLabel),
+    format_switch_on_term_lit(ConstCases, StructCases, ListLabel, 2, Lit).
+
+wam_parts_to_scala(["switch_on_constant_a2" | Cases], Lit) :-
+    normalize_switch_case_tokens(Cases, NormalizedCases),
+    parse_switch_cases(NormalizedCases, CaseLits),
+    atomic_list_concat(CaseLits, ', ', CasesStr),
+    format(string(Lit), 'SwitchOnConstant(Array(~w), 2)', [CasesStr]).
+
+wam_parts_to_scala(["switch_on_constant_a2_fallthrough" | Cases], Lit) :-
+    wam_parts_to_scala(["switch_on_constant_a2" | Cases], Lit).
 
 % --- ITE soft cut ---
 wam_parts_to_scala(["cut_ite"], 'CutIte').
@@ -492,14 +545,24 @@ split_at_first_colon(Token, Before, After) :-
     B1 is B + 1,
     sub_string(Token, B1, _, 0, After).
 
-format_switch_on_term_lit(ConstCases, StructCases, ListLabel, Lit) :-
+%% format_switch_on_term_lit(+ConstCases, +StructCases, +ListLabel, +Reg, -Lit)
+%  Reg selects the indexed argument register (1 for switch_on_term, 2 for
+%  switch_on_term_a2). The Scala SwitchOnTerm case class defaults reg to 1,
+%  so for Reg==1 we omit it (keeping output identical to the pre-A2 codegen)
+%  and for Reg==2 we pass it as a named argument.
+format_switch_on_term_lit(ConstCases, StructCases, ListLabel, Reg, Lit) :-
     maplist(const_case_lit, ConstCases, ConstLits),
     atomic_list_concat(ConstLits, ', ', ConstStr),
     maplist(struct_case_lit, StructCases, StructLits),
     atomic_list_concat(StructLits, ', ', StructStr),
-    format(string(Lit),
-           'SwitchOnTerm(Array(~w), Array(~w), "~w")',
-           [ConstStr, StructStr, ListLabel]).
+    (   Reg =:= 1
+    ->  format(string(Lit),
+               'SwitchOnTerm(Array(~w), Array(~w), "~w")',
+               [ConstStr, StructStr, ListLabel])
+    ;   format(string(Lit),
+               'SwitchOnTerm(Array(~w), Array(~w), "~w", reg = ~w)',
+               [ConstStr, StructStr, ListLabel, Reg])
+    ).
 
 const_case_lit(case(ValueLit, Label), Lit) :-
     format(string(Lit), 'TermSwitchConst(~w, "~w")', [ValueLit, Label]).
@@ -655,9 +718,12 @@ emit_scala_wrapper(Pred, Arity, StartPc, Code) :-
     maplist([N, Arg]>>(format(string(Arg), 'a~w', [N])), ArgNums, ArgNames),
     atomic_list_concat(ArgNames, ', ', ArgNameStr),
     scala_pred_name(Pred, ScalaName),
+    % Route through runEntry so a lowered fast path (when present) is used;
+    % runEntry falls back to runPredicate at StartPc otherwise. Behaviour is
+    % identical in interpreter mode (loweredEntries is empty).
     format(string(Code),
-           '  def ~w(~w): Boolean =\n    WamRuntime.runPredicate(sharedProgram, ~w, Array(~w))\n',
-           [ScalaName, ArgDeclStr, StartPc, ArgNameStr]).
+           '  def ~w(~w): Boolean =\n    runEntry("~w/~w", ~w, Array(~w))\n',
+           [ScalaName, ArgDeclStr, Pred, Arity, StartPc, ArgNameStr]).
 
 %% scala_pred_name(+PrologName, -ScalaName)
 %  Converts a Prolog predicate atom to a Scala camelCase identifier.
@@ -902,6 +968,11 @@ write_wam_scala_project(Predicates, Options0, ProjectDir) :-
     % --- Compile all predicates ---
     compile_predicates_for_project(Predicates, Options,
         AllInstrs, TopLevelLabelEntries, AllLabelEntries, WrapperCode),
+    % --- Lowered per-predicate fast-path functions (emit_mode functions/mixed).
+    %     Runs in the SAME intern-table session as the compile above so atom
+    %     IDs match the shared instruction array. Must precede emit_scala_intern_table/1
+    %     so any atom it interns is captured in the emitted seed array. --
+    scala_generate_lowered(Predicates, Options, LoweredFunctionsBody, LoweredEntriesBody),
     % --- Intern table ---
     emit_scala_intern_table(IdToStringStr),
     % --- Format instruction array body ---
@@ -922,7 +993,8 @@ write_wam_scala_project(Predicates, Options0, ProjectDir) :-
     write_program_source(ProjectDir, Pkg, RPkg,
                          InstrBody, LabelBody, DispatchBody,
                          WrapperCode, IdToStringStr,
-                         ForeignHandlersBody).
+                         ForeignHandlersBody,
+                         LoweredFunctionsBody, LoweredEntriesBody).
 
 write_build_sbt(ProjectDir, ModName) :-
     find_template('templates/targets/scala_wam/build.sbt.mustache', Template),
@@ -949,7 +1021,8 @@ write_runtime_source(ProjectDir, Package, _RuntimePkg) :-
 write_program_source(ProjectDir, Package, RuntimePkg,
                      InstrBody, LabelBody, DispatchBody,
                      WrapperCode, IdToStringStr,
-                     ForeignHandlersBody) :-
+                     ForeignHandlersBody,
+                     LoweredFunctionsBody, LoweredEntriesBody) :-
     find_template('templates/targets/scala_wam/program.scala.mustache', Template),
     get_time(T), format_time(string(DateStr), "%Y-%m-%d", T),
     render_template(Template,
@@ -961,11 +1034,109 @@ write_program_source(ProjectDir, Package, RuntimePkg,
           'dispatch'=DispatchBody,
           'wrappers'=WrapperCode,
           'intern_id_to_string'=IdToStringStr,
-          'foreign_handlers'=ForeignHandlersBody
+          'foreign_handlers'=ForeignHandlersBody,
+          'lowered_functions'=LoweredFunctionsBody,
+          'lowered_entries'=LoweredEntriesBody
         ], Content),
     scala_source_path(ProjectDir, Package, 'GeneratedProgram', Path),
     make_directory_path_for(Path),
     write_file(Path, Content).
+
+% ============================================================================
+% EMIT MODE + LOWERED-FUNCTION GENERATION
+% ============================================================================
+% Mirrors the dual-mode lowering seam in the F#/Rust/Haskell targets.
+%   emit_mode(interpreter)  — default; all predicates run in the step loop.
+%   emit_mode(functions)    — every lowerable predicate also gets a native
+%                             Scala fast-path function tried before the loop.
+%   emit_mode(mixed([P/A])) — only the listed predicates are lowered.
+% Resolution order: Options, then user:wam_scala_emit_mode/1, then default.
+
+:- multifile user:wam_scala_emit_mode/1.
+
+%% scala_resolve_emit_mode(+Options, -Mode)
+scala_resolve_emit_mode(Options, Mode) :-
+    (   option(emit_mode(M0), Options)
+    ->  scala_validate_emit_mode(M0, Mode)
+    ;   catch(user:wam_scala_emit_mode(M1), _, fail)
+    ->  scala_validate_emit_mode(M1, Mode)
+    ;   Mode = interpreter
+    ).
+
+scala_validate_emit_mode(interpreter, interpreter) :- !.
+scala_validate_emit_mode(functions,   functions)   :- !.
+scala_validate_emit_mode(mixed(L),    mixed(L))    :- is_list(L), !.
+scala_validate_emit_mode(Other, _) :-
+    throw(error(domain_error(wam_scala_emit_mode, Other),
+                scala_resolve_emit_mode/2)).
+
+%% scala_partition_predicates(+Mode, +Predicates, -Interpreted, -Lowered)
+scala_partition_predicates(interpreter, Predicates, Predicates, []) :- !.
+scala_partition_predicates(functions, Predicates, Interp, Lowered) :- !,
+    scala_partition_try_lower(Predicates, Interp, Lowered).
+scala_partition_predicates(mixed(Hot), Predicates, Interp, Lowered) :- !,
+    scala_partition_mixed(Predicates, Hot, Interp, Lowered).
+
+scala_partition_try_lower([], [], []).
+scala_partition_try_lower([P|Rest], Interp, Lowered) :-
+    (   scala_predicate_is_lowerable(P)
+    ->  Lowered = [P|LR], scala_partition_try_lower(Rest, Interp, LR)
+    ;   Interp = [P|IR], scala_partition_try_lower(Rest, IR, Lowered)
+    ).
+
+scala_partition_mixed([], _, [], []).
+scala_partition_mixed([P|Rest], Hot, Interp, Lowered) :-
+    (   scala_indicator_in_list(P, Hot),
+        scala_predicate_is_lowerable(P)
+    ->  Lowered = [P|LR], scala_partition_mixed(Rest, Hot, Interp, LR)
+    ;   Interp = [P|IR], scala_partition_mixed(Rest, Hot, IR, Lowered)
+    ).
+
+scala_indicator_in_list(P, L) :- memberchk(P, L), !.
+scala_indicator_in_list(_:Pred/Arity, L) :- memberchk(Pred/Arity, L), !.
+
+scala_predicate_is_lowerable(P) :-
+    catch(scala_predicate_wamcode(P, WamCode), _, fail),
+    catch(wam_scala_lowerable(P, WamCode, _), _, fail).
+
+scala_predicate_wamcode(user:Pred/Arity, WamCode) :- !,
+    compile_predicate_to_wam(Pred/Arity, [], WamCode).
+scala_predicate_wamcode(Module:Pred/Arity, WamCode) :- !,
+    compile_predicate_to_wam(Module:Pred/Arity, [], WamCode).
+scala_predicate_wamcode(Pred/Arity, WamCode) :-
+    compile_predicate_to_wam(Pred/Arity, [], WamCode).
+
+%% scala_generate_lowered(+Predicates, +Options, -FunctionsBody, -EntriesBody)
+%  Produces the Scala source for the lowered functions and the
+%  loweredEntries Map body. Empty strings in interpreter mode so the
+%  generated program is byte-identical to the pre-lowering output.
+scala_generate_lowered(Predicates, Options, FunctionsBody, EntriesBody) :-
+    scala_resolve_emit_mode(Options, Mode),
+    (   Mode == interpreter
+    ->  FunctionsBody = "", EntriesBody = ""
+    ;   scala_partition_predicates(Mode, Predicates, _Interp, Lowered0),
+        exclude(scala_pred_is_foreign(Options), Lowered0, Lowered),
+        scala_lower_each(Lowered, FuncCodes, Entries),
+        atomic_list_concat(FuncCodes, '\n', FunctionsBody),
+        atomic_list_concat(Entries, ',\n', EntriesBody)
+    ).
+
+scala_pred_is_foreign(Options, P) :-
+    ( P = _:Pred/Arity -> true ; P = Pred/Arity ),
+    scala_foreign_predicate(Pred, Arity, Options).
+
+scala_lower_each([], [], []).
+scala_lower_each([P|Rest], [Code|Cs], [Entry|Es]) :-
+    scala_predicate_wamcode(P, WamCode),
+    lower_predicate_to_scala(P, WamCode, [], lowered(PredKey, FuncName, Code)),
+    % Entry wrapper: try the lowered clause-1 fast path; on failure fall
+    % back to a fresh interpreter run of the same predicate. This keeps
+    % results identical to the pure interpreter (a lowered `false` defers
+    % to the complete step loop) while taking the fast path on success.
+    format(string(Entry),
+        '    "~w" -> ((prog: WamProgram, args: Array[WamTerm]) => { val startPc = prog.dispatch("~w"); if (~w(WamRuntime.newState(startPc, args), prog)) true else WamRuntime.runPredicate(prog, startPc, args) })',
+        [PredKey, PredKey, FuncName]),
+    scala_lower_each(Rest, Cs, Es).
 
 % ============================================================================
 % HELPERS
@@ -1002,3 +1173,15 @@ find_template(RelPath, Template) :-
     ;   AbsPath = RelPath
     ),
     read_file_to_string(AbsPath, Template, []).
+
+% ============================================================================
+% LOWERED EMITTER WIRING
+% ============================================================================
+% Loaded last so that, when wam_scala_lowered_emitter.pl re-imports the
+% scala_lowered_* hook predicates from this module, they are already defined.
+% The dependency is mutual (the emitter uses our hooks; we use its
+% lower_predicate_to_scala/4 + wam_scala_lowerable/3), so load order matters.
+:- use_module('../targets/wam_scala_lowered_emitter', [
+       wam_scala_lowerable/3,
+       lower_predicate_to_scala/4
+   ]).

--- a/templates/targets/scala_wam/program.scala.mustache
+++ b/templates/targets/scala_wam/program.scala.mustache
@@ -68,6 +68,30 @@ object GeneratedProgram {
 {{wrappers}}
 
   // ----------------------------------------------------------
+  // Lowered per-predicate fast-path functions (emit_mode functions/mixed)
+  // ----------------------------------------------------------
+  // Empty in interpreter mode. Each function bypasses the step-loop
+  // dispatch for its predicate's deterministic clause 1, falling back to
+  // the interpreter for clause 2+ / nondeterministic continuations.
+{{lowered_functions}}
+
+  // loweredEntries maps "pred/arity" -> an entry function that builds a
+  // fresh state at the predicate's start PC and runs the lowered fast path.
+  // Empty when emit_mode is interpreter, so runEntry just delegates to the
+  // interpreter and behaviour is identical to the non-lowered build.
+  val loweredEntries: Map[String, (WamProgram, Array[WamTerm]) => Boolean] = Map(
+{{lowered_entries}}
+  )
+
+  /** Run a top-level query, preferring the lowered fast path when one is
+   *  registered for `key`, otherwise the step-loop interpreter. */
+  def runEntry(key: String, startPc: Int, args: Array[WamTerm]): Boolean =
+    loweredEntries.get(key) match {
+      case Some(f) => f(sharedProgram, args)
+      case None    => WamRuntime.runPredicate(sharedProgram, startPc, args)
+    }
+
+  // ----------------------------------------------------------
   // Main entrypoint
   // ----------------------------------------------------------
 
@@ -104,7 +128,7 @@ object GeneratedProgram {
                     println(s"unknown:$key")
                   case Some(startPc) =>
                     val argRegs = rest.map(parseArg).toArray
-                    val ok = WamRuntime.runPredicate(sharedProgram, startPc, argRegs)
+                    val ok = runEntry(key, startPc, argRegs)
                     println(ok)
                 }
               case _ =>
@@ -130,14 +154,14 @@ object GeneratedProgram {
             val warmup = math.min(50, math.max(1, n / 20))
             var i = 0
             while (i < warmup) {
-              WamRuntime.runPredicate(sharedProgram, startPc, argTerms.clone())
+              runEntry(key, startPc, argTerms.clone())
               i += 1
             }
             val t0 = System.nanoTime()
             var last = false
             i = 0
             while (i < n) {
-              last = WamRuntime.runPredicate(sharedProgram, startPc, argTerms.clone())
+              last = runEntry(key, startPc, argTerms.clone())
               i += 1
             }
             val elapsed = (System.nanoTime() - t0) / 1.0e9
@@ -150,7 +174,7 @@ object GeneratedProgram {
             sys.exit(1)
           case Some(startPc) =>
             val argRegs = rest.map(parseArg).toArray
-            val result  = WamRuntime.runPredicate(sharedProgram, startPc, argRegs)
+            val result  = runEntry(key, startPc, argRegs)
             println(result)
         }
       case _ =>

--- a/templates/targets/scala_wam/runtime.scala.mustache
+++ b/templates/targets/scala_wam/runtime.scala.mustache
@@ -173,7 +173,10 @@ case class UnifyConstant(value: WamTerm)                extends Instruction
 // Choice
 case object TrustMe                                     extends Instruction
 // First-argument indexing
-case class SwitchOnConstant(cases: Array[SwitchCase])   extends Instruction
+// `reg` selects the indexed argument register: 1 for the A1-indexed
+// forms (switch_on_constant), 2 for the A2-indexed forms
+// (switch_on_constant_a2). Defaults to 1 so existing codegen is unchanged.
+case class SwitchOnConstant(cases: Array[SwitchCase], reg: Int = 1) extends Instruction
 // Type-based first-arg discrimination. Emitted when a predicate's
 // clauses mix const, list, and compound first args. Each TermSwitch*
 // case carries a target label resolved to a PC by resolveInstructions.
@@ -185,7 +188,8 @@ final case class TermSwitchStruct(functorId: Int, arity: Int, label: String, tar
 case class SwitchOnTerm(constCases:  Array[TermSwitchConst],
                         structCases: Array[TermSwitchStruct],
                         listLabel:   String,
-                        listTargetPc: Int = -1) extends Instruction
+                        listTargetPc: Int = -1,
+                        reg: Int = 1) extends Instruction
 // Builtins and foreign
 case class BuiltinCall(pred: String, arity: Int)        extends Instruction
 case class CallForeign(pred: String, arity: Int)        extends Instruction
@@ -566,13 +570,13 @@ object WamRuntime {
       case Try(lbl)              => labels.get(lbl).map(TryPc(_)).getOrElse(Try(lbl))
       case Retry(lbl)            => labels.get(lbl).map(RetryPc(_)).getOrElse(Retry(lbl))
       case Trust(lbl)            => labels.get(lbl).map(TrustPc(_)).getOrElse(Trust(lbl))
-      case SwitchOnConstant(cases) =>
+      case SwitchOnConstant(cases, reg) =>
         val resolved = cases.map { sc =>
           if (sc.label == "default") sc  // default = fallthrough (targetPc stays -1) or resolved below
           else labels.get(sc.label).map(pc => sc.copy(targetPc = pc)).getOrElse(sc)
         }
-        SwitchOnConstant(resolved)
-      case SwitchOnTerm(consts, structs, listLabel, _) =>
+        SwitchOnConstant(resolved, reg)
+      case SwitchOnTerm(consts, structs, listLabel, _, reg) =>
         val rConsts  = consts.map { c =>
           if (c.label == "default") c
           else labels.get(c.label).map(pc => c.copy(targetPc = pc)).getOrElse(c)
@@ -582,7 +586,7 @@ object WamRuntime {
           else labels.get(c.label).map(pc => c.copy(targetPc = pc)).getOrElse(c)
         }
         val rListPc  = labels.getOrElse(listLabel, -1)
-        SwitchOnTerm(rConsts, rStructs, listLabel, rListPc)
+        SwitchOnTerm(rConsts, rStructs, listLabel, rListPc, reg)
       case other => other
     }
 
@@ -926,8 +930,8 @@ object WamRuntime {
   // First-argument indexing
   // ----------------------------------------------------------
 
-  def switchTarget(s: WamState, cases: Array[SwitchCase]): Unit = {
-    val key = deref(s.bindings, s.regs(1))
+  def switchTarget(s: WamState, cases: Array[SwitchCase], reg: Int = 1): Unit = {
+    val key = deref(s.bindings, s.regs(reg))
     // Find every case (including "default"-labeled ones) whose value
     // matches the key. The WAM compiler emits a "default"-labeled case
     // for every value whose first matching clause sits at the head of
@@ -1238,11 +1242,12 @@ object WamRuntime {
 
       // --- Indexing ---
 
-      case SwitchOnConstant(cases) =>
-        switchTarget(s, cases)
+      case SwitchOnConstant(cases, reg) =>
+        switchTarget(s, cases, reg)
 
-      case SwitchOnTerm(consts, structs, _listLabel, listPc) =>
-        // Type-discriminating dispatch on regs(1):
+      case SwitchOnTerm(consts, structs, _listLabel, listPc, switchReg) =>
+        // Type-discriminating dispatch on regs(switchReg) (1 for A1-indexed
+        // forms, 2 for the _a2 forms):
         //   * Ref       → fall through (variable: any clause may match)
         //   * Atom/Int/Float → look up in const cases
         //   * Cons cell ([|]/2) → jump to listPc if set, else fall through
@@ -1250,7 +1255,7 @@ object WamRuntime {
         // "default" labels mean "fall through to the try_me_else chain
         // at pc + 1" — i.e. the WAM compiler is saying "I don't have a
         // single direct clause; let the chain enumerate".
-        val v = deref(s.bindings, s.regs(1))
+        val v = deref(s.bindings, s.regs(switchReg))
         v match {
           case Ref(_) =>
             s.pc += 1
@@ -2464,5 +2469,193 @@ object WamRuntime {
   def runPredicate(program: WamProgram, startPc: Int, argRegs: Array[WamTerm]): Boolean = {
     val s = newState(startPc, argRegs)
     run(s, program)
+  }
+
+  // ==========================================================
+  // Lowered fast-path primitives (Layer B′)
+  // ==========================================================
+  // Helper methods invoked by the per-predicate functions emitted by
+  // wam_scala_lowered_emitter.pl (emit_mode functions / mixed). Each one
+  // performs the forward semantics of the corresponding `step` case but
+  // returns a Boolean instead of calling `backtrack` — the lowered
+  // function decides what to do on failure. No method here advances
+  // `s.pc`; the lowered function controls its own straight-line flow.
+
+  /** get_constant: bind an unbound register or unify against its value. */
+  def loGetConstant(s: WamState, value: WamTerm, reg: Int): Boolean = {
+    val current = deref(s.bindings, s.regs(reg))
+    if (current == null) { s.regs(reg) = value; true }
+    else unify(s, current, value)
+  }
+
+  /** get_value: unify two registers' dereferenced values. */
+  def loGetValue(s: WamState, varReg: Int, argReg: Int): Boolean =
+    unify(s, deref(s.bindings, getReg(s, varReg)), deref(s.bindings, s.regs(argReg)))
+
+  /** get_structure: read-mode against a matching Struct, write-mode against
+   *  an unbound Ref. Arity is supplied by codegen (no peek-ahead needed). */
+  def loGetStructure(s: WamState, program: WamProgram, functorId: Int, reg: Int, arity: Int): Boolean = {
+    deref(s.bindings, s.regs(reg)) match {
+      case Struct(f, _, args) if f == functorId =>
+        s.unifyMode = true; s.unifyQueue = args.toList; true
+      case Ref(_) =>
+        s.buildStack = BuildFrame(reg, functorId, arity, Nil) :: s.buildStack
+        s.unifyMode = false; true
+      case _ => false
+    }
+  }
+
+  /** get_list: read-mode against a cons Struct, write-mode against a Ref. */
+  def loGetList(s: WamState, program: WamProgram, reg: Int, consId: Int): Boolean = {
+    deref(s.bindings, s.regs(reg)) match {
+      case Struct(f, 2, args) if f == consId =>
+        s.unifyMode = true; s.unifyQueue = args.toList; true
+      case Ref(_) =>
+        s.buildStack = BuildFrame(reg, consId, 2, Nil) :: s.buildStack
+        s.unifyMode = false; true
+      case _ => false
+    }
+  }
+
+  /** unify_variable: read-mode pops the queue into reg; write-mode appends
+   *  a fresh var to the active build frame. */
+  def loUnifyVariable(s: WamState, reg: Int): Boolean = {
+    if (s.unifyMode) s.unifyQueue match {
+      case Nil => false
+      case item :: rest => setReg(s, reg, item); s.unifyQueue = rest; true
+    } else {
+      val v = freshVar(s); setReg(s, reg, v); appendBuildArg(s, v); true
+    }
+  }
+
+  /** unify_value: read-mode unifies reg with the queue head; write-mode
+   *  appends reg's value to the build frame. */
+  def loUnifyValue(s: WamState, reg: Int): Boolean = {
+    if (s.unifyMode) s.unifyQueue match {
+      case Nil => false
+      case item :: rest =>
+        val ok = unify(s, deref(s.bindings, getReg(s, reg)), item)
+        s.unifyQueue = rest; ok
+    } else {
+      appendBuildArg(s, deref(s.bindings, getReg(s, reg))); true
+    }
+  }
+
+  /** unify_constant: read-mode unifies the queue head with the constant;
+   *  write-mode appends the constant to the build frame. */
+  def loUnifyConstant(s: WamState, value: WamTerm): Boolean = {
+    if (s.unifyMode) s.unifyQueue match {
+      case Nil => false
+      case item :: rest =>
+        val ok = unify(s, deref(s.bindings, item), value)
+        s.unifyQueue = rest; ok
+    } else {
+      appendBuildArg(s, value); true
+    }
+  }
+
+  /** set_variable: fresh var into reg + build frame (always succeeds). */
+  def loSetVariable(s: WamState, reg: Int): Boolean = {
+    val v = freshVar(s); setReg(s, reg, v); appendBuildArg(s, v); true
+  }
+
+  /** set_value: reg's value appended to the build frame. */
+  def loSetValue(s: WamState, reg: Int): Boolean = {
+    appendBuildArg(s, deref(s.bindings, getReg(s, reg))); true
+  }
+
+  /** set_constant: constant appended to the build frame. */
+  def loSetConstant(s: WamState, value: WamTerm): Boolean = {
+    appendBuildArg(s, value); true
+  }
+
+  /** put_structure: open a new struct build frame (write mode). */
+  def loPutStructure(s: WamState, functorId: Int, reg: Int, sArity: Int): Unit =
+    s.buildStack = BuildFrame(reg, functorId, sArity, Nil) :: s.buildStack
+
+  /** put_list: open a new cons build frame (write mode). */
+  def loPutList(s: WamState, reg: Int, consId: Int): Unit =
+    s.buildStack = BuildFrame(reg, consId, 2, Nil) :: s.buildStack
+
+  /** allocate: push an environment frame, set the cut barrier. */
+  def loAllocate(s: WamState): Unit = {
+    val frame = EnvFrame(new Array[WamTerm](100))
+    var i = 201
+    while (i < 300) { if (s.regs(i) != null) frame.savedRegs(i - 200) = s.regs(i); i += 1 }
+    s.envStack = frame :: s.envStack
+    s.cutBar = s.choicePoints.length
+  }
+
+  /** deallocate: pop the top environment frame. */
+  def loDeallocate(s: WamState): Unit =
+    s.envStack = s.envStack.drop(1)
+
+  /** Deterministic builtins. Returns success/failure without backtracking.
+   *  Only the operators the lowered emitter whitelists reach here. */
+  def loBuiltin(s: WamState, program: WamProgram, pred: String): Boolean = {
+    def cmp(op: (Num, Num) => Boolean): Boolean =
+      (evalArith(s, program, s.regs(1)), evalArith(s, program, s.regs(2))) match {
+        case (Some(a), Some(b)) => op(a, b)
+        case _                  => false
+      }
+    pred match {
+      case "=/2"    => unify(s, deref(s.bindings, s.regs(1)), deref(s.bindings, s.regs(2)))
+      case "true/0" => true
+      case "fail/0" => false
+      case "!/0" =>
+        val len = s.choicePoints.length
+        if (len > s.cutBar) s.choicePoints.remove(s.cutBar, len - s.cutBar)
+        true
+      case "is/2" =>
+        evalArith(s, program, s.regs(2)) match {
+          case Some(n) => unify(s, s.regs(1), numToTerm(n))
+          case None    => false
+        }
+      case "=:=/2"  => cmp(numEq)
+      case "=\\=/2" => cmp((a, b) => !numEq(a, b))
+      case "</2"    => cmp(numLt)
+      case ">/2"    => cmp((a, b) => numLt(b, a))
+      case "=</2"   => cmp((a, b) => !numLt(b, a))
+      case ">=/2"   => cmp((a, b) => !numLt(a, b))
+      case "var/1"     => deref(s.bindings, s.regs(1)) match { case Ref(_) => true; case _ => false }
+      case "nonvar/1"  => deref(s.bindings, s.regs(1)) match { case Ref(_) => false; case _ => true }
+      case "atom/1"    => deref(s.bindings, s.regs(1)) match { case Atom(_) => true; case _ => false }
+      case "integer/1" => deref(s.bindings, s.regs(1)) match { case IntTerm(_) => true; case _ => false }
+      case "float/1"   => deref(s.bindings, s.regs(1)) match { case FloatTerm(_) => true; case _ => false }
+      case "number/1"  => deref(s.bindings, s.regs(1)) match { case IntTerm(_) | FloatTerm(_) => true; case _ => false }
+      case "atomic/1"  => deref(s.bindings, s.regs(1)) match { case Atom(_) | IntTerm(_) | FloatTerm(_) => true; case _ => false }
+      case _ => false
+    }
+  }
+
+  /** call: run a sub-predicate to its first solution, then continue the
+   *  lowered body. Resolves through dispatch, so it transparently handles
+   *  foreign-predicate stubs too. Deterministic-prefix semantics: only the
+   *  first solution is taken (matches the Rust/Clojure lowered contract). */
+  def loCall(s: WamState, program: WamProgram, name: String, arity: Int): Boolean = {
+    program.dispatch.get(s"$name/$arity") match {
+      case None => false
+      case Some(pc) =>
+        val savedCS = s.callStack
+        s.callStack = Nil
+        s.pc = pc
+        s.status = Running
+        val ok = run(s, program)
+        s.callStack = savedCS
+        s.status = Running
+        ok
+    }
+  }
+
+  /** execute: tail call into a sub-predicate; its result is this clause's
+   *  result. */
+  def loExecute(s: WamState, program: WamProgram, name: String, arity: Int): Boolean = {
+    program.dispatch.get(s"$name/$arity") match {
+      case None => false
+      case Some(pc) =>
+        s.pc = pc
+        s.status = Running
+        run(s, program)
+    }
   }
 }

--- a/tests/test_wam_scala_lowered_emitter.pl
+++ b/tests/test_wam_scala_lowered_emitter.pl
@@ -1,0 +1,322 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (@s243a)
+%
+% test_wam_scala_lowered_emitter.pl
+%
+% Tests for the WAM Scala per-predicate lowered emitter
+% (wam_scala_lowered_emitter.pl), the feature that brings the Scala
+% hybrid WAM target to parity with the Haskell/Rust/C++/F#/Go/Clojure
+% targets — all of which ship a `wam_*_lowered_emitter.pl`.
+%
+% Two suites:
+%   wam_scala_lowered_structural  — always runs.  Exercises emit-mode
+%       resolution, predicate partitioning, lowerability analysis, and
+%       the generated source (lowered functions + loweredEntries map).
+%   wam_scala_lowered_runtime     — gated on scalac/scala (or
+%       SCALA_SMOKE_TESTS=1).  Generates the SAME predicates in both
+%       interpreter and functions mode, compiles both, and asserts that
+%       every query yields identical AND correct results — i.e. the
+%       lowered fast path is behaviour-preserving.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_scala_target').
+:- use_module('../src/unifyweaver/targets/wam_scala_lowered_emitter').
+
+% ============================================================
+% Sample predicates
+% ============================================================
+
+:- dynamic user:lp_fact/2.
+:- dynamic user:lp_edge/2.
+:- dynamic user:lp_append/3.
+:- dynamic user:lp_member/2.
+:- dynamic user:lp_len/2.
+
+% Factorial — arithmetic recursion (is/2, >/2, recursive call).
+user:lp_fact(0, 1).
+user:lp_fact(N, F) :- N > 0, N1 is N - 1, lp_fact(N1, F1), F is N * F1.
+
+% Facts — first-argument indexed, multi-clause, deterministic.
+user:lp_edge(a, b).
+user:lp_edge(b, c).
+user:lp_edge(c, d).
+
+% append/3 — list recursion (get_list / unify_* read+write modes).
+user:lp_append([], L, L).
+user:lp_append([H|T], L, [H|R]) :- lp_append(T, L, R).
+
+% member/2 — NONdeterministic builtin in the body; must NOT be lowered
+% as a deterministic fast path (it relies on the interpreter's
+% choice points). Used to verify the partition keeps it interpreted.
+user:lp_member(X, [X|_]).
+user:lp_member(X, [_|T]) :- lp_member(X, T).
+
+% length/2 via accumulator — deterministic in (+,?) mode.
+user:lp_len([], 0).
+user:lp_len([_|T], N) :- lp_len(T, N0), N is N0 + 1.
+
+% ============================================================
+% Structural suite (always runs)
+% ============================================================
+
+:- begin_tests(wam_scala_lowered_structural).
+
+% --- emit-mode resolution ---------------------------------
+
+test(emit_mode_default_interpreter) :-
+    scala_resolve_emit_mode([], Mode),
+    assertion(Mode == interpreter).
+
+test(emit_mode_functions) :-
+    scala_resolve_emit_mode([emit_mode(functions)], Mode),
+    assertion(Mode == functions).
+
+test(emit_mode_mixed) :-
+    scala_resolve_emit_mode([emit_mode(mixed([lp_fact/2]))], Mode),
+    assertion(Mode == mixed([lp_fact/2])).
+
+test(emit_mode_invalid_throws, throws(_)) :-
+    scala_resolve_emit_mode([emit_mode(nonsense)], _).
+
+% --- lowerability analysis --------------------------------
+
+test(fact_is_lowerable) :-
+    wam_predicate_wamcode(user:lp_fact/2, Code),
+    assertion(wam_scala_lowerable(user:lp_fact/2, Code, _)).
+
+test(edge_is_lowerable) :-
+    wam_predicate_wamcode(user:lp_edge/2, Code),
+    assertion(wam_scala_lowerable(user:lp_edge/2, Code, _)).
+
+test(append_is_lowerable) :-
+    wam_predicate_wamcode(user:lp_append/3, Code),
+    assertion(wam_scala_lowerable(user:lp_append/3, Code, _)).
+
+% member/2's clause 1 is just a head match (no nondeterministic builtin),
+% so it IS lowerable; the entry wrapper's interpreter fallback preserves
+% the multi-solution semantics.  This documents that lowerability is a
+% clause-1 property, not a whole-predicate determinism claim.
+test(member_clause1_lowerable) :-
+    wam_predicate_wamcode(user:lp_member/2, Code),
+    assertion(wam_scala_lowerable(user:lp_member/2, Code, _)).
+
+% --- partition --------------------------------------------
+
+test(partition_interpreter_keeps_all) :-
+    scala_partition_predicates(interpreter,
+        [user:lp_fact/2, user:lp_edge/2], Interp, Lowered),
+    assertion(Interp == [user:lp_fact/2, user:lp_edge/2]),
+    assertion(Lowered == []).
+
+test(partition_functions_lowers_deterministic) :-
+    scala_partition_predicates(functions,
+        [user:lp_fact/2, user:lp_edge/2, user:lp_append/3],
+        _Interp, Lowered),
+    assertion(memberchk(user:lp_fact/2, Lowered)),
+    assertion(memberchk(user:lp_edge/2, Lowered)),
+    assertion(memberchk(user:lp_append/3, Lowered)).
+
+test(partition_mixed_only_listed) :-
+    scala_partition_predicates(mixed([lp_fact/2]),
+        [user:lp_fact/2, user:lp_edge/2], Interp, Lowered),
+    assertion(memberchk(user:lp_fact/2, Lowered)),
+    assertion(memberchk(user:lp_edge/2, Interp)),
+    assertion(\+ memberchk(user:lp_edge/2, Lowered)).
+
+% --- function-name generation -----------------------------
+
+test(func_name_sanitized) :-
+    scala_lowered_func_name(lp_fact/2, N1),
+    assertion(N1 == 'lowered_lp_fact_2'),
+    scala_lowered_func_name('weird$name'/3, N2),
+    assertion(N2 == 'lowered_weird_name_3').
+
+% --- generated source: functions mode ---------------------
+
+test(functions_mode_emits_lowered_code) :-
+    once((
+        tmp_dir('tmp_scala_low_fn', Dir),
+        write_wam_scala_project(
+            [user:lp_fact/2, user:lp_edge/2],
+            [ package('gen.low.core'), runtime_package('gen.low.core'),
+              module_name('low'), emit_mode(functions) ],
+            Dir),
+        program_source(Dir, 'gen.low.core', Src),
+        assertion(sub_string(Src, _, _, _, "def lowered_lp_fact_2")),
+        assertion(sub_string(Src, _, _, _, "def lowered_lp_edge_2")),
+        % loweredEntries holds real entry wrappers (the "-> ((prog:" form
+        % is unique to lowered entries; the dispatch/labels maps use plain
+        % "-> <Int>").
+        assertion(sub_string(Src, _, _, _, "\"lp_fact/2\" -> ((prog: WamProgram")),
+        assertion(sub_string(Src, _, _, _, "loweredEntries")),
+        % The entry wrapper falls back to the interpreter on a miss.
+        assertion(sub_string(Src, _, _, _, "WamRuntime.runPredicate(prog, startPc, args)")),
+        delete_directory_and_contents(Dir)
+    )).
+
+% --- generated source: interpreter mode (default) ---------
+% Must be behaviourally identical to the pre-lowering target: no lowered
+% functions, and an EMPTY loweredEntries map so runEntry just delegates.
+
+test(interpreter_mode_has_empty_lowered) :-
+    once((
+        tmp_dir('tmp_scala_low_it', Dir),
+        write_wam_scala_project(
+            [user:lp_fact/2, user:lp_edge/2],
+            [ package('gen.it.core'), runtime_package('gen.it.core'),
+              module_name('it') ],
+            Dir),
+        program_source(Dir, 'gen.it.core', Src),
+        assertion(\+ sub_string(Src, _, _, _, "def lowered_lp_fact_2")),
+        % loweredEntries present (always) but with no entry wrappers.
+        assertion(sub_string(Src, _, _, _, "loweredEntries")),
+        assertion(\+ sub_string(Src, _, _, _, "-> ((prog: WamProgram")),
+        delete_directory_and_contents(Dir)
+    )).
+
+:- end_tests(wam_scala_lowered_structural).
+
+% ============================================================
+% Runtime parity suite (gated on scalac/scala)
+% ============================================================
+
+:- begin_tests(wam_scala_lowered_runtime,
+               [condition(scala_available)]).
+
+% lp_edge/2 — facts.  Identical results across modes, all correct.
+test(edge_parity,
+     [setup(with_both_modes([user:lp_edge/2], 'gen.edge', Run)),
+      cleanup(cleanup_run(Run))]) :-
+    assert_same_and(Run, 'lp_edge/2', [a,b], "true"),
+    assert_same_and(Run, 'lp_edge/2', [b,c], "true"),
+    assert_same_and(Run, 'lp_edge/2', [c,d], "true"),
+    assert_same_and(Run, 'lp_edge/2', [a,c], "false"),
+    assert_same_and(Run, 'lp_edge/2', [x,y], "false").
+
+% lp_fact/2 — arithmetic recursion (exercises is/2, >/2, recursive call,
+% and the switch_on_constant_fallthrough first-arg index prefix).
+test(fact_parity,
+     [setup(with_both_modes([user:lp_fact/2], 'gen.fact', Run)),
+      cleanup(cleanup_run(Run))]) :-
+    assert_same_and(Run, 'lp_fact/2', ['0','1'],   "true"),
+    assert_same_and(Run, 'lp_fact/2', ['5','120'], "true"),
+    assert_same_and(Run, 'lp_fact/2', ['6','720'], "true"),
+    assert_same_and(Run, 'lp_fact/2', ['5','121'], "false").
+
+% lp_append/3 — list recursion (get_list, unify_* read+write).
+test(append_parity,
+     [setup(with_both_modes([user:lp_append/3], 'gen.app', Run)),
+      cleanup(cleanup_run(Run))]) :-
+    assert_same_and(Run, 'lp_append/3', ['[a,b]','[c]','[a,b,c]'], "true"),
+    assert_same_and(Run, 'lp_append/3', ['[]','[c]','[c]'],        "true"),
+    assert_same_and(Run, 'lp_append/3', ['[a]','[b]','[a,x]'],     "false").
+
+% lp_member/2 — nondeterministic; the lowered fast path's clause-1 miss
+% must fall back to the interpreter so later list elements still match.
+test(member_parity,
+     [setup(with_both_modes([user:lp_member/2], 'gen.mem', Run)),
+      cleanup(cleanup_run(Run))]) :-
+    assert_same_and(Run, 'lp_member/2', [a, '[a,b,c]'], "true"),
+    assert_same_and(Run, 'lp_member/2', [c, '[a,b,c]'], "true"),
+    assert_same_and(Run, 'lp_member/2', [z, '[a,b,c]'], "false").
+
+:- end_tests(wam_scala_lowered_runtime).
+
+% ============================================================
+% Helpers
+% ============================================================
+
+scala_available :-
+    (   getenv('SCALA_SMOKE_TESTS', "1") -> true
+    ;   catch(
+            process_create(path(scalac), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            _, fail),
+        process_wait(Pid, exit(0))
+    ).
+
+wam_predicate_wamcode(user:Pred/Arity, Code) :- !,
+    wam_target:compile_predicate_to_wam(Pred/Arity, [], Code).
+wam_predicate_wamcode(PI, Code) :-
+    wam_target:compile_predicate_to_wam(PI, [], Code).
+
+tmp_dir(Prefix, Dir) :-
+    get_time(T), Stamp is floor(T * 1000),
+    format(atom(Dir), '~w_~w', [Prefix, Stamp]).
+
+%% program_source(+Dir, +Package, -Src)
+program_source(Dir, Package, Src) :-
+    atom_string(Package, PkgStr),
+    split_string(PkgStr, ".", "", Parts),
+    atomic_list_concat(Parts, '/', PkgPath),
+    format(atom(Rel), 'src/main/scala/~w/GeneratedProgram.scala', [PkgPath]),
+    directory_file_path(Dir, Rel, Path),
+    read_file_to_string(Path, Src, []).
+
+%% with_both_modes(+Preds, +PkgBase, -Run)
+%  Generates and compiles the predicates twice (interpreter + functions
+%  mode), returning a closure descriptor Run = run(InterpDir, FnDir, Pkg)
+%  for assert_same_and/4 to invoke. Cleanup is deferred to the caller via
+%  the dynamic registry so test bodies stay readable; we clean eagerly
+%  inside assert_same_and's owner instead — here we just build dirs.
+with_both_modes(Preds, PkgBase, run(ItDir, FnDir, ItPkg, FnPkg)) :-
+    format(atom(ItPkg), '~w.it.core', [PkgBase]),
+    format(atom(FnPkg), '~w.fn.core', [PkgBase]),
+    tmp_dir('tmp_scala_pit', ItDir),
+    tmp_dir('tmp_scala_pfn', FnDir),
+    write_wam_scala_project(Preds,
+        [package(ItPkg), runtime_package(ItPkg), module_name('pit')], ItDir),
+    write_wam_scala_project(Preds,
+        [package(FnPkg), runtime_package(FnPkg), module_name('pfn'),
+         emit_mode(functions)], FnDir),
+    compile_project(ItDir),
+    compile_project(FnDir).
+
+%% assert_same_and(+Run, +PredKey, +Args, +Expected)
+%  Runs PredKey(Args) in both the interpreter and functions builds,
+%  asserting they agree with each other AND with Expected.
+assert_same_and(run(ItDir, FnDir, ItPkg, FnPkg), PredKey, Args, Expected) :-
+    run_query(ItDir, ItPkg, PredKey, Args, ItOut),
+    run_query(FnDir, FnPkg, PredKey, Args, FnOut),
+    (   ItOut == FnOut, ItOut == Expected
+    ->  true
+    ;   throw(error(parity_mismatch(PredKey, Args,
+                expected(Expected), interp(ItOut), functions(FnOut)), _))
+    ).
+
+cleanup_run(run(ItDir, FnDir, _, _)) :-
+    ignore(delete_directory_and_contents(ItDir)),
+    ignore(delete_directory_and_contents(FnDir)).
+
+compile_project(Dir) :-
+    absolute_file_name(Dir, AbsDir),
+    directory_file_path(AbsDir, 'classes', ClassDir),
+    make_directory_path(ClassDir),
+    findall(F,
+        ( directory_member(AbsDir, RelF,
+              [extensions([scala]), recursive(true)]),
+          directory_file_path(AbsDir, RelF, F)
+        ), Sources),
+    Sources \= [],
+    process_create(path(scalac), ['-d', ClassDir | Sources],
+        [cwd(AbsDir), stdout(pipe(O)), stderr(pipe(E)), process(Pid)]),
+    read_string(O, _, _), read_string(E, _, Err), close(O), close(E),
+    process_wait(Pid, exit(Code)),
+    (   Code =:= 0 -> true
+    ;   throw(error(scala_compile_failed(Dir, Code, Err), _))
+    ).
+
+run_query(Dir, Package, PredKey, Args, Output) :-
+    absolute_file_name(Dir, AbsDir),
+    directory_file_path(AbsDir, 'classes', ClassDir),
+    format(atom(Main), '~w.GeneratedProgram', [Package]),
+    atom_string(PredKey, PredStr),
+    maplist([A,S]>>atom_string(A,S), Args, ArgStrs),
+    append(['-classpath', ClassDir, Main, PredStr], ArgStrs, ProcArgs),
+    process_create(path(scala), ProcArgs,
+        [cwd(AbsDir), stdout(pipe(O)), stderr(pipe(E)), process(Pid)]),
+    read_string(O, _, Out0), read_string(E, _, _), close(O), close(E),
+    process_wait(Pid, exit(_)),
+    normalize_space(string(Output), Out0).


### PR DESCRIPTION
Brings the Scala hybrid WAM target to parity with the Haskell/Rust/C++/
F#/Go/Clojure/Lua/Elixir targets, all of which already shipped a
wam_*_lowered_emitter.pl. This closes the gap the roadmap named as
Scala's "single biggest gap": WAM-instruction lowering only, no
per-predicate native fast-path emitter.

New wam_scala_lowered_emitter.pl emits a native Scala
lowered_<pred>_<arity>(s, program): Boolean per lowerable predicate
(deterministic clause 1; simple register ops inlined as in-place
WamState mutations, structure/unify ops via new lo* WamRuntime helpers,
deterministic builtins via loBuiltin). Modelled on the Rust emitter
since the Scala runtime is imperative/mutable.

New emit_mode(Mode) option on write_wam_scala_project/3 (interpreter
default / functions / mixed([P/A,...])) plus a user:wam_scala_emit_mode/1
hook. The generated loweredEntries map + runEntry try the fast path and
fall back to a fresh interpreter run on a clause-1 miss, so results are
identical to the pure interpreter for any boolean query.

Also fixes pre-existing first-argument-indexing gaps (found via the new
parity tests) where instructions degraded to Raw(...) stubs and broke
the interpreter, now matching F#/C/C++/R:
- switch_on_constant_fallthrough (mixed fact+rule predicates such as the
  factorial/Ackermann/Fibonacci base cases) reuses SwitchOnConstant.
- switch_on_term_a2 / switch_on_constant_a2 (+_fallthrough) second-arg
  indexing (e.g. member/2) dispatch on the correct register via a new
  reg field on the SwitchOnConstant / SwitchOnTerm runtime instructions
  (defaulting to 1, so A1-indexed codegen is unchanged).

New tests/test_wam_scala_lowered_emitter.pl: structural tests (always
run) + gated runtime parity tests that compile the same predicates in
both modes and assert identical, correct results. All 18 pass.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw