### PR TITLE
Feat/wam go output polish

### DIFF
--- a/PR_go_wam_output_polish.md
+++ b/PR_go_wam_output_polish.md
@@ -1,0 +1,23 @@
+# PR Title
+
+Add Go WAM print and writeln builtins
+
+# PR Description
+
+## Summary
+
+- Register `print/1` and `writeln/1` as direct Go WAM builtins.
+- Implement Go WAM runtime handling for `print/1` as a `write/1` alias and `writeln/1` as term output plus newline.
+- Add generated Go WAM E2E coverage for `write/1`, `print/1`, `writeln/1`, and `nl/0`.
+- Update the Go WAM parity audit to record the closed simple-output gap against richer sibling targets.
+
+## Validation
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+
+Existing non-fatal choicepoint warnings still appear in the same Go WAM tests.

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -21,7 +21,7 @@ current cross-target builtin/runtime baseline.
 | Univ | `=../2` compose/decompose | `=../2` compose/decompose | Present |
 | Copying | `copy_term/2` with fresh variables and preserved sharing | `copy_term/2` with fresh variables and preserved sharing | Present |
 | Control | `true/0`, `fail/0`, `!/0`, `\+/1`, `CutIte` | Same baseline, with broader isolated-goal NAF in Haskell/Python | Present for current baseline, including isolated user-goal NAF and race-to-true over multi-clause WAM targets |
-| IO | `write/1`, `display/1`, `nl/0`, `tab/1`, `getenv/2`, `setenv/2` | `write/1`, `display/1`, `nl/0`; R/C++ also cover `tab/1`; LLVM covers `getenv/2` and `setenv/2` | Present for current baseline plus tab output and bounded environment access |
+| IO | `write/1`, `display/1`, `writeln/1`, `print/1`, `nl/0`, `tab/1`, `getenv/2`, `setenv/2` | `write/1`, `display/1`, `nl/0`; R/C++ also cover `writeln/1`, `print/1`, and `tab/1`; LLVM covers `getenv/2` and `setenv/2` | Present for current baseline plus simple output aliases, tab output, and bounded environment access |
 
 ## Immediate Findings
 
@@ -59,6 +59,11 @@ current cross-target builtin/runtime baseline.
   builtin E2E test for concatenating proper lists, empty-left and empty-right
   behavior, bound-output success and mismatch failure, malformed-list failure,
   and unsupported unbound input modes, matching the current Go runtime surface.
+- Simple output aliases `writeln/1` and `print/1` are now direct Go WAM
+  builtins and are covered by the generated builtin E2E test. `print/1` shares
+  `write/1` rendering, while `writeln/1` appends a newline, matching the
+  bounded R/C++ output-polish surface without adding broader `format/N`
+  parsing.
 - Deterministic `subtract/3` is now covered by the generated Go WAM builtin
   E2E test for filtering all right-list matches from the left list, preserving
   left-list order, empty-list behavior, all-removed results, duplicate removal,

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -480,6 +480,12 @@ wam_go_direct_builtin("numlist/3", 3, 'numlist/3').
 wam_go_direct_builtin(between/3, 3, 'between/3').
 wam_go_direct_builtin('between/3', 3, 'between/3').
 wam_go_direct_builtin("between/3", 3, 'between/3').
+wam_go_direct_builtin(writeln/1, 1, 'writeln/1').
+wam_go_direct_builtin('writeln/1', 1, 'writeln/1').
+wam_go_direct_builtin("writeln/1", 1, 'writeln/1').
+wam_go_direct_builtin(print/1, 1, 'print/1').
+wam_go_direct_builtin('print/1', 1, 'print/1').
+wam_go_direct_builtin("print/1", 1, 'print/1').
 wam_go_direct_builtin(sum_list/2, 2, 'sum_list/2').
 wam_go_direct_builtin('sum_list/2', 2, 'sum_list/2').
 wam_go_direct_builtin("sum_list/2", 2, 'sum_list/2').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1312,6 +1312,12 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 	case "write/1":
 		fmt.Print(vm.deref(arg1).String())
 		return true
+	case "writeln/1":
+		fmt.Println(vm.deref(arg1).String())
+		return true
+	case "print/1":
+		fmt.Print(vm.deref(arg1).String())
+		return true
 	case "nl/0":
 		fmt.Println()
 		return true

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -29,6 +29,7 @@
 :- dynamic user:test_char_type_builtin/0.
 :- dynamic user:test_string_code_builtin/0.
 :- dynamic user:test_split_string_builtin/0.
+:- dynamic user:test_output_builtin/0.
 :- dynamic user:test_tab_builtin/0.
 :- dynamic user:test_env_builtin/0.
 :- dynamic user:test_succ_builtin/0.
@@ -678,6 +679,12 @@ test(builtins_execution) :-
                 \+ atom_string(_, _),
                 \+ string_to_atom(_, _)
             )),
+          assertz(user:test_output_builtin :-
+            (   write(go_write),
+                writeln(go_writeln),
+                print(go_print),
+                nl
+            )),
           assertz(user:test_set_aggregate :-
             (   aggregate_all(set(X), member(X, [a,b,a]), S),
                 length(S, 2),
@@ -739,6 +746,7 @@ test(builtins_execution) :-
           retractall(user:test_string_list_builtin),
           retractall(user:test_number_list_builtin),
           retractall(user:test_atom_string_builtin),
+          retractall(user:test_output_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
           retractall(user:test_neg_fact(_)),
@@ -748,7 +756,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_arithmetic_expr_builtin/0, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_append_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_tab_builtin/0, test_env_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_arithmetic_expr_builtin/0, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_append_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_output_builtin/0, test_tab_builtin/0, test_env_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -814,6 +822,8 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "tab/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "getenv/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "setenv/2"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "writeln/1"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "print/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "succ/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "atom_number/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "upcase_atom/2"')),
@@ -1171,6 +1181,14 @@ func main() {
 		fmt.Println("ATOM_STRING_FAILURE")
 	}
 
+	outputVM := wam.NewWamState(wam.Test_output_builtinCode, wam.Test_output_builtinLabels)
+	outputVM.PC = wam.Test_output_builtinStartPC
+	if outputVM.Run() {
+		fmt.Println("OUTPUT_SUCCESS")
+	} else {
+		fmt.Println("OUTPUT_FAILURE")
+	}
+
 	setVM := wam.NewWamState(wam.Test_set_aggregateCode, wam.Test_set_aggregateLabels)
 	setVM.PC = wam.Test_set_aggregateStartPC
 	if setVM.Run() {
@@ -1260,6 +1278,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "STRING_LIST_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NUMBER_LIST_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_STRING_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "OUTPUT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NEG_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM print and writeln builtins

## Summary

- Register `print/1` and `writeln/1` as direct Go WAM builtins.
- Implement Go WAM runtime handling for `print/1` as a `write/1` alias and `writeln/1` as term output plus newline.
- Add generated Go WAM E2E coverage for `write/1`, `print/1`, `writeln/1`, and `nl/0`.
- Update the Go WAM parity audit to record the closed simple-output gap against richer sibling targets.

## Validation

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`

Existing non-fatal choicepoint warnings still appear in the same Go WAM tests.
