### PR TITLE
feat(go,rust): if-then-else / negation / once lowering parity (fixes latent Go bug)

### DIFF
--- a/src/unifyweaver/targets/wam_go_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_go_lowered_emitter.pl
@@ -87,21 +87,124 @@ instr_from_parts(["jump", L], jump(L)).
 instr_from_parts(["cut_ite"], cut_ite).
 
 % =====================================================================
+% Label-preserving parse + if-then-else structuring
+% =====================================================================
+%
+%  The base parser (parse_wam_text) drops label lines, which erases the
+%  boundaries of an (C -> T ; E) / \+ / once block. Without those
+%  boundaries the old emitter used a "peel the trailing epilogue"
+%  heuristic to split the else body from the continuation — which placed a
+%  *sequential* second ITE (and broke a nested one) inside the preceding
+%  else branch, silently miscompiling the clause.
+%
+%  parse_wam_text_labeled keeps label(Name) markers (and cut_ite) so
+%  structure_ite_go can fold each block into an ite(Cond,Then,Else) term
+%  using the real else/cont labels. The continuation is then emitted as a
+%  sibling of the if/else (not nested in the else), fixing sequential and
+%  nested blocks. Mirrors structure_ite_scala.
+
+parse_wam_text_labeled(WamText, Instrs) :-
+    atom_string(WamText, S),
+    split_string(S, "\n", "", Lines),
+    parse_lines_labeled(Lines, Instrs).
+
+parse_lines_labeled([], []).
+parse_lines_labeled([Line|Rest], Instrs) :-
+    split_string(Line, " \t,", " \t,", Parts),
+    delete(Parts, "", CleanParts),
+    (   CleanParts == []
+    ->  parse_lines_labeled(Rest, Instrs)
+    ;   CleanParts = [First|_],
+        (   sub_string(First, _, 1, 0, ":")
+        ->  sub_string(First, 0, _, 1, LabelStr),
+            Instrs = [label(LabelStr)|More],   % keep as string to match try_me_else/jump args
+            parse_lines_labeled(Rest, More)
+        ;   instr_from_parts(CleanParts, Instr)
+        ->  Instrs = [Instr|More],
+            parse_lines_labeled(Rest, More)
+        ;   parse_lines_labeled(Rest, Instrs)
+        )
+    ).
+
+%% structure_ite_go(+Flat, -Structured) is semidet.
+%  Folds each well-formed ITE block into ite(Cond,Then,Else); drops the
+%  structural markers (try_me_else/trust_me/cut_ite/jump/label). Fails if a
+%  try_me_else cannot be matched to a clean block.
+structure_ite_go([], []).
+structure_ite_go([try_me_else(LE)|Rest0], [ite(CondS,ThenS,ElseS)|Out]) :-
+    !,
+    append(ThenWithJump, [label(LE), trust_me | ElseAndRest], Rest0),
+    \+ member(label(LE), ThenWithJump),          % first (matching) else label
+    append(ThenPath, [jump(LC)], ThenWithJump),  % then-path ends in its jump
+    append(ElsePath, [label(LC) | AfterCont], ElseAndRest),
+    \+ member(label(LC), ElsePath),
+    split_commit_go(ThenPath, Cond, Then),
+    structure_ite_go(Cond, CondS),
+    structure_ite_go(Then, ThenS),
+    structure_ite_go(ElsePath, ElseS),
+    structure_ite_go(AfterCont, Out).
+structure_ite_go([label(_)|Rest], Out) :- !,
+    structure_ite_go(Rest, Out).
+structure_ite_go([I|Rest], [I|Out]) :-
+    structure_ite_go(Rest, Out).
+
+%% split_commit_go(+ThenPath, -Cond, -Then)
+%  Splits a then-path at its commit instruction (cut_ite for ->, the !/0
+%  builtin for \+). The commit itself is dropped.
+split_commit_go(Path, Cond, Then) :-
+    append(Cond, [Commit|Then], Path),
+    is_commit_go(Commit),
+    \+ ( member(C0, Cond), is_commit_go(C0) ),   % split at the first commit
+    !.
+
+is_commit_go(cut_ite).
+is_commit_go(builtin_call("!/0", _)).
+is_commit_go(builtin_call('!/0', _)).
+
+%% go_base_instrs(+WamCode, -Instrs)  — base (label-stripped) parse or list.
+go_base_instrs(WamCode, Instrs) :-
+    ( is_list(WamCode) -> Instrs = WamCode ; parse_wam_text(WamCode, Instrs) ).
+
+%% go_structured_clause1(+WamCode, -Structured) is semidet.
+%  Re-parse keeping labels/cut_ite, take clause 1, fold ITE blocks. Only
+%  succeeds for a single-clause predicate (no predicate-level try_me_else
+%  head) whose every block is consumed.
+go_structured_clause1(WamCode, Structured) :-
+    ( is_list(WamCode) -> LInstrs = WamCode ; parse_wam_text_labeled(WamCode, LInstrs) ),
+    \+ ( LInstrs = [try_me_else(_)|_] ),   % not predicate-level multi-clause
+    take_to_proceed(LInstrs, C1L),
+    structure_ite_go(C1L, Structured),
+    \+ member(try_me_else(_), Structured),  % every block consumed
+    \+ member(trust_me, Structured),
+    \+ member(retry_me_else(_), Structured).
+
+%% go_supported_structured(+StructuredInstr)
+go_supported_structured(ite(C, T, E)) :- !,
+    forall(member(I, C), go_supported_structured(I)),
+    forall(member(I, T), go_supported_structured(I)),
+    forall(member(I, E), go_supported_structured(I)).
+go_supported_structured(I) :- go_supported(I).
+
+% =====================================================================
 % Lowerability
 % =====================================================================
 
 %% wam_go_lowerable(+Pred/Arity, +WamCode, -Reason)
 %  True if the predicate can be lowered to a direct Go function.
 wam_go_lowerable(PI, WamCode, Reason) :-
-    (   is_list(WamCode) -> Instrs = WamCode
-    ;   atom(WamCode) -> parse_wam_text(WamCode, Instrs)
-    ;   atom_string(WamCode, _), parse_wam_text(WamCode, Instrs)
-    ),
+    go_base_instrs(WamCode, Instrs),
     clause1_instrs(Instrs, C1),
-    forall(member(I, C1), go_supported(I)),
-    (   is_deterministic_pred_go(Instrs)
-    ->  Reason = deterministic
-    ;   Reason = multi_clause_1
+    (   % No internal ITE: existing deterministic / multi-clause path.
+        \+ member(try_me_else(_), C1),
+        forall(member(I, C1), go_supported(I))
+    ->  ( is_deterministic_pred_go(Instrs) -> Reason = deterministic
+        ; Reason = multi_clause_1 )
+    ;   % Clause-1 has an inner choice point: lower only if it is a pure
+        % (C -> T ; E) / \+ / once block whose pieces are all supported.
+        \+ ( Instrs = [try_me_else(_)|_] ),   % single-clause predicate
+        go_structured_clause1(WamCode, Structured),
+        forall(member(I, Structured), go_supported_structured(I)),
+        Reason = ite_lowered
     ),
     ( PI = _M:_P/_A -> true ; PI = _/_A2 -> true ; true ).
 
@@ -195,11 +298,15 @@ capitalize_first(Str, Cap) :-
 lower_predicate_to_go(PI, WamCode, _Options, GoLines) :-
     ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     go_func_name(Pred/Arity, FuncName),
-    (   is_list(WamCode) -> Instrs = WamCode
-    ;   parse_wam_text(WamCode, Instrs)
-    ),
+    go_base_instrs(WamCode, Instrs),
     clause1_instrs(Instrs, C1Instrs),
-    with_output_to(string(Body), emit_instrs(C1Instrs, "    ")),
+    % Emit the plain clause-1 when it has no inner choice point; otherwise
+    % fold its ITE block(s) into structured form (ite/3) first.
+    (   \+ member(try_me_else(_), C1Instrs)
+    ->  EmitInstrs = C1Instrs
+    ;   go_structured_clause1(WamCode, EmitInstrs)
+    ),
+    with_output_to(string(Body), emit_instrs(EmitInstrs, "    ")),
     format(string(Header),
 '// ~w — lowered from ~w/~w
 func (vm *WamState) ~w() bool {', [FuncName, Pred, Arity, FuncName]),
@@ -214,88 +321,59 @@ func (vm *WamState) ~w() bool {', [FuncName, Pred, Arity, FuncName]),
 %  `return false` failure paths short-circuit cleanly; on failure the
 %  trail is unwound to its pre-condition mark before the else branch.
 emit_instrs([], _).
-emit_instrs([try_me_else(_)|Rest], Ind) :-
-    split_ite_blocks_go(Rest, CondInstrs, ThenInstrs, ElseInstrs, ContInstrs),
-    !,
-    emit_ite_block(CondInstrs, ThenInstrs, ElseInstrs, Ind),
-    emit_instrs(ContInstrs, Ind).
+emit_instrs([ite(Cond, Then, Else)|Rest], Ind) :- !,
+    emit_ite_block(Cond, Then, Else, Ind),
+    emit_instrs(Rest, Ind).
+emit_instrs([label(_)|Rest], Ind) :- !,   % safety: drop any stray label marker
+    emit_instrs(Rest, Ind).
 emit_instrs([Instr|Rest], Ind) :-
     emit_one(Instr, Ind),
     emit_instrs(Rest, Ind).
 
 %% has_internal_ite_pattern(+Instrs)
-%  True if the instruction list contains a complete try_me_else /
-%  cut_ite / jump / trust_me sequence. Used by tests to assert that the
-%  emitter actually triggers ITE lowering on a given input.
+%  True if the (clause-1 of the) given instruction stream contains a
+%  well-formed if-then-else block, i.e. structure_ite_go folds out at
+%  least one ite/3 term. Used by tests to assert that ITE lowering fires.
 has_internal_ite_pattern(Instrs) :-
-    append(_, [try_me_else(_)|Rest], Instrs),
-    split_ite_blocks_go(Rest, _, _, _, _),
-    !.
-
-%% split_ite_blocks_go(+Instrs, -CondInstrs, -ThenInstrs, -ElseInstrs, -ContInstrs)
-%  Slice the instruction stream after a try_me_else into the four parts
-%  of an if-then-else:
-%    <cond_instrs> cut_ite <then_instrs> jump(_) trust_me <else_instrs> <cont_instrs>
-%
-%  We don't currently have label PC information at this layer, so we
-%  use a heuristic to separate the else body from the continuation:
-%  the continuation is the trailing tail of "epilogue" instructions
-%  (deallocate followed by proceed, or just proceed). Everything before
-%  that tail belongs to the else body. This matches what the WAM
-%  compiler emits for `(C -> T ; E), epilogue` and ensures the then
-%  branch can be augmented with the same epilogue (otherwise it leaks
-%  an env frame and Go fails to compile the function with "missing
-%  return").
-split_ite_blocks_go(Instrs, CondInstrs, ThenInstrs, ElseInstrs, ContInstrs) :-
-    split_at_instr_go(Instrs, cut_ite, CondInstrs, AfterCut),
-    split_at_jump_go(AfterCut, ThenInstrs, AfterJump),
-    AfterJump = [trust_me|ElseAndCont],
-    split_else_from_cont(ElseAndCont, ElseInstrs, ContInstrs).
-
-%% split_else_from_cont(+ElseAndCont, -ElseInstrs, -ContInstrs)
-%  Peel off the trailing epilogue (deallocate*, proceed) as the
-%  continuation. Falls back to "everything is else, cont is empty"
-%  when the trailing pattern doesn't match.
-split_else_from_cont(Instrs, ElseInstrs, ContInstrs) :-
-    (   peel_epilogue(Instrs, ElseInstrs0, ContInstrs0),
-        ContInstrs0 \= []
-    ->  ElseInstrs = ElseInstrs0,
-        ContInstrs = ContInstrs0
-    ;   ElseInstrs = Instrs,
-        ContInstrs = []
-    ).
-
-peel_epilogue(Instrs, Body, Epilogue) :-
-    append(Body, Epilogue, Instrs),
-    is_epilogue(Epilogue),
-    !.
-peel_epilogue(Instrs, Instrs, []).
-
-is_epilogue([proceed]).
-is_epilogue([deallocate, proceed]).
-
-split_at_instr_go([], _, _, _) :- !, fail.
-split_at_instr_go([Instr|Rest], Instr, [], Rest) :- !.
-split_at_instr_go([H|T], Instr, [H|Before], After) :-
-    split_at_instr_go(T, Instr, Before, After).
-
-split_at_jump_go([], [], []) :- !, fail.
-split_at_jump_go([jump(_)|Rest], [], Rest) :- !.
-split_at_jump_go([H|T], [H|Then], Rest) :-
-    split_at_jump_go(T, Then, Rest).
+    catch(go_structured_clause1(Instrs, Structured), _, fail),
+    once(member(ite(_, _, _), Structured)).
 
 %% emit_ite_block(+CondInstrs, +ThenInstrs, +ElseInstrs, +Indent)
 %  Emit native Go if/else for the WAM if-then-else pattern.
 %  The condition runs in an immediately-invoked closure that returns
 %  bool, so any inner `return false` short-circuits to a false outcome
-%  without escaping the surrounding lowered function. The trail mark
-%  taken before the closure is used to unwind any partial bindings made
-%  by the condition before the else branch executes.
+%  without escaping the surrounding lowered function.
+%
+%  When the condition fails we must restore the pre-condition machine
+%  state before running the else branch — exactly what a choice point
+%  does on backtracking. Three things can change during the condition,
+%  and Go's runtime tracks them in different places:
+%
+%    1. Variable bindings — reverted via the trail mark + unwindTrailTo.
+%    2. Existing argument / Y registers that bindUnbound rewrote in place
+%       (the trail does not track these) — reverted via a full snapshot of
+%       the register file (copy of vm.Regs). We can't use snapshotAllRegs:
+%       it sizes its Y-range from MaxYReg, but the lowered code sets
+%       Y-registers with direct `vm.Regs[i] = ...` writes (not putReg), so
+%       MaxYReg is stale and restoreSavedRegs would wipe live Y-regs.
+%    3. Fresh variables the condition itself created with put_variable.
+%       getReg reads the register array directly (not the binding table),
+%       so after restoring the pre-condition registers we re-run the
+%       condition's put_variable instructions to reset those registers to
+%       fresh unbound vars, matching the interpreter's post-backtrack
+%       state.
+%
+%  Without all three, a binding condition like ((Y=a,Y=b) -> ... ; ...)
+%  leaves Y holding the stale `a` after the trail is unwound, so a later
+%  `X = Y` in the else/continuation sees the wrong value. The then branch
+%  keeps the condition's results, so only the else restores.
 emit_ite_block(CondInstrs, ThenInstrs, ElseInstrs, I) :-
     atom_concat(I, "    ", InnerInd),
+    cond_put_variable_instrs(CondInstrs, FreshVarInstrs),
     format("~w// if-then-else (lowered from try_me_else/cut_ite/jump/trust_me)~n", [I]),
     format("~w{~n", [I]),
     format("~w    _trailMark := vm.TrailLen~n", [I]),
+    format("~w    _savedRegs := vm.Regs   // Regs is a fixed array; assignment copies it~n", [I]),
     format("~w    _condOk := func() bool {~n", [I]),
     emit_instrs(CondInstrs, InnerInd),
     format("~w        return true~n", [I]),
@@ -303,10 +381,21 @@ emit_ite_block(CondInstrs, ThenInstrs, ElseInstrs, I) :-
     format("~w    if _condOk {~n", [I]),
     emit_instrs(ThenInstrs, InnerInd),
     format("~w    } else {~n", [I]),
+    format("~w        vm.Regs = _savedRegs~n", [I]),
     format("~w        vm.unwindTrailTo(_trailMark)~n", [I]),
+    emit_instrs(FreshVarInstrs, InnerInd),   % reset condition-local fresh vars
     emit_instrs(ElseInstrs, InnerInd),
     format("~w    }~n", [I]),
     format("~w}~n", [I]).
+
+%% cond_put_variable_instrs(+CondInstrs, -PutVarInstrs)
+%  The put_variable instructions in a condition, in order. Re-running them
+%  in the else branch resets the fresh variables the condition created.
+cond_put_variable_instrs([], []).
+cond_put_variable_instrs([put_variable(X, A)|T], [put_variable(X, A)|R]) :- !,
+    cond_put_variable_instrs(T, R).
+cond_put_variable_instrs([_|T], R) :-
+    cond_put_variable_instrs(T, R).
 
 % --- Terminal instructions ---
 

--- a/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
@@ -83,21 +83,116 @@ instr_from_parts(["jump", L], jump(L)).
 instr_from_parts(["cut_ite"], cut_ite).
 
 % =====================================================================
+% Label-preserving parse + if-then-else structuring
+% =====================================================================
+%
+%  The base parser drops label lines, so the boundaries of an
+%  (C -> T ; E) / \+ / once block are lost. The previous emitter simply
+%  no-op'd try_me_else/cut_ite/jump/trust_me, which dropped the structure
+%  entirely and emitted the condition, then- and else-branches as one flat
+%  conjunction (e.g. unifying the output with BOTH branch values), so the
+%  lowered function always failed.
+%
+%  parse_wam_text_labeled keeps label(Name) markers (and cut_ite) so
+%  structure_ite_rust can fold each block into an ite(Cond,Then,Else) term.
+%  Rust's get_reg derefs through the binding table, so trail save/undo
+%  alone restores a failed condition's bindings — no register snapshot is
+%  needed (unlike the Go backend). Mirrors structure_ite_scala.
+
+parse_wam_text_labeled(WamText, Instrs) :-
+    atom_string(WamText, S),
+    split_string(S, "\n", "", Lines),
+    parse_lines_labeled(Lines, Instrs).
+
+parse_lines_labeled([], []).
+parse_lines_labeled([Line|Rest], Instrs) :-
+    split_string(Line, " \t,", " \t,", Parts),
+    delete(Parts, "", CleanParts),
+    (   CleanParts == []
+    ->  parse_lines_labeled(Rest, Instrs)
+    ;   CleanParts = [First|_],
+        (   sub_string(First, _, 1, 0, ":")
+        ->  sub_string(First, 0, _, 1, LabelStr),
+            Instrs = [label(LabelStr)|More],   % keep as string to match try_me_else/jump args
+            parse_lines_labeled(Rest, More)
+        ;   instr_from_parts(CleanParts, Instr)
+        ->  Instrs = [Instr|More],
+            parse_lines_labeled(Rest, More)
+        ;   parse_lines_labeled(Rest, Instrs)
+        )
+    ).
+
+%% structure_ite_rust(+Flat, -Structured) is semidet.
+structure_ite_rust([], []).
+structure_ite_rust([try_me_else(LE)|Rest0], [ite(CondS,ThenS,ElseS)|Out]) :-
+    !,
+    append(ThenWithJump, [label(LE), trust_me | ElseAndRest], Rest0),
+    \+ member(label(LE), ThenWithJump),
+    append(ThenPath, [jump(LC)], ThenWithJump),
+    append(ElsePath, [label(LC) | AfterCont], ElseAndRest),
+    \+ member(label(LC), ElsePath),
+    split_commit_rust(ThenPath, Cond, Then),
+    structure_ite_rust(Cond, CondS),
+    structure_ite_rust(Then, ThenS),
+    structure_ite_rust(ElsePath, ElseS),
+    structure_ite_rust(AfterCont, Out).
+structure_ite_rust([label(_)|Rest], Out) :- !,
+    structure_ite_rust(Rest, Out).
+structure_ite_rust([I|Rest], [I|Out]) :-
+    structure_ite_rust(Rest, Out).
+
+%% split_commit_rust(+ThenPath, -Cond, -Then)  — split at cut_ite (->) or !/0 (\+).
+split_commit_rust(Path, Cond, Then) :-
+    append(Cond, [Commit|Then], Path),
+    is_commit_rust(Commit),
+    \+ ( member(C0, Cond), is_commit_rust(C0) ),
+    !.
+
+is_commit_rust(cut_ite).
+is_commit_rust(builtin_call("!/0", _)).
+is_commit_rust(builtin_call('!/0', _)).
+
+%% rust_base_instrs(+WamCode, -Instrs)  — base (label-stripped) parse or list.
+rust_base_instrs(WamCode, Instrs) :-
+    ( is_list(WamCode) -> Instrs = WamCode ; parse_wam_text(WamCode, Instrs) ).
+
+%% rust_structured_clause1(+WamCode, -Structured) is semidet.
+rust_structured_clause1(WamCode, Structured) :-
+    ( is_list(WamCode) -> LInstrs = WamCode ; parse_wam_text_labeled(WamCode, LInstrs) ),
+    \+ ( LInstrs = [try_me_else(_)|_] ),   % not predicate-level multi-clause
+    take_to_proceed(LInstrs, C1L),
+    structure_ite_rust(C1L, Structured),
+    \+ member(try_me_else(_), Structured),
+    \+ member(trust_me, Structured),
+    \+ member(retry_me_else(_), Structured).
+
+%% rust_supported_structured(+StructuredInstr)
+rust_supported_structured(ite(C, T, E)) :- !,
+    forall(member(I, C), rust_supported_structured(I)),
+    forall(member(I, T), rust_supported_structured(I)),
+    forall(member(I, E), rust_supported_structured(I)).
+rust_supported_structured(I) :- rust_supported(I).
+
+% =====================================================================
 % Lowerability
 % =====================================================================
 
 %% wam_rust_lowerable(+Pred/Arity, +WamCode, -Reason)
 %  True if the predicate can be lowered to a direct Rust function.
 wam_rust_lowerable(PI, WamCode, Reason) :-
-    (   is_list(WamCode) -> Instrs = WamCode
-    ;   atom(WamCode) -> parse_wam_text(WamCode, Instrs)
-    ;   atom_string(WamCode, _), parse_wam_text(WamCode, Instrs)
-    ),
+    rust_base_instrs(WamCode, Instrs),
     clause1_instrs(Instrs, C1),
-    forall(member(I, C1), rust_supported(I)),
-    (   is_deterministic_pred_rust(Instrs)
-    ->  Reason = deterministic
-    ;   Reason = multi_clause_1
+    (   % No internal ITE: existing deterministic / multi-clause path.
+        \+ member(try_me_else(_), C1),
+        forall(member(I, C1), rust_supported(I))
+    ->  ( is_deterministic_pred_rust(Instrs) -> Reason = deterministic
+        ; Reason = multi_clause_1 )
+    ;   % Clause-1 has an inner choice point: lower only if it is a pure
+        % (C -> T ; E) / \+ / once block whose pieces are all supported.
+        \+ ( Instrs = [try_me_else(_)|_] ),   % single-clause predicate
+        rust_structured_clause1(WamCode, Structured),
+        forall(member(I, Structured), rust_supported_structured(I)),
+        Reason = ite_lowered
     ),
     ( PI = _M:_P/_A -> true ; PI = _/_A2 -> true ; true ).
 
@@ -184,15 +279,20 @@ rust_safe_code(_, 0'_).
 lower_predicate_to_rust(PI, WamCode, Options, RustLines) :-
     ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     rust_lowered_func_name(Pred/Arity, FuncName),
-    (   is_list(WamCode) -> Instrs = WamCode
-    ;   parse_wam_text(WamCode, Instrs)
-    ),
+    rust_base_instrs(WamCode, Instrs),
     clause1_instrs(Instrs, C1Instrs),
     (   member(foreign_pred_keys(ForeignPreds0), Options)
     ->  maplist(foreign_key_string, ForeignPreds0, ForeignPreds)
     ;   ForeignPreds = []
     ),
-    with_output_to(string(Body), emit_instrs(C1Instrs, "    ", ForeignPreds)),
+    % Emit the plain clause-1 when it has no inner choice point; otherwise
+    % fold its ITE block(s) into structured form (ite/3) first.
+    (   \+ member(try_me_else(_), C1Instrs)
+    ->  EmitInstrs = C1Instrs
+    ;   rust_structured_clause1(WamCode, EmitInstrs)
+    ),
+    nb_setval(rust_ite_ctr, 0),
+    with_output_to(string(Body), emit_instrs(EmitInstrs, "    ", ForeignPreds)),
     format(string(Header),
 '// ~w — lowered from ~w/~w
 pub fn ~w(vm: &mut WamState) -> bool {', [FuncName, Pred, Arity, FuncName]),
@@ -219,6 +319,26 @@ emit_one(execute(PredStr), I, ForeignPreds) :-
     format("~w// execute ~w via foreign kernel~n", [I, PredStr]),
     format("~wreturn vm.step(&Instruction::CallForeign(\"~w\".to_string(), ~w));~n",
            [I, PredStr, Arity]).
+% --- If-then-else (structured; see structure_ite_rust) ---
+% The condition runs in an immediately-invoked closure so its `return
+% false` means "condition failed"; inside then/else, `return false`
+% returns from the lowered function. Rust's get_reg derefs through the
+% binding table, so unwinding the trail before the else branch restores
+% any partial bindings the condition made (no register snapshot needed).
+emit_one(ite(Cond, Then, Else), I, ForeignPreds) :- !,
+    nb_getval(rust_ite_ctr, N0), N is N0 + 1, nb_setval(rust_ite_ctr, N),
+    string_concat(I, "    ", I2),
+    format("~wlet _ite_mark~w = vm.trail.len();~n", [I, N]),
+    format("~wlet _ite_cond~w = (|vm: &mut WamState| -> bool {~n", [I, N]),
+    emit_instrs(Cond, I2, ForeignPreds),
+    format("~w    true~n", [I]),
+    format("~w})(vm);~n", [I]),
+    format("~wif _ite_cond~w {~n", [I, N]),
+    emit_instrs(Then, I2, ForeignPreds),
+    format("~w} else {~n", [I]),
+    format("~w    vm.unwind_trail_to(_ite_mark~w);~n", [I, N]),
+    emit_instrs(Else, I2, ForeignPreds),
+    format("~w}~n", [I]).
 emit_one(Instr, I, _) :-
     emit_one(Instr, I).
 

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -751,6 +751,33 @@ impl WamState {
         self.bindings.insert(var_name.to_string(), val);
     }
 
+    /// Unwind the trail back to `mark`, undoing every binding (and any
+    /// register entry) recorded since the mark. Used by lowered
+    /// if-then-else: when the condition fails, its partial bindings are
+    /// discarded before the else branch runs. Because get_reg derefs
+    /// through `bindings`, reverting these entries fully restores the
+    /// pre-condition view of every variable.
+    pub fn unwind_trail_to(&mut self, mark: usize) {
+        while self.trail.len() > mark {
+            let entry = match self.trail.pop() {
+                Some(e) => e,
+                None => break,
+            };
+            if let Some(var) = entry.key.strip_prefix("__binding__") {
+                match entry.old_value {
+                    Some(v) => { self.bindings.insert(var.to_string(), v); }
+                    None => { self.bindings.remove(var); }
+                }
+            } else {
+                // Register trail entry: key is a register name.
+                match entry.old_value {
+                    Some(v) => self.put_reg(&entry.key, v),
+                    None => self.put_reg(&entry.key, Value::Uninit),
+                }
+            }
+        }
+    }
+
     /// Reset mutable query state without cloning code/labels.
     pub fn reset_query(&mut self) {
         self.regs.fill(Value::Uninit);

--- a/tests/test_wam_go_lowered_ite_exec.pl
+++ b/tests/test_wam_go_lowered_ite_exec.pl
@@ -1,0 +1,144 @@
+% test_wam_go_lowered_ite_exec.pl
+%
+% End-to-end execution test for Go if-then-else / negation / once lowering.
+%
+% Generates a WAM Go project for a set of ITE predicates, compiles the WAM
+% runtime + lowered functions with the real `go` toolchain, and runs a Go
+% test that calls each lowered function and asserts the boolean result is
+% correct. This is the execution-level counterpart to the structural checks
+% in test_wam_go_lowered_phase3.pl, and it specifically pins:
+%
+%   * sequential ITEs   — seqite(10,pos,small) must be false (the old
+%                         epilogue heuristic mislowered the 2nd block into
+%                         the 1st's else and wrongly returned true);
+%   * nested ITEs       — nestite/2;
+%   * negation (\+)     — neg/1, which commits with !/0 not cut_ite;
+%   * binding condition — undoite/2, whose condition binds a fresh var then
+%                         fails, so the trail unwind + register restore +
+%                         fresh-var reset must leave it unbound for X = Y.
+%
+% Skipped automatically when `go` is not on PATH (mirrors the cargo gating
+% in test_wam_rust_runtime.pl).
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_go_target').
+
+:- dynamic user:gite/2.
+:- dynamic user:gneg/1.
+:- dynamic user:gseqite/3.
+:- dynamic user:gnestite/2.
+:- dynamic user:gundoite/2.
+
+user:gite(X, Y)      :- ( X > 0 -> Y = pos ; Y = nonpos ).
+user:gneg(X)         :- \+ X > 0.
+user:gseqite(X, Y, Z) :- ( X > 0 -> Y = pos ; Y = nonpos ),
+                         ( X > 5 -> Z = big ; Z = small ).
+user:gnestite(X, Y)  :- ( X > 0 -> ( X > 10 -> Y = big ; Y = small ) ; Y = neg ).
+user:gundoite(X, R)  :- ( (Y = a, Y = b) -> R = then ; R = els ), X = Y.
+
+go_available :-
+    catch(
+        ( process_create(path(go), ['version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          process_wait(Pid, exit(0)) ),
+        _, fail).
+
+:- begin_tests(wam_go_lowered_ite_exec, [condition(go_available)]).
+
+test(ite_exec_parity) :-
+    Dir = 'output/test_wam_go_ite_exec',
+    Proj = 'output/test_wam_go_ite_exec_gen',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ),
+    make_directory_path(Dir),
+    % 1. Generate the WAM Go project (lowered functions + runtime).
+    write_wam_go_project(
+        [user:gite/2, user:gneg/1, user:gseqite/3, user:gnestite/2, user:gundoite/2],
+        [module_name('iteexec'), wam_fallback(true)], Proj),
+    % 2. Copy the WAM runtime + lowered sources into a clean module. lib.go
+    %    is the separate native-strategy artifact (not the WAM path) and is
+    %    intentionally excluded.
+    atomic_list_concat(
+        ['cp ', Proj, '/*.go ', Dir, '/ && rm -f ', Dir, '/lib.go'], CpCmd),
+    shell_ok(CpCmd),
+    % 3. go.mod + the execution test.
+    write_file(Dir/'go.mod', "module iteexec\n\ngo 1.21\n"),
+    go_test_source(GoTestSrc),
+    write_file(Dir/'ite_exec_test.go', GoTestSrc),
+    % 4. Compile + run.
+    format(atom(TestCmd), 'cd ~w && go test ./... 2>&1', [Dir]),
+    process_create(path(sh), ['-c', TestCmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    ->  true
+    ;   format(user_error, "~n[go test output]~n~w~n", [OutStr]),
+        throw(go_test_failed(Status))
+    ).
+
+:- end_tests(wam_go_lowered_ite_exec).
+
+shell_ok(Cmd) :-
+    process_create(path(sh), ['-c', Cmd], [process(Pid)]),
+    process_wait(Pid, exit(0)).
+
+write_file(PathSpec, Text) :-
+    ( atom(PathSpec) -> Path = PathSpec ; PathSpec = D/F, atomic_list_concat([D, '/', F], Path) ),
+    setup_call_cleanup(open(Path, write, S), write(S, Text), close(S)).
+
+% Calls each lowered method (A-registers Regs[0..] hold the query args) and
+% asserts the boolean outcome. seqite(10,pos,small)=false and undoite(c,els)
+% =true are the discriminating cases for the bugs this fix addresses.
+go_test_source(
+"package wam
+
+import \"testing\"
+
+func callPred(setup func(vm *WamState), pred func(vm *WamState) bool) bool {
+	vm := NewWamState(nil, nil)
+	setup(vm)
+	return pred(vm)
+}
+
+func TestITELowering(t *testing.T) {
+	I := func(n int64) Value { return &Integer{Val: n} }
+	A := func(s string) Value { return internAtom(s) }
+	set := func(vals ...Value) func(vm *WamState) {
+		return func(vm *WamState) {
+			for i, v := range vals {
+				vm.Regs[i] = v
+			}
+		}
+	}
+	cases := []struct {
+		name string
+		got  bool
+		want bool
+	}{
+		{\"gite(5,pos)\", callPred(set(I(5), A(\"pos\")), (*WamState).PredGite2), true},
+		{\"gite(5,nonpos)\", callPred(set(I(5), A(\"nonpos\")), (*WamState).PredGite2), false},
+		{\"gite(-1,nonpos)\", callPred(set(I(-1), A(\"nonpos\")), (*WamState).PredGite2), true},
+		{\"gite(-1,pos)\", callPred(set(I(-1), A(\"pos\")), (*WamState).PredGite2), false},
+		{\"gneg(5)\", callPred(set(I(5)), (*WamState).PredGneg1), false},
+		{\"gneg(-1)\", callPred(set(I(-1)), (*WamState).PredGneg1), true},
+		{\"gneg(0)\", callPred(set(I(0)), (*WamState).PredGneg1), true},
+		{\"gseqite(10,pos,big)\", callPred(set(I(10), A(\"pos\"), A(\"big\")), (*WamState).PredGseqite3), true},
+		{\"gseqite(10,pos,small)\", callPred(set(I(10), A(\"pos\"), A(\"small\")), (*WamState).PredGseqite3), false},
+		{\"gseqite(3,pos,small)\", callPred(set(I(3), A(\"pos\"), A(\"small\")), (*WamState).PredGseqite3), true},
+		{\"gseqite(-1,nonpos,small)\", callPred(set(I(-1), A(\"nonpos\"), A(\"small\")), (*WamState).PredGseqite3), true},
+		{\"gnestite(20,big)\", callPred(set(I(20), A(\"big\")), (*WamState).PredGnestite2), true},
+		{\"gnestite(5,small)\", callPred(set(I(5), A(\"small\")), (*WamState).PredGnestite2), true},
+		{\"gnestite(-1,neg)\", callPred(set(I(-1), A(\"neg\")), (*WamState).PredGnestite2), true},
+		{\"gnestite(20,small)\", callPred(set(I(20), A(\"small\")), (*WamState).PredGnestite2), false},
+		{\"gundoite(c,els)\", callPred(set(A(\"c\"), A(\"els\")), (*WamState).PredGundoite2), true},
+		{\"gundoite(c,then)\", callPred(set(A(\"c\"), A(\"then\")), (*WamState).PredGundoite2), false},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf(\"%s: got %v, want %v\", c.name, c.got, c.want)
+		}
+	}
+}
+").

--- a/tests/test_wam_go_lowered_phase3.pl
+++ b/tests/test_wam_go_lowered_phase3.pl
@@ -128,8 +128,10 @@ test_has_internal_ite_pattern_detects :-
         cut_ite,
         put_constant("then_val", "A2"),
         jump("L_cont"),
+        label("L_else"),
         trust_me,
         put_constant("else_val", "A2"),
+        label("L_cont"),
         proceed
     ],
     (   has_internal_ite_pattern(Instrs)
@@ -163,8 +165,10 @@ test_ite_emits_native_if_else :-
         cut_ite,
         put_constant("then_val", "A2"),
         jump("L_cont"),
+        label("L_else"),
         trust_me,
         put_constant("else_val", "A2"),
+        label("L_cont"),
         proceed
     ],
     emit_to_string(p/2, Instrs, Code),
@@ -174,6 +178,11 @@ test_ite_emits_native_if_else :-
         sub_string(S, _, _, _, "_condOk := func() bool {"),
         sub_string(S, _, _, _, "if _condOk {"),
         sub_string(S, _, _, _, "} else {"),
+        % On condition failure the else branch must restore the register
+        % file (saved as a value copy of the fixed Regs array) and unwind
+        % the trail, so a failed binding condition leaves no stale state.
+        sub_string(S, _, _, _, "_savedRegs := vm.Regs"),
+        sub_string(S, _, _, _, "vm.Regs = _savedRegs"),
         sub_string(S, _, _, _, "vm.unwindTrailTo(_trailMark)"),
         % And the cond/then/else atoms all appear via interning.
         sub_string(S, _, _, _, "wamAtom_c_"),
@@ -192,8 +201,10 @@ test_ite_does_not_silently_drop_choice_instrs :-
         cut_ite,
         put_constant("then_val", "A2"),
         jump("L_cont"),
+        label("L_else"),
         trust_me,
         put_constant("else_val", "A2"),
+        label("L_cont"),
         proceed
     ],
     emit_to_string(p/2, Instrs, Code),

--- a/tests/test_wam_rust_lowered_ite_exec.pl
+++ b/tests/test_wam_rust_lowered_ite_exec.pl
@@ -1,0 +1,136 @@
+% test_wam_rust_lowered_ite_exec.pl
+%
+% End-to-end execution test for Rust if-then-else / negation / once
+% lowering (emit_mode(functions)).
+%
+% Generates a WAM Rust project for a set of ITE predicates with the lowered
+% emitter enabled, compiles it with the real `cargo` toolchain, and runs a
+% Rust integration test that calls each lowered function and asserts the
+% boolean result is correct. Counterpart to the Go test
+% test_wam_go_lowered_ite_exec.pl. Pins:
+%
+%   * sequential ITEs   — rseqite(10,pos,small) must be false;
+%   * nested ITEs       — rnestite/2;
+%   * negation (\+)     — rneg/1 (commits with !/0, not cut_ite);
+%   * binding condition — rundoite/2, whose condition binds a fresh var then
+%                         fails; Rust's get_reg derefs through the binding
+%                         table, so unwind_trail_to alone restores it.
+%
+% Before this fix the lowered emitter no-op'd try_me_else/cut_ite/jump/
+% trust_me, emitting the condition + then + else as one flat conjunction
+% (unifying the output with both branch values), so the function always
+% failed. Skipped automatically when `cargo` is not on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_rust_target').
+
+:- dynamic user:rite/2.
+:- dynamic user:rneg/1.
+:- dynamic user:rseqite/3.
+:- dynamic user:rnestite/2.
+:- dynamic user:rundoite/2.
+
+user:rite(X, Y)       :- ( X > 0 -> Y = pos ; Y = nonpos ).
+user:rneg(X)          :- \+ X > 0.
+user:rseqite(X, Y, Z) :- ( X > 0 -> Y = pos ; Y = nonpos ),
+                         ( X > 5 -> Z = big ; Z = small ).
+user:rnestite(X, Y)   :- ( X > 0 -> ( X > 10 -> Y = big ; Y = small ) ; Y = neg ).
+user:rundoite(X, R)   :- ( (Y = a, Y = b) -> R = then ; R = els ), X = Y.
+
+cargo_available :-
+    catch(
+        ( process_create(path(cargo), ['--version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          process_wait(Pid, exit(0)) ),
+        _, fail).
+
+:- begin_tests(wam_rust_lowered_ite_exec, [condition(cargo_available)]).
+
+test(ite_exec_parity) :-
+    Dir = 'output/test_wam_rust_ite_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    % 1. Generate the WAM Rust project with the lowered emitter enabled.
+    write_wam_rust_project(
+        [user:rite/2, user:rneg/1, user:rseqite/3, user:rnestite/2, user:rundoite/2],
+        [module_name('iterust'), wam_fallback(true), emit_mode(functions)], Dir),
+    % 2. Drop the bench bin (a separate generated artifact unrelated to the
+    %    lowered library, which does not compile for these toy predicates)
+    %    so cargo only has to build the lib + our integration test.
+    atomic_list_concat(
+        ['cd ', Dir,
+         ' && sed -i ''/^\\[\\[bin\\]\\]/,/^path = "src\\/main.rs"/d'' Cargo.toml',
+         ' && rm -f src/main.rs'], FixCmd),
+    shell_ok(FixCmd),
+    % 3. Integration test source.
+    atomic_list_concat([Dir, '/tests'], TestsDir),
+    make_directory_path(TestsDir),
+    atomic_list_concat([Dir, '/tests/ite_exec.rs'], TestPath),
+    rust_test_source(RustSrc),
+    write_file(TestPath, RustSrc),
+    % 4. Compile + run only this test target.
+    format(atom(TestCmd), 'cd ~w && cargo test --test ite_exec 2>&1', [Dir]),
+    process_create(path(sh), ['-c', TestCmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    ->  true
+    ;   format(user_error, "~n[cargo test output]~n~w~n", [OutStr]),
+        throw(rust_test_failed(Status))
+    ).
+
+:- end_tests(wam_rust_lowered_ite_exec).
+
+shell_ok(Cmd) :-
+    process_create(path(sh), ['-c', Cmd], [process(Pid)]),
+    process_wait(Pid, exit(0)).
+
+write_file(Path, Text) :-
+    setup_call_cleanup(open(Path, write, S), write(S, Text), close(S)).
+
+% Calls each lowered function with the query arguments preloaded into the
+% A-registers and asserts the boolean outcome. rseqite(10,pos,small)=false
+% and rundoite(c,els)=true are the discriminating cases.
+rust_test_source(
+"use wam_lib::state::WamState;
+use wam_lib::value::Value;
+use wam_lib::{lowered_rite_2, lowered_rneg_1, lowered_rseqite_3, lowered_rnestite_2, lowered_rundoite_2};
+use std::collections::HashMap;
+
+fn call(setup: &dyn Fn(&mut WamState), f: fn(&mut WamState) -> bool) -> bool {
+    let mut vm = WamState::new(vec![], HashMap::new());
+    setup(&mut vm);
+    f(&mut vm)
+}
+fn i(n: i64) -> Value { Value::Integer(n) }
+fn a(s: &str) -> Value { Value::Atom(s.to_string()) }
+
+#[test]
+fn ite_parity() {
+    let cases: Vec<(&str, bool, bool)> = vec![
+        (\"rite(5,pos)\",    call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(5));  vm.set_reg(\"A2\", a(\"pos\")); },    lowered_rite_2), true),
+        (\"rite(5,nonpos)\", call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(5));  vm.set_reg(\"A2\", a(\"nonpos\")); }, lowered_rite_2), false),
+        (\"rite(-1,nonpos)\",call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(-1)); vm.set_reg(\"A2\", a(\"nonpos\")); }, lowered_rite_2), true),
+        (\"rite(-1,pos)\",   call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(-1)); vm.set_reg(\"A2\", a(\"pos\")); },    lowered_rite_2), false),
+        (\"rneg(5)\",  call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(5)); },  lowered_rneg_1), false),
+        (\"rneg(-1)\", call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(-1)); }, lowered_rneg_1), true),
+        (\"rneg(0)\",  call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(0)); },  lowered_rneg_1), true),
+        (\"rseqite(10,pos,big)\",   call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(10)); vm.set_reg(\"A2\", a(\"pos\")); vm.set_reg(\"A3\", a(\"big\")); },   lowered_rseqite_3), true),
+        (\"rseqite(10,pos,small)\", call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(10)); vm.set_reg(\"A2\", a(\"pos\")); vm.set_reg(\"A3\", a(\"small\")); }, lowered_rseqite_3), false),
+        (\"rseqite(3,pos,small)\",  call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(3));  vm.set_reg(\"A2\", a(\"pos\")); vm.set_reg(\"A3\", a(\"small\")); }, lowered_rseqite_3), true),
+        (\"rseqite(-1,nonpos,small)\", call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(-1)); vm.set_reg(\"A2\", a(\"nonpos\")); vm.set_reg(\"A3\", a(\"small\")); }, lowered_rseqite_3), true),
+        (\"rnestite(20,big)\",   call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(20)); vm.set_reg(\"A2\", a(\"big\")); },   lowered_rnestite_2), true),
+        (\"rnestite(5,small)\",  call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(5));  vm.set_reg(\"A2\", a(\"small\")); }, lowered_rnestite_2), true),
+        (\"rnestite(-1,neg)\",   call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(-1)); vm.set_reg(\"A2\", a(\"neg\")); },   lowered_rnestite_2), true),
+        (\"rnestite(20,small)\", call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(20)); vm.set_reg(\"A2\", a(\"small\")); }, lowered_rnestite_2), false),
+        (\"rundoite(c,els)\",  call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"c\")); vm.set_reg(\"A2\", a(\"els\")); },  lowered_rundoite_2), true),
+        (\"rundoite(c,then)\", call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"c\")); vm.set_reg(\"A2\", a(\"then\")); }, lowered_rundoite_2), false),
+    ];
+    let mut failures = Vec::new();
+    for (name, got, want) in cases {
+        if got != want { failures.push(format!(\"{}: got {}, want {}\", name, got, want)); }
+    }
+    assert!(failures.is_empty(), \"failures: {:?}\", failures);
+}
+").


### PR DESCRIPTION
## Summary

Brings **if-then-else / negation / `once`** lowering to the Go and Rust hybrid WAM backends, matching the Scala emitter (#2793). Both backends had latent bugs in this area that were only ever checked *structurally* — never compiled and run — so this PR fixes them and adds real **execution** tests (gated on the `go` / `cargo` toolchains).

The fix is the same proven label-based structurer in all three backends: parse keeping `label()` markers, fold each `try_me_else / <cond> / commit / <then> / jump / trust_me / <else>` block into an `ite(Cond,Then,Else)` term (commit = `cut_ite` for `->`, the `!/0` builtin for `\+`), and emit native if/else with trail save/undo. Sequential blocks become siblings; nested blocks recurse; multi-clause / unstructurable predicates decline and fall back.

## Go — fixes a shipped correctness bug

Go *had* ITE lowering, but split the block with a heuristic ("peel the trailing epilogue") because labels were dropped at parse time. That heuristic:
- **mislowered sequential ITEs** — the 2nd block was emitted *inside* the 1st's `else`, so when the 1st condition took the then-branch the 2nd ITE was skipped entirely. `seqite(10,pos,_)` wrongly succeeded for **any** third argument — a silent wrong-success in already-merged code.
- broke **nested** ITEs (split at the inner `jump`), and never detected **negation** (`\+` commits with `!/0`, not `cut_ite`).

Replaced with the label-based structurer. Go's `getReg` reads the register array directly (not through bindings), so on condition failure the else branch restores the full register file (a value copy of the fixed `Regs` array), unwinds the trail, and re-runs the condition's `put_variable`s to reset fresh variables.

## Rust — adds the capability (was a no-op)

Under `emit_mode(functions)`, Rust listed the markers as "supported" but emitted them as **no-ops**, dropping the structure entirely and emitting cond + then + else as one flat conjunction (unifying the output with *both* branch values) → the lowered function **always failed**. Ported the structurer. Rust's `get_reg` derefs through the binding table, so trail save/undo alone suffices (no register snapshot); added `WamState::unwind_trail_to(mark)` to the runtime.

## Verification

New gated execution tests compile with the real toolchains and assert correct boolean results for 17 cases each — arithmetic-guard ITE, negation, **sequential** (incl. the `seqite(10,pos,small)=false` discriminator that the old Go heuristic got wrong), **nested**, and a **binding condition with trail undo** (`undoite(c,els)=true`):
- `tests/test_wam_go_lowered_ite_exec.pl`
- `tests/test_wam_rust_lowered_ite_exec.pl`

Regression (all green): Go phase1/2/3, go generator, go builtins; Rust native-lowering (18) and `wam_rust_target`. Go phase3 structural fixtures updated for label-bearing input + the register-restore emit.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_