### PR TITLE
Root metrics Phase 0: root_metric/2 directive + recognition

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,10 @@ jobs:
         run: |
           swipl -g "asserta(user:file_search_path(library, 'src/unifyweaver/core')), asserta(user:file_search_path(library, 'tests/core')), use_module(library(test_policy)), test_policy, halt."
 
+      - name: Run root-metric directive tests
+        run: |
+          swipl -q -g run_tests -t halt tests/core/test_root_metric.pl
+
       - name: Run C# query target tests (codegen only)
         run: |
           SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g "test_csharp_query_target:test_csharp_query_target" -t halt

--- a/docs/design/ROOT_ANCHORED_METRICS_SPECIFICATION.md
+++ b/docs/design/ROOT_ANCHORED_METRICS_SPECIFICATION.md
@@ -47,10 +47,35 @@ them literally.
 - **`max_depth(D)`** — contributions beyond `D` hops from the root are not
   counted. Bounds cost and makes cyclic graphs well-defined.
 - **`cycles(Policy)`** — `bounded` (default; rely on `max_depth`), `scc`
-  (condense strongly-connected components first), or `ignore` (assume acyclic;
-  undefined behaviour on a cycle — only for known DAGs).
+  (condense strongly-connected components first), `ignore` (assume acyclic;
+  undefined behaviour on a cycle — only for known DAGs), or `visited`
+  (per-path visited set: never revisit a node *on the current path* — the
+  simple-path semantics; see §4.1). `bounded` and `visited` both terminate on
+  cyclic graphs but for `max`/`sum` they compute **different quantities**
+  (walks vs simple paths); for `min` they agree.
 - **`materialize(Where)`** — `kernel` (default; recompute per run as a node-DP)
   or `ingest` (precompute once, store `node → value`; see §6).
+
+### Presets and the default metric
+
+So a user need not spell out the algorithm fields, a directive may carry
+`preset(Name)`, which fills `combine`/`aggregate`/`max_depth`; any explicit
+option of the same kind overrides the preset. The user then declares only the
+graph-specific `edge` + `boundary`:
+
+```prolog
+:- root_metric(min_dist_to_root/3, [ edge(parent/2, up), boundary(Root, 0), preset(min_dist) ]).
+```
+
+Built-in presets: `min_dist` → `(succ, min)`, `max_dist` → `(succ, max)`,
+`effective` → `(scale(0.2), sum)`, each with `max_depth(10)`. **`min_dist` is the
+default metric** — `default_root_metric(EdgePred/2, Direction, RootTerm, Spec)`
+yields the canonical minimum-distance spec from just the edge + root, so the
+common case is effectively zero-config. (A fully implicit default that also
+infers `edge`/`boundary` from domain conventions — e.g. `parent/2` + a
+`root_category/1` fact — is a possible further step, deferred pending a
+convention decision; `edge`/`boundary` stay explicit for now because they are
+graph-specific, not algorithmic.)
 
 ## 2. The three canonical instances
 
@@ -134,6 +159,33 @@ and its direction are required. Nodes unreachable from the root within
 Determinism: results must be independent of node visitation order (the semiring
 operations are associative/commutative). This is the same purity contract the
 existing kernels rely on (`purity_certificate`).
+
+### 4.1 Walks vs simple paths — `cycles(bounded)` vs `cycles(visited)`
+
+The default node-DP counts **walks** (a node may recur within the depth budget),
+sharing one memoised value per node — this is what makes it linear. The
+`visited` policy instead carries a **per-path visited set** (the classic
+`\+ member(N, Visited)` constraint; see `PER_PATH_VISITED_RECURSION.md`,
+`visited_set/2`, and the IntSet-visited work) and counts only **simple paths**
+(no repeated node on a path). The distinction matters per aggregate:
+
+- **`min`** — shortest paths are always simple, so `bounded` and `visited`
+  produce the *same* value. `bounded` (shared memo) is strictly cheaper; prefer
+  it. `visited` is available for parity with existing simple-path kernels.
+- **`max`** — `visited` gives the longest **simple** path (the "true" longest
+  path), but that is NP-hard in general and reintroduces per-path state, so it
+  does not share the node-DP's linearity. `bounded` gives the longest **walk**
+  ≤ depth (tractable). Choose per intent: exactness vs cost.
+- **`sum`/flux** — `visited` sums over **simple paths only** and is exactly the
+  semantics of the current path-enumerating kernel — which is precisely the
+  exponential blow-up this design exists to avoid. `bounded` sums over **walks**
+  (the linear node-DP). On an acyclic subgraph the two coincide; on a cyclic one
+  they differ, and `bounded` is the supported tractable default.
+
+In short: `visited` is the faithful simple-path semantics (and the escape hatch
+to the existing kernel behaviour), while `bounded` is the walk semantics that the
+node-DP computes in linear time. For `min` they are equal; for `max`/`sum` they
+are a genuine semantic *and* cost choice, which is why both are first-class.
 
 ## 5. Equivalence to the existing effective-distance kernel
 

--- a/src/unifyweaver/core/root_metric.pl
+++ b/src/unifyweaver/core/root_metric.pl
@@ -1,0 +1,197 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (@s243a)
+%
+% root_metric.pl — Target-agnostic recognition of root-anchored graph metrics.
+%
+% A root-anchored metric is a per-node value defined by a recurrence pinned at
+% a root: value(Root) = boundary; value(Node) = AGGREGATE over parents of
+% COMBINE(value(parent), edge_step). Minimum/maximum distance to root and the
+% additive "effective distance" / flux are the three canonical instances; they
+% differ only in the (aggregate, combine) semiring.
+%
+% This module is the Phase 0 spec surface from
+% docs/design/ROOT_ANCHORED_METRICS_{PHILOSOPHY,SPECIFICATION,IMPLEMENTATION_PLAN}.md:
+% it parses + validates + normalises the `root_metric/2` directive and exposes
+% the normalised spec + the semiring table for targets to consume. It does NOT
+% emit code (same analysis-produces-terms / targets-consume-terms pattern as
+% demand_analysis.pl and purity_certificate.pl), so it is inert until a target
+% reads the registered specs.
+%
+% Usage as a directive in user code:
+%
+%   :- use_module(library(root_metric)).
+%   :- root_metric(min_dist_to_root/3,
+%          [ edge(parent/2, up), boundary('Root', 0),
+%            combine(succ), aggregate(min),
+%            max_depth(10), cycles(bounded), materialize(ingest) ]).
+%
+% Defaults: cycles(bounded), materialize(kernel), max_depth(10). `combine(succ)`
+% normalises to `combine(plus(1))`. Invalid directives throw
+% root_metric_error(Reason) so a bad spec fails loudly at load time.
+
+:- module(root_metric, [
+    root_metric/2,                 % +Name/Arity, +Opts  (directive: validate + register)
+    normalize_root_metric/3,       % +Name/Arity, +Opts, -Spec  (throws on invalid)
+    validate_root_metric/2,        % +Name/Arity, +Opts         (semidet, no throw)
+    registered_root_metric/2,      % ?Name/Arity, ?Spec         (dynamic store)
+    root_metric_name/2,            % +Spec, -Name/Arity
+    root_metric_edge/3,            % +Spec, -EdgePred/2, -Direction
+    root_metric_boundary/3,        % +Spec, -RootTerm, -V0
+    root_metric_combine/2,         % +Spec, -Combine            (normalised: plus(K)|scale(D))
+    root_metric_aggregate/2,       % +Spec, -Aggregate          (min|max|sum)
+    root_metric_max_depth/2,       % +Spec, -Depth
+    root_metric_cycles/2,          % +Spec, -Policy
+    root_metric_materialize/2,     % +Spec, -Where
+    root_metric_semiring/3,        % +Aggregate, +Combine, -semiring(Op,Combine,Annihilator,Identity)
+    combine_class/2,               % +Combine, -Class           (additive|multiplicative)
+    root_metric_preset/2,          % ?PresetName, ?AlgorithmOpts
+    default_root_metric/4          % +EdgePred/2, +Direction, +RootTerm, -Spec  (min distance)
+]).
+
+:- dynamic registered_root_metric/2.
+
+%% ========================================================================
+%% Directive entry point: validate + normalise + register.
+%% ========================================================================
+
+root_metric(NameArity, Opts) :-
+    normalize_root_metric(NameArity, Opts, Spec),
+    % Re-registering the same name replaces the prior spec (idempotent reload).
+    retractall(registered_root_metric(NameArity, _)),
+    assertz(registered_root_metric(NameArity, Spec)).
+
+%% ========================================================================
+%% Validation + normalisation.
+%% ========================================================================
+
+%% validate_root_metric(+NameArity, +Opts) is semidet.
+%  True iff the directive would normalise without error. Never throws.
+validate_root_metric(NameArity, Opts) :-
+    catch(normalize_root_metric(NameArity, Opts, _), _, fail).
+
+%% normalize_root_metric(+NameArity, +Opts, -Spec) is det.
+%  Spec = root_metric_spec(Name/Arity, NormOpts) with defaults filled and
+%  combine(succ) rewritten to combine(plus(1)). Throws root_metric_error/1.
+normalize_root_metric(NameArity, Opts0, root_metric_spec(NameArity, NormOpts)) :-
+    must_name_arity(NameArity),
+    must_be_opt_list(Opts0),
+    expand_preset(Opts0, Opts),
+    % required + defaulted fields
+    req_edge(Opts, Edge),
+    req_boundary(Opts, Boundary),
+    req_combine(Opts, Combine),
+    req_aggregate(Opts, Aggregate),
+    opt_default(max_depth(D), Opts, max_depth(10)), check_max_depth(D),
+    opt_default(cycles(Cyc), Opts, cycles(bounded)), check_cycles(Cyc),
+    opt_default(materialize(M), Opts, materialize(kernel)), check_materialize(M),
+    % cross-field: the (aggregate, combine) pair must name a known semiring
+    ( root_metric_semiring(Aggregate, Combine, _)
+    -> true
+    ;  throw(root_metric_error(unsupported_pair(Aggregate, Combine)))
+    ),
+    NormOpts = [ Edge, Boundary, combine(Combine), aggregate(Aggregate),
+                 max_depth(D), cycles(Cyc), materialize(M) ].
+
+must_name_arity(Name/Arity) :-
+    ( atom(Name), integer(Arity), Arity >= 1
+    -> true
+    ;  throw(root_metric_error(bad_name_arity(Name/Arity))) ).
+must_name_arity(Other) :-
+    \+ Other = _/_,
+    throw(root_metric_error(bad_name_arity(Other))).
+
+must_be_opt_list(Opts) :-
+    ( is_list(Opts) -> true ; throw(root_metric_error(opts_not_a_list(Opts))) ).
+
+req_edge(Opts, edge(P/2, Dir)) :-
+    ( memberchk(edge(P/2, Dir), Opts)
+    -> ( atom(P), member(Dir, [up, down])
+       -> true ; throw(root_metric_error(bad_edge(edge(P/2, Dir)))) )
+    ;  throw(root_metric_error(missing(edge))) ).
+
+req_boundary(Opts, boundary(Root, V0)) :-
+    ( memberchk(boundary(Root, V0), Opts)
+    -> ( number(V0) -> true ; throw(root_metric_error(bad_boundary_value(V0))) )
+    ;  throw(root_metric_error(missing(boundary))) ).
+
+%% combine: succ normalises to plus(1); plus(K)/scale(D) validated.
+req_combine(Opts, Norm) :-
+    ( memberchk(combine(C), Opts) -> true ; throw(root_metric_error(missing(combine))) ),
+    normalize_combine(C, Norm).
+
+normalize_combine(succ, plus(1)) :- !.
+normalize_combine(plus(K), plus(K)) :- !,
+    ( number(K) -> true ; throw(root_metric_error(bad_combine(plus(K)))) ).
+normalize_combine(scale(D), scale(D)) :- !,
+    ( number(D), D > 0, D =< 1 -> true ; throw(root_metric_error(bad_combine(scale(D)))) ).
+normalize_combine(C, _) :- throw(root_metric_error(bad_combine(C))).
+
+req_aggregate(Opts, A) :-
+    ( memberchk(aggregate(A), Opts) -> true ; throw(root_metric_error(missing(aggregate))) ),
+    ( member(A, [min, max, sum]) -> true ; throw(root_metric_error(bad_aggregate(A))) ).
+
+check_max_depth(D) :-
+    ( integer(D), D >= 0 -> true ; throw(root_metric_error(bad_max_depth(D))) ).
+check_cycles(C) :-
+    ( member(C, [bounded, scc, ignore, visited]) -> true ; throw(root_metric_error(bad_cycles(C))) ).
+check_materialize(M) :-
+    ( member(M, [kernel, ingest]) -> true ; throw(root_metric_error(bad_materialize(M))) ).
+
+%% opt_default(+TemplateWithVar, +Opts, +DefaultTerm): bind from Opts or default.
+opt_default(Template, Opts, _Default) :- memberchk(Template, Opts), !.
+opt_default(Template, _Opts, Default) :- Template = Default.
+
+%% ========================================================================
+%% Presets — name the *algorithm* shape so a user declares only the
+%% graph-specific edge + boundary. `min_dist` is the default metric.
+%% A directive may carry `preset(Name)`; explicit opts override the preset.
+%% ========================================================================
+
+root_metric_preset(min_dist,  [ combine(succ),       aggregate(min), max_depth(10) ]).
+root_metric_preset(max_dist,  [ combine(succ),       aggregate(max), max_depth(10) ]).
+root_metric_preset(effective, [ combine(scale(0.2)), aggregate(sum), max_depth(10) ]).
+
+%% default_root_metric(+EdgePred/2, +Direction, +RootTerm, -Spec)
+%  The canonical zero-thought metric: minimum distance to root over the given
+%  edge. Lets a caller get a usable spec without writing the full option list.
+default_root_metric(EdgePred/2, Direction, RootTerm, Spec) :-
+    normalize_root_metric(min_dist_to_root/3,
+        [ edge(EdgePred/2, Direction), boundary(RootTerm, 0), preset(min_dist) ],
+        Spec).
+
+%% expand_preset(+Opts, -Expanded): if a preset(Name) is present, splice in its
+%  fields, with any explicit option of the same functor/arity taking precedence.
+expand_preset(Opts, Expanded) :-
+    ( select(preset(P), Opts, Rest)
+    -> ( root_metric_preset(P, Base) -> true ; throw(root_metric_error(bad_preset(P))) ),
+       findall(B, (member(B, Base), \+ opt_present(B, Rest)), Adds),
+       append(Rest, Adds, Expanded)
+    ;  Expanded = Opts ).
+
+opt_present(Opt, List) :- functor(Opt, F, A), functor(Probe, F, A), memberchk(Probe, List).
+
+%% ========================================================================
+%% Semiring table — the (aggregate, combine-class) pairs we support.
+%% semiring(Op, Combine, Annihilator, Identity).
+%% ========================================================================
+
+combine_class(plus(_), additive).
+combine_class(scale(_), multiplicative).
+
+root_metric_semiring(min, plus(_),  semiring(min, plus,  inf,    0)).
+root_metric_semiring(max, plus(_),  semiring(max, plus,  neg_inf, 0)).
+root_metric_semiring(sum, scale(_), semiring(sum, scale, 0,      1)).
+
+%% ========================================================================
+%% Accessors over a normalised Spec.
+%% ========================================================================
+
+root_metric_name(root_metric_spec(NameArity, _), NameArity).
+root_metric_edge(root_metric_spec(_, Opts), P/2, Dir) :- memberchk(edge(P/2, Dir), Opts).
+root_metric_boundary(root_metric_spec(_, Opts), Root, V0) :- memberchk(boundary(Root, V0), Opts).
+root_metric_combine(root_metric_spec(_, Opts), C) :- memberchk(combine(C), Opts).
+root_metric_aggregate(root_metric_spec(_, Opts), A) :- memberchk(aggregate(A), Opts).
+root_metric_max_depth(root_metric_spec(_, Opts), D) :- memberchk(max_depth(D), Opts).
+root_metric_cycles(root_metric_spec(_, Opts), C) :- memberchk(cycles(C), Opts).
+root_metric_materialize(root_metric_spec(_, Opts), M) :- memberchk(materialize(M), Opts).

--- a/tests/core/test_root_metric.pl
+++ b/tests/core/test_root_metric.pl
@@ -1,0 +1,206 @@
+:- encoding(utf8).
+%% Test suite for root_metric.pl (Phase 0: directive validation + normalisation)
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_root_metric.pl
+
+:- use_module('../../src/unifyweaver/core/root_metric').
+:- use_module(library(lists)).
+
+%% ========================================================================
+%% Test runner (same shape as test_demand_analysis.pl)
+%% ========================================================================
+
+run_tests :-
+    format("~n========================================~n"),
+    format("Root Metric Tests~n"),
+    format("========================================~n~n"),
+    findall(Name, clause(test(Name), _), Tests),
+    length(Tests, Total),
+    run_all(Tests, 0, Passed),
+    format("~n========================================~n"),
+    (   Passed =:= Total
+    ->  format("All ~w tests passed~n", [Total])
+    ;   Failed is Total - Passed,
+        format("~w of ~w tests FAILED~n", [Failed, Total]),
+        format("Tests FAILED~n"),
+        halt(1)
+    ),
+    format("========================================~n").
+
+run_all([], Passed, Passed).
+run_all([Test|Rest], Acc, Passed) :-
+    (   catch(test(Test), Error,
+            (format("[FAIL] ~w: ~w~n", [Test, Error]), fail))
+    ->  Acc1 is Acc + 1, run_all(Rest, Acc1, Passed)
+    ;   run_all(Rest, Acc, Passed)
+    ).
+
+pass(Name) :- format("[PASS] ~w~n", [Name]).
+
+%% Helper: a valid min-distance opt list.
+min_opts([ edge(parent/2, up), boundary('Root', 0),
+           combine(succ), aggregate(min),
+           max_depth(10), cycles(bounded), materialize(ingest) ]).
+
+%% ========================================================================
+%% Canonical instances normalise
+%% ========================================================================
+
+test(min_dist_normalises) :-
+    min_opts(Opts),
+    normalize_root_metric(min_dist_to_root/3, Opts, Spec),
+    root_metric_aggregate(Spec, min),
+    root_metric_combine(Spec, plus(1)),      % succ -> plus(1)
+    root_metric_edge(Spec, parent/2, up),
+    root_metric_boundary(Spec, 'Root', 0),
+    root_metric_max_depth(Spec, 10),
+    root_metric_materialize(Spec, ingest),
+    pass(min_dist_normalises).
+
+test(max_dist_normalises) :-
+    normalize_root_metric(max_dist_to_root/3,
+        [ edge(parent/2, up), boundary('Root', 0),
+          combine(succ), aggregate(max), max_depth(10) ], Spec),
+    root_metric_aggregate(Spec, max),
+    root_metric_combine(Spec, plus(1)),
+    pass(max_dist_normalises).
+
+test(flux_normalises) :-
+    normalize_root_metric(effective_distance/3,
+        [ edge(parent/2, up), boundary('Root', 1.0),
+          combine(scale(0.2)), aggregate(sum), max_depth(10) ], Spec),
+    root_metric_aggregate(Spec, sum),
+    root_metric_combine(Spec, scale(0.2)),
+    root_metric_boundary(Spec, 'Root', 1.0),
+    pass(flux_normalises).
+
+%% ========================================================================
+%% Defaults
+%% ========================================================================
+
+test(defaults_applied) :-
+    normalize_root_metric(min_dist_to_root/3,
+        [ edge(parent/2, up), boundary('Root', 0),
+          combine(succ), aggregate(min) ], Spec),
+    root_metric_max_depth(Spec, 10),         % default
+    root_metric_cycles(Spec, bounded),       % default
+    root_metric_materialize(Spec, kernel),   % default
+    pass(defaults_applied).
+
+%% ========================================================================
+%% Rejections (validate_root_metric is semidet, must fail)
+%% ========================================================================
+
+test(reject_unknown_aggregate) :-
+    \+ validate_root_metric(m/3,
+        [ edge(parent/2, up), boundary('R', 0), combine(succ), aggregate(median) ]),
+    pass(reject_unknown_aggregate).
+
+test(reject_bad_combine) :-
+    \+ validate_root_metric(m/3,
+        [ edge(parent/2, up), boundary('R', 0), combine(times(2)), aggregate(min) ]),
+    pass(reject_bad_combine).
+
+test(reject_scale_out_of_range) :-
+    \+ validate_root_metric(m/3,
+        [ edge(parent/2, up), boundary('R', 1.0), combine(scale(1.5)), aggregate(sum) ]),
+    pass(reject_scale_out_of_range).
+
+test(reject_negative_depth) :-
+    \+ validate_root_metric(m/3,
+        [ edge(parent/2, up), boundary('R', 0), combine(succ), aggregate(min),
+          max_depth(-1) ]),
+    pass(reject_negative_depth).
+
+test(reject_bad_direction) :-
+    \+ validate_root_metric(m/3,
+        [ edge(parent/2, sideways), boundary('R', 0), combine(succ), aggregate(min) ]),
+    pass(reject_bad_direction).
+
+test(reject_missing_edge) :-
+    \+ validate_root_metric(m/3, [ boundary('R', 0), combine(succ), aggregate(min) ]),
+    pass(reject_missing_edge).
+
+test(reject_unsupported_pair) :-
+    % min with a multiplicative combine has no semiring entry
+    \+ validate_root_metric(m/3,
+        [ edge(parent/2, up), boundary('R', 0), combine(scale(0.5)), aggregate(min) ]),
+    pass(reject_unsupported_pair).
+
+%% ========================================================================
+%% Semiring table
+%% ========================================================================
+
+test(semiring_lookup) :-
+    root_metric_semiring(min, plus(1), semiring(min, plus, inf, 0)),
+    root_metric_semiring(max, plus(1), semiring(max, plus, neg_inf, 0)),
+    root_metric_semiring(sum, scale(0.2), semiring(sum, scale, 0, 1)),
+    combine_class(plus(1), additive),
+    combine_class(scale(0.2), multiplicative),
+    pass(semiring_lookup).
+
+%% ========================================================================
+%% Directive registration (idempotent re-register)
+%% ========================================================================
+
+%% ========================================================================
+%% Cycle policy: per-path visited (simple-path)
+%% ========================================================================
+
+test(accept_visited_cycles) :-
+    normalize_root_metric(min_dist_to_root/3,
+        [ edge(parent/2, up), boundary('R', 0), combine(succ), aggregate(min),
+          cycles(visited) ], Spec),
+    root_metric_cycles(Spec, visited),
+    pass(accept_visited_cycles).
+
+test(reject_bad_cycles) :-
+    \+ validate_root_metric(m/3,
+        [ edge(parent/2, up), boundary('R', 0), combine(succ), aggregate(min),
+          cycles(spiral) ]),
+    pass(reject_bad_cycles).
+
+%% ========================================================================
+%% Presets + default metric
+%% ========================================================================
+
+test(preset_min_dist_fills_algorithm) :-
+    % user supplies only graph-specific edge + boundary
+    normalize_root_metric(min_dist_to_root/3,
+        [ edge(parent/2, up), boundary('Root', 0), preset(min_dist) ], Spec),
+    root_metric_aggregate(Spec, min),
+    root_metric_combine(Spec, plus(1)),
+    root_metric_max_depth(Spec, 10),
+    pass(preset_min_dist_fills_algorithm).
+
+test(preset_explicit_override) :-
+    % explicit max_depth overrides the preset's default
+    normalize_root_metric(min_dist_to_root/3,
+        [ edge(parent/2, up), boundary('Root', 0), preset(min_dist), max_depth(4) ], Spec),
+    root_metric_max_depth(Spec, 4),
+    pass(preset_explicit_override).
+
+test(reject_bad_preset) :-
+    \+ validate_root_metric(m/3,
+        [ edge(parent/2, up), boundary('R', 0), preset(nonesuch) ]),
+    pass(reject_bad_preset).
+
+test(default_root_metric_is_min_dist) :-
+    default_root_metric(parent/2, up, 'Root', Spec),
+    root_metric_aggregate(Spec, min),
+    root_metric_combine(Spec, plus(1)),
+    root_metric_edge(Spec, parent/2, up),
+    root_metric_boundary(Spec, 'Root', 0),
+    pass(default_root_metric_is_min_dist).
+
+test(register_and_lookup) :-
+    min_opts(Opts),
+    root_metric(min_dist_to_root/3, Opts),
+    registered_root_metric(min_dist_to_root/3, Spec),
+    root_metric_aggregate(Spec, min),
+    % re-register replaces, no duplicate
+    root_metric(min_dist_to_root/3, Opts),
+    findall(S, registered_root_metric(min_dist_to_root/3, S), All),
+    length(All, 1),
+    pass(register_and_lookup).


### PR DESCRIPTION
  ## Summary
  First step of ROOT_ANCHORED_METRICS_IMPLEMENTATION_PLAN.md. Adds the
  `root_metric/2` directive surface in `core/root_metric.pl`: validate + normalise
  + register a root-anchored metric spec, plus the semiring table. Pure analysis
  (no codegen) — inert until a target consumes the registered specs.

  ## Design points from review (now first-class)
  - `cycles(visited)`: per-path visited / simple-path semantics alongside
    bounded/scc/ignore. = bounded for `min`; exact-but-exponential vs linear walk
    semantics for `max`/`sum` (spec §4.1).
  - Presets + default: `preset(min_dist|max_dist|effective)` fills the algorithm
    fields so users declare only edge + boundary; `default_root_metric/4` gives the
    canonical min-distance spec (min_dist = default). Fully-implicit default
    deferred pending a convention decision.

  ## Tests
  tests/core/test_root_metric.pl (19): instances, defaults, rejections, visited,
  presets/default, semiring, registration. Wired into CI. Spec doc updated.