### PR TITLE
feat(clojure): native ITE/negation/nested lowering via shared structurer (compile-run verified)

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -21,6 +21,7 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(wam_ite_structurer, [structure_ite/2]).
 
 % =====================================================================
 % Parsing
@@ -30,6 +31,31 @@ parse_wam_text(WamText, Instrs) :-
     atom_string(WamText, S),
     split_string(S, "\n", "", Lines),
     parse_lines(Lines, Instrs).
+
+% Label-preserving parse: keeps label(Name) markers so structure_ite can
+% locate the else/cont boundaries of an (C -> T ; E) / \+ / once block.
+parse_wam_text_labeled(WamText, Instrs) :-
+    atom_string(WamText, S),
+    split_string(S, "\n", "", Lines),
+    parse_lines_labeled(Lines, Instrs).
+
+parse_lines_labeled([], []).
+parse_lines_labeled([Line|Rest], Instrs) :-
+    split_string(Line, " \t,", " \t,", Parts),
+    delete(Parts, "", CleanParts),
+    (   CleanParts == []
+    ->  parse_lines_labeled(Rest, Instrs)
+    ;   CleanParts = [First|_],
+        (   sub_string(First, _, 1, 0, ":")
+        ->  sub_string(First, 0, _, 1, LabelStr),
+            Instrs = [label(LabelStr)|More],
+            parse_lines_labeled(Rest, More)
+        ;   instr_from_parts(CleanParts, Instr)
+        ->  Instrs = [Instr|More],
+            parse_lines_labeled(Rest, More)
+        ;   parse_lines_labeled(Rest, Instrs)
+        )
+    ).
 
 parse_lines([], []).
 parse_lines([Line|Rest], Instrs) :-
@@ -181,10 +207,16 @@ lower_predicate_to_clojure(PI, WamCode, _Options, ClojureCode) :-
     ),
     clause1_instrs(Instrs, C1Instrs0),
     (   is_deterministic_pred_clojure(Instrs)
-    ->  lowered_direct_prefix(C1Instrs0, allow_control, C1Instrs)
-    ;   C1Instrs = []
+    ->  lowered_direct_prefix(C1Instrs0, allow_control, C1Instrs),
+        with_output_to(string(Body), emit_instrs(C1Instrs, "  "))
+    ;   clojure_structured_clause1(WamCode, Structured)
+    ->  % Single-clause if-then-else / negation / once: emit native
+        % branching instead of the no-op stub (which delegated to run-wam).
+        with_output_to(string(Body), emit_struct_clj_body(Structured, "  "))
+    ;   % Multi-clause or unstructurable: keep the no-op stub; run-wam
+        % interprets the predicate from start-pc (sound fallback).
+        with_output_to(string(Body), emit_instrs([], "  "))
     ),
-    with_output_to(string(Body), emit_instrs(C1Instrs, "  ")),
     format(string(ClojureCode),
 ';; ~w — lowered from ~w/~w
 (defn ~w [state]
@@ -210,6 +242,76 @@ emit_instr_bindings([Instr|Rest], Index, Indent) :-
     format("~w      s~w (if (= :running (:status ~w)) ~w ~w)~n",
            [Indent, NextIndex, InState, Expr, InState]),
     emit_instr_bindings(Rest, NextIndex, Indent).
+
+% =====================================================================
+% Structured ITE emission (shared nesting-aware structurer)
+% =====================================================================
+%
+%  Clojure's flat `(let [s0 state s1 ...] sN)` threading cannot express an
+%  if-then-else (there is no jump), so the previous emitter produced a
+%  no-op stub for any predicate containing try_me_else and relied on
+%  run-wam (the interpreter) to execute it. This adds native branching:
+%  clause 1 is folded by the shared structurer into ite(Cond,Then,Else)
+%  and emitted as a let whose binding for the block is
+%      (if (= :running (:status sCond)) <then from sCond> <else from sPre>)
+%  i.e. run the condition; on success take Then (inheriting the condition's
+%  bindings), else take Else from the PRE-condition state (discarding them)
+%  — the same Maybe-style discipline as the Haskell/F# backends. A failed
+%  condition builtin calls runtime/backtrack with no choice point in scope,
+%  which yields :status :failed (not :running), so the `if` routes to Else.
+
+%% clojure_structured_clause1(+WamCode, -Structured) is semidet.
+clojure_structured_clause1(WamCode, Structured) :-
+    \+ is_list(WamCode),                       % need the text to recover labels
+    parse_wam_text_labeled(WamCode, LInstrs0),
+    ( LInstrs0 = [label(_)|LInstrs1] -> true ; LInstrs1 = LInstrs0 ),
+    \+ ( LInstrs1 = [try_me_else(_)|_] ),       % single-clause predicates only
+    take_to_terminal(LInstrs1, C1L),
+    structure_ite(C1L, Structured),
+    \+ member(try_me_else(_), Structured),
+    \+ member(trust_me, Structured),
+    \+ member(retry_me_else(_), Structured),
+    once(member(ite(_, _, _), Structured)).     % must actually contain an ITE
+
+%% emit_struct_clj_body(+Structured, +Indent)
+emit_struct_clj_body(Structured, Indent) :-
+    nb_setval(clj_sv_ctr, 0),
+    with_output_to(string(Bindings), emit_clj_bindings(Structured, "state", FinalSV, Indent)),
+    format("~w(let [~n~w~w      ]~n~w  ~w)~n", [Indent, Bindings, Indent, Indent, FinalSV]).
+
+fresh_clj_sv(SV) :-
+    nb_getval(clj_sv_ctr, N), N1 is N + 1, nb_setval(clj_sv_ctr, N1),
+    format(atom(SV), 's~w', [N1]).
+
+%% emit_clj_bindings(+Structured, +InSV, -OutSV, +Indent)
+emit_clj_bindings([], InSV, InSV, _Ind).
+emit_clj_bindings([ite(C, T, E)|Rest], InSV, OutSV, Ind) :- !,
+    emit_clj_bindings(C, InSV, CondSV, Ind),
+    fresh_clj_sv(IteSV),
+    emit_clj_branch(T, CondSV, ThenExpr, Ind),
+    emit_clj_branch(E, InSV, ElseExpr, Ind),
+    format("~w      ;; if-then-else~n", [Ind]),
+    format("~w      ~w (if (= :running (:status ~w))~n", [Ind, IteSV, CondSV]),
+    format("~w            ~w~n", [Ind, ThenExpr]),
+    format("~w            ~w)~n", [Ind, ElseExpr]),
+    emit_clj_bindings(Rest, IteSV, OutSV, Ind).
+emit_clj_bindings([Instr|Rest], InSV, OutSV, Ind) :-
+    fresh_clj_sv(SV),
+    emit_lowered_expr(Instr, InSV, Expr),
+    instr_comment(Instr, Comment),
+    format("~w      ;; ~w~n", [Ind, Comment]),
+    format("~w      ~w (if (= :running (:status ~w)) ~w ~w)~n", [Ind, SV, InSV, Expr, InSV]),
+    emit_clj_bindings(Rest, SV, OutSV, Ind).
+
+%% emit_clj_branch(+Instrs, +InSV, -Expr, +Indent)
+%  A branch body as a self-contained Clojure expression (nested let, or
+%  just InSV when the branch is empty).
+emit_clj_branch(Instrs, InSV, Expr, Ind) :-
+    with_output_to(string(B), emit_clj_bindings(Instrs, InSV, FSV, Ind)),
+    (   B == ""
+    ->  Expr = FSV
+    ;   format(atom(Expr), '(let [~n~w~w            ] ~w)', [B, Ind, FSV])
+    ).
 
 lowered_direct_prefix(Instrs, Prefix) :-
     lowered_direct_prefix(Instrs, allow_control, Prefix).

--- a/tests/test_wam_clojure_lowered_ite_exec.pl
+++ b/tests/test_wam_clojure_lowered_ite_exec.pl
@@ -1,0 +1,104 @@
+% test_wam_clojure_lowered_ite_exec.pl
+%
+% End-to-end execution test for Clojure if-then-else / negation / once
+% lowering.
+%
+% Generates a WAM Clojure project, compiles+runs it with the JVM Clojure
+% toolchain, and calls each lowered predicate wrapper, asserting the
+% boolean (success/failure) outcome. Counterpart to the Go/Rust/C++/
+% Haskell/F# exec tests. Pins:
+%
+%   * sequential ITEs   — cseqite(10,pos,small) must fail;
+%   * nested ITEs       — cnestite/2;
+%   * negation (\+)      — cneg/1 (commit is the !/0 builtin);
+%   * simple ITEs        — cite/2.
+%
+% Clojure previously emitted a no-op stub for any predicate containing an
+% if-then-else (its flat let-threading can't branch), relying on the
+% run-wam interpreter. The shared-structurer conversion emits native
+% branching. Skipped unless java + a Clojure jar are present.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_clojure_target').
+
+:- dynamic user:cite/2.
+:- dynamic user:cneg/1.
+:- dynamic user:cseqite/3.
+:- dynamic user:cnestite/2.
+
+user:cite(X, Y)       :- ( X > 0 -> Y = pos ; Y = nonpos ).
+user:cneg(X)          :- \+ X > 0.
+user:cseqite(X, Y, Z) :- ( X > 0 -> Y = pos ; Y = nonpos ),
+                         ( X > 5 -> Z = big ; Z = small ).
+user:cnestite(X, Y)   :- ( X > 0 -> ( X > 10 -> Y = big ; Y = small ) ; Y = neg ).
+
+clojure_jar('/usr/share/java/clojure.jar').
+clojure_jar('/usr/share/java/clojure-1.11.jar').
+clojure_jar('/usr/share/java/clojure-1.11.1.jar').
+
+clojure_runnable(Jar) :-
+    catch(( process_create(path(java), ['-version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail),
+    clojure_jar(Jar), exists_file(Jar), !.
+
+:- begin_tests(wam_clojure_lowered_ite_exec, [condition(clojure_runnable(_))]).
+
+test(ite_exec_parity) :-
+    clojure_runnable(Jar),
+    Dir = 'output/test_wam_clojure_ite_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    % 1. Generate the WAM Clojure project (ITE preds now lower natively).
+    write_wam_clojure_project(
+        [user:cite/2, user:cneg/1, user:cseqite/3, user:cnestite/2],
+        [module_name('iteproj')], Dir),
+    % 2. Harness that calls each lowered wrapper and checks success/failure.
+    atomic_list_concat([Dir, '/test_ite.clj'], TestPath),
+    clojure_test_source(Src),
+    setup_call_cleanup(open(TestPath, write, S), write(S, Src), close(S)),
+    % 3. Compile + run on the JVM.
+    atomic_list_concat([Dir, '/src'], SrcDir),
+    format(atom(Cmd),
+        'java -cp "~w:~w" clojure.main ~w 2>&1',
+        [Jar, SrcDir, TestPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 15 PASS")
+    ->  true
+    ;   format(user_error, "~n[clojure ite test output]~n~w~n", [OutStr]),
+        throw(clojure_test_failed(Status))
+    ).
+
+:- end_tests(wam_clojure_lowered_ite_exec).
+
+% Calls each lowered predicate wrapper; run-wam returns a boolean. Atoms are
+% built through the generated compile-time intern context. cseqite(10,pos,
+% small)=false and cnestite are the sequential/nested discriminators.
+clojure_test_source(
+"(require '[generated.wam.core :as core])
+(require '[generated.wam.runtime :as runtime])
+(defn a [s] (runtime/normalize-literal-term core/atom-intern-context s))
+(def cases
+  [[\"cite(5,pos)\"        (core/cite 5 (a \"pos\"))        true]
+   [\"cite(5,nonpos)\"     (core/cite 5 (a \"nonpos\"))     false]
+   [\"cite(-1,nonpos)\"    (core/cite -1 (a \"nonpos\"))    true]
+   [\"cite(-1,pos)\"       (core/cite -1 (a \"pos\"))       false]
+   [\"cneg(5)\"            (core/cneg 5)                  false]
+   [\"cneg(-1)\"           (core/cneg -1)                 true]
+   [\"cneg(0)\"            (core/cneg 0)                  true]
+   [\"cseqite(10,pos,big)\"      (core/cseqite 10 (a \"pos\") (a \"big\"))      true]
+   [\"cseqite(10,pos,small)\"    (core/cseqite 10 (a \"pos\") (a \"small\"))    false]
+   [\"cseqite(3,pos,small)\"     (core/cseqite 3 (a \"pos\") (a \"small\"))     true]
+   [\"cseqite(-1,nonpos,small)\" (core/cseqite -1 (a \"nonpos\") (a \"small\")) true]
+   [\"cnestite(20,big)\"   (core/cnestite 20 (a \"big\"))   true]
+   [\"cnestite(5,small)\"  (core/cnestite 5 (a \"small\"))  true]
+   [\"cnestite(-1,neg)\"   (core/cnestite -1 (a \"neg\"))   true]
+   [\"cnestite(20,small)\" (core/cnestite 20 (a \"small\")) false]])
+(let [fails (filter (fn [[_ got want]] (not= (boolean got) want)) cases)]
+  (doseq [[n got want] fails] (println \"FAIL\" n \"got\" (boolean got) \"want\" want))
+  (if (empty? fails) (println \"ALL\" (count cases) \"PASS\")
+      (println (count fails) \"FAILURES\")))
+").


### PR DESCRIPTION
Continues the WAM if-then-else parity sweep (Scala #2793, Go/Rust #2796, C++ #2829, Haskell #2840, F# #2843).

## Starting point

Like F#, Clojure was **sound** but didn't lower ITE: its lowered model is a flat `(let [s0 state s1 …] sN)` state-threading chain with **no branching**, so the emitter produced a **no-op stub** for any predicate containing `try_me_else` (`C1Instrs = []`) and the wrapper's `run-wam` (interpreter) executed it. So this is a **parity/perf enablement**, not a bug fix — and the most divergent backend (its model needed a genuinely new branching emit, not a port).

## Change

Clause 1 is parsed keeping labels, folded by the shared `wam_ite_structurer` into `ite(Cond,Then,Else)`, and emitted as native branching:

```clojure
sIte (if (= :running (:status sCond))
         <then from sCond>      ; success: inherit the condition's bindings
         <else from sPre>)      ; failure: from the PRE-condition state
```

A failed condition builtin calls `runtime/backtrack` with no choice point in scope → `:status :failed` (not `:running`) → the `if` routes to the else (same Maybe-style discipline as Haskell/F#). `emit_clj_bindings` recurses, so **nested** and **sequential** blocks work.

Only single-clause ITE predicates take the new path; deterministic predicates keep the existing direct-prefix emit, and multi-clause/unstructurable predicates keep the no-op stub + `run-wam` fallback. **No runtime change** — reuses `runtime/advance`/`backtrack`/`succeed-state`.

## Performance (verified)

- Deterministic (non-ITE) lowered predicates emit **byte-identical** code (`diff` of `inc/2`) → zero change on existing code.
- Structurer is O(n) generation-time only.
- ITE predicates move from interpreter → native branching — faster.

## Verification — compile+run

Installed the JVM Clojure toolchain (apt) and verified end-to-end (new gated `test_wam_clojure_lowered_ite_exec.pl`): **15 cases** (simple, negation, sequential incl. `cseqite(10,pos,small)=false`, nested) → **ALL 15 PASS**. Clojure generator (11), benchmark-generator (12), lowered-emitter (97) suites stay green.

## Parity scoreboard
✅ Scala, Go, Rust, C++, Haskell, F#, **Clojure** — shared structurer, all **compile-run-verified**
⚠️ llvm (ITE-aware, no structurer) · elixir / lua / python / r (none)

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_