### PR TITLE
fix(wam-haskell): structural list unification — member/append/reverse conformant

### DIFF
--- a/docs/WAM_CROSS_TARGET_CONFORMANCE.md
+++ b/docs/WAM_CROSS_TARGET_CONFORMANCE.md
@@ -95,9 +95,8 @@ facts in the harness); WAT conforms only on `ack`, and `elixir` and
 | wat | builtins | xfail | `cbi_arith` uses `//` (integer div) and `mod`, which the WAT backend does not evaluate correctly (returns false). The comparison (`cbi_cmp`) and unification (`cbi_eq`) families are fine. |
 | wat | append, reverse | **skip** | A *separate* WAT codegen bug: the generator loops re-emitting millions of "unrecognized instruction" warnings on recursive list-**building** predicates, so the project is impractical to write. Skipped (not built) rather than xfail'd. |
 | ~~elixir~~ | ~~append, reverse~~ | **fixed** | Was: a freshly-constructed list (`./2`, from `put_list`) would not unify against an already-**ground** list compound (`[|]/2`, from `put_structure`) in a clause head, so `capp([a],[b],[a,b])` returned false while `capp([a],[b],X), X=[a,b]` succeeded. Root cause: `unify/3`'s compound clause demanded *identical* functor names and never applied the `./2`↔`[|]/2` cons-cell aliasing that the `get_structure` match path (`step_get_structure_matches?/2`) already used. Now conformant; xfails removed. |
-| haskell | member | xfail | `cmem(z,[a,b,c])` wrongly succeeds. The PR #2708 first-arg indexing fix was validated with the list injected as a `VList` in a register; on a heap-built cons list (`put_list`) the non-member case is not rejected. |
-| haskell | append, reverse | xfail | A constructed list will not unify against an already-ground list compound (`capp([a],[b],[a,b])` → false). **Two** root causes: (1) `unifyVal`/`unifyValues` do **no** structural unification — only identity (`==`) + var-binding, then `Nothing`; and (2) the cons functor `"[|]/2"` interns to its own id, distinct from `atomDot` (`"."`, id 3), so a `put_list` `VList` and a `put_structure "[|]/2"` `Str` never match. Same `./2`-vs-`[|]/2` class as the Elixir bug, but Haskell also lacks compound unification entirely. |
-| haskell | builtins | xfail | `=/2` of two identical atoms returns false (`cbi_eq(foo)`), and `//`/`mod` evaluate incorrectly (`cbi_arith`). `fib`/`ack` pass, so `+`/`-`/comparison and `is/2` bound-LHS checking are fine. |
+| ~~haskell~~ | ~~member, append, reverse~~ | **fixed** | All three failed on heap-built cons lists. Four root causes, now fixed in `wam_haskell_target.pl`: (1) `unifyVal`/`unifyValues` did **no** structural unification — added a shared `unifyTerms`; (2) the cons functor `"[|]/2"` interned to its own id, distinct from `atomDot` — `intern_struct_functor/2` folds every cons spelling onto `atomDot` (the `./2`-vs-`[|]/2` class, same as the Elixir bug); (3) `GetValue` had its own inline unify bypassing the above — now routed through `unifyVal`; (4) **the multi-element bug** — building `[a\|X]` with `X` a `set_variable` tail placeholder emitted `VList [a, X]` (`X` as a 2nd *element*) and `put_structure` filling `X` did not bind the embedded var, so `addToBuilder` now emits a `Str atomDot [hd, tl]` cons cell for a partial tail and binds the placeholder var on finalize. Fixes lists of any length; xfails removed. |
+| haskell | builtins | xfail | `=/2` of two identical atoms returns false (`cbi_eq(foo)`), and `//`/`mod` evaluate incorrectly (`cbi_arith`). `fib`/`ack` pass, so `+`/`-`/comparison and `is/2` bound-LHS checking are fine — isolated builtin bugs, not the list path. |
 
 (Haskell is opt-in — `CONFORMANCE_TARGETS=haskell` — because each program is a cabal compile. `fib` and `ack` pass; the driver, `tests/fixtures/haskell_conformance_driver.hs`, runs a 0-arity wrapper whose atoms are baked into the compiled stream, which is what removed the earlier interning mismatch — see below.)
 
@@ -174,18 +173,19 @@ baked into the compiled instruction stream, so there is **no runtime atom
 parsing** — and it wires `wcInternTable = compileTimeAtomTable`. Proof it
 discriminates correctly: `fib` and `ack` (true and false cases) pass.
 
-That unmasked the **real** backend bugs (now tracked as `ct_xfail`
-above): the heap-cons `member` false-positive, the constructed-list vs
-ground-compound unify failure (`unifyVal`/`unifyValues` do no structural
-unification, **plus** the `"[|]/2"`-vs-`atomDot` cons split), and the
-`=/2` / `//` / `mod` builtin gaps. The PR #2708 first-arg indexing fix was
-validated with the list injected as a `VList` in a register; the harness
-now exercises the realistic **heap-cons** path and shows `cmem(z,[a,b,c])`
-is not rejected there.
+That unmasked the **real** backend bugs. `member`, `append`, and
+`reverse` are **now fixed** (see the table) — the chain was: no structural
+unification, the `"[|]/2"`-vs-`atomDot` cons split, a `GetValue` inline
+unify that bypassed both, and the multi-element construction bug (a
+`set_variable` tail placeholder emitted as a `VList` *element* and never
+bound when `put_structure` filled it). The PR #2708 first-arg indexing fix
+had only been validated with the list injected as a `VList` in a register;
+the harness exercised the realistic **heap-cons** path and surfaced all of
+this. Validated with no regressions across the Haskell suites (target
+codegen, lowered phases 1–4, dispatch ghc smoke, st_regs e2e, iso, csr).
 
-Follow-up (own PR): give `unifyVal` **and** `unifyValues` real structural
-unification (recurse into `Str`/`VList` args with deref; treat `atomDot`
-and the `"[|]/2"` functor as the same cons), then fix `=/2`, `//`, `mod`.
+Still open (own PR): the `builtins` `=/2` / `//` / `mod` gaps — isolated
+builtin bugs, unrelated to the list path.
 
 ### Cross-cutting observation (investigated)
 
@@ -209,12 +209,15 @@ distinct:
 - **WAT** — a genuine runtime *gap*: the read-mode `unify_*` branches are
   nops and there is no S-register / argument queue. This is a real
   runtime feature to build, not a one-line fix.
-- **Haskell** — now verified (the new driver removed the interning mask).
-  Same `./2`-vs-`[|]/2` cons-aliasing class as Elixir (`"[|]/2"` interns
-  separately from `atomDot`), **plus** a deeper gap: both `unifyVal` and
-  `unifyValues` lack structural unification entirely (identity +
-  var-binding only). So Haskell needs more than the Elixir one-liner — it
-  needs real compound unification, then `=/2`/`//`/`mod` fixes.
+- **Haskell** — **fixed** (`member`/`append`/`reverse`). It was the same
+  `./2`-vs-`[|]/2` cons-aliasing class as Elixir, but with three more
+  layers: no structural unification at all, a `GetValue` inline-unify
+  bypass, and a multi-element construction bug (`set_variable` tail
+  placeholders emitted as `VList` elements, never bound on `put_structure`
+  finalize). So Haskell needed real compound unification *plus* a
+  cons-cell representation fix for partial tails — more than the Elixir
+  one-liner, but the same root family. `=/2`/`//`/`mod` remain (separate
+  builtin bugs).
 
 So the leverage is per-backend after all, but the harness did its job:
 it pinned each divergence to a specific runtime — made the Elixir one a

--- a/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
@@ -522,7 +522,7 @@ emit_one(get_value(XnStr, AiStr), _PC, SV, SVout, I, _FP) :-
 emit_one(get_structure(FnStr, AiStr), PC, SV, SVout, I, _FP) :-
     reg_to_int(AiStr, Ai),
     parse_functor(FnStr, FuncName, Arity),
-    wam_haskell_target:intern_atom(FuncName, FnId),
+    wam_haskell_target:intern_struct_functor(FuncName, FnId),
     fresh_sv(SV, SVout),
     format("~w~w <- step ctx (~w { wsPC = ~w }) (GetStructure ~w ~w ~w)~n",
            [I, SVout, SV, PC, FnId, Ai, Arity]).
@@ -599,7 +599,7 @@ emit_one(put_constant(CStr, AiStr), _, SV, SVout, I, _FP) :-
 emit_one(put_structure(FnStr, AiStr), _PC, SV, SVout, I, _FP) :-
     reg_to_int(AiStr, Ai),
     parse_functor(FnStr, FuncName, Arity),
-    wam_haskell_target:intern_atom(FuncName, FnId),
+    wam_haskell_target:intern_struct_functor(FuncName, FnId),
     fresh_sv(SV, SVout),
     format("~wlet ~w = ~w { wsBuilder = BuildStruct ~w ~w ~w [] }~n",
            [I, SVout, SV, FnId, Ai, Arity]).

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -145,6 +145,25 @@ intern_atom(AtomStr, Id) :-
         assertz(atom_intern_next(Next1))
     ).
 
+%% intern_struct_functor(+FunctorStr, -Id) is det.
+%  Intern a get_structure/put_structure functor, normalising the list
+%  cons functor to atomDot (".", id 3). The WAM stream names a cons cell
+%  "[|]/2" (occasionally "./2"), while get_list/put_list use atomDot —
+%  so a put_structure cons (Str "[|]/2") and a put_list cons (VList /
+%  Str atomDot) end up with different functor ids and never match or
+%  unify. Folding every cons spelling onto atomDot gives lists ONE
+%  representation. Accepts either the bare functor ("[|]", ".") or the
+%  name/arity form ("[|]/2", "./2").
+intern_struct_functor(FunctorStr, Id) :-
+    (   is_cons_functor(FunctorStr)
+    ->  intern_atom(".", Id)
+    ;   intern_atom(FunctorStr, Id)
+    ).
+
+is_cons_functor(F) :-
+    ( atom(F) -> atom_string(F, S) ; F = S ),
+    memberchk(S, ["[|]", "[|]/2", ".", "./2"]).
+
 %% emit_atom_table_haskell(-Code) is det.
 %  Emits the compile-time atom table as Haskell code.
 emit_atom_table_haskell(Code) :-
@@ -1854,22 +1873,55 @@ copyTermArgs !c !m (x : xs) =
       (xs1, c2, m2) = copyTermArgs c1 m1 xs
   in (x1 : xs1, c2, m2)
 
--- | Unify two values, binding unbound variables.
+-- | Bind an unbound variable, trailing its previous value.
+bindUnbound :: Int -> Value -> WamState -> WamState
+bindUnbound vid v s =
+  s { wsBindings = IM.insert vid v (wsBindings s)
+    , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
+    , wsTrailLen = wsTrailLen s + 1
+    }
+
+-- | PC-neutral structural unification. Recurses into compound terms
+-- (Str / VList), binding and trailing unbound subterms, so a freshly
+-- constructed list unifies with an already-ground one. A cons cell may
+-- appear as VList or as Str atomDot (codegen normalises the [|]/2
+-- functor to atomDot), and [] as Atom atomNil or VList []; all denote
+-- the same list structure.
+unifyTerms :: Value -> Value -> WamState -> Maybe WamState
+unifyTerms x y s =
+  unifyDeref (derefVar (wsBindings s) x) (derefVar (wsBindings s) y) s
+
+unifyDeref :: Value -> Value -> WamState -> Maybe WamState
+unifyDeref a b s | a == b = Just s
+unifyDeref (Unbound vid) v s = Just (bindUnbound vid v s)
+unifyDeref v (Unbound vid) s = Just (bindUnbound vid v s)
+unifyDeref (Str f1 a1) (Str f2 a2) s
+  | f1 == f2 && length a1 == length a2 = unifyArgList a1 a2 s
+unifyDeref (VList xs) (VList ys) s
+  | length xs == length ys = unifyArgList xs ys s
+unifyDeref (VList (x : xs)) (Str f [h, t]) s
+  | f == atomDot = unifyTerms x h s >>= unifyTerms (listTailVal xs) t
+unifyDeref (Str f [h, t]) (VList (x : xs)) s
+  | f == atomDot = unifyTerms h x s >>= unifyTerms t (listTailVal xs)
+unifyDeref (VList []) (Atom n) s | n == atomNil = Just s
+unifyDeref (Atom n) (VList []) s | n == atomNil = Just s
+unifyDeref _ _ _ = Nothing
+
+unifyArgList :: [Value] -> [Value] -> WamState -> Maybe WamState
+unifyArgList [] [] s = Just s
+unifyArgList (x : xs) (y : ys) s = unifyTerms x y s >>= unifyArgList xs ys
+unifyArgList _ _ _ = Nothing
+
+listTailVal :: [Value] -> Value
+listTailVal [] = Atom atomNil
+listTailVal xs = VList xs
+
+-- | Unify two values, binding unbound variables; advances PC on success
+-- (head-match contract). Delegates to the PC-neutral unifyTerms.
 unifyVal :: Value -> Value -> WamState -> Maybe WamState
-unifyVal (Unbound vid) val s =
-  Just (s { wsPC = wsPC s + 1
-          , wsBindings = IM.insert vid val (wsBindings s)
-          , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
-          , wsTrailLen = wsTrailLen s + 1
-          })
-unifyVal val (Unbound vid) s =
-  Just (s { wsPC = wsPC s + 1
-          , wsBindings = IM.insert vid val (wsBindings s)
-          , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
-          , wsTrailLen = wsTrailLen s + 1
-          })
-unifyVal a b s | a == b = Just (s { wsPC = wsPC s + 1 })
-               | otherwise = Nothing'.
+unifyVal a b s = case unifyTerms a b s of
+  Just s2 -> Just (s2 { wsPC = wsPC s + 1 })
+  Nothing -> Nothing'.
 
 % ============================================================================
 % PHASE 3: Step Function + Run Loop
@@ -1900,28 +1952,15 @@ step !ctx s (GetVariable xn ai) =
     Nothing -> Nothing
 
 step !ctx s (GetValue xn ai) =
-  let va = derefVar (wsBindings s) <$> IM.lookup ai (wsRegs s)
-      vx = getReg xn s
-  in case (va, vx) of
-    (Just a, Just x) | a == x -> Just (s { wsPC = wsPC s + 1 })
-    (Just (Unbound vid), Just x) ->
-      Just (s { wsPC = wsPC s + 1
-              , wsRegs = IM.insert ai x (wsRegs s)
-              , wsBindings = IM.insert vid x (wsBindings s)
-              , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
-              , wsTrailLen = wsTrailLen s + 1
-              })
-    -- Symmetric case: xn (X-register) holds the unbound side, ai
-    -- holds the bound value. Used by the =../2 / functor/3 compose
-    -- lowering, which emits get_value T_reg, TermReg where T_reg is
-    -- the fresh output and TermReg is the freshly-constructed Str.
-    -- Unification is symmetric, so bind the xn vid to a.
-    (Just a, Just (Unbound vid)) ->
-      Just (s { wsPC = wsPC s + 1
-              , wsBindings = IM.insert vid a (wsBindings s)
-              , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
-              , wsTrailLen = wsTrailLen s + 1
-              })
+  -- Full structural unification of the register value against the
+  -- X-register, via unifyVal (which advances PC on success). The old
+  -- inline version only matched identity / unbound-binding, so a
+  -- structurally-equal-but-differently-represented compound (e.g. a
+  -- constructed list vs an already-ground one) fell through to Nothing
+  -- -- the append/reverse base-case bug.
+  case (IM.lookup ai (wsRegs s), getReg xn s) of
+    (Just a, Just x) ->
+      unifyVal (derefVar (wsBindings s) a) (derefVar (wsBindings s) x) s
     _ -> Nothing
 
 step !ctx s (PutConstant c ai) =
@@ -5113,10 +5152,20 @@ addToBuilder val s = case wsBuilder s of
     -- but only when finalizing — args grows from 0 to arity, max arity is small.
     let args'' = val : args
     in if length args'' == arity
-       then Just (s { wsPC = wsPC s + 1
-                    , wsRegs = IM.insert ai (Str fn (reverse args'')) (wsRegs s)
-                    , wsBuilder = NoBuilder
-                    })
+       then let term = Str fn (reverse args'')
+                -- Outer-first construction (set_variable Xn for a tail,
+                -- then put_structure Xn to fill it) leaves that var
+                -- embedded in the outer term. Finalising into register ai
+                -- must ALSO bind the var ai currently holds, or the outer
+                -- term keeps an unbound tail -- the multi-element list bug
+                -- that made reverse/append wrong on lists of length >= 2.
+                sBound = case IM.lookup ai (wsRegs s) of
+                  Just (Unbound vid) -> bindUnbound vid term s
+                  _ -> s
+            in Just (sBound { wsPC = wsPC s + 1
+                            , wsRegs = IM.insert ai term (wsRegs sBound)
+                            , wsBuilder = NoBuilder
+                            })
        else Just (s { wsPC = wsPC s + 1
                     , wsBuilder = BuildStruct fn ai arity args''
                     })
@@ -5128,9 +5177,20 @@ addToBuilder val s = case wsBuilder s of
                 list = case tl of
                   VList items -> VList (hd : items)
                   Atom aid | aid == atomNil -> VList [hd]
-                  _           -> VList [hd, tl]
-            in Just (s { wsPC = wsPC s + 1
-                       , wsRegs = IM.insert ai list (wsRegs s)
+                  -- A variable / partial tail (set_variable placeholder for
+                  -- outer-first construction) is the REST of the list, not an
+                  -- element. VList [hd, tl] would wrongly make it a 2-element
+                  -- list [hd, tl]; emit a proper cons cell so the tail splices
+                  -- in once bound (the [a|X], X=[b] => [a,b] case).
+                  _           -> Str atomDot [hd, tl]
+                -- Same placeholder-var binding as BuildStruct: a list built
+                -- into a register that holds a set_variable placeholder must
+                -- bind that var so an enclosing term sees the list.
+                sBound = case IM.lookup ai (wsRegs s) of
+                  Just (Unbound vid) -> bindUnbound vid list s
+                  _ -> s
+            in Just (sBound { wsPC = wsPC s + 1
+                       , wsRegs = IM.insert ai list (wsRegs sBound)
                        , wsBuilder = NoBuilder
                        })
        else Just (s { wsPC = wsPC s + 1
@@ -5207,18 +5267,12 @@ popBuilderStack s = case wsBuilderStack s of
   [] -> s { wsBuilder = NoBuilder }
 
 -- | Unify two values. Returns updated state on success, Nothing on failure.
+-- Full structural unification, PC-neutral (the read-mode callers advance
+-- PC themselves). Delegates to the shared unifyTerms defined alongside
+-- unifyVal, so head-matching and read-mode unify share one implementation
+-- that handles compound terms and the VList / Str-atomDot cons forms.
 unifyValues :: Value -> Value -> WamState -> Maybe WamState
-unifyValues v1 v2 s
-  | v1 == v2 = Just s
-unifyValues (Unbound vid) v2 s =
-  Just (s { wsBindings = IM.insert vid v2 (wsBindings s)
-          , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
-          , wsTrailLen = wsTrailLen s + 1 })
-unifyValues v1 (Unbound vid) s =
-  Just (s { wsBindings = IM.insert vid v1 (wsBindings s)
-          , wsTrail = TrailEntry vid (IM.lookup vid (wsBindings s)) : wsTrail s
-          , wsTrailLen = wsTrailLen s + 1 })
-unifyValues _ _ _ = Nothing
+unifyValues = unifyTerms
 
 -- | Lookup a label in the label map (now in WamContext).
 lookupLabel :: String -> WamContext -> Int
@@ -6491,7 +6545,7 @@ wam_instr_to_haskell(["put_structure", FN, Ai], Hs) :-
     clean_comma(FN, CFN), clean_comma(Ai, CAi),
     parse_functor_arity(CFN, Arity),
     reg_name_to_int(CAi, AiI),
-    intern_atom(CFN, FnId),
+    intern_struct_functor(CFN, FnId),
     format(string(Hs), 'PutStructure ~w ~w ~w', [FnId, AiI, Arity]).
 wam_instr_to_haskell(["put_structure_dyn", NameReg, ArityReg, TargetReg], Hs) :-
     clean_comma(NameReg, CN), clean_comma(ArityReg, CA), clean_comma(TargetReg, CT),
@@ -6609,7 +6663,7 @@ wam_instr_to_haskell(["get_structure", FN, Ai], Hs) :-
     clean_comma(FN, CFN), clean_comma(Ai, CAi),
     parse_functor_arity(CFN, Arity),
     reg_name_to_int(CAi, AiI),
-    intern_atom(CFN, FnId),
+    intern_struct_functor(CFN, FnId),
     format(string(Hs), 'GetStructure ~w ~w ~w', [FnId, AiI, Arity]).
 wam_instr_to_haskell(["get_list", Ai], Hs) :-
     clean_comma(Ai, CAi), reg_name_to_int(CAi, AiI),

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -110,30 +110,32 @@ ct_xfail(wat, builtins).
 %  wam_elixir_target.pl; both programs are now conformant and the xfails
 %  are removed.)
 
-%  Haskell member/append/reverse/builtins. The conformance driver
+%  Haskell builtins. The conformance driver
 %  (tests/fixtures/haskell_conformance_driver.hs) runs a 0-arity wrapper
 %  whose atoms are baked into the compiled instruction stream, which
 %  removed the atom-interning mismatch that sank the earlier throwaway
-%  driver (fib/ack now pass, so the driver discriminates correctly).
-%  That unmasked real backend gaps:
-%   - member: cmem(z,[a,b,c]) wrongly succeeds. The PR #2708 first-arg
-%     indexing fix was validated with the list injected as a VList in a
-%     register; on a heap-built cons list (put_list) the non-member case
-%     is not rejected.
-%   - append/reverse: a freshly-constructed list will not unify against
-%     an already-ground list compound (capp([a],[b],[a,b]) -> false).
-%     TWO root causes: (1) unifyVal/unifyValues do NO structural
-%     unification — only identity (==) and var-binding, then Nothing; and
-%     (2) the cons functor "[|]/2" interns to its own id, distinct from
-%     atomDot (".", id 3), so a put_list VList and a put_structure
-%     "[|]/2" Str never match. (Same ./2-vs-[|]/2 class as the Elixir
-%     bug, but Haskell also lacks compound unification entirely.)
-%   - builtins: =/2 of two identical atoms returns false (cbi_eq(foo)),
-%     and // (integer div) / mod evaluate incorrectly (cbi_arith). fib
-%     and ack pass, so +/-/comparison and is/2 bound-LHS checking work.
-ct_xfail(haskell, member).
-ct_xfail(haskell, append).
-ct_xfail(haskell, reverse).
+%  driver (fib/ack discriminate correctly).
+%
+%  member/append/reverse USED to be xfail here, all failing on heap-built
+%  cons lists. Root causes (now fixed in wam_haskell_target.pl):
+%   1. unifyVal/unifyValues did NO structural unification (identity +
+%      var-binding only) — added a shared structural unifyTerms.
+%   2. the cons functor "[|]/2" interned to its own id, distinct from
+%      atomDot — intern_struct_functor/2 now folds every cons spelling
+%      onto atomDot (the ./2-vs-[|]/2 class, same as the Elixir bug).
+%   3. GetValue had its own inline unify bypassing the above — now routed
+%      through unifyVal.
+%   4. THE multi-element bug: building [a|X] with X a set_variable tail
+%      placeholder emitted VList [a, X] (X as a 2nd ELEMENT) instead of a
+%      cons cell, and put_structure filling X did not bind the embedded
+%      var. addToBuilder now emits Str atomDot [hd, tl] for a partial
+%      tail and binds the placeholder var on finalize. This fixed member,
+%      append, AND reverse on lists of any length; the xfails are removed.
+%
+%  builtins remains: =/2 of two identical atoms returns false
+%  (cbi_eq(foo)), and // (integer div) / mod evaluate incorrectly
+%  (cbi_arith). fib/ack pass, so +/-/comparison and is/2 bound-LHS
+%  checking work — these are isolated builtin bugs, not the list path.
 ct_xfail(haskell, builtins).
 
 %% ct_skip(Target, ProgramName)


### PR DESCRIPTION
## Summary

Fixes the Haskell WAM backend's list bugs surfaced by the conformance harness (PR #2733). **`member`, `append`, and `reverse` are now fully conformant** (any list length); their `ct_xfail` entries are removed. Only `builtins` remains xfail (isolated `=/2` / `//` / `mod` bugs, unrelated to lists).

What looked like one bug was **four interacting root causes**:

1. **No structural unification.** `unifyVal` and `unifyValues` only handled identity (`==`) and var-binding, then `Nothing` — two distinct compound terms never unified. Added a shared PC-neutral `unifyTerms` (recurses into `Str`/`VList` with deref) and routed both through it.
2. **Cons-functor split** (the `./2`-vs-`[|]/2` class you asked about — same as the Elixir bug). `"[|]/2"` (from `put_structure`) interned to its own id, distinct from `atomDot` (`"."`, from `put_list`), so a constructed list and a ground list compound never matched. `intern_struct_functor/2` now folds every cons spelling onto `atomDot` at codegen.
3. **`GetValue` bypass.** It had its own inline unify, so base-case result unification skipped the structural path. Routed through `unifyVal`.
4. **The multi-element construction bug** (the deep one). Outer-first list building (`put_list; set_constant a; set_variable X; put_structure X …`) emitted `VList [a, X]` — `X` as a 2nd *element* rather than the list *tail* — and the `put_structure` filling `X` never bound the var embedded in the outer term. `addToBuilder` now emits a proper `Str atomDot [hd, tl]` cons cell for a partial/variable tail and binds the placeholder var on finalize.

## Verification

- Full opt-in Haskell harness (`CONFORMANCE_TARGETS=haskell`) is **green**; `member`/`append`/`reverse` pass as real conformant programs (3-element lists, negative cases, etc.).
- **No regressions**: target codegen (the 5 failing `F1`/async cases are pre-existing on `main` — confirmed by stashing), lowered phases 1–4, dispatch ghc smoke (12/12), st_regs e2e (RESULT OK), iso + csr smoke.
- Default targets (scala/elixir) untouched.

## Files

- `src/unifyweaver/targets/wam_haskell_target.pl` — `intern_struct_functor`, `unifyTerms`/`unifyVal`/`unifyValues`, `GetValue`, `addToBuilder`
- `src/unifyweaver/targets/wam_haskell_lowered_emitter.pl` — cons normalization at the lowered get/put_structure sites
- `tests/test_wam_cross_target_conformance.pl` — removed `member`/`append`/`reverse` xfails; updated diagnosis
- `docs/WAM_CROSS_TARGET_CONFORMANCE.md` — divergence table + writeup updated

## Follow-up

`builtins` (`=/2` of identical atoms → false; `//`/`mod` wrong) — separate, isolated builtin bugs; own PR.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_