### PR TITLE
test(conformance): onboard C++ backend (conformant, no backend fixes)

### DIFF
--- a/docs/WAM_CROSS_TARGET_CONFORMANCE.md
+++ b/docs/WAM_CROSS_TARGET_CONFORMANCE.md
@@ -86,9 +86,9 @@ so any failure is reproducible from the recorded seed.
 ## Known divergences (tracked as `ct_xfail/2`)
 
 The harness is green today and **every registered backend — scala,
-elixir, wat, haskell, python, and go — passes the whole spec** (there are
-no live `ct_xfail/2` or `ct_skip/2` entries; both are declared `dynamic`
-so they may have zero clauses). The oracle is the hand-specified
+elixir, wat, haskell, python, go, rust, c, and c++ — passes the whole
+spec** (there are no live `ct_xfail/2` or `ct_skip/2` entries; both are
+declared `dynamic` so they may have zero clauses). The oracle is the hand-specified
 expected-results table in `wam_conformance_fixtures.pl` (standard Prolog
 semantics), not any backend's output; Scala was the original reference.
 A tolerated divergence would be logged via a new `ct_xfail/2`, with an
@@ -114,6 +114,10 @@ fixed.
 (Haskell is opt-in — `CONFORMANCE_TARGETS=haskell` — because each program is a cabal compile. `fib` and `ack` pass; the driver, `tests/fixtures/haskell_conformance_driver.hs`, runs a 0-arity wrapper whose atoms are baked into the compiled stream, which is what removed the earlier interning mismatch — see below.)
 
 (Go is opt-in too — `CONFORMANCE_TARGETS=go` — and now passes the whole spec. The driver is a small generated `main.go` that looks up the wrapper label in `SharedWamLabels` and runs `vm.Run()`.)
+
+(Rust and C are opt-in — `CONFORMANCE_TARGETS=rust` / `=c` — and pass the whole spec; both needed the same convention fixes the other native backends did (cons-cell aliasing, placeholder binding, integer `is/2`, and — for the indexing instructions a backend doesn't translate — degrading to a real no-op rather than dropping the instruction and shifting label PCs). See `WAM_BACKEND_CONVENTIONS.md`.)
+
+(C++ is opt-in — `CONFORMANCE_TARGETS=cpp` — and was **conformant on first onboarding**: the only WAM-runtime gaps the conventions warn about were already handled in `wam_cpp_target.pl`, so no backend fix was needed. `write_wam_cpp_project/3` with `emit_main(true)` generates the CLI driver itself (`cpp/main.cpp` runs `vm.query(key, args)` and exits 0/1), so the adapter just builds the three `.cpp` files with `g++` and reads the exit status.)
 
 `ct_xfail/2` = build and run, tolerate a wrong answer (and log `XPASS` if
 it unexpectedly matches). `ct_skip/2` = do not even build, because

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -61,6 +61,14 @@
               [write_wam_rust_project/3]).
 :- use_module('../src/unifyweaver/targets/wam_c_target',
               [write_wam_c_project/3]).
+% library(pairs) is loaded before wam_cpp_target so the latter's load-time
+% "lists_extra stdlib" directive (guarded by current_predicate(pairs_keys/2))
+% short-circuits: without pairs_keys present it would assertz user:intersection
+% etc., which clash with library(lists)' static predicates and raise a
+% permission error on load.
+:- use_module(library(pairs)).
+:- use_module('../src/unifyweaver/targets/wam_cpp_target',
+              [write_wam_cpp_project/3]).
 
 % ============================================================
 % Target registry + known-divergence (xfail) registry
@@ -74,6 +82,7 @@ conformance_target(python).
 conformance_target(go).
 conformance_target(rust).
 conformance_target(c).
+conformance_target(cpp).
 
 %% ct_default_target(Target): runs unless CONFORMANCE_TARGETS overrides.
 %  WAT and Haskell are wired up but NOT defaults: their backends still
@@ -277,6 +286,7 @@ ct_toolchain(python, [python3]).
 ct_toolchain(go,     [go]).
 ct_toolchain(rust,   [cargo]).
 ct_toolchain(c,      [gcc]).
+ct_toolchain(cpp,    ['g++']).
 
 ct_available(scala) :-
     ct_enabled(scala),
@@ -317,6 +327,7 @@ test(python, [condition(ct_available(python))]) :- run_target_conformance(python
 test(go,     [condition(ct_available(go))])     :- run_target_conformance(go).
 test(rust,   [condition(ct_available(rust))])   :- run_target_conformance(rust).
 test(c,      [condition(ct_available(c))])      :- run_target_conformance(c).
+test(cpp,    [condition(ct_available(cpp))])    :- run_target_conformance(cpp).
 
 :- end_tests(wam_cross_target_conformance).
 
@@ -894,6 +905,46 @@ ct_run(c, c_ctx(Dir, Map), K, A, Bool) :-
     ; throw(c_run_failed(KeyAtom, Status)) ).
 
 ct_teardown(c, c_ctx(Dir, Map)) :-
+    cleanup_dir(Dir), abolish_wrappers(Map).
+
+% ============================================================
+% Adapter: C++  (0-arity wrapper -> compiled binary, result via exit code)
+%
+% write_wam_cpp_project/3 with emit_main(true) materialises a self-contained
+% project under <Dir>/cpp/ (wam_runtime.{h,cpp}, generated_program.cpp, and
+% a main.cpp CLI shim). The shim runs vm.query(argv[1], parsed_args),
+% printing true/false and exiting 0/1 — so we need no hand-written driver.
+% We build the three .cpp files with g++ and exec via shell/2 (matching the
+% C adapter; process_create(path(tmpbin)) is unreliable under $TMPDIR).
+% Opt-in via CONFORMANCE_TARGETS=cpp.
+% ============================================================
+
+ct_build(cpp, Preds, Queries, cpp_ctx(Dir, Map)) :-
+    ct_tmp_dir('tmp_ct_cpp', Dir),
+    synth_wrappers(Queries, WPreds, Map),
+    maplist(strip_pred, Preds, BarePreds),
+    append(WPreds, BarePreds, AllPreds0),
+    maplist(qualify_user, AllPreds0, AllPreds),
+    write_wam_cpp_project(AllPreds, [emit_main(true)], Dir),
+    directory_file_path(Dir, cpp, CppDir),
+    run_proc('g++', ['-O1', '-std=c++17', '-o', 'runner',
+                     'wam_runtime.cpp', 'generated_program.cpp', 'main.cpp'],
+             CppDir, BExit, BErr),
+    ( BExit =:= 0 -> true ; throw(cpp_build_failed(BExit, BErr)) ).
+
+ct_run(cpp, cpp_ctx(Dir, Map), K, A, Bool) :-
+    memberchk((K-A)-WName, Map),
+    format(atom(KeyAtom), '~w/0', [WName]),
+    absolute_file_name(Dir, AbsDir),
+    directory_file_path(AbsDir, 'cpp/runner', Exe),
+    % Result carried by the process exit status: 0 = true, 1 = false.
+    format(atom(Cmd), 'timeout 30 ~w ~w', [Exe, KeyAtom]),
+    shell(Cmd, Status),
+    ( Status =:= 0 -> Bool = true
+    ; Status =:= 1 -> Bool = false
+    ; throw(cpp_run_failed(KeyAtom, Status)) ).
+
+ct_teardown(cpp, cpp_ctx(Dir, Map)) :-
     cleanup_dir(Dir), abolish_wrappers(Map).
 
 %% c_copy_runtime_header(+Dir) — copy the static wam_runtime.h into Dir.


### PR DESCRIPTION
## Summary

Onboards the **C++ backend** to the WAM cross-target conformance harness. `CONFORMANCE_TARGETS=cpp` is **green with zero xfails** — member, append, reverse, fib, ack, builtins all pass.

**No backend fix was needed.** C++ is the most mature of the native backends onboarded this session — every WAM gap the conventions doc warns about (cons-cell aliasing, placeholder binding, integer `is/2`, the `//`-in-functor split, and unhandled indexing instructions) was already handled in `wam_cpp_target.pl`. This is purely adapter work.

## Adapter
- `write_wam_cpp_project/3` with **`emit_main(true)`** materialises a self-contained `<Dir>/cpp/` project (`wam_runtime.{h,cpp}`, `generated_program.cpp`, `main.cpp`). The generated `main.cpp` **is** the driver — it runs `vm.query(argv[1], parsed_args)`, prints true/false and exits 0/1 — so unlike C/Rust, no hand-written driver is needed.
- Build the three `.cpp` files with `g++ -std=c++17`; exec via `shell/2` and read the exit status (matching the C adapter — `process_create(path(tmpbin))` is unreliable under `$TMPDIR`).
- **`library(pairs)` is preloaded** before importing `wam_cpp_target`: its load-time "lists_extra stdlib" directive is guarded by `current_predicate(pairs_keys/2)`; without that it `assertz`es `user:intersection` etc., clashing with `library(lists)`' static predicates (a permission error on load). Preloading `pairs` makes the guard short-circuit, keeping the harness load clean.

## Docs
`WAM_CROSS_TARGET_CONFORMANCE.md` status line now lists **rust, c, and c++** alongside the others (the rust/c PRs hadn't updated it), with opt-in notes for each.

## Verification
- Full `CONFORMANCE_TARGETS=cpp` harness run: **green, 0 xfails**, clean load (no permission error).
- `wam_cpp_target.pl` unchanged — no backend modifications.

## Backends now conformant
scala, elixir, python, go, rust, c, **c++** — **seven** WAM backends pass the shared spec (wat/haskell remain opt-in with their own notes).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_