### PR TITLE
LLVM WAM: truncate/2 (M112) -- libc truncate wrapper

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1512,6 +1512,7 @@ declare i32 @getppid()
 declare i32 @getpgrp()
 declare i8* @realpath(i8*, i8*)
 declare i32 @kill(i32, i32)
+declare i32 @truncate(i8*, i64)
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3603,6 +3604,7 @@ entry:
     i32 127, label %builtin_getpgrp
     i32 128, label %builtin_realpath
     i32 129, label %builtin_kill
+    i32 130, label %builtin_truncate
   ]
 
 builtin_is:
@@ -5758,6 +5760,36 @@ kl.go:
   %kl.ret = call i32 @kill(i32 %kl.pid, i32 %kl.sig)
   %kl.ok = icmp eq i32 %kl.ret, 0
   ret i1 %kl.ok
+
+builtin_truncate:
+  ; M112: truncate(+Path, +Length) -- libc truncate wrapper. Sets
+  ; the file to exactly Length bytes; grows it (with zero-fill)
+  ; if smaller, shrinks it if larger. Path must be Atom, Length
+  ; Integer (off_t is i64 on x86-64 Linux). Succeeds iff truncate
+  ; returns 0; ENOENT, EACCES, EISDIR etc. all map to a Prolog
+  ; fail. Non-atom Path or non-Integer Length fall through to
+  ; fail.
+  %tr.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %tr.t1 = call i32 @value_tag(%Value %tr.a1)
+  %tr.is_atom = icmp eq i32 %tr.t1, 0
+  br i1 %tr.is_atom, label %tr.check2, label %tr.fail
+tr.fail:
+  ret i1 false
+tr.check2:
+  %tr.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %tr.t2 = call i32 @value_tag(%Value %tr.a2)
+  %tr.is_int = icmp eq i32 %tr.t2, 1
+  br i1 %tr.is_int, label %tr.go, label %tr.fail
+tr.go:
+  %tr.aid = call i64 @value_payload(%Value %tr.a1)
+  %tr.path = call i8* @wam_atom_to_string(i64 %tr.aid)
+  %tr.path_null = icmp eq i8* %tr.path, null
+  br i1 %tr.path_null, label %tr.fail, label %tr.do
+tr.do:
+  %tr.len = call i64 @value_payload(%Value %tr.a2)
+  %tr.ret = call i32 @truncate(i8* %tr.path, i64 %tr.len)
+  %tr.ok = icmp eq i32 %tr.ret, 0
+  ret i1 %tr.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -12833,6 +12865,7 @@ builtin_op_to_id('directory_files/2', 126).   % opendir/readdir loop -> list of 
 builtin_op_to_id('getpgrp/1', 127).           % libc getpgrp() as Integer.
 builtin_op_to_id('realpath/2', 128).          % libc realpath(rel) -> Abs atom.
 builtin_op_to_id('kill/2', 129).              % libc kill(pid, sig).
+builtin_op_to_id('truncate/2', 130).          % libc truncate(path, length).
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2106,6 +2106,7 @@ is_builtin_pred(getppid, 1).            % getppid(-PPid).
 is_builtin_pred(getpgrp, 1).            % getpgrp(-PGid) -- process group id.
 is_builtin_pred(realpath, 2).           % realpath(+Path, -Abs) -- canonical absolute path.
 is_builtin_pred(kill, 2).               % kill(+Pid, +Sig) -- signal 0 = existence check.
+is_builtin_pred(truncate, 2).           % truncate(+Path, +Length) -- set file size.
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,45 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M112: truncate/2 -- libc truncate wrapper for file resizing.
+
+:- dynamic test_truncate_grow/2.
+test_truncate_grow(_, R) :-
+    % Create a tiny file via shell, truncate it to 100 bytes,
+    % verify size_file reports 100.
+    Path = '/tmp/uw_m112_truncate_test',
+    shell('touch /tmp/uw_m112_truncate_test', _),
+    truncate(Path, 100),
+    size_file(Path, Sz),
+    shell('rm -f /tmp/uw_m112_truncate_test', _),
+    ( Sz =:= 100 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_truncate_zero/2.
+test_truncate_zero(_, R) :-
+    % Truncating to 0 is a no-op on a freshly-created file but
+    % should still succeed.
+    Path = '/tmp/uw_m112_truncate_zero',
+    shell('touch /tmp/uw_m112_truncate_zero', _),
+    truncate(Path, 0),
+    size_file(Path, Sz),
+    shell('rm -f /tmp/uw_m112_truncate_zero', _),
+    ( Sz =:= 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_truncate_missing/2.
+test_truncate_missing(_, R) :-
+    % truncate on a non-existent path fails (ENOENT).
+    ( truncate('/tmp/uw_m112_does_not_exist', 0) -> R is 0
+    ; R is 1
+    ).   % 1
+
+:- dynamic test_truncate_bad_args/2.
+test_truncate_bad_args(_, R) :-
+    % Non-atom Path or non-Integer Length fail the type guards.
+    ( truncate(42, 0) -> R is 0
+    ; truncate('/tmp/x', not_int) -> R is 0
+    ; R is 1
+    ).   % 1
+
 % M111: kill/2 -- libc kill wrapper. Sig=0 is the standard existence
 % probe (no signal sent, just check process exists + permission).
 
@@ -5283,6 +5322,15 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M112 truncate/2 ---~n'),
+       run_test_r0('touch + truncate 100 + size_file -> 1',
+                   test_truncate_grow, 0, 1),
+       run_test_r0('truncate 0 -> size 0 -> 1',
+                   test_truncate_zero, 0, 1),
+       run_test_r0('truncate on missing path fails -> 1',
+                   test_truncate_missing, 0, 1),
+       run_test_r0('truncate with non-atom path / non-int length fails -> 1',
+                   test_truncate_bad_args, 0, 1),
        format('--- M111 kill/2 ---~n'),
        run_test_r0('kill(0, 0) self-probe -> 1',
                    test_kill_self_probe, 0, 1),


### PR DESCRIPTION
## Summary

- **M112 `truncate/2`** — libc `truncate(path, length)` wrapper for file resizing. Op id 130.

Reads reg 0 (Path) as Atom and reg 1 (Length) as Integer, pulls the path via `wam_atom_to_string`, and calls libc `truncate`. `off_t` is `i64` on x86-64 Linux so the Length payload goes through unchanged. Succeeds iff `truncate` returns 0; `ENOENT`, `EACCES`, `EISDIR` and friends all map to a Prolog fail. Non-atom Path or non-Integer Length fall through to fail.

Same shape as M102 `builtin_chmod` with `i64` length instead of `i32` mode bits.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `@truncate` libc decl, dispatch entry, `builtin_truncate` IR block (prefix `tr.`), op-id table entry.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred(truncate, 2)`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — four M112 tests + section.

## Test plan

- [x] Full execution suite: **676/676 PASS**, no failures, no OOM ✓
- [x] `test_truncate_grow`: `touch` + `truncate 100` + `size_file = 100` ✓
- [x] `test_truncate_zero`: truncate to 0 on a touched file leaves size 0 ✓
- [x] `test_truncate_missing`: truncate on absent path correctly fails (`ENOENT`) ✓
- [x] `test_truncate_bad_args`: non-atom path / non-int length both fail the type guards ✓

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_