### PR TITLE
Support WAM-C findall collect aggregates

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,15 +4,15 @@ Status date: 2026-06-05
 
 Latest branch verification:
 
-- `investigate/wam-c-forall-control-smoke` based on `main` at `9e997ed5`
-  (`Merge pull request #2814 from
-  s243a/investigate/wam-c-explicit-cut-scope`)
+- `investigate/wam-c-findall-aggregate-surface` based on `main` at `f971b555`
+  (`Merge pull request #2817 from
+  s243a/investigate/wam-c-forall-control-smoke`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-forall-control-smoke`
+- `investigate/wam-c-findall-aggregate-surface`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -80,6 +80,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Precise if-then-else cut scope smoke | Done | C target tests now compile `ite_use_y_level(true)` WAM with `get_level`/`cut` and run a nondeterministic-condition scope regression that must not backtrack into the else branch after commit |
 | Explicit cut call-scope fix | Done | `!/0` now prunes to the current call barrier instead of clearing all choice points; generated executable smoke preserves an outer disjunction alternative across an inner predicate cut |
 | `forall/2` control smoke | Done | Generated executable smoke covers the shared nested soft-cut rewrite for `forall/2` all-pass, action-fail, subset, and empty-generator cases |
+| `findall/3` collect aggregate surface | Done | C now parses and executes shared `begin_aggregate collect` / `end_aggregate` WAM for simple `findall/3`, preserving generator choice points under aggregate frames and building non-empty/empty result lists |
 
 ## Current C Target Baseline
 
@@ -132,6 +133,9 @@ The C target is now a credible small WAM backend:
   `=/2`, negation, legacy `cut_ite` if-then-else, and precise
   `get_level`/`cut` if-then-else, explicit `!/0` call-scope behavior, and
   `forall/2`'s generated soft-cut rewrite.
+- Supports the first aggregate surface: generated `findall/3` lowering through
+  `begin_aggregate collect` / `end_aggregate`, including empty and non-empty
+  result lists.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -154,7 +158,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Second-arg indexing | Partial | Partial/Done | Partial/Done | C has constant A2 dispatch; broaden tests if this becomes hot. |
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
 | Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
-| Aggregates (`findall`/`bagof`/`setof`) | Missing | Present in hybrid/lowered paths | Present in interpreter/lowered paths | Add only after C has enough runtime term-copy and list construction coverage. |
+| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple `findall/3` collect support over generated aggregate opcodes; remaining gaps are `bagof/3`, `setof/3`, grouping/witness handling, sort/dedup semantics, and broader aggregate forms. |
 | Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, precise `get_level`/`cut` if-then-else, explicit `!/0` scoped to the current predicate call barrier, and generated `forall/2` soft-cut rewrites; residual work should be driven by concrete meta-control demand. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
@@ -168,6 +172,31 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-findall-aggregate-surface`
+
+Goal: give the C target its first shared aggregate opcode surface by executing
+simple generated `findall/3` through `begin_aggregate collect` /
+`end_aggregate`.
+
+Evidence:
+
+- WAM text and C literal parsing now cover `begin_aggregate collect` and
+  `end_aggregate`.
+- The C runtime keeps generator choice points alive while an aggregate frame is
+  open, copies each template result into runtime-owned storage, and finalizes
+  to a normal WAM list.
+- Executable smoke coverage runs generated non-empty, empty, and pre-bound
+  result-list `findall/3` calls and checks aggregate/call/choice stacks are
+  balanced afterward.
+
+Reason:
+
+- `forall/2` proved shared control lowering, but aggregates needed new runtime
+  term-copy and list-construction behavior.
+- This branch deliberately limits the surface to simple collection. `bagof/3`,
+  `setof/3`, witness grouping, sorting/deduplication, and broader aggregate
+  forms remain separate parity work.
 
 ### Completed: `investigate/wam-c-forall-control-smoke`
 

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -22,6 +22,7 @@
 #define WAM_INITIAL_ATOM_HASH_SIZE 512
 #define WAM_FOREIGN_HASH_SIZE 256
 #define WAM_CALL_STACK_SIZE 1024
+#define WAM_AGGREGATE_STACK_SIZE 32
 
 typedef struct WamState WamState;
 typedef bool (*WamForeignHandler)(WamState *state, const char *pred, int arity);
@@ -61,6 +62,28 @@ typedef struct {
     WamValue a_regs[32]; // Reduced from MAX_REGS to save memory (typical max arity)
 } ChoicePoint;
 
+typedef struct {
+    WamValue root;
+    WamValue *cells;
+    int cell_count;
+    int cell_cap;
+} WamStoredTerm;
+
+typedef struct {
+    const char *kind;
+    int begin_pc;
+    int end_pc;
+    int base_b;
+    int sentinel_b;
+    int template_reg;
+    int template_is_y;
+    int result_reg;
+    int result_is_y;
+    WamStoredTerm *items;
+    int item_count;
+    int item_cap;
+} WamAggregateFrame;
+
 /* Environment Frame */
 typedef struct {
     int cp;
@@ -88,6 +111,7 @@ typedef enum {
     INSTR_GET_LEVEL, INSTR_CUT, INSTR_CUT_ITE, INSTR_JUMP,
     INSTR_SWITCH_ON_CONSTANT, INSTR_SWITCH_ON_STRUCTURE, INSTR_SWITCH_ON_TERM,
     INSTR_BUILTIN_CALL, INSTR_CALL_FOREIGN,
+    INSTR_BEGIN_AGGREGATE, INSTR_END_AGGREGATE,
     INSTR_NOOP
 } WamInstrTag;
 
@@ -239,6 +263,14 @@ typedef struct {
     bool no_match_fallthrough;
 } WamSwitchInstr;
 
+typedef struct {
+    char *kind;
+    int template_reg;
+    int template_is_y;
+    int result_reg;
+    int result_is_y;
+} WamAggregateInstr;
+
 typedef union {
     WamConstantInstr constant;
     WamRegPairInstr reg_pair;
@@ -248,6 +280,7 @@ typedef union {
     WamChoiceInstr choice;
     WamJumpInstr jump;
     WamSwitchInstr switch_index;
+    WamAggregateInstr aggregate;
 } InstructionPayload;
 
 /* Instruction */
@@ -305,7 +338,12 @@ struct WamState {
 
     /* First-solution call pruning */
     int call_bases[WAM_CALL_STACK_SIZE];
+    bool call_base_preserve_choice[WAM_CALL_STACK_SIZE];
     int call_base_top;
+
+    /* Aggregate/findall frames */
+    WamAggregateFrame aggregate_frames[WAM_AGGREGATE_STACK_SIZE];
+    int aggregate_top;
 
     /* Native category_ancestor kernel data */
     CategoryEdge *category_edges;

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -1615,6 +1615,15 @@ wam_instruction_to_c_literal(builtin_call(Op, N), Code) :-
     format(atom(Code), '{ .tag = INSTR_BUILTIN_CALL, .as.pred = { .pred = "~w", .arity = ~w } }', [Op, N]).
 wam_instruction_to_c_literal(call_foreign(P, N), Code) :-
     format(atom(Code), '{ .tag = INSTR_CALL_FOREIGN, .as.pred = { .pred = "~w", .arity = ~w } }', [P, N]).
+wam_instruction_to_c_literal(begin_aggregate(Kind, TemplateReg, ResultReg), Code) :-
+    c_reg_index(TemplateReg, TemplateIsY, TemplateIdx),
+    c_reg_index(ResultReg, ResultIsY, ResultIdx),
+    format(atom(Code), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w } }',
+           [Kind, TemplateIdx, TemplateIsY, ResultIdx, ResultIsY]).
+wam_instruction_to_c_literal(end_aggregate(TemplateReg), Code) :-
+    c_reg_index(TemplateReg, TemplateIsY, TemplateIdx),
+    format(atom(Code), '{ .tag = INSTR_END_AGGREGATE, .as.aggregate = { .kind = "collect", .template_reg = ~w, .template_is_y = ~w, .result_reg = 0, .result_is_y = 0 } }',
+           [TemplateIdx, TemplateIsY]).
 wam_instruction_to_c_literal(get_level(Reg), Code) :-
     c_reg_index(Reg, IsY, Idx),
     format(atom(Code), '{ .tag = INSTR_GET_LEVEL, .as.reg = { .reg = ~w, .is_y_reg = ~w } }', [Idx, IsY]).
@@ -1768,6 +1777,18 @@ wam_line_to_c_instr(["builtin_call", Op, N], Instr) :-
 wam_line_to_c_instr(["call_foreign", P, N], Instr) :-
     clean_comma(P, CP), clean_comma(N, CN),
     format(atom(Instr), '{ .tag = INSTR_CALL_FOREIGN, .as.pred = { .pred = "~w", .arity = ~w } }', [CP, CN]).
+wam_line_to_c_instr(["begin_aggregate", Kind, TemplateReg, ResultReg], Instr) :-
+    clean_comma(Kind, CKind0), clean_comma(TemplateReg, CTemplateReg),
+    clean_comma(ResultReg, CResultReg), c_escape_atom(CKind0, CKind),
+    c_reg_index(CTemplateReg, TemplateIsY, TemplateIdx),
+    c_reg_index(CResultReg, ResultIsY, ResultIdx),
+    format(atom(Instr), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w } }',
+           [CKind, TemplateIdx, TemplateIsY, ResultIdx, ResultIsY]).
+wam_line_to_c_instr(["end_aggregate", TemplateReg], Instr) :-
+    clean_comma(TemplateReg, CTemplateReg),
+    c_reg_index(CTemplateReg, TemplateIsY, TemplateIdx),
+    format(atom(Instr), '{ .tag = INSTR_END_AGGREGATE, .as.aggregate = { .kind = "collect", .template_reg = ~w, .template_is_y = ~w, .result_reg = 0, .result_is_y = 0 } }',
+           [TemplateIdx, TemplateIsY]).
 wam_line_to_c_instr(["get_level", Reg], Instr) :-
     clean_comma(Reg, CReg),
     c_reg_index(CReg, IsY, Idx),
@@ -2062,15 +2083,21 @@ compile_step_wam_to_c(_Options, CCode) :-
             case INSTR_PROCEED: {
                 int continuation = state->CP;
                 if (continuation != WAM_HALT && state->call_base_top > 0) {
-                    int target_b = state->call_bases[--state->call_base_top];
-                    wam_prune_choice_points(state, target_b);
+                    int barrier_index = --state->call_base_top;
+                    int target_b = state->call_bases[barrier_index];
+                    if (!state->call_base_preserve_choice[barrier_index]) {
+                        wam_prune_choice_points(state, target_b);
+                    }
                 }
                 state->P = continuation;
                 return true;
             }
             case INSTR_CALL: {
                 if (state->call_base_top >= WAM_CALL_STACK_SIZE) return false;
-                state->call_bases[state->call_base_top++] = state->B;
+                state->call_bases[state->call_base_top] = state->B;
+                state->call_base_preserve_choice[state->call_base_top] =
+                    state->aggregate_top > 0;
+                state->call_base_top++;
                 state->CP = state->P + 1;
                 int target = resolve_predicate_hash(state, instr->as.pred.pred);
                 if (target >= 0) { state->P = target; return true; }
@@ -2095,6 +2122,12 @@ compile_step_wam_to_c(_Options, CCode) :-
                     return true;
                 }
                 return false;
+            }
+            case INSTR_BEGIN_AGGREGATE: {
+                return wam_begin_aggregate(state, instr);
+            }
+            case INSTR_END_AGGREGATE: {
+                return wam_end_aggregate(state, instr);
             }
             case INSTR_TRY_ME_ELSE: {
                 int target = instr->as.choice.target_pc;
@@ -2464,6 +2497,305 @@ compile_wam_helpers_to_c(_Options, CCode) :-
 
 static void wam_bidirectional_distance_cache_clear(WamState *state);
 
+static bool wam_ensure_heap_slots(WamState *state, int additional) {
+    if (additional <= 0) return true;
+    if (state->H > INT_MAX - additional) return false;
+    int required = state->H + additional;
+    if (required <= state->H_cap) return true;
+    if (state->H_cap == 0) state->H_cap = WAM_INITIAL_CAP;
+    while (required > state->H_cap) {
+        if (state->H_cap > INT_MAX / 2) {
+            state->H_cap = required;
+            break;
+        }
+        state->H_cap *= 2;
+    }
+    WamValue *heap = realloc(state->H_array, sizeof(WamValue) * (size_t)state->H_cap);
+    if (!heap) return false;
+    state->H_array = heap;
+    return true;
+}
+
+static void wam_stored_term_free(WamStoredTerm *term) {
+    free(term->cells);
+    memset(term, 0, sizeof(WamStoredTerm));
+}
+
+static bool wam_stored_term_reserve(WamStoredTerm *term, int additional) {
+    if (additional <= 0) return true;
+    if (term->cell_count > INT_MAX - additional) return false;
+    int required = term->cell_count + additional;
+    if (required <= term->cell_cap) return true;
+    int new_cap = term->cell_cap ? term->cell_cap : WAM_INITIAL_CAP;
+    while (required > new_cap) {
+        if (new_cap > INT_MAX / 2) {
+            new_cap = required;
+            break;
+        }
+        new_cap *= 2;
+    }
+    WamValue *cells = realloc(term->cells, sizeof(WamValue) * (size_t)new_cap);
+    if (!cells) return false;
+    term->cells = cells;
+    term->cell_cap = new_cap;
+    return true;
+}
+
+static bool wam_parse_functor_arity(const char *functor, int *arity_out) {
+    const char *slash = strrchr(functor, 47);
+    if (!slash) return false;
+    char *end = NULL;
+    long arity = strtol(slash + 1, &end, 10);
+    if (!end || *end != 0 || arity < 0 || arity > 255) return false;
+    *arity_out = (int)arity;
+    return true;
+}
+
+static bool wam_copy_term_to_stored(WamState *state,
+                                    WamStoredTerm *term,
+                                    WamValue value,
+                                    WamValue *out) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    if (cell->tag == VAL_ATOM || cell->tag == VAL_INT || cell->tag == VAL_FLOAT) {
+        *out = *cell;
+        return true;
+    }
+    if (cell->tag == VAL_UNBOUND || cell->tag == VAL_REF) {
+        *out = val_unbound("_");
+        return true;
+    }
+    if (cell->tag == VAL_LIST) {
+        if (!wam_stored_term_reserve(term, 2)) return false;
+        int base = term->cell_count;
+        term->cell_count += 2;
+        out->tag = VAL_LIST;
+        out->data.ref_addr = base;
+        WamValue head;
+        WamValue tail;
+        if (!wam_copy_term_to_stored(state, term,
+                                     state->H_array[cell->data.ref_addr],
+                                     &head)) return false;
+        if (!wam_copy_term_to_stored(state, term,
+                                     state->H_array[cell->data.ref_addr + 1],
+                                     &tail)) return false;
+        term->cells[base] = head;
+        term->cells[base + 1] = tail;
+        return true;
+    }
+    if (cell->tag == VAL_STR) {
+        WamValue *functor = &state->H_array[cell->data.ref_addr];
+        if (functor->tag != VAL_ATOM) return false;
+        int arity = 0;
+        if (!wam_parse_functor_arity(functor->data.atom, &arity)) return false;
+        if (!wam_stored_term_reserve(term, 1 + arity)) return false;
+        int base = term->cell_count;
+        term->cell_count += 1 + arity;
+        out->tag = VAL_STR;
+        out->data.ref_addr = base;
+        term->cells[base] = *functor;
+        for (int i = 0; i < arity; i++) {
+            WamValue arg;
+            if (!wam_copy_term_to_stored(state, term,
+                                         state->H_array[cell->data.ref_addr + 1 + i],
+                                         &arg)) return false;
+            term->cells[base + 1 + i] = arg;
+        }
+        return true;
+    }
+    return false;
+}
+
+static bool wam_materialize_stored_term(WamState *state,
+                                        WamStoredTerm *term,
+                                        WamValue value,
+                                        WamValue *out) {
+    if (value.tag == VAL_ATOM) {
+        *out = val_atom(wam_intern_atom(state, value.data.atom));
+        return true;
+    }
+    if (value.tag == VAL_INT || value.tag == VAL_FLOAT || value.tag == VAL_UNBOUND) {
+        *out = value;
+        return true;
+    }
+    if (value.tag == VAL_LIST) {
+        if (value.data.ref_addr < 0 || value.data.ref_addr + 1 >= term->cell_count) return false;
+        if (!wam_ensure_heap_slots(state, 2)) return false;
+        int base = state->H;
+        state->H += 2;
+        out->tag = VAL_LIST;
+        out->data.ref_addr = base;
+        WamValue head;
+        WamValue tail;
+        if (!wam_materialize_stored_term(state, term,
+                                         term->cells[value.data.ref_addr],
+                                         &head)) return false;
+        if (!wam_materialize_stored_term(state, term,
+                                         term->cells[value.data.ref_addr + 1],
+                                         &tail)) return false;
+        state->H_array[base] = head;
+        state->H_array[base + 1] = tail;
+        return true;
+    }
+    if (value.tag == VAL_STR) {
+        if (value.data.ref_addr < 0 || value.data.ref_addr >= term->cell_count) return false;
+        WamValue *functor = &term->cells[value.data.ref_addr];
+        if (functor->tag != VAL_ATOM) return false;
+        int arity = 0;
+        if (!wam_parse_functor_arity(functor->data.atom, &arity)) return false;
+        if (value.data.ref_addr + arity >= term->cell_count) return false;
+        if (!wam_ensure_heap_slots(state, 1 + arity)) return false;
+        int base = state->H;
+        state->H += 1 + arity;
+        out->tag = VAL_STR;
+        out->data.ref_addr = base;
+        state->H_array[base] = val_atom(wam_intern_atom(state, functor->data.atom));
+        for (int i = 0; i < arity; i++) {
+            WamValue arg;
+            if (!wam_materialize_stored_term(state, term,
+                                             term->cells[value.data.ref_addr + 1 + i],
+                                             &arg)) return false;
+            state->H_array[base + 1 + i] = arg;
+        }
+        return true;
+    }
+    return false;
+}
+
+static void wam_aggregate_frame_free(WamAggregateFrame *frame) {
+    for (int i = 0; i < frame->item_count; i++) {
+        wam_stored_term_free(&frame->items[i]);
+    }
+    free(frame->items);
+    memset(frame, 0, sizeof(WamAggregateFrame));
+}
+
+static void wam_aggregate_clear_all(WamState *state) {
+    while (state->aggregate_top > 0) {
+        state->aggregate_top--;
+        wam_aggregate_frame_free(&state->aggregate_frames[state->aggregate_top]);
+    }
+}
+
+static bool wam_aggregate_append_item(WamState *state,
+                                      WamAggregateFrame *frame,
+                                      WamValue value) {
+    if (frame->item_count >= frame->item_cap) {
+        int new_cap = frame->item_cap ? frame->item_cap * 2 : WAM_INITIAL_CAP;
+        WamStoredTerm *items =
+            realloc(frame->items, sizeof(WamStoredTerm) * (size_t)new_cap);
+        if (!items) return false;
+        memset(items + frame->item_cap, 0,
+               sizeof(WamStoredTerm) * (size_t)(new_cap - frame->item_cap));
+        frame->items = items;
+        frame->item_cap = new_cap;
+    }
+    WamStoredTerm *term = &frame->items[frame->item_count];
+    memset(term, 0, sizeof(WamStoredTerm));
+    if (!wam_copy_term_to_stored(state, term, value, &term->root)) {
+        wam_stored_term_free(term);
+        return false;
+    }
+    frame->item_count++;
+    return true;
+}
+
+static bool wam_build_aggregate_list(WamState *state,
+                                     WamAggregateFrame *frame,
+                                     WamValue *out) {
+    WamValue tail = val_atom("[]");
+    for (int i = frame->item_count - 1; i >= 0; i--) {
+        WamValue head;
+        if (!wam_materialize_stored_term(state, &frame->items[i],
+                                         frame->items[i].root, &head)) return false;
+        if (!wam_ensure_heap_slots(state, 2)) return false;
+        int base = state->H;
+        state->H_array[state->H++] = head;
+        state->H_array[state->H++] = tail;
+        tail.tag = VAL_LIST;
+        tail.data.ref_addr = base;
+    }
+    *out = tail;
+    return true;
+}
+
+static int wam_find_matching_end_aggregate(WamState *state, int begin_pc) {
+    int depth = 0;
+    for (int pc = begin_pc + 1; pc < state->code_size; pc++) {
+        if (state->code[pc].tag == INSTR_BEGIN_AGGREGATE) {
+            depth++;
+        } else if (state->code[pc].tag == INSTR_END_AGGREGATE) {
+            if (depth == 0) return pc;
+            depth--;
+        }
+    }
+    return -1;
+}
+
+static bool wam_finalize_aggregate_frame(WamState *state,
+                                         WamAggregateFrame *frame) {
+    if (strcmp(frame->kind, "collect") != 0) return false;
+    int next_pc = frame->end_pc + 1;
+    int frame_index = state->aggregate_top - 1;
+    if (frame->sentinel_b > 0 && frame->sentinel_b <= state->B) {
+        ChoicePoint *sentinel = &state->B_array[frame->sentinel_b - 1];
+        restore_choice_point(state, sentinel);
+    }
+    wam_prune_choice_points(state, frame->base_b);
+
+    WamValue result_list;
+    if (!wam_build_aggregate_list(state, frame, &result_list)) return false;
+    WamValue *result_cell =
+        resolve_reg(state, frame->result_reg, frame->result_is_y);
+    bool ok = wam_unify(state, result_cell, &result_list);
+    wam_aggregate_frame_free(frame);
+    state->aggregate_top = frame_index;
+    if (!ok) return false;
+    state->P = next_pc;
+    return true;
+}
+
+static bool wam_begin_aggregate(WamState *state, Instruction *instr) {
+    if (strcmp(instr->as.aggregate.kind, "collect") != 0) return false;
+    if (state->aggregate_top > 0) {
+        WamAggregateFrame *top = &state->aggregate_frames[state->aggregate_top - 1];
+        if (top->begin_pc == state->P && top->sentinel_b == state->B) {
+            return wam_finalize_aggregate_frame(state, top);
+        }
+    }
+    if (state->aggregate_top >= WAM_AGGREGATE_STACK_SIZE) return false;
+    int end_pc = wam_find_matching_end_aggregate(state, state->P);
+    if (end_pc < 0) return false;
+
+    WamAggregateFrame *frame = &state->aggregate_frames[state->aggregate_top++];
+    memset(frame, 0, sizeof(WamAggregateFrame));
+    frame->kind = instr->as.aggregate.kind;
+    frame->begin_pc = state->P;
+    frame->end_pc = end_pc;
+    frame->base_b = state->B;
+    frame->sentinel_b = state->B + 1;
+    frame->template_reg = instr->as.aggregate.template_reg;
+    frame->template_is_y = instr->as.aggregate.template_is_y;
+    frame->result_reg = instr->as.aggregate.result_reg;
+    frame->result_is_y = instr->as.aggregate.result_is_y;
+    push_choice_point(state, state->P, 32);
+    state->P++;
+    return true;
+}
+
+static bool wam_end_aggregate(WamState *state, Instruction *instr) {
+    if (state->aggregate_top <= 0) return false;
+    WamAggregateFrame *frame = &state->aggregate_frames[state->aggregate_top - 1];
+    if (strcmp(frame->kind, "collect") != 0) return false;
+    WamValue *template_cell =
+        resolve_reg(state, instr->as.aggregate.template_reg,
+                    instr->as.aggregate.template_is_y);
+    if (!wam_aggregate_append_item(state, frame, *template_cell)) return false;
+    if (state->B > frame->sentinel_b) {
+        return false;
+    }
+    return wam_finalize_aggregate_frame(state, frame);
+}
+
 void wam_state_init(WamState *state) {
     memset(state, 0, sizeof(WamState));
     state->H_cap = WAM_INITIAL_CAP;
@@ -2478,6 +2810,7 @@ void wam_state_init(WamState *state) {
 }
 
 void wam_free_state(WamState *state) {
+    wam_aggregate_clear_all(state);
     for (int i = 0; i < state->atom_table_size; i++) {
         AtomEntry *e = state->atom_table[i];
         while (e) {
@@ -2519,12 +2852,20 @@ int wam_run_predicate(WamState *state, const char *pred,
     int base_b = state->B;
     int base_call_base_top = state->call_base_top;
     if (state->call_base_top >= WAM_CALL_STACK_SIZE) return WAM_ERR_OOB;
-    state->call_bases[state->call_base_top++] = base_b;
-    for (int i = 0; i < arity; i++) state->A[i] = args[i];
+    state->call_bases[state->call_base_top] = base_b;
+    state->call_base_preserve_choice[state->call_base_top] = false;
+    state->call_base_top++;
+    for (int i = 0; i < arity; i++) {
+        state->A[i] = val_is_unbound(args[i]) ? wam_make_ref(state) : args[i];
+    }
     state->CP = WAM_HALT;
     state->P = entry;
     int rc = wam_run(state);
     wam_prune_choice_points(state, base_b);
+    for (int i = 0; i < arity; i++) {
+        WamValue *cell = wam_deref_ptr(state, &state->A[i]);
+        state->A[i] = *cell;
+    }
     state->call_base_top = base_call_base_top;
     return rc;
 }

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -127,6 +127,15 @@ test_control_flow_instructions :-
     ;   fail_test(Test, 'missing control flow instruction arms')
     ).
 
+test_aggregate_instructions :-
+    Test = 'WAM-C: aggregate instructions present',
+    (   implemented_wam_c_cases(Cases),
+        member(begin_aggregate, Cases),
+        member(end_aggregate, Cases)
+    ->  pass(Test)
+    ;   fail_test(Test, 'missing aggregate instruction arms')
+    ).
+
 test_control_cut_jump_instructions :-
     Test = 'WAM-C: cut and jump control instructions present',
     (   implemented_wam_c_cases(Cases),
@@ -148,7 +157,8 @@ test_explicit_cut_uses_current_call_barrier :-
         atom_string(Code, S),
         sub_string(S, _, _, _, 'state->call_bases[state->call_base_top - 1]'),
         sub_string(S, _, _, _, 'wam_prune_choice_points(state, target_b)'),
-        sub_string(S, _, _, _, 'state->call_bases[state->call_base_top++] = base_b'),
+        sub_string(S, _, _, _, 'state->call_bases[state->call_base_top] = base_b'),
+        sub_string(S, _, _, _, 'state->call_base_preserve_choice[state->call_base_top] = false'),
         \+ sub_string(S, _, _, _, 'state->B = 0')
     ->  pass(Test)
     ;   fail_test(Test, 'explicit !/0 still clears all choice points instead of pruning to the current barrier')
@@ -1705,6 +1715,16 @@ test_real_prolog_forall_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_real_prolog_findall_executable_smoke :-
+    Test = 'WAM-C: real Prolog findall/3 executable smoke',
+    (   gcc_available
+    ->  (   run_real_prolog_findall_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'real Prolog findall/3 executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_real_prolog_classic_recursive_executable_smoke :-
     Test = 'WAM-C: real Prolog classic recursive executable smoke',
     (   gcc_available
@@ -2747,6 +2767,56 @@ cleanup_wam_c_forall_smoke :-
     retractall(user:wam_c_forall_fail(_)),
     retractall(user:wam_c_forall_subset(_)),
     retractall(user:wam_c_forall_empty_ok(_)).
+
+run_real_prolog_findall_executable_smoke :-
+    assertz((user:wam_c_findall_item(a) :- true)),
+    assertz((user:wam_c_findall_item(b) :- true)),
+    assertz((user:wam_c_findall_none(_) :- fail)),
+    assertz((user:wam_c_findall_all(L) :-
+        findall(X, wam_c_findall_item(X), L))),
+    assertz((user:wam_c_findall_empty(L) :-
+        findall(X, wam_c_findall_none(X), L))),
+    (   compile_predicate_to_wam(user:wam_c_findall_item/1, [], WamItem),
+        compile_predicate_to_wam(user:wam_c_findall_none/1, [], WamNone),
+        compile_predicate_to_wam(user:wam_c_findall_all/1, [], WamAll),
+        compile_predicate_to_wam(user:wam_c_findall_empty/1, [], WamEmpty),
+        sub_string(WamAll, _, _, _, 'begin_aggregate collect'),
+        sub_string(WamAll, _, _, _, 'end_aggregate'),
+        sub_string(WamEmpty, _, _, _, 'begin_aggregate collect'),
+        sub_string(WamEmpty, _, _, _, 'end_aggregate'),
+        \+ sub_string(WamAll, _, _, _, 'builtin_call findall/3'),
+        compile_wam_predicate_to_c(user:wam_c_findall_item/1, WamItem, [], ItemCode),
+        compile_wam_predicate_to_c(user:wam_c_findall_none/1, WamNone, [], NoneCode),
+        compile_wam_predicate_to_c(user:wam_c_findall_all/1, WamAll, [], AllCode),
+        compile_wam_predicate_to_c(user:wam_c_findall_empty/1, WamEmpty, [], EmptyCode),
+        atomic_list_concat([ItemCode, NoneCode, AllCode, EmptyCode],
+                           '\n\n',
+                           PredCode),
+        compile_wam_runtime_to_c([], RuntimeCode),
+        get_time(Now),
+        Stamp is round(Now * 1000000),
+        wam_c_temp_path('unifyweaver_wam_c_findall_smoke', Stamp, TmpBase),
+        format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+        format(atom(PredPath), '~w_pred.c', [TmpBase]),
+        format(atom(MainPath), '~w_main.c', [TmpBase]),
+        format(atom(ExePath), '~w_bin', [TmpBase]),
+        write_text_file(RuntimePath, RuntimeCode),
+        format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+        write_text_file(PredPath, PredTranslationUnit),
+        wam_c_findall_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_findall_smoke
+    ;   cleanup_wam_c_findall_smoke,
+        fail
+    ).
+
+cleanup_wam_c_findall_smoke :-
+    retractall(user:wam_c_findall_item(_)),
+    retractall(user:wam_c_findall_none(_)),
+    retractall(user:wam_c_findall_all(_)),
+    retractall(user:wam_c_findall_empty(_)).
 
 run_real_prolog_classic_recursive_executable_smoke :-
     assertz((user:wam_c_classic_fib(0, 0) :- true)),
@@ -5750,6 +5820,93 @@ int main(void) {
 }
 ').
 
+wam_c_findall_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_findall_item_1(WamState* state);
+void setup_wam_c_findall_none_1(WamState* state);
+void setup_wam_c_findall_all_1(WamState* state);
+void setup_wam_c_findall_empty_1(WamState* state);
+
+static bool expect_atom(WamState *state, WamValue value, const char *atom) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    return cell->tag == VAL_ATOM && strcmp(cell->data.atom, atom) == 0;
+}
+
+static bool expect_atom_list2(WamState *state, WamValue value,
+                              const char *first, const char *second) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    if (cell->tag != VAL_LIST) return false;
+    WamValue *head1 = wam_deref_ptr(state, &state->H_array[cell->data.ref_addr]);
+    WamValue *tail1 = wam_deref_ptr(state, &state->H_array[cell->data.ref_addr + 1]);
+    if (head1->tag != VAL_ATOM || strcmp(head1->data.atom, first) != 0) return false;
+    if (tail1->tag != VAL_LIST) return false;
+    WamValue *head2 = wam_deref_ptr(state, &state->H_array[tail1->data.ref_addr]);
+    WamValue *tail2 = wam_deref_ptr(state, &state->H_array[tail1->data.ref_addr + 1]);
+    return head2->tag == VAL_ATOM &&
+           strcmp(head2->data.atom, second) == 0 &&
+           tail2->tag == VAL_ATOM &&
+           strcmp(tail2->data.atom, "[]") == 0;
+}
+
+static WamValue make_atom_list2(WamState *state,
+                                const char *first,
+                                const char *second) {
+    WamValue tail = val_atom("[]");
+    int base_second = state->H;
+    state->H_array[state->H++] = val_atom(second);
+    state->H_array[state->H++] = tail;
+    tail.tag = VAL_LIST;
+    tail.data.ref_addr = base_second;
+    int base_first = state->H;
+    state->H_array[state->H++] = val_atom(first);
+    state->H_array[state->H++] = tail;
+    WamValue list;
+    list.tag = VAL_LIST;
+    list.data.ref_addr = base_first;
+    return list;
+}
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_findall_item_1(&state);
+    setup_wam_c_findall_none_1(&state);
+    setup_wam_c_findall_all_1(&state);
+    setup_wam_c_findall_empty_1(&state);
+
+    WamValue all_args[1] = { val_unbound("All") };
+    int all_rc = wam_run_predicate(&state, "wam_c_findall_all/1", all_args, 1);
+    if (all_rc != 0 || state.P != WAM_HALT ||
+        !expect_atom_list2(&state, state.A[0], "a", "b") ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue empty_args[1] = { val_unbound("Empty") };
+    int empty_rc = wam_run_predicate(&state, "wam_c_findall_empty/1", empty_args, 1);
+    if (empty_rc != 0 || state.P != WAM_HALT ||
+        !expect_atom(&state, state.A[0], "[]") ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue expected = make_atom_list2(&state, "a", "b");
+    WamValue bound_args[1] = { expected };
+    int bound_rc = wam_run_predicate(&state, "wam_c_findall_all/1", bound_args, 1);
+    if (bound_rc != 0 || state.P != WAM_HALT ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_classic_fib_smoke_main(
 '#include "wam_runtime.h"
 
@@ -5823,6 +5980,8 @@ implemented_case(call, 'case INSTR_CALL').
 implemented_case(execute, 'case INSTR_EXECUTE').
 implemented_case(builtin_call, 'case INSTR_BUILTIN_CALL').
 implemented_case(call_foreign, 'case INSTR_CALL_FOREIGN').
+implemented_case(begin_aggregate, 'case INSTR_BEGIN_AGGREGATE').
+implemented_case(end_aggregate, 'case INSTR_END_AGGREGATE').
 implemented_case(try_me_else, 'case INSTR_TRY_ME_ELSE').
 implemented_case(retry_me_else, 'case INSTR_RETRY_ME_ELSE').
 implemented_case(trust_me, 'case INSTR_TRUST_ME').
@@ -5863,6 +6022,7 @@ run_tests_once :-
     test_body_construction_instructions,
     test_unification_instructions,
     test_control_flow_instructions,
+    test_aggregate_instructions,
     test_control_cut_jump_instructions,
     test_explicit_cut_uses_current_call_barrier,
     test_control_instruction_parsing,
@@ -5960,6 +6120,7 @@ run_tests_once :-
     test_real_prolog_precise_ite_executable_smoke,
     test_real_prolog_explicit_cut_executable_smoke,
     test_real_prolog_forall_executable_smoke,
+    test_real_prolog_findall_executable_smoke,
     test_real_prolog_classic_recursive_executable_smoke,
     test_lowered_fact_helper_executable_smoke,
     test_lowered_body_call_helper_executable_smoke,


### PR DESCRIPTION
  - Add WAM-C parsing, codegen, and runtime support for `begin_aggregate collect` / `end_aggregate`
  - Preserve generator choice points while aggregate frames are active
  - Materialize collected templates into WAM lists for simple `findall/3`
  - Add executable smoke coverage for non-empty, empty, and pre-bound `findall/3` result cases
  - Update the C target roadmap to mark the first aggregate surface as complete