### PR TITLE
LLVM WAM: gethostname/1 (M88) + functor-string fast-path + test-suite GC

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1474,6 +1474,7 @@ declare i8* @getcwd(i8*, i64)
 declare i32 @chdir(i8*)
 declare i32 @getpid()
 declare i32 @usleep(i32)
+declare i32 @gethostname(i8*, i64)
 declare double @asin(double)
 declare double @acos(double)
 declare double @atan(double)
@@ -3526,6 +3527,7 @@ entry:
     i32 103, label %builtin_working_directory
     i32 104, label %builtin_getpid
     i32 105, label %builtin_sleep
+    i32 106, label %builtin_gethostname
   ]
 
 builtin_is:
@@ -4827,6 +4829,34 @@ slp.do_sleep:
   %slp.us32 = trunc i64 %slp.us to i32
   call i32 @usleep(i32 %slp.us32)
   ret i1 true
+
+builtin_gethostname:
+  ; M88: gethostname(?Name) -- unifies Name with the host name from
+  ; libc gethostname() as an atom. 256-byte stack buffer is more
+  ; than enough for HOST_NAME_MAX (typically 64 on Linux). Fails
+  ; if gethostname returns non-zero (truncation, errno set).
+  %ghn.buf = alloca [256 x i8]
+  %ghn.buf_ptr = getelementptr [256 x i8], [256 x i8]* %ghn.buf, i32 0, i32 0
+  %ghn.ret = call i32 @gethostname(i8* %ghn.buf_ptr, i64 256)
+  %ghn.ok_call = icmp eq i32 %ghn.ret, 0
+  br i1 %ghn.ok_call, label %ghn.intern, label %ghn.fail
+ghn.fail:
+  ret i1 false
+ghn.intern:
+  ; Copy the buffer into the arena, intern, build atom Value.
+  %ghn.len = call i64 @strlen(i8* %ghn.buf_ptr)
+  call void @wam_arena_ensure()
+  %ghn.bufsize = add i64 %ghn.len, 1
+  %ghn.arena = call i8* @wam_arena_alloc(i64 %ghn.bufsize)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %ghn.arena, i8* %ghn.buf_ptr, i64 %ghn.len, i1 false)
+  %ghn.term = getelementptr i8, i8* %ghn.arena, i64 %ghn.len
+  store i8 0, i8* %ghn.term
+  %ghn.aid = call i64 @wam_intern_atom(i8* %ghn.arena, i64 %ghn.len)
+  %ghn.v0 = insertvalue %Value undef, i32 0, 0
+  %ghn.v = insertvalue %Value %ghn.v0, i64 %ghn.aid, 1
+  %ghn.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %ghn.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %ghn.raw1, %Value %ghn.v)
+  ret i1 %ghn.uok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11082,19 +11112,23 @@ wam_instruction_to_llvm_literal(Instr, Lit) :-
 
 %% emit_functor_string_globals(-IR)
 %  Emits LLVM global constants for functor names collected during WAM
-%  compilation (by put_structure instructions). Each functor "name" becomes
-%  @.fn_name = private constant [N x i8] c"name\00". Byte content is
-%  emitted as per-byte hex escapes (\NN) so functor names containing
-%  ``\'' (e.g. ``/\\'' bitwise-AND, ``\\/'' bitwise-OR) survive LLVM IR
-%  parsing -- a raw ``\\'' would collide with the ``\\00'' null terminator
-%  and produce a [4 x i8] instead of the declared [3 x i8].
+%  compilation (by put_structure instructions). Each functor ``name'' becomes
+%  @.fn_name = private constant [N x i8] c"name\00".
+%
+%  M85: bytes that interact with the trailing ``\00'' null terminator
+%  in LLVM IR string syntax (``\'' and ``"'') are escaped to ``\NN''
+%  per-byte hex. Other bytes are left raw, since string_codes /
+%  maplist / append over every character of every functor string adds
+%  up to a lot of intermediate-list allocation when the same emit
+%  runs hundreds of times in one swipl session (M88 OOM tripped over
+%  this at ~580 modules in).
 emit_functor_string_globals(IR) :-
     findall(GlobalDef,
         ( functor_string_global(NameStr, Len),
           sanitize_functor_for_llvm(NameStr, SaneName),
-          llvm_ir_hex_string(NameStr, HexContent),
+          llvm_ir_string_content(NameStr, SafeContent),
           format(atom(GlobalDef), '@.fn_~w = private constant [~w x i8] c"~w\\00"',
-              [SaneName, Len, HexContent])
+              [SaneName, Len, SafeContent])
         ),
         Defs),
     ( Defs == []
@@ -11102,21 +11136,36 @@ emit_functor_string_globals(IR) :-
     ;  atomic_list_concat(Defs, '\n', IR)
     ).
 
-%% llvm_ir_hex_string(+Str, -HexEscaped)
-%  Re-encode every byte of Str as an LLVM IR hex escape ``\NN'' so the
-%  result can be dropped between c"..." quotes without any character
-%  needing further escaping.
-llvm_ir_hex_string(Str, Hex) :-
-    string_codes(Str, Codes),
-    maplist(byte_to_hex_escape, Codes, EscapedLists),
-    append(EscapedLists, AllCodes),
-    string_codes(Hex, AllCodes).
+%% llvm_ir_string_content(+Str, -Safe)
+%  Wrap Str so it can be dropped between c"..." quotes in LLVM IR.
+%  Fast path: if the input is pure printable ASCII with no ``\'' or
+%  ``"'', it''s already safe -- return as-is. Slow path: escape
+%  problem bytes (and any non-printable ones) to ``\NN'' hex.
+llvm_ir_string_content(Str, Safe) :-
+    ( name_needs_llvm_escape(Str)
+    -> string_codes(Str, Codes),
+       phrase(escape_ir_bytes(Codes), SafeCodes),
+       string_codes(Safe, SafeCodes)
+    ;  Safe = Str
+    ).
 
-byte_to_hex_escape(Byte, [0'\\, H, L]) :-
-    Hi is (Byte >> 4) /\ 0xF,
-    Lo is Byte /\ 0xF,
-    hex_digit(Hi, H),
-    hex_digit(Lo, L).
+name_needs_llvm_escape(Str) :-
+    string_codes(Str, Codes),
+    member(C, Codes),
+    ( C < 32 ; C > 126 ; C =:= 0'\\ ; C =:= 0'" ),
+    !.
+
+escape_ir_bytes([]) --> [].
+escape_ir_bytes([C|Cs]) -->
+    ( { C >= 32, C =< 126, C =\= 0'\\, C =\= 0'" }
+    -> [C]
+    ;  { Hi is (C >> 4) /\ 0xF,
+         Lo is C /\ 0xF,
+         hex_digit(Hi, H),
+         hex_digit(Lo, L) },
+       [0'\\, H, L]
+    ),
+    escape_ir_bytes(Cs).
 
 %% emit_atom_string_globals(-IR)
 %
@@ -11639,6 +11688,7 @@ builtin_op_to_id('shell/2', 102).             % libc system(cmd), Status = WEXIT
 builtin_op_to_id('working_directory/2', 103). % getcwd -> Old; chdir(New) if New atom.
 builtin_op_to_id('getpid/1', 104).            % libc getpid() as Integer.
 builtin_op_to_id('sleep/1', 105).             % libc usleep(seconds * 1e6).
+builtin_op_to_id('gethostname/1', 106).       % libc gethostname() as atom.
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2078,6 +2078,7 @@ is_builtin_pred(shell, 2).              % shell(+Command, -Status).
 is_builtin_pred(working_directory, 2).  % working_directory(?Old, ?New).
 is_builtin_pred(getpid, 1).             % getpid(-Pid).
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
+is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,28 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M88: gethostname/1 -- libc gethostname() wrapper.
+
+:- dynamic test_ghn_nonempty/2.
+test_ghn_nonempty(_, R) :-
+    gethostname(H),
+    atom_length(H, L),
+    ( L > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_ghn_stable/2.
+test_ghn_stable(_, R) :-
+    % Two gethostname calls in the same process must return the
+    % same atom (host name doesn''t change mid-run).
+    gethostname(H1),
+    gethostname(H2),
+    ( H1 == H2 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_ghn_not_empty_atom/2.
+test_ghn_not_empty_atom(_, R) :-
+    % Hostname should not be the empty atom.
+    gethostname(H),
+    ( H \== '' -> R is 1 ; R is 0 ).   % 1
+
 % M87: get_time/1 upgraded to nanosecond precision (clock_gettime).
 
 :- dynamic test_gt87_short_sleep/2.
@@ -2517,19 +2539,19 @@ test_sleep_tiny(_, R) :-
 
 :- dynamic test_sleep_elapsed_float/2.
 test_sleep_elapsed_float(_, R) :-
-    % Verify sleep actually waits. M72 get_time/1 has whole-second
-    % resolution (libc time()), so use sleep(1.0) and floor at 0.5
-    % seconds. Boundary case (T0 captured at S, T1 at S+1) still
-    % gives Diff=1.
+    % M88: tightened from sleep(1.0) -> sleep(0.05) now that M87
+    % gave get_time/1 nanosecond resolution. 50ms wait with a 40ms
+    % floor for slow CI machines.
     get_time(T0),
-    sleep(1.0),
+    sleep(0.05),
     get_time(T1),
     Diff is T1 - T0,
-    ( Diff >= 0.5 -> R is 1 ; R is 0 ).   % 1
+    ( Diff >= 0.04 -> R is 1 ; R is 0 ).   % 1
 
 :- dynamic test_sleep_elapsed_int/2.
 test_sleep_elapsed_int(_, R) :-
-    % Same shape but Integer argument exercising the from_int branch.
+    % Integer-arg branch needs a whole number of seconds; keep
+    % sleep(1) here with the original 0.5s floor.
     get_time(T0),
     sleep(1),
     get_time(T1),
@@ -3723,6 +3745,12 @@ miss:
     catch(delete_file(OPath), _, true),
     catch(delete_file(BinPath), _, true),
     clear_llvm_foreign_kernel_specs,
+    % M88: 600+ run_test invocations in one swipl session accumulate
+    % large IR-string intermediates on the global stack; tripped a 4GB
+    % stack-limit OOM around test_write_rem. Force a GC + trim of
+    % stack/heap between tests to keep memory bounded.
+    garbage_collect,
+    trim_stacks,
     assertion(ExitCode =:= Expected).
 
 % Runner for is/2 predicates: result ends up in A1 (reg 0) due to WAM register layout.
@@ -3811,6 +3839,12 @@ miss:
     catch(delete_file(OPath), _, true),
     catch(delete_file(BinPath), _, true),
     clear_llvm_foreign_kernel_specs,
+    % M88: 600+ run_test invocations in one swipl session accumulate
+    % large IR-string intermediates on the global stack; tripped a 4GB
+    % stack-limit OOM around test_write_rem. Force a GC + trim of
+    % stack/heap between tests to keep memory bounded.
+    garbage_collect,
+    trim_stacks,
     assertion(ExitCode =:= Expected).
 
 test_all :-
@@ -4642,6 +4676,13 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M88 gethostname/1 ---~n'),
+       run_test_r0('gethostname(H), length(H) > 0 -> 1',
+                   test_ghn_nonempty, 0, 1),
+       run_test_r0('gethostname stable across calls -> 1',
+                   test_ghn_stable, 0, 1),
+       run_test_r0('gethostname \\= empty atom -> 1',
+                   test_ghn_not_empty_atom, 0, 1),
        format('--- M87 get_time/1 nanosecond precision ---~n'),
        run_test_r0('sleep(0.05) elapsed in [0.04, 0.5) -> 1',
                    test_gt87_short_sleep, 0, 1),
@@ -4656,7 +4697,7 @@ test_all :-
                    test_sleep_float_zero, 0, 1),
        run_test_r0('sleep(0.001) -> 1',
                    test_sleep_tiny, 0, 1),
-       run_test_r0('sleep(1.0) elapsed >= 0.5 -> 1',
+       run_test_r0('sleep(0.05) elapsed >= 0.04 -> 1 (M87 tightened)',
                    test_sleep_elapsed_float, 0, 1),
        run_test_r0('sleep(1) elapsed >= 0.5 -> 1',
                    test_sleep_elapsed_int, 0, 1),


### PR DESCRIPTION
## Summary

- **M88 `gethostname/1`** — new libc-backed builtin (op id 106). Allocates a 256-byte stack buffer, calls `gethostname`, copies the result into the arena, interns as an atom, and unifies with reg 0. Returns `i1 false` on non-zero return so callers see standard Prolog failure.
- **`emit_functor_string_globals` fast path** — replaces the unconditional per-byte hex encode with a check-then-escape helper. Printable-ASCII functor names (the common case) skip the maplist + append loop and round-trip the string as-is. Names containing `\` or `"` still take the DCG slow path that emits `\NN` per byte, so the M85 `c"...\00"` parsing fix is preserved.
- **Test-suite GC** — `run_test` / `run_test_r0` now call `garbage_collect` + `trim_stacks` after each test. Without this, the execution suite (600+ predicates compiled in one swipl process) accumulates IR-string + parse intermediates on the global stack until SWI's 4 GB stack limit trips around `test_write_rem` in M24 (slot ~580). With the GC, resident set stays in the 1–2 GB band and the run reaches all 600 tests.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — dispatch entry, `gethostname` libc decl, `builtin_gethostname` block, `builtin_op_to_id('gethostname/1', 106)`, functor-string fast path.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred(gethostname, 1)`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — three M88 tests (`test_ghn_nonempty`, `test_ghn_stable`, `test_ghn_not_empty_atom`), `garbage_collect + trim_stacks` in the per-test cleanup.

## Test plan

- [x] Full execution suite: **600/600 PASS**, no OOM (previously OOM at slot 580 in `test_write_rem` with 3.4 GB global stack)
- [x] M88 tests pass: `test_ghn_nonempty` ✓, `test_ghn_stable` ✓, `test_ghn_not_empty_atom` ✓
- [x] RSS bounded ~1–2 GB across the run with peaks ≤4 GB

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_