### PR TITLE
feat(wam-clojure): lower variant/2 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -440,6 +440,10 @@ clojure_direct_builtin("term_variables/2", "2").
 clojure_direct_builtin("term_variables/2", 2).
 clojure_direct_builtin('term_variables/2', "2").
 clojure_direct_builtin('term_variables/2', 2).
+clojure_direct_builtin("variant/2", "2").
+clojure_direct_builtin("variant/2", 2).
+clojure_direct_builtin('variant/2', "2").
+clojure_direct_builtin('variant/2', 2).
 clojure_direct_builtin("functor/3", "3").
 clojure_direct_builtin("functor/3", 3).
 clojure_direct_builtin('functor/3', "3").
@@ -854,6 +858,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "term_variables/2" ; Op == 'term_variables/2'),
     !,
     format(atom(Expr), '(runtime/apply-term-variables-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "variant/2" ; Op == 'variant/2'),
+    !,
+    format(atom(Expr), '(runtime/apply-variant-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "functor/3" ; Op == 'functor/3'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -388,6 +388,57 @@
                   :else (interned-equal? l* r*))))]
       (identical* left right))))
 
+(defn variant-term? [state left right]
+  (let [bindings (:bindings state)]
+    (letfn [(bind-var-pair [env left-id right-id]
+              (let [left-existing (get (:left->right env) left-id ::missing)
+                    right-existing (get (:right->left env) right-id ::missing)]
+                (cond
+                  (not= left-existing ::missing)
+                  [(= left-existing right-id) env]
+
+                  (not= right-existing ::missing)
+                  [false env]
+
+                  :else
+                  [true (-> env
+                            (assoc-in [:left->right left-id] right-id)
+                            (assoc-in [:right->left right-id] left-id))])))
+            (variant-args? [env left-args right-args]
+              (loop [e env
+                     xs left-args
+                     ys right-args]
+                (cond
+                  (and (empty? xs) (empty? ys)) [true e]
+                  (or (empty? xs) (empty? ys)) [false e]
+                  :else
+                  (let [[ok next-env] (variant* e (first xs) (first ys))]
+                    (if ok
+                      (recur next-env (rest xs) (rest ys))
+                      [false e])))))
+            (variant* [env l r]
+              (let [l* (deref-value bindings l)
+                    r* (deref-value bindings r)]
+                (cond
+                  (and (logic-var? l*) (logic-var? r*))
+                  (bind-var-pair env (:var l*) (:var r*))
+
+                  (or (logic-var? l*) (logic-var? r*))
+                  [false env]
+
+                  (and (structure-term? l*) (structure-term? r*))
+                  (if (and (interned-equal? (:functor l*) (:functor r*))
+                           (= (count (:args l*)) (count (:args r*))))
+                    (variant-args? env (:args l*) (:args r*))
+                    [false env])
+
+                  (or (structure-term? l*) (structure-term? r*))
+                  [false env]
+
+                  :else
+                  [(interned-equal? l* r*) env])))]
+      (first (variant* {:left->right {} :right->left {}} left right)))))
+
 (defn term-compare [state left right]
   (let [bindings (:bindings state)
         ctx (:intern-context state)]
@@ -1867,6 +1918,13 @@
       (advance next-state)
       (backtrack state))))
 
+(defn apply-variant-solution [state]
+  (let [left (or (reg-get-raw state "A1") ::unbound)
+        right (or (reg-get-raw state "A2") ::unbound)]
+    (if (variant-term? state left right)
+      (advance state)
+      (backtrack state))))
+
 (defn term->unify-items [term]
   (if (structure-term? term)
     (seq (:args term))
@@ -2540,6 +2598,9 @@
           "term_variables/2"
           (apply-term-variables-solution state)
 
+          "variant/2"
+          (apply-variant-solution state)
+
           "functor/3"
           (apply-functor-solution state)
 
@@ -2626,6 +2687,23 @@
           (-> state
               (update :choice-points #(vec (take (:cut-bar state) %)))
               advance)
+
+          (backtrack state))
+
+        :call
+        (case (:pred instr)
+          "variant/2"
+          (apply-variant-solution state)
+
+          (backtrack state))
+
+        :execute
+        (case (:pred instr)
+          "variant/2"
+          (let [next-state (apply-variant-solution state)]
+            (if (= :running (:status next-state))
+              (succeed-state next-state)
+              next-state))
 
           (backtrack state))
 

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -139,6 +139,12 @@
 :- dynamic user:wam_term_variables_ground/0.
 :- dynamic user:wam_term_variables_single_unbound/0.
 :- dynamic user:wam_term_variables_mismatch/0.
+:- dynamic user:wam_variant_guard/2.
+:- dynamic user:wam_variant_repeated_vars/0.
+:- dynamic user:wam_variant_repeated_vars_mismatch/0.
+:- dynamic user:wam_variant_constant_mismatch/0.
+:- dynamic user:wam_variant_does_not_bind/0.
+:- dynamic user:wam_variant_same_var/0.
 :- dynamic user:wam_functor_guard/3.
 :- dynamic user:wam_functor_arity_unify/0.
 :- dynamic user:wam_functor_arity_unify_mismatch/0.
@@ -453,6 +459,12 @@ user:wam_term_variables_order :- user:wam_unbound_arg(X), user:wam_unbound_arg(Y
 user:wam_term_variables_ground :- term_variables(f(a,42), Vars), Vars = [].
 user:wam_term_variables_single_unbound :- user:wam_unbound_arg(X), term_variables(X, Vars), Vars = [X].
 user:wam_term_variables_mismatch :- user:wam_unbound_arg(X), user:wam_unbound_arg(Y), term_variables(f(X,Y), [X]).
+user:wam_variant_guard(A, B) :- variant(A, B).
+user:wam_variant_repeated_vars :- user:wam_unbound_arg(X), user:wam_unbound_arg(Y), user:wam_unbound_arg(A), user:wam_unbound_arg(B), variant(f(X,Y,X), f(A,B,A)).
+user:wam_variant_repeated_vars_mismatch :- user:wam_unbound_arg(X), user:wam_unbound_arg(Y), user:wam_unbound_arg(A), variant(f(X,Y), f(A,A)).
+user:wam_variant_constant_mismatch :- user:wam_unbound_arg(X), variant(f(a,X), f(a,b)).
+user:wam_variant_does_not_bind :- user:wam_unbound_arg(X), user:wam_unbound_arg(Y), variant(X, Y), X == Y.
+user:wam_variant_same_var :- user:wam_unbound_arg(X), variant(X, X).
 user:wam_functor_guard(Term, Name, Arity) :- functor(Term, Name, Arity).
 user:wam_functor_arity_unify :- functor(f(a,b), f, Arity), Arity = 2.
 user:wam_functor_arity_unify_mismatch :- functor(f(a,b), f, Arity), Arity = 1.
@@ -772,6 +784,12 @@ run_smoke :-
           user:wam_term_variables_ground/0,
           user:wam_term_variables_single_unbound/0,
           user:wam_term_variables_mismatch/0,
+          user:wam_variant_guard/2,
+          user:wam_variant_repeated_vars/0,
+          user:wam_variant_repeated_vars_mismatch/0,
+          user:wam_variant_constant_mismatch/0,
+          user:wam_variant_does_not_bind/0,
+          user:wam_variant_same_var/0,
           user:wam_functor_guard/3,
           user:wam_functor_arity_unify/0,
           user:wam_functor_arity_unify_mismatch/0,
@@ -991,6 +1009,7 @@ run_smoke :-
     assert_lowered_msort_builtin_emitted(TmpDir),
     assert_lowered_copy_term_builtin_emitted(TmpDir),
     assert_lowered_term_variables_builtin_emitted(TmpDir),
+    assert_lowered_variant_builtin_emitted(TmpDir),
     assert_lowered_functor_builtin_emitted(TmpDir),
     assert_lowered_arg_builtin_emitted(TmpDir),
     assert_lowered_compound_name_builtin_emitted(TmpDir),
@@ -1247,6 +1266,13 @@ smoke_cases([
     case('wam_term_variables_ground/0', no_args, "true"),
     case('wam_term_variables_single_unbound/0', no_args, "true"),
     case('wam_term_variables_mismatch/0', no_args, "false"),
+    case('wam_variant_guard/2', args('f(a,b)', 'f(a,b)'), "true"),
+    case('wam_variant_guard/2', args('f(a,b)', 'f(a,c)'), "false"),
+    case('wam_variant_repeated_vars/0', no_args, "true"),
+    case('wam_variant_repeated_vars_mismatch/0', no_args, "false"),
+    case('wam_variant_constant_mismatch/0', no_args, "false"),
+    case('wam_variant_does_not_bind/0', no_args, "false"),
+    case('wam_variant_same_var/0', no_args, "true"),
     case('wam_functor_guard/3', args('f(a)', f, 1), "true"),
     case('wam_functor_guard/3', args('f(a)', a, 1), "false"),
     case('wam_functor_guard/3', args(a, a, 0), "true"),
@@ -1749,6 +1775,14 @@ assert_lowered_term_variables_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-term-variables-order-0"),
     has(CoreCode, "runtime/apply-term-variables-solution").
 
+assert_lowered_variant_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-variant-guard-2"),
+    has(CoreCode, "defn lowered-wam-variant-repeated-vars-0"),
+    has(CoreCode, "defn lowered-wam-variant-does-not-bind-0"),
+    has(CoreCode, "runtime/apply-variant-solution").
+
 assert_lowered_functor_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
@@ -2044,6 +2078,7 @@ prolog_term_string_to_edn("bar", "\"bar\"") :- !.
 prolog_term_string_to_edn("z", "\"z\"") :- !.
 prolog_term_string_to_edn('f(a)', "{:tag :struct :functor \"f/1\" :args [\"a\"]}") :- !.
 prolog_term_string_to_edn('f(a,b)', "{:tag :struct :functor \"f/2\" :args [\"a\" \"b\"]}") :- !.
+prolog_term_string_to_edn('f(a,c)', "{:tag :struct :functor \"f/2\" :args [\"a\" \"c\"]}") :- !.
 prolog_term_string_to_edn('f(b)', "{:tag :struct :functor \"f/1\" :args [\"b\"]}") :- !.
 prolog_term_string_to_edn('[a]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}") :- !.
 prolog_term_string_to_edn('[42]', "{:tag :struct :functor \"[|]/2\" :args [42 \"[]\"]}") :- !.
@@ -2077,6 +2112,7 @@ prolog_term_string_to_edn('[f(b)]', "{:tag :struct :functor \"[|]/2\" :args [{:t
 prolog_term_string_to_edn('[a|b]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"b\"]}") :- !.
 prolog_term_string_to_edn("f(a)", "{:tag :struct :functor \"f/1\" :args [\"a\"]}") :- !.
 prolog_term_string_to_edn("f(a,b)", "{:tag :struct :functor \"f/2\" :args [\"a\" \"b\"]}") :- !.
+prolog_term_string_to_edn("f(a,c)", "{:tag :struct :functor \"f/2\" :args [\"a\" \"c\"]}") :- !.
 prolog_term_string_to_edn("f(b)", "{:tag :struct :functor \"f/1\" :args [\"b\"]}") :- !.
 prolog_term_string_to_edn("[a]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}") :- !.
 prolog_term_string_to_edn("[42]", "{:tag :struct :functor \"[|]/2\" :args [42 \"[]\"]}") :- !.


### PR DESCRIPTION
## Summary

- Adds `variant/2` to the Clojure lowered direct builtin table.
- Implements Clojure runtime alpha-equivalence checking for `variant/2` without binding variables.
- Handles `variant/2` through direct lowered calls and mixed WAM fallback `call`/tail `execute` paths.
- Extends the Clojure runtime smoke test with ground, repeated-variable, mismatch, and non-binding variant cases.

## Why

`variant/2` is a useful structural predicate for term-shape checks and purity/order-analysis-adjacent workflows. This keeps the Clojure hybrid WAM target moving toward parity with Prolog term inspection builtins while preserving the key semantic distinction from unification: variant checks must not bind either side.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

