### PR TITLE
fix(go): close cons-cell + nested-arith WAM gaps; retire all go xfails

### DIFF
--- a/docs/WAM_CROSS_TARGET_CONFORMANCE.md
+++ b/docs/WAM_CROSS_TARGET_CONFORMANCE.md
@@ -85,17 +85,17 @@ so any failure is reproducible from the recorded seed.
 
 ## Known divergences (tracked as `ct_xfail/2`)
 
-The harness is green today. **scala, elixir, wat, haskell, and python
-pass the whole spec**; **go passes append/fib/ack and has three live
-`ct_xfail/2` entries** (member, reverse, builtins) for gaps still open in
-its WAM runtime. The oracle is the hand-specified expected-results table
-in `wam_conformance_fixtures.pl` (standard Prolog semantics), not any
-backend's output; Scala was the original reference. Mismatches under an
-`ct_xfail/2` are tolerated and logged; an unexpected full match is logged
-as `XPASS` so the entry can be retired once the gap is fixed. The table
-below records every divergence the harness has surfaced — each a real
-backend gap, not a fixture artifact — marking which are fixed and which
-remain open.
+The harness is green today and **every registered backend — scala,
+elixir, wat, haskell, python, and go — passes the whole spec** (there are
+no live `ct_xfail/2` or `ct_skip/2` entries; both are declared `dynamic`
+so they may have zero clauses). The oracle is the hand-specified
+expected-results table in `wam_conformance_fixtures.pl` (standard Prolog
+semantics), not any backend's output; Scala was the original reference.
+A tolerated divergence would be logged via a new `ct_xfail/2`, with an
+unexpected full match logged as `XPASS` so the entry can be retired once
+the gap is fixed. The table below records every divergence the harness has
+surfaced — each a real backend gap, not a fixture artifact — all now
+fixed.
 
 | Backend | Program(s) | Kind | Cause |
 |---|---|---|---|
@@ -108,12 +108,12 @@ remain open.
 | ~~haskell~~ | ~~builtins~~ | **fixed** | `=/2` of two identical atoms returned false (no `BuiltinCall "=/2"` handler — added one routing through `unifyVal`), and `//`/`mod` evaluated incorrectly: the arity-stripper `takeWhile (/= '/')` truncated any operator containing `/` (so `//` → `""`). Replaced with `bareArithOp` (strips only a trailing `/<digits>`). `fib`/`ack` already passed. Now conformant; xfail removed. |
 | ~~python~~ | ~~builtins~~ | **fixed** | `cbi_arith(28)` → false: `wam_line_to_python_literal` computed the `put_structure`/`get_structure` arity with `split_string(Fn,"/","",[_,ArStr])`, which expects exactly two parts and fell back to **arity 0** for `///2` (integer division `//`). A 0-arity `//` compound carried no argument cells, so `eval_arith` could not apply it and `X is 17 // 5` failed — the same `/`-in-operator class as the Haskell/WAT `//` bugs. Added `python_functor_arity/2` (last `/`-component). The Python adapter was added to the harness in the same change; every other program already passed. |
 | ~~go~~ | ~~fib, ack~~ | **fixed** | `is/2` wrapped every result in `&Float`, but Go's `Unify` is type-strict (Integer never unifies with Float), so `R is N + 1` failed whenever R was already bound to a ground Integer — `cack(0,5,6)`, `cfib(10,55)`. Integral results now wrap as `&Integer` (mirrors the Python int-vs-float heuristic), in `templates/targets/go_wam/state.go.mustache`. Made fib and ack pass; the Go adapter was added in the same change. |
-| go | member, reverse | **xfail** | Cons-cell gap. The compiler builds a list as an outer `put_list` `*List` cell whose tail cells are `put_structure "[|]/2"` `*Structure`s, but `GetList` only recognises `*List`, so the recursion mis-unifies the tail: `cmem(z,[a,b,c])` wrongly succeeds and `clist_reverse([a,b,c],[a,b,c])` mismatches. Same `./2`-vs-`[|]/2` class as Elixir/Haskell/WAT, but a localized `GetList` fix proved insufficient (member still wrong) and regressed reverse into a non-terminating loop — the real fix is a broader overhaul of Go list unification/backtracking. |
-| go | builtins | **xfail** | Nested-arithmetic gap. A single `is` of two operands is correct (fib/ack and `//`/`mod` in isolation all pass), but an expression of depth ≥ 2 — `cbi_arith`'s `A+B+C+D+E`, i.e. `+(+(+(+(A,B),C),D),E)` — mis-evaluates, so `cbi_arith(28)` → false. The two-variable sum works; three or more does not. |
+| ~~go~~ | ~~builtins~~ | **fixed** | Nested-arithmetic gap. A depth-1 `is` was correct (`//`/`mod` too) but `cbi_arith`'s `A+B+C+D+E` — `+(+(+(+(A,B),C),D),E)` — mis-evaluated. The compiler builds nested terms outer-first: `set_variable` drops an unbound placeholder into the outer arg, then `put_structure` builds the inner term into that *same register* — but `PutStructure` overwrote the register without binding the embedded placeholder, so the outer arg stayed unbound and `evalArithmetic` gave up at depth ≥ 2. `PutStructure` now binds an unbound placeholder it overwrites (`wam_go_target.pl`), which also fixes list **tail** cells built the same way. |
+| ~~go~~ | ~~member, reverse~~ | **fixed** | Cons-cell traversal. Lists build as an outer `put_list` `*List` cell whose tails are `put_structure "[|]/2"` `*Structure`s (the `./2`-vs-`[|]/2` class). Two further `GetList` bugs, both fixed: (a) it recognised only `*List`, not the inner `[|]/2` `*Structure` tail cells — added `consHeadTail` (`state.go.mustache`); (b) it tested `isUnbound` **before** `deref`, so a *bound* variable tail (after the placeholder fix above) was mistaken for unbound and sent into write mode, wrongly succeeding `cmem(z,…)` and looping `clist_reverse` — now derefs first. With all three fixes member, reverse (and append's negative cases) pass. |
 
 (Haskell is opt-in — `CONFORMANCE_TARGETS=haskell` — because each program is a cabal compile. `fib` and `ack` pass; the driver, `tests/fixtures/haskell_conformance_driver.hs`, runs a 0-arity wrapper whose atoms are baked into the compiled stream, which is what removed the earlier interning mismatch — see below.)
 
-(Go is opt-in too — `CONFORMANCE_TARGETS=go`. `append`, `fib`, and `ack` pass; `member`, `reverse`, and `builtins` are tracked as `ct_xfail/2` — see the table above. The driver is a small generated `main.go` that looks up the wrapper label in `SharedWamLabels` and runs `vm.Run()`.)
+(Go is opt-in too — `CONFORMANCE_TARGETS=go` — and now passes the whole spec. The driver is a small generated `main.go` that looks up the wrapper label in `SharedWamLabels` and runs `vm.Run()`.)
 
 `ct_xfail/2` = build and run, tolerate a wrong answer (and log `XPASS` if
 it unexpectedly matches). `ct_skip/2` = do not even build, because

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -1554,6 +1554,7 @@ wam_go_case('GetStructure', '        val := vm.Regs[i.Ai]
 
 wam_go_case('GetList', '        val := vm.Regs[i.Ai]
         if val == nil { return false }
+        val = vm.deref(val)
         if isUnbound(val) {
             addr := vm.heapPush(nil)
             l := &List{Elements: make([]Value, 2)}
@@ -1565,9 +1566,13 @@ wam_go_case('GetList', '        val := vm.Regs[i.Ai]
             vm.PC++
             return true
         }
-        val = vm.deref(val)
         if list, ok := val.(*List); ok && len(list.Elements) > 0 {
             vm.Stack = append(vm.Stack, &UnifyCtx{Args: list.Elements})
+            vm.PC++
+            return true
+        }
+        if h, t, ok := consHeadTail(val); ok {
+            vm.Stack = append(vm.Stack, &UnifyCtx{Args: []Value{h, t}})
             vm.PC++
             return true
         }
@@ -1700,7 +1705,20 @@ wam_go_case('PutStructure', '        addr := vm.heapPush(nil)
         vm.Heap[addr] = s
         vm.CurrentStruct = s
         vm.CurrentList = nil
-        vm.Regs[i.Ai] = &Ref{Addr: addr}
+        ref := &Ref{Addr: addr}
+        // If this register holds an unbound placeholder (one a prior
+        // set_variable embedded into an enclosing structure/list arg), bind
+        // it to the new structure so the embedded copy resolves here. The
+        // compiler builds nested terms outer-first — e.g. +(+(A,B),C) or a
+        // list tail cell [|]/2 — leaving a placeholder in the arg slot that
+        // a later put_structure into the same register must fill. Trailing
+        // via bindUnbound keeps it backtrack-safe.
+        if cur := vm.Regs[i.Ai]; cur != nil {
+            if u, ok := vm.deref(cur).(*Unbound); ok {
+                vm.bindUnbound(u, ref)
+            }
+        }
+        vm.Regs[i.Ai] = ref
         vm.Stack = append(vm.Stack, &WriteCtx{N: arity})
         vm.PC++
         return true').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -592,6 +592,31 @@ func parseFunctorName(f string) string {
 	return f
 }
 
+// isConsName reports whether a bare functor name (arity stripped) is one of
+// the interchangeable cons-cell spellings WAM lists use.
+func isConsName(n string) bool {
+	return n == "[|]" || n == "."
+}
+
+// consHeadTail exposes head/tail for the cons-cell spellings that arrive as
+// a Compound/Structure (e.g. "[|]/2", built by put_structure for list tail
+// cells) rather than as a *List. Without this, GetList recognised only the
+// outer *List cell and failed on the inner "[|]/2" tail cells, so recursive
+// list predicates (member/reverse) mis-traversed the tail.
+func consHeadTail(v Value) (Value, Value, bool) {
+	switch t := v.(type) {
+	case *Compound:
+		if isConsName(parseFunctorName(t.Functor)) && len(t.Args) == 2 {
+			return t.Args[0], t.Args[1], true
+		}
+	case *Structure:
+		if isConsName(parseFunctorName(t.Functor)) && len(t.Args) == 2 {
+			return t.Args[0], t.Args[1], true
+		}
+	}
+	return nil, nil, false
+}
+
 // compareValues returns <0, 0, or >0 for sort ordering of atoms/integers.
 func compareValues(a, b Value) int {
 	// Type ordering: Atom < Integer < Float < other

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -168,29 +168,27 @@ ct_default_target(elixir).
 %  fib/ack already passed, so +/-/comparison and is/2 bound-LHS checking
 %  were fine; with these two fixes the Haskell adapter is fully green.
 
-%  Go (LIVE xfails). The Go WAM runtime is exercised here via
-%  prefer_wam(true) (its default strategy is the dataflow/stream backend,
-%  not the shared WAM pipeline). Onboarding surfaced three independent
-%  gaps; fib/ack/append are conformant, the rest are tracked below.
+%  Go (now fully conformant; the WAM runtime is exercised here via
+%  prefer_wam(true), since its default strategy is the dataflow/stream
+%  backend, not the shared WAM pipeline). Onboarding surfaced four gaps,
+%  all since fixed:
 %   - is/2 produced a Float for every result, and Unify is type-strict
 %     (Integer never unifies with Float), so `R is N + 1` failed whenever
-%     R was bound to a ground Integer. FIXED in state.go.mustache (integral
-%     results now wrap as Integer), which made fib and ack pass.
-%   - member/reverse (cons-cell gap, still open): the compiler builds a
-%     list as an outer put_list *List cell whose tail cells are
-%     put_structure "[|]/2" *Structures, but GetList only recognises *List,
-%     so the recursion mis-unifies the tail. cmem(z,[a,b,c]) wrongly
-%     succeeds and clist_reverse mismatches. A localized GetList fix was
-%     attempted but is insufficient (member still wrong) and regressed
-%     reverse into a non-terminating loop, so the proper fix is a broader
-%     overhaul of list unification/backtracking — tracked, not forced.
-%   - builtins (nested-arithmetic gap, still open): a single `is` of two
-%     operands evaluates correctly (fib/ack/`//`/`mod` all work), but a
-%     nested expression of depth >= 2 (cbi_arith's A+B+C+D+E, i.e.
-%     +(+(+(+(A,B),C),D),E)) mis-evaluates, so cbi_arith(28) fails.
-ct_xfail(go, member).
-ct_xfail(go, reverse).
-ct_xfail(go, builtins).
+%     R was bound to a ground Integer. Integral results now wrap as Integer
+%     (state.go.mustache) — fixed fib/ack.
+%   - nested-arithmetic (cbi_arith): the compiler builds `+(+(A,B),C)`
+%     outer-first, emitting a set_variable placeholder into the outer arg
+%     and then a put_structure into that placeholder register; put_structure
+%     overwrote the register but never bound the embedded placeholder, so
+%     the outer arg stayed unbound and evalArithmetic gave up at depth >= 2.
+%     PutStructure now binds an unbound placeholder it overwrites
+%     (wam_go_target.pl) — this also fixes list TAIL cells built the same
+%     way (the ./2-vs-[|]/2 class).
+%   - member/reverse (cons-cell traversal): two further GetList bugs —
+%     (a) it recognised only the outer *List cell, not the inner "[|]/2"
+%     *Structure tail cells (added consHeadTail in state.go.mustache), and
+%     (b) it tested isUnbound BEFORE deref, so a *bound* variable tail was
+%     mistaken for unbound and sent into write mode (now derefs first).
 
 %% ct_skip(Target, ProgramName)
 %  Stronger than xfail: do NOT even build/run this (target, program).


### PR DESCRIPTION
## Summary

Retires the three Go conformance xfails (`member`, `reverse`, `builtins`) from #2764 by fixing **three interacting bugs** in the Go WAM runtime. **Go now passes the whole shared spec** — all six programs, no xfails.

These bugs compounded — which is why the localized `GetList` fix tried during onboarding was insufficient (and regressed reverse into a non-terminating loop). They had to be fixed together.

### 1. Embedded-placeholder binding — `PutStructure` (`wam_go_target.pl`)
The compiler builds nested terms **outer-first**: `set_variable` drops an unbound placeholder into the enclosing arg, then `put_structure` builds the inner term into that *same register*. `PutStructure` overwrote the register but never **bound** the embedded placeholder, so the outer arg stayed unbound:
- nested arithmetic `+(+(A,B),C)` gave up at depth ≥ 2 → **`cbi_arith` (builtins) failed**;
- list **tail** cells (`"[|]/2"`, built the same way) were left unbound.

`PutStructure` now binds an unbound placeholder it overwrites, trailing via `bindUnbound` (backtrack-safe).

### 2. Cons-cell traversal — `consHeadTail` + `GetList` (`state.go.mustache`)
`GetList` recognised only the outer `put_list` `*List` cell, not the inner `"[|]/2"` `*Structure` tail cells (the `./2`-vs-`[|]/2` class seen in every other backend). Added `consHeadTail` and a `GetList` fallback accepting a cons-functor `Compound`/`Structure` as a list cell.

### 3. `deref`-before-`isUnbound` — `GetList` (`wam_go_target.pl`)
`GetList` tested `isUnbound` on the **raw** register value, before `deref`. After fix #1 the list tail is a *bound* `*Unbound` (bound via the side table), and `isUnbound` only checks the type — so the bound tail was mistaken for unbound and sent into **write mode**, wrongly succeeding `cmem(z,…)` and looping `clist_reverse`. `GetList` now derefs first.

## Result

| Program | Before (#2764) | After |
|---|---|---|
| member, reverse | xfail | ✅ |
| builtins | xfail | ✅ |
| append, fib, ack | ✅ | ✅ |

All `ct_xfail(go, …)` entries removed.

## Verification
- `CONFORMANCE_TARGETS=go` → **green**, xfails removed, **no divergences and no `XPASS`**.
- Go target suites unchanged by the runtime edits: generator **10/10**, foreign-lowering **12/12**, builtins, lowered phases 1–3 all pass.
- Python conformance still green (shared file intact).

## Note
That's the `./2`-vs-`[|]/2` cons class closed in a **6th** backend, plus the recurring "build-outer-first placeholder must be bound" pattern (the same shape as Haskell's bug #4). The shared **"WAM cons + operator-functor conventions"** doc I keep flagging would let backend #7 avoid all of this from day one — happy to write it next.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_