### PR TITLE
fix(wam-elixir): cons-functor aliasing on structural-unify path; complete conformance divergences table

### DIFF
--- a/docs/WAM_CROSS_TARGET_CONFORMANCE.md
+++ b/docs/WAM_CROSS_TARGET_CONFORMANCE.md
@@ -62,18 +62,32 @@ Suggested CI tiers:
 - **full / nightly or pre-merge:** no sampling — every program, every
   query, every available backend.
 
+Because random sampling is nondeterministic, a real divergence can pass
+one push and fail the next, which is confusing for whoever's bisecting.
+CI should **log the `CONFORMANCE_SEED` it used** (and set one explicitly)
+so any failure is reproducible from the recorded seed.
+
 ## Known divergences (tracked as `ct_xfail/2`)
 
 The harness is green today; the divergences below are tolerated and
 logged (an unexpected pass is logged as `XPASS` so the entry can be
 retired). Each is a real backend gap the harness surfaced, not a fixture
-artifact — **Scala passes the whole spec**, which is the reference.
+artifact — **Scala passes the whole spec**, so it is the reference
+*implementation*. (The oracle is the hand-specified expected-results
+table, not Scala's output — Scala is just the one backend that currently
+matches it end-to-end.)
 
 | Backend | Program(s) | Kind | Cause |
 |---|---|---|---|
 | wat | member | xfail | Read-mode structure/list argument unification is unimplemented (the read-mode branches of `unify_variable`/`unify_value`/`unify_constant` are nops; no S-register), so `get_structure`/`get_list` match only the functor. See `WAM_SWITCH_INDEXING_CROSS_TARGET.md`. |
+| wat | fib | xfail | `is/2` with an already-**bound** LHS doesn't verify the computed value — `cfib(10,54)` returns true though `fib(10)=55` (the result is stored over the bound arg instead of being unified/checked). |
+| wat | builtins | xfail | `//` (integer div) and `mod` are not evaluated correctly (return false); `cmp`/`eq` are fine. |
 | wat | append, reverse | **skip** | A *second*, separate WAT bug: the generator loops re-emitting millions of "unrecognized instruction" warnings on recursive list-**building** predicates, so the project is impractical to write. Skipped (not built) rather than xfail'd. |
 | ~~elixir~~ | ~~append, reverse~~ | **fixed** | Was: a freshly-constructed list (`./2`, from `put_list`) would not unify against an already-**ground** list compound (`[|]/2`, from `put_structure`) in a clause head, so `capp([a],[b],[a,b])` returned false while `capp([a],[b],X), X=[a,b]` succeeded. Root cause: `unify/3`'s compound clause demanded *identical* functor names and never applied the `./2`↔`[|]/2` cons-cell aliasing that the `get_structure` match path (`step_get_structure_matches?/2`) already used. Now conformant; xfails removed. |
+
+Net: WAT currently conforms only on `ack` — it diverges on `member`,
+`fib`, `builtins` (xfail) and `append`, `reverse` (skip). `elixir` and
+`scala` pass the whole spec.
 
 `ct_xfail/2` = build and run, tolerate a wrong answer (and log `XPASS` if
 it unexpectedly matches). `ct_skip/2` = do not even build, because

--- a/docs/WAM_CROSS_TARGET_CONFORMANCE.md
+++ b/docs/WAM_CROSS_TARGET_CONFORMANCE.md
@@ -73,7 +73,7 @@ artifact — **Scala passes the whole spec**, which is the reference.
 |---|---|---|---|
 | wat | member | xfail | Read-mode structure/list argument unification is unimplemented (the read-mode branches of `unify_variable`/`unify_value`/`unify_constant` are nops; no S-register), so `get_structure`/`get_list` match only the functor. See `WAM_SWITCH_INDEXING_CROSS_TARGET.md`. |
 | wat | append, reverse | **skip** | A *second*, separate WAT bug: the generator loops re-emitting millions of "unrecognized instruction" warnings on recursive list-**building** predicates, so the project is impractical to write. Skipped (not built) rather than xfail'd. |
-| elixir | append, reverse | xfail | The lowered Elixir backend fails to unify a freshly-constructed list against an already-**ground** compound head argument: `capp([a],[b],[a,b])` returns false, while `capp([a],[b],X), X=[a,b]` succeeds. `member` passes (it only matches an input list). |
+| ~~elixir~~ | ~~append, reverse~~ | **fixed** | Was: a freshly-constructed list (`./2`, from `put_list`) would not unify against an already-**ground** list compound (`[|]/2`, from `put_structure`) in a clause head, so `capp([a],[b],[a,b])` returned false while `capp([a],[b],X), X=[a,b]` succeeded. Root cause: `unify/3`'s compound clause demanded *identical* functor names and never applied the `./2`↔`[|]/2` cons-cell aliasing that the `get_structure` match path (`step_get_structure_matches?/2`) already used. Now conformant; xfails removed. |
 
 `ct_xfail/2` = build and run, tolerate a wrong answer (and log `XPASS` if
 it unexpectedly matches). `ct_skip/2` = do not even build, because
@@ -150,12 +150,33 @@ Open questions a future Haskell adapter must resolve first:
   established here (the interning bug masks it). This is worth checking
   independently of the harness.
 
-### Cross-cutting observation
+### Cross-cutting observation (investigated)
 
-The divergences the harness has found so far cluster around **matching /
-unifying heap-built compound terms**: WAT (read-mode structure unify
-unimplemented), Elixir (constructed list vs ground compound head arg),
-and the suspected Haskell path all live here. If that turns out to be one
-shared weakness in the lowering rather than N independent backend bugs,
-fixing it once would move several backends toward conformance at the same
-time — a higher-leverage option than wiring up adapters one by one.
+The divergences the harness has found cluster around **matching /
+unifying heap-built compound terms** — WAT (read-mode structure unify),
+Elixir (constructed list vs ground compound head arg), the suspected
+Haskell path. The open question was whether this is *one* shared lowering
+weakness or *N* independent backend bugs.
+
+**It is not a shared lowering bug.** The WAM lowering
+(`wam_target.pl:compile_head_arguments/5` + `compile_unify_arguments/5`)
+emits `get_structure`/`get_list`/`unify_*` identically for every backend,
+and **Scala consumes that same stream and passes the whole spec** — so
+the instruction stream is sound. The failures live in each backend's
+*runtime* implementation of the read-mode unify protocol, and they are
+distinct:
+
+- **Elixir** — a self-contained `unify/3` bug (cons-functor `./2`↔`[|]/2`
+  aliasing missing on the structural-unify path). Fixed in this pass; one
+  clause, ~6 lines. `append`/`reverse` now conformant.
+- **WAT** — a genuine runtime *gap*: the read-mode `unify_*` branches are
+  nops and there is no S-register / argument queue. This is a real
+  runtime feature to build, not a one-line fix.
+- **Haskell** — still unverified: the prototype driver's atom-interning
+  bug (above) masks it. Worth re-auditing `readNextArg`/`unifyValues`
+  against the now-fixed Elixir/Scala runtimes for the same cons-aliasing
+  and heap-cons `member/2` concerns once the driver is sound.
+
+So the leverage is per-backend after all, but the harness did its job:
+it pinned each divergence to a specific runtime and made the Elixir one a
+quick, verified fix.

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -973,11 +973,23 @@ compile_utility_helpers_to_elixir(Code) :-
         {:ref, addr1} = v1
         {:ref, addr2} = v2
         case {Map.get(state.heap, addr1), Map.get(state.heap, addr2)} do
-          {{:str, fn_name}, {:str, fn_name}} ->
-            arity = parse_functor_arity(fn_name)
-            args1 = heap_slice(state, addr1 + 1, arity)
-            args2 = heap_slice(state, addr2 + 1, arity)
-            unify_arg_list(state, args1, args2)
+          {{:str, fn1}, {:str, fn2}} ->
+            # Cons-cell functor aliasing: "./2" (put_list) and "[|]/2"
+            # (put_structure) are the SAME ISO cons functor. The
+            # get_structure match path already treats them as
+            # equivalent via step_get_structure_matches?/2; this clause
+            # must too, or a constructed list ("./2") fails to unify
+            # against an already-ground list compound ("[|]/2") in a
+            # clause head — e.g. capp([a],[b],[a,b]) returned false
+            # while capp([a],[b],X), X=[a,b] succeeded.
+            if fn1 == fn2 or step_get_structure_matches?({:str, fn1}, fn2) do
+              arity = parse_functor_arity(fn1)
+              args1 = heap_slice(state, addr1 + 1, arity)
+              args2 = heap_slice(state, addr2 + 1, arity)
+              unify_arg_list(state, args1, args2)
+            else
+              :fail
+            end
           _ -> :fail
         end
       true -> :fail

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -93,15 +93,15 @@ ct_xfail(wat, fib).
 %  backend does not evaluate correctly (returns false). cmp/eq are fine.
 ct_xfail(wat, builtins).
 
-%  Elixir append/reverse: the lowered Elixir backend fails to unify a
-%  freshly-constructed list against an already-GROUND compound argument
-%  in the clause head — e.g. capp([a],[b],[a,b]) (3rd arg ground) returns
-%  false, while capp([a],[b],X), X=[a,b] succeeds. member passes because
-%  it only matches an input list, never constructs+unifies a ground
-%  output. Scala handles both, so this is a genuine backend divergence
-%  the harness surfaced (not a harness artifact).
-ct_xfail(elixir, append).
-ct_xfail(elixir, reverse).
+%  (Elixir append/reverse used to be xfail here: a freshly-constructed
+%  list ("./2", from put_list) would not unify against an already-GROUND
+%  list compound ("[|]/2", from put_structure) in a clause head, so
+%  capp([a],[b],[a,b]) returned false while capp([a],[b],X), X=[a,b]
+%  succeeded. Root cause: unify/3's compound clause demanded identical
+%  functor names, never applying the ./2 <-> [|]/2 cons-cell aliasing
+%  that the get_structure match path already used. Fixed in
+%  wam_elixir_target.pl; both programs are now conformant and the xfails
+%  are removed.)
 
 %% ct_skip(Target, ProgramName)
 %  Stronger than xfail: do NOT even build/run this (target, program).

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -77,14 +77,15 @@ ct_default_target(elixir).
 %  match (xpass) is logged so the entry can be retired once the gap is
 %  fixed.
 %
-%  WAT member/append/reverse: WAT's runtime read-mode structure/list
-%  argument unification is unimplemented (unify_* read-mode branches are
-%  nops; no S-register), so get_structure/get_list match only the
-%  functor and element mismatches go undetected. See
-%  docs/WAM_SWITCH_INDEXING_CROSS_TARGET.md.
+%  WAT member: WAT's runtime read-mode structure/list argument
+%  unification is unimplemented (unify_* read-mode branches are nops; no
+%  S-register), so get_structure/get_list match only the functor and
+%  element mismatches go undetected. See
+%  docs/WAM_SWITCH_INDEXING_CROSS_TARGET.md. (append/reverse hit the same
+%  gap conceptually, but are ct_skip'd below — they never build — so
+%  they are NOT also xfail'd here: ct_skip is checked first and would
+%  shadow the xfail, leaving dead cruft.)
 ct_xfail(wat, member).
-ct_xfail(wat, append).
-ct_xfail(wat, reverse).
 %  WAT fib: is/2 with an already-bound LHS doesn't verify the computed
 %  value — cfib(10,54) returns true though fib(10)=55 (the result is
 %  stored over the bound arg instead of being unified/checked).


### PR DESCRIPTION
## Summary

The cross-target WAM conformance harness flagged `elixir/append` and `elixir/reverse` as `xfail`. This PR investigates the cluster of "heap-built compound term" divergences, **fixes the Elixir one**, and corrects the divergences documentation.

The starting hypothesis was that WAT, Elixir, and the suspected Haskell path shared *one* root-cause lowering bug. **They don't.** The WAM lowering (`wam_target.pl`) emits `get_structure`/`get_list`/`unify_*` identically for every backend, and **Scala consumes that same instruction stream and passes the whole spec** — so the stream is sound. The failures live in each backend's *runtime*, and they're distinct (Elixir: a one-clause unify bug, fixed here; WAT: a genuine runtime gap with no S-register; Haskell: still masked by a driver interning bug).

## The Elixir bug

List cons cells are tagged either `./2` (from `put_list`) or `[|]/2` (from `put_structure`) — the same ISO cons functor. The `get_structure` match path already treated them as aliases via `step_get_structure_matches?/2`, but `unify/3`'s structural-unify clause demanded *identical* functor names. So a freshly-constructed `./2` list never unified against an already-**ground** `[|]/2` compound in a clause head:

- `capp([a],[b],[a,b])` → **false** (wrong)
- `capp([a],[b],X), X=[a,b]` → true

Fix: apply the same `./2`↔`[|]/2` aliasing in `unify/3` (~6 lines).

## Verification

Reproduced end-to-end (built the Elixir project, ran both query shapes), applied the fix, and confirmed the ground case flips to `true` while the construct-then-unify case stays `true`. Then ran the **full Elixir conformance suite** from the regenerated source: `append` and `reverse` now pass as real greens (all four queries each, including the negative cases like `capp([a],[b],[b,a])`→false), `member` unaffected, nothing regressed. Removed both `ct_xfail(elixir, ...)` entries.

## Documentation fixes (per review)

- Completed the **Known divergences** table: added the missing `wat/fib` (is/2 with a bound LHS isn't verified) and `wat/builtins` (`//` and `mod` evaluated wrong) rows. WAT actually conforms only on `ack`, not "member + append/reverse" as the table implied.
- Rewrote the cross-cutting observation with the investigation's conclusion (per-backend runtime, not shared lowering).
- Tightened the "reference" wording — the oracle is the expected-results table, not Scala's output.
- Noted CI should log/set `CONFORMANCE_SEED` so a nondeterministically sampled failure is reproducible.
- Removed dead `ct_xfail(wat, append/reverse)` cruft (shadowed by the `ct_skip` entries, which are checked first).

## Files

- `src/unifyweaver/targets/wam_elixir_target.pl` — the fix
- `tests/test_wam_cross_target_conformance.pl` — xfails removed, dead WAT cruft dropped
- `docs/WAM_CROSS_TARGET_CONFORMANCE.md` — divergence table completed + investigation writeup

## Follow-up

Re-audit Haskell's `readNextArg`/`unifyValues` for the same cons-aliasing gap once its driver interning bug is fixed.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_