### PR TITLE
LLVM WAM: pi/e atom constants + xor/2 (M83)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1240,6 +1240,11 @@ write_wam_llvm_project(Predicates, Options, OutputFile) :-
     register_functor_string("ground"),
     register_functor_string("list"),
     register_functor_string("boolean"),
+    % M83: arithmetic atom constants. ``X is pi'' and ``X is e''
+    % resolve to Float(pi) and Float(e) in eval_arith_value via
+    % strcmp against these registered names.
+    register_functor_string("pi"),
+    register_functor_string("e"),
     % M9: intern "[]" so the empty-list atom id is known at runtime.
     % @wam_apply_aggregation's collect_case reads this id from a
     % module-level global to terminate the cons-cell chain.
@@ -9877,6 +9882,7 @@ entry:
   %expr = call %Value @wam_deref_value(%WamState* %vm, %Value %expr_raw)
   %tag = extractvalue %Value %expr, 0
   switch i32 %tag, label %ev_zero [
+    i32 0, label %ev_atom_const
     i32 1, label %ev_atomic_in
     i32 2, label %ev_atomic_in
     i32 3, label %ev_compound
@@ -9884,6 +9890,33 @@ entry:
 
 ev_atomic_in:
   ret %Value %expr
+
+ev_atom_const:
+  ; M83: arithmetic atom constants. Currently pi and e; failable
+  ; otherwise. Resolve the atom''s name to a C string, then strcmp
+  ; against the registered functor strings.
+  %atc.aid = extractvalue %Value %expr, 1
+  %atc.str = call i8* @wam_atom_to_string(i64 %atc.aid)
+  %atc.null = icmp eq i8* %atc.str, null
+  br i1 %atc.null, label %ev_zero, label %atc.try_pi
+atc.try_pi:
+  %atc.fn_pi = getelementptr [3 x i8], [3 x i8]* @.fn_pi, i32 0, i32 0
+  %atc.cmp_pi = call i32 @strcmp(i8* %atc.str, i8* %atc.fn_pi)
+  %atc.is_pi = icmp eq i32 %atc.cmp_pi, 0
+  br i1 %atc.is_pi, label %atc.ret_pi, label %atc.try_e
+atc.ret_pi:
+  ; pi as IEEE 754 double = 0x400921FB54442D18 (3.141592653589793).
+  %atc.pi_v = call %Value @value_float(double 0x400921FB54442D18)
+  ret %Value %atc.pi_v
+atc.try_e:
+  %atc.fn_e = getelementptr [2 x i8], [2 x i8]* @.fn_e, i32 0, i32 0
+  %atc.cmp_e = call i32 @strcmp(i8* %atc.str, i8* %atc.fn_e)
+  %atc.is_e = icmp eq i32 %atc.cmp_e, 0
+  br i1 %atc.is_e, label %atc.ret_e, label %ev_zero
+atc.ret_e:
+  ; e as IEEE 754 double = 0x4005BF0A8B145769 (2.718281828459045).
+  %atc.e_v = call %Value @value_float(double 0x4005BF0A8B145769)
+  ret %Value %atc.e_v
 
 ev_compound:
   %cp_bits = extractvalue %Value %expr, 1
@@ -10064,11 +10097,13 @@ ev_check_named_binary:
   ; atan2 -- functor name starts with ``a`` (M81).
   ; gcd -- functor name starts with ``g`` (M82).
   ; log/2 -- functor name starts with ``l`` (M82).
+  ; xor -- functor name starts with ``x`` (M83, integer bitwise).
   switch i8 %fn0, label %ev_zero [
     i8 109, label %ev_nb_second   ; ''m'' -> mod | max | min
     i8 97,  label %ev_nb_a_second ; ''a'' -> atan2
     i8 103, label %ev_gcd         ; ''g'' -> gcd
     i8 108, label %ev_log2        ; ''l'' -> log/2
+    i8 120, label %ev_xor         ; ''x'' -> xor
   ]
 ev_nb_a_second:
   ; M81: only atan2 starts with ``a'' in the binary path. Verify the
@@ -10121,6 +10156,16 @@ ev_log2:
   %lg2.r = fdiv double %lg2.lnx, %lg2.lnb
   %lg2.v = call %Value @value_float(double %lg2.r)
   ret %Value %lg2.v
+
+ev_xor:
+  ; M83: xor(A, B) -- integer-only bitwise XOR. Reads payloads as
+  ; i64 directly; passing a Float silently XORs its bit pattern,
+  ; consistent with the gcd treatment.
+  %xor.a_i = extractvalue %Value %a, 1
+  %xor.b_i = extractvalue %Value %b, 1
+  %xor.r = xor i64 %xor.a_i, %xor.b_i
+  %xor.v = call %Value @value_integer(i64 %xor.r)
+  ret %Value %xor.v
 
 ev_nb_second:
   %nb_fn1_ptr = getelementptr i8, i8* %fn_ptr, i32 1

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,35 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M83: pi/e atom constants + xor/2 integer bitwise.
+
+:- dynamic test_pi_50/2.
+test_pi_50(_, R) :-
+    % pi * 50 ~ 157.08; truncate -> 157 (fits in 0..255).
+    X is pi,
+    R is truncate(X * 50).   % 157
+
+:- dynamic test_pi_gt3/2.
+test_pi_gt3(_, R) :-
+    X is pi,
+    ( X > 3.0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_e_90/2.
+test_e_90(_, R) :-
+    % e * 90 ~ 244.65; truncate -> 244.
+    X is e,
+    R is truncate(X * 90).   % 244
+
+:- dynamic test_xor_small/2.
+test_xor_small(_, R) :-
+    % 5 = 0b101; 3 = 0b011; xor = 0b110 = 6.
+    R is xor(5, 3).   % 6
+
+:- dynamic test_xor_byte/2.
+test_xor_byte(_, R) :-
+    % 0xFF xor 0x0F = 0xF0 = 240.
+    R is xor(255, 15).   % 240
+
 % M82: gcd/2 (Integer Euclidean) + log/2 (Float log with base).
 
 :- dynamic test_gcd_basic/2.
@@ -4488,6 +4517,17 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M83 pi/e constants + xor/2 ---~n'),
+       run_test_r0('truncate(pi * 50) -> 157',
+                   test_pi_50, 0, 157),
+       run_test_r0('pi > 3.0 -> 1',
+                   test_pi_gt3, 0, 1),
+       run_test_r0('truncate(e * 90) -> 244',
+                   test_e_90, 0, 244),
+       run_test_r0('xor(5, 3) -> 6',
+                   test_xor_small, 0, 6),
+       run_test_r0('xor(255, 15) -> 240',
+                   test_xor_byte, 0, 240),
        format('--- M82 gcd/2 + log/2 binary arith ---~n'),
        run_test_r0('gcd(12, 18) -> 6',
                    test_gcd_basic, 0, 6),


### PR DESCRIPTION
## Summary

Two unrelated arithmetic additions sharing a milestone:

- **`pi` and `e` as zero-arity atom constants** in `is/2`. `X is pi` now binds X to Float(3.141592653589793); `X is e` binds to Float(2.718281828459045).
- **`xor/2` as a named binary** in the integer bitwise arithmetic family. Extends the M82 named-binary switch from `m`/`a`/`g`/`l` to `m`/`a`/`g`/`l`/`x`.

## What's in this PR

`src/unifyweaver/targets/wam_llvm_target.pl`

**pi / e:**
- `register_functor_string("pi")` and `("e")` in the init block — produces `@.fn_pi` and `@.fn_e` string constants.
- New tag=0 (atom) arm in the `@eval_arith_value` tag switch routing to **`ev_atom_const`** (prefix `atc.`):
  - Resolve the atom id to a C string via `@wam_atom_to_string`.
  - `@strcmp` against `@.fn_pi` → return `value_float(0x400921FB54442D18)`.
  - Else `@strcmp` against `@.fn_e` → return `value_float(0x4005BF0A8B145769)`.
  - Else fall through to `ev_zero` (fail — the atom isn't an arithmetic constant).
- Hard-coded IEEE 754 bit patterns are used instead of `0x...` decimal literals so the constants survive any constant-folding pass identically.

**xor/2:**
- New `i8 120 (\x)` entry in `ev_check_named_binary`'s switch.
- **`ev_xor`** (prefix `xor.`): one `xor i64 %a_payload, %b_payload` and box via `value_integer`. Treats inputs as Integer — passing a Float silently XORs its bit pattern (consistent with the M82 gcd treatment).

`tests/core/test_wam_llvm_builtin_execution.pl`
- 5 new M83 tests, all expected values ≤ 255:
  - `truncate(pi * 50)` → 157 (~π/2 · 100).
  - `pi > 3.0` → 1.
  - `truncate(e * 90)` → 244.
  - `xor(5, 3)` → 6 (`101 XOR 011 = 110`).
  - `xor(255, 15)` → 240 (`0xFF XOR 0x0F = 0xF0`).

## Test plan

- [x] `swipl tests/core/test_wam_llvm_builtin_execution.pl` → 579 PASS, 0 FAIL.
- [x] All 5 M83 test labels green (modules 403–407 in the log).
- [x] Existing named-binary entries (`mod`/`max`/`min`/`atan2`/`gcd`/`log/2`) still pass — verified by the surrounding sections clearing 0 FAIL.
- [x] Pre-flight single-pred `llc` smoke confirmed `@.fn_pi`/`@.fn_e` materialize correctly and the new `ev_atom_const` block dominates its uses.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_