### PR TITLE
WAM F# target: int-native LMDB-eager demand-set fact source (Stage 1)

### DIFF
--- a/examples/benchmark/generate_wam_fsharp_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_fsharp_optimized_benchmark.pl
@@ -74,10 +74,19 @@ generate(VariantAtom, OutputDir) :-
     format(user_error, '[WAM-FSharp-Optimized] variant=~w predicates=~w~n',
            [VariantAtom, Predicates]),
 
-    % Step 5: Generate F# WAM project with lowered emitter and parallel support
+    % Step 5: Generate F# WAM project with lowered emitter and parallel support.
+    %         LMDB variants add an int-native demand-set fact source (no TSV
+    %         graph): the kernel reads category_parent eagerly from the
+    %         Phase-1 resident LMDB, pruned to the demand set (descendants of
+    %         root via category_child).  The runtime opens <factsDir>/lmdb.
+    (   sub_atom(VariantAtom, 0, _, _, lmdb)
+    ->  variant_materialisation(VariantAtom, Materialisation),
+        LmdbOpts = [lmdb_path('lmdb'), lmdb_materialisation(Materialisation)]
+    ;   LmdbOpts = []
+    ),
     Options = [module_name('wam-fsharp-optimized-bench'),
                emit_mode(functions),
-               parallel(true)],
+               parallel(true) | LmdbOpts],
     write_wam_fsharp_project(Predicates, Options, OutputDir),
     format(user_error, '[WAM-FSharp-Optimized] Generated project at ~w~n', [OutputDir]).
 
@@ -92,6 +101,21 @@ parse_variant(accumulated, [
     min_closure(false),
     seeded_accumulation(auto)
 ]).
+% LMDB variants compile only the raw category_ancestor/4 kernel (no lowered
+% aggregate helpers), so the benchmark dispatches straight to the native
+% kernel via executeForeign -- the apples-to-apples eager comparison with the
+% Rust matrix bench, which also walks the kernel directly.
+parse_variant(lmdb_eager, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false)
+]).
+
+%% variant_materialisation(+Variant, -Mode)
+variant_materialisation(lmdb_eager,  eager).
+variant_materialisation(lmdb_lazy,   lazy).
+variant_materialisation(lmdb_cached, cached).
+variant_materialisation(_,           eager).
 
 %% collect_wam_predicates(+Variant, -Predicates)
 %  Collect the predicate list to compile through WAM, including
@@ -101,6 +125,10 @@ collect_wam_predicates(seeded, [
     user:max_depth/1,
     user:category_ancestor/4,
     user:power_sum_bound/4
+]).
+collect_wam_predicates(lmdb_eager, [
+    user:max_depth/1,
+    user:category_ancestor/4
 ]).
 collect_wam_predicates(accumulated, [
     user:dimension_n/1,

--- a/templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache
+++ b/templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache
@@ -127,6 +127,62 @@ let loadCategoryParent (env: LightningEnvironment) : Map<int, int list> =
 let loadCategoryChild (env: LightningEnvironment) : Map<int, int list> =
     loadDupsortRelation env "category_child"
 
+/// Demand-set BFS.  Returns every node reachable DOWN from `root` via
+/// category_child (the descendants of `root` in the child graph).  These
+/// are exactly the nodes from which `root` is reachable going UP via
+/// category_parent, so the upward category_ancestor walk can be pruned to
+/// this set: a parent outside the demand set can never lie on a path to
+/// `root`.  Mirrors the Rust `reachable_to_root` / Haskell
+/// `computeDemandSetCursorBFS` demand BFS.
+///
+/// Uses a single short-lived read transaction + cursor over category_child
+/// (no full materialisation of the child relation).  Bounded by `maxDepth`
+/// to match the kernel's depth bound; pass Int32.MaxValue for an unbounded
+/// (always-safe, never-over-prunes) demand set.
+let reachableToRoot (env: LightningEnvironment) (root: int) (maxDepth: int) : Set<int> =
+    use tx = env.BeginTransaction(TransactionBeginFlags.ReadOnly)
+    let db = tx.OpenDatabase("category_child", new DatabaseConfiguration(Flags = DatabaseOpenFlags.DuplicatesSort))
+    use cursor = tx.CreateCursor(db)
+    let childrenOf (node: int) : int list =
+        let struct (rc, _, _) = cursor.SetKey(encodeI32 node)
+        if rc <> MDBResultCode.Success then []
+        else
+            let struct (_, _, v) = cursor.GetCurrent()
+            let mutable result = [decodeI32 (v.AsSpan())]
+            let mutable ok = true
+            while ok do
+                let struct (rc2, _, _) = cursor.NextDuplicate()
+                if rc2 = MDBResultCode.Success then
+                    let struct (_, _, v2) = cursor.GetCurrent()
+                    result <- decodeI32 (v2.AsSpan()) :: result
+                else ok <- false
+            result
+    let visited = System.Collections.Generic.HashSet<int>()
+    visited.Add(root) |> ignore
+    let mutable frontier = [root]
+    let mutable depth = 0
+    while not (List.isEmpty frontier) && depth < maxDepth do
+        let next = System.Collections.Generic.List<int>()
+        for node in frontier do
+            for c in childrenOf node do
+                if visited.Add(c) then next.Add(c)
+        frontier <- List.ofSeq next
+        depth <- depth + 1
+    Set.ofSeq visited
+
+/// Load category_parent (child->parents) for LMDB-eager mode, pruned to the
+/// demand set: only edges whose endpoints lie on a possible path to `root`
+/// are retained.  Keys are restricted to demand-set nodes and each value
+/// list is filtered to demand-set parents.  The resulting Map is keyed and
+/// valued in raw LMDB int space (no string interning of the graph) and is
+/// directly usable as the kernel's `lookupParents` via WcFfiFacts.
+let loadCategoryParentDemand (env: LightningEnvironment) (demand: Set<int>) : Map<int, int list> =
+    loadCategoryParent env
+    |> Map.fold (fun acc k vs ->
+        if demand.Contains k then
+            Map.add k (vs |> List.filter demand.Contains) acc
+        else acc) Map.empty
+
 /// Load a DUPSORT database directly into a Dictionary (skipping the
 /// Map conversion). Returns O(1) lookup via DictLookupSource. Use
 /// this when the caller only needs ILookupSource access (not a Map

--- a/templates/targets/fsharp_wam/program.fs.mustache
+++ b/templates/targets/fsharp_wam/program.fs.mustache
@@ -95,18 +95,16 @@ let main argv =
 
     let sw = Stopwatch.StartNew()
 
-    // Load TSV facts
-    let categoryParents  = loadTsvPairs (System.IO.Path.Combine(factsDir, "category_parent.tsv"))
-    let articleCategories = loadTsvPairs (System.IO.Path.Combine(factsDir, "article_category.tsv"))
-    let roots            = loadSingleColumn (System.IO.Path.Combine(factsDir, "root_categories.tsv"))
-    let root = if roots.Length > 0 then roots.[0] else "Physics"
-
-    let loadMs = sw.ElapsedMilliseconds
-    eprintfn "load_ms=%d" loadMs
-
-    // Resolve call instructions
+    // Resolve call instructions (compile-time; independent of fact source).
     let foreignPreds = [ {{foreign_preds}} ]
     let resolvedCode = resolveCallInstrs allLabels foreignPreds (Array.toList allCode) |> List.toArray
+
+{{^has_lmdb}}
+    // ---- TSV fact source (in-memory, string-interned) -------------------
+    let categoryParents   = loadTsvPairs (System.IO.Path.Combine(factsDir, "category_parent.tsv"))
+    let articleCategories = loadTsvPairs (System.IO.Path.Combine(factsDir, "article_category.tsv"))
+    let roots             = loadSingleColumn (System.IO.Path.Combine(factsDir, "root_categories.tsv"))
+    let root = if roots.Length > 0 then roots.[0] else "Physics"
 
     // Build atom intern table from instructions + all TSV atoms
     let extraAtoms = seq {
@@ -119,31 +117,84 @@ let main argv =
     // Build interned FFI facts: category_parent child -> [parent ids]
     let parentsInterned = buildFfiFacts categoryParents atomIntern
 
-{{#has_lmdb}}
-    // LMDB fact source setup (materialisation mode dispatch)
-    let lmdbEnv = openEnv (System.IO.Path.Combine(factsDir, "lmdb"))
-{{match materialisation}}
-{{case eager}}
-    // Eager: load entire LMDB relation into memory for O(log n) Map lookup
-    let lmdbFactMap = loadCategoryParent lmdbEnv
-    let lmdbFactLookup (key: int) : int list =
-        Map.tryFind key lmdbFactMap |> Option.defaultValue []
-{{case lazy}}
-    // Lazy: on-demand cursor lookup, no startup materialisation cost
-    let lmdbFactSource = LmdbCursorLookup(lmdbEnv, "category_parent") :> ILookupSource
-{{default}}
-    // Cached (default): two-level L1/L2 cache over cursor lookup
-    let lmdbInner = LmdbCursorLookup(lmdbEnv, "category_parent") :> ILookupSource
-    let lmdbFactSource = TwoLevelCachedLookupSource(lmdbInner, maxL2Entries = {{l2_capacity}}) :> ILookupSource
-{{/match}}
-{{/has_lmdb}}
-
     // Seed categories (distinct second column of article_category)
     let seedCats =
         articleCategories
         |> Array.map snd
         |> Array.distinct
         |> Array.sort
+
+    let loadMs = sw.ElapsedMilliseconds
+    eprintfn "load_ms=%d" loadMs
+{{/has_lmdb}}
+{{#has_lmdb}}
+    // ---- LMDB fact source (int-native; no TSV graph, no string interning) -
+    //
+    // The Phase-1 resident LMDB stores the graph in its own int id space
+    // (s2i/i2s + category_parent/category_child keyed by those ints).  The
+    // fixture's article_category column 2 and root_ids.txt ARE those LMDB
+    // ints, so seeds and root are consumed directly as ints and the kernel
+    // recursion stays entirely in int space.  The only "interning" is an
+    // identity map over the ids that cross the WAM register boundary (seed in
+    // r1, root in r2), so Atom "4985" derefs/interns back to 4985.  This is
+    // the key parity move over the Haskell target, which string-interned the
+    // whole graph; here the graph never leaves int space.
+    let lmdbEnv = openEnv (System.IO.Path.Combine(factsDir, "lmdb"))
+
+    // Seeds: distinct ints from article_category column 2 (no header skip).
+    let seedInts =
+        System.IO.File.ReadAllLines(System.IO.Path.Combine(factsDir, "article_category.tsv"))
+        |> Array.choose (fun l ->
+            let t = l.Trim()
+            if t.Length = 0 || t.StartsWith("#") then None
+            else
+                let parts = t.Split('\t')
+                if parts.Length >= 2 then
+                    match System.Int32.TryParse(parts.[1].Trim()) with
+                    | true, v -> Some v
+                    | _ -> None
+                else None)
+        |> Array.distinct
+        |> Array.sort
+
+    // Root: first non-blank int in root_ids.txt.
+    let rootInt =
+        let rp = System.IO.Path.Combine(factsDir, "root_ids.txt")
+        match System.IO.File.ReadAllLines rp |> Array.tryFind (fun l -> l.Trim().Length > 0) with
+        | Some l -> int (l.Trim())
+        | None -> 0
+
+    // Demand-set BFS (descendants of root via category_child).  Unbounded so
+    // it can never over-prune a valid upward path; the kernel's own max_depth
+    // bounds path length.
+    let demandSet = reachableToRoot lmdbEnv rootInt System.Int32.MaxValue
+    eprintfn "demand_set=%d" demandSet.Count
+
+    // Identity intern over the ids that cross the register boundary.
+    let atomIntern =
+        seq { yield! seedInts; yield rootInt }
+        |> Seq.distinct
+        |> Seq.map (fun i -> (string i, i))
+        |> Map.ofSeq
+    let atomDeintern = atomIntern |> Map.toSeq |> Seq.map (fun (s, i) -> (i, s)) |> Map.ofSeq
+    let seedCats = seedInts |> Array.map string
+    let root = string rootInt
+
+{{match materialisation}}
+{{case eager}}
+    // Eager: materialise the demand-pruned category_parent map (int-keyed),
+    // exposed to the kernel through WcFfiFacts.
+    let parentsInterned = loadCategoryParentDemand lmdbEnv demandSet
+{{default}}
+    // Lazy / cached demand-filtered modes land here in later stages; Stage 1
+    // ships eager only, so any materialisation flag falls back to the eager
+    // demand map -- the project still builds and runs correctly.
+    let parentsInterned = loadCategoryParentDemand lmdbEnv demandSet
+{{/match}}
+
+    let loadMs = sw.ElapsedMilliseconds
+    eprintfn "load_ms=%d seeds=%d" loadMs seedCats.Length
+{{/has_lmdb}}
 
     // Build WamContext
     let ctx =
@@ -209,16 +260,16 @@ let main argv =
             // Register layout depends on which queryPred resolved.  The /3
             // candidates are lowered aggregate variants whose semantics fold
             // a target root into the call shape, so A2 is the root and A3
-            // accumulates the result.  The /4 variant is the raw
-            // category_ancestor(+Cat, -Ancestor, -Hops, +Visited) -- A2 and
-            // A3 are outputs (Unbound), and A4 must be a list-valued input
-            // seeded with [Cat] so that the cycle-detection guard (negation
-            // over member/2) sees a real list rather than an unbound
-            // variable.  Without the seeded A4 the predicate fails
-            // unconditionally and the benchmark reports solutions=0.
+            // accumulates the result.  The /4 variant dispatches straight to
+            // the native category_ancestor kernel, whose register layout
+            // (recursive_kernel_detection.pl) is input(1)=cat, input(2)=ROOT,
+            // output(3)=hops, input(4)=visited.  So A2 must be the BOUND root
+            // (not an unbound output) or the kernel's `| Atom rootS ->`
+            // scrutinee never matches and every seed reports 0; A4 is seeded
+            // with [Cat] so the cycle-detection guard sees a real list.
             if queryPred.EndsWith "/4" then
                 regs.[1] <- Atom cat
-                regs.[2] <- Unbound varId
+                regs.[2] <- Atom root
                 regs.[3] <- Unbound (varId + 1)
                 regs.[4] <- VList [ Atom cat ]
             else
@@ -226,7 +277,17 @@ let main argv =
                 regs.[2] <- Atom root
                 regs.[3] <- Unbound varId
             let s0 = { emptyState with WsPC = 0; WsRegs = regs; WsCP = 0 }
-            match dispatchCall ctx queryPred s0 with
+            // The /4 entry IS the native category_ancestor kernel: route it
+            // straight to executeForeign (via callForeign).  dispatchCall would
+            // instead run the compiled WAM bytecode for category_ancestor/4
+            // (it is present in WcLabels), which cannot resolve the
+            // category_parent fact source and so always fails.  The /3 lowered
+            // aggregates already wrap the kernel internally, so they keep the
+            // normal dispatchCall path.
+            let result =
+                if queryPred.EndsWith "/4" then callForeign ctx queryPred s0
+                else dispatchCall ctx queryPred s0
+            match result with
             | Some s1 ->
                 repSolutions <- repSolutions + 1
             | None -> ()


### PR DESCRIPTION
  Gives the F# WAM target proper LMDB capability at parity with the Rust/Haskell
  approach on the effective-distance `category_ancestor` benchmark. This is
  **Stage 1 — LMDB-eager** of the staged F# parity work; lazy/cached and CSR
  end-to-end follow.

  ### What's added

  **1. Demand-set BFS** (`lmdb_fact_source.fs.mustache`)
  - `reachableToRoot env root maxDepth : Set<int>` — a cursor BFS *down*
    `category_child` from root. These are the descendants of root, which is
    exactly the set of nodes from which root is reachable going *up* via
    `category_parent`, so the upward `category_ancestor` walk can be pruned to
    it. Mirrors the Rust `reachable_to_root` / Haskell `computeDemandSetCursorBFS`.
  - `loadCategoryParentDemand env demand` — the demand-pruned eager parent map,
    kept in raw LMDB int space.

  **2. Int-native fact source — no TSV graph, no string interning** (`program.fs.mustache`)
  - `main` is split into an inverted `{{^has_lmdb}}` TSV path (unchanged
    behaviour) and a `{{#has_lmdb}}` int-native path.
  - The Phase-1 resident LMDB already stores the graph in its own int id space,
    and the fixture's `article_category` column 2 / `root_ids.txt` *are* those
    ints. Seeds and root are consumed directly as ints; the eager parent map is
    keyed in raw LMDB int space; the only "interning" is an identity map over the
    ids that cross the WAM register boundary. The graph never leaves int space —
    this is the key parity move over the Haskell target, which string-interned
    the whole graph.

  **3. Benchmark generator path** (`generate_wam_fsharp_optimized_benchmark.pl`)
  - New `lmdb_eager` variant: emits an LMDB-eager project reading the resident
    fixture and compiling only `category_ancestor/4`, so the benchmark dispatches
    straight to the native kernel (the apples-to-apples eager comparison with the
    Rust matrix bench, which also walks the kernel directly).

  ### Latent `/4` bug fixed along the way

  The native kernel's register layout (`recursive_kernel_detection.pl`) is
  `input(1)=cat, input(2)=root, output(3)=hops, input(4)=visited`, but the
  benchmark loop bound A2 to an *unbound output* and dispatched the `/4` entry
  through `dispatchCall` — which runs the compiled WAM bytecode for
  `category_ancestor/4` (present in `WcLabels`) and never reaches the foreign
  kernel, so every seed reported 0 solutions. Now A2 is the bound root and the
  `/4` kernel entry routes through `callForeign`/`executeForeign`. The `/3`
  lowered aggregates already wrap the kernel internally and keep the normal
  `dispatchCall` path.

  ### Validation

  On `data/benchmark/simplewiki_articles` (root 2, 14,680 seeds):

  | metric | value |
  |---|---|
  | demand set | 14,680 |
  | solutions | **970 — exact match vs independent Python oracle** over the same LMDB |
  | eager load | 488 ms |
  | warm query | 61 ms (3 reps) |

  The fixture's `i2s` string table holds only 512 entries while the graph has
  297k edges on raw int ids — precisely why int-native (not string-interning) is
  the right design here.

  All F# target tests pass (`tests/test_wam_fsharp_target.pl`). Build is
  offline-clean (LightningDB 0.21.0 from NuGet cache); run with
  `DOTNET_ROLL_FORWARD=Major` since the generated `.fsproj` targets net8.0.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)