### PR TITLE
fix(wam): scope a cut in an if-then-else condition to the condition

### DIFF
--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -132,6 +132,9 @@ compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code) :-
     ->  b_setval(wam_ite_use_y_level, true)
     ;   b_setval(wam_ite_use_y_level, false)
     ),
+    % Reset cut scope to clause level at the start of each predicate
+    % compilation (see current_cut_target/1).
+    set_cut_target(clause),
     % args_first_emission: emit set_variable for ALL outer-compound
     % args BEFORE any nested put_structure. The legacy emit
     % interleaved `set_variable Xn ; put_structure F/N, Xn ;
@@ -813,6 +816,22 @@ wam_inline_not_enabled :-
 
 wam_ite_use_y_level_enabled :-
     catch(b_getval(wam_ite_use_y_level, true), _, fail).
+
+% Current cut scope for a plain `!` emission. `clause` (the default)
+% means a `!` is transparent to the enclosing clause and emits
+% `builtin_call !/0` (the runtime cuts to the clause B0). Inside an
+% if-then-else CONDITION the cut is OPAQUE (local to the condition, like
+% call/1): the target is set to the condition''s barrier Y-register and a
+% `!` emits `cut Yn`, pruning only the condition''s own choicepoints and
+% leaving the if-then-else choicepoint intact. Saved/restored around
+% condition compilation so Then/Else branches revert to the enclosing
+% scope. Only meaningful under wam_ite_use_y_level_enabled (get_level/cut
+% targets); legacy targets always emit builtin_call !/0.
+current_cut_target(Target) :-
+    ( catch(b_getval(wam_cut_target, T), _, fail) -> Target = T ; Target = clause ).
+
+set_cut_target(Target) :-
+    b_setval(wam_cut_target, Target).
 
 is_builtin_goal(is).
 is_builtin_goal(=).
@@ -1722,12 +1741,44 @@ compile_if_then_else(CondGoal, ThenGoal, ElseGoal, V0, Vf, _HasEnv, Code) :-
        NextY is MaxY + 1,
        format(atom(BarrierReg), "Y~w", [NextY]),
        gensym('$ite_barrier_', BarrierVar),
-       V0a = vmap([b(BarrierVar, BarrierReg)|Bindings0], XCount0)
+       % A cut in the CONDITION is local to it (ISO: the condition of
+       % ->/2 is opaque to cut, like call/1). If the condition has a
+       % top-level cut, reserve a SECOND Y and snapshot the condition''s
+       % entry level into it with a get_level emitted AFTER try_me_else
+       % (so it captures the level WITH the ITE choice point but BEFORE
+       % any CP the condition pushes). A `!` in the condition then emits
+       % `cut CondBarrierReg`, pruning only the condition''s own CPs and
+       % leaving the ITE choice point intact -- so e.g. \+ (G, !, fail)
+       % (which desugars to ((G,!,fail) -> fail ; true)) correctly
+       % succeeds when the cut-guarded condition fails.
+       flatten_conjunction(CondGoal, CondGoals),
+       (   memberchk('!', CondGoals)
+       ->  CondY is MaxY + 2,
+           format(atom(CondBarrierReg), "Y~w", [CondY]),
+           gensym('$ite_cond_barrier_', CondBarrierVar),
+           V0a = vmap([b(BarrierVar, BarrierReg),
+                       b(CondBarrierVar, CondBarrierReg)|Bindings0], XCount0),
+           format(string(CondGetLevel), "    get_level ~w~n", [CondBarrierReg])
+       ;   CondBarrierReg = none,
+           V0a = vmap([b(BarrierVar, BarrierReg)|Bindings0], XCount0),
+           CondGetLevel = ""
+       )
     ;  V0a = V0,
-       BarrierReg = none
+       BarrierReg = none,
+       CondBarrierReg = none,
+       CondGetLevel = "",
+       flatten_conjunction(CondGoal, CondGoals)
     ),
-    flatten_conjunction(CondGoal, CondGoals),
-    compile_inner_call_goals(CondGoals, V0a, V1, CondCode),
+    % Compile the condition with cuts scoped to CondBarrierReg (when one
+    % was reserved); Then/Else revert to the enclosing scope so their
+    % cuts stay transparent to the clause / outer condition.
+    (   CondBarrierReg == none
+    ->  compile_inner_call_goals(CondGoals, V0a, V1, CondCode)
+    ;   current_cut_target(OldTarget),
+        set_cut_target(CondBarrierReg),
+        compile_inner_call_goals(CondGoals, V0a, V1, CondCode),
+        set_cut_target(OldTarget)
+    ),
     % Then and Else can each be themselves a nested if-then-else --
     % compile_ite_branch recurses on those forms. Else starts from
     % V0a since backtrack restores to before the condition (but the
@@ -1743,8 +1794,8 @@ compile_if_then_else(CondGoal, ThenGoal, ElseGoal, V0, Vf, _HasEnv, Code) :-
           [ElseLabel, CondCode, ThenCode, ContLabel,
            ElseLabel, ElseCode, ContLabel])
     ;  format(string(Code),
-          "    get_level ~w~n    try_me_else ~w~n~w~n    cut ~w~n~w~n    jump ~w~n~w:~n    trust_me~n~w~n~w:",
-          [BarrierReg, ElseLabel, CondCode, BarrierReg, ThenCode,
+          "    get_level ~w~n    try_me_else ~w~n~w~w~n    cut ~w~n~w~n    jump ~w~n~w:~n    trust_me~n~w~n~w:",
+          [BarrierReg, ElseLabel, CondGetLevel, CondCode, BarrierReg, ThenCode,
            ContLabel, ElseLabel, ElseCode, ContLabel])
     ).
 
@@ -1868,6 +1919,17 @@ allocate_var(Var, VIn, VOut, Reg) :-
 % that genuinely needs a module registry which no target has yet.
 % String + atom guard per #1647 follow-up review (Perplexity)
 % covers any code path that represents module names as strings.
+% Plain cut. Emit a scope-correct cut: inside an if-then-else condition
+% the cut is local to the condition (cut Yn to the condition barrier);
+% elsewhere it is transparent to the clause (builtin_call !/0, runtime
+% cuts to clause B0). See current_cut_target/1.
+compile_goal_call('!', V, V, Code) :-
+    !,
+    (   current_cut_target(Target),
+        Target \== clause
+    ->  format(string(Code), "    cut ~w", [Target])
+    ;   Code = "    builtin_call !/0, 0"
+    ).
 compile_goal_call(M:InnerGoal, V0, Vf, Code) :-
     (atom(M) ; string(M)),
     !,

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -1362,6 +1362,20 @@ user:wam_cpp_test_not_alias_fails    :- not(true).
 % because NaN =:= NaN is false but \=== NaN at the structural level.
 user:wam_cpp_test_not_nan_check   :- R is 0.0 / 0.0, \+ (R =:= R).
 
+% Cut INSIDE a negated conjunction. \+ G desugars to (G -> fail ; true),
+% so the cut becomes a cut in the if-then-else CONDITION, which is opaque
+% (local to the condition, like call/1): it must commit gen''s first
+% solution but leave the negation''s own choicepoint intact, so the goal
+% fails and the negation succeeds → true. Regression guard for the
+% condition-cut scoping fix (a clause-scope cut would prune the negation
+% CP and make this wrongly fail).
+:- dynamic user:wam_cpp_test_not_inline_cut/0.
+:- dynamic user:wam_cpp_ncut_gen/1.
+user:wam_cpp_ncut_gen(1).
+user:wam_cpp_ncut_gen(2).
+user:wam_cpp_ncut_gen(3).
+user:wam_cpp_test_not_inline_cut :- \+ (wam_cpp_ncut_gen(_), !, fail).
+
 % call/N (meta-call):
 :- dynamic user:wam_cpp_call_helper/1.
 :- dynamic user:wam_cpp_test_call_atom/0.
@@ -6463,6 +6477,24 @@ test(cpp_e2e_not_compound_conjunction,
                               [emit_main(true)], TmpDir),
         ( build_e2e_binary(TmpDir, BinPath),
           run_query(BinPath, 'wam_cpp_test_not_compound/0', [], true)
+        ),
+        delete_directory_and_contents(TmpDir)
+    ).
+
+test(cpp_e2e_not_inline_cut, [condition(cpp_compiler_available)]) :-
+    % `\+ (gen(_), !, fail)` — a cut inside the negated conjunction is
+    % local to the negation (the ->/2 condition is opaque to cut). The
+    % cut commits gen''s first solution; `fail` then fails the goal, so
+    % the negation succeeds → true. Guards the if-then-else condition
+    % cut-scope fix: a clause-scope cut would prune the negation''s own
+    % choicepoint and make this wrongly return false.
+    unique_cpp_tmp_dir('tmp_cpp_e2e_not_inline_cut', TmpDir),
+    setup_call_cleanup(
+        write_wam_cpp_project([user:wam_cpp_ncut_gen/1,
+                               user:wam_cpp_test_not_inline_cut/0],
+                              [emit_main(true)], TmpDir),
+        ( build_e2e_binary(TmpDir, BinPath),
+          run_query(BinPath, 'wam_cpp_test_not_inline_cut/0', [], true)
         ),
         delete_directory_and_contents(TmpDir)
     ).


### PR DESCRIPTION
 A plain cut inside the condition of (Cond -> Then ; Else) was compiled to builtin_call !/0, which — with the B0
  cut-locality fix — cuts to the enclosing clause level and so wrongly pruned the if-then-else's own choicepoint. Per
  ISO, the condition of ->/2 is opaque to cut (local to the condition, like call/1): the cut must commit only the
  condition's own choices.

  This surfaced through negation: \+ (G, !, fail) desugars to ((G, !, fail) -> fail ; true), so the cut lands in the
  condition. With the escaping cut it removed the negation's choicepoint and the negation wrongly failed — e.g. \+
  (member(_,L), !, fail) returned false instead of true.

  Fix (gated on ite_use_y_level, i.e. C++/LLVM which have get_level/cut):
  - When an if-then-else condition contains a top-level cut, reserve a second barrier Y register and emit get_level
  CondBarrierReg immediately after try_me_else — capturing the level with the ITE choicepoint but before any CP the
  condition pushes.
  - Compile the condition with the cut scope set to that register, so a ! in the condition emits cut CondBarrierReg
  (prunes only the condition's CPs, leaves the ITE choicepoint intact). Then/Else revert to the enclosing scope, keeping
  their cuts transparent to the clause.
  - No extra register or instruction when the condition has no cut, so the common case is unchanged. Legacy targets keep
  builtin_call !/0.

  Adds cpp_e2e_not_inline_cut regression test.

  Test plan: test_wam_cpp_generator 401/401 (incl. new test); test_wam_llvm_target, test_wam_cross_target_conformance,
  test_wam_cross_target_consistency, test_wam_target, test_wam_e2e, test_wam_text_parser all green. Zero regressions.

  🤖 Generated with Claude Code (https://claude.com/claude-code)