### PR TITLE
fix(wam-scala): support 0-arity comparison-only predicates

### DIFF
--- a/docs/WAM_CROSS_TARGET_CONFORMANCE.md
+++ b/docs/WAM_CROSS_TARGET_CONFORMANCE.md
@@ -102,13 +102,22 @@ it unexpectedly matches). `ct_skip/2` = do not even build, because
 only — they are never built; the formerly-shadowing `ct_xfail` facts have
 been removed.)
 
-### Other backend issue surfaced (not xfail)
+### Other backend issue surfaced
 
-- **Scala loops compiling 0-arity predicates with comparison-only
-  bodies** (e.g. `p :- 3 > 2.`). The harness sidesteps this by (a) giving
-  Scala direct args rather than 0-arity wrappers, and (b) phrasing the
-  `builtins` comparison fixture as a 1-arity predicate. Worth fixing in
-  the Scala backend separately.
+- **Scala 0-arity predicates with comparison-only bodies** (e.g.
+  `p :- 3 > 2.`) — **fixed.** Two independent gaps: (1)
+  `emit_scala_wrapper/4` called `numlist(1, 0, _)`, which *fails* when
+  `Low > High`, silently failing the whole project write for any 0-arity
+  predicate; and (2) the CLI driver's single-query / `--queries` dispatch
+  required at least one argument (`rest.nonEmpty`), so even a compiled
+  0-arity predicate could not be invoked. Now the wrapper guards the
+  empty-arg case (and emits a typed `Array[WamTerm]()`), and dispatch
+  keys on `key.contains("/")` so a lone `pred/0` runs with no args.
+  Covered by `tests/test_wam_scala_classic_programs.pl`
+  (`zero_arity_comparison`). The harness still gives Scala direct args
+  rather than 0-arity wrappers (for list-arg passing), and the `builtins`
+  comparison fixture stays 1-arity — that workaround is no longer
+  *required*, just retained.
 
 ## Adding more backends
 

--- a/src/unifyweaver/targets/wam_scala_target.pl
+++ b/src/unifyweaver/targets/wam_scala_target.pl
@@ -714,7 +714,10 @@ is_pred_label(PredKey, Entry) :-
 %  Generates a def wrapper that calls runPredicate with the right start PC.
 emit_scala_wrapper(Pred, Arity, StartPc, Code) :-
     % Build argument list: a1: WamTerm, a2: WamTerm, ...
-    numlist(1, Arity, ArgNums),
+    % numlist/3 fails when Low > High, so guard the 0-arity case (e.g.
+    % `p :- 3 > 2.`): without this the wrapper — and the whole project
+    % write — silently fails for any 0-arity predicate.
+    (   Arity >= 1 -> numlist(1, Arity, ArgNums) ; ArgNums = [] ),
     maplist([N, Arg]>>(format(string(Arg), 'a~w: WamTerm', [N])), ArgNums, ArgDecls),
     atomic_list_concat(ArgDecls, ', ', ArgDeclStr),
     maplist([N, Arg]>>(format(string(Arg), 'a~w', [N])), ArgNums, ArgNames),
@@ -723,8 +726,11 @@ emit_scala_wrapper(Pred, Arity, StartPc, Code) :-
     % Route through runEntry so a lowered fast path (when present) is used;
     % runEntry falls back to runPredicate at StartPc otherwise. Behaviour is
     % identical in interpreter mode (loweredEntries is empty).
+    % Array[WamTerm](...) is typed explicitly so the 0-arg case emits a
+    % well-typed empty array (`Array()` alone infers Array[Nothing] and
+    % won't match runEntry's Array[WamTerm] parameter).
     format(string(Code),
-           '  def ~w(~w): Boolean =\n    runEntry("~w/~w", ~w, Array(~w))\n',
+           '  def ~w(~w): Boolean =\n    runEntry("~w/~w", ~w, Array[WamTerm](~w))\n',
            [ScalaName, ArgDeclStr, Pred, Arity, StartPc, ArgNameStr]).
 
 %% scala_pred_name(+PrologName, -ScalaName)

--- a/templates/targets/scala_wam/program.scala.mustache
+++ b/templates/targets/scala_wam/program.scala.mustache
@@ -121,8 +121,10 @@ object GeneratedProgram {
             // Tokenise on whitespace. CLI-style argument parsing — same
             // as for single-query mode, just one query per line.
             val tokens = line.split("\\s+").toList
+            // Guard on a "name/arity" key (not rest.nonEmpty) so 0-arity
+            // queries like "p/0" with no args still dispatch.
             tokens match {
-              case key :: rest if rest.nonEmpty =>
+              case key :: rest if key.contains("/") =>
                 sharedProgram.dispatch.get(key) match {
                   case None =>
                     println(s"unknown:$key")
@@ -167,7 +169,10 @@ object GeneratedProgram {
             val elapsed = (System.nanoTime() - t0) / 1.0e9
             println(f"BENCH n=$n elapsed=$elapsed%.6f last=$last")
         }
-      case key :: rest if rest.nonEmpty =>
+      // Guard on a "name/arity" key (not rest.nonEmpty) so 0-arity
+      // predicates like "p/0" invoked with no args still dispatch
+      // instead of falling through to the usage error.
+      case key :: rest if key.contains("/") =>
         sharedProgram.dispatch.get(key) match {
           case None =>
             System.err.println(s"Unknown predicate: $key")

--- a/tests/test_wam_scala_classic_programs.pl
+++ b/tests/test_wam_scala_classic_programs.pl
@@ -22,6 +22,18 @@
 % Sample programs
 % ============================================================
 
+% --- 0-arity comparison-only predicates ---
+% Regression for the Scala-target gap the cross-target conformance doc
+% flagged: a 0-arity body like `p :- 3 > 2.` used to break the backend.
+% emit_scala_wrapper/4 called numlist(1, 0, _) (which fails when Low >
+% High), silently failing the whole project write; and the CLI driver's
+% single-query dispatch required at least one argument, so even a
+% compiled 0-arity predicate could not be invoked. Both are fixed.
+:- dynamic user:zarity_true/0.
+:- dynamic user:zarity_false/0.
+user:zarity_true  :- 3 > 2.
+user:zarity_false :- 3 > 4.
+
 % --- List reverse via accumulator (linear time) ---
 :- dynamic user:rev_acc/3.
 :- dynamic user:list_reverse/2.
@@ -124,6 +136,17 @@ scala_available :-
 
 :- begin_tests(wam_scala_classic_programs,
                [ condition(scala_available) ]).
+
+% 0-arity comparison-only predicates: compile + dispatch with no args.
+test(zero_arity_comparison) :-
+    with_scala_project(
+        [user:zarity_true/0, user:zarity_false/0],
+        _Opts,
+        TmpDir,
+        (
+            verify_scala_args(TmpDir, 'zarity_true/0',  [], "true"),
+            verify_scala_args(TmpDir, 'zarity_false/0', [], "false")
+        )).
 
 test(list_reverse) :-
     with_scala_project(


### PR DESCRIPTION
## Summary

Fixes the Scala-backend 0-arity gap the cross-target conformance doc flagged as an open issue. A 0-arity predicate with a comparison-only body (e.g. `p :- 3 > 2.`) could neither be compiled nor invoked. There were **two independent gaps** — neither was actually an infinite loop (the doc's "loops compiling" wording predated this investigation):

1. **Codegen fails silently.** `emit_scala_wrapper/4` called `numlist(1, 0, _)`, which *fails* in SWI when `Low > High`. That failed the wrapper goal — and the entire `write_wam_scala_project/3` call — for **any** 0-arity predicate. Fixed by guarding the empty-arg case and emitting a typed `Array[WamTerm](...)` (a bare `Array()` infers `Array[Nothing]` and wouldn't match `runEntry`'s `Array[WamTerm]` parameter).

2. **CLI driver can't dispatch 0-arity.** The generated `GeneratedProgram` main matched `case key :: rest if rest.nonEmpty` in both single-query and `--queries` modes, so `GeneratedProgram pred/0` (no args) fell through to the usage error. Changed the guard to `key.contains("/")` so a lone `pred/0` runs with empty args; genuinely-empty / flag input still falls through to usage.

## Verification

- End-to-end: `p :- 3 > 2.` → `true`, `f :- 3 > 4.` → `false`; `scalac` compiles clean (no hang).
- New gated regression test `zero_arity_comparison` in `tests/test_wam_scala_classic_programs.pl`.
- Existing multi-arg classic tests (`list_reverse`, `ackermann`, `nqueens`) still pass — confirms the `Array[WamTerm](...)` change is safe across arities 1–3 and backtracking.

## Files

- `src/unifyweaver/targets/wam_scala_target.pl` — `emit_scala_wrapper/4` fix
- `templates/targets/scala_wam/program.scala.mustache` — driver dispatch fix (single-query + `--queries`)
- `tests/test_wam_scala_classic_programs.pl` — `zero_arity_comparison` regression test
- `docs/WAM_CROSS_TARGET_CONFORMANCE.md` — marks the issue fixed

## Note

The conformance harness's existing workarounds (direct-args for Scala; the `builtins` comparison fixture phrased as 1-arity) are left in place — they're no longer *required* for the 0-arity hang, but the direct-args choice is still useful for list-arg passing, so this PR doesn't churn the harness.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_