### PR TITLE
Support bound witness bagof and setof in WAM-C

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,15 +4,15 @@ Status date: 2026-06-05
 
 Latest branch verification:
 
-- `investigate/wam-c-bagof-setof-aggregate-surface` based on `main` at
-  `a493993d` (`Merge pull request #2844 from
-  s243a/investigate/wam-c-inline-nested-findall-lowering`)
+- `investigate/wam-c-bagof-setof-witness-surface` based on `main` at
+  `2a473d77` (`Merge pull request #2846 from
+  s243a/investigate/wam-c-bagof-setof-aggregate-surface`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-bagof-setof-aggregate-surface`
+- `investigate/wam-c-bagof-setof-witness-surface`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -84,6 +84,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | `findall/3` nested/template smoke | Done | C now parses compiler temporary `_XTn` registers and the generated executable smoke covers helper-nested `findall/3`, `pair(X, [X])` templates, and `[X, X]` templates |
 | Direct inline nested `findall/3` lowering | Done | Inner-body `findall/3` now lowers to nested aggregate opcodes instead of `call findall/3`; local aggregate result slots are initialized before finalization, and the executable smoke covers `findall(X, (item(X), findall(Y, item(Y), Ys), Ys = [a,b]), L)` |
 | No-witness `bagof/3` and `setof/3` aggregate surface | Done | C parses the shared 4-field no-witness `begin_aggregate bagof/setof` form, `bagof/3` preserves duplicate solution order and fails empty, and `setof/3` sorts/deduplicates and fails empty |
+| Bound-witness `bagof/3` and `setof/3` grouping | Done | C parses witness register lists into aggregate payload arrays, copies witness tuples per aggregate item, selects the caller-bound witness group, and covers grouped `bagof/3` order plus grouped `setof/3` sort/dedup in an executable smoke |
 
 ## Current C Target Baseline
 
@@ -139,7 +140,8 @@ The C target is now a credible small WAM backend:
 - Supports the first aggregate surface: generated `findall/3` lowering through
   `begin_aggregate collect` / `end_aggregate`, including empty and non-empty
   result lists, helper-nested aggregate calls, direct inline nested `findall/3`
-  bodies, compound/list templates, and no-witness `bagof/3` / `setof/3`.
+  bodies, compound/list templates, no-witness `bagof/3` / `setof/3`, and
+  caller-bound witness grouping for `bagof/3` / `setof/3`.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -162,7 +164,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Second-arg indexing | Partial | Partial/Done | Partial/Done | C has constant A2 dispatch; broaden tests if this becomes hot. |
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
 | Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
-| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness `bagof/3` / `setof/3`; remaining gaps are witness grouping, existential `^/2` inner-goal lowering, and broader aggregate forms. |
+| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness and caller-bound witness `bagof/3` / `setof/3`; remaining gaps are unbound witness group enumeration, existential `^/2` inner-goal lowering, and broader aggregate forms. |
 | Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, precise `get_level`/`cut` if-then-else, explicit `!/0` scoped to the current predicate call barrier, and generated `forall/2` soft-cut rewrites; residual work should be driven by concrete meta-control demand. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
@@ -176,6 +178,32 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-bagof-setof-witness-surface`
+
+Goal: extend the no-witness `bagof/3` / `setof/3` C aggregate surface to the
+first grouped witness case where the witness variable is supplied by the caller.
+
+Evidence:
+
+- The C WAM aggregate payload now stores parsed witness register indices instead
+  of a raw witness string.
+- Aggregate frames copy a witness tuple alongside each collected template item.
+- Finalization selects the matching caller-bound witness group, unifies witness
+  registers with the selected key, preserves duplicate order for grouped
+  `bagof/3`, and sorts/deduplicates selected-group items for grouped `setof/3`.
+- The real-Prolog executable smoke compiles `bagof(X, pair(X, Y), L)` and
+  `setof(X, pair(X, Y), L)`, calls them with `Y = red` and `Y = blue`, verifies
+  the grouped bag/set results, and verifies a missing witness fails.
+
+Reason:
+
+- The previous branch proved the no-witness aggregate semantics and stored-term
+  sorting/deduplication path.
+- Full ISO-style unbound witness enumeration would require the C runtime to
+  leave resumable group alternatives. This branch deliberately handles the
+  caller-bound witness case first, which closes a practical grouped lookup
+  surface without expanding the choicepoint model.
 
 ### Completed: `investigate/wam-c-bagof-setof-aggregate-surface`
 
@@ -200,9 +228,9 @@ Reason:
 
 - Direct inline nested `findall/3` proved that nested aggregate frames and local
   aggregate result variables work in C.
-- The next aggregate parity step is the no-witness subset the shared compiler
-  already describes. Grouped/witness `bagof` and `setof`, including inner
-  existential `^/2` lowering, remain a separate larger semantic surface.
+- The follow-up `investigate/wam-c-bagof-setof-witness-surface` branch covers
+  caller-bound witness grouping. Unbound witness group enumeration and inner
+  existential `^/2` lowering remain larger semantic surfaces.
 
 ### Completed: `investigate/wam-c-inline-nested-findall-lowering`
 

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -23,6 +23,7 @@
 #define WAM_FOREIGN_HASH_SIZE 256
 #define WAM_CALL_STACK_SIZE 1024
 #define WAM_AGGREGATE_STACK_SIZE 32
+#define WAM_AGGREGATE_MAX_WITNESSES 8
 
 typedef struct WamState WamState;
 typedef bool (*WamForeignHandler)(WamState *state, const char *pred, int arity);
@@ -80,8 +81,12 @@ typedef struct {
     int result_reg;
     int result_is_y;
     WamStoredTerm *items;
+    WamStoredTerm *witnesses;
     int item_count;
     int item_cap;
+    int witness_count;
+    int witness_regs[WAM_AGGREGATE_MAX_WITNESSES];
+    int witness_is_y[WAM_AGGREGATE_MAX_WITNESSES];
 } WamAggregateFrame;
 
 /* Environment Frame */
@@ -269,7 +274,9 @@ typedef struct {
     int template_is_y;
     int result_reg;
     int result_is_y;
-    char *witness_regs;
+    int witness_count;
+    int witness_regs[WAM_AGGREGATE_MAX_WITNESSES];
+    int witness_is_y[WAM_AGGREGATE_MAX_WITNESSES];
 } WamAggregateInstr;
 
 typedef union {

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -1618,18 +1618,19 @@ wam_instruction_to_c_literal(call_foreign(P, N), Code) :-
 wam_instruction_to_c_literal(begin_aggregate(Kind, TemplateReg, ResultReg), Code) :-
     c_reg_index(TemplateReg, TemplateIsY, TemplateIdx),
     c_reg_index(ResultReg, ResultIsY, ResultIdx),
-    format(atom(Code), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w, .witness_regs = "" } }',
+    format(atom(Code), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w, .witness_count = 0, .witness_regs = {0}, .witness_is_y = {0} } }',
            [Kind, TemplateIdx, TemplateIsY, ResultIdx, ResultIsY]).
 wam_instruction_to_c_literal(begin_aggregate(Kind, TemplateReg, ResultReg, WitnessRegs), Code) :-
     clean_aggregate_witness(WitnessRegs, WitnessString),
-    ensure_supported_aggregate_witness(WitnessString),
+    aggregate_witness_fields(WitnessString, WitnessCount, WitnessRegInit, WitnessIsYInit),
     c_reg_index(TemplateReg, TemplateIsY, TemplateIdx),
     c_reg_index(ResultReg, ResultIsY, ResultIdx),
-    format(atom(Code), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w, .witness_regs = "" } }',
-           [Kind, TemplateIdx, TemplateIsY, ResultIdx, ResultIsY]).
+    format(atom(Code), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w, .witness_count = ~w, .witness_regs = ~w, .witness_is_y = ~w } }',
+           [Kind, TemplateIdx, TemplateIsY, ResultIdx, ResultIsY,
+            WitnessCount, WitnessRegInit, WitnessIsYInit]).
 wam_instruction_to_c_literal(end_aggregate(TemplateReg), Code) :-
     c_reg_index(TemplateReg, TemplateIsY, TemplateIdx),
-    format(atom(Code), '{ .tag = INSTR_END_AGGREGATE, .as.aggregate = { .kind = "collect", .template_reg = ~w, .template_is_y = ~w, .result_reg = 0, .result_is_y = 0, .witness_regs = "" } }',
+    format(atom(Code), '{ .tag = INSTR_END_AGGREGATE, .as.aggregate = { .kind = "collect", .template_reg = ~w, .template_is_y = ~w, .result_reg = 0, .result_is_y = 0, .witness_count = 0, .witness_regs = {0}, .witness_is_y = {0} } }',
            [TemplateIdx, TemplateIsY]).
 wam_instruction_to_c_literal(get_level(Reg), Code) :-
     c_reg_index(Reg, IsY, Idx),
@@ -1793,21 +1794,22 @@ wam_line_to_c_instr(["begin_aggregate", Kind, TemplateReg, ResultReg], Instr) :-
     clean_comma(ResultReg, CResultReg), c_escape_atom(CKind0, CKind),
     c_reg_index(CTemplateReg, TemplateIsY, TemplateIdx),
     c_reg_index(CResultReg, ResultIsY, ResultIdx),
-    format(atom(Instr), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w, .witness_regs = "" } }',
+    format(atom(Instr), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w, .witness_count = 0, .witness_regs = {0}, .witness_is_y = {0} } }',
            [CKind, TemplateIdx, TemplateIsY, ResultIdx, ResultIsY]).
 wam_line_to_c_instr(["begin_aggregate", Kind, TemplateReg, ResultReg, WitnessRegs], Instr) :-
     clean_comma(Kind, CKind0), clean_comma(TemplateReg, CTemplateReg),
     clean_comma(ResultReg, CResultReg), c_escape_atom(CKind0, CKind),
     clean_aggregate_witness(WitnessRegs, WitnessString),
-    ensure_supported_aggregate_witness(WitnessString),
+    aggregate_witness_fields(WitnessString, WitnessCount, WitnessRegInit, WitnessIsYInit),
     c_reg_index(CTemplateReg, TemplateIsY, TemplateIdx),
     c_reg_index(CResultReg, ResultIsY, ResultIdx),
-    format(atom(Instr), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w, .witness_regs = "" } }',
-           [CKind, TemplateIdx, TemplateIsY, ResultIdx, ResultIsY]).
+    format(atom(Instr), '{ .tag = INSTR_BEGIN_AGGREGATE, .as.aggregate = { .kind = "~w", .template_reg = ~w, .template_is_y = ~w, .result_reg = ~w, .result_is_y = ~w, .witness_count = ~w, .witness_regs = ~w, .witness_is_y = ~w } }',
+           [CKind, TemplateIdx, TemplateIsY, ResultIdx, ResultIsY,
+            WitnessCount, WitnessRegInit, WitnessIsYInit]).
 wam_line_to_c_instr(["end_aggregate", TemplateReg], Instr) :-
     clean_comma(TemplateReg, CTemplateReg),
     c_reg_index(CTemplateReg, TemplateIsY, TemplateIdx),
-    format(atom(Instr), '{ .tag = INSTR_END_AGGREGATE, .as.aggregate = { .kind = "collect", .template_reg = ~w, .template_is_y = ~w, .result_reg = 0, .result_is_y = 0, .witness_regs = "" } }',
+    format(atom(Instr), '{ .tag = INSTR_END_AGGREGATE, .as.aggregate = { .kind = "collect", .template_reg = ~w, .template_is_y = ~w, .result_reg = 0, .result_is_y = 0, .witness_count = 0, .witness_regs = {0}, .witness_is_y = {0} } }',
            [TemplateIdx, TemplateIsY]).
 wam_line_to_c_instr(["get_level", Reg], Instr) :-
     clean_comma(Reg, CReg),
@@ -1857,9 +1859,23 @@ clean_aggregate_witness(Witness0, Witness) :-
     ;   Witness = S0
     ).
 
-ensure_supported_aggregate_witness("") :- !.
-ensure_supported_aggregate_witness(Witness) :-
-    throw(error(wam_c_target_error(unsupported_bagof_setof_witnesses(Witness)), _)).
+aggregate_witness_fields("", 0, "{0}", "{0}") :- !.
+aggregate_witness_fields(WitnessString, Count, RegInit, IsYInit) :-
+    split_string(WitnessString, ";", "", WitnessRegs0),
+    exclude(=(""), WitnessRegs0, WitnessRegs),
+    length(WitnessRegs, Count),
+    (   Count =< 8
+    ->  true
+    ;   throw(error(wam_c_target_error(too_many_bagof_setof_witnesses(Count)), _))
+    ),
+    maplist(aggregate_witness_reg_indices, WitnessRegs, RegIndices, IsYIndices),
+    atomic_list_concat(RegIndices, ', ', RegBody),
+    atomic_list_concat(IsYIndices, ', ', IsYBody),
+    format(atom(RegInit), '{~w}', [RegBody]),
+    format(atom(IsYInit), '{~w}', [IsYBody]).
+
+aggregate_witness_reg_indices(WitnessReg, RegIdx, IsY) :-
+    c_reg_index(WitnessReg, IsY, RegIdx).
 
 %% c_escape_atom(+Atom, -Escaped)
 %  Escape backslashes and double quotes so the value is safe inside a C
@@ -2821,11 +2837,200 @@ static void wam_aggregate_sort_dedup_items(WamAggregateFrame *frame) {
     frame->item_count = out;
 }
 
+static void wam_sort_aggregate_item_indices(WamAggregateFrame *frame,
+                                            int *indices,
+                                            int index_count) {
+    for (int i = 1; i < index_count; i++) {
+        int current = indices[i];
+        int j = i - 1;
+        while (j >= 0 &&
+               wam_compare_stored_value(&frame->items[indices[j]],
+                                         frame->items[indices[j]].root,
+                                         &frame->items[current],
+                                         frame->items[current].root) > 0) {
+            indices[j + 1] = indices[j];
+            j--;
+        }
+        indices[j + 1] = current;
+    }
+}
+
+static int wam_dedup_sorted_aggregate_item_indices(WamAggregateFrame *frame,
+                                                   int *indices,
+                                                   int index_count) {
+    if (index_count < 2) return index_count;
+    int out = 1;
+    for (int i = 1; i < index_count; i++) {
+        WamStoredTerm *previous = &frame->items[indices[out - 1]];
+        WamStoredTerm *current = &frame->items[indices[i]];
+        if (wam_compare_stored_value(previous, previous->root,
+                                     current, current->root) != 0) {
+            indices[out++] = indices[i];
+        }
+    }
+    return out;
+}
+
+static bool wam_build_aggregate_list_from_indices(WamState *state,
+                                                  WamAggregateFrame *frame,
+                                                  int *indices,
+                                                  int index_count,
+                                                  WamValue *out) {
+    WamValue tail = val_atom("[]");
+    for (int i = index_count - 1; i >= 0; i--) {
+        int item_index = indices[i];
+        WamValue head;
+        if (!wam_materialize_stored_term(state, &frame->items[item_index],
+                                         frame->items[item_index].root,
+                                         &head)) return false;
+        if (!wam_ensure_heap_slots(state, 2)) return false;
+        int base = state->H;
+        state->H_array[state->H++] = head;
+        state->H_array[state->H++] = tail;
+        tail.tag = VAL_LIST;
+        tail.data.ref_addr = base;
+    }
+    *out = tail;
+    return true;
+}
+
+static bool wam_copy_current_witness_tuple(WamState *state,
+                                           WamAggregateFrame *frame,
+                                           WamStoredTerm *term) {
+    memset(term, 0, sizeof(WamStoredTerm));
+    if (frame->witness_count <= 0) {
+        term->root = val_atom("[]");
+        return true;
+    }
+    if (frame->witness_count == 1) {
+        WamValue *cell =
+            resolve_reg(state, frame->witness_regs[0], frame->witness_is_y[0]);
+        return wam_copy_term_to_stored(state, term, *cell, &term->root);
+    }
+
+    WamValue tail = val_atom("[]");
+    for (int i = frame->witness_count - 1; i >= 0; i--) {
+        WamValue *cell =
+            resolve_reg(state, frame->witness_regs[i], frame->witness_is_y[i]);
+        WamValue head;
+        if (!wam_copy_term_to_stored(state, term, *cell, &head)) return false;
+        if (!wam_stored_term_reserve(term, 2)) return false;
+        int base = term->cell_count;
+        term->cell_count += 2;
+        term->cells[base] = head;
+        term->cells[base + 1] = tail;
+        tail.tag = VAL_LIST;
+        tail.data.ref_addr = base;
+    }
+    term->root = tail;
+    return true;
+}
+
+static bool wam_witness_regs_are_bound(WamState *state,
+                                       WamAggregateFrame *frame) {
+    for (int i = 0; i < frame->witness_count; i++) {
+        WamValue *cell =
+            wam_deref_ptr(state, resolve_reg(state, frame->witness_regs[i],
+                                             frame->witness_is_y[i]));
+        if (val_is_unbound(*cell)) return false;
+    }
+    return true;
+}
+
+static int wam_select_aggregate_witness_group(WamState *state,
+                                              WamAggregateFrame *frame) {
+    if (frame->witness_count <= 0) return 0;
+    if (frame->item_count <= 0) return -1;
+    if (!wam_witness_regs_are_bound(state, frame)) {
+        return 0;
+    }
+
+    WamStoredTerm selected;
+    if (!wam_copy_current_witness_tuple(state, frame, &selected)) return -1;
+    int selected_index = -1;
+    for (int i = 0; i < frame->item_count; i++) {
+        if (wam_compare_stored_value(&selected, selected.root,
+                                     &frame->witnesses[i],
+                                     frame->witnesses[i].root) == 0) {
+            selected_index = i;
+            break;
+        }
+    }
+    wam_stored_term_free(&selected);
+    return selected_index;
+}
+
+static bool wam_build_witness_group_indices(WamAggregateFrame *frame,
+                                            int selected_index,
+                                            int **indices_out,
+                                            int *index_count_out) {
+    if (selected_index < 0 || selected_index >= frame->item_count) return false;
+    int *indices = malloc(sizeof(int) * (size_t)frame->item_count);
+    if (!indices) return false;
+    int count = 0;
+    WamStoredTerm *selected = &frame->witnesses[selected_index];
+    for (int i = 0; i < frame->item_count; i++) {
+        if (wam_compare_stored_value(selected, selected->root,
+                                     &frame->witnesses[i],
+                                     frame->witnesses[i].root) == 0) {
+            indices[count++] = i;
+        }
+    }
+    *indices_out = indices;
+    *index_count_out = count;
+    return true;
+}
+
+static bool wam_materialize_witness_component(WamState *state,
+                                              WamStoredTerm *witness,
+                                              int witness_count,
+                                              int component_index,
+                                              WamValue *out) {
+    if (component_index < 0 || component_index >= witness_count) return false;
+    if (witness_count == 1) {
+        return wam_materialize_stored_term(state, witness, witness->root, out);
+    }
+
+    WamValue cursor = witness->root;
+    for (int i = 0; i <= component_index; i++) {
+        if (cursor.tag != VAL_LIST) return false;
+        int base = cursor.data.ref_addr;
+        if (base < 0 || base + 1 >= witness->cell_count) return false;
+        if (i == component_index) {
+            return wam_materialize_stored_term(state, witness,
+                                               witness->cells[base], out);
+        }
+        cursor = witness->cells[base + 1];
+    }
+    return false;
+}
+
+static bool wam_unify_witness_registers_from_group(WamState *state,
+                                                   WamAggregateFrame *frame,
+                                                   int selected_index) {
+    if (frame->witness_count <= 0) return true;
+    WamStoredTerm *witness = &frame->witnesses[selected_index];
+    for (int i = 0; i < frame->witness_count; i++) {
+        WamValue value;
+        if (!wam_materialize_witness_component(state, witness,
+                                               frame->witness_count,
+                                               i, &value)) return false;
+        WamValue *target =
+            resolve_reg(state, frame->witness_regs[i], frame->witness_is_y[i]);
+        if (!wam_unify(state, target, &value)) return false;
+    }
+    return true;
+}
+
 static void wam_aggregate_frame_free(WamAggregateFrame *frame) {
     for (int i = 0; i < frame->item_count; i++) {
         wam_stored_term_free(&frame->items[i]);
+        if (frame->witnesses) {
+            wam_stored_term_free(&frame->witnesses[i]);
+        }
     }
     free(frame->items);
+    free(frame->witnesses);
     memset(frame, 0, sizeof(WamAggregateFrame));
 }
 
@@ -2844,9 +3049,20 @@ static bool wam_aggregate_append_item(WamState *state,
         WamStoredTerm *items =
             realloc(frame->items, sizeof(WamStoredTerm) * (size_t)new_cap);
         if (!items) return false;
+        frame->items = items;
+        WamStoredTerm *witnesses = frame->witnesses;
+        if (frame->witness_count > 0) {
+            witnesses =
+                realloc(frame->witnesses, sizeof(WamStoredTerm) * (size_t)new_cap);
+            if (!witnesses) return false;
+            frame->witnesses = witnesses;
+        }
         memset(items + frame->item_cap, 0,
                sizeof(WamStoredTerm) * (size_t)(new_cap - frame->item_cap));
-        frame->items = items;
+        if (frame->witness_count > 0) {
+            memset(witnesses + frame->item_cap, 0,
+                   sizeof(WamStoredTerm) * (size_t)(new_cap - frame->item_cap));
+        }
         frame->item_cap = new_cap;
     }
     WamStoredTerm *term = &frame->items[frame->item_count];
@@ -2854,6 +3070,14 @@ static bool wam_aggregate_append_item(WamState *state,
     if (!wam_copy_term_to_stored(state, term, value, &term->root)) {
         wam_stored_term_free(term);
         return false;
+    }
+    if (frame->witness_count > 0) {
+        WamStoredTerm *witness = &frame->witnesses[frame->item_count];
+        if (!wam_copy_current_witness_tuple(state, frame, witness)) {
+            wam_stored_term_free(term);
+            wam_stored_term_free(witness);
+            return false;
+        }
     }
     frame->item_count++;
     return true;
@@ -2911,12 +3135,38 @@ static bool wam_finalize_aggregate_frame(WamState *state,
         state->P = next_pc;
         return false;
     }
-    if (is_setof) {
-        wam_aggregate_sort_dedup_items(frame);
-    }
 
     WamValue result_list;
-    if (!wam_build_aggregate_list(state, frame, &result_list)) return false;
+    if (frame->witness_count > 0) {
+        int selected_index = wam_select_aggregate_witness_group(state, frame);
+        if (selected_index < 0) {
+            wam_aggregate_frame_free(frame);
+            state->aggregate_top = frame_index;
+            state->P = next_pc;
+            return false;
+        }
+        int *indices = NULL;
+        int index_count = 0;
+        if (!wam_build_witness_group_indices(frame, selected_index,
+                                             &indices, &index_count)) return false;
+        if (is_setof) {
+            wam_sort_aggregate_item_indices(frame, indices, index_count);
+            index_count =
+                wam_dedup_sorted_aggregate_item_indices(frame, indices, index_count);
+        }
+        bool witness_ok =
+            wam_unify_witness_registers_from_group(state, frame, selected_index);
+        bool list_ok = witness_ok &&
+            wam_build_aggregate_list_from_indices(state, frame, indices,
+                                                  index_count, &result_list);
+        free(indices);
+        if (!list_ok) return false;
+    } else {
+        if (is_setof) {
+            wam_aggregate_sort_dedup_items(frame);
+        }
+        if (!wam_build_aggregate_list(state, frame, &result_list)) return false;
+    }
     WamValue *result_cell =
         resolve_reg(state, frame->result_reg, frame->result_is_y);
     bool ok = wam_unify(state, result_cell, &result_list);
@@ -2931,8 +3181,8 @@ static bool wam_begin_aggregate(WamState *state, Instruction *instr) {
     if (strcmp(instr->as.aggregate.kind, "collect") != 0 &&
         strcmp(instr->as.aggregate.kind, "bagof") != 0 &&
         strcmp(instr->as.aggregate.kind, "setof") != 0) return false;
-    if (instr->as.aggregate.witness_regs &&
-        instr->as.aggregate.witness_regs[0] != 0) return false;
+    if (instr->as.aggregate.witness_count < 0 ||
+        instr->as.aggregate.witness_count > WAM_AGGREGATE_MAX_WITNESSES) return false;
     if (state->aggregate_top > 0) {
         WamAggregateFrame *top = &state->aggregate_frames[state->aggregate_top - 1];
         if (top->begin_pc == state->P && top->sentinel_b == state->B) {
@@ -2954,6 +3204,11 @@ static bool wam_begin_aggregate(WamState *state, Instruction *instr) {
     frame->template_is_y = instr->as.aggregate.template_is_y;
     frame->result_reg = instr->as.aggregate.result_reg;
     frame->result_is_y = instr->as.aggregate.result_is_y;
+    frame->witness_count = instr->as.aggregate.witness_count;
+    for (int i = 0; i < frame->witness_count; i++) {
+        frame->witness_regs[i] = instr->as.aggregate.witness_regs[i];
+        frame->witness_is_y[i] = instr->as.aggregate.witness_is_y[i];
+    }
     push_choice_point(state, state->P, 32);
     state->P++;
     return true;

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -1735,6 +1735,16 @@ test_real_prolog_bagof_setof_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_real_prolog_bagof_setof_witness_executable_smoke :-
+    Test = 'WAM-C: real Prolog grouped bagof/3 and setof/3 witness smoke',
+    (   gcc_available
+    ->  (   run_real_prolog_bagof_setof_witness_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'real Prolog grouped bagof/3 and setof/3 executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_real_prolog_classic_recursive_executable_smoke :-
     Test = 'WAM-C: real Prolog classic recursive executable smoke',
     (   gcc_available
@@ -2929,6 +2939,55 @@ cleanup_wam_c_bagof_setof_smoke :-
     retractall(user:wam_c_bagset_set(_)),
     retractall(user:wam_c_bagset_bag_empty(_)),
     retractall(user:wam_c_bagset_set_empty(_)).
+
+run_real_prolog_bagof_setof_witness_executable_smoke :-
+    Options = [inline_bagof_setof(true)],
+    assertz((user:wam_c_group_pair(b, red) :- true)),
+    assertz((user:wam_c_group_pair(a, red) :- true)),
+    assertz((user:wam_c_group_pair(c, blue) :- true)),
+    assertz((user:wam_c_group_bag(Y, L) :-
+        bagof(X, wam_c_group_pair(X, Y), L))),
+    assertz((user:wam_c_group_set(Y, L) :-
+        setof(X, wam_c_group_pair(X, Y), L))),
+    (   compile_predicate_to_wam(user:wam_c_group_pair/2, Options, WamPair),
+        compile_predicate_to_wam(user:wam_c_group_bag/2, Options, WamBag),
+        compile_predicate_to_wam(user:wam_c_group_set/2, Options, WamSet),
+        sub_string(WamBag, _, _, _, 'begin_aggregate bagof'),
+        sub_string(WamBag, _, _, _, "'Y"),
+        \+ sub_string(WamBag, _, _, _, 'call bagof/3'),
+        sub_string(WamSet, _, _, _, 'begin_aggregate setof'),
+        sub_string(WamSet, _, _, _, "'Y"),
+        \+ sub_string(WamSet, _, _, _, 'call setof/3'),
+        compile_wam_predicate_to_c(user:wam_c_group_pair/2, WamPair, Options, PairCode),
+        compile_wam_predicate_to_c(user:wam_c_group_bag/2, WamBag, Options, BagCode),
+        compile_wam_predicate_to_c(user:wam_c_group_set/2, WamSet, Options, SetCode),
+        atomic_list_concat([PairCode, BagCode, SetCode],
+                           '\n\n',
+                           PredCode),
+        compile_wam_runtime_to_c([], RuntimeCode),
+        get_time(Now),
+        Stamp is round(Now * 1000000),
+        wam_c_temp_path('unifyweaver_wam_c_bagof_setof_witness_smoke', Stamp, TmpBase),
+        format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+        format(atom(PredPath), '~w_pred.c', [TmpBase]),
+        format(atom(MainPath), '~w_main.c', [TmpBase]),
+        format(atom(ExePath), '~w_bin', [TmpBase]),
+        write_text_file(RuntimePath, RuntimeCode),
+        format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+        write_text_file(PredPath, PredTranslationUnit),
+        wam_c_bagof_setof_witness_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_bagof_setof_witness_smoke
+    ;   cleanup_wam_c_bagof_setof_witness_smoke,
+        fail
+    ).
+
+cleanup_wam_c_bagof_setof_witness_smoke :-
+    retractall(user:wam_c_group_pair(_, _)),
+    retractall(user:wam_c_group_bag(_, _)),
+    retractall(user:wam_c_group_set(_, _)).
 
 run_real_prolog_classic_recursive_executable_smoke :-
     assertz((user:wam_c_classic_fib(0, 0) :- true)),
@@ -6229,6 +6288,101 @@ int main(void) {
 }
 ').
 
+wam_c_bagof_setof_witness_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_group_pair_2(WamState* state);
+void setup_wam_c_group_bag_2(WamState* state);
+void setup_wam_c_group_set_2(WamState* state);
+
+static bool expect_atom_slot(WamState *state, WamValue *slot, const char *atom) {
+    WamValue *cell = wam_deref_ptr(state, slot);
+    return cell->tag == VAL_ATOM && strcmp(cell->data.atom, atom) == 0;
+}
+
+static bool expect_nil(WamValue *cell) {
+    return cell->tag == VAL_ATOM && strcmp(cell->data.atom, "[]") == 0;
+}
+
+static bool expect_atom_value(WamState *state, WamValue value, const char *atom) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    return cell->tag == VAL_ATOM && strcmp(cell->data.atom, atom) == 0;
+}
+
+static bool expect_atom_list1(WamState *state, WamValue value,
+                              const char *first) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    int cell_addr = wam_cons_head_addr(state, cell);
+    if (cell_addr < 0) return false;
+    WamValue *tail = wam_deref_ptr(state, &state->H_array[cell_addr + 1]);
+    return expect_atom_slot(state, &state->H_array[cell_addr], first) &&
+           expect_nil(tail);
+}
+
+static bool expect_atom_list2(WamState *state, WamValue value,
+                              const char *first, const char *second) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    int cell_addr = wam_cons_head_addr(state, cell);
+    if (cell_addr < 0) return false;
+    WamValue *tail1 = wam_deref_ptr(state, &state->H_array[cell_addr + 1]);
+    int tail1_addr = wam_cons_head_addr(state, tail1);
+    if (tail1_addr < 0) return false;
+    WamValue *tail2 = wam_deref_ptr(state, &state->H_array[tail1_addr + 1]);
+    return expect_atom_slot(state, &state->H_array[cell_addr], first) &&
+           expect_atom_slot(state, &state->H_array[tail1_addr], second) &&
+           expect_nil(tail2);
+}
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_group_pair_2(&state);
+    setup_wam_c_group_bag_2(&state);
+    setup_wam_c_group_set_2(&state);
+
+    WamValue bag_red_args[2] = { val_atom("red"), val_unbound("BagRed") };
+    int bag_red_rc = wam_run_predicate(&state, "wam_c_group_bag/2", bag_red_args, 2);
+    if (bag_red_rc != 0 || state.P != WAM_HALT ||
+        !expect_atom_value(&state, state.A[0], "red") ||
+        !expect_atom_list2(&state, state.A[1], "b", "a") ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue set_red_args[2] = { val_atom("red"), val_unbound("SetRed") };
+    int set_red_rc = wam_run_predicate(&state, "wam_c_group_set/2", set_red_args, 2);
+    if (set_red_rc != 0 || state.P != WAM_HALT ||
+        !expect_atom_value(&state, state.A[0], "red") ||
+        !expect_atom_list2(&state, state.A[1], "a", "b") ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue bag_blue_args[2] = { val_atom("blue"), val_unbound("BagBlue") };
+    int bag_blue_rc = wam_run_predicate(&state, "wam_c_group_bag/2", bag_blue_args, 2);
+    if (bag_blue_rc != 0 || state.P != WAM_HALT ||
+        !expect_atom_value(&state, state.A[0], "blue") ||
+        !expect_atom_list1(&state, state.A[1], "c") ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    WamValue bag_missing_args[2] = { val_atom("green"), val_unbound("BagMissing") };
+    int bag_missing_rc = wam_run_predicate(&state, "wam_c_group_bag/2", bag_missing_args, 2);
+    if (bag_missing_rc != WAM_HALT ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_classic_fib_smoke_main(
 '#include "wam_runtime.h"
 
@@ -6444,6 +6598,7 @@ run_tests_once :-
     test_real_prolog_forall_executable_smoke,
     test_real_prolog_findall_executable_smoke,
     test_real_prolog_bagof_setof_executable_smoke,
+    test_real_prolog_bagof_setof_witness_executable_smoke,
     test_real_prolog_classic_recursive_executable_smoke,
     test_lowered_fact_helper_executable_smoke,
     test_lowered_body_call_helper_executable_smoke,


### PR DESCRIPTION
  ## Summary
  - Add bounded witness register payloads to WAM-C aggregate instructions and runtime frames.
  - Materialize caller-bound witness groups for inline `bagof/3` and `setof/3`.
  - Cover grouped `bagof/3` ordering and grouped `setof/3` sort/dedup with an executable WAM-C smoke test.
  - Update the WAM-C next-steps doc to mark bound-witness aggregate grouping as complete.

  ## Validation
  - `git diff --check`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`