### PR TITLE
docs(wam-conformance): complete the divergence table to match the harness

### DIFF
--- a/docs/WAM_CROSS_TARGET_CONFORMANCE.md
+++ b/docs/WAM_CROSS_TARGET_CONFORMANCE.md
@@ -75,17 +75,27 @@ Suggested CI tiers:
 The harness is green today; the divergences below are tolerated and
 logged (an unexpected pass is logged as `XPASS` so the entry can be
 retired). Each is a real backend gap the harness surfaced, not a fixture
-artifact — **Scala passes the whole spec**, which is the reference.
+artifact. The oracle is the hand-specified expected-results table in
+`wam_conformance_fixtures.pl` (standard Prolog semantics); among the
+backends, **Scala is the reference implementation** — it passes the whole
+spec. The table below is the full set of tracked divergences (it matches
+the `ct_xfail/2` / `ct_skip/2` facts in the harness); WAT conforms only on
+`ack`.
 
 | Backend | Program(s) | Kind | Cause |
 |---|---|---|---|
 | wat | member | xfail | Read-mode structure/list argument unification is unimplemented (the read-mode branches of `unify_variable`/`unify_value`/`unify_constant` are nops; no S-register), so `get_structure`/`get_list` match only the functor. See `WAM_SWITCH_INDEXING_CROSS_TARGET.md`. |
-| wat | append, reverse | **skip** | A *second*, separate WAT bug: the generator loops re-emitting millions of "unrecognized instruction" warnings on recursive list-**building** predicates, so the project is impractical to write. Skipped (not built) rather than xfail'd. |
+| wat | fib | xfail | `is/2` with an already-bound LHS doesn't verify the computed value — `cfib(10,54)` returns true though `fib(10)=55` (the result is stored over the bound arg instead of being unified/checked). |
+| wat | builtins | xfail | `cbi_arith` uses `//` (integer div) and `mod`, which the WAT backend does not evaluate correctly (returns false). The comparison (`cbi_cmp`) and unification (`cbi_eq`) families are fine. |
+| wat | append, reverse | **skip** | A *separate* WAT codegen bug: the generator loops re-emitting millions of "unrecognized instruction" warnings on recursive list-**building** predicates, so the project is impractical to write. Skipped (not built) rather than xfail'd. |
 | elixir | append, reverse | xfail | The lowered Elixir backend fails to unify a freshly-constructed list against an already-**ground** compound head argument: `capp([a],[b],[a,b])` returns false, while `capp([a],[b],X), X=[a,b]` succeeds. `member` passes (it only matches an input list). |
 
 `ct_xfail/2` = build and run, tolerate a wrong answer (and log `XPASS` if
 it unexpectedly matches). `ct_skip/2` = do not even build, because
-*generation itself* is unusable.
+*generation itself* is unusable. (`append`/`reverse` on WAT carry both an
+`ct_xfail` and a `ct_skip` fact in the harness; `ct_skip` wins — it is
+checked first — so they are never built. The shadowed xfail facts are
+harmless leftovers.)
 
 ### Other backend issue surfaced (not xfail)
 


### PR DESCRIPTION
  ## Summary

  The `WAM_CROSS_TARGET_CONFORMANCE.md` "Known divergences" table was
  incomplete relative to the harness facts in
  `tests/test_wam_cross_target_conformance.pl` — it understated WAT. Docs-only
  change to bring the table in line with the code.

  ## What changed

  - **Added the two missing WAT xfail rows** (causes taken verbatim from the
    harness comments):
    - `wat/fib` — `is/2` with an already-bound LHS isn't verified, so
      `cfib(10,54)` returns true though `fib(10)=55`.
    - `wat/builtins` — `//` (integer div) and `mod` are mis-evaluated
      (`cbi_arith` returns false); `cbi_cmp`/`cbi_eq` are fine.
    - Net: WAT actually conforms only on `ack`, not the "member + append/reverse"
      the old table implied. Added that note explicitly.
  - **Documented the shadowed leftover**: `(wat, append)` / `(wat, reverse)`
    carry both a `ct_xfail` and a `ct_skip` fact; `ct_skip` wins (checked
    first), so they're never built and the xfail facts are harmless leftovers.
  - **Tightened the oracle wording**: the oracle is the hand-specified
    expected-results table in `wam_conformance_fixtures.pl` (standard Prolog
    semantics); Scala is the *reference implementation among backends* (it
    passes the whole spec), not the oracle itself.

  ## Verification

  - Cross-checked every table row against the `ct_xfail/2` / `ct_skip/2` facts
    in `test_wam_cross_target_conformance.pl` (lines 86–119).
  - Ran the harness on the available toolchains here (scala, elixir; wat skips —
    no `wat2wasm`/`wasmtime`): both targets **pass** green
    (`CONFORMANCE_PROGRAMS=member,builtins`, ~48s), confirming the doc's "green
    today" claim for the runnable backends.

  No code changes; behavior unaffected.

  ## Possible follow-ups (not in this PR)

  - Delete the dead `ct_xfail(wat, append/reverse)` facts so code and doc are
    literally 1:1 (code change).
  - The Scala 0-arity-comparison codegen hang the doc flags (§"Other backend
    issue surfaced") is still worth fixing in the Scala backend separately.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)