### PR TITLE
feat(wam-clojure): lower keysort/2 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -432,6 +432,10 @@ clojure_direct_builtin("msort/2", "2").
 clojure_direct_builtin("msort/2", 2).
 clojure_direct_builtin('msort/2', "2").
 clojure_direct_builtin('msort/2', 2).
+clojure_direct_builtin("keysort/2", "2").
+clojure_direct_builtin("keysort/2", 2).
+clojure_direct_builtin('keysort/2', "2").
+clojure_direct_builtin('keysort/2', 2).
 clojure_direct_builtin("copy_term/2", "2").
 clojure_direct_builtin("copy_term/2", 2).
 clojure_direct_builtin('copy_term/2', "2").
@@ -848,6 +852,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "msort/2" ; Op == 'msort/2'),
     !,
     format(atom(Expr), '(runtime/apply-msort-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "keysort/2" ; Op == 'keysort/2'),
+    !,
+    format(atom(Expr), '(runtime/apply-keysort-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "copy_term/2" ; Op == 'copy_term/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1205,6 +1205,32 @@
 (defn sorted-list? [state items]
   (= items (vec (sorted-terms state items))))
 
+(defn pair-term-key [state value]
+  (let [value* (deref-value (:bindings state) value)]
+    (when (and (structure-term? value*)
+               (= "-/2" (functor-key (:intern-context state) (:functor value*)))
+               (= 2 (count (:args value*))))
+      (first (:args value*)))))
+
+(defn keyed-pairs [state items]
+  (loop [remaining items
+         idx 0
+         out []]
+    (if-let [item (first remaining)]
+      (if-let [key (pair-term-key state item)]
+        (recur (rest remaining) (inc idx) (conj out {:key key :idx idx :pair item}))
+        nil)
+      out)))
+
+(defn sorted-keyed-pairs [state keyed]
+  (mapv :pair
+        (sort (fn [left right]
+                (let [key-cmp (term-compare state (:key left) (:key right))]
+                  (if (zero? key-cmp)
+                    (compare (:idx left) (:idx right))
+                    key-cmp)))
+              keyed)))
+
 (defn apply-sort-solution [state]
   (let [list-value (deref-value (:bindings state)
                                 (or (reg-get-raw state "A1") ::unbound))
@@ -1248,6 +1274,22 @@
               (backtrack state)))
           (backtrack state))
         (backtrack state)))))
+
+(defn apply-keysort-solution [state]
+  (let [list-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A2") ::unbound))]
+    (if-let [items (proper-list-items state list-value)]
+      (if-let [keyed (keyed-pairs state items)]
+        (let [sorted-term (list->term (:intern-context state)
+                                      (sorted-keyed-pairs state keyed))
+              [ok next-state] (unify-values state out sorted-term)]
+          (if ok
+            (advance next-state)
+            (backtrack state)))
+        (backtrack state))
+      (backtrack state))))
 
 (defn atom-text [state value]
   (cond
@@ -2591,6 +2633,9 @@
 
           "msort/2"
           (apply-msort-solution state)
+
+          "keysort/2"
+          (apply-keysort-solution state)
 
           "copy_term/2"
           (apply-copy-term-solution state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -131,6 +131,12 @@
 :- dynamic user:wam_msort_guard/2.
 :- dynamic user:wam_msort_bad_list/1.
 :- dynamic user:wam_msort_unbound_list/1.
+:- dynamic user:wam_keysort_guard/2.
+:- dynamic user:wam_keysort_stable/0.
+:- dynamic user:wam_keysort_atom_keys/0.
+:- dynamic user:wam_keysort_empty/0.
+:- dynamic user:wam_keysort_bad_list/1.
+:- dynamic user:wam_keysort_bad_pair/0.
 :- dynamic user:wam_copy_term_guard/2.
 :- dynamic user:wam_copy_term_sharing_fail/0.
 :- dynamic user:wam_copy_term_independent_ok/0.
@@ -451,6 +457,12 @@ user:wam_sort_unbound_list(S) :- sort(L, S), is_list(L).
 user:wam_msort_guard(L, S) :- msort(L, S).
 user:wam_msort_bad_list(S) :- msort([a|b], S).
 user:wam_msort_unbound_list(S) :- msort(L, S), is_list(L).
+user:wam_keysort_guard(Pairs, Sorted) :- keysort(Pairs, Sorted).
+user:wam_keysort_stable :- keysort([2-first,1-x,2-second,1-y], Sorted), Sorted = [1-x,1-y,2-first,2-second].
+user:wam_keysort_atom_keys :- keysort([banana-2,apple-1,cherry-3], Sorted), Sorted = [apple-1,banana-2,cherry-3].
+user:wam_keysort_empty :- keysort([], Sorted), Sorted = [].
+user:wam_keysort_bad_list(_) :- keysort([a|b], _).
+user:wam_keysort_bad_pair :- keysort([not_a_pair], _).
 user:wam_copy_term_guard(A, B) :- copy_term(A, B).
 user:wam_copy_term_sharing_fail :- user:wam_unbound_arg(X), copy_term(f(X, X), f(a, b)).
 user:wam_copy_term_independent_ok :- copy_term(f(_, _), f(a, b)).
@@ -776,6 +788,12 @@ run_smoke :-
           user:wam_msort_guard/2,
           user:wam_msort_bad_list/1,
           user:wam_msort_unbound_list/1,
+          user:wam_keysort_guard/2,
+          user:wam_keysort_stable/0,
+          user:wam_keysort_atom_keys/0,
+          user:wam_keysort_empty/0,
+          user:wam_keysort_bad_list/1,
+          user:wam_keysort_bad_pair/0,
           user:wam_copy_term_guard/2,
           user:wam_copy_term_sharing_fail/0,
           user:wam_copy_term_independent_ok/0,
@@ -1007,6 +1025,7 @@ run_smoke :-
     assert_lowered_delete_builtin_emitted(TmpDir),
     assert_lowered_sort_builtin_emitted(TmpDir),
     assert_lowered_msort_builtin_emitted(TmpDir),
+    assert_lowered_keysort_builtin_emitted(TmpDir),
     assert_lowered_copy_term_builtin_emitted(TmpDir),
     assert_lowered_term_variables_builtin_emitted(TmpDir),
     assert_lowered_variant_builtin_emitted(TmpDir),
@@ -1254,6 +1273,13 @@ smoke_cases([
     case('wam_msort_bad_list/1', '[a,b,c]', "false"),
     case('wam_msort_unbound_list/1', '[a,b,c]', "true"),
     case('wam_msort_unbound_list/1', '[a,a,b,c]', "true"),
+    case('wam_keysort_guard/2', args('[3-a,1-b,2-c]', '[1-b,2-c,3-a]'), "true"),
+    case('wam_keysort_guard/2', args('[3-a,1-b,2-c]', '[1-b,3-a,2-c]'), "false"),
+    case('wam_keysort_stable/0', no_args, "true"),
+    case('wam_keysort_atom_keys/0', no_args, "true"),
+    case('wam_keysort_empty/0', no_args, "true"),
+    case('wam_keysort_bad_list/1', a, "false"),
+    case('wam_keysort_bad_pair/0', no_args, "false"),
     case('wam_copy_term_guard/2', args(a, a), "true"),
     case('wam_copy_term_guard/2', args(a, b), "false"),
     case('wam_copy_term_guard/2', args('f(a)', 'f(a)'), "true"),
@@ -1760,6 +1786,14 @@ assert_lowered_msort_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-msort-unbound-list-1"),
     has(CoreCode, "runtime/apply-msort-solution").
 
+assert_lowered_keysort_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-keysort-guard-2"),
+    has(CoreCode, "defn lowered-wam-keysort-stable-0"),
+    has(CoreCode, "defn lowered-wam-keysort-bad-pair-0"),
+    has(CoreCode, "runtime/apply-keysort-solution").
+
 assert_lowered_copy_term_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
@@ -2090,6 +2124,9 @@ prolog_term_string_to_edn('[1,2,3]', "{:tag :struct :functor \"[|]/2\" :args [1 
 prolog_term_string_to_edn('[1,3]', "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[2,3]', "{:tag :struct :functor \"[|]/2\" :args [2 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[2]', "{:tag :struct :functor \"[|]/2\" :args [2 \"[]\"]}") :- !.
+prolog_term_string_to_edn('[3-a,1-b,2-c]', "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [3 \"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [1 \"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [2 \"c\"]} \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn('[1-b,2-c,3-a]', "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [1 \"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [2 \"c\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [3 \"a\"]} \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn('[1-b,3-a,2-c]', "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [1 \"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [3 \"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [2 \"c\"]} \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[f,o]', "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"o\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[f,o,o]', "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"o\" {:tag :struct :functor \"[|]/2\" :args [\"o\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[''4'']', "{:tag :struct :functor \"[|]/2\" :args [\"4\" \"[]\"]}") :- !.
@@ -2123,6 +2160,9 @@ prolog_term_string_to_edn("[102,111,111]", "{:tag :struct :functor \"[|]/2\" :ar
 prolog_term_string_to_edn("[1,2,3]", "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [2 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[1,3]", "{:tag :struct :functor \"[|]/2\" :args [1 {:tag :struct :functor \"[|]/2\" :args [3 \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[2]", "{:tag :struct :functor \"[|]/2\" :args [2 \"[]\"]}") :- !.
+prolog_term_string_to_edn("[3-a,1-b,2-c]", "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [3 \"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [1 \"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [2 \"c\"]} \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn("[1-b,2-c,3-a]", "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [1 \"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [2 \"c\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [3 \"a\"]} \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn("[1-b,3-a,2-c]", "{:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [1 \"b\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [3 \"a\"]} {:tag :struct :functor \"[|]/2\" :args [{:tag :struct :functor \"-/2\" :args [2 \"c\"]} \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[f,o]", "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"o\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[f,o,o]", "{:tag :struct :functor \"[|]/2\" :args [\"f\" {:tag :struct :functor \"[|]/2\" :args [\"o\" {:tag :struct :functor \"[|]/2\" :args [\"o\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("['4']", "{:tag :struct :functor \"[|]/2\" :args [\"4\" \"[]\"]}") :- !.


### PR DESCRIPTION
## Summary

- Adds `keysort/2` to the Clojure lowered WAM direct builtin set.
- Implements `runtime/apply-keysort-solution` for stable sorting of `Key-Value` pairs by key.
- Reuses the existing Clojure WAM standard term comparator for key ordering.
- Adds runtime smoke coverage for integer keys, stable duplicate keys, atom keys, empty lists, improper lists, and non-pair elements.

## Why

The Clojure WAM target already supports `sort/2` and `msort/2`. Adding `keysort/2` closes the next adjacent list-ordering parity gap and aligns Clojure with recent Go WAM keysort coverage.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`

