### PR TITLE
WAM Rust matrix bench: WAM_DEMAND=off skips the query-time demand BFS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,10 @@ jobs:
         run: |
           python3 -m unittest tests.test_build_scoped_subtree_lmdb
 
+      - name: Run WAM Rust matrix-bench demand-flag codegen test
+        run: |
+          python3 -m unittest tests.test_wam_rust_matrix_demand_flag
+
       - name: Generate and run inference test runner
         run: |
           swipl -g "use_module('src/unifyweaver/core/advanced/test_runner_inference'), generate_test_runner_inferred('output/advanced/inferred_test_runner.sh'), halt."

--- a/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
+++ b/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
@@ -1351,19 +1351,42 @@ fn main() {
     });
 
     let max_depth_limit = 10usize;
-    let reachable_ids: HashSet<i32> = lmdb
-        .reachable_to_root(root_id, max_depth_limit)
-        .expect("reachable_to_root");
+    // WAM_DEMAND=off skips the reachable_to_root BFS: the DB is assumed to be a
+    // pre-scoped subtree (built by build_scoped_subtree_lmdb.py), so every node
+    // is already in scope and query-time demand filtering is redundant. An
+    // empty reachable_ids set leaves the kernel demand filter a no-op (it
+    // guards on !is_empty), so lazy/cached need no further change; the eager
+    // branch below loads all edges instead of the demand-filtered subset.
+    let demand_enabled = std::env::var("WAM_DEMAND")
+        .map(|v| v != "off")
+        .unwrap_or(true);
+    let reachable_ids: HashSet<i32> = if demand_enabled {
+        lmdb.reachable_to_root(root_id, max_depth_limit)
+            .expect("reachable_to_root")
+    } else {
+        HashSet::new()
+    };
 
-    // Build runtime_category_parents by iterating each reachable child and
-    // looking up its parents.  Only edges where BOTH endpoints are in the
-    // demand set are kept, matching TSV-mode filtering semantics.
+    // Build runtime_category_parents (eager materialisation). With demand
+    // enabled, iterate each reachable child and keep only edges where BOTH
+    // endpoints are in the demand set (matches TSV-mode filtering). With demand
+    // disabled (pre-scoped DB), every edge is in scope, so load them all.
     let mut runtime_category_parents: Vec<(String, String)> = Vec::new();
-    for child_id in &reachable_ids {
-        let parents = lmdb.lookup_parents(*child_id).unwrap_or_default();
-        for parent_id in parents {
-            if reachable_ids.contains(&parent_id) {
-                if let (Some(c), Some(p)) = (i2s.get(child_id), i2s.get(&parent_id)) {
+    if demand_enabled {
+        for child_id in &reachable_ids {
+            let parents = lmdb.lookup_parents(*child_id).unwrap_or_default();
+            for parent_id in parents {
+                if reachable_ids.contains(&parent_id) {
+                    if let (Some(c), Some(p)) = (i2s.get(child_id), i2s.get(&parent_id)) {
+                        runtime_category_parents.push((c.clone(), p.clone()));
+                    }
+                }
+            }
+        }
+    } else {
+        for (child_id, c) in &i2s {
+            for parent_id in lmdb.lookup_parents(*child_id).unwrap_or_default() {
+                if let Some(p) = i2s.get(&parent_id) {
                     runtime_category_parents.push((c.clone(), p.clone()));
                 }
             }

--- a/tests/test_wam_rust_matrix_demand_flag.py
+++ b/tests/test_wam_rust_matrix_demand_flag.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Codegen guard for the WAM matrix-bench generator (Rust target).
+
+The Rust matrix bench is a large Prolog-atom template; the only end-to-end
+exercise of it (the LMDB cross-target conformance test) builds with cargo and is
+opt-in, so template corruption otherwise reaches no CI guard. This test runs the
+generator (swipl only, no cargo) and asserts the emitted main.rs contains the
+WAM_DEMAND skip-demand-BFS wiring and that the lazy/cached transform still
+splices in (a regression there would silently drop demand setup).
+
+Skips gracefully if swipl is not on PATH.
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GEN = REPO_ROOT / "examples" / "benchmark" / "generate_wam_rust_matrix_benchmark.pl"
+HAVE_SWIPL = shutil.which("swipl") is not None
+
+
+@unittest.skipUnless(HAVE_SWIPL, "swipl not on PATH")
+class TestMatrixDemandFlag(unittest.TestCase):
+    def _generate(self, materialisation):
+        out = Path(self.tmp.name) / materialisation
+        env = dict(os.environ)
+        env.setdefault("LANG", "C.UTF-8")
+        proc = subprocess.run(
+            ["swipl", "-q", "-s", str(GEN), "--",
+             "dummy", str(out), "accumulated", "functions", "kernels_on",
+             "cursor", "auto", materialisation, "297283"],
+            capture_output=True, text=True, env=env, cwd=str(REPO_ROOT))
+        self.assertEqual(proc.returncode, 0,
+                         f"generate ({materialisation}) failed:\n{proc.stderr}")
+        main_rs = (out / "src" / "main.rs").read_text()
+        return main_rs
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_eager_has_demand_flag_and_branch(self):
+        src = self._generate("eager")
+        self.assertIn('std::env::var("WAM_DEMAND")', src,
+                      "WAM_DEMAND env read missing from eager bench")
+        self.assertIn("demand_enabled", src)
+        # both branches of the eager edge-load present
+        self.assertIn("if demand_enabled {", src)
+        self.assertIn("reachable_to_root(root_id, max_depth_limit)", src)
+
+    def test_lazy_has_demand_flag_and_lazy_setup(self):
+        src = self._generate("lazy")
+        self.assertIn('std::env::var("WAM_DEMAND")', src)
+        self.assertIn("demand_enabled", src)
+        # the lazy materialisation transform still splices in: demand-set wiring
+        # + the LazyCategoryParents struct must survive the rewrite.
+        self.assertIn("set_demand_set", src)
+        self.assertIn("LazyCategoryParents", src)
+        self.assertIn("register_lazy_lookup", src)
+
+    def test_cached_has_demand_flag_and_cache(self):
+        src = self._generate("cached")
+        self.assertIn('std::env::var("WAM_DEMAND")', src)
+        self.assertIn("CachedLookup", src)
+        self.assertIn("set_demand_set", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary
  On a pre-scoped subtree LMDB (from `build_scoped_subtree_lmdb.py`), the runtime
  `reachable_to_root` BFS just re-walks the whole DB to rediscover what is already
  entirely in scope — pure load-time overhead. `WAM_DEMAND=off` skips it: the
  demand set stays empty, leaving the kernel demand filter a no-op, so lazy/cached
  are unchanged and the eager branch loads all edges.

  Demand filtering is purely an optimization → this never changes results.

  ## Validation (simplewiki, lazy, int-native, same full seed list)
  | scenario | load_ms | demand_set_size | tuple_count |
  |---|---|---|---|
  | scoped, on | 36 | 14,680 | 53 |
  | scoped, off | **23** | 0 | 53 |
  | full, off | 87 | 0 | 53 |

  Identical results; scoped load 36→23ms (the BFS was ~13ms).

  ## Compatibility
  `WAM_DEMAND` defaults to `on` (unset ⇒ on); existing benches + the LMDB
  cross-target conformance test (cached, demand on) are unchanged.

  ## Tests
  `tests/test_wam_rust_matrix_demand_flag.py` — codegen guard (swipl only, no
  cargo): asserts the emitted `main.rs` carries the `WAM_DEMAND` wiring and that
  the lazy/cached materialisation transform still splices in
  (`set_demand_set` + `LazyCategoryParents` + `register_lazy_lookup`). The matrix
  bench previously had no CI codegen guard. Wired into CI.