### PR TITLE
LLVM WAM: realpath/2 (M110) -- canonical absolute path via libc

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1510,6 +1510,7 @@ declare i32 @getgid()
 declare i32 @getegid()
 declare i32 @getppid()
 declare i32 @getpgrp()
+declare i8* @realpath(i8*, i8*)
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3599,6 +3600,7 @@ entry:
     i32 125, label %builtin_access
     i32 126, label %builtin_directory_files
     i32 127, label %builtin_getpgrp
+    i32 128, label %builtin_realpath
   ]
 
 builtin_is:
@@ -5687,6 +5689,46 @@ builtin_getpgrp:
   %gpg.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %gpg.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %gpg.raw1, %Value %gpg.v)
   ret i1 %gpg.ok
+
+builtin_realpath:
+  ; M110: realpath(+Path, -Abs) -- libc realpath wrapper.
+  ; Stack-alloc a PATH_MAX-sized (4096) buffer for the result.
+  ; realpath returns NULL on failure (ENOENT for missing path,
+  ; EACCES for unreadable parent dir, etc.); we map that to a
+  ; Prolog fail. Non-atom Path also fails the type guard. On
+  ; success, the resolved path is copied into the arena, interned,
+  ; and the resulting atom is unified with reg 1.
+  %rp.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %rp.t1 = call i32 @value_tag(%Value %rp.a1)
+  %rp.is_atom = icmp eq i32 %rp.t1, 0
+  br i1 %rp.is_atom, label %rp.go, label %rp.fail
+rp.fail:
+  ret i1 false
+rp.go:
+  %rp.aid = call i64 @value_payload(%Value %rp.a1)
+  %rp.path = call i8* @wam_atom_to_string(i64 %rp.aid)
+  %rp.path_null = icmp eq i8* %rp.path, null
+  br i1 %rp.path_null, label %rp.fail, label %rp.do
+rp.do:
+  %rp.buf = alloca [4096 x i8]
+  %rp.buf_ptr = getelementptr [4096 x i8], [4096 x i8]* %rp.buf, i32 0, i32 0
+  %rp.res = call i8* @realpath(i8* %rp.path, i8* %rp.buf_ptr)
+  %rp.res_null = icmp eq i8* %rp.res, null
+  br i1 %rp.res_null, label %rp.fail, label %rp.intern
+rp.intern:
+  %rp.len = call i64 @strlen(i8* %rp.buf_ptr)
+  call void @wam_arena_ensure()
+  %rp.bufsize = add i64 %rp.len, 1
+  %rp.arena = call i8* @wam_arena_alloc(i64 %rp.bufsize)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %rp.arena, i8* %rp.buf_ptr, i64 %rp.len, i1 false)
+  %rp.term = getelementptr i8, i8* %rp.arena, i64 %rp.len
+  store i8 0, i8* %rp.term
+  %rp.atom_id = call i64 @wam_intern_atom(i8* %rp.arena, i64 %rp.len)
+  %rp.v0 = insertvalue %Value undef, i32 0, 0
+  %rp.v = insertvalue %Value %rp.v0, i64 %rp.atom_id, 1
+  %rp.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %rp.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %rp.raw2, %Value %rp.v)
+  ret i1 %rp.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -12760,6 +12802,7 @@ builtin_op_to_id('numbervars/3', 124).        % bind free vars to $VAR(N).
 builtin_op_to_id('access/2', 125).            % libc access(path, mode_bits).
 builtin_op_to_id('directory_files/2', 126).   % opendir/readdir loop -> list of atoms.
 builtin_op_to_id('getpgrp/1', 127).           % libc getpgrp() as Integer.
+builtin_op_to_id('realpath/2', 128).          % libc realpath(rel) -> Abs atom.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2104,6 +2104,7 @@ is_builtin_pred(getgid, 1).             % getgid(-Gid).
 is_builtin_pred(getegid, 1).            % getegid(-EGid).
 is_builtin_pred(getppid, 1).            % getppid(-PPid).
 is_builtin_pred(getpgrp, 1).            % getpgrp(-PGid) -- process group id.
+is_builtin_pred(realpath, 2).           % realpath(+Path, -Abs) -- canonical absolute path.
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,36 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M110: realpath/2 -- libc realpath wrapper for canonical absolute paths.
+
+:- dynamic test_rp_tmp/2.
+test_rp_tmp(_, R) :-
+    % /tmp is its own canonical absolute path -- realpath returns
+    % the same atom (no symlinks involved here).
+    realpath('/tmp', Abs),
+    ( Abs == '/tmp' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_rp_relative/2.
+test_rp_relative(_, R) :-
+    % realpath resolves . to the CWD; just check the result is a
+    % non-empty atom starting with /.
+    realpath('.', Abs),
+    atom_length(Abs, L),
+    atom_chars(Abs, [First | _]),
+    ( L > 0, First == '/' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_rp_missing/2.
+test_rp_missing(_, R) :-
+    % realpath on a non-existent path fails (ENOENT).
+    ( realpath('/tmp/uw_m110_definitely_not_here', _) -> R is 0
+    ; R is 1
+    ).   % 1
+
+:- dynamic test_rp_bad_arg/2.
+test_rp_bad_arg(_, R) :-
+    % Non-atom Path fails the type guard.
+    ( realpath(42, _) -> R is 0 ; R is 1 ).   % 1
+
 % M109: getpgrp/1 -- libc process group id wrapper.
 
 :- dynamic test_pgrp_positive/2.
@@ -5230,6 +5260,15 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M110 realpath/2 ---~n'),
+       run_test_r0('realpath(/tmp, Abs), Abs == /tmp -> 1',
+                   test_rp_tmp, 0, 1),
+       run_test_r0('realpath(., Abs), starts with / -> 1',
+                   test_rp_relative, 0, 1),
+       run_test_r0('realpath on missing path fails -> 1',
+                   test_rp_missing, 0, 1),
+       run_test_r0('realpath(42, _) fails (non-atom) -> 1',
+                   test_rp_bad_arg, 0, 1),
        format('--- M109 getpgrp/1 ---~n'),
        run_test_r0('getpgrp(PG), PG > 0 -> 1',
                    test_pgrp_positive, 0, 1),


### PR DESCRIPTION
## Summary

- **M110 `realpath/2`** — resolves a path to its canonical absolute form via libc `realpath`. Op id 128.

Reads reg 0 (Path) as Atom, calls libc `realpath` with a 4096-byte (PATH_MAX) stack buffer for the result. `NULL` return (`ENOENT` for missing path, `EACCES` for unreadable parent, etc.) maps to a Prolog fail. Non-atom Path also fails the type guard. On success, the resolved path is copied to the arena, interned as an atom, and unified with reg 1.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `@realpath` libc decl, dispatch entry, `builtin_realpath` IR block (prefix `rp.`), op-id table entry.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred(realpath, 2)`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — four M110 tests + section.

## Test plan

- [x] Full execution suite: **669/669 PASS**, no failures, no OOM ✓
- [x] `test_rp_tmp`: `realpath('/tmp')` round-trips to `/tmp` (no symlinks) ✓
- [x] `test_rp_relative`: `realpath('.')` yields a path starting with `/` ✓
- [x] `test_rp_missing`: `realpath` on a non-existent path correctly fails (`ENOENT`) ✓
- [x] `test_rp_bad_arg`: non-atom path fails the type guard ✓

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_