### PR TITLE
fix(rust): list model — member/append/reverse conformant (Rust now 6/6)

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -89,6 +89,14 @@ wam_instruction_arm('Instruction::GetConstant(c, ai)', Body) :-
                 let val = raw_val.map(|v| self.deref_var(&v));
                 match val {
                     Some(v) if v == *c => { self.pc += 1; true }
+                    // Empty-list aliasing: the [] atom and an empty Value::List
+                    // are the same term. A list tail peeled down to its end is
+                    // Value::List([]), and a clause head get_constant [] must
+                    // match it (e.g. append/3 base case capp([],L,L)).
+                    Some(Value::List(ref items)) if items.is_empty()
+                        && matches!(c, Value::Atom(s) if s == "[]") => {
+                        self.pc += 1; true
+                    }
                     Some(Value::Unbound(ref var_name)) => {
                         self.trail_binding(ai);
                         self.set_reg_str(ai, c.clone());
@@ -109,23 +117,18 @@ wam_instruction_arm('Instruction::GetVariable(xn, ai)', Body) :-
                 } else { false }'.
 
 wam_instruction_arm('Instruction::GetValue(xn, ai)', Body) :-
-    Body = '                let val_a = self.get_reg_raw(ai);
+    Body = '                // get_value Xn, Ai is full unification of the two.
+                // The old hand-rolled version only did raw equality plus
+                // unbound-binding, so it could not unify two bound compound
+                // terms or follow a heap Ref — e.g. append/3 binding the
+                // accumulated result list against a tail cell. Route through
+                // unify(), which derefs (incl. Ref->heap), binds vars, and
+                // structurally unifies with cons-cell aliasing.
+                let val_a = self.get_reg_raw(ai);
                 let val_x = self.get_reg(xn);
                 match (val_a, val_x) {
-                    (Some(a), Some(x)) if a == x => { self.pc += 1; true }
-                    (Some(a), _) if a.is_unbound() => {
-                        self.trail_binding(ai);
-                        if let Some(x) = self.get_reg(xn) {
-                            self.set_reg_str(ai, x);
-                        }
-                        self.pc += 1; true
-                    }
-                    (_, Some(x)) if x.is_unbound() => {
-                        self.trail_binding(xn);
-                        if let Some(a) = self.get_reg_raw(ai) {
-                            self.put_reg(xn, a);
-                        }
-                        self.pc += 1; true
+                    (Some(a), Some(x)) => {
+                        if self.unify(&a, &x) { self.pc += 1; true } else { false }
                     }
                     _ => false,
                 }'.
@@ -705,6 +708,9 @@ wam_instruction_arm('Instruction::Proceed', Body) :-
                 self.cp = 0; // halt
                 self.pc = ret;
                 true'.
+
+wam_instruction_arm('Instruction::NoOp', Body) :-
+    Body = '                self.pc += 1; true'.
 
 wam_instruction_arm('Instruction::BuiltinCall(op, arity)', Body) :-
     Body = '                self.execute_builtin(op, *arity)'.
@@ -2911,10 +2917,15 @@ wam_line_to_rust_instr(["switch_on_constant_a2"|Entries], _, _, Rust) :-
     maplist(parse_index_entry_constant, Entries, RustEntries),
     atomic_list_concat(RustEntries, ', ', Joined),
     format(string(Rust), 'Instruction::SwitchOnConstantA2(vec![~w])', [Joined]).
-% Fallback for unknown instructions
+% Fallback for unknown instructions. Emit a real NoOp (not a bare comment):
+% a comment is dropped from the vec! literal, which shifts every later label
+% PC by one and corrupts backtracking (a missing trust_me/retry_me_else made
+% the choice point loop). NoOp preserves alignment, and for the indexing
+% hints that land here (switch_on_term, ...) falling through to the
+% try_me_else chain is correct.
 wam_line_to_rust_instr(Parts, _, _, Rust) :-
     atomic_list_concat(Parts, ' ', Joined),
-    format(string(Rust), '/* unknown: ~w */', [Joined]).
+    format(string(Rust), 'Instruction::NoOp /* unknown: ~w */', [Joined]).
 
 %% rust_const_value(+Const, -RustValueExpr)
 %  Render a WAM constant token as the right Value variant. Numeric

--- a/templates/targets/rust_wam/instructions.rs.mustache
+++ b/templates/targets/rust_wam/instructions.rs.mustache
@@ -80,6 +80,13 @@ pub enum Instruction {
     ExecutePc(usize),
     /// Return from predicate (jump to CP).
     Proceed,
+    /// No-op: advances the program counter by one. Emitted for WAM
+    /// instructions the Rust backend does not (yet) translate — chiefly the
+    /// first-argument indexing hints (switch_on_term, ...). Indexing is only
+    /// an optimisation, so skipping it and letting the try_me_else clause
+    /// chain run is correct; emitting a real instruction (rather than a
+    /// dropped comment) keeps every later label PC aligned.
+    NoOp,
     /// Evaluate a built-in predicate.
     BuiltinCall(String, usize),
     /// Start collecting solutions for an aggregate.

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -825,7 +825,19 @@ impl WamState {
                             let tail = self.heap[marker + 1].clone();
                             let list = match tail {
                                 Value::List(mut items) => { items.insert(0, head); Value::List(items) }
-                                _ => Value::List(vec![head, tail]),
+                                Value::Atom(ref s) if s == "[]" => Value::List(vec![head]),
+                                // Partial list: the tail is still an unbound
+                                // variable (or a ref/cons) that a later
+                                // put_structure will fill — e.g. building
+                                // [a|X2] then X2=[b|X3]. Materialising this as
+                                // Value::List([head, tail]) would treat the
+                                // tail var as a SECOND ELEMENT (so [a|X] looked
+                                // like the 2-list [a,X]); get_list then peeled
+                                // a wrong tail and member(z,...) bound the var
+                                // and wrongly succeeded. Keep it as a cons cell
+                                // so the tail var derefs to the rest of the
+                                // list. get_list/unify already alias [|]/2.
+                                _ => Value::Str("[|]/2".to_string(), vec![head, tail]),
                             };
                             // Update the register holding Ref(marker) or Integer(marker)
                             let ref_val = Value::Ref(marker);

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -193,8 +193,8 @@ ct_default_target(elixir).
 %     (b) it tested isUnbound BEFORE deref, so a *bound* variable tail was
 %     mistaken for unbound and sent into write mode (now derefs first).
 
-%  Rust (onboarding in progress). The Rust WAM runtime had the same gap
-%  family as Go, plus a missing =/2; fixed so far (wam_rust_target.pl /
+%  Rust is now fully conformant. The Rust WAM runtime had the same gap
+%  family as Go, plus a missing =/2; the fixes (wam_rust_target.pl /
 %  templates/targets/rust_wam/state.rs.mustache):
 %   - =/2 had NO handler in execute_builtin (the compiler emits `X = Y` as
 %     builtin_call =/2), so even `a = a` returned false. Added a handler
@@ -224,16 +224,25 @@ ct_default_target(elixir).
 %     and ack (cack(0,_)/cack(M,_)). Added the instruction with proper
 %     fallthrough semantics (jump on a table hit; advance to the try_me_else
 %     chain on unbound/miss — never fail). fib and ack are now conformant.
-%  STILL diverging, tracked below for a follow-up — all in the list model:
-%   - member: cmem(z,[a,b,c]) wrongly succeeds (cons traversal in the
-%     heap-materialisation list representation).
-%   - append/reverse: positive cases (capp([a,b],[c],[a,b,c]),
-%     crev([a,b,c],[c,b,a])) fail.
-%  The runner driver keeps vm.step_limit as a guard so any remaining
-%  non-termination returns false rather than hanging the harness.
-ct_xfail(rust, member).
-ct_xfail(rust, append).
-ct_xfail(rust, reverse).
+%   - the list model (member/append/reverse) needed four fixes:
+%     (a) a partial list whose tail is still an unbound variable
+%         ([a|X2] then X2=[b|X3]) was materialised as Value::List([a,X2]),
+%         treating the tail var as a SECOND ELEMENT; get_list then peeled a
+%         wrong tail and member(z,...) bound the var and wrongly succeeded.
+%         set_heap_or_list now keeps such a cell as a "[|]/2" cons so the
+%         tail var derefs to the rest of the list.
+%     (b) switch_on_term had no codegen and was dropped (same label-shift
+%         class as switch_on_constant_fallthrough: a skipped trust_me made
+%         the choice point loop). Unknown instructions now emit a real NoOp,
+%         preserving PC alignment; falling through to the try chain is
+%         correct for indexing hints.
+%     (c) get_constant [] now matches an empty Value::List (append's base
+%         case capp([],L,L) sees the peeled tail as Value::List([])).
+%     (d) get_value did only raw equality + unbound-binding; it now routes
+%         through unify(), so it follows heap Refs and structurally unifies
+%         the accumulated result list (append/reverse output).
+%  The runner driver keeps vm.step_limit as a guard against accidental
+%  non-termination.
 
 %% ct_skip(Target, ProgramName)
 %  Stronger than xfail: do NOT even build/run this (target, program).


### PR DESCRIPTION
## Summary

Fixes the Rust WAM list model — **member, append, and reverse are now conformant**. With this, **Rust is fully conformant: 6/6**, zero xfails.

Four fixes, each found by tracing the step loop:

### 1. Partial lists materialized wrong (member)
Building `[a|X2]` then `X2=[b|X3]` materialized `A2` as `Value::List([a, X2])` — treating the unbound **tail var as a second element**. `get_list` then peeled a wrong tail, so `cmem(z,[a,b,c])` bound the leftover var and **wrongly succeeded**. `set_heap_or_list` now keeps a cell whose tail isn't a proper list as a `"[|]/2"` cons, so the tail var derefs to the rest of the list.

### 2. `switch_on_term` dropped → label shift (append/reverse loop)
`switch_on_term` had no codegen, so it hit the unknown-instruction fallback and was emitted as a `/* comment */` — **dropped from the `vec!`**, shifting every later label PC by one (same class as the `switch_on_constant_fallthrough` bug from #2782). A skipped `trust_me` left the choice point looping. The fallback now emits a real `Instruction::NoOp` (new variant) instead of a comment, preserving PC alignment; falling through to the try chain is correct for indexing hints.

### 3. `get_constant []` vs empty `Value::List` (append base case)
A list tail peeled to its end is `Value::List([])`, and `capp([],L,L)` must match `[]` against it. Added empty-list aliasing to `GetConstant`.

### 4. `get_value` didn't unify (append/reverse output)
`get_value` did only raw equality + unbound-binding — it couldn't follow a heap `Ref` or structurally unify two bound compounds. Now routes through `unify()`. This is what binds the accumulated result list against the output tail cell.

## Verification
- Full `CONFORMANCE_TARGETS=rust` harness: **green, zero xfails** — all six programs (member, append, reverse, fib, ack, builtins) pass. This is the authoritative oracle (every fixture query), not a spot-check.
- `test_wam_rust_target` passes — no regressions (the `get_value`→`unify` change is broad but the full harness confirms fib/ack/builtins still pass). The pre-existing `test_wam_rust_runtime` breakage is unrelated (identical on clean main, verified by stash).

## Arc
Across this session Rust went **0/6 → 6/6**: onboarding (#2773), backtracking/`is/2` (#2779), first-arg indexing fixing fib+ack (#2782), and now the list model.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_