### PR TITLE
WAM F# target: forward CSR direction + CSR-kernel path (Stage 3b)

### DIFF
--- a/examples/benchmark/build_reverse_csr_artifact.py
+++ b/examples/benchmark/build_reverse_csr_artifact.py
@@ -53,7 +53,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--index-backend",
         choices=["sorted_array", "lmdb_offset"],
         default="sorted_array",
-        help="parent -> offset/count lookup backend to emit",
+        help="key -> offset/count lookup backend to emit",
+    )
+    parser.add_argument(
+        "--direction",
+        choices=["reverse", "forward"],
+        default="reverse",
+        help=(
+            "reverse (default): group category_parent BY VALUE -> a "
+            "category_child (parent->children) CSR, keyed by parent. "
+            "forward: group BY KEY -> a category_parent (child->parents) CSR, "
+            "keyed by child (for the upward category_ancestor kernel walk)."
+        ),
     )
     return parser.parse_args(argv)
 
@@ -74,7 +85,13 @@ def main(argv: list[str] | None = None) -> int:
         shutil.rmtree(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    children_by_parent: dict[int, list[int]] = defaultdict(list)
+    forward = (args.direction == "forward")
+    # reverse: out relation category_child, grouped BY VALUE (parent->children).
+    # forward: out relation category_parent, grouped BY KEY  (child->parents).
+    out_rel = "category_parent" if forward else "category_child"
+    value_field = "parent" if forward else "child"
+
+    groups: dict[int, list[int]] = defaultdict(list)
     edge_count = 0
     max_id = 0
 
@@ -88,16 +105,20 @@ def main(argv: list[str] | None = None) -> int:
                     continue
                 child = I32.unpack(key)[0]
                 parent = I32.unpack(value)[0]
-                children_by_parent[parent].append(child)
+                if forward:
+                    groups[child].append(parent)   # key=child -> parents
+                else:
+                    groups[parent].append(child)   # key=parent -> children
                 edge_count += 1
                 max_id = max(max_id, child, parent)
     finally:
         env.close()
 
-    idx_path = out_dir / "category_child.csr.idx"
-    val_path = out_dir / "category_child.csr.val"
-    offset_lmdb_path = out_dir / "category_child.csr.offsets.lmdb"
-    meta_path = out_dir / "category_child.csr.meta"
+    children_by_parent = groups
+    idx_path = out_dir / f"{out_rel}.csr.idx"
+    val_path = out_dir / f"{out_rel}.csr.val"
+    offset_lmdb_path = out_dir / f"{out_rel}.csr.offsets.lmdb"
+    meta_path = out_dir / f"{out_rel}.csr.meta"
 
     offset_edges = 0
     parent_count = 0
@@ -133,7 +154,7 @@ def main(argv: list[str] | None = None) -> int:
     manifest = {
         "format": "unifyweaver.reverse_csr.v1",
         "schema_version": 1,
-        "relation": "category_child/2",
+        "relation": f"{out_rel}/2",
         "source_relation": "category_parent/2",
         "source_environment_path": str(src_dir),
         "storage_kind": "csr_pread_artifact",
@@ -147,7 +168,7 @@ def main(argv: list[str] | None = None) -> int:
         "offset_index_database": "offsets" if args.index_backend == "lmdb_offset" else None,
         "index_record_format": "int32_le parent, uint64_le offset_edges, uint32_le count_edges",
         "offset_index_record_format": "uint64_le offset_edges, uint32_le count_edges",
-        "value_record_format": "int32_le child",
+        "value_record_format": f"int32_le {value_field}",
         "index_record_bytes": IDX_RECORD.size,
         "offset_index_record_bytes": OFFSET_RECORD.size,
         "value_record_bytes": I32.size,

--- a/examples/benchmark/generate_wam_fsharp_optimized_benchmark.pl
+++ b/examples/benchmark/generate_wam_fsharp_optimized_benchmark.pl
@@ -84,8 +84,10 @@ generate(VariantAtom, OutputDir) :-
         % `*_csr` variants build the demand set from a category_child CSR
         % artifact at <factsDir>/csr (binary-searched, int-native) instead of
         % the LMDB cursor; csr_path triggers has_csr + CsrReader.fs compilation.
-        (   sub_atom(VariantAtom, _, _, 0, csr)
-        ->  CsrOpts = [csr_path('csr')]
+        (   sub_atom(VariantAtom, _, _, _, csr_kernel)
+        ->  CsrOpts = [csr_path('csr'), csr_kernel(true)]   % forward CSR for the kernel
+        ;   sub_atom(VariantAtom, _, _, 0, csr)
+        ->  CsrOpts = [csr_path('csr')]                     % reverse CSR for the demand BFS
         ;   CsrOpts = []
         ),
         append([lmdb_path('lmdb'), lmdb_materialisation(Materialisation)], CsrOpts, LmdbOpts)
@@ -132,12 +134,18 @@ parse_variant(lmdb_eager_csr, [
     branch_pruning(false),
     min_closure(false)
 ]).
+parse_variant(lmdb_csr_kernel, [
+    dialect(swi),
+    branch_pruning(false),
+    min_closure(false)
+]).
 
 %% variant_materialisation(+Variant, -Mode)
 variant_materialisation(lmdb_eager,     eager).
 variant_materialisation(lmdb_lazy,      lazy).
 variant_materialisation(lmdb_cached,    cached).
 variant_materialisation(lmdb_eager_csr, eager).
+variant_materialisation(lmdb_csr_kernel, lazy).
 variant_materialisation(_,              eager).
 
 %% collect_wam_predicates(+Variant, -Predicates)
@@ -162,6 +170,10 @@ collect_wam_predicates(lmdb_cached, [
     user:category_ancestor/4
 ]).
 collect_wam_predicates(lmdb_eager_csr, [
+    user:max_depth/1,
+    user:category_ancestor/4
+]).
+collect_wam_predicates(lmdb_csr_kernel, [
     user:max_depth/1,
     user:category_ancestor/4
 ]).

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -5036,6 +5036,7 @@ generate_program_fs(_Predicates, DetectedKernels, Options, Code) :-
     format_foreign_preds_fs(ForeignKeys, ForeignPredsStr),
     generate_lookup_sources_expr_fs(Options, LookupSourcesExpr),
     (option(csr_path(_), Options) -> HasCsr = true ; HasCsr = false),
+    (option(csr_kernel(true), Options) -> HasCsrKernel = true ; HasCsrKernel = false),
     (option(lmdb_path(_), Options) -> HasLmdb = true ; HasLmdb = false),
     option(lmdb_materialisation(Materialisation), Options, cached),
     option(lmdb_l2_capacity(L2Cap), Options, 4096),
@@ -5053,6 +5054,7 @@ generate_program_fs(_Predicates, DetectedKernels, Options, Code) :-
         foreign_preds = ForeignPredsStr,
         lookup_sources_expr = LookupSourcesExpr,
         has_csr = HasCsr,
+        has_csr_kernel = HasCsrKernel,
         has_lmdb = HasLmdb,
         has_bidirectional = HasBidir,
         branch_factor = BranchFactor,
@@ -5082,6 +5084,10 @@ generate_lookup_sources_expr_fs(Options, Expr) :-
 
 lookup_source_entry_fs(Options, Entry) :-
     option(csr_path(CsrPath), Options),
+    % csr_kernel mode constructs its CSR source directly in the kernel branch
+    % (forward category_parent CSR), so skip the auto WcLookupSources entry --
+    % its default category_child relation would point at a non-existent file.
+    \+ option(csr_kernel(true), Options),
     option(csr_relation(Rel), Options, category_child),
     % Resolve the CSR artifact dir against factsDir at runtime (a relative
     % csr_path like "csr" would otherwise be opened against the process CWD,

--- a/templates/targets/fsharp_wam/program.fs.mustache
+++ b/templates/targets/fsharp_wam/program.fs.mustache
@@ -164,6 +164,24 @@ let main argv =
         | Some l -> int (l.Trim())
         | None -> 0
 
+{{#has_csr_kernel}}
+    // Forward-CSR kernel path: the kernel's UPWARD category_parent lookup reads
+    // a forward (child->parents) CSR artifact at <factsDir>/csr -- a lazy-class
+    // path (per-lookup binary search + .val file seek), but via a raw
+    // FileStream rather than LightningDB's managed cursor. Demand set is built
+    // from the LMDB category_child cursor (load-time); lookups are
+    // demand-filtered so the upward walk never leaves it. No LMDB in the kernel
+    // hot path. Hypothesis: beats LMDB-lazy by avoiding the managed per-call
+    // P/Invoke overhead.
+    let demandSet = reachableToRoot lmdbEnv rootInt System.Int32.MaxValue
+    let csrParent =
+        CsrReader.CsrLookupSource(System.IO.Path.Combine(factsDir, "csr"), "category_parent")
+        :> ILookupSource
+    let lmdbLookupFn (k: int) : int list =
+        if demandSet.Contains k then csrParent.Lookup k |> List.filter demandSet.Contains
+        else []
+{{/has_csr_kernel}}
+{{^has_csr_kernel}}
 {{match materialisation}}
 {{case eager}}
 {{#has_csr}}
@@ -237,6 +255,7 @@ let main argv =
     // O(log n) F# Set lookup from every kernel call -- the last gap to eager.
     let lmdbLookupFn (k: int) : int list = cachedSource.Lookup k
 {{/match}}
+{{/has_csr_kernel}}
     eprintfn "demand_set=%d" demandSet.Count
     let parentsInterned : Map<int, int list> = Map.empty
 


### PR DESCRIPTION
  Two commits completing the CSR sub-arc:

  **1. `build_reverse_csr_artifact.py --direction forward`** — groups
  `category_parent` BY KEY (child) instead of by value, emitting a
  `category_parent` (child→parents) CSR keyed by child — the forward index the
  upward `category_ancestor` kernel walk needs. `reverse` (the
  `category_child` parent→children demand index) stays the default, unchanged.
  The F# `CsrReader` is already relation-generic, so it reads the forward
  artifact unchanged.

  **2. F# forward-CSR kernel path** — the kernel's upward `category_parent`
  lookup can now read the forward CSR instead of LMDB: a lazy-class path
  (per-lookup binary search + `.val` file seek via raw `FileStream`),
  demand-filtered, with no LMDB in the kernel hot path.
  - `wam_fsharp_target.pl`: `csr_kernel(true)` → `has_csr_kernel`;
    `lookup_source_entry_fs` suppresses the auto `WcLookupSources` CSR entry in
    `csr_kernel` mode (the kernel builds its own forward source; the default
    `category_child` entry would point at a missing file).
  - `program.fs`: `{{#has_csr_kernel}}` branch (demand set from the LMDB
    `category_child` cursor; kernel lookup from the forward CSR).
  - generator: `lmdb_csr_kernel` variant.

  ### Results (simplewiki_articles, root 2, 14,680 seeds, serial, warm)

  `solutions=970` (correct), load ~155 ms, query ~15 ms — **tied with LMDB-lazy**
  (~150/~15). The "raw-FileStream CSR beats LMDB-lazy" hypothesis did not hold;
  the per-lookup `FileStream` seek+read + binary search costs ≈ the LMDB cursor.
  Forward-CSR-kernel is a valid, on-par, LMDB-free-hot-path alternative, not a
  speedup. (Tiny int-native fixture: `demand_set=4 solutions=3`.) All F# target
  tests pass.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)