### PR TITLE
Enumerate unbound bagof/setof witness groups in WAM-C

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,15 +4,15 @@ Status date: 2026-06-06
 
 Latest branch verification:
 
-- `investigate/wam-c-bagof-setof-existential-surface` based on `main` at
-  `5e9967bc` (`Merge pull request #2850 from
-  s243a/investigate/wam-c-bagof-setof-witness-surface`)
+- `investigate/wam-c-bagof-setof-unbound-witness-groups` based on `main` at
+  `fff202ad` (`Merge pull request #2858 from
+  s243a/investigate/wam-c-bagof-setof-existential-surface`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-bagof-setof-existential-surface`
+- `investigate/wam-c-bagof-setof-unbound-witness-groups`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -86,6 +86,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | No-witness `bagof/3` and `setof/3` aggregate surface | Done | C parses the shared 4-field no-witness `begin_aggregate bagof/setof` form, `bagof/3` preserves duplicate solution order and fails empty, and `setof/3` sorts/deduplicates and fails empty |
 | Bound-witness `bagof/3` and `setof/3` grouping | Done | C parses witness register lists into aggregate payload arrays, copies witness tuples per aggregate item, selects the caller-bound witness group, and covers grouped `bagof/3` order plus grouped `setof/3` sort/dedup in an executable smoke |
 | Existential `^/2` aggregate body lowering | Done | Goal-level `^/2` wrappers are transparent in inner call positions, witness discovery still suppresses quantified variables, and the C executable smoke covers flattened existential `bagof/3` plus sorted/deduplicated existential `setof/3` |
+| Unbound-witness `bagof/3` and `setof/3` group enumeration | Done | C retains aggregate groups behind a backtrackable iterator, binds each witness/result group through a synthetic aggregate-group choicepoint, and covers outer `findall/3` consuming all grouped `bagof/3` and `setof/3` alternatives |
 
 ## Current C Target Baseline
 
@@ -143,7 +144,8 @@ The C target is now a credible small WAM backend:
   result lists, helper-nested aggregate calls, direct inline nested `findall/3`
   bodies, compound/list templates, no-witness `bagof/3` / `setof/3`,
   caller-bound witness grouping for `bagof/3` / `setof/3`, and
-  existential `^/2` suppression inside inline `bagof/3` / `setof/3` bodies.
+  existential `^/2` suppression plus unbound witness group enumeration inside
+  inline `bagof/3` / `setof/3` bodies.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -166,7 +168,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Second-arg indexing | Partial | Partial/Done | Partial/Done | C has constant A2 dispatch; broaden tests if this becomes hot. |
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
 | Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
-| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness, caller-bound witness, and existential `^/2` `bagof/3` / `setof/3`; remaining gaps are unbound witness group enumeration, meta-call aggregate dispatch, and broader aggregate forms. |
+| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness, caller-bound witness, existential `^/2`, and unbound witness group enumeration for inline `bagof/3` / `setof/3`; remaining gaps are meta-call aggregate dispatch and broader aggregate forms. |
 | Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, precise `get_level`/`cut` if-then-else, explicit `!/0` scoped to the current predicate call barrier, and generated `forall/2` soft-cut rewrites; residual work should be driven by concrete meta-control demand. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
@@ -180,6 +182,36 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-bagof-setof-unbound-witness-groups`
+
+Goal: make inline `bagof/3` and `setof/3` enumerate all unbound witness groups
+on backtracking instead of returning only the first discovered group.
+
+Evidence:
+
+- The C runtime now has a retained aggregate-group iterator stack and a
+  synthetic aggregate-group choicepoint target.
+- Choicepoint snapshots preserve the iterator depth, and pruning trims stale
+  iterators so cuts and top-level query cleanup do not leave retained groups
+  behind.
+- Aggregate finalization partitions collected template rows by witness tuple
+  when witness registers are unbound, binds the first group immediately, and
+  leaves later groups as backtrackable alternatives.
+- The real-Prolog executable smoke compiles grouped `bagof/3` and `setof/3`
+  helper predicates, then uses an outer `findall/3` to consume every witness
+  group. It verifies grouped `bagof/3` preserves row order and grouped
+  `setof/3` sorts/deduplicates each group.
+
+Reason:
+
+- The previous branches closed no-witness, caller-bound witness, and
+  existential suppression semantics.
+- Full unbound witness enumeration was the remaining inline aggregate semantic
+  gap and required runtime state rather than another compiler-only lowering.
+- Meta-call aggregate dispatch remains separate because it requires runtime
+  goal-term execution for `findall/3`, `bagof/3`, and `setof/3` calls that are
+  not inlined by the compiler.
 
 ### Completed: `investigate/wam-c-bagof-setof-existential-surface`
 
@@ -204,9 +236,10 @@ Reason:
   register is supplied by the caller.
 - Existential suppression is the complementary case: it removes a variable from
   grouping and can reuse the no-witness aggregate finalizer.
-- Full unbound witness group enumeration remains a larger runtime-choicepoint
-  feature, so this branch deliberately avoids introducing resumable aggregate
-  group alternatives.
+- The follow-up
+  `investigate/wam-c-bagof-setof-unbound-witness-groups` branch adds the
+  runtime iterator and choicepoint machinery for full unbound group
+  enumeration.
 
 ### Completed: `investigate/wam-c-bagof-setof-witness-surface`
 
@@ -229,11 +262,8 @@ Reason:
 
 - The previous branch proved the no-witness aggregate semantics and stored-term
   sorting/deduplication path.
-- Full ISO-style unbound witness enumeration would require the C runtime to
-  leave resumable group alternatives. This branch deliberately handles the
-  caller-bound witness case first, while the follow-up
-  `investigate/wam-c-bagof-setof-existential-surface` covers existential
-  suppression without expanding the choicepoint model.
+- This branch deliberately handled the caller-bound witness case first. Follow
+  ups cover existential suppression and full unbound witness group enumeration.
 
 ### Completed: `investigate/wam-c-bagof-setof-aggregate-surface`
 
@@ -258,9 +288,8 @@ Reason:
 
 - Direct inline nested `findall/3` proved that nested aggregate frames and local
   aggregate result variables work in C.
-- Follow-up branches cover caller-bound witness grouping and inner existential
-  `^/2` suppression. Unbound witness group enumeration remains the larger
-  semantic surface.
+- Follow-up branches cover caller-bound witness grouping, inner existential
+  `^/2` suppression, and full unbound witness group enumeration.
 
 ### Completed: `investigate/wam-c-inline-nested-findall-lowering`
 
@@ -1148,12 +1177,14 @@ Evidence:
 
 ## Suggested Immediate Next Step
 
-The aggregate parity sequence now has no-witness, caller-bound witness, and
-existential `^/2` inline `bagof/3` / `setof/3` coverage. The next aggregate
-feature worth considering is full unbound witness group enumeration, using the
-C++ or Elixir iterator/choicepoint designs as references. Keep that as a
-separate branch because it needs resumable aggregate group alternatives rather
-than only compile-time wrapper stripping or single-shot finalization.
+The aggregate parity sequence now has no-witness, caller-bound witness,
+existential `^/2`, and unbound witness group enumeration coverage for inline
+`bagof/3` / `setof/3`. The next aggregate feature worth considering is
+meta-call aggregate dispatch, where runtime calls to `findall/3`, `bagof/3`,
+and `setof/3` execute through the aggregate machinery even without
+`inline_bagof_setof(true)`. Keep that separate because it needs goal-term
+dispatch and witness discovery at runtime rather than only generated WAM
+aggregate opcodes.
 
 For the effective-distance/CSR line, result-capped and sampled runs already
 confirm child-CSR variants agree, and parent plus child reachability prefilters

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -24,6 +24,7 @@
 #define WAM_CALL_STACK_SIZE 1024
 #define WAM_AGGREGATE_STACK_SIZE 32
 #define WAM_AGGREGATE_MAX_WITNESSES 8
+#define WAM_AGGREGATE_NEXT_GROUP -3
 
 typedef struct WamState WamState;
 typedef bool (*WamForeignHandler)(WamState *state, const char *pred, int arity);
@@ -59,6 +60,7 @@ typedef struct {
     int trail_size;
     int stack_size;
     int call_base_top;
+    int aggregate_group_top;
     int arity;
     WamValue a_regs[32]; // Reduced from MAX_REGS to save memory (typical max arity)
 } ChoicePoint;
@@ -88,6 +90,23 @@ typedef struct {
     int witness_regs[WAM_AGGREGATE_MAX_WITNESSES];
     int witness_is_y[WAM_AGGREGATE_MAX_WITNESSES];
 } WamAggregateFrame;
+
+typedef struct {
+    const char *kind;
+    int return_pc;
+    int result_reg;
+    int result_is_y;
+    WamStoredTerm *items;
+    WamStoredTerm *witnesses;
+    int item_count;
+    int item_cap;
+    int witness_count;
+    int witness_regs[WAM_AGGREGATE_MAX_WITNESSES];
+    int witness_is_y[WAM_AGGREGATE_MAX_WITNESSES];
+    int *group_reps;
+    int group_count;
+    int next_group;
+} WamAggregateGroupIterator;
 
 /* Environment Frame */
 typedef struct {
@@ -352,6 +371,8 @@ struct WamState {
     /* Aggregate/findall frames */
     WamAggregateFrame aggregate_frames[WAM_AGGREGATE_STACK_SIZE];
     int aggregate_top;
+    WamAggregateGroupIterator aggregate_group_iters[WAM_AGGREGATE_STACK_SIZE];
+    int aggregate_group_top;
 
     /* Native category_ancestor kernel data */
     CategoryEdge *category_edges;
@@ -796,6 +817,37 @@ static inline bool wam_unify(WamState *state, WamValue *v1, WamValue *v2) {
     }
     return true;
 }
+
+static inline void wam_stored_term_inline_free(WamStoredTerm *term) {
+    free(term->cells);
+    memset(term, 0, sizeof(WamStoredTerm));
+}
+
+static inline void wam_aggregate_group_iterator_free(WamAggregateGroupIterator *iter) {
+    for (int i = 0; i < iter->item_count; i++) {
+        wam_stored_term_inline_free(&iter->items[i]);
+        if (iter->witnesses) {
+            wam_stored_term_inline_free(&iter->witnesses[i]);
+        }
+    }
+    free(iter->items);
+    free(iter->witnesses);
+    free(iter->group_reps);
+    memset(iter, 0, sizeof(WamAggregateGroupIterator));
+}
+
+static inline void wam_trim_aggregate_group_iters(WamState *state, int target_top) {
+    if (target_top < 0) target_top = 0;
+    if (target_top > state->aggregate_group_top) {
+        target_top = state->aggregate_group_top;
+    }
+    while (state->aggregate_group_top > target_top) {
+        state->aggregate_group_top--;
+        wam_aggregate_group_iterator_free(
+            &state->aggregate_group_iters[state->aggregate_group_top]);
+    }
+}
+
 static inline void push_choice_point(WamState *state, int next_pc, int arity) {
     if (state->B >= state->B_cap) {
         state->B_cap = state->B_cap ? state->B_cap * 2 : WAM_INITIAL_CAP;
@@ -808,6 +860,7 @@ static inline void push_choice_point(WamState *state, int next_pc, int arity) {
     cp->trail_size = state->TR;
     cp->stack_size = state->E;
     cp->call_base_top = state->call_base_top;
+    cp->aggregate_group_top = state->aggregate_group_top;
     
     int save_arity = arity < 32 ? arity : 32;
     cp->arity = save_arity;
@@ -827,6 +880,7 @@ static inline void restore_choice_point(WamState *state, ChoicePoint *cp) {
     state->E = cp->stack_size;
     state->CP = cp->cp;
     state->call_base_top = cp->call_base_top;
+    wam_trim_aggregate_group_iters(state, cp->aggregate_group_top);
     unwind_trail(state, cp->trail_size);
     memcpy(state->A, cp->a_regs, sizeof(WamValue) * cp->arity);
 }
@@ -841,9 +895,14 @@ static inline void pop_choice_point(WamState *state) {
     }
 }
 static inline void wam_prune_choice_points(WamState *state, int target_b) {
+    int target_group_top = 0;
+    if (target_b > 0 && target_b <= state->B) {
+        target_group_top = state->B_array[target_b - 1].aggregate_group_top;
+    }
     while (state->B > target_b) {
         pop_choice_point(state);
     }
+    wam_trim_aggregate_group_iters(state, target_group_top);
 }
 static inline void update_choice_point(WamState *state, int next_pc) {
     if (state->B > 0) {

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -2528,12 +2528,22 @@ compile_step_wam_to_c(_Options, CCode) :-
         while (state->P >= 0 && state->P < state->code_size) {
             Instruction* instr = &state->code[state->P];
             if (!step_wam(state, instr)) {
-                if (state->B == 0) {
+                bool recovered = false;
+                while (state->B > 0 && !recovered) {
+                    ChoicePoint* cp = &state->B_array[state->B - 1];
+                    int next_pc = cp->next_pc;
+                    restore_choice_point(state, cp); // Restores H, E, CP, A, unwinds TR
+                    if (next_pc == WAM_AGGREGATE_NEXT_GROUP) {
+                        pop_choice_point(state);
+                        recovered = wam_bind_next_aggregate_group(state);
+                    } else {
+                        state->P = next_pc; // Explicitly jump to alternative
+                        recovered = true;
+                    }
+                }
+                if (!recovered) {
                     return WAM_HALT; // Failure, no choice points left
                 }
-                ChoicePoint* cp = &state->B_array[state->B - 1];
-                restore_choice_point(state, cp); // Restores H, E, CP, A, unwinds TR
-                state->P = cp->next_pc; // Explicitly jump to alternative
             }
         }
         return (state->P == WAM_HALT) ? 0 : WAM_ERR_OOB; // 0 on success (HALT), else OOB error
@@ -2981,6 +2991,38 @@ static bool wam_build_witness_group_indices(WamAggregateFrame *frame,
     return true;
 }
 
+static bool wam_build_witness_group_reps(WamAggregateFrame *frame,
+                                         int **reps_out,
+                                         int *group_count_out) {
+    if (frame->item_count <= 0) {
+        *reps_out = NULL;
+        *group_count_out = 0;
+        return true;
+    }
+    int *reps = malloc(sizeof(int) * (size_t)frame->item_count);
+    if (!reps) return false;
+    int group_count = 0;
+    for (int i = 0; i < frame->item_count; i++) {
+        bool seen = false;
+        for (int g = 0; g < group_count; g++) {
+            int rep = reps[g];
+            if (wam_compare_stored_value(&frame->witnesses[rep],
+                                         frame->witnesses[rep].root,
+                                         &frame->witnesses[i],
+                                         frame->witnesses[i].root) == 0) {
+                seen = true;
+                break;
+            }
+        }
+        if (!seen) {
+            reps[group_count++] = i;
+        }
+    }
+    *reps_out = reps;
+    *group_count_out = group_count;
+    return true;
+}
+
 static bool wam_materialize_witness_component(WamState *state,
                                               WamStoredTerm *witness,
                                               int witness_count,
@@ -3022,6 +3064,116 @@ static bool wam_unify_witness_registers_from_group(WamState *state,
     return true;
 }
 
+static bool wam_bind_aggregate_group(WamState *state,
+                                     WamAggregateGroupIterator *iter,
+                                     int group_index) {
+    if (group_index < 0 || group_index >= iter->group_count) return false;
+    int selected_index = iter->group_reps[group_index];
+    WamAggregateFrame frame_view;
+    memset(&frame_view, 0, sizeof(WamAggregateFrame));
+    frame_view.kind = iter->kind;
+    frame_view.result_reg = iter->result_reg;
+    frame_view.result_is_y = iter->result_is_y;
+    frame_view.items = iter->items;
+    frame_view.witnesses = iter->witnesses;
+    frame_view.item_count = iter->item_count;
+    frame_view.item_cap = iter->item_cap;
+    frame_view.witness_count = iter->witness_count;
+    for (int i = 0; i < iter->witness_count; i++) {
+        frame_view.witness_regs[i] = iter->witness_regs[i];
+        frame_view.witness_is_y[i] = iter->witness_is_y[i];
+    }
+
+    int *indices = NULL;
+    int index_count = 0;
+    if (!wam_build_witness_group_indices(&frame_view, selected_index,
+                                         &indices, &index_count)) return false;
+    if (strcmp(iter->kind, "setof") == 0) {
+        wam_sort_aggregate_item_indices(&frame_view, indices, index_count);
+        index_count =
+            wam_dedup_sorted_aggregate_item_indices(&frame_view, indices,
+                                                    index_count);
+    }
+
+    WamValue result_list;
+    bool witness_ok =
+        wam_unify_witness_registers_from_group(state, &frame_view,
+                                               selected_index);
+    bool list_ok = witness_ok &&
+        wam_build_aggregate_list_from_indices(state, &frame_view, indices,
+                                              index_count, &result_list);
+    free(indices);
+    if (!list_ok) return false;
+
+    WamValue *result_cell =
+        resolve_reg(state, iter->result_reg, iter->result_is_y);
+    if (!wam_unify(state, result_cell, &result_list)) return false;
+    state->P = iter->return_pc;
+    return true;
+}
+
+static bool wam_bind_next_aggregate_group(WamState *state) {
+    if (state->aggregate_group_top <= 0) return false;
+    WamAggregateGroupIterator *iter =
+        &state->aggregate_group_iters[state->aggregate_group_top - 1];
+    if (iter->next_group >= iter->group_count) {
+        state->aggregate_group_top--;
+        wam_aggregate_group_iterator_free(iter);
+        return false;
+    }
+
+    int group_index = iter->next_group++;
+    bool has_more = iter->next_group < iter->group_count;
+    int return_pc = iter->return_pc;
+    if (has_more) {
+        push_choice_point(state, WAM_AGGREGATE_NEXT_GROUP, 32);
+    }
+
+    bool ok = wam_bind_aggregate_group(state, iter, group_index);
+    if (!has_more) {
+        state->aggregate_group_top--;
+        wam_aggregate_group_iterator_free(iter);
+    }
+    if (ok) {
+        state->P = return_pc;
+    }
+    return ok;
+}
+
+static bool wam_push_aggregate_group_iterator(WamState *state,
+                                              WamAggregateFrame *frame,
+                                              int *group_reps,
+                                              int group_count,
+                                              int return_pc) {
+    if (state->aggregate_group_top >= WAM_AGGREGATE_STACK_SIZE) return false;
+    WamAggregateGroupIterator *iter =
+        &state->aggregate_group_iters[state->aggregate_group_top];
+    wam_aggregate_group_iterator_free(iter);
+    iter->kind = frame->kind;
+    iter->return_pc = return_pc;
+    iter->result_reg = frame->result_reg;
+    iter->result_is_y = frame->result_is_y;
+    iter->items = frame->items;
+    iter->witnesses = frame->witnesses;
+    iter->item_count = frame->item_count;
+    iter->item_cap = frame->item_cap;
+    iter->witness_count = frame->witness_count;
+    for (int i = 0; i < frame->witness_count; i++) {
+        iter->witness_regs[i] = frame->witness_regs[i];
+        iter->witness_is_y[i] = frame->witness_is_y[i];
+    }
+    iter->group_reps = group_reps;
+    iter->group_count = group_count;
+    iter->next_group = 0;
+    state->aggregate_group_top++;
+
+    frame->items = NULL;
+    frame->witnesses = NULL;
+    frame->item_count = 0;
+    frame->item_cap = 0;
+    return true;
+}
+
 static void wam_aggregate_frame_free(WamAggregateFrame *frame) {
     for (int i = 0; i < frame->item_count; i++) {
         wam_stored_term_free(&frame->items[i]);
@@ -3039,6 +3191,7 @@ static void wam_aggregate_clear_all(WamState *state) {
         state->aggregate_top--;
         wam_aggregate_frame_free(&state->aggregate_frames[state->aggregate_top]);
     }
+    wam_trim_aggregate_group_iters(state, 0);
 }
 
 static bool wam_aggregate_append_item(WamState *state,
@@ -3138,6 +3291,27 @@ static bool wam_finalize_aggregate_frame(WamState *state,
 
     WamValue result_list;
     if (frame->witness_count > 0) {
+        if (!wam_witness_regs_are_bound(state, frame)) {
+            int *group_reps = NULL;
+            int group_count = 0;
+            if (!wam_build_witness_group_reps(frame, &group_reps,
+                                              &group_count)) return false;
+            if (group_count <= 0) {
+                free(group_reps);
+                wam_aggregate_frame_free(frame);
+                state->aggregate_top = frame_index;
+                state->P = next_pc;
+                return false;
+            }
+            if (!wam_push_aggregate_group_iterator(state, frame, group_reps,
+                                                   group_count, next_pc)) {
+                free(group_reps);
+                return false;
+            }
+            memset(frame, 0, sizeof(WamAggregateFrame));
+            state->aggregate_top = frame_index;
+            return wam_bind_next_aggregate_group(state);
+        }
         int selected_index = wam_select_aggregate_witness_group(state, frame);
         if (selected_index < 0) {
             wam_aggregate_frame_free(frame);

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -1755,6 +1755,16 @@ test_real_prolog_bagof_setof_existential_executable_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_real_prolog_bagof_setof_unbound_witness_groups_smoke :-
+    Test = 'WAM-C: real Prolog bagof/3 and setof/3 unbound witness groups smoke',
+    (   gcc_available
+    ->  (   run_real_prolog_bagof_setof_unbound_witness_groups_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'real Prolog unbound witness groups executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_real_prolog_classic_recursive_executable_smoke :-
     Test = 'WAM-C: real Prolog classic recursive executable smoke',
     (   gcc_available
@@ -3052,6 +3062,73 @@ cleanup_wam_c_bagof_setof_existential_smoke :-
     retractall(user:wam_c_exist_pair(_, _)),
     retractall(user:wam_c_exist_bag(_)),
     retractall(user:wam_c_exist_set(_)).
+
+run_real_prolog_bagof_setof_unbound_witness_groups_smoke :-
+    Options = [inline_bagof_setof(true)],
+    assertz((user:wam_c_uw_pair(b, red) :- true)),
+    assertz((user:wam_c_uw_pair(a, red) :- true)),
+    assertz((user:wam_c_uw_pair(c, blue) :- true)),
+    assertz((user:wam_c_uw_pair(d, blue) :- true)),
+    assertz((user:wam_c_uw_bag(Y, L) :-
+        bagof(X, wam_c_uw_pair(X, Y), L))),
+    assertz((user:wam_c_uw_set(Y, L) :-
+        setof(X, wam_c_uw_pair(X, Y), L))),
+    assertz((user:wam_c_uw_bag_groups_ok :-
+        findall(Y-L, wam_c_uw_bag(Y, L), Groups),
+        Groups = [red-[b, a], blue-[c, d]])),
+    assertz((user:wam_c_uw_set_groups_ok :-
+        findall(Y-L, wam_c_uw_set(Y, L), Groups),
+        Groups = [red-[a, b], blue-[c, d]])),
+    (   compile_predicate_to_wam(user:wam_c_uw_pair/2, Options, WamPair),
+        compile_predicate_to_wam(user:wam_c_uw_bag/2, Options, WamBag),
+        compile_predicate_to_wam(user:wam_c_uw_set/2, Options, WamSet),
+        compile_predicate_to_wam(user:wam_c_uw_bag_groups_ok/0, Options, WamBagGroups),
+        compile_predicate_to_wam(user:wam_c_uw_set_groups_ok/0, Options, WamSetGroups),
+        sub_string(WamBag, _, _, _, 'begin_aggregate bagof'),
+        sub_string(WamBag, _, _, _, "'Y"),
+        \+ sub_string(WamBag, _, _, _, 'call bagof/3'),
+        sub_string(WamSet, _, _, _, 'begin_aggregate setof'),
+        sub_string(WamSet, _, _, _, "'Y"),
+        \+ sub_string(WamSet, _, _, _, 'call setof/3'),
+        sub_string(WamBagGroups, _, _, _, 'begin_aggregate collect'),
+        sub_string(WamBagGroups, _, _, _, 'call wam_c_uw_bag/2'),
+        sub_string(WamSetGroups, _, _, _, 'begin_aggregate collect'),
+        sub_string(WamSetGroups, _, _, _, 'call wam_c_uw_set/2'),
+        compile_wam_predicate_to_c(user:wam_c_uw_pair/2, WamPair, Options, PairCode),
+        compile_wam_predicate_to_c(user:wam_c_uw_bag/2, WamBag, Options, BagCode),
+        compile_wam_predicate_to_c(user:wam_c_uw_set/2, WamSet, Options, SetCode),
+        compile_wam_predicate_to_c(user:wam_c_uw_bag_groups_ok/0, WamBagGroups, Options, BagGroupsCode),
+        compile_wam_predicate_to_c(user:wam_c_uw_set_groups_ok/0, WamSetGroups, Options, SetGroupsCode),
+        atomic_list_concat([PairCode, BagCode, SetCode,
+                            BagGroupsCode, SetGroupsCode],
+                           '\n\n',
+                           PredCode),
+        compile_wam_runtime_to_c([], RuntimeCode),
+        get_time(Now),
+        Stamp is round(Now * 1000000),
+        wam_c_temp_path('unifyweaver_wam_c_bagof_setof_unbound_witness_smoke', Stamp, TmpBase),
+        format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+        format(atom(PredPath), '~w_pred.c', [TmpBase]),
+        format(atom(MainPath), '~w_main.c', [TmpBase]),
+        format(atom(ExePath), '~w_bin', [TmpBase]),
+        write_text_file(RuntimePath, RuntimeCode),
+        format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+        write_text_file(PredPath, PredTranslationUnit),
+        wam_c_bagof_setof_unbound_witness_groups_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_bagof_setof_unbound_witness_groups_smoke
+    ;   cleanup_wam_c_bagof_setof_unbound_witness_groups_smoke,
+        fail
+    ).
+
+cleanup_wam_c_bagof_setof_unbound_witness_groups_smoke :-
+    retractall(user:wam_c_uw_pair(_, _)),
+    retractall(user:wam_c_uw_bag(_, _)),
+    retractall(user:wam_c_uw_set(_, _)),
+    retractall(user:wam_c_uw_bag_groups_ok),
+    retractall(user:wam_c_uw_set_groups_ok).
 
 run_real_prolog_classic_recursive_executable_smoke :-
     assertz((user:wam_c_classic_fib(0, 0) :- true)),
@@ -6538,6 +6615,45 @@ int main(void) {
 }
 ').
 
+wam_c_bagof_setof_unbound_witness_groups_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_uw_pair_2(WamState* state);
+void setup_wam_c_uw_bag_2(WamState* state);
+void setup_wam_c_uw_set_2(WamState* state);
+void setup_wam_c_uw_bag_groups_ok_0(WamState* state);
+void setup_wam_c_uw_set_groups_ok_0(WamState* state);
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_uw_pair_2(&state);
+    setup_wam_c_uw_bag_2(&state);
+    setup_wam_c_uw_set_2(&state);
+    setup_wam_c_uw_bag_groups_ok_0(&state);
+    setup_wam_c_uw_set_groups_ok_0(&state);
+
+    int bag_rc = wam_run_predicate(&state, "wam_c_uw_bag_groups_ok/0", NULL, 0);
+    if (bag_rc != 0 || state.P != WAM_HALT ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    int set_rc = wam_run_predicate(&state, "wam_c_uw_set_groups_ok/0", NULL, 0);
+    if (set_rc != 0 || state.P != WAM_HALT ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_classic_fib_smoke_main(
 '#include "wam_runtime.h"
 
@@ -6755,6 +6871,7 @@ run_tests_once :-
     test_real_prolog_bagof_setof_executable_smoke,
     test_real_prolog_bagof_setof_witness_executable_smoke,
     test_real_prolog_bagof_setof_existential_executable_smoke,
+    test_real_prolog_bagof_setof_unbound_witness_groups_smoke,
     test_real_prolog_classic_recursive_executable_smoke,
     test_lowered_fact_helper_executable_smoke,
     test_lowered_body_call_helper_executable_smoke,


### PR DESCRIPTION
  ## Summary
  - Add a retained WAM-C aggregate group iterator and synthetic aggregate-group backtracking target.
  - Preserve iterator depth in choicepoint snapshots and trim stale iterators during pruning/cleanup.
  - Make inline `bagof/3` and `setof/3` with unbound witnesses enumerate all witness groups on backtracking.
  - Add executable coverage where outer `findall/3` consumes every grouped `bagof/3` and `setof/3` alternative.
  - Update the WAM-C roadmap to mark unbound witness group enumeration complete.

  ## Validation
  - `git diff --check`
  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`