### PR TITLE
Add Go WAM environment builtins

### DIFF
--- a/PR_go_wam_env_builtins.md
+++ b/PR_go_wam_env_builtins.md
@@ -1,0 +1,19 @@
+Title: Add Go WAM environment builtins
+
+Description:
+
+## Summary
+
+- add Go WAM direct builtin lowering for `getenv/2` and `setenv/2`
+- implement runtime handling with atom-only arguments, missing-env failure, and empty-value support
+- extend the generated Go WAM builtin E2E test and parity audit for the LLVM environment surface
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -21,7 +21,7 @@ current cross-target builtin/runtime baseline.
 | Univ | `=../2` compose/decompose | `=../2` compose/decompose | Present |
 | Copying | `copy_term/2` with fresh variables and preserved sharing | `copy_term/2` with fresh variables and preserved sharing | Present |
 | Control | `true/0`, `fail/0`, `!/0`, `\+/1`, `CutIte` | Same baseline, with broader isolated-goal NAF in Haskell/Python | Present for current baseline, including isolated user-goal NAF and race-to-true over multi-clause WAM targets |
-| IO | `write/1`, `display/1`, `nl/0`, `tab/1` | `write/1`, `display/1`, `nl/0`; R/C++ also cover `tab/1` | Present for current baseline plus tab output |
+| IO | `write/1`, `display/1`, `nl/0`, `tab/1`, `getenv/2`, `setenv/2` | `write/1`, `display/1`, `nl/0`; R/C++ also cover `tab/1`; LLVM covers `getenv/2` and `setenv/2` | Present for current baseline plus tab output and bounded environment access |
 
 ## Immediate Findings
 
@@ -126,6 +126,10 @@ current cross-target builtin/runtime baseline.
   nonnegative space output, zero-width success, negative integer failure,
   unbound argument failure, and non-integer failure, matching the R/C++
   basic I/O polish surface.
+- `getenv/2` and `setenv/2` are now covered by the generated Go WAM builtin
+  E2E test for missing environment lookup failure, set/get, overwrite, empty
+  value handling, and unbound argument failure, matching the bounded LLVM
+  environment surface.
 - Bidirectional `succ/2` is now covered by the generated Go WAM builtin E2E
   test for forward binding, reverse binding, matching integer pairs, mismatch
   failure, negative predecessor failure, non-positive successor failure, and

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -528,6 +528,12 @@ wam_go_direct_builtin("split_string/4", 4, 'split_string/4').
 wam_go_direct_builtin(tab/1, 1, 'tab/1').
 wam_go_direct_builtin('tab/1', 1, 'tab/1').
 wam_go_direct_builtin("tab/1", 1, 'tab/1').
+wam_go_direct_builtin(getenv/2, 2, 'getenv/2').
+wam_go_direct_builtin('getenv/2', 2, 'getenv/2').
+wam_go_direct_builtin("getenv/2", 2, 'getenv/2').
+wam_go_direct_builtin(setenv/2, 2, 'setenv/2').
+wam_go_direct_builtin('setenv/2', 2, 'setenv/2').
+wam_go_direct_builtin("setenv/2", 2, 'setenv/2').
 wam_go_direct_builtin(succ/2, 2, 'succ/2').
 wam_go_direct_builtin('succ/2', 2, 'succ/2').
 wam_go_direct_builtin("succ/2", 2, 'succ/2').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -3,6 +3,7 @@ package {{package_name}}
 import (
 	"fmt"
 	"math"
+	"os"
 	"runtime"
 	"sort"
 	"strconv"
@@ -1238,6 +1239,23 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 		}
 		fmt.Print(strings.Repeat(" ", int(count.Val)))
 		return true
+	case "getenv/2":
+		name, ok := vm.deref(arg1).(*Atom)
+		if !ok {
+			return false
+		}
+		value, ok := os.LookupEnv(name.Name)
+		if !ok {
+			return false
+		}
+		return vm.Unify(arg2, internAtom(value))
+	case "setenv/2":
+		name, okName := vm.deref(arg1).(*Atom)
+		value, okValue := vm.deref(arg2).(*Atom)
+		if !okName || !okValue {
+			return false
+		}
+		return os.Setenv(name.Name, value.Name) == nil
 	case "true/0":
 		return true
 	case "fail/0":

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -28,6 +28,7 @@
 :- dynamic user:test_string_code_builtin/0.
 :- dynamic user:test_split_string_builtin/0.
 :- dynamic user:test_tab_builtin/0.
+:- dynamic user:test_env_builtin/0.
 :- dynamic user:test_succ_builtin/0.
 :- dynamic user:test_between_builtin/0.
 :- dynamic user:test_list_numeric_builtin/0.
@@ -406,6 +407,22 @@ test(builtins_execution) :-
                 \+ tab(_),
                 \+ tab(foo)
             )),
+          assertz(user:test_env_builtin :-
+            (   setenv('UW_GO_WAM_ENV_TEST', go_wam_value),
+                getenv('UW_GO_WAM_ENV_TEST', V),
+                V == go_wam_value,
+                setenv('UW_GO_WAM_ENV_TEST', overwritten),
+                getenv('UW_GO_WAM_ENV_TEST', V2),
+                V2 == overwritten,
+                setenv('UW_GO_WAM_EMPTY', ''),
+                getenv('UW_GO_WAM_EMPTY', Empty),
+                atom_length(Empty, Len),
+                Len =:= 0,
+                \+ getenv('UW_GO_WAM_DEFINITELY_UNSET', _),
+                \+ getenv(_, _),
+                \+ setenv(_, value),
+                \+ setenv('UW_GO_WAM_ENV_TEST', _)
+            )),
           assertz(user:test_succ_builtin :-
             (   succ(0, 1),
                 succ(2, X),
@@ -615,6 +632,7 @@ test(builtins_execution) :-
           retractall(user:test_string_code_builtin),
           retractall(user:test_split_string_builtin),
           retractall(user:test_tab_builtin),
+          retractall(user:test_env_builtin),
           retractall(user:test_succ_builtin),
           retractall(user:test_between_builtin),
           retractall(user:test_list_numeric_builtin),
@@ -638,7 +656,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_tab_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_tab_builtin/0, test_env_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -701,6 +719,8 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "string_code/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "split_string/4"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "tab/1"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "getenv/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "setenv/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "succ/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "atom_number/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "upcase_atom/2"')),
@@ -922,6 +942,14 @@ func main() {
 		fmt.Println("TAB_FAILURE")
 	}
 
+	envVM := wam.NewWamState(wam.Test_env_builtinCode, wam.Test_env_builtinLabels)
+	envVM.PC = wam.Test_env_builtinStartPC
+	if envVM.Run() {
+		fmt.Println("ENV_SUCCESS")
+	} else {
+		fmt.Println("ENV_FAILURE")
+	}
+
 	succVM := wam.NewWamState(wam.Test_succ_builtinCode, wam.Test_succ_builtinLabels)
 	succVM.PC = wam.Test_succ_builtinStartPC
 	if succVM.Run() {
@@ -1106,6 +1134,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "STRING_CODE_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SPLIT_STRING_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "   tabbedTAB_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "ENV_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SUCC_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "BETWEEN_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "LIST_NUMERIC_SUCCESS")),


### PR DESCRIPTION
## Summary

- add Go WAM direct builtin lowering for `getenv/2` and `setenv/2`
- implement runtime handling with atom-only arguments, missing-env failure, and empty-value support
- extend the generated Go WAM builtin E2E test and parity audit for the LLVM environment surface

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `git diff --check`
