### PR TITLE
Add no-witness bagof and setof aggregates to WAM-C

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,15 +4,15 @@ Status date: 2026-06-05
 
 Latest branch verification:
 
-- `investigate/wam-c-inline-nested-findall-lowering` based on `main` at
-  `8183cce6` (`Merge pull request #2825 from
-  s243a/investigate/wam-c-findall-nested-template-smoke`)
+- `investigate/wam-c-bagof-setof-aggregate-surface` based on `main` at
+  `a493993d` (`Merge pull request #2844 from
+  s243a/investigate/wam-c-inline-nested-findall-lowering`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-inline-nested-findall-lowering`
+- `investigate/wam-c-bagof-setof-aggregate-surface`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -83,6 +83,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | `findall/3` collect aggregate surface | Done | C now parses and executes shared `begin_aggregate collect` / `end_aggregate` WAM for simple `findall/3`, preserving generator choice points under aggregate frames and building non-empty/empty result lists |
 | `findall/3` nested/template smoke | Done | C now parses compiler temporary `_XTn` registers and the generated executable smoke covers helper-nested `findall/3`, `pair(X, [X])` templates, and `[X, X]` templates |
 | Direct inline nested `findall/3` lowering | Done | Inner-body `findall/3` now lowers to nested aggregate opcodes instead of `call findall/3`; local aggregate result slots are initialized before finalization, and the executable smoke covers `findall(X, (item(X), findall(Y, item(Y), Ys), Ys = [a,b]), L)` |
+| No-witness `bagof/3` and `setof/3` aggregate surface | Done | C parses the shared 4-field no-witness `begin_aggregate bagof/setof` form, `bagof/3` preserves duplicate solution order and fails empty, and `setof/3` sorts/deduplicates and fails empty |
 
 ## Current C Target Baseline
 
@@ -138,7 +139,7 @@ The C target is now a credible small WAM backend:
 - Supports the first aggregate surface: generated `findall/3` lowering through
   `begin_aggregate collect` / `end_aggregate`, including empty and non-empty
   result lists, helper-nested aggregate calls, direct inline nested `findall/3`
-  bodies, and compound/list templates.
+  bodies, compound/list templates, and no-witness `bagof/3` / `setof/3`.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -161,7 +162,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Second-arg indexing | Partial | Partial/Done | Partial/Done | C has constant A2 dispatch; broaden tests if this becomes hot. |
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
 | Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
-| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support over generated aggregate opcodes; remaining gaps are `bagof/3`, `setof/3`, grouping/witness handling, sort/dedup semantics, and broader aggregate forms. |
+| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness `bagof/3` / `setof/3`; remaining gaps are witness grouping, existential `^/2` inner-goal lowering, and broader aggregate forms. |
 | Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, precise `get_level`/`cut` if-then-else, explicit `!/0` scoped to the current predicate call barrier, and generated `forall/2` soft-cut rewrites; residual work should be driven by concrete meta-control demand. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
@@ -175,6 +176,33 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-bagof-setof-aggregate-surface`
+
+Goal: extend the C aggregate runtime from `findall/3` collection into the
+compiler's no-witness `bagof/3` and `setof/3` surface.
+
+Evidence:
+
+- The C WAM parser accepts `begin_aggregate bagof/setof, Template, Result, ''`
+  and rejects non-empty witness strings instead of silently compiling grouped
+  semantics that the C runtime does not yet implement.
+- The aggregate finalizer now supports `bagof` and `setof`: `bagof` fails on
+  empty generators while preserving duplicate solution order, and `setof`
+  fails empty then sorts and deduplicates copied stored terms before list
+  materialization.
+- The real-Prolog executable smoke compiles `bagof/3` and `setof/3` with
+  `inline_bagof_setof(true)`, checks no `call bagof/3` / `call setof/3`
+  remains, verifies duplicate bag output, verifies sorted unique set output,
+  and checks empty-generator failure for both predicates.
+
+Reason:
+
+- Direct inline nested `findall/3` proved that nested aggregate frames and local
+  aggregate result variables work in C.
+- The next aggregate parity step is the no-witness subset the shared compiler
+  already describes. Grouped/witness `bagof` and `setof`, including inner
+  existential `^/2` lowering, remain a separate larger semantic surface.
 
 ### Completed: `investigate/wam-c-inline-nested-findall-lowering`
 

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -269,6 +269,7 @@ typedef struct {
     int template_is_y;
     int result_reg;
     int result_is_y;
+    char *witness_regs;
 } WamAggregateInstr;
 
 typedef union {

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -1618,11 +1618,18 @@ wam_instruction_to_c_literal(call_foreign(P, N), Code) :-
 wam_instruction_to_c_literal(begin_aggregate(Kind, TemplateReg, ResultReg), Code) :-
     c_reg_index(TemplateReg, TemplateIsY, TemplateIdx),
     c_reg_index(ResultReg, ResultIsY, ResultIdx),
-    format(atom(Code), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w } }',
+    format(atom(Code), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w, .witness_regs = "" } }',
+           [Kind, TemplateIdx, TemplateIsY, ResultIdx, ResultIsY]).
+wam_instruction_to_c_literal(begin_aggregate(Kind, TemplateReg, ResultReg, WitnessRegs), Code) :-
+    clean_aggregate_witness(WitnessRegs, WitnessString),
+    ensure_supported_aggregate_witness(WitnessString),
+    c_reg_index(TemplateReg, TemplateIsY, TemplateIdx),
+    c_reg_index(ResultReg, ResultIsY, ResultIdx),
+    format(atom(Code), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w, .witness_regs = "" } }',
            [Kind, TemplateIdx, TemplateIsY, ResultIdx, ResultIsY]).
 wam_instruction_to_c_literal(end_aggregate(TemplateReg), Code) :-
     c_reg_index(TemplateReg, TemplateIsY, TemplateIdx),
-    format(atom(Code), '{ .tag = INSTR_END_AGGREGATE, .as.aggregate = { .kind = "collect", .template_reg = ~w, .template_is_y = ~w, .result_reg = 0, .result_is_y = 0 } }',
+    format(atom(Code), '{ .tag = INSTR_END_AGGREGATE, .as.aggregate = { .kind = "collect", .template_reg = ~w, .template_is_y = ~w, .result_reg = 0, .result_is_y = 0, .witness_regs = "" } }',
            [TemplateIdx, TemplateIsY]).
 wam_instruction_to_c_literal(get_level(Reg), Code) :-
     c_reg_index(Reg, IsY, Idx),
@@ -1786,12 +1793,21 @@ wam_line_to_c_instr(["begin_aggregate", Kind, TemplateReg, ResultReg], Instr) :-
     clean_comma(ResultReg, CResultReg), c_escape_atom(CKind0, CKind),
     c_reg_index(CTemplateReg, TemplateIsY, TemplateIdx),
     c_reg_index(CResultReg, ResultIsY, ResultIdx),
-    format(atom(Instr), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w } }',
+    format(atom(Instr), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w, .witness_regs = "" } }',
+           [CKind, TemplateIdx, TemplateIsY, ResultIdx, ResultIsY]).
+wam_line_to_c_instr(["begin_aggregate", Kind, TemplateReg, ResultReg, WitnessRegs], Instr) :-
+    clean_comma(Kind, CKind0), clean_comma(TemplateReg, CTemplateReg),
+    clean_comma(ResultReg, CResultReg), c_escape_atom(CKind0, CKind),
+    clean_aggregate_witness(WitnessRegs, WitnessString),
+    ensure_supported_aggregate_witness(WitnessString),
+    c_reg_index(CTemplateReg, TemplateIsY, TemplateIdx),
+    c_reg_index(CResultReg, ResultIsY, ResultIdx),
+    format(atom(Instr), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w, .witness_regs = "" } }',
            [CKind, TemplateIdx, TemplateIsY, ResultIdx, ResultIsY]).
 wam_line_to_c_instr(["end_aggregate", TemplateReg], Instr) :-
     clean_comma(TemplateReg, CTemplateReg),
     c_reg_index(CTemplateReg, TemplateIsY, TemplateIdx),
-    format(atom(Instr), '{ .tag = INSTR_END_AGGREGATE, .as.aggregate = { .kind = "collect", .template_reg = ~w, .template_is_y = ~w, .result_reg = 0, .result_is_y = 0 } }',
+    format(atom(Instr), '{ .tag = INSTR_END_AGGREGATE, .as.aggregate = { .kind = "collect", .template_reg = ~w, .template_is_y = ~w, .result_reg = 0, .result_is_y = 0, .witness_regs = "" } }',
            [TemplateIdx, TemplateIsY]).
 wam_line_to_c_instr(["get_level", Reg], Instr) :-
     clean_comma(Reg, CReg),
@@ -1826,6 +1842,24 @@ clean_comma(S, Clean) :-
     ->  sub_string(S, 0, _, 1, Clean)
     ;   Clean = S
     ).
+
+clean_aggregate_witness(Witness0, Witness) :-
+    clean_comma(Witness0, Clean0),
+    (   string(Clean0)
+    ->  S0 = Clean0
+    ;   atom(Clean0)
+    ->  atom_string(Clean0, S0)
+    ;   term_string(Clean0, S0)
+    ),
+    (   sub_string(S0, 0, 1, _, "'"),
+        sub_string(S0, _, 1, 0, "'")
+    ->  sub_string(S0, 1, _, 1, Witness)
+    ;   Witness = S0
+    ).
+
+ensure_supported_aggregate_witness("") :- !.
+ensure_supported_aggregate_witness(Witness) :-
+    throw(error(wam_c_target_error(unsupported_bagof_setof_witnesses(Witness)), _)).
 
 %% c_escape_atom(+Atom, -Escaped)
 %  Escape backslashes and double quotes so the value is safe inside a C
@@ -2665,6 +2699,128 @@ static bool wam_materialize_stored_term(WamState *state,
     return false;
 }
 
+static int wam_stored_term_tag_rank(WamValueTag tag) {
+    switch (tag) {
+        case VAL_UNBOUND: return 0;
+        case VAL_INT: return 1;
+        case VAL_FLOAT: return 2;
+        case VAL_ATOM: return 3;
+        case VAL_LIST: return 4;
+        case VAL_STR: return 5;
+        case VAL_REF: return 6;
+        default: return 7;
+    }
+}
+
+static int wam_compare_ints(int left, int right) {
+    return (left > right) - (left < right);
+}
+
+static int wam_compare_doubles(double left, double right) {
+    return (left > right) - (left < right);
+}
+
+static int wam_compare_stored_value(const WamStoredTerm *left_term,
+                                    WamValue left,
+                                    const WamStoredTerm *right_term,
+                                    WamValue right) {
+    int left_rank = wam_stored_term_tag_rank(left.tag);
+    int right_rank = wam_stored_term_tag_rank(right.tag);
+    if (left_rank != right_rank) return wam_compare_ints(left_rank, right_rank);
+
+    switch (left.tag) {
+        case VAL_UNBOUND:
+            return 0;
+        case VAL_INT:
+            return wam_compare_ints(left.data.integer, right.data.integer);
+        case VAL_FLOAT:
+            return wam_compare_doubles(left.data.floating, right.data.floating);
+        case VAL_ATOM:
+            return strcmp(left.data.atom, right.data.atom);
+        case VAL_LIST: {
+            int left_base = left.data.ref_addr;
+            int right_base = right.data.ref_addr;
+            if (left_base < 0 || left_base + 1 >= left_term->cell_count ||
+                right_base < 0 || right_base + 1 >= right_term->cell_count) {
+                return wam_compare_ints(left_base, right_base);
+            }
+            int head_cmp =
+                wam_compare_stored_value(left_term, left_term->cells[left_base],
+                                         right_term, right_term->cells[right_base]);
+            if (head_cmp != 0) return head_cmp;
+            return wam_compare_stored_value(left_term, left_term->cells[left_base + 1],
+                                            right_term, right_term->cells[right_base + 1]);
+        }
+        case VAL_STR: {
+            int left_base = left.data.ref_addr;
+            int right_base = right.data.ref_addr;
+            if (left_base < 0 || left_base >= left_term->cell_count ||
+                right_base < 0 || right_base >= right_term->cell_count) {
+                return wam_compare_ints(left_base, right_base);
+            }
+            WamValue left_functor = left_term->cells[left_base];
+            WamValue right_functor = right_term->cells[right_base];
+            int functor_cmp =
+                wam_compare_stored_value(left_term, left_functor,
+                                         right_term, right_functor);
+            if (functor_cmp != 0) return functor_cmp;
+            if (left_functor.tag != VAL_ATOM || right_functor.tag != VAL_ATOM) {
+                return 0;
+            }
+            int left_arity = 0;
+            int right_arity = 0;
+            if (!wam_parse_functor_arity(left_functor.data.atom, &left_arity) ||
+                !wam_parse_functor_arity(right_functor.data.atom, &right_arity)) {
+                return 0;
+            }
+            int arity_cmp = wam_compare_ints(left_arity, right_arity);
+            if (arity_cmp != 0) return arity_cmp;
+            for (int i = 0; i < left_arity; i++) {
+                int arg_cmp =
+                    wam_compare_stored_value(left_term, left_term->cells[left_base + 1 + i],
+                                             right_term, right_term->cells[right_base + 1 + i]);
+                if (arg_cmp != 0) return arg_cmp;
+            }
+            return 0;
+        }
+        case VAL_REF:
+            return wam_compare_ints(left.data.ref_addr, right.data.ref_addr);
+        default:
+            return 0;
+    }
+}
+
+static int wam_compare_stored_terms_for_qsort(const void *left,
+                                              const void *right) {
+    const WamStoredTerm *left_term = (const WamStoredTerm *)left;
+    const WamStoredTerm *right_term = (const WamStoredTerm *)right;
+    return wam_compare_stored_value(left_term, left_term->root,
+                                    right_term, right_term->root);
+}
+
+static void wam_aggregate_sort_dedup_items(WamAggregateFrame *frame) {
+    if (frame->item_count < 2) return;
+    qsort(frame->items, (size_t)frame->item_count, sizeof(WamStoredTerm),
+          wam_compare_stored_terms_for_qsort);
+
+    int out = 1;
+    for (int i = 1; i < frame->item_count; i++) {
+        WamStoredTerm *previous = &frame->items[out - 1];
+        WamStoredTerm *current = &frame->items[i];
+        if (wam_compare_stored_value(previous, previous->root,
+                                     current, current->root) == 0) {
+            wam_stored_term_free(current);
+        } else {
+            if (out != i) {
+                frame->items[out] = *current;
+                memset(current, 0, sizeof(WamStoredTerm));
+            }
+            out++;
+        }
+    }
+    frame->item_count = out;
+}
+
 static void wam_aggregate_frame_free(WamAggregateFrame *frame) {
     for (int i = 0; i < frame->item_count; i++) {
         wam_stored_term_free(&frame->items[i]);
@@ -2737,7 +2893,10 @@ static int wam_find_matching_end_aggregate(WamState *state, int begin_pc) {
 
 static bool wam_finalize_aggregate_frame(WamState *state,
                                          WamAggregateFrame *frame) {
-    if (strcmp(frame->kind, "collect") != 0) return false;
+    bool is_collect = strcmp(frame->kind, "collect") == 0;
+    bool is_bagof = strcmp(frame->kind, "bagof") == 0;
+    bool is_setof = strcmp(frame->kind, "setof") == 0;
+    if (!is_collect && !is_bagof && !is_setof) return false;
     int next_pc = frame->end_pc + 1;
     int frame_index = state->aggregate_top - 1;
     if (frame->sentinel_b > 0 && frame->sentinel_b <= state->B) {
@@ -2745,6 +2904,16 @@ static bool wam_finalize_aggregate_frame(WamState *state,
         restore_choice_point(state, sentinel);
     }
     wam_prune_choice_points(state, frame->base_b);
+
+    if ((is_bagof || is_setof) && frame->item_count == 0) {
+        wam_aggregate_frame_free(frame);
+        state->aggregate_top = frame_index;
+        state->P = next_pc;
+        return false;
+    }
+    if (is_setof) {
+        wam_aggregate_sort_dedup_items(frame);
+    }
 
     WamValue result_list;
     if (!wam_build_aggregate_list(state, frame, &result_list)) return false;
@@ -2759,7 +2928,11 @@ static bool wam_finalize_aggregate_frame(WamState *state,
 }
 
 static bool wam_begin_aggregate(WamState *state, Instruction *instr) {
-    if (strcmp(instr->as.aggregate.kind, "collect") != 0) return false;
+    if (strcmp(instr->as.aggregate.kind, "collect") != 0 &&
+        strcmp(instr->as.aggregate.kind, "bagof") != 0 &&
+        strcmp(instr->as.aggregate.kind, "setof") != 0) return false;
+    if (instr->as.aggregate.witness_regs &&
+        instr->as.aggregate.witness_regs[0] != 0) return false;
     if (state->aggregate_top > 0) {
         WamAggregateFrame *top = &state->aggregate_frames[state->aggregate_top - 1];
         if (top->begin_pc == state->P && top->sentinel_b == state->B) {
@@ -2789,7 +2962,9 @@ static bool wam_begin_aggregate(WamState *state, Instruction *instr) {
 static bool wam_end_aggregate(WamState *state, Instruction *instr) {
     if (state->aggregate_top <= 0) return false;
     WamAggregateFrame *frame = &state->aggregate_frames[state->aggregate_top - 1];
-    if (strcmp(frame->kind, "collect") != 0) return false;
+    if (strcmp(frame->kind, "collect") != 0 &&
+        strcmp(frame->kind, "bagof") != 0 &&
+        strcmp(frame->kind, "setof") != 0) return false;
     WamValue *template_cell =
         resolve_reg(state, instr->as.aggregate.template_reg,
                     instr->as.aggregate.template_is_y);

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -1725,6 +1725,16 @@ test_real_prolog_findall_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_real_prolog_bagof_setof_executable_smoke :-
+    Test = 'WAM-C: real Prolog bagof/3 and setof/3 executable smoke',
+    (   gcc_available
+    ->  (   run_real_prolog_bagof_setof_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'real Prolog bagof/3 and setof/3 executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_real_prolog_classic_recursive_executable_smoke :-
     Test = 'WAM-C: real Prolog classic recursive executable smoke',
     (   gcc_available
@@ -2856,6 +2866,69 @@ cleanup_wam_c_findall_smoke :-
     retractall(user:wam_c_findall_inline_nested(_)),
     retractall(user:wam_c_findall_struct_template(_)),
     retractall(user:wam_c_findall_list_template(_)).
+
+run_real_prolog_bagof_setof_executable_smoke :-
+    Options = [inline_bagof_setof(true)],
+    assertz((user:wam_c_bagset_item(b) :- true)),
+    assertz((user:wam_c_bagset_item(a) :- true)),
+    assertz((user:wam_c_bagset_none(_) :- fail)),
+    assertz((user:wam_c_bagset_bag(L) :-
+        bagof(X, (wam_c_bagset_item(X) ; wam_c_bagset_item(X)), L))),
+    assertz((user:wam_c_bagset_set(L) :-
+        setof(X, (wam_c_bagset_item(X) ; wam_c_bagset_item(X)), L))),
+    assertz((user:wam_c_bagset_bag_empty(L) :-
+        bagof(X, wam_c_bagset_none(X), L))),
+    assertz((user:wam_c_bagset_set_empty(L) :-
+        setof(X, wam_c_bagset_none(X), L))),
+    (   compile_predicate_to_wam(user:wam_c_bagset_item/1, Options, WamItem),
+        compile_predicate_to_wam(user:wam_c_bagset_none/1, Options, WamNone),
+        compile_predicate_to_wam(user:wam_c_bagset_bag/1, Options, WamBag),
+        compile_predicate_to_wam(user:wam_c_bagset_set/1, Options, WamSet),
+        compile_predicate_to_wam(user:wam_c_bagset_bag_empty/1, Options, WamBagEmpty),
+        compile_predicate_to_wam(user:wam_c_bagset_set_empty/1, Options, WamSetEmpty),
+        sub_string(WamBag, _, _, _, 'begin_aggregate bagof'),
+        sub_string(WamBag, _, _, _, "''"),
+        \+ sub_string(WamBag, _, _, _, 'call bagof/3'),
+        sub_string(WamSet, _, _, _, 'begin_aggregate setof'),
+        sub_string(WamSet, _, _, _, "''"),
+        \+ sub_string(WamSet, _, _, _, 'call setof/3'),
+        compile_wam_predicate_to_c(user:wam_c_bagset_item/1, WamItem, Options, ItemCode),
+        compile_wam_predicate_to_c(user:wam_c_bagset_none/1, WamNone, Options, NoneCode),
+        compile_wam_predicate_to_c(user:wam_c_bagset_bag/1, WamBag, Options, BagCode),
+        compile_wam_predicate_to_c(user:wam_c_bagset_set/1, WamSet, Options, SetCode),
+        compile_wam_predicate_to_c(user:wam_c_bagset_bag_empty/1, WamBagEmpty, Options, BagEmptyCode),
+        compile_wam_predicate_to_c(user:wam_c_bagset_set_empty/1, WamSetEmpty, Options, SetEmptyCode),
+        atomic_list_concat([ItemCode, NoneCode, BagCode, SetCode,
+                            BagEmptyCode, SetEmptyCode],
+                           '\n\n',
+                           PredCode),
+        compile_wam_runtime_to_c([], RuntimeCode),
+        get_time(Now),
+        Stamp is round(Now * 1000000),
+        wam_c_temp_path('unifyweaver_wam_c_bagof_setof_smoke', Stamp, TmpBase),
+        format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+        format(atom(PredPath), '~w_pred.c', [TmpBase]),
+        format(atom(MainPath), '~w_main.c', [TmpBase]),
+        format(atom(ExePath), '~w_bin', [TmpBase]),
+        write_text_file(RuntimePath, RuntimeCode),
+        format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+        write_text_file(PredPath, PredTranslationUnit),
+        wam_c_bagof_setof_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_bagof_setof_smoke
+    ;   cleanup_wam_c_bagof_setof_smoke,
+        fail
+    ).
+
+cleanup_wam_c_bagof_setof_smoke :-
+    retractall(user:wam_c_bagset_item(_)),
+    retractall(user:wam_c_bagset_none(_)),
+    retractall(user:wam_c_bagset_bag(_)),
+    retractall(user:wam_c_bagset_set(_)),
+    retractall(user:wam_c_bagset_bag_empty(_)),
+    retractall(user:wam_c_bagset_set_empty(_)).
 
 run_real_prolog_classic_recursive_executable_smoke :-
     assertz((user:wam_c_classic_fib(0, 0) :- true)),
@@ -6049,6 +6122,113 @@ int main(void) {
 }
 ').
 
+wam_c_bagof_setof_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_bagset_item_1(WamState* state);
+void setup_wam_c_bagset_none_1(WamState* state);
+void setup_wam_c_bagset_bag_1(WamState* state);
+void setup_wam_c_bagset_set_1(WamState* state);
+void setup_wam_c_bagset_bag_empty_1(WamState* state);
+void setup_wam_c_bagset_set_empty_1(WamState* state);
+
+static bool expect_atom_slot(WamState *state, WamValue *slot, const char *atom) {
+    WamValue *cell = wam_deref_ptr(state, slot);
+    return cell->tag == VAL_ATOM && strcmp(cell->data.atom, atom) == 0;
+}
+
+static bool expect_nil(WamValue *cell) {
+    return cell->tag == VAL_ATOM && strcmp(cell->data.atom, "[]") == 0;
+}
+
+static bool expect_atom_list2(WamState *state, WamValue value,
+                              const char *first, const char *second) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    int cell_addr = wam_cons_head_addr(state, cell);
+    if (cell_addr < 0) return false;
+    WamValue *tail1 = wam_deref_ptr(state, &state->H_array[cell_addr + 1]);
+    int tail1_addr = wam_cons_head_addr(state, tail1);
+    if (tail1_addr < 0) return false;
+    WamValue *tail2 = wam_deref_ptr(state, &state->H_array[tail1_addr + 1]);
+    return expect_atom_slot(state, &state->H_array[cell_addr], first) &&
+           expect_atom_slot(state, &state->H_array[tail1_addr], second) &&
+           expect_nil(tail2);
+}
+
+static bool expect_atom_list4(WamState *state, WamValue value,
+                              const char *first,
+                              const char *second,
+                              const char *third,
+                              const char *fourth) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    int cell_addr = wam_cons_head_addr(state, cell);
+    if (cell_addr < 0) return false;
+    WamValue *tail1 = wam_deref_ptr(state, &state->H_array[cell_addr + 1]);
+    int tail1_addr = wam_cons_head_addr(state, tail1);
+    if (tail1_addr < 0) return false;
+    WamValue *tail2 = wam_deref_ptr(state, &state->H_array[tail1_addr + 1]);
+    int tail2_addr = wam_cons_head_addr(state, tail2);
+    if (tail2_addr < 0) return false;
+    WamValue *tail3 = wam_deref_ptr(state, &state->H_array[tail2_addr + 1]);
+    int tail3_addr = wam_cons_head_addr(state, tail3);
+    if (tail3_addr < 0) return false;
+    WamValue *tail4 = wam_deref_ptr(state, &state->H_array[tail3_addr + 1]);
+    return expect_atom_slot(state, &state->H_array[cell_addr], first) &&
+           expect_atom_slot(state, &state->H_array[tail1_addr], second) &&
+           expect_atom_slot(state, &state->H_array[tail2_addr], third) &&
+           expect_atom_slot(state, &state->H_array[tail3_addr], fourth) &&
+           expect_nil(tail4);
+}
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_bagset_item_1(&state);
+    setup_wam_c_bagset_none_1(&state);
+    setup_wam_c_bagset_bag_1(&state);
+    setup_wam_c_bagset_set_1(&state);
+    setup_wam_c_bagset_bag_empty_1(&state);
+    setup_wam_c_bagset_set_empty_1(&state);
+
+    WamValue bag_args[1] = { val_unbound("Bag") };
+    int bag_rc = wam_run_predicate(&state, "wam_c_bagset_bag/1", bag_args, 1);
+    if (bag_rc != 0 || state.P != WAM_HALT ||
+        !expect_atom_list4(&state, state.A[0], "b", "a", "b", "a") ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue set_args[1] = { val_unbound("Set") };
+    int set_rc = wam_run_predicate(&state, "wam_c_bagset_set/1", set_args, 1);
+    if (set_rc != 0 || state.P != WAM_HALT ||
+        !expect_atom_list2(&state, state.A[0], "a", "b") ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue bag_empty_args[1] = { val_unbound("BagEmpty") };
+    int bag_empty_rc = wam_run_predicate(&state, "wam_c_bagset_bag_empty/1", bag_empty_args, 1);
+    if (bag_empty_rc != WAM_HALT ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    WamValue set_empty_args[1] = { val_unbound("SetEmpty") };
+    int set_empty_rc = wam_run_predicate(&state, "wam_c_bagset_set_empty/1", set_empty_args, 1);
+    if (set_empty_rc != WAM_HALT ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_classic_fib_smoke_main(
 '#include "wam_runtime.h"
 
@@ -6263,6 +6443,7 @@ run_tests_once :-
     test_real_prolog_explicit_cut_executable_smoke,
     test_real_prolog_forall_executable_smoke,
     test_real_prolog_findall_executable_smoke,
+    test_real_prolog_bagof_setof_executable_smoke,
     test_real_prolog_classic_recursive_executable_smoke,
     test_lowered_fact_helper_executable_smoke,
     test_lowered_body_call_helper_executable_smoke,


### PR DESCRIPTION
  ## Summary

  - Parse no-witness `begin_aggregate bagof/setof, Template, Result, ''` in the C WAM target
  - Add C runtime support for no-witness `bagof/3` and `setof/3`
  - Preserve duplicate solution order for `bagof/3`
  - Sort and deduplicate stored terms for `setof/3`
  - Make both `bagof/3` and `setof/3` fail on empty generators
  - Explicitly reject non-empty witness strings for grouped `bagof`/`setof` until that semantic surface is implemented
  - Add a real-Prolog WAM-C executable smoke and update the C target notes

  ## Verification

  - `swipl -q -g "['tests/test_wam_c_target.pl'], run_real_prolog_bagof_setof_executable_smoke, halt"`
  - `swipl -q -g "['tests/test_wam_c_target.pl'], test_real_prolog_bagof_setof_executable_smoke, halt"`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `git diff --check`