### PR TITLE
Add hybrid lowered fast paths for WAM‑WAT (lowered emitter + integration)

### DIFF
--- a/docs/WAM_TARGET_ROADMAP.md
+++ b/docs/WAM_TARGET_ROADMAP.md
@@ -120,7 +120,7 @@ haven't yet hit the kernel-or-LMDB inflection point.
 
 | Target | Source size | Status | Notes |
 |---|---|---|---|
-| **WAT** (WebAssembly text) | `wam_wat_target.pl` (6325 lines) | Substantial WAM-instruction lowering pipeline | No `wam_wat_lowered_emitter.pl`; single-mode interpreter (Scala-shaped). Browser-deployment angle is the differentiator |
+| **WAT** (WebAssembly text) | `wam_wat_target.pl` + `wam_wat_lowered_emitter.pl` | Substantial WAM-instruction lowering pipeline plus deterministic clause-1 lowered fast paths | Hybrid mode now mirrors Rust/Scala-style public-entry replay: lowered success returns immediately; lowered failure reinitialises and falls back to `$run_loop`. Browser-deployment angle remains the differentiator |
 | **C** | `wam_c_target.pl` (907 lines) + `wam_c_runtime/wam_runtime.h` | Has a C runtime header | Smaller surface; useful as a portable substrate for FFI kernels (Rust/Go FFI kernels could share C glue) |
 | **JVM** | `wam_jvm_target.pl` (711 lines) | Smaller than the Scala/Clojure entries | Generic JVM bytecode emit; both Scala and Clojure target the JVM via different routes — this is the third |
 

--- a/docs/targets/wam-wat.md
+++ b/docs/targets/wam-wat.md
@@ -32,6 +32,11 @@ For implementation and architecture details, see
   produces a `.wasm` module with no external dependencies beyond
   three small host imports (`print_i64`, `print_char`,
   `print_newline`) used only for optional output.
+- **Hybrid lowered fast paths**: In mixed mode, deterministic clause-1
+  predicates also get a `lowered_<pred>_<arity>` WAT function emitted by
+  `wam_wat_lowered_emitter.pl`. The public export tries that direct
+  sequence of `$do_*` instruction calls first, then reinitializes VM
+  state and falls back to `$run_loop` if the fast path fails.
 - **V8 JIT-friendly dispatch**: The runtime uses a `br_table`
   dispatch in a single `$step` function that returns after each
   instruction, paired with an outer `$run_loop` driver. V8's

--- a/src/unifyweaver/targets/wam_wat_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_wat_lowered_emitter.pl
@@ -1,0 +1,131 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (@s243a)
+%
+% wam_wat_lowered_emitter.pl — WAM-lowered WAT emission
+%
+% Emits per-predicate WAT fast-path functions for deterministic clause-1
+% prefixes.  The shape mirrors the hybrid WAM targets (Rust, Scala,
+% Haskell, F#, LLVM): try the lowered clause-1 path first, and if it fails
+% the generated public entry point reinitialises state and falls back to
+% the complete bytecode interpreter.
+
+:- module(wam_wat_lowered_emitter, [
+    wam_wat_lowerable/3,
+    lower_predicate_to_wat/4,
+    wat_lowered_func_name/2
+]).
+
+:- use_module(library(lists)).
+
+%% wam_wat_lowerable(+PI, +WamCode, -Reason) is semidet.
+wam_wat_lowerable(_PI, WamCode, Reason) :-
+    parse_wam_text_wat(WamCode, Instrs),
+    clause1_instrs_wat(Instrs, C1, MultiClause),
+    is_deterministic_pred_wat(C1),
+    forall(member(I, C1), wat_supported(I)),
+    ( MultiClause == true -> Reason = multi_clause_1 ; Reason = single_clause ).
+
+parse_wam_text_wat(WamCode, Instrs) :-
+    (   string(WamCode) -> S = WamCode
+    ;   atom_string(WamCode, S)
+    ),
+    split_string(S, "\n", "", Lines),
+    wam_wat_target:wam_lines_to_instrs(Lines, 0, Instrs, _Labels).
+
+clause1_instrs_wat([try_me_else(_)|Rest], C1, true) :- !,
+    take_to_proceed_wat(Rest, C1).
+clause1_instrs_wat(Instrs, Instrs, false).
+
+take_to_proceed_wat([], []).
+take_to_proceed_wat([proceed|_], [proceed]) :- !.
+take_to_proceed_wat([I|Rest], [I|More]) :- take_to_proceed_wat(Rest, More).
+
+is_deterministic_pred_wat(Instrs) :-
+    \+ member(try_me_else(_), Instrs),
+    \+ member(retry_me_else(_), Instrs),
+    \+ member(trust_me, Instrs).
+
+wat_supported(get_constant(_, _)).
+wat_supported(get_variable(_, _)).
+wat_supported(get_value(_, _)).
+wat_supported(get_structure(_, _)).
+wat_supported(get_list(_)).
+wat_supported(unify_variable(_)).
+wat_supported(unify_value(_)).
+wat_supported(unify_constant(_)).
+wat_supported(put_constant(_, _)).
+wat_supported(put_variable(_, _)).
+wat_supported(put_value(_, _)).
+wat_supported(put_structure(_, _)).
+wat_supported(put_list(_)).
+wat_supported(set_variable(_)).
+wat_supported(set_value(_)).
+wat_supported(set_constant(_)).
+wat_supported(allocate).
+wat_supported(deallocate).
+wat_supported(proceed).
+wat_supported(builtin_call(Op, _)) :- deterministic_builtin_wat(Op).
+
+% Keep calls/execute in the interpreter for now: a lowered WAT function has
+% no cross-predicate continuation frame, so inlining them would not be sound.
+deterministic_builtin_wat('=/2').
+deterministic_builtin_wat('true/0').
+deterministic_builtin_wat('fail/0').
+deterministic_builtin_wat('!/0').
+deterministic_builtin_wat('is/2').
+deterministic_builtin_wat('=:=/2').
+deterministic_builtin_wat('=\\=/2').
+deterministic_builtin_wat('</2').
+deterministic_builtin_wat('>/2').
+deterministic_builtin_wat('=</2').
+deterministic_builtin_wat('>=/2').
+deterministic_builtin_wat('var/1').
+deterministic_builtin_wat('nonvar/1').
+deterministic_builtin_wat('atom/1').
+deterministic_builtin_wat('number/1').
+deterministic_builtin_wat('integer/1').
+deterministic_builtin_wat('float/1').
+deterministic_builtin_wat('atomic/1').
+deterministic_builtin_wat('is_list/1').
+
+wat_lowered_func_name(Pred/Arity, Name) :-
+    atom_string(Pred, S),
+    string_codes(S, Codes),
+    maplist(wat_safe_code, Codes, SafeCodes),
+    string_codes(Safe, SafeCodes),
+    format(atom(Name), 'lowered_~w_~w', [Safe, Arity]).
+
+wat_safe_code(C, C) :-
+    (   C >= 0'a, C =< 0'z
+    ;   C >= 0'A, C =< 0'Z
+    ;   C >= 0'0, C =< 0'9
+    ;   C =:= 0'_
+    ), !.
+wat_safe_code(_, 0'_).
+
+%% lower_predicate_to_wat(+PI, +WamCode, +Options, -lowered(PredName, FuncName, Code))
+lower_predicate_to_wat(PI, WamCode, _Options, lowered(PredName, FuncName, Code)) :-
+    ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
+    format(atom(PredName), '~w/~w', [Pred, Arity]),
+    wat_lowered_func_name(Pred/Arity, FuncName),
+    wam_wat_lowerable(PI, WamCode, _Reason),
+    parse_wam_text_wat(WamCode, Instrs),
+    clause1_instrs_wat(Instrs, C1, _MultiClause),
+    with_output_to(atom(Code), emit_lowered_function_wat(FuncName, C1)).
+
+emit_lowered_function_wat(FuncName, Instrs) :-
+    format('(func $~w (result i32)~n', [FuncName]),
+    format('  ;; WAM-WAT lowered clause-1 fast path. On failure the public entry replays via $run_loop.~n'),
+    emit_lowered_instrs_wat(Instrs),
+    format('  (i32.const 1)~n'),
+    format(')~n').
+
+emit_lowered_instrs_wat([]).
+emit_lowered_instrs_wat([proceed|_]) :- !,
+    format('  (return (i32.const 1))~n').
+emit_lowered_instrs_wat([Instr|Rest]) :-
+    wam_wat_target:wam_instruction_to_wat_operands(Instr, [], DoName, Op1, Op2),
+    format('  (if (i32.eqz (call $do_~w (i64.const ~w) (i64.const ~w)))~n', [DoName, Op1, Op2]),
+    format('    (then (return (i32.const 0))))~n'),
+    emit_lowered_instrs_wat(Rest).

--- a/src/unifyweaver/targets/wam_wat_target.pl
+++ b/src/unifyweaver/targets/wam_wat_target.pl
@@ -19,6 +19,7 @@
     compile_wam_runtime_to_wat/2,       % +Options, -WatCode
     compile_wam_predicate_to_wat/4,     % +Pred/Arity, +WamCode, +Options, -WatCode
     wam_instruction_to_wat_bytes/3,     % +WamInstr, +LabelMap, -ByteHex
+    wam_instruction_to_wat_operands/5,  % +WamInstr, +LabelMap, -DoName, -Op1, -Op2
     reg_name_to_index/2,                % +Name, -Index
     atom_hash_i64/2,                    % +Atom, -Hash
     write_wam_wat_project/3             % +Predicates, +Options, +OutputFile
@@ -29,6 +30,10 @@
 :- use_module(library(filesex), [make_directory_path/1, directory_file_path/3]).
 :- use_module('../core/template_system').
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../targets/wam_wat_lowered_emitter', [
+    wam_wat_lowerable/3,
+    lower_predicate_to_wat/4
+]).
 
 :- discontiguous wam_wat_case/2.
 
@@ -1485,6 +1490,49 @@ compile_wam_predicate_to_wat(Pred/Arity, WamCode, Options, WatResult) :-
 
 encode_instr_with_labels(Labels, Instr, Hex) :-
     wam_instruction_to_wat_bytes(Instr, Labels, Hex).
+
+%% wam_instruction_to_wat_operands(+WamInstr, +LabelMap, -DoName, -Op1, -Op2)
+%  Public helper for the lowered WAT emitter. It reuses the canonical
+%  bytecode encoder, then decodes the two 64-bit operands, so lowered
+%  functions and bytecode data segments cannot drift apart.
+wam_instruction_to_wat_operands(Instr, Labels, DoName, Op1, Op2) :-
+    functor(Instr, DoName, _),
+    wam_instruction_to_wat_bytes(Instr, Labels, Hex),
+    wat_instr_hex_operands(Hex, Op1, Op2).
+
+wat_instr_hex_operands(Hex, Op1, Op2) :-
+    atom_codes(Hex, Codes),
+    wat_hex_bytes(Codes, Bytes),
+    Bytes = [_,_,_,_|OpBytes],
+    take_n(8, OpBytes, Op1Bytes, Op2Bytes),
+    le_bytes_u64(Op1Bytes, Op1),
+    le_bytes_u64(Op2Bytes, Op2).
+
+wat_hex_bytes([], []).
+wat_hex_bytes([92, H, L | Rest], [B|Bs]) :-
+    hex_digit_value(H, HV),
+    hex_digit_value(L, LV),
+    B is (HV << 4) \/ LV,
+    wat_hex_bytes(Rest, Bs).
+
+take_n(0, Rest, [], Rest) :- !.
+take_n(N, [X|Xs], [X|Ys], Rest) :-
+    N1 is N - 1,
+    take_n(N1, Xs, Ys, Rest).
+
+le_bytes_u64(Bytes, Value) :-
+    le_bytes_u64(Bytes, 0, 0, Value).
+le_bytes_u64([], _, Acc, Acc).
+le_bytes_u64([B|Bs], Shift, Acc0, Value) :-
+    Acc is Acc0 \/ (B << Shift),
+    Shift1 is Shift + 8,
+    le_bytes_u64(Bs, Shift1, Acc, Value).
+
+hex_digit_value(C, V) :-
+    (   C >= 0'0, C =< 0'9 -> V is C - 0'0
+    ;   C >= 0'a, C =< 0'f -> V is C - 0'a + 10
+    ;   C >= 0'A, C =< 0'F -> V is C - 0'A + 10
+    ).
 
 wat_pred_name(Pred, Arity, Name) :-
     format(atom(Name), '~w_~w', [Pred, Arity]).
@@ -5586,8 +5634,10 @@ compile_wat_predicates(Predicates, Options, CodeBase, DataSegs, Funcs, Exports) 
     %% Entry functions: one per predicate, each setting its own
     %% start PC before invoking the shared run loop.
     option(wam_heap_start(HeapStart), Options, 196608),
+    wat_generate_lowered(PredData, Options, LoweredFuncs, LoweredPairs),
     gen_all_entry_funcs(PredData, HeapStart, CodeBase, TotalInstrs,
-                        Funcs, Exports).
+                        LoweredPairs, EntryFuncs, Exports),
+    atomic_list_concat([LoweredFuncs, '\n', EntryFuncs], Funcs).
 
 %% wam_atom_table_base(-Offset)
 %  Fixed start address of the atom name table. Lives on page 5
@@ -6491,25 +6541,81 @@ same_label(X, X) :- !.
 same_label(X, Y) :- atom(X), string(Y), atom_string(X, Y), !.
 same_label(X, Y) :- string(X), atom(Y), atom_string(Y, X).
 
+%% wat_generate_lowered(+PredData, +Options, -Functions, -Pairs)
+%  Build per-predicate lowered WAT fast paths in mixed mode. A pair is
+%  Pred/Arity-FuncName and is consumed by gen_all_entry_funcs/7.
+wat_generate_lowered(PredData, Options, Functions, Pairs) :-
+    wat_resolve_emit_mode(Options, Mode),
+    (   Mode == interpreter
+    ->  Functions = '', Pairs = []
+    ;   findall(Code-Pair,
+            ( member(pred_data(Pred/Arity, _, _, _, _), PredData),
+              wat_mode_allows_lowering(Mode, Pred/Arity),
+              catch(wam_target:compile_predicate_to_wam(Pred/Arity, Options, WamCode), _, fail),
+              wam_wat_lowerable(Pred/Arity, WamCode, _Reason),
+              lower_predicate_to_wat(Pred/Arity, WamCode, Options, lowered(_Key, FuncName, Code)),
+              Pair = (Pred/Arity-FuncName)
+            ), CodePairs),
+        pairs_codes_pairs(CodePairs, Codes, Pairs),
+        atomic_list_concat(Codes, '\n', Functions)
+    ).
+
+pairs_codes_pairs([], [], []).
+pairs_codes_pairs([Code-Pair|Rest], [Code|Codes], [Pair|Pairs]) :-
+    pairs_codes_pairs(Rest, Codes, Pairs).
+
+wat_resolve_emit_mode(Options, Mode) :-
+    (   option(emit_mode(Mode0), Options)
+    ->  wat_normalize_emit_mode(Mode0, Mode)
+    ;   option(lowered(false), Options)
+    ->  Mode = interpreter
+    ;   Mode = mixed(auto)
+    ).
+
+wat_normalize_emit_mode(interpreter, interpreter) :- !.
+wat_normalize_emit_mode(bytecode, interpreter) :- !.
+wat_normalize_emit_mode(lowered, mixed(auto)) :- !.
+wat_normalize_emit_mode(mixed(List), mixed(List)) :- !.
+wat_normalize_emit_mode(_, mixed(auto)).
+
+wat_mode_allows_lowering(mixed(auto), _) :- !.
+wat_mode_allows_lowering(mixed(List), Pred/Arity) :-
+    (   List == auto
+    ->  true
+    ;   memberchk(Pred/Arity, List)
+    ).
+
 %% gen_all_entry_funcs(+PredData, +HeapStart, +CodeBase, +TotalInstrs,
-%%                     -Funcs, -Exports)
+%%                     +LoweredPairs, -Funcs, -Exports)
 %  Emit one exported entry function per predicate. All entry functions
 %  share the same CodeBase and TotalInstrs; they differ only in their
 %  StartPC, which each function writes into the VM's PC register
 %  immediately after $wam_init (before invoking the run loop).
-gen_all_entry_funcs([], _, _, _, '', '').
+gen_all_entry_funcs([], _, _, _, _, '', '').
 gen_all_entry_funcs([pred_data(Pred/Arity, _, _, StartPC, _)|Rest],
-                    HeapStart, CodeBase, TotalInstrs,
+                    HeapStart, CodeBase, TotalInstrs, LoweredPairs,
                     EntryFuncs, Exports) :-
     wat_pred_name(Pred, Arity, FName),
-    format(atom(EF),
+    (   memberchk(Pred/Arity-LoweredName, LoweredPairs)
+    ->  format(atom(EF),
+'(func $~w (export "~w") (result i32)
+  (call $wam_init (i32.const ~w))
+  (if (call $~w)
+    (then (return (i32.const 1))))
+  ;; Lowered clause-1 failed: replay with a fresh VM state through the full interpreter.
+  (call $wam_init (i32.const ~w))
+  (call $set_pc (i32.const ~w))
+  (call $run_loop (i32.const ~w) (i32.const ~w)))',
+            [FName, FName, HeapStart, LoweredName, HeapStart, StartPC, CodeBase, TotalInstrs])
+    ;   format(atom(EF),
 '(func $~w (export "~w") (result i32)
   (call $wam_init (i32.const ~w))
   (call $set_pc (i32.const ~w))
   (call $run_loop (i32.const ~w) (i32.const ~w)))',
-        [FName, FName, HeapStart, StartPC, CodeBase, TotalInstrs]),
+            [FName, FName, HeapStart, StartPC, CodeBase, TotalInstrs])
+    ),
     format(atom(Export), '  ;; exported: ~w', [FName]),
-    gen_all_entry_funcs(Rest, HeapStart, CodeBase, TotalInstrs,
+    gen_all_entry_funcs(Rest, HeapStart, CodeBase, TotalInstrs, LoweredPairs,
                         RestEF, RestExports),
     atomic_list_concat([EF, '\n', RestEF], EntryFuncs),
     atomic_list_concat([Export, '\n', RestExports], Exports).

--- a/tests/test_wam_wat_target.pl
+++ b/tests/test_wam_wat_target.pl
@@ -1,6 +1,7 @@
 :- encoding(utf8).
 :- use_module(library(plunit)).
 :- use_module('../src/unifyweaver/targets/wam_wat_target').
+:- use_module('../src/unifyweaver/targets/wam_wat_lowered_emitter').
 
 :- begin_tests(wam_wat_target).
 
@@ -65,6 +66,24 @@ test(encode_get_value) :-
     wam_instruction_to_wat_bytes(get_value('X1', 'A2'), [], Hex),
     assertion(atom(Hex)),
     assertion(sub_string(Hex, 0, _, _, "\\02")).  % tag=2
+
+test(operand_helper_decodes_canonical_encoding) :-
+    wam_instruction_to_wat_operands(put_constant(42, 'A1'), [], put_constant, Op1, Op2),
+    assertion(Op1 == 42),
+    assertion(Op2 =:= (1 << 32)).
+
+test(lowered_emitter_accepts_deterministic_clause) :-
+    WamCode = 'put_constant 42 A1
+builtin_call integer/1 1
+proceed
+',
+    wam_wat_lowerable(answer/0, WamCode, Reason),
+    assertion(Reason == single_clause),
+    lower_predicate_to_wat(answer/0, WamCode, [], lowered('answer/0', FuncName, Code)),
+    assertion(FuncName == lowered_answer_0),
+    assertion(sub_atom(Code, _, _, _, '(func $lowered_answer_0')),
+    assertion(sub_atom(Code, _, _, _, '(call $do_put_constant')),
+    assertion(sub_atom(Code, _, _, _, '(call $do_builtin_call')).
 
 test(encode_get_structure) :-
     wam_instruction_to_wat_bytes(get_structure('f/2', 'A1'), [], Hex),


### PR DESCRIPTION
### Motivation
- Bring the WAT hybrid WAM target up to parity with other hybrid targets by emitting per‑predicate deterministic clause‑1 fast paths that call the `$do_*` helpers directly. 
- Avoid duplicated encoder/operand drift between lowered functions and the bytecode data segments by decoding operands from the canonical bytecode encoding.

### Description
- Add `src/unifyweaver/targets/wam_wat_lowered_emitter.pl` implementing `wam_wat_lowerable/3`, `lower_predicate_to_wat/4`, and `wat_lowered_func_name/2` to detect deterministic clause‑1 bodies and emit `lowered_<pred>_<arity>` WAT functions. 
- Add `wam_instruction_to_wat_operands/5` and supporting hex/LE decode helpers to `src/unifyweaver/targets/wam_wat_target.pl` so lowered emitters invoke the canonical `$do_*` helpers with decoded `op1`/`op2` values. 
- Integrate lowered generation into project assembly via `wat_generate_lowered/4` and wire lowered entries into `gen_all_entry_funcs/7` so each exported predicate first attempts the lowered fast path and on failure reinitializes state and falls back to the shared `$run_loop`. 
- Add unit coverage and examples: updated `tests/test_wam_wat_target.pl` with `wam_instruction_to_wat_operands/5` checks and lowered‑emitter smoke tests, and update documentation in `docs/targets/wam-wat.md` and `docs/WAM_TARGET_ROADMAP.md` to describe the hybrid lowered fast paths.

### Testing
- Ran static checks (`git diff --check`) with no issues detected. 
- Added Prolog unit tests in `tests/test_wam_wat_target.pl` covering operand decoding and lowered emitter behavior, but the test runner `swipl` is not installed in this environment so the suite was not executed here. 
- No runtime `wat2wasm`/WASM validation was performed in this container due to missing toolchain; the changes are structured to reuse the existing encoder/runtime helpers to minimise regression risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a239e926d1883248b02bff3690de6bc)