### PR TITLE
test(cpp): crash-safe wam_runtime.o cache (the 3 "failures" were stale-cache artifacts)

### DIFF
--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -10412,12 +10412,25 @@ cached_wam_runtime_object(RuntimeCpp, CachedObj) :-
     format(atom(CachedObj), '~w/wam_runtime_~w.o', [CacheDir, Hash]),
     (   exists_file(CachedObj)
     ->  true
-    ;   process_create(path('g++'),
+    ;   %% Compile to a unique temp file, then atomically rename into
+        %% place. A direct `g++ -c -o CachedObj` is NOT crash-safe: if the
+        %% compile is interrupted (e.g. the suite is killed by a timeout),
+        %% a truncated .o is left at CachedObj and every later run reuses
+        %% it via exists_file/1, linking a corrupt runtime and producing
+        %% spurious e2e failures. rename/2 on the same filesystem is
+        %% atomic, so the cache only ever holds a complete object.
+        random_between(100000, 999999, Salt),
+        format(atom(TmpObj), '~w/wam_runtime_~w.~w.tmp.o', [CacheDir, Hash, Salt]),
+        process_create(path('g++'),
                        ['-std=c++17', '-O0', '-c',
-                        '-o', CachedObj, RuntimeCpp],
+                        '-o', TmpObj, RuntimeCpp],
                        [stderr(null), process(PID)]),
         process_wait(PID, Status),
-        assertion(Status == exit(0))
+        assertion(Status == exit(0)),
+        catch(rename_file(TmpObj, CachedObj), _,
+              %% Lost a race with a concurrent compile: the winner's
+              %% complete object is already in place; drop our temp.
+              catch(delete_file(TmpObj), _, true))
     ).
 
 run_query(BinPath, PredKey, Args, Expected) :-


### PR DESCRIPTION
## TL;DR

The 3 "pre-existing" cpp e2e failures (`cpp_e2e_bagof_inlined_groups_by_witness`, `cpp_e2e_setof_inlined_groups_sorted`, `cpp_e2e_lists_cleanup`) **are not real bugs.** With the shared runtime cache cleared, **`test_wam_cpp_generator` passes 386/386 on main.** This PR hardens the cache so the spurious failures can't recur — no product code changes.

## Investigation

The failures did not reproduce in isolation. The exact predicates pass:
- generated + built + run standalone (`true`),
- via the harness's separate-compilation build,
- through plunit run singly (full file loaded),
- a related meta-aggregate test + the inlined one in one process,
- even after a *polluting* prior project (extra atoms / ITE / aggregate).

They only failed inside a full ~386-test run. Clearing `/tmp/uw_cpp_runtime_cache` → **386/386 pass**.

## Root cause

`cached_wam_runtime_object/2` compiled `wam_runtime.cpp` **directly** to its content-hashed cache path (`g++ -c -o CachedObj`). That isn't crash-safe: if the suite is interrupted mid-compile (e.g. killed by a timeout — which happened repeatedly while I was iterating on the cpp backend this session), a **truncated `.o`** is left at `CachedObj`, and every later run reuses it via `exists_file/1`, linking a corrupt runtime → `assertion_failed` in unrelated e2e tests. The content hash guarantees the *source* matches but not that the *object* is complete.

## Fix

Compile to a unique temp object, then `rename/2` into place. Rename on the same filesystem is atomic, so the cache only ever exposes a complete object; an interrupted compile leaves a harmless stray `.tmp.o` rather than a poisoned cache entry. A lost rename race falls back to the winner's complete object.

## Verification

Cache cleared → full suite **386/386**. The 3 previously-"failing" tests pass, and the cache holds exactly one complete `.o` with no temp leftovers.

> Honest note: these phantom failures were partly self-inflicted — my many timeout-killed cpp suite runs this session poisoned the shared `/tmp` cache. The atomic-rename fix makes the harness robust to that regardless of cause.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_