### PR TITLE
LLVM WAM: set_random/1 (M97) -- srand48 via seed(N) compound

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1245,6 +1245,11 @@ write_wam_llvm_project(Predicates, Options, OutputFile) :-
     % strcmp against these registered names.
     register_functor_string("pi"),
     register_functor_string("e"),
+    % M97: set_random(seed(N)) -- builtin_set_random does strcmp on
+    % the compound''s functor string against "seed". Pre-register so
+    % @.fn_seed is in the module even for programs that never
+    % explicitly construct a `seed/1' compound elsewhere.
+    register_functor_string("seed"),
     % M9: intern "[]" so the empty-list atom id is known at runtime.
     % @wam_apply_aggregation's collect_case reads this id from a
     % module-level global to terminate the cons-cell chain.
@@ -1483,6 +1488,7 @@ declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
 declare i64 @lrand48()
+declare void @srand48(i64)
 declare i8* @localtime_r(i64*, i8*)
 declare i64 @strftime(i8*, i64, i8*, i8*)
 declare double @asin(double)
@@ -3550,6 +3556,7 @@ entry:
     i32 116, label %builtin_getgid
     i32 117, label %builtin_getegid
     i32 118, label %builtin_getppid
+    i32 119, label %builtin_set_random
   ]
 
 builtin_is:
@@ -5104,6 +5111,47 @@ builtin_getppid:
   %gpp.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %gpp.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %gpp.raw1, %Value %gpp.v)
   ret i1 %gpp.ok
+
+builtin_set_random:
+  ; M97: set_random(+Option) -- seeds libc srand48. Option must be
+  ; the compound seed/1 with an Integer arg (matches SWI''s
+  ; set_random/1 calling convention). Other Option shapes fail
+  ; rather than erroring -- this isn''t the place to validate every
+  ; SWI-side option since the only one with a libc-mappable
+  ; semantic is the seed/1 compound.
+  %sr.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %sr.tag = call i32 @value_tag(%Value %sr.a1)
+  %sr.is_cp = icmp eq i32 %sr.tag, 3
+  br i1 %sr.is_cp, label %sr.check_arity, label %sr.fail
+sr.fail:
+  ret i1 false
+sr.check_arity:
+  %sr.cp_bits = call i64 @value_payload(%Value %sr.a1)
+  %sr.cp_ptr = inttoptr i64 %sr.cp_bits to %Compound*
+  %sr.ar_slot = getelementptr %Compound, %Compound* %sr.cp_ptr, i32 0, i32 1
+  %sr.ar = load i32, i32* %sr.ar_slot
+  %sr.ar_ok = icmp eq i32 %sr.ar, 1
+  br i1 %sr.ar_ok, label %sr.check_name, label %sr.fail
+sr.check_name:
+  %sr.fn_slot = getelementptr %Compound, %Compound* %sr.cp_ptr, i32 0, i32 0
+  %sr.fn_i8 = load i8*, i8** %sr.fn_slot
+  %sr.want = getelementptr [5 x i8], [5 x i8]* @.fn_seed, i32 0, i32 0
+  %sr.cmp = call i32 @strcmp(i8* %sr.fn_i8, i8* %sr.want)
+  %sr.name_ok = icmp eq i32 %sr.cmp, 0
+  br i1 %sr.name_ok, label %sr.read_arg, label %sr.fail
+sr.read_arg:
+  %sr.args_slot = getelementptr %Compound, %Compound* %sr.cp_ptr, i32 0, i32 2
+  %sr.args = load %Value*, %Value** %sr.args_slot
+  %sr.arg0_ptr = getelementptr %Value, %Value* %sr.args, i32 0
+  %sr.arg0_raw = load %Value, %Value* %sr.arg0_ptr
+  %sr.arg0 = call %Value @wam_deref_value(%WamState* %vm, %Value %sr.arg0_raw)
+  %sr.arg0_tag = call i32 @value_tag(%Value %sr.arg0)
+  %sr.is_int = icmp eq i32 %sr.arg0_tag, 1
+  br i1 %sr.is_int, label %sr.do_seed, label %sr.fail
+sr.do_seed:
+  %sr.seed = call i64 @value_payload(%Value %sr.arg0)
+  call void @srand48(i64 %sr.seed)
+  ret i1 true
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11948,6 +11996,7 @@ builtin_op_to_id('geteuid/1', 115).           % libc geteuid() as Integer.
 builtin_op_to_id('getgid/1', 116).            % libc getgid() as Integer.
 builtin_op_to_id('getegid/1', 117).           % libc getegid() as Integer.
 builtin_op_to_id('getppid/1', 118).           % libc getppid() as Integer.
+builtin_op_to_id('set_random/1', 119).        % srand48 via seed(N) compound.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,36 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M97: set_random/1 -- libc srand48 via the SWI-style seed(N) compound.
+
+:- dynamic test_setrand_changes_output/2.
+test_setrand_changes_output(_, R) :-
+    % Default seed (0) gives a fixed first lrand48() value. Re-seed
+    % with a different N and lrand48 produces a different value.
+    random_between(1, 1000000, V0),
+    set_random(seed(424242)),
+    random_between(1, 1000000, V1),
+    ( V0 =\= V1 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_setrand_repeatable/2.
+test_setrand_repeatable(_, R) :-
+    % Seeding twice with the same N gives the same draws -- proves
+    % srand48 is actually being called with our seed, not ignored.
+    set_random(seed(99)),
+    random_between(1, 1000000, A),
+    set_random(seed(99)),
+    random_between(1, 1000000, B),
+    ( A =:= B -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_setrand_bad_option/2.
+test_setrand_bad_option(_, R) :-
+    % Wrong functor / non-Integer arg / non-compound all fail.
+    ( set_random(garbage) -> R is 0
+    ; set_random(seed(not_an_int)) -> R is 0
+    ; set_random(42) -> R is 0
+    ; R is 1
+    ).   % 1
+
 % M96: getgid/1 + getegid/1 + getppid/1 -- more libc process-info wrappers.
 
 :- dynamic test_gid_nonneg/2.
@@ -4848,6 +4878,13 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M97 set_random/1 ---~n'),
+       run_test_r0('set_random(seed(N)) changes lrand48 output -> 1',
+                   test_setrand_changes_output, 0, 1),
+       run_test_r0('same seed gives same draw -> 1',
+                   test_setrand_repeatable, 0, 1),
+       run_test_r0('bad option (non-seed compound, etc.) fails -> 1',
+                   test_setrand_bad_option, 0, 1),
        format('--- M96 getgid/1 + getegid/1 + getppid/1 ---~n'),
        run_test_r0('getgid(G), G >= 0 -> 1',
                    test_gid_nonneg, 0, 1),


### PR DESCRIPTION
## Summary

- **M97 `set_random/1`** — SWI-style `set_random(seed(N))` shape: `Option` must be the compound `seed/1` with an Integer `N`. Other Option forms fail. Op id 119.

Wires up the libc `srand48` PRNG seed, so M90's `random/1` / `random_between/3` are no longer pinned to the deterministic seed-0 sequence. This is the first builtin that does real **compound inspection** in IR (tag + arity + functor strcmp + arg deref + tag check), so it's a small foundation for future compound-input builtins like `date_time_stamp/2`.

## Pipeline (`builtin_set_random`, prefix `sr.`)

1. Deref reg 0. Tag check Compound (`3`); else fail.
2. Load `%Compound*` from payload. Arity check `==1`; else fail.
3. Load functor `i8*` from the compound. `strcmp` against `@.fn_seed`; non-zero match → fail.
4. Load `args[0]`, deref. Tag check Integer (`1`); else fail.
5. Extract `i64` payload, call `srand48`, return true.

Pre-registers the `"seed"` functor string in `write_wam_llvm_project` so `@.fn_seed` is in every module — even ones whose only `seed/1` construction is at the `set_random` call site (the `put_structure` there would register it anyway, but eager registration matches how M9 / M58 / M60 / M83 handle their own well-known functor names).

Declares `@srand48` alongside the other libc PRNG imports (`@drand48`, `@lrand48`).

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `@srand48` decl, dispatch entry, `builtin_set_random` IR block, op-id table entry, `register_functor_string("seed")` in the project-emit prologue.
- `tests/core/test_wam_llvm_builtin_execution.pl` — three M97 tests + section in `test_all`.

(`is_builtin_pred(set_random, 1)` was already declared in `wam_target.pl` — only the LLVM target was missing the dispatch.)

## Test plan

- [x] Full execution suite: **626/626 PASS**, no failures, no OOM
- [x] `test_setrand_changes_output`: re-seeding with a non-default N changes `lrand48`'s output (proves the call reaches libc) ✓
- [x] `test_setrand_repeatable`: seeding twice with the same N gives the same draws (proves `srand48` is being called with our value, not ignored) ✓
- [x] `test_setrand_bad_option`: garbage atom, non-Integer arg, plain Integer all fail the tag/arity/functor guards ✓

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_