### PR TITLE
LLVM WAM: sleep/1 (M86)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1472,6 +1472,7 @@ declare i32 @system(i8*)
 declare i8* @getcwd(i8*, i64)
 declare i32 @chdir(i8*)
 declare i32 @getpid()
+declare i32 @usleep(i32)
 declare double @asin(double)
 declare double @acos(double)
 declare double @atan(double)
@@ -3523,6 +3524,7 @@ entry:
     i32 102, label %builtin_shell2
     i32 103, label %builtin_working_directory
     i32 104, label %builtin_getpid
+    i32 105, label %builtin_sleep
   ]
 
 builtin_is:
@@ -4778,6 +4780,40 @@ builtin_getpid:
   %gp.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %gp.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %gp.raw1, %Value %gp.v)
   ret i1 %gp.ok
+
+builtin_sleep:
+  ; M86: sleep(+Seconds) -- accepts Integer or Float seconds and
+  ; calls libc usleep(microseconds). usleep takes i32, so very
+  ; long sleeps (more than ~71 minutes) silently truncate; for
+  ; typical usage this is fine. Returns success unconditionally
+  ; once the call returns (any signal that woke usleep early
+  ; still counts as a successful sleep). Prefix ``slp.'' to avoid
+  ; the ``sl.'' collision with builtin_sum_list (M42).
+  %slp.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %slp.t1 = extractvalue %Value %slp.a1, 0
+  %slp.is_int = icmp eq i32 %slp.t1, 1
+  %slp.is_float = icmp eq i32 %slp.t1, 2
+  %slp.is_num = or i1 %slp.is_int, %slp.is_float
+  br i1 %slp.is_num, label %slp.dispatch, label %slp.fail
+slp.fail:
+  ret i1 false
+slp.dispatch:
+  br i1 %slp.is_float, label %slp.from_float, label %slp.from_int
+slp.from_int:
+  %slp.sec_i = extractvalue %Value %slp.a1, 1
+  %slp.us_int = mul i64 %slp.sec_i, 1000000
+  br label %slp.do_sleep
+slp.from_float:
+  %slp.sec_bits = extractvalue %Value %slp.a1, 1
+  %slp.sec_d = bitcast i64 %slp.sec_bits to double
+  %slp.us_d = fmul double %slp.sec_d, 1.000000e+06
+  %slp.us_flt = fptosi double %slp.us_d to i64
+  br label %slp.do_sleep
+slp.do_sleep:
+  %slp.us = phi i64 [ %slp.us_int, %slp.from_int ], [ %slp.us_flt, %slp.from_float ]
+  %slp.us32 = trunc i64 %slp.us to i32
+  call i32 @usleep(i32 %slp.us32)
+  ret i1 true
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11589,6 +11625,7 @@ builtin_op_to_id('shell/1', 101).             % libc system(cmd) succeeds iff ex
 builtin_op_to_id('shell/2', 102).             % libc system(cmd), Status = WEXITSTATUS.
 builtin_op_to_id('working_directory/2', 103). % getcwd -> Old; chdir(New) if New atom.
 builtin_op_to_id('getpid/1', 104).            % libc getpid() as Integer.
+builtin_op_to_id('sleep/1', 105).             % libc usleep(seconds * 1e6).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2077,6 +2077,7 @@ is_builtin_pred(shell, 1).              % shell(+Command).
 is_builtin_pred(shell, 2).              % shell(+Command, -Status).
 is_builtin_pred(working_directory, 2).  % working_directory(?Old, ?New).
 is_builtin_pred(getpid, 1).             % getpid(-Pid).
+is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,46 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M86: sleep/1 -- libc usleep wrapper.
+
+:- dynamic test_sleep_zero/2.
+test_sleep_zero(_, R) :-
+    sleep(0),
+    R is 1.   % 1
+
+:- dynamic test_sleep_float_zero/2.
+test_sleep_float_zero(_, R) :-
+    sleep(0.0),
+    R is 1.   % 1
+
+:- dynamic test_sleep_tiny/2.
+test_sleep_tiny(_, R) :-
+    % 1ms is the floor we use for ``definitely returned'' tests; any
+    % usleep call should at least cycle through the kernel and return.
+    sleep(0.001),
+    R is 1.   % 1
+
+:- dynamic test_sleep_elapsed_float/2.
+test_sleep_elapsed_float(_, R) :-
+    % Verify sleep actually waits. M72 get_time/1 has whole-second
+    % resolution (libc time()), so use sleep(1.0) and floor at 0.5
+    % seconds. Boundary case (T0 captured at S, T1 at S+1) still
+    % gives Diff=1.
+    get_time(T0),
+    sleep(1.0),
+    get_time(T1),
+    Diff is T1 - T0,
+    ( Diff >= 0.5 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_sleep_elapsed_int/2.
+test_sleep_elapsed_int(_, R) :-
+    % Same shape but Integer argument exercising the from_int branch.
+    get_time(T0),
+    sleep(1),
+    get_time(T1),
+    Diff is T1 - T0,
+    ( Diff >= 0.5 -> R is 1 ; R is 0 ).   % 1
+
 % M85: bitwise /\ (AND), \/ (OR), \ (unary NOT).
 
 :- dynamic test_band_basic/2.
@@ -4565,6 +4605,17 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M86 sleep/1 ---~n'),
+       run_test_r0('sleep(0) -> 1',
+                   test_sleep_zero, 0, 1),
+       run_test_r0('sleep(0.0) -> 1',
+                   test_sleep_float_zero, 0, 1),
+       run_test_r0('sleep(0.001) -> 1',
+                   test_sleep_tiny, 0, 1),
+       run_test_r0('sleep(1.0) elapsed >= 0.5 -> 1',
+                   test_sleep_elapsed_float, 0, 1),
+       run_test_r0('sleep(1) elapsed >= 0.5 -> 1',
+                   test_sleep_elapsed_int, 0, 1),
        format('--- M85 bitwise /\\ \\/ \\ ---~n'),
        run_test_r0('12 /\\ 10 -> 8',
                    test_band_basic, 0, 8),


### PR DESCRIPTION
## Summary

- Adds `sleep/1` as a native LLVM builtin (op id 105).
- Wraps libc `usleep()`. Accepts Integer or Float seconds and converts to i32 microseconds. Continues the OS-access cluster started in M77/M78/M79.

## What's in this PR

`src/unifyweaver/targets/wam_llvm_target.pl`
- Dispatch entry `i32 105 -> builtin_sleep`.
- `builtin_op_to_id('sleep/1', 105)`.
- New `declare i32 @usleep(i32)` in the libc-decls block.
- **`builtin_sleep`** (prefix `slp.` — see below): deref reg 0, check tag is Integer (1) or Float (2), bail otherwise. Compute microseconds via a `phi`:
  - Integer path: `mul i64 %sec, 1000000`.
  - Float path: `bitcast i64 → double`, `fmul 1e6`, `fptosi → i64`.
  - Truncate i64 → i32 and call `@usleep`. Always returns true once usleep returns (a signal-interrupted sleep still counts as a successful predicate call).

`src/unifyweaver/targets/wam_target.pl`
- `is_builtin_pred(sleep, 1)` so WAM-fallback predicates route through the builtin dispatcher.

`tests/core/test_wam_llvm_builtin_execution.pl`
- 5 new M86 tests:
  - `sleep(0)` succeeds (Integer fast path).
  - `sleep(0.0)` succeeds (Float fast path).
  - `sleep(0.001)` succeeds (1ms, exercises the syscall round-trip).
  - `sleep(1.0)`, `T1 - T0 >= 0.5`.
  - `sleep(1)` (Integer arg), `T1 - T0 >= 0.5`.

## Gotchas hit during dev

**Prefix collision.** First pass used prefix `sl.` for the IR block. That collided with `builtin_sum_list` (M42) — llc rejected with `multiple definition of local value named 'sl.a1'`. Renamed to `slp.` end-to-end.

**Elapsed-time resolution.** First pass used `sleep(0.05)` for the elapsed-check tests, but M72 `get_time/1` is implemented via libc `time()` which has whole-second resolution. A 50ms sleep produced `T1 - T0 = 0` and the test reported `got 0, expected 1`. Switched the elapsed tests to `sleep(1)` with a 0.5s floor — that buys headroom even when both `get_time` samples happen to capture the same second boundary. Suite cost is ~2 extra seconds for the two 1-second elapsed tests.

## Test plan

- [x] `swipl tests/core/test_wam_llvm_builtin_execution.pl` → 594 PASS, 0 FAIL.
- [x] All 5 M86 test labels green (modules 403–407 in the log).
- [x] `builtin_sum_list` still passes (M42, the section that caught the `sl.` prefix collision after rename) — confirmed by the surrounding sections clearing 0 FAIL.
- [x] Pre-flight single-pred `llc` smoke confirmed the phi-node structure and the prefix rename.


---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_