### PR TITLE
Dispatch WAM-C aggregate meta calls

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,15 +4,15 @@ Status date: 2026-06-06
 
 Latest branch verification:
 
-- `investigate/wam-c-bagof-setof-unbound-witness-groups` based on `main` at
-  `fff202ad` (`Merge pull request #2858 from
-  s243a/investigate/wam-c-bagof-setof-existential-surface`)
+- `investigate/wam-c-meta-aggregate-dispatch` based on `main` at `993ff338`
+  (`Merge pull request #2861 from
+  s243a/investigate/wam-c-bagof-setof-unbound-witness-groups`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-bagof-setof-unbound-witness-groups`
+- `investigate/wam-c-meta-aggregate-dispatch`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -87,6 +87,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Bound-witness `bagof/3` and `setof/3` grouping | Done | C parses witness register lists into aggregate payload arrays, copies witness tuples per aggregate item, selects the caller-bound witness group, and covers grouped `bagof/3` order plus grouped `setof/3` sort/dedup in an executable smoke |
 | Existential `^/2` aggregate body lowering | Done | Goal-level `^/2` wrappers are transparent in inner call positions, witness discovery still suppresses quantified variables, and the C executable smoke covers flattened existential `bagof/3` plus sorted/deduplicated existential `setof/3` |
 | Unbound-witness `bagof/3` and `setof/3` group enumeration | Done | C retains aggregate groups behind a backtrackable iterator, binds each witness/result group through a synthetic aggregate-group choicepoint, and covers outer `findall/3` consuming all grouped `bagof/3` and `setof/3` alternatives |
+| Runtime aggregate meta-call dispatch | Done | C dispatches non-inline runtime `findall/3`, `bagof/3`, and `setof/3` calls through meta aggregate frames, invokes simple callable goal terms, and covers non-inline `bagof/3` / `setof/3` executable smoke without `inline_bagof_setof(true)` |
 
 ## Current C Target Baseline
 
@@ -139,13 +140,14 @@ The C target is now a credible small WAM backend:
   `=/2`, negation, legacy `cut_ite` if-then-else, and precise
   `get_level`/`cut` if-then-else, explicit `!/0` call-scope behavior, and
   `forall/2`'s generated soft-cut rewrite.
-- Supports the first aggregate surface: generated `findall/3` lowering through
+- Supports aggregate surfaces: generated `findall/3` lowering through
   `begin_aggregate collect` / `end_aggregate`, including empty and non-empty
   result lists, helper-nested aggregate calls, direct inline nested `findall/3`
   bodies, compound/list templates, no-witness `bagof/3` / `setof/3`,
   caller-bound witness grouping for `bagof/3` / `setof/3`, and
   existential `^/2` suppression plus unbound witness group enumeration inside
-  inline `bagof/3` / `setof/3` bodies.
+  inline `bagof/3` / `setof/3` bodies. It also has runtime meta-call dispatch
+  for non-inline aggregate calls over simple callable goal terms.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -168,7 +170,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Second-arg indexing | Partial | Partial/Done | Partial/Done | C has constant A2 dispatch; broaden tests if this becomes hot. |
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
 | Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
-| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness, caller-bound witness, existential `^/2`, and unbound witness group enumeration for inline `bagof/3` / `setof/3`; remaining gaps are meta-call aggregate dispatch and broader aggregate forms. |
+| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness, caller-bound witness, existential `^/2`, and unbound witness group enumeration for inline `bagof/3` / `setof/3`; runtime meta-call aggregate dispatch now covers simple callable goals, while conjunction/disjunction and broader meta-goal forms remain gaps. |
 | Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, precise `get_level`/`cut` if-then-else, explicit `!/0` scoped to the current predicate call barrier, and generated `forall/2` soft-cut rewrites; residual work should be driven by concrete meta-control demand. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
@@ -182,6 +184,35 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-meta-aggregate-dispatch`
+
+Goal: route non-inline runtime calls to `findall/3`, `bagof/3`, and `setof/3`
+through C aggregate machinery instead of failing normal predicate lookup.
+
+Evidence:
+
+- The C step loop now intercepts `call` and `execute` for `findall/3`,
+  `bagof/3`, and `setof/3` before predicate-hash lookup.
+- Meta aggregate frames store heap-reference template/result values directly,
+  preserving variable sharing after the wrapper predicate reuses A-registers
+  for aggregate arguments.
+- Synthetic meta collect/finalize continuations collect each goal solution,
+  retry the goal through normal backtracking, and finalize empty/non-empty
+  `findall/3`, `bagof/3`, and `setof/3` results through the existing aggregate
+  list and grouping code.
+- The real-Prolog executable smoke compiles `bagof/3` and `setof/3` without
+  `inline_bagof_setof(true)`, verifies the generated WAM contains
+  `execute bagof/3` / `execute setof/3` rather than inline aggregate opcodes,
+  and checks ordered `bagof/3`, sorted/deduplicated `setof/3`, and empty
+  `bagof/3` failure.
+
+Remaining gaps:
+
+- The first meta-call implementation invokes atoms, module-qualified simple
+  predicate terms, `^/2`, direct builtins, and nested aggregate terms. It does
+  not yet cover conjunction, disjunction, if-then-else, or general `call/N`
+  goal composition in the C runtime.
 
 ### Completed: `investigate/wam-c-bagof-setof-unbound-witness-groups`
 
@@ -1177,14 +1208,13 @@ Evidence:
 
 ## Suggested Immediate Next Step
 
-The aggregate parity sequence now has no-witness, caller-bound witness,
-existential `^/2`, and unbound witness group enumeration coverage for inline
-`bagof/3` / `setof/3`. The next aggregate feature worth considering is
-meta-call aggregate dispatch, where runtime calls to `findall/3`, `bagof/3`,
-and `setof/3` execute through the aggregate machinery even without
-`inline_bagof_setof(true)`. Keep that separate because it needs goal-term
-dispatch and witness discovery at runtime rather than only generated WAM
-aggregate opcodes.
+The aggregate parity sequence now has inline no-witness, caller-bound witness,
+existential `^/2`, unbound witness group enumeration, and a first runtime
+meta-call aggregate path for simple callable goals. The next aggregate feature
+worth considering is broader C goal-term dispatch for meta aggregate bodies:
+conjunction, disjunction, if-then-else, and `call/N` composition. Keep that
+separate because it changes general meta-call control flow, not just aggregate
+frame finalization.
 
 For the effective-distance/CSR line, result-capped and sampled runs already
 confirm child-CSR variants agree, and parent plus child reachability prefilters

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -24,7 +24,10 @@
 #define WAM_CALL_STACK_SIZE 1024
 #define WAM_AGGREGATE_STACK_SIZE 32
 #define WAM_AGGREGATE_MAX_WITNESSES 8
+#define WAM_AGGREGATE_META_MAX_VARS 64
 #define WAM_AGGREGATE_NEXT_GROUP -3
+#define WAM_AGGREGATE_META_COLLECT -4
+#define WAM_AGGREGATE_META_DONE -5
 
 typedef struct WamState WamState;
 typedef bool (*WamForeignHandler)(WamState *state, const char *pred, int arity);
@@ -74,14 +77,19 @@ typedef struct {
 
 typedef struct {
     const char *kind;
+    bool is_meta;
     int begin_pc;
     int end_pc;
+    int return_pc;
     int base_b;
     int sentinel_b;
     int template_reg;
     int template_is_y;
     int result_reg;
     int result_is_y;
+    WamValue meta_template;
+    WamValue meta_result;
+    WamValue meta_witnesses[WAM_AGGREGATE_MAX_WITNESSES];
     WamStoredTerm *items;
     WamStoredTerm *witnesses;
     int item_count;
@@ -93,9 +101,12 @@ typedef struct {
 
 typedef struct {
     const char *kind;
+    bool is_meta;
     int return_pc;
     int result_reg;
     int result_is_y;
+    WamValue meta_result;
+    WamValue meta_witnesses[WAM_AGGREGATE_MAX_WITNESSES];
     WamStoredTerm *items;
     WamStoredTerm *witnesses;
     int item_count;

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -2136,6 +2136,9 @@ compile_step_wam_to_c(_Options, CCode) :-
             }
             case INSTR_PROCEED: {
                 int continuation = state->CP;
+                if (continuation == WAM_AGGREGATE_META_COLLECT) {
+                    return wam_collect_meta_aggregate_success(state);
+                }
                 if (continuation != WAM_HALT && state->call_base_top > 0) {
                     int barrier_index = --state->call_base_top;
                     int target_b = state->call_bases[barrier_index];
@@ -2147,6 +2150,15 @@ compile_step_wam_to_c(_Options, CCode) :-
                 return true;
             }
             case INSTR_CALL: {
+                if (strcmp(instr->as.pred.pred, "findall/3") == 0) {
+                    return wam_dispatch_aggregate_meta(state, "collect", state->P + 1);
+                }
+                if (strcmp(instr->as.pred.pred, "bagof/3") == 0 ||
+                    strcmp(instr->as.pred.pred, "setof/3") == 0) {
+                    const char *kind =
+                        strcmp(instr->as.pred.pred, "bagof/3") == 0 ? "bagof" : "setof";
+                    return wam_dispatch_aggregate_meta(state, kind, state->P + 1);
+                }
                 if (state->call_base_top >= WAM_CALL_STACK_SIZE) return false;
                 state->call_bases[state->call_base_top] = state->B;
                 state->call_base_preserve_choice[state->call_base_top] =
@@ -2159,6 +2171,15 @@ compile_step_wam_to_c(_Options, CCode) :-
                 return false;
             }
             case INSTR_EXECUTE: {
+                if (strcmp(instr->as.pred.pred, "findall/3") == 0) {
+                    return wam_dispatch_aggregate_meta(state, "collect", state->CP);
+                }
+                if (strcmp(instr->as.pred.pred, "bagof/3") == 0 ||
+                    strcmp(instr->as.pred.pred, "setof/3") == 0) {
+                    const char *kind =
+                        strcmp(instr->as.pred.pred, "bagof/3") == 0 ? "bagof" : "setof";
+                    return wam_dispatch_aggregate_meta(state, kind, state->CP);
+                }
                 int target = resolve_predicate_hash(state, instr->as.pred.pred);
                 if (target >= 0) { state->P = target; return true; }
                 return false;
@@ -2536,6 +2557,8 @@ compile_step_wam_to_c(_Options, CCode) :-
                     if (next_pc == WAM_AGGREGATE_NEXT_GROUP) {
                         pop_choice_point(state);
                         recovered = wam_bind_next_aggregate_group(state);
+                    } else if (next_pc == WAM_AGGREGATE_META_DONE) {
+                        recovered = wam_finalize_meta_aggregate(state);
                     } else {
                         state->P = next_pc; // Explicitly jump to alternative
                         recovered = true;
@@ -2560,6 +2583,12 @@ compile_wam_helpers_to_c(_Options, CCode) :-
 #include <unistd.h>
 
 static void wam_bidirectional_distance_cache_clear(WamState *state);
+static bool wam_dispatch_aggregate_meta(WamState *state, const char *kind,
+                                        int return_pc);
+static bool wam_invoke_goal_as_call(WamState *state, WamValue goal,
+                                    int return_pc);
+static bool wam_collect_meta_aggregate_success(WamState *state);
+static bool wam_finalize_meta_aggregate(WamState *state);
 
 static bool wam_ensure_heap_slots(WamState *state, int additional) {
     if (additional <= 0) return true;
@@ -2613,6 +2642,251 @@ static bool wam_parse_functor_arity(const char *functor, int *arity_out) {
     if (!end || *end != 0 || arity < 0 || arity > 255) return false;
     *arity_out = (int)arity;
     return true;
+}
+
+static bool wam_ref_addr(WamState *state, WamValue value, int *addr_out) {
+    if (value.tag != VAL_REF) return false;
+    int addr = value.data.ref_addr;
+    for (int steps = 0; steps < state->H_cap; steps++) {
+        if (addr < 0 || addr >= state->H) return false;
+        WamValue cell = state->H_array[addr];
+        if (cell.tag == VAL_UNBOUND) {
+            *addr_out = addr;
+            return true;
+        }
+        if (cell.tag != VAL_REF) return false;
+        if (cell.data.ref_addr == addr) {
+            *addr_out = addr;
+            return true;
+        }
+        addr = cell.data.ref_addr;
+    }
+    return false;
+}
+
+static bool wam_ref_array_contains(WamState *state, WamValue *values,
+                                   int count, WamValue value) {
+    int addr = -1;
+    if (!wam_ref_addr(state, value, &addr)) return false;
+    for (int i = 0; i < count; i++) {
+        int other = -1;
+        if (wam_ref_addr(state, values[i], &other) && other == addr) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool wam_ref_array_append_unique_limit(WamState *state, WamValue *values,
+                                              int *count, int max_count,
+                                              WamValue value) {
+    if (wam_ref_array_contains(state, values, *count, value)) return true;
+    if (*count >= max_count) return false;
+    values[*count] = value;
+    (*count)++;
+    return true;
+}
+
+static bool wam_ref_array_append_unique(WamState *state, WamValue *values,
+                                        int *count, WamValue value) {
+    return wam_ref_array_append_unique_limit(state, values, count,
+                                             WAM_AGGREGATE_MAX_WITNESSES,
+                                             value);
+}
+
+static bool wam_collect_term_vars(WamState *state, WamValue value,
+                                  WamValue *vars, int *count,
+                                  int max_count) {
+    if (value.tag == VAL_REF) {
+        int addr = -1;
+        if (wam_ref_addr(state, value, &addr)) {
+            WamValue ref;
+            ref.tag = VAL_REF;
+            ref.data.ref_addr = addr;
+            return wam_ref_array_append_unique_limit(state, vars, count,
+                                                     max_count, ref);
+        }
+    }
+    WamValue *cell = wam_deref_ptr(state, &value);
+    if (cell->tag == VAL_LIST) {
+        int base = cell->data.ref_addr;
+        if (base < 0 || base + 1 >= state->H) return false;
+        return wam_collect_term_vars(state, state->H_array[base], vars,
+                                     count, max_count) &&
+               wam_collect_term_vars(state, state->H_array[base + 1], vars,
+                                     count, max_count);
+    }
+    if (cell->tag == VAL_STR) {
+        int base = cell->data.ref_addr;
+        if (base < 0 || base >= state->H) return false;
+        WamValue *functor = &state->H_array[base];
+        if (functor->tag != VAL_ATOM) return false;
+        int arity = 0;
+        if (!wam_parse_functor_arity(functor->data.atom, &arity)) return false;
+        if (base + arity >= state->H) return false;
+        for (int i = 0; i < arity; i++) {
+            if (!wam_collect_term_vars(state, state->H_array[base + 1 + i],
+                                       vars, count, max_count)) return false;
+        }
+    }
+    return true;
+}
+
+static bool wam_collect_goal_witnesses(WamState *state, WamValue goal,
+                                       WamValue *exclude, int *exclude_count,
+                                       int exclude_max,
+                                       WamValue *witnesses,
+                                       int *witness_count) {
+    if (goal.tag == VAL_REF) {
+        int addr = -1;
+        if (wam_ref_addr(state, goal, &addr)) {
+            WamValue ref;
+            ref.tag = VAL_REF;
+            ref.data.ref_addr = addr;
+            if (!wam_ref_array_contains(state, exclude, *exclude_count, ref)) {
+                if (!wam_ref_array_append_unique(state, witnesses,
+                                                 witness_count, ref)) return false;
+                return wam_ref_array_append_unique_limit(state, exclude,
+                                                         exclude_count,
+                                                         exclude_max, ref);
+            }
+            return true;
+        }
+    }
+    WamValue *cell = wam_deref_ptr(state, &goal);
+    if (cell->tag == VAL_LIST) {
+        int base = cell->data.ref_addr;
+        if (base < 0 || base + 1 >= state->H) return false;
+        return wam_collect_goal_witnesses(state, state->H_array[base],
+                                          exclude, exclude_count, exclude_max,
+                                          witnesses, witness_count) &&
+               wam_collect_goal_witnesses(state, state->H_array[base + 1],
+                                          exclude, exclude_count, exclude_max,
+                                          witnesses, witness_count);
+    }
+    if (cell->tag != VAL_STR) return true;
+    int base = cell->data.ref_addr;
+    if (base < 0 || base >= state->H) return false;
+    WamValue *functor = &state->H_array[base];
+    if (functor->tag != VAL_ATOM) return false;
+    int arity = 0;
+    if (!wam_parse_functor_arity(functor->data.atom, &arity)) return false;
+    if (base + arity >= state->H) return false;
+    if (strcmp(functor->data.atom, "^/2") == 0 && arity == 2) {
+        if (!wam_collect_term_vars(state, state->H_array[base + 1],
+                                   exclude, exclude_count,
+                                   exclude_max)) return false;
+        return wam_collect_goal_witnesses(state, state->H_array[base + 2],
+                                          exclude, exclude_count, exclude_max,
+                                          witnesses, witness_count);
+    }
+    for (int i = 0; i < arity; i++) {
+        if (!wam_collect_goal_witnesses(state, state->H_array[base + 1 + i],
+                                        exclude, exclude_count, exclude_max,
+                                        witnesses, witness_count)) return false;
+    }
+    return true;
+}
+
+static WamValue *wam_aggregate_result_cell(WamState *state,
+                                           WamAggregateFrame *frame) {
+    if (frame->is_meta) return &frame->meta_result;
+    return resolve_reg(state, frame->result_reg, frame->result_is_y);
+}
+
+static WamValue *wam_aggregate_witness_cell(WamState *state,
+                                            WamAggregateFrame *frame,
+                                            int index) {
+    if (index < 0 || index >= frame->witness_count) return NULL;
+    if (frame->is_meta) return &frame->meta_witnesses[index];
+    return resolve_reg(state, frame->witness_regs[index],
+                       frame->witness_is_y[index]);
+}
+
+static bool wam_goal_structure(WamState *state, WamValue goal,
+                               const char **functor_out, int *base_out) {
+    WamValue current = goal;
+    for (int strip = 0; strip < 8; strip++) {
+        WamValue *cell = wam_deref_ptr(state, &current);
+        if (cell->tag != VAL_STR) return false;
+        int base = cell->data.ref_addr;
+        if (base < 0 || base >= state->H) return false;
+        WamValue *functor = &state->H_array[base];
+        if (functor->tag != VAL_ATOM) return false;
+        int arity = 0;
+        if (!wam_parse_functor_arity(functor->data.atom, &arity)) return false;
+        if (base + arity >= state->H) return false;
+        if (strcmp(functor->data.atom, ":/2") == 0 && arity == 2) {
+            current = state->H_array[base + 2];
+            continue;
+        }
+        *functor_out = functor->data.atom;
+        *base_out = base;
+        return true;
+    }
+    return false;
+}
+
+static bool wam_invoke_goal_as_call(WamState *state, WamValue goal,
+                                    int return_pc) {
+    WamValue *cell = wam_deref_ptr(state, &goal);
+    if (cell->tag == VAL_ATOM) {
+        if (strcmp(cell->data.atom, "true") == 0) {
+            if (return_pc == WAM_AGGREGATE_META_COLLECT) {
+                return wam_collect_meta_aggregate_success(state);
+            }
+            state->P = return_pc;
+            return true;
+        }
+        if (strcmp(cell->data.atom, "fail") == 0 ||
+            strcmp(cell->data.atom, "false") == 0) {
+            return false;
+        }
+        char key[256];
+        int written = snprintf(key, sizeof(key), "%s/0", cell->data.atom);
+        if (written <= 0 || written >= (int)sizeof(key)) return false;
+        int target = resolve_predicate_hash(state, key);
+        if (target < 0) return false;
+        state->CP = return_pc;
+        state->P = target;
+        return true;
+    }
+    const char *functor = NULL;
+    int base = -1;
+    if (!wam_goal_structure(state, goal, &functor, &base)) return false;
+    int arity = 0;
+    if (!wam_parse_functor_arity(functor, &arity)) return false;
+    if (arity > WAM_MAX_REGS) return false;
+    if (strcmp(functor, "^/2") == 0 && arity == 2) {
+        return wam_invoke_goal_as_call(state, state->H_array[base + 2],
+                                       return_pc);
+    }
+    for (int i = 0; i < arity; i++) {
+        state->A[i] = state->H_array[base + 1 + i];
+    }
+    if (strcmp(functor, "findall/3") == 0) {
+        return wam_dispatch_aggregate_meta(state, "collect", return_pc);
+    }
+    if (strcmp(functor, "bagof/3") == 0) {
+        return wam_dispatch_aggregate_meta(state, "bagof", return_pc);
+    }
+    if (strcmp(functor, "setof/3") == 0) {
+        return wam_dispatch_aggregate_meta(state, "setof", return_pc);
+    }
+    int target = resolve_predicate_hash(state, functor);
+    if (target >= 0) {
+        state->CP = return_pc;
+        state->P = target;
+        return true;
+    }
+    if (wam_execute_builtin(state, functor, arity)) {
+        if (return_pc == WAM_AGGREGATE_META_COLLECT) {
+            return wam_collect_meta_aggregate_success(state);
+        }
+        state->P = return_pc;
+        return true;
+    }
+    return false;
 }
 
 static bool wam_copy_term_to_stored(WamState *state,
@@ -2913,15 +3187,15 @@ static bool wam_copy_current_witness_tuple(WamState *state,
         return true;
     }
     if (frame->witness_count == 1) {
-        WamValue *cell =
-            resolve_reg(state, frame->witness_regs[0], frame->witness_is_y[0]);
+        WamValue *cell = wam_aggregate_witness_cell(state, frame, 0);
+        if (!cell) return false;
         return wam_copy_term_to_stored(state, term, *cell, &term->root);
     }
 
     WamValue tail = val_atom("[]");
     for (int i = frame->witness_count - 1; i >= 0; i--) {
-        WamValue *cell =
-            resolve_reg(state, frame->witness_regs[i], frame->witness_is_y[i]);
+        WamValue *cell = wam_aggregate_witness_cell(state, frame, i);
+        if (!cell) return false;
         WamValue head;
         if (!wam_copy_term_to_stored(state, term, *cell, &head)) return false;
         if (!wam_stored_term_reserve(term, 2)) return false;
@@ -2939,9 +3213,9 @@ static bool wam_copy_current_witness_tuple(WamState *state,
 static bool wam_witness_regs_are_bound(WamState *state,
                                        WamAggregateFrame *frame) {
     for (int i = 0; i < frame->witness_count; i++) {
-        WamValue *cell =
-            wam_deref_ptr(state, resolve_reg(state, frame->witness_regs[i],
-                                             frame->witness_is_y[i]));
+        WamValue *witness = wam_aggregate_witness_cell(state, frame, i);
+        if (!witness) return false;
+        WamValue *cell = wam_deref_ptr(state, witness);
         if (val_is_unbound(*cell)) return false;
     }
     return true;
@@ -3057,8 +3331,8 @@ static bool wam_unify_witness_registers_from_group(WamState *state,
         if (!wam_materialize_witness_component(state, witness,
                                                frame->witness_count,
                                                i, &value)) return false;
-        WamValue *target =
-            resolve_reg(state, frame->witness_regs[i], frame->witness_is_y[i]);
+        WamValue *target = wam_aggregate_witness_cell(state, frame, i);
+        if (!target) return false;
         if (!wam_unify(state, target, &value)) return false;
     }
     return true;
@@ -3072,8 +3346,10 @@ static bool wam_bind_aggregate_group(WamState *state,
     WamAggregateFrame frame_view;
     memset(&frame_view, 0, sizeof(WamAggregateFrame));
     frame_view.kind = iter->kind;
+    frame_view.is_meta = iter->is_meta;
     frame_view.result_reg = iter->result_reg;
     frame_view.result_is_y = iter->result_is_y;
+    frame_view.meta_result = iter->meta_result;
     frame_view.items = iter->items;
     frame_view.witnesses = iter->witnesses;
     frame_view.item_count = iter->item_count;
@@ -3082,6 +3358,7 @@ static bool wam_bind_aggregate_group(WamState *state,
     for (int i = 0; i < iter->witness_count; i++) {
         frame_view.witness_regs[i] = iter->witness_regs[i];
         frame_view.witness_is_y[i] = iter->witness_is_y[i];
+        frame_view.meta_witnesses[i] = iter->meta_witnesses[i];
     }
 
     int *indices = NULL;
@@ -3105,9 +3382,12 @@ static bool wam_bind_aggregate_group(WamState *state,
     free(indices);
     if (!list_ok) return false;
 
-    WamValue *result_cell =
-        resolve_reg(state, iter->result_reg, iter->result_is_y);
+    WamValue *result_cell = wam_aggregate_result_cell(state, &frame_view);
     if (!wam_unify(state, result_cell, &result_list)) return false;
+    if (frame_view.is_meta) {
+        WamValue *meta_result = wam_deref_ptr(state, &frame_view.meta_result);
+        state->A[0] = *meta_result;
+    }
     state->P = iter->return_pc;
     return true;
 }
@@ -3150,9 +3430,11 @@ static bool wam_push_aggregate_group_iterator(WamState *state,
         &state->aggregate_group_iters[state->aggregate_group_top];
     wam_aggregate_group_iterator_free(iter);
     iter->kind = frame->kind;
+    iter->is_meta = frame->is_meta;
     iter->return_pc = return_pc;
     iter->result_reg = frame->result_reg;
     iter->result_is_y = frame->result_is_y;
+    iter->meta_result = frame->meta_result;
     iter->items = frame->items;
     iter->witnesses = frame->witnesses;
     iter->item_count = frame->item_count;
@@ -3161,6 +3443,7 @@ static bool wam_push_aggregate_group_iterator(WamState *state,
     for (int i = 0; i < frame->witness_count; i++) {
         iter->witness_regs[i] = frame->witness_regs[i];
         iter->witness_is_y[i] = frame->witness_is_y[i];
+        iter->meta_witnesses[i] = frame->meta_witnesses[i];
     }
     iter->group_reps = group_reps;
     iter->group_count = group_count;
@@ -3274,7 +3557,7 @@ static bool wam_finalize_aggregate_frame(WamState *state,
     bool is_bagof = strcmp(frame->kind, "bagof") == 0;
     bool is_setof = strcmp(frame->kind, "setof") == 0;
     if (!is_collect && !is_bagof && !is_setof) return false;
-    int next_pc = frame->end_pc + 1;
+    int next_pc = frame->is_meta ? frame->return_pc : frame->end_pc + 1;
     int frame_index = state->aggregate_top - 1;
     if (frame->sentinel_b > 0 && frame->sentinel_b <= state->B) {
         ChoicePoint *sentinel = &state->B_array[frame->sentinel_b - 1];
@@ -3341,14 +3624,79 @@ static bool wam_finalize_aggregate_frame(WamState *state,
         }
         if (!wam_build_aggregate_list(state, frame, &result_list)) return false;
     }
-    WamValue *result_cell =
-        resolve_reg(state, frame->result_reg, frame->result_is_y);
+    WamValue *result_cell = wam_aggregate_result_cell(state, frame);
     bool ok = wam_unify(state, result_cell, &result_list);
+    if (ok && frame->is_meta) {
+        WamValue *meta_result = wam_deref_ptr(state, &frame->meta_result);
+        state->A[0] = *meta_result;
+    }
     wam_aggregate_frame_free(frame);
     state->aggregate_top = frame_index;
     if (!ok) return false;
     state->P = next_pc;
     return true;
+}
+
+static bool wam_collect_meta_aggregate_success(WamState *state) {
+    if (state->aggregate_top <= 0) return false;
+    WamAggregateFrame *frame =
+        &state->aggregate_frames[state->aggregate_top - 1];
+    if (!frame->is_meta) return false;
+    (void)wam_aggregate_append_item(state, frame, frame->meta_template);
+    return false;
+}
+
+static bool wam_finalize_meta_aggregate(WamState *state) {
+    if (state->aggregate_top <= 0) return false;
+    WamAggregateFrame *frame =
+        &state->aggregate_frames[state->aggregate_top - 1];
+    if (!frame->is_meta) return false;
+    return wam_finalize_aggregate_frame(state, frame);
+}
+
+static bool wam_dispatch_aggregate_meta(WamState *state, const char *kind,
+                                        int return_pc) {
+    if (strcmp(kind, "collect") != 0 &&
+        strcmp(kind, "bagof") != 0 &&
+        strcmp(kind, "setof") != 0) return false;
+    if (state->aggregate_top >= WAM_AGGREGATE_STACK_SIZE) return false;
+
+    WamAggregateFrame *frame = &state->aggregate_frames[state->aggregate_top++];
+    memset(frame, 0, sizeof(WamAggregateFrame));
+    frame->kind = kind;
+    frame->is_meta = true;
+    frame->begin_pc = state->P;
+    frame->end_pc = return_pc - 1;
+    frame->return_pc = return_pc;
+    frame->base_b = state->B;
+    frame->sentinel_b = state->B + 1;
+    frame->meta_template = state->A[0];
+    frame->meta_result = state->A[2];
+
+    if (strcmp(kind, "bagof") == 0 || strcmp(kind, "setof") == 0) {
+        WamValue exclude[WAM_AGGREGATE_META_MAX_VARS];
+        int exclude_count = 0;
+        if (!wam_collect_term_vars(state, state->A[0], exclude,
+                                   &exclude_count,
+                                   WAM_AGGREGATE_META_MAX_VARS)) {
+            state->aggregate_top--;
+            memset(frame, 0, sizeof(WamAggregateFrame));
+            return false;
+        }
+        if (!wam_collect_goal_witnesses(state, state->A[1], exclude,
+                                        &exclude_count,
+                                        WAM_AGGREGATE_META_MAX_VARS,
+                                        frame->meta_witnesses,
+                                        &frame->witness_count)) {
+            state->aggregate_top--;
+            memset(frame, 0, sizeof(WamAggregateFrame));
+            return false;
+        }
+    }
+
+    push_choice_point(state, WAM_AGGREGATE_META_DONE, 32);
+    return wam_invoke_goal_as_call(state, state->A[1],
+                                   WAM_AGGREGATE_META_COLLECT);
 }
 
 static bool wam_begin_aggregate(WamState *state, Instruction *instr) {

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -1765,6 +1765,16 @@ test_real_prolog_bagof_setof_unbound_witness_groups_smoke :-
     ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
     ).
 
+test_real_prolog_bagof_setof_meta_call_smoke :-
+    Test = 'WAM-C: runtime bagof/3 and setof/3 meta-call smoke',
+    (   gcc_available
+    ->  (   run_real_prolog_bagof_setof_meta_call_smoke
+        ->  pass(Test)
+        ;   fail_test(Test, 'runtime bagof/3 and setof/3 meta-call executable failed')
+        )
+    ;   format('[PASS] ~w (gcc unavailable; skipped executable smoke)~n', [Test])
+    ).
+
 test_real_prolog_classic_recursive_executable_smoke :-
     Test = 'WAM-C: real Prolog classic recursive executable smoke',
     (   gcc_available
@@ -3129,6 +3139,67 @@ cleanup_wam_c_bagof_setof_unbound_witness_groups_smoke :-
     retractall(user:wam_c_uw_set(_, _)),
     retractall(user:wam_c_uw_bag_groups_ok),
     retractall(user:wam_c_uw_set_groups_ok).
+
+run_real_prolog_bagof_setof_meta_call_smoke :-
+    assertz((user:wam_c_meta_item(a) :- true)),
+    assertz((user:wam_c_meta_item(b) :- true)),
+    assertz((user:wam_c_meta_dup(b) :- true)),
+    assertz((user:wam_c_meta_dup(a) :- true)),
+    assertz((user:wam_c_meta_dup(b) :- true)),
+    assertz((user:wam_c_meta_none(_) :- fail)),
+    assertz((user:wam_c_meta_bag(L) :-
+        bagof(X, wam_c_meta_item(X), L))),
+    assertz((user:wam_c_meta_set(L) :-
+        setof(X, wam_c_meta_dup(X), L))),
+    assertz((user:wam_c_meta_empty_bag(L) :-
+        bagof(X, wam_c_meta_none(X), L))),
+    (   compile_predicate_to_wam(user:wam_c_meta_item/1, [], WamItem),
+        compile_predicate_to_wam(user:wam_c_meta_dup/1, [], WamDup),
+        compile_predicate_to_wam(user:wam_c_meta_none/1, [], WamNone),
+        compile_predicate_to_wam(user:wam_c_meta_bag/1, [], WamBag),
+        compile_predicate_to_wam(user:wam_c_meta_set/1, [], WamSet),
+        compile_predicate_to_wam(user:wam_c_meta_empty_bag/1, [], WamEmptyBag),
+        sub_string(WamBag, _, _, _, 'execute bagof/3'),
+        \+ sub_string(WamBag, _, _, _, 'begin_aggregate bagof'),
+        sub_string(WamSet, _, _, _, 'execute setof/3'),
+        \+ sub_string(WamSet, _, _, _, 'begin_aggregate setof'),
+        compile_wam_predicate_to_c(user:wam_c_meta_item/1, WamItem, [], ItemCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_dup/1, WamDup, [], DupCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_none/1, WamNone, [], NoneCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_bag/1, WamBag, [], BagCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_set/1, WamSet, [], SetCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_empty_bag/1, WamEmptyBag, [], EmptyBagCode),
+        atomic_list_concat([ItemCode, DupCode, NoneCode,
+                            BagCode, SetCode, EmptyBagCode],
+                           '\n\n',
+                           PredCode),
+        compile_wam_runtime_to_c([], RuntimeCode),
+        get_time(Now),
+        Stamp is round(Now * 1000000),
+        wam_c_temp_path('unifyweaver_wam_c_bagof_setof_meta_smoke', Stamp, TmpBase),
+        format(atom(RuntimePath), '~w_runtime.c', [TmpBase]),
+        format(atom(PredPath), '~w_pred.c', [TmpBase]),
+        format(atom(MainPath), '~w_main.c', [TmpBase]),
+        format(atom(ExePath), '~w_bin', [TmpBase]),
+        write_text_file(RuntimePath, RuntimeCode),
+        format(atom(PredTranslationUnit), '#include "wam_runtime.h"~n~n~w', [PredCode]),
+        write_text_file(PredPath, PredTranslationUnit),
+        wam_c_bagof_setof_meta_call_main(MainCode),
+        write_text_file(MainPath, MainCode),
+        compile_c_smoke_plain(RuntimePath, PredPath, MainPath, ExePath),
+        run_c_smoke_plain(ExePath)
+    ->  cleanup_wam_c_bagof_setof_meta_call_smoke
+    ;   cleanup_wam_c_bagof_setof_meta_call_smoke,
+        fail
+    ).
+
+cleanup_wam_c_bagof_setof_meta_call_smoke :-
+    retractall(user:wam_c_meta_item(_)),
+    retractall(user:wam_c_meta_dup(_)),
+    retractall(user:wam_c_meta_none(_)),
+    retractall(user:wam_c_meta_bag(_)),
+    retractall(user:wam_c_meta_set(_)),
+    retractall(user:wam_c_meta_empty_bag(_)).
 
 run_real_prolog_classic_recursive_executable_smoke :-
     assertz((user:wam_c_classic_fib(0, 0) :- true)),
@@ -6654,6 +6725,80 @@ int main(void) {
 }
 ').
 
+wam_c_bagof_setof_meta_call_main(
+'#include "wam_runtime.h"
+
+void setup_wam_c_meta_item_1(WamState* state);
+void setup_wam_c_meta_dup_1(WamState* state);
+void setup_wam_c_meta_none_1(WamState* state);
+void setup_wam_c_meta_bag_1(WamState* state);
+void setup_wam_c_meta_set_1(WamState* state);
+void setup_wam_c_meta_empty_bag_1(WamState* state);
+
+static bool wam_c_meta_expect_atom_list2(WamState *state, WamValue value,
+                                         const char *first,
+                                         const char *second) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    if (cell->tag != VAL_LIST) return false;
+    int first_addr = cell->data.ref_addr;
+    WamValue *head1 = wam_deref_ptr(state, &state->H_array[first_addr]);
+    WamValue *tail1 = wam_deref_ptr(state, &state->H_array[first_addr + 1]);
+    if (head1->tag != VAL_ATOM || strcmp(head1->data.atom, first) != 0) return false;
+    if (tail1->tag != VAL_LIST) return false;
+    int second_addr = tail1->data.ref_addr;
+    WamValue *head2 = wam_deref_ptr(state, &state->H_array[second_addr]);
+    WamValue *tail2 = wam_deref_ptr(state, &state->H_array[second_addr + 1]);
+    return head2->tag == VAL_ATOM &&
+           strcmp(head2->data.atom, second) == 0 &&
+           tail2->tag == VAL_ATOM &&
+           strcmp(tail2->data.atom, "[]") == 0;
+}
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_wam_c_meta_item_1(&state);
+    setup_wam_c_meta_dup_1(&state);
+    setup_wam_c_meta_none_1(&state);
+    setup_wam_c_meta_bag_1(&state);
+    setup_wam_c_meta_set_1(&state);
+    setup_wam_c_meta_empty_bag_1(&state);
+
+    WamValue bag_args[1] = { val_unbound("Bag") };
+    int bag_rc = wam_run_predicate(&state, "wam_c_meta_bag/1", bag_args, 1);
+    if (bag_rc != 0 || state.P != WAM_HALT ||
+        !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "b") ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0) {
+        wam_free_state(&state);
+        return 10;
+    }
+
+    WamValue set_args[1] = { val_unbound("Set") };
+    int set_rc = wam_run_predicate(&state, "wam_c_meta_set/1", set_args, 1);
+    if (set_rc != 0 || state.P != WAM_HALT ||
+        !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "b") ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0) {
+        wam_free_state(&state);
+        return 20;
+    }
+
+    WamValue empty_args[1] = { val_unbound("Empty") };
+    int empty_rc = wam_run_predicate(&state, "wam_c_meta_empty_bag/1",
+                                     empty_args, 1);
+    if (empty_rc != WAM_HALT ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0) {
+        wam_free_state(&state);
+        return 30;
+    }
+
+    wam_free_state(&state);
+    return 0;
+}
+').
+
 wam_c_classic_fib_smoke_main(
 '#include "wam_runtime.h"
 
@@ -6872,6 +7017,7 @@ run_tests_once :-
     test_real_prolog_bagof_setof_witness_executable_smoke,
     test_real_prolog_bagof_setof_existential_executable_smoke,
     test_real_prolog_bagof_setof_unbound_witness_groups_smoke,
+    test_real_prolog_bagof_setof_meta_call_smoke,
     test_real_prolog_classic_recursive_executable_smoke,
     test_lowered_fact_helper_executable_smoke,
     test_lowered_body_call_helper_executable_smoke,


### PR DESCRIPTION
  ## Summary

  - Add WAM-C runtime dispatch for non-inline `findall/3`, `bagof/3`, and `setof/3`
  - Introduce meta aggregate frames with synthetic collect/finalize continuations
  - Invoke simple callable goal terms at runtime while preserving template/result heap sharing
  - Add executable smoke coverage for non-inline `bagof/3` and `setof/3` without `inline_bagof_setof(true)`
  - Update WAM-C next-step docs with completed scope and remaining meta-goal gaps

  ## Testing

  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `git diff --check`

  ## Notes

  This covers simple callable aggregate goals. Broader goal-term dispatch for conjunction, disjunction, if-then-else,
  and `call/N` composition remains follow-up work.