### PR TITLE
test(conformance): onboard Rust backend (partial — all programs tracked as xfail)

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -164,11 +164,18 @@ wam_instruction_arm('Instruction::GetStructure(fn_str, ai)', Body) :-
                 } else { false }'.
 
 wam_instruction_arm('Instruction::GetList(ai)', Body) :-
-    Body = '                if let Some(val) = self.get_reg_raw(ai) {
+    Body = '                if let Some(raw) = self.get_reg_raw(ai) {
+                    // Deref BEFORE the unbound test: a bound variable is still
+                    // typed Unbound, and treating a bound list tail as unbound
+                    // would wrongly take the write-mode branch.
+                    let val = self.deref_var(&raw);
                     if val.is_unbound() {
                         let addr = self.heap.len();
                         self.heap.push(Value::Str("str(./2)".to_string(), vec![]));
                         self.trail_binding(ai);
+                        if let Value::Unbound(ref name) = val {
+                            self.bind_var(name, Value::Ref(addr));
+                        }
                         self.set_reg_str(ai, Value::Ref(addr));
                         self.smut().push(StackEntry::WriteCtx(2));
                         self.pc += 1; true
@@ -178,9 +185,15 @@ wam_instruction_arm('Instruction::GetList(ai)', Body) :-
                                 vec![head.clone(), Value::List(tail.to_vec())]));
                             self.pc += 1; true
                         } else { false }
+                    } else if let Value::Str(s, args) = &val {
+                        // Materialised cons cell, e.g. "[|]/2"/"./2".
+                        if self.is_cons_functor(s) && args.len() == 2 {
+                            self.smut().push(StackEntry::UnifyCtx(args.clone()));
+                            self.pc += 1; true
+                        } else { false }
                     } else if let Value::Ref(addr) = &val {
                         if let Some(Value::Str(s, _)) = self.heap.get(*addr) {
-                            if s == "str(./2)" {
+                            if self.is_cons_functor(s) {
                                 let args = self.heap_subargs(addr + 1, 2);
                                 self.smut().push(StackEntry::UnifyCtx(args));
                                 self.pc += 1; true
@@ -303,6 +316,16 @@ wam_instruction_arm('Instruction::PutStructure(fn_str, ai)', Body) :-
                 }
                 // Enter structure-write mode: next N SetValue/SetConstant calls fill args
                 self.smut().push(StackEntry::WriteCtx(addr));
+                // If this register holds an unbound placeholder (one a prior
+                // set_variable embedded into an enclosing term), bind it to the
+                // new structure so the embedded copy resolves here. The compiler
+                // builds nested terms outer-first — +(+(A,B),C), or a list tail
+                // cell — leaving a placeholder a later put_structure must fill.
+                if let Some(cur) = self.get_reg_raw(ai) {
+                    if let Value::Unbound(name) = self.deref_var(&cur) {
+                        self.bind_var(&name, Value::Ref(addr));
+                    }
+                }
                 self.set_reg_str(ai, Value::Ref(addr));
                 self.pc += 1; true'.
 
@@ -322,8 +345,13 @@ wam_instruction_arm('Instruction::PutList(ai)', Body) :-
 wam_instruction_arm('Instruction::SetVariable(xn)', Body) :-
     Body = '                let addr = self.heap.len();
                 let var = Value::Unbound(format!("_H{}", addr));
-                self.heap.push(var.clone());
-                self.put_reg(xn, var);
+                self.put_reg(xn, var.clone());
+                // Write the fresh variable into the current structure/list arg
+                // slot, exactly as set_value/set_constant do. Without this the
+                // placeholder never lands in the term being built, so any
+                // structure/list with a variable argument (nested arithmetic
+                // +(+(A,B),C); list tail cells [H|T]) had its args misaligned.
+                self.set_heap_or_list(var);
                 self.pc += 1; true'.
 
 wam_instruction_arm('Instruction::SetValue(xn)', Body) :-
@@ -1010,6 +1038,14 @@ compile_execute_builtin_to_rust(Code) :-
             "true/0" => { self.pc += 1; true }
             "fail/0" => false,
             "!/0" => { self.choice_points.truncate(self.cut_barrier); self.pc += 1; true }
+            "=/2" => {
+                // Unification: the compiler emits `X = Y` as builtin_call =/2.
+                // Without a handler it fell through to `_ => false`, so even
+                // `a = a` failed.
+                let a1 = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+                let a2 = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+                if self.unify(&a1, &a2) { self.pc += 1; true } else { false }
+            }
             _ => false,
         }
     }'.
@@ -2493,6 +2529,14 @@ compile_eval_arith_to_rust(Code) :-
                 }
             }
             Value::Str(op, args) => self.eval_arith_compound(op, args),
+            Value::Unbound(_) => {
+                // A bound placeholder variable (e.g. the embedded arg of a
+                // nested expression +(+(A,B),C)) derefs through the binding
+                // table to the real subterm. Without this it fell to None and
+                // any depth>=2 arithmetic failed.
+                let d = self.deref_var(expr);
+                if d == *expr { None } else { self.eval_arith(&d) }
+            }
             Value::Atom(name) => {
                 // Try register dereference
                 if name.starts_with(\'A\') || name.starts_with(\'X\') || name.starts_with(\'Y\') {
@@ -3334,9 +3378,22 @@ write_file(Path, Content) :-
 read_template_file(RelativePath, Content) :-
     (   exists_file(RelativePath)
     ->  read_file_to_string(RelativePath, Content, [])
+    ;   resolve_template_path(RelativePath, AbsPath), exists_file(AbsPath)
+    ->  read_file_to_string(AbsPath, Content, [])
     ;   format(atom(Content),
             '// Template not found: ~w', [RelativePath])
     ).
+
+%% resolve_template_path(+RelativePath, -AbsPath)
+%  Resolve a repo-root-relative template path against this module's source
+%  location, so generation works from any working directory (e.g. the
+%  conformance harness runs from tests/, where the cwd-relative
+%  'templates/...' path does not exist). Mirrors the python/go targets.
+resolve_template_path(RelativePath, AbsPath) :-
+    source_file(wam_rust_target:write_wam_rust_project(_,_,_), ThisFile),
+    file_directory_name(ThisFile, TargetsDir),   % src/unifyweaver/targets
+    atomic_list_concat([TargetsDir, '/../../../', RelativePath], Raw),
+    absolute_file_name(Raw, AbsPath).
 
 % ============================================================================
 % CARGO CHECK VALIDATION

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -684,6 +684,22 @@ impl WamState {
         self.edge_parents_via(cat_id, &acc)
     }
 
+    /// True if a structure functor string is one of the interchangeable
+    /// cons-cell spellings WAM lists use. Accepts the bare name, an arity
+    /// suffix, and the "str(...)" wrapper the heap sometimes carries — i.e.
+    /// "[|]/2", "./2", "str([|]/2)", "str(./2)", "[|]", "." all match. The
+    /// compiler builds the outer list cell with put_list (a Value::List) but
+    /// inner tail cells with put_structure "[|]/2"; without aliasing these,
+    /// get_list mis-traversed the tail.
+    pub fn is_cons_functor(&self, s: &str) -> bool {
+        let s = s.strip_prefix("str(").and_then(|x| x.strip_suffix(')')).unwrap_or(s);
+        let name = match s.rsplit_once('/') {
+            Some((n, ar)) if ar.chars().all(|c| c.is_ascii_digit()) => n,
+            _ => s,
+        };
+        name == "[|]" || name == "."
+    }
+
     /// Dereference an Unbound variable through the binding table.
     /// Follows chains: if Unbound("X") -> Unbound("Y") -> Atom("hello"), returns Atom("hello").
     pub fn deref_var(&self, val: &Value) -> Value {
@@ -892,17 +908,34 @@ impl WamState {
             (Value::Integer(i1), Value::Integer(i2)) => i1 == i2,
             (Value::Float(f1), Value::Float(f2)) => (f1 - f2).abs() < f64::EPSILON,
             (Value::Bool(b1), Value::Bool(b2)) => b1 == b2,
+            // Empty-list aliasing: the [] atom and the empty Value::List.
+            (Value::List(l), Value::Atom(s)) | (Value::Atom(s), Value::List(l))
+                if l.is_empty() && s == "[]" => true,
+            // Cons-cell aliasing: one logical list is built from both put_list
+            // (Value::List) and put_structure "[|]/2" (Value::Str) cells, so a
+            // List and a cons-functor Str of arity 2 are the same cell.
+            (Value::List(l), Value::Str(f, a)) | (Value::Str(f, a), Value::List(l))
+                if self.is_cons_functor(f) && a.len() == 2 && !l.is_empty() => {
+                let h = l[0].clone();
+                let t = Value::List(l[1..].to_vec());
+                let (a0, a1v) = (a[0].clone(), a[1].clone());
+                self.unify(&h, &a0) && self.unify(&t, &a1v)
+            }
             (Value::Str(f1, a1), Value::Str(f2, a2)) => {
-                if f1 != f2 || a1.len() != a2.len() { return false; }
-                for (arg1, arg2) in a1.iter().zip(a2.iter()) {
-                    if !self.unify(arg1, arg2) { return false; }
+                // Alias cons spellings ("[|]/2" vs "./2") against each other.
+                let same = f1 == f2 || (self.is_cons_functor(f1) && self.is_cons_functor(f2));
+                if !same || a1.len() != a2.len() { return false; }
+                let pairs: Vec<(Value, Value)> = a1.iter().cloned().zip(a2.iter().cloned()).collect();
+                for (arg1, arg2) in pairs {
+                    if !self.unify(&arg1, &arg2) { return false; }
                 }
                 true
             }
             (Value::List(l1), Value::List(l2)) => {
                 if l1.len() != l2.len() { return false; }
-                for (i1, i2) in l1.iter().zip(l2.iter()) {
-                    if !self.unify(i1, i2) { return false; }
+                let pairs: Vec<(Value, Value)> = l1.iter().cloned().zip(l2.iter().cloned()).collect();
+                for (i1, i2) in pairs {
+                    if !self.unify(&i1, &i2) { return false; }
                 }
                 true
             }

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -57,6 +57,8 @@
               [write_wam_python_project/3]).
 :- use_module('../src/unifyweaver/targets/wam_go_target',
               [write_wam_go_project/3]).
+:- use_module('../src/unifyweaver/targets/wam_rust_target',
+              [write_wam_rust_project/3]).
 
 % ============================================================
 % Target registry + known-divergence (xfail) registry
@@ -68,6 +70,7 @@ conformance_target(wat).
 conformance_target(haskell).
 conformance_target(python).
 conformance_target(go).
+conformance_target(rust).
 
 %% ct_default_target(Target): runs unless CONFORMANCE_TARGETS overrides.
 %  WAT and Haskell are wired up but NOT defaults: their backends still
@@ -190,6 +193,34 @@ ct_default_target(elixir).
 %     (b) it tested isUnbound BEFORE deref, so a *bound* variable tail was
 %     mistaken for unbound and sent into write mode (now derefs first).
 
+%  Rust (onboarding in progress). The Rust WAM runtime had the same gap
+%  family as Go, plus a missing =/2; fixed so far (wam_rust_target.pl /
+%  templates/targets/rust_wam/state.rs.mustache):
+%   - =/2 had NO handler in execute_builtin (the compiler emits `X = Y` as
+%     builtin_call =/2), so even `a = a` returned false. Added a handler
+%     routing through unify(). This made fib and builtins pass.
+%   - set_variable did not write the fresh var into the current
+%     structure/list arg slot (unlike set_value/set_constant), so terms
+%     with a variable argument had their args misaligned — now calls
+%     set_heap_or_list.
+%   - nested arithmetic: put_structure into a placeholder register did not
+%     bind the embedded placeholder, and eval_arith did not deref Unbound.
+%     Both fixed; nested cbi_arith now evaluates.
+%   - cons-cell aliasing added to get_list (accepts "[|]/2"/"./2" Str and
+%     Ref, derefs before the unbound test) and to unify (List <-> cons Str,
+%     empty-list <-> "[]" atom).
+%  STILL failing, tracked below (Rust's heap-materialisation list model has
+%  deeper issues than the convention fixes cover, and recursive list/ack
+%  predicates do not yet terminate with the right answer):
+%   - member: cmem(z,[a,b,c]) wrongly succeeds.
+%   - append/reverse: positive cases (capp([a,b],[c],[a,b,c])) fail.
+%   - ack: cack(2,3,9) fails (deep integer recursion).
+%  fib and builtins are conformant. These four are tracked for a follow-up.
+ct_xfail(rust, member).
+ct_xfail(rust, append).
+ct_xfail(rust, reverse).
+ct_xfail(rust, ack).
+
 %% ct_skip(Target, ProgramName)
 %  Stronger than xfail: do NOT even build/run this (target, program).
 %  Used when *generation itself* is unusable, not just the answer.
@@ -218,6 +249,7 @@ ct_toolchain(wat,    [wat2wasm, node]).
 ct_toolchain(haskell, [ghc, cabal]).
 ct_toolchain(python, [python3]).
 ct_toolchain(go,     [go]).
+ct_toolchain(rust,   [cargo]).
 
 ct_available(scala) :-
     ct_enabled(scala),
@@ -256,6 +288,7 @@ test(elixir, [condition(ct_available(elixir))]) :- run_target_conformance(elixir
 test(wat,    [condition(ct_available(wat))])    :- run_target_conformance(wat).
 test(python, [condition(ct_available(python))]) :- run_target_conformance(python).
 test(go,     [condition(ct_available(go))])     :- run_target_conformance(go).
+test(rust,   [condition(ct_available(rust))])   :- run_target_conformance(rust).
 
 :- end_tests(wam_cross_target_conformance).
 
@@ -723,6 +756,67 @@ ct_run(go, go_ctx(Dir, Map), K, A, Bool) :-
     normalize_space(string(Out), OutStr), bool_of_string(Out, Bool).
 
 ct_teardown(go, go_ctx(Dir, Map)) :-
+    cleanup_dir(Dir), abolish_wrappers(Map).
+
+% ============================================================
+% Adapter: Rust  (0-arity wrapper -> `cargo run -- <key>` -> true/false)
+%
+% Like Go, write_wam_rust_project/3 attempts native lowering first and
+% falls back to the shared WAM pipeline; the conformance predicates all
+% take the WAM path. We generate the project, overwrite the emitted
+% benchmark src/main.rs with a tiny query-runner driver (look up the
+% wrapper label in shared_wam_program(), set vm.pc, run vm.run() — which
+% returns true when the machine halts with pc==0), gate compilation with
+% `cargo build`, and run each query with `cargo run` (cargo execs the
+% binary from its own target dir, sidestepping the $TMPDIR exec issue the
+% Go adapter hit). The generated crate has no external deps, so --offline
+% needs no network. Opt-in via CONFORMANCE_TARGETS=rust.
+% ============================================================
+
+rust_runner_driver('use std::env;
+use wam_lib::state::WamState;
+use wam_lib::{shared_wam_program, setup_foreign_predicates};
+
+fn main() {
+    let key = match env::args().nth(1) {
+        Some(k) => k,
+        None => { eprintln!("usage: runner <pred/arity>"); std::process::exit(2); }
+    };
+    let (code, labels) = shared_wam_program();
+    let mut vm = WamState::new(code, labels.clone());
+    setup_foreign_predicates(&mut vm);
+    match labels.get(&key) {
+        Some(&pc) => {
+            vm.pc = pc;
+            println!("{}", if vm.run() { "true" } else { "false" });
+        }
+        None => { eprintln!("unknown predicate: {}", key); std::process::exit(3); }
+    }
+}
+').
+
+ct_build(rust, Preds, Queries, rust_ctx(Dir, Map)) :-
+    ct_tmp_dir('tmp_ct_rust', Dir),
+    synth_wrappers(Queries, WPreds, Map),
+    maplist(strip_pred, Preds, BarePreds),
+    append(WPreds, BarePreds, AllPreds0),
+    maplist(qualify_user, AllPreds0, AllPreds),
+    write_wam_rust_project(AllPreds,
+        [module_name('uw_rust_ct'), no_kernels(true)], Dir),
+    rust_runner_driver(DriverSrc),
+    directory_file_path(Dir, 'src/main.rs', MainPath),
+    setup_call_cleanup(open(MainPath, write, S), write(S, DriverSrc), close(S)),
+    run_proc(cargo, ['build', '--offline', '-q'], Dir, BExit, BErr),
+    ( BExit =:= 0 -> true ; throw(rust_build_failed(BExit, BErr)) ).
+
+ct_run(rust, rust_ctx(Dir, Map), K, A, Bool) :-
+    memberchk((K-A)-WName, Map),
+    format(atom(KeyAtom), '~w/0', [WName]), atom_string(KeyAtom, KeyStr),
+    run_proc_out(cargo, ['run', '--offline', '-q', '--bin', bench, '--', KeyStr],
+                 Dir, _Exit, OutStr),
+    normalize_space(string(Out), OutStr), bool_of_string(Out, Bool).
+
+ct_teardown(rust, rust_ctx(Dir, Map)) :-
     cleanup_dir(Dir), abolish_wrappers(Map).
 
 qualify_user(_M:N/A, user:N/A) :- !.

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -209,16 +209,27 @@ ct_default_target(elixir).
 %   - cons-cell aliasing added to get_list (accepts "[|]/2"/"./2" Str and
 %     Ref, derefs before the unbound test) and to unify (List <-> cons Str,
 %     empty-list <-> "[]" atom).
-%  STILL failing, tracked below (Rust's heap-materialisation list model has
-%  deeper issues than the convention fixes cover, and recursive list/ack
-%  predicates do not yet terminate with the right answer):
-%   - member: cmem(z,[a,b,c]) wrongly succeeds.
-%   - append/reverse: positive cases (capp([a,b],[c],[a,b,c])) fail.
-%   - ack: cack(2,3,9) fails (deep integer recursion).
-%  fib and builtins are conformant. These four are tracked for a follow-up.
+%  STILL diverging, tracked below. Onboarding bounded execution with a
+%  step_limit in the runner driver after finding that some recursive
+%  programs do not terminate (runaway backtracking), so a wrong answer is
+%  returned instead of hanging the harness. All six programs are tracked
+%  for a follow-up; the fixes above are real progress, not full conformance:
+%   - member: cmem(z,[a,b,c]) wrongly succeeds (cons traversal in the
+%     heap-materialisation list model).
+%   - append/reverse: positive cases fail / backtrack without terminating.
+%   - fib: a query does not terminate (hits the step_limit) — the
+%     result-check on a bound R or the choice-point/backtracking management
+%     loops; needs the same kind of bound-LHS/cut audit the other backends
+%     had.
+%   - builtins: cbi_arith(28) — `R is <sum>` with R bound to a ground
+%     integer (the head arg) still fails, distinct from the =:= path that
+%     the nested-arith fix covered.
+%   - ack: cack(2,3,9) deep integer recursion fails.
 ct_xfail(rust, member).
 ct_xfail(rust, append).
 ct_xfail(rust, reverse).
+ct_xfail(rust, fib).
+ct_xfail(rust, builtins).
 ct_xfail(rust, ack).
 
 %% ct_skip(Target, ProgramName)
@@ -785,6 +796,11 @@ fn main() {
     let (code, labels) = shared_wam_program();
     let mut vm = WamState::new(code, labels.clone());
     setup_foreign_predicates(&mut vm);
+    // Bound execution so a not-yet-conformant (xfailed) program that loops
+    // returns false instead of hanging the harness. 5M is generous for the
+    // legitimate conformance computations (fib(10)/ack(2,3) are well under
+    // it) while bounding the runaway backtracking some programs still hit.
+    vm.step_limit = 5_000_000;
     match labels.get(&key) {
         Some(&pc) => {
             vm.pc = pc;


### PR DESCRIPTION
## Summary

Onboards a 7th backend, **Rust**, to the WAM conformance harness, and lands several Rust WAM runtime fixes guided by `docs/WAM_BACKEND_CONVENTIONS.md`. 

**Honest status: this is onboarding-in-progress, not conformance.** Unlike Python (clean) and Go (fully fixed), the Rust WAM runtime has deeper issues than the convention checklist covers. All six programs are currently tracked as `ct_xfail` — the harness is green (divergences tolerated), but Rust passes **0/6** outright. The fixes here are real, regression-safe progress; Rust needs a dedicated follow-up (same two-PR shape as Go, but with more to do).

### Harness adapter
- `conformance_target(rust)` + `ct_toolchain(rust,[cargo])` + `test/2`; opt-in via `CONFORMANCE_TARGETS=rust`.
- `ct_build` generates the project, overwrites the benchmark `src/main.rs` with a query-runner driver (look up the wrapper label in `shared_wam_program()`, `vm.run()`), and gates compilation with `cargo build --offline` (no deps).
- `ct_run` uses `cargo run` (cargo execs from its own target dir — sidesteps the `$TMPDIR` exec issue Go hit).
- The driver sets `vm.step_limit = 5_000_000` so a **non-terminating** query returns false instead of hanging the harness (some recursive programs have runaway backtracking).

### Backend fixes (regression-safe — `test_wam_rust_target` passes)
Each is a class from the conventions doc:
- **`=/2` had no handler** in `execute_builtin` (the compiler emits `X = Y` as `builtin_call =/2`), so even `a = a` was false. Added one via `unify()`.
- **`set_variable`** didn't fill the current struct/list write slot (unlike `set_value`/`set_constant`) → misaligned args.
- **nested arithmetic**: `put_structure` into a placeholder register didn't bind the placeholder, and `eval_arith` didn't deref `Unbound`. Both fixed.
- **cons-cell aliasing** (`get_list` accepts `[|]/2`/`./2` Str/Ref + derefs before the unbound test; `unify` aliases `List` ↔ cons-`Str` and `[]`-atom).
- **`read_template_file`** now resolves templates module-relative (mirrors python/go), so generation works from `tests/`.

### Still diverging (tracked as `ct_xfail`, with diagnoses)
A full harness run — not the simplified spot-checks that initially misled me — showed every program diverges:
- **fib**: `cfib(10,55)` does **not terminate** (runaway backtracking; base case `cfib(0,0)` and `cfib(10,54)` are fine) — needs a choice-point/cut audit.
- **builtins**: `cbi_arith(28)` — `R is <sum>` with `R` bound to a ground integer still fails (distinct from the `=:=` path the nested-arith fix covered).
- **member/append/reverse**: the heap-materialization list model has issues beyond the cons aliasing.
- **ack**: deep integer recursion fails.

## Verification
- `CONFORMANCE_TARGETS=rust CONFORMANCE_PROGRAMS=fib` → **green**: `cfib(0,0)`/`cfib(10,54)` XPASS, `cfib(10,55)` tolerated, no hang (step_limit bounds it).
- `test_wam_rust_target` passes (fixes are regression-safe). The pre-existing `test_wam_rust_runtime` breakage is unrelated (present on clean main).

## Recommendation
The remaining Rust gaps (backtracking non-termination, bound-LHS `is/2`, list materialization) are each a substantial dive in Rust's intricate heap model with a slow cargo build loop. I'd treat the deep fixes as a focused follow-up rather than block this onboarding. Open to feedback on whether to merge this as tracked progress or hold.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_