### PR TITLE
ci(wam): add sampled cross-target conformance smoke

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,36 @@ jobs:
           echo "✓ Visualization glue tests (478 tests)"
           echo "=========================================="
 
+  wam_conformance_smoke:
+    name: WAM Conformance Smoke (${{ matrix.target }})
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [scala, elixir, wat, haskell, python, go, rust, c, cpp]
+    env:
+      CONFORMANCE_TARGETS: ${{ matrix.target }}
+      CONFORMANCE_PROGRAMS: member,builtins
+      CONFORMANCE_SAMPLE: 2
+      CONFORMANCE_SEED: ${{ github.run_number }}
+      UW_SMOKE_TMPDIR: ${{ runner.temp }}/unifyweaver-smoke
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install SWI-Prolog
+        run: bash scripts/ci/install_swi_prolog.sh
+
+      - name: Create smoke temp root
+        run: mkdir -p "$UW_SMOKE_TMPDIR"
+
+      - name: Run sampled WAM conformance
+        run: |
+          swipl -q -f init.pl -s tests/test_wam_cross_target_conformance.pl -g "seed_sampler,run_tests" -t halt
+
   csharp_query_runtime_smoke:
     name: C# Query Runtime Smoke
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'

--- a/docs/WAM_CROSS_TARGET_CONFORMANCE.md
+++ b/docs/WAM_CROSS_TARGET_CONFORMANCE.md
@@ -72,16 +72,20 @@ local Scala maven cache.
 
 Suggested CI tiers:
 
-- **fast / every push:** `CONFORMANCE_PROGRAMS=member,builtins
-  CONFORMANCE_SAMPLE=2` — broad builtin coverage, set operation, minimal
-  compute. Seed varies per run so sampling rotates coverage.
+- **fast / PR + main smoke:** one backend per matrix job with
+  `CONFORMANCE_TARGETS=<target> CONFORMANCE_PROGRAMS=member,builtins
+  CONFORMANCE_SAMPLE=2 CONFORMANCE_SEED=<run number>` — broad builtin
+  coverage, set operation, minimal compute, and failures attributed to a
+  single backend. Missing toolchains still skip through the harness's
+  normal `ct_available/1` guards.
 - **full / nightly or pre-merge:** no sampling — every program, every
   query, every available backend.
 
 Because random sampling is nondeterministic, a real divergence can pass
 one push and fail the next, which is confusing for whoever's bisecting.
-CI should **log the `CONFORMANCE_SEED` it used** (and set one explicitly)
-so any failure is reproducible from the recorded seed.
+CI sets `CONFORMANCE_SEED` explicitly, and the harness logs
+`CONFORMANCE_SEED=<n>` once per run so any failure is reproducible from
+the recorded seed.
 
 ## Known divergences (tracked as `ct_xfail/2`)
 

--- a/tests/test_wam_cross_target_conformance.pl
+++ b/tests/test_wam_cross_target_conformance.pl
@@ -348,8 +348,21 @@ run_target_conformance(Target) :-
     ).
 
 seed_sampler :-
-    ( getenv('CONFORMANCE_SEED', S), atom_number(S, Seed)
-    -> set_random(seed(Seed)) ; true ).
+    (   getenv('CONFORMANCE_SEED', S), S \== ''
+    ->  (   atom_number(S, Seed), integer(Seed)
+        ->  set_random(seed(Seed)),
+            log_conformance_seed_once(Seed)
+        ;   throw(error(domain_error(conformance_seed, S), _))
+        )
+    ;   true
+    ).
+
+log_conformance_seed_once(Seed) :-
+    (   nb_current(ct_conformance_seed_logged, Seed)
+    ->  true
+    ;   format(user_error, '  [conformance] CONFORMANCE_SEED=~w~n', [Seed]),
+        nb_setval(ct_conformance_seed_logged, Seed)
+    ).
 
 selected_programs(Programs) :-
     findall(P, conformance_program(P, _), All0),


### PR DESCRIPTION
## Summary

- Adds a PR/main GitHub Actions matrix job that runs sampled WAM conformance one backend at a time.
- Sets `CONFORMANCE_TARGETS`, `CONFORMANCE_PROGRAMS=member,builtins`, `CONFORMANCE_SAMPLE=2`, and a reproducible `CONFORMANCE_SEED` from the Actions run number.
- Makes the conformance harness validate and print `CONFORMANCE_SEED=<n>` once, so sampled failures can be reproduced locally.
- Updates the cross-target conformance docs to describe the new smoke tier and seed logging behavior.

## Why

The full cross-target conformance harness is useful but too expensive to run wholesale on every push. This adds a cheap smoke tier that still samples broad builtin/list coverage, keeps backend failures isolated by matrix target, and preserves the existing toolchain skip behavior for unavailable backends.

## Verification

- `swipl -q -t halt -s tests/test_wam_cross_target_conformance.pl`
- `CONFORMANCE_TARGETS=python CONFORMANCE_PROGRAMS=member,builtins CONFORMANCE_SAMPLE=1 CONFORMANCE_SEED=123 swipl -q -f init.pl -s tests/test_wam_cross_target_conformance.pl -g "seed_sampler,run_tests" -t halt`
- `git diff --check`
