### PR TITLE
LLVM WAM: functor/3 + =.. atom-rep fix + univ cons-functor fix (M100)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -5870,7 +5870,12 @@ u.build_cons:
   %u.cons_mem = call i8* @wam_arena_alloc(i64 %u.cp_size)
   %u.cons = bitcast i8* %u.cons_mem to %Compound*
   %u.cons_fn = getelementptr %Compound, %Compound* %u.cons, i32 0, i32 0
-  store i8* getelementptr ([2 x i8], [2 x i8]* @.fn__2E, i32 0, i32 0), i8** %u.cons_fn
+  ; M100: use the SWI [|] cons functor (matches put_list, put_structure
+  ; for list-syntax, findall output, and every other cons-cell producer
+  ; in the codebase). The previous . (period) functor used here made
+  ; univ-built lists fail to unify with source-level list patterns
+  ; like [H|T], because put_list emits [|](H,T) compounds.
+  store i8* getelementptr ([4 x i8], [4 x i8]* @.fn__5B_7C_5D, i32 0, i32 0), i8** %u.cons_fn
   %u.cons_ar = getelementptr %Compound, %Compound* %u.cons, i32 0, i32 1
   store i32 2, i32* %u.cons_ar
   %u.cargs_mem = call i8* @wam_arena_alloc(i64 32)

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -5633,7 +5633,16 @@ fn.compound:
   %fn.ar_slot = getelementptr %Compound, %Compound* %fn.cp_ptr, i32 0, i32 1
   %fn.ar = load i32, i32* %fn.ar_slot
   %fn.ar_i64 = sext i32 %fn.ar to i64
-  %fn.name_val = call %Value @value_atom(i8* %fn.fn_i8)
+  ; M100: intern the functor string into the runtime atom table so
+  ; the resulting Atom Value carries an atom_id payload that matches
+  ; user-level atom literals (which compile to id-based put_constant
+  ; via the static atom table). The legacy value_atom(i8*) form
+  ; packed the pointer as payload, so functor(C, Name, _) followed
+  ; by Name == foo spuriously failed (pointer-based vs id-based).
+  %fn.fn_len = call i64 @strlen(i8* %fn.fn_i8)
+  %fn.fn_aid = call i64 @wam_intern_atom(i8* %fn.fn_i8, i64 %fn.fn_len)
+  %fn.name_val0 = insertvalue %Value undef, i32 0, 0
+  %fn.name_val = insertvalue %Value %fn.name_val0, i64 %fn.fn_aid, 1
   %fn.ar_val = call %Value @value_integer(i64 %fn.ar_i64)
   br label %fn.bind_both
 
@@ -5797,7 +5806,12 @@ u.setup_compound:
   %u.args_c = load %Value*, %Value** %u.args_slot
   %u.fn_slot = getelementptr %Compound, %Compound* %u.cp_ptr, i32 0, i32 0
   %u.fn_ptr = load i8*, i8** %u.fn_slot
-  %u.fn_val_c = call %Value @value_atom(i8* %u.fn_ptr)
+  ; M100: same fix as builtin_functor -- intern the functor string
+  ; so the head of the =.. list is an id-based Atom Value.
+  %u.fn_len = call i64 @strlen(i8* %u.fn_ptr)
+  %u.fn_aid = call i64 @wam_intern_atom(i8* %u.fn_ptr, i64 %u.fn_len)
+  %u.fn_val_c0 = insertvalue %Value undef, i32 0, 0
+  %u.fn_val_c = insertvalue %Value %u.fn_val_c0, i64 %u.fn_aid, 1
   br label %u.loop_init
 
 u.loop_init:
@@ -5812,7 +5826,14 @@ u.loop_init:
   %u.args = phi %Value* [ null, %u.setup_atomic ], [ %u.args_c, %u.setup_compound ]
   %u.fn_val = phi %Value [ zeroinitializer, %u.setup_atomic ], [ %u.fn_val_c, %u.setup_compound ]
   call void @wam_arena_ensure()
-  %u.empty = call %Value @value_atom(i8* getelementptr ([3 x i8], [3 x i8]* @.fn__5B_5D, i32 0, i32 0))
+  ; M100: build the empty-list tail sentinel via the pre-computed
+  ; @wam_empty_list_atom_id so it matches put_constant of [] in user
+  ; code (both id-based). The old value_atom(@.fn__5B_5D) packed the
+  ; functor-string pointer, which did not compare equal to a literal
+  ; [] in T == [] type tests.
+  %u.empty_aid = load i64, i64* @wam_empty_list_atom_id
+  %u.empty_v0 = insertvalue %Value undef, i32 0, 0
+  %u.empty = insertvalue %Value %u.empty_v0, i64 %u.empty_aid, 1
   br label %u.loop_body
 
 u.loop_body:
@@ -5911,7 +5932,13 @@ u.c.walk_init:
   ; Each cons is a %Compound { ".", 2, [head, tail] }. Empty list is
   ; Atom("[]") with payload = ptrtoint(@.fn__5B_5D).
   call void @wam_arena_ensure()
-  %u.c.empty_val = call %Value @value_atom(i8* getelementptr ([3 x i8], [3 x i8]* @.fn__5B_5D, i32 0, i32 0))
+  ; M100: match the empty-list representation produced by put_constant
+  ; of [] (id-based via @wam_empty_list_atom_id), so the list-walk
+  ; comparison correctly terminates on both univ-built and source-
+  ; literal lists.
+  %u.c.empty_aid = load i64, i64* @wam_empty_list_atom_id
+  %u.c.empty_val0 = insertvalue %Value undef, i32 0, 0
+  %u.c.empty_val = insertvalue %Value %u.c.empty_val0, i64 %u.c.empty_aid, 1
   %u.c.empty_payload = call i64 @value_payload(%Value %u.c.empty_val)
   br label %u.c.count_loop
 

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2483,8 +2483,13 @@ test_functor_arity_check(_, R) :-
 test_univ_head_eq_literal(_, R) :-
     % Same fix applied to =.. (univ): the list head is the functor
     % as an id-based Atom Value, comparing correctly with literals.
+    % Uses the two-step =.. L, L = [H|_] form -- the direct
+    % =.. [H|_] form has a separate pre-existing WAM-compile
+    % issue (partial-list arg to =.. doesn''t reach the builtin in
+    % a unifiable shape).
     Term = baz(7, 8),
-    Term =.. [H | _],
+    Term =.. L,
+    L = [H | _],
     ( H == baz -> R is 1 ; R is 0 ).   % 1
 
 :- dynamic test_univ_tail_is_empty_list/2.
@@ -2492,7 +2497,8 @@ test_univ_tail_is_empty_list(_, R) :-
     % =.. terminates with the [] atom -- M100 makes that id-based
     % via @wam_empty_list_atom_id, matching the literal [].
     Term = quux(1),
-    Term =.. [_, _ | Tail],
+    Term =.. L,
+    L = [_, _ | Tail],
     ( Tail == [] -> R is 1 ; R is 0 ).   % 1
 
 % M99: date_time_stamp/2 -- inverse of M98 stamp_date_time/3 via libc mktime.

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,42 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M100: functor/3 + =.. read-mode atom representation fix.
+
+:- dynamic test_functor_name_eq_literal/2.
+test_functor_name_eq_literal(_, R) :-
+    % functor(C, Name, _) extracts the functor as an Atom Value.
+    % Pre-M100 that was pointer-based, so Name == foo failed even
+    % when the compound was foo(...). The fix interns the functor
+    % string into the atom table so Name carries an id payload that
+    % matches the literal `foo' (also id-based via put_constant).
+    Term = foo(1, 2, 3),
+    functor(Term, Name, _),
+    ( Name == foo -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_functor_arity_check/2.
+test_functor_arity_check(_, R) :-
+    % And the canonical pattern `functor(T, Name, Arity)' with both
+    % name and arity literals now works as a structure shape check.
+    Term = bar(a, b),
+    ( functor(Term, bar, 2) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_univ_head_eq_literal/2.
+test_univ_head_eq_literal(_, R) :-
+    % Same fix applied to =.. (univ): the list head is the functor
+    % as an id-based Atom Value, comparing correctly with literals.
+    Term = baz(7, 8),
+    Term =.. [H | _],
+    ( H == baz -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_univ_tail_is_empty_list/2.
+test_univ_tail_is_empty_list(_, R) :-
+    % =.. terminates with the [] atom -- M100 makes that id-based
+    % via @wam_empty_list_atom_id, matching the literal [].
+    Term = quux(1),
+    Term =.. [_, _ | Tail],
+    ( Tail == [] -> R is 1 ; R is 0 ).   % 1
+
 % M99: date_time_stamp/2 -- inverse of M98 stamp_date_time/3 via libc mktime.
 
 :- dynamic test_dts_roundtrip/2.
@@ -4959,6 +4995,15 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M100 functor/3 + =.. atom-rep fix ---~n'),
+       run_test_r0('functor(foo(...), Name, _), Name == foo -> 1',
+                   test_functor_name_eq_literal, 0, 1),
+       run_test_r0('functor(bar(a,b), bar, 2) -> 1',
+                   test_functor_arity_check, 0, 1),
+       run_test_r0('baz(7,8) =.. [H|_], H == baz -> 1',
+                   test_univ_head_eq_literal, 0, 1),
+       run_test_r0('quux(1) =.. [_,_|T], T == [] -> 1',
+                   test_univ_tail_is_empty_list, 0, 1),
        format('--- M99 date_time_stamp/2 ---~n'),
        run_test_r0('stamp -> DT -> stamp round-trip -> 1',
                    test_dts_roundtrip, 0, 1),


### PR DESCRIPTION
## Summary

Fixes two long-standing atom-representation bugs in `functor/3` and `=..` (univ), plus a related cons-functor mismatch in univ output. Together these make the canonical Prolog shape-inspection patterns work:

```prolog
functor(foo(1, 2), Name, Arity),  Name == foo,  Arity =:= 2.
Term =.. L,  L = [H | _],  H == baz.
```

Both of those silently failed before M100.

## Bug 1: pointer-based vs id-based atom payloads

Pre-M100, `builtin_functor` and univ extracted compound functor names via `value_atom(i8*)`, which packed the functor-string pointer as the Atom Value payload. But `put_constant` for an atom literal packs the static-table `atom_id` as payload. `wam_unify_value` / `value_equals` compare payloads directly via `icmp eq i64`, so `Name == foo` was always false even when `Name` did name `foo`.

**Fix**: Both extraction sites now call `wam_intern_atom(functor_str, strlen)` and build an Atom Value with `tag 0 + atom_id payload`. `wam_intern_atom` deduplicates against the static atom table, so a functor that was also used as a literal returns the same id.

The two empty-list sentinels in univ (`u.empty` in the output loop, `u.c.empty_val` in the input list walk) now read `@wam_empty_list_atom_id` — the static `[]` atom id already baked into every module — and pack that as the Atom payload. Avoids the runtime `strlen + intern` lookup for a value we know at compile time.

## Bug 2: univ output used `.` cons functor instead of `[|]`

While testing with `=.. [H | _]`, the pattern match was silently failing. Root cause: `builtin_univ` constructed its output cons cells with `@.fn__2E` (the `.` functor) while every other cons-cell producer in the codebase (`put_list`, `put_structure` for `[|]`-syntax, `findall` result chain, `sort` / `keysort` buffers, list builders for `char_codes` etc) uses `@.fn__5B_7C_5D` (the SWI `[|]` functor).

The result was univ-built lists couldn't unify with any source-level list pattern. `Term =.. L` would succeed and `L` would print as `.(baz, .(7, .(8, [])))` — the giveaway it wasn't a real list — but then `L = [H | _]` failed because `.` and `[|]` are different functors. After the fix, `L` prints as `[baz, 7, 8]` and pattern matching works.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `builtin_functor` + univ output use `wam_intern_atom`; both `[]` sentinels read `@wam_empty_list_atom_id`; univ cons cells use `[|]`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — four M100 tests + section in `test_all`.

## Test plan

- [x] Full execution suite: **638/638 PASS**, no failures, no OOM
- [x] `test_functor_name_eq_literal`: `functor(foo(...), N, _), N == foo` ✓
- [x] `test_functor_arity_check`: `functor(bar(a,b), bar, 2)` canonical shape-check ✓
- [x] `test_univ_head_eq_literal`: `baz(...) =.. L, L = [H|_], H == baz` ✓
- [x] `test_univ_tail_is_empty_list`: `quux(1) =.. L, L = [_,_|T], T == []` ✓

## Known follow-up

Tests use the two-step `=.. L, L = [H | _]` form rather than the direct `=.. [H | _]` form. The direct form hits a separate pre-existing WAM-compile issue (partial-list arg to `=..` doesn't reach the builtin in a unifiable shape). Independent fix for a future milestone — does not block this PR since the two-step form exercises the same atom-rep path.

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_