### PR TITLE
LLVM WAM: getgid/1 + getegid/1 + getppid/1 (M96)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1476,6 +1476,9 @@ declare i32 @chdir(i8*)
 declare i32 @getpid()
 declare i32 @getuid()
 declare i32 @geteuid()
+declare i32 @getgid()
+declare i32 @getegid()
+declare i32 @getppid()
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3544,6 +3547,9 @@ entry:
     i32 113, label %builtin_unsetenv
     i32 114, label %builtin_getuid
     i32 115, label %builtin_geteuid
+    i32 116, label %builtin_getgid
+    i32 117, label %builtin_getegid
+    i32 118, label %builtin_getppid
   ]
 
 builtin_is:
@@ -5068,6 +5074,36 @@ builtin_geteuid:
   %geu.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %geu.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %geu.raw1, %Value %geu.v)
   ret i1 %geu.ok
+
+builtin_getgid:
+  ; M96: getgid(?Gid) -- real group id via libc getgid(). gid_t is
+  ; unsigned 32 bits on Linux; zext to i64. Always succeeds.
+  %gg.gid = call i32 @getgid()
+  %gg.gid64 = zext i32 %gg.gid to i64
+  %gg.v = call %Value @value_integer(i64 %gg.gid64)
+  %gg.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %gg.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %gg.raw1, %Value %gg.v)
+  ret i1 %gg.ok
+
+builtin_getegid:
+  ; M96: getegid(?EGid) -- effective gid via libc getegid().
+  %gegg.gid = call i32 @getegid()
+  %gegg.gid64 = zext i32 %gegg.gid to i64
+  %gegg.v = call %Value @value_integer(i64 %gegg.gid64)
+  %gegg.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %gegg.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %gegg.raw1, %Value %gegg.v)
+  ret i1 %gegg.ok
+
+builtin_getppid:
+  ; M96: getppid(?PPid) -- parent process id via libc getppid().
+  ; pid_t is signed 32 bits; sext to i64 to keep the sign correct
+  ; even though a real ppid is always positive.
+  %gpp.pid = call i32 @getppid()
+  %gpp.pid64 = sext i32 %gpp.pid to i64
+  %gpp.v = call %Value @value_integer(i64 %gpp.pid64)
+  %gpp.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %gpp.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %gpp.raw1, %Value %gpp.v)
+  ret i1 %gpp.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11909,6 +11945,9 @@ builtin_op_to_id('halt/1', 112).              % libc exit(Code).
 builtin_op_to_id('unsetenv/1', 113).          % libc unsetenv(Name).
 builtin_op_to_id('getuid/1', 114).            % libc getuid() as Integer.
 builtin_op_to_id('geteuid/1', 115).           % libc geteuid() as Integer.
+builtin_op_to_id('getgid/1', 116).            % libc getgid() as Integer.
+builtin_op_to_id('getegid/1', 117).           % libc getegid() as Integer.
+builtin_op_to_id('getppid/1', 118).           % libc getppid() as Integer.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2098,6 +2098,9 @@ is_builtin_pred(working_directory, 2).  % working_directory(?Old, ?New).
 is_builtin_pred(getpid, 1).             % getpid(-Pid).
 is_builtin_pred(getuid, 1).             % getuid(-Uid).
 is_builtin_pred(geteuid, 1).            % geteuid(-EUid).
+is_builtin_pred(getgid, 1).             % getgid(-Gid).
+is_builtin_pred(getegid, 1).            % getegid(-EGid).
+is_builtin_pred(getppid, 1).            % getppid(-PPid).
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,38 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M96: getgid/1 + getegid/1 + getppid/1 -- more libc process-info wrappers.
+
+:- dynamic test_gid_nonneg/2.
+test_gid_nonneg(_, R) :-
+    getgid(G),
+    ( G >= 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_egid_nonneg/2.
+test_egid_nonneg(_, R) :-
+    getegid(E),
+    ( E >= 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_gid_eq_egid/2.
+test_gid_eq_egid(_, R) :-
+    % Unprivileged context: real == effective.
+    getgid(G),
+    getegid(E),
+    ( G =:= E -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_ppid_positive/2.
+test_ppid_positive(_, R) :-
+    % A spawned binary always has a positive parent pid (its launcher).
+    getppid(PP),
+    ( PP > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_ppid_neq_pid/2.
+test_ppid_neq_pid(_, R) :-
+    % The test binary cannot be its own parent.
+    getpid(P),
+    getppid(PP),
+    ( P =\= PP -> R is 1 ; R is 0 ).   % 1
+
 % M95: getuid/1 + geteuid/1 -- libc uid_t wrappers.
 
 :- dynamic test_uid_nonneg/2.
@@ -4816,6 +4848,17 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M96 getgid/1 + getegid/1 + getppid/1 ---~n'),
+       run_test_r0('getgid(G), G >= 0 -> 1',
+                   test_gid_nonneg, 0, 1),
+       run_test_r0('getegid(E), E >= 0 -> 1',
+                   test_egid_nonneg, 0, 1),
+       run_test_r0('getgid =:= getegid (no setgid) -> 1',
+                   test_gid_eq_egid, 0, 1),
+       run_test_r0('getppid(PP), PP > 0 -> 1',
+                   test_ppid_positive, 0, 1),
+       run_test_r0('getpid =\\= getppid -> 1',
+                   test_ppid_neq_pid, 0, 1),
        format('--- M95 getuid/1 + geteuid/1 ---~n'),
        run_test_r0('getuid(U), U >= 0 -> 1',
                    test_uid_nonneg, 0, 1),


### PR DESCRIPTION
## Summary

Three more libc process-info wrappers, all shape-identical to M79 `builtin_getpid` and M95 `builtin_getuid` / `builtin_geteuid`: call the libc routine, widen the `i32` result to `i64`, pack as Integer, unify with reg 0. Always succeed.

- **M96 `getgid/1`** (op 116) — real gid via `getgid()`. `gid_t` is unsigned, `zext`.
- **M96 `getegid/1`** (op 117) — effective gid via `getegid()`. `gid_t`, `zext`.
- **M96 `getppid/1`** (op 118) — parent pid via `getppid()`. `pid_t` is signed, `sext` to keep the sign correct even though a real ppid is positive.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — three libc decls, three dispatch entries, three IR blocks (`gg.` / `gegg.` / `gpp.` prefixes), three op-id table entries.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred` entries for all three.
- `tests/core/test_wam_llvm_builtin_execution.pl` — five M96 tests + section in `test_all`.

## Test plan

- [x] Full execution suite: **623/623 PASS**, no failures, no OOM
- [x] `test_gid_nonneg` / `test_egid_nonneg`: zext sanity ✓
- [x] `test_gid_eq_egid`: unprivileged context, real == effective ✓
- [x] `test_ppid_positive`: a spawned binary always has a positive ppid ✓
- [x] `test_ppid_neq_pid`: the binary cannot be its own parent ✓

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_