### PR TITLE
feat(haskell): lower nested ITE + negation via shared structurer (perf-neutral)

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
@@ -29,6 +29,7 @@
 
 :- use_module(library(lists)).
 :- use_module(wam_text_parser, [wam_classify_constant_token/2]).
+:- use_module(wam_ite_structurer, [structure_ite/2]).
 
 %% =====================================================================
 %% Parsing
@@ -75,7 +76,28 @@ wam_haskell_lowerable(_PI, WamCode, _Reason) :-
     %   - Detected kernels are excluded from lowering by the partition
     %     logic (they use FFI via CallForeign, lowering would be dead code).
     clause1_instrs(PCInstrs, C1),
-    forall(member(I, C1), supported(I)).
+    forall(member(I, C1), supported(I)),
+    % Verify clause 1 actually folds via the shared structurer. Negation
+    % (!/0 commit) and nested ITEs now structure and lower; a genuinely
+    % ill-formed control block fails here and falls back to the interpreter
+    % instead of failing lower_all (keeps gate <-> emit in lockstep).
+    clause1_pc(PCInstrs, C1PC),
+    parse_wam_text(WamCode, _, LabelMap),
+    struct_stream(C1PC, LabelMap, Stream),
+    structure_ite(Stream, _).
+
+%% clause1_pc(+PCInstrs, -Clause1PCs)
+%  Like clause1_instrs/2 but keeps pc(PC,Instr) form, matching exactly the
+%  clause-1 slice emit_func/4 structures (strip switch prefixes, then the
+%  predicate-level try_me_else, then take to proceed).
+clause1_pc([], []).
+clause1_pc(PCInstrs0, C1) :-
+    strip_switch_prefixes(PCInstrs0, PCInstrs),
+    PCInstrs0 \== PCInstrs, !,
+    clause1_pc(PCInstrs, C1).
+clause1_pc([pc(_, try_me_else(_))|Rest], C1) :- !,
+    take_to_proceed_pc(Rest, C1).
+clause1_pc(PCInstrs, PCInstrs).
 
 clause1_instrs([], []).
 % Skip switch_on_constant* prefixes (multi-clause indexing).
@@ -217,10 +239,10 @@ emit_func(FN, PCInstrs, LabelMap, ForeignPreds) :-
         format("  where~n"),
         format("    clause1 s_c1 = do~n"),
         take_to_proceed_pc(BodyPCs, Clause1PCs),
-        emit_instrs_lm(Clause1PCs, "s_c1", "      ", ForeignPreds, LabelMap)
+        emit_clause_struct(Clause1PCs, LabelMap, "s_c1", "      ", ForeignPreds)
     ;   % Single-clause: simple do-notation
         format("~w !ctx s_init = do~n", [FN]),
-        emit_instrs_lm(PCInstrs1, "s_init", "  ", ForeignPreds, LabelMap)
+        emit_clause_struct(PCInstrs1, LabelMap, "s_init", "  ", ForeignPreds)
     ).
 
 take_to_proceed_pc([], []).
@@ -432,6 +454,125 @@ split_else_cont_([pc(PC, Instr)|Rest], ContLabel, LM, Else, Cont) :-
         Cont = [pc(PC, Instr)|Rest]
     ;   Else = [pc(PC, Instr)|ElseRest],
         split_else_cont_(Rest, ContLabel, LM, ElseRest, Cont)
+    ).
+
+%% =====================================================================
+%% Structured ITE emission (shared nesting-aware structurer)
+%% =====================================================================
+%
+%  The flat split_ite_blocks_lm/split_at_jump heuristic is NOT nesting
+%  aware (split_at_jump stops at an inner jump) and only recognises
+%  cut_ite (not the !/0 negation commit), so nested ITEs and \+ failed to
+%  lower. We instead feed clause 1 through the shared wam_ite_structurer:
+%  struct_stream/3 rebuilds a label-marked instruction stream (control
+%  markers stay bare so the structurer can match them; data instructions
+%  keep their pc(PC,_) wrapper so emit_one still has the PC), structure_ite
+%  folds every (C->T;E)/\+/once block into ite(Cond,Then,Else), and
+%  emit_structured/4 walks the result.
+%
+%  emit_structured reuses the EXACT case-(do…)of formats of the previous
+%  emit_instrs_lm + emit_ite_block, so a simple or sequential ITE produces
+%  byte-identical Haskell (no performance change); nested blocks recurse
+%  through the same path and negation is just an ite whose commit was !/0.
+
+%% emit_clause_struct(+ClausePCs, +LabelMap, +SV, +Ind, +FP)
+emit_clause_struct(ClausePCs, LabelMap, SV, Ind, FP) :-
+    struct_stream(ClausePCs, LabelMap, Stream),
+    structure_ite(Stream, Structured),
+    emit_structured(Structured, SV, Ind, FP).
+
+%% struct_stream(+ClausePCs, +LabelMap, -Stream)
+%  Re-insert label(L) markers at their PCs and keep ITE control markers
+%  (try_me_else/jump/trust_me/cut_ite and the !/0 commit) bare so the
+%  structurer matches them; every other instruction stays pc(PC,Instr).
+struct_stream([], _LM, []).
+struct_stream([pc(PC, Instr)|Rest], LM, Out) :-
+    % LabelMap keys are atoms, but try_me_else/jump args are strings; emit
+    % label markers as strings so structure_ite unifies them.
+    findall(label(LStr), (member(L-PC, LM), atom_string(L, LStr)), Labels),
+    struct_item(PC, Instr, Item),
+    append(Labels, [Item|More], Out),
+    struct_stream(Rest, LM, More).
+
+struct_item(_PC, try_me_else(L), try_me_else(L)) :- !.
+struct_item(_PC, jump(L),        jump(L))        :- !.
+struct_item(_PC, trust_me,       trust_me)       :- !.
+struct_item(_PC, cut_ite,        cut_ite)        :- !.
+struct_item(_PC, builtin_call(Op, N), builtin_call(Op, N)) :- neg_commit_op(Op), !.
+struct_item(PC, Instr, pc(PC, Instr)).
+
+neg_commit_op("!/0").
+neg_commit_op('!/0').
+
+%% emit_structured(+Structured, +SV, +Ind, +FP)
+%  Structured is a list of pc(PC,Instr) and ite(Cond,Then,Else) terms.
+%  Emits a do-block body yielding (Maybe WamState).
+emit_structured([], SV, Ind, _FP) :-
+    format("~wreturn ~w~n", [Ind, SV]).
+% Terminal: fail
+emit_structured([pc(_PC, fail)|Rest], _SV, Ind, _FP) :- !,
+    (   Rest \= []
+    ->  format("~w-- WARNING: fail is not the last instruction — unreachable code follows~n", [Ind])
+    ;   true
+    ),
+    format("~wNothing~n", [Ind]).
+% Terminal: execute (tail call)
+emit_structured([pc(PC, execute(PredStr))|Rest], SV, Ind, FP) :- !,
+    (   Rest \= []
+    ->  format("~w-- WARNING: execute(~w) is not the last instruction — tail-call semantics violated~n",
+               [Ind, PredStr])
+    ;   true
+    ),
+    emit_one(execute(PredStr), PC, SV, _, Ind, FP).
+% If-then-else as the final expression (no continuation)
+emit_structured([ite(Cond, Then, Else)], SV, Ind, FP) :- !,
+    format("~wcase (do~n", [Ind]),
+    atom_concat(Ind, "      ", CondInd),
+    emit_structured(Cond, SV, CondInd, FP),
+    format("~w  ) of~n", [Ind]),
+    fresh_sv(SV, SVthen),
+    format("~w    Just ~w -> do~n", [Ind, SVthen]),
+    atom_concat(Ind, "      ", ThenInd),
+    emit_structured(Then, SVthen, ThenInd, FP),
+    format("~w    Nothing -> do~n", [Ind]),
+    atom_concat(Ind, "      ", ElseInd),
+    emit_structured(Else, SV, ElseInd, FP).
+% If-then-else with a continuation — bind the result, then continue.
+emit_structured([ite(Cond, Then, Else)|Rest], SV, Ind, FP) :- Rest \= [], !,
+    fresh_sv(SV, SVcont),
+    format("~w~w <- case (do~n", [Ind, SVcont]),
+    atom_concat(Ind, "          ", CondInd),
+    emit_structured(Cond, SV, CondInd, FP),
+    format("~w      ) of~n", [Ind]),
+    fresh_sv(SV, SVthen),
+    format("~w        Just ~w -> do~n", [Ind, SVthen]),
+    atom_concat(Ind, "          ", ThenInd),
+    emit_structured(Then, SVthen, ThenInd, FP),
+    format("~w        Nothing -> do~n", [Ind]),
+    atom_concat(Ind, "          ", ElseInd),
+    emit_structured(Else, SV, ElseInd, FP),
+    emit_structured(Rest, SVcont, Ind, FP).
+% Last plain instruction — emit, then return its state unless terminal.
+emit_structured([pc(PC, Instr)], SV, Ind, FP) :- !,
+    emit_one(Instr, PC, SV, SVout, Ind, FP),
+    (   is_terminal_instr(Instr) -> true
+    ;   format("~wreturn ~w~n", [Ind, SVout])
+    ).
+% Plain instruction with more following.
+emit_structured([pc(PC, Instr)|Rest], SV, Ind, FP) :- Rest \= [], !,
+    emit_one(Instr, PC, SV, SVout, Ind, FP),
+    emit_structured(Rest, SVout, Ind, FP).
+% A bare !/0 that was NOT an ITE commit (a user cut left by the
+% structurer's pass-through). emit_one ignores the PC for !/0.
+emit_structured([builtin_call(Op, N)|Rest], SV, Ind, FP) :- !,
+    emit_one(builtin_call(Op, N), 0, SV, SVout, Ind, FP),
+    (   Rest == [] -> format("~wreturn ~w~n", [Ind, SVout])
+    ;   emit_structured(Rest, SVout, Ind, FP)
+    ).
+% A bare cut_ite outside any ITE block (defensive; should not occur).
+emit_structured([cut_ite|Rest], SV, Ind, FP) :- !,
+    (   Rest == [] -> format("~wreturn ~w~n", [Ind, SV])
+    ;   emit_structured(Rest, SV, Ind, FP)
     ).
 
 %% =====================================================================

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2277,6 +2277,15 @@ step !ctx s (BuiltinCall "!/0" _) =
   -- Cut: truncate wsCPs to the barrier depth saved at clause Allocate.
   Just (s { wsPC = wsPC s + 1, wsCPs = take (wsCutBar s) (wsCPs s), wsCPsLen = wsCutBar s })
 
+-- true/0 always succeeds; fail/0 always fails. The WAM compiler emits these
+-- for if-then-else and negation bodies (negation of G compiles to
+-- (G -> fail ; true)), so the lowered and interpreted paths both need them.
+step !ctx s (BuiltinCall "true/0" _) =
+  Just (s { wsPC = wsPC s + 1 })
+
+step !ctx s (BuiltinCall "fail/0" _) =
+  Nothing
+
 -- CutIte: soft cut for if-then-else — pops exactly the top choice point
 -- (the one pushed by try_me_else for the Else branch). Unlike !/0 which
 -- truncates to wsCutBar (clause-level), this only removes the immediately

--- a/tests/test_wam_haskell_lowered_ite_exec.pl
+++ b/tests/test_wam_haskell_lowered_ite_exec.pl
@@ -1,0 +1,122 @@
+% test_wam_haskell_lowered_ite_exec.pl
+%
+% End-to-end execution test for Haskell if-then-else / negation / once
+% lowering (emit_mode(functions)).
+%
+% Generates a WAM Haskell project with the lowered emitter enabled,
+% compiles it with GHC, and runs a harness that calls each lowered function
+% and asserts the boolean (Just/Nothing) outcome. Counterpart to the Go,
+% Rust and C++ tests. Pins:
+%
+%   * sequential ITEs   — hseqite(10,pos,small) must fail;
+%   * nested ITEs       — hnestite/2 (the inner block sits in the then-arm);
+%   * negation (\+)     — hneg/1 (commit is the !/0 builtin, not cut_ite);
+%   * simple ITEs       — hite/2.
+%
+% Before the shared-structurer conversion the flat split heuristic was not
+% nesting-aware and only recognised cut_ite, so negation and nested ITEs
+% failed to lower (in functions/mixed mode that failed generation). The
+% runtime also lacked true/0 and fail/0, which negation needs. Skipped when
+% GHC is not on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_haskell_target').
+
+:- dynamic user:hite/2.
+:- dynamic user:hneg/1.
+:- dynamic user:hseqite/3.
+:- dynamic user:hnestite/2.
+
+user:hite(X, Y)       :- ( X > 0 -> Y = pos ; Y = nonpos ).
+user:hneg(X)          :- \+ X > 0.
+user:hseqite(X, Y, Z) :- ( X > 0 -> Y = pos ; Y = nonpos ),
+                         ( X > 5 -> Z = big ; Z = small ).
+user:hnestite(X, Y)   :- ( X > 0 -> ( X > 10 -> Y = big ; Y = small ) ; Y = neg ).
+
+ghc_available :-
+    catch(( process_create(path(ghc), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_haskell_lowered_ite_exec, [condition(ghc_available)]).
+
+test(ite_exec_parity) :-
+    Dir = 'output/test_wam_haskell_ite_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    % 1. Generate the WAM Haskell project with the lowered emitter enabled.
+    write_wam_haskell_project(
+        [user:hite/2, user:hneg/1, user:hseqite/3, user:hnestite/2],
+        [module_name('iteproj'), emit_mode(functions)], Dir),
+    % 2. Test harness calling the lowered functions directly. Atom IDs are
+    %    resolved by name through the generated compile-time intern table
+    %    (robust to intern-order changes).
+    atomic_list_concat([Dir, '/src/TestMain.hs'], TestPath),
+    haskell_test_source(Src),
+    setup_call_cleanup(open(TestPath, write, S), write(S, Src), close(S)),
+    % 3. Compile + run.
+    atomic_list_concat([Dir, '/src'], SrcDir),
+    atomic_list_concat([Dir, '/ite_test'], Bin),
+    format(atom(Cmd),
+        'ghc --make -i~w ~w/TestMain.hs -o ~w -main-is Main 2>&1 && ~w',
+        [SrcDir, SrcDir, Bin, Bin]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 15 PASS")
+    ->  true
+    ;   format(user_error, "~n[haskell ite test output]~n~w~n", [OutStr]),
+        throw(haskell_test_failed(Status))
+    ).
+
+:- end_tests(wam_haskell_lowered_ite_exec).
+
+% Calls each lowered function (WamContext -> WamState -> Maybe WamState)
+% with the query arguments preloaded into the A-registers and checks
+% Just (success) / Nothing (failure). hseqite(10,pos,small) and
+% hnestite(20,small) are the sequential/nested discriminators; hneg
+% exercises the !/0-commit negation path (needs true/0 + fail/0).
+haskell_test_source(
+"module Main where
+import qualified Data.HashMap.Strict as Map
+import qualified Data.IntMap.Strict as IM
+import WamTypes
+import WamRuntime ()
+import Lowered
+import Predicates (compileTimeAtomTable)
+
+runP :: (WamContext -> WamState -> Maybe WamState) -> [(Int, Value)] -> Bool
+runP f regs =
+  let ctx = (mkContext [] Map.empty) { wcLoweredPredicates = loweredPredicates }
+      s0  = emptyState { wsRegs = IM.fromList regs }
+  in case f ctx s0 of { Just _ -> True; Nothing -> False }
+
+i :: Int -> Value
+i = Integer . fromIntegral
+a :: String -> Value
+a s = Atom (internAtomPure compileTimeAtomTable s)
+
+main :: IO ()
+main = do
+  let cases =
+        [ (\"hite(5,pos)\", runP lowered_hite_2 [(1,i 5),(2,a \"pos\")], True)
+        , (\"hite(5,nonpos)\", runP lowered_hite_2 [(1,i 5),(2,a \"nonpos\")], False)
+        , (\"hite(-1,nonpos)\", runP lowered_hite_2 [(1,i (-1)),(2,a \"nonpos\")], True)
+        , (\"hite(-1,pos)\", runP lowered_hite_2 [(1,i (-1)),(2,a \"pos\")], False)
+        , (\"hneg(5)\", runP lowered_hneg_1 [(1,i 5)], False)
+        , (\"hneg(-1)\", runP lowered_hneg_1 [(1,i (-1))], True)
+        , (\"hneg(0)\", runP lowered_hneg_1 [(1,i 0)], True)
+        , (\"hseqite(10,pos,big)\", runP lowered_hseqite_3 [(1,i 10),(2,a \"pos\"),(3,a \"big\")], True)
+        , (\"hseqite(10,pos,small)\", runP lowered_hseqite_3 [(1,i 10),(2,a \"pos\"),(3,a \"small\")], False)
+        , (\"hseqite(3,pos,small)\", runP lowered_hseqite_3 [(1,i 3),(2,a \"pos\"),(3,a \"small\")], True)
+        , (\"hseqite(-1,nonpos,small)\", runP lowered_hseqite_3 [(1,i (-1)),(2,a \"nonpos\"),(3,a \"small\")], True)
+        , (\"hnestite(20,big)\", runP lowered_hnestite_2 [(1,i 20),(2,a \"big\")], True)
+        , (\"hnestite(5,small)\", runP lowered_hnestite_2 [(1,i 5),(2,a \"small\")], True)
+        , (\"hnestite(-1,neg)\", runP lowered_hnestite_2 [(1,i (-1)),(2,a \"neg\")], True)
+        , (\"hnestite(20,small)\", runP lowered_hnestite_2 [(1,i 20),(2,a \"small\")], False)
+        ]
+      fails = [ n | (n,got,want) <- cases, got /= want ]
+  mapM_ (\\(n,got,want) -> if got/=want then putStrLn (\"FAIL \" ++ n ++ \": got \" ++ show got ++ \" want \" ++ show want) else return ()) cases
+  if null fails then putStrLn (\"ALL \" ++ show (length cases) ++ \" PASS\") else putStrLn (show (length fails) ++ \" FAILURES\")
+").


### PR DESCRIPTION
Continues the WAM if-then-else parity sweep (Scala #2793, Go/Rust #2796, C++ #2829). Haskell is the last heuristic-based backend.

## The bug

Haskell's lowered ITE used a flat `split_ite_blocks_lm` / `split_at_jump` heuristic that:
- was **not nesting-aware** (`split_at_jump` stops at an *inner* `jump`), so nested `(C->T;E)` mis-split; and
- only recognised `cut_ite`, not the **`!/0`** negation commit.

So **nested** and **negation** failed to lower. And because the gate *accepted* them (all instrs `supported`) while `lower_all` had no catch, in `emit_mode(functions)`/`mixed` this **failed generation outright**. (Default `interpreter` mode was unaffected; simple + sequential ITEs already lowered.)

## The fix

Convert clause-1 emission to the shared nesting-aware `wam_ite_structurer`:
- `struct_stream/3` rebuilds a label-marked stream from the PC/LabelMap (control markers bare so the structurer matches them; labels emitted as strings to match `try_me_else`/`jump` args; data instrs keep `pc(PC,_)` so `emit_one` still has the PC);
- `structure_ite` folds every block into `ite(Cond,Then,Else)`;
- `emit_structured/4` walks it, **reusing the exact `case (do…) of` formats** of the old emitter and recursing into Cond/Then/Else (nested just works; negation is an `ite` whose commit was `!/0`).

The gate now verifies clause 1 actually structures, so an ill-formed block falls back to the interpreter instead of failing `lower_all`.

**Runtime:** added `step` clauses for `true/0` and `fail/0` (negation compiles to `(G -> fail ; true)`) — they were missing, which broke negation on **both** the lowered and interpreted paths.

## Performance (explicitly verified — this was a requirement)

- The emitted Haskell for already-lowered **simple/sequential** predicates is **byte-identical** to main (verified by `diff` of `lowered_hite_2` + `lowered_hseqite_3`) → **zero runtime change** on existing code.
- The structurer is O(n) **generation-time** work only.
- The two new builtin clauses are length-discriminated string-literal matches (negligible) and only meaningfully touch the rare ITE/negation paths.
- Newly-lowered negation/nested go from interpreter (or generation failure) to native code — **strictly faster**.

## Verification

New gated `test_wam_haskell_lowered_ite_exec.pl` compiles with **GHC** and runs **15 cases** (simple, negation, sequential incl. `hseqite(10,pos,small)=false`, nested `hnestite`) — all correct. Lowered phase1-3 stay green (phase4 fails pre-existing on main — GHC/env, unrelated).

## Note

The old `emit_instrs_lm`/`emit_ite_block`/`split_*` heuristic is now unused (it interleaves with the still-live `is_terminal_instr`, so I left it for a small follow-up cleanup rather than risk the deletion here).

## Parity scoreboard
✅ Scala, Go, Rust, C++, **Haskell** — shared structurer + verified exec tests.
⚠️ Remaining: fsharp/clojure/llvm (ITE-aware, no structurer), elixir/lua/python/r (none).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_