### PR TITLE
feat(wam-rust): wire compiled runtime parser mode

### DIFF
--- a/docs/WAM_RUNTIME_PARSER_STATUS.md
+++ b/docs/WAM_RUNTIME_PARSER_STATUS.md
@@ -71,7 +71,7 @@ each WAM instruction).
 | **C++**      | ✅ | ✅ | ✅ | `native(parse_term)` | partial — codegen tests in `test_wam_cpp_generator.pl`, one `'42'` parse verified end-to-end during the audit |
 | **R**        | ✅ | ✅ | ✅ | `native(parse_term)` | codegen tests; runtime end-to-end via the R smoke harness |
 | **Elixir**   | ✅ | — | — | `none` | n/a — `runtime_parser(compiled)` correctly throws `domain_error` (since Elixir isn't in the capability table); guarded by `test_runtime_parser_compiled_request_errors` |
-| **Rust**     | ✅ | — | — | `none` | n/a (no parser-mode wiring) |
+| **Rust**     | ✅ | — | ✅ | `none` | partial — capability and project-expansion wiring; runtime builtin bridge still pending |
 | **Haskell**  | ✅ | — | ✅ | `none` | partial — capability and project-expansion wiring; generated parser E2E is noted as slow in `docs/SESSION_HASKELL_PARITY_SUMMARY.md` |
 | **Go**       | ✅ | — | — | `none` | n/a (no parser-mode wiring) |
 | **Clojure**  | ✅ | — | — | `none` | n/a (no parser-mode wiring) |
@@ -96,7 +96,7 @@ Auditing the other targets for the same bug classes turned up:
 | **Rust** | `rust_val_literal` re-emitted quoted-numeric atoms verbatim (`Value::Atom("'42'")` instead of `Value::Atom("42")`) — same class as F# #2422 | #2431 |
 | **Python** | `_constant_term` re-parsed `Atom("42").name` through `_parse_constant`, silently promoting it to `Int(42)` at `put_constant` time; `wam_lines_to_python` used a naive whitespace split that broke any atom token containing a space (`':- p'`) | #2433 |
 | **C++** | audit clean — uses `wam_text_to_items/2` + `wam_classify_constant_token/2` which already honour the quoted-atom convention.  One end-to-end `'42'` parse verified before the ~12-min-per-case compile time made `:- p` / `\+ foo` impractical to also verify. | none |
-| **R, Elixir, Lua, Clojure, Go, Rust** (compiled path) | not applicable — these targets either use native parsing or don't bundle the compiled parser | none |
+| **R, Elixir, Lua, Clojure, Go** (compiled path) | not applicable — these targets either use native parsing or don't bundle the compiled parser | none |
 | **Haskell** (compiled path) | added after the original audit; appends portable parser + wrapper predicates but keeps the default off because parser-bundled generation is heavyweight | #2522 |
 
 The bug classes are roughly:
@@ -172,14 +172,16 @@ Significant work; worth it if there's a real user, not otherwise.
 
 ### 2. Add `compiled` to one more target with a real use case
 
-Haskell now has opt-in compiled-parser wiring: `runtime_parser(compiled)`
-appends the portable parser and target-agnostic wrapper predicates while
-leaving the default at `none`.  Rust remains the next natural candidate —
-it has the largest gap between "target has WAM but no parser" and "target
-needs to read user terms" (LMDB fact sources, anything reading config-file
-Prolog).  The work mirrors what's already done for Python and Haskell:
-append `prolog_term_parser` predicates, write a Python-style
-`_execute_read_term_from_atom` wrapper in Rust, expose it as a WAM builtin.
+Haskell and Rust now have opt-in compiled-parser wiring:
+`runtime_parser(compiled)` appends the portable parser and
+target-agnostic wrapper predicates while leaving the default at `none`.
+For Rust this is currently the compile-time/project-expansion half only:
+the generated project carries labels for `prolog_term_parser` and the
+wrapper predicates, and `runtime_parser(off)` rejects statically visible
+parser-dependent bodies.  The remaining Rust work is the runtime bridge:
+write a Python-style `_execute_read_term_from_atom` wrapper in Rust and
+expose it through WAM builtin dispatch so standard-name calls can execute
+instead of merely being present in the shared WAM table.
 
 Pre-work that benefits everyone: factor out the existing C++ and
 Python wrapper logic into a shared template so the Rust port (and any

--- a/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/RUNTIME_PARSER_TRANSPILATION_IMPLEMENTATION_PLAN.md
@@ -73,7 +73,8 @@ The initial implementation is intentionally small:
 - R is registered as `native(parse_term)` by default;
 - targets without runtime source-term parsing resolve to `none`;
 - `compiled(prolog_term_parser)` is available only for targets
-  with compile and runtime proof tests.
+  with proof tests for the advertised scope (project expansion first,
+  runtime execution where the target bridge exists).
 - the R project writer records the resolved mode in the generated
   `shared_program$runtime_parser` metadata.
 
@@ -105,6 +106,12 @@ parser predicates. A follow-up PR adds wrapper predicates
 get the standard SWI builtin surface on top of the portable
 parser. The remaining work is target-by-target adoption, not
 inventing the contract.
+Python, F#, Haskell, and Rust are also registered for opt-in
+`compiled(prolog_term_parser)`. Rust currently has the capability and
+project-expansion half: `write_wam_rust_project/3` appends the portable
+parser and wrapper predicates and rejects parser-dependent bodies when
+`runtime_parser(off)`/`none` is selected. The remaining Rust work is the
+runtime builtin bridge for standard `read_term_from_atom/2,3` execution.
 
 ### Subset generation
 
@@ -204,9 +211,12 @@ availability alone. Good candidates are targets adding:
 - reverse `term_to_atom/2`;
 - user-facing CLI term arguments.
 
-Python, Elixir, Lua, and future R experiments are reasonable candidates, but R
-should stay the semantic reference while keeping its inline parser as the
-production path.
+Python, Haskell, and Rust now have opt-in compiled-parser project wiring.
+Rust remains the next execution candidate: add a Python-style
+`_execute_read_term_from_atom` bridge in Rust and expose it through WAM
+builtin dispatch. Elixir, Lua, and future R experiments are reasonable
+candidates too, but R should stay the semantic reference while keeping its
+inline parser as the production path.
 
 ## Risks
 

--- a/src/unifyweaver/targets/wam_runtime_parser_capability.pl
+++ b/src/unifyweaver/targets/wam_runtime_parser_capability.pl
@@ -134,6 +134,7 @@ target_runtime_parser_default(wam_cpp, native(parse_term)).
 % and why we don't flip the default.
 target_runtime_parser_default(wam_fsharp, none).
 target_runtime_parser_default(wam_haskell, none).
+target_runtime_parser_default(wam_rust, none).
 
 target_runtime_parser_mode_(wam_r, native(parse_term)).
 target_runtime_parser_mode_(wam_r, compiled(prolog_term_parser)).
@@ -142,6 +143,7 @@ target_runtime_parser_mode_(wam_cpp, compiled(prolog_term_parser)).
 target_runtime_parser_mode_(wam_python, compiled(prolog_term_parser)).
 target_runtime_parser_mode_(wam_fsharp, compiled(prolog_term_parser)).
 target_runtime_parser_mode_(wam_haskell, compiled(prolog_term_parser)).
+target_runtime_parser_mode_(wam_rust, compiled(prolog_term_parser)).
 
 normalize_runtime_parser_target(r, wam_r) :- !.
 normalize_runtime_parser_target(wam_r, wam_r) :- !.
@@ -151,6 +153,8 @@ normalize_runtime_parser_target(fsharp, wam_fsharp) :- !.
 normalize_runtime_parser_target(wam_fsharp, wam_fsharp) :- !.
 normalize_runtime_parser_target(haskell, wam_haskell) :- !.
 normalize_runtime_parser_target(wam_haskell, wam_haskell) :- !.
+normalize_runtime_parser_target(rust, wam_rust) :- !.
+normalize_runtime_parser_target(wam_rust, wam_rust) :- !.
 normalize_runtime_parser_target(Target, Target).
 
 strip_module_qualifier(Module:Goal, Stripped) :-

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -33,6 +33,12 @@
     lower_predicate_to_rust/4,
     rust_lowered_func_name/2
 ]).
+:- use_module('../targets/wam_runtime_parser_capability', [
+    parser_dependent_body_goal/2,
+    wam_target_runtime_parser/3
+]).
+:- use_module('../core/prolog_term_parser', []).
+:- use_module('../core/cpp_runtime_parser_wrappers', []).
 :- use_module('../core/recursive_kernel_detection', [
     detect_recursive_kernel/4,
     kernel_metadata/4,
@@ -3039,9 +3045,13 @@ build_rust_wam_arg_setup(Arity, Setup) :-
 %  full recursive_kernel(Kind, Pred/Arity, ConfigOps) term.
 detect_kernels([], []).
 detect_kernels([PI|Rest], Kernels) :-
-    (   PI = _Mod:Pred/Arity -> true ; PI = Pred/Arity ),
+    (   PI = Module:Pred/Arity -> true ; PI = Pred/Arity, Module = user ),
     functor(Head, Pred, Arity),
-    findall(Head-Body, user:clause(Head, Body), Clauses),
+    (   rust_runtime_parser_support_module(Module)
+    ->  Clauses = []
+    ;   catch(findall(Head-Body, Module:clause(Head, Body), Clauses),
+              _, Clauses = [])
+    ),
     (   Clauses \= [],
         detect_recursive_kernel(Pred, Arity, Clauses, Kernel)
     ->  format(atom(Key), '~w/~w', [Pred, Arity]),
@@ -3132,6 +3142,9 @@ write_wam_rust_project(Predicates, Options, ProjectDir) :-
     option(module_name(ModuleName), Options, 'wam_generated'),
     get_time(TimeStamp),
     format_time(string(Date), "%Y-%m-%d %H:%M:%S", TimeStamp),
+    wam_target_runtime_parser(wam_rust, Options, RuntimeParserMode),
+    rust_validate_runtime_parser_mode(Predicates, RuntimeParserMode),
+    rust_project_predicates(Predicates, RuntimeParserMode, ProjectPredicates),
 
     % Detect recursive kernels in the predicate list. Detected kernels
     % are handled by the FFI (execute_foreign_predicate) at runtime and
@@ -3140,7 +3153,7 @@ write_wam_rust_project(Predicates, Options, ProjectDir) :-
     (   option(no_kernels(true), Options)
     ->  DetectedKernels = [],
         format(user_error, '[WAM-Rust] kernel detection suppressed~n', [])
-    ;   detect_kernels(Predicates, DetectedKernels),
+    ;   detect_kernels(ProjectPredicates, DetectedKernels),
         (   DetectedKernels \= []
         ->  pairs_keys(DetectedKernels, DetectedKeys),
             format(user_error, '[WAM-Rust] detected kernels: ~w~n', [DetectedKeys])
@@ -3234,7 +3247,7 @@ write_wam_rust_project(Predicates, Options, ProjectDir) :-
 
     % Compile predicates and generate lib.rs
     pairs_keys(DetectedKernels, DetectedKeys),
-    compile_predicates_for_project(Predicates, [foreign_pred_keys(DetectedKeys)|Options], PredicatesCode),
+    compile_predicates_for_project(ProjectPredicates, [foreign_pred_keys(DetectedKeys)|Options], PredicatesCode),
     format(string(FullPredicatesCode), "~w\n\n~w", [SetupForeignCode, PredicatesCode]),
     render_named_template(rust_wam_lib,
         [module_name=ModuleName, date=Date, predicates_code=FullPredicatesCode,
@@ -3251,7 +3264,66 @@ write_wam_rust_project(Predicates, Options, ProjectDir) :-
     write_file(MainRsPath, MainContent),
 
     format('WAM Rust project created at: ~w~n', [ProjectDir]),
-    format('  Predicates compiled: ~w~n', [Predicates]).
+    format('  Predicates compiled: ~w~n', [ProjectPredicates]).
+
+%% rust_project_predicates(+UserPreds, +Mode, -ProjectPreds)
+%  In `compiled` mode, append the portable parser plus the target-agnostic
+%  wrapper predicates. Other modes leave the user predicate list unchanged.
+rust_project_predicates(Predicates, compiled(prolog_term_parser), ProjectPredicates) :-
+    !,
+    rust_runtime_parser_predicates(ParserPreds),
+    rust_runtime_parser_wrapper_predicates(WrapperPreds),
+    append([Predicates, ParserPreds, WrapperPreds], Combined),
+    sort(Combined, ProjectPredicates).
+rust_project_predicates(Predicates, _RuntimeParserMode, Predicates).
+
+rust_runtime_parser_support_module(prolog_term_parser).
+rust_runtime_parser_support_module(cpp_runtime_parser_wrappers).
+
+rust_runtime_parser_predicates(Predicates) :-
+    findall(prolog_term_parser:Name/Arity,
+        (   current_predicate(prolog_term_parser:Name/Arity),
+            functor(Head, Name, Arity),
+            \+ predicate_property(prolog_term_parser:Head, imported_from(_)),
+            once(clause(prolog_term_parser:Head, _))
+        ),
+        Raw),
+    sort(Raw, Predicates).
+
+rust_runtime_parser_wrapper_predicates(Predicates) :-
+    findall(cpp_runtime_parser_wrappers:Name/Arity,
+        (   current_predicate(cpp_runtime_parser_wrappers:Name/Arity),
+            functor(Head, Name, Arity),
+            \+ predicate_property(cpp_runtime_parser_wrappers:Head,
+                                  imported_from(_)),
+            once(clause(cpp_runtime_parser_wrappers:Head, _))
+        ),
+        Raw),
+    sort(Raw, Predicates).
+
+rust_validate_runtime_parser_mode(Predicates, none) :-
+    !,
+    (   rust_predicates_parser_dependency(Predicates, Pred, Builtin)
+    ->  throw(error(permission_error(use, runtime_parser, Builtin),
+                    context(write_wam_rust_project/3,
+                            parser_disabled_for_predicate(Pred))))
+    ;   true
+    ).
+rust_validate_runtime_parser_mode(_Predicates, _Mode).
+
+rust_predicates_parser_dependency(Predicates, Pred, Builtin) :-
+    member(Pred, Predicates),
+    rust_predicate_clause(Pred, _Head, Body),
+    parser_dependent_body_goal(Body, Builtin),
+    !.
+
+rust_predicate_clause(Module:Name/Arity, Head, Body) :-
+    !,
+    functor(Head, Name, Arity),
+    clause(Module:Head, Body).
+rust_predicate_clause(Name/Arity, Head, Body) :-
+    functor(Head, Name, Arity),
+    clause(user:Head, Body).
 
 %% compile_predicates_for_project(+Predicates, +Options, -Code)
 %  Two-pass compilation: collects all WAM-fallback predicates into a shared
@@ -3306,6 +3378,7 @@ classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
     ),
     (   % Check for auto-detectable FFI kernel FIRST (unless suppressed)
         \+ option(no_kernels(true), Options),
+        \+ rust_runtime_parser_support_module(Module),
         functor(KHead, Pred, Arity),
         findall(KHead-KBody, Module:clause(KHead, KBody), KClauses),
         KClauses \= [],

--- a/tests/test_wam_runtime_parser_capability.pl
+++ b/tests/test_wam_runtime_parser_capability.pl
@@ -174,4 +174,28 @@ test(haskell_cannot_require_native_parser_yet,
 test(haskell_off_explicit_none) :-
     wam_target_runtime_parser(wam_haskell, [runtime_parser(off)], none).
 
+
+% --- Rust WAM target (compiled mode opt-in only) --------------------------
+
+test(rust_defaults_to_none) :-
+    wam_target_runtime_parser(wam_rust, [], none).
+
+test(rust_alias_defaults_to_none) :-
+    wam_target_runtime_parser(rust, [], none).
+
+test(rust_alias_can_opt_into_compiled_parser) :-
+    wam_target_runtime_parser(rust, [runtime_parser(compiled)],
+                              compiled(prolog_term_parser)).
+
+test(rust_can_opt_into_compiled_parser) :-
+    wam_target_runtime_parser(wam_rust, [runtime_parser(compiled)],
+                              compiled(prolog_term_parser)).
+
+test(rust_cannot_require_native_parser_yet,
+     [throws(error(domain_error(runtime_parser_mode(wam_rust), native), _))]) :-
+    wam_target_runtime_parser(wam_rust, [runtime_parser(native)], _).
+
+test(rust_off_explicit_none) :-
+    wam_target_runtime_parser(wam_rust, [runtime_parser(off)], none).
+
 :- end_tests(wam_runtime_parser_capability).

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -34,6 +34,14 @@ test_simple_fact(foo, bar).
 
 :- dynamic test_failed/0.
 
+:- dynamic rust_parser_read_demo/0.
+rust_parser_read_demo :-
+    read_term_from_atom('p(a)', _).
+
+:- dynamic rust_parser_term_to_atom_forward/0.
+rust_parser_term_to_atom_forward :-
+    term_to_atom(p(a), _).
+
 :- dynamic category_ancestor/4.
 :- dynamic category_parent/2.
 :- dynamic tail_suffix/2.
@@ -1703,6 +1711,94 @@ test_generated_project_has_parser :-
         fail_test(Test, 'Generated state.rs missing parser')
     ).
 
+test_runtime_parser_off_rejects_read :-
+    Test = 'WAM-Rust: runtime_parser(off) rejects parser-dependent bodies',
+    TmpDir = 'output/test_wam_rust_runtime_parser_off',
+    (   exists_directory(TmpDir)
+    ->  catch(delete_directory_and_contents(TmpDir), _, true)
+    ;   true
+    ),
+    (   catch(
+            write_wam_rust_project(
+                [user:rust_parser_read_demo/0],
+                [module_name('rust_parser_off'), runtime_parser(off)],
+                TmpDir),
+            error(permission_error(use, runtime_parser, read_term_from_atom/2), _),
+            true)
+    ->  catch(delete_directory_and_contents(TmpDir), _, true),
+        pass(Test)
+    ;   catch(delete_directory_and_contents(TmpDir), _, true),
+        fail_test(Test, 'runtime_parser(off) did not reject read_term_from_atom/2')
+    ).
+
+test_runtime_parser_off_allows_forward_term_to_atom :-
+    Test = 'WAM-Rust: runtime_parser(off) allows forward term_to_atom/2',
+    TmpDir = 'output/test_wam_rust_runtime_parser_term_to_atom_forward',
+    (   exists_directory(TmpDir)
+    ->  catch(delete_directory_and_contents(TmpDir), _, true)
+    ;   true
+    ),
+    (   write_wam_rust_project(
+            [user:rust_parser_term_to_atom_forward/0],
+            [module_name('rust_parser_forward'), runtime_parser(off)],
+            TmpDir),
+        directory_file_path(TmpDir, 'src', SrcDir),
+        directory_file_path(SrcDir, 'lib.rs', LibPath),
+        read_file_to_string(LibPath, LibStr, []),
+        sub_string(LibStr, _, _, _, 'Module: rust_parser_forward'),
+        \+ sub_string(LibStr, _, _, _, 'labels.insert("read_term_from_atom/2"')
+    ->  catch(delete_directory_and_contents(TmpDir), _, true),
+        pass(Test)
+    ;   catch(delete_directory_and_contents(TmpDir), _, true),
+        fail_test(Test, 'runtime_parser(off) rejected safe forward term_to_atom/2')
+    ).
+
+test_runtime_parser_compiled_includes_parser_and_wrappers :-
+    Test = 'WAM-Rust: runtime_parser(compiled) includes parser and wrappers',
+    TmpDir = 'output/test_wam_rust_runtime_parser_compiled',
+    (   exists_directory(TmpDir)
+    ->  catch(delete_directory_and_contents(TmpDir), _, true)
+    ;   true
+    ),
+    (   write_wam_rust_project(
+            [user:rust_parser_read_demo/0],
+            [module_name('rust_parser_compiled'), runtime_parser(compiled)],
+            TmpDir),
+        directory_file_path(TmpDir, 'src', SrcDir),
+        directory_file_path(SrcDir, 'lib.rs', LibPath),
+        read_file_to_string(LibPath, LibStr, []),
+        sub_string(LibStr, _, _, _, 'labels.insert("parse_term_from_atom/3"'),
+        sub_string(LibStr, _, _, _, 'labels.insert("canonical_op_table/1"'),
+        sub_string(LibStr, _, _, _, 'labels.insert("read_term_from_atom/2"'),
+        sub_string(LibStr, _, _, _, 'labels.insert("parse_atom_to_term/2"')
+    ->  catch(delete_directory_and_contents(TmpDir), _, true),
+        pass(Test)
+    ;   catch(delete_directory_and_contents(TmpDir), _, true),
+        fail_test(Test, 'runtime_parser(compiled) did not include parser/wrapper labels')
+    ).
+
+test_runtime_parser_default_excludes_wrappers :-
+    Test = 'WAM-Rust: runtime_parser(auto) does not bundle parser wrappers',
+    TmpDir = 'output/test_wam_rust_runtime_parser_default',
+    (   exists_directory(TmpDir)
+    ->  catch(delete_directory_and_contents(TmpDir), _, true)
+    ;   true
+    ),
+    (   write_wam_rust_project(
+            [user:test_simple_fact/2],
+            [module_name('rust_parser_default')],
+            TmpDir),
+        directory_file_path(TmpDir, 'src', SrcDir),
+        directory_file_path(SrcDir, 'lib.rs', LibPath),
+        read_file_to_string(LibPath, LibStr, []),
+        \+ sub_string(LibStr, _, _, _, 'labels.insert("read_term_from_atom/2"'),
+        \+ sub_string(LibStr, _, _, _, 'labels.insert("parse_term_from_atom/3"')
+    ->  catch(delete_directory_and_contents(TmpDir), _, true),
+        pass(Test)
+    ;   catch(delete_directory_and_contents(TmpDir), _, true),
+        fail_test(Test, 'runtime_parser(auto) unexpectedly bundled parser wrappers')
+    ).
+
 test_parser_resilience :-
     Test = 'WAM-Rust: parser handles malformed input gracefully',
     (   read_file_to_string(
@@ -2020,6 +2116,10 @@ run_tests :-
     test_state_template_has_parser,
     test_parser_handles_all_instructions,
     test_generated_project_has_parser,
+    test_runtime_parser_off_rejects_read,
+    test_runtime_parser_off_allows_forward_term_to_atom,
+    test_runtime_parser_compiled_includes_parser_and_wrappers,
+    test_runtime_parser_default_excludes_wrappers,
     test_parser_resilience,
     test_cross_predicate_shared_wam,
     test_cross_predicate_distinct_pcs,


### PR DESCRIPTION
## Summary

- Registers WAM-Rust for opt-in `runtime_parser(compiled)` while keeping the default at `none`.
- Updates `write_wam_rust_project/3` to append the portable Prolog term parser and target-agnostic parser wrappers in compiled mode.
- Adds Rust guardrails so `runtime_parser(off)` rejects statically visible parser-dependent bodies, while forward `term_to_atom/2` remains allowed.
- Skips parser support modules during Rust FFI kernel detection so bundled parser predicates are compiled through normal WAM fallback.
- Updates runtime-parser status/design docs to mark Rust as partial: project expansion is wired, runtime builtin execution bridge remains a follow-up.

## Scope Note

This PR does not claim full Rust runtime parsing execution yet. It wires the compile-time/project-expansion half and documents that the next Rust step is a Python-style `read_term_from_atom/2,3` builtin bridge in the runtime.

## Verification

- `swipl -q -s tests/test_wam_runtime_parser_capability.pl -g run_tests -t halt`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `swipl -q -s tests/test_wam_rust_target.pl -g run_tests -t halt`
- `git diff --check`
