### PR TITLE
Scope WAM-C explicit cuts to the current call

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,15 +4,16 @@ Status date: 2026-06-05
 
 Latest branch verification:
 
-- `investigate/wam-c-precise-ite-cut-scope` based on `main` at `040de10c`
-  (`Merge pull request #2809 from
-  s243a/investigate/wam-c-control-builtins-parity`)
+- `investigate/wam-c-explicit-cut-scope` based on `main` at `d1b94363`
+  (`Merge pull request #2813 from
+  s243a/investigate/wam-c-precise-ite-cut-scope`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-precise-ite-cut-scope`
+- `investigate/wam-c-explicit-cut-scope`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -78,6 +79,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Native weighted-kernel float output | Done | C runtime has `VAL_FLOAT`, numeric unification, double weighted/direct edge storage, and executable weighted/A* smokes for fractional 1.5 results while preserving exact-integer outputs as `VAL_INT` |
 | Control instruction parity smoke | Done | `INSTR_GET_LEVEL`, `INSTR_CUT`, `INSTR_CUT_ITE`, and `INSTR_JUMP` now parse, emit, and execute; generated executable smoke covers `\+/1` and if-then-else success/failure paths |
 | Precise if-then-else cut scope smoke | Done | C target tests now compile `ite_use_y_level(true)` WAM with `get_level`/`cut` and run a nondeterministic-condition scope regression that must not backtrack into the else branch after commit |
+| Explicit cut call-scope fix | Done | `!/0` now prunes to the current call barrier instead of clearing all choice points; generated executable smoke preserves an outer disjunction alternative across an inner predicate cut |
 
 ## Current C Target Baseline
 
@@ -128,7 +130,7 @@ The C target is now a credible small WAM backend:
   foreign calls, native category ancestor, file-backed facts, streaming native
   results, real multi-clause predicates, structure indexing, `is_list/1`,
   `=/2`, negation, legacy `cut_ite` if-then-else, and precise
-  `get_level`/`cut` if-then-else.
+  `get_level`/`cut` if-then-else, plus explicit `!/0` call-scope behavior.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -152,7 +154,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
 | Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
-| Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, and precise `get_level`/`cut` if-then-else; residual work is broader explicit `!/0` cut coverage outside compiler-lowered control forms. |
+| Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, precise `get_level`/`cut` if-then-else, and explicit `!/0` scoped to the current predicate call barrier; residual work is broader meta-control coverage such as `forall/2` as demanded. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
 | Shared kernel detector integration | Partial/Done | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`, `transitive_closure2`, `transitive_distance3`, `transitive_parent_distance4`, `transitive_step_parent_distance5`, `weighted_shortest_path3`, and `astar_shortest_path4`; Haskell and Rust still have broader wrapper/fact-layout integration. |
@@ -165,6 +167,30 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-explicit-cut-scope`
+
+Goal: fix C `!/0` so explicit cut prunes only to the current predicate call
+barrier, not to zero choice points globally.
+
+Evidence:
+
+- `wam_run_predicate` now pushes a top-level call barrier before entering the
+  predicate and restores the caller's barrier stack after execution.
+- C `!/0` reads the current barrier from `call_bases[call_base_top - 1]` and
+  calls `wam_prune_choice_points` instead of assigning `state->B = 0`.
+- Executable smoke coverage runs an inner predicate with `!` under an outer
+  disjunction. The outer branch fails after the inner cut, and the outer
+  alternative must still be available.
+
+Reason:
+
+- The previous control branches proved compiler-lowered cut forms, but explicit
+  `!/0` still used a global clear. That was too strong for nested predicate
+  calls and could erase caller choice points.
+- The existing C call-base stack already held the correct call-entry choice
+  depth for normal calls; this branch reuses it as the explicit cut barrier
+  and adds a top-level public-call barrier for `wam_run_predicate`.
 
 ### Completed: `investigate/wam-c-precise-ite-cut-scope`
 

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -2518,6 +2518,8 @@ int wam_run_predicate(WamState *state, const char *pred,
     if (entry < 0) return WAM_ERR_OOB;
     int base_b = state->B;
     int base_call_base_top = state->call_base_top;
+    if (state->call_base_top >= WAM_CALL_STACK_SIZE) return WAM_ERR_OOB;
+    state->call_bases[state->call_base_top++] = base_b;
     for (int i = 0; i < arity; i++) state->A[i] = args[i];
     state->CP = WAM_HALT;
     state->P = entry;
@@ -2725,7 +2727,10 @@ bool wam_execute_builtin(WamState *state, const char *op, int arity) {
     if (strcmp(op, "true/0") == 0 && arity == 0) return true;
     if ((strcmp(op, "fail/0") == 0 || strcmp(op, "false/0") == 0) && arity == 0) return false;
     if (strcmp(op, "!/0") == 0 && arity == 0) {
-        state->B = 0;
+        if (state->call_base_top <= 0) return false;
+        int target_b = state->call_bases[state->call_base_top - 1];
+        if (target_b < 0 || target_b > state->B) return false;
+        wam_prune_choice_points(state, target_b);
         return true;
     }
 

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -142,6 +142,18 @@ test_control_cut_jump_instructions :-
     ;   fail_test(Test, 'missing cut/jump control instruction arms')
     ).
 
+test_explicit_cut_uses_current_call_barrier :-
+    Test = 'WAM-C: explicit cut prunes to current call barrier',
+    (   compile_wam_helpers_to_c([], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'state->call_bases[state->call_base_top - 1]'),
+        sub_string(S, _, _, _, 'wam_prune_choice_points(state, target_b)'),
+        sub_string(S, _, _, _, 'state->call_bases[state->call_base_top++] = base_b'),
+        \+ sub_string(S, _, _, _, 'state->B = 0')
+    ->  pass(Test)
+    ;   fail_test(Test, 'explicit !/0 still clears all choice points instead of pruning to the current barrier')
+    ).
+
 test_control_instruction_parsing :-
     Test = 'WAM-C: cut and jump instructions parse to typed payloads',
     WamCode = 'wam_c_ctrl_parse/1:\n    get_level Y1\n    try_me_else L_else\n    cut Y1\n    cut_ite\n    jump L_done\nL_else:\n    trust_me\nL_done:\n    proceed',
@@ -1673,6 +1685,16 @@ test_real_prolog_precise_ite_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_real_prolog_explicit_cut_executable_smoke :-
+    Test = 'WAM-C: real Prolog explicit cut executable smoke',
+    (   gcc_available
+    ->  (   run_real_prolog_explicit_cut_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'real Prolog explicit cut executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_real_prolog_classic_recursive_executable_smoke :-
     Test = 'WAM-C: real Prolog classic recursive executable smoke',
     (   gcc_available
@@ -2606,6 +2628,45 @@ cleanup_wam_c_precise_ite_smoke :-
     retractall(user:wam_c_precise_then(_, _)),
     retractall(user:wam_c_precise_else(_, _)),
     retractall(user:wam_c_precise_scope(_)).
+
+run_real_prolog_explicit_cut_executable_smoke :-
+    assertz((user:wam_c_cut_choice(a) :- true)),
+    assertz((user:wam_c_cut_choice(b) :- true)),
+    assertz((user:wam_c_inner_cut :- wam_c_cut_choice(_), !)),
+    assertz((user:wam_c_outer_cut(ok) :- (wam_c_inner_cut, fail ; true))),
+    (   compile_predicate_to_wam(user:wam_c_cut_choice/1, [], WamChoice),
+        compile_predicate_to_wam(user:wam_c_inner_cut/0, [], WamInner),
+        compile_predicate_to_wam(user:wam_c_outer_cut/1, [], WamOuter),
+        sub_string(WamInner, _, _, _, 'builtin_call !/0, 0'),
+        sub_string(WamOuter, _, _, _, 'try_me_else'),
+        compile_wam_predicate_to_c(user:wam_c_cut_choice/1, WamChoice, [], ChoiceCode),
+        compile_wam_predicate_to_c(user:wam_c_inner_cut/0, WamInner, [], InnerCode),
+        compile_wam_predicate_to_c(user:wam_c_outer_cut/1, WamOuter, [], OuterCode),
+        atomic_list_concat([ChoiceCode, InnerCode, OuterCode], '\n\n', PredCode),
+        compile_wam_runtime_to_c([], RuntimeCode),
+        get_time(Now),
+        Stamp is round(Now * 1000000),
+        wam_c_temp_path('unifyweaver_wam_c_explicit_cut_smoke', Stamp, TmpBase),
+        format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+        format(atom(PredPath), '~w_pred.c', [TmpBase]),
+        format(atom(MainPath), '~w_main.c', [TmpBase]),
+        format(atom(ExePath), '~w_bin', [TmpBase]),
+        write_text_file(RuntimePath, RuntimeCode),
+        format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+        write_text_file(PredPath, PredTranslationUnit),
+        wam_c_explicit_cut_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_explicit_cut_smoke
+    ;   cleanup_wam_c_explicit_cut_smoke,
+        fail
+    ).
+
+cleanup_wam_c_explicit_cut_smoke :-
+    retractall(user:wam_c_cut_choice(_)),
+    retractall(user:wam_c_inner_cut),
+    retractall(user:wam_c_outer_cut(_)).
 
 run_real_prolog_classic_recursive_executable_smoke :-
     assertz((user:wam_c_classic_fib(0, 0) :- true)),
@@ -5506,6 +5567,45 @@ int main(void) {
 }
 ').
 
+wam_c_explicit_cut_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_cut_choice_1(WamState* state);
+void setup_wam_c_inner_cut_0(WamState* state);
+void setup_wam_c_outer_cut_1(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_cut_choice_1(&state);
+    setup_wam_c_inner_cut_0(&state);
+    setup_wam_c_outer_cut_1(&state);
+
+    int inner_rc = wam_run_predicate(&state, "wam_c_inner_cut/0", NULL, 0);
+    if (inner_rc != 0 || state.P != WAM_HALT || state.B != 0 || state.call_base_top != 0) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue outer_args[1] = { val_atom("ok") };
+    int outer_rc = wam_run_predicate(&state, "wam_c_outer_cut/1", outer_args, 1);
+    if (outer_rc != 0 || state.P != WAM_HALT || state.B != 0 || state.call_base_top != 0) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue outer_fail_args[1] = { val_atom("bad") };
+    int outer_fail_rc = wam_run_predicate(&state, "wam_c_outer_cut/1", outer_fail_args, 1);
+    if (outer_fail_rc != WAM_HALT || state.B != 0 || state.call_base_top != 0) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_classic_fib_smoke_main(
 '#include "wam_runtime.h"
 
@@ -5620,6 +5720,7 @@ run_tests_once :-
     test_unification_instructions,
     test_control_flow_instructions,
     test_control_cut_jump_instructions,
+    test_explicit_cut_uses_current_call_barrier,
     test_control_instruction_parsing,
     test_precise_ite_y_level_generation,
     test_choice_point_instructions,
@@ -5713,6 +5814,7 @@ run_tests_once :-
     test_real_prolog_unify_executable_smoke,
     test_real_prolog_control_executable_smoke,
     test_real_prolog_precise_ite_executable_smoke,
+    test_real_prolog_explicit_cut_executable_smoke,
     test_real_prolog_classic_recursive_executable_smoke,
     test_lowered_fact_helper_executable_smoke,
     test_lowered_body_call_helper_executable_smoke,


### PR DESCRIPTION
  ## Summary

  - Fix C `!/0` so it prunes to the current predicate call barrier instead of clearing all choice points globally
  - Push a top-level call barrier in `wam_run_predicate`
  - Add an executable regression where an inner predicate cut must not erase an outer disjunction alternative
  - Update `WAM_C_TARGET_NEXT_STEPS.md` with the completed cut-scope slice

  ## Validation

  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
  - `git diff --check`