### PR TITLE
fix(wam-haskell): integer div // and =/2 unification — builtins conformant (Haskell fully green)

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2330,6 +2330,17 @@ step !ctx s (BuiltinCall "is/2" _) =
     (Just (Integer n), Just r) | fromIntegral n == r -> Just (s { wsPC = wsPC s + 1 })
     _ -> Nothing
 
+-- =/2 is term unification (the compiler emits it as a BuiltinCall rather
+-- than inline get/put instructions). Route through unifyVal so it handles
+-- constants, var binding, and full structural unification of compounds
+-- (and advances PC on success). Without this it fell to the default
+-- BuiltinCall branch and always failed (cbi_eq(foo) -> false).
+step !ctx s (BuiltinCall "=/2" _) =
+  case (IM.lookup 1 (wsRegs s), IM.lookup 2 (wsRegs s)) of
+    (Just a, Just b) ->
+      unifyVal (derefVar (wsBindings s) a) (derefVar (wsBindings s) b) s
+    _ -> Nothing
+
 step !ctx s (BuiltinCall "length/2" _) =
   let listVal = derefVar (wsBindings s) $ fromMaybe (VList []) (IM.lookup 1 (wsRegs s))
   in case listVal of
@@ -5083,6 +5094,18 @@ isoMetaBuiltinArity pred = case pred of
 
 -- | Evaluate arithmetic expression. InternTable needed for reverse
 -- lookup of atom strings (numeric atom parsing, operator names).
+-- Strip a trailing "/<arity>" from a functor name (e.g. "+/2" -> "+",
+-- "mod/2" -> "mod"). Must NOT use takeWhile (/= ''/''): operators that
+-- contain ''/'' themselves -- "//" (interns as "///2") and "/" ("//2") --
+-- would be truncated to "", making integer div and float div evaluate to
+-- Nothing and silently failing the whole `is/2` goal.
+bareArithOp :: String -> String
+bareArithOp name =
+  case break (== ''/'') (reverse name) of
+    (revArity, ''/'' : revHead)
+      | not (null revArity) && all (`elem` "0123456789") revArity -> reverse revHead
+    _ -> name
+
 evalArith :: InternTable -> IM.IntMap Value -> Value -> Maybe Double
 evalArith _ _ (Integer n) = Just (fromIntegral n)
 evalArith _ _ (Float f) = Just f
@@ -5091,7 +5114,7 @@ evalArith tbl _ (Atom aid) = case reads (lookupAtom tbl aid) of
   _ -> Nothing
 evalArith tbl bindings (Str opId [a]) = do
   va <- evalArith tbl bindings (derefVar bindings a)
-  let bareOp = takeWhile (/= ''/'') (lookupAtom tbl opId)
+  let bareOp = bareArithOp (lookupAtom tbl opId)
   case bareOp of
     "-" -> Just (negate va)
     "abs" -> Just (abs va)
@@ -5099,7 +5122,7 @@ evalArith tbl bindings (Str opId [a]) = do
 evalArith tbl bindings (Str opId [a, b]) = do
   va <- evalArith tbl bindings (derefVar bindings a)
   vb <- evalArith tbl bindings (derefVar bindings b)
-  let bareOp = takeWhile (/= ''/'') (lookupAtom tbl opId)
+  let bareOp = bareArithOp (lookupAtom tbl opId)
   case bareOp of
     "+" -> Just (va + vb)
     "-" -> Just (va - vb)

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -132,11 +132,17 @@ ct_xfail(wat, builtins).
 %      tail and binds the placeholder var on finalize. This fixed member,
 %      append, AND reverse on lists of any length; the xfails are removed.
 %
-%  builtins remains: =/2 of two identical atoms returns false
-%  (cbi_eq(foo)), and // (integer div) / mod evaluate incorrectly
-%  (cbi_arith). fib/ack pass, so +/-/comparison and is/2 bound-LHS
-%  checking work — these are isolated builtin bugs, not the list path.
-ct_xfail(haskell, builtins).
+%  builtins USED to be xfail (=/2 and //,mod). Both fixed in
+%  wam_haskell_target.pl:
+%   - // (interns as "///2") and / ("//2") evaluated to Nothing because
+%     the arity-stripper used takeWhile (/= '/'), which truncates any
+%     operator that contains '/'. Replaced with bareArithOp, which strips
+%     only a trailing /<digits>. (cbi_arith's 17//5 + 17 mod 5 now folds.)
+%   - =/2 is emitted by the compiler as BuiltinCall "=/2" but had no
+%     handler, so it fell to the default branch and always failed
+%     (cbi_eq(foo) -> false). Added a handler routing through unifyVal.
+%  fib/ack already passed, so +/-/comparison and is/2 bound-LHS checking
+%  were fine; with these two fixes the Haskell adapter is fully green.
 
 %% ct_skip(Target, ProgramName)
 %  Stronger than xfail: do NOT even build/run this (target, program).


### PR DESCRIPTION
## Summary

Closes the **last Haskell conformance xfail** (`builtins`). Two isolated bugs, both fixed in `wam_haskell_target.pl`:

1. **`//` (integer div) and `/` (float div) evaluated to `Nothing`.** `evalArith` stripped the functor's `/<arity>` suffix with `takeWhile (/= '/')`, which truncates any operator that itself contains `/`: `//` interns as `///2` → `""`, `/` as `//2` → `""`. So `D is 17 // 5` failed and took the whole `cbi_arith` clause down (both `28` and `27` returned false). Replaced with `bareArithOp`, which strips only a trailing `/<digits>`, leaving `//`/`/` intact.

2. **`=/2` always failed.** The compiler emits term unification `X = Y` as `BuiltinCall "=/2"`, but there was no handler — it fell through to the default `BuiltinCall` branch and returned `Nothing` (`cbi_eq(foo)` → false). Added a handler that routes `A1`/`A2` through `unifyVal` (constants, var binding, and structural compound unification; advances PC).

`cbi_arith` (`//`, `mod`), `cbi_eq` (`=/2`), and `cbi_cmp` now all pass; `ct_xfail(haskell, builtins)` is removed. **The Haskell adapter is now fully conformant — zero xfails.**

## Verification

- Full opt-in Haskell harness (`CONFORMANCE_TARGETS=haskell`) is **green** with no xfails.
- **No regressions**: `iso_smoke`, lowered phases 2/4 (0 fails); target codegen's 5 failures are pre-existing on `main` (the `F1`/async cases, unrelated).

## Follow-up

WAT remains the open target (read-mode `unify_*` are nops, no S-register / arg queue — `member`/`fib`/`builtins` xfail, `append`/`reverse` skipped). That's the larger runtime-feature track.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_