### PR TITLE
fix(wam-go): call-time B0 so a plain cut actually commits

### DIFF
--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -1981,7 +1981,7 @@ wam_go_case('Allocate', '        // Env trimming: PrevE links the new frame back
         // active env frame. vm.E moves to the index of the just-pushed
         // frame so peekEnvFrame is O(1) and Deallocate can walk the
         // PrevE chain without scanning the stack.
-        env := &EnvFrame{CP: vm.CP, B0: len(vm.ChoicePoints), PrevE: vm.E}
+        env := &EnvFrame{CP: vm.CP, B0: len(vm.ChoicePoints), CutB0: vm.PendingB0, PrevE: vm.E}
         // Snapshot the Y-reg range (200..299) into the env frame so a
         // nested predicate that uses the same slot numbers via
         // PutVariable doesn''t silently clobber the caller''s Y-regs.
@@ -2021,6 +2021,7 @@ wam_go_case('Deallocate', '        if vm.E >= 0 && vm.E < len(vm.Stack) {
 
 wam_go_case('Call', '        vm.CP = vm.PC + 1
         if pc, ok := vm.Ctx.Labels[i.Pred]; ok {
+            vm.PendingB0 = len(vm.ChoicePoints)
             vm.PC = pc
             return true
         }
@@ -2075,10 +2076,12 @@ wam_go_case('CallForeign', '        return vm.executeForeignPredicate(i.Pred, i.
 wam_go_case('CallIndexedAtomFact2', '        return vm.executeIndexedAtomFact2(i.Pred)').
 
 wam_go_case('CallPc', '        vm.CP = vm.PC + 1
+        vm.PendingB0 = len(vm.ChoicePoints)
         vm.PC = i.TargetPC
         return true').
 
 wam_go_case('Execute', '        if pc, ok := vm.Ctx.Labels[i.Pred]; ok {
+            vm.PendingB0 = len(vm.ChoicePoints)
             vm.PC = pc
             return true
         }
@@ -2087,7 +2090,8 @@ wam_go_case('Execute', '        if pc, ok := vm.Ctx.Labels[i.Pred]; ok {
         }
         return vm.executeIndexedAtomFact2(i.Pred)').
 
-wam_go_case('ExecutePc', '        vm.PC = i.TargetPC
+wam_go_case('ExecutePc', '        vm.PendingB0 = len(vm.ChoicePoints)
+        vm.PC = i.TargetPC
         return true').
 
 wam_go_case('Jump', '        if pc, ok := vm.Ctx.Labels[i.Label]; ok {

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -102,6 +102,11 @@ type EnvFrame struct {
 	// restore, so reading the restored Y-reg dereferences through the
 	// (still-bound) Unbound to the bound value.
 	SavedYRegs [100]Value
+	// CutB0: the predicate's call-time choicepoint height (copied from
+	// vm.PendingB0 at Allocate). A plain cut truncates choicepoints back
+	// to CutB0. Kept separate from B0 (allocate-time) because B0 drives
+	// Deallocate's physical-pop heuristic and must not change meaning.
+	CutB0 int
 }
 
 type UnifyCtx struct {
@@ -149,6 +154,12 @@ type WamState struct {
 	Ctx          *WamContext
 	PC           int
 	CP           int
+	// PendingB0: choicepoint-stack height captured by Call/Execute just
+	// before transferring to a user predicate (BEFORE its try_me_else
+	// pushes the clause-chain CP). Allocate copies it into EnvFrame.CutB0
+	// so a plain cut (!/0) truncates back to the callee's entry level --
+	// its own clause alternatives, not a caller's choicepoint.
+	PendingB0    int
 	// Regs holds A/X/Y registers in a single flat array.
 	//   * A1..A8: indices 0..7 (argument registers)
 	//   * X-regs: 8..199  (clause-local temporaries)
@@ -1440,7 +1451,11 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 	case "!/0":
 		limit := 0
 		if env := vm.peekEnvFrame(); env != nil {
-			limit = env.B0
+			// CutB0 = call-time choicepoint height, so the cut removes this
+			// predicate's own clause alternatives but not a caller's CP.
+			// (B0 is allocate-time and one too high -- it would leave
+			// sibling clauses uncut, making the cut a no-op.)
+			limit = env.CutB0
 		}
 		if limit < 0 {
 			limit = 0

--- a/tests/test_wam_go_negation_cut.pl
+++ b/tests/test_wam_go_negation_cut.pl
@@ -27,6 +27,27 @@ user:ggen(2).
 user:ggen(3).
 user:gnc :- \+ (ggen(_), !, fail).
 
+% Clause-cut B0: a plain cut commits the clause and a cut inside a CALLED
+% predicate stays local to it. proper_length-style: the var-guard clause
+% must reject a partial list. These exercise the call-time B0 cut + the
+% GetConstant deref fix together.
+:- dynamic user:gpacc/3.
+:- dynamic user:gplen/2.
+:- dynamic user:gpl_proper/0.
+:- dynamic user:gpl_partial/0.
+:- dynamic user:gpick/1.
+:- dynamic user:gcommit/0.
+
+user:gpacc(L, _, _) :- var(L), !, fail.
+user:gpacc([], N, N) :- !.
+user:gpacc([_|T], A, N) :- A1 is A + 1, gpacc(T, A1, N).
+user:gplen(L, N) :- gpacc(L, 0, N).
+user:gpl_proper :- gplen([a,b,c], N), N =:= 3.   % proper list → length 3
+user:gpl_partial :- \+ gplen([a,b|_], _).        % partial list → gplen fails → \+ succeeds
+user:gpick(a) :- !.
+user:gpick(b).
+user:gcommit :- gpick(X), X == a.                % neck cut commits to a
+
 go_available :-
     catch(
         ( process_create(path(go), ['version'],
@@ -70,6 +91,45 @@ test(inline_cut_in_negation_succeeds) :-
         throw(go_run_failed(Status))
     ),
     assertion(sub_string(OutStr, _, _, _, "GNC=true")),
+    ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ).
+
+test(clause_cut_b0_and_partial_list) :-
+    Proj = 'output/test_wam_go_b0cut_gen',
+    ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ),
+    write_wam_go_project([user:gpacc/3, user:gplen/2,
+                          user:gpl_proper/0, user:gpl_partial/0,
+                          user:gpick/1, user:gcommit/0],
+                         [module_name(b0cut), prefer_wam(true)], Proj),
+    directory_file_path(Proj, 'cmd', CmdDir),
+    directory_file_path(CmdDir, 'run', RunDir),
+    make_directory_path(RunDir),
+    directory_file_path(RunDir, 'main.go', MainPath),
+    setup_call_cleanup(
+        open(MainPath, write, MS),
+        write(MS,
+'package main\n\nimport (\n\t"fmt"\n\twam "b0cut"\n)\n\nfunc run(code []wam.Instruction, labels map[string]int, pc int) bool {\n\tvm := wam.NewWamState(code, labels)\n\tvm.PC = pc\n\treturn vm.Run()\n}\n\nfunc main() {\n\tfmt.Printf("PROPER=%v\\n", run(wam.Gpl_properCode, wam.Gpl_properLabels, wam.Gpl_properStartPC))\n\tfmt.Printf("PARTIAL=%v\\n", run(wam.Gpl_partialCode, wam.Gpl_partialLabels, wam.Gpl_partialStartPC))\n\tfmt.Printf("COMMIT=%v\\n", run(wam.GcommitCode, wam.GcommitLabels, wam.GcommitStartPC))\n}\n'),
+        close(MS)),
+    directory_file_path(Proj, 'go.mod', GoModPath),
+    read_file_to_string(GoModPath, GoModOld, []),
+    atomic_list_concat([GoModOld, "\nreplace b0cut => ../../\n"], GoModNew),
+    setup_call_cleanup(
+        open(GoModPath, write, GS),
+        write(GS, GoModNew),
+        close(GS)),
+    format(atom(RunCmd), 'cd ~w && go run main.go 2>&1', [RunDir]),
+    process_create(path(sh), ['-c', RunCmd],
+                   [stdout(pipe(Out)), process(Pid)]),
+    read_string(Out, _, OutStr),
+    close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    ->  true
+    ;   format(user_error, "~n[go run output]~n~w~n", [OutStr]),
+        throw(go_run_failed(Status))
+    ),
+    assertion(sub_string(OutStr, _, _, _, "PROPER=true")),
+    assertion(sub_string(OutStr, _, _, _, "PARTIAL=true")),
+    assertion(sub_string(OutStr, _, _, _, "COMMIT=true")),
     ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ).
 
 :- end_tests(wam_go_negation_cut).


### PR DESCRIPTION
  Go's !/0 was a structural no-op: Allocate captured EnvFrame.B0 = len(ChoicePoints) after the clause's try_me_else pushed the chain choicepoint, so B0 == len and the cut truncated nothing. A clause cut never removed its own alternatives — so proper_length-style predicates failed to reject partial lists, and a cut in a called predicate under  \+ behaved wrongly.

  Capture B0 at call time: WamState.PendingB0 (set by Call/Execute/CallPc/ExecutePc before transferring to a user predicate, i.e. before its try_me_else); EnvFrame.CutB0 (copied from PendingB0 at Allocate; B0 stays allocate-time for Deallocate's heuristic); !/0 truncates to env.CutB0.

  This depended on the prior GetConstant deref fix (PR #2868) — an earlier attempt regressed list recursion because get_constant on a bound *Unbound partial-list tail corrupted it; with that fixed, the call-time cut is safe. Adds clause_cut_b0_and_partial_list test.

  Test plan: Fixes clause-cut commit, cut-in-called-predicate-under-negation, and var/1-on-partial-list-tail. Zero regressions across 14 Go suites.

  Known remaining (separate, pre-existing M17 path, not regressed): \+ forall(g(X), Test) over a generator — the generator variable isn't rebound across backtracks under nested get_level/cut. Tracked in memory as the next forall-parity target.

  🤖 Generated with Claude Code (https://claude.com/claude-code)