### PR TITLE
Feat/wam go append coverage

### DIFF
--- a/PR_go_wam_append_coverage.md
+++ b/PR_go_wam_append_coverage.md
@@ -1,0 +1,20 @@
+Title: Cover Go WAM append builtin
+
+Description:
+
+## Summary
+
+- register `append/3` in the Go WAM direct-builtin table
+- add generated Go WAM E2E coverage for bounded deterministic `append/3`
+- cover proper-list concatenation, empty-left and empty-right behavior, bound-output success, mismatch failure, malformed-list failure, and unsupported unbound input modes
+- update the Go WAM parity audit for the covered structural builtin surface
+
+## Verification
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+- `git diff --check`

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -55,6 +55,10 @@ current cross-target builtin/runtime baseline.
 - Deterministic `delete/3` is now covered by the generated Go WAM builtin E2E
   test for removing one, none, or all matching atom elements and malformed-list
   failure, matching the Clojure/C++ structural-list surface for proper lists.
+- Bounded deterministic `append/3` is now covered by the generated Go WAM
+  builtin E2E test for concatenating proper lists, empty-left and empty-right
+  behavior, bound-output success and mismatch failure, malformed-list failure,
+  and unsupported unbound input modes, matching the current Go runtime surface.
 - Deterministic `subtract/3` is now covered by the generated Go WAM builtin
   E2E test for filtering all right-list matches from the left list, preserving
   left-list order, empty-list behavior, all-removed results, duplicate removal,

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -457,6 +457,9 @@ wam_go_direct_builtin("intersection/3", 3, 'intersection/3').
 wam_go_direct_builtin(union/3, 3, 'union/3').
 wam_go_direct_builtin('union/3', 3, 'union/3').
 wam_go_direct_builtin("union/3", 3, 'union/3').
+wam_go_direct_builtin(append/3, 3, 'append/3').
+wam_go_direct_builtin('append/3', 3, 'append/3').
+wam_go_direct_builtin("append/3", 3, 'append/3').
 wam_go_direct_builtin(permutation/2, 2, 'permutation/2').
 wam_go_direct_builtin('permutation/2', 2, 'permutation/2').
 wam_go_direct_builtin("permutation/2", 2, 'permutation/2').

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -12,6 +12,7 @@
 :- dynamic user:test_memberchk_builtin/0.
 :- dynamic user:test_select_builtin/0.
 :- dynamic user:test_delete_builtin/0.
+:- dynamic user:test_append_builtin/0.
 :- dynamic user:test_subtract_builtin/0.
 :- dynamic user:test_intersection_builtin/0.
 :- dynamic user:test_union_builtin/0.
@@ -190,6 +191,22 @@ test(builtins_execution) :-
                 delete([a,a,a], a, Empty),
                 Empty = [],
                 \+ delete([a|b], a, _)
+            )),
+          assertz(user:test_append_builtin :-
+            (   append([a,b], [c,d], R),
+                R = [a,b,c,d],
+                append([], [z], EmptyLeft),
+                EmptyLeft = [z],
+                append([x], [], EmptyRight),
+                EmptyRight = [x],
+                append([1,2], [3], [1,2,3]),
+                append([a], [b], Bound),
+                Bound = [a,b],
+                \+ append([a], [b], [a,c]),
+                \+ append([a|b], [c], _),
+                \+ append([a], [b|c], _),
+                \+ append(_, [b], _),
+                \+ append([a], _, _)
             )),
           assertz(user:test_subtract_builtin :-
             (   subtract([a,b,c,b], [b,d], R),
@@ -689,6 +706,7 @@ test(builtins_execution) :-
           retractall(user:test_memberchk_builtin),
           retractall(user:test_select_builtin),
           retractall(user:test_delete_builtin),
+          retractall(user:test_append_builtin),
           retractall(user:test_subtract_builtin),
           retractall(user:test_intersection_builtin),
           retractall(user:test_union_builtin),
@@ -730,7 +748,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_arithmetic_expr_builtin/0, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_tab_builtin/0, test_env_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_arithmetic_expr_builtin/0, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_append_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_tab_builtin/0, test_env_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -765,6 +783,7 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "memberchk/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "select/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "delete/3"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "append/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "subtract/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "intersection/3"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "union/3"')),
@@ -886,6 +905,14 @@ func main() {
 		fmt.Println("DELETE_SUCCESS")
 	} else {
 		fmt.Println("DELETE_FAILURE")
+	}
+
+	appendVM := wam.NewWamState(wam.Test_append_builtinCode, wam.Test_append_builtinLabels)
+	appendVM.PC = wam.Test_append_builtinStartPC
+	if appendVM.Run() {
+		fmt.Println("APPEND_SUCCESS")
+	} else {
+		fmt.Println("APPEND_FAILURE")
 	}
 
 	subtractVM := wam.NewWamState(wam.Test_subtract_builtinCode, wam.Test_subtract_builtinLabels)
@@ -1200,6 +1227,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "MEMBERCHK_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SELECT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "DELETE_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "APPEND_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SUBTRACT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "INTERSECTION_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNION_SUCCESS")),


### PR DESCRIPTION
# Cover Go WAM append builtin

## Summary

- register `append/3` in the Go WAM direct-builtin table
- add generated Go WAM E2E coverage for bounded deterministic `append/3`
- cover proper-list concatenation, empty-left and empty-right behavior, bound-output success, mismatch failure, malformed-list failure, and unsupported unbound input modes
- update the Go WAM parity audit for the covered structural builtin surface

## Verification

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
- `git diff --check`
