### PR TITLE
fix(rust,go): generated WAM projects compile fully (native-strategy codegen)

### DIFF
--- a/docs/GO_TARGET.md
+++ b/docs/GO_TARGET.md
@@ -66,6 +66,59 @@ The Go target generates standalone Go executables from Prolog predicates, provid
 - **Cost-Based Optimization**: Using statistics for join ordering
 - **Custom Go functions**: User-defined Go helpers
 
+### Known Limitations
+
+#### Native control-construct codegen (deferred — routed to WAM)
+
+In **WAM Go projects** (`write_wam_go_project/3`), predicates whose clause
+bodies use control constructs are **not** compiled by the native Go
+strategy. They are routed to the WAM-lowered path instead, which handles
+them correctly. The gate lives in `go_pred_has_control_constructs/1`
+(`src/unifyweaver/targets/wam_go_target.pl`) and currently blocks the
+native strategy for:
+
+- **If-then-else** `( Cond -> Then ; Else )`
+- **Disjunction** `( A ; B )`
+- **Negation** `\+ Goal` (and `not/1`)
+- **once/1**
+
+**Why it's blocked.** The current native templates emit code that does not
+compile for these constructs:
+
+- `( X > 0 -> ... )` was compiled to `if arg1 > 0 { ... }` where `arg1` is
+  typed `interface{}` — Go cannot apply `>` to an `interface{}`, so it does
+  not type-check.
+- `\+ Goal` was emitted as an *unwrapped* stdin-pipeline fragment (a
+  `bufio.Scanner` loop at file scope with no enclosing function), a syntax
+  error.
+
+Routing these to the WAM-lowered path keeps generated projects compiling
+(`go build ./...`) and produces correct results today, verified end-to-end
+by `tests/test_wam_go_lowered_ite_exec.pl`.
+
+**What fixing the native templates could add (deferred, not abandoned).** A
+correct native implementation could provide functionality the WAM path
+does not:
+
+1. **Idiomatic, VM-free Go for control-flow predicates.** Native output is
+   a plain Go function rather than WAM register-machine instructions run by
+   the interpreter — potentially faster and easier to read/embed, the same
+   motivation as native fact/aggregation compilation. This requires real
+   type handling (e.g. `arg1.(int)` assertions, or threading static types
+   through codegen instead of `interface{}` everywhere) so comparisons and
+   arithmetic type-check.
+2. **Streaming negation / filter pipelines.** The `\+` template is shaped
+   as a *stdin records → filter → stdout* stream — the Go target's core
+   record-processing model. Finishing it would let `\+`-style filtering run
+   as a streaming Unix-pipe stage, which the WAM register machine does not
+   currently express. This is a deliberate feature (define the streaming
+   semantics and wrap the fragment in a proper function / `main` stage),
+   not just a template patch.
+
+Until then, control-flow predicates compile via the WAM path in Go
+projects, and the same predicates also get fast direct-function versions in
+`lowered.go` via the lowered emitter.
+
 ---
 
 ## Quick Start

--- a/src/unifyweaver/targets/go_target.pl
+++ b/src/unifyweaver/targets/go_target.pl
@@ -21377,23 +21377,31 @@ compile_clause_parallel_to_go(PredSpec, Clauses, Code) :-
 %% compile_clause_parallel_branches(+PredSpec, +Clauses, +Idx, -BranchCodes)
 compile_clause_parallel_branches(_, [], _, []).
 compile_clause_parallel_branches(PredSpec, [Head-Body|Rest], Idx, [BranchCode|RestCodes]) :-
-    (   native_go_clause(PredSpec, Head, Body, Condition, ClauseCode)
-    ->  (   Condition == "true"
+    (   native_go_clause(PredSpec, Head, Body, Condition, ClauseCode0)
+    ->  % native_go_clause emits `return <expr>`, which is valid in a plain
+        % sequential function but not inside this goroutine (whose closure
+        % returns nothing). Run the clause in an inner closure returning
+        % (value, matched); on a match, send the value over the channel.
+        transform_returns_to_tuple(ClauseCode0, ClauseCode),
+        (   Condition == "true"
         ->  CondBlock = ClauseCode
         ;   format(string(CondBlock),
-'\t\tif ~w {
+'\t\t\tif ~w {
 ~w
-\t\t}', [Condition, ClauseCode])
+\t\t\t}', [Condition, ClauseCode])
         ),
         format(string(BranchCode),
 '\tgo func() { // clause ~w
 \t\tdefer wg.Done()
 \t\tdefer func() { recover() }() // prevent panics from crashing program
+\t\tif val, ok := func() (interface{}, bool) {
 ~w
-\t\tselect {
-\t\tcase <-ctx.Done():
-\t\t\treturn // cancelled — another clause already produced a result
-\t\tcase results <- result:
+\t\t\treturn nil, false
+\t\t}(); ok {
+\t\t\tselect {
+\t\t\tcase <-ctx.Done(): // cancelled — another clause already produced a result
+\t\t\tcase results <- val:
+\t\t\t}
 \t\t}
 \t}()', [Idx, CondBlock])
     ;   % Clause didn't compile — skip with comment
@@ -21404,3 +21412,22 @@ compile_clause_parallel_branches(PredSpec, [Head-Body|Rest], Idx, [BranchCode|Re
     ),
     NextIdx is Idx + 1,
     compile_clause_parallel_branches(PredSpec, Rest, NextIdx, RestCodes).
+
+%% transform_returns_to_tuple(+Code, -Out)
+%  Rewrite each `return <expr>` statement to `return <expr>, true` so a
+%  clause body produced by native_go_clause can be reused inside an inner
+%  closure of type func() (interface{}, bool). Only lines whose sole
+%  leading content is `return ` are rewritten (a string value containing
+%  "return " is left untouched because the leading text isn't whitespace).
+transform_returns_to_tuple(Code, Out) :-
+    split_string(Code, "\n", "", Lines),
+    maplist(transform_return_line, Lines, OutLines),
+    atomic_list_concat(OutLines, "\n", Out).
+
+transform_return_line(Line, Out) :-
+    (   sub_string(Line, Before, _, _, "return "),
+        sub_string(Line, 0, Before, _, Prefix),
+        split_string(Prefix, "", " \t", [""])   % only whitespace before `return`
+    ->  string_concat(Line, ", true", Out)
+    ;   Out = Line
+    ).

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -238,6 +238,28 @@ go_strip_line_comments(Code, Stripped) :-
 go_strip_line_comment(Line, Out) :-
     ( sub_string(Line, B, _, _, "//") -> sub_string(Line, 0, B, _, Out) ; Out = Line ).
 
+%% go_pred_has_control_constructs(+Module:Pred/Arity)
+%  True if any clause body uses ->, ; (disjunction / if-then-else), \+, or
+%  once. The native Go strategy mis-compiles these (interface{} comparisons
+%  for ->, an unwrapped stdin-pipeline fragment for \+); the WAM-lowered
+%  path handles them correctly, so such predicates are routed to WAM.
+%  See docs/GO_TARGET.md "Native control-construct codegen (deferred)" for
+%  what is blocked and what a proper native implementation could add.
+go_pred_has_control_constructs(Module:Pred/Arity) :-
+    functor(Head, Pred, Arity),
+    clause(Module:Head, Body),
+    go_body_has_control(Body),
+    !.
+
+go_body_has_control(G) :- var(G), !, fail.
+go_body_has_control((_ -> _)) :- !.
+go_body_has_control((_ ; _)) :- !.
+go_body_has_control(\+ _) :- !.
+go_body_has_control(not(_)) :- !.
+go_body_has_control(once(_)) :- !.
+go_body_has_control((A , B)) :- !, ( go_body_has_control(A) -> true ; go_body_has_control(B) ).
+go_body_has_control(_) :- fail.
+
 %% go_std_import(+UsageMarker, -ImportPath)
 go_std_import("fmt.",     "fmt").
 go_std_import("context.", "context").
@@ -375,7 +397,13 @@ classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
     ->  compile_wam_predicate_to_go(Module:Pred/Arity, WamCode, Options, PredCode),
         format(user_error, '  ~w/~w: WAM fallback (foreign)~n', [Pred, Arity]),
         Entry = classified(Module, Pred, Arity, wam_foreign, PredCode)
-    ;   catch(
+    ;   % The native Go strategy mis-compiles control constructs: (C->T;E)
+        % becomes an `interface{} > 0` comparison (a type error) and \+ an
+        % unwrapped stdin-pipeline fragment. These are handled correctly by
+        % the WAM-lowered path, so decline native here and fall through to
+        % the WAM fallback branch below.
+        \+ go_pred_has_control_constructs(Module:Pred/Arity),
+        catch(
             go_target:compile_predicate_to_go(Module:Pred/Arity,
                 [include_package(false)|Options], PredCode),
             _, fail)

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -102,11 +102,16 @@ write_wam_go_project(Predicates, Options, ProjectDir) :-
     % can reference the same vars from anywhere in `package main`.
     init_atom_intern_table_go,
     compile_predicates_for_project(Predicates, Options, PredicatesCode),
+    % lib.go has no import block of its own, but the native-strategy
+    % predicate bodies reference std packages (fmt/context/sync/bufio/os/…).
+    % Emit exactly the imports the generated code actually uses — Go errors
+    % on both missing and unused imports.
+    go_lib_import_block(PredicatesCode, ImportBlock),
     format(atom(LibContent),
 'package ~w
 
-~w
-', [PackageName, PredicatesCode]),
+~w~w
+', [PackageName, ImportBlock, PredicatesCode]),
     directory_file_path(ProjectDir, 'lib.go', LibPath),
     write_file(LibPath, LibContent),
 
@@ -206,6 +211,42 @@ func main() {
     ),
 
     format('WAM Go project created at: ~w~n', [ProjectDir]).
+
+%% go_lib_import_block(+Code, -ImportBlock)
+%  Emit a Go `import (...)` block listing exactly the std packages the
+%  generated native predicate bodies reference. Go rejects both missing
+%  and unused imports, so we detect actual usage ("<pkg>.") in the code
+%  with line comments stripped (to avoid false positives like
+%  "// fmt.Sprintf style"). Empty block when nothing is used.
+go_lib_import_block(Code, ImportBlock) :-
+    go_strip_line_comments(Code, Stripped),
+    findall(Path,
+        ( go_std_import(Marker, Path), sub_string(Stripped, _, _, _, Marker) ),
+        Paths0),
+    sort(Paths0, Paths),
+    (   Paths == []
+    ->  ImportBlock = ""
+    ;   maplist([P, L]>>format(string(L), '\t"~w"', [P]), Paths, Ls),
+        atomic_list_concat(Ls, "\n", Inner),
+        format(string(ImportBlock), 'import (\n~w\n)\n\n', [Inner])
+    ).
+
+go_strip_line_comments(Code, Stripped) :-
+    split_string(Code, "\n", "", Lines),
+    maplist(go_strip_line_comment, Lines, SLines),
+    atomic_list_concat(SLines, "\n", Stripped).
+go_strip_line_comment(Line, Out) :-
+    ( sub_string(Line, B, _, _, "//") -> sub_string(Line, 0, B, _, Out) ; Out = Line ).
+
+%% go_std_import(+UsageMarker, -ImportPath)
+go_std_import("fmt.",     "fmt").
+go_std_import("context.", "context").
+go_std_import("sync.",    "sync").
+go_std_import("bufio.",   "bufio").
+go_std_import("os.",      "os").
+go_std_import("strings.", "strings").
+go_std_import("strconv.", "strconv").
+go_std_import("sort.",    "sort").
 
 %% compile_lowered_predicates(+Predicates, +Options, -Code)
 %  Attempts lowered emission for each predicate. Lowerable deterministic

--- a/templates/targets/rust_wam/main.rs.mustache
+++ b/templates/targets/rust_wam/main.rs.mustache
@@ -143,14 +143,16 @@ fn main() {
         let root_id = vm.intern_atom(&root);
         for cat in &seed_cats {
             let cat_id = vm.intern_atom(cat);
-            let visited_ids = vec![cat_id];
+            let mut visited_ids = vec![cat_id];
             let mut hops: Vec<i64> = Vec::new();
+            let acc = vm.resolve_edge_accessor("category_parent");
             vm.collect_native_category_ancestor_hops(
                 cat_id,
                 root_id,
-                &visited_ids,
+                &mut visited_ids,
                 max_depth_limit,
-                "category_parent",
+                &acc,
+                0,
                 &mut hops,
             );
             let weight_sum: f64 = hops.iter()

--- a/tests/test_wam_go_lowered_ite_exec.pl
+++ b/tests/test_wam_go_lowered_ite_exec.pl
@@ -56,9 +56,24 @@ test(ite_exec_parity) :-
     write_wam_go_project(
         [user:gite/2, user:gneg/1, user:gseqite/3, user:gnestite/2, user:gundoite/2],
         [module_name('iteexec'), wam_fallback(true)], Proj),
-    % 2. Copy the WAM runtime + lowered sources into a clean module. lib.go
-    %    is the separate native-strategy artifact (not the WAM path) and is
-    %    intentionally excluded.
+    % 1b. The whole generated project must compile. This guards lib.go's
+    %     computed imports, the clause-parallel goroutine template, and the
+    %     routing of -> / \+ predicates away from the broken native strategy
+    %     to WAM (go_pred_has_control_constructs/1).
+    format(atom(BuildCmd), 'cd ~w && go build ./... 2>&1', [Proj]),
+    process_create(path(sh), ['-c', BuildCmd],
+                   [stdout(pipe(BOut)), stderr(std), process(BPid)]),
+    read_string(BOut, _, BOutStr), close(BOut),
+    process_wait(BPid, BStatus),
+    ( BStatus == exit(0)
+    ->  true
+    ;   format(user_error, "~n[go build ./... output]~n~w~n", [BOutStr]),
+        throw(go_project_build_failed(BStatus))
+    ),
+    % 2. Copy the WAM runtime + lowered sources into a clean module to call
+    %    the lowered functions directly. lib.go is excluded only because the
+    %    direct-call harness needs no WAM entry points, not because it is
+    %    broken (1b already proved the whole project builds).
     atomic_list_concat(
         ['cp ', Proj, '/*.go ', Dir, '/ && rm -f ', Dir, '/lib.go'], CpCmd),
     shell_ok(CpCmd),

--- a/tests/test_wam_rust_lowered_ite_exec.pl
+++ b/tests/test_wam_rust_lowered_ite_exec.pl
@@ -54,21 +54,15 @@ test(ite_exec_parity) :-
     write_wam_rust_project(
         [user:rite/2, user:rneg/1, user:rseqite/3, user:rnestite/2, user:rundoite/2],
         [module_name('iterust'), wam_fallback(true), emit_mode(functions)], Dir),
-    % 2. Drop the bench bin (a separate generated artifact unrelated to the
-    %    lowered library, which does not compile for these toy predicates)
-    %    so cargo only has to build the lib + our integration test.
-    atomic_list_concat(
-        ['cd ', Dir,
-         ' && sed -i ''/^\\[\\[bin\\]\\]/,/^path = "src\\/main.rs"/d'' Cargo.toml',
-         ' && rm -f src/main.rs'], FixCmd),
-    shell_ok(FixCmd),
-    % 3. Integration test source.
+    % 2. Integration test source. `cargo test` also builds the bench bin
+    %    (src/main.rs), so this run additionally guards that the whole
+    %    generated project compiles, not just the lowered library.
     atomic_list_concat([Dir, '/tests'], TestsDir),
     make_directory_path(TestsDir),
     atomic_list_concat([Dir, '/tests/ite_exec.rs'], TestPath),
     rust_test_source(RustSrc),
     write_file(TestPath, RustSrc),
-    % 4. Compile + run only this test target.
+    % 3. Compile (lib + bench bin + test) and run the integration test.
     format(atom(TestCmd), 'cd ~w && cargo test --test ite_exec 2>&1', [Dir]),
     process_create(path(sh), ['-c', TestCmd],
                    [stdout(pipe(Out)), stderr(std), process(Pid)]),
@@ -81,10 +75,6 @@ test(ite_exec_parity) :-
     ).
 
 :- end_tests(wam_rust_lowered_ite_exec).
-
-shell_ok(Cmd) :-
-    process_create(path(sh), ['-c', Cmd], [process(Pid)]),
-    process_wait(Pid, exit(0)).
 
 write_file(Path, Text) :-
     setup_call_cleanup(open(Path, write, S), write(S, Text), close(S)).


### PR DESCRIPTION
## Summary

Follow-up to the ITE-lowering work (#2796). Generated WAM projects didn't compile **as a whole** for *any* input — even a trivial `parent/2` — because the native-strategy code (separate from the WAM path) was broken in both backends. Only `cargo build --lib` / building individual files worked, which is why the suites never caught it. This PR makes the full `cargo build` / `go build ./...` pass.

## Rust — bench `main.rs` arg drift (universal)

`templates/targets/rust_wam/main.rs.mustache` called `collect_native_category_ancestor_hops` with **6** args where the method takes **7**, and passed a `&str` where an `&EdgeAccessor` is required. Fixed to mirror the working internal caller (`wam_rust_target.pl:1476`): `let mut visited_ids`, `let acc = vm.resolve_edge_accessor("category_parent")`, and all seven args. The call is under `if has_ca_foreign`, so it stays dead at runtime for non-category projects but now type-checks.

## Go — `lib.go` imports + clause-parallel + control-construct gating (universal)

1. **No import block.** `lib.go` was emitted with no imports, yet native bodies use `context`/`sync`/`fmt`/`bufio`/`os`. Now computes the import block from packages the generated code actually references (comments stripped; Go rejects both missing *and* unused imports).
2. **Clause-parallel goroutine result flow.** The template reused `native_go_clause`'s `return <expr>` inside a `go func(){}` whose closure returns nothing, and sent an undeclared `result`. Now each clause runs in an inner `func() (interface{}, bool)` (`transform_returns_to_tuple` rewrites `return X` → `return X, true`) and sends the value over the channel. Fact predicates (`parent/2`) build cleanly.
3. **Control-construct gating.** The native strategy mis-compiles `( C -> T ; E )` (as `interface{} > 0`, a type error) and `\+` (an unwrapped stdin-pipeline fragment). `go_pred_has_control_constructs/1` routes predicates using `->`, `;`, `\+`/`not`, or `once` to the WAM-lowered path (which already handles them correctly), so the ITE project's full `go build ./...` passes.

### Documented, not silent

Per review, `docs/GO_TARGET.md` gains a **Known Limitations** section spelling out exactly what native codegen is gated and what a correct native implementation could add later — idiomatic VM-free Go for control-flow predicates, and streaming negation/filter pipelines from the stdin-stream `\+` template. The gate predicate's comment links back to it.

## Verification

- Trivial `parent/2` and the ITE project both `cargo build` / `go build ./...` cleanly.
- Both ITE exec tests now build the **whole** generated project (Rust drops its bench workaround; Go adds a `go build ./...` assertion) in addition to running the 17-case correctness checks.
- Green: Go generator / phase3 / builtins / ite-exec; Rust native-lowering (18) / `wam_rust_target` / ite-exec.

## Not included

Actually *rewriting* the native `->`/`\+` Go templates (vs. gating them) — deferred and documented as above.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw