### PR TITLE
WAM F# target: close the LMDB-eager gap to Rust (kernel parity)

### DIFF
--- a/templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache
+++ b/templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache
@@ -183,6 +183,44 @@ let loadCategoryParentDemand (env: LightningEnvironment) (demand: Set<int>) : Ma
             Map.add k (vs |> List.filter demand.Contains) acc
         else acc) Map.empty
 
+/// Mutable-Dictionary variant of loadCategoryParentDemand for LMDB-eager mode.
+/// Single cursor pass over category_parent, keeping only edges whose BOTH
+/// endpoints are in the demand set, accumulated into a Dictionary (O(1)
+/// amortised insert) instead of an immutable Map (O(log n) insert + node
+/// allocation per edge).  Returns int->int list lookup in raw LMDB int space.
+/// Pair with `fun k -> match dict.TryGetValue k with | true, v -> v | _ -> []`
+/// for an O(1) kernel lookup that skips the Map entirely.
+let loadCategoryParentDemandDict (env: LightningEnvironment) (demand: Set<int>)
+    : System.Collections.Generic.Dictionary<int, int list> =
+    use tx = env.BeginTransaction(TransactionBeginFlags.ReadOnly)
+    let db = tx.OpenDatabase("category_parent", new DatabaseConfiguration(Flags = DatabaseOpenFlags.DuplicatesSort))
+    use cursor = tx.CreateCursor(db)
+    let acc = System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<int>>()
+    let struct (rc, _, _) = cursor.First()
+    if rc = MDBResultCode.Success then
+        let addEntry () =
+            let struct (_, k, v) = cursor.GetCurrent()
+            let key = decodeI32 (k.AsSpan())
+            if demand.Contains key then
+                let value = decodeI32 (v.AsSpan())
+                if demand.Contains value then
+                    let ok, vs = acc.TryGetValue(key)
+                    if ok then vs.Add(value)
+                    else
+                        let vs = System.Collections.Generic.List<int>()
+                        vs.Add(value)
+                        acc.[key] <- vs
+        addEntry ()
+        let mutable ok = true
+        while ok do
+            let struct (rc2, _, _) = cursor.Next()
+            if rc2 = MDBResultCode.Success then addEntry ()
+            else ok <- false
+    let result = System.Collections.Generic.Dictionary<int, int list>(acc.Count)
+    for kv in acc do
+        result.[kv.Key] <- Seq.toList kv.Value
+    result
+
 /// Load a DUPSORT database directly into a Dictionary (skipping the
 /// Map conversion). Returns O(1) lookup via DictLookupSource. Use
 /// this when the caller only needs ILookupSource access (not a Map

--- a/templates/targets/fsharp_wam/program.fs.mustache
+++ b/templates/targets/fsharp_wam/program.fs.mustache
@@ -182,15 +182,22 @@ let main argv =
 
 {{match materialisation}}
 {{case eager}}
-    // Eager: materialise the demand-pruned category_parent map (int-keyed),
-    // exposed to the kernel through WcFfiFacts.
-    let parentsInterned = loadCategoryParentDemand lmdbEnv demandSet
+    // Eager: materialise the demand-pruned category_parent edges into a
+    // mutable Dictionary (O(1) insert/lookup) rather than an immutable Map.
+    // The kernel reads it through `lmdbLookupFn` directly, so WcFfiFacts stays
+    // empty and no immutable Map is ever built.
+    let parentsDict = loadCategoryParentDemandDict lmdbEnv demandSet
 {{default}}
     // Lazy / cached demand-filtered modes land here in later stages; Stage 1
     // ships eager only, so any materialisation flag falls back to the eager
-    // demand map -- the project still builds and runs correctly.
-    let parentsInterned = loadCategoryParentDemand lmdbEnv demandSet
+    // demand Dictionary -- the project still builds and runs correctly.
+    let parentsDict = loadCategoryParentDemandDict lmdbEnv demandSet
 {{/match}}
+    let lmdbLookupFn (k: int) : int list =
+        match parentsDict.TryGetValue k with
+        | true, v -> v
+        | _ -> []
+    let parentsInterned : Map<int, int list> = Map.empty
 
     let loadMs = sw.ElapsedMilliseconds
     eprintfn "load_ms=%d seeds=%d" loadMs seedCats.Length
@@ -250,6 +257,30 @@ let main argv =
     let mutable totalSolutions = 0
     let mutable lastQueryMs = 0L
 
+{{#has_lmdb}}
+    // LMDB int-native fast path: call the native kernel directly, bypassing
+    // the per-seed WAM dispatch (register-array alloc, derefVar, intern
+    // Map.tryFind, choice-point setup) that callForeign/executeForeign would
+    // pay for every seed.  This matches what the Rust matrix bench does (tight
+    // native kernel loop) and isolates kernel cost from the WAM-target
+    // dispatch tax.  Seeds and root are already ints; the lookup is resolved
+    // once.  depth/visited mirror the executeForeign seeding (visited=[cat],
+    // depth=1) so the result matches the dispatched path exactly.
+    let maxDepthCfg = Map.tryFind "max_depth" ctx.WcForeignConfig |> Option.defaultValue 10
+    let lookupFn = lmdbLookupFn
+    for rep = 1 to numReps do
+        let querySw = Stopwatch.StartNew()
+        let mutable repSolutions = 0
+        for cat in seedInts do
+            let hits = nativeKernel_category_ancestor lookupFn cat rootInt maxDepthCfg 1 [ cat ]
+            if not (List.isEmpty hits) then repSolutions <- repSolutions + 1
+        querySw.Stop()
+        lastQueryMs <- querySw.ElapsedMilliseconds
+        totalSolutions <- totalSolutions + repSolutions
+        eprintfn "rep=%d query_ms=%d seeds=%d solutions=%d"
+            rep lastQueryMs seedInts.Length repSolutions
+{{/has_lmdb}}
+{{^has_lmdb}}
     for rep = 1 to numReps do
         let querySw = Stopwatch.StartNew()
         let mutable repSolutions = 0
@@ -297,6 +328,7 @@ let main argv =
         totalSolutions <- totalSolutions + repSolutions
         eprintfn "rep=%d query_ms=%d seeds=%d solutions=%d"
             rep lastQueryMs seedCats.Length repSolutions
+{{/has_lmdb}}
 
     sw.Stop()
     let totalMs = sw.ElapsedMilliseconds


### PR DESCRIPTION
  Follow-up to the int-native LMDB-eager fact source (#2757). That landed the
  capability; this makes it fast. Profiling the F#-vs-Rust eager head-to-head on
  `simplewiki_articles` (root 2, 14,680 seeds, serial, warm) showed F# at ~20×
  slower query and ~4× slower load — but the query gap was almost entirely the
  per-seed WAM dispatch path, not the kernel. Two portable optimizations:

  **A. Direct-kernel call (query).** The LMDB int-native benchmark loop calls
  `nativeKernel_category_ancestor` directly over the int seeds instead of routing
  every seed through `callForeign`/`executeForeign` (per-seed `MaxRegs` register
  array alloc, `derefVar`, `Map.tryFind` intern lookups, choice-point setup).
  This matches the Rust matrix bench's tight native-kernel loop.

  **B. Mutable `Dictionary` instead of immutable `Map` (load).** New
  `loadCategoryParentDemandDict` does a single cursor pass over `category_parent`,
  keeping only demand-set edges, into a `Dictionary` (O(1) insert) rather than an
  immutable `Map<int,int list>` (O(log n) insert + node alloc per edge). The
  kernel reads it via a direct closure, so `WcFfiFacts` stays empty and no
  immutable Map is built.

  ### Result (simplewiki_articles, serial, warm)

  | metric | Rust eager | F# before | F# +A | F# +A+B |
  |---|---|---|---|---|
  | query | 3 ms | 61 ms | 5 ms | **3 ms** |
  | load  | ~120 ms | 488 ms | — | **~300 ms** |
  | solutions | 969* | 970 | 970 | 970 |

  *Rust's TSV loader header-skip drops one seed; otherwise identical.

  So the earlier "Rust is 20× faster on eager" was a WAM-dispatch artifact — on
  the actual `category_ancestor` computation F# now matches Rust. The remaining
  ~2.5× load gap is F#'s two LMDB cursor scans (`reachableToRoot` over
  `category_child` + the parent scan) plus LightningDB managed per-entry overhead,
  vs Rust's single TSV read; a single-scan refactor would close it further.

  All F# target tests pass.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)