### PR TITLE
Root metrics: min_dist_to_root as a lookup-served query

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,10 @@ jobs:
         run: |
           python3 -m unittest tests.test_build_scoped_subtree_lmdb
 
+      - name: Run root-metric query tool test
+        run: |
+          python3 -m unittest tests.test_query_root_metric
+
       - name: Run WAM Rust matrix-bench demand-flag codegen test
         run: |
           python3 -m unittest tests.test_wam_rust_matrix_demand_flag

--- a/examples/benchmark/query_root_metric.py
+++ b/examples/benchmark/query_root_metric.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+"""
+query_root_metric.py — answer a materialised root-anchored metric as a lookup.
+
+This is the query surface for the ingest-materialised path of
+docs/design/ROOT_ANCHORED_METRICS_*. Once build_scoped_subtree_lmdb.py has
+written a `metric_<name>` sub-db, answering the metric for a node is a single
+keyed get — no graph traversal at all. For `min_dist_to_root` that means the
+"how far is this category from the root" query is O(1) per node at full scale.
+
+  min_dist_to_root(Root, Node, D)  ==  metric_min_dist_to_root[Node]
+
+Usage:
+  python3 query_root_metric.py --lmdb data/benchmark/enwiki_cats_correct/lmdb_scoped \
+      7345184 1234 5678            # look up these node ids
+  python3 query_root_metric.py --lmdb <dir> --nodes-file ids.txt
+  python3 query_root_metric.py --lmdb <dir> --histogram
+  python3 query_root_metric.py --lmdb <dir> --verify [--sample N]
+
+`--verify` recomputes the metric from scratch (BFS over category_child from the
+stored root) and asserts every materialised value matches — an independent check
+that the lookup table is correct, separate from the builder that wrote it.
+"""
+import argparse
+import collections
+import struct
+import sys
+import time
+from pathlib import Path
+
+import lmdb
+
+I32 = struct.Struct("<i")
+
+
+def enc(i):
+    return I32.pack(i)
+
+
+def dec(b):
+    return I32.unpack(b)[0]
+
+
+def metric_meta(env, meta_db, name):
+    """Read the stored provenance for metric `name` (root, max_depth, aggregate)."""
+    out = {}
+    with env.begin() as txn:
+        for field in ("root", "max_depth", "aggregate"):
+            v = txn.get(f"metric_{name}.{field}".encode(), db=meta_db)
+            if v is not None:
+                out[field] = v.decode()
+    return out
+
+
+def recompute_min_dist(env, cc_db, root, max_depth):
+    """Independent oracle: BFS down category_child from root; layer = min dist."""
+    dist = {root: 0}
+    frontier = [root]
+    depth = 0
+    with env.begin() as txn:
+        cur = txn.cursor(db=cc_db)
+        while frontier and depth < max_depth:
+            nxt = []
+            for node in frontier:
+                if cur.set_key(enc(node)):
+                    for v in cur.iternext_dup(keys=False, values=True):
+                        child = dec(v)
+                        if child not in dist:
+                            dist[child] = depth + 1
+                            nxt.append(child)
+            frontier = nxt
+            depth += 1
+    return dist
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--lmdb", required=True, help="scoped LMDB dir with a metric_* sub-db")
+    ap.add_argument("--metric", default="min_dist_to_root", help="metric name (default min_dist_to_root)")
+    ap.add_argument("nodes", nargs="*", type=int, help="node ids to look up")
+    ap.add_argument("--nodes-file", help="file of node ids (one per line)")
+    ap.add_argument("--histogram", action="store_true", help="print the value histogram")
+    ap.add_argument("--verify", action="store_true",
+                    help="cross-check the materialised table against a fresh BFS oracle")
+    ap.add_argument("--sample", type=int, default=0,
+                    help="with --verify, check this many table entries (0 = all)")
+    args = ap.parse_args()
+
+    metric_sub = f"metric_{args.metric}".encode()
+    env = lmdb.open(str(args.lmdb), max_dbs=16, readonly=True, subdir=True, lock=False,
+                    map_size=4 * 1024 ** 3)
+    try:
+        metric_db = env.open_db(metric_sub, create=False)
+    except lmdb.NotFoundError:
+        sys.stderr.write(f"error: no '{metric_sub.decode()}' sub-db in {args.lmdb}; "
+                         f"rebuild with build_scoped_subtree_lmdb.py (--min-dist)\n")
+        return 1
+    meta_db = env.open_db(b"meta", create=False)
+    meta = metric_meta(env, meta_db, args.metric)
+    if meta:
+        sys.stderr.write(f"[{args.metric}] root={meta.get('root')} "
+                         f"max_depth={meta.get('max_depth')} aggregate={meta.get('aggregate')}\n")
+
+    # Collect node ids to look up.
+    ids = list(args.nodes)
+    if args.nodes_file:
+        with open(args.nodes_file) as f:
+            ids += [int(x) for x in (line.split()[0] for line in f if line.strip())]
+
+    # O(1) lookups.
+    if ids:
+        t0 = time.perf_counter()
+        with env.begin() as txn:
+            for nid in ids:
+                v = txn.get(enc(nid), db=metric_db)
+                if v is None:
+                    print(f"{nid}\tunreachable")
+                else:
+                    print(f"{nid}\t{dec(v)}")
+        dt = time.perf_counter() - t0
+        sys.stderr.write(f"{len(ids)} lookups in {dt*1e3:.3f} ms "
+                         f"({len(ids)/dt:,.0f} lookups/s)\n")
+
+    if args.histogram:
+        hist = collections.Counter()
+        with env.begin() as txn:
+            for _k, v in txn.cursor(db=metric_db):
+                hist[dec(v)] += 1
+        total = sum(hist.values())
+        sys.stderr.write(f"value histogram over {total} nodes:\n")
+        for val in sorted(hist):
+            print(f"{val}\t{hist[val]}")
+
+    rc = 0
+    if args.verify:
+        if args.metric != "min_dist_to_root":
+            sys.stderr.write(f"--verify only supports min_dist_to_root (got {args.metric})\n")
+            return 2
+        if not meta.get("root"):
+            sys.stderr.write("error: no stored root for this metric; cannot verify\n")
+            return 2
+        cc_db = env.open_db(b"category_child", dupsort=True, create=False)
+        oracle = recompute_min_dist(env, cc_db, int(meta["root"]), int(meta["max_depth"]))
+        mismatches = 0
+        checked = 0
+        with env.begin() as txn:
+            cur = txn.cursor(db=metric_db)
+            for k, v in cur:
+                node, stored = dec(k), dec(v)
+                if oracle.get(node) != stored:
+                    mismatches += 1
+                    if mismatches <= 10:
+                        sys.stderr.write(f"  mismatch node {node}: stored {stored} "
+                                         f"oracle {oracle.get(node)}\n")
+                checked += 1
+                if args.sample and checked >= args.sample:
+                    break
+        # also: every oracle node should be in the table (when checking all)
+        missing = 0
+        if not args.sample:
+            with env.begin() as txn:
+                for node in oracle:
+                    if txn.get(enc(node), db=metric_db) is None:
+                        missing += 1
+        sys.stderr.write(f"verify: checked {checked} entries, {mismatches} mismatches, "
+                         f"{missing} oracle nodes missing from table\n")
+        if mismatches == 0 and missing == 0:
+            sys.stderr.write("verify: OK — materialised metric matches the BFS oracle\n")
+        else:
+            sys.stderr.write("verify: FAILED\n")
+            rc = 1
+
+    env.close()
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_query_root_metric.py
+++ b/tests/test_query_root_metric.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+"""Unit test for examples/benchmark/query_root_metric.py.
+
+Builds a tiny scoped LMDB (with the metric_min_dist_to_root sub-db) via
+build_scoped_subtree_lmdb.py, then checks that query_root_metric.py answers
+min_dist_to_root by lookup and that its --verify (fresh BFS oracle) passes.
+
+Skips gracefully if python-lmdb is not installed.
+"""
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import lmdb  # noqa: F401
+    HAVE_LMDB = True
+except ImportError:
+    HAVE_LMDB = False
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BUILDER = REPO_ROOT / "examples" / "benchmark" / "build_scoped_subtree_lmdb.py"
+QUERY = REPO_ROOT / "examples" / "benchmark" / "query_root_metric.py"
+I32 = struct.Struct("<i")
+
+
+def enc(i):
+    return I32.pack(i)
+
+
+@unittest.skipUnless(HAVE_LMDB, "python-lmdb not installed")
+class TestQueryRootMetric(unittest.TestCase):
+    def setUp(self):
+        import lmdb
+        self.tmp = tempfile.TemporaryDirectory()
+        self.src = Path(self.tmp.name) / "full"
+        self.out = Path(self.tmp.name) / "scoped"
+        self.src.mkdir()
+        # Same graph as the builder test: 2->{3,4}, 3->{5}; min dist to root 2
+        # is 2:0, 3:1, 4:1, 5:2. Out-of-scope 9->8 dropped.
+        cp_edges = [(3, 2), (4, 2), (5, 3), (9, 8)]
+        cc_edges = [(2, 3), (2, 4), (3, 5), (8, 9)]
+        env = lmdb.open(str(self.src), max_dbs=16, map_size=10 * 1024 * 1024, subdir=True)
+        cp = env.open_db(b"category_parent", dupsort=True, create=True)
+        cc = env.open_db(b"category_child", dupsort=True, create=True)
+        with env.begin(write=True) as txn:
+            for child, parent in cp_edges:
+                txn.put(enc(child), enc(parent), db=cp, dupdata=True)
+            for parent, child in cc_edges:
+                txn.put(enc(parent), enc(child), db=cc, dupdata=True)
+        env.sync()
+        env.close()
+        # Build the scoped DB (default --min-dist on).
+        env_os = dict(os.environ)
+        env_os.setdefault("LANG", "C.UTF-8")
+        proc = subprocess.run(
+            [sys.executable, str(BUILDER), "--src", str(self.src), "--root", "2",
+             "--out", str(self.out), "--max-depth", "10"],
+            capture_output=True, text=True, env=env_os)
+        self.assertEqual(proc.returncode, 0, f"builder failed:\n{proc.stderr}")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _query(self, *extra):
+        env_os = dict(os.environ)
+        env_os.setdefault("LANG", "C.UTF-8")
+        return subprocess.run(
+            [sys.executable, str(QUERY), "--lmdb", str(self.out), *extra],
+            capture_output=True, text=True, env=env_os)
+
+    def test_lookup_distances(self):
+        proc = self._query("2", "3", "4", "5", "9")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        rows = dict(line.split("\t") for line in proc.stdout.splitlines() if "\t" in line)
+        self.assertEqual(rows["2"], "0")
+        self.assertEqual(rows["3"], "1")
+        self.assertEqual(rows["4"], "1")
+        self.assertEqual(rows["5"], "2")
+        self.assertEqual(rows["9"], "unreachable")  # out of scope
+
+    def test_verify_passes(self):
+        proc = self._query("--verify")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("verify: OK", proc.stderr)
+
+    def test_histogram(self):
+        proc = self._query("--histogram")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        hist = dict(line.split("\t") for line in proc.stdout.splitlines() if "\t" in line)
+        # distances 0,1,2 with counts 1,2,1
+        self.assertEqual(hist.get("0"), "1")
+        self.assertEqual(hist.get("1"), "2")
+        self.assertEqual(hist.get("2"), "1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary
  Completes the ingest-materialised root-metric path: query_root_metric.py answers
  min_dist_to_root(Root, Node, D) as a single keyed get against the
  metric_min_dist_to_root sub-db — no graph traversal. Reads the metric's stored
  provenance, supports node lookups / --histogram / --verify (independent BFS-oracle
  cross-check).

  ## Validation
  - tiny fixture (CI-wired): lookups {2:0,3:1,4:1,5:2}, unreachable handling,
    histogram, --verify OK.
  - enwiki content graph (root 7345184): --verify checked all 2,248,538 entries
    vs a fresh BFS oracle — 0 mismatches, 0 missing.