### PR TITLE
LLVM WAM: atan2/2 binary inverse tangent (M81)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1469,7 +1469,8 @@ declare i32 @chdir(i8*)
 declare i32 @getpid()
 declare double @asin(double)
 declare double @acos(double)
-declare double @atan(double)'
+declare double @atan(double)
+declare double @atan2(double, double)'
     ).
 
 %% generate_wasm_exports(+Predicates, -ExportCode)
@@ -10060,8 +10061,25 @@ ev_div_f_go:
 
 ev_check_named_binary:
   ; mod / max / min -- functor name starts with ``m``.
-  %nb_is_m = icmp eq i8 %fn0, 109
-  br i1 %nb_is_m, label %ev_nb_second, label %ev_zero
+  ; atan2 -- functor name starts with ``a`` (M81).
+  switch i8 %fn0, label %ev_zero [
+    i8 109, label %ev_nb_second   ; ''m'' -> mod | max | min
+    i8 97,  label %ev_nb_a_second ; ''a'' -> atan2
+  ]
+ev_nb_a_second:
+  ; M81: only atan2 starts with ``a'' in the binary path. Verify the
+  ; second byte is ``t'' so a stray ``a''-prefixed binary name
+  ; doesn''t pretend to be atan2.
+  %nba.fn1_ptr = getelementptr i8, i8* %fn_ptr, i32 1
+  %nba.fn1 = load i8, i8* %nba.fn1_ptr
+  %nba.is_t = icmp eq i8 %nba.fn1, 116
+  br i1 %nba.is_t, label %ev_atan2, label %ev_zero
+ev_atan2:
+  %a2.a_d = call double @value_to_double(%Value %a)
+  %a2.b_d = call double @value_to_double(%Value %b)
+  %a2.r = call double @atan2(double %a2.a_d, double %a2.b_d)
+  %a2.v = call %Value @value_float(double %a2.r)
+  ret %Value %a2.v
 ev_nb_second:
   %nb_fn1_ptr = getelementptr i8, i8* %fn_ptr, i32 1
   %nb_fn1 = load i8, i8* %nb_fn1_ptr

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,38 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M81: atan2/2 -- binary inverse tangent (4-quadrant).
+
+:- dynamic test_atan2_xaxis/2.
+test_atan2_xaxis(_, R) :-
+    % atan2(0, 1) -- positive x-axis -- is 0.
+    X is atan2(0.0, 1.0),
+    R is truncate(X * 100).   % 0
+
+:- dynamic test_atan2_diag/2.
+test_atan2_diag(_, R) :-
+    % atan2(1, 1) = pi/4 ~ 0.7854; *200 truncated -> 157.
+    X is atan2(1.0, 1.0),
+    R is truncate(X * 200).   % 157
+
+:- dynamic test_atan2_yaxis/2.
+test_atan2_yaxis(_, R) :-
+    % atan2(1, 0) = pi/2 ~ 1.5708; *100 truncated -> 157.
+    X is atan2(1.0, 0.0),
+    R is truncate(X * 100).   % 157
+
+:- dynamic test_atan2_diag_scaled/2.
+test_atan2_diag_scaled(_, R) :-
+    % atan2 only cares about the ratio: (2,2) is the same angle as (1,1).
+    X is atan2(2.0, 2.0),
+    R is truncate(X * 200).   % 157
+
+:- dynamic test_atan2_pi/2.
+test_atan2_pi(_, R) :-
+    % atan2(0, -1) = pi ~ 3.14159; *50 truncated -> 157.
+    X is atan2(0.0, -1.0),
+    R is truncate(X * 50).   % 157
+
 % M80: inverse trig -- asin/1, acos/1, atan/1 via libm.
 
 :- dynamic test_asin_zero/2.
@@ -4428,6 +4460,17 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M81 atan2/2 binary inverse tangent ---~n'),
+       run_test_r0('atan2(0,1) -> 0 (x-axis)',
+                   test_atan2_xaxis, 0, 0),
+       run_test_r0('atan2(1,1) * 200 -> 157 (~ pi/4)',
+                   test_atan2_diag, 0, 157),
+       run_test_r0('atan2(1,0) * 100 -> 157 (~ pi/2)',
+                   test_atan2_yaxis, 0, 157),
+       run_test_r0('atan2(2,2) * 200 -> 157 (ratio only)',
+                   test_atan2_diag_scaled, 0, 157),
+       run_test_r0('atan2(0,-1) * 50 -> 157 (~ pi)',
+                   test_atan2_pi, 0, 157),
        format('--- M80 inverse trig -- asin/1, acos/1, atan/1 ---~n'),
        run_test_r0('truncate(asin(0.0) * 100) -> 0',
                    test_asin_zero, 0, 0),


### PR DESCRIPTION
## Summary

- Adds `atan2/2` as an arithmetic function in `is/2` (M81).
- Completes the inverse-trig set started in M80 — `asin`/`acos`/`atan` were the unary half; `atan2(Y, X)` is the four-quadrant binary variant. Always returns Float.

## What's in this PR

`src/unifyweaver/targets/wam_llvm_target.pl`
- New `declare double @atan2(double, double)` libc decl.
- Generalizes the named-binary dispatch (`ev_check_named_binary`) from a single `is m` check to a switch:
  - `m` (109) → `ev_nb_second` (mod | max | min, unchanged).
  - `a` (97) → new `ev_nb_a_second`.
- **`ev_nb_a_second`** verifies the second functor byte is `'t'` (defensive in case some future `a`-prefix binary functor lands) then jumps to `ev_atan2`.
- **`ev_atan2`** calls `value_to_double` on both args, invokes `@atan2`, boxes via `value_float`.

`tests/core/test_wam_llvm_builtin_execution.pl`
- 5 new M81 tests covering the four cardinal directions of the arctangent plus a scale-invariance check:
  - `atan2(0, 1)` → 0 (positive x-axis).
  - `atan2(1, 1) * 200` → 157 (~π/4, first-quadrant diagonal).
  - `atan2(1, 0) * 100` → 157 (~π/2, positive y-axis).
  - `atan2(2, 2) * 200` → 157 (ratio only — (2,2) gives the same angle as (1,1)).
  - `atan2(0, -1) * 50` → 157 (~π, negative x-axis).

All expected exit codes ≤ 255 so the 8-bit truncation gotcha from M80 doesn't apply.

## Test plan

- [x] `swipl tests/core/test_wam_llvm_builtin_execution.pl` → 569 PASS, 0 FAIL.
- [x] All 5 M81 test labels green (modules 403–407 in the log).
- [x] Existing `mod`/`max`/`min` arith (the other 'm'-prefix binary path that runs through the same `ev_check_named_binary` site) still passes — verified by the surrounding sections clearing 0 FAIL through M43+.
- [x] Pre-flight single-pred `llc` smoke against the binary dispatch — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_