### PR TITLE
Add ingest-time scoped-subtree LMDB builder (demand-set materialisation)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,10 @@ jobs:
         run: |
           swipl -q -g main -t halt tests/run_wam_fsharp_tests.pl
 
+      - name: Run scoped-subtree LMDB builder test
+        run: |
+          python3 -m unittest tests.test_build_scoped_subtree_lmdb
+
       - name: Generate and run inference test runner
         run: |
           swipl -g "use_module('src/unifyweaver/core/advanced/test_runner_inference'), generate_test_runner_inferred('output/advanced/inferred_test_runner.sh'), halt."

--- a/examples/benchmark/build_scoped_subtree_lmdb.py
+++ b/examples/benchmark/build_scoped_subtree_lmdb.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Build a *scoped subtree* LMDB from a full-graph Phase-1 category LMDB.
+
+Demand-set scoping belongs at INGEST time, not per query: when a good root is
+known (e.g. the *Articles* subtree in simplewiki, or *Main topic
+classifications* in full enwiki), materialise the reachable subtree once into a
+self-contained LMDB.  Queries against the scoped DB then never re-run the
+`reachable_to_root` BFS — `demand_set == all nodes` by construction, so the
+runtime demand filters are no-ops.
+
+Semantics mirror the F# WAM target (the cleanest existing spec):
+  * node set = `reachableToRoot(root, max_depth)` — BFS DOWN `category_child`
+    (parent -> child), bounded by `max_depth`
+    (templates/targets/fsharp_wam/lmdb_fact_source.fs.mustache).
+  * edges kept = every `category_parent` edge (child -> parent) whose BOTH
+    endpoints are in the node set (cf. `loadCategoryParentDemandDict`).
+
+The output is a drop-in fixture for the WAM matrix benches: it writes the
+scoped `category_parent` / `category_child` DUPSORT sub-dbs, the restricted
+`s2i` / `i2s`, plus `root_ids.txt`, `article_category.tsv`, and `metadata.json`
+in the same layout `simplewiki_post_ingest.py` produces.
+
+Usage:
+  python3 build_scoped_subtree_lmdb.py \
+      --src  data/benchmark/simplewiki_cats/lmdb_resident \
+      --root 2 \
+      --out  data/benchmark/simplewiki_cats/lmdb_scoped \
+      [--max-depth 10] [--map-size-gib 2] [--fixture-dir DIR]
+
+`--fixture-dir` (default: parent of --out) is where the sidecar txt/json files
+are written.
+"""
+import argparse
+import collections
+import json
+import struct
+import sys
+import time
+from pathlib import Path
+
+import lmdb
+
+I32 = struct.Struct("<i")
+
+
+def enc(i: int) -> bytes:
+    return I32.pack(i)
+
+
+def dec(b: bytes) -> int:
+    return I32.unpack(b)[0]
+
+
+def reachable_to_root(txn, cc_db, root: int, max_depth: int) -> set:
+    """BFS DOWN category_child (parent -> children), bounded by max_depth.
+
+    Mirrors F# `reachableToRoot`: returns every node reachable from `root`
+    within `max_depth` hops, i.e. the set of nodes that can reach `root` going
+    UP through category_parent.
+    """
+    visited = {root}
+    frontier = [root]
+    cur = txn.cursor(db=cc_db)
+    depth = 0
+    while frontier and depth < max_depth:
+        nxt = []
+        for node in frontier:
+            if cur.set_key(enc(node)):
+                for v in cur.iternext_dup(keys=False, values=True):
+                    child = dec(v)
+                    if child not in visited:
+                        visited.add(child)
+                        nxt.append(child)
+        frontier = nxt
+        depth += 1
+    return visited
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--src", required=True, help="source full-graph LMDB dir")
+    ap.add_argument("--root", required=True, type=int, help="root node id (LMDB int)")
+    ap.add_argument("--out", required=True, help="output scoped LMDB dir")
+    ap.add_argument("--max-depth", type=int, default=10,
+                    help="BFS depth bound (must match the query's max_depth; default 10)")
+    ap.add_argument("--map-size-gib", type=float, default=2.0,
+                    help="output map size in GiB (default 2)")
+    ap.add_argument("--fixture-dir", default=None,
+                    help="dir for sidecar files (default: parent of --out)")
+    args = ap.parse_args()
+
+    src_dir = Path(args.src)
+    out_dir = Path(args.out)
+    fixture_dir = Path(args.fixture_dir) if args.fixture_dir else out_dir.parent
+    map_size = int(args.map_size_gib * 1024 * 1024 * 1024)
+    t0 = time.time()
+
+    if not src_dir.exists():
+        sys.stderr.write(f"error: source LMDB dir not found: {src_dir}\n")
+        return 1
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    src_env = lmdb.open(str(src_dir), max_dbs=16, readonly=True, subdir=True,
+                        lock=False, map_size=map_size)
+    src_cp = src_env.open_db(b"category_parent", dupsort=True)
+    # category_child must exist (Phase-1 layout / post-ingest builds it).
+    try:
+        src_cc = src_env.open_db(b"category_child", dupsort=True, create=False)
+    except lmdb.NotFoundError:
+        sys.stderr.write(
+            "error: source LMDB has no 'category_child' sub-db; run the "
+            "post-ingest reverse-edge pass first.\n")
+        return 1
+
+    # 1. demand set = reachable subtree of root (F# reachableToRoot semantics).
+    with src_env.begin() as txn:
+        demand = reachable_to_root(txn, src_cc, args.root, args.max_depth)
+    sys.stderr.write(
+        f"reachable_to_root(root={args.root}, max_depth={args.max_depth}) "
+        f"= {len(demand)} nodes\n")
+    if len(demand) <= 1:
+        sys.stderr.write(
+            "warning: demand set is trivial (root has no children within "
+            "max_depth) — check the root id and that category_child is "
+            "populated.\n")
+
+    # 2. write scoped edges: keep child->parent iff BOTH endpoints in demand.
+    out_env = lmdb.open(str(out_dir), max_dbs=16, subdir=True, map_size=map_size)
+    out_cp = out_env.open_db(b"category_parent", dupsort=True, create=True)
+    out_cc = out_env.open_db(b"category_child", dupsort=True, create=True)
+    kept_edges = 0
+    scanned = 0
+    children_in_scope = set()
+    with src_env.begin() as rtxn, out_env.begin(write=True) as wtxn:
+        cur = rtxn.cursor(db=src_cp)
+        for k, v in cur:
+            scanned += 1
+            child = dec(k)
+            if child not in demand:
+                continue
+            parent = dec(v)
+            if parent not in demand:
+                continue
+            wtxn.put(k, v, db=out_cp, dupdata=True, overwrite=True)
+            wtxn.put(v, k, db=out_cc, dupdata=True, overwrite=True)
+            kept_edges += 1
+            children_in_scope.add(child)
+            if scanned % 500_000 == 0:
+                sys.stderr.write(f"  ...scanned {scanned} edges, kept {kept_edges}\n")
+    sys.stderr.write(
+        f"edges: scanned {scanned}, kept {kept_edges} (both endpoints in demand)\n")
+
+    # 3. copy s2i/i2s entries restricted to demand nodes, so the scoped DB is
+    #    self-contained for string<->int seed/root resolution + result decode.
+    nid_to_str = {}
+    try:
+        src_i2s = src_env.open_db(b"i2s", create=False)
+        src_s2i = src_env.open_db(b"s2i", create=False)
+        out_i2s = out_env.open_db(b"i2s", create=True)
+        out_s2i = out_env.open_db(b"s2i", create=True)
+        with src_env.begin() as rtxn, out_env.begin(write=True) as wtxn:
+            cur = rtxn.cursor(db=src_i2s)
+            for k, v in cur:
+                if dec(k) in demand:
+                    wtxn.put(k, v, db=out_i2s)
+                    nid_to_str[dec(k)] = v.decode("utf-8", "replace")
+            cur = rtxn.cursor(db=src_s2i)
+            for k, v in cur:
+                if dec(v) in demand:
+                    wtxn.put(k, v, db=out_s2i)
+        sys.stderr.write(f"s2i/i2s: copied {len(nid_to_str)} demand-node mappings\n")
+    except lmdb.NotFoundError:
+        sys.stderr.write("note: source has no s2i/i2s sub-dbs; skipping (int-native fixture)\n")
+
+    out_env.sync()
+    out_env.close()
+    src_env.close()
+
+    # 4. sidecar fixture files (same layout as simplewiki_post_ingest.py).
+    fixture_dir.mkdir(parents=True, exist_ok=True)
+    nodes = sorted(demand)
+    with open(fixture_dir / "root_ids.txt", "w") as f:
+        f.write(f"{args.root}\n")
+    with open(fixture_dir / "article_category.scoped.tsv", "w") as f:
+        f.write("article\tcategory\n")
+        for nid in nodes:
+            name = nid_to_str.get(nid, str(nid))
+            f.write(f"{name}\t{name}\n")
+    with open(fixture_dir / "metadata.scoped.json", "w") as f:
+        json.dump({
+            "scoped_from": str(src_dir),
+            "root_id": args.root,
+            "max_depth": args.max_depth,
+            "node_count": len(demand),
+            "edge_count": kept_edges,
+            "children_in_scope": len(children_in_scope),
+            "out_lmdb": str(out_dir),
+            "build_seconds": round(time.time() - t0, 2),
+        }, f, indent=2)
+
+    sys.stderr.write(
+        f"scoped subtree LMDB written to {out_dir} "
+        f"({len(demand)} nodes, {kept_edges} edges) in {time.time() - t0:.2f}s\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_build_scoped_subtree_lmdb.py
+++ b/tests/test_build_scoped_subtree_lmdb.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Unit test for examples/benchmark/build_scoped_subtree_lmdb.py.
+
+Builds a tiny full-graph LMDB with a known root subtree plus out-of-scope
+nodes, runs the scoped-subtree builder, and asserts the scoped LMDB contains
+exactly the reachable subtree (F# `reachableToRoot` + both-endpoints-in-demand
+edge filter semantics).
+
+Skips gracefully if python-lmdb is not installed.
+"""
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import lmdb
+    HAVE_LMDB = True
+except ImportError:
+    HAVE_LMDB = False
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BUILDER = REPO_ROOT / "examples" / "benchmark" / "build_scoped_subtree_lmdb.py"
+I32 = struct.Struct("<i")
+
+
+def enc(i):
+    return I32.pack(i)
+
+
+def dec(b):
+    return I32.unpack(b)[0]
+
+
+@unittest.skipUnless(HAVE_LMDB, "python-lmdb not installed")
+class TestBuildScopedSubtreeLmdb(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.src = Path(self.tmp.name) / "full"
+        self.out = Path(self.tmp.name) / "scoped"
+        self.src.mkdir()
+        # Graph: root 2. category_child (parent -> children): 2->{3,4}, 3->{5}.
+        # category_parent (child -> parent): 3->2, 4->2, 5->3, and an
+        # out-of-scope edge 9->8. Reachable-from-2 set = {2,3,4,5}; node 8/9
+        # are unreachable and must be dropped.
+        cp_edges = [(3, 2), (4, 2), (5, 3), (9, 8)]   # child -> parent
+        cc_edges = [(2, 3), (2, 4), (3, 5), (8, 9)]   # parent -> child
+        env = lmdb.open(str(self.src), max_dbs=16, map_size=10 * 1024 * 1024,
+                        subdir=True)
+        cp = env.open_db(b"category_parent", dupsort=True, create=True)
+        cc = env.open_db(b"category_child", dupsort=True, create=True)
+        i2s = env.open_db(b"i2s", create=True)
+        s2i = env.open_db(b"s2i", create=True)
+        with env.begin(write=True) as txn:
+            for child, parent in cp_edges:
+                txn.put(enc(child), enc(parent), db=cp, dupdata=True)
+            for parent, child in cc_edges:
+                txn.put(enc(parent), enc(child), db=cc, dupdata=True)
+            for nid in (2, 3, 4, 5, 8, 9):
+                txn.put(enc(nid), str(nid).encode(), db=i2s)
+                txn.put(str(nid).encode(), enc(nid), db=s2i)
+        env.sync()
+        env.close()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run_builder(self, root=2, max_depth=10):
+        env = dict(os.environ)
+        env.setdefault("LANG", "C.UTF-8")
+        proc = subprocess.run(
+            [sys.executable, str(BUILDER),
+             "--src", str(self.src), "--root", str(root),
+             "--out", str(self.out), "--max-depth", str(max_depth)],
+            capture_output=True, text=True, env=env)
+        self.assertEqual(proc.returncode, 0,
+                         f"builder failed:\n{proc.stderr}")
+        return proc
+
+    def _read_scoped(self):
+        env = lmdb.open(str(self.out), max_dbs=16, readonly=True, subdir=True,
+                        lock=False)
+        cp = env.open_db(b"category_parent", dupsort=True, create=False)
+        cc = env.open_db(b"category_child", dupsort=True, create=False)
+        parent_edges, child_edges, nodes = set(), set(), set()
+        with env.begin() as txn:
+            for k, v in txn.cursor(db=cp):
+                parent_edges.add((dec(k), dec(v)))
+                nodes.add(dec(k))
+                nodes.add(dec(v))
+            for k, v in txn.cursor(db=cc):
+                child_edges.add((dec(k), dec(v)))
+        env.close()
+        return parent_edges, child_edges, nodes
+
+    def test_scoped_contains_only_subtree(self):
+        self._run_builder()
+        parent_edges, child_edges, nodes = self._read_scoped()
+        # child->parent edges with both endpoints in {2,3,4,5}
+        self.assertEqual(parent_edges, {(3, 2), (4, 2), (5, 3)})
+        # reverse edges parent->child
+        self.assertEqual(child_edges, {(2, 3), (2, 4), (3, 5)})
+        # node set is exactly the reachable subtree; 8 and 9 excluded
+        self.assertEqual(nodes, {2, 3, 4, 5})
+        self.assertNotIn(8, nodes)
+        self.assertNotIn(9, nodes)
+
+    def test_depth_bound_prunes(self):
+        # max_depth=1 keeps only root's direct children: {2,3,4}; 5 (depth 2)
+        # drops, so edge 5->3 is excluded.
+        self._run_builder(max_depth=1)
+        parent_edges, _child_edges, nodes = self._read_scoped()
+        self.assertEqual(nodes, {2, 3, 4})
+        self.assertEqual(parent_edges, {(3, 2), (4, 2)})
+
+    def test_scoped_i2s_restricted_to_demand(self):
+        self._run_builder()
+        env = lmdb.open(str(self.out), max_dbs=16, readonly=True, subdir=True,
+                        lock=False)
+        i2s = env.open_db(b"i2s", create=False)
+        ids = set()
+        with env.begin() as txn:
+            for k, _v in txn.cursor(db=i2s):
+                ids.add(dec(k))
+        env.close()
+        self.assertEqual(ids, {2, 3, 4, 5})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary
  Materialise the demand-set (reachable subtree) at **ingest**, not per query.
  When a good root is known (Articles subtree at simplewiki, Main-topic
  classifications at enwiki), `build_scoped_subtree_lmdb.py` builds the reachable
  subtree once into a self-contained LMDB. Queries against it never re-run the
  `reachable_to_root` BFS — `demand_set == all nodes` by construction.

  ## Semantics (mirrors the F# WAM target)
  - node set = `reachableToRoot(root, max_depth)` — BFS down `category_child`, depth-bounded.
  - edges kept = every `category_parent` edge whose **both** endpoints are in the node set.

  Output is a drop-in matrix-bench fixture (scoped `category_parent`/`category_child`
  DUPSORT + restricted `s2i`/`i2s` + `root_ids.txt` / `article_category.scoped.tsv` /
  `metadata.scoped.json`).

  ## Validation (simplewiki, root 2, max_depth 10, same full seed list)
  | | nodes | edges | DB size | load_ms (warm) | tuple_count |
  |---|---|---|---|---|---|
  | Full | — | 297,283 | 20 MB | ~48–51 (181 cold) | 53 |
  | Scoped | 14,680 | 14,887 | 864 KB | ~26 (stable) | **53** |

  Correctness preserved; 20× smaller; ~2× faster load.

  ## Tests
  `tests/test_build_scoped_subtree_lmdb.py` — tiny graph with a known subtree +
  out-of-scope nodes; asserts the scoped DB contains exactly the reachable
  subtree (incl. depth-bound pruning + s2i/i2s restriction). Wired into CI; skips
  without python-lmdb.