### PR TITLE
LLVM WAM: shell/1 + shell/2 (M78)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1462,7 +1462,8 @@ declare i32 @rename(i8*, i8*)
 declare i32 @rmdir(i8*)
 declare i8* @getenv(i8*)
 declare i32 @setenv(i8*, i8*, i32)
-declare i64 @strlen(i8*)'
+declare i64 @strlen(i8*)
+declare i32 @system(i8*)'
     ).
 
 %% generate_wasm_exports(+Predicates, -ExportCode)
@@ -3506,6 +3507,8 @@ entry:
     i32 98, label %builtin_time_file
     i32 99, label %builtin_getenv
     i32 100, label %builtin_setenv
+    i32 101, label %builtin_shell1
+    i32 102, label %builtin_shell2
   ]
 
 builtin_is:
@@ -4651,6 +4654,57 @@ se.do:
   %se.ret = call i32 @setenv(i8* %se.name, i8* %se.val, i32 1)
   %se.ok = icmp eq i32 %se.ret, 0
   ret i1 %se.ok
+
+builtin_shell1:
+  ; M78: shell(+Command) -- atom Command; runs ``/bin/sh -c Command``
+  ; via libc system(); succeeds iff the raw wait status is 0
+  ; (i.e. exit 0, no signal). Note that on Linux system() returns
+  ; the wait status, which is 0 only when the child exited
+  ; normally with code 0 -- exactly the desired semantics for
+  ; shell/1.
+  %sh1.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %sh1.t1 = extractvalue %Value %sh1.a1, 0
+  %sh1.is_atom = icmp eq i32 %sh1.t1, 0
+  br i1 %sh1.is_atom, label %sh1.go, label %sh1.fail
+sh1.fail:
+  ret i1 false
+sh1.go:
+  %sh1.aid = extractvalue %Value %sh1.a1, 1
+  %sh1.cmd = call i8* @wam_atom_to_string(i64 %sh1.aid)
+  %sh1.cmd_null = icmp eq i8* %sh1.cmd, null
+  br i1 %sh1.cmd_null, label %sh1.fail, label %sh1.run
+sh1.run:
+  %sh1.raw = call i32 @system(i8* %sh1.cmd)
+  %sh1.ok = icmp eq i32 %sh1.raw, 0
+  ret i1 %sh1.ok
+
+builtin_shell2:
+  ; M78: shell(+Command, ?Status) -- atom Command; unifies Status
+  ; with WEXITSTATUS(raw) (decoded exit code 0..255), matching
+  ; SWI-Prolog''s convention. For abnormal termination (signal,
+  ; system() == -1) Status reflects the high bits as encoded
+  ; by the kernel; callers can compare against 0 for ``ran and
+  ; exited cleanly''.
+  %sh2.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %sh2.t1 = extractvalue %Value %sh2.a1, 0
+  %sh2.is_atom = icmp eq i32 %sh2.t1, 0
+  br i1 %sh2.is_atom, label %sh2.go, label %sh2.fail
+sh2.fail:
+  ret i1 false
+sh2.go:
+  %sh2.aid = extractvalue %Value %sh2.a1, 1
+  %sh2.cmd = call i8* @wam_atom_to_string(i64 %sh2.aid)
+  %sh2.cmd_null = icmp eq i8* %sh2.cmd, null
+  br i1 %sh2.cmd_null, label %sh2.fail, label %sh2.run
+sh2.run:
+  %sh2.raw = call i32 @system(i8* %sh2.cmd)
+  %sh2.shifted = ashr i32 %sh2.raw, 8
+  %sh2.exit = and i32 %sh2.shifted, 255
+  %sh2.exit64 = sext i32 %sh2.exit to i64
+  %sh2.v = call %Value @value_integer(i64 %sh2.exit64)
+  %sh2.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %sh2.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %sh2.raw2, %Value %sh2.v)
+  ret i1 %sh2.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11233,6 +11287,8 @@ builtin_op_to_id('size_file/2', 97).          % stat -> st_size as Integer.
 builtin_op_to_id('time_file/2', 98).          % stat -> st_mtime as Float seconds.
 builtin_op_to_id('getenv/2', 99).             % libc getenv(name) -> atom value or fail.
 builtin_op_to_id('setenv/2', 100).            % libc setenv(name, value, 1).
+builtin_op_to_id('shell/1', 101).             % libc system(cmd) succeeds iff exit 0.
+builtin_op_to_id('shell/2', 102).             % libc system(cmd), Status = WEXITSTATUS.
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2073,6 +2073,8 @@ is_builtin_pred(size_file, 2).          % size_file(+Path, -Size).
 is_builtin_pred(time_file, 2).          % time_file(+Path, -Time).
 is_builtin_pred(getenv, 2).             % getenv(+Name, -Value).
 is_builtin_pred(setenv, 2).             % setenv(+Name, +Value).
+is_builtin_pred(shell, 1).              % shell(+Command).
+is_builtin_pred(shell, 2).              % shell(+Command, -Status).
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,30 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M78: shell/1 + shell/2 -- libc system() process spawn.
+
+:- dynamic test_sh1_true/2.
+test_sh1_true(_, R) :-
+    ( shell('true') -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_sh1_false/2.
+test_sh1_false(_, R) :-
+    ( shell('false') -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_sh1_nonexistent/2.
+test_sh1_nonexistent(_, R) :-
+    ( shell('/nonexistent/uw_m78_definitely_no_such_binary') -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_sh2_true/2.
+test_sh2_true(_, R) :-
+    shell('true', S),
+    R is S.   % 0
+
+:- dynamic test_sh2_exit42/2.
+test_sh2_exit42(_, R) :-
+    shell('exit 42', S),
+    R is S.   % 42
+
 % M77: getenv/2 + setenv/2 -- libc env-var access.
 
 :- dynamic test_ge_path/2.
@@ -4337,6 +4361,17 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M78 shell/1 + shell/2 ---~n'),
+       run_test_r0('shell(true) -> 1',
+                   test_sh1_true, 0, 1),
+       run_test_r0('shell(false) -> 0',
+                   test_sh1_false, 0, 0),
+       run_test_r0('shell(/nonexistent/...) -> 0',
+                   test_sh1_nonexistent, 0, 0),
+       run_test_r0('shell(true, S), S=0 -> 0',
+                   test_sh2_true, 0, 0),
+       run_test_r0('shell(exit 42, S), S=42 -> 42',
+                   test_sh2_exit42, 0, 42),
        format('--- M77 getenv/2 + setenv/2 ---~n'),
        run_test_r0('getenv(PATH) length > 0 -> 1',
                    test_ge_path, 0, 1),


### PR DESCRIPTION
## Summary

- Adds `shell/1` and `shell/2` as native LLVM builtins (op ids 101, 102).
- Both wrap libc `system()` — runs `/bin/sh -c Command` and returns the wait status. Continues the M77 "OS access for compiled Prolog scripts" theme.
- Semantics match SWI-Prolog: `shell/1` succeeds iff the command exited cleanly with code 0; `shell/2` always succeeds (modulo argument validity) and binds Status to the decoded exit code (`WEXITSTATUS`).

## What's in this PR

`src/unifyweaver/targets/wam_llvm_target.pl`
- Dispatch entries `i32 101 -> builtin_shell1`, `i32 102 -> builtin_shell2`.
- `builtin_op_to_id('shell/1', 101)` and `('shell/2', 102)`.
- New `declare i32 @system(i8*)`.
- **`builtin_shell1`** (prefix `sh1.`): deref reg 0, atom-check, resolve via `@wam_atom_to_string`, call `@system`, succeed iff return is 0.
- **`builtin_shell2`** (prefix `sh2.`): same atom path, then decode the i32 wait status via `(raw >> 8) & 0xff` (the libc `WEXITSTATUS` macro), `sext` to i64, box via `@value_integer`, unify with reg 1.

`src/unifyweaver/targets/wam_target.pl`
- `is_builtin_pred(shell, 1)` and `is_builtin_pred(shell, 2)` so WAM-fallback predicates route through the builtin dispatcher.

`tests/core/test_wam_llvm_builtin_execution.pl`
- 5 new M78 tests, behind the `R is N` reg-0 routing convention:
  - `shell('true')` → 1 (positive — exits cleanly).
  - `shell('false')` → 0 (negative — non-zero exit).
  - `shell('/nonexistent/uw_m78_definitely_no_such_binary')` → 0 (negative — /bin/sh prints "not found" and returns 127).
  - `shell('true', S), R is S` → 0 (status binding, positive case).
  - `shell('exit 42', S), R is S` → 42 (specific decoded exit code).

## Test plan

- [x] `swipl tests/core/test_wam_llvm_builtin_execution.pl` → 554 PASS, 0 FAIL.
- [x] All 5 M78 test labels green (modules 403–407 in the log).
- [x] 0 `unknown label` warnings.
- [x] Single-pred `llc` smoke confirms no SSA name conflicts (M77 caught one of those — wanted to verify M78 was clean before the full run).
- [x] `shell('/nonexistent/...')` test produced the expected `sh: 1: ... not found` to stderr — confirms the libc-level dispatch is going through `/bin/sh`.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_