### PR TITLE
feat(wam-go): M17 get_level/cut — fix cut inside a negated goal

### DIFF
--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -380,20 +380,20 @@ classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
         option(wam_fallback(WamFB0), Options, true),
         WamFB0 \== false,
         go_foreign_spec(Module:Pred/Arity, Options, _SetupOps0, _RewriteCalls0, _EntryPred0/_EntryArity0),
-        wam_target:compile_predicate_to_wam(Module:Pred/Arity, Options, WamCode0)
+        wam_target:compile_predicate_to_wam(Module:Pred/Arity, [ite_use_y_level(true)|Options], WamCode0)
     ->  compile_wam_predicate_to_go(Module:Pred/Arity, WamCode0, Options, PredCode0),
         format(user_error, '  ~w/~w: WAM fallback (foreign, preferred)~n', [Pred, Arity]),
         Entry = classified(Module, Pred, Arity, wam_foreign, PredCode0)
     ;   option(prefer_wam(true), Options),
         option(wam_fallback(WamFB1), Options, true),
         WamFB1 \== false,
-        wam_target:compile_predicate_to_wam(Module:Pred/Arity, Options, WamCode1)
+        wam_target:compile_predicate_to_wam(Module:Pred/Arity, [ite_use_y_level(true)|Options], WamCode1)
     ->  format(user_error, '  ~w/~w: WAM fallback (preferred)~n', [Pred, Arity]),
         Entry = classified(Module, Pred, Arity, wam, WamCode1)
     ;   go_foreign_spec(Module:Pred/Arity, Options, _SetupOps, _RewriteCalls, _EntryPred/_EntryArity),
         option(wam_fallback(WamFB), Options, true),
         WamFB \== false,
-        wam_target:compile_predicate_to_wam(Module:Pred/Arity, Options, WamCode)
+        wam_target:compile_predicate_to_wam(Module:Pred/Arity, [ite_use_y_level(true)|Options], WamCode)
     ->  compile_wam_predicate_to_go(Module:Pred/Arity, WamCode, Options, PredCode),
         format(user_error, '  ~w/~w: WAM fallback (foreign)~n', [Pred, Arity]),
         Entry = classified(Module, Pred, Arity, wam_foreign, PredCode)
@@ -411,7 +411,7 @@ classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
         Entry = classified(Module, Pred, Arity, native, PredCode)
     ;   option(wam_fallback(WamFB), Options, true),
         WamFB \== false,
-        wam_target:compile_predicate_to_wam(Module:Pred/Arity, Options, WamCode)
+        wam_target:compile_predicate_to_wam(Module:Pred/Arity, [ite_use_y_level(true)|Options], WamCode)
     ->  (   go_foreign_spec(Module:Pred/Arity, Options, _SetupOps, _RewriteCalls, _EntryPred/_EntryArity)
         ->  compile_wam_predicate_to_go(Module:Pred/Arity, WamCode, Options, PredCode),
             format(user_error, '  ~w/~w: WAM fallback (foreign)~n', [Pred, Arity]),
@@ -753,6 +753,12 @@ wam_instruction_to_go_literal(retry_me_else(Label, Arity), GoLiteral) :-
 wam_instruction_to_go_literal(retry_me_else(Label), GoLiteral) :-
     format(atom(GoLiteral), '&RetryMeElse{Label: "~w", Arity: 100}', [Label]).
 wam_instruction_to_go_literal(trust_me, '&TrustMe{}').
+wam_instruction_to_go_literal(get_level(Yn), GoLiteral) :-
+    go_reg_index(Yn, YnIdx),
+    format(atom(GoLiteral), '&GetLevel{Reg: ~w}', [YnIdx]).
+wam_instruction_to_go_literal(cut(Yn), GoLiteral) :-
+    go_reg_index(Yn, YnIdx),
+    format(atom(GoLiteral), '&Cut{Reg: ~w}', [YnIdx]).
 
 wam_instruction_to_go_literal(switch_on_constant(Table), GoLiteral) :-
     maplist(go_const_case, Table, Cases),
@@ -1354,6 +1360,14 @@ wam_line_to_go_literal(["jump", L], GoLit) :-
     clean_comma(L, CL),
     format(atom(GoLit), '&Jump{Label: "~w"}', [CL]).
 wam_line_to_go_literal(["cut_ite"], '&CutIte{}').
+wam_line_to_go_literal(["get_level", Yn], GoLit) :-
+    clean_comma(Yn, CYn),
+    go_reg_index(CYn, YnIdx),
+    format(atom(GoLit), '&GetLevel{Reg: ~w}', [YnIdx]).
+wam_line_to_go_literal(["cut", Yn], GoLit) :-
+    clean_comma(Yn, CYn),
+    go_reg_index(CYn, YnIdx),
+    format(atom(GoLit), '&Cut{Reg: ~w}', [YnIdx]).
 wam_line_to_go_literal(["begin_aggregate", AggType, ValueReg, ResultReg], GoLit) :-
     clean_comma(AggType, CAggType),
     clean_comma(ValueReg, CValueReg),
@@ -2079,6 +2093,24 @@ wam_go_case('JumpPc', '        vm.PC = i.TargetPC
 
 wam_go_case('CutIte', '        if len(vm.ChoicePoints) > 0 {
             vm.ChoicePoints = vm.ChoicePoints[:len(vm.ChoicePoints)-1]
+        }
+        vm.PC++
+        return true').
+
+% M17 soft cut (enabled by ite_use_y_level). GetLevel snapshots the
+% current choicepoint-stack height into a Y register; Cut truncates the
+% stack back to that snapshot. Unlike CutIte (drop one CP), this removes
+% the if-then-else / negation choicepoint AND every CP the condition
+% pushed above it -- the cut a proper negation / soft-cut condition needs.
+wam_go_case('GetLevel', '        vm.putReg(i.Reg, &Integer{Val: int64(len(vm.ChoicePoints))})
+        vm.PC++
+        return true').
+
+wam_go_case('Cut', '        if iv, ok := vm.deref(vm.getReg(i.Reg)).(*Integer); ok {
+            target := int(iv.Val)
+            if target >= 0 && target < len(vm.ChoicePoints) {
+                vm.ChoicePoints = vm.ChoicePoints[:target]
+            }
         }
         vm.PC++
         return true').

--- a/templates/targets/go_wam/instructions.go.mustache
+++ b/templates/targets/go_wam/instructions.go.mustache
@@ -96,6 +96,17 @@ func (i *JumpPc) instrTag() {}
 type CutIte struct{}
 func (i *CutIte) instrTag() {}
 
+// M17 soft cut. GetLevel snapshots the choicepoint-stack height into a Y
+// register (before an if-then-else / negation try_me_else); Cut truncates
+// the choicepoint stack back to that snapshot at the commit site, removing
+// the ITE/negation choicepoint AND any CPs the condition pushed above it.
+// Replaces the legacy CutIte (which dropped only the single topmost CP).
+type GetLevel struct { Reg int }
+func (i *GetLevel) instrTag() {}
+
+type Cut struct { Reg int }
+func (i *Cut) instrTag() {}
+
 type BeginAggregate struct { AggType string; ValueReg int; ResultReg int }
 func (i *BeginAggregate) instrTag() {}
 

--- a/tests/test_wam_go_negation_cut.pl
+++ b/tests/test_wam_go_negation_cut.pl
@@ -1,0 +1,75 @@
+% test_wam_go_negation_cut.pl
+%
+% End-to-end execution test for a cut INSIDE a negated goal on the Go WAM
+% target. \+ G desugars to (G -> fail ; true), so a cut in G lands in the
+% if-then-else CONDITION, which is opaque to cut (local to the condition,
+% like call/1). Under ite_use_y_level the Go target now emits M17
+% get_level/cut for the condition's cut, so it prunes only the condition's
+% own choicepoints and leaves the negation's choicepoint intact.
+%
+% gnc :- \+ (ggen(_), !, fail).  The cut commits ggen's first solution and
+% `fail` then fails the goal, so the negation SUCCEEDS (true). Before the
+% M17 get_level/cut + ite_use_y_level change the inline cut escaped and the
+% negation wrongly failed.
+%
+% Skipped automatically when `go` is not on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module(library(process)).
+:- use_module('../src/unifyweaver/targets/wam_go_target').
+
+:- dynamic user:ggen/1.
+:- dynamic user:gnc/0.
+
+user:ggen(1).
+user:ggen(2).
+user:ggen(3).
+user:gnc :- \+ (ggen(_), !, fail).
+
+go_available :-
+    catch(
+        ( process_create(path(go), ['version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          process_wait(Pid, exit(0)) ),
+        _, fail).
+
+:- begin_tests(wam_go_negation_cut, [condition(go_available)]).
+
+test(inline_cut_in_negation_succeeds) :-
+    Proj = 'output/test_wam_go_negcut_gen',
+    ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ),
+    write_wam_go_project([user:ggen/1, user:gnc/0],
+                         [module_name(negcut), prefer_wam(true)], Proj),
+    % Drive the gnc/0 WAM entry and print the boolean result.
+    directory_file_path(Proj, 'cmd', CmdDir),
+    directory_file_path(CmdDir, 'run', RunDir),
+    make_directory_path(RunDir),
+    directory_file_path(RunDir, 'main.go', MainPath),
+    setup_call_cleanup(
+        open(MainPath, write, MS),
+        write(MS,
+'package main\n\nimport (\n\t"fmt"\n\twam "negcut"\n)\n\nfunc main() {\n\tvm := wam.NewWamState(wam.GncCode, wam.GncLabels)\n\tvm.PC = wam.GncStartPC\n\tif vm.Run() {\n\t\tfmt.Println("GNC=true")\n\t} else {\n\t\tfmt.Println("GNC=false")\n\t}\n}\n'),
+        close(MS)),
+    directory_file_path(Proj, 'go.mod', GoModPath),
+    read_file_to_string(GoModPath, GoModOld, []),
+    atomic_list_concat([GoModOld, "\nreplace negcut => ../../\n"], GoModNew),
+    setup_call_cleanup(
+        open(GoModPath, write, GS),
+        write(GS, GoModNew),
+        close(GS)),
+    format(atom(RunCmd), 'cd ~w && go run main.go 2>&1', [RunDir]),
+    process_create(path(sh), ['-c', RunCmd],
+                   [stdout(pipe(Out)), process(Pid)]),
+    read_string(Out, _, OutStr),
+    close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    ->  true
+    ;   format(user_error, "~n[go run output]~n~w~n", [OutStr]),
+        throw(go_run_failed(Status))
+    ),
+    assertion(sub_string(OutStr, _, _, _, "GNC=true")),
+    ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ).
+
+:- end_tests(wam_go_negation_cut).


### PR DESCRIPTION
  Ports the M17 soft-cut mechanism to the Go hybrid-WAM target so a cut inside a negated goal is scoped correctly. \+ G
  desugars to (G -> fail ; true), which puts a cut in G into the if-then-else condition — opaque to cut, local to the
  condition like call/1. The shared compiler already emits get_level/cut for this under ite_use_y_level (the
  condition-cut scoping from the C++ work); Go just needed the runtime support and to opt in.

  - Add GetLevel/Cut instruction structs + Step handlers: GetLevel snapshots len(ChoicePoints) into a Y register; Cut
  truncates the choicepoint stack back to that snapshot (removing the ITE/negation CP and any CPs the condition pushed
  above it) — replacing the legacy single-CP-drop CutIte for these cases.
  - Parse get_level/cut WAM text into the new instructions (line- and term-based).
  - Pass ite_use_y_level(true) on the four WAM-interpreter compile sites (not the lowered-emitter path, which has no
  get_level/cut support).

  Adds test_wam_go_negation_cut: \+ (gen(_), !, fail) now correctly succeeds (was wrongly failing).

  Test plan: New test passes; zero regressions across test_wam_go_generator, test_go_wam_builtins,
  test_wam_go_lowered_ite_exec, test_go_validation, test_wam_go_lowered_phase1..3 (final broader batch confirming).

  Known follow-up (not in this PR): Go's plain !/0 clause cut is a structural no-op (B0 captured after try_me_else), and
  making it real exposes a deeper Go-runtime bug — a variable-index collision when a cut removes a choicepoint in
  value-producing list recursion. That clause-cut/B0 fix and forall parity need a separate Go-runtime rework
  (root-caused and recorded in memory).

  🤖 Generated with Claude Code (https://claude.com/claude-code)