### PR TITLE
feat(RES): Phase 1 — three-tier signal classification

### DIFF
--- a/src/unifyweaver/core/recurrence_evaluation_strategy.pl
+++ b/src/unifyweaver/core/recurrence_evaluation_strategy.pl
@@ -10,11 +10,13 @@
 % return the strategy the target should use to emit code, plus a
 % structured reasoning trace.
 %
-% Phase 0 status: SKELETON. The public API is wired (call chain
-% classify -> concat -> cost-model -> resolve), but every helper
-% returns a `not_yet_implemented(Phase)` sentinel. The baseline
-% strategy is `per_query(unidirectional)` and the trace contains a
-% single `step(stub, not_yet_implemented(phase_0), [])` entry.
+% Phase status: Phase 0 (skeleton) + Phase 1 (signal classification)
+% landed. classify_signals/4 is real; apply_cost_model/3,
+% resolve_against_intent/5, and the renderers remain stubs. The
+% baseline strategy is still `per_query(unidirectional)` (from the
+% Phase 0 cost-model stub) and the trace still contains the Phase 0
+% `step(stub, ...)` marker for the Phase 5 leak-detector to assert
+% against. Phases 2-4 will replace the remaining stubs.
 %
 % This baseline lets the F# WAM target integration (Phase 5) call
 % against the module from day one, and lets the stub-leak assertion
@@ -87,20 +89,127 @@
 select_evaluation_strategy(Recurrence, Workload, strategy_choice(Strategy, Trace)) :-
     valid_recurrence(Recurrence),
     valid_workload(Workload),
-    classify_signals(Workload, IntentSignals, DeclaredData, InferredData),
+    %% Phase 1: real classification + collect unknowns for the trace step.
+    classify_signals_internal(Workload, IntentSignals, DeclaredData, InferredData,
+                              Unknowns),
     append(DeclaredData, InferredData, DataSignals),
     apply_cost_model(Recurrence, DataSignals, CostModelChoice),
     resolve_against_intent(IntentSignals, CostModelChoice, Recurrence, Strategy, Trace0),
+    %% Build the classify_signals trace step from the classification result.
+    build_classify_signals_step(IntentSignals, DeclaredData, InferredData, Unknowns,
+                                ClassifyStep),
+    Trace0 = trace(ResolveSteps),
     %% Phase 0: prepend the stub marker so the stub-leak assertion can
-    %% detect partial implementation.
-    Trace0 = trace(Steps0),
-    Trace  = trace([step(stub, not_yet_implemented(phase_0), []) | Steps0]).
+    %% detect partial implementation while phases 2-4 are still in
+    %% progress. Removed once all phases land.
+    Trace  = trace([step(stub, not_yet_implemented(phase_0), []),
+                    ClassifyStep
+                    | ResolveSteps]).
+
+build_classify_signals_step(Intent, Declared, Inferred, Unknowns,
+                            step(classify_signals,
+                                 classified(Intent, Declared, Inferred),
+                                 Details)) :-
+    (   Unknowns == []
+    ->  Details = []
+    ;   maplist(wrap_unknown_signal, Unknowns, UnknownDetails),
+        Details = UnknownDetails
+    ).
+
+wrap_unknown_signal(Signal, unknown_signal(Signal)).
 
 %% classify_signals(+Workload, -IntentSignals, -DeclaredData, -InferredData)
 %
-% Phase 0 stub: returns three empty lists regardless of input.
-% Phase 1 implements the real dispatch table.
-classify_signals(_Workload, [], [], []).
+% Phase 1: sort each workload term into one of three tiers using the
+% signal_tier/3 dispatch table. Unknown signal functors land in
+% InferredData (with their unknown status surfaced via the trace
+% step that select_evaluation_strategy/3 builds — the unknown-signal
+% warning is NOT visible from this predicate alone, by design: the
+% module is pure-functional and does not write to streams).
+%
+% Public arity-4 version drops the unknown-signal list; use the
+% internal /5 version from inside this module when the warning list
+% is needed.
+classify_signals(Workload, IntentSignals, DeclaredData, InferredData) :-
+    classify_signals_internal(Workload, IntentSignals, DeclaredData, InferredData,
+                              _Unknowns).
+
+%% classify_signals_internal(+Workload, -Intent, -Declared, -Inferred,
+%%                            -Unknowns)
+%
+% Five-argument internal version that also returns the list of
+% workload terms whose functor was not in the dispatch table. These
+% terms were classified into InferredData per the forward-compat
+% policy; Unknowns is the subset surfaced as warnings in the trace.
+classify_signals_internal([], [], [], [], []).
+classify_signals_internal([Signal|Rest], Intent, Declared, Inferred, Unknowns) :-
+    (   signal_tier(Signal, Tier, _Source)
+    ->  classify_signals_internal(Rest, Intent0, Declared0, Inferred0, Unknowns),
+        add_to_tier(Tier, Signal, Intent0, Declared0, Inferred0,
+                    Intent, Declared, Inferred)
+    ;   %% Unknown functor: lands in Inferred per forward-compat policy,
+        %% AND added to Unknowns so the caller can surface a warning.
+        classify_signals_internal(Rest, Intent, Declared, Inferred0, Unknowns0),
+        Inferred = [Signal|Inferred0],
+        Unknowns = [Signal|Unknowns0]
+    ).
+
+add_to_tier(intent,        S, I, D, F, [S|I], D, F).
+add_to_tier(declared_data, S, I, D, F, I, [S|D], F).
+add_to_tier(inferred_data, S, I, D, F, I, D, [S|F]).
+
+%% ============================================================
+%% Signal dispatch table — signal_tier(+SignalTerm, -Tier, -Source)
+%%
+%% Tier is one of: intent | declared_data | inferred_data
+%% Source is metadata describing where this signal typically comes
+%% from (caller / manifest / relation_policy / calibration /
+%% static_analysis / inferred_default). The source is not consumed
+%% in Phase 1; Phase 2's confidence-weighting layer and the trace
+%% renderer may use it.
+%%
+%% Pattern matching is by clause head — value-specific dispatch for
+%% functors whose tier depends on value (csr_available) is expressed
+%% as separate clauses rather than a single clause with a guard.
+%%
+%% Adding a new signal type means adding a clause here.
+%% ============================================================
+
+%% Intent signals
+signal_tier(kernel_mode(_),                  intent, caller).
+signal_tier(strategy(_),                     intent, manifest).
+signal_tier(force_search_algorithm(_),       intent, caller).
+
+%% Declared-data signals
+signal_tier(csr_path(_),                     declared_data, caller).
+signal_tier(csr_available(true),             declared_data, caller).
+signal_tier(cardinality(_),                  declared_data, relation_policy).
+signal_tier(determinism(_),                  declared_data, relation_policy).
+signal_tier(unique(_),                       declared_data, relation_policy).
+signal_tier(graph_mutability(_),             declared_data, manifest).
+signal_tier(heuristic_predicate_available(_), declared_data, caller).
+signal_tier(heuristic_predicate(_),          declared_data, caller).
+signal_tier(b_eff(_),                        declared_data, calibration).
+signal_tier(branching_d(_),                  declared_data, calibration).
+signal_tier(contraction_r(_),                declared_data, calibration).
+
+%% Inferred-data signals
+%%
+%% csr_available(false) is the default inference when no csr_path was
+%% supplied; csr_buildable(_) and the second variants of query_pattern /
+%% query_frequency come from static analysis when not declared in
+%% manifest.
+signal_tier(csr_available(false),            inferred_data, inferred_default).
+signal_tier(csr_buildable(_),                inferred_data, static_analysis).
+
+%% Dual-source signals — query_pattern and query_frequency can be
+%% either declared (manifest) or inferred (static analysis). Phase 1
+%% defaults them to declared_data; build_workload_signals/2 in
+%% recurrence_inputs.pl (Phase 5) can wrap inferred occurrences
+%% differently if it needs the inferred tier. For now, both arrive
+%% from manifest-style sources.
+signal_tier(query_pattern(_),                declared_data, manifest).
+signal_tier(query_frequency(_),              declared_data, manifest).
 
 %% apply_cost_model(+Recurrence, +DataSignals, -CostModelChoice)
 %

--- a/tests/core/test_res_signals.pl
+++ b/tests/core/test_res_signals.pl
@@ -1,0 +1,284 @@
+:- encoding(utf8).
+%% Phase 1 test suite for recurrence_evaluation_strategy:classify_signals/4
+%%
+%% Verifies the three-tier signal classification (intent / declared-data /
+%% inferred-data) implemented in Phase 1.
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_res_signals.pl
+
+:- use_module('../../src/unifyweaver/core/recurrence_evaluation_strategy').
+:- use_module(library(lists)).
+
+%% ========================================================================
+%% Test runner
+%% ========================================================================
+
+run_tests :-
+    format("~n========================================~n"),
+    format("RES Phase 1 Signal-Classification Tests~n"),
+    format("========================================~n~n"),
+    findall(Test, test(Test), Tests),
+    length(Tests, Total),
+    run_all(Tests, 0, Passed),
+    format("~n========================================~n"),
+    (   Passed =:= Total
+    ->  format("All ~w tests passed~n", [Total])
+    ;   Failed is Total - Passed,
+        format("~w of ~w tests FAILED~n", [Failed, Total]),
+        format("Tests FAILED~n"),
+        halt(1)
+    ),
+    format("========================================~n").
+
+run_all([], Passed, Passed).
+run_all([Test|Rest], Acc, Passed) :-
+    (   catch(call(Test), Error,
+            (format("[FAIL] ~w: ~w~n", [Test, Error]), fail))
+    ->  format("[PASS] ~w~n", [Test]),
+        Acc1 is Acc + 1,
+        run_all(Rest, Acc1, Passed)
+    ;   run_all(Rest, Acc, Passed)
+    ).
+
+%% ========================================================================
+%% Test declarations
+%% ========================================================================
+
+test(test_empty_workload).
+
+%% Intent-tier classification
+test(test_intent_kernel_mode).
+test(test_intent_strategy).
+test(test_intent_force_search_algorithm).
+
+%% Declared-data-tier classification
+test(test_declared_csr_path).
+test(test_declared_csr_available_true).
+test(test_declared_cardinality).
+test(test_declared_determinism).
+test(test_declared_unique).
+test(test_declared_query_pattern).
+test(test_declared_query_frequency).
+test(test_declared_graph_mutability).
+test(test_declared_heuristic_predicate_available).
+test(test_declared_heuristic_predicate).
+test(test_declared_calibration_signals).
+
+%% Inferred-data-tier classification
+test(test_inferred_csr_available_false).
+test(test_inferred_csr_buildable).
+
+%% Forward-compat: unknown functor lands in inferred + surfaces as warning
+test(test_unknown_signal_lands_in_inferred).
+test(test_unknown_signal_appears_in_trace).
+test(test_unknown_signal_does_not_write_stderr).
+
+%% Mixed-tier and edge-case workloads
+test(test_mix_all_three_tiers).
+test(test_only_intent_signals).
+test(test_only_declared_signals).
+test(test_only_inferred_signals).
+test(test_csr_available_value_specific_dispatch).
+test(test_preserves_signal_terms).
+test(test_preserves_signal_order_within_tier).
+
+%% Integration: classify_signals trace step appears in
+%% select_evaluation_strategy/3 result
+test(test_classify_signals_step_in_trace).
+test(test_classify_signals_step_records_unknown).
+
+%% ========================================================================
+%% Test fixtures
+%% ========================================================================
+
+a_recurrence(recurrence(transitive_closure2, my_pred/2,
+    [value_domain(combinatorial), monotone(true)])).
+
+%% ========================================================================
+%% Tests
+%% ========================================================================
+
+test_empty_workload :-
+    classify_signals([], I, D, F),
+    I == [], D == [], F == [].
+
+%% Intent tier --------------------------------------------------------------
+
+test_intent_kernel_mode :-
+    classify_signals([kernel_mode(bidirectional)], I, D, F),
+    I == [kernel_mode(bidirectional)], D == [], F == [].
+
+test_intent_strategy :-
+    classify_signals([strategy(per_query(unidirectional))], I, D, F),
+    I == [strategy(per_query(unidirectional))], D == [], F == [].
+
+test_intent_force_search_algorithm :-
+    classify_signals([force_search_algorithm(bfs)], I, D, F),
+    I == [force_search_algorithm(bfs)], D == [], F == [].
+
+%% Declared-data tier -------------------------------------------------------
+
+test_declared_csr_path :-
+    classify_signals([csr_path('/some/path.lmdb')], I, D, F),
+    I == [], D == [csr_path('/some/path.lmdb')], F == [].
+
+test_declared_csr_available_true :-
+    classify_signals([csr_available(true)], I, D, F),
+    I == [], D == [csr_available(true)], F == [].
+
+test_declared_cardinality :-
+    classify_signals([cardinality(large)], I, D, F),
+    I == [], D == [cardinality(large)], F == [].
+
+test_declared_determinism :-
+    classify_signals([determinism(semidet)], I, D, F),
+    I == [], D == [determinism(semidet)], F == [].
+
+test_declared_unique :-
+    classify_signals([unique(true)], I, D, F),
+    I == [], D == [unique(true)], F == [].
+
+test_declared_query_pattern :-
+    classify_signals([query_pattern(single_pair)], I, D, F),
+    I == [], D == [query_pattern(single_pair)], F == [].
+
+test_declared_query_frequency :-
+    classify_signals([query_frequency(high)], I, D, F),
+    I == [], D == [query_frequency(high)], F == [].
+
+test_declared_graph_mutability :-
+    classify_signals([graph_mutability(static)], I, D, F),
+    I == [], D == [graph_mutability(static)], F == [].
+
+test_declared_heuristic_predicate_available :-
+    classify_signals([heuristic_predicate_available(true)], I, D, F),
+    I == [], D == [heuristic_predicate_available(true)], F == [].
+
+test_declared_heuristic_predicate :-
+    classify_signals([heuristic_predicate(my_heuristic/2)], I, D, F),
+    I == [], D == [heuristic_predicate(my_heuristic/2)], F == [].
+
+test_declared_calibration_signals :-
+    classify_signals([b_eff(15.0), branching_d(4.5), contraction_r(0.04)], I, D, F),
+    I == [],
+    sort(D, [b_eff(15.0), branching_d(4.5), contraction_r(0.04)]),
+    F == [].
+
+%% Inferred-data tier -------------------------------------------------------
+
+test_inferred_csr_available_false :-
+    classify_signals([csr_available(false)], I, D, F),
+    I == [], D == [], F == [csr_available(false)].
+
+test_inferred_csr_buildable :-
+    classify_signals([csr_buildable(true)], I, D, F),
+    I == [], D == [], F == [csr_buildable(true)].
+
+%% Forward-compat ----------------------------------------------------------
+
+test_unknown_signal_lands_in_inferred :-
+    classify_signals([quantum_signal(foo)], I, D, F),
+    I == [], D == [], F == [quantum_signal(foo)].
+
+%% Unknown signals appear in the classify_signals trace step that
+%% select_evaluation_strategy/3 builds (via the unknown_signal/1
+%% wrapper). The classify_signals/4 predicate itself doesn't surface
+%% them — the module is pure-functional and doesn't write to streams.
+test_unknown_signal_appears_in_trace :-
+    a_recurrence(R),
+    select_evaluation_strategy(R, [quantum_signal(foo)],
+                               strategy_choice(_Strategy, trace(Steps))),
+    member(step(classify_signals, classified(_, _, [quantum_signal(foo)]), Details),
+           Steps),
+    member(unknown_signal(quantum_signal(foo)), Details).
+
+%% Verify the module doesn't write anything to user_error or
+%% user_output when processing an unknown signal. We do this by
+%% running classify_signals/4 inside a with_output_to/2 scope and
+%% asserting the captured string is empty.
+test_unknown_signal_does_not_write_stderr :-
+    with_output_to(string(Captured),
+        ( current_output(Out),
+          set_stream(user_error, alias(my_test_err)),
+          classify_signals([quantum_signal(foo)], _, _, _),
+          set_stream(Out, alias(user_output))
+        )),
+    Captured == "".
+
+%% Mixed / edge-case -------------------------------------------------------
+
+test_mix_all_three_tiers :-
+    Workload = [
+        kernel_mode(bidirectional),       % intent
+        cardinality(large),                % declared
+        csr_buildable(true)                % inferred
+    ],
+    classify_signals(Workload, I, D, F),
+    I == [kernel_mode(bidirectional)],
+    D == [cardinality(large)],
+    F == [csr_buildable(true)].
+
+test_only_intent_signals :-
+    classify_signals([kernel_mode(bidirectional), strategy(per_query(_))],
+                     I, D, F),
+    length(I, 2), D == [], F == [].
+
+test_only_declared_signals :-
+    classify_signals([cardinality(large), determinism(det), unique(true)],
+                     I, D, F),
+    I == [], length(D, 3), F == [].
+
+test_only_inferred_signals :-
+    classify_signals([csr_available(false), csr_buildable(true)],
+                     I, D, F),
+    I == [], D == [], length(F, 2).
+
+%% This is the value-specific dispatch case: csr_available(true) is
+%% declared, csr_available(false) is inferred. Same functor, different
+%% tier based on value.
+test_csr_available_value_specific_dispatch :-
+    classify_signals([csr_available(true), csr_available(false)], I, D, F),
+    I == [],
+    D == [csr_available(true)],
+    F == [csr_available(false)].
+
+%% Verify the classifier preserves the signal terms as-is (no
+%% wrapping, no transformation) in the output lists.
+test_preserves_signal_terms :-
+    classify_signals([cardinality(large)], _I, D, _F),
+    D = [Signal],
+    Signal == cardinality(large).
+
+%% When multiple signals land in the same tier, their original input
+%% order is preserved (left-to-right). The implementation uses
+%% cons-onto-front recursion which naturally preserves order when
+%% combined with the recursive call's already-built list.
+test_preserves_signal_order_within_tier :-
+    classify_signals([cardinality(large), determinism(det), unique(true)],
+                     _I, D, _F),
+    D == [cardinality(large), determinism(det), unique(true)].
+
+%% Integration with select_evaluation_strategy/3 ----------------------------
+
+test_classify_signals_step_in_trace :-
+    a_recurrence(R),
+    select_evaluation_strategy(R, [cardinality(large), kernel_mode(bidirectional)],
+                               strategy_choice(_Strategy, trace(Steps))),
+    member(step(classify_signals,
+                classified([kernel_mode(bidirectional)],
+                           [cardinality(large)],
+                           []),
+                _Details),
+           Steps).
+
+%% When unknown signals are present, the trace step's Details list
+%% contains unknown_signal/1 markers wrapping each unknown term.
+test_classify_signals_step_records_unknown :-
+    a_recurrence(R),
+    Workload = [cardinality(large), quantum_signal(foo), warp_drive(on)],
+    select_evaluation_strategy(R, Workload,
+                               strategy_choice(_Strategy, trace(Steps))),
+    member(step(classify_signals, _Outcome, Details), Steps),
+    member(unknown_signal(quantum_signal(foo)), Details),
+    member(unknown_signal(warp_drive(on)), Details).


### PR DESCRIPTION
  ## Summary

  Implements **Phase 1** of the recurrence-evaluation-strategy implementation plan. Replaces the Phase 0
  `classify_signals/4` stub with a real dispatch-table-driven implementation, and updates `select_evaluation_strategy/3`
  to build a structured `step(classify_signals, ...)` trace entry from the actual classification result.

  This is the second of seven phases. Builds on Phase 0 (#2873). Phase 2 (cost-model rules) comes next.

  ## What this PR delivers

  ### `classify_signals/4` is now real

  Walks the workload list and dispatches each signal to one of three tiers — `intent` / `declared_data` /
  `inferred_data` — using a static `signal_tier/3` dispatch table. Every signal in the SPEC's vocabulary tables is
  covered.

  **Value-specific dispatch** for `csr_available`: `csr_available(true)` is declared (caller asserts the index exists);
  `csr_available(false)` is inferred (the default when no `csr_path` was supplied). Same functor, different tier by
  value — expressed as separate dispatch clauses rather than a clause-with-guard for clarity.

  ### Internal `classify_signals_internal/5`

  Returns the same three lists *plus* the list of unknown-functor signals. The public `classify_signals/4` predicate
  drops the unknown list per the SPEC's signature; `select_evaluation_strategy/3` uses the internal `/5` version to
  build the trace step's `unknown_signal(...)` details.

  ### Forward-compat: unknown signals

  Per the SPEC's forward-compat policy: unknown functors land in `inferred_data` (rather than failing or being silently
  dropped). The unknown-signal terms surface via the `classify_signals` trace step's `Details` list, wrapped in
  `unknown_signal/1`. The module itself does not write to any stream — pure-functional contract preserved.

  ### `select_evaluation_strategy/3` updated

  Builds a real `step(classify_signals, classified(I, D, F), Details)` trace entry using a new
  `build_classify_signals_step/5` helper. The Phase 0 stub marker `step(stub, not_yet_implemented(phase_0), [])` is
  still prepended so the Phase 5 leak detector remains feasible until all phases land.

  ## Test plan

  `tests/core/test_res_signals.pl` (29 tests, all pass):

  - Empty workload → three empty lists
  - Every intent signal type classifies to `intent`
  - Every declared-data signal type classifies to `declared_data` (all 12 entries)
  - Inferred-data signals (`csr_available(false)`, `csr_buildable(_)`) classify to `inferred_data`
  - Unknown signal lands in inferred AND surfaces as `unknown_signal/1` in the trace step
  - Module does not write to `user_error` or `user_output` when processing unknown signals (verified with output
  capture)
  - Mixed-tier workloads partition correctly
  - Only-intent / only-declared / only-inferred edge cases
  - `csr_available` value-specific dispatch verified explicitly
  - Signal terms preserved as-is (no wrapping, no transformation)
  - Signal order within tier preserved (left-to-right)
  - Integration: `select_evaluation_strategy/3` trace contains the classify_signals step with the correct outcome;
  unknown signals appear in Details

  `tests/core/test_res_skeleton.pl` (12 Phase 0 tests, all pass): the stub marker is still in the trace; the baseline
  strategy is unchanged; the Phase 0 contract is preserved.

  ## What's NOT in this PR

  Phases 2–7. Specifically:

  - No real cost-model rules yet (`apply_cost_model/3` still returns the `default_fallback` stub choice). Phase 2.
  - No real conflict-resolution machine (`resolve_against_intent/5` still returns the cost-model choice unchanged).
  Phase 3.
  - No trace renderers (`render_trace_for_stderr/2` returns `[]`; `format_trace_for_comment/3` returns `""`). Phase 4.

  The selector's call chain `classify_signals → apply_cost_model → resolve_against_intent` is fully wired; Phase 2+ will
  replace the stubs without changing the structure.

  ## Effort

  Estimated 1.5 hours per the implementation plan. Actual ~1.5 hours.

  ## Files

  src/unifyweaver/core/recurrence_evaluation_strategy.pl   (+121 -12)
  tests/core/test_res_signals.pl                            (NEW, 284 lines, 29 tests)