### PR TITLE
docs: apply four empirical refinements from budget-variants report

### DIFF
--- a/docs/design/TREE_LIKENESS_INDEX.md
+++ b/docs/design/TREE_LIKENESS_INDEX.md
@@ -245,6 +245,45 @@ exhibit this — we measured exactly this divergence (5.044 → 0.29,
 a 90% drift) before introducing the direction-weighted metric. The
 graph didn't change; the metric did.
 
+#### 3.3.1 Three sub-claims for "shortcuts are rare" (refined 2026-06-06)
+
+The Python and F# per-node measurements in
+`docs/reports/depth_likeness_budget_variants.md` showed that the
+"shortcuts are rare" claim is **direction- and query-dependent**.
+Stated precisely, three distinct sub-claims emerge, each with a
+different empirical answer:
+
+- **(child-to-root shortcuts are rare)** — confirmed empirically.
+  Setting `B = depth(v)` (tightest budget admitting only the
+  carrot), `d_wPow = depth + 1` exactly for 0% shortcut rate on
+  simplewiki Articles at depths 1-9 and on enwiki MTC at depths
+  1-11. Child-direction routes shorter than the BFS-shortest
+  pure-parent route do not exist for shallow-to-moderate seeds
+  under the tightest budget.
+- **(parent-direction shortcuts are abundant)** — *refutes* the
+  naive reading. Setting `B = max parent distance`, ~76% of enwiki
+  nodes have `d_wPow < max_d + 1`. The graph's multi-parent
+  topology provides many alternate ancestor chains shorter than
+  the longest possible pure-parent route. The metric correctly
+  detects this — it just doesn't read as "child shortcut" because
+  no child hop is involved.
+- **(arbitrary-pair shortcuts between topical nodes are common)** —
+  also refutes the naive reading. At least 39% of random topical
+  pairs on simplewiki show `d_wPow < min_carrot + 1` (61% timed
+  out, likely undercount). Cross-topical multi-parent structure
+  provides shortcuts that don't appear when one endpoint is the
+  root.
+
+The original §3.3 claim is *true* under the implicit conditioning
+"child-direction, to topical root, at tight budget" — which
+matches the design note's standard certificate setting (§6.1).
+For other query distributions (pair-to-pair, looser budget,
+deeper seeds) the claim doesn't hold and shortcut rates can be
+substantial.
+
+This refinement preserves the original §3.3 framing for its
+intended scope while documenting where it doesn't apply.
+
 ## 4. Evidence (so far)
 
 ### 4.1 Aggregate, simplewiki rooted at Physics
@@ -805,6 +844,34 @@ cross-paths structurally, and the certificate is honest: it's a
 statistical claim about *this* graph under *this* metric for
 queries from *this* distribution *at this budget*, not a universal
 one.
+
+**Per-node budget-choice tradeoff (refined 2026-06-06).** The
+multi-budget empirical study in
+`docs/reports/depth_likeness_budget_variants.md` shows the
+certificate at different budgets answers different questions:
+
+- **B = depth(v)** (tightest): admits only the carrot. Certificate
+  here is the strictest possible — TLI < 0.1% means the metric
+  cannot find shorter routes via children at all. Empirically:
+  enwiki MTC and simplewiki Articles both pass with 0% shortcuts
+  at depths 1-9 (simplewiki) or 1-11 (enwiki).
+- **B = 15 (or similar fixed)** (standard, this section's
+  recommendation): admits some M ≥ 1 paths within budget. Includes
+  detour contribution that tightens the certificate's interpretation
+  but still validates "tree-search ≈ bidirectional within ε" for
+  reasonable seeds.
+- **B = max parent distance** (loosest reasonable): admits all
+  alternate-ancestor paths plus child shortcuts. Certificate
+  here measures whether the metric tracks the "natural depth
+  range" of the topical hierarchy. Empirically: ~24% of nodes
+  show $d_\text{wPow} \approx \min + 1$ (no parent-shortcut
+  effect), but ~76% on enwiki show $d_\text{wPow}$ below
+  $\max_d + 1$ due to multi-ancestor averaging.
+
+For production, `B = depth + 5` to `B = 2 \cdot \max_d` covers
+the practical range. The standard `B = 15` recommendation in this
+section corresponds to a moderate-budget regime that includes
+detour contribution but isn't dominated by it.
 
 ### 6.2 Drift as a diagnostic
 

--- a/docs/design/TREE_LIKENESS_INDEX_THEORY.md
+++ b/docs/design/TREE_LIKENESS_INDEX_THEORY.md
@@ -679,17 +679,46 @@ homogeneity precondition of Definition 0.6 holds to a degree
 sufficient for low TLI in practice (within tolerance for $\psi$
 of Conjecture 3.1).
 
-**Partial support.** Design note §4.5 measures
-$b_{\text{eff}}$ on `Category:Articles` (9.59) and on
-`Category:Physics` (9.51), finding ~1% agreement. This is
-evidence that the topical core is *statistically self-similar*
-across different sub-trees — a necessary condition for
-homogeneity (H3 of Definition 0.6).
+**Support.**
 
-**Caveat.** The conjecture has been tested on simplewiki only.
-The enwiki topical-root verification (page_id 7345184 confirmed
-via Wikipedia API, LMDB construction pending) is task #14 in the
-design note.
+*Simplewiki (within-wiki self-similarity).* Design note §4.5
+measures $b_{\text{eff}}$ on `Category:Articles` (9.59) and on
+`Category:Physics` (9.51), finding ~1% agreement — direct
+evidence the topical core is *statistically self-similar* across
+different sub-trees (H3 of Definition 0.6).
+
+*Enwiki (cross-wiki extension, 2026-06-06).* The post-fix
+enwiki LMDB rooted at `Category:Main_topic_classifications`
+(page_id 7345184) was built (2.26M reachable nodes, 6.7M edges,
+30× the size of simplewiki Articles). The F# probe ran V1
+(B = depth) on 240 sampled seeds at depths 1-12 — `d_wPow =
+depth + 1` exactly at depths 1-11 (0/220 nodes show shortcuts),
+20% at depth 12. This is *stronger* tree-likeness than simplewiki
+at the same depth range (where simplewiki saturated at 100%
+shortcuts at depth ≥ 10).
+
+The geometric-series analysis in
+`docs/reports/depth_likeness_budget_variants.md` gives the
+quantitative cross-wiki comparison: estimated convergence ratio
+$r \approx 0.16$ on simplewiki vs $r \approx 0.04$ on enwiki —
+a ~4× larger safety margin on enwiki, despite 30× scale.
+
+**Status: confirmed at both simplewiki and enwiki scale, with
+enwiki showing stronger tree-likeness than simplewiki.** The
+multi-wiki, multi-scale agreement supports promoting
+Conjecture 3.4 from "topical scoping is sufficient for
+homogeneity in practice" to "topical scoping yields verified
+tree-like calibration across two Wikipedia language editions
+spanning 30× scale difference."
+
+**Open questions still standing.** Whether the pattern extends
+to non-Wikipedia DAGs with topical scoping (e.g. dewiki,
+non-Wikipedia hierarchies like DMOZ or schema.org subtrees)
+remains untested. The Wikipedia-specific result alone doesn't
+distinguish "topical scoping works on any well-curated
+hierarchical DAG" from "topical scoping works specifically on
+Wikipedia-style category structures." See §5.3 for follow-up
+suggestions.
 
 ### 3.5 Symmetric DAGs have high TLI under any directional metric
 
@@ -979,6 +1008,15 @@ evaluation at varying $r$ to fit $\alpha$ empirically.
   regime confirmed. Indirectly supports homogeneity: the topical
   subgraph behaves uniformly enough for the Chung-Lu distance
   formula to fit. See `docs/reports/topical_geometric_regime_simplewiki.md`.
+- **Task #17 enwiki extension (2026-06-06)**: F# probe at enwiki
+  scale (2.26M reachable nodes from `Main_topic_classifications`,
+  30× simplewiki). V1 result: $d_\text{wPow} = \text{depth} + 1$
+  exactly at depths 1-11 (220 nodes, zero stdev), 20% shortcut
+  rate only at depth 12. *Stronger* tree-likeness than simplewiki
+  at the same depth range. Conjecture 3.4 promoted from
+  "simplewiki only" to "confirmed at two wikis spanning 30×
+  scale." See `docs/reports/depth_likeness_budget_variants.md`
+  addendum.
 
 ### 4.5 Conjecture 3.5 (symmetric DAG falsification)
 
@@ -1070,6 +1108,34 @@ truncated $L_M, R_M$ sums, or (ii) Monte Carlo evaluation at
 varying $r$ to fit the exponent empirically. Conjecture 3.3 as
 stated is *consistent with* the empirical gap but not yet
 derived from theory.
+
+**Cross-wiki empirical anchor for $r$ (2026-06-06).** Beyond the
+simplewiki-only $r \approx 0.157$ used above, the F# V3 enwiki
+measurement gives a second data point. Treating the per-zig-zag
+empirical shortcut probability $p_\text{child} \approx 0.04$ as
+a proxy for $r$ on enwiki (the geometric series
+$\sum_n p^n = 1/(1-p)$ matches the theoretical
+$r/(1-r)$ contribution-sum form), we get:
+
+| Wiki | Estimated $r$ | Safety margin vs $r = 1$ |
+|---|---|---|
+| simplewiki Articles | $\approx 0.16$ | $\approx 6\times$ |
+| enwiki MTC | $\approx 0.04$ | $\approx 25\times$ |
+
+The 4× larger safety margin on enwiki despite 30× scale is
+counter-intuitive but explainable: more multi-parent topology
+produces more *long* alternate paths (parent-direction shortcuts,
+which the weighting crushes — boosting $b_\text{eff} \cdot D$)
+but *fewer short* child shortcuts (which would inflate $b'$).
+Conjecture 3.1's convergence ratio shrinks even as graph size
+grows, provided topical scoping is enforced.
+
+See `docs/reports/depth_likeness_budget_variants.md` § "Zig-zag
+shortcuts and the geometric series" for the derivation. Both
+empirical $r$ values fall in the comfortable-convergence regime
+($r \ll 1$), supporting the per-step partial-cancellation
+analysis above as the right asymptotic story even if its
+quantitative bound is loose.
 
 ### 5.2 Quantitative homogeneity ↔ calibration error
 


### PR DESCRIPTION
  ## Summary

  Folds the empirical learnings from `docs/reports/depth_likeness_budget_variants.md` (merged in PR #2851) back into the
  formal design note and theory doc. No new conjectures introduced; all refinements are interpretive — translating
  completed empirical work into the doc claims that should reflect it.

  ## Four refinements

  ### 1. Design note §3.3 — "shortcuts are rare" → three sub-claims

  The original `§3.3 "What it is: the 'child shortcuts are statistically rare' property"` is preserved as written; a new
  `§3.3.1 Three sub-claims` adds:

  | Sub-claim | Verdict |
  |---|---|
  | child-to-root shortcuts (V1, B=d) | confirmed rare (0% at depths 1-9 simplewiki, 1-11 enwiki) |
  | parent-direction shortcuts (V3, B=max_d) | abundant (~76% on enwiki) — *refutes* the naive reading |
  | arbitrary-pair shortcuts (V2) | common (≥39%) — *refutes* the naive reading |

  The original §3.3 framing is true under the implicit conditioning "child-direction, to topical root, at tight budget"
  — which matches the standard certificate (§6.1).

  ### 2. Theory doc §3.4 (Conjecture 3.4) — simplewiki-only → confirmed at enwiki scale

  Updated "Partial support" section with the F# V1 enwiki result (0% shortcuts at depths 1-11, 220 nodes, 30× simplewiki
  scale) and the cross-wiki r comparison. Status promoted to "confirmed at two wikis spanning 30× scale difference."
  Lists remaining open questions about non-Wikipedia DAGs.

  ### 3. Theory doc §5.1 (Tightness) — empirical r anchor

  Adds cross-wiki r comparison:

  | Wiki | Estimated r | Safety margin vs r=1 |
  |---|---|---|
  | simplewiki Articles | ~0.16 | ~6× |
  | enwiki MTC | ~0.04 | ~25× |

  The 4× larger safety margin on the 30× larger graph is counter-intuitive but explainable via the parent-vs-child
  shortcut decomposition (more multi-parent topology → more parent-direction alternates the weighting crushes → boosts
  b_eff·D → smaller r). Supports the per-step partial-cancellation analysis as the right asymptotic story.

  ### 4. Design note §6.1 (Certificate at production budget) — budget-choice tradeoff

  Adds "per-node budget-choice tradeoff" subsection explaining what certificates at B=depth(v), B=15, B=max_d each
  answer, with empirical references.

  ### Bonus: theory doc §4.4 — task #17 entry

  Appended brief task #17 entry to the empirical-status section for Conjecture 3.4.

  ## What's not in this PR

  - **No new conjectures.** All refinements are interpretive.
  - **No code changes.** Pure docs.
  - **Task #14 (routing-correction redundancy)** — still pending. The F# infrastructure is ready; the experiment itself
  is the natural next PR.
  - **V2 F# port** — still pending. Generalising the kernel's A* heuristic for arbitrary targets is a separate piece of
  work.

  ## Files

  docs/design/TREE_LIKENESS_INDEX.md         (+67 lines: §3.3.1 + §6.1 budget-choice subsection)
  docs/design/TREE_LIKENESS_INDEX_THEORY.md  (+77 lines: §3.4 enwiki extension, §5.1 cross-wiki r, §4.4 task #17 entry)

  ## Test plan

  - [ ] Markdown renders cleanly in GitHub preview
  - [ ] LaTeX in §5.1 cross-wiki r table renders correctly
  - [ ] Cross-references resolve:
    - design note §3.3.1 ↔ reports/depth_likeness_budget_variants.md
    - theory doc §3.4 ↔ design note §4.5 + reports
    - theory doc §5.1 ↔ reports (zig-zag section)
    - design note §6.1 ↔ reports (per-node budget-choice tradeoff)