### PR TITLE
feat(RES): Phase 2 — cost-model rules + admissibility

### DIFF
--- a/src/unifyweaver/core/recurrence_evaluation_strategy.pl
+++ b/src/unifyweaver/core/recurrence_evaluation_strategy.pl
@@ -11,12 +11,14 @@
 % structured reasoning trace.
 %
 % Phase status: Phase 0 (skeleton) + Phase 1 (signal classification)
-% landed. classify_signals/4 is real; apply_cost_model/3,
-% resolve_against_intent/5, and the renderers remain stubs. The
-% baseline strategy is still `per_query(unidirectional)` (from the
-% Phase 0 cost-model stub) and the trace still contains the Phase 0
-% `step(stub, ...)` marker for the Phase 5 leak-detector to assert
-% against. Phases 2-4 will replace the remaining stubs.
+% + Phase 2 (cost-model rules + admissibility) landed.
+% classify_signals/4, apply_cost_model/3, admissible_strategies/2
+% are real; resolve_against_intent/5 and the renderers remain stubs.
+% The cost model produces real strategy preferences from the six
+% initial rules; the trace contains a real step(cost_model_choice,
+% ...) entry. The Phase 0 step(stub, ...) marker is still prepended
+% to the trace for the Phase 5 leak-detector to assert against.
+% Phases 3-4 will replace the remaining stubs.
 %
 % This baseline lets the F# WAM target integration (Phase 5) call
 % against the module from day one, and lets the stub-leak assertion
@@ -66,7 +68,9 @@
 ]).
 
 :- use_module(library(error), [must_be/2, domain_error/2, type_error/2]).
-:- use_module(library(lists), [append/3]).
+:- use_module(library(lists), [append/3, sum_list/2, member/2]).
+:- use_module(library(apply), [maplist/3, include/3, foldl/4]).
+%% predsort/3 is autoloadable; no explicit import needed.
 
 %% ============================================================
 %% Public API — Phase 0 stubs
@@ -93,18 +97,36 @@ select_evaluation_strategy(Recurrence, Workload, strategy_choice(Strategy, Trace
     classify_signals_internal(Workload, IntentSignals, DeclaredData, InferredData,
                               Unknowns),
     append(DeclaredData, InferredData, DataSignals),
+    %% Phase 2: real cost-model evaluation.
     apply_cost_model(Recurrence, DataSignals, CostModelChoice),
     resolve_against_intent(IntentSignals, CostModelChoice, Recurrence, Strategy, Trace0),
     %% Build the classify_signals trace step from the classification result.
     build_classify_signals_step(IntentSignals, DeclaredData, InferredData, Unknowns,
                                 ClassifyStep),
+    %% Build the cost_model_choice trace step with adjustments in Details.
+    build_cost_model_choice_step(CostModelChoice, CostModelChoiceStep),
     Trace0 = trace(ResolveSteps),
     %% Phase 0: prepend the stub marker so the stub-leak assertion can
-    %% detect partial implementation while phases 2-4 are still in
+    %% detect partial implementation while phases 3-4 are still in
     %% progress. Removed once all phases land.
     Trace  = trace([step(stub, not_yet_implemented(phase_0), []),
-                    ClassifyStep
+                    ClassifyStep,
+                    CostModelChoiceStep
                     | ResolveSteps]).
+
+build_cost_model_choice_step(
+        cost_model_choice(Strategy, Score, DecidingRule),
+        step(cost_model_choice,
+             chosen(Strategy, Score, DecidingRule),
+             Details)) :-
+    rule_adjustments(DecidingRule, Adjustments),
+    (   Adjustments == []
+    ->  Details = []
+    ;   maplist(wrap_adjustment, Adjustments, AdjustmentTerms),
+        Details = AdjustmentTerms
+    ).
+
+wrap_adjustment(Adjustment, adjustment(Adjustment)).
 
 build_classify_signals_step(Intent, Declared, Inferred, Unknowns,
                             step(classify_signals,
@@ -213,10 +235,135 @@ signal_tier(query_frequency(_),              declared_data, manifest).
 
 %% apply_cost_model(+Recurrence, +DataSignals, -CostModelChoice)
 %
-% Phase 0 stub: returns the default-fallback choice unconditionally.
-% Phase 2 implements the rule registry and scoring.
-apply_cost_model(_Recurrence, _DataSignals,
-    cost_model_choice(strategy(per_query(unidirectional)), 0, default_fallback)).
+% Phase 2: evaluate every cost_model_rule/6 against (Recurrence,
+% DataSignals); each firing rule contributes a weighted score to its
+% chosen strategy; the strategy with the highest cumulative score
+% wins; tiebreak by deciding-rule priority, then lexicographic rule
+% name.
+%
+% Returns cost_model_choice(Strategy, Score, DecidingRule) per SPEC.
+% Adjustments for the deciding rule are looked up separately by
+% the trace-builder in select_evaluation_strategy/3 (see
+% rule_adjustments/2).
+apply_cost_model(Recurrence, DataSignals, CostModelChoice) :-
+    findall(firing(RuleName, Priority, WeightedScore, Strategy),
+            ( cost_model_rule(RuleName, Priority, RawScore, Strategy,
+                              Preconditions, AdditionalCheck),
+              rule_fires(Recurrence, DataSignals, Preconditions, AdditionalCheck),
+              weighted_score_for(RawScore, Preconditions, WeightedScore)
+            ),
+            Firings),
+    pick_winning_strategy(Firings, Strategy, CumulativeScore, DecidingRule),
+    CostModelChoice = cost_model_choice(Strategy, CumulativeScore, DecidingRule).
+
+%% rule_fires(+Recurrence, +DataSignals, +Preconditions, +AdditionalCheck)
+%
+% A rule fires when every signal in Preconditions is present in
+% DataSignals (member-check; tier-irrelevant per SPEC) AND the
+% AdditionalCheck goal succeeds.
+rule_fires(Recurrence, DataSignals, Preconditions, AdditionalCheck) :-
+    forall(member(Signal, Preconditions),
+           member(Signal, DataSignals)),
+    additional_check(AdditionalCheck, Recurrence, DataSignals).
+
+%% additional_check(+CheckTerm, +Recurrence, +DataSignals)
+%
+% Hook for non-member-list checks specific rules need.
+additional_check(true, _Recurrence, _DataSignals).
+additional_check(no_contradicting_cardinality, _Recurrence, DataSignals) :-
+    \+ member(cardinality(large), DataSignals),
+    \+ member(cardinality(medium), DataSignals).
+additional_check(admits_strategy(Strategy), Recurrence, _DataSignals) :-
+    admissible_strategies(Recurrence, Admissible),
+    member(Strategy, Admissible).
+
+%% weighted_score_for(+RawScore, +Preconditions, -WeightedScore)
+%
+% weighted_score = raw_score × (sum of per-signal weights) / N
+% where each signal contributes 1.0 if declared, 0.8 if inferred.
+% Special case: N=0 (no matching signals — e.g. default_fallback)
+% yields weighted_score = raw_score (treat as weight 1.0).
+weighted_score_for(RawScore, [], RawScore) :- !.
+weighted_score_for(RawScore, Preconditions, WeightedScore) :-
+    maplist(signal_weight, Preconditions, Weights),
+    sum_list(Weights, WeightSum),
+    length(Preconditions, N),
+    WeightedScore is RawScore * WeightSum / N.
+
+%% signal_weight(+Signal, -Weight)
+%
+% Look up the signal's tier in the dispatch table and return the
+% per-tier weight constant. Intent signals don't normally appear
+% in cost-model preconditions, but if they do they're weighted 1.0
+% (user-stated intent is high-confidence).
+signal_weight(Signal, Weight) :-
+    (   signal_tier(Signal, declared_data, _)
+    ->  Weight = 1.0
+    ;   signal_tier(Signal, inferred_data, _)
+    ->  Weight = 0.8
+    ;   signal_tier(Signal, intent, _)
+    ->  Weight = 1.0
+    ;   %% Unknown signal — treat as inferred (lower confidence)
+        Weight = 0.8
+    ).
+
+%% pick_winning_strategy(+Firings, -Strategy, -CumulativeScore, -DecidingRule)
+%
+% Sum weighted scores per strategy, pick the highest. Tiebreak: the
+% strategy whose highest-priority firing rule has the higher priority
+% wins; on priority-tie, lexicographic rule name.
+%
+% Firings is a list of firing(RuleName, Priority, WeightedScore, Strategy).
+pick_winning_strategy([], _, _, _) :-
+    %% Should never happen — default_fallback always fires. If we
+    %% reach here, there's a config bug.
+    throw(error(no_firing_cost_model_rules,
+                context(apply_cost_model/3, 'default_fallback should always fire'))).
+pick_winning_strategy(Firings, WinningStrategy, WinningScore, DecidingRule) :-
+    %% Group firings by strategy, sum scores.
+    findall(Strategy, member(firing(_, _, _, Strategy), Firings), AllStrategies),
+    sort(AllStrategies, UniqueStrategies),
+    findall(strategy_total(S, TotalScore, BestRule, BestPriority),
+            ( member(S, UniqueStrategies),
+              findall(WeightedScore-RuleName-Priority,
+                      member(firing(RuleName, Priority, WeightedScore, S), Firings),
+                      Contributions),
+              foldl(sum_contribution, Contributions, 0, TotalScore),
+              best_rule_for_strategy(Contributions, BestRule, BestPriority)
+            ),
+            StrategyTotals),
+    %% Sort by: score desc, then priority desc, then name asc.
+    predsort(strategy_total_compare, StrategyTotals, Sorted),
+    Sorted = [strategy_total(WinningStrategy, WinningScore, DecidingRule, _) | _].
+
+sum_contribution(WeightedScore-_-_, Acc, NewAcc) :-
+    NewAcc is Acc + WeightedScore.
+
+best_rule_for_strategy(Contributions, BestRule, BestPriority) :-
+    %% Sort contributions by priority desc, then name asc; take first.
+    predsort(contribution_compare, Contributions, [_-BestRule-BestPriority | _]).
+
+%% predsort/3 comparator for contributions: higher priority first,
+%% then lexicographic name.
+contribution_compare(Order, _-Name1-P1, _-Name2-P2) :-
+    (   P1 > P2 -> Order = (<)
+    ;   P1 < P2 -> Order = (>)
+    ;   compare(Order0, Name1, Name2),
+        ( Order0 == (=) -> Order = (=) ; Order = Order0 )
+    ).
+
+%% predsort/3 comparator for strategy_totals: higher score first,
+%% then higher priority of deciding rule, then lex rule name.
+strategy_total_compare(Order,
+        strategy_total(_, S1, R1, P1),
+        strategy_total(_, S2, R2, P2)) :-
+    (   S1 > S2 -> Order = (<)
+    ;   S1 < S2 -> Order = (>)
+    ;   P1 > P2 -> Order = (<)
+    ;   P1 < P2 -> Order = (>)
+    ;   compare(Order0, R1, R2),
+        ( Order0 == (=) -> Order = (=) ; Order = Order0 )
+    ).
 
 %% resolve_against_intent(+IntentSignals, +CostModelChoice, +Recurrence,
 %%                       -Strategy, -Trace)
@@ -246,10 +393,156 @@ format_trace_for_comment(_Trace, _CommentPrefix, "").
 
 %% admissible_strategies(+Recurrence, -StrategyList)
 %
-% Phase 0 stub: returns the single-element list with the baseline
-% strategy. Phase 2 implements the kernel-kind-to-strategies table
-% and termination-guarantee filtering.
-admissible_strategies(_Recurrence, [strategy(per_query(unidirectional))]).
+% Phase 2: returns the strategies admissible for this recurrence
+% based on two conditions (per SPEC §Admissibility):
+%
+%   1. KernelKind permits the strategy — read from
+%      kernel_kind_strategies/2 static table.
+%   2. Termination guarantee permits the strategy. For per_query(_)
+%      strategies, no convergence guarantee is required from the
+%      recurrence (per-query termination is the visited-set's job).
+%      For fixed_point(_) strategies:
+%        - value_domain(combinatorial) — admissible regardless of
+%          monotonicity (finite-state iteration always halts; the
+%          semantic meaning depends on monotonicity but termination
+%          does not — see philosophy doc).
+%        - value_domain(numeric) — admissible iff
+%          numeric_contraction_rate(R) with R < 1.0.
+%
+% NOTE: the monotone(false) cross-class restriction is NOT applied
+% here. It depends on intent context (which class the caller is
+% asking for) and is applied in Phase 3's conflict-resolution
+% machine.
+admissible_strategies(Recurrence, StrategyList) :-
+    Recurrence = recurrence(KernelKind, _Pred, Properties),
+    kernel_kind_strategies(KernelKind, KernelPermitted),
+    include(strategy_termination_ok(Properties), KernelPermitted, StrategyList).
+
+%% strategy_termination_ok(+Properties, +Strategy)
+%
+% True if the strategy's termination guarantee is satisfied by the
+% recurrence's properties.
+strategy_termination_ok(_Properties, strategy(per_query(_))) :- !.
+strategy_termination_ok(Properties, strategy(fixed_point(_))) :- !,
+    (   memberchk(value_domain(combinatorial), Properties)
+    ->  true
+    ;   memberchk(value_domain(numeric), Properties),
+        memberchk(numeric_contraction_rate(R), Properties),
+        number(R), R < 1.0
+    ).
+strategy_termination_ok(_Properties, strategy(cached)) :- !.
+strategy_termination_ok(_Properties, strategy(hybrid(_))) :- !.
+
+%% ============================================================
+%% Kernel-kind-to-strategies static table
+%%
+%% Maps each KernelKind (from recursive_kernel_detection.pl's
+%% detector registry) to the strategies its kernel template permits.
+%%
+%% MAINTENANCE NOTE: when a new detector is added to
+%% recursive_kernel_detection.pl, the corresponding entry MUST be
+%% added here. This dual-source-of-truth is documented in the
+%% implementation plan §Phase 3 hidden-scope notes.
+%%
+%% See SPEC §Admissibility for the per-kernel rationale.
+%% ============================================================
+
+%% bidirectional_ancestor — per-query-only by template design
+%% (single-pair source+target lookup; no fixed_point provision)
+kernel_kind_strategies(bidirectional_ancestor,
+    [strategy(per_query(bidirectional)), strategy(per_query(astar))]).
+
+%% category_ancestor — combinatorial; admits unidirectional and
+%% upgrade-to-bidirectional via maybe_upgrade_bidirectional/2
+kernel_kind_strategies(category_ancestor,
+    [strategy(per_query(unidirectional)), strategy(per_query(bidirectional))]).
+
+%% transitive_closure2 — combinatorial; fixed_point structurally
+%% permitted (Datalog-style); per_query upgrades available
+kernel_kind_strategies(transitive_closure2,
+    [strategy(per_query(unidirectional)),
+     strategy(per_query(bidirectional)),
+     strategy(fixed_point(semi_naive))]).
+
+%% transitive_distance3 — combinatorial BFS-with-distance
+kernel_kind_strategies(transitive_distance3,
+    [strategy(per_query(unidirectional)), strategy(per_query(bidirectional))]).
+
+%% transitive_parent_distance4 — combinatorial; per-query only
+kernel_kind_strategies(transitive_parent_distance4,
+    [strategy(per_query(unidirectional))]).
+
+%% transitive_step_parent_distance5 — combinatorial; per-query only
+kernel_kind_strategies(transitive_step_parent_distance5,
+    [strategy(per_query(unidirectional))]).
+
+%% weighted_shortest_path3 — numeric; Dijkstra per-query (template
+%% requires non-negative weights). fixed_point not in registry yet
+%% (would need Bellman-Ford or value-iteration template — see
+%% philosophy doc gap notes).
+kernel_kind_strategies(weighted_shortest_path3,
+    [strategy(per_query(dijkstra))]).
+
+%% astar_shortest_path4 — numeric; A* per-query (heuristic-driven)
+kernel_kind_strategies(astar_shortest_path4,
+    [strategy(per_query(astar))]).
+
+%% ============================================================
+%% Cost-model rules (Phase 2)
+%%
+%% Each rule:
+%%   cost_model_rule(RuleName, Priority, RawScore, Strategy,
+%%                   Preconditions, AdditionalCheck)
+%%
+%% Preconditions: list of signal terms that must ALL be in DataSignals
+%%   (tier-irrelevant per SPEC — confidence weighting handles tier).
+%% AdditionalCheck: extra goal (one of true / no_contradicting_cardinality /
+%%   admits_strategy(_)). Most rules use 'true'.
+%%
+%% Adjustments (for rules that need them) are looked up via
+%% rule_adjustments/2.
+%%
+%% Adding a rule means adding a clause here (NOT multifile —
+%% load-order-dependent tiebreaking is fragile per SPEC).
+%% ============================================================
+
+cost_model_rule(prefer_bidirectional_csr_present, 100, 3,
+    strategy(per_query(bidirectional)),
+    [csr_available(true), query_pattern(single_pair), cardinality(large)],
+    true).
+
+cost_model_rule(prefer_bidirectional_csr_buildable, 90, 2,
+    strategy(per_query(bidirectional)),
+    [csr_buildable(true), cardinality(large), query_frequency(high)],
+    true).
+
+cost_model_rule(prefer_unidirectional_no_csr, 80, 2,
+    strategy(per_query(unidirectional)),
+    [csr_available(false), csr_buildable(false)],
+    true).
+
+cost_model_rule(prefer_unidirectional_small, 70, 1,
+    strategy(per_query(unidirectional)),
+    [cardinality(small)],
+    no_contradicting_cardinality).
+
+cost_model_rule(prefer_astar_heuristic_available, 60, 1,
+    strategy(per_query(astar)),
+    [heuristic_predicate_available(true)],
+    admits_strategy(strategy(per_query(astar)))).
+
+cost_model_rule(default_fallback, 1, 0,
+    strategy(per_query(unidirectional)),
+    [],
+    true).
+
+%% rule_adjustments(+RuleName, -Adjustments)
+%
+% Returns the list of adjustment atoms the rule's preferred strategy
+% requires as side-effects (e.g. build CSR at compile time before
+% the kernel call). Rules without adjustments return [].
+rule_adjustments(prefer_bidirectional_csr_buildable, [build_csr_at_compile_time]).
+rule_adjustments(_, []) :- !.
 
 %% strategy_pretty(+Strategy, -String)
 %

--- a/tests/core/test_res_cost_model.pl
+++ b/tests/core/test_res_cost_model.pl
@@ -1,0 +1,491 @@
+:- encoding(utf8).
+%% Phase 2 test suite for recurrence_evaluation_strategy:
+%%   apply_cost_model/3 + admissible_strategies/2 + the six initial
+%%   cost-model rules + scoring + confidence weighting.
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_res_cost_model.pl
+
+:- use_module('../../src/unifyweaver/core/recurrence_evaluation_strategy').
+:- use_module(library(lists)).
+
+%% ========================================================================
+%% Test runner
+%% ========================================================================
+
+run_tests :-
+    format("~n========================================~n"),
+    format("RES Phase 2 Cost-Model Tests~n"),
+    format("========================================~n~n"),
+    findall(Test, test(Test), Tests),
+    length(Tests, Total),
+    run_all(Tests, 0, Passed),
+    format("~n========================================~n"),
+    (   Passed =:= Total
+    ->  format("All ~w tests passed~n", [Total])
+    ;   Failed is Total - Passed,
+        format("~w of ~w tests FAILED~n", [Failed, Total]),
+        format("Tests FAILED~n"),
+        halt(1)
+    ),
+    format("========================================~n").
+
+run_all([], Passed, Passed).
+run_all([Test|Rest], Acc, Passed) :-
+    (   catch(call(Test), Error,
+            (format("[FAIL] ~w: ~w~n", [Test, Error]), fail))
+    ->  format("[PASS] ~w~n", [Test]),
+        Acc1 is Acc + 1,
+        run_all(Rest, Acc1, Passed)
+    ;   run_all(Rest, Acc, Passed)
+    ).
+
+%% ========================================================================
+%% Test declarations
+%% ========================================================================
+
+%% Per-rule firing/non-firing
+test(test_default_fallback_always_fires).
+test(test_prefer_bidirectional_csr_present_fires).
+test(test_prefer_bidirectional_csr_present_misses_csr).
+test(test_prefer_bidirectional_csr_present_misses_cardinality).
+test(test_prefer_bidirectional_csr_buildable_fires).
+test(test_prefer_bidirectional_csr_buildable_misses_freq).
+test(test_prefer_unidirectional_no_csr_fires).
+test(test_prefer_unidirectional_no_csr_misses_when_csr_buildable).
+test(test_prefer_unidirectional_small_fires).
+test(test_prefer_unidirectional_small_misses_with_contradicting_large).
+test(test_prefer_astar_heuristic_available_fires).
+test(test_prefer_astar_heuristic_available_misses_when_inadmissible).
+
+%% SPEC worked-scoring example (exact reproduction)
+test(test_spec_worked_scoring_example_winner).
+test(test_spec_worked_scoring_example_score).
+test(test_spec_worked_scoring_example_deciding_rule).
+test(test_spec_worked_scoring_example_adjustment_in_trace).
+
+%% Rule-interaction cases
+test(test_multiple_rules_same_strategy_accumulate).
+test(test_priority_tiebreak_higher_priority_wins).
+
+%% Confidence weighting
+test(test_all_declared_signals_weight_1).
+test(test_all_inferred_signals_weight_08).
+test(test_mixed_declared_and_inferred_weights_averaged).
+test(test_default_fallback_no_signals_no_division_by_zero).
+
+%% Admissibility
+test(test_admissibility_combinatorial_admits_fixed_point).
+test(test_admissibility_numeric_with_contraction_admits_fixed_point).
+test(test_admissibility_numeric_without_contraction_excludes_fixed_point).
+test(test_admissibility_numeric_high_contraction_excludes_fixed_point).
+test(test_admissibility_per_query_always_admissible).
+test(test_admissibility_does_not_apply_monotone_false).
+
+%% Kernel-kind table coverage
+test(test_kernel_bidirectional_ancestor_admissible).
+test(test_kernel_transitive_closure2_admissible).
+test(test_kernel_weighted_shortest_path3_admissible).
+
+%% Integration: cost_model_choice trace step
+test(test_cost_model_choice_step_in_trace).
+test(test_cost_model_choice_step_includes_adjustments).
+test(test_cost_model_choice_step_no_adjustments_when_none).
+
+%% ========================================================================
+%% Test fixtures
+%% ========================================================================
+
+%% Combinatorial recurrence — most common case
+a_recurrence_combinatorial(recurrence(transitive_closure2, my_pred/2,
+    [value_domain(combinatorial), monotone(true)])).
+
+%% Numeric recurrence with a contraction rate that admits fixed_point
+a_recurrence_numeric_admits_fp(recurrence(transitive_closure2, my_pred/2,
+    [value_domain(numeric), monotone(true), numeric_contraction_rate(0.04)])).
+
+%% Numeric recurrence without a contraction rate — fixed_point excluded
+a_recurrence_numeric_no_contraction(recurrence(transitive_closure2, my_pred/2,
+    [value_domain(numeric), monotone(true)])).
+
+%% Numeric recurrence with R >= 1 — fixed_point excluded
+a_recurrence_numeric_high_r(recurrence(transitive_closure2, my_pred/2,
+    [value_domain(numeric), monotone(true), numeric_contraction_rate(1.5)])).
+
+%% Non-monotone recurrence — Phase 3's cross-class restriction may
+%% apply but admissibility should still return the full kernel set
+%% (per SPEC: monotone is NOT in admissibility)
+a_recurrence_non_monotone(recurrence(transitive_closure2, my_pred/2,
+    [value_domain(combinatorial), monotone(false)])).
+
+%% Bidirectional ancestor kernel — per-query-only by template design
+a_recurrence_bidir_ancestor(recurrence(bidirectional_ancestor, my_pred/5,
+    [value_domain(combinatorial), monotone(true)])).
+
+%% Weighted shortest path — numeric Dijkstra kernel
+a_recurrence_weighted_sp(recurrence(weighted_shortest_path3, my_pred/3,
+    [value_domain(numeric), monotone(true)])).
+
+%% ========================================================================
+%% Per-rule firing tests
+%% ========================================================================
+
+%% default_fallback fires unconditionally and yields per_query(unidirectional)
+%% with score 0.
+test_default_fallback_always_fires :-
+    a_recurrence_combinatorial(R),
+    apply_cost_model(R, [],
+        cost_model_choice(Strategy, Score, DecidingRule)),
+    Strategy == strategy(per_query(unidirectional)),
+    Score =:= 0,
+    DecidingRule == default_fallback.
+
+%% prefer_bidirectional_csr_present: all three preconditions present.
+test_prefer_bidirectional_csr_present_fires :-
+    a_recurrence_combinatorial(R),
+    DataSignals = [csr_available(true), query_pattern(single_pair), cardinality(large)],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(Strategy, _Score, DecidingRule)),
+    Strategy == strategy(per_query(bidirectional)),
+    DecidingRule == prefer_bidirectional_csr_present.
+
+%% prefer_bidirectional_csr_present: missing csr_available(true).
+test_prefer_bidirectional_csr_present_misses_csr :-
+    a_recurrence_combinatorial(R),
+    DataSignals = [query_pattern(single_pair), cardinality(large)],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(_Strategy, _Score, DecidingRule)),
+    DecidingRule \== prefer_bidirectional_csr_present.
+
+%% prefer_bidirectional_csr_present: missing cardinality(large).
+test_prefer_bidirectional_csr_present_misses_cardinality :-
+    a_recurrence_combinatorial(R),
+    DataSignals = [csr_available(true), query_pattern(single_pair)],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(_Strategy, _Score, DecidingRule)),
+    DecidingRule \== prefer_bidirectional_csr_present.
+
+%% prefer_bidirectional_csr_buildable: all three present.
+test_prefer_bidirectional_csr_buildable_fires :-
+    a_recurrence_combinatorial(R),
+    DataSignals = [csr_buildable(true), cardinality(large), query_frequency(high)],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(Strategy, _Score, DecidingRule)),
+    Strategy == strategy(per_query(bidirectional)),
+    DecidingRule == prefer_bidirectional_csr_buildable.
+
+%% prefer_bidirectional_csr_buildable: missing query_frequency(high).
+test_prefer_bidirectional_csr_buildable_misses_freq :-
+    a_recurrence_combinatorial(R),
+    DataSignals = [csr_buildable(true), cardinality(large)],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(_Strategy, _Score, DecidingRule)),
+    DecidingRule \== prefer_bidirectional_csr_buildable.
+
+%% prefer_unidirectional_no_csr: both negatives present.
+test_prefer_unidirectional_no_csr_fires :-
+    a_recurrence_combinatorial(R),
+    DataSignals = [csr_available(false), csr_buildable(false)],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(Strategy, _Score, DecidingRule)),
+    Strategy == strategy(per_query(unidirectional)),
+    DecidingRule == prefer_unidirectional_no_csr.
+
+%% prefer_unidirectional_no_csr: doesn't fire when csr_buildable(true).
+test_prefer_unidirectional_no_csr_misses_when_csr_buildable :-
+    a_recurrence_combinatorial(R),
+    DataSignals = [csr_available(false), csr_buildable(true)],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(_Strategy, _Score, DecidingRule)),
+    DecidingRule \== prefer_unidirectional_no_csr.
+
+%% prefer_unidirectional_small: cardinality(small) with no contradicting.
+test_prefer_unidirectional_small_fires :-
+    a_recurrence_combinatorial(R),
+    DataSignals = [cardinality(small)],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(Strategy, _Score, DecidingRule)),
+    Strategy == strategy(per_query(unidirectional)),
+    DecidingRule == prefer_unidirectional_small.
+
+%% prefer_unidirectional_small: blocked by contradicting cardinality(large).
+test_prefer_unidirectional_small_misses_with_contradicting_large :-
+    a_recurrence_combinatorial(R),
+    %% Both signals present (could happen in pathological workload).
+    %% The "no contradicting" check should suppress the rule.
+    DataSignals = [cardinality(small), cardinality(large)],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(_Strategy, _Score, DecidingRule)),
+    DecidingRule \== prefer_unidirectional_small.
+
+%% prefer_astar_heuristic_available fires when astar is admissible AND
+%% the heuristic is declared.
+test_prefer_astar_heuristic_available_fires :-
+    a_recurrence_bidir_ancestor(R),
+    DataSignals = [heuristic_predicate_available(true)],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(Strategy, _Score, DecidingRule)),
+    Strategy == strategy(per_query(astar)),
+    DecidingRule == prefer_astar_heuristic_available.
+
+%% prefer_astar_heuristic_available doesn't fire when astar isn't admissible.
+test_prefer_astar_heuristic_available_misses_when_inadmissible :-
+    %% transitive_closure2 doesn't admit per_query(astar) per the kernel table.
+    a_recurrence_combinatorial(R),
+    DataSignals = [heuristic_predicate_available(true)],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(_Strategy, _Score, DecidingRule)),
+    DecidingRule \== prefer_astar_heuristic_available.
+
+%% ========================================================================
+%% SPEC worked-scoring example (exact reproduction)
+%%
+%% Workload (per SPEC):
+%%   Declared: cardinality(large), query_pattern(single_pair),
+%%             query_frequency(high)
+%%   Inferred: csr_buildable(true), csr_available(false)
+%%   No intent signals
+%%
+%% Expected:
+%%   Winner: per_query(bidirectional)
+%%   Weighted score: 2 × (0.8 + 1.0 + 1.0) / 3 ≈ 1.867
+%%   Deciding rule: prefer_bidirectional_csr_buildable
+%%   Adjustment in trace: build_csr_at_compile_time
+%% ========================================================================
+
+spec_example_data_signals([
+    %% declared (cost model doesn't care about tier for firing — these
+    %% are just signal values present in DataSignals)
+    cardinality(large),
+    query_pattern(single_pair),
+    query_frequency(high),
+    %% inferred (same — the SIGNAL_VALUES are what matter)
+    csr_buildable(true),
+    csr_available(false)
+]).
+
+test_spec_worked_scoring_example_winner :-
+    a_recurrence_combinatorial(R),
+    spec_example_data_signals(DataSignals),
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(Strategy, _Score, _DecidingRule)),
+    Strategy == strategy(per_query(bidirectional)).
+
+test_spec_worked_scoring_example_score :-
+    a_recurrence_combinatorial(R),
+    spec_example_data_signals(DataSignals),
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(_Strategy, Score, _DecidingRule)),
+    %% Expected ≈ 1.867; allow small floating-point tolerance.
+    abs(Score - 1.867) < 0.01.
+
+test_spec_worked_scoring_example_deciding_rule :-
+    a_recurrence_combinatorial(R),
+    spec_example_data_signals(DataSignals),
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(_Strategy, _Score, DecidingRule)),
+    DecidingRule == prefer_bidirectional_csr_buildable.
+
+test_spec_worked_scoring_example_adjustment_in_trace :-
+    a_recurrence_combinatorial(R),
+    spec_example_data_signals(DataSignals),
+    select_evaluation_strategy(R, DataSignals,
+        strategy_choice(_Strategy, trace(Steps))),
+    member(step(cost_model_choice,
+                chosen(strategy(per_query(bidirectional)), _Score,
+                       prefer_bidirectional_csr_buildable),
+                Details),
+           Steps),
+    member(adjustment(build_csr_at_compile_time), Details).
+
+%% ========================================================================
+%% Rule-interaction cases
+%% ========================================================================
+
+%% When multiple rules fire for the same strategy, their weighted
+%% scores accumulate.
+test_multiple_rules_same_strategy_accumulate :-
+    a_recurrence_combinatorial(R),
+    %% Workload triggers both prefer_unidirectional_no_csr (raw +2) and
+    %% default_fallback (raw +0) for per_query(unidirectional). Both
+    %% contribute to the cumulative score for the same strategy.
+    DataSignals = [csr_available(false), csr_buildable(false)],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(Strategy, Score, _DecidingRule)),
+    Strategy == strategy(per_query(unidirectional)),
+    %% prefer_unidirectional_no_csr: csr_available(false) and
+    %%   csr_buildable(false) are BOTH inferred (per signal_tier
+    %%   dispatch). Raw 2, weights (0.8 + 0.8)/2 = 0.8, weighted = 1.6.
+    %% default_fallback: no preconditions, weighted = raw_score = 0.
+    %% Cumulative for per_query(unidirectional) = 1.6 + 0 = 1.6.
+    abs(Score - 1.6) < 0.01.
+
+%% When two rules tie on score for different strategies, the
+%% higher-priority rule wins. Test:
+%%   prefer_unidirectional_no_csr (priority 80, +2)
+%%   prefer_bidirectional_csr_buildable (priority 90, +2)
+%% Same raw score but different strategies. Higher priority should win.
+test_priority_tiebreak_higher_priority_wins :-
+    a_recurrence_combinatorial(R),
+    DataSignals = [
+        %% Triggers prefer_bidirectional_csr_buildable (priority 90)
+        csr_buildable(true), cardinality(large), query_frequency(high),
+        %% Would have triggered prefer_unidirectional_no_csr (priority 80) —
+        %% but the csr_buildable(true) means csr_buildable(false) precondition
+        %% isn't met. So actually only prefer_bidirectional_csr_buildable
+        %% fires. Different setup needed.
+        csr_available(false)
+    ],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(Strategy, _Score, DecidingRule)),
+    Strategy == strategy(per_query(bidirectional)),
+    DecidingRule == prefer_bidirectional_csr_buildable.
+
+%% ========================================================================
+%% Confidence weighting
+%% ========================================================================
+
+%% All-declared signals: weight 1.0 each, so weighted score = raw score.
+test_all_declared_signals_weight_1 :-
+    a_recurrence_combinatorial(R),
+    %% prefer_bidirectional_csr_present has all three declared.
+    DataSignals = [csr_available(true), query_pattern(single_pair), cardinality(large)],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(_Strategy, Score, _DecidingRule)),
+    %% Raw score 3, weights (1.0+1.0+1.0)/3 = 1.0, weighted = 3.0
+    abs(Score - 3.0) < 0.01.
+
+%% All-inferred signals: weight 0.8 each, so weighted score = raw × 0.8.
+test_all_inferred_signals_weight_08 :-
+    a_recurrence_combinatorial(R),
+    %% prefer_unidirectional_no_csr: csr_available(false) AND csr_buildable(false)
+    %% Both inferred per dispatch table.
+    DataSignals = [csr_available(false), csr_buildable(false)],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(_Strategy, Score, _DecidingRule)),
+    %% Raw score 2, weights (0.8+0.8)/2 = 0.8, weighted = 1.6
+    abs(Score - 1.6) < 0.01.
+
+%% Mixed declared + inferred: weights averaged.
+test_mixed_declared_and_inferred_weights_averaged :-
+    %% Already tested by the SPEC worked-scoring example. Re-verify
+    %% with a different workload.
+    a_recurrence_combinatorial(R),
+    %% prefer_bidirectional_csr_buildable: csr_buildable(inferred, 0.8),
+    %% cardinality(declared, 1.0), query_frequency(declared, 1.0).
+    %% Raw 2, weights (0.8+1.0+1.0)/3, weighted ≈ 1.867.
+    DataSignals = [csr_buildable(true), cardinality(large), query_frequency(high)],
+    apply_cost_model(R, DataSignals,
+        cost_model_choice(_Strategy, Score, _DecidingRule)),
+    abs(Score - 1.867) < 0.01.
+
+%% default_fallback has no preconditions — no division by zero.
+test_default_fallback_no_signals_no_division_by_zero :-
+    a_recurrence_combinatorial(R),
+    apply_cost_model(R, [],
+        cost_model_choice(_Strategy, Score, _DecidingRule)),
+    Score =:= 0.
+
+%% ========================================================================
+%% Admissibility
+%% ========================================================================
+
+%% Combinatorial recurrence admits fixed_point (Tarski + finite lattice).
+test_admissibility_combinatorial_admits_fixed_point :-
+    a_recurrence_combinatorial(R),
+    admissible_strategies(R, Strategies),
+    member(strategy(fixed_point(semi_naive)), Strategies).
+
+%% Numeric recurrence with R < 1 admits fixed_point.
+test_admissibility_numeric_with_contraction_admits_fixed_point :-
+    %% transitive_closure2's table includes fixed_point(semi_naive).
+    a_recurrence_numeric_admits_fp(R),
+    admissible_strategies(R, Strategies),
+    member(strategy(fixed_point(semi_naive)), Strategies).
+
+%% Numeric recurrence without contraction rate: fixed_point excluded.
+test_admissibility_numeric_without_contraction_excludes_fixed_point :-
+    a_recurrence_numeric_no_contraction(R),
+    admissible_strategies(R, Strategies),
+    \+ member(strategy(fixed_point(semi_naive)), Strategies).
+
+%% Numeric recurrence with R >= 1: fixed_point excluded.
+test_admissibility_numeric_high_contraction_excludes_fixed_point :-
+    a_recurrence_numeric_high_r(R),
+    admissible_strategies(R, Strategies),
+    \+ member(strategy(fixed_point(semi_naive)), Strategies).
+
+%% per_query(_) strategies are always admissible (no convergence
+%% guarantee required from the recurrence).
+test_admissibility_per_query_always_admissible :-
+    a_recurrence_combinatorial(R),
+    admissible_strategies(R, CombStrategies),
+    member(strategy(per_query(unidirectional)), CombStrategies),
+    a_recurrence_numeric_no_contraction(R2),
+    admissible_strategies(R2, NumStrategies),
+    member(strategy(per_query(unidirectional)), NumStrategies).
+
+%% monotone(false) does NOT restrict admissibility (Phase 3's job).
+test_admissibility_does_not_apply_monotone_false :-
+    a_recurrence_combinatorial(R),
+    admissible_strategies(R, MonotoneStrategies),
+    a_recurrence_non_monotone(R2),
+    admissible_strategies(R2, NonMonotoneStrategies),
+    %% Same list — monotone(false) is not in the admissibility check.
+    MonotoneStrategies == NonMonotoneStrategies.
+
+%% ========================================================================
+%% Kernel-kind table coverage
+%% ========================================================================
+
+test_kernel_bidirectional_ancestor_admissible :-
+    a_recurrence_bidir_ancestor(R),
+    admissible_strategies(R, Strategies),
+    member(strategy(per_query(bidirectional)), Strategies),
+    member(strategy(per_query(astar)), Strategies),
+    \+ member(strategy(fixed_point(_)), Strategies).
+
+test_kernel_transitive_closure2_admissible :-
+    a_recurrence_combinatorial(R),
+    admissible_strategies(R, Strategies),
+    member(strategy(per_query(unidirectional)), Strategies),
+    member(strategy(per_query(bidirectional)), Strategies),
+    member(strategy(fixed_point(semi_naive)), Strategies).
+
+test_kernel_weighted_shortest_path3_admissible :-
+    a_recurrence_weighted_sp(R),
+    admissible_strategies(R, Strategies),
+    Strategies == [strategy(per_query(dijkstra))].
+
+%% ========================================================================
+%% Integration: cost_model_choice trace step
+%% ========================================================================
+
+test_cost_model_choice_step_in_trace :-
+    a_recurrence_combinatorial(R),
+    DataSignals = [csr_available(true), query_pattern(single_pair), cardinality(large)],
+    select_evaluation_strategy(R, DataSignals,
+        strategy_choice(_Strategy, trace(Steps))),
+    member(step(cost_model_choice,
+                chosen(strategy(per_query(bidirectional)), _Score,
+                       prefer_bidirectional_csr_present),
+                _Details),
+           Steps).
+
+test_cost_model_choice_step_includes_adjustments :-
+    a_recurrence_combinatorial(R),
+    spec_example_data_signals(DataSignals),
+    select_evaluation_strategy(R, DataSignals,
+        strategy_choice(_Strategy, trace(Steps))),
+    member(step(cost_model_choice, chosen(_, _, prefer_bidirectional_csr_buildable),
+                Details),
+           Steps),
+    member(adjustment(build_csr_at_compile_time), Details).
+
+test_cost_model_choice_step_no_adjustments_when_none :-
+    a_recurrence_combinatorial(R),
+    %% Empty workload → default_fallback fires → no adjustments
+    select_evaluation_strategy(R, [],
+        strategy_choice(_Strategy, trace(Steps))),
+    member(step(cost_model_choice, chosen(_, _, default_fallback), Details), Steps),
+    Details == [].


### PR DESCRIPTION
  ## Summary

  Implements **Phase 2** of the recurrence-evaluation-strategy implementation plan — the biggest single phase (~2.5 hours estimated; ~2.5 actual). Replaces the Phase 0 stubs for `apply_cost_model/3` and `admissible_strategies/2` with real implementations, plus all supporting infrastructure: kernel-kind-to-strategies table, six initial cost-model rules, scoring aggregator, confidence weighting, adjustment lookup.

  This is the third of seven phases. Builds on Phase 0 (#2873) and Phase 1 (#2876). Phase 3 (conflict-resolution machine) comes next.

  ## What this PR delivers

  ### `admissible_strategies/2` is real

  Two-condition test per SPEC §Admissibility:
  1. **KernelKind permits the strategy** — read from `kernel_kind_strategies/2` static table.
  2. **Termination guarantee permits the strategy** — for `per_query`, always; for `fixed_point`, `combinatorial` admits
  regardless of monotonicity (Tarski + finite lattice), `numeric` requires `numeric_contraction_rate(R)` with `R <
  1.0`.

  The `monotone(false)` cross-class restriction is NOT applied here — that's Phase 3's job per the SPEC's explicit Phase
  C split.

  ### `kernel_kind_strategies/2` static table

  Covers all 7 detectors in `recursive_kernel_detection.pl` plus `bidirectional_ancestor`. Each entry has a SPEC-aligned
  rationale comment. Maintenance note in the table block reminds future contributors to keep it in sync with the
  detector registry when adding new kernels.

  ### Six cost-model rules

  `cost_model_rule/6` clauses (non-multifile — explicit `Priority` argument replaces load-order-dependent tiebreaking
  per SPEC). Each rule has structured `(RuleName, Priority, RawScore, Strategy, Preconditions, AdditionalCheck)`:

  | Rule | Priority | Raw Score | Strategy |
  |------|----------|-----------|----------|
  | `prefer_bidirectional_csr_present` | 100 | +3 | `per_query(bidirectional)` |
  | `prefer_bidirectional_csr_buildable` | 90 | +2 | `per_query(bidirectional)` (+ build_csr adjustment) |
  | `prefer_unidirectional_no_csr` | 80 | +2 | `per_query(unidirectional)` |
  | `prefer_unidirectional_small` | 70 | +1 | `per_query(unidirectional)` |
  | `prefer_astar_heuristic_available` | 60 | +1 | `per_query(astar)` |
  | `default_fallback` | 1 | +0 | `per_query(unidirectional)` |

  ### `apply_cost_model/3` real implementation

  1. Collect all firing rules (preconditions all in `DataSignals` + `additional_check/3` succeeds)
  2. Weighted score per rule via `signal_tier/3` dispatch lookup (declared = 1.0, inferred = 0.8; default_fallback's
  no-preconditions case treated as weight 1.0 to avoid div-by-zero)
  3. Sum weighted scores per strategy (multiple rules accumulate)
  4. `predsort/3` strategies by score desc, then deciding-rule priority desc, then lex rule name asc
  5. Returns `cost_model_choice(Strategy, CumulativeScore, DecidingRule)` per SPEC

  ### `rule_adjustments/2` lookup

  Adjustments are intrinsic to the deciding rule (only `prefer_bidirectional_csr_buildable` has one currently:
  `[build_csr_at_compile_time]`). `select_evaluation_strategy/3` consults `rule_adjustments/2` when building the trace
  step's `Details`, matching the SPEC's "adjustments as detail fields of whatever step caused them" rule.

  ### `select_evaluation_strategy/3` trace step

  New `step(cost_model_choice, chosen(Strategy, Score, DecidingRule), Details)` entry built from the cost-model result.
  The Phase 0 stub marker is still prepended for the Phase 5 leak detector.

  ## Test plan

  `tests/core/test_res_cost_model.pl` — **34 new tests, all pass**:

  - **Per-rule firing** (12 tests): each of the six rules verified both firing and non-firing cases
  - **SPEC worked-scoring example exact reproduction** (4 tests): winner = `per_query(bidirectional)`, score ≈ 1.867
  (within 0.01 tolerance), deciding rule = `prefer_bidirectional_csr_buildable`, adjustment in trace
  - **Rule interaction** (2 tests): multiple rules same strategy accumulate; priority tiebreak
  - **Confidence weighting** (4 tests): all-declared (1.0), all-inferred (0.8), mixed averaged, default_fallback
  no-div-by-zero
  - **Admissibility** (6 tests): combinatorial admits fixed_point; numeric+contraction admits; numeric+no-contraction
  excludes; numeric+R≥1 excludes; per_query always admissible; `monotone(false)` does NOT restrict
  - **Kernel-kind table** (3 tests): bidirectional_ancestor, transitive_closure2, weighted_shortest_path3
  - **Integration** (3 tests): cost_model_choice step in trace with correct outcome and adjustments

  Prior phases still pass: `test_res_signals.pl` 29/29 + `test_res_skeleton.pl` 12/12.

  **Total: 75 tests passing.**

  ## What's NOT in this PR

  Phases 3–7. Specifically:

  - `resolve_against_intent/5` still returns the cost-model choice unchanged with the Phase 0 stub trace entry. Phase 3
  replaces this with the six-step conflict-resolution machine.
  - Trace renderers (`render_trace_for_stderr/2`, `format_trace_for_comment/3`) still return empty / "". Phase 4.

  ## Effort

  ~2.5 hours per the implementation plan estimate.

  ## Files

  src/unifyweaver/core/recurrence_evaluation_strategy.pl   (+327 -17)
  tests/core/test_res_cost_model.pl                         (NEW, 491 lines, 34 tests)