### PR TITLE
fix(wam-runtime): dispatch arity-1 type-check builtins (atom/1 et al.)

### DIFF
--- a/src/unifyweaver/runtime/wam_runtime.pl
+++ b/src/unifyweaver/runtime/wam_runtime.pl
@@ -1065,6 +1065,20 @@ step_wam(builtin_call('var/1', 1), wam_state(PC, R, S, H, T, CP, CPS, Code, L),
     is_wam_unbound(DVal),
     NPC is PC + 1.
 
+%% Type-check builtins (atom/1, integer/1, float/1, number/1,
+%% compound/1, is_list/1). These were defined in apply_type_check/2
+%% but had no step_wam dispatch clause — only var/1 and nonvar/1 above
+%% were wired up — so e.g. atom(hello) matched no clause and failed.
+%% Read A1, deref, and apply the type test. (var/1 and nonvar/1 are
+%% also is_type_check_op/1 ops but are handled by the explicit clauses
+%% above, which take priority.)
+step_wam(builtin_call(Op, 1), wam_state(PC, R, S, H, T, CP, CPS, Code, L),
+         wam_state(NPC, R, S, H, T, CP, CPS, Code, L)) :-
+    is_type_check_op(Op), !,
+    get_assoc('A1', R, Val), wam_deref(Val, DVal),
+    apply_type_check(Op, DVal),
+    NPC is PC + 1.
+
 %% !/0 — cut: truncate choice points to the cut barrier.
 %  The cut barrier is saved at Allocate time in the env frame.
 step_wam(builtin_call('!/0', 0), wam_state(PC, R, S, H, T, CP, CPS, Code, L),


### PR DESCRIPTION
  ## Summary

  `test_wam_e2e`'s "Built-in type check (atom/1)" case was failing because the
  WAM interpreter (`src/unifyweaver/runtime/wam_runtime.pl`) had no dispatch for
  arity-1 type-check builtins.

  ## Root cause

  `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `is_list/1` were
  declared in `is_type_check_op/1` and implemented in `apply_type_check/2`, but
  no `step_wam` clause routed `builtin_call(Op, 1)` to them — only `var/1` and
  `nonvar/1` had explicit clauses. So `builtin_call('atom/1', 1)` matched no
  clause, `step_wam` failed, and the goal failed: `execute_wam(Code,
  e2e_is_atom(hello), _)` (compiled to `builtin_call atom/1, 1`) returned
  failure even though `hello` is an atom.

  ## Fix

  Add a generic clause guarded by `is_type_check_op/1`:

  ```prolog
  step_wam(builtin_call(Op, 1), wam_state(PC, R, S, H, T, CP, CPS, Code, L),
           wam_state(NPC, R, S, H, T, CP, CPS, Code, L)) :-
      is_type_check_op(Op), !,
      get_assoc('A1', R, Val), wam_deref(Val, DVal),
      apply_type_check(Op, DVal),
      NPC is PC + 1.
  ```

  Placed after the explicit `var/1`/`nonvar/1` clauses, which keep priority.

  ## Verification
  - `atom(hello)`=true, `atom(123)`=false, `integer(7)`=true,
    `integer(foo)`=false, `compound(f(a))`=true, `compound(foo)`=false,
    `is_list([a,b])`=true, `var(hello)`=false.
  - `test_wam_e2e` passes; `test_wam_target` and
    `test_wam_runtime_parser_capability` still pass