### PR TITLE
Feat/wam go arithmetic expr coverage

### DIFF
--- a/PR_go_wam_arithmetic_expr_coverage.md
+++ b/PR_go_wam_arithmetic_expr_coverage.md
@@ -1,0 +1,20 @@
+Title: Cover Go WAM arithmetic expressions
+
+Description:
+
+## Summary
+
+- add generated Go WAM E2E coverage for arithmetic expression evaluation through `is/2`
+- cover unary numeric functions, coercion helpers, division/modulo, min/max, exponentiation, bitwise operators, shifts, and evaluator failure cases
+- fix Go string escaping for structure functors in both normal WAM literal emission and lowered Go emission, so operators such as `/\` and `\/` compile correctly
+- update the Go WAM parity audit against the Rust/Haskell arithmetic evaluator baseline
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -13,7 +13,7 @@ current cross-target builtin/runtime baseline.
 | Aggregates | `begin_aggregate`, `end_aggregate`; `collect`, `bag`, `bagof`, `count`, `sum`, `min`, `max`, `set`, `setof` | `findall/3`, `aggregate_all/3` count/sum/min/max/set families | Present for current aggregate baseline |
 | Structural builtins | `member/2`, `memberchk/2`, `select/3`, `delete/3`, `subtract/3`, `intersection/3`, `union/3`, `permutation/2`, `length/2`, `append/3`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, `sum_list/2`, `min_list/2`, `max_list/2`, `list_to_set/2`, `sort/2`, `msort/2`, `keysort/2` | `member/2`, `memberchk/2`, `length/2`; Rust `append/3` is explicitly unimplemented. Clojure/R/C++/LLVM also cover richer list builtins including `select/3`, `delete/3`, `subtract/3`, `intersection/3`, `union/3`, `permutation/2`, `reverse/2`, `last/2`, `nth0/3`, `nth1/3`, `numlist/3`, numeric list reducers, `list_to_set/2`, `sort/2`, `msort/2`, and `keysort/2` | Present for current baseline structural checks, with expanded cross-target list builtins |
 | Type builtins | `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`, `is_list/1`, `ground/1` | Includes `is_list/1` and Clojure direct `ground/1` in the current baseline | Present for current baseline type and groundness checks |
-| Arithmetic builtins | `is/2`, `succ/2`, `between/3` | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir; R/C++ also cover `between/3` | Present for current baseline arithmetic checks, with expanded successor and integer-range coverage |
+| Arithmetic builtins | `is/2`, `succ/2`, `between/3`; expanded arithmetic expression evaluator coverage | Arithmetic evaluation plus sibling-target `succ/2` coverage in Clojure and Elixir; Rust/Haskell cover the common `+`, `-`, `*`, `/`, `//`, `mod`, `**`/`^`, and `abs` evaluator baseline; R/C++ also cover `between/3` | Present for current baseline arithmetic checks, with expanded expression, successor, and integer-range coverage |
 | Atom/text conversion | `atom_number/2`, `atom_codes/2`, `atom_chars/2`, `string_codes/2`, `string_chars/2`, `number_codes/2`, `number_chars/2`, `atom_string/2`, `string_to_atom/2`, `upcase_atom/2`, `downcase_atom/2`, `atom_concat/3`, `atom_length/2`, `string_length/2`, `char_code/2`, `sub_atom/5` forward mode, `char_type/2` forward mode, `string_code/3` forward mode, `split_string/4` forward mode | Clojure direct builtin surface includes bidirectional `atom_number/2`, atom/string/number code-list and char-list conversion, atom/string conversion, atom case conversion, deterministic atom concatenation, text length checks, and char-code conversion | Present for current atom-number, atom/string/number code-list, atom/string/number char-list, atom/string, atom-case, atom-concat, text-length, char-code, forward sub-atom, forward char-type, forward string-code, and forward split-string checks |
 | Comparison builtins | `==/2`, `\==/2`, `\=/2`, `=:=/2`, `=\=/2`, `</2`, `>/2`, `=</2`, `>=/2`, `@</2`, `@=</2`, `@>/2`, `@>=/2`, `compare/3` | Includes `=</2`; Haskell mode analysis and Clojure lowering also cover term-order comparisons | Present for current baseline comparisons, with expanded term-order coverage |
 | Unification builtin | `=/2`, `\=/2` | `=/2`, `\=/2` | Present |
@@ -33,6 +33,13 @@ current cross-target builtin/runtime baseline.
   are now deduplicated like Haskell's `nub` behavior.
 - `member/2` now pushes builtin choice points for later list members, so
   `findall/3` can collect every unifiable element.
+- Go WAM arithmetic expressions are now covered by a generated E2E predicate
+  for unary minus, `abs/1`, `sign/1`, `float/1`, `truncate/1`, `integer/1`,
+  `float_integer_part/1`, division, integer division, modulo, `max/2`,
+  `min/2`, exponentiation, bitwise and/or/xor, shifts, divide-by-zero
+  failure, unbound operand failure, and unknown evaluator failure. This keeps
+  the broader Go arithmetic surface anchored to the Rust/Haskell evaluator
+  baseline before adding more target-specific math.
 - Deterministic `memberchk/2` is now covered by the generated Go WAM builtin
   E2E test, committing to the first unifiable list element without adding
   builtin choice points.

--- a/src/unifyweaver/targets/wam_go_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_go_lowered_emitter.pl
@@ -376,8 +376,9 @@ emit_one(get_value(XnStr, AiStr), I) :-
 
 emit_one(get_structure(FStr, AiStr), I) :-
     go_reg_idx(AiStr, Ai),
+    escape_go_string(FStr, EscapedFunctor),
     format("~w// get_structure ~w, ~w~n", [I, FStr, AiStr]),
-    format("~wif !vm.Step(&GetStructure{Functor: \"~w\", Ai: ~w}) {~n", [I, FStr, Ai]),
+    format("~wif !vm.Step(&GetStructure{Functor: \"~w\", Ai: ~w}) {~n", [I, EscapedFunctor, Ai]),
     format("~w    return false~n", [I]),
     format("~w}~n", [I]).
 
@@ -412,8 +413,9 @@ emit_one(put_value(XnStr, AiStr), I) :-
 
 emit_one(put_structure(FStr, AiStr), I) :-
     go_reg_idx(AiStr, Ai),
+    escape_go_string(FStr, EscapedFunctor),
     format("~w// put_structure ~w, ~w~n", [I, FStr, AiStr]),
-    format("~wif !vm.Step(&PutStructure{Functor: \"~w\", Ai: ~w}) {~n", [I, FStr, Ai]),
+    format("~wif !vm.Step(&PutStructure{Functor: \"~w\", Ai: ~w}) {~n", [I, EscapedFunctor, Ai]),
     format("~w    return false~n", [I]),
     format("~w}~n", [I]).
 

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -595,7 +595,8 @@ wam_instruction_to_go_literal(get_value(Xn, Ai), GoLiteral) :-
     format(atom(GoLiteral), '&GetValue{Xn: ~w, Ai: ~w}', [XnIdx, AiIdx]).
 wam_instruction_to_go_literal(get_structure(F, Ai), GoLiteral) :-
     go_reg_index(Ai, AiIdx),
-    format(atom(GoLiteral), '&GetStructure{Functor: "~w", Ai: ~w}', [F, AiIdx]).
+    escape_go_string(F, EscapedFunctor),
+    format(atom(GoLiteral), '&GetStructure{Functor: "~w", Ai: ~w}', [EscapedFunctor, AiIdx]).
 wam_instruction_to_go_literal(get_list(Ai), GoLiteral) :-
     go_reg_index(Ai, AiIdx),
     format(atom(GoLiteral), '&GetList{Ai: ~w}', [AiIdx]).
@@ -621,7 +622,8 @@ wam_instruction_to_go_literal(put_value(Xn, Ai), GoLiteral) :-
     format(atom(GoLiteral), '&PutValue{Xn: ~w, Ai: ~w}', [XnIdx, AiIdx]).
 wam_instruction_to_go_literal(put_structure(F, Ai), GoLiteral) :-
     go_reg_index(Ai, AiIdx),
-    format(atom(GoLiteral), '&PutStructure{Functor: "~w", Ai: ~w}', [F, AiIdx]).
+    escape_go_string(F, EscapedFunctor),
+    format(atom(GoLiteral), '&PutStructure{Functor: "~w", Ai: ~w}', [EscapedFunctor, AiIdx]).
 wam_instruction_to_go_literal(put_list(Ai), GoLiteral) :-
     go_reg_index(Ai, AiIdx),
     format(atom(GoLiteral), '&PutList{Ai: ~w}', [AiIdx]).
@@ -1228,7 +1230,8 @@ wam_line_to_go_literal(["get_value", Xn, Ai], GoLit) :-
 wam_line_to_go_literal(["get_structure", FN, Ai], GoLit) :-
     clean_comma(FN, CFN), clean_comma(Ai, CAi),
     go_reg_index(CAi, AiIdx),
-    format(atom(GoLit), '&GetStructure{Functor: "~w", Ai: ~w}', [CFN, AiIdx]).
+    escape_go_string(CFN, EscapedFunctor),
+    format(atom(GoLit), '&GetStructure{Functor: "~w", Ai: ~w}', [EscapedFunctor, AiIdx]).
 wam_line_to_go_literal(["get_list", Ai], GoLit) :-
     clean_comma(Ai, CAi),
     go_reg_index(CAi, AiIdx),
@@ -1262,7 +1265,8 @@ wam_line_to_go_literal(["put_value", Xn, Ai], GoLit) :-
 wam_line_to_go_literal(["put_structure", FN, Ai], GoLit) :-
     clean_comma(FN, CFN), clean_comma(Ai, CAi),
     go_reg_index(CAi, AiIdx),
-    format(atom(GoLit), '&PutStructure{Functor: "~w", Ai: ~w}', [CFN, AiIdx]).
+    escape_go_string(CFN, EscapedFunctor),
+    format(atom(GoLit), '&PutStructure{Functor: "~w", Ai: ~w}', [EscapedFunctor, AiIdx]).
 wam_line_to_go_literal(["put_list", Ai], GoLit) :-
     clean_comma(Ai, CAi),
     go_reg_index(CAi, AiIdx),

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -6,6 +6,7 @@
 :- begin_tests(go_wam_builtins).
 
 :- dynamic user:test_builtins/1.
+:- dynamic user:test_arithmetic_expr_builtin/0.
 :- dynamic user:test_term_builtins/0.
 :- dynamic user:test_member_collect/0.
 :- dynamic user:test_memberchk_builtin/0.
@@ -63,6 +64,55 @@ test(builtins_execution) :-
                 nl,
                 atom(foo),
                 \+ atom(5)
+            )),
+          assertz(user:test_arithmetic_expr_builtin :-
+            (   Abs is abs(-7),
+                Abs =:= 7,
+                Neg is -5,
+                Neg =:= -5,
+                SignNeg is sign(-3),
+                SignNeg =:= -1,
+                SignZero is sign(0),
+                SignZero =:= 0,
+                SignPos is sign(3),
+                SignPos =:= 1,
+                FloatVal is float(3),
+                FloatVal =:= 3,
+                Trunc is truncate(3.9),
+                Trunc =:= 3,
+                IntegerVal is integer(4.8),
+                IntegerVal =:= 4,
+                FloatIntegerPart is float_integer_part(5.7),
+                FloatIntegerPart =:= 5,
+                Div is 7 / 2,
+                Div =:= 3.5,
+                IntDiv is 7 // 2,
+                IntDiv =:= 3,
+                Mod is 7 mod 3,
+                Mod =:= 1,
+                Max is max(4, 9),
+                Max =:= 9,
+                Min is min(4, 9),
+                Min =:= 4,
+                PowA is 2 ** 3,
+                PowA =:= 8,
+                PowB is 2 ^ 4,
+                PowB =:= 16,
+                And is 6 /\ 3,
+                And =:= 2,
+                Or is 4 \/ 1,
+                Or =:= 5,
+                Xor is 6 xor 3,
+                Xor =:= 5,
+                ShiftRight is 16 >> 2,
+                ShiftRight =:= 4,
+                ShiftLeft is 3 << 2,
+                ShiftLeft =:= 12,
+                \+ (_ is 1 / 0),
+                \+ (_ is 1 // 0),
+                \+ (_ is 1 mod 0),
+                \+ (_ is _ + 1),
+                \+ (_ is unknown(1))
             )),
           assertz(user:test_term_builtins :-
             (   functor(f(a, 7), F, A),
@@ -610,6 +660,7 @@ test(builtins_execution) :-
         ),
         run_builtins_test(TmpDir),
         ( retractall(user:test_builtins(_)),
+          retractall(user:test_arithmetic_expr_builtin),
           retractall(user:test_term_builtins),
           retractall(user:test_member_collect),
           retractall(user:test_memberchk_builtin),
@@ -656,7 +707,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_tab_builtin/0, test_env_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_arithmetic_expr_builtin/0, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_tab_builtin/0, test_env_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -764,6 +815,14 @@ func main() {
 		fmt.Printf("SUCCESS: X=%v\\n", vm.Deref(x))
 	} else {
 		fmt.Println("FAILURE")
+	}
+
+	arithVM := wam.NewWamState(wam.Test_arithmetic_expr_builtinCode, wam.Test_arithmetic_expr_builtinLabels)
+	arithVM.PC = wam.Test_arithmetic_expr_builtinStartPC
+	if arithVM.Run() {
+		fmt.Println("ARITH_EXPR_SUCCESS")
+	} else {
+		fmt.Println("ARITH_EXPR_FAILURE")
 	}
 
 	termVM := wam.NewWamState(wam.Test_term_builtinsCode, wam.Test_term_builtinsLabels)
@@ -1112,6 +1171,7 @@ func main() {
         assertion(Exit == exit(0)),
         assertion(sub_string(FullOutput, _, _, _, "ok")),
         assertion(sub_string(FullOutput, _, _, _, "SUCCESS: X=3")),
+        assertion(sub_string(FullOutput, _, _, _, "ARITH_EXPR_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "TERM_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "MEMBER_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "MEMBERCHK_SUCCESS")),


### PR DESCRIPTION
# Cover Go WAM arithmetic expressions

## Summary

- add generated Go WAM E2E coverage for arithmetic expression evaluation through `is/2`
- cover unary numeric functions, coercion helpers, division/modulo, min/max, exponentiation, bitwise operators, shifts, and evaluator failure cases
- fix Go string escaping for structure functors in both normal WAM literal emission and lowered Go emission, so operators such as `/\` and `\/` compile correctly
- update the Go WAM parity audit against the Rust/Haskell arithmetic evaluator baseline

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `git diff --check`
