### PR TITLE
LLVM WAM: =.. partial-list unify (M101)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -5908,8 +5908,16 @@ u.a2_bind:
   ret i1 true
 
 u.a2_check:
-  ; A2 already bound — limited support: accept iff structural-equal.
-  %u.a2_eq = call i1 @value_equals(%Value %u.a2, %Value %u.cons_val)
+  ; M101: A2 already bound -- unify (not just structurally compare)
+  ; with the freshly-built result list. value_equals only tests
+  ; equality of fully-bound terms and would silently fail for a
+  ; partial-list arg like [H|_] (unbound H plus unbound tail), so
+  ; the canonical pattern Term =.. [H|_] never matched. Routing
+  ; through wam_unify_value binds H to the functor atom and the
+  ; tail to the rest of the list -- exactly what the source-level
+  ; partial pattern asks for.
+  %u.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %u.a2_eq = call i1 @wam_unify_value(%WamState* %vm, %Value %u.raw2, %Value %u.cons_val)
   ret i1 %u.a2_eq
 
 u.fail:

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,35 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M101: =.. with partial-list second arg now unifies (was broken
+% in M100 -- u.a2_check used value_equals which couldn''t bind
+% through the unbound vars in [H|_]).
+
+:- dynamic test_univ_partial_head/2.
+test_univ_partial_head(_, R) :-
+    % Direct form: Term =.. [H | _] -- partial list with unbound
+    % H and unbound tail. The freshly-built result list unifies
+    % with the pattern, binding H to the functor atom.
+    Term = baz(7, 8),
+    Term =.. [H | _],
+    ( H == baz -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_univ_partial_arity/2.
+test_univ_partial_arity(_, R) :-
+    % [_, _, _] with three unbound element slots -- result list
+    % from a 2-ary compound has exactly 3 elements (functor + 2
+    % args), so unification succeeds and the pattern serves as
+    % a deterministic arity check.
+    Term = quux(a, b),
+    ( Term =.. [_, _, _] -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_univ_partial_no_match/2.
+test_univ_partial_no_match(_, R) :-
+    % [_, _] is a 2-element partial pattern; a 2-ary compound''s
+    % result list has 3 elements, so the unify fails.
+    Term = quux(a, b),
+    ( Term =.. [_, _] -> R is 0 ; R is 1 ).   % 1
+
 % M100: functor/3 + =.. read-mode atom representation fix.
 
 :- dynamic test_functor_name_eq_literal/2.
@@ -5001,6 +5030,13 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M101 =.. partial-list unify ---~n'),
+       run_test_r0('baz(7,8) =.. [H|_], H == baz -> 1',
+                   test_univ_partial_head, 0, 1),
+       run_test_r0('quux(a,b) =.. [_,_,_] -> 1 (arity check)',
+                   test_univ_partial_arity, 0, 1),
+       run_test_r0('quux(a,b) =.. [_,_] fails -> 1',
+                   test_univ_partial_no_match, 0, 1),
        format('--- M100 functor/3 + =.. atom-rep fix ---~n'),
        run_test_r0('functor(foo(...), Name, _), Name == foo -> 1',
                    test_functor_name_eq_literal, 0, 1),


### PR DESCRIPTION
## Summary

Fixes the `=..` partial-list arg bug I noted in M100. Now the canonical Prolog idiom `Term =.. [H | _]` works directly without the two-step workaround.

## The bug

When `=..` was called with a partial list pattern on the second arg, `builtin_univ`'s `u.a2_check` path called `value_equals` to compare the freshly-built result list against the bound `A2`. But `value_equals` tests structural equality of fully-bound terms — it can't bind through unbound elements of the partial pattern. So

```prolog
Term =.. [H | _], H == foo
```

silently failed: univ built the result correctly, then `value_equals` returned false because `H` and the tail were unbound.

## The fix

Route `u.a2_check` through `wam_unify_value` instead of `value_equals`. Unification binds `H` to the functor atom and the tail to the remaining elements, which is exactly what the source-level partial pattern asks for. Structural equality is preserved when `A2` is fully ground because unify is a generalization of equals.

Isolated reproducer confirms: pre-fix `baz(7,8) =.. [H|_]` returned 255 (`run_loop` false); post-fix it returns 1 with `H = baz`.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `u.a2_check` now calls `@wam_unify_value` (with `wam_get_reg` for `A2`'s raw register slot so binding writes through), 4 lines.
- `tests/core/test_wam_llvm_builtin_execution.pl` — three M101 tests + section in `test_all`.

## Test plan

- [x] Full execution suite: **641/641 PASS**, no failures, no OOM
- [x] `test_univ_partial_head`: direct `[H|_]` pattern binds `H` correctly to the functor ✓
- [x] `test_univ_partial_arity`: `[_,_,_]` succeeds against 2-ary compound — partial-pattern as a deterministic arity check ✓
- [x] `test_univ_partial_no_match`: `[_,_]` fails against 2-ary compound (length mismatch — 2 vs 3) ✓
- [x] The two M100 univ tests that previously used the two-step workaround still pass; the direct form now works alongside them.

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_