### PR TITLE
LLVM WAM: target_os abstraction (M113) -- platform-aware libc struct layouts

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3323,10 +3323,10 @@ cy.skip:
 
 %% compile_wam_helpers_to_llvm(+Options, -LLVMCode)
 %  Generates LLVM IR for WAM runtime helpers.
-compile_wam_helpers_to_llvm(_Options, LLVMCode) :-
+compile_wam_helpers_to_llvm(Options, LLVMCode) :-
     compile_backtrack_to_llvm(BacktrackCode),
     compile_unwind_trail_to_llvm(UnwindCode),
-    compile_execute_builtin_to_llvm(BuiltinCode),
+    compile_execute_builtin_to_llvm(Options, BuiltinCode),
     compile_eval_arith_to_llvm(ArithCode),
     compile_copy_term_to_llvm(CopyTermCode),
     compile_term_cmp_to_llvm(TermCmpCode),
@@ -3464,8 +3464,13 @@ done:
   ret void
 }'.
 
-compile_execute_builtin_to_llvm(Code) :-
-    Code = '; Execute builtin operations
+compile_execute_builtin_to_llvm(Options, Code) :-
+    % M113: resolve target OS for struct dirent / struct tm offsets.
+    % Default mode is auto (derive from target_triple); callers can
+    % override with target_os(linux|darwin|freebsd|...).
+    target_os_resolved(Options, OS),
+    target_dirent_d_name_offset(OS, DirentNameOff),
+    Template = '; Execute builtin operations
 ; Dispatches on integer op codes:
 ;   0 = is/2, 1 = >/2, 2 = </2, 3 = >=/2, 4 = =</2
 ;   5 = =:=/2, 6 = =\\=/2, 7 = ==/2, 8 = true/0, 9 = fail/0
@@ -5647,7 +5652,7 @@ dirf.loop:
   br i1 %dirf.entry_null, label %dirf.close, label %dirf.append
 dirf.append:
   ; Build a new cons cell [|](Atom, acc) on the arena.
-  %dirf.name_ptr = getelementptr i8, i8* %dirf.entry, i64 19
+  %dirf.name_ptr = getelementptr i8, i8* %dirf.entry, i64 __M113_DIRENT_NAME_OFF__
   %dirf.name_len = call i64 @strlen(i8* %dirf.name_ptr)
   %dirf.bufsize = add i64 %dirf.name_len, 1
   %dirf.buf = call i8* @wam_arena_alloc(i64 %dirf.bufsize)
@@ -10754,7 +10759,14 @@ mb.bool_no:
 
 unknown:
   ret i1 false
-}'.
+}',
+    % Splice DirentNameOff into the placeholder. atomic_list_concat
+    % in reverse mode splits Template at every placeholder occurrence,
+    % then forward mode joins with the replacement between segments.
+    % Avoids format/2''s ~ escaping problem (the IR template has many
+    % `~'' chars in comments that format would treat as directives).
+    atomic_list_concat(Parts, '__M113_DIRENT_NAME_OFF__', Template),
+    atomic_list_concat(Parts, DirentNameOff, Code).
 
 compile_eval_arith_to_llvm(Code) :-
     Code = '; Evaluate arithmetic expression
@@ -12723,6 +12735,83 @@ intern_atom(AtomName, Id) :-
         assertz(atom_table_next_id(NextId)),
         assertz(atom_table_entry(AtomName, Id))
     ).
+
+% ----------------------------------------------------------------------
+% M113: target-platform abstraction for libc struct layouts.
+% Most libc *functions* are POSIX-portable, but the *struct field
+% offsets* we read at IR-emit time (struct dirent for M107, struct tm
+% for M91/M98/M99, struct stat for M73-M76) are libc-specific. To keep
+% IR generation cross-target, callers pick a strategy via
+%   target_os(auto)    -- (default) derive OS from target_triple option
+%   target_os(linux)   -- explicit; linux | darwin | freebsd | netbsd
+%                          | openbsd | wasi | ... (atom)
+% adapt-at-runtime (a third mode that emits a probe to discover offsets
+% at program startup) is a follow-up milestone -- see todo at end of
+% this block.
+
+%% target_os_from_triple(+Triple, -OS) is det.
+%  Maps an LLVM target triple ("x86_64-pc-linux-gnu", "x86_64-apple-darwin",
+%  "x86_64-unknown-freebsd13.0", "wasm32-unknown-wasi", ...) to a short
+%  atom we can pattern-match against in layout predicates.
+target_os_from_triple(Triple, OS) :-
+    atom_string(Triple, S),
+    (   sub_string(S, _, _, _, "linux")   -> OS = linux
+    ;   sub_string(S, _, _, _, "darwin")  -> OS = darwin
+    ;   sub_string(S, _, _, _, "freebsd") -> OS = freebsd
+    ;   sub_string(S, _, _, _, "openbsd") -> OS = openbsd
+    ;   sub_string(S, _, _, _, "netbsd")  -> OS = netbsd
+    ;   sub_string(S, _, _, _, "wasi")    -> OS = wasi
+    ;   sub_string(S, _, _, _, "windows") -> OS = windows
+    ;   sub_string(S, _, _, _, "mingw")   -> OS = windows
+    ;   OS = linux   % default to linux on unknown triples (warns elsewhere)
+    ).
+
+%% resolve_target_os(+Options, -OS) is det.
+%  Consults the Options list for target_os(Mode):
+%   - target_os(auto)  (default if absent) -> derive from target_triple
+%   - target_os(<atom>) (linux/darwin/etc.) -> use that OS directly
+target_os_resolved(Options, OS) :-
+    ( option(target_os(Mode), Options) -> true ; Mode = auto ),
+    ( Mode == auto
+    -> ( option(target_triple(T), Options)
+       -> target_os_from_triple(T, OS)
+       ;  OS = linux
+       )
+    ;  OS = Mode
+    ).
+
+%% target_dirent_d_name_offset(+OS, -Offset) is det.
+%  Byte offset of d_name within struct dirent on the named OS.
+%  Linux glibc: ino(8) + off(8) + reclen(2) + type(1) = 19.
+%  Darwin (BSD libc): ino(8) + seekoff(8) + reclen(2) + namlen(2) + type(1) = 21.
+%  FreeBSD/NetBSD/OpenBSD vary -- 11/12 historically, modern is 21.
+%  WASI uses dirent compatible with Linux (the wasi-libc preview).
+target_dirent_d_name_offset(linux,   19).
+target_dirent_d_name_offset(darwin,  21).
+target_dirent_d_name_offset(freebsd, 21).
+target_dirent_d_name_offset(netbsd,  21).
+target_dirent_d_name_offset(openbsd, 21).
+target_dirent_d_name_offset(wasi,    19).
+target_dirent_d_name_offset(_, 19).   % fall-back
+
+%% target_struct_tm_size(+OS, -SizeBytes) is det.
+%  Glibc struct tm is 56 bytes; Darwin/BSD also 56 with same field
+%  order (the GNU tm_gmtoff/tm_zone extension is also present on
+%  Darwin and modern BSDs).
+target_struct_tm_size(_, 56).
+
+%% target_struct_tm_gmtoff_offset(+OS, -Offset) is det.
+target_struct_tm_gmtoff_offset(linux,   40).
+target_struct_tm_gmtoff_offset(darwin,  40).
+target_struct_tm_gmtoff_offset(freebsd, 40).
+target_struct_tm_gmtoff_offset(_, 40).
+
+% TODO: target_os(adapt) -- emit a small startup probe that opens
+% "." via opendir, calls readdir once (which always returns "." as
+% the first entry), and computes the d_name offset from where the
+% '.' byte lands in the buffer. Result stored in a runtime global so
+% builtin_directory_files reads the resolved offset instead of a
+% compile-time constant. Defer to a future milestone.
 
 % --- Value packing helpers ---
 


### PR DESCRIPTION
## Summary

UnifyWeaver's libc builtins use POSIX-standard functions (`access`, `chmod`, `kill`, `opendir`/`readdir`/`closedir`, `getuid`/`getpid`/`getpgrp`, `mktime`/`localtime_r`/`strftime`, `realpath`, `truncate`, ...), but a handful of them read struct fields by **byte offset**:

- `struct dirent::d_name` (M107)
- `struct tm::tm_gmtoff` (M91 / M98 / M99)
- `struct timespec` (M87 / M89 — happens to be portable)

Those offsets vary by libc:

| OS | `dirent::d_name` offset |
|---|---|
| Linux glibc | 19 |
| macOS / BSD | 21 |
| WASI libc | 19 (Linux-compatible) |

## The framework

Callers pick how the target OS is chosen via the new `target_os(Mode)` option to `write_wam_llvm_project`:

```
target_os(auto)        % (default) derive OS from target_triple
target_os(linux)       % explicit -- linux | darwin | freebsd
target_os(darwin)      %             | openbsd | netbsd | wasi | windows
...
```

`auto` derives the OS from the `target_triple` option via `target_os_from_triple/2`. Explicit modes override.

Resolution happens in `target_os_resolved/2` inside `compile_execute_builtin_to_llvm`.

## How the substitution works

The IR template for `builtin_directory_files` now carries a placeholder `__M113_DIRENT_NAME_OFF__` where the `i64` offset used to be hardcoded as `19`. `compile_execute_builtin_to_llvm` splits the template at that placeholder and joins with the resolved offset via `atomic_list_concat/3`. (`format/2` wasn't usable — the template has many `~` chars in IR comments that `format` would treat as directives.)

## Helper predicates added

- `target_os_from_triple(+Triple, -OS)`
- `target_os_resolved(+Options, -OS)`
- `target_dirent_d_name_offset(+OS, -Offset)`
- `target_struct_tm_size(+OS, -SizeBytes)`
- `target_struct_tm_gmtoff_offset(+OS, -Offset)`

## Smoke-tested

- `target_triple('x86_64-pc-linux-gnu')` + default `target_os(auto)` → offset `19` ✓
- `target_triple('x86_64-apple-darwin')` + `target_os(auto)` → offset `21` ✓
- `target_triple('x86_64-pc-linux-gnu')` + explicit `target_os(freebsd)` → offset `21` (explicit overrides triple) ✓

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — five new helper predicates, `compile_execute_builtin_to_llvm/1` → `/2` with Options, placeholder substitution in the dirent offset.

## Test plan

- [x] Full execution suite: **676/676 PASS**, no failures, no OOM — no behaviour change for the default Linux path ✓
- [x] All three resolution modes (auto/Linux, auto/Darwin, explicit/FreeBSD) verified by inspecting the emitted IR

## Future

- Extend with more layouts (`struct stat` for M73–M76, more `struct tm` fields if needed)
- Add `target_os(adapt)` mode — emit a runtime probe at startup that opens `.`, reads the first entry, and computes the `d_name` offset from where the `.` byte lands; store in a runtime global so the IR reads the resolved offset instead of a compile-time constant
- Explicit unit tests for the OS-resolution predicates

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_