### PR TITLE
Feat/wam go format directives

### DIFF
--- a/PR_go_wam_format_directives.md
+++ b/PR_go_wam_format_directives.md
@@ -1,0 +1,28 @@
+# PR Title
+
+Broaden Go WAM format directive support
+
+# PR Description
+
+## Summary
+
+- Extend Go WAM `format/1` and `format/2` directive handling beyond `~w`, `~n`, and `~~`.
+- Add bounded support for `~a`, `~d`, `~p`, and `~q`.
+- Keep `~p` and `~q` aligned with the current Go WAM term rendering path.
+- Add generated Go WAM E2E coverage for the expanded directive set.
+- Update the Go WAM parity audit for the broadened R/Python/C++ format subset.
+
+## Scope
+
+This does not add `format/3`, stream capture, `with_output_to/2`, `~s`, tab directives, or richer canonical quoting. Those remain separate runtime-surface slices.
+
+## Validation
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+
+Existing non-fatal choicepoint warnings still appear in the same Go WAM tests.

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -66,9 +66,10 @@ current cross-target builtin/runtime baseline.
   parsing.
 - Bounded `format/1` and `format/2` are now direct Go WAM builtins and are
   covered by the generated builtin E2E test for literal `~~`, newline `~n`,
-  `~w` argument substitution, and missing-argument failure. Stream capture,
-  destination-aware `format/3`, and broader formatting directives remain
-  separate from this small R/C++/Python output-parity slice.
+  `~w`, `~a`, `~d`, `~p`, and `~q` argument substitution, and
+  missing-argument failure. Stream capture, destination-aware `format/3`,
+  `~s`, tab directives, and richer canonical quoting remain separate from
+  this small R/C++/Python output-parity slice.
 - Deterministic `subtract/3` is now covered by the generated Go WAM builtin
   E2E test for filtering all right-list matches from the left list, preserving
   left-list order, empty-list behavior, all-removed results, duplicate removal,

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -890,11 +890,33 @@ func (vm *WamState) formatTemplate(template string, args []Value) (string, bool)
 			b.WriteByte('\n')
 		case '~':
 			b.WriteByte('~')
-		case 'w':
+		case 'w', 'p', 'q':
 			if argIdx >= len(args) {
 				return "", false
 			}
 			b.WriteString(vm.deref(args[argIdx]).String())
+			argIdx++
+		case 'a':
+			if argIdx >= len(args) {
+				return "", false
+			}
+			value := vm.deref(args[argIdx])
+			if atom, ok := value.(*Atom); ok {
+				b.WriteString(atom.Name)
+			} else {
+				b.WriteString(value.String())
+			}
+			argIdx++
+		case 'd':
+			if argIdx >= len(args) {
+				return "", false
+			}
+			value := vm.deref(args[argIdx])
+			if integer, ok := value.(*Integer); ok {
+				b.WriteString(strconv.FormatInt(integer.Val, 10))
+			} else {
+				b.WriteString(value.String())
+			}
 			argIdx++
 		default:
 			b.WriteByte('~')

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -689,6 +689,7 @@ test(builtins_execution) :-
           assertz(user:test_format_builtin :-
             (   format('fmt_one ~~ ok~n'),
                 format('fmt_two ~w ~w~~~n', [go, 42]),
+                format('fmt_more ~a ~d ~p ~q~n', [atom_arg, 17, pair(a,b), quoted_atom]),
                 \+ format('fmt_missing ~w', [])
             )),
           assertz(user:test_set_aggregate :-
@@ -1298,6 +1299,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "OUTPUT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "fmt_one ~ ok")),
         assertion(sub_string(FullOutput, _, _, _, "fmt_two go 42~")),
+        assertion(sub_string(FullOutput, _, _, _, "fmt_more atom_arg 17 pair/2/2 quoted_atom")),
         assertion(sub_string(FullOutput, _, _, _, "FORMAT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),


### PR DESCRIPTION
# Broaden Go WAM format directive support

## Summary

- Extend Go WAM `format/1` and `format/2` directive handling beyond `~w`, `~n`, and `~~`.
- Add bounded support for `~a`, `~d`, `~p`, and `~q`.
- Keep `~p` and `~q` aligned with the current Go WAM term rendering path.
- Add generated Go WAM E2E coverage for the expanded directive set.
- Update the Go WAM parity audit for the broadened R/Python/C++ format subset.

## Scope

This does not add `format/3`, stream capture, `with_output_to/2`, `~s`, tab directives, or richer canonical quoting. Those remain separate runtime-surface slices.

## Validation

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`

Existing non-fatal choicepoint warnings still appear in the same Go WAM tests.
