### PR TITLE
LLVM WAM: cpu_time/1 (M89) -- process CPU time via CLOCK_PROCESS_CPUTIME_ID

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3528,6 +3528,7 @@ entry:
     i32 104, label %builtin_getpid
     i32 105, label %builtin_sleep
     i32 106, label %builtin_gethostname
+    i32 107, label %builtin_cpu_time
   ]
 
 builtin_is:
@@ -4857,6 +4858,30 @@ ghn.intern:
   %ghn.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %ghn.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %ghn.raw1, %Value %ghn.v)
   ret i1 %ghn.uok
+
+builtin_cpu_time:
+  ; M89: cpu_time(?Time) -- process CPU time in seconds as Float, via
+  ; clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts). Same struct timespec
+  ; layout as M87 get_time; only the clock id differs (CLOCK_REALTIME=0
+  ; vs CLOCK_PROCESS_CPUTIME_ID=2 on Linux glibc).
+  %cpu.ts_buf = alloca [16 x i8]
+  %cpu.ts_ptr = getelementptr [16 x i8], [16 x i8]* %cpu.ts_buf, i32 0, i32 0
+  %cpu.cg_ret = call i32 @clock_gettime(i32 2, i8* %cpu.ts_ptr)
+  %cpu.sec_ptr = bitcast i8* %cpu.ts_ptr to i64*
+  %cpu.sec = load i64, i64* %cpu.sec_ptr
+  %cpu.nsec_ptr_i8 = getelementptr i8, i8* %cpu.ts_ptr, i64 8
+  %cpu.nsec_ptr = bitcast i8* %cpu.nsec_ptr_i8 to i64*
+  %cpu.nsec = load i64, i64* %cpu.nsec_ptr
+  %cpu.sec_d = sitofp i64 %cpu.sec to double
+  %cpu.nsec_d = sitofp i64 %cpu.nsec to double
+  %cpu.frac = fdiv double %cpu.nsec_d, 1.000000e+09
+  %cpu.t_d = fadd double %cpu.sec_d, %cpu.frac
+  %cpu.t_bits = bitcast double %cpu.t_d to i64
+  %cpu.v0 = insertvalue %Value undef, i32 2, 0
+  %cpu.v = insertvalue %Value %cpu.v0, i64 %cpu.t_bits, 1
+  %cpu.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %cpu.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %cpu.raw1, %Value %cpu.v)
+  ret i1 %cpu.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11689,6 +11714,7 @@ builtin_op_to_id('working_directory/2', 103). % getcwd -> Old; chdir(New) if New
 builtin_op_to_id('getpid/1', 104).            % libc getpid() as Integer.
 builtin_op_to_id('sleep/1', 105).             % libc usleep(seconds * 1e6).
 builtin_op_to_id('gethostname/1', 106).       % libc gethostname() as atom.
+builtin_op_to_id('cpu_time/1', 107).          % clock_gettime(CLOCK_PROCESS_CPUTIME_ID).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2079,6 +2079,7 @@ is_builtin_pred(working_directory, 2).  % working_directory(?Old, ?New).
 is_builtin_pred(getpid, 1).             % getpid(-Pid).
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
+is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).
 is_builtin_pred(write, 1).  % I/O — useful for runtime instrumentation.
 is_builtin_pred(display, 1).
 is_builtin_pred(nl, 0).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,35 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M89: cpu_time/1 -- process CPU time via clock_gettime(CLOCK_PROCESS_CPUTIME_ID).
+
+:- dynamic test_cpu_nonneg/2.
+test_cpu_nonneg(_, R) :-
+    % A freshly-started process always has cpu_time >= 0.
+    cpu_time(T),
+    ( T >= 0.0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_cpu_monotonic/2.
+test_cpu_monotonic(_, R) :-
+    % CPU time is monotonically non-decreasing within a process.
+    cpu_time(T0),
+    cpu_time(T1),
+    ( T1 >= T0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_cpu_under_wall/2.
+test_cpu_under_wall(_, R) :-
+    % CPU time accrued during a sleep should be much less than the
+    % wall-clock elapsed time -- sleeping doesn''t consume CPU.
+    % 50ms sleep => wall ~0.05s, CPU should be < 0.04s.
+    cpu_time(C0),
+    get_time(W0),
+    sleep(0.05),
+    cpu_time(C1),
+    get_time(W1),
+    CpuDiff is C1 - C0,
+    WallDiff is W1 - W0,
+    ( CpuDiff < WallDiff -> R is 1 ; R is 0 ).   % 1
+
 % M88: gethostname/1 -- libc gethostname() wrapper.
 
 :- dynamic test_ghn_nonempty/2.
@@ -4676,6 +4705,13 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M89 cpu_time/1 ---~n'),
+       run_test_r0('cpu_time(T), T >= 0.0 -> 1',
+                   test_cpu_nonneg, 0, 1),
+       run_test_r0('cpu_time monotonic across calls -> 1',
+                   test_cpu_monotonic, 0, 1),
+       run_test_r0('cpu_time accrued < wall during sleep -> 1',
+                   test_cpu_under_wall, 0, 1),
        format('--- M88 gethostname/1 ---~n'),
        run_test_r0('gethostname(H), length(H) > 0 -> 1',
                    test_ghn_nonempty, 0, 1),


### PR DESCRIPTION
## Summary

- **M89 `cpu_time/1`** — process CPU time (seconds since process start) as a Float, via `clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts)`. New builtin op id 107.
- IR (`builtin_cpu_time`, prefix `cpu.`) is structurally identical to M87's `builtin_get_time`; only the clock id differs (`i32 2` vs `i32 0`). Reuses the already-declared `@clock_gettime` libc import — no new external declarations needed.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — dispatch entry, `builtin_cpu_time` block, `builtin_op_to_id('cpu_time/1', 107)`.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred(cpu_time, 1)`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — three M89 tests + section in `test_all`.

## Test plan

- [x] Full execution suite: **603/603 PASS**, no failures, no OOM
- [x] `test_cpu_nonneg`: `cpu_time(T)` returns `T >= 0.0` ✓
- [x] `test_cpu_monotonic`: two successive `cpu_time` calls satisfy `T1 >= T0` ✓
- [x] `test_cpu_under_wall`: CPU time accrued during `sleep(0.05)` is less than wall-clock elapsed ✓

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_