### PR TITLE
fix(python): lowered builtin_call dispatch + if-then-else / negation / once

### DIFF
--- a/src/unifyweaver/targets/wam_python_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_python_lowered_emitter.pl
@@ -25,14 +25,18 @@
 	is_deterministic_pred_py/1,      % +Instrs
 	python_func_name/2,              % +Functor/Arity, -PythonName
 	parse_wam_text_py/2,             % +WamText, -Instrs
+	parse_wam_text_py_labeled/2,     % +WamText, -Instrs (keeps label/1 markers)
 	is_match_instr_py/1,             % +Instr
 	is_ite_block_py/2,               % +Instrs, -Blocks
-	emit_ite_block_py/5              % +FuncName, +Blocks, +Indent, +Opts, -Lines
+	emit_ite_block_py/5,             % +FuncName, +Blocks, +Indent, +Opts, -Lines
+	py_structured_clause1/2,         % +WamCode, -StructuredInstrs (soft-cut ITE)
+	emit_structured_python/4         % +FunctorArity, +Structured, +Opts, -Lines
 ]).
 
 :- use_module(library(lists)).
 :- use_module(library(option)).
 :- use_module('../targets/wam_text_parser', [wam_classify_constant_token/2]).
+:- use_module(wam_ite_structurer, [structure_ite/2]).
 
 % ============================================================================
 % Deterministic predicate detection
@@ -139,6 +143,151 @@ parse_wam_text_py(WamText, Instrs) :-
 	split_string(S, "\n", "", Lines),
 	parse_lines_py(Lines, Instrs).
 
+%% parse_wam_text_py_labeled(+WamText, -Instrs)
+%  Like parse_wam_text_py/2 but keeps label(Name) markers (as strings, so
+%  they unify with the string arguments of try_me_else / jump), so the
+%  shared structurer can find the LElse / LCont boundaries of an
+%  if-then-else block. Mirrors the Rust/Clojure/LLVM labeled parsers.
+parse_wam_text_py_labeled(WamText, Instrs) :-
+	atom_string(WamText, S),
+	split_string(S, "\n", "", Lines),
+	parse_lines_py_labeled(Lines, Instrs).
+
+parse_lines_py_labeled([], []).
+parse_lines_py_labeled([Line|Rest], Instrs) :-
+	split_string(Line, " \t,", " \t,", Parts),
+	delete(Parts, "", CleanParts),
+	(   CleanParts == []
+	->  parse_lines_py_labeled(Rest, Instrs)
+	;   CleanParts = [First|_],
+		(   sub_string(First, _, 1, 0, ":")
+		->  sub_string(First, 0, _, 1, LabelStr),
+			Instrs = [label(LabelStr)|More],
+			parse_lines_py_labeled(Rest, More)
+		;   instr_from_parts_py(CleanParts, Instr)
+		->  Instrs = [Instr|More],
+			parse_lines_py_labeled(Rest, More)
+		;   parse_lines_py_labeled(Rest, Instrs)
+		)
+	).
+
+% ============================================================================
+% If-then-else / negation / once lowering (shared structurer)
+%
+% Predicates with a soft-cut block — ( Cond -> Then ; Else ), \+ Goal,
+% once/1 — compile to try_me_else(LElse) <cond> cut_ite <then> jump(LCont) ;
+% LElse: trust_me <else> ; LCont: <cont>. is_deterministic_pred_py/1
+% rejects the internal try_me_else, so previously such predicates stayed in
+% the interpreter (sound but not lowered). Folding clause 1 through
+% wam_ite_structurer lets them lower to native Python if/else.
+%
+% Python derefs registers through the binding table, so — like the Rust
+% emitter — undoing the trail before the else branch restores any partial
+% bindings the condition made; no register snapshot is needed. The runtime
+% only trails a binding when state.b >= 0 (a choice point is live), and a
+% lowered ITE pushes no choice point, so the emitted code sets state.b to
+% the trail mark for the duration of the condition to force trailing, then
+% restores it.
+% ============================================================================
+
+%% py_structured_clause1(+WamCode, -Structured) is semidet.
+%  Parse the label-preserving stream, take clause 1, and fold its ITE
+%  blocks. Fails for genuine multi-clause predicates (their try_me_else is
+%  the first instruction, or the structurer cannot match a clean block).
+py_structured_clause1(WamCode, Structured) :-
+	(   is_list(WamCode) -> LInstrs = WamCode
+	;   parse_wam_text_py_labeled(WamCode, LInstrs)
+	),
+	\+ ( LInstrs = [try_me_else(_)|_] ),    % not predicate-level multi-clause
+	take_to_proceed_py(LInstrs, C1L),
+	structure_ite(C1L, Structured),
+	member(ite(_,_,_), Structured),         % there is an ITE to lower
+	\+ member(try_me_else(_), Structured),   % nothing unstructured survived
+	\+ member(retry_me_else(_), Structured),
+	\+ member(trust_me, Structured),
+	forall(member(I, Structured), py_supported_structured(I)).
+
+%% take_to_proceed_py(+Instrs, -Clause1) — up to and including the first
+%  proceed / fail terminator (label/1 markers pass through to the
+%  structurer, which drops them).
+take_to_proceed_py([], []).
+take_to_proceed_py([proceed|_], [proceed]) :- !.
+take_to_proceed_py([fail|_], [fail]) :- !.
+take_to_proceed_py([I|Rest], [I|Out]) :- take_to_proceed_py(Rest, Out).
+
+%% py_supported_structured(+StructuredInstr) — recurse through ite/3; each
+%  leaf must be an instruction emit_instr_py/2 can render.
+py_supported_structured(ite(C, T, E)) :- !,
+	forall(member(I, C), py_supported_structured(I)),
+	forall(member(I, T), py_supported_structured(I)),
+	forall(member(I, E), py_supported_structured(I)).
+py_supported_structured(I) :-
+	catch(emit_instr_py(I, _), _, fail).
+
+%% emit_structured_python(+Functor/Arity, +Structured, +Options, -Lines)
+%  Render a structured (ITE-folded) clause 1 as a lowered Python function.
+emit_structured_python(Functor/Arity, Structured, _Options, Lines) :-
+	python_func_name(Functor/Arity, FuncName),
+	atom_string(Functor, FStr),
+	nb_setval(py_ite_ctr, 0),
+	emit_struct_py(Structured, 4, BodyLines0),
+	(   BodyLines0 == [] -> BodyLines = ["    return True"] ; BodyLines = BodyLines0 ),
+	atomic_list_concat(BodyLines, '\n', Body),
+	format(string(Lines),
+'def ~w(state):
+    """Lowered predicate: ~w/~w (if-then-else / negation / once)"""
+~w', [FuncName, FStr, Arity, Body]).
+
+fresh_py_ite(N) :-
+	nb_getval(py_ite_ctr, N0), N is N0 + 1, nb_setval(py_ite_ctr, N).
+
+%% emit_struct_py(+Items, +Indent, -Lines) — Lines is a list of Python
+%  source lines at absolute indent Indent.
+emit_struct_py([], _Indent, []).
+emit_struct_py([Item|Rest], Indent, Lines) :-
+	emit_struct_item_py(Item, Indent, ItemLines),
+	emit_struct_py(Rest, Indent, RestLines),
+	append(ItemLines, RestLines, Lines).
+
+emit_struct_item_py(ite(Cond, Then, Else), Indent, Lines) :- !,
+	fresh_py_ite(N),
+	I1 is Indent + 4,
+	indent_str(Indent, Pad),
+	indent_str(I1, Pad1),
+	emit_struct_py(Cond, I1, CondLines),
+	emit_struct_py(Then, I1, ThenLines),
+	emit_struct_py(Else, I1, ElseLines),
+	format(string(LMark),  "~w_ite_mark~w = state.trail_len", [Pad, N]),
+	format(string(LSave),  "~w_ite_savedb~w = state.b", [Pad, N]),
+	format(string(LForce), "~wstate.b = _ite_mark~w", [Pad, N]),
+	format(string(LDef),   "~wdef _ite_cond~w():", [Pad, N]),
+	format(string(LCondT), "~wreturn True", [Pad1]),
+	format(string(LIf),    "~wif _ite_cond~w():", [Pad, N]),
+	format(string(LThenB), "~wstate.b = _ite_savedb~w", [Pad1, N]),
+	format(string(LElse),  "~welse:", [Pad]),
+	format(string(LElseB), "~wstate.b = _ite_savedb~w", [Pad1, N]),
+	format(string(LUndo),  "~wundo_trail(state, _ite_mark~w)", [Pad1, N]),
+	% then-branch body (may be empty -> the state.b restore is the body)
+	append([LThenB], ThenLines, ThenBody),
+	% else-branch body: restore b, roll back the condition's bindings, run else
+	append([LElseB, LUndo], ElseLines, ElseBody),
+	append([LMark, LSave, LForce, LDef | CondLines], [LCondT, LIf | ThenBody], Head0),
+	append(Head0, [LElse | ElseBody], Lines).
+emit_struct_item_py(Instr, Indent, Lines) :-
+	emit_instr_py(Instr, Code0),
+	reindent_py(Code0, Indent, Lines).
+
+%% reindent_py(+Code, +Indent, -Lines) — split the 4-space-based Code from
+%  emit_instr_py/2 into lines and shift each to absolute indent Indent.
+reindent_py(Code, Indent, Lines) :-
+	Extra is Indent - 4,
+	indent_str(Extra, ExtraPad),
+	split_string(Code, "\n", "", Raw),
+	maplist(shift_line_py(ExtraPad), Raw, Lines).
+
+shift_line_py(_ExtraPad, "", "") :- !.
+shift_line_py(ExtraPad, Line, Out) :- string_concat(ExtraPad, Line, Out).
+
 parse_lines_py([], []).
 parse_lines_py([Line|Rest], Instrs) :-
 	split_string(Line, " \t,", " \t,", Parts),
@@ -210,6 +359,12 @@ instr_from_parts_py(["return_add1", OutReg, InReg], return_add1(OutReg, InReg)).
 instr_from_parts_py(["neck_cut"], neck_cut).
 instr_from_parts_py(["get_level", Yn], get_level(Yn)).
 instr_from_parts_py(["cut", Yn], cut(Yn)).
+% Soft-cut commit and the then-branch's jump-to-continuation. Needed by the
+% label-preserving parse + wam_ite_structurer so ( Cond -> Then ; Else ),
+% \+ Goal and once/1 fold into ite(Cond,Then,Else). For ordinary
+% (non-ITE) predicates these never appear, so adding them here is inert.
+instr_from_parts_py(["cut_ite"], cut_ite).
+instr_from_parts_py(["jump", L], jump(L)).
 
 % ============================================================================
 % ITE (if/then/else) block detection
@@ -775,12 +930,20 @@ emit_instr_py(is(TargetStr, ExprStr), Code) :-
 
 % --- Built-in calls ---
 
+% A builtin_call dispatches to the SAME builtin implementation the
+% interpreter uses (execute_builtin, the public alias of the runtime's
+% _execute_builtin). It reads its arguments straight from the A-registers
+% (and derefs internally), so no _args list is needed. The previous
+% execute_foreign route only knew user-registered foreign predicates and
+% raised "Unknown foreign predicate" for every standard builtin (=/2, >/2,
+% is/2, true/0, fail/0, ...), so any lowered predicate containing one
+% crashed. call_foreign (below) keeps the execute_foreign path — that is
+% the genuine foreign-predicate instruction.
 emit_instr_py(builtin_call(OpStr, ArStr), Code) :-
 	escape_py(OpStr, EOp),
 	format(string(Code),
-'    _args = [deref(state.regs[i+1], state) for i in range(~w)]
-    if not execute_foreign("~w", ~w, _args, state): return False',
-		[ArStr, EOp, ArStr]).
+'    if not execute_builtin("~w", ~w, state): return False',
+		[EOp, ArStr]).
 
 emit_instr_py(call_foreign(PredStr, ArStr), Code) :-
 	escape_py(PredStr, EP),

--- a/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
+++ b/src/unifyweaver/targets/wam_python_runtime/WamRuntime.py
@@ -2286,7 +2286,13 @@ def throw_iso_error(state: WamState, err_term: Term) -> bool:
 
 
 def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int = -1) -> bool:
-    """Execute a WAM builtin_call instruction."""
+    """Execute a WAM builtin_call instruction.
+
+    Public alias `execute_builtin` is defined below: lowered predicate
+    functions call it (they import the runtime via `from wam_runtime import *`,
+    which skips underscore-prefixed names) to dispatch standard builtins the
+    same way the interpreter loop does.
+    """
     if builtin in ('catch/3', 'catch') and arity == 3:
         return _execute_catch(state)
     if builtin in ('throw/1', 'throw') and arity == 1:
@@ -2551,6 +2557,11 @@ def _execute_builtin(builtin: str, arity: int, state: 'WamState', resume_ip: int
     if builtin in ('nl/0', 'nl'):
         return _emit_output('\n', state=state)
     return False
+
+
+# Public alias so `from wam_runtime import *` (which skips underscore names)
+# exposes the builtin dispatcher to generated lowered predicate functions.
+execute_builtin = _execute_builtin
 
 
 # -- Main WAM interpreter loop ---------------------------------------------

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -66,7 +66,9 @@
 	emit_lowered_python/4,
 	is_deterministic_pred_py/1,
 	parse_wam_text_py/2,
-	python_func_name/2
+	python_func_name/2,
+	py_structured_clause1/2,
+	emit_structured_python/4
 ]).
 :- use_module('../targets/wam_text_parser',
               [wam_classify_constant_token/2,
@@ -1618,9 +1620,15 @@ format_python_wam_registrar(Pred/Arity, Options, InstrLiterals, PythonCode) :-
 %  inserts a call_lowered stub into raw_program. The separate registrar avoids
 %  a name collision with the pred_* lowered function itself.
 compile_lowered_wam_predicate_to_python(Pred/Arity, WamCode, Options, PythonCode) :-
-	parse_wam_text_py(WamCode, Instrs),
-	is_deterministic_pred_py(Instrs),
-	emit_lowered_python(Pred/Arity, Instrs, Options, LoweredFn),
+	% Soft-cut if-then-else / negation / once lowers via the shared
+	% structurer; everything else takes the straight-line deterministic
+	% path (unchanged).
+	(   py_structured_clause1(WamCode, Structured)
+	->  emit_structured_python(Pred/Arity, Structured, Options, LoweredFn)
+	;   parse_wam_text_py(WamCode, Instrs),
+	    is_deterministic_pred_py(Instrs),
+	    emit_lowered_python(Pred/Arity, Instrs, Options, LoweredFn)
+	),
 	atom_string(Pred, PredStr),
 	python_func_name(Pred/Arity, FuncName),
 	atom_concat(register_, FuncName, RegistrarName),
@@ -2143,8 +2151,10 @@ lowered_route_set(Plans, Options, LoweredSet) :-
 
 lowered_candidate_wam(Wam) :-
 	wam_plan_text(Wam, WamText),
-	parse_wam_text_py(WamText, Instrs),
-	is_deterministic_pred_py(Instrs).
+	(   parse_wam_text_py(WamText, Instrs),
+	    is_deterministic_pred_py(Instrs)
+	;   py_structured_clause1(WamText, _)    % soft-cut if-then-else / \+ / once
+	).
 
 fix_lowered_route_set(Current, Plans, Options, Final) :-
 	include(lowered_route_supported(Plans, Options, Current), Current, Next0),
@@ -2515,8 +2525,12 @@ if __name__ == \'__main__\':
 ', [ModuleName]).
 
 %% write_file(+Path, +Content)
-%  Write content to a file.
+%  Write content to a file. The runtime and generated modules embed UTF-8
+%  characters (arrows / dashes in comments and docstrings), so the stream
+%  is opened as UTF-8 regardless of the process locale (POSIX/ASCII in many
+%  CI containers) — otherwise write/2 raises an encoding error.
 write_file(Path, Content) :-
-	open(Path, write, Stream),
-	write(Stream, Content),
-	close(Stream).
+	setup_call_cleanup(
+		open(Path, write, Stream, [encoding(utf8)]),
+		write(Stream, Content),
+		close(Stream)).

--- a/tests/test_wam_python_lowered_ite.pl
+++ b/tests/test_wam_python_lowered_ite.pl
@@ -1,0 +1,134 @@
+% test_wam_python_lowered_ite.pl
+%
+% End-to-end execution test for WAM-Python if-then-else / negation / once
+% lowering (emit_mode(lowered)). Counterpart to the Go / Rust / C++ /
+% Haskell / F# / Clojure / LLVM / Elixir lowered-ITE exec tests. Pins:
+%
+%   * simple ITE         — pite/2;
+%   * negation (\+)       — pneg/1 (commit is the !/0 builtin: then = fail/0,
+%                          else = true/0, run after a trail rollback);
+%   * sequential ITEs    — pseqite/3 (two sibling blocks);
+%   * nested ITEs         — pnestite/2 (inner block in the then-arm).
+%
+% Python previously kept every predicate with a choice point (including the
+% internal try_me_else of a soft-cut block) in interpreter mode — sound but
+% not lowered. Folding clause 1 through wam_ite_structurer lets these lower
+% to native Python if/else. This test ALSO guards a prerequisite fix: the
+% lowered `builtin_call` instruction now dispatches through execute_builtin
+% (the runtime's standard-builtin dispatcher) instead of execute_foreign,
+% which only knew user-registered foreign predicates and raised
+% "Unknown foreign predicate" for =/2, >/2, true/0, fail/0, ... — so any
+% lowered predicate using a builtin (every ITE here) used to crash.
+%
+% Generates a lowered Python project and calls each lowered function with
+% the A-registers set, asserting the boolean outcome. Skipped unless
+% `python3` is on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module(library(process)).
+:- use_module('../src/unifyweaver/targets/wam_python_target').
+
+:- dynamic user:pite/2.
+:- dynamic user:pneg/1.
+:- dynamic user:pseqite/3.
+:- dynamic user:pnestite/2.
+
+user:pite(X, Y)       :- ( X > 0 -> Y = pos ; Y = nonpos ).
+user:pneg(X)          :- \+ X > 0.
+user:pseqite(X, Y, Z) :- ( X > 0 -> Y = pos ; Y = nonpos ),
+                         ( X > 5 -> Z = big ; Z = small ).
+user:pnestite(X, Y)   :- ( X > 0 -> ( X > 10 -> Y = big ; Y = small ) ; Y = neg ).
+
+python3_available :-
+    catch(( process_create(path(python3), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_python_lowered_ite, [condition(python3_available)]).
+
+test(ite_exec_parity) :-
+    Dir = 'output/test_wam_python_ite_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    % 1. Generate the lowered Python project.
+    write_wam_python_project(
+        [user:pite/2, user:pneg/1, user:pseqite/3, user:pnestite/2],
+        [module_name('iteproj'), emit_mode(lowered)], Dir),
+    % Sanity: the predicates must actually be lowered (native if/else),
+    % else the test would pass vacuously.
+    atomic_list_concat([Dir, '/predicates.py'], PredsPath),
+    read_file_to_string(PredsPath, PredsSrc, []),
+    forall(member(F, ["def pred_pite_2", "def pred_pneg_1",
+                      "def pred_pseqite_3", "def pred_pnestite_2"]),
+           assertion(sub_string(PredsSrc, _, _, _, F))),
+    assertion(sub_string(PredsSrc, _, _, _, "execute_builtin")),
+    % 2. Write the harness.
+    atomic_list_concat([Dir, '/harness.py'], HPath),
+    harness_source(Src),
+    setup_call_cleanup(open(HPath, write, S, [encoding(utf8)]),
+                       write(S, Src), close(S)),
+    % 3. Run it.
+    format(atom(Cmd), 'cd ~w && python3 harness.py 2>&1', [Dir]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 15 PASS")
+    ->  true
+    ;   format(user_error, "~n[python ite test output]~n~w~n", [OutStr]),
+        throw(python_ite_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_python_lowered_ite).
+
+% Builds a fresh WamState, sets the A-registers, calls each lowered function
+% and checks the boolean result. Atoms are plain Atom(name) values
+% (structural equality), so no interning coordination is needed.
+harness_source(
+"import sys
+sys.path.insert(0, '.')
+from wam_runtime import *
+from predicates import pred_pite_2, pred_pneg_1, pred_pseqite_3, pred_pnestite_2
+
+def fresh():
+    return WamState()
+
+def run1(fn, regs):
+    s = fresh()
+    for i, v in regs:
+        set_reg(s, i, v)
+    return bool(fn(s))
+
+I = Int
+A = Atom
+fails = 0
+total = 0
+def chk(name, got, want):
+    global fails, total
+    total += 1
+    if got != want:
+        fails += 1
+        print('FAIL', name, 'got', got, 'want', want)
+
+chk('pite(5,pos)',        run1(pred_pite_2, [(1, I(5)), (2, A('pos'))]),        True)
+chk('pite(5,nonpos)',     run1(pred_pite_2, [(1, I(5)), (2, A('nonpos'))]),     False)
+chk('pite(-1,nonpos)',    run1(pred_pite_2, [(1, I(-1)), (2, A('nonpos'))]),    True)
+chk('pite(-1,pos)',       run1(pred_pite_2, [(1, I(-1)), (2, A('pos'))]),       False)
+chk('pneg(5)',            run1(pred_pneg_1, [(1, I(5))]),                       False)
+chk('pneg(-1)',           run1(pred_pneg_1, [(1, I(-1))]),                      True)
+chk('pneg(0)',            run1(pred_pneg_1, [(1, I(0))]),                       True)
+chk('pseqite(10,pos,big)',      run1(pred_pseqite_3, [(1, I(10)), (2, A('pos')), (3, A('big'))]),     True)
+chk('pseqite(10,pos,small)',    run1(pred_pseqite_3, [(1, I(10)), (2, A('pos')), (3, A('small'))]),   False)
+chk('pseqite(3,pos,small)',     run1(pred_pseqite_3, [(1, I(3)), (2, A('pos')), (3, A('small'))]),    True)
+chk('pseqite(-1,nonpos,small)', run1(pred_pseqite_3, [(1, I(-1)), (2, A('nonpos')), (3, A('small'))]), True)
+chk('pnestite(20,big)',   run1(pred_pnestite_2, [(1, I(20)), (2, A('big'))]),   True)
+chk('pnestite(5,small)',  run1(pred_pnestite_2, [(1, I(5)), (2, A('small'))]),  True)
+chk('pnestite(-1,neg)',   run1(pred_pnestite_2, [(1, I(-1)), (2, A('neg'))]),   True)
+chk('pnestite(20,small)', run1(pred_pnestite_2, [(1, I(20)), (2, A('small'))]), False)
+
+if fails == 0:
+    print('ALL', total, 'PASS')
+else:
+    print(fails, 'FAILURES')
+").


### PR DESCRIPTION
## Summary

Continues the WAM if-then-else / negation / once parity sweep with the **Python** backend. Two related fixes, both verified end-to-end (the lowered Python path had **no runtime test** before this, which is why both bugs went unnoticed).

### 1. `builtin_call` dispatch (prerequisite bug)

A lowered `builtin_call` emitted `execute_foreign(op, arity, args, state)`, but `execute_foreign` only resolves user-registered **foreign** predicates and raises `Unknown foreign predicate` for every standard builtin (`=/2`, `>/2`, `is/2`, `true/0`, `fail/0`, …). So **any lowered predicate using a builtin crashed at runtime** — reproduced directly:

```
gtp(5)   CRASH: WAMError Unknown foreign predicate: >_lax/2/2
eqp(a,a) CRASH: WAMError Unknown foreign predicate: =/2/2
```

It now calls `execute_builtin` — the same dispatcher the interpreter loop uses — reading arguments straight from the A-registers. `execute_builtin` is added to `WamRuntime.py` as a public alias of `_execute_builtin` (generated modules do `from wam_runtime import *`, which skips underscore-prefixed names). `call_foreign` (the genuine foreign instruction) keeps the `execute_foreign` path.

### 2. if-then-else / negation / once lowering

`( Cond -> Then ; Else )`, `\+ Goal` and `once/1` compile to a `try_me_else` soft-cut block; `is_deterministic_pred_py/1` rejected the internal `try_me_else`, so these stayed in the interpreter (sound but not lowered). Clause 1 now folds through the shared `wam_ite_structurer` and emits native Python if/else:

```python
_ite_markN = state.trail_len; _ite_savedbN = state.b
state.b = _ite_markN          # force conditional trailing during the cond
def _ite_condN(): <cond>; return True
if _ite_condN():
    state.b = _ite_savedbN    # commit
    <then>
else:
    state.b = _ite_savedbN
    undo_trail(state, _ite_markN)   # roll back the cond's bindings
    <else>
```

Python derefs registers through the binding table, so unwinding the trail before the else restores any partial bindings the condition made (no register snapshot needed — same model as the Rust emitter). The runtime only trails when `state.b >= 0`; a lowered ITE pushes no choice point, so the code forces `state.b` for the condition's duration. Nested ITEs recurse; the `cut_ite` commit is structural (dropped by the structurer).

## Scope / neutrality

- The gate (`lowered_candidate_wam`) and `compile_lowered_wam_predicate_to_python` accept a structurable single-clause ITE in addition to the deterministic case.
- Predicates **without** an ITE take the unchanged deterministic path (byte-identical when they use no builtins).
- Predicates that **use builtins** now dispatch correctly instead of crashing (the only non-ITE behavior change — a fix, not a regression).
- `write_wam_python_project` opens output files as UTF-8 so the runtime's non-ASCII characters write under a POSIX/ASCII process locale.

## Tests

- `tests/test_wam_python_lowered_ite.pl` — gated on `python3`; generates the lowered project and runs simple, sequential, nested ITE and negation. **15/15 correct.**
- Existing `test_wam_python_target` and `test_wam_python_effective_distance_smoke` still pass.

## Sweep status

ITE parity now covers **Go, Rust, C++, Haskell, F#, Clojure, LLVM, Elixir, and Python**. Remaining: **lua, r** are sound-but-unlowered (reject ITE, fall back to their interpreters) — perf-enablement, and their toolchains (lua / Rscript) aren't installed in this environment.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_