### PR TITLE
LLVM WAM: access/2 (M106) -- libc access wrapper

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1493,6 +1493,7 @@ declare i8* @getenv(i8*)
 declare i32 @setenv(i8*, i8*, i32)
 declare i32 @unsetenv(i8*)
 declare i32 @chmod(i8*, i32)
+declare i32 @access(i8*, i32)
 declare i64 @strlen(i8*)
 declare i32 @system(i8*)
 declare i8* @getcwd(i8*, i64)
@@ -3582,6 +3583,7 @@ entry:
     i32 122, label %builtin_chmod
     i32 123, label %builtin_term_variables
     i32 124, label %builtin_numbervars
+    i32 125, label %builtin_access
   ]
 
 builtin_is:
@@ -5555,6 +5557,35 @@ nv.go:
   %nv.raw3 = call %Value @wam_get_reg(%WamState* %vm, i32 2)
   %nv.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %nv.raw3, %Value %nv.end_v)
   ret i1 %nv.ok
+
+builtin_access:
+  ; M106: access(+Path, +ModeBits) -- Path Atom, ModeBits Integer.
+  ; libc access(path, mode) returns 0 iff the calling process has
+  ; the requested permission. Mode is the standard libc bitmask:
+  ; F_OK=0 (exists), R_OK=4, W_OK=2, X_OK=1, or any OR of those.
+  ; Non-atom Path or non-Integer ModeBits fail the type guards.
+  %ax.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %ax.t1 = call i32 @value_tag(%Value %ax.a1)
+  %ax.is_atom = icmp eq i32 %ax.t1, 0
+  br i1 %ax.is_atom, label %ax.check2, label %ax.fail
+ax.fail:
+  ret i1 false
+ax.check2:
+  %ax.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %ax.t2 = call i32 @value_tag(%Value %ax.a2)
+  %ax.is_int = icmp eq i32 %ax.t2, 1
+  br i1 %ax.is_int, label %ax.go, label %ax.fail
+ax.go:
+  %ax.aid = call i64 @value_payload(%Value %ax.a1)
+  %ax.path = call i8* @wam_atom_to_string(i64 %ax.aid)
+  %ax.path_null = icmp eq i8* %ax.path, null
+  br i1 %ax.path_null, label %ax.fail, label %ax.do
+ax.do:
+  %ax.mode64 = call i64 @value_payload(%Value %ax.a2)
+  %ax.mode = trunc i64 %ax.mode64 to i32
+  %ax.ret = call i32 @access(i8* %ax.path, i32 %ax.mode)
+  %ax.ok = icmp eq i32 %ax.ret, 0
+  ret i1 %ax.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -12625,6 +12656,7 @@ builtin_op_to_id('date_time_stamp/2', 121).   % mktime via date/9 compound.
 builtin_op_to_id('chmod/2', 122).             % libc chmod(Path, Mode).
 builtin_op_to_id('term_variables/2', 123).    % depth-first var collection.
 builtin_op_to_id('numbervars/3', 124).        % bind free vars to $VAR(N).
+builtin_op_to_id('access/2', 125).            % libc access(path, mode_bits).
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2093,6 +2093,7 @@ is_builtin_pred(getenv, 2).             % getenv(+Name, -Value).
 is_builtin_pred(setenv, 2).             % setenv(+Name, +Value).
 is_builtin_pred(unsetenv, 1).           % unsetenv(+Name).
 is_builtin_pred(chmod, 2).              % chmod(+Path, +Mode).
+is_builtin_pred(access, 2).             % access(+Path, +ModeBits) -- F_OK=0, R_OK=4, W_OK=2, X_OK=1.
 is_builtin_pred(shell, 1).              % shell(+Command).
 is_builtin_pred(shell, 2).              % shell(+Command, -Status).
 is_builtin_pred(working_directory, 2).  % working_directory(?Old, ?New).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,32 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M106: access/2 -- libc access(path, mode_bits). Mode is the libc
+% bitmask: F_OK=0, R_OK=4, W_OK=2, X_OK=1.
+
+:- dynamic test_access_tmp_exists/2.
+test_access_tmp_exists(_, R) :-
+    % /tmp exists -- F_OK (0) succeeds.
+    ( access('/tmp', 0) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_access_missing_file/2.
+test_access_missing_file(_, R) :-
+    % A path that doesn''t exist -- F_OK fails.
+    ( access('/tmp/uw_m106_definitely_not_here', 0) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_access_tmp_writable/2.
+test_access_tmp_writable(_, R) :-
+    % /tmp is world-writable -- W_OK (2) succeeds.
+    ( access('/tmp', 2) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_access_bad_args/2.
+test_access_bad_args(_, R) :-
+    % Non-atom path or non-int mode fail the type guards.
+    ( access(42, 0) -> R is 0
+    ; access('/tmp', not_an_int) -> R is 0
+    ; R is 1
+    ).   % 1
+
 % M105: numbervars/3 -- bind free vars to $VAR(N) compounds.
 
 :- dynamic test_nv_basic/2.
@@ -5154,6 +5180,15 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M106 access/2 ---~n'),
+       run_test_r0('access(/tmp, F_OK=0) -> 1',
+                   test_access_tmp_exists, 0, 1),
+       run_test_r0('access on missing path fails -> 1',
+                   test_access_missing_file, 0, 1),
+       run_test_r0('access(/tmp, W_OK=2) -> 1',
+                   test_access_tmp_writable, 0, 1),
+       run_test_r0('access with non-atom path / non-int mode fails -> 1',
+                   test_access_bad_args, 0, 1),
        format('--- M105 numbervars/3 ---~n'),
        run_test_r0('foo(X,Y,Z), nv 0 -> 3, vars 0/1/2 -> 1',
                    test_nv_basic, 0, 1),


### PR DESCRIPTION
## Summary

- **M106 `access/2`** — libc `access(path, mode_bits)` wrapper for file permission checks. Op id 125.

Reads reg 0 (Path) as Atom, reg 1 (ModeBits) as Integer, pulls the path string via `wam_atom_to_string`, truncates the `i64` ModeBits payload to `i32`, and calls libc `access`. Succeeds iff `access` returns 0. Non-atom Path or non-Integer Mode fall through to fail.

`Mode` is the standard libc bitmask:
- `F_OK = 0` — file exists
- `R_OK = 4` — read permission
- `W_OK = 2` — write permission
- `X_OK = 1` — execute permission
- any OR combination

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `@access` libc decl, dispatch entry, `builtin_access` IR block (prefix `ax.`), op-id table entry.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred(access, 2)`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — four M106 tests + section.

## Test plan

- [x] Full execution suite: **659/659 PASS**, no failures, no OOM
- [x] `test_access_tmp_exists`: `access('/tmp', 0)` (F_OK) ✓
- [x] `test_access_missing_file`: `access` on absent path correctly fails ✓
- [x] `test_access_tmp_writable`: `access('/tmp', 2)` (W_OK on world-writable dir) ✓
- [x] `test_access_bad_args`: non-atom path, non-int mode both fail type guards ✓

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_