### PR TITLE
LLVM WAM: unsetenv/1 (M93) -- complement to M77 setenv/2

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1468,6 +1468,7 @@ declare i32 @rename(i8*, i8*)
 declare i32 @rmdir(i8*)
 declare i8* @getenv(i8*)
 declare i32 @setenv(i8*, i8*, i32)
+declare i32 @unsetenv(i8*)
 declare i64 @strlen(i8*)
 declare i32 @system(i8*)
 declare i8* @getcwd(i8*, i64)
@@ -3538,6 +3539,7 @@ entry:
     i32 110, label %builtin_format_time
     i32 111, label %builtin_halt0
     i32 112, label %builtin_halt1
+    i32 113, label %builtin_unsetenv
   ]
 
 builtin_is:
@@ -5018,6 +5020,27 @@ h1.do_exit:
   %h1.code32 = trunc i64 %h1.code64 to i32
   call void @exit(i32 %h1.code32)
   unreachable
+
+builtin_unsetenv:
+  ; M93: unsetenv(+Name) -- complements M77 setenv/2. Name must be an
+  ; atom; non-atom fails. libc unsetenv returns 0 on success and -1
+  ; only on EINVAL (invalid name like one containing ``=''). Treats
+  ; an unset-when-not-set as success, matching SWI-Prolog semantics.
+  %us.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %us.t1 = extractvalue %Value %us.a1, 0
+  %us.is_atom = icmp eq i32 %us.t1, 0
+  br i1 %us.is_atom, label %us.go, label %us.fail
+us.fail:
+  ret i1 false
+us.go:
+  %us.aid = extractvalue %Value %us.a1, 1
+  %us.name = call i8* @wam_atom_to_string(i64 %us.aid)
+  %us.name_null = icmp eq i8* %us.name, null
+  br i1 %us.name_null, label %us.fail, label %us.do
+us.do:
+  %us.ret = call i32 @unsetenv(i8* %us.name)
+  %us.ok = icmp eq i32 %us.ret, 0
+  ret i1 %us.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11856,6 +11879,7 @@ builtin_op_to_id('random_between/3', 109).    % L + lrand48() % (H-L+1).
 builtin_op_to_id('format_time/3', 110).       % strftime(Fmt, localtime(Stamp)).
 builtin_op_to_id('halt/0', 111).              % libc exit(0).
 builtin_op_to_id('halt/1', 112).              % libc exit(Code).
+builtin_op_to_id('unsetenv/1', 113).          % libc unsetenv(Name).
 builtin_op_to_id(_, 99).  % Unknown
 
 % ============================================================================

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2073,6 +2073,7 @@ is_builtin_pred(size_file, 2).          % size_file(+Path, -Size).
 is_builtin_pred(time_file, 2).          % time_file(+Path, -Time).
 is_builtin_pred(getenv, 2).             % getenv(+Name, -Value).
 is_builtin_pred(setenv, 2).             % setenv(+Name, +Value).
+is_builtin_pred(unsetenv, 1).           % unsetenv(+Name).
 is_builtin_pred(shell, 1).              % shell(+Command).
 is_builtin_pred(shell, 2).              % shell(+Command, -Status).
 is_builtin_pred(working_directory, 2).  % working_directory(?Old, ?New).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,29 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M93: unsetenv/1 -- libc unsetenv() wrapper, complement to M77 setenv/2.
+
+:- dynamic test_unsetenv_roundtrip/2.
+test_unsetenv_roundtrip(_, R) :-
+    % Set var, confirm it''s set, unsetenv, confirm getenv fails.
+    setenv('UW_M93_TEST', 'hello'),
+    getenv('UW_M93_TEST', V1),
+    V1 == 'hello',
+    unsetenv('UW_M93_TEST'),
+    ( \+ getenv('UW_M93_TEST', _) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_unsetenv_idempotent/2.
+test_unsetenv_idempotent(_, R) :-
+    % Unsetting a var that isn''t set still succeeds (matches SWI).
+    unsetenv('UW_M93_NOT_SET_VAR_NAME'),
+    unsetenv('UW_M93_NOT_SET_VAR_NAME'),
+    R is 1.   % 1
+
+:- dynamic test_unsetenv_non_atom/2.
+test_unsetenv_non_atom(_, R) :-
+    % Integer arg fails (non-atom).
+    ( unsetenv(42) -> R is 0 ; R is 1 ).   % 1
+
 % M92: halt/0 + halt/1 -- libc exit() wrapper. Process terminates
 % inside the WAM run loop, so the test driver never reaches its
 % normal `read reg 0 + return as exit code' path -- the exit code
@@ -4771,6 +4794,13 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M93 unsetenv/1 ---~n'),
+       run_test_r0('setenv/getenv/unsetenv/getenv-fails roundtrip -> 1',
+                   test_unsetenv_roundtrip, 0, 1),
+       run_test_r0('unsetenv on already-unset succeeds -> 1',
+                   test_unsetenv_idempotent, 0, 1),
+       run_test_r0('unsetenv(42) fails (non-atom) -> 1',
+                   test_unsetenv_non_atom, 0, 1),
        format('--- M92 halt/0 + halt/1 ---~n'),
        run_test_r0('halt/0 -> exit 0',
                    test_halt_zero, 0, 0),

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2464,11 +2464,14 @@ test_forall_manual(_, R) :-
 :- dynamic test_unsetenv_roundtrip/2.
 test_unsetenv_roundtrip(_, R) :-
     % Set var, confirm it''s set, unsetenv, confirm getenv fails.
+    % Uses explicit if-then-else rather than \+ getenv(...) -- the
+    % WAM backend has a pre-existing issue where \+ over a builtin
+    % can mis-evaluate as "negation succeeds when getenv succeeds".
     setenv('UW_M93_TEST', 'hello'),
     getenv('UW_M93_TEST', V1),
     V1 == 'hello',
     unsetenv('UW_M93_TEST'),
-    ( \+ getenv('UW_M93_TEST', _) -> R is 1 ; R is 0 ).   % 1
+    ( getenv('UW_M93_TEST', _) -> R is 0 ; R is 1 ).   % 1
 
 :- dynamic test_unsetenv_idempotent/2.
 test_unsetenv_idempotent(_, R) :-


### PR DESCRIPTION
## Summary

- **M93 `unsetenv/1`** — libc `unsetenv` wrapper. Complements M77 `setenv/2`. Op id 113.

Reads reg 0, requires Atom (non-atom fails), pulls the string via `wam_atom_to_string`, calls libc `unsetenv`. Treats unset-on-already-unset as success, matching SWI semantics — the only failure mode is `EINVAL` (invalid name, e.g. one containing `=`).

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `@unsetenv` libc decl, dispatch entry, `builtin_unsetenv` block (prefix `us.`), op-id table entry.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred(unsetenv, 1)`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — three M93 tests + section in `test_all`.

## Test plan

- [x] Full execution suite: **615/615 PASS**, no failures, no OOM
- [x] `test_unsetenv_roundtrip`: `setenv` → `getenv` → `unsetenv` → `getenv` fails ✓
- [x] `test_unsetenv_idempotent`: unset on never-set var still succeeds ✓
- [x] `test_unsetenv_non_atom`: `unsetenv(42)` fails (Integer arg, type guard) ✓

## Notes

The roundtrip test originally used `\+ getenv(...)` to assert the var is no longer present. That tripped a pre-existing WAM-backend issue: `\+ Builtin` mis-evaluates — isolated reproducer confirms `\+ getenv(NEVER_SET, _)` incorrectly returns false even though `getenv` itself correctly fails. The bug is in `\+` over a builtin, not `unsetenv` or `getenv`. Test was rewritten to use the explicit `(Goal -> R is 0 ; R is 1)` form, which exercises the same condition cleanly. Underlying `\+ builtin` issue deferred to its own fix.

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_