### PR TITLE
fix(wam-go): trail register-alias rewrites so generators rebind under forall

### DIFF
--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -16,6 +16,16 @@ type TrailEntry struct {
 	Addr   int
 	Old    Value
 	HadOld bool
+	// Register-restore entry: when RegIdx >= 0, this entry records a
+	// register-alias rewrite done by bindUnbound (Regs[RegIdx] was RegOld,
+	// an Unbound, before being rewritten to the bound value). Backtrack
+	// restores Regs[RegIdx] = RegOld so the register goes back to sharing
+	// the (now-unbound) variable cell -- otherwise a register that aliased
+	// a bound var keeps the stale value across backtracking and a later
+	// rebind of the same var doesn't reach it. RegIdx == -1 for the normal
+	// Bindings-restore entry.
+	RegIdx int
+	RegOld Value
 }
 
 type AtomPair struct {
@@ -342,7 +352,7 @@ func (vm *WamState) setBinding(addr int, val Value) {
 
 func (vm *WamState) trailBinding(addr int) {
 	old := vm.getBinding(addr)
-	vm.Trail = append(vm.Trail, TrailEntry{Addr: addr, Old: old, HadOld: old != nil})
+	vm.Trail = append(vm.Trail, TrailEntry{Addr: addr, Old: old, HadOld: old != nil, RegIdx: -1})
 	vm.TrailLen++
 }
 
@@ -365,6 +375,14 @@ func (vm *WamState) bindUnbound(u *Unbound, val Value) {
 	vm.setBinding(u.Idx, val)
 	for idx, reg := range vm.Regs {
 		if reg == u {
+			// Trail the rewrite so backtrack restores this register to the
+			// (now-unbound) variable cell. Without this, a register that
+			// aliased u keeps the stale bound value after backtrack and a
+			// later rebind of u (e.g. a generator yielding its next
+			// solution) never reaches it -- which made forall over a
+			// generator see only the first element.
+			vm.Trail = append(vm.Trail, TrailEntry{RegIdx: idx, RegOld: reg})
+			vm.TrailLen++
 			vm.Regs[idx] = val
 		}
 	}
@@ -2750,6 +2768,12 @@ func (vm *WamState) backtrack() bool {
 func (vm *WamState) unwindTrailTo(mark int) {
     for i := vm.TrailLen - 1; i >= mark; i-- {
         entry := vm.Trail[i]
+        if entry.RegIdx >= 0 {
+            // Register-alias rewrite: restore the register to the variable
+            // cell it shared before bindUnbound rewrote it to a value.
+            vm.Regs[entry.RegIdx] = entry.RegOld
+            continue
+        }
         // setBinding handles the bookkeeping: writing nil reverts an
         // address to its unbound state, exactly matching the previous
         // map-based delete-on-!HadOld for the slice rep.

--- a/tests/test_wam_go_negation_cut.pl
+++ b/tests/test_wam_go_negation_cut.pl
@@ -48,6 +48,18 @@ user:gpick(a) :- !.
 user:gpick(b).
 user:gcommit :- gpick(X), X == a.                % neck cut commits to a
 
+% forall over a multi-solution generator. forall drives backtracking by
+% failing after each test-success; the generator variable must be rebound
+% across backtracks (the register-alias rewrite in bindUnbound is trailed
+% so it survives backtrack). Before the fix, forall saw only the first
+% element and so wrongly succeeded for the failing cases.
+:- dynamic user:gfa_all/0.
+:- dynamic user:gfa_neg/0.
+:- dynamic user:gfa_posfail/0.
+user:gfa_all :- forall(member(X, [1,2,3]), X >= 1).          % all hold → true
+user:gfa_neg :- \+ forall(member(X, [1,2,3]), X =:= 1).      % not all → \+ true
+user:gfa_posfail :- forall(member(X, [1,2,3]), X =:= 1).     % not all → forall false
+
 go_available :-
     catch(
         ( process_create(path(go), ['version'],
@@ -130,6 +142,43 @@ test(clause_cut_b0_and_partial_list) :-
     assertion(sub_string(OutStr, _, _, _, "PROPER=true")),
     assertion(sub_string(OutStr, _, _, _, "PARTIAL=true")),
     assertion(sub_string(OutStr, _, _, _, "COMMIT=true")),
+    ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ).
+
+test(forall_over_generator) :-
+    Proj = 'output/test_wam_go_forall_gen',
+    ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ),
+    write_wam_go_project([user:gfa_all/0, user:gfa_neg/0, user:gfa_posfail/0],
+                         [module_name(faall), prefer_wam(true)], Proj),
+    directory_file_path(Proj, 'cmd', CmdDir),
+    directory_file_path(CmdDir, 'run', RunDir),
+    make_directory_path(RunDir),
+    directory_file_path(RunDir, 'main.go', MainPath),
+    setup_call_cleanup(
+        open(MainPath, write, MS),
+        write(MS,
+'package main\n\nimport (\n\t"fmt"\n\twam "faall"\n)\n\nfunc run(code []wam.Instruction, labels map[string]int, pc int) bool {\n\tvm := wam.NewWamState(code, labels)\n\tvm.PC = pc\n\treturn vm.Run()\n}\n\nfunc main() {\n\tfmt.Printf("ALL=%v\\n", run(wam.Gfa_allCode, wam.Gfa_allLabels, wam.Gfa_allStartPC))\n\tfmt.Printf("NEG=%v\\n", run(wam.Gfa_negCode, wam.Gfa_negLabels, wam.Gfa_negStartPC))\n\tfmt.Printf("POSFAIL=%v\\n", run(wam.Gfa_posfailCode, wam.Gfa_posfailLabels, wam.Gfa_posfailStartPC))\n}\n'),
+        close(MS)),
+    directory_file_path(Proj, 'go.mod', GoModPath),
+    read_file_to_string(GoModPath, GoModOld, []),
+    atomic_list_concat([GoModOld, "\nreplace faall => ../../\n"], GoModNew),
+    setup_call_cleanup(
+        open(GoModPath, write, GS),
+        write(GS, GoModNew),
+        close(GS)),
+    format(atom(RunCmd), 'cd ~w && go run main.go 2>&1', [RunDir]),
+    process_create(path(sh), ['-c', RunCmd],
+                   [stdout(pipe(Out)), process(Pid)]),
+    read_string(Out, _, OutStr),
+    close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    ->  true
+    ;   format(user_error, "~n[go run output]~n~w~n", [OutStr]),
+        throw(go_run_failed(Status))
+    ),
+    assertion(sub_string(OutStr, _, _, _, "ALL=true")),
+    assertion(sub_string(OutStr, _, _, _, "NEG=true")),
+    assertion(sub_string(OutStr, _, _, _, "POSFAIL=false")),
     ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ).
 
 :- end_tests(wam_go_negation_cut).


### PR DESCRIPTION
  bindUnbound rewrites every register aliasing the bound variable to the bound value, but didn't trail those register writes. After put_variable X1,A1 (X1 and A1 share one cell U), binding U rewrote both to the value; on backtrack the trail unwound Bindings[U] but X1/A1 kept the stale value. A generator yielding its next solution rebinds only its output register, then the consumer's put_value copies the stale aliased register back — so forall over a generator saw only the first element and wrongly succeeded (e.g. forall(member(X,[1,2,3]), X=:=1) returned true).

  Trail the register-alias rewrites: TrailEntry gains RegIdx/RegOld (RegIdx == -1 for the normal Bindings entry), bindUnbound records each rewritten register, and unwindTrailTo restores Regs[RegIdx] to the shared (now-unbound) cell on backtrack. The generator's rebind then propagates to all aliases.

  Test plan: Fixes forall over a multi-solution generator (member + fact generators). Adds forall_over_generator to test_wam_go_negation_cut. Zero regressions across 14 Go suites.

  🤖 Generated with Claude Code (https://claude.com/claude-code)