### PR TITLE
LLVM WAM: chmod/2 (M102) -- libc chmod wrapper

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1479,6 +1479,7 @@ declare i32 @rmdir(i8*)
 declare i8* @getenv(i8*)
 declare i32 @setenv(i8*, i8*, i32)
 declare i32 @unsetenv(i8*)
+declare i32 @chmod(i8*, i32)
 declare i64 @strlen(i8*)
 declare i32 @system(i8*)
 declare i8* @getcwd(i8*, i64)
@@ -3565,6 +3566,7 @@ entry:
     i32 119, label %builtin_set_random
     i32 120, label %builtin_stamp_date_time
     i32 121, label %builtin_date_time_stamp
+    i32 122, label %builtin_chmod
   ]
 
 builtin_is:
@@ -5471,6 +5473,34 @@ dts.do_unify:
   %dts.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
   %dts.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %dts.raw2, %Value %dts.v)
   ret i1 %dts.uok
+
+builtin_chmod:
+  ; M102: chmod(+Path, +Mode) -- Path is atom, Mode is Integer
+  ; (interpreted as octal in source via the user''s 0o... or 0''o...
+  ; literal; the WAM just receives the i64 payload). Succeeds iff
+  ; libc chmod returns 0.
+  %ch.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %ch.t1 = call i32 @value_tag(%Value %ch.a1)
+  %ch.is_atom = icmp eq i32 %ch.t1, 0
+  br i1 %ch.is_atom, label %ch.check2, label %ch.fail
+ch.fail:
+  ret i1 false
+ch.check2:
+  %ch.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %ch.t2 = call i32 @value_tag(%Value %ch.a2)
+  %ch.is_int = icmp eq i32 %ch.t2, 1
+  br i1 %ch.is_int, label %ch.go, label %ch.fail
+ch.go:
+  %ch.aid = call i64 @value_payload(%Value %ch.a1)
+  %ch.path = call i8* @wam_atom_to_string(i64 %ch.aid)
+  %ch.path_null = icmp eq i8* %ch.path, null
+  br i1 %ch.path_null, label %ch.fail, label %ch.do
+ch.do:
+  %ch.mode64 = call i64 @value_payload(%Value %ch.a2)
+  %ch.mode = trunc i64 %ch.mode64 to i32
+  %ch.ret = call i32 @chmod(i8* %ch.path, i32 %ch.mode)
+  %ch.ok = icmp eq i32 %ch.ret, 0
+  ret i1 %ch.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -12358,6 +12388,7 @@ builtin_op_to_id('getppid/1', 118).           % libc getppid() as Integer.
 builtin_op_to_id('set_random/1', 119).        % srand48 via seed(N) compound.
 builtin_op_to_id('stamp_date_time/3', 120).   % localtime_r + build 9-arity date/9.
 builtin_op_to_id('date_time_stamp/2', 121).   % mktime via date/9 compound.
+builtin_op_to_id('chmod/2', 122).             % libc chmod(Path, Mode).
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2092,6 +2092,7 @@ is_builtin_pred(time_file, 2).          % time_file(+Path, -Time).
 is_builtin_pred(getenv, 2).             % getenv(+Name, -Value).
 is_builtin_pred(setenv, 2).             % setenv(+Name, +Value).
 is_builtin_pred(unsetenv, 1).           % unsetenv(+Name).
+is_builtin_pred(chmod, 2).              % chmod(+Path, +Mode).
 is_builtin_pred(shell, 1).              % shell(+Command).
 is_builtin_pred(shell, 2).              % shell(+Command, -Status).
 is_builtin_pred(working_directory, 2).  % working_directory(?Old, ?New).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,40 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M102: chmod/2 -- libc chmod wrapper for file mode bits.
+
+:- dynamic test_chmod_set_readonly/2.
+test_chmod_set_readonly(_, R) :-
+    % Create a temp file, chmod 0o444 (read-only), confirm size_file
+    % still works (read succeeds). Cleanup afterwards.
+    Path = '/tmp/uw_m102_chmod_test',
+    setup_call_cleanup(
+        ( open(Path, write, S),
+          write(S, x),
+          close(S)
+        ),
+        ( chmod(Path, 0o444),
+          size_file(Path, _Sz),
+          R = 1
+        ),
+        ( catch(chmod(Path, 0o644), _, true),
+          catch(delete_file(Path), _, true)
+        )
+    ).   % 1
+
+:- dynamic test_chmod_missing_file/2.
+test_chmod_missing_file(_, R) :-
+    % chmod on a path that doesn''t exist fails (returns -1, ENOENT).
+    ( chmod('/tmp/uw_m102_nope_xyz', 0o644) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_chmod_bad_args/2.
+test_chmod_bad_args(_, R) :-
+    % Non-atom path or non-integer mode falls through to plain fail.
+    ( chmod(42, 0o644) -> R is 0
+    ; chmod('/tmp/x', not_an_int) -> R is 0
+    ; R is 1
+    ).   % 1
+
 % M101: =.. with partial-list second arg now unifies (was broken
 % in M100 -- u.a2_check used value_equals which couldn''t bind
 % through the unbound vars in [H|_]).
@@ -5030,6 +5064,13 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M102 chmod/2 ---~n'),
+       run_test_r0('create + chmod 0o444 + size_file roundtrip -> 1',
+                   test_chmod_set_readonly, 0, 1),
+       run_test_r0('chmod on missing file fails -> 1',
+                   test_chmod_missing_file, 0, 1),
+       run_test_r0('chmod with non-atom path / non-int mode fails -> 1',
+                   test_chmod_bad_args, 0, 1),
        format('--- M101 =.. partial-list unify ---~n'),
        run_test_r0('baz(7,8) =.. [H|_], H == baz -> 1',
                    test_univ_partial_head, 0, 1),

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2463,22 +2463,17 @@ test_forall_manual(_, R) :-
 
 :- dynamic test_chmod_set_readonly/2.
 test_chmod_set_readonly(_, R) :-
-    % Create a temp file, chmod 0o444 (read-only), confirm size_file
-    % still works (read succeeds). Cleanup afterwards.
+    % Use shell to create + cleanup so the test doesn''t depend on
+    % open/3 + setup_call_cleanup interactions in the WAM backend
+    % (which currently segfault when stacked). Verifies chmod
+    % actually reaches the file by checking exists_file still
+    % succeeds after the mode change.
     Path = '/tmp/uw_m102_chmod_test',
-    setup_call_cleanup(
-        ( open(Path, write, S),
-          write(S, x),
-          close(S)
-        ),
-        ( chmod(Path, 0o444),
-          size_file(Path, _Sz),
-          R = 1
-        ),
-        ( catch(chmod(Path, 0o644), _, true),
-          catch(delete_file(Path), _, true)
-        )
-    ).   % 1
+    shell('touch /tmp/uw_m102_chmod_test', _),
+    chmod(Path, 0o444),
+    exists_file(Path),
+    shell('rm -f /tmp/uw_m102_chmod_test', _),
+    R is 1.   % 1
 
 :- dynamic test_chmod_missing_file/2.
 test_chmod_missing_file(_, R) :-


### PR DESCRIPTION
## Summary

- **M102 `chmod/2`** — libc `chmod` wrapper for file mode bits. Op id 122.

Reads reg 0 (Path) as Atom, reg 1 (Mode) as Integer, pulls the path string via `wam_atom_to_string`, truncates the `i64` Mode payload to `i32` (`mode_t` fits comfortably — Linux mode bits top out at `0o7777`), and calls libc `chmod`. Succeeds iff `chmod` returns 0; any libc failure (`ENOENT`, `EACCES`, `EPERM` etc.) just becomes a Prolog fail. Non-atom Path or non-Integer Mode also fall through to fail rather than throw.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `@chmod` libc decl, dispatch entry, `builtin_chmod` IR block (prefix `ch.`), op-id table entry.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred(chmod, 2)`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — three M102 tests + section in `test_all`.

## Test plan

- [x] Full execution suite: **644/644 PASS**, no failures, no OOM
- [x] `test_chmod_set_readonly`: shell-create + chmod 0o444 + exists_file roundtrip ✓
- [x] `test_chmod_missing_file`: chmod on non-existent path correctly fails (`ENOENT`) ✓
- [x] `test_chmod_bad_args`: non-atom Path and non-Integer Mode both fail the type guards ✓

## Notes

The roundtrip test uses `shell('touch ...', _)` / `shell('rm -f ...', _)` for setup and cleanup rather than the natural `setup_call_cleanup` + `open/3` form. Initial test was the latter; it crashed with SIGSEGV inside the WAM run_loop. Isolated reproducer confirmed `chmod` itself works fine — the crash is in the `open/3` + `setup_call_cleanup` interaction in the WAM backend. Independent bug, out of scope for M102. Shell form still pins what M102 actually changes (the file mode flip).

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_