### PR TITLE
fix(rust): implement switch_on_constant_fallthrough — fixes fib + ack

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -820,6 +820,27 @@ wam_instruction_arm('Instruction::SwitchOnConstant(table)', Body) :-
                 // Unbound A1: skip dispatch, advance to next instruction
                 self.pc += 1; true'.
 
+wam_instruction_arm('Instruction::SwitchOnConstantFallthrough(table)', Body) :-
+    Body = '                let raw = self.get_reg_raw("A1").map(|v| self.deref_var(&v));
+                if let Some(val) = raw {
+                    if !val.is_unbound() {
+                        for (key, label) in table {
+                            if *key == val {
+                                if let Some(&pc) = self.labels.get(label) {
+                                    self.pc = pc; return true;
+                                }
+                            }
+                        }
+                    }
+                }
+                // No table key matched (or A1 unbound): fall through to the
+                // next instruction (the try_me_else clause chain). Unlike
+                // SwitchOnConstant this never fails — failing here skipped the
+                // chain entirely and, because the dropped instruction also
+                // shifted every later label by one, backtracking landed past
+                // retry_me_else and looped.
+                self.pc += 1; true'.
+
 wam_instruction_arm('Instruction::SwitchOnConstantPc(table)', Body) :-
     Body = '                let raw = self.get_reg_raw("A1").map(|v| self.deref_var(&v));
                 if let Some(val) = raw {
@@ -2872,6 +2893,16 @@ wam_line_to_rust_instr(["switch_on_constant"|Entries], _, _, Rust) :-
     maplist(parse_index_entry_constant, Entries, RustEntries),
     atomic_list_concat(RustEntries, ', ', Joined),
     format(string(Rust), 'Instruction::SwitchOnConstant(vec![~w])', [Joined]).
+wam_line_to_rust_instr(["switch_on_constant_fallthrough"|Entries], _, _, Rust) :-
+    % Entries with a "default" target mean "fall through" for that key, so
+    % they carry no jump and are dropped from the table. Emitting this as a
+    % real instruction (rather than the unknown-fallback comment) keeps every
+    % later label PC aligned — the missing instruction shifted them by one.
+    exclude(is_default_index_entry, Entries, JumpEntries),
+    maplist(parse_index_entry_constant, JumpEntries, RustEntries),
+    atomic_list_concat(RustEntries, ', ', Joined),
+    format(string(Rust),
+        'Instruction::SwitchOnConstantFallthrough(vec![~w])', [Joined]).
 wam_line_to_rust_instr(["switch_on_structure"|Entries], _, _, Rust) :-
     maplist(parse_index_entry_structure, Entries, RustEntries),
     atomic_list_concat(RustEntries, ', ', Joined),
@@ -2925,6 +2956,11 @@ rust_foreign_spec(Pred/Arity,
         Pred/Arity) :-
     is_list(SetupOps),
     is_list(RewriteCalls).
+
+%% is_default_index_entry(+Entry) — true for a "K:default" switch entry.
+is_default_index_entry(Entry) :-
+    ( string(Entry) -> S = Entry ; atom_string(Entry, S) ),
+    sub_string(S, _, _, 0, ":default").
 
 parse_index_entry_constant(Entry, Rust) :-
     (   sub_string(Entry, Before, 1, After, ":")

--- a/templates/targets/rust_wam/instructions.rs.mustache
+++ b/templates/targets/rust_wam/instructions.rs.mustache
@@ -102,6 +102,10 @@ pub enum Instruction {
     // === Indexing ===
     /// First-argument constant dispatch.
     SwitchOnConstant(Vec<(Value, String)>),
+    /// First-argument constant dispatch that falls through to the next
+    /// instruction (the try_me_else chain) when the argument is unbound or
+    /// matches no table key — as opposed to SwitchOnConstant, which fails.
+    SwitchOnConstantFallthrough(Vec<(Value, String)>),
     /// First-argument constant dispatch with pre-resolved PCs.
     SwitchOnConstantPc(Vec<(Value, usize)>),
     /// First-argument structure dispatch.

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -212,32 +212,28 @@ ct_default_target(elixir).
 %   - put_constant/get_constant emitted Value::Atom("28") for the integer
 %     28 (unlike set_/unify_constant, which already used Value::Integer), so
 %     `R is <expr>` with R bound to a ground integer (the head arg) failed —
-%     is/2's result match handles Unbound/Integer/Float, not Atom. That
-%     wrong is/2 answer was the BACKTRACKING root cause: it made cfib(10,55)
-%     fail its result check and then re-search exponentially (looping to the
-%     step_limit). Both now route through rust_const_value. builtins is now
-%     conformant, and fib no longer loops (it returns fast) — though it
-%     still gives the wrong answer (see below), so the non-termination is
-%     fixed but fib is not yet green.
-%  STILL diverging, tracked below for a follow-up:
+%     is/2's result match handles Unbound/Integer/Float, not Atom. Now route
+%     through rust_const_value; this made builtins conformant.
+%   - switch_on_constant_fallthrough had NO codegen, so it fell to the
+%     unknown-instruction comment and was dropped from the emitted vector.
+%     That shifted every later label PC by one: backtracking into a clause
+%     chain landed one instruction PAST retry_me_else, so the choice point's
+%     next_pc was never advanced and execution looped on the same clause
+%     (returning false at the step_limit). Any predicate indexed on a
+%     constant first argument with 3+ clauses hit this — fib (cfib(0/1/N))
+%     and ack (cack(0,_)/cack(M,_)). Added the instruction with proper
+%     fallthrough semantics (jump on a table hit; advance to the try_me_else
+%     chain on unbound/miss — never fail). fib and ack are now conformant.
+%  STILL diverging, tracked below for a follow-up — all in the list model:
 %   - member: cmem(z,[a,b,c]) wrongly succeeds (cons traversal in the
-%     heap-materialisation list model).
-%   - append/reverse: positive cases fail (the list model again).
-%   - fib: cfib(10,55) now returns false fast (no longer loops). Compiled
-%     ALONE it fails, though it succeeded when co-compiled with other
-%     predicates — a first-arg-indexing / shared-program-assembly
-%     sensitivity (the integer constants changed the switch dispatch),
-%     distinct from the is/2 fix.
-%   - ack: cack(2,3,9) fails — the doubly-recursive integer case (base
-%     cack(0,N,R) and cack(2,3,8)->false work; the nested
-%     cack(M,N1,R1),cack(M1,R1,R) does not yield the right result).
+%     heap-materialisation list representation).
+%   - append/reverse: positive cases (capp([a,b],[c],[a,b,c]),
+%     crev([a,b,c],[c,b,a])) fail.
 %  The runner driver keeps vm.step_limit as a guard so any remaining
 %  non-termination returns false rather than hanging the harness.
 ct_xfail(rust, member).
 ct_xfail(rust, append).
 ct_xfail(rust, reverse).
-ct_xfail(rust, fib).
-ct_xfail(rust, ack).
 
 %% ct_skip(Target, ProgramName)
 %  Stronger than xfail: do NOT even build/run this (target, program).


### PR DESCRIPTION
## Summary

Implements `switch_on_constant_fallthrough` in the Rust WAM backend, fixing **both fib and ack** — they're now conformant. Rust goes from 1/6 → 3/6 (builtins, fib, ack); the remaining three are all the list model.

## The bug
`cfib(10,55)`→false and `cack(2,3,9)`→false — any predicate indexed on a **constant first argument with 3+ clauses** returned wrong answers. Found by tracing the step loop:

`switch_on_constant_fallthrough` had **no codegen**, so it fell to the unknown-instruction fallback and was emitted as a `/* ... */` comment — i.e. **dropped from the instruction vector**. That shifted every later label PC by one:
- Entry labels survived (the dropped switch slot became `try_me_else`, which is where entry should land).
- But a body label like `L_p_2_2` then pointed **one instruction past `retry_me_else`**.

So on the second backtrack, the choice point's `next_pc` was never advanced, and execution **looped on the same `get_constant` forever**, bottoming out false at the step_limit. The trace made it unmistakable:
```
pc=  6 | TryMeElse("L_p_2_2")
pc=  7 | GetConstant(Integer(0),"A1")   step FAIL -> backtrack to pc=11
pc= 11 | GetConstant(Integer(1),"A1")   step FAIL -> backtrack to pc=11   <-- skipped RetryMeElse!
pc= 11 | GetConstant(Integer(1),"A1")   ...loops forever
```
`p(0)`/`p(1)` (depth 1–2) worked; `p(2)` (depth 3, needs the retry) did not.

## The fix
Emit a real `SwitchOnConstantFallthrough` instruction (enum variant + step arm + codegen + a helper that drops the `K:default` fallthrough entries). Semantics: deref `A1`, jump on a table hit, otherwise **advance to the `try_me_else` chain** — it never fails, unlike `SwitchOnConstant`. Restoring the instruction also re-aligns the labels.

## Result
| Program | Before | After |
|---|---|---|
| **fib** | xfail | ✅ conformant |
| **ack** | xfail | ✅ conformant |
| member, append, reverse | xfail | xfail (list model) |

## Verification
- Full `CONFORMANCE_TARGETS=rust` harness run: **green** — no failures, only member/append/reverse tolerated (fib + ack + builtins pass). This is the authoritative oracle, not a manual spot-check.
- `test_wam_rust_target` passes — no regressions.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_