### PR TITLE
feat(llvm): lower if-then-else / negation / once via shared structurer

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_llvm_lowered_emitter.pl
@@ -70,6 +70,7 @@
 :- use_module(library(lists)).
 :- use_module(library(option)).
 :- use_module('../bindings/llvm_wam_bindings', [reg_name_to_index/2]).
+:- use_module(wam_ite_structurer, [structure_ite/2]).
 
 % NB: we DO NOT `:- use_module(wam_llvm_target, ...)` here, because
 % wam_llvm_target.pl `:- use_module`s this file in turn. The two
@@ -132,6 +133,49 @@ instr_from_parts(["retry_me_else", L], retry_me_else(L)).
 instr_from_parts(["trust_me"], trust_me).
 instr_from_parts(["jump", L], jump(L)).
 instr_from_parts(["cut_ite"], cut_ite).
+% ite_use_y_level(true) soft-cut form (the LLVM pipeline's default): a
+% get_level Yn snapshots the choice-point level into a permanent register
+% in the clause prefix; cut Yn commits to it. In the lowered (single
+% basic-block-graph) form there are no tracked choice points, so cut Yn is
+% the structural ITE commit (dropped by wam_ite_structurer's is_commit/1)
+% and get_level Yn is dead — emitted as a no-op (see emit_instr/4 below).
+instr_from_parts(["get_level", Yn], get_level(Yn)).
+instr_from_parts(["cut", Yn], cut(Yn)).
+
+% ----------------------------------------------------------------------------
+% Label-preserving parse (for if-then-else / negation / once lowering)
+%
+% The base parse_wam_text/2 above drops label lines (and the structural
+% try_me_else / trust_me / jump / cut_ite become no-ops once labels are
+% gone), which erases the LElse/LCont boundaries of an ITE block. The
+% lowered ITE path needs them, so it parses through parse_wam_text_labeled/2
+% which keeps label(Name) markers (as strings, so they unify with the
+% string arguments of try_me_else/jump) and then folds the stream with the
+% shared wam_ite_structurer. Mirrors the Rust/Clojure labeled parsers.
+% ----------------------------------------------------------------------------
+
+parse_wam_text_labeled(WamText, Instrs) :-
+    atom_string(WamText, S),
+    split_string(S, "\n", "", Lines),
+    parse_lines_labeled(Lines, Instrs).
+
+parse_lines_labeled([], []).
+parse_lines_labeled([Line|Rest], Instrs) :-
+    split_string(Line, " \t,", " \t,", Parts),
+    delete(Parts, "", CleanParts),
+    (   CleanParts == []
+    ->  parse_lines_labeled(Rest, Instrs)
+    ;   CleanParts = [First|_],
+        (   sub_string(First, _, 1, 0, ":")
+        ->  sub_string(First, 0, _, 1, LabelStr),   % strip trailing ':'
+            Instrs = [label(LabelStr)|More],
+            parse_lines_labeled(Rest, More)
+        ;   instr_from_parts(CleanParts, Instr)
+        ->  Instrs = [Instr|More],
+            parse_lines_labeled(Rest, More)
+        ;   parse_lines_labeled(Rest, Instrs)
+        )
+    ).
 
 % ============================================================================
 % Lowerability gate
@@ -169,6 +213,44 @@ wam_llvm_lowerable(_PI, WamCode, Shape) :-
     -> Shape = multi_clause_c1
     ;  Shape = single_clause
     ).
+% ITE / negation / once: clause 1 contains an internal choice point
+% (try_me_else) that is NOT a multi-clause separator but a soft-cut block
+% emitted for ( Cond -> Then ; Else ) / \+ Goal / once/1. The base path
+% above rejects it (is_deterministic_pred_llvm fails on the try_me_else);
+% here we accept it iff the labeled stream folds cleanly into structured
+% ite(...) blocks whose every leaf instruction is supported. Such a
+% predicate lowers as a single self-contained function (no bytecode
+% fallback needed), so Shape = single_clause.
+wam_llvm_lowerable(_PI, WamCode, single_clause) :-
+    llvm_structured_clause1(WamCode, Structured),
+    forall(member(I, Structured), llvm_supported_structured(I)).
+
+%% llvm_structured_clause1(+WamCode, -Structured) is semidet.
+%
+%  Parse the label-preserving stream, take clause 1's body, and fold its
+%  if-then-else blocks into ite(Cond,Then,Else) terms via the shared
+%  structurer. Fails (so the caller declines) for genuine multi-clause
+%  predicates — their try_me_else is the first instruction and/or the
+%  structurer cannot match a clean jump-terminated then-path.
+llvm_structured_clause1(WamCode, Structured) :-
+    ( is_list(WamCode) -> LInstrs = WamCode
+    ; parse_wam_text_labeled(WamCode, LInstrs)
+    ),
+    \+ ( LInstrs = [try_me_else(_)|_] ),    % not a predicate-level multi-clause
+    take_to_proceed(LInstrs, C1L),
+    structure_ite(C1L, Structured),
+    member(ite(_,_,_), Structured),         % there is at least one ITE to lower
+    \+ member(try_me_else(_), Structured),  % no choice point survived structuring
+    \+ member(retry_me_else(_), Structured),
+    \+ member(trust_me, Structured).
+
+%% llvm_supported_structured(+StructuredInstr) is semidet.
+%  Recurse through ite(Cond,Then,Else); plain instrs must be supported.
+llvm_supported_structured(ite(C, T, E)) :- !,
+    forall(member(I, C), llvm_supported_structured(I)),
+    forall(member(I, T), llvm_supported_structured(I)),
+    forall(member(I, E), llvm_supported_structured(I)).
+llvm_supported_structured(I) :- supported(I).
 
 is_deterministic_pred_llvm(Instrs) :-
     \+ member(try_me_else(_), Instrs),
@@ -287,6 +369,7 @@ supported(set_variable(_)).
 supported(set_value(_)).
 supported(allocate).
 supported(deallocate).
+supported(get_level(_)).   % no-op in lowered form (soft-cut is structural)
 supported(builtin_call(_, _)).
 supported(call(_, _)).         % M4 — direct call into another lowered kernel
 supported(execute(_)).         % M4 — tail call into another lowered kernel
@@ -342,6 +425,13 @@ llvm_safe_code(_, 0'_).
 %  through the trail naturally. Without this change, every nested
 %  call would need to package args as `%Value` and allocate a fresh
 %  state, defeating the perf benefit and breaking binding propagation.
+% ITE / negation / once predicates take the structured-emit path (basic
+% blocks with a soft-cut commit and trail-rollback else branch); everything
+% else takes the straight-line clause-1 path below, which is byte-for-byte
+% unchanged.
+lower_predicate_to_llvm(PI, WamCode, _Options, LLVMCode) :-
+    llvm_structured_clause1(WamCode, Structured), !,
+    lower_ite_predicate_to_llvm(PI, Structured, LLVMCode).
 lower_predicate_to_llvm(PI, WamCode, _Options, LLVMCode) :-
     ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     llvm_lowered_func_name(Pred/Arity, FuncName),
@@ -378,6 +468,141 @@ lowered_fail:
   ret i1 false
 }',
         [Pred, Arity, Arity, FuncName, BodyStr]).
+
+% ============================================================================
+% Structured (if-then-else / negation / once) emission
+%
+% Where the straight-line path chains one basic block per instruction with
+% every failure branching to %lowered_fail, the structured path emits an
+% ite(Cond,Then,Else) block as:
+%
+%   ite_<K>:                              ; capture pre-condition trail mark
+%     %ite_<K>.tmv = load <trail size>
+%     br label %<first cond block>
+%   <cond blocks: failure → ite_<K>_else, success → first then block>
+%   <then blocks: failure → outer fail, success → continuation>
+%   ite_<K>_else:                         ; condition failed: roll back, run else
+%     call void @unwind_trail(%vm, i32 %ite_<K>.tmv)
+%     br label %<first else block>
+%   <else blocks: failure → outer fail, success → continuation>
+%
+% Because the WAM state is a single mutable %WamState* (registers, heap and
+% trail are all mutated in place and every binding is trailed), unwinding
+% the trail to the pre-condition mark fully restores any partial bindings a
+% failed condition made — no phi nodes or register snapshots are needed
+% (mirrors the Rust emitter's vm.unwind_trail_to and the Go register copy).
+%
+% The per-instruction emitters are reused verbatim through emit_instr_f/5,
+% which simply redirects their hard-coded `%lowered_fail` branch to the
+% supplied failure label. Non-ITE output is therefore byte-identical.
+% ============================================================================
+
+%% lower_ite_predicate_to_llvm(+PI, +Structured, -LLVMCode) is det.
+lower_ite_predicate_to_llvm(PI, Structured, LLVMCode) :-
+    ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
+    llvm_lowered_func_name(Pred/Arity, FuncName),
+    nb_setval(wam_llvm_lowered_uid, 0),
+    emit_seq(Structured, 'lowered_fail', 'lowered_succeed', BodyStr, FirstLabel),
+    format(atom(LLVMCode),
+'; === lowered kernel (if-then-else / negation / once): ~w/~w ===
+; M4: takes a caller-supplied %WamState*. Each plain instruction lives in
+; its own basic block (pc_<N>); each ( Cond -> Then ; Else ) / \\+ / once
+; block lives in ite_<K>* blocks with a trail-rollback else branch. The
+; condition\'s commit (cut_ite / !/0) is structural and not emitted.
+define i1 @~w(%WamState* %vm) {
+entry:
+  br label %~w
+
+~w
+
+lowered_succeed:
+  ret i1 true
+
+lowered_fail:
+  ret i1 false
+}',
+        [Pred, Arity, FuncName, FirstLabel, BodyStr]).
+
+%% fresh_uid(-Uid) — monotonic counter for unique block / SSA names.
+fresh_uid(Uid) :-
+    nb_getval(wam_llvm_lowered_uid, Uid),
+    Uid1 is Uid + 1,
+    nb_setval(wam_llvm_lowered_uid, Uid1).
+
+%% item_entry_label(+Item, +Uid, -Label) — block a predecessor branches to.
+item_entry_label(ite(_,_,_), Uid, Label) :- !,
+    format(atom(Label), 'ite_~w', [Uid]).
+item_entry_label(_Plain, Uid, Label) :-
+    format(atom(Label), 'pc_~w', [Uid]).
+
+%% emit_seq(+Items, +FailLabel, +ContLabel, -Code, -FirstLabel) is det.
+%
+%  Chain a list of structured items (plain instrs and ite(...) blocks) into
+%  basic blocks. Each item's success flows to the next item's entry block,
+%  the last to ContLabel; each item's failure flows to FailLabel. FirstLabel
+%  is the entry block of the whole chain (ContLabel when the list is empty),
+%  so the caller can branch into it.
+emit_seq([], _Fail, ContLabel, '', ContLabel) :- !.
+emit_seq([Item|Rest], Fail, ContLabel, Code, FirstLabel) :-
+    fresh_uid(Uid),
+    item_entry_label(Item, Uid, FirstLabel),
+    emit_seq(Rest, Fail, ContLabel, RestCode, NextLabel),
+    emit_item(Item, Uid, Fail, NextLabel, ItemCode),
+    ( RestCode == ''
+    -> Code = ItemCode
+    ;  atomic_list_concat([ItemCode, RestCode], '\n', Code)
+    ).
+
+%% emit_item(+Item, +Uid, +FailLabel, +NextLabel, -Code) is det.
+%
+%  Plain instruction → one basic block (pc_<Uid>) via emit_instr_f/5.
+%  ite(Cond,Then,Else) → the entry/cond/then/else block group described
+%  in the section header above.
+emit_item(ite(Cond, Then, Else), Uid, Fail, Cont, Code) :- !,
+    format(atom(EntryLabel), 'ite_~w', [Uid]),
+    format(atom(ElseLabel),  'ite_~w_else', [Uid]),
+    % then/else flow to the shared continuation; their failures escape to
+    % the enclosing failure label.
+    emit_seq(Then, Fail, Cont, ThenCode, ThenFirst),
+    emit_seq(Else, Fail, Cont, ElseCode, ElseFirst),
+    % the condition's failure goes to the else block; success falls into
+    % the first then block.
+    emit_seq(Cond, ElseLabel, ThenFirst, CondCode, CondFirst),
+    % entry block: snapshot the trail length (struct field 9) before the
+    % condition runs, then enter the condition.
+    format(atom(EntryBlock),
+'~w:
+  ; ( Cond -> Then ; Else ) / negation / once  [block ~w]
+  %ite_~w.tm = getelementptr %WamState, %WamState* %vm, i32 0, i32 9
+  %ite_~w.tmv = load i32, i32* %ite_~w.tm
+  br label %~w',
+        [EntryLabel, Uid, Uid, Uid, Uid, CondFirst]),
+    % else preamble: roll back any bindings the failed condition made, then
+    % enter the else branch.
+    format(atom(ElseBlock),
+'~w:
+  ; condition failed -- unwind to pre-condition trail mark, run else
+  call void @unwind_trail(%WamState* %vm, i32 %ite_~w.tmv)
+  br label %~w',
+        [ElseLabel, Uid, ElseFirst]),
+    atomic_list_concat(
+        [EntryBlock, CondCode, ThenCode, ElseBlock, ElseCode], '\n', Code).
+emit_item(Instr, Uid, Fail, Next, Code) :-
+    emit_instr_f(Instr, Uid, Next, Fail, Code).
+
+%% emit_instr_f(+Instr, +N, +Next, +FailLabel, -Code) is det.
+%
+%  Emit a single instruction's basic block, redirecting its failure branch
+%  to FailLabel. Reuses the straight-line emit_instr/4 verbatim and rewrites
+%  its hard-coded `%lowered_fail` target. When FailLabel is the default
+%  'lowered_fail' this is byte-identical to emit_instr/4 (no rewrite).
+emit_instr_f(Instr, N, Next, lowered_fail, Code) :- !,
+    emit_instr(Instr, N, Next, Code).
+emit_instr_f(Instr, N, Next, FailLabel, Code) :-
+    emit_instr(Instr, N, Next, Code0),
+    atom_concat('%', FailLabel, FailRef),
+    atomic_list_concat(Parts, '%lowered_fail', Code0),
+    atomic_list_concat(Parts, FailRef, Code).
 
 build_param_list(0, "") :- !.
 build_param_list(Arity, ParamList) :-
@@ -444,6 +669,17 @@ emit_instr(fail, N, _Next, Block) :- !,
 'pc_~w:
   ; fail
   br label %lowered_fail', [N]).
+
+% --- get_level Yn: snapshot CP level (no-op in lowered form) ---
+% The soft cut is realised structurally by the basic-block layout (a failed
+% condition branches to the else block), so there is no choice-point level
+% to capture. Emit an empty block that falls through to the next instr.
+emit_instr(get_level(YnStr), N, Next, Block) :- !,
+    format(atom(Block),
+'pc_~w:
+  ; get_level ~w (no-op: soft cut is structural in the lowered form)
+  br label %~w',
+        [N, YnStr, Next]).
 
 % --- get_variable Xn, Ai: copy reg Ai → reg Xn ---
 emit_instr(get_variable(XnStr, AiStr), N, Next, Block) :- !,

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1328,9 +1328,12 @@ write_wam_llvm_project(Predicates, Options, OutputFile) :-
         interop_bridge=""
     ], FullModule),
 
-    % Write output file
+    % Write output file. The generated module embeds UTF-8 characters from
+    % the runtime templates (arrows, dashes in comments), so the stream must
+    % be UTF-8 regardless of the process locale (which is POSIX/ASCII in many
+    % CI containers) — otherwise format/3 raises an encoding error.
     setup_call_cleanup(
-        open(OutputFile, write, Stream),
+        open(OutputFile, write, Stream, [encoding(utf8)]),
         format(Stream, "~w", [FullModule]),
         close(Stream)
     ),
@@ -1396,7 +1399,7 @@ write_wam_llvm_wasm_project(Predicates, Options, OutputFile) :-
     ], FullModule),
 
     setup_call_cleanup(
-        open(OutputFile, write, Stream),
+        open(OutputFile, write, Stream, [encoding(utf8)]),
         format(Stream, "~w", [FullModule]),
         close(Stream)
     ),

--- a/tests/test_wam_llvm_lowered_ite.pl
+++ b/tests/test_wam_llvm_lowered_ite.pl
@@ -1,0 +1,119 @@
+% test_wam_llvm_lowered_ite.pl
+%
+% Structural tests for LLVM if-then-else / negation / once lowering
+% (the shared-structurer conversion that enabled ITE lowering for the
+% wam_llvm_lowered_emitter).
+%
+% LLVM previously did NOT lower any predicate whose clause 1 contained an
+% if-then-else (is_deterministic_pred_llvm/1 rejected the internal
+% try_me_else, and the soft-cut commit instructions were not in the
+% supported set), so such predicates fell back to the WAM bytecode
+% interpreter emitted in LLVM IR — sound, but not lowered. Wiring clause-1
+% emission through wam_ite_structurer emits native basic-block branching:
+% a condition block, a trail-rollback else block, and a shared
+% continuation.
+%
+% NOTE: the LLVM pipeline compiles ITE with ite_use_y_level(true) (the
+% default forced by compile_predicates_for_llvm/4), so the soft cut is the
+% `cut Yn` form preceded by a `get_level Yn` snapshot — NOT the naive
+% cut_ite. These tests therefore use that option to exercise the real path.
+%
+% These checks assert on the emitted LLVM *text* (the generated basic-block
+% structure). End-to-end compile+run verification (clang + the WAM runtime)
+% lives in tests/test_wam_llvm_lowered_ite_exec.pl and is gated on the LLVM
+% toolchain; this suite runs anywhere SWI-Prolog does.
+
+:- use_module(library(plunit)).
+:- use_module('../src/unifyweaver/targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../src/unifyweaver/targets/wam_llvm_lowered_emitter').
+
+:- dynamic user:lite/2.
+:- dynamic user:lneg/1.
+:- dynamic user:lseqite/3.
+:- dynamic user:lnestite/2.
+
+user:lite(X, Y)       :- ( X > 0 -> Y = pos ; Y = nonpos ).
+user:lneg(X)          :- \+ X > 0.
+user:lseqite(X, Y, Z) :- ( X > 0 -> Y = pos ; Y = nonpos ),
+                         ( X > 5 -> Z = big ; Z = small ).
+user:lnestite(X, Y)   :- ( X > 0 -> ( X > 10 -> Y = big ; Y = small ) ; Y = neg ).
+
+% Compile with ite_use_y_level(true) — the form the LLVM pipeline uses.
+ite_opts([ite_use_y_level(true)]).
+
+lowered_code(PI, Code) :-
+    ite_opts(Opts),
+    compile_predicate_to_wam(user:PI, Opts, W),
+    lower_predicate_to_llvm(PI, W, Opts, Code).
+
+count_substr(Str, Sub, N) :-
+    findall(x, sub_atom(Str, _, _, _, Sub), Xs),
+    length(Xs, N).
+
+:- begin_tests(wam_llvm_lowered_ite).
+
+% The gate now accepts ITE predicates as single-clause lowerable
+% (previously rejected on the internal try_me_else).
+test(all_lowerable) :-
+    ite_opts(Opts),
+    forall(member(PI, [lite/2, lneg/1, lseqite/3, lnestite/2]),
+           ( compile_predicate_to_wam(user:PI, Opts, W),
+             assertion(wam_llvm_lowerable(PI, W, single_clause)) )).
+
+% Simple ITE emits the condition / else-rollback / continuation block group
+% and no leftover structural markers.
+test(simple_ite_blocks) :-
+    lowered_code(lite/2, Code),
+    assertion(sub_atom(Code, _, _, _, 'ite_')),
+    assertion(sub_atom(Code, _, _, _, '_else:')),
+    assertion(sub_atom(Code, _, _, _, '@unwind_trail(%WamState* %vm')),
+    % no structural choice-point markers survived into the emitted body
+    % (the soft-cut commit is realised by the block layout, not an instr)
+    assertion(\+ sub_atom(Code, _, _, _, 'try_me_else')),
+    assertion(\+ sub_atom(Code, _, _, _, 'trust_me')).
+
+% The condition's failure branch is redirected to the else block (not the
+% function epilogue %lowered_fail).
+test(condition_branches_to_else) :-
+    lowered_code(lite/2, Code),
+    assertion(sub_atom(Code, _, _, _, ', label %ite_')).
+
+% Negation lowers with the !/0-commit shape: the then-arm is the fail/0
+% builtin, the else-arm the true/0 builtin.
+test(negation_uses_true_fail) :-
+    lowered_code(lneg/1, Code),
+    assertion(sub_atom(Code, _, _, _, 'builtin_call fail/0')),
+    assertion(sub_atom(Code, _, _, _, 'builtin_call true/0')),
+    assertion(sub_atom(Code, _, _, _, '@unwind_trail(%WamState* %vm')).
+
+% get_level Yn is emitted as a no-op (soft cut is structural).
+test(get_level_is_noop) :-
+    lowered_code(lite/2, Code),
+    assertion(sub_atom(Code, _, _, _, 'get_level')),
+    assertion(sub_atom(Code, _, _, _, 'no-op')).
+
+% Sequential ITE emits two sibling ite block groups.
+test(sequential_two_ites) :-
+    lowered_code(lseqite/3, Code),
+    count_substr(Code, '_else:', N),
+    assertion(N >= 2).
+
+% Nested ITE emits a nested ite group (inner block in the then-arm).
+test(nested_two_ites) :-
+    lowered_code(lnestite/2, Code),
+    count_substr(Code, '_else:', N),
+    assertion(N >= 2),
+    assertion(\+ sub_atom(Code, _, _, _, 'try_me_else')),
+    assertion(\+ sub_atom(Code, _, _, _, 'trust_me')).
+
+% Each lowered ITE function still defines the single shared succeed/fail
+% epilogue exactly once (no duplicate basic-block labels → valid SSA).
+test(single_epilogue) :-
+    lowered_code(lite/2, Code),
+    count_substr(Code, 'lowered_succeed:', NS),
+    count_substr(Code, 'lowered_fail:', NF),
+    assertion(NS =:= 1),
+    assertion(NF =:= 1).
+
+:- end_tests(wam_llvm_lowered_ite).

--- a/tests/test_wam_llvm_lowered_ite_exec.pl
+++ b/tests/test_wam_llvm_lowered_ite_exec.pl
@@ -1,0 +1,138 @@
+% test_wam_llvm_lowered_ite_exec.pl
+%
+% End-to-end execution test for LLVM if-then-else / negation / once lowering
+% (emit_mode(functions)).
+%
+% Generates a WAM LLVM module with the lowered emitter enabled, compiles it
+% with clang together with a small C harness that calls each lowered kernel
+% (lowered_<pred>_<arity>(%WamState*)) on a fresh state with the argument
+% registers set, and asserts the i1 (success/failure) outcome. Counterpart
+% to the Go, Rust, C++, Haskell, F# and Clojure exec tests. Pins:
+%
+%   * sequential ITEs   — lseqite(10,pos,small) must fail;
+%   * nested ITEs       — lnestite/2 (inner block in the then-arm);
+%   * negation (\+)      — lneg/1 (commit is the !/0 builtin, then=fail/0,
+%                          else=true/0, else runs after a trail rollback);
+%   * simple ITEs        — lite/2.
+%
+% LLVM previously did NOT lower any predicate with an if-then-else in clause 1
+% (the gate rejected the internal try_me_else and the soft-cut commit was not
+% in the supported set); the shared-structurer conversion enabled it. The
+% behaviour was already SOUND before this change — ITE predicates fell back to
+% the full WAM interpreter emitted in LLVM IR — so this verifies the native
+% basic-block lowering produces the same results. Skipped unless clang is on
+% PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+:- dynamic user:lite/2.
+:- dynamic user:lneg/1.
+:- dynamic user:lseqite/3.
+:- dynamic user:lnestite/2.
+
+user:lite(X, Y)       :- ( X > 0 -> Y = pos ; Y = nonpos ).
+user:lneg(X)          :- \+ X > 0.
+user:lseqite(X, Y, Z) :- ( X > 0 -> Y = pos ; Y = nonpos ),
+                         ( X > 5 -> Z = big ; Z = small ).
+user:lnestite(X, Y)   :- ( X > 0 -> ( X > 10 -> Y = big ; Y = small ) ; Y = neg ).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_llvm_lowered_ite_exec, [condition(clang_available)]).
+
+test(ite_exec_parity) :-
+    Dir = 'output/test_wam_llvm_ite_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    make_directory_path(Dir),
+    atomic_list_concat([Dir, '/iteproj.ll'], LLPath),
+    % 1. Generate the WAM LLVM module with the lowered emitter enabled.
+    write_wam_llvm_project(
+        [user:lite/2, user:lneg/1, user:lseqite/3, user:lnestite/2],
+        [module_name('iteproj'), emit_mode(functions)], LLPath),
+    % Sanity: the four predicates must have been lowered natively (not the
+    % WAM-interpreter fallback), otherwise the test would pass vacuously.
+    read_file_to_string(LLPath, LLSrc, []),
+    forall(member(F, ['@lowered_lite_2(', '@lowered_lneg_1(',
+                      '@lowered_lseqite_3(', '@lowered_lnestite_2(']),
+           assertion(sub_string(LLSrc, _, _, _, F))),
+    % 2. Write the C harness next to the module.
+    atomic_list_concat([Dir, '/harness.c'], HPath),
+    harness_source(HSrc),
+    setup_call_cleanup(open(HPath, write, S), write(S, HSrc), close(S)),
+    % 3. Compile (clang links the module + harness; -lm for the math builtins
+    %    referenced by the WAM arithmetic runtime) and run.
+    atomic_list_concat([Dir, '/ite_test'], ExePath),
+    format(atom(Cmd),
+        'clang -w ~w ~w -o ~w -lm 2>&1 && ~w',
+        [HPath, LLPath, ExePath, ExePath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 15 PASS")
+    ->  true
+    ;   format(user_error, "~n[llvm ite test output]~n~w~n", [OutStr]),
+        throw(llvm_test_failed(Status))
+    ).
+
+:- end_tests(wam_llvm_lowered_ite_exec).
+
+% Calls each lowered kernel directly on a fresh %WamState with the argument
+% registers set via @wam_set_reg_int / @wam_set_reg_atom_id. The atom ids
+% (pos=97, nonpos=98, big=99, small=100, neg=101) are the interned ids the
+% generated kernels compare against — passing the same id makes =/2 succeed,
+% a different id makes it fail. lseqite(10,pos,small)=false and the lnestite
+% rows are the sequential / nested discriminators.
+harness_source(
+"#include <stdio.h>
+typedef struct WamState WamState;
+extern WamState* wam_state_new(void* code, int n, int* labels, int nl);
+extern void wam_set_reg_int(WamState*, int, long);
+extern void wam_set_reg_atom_id(WamState*, int, long);
+extern unsigned char lowered_lite_2(WamState*);
+extern unsigned char lowered_lneg_1(WamState*);
+extern unsigned char lowered_lseqite_3(WamState*);
+extern unsigned char lowered_lnestite_2(WamState*);
+
+#define POS 97
+#define NONPOS 98
+#define BIG 99
+#define SMALL 100
+#define NEG 101
+
+static int fails = 0, total = 0;
+static WamState* mk(void){ return wam_state_new(0,0,0,0); }
+static int b(unsigned char r){ return r & 1; }
+static void check(const char* name, int got, int want){
+  total++;
+  if(got != want){ fails++; printf(\"FAIL %s: got %d want %d\\n\", name, got, want); }
+}
+
+int main(void){
+  WamState* s;
+  s=mk(); wam_set_reg_int(s,0,5);  wam_set_reg_atom_id(s,1,POS);    check(\"lite(5,pos)\",    b(lowered_lite_2(s)), 1);
+  s=mk(); wam_set_reg_int(s,0,5);  wam_set_reg_atom_id(s,1,NONPOS); check(\"lite(5,nonpos)\", b(lowered_lite_2(s)), 0);
+  s=mk(); wam_set_reg_int(s,0,-1); wam_set_reg_atom_id(s,1,NONPOS); check(\"lite(-1,nonpos)\",b(lowered_lite_2(s)), 1);
+  s=mk(); wam_set_reg_int(s,0,-1); wam_set_reg_atom_id(s,1,POS);    check(\"lite(-1,pos)\",   b(lowered_lite_2(s)), 0);
+  s=mk(); wam_set_reg_int(s,0,5);  check(\"lneg(5)\",  b(lowered_lneg_1(s)), 0);
+  s=mk(); wam_set_reg_int(s,0,-1); check(\"lneg(-1)\", b(lowered_lneg_1(s)), 1);
+  s=mk(); wam_set_reg_int(s,0,0);  check(\"lneg(0)\",  b(lowered_lneg_1(s)), 1);
+  s=mk(); wam_set_reg_int(s,0,10); wam_set_reg_atom_id(s,1,POS);    wam_set_reg_atom_id(s,2,BIG);   check(\"lseqite(10,pos,big)\",     b(lowered_lseqite_3(s)), 1);
+  s=mk(); wam_set_reg_int(s,0,10); wam_set_reg_atom_id(s,1,POS);    wam_set_reg_atom_id(s,2,SMALL); check(\"lseqite(10,pos,small)\",   b(lowered_lseqite_3(s)), 0);
+  s=mk(); wam_set_reg_int(s,0,3);  wam_set_reg_atom_id(s,1,POS);    wam_set_reg_atom_id(s,2,SMALL); check(\"lseqite(3,pos,small)\",    b(lowered_lseqite_3(s)), 1);
+  s=mk(); wam_set_reg_int(s,0,-1); wam_set_reg_atom_id(s,1,NONPOS); wam_set_reg_atom_id(s,2,SMALL); check(\"lseqite(-1,nonpos,small)\",b(lowered_lseqite_3(s)), 1);
+  s=mk(); wam_set_reg_int(s,0,20); wam_set_reg_atom_id(s,1,BIG);   check(\"lnestite(20,big)\",  b(lowered_lnestite_2(s)), 1);
+  s=mk(); wam_set_reg_int(s,0,5);  wam_set_reg_atom_id(s,1,SMALL); check(\"lnestite(5,small)\", b(lowered_lnestite_2(s)), 1);
+  s=mk(); wam_set_reg_int(s,0,-1); wam_set_reg_atom_id(s,1,NEG);   check(\"lnestite(-1,neg)\",  b(lowered_lnestite_2(s)), 1);
+  s=mk(); wam_set_reg_int(s,0,20); wam_set_reg_atom_id(s,1,SMALL); check(\"lnestite(20,small)\",b(lowered_lnestite_2(s)), 0);
+
+  if(fails==0) printf(\"ALL %d PASS\\n\", total);
+  else printf(\"%d FAILURES\\n\", fails);
+  return fails ? 1 : 0;
+}
+").


### PR DESCRIPTION
## Summary

Completes the WAM if-then-else / negation / once lowering parity sweep for the **LLVM** backend — the last and most complex of the "lowered" code-generation targets (after Go, Rust, C++, Haskell, F# and Clojure).

LLVM was already **sound**: predicates containing `( Cond -> Then ; Else )`, `\+ Goal` or `once/1` fell back to the full WAM interpreter emitted in LLVM IR, because the lowerability gate rejected the internal `try_me_else` and the soft-cut commit instructions were not in the supported set. This change makes them lower to **native LLVM basic blocks** instead. It is therefore a **perf optimization, not a correctness fix** — verified by the exec test producing identical results to the interpreter path.

## How it works

The WAM state is a single mutable `%WamState*` (registers, heap and trail are mutated in place and every binding is trailed), so each `ite(Cond,Then,Else)` lowers to a basic-block group with no phi nodes or register snapshots:

```
ite_<K>:        snapshot the trail length, enter the condition
<cond blocks>   failure → ite_<K>_else, success → the then block
<then blocks>   success → the shared continuation
ite_<K>_else:   @unwind_trail to the pre-condition mark, run the else
<else blocks>   success → the shared continuation
```

Unwinding the trail to the pre-condition mark fully restores any partial bindings a failed condition made (the same model the Rust emitter uses with `vm.unwind_trail_to`, and the Go emitter with its register copy).

## Key points

- **Byte-identical for non-ITE predicates.** The per-instruction emitters are reused verbatim through `emit_instr_f/5`, which only redirects their hard-coded `%lowered_fail` branch to the supplied failure label. `emit_all_instrs/3` and every existing `emit_instr/4` clause are untouched. Verified by diffing a deterministic predicate's lowered IR before/after the change (identical).
- **Shared structurer.** Clause-1 emission now goes through `wam_ite_structurer` via a new label-preserving parser (`parse_wam_text_labeled/2`), exactly like the sibling backends.
- **`ite_use_y_level(true)` form.** The LLVM pipeline forces this option, so the commit is `cut Yn` (recognised and dropped by the structurer's `is_commit/1`) preceded by a `get_level Yn` snapshot. `get_level` is parsed, marked supported, and emitted as a no-op (the soft cut is structural in the lowered form); `cut Yn` is parsed so the structurer can drop it.
- **UTF-8 project write.** `write_wam_llvm_project/3` now opens its output stream with `encoding(utf8)` so the UTF-8 characters in the runtime templates write correctly under a POSIX/ASCII process locale (otherwise `format/3` raised an encoding error).

## Tests

- `tests/test_wam_llvm_lowered_ite.pl` — structural checks on the emitted IR (block group, trail rollback, `get_level` no-op, no leftover `try_me_else`/`trust_me`, single epilogue). Runs anywhere SWI-Prolog does. **8/8 pass.**
- `tests/test_wam_llvm_lowered_ite_exec.pl` — gated on `clang`: generates the module, compiles it with a C harness that calls each lowered kernel on a fresh `%WamState`, and asserts the success/failure outcome across simple, sequential, nested ITE and negation (with trail rollback). **ALL 15 PASS.**
- Existing `test_wam_llvm_target` and `test_llvm_target` suites — still pass.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_