### PR TITLE
fix(wam-scala): route extended builtins through interceptedExecuteBuiltin

### DIFF
--- a/templates/targets/scala_wam/runtime.scala.mustache
+++ b/templates/targets/scala_wam/runtime.scala.mustache
@@ -1282,7 +1282,7 @@ object WamRuntime {
 
       // --- Builtins ---
 
-      case BuiltinCall(pred, _) => pred match {
+      case BuiltinCall(pred, builtinArity) => pred match {
         case "=/2" =>
           val a = deref(s.bindings, s.regs(1))
           val b = deref(s.bindings, s.regs(2))
@@ -1452,7 +1452,17 @@ object WamRuntime {
           }
 
         case _ =>
-          backtrack(s)
+          // Extended builtins (atom_codes, atom_length, ground, atomic,
+          // sort, msort, bagof, setof, write, nl, between, format, succ,
+          // atom_concat, sub_atom, call/N) are implemented in
+          // interceptedExecuteBuiltin. The WAM compiler emits them as
+          // `builtin_call <name>/<arity>`, so route the unhandled cases
+          // there (withReturn = true → advance to the next instruction on
+          // success) before treating it as an unknown builtin and failing.
+          val slash = pred.lastIndexOf('/')
+          val bname = if (slash >= 0) pred.substring(0, slash) else pred
+          if (!interceptedExecuteBuiltin(s, program, bname, builtinArity, withReturn = true))
+            backtrack(s)
       }
 
       // --- Foreign ---


### PR DESCRIPTION
## Summary

Fixes 10 pre-existing failures in the WAM Scala runtime smoke suite where common builtins silently returned `false`.

The runtime's `BuiltinCall` step handler implemented only a subset of builtins inline (`=/2`, `is/2`, comparisons, `member`, `length`, `append`, …). The **extended** builtins — `atom_codes`, `atom_length`, `ground`, `atomic`, `sort`/`msort`, `bagof`/`setof`, `between`, `format`, `succ`, `atom_concat`, `sub_atom` — were only wired into `interceptedExecuteBuiltin`, which is reached from the `call`/`execute` opcodes. But the WAM compiler emits these as `builtin_call <name>/<arity>`, whose default case was `backtrack(s)` → every such call silently failed.

## Fix

The `BuiltinCall` default case now delegates to `interceptedExecuteBuiltin` (with `withReturn = true`, i.e. advance to the next instruction on success) before treating the call as an unknown builtin and failing. One small change to `templates/targets/scala_wam/runtime.scala.mustache` (12 insertions, 2 deletions).

## Tests fixed

These `tests/test_wam_scala_runtime_smoke.pl` tests now pass:
`builtin_atom_codes`, `builtin_atom_length`, `builtin_is_list_ground`, `builtin_sort`, `builtin_between`, `builtin_format`, `builtin_atom_concat`, `builtin_atom_concat_split`, `builtin_sub_atom`, `builtin_sub_atom_find`.

## Verification

Each affected builtin was verified end-to-end (generate → `scalac` → `scala`) returning the correct `true`/`false`, e.g.:

```
atom_codes(abc,[97,98,99]) = true
atom_length(abc,3)         = true
ground(a)                  = true
sort([c,a,b],[a,b,c])      = true
between(1,5,3)             = true   between(1,5,9) = false
atom_concat(a,b,ab)        = true
format("v=~w",[5])         = v=5true
sub_atom(hello,0,3,2,hel)  = true
sub_atom(hello,_,_,_,ell)  = true   sub_atom(hello,_,_,_,xyz) = false
```

This is a pure correctness fix that does not change the handling of any builtin already dispatched by the `BuiltinCall` match (those cases match before the default), and does not touch the lowered emitter.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_