### PR TITLE
feat(wam-clojure): lower subtract/3 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -424,6 +424,10 @@ clojure_direct_builtin("delete/3", "3").
 clojure_direct_builtin("delete/3", 3).
 clojure_direct_builtin('delete/3', "3").
 clojure_direct_builtin('delete/3', 3).
+clojure_direct_builtin("subtract/3", "3").
+clojure_direct_builtin("subtract/3", 3).
+clojure_direct_builtin('subtract/3', "3").
+clojure_direct_builtin('subtract/3', 3).
 clojure_direct_builtin("list_to_set/2", "2").
 clojure_direct_builtin("list_to_set/2", 2).
 clojure_direct_builtin('list_to_set/2', "2").
@@ -846,6 +850,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "delete/3" ; Op == 'delete/3'),
     !,
     format(atom(Expr), '(runtime/apply-delete-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "subtract/3" ; Op == 'subtract/3'),
+    !,
+    format(atom(Expr), '(runtime/apply-subtract-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "list_to_set/2" ; Op == 'list_to_set/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1199,6 +1199,29 @@
       :else
       (backtrack state))))
 
+(defn list-minus-items [state left right]
+  (remove (fn [item]
+            (some #(term-identical? state item %) right))
+          left))
+
+(defn apply-subtract-solution [state]
+  (let [left-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        right-value (deref-value (:bindings state)
+                                 (or (reg-get-raw state "A2") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A3") ::unbound))
+        left-items (proper-list-items state left-value)
+        right-items (proper-list-items state right-value)]
+    (if (and (some? left-items) (some? right-items))
+      (let [result-term (list->term (:intern-context state)
+                                    (list-minus-items state left-items right-items))
+            [ok next-state] (unify-values state out result-term)]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+      (backtrack state))))
+
 (defn list-to-set-items [state items]
   (reduce (fn [out item]
             (if (some #(term-identical? state % item) out)
@@ -2649,6 +2672,9 @@
 
           "delete/3"
           (apply-delete-solution state)
+
+          "subtract/3"
+          (apply-subtract-solution state)
 
           "list_to_set/2"
           (apply-list-to-set-solution state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -125,6 +125,11 @@
 :- dynamic user:wam_delete_guard/3.
 :- dynamic user:wam_delete_bad_list/1.
 :- dynamic user:wam_delete_unbound_list/1.
+:- dynamic user:wam_subtract_guard/3.
+:- dynamic user:wam_subtract_empty_left/0.
+:- dynamic user:wam_subtract_duplicates/0.
+:- dynamic user:wam_subtract_bad_left/1.
+:- dynamic user:wam_subtract_bad_right/1.
 :- dynamic user:wam_list_to_set_guard/2.
 :- dynamic user:wam_list_to_set_empty/0.
 :- dynamic user:wam_list_to_set_singleton/0.
@@ -456,6 +461,11 @@ user:wam_numlist_unbound_low(List) :- numlist(Low, 3, List), integer(Low).
 user:wam_delete_guard(L, Elem, Rest) :- delete(L, Elem, Rest).
 user:wam_delete_bad_list(Rest) :- delete([a|b], a, Rest).
 user:wam_delete_unbound_list(Rest) :- delete(L, a, Rest), is_list(L).
+user:wam_subtract_guard(Left, Right, Diff) :- subtract(Left, Right, Diff).
+user:wam_subtract_empty_left :- subtract([], [a], Diff), Diff = [].
+user:wam_subtract_duplicates :- subtract([a,a,b,c], [b], Diff), Diff = [a,a,c].
+user:wam_subtract_bad_left(_) :- subtract([a|b], [a], _).
+user:wam_subtract_bad_right(_) :- subtract([a], [a|b], _).
 user:wam_list_to_set_guard(List, Set) :- list_to_set(List, Set).
 user:wam_list_to_set_empty :- list_to_set([], Set), Set = [].
 user:wam_list_to_set_singleton :- list_to_set([x], Set), Set = [x].
@@ -792,6 +802,11 @@ run_smoke :-
           user:wam_delete_guard/3,
           user:wam_delete_bad_list/1,
           user:wam_delete_unbound_list/1,
+          user:wam_subtract_guard/3,
+          user:wam_subtract_empty_left/0,
+          user:wam_subtract_duplicates/0,
+          user:wam_subtract_bad_left/1,
+          user:wam_subtract_bad_right/1,
           user:wam_list_to_set_guard/2,
           user:wam_list_to_set_empty/0,
           user:wam_list_to_set_singleton/0,
@@ -1038,6 +1053,7 @@ run_smoke :-
     assert_lowered_select_builtin_emitted(TmpDir),
     assert_lowered_numlist_builtin_emitted(TmpDir),
     assert_lowered_delete_builtin_emitted(TmpDir),
+    assert_lowered_subtract_builtin_emitted(TmpDir),
     assert_lowered_list_to_set_builtin_emitted(TmpDir),
     assert_lowered_sort_builtin_emitted(TmpDir),
     assert_lowered_msort_builtin_emitted(TmpDir),
@@ -1277,6 +1293,12 @@ smoke_cases([
     case('wam_delete_unbound_list/1', '[]', "true"),
     case('wam_delete_unbound_list/1', '[b,c]', "true"),
     case('wam_delete_unbound_list/1', '[a]', "false"),
+    case('wam_subtract_guard/3', args('[a,b,a,c]', '[a,b]', '[c]'), "true"),
+    case('wam_subtract_guard/3', args('[a,b,a,c]', '[a,b]', '[a,c]'), "false"),
+    case('wam_subtract_empty_left/0', no_args, "true"),
+    case('wam_subtract_duplicates/0', no_args, "true"),
+    case('wam_subtract_bad_left/1', a, "false"),
+    case('wam_subtract_bad_right/1', a, "false"),
     case('wam_list_to_set_guard/2', args('[a,b,c,a,b,d,a]', '[a,b,c,d]'), "true"),
     case('wam_list_to_set_guard/2', args('[a,b,c,a,b,d,a]', '[a,b,c,a]'), "false"),
     case('wam_list_to_set_empty/0', no_args, "true"),
@@ -1791,6 +1813,15 @@ assert_lowered_delete_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-delete-bad-list-1"),
     has(CoreCode, "defn lowered-wam-delete-unbound-list-1"),
     has(CoreCode, "runtime/apply-delete-solution").
+
+assert_lowered_subtract_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-subtract-guard-3"),
+    has(CoreCode, "defn lowered-wam-subtract-duplicates-0"),
+    has(CoreCode, "defn lowered-wam-subtract-bad-left-1"),
+    has(CoreCode, "defn lowered-wam-subtract-bad-right-1"),
+    has(CoreCode, "runtime/apply-subtract-solution").
 
 assert_lowered_list_to_set_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM direct-lowered support for `subtract/3`.
- Implements the runtime helper for deterministic set-difference-style list filtering.
- Extends the Clojure runtime smoke fixture with success, mismatch, empty-left, duplicate-preservation, and malformed-list cases.

## Why

This continues Clojure WAM list/set builtin parity after `list_to_set/2`. Go and LLVM already cover the `subtract/3`, `intersection/3`, `union/3`, and `list_to_set/2` family; this PR adds the next adjacent Clojure runtime piece.

## Behavior

- Requires both input lists to be proper bound lists.
- Preserves left-list order.
- Preserves duplicates from the left list when the value is not removed.
- Removes any left item that is identical to any item in the right list.
- Fails deterministically for malformed input lists or output unification mismatch.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
