### PR TITLE
feat(wam-elixir): use shared WAM items bridge in interpreter mode

### DIFF
--- a/docs/design/WAM_ELIXIR_GAPS_SPECIFICATION.md
+++ b/docs/design/WAM_ELIXIR_GAPS_SPECIFICATION.md
@@ -71,12 +71,16 @@ Survey columns: ✅ shipped · ⚠️ partial · ❌ missing.
 
 | Status | Elixir | C++ | Rust | Haskell |
 |---|---|---|---|---|
-| Consumes `compile_predicate_to_wam_items` | ❌ | ❌ | ❌ | ❌ |
-| Calls `parse_wam_text` (legacy text path) | ✅ | ✅ | ✅ | ✅ |
+| Interpreter consumes shared WAM items | ✅ | ❌ | ❌ | ❌ |
+| Lowered emitter consumes shared WAM items | ❌ | ❌ | ❌ | ❌ |
+| Calls `parse_wam_text` / text rewrite path | ✅ | ✅ | ✅ | ✅ |
 | `format(string(...))` site count | 56 | 22 | 74 | 88 |
 
-Phase 1 of the Items API hasn't landed in `wam_target.pl` yet.
-Tracked separately in `WAM_ITEMS_API_SPECIFICATION.md`.
+The Elixir interpreter path now converts ISO-rewritten WAM text through the
+shared items bridge before emitting instruction tuples. The lowered emitter
+still consumes WAM text directly. Native `compile_predicate_to_wam_items/3`
+generation and fully items-level ISO rewriting remain tracked in
+`WAM_ITEMS_API_SPECIFICATION.md` and `WAM_REPRESENTATION_MODES.md`.
 
 ## 2. Dependency graph
 
@@ -424,7 +428,8 @@ After this roadmap completes, natural follow-ups:
 - **`bagof/3` + `setof/3`** — mirror C++ PR series #2086 → #2112.
   Larger scope; needs witness-grouping infrastructure and the
   `aggregate_next_group` synthetic op.
-- **Items API migration** — Elixir is #6 in the
+- **Items API migration** — Elixir interpreter mode now uses the shared
+  items bridge, but lowered mode still needs migration. Elixir is #6 in the
   `WAM_ITEMS_API_SPECIFICATION.md` Phase 2 plan. Drops the 56
   `format(string(...))` calls.
 - **Option B for catch/throw** — if PR #2 bench shows side-stack

--- a/docs/design/WAM_ELIXIR_STATUS.md
+++ b/docs/design/WAM_ELIXIR_STATUS.md
@@ -57,7 +57,7 @@ Companion docs:
 - Explicit `*_iso/N` forms always throw structured ISO errors.
 - Explicit `*_lax/N` forms always preserve lax/fail-style behavior.
 
-The rewrite is text-level at project-write time (see `iso_errors_rewrite_text/4` in `wam_elixir_target.pl`). Items-level dispatch is deferred — the lowered emitter parses WAM line-by-line and has no items intermediate. Adding one would be the Items API refactor (`WAM_ITEMS_API_SPECIFICATION.md`).
+The rewrite is text-level at project-write time (see `iso_errors_rewrite_text/4` in `wam_elixir_target.pl`). Interpreter-mode predicate modules now parse the rewritten text through the shared WAM-items bridge before emitting Elixir instruction tuples. The lowered emitter still parses WAM line-by-line and has no items intermediate; moving that path to items remains the larger Items API refactor (`WAM_ITEMS_API_SPECIFICATION.md`).
 
 **Aggregates.** `findall/3`, `bagof/3`, `setof/3`, `aggregate_all(Template, Goal, Result)` with all spec-compliant templates (`bag`, `set`, `count`, `sum`, `max`, `min`). Both compiled-inline (`begin_aggregate`/`end_aggregate`) and meta-call dispatch (`execute findall/3` etc.) paths work. Full ISO witness-group backtracking for `bagof/setof` — free-variable bindings are grouped and iterable via `{:agg_next_group, ...}` choice-point frames. The `^/2` existential quantifier is supported.
 
@@ -101,7 +101,7 @@ These choices are load-bearing and worth understanding before working on the tar
 
 **Side-stack catcher frames.** `catch/3` snapshots regs/y_regs/stack/trail-mark/cp-count into `state.catcher_frames`. `throw/1` raises `{:wam_throw, term, heap, heap_len}` as a BEAM throw — bundling the heap is critical for compound thrown terms (deep_copy creates cells in a state that gets discarded before the throw fires).
 
-**ISO error rewriting is text-level.** `iso_errors_rewrite_text/4` recognizes `builtin_call`/`put_structure`/`call`/`execute` line shapes and substitutes keys per the predicate's ISO mode. No items intermediate.
+**ISO error rewriting is text-level.** `iso_errors_rewrite_text/4` recognizes `builtin_call`/`put_structure`/`call`/`execute` line shapes and substitutes keys per the predicate's ISO mode. Interpreter mode then converts the rewritten text to shared WAM items; lowered mode still consumes the rewritten text directly.
 
 ## Deferred Work
 
@@ -114,7 +114,7 @@ In rough priority order:
 5. ~~**switch_on_term + switch_on_constant_fallthrough**~~ — DONE (PR #2535). All WAM indexed dispatch instructions lowered. fibonacci and ackermann now pass.
 6. **IEEE-754 lax float-divide** — BEAM raises on `1.0/0.0`. Would need atom sentinels (`:inf`, `:nan`) plumbed through the lax arithmetic path.
 7. **BEAM-native catch (Option B from PHILOSOPHY §5)** — only if perf measurements show the side-stack walk dominates. Current bench does not exercise it.
-8. **Items API for the lowered emitter** — would let ISO-error rewriting move from text-level to items-level. Cross-cutting; not Elixir-specific.
+8. **Items API for the lowered emitter** — interpreter mode now uses the shared items bridge after text rewrite; the lowered emitter still needs an items-level path before ISO rewriting can move fully out of text. Cross-cutting; not Elixir-specific.
 
 ## Lessons Learned
 

--- a/docs/design/WAM_REPRESENTATION_MODES.md
+++ b/docs/design/WAM_REPRESENTATION_MODES.md
@@ -42,14 +42,18 @@ conservative:
 - Lua lowered/functions mode: `wam_text`
 - R interpreter mode: `wam_items_bridge`
 - R lowered/functions mode: `wam_text`
+- Elixir interpreter mode: `wam_items_bridge`
+- Elixir lowered mode: `wam_text`
 - Unknown WAM targets: `wam_text`
 
 WAM-specific targets may reject `direct_target`; callers should use the ordinary
 non-WAM target when they want direct target-native code.
 
-Lua and R follow the same partial migration shape as Python: interpreter-mode
-generated predicates consume common WAM items through the bridge, while lowered
-emission keeps the text path because lowerability analysis and target-specific
-classifiers still work over tokenized WAM text. R additionally keeps WAM text for
-fact-shape classification and recursive-kernel detection even when the emitted
-instruction array comes from bridged WAM items.
+Lua, R, and Elixir follow the same partial migration shape as Python:
+interpreter-mode generated predicates consume common WAM items through the
+bridge, while lowered emission keeps the text path because lowerability analysis
+and target-specific classifiers still work over tokenized WAM text. R
+additionally keeps WAM text for fact-shape classification and recursive-kernel
+detection even when the emitted instruction array comes from bridged WAM items.
+Elixir keeps its ISO-error rewrite as a text-level pre-pass, then parses the
+rewritten text to shared WAM items for interpreter-mode predicate modules.

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -39,6 +39,7 @@
 :- use_module('../core/template_system').
 :- use_module('../bindings/elixir_wam_bindings').
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../targets/wam_ir_mode', [wam_ir_mode/4]).
 :- use_module('../core/iso_errors',
               [ iso_errors_resolve_options/2,
                 iso_errors_load_config/2,
@@ -51,7 +52,8 @@
               ]).
 :- use_module('wam_text_parser',
               [ wam_tokenize_line/2,
-                wam_recognise_instruction/2
+                wam_recognise_instruction/2,
+                wam_text_to_items/2
               ]).
 :- use_module('../targets/wam_elixir_utils', [camel_case/2]).
 :- use_module('../core/recursive_kernel_detection',
@@ -70,6 +72,21 @@ wam_elixir_resolve_emit_mode(Options, Mode) :-
     (   option(emit_mode(M), Options)
     ->  Mode = M
     ;   Mode = interpreter
+    ).
+
+%% wam_elixir_emit_ir_mode(+Options, +EmitMode, -IrMode) is det.
+%  Elixir interpreter mode can consume shared WAM items through the bridge.
+%  Lowered mode remains text-backed because its classifiers and emitter still
+%  analyse WAM text directly.
+wam_elixir_emit_ir_mode(Options, EmitMode, IrMode) :-
+    wam_ir_mode(wam_elixir, EmitMode, Options, IrMode),
+    (   IrMode == direct_target
+    ->  throw(error(domain_error(wam_elixir_ir_mode, direct_target),
+                    wam_elixir_emit_ir_mode/3))
+    ;   IrMode == wam_items_native
+    ->  throw(error(existence_error(wam_ir_mode, wam_items_native),
+                    wam_elixir_emit_ir_mode/3))
+    ;   true
     ).
 
 % ============================================================================
@@ -4974,6 +4991,13 @@ end', [PredStr, PredStr, Arity, InstrLiterals, LabelLiterals]).
 %  Two-pass: pass 1 collects labels → PC map; pass 2 emits instructions
 %  with label references pre-resolved to integer PCs where possible.
 wam_code_to_elixir_instructions(WamCode, InstrLiterals, LabelLiterals) :-
+    is_list(WamCode),
+    !,
+    collect_item_labels_pass(WamCode, 1, LabelsList),
+    wam_items_to_elixir(WamCode, 1, LabelsList, InstrParts, LabelParts),
+    atomic_list_concat(InstrParts, '\n', InstrLiterals),
+    atomic_list_concat(LabelParts, ', ', LabelLiterals).
+wam_code_to_elixir_instructions(WamCode, InstrLiterals, LabelLiterals) :-
     atom_string(WamCode, WamStr),
     split_string(WamStr, "\n", "", Lines),
     collect_labels_pass(Lines, 1, LabelsList),
@@ -5014,6 +5038,100 @@ wam_lines_to_elixir([Line|Rest], PC, LabelsList, Instrs, Labels) :-
             Instrs = [InstrEntry|RestInstrs],
             wam_lines_to_elixir(Rest, NPC, LabelsList, RestInstrs, Labels)
         )
+    ).
+
+collect_item_labels_pass([], _, []).
+collect_item_labels_pass([label(LabelName)|Rest], PC, [LabelName-PC|Labels]) :-
+    !,
+    collect_item_labels_pass(Rest, PC, Labels).
+collect_item_labels_pass([_|Rest], PC, Labels) :-
+    NPC is PC + 1,
+    collect_item_labels_pass(Rest, NPC, Labels).
+
+wam_items_to_elixir([], _, _, [], []).
+wam_items_to_elixir([label(LabelName)|Rest], PC, LabelsList, Instrs, Labels) :-
+    !,
+    format(string(LabelInsert), '"~w" => ~w', [LabelName, PC]),
+    Labels = [LabelInsert|RestLabels],
+    wam_items_to_elixir(Rest, PC, LabelsList, Instrs, RestLabels).
+wam_items_to_elixir([Item|Rest], PC, LabelsList, [InstrEntry|RestInstrs], Labels) :-
+    wam_item_parts(Item, Parts),
+    wam_line_to_elixir_instr(Parts, LabelsList, ElixirInstr),
+    format(string(InstrEntry), '      ~w,', [ElixirInstr]),
+    NPC is PC + 1,
+    wam_items_to_elixir(Rest, NPC, LabelsList, RestInstrs, Labels).
+
+wam_item_parts(get_constant(C, Ai), ["get_constant", C, Ai]).
+wam_item_parts(get_variable(Xn, Ai), ["get_variable", Xn, Ai]).
+wam_item_parts(get_value(Xn, Ai), ["get_value", Xn, Ai]).
+wam_item_parts(get_structure(F, Ai), ["get_structure", F, Ai]).
+wam_item_parts(get_list(Ai), ["get_list", Ai]).
+wam_item_parts(get_nil(Ai), ["get_nil", Ai]).
+wam_item_parts(get_integer(N, Ai), ["get_integer", N, Ai]).
+wam_item_parts(get_float(F, Ai), ["get_float", F, Ai]).
+wam_item_parts(unify_variable(Xn), ["unify_variable", Xn]).
+wam_item_parts(unify_value(Xn), ["unify_value", Xn]).
+wam_item_parts(unify_constant(C), ["unify_constant", C]).
+wam_item_parts(unify_nil, ["unify_nil"]).
+wam_item_parts(unify_void(N), ["unify_void", N]).
+wam_item_parts(put_variable(Xn, Ai), ["put_variable", Xn, Ai]).
+wam_item_parts(put_value(Xn, Ai), ["put_value", Xn, Ai]).
+wam_item_parts(put_unsafe_value(Yn, Ai), ["put_unsafe_value", Yn, Ai]).
+wam_item_parts(put_constant(C, Ai), ["put_constant", C, Ai]).
+wam_item_parts(put_nil(Ai), ["put_nil", Ai]).
+wam_item_parts(put_integer(N, Ai), ["put_integer", N, Ai]).
+wam_item_parts(put_float(F, Ai), ["put_float", F, Ai]).
+wam_item_parts(put_structure(F, Ai), ["put_structure", F, Ai]).
+wam_item_parts(put_list(Ai), ["put_list", Ai]).
+wam_item_parts(set_variable(Xn), ["set_variable", Xn]).
+wam_item_parts(set_value(Xn), ["set_value", Xn]).
+wam_item_parts(set_local_value(Xn), ["set_local_value", Xn]).
+wam_item_parts(set_constant(C), ["set_constant", C]).
+wam_item_parts(set_nil, ["set_nil"]).
+wam_item_parts(set_integer(N), ["set_integer", N]).
+wam_item_parts(set_void(N), ["set_void", N]).
+wam_item_parts(call(P, N), ["call", P, N]).
+wam_item_parts(execute(P), ["execute", P]).
+wam_item_parts(proceed, ["proceed"]).
+wam_item_parts(fail, ["fail"]).
+wam_item_parts(allocate, ["allocate"]).
+wam_item_parts(deallocate, ["deallocate"]).
+wam_item_parts(builtin_call(Op, Ar), ["builtin_call", Op, Ar]).
+wam_item_parts(call_foreign(Pred, Ar), ["call_foreign", Pred, Ar]).
+wam_item_parts(arg(N, Reg, OutReg), ["arg", N, Reg, OutReg]).
+wam_item_parts(try_me_else(L), ["try_me_else", L]).
+wam_item_parts(retry_me_else(L), ["retry_me_else", L]).
+wam_item_parts(trust_me, ["trust_me"]).
+wam_item_parts(try(L), ["try", L]).
+wam_item_parts(retry(L), ["retry", L]).
+wam_item_parts(trust(L), ["trust", L]).
+wam_item_parts(jump(L), ["jump", L]).
+wam_item_parts(cut_ite, ["cut_ite"]).
+wam_item_parts(begin_aggregate(K, V, R), ["begin_aggregate", K, V, R]).
+wam_item_parts(begin_aggregate(K, V, R, W), ["begin_aggregate", K, V, R, W]).
+wam_item_parts(end_aggregate(R), ["end_aggregate", R]).
+wam_item_parts(switch_on_constant(Es), ["switch_on_constant"|Es]).
+wam_item_parts(switch_on_constant_fallthrough(Es), ["switch_on_constant_fallthrough"|Es]).
+wam_item_parts(switch_on_constant_a2(Es), ["switch_on_constant_a2"|Es]).
+wam_item_parts(switch_on_constant_a2_fallthrough(Es), ["switch_on_constant_a2_fallthrough"|Es]).
+wam_item_parts(switch_on_structure(Es), ["switch_on_structure"|Es]).
+wam_item_parts(switch_on_structure_a2(Es), ["switch_on_structure_a2"|Es]).
+wam_item_parts(switch_on_term(Ts), ["switch_on_term"|Ts]).
+wam_item_parts(switch_on_term_a2(Ts), ["switch_on_term_a2"|Ts]).
+wam_item_parts(Item, Parts) :-
+    Item =.. [Name|Args],
+    atom_string(Name, NameStr),
+    maplist(wam_item_arg_string, Args, ArgStrs),
+    Parts = [NameStr|ArgStrs].
+
+wam_item_arg_string(Value, Str) :-
+    (   string(Value)
+    ->  Str = Value
+    ;   atom(Value)
+    ->  atom_string(Value, Str)
+    ;   number(Value)
+    ->  number_string(Value, Str)
+    ;   term_string(Value, Str)
     ).
 
 %% resolve_label(+LabelStr, +LabelsList, -Resolved)
@@ -5127,6 +5245,7 @@ wam_line_to_elixir_instr(Parts, _, Instr) :-
 write_wam_elixir_project(Predicates, Options, ProjectDir) :-
     option(module_name(ModuleName), Options, 'wam_generated'),
     wam_elixir_resolve_emit_mode(Options, Mode),
+    wam_elixir_emit_ir_mode(Options, Mode, IrMode),
     wam_target_runtime_parser(wam_elixir, Options, RuntimeParserMode),
     validate_elixir_runtime_parser_mode(Predicates, RuntimeParserMode),
     Options1 = [runtime_parser_mode(RuntimeParserMode)|Options],
@@ -5142,7 +5261,7 @@ write_wam_elixir_project(Predicates, Options, ProjectDir) :-
     setup_call_cleanup(
         atom_interning_setup(Options1),
         do_write_wam_elixir_project(Predicates, Options1, ProjectDir,
-                                     Mode, ModuleName, LibDir),
+                                     Mode, IrMode, ModuleName, LibDir),
         atom_interning_cleanup(Options1)
     ).
 
@@ -6239,8 +6358,13 @@ atom_interning_cleanup(Options) :-
     ;   true
     ).
 
+elixir_interpreter_wam_code(WamText, wam_text, WamText) :- !.
+elixir_interpreter_wam_code(WamText, wam_items_bridge, Items) :-
+    wam_text_to_items(WamText, Items).
+
+
 do_write_wam_elixir_project(Predicates, Options, ProjectDir,
-                             Mode, ModuleName, LibDir) :-
+                             Mode, IrMode, ModuleName, LibDir) :-
     % PR #4: resolve ISO config + warn on multi-module bare overrides
     % BEFORE per-predicate compilation, then thread the per-PI
     % rewrite into the predicate emit loop below.
@@ -6284,8 +6408,10 @@ do_write_wam_elixir_project(Predicates, Options, ProjectDir,
                 ;   (   Mode == lowered
                     ->  lower_predicate_to_elixir(Pred/Arity,
                             RewrittenWamCode, Options, PredCode)
-                    ;   compile_wam_predicate_to_elixir(Pred/Arity,
-                            RewrittenWamCode, Options, PredCode)
+                    ;   elixir_interpreter_wam_code(RewrittenWamCode, IrMode,
+                            InterpreterWamCode),
+                        compile_wam_predicate_to_elixir(Pred/Arity,
+                            InterpreterWamCode, Options, PredCode)
                     )
                 )
             ),

--- a/src/unifyweaver/targets/wam_ir_mode.pl
+++ b/src/unifyweaver/targets/wam_ir_mode.pl
@@ -55,7 +55,7 @@ wam_ir_mode_uses_wam(wam_items_native).
 wam_ir_mode_skips_text(wam_items_native).
 wam_ir_mode_skips_text(direct_target).
 
-% Conservative current defaults. Interpreter-mode Python, Lua, and R already
+% Conservative current defaults. Interpreter-mode Python, Lua, R, and Elixir
 % consume the common items bridge; their lowered paths still need WAM text for
 % analyzers, fact classifiers, kernel detectors, and lowered emitters.
 wam_ir_mode_default(wam_python, interpreter, wam_items_bridge) :- !.
@@ -64,5 +64,7 @@ wam_ir_mode_default(wam_python, functions, wam_text) :- !.
 wam_ir_mode_default(wam_python, mixed(_), wam_text) :- !.
 wam_ir_mode_default(wam_lua, interpreter, wam_items_bridge) :- !.
 wam_ir_mode_default(wam_r, interpreter, wam_items_bridge) :- !.
+wam_ir_mode_default(wam_elixir, interpreter, wam_items_bridge) :- !.
+wam_ir_mode_default(wam_elixir, lowered, wam_text) :- !.
 wam_ir_mode_default(_, direct_target, direct_target) :- !.
 wam_ir_mode_default(_, _, wam_text).

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -4888,6 +4888,12 @@ WamRuntime$call_builtin <- function(program, state, pred, arity) {
     return(WamRuntime$unify(state, WamRuntime$get_reg(state, 3L), t_v$args[[i]]))
   }
 
+  # Some stdlib predicates are emitted as BuiltinCall by the WAM
+  # compiler, while older paths reached them through Call/Execute label
+  # fallback. Keep both shapes routed through the same library table.
+  lib <- WamRuntime$call_library(program, state, pred, arity)
+  if (!is.null(lib)) return(isTRUE(lib))
+
   # Unknown builtin -> failure (matches WAM convention).
   FALSE
 }
@@ -4909,7 +4915,7 @@ WamRuntime$call_builtin <- function(program, state, pred, arity) {
 
 WamRuntime$call_library <- function(program, state, pred, arity) {
   table <- program$intern_table
-  key <- paste0(pred, "/", arity)
+  key <- if (grepl("/[0-9]+$", pred)) pred else paste0(pred, "/", arity)
 
   # ----- ^/2 existential scope -----
   # When the WAM compiler emits `Y^Goal` as a Call("^", 2), treat

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -192,6 +192,89 @@ elixir_test_tmp_dir(Name, TmpDir) :-
     catch(delete_directory_and_contents(TmpDir), _, true),
     make_directory_path(TmpDir).
 
+test_elixir_interpreter_uses_items_ir_policy_source :-
+    Test = 'WAM-Elixir: interpreter mode uses shared items IR policy',
+    (   once(source_file(wam_elixir_target:write_wam_elixir_project(_, _, _), Path)),
+        read_file_to_string(Path, Content, []),
+        sub_string(Content, _, _, _, 'wam_elixir_emit_ir_mode(Options, Mode, IrMode)'),
+        sub_string(Content, _, _, _, 'wam_ir_mode(wam_elixir, EmitMode, Options, IrMode)'),
+        sub_string(Content, _, _, _, 'elixir_interpreter_wam_code(RewrittenWamCode, IrMode'),
+        sub_string(Content, _, _, _, 'wam_text_to_items(WamText, Items)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'items IR policy wiring missing from source')
+    ).
+
+test_elixir_items_adapter_accepts_shared_items :-
+    Test = 'WAM-Elixir: shared WAM items convert to instruction literals',
+    Items = [label("demo/1"), put_constant("foo", "A1"),
+             call("other/0", "0"), proceed],
+    (   wam_elixir_target:wam_code_to_elixir_instructions(Items, Instrs, Labels),
+        sub_string(Instrs, _, _, _, '{:put_constant, "foo", 1}'),
+        sub_string(Instrs, _, _, _, '{:call, "other/0", 0}'),
+        sub_string(Instrs, _, _, _, ':proceed'),
+        sub_string(Labels, _, _, _, '"demo/1" => 1')
+    ->  pass(Test)
+    ;   fail_test(Test, 'items adapter did not emit expected Elixir literals')
+    ).
+
+test_elixir_generated_predicate_allows_text_ir_override :-
+    Test = 'WAM-Elixir: generated predicate allows wam_text IR override',
+    WamCode = 'elixir_text_ir/1:
+  put_constant foo, A1
+  proceed',
+    setup_call_cleanup(
+        elixir_test_tmp_dir('tmp_wam_elixir_text_ir', TmpDir),
+        (   write_wam_elixir_project([elixir_text_ir/1-WamCode],
+                                    [wam_ir(wam_text)], TmpDir),
+            directory_file_path(TmpDir, 'lib', LibDir),
+            directory_file_path(LibDir, 'elixir_text_ir.ex', PredPath),
+            read_file_to_string(PredPath, Code, []),
+            (   sub_string(Code, _, _, _, '{:put_constant, "foo", 1}')
+            ->  pass(Test)
+            ;   fail_test(Test, 'text IR override did not emit predicate code')
+            )
+        ),
+        elixir_parser_cleanup_tmp_dir(TmpDir)
+    ).
+
+test_elixir_generated_predicate_rejects_direct_target_ir :-
+    Test = 'WAM-Elixir: generated predicate rejects direct_target IR',
+    WamCode = 'elixir_direct_ir/0:
+  proceed',
+    setup_call_cleanup(
+        elixir_test_tmp_dir('tmp_wam_elixir_direct_ir', TmpDir),
+        (   catch((write_wam_elixir_project([elixir_direct_ir/0-WamCode],
+                                            [wam_ir(direct_target)], TmpDir),
+                   Caught = false),
+                  error(domain_error(wam_elixir_ir_mode, direct_target), _),
+                  Caught = true),
+            (   Caught == true
+            ->  pass(Test)
+            ;   fail_test(Test, 'expected direct_target IR domain_error')
+            )
+        ),
+        elixir_parser_cleanup_tmp_dir(TmpDir)
+    ).
+
+test_elixir_generated_predicate_rejects_native_items_until_available :-
+    Test = 'WAM-Elixir: generated predicate rejects wam_items_native IR',
+    WamCode = 'elixir_native_ir/0:
+  proceed',
+    setup_call_cleanup(
+        elixir_test_tmp_dir('tmp_wam_elixir_native_ir', TmpDir),
+        (   catch((write_wam_elixir_project([elixir_native_ir/0-WamCode],
+                                            [wam_ir(wam_items_native)], TmpDir),
+                   Caught = false),
+                  error(existence_error(wam_ir_mode, wam_items_native), _),
+                  Caught = true),
+            (   Caught == true
+            ->  pass(Test)
+            ;   fail_test(Test, 'expected wam_items_native existence_error')
+            )
+        ),
+        elixir_parser_cleanup_tmp_dir(TmpDir)
+    ).
+
 test_instruction_count :-
     Test = 'WAM-Elixir: instruction arm count',
     (   findall(N, wam_elixir_case(N, _), Cases),
@@ -3242,6 +3325,11 @@ run_tests :-
     test_runtime_parser_compiled_request_errors,
     test_runtime_parser_none_rejects_parser_dependent_builtin,
     test_runtime_parser_none_allows_term_to_atom_forward,
+    test_elixir_interpreter_uses_items_ir_policy_source,
+    test_elixir_items_adapter_accepts_shared_items,
+    test_elixir_generated_predicate_allows_text_ir_override,
+    test_elixir_generated_predicate_rejects_direct_target_ir,
+    test_elixir_generated_predicate_rejects_native_items_until_available,
     test_instruction_count,
     test_head_unification_instructions,
     test_body_construction_instructions,

--- a/tests/test_wam_ir_mode.pl
+++ b/tests/test_wam_ir_mode.pl
@@ -13,11 +13,17 @@ test(python_lowered_defaults_to_text) :-
     wam_ir_mode(wam_python, lowered, [], Mode),
     assertion(Mode == wam_text).
 
-test(lua_and_r_interpreter_defaults_to_items_bridge) :-
+test(lua_r_and_elixir_interpreter_default_to_items_bridge) :-
     wam_ir_mode(wam_lua, interpreter, [], LuaMode),
     wam_ir_mode(wam_r, interpreter, [], RMode),
+    wam_ir_mode(wam_elixir, interpreter, [], ElixirMode),
     assertion(LuaMode == wam_items_bridge),
-    assertion(RMode == wam_items_bridge).
+    assertion(RMode == wam_items_bridge),
+    assertion(ElixirMode == wam_items_bridge).
+
+test(elixir_lowered_defaults_to_text) :-
+    wam_ir_mode(wam_elixir, lowered, [], Mode),
+    assertion(Mode == wam_text).
 
 test(unknown_target_defaults_to_text) :-
     wam_ir_mode(wam_unknown, interpreter, [], Mode),

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -1396,11 +1396,10 @@ e2e_term_inspection_via_rscript :-
 
 % ------------------------------------------------------------------
 % End-to-end: list / atom library builtins.
-% length/2 and append/3 dispatch via builtin_call; atom_codes/2,
-% atom_chars/2, atom_length/2, atom_concat/3, reverse/2 and last/2
-% dispatch via the runtime's call_library fallback when the WAM-emitted
-% Execute / Call hits a missing label. Auto-skips when Rscript is not
-% on PATH.
+% length/2 and append/3 dispatch via builtin_call. The remaining
+% list/atom stdlib predicates can arrive as either BuiltinCall or as
+% Execute / Call fallback; both route through the runtime's
+% call_library table. Auto-skips when Rscript is not on PATH.
 % ------------------------------------------------------------------
 test(list_atom_builtins_e2e_rscript) :-
     once((


### PR DESCRIPTION
## Summary

- routes WAM-Elixir interpreter-mode predicate modules through the shared `wam_items_bridge` after the existing ISO text rewrite
- keeps WAM-Elixir lowered mode on WAM text because the lowered emitter and analyzers still consume text directly
- fixes R WAM stdlib dispatch so `BuiltinCall` forms can reach `call_library`, restoring list/stdlib Rscript e2e behavior

## Tests

- `swipl -q -g "run_tests(wam_ir_mode),halt" -t "halt(1)" tests/test_wam_ir_mode.pl`
- `swipl -q -g "test_elixir_interpreter_uses_items_ir_policy_source,test_elixir_items_adapter_accepts_shared_items,test_elixir_generated_predicate_allows_text_ir_override,test_elixir_generated_predicate_rejects_direct_target_ir,test_elixir_generated_predicate_rejects_native_items_until_available,halt" -t "halt(1)" tests/test_wam_elixir_target.pl`
- `swipl -q -g "run_tests([wam_r_generator:list_atom_builtins_e2e_rscript,wam_r_generator:stdlib_round4_e2e_rscript,wam_r_generator:higherorder_listutil_e2e_rscript,wam_r_generator:stdlib_polish_e2e_rscript]),halt" -t "halt(1)" tests/test_wam_r_generator.pl`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_elixir_target.pl`
- `swipl -q -t halt -s tests/test_wam_elixir_target.pl`
- `swipl -q -t halt -s tests/test_wam_r_generator.pl`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_ir_mode.pl`
- `git diff --check`

## Notes

The full custom `tests/test_wam_elixir_target.pl` runner was started, but stopped after it hit pre-existing Phase A fact-shape failures unrelated to this branch. The focused Elixir IR-mode tests above passed.
