### PR TITLE
LLVM WAM: random/1 + random_between/3 (M90) via libc drand48/lrand48

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1475,6 +1475,8 @@ declare i32 @chdir(i8*)
 declare i32 @getpid()
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
+declare double @drand48()
+declare i64 @lrand48()
 declare double @asin(double)
 declare double @acos(double)
 declare double @atan(double)
@@ -3529,6 +3531,8 @@ entry:
     i32 105, label %builtin_sleep
     i32 106, label %builtin_gethostname
     i32 107, label %builtin_cpu_time
+    i32 108, label %builtin_random
+    i32 109, label %builtin_random_between
   ]
 
 builtin_is:
@@ -4882,6 +4886,51 @@ builtin_cpu_time:
   %cpu.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %cpu.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %cpu.raw1, %Value %cpu.v)
   ret i1 %cpu.ok
+
+builtin_random:
+  ; M90: random(?X) -- libc drand48() returns double in [0, 1). Pack as
+  ; Float (tag 2). Default seed is 0, so values are deterministic across
+  ; runs unless srand48 is called (not yet exposed).
+  %rnd.d = call double @drand48()
+  %rnd.bits = bitcast double %rnd.d to i64
+  %rnd.v0 = insertvalue %Value undef, i32 2, 0
+  %rnd.v = insertvalue %Value %rnd.v0, i64 %rnd.bits, 1
+  %rnd.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %rnd.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %rnd.raw1, %Value %rnd.v)
+  ret i1 %rnd.ok
+
+builtin_random_between:
+  ; M90: random_between(+L, +H, ?X) -- Integer X in [L, H] inclusive.
+  ; Both bounds must be Integer (tag 1); fails if either is not, or if
+  ; H < L. Implementation: lrand48() % (H - L + 1) + L. The modulo bias
+  ; is acceptable for typical small ranges (Prolog idiom).
+  %rb.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %rb.t1 = extractvalue %Value %rb.a1, 0
+  %rb.is_int1 = icmp eq i32 %rb.t1, 1
+  br i1 %rb.is_int1, label %rb.check2, label %rb.fail
+rb.fail:
+  ret i1 false
+rb.check2:
+  %rb.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %rb.t2 = extractvalue %Value %rb.a2, 0
+  %rb.is_int2 = icmp eq i32 %rb.t2, 1
+  br i1 %rb.is_int2, label %rb.go, label %rb.fail
+rb.go:
+  %rb.lo = extractvalue %Value %rb.a1, 1
+  %rb.hi = extractvalue %Value %rb.a2, 1
+  %rb.le = icmp sle i64 %rb.lo, %rb.hi
+  br i1 %rb.le, label %rb.draw, label %rb.fail
+rb.draw:
+  %rb.range_m1 = sub i64 %rb.hi, %rb.lo
+  %rb.range = add i64 %rb.range_m1, 1
+  %rb.raw = call i64 @lrand48()
+  %rb.mod = srem i64 %rb.raw, %rb.range
+  %rb.x = add i64 %rb.mod, %rb.lo
+  %rb.v0 = insertvalue %Value undef, i32 1, 0
+  %rb.v = insertvalue %Value %rb.v0, i64 %rb.x, 1
+  %rb.raw3 = call %Value @wam_get_reg(%WamState* %vm, i32 2)
+  %rb.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %rb.raw3, %Value %rb.v)
+  ret i1 %rb.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11715,6 +11764,8 @@ builtin_op_to_id('getpid/1', 104).            % libc getpid() as Integer.
 builtin_op_to_id('sleep/1', 105).             % libc usleep(seconds * 1e6).
 builtin_op_to_id('gethostname/1', 106).       % libc gethostname() as atom.
 builtin_op_to_id('cpu_time/1', 107).          % clock_gettime(CLOCK_PROCESS_CPUTIME_ID).
+builtin_op_to_id('random/1', 108).            % libc drand48() in [0, 1) as Float.
+builtin_op_to_id('random_between/3', 109).    % L + lrand48() % (H-L+1).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,26 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M90: random/1 + random_between/3 -- libc drand48 / lrand48 wrappers.
+
+:- dynamic test_rand_in_unit/2.
+test_rand_in_unit(_, R) :-
+    % drand48() result must satisfy 0.0 <= X < 1.0.
+    random(X),
+    ( X >= 0.0, X < 1.0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_rand_between_in_range/2.
+test_rand_between_in_range(_, R) :-
+    % random_between(1, 10, X), 1 <= X <= 10.
+    random_between(1, 10, X),
+    ( X >= 1, X =< 10 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_rand_between_singleton/2.
+test_rand_between_singleton(_, R) :-
+    % random_between(7, 7, X) -- only valid value is 7.
+    random_between(7, 7, X),
+    ( X =:= 7 -> R is 1 ; R is 0 ).   % 1
+
 % M89: cpu_time/1 -- process CPU time via clock_gettime(CLOCK_PROCESS_CPUTIME_ID).
 
 :- dynamic test_cpu_nonneg/2.
@@ -4705,6 +4725,13 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M90 random/1 + random_between/3 ---~n'),
+       run_test_r0('random(X), 0.0 <= X < 1.0 -> 1',
+                   test_rand_in_unit, 0, 1),
+       run_test_r0('random_between(1, 10, X), 1 <= X <= 10 -> 1',
+                   test_rand_between_in_range, 0, 1),
+       run_test_r0('random_between(7, 7, X) =:= 7 -> 1',
+                   test_rand_between_singleton, 0, 1),
        format('--- M89 cpu_time/1 ---~n'),
        run_test_r0('cpu_time(T), T >= 0.0 -> 1',
                    test_cpu_nonneg, 0, 1),


### PR DESCRIPTION
## Summary

- **M90 `random/1`** — wraps libc `drand48()` (returns double in `[0, 1)` by value). Result packed as Float (tag 2). Op id 108.
- **M90 `random_between/3`** — `random_between(+L, +H, ?X)` returns Integer in `[L, H]` inclusive via `L + lrand48() % (H - L + 1)`. Fails on non-integer bounds or `H < L`. Op id 109.

Both predicates were already declared in `wam_target.pl`'s `is_builtin_pred/2` table but the LLVM target had no dispatch entry, so any program calling them was silently falling back to the SWI interpreter. This wires them through end-to-end.

Default seed is 0, giving deterministic output across runs. `srand48` is not exposed yet — tests rely on the deterministic property to assert structural invariants (range bounds) rather than specific values.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `@drand48` + `@lrand48` libc decls, two dispatch entries, `builtin_random` + `builtin_random_between` IR blocks (prefixes `rnd.` / `rb.`), op-id table entries.
- `tests/core/test_wam_llvm_builtin_execution.pl` — three M90 tests + section in `test_all`.

## Test plan

- [x] Full execution suite: **606/606 PASS**, no failures, no OOM
- [x] `test_rand_in_unit`: `random(X)` in `[0.0, 1.0)` ✓
- [x] `test_rand_between_in_range`: `random_between(1, 10, X)` in `[1, 10]` ✓
- [x] `test_rand_between_singleton`: `random_between(7, 7, X) =:= 7` ✓

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_