### PR TITLE
Harden WAM-C findall template smokes

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,15 +4,15 @@ Status date: 2026-06-05
 
 Latest branch verification:
 
-- `investigate/wam-c-findall-aggregate-surface` based on `main` at `f971b555`
-  (`Merge pull request #2817 from
-  s243a/investigate/wam-c-forall-control-smoke`)
+- `investigate/wam-c-findall-nested-template-smoke` based on `main` at
+  `b8ebd240` (`Merge pull request #2821 from
+  s243a/investigate/wam-c-findall-aggregate-surface`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-findall-aggregate-surface`
+- `investigate/wam-c-findall-nested-template-smoke`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -81,6 +81,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Explicit cut call-scope fix | Done | `!/0` now prunes to the current call barrier instead of clearing all choice points; generated executable smoke preserves an outer disjunction alternative across an inner predicate cut |
 | `forall/2` control smoke | Done | Generated executable smoke covers the shared nested soft-cut rewrite for `forall/2` all-pass, action-fail, subset, and empty-generator cases |
 | `findall/3` collect aggregate surface | Done | C now parses and executes shared `begin_aggregate collect` / `end_aggregate` WAM for simple `findall/3`, preserving generator choice points under aggregate frames and building non-empty/empty result lists |
+| `findall/3` nested/template smoke | Done | C now parses compiler temporary `_XTn` registers and the generated executable smoke covers helper-nested `findall/3`, `pair(X, [X])` templates, and `[X, X]` templates |
 
 ## Current C Target Baseline
 
@@ -135,7 +136,7 @@ The C target is now a credible small WAM backend:
   `forall/2`'s generated soft-cut rewrite.
 - Supports the first aggregate surface: generated `findall/3` lowering through
   `begin_aggregate collect` / `end_aggregate`, including empty and non-empty
-  result lists.
+  result lists, helper-nested aggregate calls, and compound/list templates.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -172,6 +173,30 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-findall-nested-template-smoke`
+
+Goal: harden the first C `findall/3` aggregate surface against generated WAM
+shapes that appear once templates contain nested lists or helper predicates run
+their own `findall/3`.
+
+Evidence:
+
+- The C WAM register parser now accepts compiler temporary `_XTn` registers,
+  mapping them to high X-register slots for structure/list construction.
+- The real-Prolog `findall/3` executable smoke now covers helper-nested
+  aggregate frames while an outer aggregate frame is open.
+- The same smoke validates copied compound and list templates:
+  `pair(X, [X])` and `[X, X]`.
+
+Reason:
+
+- Generated compound/list templates use temporary registers that the first
+  aggregate branch did not parse.
+- Direct inline nested `findall/3` still lowers to a call to `findall/3` in the
+  shared compiler; this branch proves the C aggregate runtime behavior through
+  an indirect helper and leaves the broader compiler/runtime surface for a
+  separate branch.
 
 ### Completed: `investigate/wam-c-findall-aggregate-surface`
 

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -1690,6 +1690,10 @@ c_reg_index(RegAtom, IsY, Idx) :-
     ->  IsY = 1,
         catch(number_chars(RegNo, NumChars), _, fail),
         Idx is RegNo - 1
+    ;   append(['_', 'X', 'T'], NumChars, Chars)
+    ->  IsY = 2,
+        catch(number_chars(TempNo, NumChars), _, fail),
+        Idx is 128 + TempNo
     ;   throw(error(wam_c_target_error(unknown_register(RegAtom)), _))
     ).
 

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -2776,20 +2776,42 @@ run_real_prolog_findall_executable_smoke :-
         findall(X, wam_c_findall_item(X), L))),
     assertz((user:wam_c_findall_empty(L) :-
         findall(X, wam_c_findall_none(X), L))),
+    assertz((user:wam_c_findall_nested_inner(L) :-
+        findall(Y, wam_c_findall_item(Y), L))),
+    assertz((user:wam_c_findall_nested_outer(L) :-
+        findall(X, (wam_c_findall_item(X), wam_c_findall_nested_inner(_Ys)), L))),
+    assertz((user:wam_c_findall_struct_template(L) :-
+        findall(pair(X, [X]), wam_c_findall_item(X), L))),
+    assertz((user:wam_c_findall_list_template(L) :-
+        findall([X, X], wam_c_findall_item(X), L))),
     (   compile_predicate_to_wam(user:wam_c_findall_item/1, [], WamItem),
         compile_predicate_to_wam(user:wam_c_findall_none/1, [], WamNone),
         compile_predicate_to_wam(user:wam_c_findall_all/1, [], WamAll),
         compile_predicate_to_wam(user:wam_c_findall_empty/1, [], WamEmpty),
+        compile_predicate_to_wam(user:wam_c_findall_nested_inner/1, [], WamNestedInner),
+        compile_predicate_to_wam(user:wam_c_findall_nested_outer/1, [], WamNestedOuter),
+        compile_predicate_to_wam(user:wam_c_findall_struct_template/1, [], WamStructTemplate),
+        compile_predicate_to_wam(user:wam_c_findall_list_template/1, [], WamListTemplate),
         sub_string(WamAll, _, _, _, 'begin_aggregate collect'),
         sub_string(WamAll, _, _, _, 'end_aggregate'),
         sub_string(WamEmpty, _, _, _, 'begin_aggregate collect'),
         sub_string(WamEmpty, _, _, _, 'end_aggregate'),
+        sub_string(WamNestedInner, _, _, _, 'begin_aggregate collect'),
+        sub_string(WamNestedOuter, _, _, _, 'begin_aggregate collect'),
+        sub_string(WamStructTemplate, _, _, _, 'begin_aggregate collect'),
+        sub_string(WamListTemplate, _, _, _, 'begin_aggregate collect'),
         \+ sub_string(WamAll, _, _, _, 'builtin_call findall/3'),
         compile_wam_predicate_to_c(user:wam_c_findall_item/1, WamItem, [], ItemCode),
         compile_wam_predicate_to_c(user:wam_c_findall_none/1, WamNone, [], NoneCode),
         compile_wam_predicate_to_c(user:wam_c_findall_all/1, WamAll, [], AllCode),
         compile_wam_predicate_to_c(user:wam_c_findall_empty/1, WamEmpty, [], EmptyCode),
-        atomic_list_concat([ItemCode, NoneCode, AllCode, EmptyCode],
+        compile_wam_predicate_to_c(user:wam_c_findall_nested_inner/1, WamNestedInner, [], NestedInnerCode),
+        compile_wam_predicate_to_c(user:wam_c_findall_nested_outer/1, WamNestedOuter, [], NestedOuterCode),
+        compile_wam_predicate_to_c(user:wam_c_findall_struct_template/1, WamStructTemplate, [], StructTemplateCode),
+        compile_wam_predicate_to_c(user:wam_c_findall_list_template/1, WamListTemplate, [], ListTemplateCode),
+        atomic_list_concat([ItemCode, NoneCode, AllCode, EmptyCode,
+                            NestedInnerCode, NestedOuterCode,
+                            StructTemplateCode, ListTemplateCode],
                            '\n\n',
                            PredCode),
         compile_wam_runtime_to_c([], RuntimeCode),
@@ -2816,7 +2838,11 @@ cleanup_wam_c_findall_smoke :-
     retractall(user:wam_c_findall_item(_)),
     retractall(user:wam_c_findall_none(_)),
     retractall(user:wam_c_findall_all(_)),
-    retractall(user:wam_c_findall_empty(_)).
+    retractall(user:wam_c_findall_empty(_)),
+    retractall(user:wam_c_findall_nested_inner(_)),
+    retractall(user:wam_c_findall_nested_outer(_)),
+    retractall(user:wam_c_findall_struct_template(_)),
+    retractall(user:wam_c_findall_list_template(_)).
 
 run_real_prolog_classic_recursive_executable_smoke :-
     assertz((user:wam_c_classic_fib(0, 0) :- true)),
@@ -5827,24 +5853,85 @@ void setup_wam_c_findall_item_1(WamState* state);
 void setup_wam_c_findall_none_1(WamState* state);
 void setup_wam_c_findall_all_1(WamState* state);
 void setup_wam_c_findall_empty_1(WamState* state);
+void setup_wam_c_findall_nested_inner_1(WamState* state);
+void setup_wam_c_findall_nested_outer_1(WamState* state);
+void setup_wam_c_findall_struct_template_1(WamState* state);
+void setup_wam_c_findall_list_template_1(WamState* state);
 
 static bool expect_atom(WamState *state, WamValue value, const char *atom) {
     WamValue *cell = wam_deref_ptr(state, &value);
     return cell->tag == VAL_ATOM && strcmp(cell->data.atom, atom) == 0;
 }
 
+static bool expect_atom_slot(WamState *state, WamValue *slot, const char *atom) {
+    WamValue *cell = wam_deref_ptr(state, slot);
+    return cell->tag == VAL_ATOM && strcmp(cell->data.atom, atom) == 0;
+}
+
 static bool expect_atom_list2(WamState *state, WamValue value,
                               const char *first, const char *second) {
     WamValue *cell = wam_deref_ptr(state, &value);
-    if (cell->tag != VAL_LIST) return false;
-    WamValue *head1 = wam_deref_ptr(state, &state->H_array[cell->data.ref_addr]);
-    WamValue *tail1 = wam_deref_ptr(state, &state->H_array[cell->data.ref_addr + 1]);
-    if (head1->tag != VAL_ATOM || strcmp(head1->data.atom, first) != 0) return false;
-    if (tail1->tag != VAL_LIST) return false;
-    WamValue *head2 = wam_deref_ptr(state, &state->H_array[tail1->data.ref_addr]);
-    WamValue *tail2 = wam_deref_ptr(state, &state->H_array[tail1->data.ref_addr + 1]);
-    return head2->tag == VAL_ATOM &&
-           strcmp(head2->data.atom, second) == 0 &&
+    int cell_addr = wam_cons_head_addr(state, cell);
+    if (cell_addr < 0) return false;
+    WamValue *tail1 = wam_deref_ptr(state, &state->H_array[cell_addr + 1]);
+    int tail1_addr = wam_cons_head_addr(state, tail1);
+    if (tail1_addr < 0) return false;
+    WamValue *tail2 = wam_deref_ptr(state, &state->H_array[tail1_addr + 1]);
+    return expect_atom_slot(state, &state->H_array[cell_addr], first) &&
+           expect_atom_slot(state, &state->H_array[tail1_addr], second) &&
+           tail2->tag == VAL_ATOM &&
+           strcmp(tail2->data.atom, "[]") == 0;
+}
+
+static bool expect_atom_list1(WamState *state, WamValue value,
+                              const char *first) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    int cell_addr = wam_cons_head_addr(state, cell);
+    if (cell_addr < 0) return false;
+    WamValue *tail = wam_deref_ptr(state, &state->H_array[cell_addr + 1]);
+    return expect_atom_slot(state, &state->H_array[cell_addr], first) &&
+           tail->tag == VAL_ATOM &&
+           strcmp(tail->data.atom, "[]") == 0;
+}
+
+static bool expect_pair_atom_singleton(WamState *state, WamValue value,
+                                       const char *atom) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    if (cell->tag != VAL_STR) return false;
+    WamValue *functor = &state->H_array[cell->data.ref_addr];
+    if (functor->tag != VAL_ATOM || strcmp(functor->data.atom, "pair/2") != 0) {
+        return false;
+    }
+    return expect_atom_slot(state, &state->H_array[cell->data.ref_addr + 1], atom) &&
+           expect_atom_list1(state, state->H_array[cell->data.ref_addr + 2], atom);
+}
+
+static bool expect_pair_list2(WamState *state, WamValue value,
+                              const char *first, const char *second) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    int cell_addr = wam_cons_head_addr(state, cell);
+    if (cell_addr < 0) return false;
+    WamValue *tail1 = wam_deref_ptr(state, &state->H_array[cell_addr + 1]);
+    int tail1_addr = wam_cons_head_addr(state, tail1);
+    if (tail1_addr < 0) return false;
+    WamValue *tail2 = wam_deref_ptr(state, &state->H_array[tail1_addr + 1]);
+    return expect_pair_atom_singleton(state, state->H_array[cell_addr], first) &&
+           expect_pair_atom_singleton(state, state->H_array[tail1_addr], second) &&
+           tail2->tag == VAL_ATOM &&
+           strcmp(tail2->data.atom, "[]") == 0;
+}
+
+static bool expect_nested_atom_list2(WamState *state, WamValue value,
+                                     const char *first, const char *second) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    int cell_addr = wam_cons_head_addr(state, cell);
+    if (cell_addr < 0) return false;
+    WamValue *tail1 = wam_deref_ptr(state, &state->H_array[cell_addr + 1]);
+    int tail1_addr = wam_cons_head_addr(state, tail1);
+    if (tail1_addr < 0) return false;
+    WamValue *tail2 = wam_deref_ptr(state, &state->H_array[tail1_addr + 1]);
+    return expect_atom_list2(state, state->H_array[cell_addr], first, first) &&
+           expect_atom_list2(state, state->H_array[tail1_addr], second, second) &&
            tail2->tag == VAL_ATOM &&
            strcmp(tail2->data.atom, "[]") == 0;
 }
@@ -5874,6 +5961,10 @@ int main(void) {
     setup_wam_c_findall_none_1(&state);
     setup_wam_c_findall_all_1(&state);
     setup_wam_c_findall_empty_1(&state);
+    setup_wam_c_findall_nested_inner_1(&state);
+    setup_wam_c_findall_nested_outer_1(&state);
+    setup_wam_c_findall_struct_template_1(&state);
+    setup_wam_c_findall_list_template_1(&state);
 
     WamValue all_args[1] = { val_unbound("All") };
     int all_rc = wam_run_predicate(&state, "wam_c_findall_all/1", all_args, 1);
@@ -5900,6 +5991,33 @@ int main(void) {
         state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
         wam_free_state(&state);
         return 30;
+    }
+
+    WamValue nested_args[1] = { val_unbound("Nested") };
+    int nested_rc = wam_run_predicate(&state, "wam_c_findall_nested_outer/1", nested_args, 1);
+    if (nested_rc != 0 || state.P != WAM_HALT ||
+        !expect_atom_list2(&state, state.A[0], "a", "b") ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    WamValue struct_args[1] = { val_unbound("Struct") };
+    int struct_rc = wam_run_predicate(&state, "wam_c_findall_struct_template/1", struct_args, 1);
+    if (struct_rc != 0 || state.P != WAM_HALT ||
+        !expect_pair_list2(&state, state.A[0], "a", "b") ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 50;
+    }
+
+    WamValue list_args[1] = { val_unbound("List") };
+    int list_rc = wam_run_predicate(&state, "wam_c_findall_list_template/1", list_args, 1);
+    if (list_rc != 0 || state.P != WAM_HALT ||
+        !expect_nested_atom_list2(&state, state.A[0], "a", "b") ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 60;
     }
 
     wam_free_state(&state);


### PR DESCRIPTION
  - Add C WAM register parsing for compiler temporary `_XTn` registers
  - Extend the generated `findall/3` executable smoke to cover helper-nested aggregate frames
  - Validate compound and list templates including `pair(X, [X])` and `[X, X]`
  - Update the WAM-C roadmap with the completed branch and remaining direct inline nested `findall/3` compiler gap

  Validation:
  - `swipl -q -g "['tests/test_wam_c_target.pl'], run_real_prolog_findall_executable_smoke, halt"`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `git diff --check