### PR TITLE
Calibrate WAM-C candidate-root filtering

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -1,30 +1,21 @@
 # WAM C Target - Status And Next Steps
 
-Status date: 2026-06-02
+Status date: 2026-06-05
 
 Latest branch verification:
 
-- `investigate/wam-c-child-search-scale-ceiling` based on `main` at `a05c8fa3`
-  (`Merge pull request #2707 from
-  s243a/investigate/wam-c-root-distance-cache`)
-- `python3 -m py_compile examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py tests/test_wam_c_child_search_runtime_sweep.py`
-- `python3 -m py_compile examples/benchmark/benchmark_effective_distance_matrix.py tests/test_benchmark_target_matrix.py`
-- `python3 -m py_compile examples/benchmark/benchmark_wam_c_bidirectional_kernel.py tests/test_wam_c_bidirectional_kernel_benchmark.py`
-- `python3 tests/test_wam_c_child_search_runtime_sweep.py`
-- `python3 tests/test_benchmark_target_matrix.py`
-- `python3 tests/test_wam_c_bidirectional_kernel_benchmark.py`
-- `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --dry-run --scales 10k --include-parent-only`
-- `python3 examples/benchmark/benchmark_wam_c_child_search_runtime_sweep.py --scales 10k --include-parent-only --run-timeout-seconds 120`
-- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 10k --targets c-wam-accumulated-child-csr --compile-only-targets c-wam-accumulated-child-csr --repetitions 1 --baseline-target c-wam-accumulated-child-csr`
-- `python3 examples/benchmark/benchmark_effective_distance_matrix.py --scales 50k_cats --targets c-wam-accumulated-child-csr --compile-only-targets c-wam-accumulated-child-csr --repetitions 1 --baseline-target c-wam-accumulated-child-csr`
-- `python3 examples/benchmark/benchmark_wam_c_bidirectional_kernel.py --scales 10k --modes scan,sorted_array --sample-queries 100 --sample-roots 1 --iterations 1 --warmups 1`
-- `python3 examples/benchmark/benchmark_wam_c_bidirectional_kernel.py --scales 50k_cats --modes sorted_array --sample-queries 10 --sample-roots 1 --iterations 1 --warmups 1`
-- `python3 examples/benchmark/benchmark_wam_c_bidirectional_kernel.py --scales dev --modes lmdb_offset --sample-queries 3 --sample-roots 1 --iterations 1 --warmups 0`
+- `investigate/wam-c-candidate-filter-calibration` based on `main` at
+  `718d1a79` (`Merge pull request #2776 from
+  s243a/investigate/wam-c-child-search-scale-ceiling`)
+- `python3 -m py_compile examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py tests/test_wam_c_candidate_filter_threshold_sweep.py`
+- `python3 tests/test_wam_c_candidate_filter_threshold_sweep.py`
+- `python3 examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py --dry-run --scales 50k_cats --profiles low,high-capped --thresholds auto,always,off`
+- `python3 examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py --scales dev --profiles low --thresholds auto,always,off --run-timeout-seconds 120`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-child-search-scale-ceiling`
+- `investigate/wam-c-candidate-filter-calibration`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -371,7 +362,7 @@ Open measurement:
 - The next scalability check should run larger child-search sweeps and compare
   root-cache memory growth against the number of distinct roots.
 
-### Active: `investigate/wam-c-child-search-scale-ceiling`
+### Completed Investigation: `investigate/wam-c-child-search-scale-ceiling`
 
 Goal: find the next full-generated WAM-C child-search scale ceiling after
 root-distance cache reuse, while reporting enough cache-input shape data to
@@ -793,6 +784,34 @@ After hash-bucket row dispatch but before compact row tables:
 | `100x` | 1600 | match | 0.004s | 0.008s | 1.81x |
 | `1k` | 4000 | match | 0.005s | 0.031s | 5.79x |
 
+### Active: `investigate/wam-c-candidate-filter-calibration`
+
+Goal: make the candidate-root filter threshold calibration repeatable enough to
+decide whether `auto` should stay at the current dense-root ceiling or consume
+measured workload costs.
+
+Implemented so far:
+
+- Added `benchmark_wam_c_candidate_filter_threshold_sweep.py`, a thin wrapper
+  around the effective-distance matrix runner. It sweeps root-count profiles
+  (`low`, `medium`, `high-capped`) against threshold policies (`auto`,
+  `always`, `off`, or explicit integers) and emits TSV or Markdown summaries.
+- The summary extracts generated-runner counters from the matrix message field:
+  selected article/root counts, output hash, dense hash agreement, query time,
+  candidate-filter time, schedule roots, skipped roots, and category visits.
+- Added unit coverage for threshold alias parsing, matrix command construction,
+  message parsing, dense-baseline selection, and TSV rendering.
+
+Evidence:
+
+- Dry-run over `50k_cats` low/high-capped profiles prints the expected matrix
+  commands, with `auto` omitting the runtime override, `always` passing
+  `--wam-c-candidate-filter-min-roots 1`, and `off` passing a large threshold.
+- Live `dev` low-profile smoke over `auto,always,off` preserved the same
+  `e94e9c7a70e3` output hash for all three policies. `auto` and `off` stayed
+  dense, while `always` used sparse scheduling and reported
+  `candidate_schedule_roots=1`.
+
 ## Suggested Immediate Next Step
 
 Result-capped and sampled runs now confirm child-CSR variants agree, and parent
@@ -801,9 +820,11 @@ each visited article/root pair. Per-article candidate-root filtering plus sparse
 candidate-root scheduling now avoids most impossible root traversals when many
 roots are selected, while staying off for low-root workloads by default and
 preserving dense semantics when an explicit query cap is active. The threshold
-default now has a cost-model resolver and a Prolog option surface; the next
-useful work is broader scale validation of the `auto` dense-root ceiling and,
-if needed, feeding measured query/artifact costs into that resolver.
+default now has a cost-model resolver, a Prolog option surface, and a repeatable
+calibration wrapper. The next useful work is to run the wrapper on `50k_cats`
+over `low,medium,high-capped` profiles with a wider threshold set such as
+`auto,always,16,64,256,1024,off`; if the boundary is stable, keep `auto` at
+`256`, otherwise feed the measured query/artifact costs into the resolver.
 Keep
 `benchmark_wam_c_child_csr_scale_sweep.py --artifact-only` for large
 category-graph artifact bytes, and use `benchmark_wam_c_reverse_csr_lookup.py`

--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -9,8 +9,11 @@ Latest branch verification:
   s243a/investigate/wam-c-child-search-scale-ceiling`)
 - `python3 -m py_compile examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py tests/test_wam_c_candidate_filter_threshold_sweep.py`
 - `python3 tests/test_wam_c_candidate_filter_threshold_sweep.py`
+- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `python3 examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py --dry-run --scales 50k_cats --profiles low,high-capped --thresholds auto,always,off`
 - `python3 examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py --scales dev --profiles low --thresholds auto,always,off --run-timeout-seconds 120`
+- `python3 examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py --scales 50k_cats --profiles low,medium,high-capped --thresholds auto,always,16,64,256,1024,off --run-timeout-seconds 180`
+- `python3 examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py --scales 50k_cats --profiles medium --thresholds auto,256,512,1024,off --repetitions 3 --run-timeout-seconds 180`
 - `git diff --check`
 
 Active branch:
@@ -801,6 +804,9 @@ Implemented so far:
   candidate-filter time, schedule roots, skipped roots, and category visits.
 - Added unit coverage for threshold alias parsing, matrix command construction,
   message parsing, dense-baseline selection, and TSV rendering.
+- The generated effective-distance runner now uses `CLOCK_MONOTONIC` for setup
+  and query counters, matching the narrower WAM-C timing harnesses and avoiding
+  wall-clock adjustments in calibration rows.
 
 Evidence:
 
@@ -811,6 +817,20 @@ Evidence:
   `e94e9c7a70e3` output hash for all three policies. `auto` and `off` stayed
   dense, while `always` used sparse scheduling and reported
   `candidate_schedule_roots=1`.
+- Full `50k_cats` threshold sweep over `low,medium,high-capped` profiles and
+  `auto,always,16,64,256,1024,off` preserved output hashes for every row.
+  Low selected `50` articles and `41` roots; `auto` stayed dense
+  (`query_ms=25.338`) while forced sparse rows were much slower
+  (`query_ms=108.324` for `always`, `114.917` for `16`). High-capped selected
+  all `4,054` roots and reached the same `50` rows with hash `8da5f8534aba`;
+  `auto` stayed sparse with `query_ms=483.756`, while `off` dense traversal
+  took `query_ms=4546.297`.
+- The medium profile selected `50` articles and `406` roots with hash
+  `226c7fdad57d`. One full sweep put sparse `auto` at `query_ms=119.097` and
+  dense `off` at `105.482`; a focused 3-repetition medium rerun put `auto` at
+  `106.188`, `256` at `108.198`, `512` dense at `100.884`, `1024` dense at
+  `110.546`, and `off` at `130.339`. Treat this as the noisy boundary region,
+  not as a reason to move the default yet.
 
 ## Suggested Immediate Next Step
 
@@ -821,10 +841,13 @@ candidate-root scheduling now avoids most impossible root traversals when many
 roots are selected, while staying off for low-root workloads by default and
 preserving dense semantics when an explicit query cap is active. The threshold
 default now has a cost-model resolver, a Prolog option surface, and a repeatable
-calibration wrapper. The next useful work is to run the wrapper on `50k_cats`
-over `low,medium,high-capped` profiles with a wider threshold set such as
-`auto,always,16,64,256,1024,off`; if the boundary is stable, keep `auto` at
-`256`, otherwise feed the measured query/artifact costs into the resolver.
+calibration wrapper. The `50k_cats` sweep supports keeping `auto` at `256` for
+now: low-root workloads remain dense, high-root workloads get the sparse
+candidate schedule, and the 406-root profile is close/noisy enough that a more
+complex resolver is not justified yet. The next useful work is either a
+repeatability sweep around the 400-1000 root boundary or feeding measured
+query/artifact costs into the resolver if future datasets show a sharper
+crossover.
 Keep
 `benchmark_wam_c_child_csr_scale_sweep.py --artifact-only` for large
 category-graph artifact bytes, and use `benchmark_wam_c_reverse_csr_lookup.py`

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -886,6 +886,7 @@ Tables:
 | `benchmark_common.py` | Shared build/run utilities for cross-target benchmark runners |
 | `compute_effective_distance.py` | Post-processing aggregation (validation tool) |
 | `benchmark_effective_distance.py` | Rebuild and time effective distance across the C# query engine, accumulated Prolog, optional direct article/root and root-bound Prolog variants, and C#/Rust/Go DFS binaries |
+| `benchmark_wam_c_candidate_filter_threshold_sweep.py` | Sweep WAM-C effective-distance candidate-root filter thresholds across root-count profiles and summarize hash agreement plus generated-runner counters |
 | `benchmark_shortest_path_to_root.py` | Compare counted simple-path `All` vs minimum-depth pruning inside the C# query runtime and emit path-state metrics |
 | `benchmark_shortest_path_cross_target.py` | Compare shortest-path-to-root across C# query, seeded Prolog `min`, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_depth_cross_target.py` | Compare synthetic dependency reach-count across C# query, C# DFS, Rust DFS, and Go DFS |

--- a/examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py
+++ b/examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""
+Sweep WAM-C candidate-root filtering thresholds for effective distance.
+
+The generated WAM-C runner now has an `auto` threshold for candidate-root
+filtering. This wrapper keeps threshold calibration repeatable by running the
+existing effective-distance matrix over a small set of root-count profiles and
+threshold policies, then reporting hash agreement and the relevant WAM-C
+runtime counters.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "examples" / "benchmark" / "benchmark_effective_distance_matrix.py"
+TARGET = "c-wam-accumulated-child-csr"
+DEFAULT_SCALE = "50k_cats"
+DEFAULT_PROFILES = "low,medium,high-capped"
+DEFAULT_THRESHOLDS = "auto,always,off"
+DEFAULT_REPETITIONS = 1
+DEFAULT_TIMEOUT_SECONDS = 180.0
+OFF_THRESHOLD = 999_999_999
+METRIC_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)=([^\s;]+)")
+
+
+@dataclass(frozen=True)
+class Profile:
+    name: str
+    description: str
+    matrix_args: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ThresholdSpec:
+    label: str
+    min_roots: int | None
+
+
+@dataclass(frozen=True)
+class SweepRow:
+    scale: str
+    profile: str
+    threshold_label: str
+    threshold_min_roots: int | None
+    target: str
+    status: str
+    median_s: float | None
+    rows: int | None
+    stdout_sha256: str
+    message: str
+    metrics: dict[str, str]
+
+
+PROFILES: dict[str, Profile] = {
+    "low": Profile(
+        "low",
+        "sampled articles and sparse roots; validates the dense low-root path",
+        (
+            "--wam-c-article-stride",
+            "1000",
+            "--wam-c-root-stride",
+            "100",
+        ),
+    ),
+    "medium": Profile(
+        "medium",
+        "sampled articles and medium root fanout; probes the auto threshold boundary",
+        (
+            "--wam-c-article-stride",
+            "1000",
+            "--wam-c-root-stride",
+            "10",
+        ),
+    ),
+    "high-capped": Profile(
+        "high-capped",
+        "all roots with a result cap; validates sparse scheduling at high fanout",
+        (
+            "--wam-c-max-results",
+            "50",
+            "--wam-c-progress-queries",
+            "5000",
+        ),
+    ),
+}
+
+SUMMARY_FIELDS = [
+    "scale",
+    "profile",
+    "threshold",
+    "threshold_min_roots",
+    "status",
+    "policy",
+    "selected_articles",
+    "selected_roots",
+    "rows",
+    "stdout_sha256",
+    "hash_agreement",
+    "median_s",
+    "query_ms",
+    "query_ms_vs_dense",
+    "candidate_filter_ms",
+    "candidate_filter_articles",
+    "candidate_filter_skips",
+    "candidate_schedule_roots",
+    "category_visits",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default=DEFAULT_SCALE)
+    parser.add_argument(
+        "--profiles",
+        default=DEFAULT_PROFILES,
+        help=f"Comma-separated profiles. Available: {','.join(PROFILES)}.",
+    )
+    parser.add_argument(
+        "--thresholds",
+        default=DEFAULT_THRESHOLDS,
+        help=(
+            "Comma-separated thresholds. Use auto, always, off, or a nonnegative "
+            f"integer. Default: {DEFAULT_THRESHOLDS}."
+        ),
+    )
+    parser.add_argument("--repetitions", type=nonnegative_int, default=DEFAULT_REPETITIONS)
+    parser.add_argument("--run-timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--format", choices=("tsv", "markdown"), default="tsv")
+    parser.add_argument("--dry-run", action="store_true", help="Print matrix commands without running them.")
+    parser.add_argument(
+        "matrix_args",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments passed after -- to the matrix runner.",
+    )
+    return parser.parse_args()
+
+
+def nonnegative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be nonnegative")
+    return parsed
+
+
+def csv_values(values: str) -> list[str]:
+    return [part.strip() for part in values.split(",") if part.strip()]
+
+
+def resolve_profiles(profiles: str) -> list[Profile]:
+    resolved: list[Profile] = []
+    for name in csv_values(profiles):
+        try:
+            resolved.append(PROFILES[name])
+        except KeyError as exc:
+            known = ",".join(PROFILES)
+            raise argparse.ArgumentTypeError(f"unknown profile {name!r}; expected one of {known}") from exc
+    return resolved
+
+
+def parse_thresholds(thresholds: str) -> list[ThresholdSpec]:
+    specs: list[ThresholdSpec] = []
+    for raw in csv_values(thresholds):
+        lower = raw.lower()
+        if lower == "auto":
+            specs.append(ThresholdSpec("auto", None))
+        elif lower == "always":
+            specs.append(ThresholdSpec("always", 1))
+        elif lower in {"off", "never"}:
+            specs.append(ThresholdSpec("off", OFF_THRESHOLD))
+        else:
+            min_roots = nonnegative_int(raw)
+            label = "auto" if min_roots == 0 else str(min_roots)
+            specs.append(ThresholdSpec(label, None if min_roots == 0 else min_roots))
+    return specs
+
+
+def matrix_command(
+    scale: str,
+    profile: Profile,
+    threshold: ThresholdSpec,
+    repetitions: int = DEFAULT_REPETITIONS,
+    run_timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    extra_args: list[str] | None = None,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(MATRIX),
+        "--scales",
+        scale,
+        "--targets",
+        TARGET,
+        "--repetitions",
+        str(repetitions),
+        "--baseline-target",
+        TARGET,
+        "--run-timeout-seconds",
+        f"{run_timeout_seconds:g}",
+        "--timeout-targets",
+        TARGET,
+        *profile.matrix_args,
+    ]
+    if threshold.min_roots is not None:
+        command.extend(["--wam-c-candidate-filter-min-roots", str(threshold.min_roots)])
+    if extra_args:
+        command.extend(extra_args)
+    return command
+
+
+def run_matrix_row(
+    scale: str,
+    profile: Profile,
+    threshold: ThresholdSpec,
+    repetitions: int,
+    timeout_seconds: float,
+    extra_args: list[str],
+) -> list[SweepRow]:
+    command = matrix_command(scale, profile, threshold, repetitions, timeout_seconds, extra_args)
+    result = subprocess.run(command, cwd=ROOT, capture_output=True, text=True, check=False)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr, end="" if result.stderr.endswith("\n") else "\n")
+    rows = parse_matrix_output(result.stdout, profile.name, threshold)
+    if result.returncode != 0 and not rows:
+        raise RuntimeError(f"matrix command failed for {scale}/{profile.name}/{threshold.label}: {result.stderr}")
+    return rows
+
+
+def parse_matrix_output(output: str, profile: str, threshold: ThresholdSpec) -> list[SweepRow]:
+    lines = [line for line in output.splitlines() if line.strip() and "\t" in line]
+    if not lines:
+        return []
+    reader = csv.DictReader(io.StringIO("\n".join(lines)), delimiter="\t")
+    rows: list[SweepRow] = []
+    for raw in reader:
+        message = raw.get("message", "")
+        rows.append(
+            SweepRow(
+                scale=raw.get("scale", ""),
+                profile=profile,
+                threshold_label=threshold.label,
+                threshold_min_roots=threshold.min_roots,
+                target=raw.get("target", ""),
+                status=raw.get("status", ""),
+                median_s=parse_optional_float(raw.get("median_s")),
+                rows=parse_optional_int(raw.get("rows")),
+                stdout_sha256=raw.get("stdout_sha256", ""),
+                message=message,
+                metrics=parse_message_metrics(message),
+            )
+        )
+    return rows
+
+
+def parse_message_metrics(message: str) -> dict[str, str]:
+    return {match.group(1): match.group(2) for match in METRIC_RE.finditer(message)}
+
+
+def parse_optional_int(value: str | None) -> int | None:
+    if value in (None, ""):
+        return None
+    return int(value)
+
+
+def parse_optional_float(value: str | None) -> float | None:
+    if value in (None, "", "nan"):
+        return None
+    return float(value)
+
+
+def row_policy(row: SweepRow) -> str:
+    if row.status != "ok":
+        return row.status
+    if metric_int(row, "candidate_schedule_roots") > 0:
+        return "sparse"
+    if metric_int(row, "candidate_filter_articles") > 0:
+        return "filtered-dense"
+    return "dense"
+
+
+def metric_int(row: SweepRow, key: str) -> int:
+    value = row.metrics.get(key)
+    return int(value) if value not in (None, "") else 0
+
+
+def metric_float(row: SweepRow, key: str) -> float | None:
+    value = row.metrics.get(key)
+    return float(value) if value not in (None, "") else None
+
+
+def summarize_rows(rows: list[SweepRow]) -> list[dict[str, str]]:
+    dense_baselines = dense_baselines_by_group(rows)
+    summaries: list[dict[str, str]] = []
+    for row in rows:
+        group = (row.scale, row.profile)
+        dense = dense_baselines.get(group)
+        query_ms = metric_float(row, "query_ms")
+        dense_query_ms = metric_float(dense, "query_ms") if dense is not None else None
+        summaries.append(
+            {
+                "scale": row.scale,
+                "profile": row.profile,
+                "threshold": row.threshold_label,
+                "threshold_min_roots": "" if row.threshold_min_roots is None else str(row.threshold_min_roots),
+                "status": row.status,
+                "policy": row_policy(row),
+                "selected_articles": row.metrics.get("selected_articles", ""),
+                "selected_roots": row.metrics.get("selected_roots", ""),
+                "rows": "" if row.rows is None else str(row.rows),
+                "stdout_sha256": row.stdout_sha256,
+                "hash_agreement": hash_agreement(row, dense),
+                "median_s": format_optional_float(row.median_s, 3),
+                "query_ms": format_optional_float(query_ms, 3),
+                "query_ms_vs_dense": ratio_text(query_ms, dense_query_ms),
+                "candidate_filter_ms": row.metrics.get("candidate_filter_ms", ""),
+                "candidate_filter_articles": row.metrics.get("candidate_filter_articles", ""),
+                "candidate_filter_skips": row.metrics.get("candidate_filter_skips", ""),
+                "candidate_schedule_roots": row.metrics.get("candidate_schedule_roots", ""),
+                "category_visits": row.metrics.get("category_visits", ""),
+            }
+        )
+    return summaries
+
+
+def dense_baselines_by_group(rows: list[SweepRow]) -> dict[tuple[str, str], SweepRow]:
+    grouped: dict[tuple[str, str], list[SweepRow]] = {}
+    for row in rows:
+        grouped.setdefault((row.scale, row.profile), []).append(row)
+
+    baselines: dict[tuple[str, str], SweepRow] = {}
+    for key, group_rows in grouped.items():
+        off_rows = [row for row in group_rows if row.threshold_label == "off"]
+        if off_rows:
+            baselines[key] = off_rows[0]
+            continue
+        dense_rows = [row for row in group_rows if row_policy(row) == "dense"]
+        if dense_rows:
+            baselines[key] = dense_rows[0]
+            continue
+        baselines[key] = group_rows[0]
+    return baselines
+
+
+def hash_agreement(row: SweepRow, dense: SweepRow | None) -> str:
+    if dense is None or not dense.stdout_sha256 or not row.stdout_sha256:
+        return ""
+    return "match" if row.stdout_sha256 == dense.stdout_sha256 else "diff"
+
+
+def ratio_text(value: float | None, baseline: float | None) -> str:
+    if value is None or baseline in (None, 0.0):
+        return ""
+    return f"{value / baseline:.2f}x"
+
+
+def format_optional_float(value: float | None, digits: int) -> str:
+    if value is None:
+        return ""
+    return f"{value:.{digits}f}"
+
+
+def render_tsv(rows: list[dict[str, str]]) -> str:
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=SUMMARY_FIELDS, delimiter="\t", lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def render_markdown(rows: list[dict[str, str]]) -> str:
+    if not rows:
+        return ""
+    lines = [
+        "| " + " | ".join(SUMMARY_FIELDS) + " |",
+        "| " + " | ".join("---" for _ in SUMMARY_FIELDS) + " |",
+    ]
+    for row in rows:
+        lines.append("| " + " | ".join(row.get(field, "") for field in SUMMARY_FIELDS) + " |")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    profiles = resolve_profiles(args.profiles)
+    thresholds = parse_thresholds(args.thresholds)
+    scales = csv_values(args.scales)
+    extra_args = args.matrix_args
+    if extra_args and extra_args[0] == "--":
+        extra_args = extra_args[1:]
+
+    commands = [
+        (scale, profile, threshold, matrix_command(scale, profile, threshold,
+                                                   args.repetitions,
+                                                   args.run_timeout_seconds,
+                                                   extra_args))
+        for scale in scales
+        for profile in profiles
+        for threshold in thresholds
+    ]
+    if args.dry_run:
+        for scale, profile, threshold, command in commands:
+            print(f"{scale}\t{profile.name}\t{threshold.label}\t{' '.join(command)}")
+        return 0
+
+    rows: list[SweepRow] = []
+    for scale, profile, threshold, _command in commands:
+        rows.extend(run_matrix_row(scale, profile, threshold,
+                                   args.repetitions,
+                                   args.run_timeout_seconds,
+                                   extra_args))
+    summaries = summarize_rows(rows)
+    if args.format == "markdown":
+        print(render_markdown(summaries), end="")
+    else:
+        print(render_tsv(summaries), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_wam_c_effective_distance_benchmark.pl
@@ -848,11 +848,12 @@ effective_distance_main_code(KernelMode, FactStorage, ChildSearch, ReverseIndexO
     reverse_index_teardown_call(ReverseIndexOptions, ReverseIndexTeardownCall),
     candidate_filter_default_min_roots(CandidateFilter, CandidateFilterDefaultMinRoots),
     format(atom(Code),
-'#include <math.h>
+'#define _GNU_SOURCE
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#include <time.h>
 #include "wam_runtime.h"
 
 void setup_category_ancestor_4(WamState* state);
@@ -864,9 +865,9 @@ void setup_category_ancestor_4(WamState* state);
 ~w
 
 static double wam_now_ms(void) {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return ((double)tv.tv_sec * 1000.0) + ((double)tv.tv_usec / 1000.0);
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ((double)ts.tv_sec * 1000.0) + ((double)ts.tv_nsec / 1000000.0);
 }
 
 static long long wam_read_env_limit(const char *name) {

--- a/tests/test_wam_c_candidate_filter_threshold_sweep.py
+++ b/tests/test_wam_c_candidate_filter_threshold_sweep.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "examples" / "benchmark"))
+
+from benchmark_wam_c_candidate_filter_threshold_sweep import (  # noqa: E402
+    OFF_THRESHOLD,
+    PROFILES,
+    TARGET,
+    ThresholdSpec,
+    matrix_command,
+    parse_matrix_output,
+    parse_thresholds,
+    render_tsv,
+    summarize_rows,
+)
+
+
+class WamCCandidateFilterThresholdSweepTests(unittest.TestCase):
+    def test_parse_threshold_aliases(self) -> None:
+        thresholds = parse_thresholds("auto,always,off,16,0")
+
+        self.assertEqual(
+            [(item.label, item.min_roots) for item in thresholds],
+            [
+                ("auto", None),
+                ("always", 1),
+                ("off", OFF_THRESHOLD),
+                ("16", 16),
+                ("auto", None),
+            ],
+        )
+
+    def test_matrix_command_uses_profile_and_threshold(self) -> None:
+        command = matrix_command(
+            "50k_cats",
+            PROFILES["low"],
+            ThresholdSpec("always", 1),
+            repetitions=2,
+            run_timeout_seconds=45.0,
+            extra_args=["--keep-temp"],
+        )
+
+        self.assertEqual(command[0], sys.executable)
+        self.assertIn("benchmark_effective_distance_matrix.py", command[1])
+        self.assertEqual(command[command.index("--scales") + 1], "50k_cats")
+        self.assertEqual(command[command.index("--targets") + 1], TARGET)
+        self.assertEqual(command[command.index("--repetitions") + 1], "2")
+        self.assertEqual(command[command.index("--run-timeout-seconds") + 1], "45")
+        self.assertEqual(command[command.index("--wam-c-article-stride") + 1], "1000")
+        self.assertEqual(command[command.index("--wam-c-root-stride") + 1], "100")
+        self.assertEqual(command[command.index("--wam-c-candidate-filter-min-roots") + 1], "1")
+        self.assertEqual(command[-1], "--keep-temp")
+
+    def test_matrix_command_omits_auto_threshold_override(self) -> None:
+        command = matrix_command("50k_cats", PROFILES["high-capped"], ThresholdSpec("auto", None))
+
+        self.assertNotIn("--wam-c-candidate-filter-min-roots", command)
+        self.assertEqual(command[command.index("--wam-c-max-results") + 1], "50")
+
+    def test_parse_matrix_output_extracts_metrics(self) -> None:
+        output = (
+            "scale\ttarget\tcategory\tstatus\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256\tmessage\n"
+            "50k_cats\tc-wam-accumulated-child-csr\thybrid-wam-child-search\tok\t0.1\t0.1\t0.1\t"
+            "1\tabcdef123456\twam_c_effective_setup selected_articles=50 selected_roots=41 "
+            "candidate_filter_min_roots=256 setup_ms=1.0; wam_c_effective_runtime queries=2050 "
+            "results=1 category_visits=2050 candidate_filter_articles=0 "
+            "candidate_schedule_roots=0 query_ms=26.435\n"
+        )
+
+        rows = parse_matrix_output(output, "low", ThresholdSpec("auto", None))
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].scale, "50k_cats")
+        self.assertEqual(rows[0].profile, "low")
+        self.assertEqual(rows[0].median_s, 0.1)
+        self.assertEqual(rows[0].rows, 1)
+        self.assertEqual(rows[0].metrics["selected_roots"], "41")
+        self.assertEqual(rows[0].metrics["query_ms"], "26.435")
+
+    def test_summary_compares_rows_to_dense_off_baseline(self) -> None:
+        dense_output = (
+            "scale\ttarget\tcategory\tstatus\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256\tmessage\n"
+            "50k_cats\tc-wam-accumulated-child-csr\thybrid-wam-child-search\tok\t0.1\t0.1\t0.1\t"
+            "1\thash1\twam_c_effective_setup selected_articles=50 selected_roots=41; "
+            "wam_c_effective_runtime query_ms=25.000 candidate_filter_articles=0 "
+            "candidate_schedule_roots=0 category_visits=2050\n"
+        )
+        sparse_output = (
+            "scale\ttarget\tcategory\tstatus\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256\tmessage\n"
+            "50k_cats\tc-wam-accumulated-child-csr\thybrid-wam-child-search\tok\t0.2\t0.2\t0.2\t"
+            "1\thash1\twam_c_effective_setup selected_articles=50 selected_roots=41; "
+            "wam_c_effective_runtime query_ms=100.000 candidate_filter_articles=50 "
+            "candidate_schedule_roots=41 category_visits=1\n"
+        )
+        rows = (
+            parse_matrix_output(dense_output, "low", ThresholdSpec("off", OFF_THRESHOLD))
+            + parse_matrix_output(sparse_output, "low", ThresholdSpec("always", 1))
+        )
+
+        summary = summarize_rows(rows)
+
+        self.assertEqual(summary[0]["policy"], "dense")
+        self.assertEqual(summary[0]["hash_agreement"], "match")
+        self.assertEqual(summary[0]["query_ms_vs_dense"], "1.00x")
+        self.assertEqual(summary[1]["policy"], "sparse")
+        self.assertEqual(summary[1]["hash_agreement"], "match")
+        self.assertEqual(summary[1]["query_ms_vs_dense"], "4.00x")
+        self.assertIn("candidate_schedule_roots", render_tsv(summary))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wam_c_effective_distance_benchmark.pl
+++ b/tests/test_wam_c_effective_distance_benchmark.pl
@@ -97,6 +97,19 @@ test_generated_runner_indexes_article_categories :-
     ;   fail_test(Test, 'generated runner did not use article-category slices')
     ).
 
+test_generated_runner_uses_monotonic_timer :-
+    Test = 'WAM-C effective-distance: generated runner uses monotonic timing',
+    (   unique_tmp_dir(monotonic_timer, OutputDir),
+        write_test_facts(OutputDir, FactsPath),
+        generate_wam_c_effective_distance_benchmark:generate(FactsPath, OutputDir, kernels_on, facts_tsv),
+        directory_file_path(OutputDir, 'main.c', MainPath),
+        read_file_to_string(MainPath, Main, []),
+        sub_string(Main, _, _, _, 'clock_gettime(CLOCK_MONOTONIC, &ts);'),
+        \+ sub_string(Main, _, _, _, 'gettimeofday(')
+    ->  pass(Test)
+    ;   fail_test(Test, 'generated runner timing is not monotonic')
+    ).
+
 test_generate_and_run_lmdb_if_available :-
     Test = 'WAM-C effective-distance: facts_lmdb generated runner emits expected result',
     (   lmdb_toolchain_available
@@ -755,6 +768,7 @@ run_tests_once :-
     test_generate_lmdb_mode_files,
     test_generated_runner_bounds_kernel_heap,
     test_generated_runner_indexes_article_categories,
+    test_generated_runner_uses_monotonic_timer,
     test_generate_and_run_lmdb_if_available,
     test_generated_runner_supports_runtime_caps,
     test_generated_runner_supports_runtime_sampling,


### PR DESCRIPTION
 ## Summary
  - Add a WAM-C candidate-filter threshold sweep wrapper for effective-distance runs.
  - Compare `auto`, `always`, `off`, and numeric thresholds across low, medium, and high root-count profiles.
  - Switch generated WAM-C effective-distance timing to `CLOCK_MONOTONIC` so calibration counters cannot go negative
  from wall-clock adjustments.
  - Record `50k_cats` calibration evidence and keep `auto` at `256` for now.

  ## Validation
  - `python3 -m py_compile examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py tests/
  test_wam_c_candidate_filter_threshold_sweep.py`
  - `python3 tests/test_wam_c_candidate_filter_threshold_sweep.py`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
  - `git diff --check`
  - `50k_cats` full threshold sweep over `low,medium,high-capped`
  - `50k_cats` focused medium 3-repetition sweep