### PR TITLE
Inline nested findall in WAM-C aggregate bodies

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,15 +4,15 @@ Status date: 2026-06-05
 
 Latest branch verification:
 
-- `investigate/wam-c-findall-nested-template-smoke` based on `main` at
-  `b8ebd240` (`Merge pull request #2821 from
-  s243a/investigate/wam-c-findall-aggregate-surface`)
+- `investigate/wam-c-inline-nested-findall-lowering` based on `main` at
+  `8183cce6` (`Merge pull request #2825 from
+  s243a/investigate/wam-c-findall-nested-template-smoke`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-findall-nested-template-smoke`
+- `investigate/wam-c-inline-nested-findall-lowering`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -82,6 +82,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | `forall/2` control smoke | Done | Generated executable smoke covers the shared nested soft-cut rewrite for `forall/2` all-pass, action-fail, subset, and empty-generator cases |
 | `findall/3` collect aggregate surface | Done | C now parses and executes shared `begin_aggregate collect` / `end_aggregate` WAM for simple `findall/3`, preserving generator choice points under aggregate frames and building non-empty/empty result lists |
 | `findall/3` nested/template smoke | Done | C now parses compiler temporary `_XTn` registers and the generated executable smoke covers helper-nested `findall/3`, `pair(X, [X])` templates, and `[X, X]` templates |
+| Direct inline nested `findall/3` lowering | Done | Inner-body `findall/3` now lowers to nested aggregate opcodes instead of `call findall/3`; local aggregate result slots are initialized before finalization, and the executable smoke covers `findall(X, (item(X), findall(Y, item(Y), Ys), Ys = [a,b]), L)` |
 
 ## Current C Target Baseline
 
@@ -136,7 +137,8 @@ The C target is now a credible small WAM backend:
   `forall/2`'s generated soft-cut rewrite.
 - Supports the first aggregate surface: generated `findall/3` lowering through
   `begin_aggregate collect` / `end_aggregate`, including empty and non-empty
-  result lists, helper-nested aggregate calls, and compound/list templates.
+  result lists, helper-nested aggregate calls, direct inline nested `findall/3`
+  bodies, and compound/list templates.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -159,7 +161,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Second-arg indexing | Partial | Partial/Done | Partial/Done | C has constant A2 dispatch; broaden tests if this becomes hot. |
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
 | Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
-| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple `findall/3` collect support over generated aggregate opcodes; remaining gaps are `bagof/3`, `setof/3`, grouping/witness handling, sort/dedup semantics, and broader aggregate forms. |
+| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support over generated aggregate opcodes; remaining gaps are `bagof/3`, `setof/3`, grouping/witness handling, sort/dedup semantics, and broader aggregate forms. |
 | Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, precise `get_level`/`cut` if-then-else, explicit `!/0` scoped to the current predicate call barrier, and generated `forall/2` soft-cut rewrites; residual work should be driven by concrete meta-control demand. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
@@ -173,6 +175,34 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-inline-nested-findall-lowering`
+
+Goal: close the direct inline nested `findall/3` gap left by the helper-nested
+smoke branch, so aggregate bodies can contain another `findall/3` without
+falling through to an unsupported runtime `call findall/3`.
+
+Evidence:
+
+- `compile_inner_call_goals/4` now dispatches `findall/3` through
+  `compile_findall/6`, so inner-body aggregates emit nested
+  `begin_aggregate collect` / `end_aggregate` WAM.
+- `compile_aggregate_all/6` initializes a newly introduced local result
+  register before `begin_aggregate`, allowing nested aggregate finalization to
+  bind local variables such as `Ys` reliably.
+- The real-Prolog `findall/3` executable smoke now rejects any generated
+  `call findall/3` in the direct inline nested case and checks the compiled C
+  executable returns `[a,b]` for a guarded nested aggregate body.
+
+Reason:
+
+- The prior nested/template branch proved that C aggregate frames survived
+  helper-nested calls and copied compound/list templates, but direct inline
+  nested `findall/3` still compiled as a normal call in inner-goal positions.
+- The first direct inline attempt exposed a separate register-initialization
+  bug: a local aggregate result variable could be assigned a Y register without
+  a backing unbound cell, causing aggregate finalization to fail before later
+  goals could inspect that result.
 
 ### Completed: `investigate/wam-c-findall-nested-template-smoke`
 
@@ -193,10 +223,9 @@ Reason:
 
 - Generated compound/list templates use temporary registers that the first
   aggregate branch did not parse.
-- Direct inline nested `findall/3` still lowers to a call to `findall/3` in the
-  shared compiler; this branch proves the C aggregate runtime behavior through
-  an indirect helper and leaves the broader compiler/runtime surface for a
-  separate branch.
+- The follow-up `investigate/wam-c-inline-nested-findall-lowering` branch closes
+  the direct inline nested compiler/runtime gap; this branch remains the
+  helper-nested and template-copying proof point.
 
 ### Completed: `investigate/wam-c-findall-aggregate-surface`
 

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1358,10 +1358,20 @@ compile_aggregate_all(Template, InnerGoal, Result, V0, Vf, Code) :-
     ;   Template = collect-CollectVar -> AggType = collect, ValueVar = CollectVar
     ;   AggType = collect, ValueVar = Template  % default: direct callers
     ),
-    % Find or allocate the Result register (where output goes)
+    % Find or allocate the Result register (where output goes).  If the
+    % result is a local variable first introduced by this aggregate,
+    % initialize its register before begin_aggregate so finalization has
+    % an unbound cell to unify with; head-bound results are already
+    % initialized by get_variable/get_value.
     (   var(Result), get_var_reg(Result, V0, ResultReg0)
-    ->  V1 = V0
-    ;   allocate_var(Result, V0, V1, ResultReg0)
+    ->  V1 = V0,
+        InitResultCode = ""
+    ;   var(Result)
+    ->  allocate_var(Result, V0, V1, ResultReg0),
+        format(string(InitResultCode), "    put_variable ~w, ~w",
+               [ResultReg0, ResultReg0])
+    ;   allocate_var(Result, V0, V1, ResultReg0),
+        InitResultCode = ""
     ),
     % Compile the Value register (what gets collected per solution)
     (   var(ValueVar)
@@ -1426,10 +1436,17 @@ compile_aggregate_all(Template, InnerGoal, Result, V0, Vf, Code) :-
     % for lookup.
     aggregate_witness_clause(AggType, ValueVar, InnerGoal, Vf,
                              WitnessRegsClause),
-    (   InitValueCode \= ""
+    (   InitResultCode == ""
+    ->  InitAggregateCode = InitValueCode
+    ;   InitValueCode == ""
+    ->  InitAggregateCode = InitResultCode
+    ;   format(string(InitAggregateCode), "~w~n~w",
+               [InitResultCode, InitValueCode])
+    ),
+    (   InitAggregateCode \= ""
     ->  format(string(Code),
             "~w~n    begin_aggregate ~w, ~w, ~w~w~n~w~n    end_aggregate ~w",
-            [InitValueCode, AggType, ValueReg, ResultReg0,
+            [InitAggregateCode, AggType, ValueReg, ResultReg0,
              WitnessRegsClause, FullInnerCode, ValueReg])
     ;   format(string(Code),
             "    begin_aggregate ~w, ~w, ~w~w~n~w~n    end_aggregate ~w",
@@ -1764,6 +1781,10 @@ compile_inner_call_goals([Goal|Rest], V0, Vf, Code) :-
     ;   Goal = (LeftGoal ; RightGoal),
         \+ (LeftGoal = (_ -> _))
     ->  compile_disjunction(LeftGoal, RightGoal, V0, V1, no, GoalCode),
+        compile_inner_call_goals(Rest, V1, Vf, RestCode),
+        join_goal_codes(GoalCode, RestCode, Code)
+    ;   Goal = findall(Template, InnerGoal, Result)
+    ->  compile_findall(Template, InnerGoal, Result, V0, V1, GoalCode),
         compile_inner_call_goals(Rest, V1, Vf, RestCode),
         join_goal_codes(GoalCode, RestCode, Code)
     % M93b: \+ G inlining for inner goal positions (if-then-else

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -2780,6 +2780,13 @@ run_real_prolog_findall_executable_smoke :-
         findall(Y, wam_c_findall_item(Y), L))),
     assertz((user:wam_c_findall_nested_outer(L) :-
         findall(X, (wam_c_findall_item(X), wam_c_findall_nested_inner(_Ys)), L))),
+    assertz((user:wam_c_findall_inline_nested(L) :-
+        findall(X,
+                (   wam_c_findall_item(X),
+                    findall(Y, wam_c_findall_item(Y), Ys),
+                    Ys = [a, b]
+                ),
+                L))),
     assertz((user:wam_c_findall_struct_template(L) :-
         findall(pair(X, [X]), wam_c_findall_item(X), L))),
     assertz((user:wam_c_findall_list_template(L) :-
@@ -2790,6 +2797,7 @@ run_real_prolog_findall_executable_smoke :-
         compile_predicate_to_wam(user:wam_c_findall_empty/1, [], WamEmpty),
         compile_predicate_to_wam(user:wam_c_findall_nested_inner/1, [], WamNestedInner),
         compile_predicate_to_wam(user:wam_c_findall_nested_outer/1, [], WamNestedOuter),
+        compile_predicate_to_wam(user:wam_c_findall_inline_nested/1, [], WamInlineNested),
         compile_predicate_to_wam(user:wam_c_findall_struct_template/1, [], WamStructTemplate),
         compile_predicate_to_wam(user:wam_c_findall_list_template/1, [], WamListTemplate),
         sub_string(WamAll, _, _, _, 'begin_aggregate collect'),
@@ -2798,6 +2806,8 @@ run_real_prolog_findall_executable_smoke :-
         sub_string(WamEmpty, _, _, _, 'end_aggregate'),
         sub_string(WamNestedInner, _, _, _, 'begin_aggregate collect'),
         sub_string(WamNestedOuter, _, _, _, 'begin_aggregate collect'),
+        sub_string(WamInlineNested, _, _, _, 'begin_aggregate collect'),
+        \+ sub_string(WamInlineNested, _, _, _, 'call findall/3'),
         sub_string(WamStructTemplate, _, _, _, 'begin_aggregate collect'),
         sub_string(WamListTemplate, _, _, _, 'begin_aggregate collect'),
         \+ sub_string(WamAll, _, _, _, 'builtin_call findall/3'),
@@ -2807,10 +2817,12 @@ run_real_prolog_findall_executable_smoke :-
         compile_wam_predicate_to_c(user:wam_c_findall_empty/1, WamEmpty, [], EmptyCode),
         compile_wam_predicate_to_c(user:wam_c_findall_nested_inner/1, WamNestedInner, [], NestedInnerCode),
         compile_wam_predicate_to_c(user:wam_c_findall_nested_outer/1, WamNestedOuter, [], NestedOuterCode),
+        compile_wam_predicate_to_c(user:wam_c_findall_inline_nested/1, WamInlineNested, [], InlineNestedCode),
         compile_wam_predicate_to_c(user:wam_c_findall_struct_template/1, WamStructTemplate, [], StructTemplateCode),
         compile_wam_predicate_to_c(user:wam_c_findall_list_template/1, WamListTemplate, [], ListTemplateCode),
         atomic_list_concat([ItemCode, NoneCode, AllCode, EmptyCode,
                             NestedInnerCode, NestedOuterCode,
+                            InlineNestedCode,
                             StructTemplateCode, ListTemplateCode],
                            '\n\n',
                            PredCode),
@@ -2841,6 +2853,7 @@ cleanup_wam_c_findall_smoke :-
     retractall(user:wam_c_findall_empty(_)),
     retractall(user:wam_c_findall_nested_inner(_)),
     retractall(user:wam_c_findall_nested_outer(_)),
+    retractall(user:wam_c_findall_inline_nested(_)),
     retractall(user:wam_c_findall_struct_template(_)),
     retractall(user:wam_c_findall_list_template(_)).
 
@@ -5855,6 +5868,7 @@ void setup_wam_c_findall_all_1(WamState* state);
 void setup_wam_c_findall_empty_1(WamState* state);
 void setup_wam_c_findall_nested_inner_1(WamState* state);
 void setup_wam_c_findall_nested_outer_1(WamState* state);
+void setup_wam_c_findall_inline_nested_1(WamState* state);
 void setup_wam_c_findall_struct_template_1(WamState* state);
 void setup_wam_c_findall_list_template_1(WamState* state);
 
@@ -5963,6 +5977,7 @@ int main(void) {
     setup_wam_c_findall_empty_1(&state);
     setup_wam_c_findall_nested_inner_1(&state);
     setup_wam_c_findall_nested_outer_1(&state);
+    setup_wam_c_findall_inline_nested_1(&state);
     setup_wam_c_findall_struct_template_1(&state);
     setup_wam_c_findall_list_template_1(&state);
 
@@ -6000,6 +6015,15 @@ int main(void) {
         state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
         wam_free_state(&state);
         return 40;
+    }
+
+    WamValue inline_nested_args[1] = { val_unbound("InlineNested") };
+    int inline_nested_rc = wam_run_predicate(&state, "wam_c_findall_inline_nested/1", inline_nested_args, 1);
+    if (inline_nested_rc != 0 || state.P != WAM_HALT ||
+        !expect_atom_list2(&state, state.A[0], "a", "b") ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 45;
     }
 
     WamValue struct_args[1] = { val_unbound("Struct") };


### PR DESCRIPTION
  ## Summary

  - Lower `findall/3` inside inner goal positions to nested aggregate opcodes instead of emitting `call findall/3`
  - Initialize fresh local aggregate result registers before `begin_aggregate`, so nested aggregate finalization can
  bind local results like `Ys`
  - Add a WAM-C executable smoke for direct inline nested `findall/3` with a guarded nested result
  - Update the C target next-steps notes

  ## Verification

  - `swipl -q -g "['tests/test_wam_c_target.pl'], run_real_prolog_findall_executable_smoke, halt"`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `git diff --check`