### PR TITLE
feat(fsharp): enable ITE/negation/nested lowering via shared structurer (compile-run verified)

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
@@ -29,6 +29,7 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(wam_ite_structurer, [structure_ite/2]).
 
 % ============================================================================
 % Parsing — identical to Haskell emitter (WAM text format is target-agnostic)
@@ -73,10 +74,33 @@ tokenize_fs(Line, Term) :-
 %    - CallForeign resolves ambiguity for foreign calls at compile time
 %    - Detected kernels are excluded upstream by wam_fsharp_partition_predicates
 wam_fsharp_lowerable(_PI, WamCode, lowerable) :-
-    parse_wam_text_fs(WamCode, PCInstrs, _),
+    parse_wam_text_fs(WamCode, PCInstrs, LabelMap),
     clause1_instrs_fs(PCInstrs, C1),
-    is_deterministic_pred_fs(C1),
-    forall(member(I, C1), supported_fs(I)).
+    forall(member(I, C1), supported_fs(I)),
+    % Clause 1 must fold cleanly via the shared structurer. This enables
+    % if-then-else / negation lowering (clause 1's internal try_me_else is a
+    % well-formed ITE block, consumed into ite/3) while still rejecting any
+    % stray choice-point markers (predicate-level try/retry/trust that are
+    % not part of a clean block remain in the structured form, failing the
+    % checks below, so such predicates fall back to the interpreter).
+    clause1_pc_fs(PCInstrs, C1PC),
+    struct_stream_fs(C1PC, LabelMap, Stream),
+    structure_ite(Stream, Structured),
+    \+ member(try_me_else(_), Structured),
+    \+ member(trust_me, Structured),
+    \+ member(retry_me_else(_), Structured).
+
+%% clause1_pc_fs(+PCInstrs, -Clause1PCs)
+%  Like clause1_instrs_fs/2 but keeps pc(PC,Instr) form, matching exactly the
+%  clause-1 slice emit_func_fs structures.
+clause1_pc_fs([], []).
+clause1_pc_fs(PCInstrs0, C1) :-
+    strip_switch_prefixes_fs(PCInstrs0, PCInstrs),
+    PCInstrs0 \== PCInstrs, !,
+    clause1_pc_fs(PCInstrs, C1).
+clause1_pc_fs([pc(_, try_me_else(_))|Rest], C1) :- !,
+    take_to_proceed_pc_fs(Rest, C1).
+clause1_pc_fs(PCInstrs, PCInstrs).
 
 % Match Rust/Clojure lowered emitters: only deterministic clause-1 bodies are
 % lowered. Choicepoint-manipulating instructions should stay interpreter-driven.
@@ -238,14 +262,14 @@ emit_func_fs(FN, PCInstrs, LabelMap, ForeignPreds) :-
         format("            WsCPsLen = s_init.WsCPsLen + 1 }~n"),
         format("    let clause1 (s_c1: WamState) : WamState option =~n"),
         take_to_proceed_pc_fs(BodyPCs, Clause1PCs),
-        emit_instrs_lm_fs(Clause1PCs, "s_c1", "        ", ForeignPreds, LabelMap),
+        emit_clause_struct_fs(Clause1PCs, LabelMap, "s_c1", "        ", ForeignPreds),
         format("    match clause1 s_cp with~n"),
         format("    | Some result -> Some result~n"),
         format("    | None ->~n"),
         format("        // Clause 1 failed — backtrack to clause 2+ in the interpreter~n"),
         format("        backtrack s_cp |> Option.bind (fun s_bt -> run ctx { s_bt with WsPC = s_bt.WsPC + 1 })~n")
     ;   % Single-clause: straightforward binding chain
-        emit_instrs_lm_fs(PCInstrs1, "s_init", "    ", ForeignPreds, LabelMap)
+        emit_clause_struct_fs(PCInstrs1, LabelMap, "s_init", "    ", ForeignPreds)
     ).
 
 take_to_proceed_pc_fs([], []).
@@ -504,6 +528,113 @@ emit_ite_block_fs([pc(PC, Instr)|Rest], SV, Ind, FP) :-
 is_terminal_instr_fs(proceed).
 is_terminal_instr_fs(fail).
 is_terminal_instr_fs(execute(_)).
+
+% ============================================================================
+% Structured ITE emission (shared nesting-aware structurer)
+% ============================================================================
+%
+%  The flat split_ite_blocks_lm_fs/split_at_jump_fs heuristic is NOT nesting
+%  aware (split_at_jump_fs stops at an inner jump) and only recognises
+%  cut_ite, not the !/0 negation commit. Feed clause 1 through the shared
+%  wam_ite_structurer instead: struct_stream_fs/3 rebuilds a label-marked
+%  stream (control markers bare so the structurer matches them, labels as
+%  strings to match try_me_else/jump args, data instructions keep pc(PC,_)
+%  for emit_one_fs), structure_ite folds every block into ite(Cond,Then,Else),
+%  and emit_structured_fs/4 walks it — reusing the exact F# match-arm
+%  threading (is_match_instr_fs / "| None -> None") so non-ITE predicates
+%  emit byte-identically and nested blocks recurse for free.
+
+emit_clause_struct_fs(ClausePCs, LabelMap, SV, Ind, FP) :-
+    struct_stream_fs(ClausePCs, LabelMap, Stream),
+    structure_ite(Stream, Structured),
+    emit_structured_fs(Structured, SV, Ind, FP).
+
+struct_stream_fs([], _LM, []).
+struct_stream_fs([pc(PC, Instr)|Rest], LM, Out) :-
+    findall(label(LStr), (member(L-PC, LM), atom_string(L, LStr)), Labels),
+    struct_item_fs(PC, Instr, Item),
+    append(Labels, [Item|More], Out),
+    struct_stream_fs(Rest, LM, More).
+
+struct_item_fs(_PC, try_me_else(L), try_me_else(L)) :- !.
+struct_item_fs(_PC, jump(L),        jump(L))        :- !.
+struct_item_fs(_PC, trust_me,       trust_me)       :- !.
+struct_item_fs(_PC, cut_ite,        cut_ite)        :- !.
+struct_item_fs(_PC, builtin_call(Op, N), builtin_call(Op, N)) :- neg_commit_op_fs(Op), !.
+struct_item_fs(PC, Instr, pc(PC, Instr)).
+
+neg_commit_op_fs("!/0").
+neg_commit_op_fs('!/0').
+
+%% emit_structured_fs(+Structured, +SV, +Ind, +FP)
+%  Structured is a list of pc(PC,Instr) and ite(Cond,Then,Else). Emits an
+%  F# expression of type WamState option.
+emit_structured_fs([], SV, I, _FP) :-
+    format("~wSome ~w~n", [I, SV]).
+% If-then-else with a continuation — bind the result, then continue.
+emit_structured_fs([ite(C, T, E)|Rest], SV, Ind, FP) :- Rest \= [], !,
+    format("~wmatch (~n", [Ind]),
+    atom_concat(Ind, "    ", IteInd),
+    emit_ite_match_struct_fs(SV, C, T, E, IteInd, FP),
+    format("~w) with~n", [Ind]),
+    fresh_sv_fs(SV, SVcont),
+    format("~w| Some ~w ->~n", [Ind, SVcont]),
+    atom_concat(Ind, "    ", ContInd),
+    emit_structured_fs(Rest, SVcont, ContInd, FP),
+    format("~w| None -> None~n", [Ind]).
+% If-then-else as the final expression.
+emit_structured_fs([ite(C, T, E)], SV, Ind, FP) :- !,
+    emit_ite_match_struct_fs(SV, C, T, E, Ind, FP).
+% Terminal: fail
+emit_structured_fs([pc(_PC, fail)|Rest], _SV, Ind, _FP) :- !,
+    (   Rest \= []
+    ->  format("~w// WARNING: fail is not the last instruction — ~w instruction(s) unreachable~n", [Ind, Rest])
+    ;   true
+    ),
+    format("~wNone~n", [Ind]).
+% Terminal: execute (tail call)
+emit_structured_fs([pc(PC, execute(PredStr))|Rest], SV, Ind, FP) :- !,
+    (   Rest \= []
+    ->  format("~w// WARNING: execute(~w) is not the last instruction — tail-call semantics violated; ~w instruction(s) unreachable~n",
+               [Ind, PredStr, Rest])
+    ;   true
+    ),
+    emit_one_fs(execute(PredStr), PC, SV, _, Ind, FP).
+% Last plain instruction.
+emit_structured_fs([pc(PC, Instr)], SV, Ind, FP) :- !,
+    emit_one_fs(Instr, PC, SV, SVout, Ind, FP),
+    atom_concat(Ind, "    ", IndInner),
+    (   is_terminal_instr_fs(Instr) -> true
+    ;   is_match_instr_fs(Instr)
+    ->  format("~wSome ~w~n", [IndInner, SVout]),
+        format("~w| None -> None~n", [Ind])
+    ;   format("~wSome ~w~n", [Ind, SVout])
+    ).
+% Plain instruction with more following.
+emit_structured_fs([pc(PC, Instr)|Rest], SV, Ind, FP) :- Rest \= [], !,
+    emit_one_fs(Instr, PC, SV, SVout, Ind, FP),
+    atom_concat(Ind, "    ", IndInner),
+    (   is_match_instr_fs(Instr)
+    ->  emit_structured_fs(Rest, SVout, IndInner, FP),
+        format("~w| None -> None~n", [Ind])
+    ;   emit_structured_fs(Rest, SVout, Ind, FP)
+    ).
+
+%% emit_ite_match_struct_fs(+SV, +Cond, +Then, +Else, +Ind, +FP)
+%  F# nested match for one ite/3 block; branches recurse through
+%  emit_structured_fs so nested blocks are handled.
+emit_ite_match_struct_fs(SV, CondInstrs, ThenInstrs, ElseInstrs, Ind, FP) :-
+    format("~wmatch (~n", [Ind]),
+    atom_concat(Ind, "    ", CondInd),
+    emit_structured_fs(CondInstrs, SV, CondInd, FP),
+    format("~w) with~n", [Ind]),
+    fresh_sv_fs(SV, SVthen),
+    format("~w| Some ~w ->~n", [Ind, SVthen]),
+    atom_concat(Ind, "    ", ThenInd),
+    emit_structured_fs(ThenInstrs, SVthen, ThenInd, FP),
+    format("~w| None ->~n", [Ind]),
+    atom_concat(Ind, "    ", ElseInd),
+    emit_structured_fs(ElseInstrs, SV, ElseInd, FP).
 
 %% split_ite_blocks_fs/6 — legacy no-LabelMap version
 %  Used inside emit_instrs_fs (4-arg). ContInstrs is always [] here

--- a/tests/test_wam_fsharp_lowered_ite.pl
+++ b/tests/test_wam_fsharp_lowered_ite.pl
@@ -1,0 +1,77 @@
+% test_wam_fsharp_lowered_ite.pl
+%
+% Structural tests for F# if-then-else / negation / once lowering
+% (the shared-structurer conversion that enabled ITE lowering for F#).
+%
+% F# previously did NOT lower any predicate whose clause 1 contained an
+% if-then-else (the gate's is_deterministic_pred_fs/1 rejected the internal
+% try_me_else, so such predicates fell back to the interpreter — sound but
+% not lowered). Wiring clause-1 emission through wam_ite_structurer enables
+% lowering of simple, sequential, negation and nested ITE.
+%
+% These checks assert on the emitted F# *text* (the generated match
+% structure). End-to-end compile+run verification needs the dotnet/F#
+% toolchain (mirroring the GHC test for Haskell) and is left as a gated
+% follow-up; this suite runs anywhere SWI-Prolog does.
+
+:- use_module(library(plunit)).
+:- use_module('../src/unifyweaver/targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../src/unifyweaver/targets/wam_fsharp_target').
+:- use_module('../src/unifyweaver/targets/wam_fsharp_lowered_emitter').
+
+:- dynamic user:fite/2.
+:- dynamic user:fneg/1.
+:- dynamic user:fseqite/3.
+:- dynamic user:fnestite/2.
+
+user:fite(X, Y)       :- ( X > 0 -> Y = pos ; Y = nonpos ).
+user:fneg(X)          :- \+ X > 0.
+user:fseqite(X, Y, Z) :- ( X > 0 -> Y = pos ; Y = nonpos ),
+                         ( X > 5 -> Z = big ; Z = small ).
+user:fnestite(X, Y)   :- ( X > 0 -> ( X > 10 -> Y = big ; Y = small ) ; Y = neg ).
+
+lowered_code(PI, Code) :-
+    compile_predicate_to_wam(user:PI, [], W),
+    lower_predicate_to_fsharp(PI, W, [], lowered(_, _, Code)).
+
+count_substr(Str, Sub, N) :-
+    findall(x, sub_string(Str, _, _, _, Sub), Xs),
+    length(Xs, N).
+
+:- begin_tests(wam_fsharp_lowered_ite).
+
+% The gate now accepts ITE predicates (previously rejected).
+test(all_lowerable) :-
+    forall(member(PI, [fite/2, fneg/1, fseqite/3, fnestite/2]),
+           ( compile_predicate_to_wam(user:PI, [], W),
+             assertion(wam_fsharp_lowerable(PI, W, _)) )).
+
+% Simple ITE emits an F# match with Some/None arms.
+test(simple_ite_match) :-
+    lowered_code(fite/2, Code),
+    assertion(sub_string(Code, _, _, _, "match (")),
+    assertion(sub_string(Code, _, _, _, "| Some ")),
+    assertion(sub_string(Code, _, _, _, "| None ->")).
+
+% Negation lowers with the !/0-commit shape: then = fail/0, else = true/0.
+test(negation_uses_true_fail) :-
+    lowered_code(fneg/1, Code),
+    assertion(sub_string(Code, _, _, _, "fail/0")),
+    assertion(sub_string(Code, _, _, _, "true/0")).
+
+% Sequential ITE emits two sibling match blocks.
+test(sequential_two_matches) :-
+    lowered_code(fseqite/3, Code),
+    count_substr(Code, "match (", N),
+    assertion(N >= 2).
+
+% Nested ITE emits a nested match (inner block inside the then-arm).
+test(nested_match) :-
+    lowered_code(fnestite/2, Code),
+    count_substr(Code, "match (", N),
+    assertion(N >= 2),
+    % no stray choice-point markers leaked into the emitted code
+    assertion(\+ sub_string(Code, _, _, _, "try_me_else")),
+    assertion(\+ sub_string(Code, _, _, _, "trust_me")).
+
+:- end_tests(wam_fsharp_lowered_ite).

--- a/tests/test_wam_fsharp_lowered_ite_exec.pl
+++ b/tests/test_wam_fsharp_lowered_ite_exec.pl
@@ -1,0 +1,125 @@
+% test_wam_fsharp_lowered_ite_exec.pl
+%
+% End-to-end execution test for F# if-then-else / negation / once lowering
+% (emit_mode(functions)).
+%
+% Generates a WAM F# project with the lowered emitter enabled, compiles it
+% with the dotnet/F# toolchain, and runs a harness that calls each lowered
+% function and asserts the (Some/None) outcome. Counterpart to the Go, Rust,
+% C++ and Haskell exec tests. Pins:
+%
+%   * sequential ITEs   — fseqite(10,pos,small) must fail;
+%   * nested ITEs       — fnestite/2 (inner block in the then-arm);
+%   * negation (\+)      — fneg/1 (commit is the !/0 builtin);
+%   * simple ITEs        — fite/2.
+%
+% F# previously did NOT lower any predicate with an if-then-else in clause 1
+% (the gate rejected the internal try_me_else); the shared-structurer
+% conversion enabled it. Skipped when `dotnet` is not on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_fsharp_target').
+
+:- dynamic user:fite/2.
+:- dynamic user:fneg/1.
+:- dynamic user:fseqite/3.
+:- dynamic user:fnestite/2.
+
+user:fite(X, Y)       :- ( X > 0 -> Y = pos ; Y = nonpos ).
+user:fneg(X)          :- \+ X > 0.
+user:fseqite(X, Y, Z) :- ( X > 0 -> Y = pos ; Y = nonpos ),
+                         ( X > 5 -> Z = big ; Z = small ).
+user:fnestite(X, Y)   :- ( X > 0 -> ( X > 10 -> Y = big ; Y = small ) ; Y = neg ).
+
+dotnet_available :-
+    catch(( process_create(path(dotnet), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_fsharp_lowered_ite_exec, [condition(dotnet_available)]).
+
+test(ite_exec_parity) :-
+    Dir = 'output/test_wam_fsharp_ite_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    % 1. Generate the WAM F# project with the lowered emitter enabled.
+    write_wam_fsharp_project(
+        [user:fite/2, user:fneg/1, user:fseqite/3, user:fnestite/2],
+        [module_name('iteproj'), emit_mode(functions)], Dir),
+    % 2. Replace the generated bench Program.fs (the last-compiled, entry
+    %    module) with a harness that calls the lowered functions directly.
+    atomic_list_concat([Dir, '/Program.fs'], ProgPath),
+    fsharp_test_source(Src),
+    setup_call_cleanup(open(ProgPath, write, S), write(S, Src), close(S)),
+    % 3. Compile + run.
+    format(atom(Cmd),
+        'cd ~w && DOTNET_CLI_TELEMETRY_OPTOUT=1 DOTNET_NOLOGO=1 dotnet run --project iteproj.fsproj -c Release 2>&1',
+        [Dir]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 15 PASS")
+    ->  true
+    ;   format(user_error, "~n[fsharp ite test output]~n~w~n", [OutStr]),
+        throw(fsharp_test_failed(Status))
+    ).
+
+:- end_tests(wam_fsharp_lowered_ite_exec).
+
+% Builds a minimal WamContext/WamState, sets the A-registers, calls each
+% lowered function, and checks Some (success) / None (failure). F# atoms are
+% plain strings (Atom of string), so no atom-id coordination is needed.
+fsharp_test_source(
+"module Program
+
+open WamTypes
+open WamRuntime
+open Lowered
+
+let testEmptyState =
+    { WsPC = 0; WsRegs = Array.create MaxRegs (Unbound -1); WsStack = []
+      WsHeap = []; WsHeapLen = 0; WsTrail = []; WsTrailLen = 0
+      WsCP = 0; WsCPs = []; WsCPsLen = 0; WsBindings = Map.empty
+      WsCutBar = 0; WsVarCounter = 0; WsBuilder = None; WsBuilderStack = []
+      WsAggAccum = []; WsB0Stack = []; WsCatchers = [] }
+
+let testCtx : WamContext =
+    { WcCode = [||]; WcLabels = Map.empty; WcForeignFacts = Map.empty
+      WcFfiFacts = Map.empty; WcFfiWeightedFacts = Map.empty
+      WcAtomIntern = Map.empty; WcAtomDeintern = Map.empty
+      WcForeignConfig = Map.empty; WcLoweredPredicates = loweredPredicates
+      WcLookupSources = Map.empty; WcCancellationToken = None }
+
+let runP (f: WamContext -> WamState -> WamState option) (regs: (int * Value) list) : bool =
+    let arr = Array.create MaxRegs (Unbound -1)
+    regs |> List.iter (fun (idx, v) -> arr.[idx] <- v)
+    let s0 = { testEmptyState with WsRegs = arr }
+    match f testCtx s0 with Some _ -> true | None -> false
+
+let i (n: int) : Value = Integer n
+let a (s: string) : Value = Atom s
+
+[<EntryPoint>]
+let main _argv =
+    let cases : (string * bool * bool) list =
+        [ (\"fite(5,pos)\", runP lowered_fite_2 [(1, i 5); (2, a \"pos\")], true)
+          (\"fite(5,nonpos)\", runP lowered_fite_2 [(1, i 5); (2, a \"nonpos\")], false)
+          (\"fite(-1,nonpos)\", runP lowered_fite_2 [(1, i -1); (2, a \"nonpos\")], true)
+          (\"fite(-1,pos)\", runP lowered_fite_2 [(1, i -1); (2, a \"pos\")], false)
+          (\"fneg(5)\", runP lowered_fneg_1 [(1, i 5)], false)
+          (\"fneg(-1)\", runP lowered_fneg_1 [(1, i -1)], true)
+          (\"fneg(0)\", runP lowered_fneg_1 [(1, i 0)], true)
+          (\"fseqite(10,pos,big)\", runP lowered_fseqite_3 [(1, i 10); (2, a \"pos\"); (3, a \"big\")], true)
+          (\"fseqite(10,pos,small)\", runP lowered_fseqite_3 [(1, i 10); (2, a \"pos\"); (3, a \"small\")], false)
+          (\"fseqite(3,pos,small)\", runP lowered_fseqite_3 [(1, i 3); (2, a \"pos\"); (3, a \"small\")], true)
+          (\"fseqite(-1,nonpos,small)\", runP lowered_fseqite_3 [(1, i -1); (2, a \"nonpos\"); (3, a \"small\")], true)
+          (\"fnestite(20,big)\", runP lowered_fnestite_2 [(1, i 20); (2, a \"big\")], true)
+          (\"fnestite(5,small)\", runP lowered_fnestite_2 [(1, i 5); (2, a \"small\")], true)
+          (\"fnestite(-1,neg)\", runP lowered_fnestite_2 [(1, i -1); (2, a \"neg\")], true)
+          (\"fnestite(20,small)\", runP lowered_fnestite_2 [(1, i 20); (2, a \"small\")], false) ]
+    let fails = cases |> List.filter (fun (_, got, want) -> got <> want)
+    fails |> List.iter (fun (n, got, want) -> printfn \"FAIL %s: got %b want %b\" n got want)
+    if List.isEmpty fails then printfn \"ALL %d PASS\" (List.length cases); 0
+    else printfn \"%d FAILURES\" (List.length fails); 1
+").


### PR DESCRIPTION
Continues the WAM if-then-else parity sweep (Scala #2793, Go/Rust #2796, C++ #2829, Haskell #2840).

## Starting point (different from the others)

Unlike Go/Rust/C++/Haskell — which had **correctness bugs** — F# was already **sound**: its gate (`is_deterministic_pred_fs/1`) rejected any clause-1 containing an internal `try_me_else`, so ITE predicates fell back to the interpreter and were **never lowered**. So this PR is a **parity/perf enablement**, not a bug fix.

## Change

Wire clause-1 emission through the shared nesting-aware `wam_ite_structurer` (same approach as Haskell #2840):
- `struct_stream_fs/3` rebuilds a label-marked stream from the PC/LabelMap (control markers bare; labels as strings to match `try_me_else`/`jump` args; data instrs keep `pc(PC,_)` for `emit_one_fs`);
- `structure_ite` folds each block into `ite(Cond,Then,Else)`;
- `emit_structured_fs/4` walks it, **reusing the exact F# match-arm threading** (`is_match_instr_fs` / `| None -> None`) and recursing into Cond/Then/Else (nested just works; negation is an `ite` whose commit was `!/0`).

The gate now accepts a predicate iff clause 1 folds cleanly (no stray `try`/`retry`/`trust`), enabling ITE lowering while routing anything unstructurable to the interpreter. **No runtime change** — F#'s runtime already implements `true/0`/`fail/0`.

## Performance (verified)

- Emitted F# for already-lowered **non-ITE** predicates is **byte-identical** to main (`diff` of `inc/2` + `pickone/2`) → zero change on existing code.
- Structurer is O(n) generation-time only.
- Newly-lowered ITE/negation/nested move interpreter → native — strictly faster.

## Verification — now full compile+run

I installed the dotnet/F# SDK (8.0) in the working environment, so F# is verified the **same way as the other backends**, not just structurally:
- **`test_wam_fsharp_lowered_ite_exec.pl`** (gated on `dotnet`) generates the project, swaps in a harness calling the lowered functions, and `dotnet run`s it: **15 cases** (simple, negation, sequential incl. `fseqite(10,pos,small)=false`, nested) → **ALL 15 PASS**.
- **`test_wam_fsharp_lowered_ite.pl`** (structural, no toolchain) asserts gate acceptance + emitted match structure — keeps coverage where `dotnet` is absent (the exec test skips cleanly there).
- `fsharp_target` + `fsharp_iso_unit` suites stay green.

## Parity scoreboard
✅ Scala, Go, Rust, C++, Haskell, **F#** — shared structurer + **compile-run-verified**
⚠️ clojure/llvm (ITE-aware, no structurer), elixir/lua/python/r (none)

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw