### PR TITLE
WAM Rust matrix bench: int-native cursor mode (fixes s2i id-space mismatch)

### DIFF
--- a/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
+++ b/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
@@ -1450,12 +1450,32 @@ fn main() {
         // (intern_atom is &mut self), then resolve the constant edge
         // accessor once. After this point vm is only borrowed &self, so the
         // par_iter below can share it across workers.
-        let root_id = vm.intern_atom(&root);
+        // Int-native cursor mode (WAM_INT_NATIVE=1): seeds, root, and the graph
+        // share ONE raw page-id space (no s2i indirection), so parse seeds /
+        // reuse the raw root int directly and tell the lazy edge accessor to
+        // skip the wam<->lmdb maps. Matches the eager int-seed path and the F#
+        // target on int-native fixtures (e.g. simplewiki_articles), where the
+        // s2i-backed path would remap seeds into the wrong id space.
+        let int_native = std::env::var("WAM_INT_NATIVE")
+            .map(|v| v == "1" || v == "true")
+            .unwrap_or(false);
+        if int_native {
+            vm.set_int_native_edges(true);
+        }
+        let root_id_raw_i32 = root_id;
+        let root_id: u32 = if int_native {
+            root_id_raw_i32 as u32
+        } else {
+            vm.intern_atom(&root)
+        };
         let seed_ids: Vec<(String, u32)> = seed_cats
             .iter()
-            .map(|cat| {
-                let id = vm.intern_atom(cat);
-                (cat.clone(), id)
+            .filter_map(|cat| {
+                if int_native {
+                    cat.trim().parse::<u32>().ok().map(|id| (cat.clone(), id))
+                } else {
+                    Some((cat.clone(), vm.intern_atom(cat)))
+                }
             })
             .collect();
         let acc = vm.resolve_edge_accessor("category_parent");

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -361,6 +361,13 @@ pub struct WamState {
     /// path must filter identically or the kernel over-explores
     /// non-reachable ancestor branches. Empty = no filter (eager/other).
     pub demand_set: FxSet<i32>,
+    /// Int-native edge mode: when true, the lazy edge path treats the kernel's
+    /// u32 node id AS the raw LMDB int key directly (identity), bypassing
+    /// `wam_to_lmdb`/`lmdb_to_wam`. Used for int-native fixtures whose seeds,
+    /// root, and graph keys are all the same raw page-id space (no s2i
+    /// indirection) -- mirrors the eager int-seed path and the F# target.
+    /// When false (default), the s2i-backed wam<->lmdb maps are used.
+    pub int_native_edges: bool,
     /// Variable binding table: maps Unbound variable names to their bound values.
     /// This simulates the WAM heap's shared binding semantics when PutVariable
     /// creates a variable that's stored in both a Y-register and an A-register.
@@ -424,6 +431,7 @@ impl WamState {
             lazy_lookups: HashMap::new(),
             wam_to_lmdb: FxMap::default(),
             lmdb_to_wam: FxMap::default(),
+            int_native_edges: false,
             demand_set: FxSet::default(),
             bindings: HashMap::new(),
             var_counter: 0,
@@ -619,6 +627,13 @@ impl WamState {
         self.demand_set = demand.iter().copied().collect();
     }
 
+    /// Enable int-native edge mode: the lazy edge path treats the kernel's
+    /// node id as the raw LMDB key directly, bypassing the wam<->lmdb maps.
+    /// For int-native fixtures (raw page-id seeds/root/graph, no s2i).
+    pub fn set_int_native_edges(&mut self, enabled: bool) {
+        self.int_native_edges = enabled;
+    }
+
     /// Fetch a lazy edge-lookup backend by "name/arity".
     pub fn lazy_lookup(&self, pred: &str) -> Option<Arc<dyn LookupSource>> {
         self.lazy_lookups.get(pred).cloned()
@@ -655,8 +670,16 @@ impl WamState {
                 table.get(&cat_id).cloned().unwrap_or_default()
             }
             EdgeAccessor::Lazy(source) => {
-                let Some(&int_key) = self.wam_to_lmdb.get(&cat_id) else {
-                    return Vec::new();
+                // Int-native mode: the kernel's node id IS the raw LMDB key
+                // (seeds/root/graph share one raw id space, no s2i), so look up
+                // directly and return raw pids — bypassing the wam<->lmdb maps.
+                let int_key = if self.int_native_edges {
+                    cat_id as i32
+                } else {
+                    match self.wam_to_lmdb.get(&cat_id) {
+                        Some(&k) => k,
+                        None => return Vec::new(),
+                    }
                 };
                 let parent_ints = source.lookup_parents(int_key);
                 let mut out = Vec::with_capacity(parent_ints.len());
@@ -667,7 +690,9 @@ impl WamState {
                     if !self.demand_set.is_empty() && !self.demand_set.contains(&pid) {
                         continue;
                     }
-                    if let Some(&wam) = self.lmdb_to_wam.get(&pid) {
+                    if self.int_native_edges {
+                        out.push(pid as u32);
+                    } else if let Some(&wam) = self.lmdb_to_wam.get(&pid) {
                         out.push(wam);
                     }
                 }


### PR DESCRIPTION
  The cursor (lazy/cached) path resolved seeds through `s2i` (page-id-string →
  dense id) before looking them up in `category_parent`. Correct when seeds are
  category-name strings whose `s2i` maps into the graph's key space — but **wrong
  on int-native fixtures** (e.g. `data/benchmark/simplewiki_articles`) where the
  graph is keyed by raw page ids and the seed/root files carry those same raw
  ids. There `s2i` is a separate dense renumbering (`s2i["4985"]=0`, not
  identity), so every seed got remapped onto a low root-adjacent node and
  spuriously "reached" root — `tuple_count=14678` instead of the correct 970
  (eager-TSV, the F# target, and an independent Python oracle all agree on
  969/970).

  Add an int-native cursor mode (`WAM_INT_NATIVE=1`):
  - **`state.rs`**: an `int_native_edges` flag (+ `set_int_native_edges`). In
    `edge_parents_via`'s Lazy branch, when set, the kernel's `u32` node id is used
    *as* the raw LMDB key and raw pids are returned, bypassing the `wam↔lmdb`
    maps. Default `false` (s2i path unchanged).
  - **matrix-bench cursor `main`**: when `WAM_INT_NATIVE=1`, parse seeds as raw
    `u32`, reuse the raw root int, and enable `int_native_edges` — mirroring the
    eager int-seed path and the F# target. Inert (intern path) when the env is
    unset, so the name-keyed cursor path is unchanged. (TSV `main` template is
    untouched — it has no pre-seed raw `root_id`.)

  ### Validated (simplewiki_articles, root 2, 14,680 seeds, serial)

  | mode | tuple_count | load | query |
  |---|---|---|---|
  | Rust lazy int-native | 969 | 167 ms | 225 ms |
  | Rust cached int-native | 969 | 42 ms | 10 ms |

  matching Rust-eager (969) and F# (970). Unblocks the F#-vs-Rust lazy/cached
  perf head-to-head. `test_wam_rust_target.pl` + F# target tests pass.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)