### PR TITLE
LLVM WAM: rename_file/2 + delete_directory/1 (M75)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1457,7 +1457,9 @@ declare i32 @putchar(i32)
 declare i64 @time(i64*)
 declare i32 @stat(i8*, i8*)
 declare i32 @unlink(i8*)
-declare i32 @mkdir(i8*, i32)'
+declare i32 @mkdir(i8*, i32)
+declare i32 @rename(i8*, i8*)
+declare i32 @rmdir(i8*)'
     ).
 
 %% generate_wasm_exports(+Predicates, -ExportCode)
@@ -3495,6 +3497,8 @@ entry:
     i32 92, label %builtin_exists_directory
     i32 93, label %builtin_delete_file
     i32 94, label %builtin_make_directory
+    i32 95, label %builtin_rename_file
+    i32 96, label %builtin_delete_directory
   ]
 
 builtin_is:
@@ -4455,6 +4459,54 @@ mkd.mkdir:
   %mkd.ret = call i32 @mkdir(i8* %mkd.path, i32 493)
   %mkd.ok = icmp eq i32 %mkd.ret, 0
   ret i1 %mkd.ok
+
+builtin_rename_file:
+  ; M75: rename_file(+Old, +New) -- both atoms. Calls libc
+  ; rename(old, new); succeeds iff rename returns 0.
+  %rnf.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %rnf.t1 = extractvalue %Value %rnf.a1, 0
+  %rnf.a1_atom = icmp eq i32 %rnf.t1, 0
+  br i1 %rnf.a1_atom, label %rnf.chk2, label %rnf.fail
+rnf.fail:
+  ret i1 false
+rnf.chk2:
+  %rnf.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %rnf.t2 = extractvalue %Value %rnf.a2, 0
+  %rnf.a2_atom = icmp eq i32 %rnf.t2, 0
+  br i1 %rnf.a2_atom, label %rnf.go, label %rnf.fail
+rnf.go:
+  %rnf.aid1 = extractvalue %Value %rnf.a1, 1
+  %rnf.old = call i8* @wam_atom_to_string(i64 %rnf.aid1)
+  %rnf.old_null = icmp eq i8* %rnf.old, null
+  br i1 %rnf.old_null, label %rnf.fail, label %rnf.go2
+rnf.go2:
+  %rnf.aid2 = extractvalue %Value %rnf.a2, 1
+  %rnf.new = call i8* @wam_atom_to_string(i64 %rnf.aid2)
+  %rnf.new_null = icmp eq i8* %rnf.new, null
+  br i1 %rnf.new_null, label %rnf.fail, label %rnf.do
+rnf.do:
+  %rnf.ret = call i32 @rename(i8* %rnf.old, i8* %rnf.new)
+  %rnf.ok = icmp eq i32 %rnf.ret, 0
+  ret i1 %rnf.ok
+
+builtin_delete_directory:
+  ; M75: delete_directory(+Path) -- atom Path. Calls libc rmdir(path);
+  ; succeeds iff rmdir returns 0 (target was an empty directory).
+  %ddr.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %ddr.t1 = extractvalue %Value %ddr.a1, 0
+  %ddr.is_atom = icmp eq i32 %ddr.t1, 0
+  br i1 %ddr.is_atom, label %ddr.go, label %ddr.fail
+ddr.fail:
+  ret i1 false
+ddr.go:
+  %ddr.aid = extractvalue %Value %ddr.a1, 1
+  %ddr.path = call i8* @wam_atom_to_string(i64 %ddr.aid)
+  %ddr.path_null = icmp eq i8* %ddr.path, null
+  br i1 %ddr.path_null, label %ddr.fail, label %ddr.rmdir
+ddr.rmdir:
+  %ddr.ret = call i32 @rmdir(i8* %ddr.path)
+  %ddr.ok = icmp eq i32 %ddr.ret, 0
+  ret i1 %ddr.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11031,6 +11083,8 @@ builtin_op_to_id('exists_file/1', 91).        % path exists AND is a regular fil
 builtin_op_to_id('exists_directory/1', 92).   % path exists AND is a directory.
 builtin_op_to_id('delete_file/1', 93).        % libc unlink(path).
 builtin_op_to_id('make_directory/1', 94).     % libc mkdir(path, 0o755).
+builtin_op_to_id('rename_file/2', 95).        % libc rename(old, new).
+builtin_op_to_id('delete_directory/1', 96).   % libc rmdir(path) (empty dirs only).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2067,6 +2067,8 @@ is_builtin_pred(exists_directory, 1).   % exists_directory(+Path).
 is_builtin_pred(directory_files, 2).    % directory_files(+Dir, -Files).
 is_builtin_pred(make_directory, 1).     % make_directory(+Path).
 is_builtin_pred(delete_file, 1).        % delete_file(+Path).
+is_builtin_pred(rename_file, 2).        % rename_file(+Old, +New).
+is_builtin_pred(delete_directory, 1).   % delete_directory(+Path).
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,45 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M75: rename_file/2 + delete_directory/1 -- libc rename + rmdir.
+
+:- dynamic test_rnf_basic/2.
+test_rnf_basic(_, R) :-
+    % Make a directory we can write a sentinel file into, rename it,
+    % then check both old-name absence and new-name presence. Pre-clean
+    % via best-effort delete (ignored if missing).
+    ( delete_directory('/tmp/uw_m75_rnf_dst') ; true ),
+    ( delete_directory('/tmp/uw_m75_rnf_src') ; true ),
+    make_directory('/tmp/uw_m75_rnf_src'),
+    rename_file('/tmp/uw_m75_rnf_src', '/tmp/uw_m75_rnf_dst'),
+    exists_directory('/tmp/uw_m75_rnf_dst'),
+    \+ exists_directory('/tmp/uw_m75_rnf_src'),
+    R is 1.   % 1
+
+:- dynamic test_rnf_fail_missing/2.
+test_rnf_fail_missing(_, R) :-
+    % Source doesn''t exist -> ENOENT.
+    ( rename_file('/nonexistent/source/foo', '/tmp/uw_m75_target') -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_ddr_basic/2.
+test_ddr_basic(_, R) :-
+    % Roundtrip: create then delete, verify gone.
+    ( delete_directory('/tmp/uw_m75_ddr_test') ; true ),
+    make_directory('/tmp/uw_m75_ddr_test'),
+    delete_directory('/tmp/uw_m75_ddr_test'),
+    \+ exists_directory('/tmp/uw_m75_ddr_test'),
+    R is 1.   % 1
+
+:- dynamic test_ddr_fail_missing/2.
+test_ddr_fail_missing(_, R) :-
+    % Path doesn''t exist -> ENOENT.
+    ( delete_directory('/nonexistent/dir/qqq') -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_ddr_fail_file/2.
+test_ddr_fail_file(_, R) :-
+    % rmdir() refuses non-directories (ENOTDIR).
+    ( delete_directory('/etc/hostname') -> R is 1 ; R is 0 ).   % 0
+
 % M74: delete_file/1 + make_directory/1 -- libc unlink + mkdir.
 
 :- dynamic test_mkd_basic/2.
@@ -4235,6 +4274,17 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M75 rename_file/2 + delete_directory/1 ---~n'),
+       run_test_r0('rename_file(src, dst) roundtrip -> 1',
+                   test_rnf_basic, 0, 1),
+       run_test_r0('rename_file(/nonexistent, ...) -> 0',
+                   test_rnf_fail_missing, 0, 0),
+       run_test_r0('delete_directory roundtrip -> 1',
+                   test_ddr_basic, 0, 1),
+       run_test_r0('delete_directory(/nonexistent/...) -> 0',
+                   test_ddr_fail_missing, 0, 0),
+       run_test_r0('delete_directory(/etc/hostname) file -> 0',
+                   test_ddr_fail_file, 0, 0),
        format('--- M74 delete_file/1 + make_directory/1 ---~n'),
        run_test_r0('make_directory + exists_directory roundtrip -> 1',
                    test_mkd_basic, 0, 1),


### PR DESCRIPTION
## Summary

- Adds `rename_file/2` and `delete_directory/1` as native LLVM builtins (op ids 95, 96).
- Thin libc wrappers: `rename(old, new)` and `rmdir(path)`. Args must be atoms; predicates succeed iff the syscall returns 0.
- Companion to M73 (stat-based exists checks) and M74 (`delete_file`/`make_directory`). The four together cover the canonical create/check/move/delete filesystem cycle.

## What's in this PR

`src/unifyweaver/targets/wam_llvm_target.pl`
- `declare i32 @rename(i8*, i8*)` and `declare i32 @rmdir(i8*)` in the Decls block (alongside `@unlink`/`@mkdir` from M74).
- Dispatch entries `i32 95 -> builtin_rename_file`, `i32 96 -> builtin_delete_directory`.
- `builtin_op_to_id('rename_file/2', 95)` and `('delete_directory/1', 96)`.
- IR blocks `builtin_rename_file` (prefix `rnf.`) and `builtin_delete_directory` (prefix `ddr.`):
  - Each derefs its arg registers, atom-tag-checks, resolves to `i8*` via `@wam_atom_to_string`, calls libc, returns `icmp eq i32 ret, 0`.
  - `rename_file/2` reads regs 0 and 1; null-checks both atom-string resolutions before calling.

`src/unifyweaver/targets/wam_target.pl`
- `is_builtin_pred(rename_file, 2)` and `is_builtin_pred(delete_directory, 1)`.
- Without these, WAM-fallback predicates calling rename/delete_directory emit a `call` that's looked up against the label map, doesn't find it, falls back to index 0, and crashes at runtime. (Caught on the first test run — `pass=402 fail=1` with exit 137 / SIGKILL.)

`tests/core/test_wam_llvm_builtin_execution.pl`
- 5 new M75 tests, all behind the `R is N` reg-0 routing convention:
  - rename `src` → `dst` roundtrip (positive; verifies dst exists and src is gone).
  - `rename_file(/nonexistent/source, ...)` ENOENT (negative).
  - `delete_directory` create-then-delete roundtrip (positive; verifies target is gone).
  - `delete_directory(/nonexistent/dir)` ENOENT (negative).
  - `delete_directory(/etc/hostname)` ENOTDIR — rmdir refuses non-directories (negative).

## Test plan

- [x] `swipl tests/core/test_wam_llvm_builtin_execution.pl` → 539 PASS, 0 FAIL on the post-fix tree.
- [x] All 5 M75 test labels green (modules 403–407 in the log).
- [x] 0 ``unknown label`` warnings — `is_builtin_pred` entries route the calls through the builtin dispatcher.
- [x] Verified failure mode without `is_builtin_pred`: rename_file/delete_directory dispatched to label 0, SIGKILL'd the test process. Recovery via the registration fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_