### PR TITLE
fix(wam-scala): correct category_ancestor interpreter claim; add parity test

### DIFF
--- a/docs/WAM_SCALA_TARGET.md
+++ b/docs/WAM_SCALA_TARGET.md
@@ -156,12 +156,15 @@ recognises (`weighted_shortest_path3`, `astar_shortest_path4`) follow the
 same pattern and are slated as follow-ups; until then those predicates
 fall back to ordinary WAM compilation (correct, just not accelerated).
 
-> Note: `category_ancestor`'s recursive clause (`length/2` + cut + `\+` +
-> recursion) exceeds what the plain step-loop interpreter currently runs
-> correctly, so it should be run with `kernel_dispatch(true)` — which is
-> precisely the depth-bounded search the cross-target `effective_distance`
-> benchmark relies on. The native kernel's results are verified against
-> SWI-Prolog ground truth.
+> Note: `category_ancestor` reads `max_depth/1` at runtime (via the
+> recursive clause's `max_depth(M)` goal), so when running it through the
+> *interpreter* be sure to include `max_depth/1` in the predicate list
+> passed to `write_wam_scala_project/3` — otherwise the `max_depth/1` call
+> has no dispatch target and the recursive clause silently fails. The
+> native kernel bakes `max_depth` in from the kernel config, so it does
+> not depend on `max_depth/1` being compiled. With `max_depth/1` compiled,
+> interpreter and kernel modes agree, and both match SWI-Prolog ground
+> truth (verified in the test suite).
 
 The distance kernel returns the **shortest** path length per reachable
 node (matching the Haskell/Rust/Elixir kernels). The Prolog source

--- a/tests/test_wam_scala_kernels.pl
+++ b/tests/test_wam_scala_kernels.pl
@@ -280,21 +280,21 @@ test(transitive_step_parent_distance_parity,
     ksame(Run, 'ksp/5', [a,d,e,c,'3'], "false"),
     ksame(Run, 'ksp/5', [a,d,b,b,'3'], "false").
 
-% category_ancestor: the recursive clause (length/2 + cut + \+ + recursion)
-% exceeds what the plain step-loop interpreter currently runs correctly, so
-% we assert the KERNEL's results against SWI-Prolog ground truth rather than
-% interpreter parity. This is exactly the case the native kernel exists for:
-% the depth-bounded ancestor search that the cross-target effective_distance
-% benchmark relies on. Parent chain c1 -> c2 -> c3 -> c4, max_depth 10.
-test(category_ancestor_kernel_correct,
-     [setup(kbuild_kernel([user:kca/4, user:kcat_parent/2], 'gen.kca', Run)),
-      cleanup(kcleanup_k(Run))]) :-
-    kassert_kernel(Run, 'kca/4', [c1,c2,'1','[]'], "true"),
-    kassert_kernel(Run, 'kca/4', [c1,c3,'2','[]'], "true"),
-    kassert_kernel(Run, 'kca/4', [c1,c4,'3','[]'], "true"),
-    kassert_kernel(Run, 'kca/4', [c2,c4,'2','[]'], "true"),
-    kassert_kernel(Run, 'kca/4', [c1,c4,'2','[]'], "false"),
-    kassert_kernel(Run, 'kca/4', [c1,c2,'2','[]'], "false").
+% category_ancestor: depth-bounded ancestor search. The recursive clause
+% reads max_depth/1 at runtime, so max_depth/1 is included in the predicate
+% list (otherwise the interpreter's max_depth/1 call has no dispatch target).
+% With it compiled, interpreter and kernel modes agree and both match SWI
+% ground truth. Parent chain c1 -> c2 -> c3 -> c4, max_depth 10.
+test(category_ancestor_parity,
+     [setup(kbuild_both([user:kca/4, user:kcat_parent/2, user:max_depth/1],
+                        'gen.kca', Run)),
+      cleanup(kcleanup(Run))]) :-
+    ksame(Run, 'kca/4', [c1,c2,'1','[]'], "true"),
+    ksame(Run, 'kca/4', [c1,c3,'2','[]'], "true"),
+    ksame(Run, 'kca/4', [c1,c4,'3','[]'], "true"),
+    ksame(Run, 'kca/4', [c2,c4,'2','[]'], "true"),
+    ksame(Run, 'kca/4', [c1,c4,'2','[]'], "false"),
+    ksame(Run, 'kca/4', [c1,c2,'2','[]'], "false").
 
 :- end_tests(wam_scala_kernels_runtime).
 
@@ -351,27 +351,6 @@ ksame(run(ItDir, KnDir, ItPkg, KnPkg), PredKey, Args, Expected) :-
 
 kcleanup(run(ItDir, KnDir, _, _)) :-
     ignore(delete_directory_and_contents(ItDir)),
-    ignore(delete_directory_and_contents(KnDir)).
-
-%% kbuild_kernel(+Preds, +PkgBase, -run_k(KnDir, KnPkg))
-%  Builds only the kernel-mode project (used where the plain interpreter
-%  cannot run the predicate, so results are checked against ground truth).
-kbuild_kernel(Preds, PkgBase, run_k(KnDir, KnPkg)) :-
-    format(atom(KnPkg), '~w.kn.core', [PkgBase]),
-    ktmp('tmp_scala_konly', KnDir),
-    write_wam_scala_project(Preds,
-        [package(KnPkg), runtime_package(KnPkg), module_name('konly'),
-         kernel_dispatch(true)], KnDir),
-    kcompile(KnDir).
-
-kassert_kernel(run_k(KnDir, KnPkg), PredKey, Args, Expected) :-
-    krun(KnDir, KnPkg, PredKey, Args, Out),
-    (   Out == Expected
-    ->  true
-    ;   throw(error(kernel_wrong(PredKey, Args, expected(Expected), got(Out)), _))
-    ).
-
-kcleanup_k(run_k(KnDir, _)) :-
     ignore(delete_directory_and_contents(KnDir)).
 
 kcompile(Dir) :-


### PR DESCRIPTION
## Summary

You asked me to fix the suspected interpreter cut bug. **There is no cut bug** — the interpreter's cut/choicepoint handling is correct. This PR corrects the mistaken diagnosis I shipped with the `category_ancestor` kernel and strengthens its test.

## Root cause

While isolating the failure I built a series of probe predicates and traced the runtime. The recursive `category_ancestor` clause failed in the interpreter **only because `max_depth/1` was omitted from the compiled predicate list**. Its `max_depth(M)` goal compiled to `call max_depth/1`, which had no dispatch entry, so the call backtracked and the whole recursive clause silently failed — leaving only the base (direct-parent) results. The trace made it unambiguous: `BACKTRACK pc=13` landed exactly on the `call max_depth/1` instruction.

The isolation probes confirmed it precisely: a sub-clause that used a builtin before the cut (`length`, `<`) worked; only the one that *called a sub-predicate not in the compile set* failed.

With `max_depth/1` included, the plain step-loop interpreter runs `category_ancestor` **correctly** — verified against SWI-Prolog ground truth (`ca(c1,c3,2)=true`, `ca(c1,c4,3)=true`, `ca(c2,c4,2)=true`, `ca(c1,c4,2)=false`) and identical to the native kernel.

## Changes

- **`docs/WAM_SCALA_TARGET.md`** — replace the inaccurate note (that the interpreter can't run `category_ancestor`) with the real guidance: include `max_depth/1` in the predicate list when running through the interpreter; the kernel bakes `max_depth` in from config and doesn't need it compiled. Both modes then agree and match SWI.
- **`tests/test_wam_scala_kernels.pl`** — upgrade the `category_ancestor` runtime test from kernel-only correctness to full **interpreter-vs-kernel parity** (added `max_depth/1` to the predicate list), matching the other four kernels. Removed the now-unused kernel-only helpers.

No runtime change. Suite: **11 structural + 5 runtime parity, all green.**

## Note

This corrects documentation/test introduced earlier in the same Unreleased cycle (the `category_ancestor` kernel, #2694), so no separate CHANGELOG entry — the existing "kernel-mode and interpreter-mode results are identical" line is now accurate for all five kernels.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_