### PR TITLE
LLVM WAM: size_file/2 + time_file/2 (M76)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3499,6 +3499,8 @@ entry:
     i32 94, label %builtin_make_directory
     i32 95, label %builtin_rename_file
     i32 96, label %builtin_delete_directory
+    i32 97, label %builtin_size_file
+    i32 98, label %builtin_time_file
   ]
 
 builtin_is:
@@ -4507,6 +4509,76 @@ ddr.rmdir:
   %ddr.ret = call i32 @rmdir(i8* %ddr.path)
   %ddr.ok = icmp eq i32 %ddr.ret, 0
   ret i1 %ddr.ok
+
+builtin_size_file:
+  ; M76: size_file(+Path, ?Size) -- atom Path; unifies A2 with stat
+  ; result st_size (i64, offset 48 on Linux glibc). Fails if stat
+  ; fails (missing path, permission denied, etc).
+  %sf.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %sf.t1 = extractvalue %Value %sf.a1, 0
+  %sf.is_atom = icmp eq i32 %sf.t1, 0
+  br i1 %sf.is_atom, label %sf.go, label %sf.fail
+sf.fail:
+  ret i1 false
+sf.go:
+  %sf.aid = extractvalue %Value %sf.a1, 1
+  %sf.path = call i8* @wam_atom_to_string(i64 %sf.aid)
+  %sf.path_null = icmp eq i8* %sf.path, null
+  br i1 %sf.path_null, label %sf.fail, label %sf.stat
+sf.stat:
+  %sf.buf = alloca [256 x i8]
+  %sf.buf_ptr = getelementptr [256 x i8], [256 x i8]* %sf.buf, i32 0, i32 0
+  %sf.ret = call i32 @stat(i8* %sf.path, i8* %sf.buf_ptr)
+  %sf.stat_ok = icmp eq i32 %sf.ret, 0
+  br i1 %sf.stat_ok, label %sf.read, label %sf.fail
+sf.read:
+  %sf.size_ptr_i8 = getelementptr i8, i8* %sf.buf_ptr, i64 48
+  %sf.size_ptr = bitcast i8* %sf.size_ptr_i8 to i64*
+  %sf.size = load i64, i64* %sf.size_ptr
+  %sf.v = call %Value @value_integer(i64 %sf.size)
+  %sf.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %sf.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %sf.raw2, %Value %sf.v)
+  ret i1 %sf.ok
+
+builtin_time_file:
+  ; M76: time_file(+Path, ?Time) -- atom Path; unifies A2 with the
+  ; modification time as Float seconds since the epoch
+  ; (st_mtim.tv_sec at offset 88 + tv_nsec at offset 96 / 1e9).
+  ; Fails if stat fails.
+  %tf.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %tf.t1 = extractvalue %Value %tf.a1, 0
+  %tf.is_atom = icmp eq i32 %tf.t1, 0
+  br i1 %tf.is_atom, label %tf.go, label %tf.fail
+tf.fail:
+  ret i1 false
+tf.go:
+  %tf.aid = extractvalue %Value %tf.a1, 1
+  %tf.path = call i8* @wam_atom_to_string(i64 %tf.aid)
+  %tf.path_null = icmp eq i8* %tf.path, null
+  br i1 %tf.path_null, label %tf.fail, label %tf.stat
+tf.stat:
+  %tf.buf = alloca [256 x i8]
+  %tf.buf_ptr = getelementptr [256 x i8], [256 x i8]* %tf.buf, i32 0, i32 0
+  %tf.ret = call i32 @stat(i8* %tf.path, i8* %tf.buf_ptr)
+  %tf.stat_ok = icmp eq i32 %tf.ret, 0
+  br i1 %tf.stat_ok, label %tf.read, label %tf.fail
+tf.read:
+  %tf.sec_ptr_i8 = getelementptr i8, i8* %tf.buf_ptr, i64 88
+  %tf.sec_ptr = bitcast i8* %tf.sec_ptr_i8 to i64*
+  %tf.sec = load i64, i64* %tf.sec_ptr
+  %tf.nsec_ptr_i8 = getelementptr i8, i8* %tf.buf_ptr, i64 96
+  %tf.nsec_ptr = bitcast i8* %tf.nsec_ptr_i8 to i64*
+  %tf.nsec = load i64, i64* %tf.nsec_ptr
+  %tf.sec_d = sitofp i64 %tf.sec to double
+  %tf.nsec_d = sitofp i64 %tf.nsec to double
+  %tf.frac = fdiv double %tf.nsec_d, 1.000000e+09
+  %tf.total = fadd double %tf.sec_d, %tf.frac
+  %tf.bits = bitcast double %tf.total to i64
+  %tf.v0 = insertvalue %Value undef, i32 2, 0
+  %tf.v = insertvalue %Value %tf.v0, i64 %tf.bits, 1
+  %tf.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %tf.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %tf.raw2, %Value %tf.v)
+  ret i1 %tf.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11085,6 +11157,8 @@ builtin_op_to_id('delete_file/1', 93).        % libc unlink(path).
 builtin_op_to_id('make_directory/1', 94).     % libc mkdir(path, 0o755).
 builtin_op_to_id('rename_file/2', 95).        % libc rename(old, new).
 builtin_op_to_id('delete_directory/1', 96).   % libc rmdir(path) (empty dirs only).
+builtin_op_to_id('size_file/2', 97).          % stat -> st_size as Integer.
+builtin_op_to_id('time_file/2', 98).          % stat -> st_mtime as Float seconds.
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2069,6 +2069,8 @@ is_builtin_pred(make_directory, 1).     % make_directory(+Path).
 is_builtin_pred(delete_file, 1).        % delete_file(+Path).
 is_builtin_pred(rename_file, 2).        % rename_file(+Old, +New).
 is_builtin_pred(delete_directory, 1).   % delete_directory(+Path).
+is_builtin_pred(size_file, 2).          % size_file(+Path, -Size).
+is_builtin_pred(time_file, 2).          % time_file(+Path, -Time).
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,34 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M76: size_file/2 + time_file/2 -- stat-based mtime + size readers.
+
+:- dynamic test_sf_etc_hostname/2.
+test_sf_etc_hostname(_, R) :-
+    % /etc/hostname is small but > 0 bytes on every Linux container.
+    size_file('/etc/hostname', N),
+    ( N > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_sf_zero/2.
+test_sf_zero(_, R) :-
+    % /dev/null is a 0-byte character device; stat reports size = 0.
+    size_file('/dev/null', N),
+    R is N.   % 0
+
+:- dynamic test_sf_fail_missing/2.
+test_sf_fail_missing(_, R) :-
+    ( size_file('/nonexistent/file/qqq', _) -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_tf_etc_hostname/2.
+test_tf_etc_hostname(_, R) :-
+    % Mtime on /etc/hostname is some Float > 0 (epoch seconds).
+    time_file('/etc/hostname', T),
+    ( T > 0.0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_tf_fail_missing/2.
+test_tf_fail_missing(_, R) :-
+    ( time_file('/nonexistent/file/qqq', _) -> R is 1 ; R is 0 ).   % 0
+
 % M75: rename_file/2 + delete_directory/1 -- libc rename + rmdir.
 
 :- dynamic test_rnf_basic/2.
@@ -4274,6 +4302,17 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M76 size_file/2 + time_file/2 ---~n'),
+       run_test_r0('size_file(/etc/hostname) > 0 -> 1',
+                   test_sf_etc_hostname, 0, 1),
+       run_test_r0('size_file(/dev/null) -> 0',
+                   test_sf_zero, 0, 0),
+       run_test_r0('size_file(/nonexistent/...) -> 0',
+                   test_sf_fail_missing, 0, 0),
+       run_test_r0('time_file(/etc/hostname) > 0.0 -> 1',
+                   test_tf_etc_hostname, 0, 1),
+       run_test_r0('time_file(/nonexistent/...) -> 0',
+                   test_tf_fail_missing, 0, 0),
        format('--- M75 rename_file/2 + delete_directory/1 ---~n'),
        run_test_r0('rename_file(src, dst) roundtrip -> 1',
                    test_rnf_basic, 0, 1),


### PR DESCRIPTION
## Summary

- Adds `size_file/2` and `time_file/2` as native LLVM builtins (op ids 97, 98).
- Both are thin stat-based readers; they share the 256-byte `alloca` scaffold from M73 and just read different fields of the result.
- Rounds out the M73–M76 filesystem cluster: exists check → create/move/delete (M73–M75) → stat read (M76).

## What's in this PR

`src/unifyweaver/targets/wam_llvm_target.pl`
- Dispatch entries `i32 97 -> builtin_size_file`, `i32 98 -> builtin_time_file`.
- `builtin_op_to_id('size_file/2', 97)` and `('time_file/2', 98)`.
- IR blocks `builtin_size_file` (prefix `sf.`) and `builtin_time_file` (prefix `tf.`):
  - Deref reg 0, atom-tag-check, resolve via `@wam_atom_to_string`, alloca 256-byte stat buf, call `@stat`, fail if non-zero.
  - **`size_file`**: load i64 from offset 48 (`st_size`), box via `@value_integer`, unify with reg 1.
  - **`time_file`**: load i64 from offset 88 (`st_mtim.tv_sec`) and offset 96 (`st_mtim.tv_nsec`), compute `sec + nsec/1e9` as `double`, build Float `%Value` inline (same shape as M72 `get_time/1`), unify with reg 1.
- No new libc declarations needed — reuses M73's `@stat`.

`src/unifyweaver/targets/wam_target.pl`
- `is_builtin_pred(size_file, 2)` and `is_builtin_pred(time_file, 2)` so WAM-fallback test predicates route the call through the builtin dispatcher instead of label-map fallback (the gotcha from M75).

`tests/core/test_wam_llvm_builtin_execution.pl`
- 5 new M76 tests, behind the `R is N` reg-0 routing convention:
  - `size_file(/etc/hostname) > 0` (positive — non-empty file).
  - `size_file(/dev/null) -> 0` (boundary — character device reports size 0).
  - `size_file(/nonexistent/...)` ENOENT (negative).
  - `time_file(/etc/hostname) > 0.0` (positive — mtime is some Float epoch second).
  - `time_file(/nonexistent/...)` ENOENT (negative).

## Stat-offset verification

Compiled a tiny `offsetof()` reproducer against `<sys/stat.h>` on the container's glibc:

```
st_size:        offset=48  size=8
st_mtim.tv_sec: offset=88  size=8
st_mtim.tv_nsec: offset=96 size=8
st_mode:        offset=24  size=4   (matches M73)
```

Confirms the canonical Linux x86-64 glibc layout used in the IR blocks.

## Test plan

- [x] `swipl tests/core/test_wam_llvm_builtin_execution.pl` → 544 PASS, 0 FAIL.
- [x] All 5 M76 test labels green (modules 403–407 in the log).
- [x] 0 ``unknown label`` warnings.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_