### PR TITLE
fix(wam-cpp): nondeterministic builtin dispatch + M17 soft-cut (sub_atom, forall)

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -308,6 +308,12 @@ wam_instruction_to_cpp_literal_det(jump(L), LabelMap, Code) :-
     label_index(L, LabelMap, Idx),
     format(atom(Code), 'Instruction::Jump(~w)', [Idx]).
 wam_instruction_to_cpp_literal_det(cut_ite, _, 'Instruction::CutIte()').
+wam_instruction_to_cpp_literal_det(get_level(Yn), _, Code) :-
+    to_string(Yn, YS),
+    format(atom(Code), 'Instruction::GetLevel("~w")', [YS]).
+wam_instruction_to_cpp_literal_det(cut(Yn), _, Code) :-
+    to_string(Yn, YS),
+    format(atom(Code), 'Instruction::Cut("~w")', [YS]).
 wam_instruction_to_cpp_literal_det(begin_aggregate(K, V, R), _, Code) :-
     to_string(K, KS), to_string(V, VS), to_string(R, RS),
     escape_cpp_string(KS, EK), escape_cpp_string(VS, EV), escape_cpp_string(RS, ER),
@@ -418,7 +424,7 @@ emit_setup_function(Predicates, Options, SetupCpp) :-
     findall(Items, (
         member(PI, Predicates),
         catch(
-            ( compile_predicate_to_wam(PI, [inline_bagof_setof(true)], WamText),
+            ( compile_predicate_to_wam(PI, [inline_bagof_setof(true), ite_use_y_level(true)], WamText),
               parse_pred_blocks(WamText, Items0),
               iso_errors_rewrite(IsoConfig, PI, Items0, Items)
             ),
@@ -1404,7 +1410,7 @@ wam_cpp_iso_audit(Predicates, Options, Audit) :-
 
 iso_errors_audit_predicate(PI, Mode, Sites) :-
     (   catch(
-            ( compile_predicate_to_wam(PI, [inline_bagof_setof(true)], WamText),
+            ( compile_predicate_to_wam(PI, [inline_bagof_setof(true), ite_use_y_level(true)], WamText),
               parse_pred_blocks(WamText, Items)
             ),
             _, fail)
@@ -2620,7 +2626,7 @@ compile_predicates_for_project(Predicates, Options, PredicatesCode) :-
     findall(Code, (
         member(PI, Predicates),
         catch(
-            ( compile_predicate_to_wam(PI, [inline_bagof_setof(true)], WamCode),
+            ( compile_predicate_to_wam(PI, [inline_bagof_setof(true), ite_use_y_level(true)], WamCode),
               compile_wam_predicate_to_cpp(PI, WamCode, Options1, Code)
             ),
             Err,
@@ -3095,6 +3101,7 @@ struct Instruction {
         TryMeElse, RetryMeElse, TrustMe,
         Try, Retry, Trust,                                   // chain ops (#2400)
         Jump, CutIte,
+        GetLevel, Cut,                                       // M17 soft cut
         BeginAggregate, EndAggregate,
         SwitchOnConstant, SwitchOnConstantA2,
         SwitchOnStructure, SwitchOnStructureA2,
@@ -3200,6 +3207,10 @@ struct Instruction {
     static Instruction Jump(std::size_t target)
         { Instruction i; i.op = Op::Jump; i.target = target; return i; }
     static Instruction CutIte()     { Instruction i; i.op = Op::CutIte;     return i; }
+    static Instruction GetLevel(std::string yn)
+        { Instruction i; i.op = Op::GetLevel; i.a = std::move(yn); return i; }
+    static Instruction Cut(std::string yn)
+        { Instruction i; i.op = Op::Cut; i.a = std::move(yn); return i; }
     static Instruction BeginAggregate(std::string kind, std::string vreg, std::string rreg)
         { Instruction i; i.op = Op::BeginAggregate; i.a = std::move(kind);
           i.b = std::move(vreg); i.val = Value::Atom(std::move(rreg)); return i; }
@@ -8165,6 +8176,32 @@ bool WamState::step(const Instruction& instr) {
                     choice_points[top_idx].cut_barrier;
                 choice_points.resize(top_idx);
                 cut_barrier = saved_barrier;
+            }
+            pc += 1; return true;
+        }
+        // M17 soft cut. get_level snapshots the choicepoint level into a
+        // Y register BEFORE the if-then-else / negation try_me_else; cut
+        // truncates choicepoints back to that level at the commit site,
+        // removing the ITE/negation CP AND every CP the condition (or a
+        // negated goals generator) pushed above it. This fixes the legacy
+        // cut_ite, which only dropped the single topmost CP and so could
+        // not cut a negation over a generator (e.g. the forall negative
+        // case left the generators CP alive).
+        case Instruction::Op::GetLevel: {
+            CellPtr c = get_cell(instr.a);
+            bind_cell(c, Value::Integer(
+                static_cast<std::int64_t>(choice_points.size())));
+            pc += 1; return true;
+        }
+        case Instruction::Op::Cut: {
+            CellPtr c = get_cell(instr.a);
+            Value v = deref(*c);
+            if (v.tag == Value::Tag::Integer) {
+                std::size_t target = static_cast<std::size_t>(v.i);
+                if (choice_points.size() > target) {
+                    choice_points.resize(target);
+                }
+                if (cut_barrier > target) cut_barrier = target;
             }
             pc += 1; return true;
         }

--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -8180,6 +8180,17 @@ bool WamState::step(const Instruction& instr) {
                 pc = it->second;
                 return true;
             }
+            // Nondeterministic / CP-aware builtins need their own dispatch
+            // arms (mirroring the Call opcode) because builtin() only
+            // handles the deterministic ops. The shared WAM compiler emits
+            // these as builtin_call, so without these arms they fall
+            // through to builtin() and silently fail.
+            if (instr.a == "sub_atom/5" || instr.a == "sub_string/5")
+                return dispatch_sub_atom(pc + 1);
+            if (instr.a == "retract/1") return dispatch_retract(pc + 1);
+            if (instr.a == "clause/2") return dispatch_clause(pc + 1);
+            if (instr.a == "current_predicate/1")
+                return dispatch_current_predicate(pc + 1);
             return builtin(instr.a, instr.n);
         }
         case Instruction::Op::CallForeign:

--- a/src/unifyweaver/targets/wam_text_parser.pl
+++ b/src/unifyweaver/targets/wam_text_parser.pl
@@ -241,6 +241,10 @@ wam_recognise_instruction(["retry", L],                retry(L)).
 wam_recognise_instruction(["trust", L],                trust(L)).
 wam_recognise_instruction(["jump", L],                 jump(L)).
 wam_recognise_instruction(["cut_ite"],                 cut_ite).
+% M17 soft-cut for if-then-else / negation: get_level Yn snapshots the
+% choicepoint level into Yn; cut Yn truncates choicepoints back to it.
+wam_recognise_instruction(["get_level", Yn],           get_level(Yn)).
+wam_recognise_instruction(["cut", Yn],                 cut(Yn)).
 wam_recognise_instruction(["begin_aggregate", K, V, R], begin_aggregate(K, V, R)).
 wam_recognise_instruction(["begin_aggregate", K, V, R, W],
                                                        begin_aggregate(K, V, R, W)).


### PR DESCRIPTION
  ## Summary

  Two independent C++ WAM-target bugs surfaced by `test_wam_cpp_generator`
  (14 → 4 failures, no regressions across the full 400-case suite).

  ### 1. Nondeterministic builtins not dispatched from `BuiltinCall` (commit 1)
  The shared WAM compiler emits `sub_atom/5` (and `sub_string/5`, `retract/1`,
  `clause/2`, `current_predicate/1`) as `builtin_call`, but the C++ runtime's
  `BuiltinCall` opcode only did label-dispatch then `builtin()` — which
  implements only deterministic builtins. The CP-aware ones were handled only
  in the `Call`/`Execute` arms, so `builtin_call sub_atom/5` fell through and
  silently returned false. Added the same dispatch arms to `BuiltinCall`.
  Fixes the 9 `cpp_e2e_sub_atom_*` tests.

  ### 2. `forall` negative case via M17 soft-cut (commit 2)
  `forall(Cond, Action)` → `\+ (Cond, \+ Action)` lowered with legacy
  `cut_ite`, which removes only the topmost choicepoint and so cannot cut a
  generator's CP inside a negation: `forall(member(X,[1,2,3]), X=1)` wrongly
  succeeded. (Shared bug — also reproduces on Go.) Adopted the existing M17
  mechanism (`get_level Yn` / `cut Yn`, a proper deep cut; previously
  LLVM-only) for C++: recognise the ops in the shared `wam_text_parser`;
  enable `ite_use_y_level(true)` at the C++ compile sites; add
  `Op::GetLevel`/`Op::Cut`, factories, translator clauses, and Step cases.
  Cost: +1 instruction and a Y-reg per if-then-else/negation.

  ## Verification
  - `forall(member(X,[1,2,3]), X=1)` → false; `\+ forall(...)` → true (all
    forall probes correct).
  - Full `test_wam_cpp_generator`: 14 → 4 failures, **no new failures** from
    enabling M17 across all C++ if-then-else codegen.

  ## Follow-ups (out of scope)
  Remaining 4 failures are unrelated: `lmdb_sort_warning` (test hard-coded
  path), `bagof`/`setof` inlined witness grouping, `lists_cleanup`. And other
  legacy-`cut_ite` targets (Go, Lua) still carry the same latent `forall`
  bug — M17 adoption recipe is the same.