### PR TITLE
LLVM WAM: working_directory/2 + getpid/1 (M79)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1463,7 +1463,10 @@ declare i32 @rmdir(i8*)
 declare i8* @getenv(i8*)
 declare i32 @setenv(i8*, i8*, i32)
 declare i64 @strlen(i8*)
-declare i32 @system(i8*)'
+declare i32 @system(i8*)
+declare i8* @getcwd(i8*, i64)
+declare i32 @chdir(i8*)
+declare i32 @getpid()'
     ).
 
 %% generate_wasm_exports(+Predicates, -ExportCode)
@@ -3509,6 +3512,8 @@ entry:
     i32 100, label %builtin_setenv
     i32 101, label %builtin_shell1
     i32 102, label %builtin_shell2
+    i32 103, label %builtin_working_directory
+    i32 104, label %builtin_getpid
   ]
 
 builtin_is:
@@ -4705,6 +4710,65 @@ sh2.run:
   %sh2.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
   %sh2.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %sh2.raw2, %Value %sh2.v)
   ret i1 %sh2.ok
+
+builtin_working_directory:
+  ; M79: working_directory(?Old, ?New) -- unifies Old with the
+  ; current CWD read via getcwd. If New is an atom, chdir to
+  ; that path; if New is unbound, it gets unified with Old as
+  ; well (the canonical ``query mode'' for working_directory(D,D)).
+  ; 4096-byte stack buffer covers PATH_MAX on Linux.
+  %wd.buf = alloca [4096 x i8]
+  %wd.buf_ptr = getelementptr [4096 x i8], [4096 x i8]* %wd.buf, i32 0, i32 0
+  %wd.got = call i8* @getcwd(i8* %wd.buf_ptr, i64 4096)
+  %wd.got_null = icmp eq i8* %wd.got, null
+  br i1 %wd.got_null, label %wd.fail, label %wd.intern
+wd.fail:
+  ret i1 false
+wd.intern:
+  ; Copy the cwd string into the arena, intern, build atom Value.
+  %wd.len = call i64 @strlen(i8* %wd.buf_ptr)
+  call void @wam_arena_ensure()
+  %wd.bufsize = add i64 %wd.len, 1
+  %wd.arena = call i8* @wam_arena_alloc(i64 %wd.bufsize)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %wd.arena, i8* %wd.buf_ptr, i64 %wd.len, i1 false)
+  %wd.term = getelementptr i8, i8* %wd.arena, i64 %wd.len
+  store i8 0, i8* %wd.term
+  %wd.aid = call i64 @wam_intern_atom(i8* %wd.arena, i64 %wd.len)
+  %wd.v0 = insertvalue %Value undef, i32 0, 0
+  %wd.cwd_v = insertvalue %Value %wd.v0, i64 %wd.aid, 1
+  %wd.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %wd.u1 = call i1 @wam_unify_value(%WamState* %vm, %Value %wd.raw1, %Value %wd.cwd_v)
+  br i1 %wd.u1, label %wd.chk_new, label %wd.fail
+wd.chk_new:
+  ; Inspect New (reg 1, deref). Atom -> chdir; anything else
+  ; (typically an unbound var) -> unify it with CWD, no chdir.
+  %wd.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %wd.t2 = extractvalue %Value %wd.a2, 0
+  %wd.is_atom = icmp eq i32 %wd.t2, 0
+  br i1 %wd.is_atom, label %wd.chdir, label %wd.unify_new
+wd.unify_new:
+  %wd.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %wd.u2 = call i1 @wam_unify_value(%WamState* %vm, %Value %wd.raw2, %Value %wd.cwd_v)
+  ret i1 %wd.u2
+wd.chdir:
+  %wd.aid2 = extractvalue %Value %wd.a2, 1
+  %wd.path = call i8* @wam_atom_to_string(i64 %wd.aid2)
+  %wd.path_null = icmp eq i8* %wd.path, null
+  br i1 %wd.path_null, label %wd.fail, label %wd.dochdir
+wd.dochdir:
+  %wd.ret = call i32 @chdir(i8* %wd.path)
+  %wd.ok = icmp eq i32 %wd.ret, 0
+  ret i1 %wd.ok
+
+builtin_getpid:
+  ; M79: getpid(?Pid) -- unifies Pid with the process id from
+  ; libc getpid() as Integer. Always succeeds (getpid cannot fail).
+  %gp.pid = call i32 @getpid()
+  %gp.pid64 = sext i32 %gp.pid to i64
+  %gp.v = call %Value @value_integer(i64 %gp.pid64)
+  %gp.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %gp.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %gp.raw1, %Value %gp.v)
+  ret i1 %gp.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11289,6 +11353,8 @@ builtin_op_to_id('getenv/2', 99).             % libc getenv(name) -> atom value 
 builtin_op_to_id('setenv/2', 100).            % libc setenv(name, value, 1).
 builtin_op_to_id('shell/1', 101).             % libc system(cmd) succeeds iff exit 0.
 builtin_op_to_id('shell/2', 102).             % libc system(cmd), Status = WEXITSTATUS.
+builtin_op_to_id('working_directory/2', 103). % getcwd -> Old; chdir(New) if New atom.
+builtin_op_to_id('getpid/1', 104).            % libc getpid() as Integer.
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2075,6 +2075,8 @@ is_builtin_pred(getenv, 2).             % getenv(+Name, -Value).
 is_builtin_pred(setenv, 2).             % setenv(+Name, +Value).
 is_builtin_pred(shell, 1).              % shell(+Command).
 is_builtin_pred(shell, 2).              % shell(+Command, -Status).
+is_builtin_pred(working_directory, 2).  % working_directory(?Old, ?New).
+is_builtin_pred(getpid, 1).             % getpid(-Pid).
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,41 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M79: working_directory/2 + getpid/1 -- libc getcwd/chdir/getpid.
+
+:- dynamic test_wd_query/2.
+test_wd_query(_, R) :-
+    % Query mode: working_directory(D, D) -- after the call D is
+    % bound to CWD; no chdir happens. CWD should not be empty.
+    working_directory(D, D),
+    atom_length(D, L),
+    ( L > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_wd_chdir/2.
+test_wd_chdir(_, R) :-
+    % Save current CWD, chdir to /tmp, read CWD again, restore.
+    working_directory(Old, '/tmp'),
+    working_directory(New, New),
+    working_directory(_, Old),
+    ( New == '/tmp' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_wd_fail/2.
+test_wd_fail(_, R) :-
+    % chdir to a non-existent directory must fail (ENOENT).
+    ( working_directory(_, '/nonexistent/uw_m79_dir') -> R is 1 ; R is 0 ).   % 0
+
+:- dynamic test_getpid_pos/2.
+test_getpid_pos(_, R) :-
+    getpid(P),
+    ( P > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_getpid_stable/2.
+test_getpid_stable(_, R) :-
+    % Two getpid calls in the same process should return the same value.
+    getpid(P1),
+    getpid(P2),
+    ( P1 =:= P2 -> R is 1 ; R is 0 ).   % 1
+
 % M78: shell/1 + shell/2 -- libc system() process spawn.
 
 :- dynamic test_sh1_true/2.
@@ -4361,6 +4396,17 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M79 working_directory/2 + getpid/1 ---~n'),
+       run_test_r0('working_directory(D, D) query -> 1',
+                   test_wd_query, 0, 1),
+       run_test_r0('working_directory chdir/restore roundtrip -> 1',
+                   test_wd_chdir, 0, 1),
+       run_test_r0('working_directory chdir to /nonexistent -> 0',
+                   test_wd_fail, 0, 0),
+       run_test_r0('getpid(P), P > 0 -> 1',
+                   test_getpid_pos, 0, 1),
+       run_test_r0('getpid stable across calls -> 1',
+                   test_getpid_stable, 0, 1),
        format('--- M78 shell/1 + shell/2 ---~n'),
        run_test_r0('shell(true) -> 1',
                    test_sh1_true, 0, 1),


### PR DESCRIPTION
## Summary

- Adds `working_directory/2` and `getpid/1` as native LLVM builtins (op ids 103, 104).
- Continues the OS-access cluster — M77 (env vars), M78 (shell spawn), M79 (process state). These three together cover most "compiled Prolog script can drive a shell pipeline" needs.

## What's in this PR

`src/unifyweaver/targets/wam_llvm_target.pl`
- Dispatch entries `i32 103 -> builtin_working_directory`, `i32 104 -> builtin_getpid`.
- `builtin_op_to_id('working_directory/2', 103)` and `('getpid/1', 104)`.
- Three new libc declarations: `@getcwd`, `@chdir`, `@getpid`.
- **`builtin_working_directory`** (prefix `wd.`):
  - 4096-byte stack `alloca` for the CWD buffer (PATH_MAX on Linux).
  - `@getcwd` → null check → strlen → arena-copy → `@wam_intern_atom` → atom Value.
  - Unify Old (reg 0) with the CWD atom; bail on unify failure.
  - Deref New (reg 1). If atom → `@wam_atom_to_string` + `@chdir`, succeed iff return is 0. If anything else (typically unbound) → unify New with the same CWD atom, no chdir. Matches the SWI-Prolog `working_directory(D, D)` query idiom.
- **`builtin_getpid`** (prefix `gp.`): `@getpid` → `sext` to i64 → `@value_integer` → unify with reg 0. Cannot fail.

`src/unifyweaver/targets/wam_target.pl`
- `is_builtin_pred(working_directory, 2)` and `is_builtin_pred(getpid, 1)` so WAM-fallback test predicates route through the builtin dispatcher.

`tests/core/test_wam_llvm_builtin_execution.pl`
- 5 new M79 tests:
  - `working_directory(D, D)` query — D is non-empty after the call.
  - chdir roundtrip: save CWD, chdir to `/tmp`, verify, restore. The restore step is important because `chdir` is process-wide and would otherwise leak into later tests.
  - chdir to `/nonexistent/uw_m79_dir` fails (ENOENT).
  - `getpid(P), P > 0`.
  - getpid stable across two calls (same value).

## Test plan

- [x] `swipl tests/core/test_wam_llvm_builtin_execution.pl` → 559 PASS, 0 FAIL.
- [x] All 5 M79 test labels green (modules 403–407 in the log).
- [x] 0 `unknown label` warnings.
- [x] Pre-flight single-pred `llc` smoke (the same harness M77 used to catch the `ge.` prefix collision) — clean.
- [x] Confirmed the chdir-restore step actually fires: removing it from `test_wd_chdir` made the suite leave `/tmp` as CWD, which I caught while writing the test.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_