### PR TITLE
Add Root-Anchored Metrics design docs (philosophy/spec/plan)

### DIFF
--- a/docs/design/ROOT_ANCHORED_METRICS_IMPLEMENTATION_PLAN.md
+++ b/docs/design/ROOT_ANCHORED_METRICS_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,155 @@
+# Root-Anchored Metrics — Implementation Plan
+
+Companion to `ROOT_ANCHORED_METRICS_PHILOSOPHY.md` and
+`ROOT_ANCHORED_METRICS_SPECIFICATION.md`. Phased delivery, smallest-useful-first,
+with a recommendation at each fork. **Minimum distance to root is Phase 1** — it
+is the simplest, cycle-safe, useful on its own, and unlocks the branch-prune that
+the other metrics also benefit from.
+
+Guiding constraint: reuse existing machinery wherever it already fits
+(`recursive_kernel_detection`, the shortest-path kernels, `demand_analysis`'s
+cursor BFS over `category_child`, the visited-set instructions, the LMDB fact
+source, `build_scoped_subtree_lmdb.py`, `cost_model`/`algorithm_manifest`).
+
+## Phase 0 — Spec surface + recognition (no algorithm yet)
+
+- Add a `root_metric/2` directive parser to a new
+  `src/unifyweaver/core/root_metric.pl` (sibling of `demand_analysis.pl`):
+  validate the tuple (§1 of the spec), normalise `succ → plus(1)`, default
+  `cycles(bounded)`, `materialize(kernel)`.
+- Expose `root_metric_spec(Name/Arity, Normalised)` for downstream consumers and
+  a `root_metric_semiring(Aggregate, Combine, Semiring)` table (§3).
+- Tests: `tests/core/test_root_metric.pl` — tuple validation, defaults,
+  rejection of unknown combine/aggregate and negative depth.
+- **No regression risk**: directive is inert until a target consumes it.
+
+**Recommendation:** land Phase 0 alone first; it is pure analysis + tests and
+defines the contract every later phase implements.
+
+## Phase 1 — Minimum distance to root (in-kernel node-DP)
+
+Goal: `min_dist_to_root/3` computed as a BFS-from-root node-DP, validated against
+the naive Prolog reference on small graphs and run at scale on the coherent
+enwiki fixture.
+
+- **Algorithm**: single BFS from the root over the *reverse* edge direction
+  (`down` `category_child` for an `up` `parent` metric), labelling each node with
+  its first-seen depth = min distance. This is exactly the cursor BFS already in
+  `demand_analysis` / the Rust `reachable_to_root` — extend it to *record depth*,
+  not just membership.
+- **Reuse**: the demand BFS infrastructure and `weighted_shortest_path3` /
+  `astar_shortest_path4` kernels are the precedent; prefer extending the demand
+  BFS (it already walks `category_child` with a visited set).
+- **Reference oracle**: the naive `aggregate_all(min(...), dist_to_root, D)` run
+  in SWI-Prolog on a tiny fixture; assert the DP matches.
+- **Validate at scale**: on `enwiki_cats_correct` (root 7345184), the BFS is
+  `O(edges)` once → seconds, vs the ~17 h path-enumeration. Capture the timing
+  contrast as the headline result.
+- Tests: tiny-graph equivalence (incl. a cycle, to show cycle-safety) +
+  unreachable-node handling.
+
+**Fork — where does the BFS run?** (a) in the generated kernel at query/load
+time, or (b) as a one-shot at ingest (Phase 2). Phase 1 does (a); it is the
+ad-hoc-root path and needs no schema change.
+
+## Phase 2 — Materialise min-distance at ingest
+
+Goal: for a fixed known root, store `node → min_dist` once so queries are lookups
++ prune.
+
+- Extend `build_scoped_subtree_lmdb.py` (or a sibling `build_root_metric_lmdb.py`)
+  to compute min-distance during the same BFS it already runs from the root and
+  write a `metric_min_dist_to_root` sub-db (`int32_le node → int32_le dist`) plus
+  a `meta` provenance entry (root, max_depth, aggregate) per §6 of the spec.
+  *It is the same BFS — the scoped builder already visits every node from the
+  root; it just isn't recording the depth yet.* Near-zero marginal cost.
+- Runtime: a lookup stub (`Name(Root,Node,V)` → keyed get) + the branch-prune
+  helper that consults the table. Wire an opt-in flag mirroring `WAM_DEMAND`
+  (e.g. the kernel consults `metric_min_dist_to_root` when present).
+- Tests: extend `tests/test_build_scoped_subtree_lmdb.py` to assert the metric
+  sub-db matches a BFS oracle on the tiny fixture; codegen guard for the lookup
+  stub.
+
+**Recommendation:** default to ingest-materialisation (this phase) for a fixed
+root, fall back to Phase 1's in-kernel DP for runtime-chosen roots — the same
+both-and conclusion as demand-set-at-ingest.
+
+## Phase 3 — Effective distance as a linear difference equation
+
+Goal: replace the path-enumerating `effective_distance_sum` with the
+length-bucketed node-DP (§5 of the spec), proving equality and the asymptotic
+collapse.
+
+- **Algorithm**: `count[N][L] = Σ_parents count[N'][L-1]` over the reverse BFS
+  layers, `count[R][0]=1`, `L ≤ max_depth`; then
+  `S(N) = Σ_L count[N][L]·(L+1)^(-n)`. Each node carries an
+  `(max_depth+1)`-wide vector; one pass, `O(edges·max_depth)`.
+- **Equivalence test**: on a small graph, assert the DP's `S(N)` equals the
+  existing kernel's per-seed path-sum exactly (not approximately).
+- **Scale**: run on `enwiki_cats_correct` and contrast with the ~24 ms/seed
+  path-enumeration baseline; this is the quantitative payoff.
+- **Cycles**: `cycles(bounded)` via `max_depth` truncation is the supported
+  default; document the `decay<1` convergence note and leave exact cyclic linear
+  solve as a non-goal.
+- Materialisation: `f64` value sub-db (§6); same builder extension as Phase 2.
+
+## Phase 4 — Maximum distance to root
+
+Goal: `max_dist_to_root/3` (depth-bounded longest walk), the `(max,+)` instance.
+
+- **Algorithm**: longest-walk DP over reverse BFS layers, capped at `max_depth`;
+  with `cycles(scc)` optionally condense SCCs first.
+- Lower priority than 1–3 (semantic is "specificity/depth," useful but not on the
+  query critical path). Implement once the semiring template from Phases 1/3 is
+  proven so it is mostly a parameter change.
+
+## Phase 5 — Generalisation + (optional) inference
+
+- Factor Phases 1/3/4 into one **semiring-parameterised lowering template** so a
+  new metric is a new `(aggregate, combine)` row, not new traversal code.
+- Optional: infer the `root_metric` shape from bare `aggregate_all/3` over a
+  transitive closure (the spec's §7 out-of-scope item) as a convenience on top of
+  the explicit directive.
+
+## Integration points (where each phase touches the tree)
+
+| Concern                    | Module / file                                              |
+|----------------------------|-----------------------------------------------------------|
+| directive + recognition    | `src/unifyweaver/core/root_metric.pl` (new)               |
+| kernel shape detection     | `recursive_kernel_detection.pl`, `KERNEL_SHAPE_RECOGNITION`|
+| reuse shortest-path kernels| existing `weighted_shortest_path3`, `astar_shortest_path4` |
+| reverse BFS / demand walk  | `demand_analysis.pl`, Rust `reachable_to_root`            |
+| ingest materialisation     | `build_scoped_subtree_lmdb.py` (+ metric sub-db)          |
+| runtime lookup + prune     | LMDB fact source templates per target                     |
+| cost/algorithm selection   | `cost_model.pl`, `algorithm_manifest.pl`                  |
+| bench                      | the WAM matrix bench (replace the path kernel)            |
+
+## Validation strategy (every phase)
+
+1. **Oracle equivalence** on a tiny hand-checked fixture (incl. a cycle).
+2. **Cross-check** the materialised table vs the in-kernel DP vs the naive Prolog.
+3. **Scale run** on `enwiki_cats_correct` (root 7345184), reporting the timing
+   contrast vs the path-enumeration baseline — and stating seed counts /
+   denominators explicitly (per `feedback_perf_skepticism`; the old enwiki
+   numbers were degenerate because the graph was a broken flat star).
+4. **No-regression** on the existing WAM test suites.
+
+## Recommendations summary
+
+- **Order**: Phase 0 → 1 → 2 → 3 → (4, 5). Ship min-distance end-to-end
+  (in-kernel then materialised) before touching flux.
+- **Spec style**: explicit `root_metric/2` directive over inference (robust,
+  matches the codebase); inference is a later nicety.
+- **Where to compute**: materialise at ingest for a fixed root (default),
+  in-kernel DP for runtime roots — both, mirroring demand-set-at-ingest.
+- **Effective distance**: length-bucketed node-DP, depth-bounded; it is *exactly*
+  the current quantity, not an approximation.
+- **Cycles**: rely on `max_depth` (`bounded`) by default; `scc` only where
+  longest-path semantics demand it.
+
+## See also
+
+`ROOT_ANCHORED_METRICS_PHILOSOPHY.md`, `ROOT_ANCHORED_METRICS_SPECIFICATION.md`,
+`WAM_DEMAND_FILTER_IMPLEMENTATION_PLAN.md`, `SCAN_STRATEGY_IMPLEMENTATION_PLAN.md`,
+`KERNEL_SHAPE_RECOGNITION.md`; memory `project_enwiki_correct_ingest`,
+`project_demand_set_at_ingest`.

--- a/docs/design/ROOT_ANCHORED_METRICS_PHILOSOPHY.md
+++ b/docs/design/ROOT_ANCHORED_METRICS_PHILOSOPHY.md
@@ -1,0 +1,188 @@
+# Root-Anchored Metrics — Philosophy
+
+## What this is
+
+A design for expressing **per-node graph metrics that are anchored at a root**
+— minimum distance to root, maximum distance to root, and additive
+"effective distance" / flux — as **declarative Prolog difference equations with
+a boundary condition at the root**, which the compiler recognises and lowers to
+an efficient **node-based dynamic program** (and, when the root is fixed,
+materialises once at ingest into the fact store).
+
+The deliverable in one sentence: *write the metric as a recurrence pinned at the
+root in Prolog; let the target compute it in time linear in the graph (not
+exponential in its paths), and store it so queries become lookups.*
+
+This sits directly above two threads that already landed:
+
+- **Demand-set-at-ingest** (`project_demand_set_at_ingest`, the scoped-subtree
+  builder + `WAM_DEMAND` flag): do the expensive whole-graph work once at
+  ingest, store it, make queries cheap. Root-anchored metrics are the natural
+  next quantity to precompute and store alongside the scoped subtree.
+- **Kernel shape recognition** (`KERNEL_SHAPE_RECOGNITION.md`) and the WAM
+  lowering pipeline: the compiler already detects recursive kernel shapes and
+  emits specialised code. Root-anchored metrics are a new shape to recognise.
+
+## Why now
+
+Benching the `category_ancestor` effective-distance query on the **coherent**
+enwiki content graph (3-dump Correct-mode ingest; see
+`project_enwiki_correct_ingest`) exposed a wall the older fixtures hid:
+
+- On the genuine content DAG (**~2.98 edges/node**, deep), the current
+  effective-distance kernel costs **~24 ms/seed** — a full 2.6M-seed query would
+  take **~17 h** single-threaded.
+- The kernel is **path-based**: per seed it walks to the root and records a hop
+  value *for every distinct path*. On a near-tree (simplewiki, 1.03 edges/node)
+  the path count ≈ the node count, so it was microseconds. On a dense DAG the
+  number of distinct seed→root paths grows **multiplicatively** with branching
+  — exponential — so a single seed spawns millions of paths.
+- The earlier "fast" enwiki numbers were measured on the **broken flat-star
+  graph** (mixed id-space ingest, 1.03 edges/node, almost nothing to traverse).
+  They were a degenerate artifact, not real performance — a textbook case for
+  `feedback_perf_skepticism`.
+
+The data is now correct; the bottleneck has moved to the **algorithm**. The fix
+is not to optimise path enumeration but to *stop enumerating paths* — compute a
+per-node value once and reuse it.
+
+## The core principle: the Prolog is the *what*, the target is the *how*
+
+The same idea that motivates the whole WAM-target project applies here. The
+Prolog should be a **specification of the quantity**, not an algorithm. It must
+capture exactly the details that (a) determine correctness and (b) let the
+compiler recognise *which* algorithm to apply — and nothing about the algorithm
+itself.
+
+A root-anchored metric, written declaratively, *is* a fixed-point with a
+boundary. For minimum distance:
+
+```prolog
+dist_to_root(Root, Root, 0).
+dist_to_root(Root, Node, D) :-
+    parent(Node, P), dist_to_root(Root, P, D0), D is D0 + 1.
+
+min_dist_to_root(Root, Node, D) :-
+    aggregate_all(min(D0), dist_to_root(Root, Node, D0), D).
+```
+
+The base clause `dist_to_root(Root, Root, 0)` is the **fixed value at the root**.
+Run naively this Prolog *is* the path enumeration that explodes. The point is
+that the compiler recognises the pattern — `min` aggregation over an additive
+`+1` transitive closure with a root boundary — and lowers it to **BFS from the
+root with a visited set / stored distance**, never literal backtracking. The
+declarative text stays simple; the efficiency lives in the target.
+
+## Theory: one recurrence skeleton, three semirings
+
+All three metrics share a recurrence shape — a node's value is an aggregate over
+its parents' values, combined with a per-edge step, pinned at the root:
+
+```
+value(Root) = identity_boundary
+value(Node) = AGGREGATE over p in parents(Node) of  COMBINE(value(p), edge_step)
+```
+
+They differ only in the `(AGGREGATE, COMBINE)` pair — i.e. in the **semiring**:
+
+| Metric                | AGGREGATE | COMBINE      | boundary | algorithm class            |
+|-----------------------|-----------|--------------|----------|----------------------------|
+| min distance to root  | `min`     | `+1`         | `0`      | single-source shortest path|
+| max distance to root  | `max`     | `+1`         | `0`      | longest path / longest walk|
+| effective distance    | `+` (sum) | `× decay`    | `1`      | linear fixed point (KCL)   |
+
+- **Min** is the tropical `(min, +)` semiring → Dijkstra/BFS. Each node's value
+  is its shortest hop-distance to root.
+- **Max** is `(max, +)` → longest path. Well-defined only on a DAG; on a cyclic
+  graph it must be bounded (see *Cycles* below).
+- **Effective distance** is the ordinary `(+, ×)` ring with a decay weight per
+  edge → a linear difference equation `V = decay·Mᵀ·V` pinned at the root
+  (`V(root)=1`). This is the discrete KCL / Green's-function form already
+  sketched in `project_scan_strategy_cost_functions` (the additive
+  flux / PPR variants). It reproduces the path-sum `Σ_paths (len+1)^(-n)` **without
+  enumerating paths**, by counting paths bucketed by length:
+  `count[Node][L] = Σ_parents count[parent][L-1]`, then
+  `S(Node) = Σ_{L≤max_depth} count[Node][L]·(L+1)^(-n)`. `L` is bounded by
+  `max_depth`, so each node carries a tiny fixed-width vector and the whole
+  computation is one pass, `O(edges × max_depth)`.
+
+Seeing all three as the same skeleton over different semirings is what lets a
+single recognition rule + a single lowering template cover them.
+
+## Cycles
+
+The Wikipedia category graph has cycles, so cycle behaviour is part of
+correctness, not an afterthought:
+
+- **Min** is cycle-safe for free: BFS never re-visits, and a cycle can only ever
+  offer a *longer* path, so it never improves the minimum.
+- **Max** diverges on a cycle (you can loop forever to grow the length). It is
+  only meaningful as a **depth-bounded longest walk** (cap at `max_depth`, the
+  bound the kernel already uses) or after **SCC condensation** (collapse each
+  strongly-connected component to one node). Depth-bounding is the simpler
+  default and matches existing kernel behaviour.
+- **Effective distance** with `decay < 1` converges even with cycles (it is a
+  contraction), but the depth-bounded truncation makes it finite and exact to
+  `max_depth` regardless; that is the recommended default.
+
+## Alternatives considered
+
+### A. Keep path enumeration, optimise constants
+Status quo. Memoise sub-walks, prune aggressively, parallelise. **Rejected as the
+primary fix**: the work is exponential in graph density; constant-factor wins
+don't change the asymptotics. (Parallelism still helps once the algorithm is
+linear.)
+
+### B. In-kernel node-DP (memoised, per run)
+Recognise the shape and emit a memoised node-DP that runs at query/load time.
+Linear in edges, no schema change. **Recommended for ad-hoc / runtime-chosen
+roots** — the analogue of the query-time demand BFS.
+
+### C. Ingest-materialised per-node value (stored in the DB)
+Compute the metric once at ingest (when the root is known) and store
+`node → value` in a sub-db; queries become O(1) lookups plus the prune.
+**Recommended as the default for a known fixed root** — the exact analogue of the
+pre-scoped subtree DB, and it composes with it (store the metric *in* the scoped
+DB).
+
+The B-vs-C choice mirrors the demand-set "option 3" conclusion: support both,
+default to ingest-materialisation (C) when the root is fixed, fall back to
+in-kernel (B) at small scale or for a runtime root.
+
+### D. How explicitly should the Prolog declare the pattern?
+- **Inferred** — write pure `aggregate_all(min(...), closure, ...)` and have the
+  compiler detect the shape. Cleanest Prolog, but brittle: inference must catch
+  every spelling.
+- **Declared** — keep the relational clauses and add a small directive naming the
+  recurrence class. UnifyWeaver already leans on directives (`visited_set/2`, the
+  algorithm manifest, demand directives), so this is consistent and robust.
+
+**Recommendation: declared.** A directive that names the five details below is
+the right "spec surface"; inference can be a later convenience layer on top.
+
+## What the Prolog must capture (and what it must not)
+
+Must capture — the five details that fix correctness *and* select the algorithm:
+
+1. **Edge relation + direction** — `parent/2`, i.e. which way is "up."
+2. **Boundary** — the root node and its fixed value (`0` for distance, `1` for flux).
+3. **Combine** — the per-edge step (`succ`/`+1`, or `× decay`).
+4. **Aggregate** — `min` / `max` / `sum`; this one choice picks the semiring.
+5. **Depth bound** — `max_depth` (and, implicitly, the cycle policy it induces).
+
+Must **not** capture — these belong to the target and existing machinery:
+traversal order, the visited set, memoisation, the iteration/convergence scheme,
+SCC handling, the demand set, LMDB layout, parallelism.
+
+That five-tuple is exactly what distinguishes min from max from flux while
+leaving the algorithm entirely to the backend. The specification doc turns it
+into a concrete directive; the implementation plan sequences min-distance first.
+
+## See also
+
+- `ROOT_ANCHORED_METRICS_SPECIFICATION.md` — the directive + semantics.
+- `ROOT_ANCHORED_METRICS_IMPLEMENTATION_PLAN.md` — phased delivery.
+- `KERNEL_SHAPE_RECOGNITION.md`, `WAM_DEMAND_FILTER_PHILOSOPHY.md`,
+  `SCAN_STRATEGY_PHILOSOPHY.md`, `COST_FUNCTION_PHILOSOPHY.md`,
+  `TREE_LIKENESS_INDEX_THEORY.md` (graph density is what triggers the blowup).
+- `project_enwiki_correct_ingest`, `project_demand_set_at_ingest` (memory).

--- a/docs/design/ROOT_ANCHORED_METRICS_SPECIFICATION.md
+++ b/docs/design/ROOT_ANCHORED_METRICS_SPECIFICATION.md
@@ -1,0 +1,208 @@
+# Root-Anchored Metrics — Specification
+
+Companion to `ROOT_ANCHORED_METRICS_PHILOSOPHY.md`. This doc fixes the **spec
+surface**: the directive a user writes, the semantics of each metric, the
+semiring abstraction, cycle/depth rules, the recognition contract, and the
+materialised output layout. It does not prescribe the algorithm (that is the
+implementation plan's job) beyond what correctness requires.
+
+## 1. The directive
+
+A root-anchored metric is declared with one directive next to the relational
+clauses that define the edge relation:
+
+```prolog
+:- root_metric(Name/Arity,
+       [ edge(EdgePred/2, Direction),   % Direction = up | down
+         boundary(RootTerm, V0),        % fixed value at the root
+         combine(Combine),              % succ | plus(K) | scale(Decay)
+         aggregate(Aggregate),          % min | max | sum
+         max_depth(D),                  % non-negative integer
+         cycles(Policy),                % bounded | scc | ignore (default bounded)
+         materialize(Where) ]).         % ingest | kernel (default kernel)
+```
+
+`Name/Arity` is the user-facing predicate the metric is exposed as, conventional
+arity 3: `Name(Root, Node, Value)`. The relational clauses may still be present
+(for the Prolog reference semantics / non-WAM targets); the directive tells the
+compiler the recurrence class so it can lower efficiently instead of executing
+them literally.
+
+### Field semantics
+
+- **`edge(EdgePred/2, Direction)`** — the adjacency relation. `Direction = up`
+  means the metric is computed by following `EdgePred` from a node toward the
+  root (child → parent); `down` follows the reverse. Internally the engine walks
+  *from the root outward* over the opposite direction (see §4), so it needs both
+  the relation and which way "toward root" points.
+- **`boundary(RootTerm, V0)`** — the root node (a term, possibly a variable bound
+  at query time) and the value assigned to it. `V0 = 0` for distances, `1.0` for
+  flux.
+- **`combine(Combine)`** — the per-edge step applied to a parent's value:
+  - `succ` ≡ `plus(1)` — add one hop.
+  - `plus(K)` — add a constant edge weight `K`.
+  - `scale(Decay)` — multiply by `Decay` (0 < Decay ≤ 1) for flux.
+- **`aggregate(Aggregate)`** — how a node combines contributions from multiple
+  parents: `min`, `max`, or `sum`. This selects the semiring (§3).
+- **`max_depth(D)`** — contributions beyond `D` hops from the root are not
+  counted. Bounds cost and makes cyclic graphs well-defined.
+- **`cycles(Policy)`** — `bounded` (default; rely on `max_depth`), `scc`
+  (condense strongly-connected components first), or `ignore` (assume acyclic;
+  undefined behaviour on a cycle — only for known DAGs).
+- **`materialize(Where)`** — `kernel` (default; recompute per run as a node-DP)
+  or `ingest` (precompute once, store `node → value`; see §6).
+
+## 2. The three canonical instances
+
+### 2.1 Minimum distance to root
+
+```prolog
+:- root_metric(min_dist_to_root/3,
+       [ edge(parent/2, up), boundary(Root, 0),
+         combine(succ), aggregate(min),
+         max_depth(10), cycles(bounded), materialize(ingest) ]).
+```
+
+`min_dist_to_root(Root, Node, D)` — `D` is the fewest `parent` hops from `Node`
+to `Root`, or unbound/`+inf` (absent from the materialised table) if `Node`
+cannot reach `Root` within `max_depth`. Cycle-safe with no special handling.
+
+### 2.2 Maximum distance to root
+
+```prolog
+:- root_metric(max_dist_to_root/3,
+       [ edge(parent/2, up), boundary(Root, 0),
+         combine(succ), aggregate(max),
+         max_depth(10), cycles(bounded), materialize(ingest) ]).
+```
+
+`max_dist_to_root(Root, Node, D)` — the longest `parent` *walk* from `Node` to
+`Root` of length `≤ max_depth`. With `cycles(bounded)` this is the longest walk
+within the budget; with `cycles(scc)` it is the longest path in the condensed
+DAG; with `cycles(ignore)` it is the DAG longest path (undefined if a cycle
+exists).
+
+### 2.3 Effective distance (flux)
+
+```prolog
+:- root_metric(effective_distance/3,
+       [ edge(parent/2, up), boundary(Root, 1.0),
+         combine(scale(0.2)), aggregate(sum),
+         max_depth(10), cycles(bounded), materialize(kernel) ]).
+```
+
+`effective_distance(Root, Node, V)` — the linear difference equation
+`V(Node) = Decay · Σ_{p∈parents} V(p)`, `V(Root) = 1`, truncated at `max_depth`.
+This reproduces the path-sum `Σ_paths f(len)` without path enumeration; see §5
+for the equivalence to the existing `effective_distance_sum` kernel.
+
+## 3. The semiring abstraction
+
+Each `(aggregate, combine)` pair is a semiring `(⊕, ⊗, 0̄, 1̄)`. The node value is
+
+```
+value(Node) = ⊕_{p ∈ parents(Node)}  ( value(p) ⊗ edge_weight )
+value(Root) = 1̄   (the boundary V0 maps to the semiring identity / source)
+```
+
+| Metric    | ⊕ (aggregate) | ⊗ (combine)     | annihilator 0̄ | identity 1̄ |
+|-----------|---------------|-----------------|---------------|-------------|
+| min dist  | `min`         | `+`             | `+inf`        | `0`         |
+| max dist  | `max`         | `+`             | `-inf`        | `0`         |
+| flux      | `+`           | `× decay`       | `0`           | `1`         |
+
+A single lowering template parameterised by the semiring covers all three. New
+metrics (e.g. count-of-paths with `(sum, ×1)`, or PPR with a teleport term) are
+added by naming a new semiring, not by writing a new traversal.
+
+## 4. Evaluation semantics (what any correct lowering must produce)
+
+Independent of algorithm, a conforming implementation must compute, for the
+declared root `R` and every node `N` within `max_depth`:
+
+- the **least fixed point** of the recurrence in §3 for `min`/`max`
+  (shortest/longest under the depth bound), and
+- the **depth-`D` truncation** of the linear fixed point for `sum` flux:
+  `value(N) = Σ_{k=0}^{D} (contributions along walks of exactly k steps)`.
+
+Canonical evaluation order (what the engine actually does): **start at the root**
+and relax outward over the *reverse* of `edge`'s `Direction` (for `up`, walk the
+reverse `child` adjacency `down` from the root). This is why both the relation
+and its direction are required. Nodes unreachable from the root within
+`max_depth` have value `0̄` and are omitted from the materialised table.
+
+Determinism: results must be independent of node visitation order (the semiring
+operations are associative/commutative). This is the same purity contract the
+existing kernels rely on (`purity_certificate`).
+
+## 5. Equivalence to the existing effective-distance kernel
+
+The current kernel computes, per seed, `Σ over discovered hops of (hop+1)^(-n)`.
+With `aggregate(sum)` + `combine(scale(1))` and a post-map, the bucketed-by-length
+DP yields the identical sum:
+
+```
+count[N][L] = Σ_{p∈parents(N)} count[p][L-1],   count[R][0] = 1
+effective_distance_sum(N) = Σ_{L=0}^{max_depth} count[N][L] · (L+1)^(-n)
+```
+
+This is the formal statement that the node-DP is **not an approximation** — it is
+the same quantity, reorganised from "sum over paths" to "sum over path-lengths
+weighted by path-count," which collapses the exponential to `O(edges·max_depth)`.
+
+## 6. Materialised output layout (`materialize(ingest)`)
+
+When materialised at ingest, the metric is stored in the Phase-1 LMDB next to the
+graph (mirrors the scoped-subtree marker convention in
+`build_scoped_subtree_lmdb.py`):
+
+- A sub-db `metric_<name>` mapping `int32_le node → value`:
+  - distances: `int32_le` value;
+  - flux: `f64` little-endian (8-byte) value.
+- A `meta` entry recording the metric's directive tuple + root + max_depth +
+  build provenance, so a consumer can verify the stored table matches the query
+  it intends (same root, same depth, same aggregate).
+
+Query semantics against a materialised table:
+
+- `Name(Root, Node, V)` is a single keyed lookup; absent ⇒ unreachable within
+  depth.
+- **Pruning** falls out: any traversal that needs "can a path through `N` still
+  improve the best?" consults `metric_min_dist_to_root[N]`; if
+  `stored_min + remaining_budget` cannot beat the incumbent, the branch is cut.
+  This is the branch-prune the philosophy doc motivates.
+
+A materialised table is only valid for the root it was built against; a different
+root needs either its own table or the `kernel` mode.
+
+## 7. Recognition contract
+
+The compiler recognises a `root_metric/2` directive and, for each declared
+metric, must:
+
+1. Validate the tuple (known `combine`/`aggregate`/`cycles`; `max_depth ≥ 0`;
+   `edge` predicate exists; boundary arity matches).
+2. Emit (or look up) the semiring for `(aggregate, combine)`.
+3. Choose the lowering by `materialize`: a node-DP kernel (`kernel`) or an
+   ingest-time table builder + lookup stub (`ingest`).
+4. Reuse existing infrastructure where it already fits — the shortest-path
+   kernels (`weighted_shortest_path3`, `astar_shortest_path4`), the demand BFS
+   over `category_child`, the visited-set machinery, and the LMDB fact source.
+
+Inference of the pattern from bare `aggregate_all/3` over a transitive closure
+(without the directive) is **out of scope for v1** and listed as a later
+convenience in the plan.
+
+## 8. Non-goals (v1)
+
+- Multiple simultaneous roots / multi-source metrics (one root per table).
+- Negative edge weights for `min` (would break the shortest-path lowering).
+- Exact (non-truncated) flux on cyclic graphs via linear solve — the
+  depth-bounded truncation is the supported semantics.
+- Automatic inference without the directive (§7).
+
+## See also
+
+`ROOT_ANCHORED_METRICS_PHILOSOPHY.md`, `ROOT_ANCHORED_METRICS_IMPLEMENTATION_PLAN.md`,
+`ALGORITHM_MANIFEST_SPECIFICATION.md`, `KERNEL_SHAPE_RECOGNITION.md`,
+`WAM_DEMAND_FILTER_SPECIFICATION.md`.


### PR DESCRIPTION
  ## Summary
  Design docs for expressing root-anchored graph metrics (min/max distance to
  root, additive effective-distance/flux) as declarative Prolog difference
  equations with a boundary at the root — recognised by the compiler and lowered
  to node-based DP (optionally materialised at ingest), replacing the
  path-enumerating kernel that explodes on dense graphs.

  Motivated by the coherent-enwiki finding: the path-based effective-distance
  kernel is ~24ms/seed (~17h full) on the real content DAG (2.98 edges/node); the
  prior "fast" enwiki numbers were a degenerate artifact of the broken flat-star
  graph.

  ## Docs (docs/design/)
  - ROOT_ANCHORED_METRICS_PHILOSOPHY.md — why now, Prolog-is-the-what, the
    one-recurrence/three-semirings theory, cycles, alternatives + recommendations.
  - ROOT_ANCHORED_METRICS_SPECIFICATION.md — the root_metric/2 directive, three
    instances, semiring table, the exact flux-DP↔kernel equivalence, materialised
    layout + prune.
  - ROOT_ANCHORED_METRICS_IMPLEMENTATION_PLAN.md — phased (min-distance first),
    integration points, validation, recommendations.