### PR TITLE
Handle existential bagof/setof bodies in WAM-C

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -1,18 +1,18 @@
 # WAM C Target - Status And Next Steps
 
-Status date: 2026-06-05
+Status date: 2026-06-06
 
 Latest branch verification:
 
-- `investigate/wam-c-bagof-setof-witness-surface` based on `main` at
-  `2a473d77` (`Merge pull request #2846 from
-  s243a/investigate/wam-c-bagof-setof-aggregate-surface`)
+- `investigate/wam-c-bagof-setof-existential-surface` based on `main` at
+  `5e9967bc` (`Merge pull request #2850 from
+  s243a/investigate/wam-c-bagof-setof-witness-surface`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-bagof-setof-witness-surface`
+- `investigate/wam-c-bagof-setof-existential-surface`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -85,6 +85,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Direct inline nested `findall/3` lowering | Done | Inner-body `findall/3` now lowers to nested aggregate opcodes instead of `call findall/3`; local aggregate result slots are initialized before finalization, and the executable smoke covers `findall(X, (item(X), findall(Y, item(Y), Ys), Ys = [a,b]), L)` |
 | No-witness `bagof/3` and `setof/3` aggregate surface | Done | C parses the shared 4-field no-witness `begin_aggregate bagof/setof` form, `bagof/3` preserves duplicate solution order and fails empty, and `setof/3` sorts/deduplicates and fails empty |
 | Bound-witness `bagof/3` and `setof/3` grouping | Done | C parses witness register lists into aggregate payload arrays, copies witness tuples per aggregate item, selects the caller-bound witness group, and covers grouped `bagof/3` order plus grouped `setof/3` sort/dedup in an executable smoke |
+| Existential `^/2` aggregate body lowering | Done | Goal-level `^/2` wrappers are transparent in inner call positions, witness discovery still suppresses quantified variables, and the C executable smoke covers flattened existential `bagof/3` plus sorted/deduplicated existential `setof/3` |
 
 ## Current C Target Baseline
 
@@ -140,8 +141,9 @@ The C target is now a credible small WAM backend:
 - Supports the first aggregate surface: generated `findall/3` lowering through
   `begin_aggregate collect` / `end_aggregate`, including empty and non-empty
   result lists, helper-nested aggregate calls, direct inline nested `findall/3`
-  bodies, compound/list templates, no-witness `bagof/3` / `setof/3`, and
-  caller-bound witness grouping for `bagof/3` / `setof/3`.
+  bodies, compound/list templates, no-witness `bagof/3` / `setof/3`,
+  caller-bound witness grouping for `bagof/3` / `setof/3`, and
+  existential `^/2` suppression inside inline `bagof/3` / `setof/3` bodies.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -164,7 +166,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Second-arg indexing | Partial | Partial/Done | Partial/Done | C has constant A2 dispatch; broaden tests if this becomes hot. |
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
 | Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
-| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness and caller-bound witness `bagof/3` / `setof/3`; remaining gaps are unbound witness group enumeration, existential `^/2` inner-goal lowering, and broader aggregate forms. |
+| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness, caller-bound witness, and existential `^/2` `bagof/3` / `setof/3`; remaining gaps are unbound witness group enumeration, meta-call aggregate dispatch, and broader aggregate forms. |
 | Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, precise `get_level`/`cut` if-then-else, explicit `!/0` scoped to the current predicate call barrier, and generated `forall/2` soft-cut rewrites; residual work should be driven by concrete meta-control demand. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
@@ -178,6 +180,33 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-bagof-setof-existential-surface`
+
+Goal: make inline `bagof/3` and `setof/3` treat goal-level `^/2` as
+existential quantification instead of compiling it as a runtime predicate call.
+
+Evidence:
+
+- The shared WAM compiler strips goal-level `^/2` wrappers in inner call
+  positions and compiles the RHS directly.
+- Existing witness discovery still walks the original aggregate goal, so
+  variables on the LHS of `^/2` are excluded from the emitted witness-register
+  list.
+- The real-Prolog executable smoke compiles `bagof(X, Y^pair(X, Y), L)` and
+  `setof(X, Y^pair(X, Y), L)`, verifies the generated WAM has an empty witness
+  field and no `call ^/2`, and checks that C flattens across witness values for
+  `bagof/3` while sorting/deduplicating for `setof/3`.
+
+Reason:
+
+- The previous branch made caller-bound witness groups work when the witness
+  register is supplied by the caller.
+- Existential suppression is the complementary case: it removes a variable from
+  grouping and can reuse the no-witness aggregate finalizer.
+- Full unbound witness group enumeration remains a larger runtime-choicepoint
+  feature, so this branch deliberately avoids introducing resumable aggregate
+  group alternatives.
 
 ### Completed: `investigate/wam-c-bagof-setof-witness-surface`
 
@@ -202,8 +231,9 @@ Reason:
   sorting/deduplication path.
 - Full ISO-style unbound witness enumeration would require the C runtime to
   leave resumable group alternatives. This branch deliberately handles the
-  caller-bound witness case first, which closes a practical grouped lookup
-  surface without expanding the choicepoint model.
+  caller-bound witness case first, while the follow-up
+  `investigate/wam-c-bagof-setof-existential-surface` covers existential
+  suppression without expanding the choicepoint model.
 
 ### Completed: `investigate/wam-c-bagof-setof-aggregate-surface`
 
@@ -228,9 +258,9 @@ Reason:
 
 - Direct inline nested `findall/3` proved that nested aggregate frames and local
   aggregate result variables work in C.
-- The follow-up `investigate/wam-c-bagof-setof-witness-surface` branch covers
-  caller-bound witness grouping. Unbound witness group enumeration and inner
-  existential `^/2` lowering remain larger semantic surfaces.
+- Follow-up branches cover caller-bound witness grouping and inner existential
+  `^/2` suppression. Unbound witness group enumeration remains the larger
+  semantic surface.
 
 ### Completed: `investigate/wam-c-inline-nested-findall-lowering`
 
@@ -1118,19 +1148,20 @@ Evidence:
 
 ## Suggested Immediate Next Step
 
-Result-capped and sampled runs now confirm child-CSR variants agree, and parent
-plus child reachability prefilters remove most avoidable traversal work inside
-each visited article/root pair. Per-article candidate-root filtering plus sparse
-candidate-root scheduling now avoids most impossible root traversals when many
-roots are selected, while staying off for low-root workloads by default and
-preserving dense semantics when an explicit query cap is active. The threshold
-default now has a cost-model resolver, a Prolog option surface, and a repeatable
-calibration wrapper. The boundary-repeatability sweep supports moving `auto` to
-`512`, and the observability follow-up makes future sweep rows display that
-resolved value directly. The next useful work is feeding measured query/artifact
-costs into the resolver only if future datasets show a sharper crossover or if
-manual threshold overrides become common.
-Keep `benchmark_wam_c_child_csr_scale_sweep.py --artifact-only` for large
+The aggregate parity sequence now has no-witness, caller-bound witness, and
+existential `^/2` inline `bagof/3` / `setof/3` coverage. The next aggregate
+feature worth considering is full unbound witness group enumeration, using the
+C++ or Elixir iterator/choicepoint designs as references. Keep that as a
+separate branch because it needs resumable aggregate group alternatives rather
+than only compile-time wrapper stripping or single-shot finalization.
+
+For the effective-distance/CSR line, result-capped and sampled runs already
+confirm child-CSR variants agree, and parent plus child reachability prefilters
+remove most avoidable traversal work inside each visited article/root pair. The
+next useful work there is feeding measured query/artifact costs into the
+resolver only if future datasets show a sharper crossover or if manual
+threshold overrides become common. Keep
+`benchmark_wam_c_child_csr_scale_sweep.py --artifact-only` for large
 category-graph artifact bytes, and use `benchmark_wam_c_reverse_csr_lookup.py`
 only when changing CSR lookup storage. Do not persist root-distance maps to
 LMDB or a separate artifact by default; add that only behind a cost-analyzer

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -1790,6 +1790,11 @@ compile_inner_call_goals([Goal|Rest], V0, Vf, Code) :-
     ->  compile_if_then_else(CondGoal, ThenGoal, ElseGoal, V0, V1, no, GoalCode),
         compile_inner_call_goals(Rest, V1, Vf, RestCode),
         join_goal_codes(GoalCode, RestCode, Code)
+    ;   nonvar(Goal),
+        Goal = _ExistentialVars^ExistentialGoal
+    ->  flatten_conjunction(ExistentialGoal, ExistentialGoals),
+        append(ExistentialGoals, Rest, ExpandedGoals),
+        compile_inner_call_goals(ExpandedGoals, V0, Vf, Code)
     ;   Goal = (CondGoal -> ThenGoal)
     ->  compile_if_then_else(CondGoal, ThenGoal, fail, V0, V1, no, GoalCode),
         compile_inner_call_goals(Rest, V1, Vf, RestCode),

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -1745,6 +1745,16 @@ test_real_prolog_bagof_setof_witness_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_real_prolog_bagof_setof_existential_executable_smoke :-
+    Test = 'WAM-C: real Prolog bagof/3 and setof/3 existential smoke',
+    (   gcc_available
+    ->  (   run_real_prolog_bagof_setof_existential_executable_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'real Prolog existential bagof/3 and setof/3 executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_real_prolog_classic_recursive_executable_smoke :-
     Test = 'WAM-C: real Prolog classic recursive executable smoke',
     (   gcc_available
@@ -2988,6 +2998,60 @@ cleanup_wam_c_bagof_setof_witness_smoke :-
     retractall(user:wam_c_group_pair(_, _)),
     retractall(user:wam_c_group_bag(_, _)),
     retractall(user:wam_c_group_set(_, _)).
+
+run_real_prolog_bagof_setof_existential_executable_smoke :-
+    Options = [inline_bagof_setof(true)],
+    assertz((user:wam_c_exist_pair(b, red) :- true)),
+    assertz((user:wam_c_exist_pair(a, red) :- true)),
+    assertz((user:wam_c_exist_pair(c, blue) :- true)),
+    assertz((user:wam_c_exist_pair(b, blue) :- true)),
+    assertz((user:wam_c_exist_bag(L) :-
+        bagof(X, Y^wam_c_exist_pair(X, Y), L))),
+    assertz((user:wam_c_exist_set(L) :-
+        setof(X, Y^wam_c_exist_pair(X, Y), L))),
+    (   compile_predicate_to_wam(user:wam_c_exist_pair/2, Options, WamPair),
+        compile_predicate_to_wam(user:wam_c_exist_bag/1, Options, WamBag),
+        compile_predicate_to_wam(user:wam_c_exist_set/1, Options, WamSet),
+        sub_string(WamBag, _, _, _, 'begin_aggregate bagof'),
+        sub_string(WamBag, _, _, _, "''"),
+        sub_string(WamBag, _, _, _, 'call wam_c_exist_pair/2'),
+        \+ sub_string(WamBag, _, _, _, 'call ^/2'),
+        \+ sub_string(WamBag, _, _, _, 'call bagof/3'),
+        sub_string(WamSet, _, _, _, 'begin_aggregate setof'),
+        sub_string(WamSet, _, _, _, "''"),
+        sub_string(WamSet, _, _, _, 'call wam_c_exist_pair/2'),
+        \+ sub_string(WamSet, _, _, _, 'call ^/2'),
+        \+ sub_string(WamSet, _, _, _, 'call setof/3'),
+        compile_wam_predicate_to_c(user:wam_c_exist_pair/2, WamPair, Options, PairCode),
+        compile_wam_predicate_to_c(user:wam_c_exist_bag/1, WamBag, Options, BagCode),
+        compile_wam_predicate_to_c(user:wam_c_exist_set/1, WamSet, Options, SetCode),
+        atomic_list_concat([PairCode, BagCode, SetCode],
+                           '\n\n',
+                           PredCode),
+        compile_wam_runtime_to_c([], RuntimeCode),
+        get_time(Now),
+        Stamp is round(Now * 1000000),
+        wam_c_temp_path('unifyweaver_wam_c_bagof_setof_existential_smoke', Stamp, TmpBase),
+        format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+        format(atom(PredPath), '~w_pred.c', [TmpBase]),
+        format(atom(MainPath), '~w_main.c', [TmpBase]),
+        format(atom(ExePath), '~w_bin', [TmpBase]),
+        write_text_file(RuntimePath, RuntimeCode),
+        format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+        write_text_file(PredPath, PredTranslationUnit),
+        wam_c_bagof_setof_existential_smoke_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_bagof_setof_existential_smoke
+    ;   cleanup_wam_c_bagof_setof_existential_smoke,
+        fail
+    ).
+
+cleanup_wam_c_bagof_setof_existential_smoke :-
+    retractall(user:wam_c_exist_pair(_, _)),
+    retractall(user:wam_c_exist_bag(_)),
+    retractall(user:wam_c_exist_set(_)).
 
 run_real_prolog_classic_recursive_executable_smoke :-
     assertz((user:wam_c_classic_fib(0, 0) :- true)),
@@ -6383,6 +6447,97 @@ int main(void) {
 }
 ').
 
+wam_c_bagof_setof_existential_smoke_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_exist_pair_2(WamState* state);
+void setup_wam_c_exist_bag_1(WamState* state);
+void setup_wam_c_exist_set_1(WamState* state);
+
+static bool expect_atom_slot(WamState *state, WamValue *slot, const char *atom) {
+    WamValue *cell = wam_deref_ptr(state, slot);
+    return cell->tag == VAL_ATOM && strcmp(cell->data.atom, atom) == 0;
+}
+
+static bool expect_nil(WamValue *cell) {
+    return cell->tag == VAL_ATOM && strcmp(cell->data.atom, "[]") == 0;
+}
+
+static bool expect_atom_list3(WamState *state, WamValue value,
+                              const char *first,
+                              const char *second,
+                              const char *third) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    int cell_addr = wam_cons_head_addr(state, cell);
+    if (cell_addr < 0) return false;
+    WamValue *tail1 = wam_deref_ptr(state, &state->H_array[cell_addr + 1]);
+    int tail1_addr = wam_cons_head_addr(state, tail1);
+    if (tail1_addr < 0) return false;
+    WamValue *tail2 = wam_deref_ptr(state, &state->H_array[tail1_addr + 1]);
+    int tail2_addr = wam_cons_head_addr(state, tail2);
+    if (tail2_addr < 0) return false;
+    WamValue *tail3 = wam_deref_ptr(state, &state->H_array[tail2_addr + 1]);
+    return expect_atom_slot(state, &state->H_array[cell_addr], first) &&
+           expect_atom_slot(state, &state->H_array[tail1_addr], second) &&
+           expect_atom_slot(state, &state->H_array[tail2_addr], third) &&
+           expect_nil(tail3);
+}
+
+static bool expect_atom_list4(WamState *state, WamValue value,
+                              const char *first,
+                              const char *second,
+                              const char *third,
+                              const char *fourth) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    int cell_addr = wam_cons_head_addr(state, cell);
+    if (cell_addr < 0) return false;
+    WamValue *tail1 = wam_deref_ptr(state, &state->H_array[cell_addr + 1]);
+    int tail1_addr = wam_cons_head_addr(state, tail1);
+    if (tail1_addr < 0) return false;
+    WamValue *tail2 = wam_deref_ptr(state, &state->H_array[tail1_addr + 1]);
+    int tail2_addr = wam_cons_head_addr(state, tail2);
+    if (tail2_addr < 0) return false;
+    WamValue *tail3 = wam_deref_ptr(state, &state->H_array[tail2_addr + 1]);
+    int tail3_addr = wam_cons_head_addr(state, tail3);
+    if (tail3_addr < 0) return false;
+    WamValue *tail4 = wam_deref_ptr(state, &state->H_array[tail3_addr + 1]);
+    return expect_atom_slot(state, &state->H_array[cell_addr], first) &&
+           expect_atom_slot(state, &state->H_array[tail1_addr], second) &&
+           expect_atom_slot(state, &state->H_array[tail2_addr], third) &&
+           expect_atom_slot(state, &state->H_array[tail3_addr], fourth) &&
+           expect_nil(tail4);
+}
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_exist_pair_2(&state);
+    setup_wam_c_exist_bag_1(&state);
+    setup_wam_c_exist_set_1(&state);
+
+    WamValue bag_args[1] = { val_unbound("Bag") };
+    int bag_rc = wam_run_predicate(&state, "wam_c_exist_bag/1", bag_args, 1);
+    if (bag_rc != 0 || state.P != WAM_HALT ||
+        !expect_atom_list4(&state, state.A[0], "b", "a", "c", "b") ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue set_args[1] = { val_unbound("Set") };
+    int set_rc = wam_run_predicate(&state, "wam_c_exist_set/1", set_args, 1);
+    if (set_rc != 0 || state.P != WAM_HALT ||
+        !expect_atom_list3(&state, state.A[0], "a", "b", "c") ||
+        state.B != 0 || state.call_base_top != 0 || state.aggregate_top != 0) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_classic_fib_smoke_main(
 '#include "wam_runtime.h"
 
@@ -6599,6 +6754,7 @@ run_tests_once :-
     test_real_prolog_findall_executable_smoke,
     test_real_prolog_bagof_setof_executable_smoke,
     test_real_prolog_bagof_setof_witness_executable_smoke,
+    test_real_prolog_bagof_setof_existential_executable_smoke,
     test_real_prolog_classic_recursive_executable_smoke,
     test_lowered_fact_helper_executable_smoke,
     test_lowered_body_call_helper_executable_smoke,


### PR DESCRIPTION
  ## Summary
  - Treat goal-level `^/2` as transparent in shared WAM inner-call compilation.
  - Preserve existing witness discovery semantics so quantified variables are excluded from `bagof/3` / `setof/3`
  witness groups.
  - Add a WAM-C executable smoke covering existential `bagof/3` flattening and existential `setof/3` sort/dedup
  behavior.
  - Update the WAM-C roadmap to mark existential aggregate lowering complete and leave unbound witness group enumeration
  as the next aggregate gap.

  ## Validation
  - `git diff --check`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`