### PR TITLE
LLVM WAM: fix \+ over builtins (M94) -- op-id collision + inner \+ inlining

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -11880,7 +11880,16 @@ builtin_op_to_id('format_time/3', 110).       % strftime(Fmt, localtime(Stamp)).
 builtin_op_to_id('halt/0', 111).              % libc exit(0).
 builtin_op_to_id('halt/1', 112).              % libc exit(Code).
 builtin_op_to_id('unsetenv/1', 113).          % libc unsetenv(Name).
-builtin_op_to_id(_, 99).  % Unknown
+% Catch-all for builtin names with no dedicated dispatch entry. Must
+% be a value that no real builtin uses AND that the switch in
+% @execute_builtin has no case for, so dispatch falls through to the
+% %unknown label (ret i1 false). 99 was previously used here, but
+% 99 is also the dispatch case for getenv/2 -- so `\+ G' where G is
+% any non-builtin or a non-dispatched builtin would route to
+% builtin_getenv, read whatever junk reg 0 held, and return false
+% instead of running the metacall semantics. 200 is well above the
+% currently-defined range and not in the switch.
+builtin_op_to_id(_, 200).  % Unknown
 
 % ============================================================================
 % WAM line parser → LLVM struct literals (from WAM assembly text)

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1746,6 +1746,24 @@ compile_inner_call_goals([Goal|Rest], V0, Vf, Code) :-
     ->  compile_disjunction(LeftGoal, RightGoal, V0, V1, no, GoalCode),
         compile_inner_call_goals(Rest, V1, Vf, RestCode),
         join_goal_codes(GoalCode, RestCode, Code)
+    % M93b: \+ G inlining for inner goal positions (if-then-else
+    % conditions, disjunction arms, etc). Without this, an inner
+    % `\+ G' falls through to compile_goal_call which emits
+    % `builtin_call \+/1, 1' -- but the LLVM target has no \+/1
+    % dispatch case, so the runtime metacall path is taken. That
+    % path was previously colliding with op id 99 (getenv) via the
+    % catch-all in builtin_op_to_id; even after fixing the
+    % collision, no inner backend actually implements \+ as a
+    % builtin, so \+ G in an inner position would always fail.
+    % Inline-rewrite to the soft-cut form `(G -> fail ; true)' to
+    % match the existing top-level handling (compile_goals at the
+    % outer call site) and to avoid the nested-cut barrier issue
+    % the hard-cut form has when stacked.
+    ;   nonvar(Goal),
+        Goal = \+(NotGoal),
+        wam_inline_not_enabled
+    ->  compile_inner_call_goals([((NotGoal -> fail ; true)) | Rest],
+                                  V0, Vf, Code)
     % once(G) / forall(G, T) — same desugarings as compile_goals.
     % Recurse with the rewritten goal so the if-then-else / negation
     % machinery picks it up.

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2464,14 +2464,11 @@ test_forall_manual(_, R) :-
 :- dynamic test_unsetenv_roundtrip/2.
 test_unsetenv_roundtrip(_, R) :-
     % Set var, confirm it''s set, unsetenv, confirm getenv fails.
-    % Uses explicit if-then-else rather than \+ getenv(...) -- the
-    % WAM backend has a pre-existing issue where \+ over a builtin
-    % can mis-evaluate as "negation succeeds when getenv succeeds".
     setenv('UW_M93_TEST', 'hello'),
     getenv('UW_M93_TEST', V1),
     V1 == 'hello',
     unsetenv('UW_M93_TEST'),
-    ( getenv('UW_M93_TEST', _) -> R is 0 ; R is 1 ).   % 1
+    ( \+ getenv('UW_M93_TEST', _) -> R is 1 ; R is 0 ).   % 1
 
 :- dynamic test_unsetenv_idempotent/2.
 test_unsetenv_idempotent(_, R) :-


### PR DESCRIPTION
## Summary

Fixes `\+ Builtin` in inner goal positions (if-then-else conditions, disjunction arms). Two underlying bugs that compounded:

### Bug 1: `builtin_op_to_id` catch-all collided with `getenv/2`

`builtin_op_to_id(_, 99)` was the unknown-builtin fallback, but `99` is also the dispatch case for `getenv/2`. Any call to an unrecognised builtin therefore routed to `builtin_getenv`, read reg 0 as if it were a name atom, and silently returned false (or garbage). Catch-all moved to `200` — well above the current range (highest defined is 113) and not in the switch, so dispatch falls through to `%unknown → ret i1 false` as designed.

### Bug 2: `compile_inner_call_goals` didn't inline `\+`

The top-level goal compiler (`compile_goals`) rewrites `\+ G` to the hard-cut form `((G, !, fail) ; true)`. But `compile_inner_call_goals` — used for if-then-else conditions, disjunction arms, and other inner-call positions — skipped that rewrite and fell through to `compile_goal_call`, which emitted `builtin_call \+/1, 1`. The LLVM target has no `\+/1` dispatch case, so combined with bug 1 this misrouted to `getenv`; even after fixing bug 1, no inner backend implements `\+` as a builtin, so `\+ G` in an inner position would consistently fail.

Adds the inline-rewrite to `compile_inner_call_goals`, but uses the **soft-cut** form `(G -> fail ; true)` rather than hard-cut. Rationale: a hard `!` in an inner `\+` would target the clause's `cut_barrier` (set at allocate-to-cpn at clause entry), which is broader than `\+`'s scope and would wipe the enclosing if-then-else or disjunction's CP — a real correctness bug. Soft-cut scopes to the local ITE, which is correct for builtin G (no CPs) and correct-with-CP-leak for multi-clause G (the leftover CPs are stale but unreachable through the cut).

### Test

Restores `test_unsetenv_roundtrip` to its original `\+ getenv(...)` form (M93 had worked around it with explicit if-then-else).

## How it was found

While writing M93's `unsetenv/1` test, `test_unsetenv_roundtrip` used `\+ getenv(...)` and failed. Isolated reproducers showed:
- `getenv('NEVER_SET', V)` correctly fails ✓
- `\+ getenv('NEVER_SET', V)` returns false (should be true) ✗

Dumping the generated WAM bytecode for `\+ getenv(...)` showed `builtin_call \+/1, 1` — the rewrite hadn't happened. Tracing the op-id resolution caught the `99` collision with `getenv`.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — catch-all op id `99 → 200`.
- `src/unifyweaver/targets/wam_target.pl` — `\+` inlining in `compile_inner_call_goals`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — restore `\+ getenv(...)` form in M93 roundtrip test.

## Test plan

- [x] Full execution suite: **615/615 PASS**, no failures, no OOM
- [x] M93 `test_unsetenv_roundtrip` passes with original `\+` form ✓
- [x] M10 `\+` regression section (slot ~605) still passes ✓
- [x] All other `\+` usages in the suite continue to work ✓

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_