### PR TITLE
Add WAM-C child-search runtime sweep

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -190,12 +190,13 @@ Reason:
 - Weighted/A* native kernels previously covered only integer results, while
   Haskell and Rust had broader numeric-result surfaces.
 
-### Active: `investigate/wam-c-csr-lookup-microbenchmark`
+### Active: `investigate/wam-c-child-search-runtime-sweep`
 
 Goal: measure whether the newer parent-only LMDB and reverse CSR artifact
 layouts remain the right defaults at larger category scales, without forcing
 full WAM-C query-runner generation and C compilation when only artifact bytes
-or narrow lookup timings are needed.
+or narrow lookup timings are needed, then confirm the end-to-end bounded
+child-search query cost before promoting child expansion beyond smoke scale.
 
 Implemented so far:
 
@@ -248,16 +249,30 @@ Implemented so far:
   `50k_cats`/`100k_cats` category graph, sorted-array is about `1.15-1.17us`,
   pread/drop sorted-array about `1.48us`, LMDB-offset about `1.39-1.44us`,
   and LMDB-offset pread/drop about `1.75us` per parent lookup.
+- Added `benchmark_wam_c_child_search_runtime_sweep.py`, a small wrapper for
+  the generated WAM-C end-to-end child-search target set. It defaults to `dev`,
+  one repetition, and a `180s` per-invocation timeout, with parent-only WAM-C
+  available as an explicit comparison row.
+- Runtime sweep evidence: at `dev`, parent-only WAM-C finishes in `0.003s`
+  and emits a different output hash, while all child-search layouts agree on
+  `19` rows. Child scan and sorted-array CSR are essentially tied
+  (`0.129s` versus `0.128s`); pread/drop CSR is `0.139s`, and LMDB-offset CSR
+  is `0.142s`.
+- At `10x`, parent-only WAM-C finishes in `0.071s` with `183` rows, but all
+  four child-search layouts hit the `180s` timeout. This says the current
+  bounded child expansion query shape, not reverse CSR lookup itself, is the
+  blocker beyond smoke scale.
 
 Open measurement:
 
-- `10x` child-search layout runs are not a routine local gate even with a small
-  child-expansion cap; run them only as an explicit longer benchmark window.
 - Use compile-only rows for routine generated-project comparisons through
   `10k`, use `--artifact-only` for `50k_cats` and `100k_cats` size checks, and
   use the WAM-C CSR lookup microbenchmark when choosing sorted-array versus
   LMDB-offset file-backed layouts. Schedule full child-search runtime rows
-  separately for scales where query execution is acceptable.
+  only for `dev` unless the query shape or expansion policy changes.
+- The next child-search improvement should focus on pruning/query policy, not
+  on in-memory CSR. The file-backed sorted-array lookup is already cheap in the
+  narrow runtime benchmark.
 - Parent-only TSV and LMDB targets remain the priority memory structures for
   current effective-distance workloads. Reverse CSR targets are now available
   for future child-path variants and artifact-layout measurements.
@@ -456,6 +471,8 @@ generated-project artifact comparisons through `10k`, and use
 `benchmark_wam_c_child_csr_scale_sweep.py --artifact-only --scales
 50k_cats,100k_cats` for large category-graph artifact bytes. Use
 `benchmark_wam_c_reverse_csr_lookup.py` for narrow WAM-C runtime lookup costs.
-The current evidence supports keeping sorted-array file-backed CSR as the first
-child-lookup layout and deferring in-memory compressed CSR until a full
-child-search workload shows the file-backed reader is the limiting factor.
+Use `benchmark_wam_c_child_search_runtime_sweep.py` only for smoke-scale
+end-to-end child-search runs until the expansion policy is narrowed. The current
+evidence supports keeping sorted-array file-backed CSR as the first child-lookup
+layout, deferring in-memory compressed CSR, and next improving child-search
+pruning/cost policy before spending more effort on storage layout.

--- a/examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py
+++ b/examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Run an end-to-end WAM-C bounded child-search runtime sweep.
+
+This wrapper exercises the generated effective-distance programs instead of
+only compiling CSR artifacts. The default run is intentionally small; larger
+scales should be requested explicitly because bounded child expansion can make
+the full query body expensive.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "examples" / "benchmark" / "benchmark_effective_distance_matrix.py"
+CHILD_SEARCH_TARGETS = [
+    "c-wam-accumulated-child-scan",
+    "c-wam-accumulated-child-csr",
+    "c-wam-accumulated-child-csr-drop",
+    "c-wam-accumulated-child-csr-lmdb-offset",
+]
+PARENT_ONLY_TARGET = "c-wam-accumulated"
+DEFAULT_SCALES = "dev"
+DEFAULT_REPETITIONS = 1
+DEFAULT_TIMEOUT_SECONDS = 180.0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scales",
+        default=DEFAULT_SCALES,
+        help=(
+            f"Comma-separated benchmark scales. Default: {DEFAULT_SCALES}. "
+            "Use --scales dev,10x explicitly for the first larger runtime check."
+        ),
+    )
+    parser.add_argument("--repetitions", type=int, default=DEFAULT_REPETITIONS)
+    parser.add_argument("--run-timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument(
+        "--include-parent-only",
+        action="store_true",
+        help="Also run the parent-only WAM-C accumulated target for semantic/runtime comparison.",
+    )
+    parser.add_argument(
+        "--baseline-target",
+        default="c-wam-accumulated-child-csr",
+        help="Matrix baseline for speedup rows. Default: c-wam-accumulated-child-csr.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print the matrix command without running it.")
+    parser.add_argument(
+        "matrix_args",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments passed after -- to the matrix runner.",
+    )
+    return parser.parse_args()
+
+
+def matrix_command(
+    scales: str,
+    repetitions: int = DEFAULT_REPETITIONS,
+    run_timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    include_parent_only: bool = False,
+    baseline_target: str = "c-wam-accumulated-child-csr",
+    extra_args: list[str] | None = None,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(MATRIX),
+        "--scales",
+        scales,
+        "--target-sets",
+        "c-wam-child-search-layouts",
+        "--repetitions",
+        str(repetitions),
+        "--baseline-target",
+        baseline_target,
+        "--run-timeout-seconds",
+        f"{run_timeout_seconds:g}",
+    ]
+    if include_parent_only:
+        command.extend(["--include-targets", PARENT_ONLY_TARGET])
+    if extra_args:
+        command.extend(extra_args)
+    return command
+
+
+def main() -> int:
+    args = parse_args()
+    extra_args = args.matrix_args
+    if extra_args and extra_args[0] == "--":
+        extra_args = extra_args[1:]
+    command = matrix_command(
+        args.scales,
+        args.repetitions,
+        args.run_timeout_seconds,
+        args.include_parent_only,
+        args.baseline_target,
+        extra_args,
+    )
+    if args.dry_run:
+        print(" ".join(command))
+        return 0
+    return subprocess.run(command, cwd=ROOT, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_wam_c_child_search_runtime_sweep.py
+++ b/tests/test_wam_c_child_search_runtime_sweep.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
+
+from benchmark_wam_c_child_search_runtime_sweep import (  # noqa: E402
+    CHILD_SEARCH_TARGETS,
+    DEFAULT_REPETITIONS,
+    DEFAULT_TIMEOUT_SECONDS,
+    PARENT_ONLY_TARGET,
+    matrix_command,
+)
+
+
+class WamCChildSearchRuntimeSweepTests(unittest.TestCase):
+    def test_matrix_command_runs_child_search_target_set(self) -> None:
+        command = matrix_command("dev")
+
+        self.assertEqual(command[0], sys.executable)
+        self.assertIn("benchmark_effective_distance_matrix.py", command[1])
+        self.assertIn("--target-sets", command)
+        self.assertEqual(command[command.index("--target-sets") + 1], "c-wam-child-search-layouts")
+        self.assertIn("--repetitions", command)
+        self.assertEqual(command[command.index("--repetitions") + 1], str(DEFAULT_REPETITIONS))
+        self.assertIn("--run-timeout-seconds", command)
+        self.assertEqual(command[command.index("--run-timeout-seconds") + 1], f"{DEFAULT_TIMEOUT_SECONDS:g}")
+        self.assertEqual(command[command.index("--baseline-target") + 1], "c-wam-accumulated-child-csr")
+        self.assertNotIn("--compile-only-targets", command)
+        self.assertNotIn("--include-targets", command)
+
+    def test_matrix_command_can_include_parent_only_baseline(self) -> None:
+        command = matrix_command("dev", include_parent_only=True)
+
+        self.assertIn("--include-targets", command)
+        self.assertEqual(command[command.index("--include-targets") + 1], PARENT_ONLY_TARGET)
+
+    def test_matrix_command_accepts_runtime_controls_and_extra_args(self) -> None:
+        command = matrix_command(
+            "dev,10x",
+            repetitions=2,
+            run_timeout_seconds=45.0,
+            baseline_target=CHILD_SEARCH_TARGETS[0],
+            extra_args=["--keep-temp"],
+        )
+
+        self.assertEqual(command[command.index("--scales") + 1], "dev,10x")
+        self.assertEqual(command[command.index("--repetitions") + 1], "2")
+        self.assertEqual(command[command.index("--run-timeout-seconds") + 1], "45")
+        self.assertEqual(command[command.index("--baseline-target") + 1], CHILD_SEARCH_TARGETS[0])
+        self.assertEqual(command[-1], "--keep-temp")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  - add a WAM-C child-search runtime sweep wrapper around the effective-distance matrix
  - default the sweep to smoke-scale `dev`, one repetition, and a bounded runtime timeout
  - allow parent-only WAM-C as an explicit comparison row
  - document runtime evidence showing `dev` child-search layouts agree, while `10x` child-search times out across scan
  and CSR layouts

  ## Verification

  - `python3 -m py_compile examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py tests/
  test_wam_c_child_search_runtime_sweep.py`
  - `python3 tests/test_wam_c_child_search_runtime_sweep.py`
  - `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --scales dev --include-parent-only`
  - `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --scales 10x --include-parent-only`
  - `git diff --check`