### PR TITLE
WAM F# target: fix non-LMDB /4 regression + wire LMDB conformance into the runner

### DIFF
--- a/templates/targets/fsharp_wam/program.fs.mustache
+++ b/templates/targets/fsharp_wam/program.fs.mustache
@@ -358,19 +358,19 @@ let main argv =
         for cat in seedCats do
             let varId = 1000000
             let regs = Array.create MaxRegs (Unbound -1)
-            // Register layout depends on which queryPred resolved.  The /3
-            // candidates are lowered aggregate variants whose semantics fold
-            // a target root into the call shape, so A2 is the root and A3
-            // accumulates the result.  The /4 variant dispatches straight to
-            // the native category_ancestor kernel, whose register layout
-            // (recursive_kernel_detection.pl) is input(1)=cat, input(2)=ROOT,
-            // output(3)=hops, input(4)=visited.  So A2 must be the BOUND root
-            // (not an unbound output) or the kernel's `| Atom rootS ->`
-            // scrutinee never matches and every seed reports 0; A4 is seeded
-            // with [Cat] so the cycle-detection guard sees a real list.
+            // NON-LMDB path: facts live in WcFfiFacts (in-memory), so
+            // category_ancestor/4 runs as compiled WAM bytecode via
+            // dispatchCall, with the raw /4 shape category_ancestor(+Cat,
+            // -Ancestor, -Hops, +Visited): A2 and A3 are OUTPUTs (Unbound) and
+            // A4 is seeded with [Cat] for the cycle-detection guard. The /3
+            // lowered aggregates fold a target root in, so they use A2=root.
+            // (The LMDB int-native path does NOT use this loop -- it calls the
+            // native kernel directly in the has_lmdb branch above, where A2=root
+            // is the kernel's input(2). Conflating the two here regressed the
+            // non-LMDB category-ancestor smoke to solutions=0.)
             if queryPred.EndsWith "/4" then
                 regs.[1] <- Atom cat
-                regs.[2] <- Atom root
+                regs.[2] <- Unbound varId
                 regs.[3] <- Unbound (varId + 1)
                 regs.[4] <- VList [ Atom cat ]
             else
@@ -378,17 +378,7 @@ let main argv =
                 regs.[2] <- Atom root
                 regs.[3] <- Unbound varId
             let s0 = { emptyState with WsPC = 0; WsRegs = regs; WsCP = 0 }
-            // The /4 entry IS the native category_ancestor kernel: route it
-            // straight to executeForeign (via callForeign).  dispatchCall would
-            // instead run the compiled WAM bytecode for category_ancestor/4
-            // (it is present in WcLabels), which cannot resolve the
-            // category_parent fact source and so always fails.  The /3 lowered
-            // aggregates already wrap the kernel internally, so they keep the
-            // normal dispatchCall path.
-            let result =
-                if queryPred.EndsWith "/4" then callForeign ctx queryPred s0
-                else dispatchCall ctx queryPred s0
-            match result with
+            match dispatchCall ctx queryPred s0 with
             | Some s1 ->
                 repSolutions <- repSolutions + 1
             | None -> ()

--- a/tests/run_wam_fsharp_tests.pl
+++ b/tests/run_wam_fsharp_tests.pl
@@ -13,6 +13,13 @@
 %%     - dotnet build + run smokes (8 cases including category-ancestor
 %%       end-to-end + NAF micro-benchmark).  Each sub-case skips
 %%       gracefully if `dotnet` isn't on PATH.
+%%   tests/core/test_wam_lmdb_cross_target_conformance.pl
+%%     - builds a tiny int-native LMDB fixture (needs python3 + lmdb) and
+%%       asserts every available target's LMDB category_ancestor benchmark
+%%       agrees with the oracle.  F# eager/lazy/cached run when `dotnet` is
+%%       present; the Rust cursor leg is opt-in (UW_CONFORMANCE_RUST=1 + cargo).
+%%       All legs skip gracefully when their toolchain is absent.  This is the
+%%       guard for the LMDB-mode id-space divergence class (the Rust s2i bug).
 %%
 %% Exit code: 0 iff every spawned test exits 0.
 %%
@@ -34,6 +41,8 @@ fsharp_test('tests/test_wam_fsharp_target.pl',
             'F# WAM codegen tests').
 fsharp_test('tests/core/test_wam_fsharp_dotnet_smoke.pl',
             'F# WAM dotnet runtime smoke').
+fsharp_test('tests/core/test_wam_lmdb_cross_target_conformance.pl',
+            'WAM LMDB cross-target conformance (F# eager/lazy/cached vs oracle; Rust opt-in)').
 
 run_one(RelPath, Label, Status) :-
     repo_root(Root),


### PR DESCRIPTION
  Wiring the LMDB cross-target conformance test into the F# aggregator
  (`run_wam_fsharp_tests.pl`) immediately surfaced a regression: the non-LMDB
  category-ancestor dotnet smoke reported `solutions=0`.

  **Root cause** — Stage 1 (PR #2757) changed the *shared* `/4` benchmark-loop
  register setup to `A2=root + callForeign` (native kernel = "hops to a bound
  root"). Correct for the LMDB int-native path, but wrong for the non-LMDB path,
  where `category_ancestor/4` runs as compiled WAM bytecode over in-memory
  `WcFfiFacts` with the raw shape `(+Cat, -Ancestor, -Hops, +Visited)` — A2/A3 are
  outputs. The LMDB path later moved to its own direct-kernel loop
  (`{{#has_lmdb}}`), leaving `{{^has_lmdb}}` the only consumer of this loop but
  still carrying the LMDB-oriented setup. Red on main since #2757, unnoticed
  because the smoke wasn't in any invoked runner.

  **Fixes**
  - `program.fs` `{{^has_lmdb}}` loop: revert `/4` to `A2=Unbound`, `A4=VList[Cat]`,
    plain `dispatchCall`. LMDB int-native direct-kernel loop untouched.
  - `run_wam_fsharp_tests.pl`: register
    `tests/core/test_wam_lmdb_cross_target_conformance.pl` (self-runs via
    `:- initialization(main)`; legs skip-guard on python-lmdb/dotnet/cargo).

  Verified: **F# WAM suite 3/3** (codegen + dotnet smoke incl. category-ancestor
  now PASS at solutions=21 + LMDB conformance 970/3).

  🤖 Generated with [Claude Code](https://claude.com/claude-code)