### PR TITLE
Tune WAM-C candidate filter auto boundary

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,21 +4,20 @@ Status date: 2026-06-05
 
 Latest branch verification:
 
-- `investigate/wam-c-candidate-filter-calibration` based on `main` at
-  `718d1a79` (`Merge pull request #2776 from
-  s243a/investigate/wam-c-child-search-scale-ceiling`)
+- `investigate/wam-c-candidate-filter-boundary-repeatability` based on `main`
+  at `f1b9402b` (`Merge pull request #2799 from
+  s243a/investigate/wam-c-candidate-filter-calibration`)
 - `python3 -m py_compile examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py tests/test_wam_c_candidate_filter_threshold_sweep.py`
 - `python3 tests/test_wam_c_candidate_filter_threshold_sweep.py`
 - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
-- `python3 examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py --dry-run --scales 50k_cats --profiles low,high-capped --thresholds auto,always,off`
-- `python3 examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py --scales dev --profiles low --thresholds auto,always,off --run-timeout-seconds 120`
-- `python3 examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py --scales 50k_cats --profiles low,medium,high-capped --thresholds auto,always,16,64,256,1024,off --run-timeout-seconds 180`
-- `python3 examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py --scales 50k_cats --profiles medium --thresholds auto,256,512,1024,off --repetitions 3 --run-timeout-seconds 180`
+- `python3 examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py --dry-run --scales 50k_cats --profiles boundary-250,medium,boundary-500,boundary-800 --thresholds auto,256,512,off`
+- `python3 examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py --scales 50k_cats --profiles boundary-250,medium,boundary-500,boundary-800 --thresholds auto,256,512,off --repetitions 3 --run-timeout-seconds 180`
+- `python3 examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py --scales 50k_cats --profiles medium,boundary-800 --thresholds auto,off --repetitions 1 --run-timeout-seconds 180`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-candidate-filter-calibration`
+- `investigate/wam-c-candidate-filter-boundary-repeatability`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -528,15 +527,16 @@ Evidence:
   scheduling and dense traversal both produced `1` row with hash
   `e2bde0c720fe`, but dense traversal was faster (`query_ms=25.390`) than
   sparse scheduling (`query_ms=100.436`) because candidate discovery cost
-  dominated at only `41` roots. With the default `candidate_filter_min_roots=256`,
-  the same sample now stays dense by default, preserves the hash, and reports
-  `candidate_filter_articles=0` with `query_ms=26.435`. This is why the default
-  root threshold is conservative and the CLI override exists.
+  dominated at only `41` roots. With the then-default
+  `candidate_filter_min_roots=256`, the same sample stayed dense by default,
+  preserved the hash, and reported `candidate_filter_articles=0` with
+  `query_ms=26.435`. This is why the default root threshold is conservative and
+  the CLI override exists.
 - The generated runner now resolves the default candidate-root threshold through
   `cost_model:resolve_candidate_filter_min_roots/2`, so Prolog workload options
   can declare `candidate_filter_min_roots(N)`, `always`, `off`, or `auto`.
   `auto` currently preserves the measured dense-root ceiling by generating
-  `256`, while `UW_WAM_C_EFFECTIVE_CANDIDATE_FILTER_MIN_ROOTS` remains a runtime
+  `512`, while `UW_WAM_C_EFFECTIVE_CANDIDATE_FILTER_MIN_ROOTS` remains a runtime
   override for sweeps.
 - Before category-ID indexing, narrow runtime evidence bypassing full WAM-C
   project generation at `10k` showed `100` warm-cache sampled queries over one
@@ -787,7 +787,7 @@ After hash-bucket row dispatch but before compact row tables:
 | `100x` | 1600 | match | 0.004s | 0.008s | 1.81x |
 | `1k` | 4000 | match | 0.005s | 0.031s | 5.79x |
 
-### Active: `investigate/wam-c-candidate-filter-calibration`
+### Completed Investigation: `investigate/wam-c-candidate-filter-calibration`
 
 Goal: make the candidate-root filter threshold calibration repeatable enough to
 decide whether `auto` should stay at the current dense-root ceiling or consume
@@ -832,6 +832,37 @@ Evidence:
   `110.546`, and `off` at `130.339`. Treat this as the noisy boundary region,
   not as a reason to move the default yet.
 
+### Active: `investigate/wam-c-candidate-filter-boundary-repeatability`
+
+Goal: pin the noisy candidate-root filter crossover with repeatable boundary
+profiles and change the generated `auto` threshold only when boundary evidence
+supports it.
+
+Implemented so far:
+
+- Added boundary calibration profiles around the crossover band:
+  `boundary-250`, `boundary-500`, and `boundary-800`.
+- Changed the cost-model `auto` dense-root ceiling from `255` to `511`, so the
+  generated default `candidate_filter_min_roots` becomes `512`.
+- Kept `candidate_filter_min_roots(N)`, `always`, `off`, and the environment
+  override available for workloads whose measured crossover differs.
+
+Evidence:
+
+- Dry-run coverage confirms the boundary profiles pass the expected root
+  strides into the existing effective-distance matrix runner.
+- A 3-repetition `50k_cats` boundary sweep over
+  `boundary-250,medium,boundary-500,boundary-800` and `auto,256,512,off`
+  preserved output hashes for every row.
+- Explicit `512` is the simulated new `auto` threshold on the old build:
+  `254` selected roots stay dense, `406` roots stay in the noisy dense-favored
+  boundary band, `507` roots are near parity, and `811` roots choose sparse
+  scheduling with much lower query time than dense traversal.
+- After changing the generated default to `512`, a focused sanity sweep showed
+  `medium` (`406` selected roots) staying dense with matching hash
+  `226c7fdad57d`, while `boundary-800` (`811` selected roots) used sparse
+  scheduling with matching hash `92be2a9b5ac1`.
+
 ## Suggested Immediate Next Step
 
 Result-capped and sampled runs now confirm child-CSR variants agree, and parent
@@ -841,15 +872,13 @@ candidate-root scheduling now avoids most impossible root traversals when many
 roots are selected, while staying off for low-root workloads by default and
 preserving dense semantics when an explicit query cap is active. The threshold
 default now has a cost-model resolver, a Prolog option surface, and a repeatable
-calibration wrapper. The `50k_cats` sweep supports keeping `auto` at `256` for
-now: low-root workloads remain dense, high-root workloads get the sparse
-candidate schedule, and the 406-root profile is close/noisy enough that a more
-complex resolver is not justified yet. The next useful work is either a
-repeatability sweep around the 400-1000 root boundary or feeding measured
-query/artifact costs into the resolver if future datasets show a sharper
-crossover.
-Keep
-`benchmark_wam_c_child_csr_scale_sweep.py --artifact-only` for large
+calibration wrapper. The boundary-repeatability sweep supports moving `auto` to
+`512`: low-root workloads remain dense, the 406-root profile avoids forced
+sparse scheduling, the 507-root profile is near parity, and the 811-root profile
+still uses sparse scheduling. The next useful work is either a PR for this
+threshold adjustment or feeding measured query/artifact costs into the resolver
+if future datasets show a sharper crossover.
+Keep `benchmark_wam_c_child_csr_scale_sweep.py --artifact-only` for large
 category-graph artifact bytes, and use `benchmark_wam_c_reverse_csr_lookup.py`
 only when changing CSR lookup storage. Do not persist root-distance maps to
 LMDB or a separate artifact by default; add that only behind a cost-analyzer

--- a/examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py
+++ b/examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py
@@ -82,6 +82,36 @@ PROFILES: dict[str, Profile] = {
             "10",
         ),
     ),
+    "boundary-250": Profile(
+        "boundary-250",
+        "sampled articles and about 250 roots; probes below the noisy boundary",
+        (
+            "--wam-c-article-stride",
+            "1000",
+            "--wam-c-root-stride",
+            "16",
+        ),
+    ),
+    "boundary-500": Profile(
+        "boundary-500",
+        "sampled articles and about 500 roots; probes just above the noisy boundary",
+        (
+            "--wam-c-article-stride",
+            "1000",
+            "--wam-c-root-stride",
+            "8",
+        ),
+    ),
+    "boundary-800": Profile(
+        "boundary-800",
+        "sampled articles and about 800 roots; probes the upper boundary band",
+        (
+            "--wam-c-article-stride",
+            "1000",
+            "--wam-c-root-stride",
+            "5",
+        ),
+    ),
     "high-capped": Profile(
         "high-capped",
         "all roots with a result cap; validates sparse scheduling at high fanout",

--- a/src/unifyweaver/core/cost_model.pl
+++ b/src/unifyweaver/core/cost_model.pl
@@ -269,7 +269,7 @@ resolve_reverse_index_spec(Spec, _Options, ReverseIndex) :-
 %
 %  Resolve the root-count threshold for WAM-C candidate-root filtering.
 %  The current auto policy encodes the measured low-root dense ceiling:
-%  keep candidate discovery off until at least 256 selected roots unless
+%  keep candidate discovery off until at least 512 selected roots unless
 %  an explicit workload option overrides it.
 resolve_candidate_filter_min_roots(Options, MinRoots) :-
     option(candidate_filter_min_roots(Spec), Options, auto),
@@ -277,7 +277,7 @@ resolve_candidate_filter_min_roots(Options, MinRoots) :-
 
 resolve_candidate_filter_min_roots_spec(auto, Options, MinRoots) :-
     !,
-    option(candidate_filter_dense_root_ceiling(DenseRootCeiling), Options, 255),
+    option(candidate_filter_dense_root_ceiling(DenseRootCeiling), Options, 511),
     validate_nonnegative_integer(candidate_filter_dense_root_ceiling,
                                  DenseRootCeiling),
     MinRoots is DenseRootCeiling + 1.

--- a/tests/test_wam_c_candidate_filter_threshold_sweep.py
+++ b/tests/test_wam_c_candidate_filter_threshold_sweep.py
@@ -64,6 +64,19 @@ class WamCCandidateFilterThresholdSweepTests(unittest.TestCase):
         self.assertNotIn("--wam-c-candidate-filter-min-roots", command)
         self.assertEqual(command[command.index("--wam-c-max-results") + 1], "50")
 
+    def test_boundary_profiles_select_expected_root_strides(self) -> None:
+        expected = {
+            "boundary-250": "16",
+            "boundary-500": "8",
+            "boundary-800": "5",
+        }
+
+        for profile_name, root_stride in expected.items():
+            with self.subTest(profile=profile_name):
+                command = matrix_command("50k_cats", PROFILES[profile_name], ThresholdSpec("auto", None))
+                self.assertEqual(command[command.index("--wam-c-article-stride") + 1], "1000")
+                self.assertEqual(command[command.index("--wam-c-root-stride") + 1], root_stride)
+
     def test_parse_matrix_output_extracts_metrics(self) -> None:
         output = (
             "scale\ttarget\tcategory\tstatus\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256\tmessage\n"

--- a/tests/test_wam_c_effective_distance_benchmark.pl
+++ b/tests/test_wam_c_effective_distance_benchmark.pl
@@ -20,7 +20,7 @@ fail_test(Test, Reason) :-
 
 test_candidate_filter_cost_model_resolver :-
     Test = 'WAM-C effective-distance: candidate filter threshold resolver handles policy modes',
-    (   resolve_candidate_filter_min_roots([], 256),
+    (   resolve_candidate_filter_min_roots([], 512),
         resolve_candidate_filter_min_roots([candidate_filter_dense_root_ceiling(31)], 32),
         resolve_candidate_filter_min_roots([candidate_filter_min_roots(always)], 0),
         resolve_candidate_filter_min_roots([candidate_filter_min_roots(off)], Off),


### PR DESCRIPTION
  ## Summary

  - Adds repeatable WAM-C candidate-filter boundary sweep profiles around ~250, ~500, and ~800 selected roots.
  - Moves the WAM-C `auto` candidate-filter threshold from 256 to 512 selected roots.
  - Updates tests and C target notes with the boundary evidence and new default behavior.

  ## Testing

  - `python3 -m py_compile examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py tests/
  test_wam_c_candidate_filter_threshold_sweep.py`
  - `python3 tests/test_wam_c_candidate_filter_threshold_sweep.py`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
  - `python3 examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py --scales 50k_cats --profiles
  medium,boundary-800 --thresholds auto,off --repetitions 1 --run-timeout-seconds 180`
  - `git diff --check`