### PR TITLE
LLVM WAM: getenv/2 + setenv/2 (M77)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1459,7 +1459,10 @@ declare i32 @stat(i8*, i8*)
 declare i32 @unlink(i8*)
 declare i32 @mkdir(i8*, i32)
 declare i32 @rename(i8*, i8*)
-declare i32 @rmdir(i8*)'
+declare i32 @rmdir(i8*)
+declare i8* @getenv(i8*)
+declare i32 @setenv(i8*, i8*, i32)
+declare i64 @strlen(i8*)'
     ).
 
 %% generate_wasm_exports(+Predicates, -ExportCode)
@@ -3501,6 +3504,8 @@ entry:
     i32 96, label %builtin_delete_directory
     i32 97, label %builtin_size_file
     i32 98, label %builtin_time_file
+    i32 99, label %builtin_getenv
+    i32 100, label %builtin_setenv
   ]
 
 builtin_is:
@@ -4579,6 +4584,73 @@ tf.read:
   %tf.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
   %tf.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %tf.raw2, %Value %tf.v)
   ret i1 %tf.ok
+
+builtin_getenv:
+  ; M77: getenv(+Name, ?Value) -- atom Name; if env var exists,
+  ; copies its value into the arena, interns as an atom, and
+  ; unifies with A2. Fails if the var is unset.
+  %gev.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %gev.t1 = extractvalue %Value %gev.a1, 0
+  %gev.is_atom = icmp eq i32 %gev.t1, 0
+  br i1 %gev.is_atom, label %gev.go, label %gev.fail
+gev.fail:
+  ret i1 false
+gev.go:
+  %gev.aid = extractvalue %Value %gev.a1, 1
+  %gev.name = call i8* @wam_atom_to_string(i64 %gev.aid)
+  %gev.name_null = icmp eq i8* %gev.name, null
+  br i1 %gev.name_null, label %gev.fail, label %gev.call
+gev.call:
+  %gev.val = call i8* @getenv(i8* %gev.name)
+  %gev.val_null = icmp eq i8* %gev.val, null
+  br i1 %gev.val_null, label %gev.fail, label %gev.copy
+gev.copy:
+  ; getenv returns a pointer into the libc env block. Copy into
+  ; the arena (so the atom table owns the bytes) before interning.
+  %gev.len = call i64 @strlen(i8* %gev.val)
+  call void @wam_arena_ensure()
+  %gev.bufsize = add i64 %gev.len, 1
+  %gev.buf = call i8* @wam_arena_alloc(i64 %gev.bufsize)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %gev.buf, i8* %gev.val, i64 %gev.len, i1 false)
+  %gev.term = getelementptr i8, i8* %gev.buf, i64 %gev.len
+  store i8 0, i8* %gev.term
+  %gev.new_id = call i64 @wam_intern_atom(i8* %gev.buf, i64 %gev.len)
+  %gev.v0 = insertvalue %Value undef, i32 0, 0
+  %gev.v = insertvalue %Value %gev.v0, i64 %gev.new_id, 1
+  %gev.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %gev.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %gev.raw2, %Value %gev.v)
+  ret i1 %gev.ok
+
+builtin_setenv:
+  ; M77: setenv(+Name, +Value) -- both atoms. Calls libc
+  ; setenv(name, value, 1) -- the trailing 1 is the "overwrite"
+  ; flag, matching SWI-Prolog''s set-without-checking semantics.
+  ; Succeeds iff setenv returns 0.
+  %se.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %se.t1 = extractvalue %Value %se.a1, 0
+  %se.a1_atom = icmp eq i32 %se.t1, 0
+  br i1 %se.a1_atom, label %se.chk2, label %se.fail
+se.fail:
+  ret i1 false
+se.chk2:
+  %se.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %se.t2 = extractvalue %Value %se.a2, 0
+  %se.a2_atom = icmp eq i32 %se.t2, 0
+  br i1 %se.a2_atom, label %se.go, label %se.fail
+se.go:
+  %se.aid1 = extractvalue %Value %se.a1, 1
+  %se.name = call i8* @wam_atom_to_string(i64 %se.aid1)
+  %se.name_null = icmp eq i8* %se.name, null
+  br i1 %se.name_null, label %se.fail, label %se.go2
+se.go2:
+  %se.aid2 = extractvalue %Value %se.a2, 1
+  %se.val = call i8* @wam_atom_to_string(i64 %se.aid2)
+  %se.val_null = icmp eq i8* %se.val, null
+  br i1 %se.val_null, label %se.fail, label %se.do
+se.do:
+  %se.ret = call i32 @setenv(i8* %se.name, i8* %se.val, i32 1)
+  %se.ok = icmp eq i32 %se.ret, 0
+  ret i1 %se.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11159,6 +11231,8 @@ builtin_op_to_id('rename_file/2', 95).        % libc rename(old, new).
 builtin_op_to_id('delete_directory/1', 96).   % libc rmdir(path) (empty dirs only).
 builtin_op_to_id('size_file/2', 97).          % stat -> st_size as Integer.
 builtin_op_to_id('time_file/2', 98).          % stat -> st_mtime as Float seconds.
+builtin_op_to_id('getenv/2', 99).             % libc getenv(name) -> atom value or fail.
+builtin_op_to_id('setenv/2', 100).            % libc setenv(name, value, 1).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2071,6 +2071,8 @@ is_builtin_pred(rename_file, 2).        % rename_file(+Old, +New).
 is_builtin_pred(delete_directory, 1).   % delete_directory(+Path).
 is_builtin_pred(size_file, 2).          % size_file(+Path, -Size).
 is_builtin_pred(time_file, 2).          % time_file(+Path, -Time).
+is_builtin_pred(getenv, 2).             % getenv(+Name, -Value).
+is_builtin_pred(setenv, 2).             % setenv(+Name, +Value).
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,41 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M77: getenv/2 + setenv/2 -- libc env-var access.
+
+:- dynamic test_ge_path/2.
+test_ge_path(_, R) :-
+    % PATH is set in every container shell.
+    getenv('PATH', P),
+    atom_length(P, L),
+    ( L > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_ge_missing/2.
+test_ge_missing(_, R) :-
+    ( getenv('UW_M77_DEFINITELY_UNSET', _) -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_se_basic/2.
+test_se_basic(_, R) :-
+    setenv('UW_M77_TEST', 'hello'),
+    getenv('UW_M77_TEST', V),
+    ( V == 'hello' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_se_overwrite/2.
+test_se_overwrite(_, R) :-
+    setenv('UW_M77_OVR', 'first'),
+    setenv('UW_M77_OVR', 'second'),
+    getenv('UW_M77_OVR', V),
+    ( V == 'second' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_se_empty/2.
+test_se_empty(_, R) :-
+    % Empty string is a valid value (setenv accepts ""). getenv
+    % then succeeds and returns the empty atom.
+    setenv('UW_M77_EMPTY', ''),
+    getenv('UW_M77_EMPTY', V),
+    atom_length(V, L),
+    R is L.   % 0
+
 % M76: size_file/2 + time_file/2 -- stat-based mtime + size readers.
 
 :- dynamic test_sf_etc_hostname/2.
@@ -4302,6 +4337,17 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M77 getenv/2 + setenv/2 ---~n'),
+       run_test_r0('getenv(PATH) length > 0 -> 1',
+                   test_ge_path, 0, 1),
+       run_test_r0('getenv(unset) -> 0',
+                   test_ge_missing, 0, 0),
+       run_test_r0('setenv + getenv roundtrip -> 1',
+                   test_se_basic, 0, 1),
+       run_test_r0('setenv overwrite -> 1 (last write wins)',
+                   test_se_overwrite, 0, 1),
+       run_test_r0('setenv empty value -> 0 (empty atom length)',
+                   test_se_empty, 0, 0),
        format('--- M76 size_file/2 + time_file/2 ---~n'),
        run_test_r0('size_file(/etc/hostname) > 0 -> 1',
                    test_sf_etc_hostname, 0, 1),


### PR DESCRIPTION
## Summary

- Adds `getenv/2` and `setenv/2` as native LLVM builtins (op ids 99, 100).
- First M-series milestone outside the M73–M76 filesystem cluster — covers env-var access so containerized scripts that branch on `PATH` / `HOME` / config flags can compile end-to-end.
- Both predicates follow SWI-Prolog's standard semantics: `getenv` succeeds with the value atom or fails when unset; `setenv` overwrites unconditionally and succeeds iff libc returns 0.

## What's in this PR

`src/unifyweaver/targets/wam_llvm_target.pl`
- Dispatch entries `i32 99 -> builtin_getenv`, `i32 100 -> builtin_setenv`.
- `builtin_op_to_id('getenv/2', 99)` and `('setenv/2', 100)`.
- Three new libc declarations: `@getenv`, `@setenv`, `@strlen`.
- **`builtin_getenv`** (prefix `gev.`): deref reg 0, atom-check, resolve to `i8*` via `@wam_atom_to_string`, call `@getenv`. On non-null result, `@strlen` it, copy into the WAM arena (since libc owns the original bytes), null-terminate, `@wam_intern_atom`, unify with reg 1.
- **`builtin_setenv`** (prefix `se.`): atom-check both regs, resolve to `i8*`, call `@setenv(name, value, 1)` (overwrite=1), succeed iff return is 0.

`src/unifyweaver/targets/wam_target.pl`
- `is_builtin_pred(getenv, 2)` and `is_builtin_pred(setenv, 2)` so WAM-fallback predicates dispatch through the builtin path (the registration gotcha from M75).

`tests/core/test_wam_llvm_builtin_execution.pl`
- 5 new M77 tests, behind the `R is N` reg-0 routing convention:
  - `getenv(PATH)` length > 0 (positive — `PATH` is always set in container shells).
  - `getenv(UW_M77_DEFINITELY_UNSET)` → 0 (negative).
  - `setenv + getenv` roundtrip (`'UW_M77_TEST'` → `'hello'`).
  - `setenv` overwrites prior value (`UW_M77_OVR`: `first` then `second`).
  - `setenv('UW_M77_EMPTY', '')` → `getenv` returns empty atom with length 0 (boundary — libc accepts empty values).

## Dev notes — gotchas hit on this PR

- **SSA prefix collision**: `ge.` was already used by `builtin_ge` (arithmetic `>=/2`), so llc rejected the module with `multiple definition of local value named 'ge.a1'`. Renamed the M77 getenv block end-to-end to `gev.`.
- **Stray apostrophe**: an IR comment line read `; ... matching SWI-Prolog's set-without-checking semantics.` — the apostrophe broke the surrounding Prolog single-quoted string that holds the IR. Escaped to `''`. Caught during the first parse attempt (16 cascading "Operator expected" errors).

## Test plan

- [x] `swipl tests/core/test_wam_llvm_builtin_execution.pl` → 549 PASS, 0 FAIL.
- [x] All 5 M77 test labels green (modules 403–407 in the log).
- [x] 0 `unknown label` warnings.
- [x] Single-pred `llc` smoke pass on the regenerated IR after the prefix rename, confirming the multiple-definition error is gone.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_