### PR TITLE
WAM F# target: CSR-backed demand BFS (Stage 3a)

### DIFF
--- a/examples/benchmark/generate_wam_fsharp_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_fsharp_optimized_benchmark.pl
@@ -81,7 +81,14 @@ generate(VariantAtom, OutputDir) :-
     %         root via category_child).  The runtime opens <factsDir>/lmdb.
     (   sub_atom(VariantAtom, 0, _, _, lmdb)
     ->  variant_materialisation(VariantAtom, Materialisation),
-        LmdbOpts = [lmdb_path('lmdb'), lmdb_materialisation(Materialisation)]
+        % `*_csr` variants build the demand set from a category_child CSR
+        % artifact at <factsDir>/csr (binary-searched, int-native) instead of
+        % the LMDB cursor; csr_path triggers has_csr + CsrReader.fs compilation.
+        (   sub_atom(VariantAtom, _, _, 0, csr)
+        ->  CsrOpts = [csr_path('csr')]
+        ;   CsrOpts = []
+        ),
+        append([lmdb_path('lmdb'), lmdb_materialisation(Materialisation)], CsrOpts, LmdbOpts)
     ;   LmdbOpts = []
     ),
     Options = [module_name('wam-fsharp-optimized-bench'),
@@ -120,12 +127,18 @@ parse_variant(lmdb_cached, [
     branch_pruning(false),
     min_closure(false)
 ]).
+parse_variant(lmdb_eager_csr, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false)
+]).
 
 %% variant_materialisation(+Variant, -Mode)
-variant_materialisation(lmdb_eager,  eager).
-variant_materialisation(lmdb_lazy,   lazy).
-variant_materialisation(lmdb_cached, cached).
-variant_materialisation(_,           eager).
+variant_materialisation(lmdb_eager,     eager).
+variant_materialisation(lmdb_lazy,      lazy).
+variant_materialisation(lmdb_cached,    cached).
+variant_materialisation(lmdb_eager_csr, eager).
+variant_materialisation(_,              eager).
 
 %% collect_wam_predicates(+Variant, -Predicates)
 %  Collect the predicate list to compile through WAM, including
@@ -145,6 +158,10 @@ collect_wam_predicates(lmdb_lazy, [
     user:category_ancestor/4
 ]).
 collect_wam_predicates(lmdb_cached, [
+    user:max_depth/1,
+    user:category_ancestor/4
+]).
+collect_wam_predicates(lmdb_eager_csr, [
     user:max_depth/1,
     user:category_ancestor/4
 ]).

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -5083,14 +5083,17 @@ generate_lookup_sources_expr_fs(Options, Expr) :-
 lookup_source_entry_fs(Options, Entry) :-
     option(csr_path(CsrPath), Options),
     option(csr_relation(Rel), Options, category_child),
+    % Resolve the CSR artifact dir against factsDir at runtime (a relative
+    % csr_path like "csr" would otherwise be opened against the process CWD,
+    % not the fixture dir). Path.Combine leaves an absolute csr_path unchanged.
     format(atom(Entry),
-        '("~w", CsrReader.CsrLookupSource("~w", "~w") :> ILookupSource)',
+        '("~w", CsrReader.CsrLookupSource(System.IO.Path.Combine(factsDir, "~w"), "~w") :> ILookupSource)',
         [Rel, CsrPath, Rel]).
 
 lookup_source_entry_fs(Options, Entry) :-
     option(csr_parent_path(CsrParentPath), Options),
     format(atom(Entry),
-        '("category_parent", CsrReader.CsrLookupSource("~w", "category_parent") :> ILookupSource)',
+        '("category_parent", CsrReader.CsrLookupSource(System.IO.Path.Combine(factsDir, "~w"), "category_parent") :> ILookupSource)',
         [CsrParentPath]).
 
 %% generate_fsproj(+ModName, +Options, -Code)

--- a/templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache
+++ b/templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache
@@ -139,6 +139,23 @@ let loadCategoryChild (env: LightningEnvironment) : Map<int, int list> =
 /// (no full materialisation of the child relation).  Bounded by `maxDepth`
 /// to match the kernel's depth bound; pass Int32.MaxValue for an unbounded
 /// (always-safe, never-over-prunes) demand set.
+/// Generic demand-set BFS over any `childrenOf` closure (int -> int list),
+/// unbounded.  Lets the demand set be built from any reverse-edge source --
+/// the LMDB category_child cursor OR a CSR `category_child` artifact's
+/// ILookupSource -- without this module depending on the CSR module (which is
+/// compiled after it). Used by the F# CSR mode.
+let reachableToRootVia (childrenOf: int -> int list) (root: int) : Set<int> =
+    let visited = System.Collections.Generic.HashSet<int>()
+    visited.Add(root) |> ignore
+    let mutable frontier = [root]
+    while not (List.isEmpty frontier) do
+        let next = System.Collections.Generic.List<int>()
+        for node in frontier do
+            for c in childrenOf node do
+                if visited.Add(c) then next.Add(c)
+        frontier <- List.ofSeq next
+    Set.ofSeq visited
+
 let reachableToRoot (env: LightningEnvironment) (root: int) (maxDepth: int) : Set<int> =
     use tx = env.BeginTransaction(TransactionBeginFlags.ReadOnly)
     let db = tx.OpenDatabase("category_child", new DatabaseConfiguration(Flags = DatabaseOpenFlags.DuplicatesSort))

--- a/templates/targets/fsharp_wam/program.fs.mustache
+++ b/templates/targets/fsharp_wam/program.fs.mustache
@@ -166,6 +166,23 @@ let main argv =
 
 {{match materialisation}}
 {{case eager}}
+{{#has_csr}}
+    // Eager + CSR demand BFS: build the demand set by walking DOWN
+    // category_child via the compact binary-searched CSR artifact (no LMDB
+    // cursor for the down-walk), then materialise the demand-pruned
+    // category_parent map from LMDB. CSR is keyed by raw page ids (sorted
+    // index), so this stays int-native -- no s2i indirection.
+    let csrChild =
+        CsrReader.CsrLookupSource(System.IO.Path.Combine(factsDir, "csr"), "category_child")
+        :> ILookupSource
+    let demandSet = reachableToRootVia (fun k -> csrChild.Lookup k) rootInt
+    let parentsDict = loadCategoryParentDemandDict lmdbEnv demandSet
+    let lmdbLookupFn (k: int) : int list =
+        match parentsDict.TryGetValue k with
+        | true, v -> v
+        | _ -> []
+{{/has_csr}}
+{{^has_csr}}
     // Eager (single LMDB scan): read category_parent ONCE, build the reverse
     // (= category_child) in memory, BFS the demand set from it, and prune the
     // parent Dictionary to demand-set edges -- one cursor pass instead of two.
@@ -177,6 +194,7 @@ let main argv =
         match parentsDict.TryGetValue k with
         | true, v -> v
         | _ -> []
+{{/has_csr}}
 {{case lazy}}
     // Lazy: NO parent materialisation.  Only the demand set is built (a cursor
     // BFS down category_child); each kernel lookup opens a short-lived cursor


### PR DESCRIPTION
  Integrates the existing F# `CsrReader` (a `category_child` reverse-index CSR
  artifact from `build_reverse_csr_artifact.py`) into the int-native LMDB-eager
  path: the demand set is built by walking DOWN `category_child` via the compact
  binary-searched CSR instead of an LMDB cursor, then the kernel's
  `category_parent` map is materialised from LMDB (demand-pruned). CSR is keyed by
  raw page ids (sorted index, binary search) — no dense remap, no `s2i` hazard.

  - **`lmdb_fact_source.fs`** — `reachableToRootVia` (generic demand BFS over any
    `int -> int list` closure; plain closure so this module needs no dependency on
    the later-compiled `CsrReader`).
  - **`program.fs`** eager case — `{{#has_csr}}` builds the demand set via
    `reachableToRootVia(csrChild.Lookup)` + `loadCategoryParentDemandDict`;
    `{{^has_csr}}` keeps the single-scan loader.
  - **`generate_wam_fsharp_optimized_benchmark.pl`** — `lmdb_eager_csr` variant
    (`csr_path('csr')` → `has_csr` + `CsrReader.fs` compilation; reads
    `<factsDir>/csr`).
  - **`wam_fsharp_target.pl`** — `lookup_source_entry_fs` now resolves the CSR
    artifact dir against `factsDir` at runtime (`System.IO.Path.Combine`); a
    relative `csr_path` was being opened against the process CWD, crashing the
    eager `WcLookupSources` constructor.

  Validated: tiny int-native fixture `demand_set=4 solutions=3`;
  `simplewiki_articles` `demand_set=14680 solutions=970` (correct), load ~325 ms /
  query ~4 ms (cold). At this scale CSR demand-BFS load is ≈/slightly slower than
  the single-scan eager (~255 ms) since it's two passes (CSR down + LMDB parent)
  vs one; CSR's win is the forward-`category_parent`-CSR kernel path (Stage 3b,
  needs the builder parameterized to group-by-key). All F# target tests pass.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)