### PR TITLE
Add WAM-C root-distance child-search pruning

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -1,24 +1,21 @@
 # WAM C Target - Status And Next Steps
 
-Status date: 2026-05-31
+Status date: 2026-06-02
 
 Latest branch verification:
 
-- `investigate/wam-c-child-csr-scale-sweep` based on `main` at `05de16c8`
-  (`Merge pull request #2662 from s243a/investigate/wam-c-larger-artifact-layouts`)
+- `investigate/wam-c-child-search-root-distance-pruning` based on `main` at
+  `e9ce608f` (`Merge pull request #2697 from
+  s243a/investigate/wam-c-child-search-runtime-sweep`)
+- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
-- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py examples/benchmark/benchmark_target_matrix.py examples/benchmark/benchmark_common.py tests/test_benchmark_target_matrix.py`
-- `python3 tests/test_benchmark_target_matrix.py`
-- `python3 -m py_compile examples/benchmark/benchmark_wam_c_child_csr_scale_sweep.py tests/test_wam_c_child_csr_scale_sweep.py`
-- `python3 tests/test_wam_c_child_csr_scale_sweep.py`
-- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales dev --target-sets c-wam-child-search-layouts --repetitions 1 --baseline-target c-wam-accumulated-child-scan --run-timeout-seconds 180`
-- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10x --target-sets c-wam-child-csr-layouts --compile-only-targets c-wam-accumulated-child-csr,c-wam-accumulated-child-csr-drop,c-wam-accumulated-child-csr-lmdb-offset --baseline-target c-wam-accumulated-child-csr`
-- `python3 examples/benchmark/benchmark_wam_c_child_csr_scale_sweep.py`
+- `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --scales dev --include-parent-only`
+- `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --scales 10x --include-parent-only --run-timeout-seconds 60`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-child-csr-scale-sweep`
+- `investigate/wam-c-child-search-root-distance-pruning`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -190,7 +187,7 @@ Reason:
 - Weighted/A* native kernels previously covered only integer results, while
   Haskell and Rust had broader numeric-result surfaces.
 
-### Active: `investigate/wam-c-child-search-runtime-sweep`
+### Completed Investigation: `investigate/wam-c-child-search-runtime-sweep`
 
 Goal: measure whether the newer parent-only LMDB and reverse CSR artifact
 layouts remain the right defaults at larger category scales, without forcing
@@ -263,19 +260,60 @@ Implemented so far:
   bounded child expansion query shape, not reverse CSR lookup itself, is the
   blocker beyond smoke scale.
 
-Open measurement:
+Branch conclusion before pruning follow-up:
 
-- Use compile-only rows for routine generated-project comparisons through
-  `10k`, use `--artifact-only` for `50k_cats` and `100k_cats` size checks, and
-  use the WAM-C CSR lookup microbenchmark when choosing sorted-array versus
-  LMDB-offset file-backed layouts. Schedule full child-search runtime rows
-  only for `dev` unless the query shape or expansion policy changes.
-- The next child-search improvement should focus on pruning/query policy, not
-  on in-memory CSR. The file-backed sorted-array lookup is already cheap in the
-  narrow runtime benchmark.
+- The sweep showed full child-search runtime rows should stay smoke-scale until
+  query pruning changed.
+- The next child-search improvement needed to focus on pruning/query policy,
+  not in-memory CSR. The file-backed sorted-array lookup was already cheap in
+  the narrow runtime benchmark.
 - Parent-only TSV and LMDB targets remain the priority memory structures for
   current effective-distance workloads. Reverse CSR targets are now available
   for future child-path variants and artifact-layout measurements.
+
+### Active: `investigate/wam-c-child-search-root-distance-pruning`
+
+Goal: bring WAM-C child-search pruning closer to the F# and Haskell hybrid WAM
+kernels by adding the root-distance lower bound that makes bounded child path
+exploration viable beyond smoke scale.
+
+Implemented so far:
+
+- Added a per-query `WamBidirectionalDistanceMap` to the generated C runtime.
+  It is built by BFS from the requested root over child edges, using the
+  attached reverse CSR artifact when available and falling back to the loaded
+  parent-edge table when no CSR is attached.
+- Parent and child frontier candidates now require
+  `next_cost + min_parent_hops_to_root * parent_step_cost <= budget`. Missing
+  min-distance entries are pruned, matching the F#/Haskell behavior for nodes
+  that cannot route back to the requested root.
+- Changed bounded child-search generator defaults from effectively unbounded
+  child exploration to `parent_step_cost(1.0)`, `child_step_cost(3.0)`, and
+  `child_search_budget(10.0)`. Explicit options still override these values.
+- Updated CSR smokes so reverse CSR fixtures contain both the expansion row and
+  the root-descendant row required by root-distance calibration.
+
+Evidence:
+
+- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
+- `dev` runtime sweep: parent-only and all child-search layouts now agree on
+  `19` rows; child CSR, pread/drop CSR, LMDB-offset CSR, and scan complete in
+  roughly `0.004-0.005s`.
+- `10x` runtime sweep with a `60s` timeout: sorted-array CSR completes in
+  `1.460s`, pread/drop CSR in `1.449s`, LMDB-offset CSR in `1.479s`, and
+  scan fallback in `4.100s`. The prior child-search timeout is gone, and all
+  child-search layouts agree on `187` rows. Parent-only remains faster
+  (`0.066s`) and emits `183` rows, so the output mismatch is expected when
+  child paths are enabled.
+
+Open measurement:
+
+- The min-distance map is intentionally per-query for now. If repeated roots
+  dominate a workload, add a root-keyed cache or generated warmup path before
+  pushing child search to larger English Wikipedia category workloads.
+- The CSR path is now fast enough to be useful at `10x`; the next scalability
+  question is query policy and repeated-root reuse, not raw CSR lookup cost.
 
 ### Completed Investigation: `investigate/wam-c-next-benchmark-demand`
 
@@ -466,13 +504,11 @@ After hash-bucket row dispatch but before compact row tables:
 
 ## Suggested Immediate Next Step
 
-Use `benchmark_wam_c_child_csr_scale_sweep.py` for routine compile-only
-generated-project artifact comparisons through `10k`, and use
-`benchmark_wam_c_child_csr_scale_sweep.py --artifact-only --scales
-50k_cats,100k_cats` for large category-graph artifact bytes. Use
-`benchmark_wam_c_reverse_csr_lookup.py` for narrow WAM-C runtime lookup costs.
-Use `benchmark_wam_c_child_search_runtime_sweep.py` only for smoke-scale
-end-to-end child-search runs until the expansion policy is narrowed. The current
-evidence supports keeping sorted-array file-backed CSR as the first child-lookup
-layout, deferring in-memory compressed CSR, and next improving child-search
-pruning/cost policy before spending more effort on storage layout.
+Use `benchmark_wam_c_child_search_runtime_sweep.py` as the routine child-search
+runtime check through `10x`, now that root-distance pruning removes the previous
+timeout. Keep `benchmark_wam_c_child_csr_scale_sweep.py --artifact-only` for
+large category-graph artifact bytes, and use
+`benchmark_wam_c_reverse_csr_lookup.py` only when changing CSR lookup storage.
+The next useful C child-search work is repeated-root reuse for the per-query
+min-distance map, followed by a larger-scale runtime sweep before considering
+in-memory compressed CSR.

--- a/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
@@ -201,8 +201,8 @@ child_search_layout_options([
     max_child_expansions(8),
     child_search_depth(1),
     parent_step_cost(1.0),
-    child_step_cost(2.0),
-    child_search_budget(1.0e100)
+    child_step_cost(3.0),
+    child_search_budget(10.0)
 ]).
 
 parse_child_search_options(Options, ChildSearch) :-
@@ -215,8 +215,8 @@ parse_child_search_options(Options, ChildSearch) :-
     option_or_default(max_child_expansions, Options, 0, MaxChildren),
     option_or_default(child_search_depth, Options, 1, ChildDepth),
     option_or_default(parent_step_cost, Options, 1.0, ParentCost),
-    option_or_default(child_step_cost, Options, 1.0, ChildCost),
-    option_or_default(child_search_budget, Options, 1.0e100, Budget),
+    option_or_default(child_step_cost, Options, 3.0, ChildCost),
+    option_or_default(child_search_budget, Options, 10.0, Budget),
     validate_nonnegative_int(max_child_expansions, MaxChildren),
     validate_nonnegative_int(child_search_depth, ChildDepth),
     validate_positive_number(parent_step_cost, ParentCost),

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -3511,6 +3511,258 @@ static bool wam_category_id_to_atom(WamState *state, int id, const char **atom_o
     return false;
 }
 
+typedef struct {
+    const char **keys;
+    int *distances;
+    int capacity;
+    int count;
+} WamBidirectionalDistanceMap;
+
+typedef struct {
+    const char **items;
+    int count;
+    int cap;
+} WamBidirectionalAtomQueue;
+
+static uint64_t wam_bidirectional_atom_hash(const char *atom) {
+    uint64_t h = 1469598103934665603ULL;
+    const unsigned char *p = (const unsigned char *)atom;
+    while (*p) {
+        h ^= (uint64_t)(*p++);
+        h *= 1099511628211ULL;
+    }
+    return h;
+}
+
+static void wam_bidirectional_distance_map_init(WamBidirectionalDistanceMap *map) {
+    memset(map, 0, sizeof(WamBidirectionalDistanceMap));
+}
+
+static void wam_bidirectional_distance_map_close(WamBidirectionalDistanceMap *map) {
+    free(map->keys);
+    free(map->distances);
+    memset(map, 0, sizeof(WamBidirectionalDistanceMap));
+}
+
+static int wam_bidirectional_distance_map_slot(const char **keys,
+                                               int capacity,
+                                               const char *key,
+                                               bool *present) {
+    uint64_t h = wam_bidirectional_atom_hash(key);
+    int mask = capacity - 1;
+    int slot = (int)(h & (uint64_t)mask);
+    while (keys[slot]) {
+        if (strcmp(keys[slot], key) == 0) {
+            *present = true;
+            return slot;
+        }
+        slot = (slot + 1) & mask;
+    }
+    *present = false;
+    return slot;
+}
+
+static bool wam_bidirectional_distance_map_reserve(WamBidirectionalDistanceMap *map,
+                                                   int min_capacity) {
+    if (min_capacity < WAM_INITIAL_CAP) min_capacity = WAM_INITIAL_CAP;
+    if (map->capacity >= min_capacity) return true;
+
+    int new_capacity = map->capacity ? map->capacity : WAM_INITIAL_CAP;
+    while (new_capacity < min_capacity) {
+        if (new_capacity > INT_MAX / 2) return false;
+        new_capacity *= 2;
+    }
+
+    const char **new_keys = calloc((size_t)new_capacity, sizeof(const char *));
+    int *new_distances = malloc(sizeof(int) * (size_t)new_capacity);
+    if (!new_keys || !new_distances) {
+        free(new_keys);
+        free(new_distances);
+        return false;
+    }
+
+    for (int i = 0; i < map->capacity; i++) {
+        if (!map->keys[i]) continue;
+        bool present = false;
+        int slot = wam_bidirectional_distance_map_slot(
+            new_keys, new_capacity, map->keys[i], &present);
+        new_keys[slot] = map->keys[i];
+        new_distances[slot] = map->distances[i];
+    }
+
+    free(map->keys);
+    free(map->distances);
+    map->keys = new_keys;
+    map->distances = new_distances;
+    map->capacity = new_capacity;
+    return true;
+}
+
+static bool wam_bidirectional_distance_map_get(WamBidirectionalDistanceMap *map,
+                                               const char *key,
+                                               int *distance_out) {
+    if (map->capacity == 0) return false;
+    bool present = false;
+    int slot = wam_bidirectional_distance_map_slot(
+        map->keys, map->capacity, key, &present);
+    if (!present) return false;
+    *distance_out = map->distances[slot];
+    return true;
+}
+
+static bool wam_bidirectional_distance_map_put_if_absent(
+        WamBidirectionalDistanceMap *map,
+        const char *key,
+        int distance,
+        bool *inserted) {
+    if (map->capacity == 0 || map->count >= map->capacity / 2) {
+        int next_capacity = WAM_INITIAL_CAP;
+        if (map->capacity) {
+            if (map->capacity > INT_MAX / 2) return false;
+            next_capacity = map->capacity * 2;
+        }
+        if (!wam_bidirectional_distance_map_reserve(map, next_capacity)) return false;
+    }
+
+    bool present = false;
+    int slot = wam_bidirectional_distance_map_slot(
+        map->keys, map->capacity, key, &present);
+    if (present) {
+        *inserted = false;
+        return true;
+    }
+    map->keys[slot] = key;
+    map->distances[slot] = distance;
+    map->count++;
+    *inserted = true;
+    return true;
+}
+
+static void wam_bidirectional_atom_queue_init(WamBidirectionalAtomQueue *queue) {
+    memset(queue, 0, sizeof(WamBidirectionalAtomQueue));
+}
+
+static void wam_bidirectional_atom_queue_close(WamBidirectionalAtomQueue *queue) {
+    free(queue->items);
+    memset(queue, 0, sizeof(WamBidirectionalAtomQueue));
+}
+
+static bool wam_bidirectional_atom_queue_push(WamBidirectionalAtomQueue *queue,
+                                              const char *atom) {
+    if (queue->count >= queue->cap) {
+        int next_cap = WAM_INITIAL_CAP;
+        if (queue->cap) {
+            if (queue->cap > INT_MAX / 2) return false;
+            next_cap = queue->cap * 2;
+        }
+        const char **items = realloc(queue->items,
+                                     sizeof(const char *) * (size_t)next_cap);
+        if (!items) return false;
+        queue->items = items;
+        queue->cap = next_cap;
+    }
+    queue->items[queue->count++] = atom;
+    return true;
+}
+
+static bool wam_bidirectional_build_min_distances(WamState *state,
+                                                  const char *root,
+                                                  WamBidirectionalDistanceMap *map) {
+    WamBidirectionalAtomQueue queue;
+    wam_bidirectional_atom_queue_init(&queue);
+
+    bool inserted = false;
+    if (!wam_bidirectional_distance_map_put_if_absent(map, root, 0, &inserted) ||
+        !wam_bidirectional_atom_queue_push(&queue, root)) {
+        wam_bidirectional_atom_queue_close(&queue);
+        return false;
+    }
+
+    for (int head = 0; head < queue.count; head++) {
+        const char *node = queue.items[head];
+        int distance = 0;
+        if (!wam_bidirectional_distance_map_get(map, node, &distance)) continue;
+        int next_distance = distance + 1;
+
+        if (state->bidirectional_child_csr) {
+            int parent_id = 0;
+            if (!wam_category_atom_to_id(state, node, &parent_id)) continue;
+            int child_count = wam_reverse_csr_lookup_children(
+                state->bidirectional_child_csr, parent_id, NULL, 0);
+            if (child_count < 0) {
+                wam_bidirectional_atom_queue_close(&queue);
+                return false;
+            }
+            if (child_count == 0) continue;
+            int *child_ids = malloc(sizeof(int) * (size_t)child_count);
+            if (!child_ids) {
+                wam_bidirectional_atom_queue_close(&queue);
+                return false;
+            }
+            int read_count = wam_reverse_csr_lookup_children(
+                state->bidirectional_child_csr, parent_id, child_ids, child_count);
+            if (read_count < 0) {
+                free(child_ids);
+                wam_bidirectional_atom_queue_close(&queue);
+                return false;
+            }
+            int limit = read_count < child_count ? read_count : child_count;
+            for (int i = 0; i < limit; i++) {
+                const char *child = NULL;
+                if (!wam_category_id_to_atom(state, child_ids[i], &child)) continue;
+                bool child_inserted = false;
+                if (!wam_bidirectional_distance_map_put_if_absent(
+                        map, child, next_distance, &child_inserted)) {
+                    free(child_ids);
+                    wam_bidirectional_atom_queue_close(&queue);
+                    return false;
+                }
+                if (child_inserted &&
+                    !wam_bidirectional_atom_queue_push(&queue, child)) {
+                    free(child_ids);
+                    wam_bidirectional_atom_queue_close(&queue);
+                    return false;
+                }
+            }
+            free(child_ids);
+            continue;
+        }
+
+        for (int i = 0; i < state->category_edge_count; i++) {
+            CategoryEdge *edge = &state->category_edges[i];
+            if (strcmp(edge->parent, node) != 0) continue;
+            bool child_inserted = false;
+            if (!wam_bidirectional_distance_map_put_if_absent(
+                    map, edge->child, next_distance, &child_inserted)) {
+                wam_bidirectional_atom_queue_close(&queue);
+                return false;
+            }
+            if (child_inserted &&
+                !wam_bidirectional_atom_queue_push(&queue, edge->child)) {
+                wam_bidirectional_atom_queue_close(&queue);
+                return false;
+            }
+        }
+    }
+
+    wam_bidirectional_atom_queue_close(&queue);
+    return true;
+}
+
+static bool wam_bidirectional_can_reach_root_within_budget(
+        WamBidirectionalDistanceMap *min_distances,
+        const char *node,
+        double next_cost,
+        double parent_cost,
+        double budget) {
+    int min_parent_hops = 0;
+    if (!wam_bidirectional_distance_map_get(
+            min_distances, node, &min_parent_hops)) {
+        return false;
+    }
+    return next_cost + ((double)min_parent_hops * parent_cost) <= budget;
+}
+
 static bool wam_category_ancestor_dfs(WamState *state,
                                       const char *cat,
                                       const char *root,
@@ -3607,6 +3859,7 @@ static bool wam_bidirectional_ancestor_dfs(WamState *state,
                                            int parent_hops,
                                            int child_hops,
                                            double cost,
+                                           WamBidirectionalDistanceMap *min_distances,
                                            WamBidirectionalAncestorResults *results);
 
 static bool wam_bidirectional_ancestor_step_child(
@@ -3620,13 +3873,19 @@ static bool wam_bidirectional_ancestor_step_child(
         int parent_hops,
         int child_hops,
         double cost,
+        double parent_cost,
         double child_cost,
         double budget,
+        WamBidirectionalDistanceMap *min_distances,
         WamBidirectionalAncestorResults *results,
         bool *found) {
     if (wam_visited_array_contains(visited, visited_len, child)) return true;
     double next_cost = cost + child_cost;
     if (next_cost > budget) return true;
+    if (!wam_bidirectional_can_reach_root_within_budget(
+            min_distances, child, next_cost, parent_cost, budget)) {
+        return true;
+    }
     int next_child_hops = child_hops + 1;
     if (strcmp(child, root) == 0) {
         if (!wam_bidirectional_ancestor_results_push(
@@ -3643,7 +3902,7 @@ static bool wam_bidirectional_ancestor_step_child(
                                        depth + 1, max_depth,
                                        visited, visited_len + 1,
                                        parent_hops, next_child_hops,
-                                       next_cost, results)) {
+                                       next_cost, min_distances, results)) {
         *found = true;
     }
     return true;
@@ -3660,8 +3919,10 @@ static bool wam_bidirectional_ancestor_expand_children(
         int parent_hops,
         int child_hops,
         double cost,
+        double parent_cost,
         double child_cost,
         double budget,
+        WamBidirectionalDistanceMap *min_distances,
         WamBidirectionalAncestorResults *results,
         bool *found) {
     if (state->bidirectional_child_csr) {
@@ -3677,8 +3938,8 @@ static bool wam_bidirectional_ancestor_expand_children(
             if (!wam_category_id_to_atom(state, child_ids[i], &child)) continue;
             if (!wam_bidirectional_ancestor_step_child(
                     state, child, root, depth, max_depth, visited, visited_len,
-                    parent_hops, child_hops, cost, child_cost, budget,
-                    results, found)) {
+                    parent_hops, child_hops, cost, parent_cost, child_cost,
+                    budget, min_distances, results, found)) {
                 return false;
             }
         }
@@ -3690,8 +3951,8 @@ static bool wam_bidirectional_ancestor_expand_children(
         if (strcmp(edge->parent, node) != 0) continue;
         if (!wam_bidirectional_ancestor_step_child(
                 state, edge->child, root, depth, max_depth, visited, visited_len,
-                parent_hops, child_hops, cost, child_cost, budget,
-                results, found)) {
+                parent_hops, child_hops, cost, parent_cost, child_cost,
+                budget, min_distances, results, found)) {
             return false;
         }
     }
@@ -3708,6 +3969,7 @@ static bool wam_bidirectional_ancestor_dfs(WamState *state,
                                            int parent_hops,
                                            int child_hops,
                                            double cost,
+                                           WamBidirectionalDistanceMap *min_distances,
                                            WamBidirectionalAncestorResults *results) {
     bool found = false;
     double parent_cost = state->bidirectional_parent_step_cost > 0.0
@@ -3728,6 +3990,10 @@ static bool wam_bidirectional_ancestor_dfs(WamState *state,
         if (wam_visited_array_contains(visited, visited_len, edge->parent)) continue;
         double next_cost = cost + parent_cost;
         if (next_cost > budget) continue;
+        if (!wam_bidirectional_can_reach_root_within_budget(
+                min_distances, edge->parent, next_cost, parent_cost, budget)) {
+            continue;
+        }
         int next_parent_hops = parent_hops + 1;
         if (strcmp(edge->parent, root) == 0) {
             if (!wam_bidirectional_ancestor_results_push(
@@ -3744,15 +4010,15 @@ static bool wam_bidirectional_ancestor_dfs(WamState *state,
                                            depth + 1, max_depth,
                                            visited, visited_len + 1,
                                            next_parent_hops, child_hops,
-                                           next_cost, results)) {
+                                           next_cost, min_distances, results)) {
             found = true;
         }
     }
 
     if (!wam_bidirectional_ancestor_expand_children(
             state, node, root, depth, max_depth, visited, visited_len,
-            parent_hops, child_hops, cost, child_cost, budget,
-            results, &found)) {
+            parent_hops, child_hops, cost, parent_cost, child_cost, budget,
+            min_distances, results, &found)) {
         return false;
     }
 
@@ -3771,11 +4037,20 @@ bool wam_collect_bidirectional_ancestor_hops(WamState *state,
         return wam_bidirectional_ancestor_results_push(results, 0, 0, 0);
     }
 
+    WamBidirectionalDistanceMap min_distances;
+    wam_bidirectional_distance_map_init(&min_distances);
+    if (!wam_bidirectional_build_min_distances(state, root, &min_distances)) {
+        wam_bidirectional_distance_map_close(&min_distances);
+        return false;
+    }
+
     visited[visited_len++] = cat;
     int max_depth = state->category_max_depth > 0 ? state->category_max_depth : 10;
-    return wam_bidirectional_ancestor_dfs(state, cat, root, 0, max_depth,
-                                          visited, visited_len, 0, 0, 0.0,
-                                          results);
+    bool ok = wam_bidirectional_ancestor_dfs(state, cat, root, 0, max_depth,
+                                             visited, visited_len, 0, 0, 0.0,
+                                             &min_distances, results);
+    wam_bidirectional_distance_map_close(&min_distances);
+    return ok;
 }
 
 static bool wam_unify_bidirectional_ancestor_result(

--- a/tests/test_wam_c_effective_distance_benchmark.pl
+++ b/tests/test_wam_c_effective_distance_benchmark.pl
@@ -96,7 +96,7 @@ test_generate_and_run_bounded_child_search :-
         compile_generated_project(OutputDir, facts_tsv),
         run_generated_project(OutputDir, Output),
         sub_string(Output, _, _, _, "article\troot_category\teffective_distance"),
-        sub_string(Output, _, _, _, "article_a\troot\t3.000000")
+        sub_string(Output, _, _, _, "article_a\troot\t5.000000")
     ->  pass(Test)
     ;   fail_test(Test, 'bounded child search runner output mismatch')
     ).
@@ -121,6 +121,7 @@ test_child_search_uses_bidirectional_kernel :-
         sub_string(Lib, _, _, _, 'WAM-compiled predicate: bidirectional_ancestor/5'),
         sub_string(Main, _, _, _, 'setup_bidirectional_ancestor_5(&state);'),
         sub_string(Main, _, _, _, 'wam_register_bidirectional_ancestor_kernel(&state, "bidirectional_ancestor/5"'),
+        sub_string(Main, _, _, _, 'wam_register_bidirectional_ancestor_kernel(&state, "bidirectional_ancestor/5", 10, 1.0, 3.0, 10.0);'),
         sub_string(Main, _, _, _, 'wam_collect_bidirectional_ancestor_hops(state, &bidir)'),
         sub_string(Main, _, _, _, 'path->child_hops <= 0')
     ->  pass(Test)
@@ -162,7 +163,7 @@ test_child_search_builds_reverse_csr :-
         compile_generated_project(OutputDir, facts_tsv),
         run_generated_project(OutputDir, Output),
         sub_string(Output, _, _, _, "article\troot_category\teffective_distance"),
-        sub_string(Output, _, _, _, "article_a\troot\t3.000000")
+        sub_string(Output, _, _, _, "article_a\troot\t5.000000")
     ->  pass(Test)
     ;   fail_test(Test, 'reverse_index csr child-search output mismatch')
     ).
@@ -190,7 +191,7 @@ test_child_search_builds_pread_drop_reverse_csr :-
         sub_string(Lib, _, _, _, 'wam_reverse_csr_load_pread_drop(bidirectional_child_csr, "category_child.csr.idx", "category_child.csr.val")'),
         compile_generated_project(OutputDir, facts_tsv),
         run_generated_project(OutputDir, Output),
-        sub_string(Output, _, _, _, "article_a\troot\t3.000000")
+        sub_string(Output, _, _, _, "article_a\troot\t5.000000")
     ->  pass(Test)
     ;   fail_test(Test, 'buffered_pread_drop reverse_index csr output mismatch')
     ).
@@ -232,7 +233,7 @@ test_child_search_builds_lmdb_offset_reverse_csr :-
         (   lmdb_toolchain_available
         ->  compile_generated_project(OutputDir, facts_tsv),
             run_generated_project(OutputDir, Output),
-            sub_string(Output, _, _, _, "article_a\troot\t3.000000")
+            sub_string(Output, _, _, _, "article_a\troot\t5.000000")
         ;   true
         )
     ->  pass(Test)
@@ -310,7 +311,7 @@ test_generate_and_run_bounded_child_search_kernels_off :-
         compile_generated_project(OutputDir, facts_tsv),
         run_generated_project(OutputDir, Output),
         sub_string(Output, _, _, _, "article\troot_category\teffective_distance"),
-        sub_string(Output, _, _, _, "article_a\troot\t3.000000")
+        sub_string(Output, _, _, _, "article_a\troot\t5.000000")
     ->  pass(Test)
     ;   fail_test(Test, 'kernels_off child search runner output mismatch')
     ).

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -271,6 +271,9 @@ test_bidirectional_ancestor_kernel_generation :-
         sub_string(S, _, _, _, 'wam_bidirectional_ancestor_dfs'),
         sub_string(S, _, _, _, 'void wam_attach_bidirectional_child_csr'),
         sub_string(S, _, _, _, 'void wam_register_category_id'),
+        sub_string(S, _, _, _, 'WamBidirectionalDistanceMap'),
+        sub_string(S, _, _, _, 'wam_bidirectional_build_min_distances'),
+        sub_string(S, _, _, _, 'wam_bidirectional_can_reach_root_within_budget'),
         sub_string(S, _, _, _, 'bidirectional_parent_step_cost')
     ->  pass(Test)
     ;   fail_test(Test, 'bidirectional_ancestor native kernel helpers missing')
@@ -1839,9 +1842,11 @@ run_bidirectional_ancestor_csr_child_lookup_executable_smoke :-
     format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
     write_text_file(PredPath, PredTranslationUnit),
     write_binary_file(IndexPath, [
-        20,0,0,0, 0,0,0,0,0,0,0,0, 1,0,0,0
+        20,0,0,0, 0,0,0,0,0,0,0,0, 1,0,0,0,
+        40,0,0,0, 1,0,0,0,0,0,0,0, 1,0,0,0
     ]),
     write_binary_file(ValuesPath, [
+        30,0,0,0,
         30,0,0,0
     ]),
     wam_c_bidirectional_ancestor_csr_smoke_main(IndexPath, ValuesPath, MainCode),
@@ -1879,9 +1884,11 @@ run_reverse_index_setup_executable_smoke :-
            [SetupCode, PredCode]),
     write_text_file(PredPath, PredTranslationUnit),
     write_binary_file(IndexPath, [
-        20,0,0,0, 0,0,0,0,0,0,0,0, 1,0,0,0
+        20,0,0,0, 0,0,0,0,0,0,0,0, 1,0,0,0,
+        40,0,0,0, 1,0,0,0,0,0,0,0, 1,0,0,0
     ]),
     write_binary_file(ValuesPath, [
+        30,0,0,0,
         30,0,0,0
     ]),
     wam_c_reverse_index_setup_smoke_main(MainCode),


### PR DESCRIPTION
  ## Summary

  - Add F#/Haskell-style root-distance lower-bound pruning to the WAM-C bidirectional child-search kernel.
  - Build a per-query descendant-to-root min-distance map using reverse CSR when attached, with parent-edge scan
  fallback.
  - Change bounded child-search defaults to finite direction costs: parent `1.0`, child `3.0`, budget `10.0`.
  - Update WAM-C child-search tests, CSR fixtures, and target status notes.

  ## Verification

  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
  - `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --scales dev --include-parent-only`
  - `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --scales 10x --include-parent-only --run-
  timeout-seconds 60`
  - `git diff --check`