### PR TITLE
Cover WAM-C forall control lowering

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,16 +4,15 @@ Status date: 2026-06-05
 
 Latest branch verification:
 
-- `investigate/wam-c-explicit-cut-scope` based on `main` at `d1b94363`
-  (`Merge pull request #2813 from
-  s243a/investigate/wam-c-precise-ite-cut-scope`)
+- `investigate/wam-c-forall-control-smoke` based on `main` at `9e997ed5`
+  (`Merge pull request #2814 from
+  s243a/investigate/wam-c-explicit-cut-scope`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
-- `swipl -q -g run_tests -t halt tests/test_wam_c_effective_distance_benchmark.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-explicit-cut-scope`
+- `investigate/wam-c-forall-control-smoke`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -80,6 +79,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Control instruction parity smoke | Done | `INSTR_GET_LEVEL`, `INSTR_CUT`, `INSTR_CUT_ITE`, and `INSTR_JUMP` now parse, emit, and execute; generated executable smoke covers `\+/1` and if-then-else success/failure paths |
 | Precise if-then-else cut scope smoke | Done | C target tests now compile `ite_use_y_level(true)` WAM with `get_level`/`cut` and run a nondeterministic-condition scope regression that must not backtrack into the else branch after commit |
 | Explicit cut call-scope fix | Done | `!/0` now prunes to the current call barrier instead of clearing all choice points; generated executable smoke preserves an outer disjunction alternative across an inner predicate cut |
+| `forall/2` control smoke | Done | Generated executable smoke covers the shared nested soft-cut rewrite for `forall/2` all-pass, action-fail, subset, and empty-generator cases |
 
 ## Current C Target Baseline
 
@@ -130,7 +130,8 @@ The C target is now a credible small WAM backend:
   foreign calls, native category ancestor, file-backed facts, streaming native
   results, real multi-clause predicates, structure indexing, `is_list/1`,
   `=/2`, negation, legacy `cut_ite` if-then-else, and precise
-  `get_level`/`cut` if-then-else, plus explicit `!/0` call-scope behavior.
+  `get_level`/`cut` if-then-else, explicit `!/0` call-scope behavior, and
+  `forall/2`'s generated soft-cut rewrite.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -154,7 +155,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
 | Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
 | Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
-| Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, precise `get_level`/`cut` if-then-else, and explicit `!/0` scoped to the current predicate call barrier; residual work is broader meta-control coverage such as `forall/2` as demanded. |
+| Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, precise `get_level`/`cut` if-then-else, explicit `!/0` scoped to the current predicate call barrier, and generated `forall/2` soft-cut rewrites; residual work should be driven by concrete meta-control demand. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
 | Shared kernel detector integration | Partial/Done | Done | Done | C reuses `recursive_kernel_detection.pl` for `category_ancestor/4`, `transitive_closure2`, `transitive_distance3`, `transitive_parent_distance4`, `transitive_step_parent_distance5`, `weighted_shortest_path3`, and `astar_shortest_path4`; Haskell and Rust still have broader wrapper/fact-layout integration. |
@@ -167,6 +168,28 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-forall-control-smoke`
+
+Goal: prove that C executes the shared WAM compiler's nested soft-cut rewrite
+for `forall/2`.
+
+Evidence:
+
+- Generated WAM coverage asserts `forall/2` compiles through `cut_ite` control
+  flow rather than a runtime `forall/2` builtin.
+- Executable smoke coverage runs all-pass, action-fail, subset, and
+  empty-generator `forall/2` cases over nondeterministic user predicates.
+- Each generated C run checks that public calls leave the choice-point and
+  call-barrier stacks balanced.
+
+Reason:
+
+- Recent C control branches fixed and covered the underlying cut and soft-cut
+  semantics. `forall/2` was the next higher-level meta-control construct that
+  reuses those paths.
+- This branch confirms parity without adding new runtime surface area; future
+  control work should come from concrete benchmark or conformance demand.
 
 ### Completed: `investigate/wam-c-explicit-cut-scope`
 

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -1695,6 +1695,16 @@ test_real_prolog_explicit_cut_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_real_prolog_forall_executable_smoke :-
+    Test = 'WAM-C: real Prolog forall/2 executable smoke',
+    (   gcc_available
+    ->  (   run_real_prolog_forall_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'real Prolog forall/2 executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_real_prolog_classic_recursive_executable_smoke :-
     Test = 'WAM-C: real Prolog classic recursive executable smoke',
     (   gcc_available
@@ -2667,6 +2677,76 @@ cleanup_wam_c_explicit_cut_smoke :-
     retractall(user:wam_c_cut_choice(_)),
     retractall(user:wam_c_inner_cut),
     retractall(user:wam_c_outer_cut(_)).
+
+run_real_prolog_forall_executable_smoke :-
+    assertz((user:wam_c_forall_num(1) :- true)),
+    assertz((user:wam_c_forall_num(2) :- true)),
+    assertz((user:wam_c_forall_positive(1) :- true)),
+    assertz((user:wam_c_forall_positive(2) :- true)),
+    assertz((user:wam_c_forall_only_two(2) :- true)),
+    assertz((user:wam_c_forall_empty(_) :- fail)),
+    assertz((user:wam_c_forall_all(ok) :-
+        forall(wam_c_forall_num(X), wam_c_forall_positive(X)))),
+    assertz((user:wam_c_forall_fail(ok) :-
+        forall(wam_c_forall_num(X), wam_c_forall_only_two(X)))),
+    assertz((user:wam_c_forall_subset(ok) :-
+        forall(wam_c_forall_only_two(X), wam_c_forall_positive(X)))),
+    assertz((user:wam_c_forall_empty_ok(ok) :-
+        forall(wam_c_forall_empty(X), wam_c_forall_positive(X)))),
+    (   compile_predicate_to_wam(user:wam_c_forall_num/1, [], WamNum),
+        compile_predicate_to_wam(user:wam_c_forall_positive/1, [], WamPositive),
+        compile_predicate_to_wam(user:wam_c_forall_only_two/1, [], WamOnlyTwo),
+        compile_predicate_to_wam(user:wam_c_forall_empty/1, [], WamEmpty),
+        compile_predicate_to_wam(user:wam_c_forall_all/1, [], WamAll),
+        compile_predicate_to_wam(user:wam_c_forall_fail/1, [], WamFail),
+        compile_predicate_to_wam(user:wam_c_forall_subset/1, [], WamSubset),
+        compile_predicate_to_wam(user:wam_c_forall_empty_ok/1, [], WamEmptyOk),
+        sub_string(WamAll, _, _, _, 'cut_ite'),
+        sub_string(WamFail, _, _, _, 'cut_ite'),
+        sub_string(WamSubset, _, _, _, 'cut_ite'),
+        sub_string(WamEmptyOk, _, _, _, 'cut_ite'),
+        \+ sub_string(WamAll, _, _, _, 'builtin_call forall/2'),
+        compile_wam_predicate_to_c(user:wam_c_forall_num/1, WamNum, [], NumCode),
+        compile_wam_predicate_to_c(user:wam_c_forall_positive/1, WamPositive, [], PositiveCode),
+        compile_wam_predicate_to_c(user:wam_c_forall_only_two/1, WamOnlyTwo, [], OnlyTwoCode),
+        compile_wam_predicate_to_c(user:wam_c_forall_empty/1, WamEmpty, [], EmptyCode),
+        compile_wam_predicate_to_c(user:wam_c_forall_all/1, WamAll, [], AllCode),
+        compile_wam_predicate_to_c(user:wam_c_forall_fail/1, WamFail, [], FailCode),
+        compile_wam_predicate_to_c(user:wam_c_forall_subset/1, WamSubset, [], SubsetCode),
+        compile_wam_predicate_to_c(user:wam_c_forall_empty_ok/1, WamEmptyOk, [], EmptyOkCode),
+        atomic_list_concat([NumCode, PositiveCode, OnlyTwoCode, EmptyCode,
+                            AllCode, FailCode, SubsetCode, EmptyOkCode],
+                           '\n\n',
+                           PredCode),
+        compile_wam_runtime_to_c([], RuntimeCode),
+        get_time(Now),
+        Stamp is round(Now * 1000000),
+        wam_c_temp_path('unifyweaver_wam_c_forall_smoke', Stamp, TmpBase),
+        format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+        format(atom(PredPath), '~w_pred.c', [TmpBase]),
+        format(atom(MainPath), '~w_main.c', [TmpBase]),
+        format(atom(ExePath), '~w_bin', [TmpBase]),
+        write_text_file(RuntimePath, RuntimeCode),
+        format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+        write_text_file(PredPath, PredTranslationUnit),
+        wam_c_forall_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_forall_smoke
+    ;   cleanup_wam_c_forall_smoke,
+        fail
+    ).
+
+cleanup_wam_c_forall_smoke :-
+    retractall(user:wam_c_forall_num(_)),
+    retractall(user:wam_c_forall_positive(_)),
+    retractall(user:wam_c_forall_only_two(_)),
+    retractall(user:wam_c_forall_empty(_)),
+    retractall(user:wam_c_forall_all(_)),
+    retractall(user:wam_c_forall_fail(_)),
+    retractall(user:wam_c_forall_subset(_)),
+    retractall(user:wam_c_forall_empty_ok(_)).
 
 run_real_prolog_classic_recursive_executable_smoke :-
     assertz((user:wam_c_classic_fib(0, 0) :- true)),
@@ -5606,6 +5686,70 @@ int main(void) {
 }
 ').
 
+wam_c_forall_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_forall_num_1(WamState* state);
+void setup_wam_c_forall_positive_1(WamState* state);
+void setup_wam_c_forall_only_two_1(WamState* state);
+void setup_wam_c_forall_empty_1(WamState* state);
+void setup_wam_c_forall_all_1(WamState* state);
+void setup_wam_c_forall_fail_1(WamState* state);
+void setup_wam_c_forall_subset_1(WamState* state);
+void setup_wam_c_forall_empty_ok_1(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_forall_num_1(&state);
+    setup_wam_c_forall_positive_1(&state);
+    setup_wam_c_forall_only_two_1(&state);
+    setup_wam_c_forall_empty_1(&state);
+    setup_wam_c_forall_all_1(&state);
+    setup_wam_c_forall_fail_1(&state);
+    setup_wam_c_forall_subset_1(&state);
+    setup_wam_c_forall_empty_ok_1(&state);
+
+    WamValue all_args[1] = { val_atom("ok") };
+    int all_rc = wam_run_predicate(&state, "wam_c_forall_all/1", all_args, 1);
+    if (all_rc != 0 || state.P != WAM_HALT || state.B != 0 || state.call_base_top != 0) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue fail_args[1] = { val_atom("ok") };
+    int fail_rc = wam_run_predicate(&state, "wam_c_forall_fail/1", fail_args, 1);
+    if (fail_rc != WAM_HALT || state.B != 0 || state.call_base_top != 0) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue subset_args[1] = { val_atom("ok") };
+    int subset_rc = wam_run_predicate(&state, "wam_c_forall_subset/1", subset_args, 1);
+    if (subset_rc != 0 || state.P != WAM_HALT || state.B != 0 || state.call_base_top != 0) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    WamValue empty_args[1] = { val_atom("ok") };
+    int empty_rc = wam_run_predicate(&state, "wam_c_forall_empty_ok/1", empty_args, 1);
+    if (empty_rc != 0 || state.P != WAM_HALT || state.B != 0 || state.call_base_top != 0) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    WamValue bad_args[1] = { val_atom("bad") };
+    int bad_rc = wam_run_predicate(&state, "wam_c_forall_all/1", bad_args, 1);
+    if (bad_rc != WAM_HALT || state.B != 0 || state.call_base_top != 0) {
+        wam_free_state(&state);
+        return 50;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_classic_fib_smoke_main(
 '#include "wam_runtime.h"
 
@@ -5815,6 +5959,7 @@ run_tests_once :-
     test_real_prolog_control_executable_smoke,
     test_real_prolog_precise_ite_executable_smoke,
     test_real_prolog_explicit_cut_executable_smoke,
+    test_real_prolog_forall_executable_smoke,
     test_real_prolog_classic_recursive_executable_smoke,
     test_lowered_fact_helper_executable_smoke,
     test_lowered_body_call_helper_executable_smoke,


### PR DESCRIPTION
  ## Summary
  - Add generated WAM-C executable smoke coverage for `forall/2`
  - Cover all-pass, action-fail, subset, empty-generator, and head-failure cases
  - Assert `forall/2` lowers through the shared soft-cut path (`cut_ite`) instead of a runtime builtin
  - Update `WAM_C_TARGET_NEXT_STEPS.md` with the completed control-smoke slice

  ## Validation
  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `git diff --check`