### PR TITLE
Add cross-target WAM conformance harness

### DIFF
--- a/docs/WAM_CROSS_TARGET_CONFORMANCE.md
+++ b/docs/WAM_CROSS_TARGET_CONFORMANCE.md
@@ -1,0 +1,98 @@
+# Cross-target WAM conformance harness
+
+**Files:** `tests/wam_conformance_fixtures.pl` (the shared spec),
+`tests/test_wam_cross_target_conformance.pl` (the harness).
+
+## What it is
+
+A single set of classic Prolog programs (`member`, `append`, `reverse`,
+`fib`, `ack`, and a `builtins` arithmetic/comparison/unification pack)
+with one shared table of expected query results. The harness compiles
+that *same* spec to every WAM backend whose toolchain is on `PATH`, runs
+each backend, and asserts the answers match.
+
+Per-target classic-program tests already exist, but each re-declares its
+own fixtures, so a backend can silently diverge without any test
+noticing. This harness is the safety net for exactly that — the kind of
+divergence the Haskell `Proceed` and WAT `allocate` first-argument
+indexing bugs produced (`member/2` wrongly succeeding).
+
+## How a query is run
+
+Backends disagree on how to feed list/compound args into a predicate's
+entry point, so invocation is per-target:
+
+- **scala** passes the query args straight to its `GeneratedProgram`
+  driver (`<predkey> <args...>` → `true`/`false`).
+- **elixir / wat** synthesise a ground 0-arity wrapper per query
+  (`ctw_N :- pred(args).`), compile it with the program, and ask whether
+  `ctw_N` succeeds. This is the shape their own runtime tests use.
+
+Each adapter is self-contained (`ct_build/4`, `ct_run/5`,
+`ct_teardown/2`); adding a backend is one adapter plus a
+`conformance_target/1` entry. Missing toolchains **skip**, they don't
+fail.
+
+## Coverage vs CI speed
+
+The dominant cost is process startup (scalac/JVM/BEAM/node), not compute,
+so the harness is built to stay cheap:
+
+- builds are **per program** (small projects), and the recursive samples
+  (`fib`, `ack`) use small inputs;
+- `member` — a set operation — is the preferred everyday case: high-level
+  but far cheaper than a generic recursive algorithm;
+- the query set can be **random-sampled** so any single CI run is bounded
+  while coverage accumulates across runs.
+
+Environment knobs:
+
+| Variable | Effect |
+|---|---|
+| `CONFORMANCE_TARGETS=scala,elixir` | limit which backends run |
+| `CONFORMANCE_PROGRAMS=member,fib`  | limit which programs run |
+| `CONFORMANCE_SAMPLE=N`             | random N queries per program |
+| `CONFORMANCE_SEED=N`               | seed the sampler (reproducible) |
+
+Suggested CI tiers:
+
+- **fast / every push:** `CONFORMANCE_PROGRAMS=member,builtins
+  CONFORMANCE_SAMPLE=2` — broad builtin coverage, set operation, minimal
+  compute. Seed varies per run so sampling rotates coverage.
+- **full / nightly or pre-merge:** no sampling — every program, every
+  query, every available backend.
+
+## Known divergences (tracked as `ct_xfail/2`)
+
+The harness is green today; the divergences below are tolerated and
+logged (an unexpected pass is logged as `XPASS` so the entry can be
+retired). Each is a real backend gap the harness surfaced, not a fixture
+artifact — **Scala passes the whole spec**, which is the reference.
+
+| Backend | Program(s) | Kind | Cause |
+|---|---|---|---|
+| wat | member | xfail | Read-mode structure/list argument unification is unimplemented (the read-mode branches of `unify_variable`/`unify_value`/`unify_constant` are nops; no S-register), so `get_structure`/`get_list` match only the functor. See `WAM_SWITCH_INDEXING_CROSS_TARGET.md`. |
+| wat | append, reverse | **skip** | A *second*, separate WAT bug: the generator loops re-emitting millions of "unrecognized instruction" warnings on recursive list-**building** predicates, so the project is impractical to write. Skipped (not built) rather than xfail'd. |
+| elixir | append, reverse | xfail | The lowered Elixir backend fails to unify a freshly-constructed list against an already-**ground** compound head argument: `capp([a],[b],[a,b])` returns false, while `capp([a],[b],X), X=[a,b]` succeeds. `member` passes (it only matches an input list). |
+
+`ct_xfail/2` = build and run, tolerate a wrong answer (and log `XPASS` if
+it unexpectedly matches). `ct_skip/2` = do not even build, because
+*generation itself* is unusable.
+
+### Other backend issue surfaced (not xfail)
+
+- **Scala loops compiling 0-arity predicates with comparison-only
+  bodies** (e.g. `p :- 3 > 2.`). The harness sidesteps this by (a) giving
+  Scala direct args rather than 0-arity wrappers, and (b) phrasing the
+  `builtins` comparison fixture as a 1-arity predicate. Worth fixing in
+  the Scala backend separately.
+
+## Adding more backends
+
+Targets with real toolchains that are not yet wired up (haskell, rust,
+go, cpp, c, fsharp, lua, r, clojure, llvm) each already have a
+`write_wam_<target>_project/3` and a per-target runtime test
+demonstrating how to compile+run. Wiring one in = a `ct_build/ct_run/
+ct_teardown` adapter mirroring the Scala (direct-arg) or Elixir/WAT
+(0-arity wrapper) shape, plus a `conformance_target/1` line and a
+toolchain probe.

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -1,0 +1,418 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (@s243a)
+%
+% test_wam_cross_target_conformance.pl
+%
+% Cross-target WAM conformance harness. Compiles the SHARED classic
+% programs (wam_conformance_fixtures.pl) to each WAM backend that has a
+% toolchain on PATH, runs every backend against the SAME query vectors,
+% and asserts the results match the single shared spec.
+%
+% Why: per-target classic-program tests already exist, but each
+% re-declares its own fixtures, so a backend can silently diverge from
+% the others without any test noticing. This harness is the safety net
+% for exactly that: the Haskell `Proceed` and WAT `allocate`
+% first-argument-indexing bugs (member/2 wrongly succeeding) are the kind
+% of divergence it catches.
+%
+% INVOCATION is per-target (each adapter owns build + run):
+%   - scala  passes the query args straight to GeneratedProgram (its
+%     runtime parses "[a,b,c]" etc). It is NOT given 0-arity wrappers:
+%     the Scala backend currently loops compiling 0-arity predicates.
+%   - elixir / wat synthesise a ground 0-arity wrapper per query
+%     (`ctw_N :- pred(args).`) and ask whether ctw_N succeeds — the shape
+%     their own runtime tests use, sidestepping per-backend quirks in
+%     feeding list args into a predicate entry point.
+%
+% SPEED. Builds are PER PROGRAM (one small project per program per
+% backend) and the query set can be random-sampled to keep CI cheap while
+% coverage accumulates across runs. Knobs (environment variables):
+%   CONFORMANCE_TARGETS  = scala,elixir   limit which backends run
+%   CONFORMANCE_PROGRAMS = member,fib     limit which programs run
+%   CONFORMANCE_SAMPLE   = N              random N queries per program
+%   CONFORMANCE_SEED     = N              seed the sampler (reproducible)
+%
+% Adding a target = implement ct_toolchain/2 + ct_build/4 + ct_run/5
+% (+ ct_teardown/2) and register it in conformance_target/1. Missing
+% toolchains skip rather than fail. Known-divergent (target, program)
+% pairs are tracked in ct_xfail/2 so the suite stays green while the
+% underlying gap is tracked separately.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module(library(process)).
+:- use_module(library(lists)).
+:- use_module(library(apply)).
+:- use_module(library(random)).
+:- use_module('wam_conformance_fixtures').
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_scala_target').
+:- use_module('../src/unifyweaver/targets/wam_elixir_target').
+:- use_module('../src/unifyweaver/targets/wam_wat_target').
+
+% ============================================================
+% Target registry + known-divergence (xfail) registry
+% ============================================================
+
+conformance_target(scala).
+conformance_target(elixir).
+conformance_target(wat).
+
+%% ct_default_target(Target): runs unless CONFORMANCE_TARGETS overrides.
+%  WAT is wired up but NOT a default: its backend currently diverges on
+%  most list/arithmetic programs (see ct_xfail/ct_skip below), so it is
+%  opt-in via CONFORMANCE_TARGETS=wat while those backend bugs are fixed.
+ct_default_target(scala).
+ct_default_target(elixir).
+
+% Per-target adapter clauses are grouped by target, not by predicate.
+:- discontiguous ct_build/4.
+:- discontiguous ct_run/5.
+:- discontiguous ct_teardown/2.
+
+%% ct_xfail(Target, ProgramName)
+%  (Target, program) pairs known to diverge from the shared spec.
+%  Mismatches are tolerated (logged, not failed); an unexpected full
+%  match (xpass) is logged so the entry can be retired once the gap is
+%  fixed.
+%
+%  WAT member/append/reverse: WAT's runtime read-mode structure/list
+%  argument unification is unimplemented (unify_* read-mode branches are
+%  nops; no S-register), so get_structure/get_list match only the
+%  functor and element mismatches go undetected. See
+%  docs/WAM_SWITCH_INDEXING_CROSS_TARGET.md.
+ct_xfail(wat, member).
+ct_xfail(wat, append).
+ct_xfail(wat, reverse).
+%  WAT fib: is/2 with an already-bound LHS doesn't verify the computed
+%  value — cfib(10,54) returns true though fib(10)=55 (the result is
+%  stored over the bound arg instead of being unified/checked).
+ct_xfail(wat, fib).
+%  WAT builtins: cbi_arith uses // (integer div) and mod, which the WAT
+%  backend does not evaluate correctly (returns false). cmp/eq are fine.
+ct_xfail(wat, builtins).
+
+%  Elixir append/reverse: the lowered Elixir backend fails to unify a
+%  freshly-constructed list against an already-GROUND compound argument
+%  in the clause head — e.g. capp([a],[b],[a,b]) (3rd arg ground) returns
+%  false, while capp([a],[b],X), X=[a,b] succeeds. member passes because
+%  it only matches an input list, never constructs+unifies a ground
+%  output. Scala handles both, so this is a genuine backend divergence
+%  the harness surfaced (not a harness artifact).
+ct_xfail(elixir, append).
+ct_xfail(elixir, reverse).
+
+%% ct_skip(Target, ProgramName)
+%  Stronger than xfail: do NOT even build/run this (target, program).
+%  Used when *generation itself* is unusable, not just the answer.
+%
+%  WAT append/reverse: the WAT generator loops re-emitting millions of
+%  "unrecognized instruction" warnings on recursive list-BUILDING
+%  predicates (put_list/unify_* on a constructed tail), so the project
+%  takes minutes and gigabytes of log to write. (member is fine — it only
+%  matches an input list — so it stays as an xfail demonstrating the
+%  read-mode divergence.) This is a separate WAT codegen bug from the
+%  read-mode-unify gap; both are flagged for follow-up.
+ct_skip(wat, append).
+ct_skip(wat, reverse).
+
+% ============================================================
+% Toolchain probes
+% ============================================================
+
+ct_toolchain(scala,  [scalac, scala]).
+ct_toolchain(elixir, [elixir]).
+ct_toolchain(wat,    [wat2wasm, node]).
+
+ct_available(Target) :-
+    ct_enabled(Target),
+    ct_toolchain(Target, Exes),
+    forall(member(E, Exes), exe_on_path(E)).
+
+ct_enabled(Target) :-
+    (   getenv('CONFORMANCE_TARGETS', Spec), Spec \== ''
+    ->  split_string(Spec, ",", " ", Parts), atom_string(Target, TS),
+        memberchk(TS, Parts)
+    ;   ct_default_target(Target) ).
+
+exe_on_path(Exe) :-
+    catch(
+        ( process_create(path(Exe), ['--version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          process_wait(Pid, _) ),
+        _, fail).
+
+% ============================================================
+% Tests — one per target, looping the (sampled) shared programs
+% ============================================================
+
+:- begin_tests(wam_cross_target_conformance).
+
+test(scala,  [condition(ct_available(scala))])  :- run_target_conformance(scala).
+test(elixir, [condition(ct_available(elixir))]) :- run_target_conformance(elixir).
+test(wat,    [condition(ct_available(wat))])    :- run_target_conformance(wat).
+
+:- end_tests(wam_cross_target_conformance).
+
+% ============================================================
+% Driver
+% ============================================================
+
+run_target_conformance(Target) :-
+    seed_sampler,
+    selected_programs(Programs),
+    nb_setval(ct_wrapper_counter, 0),
+    foldl(run_program(Target), Programs, [], Failures),
+    (   Failures == []
+    ->  true
+    ;   throw(error(conformance_failures(Target, Failures), _))
+    ).
+
+seed_sampler :-
+    ( getenv('CONFORMANCE_SEED', S), atom_number(S, Seed)
+    -> set_random(seed(Seed)) ; true ).
+
+selected_programs(Programs) :-
+    findall(P, conformance_program(P, _), All0),
+    list_to_set(All0, All),
+    (   getenv('CONFORMANCE_PROGRAMS', Spec), Spec \== ''
+    ->  split_string(Spec, ",", " ", Parts),
+        include([P]>>( atom_string(P, PS), memberchk(PS, Parts) ), All, Programs)
+    ;   Programs = All ).
+
+run_program(Target, Program, In, Out) :-
+    (   ct_skip(Target, Program)
+    ->  log_line(Target, Program, "SKIP (generation unusable, tracked)", []),
+        Out = In
+    ;   run_program_(Target, Program, In, Out) ).
+
+run_program_(Target, Program, In, Out) :-
+    conformance_program(Program, Preds),
+    sampled_queries(Program, Queries),      % [q(K,A,E)...]
+    (   Queries == []
+    ->  Out = In
+    ;   (   catch(
+                setup_call_cleanup(
+                    ct_build(Target, Preds, Queries, Ctx),
+                    run_queries(Target, Ctx, Program, Queries, In, Out),
+                    ct_teardown(Target, Ctx)),
+                Err,
+                build_error(Target, Program, Err, In, Out))
+        ->  true
+        ;   build_error(Target, Program, build_failed, In, Out) )
+    ).
+
+build_error(Target, Program, Err, In, Out) :-
+    (   ct_xfail(Target, Program)
+    ->  log_line(Target, Program, "XFAIL (build/run error, tolerated): ~w", [Err]),
+        Out = In
+    ;   format(atom(F), '~w/~w: build/run error: ~w', [Target, Program, Err]),
+        Out = [F|In] ).
+
+run_queries(Target, Ctx, Program, Queries, In, Out) :-
+    foldl(run_query(Target, Ctx, Program), Queries, In, Out).
+
+run_query(Target, Ctx, Program, q(K, A, Expected), In, Out) :-
+    (   catch(ct_run(Target, Ctx, K, A, Got), E, ( Got = error(E), true ))
+    ->  true ; Got = error(run_failed) ),
+    (   Got == Expected
+    ->  (   ct_xfail(Target, Program)
+        ->  log_line(Target, Program, "XPASS ~w(~w) matched under xfail", [K, A]),
+            Out = In
+        ;   Out = In )
+    ;   (   ct_xfail(Target, Program)
+        ->  log_line(Target, Program,
+                     "xfail ~w(~w): expected ~w got ~w (tolerated)",
+                     [K, A, Expected, Got]),
+            Out = In
+        ;   format(atom(F), '~w/~w: ~w(~w) expected ~w got ~w',
+                   [Target, Program, K, A, Expected, Got]),
+            Out = [F|In] ) ).
+
+log_line(Target, Program, Fmt, Args) :-
+    format(string(Body), Fmt, Args),
+    format(user_error, '  [conformance] ~w/~w: ~w~n', [Target, Program, Body]).
+
+% ============================================================
+% Query sampling
+% ============================================================
+
+sampled_queries(Program, Picked) :-
+    findall(q(K, A, E), conformance_query(Program, K, A, E), Qs),
+    (   getenv('CONFORMANCE_SAMPLE', NS), atom_number(NS, N), integer(N), N >= 0
+    ->  random_subset(Qs, N, Picked)
+    ;   Picked = Qs ).
+
+random_subset(List, N, Picked) :-
+    length(List, Len),
+    (   N >= Len -> Picked = List
+    ;   random_permutation(List, Shuffled),
+        length(Picked, N), append(Picked, _, Shuffled) ).
+
+% ============================================================
+% Shared helpers
+% ============================================================
+
+%% render_arg(+Term, -Atom): textual form the arg-passing drivers parse:
+%  ints -> '10', atoms -> 'a', atom-lists -> '[a,b,c]'.
+render_arg(Term, Atom) :- format(atom(Atom), '~w', [Term]).
+
+bool_of_string(S, B) :-
+    string_to_atom(S, A),
+    ( A == true -> B = true ; A == false -> B = false ; B = A ).
+
+ct_tmp_dir(Prefix, Dir) :-
+    get_time(T), Stamp is floor(T * 1000000),
+    format(atom(Dir), '/tmp/~w_~w', [Prefix, Stamp]),
+    make_directory_path(Dir).
+
+cleanup_dir(Dir) :-
+    ( atom(Dir), exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+strip_pred(_Mod:N/A, N/A) :- !.
+strip_pred(N/A, N/A).
+
+run_proc(Exe, Args, Cwd, Exit, ErrStr) :-
+    process_create(path(Exe), Args,
+                   [cwd(Cwd), stdout(null), stderr(pipe(Err)), process(Pid)]),
+    read_string(Err, _, ErrStr), close(Err), process_wait(Pid, exit(Exit)).
+
+run_proc_out(Exe, Args, Cwd, Exit, OutStr) :-
+    process_create(path(Exe), Args,
+                   [cwd(Cwd), stdout(pipe(Out)), stderr(null), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out), process_wait(Pid, exit(Exit)).
+
+%% Wrapper synthesis (elixir / wat). One ground 0-arity wrapper per
+%  query, asserted into user as `ctw_N :- pred(Args).`. The global
+%  counter keeps names unique across programs in one run. Returns the
+%  wrapper predicate indicators and a (K-A)->WName lookup map.
+synth_wrappers([], [], []).
+synth_wrappers([q(K, A, _E)|Rest], [WName/0|WPs], [(K-A)-WName|Map]) :-
+    nb_getval(ct_wrapper_counter, I0), I is I0 + 1,
+    nb_setval(ct_wrapper_counter, I),
+    atom_concat(ctw_, I, WName),
+    pred_name_of_key(K, PredName),
+    Goal =.. [PredName|A],
+    assertz(user:(WName :- Goal)),
+    synth_wrappers(Rest, WPs, Map).
+
+abolish_wrappers([]).
+abolish_wrappers([(_K-_A)-WName|Rest]) :-
+    ( current_predicate(user:WName/0) -> abolish(user:WName/0) ; true ),
+    abolish_wrappers(Rest).
+
+pred_name_of_key(Key, Name) :-
+    atomic_list_concat([NameA|_], '/', Key), atom_string(Name, NameA).
+
+% ============================================================
+% Adapter: Scala  (direct args: GeneratedProgram <predkey> <args>)
+% ============================================================
+
+ct_build(scala, Preds, _Queries, scala_ctx(Dir)) :-
+    ct_tmp_dir('tmp_ct_scala', Dir),
+    Opts = [ package('generated.wam_ct.core'),
+             runtime_package('generated.wam_ct.core'), module_name('wam-ct') ],
+    write_wam_scala_project(Preds, Opts, Dir),
+    absolute_file_name(Dir, Abs),
+    directory_file_path(Abs, 'classes', ClassDir), make_directory_path(ClassDir),
+    directory_file_path(Abs, 'src', SrcDir),
+    findall(F, ( directory_member(SrcDir, RelF,
+                     [extensions([scala]), recursive(true)]),
+                 directory_file_path(SrcDir, RelF, F) ), Sources),
+    Sources \= [],
+    run_proc(scalac, ['-d', ClassDir | Sources], Abs, Exit, Err),
+    ( Exit =:= 0 -> true ; throw(scala_compile_failed(Exit, Err)) ).
+
+ct_run(scala, scala_ctx(Dir), PredKey, Args, Bool) :-
+    absolute_file_name(Dir, Abs),
+    directory_file_path(Abs, 'classes', ClassDir),
+    atom_string(PredKey, PredStr),
+    maplist(render_arg, Args, ArgAtoms),
+    maplist([X,S]>>atom_string(X,S), ArgAtoms, ArgStrs),
+    append(['-classpath', ClassDir,
+            'generated.wam_ct.core.GeneratedProgram', PredStr], ArgStrs, ProcArgs),
+    run_proc_out(scala, ProcArgs, Abs, _Exit, OutStr),
+    normalize_space(string(Out), OutStr), bool_of_string(Out, Bool).
+
+ct_teardown(scala, scala_ctx(Dir)) :- cleanup_dir(Dir).
+
+% ============================================================
+% Adapter: Elixir  (0-arity wrapper via run_classic.exs <Module> <wname>/0)
+% ============================================================
+
+ct_build(elixir, Preds, Queries, elixir_ctx(Dir, Map)) :-
+    ct_tmp_dir('tmp_ct_elixir', Dir),
+    synth_wrappers(Queries, WPreds, Map),
+    maplist(strip_pred, Preds, BarePreds),
+    append(WPreds, BarePreds, AllPreds),
+    ct_compile_preds_to_wam(AllPreds, [], PredWamPairs),
+    write_wam_elixir_project(PredWamPairs,
+        [ module_name('wam_ct'), emit_mode(lowered), source_module(user) ], Dir),
+    classic_elixir_driver(DriverSrc),
+    directory_file_path(Dir, 'run_classic.exs', DriverDst),
+    copy_file(DriverSrc, DriverDst).
+
+ct_run(elixir, elixir_ctx(Dir, Map), K, A, Bool) :-
+    memberchk((K-A)-WName, Map),
+    absolute_file_name(Dir, Abs),
+    format(atom(PredKey), '~w/0', [WName]), atom_string(PredKey, PredStr),
+    run_proc_out(elixir, ['run_classic.exs', "WamCt", PredStr], Abs, _Exit, OutStr),
+    normalize_space(string(Out), OutStr), bool_of_string(Out, Bool).
+
+ct_teardown(elixir, elixir_ctx(Dir, Map)) :-
+    cleanup_dir(Dir), abolish_wrappers(Map).
+
+ct_compile_preds_to_wam([], _Opts, []).
+ct_compile_preds_to_wam([Pred|Rest], Opts, [Name/Arity-WamCode|RestPairs]) :-
+    strip_pred(Pred, Name/Arity),
+    (   wam_target:compile_predicate_to_wam(Name/Arity, Opts, WamCode) -> true
+    ;   wam_target:compile_predicate_to_wam(user:Name/Arity, Opts, WamCode) -> true
+    ;   throw(wam_compile_failed(Pred))
+    ),
+    ct_compile_preds_to_wam(Rest, Opts, RestPairs).
+
+:- ( prolog_load_context(directory, Dir),
+     directory_file_path(Dir, 'elixir_e2e/run_classic.exs', P),
+     assertz(classic_elixir_driver_fact(P))
+   ; true ).
+classic_elixir_driver(P) :- classic_elixir_driver_fact(P).
+
+% ============================================================
+% Adapter: WAT  (0-arity wrapper -> wasm export <wname>_0 -> 1/0)
+% ============================================================
+
+ct_build(wat, Preds, Queries, wat_ctx(Dir, HarnessJs, WasmFile, Map)) :-
+    ct_tmp_dir('tmp_ct_wat', Dir),
+    synth_wrappers(Queries, WPreds, Map),
+    maplist(strip_pred, Preds, BarePreds),
+    append(WPreds, BarePreds, AllPreds),
+    directory_file_path(Dir, 'prog.wat', WatFile),
+    write_wam_wat_project(AllPreds, [module_name(wam_ct)], WatFile),
+    directory_file_path(Dir, 'prog.wasm', WasmFile),
+    run_proc(wat2wasm, [WatFile, '-o', WasmFile], Dir, CExit, CErr),
+    ( CExit =:= 0 -> true ; throw(wat2wasm_failed(CExit, CErr)) ),
+    wat_write_harness(Dir, HarnessJs).
+
+ct_run(wat, wat_ctx(_Dir, HarnessJs, WasmFile, Map), K, A, Bool) :-
+    memberchk((K-A)-WName, Map),
+    format(atom(Export), '~w_0', [WName]), atom_string(Export, ExportStr),
+    run_proc_out(node, [HarnessJs, WasmFile, ExportStr], '.', _Exit, OutStr),
+    normalize_space(string(Out), OutStr),
+    ( Out == "1" -> Bool = true ; Out == "0" -> Bool = false ; atom_string(Bool, Out) ).
+
+ct_teardown(wat, wat_ctx(Dir, _, _, Map)) :-
+    cleanup_dir(Dir), abolish_wrappers(Map).
+
+wat_write_harness(Dir, HarnessJs) :-
+    directory_file_path(Dir, 'harness.js', HarnessJs),
+    Src = "const fs=require('fs');\n\c
+const [,,wasmPath,exportName]=process.argv;\n\c
+const buf=fs.readFileSync(wasmPath);\n\c
+const imports={env:{print_i64:()=>{},print_char:()=>{},print_newline:()=>{}}};\n\c
+WebAssembly.instantiate(buf,imports).then(({instance})=>{\n\c
+  const fn=instance.exports[exportName];\n\c
+  if(typeof fn!=='function'){console.log('ERR');process.exit(1);}\n\c
+  console.log(fn());\n\c
+}).catch(e=>{console.log('TRAP');process.exit(2);});\n",
+    open(HarnessJs, write, S), write(S, Src), close(S).

--- a/tests/wam_conformance_fixtures.pl
+++ b/tests/wam_conformance_fixtures.pl
@@ -1,0 +1,151 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (@s243a)
+%
+% wam_conformance_fixtures.pl
+%
+% Shared classic-program fixtures for the cross-target WAM conformance
+% harness (test_wam_cross_target_conformance.pl). One source of truth for
+% the programs and their expected query results, so every WAM backend is
+% checked against the SAME spec rather than re-declaring fixtures per
+% target. This is what catches a backend that silently diverges from the
+% others (e.g. the Haskell `Proceed` / WAT `allocate` first-arg-indexing
+% bugs, where member/2 wrongly succeeded).
+%
+% DESIGN — coverage vs CI speed. The dominant cost in this harness is
+% process startup (scalac/JVM/BEAM/node), not arithmetic. So fixtures
+% favour cheap, high-coverage shapes over heavy recursion:
+%   - `member` (a set operation) is high-level but far cheaper than a
+%     generic recursive algorithm — the preferred everyday case.
+%   - `builtins` packs the common arithmetic/comparison/unification
+%     builtins into a handful of near-zero-compute queries.
+%   - the recursive samples (fib, ack) are kept to SMALL inputs; the
+%     harness compiles all predicates into ONE project per target (one
+%     compile) and supports CONFORMANCE_SAMPLE for random query
+%     subsetting, so a CI run stays fast while coverage accumulates
+%     across runs.
+%
+% A fixture is:
+%   conformance_program(Name, Preds)
+%     Name   - atom identifying the program
+%     Preds  - list of Module:Name/Arity indicators to compile (the
+%              program clauses are asserted into `user` at load, below)
+%   conformance_query(Name, PredKey, Args, Expected)
+%     PredKey  - 'name/arity' atom (the queried predicate)
+%     Args     - list of ground PROLOG TERMS (ints, atoms, atom-lists).
+%                Kept as terms (not strings) so each adapter can render
+%                them to its own driver contract, or synthesise a goal.
+%     Expected - `true` or `false` (does the ground query hold?)
+%
+% Programs are intentionally self-contained (no list-library builtins
+% beyond arithmetic) so every target compiles them identically.
+
+:- module(wam_conformance_fixtures,
+          [ conformance_program/2,
+            conformance_query/4
+          ]).
+
+% ============================================================
+% Program clauses (asserted into user:)
+% ============================================================
+
+% --- member/2 — first-argument indexing + list/structure matching ---
+:- dynamic user:cmem/2.
+user:cmem(X, [X|_]).
+user:cmem(X, [_|T]) :- user:cmem(X, T).
+
+% --- append/3 — list construction + recursion + backtracking ---
+:- dynamic user:capp/3.
+user:capp([], L, L).
+user:capp([H|T], L, [H|R]) :- user:capp(T, L, R).
+
+% --- list reverse via accumulator (linear) ---
+:- dynamic user:crev_acc/3.
+:- dynamic user:clist_reverse/2.
+user:crev_acc([], A, A).
+user:crev_acc([H|T], A, R) :- user:crev_acc(T, [H|A], R).
+user:clist_reverse(L, R) :- user:crev_acc(L, [], R).
+
+% --- Fibonacci (naïve doubly-recursive) — arithmetic + recursion ---
+:- dynamic user:cfib/2.
+user:cfib(0, 0).
+user:cfib(1, 1).
+user:cfib(N, R) :- N > 1, N1 is N - 1, N2 is N - 2,
+                   user:cfib(N1, R1), user:cfib(N2, R2),
+                   R is R1 + R2.
+
+% --- Ackermann — recursion + arithmetic comparison. Kept to SMALL
+%     inputs for CI speed (ack(3,3) is correct but ~2400 calls; we use
+%     ack(2,_) ≈ a few dozen calls instead). ---
+:- dynamic user:cack/3.
+user:cack(0, N, R) :- R is N + 1.
+user:cack(M, 0, R) :- M > 0, M1 is M - 1, user:cack(M1, 1, R).
+user:cack(M, N, R) :- M > 0, N > 0,
+                      M1 is M - 1, N1 is N - 1,
+                      user:cack(M, N1, R1),
+                      user:cack(M1, R1, R).
+
+% --- builtins — packs the common arithmetic / comparison / unification
+%     builtins into near-zero-compute queries. Broad coverage, cheap. ---
+:- dynamic user:cbi_arith/1.
+:- dynamic user:cbi_cmp/1.
+:- dynamic user:cbi_eq/1.
+% +, -, *, integer div, mod folded into one result: 5+6+12+3+2 = 28.
+user:cbi_arith(R) :- A is 2 + 3, B is 10 - 4, C is 3 * 4,
+                     D is 17 // 5, E is 17 mod 5,
+                     R is A + B + C + D + E.
+% the comparison family: >, <, >=, =<, =:=, =\= (1-arity so it succeeds
+% only for N=5; kept off 0-arity, which trips a Scala-target codegen
+% hang on comparison-only bodies).
+user:cbi_cmp(N) :- N > 0, N < 10, N >= 1, N =< 9, N =:= 5, N =\= 4.
+% term unification =/2.
+user:cbi_eq(X) :- X = foo.
+
+% ============================================================
+% Fixture registry
+% ============================================================
+
+conformance_program(member,   [user:cmem/2]).
+conformance_program(append,   [user:capp/3]).
+conformance_program(reverse,  [user:crev_acc/3, user:clist_reverse/2]).
+conformance_program(fib,      [user:cfib/2]).
+conformance_program(ack,      [user:cack/3]).
+conformance_program(builtins, [user:cbi_arith/1, user:cbi_cmp/1, user:cbi_eq/1]).
+
+% member/2 — the regression that motivated the harness; the preferred
+% cheap everyday case (set operation, first-arg indexing, backtracking).
+conformance_query(member, 'cmem/2', [a, [a,b,c]], true).
+conformance_query(member, 'cmem/2', [b, [a,b,c]], true).
+conformance_query(member, 'cmem/2', [c, [a,b,c]], true).
+conformance_query(member, 'cmem/2', [z, [a,b,c]], false).
+conformance_query(member, 'cmem/2', [a, []],      false).
+
+% append/3
+conformance_query(append, 'capp/3', [[a,b], [c],   [a,b,c]], true).
+conformance_query(append, 'capp/3', [[],    [a],   [a]],     true).
+conformance_query(append, 'capp/3', [[a],   [b],   [a,b]],   true).
+conformance_query(append, 'capp/3', [[a],   [b],   [b,a]],   false).
+
+% reverse/2
+conformance_query(reverse, 'clist_reverse/2', [[a,b,c], [c,b,a]], true).
+conformance_query(reverse, 'clist_reverse/2', [[],      []],      true).
+conformance_query(reverse, 'clist_reverse/2', [[a],     [a]],     true).
+conformance_query(reverse, 'clist_reverse/2', [[a,b,c], [a,b,c]], false).
+
+% fib/2 — one small recursive sample (fib(10)=55, ~177 calls).
+conformance_query(fib, 'cfib/2', [0,  0],  true).
+conformance_query(fib, 'cfib/2', [10, 55], true).
+conformance_query(fib, 'cfib/2', [10, 54], false).
+
+% ack/3 — small inputs only (ack(2,n)=2n+3).
+conformance_query(ack, 'cack/3', [0, 5, 6], true).
+conformance_query(ack, 'cack/3', [2, 3, 9], true).
+conformance_query(ack, 'cack/3', [2, 3, 8], false).
+
+% builtins — arithmetic, comparison, unification (all near-zero compute).
+conformance_query(builtins, 'cbi_arith/1', [28],  true).
+conformance_query(builtins, 'cbi_arith/1', [27],  false).
+conformance_query(builtins, 'cbi_cmp/1',   [5],   true).
+conformance_query(builtins, 'cbi_cmp/1',   [4],   false).
+conformance_query(builtins, 'cbi_eq/1',    [foo], true).
+conformance_query(builtins, 'cbi_eq/1',    [bar], false).


### PR DESCRIPTION
## What

A cross-target conformance harness: one shared spec of classic programs,
compiled to every WAM backend whose toolchain is on `PATH`, run, and
asserted to produce **identical** answers.

- `tests/wam_conformance_fixtures.pl` — the single source of truth:
  `member`, `append`, `reverse`, `fib`, `ack`, and a `builtins`
  arithmetic/comparison/unification pack, each with expected query results.
- `tests/test_wam_cross_target_conformance.pl` — the harness (per-target
  adapters, sampling, xfail/skip).
- `docs/WAM_CROSS_TARGET_CONFORMANCE.md` — design + the divergences found.

## Why

Per-target classic-program tests already exist, but each re-declares its
own fixtures, so a backend can silently diverge from the others without
any test noticing — the exact class of bug the recent Haskell `Proceed`
and WAT `allocate` first-arg-indexing fixes addressed (`member/2` wrongly
succeeding). This harness is the safety net for that.

## Design — coverage vs CI speed

The dominant cost is process startup (scalac/JVM/BEAM/node), not compute:

- **per-program builds**; recursive samples (`fib`, `ack`) use small inputs;
  `member` (a set operation) is the preferred cheap everyday case.
- **random query sampling** (`CONFORMANCE_SAMPLE` / `CONFORMANCE_SEED`)
  bounds a single run while coverage accumulates across runs;
  `CONFORMANCE_TARGETS` / `CONFORMANCE_PROGRAMS` narrow scope.
- invocation is **per-target**: scala takes direct args; elixir/wat use
  ground 0-arity wrappers (the shape their own runtime tests use).
- adapters are self-contained (`ct_build`/`ct_run`/`ct_teardown`); adding a
  backend is one adapter + a `conformance_target/1` line. Missing
  toolchains **skip**, they don't fail.

Suggested CI tiers (in the doc): fast/every-push
(`CONFORMANCE_PROGRAMS=member,builtins CONFORMANCE_SAMPLE=2`) and
full/nightly (no sampling).

## Status

- **Default backends — scala, elixir — green** (Scala passes the whole
  spec). WAT is wired up but **opt-in** (`CONFORMANCE_TARGETS=wat`) because
  its backend currently diverges on most list/arithmetic programs.

## Divergences the harness surfaced

All confirmed against Scala (the reference, which passes everything) — real
backend bugs, not fixture artifacts. Tracked as `ct_xfail`/`ct_skip` with
reasons (and `XPASS` logging so entries retire once fixed):

| Backend | Issue | Handling |
|---|---|---|
| elixir | can't unify a constructed list against an already-**ground** compound head arg (`capp([a],[b],[a,b])`→false, but `capp([a],[b],X),X=[a,b]`→true) | xfail append/reverse |
| wat | read-mode structure/list arg unification unimplemented (member matches only the functor) | xfail member |
| wat | generator loops emitting millions of warnings on recursive list-**building** preds | skip append/reverse |
| wat | `is/2` with a bound LHS doesn't verify the result (`fib(10,54)`→true) | xfail fib |
| wat | `//` and `mod` evaluated incorrectly | xfail builtins |
| scala | loops compiling **0-arity predicates with comparison-only bodies** | worked around (direct args + 1-arity builtins fixture) |

## Validation

- Default suite (scala+elixir): all tests pass.
- Opt-in WAT suite: passes with the documented xfail/skip carve-outs.
- Fixtures independently verified against native SWI-Prolog (25/25).

## Follow-ups (not in this PR)

- Extend adapters to the other toolchain-backed backends (haskell, rust,
  go, cpp, c, fsharp, lua, r, clojure, llvm).
- Wire the fast tier into `.github/workflows`.
- Fix the surfaced backend bugs (Scala 0-arity hang and Elixir
  ground-output unify are the most broadly impactful).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_