### PR TITLE
LLVM WAM: side-channel module counts (M108) -- fix suite-level OOM

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -28,6 +28,7 @@
     wam_instruction_to_llvm_literal/3,   % +WamInstr, +LabelMap, -LLVMLiteral
     wam_line_to_llvm_literal/2,          % +Parts, -LLVMLit
     write_wam_llvm_project/3,            % +Predicates, +Options, +OutputFile
+    wam_llvm_last_compile_counts/2,      % ?InstrCount, ?LabelCount (side channel)
     write_wam_llvm_wasm_project/3,       % +Predicates, +Options, +OutputFile (WASM variant)
     build_wam_wasm_module/3,             % +LLFile, +OutputName, -Commands
     builtin_op_to_id/2,                  % +OpName, -IntId
@@ -90,6 +91,7 @@
 % fact table, and writes the result.
 
 :- dynamic llvm_foreign_kernel_spec/3.
+:- dynamic wam_llvm_last_compile_counts/2.   % M108: per-compile (Instr, Label) counts.
 
 clear_llvm_foreign_kernel_specs :-
     retractall(llvm_foreign_kernel_spec(_, _, _)).
@@ -2021,6 +2023,13 @@ emit_merged_wam_section(WamRecords, LabelMap, NamePCPairs, Options,
                             AllSwitchDefs),
     length(AllLiterals, InstrCount),
     length(NamePCPairs, LabelCount),
+    % M108: side-channel the module-level instruction/label counts
+    % so the test harness (and any other caller) can fetch them
+    % without re-reading and regex-grepping the multi-MB IR file --
+    % a per-test ~7MB allocation that was the dominant source of
+    % SWI-stack pressure on long suites.
+    retractall(wam_llvm_last_compile_counts(_, _)),
+    assertz(wam_llvm_last_compile_counts(InstrCount, LabelCount)),
     (   InstrCount =:= 0
     ->  CodeGlobal = '', EntryFuncs = '', SwitchDefs = ''
     ;   maplist([Lit, E]>>format(atom(E), '  ~w', [Lit]),

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -4050,9 +4050,12 @@ run_fmt_test(Label, PredAtom, ExpectedStdout) :-
           target_datalayout('')
         ],
         LLPath),
-    read_file_to_string(LLPath, Src, []),
-    extract_instr_count(Src, PredAtom, IC),
-    extract_label_count(Src, PredAtom, LC),
+    % M108: pull the module-level instruction + label counts from
+    % the side-channel asserted by write_wam_llvm_project. Avoids a
+    % per-test ~7MB read_file_to_string + 2 regex scans that
+    % accumulated SWI-stack pressure (the 4 GB cap hit was driven
+    % almost entirely by these reads).
+    wam_llvm_target:wam_llvm_last_compile_counts(IC, LC),
     format(atom(DriverIR),
 'define i32 @main() {
 entry:
@@ -4111,9 +4114,8 @@ run_pow_test(Label, Preds, EntryPred, ScaleI, ExpectedI) :-
     write_wam_llvm_project(AllPreds,
         [module_name('pow_t'), target_triple(Triple), target_datalayout('')],
         LLPath),
-    read_file_to_string(LLPath, Src, []),
-    extract_instr_count(Src, EntryPred, IC),
-    extract_label_count(Src, EntryPred, LC),
+    % M108: same side-channel as run_test_r0 -- skip the IR read-back.
+    wam_llvm_target:wam_llvm_last_compile_counts(IC, LC),
     format(atom(DriverIR),
 'define i32 @main() {
 entry:
@@ -4220,9 +4222,12 @@ run_test(Label, PredAtom, InputVal, Expected) :-
           target_datalayout('')
         ],
         LLPath),
-    read_file_to_string(LLPath, Src, []),
-    extract_instr_count(Src, PredAtom, IC),
-    extract_label_count(Src, PredAtom, LC),
+    % M108: pull the module-level instruction + label counts from
+    % the side-channel asserted by write_wam_llvm_project. Avoids a
+    % per-test ~7MB read_file_to_string + 2 regex scans that
+    % accumulated SWI-stack pressure (the 4 GB cap hit was driven
+    % almost entirely by these reads).
+    wam_llvm_target:wam_llvm_last_compile_counts(IC, LC),
     format(atom(DriverIR),
 'define i32 @main() {
 entry:
@@ -4308,9 +4313,12 @@ run_test_r0(Label, Pred, InputVal, Expected) :-
           target_datalayout('')
         ],
         LLPath),
-    read_file_to_string(LLPath, Src, []),
-    extract_instr_count(Src, PredAtom, IC),
-    extract_label_count(Src, PredAtom, LC),
+    % M108: pull the module-level instruction + label counts from
+    % the side-channel asserted by write_wam_llvm_project. Avoids a
+    % per-test ~7MB read_file_to_string + 2 regex scans that
+    % accumulated SWI-stack pressure (the 4 GB cap hit was driven
+    % almost entirely by these reads).
+    wam_llvm_target:wam_llvm_last_compile_counts(IC, LC),
     format(atom(DriverIR),
 'define i32 @main() {
 entry:


### PR DESCRIPTION
## Summary

Eliminates the per-test `read_file_to_string` that was driving the suite into SWI-Prolog 9.0.4's hard 4 GB global-stack cap. The full execution suite now completes cleanly in a single swipl process.

## The problem

After every WAM-fallback test, `run_test_r0` (and `run_test`, `run_fmt_test`, `run_pow_test`) called:

```prolog
read_file_to_string(LLPath, Src, []),
extract_instr_count(Src, PredAtom, IC),
extract_label_count(Src, PredAtom, LC),
```

— pulling the just-emitted IR file (typically 2–8 MB depending on the module) back into a Prolog string just to regex-grep two numbers from it. Times 600+ tests, that's the dominant source of global-stack pressure. Even with `garbage_collect`, `garbage_collect_atoms`, and `trim_stacks` after every test, SWI's atom-table interning of the IR text kept the suite tipping over around test 658 in the M10 `\+` section (M105 hit it before the atom-table reset; M107 hit it again after a few more tests were added).

## The fix

Both numbers are already known in plain Prolog at module-emit time — `emit_merged_wam_section` computes them via `length/2` on the resolved literal list and the predicate-label pair list, then formats them into the `[N x %Instruction]` / `[N x i32]` array dimensions. Bubble them up via a dynamic predicate:

```prolog
:- dynamic wam_llvm_last_compile_counts/2.   % (InstrCount, LabelCount)
```

`write_wam_llvm_project` now `retractall`s the previous entry and `assertz`s the new `(InstrCount, LabelCount)` before returning. Exported so the test harness can read it directly:

```prolog
wam_llvm_target:wam_llvm_last_compile_counts(IC, LC),
```

All four runners (`run_test`, `run_test_r0`, `run_fmt_test`, `run_pow_test`) now fetch from the side channel instead of reading the IR back. The IR file content is unchanged; only the in-Prolog read-back step is removed. `llc` and `clang` still consume the on-disk path as before.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `:- dynamic wam_llvm_last_compile_counts/2`, export, retract+assert in `emit_merged_wam_section`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — `read_file_to_string` + `extract_*_count` replaced by `wam_llvm_target:wam_llvm_last_compile_counts(IC, LC)` in all four runners.

## Test plan

- [x] Full execution suite: **663/663 PASS**, no failures, no OOM ✓
- [x] All sections from `head unification` through `multi-clause (first-arg indexing)` run, including M103–M107 which previously appeared after the OOM cliff
- [x] Side-channel verified by smoke test: `IC=6, LC=1` returned for a trivial predicate
- [x] Behaviour-preserving — no IR or test logic changes, only the count-fetch path

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_