### PR TITLE
fix(wam-elixir): unify ground list representations

### DIFF
--- a/docs/WAM_CROSS_TARGET_CONFORMANCE.md
+++ b/docs/WAM_CROSS_TARGET_CONFORMANCE.md
@@ -81,7 +81,6 @@ artifact — **Scala passes the whole spec**, which is the reference.
 |---|---|---|---|
 | wat | member | xfail | Read-mode structure/list argument unification is unimplemented (the read-mode branches of `unify_variable`/`unify_value`/`unify_constant` are nops; no S-register), so `get_structure`/`get_list` match only the functor. See `WAM_SWITCH_INDEXING_CROSS_TARGET.md`. |
 | wat | append, reverse | **skip** | A *second*, separate WAT bug: the generator loops re-emitting millions of "unrecognized instruction" warnings on recursive list-**building** predicates, so the project is impractical to write. Skipped (not built) rather than xfail'd. |
-| elixir | append, reverse | xfail | The lowered Elixir backend fails to unify a freshly-constructed list against an already-**ground** compound head argument: `capp([a],[b],[a,b])` returns false, while `capp([a],[b],X), X=[a,b]` succeeds. `member` passes (it only matches an input list). |
 
 `ct_xfail/2` = build and run, tolerate a wrong answer (and log `XPASS` if
 it unexpectedly matches). `ct_skip/2` = do not even build, because
@@ -161,9 +160,8 @@ Open questions a future Haskell adapter must resolve first:
 ### Cross-cutting observation
 
 The divergences the harness has found so far cluster around **matching /
-unifying heap-built compound terms**: WAT (read-mode structure unify
-unimplemented), Elixir (constructed list vs ground compound head arg),
-and the suspected Haskell path all live here. If that turns out to be one
-shared weakness in the lowering rather than N independent backend bugs,
-fixing it once would move several backends toward conformance at the same
-time — a higher-leverage option than wiring up adapters one by one.
+unifying heap-built compound terms**: WAT read-mode structure unify is
+still unimplemented, and the suspected Haskell path may live there too.
+Elixir's earlier constructed-list-vs-ground-head mismatch was fixed by
+treating native `[]` and WAM `"[]"` as equivalent empty-list constants in
+runtime matching, lowered switch dispatch, and unification.

--- a/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_elixir_lowered_emitter.pl
@@ -1096,11 +1096,17 @@ build_switch_arm_group(Suffix, Key-Labels, Arm) :-
         % CP — which points at that same clause — would cause a duplicate
         % solution on backtracking. The inline-dispatched clause pushes
         % its own retry CP, which remains correct.
-        format(string(Arm),
-               '~w -> throw({:return, ~w(%{state | choice_points: tl(state.choice_points)})})',
-               [KeyLit, LocalFunc])
-    ;   format(string(Arm), '~w -> :ok', [KeyLit])
-    ).
+        format(string(Body),
+               'throw({:return, ~w(%{state | choice_points: tl(state.choice_points)})})',
+               [LocalFunc])
+    ;   Body = ':ok'
+    ),
+    build_switch_arm_aliases(Key, KeyLit, Body, Arm).
+
+build_switch_arm_aliases("[]", KeyLit, Body, Arm) :- !,
+    format(string(Arm), '~w -> ~w\n          [] -> ~w', [KeyLit, Body, Body]).
+build_switch_arm_aliases(_, KeyLit, Body, Arm) :-
+    format(string(Arm), '~w -> ~w', [KeyLit, Body]).
 
 segment_func_name("clause_start", "clause_main") :- !.
 segment_func_name(Label, Name) :-
@@ -1631,7 +1637,7 @@ wam_elixir_lower_instr(get_constant(C, AiName), _PC, _Labels, _FuncName, _Suffix
     format(string(Code),
 '    val = Map.get(state.regs, ~w)
     state = cond do
-      val == ~w -> state
+      WamRuntime.constant_match?(val, ~w) -> state
       match?({:unbound, _}, val) ->
         {:unbound, id} = val
         state |> WamRuntime.trail_binding(id) |> WamRuntime.put_reg(id, ~w)

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -118,7 +118,7 @@ wam_elixir_case(get_constant,
 '      {:get_constant, c, ai} ->
         val = Map.get(state.regs, ai)
         cond do
-          val == c ->
+          constant_match?(val, c) ->
             %{state | pc: state.pc + 1}
           match?({:unbound, _}, val) ->
             state
@@ -925,7 +925,8 @@ compile_utility_helpers_to_elixir(Code) :-
       true ->
         # entries is expected to be a list of {key, label} or a map.
         map = if is_map(entries), do: entries, else: Map.new(entries)
-        case Map.get(map, val) do
+        key = constant_lookup_key(val)
+        case Map.get(map, key) do
           "default" -> %{state | pc: if(is_integer(state.pc), do: state.pc + 1, else: state.pc)}
           nil -> :fail
           label -> %{state | pc: resolve_label(state, label)}
@@ -933,10 +934,18 @@ compile_utility_helpers_to_elixir(Code) :-
     end
   end
 
+  def constant_match?("[]", []), do: true
+  def constant_match?([], "[]"), do: true
+  def constant_match?(a, b), do: a == b
+
+  defp constant_lookup_key([]), do: "[]"
+  defp constant_lookup_key(v), do: v
+
   @doc "Unify two WAM values"
   def unify(state, v1, v2) do
     cond do
       v1 == v2 -> {:ok, state}
+      constant_match?(v1, v2) -> {:ok, state}
       match?({:unbound, {:heap_ref, _addr}}, v1) ->
         {:unbound, {:heap_ref, addr}} = v1
         new_heap = Map.put(state.heap, addr, v2)
@@ -957,10 +966,12 @@ compile_utility_helpers_to_elixir(Code) :-
         {:ok, new_state}
       # Structural unification of two compound terms. Both args are
       # {:ref, addr} pointing to {:str, "name/arity"} heap cells.
-      # If functors + arities match, walk arg lists pairwise. Args
-      # are derefd against the LATEST state inside unify_arg_list so
-      # bindings made by earlier arg unifies are visible to later
-      # ones. Partial-fail leaves bindings in the trail; the callers
+      # If functors + arities match, walk arg lists pairwise. The
+      # list functor aliases "./2" and "[|]/2" also count as a match
+      # here, mirroring step_get_structure_ref/4. Args are derefd
+      # against the LATEST state inside unify_arg_list so bindings
+      # made by earlier arg unifies are visible to later ones.
+      # Partial-fail leaves bindings in the trail; the callers
       # choice-point unwinds them via unwind_trail on backtrack —
       # same contract as every other unify branch.
       #
@@ -973,11 +984,15 @@ compile_utility_helpers_to_elixir(Code) :-
         {:ref, addr1} = v1
         {:ref, addr2} = v2
         case {Map.get(state.heap, addr1), Map.get(state.heap, addr2)} do
-          {{:str, fn_name}, {:str, fn_name}} ->
-            arity = parse_functor_arity(fn_name)
-            args1 = heap_slice(state, addr1 + 1, arity)
-            args2 = heap_slice(state, addr2 + 1, arity)
-            unify_arg_list(state, args1, args2)
+          {{:str, fn_name1}, {:str, fn_name2}} ->
+            if step_get_structure_matches?({:str, fn_name1}, fn_name2) do
+              arity = parse_functor_arity(fn_name1)
+              args1 = heap_slice(state, addr1 + 1, arity)
+              args2 = heap_slice(state, addr2 + 1, arity)
+              unify_arg_list(state, args1, args2)
+            else
+              :fail
+            end
           _ -> :fail
         end
       true -> :fail

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -94,16 +94,6 @@ ct_xfail(wat, fib).
 %  backend does not evaluate correctly (returns false). cmp/eq are fine.
 ct_xfail(wat, builtins).
 
-%  Elixir append/reverse: the lowered Elixir backend fails to unify a
-%  freshly-constructed list against an already-GROUND compound argument
-%  in the clause head — e.g. capp([a],[b],[a,b]) (3rd arg ground) returns
-%  false, while capp([a],[b],X), X=[a,b] succeeds. member passes because
-%  it only matches an input list, never constructs+unifies a ground
-%  output. Scala handles both, so this is a genuine backend divergence
-%  the harness surfaced (not a harness artifact).
-ct_xfail(elixir, append).
-ct_xfail(elixir, reverse).
-
 %% ct_skip(Target, ProgramName)
 %  Stronger than xfail: do NOT even build/run this (target, program).
 %  Used when *generation itself* is unusable, not just the answer.

--- a/tests/test_wam_elixir_target.pl
+++ b/tests/test_wam_elixir_target.pl
@@ -2867,6 +2867,41 @@ test_runtime_list_walkers_accept_both_cons_tags :-
     ;   fail_test(Test, 'list walkers do not accept both cons tags')
     ).
 
+test_runtime_empty_list_constant_alias :-
+    Test = 'Runtime: native [] aliases WAM "[]" for constant matching and unification',
+    wam_elixir_target:compile_wam_runtime_to_elixir([], Code),
+    atom_string(Code, S),
+    (   sub_string(S, _, _, _, 'def constant_match?("[]", []), do: true'),
+        sub_string(S, _, _, _, 'def constant_match?([], "[]"), do: true'),
+        sub_string(S, _, _, _, 'constant_match?(v1, v2) -> {:ok, state}')
+    ->  pass(Test)
+    ;   fail_test(Test, 'runtime does not alias native [] and WAM "[]"')
+    ).
+
+test_runtime_structural_unify_aliases_cons_tags :-
+    Test = 'Runtime: structural unification aliases ./2 and [|]/2 cons tags',
+    wam_elixir_target:compile_wam_runtime_to_elixir([], Code),
+    atom_string(Code, S),
+    (   sub_string(S, _, _, _, 'step_get_structure_matches?({:str, fn_name1}, fn_name2)'),
+        sub_string(S, _, _, _, 'args1 = heap_slice(state, addr1 + 1, arity)'),
+        sub_string(S, _, _, _, 'args2 = heap_slice(state, addr2 + 1, arity)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'structural unify still requires identical cons tags')
+    ).
+
+test_lowered_empty_list_constant_alias :-
+    Test = 'Lowering: empty-list constants accept native [] from list destructuring',
+    wam_elixir_lowered_emitter:wam_elixir_lower_instr(get_constant("[]", "A1"), 1, [], p, "clause_main", GetCode),
+    wam_elixir_lowered_emitter:wam_elixir_lower_instr(switch_on_constant(["[]:L_nil"]), 1, [], p, "clause_main", SwitchCode),
+    atom_string(GetCode, GetS),
+    atom_string(SwitchCode, SwitchS),
+    (   sub_string(GetS, _, _, _, 'WamRuntime.constant_match?(val, "[]")'),
+        sub_string(SwitchS, _, _, _, '"[]" -> throw({:return'),
+        sub_string(SwitchS, _, _, _, '[] -> throw({:return')
+    ->  pass(Test)
+    ;   fail_test(Test, 'lowered empty-list constant still rejects native []')
+    ).
+
 %% Backslash-escape regression: `=\=/2` op name must be emitted as
 %  `"=\\=/2"` in the lowered call site so Elixir parses it as the
 %  runtime string `=\=/2` (5 chars). Without escaping, Elixir 1.14+
@@ -2913,13 +2948,13 @@ test_lowered_emits_integer_literals :-
             lower_predicate_to_elixir(int_p/1, WamCode, [module_name('TestMod')], Code),
             atom_string(Code, S),
             % Positive: bare integer literal in head-match comparison.
-            sub_string(S, _, _, _, 'val == 1'),
-            sub_string(S, _, _, _, 'val == 2'),
-            sub_string(S, _, _, _, 'val == 3'),
+            sub_string(S, _, _, _, 'WamRuntime.constant_match?(val, 1)'),
+            sub_string(S, _, _, _, 'WamRuntime.constant_match?(val, 2)'),
+            sub_string(S, _, _, _, 'WamRuntime.constant_match?(val, 3)'),
             % Negative: stringified form must NOT appear.
-            \+ sub_string(S, _, _, _, 'val == "1"'),
-            \+ sub_string(S, _, _, _, 'val == "2"'),
-            \+ sub_string(S, _, _, _, 'val == "3"')
+            \+ sub_string(S, _, _, _, 'constant_match?(val, "1")'),
+            \+ sub_string(S, _, _, _, 'constant_match?(val, "2")'),
+            \+ sub_string(S, _, _, _, 'constant_match?(val, "3")')
         ->  pass(Test)
         ;   fail_test(Test, 'integer constants stringified — head-match would silently fail')
         ),
@@ -3477,6 +3512,9 @@ run_tests :-
     test_runtime_default_arm_throws_unknown_builtin,
     test_lowered_put_structure_links_unbound_heap_ref,
     test_runtime_list_walkers_accept_both_cons_tags,
+    test_runtime_empty_list_constant_alias,
+    test_runtime_structural_unify_aliases_cons_tags,
+    test_lowered_empty_list_constant_alias,
     test_lowered_escapes_backslash_in_builtin_call,
     test_tier2_purity_gate_rejects_unknown,
     test_tier2_purity_gate_accepts_declared,


### PR DESCRIPTION
## Summary

- Treat Elixir native `[]` and WAM `"[]"` as equivalent empty-list constants during runtime constant matching, lowered constant checks, switch dispatch, and unification.
- Allow structural unification to match heap cons cells tagged as either `./2` or `[|]/2`, matching the existing `get_list` behavior.
- Retire the Elixir `append`/`reverse` cross-target conformance xfails and update the conformance docs.

## Verification

- `swipl -q -t halt -s src/unifyweaver/targets/wam_elixir_target.pl`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_elixir_lowered_emitter.pl`
- `swipl -q -s tests/test_wam_elixir_target.pl -g "test_runtime_empty_list_constant_alias,test_runtime_structural_unify_aliases_cons_tags,test_lowered_empty_list_constant_alias,test_lowered_emits_integer_literals,(test_failed->halt(1);halt)" -t "halt(1)"`
- Direct append probe: `capp([a],[b],[a,b])` now returns `true`; `capp([a],[b],[b,a])` remains `false`.
- `env CONFORMANCE_TARGETS=elixir CONFORMANCE_PROGRAMS=append,reverse swipl -q -g "use_module(library(plunit)),consult('tests/test_wam_cross_target_conformance.pl'),run_tests,halt" -t "halt(1)"`
- `env CONFORMANCE_TARGETS=elixir CONFORMANCE_PROGRAMS=member,builtins CONFORMANCE_SAMPLE=2 swipl -q -g "use_module(library(plunit)),consult('tests/test_wam_cross_target_conformance.pl'),run_tests,halt" -t "halt(1)"`
