### PR TITLE
feat(wam-clojure): lower term variables builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -436,6 +436,10 @@ clojure_direct_builtin("copy_term/2", "2").
 clojure_direct_builtin("copy_term/2", 2).
 clojure_direct_builtin('copy_term/2', "2").
 clojure_direct_builtin('copy_term/2', 2).
+clojure_direct_builtin("term_variables/2", "2").
+clojure_direct_builtin("term_variables/2", 2).
+clojure_direct_builtin('term_variables/2', "2").
+clojure_direct_builtin('term_variables/2', 2).
 clojure_direct_builtin("functor/3", "3").
 clojure_direct_builtin("functor/3", 3).
 clojure_direct_builtin('functor/3', "3").
@@ -845,6 +849,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "copy_term/2" ; Op == 'copy_term/2'),
     !,
     format(atom(Expr), '(runtime/apply-copy-term-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "term_variables/2" ; Op == 'term_variables/2'),
+    !,
+    format(atom(Expr), '(runtime/apply-term-variables-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "functor/3" ; Op == 'functor/3'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1841,6 +1841,32 @@
             (backtrack state)))
         (backtrack state)))))
 
+(defn term-variables [state term]
+  (letfn [(add-var [acc var-value]
+            (let [id (:var var-value)]
+              (if (contains? (:seen acc) id)
+                acc
+                (-> acc
+                    (update :seen conj id)
+                    (update :vars conj var-value)))))
+          (walk [acc value]
+            (let [value* (deref-value (:bindings state) value)]
+              (cond
+                (logic-var? value*) (add-var acc value*)
+                (structure-term? value*) (reduce walk acc (:args value*))
+                :else acc)))]
+    (:vars (walk {:seen #{} :vars []} term))))
+
+(defn apply-term-variables-solution [state]
+  (let [term (or (reg-get-raw state "A1") ::unbound)
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A2") ::unbound))
+        vars-term (list->term (:intern-context state) (term-variables state term))
+        [ok next-state] (unify-values state out vars-term)]
+    (if ok
+      (advance next-state)
+      (backtrack state))))
+
 (defn term->unify-items [term]
   (if (structure-term? term)
     (seq (:args term))
@@ -2510,6 +2536,9 @@
 
           "copy_term/2"
           (apply-copy-term-solution state)
+
+          "term_variables/2"
+          (apply-term-variables-solution state)
 
           "functor/3"
           (apply-functor-solution state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -134,6 +134,11 @@
 :- dynamic user:wam_copy_term_guard/2.
 :- dynamic user:wam_copy_term_sharing_fail/0.
 :- dynamic user:wam_copy_term_independent_ok/0.
+:- dynamic user:wam_term_variables_guard/2.
+:- dynamic user:wam_term_variables_order/0.
+:- dynamic user:wam_term_variables_ground/0.
+:- dynamic user:wam_term_variables_single_unbound/0.
+:- dynamic user:wam_term_variables_mismatch/0.
 :- dynamic user:wam_functor_guard/3.
 :- dynamic user:wam_functor_arity_unify/0.
 :- dynamic user:wam_functor_arity_unify_mismatch/0.
@@ -443,6 +448,11 @@ user:wam_msort_unbound_list(S) :- msort(L, S), is_list(L).
 user:wam_copy_term_guard(A, B) :- copy_term(A, B).
 user:wam_copy_term_sharing_fail :- user:wam_unbound_arg(X), copy_term(f(X, X), f(a, b)).
 user:wam_copy_term_independent_ok :- copy_term(f(_, _), f(a, b)).
+user:wam_term_variables_guard(Term, Vars) :- term_variables(Term, Vars).
+user:wam_term_variables_order :- user:wam_unbound_arg(X), user:wam_unbound_arg(Y), term_variables(f(X,Y,X), Vars), Vars = [X,Y].
+user:wam_term_variables_ground :- term_variables(f(a,42), Vars), Vars = [].
+user:wam_term_variables_single_unbound :- user:wam_unbound_arg(X), term_variables(X, Vars), Vars = [X].
+user:wam_term_variables_mismatch :- user:wam_unbound_arg(X), user:wam_unbound_arg(Y), term_variables(f(X,Y), [X]).
 user:wam_functor_guard(Term, Name, Arity) :- functor(Term, Name, Arity).
 user:wam_functor_arity_unify :- functor(f(a,b), f, Arity), Arity = 2.
 user:wam_functor_arity_unify_mismatch :- functor(f(a,b), f, Arity), Arity = 1.
@@ -757,6 +767,11 @@ run_smoke :-
           user:wam_copy_term_guard/2,
           user:wam_copy_term_sharing_fail/0,
           user:wam_copy_term_independent_ok/0,
+          user:wam_term_variables_guard/2,
+          user:wam_term_variables_order/0,
+          user:wam_term_variables_ground/0,
+          user:wam_term_variables_single_unbound/0,
+          user:wam_term_variables_mismatch/0,
           user:wam_functor_guard/3,
           user:wam_functor_arity_unify/0,
           user:wam_functor_arity_unify_mismatch/0,
@@ -975,6 +990,7 @@ run_smoke :-
     assert_lowered_sort_builtin_emitted(TmpDir),
     assert_lowered_msort_builtin_emitted(TmpDir),
     assert_lowered_copy_term_builtin_emitted(TmpDir),
+    assert_lowered_term_variables_builtin_emitted(TmpDir),
     assert_lowered_functor_builtin_emitted(TmpDir),
     assert_lowered_arg_builtin_emitted(TmpDir),
     assert_lowered_compound_name_builtin_emitted(TmpDir),
@@ -1225,6 +1241,12 @@ smoke_cases([
     case('wam_copy_term_guard/2', args('f(a)', 'f(b)'), "false"),
     case('wam_copy_term_sharing_fail/0', no_args, "false"),
     case('wam_copy_term_independent_ok/0', no_args, "true"),
+    case('wam_term_variables_guard/2', args('f(a,b)', '[]'), "true"),
+    case('wam_term_variables_guard/2', args('f(a,b)', '[a]'), "false"),
+    case('wam_term_variables_order/0', no_args, "true"),
+    case('wam_term_variables_ground/0', no_args, "true"),
+    case('wam_term_variables_single_unbound/0', no_args, "true"),
+    case('wam_term_variables_mismatch/0', no_args, "false"),
     case('wam_functor_guard/3', args('f(a)', f, 1), "true"),
     case('wam_functor_guard/3', args('f(a)', a, 1), "false"),
     case('wam_functor_guard/3', args(a, a, 0), "true"),
@@ -1719,6 +1741,13 @@ assert_lowered_copy_term_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-copy-term-sharing-fail-0"),
     has(CoreCode, "defn lowered-wam-copy-term-independent-ok-0"),
     has(CoreCode, "runtime/apply-copy-term-solution").
+
+assert_lowered_term_variables_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-term-variables-guard-2"),
+    has(CoreCode, "defn lowered-wam-term-variables-order-0"),
+    has(CoreCode, "runtime/apply-term-variables-solution").
 
 assert_lowered_functor_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Add direct lowered Clojure WAM support for `term_variables/2`.
- Add runtime variable collection that preserves first-occurrence order and deduplicates repeated variables.
- Materialize the collected variables as a proper runtime list for unification with the output argument.
- Add smoke coverage for ground terms, repeated variables, single unbound variables, guard calls, and mismatch behavior.
- Assert generated Clojure routes `term_variables/2` through `runtime/apply-term-variables-solution`.

## Why

This continues the Clojure WAM structural/materialization tier after `copy_term/2`, `functor/3`, `arg/3`, `=../2`, and the compound-name builtins. `term_variables/2` is a useful next step because it validates variable identity preservation, ordered traversal, deduplication, and proper-list materialization in the lowered runtime path.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

## Commit

- `ea3ae6b0 feat(wam-clojure): lower term variables builtin`
