### PR TITLE
fix(wam-scala): resolve mustache templates relative to source, not cwd

### DIFF
--- a/src/unifyweaver/targets/wam_scala_target.pl
+++ b/src/unifyweaver/targets/wam_scala_target.pl
@@ -1370,13 +1370,22 @@ write_file(Path, Content) :-
     ).
 
 %% find_template(+RelPath, -Template) is det.
-%  Locates a template file relative to the UnifyWeaver project root.
+%  Locates a template file relative to the UnifyWeaver project root,
+%  derived from THIS module's source location so it works regardless of
+%  the current working directory. The previous version called
+%  source_file(wam_scala_target, _) -- a bare module atom, which is a
+%  predicate Head (wam_scala_target/0, undefined), so the lookup failed
+%  and silently fell back to the cwd-relative path. It also walked up
+%  only three directories (to .../src), not four (the repo root). Both
+%  meant templates were found ONLY when the cwd was the repo root (e.g.
+%  the conformance harness, cwd=tests/, could not build Scala at all).
 find_template(RelPath, Template) :-
-    (   source_file(wam_scala_target, SrcFile)
-    ->  file_directory_name(SrcFile, SrcDir),
-        file_directory_name(SrcDir, TargetsDir),
-        file_directory_name(TargetsDir, UnifyWeaverDir),
-        atomic_list_concat([UnifyWeaverDir, '/', RelPath], AbsPath)
+    (   source_file(find_template(_, _), SrcFile)
+    ->  file_directory_name(SrcFile, SrcDir),        % .../src/unifyweaver/targets
+        file_directory_name(SrcDir, UWDir),          % .../src/unifyweaver
+        file_directory_name(UWDir, SrcRoot),         % .../src
+        file_directory_name(SrcRoot, ProjectRoot),   % .../  (repo root)
+        atomic_list_concat([ProjectRoot, '/', RelPath], AbsPath)
     ;   AbsPath = RelPath
     ),
     read_file_to_string(AbsPath, Template, []).


### PR DESCRIPTION
## Summary

The Scala target's `find_template` located its mustache templates via `source_file(wam_scala_target, SrcFile)` — but a **bare module atom is a predicate Head** (`wam_scala_target/0`, undefined), so `source_file/2` failed and the code silently fell back to the **cwd-relative** `RelPath`. It also walked up only **three** directories (to `.../src`) instead of four (the repo root).

So templates resolved **only when the process cwd was the repo root**. Run from anywhere else (e.g. the cross-target conformance harness, cwd=`tests/`) every Scala build failed with:

```
existence_error(source_sink, templates/targets/scala_wam/build.sbt.mustache)
```

This is the same class of bug as the WAT template-path fix (#2741), surfaced while verifying that PR.

## Fix

Use `source_file(find_template(_,_), SrcFile)` (a real predicate of this module) and walk up **four** levels to the project root — the same source-anchored pattern `wam_fsharp_target.pl` and the WAT target already use.

## Verification

- Scala conformance (`member`) now builds and passes from cwd=`tests/` (previously failed) **and** the repo root.
- `test_wam_scala_generator`: **18/18** from both cwds.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_