### PR TITLE
LLVM WAM: gcd/2 + log/2 binary arith (M82)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -10062,9 +10062,13 @@ ev_div_f_go:
 ev_check_named_binary:
   ; mod / max / min -- functor name starts with ``m``.
   ; atan2 -- functor name starts with ``a`` (M81).
+  ; gcd -- functor name starts with ``g`` (M82).
+  ; log/2 -- functor name starts with ``l`` (M82).
   switch i8 %fn0, label %ev_zero [
     i8 109, label %ev_nb_second   ; ''m'' -> mod | max | min
     i8 97,  label %ev_nb_a_second ; ''a'' -> atan2
+    i8 103, label %ev_gcd         ; ''g'' -> gcd
+    i8 108, label %ev_log2        ; ''l'' -> log/2
   ]
 ev_nb_a_second:
   ; M81: only atan2 starts with ``a'' in the binary path. Verify the
@@ -10080,6 +10084,44 @@ ev_atan2:
   %a2.r = call double @atan2(double %a2.a_d, double %a2.b_d)
   %a2.v = call %Value @value_float(double %a2.r)
   ret %Value %a2.v
+
+ev_gcd:
+  ; M82: gcd(A, B) -- integer-only. Iterative Euclid on i64 with
+  ; abs() of both args so negative inputs still produce a positive
+  ; gcd (matching SWI semantics). gcd(0, 0) is defined as 0.
+  %gcd.a_i = extractvalue %Value %a, 1
+  %gcd.b_i = extractvalue %Value %b, 1
+  %gcd.a_neg = icmp slt i64 %gcd.a_i, 0
+  %gcd.a_op = sub i64 0, %gcd.a_i
+  %gcd.a_abs = select i1 %gcd.a_neg, i64 %gcd.a_op, i64 %gcd.a_i
+  %gcd.b_neg = icmp slt i64 %gcd.b_i, 0
+  %gcd.b_op = sub i64 0, %gcd.b_i
+  %gcd.b_abs = select i1 %gcd.b_neg, i64 %gcd.b_op, i64 %gcd.b_i
+  br label %gcd.loop
+gcd.loop:
+  %gcd.x = phi i64 [ %gcd.a_abs, %ev_gcd ], [ %gcd.y, %gcd.step ]
+  %gcd.y = phi i64 [ %gcd.b_abs, %ev_gcd ], [ %gcd.r, %gcd.step ]
+  %gcd.y_zero = icmp eq i64 %gcd.y, 0
+  br i1 %gcd.y_zero, label %gcd.done, label %gcd.step
+gcd.step:
+  %gcd.r = srem i64 %gcd.x, %gcd.y
+  br label %gcd.loop
+gcd.done:
+  %gcd.v = call %Value @value_integer(i64 %gcd.x)
+  ret %Value %gcd.v
+
+ev_log2:
+  ; M82: log(Base, X) -- change-of-base via log(X)/log(Base).
+  ; Always Float; matches the existing log/1 (natural log) when
+  ; Base == e.
+  %lg2.base_d = call double @value_to_double(%Value %a)
+  %lg2.x_d = call double @value_to_double(%Value %b)
+  %lg2.lnb = call double @llvm.log.f64(double %lg2.base_d)
+  %lg2.lnx = call double @llvm.log.f64(double %lg2.x_d)
+  %lg2.r = fdiv double %lg2.lnx, %lg2.lnb
+  %lg2.v = call %Value @value_float(double %lg2.r)
+  ret %Value %lg2.v
+
 ev_nb_second:
   %nb_fn1_ptr = getelementptr i8, i8* %fn_ptr, i32 1
   %nb_fn1 = load i8, i8* %nb_fn1_ptr

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,34 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M82: gcd/2 (Integer Euclidean) + log/2 (Float log with base).
+
+:- dynamic test_gcd_basic/2.
+test_gcd_basic(_, R) :-
+    R is gcd(12, 18).   % 6
+
+:- dynamic test_gcd_coprime/2.
+test_gcd_coprime(_, R) :-
+    R is gcd(7, 5).   % 1
+
+:- dynamic test_gcd_with_zero/2.
+test_gcd_with_zero(_, R) :-
+    % gcd(0, n) = n -- Euclid terminates on the first iteration.
+    R is gcd(0, 5).   % 5
+
+:- dynamic test_log2_eight/2.
+test_log2_eight(_, R) :-
+    % log(2, 8) = 3 (since 2^3 = 8). Use floats to force the
+    % named-binary path; integer literals go through int eval which
+    % doesn''t recognize ``log''.
+    X is log(2.0, 8.0),
+    R is truncate(X).   % 3
+
+:- dynamic test_log10_hundred/2.
+test_log10_hundred(_, R) :-
+    X is log(10.0, 100.0),
+    R is truncate(X).   % 2
+
 % M81: atan2/2 -- binary inverse tangent (4-quadrant).
 
 :- dynamic test_atan2_xaxis/2.
@@ -4460,6 +4488,17 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M82 gcd/2 + log/2 binary arith ---~n'),
+       run_test_r0('gcd(12, 18) -> 6',
+                   test_gcd_basic, 0, 6),
+       run_test_r0('gcd(7, 5) -> 1 (coprime)',
+                   test_gcd_coprime, 0, 1),
+       run_test_r0('gcd(0, 5) -> 5',
+                   test_gcd_with_zero, 0, 5),
+       run_test_r0('truncate(log(2.0, 8.0)) -> 3',
+                   test_log2_eight, 0, 3),
+       run_test_r0('truncate(log(10.0, 100.0)) -> 2',
+                   test_log10_hundred, 0, 2),
        format('--- M81 atan2/2 binary inverse tangent ---~n'),
        run_test_r0('atan2(0,1) -> 0 (x-axis)',
                    test_atan2_xaxis, 0, 0),


### PR DESCRIPTION
## Summary

- Adds `gcd/2` and `log/2` as arithmetic functions in `is/2` (M82).
- Both extend the named-binary dispatch first generalized in M81 — now `m` (mod/max/min), `a` (atan2), `g` (gcd), and `l` (log/2) all coexist in `ev_check_named_binary`.

## What's in this PR

`src/unifyweaver/targets/wam_llvm_target.pl`
- Extends the `ev_check_named_binary` switch from M81's two entries (`'m'`, `'a'`) to four:
  - `'m'` (109) → `ev_nb_second` (mod | max | min, unchanged).
  - `'a'` (97) → `ev_nb_a_second` (atan2, unchanged).
  - `'g'` (103) → `ev_gcd`.
  - `'l'` (108) → `ev_log2`.
- **`ev_gcd`** (prefix `gcd.`): integer-only iterative Euclid on i64. Takes abs() of both inputs so negative arguments still produce a positive gcd (matching SWI semantics). gcd(0, n) = n (loop terminates on the first iteration when y == 0). Reads the i64 payload directly via `extractvalue %Value, 1` — assumes Integer inputs.
- **`ev_log2`** (prefix `lg2.`): change-of-base via `log(X) / log(Base)`, reusing the existing `@llvm.log.f64` intrinsic. Always Float. Matches the M20 `log/1` (natural log) when Base = e.

The unary `log/1` path (`ev_log` inside the unary switch) is untouched — the two paths are disambiguated by arity at the `eval_arith_value` entry, so `log(X)` and `log(Base, X)` route correctly without any further check.

`tests/core/test_wam_llvm_builtin_execution.pl`
- 5 new M82 tests:
  - `gcd(12, 18)` → 6.
  - `gcd(7, 5)` → 1 (coprime).
  - `gcd(0, 5)` → 5 (Euclid edge case — single iteration).
  - `truncate(log(2.0, 8.0))` → 3 (since 2^3 = 8).
  - `truncate(log(10.0, 100.0))` → 2.

## Test plan

- [x] `swipl tests/core/test_wam_llvm_builtin_execution.pl` → 574 PASS, 0 FAIL.
- [x] All 5 M82 test labels green (modules 403–407 in the log).
- [x] Existing `mod`/`max`/`min` and `atan2` binary arith (the other entries through `ev_check_named_binary`) still pass — verified by the surrounding sections clearing 0 FAIL.
- [x] Pre-flight single-pred `llc` smoke against the gcd loop (phi-node structure for the iterative Euclid) — clean.
- [x] Float literals in the log/2 tests are deliberate — the legacy `@eval_arith` integer evaluator doesn't recognize `'l'` as a named binary, so Float-tagged args ensure the call routes through the float-aware `@eval_arith_value`.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_