### PR TITLE
WAM F# target: real lazy + cached LMDB modes (Stage 2)

### DIFF
--- a/examples/benchmark/generate_wam_fsharp_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_fsharp_optimized_benchmark.pl
@@ -110,6 +110,16 @@ parse_variant(lmdb_eager, [
     branch_pruning(false),
     min_closure(false)
 ]).
+parse_variant(lmdb_lazy, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false)
+]).
+parse_variant(lmdb_cached, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false)
+]).
 
 %% variant_materialisation(+Variant, -Mode)
 variant_materialisation(lmdb_eager,  eager).
@@ -127,6 +137,14 @@ collect_wam_predicates(seeded, [
     user:power_sum_bound/4
 ]).
 collect_wam_predicates(lmdb_eager, [
+    user:max_depth/1,
+    user:category_ancestor/4
+]).
+collect_wam_predicates(lmdb_lazy, [
+    user:max_depth/1,
+    user:category_ancestor/4
+]).
+collect_wam_predicates(lmdb_cached, [
     user:max_depth/1,
     user:category_ancestor/4
 ]).

--- a/templates/targets/fsharp_wam/program.fs.mustache
+++ b/templates/targets/fsharp_wam/program.fs.mustache
@@ -170,19 +170,36 @@ let main argv =
     // (= category_child) in memory, BFS the demand set from it, and prune the
     // parent Dictionary to demand-set edges -- one cursor pass instead of two.
     // The kernel reads it through `lmdbLookupFn`, so WcFfiFacts stays empty and
-    // no immutable Map is ever built.
+    // no immutable Map is ever built.  parentsDict is already demand-pruned, so
+    // the lookup is a plain O(1) Dictionary hit -- no per-call demand filter.
     let parentsDict, demandSet = loadEagerDemandSingleScan lmdbEnv rootInt
-{{default}}
-    // Lazy / cached demand-filtered modes land here in later stages; Stage 1
-    // ships eager only, so any materialisation flag falls back to the eager
-    // single-scan loader -- the project still builds and runs correctly.
-    let parentsDict, demandSet = loadEagerDemandSingleScan lmdbEnv rootInt
-{{/match}}
-    eprintfn "demand_set=%d" demandSet.Count
     let lmdbLookupFn (k: int) : int list =
         match parentsDict.TryGetValue k with
         | true, v -> v
         | _ -> []
+{{case lazy}}
+    // Lazy: NO parent materialisation.  Only the demand set is built (a cursor
+    // BFS down category_child); each kernel lookup opens a short-lived cursor
+    // on category_parent and reads that child's parents on demand, filtered to
+    // the demand set so the upward walk never leaves it.  Trades the eager load
+    // cost for per-lookup cursor cost.
+    let demandSet = reachableToRoot lmdbEnv rootInt System.Int32.MaxValue
+    let lazySource = LmdbCursorLookup(lmdbEnv, "category_parent") :> ILookupSource
+    let lmdbLookupFn (k: int) : int list =
+        if demandSet.Contains k then lazySource.Lookup k |> List.filter demandSet.Contains
+        else []
+{{default}}
+    // Cached: lazy cursor lookup behind the two-level (L1 thread-local +
+    // bounded L2) cache, so repeated parent lookups across seeds are served
+    // from memory.  Demand set built and applied exactly as in lazy mode.
+    let demandSet = reachableToRoot lmdbEnv rootInt System.Int32.MaxValue
+    let lazyInner = LmdbCursorLookup(lmdbEnv, "category_parent") :> ILookupSource
+    let cachedSource = TwoLevelCachedLookupSource(lazyInner, maxL2Entries = {{l2_capacity}}) :> ILookupSource
+    let lmdbLookupFn (k: int) : int list =
+        if demandSet.Contains k then cachedSource.Lookup k |> List.filter demandSet.Contains
+        else []
+{{/match}}
+    eprintfn "demand_set=%d" demandSet.Count
     let parentsInterned : Map<int, int list> = Map.empty
 
     // Identity intern over the ids that cross the register boundary.


### PR DESCRIPTION
  Stage 1 shipped eager only; the `lazy`/`cached` materialisation flags fell back
  to the eager single-scan loader. This wires them for real in the int-native
  demand path:

  - **lazy** — no parent materialisation. Only the demand set is built
    (`reachableToRoot` cursor BFS down `category_child`). Each kernel lookup opens
    a short-lived cursor on `category_parent` via `LmdbCursorLookup` and reads
    that child's parents on demand, filtered to the demand set so the upward walk
    never leaves it.
  - **cached** — the lazy cursor behind `TwoLevelCachedLookupSource` (L1
    thread-local + bounded L2), so repeated parent lookups across seeds are served
    from memory.

  `eager` keeps its O(1) demand-pruned Dictionary. The generator gains
  `lmdb_lazy` / `lmdb_cached` variants alongside `lmdb_eager`.

  ### Results (simplewiki_articles, root 2, 14,680 seeds, serial, warm — all 970 solutions)

  | mode | load | query |
  |---|---|---|
  | eager | ~290 ms | ~1 ms |
  | lazy | ~150–270 ms | ~8 ms |
  | cached | ~160 ms | ~7 ms |

  Lazy/cached trade query speed for a lighter load and bounded memory — they don't
  materialise the full parent map, so they scale to graphs that don't fit in RAM,
  where eager can't go. At simplewiki scale the map fits, so eager wins overall.
  (`cached`'s L2 auto-resolved to 256 entries here — too small to help much;
  tuning `l2_capacity` is a follow-up.) All F# target tests pass.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)