### PR TITLE
LLVM WAM: getpgrp/1 (M109) -- libc process group id

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1509,6 +1509,7 @@ declare i32 @geteuid()
 declare i32 @getgid()
 declare i32 @getegid()
 declare i32 @getppid()
+declare i32 @getpgrp()
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3597,6 +3598,7 @@ entry:
     i32 124, label %builtin_numbervars
     i32 125, label %builtin_access
     i32 126, label %builtin_directory_files
+    i32 127, label %builtin_getpgrp
   ]
 
 builtin_is:
@@ -5674,6 +5676,17 @@ dirf.close:
   %dirf.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
   %dirf.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %dirf.raw2, %Value %dirf.acc)
   ret i1 %dirf.ok
+
+builtin_getpgrp:
+  ; M109: getpgrp(?PGid) -- process group id via libc getpgrp().
+  ; pid_t is signed 32 bits on Linux; sext to i64 for the Integer
+  ; payload. Always succeeds (getpgrp cannot fail).
+  %gpg.pid = call i32 @getpgrp()
+  %gpg.pid64 = sext i32 %gpg.pid to i64
+  %gpg.v = call %Value @value_integer(i64 %gpg.pid64)
+  %gpg.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %gpg.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %gpg.raw1, %Value %gpg.v)
+  ret i1 %gpg.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -12746,6 +12759,7 @@ builtin_op_to_id('term_variables/2', 123).    % depth-first var collection.
 builtin_op_to_id('numbervars/3', 124).        % bind free vars to $VAR(N).
 builtin_op_to_id('access/2', 125).            % libc access(path, mode_bits).
 builtin_op_to_id('directory_files/2', 126).   % opendir/readdir loop -> list of atoms.
+builtin_op_to_id('getpgrp/1', 127).           % libc getpgrp() as Integer.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2103,6 +2103,7 @@ is_builtin_pred(geteuid, 1).            % geteuid(-EUid).
 is_builtin_pred(getgid, 1).             % getgid(-Gid).
 is_builtin_pred(getegid, 1).            % getegid(-EGid).
 is_builtin_pred(getppid, 1).            % getppid(-PPid).
+is_builtin_pred(getpgrp, 1).            % getpgrp(-PGid) -- process group id.
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,20 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M109: getpgrp/1 -- libc process group id wrapper.
+
+:- dynamic test_pgrp_positive/2.
+test_pgrp_positive(_, R) :-
+    getpgrp(PG),
+    ( PG > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_pgrp_stable/2.
+test_pgrp_stable(_, R) :-
+    % Two calls in the same process return the same group id.
+    getpgrp(PG1),
+    getpgrp(PG2),
+    ( PG1 =:= PG2 -> R is 1 ; R is 0 ).   % 1
+
 % M107: directory_files/2 -- opendir/readdir loop, list of entry atoms.
 
 :- dynamic test_df_tmp_nonempty/2.
@@ -5216,6 +5230,11 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M109 getpgrp/1 ---~n'),
+       run_test_r0('getpgrp(PG), PG > 0 -> 1',
+                   test_pgrp_positive, 0, 1),
+       run_test_r0('two getpgrp calls match -> 1',
+                   test_pgrp_stable, 0, 1),
        format('--- M107 directory_files/2 ---~n'),
        run_test_r0('directory_files(/tmp, [_|_]) -> 1',
                    test_df_tmp_nonempty, 0, 1),


### PR DESCRIPTION
## Summary

- **M109 `getpgrp/1`** — libc process group id wrapper. Op id 127.

Direct parallel to M79 `builtin_getpid`, M96 `builtin_getppid`, M95 `builtin_getuid`: call the libc routine, `sext` the `i32` pid_t to `i64`, pack as Integer, unify with reg 0. Always succeeds — `getpgrp` cannot fail.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `@getpgrp` libc decl, dispatch entry, `builtin_getpgrp` IR block (prefix `gpg.`), op-id table entry.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred(getpgrp, 1)`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — two M109 tests + section in `test_all`.

## Test plan

- [x] Full execution suite: **665/665 PASS**, no failures, no OOM ✓
- [x] `test_pgrp_positive`: `getpgrp(PG), PG > 0` ✓
- [x] `test_pgrp_stable`: two `getpgrp` calls within the same process match ✓

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_