### PR TITLE
Dispatch WAM-C disjunction meta goals

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,15 +4,15 @@ Status date: 2026-06-06
 
 Latest branch verification:
 
-- `investigate/wam-c-meta-goal-composition` based on `main` at `1b022276`
-  (`Merge pull request #2862 from
-  s243a/investigate/wam-c-meta-aggregate-dispatch`)
+- `investigate/wam-c-meta-goal-disjunction` based on `main` at `db579a6f`
+  (`Merge pull request #2878 from
+  s243a/investigate/wam-c-meta-goal-composition`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-meta-goal-composition`
+- `investigate/wam-c-meta-goal-disjunction`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -89,6 +89,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Unbound-witness `bagof/3` and `setof/3` group enumeration | Done | C retains aggregate groups behind a backtrackable iterator, binds each witness/result group through a synthetic aggregate-group choicepoint, and covers outer `findall/3` consuming all grouped `bagof/3` and `setof/3` alternatives |
 | Runtime aggregate meta-call dispatch | Done | C dispatches non-inline runtime `findall/3`, `bagof/3`, and `setof/3` calls through meta aggregate frames, invokes simple callable goal terms, and covers non-inline `bagof/3` / `setof/3` executable smoke without `inline_bagof_setof(true)` |
 | Runtime conjunction goal-term dispatch | Done | C preserves `,/2` functors in WAM-to-C parsing, dispatches conjunction goal terms through a synthetic continuation frame, snapshots frame depth in choicepoints, and covers non-inline aggregate bodies with conjunction in `bagof/3` and `setof/3` |
+| Runtime disjunction goal-term dispatch | Done | C dispatches `;/2` goal terms by placing the right branch behind a synthetic choicepoint, snapshots disjunction-frame depth in choicepoints, and covers non-inline aggregate bodies with disjunction in `bagof/3` and `setof/3` |
 
 ## Current C Target Baseline
 
@@ -149,7 +150,7 @@ The C target is now a credible small WAM backend:
   existential `^/2` suppression plus unbound witness group enumeration inside
   inline `bagof/3` / `setof/3` bodies. It also has runtime meta-call dispatch
   for non-inline aggregate calls over simple callable goal terms and
-  conjunction goal terms.
+  conjunction/disjunction goal terms.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -172,7 +173,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Second-arg indexing | Partial | Partial/Done | Partial/Done | C has constant A2 dispatch; broaden tests if this becomes hot. |
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
 | Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
-| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness, caller-bound witness, existential `^/2`, and unbound witness group enumeration for inline `bagof/3` / `setof/3`; runtime meta-call aggregate dispatch now covers simple callable and conjunction goals, while disjunction and broader meta-goal forms remain gaps. |
+| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness, caller-bound witness, existential `^/2`, and unbound witness group enumeration for inline `bagof/3` / `setof/3`; runtime meta-call aggregate dispatch now covers simple callable, conjunction, and disjunction goals, while if-then-else and broader meta-goal forms remain gaps. |
 | Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, precise `get_level`/`cut` if-then-else, explicit `!/0` scoped to the current predicate call barrier, and generated `forall/2` soft-cut rewrites; residual work should be driven by concrete meta-control demand. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
@@ -186,6 +187,30 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-meta-goal-disjunction`
+
+Goal: extend C aggregate meta-call goal dispatch from conjunction to
+disjunction goal terms in aggregate bodies.
+
+Evidence:
+
+- The C runtime now has a small disjunction frame stack and synthetic
+  right-branch choicepoint target.
+- Choicepoint snapshots preserve disjunction-frame depth, and restore/prune
+  paths trim frames with the rest of runtime backtracking state.
+- Runtime `;/2` goal terms run all left-branch alternatives first, then resume
+  the right branch through normal WAM backtracking when the synthetic
+  choicepoint is selected.
+- The real-Prolog executable smoke compiles non-inline `bagof/3` and
+  `setof/3` bodies containing disjunction, verifies the generated WAM still
+  uses `execute bagof/3` / `execute setof/3`, and checks ordered bag output
+  plus sorted/deduplicated set output across both branches.
+
+Remaining gaps:
+
+- If-then-else goal terms and general `call/N` composition still need their
+  own runtime continuation machinery.
 
 ### Completed: `investigate/wam-c-meta-goal-composition`
 
@@ -210,8 +235,8 @@ Evidence:
 
 Remaining gaps:
 
-- Disjunction `;/2`, if-then-else goal terms, and general `call/N` composition
-  still need their own runtime continuation machinery.
+- If-then-else goal terms and general `call/N` composition still need their own
+  runtime continuation machinery.
 
 ### Completed: `investigate/wam-c-meta-aggregate-dispatch`
 
@@ -1239,9 +1264,9 @@ Evidence:
 The aggregate parity sequence now has inline no-witness, caller-bound witness,
 existential `^/2`, unbound witness group enumeration, runtime meta-call
 aggregate dispatch for simple callable goals, and conjunction goal-term
-dispatch inside meta aggregate bodies. The next aggregate feature worth
-considering is disjunction `;/2` in C goal-term dispatch, followed by
-if-then-else and `call/N` composition. Keep those separate because they change
+dispatch plus disjunction goal-term dispatch inside meta aggregate bodies. The
+next aggregate feature worth considering is if-then-else goal-term dispatch,
+followed by `call/N` composition. Keep those separate because they change
 general meta-call control flow, not just aggregate frame finalization.
 
 For the effective-distance/CSR line, result-capped and sampled runs already

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -30,6 +30,7 @@
 #define WAM_AGGREGATE_META_COLLECT -4
 #define WAM_AGGREGATE_META_DONE -5
 #define WAM_META_CONJ_RETURN -6
+#define WAM_META_DISJ_RIGHT -7
 
 typedef struct WamState WamState;
 typedef bool (*WamForeignHandler)(WamState *state, const char *pred, int arity);
@@ -67,6 +68,7 @@ typedef struct {
     int call_base_top;
     int aggregate_group_top;
     int conj_top;
+    int disj_top;
     int arity;
     WamValue a_regs[32]; // Reduced from MAX_REGS to save memory (typical max arity)
 } ChoicePoint;
@@ -126,6 +128,11 @@ typedef struct {
     WamValue second_goal;
     int return_pc;
 } WamConjFrame;
+
+typedef struct {
+    WamValue right_goal;
+    int return_pc;
+} WamDisjFrame;
 
 /* Environment Frame */
 typedef struct {
@@ -394,6 +401,8 @@ struct WamState {
     int aggregate_group_top;
     WamConjFrame conj_frames[WAM_META_GOAL_STACK_SIZE];
     int conj_top;
+    WamDisjFrame disj_frames[WAM_META_GOAL_STACK_SIZE];
+    int disj_top;
 
     /* Native category_ancestor kernel data */
     CategoryEdge *category_edges;
@@ -877,6 +886,14 @@ static inline void wam_trim_conj_frames(WamState *state, int target_top) {
     state->conj_top = target_top;
 }
 
+static inline void wam_trim_disj_frames(WamState *state, int target_top) {
+    if (target_top < 0) target_top = 0;
+    if (target_top > state->disj_top) {
+        target_top = state->disj_top;
+    }
+    state->disj_top = target_top;
+}
+
 static inline void push_choice_point(WamState *state, int next_pc, int arity) {
     if (state->B >= state->B_cap) {
         state->B_cap = state->B_cap ? state->B_cap * 2 : WAM_INITIAL_CAP;
@@ -891,6 +908,7 @@ static inline void push_choice_point(WamState *state, int next_pc, int arity) {
     cp->call_base_top = state->call_base_top;
     cp->aggregate_group_top = state->aggregate_group_top;
     cp->conj_top = state->conj_top;
+    cp->disj_top = state->disj_top;
     
     int save_arity = arity < 32 ? arity : 32;
     cp->arity = save_arity;
@@ -912,6 +930,7 @@ static inline void restore_choice_point(WamState *state, ChoicePoint *cp) {
     state->call_base_top = cp->call_base_top;
     wam_trim_aggregate_group_iters(state, cp->aggregate_group_top);
     wam_trim_conj_frames(state, cp->conj_top);
+    wam_trim_disj_frames(state, cp->disj_top);
     unwind_trail(state, cp->trail_size);
     memcpy(state->A, cp->a_regs, sizeof(WamValue) * cp->arity);
 }
@@ -928,15 +947,18 @@ static inline void pop_choice_point(WamState *state) {
 static inline void wam_prune_choice_points(WamState *state, int target_b) {
     int target_group_top = 0;
     int target_conj_top = 0;
+    int target_disj_top = 0;
     if (target_b > 0 && target_b <= state->B) {
         target_group_top = state->B_array[target_b - 1].aggregate_group_top;
         target_conj_top = state->B_array[target_b - 1].conj_top;
+        target_disj_top = state->B_array[target_b - 1].disj_top;
     }
     while (state->B > target_b) {
         pop_choice_point(state);
     }
     wam_trim_aggregate_group_iters(state, target_group_top);
     wam_trim_conj_frames(state, target_conj_top);
+    wam_trim_disj_frames(state, target_disj_top);
 }
 static inline void update_choice_point(WamState *state, int next_pc) {
     if (state->B > 0) {

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -2562,6 +2562,8 @@ compile_step_wam_to_c(_Options, CCode) :-
                         recovered = wam_bind_next_aggregate_group(state);
                     } else if (next_pc == WAM_AGGREGATE_META_DONE) {
                         recovered = wam_finalize_meta_aggregate(state);
+                    } else if (next_pc == WAM_META_DISJ_RIGHT) {
+                        recovered = wam_resume_disjunction(state);
                     } else {
                         state->P = next_pc; // Explicitly jump to alternative
                         recovered = true;
@@ -2593,6 +2595,7 @@ static bool wam_invoke_goal_as_call(WamState *state, WamValue goal,
 static bool wam_collect_meta_aggregate_success(WamState *state);
 static bool wam_finalize_meta_aggregate(WamState *state);
 static bool wam_continue_conjunction(WamState *state);
+static bool wam_resume_disjunction(WamState *state);
 
 static bool wam_ensure_heap_slots(WamState *state, int additional) {
     if (additional <= 0) return true;
@@ -2869,6 +2872,15 @@ static bool wam_invoke_goal_as_call(WamState *state, WamValue goal,
         return wam_invoke_goal_as_call(state, state->H_array[base + 1],
                                        WAM_META_CONJ_RETURN);
     }
+    if (strcmp(functor, ";/2") == 0 && arity == 2) {
+        if (state->disj_top >= WAM_META_GOAL_STACK_SIZE) return false;
+        WamDisjFrame *frame = &state->disj_frames[state->disj_top++];
+        frame->right_goal = state->H_array[base + 2];
+        frame->return_pc = return_pc;
+        push_choice_point(state, WAM_META_DISJ_RIGHT, 32);
+        return wam_invoke_goal_as_call(state, state->H_array[base + 1],
+                                       return_pc);
+    }
     if (strcmp(functor, "^/2") == 0 && arity == 2) {
         return wam_invoke_goal_as_call(state, state->H_array[base + 2],
                                        return_pc);
@@ -2906,6 +2918,16 @@ static bool wam_continue_conjunction(WamState *state) {
     WamConjFrame *frame = &state->conj_frames[state->conj_top - 1];
     return wam_invoke_goal_as_call(state, frame->second_goal,
                                    frame->return_pc);
+}
+
+static bool wam_resume_disjunction(WamState *state) {
+    if (state->disj_top <= 0 || state->B <= 0) return false;
+    WamDisjFrame *frame = &state->disj_frames[state->disj_top - 1];
+    WamValue right_goal = frame->right_goal;
+    int return_pc = frame->return_pc;
+    state->disj_top--;
+    pop_choice_point(state);
+    return wam_invoke_goal_as_call(state, right_goal, return_pc);
 }
 
 static bool wam_copy_term_to_stored(WamState *state,

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -3157,6 +3157,13 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
     assertz((user:wam_c_meta_conj_dup(b) :- true)),
     assertz((user:wam_c_meta_conj_set_keep(a) :- true)),
     assertz((user:wam_c_meta_conj_set_keep(b) :- true)),
+    assertz((user:wam_c_meta_disj_left(a) :- true)),
+    assertz((user:wam_c_meta_disj_left(b) :- true)),
+    assertz((user:wam_c_meta_disj_right(c) :- true)),
+    assertz((user:wam_c_meta_disj_set_left(b) :- true)),
+    assertz((user:wam_c_meta_disj_set_left(a) :- true)),
+    assertz((user:wam_c_meta_disj_set_right(b) :- true)),
+    assertz((user:wam_c_meta_disj_set_right(c) :- true)),
     assertz((user:wam_c_meta_bag(L) :-
         bagof(X, wam_c_meta_item(X), L))),
     assertz((user:wam_c_meta_set(L) :-
@@ -3171,6 +3178,14 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
         setof(X,
               (wam_c_meta_conj_dup(X), wam_c_meta_conj_set_keep(X)),
               L))),
+    assertz((user:wam_c_meta_disj_bag(L) :-
+        bagof(X,
+              (wam_c_meta_disj_left(X); wam_c_meta_disj_right(X)),
+              L))),
+    assertz((user:wam_c_meta_disj_set(L) :-
+        setof(X,
+              (wam_c_meta_disj_set_left(X); wam_c_meta_disj_set_right(X)),
+              L))),
     (   compile_predicate_to_wam(user:wam_c_meta_item/1, [], WamItem),
         compile_predicate_to_wam(user:wam_c_meta_dup/1, [], WamDup),
         compile_predicate_to_wam(user:wam_c_meta_none/1, [], WamNone),
@@ -3178,11 +3193,17 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
         compile_predicate_to_wam(user:wam_c_meta_conj_keep/1, [], WamConjKeep),
         compile_predicate_to_wam(user:wam_c_meta_conj_dup/1, [], WamConjDup),
         compile_predicate_to_wam(user:wam_c_meta_conj_set_keep/1, [], WamConjSetKeep),
+        compile_predicate_to_wam(user:wam_c_meta_disj_left/1, [], WamDisjLeft),
+        compile_predicate_to_wam(user:wam_c_meta_disj_right/1, [], WamDisjRight),
+        compile_predicate_to_wam(user:wam_c_meta_disj_set_left/1, [], WamDisjSetLeft),
+        compile_predicate_to_wam(user:wam_c_meta_disj_set_right/1, [], WamDisjSetRight),
         compile_predicate_to_wam(user:wam_c_meta_bag/1, [], WamBag),
         compile_predicate_to_wam(user:wam_c_meta_set/1, [], WamSet),
         compile_predicate_to_wam(user:wam_c_meta_empty_bag/1, [], WamEmptyBag),
         compile_predicate_to_wam(user:wam_c_meta_conj_bag/1, [], WamConjBag),
         compile_predicate_to_wam(user:wam_c_meta_conj_set/1, [], WamConjSet),
+        compile_predicate_to_wam(user:wam_c_meta_disj_bag/1, [], WamDisjBag),
+        compile_predicate_to_wam(user:wam_c_meta_disj_set/1, [], WamDisjSet),
         sub_string(WamBag, _, _, _, 'execute bagof/3'),
         \+ sub_string(WamBag, _, _, _, 'begin_aggregate bagof'),
         sub_string(WamSet, _, _, _, 'execute setof/3'),
@@ -3193,6 +3214,12 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
         sub_string(WamConjSet, _, _, _, 'put_structure ,/2'),
         sub_string(WamConjSet, _, _, _, 'execute setof/3'),
         \+ sub_string(WamConjSet, _, _, _, 'begin_aggregate setof'),
+        sub_string(WamDisjBag, _, _, _, 'put_structure ;/2'),
+        sub_string(WamDisjBag, _, _, _, 'execute bagof/3'),
+        \+ sub_string(WamDisjBag, _, _, _, 'begin_aggregate bagof'),
+        sub_string(WamDisjSet, _, _, _, 'put_structure ;/2'),
+        sub_string(WamDisjSet, _, _, _, 'execute setof/3'),
+        \+ sub_string(WamDisjSet, _, _, _, 'begin_aggregate setof'),
         compile_wam_predicate_to_c(user:wam_c_meta_item/1, WamItem, [], ItemCode),
         compile_wam_predicate_to_c(user:wam_c_meta_dup/1, WamDup, [], DupCode),
         compile_wam_predicate_to_c(user:wam_c_meta_none/1, WamNone, [], NoneCode),
@@ -3200,16 +3227,25 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
         compile_wam_predicate_to_c(user:wam_c_meta_conj_keep/1, WamConjKeep, [], ConjKeepCode),
         compile_wam_predicate_to_c(user:wam_c_meta_conj_dup/1, WamConjDup, [], ConjDupCode),
         compile_wam_predicate_to_c(user:wam_c_meta_conj_set_keep/1, WamConjSetKeep, [], ConjSetKeepCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_disj_left/1, WamDisjLeft, [], DisjLeftCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_disj_right/1, WamDisjRight, [], DisjRightCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_disj_set_left/1, WamDisjSetLeft, [], DisjSetLeftCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_disj_set_right/1, WamDisjSetRight, [], DisjSetRightCode),
         compile_wam_predicate_to_c(user:wam_c_meta_bag/1, WamBag, [], BagCode),
         compile_wam_predicate_to_c(user:wam_c_meta_set/1, WamSet, [], SetCode),
         compile_wam_predicate_to_c(user:wam_c_meta_empty_bag/1, WamEmptyBag, [], EmptyBagCode),
         compile_wam_predicate_to_c(user:wam_c_meta_conj_bag/1, WamConjBag, [], ConjBagCode),
         compile_wam_predicate_to_c(user:wam_c_meta_conj_set/1, WamConjSet, [], ConjSetCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_disj_bag/1, WamDisjBag, [], DisjBagCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_disj_set/1, WamDisjSet, [], DisjSetCode),
         atomic_list_concat([ItemCode, DupCode, NoneCode,
                             ConjItemCode, ConjKeepCode, ConjDupCode,
                             ConjSetKeepCode,
+                            DisjLeftCode, DisjRightCode,
+                            DisjSetLeftCode, DisjSetRightCode,
                             BagCode, SetCode, EmptyBagCode,
-                            ConjBagCode, ConjSetCode],
+                            ConjBagCode, ConjSetCode,
+                            DisjBagCode, DisjSetCode],
                            '\n\n',
                            PredCode),
         compile_wam_runtime_to_c([], RuntimeCode),
@@ -3240,11 +3276,17 @@ cleanup_wam_c_bagof_setof_meta_call_smoke :-
     retractall(user:wam_c_meta_conj_keep(_)),
     retractall(user:wam_c_meta_conj_dup(_)),
     retractall(user:wam_c_meta_conj_set_keep(_)),
+    retractall(user:wam_c_meta_disj_left(_)),
+    retractall(user:wam_c_meta_disj_right(_)),
+    retractall(user:wam_c_meta_disj_set_left(_)),
+    retractall(user:wam_c_meta_disj_set_right(_)),
     retractall(user:wam_c_meta_bag(_)),
     retractall(user:wam_c_meta_set(_)),
     retractall(user:wam_c_meta_empty_bag(_)),
     retractall(user:wam_c_meta_conj_bag(_)),
-    retractall(user:wam_c_meta_conj_set(_)).
+    retractall(user:wam_c_meta_conj_set(_)),
+    retractall(user:wam_c_meta_disj_bag(_)),
+    retractall(user:wam_c_meta_disj_set(_)).
 
 run_real_prolog_classic_recursive_executable_smoke :-
     assertz((user:wam_c_classic_fib(0, 0) :- true)),
@@ -6780,11 +6822,17 @@ void setup_wam_c_meta_conj_item_1(WamState* state);
 void setup_wam_c_meta_conj_keep_1(WamState* state);
 void setup_wam_c_meta_conj_dup_1(WamState* state);
 void setup_wam_c_meta_conj_set_keep_1(WamState* state);
+void setup_wam_c_meta_disj_left_1(WamState* state);
+void setup_wam_c_meta_disj_right_1(WamState* state);
+void setup_wam_c_meta_disj_set_left_1(WamState* state);
+void setup_wam_c_meta_disj_set_right_1(WamState* state);
 void setup_wam_c_meta_bag_1(WamState* state);
 void setup_wam_c_meta_set_1(WamState* state);
 void setup_wam_c_meta_empty_bag_1(WamState* state);
 void setup_wam_c_meta_conj_bag_1(WamState* state);
 void setup_wam_c_meta_conj_set_1(WamState* state);
+void setup_wam_c_meta_disj_bag_1(WamState* state);
+void setup_wam_c_meta_disj_set_1(WamState* state);
 
 static bool wam_c_meta_expect_atom_list2(WamState *state, WamValue value,
                                          const char *first,
@@ -6805,6 +6853,31 @@ static bool wam_c_meta_expect_atom_list2(WamState *state, WamValue value,
            strcmp(tail2->data.atom, "[]") == 0;
 }
 
+static bool wam_c_meta_expect_atom_list3(WamState *state, WamValue value,
+                                         const char *first,
+                                         const char *second,
+                                         const char *third) {
+    WamValue *cell = wam_deref_ptr(state, &value);
+    if (cell->tag != VAL_LIST) return false;
+    int first_addr = cell->data.ref_addr;
+    WamValue *head1 = wam_deref_ptr(state, &state->H_array[first_addr]);
+    WamValue *tail1 = wam_deref_ptr(state, &state->H_array[first_addr + 1]);
+    if (head1->tag != VAL_ATOM || strcmp(head1->data.atom, first) != 0) return false;
+    if (tail1->tag != VAL_LIST) return false;
+    int second_addr = tail1->data.ref_addr;
+    WamValue *head2 = wam_deref_ptr(state, &state->H_array[second_addr]);
+    WamValue *tail2 = wam_deref_ptr(state, &state->H_array[second_addr + 1]);
+    if (head2->tag != VAL_ATOM || strcmp(head2->data.atom, second) != 0) return false;
+    if (tail2->tag != VAL_LIST) return false;
+    int third_addr = tail2->data.ref_addr;
+    WamValue *head3 = wam_deref_ptr(state, &state->H_array[third_addr]);
+    WamValue *tail3 = wam_deref_ptr(state, &state->H_array[third_addr + 1]);
+    return head3->tag == VAL_ATOM &&
+           strcmp(head3->data.atom, third) == 0 &&
+           tail3->tag == VAL_ATOM &&
+           strcmp(tail3->data.atom, "[]") == 0;
+}
+
 int main(void) {
     WamState state;
     wam_state_init(&state);
@@ -6815,18 +6888,25 @@ int main(void) {
     setup_wam_c_meta_conj_keep_1(&state);
     setup_wam_c_meta_conj_dup_1(&state);
     setup_wam_c_meta_conj_set_keep_1(&state);
+    setup_wam_c_meta_disj_left_1(&state);
+    setup_wam_c_meta_disj_right_1(&state);
+    setup_wam_c_meta_disj_set_left_1(&state);
+    setup_wam_c_meta_disj_set_right_1(&state);
     setup_wam_c_meta_bag_1(&state);
     setup_wam_c_meta_set_1(&state);
     setup_wam_c_meta_empty_bag_1(&state);
     setup_wam_c_meta_conj_bag_1(&state);
     setup_wam_c_meta_conj_set_1(&state);
+    setup_wam_c_meta_disj_bag_1(&state);
+    setup_wam_c_meta_disj_set_1(&state);
 
     WamValue bag_args[1] = { val_unbound("Bag") };
     int bag_rc = wam_run_predicate(&state, "wam_c_meta_bag/1", bag_args, 1);
     if (bag_rc != 0 || state.P != WAM_HALT ||
         !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "b") ||
         state.B != 0 || state.call_base_top != 0 ||
-        state.aggregate_top != 0 || state.aggregate_group_top != 0) {
+        state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
+        state.conj_top != 0 || state.disj_top != 0) {
         wam_free_state(&state);
         return 10;
     }
@@ -6836,7 +6916,8 @@ int main(void) {
     if (set_rc != 0 || state.P != WAM_HALT ||
         !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "b") ||
         state.B != 0 || state.call_base_top != 0 ||
-        state.aggregate_top != 0 || state.aggregate_group_top != 0) {
+        state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
+        state.conj_top != 0 || state.disj_top != 0) {
         wam_free_state(&state);
         return 20;
     }
@@ -6846,7 +6927,8 @@ int main(void) {
                                      empty_args, 1);
     if (empty_rc != WAM_HALT ||
         state.B != 0 || state.call_base_top != 0 ||
-        state.aggregate_top != 0 || state.aggregate_group_top != 0) {
+        state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
+        state.conj_top != 0 || state.disj_top != 0) {
         wam_free_state(&state);
         return 30;
     }
@@ -6858,7 +6940,7 @@ int main(void) {
         !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "c") ||
         state.B != 0 || state.call_base_top != 0 ||
         state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
-        state.conj_top != 0) {
+        state.conj_top != 0 || state.disj_top != 0) {
         wam_free_state(&state);
         return 40;
     }
@@ -6870,9 +6952,33 @@ int main(void) {
         !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "b") ||
         state.B != 0 || state.call_base_top != 0 ||
         state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
-        state.conj_top != 0) {
+        state.conj_top != 0 || state.disj_top != 0) {
         wam_free_state(&state);
         return 50;
+    }
+
+    WamValue disj_bag_args[1] = { val_unbound("DisjBag") };
+    int disj_bag_rc = wam_run_predicate(&state, "wam_c_meta_disj_bag/1",
+                                        disj_bag_args, 1);
+    if (disj_bag_rc != 0 || state.P != WAM_HALT ||
+        !wam_c_meta_expect_atom_list3(&state, state.A[0], "a", "b", "c") ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
+        state.conj_top != 0 || state.disj_top != 0) {
+        wam_free_state(&state);
+        return 60;
+    }
+
+    WamValue disj_set_args[1] = { val_unbound("DisjSet") };
+    int disj_set_rc = wam_run_predicate(&state, "wam_c_meta_disj_set/1",
+                                        disj_set_args, 1);
+    if (disj_set_rc != 0 || state.P != WAM_HALT ||
+        !wam_c_meta_expect_atom_list3(&state, state.A[0], "a", "b", "c") ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
+        state.conj_top != 0 || state.disj_top != 0) {
+        wam_free_state(&state);
+        return 70;
     }
 
     wam_free_state(&state);


### PR DESCRIPTION
  ## Summary

  - Add C WAM runtime support for `;/2` disjunction goal terms in meta-call aggregate bodies.
  - Resume the right branch through a synthetic choicepoint after left-branch alternatives are exhausted.
  - Extend non-inline `bagof/3` and `setof/3` executable smoke coverage for disjunction goal bodies.
  - Update the WAM-C next-steps doc; remaining meta-goal gaps are if-then-else and `call/N`.

  ## Verification

  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `git diff --check HEAD~1..HEAD`