### PR TITLE
feat(scala): lower if-then-else / negation / once in the hybrid WAM lowered emitter

### DIFF
--- a/src/unifyweaver/targets/wam_scala_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_scala_lowered_emitter.pl
@@ -143,6 +143,120 @@ strip_arity_suffix_scala(Pred, Name) :-
     ).
 
 % =====================================================================
+% If-then-else structuring (cut_ite / negation / once)
+% =====================================================================
+%
+%  The compiler lowers (C -> T ; E), \+G and once/1 to a deterministic
+%  choice-point pair around a soft cut:
+%
+%      try_me_else L_else
+%      <cond>                 % C
+%      cut_ite | !/0          % commit point (-> uses cut_ite, \+ uses !/0)
+%      <then>                 % T
+%      jump L_cont
+%    L_else: trust_me
+%      <else>                 % E
+%    L_cont: <continuation>
+%
+%  The base parser strips labels and drops cut_ite, which loses this
+%  structure. parse_wam_text_labeled_scala keeps both so we can fold each
+%  block into an ite(Cond,Then,Else) term and emit native Scala if/else.
+%  Sound by construction: the condition runs in its own boolean helper
+%  with trail save/restore, so a failed cond undoes its bindings before the
+%  else branch, and a then/else failure returns false from the lowered
+%  function (the entry-wrapper interpreter fallback then re-runs the whole
+%  predicate). It can never produce a wrong success.
+
+parse_wam_text_labeled_scala(WamText, Instrs) :-
+    atom_string(WamText, S),
+    split_string(S, "\n", "", Lines),
+    parse_lines_labeled_scala(Lines, Instrs).
+
+parse_lines_labeled_scala([], []).
+parse_lines_labeled_scala([Line|Rest], Instrs) :-
+    split_string(Line, " \t,", " \t,", Parts0),
+    delete(Parts0, "", Parts),
+    (   Parts == []
+    ->  parse_lines_labeled_scala(Rest, Instrs)
+    ;   Parts = [First|_],
+        sub_string(First, _, 1, 0, ":")
+    ->  sub_string(First, 0, _, 1, LabelStr),
+        Instrs = [label(LabelStr)|More],   % keep as string to match try_me_else/jump args
+        parse_lines_labeled_scala(Rest, More)
+    ;   Parts == ["cut_ite"]
+    ->  Instrs = [cut_ite|More],
+        parse_lines_labeled_scala(Rest, More)
+    ;   instr_from_parts_scala(Parts, Instr)
+    ->  Instrs = [Instr|More],
+        parse_lines_labeled_scala(Rest, More)
+    ;   parse_lines_labeled_scala(Rest, Instrs)   % unrecognised — skip
+    ).
+
+%% structure_ite_scala(+Flat, -Structured) is semidet.
+%  Folds every well-formed ITE block into ite(Cond,Then,Else); drops the
+%  structural markers (try_me_else/trust_me/cut_ite/jump/label). Fails if a
+%  try_me_else cannot be matched to a clean block (caller then declines to
+%  lower, falling back to the interpreter).
+structure_ite_scala([], []).
+structure_ite_scala([try_me_else(LE)|Rest0], [ite(CondS,ThenS,ElseS)|Out]) :-
+    !,
+    append(ThenWithJump, [label(LE), trust_me | ElseAndRest], Rest0),
+    \+ member(label(LE), ThenWithJump),          % first (matching) else label
+    append(ThenPath, [jump(LC)], ThenWithJump),  % then-path ends in its jump
+    append(ElsePath, [label(LC) | AfterCont], ElseAndRest),
+    \+ member(label(LC), ElsePath),
+    split_commit_scala(ThenPath, Cond, Then),
+    structure_ite_scala(Cond, CondS),
+    structure_ite_scala(Then, ThenS),
+    structure_ite_scala(ElsePath, ElseS),
+    structure_ite_scala(AfterCont, Out).
+structure_ite_scala([label(_)|Rest], Out) :- !,
+    structure_ite_scala(Rest, Out).
+structure_ite_scala([I|Rest], [I|Out]) :-
+    structure_ite_scala(Rest, Out).
+
+%% split_commit_scala(+ThenPath, -Cond, -Then)
+%  Splits a then-path at its commit instruction (cut_ite for ->, the !/0
+%  builtin for \+). The commit itself is dropped.
+split_commit_scala(Path, Cond, Then) :-
+    append(Cond, [Commit|Then], Path),
+    is_commit_scala(Commit),
+    \+ ( member(C0, Cond), is_commit_scala(C0) ),   % split at the first commit
+    !.
+
+is_commit_scala(cut_ite).
+is_commit_scala(builtin_call("!/0", _)).
+is_commit_scala(builtin_call('!/0', _)).
+
+%% structured_supported_scala(+StructuredInstrs)
+%  All leaf instructions supported, and every ite() fully structured.
+structured_supported_scala(Instrs) :-
+    forall(member(I, Instrs), structured_supported_one_scala(I)).
+
+structured_supported_one_scala(ite(C, T, E)) :- !,
+    structured_supported_scala(C),
+    structured_supported_scala(T),
+    structured_supported_scala(E).
+structured_supported_one_scala(I) :- scala_supported(I).
+
+%% has_ite_block_scala(+Clause1Instrs)
+%  True when the (base-parsed) clause-1 contains an inner ITE choice point.
+has_ite_block_scala(Instrs) :- member(try_me_else(_), Instrs).
+
+%% structured_clause1_scala(+WamCode, -StructuredClause1) is semidet.
+%  Re-parse keeping labels/cut_ite, take clause 1, fold ITE blocks. Only
+%  attempted for single-clause predicates (MultiClause=false) so an inner
+%  ITE try_me_else is never confused with a predicate-level clause chain.
+structured_clause1_scala(WamCode, Structured) :-
+    parse_wam_text_labeled_scala(WamCode, LInstrs),
+    \+ ( LInstrs = [try_me_else(_)|_] ),   % not predicate-level multi-clause
+    take_to_proceed_scala(LInstrs, C1L),
+    structure_ite_scala(C1L, Structured),
+    \+ member(try_me_else(_), Structured),  % every block consumed
+    \+ member(trust_me, Structured),
+    \+ member(retry_me_else(_), Structured).
+
+% =====================================================================
 % Lowerability analysis
 % =====================================================================
 
@@ -155,9 +269,18 @@ strip_arity_suffix_scala(Pred, Name) :-
 wam_scala_lowerable(_PI, WamCode, Reason) :-
     parse_wam_text_scala(WamCode, Instrs),
     clause1_instrs_scala(Instrs, C1, MultiClause),
-    is_deterministic_pred_scala(C1),
-    forall(member(I, C1), scala_supported(I)),
-    ( MultiClause == true -> Reason = multi_clause_1 ; Reason = single_clause ).
+    (   is_deterministic_pred_scala(C1),
+        forall(member(I, C1), scala_supported(I))
+    ->  ( MultiClause == true -> Reason = multi_clause_1 ; Reason = single_clause )
+    ;   % Clause-1 has an inner choice point. Lower it only if that point is
+        % a pure (C -> T ; E) / \+ / once block whose pieces are all
+        % supported; otherwise decline (interpreter fallback).
+        MultiClause == false,
+        has_ite_block_scala(C1),
+        structured_clause1_scala(WamCode, Structured),
+        structured_supported_scala(Structured),
+        Reason = ite_lowered
+    ).
 
 %% clause1_instrs_scala(+Instrs, -Clause1, -MultiClause)
 %  Extracts clause 1.  MultiClause is `true` when the predicate opens
@@ -269,8 +392,15 @@ lower_predicate_to_scala(PI, WamCode, Options, lowered(PredName, FuncName, Code)
     ->  maplist(foreign_key_atom, FK0, ForeignKeys)
     ;   ForeignKeys = []
     ),
+    % Emit from the plain clause-1 when it is already fully supported;
+    % otherwise fold its inner ITE block(s) into structured form first.
+    (   is_deterministic_pred_scala(C1),
+        forall(member(I, C1), scala_supported(I))
+    ->  EmitBody = C1
+    ;   structured_clause1_scala(WamCode, EmitBody)
+    ),
     with_output_to(string(Code),
-        emit_function_scala(FuncName, C1, MultiClause, ForeignKeys)).
+        emit_function_scala(FuncName, EmitBody, MultiClause, ForeignKeys)).
 
 foreign_key_atom(K, A) :- ( atom(K) -> A = K ; atom_string(A, K) ).
 
@@ -292,6 +422,7 @@ foreign_key_atom(K, A) :- ( atom(K) -> A = K ; atom_string(A, K) ).
 %  the emission — the entry-wrapper fallback subsumes the old replay/CP
 %  juggling and is correct regardless of the predicate's indexing prefix.
 emit_function_scala(FuncName, C1, _MultiClause, FK) :-
+    nb_setval(scala_ite_ctr, 0),
     format("  /** ~w — clause-1 fast path (generated); entry wrapper handles fallback. */~n", [FuncName]),
     format("  def ~w(s: WamState, program: WamProgram): Boolean = {~n", [FuncName]),
     emit_body_scala(C1, "    ", FK),
@@ -322,6 +453,26 @@ emit_one_scala(proceed, I, _) :-
     format("~w// proceed (clause complete)~n", [I]).
 emit_one_scala(fail, I, _) :-
     format("~wreturn false~n", [I]).
+
+% --- If-then-else (structured; see structure_ite_scala) ---
+% The condition runs in its own boolean helper with a trail mark, so a
+% failed condition undoes its bindings before the else branch. `return
+% false` inside the helper means "condition failed"; inside then/else it
+% returns from the lowered function (clause fails -> interpreter fallback).
+emit_one_scala(ite(Cond, Then, Else), I, FK) :-
+    nb_getval(scala_ite_ctr, N0), N is N0 + 1, nb_setval(scala_ite_ctr, N),
+    string_concat(I, "  ", I2),
+    format("~wval _iteMark~w = s.trail.length~n", [I, N]),
+    format("~wdef _iteCond~w(): Boolean = {~n", [I, N]),
+    emit_body_scala(Cond, I2, FK),
+    format("~w  true~n", [I]),
+    format("~w}~n", [I]),
+    format("~wif (_iteCond~w()) {~n", [I, N]),
+    emit_body_scala(Then, I2, FK),
+    format("~w} else {~n", [I]),
+    format("~w  WamRuntime.unwindTrail(s, _iteMark~w)~n", [I, N]),
+    emit_body_scala(Else, I2, FK),
+    format("~w}~n", [I]).
 
 % --- Head unification (get_*) ---
 emit_one_scala(get_constant(CStr, AiStr), I, _) :-

--- a/tests/test_wam_scala_lowered_emitter.pl
+++ b/tests/test_wam_scala_lowered_emitter.pl
@@ -43,6 +43,27 @@ user:lp_edge(a, b).
 user:lp_edge(b, c).
 user:lp_edge(c, d).
 
+% --- If-then-else / negation lowering fixtures (cut_ite, jump) -----------
+:- dynamic user:lp_ite/2.
+:- dynamic user:lp_neg/1.
+:- dynamic user:lp_seqite/3.
+:- dynamic user:lp_nestite/2.
+:- dynamic user:lp_undoite/2.
+% Arithmetic-guard if-then-else.
+user:lp_ite(X, Y) :- ( X > 0 -> Y = pos ; Y = nonpos ).
+% Negation (compiles to (G -> fail ; true)).
+user:lp_neg(X) :- \+ X > 0.
+% Two sequential if-then-else blocks in one clause.
+user:lp_seqite(X, Y, Z) :- ( X > 0 -> Y = pos ; Y = nonpos ),
+                           ( X > 5 -> Z = big ; Z = small ).
+% Nested if-then-else (then-branch is itself an ITE).
+user:lp_nestite(X, Y) :- ( X > 0 -> ( X > 10 -> Y = big ; Y = small ) ; Y = neg ).
+% Binding condition that binds a fresh Y then fails — exercises trail
+% save/undo: (Y=a, Y=b) binds Y=a then fails, so Y must be undone before
+% `X = Y`. If the undo is skipped, Y stays bound to `a` and lp_undoite(c,_)
+% wrongly fails (c = a).
+user:lp_undoite(X, R) :- ( (Y = a, Y = b) -> R = then ; R = els ), X = Y.
+
 % append/3 — list recursion (get_list / unify_* read+write modes).
 user:lp_append([], L, L).
 user:lp_append([H|T], L, [H|R]) :- lp_append(T, L, R).
@@ -221,6 +242,53 @@ test(member_parity,
     assert_same_and(Run, 'lp_member/2', [a, '[a,b,c]'], "true"),
     assert_same_and(Run, 'lp_member/2', [c, '[a,b,c]'], "true"),
     assert_same_and(Run, 'lp_member/2', [z, '[a,b,c]'], "false").
+
+% lp_ite/2 — arithmetic-guard if-then-else. In functions mode the clause is
+% lowered to a native Scala if/else (structure_ite_scala); in interpreter
+% mode it runs the try_me_else/cut_ite block. Results must match and be
+% correct, both branches.
+test(ite_parity,
+     [setup(with_both_modes([user:lp_ite/2], 'gen.ite', Run)),
+      cleanup(cleanup_run(Run))]) :-
+    assert_same_and(Run, 'lp_ite/2', ['5','pos'],     "true"),
+    assert_same_and(Run, 'lp_ite/2', ['5','nonpos'],  "false"),
+    assert_same_and(Run, 'lp_ite/2', ['-1','nonpos'], "true"),
+    assert_same_and(Run, 'lp_ite/2', ['-1','pos'],    "false").
+
+% lp_neg/1 — negation as (G -> fail ; true).
+test(neg_parity,
+     [setup(with_both_modes([user:lp_neg/1], 'gen.neg', Run)),
+      cleanup(cleanup_run(Run))]) :-
+    assert_same_and(Run, 'lp_neg/1', ['5'],  "false"),
+    assert_same_and(Run, 'lp_neg/1', ['-1'], "true"),
+    assert_same_and(Run, 'lp_neg/1', ['0'],  "true").
+
+% lp_seqite/3 — two sequential ITE blocks.
+test(seqite_parity,
+     [setup(with_both_modes([user:lp_seqite/3], 'gen.seqite', Run)),
+      cleanup(cleanup_run(Run))]) :-
+    assert_same_and(Run, 'lp_seqite/3', ['10','pos','big'],     "true"),
+    assert_same_and(Run, 'lp_seqite/3', ['3','pos','small'],    "true"),
+    assert_same_and(Run, 'lp_seqite/3', ['-1','nonpos','small'],"true"),
+    assert_same_and(Run, 'lp_seqite/3', ['10','pos','small'],   "false").
+
+% lp_nestite/2 — nested ITE in the then-branch.
+test(nestite_parity,
+     [setup(with_both_modes([user:lp_nestite/2], 'gen.nestite', Run)),
+      cleanup(cleanup_run(Run))]) :-
+    assert_same_and(Run, 'lp_nestite/2', ['20','big'],   "true"),
+    assert_same_and(Run, 'lp_nestite/2', ['5','small'],  "true"),
+    assert_same_and(Run, 'lp_nestite/2', ['-1','neg'],   "true"),
+    assert_same_and(Run, 'lp_nestite/2', ['20','small'], "false").
+
+% lp_undoite/2 — binding condition that fails; the trail must be undone so
+% the post-ITE `X = c` sees X unbound. If the lowered path skipped the undo,
+% X would still be bound to `a` and the query would wrongly return false.
+test(undoite_parity,
+     [setup(with_both_modes([user:lp_undoite/2], 'gen.undoite', Run)),
+      cleanup(cleanup_run(Run))]) :-
+    assert_same_and(Run, 'lp_undoite/2', ['c','els'],  "true"),
+    assert_same_and(Run, 'lp_undoite/2', ['c','then'], "false").
 
 :- end_tests(wam_scala_lowered_runtime).
 


### PR DESCRIPTION
## Summary

Teaches the Scala hybrid WAM's **lowered emitter** to natively lower **if-then-else / negation / `once`** — the `(C -> T ; E)` family — instead of falling back to the WAM interpreter. This closes a real parity gap and, in fact, puts Scala **ahead** of the other hybrid backends.

### Background (and a correction to the gap analysis)
An initial automated gap analysis flagged "missing `cut_ite`/`jump` support" in the Scala lowered emitter. On verification, that framing was misleading:
- `cut_ite`/`jump` are emitted **only** inside the `try_me_else`/`trust_me` if-then-else pattern, which the determinism gate rejects in **both** Scala and Rust/Go.
- Rust/Go list `cut_ite`/`jump` as "supported" but their `emit_one` is a **no-op** — they never actually lower if-then-else either.

So "bare support" would have been cosmetic. The real, functional enhancement is **structured ITE lowering**, which this PR implements.

### How
- `parse_wam_text_labeled_scala` keeps labels and `cut_ite` (the base parser drops both), and `structure_ite_scala` folds each `try_me_else / <cond> / commit / <then> / jump / trust_me / <else>` block into an `ite(Cond,Then,Else)` term. The commit is `cut_ite` (for `->`) or the `!/0` builtin (for `\+`). Handles **sequential** and **nested** blocks; **declines** (interpreter fallback) when the condition is nondeterministic (e.g. `once(member(...))`).
- `emit_one_scala(ite(...))` emits the condition in a local `def _iteCondN(): Boolean` (its `return false` = "condition failed"), takes a trail mark, then:
  ```scala
  val _iteMarkN = s.trail.length
  def _iteCondN(): Boolean = { <cond>; true }
  if (_iteCondN()) { <then> } else { WamRuntime.unwindTrail(s, _iteMarkN); <else> }
  ```

### Soundness
Sound by construction: a failed condition undoes its bindings (trail) before the else branch; a then/else failure returns from the lowered function so the entry-wrapper interpreter fallback re-runs the whole predicate. The lowered path can only return a genuine success or defer — **never a wrong answer**. The new path is isolated: predicates without an inner `try_me_else` use the existing single-clause lowering unchanged.

### Verification
New interpreter-vs-lowered **parity** tests (both modes must match *and* be correct):
- arithmetic-guard ITE, negation, **sequential** ITEs, **nested** ITE, and a **binding condition that fails** — the last asserts the trail is undone (a missing undo would flip the result).

All green: scala lowered-emitter suite (now 9 runtime + 14 structural), scala generator (18), classic programs (7), and `CONFORMANCE_TARGETS=scala`.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_