### PR TITLE
LLVM WAM: ground/1 (M117) -- term has no unbound vars

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3658,6 +3658,7 @@ entry:
     i32 129, label %builtin_kill
     i32 130, label %builtin_truncate
     i32 131, label %builtin_chown
+    i32 132, label %builtin_ground
   ]
 
 builtin_is:
@@ -5881,6 +5882,15 @@ co.do:
   %co.ret = call i32 @chown(i8* %co.path, i32 %co.uid, i32 %co.gid)
   %co.ok = icmp eq i32 %co.ret, 0
   ret i1 %co.ok
+
+builtin_ground:
+  ; M117: ground(+Term) -- succeeds iff Term has no unbound
+  ; variables. Walks Term depth-first; atoms, ints, floats and
+  ; bound refs are ground; any unbound ref fails. Compounds
+  ; recurse over their args. wam_is_ground does the work.
+  %gr.t = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %gr.r = call i1 @wam_is_ground(%WamState* %vm, %Value %gr.t)
+  ret i1 %gr.r
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -11860,6 +11870,53 @@ tv.ret_acc:
   ret %Value %acc
 }
 
+; M117: recursive ground check. Returns true iff %term contains no
+; unbound variables. Atomic (atom/int/float) -> true; unbound -> false;
+; compound -> recurse over each arg, false if any arg is non-ground.
+define i1 @wam_is_ground(%WamState* %vm, %Value %term) {
+entry:
+  %ig.t = call %Value @wam_deref_value(%WamState* %vm, %Value %term)
+  %ig.tag = call i32 @value_tag(%Value %ig.t)
+  switch i32 %ig.tag, label %ig.atomic [
+    i32 6, label %ig.unbound
+    i32 3, label %ig.compound
+  ]
+
+ig.atomic:
+  ret i1 true
+
+ig.unbound:
+  ret i1 false
+
+ig.compound:
+  %ig.cp_bits = call i64 @value_payload(%Value %ig.t)
+  %ig.src_cp = inttoptr i64 %ig.cp_bits to %Compound*
+  %ig.ar_slot = getelementptr %Compound, %Compound* %ig.src_cp, i32 0, i32 1
+  %ig.arity = load i32, i32* %ig.ar_slot
+  %ig.args_slot = getelementptr %Compound, %Compound* %ig.src_cp, i32 0, i32 2
+  %ig.src_args = load %Value*, %Value** %ig.args_slot
+  %ig.has = icmp sgt i32 %ig.arity, 0
+  br i1 %ig.has, label %ig.loop, label %ig.true
+
+ig.loop:
+  %ig.i = phi i32 [ 0, %ig.compound ], [ %ig.i_next, %ig.step ]
+  %ig.arg_ptr = getelementptr %Value, %Value* %ig.src_args, i32 %ig.i
+  %ig.arg = load %Value, %Value* %ig.arg_ptr
+  %ig.sub = call i1 @wam_is_ground(%WamState* %vm, %Value %ig.arg)
+  br i1 %ig.sub, label %ig.step, label %ig.false
+
+ig.step:
+  %ig.i_next = add i32 %ig.i, 1
+  %ig.more = icmp slt i32 %ig.i_next, %ig.arity
+  br i1 %ig.more, label %ig.loop, label %ig.true
+
+ig.true:
+  ret i1 true
+
+ig.false:
+  ret i1 false
+}
+
 ; M105: recursive depth-first left-to-right walk that binds each
 ; Unbound variable encountered to a fresh ''$VAR''(N) compound on
 ; the arena. Counter n is threaded through and returned -- caller
@@ -13119,6 +13176,7 @@ builtin_op_to_id('realpath/2', 128).          % libc realpath(rel) -> Abs atom.
 builtin_op_to_id('kill/2', 129).              % libc kill(pid, sig).
 builtin_op_to_id('truncate/2', 130).          % libc truncate(path, length).
 builtin_op_to_id('chown/3', 131).             % libc chown(path, uid, gid).
+builtin_op_to_id('ground/1', 132).            % succeeds iff term has no unbound vars.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2232,6 +2232,7 @@ is_builtin_pred(realpath, 2).           % realpath(+Path, -Abs) -- canonical abs
 is_builtin_pred(kill, 2).               % kill(+Pid, +Sig) -- signal 0 = existence check.
 is_builtin_pred(truncate, 2).           % truncate(+Path, +Length) -- set file size.
 is_builtin_pred(chown, 3).              % chown(+Path, +Uid, +Gid) -- change owner.
+is_builtin_pred(ground, 1).             % ground(+Term) -- true iff no unbound vars.
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2501,6 +2501,51 @@ test_chown_bad_args(_, R) :-
     ; R is 1
     ).   % 1
 
+% M117: ground/1 -- succeeds iff term has no unbound variables.
+
+:- dynamic test_ground_atom/2.
+test_ground_atom(_, R) :-
+    ( ground(foo) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_ground_int/2.
+test_ground_int(_, R) :-
+    ( ground(42) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_ground_compound_closed/2.
+test_ground_compound_closed(_, R) :-
+    ( ground(foo(a, b, c)) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_ground_nested_closed/2.
+test_ground_nested_closed(_, R) :-
+    ( ground(pair(p(1, 2), q(3, [4, 5]))) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_ground_list_closed/2.
+test_ground_list_closed(_, R) :-
+    ( ground([1, 2, 3, foo]) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_ground_bare_var/2.
+test_ground_bare_var(_, R) :-
+    ( ground(_X) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_ground_compound_with_var/2.
+test_ground_compound_with_var(_, R) :-
+    ( ground(foo(a, _Y, c)) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_ground_nested_with_var/2.
+test_ground_nested_with_var(_, R) :-
+    ( ground(pair(p(1, _Z), q(3, [4, 5]))) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_ground_list_open_tail/2.
+test_ground_list_open_tail(_, R) :-
+    % Partial list [1, 2 | _T] has an unbound tail var, so not ground.
+    ( ground([1, 2 | _T]) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_ground_after_bind/2.
+test_ground_after_bind(_, R) :-
+    % Binding the var makes the term ground.
+    X = bound_atom,
+    ( ground(foo(a, X, c)) -> R is 1 ; R is 0 ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -5373,6 +5418,27 @@ test_all :-
                    test_chown_missing, 0, 1),
        run_test_r0('chown with non-atom path / non-int uid/gid fails -> 1',
                    test_chown_bad_args, 0, 1),
+       format('--- M117 ground/1 ---~n'),
+       run_test_r0('ground(atom) -> 1',
+                   test_ground_atom, 0, 1),
+       run_test_r0('ground(42) -> 1',
+                   test_ground_int, 0, 1),
+       run_test_r0('ground(foo(a,b,c)) -> 1',
+                   test_ground_compound_closed, 0, 1),
+       run_test_r0('ground(pair(p(1,2),q(3,[4,5]))) -> 1',
+                   test_ground_nested_closed, 0, 1),
+       run_test_r0('ground([1,2,3,foo]) -> 1',
+                   test_ground_list_closed, 0, 1),
+       run_test_r0('ground(_X) fails -> 1',
+                   test_ground_bare_var, 0, 1),
+       run_test_r0('ground(foo(a,_,c)) fails -> 1',
+                   test_ground_compound_with_var, 0, 1),
+       run_test_r0('ground with nested var fails -> 1',
+                   test_ground_nested_with_var, 0, 1),
+       run_test_r0('ground([1,2|_T]) fails -> 1',
+                   test_ground_list_open_tail, 0, 1),
+       run_test_r0('ground after binding var -> 1',
+                   test_ground_after_bind, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds `ground/1` as builtin op id 132. Succeeds iff the term has no unbound variables.

## Implementation

`@wam_is_ground` is a tiny i1-returning twin of `@wam_collect_vars` (M103):

```
ig.atomic    -> ret true
ig.unbound   -> ret false
ig.compound  -> recurse over args; bail false on first non-ground arg
```

Atomic (atom/int/float) and bound refs are ground; any unbound ref kills the walk; compounds recurse and short-circuit on the first non-ground subterm. Same deref + payload-fetch shape as M103 and M105.

## Three-site registration

- Dispatch switch in `run_loop`: `i32 132, label %builtin_ground`
- `builtin_op_to_id('ground/1', 132).`
- `is_builtin_pred(ground, 1).` in `wam_target.pl`

## Tests

10 execution tests, all PASS:
- ground atom, ground int, ground closed compound, ground deep nested closed
- ground closed list
- bare var fails, compound-with-var fails, deeply-nested var fails
- partial list `[1,2|_T]` fails (open tail)
- bind-then-test (`X = bound, ground(foo(a, X, c))` succeeds)

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — dispatch entry, `builtin_ground`, `@wam_is_ground` helper, `builtin_op_to_id`.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 10 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke test) ✓
- [x] All 10 M117 tests PASS individually ✓
- [ ] Full suite regression check (no other milestones touched)

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_