### PR TITLE
fix(wam-cpp): cut-in-called-predicate (B0), bagof/setof witness, lmdb test paths

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -320,12 +320,24 @@ wam_instruction_to_cpp_literal_det(begin_aggregate(K, V, R), _, Code) :-
     format(atom(Code),
            'Instruction::BeginAggregate("~w", "~w", "~w")', [EK, EV, ER]).
 wam_instruction_to_cpp_literal_det(begin_aggregate(K, V, R, W), _, Code) :-
-    to_string(K, KS), to_string(V, VS), to_string(R, RS), to_string(W, WS),
+    to_string(K, KS), to_string(V, VS), to_string(R, RS), to_string(W, WS0),
+    % The witness spec is emitted as a quoted atom in the WAM text (e.g.
+    % 'Y3' or 'Y1;Y2'), so the parser token keeps the surrounding single
+    % quotes. Strip them — otherwise witness_regs holds "'Y3'" and the
+    % runtime's get_cell("'Y3'") fails, leaving witness_cells empty and
+    % silently degrading bagof/setof grouping to a flat findall.
+    strip_surrounding_squotes(WS0, WS),
     escape_cpp_string(KS, EK), escape_cpp_string(VS, EV),
     escape_cpp_string(RS, ER), escape_cpp_string(WS, EW),
     format(atom(Code),
            'Instruction::BeginAggregate("~w", "~w", "~w", "~w")',
            [EK, EV, ER, EW]).
+strip_surrounding_squotes(S0, S) :-
+    string_chars(S0, Cs),
+    (   Cs = ['\''|Rest], append(Mid, ['\''], Rest)
+    ->  string_chars(S, Mid)
+    ;   S = S0
+    ).
 wam_instruction_to_cpp_literal_det(end_aggregate(R), _, Code) :-
     to_string(R, RS),
     escape_cpp_string(RS, ER),

--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -3320,6 +3320,15 @@ struct TrailEntry {
 // nested calls that both use Y1 don''t clobber each other.
 struct EnvFrame {
     std::size_t saved_cp = 0;
+    // B0: the choicepoint-stack height when this clause''s predicate was
+    // called (captured by Allocate from cut_barrier, which Call/Execute
+    // set to choice_points.size() before transferring control). A plain
+    // cut (!/0) in this clause truncates choicepoints back to b0, so it
+    // removes only this predicate''s own alternatives and body CPs, never
+    // a caller''s choicepoint. Survives nested calls because each callee
+    // gets its own frame; restored on backtrack via ChoicePoint''s
+    // saved_env_stack snapshot.
+    std::size_t b0 = 0;
     std::unordered_map<std::string, CellPtr> y_regs;
 };
 
@@ -4507,7 +4516,20 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
     if (op == "true/0") { pc += 1; return true; }
     if (op == "fail/0") { return false; }
     if (op == "!/0")    {
-        if (choice_points.size() > cut_barrier) choice_points.resize(cut_barrier);
+        // Cut to this clause''s B0 (the choicepoint height when its
+        // predicate was called), held in the current env frame. This
+        // keeps a cut local to the predicate: it prunes this predicate''s
+        // own alternatives and the body CPs it created, but never a
+        // caller''s choicepoint (e.g. the choicepoint of an enclosing
+        // negation or if-then-else whose condition called this
+        // predicate). Envless
+        // clauses (no Allocate) can only contain neck cuts -- they have
+        // no in-body call to clobber cut_barrier -- so the global
+        // cut_barrier (set to call-time height by Call/Execute) is the
+        // correct fallback.
+        std::size_t level = env_stack.empty() ? cut_barrier
+                                              : env_stack.back().b0;
+        if (choice_points.size() > level) choice_points.resize(level);
         pc += 1; return true;
     }
 
@@ -7670,6 +7692,12 @@ bool WamState::step(const Instruction& instr) {
         case Instruction::Op::Allocate: {
             EnvFrame f;
             f.saved_cp = cp;
+            // Capture B0 for this clause: cut_barrier was set to the
+            // caller-time choicepoint height by the Call/Execute that
+            // entered this predicate (and is restored on backtrack via
+            // the choicepoint snapshot), so it is the correct cut level
+            // for a plain cut in this clause body.
+            f.b0 = cut_barrier;
             env_stack.push_back(std::move(f));
             pc += 1; return true;
         }
@@ -7731,6 +7759,11 @@ bool WamState::step(const Instruction& instr) {
             auto it = labels.find(instr.a);
             if (it != labels.end()) {
                 cp = pc + 1;
+                // Record B0 for the callee: a plain cut in the callee
+                // cuts back to this choicepoint height (see EnvFrame::b0
+                // / Allocate). Saved/restored across backtracking by the
+                // callee''s try_me_else choicepoint snapshot of cut_barrier.
+                cut_barrier = choice_points.size();
                 pc = it->second;
                 return true;
             }
@@ -7784,6 +7817,8 @@ bool WamState::step(const Instruction& instr) {
             }
             auto it = labels.find(instr.a);
             if (it != labels.end()) {
+                // Record B0 for the tail-called callee (see Op::Call).
+                cut_barrier = choice_points.size();
                 pc = it->second;
                 return true;
             }

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1211,8 +1211,24 @@ compile_goals([Goal|Rest], V0, HasEnv, Vf, Code) :-
     ;   nonvar(Goal),
         Goal = \+(NotGoal),
         wam_inline_not_enabled
-    ->  compile_goals([((NotGoal, !, fail) ; true) | Rest],
-                      V0, HasEnv, Vf, Code)
+    ->  (   wam_ite_use_y_level_enabled
+        % M17 targets (get_level/cut): use the soft-cut form
+        % (NotGoal -> fail ; true). cut Yn truncates choicepoints back to
+        % the snapshot taken BEFORE the negation try_me_else, so it wipes
+        % the negation CP AND any CPs NotGoal pushed above it -- the same
+        % correctness the hard-cut form gives, but WITHOUT a clause-scope
+        % `!`. That matters because a clause-scope cut would (via the
+        % runtime''s B0 mechanism) cut to the enclosing clause''s level and
+        % wrongly prune sibling choicepoints created before the \+. The
+        % soft cut is scoped to the negation alone.
+        ->  compile_goals([((NotGoal -> fail ; true)) | Rest],
+                          V0, HasEnv, Vf, Code)
+        % Legacy targets (no get_level/cut): keep the hard-cut rewrite
+        % ((G, !, fail) ; true) -- see note below on why soft-cut+cut_ite
+        % gets the wrong CP when G is nondeterministic on these targets.
+        ;   compile_goals([((NotGoal, !, fail) ; true) | Rest],
+                          V0, HasEnv, Vf, Code)
+        )
     % M71: forall(Cond, Action) inlines as
     %   ((Cond, (Action -> fail ; true)) -> fail ; true)
     % i.e., \+ (Cond, \+ Action) using soft-cut (-> form) for BOTH

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -5543,10 +5543,11 @@ test(cpp_e2e_lmdb_policy_order_by_arg2_desc,
 % awkward because plunit owns it.
 test(cpp_e2e_lmdb_sort_warning_emitted,
      [condition(cpp_lmdb_available)]) :-
-    run_codegen_subprocess(
+    lmdb_subprocess_modules(WamPath, PolicyPath),
+    format(string(Source),
         "
-        :- use_module('/home/user/UnifyWeaver/src/unifyweaver/targets/wam_cpp_target').
-        :- use_module('/home/user/UnifyWeaver/src/unifyweaver/core/relation_policy').
+        :- use_module('~w').
+        :- use_module('~w').
         :- relation_policy(edge/2, [order([arg(2)])]).
         :- dynamic user:edge/2.
         user:dummy :- edge(_, _).
@@ -5554,16 +5555,18 @@ test(cpp_e2e_lmdb_sort_warning_emitted,
               [cpp_fact_sources([source(edge/2, lmdb('/tmp/x'))])],
               '/tmp/sw_warn_emit'), halt.
         ",
-        Stderr),
+        [WamPath, PolicyPath]),
+    run_codegen_subprocess(Source, Stderr),
     assertion(sub_string(Stderr, _, _, _,
                          "requires a runtime sort")).
 
 test(cpp_e2e_lmdb_sort_warning_suppressed,
      [condition(cpp_lmdb_available)]) :-
-    run_codegen_subprocess(
+    lmdb_subprocess_modules(WamPath, PolicyPath),
+    format(string(Source),
         "
-        :- use_module('/home/user/UnifyWeaver/src/unifyweaver/targets/wam_cpp_target').
-        :- use_module('/home/user/UnifyWeaver/src/unifyweaver/core/relation_policy').
+        :- use_module('~w').
+        :- use_module('~w').
         :- relation_policy(edge/2, [order([arg(2)])]).
         :- dynamic user:edge/2.
         user:dummy :- edge(_, _).
@@ -5572,16 +5575,18 @@ test(cpp_e2e_lmdb_sort_warning_suppressed,
                                   lmdb('/tmp/x', [quiet_sort(true)]))])],
               '/tmp/sw_warn_supp'), halt.
         ",
-        Stderr),
+        [WamPath, PolicyPath]),
+    run_codegen_subprocess(Source, Stderr),
     assertion(\+ sub_string(Stderr, _, _, _,
                             "requires a runtime sort")).
 
 test(cpp_e2e_lmdb_sort_warning_trivial_no_warn,
      [condition(cpp_lmdb_available)]) :-
-    run_codegen_subprocess(
+    lmdb_subprocess_modules(WamPath, PolicyPath),
+    format(string(Source),
         "
-        :- use_module('/home/user/UnifyWeaver/src/unifyweaver/targets/wam_cpp_target').
-        :- use_module('/home/user/UnifyWeaver/src/unifyweaver/core/relation_policy').
+        :- use_module('~w').
+        :- use_module('~w').
         :- relation_policy(edge/2, [order([arg(1)])]).
         :- dynamic user:edge/2.
         user:dummy :- edge(_, _).
@@ -5589,7 +5594,8 @@ test(cpp_e2e_lmdb_sort_warning_trivial_no_warn,
               [cpp_fact_sources([source(edge/2, lmdb('/tmp/x'))])],
               '/tmp/sw_warn_triv'), halt.
         ",
-        Stderr),
+        [WamPath, PolicyPath]),
+    run_codegen_subprocess(Source, Stderr),
     assertion(\+ sub_string(Stderr, _, _, _,
                             "requires a runtime sort")).
 
@@ -10788,6 +10794,17 @@ lmdb_seed_three_edges(TmpDir, EnvPath, MetaPred, SeedBin) :-
 % its stderr. Used by the sort-warning tests to verify codegen-
 % time messages without interfering with plunit's own
 % user_error.
+% Absolute paths to the two modules a codegen subprocess needs to
+% load. Resolved from the already-loaded modules (use_module at the
+% top of this file) so the subprocess works regardless of where the
+% repo is checked out -- previously these were hard-coded to
+% /home/user/UnifyWeaver/... which only matched one machine.
+lmdb_subprocess_modules(WamPath, PolicyPath) :-
+    module_property(wam_cpp_target, file(WamFile)),
+    module_property(relation_policy, file(PolicyFile)),
+    atom_string(WamFile, WamPath),
+    atom_string(PolicyFile, PolicyPath).
+
 run_codegen_subprocess(Source, Stderr) :-
     tmp_file(codegen_script, ScriptBase),
     atom_concat(ScriptBase, '.pl', ScriptPath),


### PR DESCRIPTION
  Fixes the four pre-existing test_wam_cpp_generator failures.

  1. B0 / cut locality (c65eaf90) — fixes cpp_e2e_lists_cleanup.
  A plain cut (!/0) truncated choicepoints back to a single global cut_barrier that nothing set on a call, so a cut
  inside a called predicate could prune a caller's choicepoint. \+ proper_length([a,b|_],_) wrongly failed because
  proper_length→acc/3's var(L),!,fail removed the enclosing negation's choicepoint instead of just acc/3's own
  alternatives.

  Implements the WAM B0 mechanism in the C++ runtime: EnvFrame gains b0 (the choicepoint height at predicate entry);
  Op::Call/Op::Execute (user-pred path) set cut_barrier = choice_points.size() before transfer (already saved/restored
  across backtracking by the callee's try_me_else snapshot); Op::Allocate captures f.b0 = cut_barrier; !/0 cuts to the
  current clause's b0 (fallback cut_barrier for envless neck-cut-only clauses). Compiler (wam_target.pl): under
  ite_use_y_level (C++/LLVM only) the outer \+ G now uses the soft-cut (G -> fail ; true) form so its commit cut is
  get_level/cut scoped to the negation; other targets keep the existing hard-cut form unchanged.

  2. bagof/setof witness (a4d5bc8b) — fixes inlined_groups_by_witness, inlined_groups_sorted.
  begin_aggregate(K,V,R,W) carried its witness as a quoted atom; the parser kept the quotes, so get_cell("'Y3'") failed
  and grouping silently degraded to a flat findall. Adds strip_surrounding_squotes/2.

  3. lmdb test paths (37ab083d) — fixes cpp_e2e_lmdb_sort_warning_emitted.
  Three subprocess tests hard-coded /home/user/UnifyWeaver/...; resolved at runtime via module_property/2.

  Test plan: test_wam_cpp_generator 400/400 (was 4 failing); test_wam_llvm_target, test_wam_cross_target_conformance,
  test_wam_cross_target_consistency, test_wam_target, test_wam_e2e all green. Zero regressions.

  🤖 Generated with Claude Code (https://claude.com/claude-code)