### PR TITLE
Add WAM-C control opcode parity

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,17 +4,16 @@ Status date: 2026-06-05
 
 Latest branch verification:
 
-- `investigate/wam-c-candidate-filter-observability` based on `main` at
-  `eb5f5353` (`Merge pull request #2801 from
-  s243a/investigate/wam-c-candidate-filter-boundary-repeatability`)
-- `python3 -m py_compile examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py tests/test_wam_c_candidate_filter_threshold_sweep.py`
-- `python3 tests/test_wam_c_candidate_filter_threshold_sweep.py`
-- `python3 examples/benchmark/benchmark_wam_c_candidate_filter_threshold_sweep.py --scales dev --profiles low --thresholds auto,off --repetitions 1 --run-timeout-seconds 120`
+- `investigate/wam-c-control-builtins-parity` based on `main` at `a3a279f9`
+  (`Merge pull request #2805 from
+  s243a/investigate/wam-c-candidate-filter-observability`)
+- `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-candidate-filter-observability`
+- `investigate/wam-c-control-builtins-parity`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -78,6 +77,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | `astar_shortest_path4` native kernel | Done | C shared-kernel detector accepts `astar_shortest_path4`, emits detected setup, registers a native arity-4 foreign handler, and covers direct plus detected-project executable smokes over weighted and direct-distance edges |
 | Accumulated runtime edge-index fix | Done | Lazy child indexes for `WamState` and `WamFactSource` remove repeated full-edge scans; `10x` accumulated C targets now run around 0.065-0.071s with output parity versus Prolog at 0.202s |
 | Native weighted-kernel float output | Done | C runtime has `VAL_FLOAT`, numeric unification, double weighted/direct edge storage, and executable weighted/A* smokes for fractional 1.5 results while preserving exact-integer outputs as `VAL_INT` |
+| Control instruction parity smoke | Done | `INSTR_GET_LEVEL`, `INSTR_CUT`, `INSTR_CUT_ITE`, and `INSTR_JUMP` now parse, emit, and execute; generated executable smoke covers `\+/1` and if-then-else success/failure paths |
 
 ## Current C Target Baseline
 
@@ -88,8 +88,9 @@ The C target is now a credible small WAM backend:
   structures, lists, and unification.
 - Supports `set_variable`, `set_value`, and `set_constant` for generated body
   term construction.
-- Supports `call`, `execute`, `proceed`, `allocate`, `deallocate`, and
-  choice-point instructions.
+- Supports `call`, `execute`, `proceed`, `allocate`, `deallocate`,
+  choice-point instructions, and control opcodes for `get_level`, `cut`,
+  `cut_ite`, and `jump`.
 - Supports `switch_on_constant`, `switch_on_structure`, `switch_on_term`,
   second-argument constant dispatch, and direct list dispatch.
 - Uses a tagged `InstructionPayload` union instead of a single wide instruction
@@ -125,8 +126,8 @@ The C target is now a credible small WAM backend:
   `kernels_on` / `kernels_off` accumulated target pairs.
 - Has executable smokes for generated runtime, cross-predicate calls,
   foreign calls, native category ancestor, file-backed facts, streaming native
-  results, real multi-clause predicates, structure indexing, `is_list/1`, and
-  `=/2`.
+  results, real multi-clause predicates, structure indexing, `is_list/1`,
+  `=/2`, negation, and if-then-else.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -150,7 +151,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
 | Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
-| Negation / control builtins | Partial | Broader | Broader | C likely needs explicit tests for `\+/1`, cut interactions, and if-then-else lowering. |
+| Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1` and if-then-else; residual work is broader cut/control interaction coverage. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
 | Shared kernel detector integration | Partial/Done | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`, `transitive_closure2`, `transitive_distance3`, `transitive_parent_distance4`, `transitive_step_parent_distance5`, `weighted_shortest_path3`, and `astar_shortest_path4`; Haskell and Rust still have broader wrapper/fact-layout integration. |
@@ -163,6 +164,27 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-control-builtins-parity`
+
+Goal: close the immediate C control-instruction parity gap for the shared WAM
+compiler opcodes used by negation and if-then-else lowering.
+
+Evidence:
+
+- C runtime tags, payloads, parser support, generated literals, and dispatch
+  arms now cover `get_level`, `cut`, `cut_ite`, and `jump`.
+- Generated executable smoke coverage exercises `\+/1` and if-then-else for
+  both success and failure paths.
+- The focused WAM-C target suite and effective-distance benchmark suite pass.
+
+Reason:
+
+- The C target already had choice points and builtin dispatch, but generated
+  Prolog control constructs could still emit unsupported shared WAM opcodes.
+- Supporting these opcodes is a narrow parity step with Rust/Haskell behavior
+  and keeps the next benchmark-driven gaps from being blocked by control-flow
+  lowering.
 
 ### Completed: `feat/wam-c-native-kernel-float-output`
 

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -85,6 +85,7 @@ typedef enum {
     INSTR_CALL, INSTR_EXECUTE, INSTR_PROCEED,
     INSTR_ALLOCATE, INSTR_DEALLOCATE,
     INSTR_TRY_ME_ELSE, INSTR_RETRY_ME_ELSE, INSTR_TRUST_ME,
+    INSTR_GET_LEVEL, INSTR_CUT, INSTR_CUT_ITE, INSTR_JUMP,
     INSTR_SWITCH_ON_CONSTANT, INSTR_SWITCH_ON_STRUCTURE, INSTR_SWITCH_ON_TERM,
     INSTR_BUILTIN_CALL, INSTR_CALL_FOREIGN,
     INSTR_NOOP
@@ -225,6 +226,10 @@ typedef struct {
 } WamChoiceInstr;
 
 typedef struct {
+    int target_pc;
+} WamJumpInstr;
+
+typedef struct {
     int reg;
     HashEntry *hash_table;
     int hash_size;
@@ -241,6 +246,7 @@ typedef union {
     WamFunctorInstr functor;
     WamPredInstr pred;
     WamChoiceInstr choice;
+    WamJumpInstr jump;
     WamSwitchInstr switch_index;
 } InstructionPayload;
 

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -1615,6 +1615,15 @@ wam_instruction_to_c_literal(builtin_call(Op, N), Code) :-
     format(atom(Code), '{ .tag = INSTR_BUILTIN_CALL, .as.pred = { .pred = "~w", .arity = ~w } }', [Op, N]).
 wam_instruction_to_c_literal(call_foreign(P, N), Code) :-
     format(atom(Code), '{ .tag = INSTR_CALL_FOREIGN, .as.pred = { .pred = "~w", .arity = ~w } }', [P, N]).
+wam_instruction_to_c_literal(get_level(Reg), Code) :-
+    c_reg_index(Reg, IsY, Idx),
+    format(atom(Code), '{ .tag = INSTR_GET_LEVEL, .as.reg = { .reg = ~w, .is_y_reg = ~w } }', [Idx, IsY]).
+wam_instruction_to_c_literal(cut(Reg), Code) :-
+    c_reg_index(Reg, IsY, Idx),
+    format(atom(Code), '{ .tag = INSTR_CUT, .as.reg = { .reg = ~w, .is_y_reg = ~w } }', [Idx, IsY]).
+wam_instruction_to_c_literal(cut_ite, '{ .tag = INSTR_CUT_ITE }').
+wam_instruction_to_c_literal(jump(_Label), _) :-
+    throw(error(context_error(missing_label_map, "jump/1 requires LabelMap for target_pc resolution. Use wam_instruction_to_c_literal/3 instead."), _)).
 wam_instruction_to_c_literal(try_me_else(_Label), _) :-
     throw(error(context_error(missing_label_map, "try_me_else/1 requires LabelMap for target_pc resolution. Use wam_instruction_to_c_literal/3 instead."), _)).
 wam_instruction_to_c_literal(retry_me_else(_Label), _) :-
@@ -1634,6 +1643,9 @@ wam_instruction_to_c_literal(try_me_else(Label), LabelMap, Code) :-
 wam_instruction_to_c_literal(retry_me_else(Label), LabelMap, Code) :-
     ( member(Label-TargetPC, LabelMap) -> true ; TargetPC = -1 ),
     format(atom(Code), '{ .tag = INSTR_RETRY_ME_ELSE, .as.choice = { .target_pc = ~w } }', [TargetPC]).
+wam_instruction_to_c_literal(jump(Label), LabelMap, Code) :-
+    ( member(Label-TargetPC, LabelMap) -> true ; TargetPC = -1 ),
+    format(atom(Code), '{ .tag = INSTR_JUMP, .as.jump = { .target_pc = ~w } }', [TargetPC]).
 wam_instruction_to_c_literal(Instr, _, Code) :- wam_instruction_to_c_literal(Instr, Code).
 
 
@@ -1756,6 +1768,18 @@ wam_line_to_c_instr(["builtin_call", Op, N], Instr) :-
 wam_line_to_c_instr(["call_foreign", P, N], Instr) :-
     clean_comma(P, CP), clean_comma(N, CN),
     format(atom(Instr), '{ .tag = INSTR_CALL_FOREIGN, .as.pred = { .pred = "~w", .arity = ~w } }', [CP, CN]).
+wam_line_to_c_instr(["get_level", Reg], Instr) :-
+    clean_comma(Reg, CReg),
+    c_reg_index(CReg, IsY, Idx),
+    format(atom(Instr), '{ .tag = INSTR_GET_LEVEL, .as.reg = { .reg = ~w, .is_y_reg = ~w } }', [Idx, IsY]).
+wam_line_to_c_instr(["cut", Reg], Instr) :-
+    clean_comma(Reg, CReg),
+    c_reg_index(CReg, IsY, Idx),
+    format(atom(Instr), '{ .tag = INSTR_CUT, .as.reg = { .reg = ~w, .is_y_reg = ~w } }', [Idx, IsY]).
+wam_line_to_c_instr(["jump", L], LabelMap, _Arity, OffsetVar, Instr) :-
+    clean_comma(L, CL),
+    ( member(CL-TargetPC0, LabelMap) -> c_pc_expr(OffsetVar, TargetPC0, TargetPC) ; TargetPC = -1 ),
+    format(atom(Instr), '{ .tag = INSTR_JUMP, .as.jump = { .target_pc = ~w } }', [TargetPC]).
 wam_line_to_c_instr(["try_me_else", L], LabelMap, Arity, OffsetVar, Instr) :-
     clean_comma(L, CL),
     ( member(CL-TargetPC0, LabelMap) -> c_pc_expr(OffsetVar, TargetPC0, TargetPC) ; TargetPC = -1 ),
@@ -1765,6 +1789,7 @@ wam_line_to_c_instr(["retry_me_else", L], LabelMap, Arity, OffsetVar, Instr) :-
     ( member(CL-TargetPC0, LabelMap) -> c_pc_expr(OffsetVar, TargetPC0, TargetPC) ; TargetPC = -1 ),
     format(atom(Instr), '{ .tag = INSTR_RETRY_ME_ELSE, .as.choice = { .target_pc = ~w, .arity = ~w } }', [TargetPC, Arity]).
 wam_line_to_c_instr(["trust_me"], _, '{ .tag = INSTR_TRUST_ME }').
+wam_line_to_c_instr(["cut_ite"], _, '{ .tag = INSTR_CUT_ITE }').
 wam_line_to_c_instr(["proceed"], _, '{ .tag = INSTR_PROCEED }').
 wam_line_to_c_instr(["allocate"], _, '{ .tag = INSTR_ALLOCATE }').
 wam_line_to_c_instr(["deallocate"], _, '{ .tag = INSTR_DEALLOCATE }').
@@ -2090,6 +2115,33 @@ compile_step_wam_to_c(_Options, CCode) :-
             case INSTR_TRUST_ME: {
                 pop_choice_point(state);
                 state->P++;
+                return true;
+            }
+            case INSTR_GET_LEVEL: {
+                WamValue *cell = resolve_reg(state, instr->as.reg.reg, instr->as.reg.is_y_reg);
+                *cell = val_int(state->B);
+                state->P++;
+                return true;
+            }
+            case INSTR_CUT: {
+                WamValue *cell = wam_deref_ptr(state, resolve_reg(state, instr->as.reg.reg, instr->as.reg.is_y_reg));
+                if (cell->tag != VAL_INT) return false;
+                int target_b = cell->data.integer;
+                if (target_b < 0 || target_b > state->B) return false;
+                wam_prune_choice_points(state, target_b);
+                state->P++;
+                return true;
+            }
+            case INSTR_CUT_ITE: {
+                if (state->B <= 0) return false;
+                pop_choice_point(state);
+                state->P++;
+                return true;
+            }
+            case INSTR_JUMP: {
+                int target = instr->as.jump.target_pc;
+                if (target < 0) return false;
+                state->P = target;
                 return true;
             }
             case INSTR_SWITCH_ON_CONSTANT: {

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -127,6 +127,35 @@ test_control_flow_instructions :-
     ;   fail_test(Test, 'missing control flow instruction arms')
     ).
 
+test_control_cut_jump_instructions :-
+    Test = 'WAM-C: cut and jump control instructions present',
+    (   implemented_wam_c_cases(Cases),
+        member(get_level, Cases),
+        member(cut, Cases),
+        member(cut_ite, Cases),
+        member(jump, Cases),
+        compile_step_wam_to_c([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'wam_prune_choice_points(state, target_b)'),
+        sub_string(S, _, _, _, 'state->P = target')
+    ->  pass(Test)
+    ;   fail_test(Test, 'missing cut/jump control instruction arms')
+    ).
+
+test_control_instruction_parsing :-
+    Test = 'WAM-C: cut and jump instructions parse to typed payloads',
+    WamCode = 'wam_c_ctrl_parse/1:\n    get_level Y1\n    try_me_else L_else\n    cut Y1\n    cut_ite\n    jump L_done\nL_else:\n    trust_me\nL_done:\n    proceed',
+    (   compile_wam_predicate_to_c(user:wam_c_ctrl_parse/1, WamCode, [], CCode),
+        atom_string(CCode, S),
+        sub_string(S, _, _, _, 'INSTR_GET_LEVEL'),
+        sub_string(S, _, _, _, 'INSTR_CUT'),
+        sub_string(S, _, _, _, 'INSTR_CUT_ITE'),
+        sub_string(S, _, _, _, 'INSTR_JUMP'),
+        sub_string(S, _, _, _, '.as.jump = { .target_pc = base_pc +')
+    ->  pass(Test)
+    ;   fail_test(Test, 'cut/jump instruction parsing missing typed payloads')
+    ).
+
 test_choice_point_instructions :-
     Test = 'WAM-C: choice point instructions present',
     (   implemented_wam_c_cases(Cases),
@@ -1600,6 +1629,16 @@ test_real_prolog_unify_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_real_prolog_control_executable_smoke :-
+    Test = 'WAM-C: real Prolog negation and if-then-else executable smoke',
+    (   gcc_available
+    ->  (   run_real_prolog_control_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'real Prolog control executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_real_prolog_classic_recursive_executable_smoke :-
     Test = 'WAM-C: real Prolog classic recursive executable smoke',
     (   gcc_available
@@ -2432,6 +2471,52 @@ run_real_prolog_unify_executable_smoke :-
     ;   retractall(user:wam_c_real_unify(_, _)),
         fail
     ).
+
+run_real_prolog_control_executable_smoke :-
+    assertz((user:wam_c_ctrl_known(a) :- true)),
+    assertz((user:wam_c_ctrl_neg(X, ok) :- \+ wam_c_ctrl_known(X))),
+    assertz((user:wam_c_ctrl_if_known(X, yes) :-
+        (wam_c_ctrl_known(X) -> true ; fail))),
+    assertz((user:wam_c_ctrl_if_missing(X, no) :-
+        (wam_c_ctrl_known(X) -> fail ; true))),
+    (   compile_predicate_to_wam(user:wam_c_ctrl_known/1, [], WamKnown),
+        compile_predicate_to_wam(user:wam_c_ctrl_neg/2, [], WamNeg),
+        compile_predicate_to_wam(user:wam_c_ctrl_if_known/2, [], WamIfKnown),
+        compile_predicate_to_wam(user:wam_c_ctrl_if_missing/2, [], WamIfMissing),
+        sub_string(WamNeg, _, _, _, 'jump '),
+        sub_string(WamIfKnown, _, _, _, 'cut_ite'),
+        sub_string(WamIfKnown, _, _, _, 'jump '),
+        sub_string(WamIfMissing, _, _, _, 'cut_ite'),
+        compile_wam_predicate_to_c(user:wam_c_ctrl_known/1, WamKnown, [], KnownCode),
+        compile_wam_predicate_to_c(user:wam_c_ctrl_neg/2, WamNeg, [], NegCode),
+        compile_wam_predicate_to_c(user:wam_c_ctrl_if_known/2, WamIfKnown, [], IfKnownCode),
+        compile_wam_predicate_to_c(user:wam_c_ctrl_if_missing/2, WamIfMissing, [], IfMissingCode),
+        atomic_list_concat([KnownCode, NegCode, IfKnownCode, IfMissingCode], '\n\n', PredCode),
+        compile_wam_runtime_to_c([], RuntimeCode),
+        get_time(Now),
+        Stamp is round(Now * 1000000),
+        wam_c_temp_path('unifyweaver_wam_c_real_control_smoke', Stamp, TmpBase),
+        format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+        format(atom(PredPath), '~w_pred.c', [TmpBase]),
+        format(atom(MainPath), '~w_main.c', [TmpBase]),
+        format(atom(ExePath), '~w_bin', [TmpBase]),
+        write_text_file(RuntimePath, RuntimeCode),
+        format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+        write_text_file(PredPath, PredTranslationUnit),
+        wam_c_real_control_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_real_control_smoke
+    ;   cleanup_wam_c_real_control_smoke,
+        fail
+    ).
+
+cleanup_wam_c_real_control_smoke :-
+    retractall(user:wam_c_ctrl_known(_)),
+    retractall(user:wam_c_ctrl_neg(_, _)),
+    retractall(user:wam_c_ctrl_if_known(_, _)),
+    retractall(user:wam_c_ctrl_if_missing(_, _)).
 
 run_real_prolog_classic_recursive_executable_smoke :-
     assertz((user:wam_c_classic_fib(0, 0) :- true)),
@@ -5206,6 +5291,69 @@ int main(void) {
 }
 ').
 
+wam_c_real_control_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_ctrl_known_1(WamState* state);
+void setup_wam_c_ctrl_neg_2(WamState* state);
+void setup_wam_c_ctrl_if_known_2(WamState* state);
+void setup_wam_c_ctrl_if_missing_2(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_ctrl_known_1(&state);
+    setup_wam_c_ctrl_neg_2(&state);
+    setup_wam_c_ctrl_if_known_2(&state);
+    setup_wam_c_ctrl_if_missing_2(&state);
+
+    WamValue neg_success_args[2] = { val_atom("b"), val_atom("ok") };
+    int neg_success_rc = wam_run_predicate(&state, "wam_c_ctrl_neg/2", neg_success_args, 2);
+    if (neg_success_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue neg_fail_args[2] = { val_atom("a"), val_atom("ok") };
+    int neg_fail_rc = wam_run_predicate(&state, "wam_c_ctrl_neg/2", neg_fail_args, 2);
+    if (neg_fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue if_known_success_args[2] = { val_atom("a"), val_atom("yes") };
+    int if_known_success_rc = wam_run_predicate(&state, "wam_c_ctrl_if_known/2", if_known_success_args, 2);
+    if (if_known_success_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    WamValue if_known_fail_args[2] = { val_atom("b"), val_atom("yes") };
+    int if_known_fail_rc = wam_run_predicate(&state, "wam_c_ctrl_if_known/2", if_known_fail_args, 2);
+    if (if_known_fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    WamValue if_missing_success_args[2] = { val_atom("b"), val_atom("no") };
+    int if_missing_success_rc = wam_run_predicate(&state, "wam_c_ctrl_if_missing/2", if_missing_success_args, 2);
+    if (if_missing_success_rc != 0 || state.P != WAM_HALT) {
+        wam_free_state(&state);
+        return 50;
+    }
+
+    WamValue if_missing_fail_args[2] = { val_atom("a"), val_atom("no") };
+    int if_missing_fail_rc = wam_run_predicate(&state, "wam_c_ctrl_if_missing/2", if_missing_fail_args, 2);
+    if (if_missing_fail_rc != WAM_HALT) {
+        wam_free_state(&state);
+        return 60;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_classic_fib_smoke_main(
 '#include "wam_runtime.h"
 
@@ -5282,6 +5430,10 @@ implemented_case(call_foreign, 'case INSTR_CALL_FOREIGN').
 implemented_case(try_me_else, 'case INSTR_TRY_ME_ELSE').
 implemented_case(retry_me_else, 'case INSTR_RETRY_ME_ELSE').
 implemented_case(trust_me, 'case INSTR_TRUST_ME').
+implemented_case(get_level, 'case INSTR_GET_LEVEL').
+implemented_case(cut, 'case INSTR_CUT').
+implemented_case(cut_ite, 'case INSTR_CUT_ITE').
+implemented_case(jump, 'case INSTR_JUMP').
 implemented_case(switch_on_constant, 'case INSTR_SWITCH_ON_CONSTANT').
 implemented_case(switch_on_structure, 'case INSTR_SWITCH_ON_STRUCTURE').
 implemented_case(switch_on_term, 'case INSTR_SWITCH_ON_TERM').
@@ -5315,6 +5467,8 @@ run_tests_once :-
     test_body_construction_instructions,
     test_unification_instructions,
     test_control_flow_instructions,
+    test_control_cut_jump_instructions,
+    test_control_instruction_parsing,
     test_choice_point_instructions,
     test_choice_point_content,
     test_switch_on_term_list_dispatch,
@@ -5404,6 +5558,7 @@ run_tests_once :-
     test_real_prolog_structure_index_executable_smoke,
     test_real_prolog_is_list_executable_smoke,
     test_real_prolog_unify_executable_smoke,
+    test_real_prolog_control_executable_smoke,
     test_real_prolog_classic_recursive_executable_smoke,
     test_lowered_fact_helper_executable_smoke,
     test_lowered_body_call_helper_executable_smoke,


### PR DESCRIPTION
  ## Summary

  - Add WAM-C runtime support for `get_level`, `cut`, `cut_ite`, and `jump`
  - Add parser and generated C literal support for those control opcodes
  - Add executable smoke coverage for generated Prolog `\+/1` and if-then-else success/failure paths
  - Update the WAM-C next-steps doc to record the completed control parity slice

  ## Validation

  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
  - `git diff --check`