### PR TITLE
Cover precise WAM-C if-then-else cuts

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,16 +4,15 @@ Status date: 2026-06-05
 
 Latest branch verification:
 
-- `investigate/wam-c-control-builtins-parity` based on `main` at `a3a279f9`
-  (`Merge pull request #2805 from
-  s243a/investigate/wam-c-candidate-filter-observability`)
+- `investigate/wam-c-precise-ite-cut-scope` based on `main` at `040de10c`
+  (`Merge pull request #2809 from
+  s243a/investigate/wam-c-control-builtins-parity`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-control-builtins-parity`
+- `investigate/wam-c-precise-ite-cut-scope`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -78,6 +77,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Accumulated runtime edge-index fix | Done | Lazy child indexes for `WamState` and `WamFactSource` remove repeated full-edge scans; `10x` accumulated C targets now run around 0.065-0.071s with output parity versus Prolog at 0.202s |
 | Native weighted-kernel float output | Done | C runtime has `VAL_FLOAT`, numeric unification, double weighted/direct edge storage, and executable weighted/A* smokes for fractional 1.5 results while preserving exact-integer outputs as `VAL_INT` |
 | Control instruction parity smoke | Done | `INSTR_GET_LEVEL`, `INSTR_CUT`, `INSTR_CUT_ITE`, and `INSTR_JUMP` now parse, emit, and execute; generated executable smoke covers `\+/1` and if-then-else success/failure paths |
+| Precise if-then-else cut scope smoke | Done | C target tests now compile `ite_use_y_level(true)` WAM with `get_level`/`cut` and run a nondeterministic-condition scope regression that must not backtrack into the else branch after commit |
 
 ## Current C Target Baseline
 
@@ -127,7 +127,8 @@ The C target is now a credible small WAM backend:
 - Has executable smokes for generated runtime, cross-predicate calls,
   foreign calls, native category ancestor, file-backed facts, streaming native
   results, real multi-clause predicates, structure indexing, `is_list/1`,
-  `=/2`, negation, and if-then-else.
+  `=/2`, negation, legacy `cut_ite` if-then-else, and precise
+  `get_level`/`cut` if-then-else.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -151,7 +152,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
 | Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
-| Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1` and if-then-else; residual work is broader cut/control interaction coverage. |
+| Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, and precise `get_level`/`cut` if-then-else; residual work is broader explicit `!/0` cut coverage outside compiler-lowered control forms. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
 | Shared kernel detector integration | Partial/Done | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`, `transitive_closure2`, `transitive_distance3`, `transitive_parent_distance4`, `transitive_step_parent_distance5`, `weighted_shortest_path3`, and `astar_shortest_path4`; Haskell and Rust still have broader wrapper/fact-layout integration. |
@@ -164,6 +165,30 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-precise-ite-cut-scope`
+
+Goal: prove that the C target can execute the newer shared WAM
+`ite_use_y_level(true)` if-then-else lowering that commits with
+`get_level`/`cut` rather than the legacy single-pop `cut_ite`.
+
+Evidence:
+
+- Codegen coverage asserts precise ITE WAM contains `get_level` and `cut`
+  while omitting `cut_ite`.
+- Generated C coverage asserts those WAM instructions emit typed
+  `INSTR_GET_LEVEL` and `INSTR_CUT` payloads.
+- Executable smoke coverage runs success/failure ITE cases plus a
+  nondeterministic-condition scope regression where a later guard must not
+  backtrack into the else branch after the commit.
+
+Reason:
+
+- The previous control branch implemented all needed opcodes, but default C
+  coverage still mostly exercised the legacy `cut_ite` path.
+- This branch closes the immediate proof gap for the precise cut-barrier mode
+  already used by the LLVM hybrid WAM path and available to future C target
+  options.
 
 ### Completed: `investigate/wam-c-control-builtins-parity`
 

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -156,6 +156,30 @@ test_control_instruction_parsing :-
     ;   fail_test(Test, 'cut/jump instruction parsing missing typed payloads')
     ).
 
+test_precise_ite_y_level_generation :-
+    Test = 'WAM-C: precise if-then-else lowers to get_level/cut',
+    assertz((user:wam_c_precise_codegen(X, R) :-
+        (X = a -> R = then ; R = else))),
+    (   compile_predicate_to_wam(user:wam_c_precise_codegen/2,
+                                 [ite_use_y_level(true)],
+                                 WamCode),
+        sub_string(WamCode, _, _, _, 'get_level '),
+        sub_string(WamCode, _, _, _, 'cut Y'),
+        \+ sub_string(WamCode, _, _, _, 'cut_ite'),
+        compile_wam_predicate_to_c(user:wam_c_precise_codegen/2,
+                                   WamCode,
+                                   [ite_use_y_level(true)],
+                                   CCode),
+        atom_string(CCode, S),
+        sub_string(S, _, _, _, 'INSTR_GET_LEVEL'),
+        sub_string(S, _, _, _, 'INSTR_CUT'),
+        \+ sub_string(S, _, _, _, 'INSTR_CUT_ITE')
+    ->  retractall(user:wam_c_precise_codegen(_, _)),
+        pass(Test)
+    ;   retractall(user:wam_c_precise_codegen(_, _)),
+        fail_test(Test, 'precise ITE mode did not emit get_level/cut-only control flow')
+    ).
+
 test_choice_point_instructions :-
     Test = 'WAM-C: choice point instructions present',
     (   implemented_wam_c_cases(Cases),
@@ -1639,6 +1663,16 @@ test_real_prolog_control_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_real_prolog_precise_ite_executable_smoke :-
+    Test = 'WAM-C: real Prolog precise if-then-else executable smoke',
+    (   gcc_available
+    ->  (   run_real_prolog_precise_ite_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'real Prolog precise if-then-else executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_real_prolog_classic_recursive_executable_smoke :-
     Test = 'WAM-C: real Prolog classic recursive executable smoke',
     (   gcc_available
@@ -2517,6 +2551,61 @@ cleanup_wam_c_real_control_smoke :-
     retractall(user:wam_c_ctrl_neg(_, _)),
     retractall(user:wam_c_ctrl_if_known(_, _)),
     retractall(user:wam_c_ctrl_if_missing(_, _)).
+
+run_real_prolog_precise_ite_executable_smoke :-
+    assertz((user:wam_c_precise_choice(a) :- true)),
+    assertz((user:wam_c_precise_choice(a) :- true)),
+    assertz((user:wam_c_precise_then(X, then) :-
+        (wam_c_precise_choice(X) -> true ; fail))),
+    assertz((user:wam_c_precise_else(X, else) :-
+        (wam_c_precise_choice(X) -> fail ; true))),
+    assertz((user:wam_c_precise_scope(X) :-
+        (wam_c_precise_choice(X) -> R = then ; R = else),
+        R = else)),
+    Options = [ite_use_y_level(true)],
+    (   compile_predicate_to_wam(user:wam_c_precise_choice/1, Options, WamChoice),
+        compile_predicate_to_wam(user:wam_c_precise_then/2, Options, WamThen),
+        compile_predicate_to_wam(user:wam_c_precise_else/2, Options, WamElse),
+        compile_predicate_to_wam(user:wam_c_precise_scope/1, Options, WamScope),
+        sub_string(WamThen, _, _, _, 'get_level '),
+        sub_string(WamThen, _, _, _, 'cut Y'),
+        \+ sub_string(WamThen, _, _, _, 'cut_ite'),
+        sub_string(WamElse, _, _, _, 'get_level '),
+        sub_string(WamElse, _, _, _, 'cut Y'),
+        \+ sub_string(WamElse, _, _, _, 'cut_ite'),
+        sub_string(WamScope, _, _, _, 'get_level '),
+        sub_string(WamScope, _, _, _, 'cut Y'),
+        \+ sub_string(WamScope, _, _, _, 'cut_ite'),
+        compile_wam_predicate_to_c(user:wam_c_precise_choice/1, WamChoice, Options, ChoiceCode),
+        compile_wam_predicate_to_c(user:wam_c_precise_then/2, WamThen, Options, ThenCode),
+        compile_wam_predicate_to_c(user:wam_c_precise_else/2, WamElse, Options, ElseCode),
+        compile_wam_predicate_to_c(user:wam_c_precise_scope/1, WamScope, Options, ScopeCode),
+        atomic_list_concat([ChoiceCode, ThenCode, ElseCode, ScopeCode], '\n\n', PredCode),
+        compile_wam_runtime_to_c([], RuntimeCode),
+        get_time(Now),
+        Stamp is round(Now * 1000000),
+        wam_c_temp_path('unifyweaver_wam_c_precise_ite_smoke', Stamp, TmpBase),
+        format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+        format(atom(PredPath), '~w_pred.c', [TmpBase]),
+        format(atom(MainPath), '~w_main.c', [TmpBase]),
+        format(atom(ExePath), '~w_bin', [TmpBase]),
+        write_text_file(RuntimePath, RuntimeCode),
+        format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+        write_text_file(PredPath, PredTranslationUnit),
+        wam_c_precise_ite_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_precise_ite_smoke
+    ;   cleanup_wam_c_precise_ite_smoke,
+        fail
+    ).
+
+cleanup_wam_c_precise_ite_smoke :-
+    retractall(user:wam_c_precise_choice(_)),
+    retractall(user:wam_c_precise_then(_, _)),
+    retractall(user:wam_c_precise_else(_, _)),
+    retractall(user:wam_c_precise_scope(_)).
 
 run_real_prolog_classic_recursive_executable_smoke :-
     assertz((user:wam_c_classic_fib(0, 0) :- true)),
@@ -5354,6 +5443,69 @@ int main(void) {
 }
 ').
 
+wam_c_precise_ite_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_precise_choice_1(WamState* state);
+void setup_wam_c_precise_then_2(WamState* state);
+void setup_wam_c_precise_else_2(WamState* state);
+void setup_wam_c_precise_scope_1(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_precise_choice_1(&state);
+    setup_wam_c_precise_then_2(&state);
+    setup_wam_c_precise_else_2(&state);
+    setup_wam_c_precise_scope_1(&state);
+
+    WamValue then_success_args[2] = { val_atom("a"), val_atom("then") };
+    int then_success_rc = wam_run_predicate(&state, "wam_c_precise_then/2", then_success_args, 2);
+    if (then_success_rc != 0 || state.P != WAM_HALT || state.B != 0) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue then_fail_args[2] = { val_atom("b"), val_atom("then") };
+    int then_fail_rc = wam_run_predicate(&state, "wam_c_precise_then/2", then_fail_args, 2);
+    if (then_fail_rc != WAM_HALT || state.B != 0) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue else_success_args[2] = { val_atom("b"), val_atom("else") };
+    int else_success_rc = wam_run_predicate(&state, "wam_c_precise_else/2", else_success_args, 2);
+    if (else_success_rc != 0 || state.P != WAM_HALT || state.B != 0) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    WamValue else_fail_args[2] = { val_atom("a"), val_atom("else") };
+    int else_fail_rc = wam_run_predicate(&state, "wam_c_precise_else/2", else_fail_args, 2);
+    if (else_fail_rc != WAM_HALT || state.B != 0) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    WamValue scope_fail_args[1] = { val_atom("a") };
+    int scope_fail_rc = wam_run_predicate(&state, "wam_c_precise_scope/1", scope_fail_args, 1);
+    if (scope_fail_rc != WAM_HALT || state.B != 0) {
+        wam_free_state(&state);
+        return 50;
+    }
+
+    WamValue scope_success_args[1] = { val_atom("b") };
+    int scope_success_rc = wam_run_predicate(&state, "wam_c_precise_scope/1", scope_success_args, 1);
+    if (scope_success_rc != 0 || state.P != WAM_HALT || state.B != 0) {
+        wam_free_state(&state);
+        return 60;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_classic_fib_smoke_main(
 '#include "wam_runtime.h"
 
@@ -5469,6 +5621,7 @@ run_tests_once :-
     test_control_flow_instructions,
     test_control_cut_jump_instructions,
     test_control_instruction_parsing,
+    test_precise_ite_y_level_generation,
     test_choice_point_instructions,
     test_choice_point_content,
     test_switch_on_term_list_dispatch,
@@ -5559,6 +5712,7 @@ run_tests_once :-
     test_real_prolog_is_list_executable_smoke,
     test_real_prolog_unify_executable_smoke,
     test_real_prolog_control_executable_smoke,
+    test_real_prolog_precise_ite_executable_smoke,
     test_real_prolog_classic_recursive_executable_smoke,
     test_lowered_fact_helper_executable_smoke,
     test_lowered_body_call_helper_executable_smoke,


### PR DESCRIPTION
  ## Summary

  - Add WAM-C codegen coverage for `ite_use_y_level(true)` precise if-then-else lowering
  - Assert precise ITE emits `get_level`/`cut` and does not fall back to `cut_ite`
  - Add an executable smoke covering success/failure ITE paths and a nondeterministic-condition cut-scope regression
  - Update `WAM_C_TARGET_NEXT_STEPS.md` with the completed branch status and parity note

  ## Validation

  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `git diff --check`

  Note: ASAN lifecycle smoke was skipped by the test harness because ASAN was unavailable in that run.