### PR TITLE
LLVM WAM: format_time/3 (M91) via libc strftime + localtime_r

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1477,6 +1477,8 @@ declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
 declare i64 @lrand48()
+declare i8* @localtime_r(i64*, i8*)
+declare i64 @strftime(i8*, i64, i8*, i8*)
 declare double @asin(double)
 declare double @acos(double)
 declare double @atan(double)
@@ -3533,6 +3535,7 @@ entry:
     i32 107, label %builtin_cpu_time
     i32 108, label %builtin_random
     i32 109, label %builtin_random_between
+    i32 110, label %builtin_format_time
   ]
 
 builtin_is:
@@ -4931,6 +4934,65 @@ rb.draw:
   %rb.raw3 = call %Value @wam_get_reg(%WamState* %vm, i32 2)
   %rb.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %rb.raw3, %Value %rb.v)
   ret i1 %rb.ok
+
+builtin_format_time:
+  ; M91: format_time(?Atom, +Format, +Stamp) -- Stamp is the get_time-
+  ; style epoch seconds (Integer or Float), Format is a strftime atom
+  ; (e.g. ``%Y-%m-%d %H:%M:%S''), result Atom is the rendered string.
+  ; Pipeline: time_t = (i64)Stamp -> localtime_r(&t, &tm) ->
+  ; strftime(buf, 256, fmt, &tm) -> intern buf as atom -> unify.
+  ; struct tm on x86-64 glibc is 56 bytes; alloca 64 for headroom.
+  %ft.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %ft.t2 = extractvalue %Value %ft.a2, 0
+  %ft.fmt_is_atom = icmp eq i32 %ft.t2, 0
+  br i1 %ft.fmt_is_atom, label %ft.have_fmt, label %ft.fail
+ft.fail:
+  ret i1 false
+ft.have_fmt:
+  %ft.fmt_aid = extractvalue %Value %ft.a2, 1
+  %ft.fmt_str = call i8* @wam_atom_to_string(i64 %ft.fmt_aid)
+  %ft.fmt_null = icmp eq i8* %ft.fmt_str, null
+  br i1 %ft.fmt_null, label %ft.fail, label %ft.read_stamp
+ft.read_stamp:
+  %ft.a3 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 2)
+  %ft.t3 = extractvalue %Value %ft.a3, 0
+  %ft.is_int = icmp eq i32 %ft.t3, 1
+  br i1 %ft.is_int, label %ft.from_int, label %ft.maybe_float
+ft.from_int:
+  %ft.t_int = extractvalue %Value %ft.a3, 1
+  br label %ft.have_time
+ft.maybe_float:
+  %ft.is_float = icmp eq i32 %ft.t3, 2
+  br i1 %ft.is_float, label %ft.from_float, label %ft.fail
+ft.from_float:
+  %ft.bits = extractvalue %Value %ft.a3, 1
+  %ft.d = bitcast i64 %ft.bits to double
+  %ft.t_flt = fptosi double %ft.d to i64
+  br label %ft.have_time
+ft.have_time:
+  %ft.time_t = phi i64 [ %ft.t_int, %ft.from_int ],
+                       [ %ft.t_flt, %ft.from_float ]
+  ; Stack-alloc time_t cell + struct tm cell.
+  %ft.tp = alloca i64
+  store i64 %ft.time_t, i64* %ft.tp
+  %ft.tp_i8 = bitcast i64* %ft.tp to i8*
+  %ft.tm_buf = alloca [64 x i8]
+  %ft.tm_ptr = getelementptr [64 x i8], [64 x i8]* %ft.tm_buf, i32 0, i32 0
+  %ft.lt = call i8* @localtime_r(i64* %ft.tp, i8* %ft.tm_ptr)
+  %ft.lt_null = icmp eq i8* %ft.lt, null
+  br i1 %ft.lt_null, label %ft.fail, label %ft.do_strftime
+ft.do_strftime:
+  ; Render into a 256-byte arena buffer. Most strftime patterns fit
+  ; comfortably; truncation just means a shorter atom.
+  call void @wam_arena_ensure()
+  %ft.out = call i8* @wam_arena_alloc(i64 256)
+  %ft.len = call i64 @strftime(i8* %ft.out, i64 256, i8* %ft.fmt_str, i8* %ft.tm_ptr)
+  %ft.aid = call i64 @wam_intern_atom(i8* %ft.out, i64 %ft.len)
+  %ft.v0 = insertvalue %Value undef, i32 0, 0
+  %ft.v = insertvalue %Value %ft.v0, i64 %ft.aid, 1
+  %ft.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %ft.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %ft.raw1, %Value %ft.v)
+  ret i1 %ft.uok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11766,6 +11828,7 @@ builtin_op_to_id('gethostname/1', 106).       % libc gethostname() as atom.
 builtin_op_to_id('cpu_time/1', 107).          % clock_gettime(CLOCK_PROCESS_CPUTIME_ID).
 builtin_op_to_id('random/1', 108).            % libc drand48() in [0, 1) as Float.
 builtin_op_to_id('random_between/3', 109).    % L + lrand48() % (H-L+1).
+builtin_op_to_id('format_time/3', 110).       % strftime(Fmt, localtime(Stamp)).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,35 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M91: format_time/3 -- libc strftime + localtime_r wrapper.
+
+:- dynamic test_ft_year/2.
+test_ft_year(_, R) :-
+    % format_time(?Atom, +Fmt, +Stamp) -- direct atom output. Stamp
+    % 1609459200 = 2021-01-01 00:00:00 UTC; with timezone offset the
+    % calendar year is 2020 or 2021, so length-of-year = 4.
+    Stamp is 1609459200,
+    format_time(Y, '%Y', Stamp),
+    atom_length(Y, L),
+    ( L =:= 4 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_ft_iso_len/2.
+test_ft_iso_len(_, R) :-
+    % '%Y-%m-%d %H:%M:%S' renders as 19 chars regardless of timezone.
+    Stamp is 1700000000,
+    format_time(S, '%Y-%m-%d %H:%M:%S', Stamp),
+    atom_length(S, L),
+    ( L =:= 19 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_ft_float_stamp/2.
+test_ft_float_stamp(_, R) :-
+    % Float Stamp must also work -- the fractional part is dropped to
+    % whole-second precision before localtime_r.
+    Stamp is 1700000000.5,
+    format_time(S, '%S', Stamp),
+    atom_length(S, L),
+    ( L =:= 2 -> R is 1 ; R is 0 ).   % 1
+
 % M90: random/1 + random_between/3 -- libc drand48 / lrand48 wrappers.
 
 :- dynamic test_rand_in_unit/2.
@@ -4725,6 +4754,13 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M91 format_time/3 ---~n'),
+       run_test_r0('format_time(Y, ''%Y'', stamp), len(Y) = 4 -> 1',
+                   test_ft_year, 0, 1),
+       run_test_r0('format_time(S, ISO, stamp), len(S) = 19 -> 1',
+                   test_ft_iso_len, 0, 1),
+       run_test_r0('format_time(S, ''%S'', Float stamp), len(S) = 2 -> 1',
+                   test_ft_float_stamp, 0, 1),
        format('--- M90 random/1 + random_between/3 ---~n'),
        run_test_r0('random(X), 0.0 <= X < 1.0 -> 1',
                    test_rand_in_unit, 0, 1),


### PR DESCRIPTION
## Summary

- **M91 `format_time/3`** — wraps libc `localtime_r` + `strftime` to render a Unix epoch timestamp as an atom via a `strftime(3)` format string.

Implements the simpler `format_time(?Atom, +Format, +Stamp)` shape (direct atom result), not SWI's `atom(X)`/`string(X)` sink-compound form. `Stamp` accepts both `Integer` and `Float` — `Float` is `fptosi`-truncated to whole-second `time_t` before `localtime_r`. Non-numeric `Stamp` or non-atom `Format` causes failure.

Op id 110.

## Pipeline (`builtin_format_time`, prefix `ft.`)

1. Read atom-tagged `Format` from reg 1.
2. Read `Integer` or `Float` `Stamp` from reg 2; phi-converge on a single `i64` `time_t`.
3. Stack-alloc the `time_t` cell and a 64-byte `struct tm` buffer (glibc layout is 56 bytes — 64 is safe headroom).
4. `localtime_r(&time_t, &tm)`. NULL return → fail.
5. Arena-alloc a 256-byte output buffer, `strftime` into it. Length comes from the `strftime` return; truncation just gives a shorter atom.
6. Intern as atom, unify with reg 0.

Declares `@localtime_r` and `@strftime` alongside the other libc imports.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — two new libc decls, dispatch entry, `builtin_format_time` block, op-id table entry.
- `tests/core/test_wam_llvm_builtin_execution.pl` — three M91 tests + section in `test_all`.

## Test plan

- [x] Full execution suite: **609/609 PASS**, no failures, no OOM
- [x] `test_ft_year`: `format_time(Y, '%Y', stamp)` → 4-char atom (timezone-agnostic) ✓
- [x] `test_ft_iso_len`: `format_time(S, '%Y-%m-%d %H:%M:%S', stamp)` → 19-char atom ✓
- [x] `test_ft_float_stamp`: `Float` stamp truncates correctly, `'%S'` → 2-char atom ✓

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_