### PR TITLE
Apply demand filtering and article-based seeds to Rust and Go benchmarks

### DIFF
--- a/examples/benchmark/run_cross_target_benchmark.sh
+++ b/examples/benchmark/run_cross_target_benchmark.sh
@@ -103,7 +103,7 @@ fi
 # Rust
 RUST_BIN=""
 if [ -n "${RUST_DIR:-}" ] && [ -f "$RUST_DIR/Cargo.toml" ]; then
-    if [ ! -f "$RUST_DIR/target/release/wam-rust-bench" ] && [ ! -f "$RUST_DIR/target/release/main" ]; then
+    if [ ! -f "$RUST_DIR/target/release/bench" ] && [ ! -f "$RUST_DIR/target/release/wam-rust-bench" ] && [ ! -f "$RUST_DIR/target/release/main" ]; then
         echo -n "  Building Rust... "
         BUILD_START=$(date +%s%N)
         (cd "$RUST_DIR" && cargo build --release 2>&1 | tail -1) || {
@@ -116,7 +116,7 @@ if [ -n "${RUST_DIR:-}" ] && [ -f "$RUST_DIR/Cargo.toml" ]; then
         echo "  Rust binary cached"
     fi
     # Find the binary
-    for name in wam-rust-bench main; do
+    for name in bench wam-rust-bench main; do
         if [ -f "$RUST_DIR/target/release/$name" ]; then
             RUST_BIN="$RUST_DIR/target/release/$name"
             break

--- a/examples/benchmark/run_cross_target_benchmark.sh
+++ b/examples/benchmark/run_cross_target_benchmark.sh
@@ -157,7 +157,7 @@ run_benchmark() {
     for i in $(seq 1 $REPS); do
         local stdout_file="$OUTPUT_DIR/${name}_run${i}.tsv"
         local stderr_file="$OUTPUT_DIR/${name}_run${i}.stderr"
-        eval "$cmd" "$data_arg" > "$stdout_file" 2> "$stderr_file" || true
+        LANG=C.utf8 LC_ALL=C.utf8 eval "$cmd" "$data_arg" > "$stdout_file" 2> "$stderr_file" || true
         local qms=$(grep 'query_ms=' "$stderr_file" 2>/dev/null | sed 's/query_ms=//')
         local tms=$(grep 'total_ms=' "$stderr_file" 2>/dev/null | sed 's/total_ms=//')
         times+=("${qms:-?}")

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -172,28 +172,14 @@ var _ = fmt.Sprintf
     ;   true
     ),
 
-    % Generate main.go with RunParallel when parallel(true)
-    (   option(parallel(true), Options)
-    ->  (   PackageName == main
-        ->  format(atom(MainContent),
-'package main
-
-import "fmt"
-
-func main() {
-	ctx := NewWamContext(SharedWamCode, SharedWamLabels)
-	seeds := [][]Value{
-		{&Atom{Name: "query"}},
-	}
-	results := RunParallel(ctx, seeds, 0)
-	for i, res := range results {
-		if res != nil {
-			fmt.Printf("Seed %%d: %%v\\n", i, res)
-		}
-	}
-}
-', [])
-        ;   format(atom(MainContent),
+    % Generate main.go benchmark harness from template (when package is main)
+    (   PackageName == main
+    ->  read_template_file('templates/targets/go_wam/main_bench.go.mustache', MainTemplate),
+        render_template(MainTemplate, [package_name=PackageName], MainContent),
+        directory_file_path(ProjectDir, 'main.go', MainPath),
+        write_file(MainPath, MainContent)
+    ;   option(parallel(true), Options)
+    ->  format(atom(MainContent),
 'package main
 
 import (
@@ -213,8 +199,7 @@ func main() {
 		}
 	}
 }
-', [ModuleName, PackageName, PackageName, PackageName, PackageName, PackageName, PackageName])
-        ),
+', [ModuleName, PackageName, PackageName, PackageName, PackageName, PackageName, PackageName]),
         directory_file_path(ProjectDir, 'main.go', MainPath),
         write_file(MainPath, MainContent)
     ;   true
@@ -1776,6 +1761,17 @@ wam_go_case('Call', '        vm.CP = vm.PC + 1
             vm.PC = pc
             return true
         }
+        if _, ok := vm.Ctx.ForeignNativeKinds[i.Pred]; ok {
+            if vm.executeForeignPredicate(i.Pred, i.Arity) {
+                vm.PC = vm.CP
+                return true
+            }
+            return false
+        }
+        if vm.executeIndexedAtomFact2(i.Pred) {
+            vm.PC = vm.CP
+            return true
+        }
         return false').
 
 wam_go_case('CallForeign', '        return vm.executeForeignPredicate(i.Pred, i.Arity)').
@@ -1790,7 +1786,10 @@ wam_go_case('Execute', '        if pc, ok := vm.Ctx.Labels[i.Pred]; ok {
             vm.PC = pc
             return true
         }
-        return false').
+        if _, ok := vm.Ctx.ForeignNativeKinds[i.Pred]; ok {
+            return vm.executeForeignPredicate(i.Pred, 0)
+        }
+        return vm.executeIndexedAtomFact2(i.Pred)').
 
 wam_go_case('ExecutePc', '        vm.PC = i.TargetPC
         return true').

--- a/templates/targets/go_wam/main_bench.go.mustache
+++ b/templates/targets/go_wam/main_bench.go.mustache
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+func loadTsvPairs(path string) []AtomPair {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	var pairs []AtomPair
+	scanner := bufio.NewScanner(f)
+	first := true
+	for scanner.Scan() {
+		if first {
+			first = false
+			continue
+		}
+		cols := strings.SplitN(scanner.Text(), "\t", 3)
+		if len(cols) >= 2 {
+			pairs = append(pairs, AtomPair{Left: cols[0], Right: cols[1]})
+		}
+	}
+	return pairs
+}
+
+func loadSingleColumn(path string) []string {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	var vals []string
+	scanner := bufio.NewScanner(f)
+	first := true
+	for scanner.Scan() {
+		if first {
+			first = false
+			continue
+		}
+		s := strings.TrimSpace(scanner.Text())
+		if s != "" {
+			vals = append(vals, s)
+		}
+	}
+	return vals
+}
+
+func collectSolutions(ctx *WamContext, pc int, cat, root string, negN float64) float64 {
+	vm := NewWamStateFromCtx(ctx)
+	setupSharedForeignPredicates(vm)
+	vm.PC = pc
+	vm.Regs[0] = internAtom(cat)
+	vm.Regs[1] = internAtom(root)
+	vm.Regs[2] = &Unbound{Name: "_Hops", Idx: 1000000}
+	vm.Regs[3] = &List{Elements: []Value{internAtom(cat)}}
+	vm.CP = 0
+
+	var weightSum float64
+	for {
+		if !vm.Run() {
+			break
+		}
+		v := vm.getReg(2)
+		if v != nil {
+			v = vm.deref(v)
+			switch val := v.(type) {
+			case *Integer:
+				weightSum += math.Pow(float64(val.Val)+1.0, negN)
+			case *Float:
+				weightSum += math.Pow(val.Val+1.0, negN)
+			}
+		}
+		if !vm.backtrack() {
+			break
+		}
+	}
+	return weightSum
+}
+
+func main() {
+	factsDir := "."
+	if len(os.Args) > 1 {
+		factsDir = os.Args[1]
+	}
+
+	t0 := time.Now()
+
+	categoryParents := loadTsvPairs(factsDir + "/category_parent.tsv")
+	articleCategories := loadTsvPairs(factsDir + "/article_category.tsv")
+	roots := loadSingleColumn(factsDir + "/root_categories.tsv")
+
+	ctx := NewWamContext(SharedWamCode, SharedWamLabels)
+
+	vm := NewWamStateFromCtx(ctx)
+	setupSharedForeignPredicates(vm)
+	vm.registerIndexedAtomFact2Pairs("category_parent/2", categoryParents)
+
+	root := ""
+	if len(roots) > 0 {
+		root = roots[0]
+	}
+
+	seedSet := make(map[string]bool)
+	for _, p := range categoryParents {
+		seedSet[p.Left] = true
+	}
+	seedCats := make([]string, 0, len(seedSet))
+	for k := range seedSet {
+		seedCats = append(seedCats, k)
+	}
+	sort.Strings(seedCats)
+
+	n := 5.0
+	if pc, ok := SharedWamLabels["dimension_n/1"]; ok {
+		nvm := NewWamStateFromCtx(ctx)
+		nvm.PC = pc
+		nvm.Regs[0] = &Unbound{Name: "_N", Idx: 999999}
+		if nvm.Run() {
+			v := nvm.deref(nvm.getReg(0))
+			switch val := v.(type) {
+			case *Integer:
+				n = float64(val.Val)
+			case *Float:
+				n = val.Val
+			}
+		}
+	}
+	negN := -n
+
+	loadMs := time.Since(t0).Milliseconds()
+
+	t2 := time.Now()
+
+	caPC, hasCA := SharedWamLabels["category_ancestor/4"]
+	seedWeightSums := make(map[string]float64)
+
+	if hasCA {
+		for _, cat := range seedCats {
+			ws := collectSolutions(ctx, caPC, cat, root, negN)
+			if ws > 0 {
+				seedWeightSums[cat] = ws
+			}
+		}
+	}
+
+	queryMs := time.Since(t2).Milliseconds()
+
+	t3 := time.Now()
+
+	invN := -1.0 / n
+	articleSums := make(map[string]float64)
+	for _, ac := range articleCategories {
+		ws := 0.0
+		if ac.Right == root {
+			ws = 1.0
+		}
+		catWs := seedWeightSums[ac.Right]
+		articleSums[ac.Left] += ws + catWs
+	}
+
+	type result struct {
+		deff    float64
+		article string
+	}
+	var results []result
+	for art, ws := range articleSums {
+		if ws > 0 {
+			results = append(results, result{math.Pow(ws, invN), art})
+		}
+	}
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].deff != results[j].deff {
+			return results[i].deff < results[j].deff
+		}
+		return results[i].article < results[j].article
+	})
+
+	aggMs := time.Since(t3).Milliseconds()
+	totalMs := time.Since(t0).Milliseconds()
+
+	w := bufio.NewWriter(os.Stdout)
+	fmt.Fprintln(w, "article\troot_category\teffective_distance")
+	for _, r := range results {
+		fmt.Fprintf(w, "%s\t%s\t%.6f\n", r.article, root, r.deff)
+	}
+	w.Flush()
+
+	fmt.Fprintf(os.Stderr, "mode=wam_go_bench\n")
+	fmt.Fprintf(os.Stderr, "load_ms=%d\n", loadMs)
+	fmt.Fprintf(os.Stderr, "query_ms=%d\n", queryMs)
+	fmt.Fprintf(os.Stderr, "aggregation_ms=%d\n", aggMs)
+	fmt.Fprintf(os.Stderr, "total_ms=%d\n", totalMs)
+	fmt.Fprintf(os.Stderr, "seed_count=%d\n", len(seedCats))
+	fmt.Fprintf(os.Stderr, "tuple_count=%d\n", len(seedWeightSums))
+	fmt.Fprintf(os.Stderr, "article_count=%d\n", len(results))
+}

--- a/templates/targets/go_wam/main_bench.go.mustache
+++ b/templates/targets/go_wam/main_bench.go.mustache
@@ -86,6 +86,32 @@ func collectSolutions(ctx *WamContext, pc int, cat, root string, negN float64) f
 	return weightSum
 }
 
+func computeReachableToRoot(root string, reverseIndex map[string][]string, maxDepth int) map[string]bool {
+	reachable := make(map[string]bool)
+	bestDepth := make(map[string]int)
+	type entry struct {
+		node  string
+		depth int
+	}
+	queue := []entry{{root, 0}}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if prev, ok := bestDepth[cur.node]; ok && cur.depth >= prev {
+			continue
+		}
+		bestDepth[cur.node] = cur.depth
+		reachable[cur.node] = true
+		if cur.depth >= maxDepth {
+			continue
+		}
+		for _, child := range reverseIndex[cur.node] {
+			queue = append(queue, entry{child, cur.depth + 1})
+		}
+	}
+	return reachable
+}
+
 func main() {
 	factsDir := "."
 	if len(os.Args) > 1 {
@@ -98,20 +124,33 @@ func main() {
 	articleCategories := loadTsvPairs(factsDir + "/article_category.tsv")
 	roots := loadSingleColumn(factsDir + "/root_categories.tsv")
 
-	ctx := NewWamContext(SharedWamCode, SharedWamLabels)
-
-	vm := NewWamStateFromCtx(ctx)
-	setupSharedForeignPredicates(vm)
-	vm.registerIndexedAtomFact2Pairs("category_parent/2", categoryParents)
-
 	root := ""
 	if len(roots) > 0 {
 		root = roots[0]
 	}
+	const maxDepthLimit = 10
+
+	reverseIndex := make(map[string][]string)
+	for _, p := range categoryParents {
+		reverseIndex[p.Right] = append(reverseIndex[p.Right], p.Left)
+	}
+	reachableToRoot := computeReachableToRoot(root, reverseIndex, maxDepthLimit)
+	var filteredEdges []AtomPair
+	for _, p := range categoryParents {
+		if reachableToRoot[p.Right] {
+			filteredEdges = append(filteredEdges, p)
+		}
+	}
+
+	ctx := NewWamContext(SharedWamCode, SharedWamLabels)
+
+	vm := NewWamStateFromCtx(ctx)
+	setupSharedForeignPredicates(vm)
+	vm.registerIndexedAtomFact2Pairs("category_parent/2", filteredEdges)
 
 	seedSet := make(map[string]bool)
-	for _, p := range categoryParents {
-		seedSet[p.Left] = true
+	for _, ac := range articleCategories {
+		seedSet[ac.Right] = true
 	}
 	seedCats := make([]string, 0, len(seedSet))
 	for k := range seedSet {

--- a/templates/targets/rust_wam/main.rs.mustache
+++ b/templates/targets/rust_wam/main.rs.mustache
@@ -2,7 +2,7 @@
 // Benchmark harness for effective-distance workload
 // Date: {{date}}
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::env;
 use std::fs;
 use std::io::{self, Write};
@@ -33,25 +33,32 @@ fn load_single_column(path: &str) -> Vec<String> {
         .collect()
 }
 
-fn collect_solutions(vm: &mut WamState) -> Vec<f64> {
-    let mut results = Vec::new();
-    loop {
-        if !vm.run() {
-            break;
-        }
-        if let Some(val) = vm.get_reg("A3") {
-            let derefed = vm.deref_var(&val);
-            match derefed {
-                Value::Integer(n) => results.push(n as f64),
-                Value::Float(f) => results.push(f),
-                _ => {}
+fn compute_reachable_to_root(
+    root: &str,
+    reverse_index: &HashMap<String, Vec<String>>,
+    max_depth: usize,
+) -> HashSet<String> {
+    let mut reachable = HashSet::new();
+    let mut best_depth: HashMap<String, usize> = HashMap::new();
+    let mut queue: VecDeque<(String, usize)> = VecDeque::from([(root.to_string(), 0)]);
+    while let Some((current, depth)) = queue.pop_front() {
+        if let Some(&prev) = best_depth.get(&current) {
+            if depth >= prev {
+                continue;
             }
         }
-        if !vm.backtrack() {
-            break;
+        best_depth.insert(current.clone(), depth);
+        reachable.insert(current.clone());
+        if depth >= max_depth {
+            continue;
+        }
+        if let Some(children) = reverse_index.get(&current) {
+            for child in children {
+                queue.push_back((child.clone(), depth + 1));
+            }
         }
     }
-    results
+    reachable
 }
 
 fn main() {
@@ -64,17 +71,34 @@ fn main() {
     let article_categories = load_tsv_pairs(&format!("{}/article_category.tsv", facts_dir));
     let roots = load_single_column(&format!("{}/root_categories.tsv", facts_dir));
 
+    let root = if roots.is_empty() { String::new() } else { roots[0].clone() };
+    let max_depth_limit: usize = 10;
+
+    // Demand-filter: build reverse index (parent -> children) and find all
+    // categories reachable BACKWARD from root within max_depth. Only keep
+    // category_parent edges whose parent is reachable to root.
+    let mut reverse_index: HashMap<String, Vec<String>> = HashMap::new();
+    for (child, parent) in &category_parents {
+        reverse_index.entry(parent.clone()).or_default().push(child.clone());
+    }
+    let reachable_to_root = compute_reachable_to_root(&root, &reverse_index, max_depth_limit);
+    let filtered_edges: Vec<(String, String)> = category_parents
+        .iter()
+        .filter(|(_, parent)| reachable_to_root.contains(parent))
+        .cloned()
+        .collect();
+
     let (code, labels) = shared_wam_program();
     let mut vm = WamState::new(code, labels.clone());
 
     vm.register_indexed_atom_fact2_pairs(
         "category_parent",
-        &category_parents.iter().map(|(a, b)| (a.as_str(), b.as_str())).collect::<Vec<_>>(),
+        &filtered_edges.iter().map(|(a, b)| (a.as_str(), b.as_str())).collect::<Vec<_>>(),
     );
 
     {
         let mut ffi_index: HashMap<u32, Vec<u32>> = HashMap::new();
-        for (child, parent) in &category_parents {
+        for (child, parent) in &filtered_edges {
             let child_id = vm.intern_atom(child);
             let parent_id = vm.intern_atom(parent);
             ffi_index.entry(child_id).or_insert_with(Vec::new).push(parent_id);
@@ -84,11 +108,11 @@ fn main() {
 
     setup_foreign_predicates(&mut vm);
 
-    let root = if roots.is_empty() { String::new() } else { roots[0].clone() };
-
-    let mut seed_cats: Vec<String> = category_parents.iter()
-        .map(|(child, _)| child.clone())
-        .collect::<std::collections::HashSet<_>>()
+    // Seeds = distinct categories from article_categories (categories that
+    // articles actually belong to), matching the canonical workload semantic.
+    let mut seed_cats: Vec<String> = article_categories.iter()
+        .map(|(_, cat)| cat.clone())
+        .collect::<HashSet<_>>()
         .into_iter()
         .collect();
     seed_cats.sort();
@@ -112,72 +136,28 @@ fn main() {
     let t2 = Instant::now();
 
     let has_ca_foreign = vm.foreign_predicates.contains("category_ancestor/4");
-    let ca_pc = labels.get("category_ancestor/4").copied();
-    let psb_pc = labels.get("power_sum_bound/4").copied();
 
     let mut seed_weight_sums: HashMap<String, f64> = HashMap::new();
 
-    if has_ca_foreign || ca_pc.is_some() || psb_pc.is_some() {
+    if has_ca_foreign {
+        let root_id = vm.intern_atom(&root);
         for cat in &seed_cats {
-            vm.reset_query();
-
-            if has_ca_foreign {
-                vm.set_reg("A1", Value::Atom(cat.clone()));
-                vm.set_reg("A2", Value::Atom(root.clone()));
-                vm.set_reg("A3", Value::Unbound("_Hops".to_string()));
-                vm.set_reg("A4", Value::List(vec![Value::Atom(cat.clone())]));
-
-                let mut weight_sum: f64 = 0.0;
-                if vm.execute_foreign_predicate("category_ancestor/4", 4) {
-                    loop {
-                        if let Some(val) = vm.get_reg("A3") {
-                            let derefed = vm.deref_var(&val);
-                            match derefed {
-                                Value::Integer(h) => weight_sum += ((h as f64) + 1.0).powf(neg_n),
-                                Value::Float(h) => weight_sum += (h + 1.0).powf(neg_n),
-                                _ => {}
-                            }
-                        }
-                        if !vm.backtrack() { break; }
-                    }
-                }
-                if weight_sum > 0.0 {
-                    seed_weight_sums.insert(cat.clone(), weight_sum);
-                }
-            } else if let Some(pc) = psb_pc {
-                vm.pc = pc;
-                vm.set_reg("A1", Value::Atom(cat.clone()));
-                vm.set_reg("A2", Value::Atom(root.clone()));
-                vm.set_reg("A3", Value::Float(neg_n));
-                vm.set_reg("A4", Value::Unbound("_WS".to_string()));
-                if vm.run() {
-                    if let Some(val) = vm.get_reg("A4").map(|v| vm.deref_var(&v)) {
-                        match val {
-                            Value::Float(ws) if ws > 0.0 => {
-                                seed_weight_sums.insert(cat.clone(), ws);
-                            }
-                            Value::Integer(ws) if ws > 0 => {
-                                seed_weight_sums.insert(cat.clone(), ws as f64);
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-            } else if let Some(pc) = ca_pc {
-                vm.pc = pc;
-                vm.set_reg("A1", Value::Atom(cat.clone()));
-                vm.set_reg("A2", Value::Atom(root.clone()));
-                vm.set_reg("A3", Value::Unbound("_Hops".to_string()));
-                vm.set_reg("A4", Value::List(vec![Value::Atom(cat.clone())]));
-                vm.cp = 0;
-
-                let solutions = collect_solutions(&mut vm);
-                let weight_sum: f64 = solutions.iter()
-                    .map(|&hops| (hops + 1.0).powf(neg_n))
-                    .sum();
-                if weight_sum > 0.0 {
-                    seed_weight_sums.insert(cat.clone(), weight_sum);
-                }
+            let cat_id = vm.intern_atom(cat);
+            let visited_ids = vec![cat_id];
+            let mut hops: Vec<i64> = Vec::new();
+            vm.collect_native_category_ancestor_hops(
+                cat_id,
+                root_id,
+                &visited_ids,
+                max_depth_limit,
+                "category_parent",
+                &mut hops,
+            );
+            let weight_sum: f64 = hops.iter()
+                .map(|&h| ((h as f64) + 1.0).powf(neg_n))
+                .sum();
+            if weight_sum > 0.0 {
+                seed_weight_sums.insert(cat.clone(), weight_sum);
             }
         }
     }
@@ -198,7 +178,7 @@ fn main() {
         .filter(|(_, &ws)| ws > 0.0)
         .map(|(art, &ws)| (ws.powf(inv_n), art.clone()))
         .collect();
-    results.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    results.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal).then(a.1.cmp(&b.1)));
 
     let agg_ms = t3.elapsed().as_millis();
     let total_ms = t0.elapsed().as_millis();


### PR DESCRIPTION
## Summary

Port two optimizations from `generate_wam_rust_matrix_benchmark.pl` into the simpler benchmark templates so cross-target comparisons measure the same workload:

1. **Demand filtering**: reverse-index BFS from root to find reachable categories, drop edges whose parent can't reach root
2. **Article-based seeds**: derive seeds from `article_categories` (categories articles belong to) rather than all child categories — 2165 → 386 at scale 300

Also pass `LANG=C.utf8/LC_ALL=C.utf8` in the cross-target script so Haskell can read UTF-8 TSV files.

## Results at scale 300 (3 reps, median query_ms)

| Target | query_ms | Notes |
|--------|----------|-------|
| Rust | 5ms | Native FFI kernel |
| Haskell | 38ms | STArray + WAM |
| Go | 1876ms | Pure WAM interpreter |

All three targets produce 272 rows matching the reference output.

## Test plan

- [x] Rust benchmark: 272 rows, query_ms=5
- [x] Haskell benchmark: 272 rows, query_ms=38 (no regression)
- [x] Go benchmark: 272 rows, query_ms=1876
- [x] Cross-target script runs end-to-end for all three targets, OK rows match for each
- [x] Existing test suites pass: CSR (15/15), ISO (9/9)

https://claude.ai/code/session_01NMTuARifW7HDSMhiu7JG5g

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMTuARifW7HDSMhiu7JG5g)_