### PR TITLE
fix(wam-go): deref register in GetConstant before inspecting

### DIFF
--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -1655,6 +1655,14 @@ compile_go_step_case(CaseCode) :-
 
 wam_go_case('GetConstant', '        val := vm.Regs[i.Ai]
         if val == nil { return false }
+        // Dereference before inspecting: the register may hold a *Ref or a
+        // bound *Unbound (bound via the Bindings table), e.g. the tail of a
+        // partial list carried through a recursive call. Without the deref,
+        // isUnbound() sees the raw *Unbound as unbound and rebinds it to the
+        // constant -- silently corrupting an already-bound value (get_constant
+        // [] would overwrite a bound [H|T] tail with []). Mirrors the deref
+        // GetStructure / GetList already do.
+        val = vm.deref(val)
         if isUnbound(val) {
             u := val.(*Unbound)
             vm.bindUnbound(u, i.C)


### PR DESCRIPTION
 GetConstant read vm.Regs[i.Ai] and tested isUnbound/valueEquals on the raw value, unlike GetStructure/GetList which deref first. When the register holds a *Ref or a bound *Unbound (bound via the Bindings table) — e.g. the tail of a partial list carried through a recursive call — isUnbound() saw the raw *Unbound as unbound and rebound it to the  constant, silently corrupting an already-bound value (get_constant [] overwriting a bound [H|T] tail with []).

  Adds val = vm.deref(val) before the checks, mirroring GetStructure/GetList.

  A correctness hardening and prerequisite for fixing var/1 on a partial-list tail. The full symptom additionally requires Go's structural cut no-op fix (separate, larger runtime rework — see memory). Verified zero regressions across 14 Go suites; a standalone regression test can't be isolated yet because the trigger is entangled with the cut.

  🤖 Generated with Claude Code (https://claude.com/claude-code)