### PR TITLE
fix(rust): integer constants for put/get_constant — fixes fib backtracking + builtins

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -2748,9 +2748,10 @@ wam_lines_to_rust([Line|Rest], PC, PredIndicator, Options, Instrs, Labels) :-
 %  Converts parsed WAM instruction parts to a Rust Instruction enum literal.
 wam_line_to_rust_instr(["get_constant", C, Ai], _, _, Rust) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),
+    rust_const_value(CC, VExpr),
     format(string(Rust),
-        'Instruction::GetConstant(Value::Atom("~w".to_string()), "~w".to_string())',
-        [CC, CAi]).
+        'Instruction::GetConstant(~w, "~w".to_string())',
+        [VExpr, CAi]).
 wam_line_to_rust_instr(["get_variable", Xn, Ai], _, _, Rust) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
     format(string(Rust),
@@ -2785,9 +2786,11 @@ wam_line_to_rust_instr(["unify_constant", C], _, _, Rust) :-
     ).
 wam_line_to_rust_instr(["put_constant", C, Ai], _, _, Rust) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),
+    rust_const_value(CC, VExpr),
     format(string(Rust),
-        'Instruction::PutConstant(Value::Atom("~w".to_string()), "~w".to_string())',
-        [CC, CAi]).
+        'Instruction::PutConstant(~w, "~w".to_string())',
+        [VExpr, CAi]).
+
 wam_line_to_rust_instr(["put_variable", Xn, Ai], _, _, Rust) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
     format(string(Rust),
@@ -2881,6 +2884,24 @@ wam_line_to_rust_instr(["switch_on_constant_a2"|Entries], _, _, Rust) :-
 wam_line_to_rust_instr(Parts, _, _, Rust) :-
     atomic_list_concat(Parts, ' ', Joined),
     format(string(Rust), '/* unknown: ~w */', [Joined]).
+
+%% rust_const_value(+Const, -RustValueExpr)
+%  Render a WAM constant token as the right Value variant. Numeric
+%  constants MUST become Value::Integer/Value::Float, not Value::Atom:
+%  put_constant/get_constant previously emitted Value::Atom("28") for the
+%  integer 28, so `R is <expr>` with R bound to a ground integer (the head
+%  arg, e.g. cbi_arith(28) or the cfib(N,R) result check) failed — is/2's
+%  result match only handles Unbound/Integer/Float, not Atom. That failure
+%  triggered runaway backtracking in recursive programs (fib). set_/
+%  unify_constant already did this; this routes the remaining two through
+%  the same rule.
+rust_const_value(C, Expr) :-
+    (   number_string(N, C), integer(N)
+    ->  format(string(Expr), 'Value::Integer(~w)', [N])
+    ;   number_string(N, C), float(N)
+    ->  format(string(Expr), 'Value::Float(~w)', [N])
+    ;   format(string(Expr), 'Value::Atom("~w".to_string())', [C])
+    ).
 
 rust_foreign_rewrite_call(Options, CurrentPred, TargetPredArity, Num, ForeignPred, ForeignArity) :-
     option(foreign_lowering(ForeignSpec), Options),

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -209,27 +209,34 @@ ct_default_target(elixir).
 %   - cons-cell aliasing added to get_list (accepts "[|]/2"/"./2" Str and
 %     Ref, derefs before the unbound test) and to unify (List <-> cons Str,
 %     empty-list <-> "[]" atom).
-%  STILL diverging, tracked below. Onboarding bounded execution with a
-%  step_limit in the runner driver after finding that some recursive
-%  programs do not terminate (runaway backtracking), so a wrong answer is
-%  returned instead of hanging the harness. All six programs are tracked
-%  for a follow-up; the fixes above are real progress, not full conformance:
+%   - put_constant/get_constant emitted Value::Atom("28") for the integer
+%     28 (unlike set_/unify_constant, which already used Value::Integer), so
+%     `R is <expr>` with R bound to a ground integer (the head arg) failed —
+%     is/2's result match handles Unbound/Integer/Float, not Atom. That
+%     wrong is/2 answer was the BACKTRACKING root cause: it made cfib(10,55)
+%     fail its result check and then re-search exponentially (looping to the
+%     step_limit). Both now route through rust_const_value. builtins is now
+%     conformant, and fib no longer loops (it returns fast) — though it
+%     still gives the wrong answer (see below), so the non-termination is
+%     fixed but fib is not yet green.
+%  STILL diverging, tracked below for a follow-up:
 %   - member: cmem(z,[a,b,c]) wrongly succeeds (cons traversal in the
 %     heap-materialisation list model).
-%   - append/reverse: positive cases fail / backtrack without terminating.
-%   - fib: a query does not terminate (hits the step_limit) — the
-%     result-check on a bound R or the choice-point/backtracking management
-%     loops; needs the same kind of bound-LHS/cut audit the other backends
-%     had.
-%   - builtins: cbi_arith(28) — `R is <sum>` with R bound to a ground
-%     integer (the head arg) still fails, distinct from the =:= path that
-%     the nested-arith fix covered.
-%   - ack: cack(2,3,9) deep integer recursion fails.
+%   - append/reverse: positive cases fail (the list model again).
+%   - fib: cfib(10,55) now returns false fast (no longer loops). Compiled
+%     ALONE it fails, though it succeeded when co-compiled with other
+%     predicates — a first-arg-indexing / shared-program-assembly
+%     sensitivity (the integer constants changed the switch dispatch),
+%     distinct from the is/2 fix.
+%   - ack: cack(2,3,9) fails — the doubly-recursive integer case (base
+%     cack(0,N,R) and cack(2,3,8)->false work; the nested
+%     cack(M,N1,R1),cack(M1,R1,R) does not yield the right result).
+%  The runner driver keeps vm.step_limit as a guard so any remaining
+%  non-termination returns false rather than hanging the harness.
 ct_xfail(rust, member).
 ct_xfail(rust, append).
 ct_xfail(rust, reverse).
 ct_xfail(rust, fib).
-ct_xfail(rust, builtins).
 ct_xfail(rust, ack).
 
 %% ct_skip(Target, ProgramName)


### PR DESCRIPTION
## Summary

Fixes the **root cause of Rust's runaway backtracking** (the fib non-termination from #2773) and retires the **builtins** xfail. 

### The bug
`cfib(10,55)` looped to the step_limit. The cause was *not* the choice-point machinery — it was a **wrong `is/2` answer** triggering exponential re-search:

`put_constant`/`get_constant` rendered every constant as `Value::Atom`, so the integer `55`/`28` became `Atom("55")` — unlike `set_constant`/`unify_constant`, which already emitted `Value::Integer`. `is/2`'s result match only handles `Unbound`/`Integer`/`Float` (not `Atom`), so `R is <expr>` with `R` bound to a ground integer (the `cfib(N,R)` result check, or `cbi_arith(28)`'s head arg) **failed** — and the recursive predicate then backtracked exponentially instead of succeeding.

### The fix
Route `put_constant`/`get_constant` through a new `rust_const_value/2` that emits `Value::Integer`/`Value::Float` for numeric tokens.

## Result

| Program | Before | After |
|---|---|---|
| **builtins** | xfail | ✅ **conformant** (xfail retired) |
| **fib** | xfail (looped) | still xfail, but **no longer loops** — returns fast |
| member, append, reverse, ack | xfail | xfail (unchanged) |

- **The non-termination this task targeted is fixed** — fib returns fast instead of hitting the step_limit.
- **builtins is now green** (the `cbi_arith` bound-LHS `is/2` shared the same root cause).
- fib still returns the *wrong answer* when compiled **alone** (it succeeded co-compiled with other predicates) — a **first-arg-indexing / shared-program-assembly sensitivity** exposed now that the first arg is an `Integer` rather than an `Atom`. That's a distinct bug from the `is/2` fix, so fib stays xfailed with that diagnosis.

## A candid note on process
I twice got misled by fast manual spot-checks in a single mega-project (`fib` looked green there but fails in the harness's one-project-per-program build). The harness is authoritative, and the conclusion here is taken from the **full harness run** (which threw on `fib` only; builtins passed silently) — not a manual check. With `fib` re-xfailed, that run's sole failure is tolerated, so the suite is green.

## Verification
- Full `CONFORMANCE_TARGETS=rust` run: only `rust/fib` failed (now re-xfailed); builtins passed → green.
- `test_wam_rust_target` passes; the change only affects numeric-constant emission (no regressions).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_