### PR TITLE
Dispatch WAM-C conjunction meta goals

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,15 +4,15 @@ Status date: 2026-06-06
 
 Latest branch verification:
 
-- `investigate/wam-c-meta-aggregate-dispatch` based on `main` at `993ff338`
-  (`Merge pull request #2861 from
-  s243a/investigate/wam-c-bagof-setof-unbound-witness-groups`)
+- `investigate/wam-c-meta-goal-composition` based on `main` at `1b022276`
+  (`Merge pull request #2862 from
+  s243a/investigate/wam-c-meta-aggregate-dispatch`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-meta-aggregate-dispatch`
+- `investigate/wam-c-meta-goal-composition`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -88,6 +88,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Existential `^/2` aggregate body lowering | Done | Goal-level `^/2` wrappers are transparent in inner call positions, witness discovery still suppresses quantified variables, and the C executable smoke covers flattened existential `bagof/3` plus sorted/deduplicated existential `setof/3` |
 | Unbound-witness `bagof/3` and `setof/3` group enumeration | Done | C retains aggregate groups behind a backtrackable iterator, binds each witness/result group through a synthetic aggregate-group choicepoint, and covers outer `findall/3` consuming all grouped `bagof/3` and `setof/3` alternatives |
 | Runtime aggregate meta-call dispatch | Done | C dispatches non-inline runtime `findall/3`, `bagof/3`, and `setof/3` calls through meta aggregate frames, invokes simple callable goal terms, and covers non-inline `bagof/3` / `setof/3` executable smoke without `inline_bagof_setof(true)` |
+| Runtime conjunction goal-term dispatch | Done | C preserves `,/2` functors in WAM-to-C parsing, dispatches conjunction goal terms through a synthetic continuation frame, snapshots frame depth in choicepoints, and covers non-inline aggregate bodies with conjunction in `bagof/3` and `setof/3` |
 
 ## Current C Target Baseline
 
@@ -147,7 +148,8 @@ The C target is now a credible small WAM backend:
   caller-bound witness grouping for `bagof/3` / `setof/3`, and
   existential `^/2` suppression plus unbound witness group enumeration inside
   inline `bagof/3` / `setof/3` bodies. It also has runtime meta-call dispatch
-  for non-inline aggregate calls over simple callable goal terms.
+  for non-inline aggregate calls over simple callable goal terms and
+  conjunction goal terms.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -170,7 +172,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Second-arg indexing | Partial | Partial/Done | Partial/Done | C has constant A2 dispatch; broaden tests if this becomes hot. |
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
 | Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
-| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness, caller-bound witness, existential `^/2`, and unbound witness group enumeration for inline `bagof/3` / `setof/3`; runtime meta-call aggregate dispatch now covers simple callable goals, while conjunction/disjunction and broader meta-goal forms remain gaps. |
+| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness, caller-bound witness, existential `^/2`, and unbound witness group enumeration for inline `bagof/3` / `setof/3`; runtime meta-call aggregate dispatch now covers simple callable and conjunction goals, while disjunction and broader meta-goal forms remain gaps. |
 | Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, precise `get_level`/`cut` if-then-else, explicit `!/0` scoped to the current predicate call barrier, and generated `forall/2` soft-cut rewrites; residual work should be driven by concrete meta-control demand. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
@@ -184,6 +186,32 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-meta-goal-composition`
+
+Goal: extend the first C aggregate meta-call path from simple callable goals to
+conjunction goal terms in aggregate bodies.
+
+Evidence:
+
+- The C runtime now has a small conjunction frame stack and synthetic
+  conjunction return continuation.
+- Choicepoint snapshots preserve conjunction-frame depth, and restore/prune
+  paths trim frames with the rest of runtime backtracking state.
+- Runtime `,/2` goal terms dispatch the left goal first, then re-dispatch the
+  right goal on each left-goal success, preserving normal retry behavior for
+  both sides under aggregate collection.
+- The WAM text parser now keeps leading-comma functors such as `,/2` intact
+  instead of treating the comma as a field separator during pass 2.
+- The real-Prolog executable smoke compiles non-inline `bagof/3` and `setof/3`
+  bodies containing conjunction, verifies the generated WAM still uses
+  `execute bagof/3` / `execute setof/3`, and checks ordered bag output plus
+  sorted/deduplicated set output.
+
+Remaining gaps:
+
+- Disjunction `;/2`, if-then-else goal terms, and general `call/N` composition
+  still need their own runtime continuation machinery.
 
 ### Completed: `investigate/wam-c-meta-aggregate-dispatch`
 
@@ -211,8 +239,8 @@ Remaining gaps:
 
 - The first meta-call implementation invokes atoms, module-qualified simple
   predicate terms, `^/2`, direct builtins, and nested aggregate terms. It does
-  not yet cover conjunction, disjunction, if-then-else, or general `call/N`
-  goal composition in the C runtime.
+  not yet cover disjunction, if-then-else, or general `call/N` goal
+  composition in the C runtime.
 
 ### Completed: `investigate/wam-c-bagof-setof-unbound-witness-groups`
 
@@ -1185,7 +1213,7 @@ Evidence:
   `226c7fdad57d`, while `boundary-800` (`811` selected roots) used sparse
   scheduling with matching hash `92be2a9b5ac1`.
 
-### Active: `investigate/wam-c-candidate-filter-observability`
+### Completed Investigation: `investigate/wam-c-candidate-filter-observability`
 
 Goal: make threshold sweep output self-describing enough that future
 calibration rows show both the requested policy and the resolved runtime
@@ -1209,12 +1237,12 @@ Evidence:
 ## Suggested Immediate Next Step
 
 The aggregate parity sequence now has inline no-witness, caller-bound witness,
-existential `^/2`, unbound witness group enumeration, and a first runtime
-meta-call aggregate path for simple callable goals. The next aggregate feature
-worth considering is broader C goal-term dispatch for meta aggregate bodies:
-conjunction, disjunction, if-then-else, and `call/N` composition. Keep that
-separate because it changes general meta-call control flow, not just aggregate
-frame finalization.
+existential `^/2`, unbound witness group enumeration, runtime meta-call
+aggregate dispatch for simple callable goals, and conjunction goal-term
+dispatch inside meta aggregate bodies. The next aggregate feature worth
+considering is disjunction `;/2` in C goal-term dispatch, followed by
+if-then-else and `call/N` composition. Keep those separate because they change
+general meta-call control flow, not just aggregate frame finalization.
 
 For the effective-distance/CSR line, result-capped and sampled runs already
 confirm child-CSR variants agree, and parent plus child reachability prefilters

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -25,9 +25,11 @@
 #define WAM_AGGREGATE_STACK_SIZE 32
 #define WAM_AGGREGATE_MAX_WITNESSES 8
 #define WAM_AGGREGATE_META_MAX_VARS 64
+#define WAM_META_GOAL_STACK_SIZE 64
 #define WAM_AGGREGATE_NEXT_GROUP -3
 #define WAM_AGGREGATE_META_COLLECT -4
 #define WAM_AGGREGATE_META_DONE -5
+#define WAM_META_CONJ_RETURN -6
 
 typedef struct WamState WamState;
 typedef bool (*WamForeignHandler)(WamState *state, const char *pred, int arity);
@@ -64,6 +66,7 @@ typedef struct {
     int stack_size;
     int call_base_top;
     int aggregate_group_top;
+    int conj_top;
     int arity;
     WamValue a_regs[32]; // Reduced from MAX_REGS to save memory (typical max arity)
 } ChoicePoint;
@@ -118,6 +121,11 @@ typedef struct {
     int group_count;
     int next_group;
 } WamAggregateGroupIterator;
+
+typedef struct {
+    WamValue second_goal;
+    int return_pc;
+} WamConjFrame;
 
 /* Environment Frame */
 typedef struct {
@@ -384,6 +392,8 @@ struct WamState {
     int aggregate_top;
     WamAggregateGroupIterator aggregate_group_iters[WAM_AGGREGATE_STACK_SIZE];
     int aggregate_group_top;
+    WamConjFrame conj_frames[WAM_META_GOAL_STACK_SIZE];
+    int conj_top;
 
     /* Native category_ancestor kernel data */
     CategoryEdge *category_edges;
@@ -859,6 +869,14 @@ static inline void wam_trim_aggregate_group_iters(WamState *state, int target_to
     }
 }
 
+static inline void wam_trim_conj_frames(WamState *state, int target_top) {
+    if (target_top < 0) target_top = 0;
+    if (target_top > state->conj_top) {
+        target_top = state->conj_top;
+    }
+    state->conj_top = target_top;
+}
+
 static inline void push_choice_point(WamState *state, int next_pc, int arity) {
     if (state->B >= state->B_cap) {
         state->B_cap = state->B_cap ? state->B_cap * 2 : WAM_INITIAL_CAP;
@@ -872,6 +890,7 @@ static inline void push_choice_point(WamState *state, int next_pc, int arity) {
     cp->stack_size = state->E;
     cp->call_base_top = state->call_base_top;
     cp->aggregate_group_top = state->aggregate_group_top;
+    cp->conj_top = state->conj_top;
     
     int save_arity = arity < 32 ? arity : 32;
     cp->arity = save_arity;
@@ -892,6 +911,7 @@ static inline void restore_choice_point(WamState *state, ChoicePoint *cp) {
     state->CP = cp->cp;
     state->call_base_top = cp->call_base_top;
     wam_trim_aggregate_group_iters(state, cp->aggregate_group_top);
+    wam_trim_conj_frames(state, cp->conj_top);
     unwind_trail(state, cp->trail_size);
     memcpy(state->A, cp->a_regs, sizeof(WamValue) * cp->arity);
 }
@@ -907,13 +927,16 @@ static inline void pop_choice_point(WamState *state) {
 }
 static inline void wam_prune_choice_points(WamState *state, int target_b) {
     int target_group_top = 0;
+    int target_conj_top = 0;
     if (target_b > 0 && target_b <= state->B) {
         target_group_top = state->B_array[target_b - 1].aggregate_group_top;
+        target_conj_top = state->B_array[target_b - 1].conj_top;
     }
     while (state->B > target_b) {
         pop_choice_point(state);
     }
     wam_trim_aggregate_group_iters(state, target_group_top);
+    wam_trim_conj_frames(state, target_conj_top);
 }
 static inline void update_choice_point(WamState *state, int next_pc) {
     if (state->B > 0) {

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -1907,7 +1907,7 @@ wam_lines_to_c_pass1([Line|Rest], PC, LabelMap) :-
 
 wam_lines_to_c_pass2([], PC, _, _, _, PC, []).
 wam_lines_to_c_pass2([Line|Rest], PC, LabelMap, Arity, OffsetVar, CodeSize, Instrs) :-
-    split_string(Line, " \t,", " \t,", Parts),
+    split_string(Line, " \t", " \t", Parts),
     delete(Parts, "", CleanParts),
     (   CleanParts == [] -> wam_lines_to_c_pass2(Rest, PC, LabelMap, Arity, OffsetVar, CodeSize, Instrs)
     ;   CleanParts = [First|_],
@@ -2138,6 +2138,9 @@ compile_step_wam_to_c(_Options, CCode) :-
                 int continuation = state->CP;
                 if (continuation == WAM_AGGREGATE_META_COLLECT) {
                     return wam_collect_meta_aggregate_success(state);
+                }
+                if (continuation == WAM_META_CONJ_RETURN) {
+                    return wam_continue_conjunction(state);
                 }
                 if (continuation != WAM_HALT && state->call_base_top > 0) {
                     int barrier_index = --state->call_base_top;
@@ -2589,6 +2592,7 @@ static bool wam_invoke_goal_as_call(WamState *state, WamValue goal,
                                     int return_pc);
 static bool wam_collect_meta_aggregate_success(WamState *state);
 static bool wam_finalize_meta_aggregate(WamState *state);
+static bool wam_continue_conjunction(WamState *state);
 
 static bool wam_ensure_heap_slots(WamState *state, int additional) {
     if (additional <= 0) return true;
@@ -2857,6 +2861,14 @@ static bool wam_invoke_goal_as_call(WamState *state, WamValue goal,
     int arity = 0;
     if (!wam_parse_functor_arity(functor, &arity)) return false;
     if (arity > WAM_MAX_REGS) return false;
+    if (strcmp(functor, ",/2") == 0 && arity == 2) {
+        if (state->conj_top >= WAM_META_GOAL_STACK_SIZE) return false;
+        WamConjFrame *frame = &state->conj_frames[state->conj_top++];
+        frame->second_goal = state->H_array[base + 2];
+        frame->return_pc = return_pc;
+        return wam_invoke_goal_as_call(state, state->H_array[base + 1],
+                                       WAM_META_CONJ_RETURN);
+    }
     if (strcmp(functor, "^/2") == 0 && arity == 2) {
         return wam_invoke_goal_as_call(state, state->H_array[base + 2],
                                        return_pc);
@@ -2887,6 +2899,13 @@ static bool wam_invoke_goal_as_call(WamState *state, WamValue goal,
         return true;
     }
     return false;
+}
+
+static bool wam_continue_conjunction(WamState *state) {
+    if (state->conj_top <= 0) return false;
+    WamConjFrame *frame = &state->conj_frames[state->conj_top - 1];
+    return wam_invoke_goal_as_call(state, frame->second_goal,
+                                   frame->return_pc);
 }
 
 static bool wam_copy_term_to_stored(WamState *state,

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -3147,30 +3147,69 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
     assertz((user:wam_c_meta_dup(a) :- true)),
     assertz((user:wam_c_meta_dup(b) :- true)),
     assertz((user:wam_c_meta_none(_) :- fail)),
+    assertz((user:wam_c_meta_conj_item(a) :- true)),
+    assertz((user:wam_c_meta_conj_item(b) :- true)),
+    assertz((user:wam_c_meta_conj_item(c) :- true)),
+    assertz((user:wam_c_meta_conj_keep(a) :- true)),
+    assertz((user:wam_c_meta_conj_keep(c) :- true)),
+    assertz((user:wam_c_meta_conj_dup(b) :- true)),
+    assertz((user:wam_c_meta_conj_dup(a) :- true)),
+    assertz((user:wam_c_meta_conj_dup(b) :- true)),
+    assertz((user:wam_c_meta_conj_set_keep(a) :- true)),
+    assertz((user:wam_c_meta_conj_set_keep(b) :- true)),
     assertz((user:wam_c_meta_bag(L) :-
         bagof(X, wam_c_meta_item(X), L))),
     assertz((user:wam_c_meta_set(L) :-
         setof(X, wam_c_meta_dup(X), L))),
     assertz((user:wam_c_meta_empty_bag(L) :-
         bagof(X, wam_c_meta_none(X), L))),
+    assertz((user:wam_c_meta_conj_bag(L) :-
+        bagof(X,
+              (wam_c_meta_conj_item(X), wam_c_meta_conj_keep(X)),
+              L))),
+    assertz((user:wam_c_meta_conj_set(L) :-
+        setof(X,
+              (wam_c_meta_conj_dup(X), wam_c_meta_conj_set_keep(X)),
+              L))),
     (   compile_predicate_to_wam(user:wam_c_meta_item/1, [], WamItem),
         compile_predicate_to_wam(user:wam_c_meta_dup/1, [], WamDup),
         compile_predicate_to_wam(user:wam_c_meta_none/1, [], WamNone),
+        compile_predicate_to_wam(user:wam_c_meta_conj_item/1, [], WamConjItem),
+        compile_predicate_to_wam(user:wam_c_meta_conj_keep/1, [], WamConjKeep),
+        compile_predicate_to_wam(user:wam_c_meta_conj_dup/1, [], WamConjDup),
+        compile_predicate_to_wam(user:wam_c_meta_conj_set_keep/1, [], WamConjSetKeep),
         compile_predicate_to_wam(user:wam_c_meta_bag/1, [], WamBag),
         compile_predicate_to_wam(user:wam_c_meta_set/1, [], WamSet),
         compile_predicate_to_wam(user:wam_c_meta_empty_bag/1, [], WamEmptyBag),
+        compile_predicate_to_wam(user:wam_c_meta_conj_bag/1, [], WamConjBag),
+        compile_predicate_to_wam(user:wam_c_meta_conj_set/1, [], WamConjSet),
         sub_string(WamBag, _, _, _, 'execute bagof/3'),
         \+ sub_string(WamBag, _, _, _, 'begin_aggregate bagof'),
         sub_string(WamSet, _, _, _, 'execute setof/3'),
         \+ sub_string(WamSet, _, _, _, 'begin_aggregate setof'),
+        sub_string(WamConjBag, _, _, _, 'put_structure ,/2'),
+        sub_string(WamConjBag, _, _, _, 'execute bagof/3'),
+        \+ sub_string(WamConjBag, _, _, _, 'begin_aggregate bagof'),
+        sub_string(WamConjSet, _, _, _, 'put_structure ,/2'),
+        sub_string(WamConjSet, _, _, _, 'execute setof/3'),
+        \+ sub_string(WamConjSet, _, _, _, 'begin_aggregate setof'),
         compile_wam_predicate_to_c(user:wam_c_meta_item/1, WamItem, [], ItemCode),
         compile_wam_predicate_to_c(user:wam_c_meta_dup/1, WamDup, [], DupCode),
         compile_wam_predicate_to_c(user:wam_c_meta_none/1, WamNone, [], NoneCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_conj_item/1, WamConjItem, [], ConjItemCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_conj_keep/1, WamConjKeep, [], ConjKeepCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_conj_dup/1, WamConjDup, [], ConjDupCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_conj_set_keep/1, WamConjSetKeep, [], ConjSetKeepCode),
         compile_wam_predicate_to_c(user:wam_c_meta_bag/1, WamBag, [], BagCode),
         compile_wam_predicate_to_c(user:wam_c_meta_set/1, WamSet, [], SetCode),
         compile_wam_predicate_to_c(user:wam_c_meta_empty_bag/1, WamEmptyBag, [], EmptyBagCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_conj_bag/1, WamConjBag, [], ConjBagCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_conj_set/1, WamConjSet, [], ConjSetCode),
         atomic_list_concat([ItemCode, DupCode, NoneCode,
-                            BagCode, SetCode, EmptyBagCode],
+                            ConjItemCode, ConjKeepCode, ConjDupCode,
+                            ConjSetKeepCode,
+                            BagCode, SetCode, EmptyBagCode,
+                            ConjBagCode, ConjSetCode],
                            '\n\n',
                            PredCode),
         compile_wam_runtime_to_c([], RuntimeCode),
@@ -3197,9 +3236,15 @@ cleanup_wam_c_bagof_setof_meta_call_smoke :-
     retractall(user:wam_c_meta_item(_)),
     retractall(user:wam_c_meta_dup(_)),
     retractall(user:wam_c_meta_none(_)),
+    retractall(user:wam_c_meta_conj_item(_)),
+    retractall(user:wam_c_meta_conj_keep(_)),
+    retractall(user:wam_c_meta_conj_dup(_)),
+    retractall(user:wam_c_meta_conj_set_keep(_)),
     retractall(user:wam_c_meta_bag(_)),
     retractall(user:wam_c_meta_set(_)),
-    retractall(user:wam_c_meta_empty_bag(_)).
+    retractall(user:wam_c_meta_empty_bag(_)),
+    retractall(user:wam_c_meta_conj_bag(_)),
+    retractall(user:wam_c_meta_conj_set(_)).
 
 run_real_prolog_classic_recursive_executable_smoke :-
     assertz((user:wam_c_classic_fib(0, 0) :- true)),
@@ -6731,9 +6776,15 @@ wam_c_bagof_setof_meta_call_main(
 void setup_wam_c_meta_item_1(WamState* state);
 void setup_wam_c_meta_dup_1(WamState* state);
 void setup_wam_c_meta_none_1(WamState* state);
+void setup_wam_c_meta_conj_item_1(WamState* state);
+void setup_wam_c_meta_conj_keep_1(WamState* state);
+void setup_wam_c_meta_conj_dup_1(WamState* state);
+void setup_wam_c_meta_conj_set_keep_1(WamState* state);
 void setup_wam_c_meta_bag_1(WamState* state);
 void setup_wam_c_meta_set_1(WamState* state);
 void setup_wam_c_meta_empty_bag_1(WamState* state);
+void setup_wam_c_meta_conj_bag_1(WamState* state);
+void setup_wam_c_meta_conj_set_1(WamState* state);
 
 static bool wam_c_meta_expect_atom_list2(WamState *state, WamValue value,
                                          const char *first,
@@ -6760,9 +6811,15 @@ int main(void) {
     setup_wam_c_meta_item_1(&state);
     setup_wam_c_meta_dup_1(&state);
     setup_wam_c_meta_none_1(&state);
+    setup_wam_c_meta_conj_item_1(&state);
+    setup_wam_c_meta_conj_keep_1(&state);
+    setup_wam_c_meta_conj_dup_1(&state);
+    setup_wam_c_meta_conj_set_keep_1(&state);
     setup_wam_c_meta_bag_1(&state);
     setup_wam_c_meta_set_1(&state);
     setup_wam_c_meta_empty_bag_1(&state);
+    setup_wam_c_meta_conj_bag_1(&state);
+    setup_wam_c_meta_conj_set_1(&state);
 
     WamValue bag_args[1] = { val_unbound("Bag") };
     int bag_rc = wam_run_predicate(&state, "wam_c_meta_bag/1", bag_args, 1);
@@ -6792,6 +6849,30 @@ int main(void) {
         state.aggregate_top != 0 || state.aggregate_group_top != 0) {
         wam_free_state(&state);
         return 30;
+    }
+
+    WamValue conj_bag_args[1] = { val_unbound("ConjBag") };
+    int conj_bag_rc = wam_run_predicate(&state, "wam_c_meta_conj_bag/1",
+                                        conj_bag_args, 1);
+    if (conj_bag_rc != 0 || state.P != WAM_HALT ||
+        !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "c") ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
+        state.conj_top != 0) {
+        wam_free_state(&state);
+        return 40;
+    }
+
+    WamValue conj_set_args[1] = { val_unbound("ConjSet") };
+    int conj_set_rc = wam_run_predicate(&state, "wam_c_meta_conj_set/1",
+                                        conj_set_args, 1);
+    if (conj_set_rc != 0 || state.P != WAM_HALT ||
+        !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "b") ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
+        state.conj_top != 0) {
+        wam_free_state(&state);
+        return 50;
     }
 
     wam_free_state(&state);


### PR DESCRIPTION
  ## Summary

  - Add C WAM runtime support for `,/2` conjunction goal terms through a small meta-goal continuation frame stack.
  - Preserve leading-comma functors like `,/2` during WAM-to-C parsing.
  - Extend non-inline aggregate meta-call coverage so `bagof/3` and `setof/3` bodies can contain conjunctions.

  ## Verification

  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `git diff --check HEAD~1..HEAD`