### PR TITLE
LLVM WAM: numbervars/3 (M105) + atom-table reset per compile

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1255,6 +1255,9 @@ write_wam_llvm_project(Predicates, Options, OutputFile) :-
     % @.fn_... globals are in every module.
     register_functor_string("date"),
     register_functor_string("local"),
+    % M105: numbervars/3 binds free vars to ''$VAR''(N) compounds.
+    % Pre-register so @.fn__24VAR exists in every module.
+    register_functor_string("$VAR"),
     % M9: intern "[]" so the empty-list atom id is known at runtime.
     % @wam_apply_aggregation's collect_case reads this id from a
     % module-level global to terminate the cons-cell chain.
@@ -3568,6 +3571,7 @@ entry:
     i32 121, label %builtin_date_time_stamp
     i32 122, label %builtin_chmod
     i32 123, label %builtin_term_variables
+    i32 124, label %builtin_numbervars
   ]
 
 builtin_is:
@@ -5517,6 +5521,30 @@ builtin_term_variables:
   %tva.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
   %tva.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %tva.raw2, %Value %tva.vars)
   ret i1 %tva.ok
+
+builtin_numbervars:
+  ; M105: numbervars(+Term, +Start, -End) -- walks Term depth-first
+  ; left-to-right and binds each free variable to a fresh
+  ; ''$VAR''(N) compound, where N starts at Start and increments by 1
+  ; per binding. End is unified with the final counter (Start +
+  ; number_of_vars_bound). Start must be Integer; non-Integer fails.
+  ; Same Ref-aliasing guarantees as M104: a single var with multiple
+  ; occurrences gets a single $VAR(N) compound visible at every
+  ; occurrence via heap-cell aliasing.
+  %nv.start_raw = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %nv.start_tag = call i32 @value_tag(%Value %nv.start_raw)
+  %nv.start_int = icmp eq i32 %nv.start_tag, 1
+  br i1 %nv.start_int, label %nv.go, label %nv.fail
+nv.fail:
+  ret i1 false
+nv.go:
+  %nv.start = call i64 @value_payload(%Value %nv.start_raw)
+  %nv.term = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %nv.end = call i64 @wam_numbervars_walk(%WamState* %vm, %Value %nv.term, i64 %nv.start)
+  %nv.end_v = call %Value @value_integer(i64 %nv.end)
+  %nv.raw3 = call %Value @wam_get_reg(%WamState* %vm, i32 2)
+  %nv.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %nv.raw3, %Value %nv.end_v)
+  ret i1 %nv.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11483,6 +11511,90 @@ tv.ret_acc:
   ret %Value %acc
 }
 
+; M105: recursive depth-first left-to-right walk that binds each
+; Unbound variable encountered to a fresh ''$VAR''(N) compound on
+; the arena. Counter n is threaded through and returned -- caller
+; gets the next-available N to unify with End.
+define i64 @wam_numbervars_walk(%WamState* %vm, %Value %term, i64 %n) {
+entry:
+  %nw.t = call %Value @wam_deref_value(%WamState* %vm, %Value %term)
+  %nw.tag = call i32 @value_tag(%Value %nw.t)
+  switch i32 %nw.tag, label %nw.atomic [
+    i32 6, label %nw.unbound
+    i32 3, label %nw.compound
+  ]
+
+nw.atomic:
+  ret i64 %n
+
+nw.unbound:
+  ; Build the ''$VAR''(n) compound on the arena. Then bind the
+  ; variable''s heap cell to it via wam_trail_heap_binding + heap_set
+  ; so backtrack restores. Use the ORIGINAL term (a Ref) to locate
+  ; the heap cell; deref''d nw.t is just an Unbound sentinel.
+  call void @wam_arena_ensure()
+  %nw.cp_size = ptrtoint %Compound* getelementptr (%Compound, %Compound* null, i32 1) to i64
+  %nw.cp_mem = call i8* @wam_arena_alloc(i64 %nw.cp_size)
+  %nw.cp = bitcast i8* %nw.cp_mem to %Compound*
+  %nw.fn_slot = getelementptr %Compound, %Compound* %nw.cp, i32 0, i32 0
+  store i8* getelementptr ([5 x i8], [5 x i8]* @.fn__24VAR, i32 0, i32 0), i8** %nw.fn_slot
+  %nw.ar_slot = getelementptr %Compound, %Compound* %nw.cp, i32 0, i32 1
+  store i32 1, i32* %nw.ar_slot
+  %nw.args_mem = call i8* @wam_arena_alloc(i64 16)
+  %nw.args = bitcast i8* %nw.args_mem to %Value*
+  %nw.args_slot = getelementptr %Compound, %Compound* %nw.cp, i32 0, i32 2
+  store %Value* %nw.args, %Value** %nw.args_slot
+  %nw.n_v = call %Value @value_integer(i64 %n)
+  %nw.arg0_ptr = getelementptr %Value, %Value* %nw.args, i32 0
+  store %Value %nw.n_v, %Value* %nw.arg0_ptr
+  %nw.cp_i64 = ptrtoint %Compound* %nw.cp to i64
+  %nw.varN_v0 = insertvalue %Value undef, i32 3, 0
+  %nw.varN_v = insertvalue %Value %nw.varN_v0, i64 %nw.cp_i64, 1
+  ; Bind the var. The original %term is the Ref into the heap cell.
+  %nw.t_tag = extractvalue %Value %term, 0
+  %nw.t_isref = icmp eq i32 %nw.t_tag, 5
+  br i1 %nw.t_isref, label %nw.bind, label %nw.skip
+nw.bind:
+  %nw.addr_i64 = extractvalue %Value %term, 1
+  %nw.addr = trunc i64 %nw.addr_i64 to i32
+  %nw.old = call %Value @wam_heap_get(%WamState* %vm, i32 %nw.addr)
+  call void @wam_trail_heap_binding(%WamState* %vm, i32 %nw.addr, %Value %nw.old)
+  call void @wam_heap_set(%WamState* %vm, i32 %nw.addr, %Value %nw.varN_v)
+  br label %nw.skip
+nw.skip:
+  %nw.n1 = add i64 %n, 1
+  ret i64 %nw.n1
+
+nw.compound:
+  %nw.cp_bits = call i64 @value_payload(%Value %nw.t)
+  %nw.src_cp = inttoptr i64 %nw.cp_bits to %Compound*
+  %nw.src_ar_slot = getelementptr %Compound, %Compound* %nw.src_cp, i32 0, i32 1
+  %nw.arity = load i32, i32* %nw.src_ar_slot
+  %nw.src_args_slot = getelementptr %Compound, %Compound* %nw.src_cp, i32 0, i32 2
+  %nw.src_args = load %Value*, %Value** %nw.src_args_slot
+  %nw.has_args = icmp sgt i32 %nw.arity, 0
+  br i1 %nw.has_args, label %nw.loop, label %nw.ret_n
+
+nw.loop:
+  %nw.i = phi i32 [ 0, %nw.compound ], [ %nw.i_next, %nw.step ]
+  %nw.n_cur = phi i64 [ %n, %nw.compound ], [ %nw.n_next, %nw.step ]
+  %nw.arg_ptr = getelementptr %Value, %Value* %nw.src_args, i32 %nw.i
+  %nw.arg = load %Value, %Value* %nw.arg_ptr
+  %nw.n_next = call i64 @wam_numbervars_walk(%WamState* %vm, %Value %nw.arg, i64 %nw.n_cur)
+  %nw.i_next = add i32 %nw.i, 1
+  %nw.done = icmp sge i32 %nw.i_next, %nw.arity
+  br i1 %nw.done, label %nw.ret_loop, label %nw.step
+
+nw.step:
+  br label %nw.loop
+
+nw.ret_loop:
+  ret i64 %nw.n_next
+
+nw.ret_n:
+  ret i64 %n
+}
+
 ; M11: deref-aware deep-copy. Resolves Refs to the heap-stored value,
 ; then copies Compounds (recursing on args) so the returned %Value
 ; is self-contained -- it survives a heap rewind. Used by
@@ -12502,6 +12614,7 @@ builtin_op_to_id('stamp_date_time/3', 120).   % localtime_r + build 9-arity date
 builtin_op_to_id('date_time_stamp/2', 121).   % mktime via date/9 compound.
 builtin_op_to_id('chmod/2', 122).             % libc chmod(Path, Mode).
 builtin_op_to_id('term_variables/2', 123).    % depth-first var collection.
+builtin_op_to_id('numbervars/3', 124).        % bind free vars to $VAR(N).
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1191,6 +1191,16 @@ write_wam_llvm_project(Predicates, Options, OutputFile) :-
     % llvm_foreign_kernel_spec/3 entry is compiled to a body of
     % WAM instructions ending in `call_foreign Kind, Arity`.
     retractall(functor_string_global(_, _)),
+    % M105: also reset the atom-table dynamic predicates per module.
+    % Atom ids are module-scoped (each module emits its own
+    % @wam_atom_strings global) so persistent state across compiles
+    % only serves to accumulate. The 600+ test suite hit Prolog''s
+    % 4GB global-stack cap around test 650 because every compile
+    % re-interns 95 ASCII chars + [] + a handful of named atoms,
+    % and those atom_table_entry asserts piled up monotonically.
+    retractall(atom_table_entry(_, _)),
+    retractall(atom_table_next_id(_)),
+    assertz(atom_table_next_id(1)),
     % Pre-register functor globals referenced directly by runtime
     % helpers (e.g. =../2 needs the cons-cell functor "." and the
     % empty-list atom "[]"). Route through register_functor_string so

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,39 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M105: numbervars/3 -- bind free vars to $VAR(N) compounds.
+
+:- dynamic test_nv_basic/2.
+test_nv_basic(_, R) :-
+    Term = foo(X, Y, Z),
+    numbervars(Term, 0, End),
+    X = '$VAR'(N0), Y = '$VAR'(N1), Z = '$VAR'(N2),
+    ( N0 =:= 0, N1 =:= 1, N2 =:= 2, End =:= 3 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_nv_shared/2.
+test_nv_shared(_, R) :-
+    % Same var twice gets the same $VAR(N) -- exercises the M104
+    % aliasing fix: binding through one Ref propagates to all
+    % occurrences of the var.
+    Term = bar(X, X),
+    numbervars(Term, 0, End),
+    X = '$VAR'(N),
+    ( N =:= 0, End =:= 1 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_nv_ground/2.
+test_nv_ground(_, R) :-
+    numbervars(foo(1, 2, 3), 5, End),
+    ( End =:= 5 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_nv_nested/2.
+test_nv_nested(_, R) :-
+    Term = outer(X, inner(Y), Z),
+    numbervars(Term, 0, End),
+    X = '$VAR'(0),
+    Y = '$VAR'(1),
+    Z = '$VAR'(2),
+    ( End =:= 3 -> R is 1 ; R is 0 ).   % 1
+
 % M104: wam_unify_value bind path now aliases two unbound vars
 % via Ref-to-Ref instead of writing the Unbound sentinel. So after
 % X = Y, var(X) and var(Y) both still hold but X == Y is now true.
@@ -5121,6 +5154,15 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M105 numbervars/3 ---~n'),
+       run_test_r0('foo(X,Y,Z), nv 0 -> 3, vars 0/1/2 -> 1',
+                   test_nv_basic, 0, 1),
+       run_test_r0('bar(X,X) shared, single $VAR(0), End=1 -> 1',
+                   test_nv_shared, 0, 1),
+       run_test_r0('ground term, End == Start -> 1',
+                   test_nv_ground, 0, 1),
+       run_test_r0('nested compound DFS L-to-R -> 1',
+                   test_nv_nested, 0, 1),
        format('--- M104 wam_unify_value Ref-to-Ref aliasing ---~n'),
        run_test_r0('X = Y, X == Y -> 1',
                    test_unify_aliases_vars, 0, 1),


### PR DESCRIPTION
## Summary

- **M105 `numbervars/3`** — walks `Term` depth-first left-to-right and binds each free variable to a fresh `$VAR(N)` compound, where `N` starts at `Start` and increments by 1 per binding. `End` is unified with `Start + number_of_vars_bound`. Op id 124.

Mirrors M103's `wam_collect_vars` pattern but threads an `i64` counter through the recursion instead of a list accumulator, and **binds** the var's heap cell (with trail entry, so backtrack restores) rather than just observing it.

## Pipeline

`builtin_numbervars` (prefix `nv.`): type-check Start as Integer, fetch raw Term, call `wam_numbervars_walk`, unify End with reg 2.

`wam_numbervars_walk(vm, term, n) -> i64`: recursive walker.
- **Atomic**: return `n` unchanged.
- **Unbound**: build `$VAR(n)` compound on the arena, trail + bind term's heap cell to it via `wam_heap_set`, return `n + 1`.
- **Compound**: loop over args **left-to-right** (numbervars assigns indices in source order, unlike `collect_vars` which prepends and walks right-to-left), threading `n` through recursive calls.

Pre-registers the `"$VAR"` functor string (sanitizes to `@.fn__24VAR` since `$` = `0x24`) in `write_wam_llvm_project`.

## Fix: atom-table leak across compiles

While testing M105 I hit a pre-existing leak: the per-compile dynamic predicates `atom_table_entry/2` and `atom_table_next_id/1` accumulated across **every** compile in a single swipl process. Each compile re-interns ~95 ASCII chars + `[]` + a handful of named atoms (`$VAR`, `local`, `date`, etc.) via `intern_atom`, and those `assertz` calls piled up monotonically. The 600+ test suite hit Prolog's 4GB global-stack cap around test 650.

Atom ids are module-scoped (each module emits its own `@wam_atom_strings` global), so persistent state across compiles only serves as a leak. The fix adds `retractall(atom_table_entry(_, _))` + `retractall(atom_table_next_id(_))` + reset to 1 next to the existing `retractall(functor_string_global)` at the top of `write_wam_llvm_project`.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — dispatch entry, `builtin_numbervars` driver block, op-id table entry, `wam_numbervars_walk` runtime helper, `register_functor_string("$VAR")`, atom-table reset.
- `tests/core/test_wam_llvm_builtin_execution.pl` — four M105 tests + section.

## Test plan

- [x] Full execution suite: **655/655 PASS**, no failures, no OOM
- [x] `test_nv_basic`: `foo(X,Y,Z)` with Start=0 → `X=$VAR(0), Y=$VAR(1), Z=$VAR(2), End=3` ✓
- [x] `test_nv_shared`: `bar(X,X)` with shared X → single `$VAR(0)`, `End=1` (exercises the M104 Ref-aliasing fix — binding one occurrence now propagates to all) ✓
- [x] `test_nv_ground`: `foo(1,2,3)` with Start=5 → `End=5` (no vars) ✓
- [x] `test_nv_nested`: `outer(X, inner(Y), Z)` → DFS L-to-R order ✓
- [x] Atom-table reset confirmed: suite reaches 655 tests without hitting Prolog's stack limit.

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_