### PR TITLE
test(conformance): add Python backend (+ fix // operator-arity bug)

### DIFF
--- a/docs/WAM_CROSS_TARGET_CONFORMANCE.md
+++ b/docs/WAM_CROSS_TARGET_CONFORMANCE.md
@@ -24,9 +24,12 @@ entry point, so invocation is per-target:
 
 - **scala** passes the query args straight to its `GeneratedProgram`
   driver (`<predkey> <args...>` → `true`/`false`).
-- **elixir / wat** synthesise a ground 0-arity wrapper per query
-  (`ctw_N :- pred(args).`), compile it with the program, and ask whether
-  `ctw_N` succeeds. This is the shape their own runtime tests use.
+- **elixir / wat / haskell / python** synthesise a ground 0-arity wrapper
+  per query (`ctw_N :- pred(args).`), build it with the program, and ask
+  whether `ctw_N` succeeds. This is the shape their own runtime tests use.
+  (Python is interpreted — no build step; its generated `main.py` prints
+  `A_i = ...` register dumps on success and `false.` on failure, so the
+  adapter reads success as the absence of `false.`.)
 
 Each adapter is self-contained (`ct_build/4`, `ct_run/5`,
 `ct_teardown/2`); adding a backend is one adapter plus a
@@ -77,16 +80,17 @@ so any failure is reproducible from the recorded seed.
 
 ## Known divergences (tracked as `ct_xfail/2`)
 
-The harness is green today; the divergences below are tolerated and
-logged (an unexpected pass is logged as `XPASS` so the entry can be
-retired). Each is a real backend gap the harness surfaced, not a fixture
-artifact. The oracle is the hand-specified expected-results table in
-`wam_conformance_fixtures.pl` (standard Prolog semantics), not any
-backend's output; among the backends, **Scala is the reference
-implementation** — it passes the whole spec. The table below is the full
-set of tracked divergences (it matches the `ct_xfail/2` / `ct_skip/2`
-facts in the harness); WAT conforms only on `ack`, and `elixir` and
-`scala` pass the whole spec.
+The harness is green today and **every registered backend — scala,
+elixir, wat, haskell, and python — now passes the whole spec** (there are
+no live `ct_xfail/2` or `ct_skip/2` entries; both are declared `dynamic`
+so they may have zero clauses). The oracle is the hand-specified
+expected-results table in `wam_conformance_fixtures.pl` (standard Prolog
+semantics), not any backend's output; Scala was the original reference.
+The table below is the historical record of divergences the harness
+surfaced and that were fixed — each was a real backend gap, not a fixture
+artifact. (A future divergence would be tolerated and logged via a new
+`ct_xfail/2`, with an unexpected pass logged as `XPASS` so the entry can
+be retired.)
 
 | Backend | Program(s) | Kind | Cause |
 |---|---|---|---|
@@ -96,7 +100,8 @@ facts in the harness); WAT conforms only on `ack`, and `elixir` and
 | ~~wat~~ | ~~append, reverse~~ | **fixed** | Two bugs. **(1) Generation:** the `switch_on_term` first-arg index that list-recursive predicates emit had no working parser clause (`parse_term_entries` expected an old operand format), so it fell to the `unrecognized instruction → allocate` fallback — looping on warnings / failing to generate. Fixed by emitting an empty (unindexed) `switch_on_term_hdr` on register 0, mirroring `switch_on_term_a2`; the `try_me_else` chain alone is correct. **(2) Unification:** with generation working, `$unify_regs` did only **shallow** (tag+payload) equality, so a constructed cons (tag-3 `[|]/2`) would not match an already-ground list cell (tag-4) and append/reverse returned false on correct answers — the same `./2`-vs-`[|]/2` split as the other backends, plus it never recursed into elements. Replaced with recursive, cons-aware `$unify_addrs`. Both conformant; skips removed. |
 | ~~elixir~~ | ~~append, reverse~~ | **fixed** | Was: a freshly-constructed list (`./2`, from `put_list`) would not unify against an already-**ground** list compound (`[|]/2`, from `put_structure`) in a clause head, so `capp([a],[b],[a,b])` returned false while `capp([a],[b],X), X=[a,b]` succeeded. Root cause: `unify/3`'s compound clause demanded *identical* functor names and never applied the `./2`↔`[|]/2` cons-cell aliasing that the `get_structure` match path (`step_get_structure_matches?/2`) already used. The runtime also aliases native Elixir `[]` with WAM `"[]"` for direct list inputs. Now conformant; xfails removed. |
 | ~~haskell~~ | ~~member, append, reverse~~ | **fixed** | All three failed on heap-built cons lists. Four root causes, now fixed in `wam_haskell_target.pl`: (1) `unifyVal`/`unifyValues` did **no** structural unification — added a shared `unifyTerms`; (2) the cons functor `"[|]/2"` interned to its own id, distinct from `atomDot` — `intern_struct_functor/2` folds every cons spelling onto `atomDot` (the `./2`-vs-`[|]/2` class, same as the Elixir bug); (3) `GetValue` had its own inline unify bypassing the above — now routed through `unifyVal`; (4) **the multi-element bug** — building `[a\|X]` with `X` a `set_variable` tail placeholder emitted `VList [a, X]` (`X` as a 2nd *element*) and `put_structure` filling `X` did not bind the embedded var, so `addToBuilder` now emits a `Str atomDot [hd, tl]` cons cell for a partial tail and binds the placeholder var on finalize. Fixes lists of any length; xfails removed. |
-| haskell | builtins | xfail | `=/2` of two identical atoms returns false (`cbi_eq(foo)`), and `//`/`mod` evaluate incorrectly (`cbi_arith`). `fib`/`ack` pass, so `+`/`-`/comparison and `is/2` bound-LHS checking are fine — isolated builtin bugs, not the list path. |
+| ~~haskell~~ | ~~builtins~~ | **fixed** | `=/2` of two identical atoms returned false (no `BuiltinCall "=/2"` handler — added one routing through `unifyVal`), and `//`/`mod` evaluated incorrectly: the arity-stripper `takeWhile (/= '/')` truncated any operator containing `/` (so `//` → `""`). Replaced with `bareArithOp` (strips only a trailing `/<digits>`). `fib`/`ack` already passed. Now conformant; xfail removed. |
+| ~~python~~ | ~~builtins~~ | **fixed** | `cbi_arith(28)` → false: `wam_line_to_python_literal` computed the `put_structure`/`get_structure` arity with `split_string(Fn,"/","",[_,ArStr])`, which expects exactly two parts and fell back to **arity 0** for `///2` (integer division `//`). A 0-arity `//` compound carried no argument cells, so `eval_arith` could not apply it and `X is 17 // 5` failed — the same `/`-in-operator class as the Haskell/WAT `//` bugs. Added `python_functor_arity/2` (last `/`-component). The Python adapter was added to the harness in the same change; every other program already passed. |
 
 (Haskell is opt-in — `CONFORMANCE_TARGETS=haskell` — because each program is a cabal compile. `fib` and `ack` pass; the driver, `tests/fixtures/haskell_conformance_driver.hs`, runs a 0-arity wrapper whose atoms are baked into the compiled stream, which is what removed the earlier interning mismatch — see below.)
 

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -1296,6 +1296,22 @@ clean_comma(S, Clean) :-
 	;   Clean = S
 	).
 
+%% python_functor_arity(+FunctorSlashArity, -Arity)
+%  Arity is the FINAL '/'-separated component of a 'name/arity' functor.
+%  Taking the last part (not requiring exactly two) is essential for
+%  operators whose functor itself contains '/', e.g. '///2' (integer
+%  division //) or '//2' (float division /): splitting those on '/' yields
+%  3-4 parts, so the old [_Name, ArStr] pattern fell through to arity 0.
+%  A 0-arity '//' compound then carried no argument cells and eval_arith
+%  could not apply it, so `X is 17 // 5` failed (the cbi_arith divergence).
+python_functor_arity(CFn, Arity) :-
+	(   split_string(CFn, "/", "", Parts),
+	    last(Parts, ArStr),
+	    number_string(A, ArStr)
+	->  Arity = A
+	;   Arity = 0
+	).
+
 %% escape_python_string(+In, -Out)
 %  Escape a string for Python string literal.
 escape_python_string(In, Out) :-
@@ -1359,10 +1375,7 @@ wam_line_to_python_literal(["get_value", Xn, Ai], Py) :-
 	format(atom(Py), '("get_value", ~w, ~w)', [CXn, CAi]).
 wam_line_to_python_literal(["get_structure", Fn, Ai], Py) :-
 	clean_comma(Fn, CFn), clean_comma(Ai, CAi),
-	(   split_string(CFn, "/", "", [_Name, ArStr])
-	->  number_string(Arity, ArStr)
-	;   Arity = 0
-	),
+	python_functor_arity(CFn, Arity),
 	escape_python_string(CFn, EFn),
 	format(atom(Py), '("get_structure", "~w", ~w, ~w)', [EFn, Arity, CAi]).
 wam_line_to_python_literal(["get_list", Ai], Py) :-
@@ -1435,10 +1448,7 @@ wam_line_to_python_literal(["put_float", F, Ai], Py) :-
 	format(atom(Py), '("put_float", ~w, ~w)', [CF, CAi]).
 wam_line_to_python_literal(["put_structure", Fn, Ai], Py) :-
 	clean_comma(Fn, CFn), clean_comma(Ai, CAi),
-	(   split_string(CFn, "/", "", [_Name, ArStr])
-	->  number_string(Arity, ArStr)
-	;   Arity = 0
-	),
+	python_functor_arity(CFn, Arity),
 	escape_python_string(CFn, EFn),
 	format(atom(Py), '("put_structure", "~w", ~w, ~w)', [EFn, Arity, CAi]).
 wam_line_to_python_literal(["put_list", Ai], Py) :-

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -53,6 +53,8 @@
 :- use_module('../src/unifyweaver/targets/wam_wat_target').
 :- use_module('../src/unifyweaver/targets/wam_haskell_target',
               [write_wam_haskell_project/3]).
+:- use_module('../src/unifyweaver/targets/wam_python_target',
+              [write_wam_python_project/3]).
 
 % ============================================================
 % Target registry + known-divergence (xfail) registry
@@ -62,6 +64,7 @@ conformance_target(scala).
 conformance_target(elixir).
 conformance_target(wat).
 conformance_target(haskell).
+conformance_target(python).
 
 %% ct_default_target(Target): runs unless CONFORMANCE_TARGETS overrides.
 %  WAT and Haskell are wired up but NOT defaults: their backends still
@@ -188,6 +191,7 @@ ct_toolchain(scala,  [scalac]).
 ct_toolchain(elixir, [elixir]).
 ct_toolchain(wat,    [wat2wasm, node]).
 ct_toolchain(haskell, [ghc, cabal]).
+ct_toolchain(python, [python3]).
 
 ct_available(scala) :-
     ct_enabled(scala),
@@ -224,6 +228,7 @@ exe_on_path(Exe) :-
 test(scala,  [condition(ct_available(scala))])  :- run_target_conformance(scala).
 test(elixir, [condition(ct_available(elixir))]) :- run_target_conformance(elixir).
 test(wat,    [condition(ct_available(wat))])    :- run_target_conformance(wat).
+test(python, [condition(ct_available(python))]) :- run_target_conformance(python).
 
 :- end_tests(wam_cross_target_conformance).
 
@@ -581,6 +586,42 @@ ct_run(haskell, haskell_ctx(Dir, Map), K, A, Bool) :-
     normalize_space(string(Out), OutStr), bool_of_string(Out, Bool).
 
 ct_teardown(haskell, haskell_ctx(Dir, Map)) :-
+    cleanup_dir(Dir), abolish_wrappers(Map).
+
+% ============================================================
+% Adapter: Python  (0-arity wrapper -> `python3 main.py <key>` -> bool)
+%
+% write_wam_python_project/3 compiles predicate INDICATORS itself (like
+% the Haskell adapter), so this mirrors that shape: synthesise one ground
+% 0-arity wrapper per query, generate the project, and run each wrapper.
+% Python is interpreted, so there is NO build step — generation in
+% ct_build is the whole cost, and ct_run is a fast `python3 main.py` per
+% query. The generated main.py prints `A_i = ...` register dumps on
+% success and the literal `false.` on failure (a 0-arity wrapper has no
+% meaningful output registers, so success is detected by the ABSENCE of
+% `false.`). Opt-in via CONFORMANCE_TARGETS=python.
+% ============================================================
+
+ct_build(python, Preds, Queries, python_ctx(Dir, Map)) :-
+    ct_tmp_dir('tmp_ct_python', Dir),
+    synth_wrappers(Queries, WPreds, Map),
+    maplist(strip_pred, Preds, BarePreds),
+    append(WPreds, BarePreds, AllPreds0),
+    maplist(qualify_user, AllPreds0, AllPreds),
+    write_wam_python_project(AllPreds, [module_name(wam_ct)], Dir).
+
+ct_run(python, python_ctx(Dir, Map), K, A, Bool) :-
+    memberchk((K-A)-WName, Map),
+    format(atom(KeyAtom), '~w/0', [WName]), atom_string(KeyAtom, KeyStr),
+    run_proc_out(python3, ['main.py', KeyStr], Dir, _Exit, OutStr),
+    (   sub_string(OutStr, _, _, _, "false.")
+    ->  Bool = false
+    ;   sub_string(OutStr, _, _, _, "Unknown predicate")
+    ->  Bool = error(unknown_predicate)
+    ;   Bool = true
+    ).
+
+ct_teardown(python, python_ctx(Dir, Map)) :-
     cleanup_dir(Dir), abolish_wrappers(Map).
 
 qualify_user(_M:N/A, user:N/A) :- !.


### PR DESCRIPTION
## Summary

Extends the cross-target WAM conformance harness to a **5th backend, Python**, and fixes the one divergence it surfaced.

### Harness adapter (`tests/test_wam_cross_target_conformance.pl`)
- Registers `conformance_target(python)` + `ct_toolchain(python,[python3])` and a `test(python,...)` plunit clause.
- `ct_build` generates the project with `write_wam_python_project/3` (no build step — Python is interpreted); `ct_run` executes `python3 main.py <wrapper>/0` per query and reads success as the **absence of `false.`** in the output (a ground 0-arity wrapper has no meaningful output registers). Same 0-arity-wrapper shape as the elixir/wat/haskell adapters. Opt-in via `CONFORMANCE_TARGETS=python`.

### Backend fix (`wam_python_target.pl`)
`cbi_arith(28)` returned false. `wam_line_to_python_literal` computed the `put_structure`/`get_structure` arity with `split_string(Fn,"/","",[_,ArStr])`, which requires exactly two parts and fell back to **arity 0** for `///2` (integer division `//`). The 0-arity `//` compound carried no argument cells, so `eval_arith` couldn't apply it and `X is 17 // 5` failed — the **same `/`-in-operator class** as the Haskell (`bareArithOp`) and WAT (`functor_arity_of`) bugs. Added `python_functor_arity/2` (last `/`-component), used at both structure sites.

## Result

With the fix, **Python passes the entire spec** (member, append, reverse, fib, builtins, ack) — no xfails. **Every registered backend (scala, elixir, wat, haskell, python) now conforms.**

## Verification
- `CONFORMANCE_TARGETS=python` → green (all programs).
- `test_wam_python_target` → **177/177**.
- scala/elixir conformance still green from the repo root (shared-file change is safe).

## Note
The `./2`-vs-`[|]/2` / `/`-in-operator family has now appeared in **Elixir, Haskell, WAT, and Python** — adding a backend keeps surfacing the same two classes (cons-spelling and operator-arity). Still think a shared "WAM cons + operator-functor conventions" doc would save the next backend from re-hitting both.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_