### PR TITLE
fix(wam-go): correct findall/aggregate results and StartPC drift from TODO comments

### DIFF
--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -1131,9 +1131,22 @@ wam_lines_to_go([Line|Rest], PC, PredIndicator, Options, GoLits, Labels) :-
             wam_lines_to_go(Rest, PC, PredIndicator, Options, GoLits, RestLabels)
         ;   % Instruction line
             wam_line_to_go_literal(CleanParts, PredIndicator, Options, GoLit),
-            GoLits = [GoLit | RestLits],
-            NPC is PC + 1,
-            wam_lines_to_go(Rest, NPC, PredIndicator, Options, RestLits, Labels)
+            (   sub_atom(GoLit, 0, 2, _, '//')
+            ->  % Non-instruction placeholder: some unimplemented ops (e.g.
+                % arg/3 in certain modes) emit a `// TODO ...` comment instead
+                % of a real instruction. Go ignores comment lines, so they
+                % occupy NO slot in the runtime instruction array. They must
+                % therefore not advance PC or be counted in InstrCount —
+                % otherwise every predicate emitted after them gets a StartPC
+                % shifted by the number of comments, so it is entered past its
+                % prologue (e.g. skipping the put_variable that allocates a
+                % findall template), silently corrupting execution. Skip the
+                % comment entirely so PC accounting matches the emitted array.
+                wam_lines_to_go(Rest, PC, PredIndicator, Options, GoLits, Labels)
+            ;   GoLits = [GoLit | RestLits],
+                NPC is PC + 1,
+                wam_lines_to_go(Rest, NPC, PredIndicator, Options, RestLits, Labels)
+            )
         )
     ).
 

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -774,6 +774,38 @@ func (vm *WamState) valueListHeadTail(v Value) (Value, Value, bool) {
 	return nil, nil, false
 }
 
+// termIdentical implements ==/2 (and, negated, \==/2) with list-representation
+// normalization. findall/aggregate build flat *List values while list literals
+// and put_list/put_structure build heap-linked cons cells, so a shallow
+// valueEquals sees the two representations of the same logical list as unequal
+// (e.g. *List{[a,b,c]} vs *List{[a, _heapTail]}). Mirror Unify's
+// valueListHeadTail walk — but without binding anything — so the two
+// representations of one logical list compare equal under ==/2. Atomics,
+// numbers and variables fall back to valueEquals (variable identity by Idx).
+func (vm *WamState) termIdentical(a, b Value) bool {
+	a = vm.deref(a)
+	b = vm.deref(b)
+	if valueEquals(a, b) {
+		return true
+	}
+	ha, ta, oka := vm.valueListHeadTail(a)
+	hb, tb, okb := vm.valueListHeadTail(b)
+	if oka || okb {
+		return oka && okb && vm.termIdentical(ha, hb) && vm.termIdentical(ta, tb)
+	}
+	fa, argsa := decompose(a)
+	fb, argsb := decompose(b)
+	if fa != "" && fa == fb && len(argsa) == len(argsb) {
+		for i := range argsa {
+			if !vm.termIdentical(argsa[i], argsb[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
 // listToSlice walks a Prolog cons list and collects its elements
 // into a Go slice. Used by `length/2`, `member/2`, `append/3`, etc.
 // Iterative implementation: the previous recursive version did
@@ -1598,8 +1630,8 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 	case "ground/1": return vm.groundTerm(arg1, make(map[Value]bool))
 	case "is_list/1": return isList(vm.deref(arg1))
 
-	case "==/2": return valueEquals(vm.deref(arg1), vm.deref(arg2))
-	case "\\==/2": return !valueEquals(vm.deref(arg1), vm.deref(arg2))
+	case "==/2": return vm.termIdentical(arg1, arg2)
+	case "\\==/2": return !vm.termIdentical(arg1, arg2)
 	case "@</2":
 		return compareValues(vm.deref(arg1), vm.deref(arg2)) < 0
 	case "@=</2":


### PR DESCRIPTION
  ## Summary

  Fixes `test_go_wam_builtins` failing wholesale (every list/`findall`/`sort`
  builtin reporting `_FAILURE`) once a `go` toolchain is present so the suite
  actually executes instead of taking its "go not found, skipping" path. Two
  independent bugs:

  ## 1. StartPC drift from `// TODO` comment placeholders
  `src/unifyweaver/targets/wam_go_target.pl`

  `arg/3` in some modes emits a `// TODO …` comment instead of a real
  instruction. `wam_lines_to_go` counted those comment lines toward
  `PC`/`InstrCount`, but Go ignores comment lines so they occupy **no slot** in
  the generated instruction array. Every predicate emitted after a `// TODO`
  got a `StartPC` shifted by the number of comments, so it was entered **past
  its prologue** — e.g. skipping the `put_variable` that allocates a `findall`
  template variable. The template register stayed `nil`, the inner generator's
  `Unify(nil, head)` failed for every element, `findall` collected nothing, and
  all downstream checks failed.

  **Fix:** skip comment GoLiterals (those starting with `//`) without advancing
  `PC` or emitting an array slot, so PC accounting matches the emitted array.
  Comments were runtime no-ops, so behaviour is unchanged except that
  `StartPC`s/labels for later predicates are now correct.

  ## 2. `==/2` and `\==/2` list-representation mismatch
  `templates/targets/go_wam/state.go.mustache`

  `findall`/aggregate build a flat `*List`, while list literals and
  `put_list`/`put_structure` build heap-linked cons cells. `Unify`, `member/2`,
  `length/2` already bridge the two via `valueListHeadTail`, but `==/2` used a
  shallow `valueEquals`/`List.Equals` that compared the flat `*List`'s elements
  against the heap-linked `*List`'s (head + unbound tail) and saw them as
  unequal — so e.g. `findall(X, member(X,[a,b,c]), L), L == [a,b,c]` failed even
  though `L` was correct (also hit `\==`, `sort`/`setof` result checks, etc.).

  **Fix:** add a VM-aware `termIdentical` helper that mirrors `Unify`'s
  `valueListHeadTail` walk (without binding) and route `==/2` and `\==/2`
  through it.

  ## Verification
  - ✅ `test_go_wam_builtins`, `test_wam_go_generator`,
    `test_wam_go_lowered_phase2`, `test_wam_go_lowered_phase3`.
  - A full WAM sweep also flags `cpp_generator`, `cross_target_consistency`,
    `e2e`, `elixir_lowered_phase3` — but those fail **identically on a clean
    tree** (verified via stash comparison) and are pre-existing / environmental,
    not caused by these Go-only changes.