### PR TITLE
fix(wam-conformance): make runner work on Termux and Scala CLI

### DIFF
--- a/docs/WAM_CROSS_TARGET_CONFORMANCE.md
+++ b/docs/WAM_CROSS_TARGET_CONFORMANCE.md
@@ -53,6 +53,14 @@ Environment knobs:
 | `CONFORMANCE_PROGRAMS=member,fib`  | limit which programs run |
 | `CONFORMANCE_SAMPLE=N`             | random N queries per program |
 | `CONFORMANCE_SEED=N`               | seed the sampler (reproducible) |
+| `UW_SMOKE_TMPDIR`, `TMPDIR`, `$PREFIX/tmp` | writable temp-root selection via `tests/helpers/smoke_paths.pl` |
+| `SCALA_MAVEN_ROOT` | optional root for Scala runtime jars when running generated Scala classes via `java -cp` |
+
+Scala builds still use `scalac`, but the harness runs generated Scala
+classes via `java -cp` when Scala 3 runtime jars are discoverable. This
+avoids Scala-CLI/JNA launcher failures on native Termux while preserving
+the legacy `scala -classpath ...` fallback for environments without a
+local Scala maven cache.
 
 Suggested CI tiers:
 

--- a/src/unifyweaver/targets/wam_wat_target.pl
+++ b/src/unifyweaver/targets/wam_wat_target.pl
@@ -839,12 +839,6 @@ wam_instruction_to_wat_bytes(
     Op2 is (CmpdPC /\ 0xFFFFFFFF) \/ ((DefaultPC /\ 0xFFFFFFFF) << 32),
     encode_instr_hex(Tag, Op1, Op2, Hex).
 
-%% resolve_opt_label(+Label, +Labels, -PC)
-%  Like resolve_label/3 but allows atom 0 (or integer 0) as "no
-%  dispatch" — returns PC = 0. Real labels resolve normally.
-resolve_opt_label(0, _, 0) :- !.
-resolve_opt_label(Lbl, Labels, PC) :- resolve_label(Lbl, Labels, PC).
-
 %% tail_call_5: fusion of a 5-arg tail-call setup window:
 %%   put_value(R1,A1) put_value(R2,A2) put_value(R3,A3)
 %%   put_value(R4,A4) put_value(R5,A5) deallocate execute(Pred)
@@ -936,6 +930,27 @@ wam_instruction_to_wat_bytes(switch_on_term_hdr(RegIdx, CC, SC), _Labels, Hex) :
     instr_tag(switch_on_term_hdr, Tag),
     Op1 is (CC << 32) \/ RegIdx,
     encode_instr_hex(Tag, Op1, SC, Hex).
+
+wam_instruction_to_wat_bytes(neck_cut_test(GuardOp, GuardArity, ElseLabel), Labels, Hex) :-
+    instr_tag(neck_cut_test, Tag),
+    resolve_label(ElseLabel, Labels, ElsePC),
+    (   builtin_id(GuardOp, GuardId) -> true ; GuardId = 255 ),
+    %% op1 = else PC, op2 = (guard_builtin_id << 32) | guard_arity
+    Op2 is (GuardId << 32) \/ GuardArity,
+    encode_instr_hex(Tag, ElsePC, Op2, Hex).
+
+%% resolve_opt_label(+Label, +Labels, -PC)
+%  Like resolve_label/3 but allows atom 0 (or integer 0) as "no
+%  dispatch" — returns PC = 0. Real labels resolve normally.
+resolve_opt_label(0, _, 0) :- !.
+resolve_opt_label(Lbl, Labels, PC) :- resolve_label(Lbl, Labels, PC).
+
+agg_type_id(sum, 0).
+agg_type_id(count, 1).
+agg_type_id(max, 2).
+agg_type_id(min, 3).
+agg_type_id(collect, 4).
+agg_type_id(_, 0).  % default to sum
 
 %% parse_switch_entries(+Parts, -Entries)
 %  Parts is a list of strings like ["10:default,", "20:L_my_fact_1_2,",
@@ -1092,21 +1107,6 @@ build_switch_term_instrs(RegIdx, AllConsts, AllStructs,
     maplist(entry_to_instr, Consts, CInstrs),
     maplist(struct_entry_to_instr, Structs, SInstrs),
     append(CInstrs, SInstrs, AllEntries).
-
-agg_type_id(sum, 0).
-agg_type_id(count, 1).
-agg_type_id(max, 2).
-agg_type_id(min, 3).
-agg_type_id(collect, 4).
-agg_type_id(_, 0).  % default to sum
-
-wam_instruction_to_wat_bytes(neck_cut_test(GuardOp, GuardArity, ElseLabel), Labels, Hex) :-
-    instr_tag(neck_cut_test, Tag),
-    resolve_label(ElseLabel, Labels, ElsePC),
-    (   builtin_id(GuardOp, GuardId) -> true ; GuardId = 255 ),
-    %% op1 = else PC, op2 = (guard_builtin_id << 32) | guard_arity
-    Op2 is (GuardId << 32) \/ GuardArity,
-    encode_instr_hex(Tag, ElsePC, Op2, Hex).
 
 % --- Encoding helpers ---
 

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -45,6 +45,7 @@
 :- use_module(library(lists)).
 :- use_module(library(apply)).
 :- use_module(library(random)).
+:- use_module('helpers/smoke_paths', [tmp_root/1]).
 :- use_module('wam_conformance_fixtures').
 :- use_module('../src/unifyweaver/targets/wam_target').
 :- use_module('../src/unifyweaver/targets/wam_scala_target').
@@ -121,11 +122,19 @@ ct_skip(wat, reverse).
 % Toolchain probes
 % ============================================================
 
-ct_toolchain(scala,  [scalac, scala]).
+ct_toolchain(scala,  [scalac]).
 ct_toolchain(elixir, [elixir]).
 ct_toolchain(wat,    [wat2wasm, node]).
 
+ct_available(scala) :-
+    ct_enabled(scala),
+    exe_on_path(scalac),
+    (   exe_on_path(java), scala_runtime_jars(_)
+    ;   exe_on_path(scala)
+    ),
+    !.
 ct_available(Target) :-
+    Target \= scala,
     ct_enabled(Target),
     ct_toolchain(Target, Exes),
     forall(member(E, Exes), exe_on_path(E)).
@@ -264,7 +273,9 @@ bool_of_string(S, B) :-
 
 ct_tmp_dir(Prefix, Dir) :-
     get_time(T), Stamp is floor(T * 1000000),
-    format(atom(Dir), '/tmp/~w_~w', [Prefix, Stamp]),
+    tmp_root(Root),
+    format(atom(Base), '~w_~w', [Prefix, Stamp]),
+    directory_file_path(Root, Base, Dir),
     make_directory_path(Dir).
 
 cleanup_dir(Dir) :-
@@ -282,6 +293,14 @@ run_proc_out(Exe, Args, Cwd, Exit, OutStr) :-
     process_create(path(Exe), Args,
                    [cwd(Cwd), stdout(pipe(Out)), stderr(null), process(Pid)]),
     read_string(Out, _, OutStr), close(Out), process_wait(Pid, exit(Exit)).
+
+run_proc_out_err(Exe, Args, Cwd, Exit, OutStr, ErrStr) :-
+    process_create(path(Exe), Args,
+                   [cwd(Cwd), stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+    read_string(Out, _, OutStr),
+    read_string(Err, _, ErrStr),
+    close(Out), close(Err),
+    process_wait(Pid, exit(Exit)).
 
 %% Wrapper synthesis (elixir / wat). One ground 0-arity wrapper per
 %  query, asserted into user as `ctw_N :- pred(Args).`. The global
@@ -330,10 +349,54 @@ ct_run(scala, scala_ctx(Dir), PredKey, Args, Bool) :-
     atom_string(PredKey, PredStr),
     maplist(render_arg, Args, ArgAtoms),
     maplist([X,S]>>atom_string(X,S), ArgAtoms, ArgStrs),
-    append(['-classpath', ClassDir,
-            'generated.wam_ct.core.GeneratedProgram', PredStr], ArgStrs, ProcArgs),
-    run_proc_out(scala, ProcArgs, Abs, _Exit, OutStr),
-    normalize_space(string(Out), OutStr), bool_of_string(Out, Bool).
+    scala_run_command(ClassDir, 'generated.wam_ct.core.GeneratedProgram', PredStr,
+                      ArgStrs, Exe, ProcArgs),
+    run_proc_out_err(Exe, ProcArgs, Abs, Exit, OutStr, ErrStr),
+    (   Exit =:= 0
+    ->  normalize_space(string(Out), OutStr), bool_of_string(Out, Bool)
+    ;   throw(scala_run_failed(Exit, PredKey, Args, ErrStr))
+    ).
+
+scala_run_command(ClassDir, MainClass, PredStr, ArgStrs, java, ProcArgs) :-
+    scala_runtime_classpath(ClassDir, ClassPath),
+    !,
+    append(['-cp', ClassPath, MainClass, PredStr], ArgStrs, ProcArgs).
+scala_run_command(ClassDir, MainClass, PredStr, ArgStrs, scala, ProcArgs) :-
+    append(['-classpath', ClassDir, MainClass, PredStr], ArgStrs, ProcArgs).
+
+scala_runtime_classpath(ClassDir, ClassPath) :-
+    scala_runtime_jars(Jars),
+    path_list_separator(Sep),
+    atomic_list_concat([ClassDir|Jars], Sep, ClassPath).
+
+scala_runtime_jars(Jars) :-
+    findall(Jar, scala_runtime_jar(Jar), Jars0),
+    sort(Jars0, Jars),
+    Jars \= [].
+
+path_list_separator(';') :- current_prolog_flag(windows, true), !.
+path_list_separator(':').
+
+scala_runtime_jar(Jar) :-
+    scala_lang_maven_root(Root),
+    member(Artifact, ['scala-library', 'scala3-library_3', 'tasty-core_3']),
+    directory_file_path(Root, Artifact, ArtifactDir),
+    exists_directory(ArtifactDir),
+    directory_member(ArtifactDir, Rel,
+                     [extensions([jar]), recursive(true)]),
+    directory_file_path(ArtifactDir, Rel, Jar).
+
+scala_lang_maven_root(Root) :-
+    getenv('SCALA_MAVEN_ROOT', Raw),
+    Raw \== '',
+    exists_directory(Raw),
+    !,
+    Root = Raw.
+scala_lang_maven_root(Root) :-
+    getenv('PREFIX', Prefix),
+    Prefix \== '',
+    directory_file_path(Prefix, 'opt/scala/maven2/org/scala-lang', Root),
+    exists_directory(Root).
 
 ct_teardown(scala, scala_ctx(Dir)) :- cleanup_dir(Dir).
 


### PR DESCRIPTION
## Summary

- Route cross-target conformance temp directories through `tests/helpers/smoke_paths.pl`, so native Termux uses `$PREFIX/tmp` instead of unwritable `/tmp`.
- Run generated Scala conformance classes with `java -cp` when Scala 3 runtime jars are discoverable, avoiding Scala CLI/JNA launcher failures on Termux.
- Keep the legacy `scala -classpath ...` fallback for environments without a local Scala runtime jar cache.
- Rearrange WAT instruction encoder predicates so `wam_instruction_to_wat_bytes/3` clauses remain contiguous, removing load warnings without a `discontiguous` directive.
- Document the temp-root and Scala runner behavior in `docs/WAM_CROSS_TARGET_CONFORMANCE.md`.

## Verification

- `swipl -q -t halt -s tests/test_wam_cross_target_conformance.pl`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_wat_target.pl`
- `env CONFORMANCE_PROGRAMS=member,builtins CONFORMANCE_SAMPLE=2 swipl -q -g "use_module(library(plunit)),consult('tests/test_wam_cross_target_conformance.pl'),run_tests,halt" -t "halt(1)"`
- `env CONFORMANCE_TARGETS=wat CONFORMANCE_PROGRAMS=member CONFORMANCE_SAMPLE=2 swipl -q -g "use_module(library(plunit)),consult('tests/test_wam_cross_target_conformance.pl'),run_tests,halt" -t "halt(1)"`
- `git diff --check`

## Notes

The default fast conformance tier now passes locally on native Termux with Scala CLI installed. The R WAM list/stdlib Rscript slice that was suspected earlier also passed locally, so this branch focuses on the conformance runner failure that actually reproduced.
