### PR TITLE
fix(test): correct stale atom-vs-integer assertion in elixir phase3 compound findall

### DIFF
--- a/tests/test_wam_elixir_lowered_phase3.pl
+++ b/tests/test_wam_elixir_lowered_phase3.pl
@@ -509,12 +509,16 @@ assert_scenario_findall_compound(StdOut) :-
     sub_string(W, _, _, _, "\"a\""),
     sub_string(W, _, _, _, "\"b\""),
     sub_string(W, _, _, _, "\"c\""),
-    % Numeric pairs lower as bare integer literals, not strings.
-    % Match within compound-tuple context to avoid spurious hits in
-    % refs/heap addresses.
-    sub_string(W, _, _, _, "\"a\", 1"),
-    sub_string(W, _, _, _, "\"b\", 2"),
-    sub_string(W, _, _, _, "\"c\", 3").
+    % The second argument is the ATOM '1'/'2'/'3' — quoted in the
+    % phase3_q/2 facts — so it lowers as an Elixir string "1"/"2"/"3",
+    % NOT a bare integer. Atom and integer terms are kept distinct
+    % (genuine integers, e.g. the aggregate_all(count, ...) → 3 case,
+    % still lower bare). The WAM carries `get_constant '1', A2`, i.e.
+    % the atom, confirming this. Match within the compound-tuple
+    % context to avoid spurious hits in refs/heap addresses.
+    sub_string(W, _, _, _, "\"a\", \"1\""),
+    sub_string(W, _, _, _, "\"b\", \"2\""),
+    sub_string(W, _, _, _, "\"c\", \"3\"").
 
 assert_scenario_cut_conj(StdOut) :-
     scope_after_label(StdOut, "SCENARIO_CUT_CONJ", W),


### PR DESCRIPTION
  ## Summary

  `test_wam_elixir_lowered_phase3`'s "compound Template + deep-copy" scenario
  (`findall(p(X,Y), phase3_q(X,Y), L)`) was failing, but the Elixir target is
  correct — the failure was a **stale test expectation**.

  ## Detail

  The facts are `phase3_q(a, '1')`, `phase3_q(b, '2')`, `phase3_q(c, '3')`: the
  second argument is the **atom** `'1'`/`'2'`/`'3'` (quoted), not the integer.
  The WAM correctly carries `get_constant '1', A2`, and the Elixir runtime
  correctly renders atoms as strings, so `findall` yields:

  ```elixir
  [{:struct, "p/2", ["a","1"]}, {:struct, "p/2", ["b","2"]}, {:struct, "p/2", ["c","3"]}]
  ```

  Compound-template construction and per-iteration deep-copy both work, and the
  atom/integer distinction is preserved (genuine integers — e.g.
  `aggregate_all(count, …) → 3` — still lower as bare literals).

  The assertion expected the atoms to render as bare integers (`"a", 1` /
  `"b", 2` / `"c", 3`), encoding a since-corrected lowering where numeric-named
  atoms were wrongly emitted as integers. Updated the assertion to expect the
  correct atom rendering (`"a", "1"` / `"b", "2"` / `"c", "3"`) and fixed the
  misleading comment.

  ## Verification
  All 7 WAM-Elixir suites pass: `test_wam_elixir_lowered_phase3`, `phase4c`,
  `phase4d`, `target`, `classic_programs`, `utils`, and `test_elixir_target`.

  What's next: of the original 4 sweep failures, this one and arg/3 are resolved. Three remain to investigate when you
  want: e2e (atom/1 in the Prolog WAM interpreter — small), cross_target_consistency (LLVM read/write mode), and
  cpp_generator (several C++ e2e cases). Say the word after you've merged and I'll verify, then we can pick the next.
