### PR TITLE
feat(wam-clojure): lower list_to_set/2 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -424,6 +424,10 @@ clojure_direct_builtin("delete/3", "3").
 clojure_direct_builtin("delete/3", 3).
 clojure_direct_builtin('delete/3', "3").
 clojure_direct_builtin('delete/3', 3).
+clojure_direct_builtin("list_to_set/2", "2").
+clojure_direct_builtin("list_to_set/2", 2).
+clojure_direct_builtin('list_to_set/2', "2").
+clojure_direct_builtin('list_to_set/2', 2).
 clojure_direct_builtin("sort/2", "2").
 clojure_direct_builtin("sort/2", 2).
 clojure_direct_builtin('sort/2', "2").
@@ -842,6 +846,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "delete/3" ; Op == 'delete/3'),
     !,
     format(atom(Expr), '(runtime/apply-delete-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "list_to_set/2" ; Op == 'list_to_set/2'),
+    !,
+    format(atom(Expr), '(runtime/apply-list-to-set-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "sort/2" ; Op == 'sort/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1199,6 +1199,28 @@
       :else
       (backtrack state))))
 
+(defn list-to-set-items [state items]
+  (reduce (fn [out item]
+            (if (some #(term-identical? state % item) out)
+              out
+              (conj out item)))
+          []
+          items))
+
+(defn apply-list-to-set-solution [state]
+  (let [list-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A2") ::unbound))]
+    (if-let [items (proper-list-items state list-value)]
+      (let [set-term (list->term (:intern-context state)
+                                 (list-to-set-items state items))
+            [ok next-state] (unify-values state out set-term)]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+      (backtrack state))))
+
 (defn sorted-unique-list? [state items]
   (= items (vec (sorted-unique-terms state items))))
 
@@ -2627,6 +2649,9 @@
 
           "delete/3"
           (apply-delete-solution state)
+
+          "list_to_set/2"
+          (apply-list-to-set-solution state)
 
           "sort/2"
           (apply-sort-solution state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -125,6 +125,11 @@
 :- dynamic user:wam_delete_guard/3.
 :- dynamic user:wam_delete_bad_list/1.
 :- dynamic user:wam_delete_unbound_list/1.
+:- dynamic user:wam_list_to_set_guard/2.
+:- dynamic user:wam_list_to_set_empty/0.
+:- dynamic user:wam_list_to_set_singleton/0.
+:- dynamic user:wam_list_to_set_numbers/0.
+:- dynamic user:wam_list_to_set_bad_list/1.
 :- dynamic user:wam_sort_guard/2.
 :- dynamic user:wam_sort_bad_list/1.
 :- dynamic user:wam_sort_unbound_list/1.
@@ -451,6 +456,11 @@ user:wam_numlist_unbound_low(List) :- numlist(Low, 3, List), integer(Low).
 user:wam_delete_guard(L, Elem, Rest) :- delete(L, Elem, Rest).
 user:wam_delete_bad_list(Rest) :- delete([a|b], a, Rest).
 user:wam_delete_unbound_list(Rest) :- delete(L, a, Rest), is_list(L).
+user:wam_list_to_set_guard(List, Set) :- list_to_set(List, Set).
+user:wam_list_to_set_empty :- list_to_set([], Set), Set = [].
+user:wam_list_to_set_singleton :- list_to_set([x], Set), Set = [x].
+user:wam_list_to_set_numbers :- list_to_set([1,2,1,3,2], Set), Set = [1,2,3].
+user:wam_list_to_set_bad_list(_) :- list_to_set([a|b], _).
 user:wam_sort_guard(L, S) :- sort(L, S).
 user:wam_sort_bad_list(S) :- sort([a|b], S).
 user:wam_sort_unbound_list(S) :- sort(L, S), is_list(L).
@@ -782,6 +792,11 @@ run_smoke :-
           user:wam_delete_guard/3,
           user:wam_delete_bad_list/1,
           user:wam_delete_unbound_list/1,
+          user:wam_list_to_set_guard/2,
+          user:wam_list_to_set_empty/0,
+          user:wam_list_to_set_singleton/0,
+          user:wam_list_to_set_numbers/0,
+          user:wam_list_to_set_bad_list/1,
           user:wam_sort_guard/2,
           user:wam_sort_bad_list/1,
           user:wam_sort_unbound_list/1,
@@ -1023,6 +1038,7 @@ run_smoke :-
     assert_lowered_select_builtin_emitted(TmpDir),
     assert_lowered_numlist_builtin_emitted(TmpDir),
     assert_lowered_delete_builtin_emitted(TmpDir),
+    assert_lowered_list_to_set_builtin_emitted(TmpDir),
     assert_lowered_sort_builtin_emitted(TmpDir),
     assert_lowered_msort_builtin_emitted(TmpDir),
     assert_lowered_keysort_builtin_emitted(TmpDir),
@@ -1261,6 +1277,12 @@ smoke_cases([
     case('wam_delete_unbound_list/1', '[]', "true"),
     case('wam_delete_unbound_list/1', '[b,c]', "true"),
     case('wam_delete_unbound_list/1', '[a]', "false"),
+    case('wam_list_to_set_guard/2', args('[a,b,c,a,b,d,a]', '[a,b,c,d]'), "true"),
+    case('wam_list_to_set_guard/2', args('[a,b,c,a,b,d,a]', '[a,b,c,a]'), "false"),
+    case('wam_list_to_set_empty/0', no_args, "true"),
+    case('wam_list_to_set_singleton/0', no_args, "true"),
+    case('wam_list_to_set_numbers/0', no_args, "true"),
+    case('wam_list_to_set_bad_list/1', a, "false"),
     case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b,c]'), "true"),
     case('wam_sort_guard/2', args('[b,a,a,c]', '[a,b]'), "false"),
     case('wam_sort_guard/2', args('[f(b),f(a),a]', '[a,f(a),f(b)]'), "true"),
@@ -1770,6 +1792,14 @@ assert_lowered_delete_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-delete-unbound-list-1"),
     has(CoreCode, "runtime/apply-delete-solution").
 
+assert_lowered_list_to_set_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-list-to-set-guard-2"),
+    has(CoreCode, "defn lowered-wam-list-to-set-numbers-0"),
+    has(CoreCode, "defn lowered-wam-list-to-set-bad-list-1"),
+    has(CoreCode, "runtime/apply-list-to-set-solution").
+
 assert_lowered_sort_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
@@ -2137,7 +2167,9 @@ prolog_term_string_to_edn('[b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"b\
 prolog_term_string_to_edn('[c]', "{:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}") :- !.
 prolog_term_string_to_edn('[a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn('[a,b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn('[a,b,c,d]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" {:tag :struct :functor \"[|]/2\" :args [\"d\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn('[a,b,a,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
+prolog_term_string_to_edn('[a,b,c,a,b,d,a]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"d\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}]}]}]}]}") :- !.
 prolog_term_string_to_edn('[a,a,b,c]', "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn('[c,b,a]', "{:tag :struct :functor \"[|]/2\" :args [\"c\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn('[b,a]', "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}") :- !.
@@ -2173,7 +2205,9 @@ prolog_term_string_to_edn("[b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"b\
 prolog_term_string_to_edn("[c]", "{:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}") :- !.
 prolog_term_string_to_edn("[a,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}") :- !.
 prolog_term_string_to_edn("[a,b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}") :- !.
+prolog_term_string_to_edn("[a,b,c,d]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" {:tag :struct :functor \"[|]/2\" :args [\"d\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn("[a,b,a,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
+prolog_term_string_to_edn("[a,b,c,a,b,d,a]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"d\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}]}]}]}]}") :- !.
 prolog_term_string_to_edn("[a,a,b,c]", "{:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"a\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"c\" \"[]\"]}]}]}]}") :- !.
 prolog_term_string_to_edn("[c,b,a]", "{:tag :struct :functor \"[|]/2\" :args [\"c\" {:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}]}") :- !.
 prolog_term_string_to_edn("[b,a]", "{:tag :struct :functor \"[|]/2\" :args [\"b\" {:tag :struct :functor \"[|]/2\" :args [\"a\" \"[]\"]}]}") :- !.


### PR DESCRIPTION
## Summary

- Adds Clojure WAM direct-lowered support for `list_to_set/2`.
- Implements the runtime helper that preserves first occurrence order while removing duplicates by Prolog term identity.
- Extends the Clojure runtime smoke fixture to verify successful, failing, empty, singleton, numeric, and improper-list cases.

## Why

This continues the Clojure WAM builtin parity work by moving another deterministic list builtin out of generic fallback handling and into the lowered runtime path. The behavior follows the existing direct-builtin pattern used for nearby list builtins such as `delete/3`, `sort/2`, `msort/2`, and `keysort/2`.

## Notes

- `list_to_set/2` currently requires a proper bound input list.
- Improper lists fail deterministically.
- Output is unified with the generated set term, so both exact-output checks and negative-output checks are covered.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
