### PR TITLE
LLVM WAM: kill/2 (M111) -- libc kill wrapper

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1511,6 +1511,7 @@ declare i32 @getegid()
 declare i32 @getppid()
 declare i32 @getpgrp()
 declare i8* @realpath(i8*, i8*)
+declare i32 @kill(i32, i32)
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3601,6 +3602,7 @@ entry:
     i32 126, label %builtin_directory_files
     i32 127, label %builtin_getpgrp
     i32 128, label %builtin_realpath
+    i32 129, label %builtin_kill
   ]
 
 builtin_is:
@@ -5729,6 +5731,33 @@ rp.intern:
   %rp.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
   %rp.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %rp.raw2, %Value %rp.v)
   ret i1 %rp.ok
+
+builtin_kill:
+  ; M111: kill(+Pid, +Sig) -- libc kill wrapper. Both args must be
+  ; Integer. Most common usage is Sig=0 which sends no signal but
+  ; returns 0 iff the process exists and the caller has permission
+  ; to signal it -- a cheap existence/permission probe. Succeeds
+  ; iff libc kill returns 0; failure modes (ESRCH for missing pid,
+  ; EPERM for forbidden) all map to a Prolog fail.
+  %kl.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %kl.t1 = call i32 @value_tag(%Value %kl.a1)
+  %kl.is_int1 = icmp eq i32 %kl.t1, 1
+  br i1 %kl.is_int1, label %kl.check2, label %kl.fail
+kl.fail:
+  ret i1 false
+kl.check2:
+  %kl.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %kl.t2 = call i32 @value_tag(%Value %kl.a2)
+  %kl.is_int2 = icmp eq i32 %kl.t2, 1
+  br i1 %kl.is_int2, label %kl.go, label %kl.fail
+kl.go:
+  %kl.pid64 = call i64 @value_payload(%Value %kl.a1)
+  %kl.pid = trunc i64 %kl.pid64 to i32
+  %kl.sig64 = call i64 @value_payload(%Value %kl.a2)
+  %kl.sig = trunc i64 %kl.sig64 to i32
+  %kl.ret = call i32 @kill(i32 %kl.pid, i32 %kl.sig)
+  %kl.ok = icmp eq i32 %kl.ret, 0
+  ret i1 %kl.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -12803,6 +12832,7 @@ builtin_op_to_id('access/2', 125).            % libc access(path, mode_bits).
 builtin_op_to_id('directory_files/2', 126).   % opendir/readdir loop -> list of atoms.
 builtin_op_to_id('getpgrp/1', 127).           % libc getpgrp() as Integer.
 builtin_op_to_id('realpath/2', 128).          % libc realpath(rel) -> Abs atom.
+builtin_op_to_id('kill/2', 129).              % libc kill(pid, sig).
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2105,6 +2105,7 @@ is_builtin_pred(getegid, 1).            % getegid(-EGid).
 is_builtin_pred(getppid, 1).            % getppid(-PPid).
 is_builtin_pred(getpgrp, 1).            % getpgrp(-PGid) -- process group id.
 is_builtin_pred(realpath, 2).           % realpath(+Path, -Abs) -- canonical absolute path.
+is_builtin_pred(kill, 2).               % kill(+Pid, +Sig) -- signal 0 = existence check.
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,29 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M111: kill/2 -- libc kill wrapper. Sig=0 is the standard existence
+% probe (no signal sent, just check process exists + permission).
+
+:- dynamic test_kill_self_probe/2.
+test_kill_self_probe(_, R) :-
+    % kill(0, 0) sends signal 0 to ALL processes in the caller''s
+    % group -- succeeds iff at least one exists and we have
+    % permission. Effectively a no-op self-check.
+    ( kill(0, 0) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_kill_missing_pid/2.
+test_kill_missing_pid(_, R) :-
+    % Some pid that''s almost certainly not running. ESRCH.
+    ( kill(99999999, 0) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_kill_bad_args/2.
+test_kill_bad_args(_, R) :-
+    % Non-int args fail the type guards.
+    ( kill(not_int, 0) -> R is 0
+    ; kill(0, not_int) -> R is 0
+    ; R is 1
+    ).   % 1
+
 % M110: realpath/2 -- libc realpath wrapper for canonical absolute paths.
 
 :- dynamic test_rp_tmp/2.
@@ -5260,6 +5283,13 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M111 kill/2 ---~n'),
+       run_test_r0('kill(0, 0) self-probe -> 1',
+                   test_kill_self_probe, 0, 1),
+       run_test_r0('kill on missing pid fails -> 1',
+                   test_kill_missing_pid, 0, 1),
+       run_test_r0('kill with non-int args fails -> 1',
+                   test_kill_bad_args, 0, 1),
        format('--- M110 realpath/2 ---~n'),
        run_test_r0('realpath(/tmp, Abs), Abs == /tmp -> 1',
                    test_rp_tmp, 0, 1),


### PR DESCRIPTION
## Summary

- **M111 `kill/2`** — libc `kill(pid, sig)` wrapper. Op id 129.

Reads reg 0 (Pid) and reg 1 (Sig) as Integers, truncates both `i64` payloads to `i32` (`pid_t` and signal numbers fit), and calls libc `kill`. Succeeds iff `kill` returns 0; `ESRCH` (no such pid), `EPERM` (no permission), `EINVAL` (bad signal) all map to a Prolog fail. Non-Integer args fall through to fail.

The common usage pattern is `Sig=0` — libc treats it as a no-signal "probe" that succeeds iff the process exists and the caller is permitted to signal it. The M111 tests exercise that shape rather than sending real signals.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `@kill` libc decl, dispatch entry, `builtin_kill` IR block (prefix `kl.`), op-id table entry.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred(kill, 2)`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — three M111 tests + section.

## Test plan

- [x] Full execution suite: **672/672 PASS**, no failures, no OOM ✓
- [x] `test_kill_self_probe`: `kill(0, 0)` probes the caller's own process group — always succeeds for a running process ✓
- [x] `test_kill_missing_pid`: `kill(99999999, 0)` correctly fails (`ESRCH`) ✓
- [x] `test_kill_bad_args`: non-int args fail the type guards ✓

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_