### PR TITLE
WAM_DEMAND=auto: auto-detect a pre-scoped DB and skip the demand BFS

### DIFF
--- a/examples/benchmark/build_scoped_subtree_lmdb.py
+++ b/examples/benchmark/build_scoped_subtree_lmdb.py
@@ -173,6 +173,15 @@ def main() -> int:
     except lmdb.NotFoundError:
         sys.stderr.write("note: source has no s2i/i2s sub-dbs; skipping (int-native fixture)\n")
 
+    # 3b. stamp a `meta` marker so the runtime can auto-detect a pre-scoped DB
+    #     (WAM_DEMAND=auto) and skip the redundant query-time reachable_to_root
+    #     BFS without a manual flag.
+    meta_db = out_env.open_db(b"meta", create=True)
+    with out_env.begin(write=True) as wtxn:
+        wtxn.put(b"scoped", b"1", db=meta_db)
+        wtxn.put(b"scoped_root", str(args.root).encode(), db=meta_db)
+        wtxn.put(b"scoped_max_depth", str(args.max_depth).encode(), db=meta_db)
+
     out_env.sync()
     out_env.close()
     src_env.close()

--- a/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
+++ b/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
@@ -1351,15 +1351,21 @@ fn main() {
     });
 
     let max_depth_limit = 10usize;
-    // WAM_DEMAND=off skips the reachable_to_root BFS: the DB is assumed to be a
-    // pre-scoped subtree (built by build_scoped_subtree_lmdb.py), so every node
-    // is already in scope and query-time demand filtering is redundant. An
-    // empty reachable_ids set leaves the kernel demand filter a no-op (it
-    // guards on !is_empty), so lazy/cached need no further change; the eager
-    // branch below loads all edges instead of the demand-filtered subset.
-    let demand_enabled = std::env::var("WAM_DEMAND")
-        .map(|v| v != "off")
-        .unwrap_or(true);
+    // WAM_DEMAND controls the query-time reachable_to_root BFS:
+    //   on   (default) - always run it.
+    //   off            - always skip it (DB assumed pre-scoped).
+    //   auto           - skip iff the DB self-declares scoped (a `meta` marker
+    //                    written by build_scoped_subtree_lmdb.py).
+    // Skipping is safe on a pre-scoped subtree: every node is already in scope,
+    // so the BFS just re-walks the whole DB. An empty reachable_ids set leaves
+    // the kernel demand filter a no-op (it guards on !is_empty), so lazy/cached
+    // need no further change; the eager branch below loads all edges instead of
+    // the demand-filtered subset.
+    let demand_enabled = match std::env::var("WAM_DEMAND").as_deref() {
+        Ok("off") => false,
+        Ok("auto") => !lmdb.is_scoped(),
+        _ => true,
+    };
     let reachable_ids: HashSet<i32> = if demand_enabled {
         lmdb.reachable_to_root(root_id, max_depth_limit)
             .expect("reachable_to_root")

--- a/templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache
+++ b/templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache
@@ -217,6 +217,31 @@ impl LmdbFactSource {
         }
         Ok(reachable)
     }
+
+    /// True if this DB carries the `scoped` marker written at ingest by
+    /// build_scoped_subtree_lmdb.py — i.e. it is a pre-scoped subtree where
+    /// every node is already in scope, so the query-time reachable_to_root BFS
+    /// is redundant. Full-graph DBs have no `meta` sub-db; opening it fails
+    /// (NOTFOUND) and we report not-scoped. Used by WAM_DEMAND=auto.
+    pub fn is_scoped(&self) -> bool {
+        let meta = match lmdb::Database::open(
+            Arc::clone(&self.env),
+            Some("meta"),
+            &lmdb::DatabaseOptions::new(lmdb::db::Flags::empty()),
+        ) {
+            Ok(db) => db,
+            Err(_) => return false,
+        };
+        let txn = match lmdb::ReadTransaction::new(&*self.env) {
+            Ok(t) => t,
+            Err(_) => return false,
+        };
+        let access = txn.access();
+        match access.get::<[u8], [u8]>(&meta, b"scoped") {
+            Ok(v) => v == b"1",
+            Err(_) => false,
+        }
+    }
 }
 
 fn decode_i32(bytes: &[u8]) -> i32 {

--- a/tests/test_build_scoped_subtree_lmdb.py
+++ b/tests/test_build_scoped_subtree_lmdb.py
@@ -128,6 +128,22 @@ class TestBuildScopedSubtreeLmdb(unittest.TestCase):
         env.close()
         self.assertEqual(ids, {2, 3, 4, 5})
 
+    def test_scoped_meta_marker(self):
+        # The `meta` marker lets the runtime auto-detect a pre-scoped DB
+        # (WAM_DEMAND=auto) and skip the redundant reachable_to_root BFS.
+        self._run_builder(root=2, max_depth=7)
+        env = lmdb.open(str(self.out), max_dbs=16, readonly=True, subdir=True,
+                        lock=False)
+        meta = env.open_db(b"meta", create=False)
+        with env.begin() as txn:
+            scoped = txn.get(b"scoped", db=meta)
+            root = txn.get(b"scoped_root", db=meta)
+            depth = txn.get(b"scoped_max_depth", db=meta)
+        env.close()
+        self.assertEqual(scoped, b"1")
+        self.assertEqual(root, b"2")
+        self.assertEqual(depth, b"7")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wam_rust_matrix_demand_flag.py
+++ b/tests/test_wam_rust_matrix_demand_flag.py
@@ -70,6 +70,17 @@ class TestMatrixDemandFlag(unittest.TestCase):
         self.assertIn("CachedLookup", src)
         self.assertIn("set_demand_set", src)
 
+    def test_auto_branch_and_is_scoped(self):
+        # WAM_DEMAND=auto consults the DB scoped marker via is_scoped().
+        src = self._generate("lazy")
+        self.assertIn('Ok("auto")', src)
+        self.assertIn(".is_scoped()", src)
+        # The is_scoped() definition lives in the emitted LmdbFactSource module.
+        src_dir = Path(self.tmp.name) / "lazy" / "src"
+        defs = [p.read_text() for p in src_dir.glob("*.rs")]
+        self.assertTrue(any("pub fn is_scoped" in d for d in defs),
+                        "is_scoped() definition missing from generated Rust")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
  ## Summary
  Removes the foot-gun of having to pass WAM_DEMAND=off on a pre-scoped DB.
  `build_scoped_subtree_lmdb.py` stamps a `meta` marker (scoped=1, scoped_root,
  scoped_max_depth); `LmdbFactSource::is_scoped()` reads it (full-graph DBs have
  no `meta` sub-db → open fails with NOTFOUND → not-scoped). `WAM_DEMAND=auto`
  maps to `!lmdb.is_scoped()`: skip the reachable_to_root BFS iff the DB
  self-declares scoped.

  ## Compatibility
  Values: `on` (default) | `off` | `auto`. Default stays `on`, so existing benches
  and the LMDB cross-target conformance test are unchanged.

  ## Validation (simplewiki, lazy, int-native, same full seed list)
  | scenario | demand_set_size | tuple_count |
  |---|---|---|
  | scoped + auto | 0 (marker → skipped) | 53 |
  | full + auto | 14,680 (no marker → ran) | 53 |

  Auto never changes results.

  ## Tests (already CI-wired)
  - `test_build_scoped_subtree_lmdb.py`: asserts the meta marker is written.
  - `test_wam_rust_matrix_demand_flag.py`: asserts the emitted code has the
    `Ok("auto")` branch, the `.is_scoped()` call, and the `is_scoped()` definition.