### PR TITLE
feat(RES): Phase 4 — pure-functional trace renderers

### DIFF
--- a/src/unifyweaver/core/recurrence_evaluation_strategy.pl
+++ b/src/unifyweaver/core/recurrence_evaluation_strategy.pl
@@ -10,14 +10,14 @@
 % return the strategy the target should use to emit code, plus a
 % structured reasoning trace.
 %
-% Phase status: Phases 0-3 landed. classify_signals/4,
-% apply_cost_model/3, admissible_strategies/2, and
-% resolve_against_intent/5 are real. Only the trace renderers
-% (render_trace_for_stderr/2, format_trace_for_comment/3) remain
-% as Phase 4 stubs. The Phase 0 step(stub, ...) marker has been
-% REMOVED from the trace as of Phase 3 — the stub-leak detector
-% in Phase 5's tests now asserts on trace structure directly
-% (no step has name='stub'), not on the presence of the marker.
+% Phase status: Phases 0-4 landed. The selector is now functionally
+% complete from the user/library perspective: classify_signals/4,
+% apply_cost_model/3, admissible_strategies/2, resolve_against_intent/5,
+% render_trace_for_stderr/2, and format_trace_for_comment/3 are all
+% real. Only the F# WAM target integration (Phase 5) and book-18
+% chapter updates (Phase 7) remain. The selector module itself is
+% pure-functional — it returns structured trace; target adapters
+% decide whether and how to render and emit.
 %
 % This baseline lets the F# WAM target integration (Phase 5) call
 % against the module from day one, and lets the stub-leak assertion
@@ -766,16 +766,157 @@ recurrence_monotone(recurrence(_KernelKind, _Pred, Properties), Value) :-
 
 %% render_trace_for_stderr(+Trace, -Lines)
 %
-% Phase 0 stub: returns an empty list (no rendering).
-% Phase 4 implements the real renderer.
-render_trace_for_stderr(_Trace, []).
+% Phase 4: renders the structured trace as a list of strings, one
+% per trace step (plus an envelope line). Target adapters write
+% these to stderr (or anywhere); the selector itself does not.
+%
+% Output format per SPEC examples:
+%   [evaluation-strategy] selecting strategy
+%   [evaluation-strategy]   <step-name>: <outcome-summary>
+%   [evaluation-strategy]   <step-name>: <outcome-summary>
+%   ...
+render_trace_for_stderr(trace(Steps), Lines) :-
+    Header = "[evaluation-strategy] selecting strategy",
+    maplist(render_step_for_stderr, Steps, StepLines),
+    Lines = [Header | StepLines].
+
+%% render_step_for_stderr(+Step, -Line)
+%
+% Render one trace step as a single indented line. The step's
+% outcome dictates the detail wording.
+render_step_for_stderr(step(Name, Outcome, Details), Line) :-
+    format(string(NameStr), "~w", [Name]),
+    render_outcome_summary(Outcome, OutcomeStr),
+    render_details_summary(Details, DetailsStr),
+    (   DetailsStr == ""
+    ->  format(string(Line),
+               "[evaluation-strategy]   ~w: ~w", [NameStr, OutcomeStr])
+    ;   format(string(Line),
+               "[evaluation-strategy]   ~w: ~w (~w)",
+               [NameStr, OutcomeStr, DetailsStr])
+    ).
+
+%% render_outcome_summary(+Outcome, -String)
+render_outcome_summary(applied,                String) :- !,
+    String = "applied".
+render_outcome_summary(passed,                 String) :- !,
+    String = "passed".
+render_outcome_summary(not_found,              String) :- !,
+    String = "not_found".
+render_outcome_summary(no_scope_overlap,       String) :- !,
+    String = "no_scope_overlap".
+render_outcome_summary(adjusted,               String) :- !,
+    String = "adjusted".
+render_outcome_summary(satisfiable,            String) :- !,
+    String = "satisfiable".
+render_outcome_summary(classified(I, D, F),    String) :- !,
+    length(I, IL), length(D, DL), length(F, FL),
+    format(string(String),
+           "classified intent=~w declared=~w inferred=~w", [IL, DL, FL]).
+render_outcome_summary(chosen(Strategy, Score, Rule), String) :- !,
+    strategy_pretty(Strategy, StrategyStr),
+    format(string(String),
+           "chosen ~w score=~3f rule=~w", [StrategyStr, Score, Rule]).
+render_outcome_summary(found(Strategy),        String) :- !,
+    strategy_pretty(Strategy, StrategyStr),
+    format(string(String), "found ~w", [StrategyStr]).
+render_outcome_summary(resolved(Strategy, by(Reason)), String) :- !,
+    strategy_pretty(Strategy, StrategyStr),
+    format(string(String),
+           "resolved ~w by ~w", [StrategyStr, Reason]).
+render_outcome_summary(degraded(Action),       String) :- !,
+    format(string(String), "degraded ~w", [Action]).
+render_outcome_summary(Other,                  String) :-
+    format(string(String), "~w", [Other]).
+
+%% render_details_summary(+Details, -String)
+%
+% Render the Details list as a concise comma-separated string.
+% Empty list renders as empty string (caller checks).
+render_details_summary([], "") :- !.
+render_details_summary(Details, String) :-
+    maplist(detail_to_string, Details, DetailStrs),
+    atomics_to_string(DetailStrs, ", ", String).
+
+%% detail_to_string(+Detail, -String)
+detail_to_string(adjustment(Action), String) :- !,
+    format(string(String), "adjustment=~w", [Action]).
+detail_to_string(unknown_signal(S), String) :- !,
+    format(string(String), "unknown_signal=~w", [S]).
+detail_to_string(reason(R), String) :- !,
+    format(string(String), "reason=~w", [R]).
+detail_to_string(Other, String) :-
+    format(string(String), "~w", [Other]).
 
 %% format_trace_for_comment(+Trace, +CommentPrefix, -CommentString)
 %
-% Phase 0 stub: returns an empty string.
-% Phase 4 implements the real comment renderer with per-line
-% CommentPrefix application.
-format_trace_for_comment(_Trace, _CommentPrefix, "").
+% Phase 4: renders the trace as a multi-line comment block with
+% the CommentPrefix applied to EVERY line (not just the first).
+% Critical for line-level comment syntaxes (Prolog %, Python #).
+%
+% Output structure:
+%   <prefix>===================================
+%   <prefix>Evaluation strategy: <chosen strategy>
+%   <prefix>Decided by: <final-decision-line>
+%   <prefix>Trace:
+%   <prefix>  - step-name: outcome-summary
+%   <prefix>  - step-name: outcome-summary
+%   <prefix>  ...
+%   <prefix>===================================
+format_trace_for_comment(trace(Steps), CommentPrefix, CommentString) :-
+    must_be(string, CommentPrefix),
+    %% Find the final-decision step for the header.
+    (   member(step(final_decision, FinalOutcome, FinalDetails), Steps)
+    ->  render_final_decision_lines(FinalOutcome, FinalDetails, HeaderLines)
+    ;   %% No final_decision step (e.g. resolved at an early step).
+        %% Use the last step's outcome as the chosen strategy.
+        last_resolved_step(Steps, LastStep),
+        render_last_step_as_header(LastStep, HeaderLines)
+    ),
+    %% Render each step as a trace line.
+    maplist(render_step_for_comment, Steps, StepLines),
+    %% Assemble: separator, header, "Trace:", step lines, separator.
+    Sep = "========================================================================",
+    append([
+        [Sep],
+        HeaderLines,
+        ["Trace:"],
+        StepLines,
+        [Sep]
+    ], AllLines),
+    %% Prepend CommentPrefix to EVERY line.
+    maplist(prefix_line(CommentPrefix), AllLines, PrefixedLines),
+    atomics_to_string(PrefixedLines, "\n", CommentString).
+
+prefix_line(Prefix, Line, PrefixedLine) :-
+    string_concat(Prefix, Line, PrefixedLine).
+
+render_final_decision_lines(Strategy, Details, Lines) :-
+    strategy_pretty(Strategy, StrategyStr),
+    Line1Str = StrategyStr,
+    format(string(Line1), "Evaluation strategy: ~w", [Line1Str]),
+    (   member(decided_by(By), Details)
+    ->  format(string(Line2), "Decided by: ~w", [By])
+    ;   Line2 = "Decided by: (unspecified)"
+    ),
+    Lines = [Line1, Line2].
+
+last_resolved_step(Steps, LastStep) :-
+    reverse(Steps, [LastStep | _]).
+
+render_last_step_as_header(step(Name, Outcome, _Details), Lines) :-
+    render_outcome_summary(Outcome, OutcomeStr),
+    format(string(Line1), "Evaluation strategy: resolved at ~w", [Name]),
+    format(string(Line2), "Outcome: ~w", [OutcomeStr]),
+    Lines = [Line1, Line2].
+
+render_step_for_comment(step(Name, Outcome, Details), Line) :-
+    render_outcome_summary(Outcome, OutcomeStr),
+    render_details_summary(Details, DetailsStr),
+    (   DetailsStr == ""
+    ->  format(string(Line), "  - ~w: ~w", [Name, OutcomeStr])
+    ;   format(string(Line), "  - ~w: ~w (~w)", [Name, OutcomeStr, DetailsStr])
+    ).
 
 %% admissible_strategies(+Recurrence, -StrategyList)
 %
@@ -932,10 +1073,12 @@ rule_adjustments(_, []) :- !.
 
 %% strategy_pretty(+Strategy, -String)
 %
-% Phase 0 stub: returns the strategy term rendered with format_to_atom.
-% Phase 4 implements the pretty-printer alongside the renderers.
-strategy_pretty(Strategy, String) :-
-    format(string(String), "~w", [Strategy]).
+% Phase 4: renders a strategy term in a compact human-readable form
+% — `per_query(bidirectional)` rather than `strategy(per_query(bidirectional))`.
+strategy_pretty(strategy(Mode), String) :- !,
+    format(string(String), "~w", [Mode]).
+strategy_pretty(Other, String) :-
+    format(string(String), "~w", [Other]).
 
 %% ============================================================
 %% Type-check helpers

--- a/tests/core/test_res_trace.pl
+++ b/tests/core/test_res_trace.pl
@@ -1,0 +1,325 @@
+:- encoding(utf8).
+%% Phase 4 test suite for the trace renderers:
+%%   render_trace_for_stderr/2 + format_trace_for_comment/3 +
+%%   strategy_pretty/2.
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_res_trace.pl
+
+:- use_module('../../src/unifyweaver/core/recurrence_evaluation_strategy').
+:- use_module(library(lists)).
+:- use_module(library(filesex), [directory_file_path/3]).
+:- use_module(library(process), [process_create/3, process_wait/2]).
+
+%% ========================================================================
+%% Test runner
+%% ========================================================================
+
+run_tests :-
+    format("~n========================================~n"),
+    format("RES Phase 4 Trace-Renderer Tests~n"),
+    format("========================================~n~n"),
+    findall(Test, test(Test), Tests),
+    length(Tests, Total),
+    run_all(Tests, 0, Passed),
+    format("~n========================================~n"),
+    (   Passed =:= Total
+    ->  format("All ~w tests passed~n", [Total])
+    ;   Failed is Total - Passed,
+        format("~w of ~w tests FAILED~n", [Failed, Total]),
+        format("Tests FAILED~n"),
+        halt(1)
+    ),
+    format("========================================~n").
+
+run_all([], Passed, Passed).
+run_all([Test|Rest], Acc, Passed) :-
+    (   catch(call(Test), Error,
+            (format("[FAIL] ~w: ~w~n", [Test, Error]), fail))
+    ->  format("[PASS] ~w~n", [Test]),
+        Acc1 is Acc + 1,
+        run_all(Rest, Acc1, Passed)
+    ;   run_all(Rest, Acc, Passed)
+    ).
+
+%% ========================================================================
+%% Test declarations
+%% ========================================================================
+
+%% strategy_pretty
+test(test_strategy_pretty_per_query).
+test(test_strategy_pretty_fixed_point).
+test(test_strategy_pretty_cached).
+
+%% render_trace_for_stderr
+test(test_render_stderr_returns_list).
+test(test_render_stderr_envelope_header).
+test(test_render_stderr_each_step_one_line).
+test(test_render_stderr_step_indented).
+test(test_render_stderr_empty_trace).
+test(test_render_stderr_classify_step).
+test(test_render_stderr_cost_model_step).
+test(test_render_stderr_no_intent_resolved).
+
+%% format_trace_for_comment
+test(test_format_comment_returns_string).
+test(test_format_comment_includes_header).
+test(test_format_comment_includes_trace_section).
+test(test_format_comment_prefix_on_every_line).
+test(test_format_comment_throws_on_non_string_prefix).
+
+%% Comment-prefix validation per language
+test(test_format_comment_fsharp_prefix).
+test(test_format_comment_haskell_prefix).
+test(test_format_comment_prolog_prefix).
+test(test_format_comment_python_prefix).
+
+%% Per-language delimiter pattern-match assertions (forward-compat
+%% safety checks)
+test(test_no_c_block_close_in_rendered).
+test(test_no_haskell_block_delimiters).
+test(test_no_fsharp_xml_doc_trigger).
+test(test_no_python_shebang_at_line_start).
+
+%% CRITICAL: Prolog round-trip parse test
+test(test_prolog_comment_round_trip_parses).
+
+%% Integration: end-to-end render from select_evaluation_strategy/3
+test(test_full_pipeline_render_stderr).
+test(test_full_pipeline_format_comment).
+
+%% ========================================================================
+%% Test fixtures
+%% ========================================================================
+
+a_recurrence(recurrence(transitive_closure2, my_pred/2,
+    [value_domain(combinatorial), monotone(true)])).
+
+a_full_trace(Trace) :-
+    a_recurrence(R),
+    select_evaluation_strategy(R,
+        [csr_available(true), query_pattern(single_pair), cardinality(large),
+         kernel_mode(bidirectional)],
+        strategy_choice(_Strategy, Trace)).
+
+%% ========================================================================
+%% strategy_pretty
+%% ========================================================================
+
+test_strategy_pretty_per_query :-
+    strategy_pretty(strategy(per_query(bidirectional)), S),
+    S == "per_query(bidirectional)".
+
+test_strategy_pretty_fixed_point :-
+    strategy_pretty(strategy(fixed_point(semi_naive)), S),
+    S == "fixed_point(semi_naive)".
+
+test_strategy_pretty_cached :-
+    strategy_pretty(strategy(cached), S),
+    S == "cached".
+
+%% ========================================================================
+%% render_trace_for_stderr
+%% ========================================================================
+
+test_render_stderr_returns_list :-
+    a_full_trace(T),
+    render_trace_for_stderr(T, Lines),
+    is_list(Lines),
+    Lines \== [].
+
+test_render_stderr_envelope_header :-
+    a_full_trace(T),
+    render_trace_for_stderr(T, [Header | _]),
+    string_concat("[evaluation-strategy] selecting strategy", _, Header).
+
+test_render_stderr_each_step_one_line :-
+    a_full_trace(T),
+    T = trace(Steps),
+    length(Steps, NSteps),
+    render_trace_for_stderr(T, Lines),
+    length(Lines, NLines),
+    %% header + one line per step
+    NLines =:= NSteps + 1.
+
+test_render_stderr_step_indented :-
+    a_full_trace(T),
+    render_trace_for_stderr(T, [_Header | StepLines]),
+    %% Every step line should start with the indented prefix
+    forall(member(L, StepLines),
+           sub_string(L, 0, _, _, "[evaluation-strategy]   ")).
+
+test_render_stderr_empty_trace :-
+    render_trace_for_stderr(trace([]), Lines),
+    %% Just the header
+    Lines = ["[evaluation-strategy] selecting strategy"].
+
+test_render_stderr_classify_step :-
+    a_full_trace(T),
+    render_trace_for_stderr(T, Lines),
+    member(L, Lines),
+    sub_string(L, _, _, _, "classify_signals"), !.
+
+test_render_stderr_cost_model_step :-
+    a_full_trace(T),
+    render_trace_for_stderr(T, Lines),
+    member(L, Lines),
+    sub_string(L, _, _, _, "cost_model_choice"),
+    sub_string(L, _, _, _, "per_query(bidirectional)"),
+    sub_string(L, _, _, _, "score=3.000"), !.
+
+test_render_stderr_no_intent_resolved :-
+    a_recurrence(R),
+    select_evaluation_strategy(R, [], strategy_choice(_, T)),
+    render_trace_for_stderr(T, Lines),
+    member(L, Lines),
+    sub_string(L, _, _, _, "no_intent: applied"), !.
+
+%% ========================================================================
+%% format_trace_for_comment
+%% ========================================================================
+
+test_format_comment_returns_string :-
+    a_full_trace(T),
+    format_trace_for_comment(T, "// ", C),
+    string(C),
+    string_length(C, L),
+    L > 0.
+
+test_format_comment_includes_header :-
+    a_full_trace(T),
+    format_trace_for_comment(T, "// ", C),
+    sub_string(C, _, _, _, "Evaluation strategy:").
+
+test_format_comment_includes_trace_section :-
+    a_full_trace(T),
+    format_trace_for_comment(T, "// ", C),
+    sub_string(C, _, _, _, "Trace:").
+
+%% Critical: every line begins with the prefix, not just the first.
+test_format_comment_prefix_on_every_line :-
+    a_full_trace(T),
+    format_trace_for_comment(T, "// ", C),
+    split_string(C, "\n", "", Lines),
+    forall(member(L, Lines),
+           string_concat("// ", _, L)).
+
+test_format_comment_throws_on_non_string_prefix :-
+    a_full_trace(T),
+    catch(format_trace_for_comment(T, not_a_string, _),
+          error(type_error(string, _), _),
+          true).
+
+%% ========================================================================
+%% Comment-prefix validation per language
+%% ========================================================================
+
+test_format_comment_fsharp_prefix :-
+    a_full_trace(T),
+    format_trace_for_comment(T, "// ", C),
+    split_string(C, "\n", "", Lines),
+    forall(member(L, Lines), string_concat("// ", _, L)).
+
+test_format_comment_haskell_prefix :-
+    a_full_trace(T),
+    format_trace_for_comment(T, "-- ", C),
+    split_string(C, "\n", "", Lines),
+    forall(member(L, Lines), string_concat("-- ", _, L)).
+
+test_format_comment_prolog_prefix :-
+    a_full_trace(T),
+    format_trace_for_comment(T, "% ", C),
+    split_string(C, "\n", "", Lines),
+    forall(member(L, Lines), string_concat("% ", _, L)).
+
+test_format_comment_python_prefix :-
+    a_full_trace(T),
+    format_trace_for_comment(T, "# ", C),
+    split_string(C, "\n", "", Lines),
+    forall(member(L, Lines), string_concat("# ", _, L)).
+
+%% ========================================================================
+%% Per-language delimiter pattern-match assertions
+%%
+%% These check that the rendered string contains no substring that
+%% would break out of the target language's comment context.
+%% ========================================================================
+
+test_no_c_block_close_in_rendered :-
+    a_full_trace(T),
+    format_trace_for_comment(T, "// ", C),
+    \+ sub_string(C, _, _, _, "*/").
+
+test_no_haskell_block_delimiters :-
+    a_full_trace(T),
+    format_trace_for_comment(T, "-- ", C),
+    \+ sub_string(C, _, _, _, "{-"),
+    \+ sub_string(C, _, _, _, "-}").
+
+test_no_fsharp_xml_doc_trigger :-
+    a_full_trace(T),
+    format_trace_for_comment(T, "// ", C),
+    %% A line starting with "/// " (XML doc comment) would be triggered
+    %% if any rendered line started with "// /" — check no occurrence.
+    \+ sub_string(C, _, _, _, "// /").
+
+test_no_python_shebang_at_line_start :-
+    a_full_trace(T),
+    format_trace_for_comment(T, "# ", C),
+    split_string(C, "\n", "", Lines),
+    forall(member(L, Lines),
+           \+ string_concat("#!", _, L)).
+
+%% ========================================================================
+%% CRITICAL: Prolog round-trip parse test
+%%
+%% Write the rendered Prolog comment + a minimal clause body to a
+%% .pl file, invoke swipl --halt, assert exit 0.
+%% Catches the failure mode where % is missing on a non-first line.
+%% ========================================================================
+
+test_prolog_comment_round_trip_parses :-
+    a_full_trace(T),
+    format_trace_for_comment(T, "% ", Comment),
+    %% Write to a temp file: comment header + a trivial clause body.
+    TempFile = '/tmp/test_res_trace_round_trip.pl',
+    setup_call_cleanup(
+        open(TempFile, write, Stream),
+        ( format(Stream, "~w~n", [Comment]),
+          format(Stream, "test_compiled :- true.~n", [])
+        ),
+        close(Stream)
+    ),
+    %% Invoke swipl with -t halt; assert exit 0.
+    process_create(path(swipl),
+                   ['-g', 'test_compiled', '-t', 'halt', '-s', TempFile],
+                   [process(PID)]),
+    process_wait(PID, exit(ExitCode)),
+    ExitCode =:= 0,
+    %% Clean up
+    delete_file(TempFile).
+
+%% ========================================================================
+%% Integration
+%% ========================================================================
+
+test_full_pipeline_render_stderr :-
+    a_recurrence(R),
+    select_evaluation_strategy(R,
+        [csr_available(true), query_pattern(single_pair), cardinality(large),
+         kernel_mode(bidirectional)],
+        strategy_choice(_Strategy, Trace)),
+    render_trace_for_stderr(Trace, Lines),
+    is_list(Lines),
+    length(Lines, NLines),
+    NLines >= 2.
+
+test_full_pipeline_format_comment :-
+    a_recurrence(R),
+    select_evaluation_strategy(R,
+        [csr_available(true), query_pattern(single_pair), cardinality(large),
+         kernel_mode(bidirectional)],
+        strategy_choice(_Strategy, Trace)),
+    format_trace_for_comment(Trace, "// ", Comment),
+    string_length(Comment, L),
+    L > 100.  % non-trivial output


### PR DESCRIPTION
  ## Summary

  Implements **Phase 4** of the recurrence-evaluation-strategy implementation plan. Replaces the Phase 0 stubs for `render_trace_for_stderr/2`, `format_trace_for_comment/3`, and `strategy_pretty/2` with real implementations.

  The selector module remains **pure-functional** — renderers return strings/lists; target adapters decide whether and where to emit them.

  This is the fifth of seven phases. Builds on Phases 0–3. Only Phase 5 (F# WAM target integration) and Phase 7 (book-18 chapter updates) remain.

  ## What this PR delivers

  ### `strategy_pretty/2`

  Compact rendering: `per_query(bidirectional)` rather than `strategy(per_query(bidirectional))`. Used by both renderers.

  ### `render_trace_for_stderr/2`

  Returns a list of strings:
  - One envelope header line: `[evaluation-strategy] selecting strategy`
  - One indented line per trace step: `[evaluation-strategy]   <step-name>: <outcome>` (optionally `(detail-summary)` if  Details are present)

  Helpers `render_outcome_summary/2` and `render_details_summary/2` produce step-specific summaries (classified counts;  chosen strategy + score + rule; found strategy; resolved by reason; etc.).

  ### `format_trace_for_comment/3`

  Returns a multi-line comment string with the `+CommentPrefix` applied to **every line**, not just the first — critical for line-level Prolog `%` and Python `#` comment syntaxes.

  Structure:

  =================================================
  Evaluation strategy: per_query(bidirectional)
  Decided by: intent_matches
  Trace:
    - classify_signals: classified intent=1 declared=3 inferred=0
    - cost_model_choice: chosen per_query(bidirectional) score=3.000 rule=prefer_bidirectional_csr_present
    - no_intent: passed (intent_signals_present)
    - intent_matches: applied (matched_intents([kernel_mode(bidirectional)]))
  =================================================

  Throws `type_error(string, _)` on non-string `CommentPrefix`.

  ## Test plan

  `tests/core/test_res_trace.pl` — **27 new tests, all pass**:

  - **`strategy_pretty`** (3 tests): per_query, fixed_point, cached
  - **`render_trace_for_stderr`** (8 tests): list-shape, envelope header, one line per step, indentation, empty trace,
  classify/cost_model/no_intent step rendering
  - **`format_trace_for_comment`** (5 tests): string return, header present, trace section present, prefix on every
  line, type-error on non-string prefix
  - **Per-language comment-prefix validation** (4 tests): F# `// `, Haskell `-- `, Prolog `% `, Python `# ` — every line
  begins with prefix
  - **Per-language delimiter pattern-match** (4 tests): no `*/` C-block close; no `{-` or `-}` Haskell block; no `// /`
  F# XML doc trigger; no `#!` Python shebang at line start
  - **CRITICAL: Prolog round-trip parse test**: writes rendered `% `-prefixed comment + minimal `test_compiled :- true.`
  clause to a tempfile, invokes `swipl -g test_compiled -t halt -s <file>`, asserts exit 0. Catches the
  missing-prefix-on-continuation-line failure mode that the SPEC explicitly flagged.
  - **Integration** (2 tests): full pipeline render_stderr + full pipeline format_comment

  Prior phases all still pass: 12 + 29 + 34 + 32 = **107 prior + 27 new = 134 total tests passing.**

  ## What's NOT in this PR

  - **Phase 5**: F# WAM target integration. The renderers are now ready for the target adapter to call them.
  - **Phase 6**: Comprehensive integration tests beyond the per-phase tests (each phase has its own integration tests
  via `select_evaluation_strategy/3`; Phase 6 is the backfill + the `monotone(false)` full-pipeline scenario from the implementation plan).
  - **Phase 7**: Book-18 chapter updates.

  ## Effort

  ~2 hours per the implementation plan estimate.

  ## Files

  src/unifyweaver/core/recurrence_evaluation_strategy.pl   (+181 -19)
  tests/core/test_res_trace.pl                              (NEW, 325 lines, 27 tests)