### PR TITLE
Feat/wam go format builtins

### DIFF
--- a/PR_go_wam_format_builtins.md
+++ b/PR_go_wam_format_builtins.md
@@ -1,0 +1,28 @@
+# PR Title
+
+Add bounded Go WAM format builtins
+
+# PR Description
+
+## Summary
+
+- Register `format/1` and `format/2` as direct Go WAM builtins.
+- Add bounded Go WAM runtime formatting for `~w`, `~n`, and `~~`.
+- Add generated Go WAM E2E coverage for format output and missing-argument failure.
+- Fix Go WAM text parsing so quoted constants with spaces and tildes survive translation into Go instructions.
+- Update the Go WAM parity audit for the closed bounded-format output gap.
+
+## Scope
+
+This intentionally keeps `format/3`, stream capture, and broader directives separate from this slice.
+
+## Validation
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+
+Existing non-fatal choicepoint warnings still appear in the same Go WAM tests.

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -21,7 +21,7 @@ current cross-target builtin/runtime baseline.
 | Univ | `=../2` compose/decompose | `=../2` compose/decompose | Present |
 | Copying | `copy_term/2` with fresh variables and preserved sharing | `copy_term/2` with fresh variables and preserved sharing | Present |
 | Control | `true/0`, `fail/0`, `!/0`, `\+/1`, `CutIte` | Same baseline, with broader isolated-goal NAF in Haskell/Python | Present for current baseline, including isolated user-goal NAF and race-to-true over multi-clause WAM targets |
-| IO | `write/1`, `display/1`, `writeln/1`, `print/1`, `nl/0`, `tab/1`, `getenv/2`, `setenv/2` | `write/1`, `display/1`, `nl/0`; R/C++ also cover `writeln/1`, `print/1`, and `tab/1`; LLVM covers `getenv/2` and `setenv/2` | Present for current baseline plus simple output aliases, tab output, and bounded environment access |
+| IO | `write/1`, `display/1`, `writeln/1`, `print/1`, `format/1`, `format/2`, `nl/0`, `tab/1`, `getenv/2`, `setenv/2` | `write/1`, `display/1`, `nl/0`; R/C++/Python also cover `format/N`; R/C++ also cover `writeln/1`, `print/1`, and `tab/1`; LLVM covers `getenv/2` and `setenv/2` | Present for current baseline plus simple output aliases, bounded format output, tab output, and bounded environment access |
 
 ## Immediate Findings
 
@@ -64,6 +64,11 @@ current cross-target builtin/runtime baseline.
   `write/1` rendering, while `writeln/1` appends a newline, matching the
   bounded R/C++ output-polish surface without adding broader `format/N`
   parsing.
+- Bounded `format/1` and `format/2` are now direct Go WAM builtins and are
+  covered by the generated builtin E2E test for literal `~~`, newline `~n`,
+  `~w` argument substitution, and missing-argument failure. Stream capture,
+  destination-aware `format/3`, and broader formatting directives remain
+  separate from this small R/C++/Python output-parity slice.
 - Deterministic `subtract/3` is now covered by the generated Go WAM builtin
   E2E test for filtering all right-list matches from the left list, preserving
   left-list order, empty-list behavior, all-removed results, duplicate removal,

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -486,6 +486,12 @@ wam_go_direct_builtin("writeln/1", 1, 'writeln/1').
 wam_go_direct_builtin(print/1, 1, 'print/1').
 wam_go_direct_builtin('print/1', 1, 'print/1').
 wam_go_direct_builtin("print/1", 1, 'print/1').
+wam_go_direct_builtin(format/1, 1, 'format/1').
+wam_go_direct_builtin('format/1', 1, 'format/1').
+wam_go_direct_builtin("format/1", 1, 'format/1').
+wam_go_direct_builtin(format/2, 2, 'format/2').
+wam_go_direct_builtin('format/2', 2, 'format/2').
+wam_go_direct_builtin("format/2", 2, 'format/2').
 wam_go_direct_builtin(sum_list/2, 2, 'sum_list/2').
 wam_go_direct_builtin('sum_list/2', 2, 'sum_list/2').
 wam_go_direct_builtin("sum_list/2", 2, 'sum_list/2').
@@ -1141,8 +1147,7 @@ go_foreign_astar_dimensionality(_Module, 5).
 %% wam_lines_to_go(+Lines, +PC, -GoLits, -LabelEntries)
 wam_lines_to_go([], _, _, _, [], []).
 wam_lines_to_go([Line|Rest], PC, PredIndicator, Options, GoLits, Labels) :-
-    split_string(Line, " \t", " \t", Parts),
-    delete(Parts, "", CleanParts),
+    wam_tokenize_line(Line, CleanParts),
     (   CleanParts == []
     ->  wam_lines_to_go(Rest, PC, PredIndicator, Options, GoLits, Labels)
     ;   CleanParts = [First|_],
@@ -1172,14 +1177,72 @@ wam_lines_to_go([Line|Rest], PC, PredIndicator, Options, GoLits, Labels) :-
         )
     ).
 
+wam_tokenize_line(Line, Parts) :-
+    string_chars(Line, Chars),
+    wam_tokenize_chars(Chars, [], RevParts),
+    reverse(RevParts, Parts).
+
+wam_tokenize_chars([], Parts, Parts).
+wam_tokenize_chars([C|Rest], Parts0, Parts) :-
+    char_type(C, space),
+    !,
+    wam_tokenize_chars(Rest, Parts0, Parts).
+wam_tokenize_chars(['\''|Rest], Parts0, Parts) :-
+    !,
+    wam_take_quoted(Rest, Token, Remaining),
+    wam_tokenize_chars(Remaining, [Token|Parts0], Parts).
+wam_tokenize_chars(Chars, Parts0, Parts) :-
+    wam_take_bare(Chars, Token, Remaining),
+    (   Token == ""
+    ->  Parts1 = Parts0
+    ;   Parts1 = [Token|Parts0]
+    ),
+    wam_tokenize_chars(Remaining, Parts1, Parts).
+
+wam_take_quoted(Rest, Token, Remaining) :-
+    wam_take_quoted_inner(Rest, ['\''], RevQuoted, AfterQuote),
+    reverse(RevQuoted, QuotedChars),
+    wam_take_bare_tail(AfterQuote, TailChars, Remaining),
+    append(QuotedChars, TailChars, TokenChars),
+    string_chars(Token, TokenChars).
+
+wam_take_quoted_inner([], Acc, Acc, []).
+wam_take_quoted_inner(['\\', C|Rest], Acc, RevQuoted, Remaining) :-
+    !,
+    wam_take_quoted_inner(Rest, [C, '\\'|Acc], RevQuoted, Remaining).
+wam_take_quoted_inner(['\''|Rest], Acc, ['\''|Acc], Rest) :-
+    !.
+wam_take_quoted_inner([C|Rest], Acc, RevQuoted, Remaining) :-
+    wam_take_quoted_inner(Rest, [C|Acc], RevQuoted, Remaining).
+
+wam_take_bare([], "", []).
+wam_take_bare(Chars, Token, Remaining) :-
+    wam_take_bare_chars(Chars, TokenChars, Remaining),
+    string_chars(Token, TokenChars).
+
+wam_take_bare_chars([], [], []).
+wam_take_bare_chars([C|Rest], [], [C|Rest]) :-
+    char_type(C, space),
+    !.
+wam_take_bare_chars([C|Rest], [C|TokenRest], Remaining) :-
+    wam_take_bare_chars(Rest, TokenRest, Remaining).
+
+wam_take_bare_tail([], [], []).
+wam_take_bare_tail([C|Rest], [], [C|Rest]) :-
+    char_type(C, space),
+    !.
+wam_take_bare_tail([C|Rest], [C|Tail], Remaining) :-
+    wam_take_bare_tail(Rest, Tail, Remaining).
+
 %% wam_line_to_go_literal(+Parts, -GoLit)
 %% parse_string_to_go_val(+Str, -GoVal)
 %
 % When the WAM compiler emits an atom that needs Prolog quoting (e.g.
 % an apostrophe-bearing category like 'People\'s_Republic_of_China'),
 % the WAM TEXT carries the quoted form. The split-on-whitespace parser
-% above hands that whole token here including the surrounding ' and
-% the backslash-escaped inner quote. If we just pass it to
+% used to break quoted constants containing whitespace into multiple tokens.
+% `wam_tokenize_line/2` now keeps that whole token here including the
+% surrounding ' and the backslash-escaped inner quote. If we just pass it to
 % go_value_literal/2 unchanged, the resulting Go literal becomes
 %     &Atom{Name: "'People\'s_Republic_of_China'"}
 % which (a) keeps the spurious outer apostrophes inside the atom's Name

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -875,6 +875,46 @@ func (vm *WamState) selectSolutions(items []Value) []SelectSolution {
 	return solutions
 }
 
+func (vm *WamState) formatTemplate(template string, args []Value) (string, bool) {
+	var b strings.Builder
+	argIdx := 0
+	for i := 0; i < len(template); i++ {
+		ch := template[i]
+		if ch != '~' || i+1 >= len(template) {
+			b.WriteByte(ch)
+			continue
+		}
+		i++
+		switch template[i] {
+		case 'n':
+			b.WriteByte('\n')
+		case '~':
+			b.WriteByte('~')
+		case 'w':
+			if argIdx >= len(args) {
+				return "", false
+			}
+			b.WriteString(vm.deref(args[argIdx]).String())
+			argIdx++
+		default:
+			b.WriteByte('~')
+			b.WriteByte(template[i])
+		}
+	}
+	return b.String(), true
+}
+
+func formatTemplateText(v Value) (string, bool) {
+	switch t := v.(type) {
+	case *Atom:
+		return t.Name, true
+	case *Integer:
+		return strconv.FormatInt(t.Val, 10), true
+	default:
+		return "", false
+	}
+}
+
 func (vm *WamState) applySelectSolution(solution SelectSolution) bool {
 	mark := vm.TrailLen
 	if !vm.Unify(vm.getReg(0), solution.Elem) {
@@ -1317,6 +1357,32 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 		return true
 	case "print/1":
 		fmt.Print(vm.deref(arg1).String())
+		return true
+	case "format/1":
+		template, ok := formatTemplateText(vm.deref(arg1))
+		if !ok {
+			return false
+		}
+		out, ok := vm.formatTemplate(template, nil)
+		if !ok {
+			return false
+		}
+		fmt.Print(out)
+		return true
+	case "format/2":
+		template, ok := formatTemplateText(vm.deref(arg1))
+		if !ok {
+			return false
+		}
+		args, ok := vm.listToSlice(arg2)
+		if !ok {
+			return false
+		}
+		out, ok := vm.formatTemplate(template, args)
+		if !ok {
+			return false
+		}
+		fmt.Print(out)
 		return true
 	case "nl/0":
 		fmt.Println()

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -30,6 +30,7 @@
 :- dynamic user:test_string_code_builtin/0.
 :- dynamic user:test_split_string_builtin/0.
 :- dynamic user:test_output_builtin/0.
+:- dynamic user:test_format_builtin/0.
 :- dynamic user:test_tab_builtin/0.
 :- dynamic user:test_env_builtin/0.
 :- dynamic user:test_succ_builtin/0.
@@ -685,6 +686,11 @@ test(builtins_execution) :-
                 print(go_print),
                 nl
             )),
+          assertz(user:test_format_builtin :-
+            (   format('fmt_one ~~ ok~n'),
+                format('fmt_two ~w ~w~~~n', [go, 42]),
+                \+ format('fmt_missing ~w', [])
+            )),
           assertz(user:test_set_aggregate :-
             (   aggregate_all(set(X), member(X, [a,b,a]), S),
                 length(S, 2),
@@ -747,6 +753,7 @@ test(builtins_execution) :-
           retractall(user:test_number_list_builtin),
           retractall(user:test_atom_string_builtin),
           retractall(user:test_output_builtin),
+          retractall(user:test_format_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
           retractall(user:test_neg_fact(_)),
@@ -756,7 +763,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_arithmetic_expr_builtin/0, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_append_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_output_builtin/0, test_tab_builtin/0, test_env_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_arithmetic_expr_builtin/0, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_append_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_output_builtin/0, test_format_builtin/0, test_tab_builtin/0, test_env_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -824,6 +831,8 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "setenv/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "writeln/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "print/1"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "format/1"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "format/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "succ/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "atom_number/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "upcase_atom/2"')),
@@ -1189,6 +1198,14 @@ func main() {
 		fmt.Println("OUTPUT_FAILURE")
 	}
 
+	formatVM := wam.NewWamState(wam.Test_format_builtinCode, wam.Test_format_builtinLabels)
+	formatVM.PC = wam.Test_format_builtinStartPC
+	if formatVM.Run() {
+		fmt.Println("FORMAT_SUCCESS")
+	} else {
+		fmt.Println("FORMAT_FAILURE")
+	}
+
 	setVM := wam.NewWamState(wam.Test_set_aggregateCode, wam.Test_set_aggregateLabels)
 	setVM.PC = wam.Test_set_aggregateStartPC
 	if setVM.Run() {
@@ -1279,6 +1296,9 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "NUMBER_LIST_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_STRING_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "OUTPUT_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "fmt_one ~ ok")),
+        assertion(sub_string(FullOutput, _, _, _, "fmt_two go 42~")),
+        assertion(sub_string(FullOutput, _, _, _, "FORMAT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "NEG_SUCCESS")),

--- a/tests/test_wam_go_generator.pl
+++ b/tests/test_wam_go_generator.pl
@@ -58,6 +58,12 @@ test(parse_wam_line_instruction) :-
     compile_wam_predicate_to_go(test/1, WamCode, [], GoCode),
     assertion(sub_string(GoCode, _, _, _, '&GetConstant{C: internAtom("john"), Ai: 0}')).
 
+test(parse_wam_line_quoted_constant_with_spaces) :-
+    reset_go_atom_literal_fallback,
+    WamCode = "    put_constant 'fmt one ~~ ok~n', A1",
+    compile_wam_predicate_to_go(test/1, WamCode, [], GoCode),
+    assertion(sub_string(GoCode, _, _, _, '&PutConstant{C: internAtom("fmt one ~~ ok~n"), Ai: 0}')).
+
 test(parse_wam_line_switch) :-
     once((
         WamCode = "    switch_on_constant john:default, jane:L1",


### PR DESCRIPTION
# Add bounded Go WAM format builtins

## Summary

- Register `format/1` and `format/2` as direct Go WAM builtins.
- Add bounded Go WAM runtime formatting for `~w`, `~n`, and `~~`.
- Add generated Go WAM E2E coverage for format output and missing-argument failure.
- Fix Go WAM text parsing so quoted constants with spaces and tildes survive translation into Go instructions.
- Update the Go WAM parity audit for the closed bounded-format output gap.

## Scope

This intentionally keeps `format/3`, stream capture, and broader directives separate from this slice.

## Validation

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`

Existing non-fatal choicepoint warnings still appear in the same Go WAM tests.
