### PR TITLE
Root metrics Phase 3: effective-distance node-DP (collapses path explosion)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,10 @@ jobs:
         run: |
           python3 -m unittest tests.test_query_root_metric
 
+      - name: Run effective-distance node-DP test
+        run: |
+          python3 -m unittest tests.test_effective_distance_nodedp
+
       - name: Run WAM Rust matrix-bench demand-flag codegen test
         run: |
           python3 -m unittest tests.test_wam_rust_matrix_demand_flag

--- a/examples/benchmark/build_effective_distance.py
+++ b/examples/benchmark/build_effective_distance.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+"""
+build_effective_distance.py — materialise the effective-distance metric via a
+length-bucketed node-DP (ROOT_ANCHORED_METRICS Phase 3).
+
+The category_ancestor effective-distance query sums, per seed, (L+1)^(-n) over
+every path of length L from the seed up to the root. Enumerating paths is
+exponential on a dense DAG (the enwiki content graph: ~24 ms/seed, ~17 h full).
+This computes the identical quantity in O(edges * max_depth) by counting paths
+bucketed by length instead of enumerating them (spec §5):
+
+    count[N][0] = 1 if N == root else 0
+    count[N][L] = Σ_{P in parents(N)} count[P][L-1]          (L = 1..max_depth)
+    S(N)        = Σ_{L=1..max_depth} count[N][L] * (L+1)^(-n)
+
+Only two length-layers are held at once (count[*][L-1] and count[*][L]) plus the
+running S accumulator, so memory is O(reachable nodes), not O(nodes*max_depth).
+
+SEMANTICS (spec §4.1): this is the *walk* count (cycles(bounded)). On a DAG it
+equals the simple-path sum the per-path kernel computes; on a cyclic graph it
+differs (walks may revisit). The depth bound makes it finite and exact to
+max_depth either way.
+
+Output: a `metric_effective_distance` sub-db (int32_le node -> f64 LE value)
+written into the scoped LMDB next to the graph, + meta provenance. Querying the
+metric is then a single keyed get.
+
+Usage:
+  python3 build_effective_distance.py --lmdb <scoped_dir> [--root ID]
+      [--max-depth D] [--exponent N] [--map-size-gib G]
+Root / max_depth default to the scoped DB's stored meta (scoped_root / _max_depth).
+"""
+import argparse
+import struct
+import sys
+import time
+from array import array
+from collections import defaultdict
+from pathlib import Path
+
+import lmdb
+
+I32 = struct.Struct("<i")
+F64 = struct.Struct("<d")
+
+
+def enc_i32(i):
+    return I32.pack(i)
+
+
+def dec_i32(b):
+    return I32.unpack(b)[0]
+
+
+def load_edges(env, cp_db):
+    """Load category_parent (child -> parent) as two parallel int arrays."""
+    children = array("i")
+    parents = array("i")
+    with env.begin() as txn:
+        for k, v in txn.cursor(db=cp_db):
+            children.append(dec_i32(k))
+            parents.append(dec_i32(v))
+    return children, parents
+
+
+def effective_distance(children, parents, root, max_depth, exponent):
+    """Length-bucketed node-DP. Returns {node: S(node)} for S(node) > 0."""
+    prev = {root: 1.0}                 # count[*][0]
+    s = defaultdict(float)             # running S(N)
+    n_edges = len(children)
+    for depth in range(1, max_depth + 1):
+        cur = defaultdict(float)
+        for i in range(n_edges):
+            c = prev.get(parents[i])
+            if c:
+                cur[children[i]] += c
+        if not cur:
+            break                      # no longer-walks possible
+        factor = (depth + 1) ** (-exponent)
+        for node, cnt in cur.items():
+            s[node] += cnt * factor
+        prev = cur
+    return s
+
+
+def read_meta(env, key, default=None):
+    try:
+        meta = env.open_db(b"meta", create=False)
+    except lmdb.NotFoundError:
+        return default
+    with env.begin() as txn:
+        v = txn.get(key, db=meta)
+    return v.decode() if v is not None else default
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--lmdb", required=True, help="scoped LMDB dir (has category_parent + meta)")
+    ap.add_argument("--root", type=int, default=None, help="root id (default: meta scoped_root)")
+    ap.add_argument("--max-depth", type=int, default=None, help="default: meta scoped_max_depth")
+    ap.add_argument("--exponent", type=float, default=5.0, help="distance exponent n (default 5)")
+    ap.add_argument("--map-size-gib", type=float, default=4.0)
+    args = ap.parse_args()
+
+    t0 = time.time()
+    env = lmdb.open(str(args.lmdb), max_dbs=16, subdir=True,
+                    map_size=int(args.map_size_gib * 1024 ** 3))
+    cp_db = env.open_db(b"category_parent", dupsort=True, create=False)
+
+    root = args.root if args.root is not None else int(read_meta(env, b"scoped_root", "-1"))
+    max_depth = args.max_depth if args.max_depth is not None else int(read_meta(env, b"scoped_max_depth", "10"))
+    if root < 0:
+        sys.stderr.write("error: no root (pass --root or build the scoped DB with a meta marker)\n")
+        return 1
+
+    children, parents = load_edges(env, cp_db)
+    sys.stderr.write(f"loaded {len(children)} edges in {time.time()-t0:.1f}s\n")
+
+    s = effective_distance(children, parents, root, max_depth, args.exponent)
+    sys.stderr.write(f"node-DP: {len(s)} nodes with S>0 (root={root}, max_depth={max_depth}, "
+                     f"n={args.exponent}) in {time.time()-t0:.1f}s\n")
+
+    metric_db = env.open_db(b"metric_effective_distance", create=True)
+    meta_db = env.open_db(b"meta", create=True)
+    with env.begin(write=True) as txn:
+        for node, val in s.items():
+            txn.put(enc_i32(node), F64.pack(val), db=metric_db)
+        txn.put(b"metric_effective_distance.root", str(root).encode(), db=meta_db)
+        txn.put(b"metric_effective_distance.max_depth", str(max_depth).encode(), db=meta_db)
+        txn.put(b"metric_effective_distance.exponent", str(args.exponent).encode(), db=meta_db)
+        txn.put(b"metric_effective_distance.aggregate", b"sum", db=meta_db)
+    env.sync()
+    env.close()
+    sys.stderr.write(f"wrote metric_effective_distance ({len(s)} entries) in {time.time()-t0:.1f}s\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_effective_distance_nodedp.py
+++ b/tests/test_effective_distance_nodedp.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+"""Equivalence test for examples/benchmark/build_effective_distance.py.
+
+On a DAG the length-bucketed node-DP must equal the brute-force sum over simple
+paths that the per-path category_ancestor kernel computes (ROOT_ANCHORED_METRICS
+spec §5). Builds a tiny DAG LMDB, runs the tool, and compares the materialised
+metric_effective_distance against an independent path-enumeration oracle.
+
+Skips gracefully if python-lmdb is not installed.
+"""
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import lmdb
+    HAVE_LMDB = True
+except ImportError:
+    HAVE_LMDB = False
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOL = REPO_ROOT / "examples" / "benchmark" / "build_effective_distance.py"
+I32 = struct.Struct("<i")
+F64 = struct.Struct("<d")
+
+
+def enc(i):
+    return I32.pack(i)
+
+
+# child -> [parents]; root = 1. Acyclic.
+ADJ = {2: [1], 3: [1, 2], 4: [2, 3]}
+ROOT = 1
+MAX_DEPTH = 10
+EXP = 2.0
+
+
+def brute_S(seed):
+    """Sum over simple paths seed->root of (L+1)^(-EXP), matching the kernel
+    (hop = depth+1, distance = hop+1 = depth+2; per-path visited set)."""
+    total = 0.0
+
+    def dfs(node, depth, visited):
+        nonlocal total
+        parents = ADJ.get(node, [])
+        if ROOT not in visited and ROOT in parents:
+            total += (depth + 2) ** (-EXP)      # L = depth+1
+        if len(visited) >= MAX_DEPTH:
+            return
+        for p in parents:
+            if p in visited:
+                continue
+            dfs(p, depth + 1, visited | {p})
+
+    dfs(seed, 0, {seed})
+    return total
+
+
+@unittest.skipUnless(HAVE_LMDB, "python-lmdb not installed")
+class TestEffectiveDistanceNodeDP(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.lmdb = Path(self.tmp.name) / "scoped"
+        env = lmdb.open(str(self.lmdb), max_dbs=16, map_size=10 * 1024 * 1024, subdir=True)
+        cp = env.open_db(b"category_parent", dupsort=True, create=True)
+        meta = env.open_db(b"meta", create=True)
+        with env.begin(write=True) as txn:
+            for child, ps in ADJ.items():
+                for p in ps:
+                    txn.put(enc(child), enc(p), db=cp, dupdata=True)
+            txn.put(b"scoped_root", str(ROOT).encode(), db=meta)
+            txn.put(b"scoped_max_depth", str(MAX_DEPTH).encode(), db=meta)
+        env.sync()
+        env.close()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run_tool(self):
+        env = dict(os.environ)
+        env.setdefault("LANG", "C.UTF-8")
+        proc = subprocess.run(
+            [sys.executable, str(TOOL), "--lmdb", str(self.lmdb),
+             "--root", str(ROOT), "--max-depth", str(MAX_DEPTH), "--exponent", str(EXP)],
+            capture_output=True, text=True, env=env)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def _read_metric(self):
+        env = lmdb.open(str(self.lmdb), max_dbs=16, readonly=True, subdir=True, lock=False)
+        m = env.open_db(b"metric_effective_distance", create=False)
+        out = {}
+        with env.begin() as txn:
+            for k, v in txn.cursor(db=m):
+                out[I32.unpack(k)[0]] = F64.unpack(v)[0]
+        env.close()
+        return out
+
+    def test_nodedp_equals_path_enumeration(self):
+        self._run_tool()
+        got = self._read_metric()
+        for node in (2, 3, 4):
+            self.assertAlmostEqual(got.get(node, 0.0), brute_S(node), places=12,
+                                   msg=f"S({node}) node-DP {got.get(node)} != oracle {brute_S(node)}")
+        # root has no path to itself in a DAG -> absent / zero
+        self.assertAlmostEqual(got.get(ROOT, 0.0), 0.0, places=12)
+
+    def test_known_values(self):
+        # S(2)=2^-2=0.25; S(3)=2^-2+3^-2; S(4)=2*3^-2+4^-2
+        self._run_tool()
+        got = self._read_metric()
+        self.assertAlmostEqual(got[2], 0.25, places=12)
+        self.assertAlmostEqual(got[3], 0.25 + 1/9, places=12)
+        self.assertAlmostEqual(got[4], 2/9 + 1/16, places=12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary
  Replaces path enumeration (exponential on a dense DAG; enwiki ~17 h, intractable)
  with the length-bucketed node-DP that computes the identical effective-distance
  quantity in O(edges * max_depth):
      count[N][L] = Σ parents count[P][L-1];  S(N) = Σ_L count[N][L]·(L+1)^(-n)
  build_effective_distance.py materialises S(N) into a metric_effective_distance
  sub-db; queries become O(1) lookups.

  ## Validation
  - DAG: node-DP == brute-force simple-path enumeration (kernel semantics) +
    hand-computed values (tests/test_effective_distance_nodedp.py, CI-wired).
  - enwiki content graph (root 7345184, n=5): S for all 2,248,537 nodes in ~39 s
    (vs the path kernel's ~17 h); ~1.1 GB RSS.

  ## Semantics
  Walk count (cycles(bounded)) — equal to the per-path kernel on a DAG, exact to
  max_depth on cyclic graphs (spec §4.1).