### PR TITLE
LLVM WAM: wam_unify_value + builtin_unify Ref-to-Ref aliasing (M104)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -5589,8 +5589,19 @@ builtin_unify:
   br i1 %uf.a1_unb, label %uf.bind_a1, label %uf.check_a2
 
 uf.bind_a1:
+  ; M104: if a2 is also unbound after deref, the underlying register
+  ; holds a Ref to a heap cell with Unbound. Bind a1 to that raw Ref
+  ; (so the two vars alias) rather than to the Unbound sentinel.
+  ; When a2 is bound (not Unbound), uf.a2 IS the bound value and we
+  ; bind a1 to it directly.
+  %uf.a2_raw = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %uf.a2_raw_tag = extractvalue %Value %uf.a2_raw, 0
+  %uf.a2_raw_isref = icmp eq i32 %uf.a2_raw_tag, 5
+  %uf.a2_d_unb = call i1 @value_is_unbound(%Value %uf.a2)
+  %uf.bind1_alias = and i1 %uf.a2_raw_isref, %uf.a2_d_unb
+  %uf.bind1_val = select i1 %uf.bind1_alias, %Value %uf.a2_raw, %Value %uf.a2
   call void @wam_trail_binding(%WamState* %vm, i32 0)
-  call void @wam_bind_reg(%WamState* %vm, i32 0, %Value %uf.a2)
+  call void @wam_bind_reg(%WamState* %vm, i32 0, %Value %uf.bind1_val)
   ret i1 true
 
 uf.check_a2:
@@ -5598,8 +5609,15 @@ uf.check_a2:
   br i1 %uf.a2_unb, label %uf.bind_a2, label %uf.both_bound
 
 uf.bind_a2:
+  ; M104: symmetric to bind_a1.
+  %uf.a1_raw = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %uf.a1_raw_tag = extractvalue %Value %uf.a1_raw, 0
+  %uf.a1_raw_isref = icmp eq i32 %uf.a1_raw_tag, 5
+  %uf.a1_d_unb = call i1 @value_is_unbound(%Value %uf.a1)
+  %uf.bind2_alias = and i1 %uf.a1_raw_isref, %uf.a1_d_unb
+  %uf.bind2_val = select i1 %uf.bind2_alias, %Value %uf.a1_raw, %Value %uf.a1
   call void @wam_trail_binding(%WamState* %vm, i32 1)
-  call void @wam_bind_reg(%WamState* %vm, i32 1, %Value %uf.a1)
+  call void @wam_bind_reg(%WamState* %vm, i32 1, %Value %uf.bind2_val)
   ret i1 true
 
 uf.both_bound:

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -668,7 +668,18 @@ bind_a_through:
   %a_addr = trunc i64 %a_addr_i64 to i32
   %a_old = call %Value @wam_heap_get(%WamState* %vm, i32 %a_addr)
   call void @wam_trail_heap_binding(%WamState* %vm, i32 %a_addr, %Value %a_old)
-  call void @wam_heap_set(%WamState* %vm, i32 %a_addr, %Value %db)
+  ; M104: if b is also a Ref to an unbound heap cell, store the
+  ; ORIGINAL b (the Ref) into a's cell rather than the deref'd
+  ; Unbound sentinel. That way a now points at b's cell, and
+  ; subsequent var(a) / var(b) / a == b / etc. all see them as
+  ; the same variable. Previously bind_a_through stored db (=
+  ; Unbound) which left a and b as two distinct unbound cells.
+  %ba_b_tag = extractvalue %Value %b, 0
+  %ba_b_is_ref = icmp eq i32 %ba_b_tag, 5
+  %ba_db_unb = call i1 @value_is_unbound(%Value %db)
+  %ba_alias = and i1 %ba_b_is_ref, %ba_db_unb
+  %ba_to_write = select i1 %ba_alias, %Value %b, %Value %db
+  call void @wam_heap_set(%WamState* %vm, i32 %a_addr, %Value %ba_to_write)
   ret i1 true
 
 check_b_unb:
@@ -685,7 +696,14 @@ bind_b_through:
   %b_addr = trunc i64 %b_addr_i64 to i32
   %b_old = call %Value @wam_heap_get(%WamState* %vm, i32 %b_addr)
   call void @wam_trail_heap_binding(%WamState* %vm, i32 %b_addr, %Value %b_old)
-  call void @wam_heap_set(%WamState* %vm, i32 %b_addr, %Value %da)
+  ; M104: symmetric to bind_a_through -- if a is also an unbound
+  ; Ref, store the original a so they alias.
+  %bb_a_tag = extractvalue %Value %a, 0
+  %bb_a_is_ref = icmp eq i32 %bb_a_tag, 5
+  %bb_da_unb = call i1 @value_is_unbound(%Value %da)
+  %bb_alias = and i1 %bb_a_is_ref, %bb_da_unb
+  %bb_to_write = select i1 %bb_alias, %Value %a, %Value %da
+  call void @wam_heap_set(%WamState* %vm, i32 %b_addr, %Value %bb_to_write)
   ret i1 true
 
 both_bound:

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,30 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M104: wam_unify_value bind path now aliases two unbound vars
+% via Ref-to-Ref instead of writing the Unbound sentinel. So after
+% X = Y, var(X) and var(Y) both still hold but X == Y is now true.
+
+:- dynamic test_unify_aliases_vars/2.
+test_unify_aliases_vars(_, R) :-
+    X = Y,
+    ( X == Y -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_unify_then_bind_propagates/2.
+test_unify_then_bind_propagates(_, R) :-
+    % After X = Y, binding one should propagate to the other.
+    X = Y,
+    X = 42,
+    ( Y =:= 42 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_term_vars_identity/2.
+test_term_vars_identity(_, R) :-
+    % The natural M103 test that used to fail: term_variables
+    % returns the list of variables, and via the M104 aliasing
+    % fix the V we get back == X.
+    term_variables(foo(X, 2), [V | _]),
+    ( V == X -> R is 1 ; R is 0 ).   % 1
+
 % M103: term_variables/2 -- depth-first left-to-right collection of
 % unbound vars from a term. No dedup -- repeated occurrences of the
 % same var appear once per occurrence (SWI dedupes; documented
@@ -5097,6 +5121,13 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M104 wam_unify_value Ref-to-Ref aliasing ---~n'),
+       run_test_r0('X = Y, X == Y -> 1',
+                   test_unify_aliases_vars, 0, 1),
+       run_test_r0('X = Y, X = 42, Y =:= 42 -> 1',
+                   test_unify_then_bind_propagates, 0, 1),
+       run_test_r0('term_variables(foo(X,_), [V|_]), V == X -> 1',
+                   test_term_vars_identity, 0, 1),
        format('--- M103 term_variables/2 ---~n'),
        run_test_r0('ground term -> [] -> 1',
                    test_tv_ground, 0, 1),


### PR DESCRIPTION
## Summary

Fixes the var-to-var unification aliasing bug noted in M103. After `X = Y` (where both are unbound vars), `X == Y` now correctly returns true, and subsequent bindings propagate from one to the other.

## The bug

Two separate bind paths both had the same bug:

- `wam_unify_value`'s `bind_a_through` (the recursive-unify helper used for compound element-by-element walks)
- `builtin_unify`'s `uf.bind_a1` / `uf.bind_a2` (the dispatch for `=/2`)

When binding an unbound `a` to an unbound `b`, both wrote the **deref'd** `Unbound` sentinel into `a`'s heap cell instead of recording a Ref pointing at `b`'s cell. So `a` and `b` stayed at distinct heap cells with identical `Unbound` contents — structurally equal via `value_equals` payload comparison, but **not the same variable**. Subsequent bindings to one didn't propagate to the other:

```prolog
X = Y, X = 42, Y =:= 42.   % failed -- only X bound, Y still unbound
```

M103's natural `V == X` test had the same shape: `term_variables` stored the correct Ref in the cons-cell head, but the subsequent `[V|T] = Vs` unification at the call site lost the aliasing.

## The fix

Both bind paths now check whether the **raw** value (pre-deref) is a Ref AND the deref'd value is `Unbound`. If so, write the raw Ref so the two vars alias to the same heap cell. Otherwise write the deref'd value (which is what we want when the other side is actually bound to a non-var term).

- `templates/targets/llvm_wam/state.ll.mustache` — `wam_unify_value`'s `bind_a_through` and `bind_b_through`.
- `src/unifyweaver/targets/wam_llvm_target.pl` — `builtin_unify`'s `uf.bind_a1` and `uf.bind_a2`.

`builtin_unify` is the one that gets reached by source-level `X = Y`, so the LLVM-target patch is the one that actually makes the user-facing test pass. The state.ll patch covers all deep-unify call sites (compound recursion, `get_value`, etc.).

## Files

- `templates/targets/llvm_wam/state.ll.mustache` — `wam_unify_value` bind paths.
- `src/unifyweaver/targets/wam_llvm_target.pl` — `builtin_unify` bind paths.
- `tests/core/test_wam_llvm_builtin_execution.pl` — three M104 tests + section.

## Test plan

- [x] Full execution suite: **651/651 PASS**, no failures, no OOM
- [x] `test_unify_aliases_vars`: `X = Y, X == Y` ✓
- [x] `test_unify_then_bind_propagates`: `X = Y, X = 42, Y =:= 42` ✓
- [x] `test_term_vars_identity`: M103's natural test `term_variables(foo(X, _), [V|_]), V == X` now works ✓
- [x] All other 648 existing tests continue to pass — no regression from changing a core unification primitive.

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_