### PR TITLE
Cache WAM-C root-distance maps by root

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,18 +4,20 @@ Status date: 2026-06-02
 
 Latest branch verification:
 
-- `investigate/wam-c-child-search-root-distance-pruning` based on `main` at
-  `e9ce608f` (`Merge pull request #2697 from
-  s243a/investigate/wam-c-child-search-runtime-sweep`)
+- `investigate/wam-c-root-distance-cache` based on `main` at `32a74aee`
+  (`Merge pull request #2705 from
+  s243a/investigate/wam-c-child-search-root-distance-pruning`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --scales dev --include-parent-only`
 - `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --scales 10x --include-parent-only --run-timeout-seconds 60`
+- `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --scales 1k --include-parent-only --run-timeout-seconds 60`
+- `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --scales 5k --include-parent-only --run-timeout-seconds 60`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-child-search-root-distance-pruning`
+- `investigate/wam-c-root-distance-cache`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -271,7 +273,7 @@ Branch conclusion before pruning follow-up:
   current effective-distance workloads. Reverse CSR targets are now available
   for future child-path variants and artifact-layout measurements.
 
-### Active: `investigate/wam-c-child-search-root-distance-pruning`
+### Completed Investigation: `investigate/wam-c-child-search-root-distance-pruning`
 
 Goal: bring WAM-C child-search pruning closer to the F# and Haskell hybrid WAM
 kernels by adding the root-distance lower bound that makes bounded child path
@@ -307,13 +309,60 @@ Evidence:
   (`0.066s`) and emits `183` rows, so the output mismatch is expected when
   child paths are enabled.
 
-Open measurement:
+Branch conclusion before cache follow-up:
 
-- The min-distance map is intentionally per-query for now. If repeated roots
-  dominate a workload, add a root-keyed cache or generated warmup path before
-  pushing child search to larger English Wikipedia category workloads.
+- The min-distance map was intentionally per-query in this branch. The next
+  useful follow-up was root-keyed cache reuse because effective-distance runs
+  query the same roots repeatedly.
 - The CSR path is now fast enough to be useful at `10x`; the next scalability
   question is query policy and repeated-root reuse, not raw CSR lookup cost.
+
+### Active: `investigate/wam-c-root-distance-cache`
+
+Goal: reuse root-distance calibration across repeated effective-distance
+queries that share the same root, without adding a preprocessing artifact yet.
+
+Implemented so far:
+
+- Added an opaque `bidirectional_min_distance_cache` pointer to `WamState`.
+- The generated C runtime now keeps a root-keyed linked list of
+  `WamBidirectionalDistanceMap` entries. `wam_collect_bidirectional_ancestor_hops`
+  reuses an existing root map when possible and builds a new one only on a
+  cache miss.
+- Cache entries are freed by `wam_free_state` and invalidated when category
+  parent facts, category IDs, or the attached child CSR artifact change.
+- Executable smokes assert that a successful bidirectional query populates the
+  cache and that fact/CSR mutations clear it.
+
+Evidence:
+
+- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
+- `dev` runtime sweep: all layouts still agree on `19` rows; child-search
+  layouts complete in roughly `0.004-0.005s`.
+- `10x` runtime sweep with a `60s` timeout: sorted-array CSR completes in
+  `0.110s`, pread/drop CSR in `0.101s`, LMDB-offset CSR in `0.102s`, and scan
+  fallback in `0.128s`. This is down from about `1.45s` for CSR and `4.10s`
+  for scan after root-distance pruning but before root-cache reuse.
+- `1k` runtime sweep with a `60s` timeout: parent-only and all child-search
+  layouts agree on `580` rows; sorted-array CSR completes in `0.584s`,
+  pread/drop CSR in `0.598s`, LMDB-offset CSR in `0.567s`, and scan fallback
+  in `0.708s`.
+- `5k` runtime sweep with a `60s` timeout: parent-only and all child-search
+  layouts agree on `3,224` rows; sorted-array CSR completes in `2.992s`,
+  pread/drop CSR in `3.185s`, LMDB-offset CSR in `3.394s`, and scan fallback
+  in `3.679s`.
+
+Open measurement:
+
+- Root-distance maps can now be reused within a generated query run, but they
+  are still runtime-local. Persisting `min_distance(root,node)` in LMDB or a
+  compact artifact could reduce cold-start work for workloads with stable roots,
+  but it adds preprocessing time, storage, invalidation complexity, and planner
+  surface area. That option should be gated by the cost analyzer rather than
+  made a default.
+- The next scalability check should run larger child-search sweeps and compare
+  root-cache memory growth against the number of distinct roots.
 
 ### Completed Investigation: `investigate/wam-c-next-benchmark-demand`
 
@@ -504,11 +553,10 @@ After hash-bucket row dispatch but before compact row tables:
 
 ## Suggested Immediate Next Step
 
-Use `benchmark_wam_c_child_search_runtime_sweep.py` as the routine child-search
-runtime check through `10x`, now that root-distance pruning removes the previous
-timeout. Keep `benchmark_wam_c_child_csr_scale_sweep.py --artifact-only` for
-large category-graph artifact bytes, and use
-`benchmark_wam_c_reverse_csr_lookup.py` only when changing CSR lookup storage.
-The next useful C child-search work is repeated-root reuse for the per-query
-min-distance map, followed by a larger-scale runtime sweep before considering
-in-memory compressed CSR.
+Use `benchmark_wam_c_child_search_runtime_sweep.py` beyond `5k` to find the
+next child-search ceiling now that root-distance maps are reused per root. Keep
+`benchmark_wam_c_child_csr_scale_sweep.py --artifact-only` for large
+category-graph artifact bytes, and use `benchmark_wam_c_reverse_csr_lookup.py`
+only when changing CSR lookup storage. Do not persist root-distance maps to
+LMDB or a separate artifact by default; add that only behind a cost-analyzer
+decision that can justify the extra preprocessing and invalidation surface.

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -298,6 +298,7 @@ struct WamState {
     double bidirectional_child_step_cost;
     double bidirectional_cost_budget;
     WamReverseCsrArtifact *bidirectional_child_csr;
+    void *bidirectional_min_distance_cache;
     WamCategoryIdEntry *category_ids;
     int category_id_count;
     int category_id_cap;

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -2341,6 +2341,8 @@ compile_wam_helpers_to_c(_Options, CCode) :-
 #include <limits.h>
 #include <unistd.h>
 
+static void wam_bidirectional_distance_cache_clear(WamState *state);
+
 void wam_state_init(WamState *state) {
     memset(state, 0, sizeof(WamState));
     state->H_cap = WAM_INITIAL_CAP;
@@ -2377,6 +2379,7 @@ void wam_free_state(WamState *state) {
     free(state->TR_array);
     free(state->B_array);
     free(state->E_array);
+    wam_bidirectional_distance_cache_clear(state);
     free(state->category_edges);
     free(state->category_edges_by_child);
     free(state->category_ids);
@@ -2677,6 +2680,7 @@ void wam_register_category_parent(WamState *state, const char *child, const char
     state->category_edges[state->category_edge_count].parent = wam_intern_atom(state, parent);
     state->category_edge_count++;
     state->category_child_index_dirty = true;
+    wam_bidirectional_distance_cache_clear(state);
 }
 
 void wam_register_transitive_edge(WamState *state, const char *child, const char *parent) {
@@ -2966,6 +2970,7 @@ void wam_register_category_id(WamState *state, const char *atom, int id) {
     for (int i = 0; i < state->category_id_count; i++) {
         if (strcmp(state->category_ids[i].atom, interned) == 0) {
             state->category_ids[i].id = id;
+            wam_bidirectional_distance_cache_clear(state);
             return;
         }
     }
@@ -2976,10 +2981,12 @@ void wam_register_category_id(WamState *state, const char *atom, int id) {
     state->category_ids[state->category_id_count].atom = interned;
     state->category_ids[state->category_id_count].id = id;
     state->category_id_count++;
+    wam_bidirectional_distance_cache_clear(state);
 }
 
 void wam_attach_bidirectional_child_csr(WamState *state, WamReverseCsrArtifact *artifact) {
     state->bidirectional_child_csr = artifact;
+    wam_bidirectional_distance_cache_clear(state);
 }
 
 static int32_t wam_read_i32_le(const unsigned char *p) {
@@ -3518,6 +3525,12 @@ typedef struct {
     int count;
 } WamBidirectionalDistanceMap;
 
+typedef struct WamBidirectionalDistanceCacheEntry {
+    const char *root;
+    WamBidirectionalDistanceMap distances;
+    struct WamBidirectionalDistanceCacheEntry *next;
+} WamBidirectionalDistanceCacheEntry;
+
 typedef struct {
     const char **items;
     int count;
@@ -3747,6 +3760,47 @@ static bool wam_bidirectional_build_min_distances(WamState *state,
 
     wam_bidirectional_atom_queue_close(&queue);
     return true;
+}
+
+static void wam_bidirectional_distance_cache_clear(WamState *state) {
+    WamBidirectionalDistanceCacheEntry *entry =
+        (WamBidirectionalDistanceCacheEntry *)state->bidirectional_min_distance_cache;
+    while (entry) {
+        WamBidirectionalDistanceCacheEntry *next = entry->next;
+        wam_bidirectional_distance_map_close(&entry->distances);
+        free(entry);
+        entry = next;
+    }
+    state->bidirectional_min_distance_cache = NULL;
+}
+
+static WamBidirectionalDistanceMap *wam_bidirectional_get_min_distances(
+        WamState *state,
+        const char *root) {
+    WamBidirectionalDistanceCacheEntry *entry =
+        (WamBidirectionalDistanceCacheEntry *)state->bidirectional_min_distance_cache;
+    while (entry) {
+        if (strcmp(entry->root, root) == 0) {
+            return &entry->distances;
+        }
+        entry = entry->next;
+    }
+
+    WamBidirectionalDistanceCacheEntry *new_entry =
+        calloc(1, sizeof(WamBidirectionalDistanceCacheEntry));
+    if (!new_entry) return NULL;
+    new_entry->root = wam_intern_atom(state, root);
+    wam_bidirectional_distance_map_init(&new_entry->distances);
+    if (!wam_bidirectional_build_min_distances(
+            state, new_entry->root, &new_entry->distances)) {
+        wam_bidirectional_distance_map_close(&new_entry->distances);
+        free(new_entry);
+        return NULL;
+    }
+    new_entry->next =
+        (WamBidirectionalDistanceCacheEntry *)state->bidirectional_min_distance_cache;
+    state->bidirectional_min_distance_cache = new_entry;
+    return &new_entry->distances;
 }
 
 static bool wam_bidirectional_can_reach_root_within_budget(
@@ -4037,10 +4091,9 @@ bool wam_collect_bidirectional_ancestor_hops(WamState *state,
         return wam_bidirectional_ancestor_results_push(results, 0, 0, 0);
     }
 
-    WamBidirectionalDistanceMap min_distances;
-    wam_bidirectional_distance_map_init(&min_distances);
-    if (!wam_bidirectional_build_min_distances(state, root, &min_distances)) {
-        wam_bidirectional_distance_map_close(&min_distances);
+    WamBidirectionalDistanceMap *min_distances =
+        wam_bidirectional_get_min_distances(state, root);
+    if (!min_distances) {
         return false;
     }
 
@@ -4048,8 +4101,7 @@ bool wam_collect_bidirectional_ancestor_hops(WamState *state,
     int max_depth = state->category_max_depth > 0 ? state->category_max_depth : 10;
     bool ok = wam_bidirectional_ancestor_dfs(state, cat, root, 0, max_depth,
                                              visited, visited_len, 0, 0, 0.0,
-                                             &min_distances, results);
-    wam_bidirectional_distance_map_close(&min_distances);
+                                             min_distances, results);
     return ok;
 }
 

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -272,8 +272,11 @@ test_bidirectional_ancestor_kernel_generation :-
         sub_string(S, _, _, _, 'void wam_attach_bidirectional_child_csr'),
         sub_string(S, _, _, _, 'void wam_register_category_id'),
         sub_string(S, _, _, _, 'WamBidirectionalDistanceMap'),
+        sub_string(S, _, _, _, 'WamBidirectionalDistanceCacheEntry'),
         sub_string(S, _, _, _, 'wam_bidirectional_build_min_distances'),
+        sub_string(S, _, _, _, 'wam_bidirectional_get_min_distances'),
         sub_string(S, _, _, _, 'wam_bidirectional_can_reach_root_within_budget'),
+        sub_string(S, _, _, _, 'bidirectional_min_distance_cache'),
         sub_string(S, _, _, _, 'bidirectional_parent_step_cost')
     ->  pass(Test)
     ;   fail_test(Test, 'bidirectional_ancestor native kernel helpers missing')
@@ -3239,6 +3242,15 @@ int main(void) {
         wam_free_state(&state);
         return 10;
     }
+    if (state.bidirectional_min_distance_cache == NULL) {
+        wam_free_state(&state);
+        return 11;
+    }
+    wam_register_category_parent(&state, "fresh_child", "root");
+    if (state.bidirectional_min_distance_cache != NULL) {
+        wam_free_state(&state);
+        return 12;
+    }
 
     wam_register_bidirectional_ancestor_kernel(&state, "bidirectional_ancestor/5",
                                                4, 1.0, 2.0, 2.5);
@@ -3303,8 +3315,18 @@ int main(void) {
         wam_free_state(&state);
         return 10;
     }
+    if (state.bidirectional_min_distance_cache == NULL) {
+        wam_reverse_csr_close(&csr);
+        wam_free_state(&state);
+        return 11;
+    }
 
     wam_attach_bidirectional_child_csr(&state, NULL);
+    if (state.bidirectional_min_distance_cache != NULL) {
+        wam_reverse_csr_close(&csr);
+        wam_free_state(&state);
+        return 12;
+    }
     WamValue fallback_args[5] = {
         val_atom("orphan"),
         val_atom("root"),


### PR DESCRIPTION
  ## Summary

  - Add a root-keyed runtime cache for WAM-C bidirectional min-distance maps.
  - Reuse root-distance calibration across repeated effective-distance queries with the same root.
  - Invalidate the cache when category facts, category IDs, or the attached child CSR artifact change.
  - Free cached maps from `wam_free_state`.
  - Document that persisted min-distance artifacts should be cost-planner-gated, not default behavior.

  ## Verification

  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
  - `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --scales dev --include-parent-only`
  - `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --scales 10x --include-parent-only --run-
  timeout-seconds 60`
  - `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --scales 1k --include-parent-only --run-
  timeout-seconds 60`
  - `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --scales 5k --include-parent-only --run-
  timeout-seconds 60`
  - `git diff --check`