### PR TITLE
refactor+feat(wam): shared if-then-else structurer; C++ ITE/negation/once lowering

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_cpp_lowered_emitter.pl
@@ -26,6 +26,7 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(wam_ite_structurer, [structure_ite/2, split_commit/3, is_commit/1]).
 :- use_module(wam_text_parser, [wam_text_to_items/2, wam_classify_constant_token/2]).
 % Inlined escape helper to avoid a circular import with wam_cpp_target.
 % Keeps this module standalone-loadable.
@@ -46,6 +47,44 @@ parse_wam_text(WamText, Instrs) :-
 
 is_label_item(label(_)).
 
+% --- Label-preserving parse + if-then-else structuring ---------------
+% wam_text_to_items already emits label(Name) items; parse_wam_text drops
+% them. For (C -> T ; E) / \+ / once we need the labels, so keep them and
+% fold each block into ite(Cond,Then,Else) via the shared structurer. The
+% previous emitter no-op'd try_me_else/cut_ite/jump/trust_me, dropping the
+% structure and emitting cond+then+else as one flat conjunction.
+
+cpp_base_instrs(WamCode, Instrs) :-
+    ( is_list(WamCode) -> Instrs = WamCode ; parse_wam_text(WamCode, Instrs) ).
+
+%% cpp_structured_clause1(+WamCode, -Structured) is semidet.
+%  Re-parse keeping labels, drop leading indexing/label items, take clause 1
+%  and fold its ITE block(s). Succeeds only for a single-clause predicate
+%  whose every block is consumed.
+cpp_structured_clause1(WamCode, Structured) :-
+    ( is_list(WamCode) -> LInstrs0 = WamCode ; wam_text_to_items(WamCode, LInstrs0) ),
+    strip_leading_index_labels(LInstrs0, LInstrs),
+    \+ ( LInstrs = [try_me_else(_)|_] ),   % not predicate-level multi-clause
+    take_to_proceed(LInstrs, C1L),
+    structure_ite(C1L, Structured),
+    \+ member(try_me_else(_), Structured),
+    \+ member(trust_me, Structured),
+    \+ member(retry_me_else(_), Structured).
+
+strip_leading_index_labels([switch_on_constant(_)|T], R) :- !, strip_leading_index_labels(T, R).
+strip_leading_index_labels([switch_on_constant_a2(_)|T], R) :- !, strip_leading_index_labels(T, R).
+strip_leading_index_labels([switch_on_structure(_)|T], R) :- !, strip_leading_index_labels(T, R).
+strip_leading_index_labels([switch_on_term(_)|T], R) :- !, strip_leading_index_labels(T, R).
+strip_leading_index_labels([label(_)|T], R) :- !, strip_leading_index_labels(T, R).
+strip_leading_index_labels(L, L).
+
+%% cpp_supported_structured(+StructuredInstr)
+cpp_supported_structured(ite(C, T, E)) :- !,
+    forall(member(I, C), cpp_supported_structured(I)),
+    forall(member(I, T), cpp_supported_structured(I)),
+    forall(member(I, E), cpp_supported_structured(I)).
+cpp_supported_structured(I) :- cpp_supported(I).
+
 % =====================================================================
 % Lowerability
 % =====================================================================
@@ -54,15 +93,19 @@ is_label_item(label(_)).
 %  True if the predicate can be lowered to a direct C++ function.
 %  Reason is `deterministic` or `multi_clause_1`.
 wam_cpp_lowerable(PI, WamCode, Reason) :-
-    (   is_list(WamCode) -> Instrs = WamCode
-    ;   atom(WamCode) -> parse_wam_text(WamCode, Instrs)
-    ;   atom_string(WamCode, _), parse_wam_text(WamCode, Instrs)
-    ),
+    cpp_base_instrs(WamCode, Instrs),
     clause1_instrs(Instrs, C1),
-    forall(member(I, C1), cpp_supported(I)),
-    (   is_deterministic_pred_cpp(Instrs)
-    ->  Reason = deterministic
-    ;   Reason = multi_clause_1
+    (   % No internal ITE: existing deterministic / multi-clause path.
+        \+ member(try_me_else(_), C1),
+        forall(member(I, C1), cpp_supported(I))
+    ->  ( is_deterministic_pred_cpp(Instrs) -> Reason = deterministic
+        ; Reason = multi_clause_1 )
+    ;   % Clause-1 has an inner choice point: lower only if it is a pure
+        % (C -> T ; E) / \+ / once block whose pieces are all supported.
+        \+ ( Instrs = [try_me_else(_)|_] ),   % single-clause predicate
+        cpp_structured_clause1(WamCode, Structured),
+        forall(member(I, Structured), cpp_supported_structured(I)),
+        Reason = ite_lowered
     ),
     ( PI = _M:_P/_A -> true ; PI = _/_A2 -> true ; true ).
 
@@ -117,6 +160,8 @@ cpp_supported(call_foreign(_, _)).
 cpp_supported(try_me_else(_)).
 cpp_supported(trust_me).
 cpp_supported(cut_ite).
+cpp_supported(cut(_)).         % Y-level soft cut (ite_use_y_level mode)
+cpp_supported(get_level(_)).   % captures the cut level in the clause prefix
 cpp_supported(jump(_)).
 cpp_supported(begin_aggregate(_, _, _)).
 cpp_supported(end_aggregate(_)).
@@ -163,15 +208,20 @@ cpp_safe_code(_, 0'_).
 lower_predicate_to_cpp(PI, WamCode, Options, CppLines) :-
     ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     cpp_lowered_func_name(Pred/Arity, FuncName),
-    (   is_list(WamCode) -> Instrs = WamCode
-    ;   parse_wam_text(WamCode, Instrs)
-    ),
+    cpp_base_instrs(WamCode, Instrs),
     clause1_instrs(Instrs, C1Instrs),
     (   member(foreign_pred_keys(ForeignPreds0), Options)
     ->  maplist(foreign_key_string, ForeignPreds0, ForeignPreds)
     ;   ForeignPreds = []
     ),
-    with_output_to(string(Body), emit_instrs(C1Instrs, "    ", ForeignPreds)),
+    % Emit the plain clause-1 when it has no inner choice point; otherwise
+    % fold its ITE block(s) into structured form (ite/3) first.
+    (   \+ member(try_me_else(_), C1Instrs)
+    ->  EmitInstrs = C1Instrs
+    ;   cpp_structured_clause1(WamCode, EmitInstrs)
+    ),
+    nb_setval(cpp_ite_ctr, 0),
+    with_output_to(string(Body), emit_instrs(EmitInstrs, "    ", ForeignPreds)),
     format(string(Header),
 '// ~w — lowered from ~w/~w
 bool ~w(WamState* vm) {', [FuncName, Pred, Arity, FuncName]),
@@ -198,6 +248,28 @@ emit_one(execute(PredStr), I, ForeignPreds) :-
     format("~w// execute ~w via foreign kernel~n", [I, PredStr]),
     format("~wreturn vm->step(Instruction::CallForeign(\"~w\", ~w));~n",
            [I, PredStr, Arity]).
+% If-then-else (structured; see wam_ite_structurer). The condition runs in
+% an immediately-invoked lambda so its `return false` means "condition
+% failed"; inside then/else, `return false` returns from the lowered
+% function. cpp's get_reg reflects cell state, so unwinding the trail
+% before the else branch restores any partial bindings the condition made
+% (cell-based, like the existing \=/2 builtin).
+emit_one(ite(Cond, Then, Else), I, ForeignPreds) :- !,
+    nb_getval(cpp_ite_ctr, N0), N is N0 + 1, nb_setval(cpp_ite_ctr, N),
+    string_concat(I, "    ", I2),
+    format("~w{~n", [I]),
+    format("~w    std::size_t _ite_mark~w = vm->trail.size();~n", [I, N]),
+    format("~w    bool _ite_cond~w = [&]() -> bool {~n", [I, N]),
+    emit_instrs(Cond, I2, ForeignPreds),
+    format("~w        return true;~n", [I]),
+    format("~w    }();~n", [I]),
+    format("~w    if (_ite_cond~w) {~n", [I, N]),
+    emit_instrs(Then, I2, ForeignPreds),
+    format("~w    } else {~n", [I]),
+    format("~w        vm->unwind_trail_to(_ite_mark~w);~n", [I, N]),
+    emit_instrs(Else, I2, ForeignPreds),
+    format("~w    }~n", [I]),
+    format("~w}~n", [I]).
 emit_one(Instr, I, _) :-
     emit_one(Instr, I).
 
@@ -293,12 +365,10 @@ emit_one(put_constant(CStr, AiStr), I) :-
 emit_one(put_variable(XnStr, AiStr), I) :-
     cpp_reg_name(XnStr, Xn), cpp_reg_name(AiStr, Ai),
     format("~w// put_variable ~w, ~w~n", [I, XnStr, AiStr]),
-    format("~w{~n", [I]),
-    format("~w    Value v = Value::Unbound(\"_V\" + std::to_string(vm->var_counter++));~n",
-           [I]),
-    format("~w    vm->put_reg(\"~w\", v);~n", [I, Xn]),
-    format("~w    vm->put_reg(\"~w\", v);~n", [I, Ai]),
-    format("~w}~n", [I]).
+    % Both registers must alias ONE fresh cell so the variable has a single
+    % identity (binding via the cell is seen through either register). Two
+    % put_reg copies would create two independent cells.
+    format("~wvm->put_variable_reg(\"~w\", \"~w\");~n", [I, Xn, Ai]).
 
 emit_one(put_value(XnStr, AiStr), I) :-
     cpp_reg_name(XnStr, Xn), cpp_reg_name(AiStr, Ai),
@@ -398,6 +468,8 @@ emit_one(call_foreign(PredStr, ArStr), I) :-
 emit_one(try_me_else(_), _) :- !.
 emit_one(trust_me, _) :- !.
 emit_one(cut_ite, _) :- !.
+emit_one(cut(_), _) :- !.        % commit consumed by the structurer
+emit_one(get_level(_), _) :- !.  % cut-level capture: no-op in the lowered if/else
 emit_one(jump(_), _) :- !.
 
 % Aggregate ops delegate to vm->step() (the interpreter handles the

--- a/src/unifyweaver/targets/wam_cpp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_cpp_lowered_emitter.pl
@@ -332,7 +332,9 @@ emit_one(get_nil(AiStr), I) :-
 emit_one(get_variable(XnStr, AiStr), I) :-
     cpp_reg_name(XnStr, Xn), cpp_reg_name(AiStr, Ai),
     format("~w// get_variable ~w, ~w~n", [I, XnStr, AiStr]),
-    format("~wvm->put_reg(\"~w\", vm->get_reg(\"~w\"));~n", [I, Xn, Ai]).
+    % Repoint Xn to share Ai's cell (matches interpreter GetVariable);
+    % put_reg would mutate Xn's cell and corrupt any register aliasing it.
+    format("~wvm->set_cell(\"~w\", vm->get_cell(\"~w\"));~n", [I, Xn, Ai]).
 
 emit_one(get_value(XnStr, AiStr), I) :-
     cpp_reg_name(XnStr, Xn), cpp_reg_name(AiStr, Ai),
@@ -360,7 +362,9 @@ emit_one(put_constant(CStr, AiStr), I) :-
     cpp_reg_name(AiStr, Ai),
     cpp_val_literal(CStr, CppVal),
     format("~w// put_constant ~w, ~w~n", [I, CStr, AiStr]),
-    format("~wvm->put_reg(\"~w\", ~w);~n", [I, Ai, CppVal]).
+    % Repoint Ai to a fresh cell (matches interpreter PutConstant); mutating
+    % would corrupt any register aliasing Ai (e.g. via a prior put_variable).
+    format("~wvm->assign_reg(\"~w\", ~w);~n", [I, Ai, CppVal]).
 
 emit_one(put_variable(XnStr, AiStr), I) :-
     cpp_reg_name(XnStr, Xn), cpp_reg_name(AiStr, Ai),
@@ -373,7 +377,8 @@ emit_one(put_variable(XnStr, AiStr), I) :-
 emit_one(put_value(XnStr, AiStr), I) :-
     cpp_reg_name(XnStr, Xn), cpp_reg_name(AiStr, Ai),
     format("~w// put_value ~w, ~w~n", [I, XnStr, AiStr]),
-    format("~wvm->put_reg(\"~w\", vm->get_reg(\"~w\"));~n", [I, Ai, Xn]).
+    % Repoint Ai to share Xn's cell (matches interpreter PutValue).
+    format("~wvm->set_cell(\"~w\", vm->get_cell(\"~w\"));~n", [I, Ai, Xn]).
 
 emit_one(put_structure(FStr, AiStr), I) :-
     cpp_reg_name(AiStr, Ai),

--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -3708,6 +3708,11 @@ struct WamState {
     void    put_reg(const std::string& name, Value v);
     CellPtr get_cell(const std::string& name);
     void    set_cell(const std::string& name, CellPtr c);
+    // Create one fresh unbound variable cell and alias it into BOTH
+    // registers, so they share identity (binding one binds the other).
+    // Used by lowered put_variable: copying a Value into two registers
+    // would give two independent cells, losing variable identity.
+    void    put_variable_reg(const std::string& a, const std::string& b);
 
     // Deref through Unbound chains until a concrete value (or a terminal
     // unbound cell) is reached. Returns by value (snapshot).
@@ -3716,6 +3721,10 @@ struct WamState {
     // bind_cell mutates *cell, recording the previous content on the trail.
     void    bind_cell(CellPtr cell, Value v);
     void    trail_binding(const std::string& name); // legacy reg-name trail
+    // Undo all bindings recorded since `mark` (trail.size() at the mark).
+    // Used by lowered if-then-else when the condition fails, before the
+    // else branch runs.
+    void    unwind_trail_to(std::size_t mark);
 
     // Unification: takes Cell pointers so binding works correctly.
     bool    unify_cells(CellPtr a, CellPtr b);
@@ -4096,6 +4105,12 @@ void WamState::set_cell(const std::string& name, CellPtr c) {
     regs[name] = std::move(c);
 }
 
+void WamState::put_variable_reg(const std::string& a, const std::string& b) {
+    CellPtr c = make_cell(Value::Unbound("_V" + std::to_string(var_counter++)));
+    set_cell(a, c);
+    set_cell(b, c);
+}
+
 Value WamState::get_reg(const std::string& name) const {
     if (is_y_reg(name)) {
         if (env_stack.empty()) return Value{};
@@ -4130,6 +4145,14 @@ void WamState::trail_binding(const std::string& name) {
     e.cell = it->second;
     e.prev = *it->second;
     trail.push_back(std::move(e));
+}
+
+void WamState::unwind_trail_to(std::size_t mark) {
+    while (trail.size() > mark) {
+        TrailEntry t = std::move(trail.back());
+        trail.pop_back();
+        *t.cell = std::move(t.prev);
+    }
 }
 
 void WamState::bind_cell(CellPtr cell, Value v) {

--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -3713,6 +3713,11 @@ struct WamState {
     // Used by lowered put_variable: copying a Value into two registers
     // would give two independent cells, losing variable identity.
     void    put_variable_reg(const std::string& a, const std::string& b);
+    // Assign a register to a fresh cell holding v (repoint, do NOT mutate
+    // the existing cell — any register aliasing this one must not see the
+    // new value). Mirrors the interpreter PutConstant. Used by lowered
+    // put_constant.
+    void    assign_reg(const std::string& name, Value v);
 
     // Deref through Unbound chains until a concrete value (or a terminal
     // unbound cell) is reached. Returns by value (snapshot).
@@ -4109,6 +4114,10 @@ void WamState::put_variable_reg(const std::string& a, const std::string& b) {
     CellPtr c = make_cell(Value::Unbound("_V" + std::to_string(var_counter++)));
     set_cell(a, c);
     set_cell(b, c);
+}
+
+void WamState::assign_reg(const std::string& name, Value v) {
+    set_cell(name, make_cell(std::move(v)));
 }
 
 Value WamState::get_reg(const std::string& name) const {

--- a/src/unifyweaver/targets/wam_go_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_go_lowered_emitter.pl
@@ -23,6 +23,7 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(wam_ite_structurer, [structure_ite/2, split_commit/3, is_commit/1]).
 :- use_module(wam_text_parser, [wam_classify_constant_token/2]).
 :- use_module(wam_go_target, [
     escape_go_string/2,
@@ -98,10 +99,10 @@ instr_from_parts(["cut_ite"], cut_ite).
 %  else branch, silently miscompiling the clause.
 %
 %  parse_wam_text_labeled keeps label(Name) markers (and cut_ite) so
-%  structure_ite_go can fold each block into an ite(Cond,Then,Else) term
+%  structure_ite can fold each block into an ite(Cond,Then,Else) term
 %  using the real else/cont labels. The continuation is then emitted as a
 %  sibling of the if/else (not nested in the else), fixing sequential and
-%  nested blocks. Mirrors structure_ite_scala.
+%  nested blocks. Mirrors the shared wam_ite_structurer.
 
 parse_wam_text_labeled(WamText, Instrs) :-
     atom_string(WamText, S),
@@ -126,40 +127,8 @@ parse_lines_labeled([Line|Rest], Instrs) :-
         )
     ).
 
-%% structure_ite_go(+Flat, -Structured) is semidet.
-%  Folds each well-formed ITE block into ite(Cond,Then,Else); drops the
-%  structural markers (try_me_else/trust_me/cut_ite/jump/label). Fails if a
-%  try_me_else cannot be matched to a clean block.
-structure_ite_go([], []).
-structure_ite_go([try_me_else(LE)|Rest0], [ite(CondS,ThenS,ElseS)|Out]) :-
-    !,
-    append(ThenWithJump, [label(LE), trust_me | ElseAndRest], Rest0),
-    \+ member(label(LE), ThenWithJump),          % first (matching) else label
-    append(ThenPath, [jump(LC)], ThenWithJump),  % then-path ends in its jump
-    append(ElsePath, [label(LC) | AfterCont], ElseAndRest),
-    \+ member(label(LC), ElsePath),
-    split_commit_go(ThenPath, Cond, Then),
-    structure_ite_go(Cond, CondS),
-    structure_ite_go(Then, ThenS),
-    structure_ite_go(ElsePath, ElseS),
-    structure_ite_go(AfterCont, Out).
-structure_ite_go([label(_)|Rest], Out) :- !,
-    structure_ite_go(Rest, Out).
-structure_ite_go([I|Rest], [I|Out]) :-
-    structure_ite_go(Rest, Out).
-
-%% split_commit_go(+ThenPath, -Cond, -Then)
-%  Splits a then-path at its commit instruction (cut_ite for ->, the !/0
-%  builtin for \+). The commit itself is dropped.
-split_commit_go(Path, Cond, Then) :-
-    append(Cond, [Commit|Then], Path),
-    is_commit_go(Commit),
-    \+ ( member(C0, Cond), is_commit_go(C0) ),   % split at the first commit
-    !.
-
-is_commit_go(cut_ite).
-is_commit_go(builtin_call("!/0", _)).
-is_commit_go(builtin_call('!/0', _)).
+% structure_ite/2, split_commit/3 and is_commit/1 are shared across the
+% lowered backends — see wam_ite_structurer.pl.
 
 %% go_base_instrs(+WamCode, -Instrs)  — base (label-stripped) parse or list.
 go_base_instrs(WamCode, Instrs) :-
@@ -173,7 +142,7 @@ go_structured_clause1(WamCode, Structured) :-
     ( is_list(WamCode) -> LInstrs = WamCode ; parse_wam_text_labeled(WamCode, LInstrs) ),
     \+ ( LInstrs = [try_me_else(_)|_] ),   % not predicate-level multi-clause
     take_to_proceed(LInstrs, C1L),
-    structure_ite_go(C1L, Structured),
+    structure_ite(C1L, Structured),
     \+ member(try_me_else(_), Structured),  % every block consumed
     \+ member(trust_me, Structured),
     \+ member(retry_me_else(_), Structured).
@@ -332,7 +301,7 @@ emit_instrs([Instr|Rest], Ind) :-
 
 %% has_internal_ite_pattern(+Instrs)
 %  True if the (clause-1 of the) given instruction stream contains a
-%  well-formed if-then-else block, i.e. structure_ite_go folds out at
+%  well-formed if-then-else block, i.e. structure_ite folds out at
 %  least one ite/3 term. Used by tests to assert that ITE lowering fires.
 has_internal_ite_pattern(Instrs) :-
     catch(go_structured_clause1(Instrs, Structured), _, fail),

--- a/src/unifyweaver/targets/wam_ite_structurer.pl
+++ b/src/unifyweaver/targets/wam_ite_structurer.pl
@@ -1,0 +1,74 @@
+% wam_ite_structurer.pl
+%
+% Shared if-then-else / negation / once structurer for the WAM "lowered"
+% emitters (Scala, Go, Rust, C++, …).
+%
+% The WAM compiler lowers ( Cond -> Then ; Else ), \+ Goal and once/1 into
+% a choice-point block:
+%
+%     try_me_else(LElse)  <cond>  <commit>  <then>  jump(LCont)
+%     LElse: trust_me     <else>
+%     LCont: <continuation>
+%
+% where <commit> is cut_ite (for ->) or the !/0 builtin (for \+). The base
+% per-target parsers drop label lines, which erases the LElse/LCont
+% boundaries; each lowered emitter therefore parses a *label-preserving*
+% instruction stream (keeping label(Name) markers) and calls structure_ite/2
+% to fold every such block into an ite(Cond,Then,Else) term, emitting the
+% continuation as a sibling of the block (not nested in the else).
+%
+% This logic is identical across targets, so it lives here once. Each target
+% keeps its own label-preserving parser (coupled to its instr_from_parts/2)
+% and its own emit_one(ite(...)) rendering; only the structural fold is
+% shared. Previously this was duplicated verbatim as structure_ite_scala/
+% _go/_rust (see git history).
+
+:- module(wam_ite_structurer, [
+    structure_ite/2,    % +FlatLabeledInstrs, -StructuredInstrs
+    split_commit/3,     % +ThenPath, -Cond, -Then
+    is_commit/1         % +Instr
+]).
+
+:- use_module(library(lists)).
+
+%% structure_ite(+Flat, -Structured) is semidet.
+%  Folds each well-formed ITE block into ite(Cond,Then,Else); drops the
+%  structural markers (try_me_else/trust_me/cut_ite/jump/label). Cond, Then
+%  and Else are themselves structured (nested blocks recurse), and the
+%  block's continuation is emitted as a following sibling. Fails if a
+%  try_me_else cannot be matched to a clean block, so callers can decline
+%  and fall back.
+structure_ite([], []).
+structure_ite([try_me_else(LE)|Rest0], [ite(CondS,ThenS,ElseS)|Out]) :-
+    !,
+    append(ThenWithJump, [label(LE), trust_me | ElseAndRest], Rest0),
+    \+ member(label(LE), ThenWithJump),          % first (matching) else label
+    append(ThenPath, [jump(LC)], ThenWithJump),  % then-path ends in its jump
+    append(ElsePath, [label(LC) | AfterCont], ElseAndRest),
+    \+ member(label(LC), ElsePath),
+    split_commit(ThenPath, Cond, Then),
+    structure_ite(Cond, CondS),
+    structure_ite(Then, ThenS),
+    structure_ite(ElsePath, ElseS),
+    structure_ite(AfterCont, Out).
+structure_ite([label(_)|Rest], Out) :- !,
+    structure_ite(Rest, Out).
+structure_ite([I|Rest], [I|Out]) :-
+    structure_ite(Rest, Out).
+
+%% split_commit(+ThenPath, -Cond, -Then) is semidet.
+%  Splits a then-path at its commit instruction (cut_ite for ->, the !/0
+%  builtin for \+). The commit itself is dropped.
+split_commit(Path, Cond, Then) :-
+    append(Cond, [Commit|Then], Path),
+    is_commit(Commit),
+    \+ ( member(C0, Cond), is_commit(C0) ),   % split at the first commit
+    !.
+
+%% is_commit(+Instr)
+%  The commit that separates a condition from its then-branch: cut_ite for
+%  if-then-else, the !/0 builtin for negation. Builtin arity is carried as a
+%  string by some targets and a number by others, hence both literals.
+is_commit(cut_ite).
+is_commit(builtin_call("!/0", _)).
+is_commit(builtin_call('!/0', _)).

--- a/src/unifyweaver/targets/wam_ite_structurer.pl
+++ b/src/unifyweaver/targets/wam_ite_structurer.pl
@@ -66,9 +66,15 @@ split_commit(Path, Cond, Then) :-
     !.
 
 %% is_commit(+Instr)
-%  The commit that separates a condition from its then-branch: cut_ite for
-%  if-then-else, the !/0 builtin for negation. Builtin arity is carried as a
-%  string by some targets and a number by others, hence both literals.
+%  The commit that separates a condition from its then-branch:
+%    - cut_ite      : the soft-cut marker (default ITE compilation), or
+%    - cut(Yn)      : the Y-level soft cut emitted under ite_use_y_level(true)
+%                     (the C++ target's mode; get_level Yn captures the level
+%                     in the clause prefix, cut Yn commits to it), or
+%    - the !/0 builtin : negation's commit.
+%  Builtin arity is carried as a string by some targets and a number by
+%  others, hence both literals.
 is_commit(cut_ite).
+is_commit(cut(_)).
 is_commit(builtin_call("!/0", _)).
 is_commit(builtin_call('!/0', _)).

--- a/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
@@ -22,6 +22,7 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(wam_ite_structurer, [structure_ite/2, split_commit/3, is_commit/1]).
 :- use_module(wam_rust_target, [escape_rust_string/2]).
 :- use_module(wam_text_parser, [wam_classify_constant_token/2]).
 
@@ -94,10 +95,10 @@ instr_from_parts(["cut_ite"], cut_ite).
 %  lowered function always failed.
 %
 %  parse_wam_text_labeled keeps label(Name) markers (and cut_ite) so
-%  structure_ite_rust can fold each block into an ite(Cond,Then,Else) term.
+%  structure_ite can fold each block into an ite(Cond,Then,Else) term.
 %  Rust's get_reg derefs through the binding table, so trail save/undo
 %  alone restores a failed condition's bindings — no register snapshot is
-%  needed (unlike the Go backend). Mirrors structure_ite_scala.
+%  needed (unlike the Go backend). Mirrors the shared wam_ite_structurer.
 
 parse_wam_text_labeled(WamText, Instrs) :-
     atom_string(WamText, S),
@@ -122,35 +123,8 @@ parse_lines_labeled([Line|Rest], Instrs) :-
         )
     ).
 
-%% structure_ite_rust(+Flat, -Structured) is semidet.
-structure_ite_rust([], []).
-structure_ite_rust([try_me_else(LE)|Rest0], [ite(CondS,ThenS,ElseS)|Out]) :-
-    !,
-    append(ThenWithJump, [label(LE), trust_me | ElseAndRest], Rest0),
-    \+ member(label(LE), ThenWithJump),
-    append(ThenPath, [jump(LC)], ThenWithJump),
-    append(ElsePath, [label(LC) | AfterCont], ElseAndRest),
-    \+ member(label(LC), ElsePath),
-    split_commit_rust(ThenPath, Cond, Then),
-    structure_ite_rust(Cond, CondS),
-    structure_ite_rust(Then, ThenS),
-    structure_ite_rust(ElsePath, ElseS),
-    structure_ite_rust(AfterCont, Out).
-structure_ite_rust([label(_)|Rest], Out) :- !,
-    structure_ite_rust(Rest, Out).
-structure_ite_rust([I|Rest], [I|Out]) :-
-    structure_ite_rust(Rest, Out).
-
-%% split_commit_rust(+ThenPath, -Cond, -Then)  — split at cut_ite (->) or !/0 (\+).
-split_commit_rust(Path, Cond, Then) :-
-    append(Cond, [Commit|Then], Path),
-    is_commit_rust(Commit),
-    \+ ( member(C0, Cond), is_commit_rust(C0) ),
-    !.
-
-is_commit_rust(cut_ite).
-is_commit_rust(builtin_call("!/0", _)).
-is_commit_rust(builtin_call('!/0', _)).
+% structure_ite/2, split_commit/3 and is_commit/1 are shared across the
+% lowered backends — see wam_ite_structurer.pl.
 
 %% rust_base_instrs(+WamCode, -Instrs)  — base (label-stripped) parse or list.
 rust_base_instrs(WamCode, Instrs) :-
@@ -161,7 +135,7 @@ rust_structured_clause1(WamCode, Structured) :-
     ( is_list(WamCode) -> LInstrs = WamCode ; parse_wam_text_labeled(WamCode, LInstrs) ),
     \+ ( LInstrs = [try_me_else(_)|_] ),   % not predicate-level multi-clause
     take_to_proceed(LInstrs, C1L),
-    structure_ite_rust(C1L, Structured),
+    structure_ite(C1L, Structured),
     \+ member(try_me_else(_), Structured),
     \+ member(trust_me, Structured),
     \+ member(retry_me_else(_), Structured).
@@ -319,7 +293,7 @@ emit_one(execute(PredStr), I, ForeignPreds) :-
     format("~w// execute ~w via foreign kernel~n", [I, PredStr]),
     format("~wreturn vm.step(&Instruction::CallForeign(\"~w\".to_string(), ~w));~n",
            [I, PredStr, Arity]).
-% --- If-then-else (structured; see structure_ite_rust) ---
+% --- If-then-else (structured; see wam_ite_structurer) ---
 % The condition runs in an immediately-invoked closure so its `return
 % false` means "condition failed"; inside then/else, `return false`
 % returns from the lowered function. Rust's get_reg derefs through the

--- a/src/unifyweaver/targets/wam_scala_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_scala_lowered_emitter.pl
@@ -54,6 +54,7 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(wam_ite_structurer, [structure_ite/2, split_commit/3, is_commit/1]).
 :- use_module('../targets/wam_scala_target', [
        scala_lowered_constant_term/2,
        scala_lowered_functor_arity/3,
@@ -192,41 +193,8 @@ parse_lines_labeled_scala([Line|Rest], Instrs) :-
     ;   parse_lines_labeled_scala(Rest, Instrs)   % unrecognised — skip
     ).
 
-%% structure_ite_scala(+Flat, -Structured) is semidet.
-%  Folds every well-formed ITE block into ite(Cond,Then,Else); drops the
-%  structural markers (try_me_else/trust_me/cut_ite/jump/label). Fails if a
-%  try_me_else cannot be matched to a clean block (caller then declines to
-%  lower, falling back to the interpreter).
-structure_ite_scala([], []).
-structure_ite_scala([try_me_else(LE)|Rest0], [ite(CondS,ThenS,ElseS)|Out]) :-
-    !,
-    append(ThenWithJump, [label(LE), trust_me | ElseAndRest], Rest0),
-    \+ member(label(LE), ThenWithJump),          % first (matching) else label
-    append(ThenPath, [jump(LC)], ThenWithJump),  % then-path ends in its jump
-    append(ElsePath, [label(LC) | AfterCont], ElseAndRest),
-    \+ member(label(LC), ElsePath),
-    split_commit_scala(ThenPath, Cond, Then),
-    structure_ite_scala(Cond, CondS),
-    structure_ite_scala(Then, ThenS),
-    structure_ite_scala(ElsePath, ElseS),
-    structure_ite_scala(AfterCont, Out).
-structure_ite_scala([label(_)|Rest], Out) :- !,
-    structure_ite_scala(Rest, Out).
-structure_ite_scala([I|Rest], [I|Out]) :-
-    structure_ite_scala(Rest, Out).
-
-%% split_commit_scala(+ThenPath, -Cond, -Then)
-%  Splits a then-path at its commit instruction (cut_ite for ->, the !/0
-%  builtin for \+). The commit itself is dropped.
-split_commit_scala(Path, Cond, Then) :-
-    append(Cond, [Commit|Then], Path),
-    is_commit_scala(Commit),
-    \+ ( member(C0, Cond), is_commit_scala(C0) ),   % split at the first commit
-    !.
-
-is_commit_scala(cut_ite).
-is_commit_scala(builtin_call("!/0", _)).
-is_commit_scala(builtin_call('!/0', _)).
+% structure_ite/2, split_commit/3 and is_commit/1 are shared across the
+% lowered backends — see wam_ite_structurer.pl.
 
 %% structured_supported_scala(+StructuredInstrs)
 %  All leaf instructions supported, and every ite() fully structured.
@@ -251,7 +219,7 @@ structured_clause1_scala(WamCode, Structured) :-
     parse_wam_text_labeled_scala(WamCode, LInstrs),
     \+ ( LInstrs = [try_me_else(_)|_] ),   % not predicate-level multi-clause
     take_to_proceed_scala(LInstrs, C1L),
-    structure_ite_scala(C1L, Structured),
+    structure_ite(C1L, Structured),
     \+ member(try_me_else(_), Structured),  % every block consumed
     \+ member(trust_me, Structured),
     \+ member(retry_me_else(_), Structured).
@@ -454,7 +422,7 @@ emit_one_scala(proceed, I, _) :-
 emit_one_scala(fail, I, _) :-
     format("~wreturn false~n", [I]).
 
-% --- If-then-else (structured; see structure_ite_scala) ---
+% --- If-then-else (structured; see wam_ite_structurer) ---
 % The condition runs in its own boolean helper with a trail mark, so a
 % failed condition undoes its bindings before the else branch. `return
 % false` inside the helper means "condition failed"; inside then/else it

--- a/tests/test_wam_cpp_lowered_ite_exec.pl
+++ b/tests/test_wam_cpp_lowered_ite_exec.pl
@@ -1,0 +1,115 @@
+% test_wam_cpp_lowered_ite_exec.pl
+%
+% End-to-end execution test for C++ if-then-else / negation / once lowering
+% (emit_mode(functions)).
+%
+% Generates a WAM C++ project with the lowered emitter enabled, compiles it
+% with the host C++17 compiler, and runs a harness that calls each lowered
+% function and asserts the boolean result. Counterpart to the Go and Rust
+% tests. Pins:
+%
+%   * sequential ITEs   — cseqite(10,pos,small) must be false;
+%   * nested ITEs       — cnestite/2;
+%   * negation (\+)     — cneg/1 (commits with !/0);
+%   * binding condition — cundoite/2, whose condition binds a fresh var then
+%                         fails; needs the trail unwind AND shared variable
+%                         identity (put_variable aliasing one cell).
+%
+% Before this fix the lowered emitter no-op'd try_me_else/cut_ite/jump/
+% trust_me, dropping the structure entirely. C++ also compiles ITE with
+% ite_use_y_level(true), so the commit is `cut Yn` (not cut_ite) — handled
+% by the shared structurer's is_commit/1. Skipped when no C++ compiler.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_cpp_target').
+
+:- dynamic user:cite/2.
+:- dynamic user:cneg/1.
+:- dynamic user:cseqite/3.
+:- dynamic user:cnestite/2.
+:- dynamic user:cundoite/2.
+
+user:cite(X, Y)       :- ( X > 0 -> Y = pos ; Y = nonpos ).
+user:cneg(X)          :- \+ X > 0.
+user:cseqite(X, Y, Z) :- ( X > 0 -> Y = pos ; Y = nonpos ),
+                         ( X > 5 -> Z = big ; Z = small ).
+user:cnestite(X, Y)   :- ( X > 0 -> ( X > 10 -> Y = big ; Y = small ) ; Y = neg ).
+user:cundoite(X, R)   :- ( (Y = a, Y = b) -> R = then ; R = els ), X = Y.
+
+cpp_compiler(CC) :-
+    ( cc_ok('g++') -> CC = 'g++'
+    ; cc_ok('clang++') -> CC = 'clang++'
+    ).
+cc_ok(CC) :-
+    catch(( process_create(path(CC), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_cpp_lowered_ite_exec, [condition(cpp_compiler(_))]).
+
+test(ite_exec_parity) :-
+    cpp_compiler(CC),
+    Dir = 'output/test_wam_cpp_ite_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    % 1. Generate the WAM C++ project with the lowered emitter enabled.
+    write_wam_cpp_project(
+        [user:cite/2, user:cneg/1, user:cseqite/3, user:cnestite/2, user:cundoite/2],
+        [module_name('itecpp'), wam_fallback(true), emit_mode(functions)], Dir),
+    % 2. Test harness alongside the generated sources.
+    atomic_list_concat([Dir, '/cpp/test_ite.cpp'], TestPath),
+    cpp_test_source(Src),
+    setup_call_cleanup(open(TestPath, write, S), write(S, Src), close(S)),
+    % 3. Compile + run.
+    atomic_list_concat([Dir, '/cpp'], CppDir),
+    format(atom(Cmd),
+        '~w -std=c++17 -O0 ~w/test_ite.cpp ~w/generated_program.cpp ~w/wam_runtime.cpp -o ~w/ite_test 2>&1 && ~w/ite_test',
+        [CC, CppDir, CppDir, CppDir, CppDir, CppDir]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 17 PASS")
+    ->  true
+    ;   format(user_error, "~n[cpp ite test output]~n~w~n", [OutStr]),
+        throw(cpp_test_failed(Status))
+    ).
+
+:- end_tests(wam_cpp_lowered_ite_exec).
+
+% Calls each lowered function with the query args preloaded into the
+% A-registers and asserts the boolean outcome. cseqite(10,pos,small)=false
+% and cundoite(c,els)=true are the discriminating cases.
+cpp_test_source(
+"#include \"wam_runtime.h\"
+#include <iostream>
+bool lowered_cite_2(WamState*); bool lowered_cneg_1(WamState*); bool lowered_cseqite_3(WamState*);
+bool lowered_cnestite_2(WamState*); bool lowered_cundoite_2(WamState*);
+static int failures = 0;
+static void chk(const char* n, bool g, bool w) {
+    if (g != w) { std::cerr << \"FAIL \" << n << \": got \" << g << \" want \" << w << \"\\n\"; failures++; }
+}
+static Value I(long long n) { return Value::Integer(n); }
+static Value A(const char* s) { return Value::Atom(s); }
+int main() {
+    { WamState v; v.put_reg(\"A1\", I(5));  v.put_reg(\"A2\", A(\"pos\"));    chk(\"cite(5,pos)\",    lowered_cite_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", I(5));  v.put_reg(\"A2\", A(\"nonpos\")); chk(\"cite(5,nonpos)\", lowered_cite_2(&v), false); }
+    { WamState v; v.put_reg(\"A1\", I(-1)); v.put_reg(\"A2\", A(\"nonpos\")); chk(\"cite(-1,nonpos)\",lowered_cite_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", I(-1)); v.put_reg(\"A2\", A(\"pos\"));    chk(\"cite(-1,pos)\",   lowered_cite_2(&v), false); }
+    { WamState v; v.put_reg(\"A1\", I(5));  chk(\"cneg(5)\",  lowered_cneg_1(&v), false); }
+    { WamState v; v.put_reg(\"A1\", I(-1)); chk(\"cneg(-1)\", lowered_cneg_1(&v), true); }
+    { WamState v; v.put_reg(\"A1\", I(0));  chk(\"cneg(0)\",  lowered_cneg_1(&v), true); }
+    { WamState v; v.put_reg(\"A1\", I(10)); v.put_reg(\"A2\", A(\"pos\")); v.put_reg(\"A3\", A(\"big\"));   chk(\"cseqite(10,pos,big)\",   lowered_cseqite_3(&v), true); }
+    { WamState v; v.put_reg(\"A1\", I(10)); v.put_reg(\"A2\", A(\"pos\")); v.put_reg(\"A3\", A(\"small\")); chk(\"cseqite(10,pos,small)\", lowered_cseqite_3(&v), false); }
+    { WamState v; v.put_reg(\"A1\", I(3));  v.put_reg(\"A2\", A(\"pos\")); v.put_reg(\"A3\", A(\"small\")); chk(\"cseqite(3,pos,small)\",  lowered_cseqite_3(&v), true); }
+    { WamState v; v.put_reg(\"A1\", I(-1)); v.put_reg(\"A2\", A(\"nonpos\")); v.put_reg(\"A3\", A(\"small\")); chk(\"cseqite(-1,nonpos,small)\", lowered_cseqite_3(&v), true); }
+    { WamState v; v.put_reg(\"A1\", I(20)); v.put_reg(\"A2\", A(\"big\"));   chk(\"cnestite(20,big)\",   lowered_cnestite_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", I(5));  v.put_reg(\"A2\", A(\"small\")); chk(\"cnestite(5,small)\",  lowered_cnestite_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", I(-1)); v.put_reg(\"A2\", A(\"neg\"));   chk(\"cnestite(-1,neg)\",   lowered_cnestite_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", I(20)); v.put_reg(\"A2\", A(\"small\")); chk(\"cnestite(20,small)\", lowered_cnestite_2(&v), false); }
+    { WamState v; v.put_reg(\"A1\", A(\"c\")); v.put_reg(\"A2\", A(\"els\"));  chk(\"cundoite(c,els)\",  lowered_cundoite_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"c\")); v.put_reg(\"A2\", A(\"then\")); chk(\"cundoite(c,then)\", lowered_cundoite_2(&v), false); }
+    if (failures == 0) { std::cout << \"ALL 17 PASS\\n\"; return 0; }
+    std::cerr << failures << \" FAILURES\\n\"; return 1;
+}
+").


### PR DESCRIPTION
Continues the WAM if-then-else parity sweep (after Scala #2793, Go/Rust #2796). Two parts:

## 1. Extract the shared structurer (refactor, no behavior change)

`structure_ite/2`, `split_commit/3` and `is_commit/1` were duplicated verbatim across the three lowered emitters. Extracted into **`wam_ite_structurer.pl`**; Scala/Go/Rust import it. Each target keeps its own label-preserving parser and `emit_one(ite(...))` rendering — only the target-agnostic fold is shared. Verified green: Scala lowered-emitter (23) + classic-programs (7); Go phase3 + ite-exec; Rust ite-exec.

## 2. C++ ITE / negation / once lowering (was a no-op)

The C++ lowered emitter no-op'd `try_me_else`/`cut_ite`/`jump`/`trust_me`, dropping the structure → wrong results. Wired C++ into the shared structurer (labels come free from `wam_text_to_items`), emitting native `if/else` with the condition in an IIFE-lambda. Details:

- **`cut Yn` commit.** C++ compiles ITE with `ite_use_y_level(true)`, so the commit is `cut Yn` (with `get_level Yn` in the prefix), not `cut_ite`. Taught the shared `is_commit/1` about `cut(_)`; prefix `get_level`/`cut` are no-ops in the lowered if/else.
- **`unwind_trail_to`** for the else branch (same cell-trail loop `\=/2` uses).
- **Variable identity.** Lowered `put_variable` copied a `Value` into two registers → two independent cells, losing identity. Added `put_variable_reg(a,b)` (aliases ONE cell into both), and made the lowered register *assignments* repoint instead of mutate (`set_cell`/`assign_reg`), matching the interpreter — otherwise reassigning an aliased register corrupts the variable.

### Verification — this is a net improvement to the C++ backend

End-to-end with g++ (new gated `test_wam_cpp_lowered_ite_exec.pl`): **17/17** — arithmetic-guard ITE, negation, sequential (`cseqite(10,pos,small)=false`), nested, and a binding condition with trail undo (`cundoite(c,els)=true`).

Full `test_wam_cpp_generator` suite, **main vs this branch**:
- `main`: **373 passed / 13 failed**
- this branch: **383 passed / 3 failed**

The fix to variable identity **repaired 10 pre-existing failures** (9 `sub_atom/5` cases + `forall_some_fail`, all broken by the old two-cell `put_variable`). The **3 remaining failures** (`cpp_e2e_bagof_inlined_groups_by_witness`, `cpp_e2e_setof_inlined_groups_sorted`, `cpp_e2e_lists_cleanup`) are a **strict subset of main's failures** — pre-existing and unrelated to this work (worth a separate look later).

## Remaining backends

Still using heuristic / no ITE handling: **haskell** (label-map heuristic — needs verification), **fsharp/clojure/llvm** (ITE-aware, no structurer), **elixir/lua/python/r** (none). All now cheap to do via the shared structurer.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw