### PR TITLE
feat(RES): Phase 0 — module skeleton + smoke test

### DIFF
--- a/src/unifyweaver/core/recurrence_evaluation_strategy.pl
+++ b/src/unifyweaver/core/recurrence_evaluation_strategy.pl
@@ -1,0 +1,210 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% recurrence_evaluation_strategy.pl — pick an evaluation strategy for
+% a detected recursive kernel.
+%
+% Given a Recurrence term (constructed from a detected kernel +
+% clause analysis + algorithm manifest) and a Workload signal list,
+% return the strategy the target should use to emit code, plus a
+% structured reasoning trace.
+%
+% Phase 0 status: SKELETON. The public API is wired (call chain
+% classify -> concat -> cost-model -> resolve), but every helper
+% returns a `not_yet_implemented(Phase)` sentinel. The baseline
+% strategy is `per_query(unidirectional)` and the trace contains a
+% single `step(stub, not_yet_implemented(phase_0), [])` entry.
+%
+% This baseline lets the F# WAM target integration (Phase 5) call
+% against the module from day one, and lets the stub-leak assertion
+% in Phase 5 tests fail loud if real selections still produce stub
+% steps after Phases 1-4 land.
+%
+% Determinism contract: every exported predicate is `det`. None
+% fails; the only errors are structural (no_admissible_strategy/1
+% from select_evaluation_strategy/3, and type errors from the
+% valid_* checkers).
+%
+% Cross-references:
+%   - docs/design/RECURRENCE_EVALUATION_STRATEGY_PHILOSOPHY.md
+%   - docs/design/RECURRENCE_EVALUATION_STRATEGY_SPECIFICATION.md
+%   - docs/design/RECURRENCE_EVALUATION_STRATEGY_IMPLEMENTATION_PLAN.md
+%
+% The trace step name `stub` is the explicit tag Phase 5 tests
+% assert against to catch leak-through of unimplemented helpers.
+
+:- module(recurrence_evaluation_strategy, [
+    %% Main entry point
+    select_evaluation_strategy/3,        % +Recurrence, +Workload, -StrategyAndTrace
+
+    %% Pipeline helpers (called by select_evaluation_strategy/3,
+    %% also exported for direct test access and future composability)
+    classify_signals/4,                  % +Workload, -Intent, -DeclaredData, -InferredData
+    apply_cost_model/3,                  % +Recurrence, +DataSignals, -CostModelChoice
+    resolve_against_intent/5,            % +IntentSignals, +CostModelChoice, +Recurrence,
+                                         %   -Strategy, -Trace
+
+    %% Trace renderers (called by target adapters, NOT by the
+    %% selector itself - the module is pure-functional)
+    render_trace_for_stderr/2,           % +Trace, -StderrLines
+    format_trace_for_comment/3,          % +Trace, +CommentPrefix, -CommentString
+
+    %% Introspection
+    admissible_strategies/2,             % +Recurrence, -StrategyList
+    strategy_pretty/2,                   % +Strategy, -String
+
+    %% Type-check helpers (exported so tests can verify the contracts
+    %% without re-implementing them)
+    valid_recurrence/1,                  % +Recurrence
+    valid_workload/1,                    % +Workload
+    valid_strategy/1                     % +Strategy (checks the outer
+                                         % strategy/1 wrapper, not just
+                                         % the inner Mode)
+]).
+
+:- use_module(library(error), [must_be/2, domain_error/2, type_error/2]).
+:- use_module(library(lists), [append/3]).
+
+%% ============================================================
+%% Public API — Phase 0 stubs
+%% ============================================================
+
+%% select_evaluation_strategy(+Recurrence, +Workload, -StrategyAndTrace)
+%
+% Pre-wires the full pipeline:
+%
+%   classify_signals(Workload, I, D, F)
+%   append(D, F, DataSignals)
+%   apply_cost_model(Recurrence, DataSignals, CostModelChoice)
+%   resolve_against_intent(I, CostModelChoice, Recurrence, Strategy, Trace)
+%
+% Phase 0: every helper returns a stub; the baseline strategy emerges
+% as `per_query(unidirectional)` with a `step(stub, ...)` trace entry.
+%
+% Phases 1-4 replace the helpers; this entry point's structure does
+% not change.
+select_evaluation_strategy(Recurrence, Workload, strategy_choice(Strategy, Trace)) :-
+    valid_recurrence(Recurrence),
+    valid_workload(Workload),
+    classify_signals(Workload, IntentSignals, DeclaredData, InferredData),
+    append(DeclaredData, InferredData, DataSignals),
+    apply_cost_model(Recurrence, DataSignals, CostModelChoice),
+    resolve_against_intent(IntentSignals, CostModelChoice, Recurrence, Strategy, Trace0),
+    %% Phase 0: prepend the stub marker so the stub-leak assertion can
+    %% detect partial implementation.
+    Trace0 = trace(Steps0),
+    Trace  = trace([step(stub, not_yet_implemented(phase_0), []) | Steps0]).
+
+%% classify_signals(+Workload, -IntentSignals, -DeclaredData, -InferredData)
+%
+% Phase 0 stub: returns three empty lists regardless of input.
+% Phase 1 implements the real dispatch table.
+classify_signals(_Workload, [], [], []).
+
+%% apply_cost_model(+Recurrence, +DataSignals, -CostModelChoice)
+%
+% Phase 0 stub: returns the default-fallback choice unconditionally.
+% Phase 2 implements the rule registry and scoring.
+apply_cost_model(_Recurrence, _DataSignals,
+    cost_model_choice(strategy(per_query(unidirectional)), 0, default_fallback)).
+
+%% resolve_against_intent(+IntentSignals, +CostModelChoice, +Recurrence,
+%%                       -Strategy, -Trace)
+%
+% Phase 0 stub: returns the cost-model's chosen strategy unchanged
+% with a single-step trace recording that resolution was skipped.
+% Phase 3 implements the six-step hierarchy.
+resolve_against_intent(_IntentSignals,
+                       cost_model_choice(Strategy, _Score, _Rule),
+                       _Recurrence,
+                       Strategy,
+                       trace([step(no_intent, applied,
+                                   [phase_0_stub_skipped_resolution])])).
+
+%% render_trace_for_stderr(+Trace, -Lines)
+%
+% Phase 0 stub: returns an empty list (no rendering).
+% Phase 4 implements the real renderer.
+render_trace_for_stderr(_Trace, []).
+
+%% format_trace_for_comment(+Trace, +CommentPrefix, -CommentString)
+%
+% Phase 0 stub: returns an empty string.
+% Phase 4 implements the real comment renderer with per-line
+% CommentPrefix application.
+format_trace_for_comment(_Trace, _CommentPrefix, "").
+
+%% admissible_strategies(+Recurrence, -StrategyList)
+%
+% Phase 0 stub: returns the single-element list with the baseline
+% strategy. Phase 2 implements the kernel-kind-to-strategies table
+% and termination-guarantee filtering.
+admissible_strategies(_Recurrence, [strategy(per_query(unidirectional))]).
+
+%% strategy_pretty(+Strategy, -String)
+%
+% Phase 0 stub: returns the strategy term rendered with format_to_atom.
+% Phase 4 implements the pretty-printer alongside the renderers.
+strategy_pretty(Strategy, String) :-
+    format(string(String), "~w", [Strategy]).
+
+%% ============================================================
+%% Type-check helpers
+%%
+%% These ARE implemented for real in Phase 0 — Phase 1+ helpers
+%% rely on them at every call site, and the smoke test exercises
+%% them directly.
+%% ============================================================
+
+%% valid_recurrence(+Recurrence) is det.
+%
+% A valid Recurrence is `recurrence(KernelKind, Pred/Arity, Properties)`
+% where KernelKind is an atom, Pred/Arity is a predicate indicator,
+% and Properties is a list.
+%
+% Throws type_error or domain_error on malformed input; succeeds
+% silently on valid input.
+valid_recurrence(recurrence(KernelKind, Pred/Arity, Properties)) :- !,
+    must_be(atom, KernelKind),
+    must_be(atom, Pred),
+    must_be(nonneg, Arity),
+    must_be(list, Properties).
+valid_recurrence(Other) :-
+    type_error(recurrence_term, Other).
+
+%% valid_workload(+Workload) is det.
+%
+% A valid Workload is a list of signal terms. Phase 0 does not
+% inspect individual signals; Phase 1 adds the dispatch-table-based
+% per-signal validation.
+valid_workload(Workload) :-
+    must_be(list, Workload).
+
+%% valid_strategy(+Strategy) is det.
+%
+% A valid Strategy is `strategy(Mode)` where Mode is one of:
+%
+%   per_query(SearchAlgo)
+%   fixed_point(IterAlgo)
+%   cached
+%   hybrid(_)
+%
+% IMPORTANT: this checks the OUTER `strategy/1` wrapper, not just
+% the inner Mode. A bare Mode term (e.g. `per_query(bidirectional)`)
+% without the outer wrapper is rejected — that was an explicit
+% Phase 0 success criterion flagged in review.
+valid_strategy(strategy(Mode)) :- !,
+    valid_mode(Mode).
+valid_strategy(Other) :-
+    type_error(strategy_wrapper, Other).
+
+valid_mode(per_query(Algo)) :- !,
+    must_be(atom, Algo).
+valid_mode(fixed_point(Algo)) :- !,
+    must_be(atom, Algo).
+valid_mode(cached) :- !.
+valid_mode(hybrid(Components)) :- !,
+    must_be(list, Components).
+valid_mode(Other) :-
+    domain_error(strategy_mode, Other).

--- a/tests/core/test_res_skeleton.pl
+++ b/tests/core/test_res_skeleton.pl
@@ -1,0 +1,155 @@
+:- encoding(utf8).
+%% Phase 0 smoke test for recurrence_evaluation_strategy.pl
+%%
+%% Verifies:
+%%   - module loads without error
+%%   - select_evaluation_strategy/3 returns the baseline strategy
+%%   - trace contains the `step(stub, ...)` marker (Phase 5 leak detector)
+%%   - determinism contract holds: deterministic inside if-then-else,
+%%     exactly one solution under findall/3
+%%   - valid_strategy/1 checks the outer strategy/1 wrapper (not just
+%%     the inner Mode term) — Phase 0 success criterion flagged in review
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_res_skeleton.pl
+
+:- use_module('../../src/unifyweaver/core/recurrence_evaluation_strategy').
+:- use_module(library(lists)).
+
+%% ========================================================================
+%% Test runner — same shape as test_algorithm_manifest.pl for consistency
+%% ========================================================================
+
+run_tests :-
+    format("~n========================================~n"),
+    format("RES Phase 0 Skeleton Tests~n"),
+    format("========================================~n~n"),
+    findall(Test, test(Test), Tests),
+    length(Tests, Total),
+    run_all(Tests, 0, Passed),
+    format("~n========================================~n"),
+    (   Passed =:= Total
+    ->  format("All ~w tests passed~n", [Total])
+    ;   Failed is Total - Passed,
+        format("~w of ~w tests FAILED~n", [Failed, Total]),
+        format("Tests FAILED~n"),
+        halt(1)
+    ),
+    format("========================================~n").
+
+run_all([], Passed, Passed).
+run_all([Test|Rest], Acc, Passed) :-
+    (   catch(call(Test), Error,
+            (format("[FAIL] ~w: ~w~n", [Test, Error]), fail))
+    ->  format("[PASS] ~w~n", [Test]),
+        Acc1 is Acc + 1,
+        run_all(Rest, Acc1, Passed)
+    ;   run_all(Rest, Acc, Passed)
+    ).
+
+%% ========================================================================
+%% Test declarations
+%% ========================================================================
+
+test(test_module_loads).
+test(test_baseline_strategy_returned).
+test(test_trace_contains_stub_step).
+test(test_determinism_in_if_then_else).
+test(test_determinism_under_findall).
+test(test_valid_strategy_accepts_wrapped).
+test(test_valid_strategy_rejects_bare_mode).
+test(test_valid_strategy_rejects_unknown_mode).
+test(test_valid_recurrence_accepts_well_formed).
+test(test_valid_recurrence_rejects_non_recurrence_term).
+test(test_valid_workload_accepts_list).
+test(test_valid_workload_rejects_non_list).
+
+%% ========================================================================
+%% Test fixtures
+%% ========================================================================
+
+a_recurrence(recurrence(transitive_closure2, my_pred/2,
+    [value_domain(combinatorial), monotone(true)])).
+
+a_workload([]).
+
+%% ========================================================================
+%% Tests
+%% ========================================================================
+
+%% Trivially true if the test file loaded at all (use_module at top
+%% would have failed otherwise). Kept as an explicit assertion so a
+%% reader sees "module loads" listed in the test output.
+test_module_loads :-
+    current_predicate(recurrence_evaluation_strategy:select_evaluation_strategy/3).
+
+test_baseline_strategy_returned :-
+    a_recurrence(R),
+    a_workload(W),
+    select_evaluation_strategy(R, W, strategy_choice(Strategy, _Trace)),
+    Strategy == strategy(per_query(unidirectional)).
+
+test_trace_contains_stub_step :-
+    a_recurrence(R),
+    a_workload(W),
+    select_evaluation_strategy(R, W, strategy_choice(_Strategy, trace(Steps))),
+    member(step(stub, not_yet_implemented(phase_0), []), Steps).
+
+%% Determinism: called inside if-then-else, the predicate succeeds
+%% in the if-branch without leaving a choicepoint. The cut after
+%% select_evaluation_strategy/3's success would suppress
+%% non-determinism, but the test runs the predicate as the if-condition
+%% which exercises the same determinism contract.
+test_determinism_in_if_then_else :-
+    a_recurrence(R),
+    a_workload(W),
+    (   select_evaluation_strategy(R, W, _Result)
+    ->  true
+    ;   fail
+    ).
+
+%% findall/3 collects all solutions; deterministic means exactly one.
+test_determinism_under_findall :-
+    a_recurrence(R),
+    a_workload(W),
+    findall(Result, select_evaluation_strategy(R, W, Result), Results),
+    length(Results, N),
+    N == 1.
+
+test_valid_strategy_accepts_wrapped :-
+    valid_strategy(strategy(per_query(bidirectional))),
+    valid_strategy(strategy(per_query(unidirectional))),
+    valid_strategy(strategy(fixed_point(semi_naive))),
+    valid_strategy(strategy(cached)),
+    valid_strategy(strategy(hybrid([per_query(astar), fixed_point(semi_naive)]))).
+
+%% A bare Mode term without the outer strategy/1 wrapper must be
+%% rejected. The Phase 0 success criterion in the implementation
+%% plan explicitly calls this out.
+test_valid_strategy_rejects_bare_mode :-
+    catch(valid_strategy(per_query(bidirectional)),
+          error(type_error(strategy_wrapper, _), _),
+          true).
+
+test_valid_strategy_rejects_unknown_mode :-
+    catch(valid_strategy(strategy(quantum)),
+          error(domain_error(strategy_mode, _), _),
+          true).
+
+test_valid_recurrence_accepts_well_formed :-
+    a_recurrence(R),
+    valid_recurrence(R).
+
+test_valid_recurrence_rejects_non_recurrence_term :-
+    catch(valid_recurrence(foo(bar)),
+          error(type_error(recurrence_term, _), _),
+          true).
+
+test_valid_workload_accepts_list :-
+    valid_workload([]),
+    valid_workload([cardinality(large), kernel_mode(bidirectional)]).
+
+test_valid_workload_rejects_non_list :-
+    catch(valid_workload(not_a_list),
+          error(type_error(_, _), _),
+          true).


### PR DESCRIPTION
  ## Summary

  Implements **Phase 0** of the recurrence-evaluation-strategy implementation plan ([`docs/design/RECURRENCE_EVALUATION_
  STRATEGY_IMPLEMENTATION_PLAN.md`](../docs/design/RECURRENCE_EVALUATION_STRATEGY_IMPLEMENTATION_PLAN.md) §Phase 0).
  This is the **module skeleton + smoke test** that the rest of the implementation phases build on. No real selection
  logic yet — every helper returns a `not_yet_implemented(phase_0)` sentinel — but the public API is wired and the call
  chain that Phases 1–4 will populate is in place from day one.

  This PR is **deliberately tiny**. Phase 0's purpose is to (a) give Phase 5 (F# WAM target integration) something to
  call against immediately, and (b) make the Phase 5 stub-leak assertion testable (it needs the `step(stub, ...)` marker
  to exist to assert against its non-existence in real selections).

  ## What this PR delivers

  ### `src/unifyweaver/core/recurrence_evaluation_strategy.pl` (210 lines)

  - **Public API matching the SPECIFICATION's module declaration**:
    `select_evaluation_strategy/3`, `classify_signals/4`, `apply_cost_model/3`, `resolve_against_intent/5`,
  `render_trace_for_stderr/2`, `format_trace_for_comment/3`, `admissible_strategies/2`, `strategy_pretty/2`, plus the
  type-check helpers `valid_recurrence/1`, `valid_workload/1`, `valid_strategy/1`.
  - **Pre-wired call chain in `select_evaluation_strategy/3`**: `classify_signals → append(Declared, Inferred, Data) →
  apply_cost_model → resolve_against_intent`, with each helper a stub. Phases 1–4 will replace the helpers without
  changing the top-level structure.
  - **Baseline strategy**: `strategy(per_query(unidirectional))`.
  - **Stub marker**: `step(stub, not_yet_implemented(phase_0), [])` prepended to every trace — the explicit tag Phase
  5's stub-leak assertion uses to detect incomplete implementation in later phases.
  - **Type-check helpers are real (not stubs)** — Phase 1+ helpers rely on them at every call site, and
  `valid_strategy/1` checks the outer `strategy/1` wrapper (not just the inner Mode term) per the explicit Phase 0
  success criterion flagged in design review.
  - **Determinism contract**: all exported predicates are `det`. None fails; errors are structural only.
  - **Module docstring** cross-references the philosophy / specification / implementation-plan triple.

  ### `tests/core/test_res_skeleton.pl` (155 lines, 12 tests, all pass)

  Runner pattern matches `test_algorithm_manifest.pl` for consistency. Coverage:

  - `test_module_loads`
  - `test_baseline_strategy_returned`
  - `test_trace_contains_stub_step` — proves the Phase 5 leak detector will work
  - `test_determinism_in_if_then_else`
  - `test_determinism_under_findall` — proves no choicepoint leftover (exactly one solution)
  - `test_valid_strategy_accepts_wrapped` — all four Mode kinds (per_query, fixed_point, cached, hybrid) accepted under
  the strategy/1 wrapper
  - `test_valid_strategy_rejects_bare_mode` — bare `per_query(_)` without wrapper rejected
  - `test_valid_strategy_rejects_unknown_mode` — `strategy(quantum)` rejected
  - `test_valid_recurrence_accepts_well_formed`
  - `test_valid_recurrence_rejects_non_recurrence_term`
  - `test_valid_workload_accepts_list`
  - `test_valid_workload_rejects_non_list`

  ## What's NOT in this PR

  Everything Phases 1–7 add. Specifically:

  - No real signal classification (Phase 1)
  - No cost-model rules (Phase 2)
  - No conflict-resolution machine (Phase 3)
  - No trace renderers (Phase 4)
  - No F# WAM target integration (Phase 5)
  - No integration tests beyond the skeleton smoke test (Phase 6)
  - No book-18 chapter updates (Phase 7)

  These will land as separate PRs in sequence per the implementation plan's phase ordering. This is the foundation
  everything else slots into.

  ## Effort

  Estimated 1 hour per the implementation plan. Actual ~1 hour. All 12 tests pass on first run.

  ## Test plan

  - [x] `swipl -g run_tests -t halt tests/core/test_res_skeleton.pl` — all 12 tests pass
  - [ ] CI integration: confirm this test gets picked up by whatever runs `tests/core/test_*.pl` in CI
  - [ ] Compatibility: verify the new module doesn't break any existing test in `tests/core/`