### PR TITLE
test(conformance): add Go backend (+ fix is/2 integer result; 3 gaps tracked)

### DIFF
--- a/docs/WAM_CROSS_TARGET_CONFORMANCE.md
+++ b/docs/WAM_CROSS_TARGET_CONFORMANCE.md
@@ -24,12 +24,17 @@ entry point, so invocation is per-target:
 
 - **scala** passes the query args straight to its `GeneratedProgram`
   driver (`<predkey> <args...>` → `true`/`false`).
-- **elixir / wat / haskell / python** synthesise a ground 0-arity wrapper
-  per query (`ctw_N :- pred(args).`), build it with the program, and ask
-  whether `ctw_N` succeeds. This is the shape their own runtime tests use.
-  (Python is interpreted — no build step; its generated `main.py` prints
-  `A_i = ...` register dumps on success and `false.` on failure, so the
-  adapter reads success as the absence of `false.`.)
+- **elixir / wat / haskell / python / go** synthesise a ground 0-arity
+  wrapper per query (`ctw_N :- pred(args).`), build it with the program,
+  and ask whether `ctw_N` succeeds. This is the shape their own runtime
+  tests use. (Python is interpreted — no build step; its generated
+  `main.py` prints `A_i = ...` register dumps on success and `false.` on
+  failure, so the adapter reads success as the absence of `false.`. Go is
+  compiled via `prefer_wam(true)` — its default strategy is the
+  dataflow/stream backend, not the shared WAM pipeline — and `ct_build`
+  gates compilation with `go build`, while `ct_run` executes `go run`,
+  which launches the program from go's build cache rather than exec'ing a
+  binary under `$TMPDIR`.)
 
 Each adapter is self-contained (`ct_build/4`, `ct_run/5`,
 `ct_teardown/2`); adding a backend is one adapter plus a
@@ -80,17 +85,17 @@ so any failure is reproducible from the recorded seed.
 
 ## Known divergences (tracked as `ct_xfail/2`)
 
-The harness is green today and **every registered backend — scala,
-elixir, wat, haskell, and python — now passes the whole spec** (there are
-no live `ct_xfail/2` or `ct_skip/2` entries; both are declared `dynamic`
-so they may have zero clauses). The oracle is the hand-specified
-expected-results table in `wam_conformance_fixtures.pl` (standard Prolog
-semantics), not any backend's output; Scala was the original reference.
-The table below is the historical record of divergences the harness
-surfaced and that were fixed — each was a real backend gap, not a fixture
-artifact. (A future divergence would be tolerated and logged via a new
-`ct_xfail/2`, with an unexpected pass logged as `XPASS` so the entry can
-be retired.)
+The harness is green today. **scala, elixir, wat, haskell, and python
+pass the whole spec**; **go passes append/fib/ack and has three live
+`ct_xfail/2` entries** (member, reverse, builtins) for gaps still open in
+its WAM runtime. The oracle is the hand-specified expected-results table
+in `wam_conformance_fixtures.pl` (standard Prolog semantics), not any
+backend's output; Scala was the original reference. Mismatches under an
+`ct_xfail/2` are tolerated and logged; an unexpected full match is logged
+as `XPASS` so the entry can be retired once the gap is fixed. The table
+below records every divergence the harness has surfaced — each a real
+backend gap, not a fixture artifact — marking which are fixed and which
+remain open.
 
 | Backend | Program(s) | Kind | Cause |
 |---|---|---|---|
@@ -102,8 +107,13 @@ be retired.)
 | ~~haskell~~ | ~~member, append, reverse~~ | **fixed** | All three failed on heap-built cons lists. Four root causes, now fixed in `wam_haskell_target.pl`: (1) `unifyVal`/`unifyValues` did **no** structural unification — added a shared `unifyTerms`; (2) the cons functor `"[|]/2"` interned to its own id, distinct from `atomDot` — `intern_struct_functor/2` folds every cons spelling onto `atomDot` (the `./2`-vs-`[|]/2` class, same as the Elixir bug); (3) `GetValue` had its own inline unify bypassing the above — now routed through `unifyVal`; (4) **the multi-element bug** — building `[a\|X]` with `X` a `set_variable` tail placeholder emitted `VList [a, X]` (`X` as a 2nd *element*) and `put_structure` filling `X` did not bind the embedded var, so `addToBuilder` now emits a `Str atomDot [hd, tl]` cons cell for a partial tail and binds the placeholder var on finalize. Fixes lists of any length; xfails removed. |
 | ~~haskell~~ | ~~builtins~~ | **fixed** | `=/2` of two identical atoms returned false (no `BuiltinCall "=/2"` handler — added one routing through `unifyVal`), and `//`/`mod` evaluated incorrectly: the arity-stripper `takeWhile (/= '/')` truncated any operator containing `/` (so `//` → `""`). Replaced with `bareArithOp` (strips only a trailing `/<digits>`). `fib`/`ack` already passed. Now conformant; xfail removed. |
 | ~~python~~ | ~~builtins~~ | **fixed** | `cbi_arith(28)` → false: `wam_line_to_python_literal` computed the `put_structure`/`get_structure` arity with `split_string(Fn,"/","",[_,ArStr])`, which expects exactly two parts and fell back to **arity 0** for `///2` (integer division `//`). A 0-arity `//` compound carried no argument cells, so `eval_arith` could not apply it and `X is 17 // 5` failed — the same `/`-in-operator class as the Haskell/WAT `//` bugs. Added `python_functor_arity/2` (last `/`-component). The Python adapter was added to the harness in the same change; every other program already passed. |
+| ~~go~~ | ~~fib, ack~~ | **fixed** | `is/2` wrapped every result in `&Float`, but Go's `Unify` is type-strict (Integer never unifies with Float), so `R is N + 1` failed whenever R was already bound to a ground Integer — `cack(0,5,6)`, `cfib(10,55)`. Integral results now wrap as `&Integer` (mirrors the Python int-vs-float heuristic), in `templates/targets/go_wam/state.go.mustache`. Made fib and ack pass; the Go adapter was added in the same change. |
+| go | member, reverse | **xfail** | Cons-cell gap. The compiler builds a list as an outer `put_list` `*List` cell whose tail cells are `put_structure "[|]/2"` `*Structure`s, but `GetList` only recognises `*List`, so the recursion mis-unifies the tail: `cmem(z,[a,b,c])` wrongly succeeds and `clist_reverse([a,b,c],[a,b,c])` mismatches. Same `./2`-vs-`[|]/2` class as Elixir/Haskell/WAT, but a localized `GetList` fix proved insufficient (member still wrong) and regressed reverse into a non-terminating loop — the real fix is a broader overhaul of Go list unification/backtracking. |
+| go | builtins | **xfail** | Nested-arithmetic gap. A single `is` of two operands is correct (fib/ack and `//`/`mod` in isolation all pass), but an expression of depth ≥ 2 — `cbi_arith`'s `A+B+C+D+E`, i.e. `+(+(+(+(A,B),C),D),E)` — mis-evaluates, so `cbi_arith(28)` → false. The two-variable sum works; three or more does not. |
 
 (Haskell is opt-in — `CONFORMANCE_TARGETS=haskell` — because each program is a cabal compile. `fib` and `ack` pass; the driver, `tests/fixtures/haskell_conformance_driver.hs`, runs a 0-arity wrapper whose atoms are baked into the compiled stream, which is what removed the earlier interning mismatch — see below.)
+
+(Go is opt-in too — `CONFORMANCE_TARGETS=go`. `append`, `fib`, and `ack` pass; `member`, `reverse`, and `builtins` are tracked as `ct_xfail/2` — see the table above. The driver is a small generated `main.go` that looks up the wrapper label in `SharedWamLabels` and runs `vm.Run()`.)
 
 `ct_xfail/2` = build and run, tolerate a wrong answer (and log `XPASS` if
 it unexpectedly matches). `ct_skip/2` = do not even build, because

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -243,8 +243,22 @@ compile_lowered_predicates(Predicates, Options, Code) :-
 read_template_file(Path, Content) :-
     (   exists_file(Path)
     ->  read_file_to_string(Path, Content, [])
+    ;   resolve_template_path(Path, AbsPath), exists_file(AbsPath)
+    ->  read_file_to_string(AbsPath, Content, [])
     ;   format(atom(Content), "// Template not found: ~w", [Path])
     ).
+
+%% resolve_template_path(+RelativePath, -AbsPath)
+%  Resolve a repo-root-relative template path against this module's source
+%  location, so generation works from any working directory (e.g. the
+%  conformance harness runs from tests/, where the cwd-relative
+%  'templates/...' path does not exist). Mirrors the python target's
+%  source_file/2-based resolution.
+resolve_template_path(RelativePath, AbsPath) :-
+    source_file(wam_go_target:write_wam_go_project(_,_,_), ThisFile),
+    file_directory_name(ThisFile, TargetsDir),   % src/unifyweaver/targets
+    atomic_list_concat([TargetsDir, '/../../../', RelativePath], Raw),
+    absolute_file_name(Raw, AbsPath).
 
 %% compile_predicates_for_project(+Predicates, +Options, -Code)
 compile_predicates_for_project([], _, "").

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1333,7 +1333,18 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 	case "is/2":
 		val, ok := vm.evalArithmetic(arg2)
 		if !ok { return false }
-		return vm.Unify(arg1, &Float{Val: val})
+		// Produce an Integer for integral results: Unify is type-strict
+		// (Integer never unifies with Float), so always wrapping in Float
+		// made `R is N + 1` fail whenever R was already bound to a ground
+		// Integer (e.g. cack(0,5,6) / cfib(10,55) / cbi_arith). Mirrors the
+		// Python target's int-vs-float result heuristic.
+		var result Value
+		if !math.IsInf(val, 0) && val == math.Trunc(val) {
+			result = &Integer{Val: int64(val)}
+		} else {
+			result = &Float{Val: val}
+		}
+		return vm.Unify(arg1, result)
 
 	case "=:=/2" :
 		v1, ok1 := vm.evalArithmetic(arg1)

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -55,6 +55,8 @@
               [write_wam_haskell_project/3]).
 :- use_module('../src/unifyweaver/targets/wam_python_target',
               [write_wam_python_project/3]).
+:- use_module('../src/unifyweaver/targets/wam_go_target',
+              [write_wam_go_project/3]).
 
 % ============================================================
 % Target registry + known-divergence (xfail) registry
@@ -65,6 +67,7 @@ conformance_target(elixir).
 conformance_target(wat).
 conformance_target(haskell).
 conformance_target(python).
+conformance_target(go).
 
 %% ct_default_target(Target): runs unless CONFORMANCE_TARGETS overrides.
 %  WAT and Haskell are wired up but NOT defaults: their backends still
@@ -165,6 +168,30 @@ ct_default_target(elixir).
 %  fib/ack already passed, so +/-/comparison and is/2 bound-LHS checking
 %  were fine; with these two fixes the Haskell adapter is fully green.
 
+%  Go (LIVE xfails). The Go WAM runtime is exercised here via
+%  prefer_wam(true) (its default strategy is the dataflow/stream backend,
+%  not the shared WAM pipeline). Onboarding surfaced three independent
+%  gaps; fib/ack/append are conformant, the rest are tracked below.
+%   - is/2 produced a Float for every result, and Unify is type-strict
+%     (Integer never unifies with Float), so `R is N + 1` failed whenever
+%     R was bound to a ground Integer. FIXED in state.go.mustache (integral
+%     results now wrap as Integer), which made fib and ack pass.
+%   - member/reverse (cons-cell gap, still open): the compiler builds a
+%     list as an outer put_list *List cell whose tail cells are
+%     put_structure "[|]/2" *Structures, but GetList only recognises *List,
+%     so the recursion mis-unifies the tail. cmem(z,[a,b,c]) wrongly
+%     succeeds and clist_reverse mismatches. A localized GetList fix was
+%     attempted but is insufficient (member still wrong) and regressed
+%     reverse into a non-terminating loop, so the proper fix is a broader
+%     overhaul of list unification/backtracking — tracked, not forced.
+%   - builtins (nested-arithmetic gap, still open): a single `is` of two
+%     operands evaluates correctly (fib/ack/`//`/`mod` all work), but a
+%     nested expression of depth >= 2 (cbi_arith's A+B+C+D+E, i.e.
+%     +(+(+(+(A,B),C),D),E)) mis-evaluates, so cbi_arith(28) fails.
+ct_xfail(go, member).
+ct_xfail(go, reverse).
+ct_xfail(go, builtins).
+
 %% ct_skip(Target, ProgramName)
 %  Stronger than xfail: do NOT even build/run this (target, program).
 %  Used when *generation itself* is unusable, not just the answer.
@@ -192,6 +219,7 @@ ct_toolchain(elixir, [elixir]).
 ct_toolchain(wat,    [wat2wasm, node]).
 ct_toolchain(haskell, [ghc, cabal]).
 ct_toolchain(python, [python3]).
+ct_toolchain(go,     [go]).
 
 ct_available(scala) :-
     ct_enabled(scala),
@@ -229,6 +257,7 @@ test(scala,  [condition(ct_available(scala))])  :- run_target_conformance(scala)
 test(elixir, [condition(ct_available(elixir))]) :- run_target_conformance(elixir).
 test(wat,    [condition(ct_available(wat))])    :- run_target_conformance(wat).
 test(python, [condition(ct_available(python))]) :- run_target_conformance(python).
+test(go,     [condition(ct_available(go))])     :- run_target_conformance(go).
 
 :- end_tests(wam_cross_target_conformance).
 
@@ -622,6 +651,80 @@ ct_run(python, python_ctx(Dir, Map), K, A, Bool) :-
     ).
 
 ct_teardown(python, python_ctx(Dir, Map)) :-
+    cleanup_dir(Dir), abolish_wrappers(Map).
+
+% ============================================================
+% Adapter: Go  (0-arity wrapper -> `./bin <key>` -> true/false)
+%
+% write_wam_go_project/3 compiles predicate INDICATORS itself, but its
+% DEFAULT strategy is the dataflow/stream Go backend (a stdin filter),
+% NOT the WAM pipeline the other backends share. prefer_wam(true) forces
+% every predicate through compile_predicate_to_wam, so Go is tested on the
+% same WAM lowering as scala/elixir/wat/haskell/python. We generate with
+% package_name(main) (which emits a domain-specific benchmark main.go) and
+% then OVERWRITE main.go with a tiny query-runner driver: it looks up the
+% wrapper label in SharedWamLabels, sets vm.PC, and runs vm.Run() — which
+% returns true only when the machine halts (Proceed with CP<=0), false on
+% backtrack exhaustion. Go compiles fast to a single binary, so ct_build
+% does the `go build` and ct_run is a cheap exec per query. Opt-in via
+% CONFORMANCE_TARGETS=go.
+% ============================================================
+
+go_runner_driver('package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: runner <pred/arity>")
+		os.Exit(2)
+	}
+	key := os.Args[1]
+	pc, ok := SharedWamLabels[key]
+	if !ok {
+		fmt.Fprintln(os.Stderr, "unknown predicate: "+key)
+		os.Exit(3)
+	}
+	ctx := NewWamContext(SharedWamCode, SharedWamLabels)
+	vm := NewWamStateFromCtx(ctx)
+	setupSharedForeignPredicates(vm)
+	vm.PC = pc
+	if vm.Run() {
+		fmt.Println("true")
+	} else {
+		fmt.Println("false")
+	}
+}
+').
+
+ct_build(go, Preds, Queries, go_ctx(Dir, Map)) :-
+    ct_tmp_dir('tmp_ct_go', Dir),
+    synth_wrappers(Queries, WPreds, Map),
+    maplist(strip_pred, Preds, BarePreds),
+    append(WPreds, BarePreds, AllPreds0),
+    maplist(qualify_user, AllPreds0, AllPreds),
+    write_wam_go_project(AllPreds,
+        [package_name(main), module_name('uw_go_ct'), prefer_wam(true)], Dir),
+    go_runner_driver(DriverSrc),
+    directory_file_path(Dir, 'main.go', MainPath),
+    setup_call_cleanup(open(MainPath, write, S), write(S, DriverSrc), close(S)),
+    run_proc(go, ['build', '-o', 'runner', '.'], Dir, BExit, BErr),
+    ( BExit =:= 0 -> true ; throw(go_build_failed(BExit, BErr)) ).
+
+ct_run(go, go_ctx(Dir, Map), K, A, Bool) :-
+    memberchk((K-A)-WName, Map),
+    format(atom(KeyAtom), '~w/0', [WName]), atom_string(KeyAtom, KeyStr),
+    % Execute via `go run` rather than exec'ing the built binary directly:
+    % process_create(path(AbsPath)) fails to launch a binary under some
+    % $TMPDIR layouts, whereas `go` is resolved on PATH and runs the program
+    % from its own (warm) build cache. ct_build already gated compilation.
+    run_proc_out(go, ['run', '.', KeyStr], Dir, _Exit, OutStr),
+    normalize_space(string(Out), OutStr), bool_of_string(Out, Bool).
+
+ct_teardown(go, go_ctx(Dir, Map)) :-
     cleanup_dir(Dir), abolish_wrappers(Map).
 
 qualify_user(_M:N/A, user:N/A) :- !.


### PR DESCRIPTION
## Summary

Onboards a **6th backend, Go**, to the cross-target WAM conformance harness. Unlike Python (a clean one-line-class fix), Go's WAM runtime turned out to have several independent gaps. This PR fixes one outright, makes another two programs pass as a result, and tracks the remainder as documented `ct_xfail/2` — the harness doing exactly its job.

### Harness adapter (`tests/test_wam_cross_target_conformance.pl`)
- `conformance_target(go)` + `ct_toolchain(go,[go])` + `test/2` clause; **opt-in** via `CONFORMANCE_TARGETS=go`.
- Go's *default* strategy is the dataflow/stream backend (a stdin filter), **not** the shared WAM pipeline, so the adapter passes **`prefer_wam(true)`** to force every predicate through `compile_predicate_to_wam` — the same WAM lowering the other backends are tested on.
- `ct_build` generates with `package_name(main)`, overwrites the emitted benchmark `main.go` with a tiny query-runner driver, and gates compilation with `go build`. `ct_run` executes **`go run`** (launches from go's build cache rather than exec'ing a binary under `$TMPDIR`, which `process_create` couldn't launch here).

### Backend fixes
- **`is/2` integer results** (`state.go.mustache`): the result was always wrapped in `&Float`, but `Unify` is type-strict (Integer never unifies with Float), so `R is N + 1` failed whenever R was a ground Integer. Integral results now wrap as `&Integer` (mirrors the Python heuristic). **→ fib and ack pass.**
- **`read_template_file`** (`wam_go_target.pl`): only resolved templates against the cwd → empty `go.mod` when run from `tests/`. Added `resolve_template_path/2` (`source_file/2`-based, like the Python target) so generation works from any directory.

## Result

| Program | Status |
|---|---|
| append, fib, ack | ✅ pass |
| member, reverse | ⚠️ `ct_xfail` — cons-cell gap |
| builtins | ⚠️ `ct_xfail` — nested-arithmetic gap |

**Tracked gaps** (precise diagnoses in `ct_xfail` comments + the doc table):
- **member/reverse** — `GetList` recognises only the outer `*List` cell, not the `"[|]/2"` `*Structure` tail cells, so list recursion mis-unifies the tail. The same `./2`-vs-`[|]/2` class as Elixir/Haskell/WAT — but a localized `GetList` fix proved insufficient (member still wrong) and regressed reverse into a non-terminating loop, so the real fix is a broader list-unification/backtracking overhaul, left for a focused follow-up.
- **builtins** — a depth-1 `is` is correct (fib/ack, `//`, `mod` all pass in isolation) but a depth ≥ 2 expression (`cbi_arith`'s `A+B+C+D+E`) mis-evaluates; two-variable sums work, three+ don't.

## Verification
- `CONFORMANCE_TARGETS=go` → **green** (xfails tolerate the 3 divergences; most queries log `XPASS`).
- Go target suites unchanged: generator **10/10**, foreign-lowering **12/12**, builtins, lowered phases 1–3 all pass (the `is/2` change is compatible).
- scala / elixir / python conformance still green (shared-file change is safe).

## Note on scope
The `is/2` fix is clean and broadly useful (any int-result Go WAM program). The two remaining gaps are genuine runtime-depth issues, not fixture artifacts, and each warrants its own focused PR — onboarding-with-xfails is how wat/haskell were introduced before being fixed in follow-ups. The cons-cell class has now appeared in **5 backends**; a shared "WAM cons + operator-functor conventions" doc would still pay for itself.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_