### PR TITLE
LLVM WAM: getuid/1 + geteuid/1 (M95) -- libc uid_t wrappers

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1474,6 +1474,8 @@ declare i32 @system(i8*)
 declare i8* @getcwd(i8*, i64)
 declare i32 @chdir(i8*)
 declare i32 @getpid()
+declare i32 @getuid()
+declare i32 @geteuid()
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3540,6 +3542,8 @@ entry:
     i32 111, label %builtin_halt0
     i32 112, label %builtin_halt1
     i32 113, label %builtin_unsetenv
+    i32 114, label %builtin_getuid
+    i32 115, label %builtin_geteuid
   ]
 
 builtin_is:
@@ -5041,6 +5045,29 @@ us.do:
   %us.ret = call i32 @unsetenv(i8* %us.name)
   %us.ok = icmp eq i32 %us.ret, 0
   ret i1 %us.ok
+
+builtin_getuid:
+  ; M95: getuid(?Uid) -- unifies Uid with the real user id from
+  ; libc getuid() as Integer. uid_t is unsigned 32 bits on Linux;
+  ; zext to i64 so reserved bits stay clear under the Integer tag.
+  ; Always succeeds (getuid cannot fail).
+  %gu.uid = call i32 @getuid()
+  %gu.uid64 = zext i32 %gu.uid to i64
+  %gu.v = call %Value @value_integer(i64 %gu.uid64)
+  %gu.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %gu.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %gu.raw1, %Value %gu.v)
+  ret i1 %gu.ok
+
+builtin_geteuid:
+  ; M95: geteuid(?EUid) -- effective uid via libc geteuid(). Same
+  ; shape as builtin_getuid; differs only when the process has a
+  ; setuid bit set or has called seteuid.
+  %geu.uid = call i32 @geteuid()
+  %geu.uid64 = zext i32 %geu.uid to i64
+  %geu.v = call %Value @value_integer(i64 %geu.uid64)
+  %geu.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %geu.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %geu.raw1, %Value %geu.v)
+  ret i1 %geu.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11880,6 +11907,8 @@ builtin_op_to_id('format_time/3', 110).       % strftime(Fmt, localtime(Stamp)).
 builtin_op_to_id('halt/0', 111).              % libc exit(0).
 builtin_op_to_id('halt/1', 112).              % libc exit(Code).
 builtin_op_to_id('unsetenv/1', 113).          % libc unsetenv(Name).
+builtin_op_to_id('getuid/1', 114).            % libc getuid() as Integer.
+builtin_op_to_id('geteuid/1', 115).           % libc geteuid() as Integer.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2096,6 +2096,8 @@ is_builtin_pred(shell, 1).              % shell(+Command).
 is_builtin_pred(shell, 2).              % shell(+Command, -Status).
 is_builtin_pred(working_directory, 2).  % working_directory(?Old, ?New).
 is_builtin_pred(getpid, 1).             % getpid(-Pid).
+is_builtin_pred(getuid, 1).             % getuid(-Uid).
+is_builtin_pred(geteuid, 1).            % geteuid(-EUid).
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,28 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M95: getuid/1 + geteuid/1 -- libc uid_t wrappers.
+
+:- dynamic test_uid_nonneg/2.
+test_uid_nonneg(_, R) :-
+    % getuid is unsigned -- always >= 0. Just sanity-check that the
+    % i32->i64 zext path doesn''t produce a negative i64.
+    getuid(U),
+    ( U >= 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_euid_nonneg/2.
+test_euid_nonneg(_, R) :-
+    geteuid(E),
+    ( E >= 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_uid_eq_euid/2.
+test_uid_eq_euid(_, R) :-
+    % In an unprivileged context (the test container) no setuid bit
+    % is in play, so real and effective uids should match.
+    getuid(U),
+    geteuid(E),
+    ( U =:= E -> R is 1 ; R is 0 ).   % 1
+
 % M93: unsetenv/1 -- libc unsetenv() wrapper, complement to M77 setenv/2.
 
 :- dynamic test_unsetenv_roundtrip/2.
@@ -4794,6 +4816,13 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M95 getuid/1 + geteuid/1 ---~n'),
+       run_test_r0('getuid(U), U >= 0 -> 1',
+                   test_uid_nonneg, 0, 1),
+       run_test_r0('geteuid(E), E >= 0 -> 1',
+                   test_euid_nonneg, 0, 1),
+       run_test_r0('getuid =:= geteuid (no setuid) -> 1',
+                   test_uid_eq_euid, 0, 1),
        format('--- M93 unsetenv/1 ---~n'),
        run_test_r0('setenv/getenv/unsetenv/getenv-fails roundtrip -> 1',
                    test_unsetenv_roundtrip, 0, 1),


### PR DESCRIPTION
## Summary

- **M95 `getuid/1` + `geteuid/1`** — symmetric libc uid_t wrappers. Op ids 114 / 115.

Both blocks are shape-identical to M79 `builtin_getpid`: call the libc routine, `zext` the `i32` uid_t to `i64` (uid_t is unsigned on Linux, so `zext` keeps reserved Integer-tag bits clear), pack as Integer Value, unify with reg 0. Always succeed — neither libc call can fail.

`getuid` returns the real uid; `geteuid` returns the effective uid. They differ only when a setuid bit is in play or `seteuid` has been called.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `@getuid` + `@geteuid` libc decls, two dispatch entries, `builtin_getuid` (prefix `gu.`) + `builtin_geteuid` (prefix `geu.`) IR blocks, op-id table entries.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred(getuid, 1)` + `is_builtin_pred(geteuid, 1)`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — three M95 tests + section in `test_all`.

## Test plan

- [x] Full execution suite: **618/618 PASS**, no failures, no OOM
- [x] `test_uid_nonneg`: `getuid(U), U >= 0` ✓ (sanity-checks the zext path)
- [x] `test_euid_nonneg`: `geteuid(E), E >= 0` ✓
- [x] `test_uid_eq_euid`: `getuid =:= geteuid` ✓ (unprivileged context, no setuid bit)

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_