### PR TITLE
LLVM WAM: delete_file/1 + make_directory/1 (M74)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1455,7 +1455,9 @@ declare i32 @strcmp(i8*, i8*)
 declare i32 @printf(i8*, ...)
 declare i32 @putchar(i32)
 declare i64 @time(i64*)
-declare i32 @stat(i8*, i8*)'
+declare i32 @stat(i8*, i8*)
+declare i32 @unlink(i8*)
+declare i32 @mkdir(i8*, i32)'
     ).
 
 %% generate_wasm_exports(+Predicates, -ExportCode)
@@ -3491,6 +3493,8 @@ entry:
     i32 90, label %builtin_get_time
     i32 91, label %builtin_exists_file
     i32 92, label %builtin_exists_directory
+    i32 93, label %builtin_delete_file
+    i32 94, label %builtin_make_directory
   ]
 
 builtin_is:
@@ -4412,6 +4416,45 @@ xd.check_mode:
   %xd.type_bits = and i32 %xd.mode, 61440  ; S_IFMT
   %xd.is_dir = icmp eq i32 %xd.type_bits, 16384  ; S_IFDIR = 0o040000
   ret i1 %xd.is_dir
+
+builtin_delete_file:
+  ; M74: delete_file(+Path) -- atom Path. Calls libc unlink(path);
+  ; succeeds iff unlink returns 0.
+  %df.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %df.t1 = extractvalue %Value %df.a1, 0
+  %df.is_atom = icmp eq i32 %df.t1, 0
+  br i1 %df.is_atom, label %df.go, label %df.fail
+df.fail:
+  ret i1 false
+df.go:
+  %df.aid = extractvalue %Value %df.a1, 1
+  %df.path = call i8* @wam_atom_to_string(i64 %df.aid)
+  %df.path_null = icmp eq i8* %df.path, null
+  br i1 %df.path_null, label %df.fail, label %df.unlink
+df.unlink:
+  %df.ret = call i32 @unlink(i8* %df.path)
+  %df.ok = icmp eq i32 %df.ret, 0
+  ret i1 %df.ok
+
+builtin_make_directory:
+  ; M74: make_directory(+Path) -- atom Path. Calls libc mkdir(path,
+  ; 0o755); succeeds iff mkdir returns 0. (0o755 = 493 decimal --
+  ; rwxr-xr-x, the conventional ``mkdir'' default; subject to umask.)
+  %mkd.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %mkd.t1 = extractvalue %Value %mkd.a1, 0
+  %mkd.is_atom = icmp eq i32 %mkd.t1, 0
+  br i1 %mkd.is_atom, label %mkd.go, label %mkd.fail
+mkd.fail:
+  ret i1 false
+mkd.go:
+  %mkd.aid = extractvalue %Value %mkd.a1, 1
+  %mkd.path = call i8* @wam_atom_to_string(i64 %mkd.aid)
+  %mkd.path_null = icmp eq i8* %mkd.path, null
+  br i1 %mkd.path_null, label %mkd.fail, label %mkd.mkdir
+mkd.mkdir:
+  %mkd.ret = call i32 @mkdir(i8* %mkd.path, i32 493)
+  %mkd.ok = icmp eq i32 %mkd.ret, 0
+  ret i1 %mkd.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -10986,6 +11029,8 @@ builtin_op_to_id('@>=/2', 89).                % standard order: greater or equal
 builtin_op_to_id('get_time/1', 90).           % wall-clock time as Float seconds since epoch.
 builtin_op_to_id('exists_file/1', 91).        % path exists AND is a regular file.
 builtin_op_to_id('exists_directory/1', 92).   % path exists AND is a directory.
+builtin_op_to_id('delete_file/1', 93).        % libc unlink(path).
+builtin_op_to_id('make_directory/1', 94).     % libc mkdir(path, 0o755).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2472,8 +2472,8 @@ test_mkd_basic(_, R) :-
 
 :- dynamic test_mkd_fail_perm/2.
 test_mkd_fail_perm(_, R) :-
-    % /etc is not writable for normal users.
-    ( make_directory('/etc/uw_m74_protected_dir') -> R is 1 ; R is 0 ).   % 0
+    % /sys is locked down (EPERM/EROFS) even for root in typical containers.
+    ( make_directory('/sys/uw_m74_protected_dir') -> R is 1 ; R is 0 ).   % 0
 
 :- dynamic test_mkd_fail_parent/2.
 test_mkd_fail_parent(_, R) :-
@@ -4238,7 +4238,7 @@ test_all :-
        format('--- M74 delete_file/1 + make_directory/1 ---~n'),
        run_test_r0('make_directory + exists_directory roundtrip -> 1',
                    test_mkd_basic, 0, 1),
-       run_test_r0('make_directory(/etc/...) no permission -> 0',
+       run_test_r0('make_directory(/sys/...) no permission -> 0',
                    test_mkd_fail_perm, 0, 0),
        run_test_r0('make_directory(/nonexistent/...) missing parent -> 0',
                    test_mkd_fail_parent, 0, 0),

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,36 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M74: delete_file/1 + make_directory/1 -- libc unlink + mkdir.
+
+:- dynamic test_mkd_basic/2.
+test_mkd_basic(_, R) :-
+    % Disjunction: either makes it new or finds it already there.
+    ( make_directory('/tmp/uw_m74_test')
+    ; exists_directory('/tmp/uw_m74_test')
+    ),
+    exists_directory('/tmp/uw_m74_test'),
+    R is 1.   % 1
+
+:- dynamic test_mkd_fail_perm/2.
+test_mkd_fail_perm(_, R) :-
+    % /etc is not writable for normal users.
+    ( make_directory('/etc/uw_m74_protected_dir') -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_mkd_fail_parent/2.
+test_mkd_fail_parent(_, R) :-
+    % Parent doesn''t exist; mkdir fails with ENOENT.
+    ( make_directory('/nonexistent/foo/bar') -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_df_fail_missing/2.
+test_df_fail_missing(_, R) :-
+    ( delete_file('/nonexistent/file/qqq') -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_df_dir_no/2.
+test_df_dir_no(_, R) :-
+    % unlink() refuses directories (EISDIR).
+    ( delete_file('/tmp') -> R is 1 ; R is 0 ).   % 0
+
 % M73: exists_file/1 + exists_directory/1 -- stat-based fs checks.
 
 :- dynamic test_xf_real/2.
@@ -4205,6 +4235,17 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M74 delete_file/1 + make_directory/1 ---~n'),
+       run_test_r0('make_directory + exists_directory roundtrip -> 1',
+                   test_mkd_basic, 0, 1),
+       run_test_r0('make_directory(/etc/...) no permission -> 0',
+                   test_mkd_fail_perm, 0, 0),
+       run_test_r0('make_directory(/nonexistent/...) missing parent -> 0',
+                   test_mkd_fail_parent, 0, 0),
+       run_test_r0('delete_file(/nonexistent/file) -> 0',
+                   test_df_fail_missing, 0, 0),
+       run_test_r0('delete_file(/tmp) directory -> 0',
+                   test_df_dir_no, 0, 0),
        format('--- M73 exists_file/1 + exists_directory/1 ---~n'),
        run_test_r0('exists_file(/etc/hostname) -> 1',
                    test_xf_real, 0, 1),


### PR DESCRIPTION
## Summary

- Adds `delete_file/1` and `make_directory/1` as native LLVM builtins (op ids 93, 94).
- Both are thin libc wrappers — `unlink(path)` and `mkdir(path, 0o755)`. Argument is a deref'd atom (`%df.path`/`%mkd.path`) resolved via `@wam_atom_to_string`; predicates succeed iff the syscall returns 0.
- Continues the M73 filesystem theme (`exists_file`/`exists_directory` were stat-based; M74 is the write side).

## What's in this PR

`src/unifyweaver/targets/wam_llvm_target.pl`
- `declare i32 @unlink(i8*)` and `declare i32 @mkdir(i8*, i32)` (Decls block at line 1459/1460).
- Dispatch entries `i32 93 -> builtin_delete_file`, `i32 94 -> builtin_make_directory`.
- `builtin_op_to_id('delete_file/1', 93)` and `('make_directory/1', 94)`.
- IR blocks `builtin_delete_file` (prefix `df.`) and `builtin_make_directory` (prefix `mkd.`):
  - Deref reg 0, tag-check for atom; non-atom or null `@wam_atom_to_string` → return false.
  - Call libc, return `icmp eq i32 ret, 0`.

`tests/core/test_wam_llvm_builtin_execution.pl`
- 5 new M74 tests, all behind the `R is N` reg-0 routing convention:
  - `make_directory + exists_directory` roundtrip (positive, disjunctive cleanup-tolerant).
  - `make_directory(/sys/...)` rejected with EPERM/EROFS (negative; uses `/sys` so it fails for root too).
  - `make_directory(/nonexistent/foo/bar)` parent missing — ENOENT (negative).
  - `delete_file(/nonexistent/file/qqq)` ENOENT (negative).
  - `delete_file(/tmp)` EISDIR — unlink refuses dirs (negative).

## Test plan

- [x] `swipl tests/core/test_wam_llvm_builtin_execution.pl` → 534 PASS, 0 FAIL on the post-fix tree.
- [x] All 5 M74 test labels green (modules 403–407 in the log).
- [x] Container ran as root; `/sys/...` path confirmed gives EPERM regardless of uid.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_