### PR TITLE
LLVM WAM: bitwise /\ \/ \ + functor-string hex-escape fix (M85)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -9950,6 +9950,7 @@ ev_eval_binary:
     i8 47, label %ev_div
     i8 60, label %ev_shl_check    ; ''<'' -> << (M84)
     i8 62, label %ev_shr_check    ; ''>'' -> >> (M84)
+    i8 92, label %ev_bor_check    ; ''\\'' -> \\/ (M85)
   ]
 
 ev_add:
@@ -10068,6 +10069,20 @@ ev_pow_pos_finish:
   ret %Value %pow_pos_v
 
 ev_div:
+  ; M85: second-byte check disambiguates ``/'' (division) from
+  ; ``/\\'' (bitwise AND). ``/\\'' has fn_ptr[1] = ''\\'' (92).
+  %div.fn1_ptr = getelementptr i8, i8* %fn_ptr, i32 1
+  %div.fn1 = load i8, i8* %div.fn1_ptr
+  %div.is_band = icmp eq i8 %div.fn1, 92
+  br i1 %div.is_band, label %ev_band, label %ev_div_normal
+ev_band:
+  ; M85: /\\ -- integer bitwise AND.
+  %band.a_i = extractvalue %Value %a, 1
+  %band.b_i = extractvalue %Value %b, 1
+  %band.r = and i64 %band.a_i, %band.b_i
+  %band.v = call %Value @value_integer(i64 %band.r)
+  ret %Value %band.v
+ev_div_normal:
   ; Prolog ``/``: int/int that divides exactly stays int; otherwise
   ; the result is float.
   br i1 %either_float, label %ev_div_f, label %ev_div_i_check
@@ -10124,6 +10139,23 @@ ev_shr:
   %shr.r = ashr i64 %shr.a_i, %shr.b_i
   %shr.v = call %Value @value_integer(i64 %shr.r)
   ret %Value %shr.v
+
+ev_bor_check:
+  ; M85: ``\\'' (92) is the first byte of binary ``\\/'' (bitwise OR).
+  ; Verify the second byte is ``/'' (47); fail otherwise (the only
+  ; other ``\\''-prefix binary in standard Prolog arithmetic would
+  ; be ``\\='' or ``\\=='' which are unification/equality, not
+  ; arith).
+  %bor.fn1_ptr = getelementptr i8, i8* %fn_ptr, i32 1
+  %bor.fn1 = load i8, i8* %bor.fn1_ptr
+  %bor.is_slash = icmp eq i8 %bor.fn1, 47
+  br i1 %bor.is_slash, label %ev_bor, label %ev_zero
+ev_bor:
+  %bor.a_i = extractvalue %Value %a, 1
+  %bor.b_i = extractvalue %Value %b, 1
+  %bor.r = or i64 %bor.a_i, %bor.b_i
+  %bor.v = call %Value @value_integer(i64 %bor.r)
+  ret %Value %bor.v
 
 ev_check_named_binary:
   ; mod / max / min -- functor name starts with ``m``.
@@ -10274,6 +10306,7 @@ ev_eval_unary:
     i8 116, label %ev_trunc_tan ; ''t'' -> truncate | tan
     i8 108, label %ev_log       ; ''l''
     i8 101, label %ev_exp       ; ''e''
+    i8 92,  label %ev_bnot      ; ''\\'' -> unary bitwise NOT (M85)
   ]
 ev_neg:
   br i1 %u_is_float, label %ev_neg_f, label %ev_neg_i
@@ -10332,6 +10365,14 @@ ev_atan:
   %atan_r = call double @atan(double %atan_d)
   %atan_v = call %Value @value_float(double %atan_r)
   ret %Value %atan_v
+
+ev_bnot:
+  ; M85: unary ``\\'' -- integer bitwise NOT. xor with all-ones is
+  ; the LLVM idiom (no dedicated ``not'' instruction).
+  %bnot.u_i = extractvalue %Value %u, 1
+  %bnot.r = xor i64 %bnot.u_i, -1
+  %bnot.v = call %Value @value_integer(i64 %bnot.r)
+  ret %Value %bnot.v
 
 ; M18 truncate/round/floor/ceiling: take a numeric Value, convert to
 ; double, apply the LLVM intrinsic, return Integer (Prolog''s
@@ -10993,19 +11034,40 @@ wam_instruction_to_llvm_literal(Instr, Lit) :-
 %% emit_functor_string_globals(-IR)
 %  Emits LLVM global constants for functor names collected during WAM
 %  compilation (by put_structure instructions). Each functor "name" becomes
-%  @.fn_name = private constant [N x i8] c"name\00".
+%  @.fn_name = private constant [N x i8] c"name\00". Byte content is
+%  emitted as per-byte hex escapes (\NN) so functor names containing
+%  ``\'' (e.g. ``/\\'' bitwise-AND, ``\\/'' bitwise-OR) survive LLVM IR
+%  parsing -- a raw ``\\'' would collide with the ``\\00'' null terminator
+%  and produce a [4 x i8] instead of the declared [3 x i8].
 emit_functor_string_globals(IR) :-
     findall(GlobalDef,
         ( functor_string_global(NameStr, Len),
           sanitize_functor_for_llvm(NameStr, SaneName),
+          llvm_ir_hex_string(NameStr, HexContent),
           format(atom(GlobalDef), '@.fn_~w = private constant [~w x i8] c"~w\\00"',
-              [SaneName, Len, NameStr])
+              [SaneName, Len, HexContent])
         ),
         Defs),
     ( Defs == []
     -> IR = ''
     ;  atomic_list_concat(Defs, '\n', IR)
     ).
+
+%% llvm_ir_hex_string(+Str, -HexEscaped)
+%  Re-encode every byte of Str as an LLVM IR hex escape ``\NN'' so the
+%  result can be dropped between c"..." quotes without any character
+%  needing further escaping.
+llvm_ir_hex_string(Str, Hex) :-
+    string_codes(Str, Codes),
+    maplist(byte_to_hex_escape, Codes, EscapedLists),
+    append(EscapedLists, AllCodes),
+    string_codes(Hex, AllCodes).
+
+byte_to_hex_escape(Byte, [0'\\, H, L]) :-
+    Hi is (Byte >> 4) /\ 0xF,
+    Lo is Byte /\ 0xF,
+    hex_digit(Hi, H),
+    hex_digit(Lo, L).
 
 %% emit_atom_string_globals(-IR)
 %

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,31 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M85: bitwise /\ (AND), \/ (OR), \ (unary NOT).
+
+:- dynamic test_band_basic/2.
+test_band_basic(_, R) :-
+    R is 12 /\ 10.   % 8 (1100 AND 1010 = 1000)
+
+:- dynamic test_band_byte/2.
+test_band_byte(_, R) :-
+    R is 0xFF /\ 0x0F.   % 15 (mask low nibble)
+
+:- dynamic test_bor_basic/2.
+test_bor_basic(_, R) :-
+    R is 5 \/ 3.   % 7 (101 OR 011 = 111)
+
+:- dynamic test_bor_combine/2.
+test_bor_combine(_, R) :-
+    % Combine bit flags: 1 | 2 | 4 | 8 | 16 = 31.
+    R is 1 \/ 2 \/ 4 \/ 8 \/ 16.   % 31
+
+:- dynamic test_bnot_byte/2.
+test_bnot_byte(_, R) :-
+    % \(0) = -1; low 8 bits = 0xFF = 255.
+    X is \0,
+    R is X /\ 0xFF.   % 255
+
 % M84: integer bitshifts -- << / >>.
 
 :- dynamic test_shl_basic/2.
@@ -4540,6 +4565,17 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M85 bitwise /\\ \\/ \\ ---~n'),
+       run_test_r0('12 /\\ 10 -> 8',
+                   test_band_basic, 0, 8),
+       run_test_r0('0xFF /\\ 0x0F -> 15',
+                   test_band_byte, 0, 15),
+       run_test_r0('5 \\/ 3 -> 7',
+                   test_bor_basic, 0, 7),
+       run_test_r0('1\\/2\\/4\\/8\\/16 -> 31',
+                   test_bor_combine, 0, 31),
+       run_test_r0('\\0 /\\ 0xFF -> 255',
+                   test_bnot_byte, 0, 255),
        format('--- M84 integer bitshifts << / >> ---~n'),
        run_test_r0('1 << 4 -> 16',
                    test_shl_basic, 0, 16),


### PR DESCRIPTION
## Summary

Completes the bitwise arithmetic operator set:

- `X is A /\ B` — integer bitwise AND (LLVM `and i64`).
- `X is A \/ B` — integer bitwise OR (LLVM `or i64`).
- `X is \A` — integer bitwise NOT, unary (`xor i64 %u, -1` — LLVM has no dedicated `not` instruction).

Routing:

- `/\` piggybacks on the existing `/` arm. `ev_div` now starts with a second-byte check: if `fn_ptr[1] == '\'` (92) the call is `/\` and falls into `ev_band`; otherwise it continues to the existing division logic via `ev_div_normal`.
- `\/` gets its own arm in the binary switch (`i8 92 -> ev_bor_check`) which verifies the second byte is `/` (47) before falling into `ev_bor`.
- `\` (unary) gets its own arm in the unary switch (`i8 92 -> ev_bnot`).

## Bug fix in this PR (codegen)

The functor-string global emitter (`emit_functor_string_globals`) was inlining the raw functor name between `c"..."` quotes in the LLVM IR string, so a name containing `\` interacted destructively with the `\00` null terminator that follows.

Example: `/\` (2 chars) produced

```llvm
@.fn__2F_5C = private constant [3 x i8] c"/\00"
```

LLVM parses that as four bytes (`/`, literal `\`, `0`, `0`) instead of the declared three. `llc` rejected the module with `error: constant expression type mismatch: got type '[4 x i8]' but expected '[3 x i8]'`.

**Fix**: encode every functor-name byte as `\NN` hex escapes via a new `llvm_ir_hex_string/2` helper. `/\` now emits

```llvm
@.fn__2F_5C = private constant [3 x i8] c"\2F\5C\00"
```

which is unambiguously 3 bytes. The fix applies to every registered functor string, future-proofing the emitter against names containing `\`, `"`, or non-printable bytes.

## What's in this PR

`src/unifyweaver/targets/wam_llvm_target.pl`
- Restructured `ev_div` with a second-byte check at the top → `ev_band` (bitwise AND) or `ev_div_normal` (existing semantics).
- New `i8 92 → ev_bor_check` arm in the binary switch; `ev_bor_check` verifies `fn_ptr[1] == '/'` then branches to `ev_bor` (`or i64`).
- New `i8 92 → ev_bnot` arm in the unary switch; `ev_bnot` does `xor i64 %u, -1`.
- `emit_functor_string_globals` rewritten to use `llvm_ir_hex_string/2` for the byte content. New helper `byte_to_hex_escape/2` formats one byte as `\HH`.

`tests/core/test_wam_llvm_builtin_execution.pl`
- 5 new M85 tests, all expected values ≤ 255:
  - `12 /\ 10` → 8 (`1100 AND 1010 = 1000`).
  - `0xFF /\ 0x0F` → 15 (low-nibble mask).
  - `5 \/ 3` → 7 (`101 OR 011 = 111`).
  - `1\/2\/4\/8\/16` → 31 (bit-flag combine).
  - `\0 /\ 0xFF` → 255 (`\0` = -1; AND with `0xFF` gives byte `0xFF` = 255).

## Test plan

- [x] `swipl tests/core/test_wam_llvm_builtin_execution.pl` → 589 PASS, 0 FAIL.
- [x] All 5 M85 test labels green (modules 403–407 in the log).
- [x] Existing division `/` (which now flows through the second-byte check) still passes — confirmed by the surrounding sections clearing 0 FAIL, plus the compound-arithmetic and float-div sections that rely on it specifically.
- [x] Reproduced the original `[4 x i8] vs [3 x i8]` error on a standalone single-pred `/\` test before the hex-escape fix; confirmed gone after.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_