### PR TITLE
feat(wam-go): implement arg/3 lowering for register-source terms

### DIFF
--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -1238,6 +1238,15 @@ wam_line_to_go_literal(["get_value", Xn, Ai], GoLit) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
     go_reg_index(CXn, XnIdx), go_reg_index(CAi, AiIdx),
     format(atom(GoLit), '&GetValue{Xn: ~w, Ai: ~w}', [XnIdx, AiIdx]).
+wam_line_to_go_literal(["arg", N, Src, Dest], GoLit) :-
+    % arg N, Src, Dest — extract argument N (1-based) of the term in
+    % register Src into register Dest. Previously unhandled: it fell
+    % through to the `// TODO` catch-all (a silent no-op), which is what
+    % left findall templates unbound after copy_term. Lower it to a real
+    % GetArgInto instruction.
+    clean_comma(N, CN), clean_comma(Src, CSrc), clean_comma(Dest, CDest),
+    go_reg_index(CSrc, SrcIdx), go_reg_index(CDest, DestIdx),
+    format(atom(GoLit), '&GetArgInto{Index: ~w, Src: ~w, Dest: ~w}', [CN, SrcIdx, DestIdx]).
 wam_line_to_go_literal(["get_structure", FN, Ai], GoLit) :-
     clean_comma(FN, CFN), clean_comma(Ai, CAi),
     go_reg_index(CAi, AiIdx),
@@ -1832,6 +1841,39 @@ wam_go_case('Call', '        vm.CP = vm.PC + 1
             return true
         }
         return false').
+
+wam_go_case('GetArgInto', '        term := vm.deref(vm.getReg(i.Src))
+        var selected Value
+        switch t := term.(type) {
+        case *Compound:
+            if i.Index < 1 || i.Index > len(t.Args) {
+                return false
+            }
+            selected = t.Args[i.Index-1]
+        case *Structure:
+            if i.Index < 1 || i.Index > len(t.Args) {
+                return false
+            }
+            selected = t.Args[i.Index-1]
+        case *List:
+            head, tail, ok := vm.listHeadTail(t)
+            if !ok {
+                return false
+            }
+            if i.Index == 1 {
+                selected = head
+            } else if i.Index == 2 {
+                selected = tail
+            } else {
+                return false
+            }
+        default:
+            return false
+        }
+        vm.trailBinding(i.Dest)
+        vm.putReg(i.Dest, selected)
+        vm.PC++
+        return true').
 
 wam_go_case('CallForeign', '        return vm.executeForeignPredicate(i.Pred, i.Arity)').
 

--- a/templates/targets/go_wam/instructions.go.mustache
+++ b/templates/targets/go_wam/instructions.go.mustache
@@ -102,6 +102,14 @@ func (i *BeginAggregate) instrTag() {}
 type EndAggregate struct { ValueReg int }
 func (i *EndAggregate) instrTag() {}
 
+// GetArgInto implements the `arg N, Src, Dest` WAM instruction: extract
+// argument N (1-based) of the compound/structure/list term held in
+// register Src into register Dest. Emitted by arg/3 when the source term
+// is a runtime value already in a register (e.g. arg(1, C, Y) after
+// copy_term), as opposed to the arg/3 builtin_call form.
+type GetArgInto struct { Index int; Src int; Dest int }
+func (i *GetArgInto) instrTag() {}
+
 type Proceed struct{}
 func (i *Proceed) instrTag() {}
 


### PR DESCRIPTION
  ## Summary

  The `arg N, Src, Dest` WAM instruction (extract argument N of the term in
  register `Src` into register `Dest`) had no Go lowering clause, so it fell
  through to the `// TODO` catch-all and became a **silent no-op**. This is the
  form `arg/3` compiles to when the source term is a runtime value already in a
  register — e.g. `arg(1, C, Y)` after `copy_term(f(X,X), C)` — as opposed to
  the `arg/3` `builtin_call` form (which already worked).

  This was the underlying gap behind the `go_wam_builtins` StartPC drift fixed
  in #2731 (those unimplemented `// TODO` lines also miscounted PC). #2731
  stopped the comments from corrupting other predicates' accounting; this PR
  actually implements the instruction so `arg/3` is correct in all modes.

  ## Changes
  - `templates/targets/go_wam/instructions.go.mustache`: add `GetArgInto`
    instruction type (`Index`, `Src`, `Dest`).
  - `src/unifyweaver/targets/wam_go_target.pl`: lower `arg N, Src, Dest` WAM
    text to `&GetArgInto`, and add the `Step` case — deref the term in `Src`,
    select argument N from a `Compound`/`Structure`/`List` (1-based; for lists
    index 1 = head, 2 = tail), and put it into `Dest`. Out-of-range or
    non-compound source fails the step.

  ## Verification
  - Probes requiring real extraction now succeed (were `false` under the no-op):
    `copy_term(f(a,b),C), arg(1,C,Y), arg(2,C,Z), Y==a, Z==b` and
    `X=g(p,q,r), arg(2,X,V), V==q`.
  - `test_go_wam_builtins`, `test_wam_go_generator`,
    `test_wam_go_lowered_phase2`, `test_wam_go_lowered_phase3` all pass.