### PR TITLE
LLVM WAM: asin/1 + acos/1 + atan/1 inverse trig (M80)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1466,7 +1466,10 @@ declare i64 @strlen(i8*)
 declare i32 @system(i8*)
 declare i8* @getcwd(i8*, i64)
 declare i32 @chdir(i8*)
-declare i32 @getpid()'
+declare i32 @getpid()
+declare double @asin(double)
+declare double @acos(double)
+declare double @atan(double)'
     ).
 
 %% generate_wasm_exports(+Predicates, -ExportCode)
@@ -10125,7 +10128,7 @@ ev_eval_unary:
   ; *_disambig labels.
   switch i8 %fn0, label %ev_zero [
     i8 45,  label %ev_neg       ; ''-''
-    i8 97,  label %ev_abs       ; ''a''
+    i8 97,  label %ev_a_disambig ; ''a'' -> abs | asin | acos | atan
     i8 114, label %ev_round     ; ''r''
     i8 102, label %ev_floor     ; ''f''
     i8 99,  label %ev_ceil_cos  ; ''c'' -> ceiling | cos
@@ -10160,6 +10163,37 @@ ev_abs_f:
   %abs_r_d = call double @llvm.fabs.f64(double %abs_u_d)
   %abs_v_f = call %Value @value_float(double %abs_r_d)
   ret %Value %abs_v_f
+
+; M80: second-byte dispatch for ''a''-prefix unary functions.
+; ``abs'' alone keeps the original ev_abs path; asin / acos / atan
+; route to libm and always return Float.
+ev_a_disambig:
+  %ad.fn1_ptr = getelementptr i8, i8* %fn_ptr, i32 1
+  %ad.fn1 = load i8, i8* %ad.fn1_ptr
+  switch i8 %ad.fn1, label %ev_zero [
+    i8 98,  label %ev_abs   ; ''b'' -> abs
+    i8 115, label %ev_asin  ; ''s'' -> asin
+    i8 99,  label %ev_acos  ; ''c'' -> acos
+    i8 116, label %ev_atan  ; ''t'' -> atan
+  ]
+
+ev_asin:
+  %asin_d = call double @value_to_double(%Value %u)
+  %asin_r = call double @asin(double %asin_d)
+  %asin_v = call %Value @value_float(double %asin_r)
+  ret %Value %asin_v
+
+ev_acos:
+  %acos_d = call double @value_to_double(%Value %u)
+  %acos_r = call double @acos(double %acos_d)
+  %acos_v = call %Value @value_float(double %acos_r)
+  ret %Value %acos_v
+
+ev_atan:
+  %atan_d = call double @value_to_double(%Value %u)
+  %atan_r = call double @atan(double %atan_d)
+  %atan_v = call %Value @value_float(double %atan_r)
+  ret %Value %atan_v
 
 ; M18 truncate/round/floor/ceiling: take a numeric Value, convert to
 ; double, apply the LLVM intrinsic, return Integer (Prolog''s

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,38 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M80: inverse trig -- asin/1, acos/1, atan/1 via libm.
+
+:- dynamic test_asin_zero/2.
+test_asin_zero(_, R) :-
+    X is asin(0.0),
+    R is truncate(X * 100).   % 0
+
+:- dynamic test_asin_one/2.
+test_asin_one(_, R) :-
+    % asin(1) = pi/2 ~ 1.5708; *100 truncated -> 157.
+    X is asin(1.0),
+    R is truncate(X * 100).   % 157
+
+:- dynamic test_acos_one/2.
+test_acos_one(_, R) :-
+    X is acos(1.0),
+    R is truncate(X * 100).   % 0
+
+:- dynamic test_acos_zero/2.
+test_acos_zero(_, R) :-
+    % acos(0) = pi/2 ~ 1.5708; *100 truncated -> 157.
+    X is acos(0.0),
+    R is truncate(X * 100).   % 157
+
+:- dynamic test_atan_one/2.
+test_atan_one(_, R) :-
+    % atan(1) = pi/4 ~ 0.7854; *200 truncated -> 157 (same as
+    % asin(1.0)/acos(0.0)). Cannot use *400 because OS exit codes
+    % are 8-bit and 314 mod 256 = 58.
+    X is atan(1.0),
+    R is truncate(X * 200).   % 157
+
 % M79: working_directory/2 + getpid/1 -- libc getcwd/chdir/getpid.
 
 :- dynamic test_wd_query/2.
@@ -4396,6 +4428,17 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M80 inverse trig -- asin/1, acos/1, atan/1 ---~n'),
+       run_test_r0('truncate(asin(0.0) * 100) -> 0',
+                   test_asin_zero, 0, 0),
+       run_test_r0('truncate(asin(1.0) * 100) -> 157 (~ pi/2)',
+                   test_asin_one, 0, 157),
+       run_test_r0('truncate(acos(1.0) * 100) -> 0',
+                   test_acos_one, 0, 0),
+       run_test_r0('truncate(acos(0.0) * 100) -> 157 (~ pi/2)',
+                   test_acos_zero, 0, 157),
+       run_test_r0('truncate(atan(1.0) * 200) -> 157 (~ pi/2)',
+                   test_atan_one, 0, 157),
        format('--- M79 working_directory/2 + getpid/1 ---~n'),
        run_test_r0('working_directory(D, D) query -> 1',
                    test_wd_query, 0, 1),


### PR DESCRIPTION
## Summary

- Adds `asin/1`, `acos/1`, and `atan/1` as arithmetic functions in `is/2` (M80).
- Completes the M20 transcendental cluster — `sin`/`cos`/`tan`/`log`/`exp`/`sqrt` were already there; this is the inverse-trig completion. All three always return Float.

## What's in this PR

`src/unifyweaver/targets/wam_llvm_target.pl`
- Three new declarations: `declare double @asin(double)`, `@acos`, `@atan`. LLVM doesn't ship intrinsics for these — they route to libm.
- **Refactor**: the unary `'a'`-prefix dispatch in `@eval_arith_value` previously went straight to `ev_abs`. Now it routes to a new `ev_a_disambig` block that switches on the second functor byte:
  - `'b'` (98) → `ev_abs` (unchanged behavior).
  - `'s'` (115) → `ev_asin`.
  - `'c'` (99) → `ev_acos`.
  - `'t'` (116) → `ev_atan`.
- Each new eval arm just calls `value_to_double`, invokes the libm function, and boxes via `value_float`.

`tests/core/test_wam_llvm_builtin_execution.pl`
- 5 new M80 tests:
  - `truncate(asin(0.0) * 100)` → 0.
  - `truncate(asin(1.0) * 100)` → 157 (~π/2 ≈ 1.5708).
  - `truncate(acos(1.0) * 100)` → 0.
  - `truncate(acos(0.0) * 100)` → 157 (~π/2).
  - `truncate(atan(1.0) * 200)` → 157 (~π/2; *200 not *400, see below).

## Dev note — Unix exit code gotcha

My first `atan` test used `truncate(atan(1.0) * 400) -> 314` (since atan(1.0)=π/4 ≈ 0.7854, *400 ≈ 314.16). The test failed with exit code **58**. Caused by Unix process exit codes being 8-bit: `314 mod 256 = 58`. The LLVM IR was computing the right value; the OS truncated it.

Scaled by 200 instead so the expected value (157) fits in one byte. Worth keeping in mind for any future `run_test_r0` expected values that approach 256 — the test driver returns the i32 truncation of the result payload, but the shell only sees the low 8 bits.

## Test plan

- [x] `swipl tests/core/test_wam_llvm_builtin_execution.pl` → 564 PASS, 0 FAIL.
- [x] All 5 M80 test labels green (modules 403–407 in the log).
- [x] `abs/1` still passes through the new disambig (confirmed by the 53 PASS / 0 FAIL through M18 + the `compound arithmetic (is/2)` section that uses abs).
- [x] Pre-flight single-pred `llc` smoke against the refactor — clean.
- [x] Reproduced and root-caused the 58/314 exit code anomaly via a minimal standalone IR file, then a stripped-down C version of the same logic — confirms it's the 8-bit exit-code truncation, not an LLVM/libm bug.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_