### PR TITLE
WAM Rust: opt-in min_dist_to_root branch-prune (+ codegen guard)

### DIFF
--- a/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
+++ b/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
@@ -1513,6 +1513,19 @@ fn main() {
                 }
             })
             .collect();
+        // ROOT_ANCHORED_METRICS: WAM_MIN_DIST_PRUNE=1 loads the materialised
+        // metric_min_dist_to_root table (built at ingest by
+        // build_scoped_subtree_lmdb.py) and hands it to the kernel as an
+        // admissible A*-style prune. Off by default (empty table => no-op), so
+        // it is opt-in and A/B-able; never changes results.
+        let min_dist_prune = std::env::var("WAM_MIN_DIST_PRUNE")
+            .map(|v| v == "1" || v == "true")
+            .unwrap_or(false);
+        if min_dist_prune {
+            let md = lmdb.load_min_dist().expect("load_min_dist");
+            eprintln!("min_dist_prune: loaded {} node distances", md.len());
+            vm.set_min_dist(&md);
+        }
         let acc = vm.resolve_edge_accessor("category_parent");
         let vm_ref = &vm;
         let acc_ref = &acc;

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -1930,6 +1930,23 @@ compile_collect_native_category_ancestor_to_rust(Code) :-
         depth: i64,
         out: &mut Vec<i64>,
     ) {
+        // ROOT_ANCHORED_METRICS admissible prune: when a materialised
+        // min_dist_to_root table is loaded, a node whose shortest remaining
+        // distance to root exceeds the remaining depth budget cannot reach
+        // root within max_depth, so the whole branch is cut. A node absent
+        // from the table is unreachable and likewise pruned. Disabled (empty
+        // table) by default; never changes results, only avoids exploring
+        // walks that provably cannot reach root in budget.
+        if !self.min_dist.is_empty() {
+            match self.min_dist.get(&(cat_id as i32)) {
+                Some(&d) => {
+                    if depth + (d as i64) > max_depth as i64 {
+                        return;
+                    }
+                }
+                None => return,
+            }
+        }
         // R7: route through self.edge_parents so lazy_lookups is
         // consulted before ffi_facts. This keeps the kernels_on
         // native path working under lmdb_materialisation(lazy).

--- a/templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache
+++ b/templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache
@@ -138,6 +138,36 @@ impl LmdbFactSource {
         Ok(out)
     }
 
+    /// Load the materialised `metric_min_dist_to_root` table (int32 node ->
+    /// int32 min hops to root) written at ingest by build_scoped_subtree_lmdb.py.
+    /// Returns an empty map if the sub-db is absent (non-scoped DBs), so the
+    /// caller can treat "no table" as "prune disabled".
+    pub fn load_min_dist(&self) -> Result<HashMap<i32, i32>, lmdb::Error> {
+        let db = match lmdb::Database::open(
+            Arc::clone(&self.env),
+            Some("metric_min_dist_to_root"),
+            &lmdb::DatabaseOptions::new(lmdb::db::Flags::empty()),
+        ) {
+            Ok(db) => db,
+            Err(_) => return Ok(HashMap::new()),
+        };
+        let txn = lmdb::ReadTransaction::new(&*self.env)?;
+        let access = txn.access();
+        let mut cursor = txn.cursor(&db)?;
+        let mut out = HashMap::new();
+        match cursor.first::<[u8], [u8]>(&access) {
+            Ok((k, v)) => {
+                out.insert(decode_i32(k), decode_i32(v));
+                while let Ok((k, v)) = cursor.next::<[u8], [u8]>(&access) {
+                    out.insert(decode_i32(k), decode_i32(v));
+                }
+            }
+            Err(lmdb::Error::Code(lmdb_zero::error::NOTFOUND)) => {}
+            Err(e) => return Err(e),
+        }
+        Ok(out)
+    }
+
     /// Look up all parents of `child_id` via cursor MDB_SET + MDB_NEXT_DUP.
     /// Returns an empty Vec if the key is absent.
     pub fn lookup_parents(&self, child_id: i32) -> Result<Vec<i32>, lmdb::Error> {

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -364,6 +364,14 @@ pub struct WamState {
     /// path must filter identically or the kernel over-explores
     /// non-reachable ancestor branches. Empty = no filter (eager/other).
     pub demand_set: FxSet<i32>,
+    /// ROOT_ANCHORED_METRICS min-distance prune: maps each in-scope node (raw
+    /// LMDB/page id) to its minimum hop-distance to root, materialised at
+    /// ingest (metric_min_dist_to_root). The category_ancestor kernel uses it
+    /// as an admissible A*-style cut: at depth `c`, a node `n` with
+    /// `c + min_dist[n] > max_depth` cannot reach root within budget, so the
+    /// whole branch is skipped (and a node absent from the table can't reach
+    /// root at all). Empty = prune disabled (default). Never changes results.
+    pub min_dist: FxMap<i32, i32>,
     /// Int-native edge mode: when true, the lazy edge path treats the kernel's
     /// u32 node id AS the raw LMDB int key directly (identity), bypassing
     /// `wam_to_lmdb`/`lmdb_to_wam`. Used for int-native fixtures whose seeds,
@@ -436,6 +444,7 @@ impl WamState {
             lmdb_to_wam: FxMap::default(),
             int_native_edges: false,
             demand_set: FxSet::default(),
+            min_dist: FxMap::default(),
             bindings: HashMap::new(),
             var_counter: 0,
             cut_barrier: 0,
@@ -628,6 +637,12 @@ impl WamState {
         // FxHash-backed demand_set so the hot `contains` on the kernel
         // path avoids SipHash.
         self.demand_set = demand.iter().copied().collect();
+    }
+
+    /// Load the materialised min_dist_to_root table (node -> min hops to root)
+    /// used by the kernel's admissible prune. Empty = prune disabled.
+    pub fn set_min_dist(&mut self, dist: &HashMap<i32, i32>) {
+        self.min_dist = dist.iter().map(|(&k, &v)| (k, v)).collect();
     }
 
     /// Enable int-native edge mode: the lazy edge path treats the kernel's

--- a/tests/test_wam_rust_matrix_demand_flag.py
+++ b/tests/test_wam_rust_matrix_demand_flag.py
@@ -81,6 +81,23 @@ class TestMatrixDemandFlag(unittest.TestCase):
         self.assertTrue(any("pub fn is_scoped" in d for d in defs),
                         "is_scoped() definition missing from generated Rust")
 
+    def test_min_dist_prune_wiring(self):
+        # WAM_MIN_DIST_PRUNE=1 loads metric_min_dist_to_root and the kernel
+        # consults it (admissible A* prune). Verify the full wiring is emitted.
+        src = self._generate("cached")
+        self.assertIn('std::env::var("WAM_MIN_DIST_PRUNE")', src)
+        self.assertIn(".load_min_dist()", src)
+        self.assertIn(".set_min_dist(", src)
+        src_dir = Path(self.tmp.name) / "cached" / "src"
+        defs = [p.read_text() for p in src_dir.glob("*.rs")]
+        # kernel prune guard + the loader + the setter definitions
+        self.assertTrue(any("self.min_dist.is_empty()" in d for d in defs),
+                        "kernel min_dist prune guard missing")
+        self.assertTrue(any("pub fn load_min_dist" in d for d in defs),
+                        "load_min_dist() definition missing")
+        self.assertTrue(any("pub fn set_min_dist" in d for d in defs),
+                        "set_min_dist() definition missing")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
  ## Summary
  Wires the ingest-materialised metric_min_dist_to_root table into the matrix-bench
  category_ancestor kernel as an admissible A*-style prune: at depth c, a node with
  c + min_dist[n] > max_depth (or absent) can't reach root in budget, so the branch
  is cut. Opt-in via WAM_MIN_DIST_PRUNE=1; empty table = no-op (default), results
  unchanged.

  ## Measured (enwiki content scoped DB, root 7345184, WAM_DEMAND=off, 4 threads)
  | seeds | OFF | ON | speedup | tuple_count |
  |---|---|---|---|---|
  | 1000 (cold) | 1952ms | 1141ms | 1.7x | 794/794 |
  | 1000 (warm) | 1128ms | 974ms | 1.16x | 794/794 |
  node-DP supersedes the effective-distance *sum*; this prune only trims the
  traversal path. Default-off.

  ## Tests
  tests/test_wam_rust_matrix_demand_flag.py gains a prune-wiring codegen guard
  (WAM_MIN_DIST_PRUNE + load_min_dist/set_min_dist + kernel guard). swipl-only,
  CI-wired.