### PR TITLE
LLVM WAM: chown/3 (M115) -- libc chown wrapper

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1513,6 +1513,7 @@ declare i32 @getpgrp()
 declare i8* @realpath(i8*, i8*)
 declare i32 @kill(i32, i32)
 declare i32 @truncate(i8*, i64)
+declare i32 @chown(i8*, i32, i32)
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3610,6 +3611,7 @@ entry:
     i32 128, label %builtin_realpath
     i32 129, label %builtin_kill
     i32 130, label %builtin_truncate
+    i32 131, label %builtin_chown
   ]
 
 builtin_is:
@@ -5795,6 +5797,44 @@ tr.do:
   %tr.ret = call i32 @truncate(i8* %tr.path, i64 %tr.len)
   %tr.ok = icmp eq i32 %tr.ret, 0
   ret i1 %tr.ok
+
+builtin_chown:
+  ; M115: chown(+Path, +Uid, +Gid) -- libc chown wrapper.
+  ; Path must be Atom, Uid and Gid Integer. uid_t / gid_t are i32
+  ; on Linux glibc and the major BSDs / macOS / WASI -- truncate
+  ; the i64 payloads. Succeeds iff chown returns 0; EPERM (not
+  ; root), ENOENT, EACCES etc. map to a Prolog fail. Special
+  ; convention: -1 (or 0xFFFFFFFF) for either Uid or Gid leaves
+  ; that side unchanged (libc semantic, preserved as-is).
+  %co.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %co.t1 = call i32 @value_tag(%Value %co.a1)
+  %co.is_atom = icmp eq i32 %co.t1, 0
+  br i1 %co.is_atom, label %co.check2, label %co.fail
+co.fail:
+  ret i1 false
+co.check2:
+  %co.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %co.t2 = call i32 @value_tag(%Value %co.a2)
+  %co.is_int2 = icmp eq i32 %co.t2, 1
+  br i1 %co.is_int2, label %co.check3, label %co.fail
+co.check3:
+  %co.a3 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 2)
+  %co.t3 = call i32 @value_tag(%Value %co.a3)
+  %co.is_int3 = icmp eq i32 %co.t3, 1
+  br i1 %co.is_int3, label %co.go, label %co.fail
+co.go:
+  %co.aid = call i64 @value_payload(%Value %co.a1)
+  %co.path = call i8* @wam_atom_to_string(i64 %co.aid)
+  %co.path_null = icmp eq i8* %co.path, null
+  br i1 %co.path_null, label %co.fail, label %co.do
+co.do:
+  %co.uid64 = call i64 @value_payload(%Value %co.a2)
+  %co.uid = trunc i64 %co.uid64 to i32
+  %co.gid64 = call i64 @value_payload(%Value %co.a3)
+  %co.gid = trunc i64 %co.gid64 to i32
+  %co.ret = call i32 @chown(i8* %co.path, i32 %co.uid, i32 %co.gid)
+  %co.ok = icmp eq i32 %co.ret, 0
+  ret i1 %co.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -13032,6 +13072,7 @@ builtin_op_to_id('getpgrp/1', 127).           % libc getpgrp() as Integer.
 builtin_op_to_id('realpath/2', 128).          % libc realpath(rel) -> Abs atom.
 builtin_op_to_id('kill/2', 129).              % libc kill(pid, sig).
 builtin_op_to_id('truncate/2', 130).          % libc truncate(path, length).
+builtin_op_to_id('chown/3', 131).             % libc chown(path, uid, gid).
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2107,6 +2107,7 @@ is_builtin_pred(getpgrp, 1).            % getpgrp(-PGid) -- process group id.
 is_builtin_pred(realpath, 2).           % realpath(+Path, -Abs) -- canonical absolute path.
 is_builtin_pred(kill, 2).               % kill(+Pid, +Sig) -- signal 0 = existence check.
 is_builtin_pred(truncate, 2).           % truncate(+Path, +Length) -- set file size.
+is_builtin_pred(chown, 3).              % chown(+Path, +Uid, +Gid) -- change owner.
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2459,6 +2459,48 @@ test_cmp_lists_diff(_, R) :-
 test_forall_manual(_, R) :-
     ( ( ( positive(X), ( X > 0 -> fail ; true ) ) -> fail ; true ) -> R is 1 ; R is 0 ).
 
+% M115: chown/3 -- libc chown wrapper. Non-root callers can only
+% chown to their OWN uid/gid (-1 means "leave that side unchanged").
+
+:- dynamic test_chown_self_self/2.
+test_chown_self_self(_, R) :-
+    % Create a temp file, chown to (our own uid, our own gid).
+    % Non-root caller can only chown a file to their own credentials,
+    % and this combination always succeeds.
+    Path = '/tmp/uw_m115_chown_self',
+    shell('touch /tmp/uw_m115_chown_self', _),
+    getuid(U),
+    getgid(G),
+    chown(Path, U, G),
+    shell('rm -f /tmp/uw_m115_chown_self', _),
+    R is 1.   % 1
+
+:- dynamic test_chown_noop/2.
+test_chown_noop(_, R) :-
+    % Passing -1 for both uid and gid is a libc no-op that
+    % succeeds iff the file exists and the caller can access it.
+    Path = '/tmp/uw_m115_chown_noop',
+    shell('touch /tmp/uw_m115_chown_noop', _),
+    chown(Path, -1, -1),
+    shell('rm -f /tmp/uw_m115_chown_noop', _),
+    R is 1.   % 1
+
+:- dynamic test_chown_missing/2.
+test_chown_missing(_, R) :-
+    % chown on a non-existent path fails (ENOENT).
+    ( chown('/tmp/uw_m115_does_not_exist', -1, -1) -> R is 0
+    ; R is 1
+    ).   % 1
+
+:- dynamic test_chown_bad_args/2.
+test_chown_bad_args(_, R) :-
+    % Non-atom path or non-int uid/gid fail the type guards.
+    ( chown(42, 0, 0) -> R is 0
+    ; chown('/tmp/x', not_int, 0) -> R is 0
+    ; chown('/tmp/x', 0, not_int) -> R is 0
+    ; R is 1
+    ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -5322,6 +5364,15 @@ test_all :-
                    test_sort_mixed_num, 0, 1),
        run_test_r0('sort already-sorted length -> 5',
                    test_sort_already_sorted, 0, 5),
+       format('--- M115 chown/3 ---~n'),
+       run_test_r0('chown to own (uid, gid) -> 1',
+                   test_chown_self_self, 0, 1),
+       run_test_r0('chown(-1, -1) no-op -> 1',
+                   test_chown_noop, 0, 1),
+       run_test_r0('chown on missing path fails -> 1',
+                   test_chown_missing, 0, 1),
+       run_test_r0('chown with non-atom path / non-int uid/gid fails -> 1',
+                   test_chown_bad_args, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

- **M115 `chown/3`** — libc `chown(path, uid, gid)` wrapper. Op id 131.

Reads reg 0 (Path) as Atom, reg 1 (Uid) and reg 2 (Gid) as Integer, pulls the path via `wam_atom_to_string`, truncates both `i64` credential payloads to `i32` (`uid_t` / `gid_t` are `i32` on Linux glibc and on the major BSDs / macOS / WASI), and calls libc `chown`. Succeeds iff `chown` returns 0; `EPERM` (not root), `ENOENT`, `EACCES` etc. all map to a Prolog fail. Non-atom Path or non-Integer Uid/Gid fall through to fail.

Special convention preserved: **`-1`** for either Uid or Gid means "leave that side unchanged" — libc semantic, no translation done. Same shape as M102 `chmod/2` with an extra `i32` gid argument.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `@chown` libc decl, dispatch entry, `builtin_chown` IR block (prefix `co.`), op-id table entry.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred(chown, 3)`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — four M115 tests + section.

## Test plan

- [x] **All four M115 tests pass** in both runs ✓
- [x] `test_chown_self_self`: chown to caller's own (uid, gid) — succeeds for unprivileged callers ✓
- [x] `test_chown_noop`: `chown(-1, -1)` no-op succeeds iff file exists ✓
- [x] `test_chown_missing`: chown on absent path fails (`ENOENT`) ✓
- [x] `test_chown_bad_args`: non-atom path / non-int uid/gid all fail type guards ✓

## Suite-level note

SWI-Prolog 9.0.4's hard 4 GB global-stack cap is reached again, this time at slot 675 in the M10 `\+` section (`test_not_absent`). This is the **same wall** M108 fixed (then at slot 658). M108's side-channel for the IR-counts read-back bought headroom for ~17 more tests, and we've now consumed it by adding M109–M115 tests. M115 itself doesn't add per-test allocation — its chown tests run cleanly at slot 403–406, well before the cliff. The OOM is the pre-existing per-test pressure pattern catching up again.

A proper fix is a future milestone (probably stream `write_wam_llvm_project`'s IR output directly to file rather than building one big Prolog atom; or split `test_all` across multiple swipl invocations).

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_