### PR TITLE
WAM F# target: cached-mode warm-query parity with eage

### DIFF
--- a/templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache
+++ b/templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache
@@ -508,3 +508,14 @@ type LmdbCursorLookup(env: LightningEnvironment, dbName: string) =
                     else
                         ok <- false
                 result
+
+/// Decorator that demand-filters an inner source's results.  Used UNDER the
+/// cache (TwoLevelCachedLookupSource(DemandFilteredSource(cursor, demand)))
+/// so the cache stores already-pruned parent lists: a cache hit then returns
+/// the filtered list directly, with no per-lookup List.filter allocation.
+/// Without this the filter sits outside the cache and re-runs (and re-allocs)
+/// on every hit, which keeps "cached" query as slow as "lazy".
+type DemandFilteredSource(inner: WamTypes.ILookupSource, demand: Set<int>) =
+    interface WamTypes.ILookupSource with
+        member _.Lookup(key: int) : int list =
+            inner.Lookup key |> List.filter demand.Contains

--- a/templates/targets/fsharp_wam/program.fs.mustache
+++ b/templates/targets/fsharp_wam/program.fs.mustache
@@ -192,12 +192,32 @@ let main argv =
     // Cached: lazy cursor lookup behind the two-level (L1 thread-local +
     // bounded L2) cache, so repeated parent lookups across seeds are served
     // from memory.  Demand set built and applied exactly as in lazy mode.
+    //
+    // Cache sizing: the demand set IS the working set -- every parent the
+    // kernel can ever touch is in it -- and its exact size is known here at
+    // runtime.  So size L2 to cover the demand set (it is what makes "cached"
+    // actually cache rather than thrash); a compile-time {{l2_capacity}} guess
+    // floors at 256 and would miss ~98% of a 14k-node working set.  The
+    // configured value is still honoured as a LOWER bound / memory ceiling
+    // override.  L1 is rounded up to the next power of two >= demand (its
+    // index is a bit-mask, so it must be a power of two).
     let demandSet = reachableToRoot lmdbEnv rootInt System.Int32.MaxValue
+    let l2Cap = max {{l2_capacity}} demandSet.Count
+    let l1Cap =
+        let mutable p = 1024
+        while p < demandSet.Count do p <- p * 2
+        p
+    // Filter UNDER the cache so it stores already-pruned lists: a cache hit
+    // then returns the filtered list directly, with no per-lookup re-filter or
+    // allocation.  (Filtering outside the cache kept cached as slow as lazy.)
     let lazyInner = LmdbCursorLookup(lmdbEnv, "category_parent") :> ILookupSource
-    let cachedSource = TwoLevelCachedLookupSource(lazyInner, maxL2Entries = {{l2_capacity}}) :> ILookupSource
-    let lmdbLookupFn (k: int) : int list =
-        if demandSet.Contains k then cachedSource.Lookup k |> List.filter demandSet.Contains
-        else []
+    let filteredInner = DemandFilteredSource(lazyInner, demandSet) :> ILookupSource
+    let cachedSource = TwoLevelCachedLookupSource(filteredInner, l1Capacity = l1Cap, maxL2Entries = l2Cap) :> ILookupSource
+    // No demandSet.Contains guard here: DemandFilteredSource already returns
+    // only demand-set parents, so a non-demand node can never be reached (all
+    // its parents are non-demand -> []).  Dropping the guard removes an
+    // O(log n) F# Set lookup from every kernel call -- the last gap to eager.
+    let lmdbLookupFn (k: int) : int list = cachedSource.Lookup k
 {{/match}}
     eprintfn "demand_set=%d" demandSet.Count
     let parentsInterned : Map<int, int list> = Map.empty


### PR DESCRIPTION
  Stage 2 shipped working lazy/cached, but cached's query was ~7ms vs eager's
  ~1ms — the cache wasn't paying off. Three fixes bring cached's WARM query to
  parity with eager (~1ms), so F# cached behaves like the Rust/Haskell cached
  mode: competitive for most query volumes, eager winning only at very high
  query counts.

  1. **Size the cache to the demand set, at runtime.** The auto-resolver floored
     L2 at 256 (no `fact_count` passed), missing ~98% of a 14,680-node working
     set. The demand set IS the working set and its size is known at runtime, so
     `L2 = max(configured, demandSet.Count)`, `L1 = next pow2 ≥ demand`. The
     configured value stays a lower-bound / memory-ceiling override.
  2. **Filter UNDER the cache** (new `DemandFilteredSource`). Previously the
     demand filter sat outside the cache, re-running `List.filter` (+ alloc) on
     every hit. Now `TwoLevelCachedLookupSource` wraps `DemandFilteredSource`, so
     the cache stores pre-pruned lists and a hit returns directly.
  3. **Drop the per-lookup `demandSet.Contains` guard** — `DemandFilteredSource`
     already returns only demand parents, so a non-demand node is unreachable.
     The guard was an O(log n) F# `Set` lookup per kernel call.

  ### Per-rep (simplewiki_articles, root 2, 14,680 seeds, serial; 970 solutions all)

  | mode | load | rep 1 | warm rep |
  |---|---|---|---|
  | eager | ~254 ms | 3 ms | ~0–1 ms |
  | cached | ~142 ms | ~40 ms (cache fill) | ~1 ms |
  | lazy | ~148 ms | 15 ms | ~8 ms |

  Total over R reps: eager ≈ 257 (flat) · cached ≈ 181 + R · lazy ≈ 148 + 8R.
  Lazy/cached win at low–moderate query volume; eager wins only beyond ~76 reps
  (~1.1M queries). Matches the Rust/Haskell cached-vs-eager crossover. All F#
  target tests pass.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)