### PR TITLE
LLVM WAM: integer bitshifts << / >> (M84)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -9948,6 +9948,8 @@ ev_eval_binary:
     i8 45, label %ev_sub
     i8 42, label %ev_mul_or_pow
     i8 47, label %ev_div
+    i8 60, label %ev_shl_check    ; ''<'' -> << (M84)
+    i8 62, label %ev_shr_check    ; ''>'' -> >> (M84)
   ]
 
 ev_add:
@@ -10091,6 +10093,37 @@ ev_div_f_go:
   %div_r_d = fdiv double %div_a_d, %div_b_d
   %div_v_f = call %Value @value_float(double %div_r_d)
   ret %Value %div_v_f
+
+ev_shl_check:
+  ; M84: << is the only ``<''-prefix binary arith op. Verify the
+  ; second byte is also ``<'' (60) so a stray ``<=''/``<+''/etc.
+  ; doesn''t fall through to ev_shl.
+  %shl.fn1_ptr = getelementptr i8, i8* %fn_ptr, i32 1
+  %shl.fn1 = load i8, i8* %shl.fn1_ptr
+  %shl.is_lt = icmp eq i8 %shl.fn1, 60
+  br i1 %shl.is_lt, label %ev_shl, label %ev_zero
+ev_shl:
+  ; Integer-only logical left shift on i64 payloads.
+  %shl.a_i = extractvalue %Value %a, 1
+  %shl.b_i = extractvalue %Value %b, 1
+  %shl.r = shl i64 %shl.a_i, %shl.b_i
+  %shl.v = call %Value @value_integer(i64 %shl.r)
+  ret %Value %shl.v
+
+ev_shr_check:
+  ; M84: >> via second-byte verify, mirroring ev_shl_check.
+  %shr.fn1_ptr = getelementptr i8, i8* %fn_ptr, i32 1
+  %shr.fn1 = load i8, i8* %shr.fn1_ptr
+  %shr.is_gt = icmp eq i8 %shr.fn1, 62
+  br i1 %shr.is_gt, label %ev_shr, label %ev_zero
+ev_shr:
+  ; Integer arithmetic right shift (sign-preserving). Prolog
+  ; integers are signed, so ashr matches the host semantics.
+  %shr.a_i = extractvalue %Value %a, 1
+  %shr.b_i = extractvalue %Value %b, 1
+  %shr.r = ashr i64 %shr.a_i, %shr.b_i
+  %shr.v = call %Value @value_integer(i64 %shr.r)
+  ret %Value %shr.v
 
 ev_check_named_binary:
   ; mod / max / min -- functor name starts with ``m``.

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,29 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M84: integer bitshifts -- << / >>.
+
+:- dynamic test_shl_basic/2.
+test_shl_basic(_, R) :-
+    R is 1 << 4.   % 16
+
+:- dynamic test_shl_byte_top/2.
+test_shl_byte_top(_, R) :-
+    R is 1 << 7.   % 128
+
+:- dynamic test_shl_31_3/2.
+test_shl_31_3(_, R) :-
+    R is 31 << 3.   % 248 (31 * 8)
+
+:- dynamic test_shr_basic/2.
+test_shr_basic(_, R) :-
+    R is 240 >> 4.   % 15
+
+:- dynamic test_shr_round/2.
+test_shr_round(_, R) :-
+    % (1 << 8) >> 4 = 256 >> 4 = 16.
+    R is 256 >> 4.   % 16
+
 % M83: pi/e atom constants + xor/2 integer bitwise.
 
 :- dynamic test_pi_50/2.
@@ -4517,6 +4540,17 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M84 integer bitshifts << / >> ---~n'),
+       run_test_r0('1 << 4 -> 16',
+                   test_shl_basic, 0, 16),
+       run_test_r0('1 << 7 -> 128',
+                   test_shl_byte_top, 0, 128),
+       run_test_r0('31 << 3 -> 248',
+                   test_shl_31_3, 0, 248),
+       run_test_r0('240 >> 4 -> 15',
+                   test_shr_basic, 0, 15),
+       run_test_r0('256 >> 4 -> 16',
+                   test_shr_round, 0, 16),
        format('--- M83 pi/e constants + xor/2 ---~n'),
        run_test_r0('truncate(pi * 50) -> 157',
                    test_pi_50, 0, 157),


### PR DESCRIPTION
## Summary

Adds the two integer bitshift operators to the binary arith dispatch in `is/2`:

- `X is A << B` — logical left shift on i64 (LLVM `shl`).
- `X is A >> B` — arithmetic right shift on i64 (LLVM `ashr`), sign-preserving for negative A to match Prolog's signed integer semantics.

Both have 2-character symbolic names with first bytes that weren't previously routed (`<` = 60, `>` = 62), so they get new direct entries in `@eval_arith_value`'s top-level binary switch rather than going through `ev_check_named_binary`.

## What's in this PR

`src/unifyweaver/targets/wam_llvm_target.pl`

- Two new arms in the binary `switch i8 %fn0`:
  - `i8 60 (\<)` → **`ev_shl_check`**.
  - `i8 62 (\>)` → **`ev_shr_check`**.
- **`ev_shl_check`** (prefix `shl.`): verifies the second functor byte is also `<` (60) so a stray `<=`/`<+`/etc. doesn't fall through into the shift arm, then branches to `ev_shl`.
- **`ev_shl`**: `shl i64 %a_payload, %b_payload` → `value_integer`.
- **`ev_shr_check`** + **`ev_shr`**: mirror structure, using `ashr` instead of `shl` so right-shifting a negative number preserves the sign bit.

Both treat inputs as Integer (extractvalue payload as i64). Passing a Float silently shifts its bit pattern, consistent with the gcd/xor pattern from M82/M83.

`tests/core/test_wam_llvm_builtin_execution.pl`
- 5 new M84 tests, all expected values ≤ 255 to dodge the M80 8-bit exit-code truncation gotcha:
  - `1 << 4` → 16.
  - `1 << 7` → 128 (top bit of a byte).
  - `31 << 3` → 248 (31 * 8 = 248, just under the byte boundary).
  - `240 >> 4` → 15 (high nibble extracted).
  - `256 >> 4` → 16 (verifies the input value isn't getting truncated to a byte).

## Test plan

- [x] `swipl tests/core/test_wam_llvm_builtin_execution.pl` → 584 PASS, 0 FAIL.
- [x] All 5 M84 test labels green (modules 403–407 in the log).
- [x] Existing `+`/`-`/`*`/`/` (the other top-level binary switch arms) still pass — verified by the surrounding sections clearing 0 FAIL.
- [x] Pre-flight single-pred `llc` smoke against the second-byte check + shift blocks — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_