### PR TITLE
LLVM WAM: file_base_name/2 + file_directory_name/2 (M118)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3659,6 +3659,8 @@ entry:
     i32 130, label %builtin_truncate
     i32 131, label %builtin_chown
     i32 132, label %builtin_ground
+    i32 133, label %builtin_file_base_name
+    i32 134, label %builtin_file_directory_name
   ]
 
 builtin_is:
@@ -5891,6 +5893,149 @@ builtin_ground:
   %gr.t = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %gr.r = call i1 @wam_is_ground(%WamState* %vm, %Value %gr.t)
   ret i1 %gr.r
+
+builtin_file_base_name:
+  ; M118: file_base_name(+Path, -Base) -- basename(1) semantics.
+  ; Scan Path backwards for the last ''/''; return everything
+  ; after it (or the whole string if no ''/''). Special cases:
+  ; ''/'' or any path ending in ''/'' returns ''''. Path must be
+  ; Atom; non-atom fails the type guard.
+  %fbn.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %fbn.t1 = call i32 @value_tag(%Value %fbn.a1)
+  %fbn.is_atom = icmp eq i32 %fbn.t1, 0
+  br i1 %fbn.is_atom, label %fbn.go, label %fbn.fail
+fbn.fail:
+  ret i1 false
+fbn.go:
+  %fbn.aid = call i64 @value_payload(%Value %fbn.a1)
+  %fbn.path = call i8* @wam_atom_to_string(i64 %fbn.aid)
+  %fbn.path_null = icmp eq i8* %fbn.path, null
+  br i1 %fbn.path_null, label %fbn.fail, label %fbn.scan_init
+fbn.scan_init:
+  %fbn.len = call i64 @strlen(i8* %fbn.path)
+  %fbn.has = icmp sgt i64 %fbn.len, 0
+  %fbn.i_init = sub i64 %fbn.len, 1
+  br i1 %fbn.has, label %fbn.loop, label %fbn.empty
+fbn.empty:
+  ; Empty path -> empty atom.
+  br label %fbn.intern_with_zero
+fbn.loop:
+  ; i counts down from len-1 looking for ''/''. No-slash exit through %step.
+  %fbn.i = phi i64 [ %fbn.i_init, %fbn.scan_init ], [ %fbn.i_dec, %fbn.step ]
+  %fbn.cp = getelementptr i8, i8* %fbn.path, i64 %fbn.i
+  %fbn.c = load i8, i8* %fbn.cp
+  %fbn.is_slash = icmp eq i8 %fbn.c, 47
+  br i1 %fbn.is_slash, label %fbn.found, label %fbn.step
+fbn.step:
+  %fbn.done = icmp eq i64 %fbn.i, 0
+  %fbn.i_dec = sub i64 %fbn.i, 1
+  br i1 %fbn.done, label %fbn.no_slash, label %fbn.loop
+fbn.no_slash:
+  ; No ''/'' anywhere -> base = whole string.
+  %fbn.start_a = phi i8* [ %fbn.path, %fbn.step ]
+  %fbn.baselen_a = phi i64 [ %fbn.len, %fbn.step ]
+  br label %fbn.intern
+fbn.found:
+  ; slash is at index i; base starts at i+1, length = len-(i+1).
+  %fbn.start_off = add i64 %fbn.i, 1
+  %fbn.start_b = getelementptr i8, i8* %fbn.path, i64 %fbn.start_off
+  %fbn.baselen_b = sub i64 %fbn.len, %fbn.start_off
+  br label %fbn.intern
+fbn.intern:
+  %fbn.start = phi i8* [ %fbn.start_a, %fbn.no_slash ], [ %fbn.start_b, %fbn.found ]
+  %fbn.baselen = phi i64 [ %fbn.baselen_a, %fbn.no_slash ], [ %fbn.baselen_b, %fbn.found ]
+  call void @wam_arena_ensure()
+  %fbn.bufsize = add i64 %fbn.baselen, 1
+  %fbn.arena = call i8* @wam_arena_alloc(i64 %fbn.bufsize)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %fbn.arena, i8* %fbn.start, i64 %fbn.baselen, i1 false)
+  %fbn.term = getelementptr i8, i8* %fbn.arena, i64 %fbn.baselen
+  store i8 0, i8* %fbn.term
+  %fbn.atom_id = call i64 @wam_intern_atom(i8* %fbn.arena, i64 %fbn.baselen)
+  br label %fbn.unify
+fbn.intern_with_zero:
+  ; Empty-string fast path: intern "" (len 0).
+  call void @wam_arena_ensure()
+  %fbn.arena_e = call i8* @wam_arena_alloc(i64 1)
+  store i8 0, i8* %fbn.arena_e
+  %fbn.atom_id_e = call i64 @wam_intern_atom(i8* %fbn.arena_e, i64 0)
+  br label %fbn.unify
+fbn.unify:
+  %fbn.final_aid = phi i64 [ %fbn.atom_id, %fbn.intern ], [ %fbn.atom_id_e, %fbn.intern_with_zero ]
+  %fbn.v0 = insertvalue %Value undef, i32 0, 0
+  %fbn.v = insertvalue %Value %fbn.v0, i64 %fbn.final_aid, 1
+  %fbn.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %fbn.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %fbn.raw2, %Value %fbn.v)
+  ret i1 %fbn.ok
+
+builtin_file_directory_name:
+  ; M118: file_directory_name(+Path, -Dir) -- dirname(1)-style.
+  ; Scan Path backwards for last ''/''. If found at index 0 the
+  ; result is ''/'' (root). If found at index >0 the result is the
+  ; prefix [0..i). If no ''/'' (or empty path), the result is ''.''.
+  ; Path must be Atom.
+  %fdn.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %fdn.t1 = call i32 @value_tag(%Value %fdn.a1)
+  %fdn.is_atom = icmp eq i32 %fdn.t1, 0
+  br i1 %fdn.is_atom, label %fdn.go, label %fdn.fail
+fdn.fail:
+  ret i1 false
+fdn.go:
+  %fdn.aid = call i64 @value_payload(%Value %fdn.a1)
+  %fdn.path = call i8* @wam_atom_to_string(i64 %fdn.aid)
+  %fdn.path_null = icmp eq i8* %fdn.path, null
+  br i1 %fdn.path_null, label %fdn.fail, label %fdn.scan_init
+fdn.scan_init:
+  %fdn.len = call i64 @strlen(i8* %fdn.path)
+  %fdn.has = icmp sgt i64 %fdn.len, 0
+  %fdn.i_init = sub i64 %fdn.len, 1
+  br i1 %fdn.has, label %fdn.loop, label %fdn.dot
+fdn.loop:
+  %fdn.i = phi i64 [ %fdn.i_init, %fdn.scan_init ], [ %fdn.i_dec, %fdn.step ]
+  %fdn.cp = getelementptr i8, i8* %fdn.path, i64 %fdn.i
+  %fdn.c = load i8, i8* %fdn.cp
+  %fdn.is_slash = icmp eq i8 %fdn.c, 47
+  br i1 %fdn.is_slash, label %fdn.found, label %fdn.step
+fdn.step:
+  %fdn.done = icmp eq i64 %fdn.i, 0
+  %fdn.i_dec = sub i64 %fdn.i, 1
+  br i1 %fdn.done, label %fdn.dot, label %fdn.loop
+fdn.dot:
+  ; No ''/'' or empty -> result is ''.''. Intern "." (1 byte + null).
+  call void @wam_arena_ensure()
+  %fdn.dot_buf = call i8* @wam_arena_alloc(i64 2)
+  store i8 46, i8* %fdn.dot_buf
+  %fdn.dot_term = getelementptr i8, i8* %fdn.dot_buf, i64 1
+  store i8 0, i8* %fdn.dot_term
+  %fdn.dot_aid = call i64 @wam_intern_atom(i8* %fdn.dot_buf, i64 1)
+  br label %fdn.unify
+fdn.found:
+  ; Slash at index i. If i == 0 -> root ''/''. Else dir = [0..i).
+  %fdn.is_root = icmp eq i64 %fdn.i, 0
+  br i1 %fdn.is_root, label %fdn.root, label %fdn.prefix
+fdn.root:
+  call void @wam_arena_ensure()
+  %fdn.root_buf = call i8* @wam_arena_alloc(i64 2)
+  store i8 47, i8* %fdn.root_buf
+  %fdn.root_term = getelementptr i8, i8* %fdn.root_buf, i64 1
+  store i8 0, i8* %fdn.root_term
+  %fdn.root_aid = call i64 @wam_intern_atom(i8* %fdn.root_buf, i64 1)
+  br label %fdn.unify
+fdn.prefix:
+  call void @wam_arena_ensure()
+  %fdn.bufsize = add i64 %fdn.i, 1
+  %fdn.arena = call i8* @wam_arena_alloc(i64 %fdn.bufsize)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %fdn.arena, i8* %fdn.path, i64 %fdn.i, i1 false)
+  %fdn.term = getelementptr i8, i8* %fdn.arena, i64 %fdn.i
+  store i8 0, i8* %fdn.term
+  %fdn.pref_aid = call i64 @wam_intern_atom(i8* %fdn.arena, i64 %fdn.i)
+  br label %fdn.unify
+fdn.unify:
+  %fdn.final_aid = phi i64 [ %fdn.dot_aid, %fdn.dot ], [ %fdn.root_aid, %fdn.root ], [ %fdn.pref_aid, %fdn.prefix ]
+  %fdn.v0 = insertvalue %Value undef, i32 0, 0
+  %fdn.v = insertvalue %Value %fdn.v0, i64 %fdn.final_aid, 1
+  %fdn.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %fdn.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %fdn.raw2, %Value %fdn.v)
+  ret i1 %fdn.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -13177,6 +13322,8 @@ builtin_op_to_id('kill/2', 129).              % libc kill(pid, sig).
 builtin_op_to_id('truncate/2', 130).          % libc truncate(path, length).
 builtin_op_to_id('chown/3', 131).             % libc chown(path, uid, gid).
 builtin_op_to_id('ground/1', 132).            % succeeds iff term has no unbound vars.
+builtin_op_to_id('file_base_name/2', 133).    % basename(1): part after last ''/''.
+builtin_op_to_id('file_directory_name/2', 134). % dirname(1): prefix before last ''/'' (or ''.'').
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2233,6 +2233,8 @@ is_builtin_pred(kill, 2).               % kill(+Pid, +Sig) -- signal 0 = existen
 is_builtin_pred(truncate, 2).           % truncate(+Path, +Length) -- set file size.
 is_builtin_pred(chown, 3).              % chown(+Path, +Uid, +Gid) -- change owner.
 is_builtin_pred(ground, 1).             % ground(+Term) -- true iff no unbound vars.
+is_builtin_pred(file_base_name, 2).     % file_base_name(+Path, -Base).
+is_builtin_pred(file_directory_name, 2).% file_directory_name(+Path, -Dir).
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2546,6 +2546,84 @@ test_ground_after_bind(_, R) :-
     X = bound_atom,
     ( ground(foo(a, X, c)) -> R is 1 ; R is 0 ).   % 1
 
+% M118: file_base_name/2 + file_directory_name/2 -- path component split.
+
+:- dynamic test_fbn_simple/2.
+test_fbn_simple(_, R) :-
+    file_base_name('/usr/bin/swipl', B),
+    ( B == swipl -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_fbn_no_slash/2.
+test_fbn_no_slash(_, R) :-
+    file_base_name(swipl, B),
+    ( B == swipl -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_fbn_root/2.
+test_fbn_root(_, R) :-
+    % "/" -> "" (basename of root is empty per SWI).
+    file_base_name('/', B),
+    ( B == '' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_fbn_trailing_slash/2.
+test_fbn_trailing_slash(_, R) :-
+    % "/usr/bin/" -> "".
+    file_base_name('/usr/bin/', B),
+    ( B == '' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_fbn_empty/2.
+test_fbn_empty(_, R) :-
+    file_base_name('', B),
+    ( B == '' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_fbn_nested/2.
+test_fbn_nested(_, R) :-
+    file_base_name('/a/b/c/d/e.txt', B),
+    ( B == 'e.txt' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_fbn_bad_arg/2.
+test_fbn_bad_arg(_, R) :-
+    % Non-atom path fails the type guard.
+    ( file_base_name(42, _) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_fdn_simple/2.
+test_fdn_simple(_, R) :-
+    file_directory_name('/usr/bin/swipl', D),
+    ( D == '/usr/bin' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_fdn_no_slash/2.
+test_fdn_no_slash(_, R) :-
+    % No "/" -> ".".
+    file_directory_name(swipl, D),
+    ( D == '.' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_fdn_root/2.
+test_fdn_root(_, R) :-
+    % "/" -> "/".
+    file_directory_name('/', D),
+    ( D == '/' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_fdn_root_child/2.
+test_fdn_root_child(_, R) :-
+    % "/etc" -> "/".
+    file_directory_name('/etc', D),
+    ( D == '/' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_fdn_trailing_slash/2.
+test_fdn_trailing_slash(_, R) :-
+    % "/usr/bin/" -- last slash at index 8, prefix [0..8) = "/usr/bin".
+    file_directory_name('/usr/bin/', D),
+    ( D == '/usr/bin' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_fdn_empty/2.
+test_fdn_empty(_, R) :-
+    % "" -> ".".
+    file_directory_name('', D),
+    ( D == '.' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_fdn_bad_arg/2.
+test_fdn_bad_arg(_, R) :-
+    ( file_directory_name(42, _) -> R is 0 ; R is 1 ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -5439,6 +5517,35 @@ test_all :-
                    test_ground_list_open_tail, 0, 1),
        run_test_r0('ground after binding var -> 1',
                    test_ground_after_bind, 0, 1),
+       format('--- M118 file_base_name/2 + file_directory_name/2 ---~n'),
+       run_test_r0('file_base_name(/usr/bin/swipl) -> swipl -> 1',
+                   test_fbn_simple, 0, 1),
+       run_test_r0('file_base_name(swipl) -> swipl -> 1',
+                   test_fbn_no_slash, 0, 1),
+       run_test_r0('file_base_name(/) -> '''' -> 1',
+                   test_fbn_root, 0, 1),
+       run_test_r0('file_base_name(/usr/bin/) -> '''' -> 1',
+                   test_fbn_trailing_slash, 0, 1),
+       run_test_r0('file_base_name('''') -> '''' -> 1',
+                   test_fbn_empty, 0, 1),
+       run_test_r0('file_base_name(/a/b/c/d/e.txt) -> e.txt -> 1',
+                   test_fbn_nested, 0, 1),
+       run_test_r0('file_base_name(42, _) fails -> 1',
+                   test_fbn_bad_arg, 0, 1),
+       run_test_r0('file_directory_name(/usr/bin/swipl) -> /usr/bin -> 1',
+                   test_fdn_simple, 0, 1),
+       run_test_r0('file_directory_name(swipl) -> . -> 1',
+                   test_fdn_no_slash, 0, 1),
+       run_test_r0('file_directory_name(/) -> / -> 1',
+                   test_fdn_root, 0, 1),
+       run_test_r0('file_directory_name(/etc) -> / -> 1',
+                   test_fdn_root_child, 0, 1),
+       run_test_r0('file_directory_name(/usr/bin/) -> /usr/bin -> 1',
+                   test_fdn_trailing_slash, 0, 1),
+       run_test_r0('file_directory_name('''') -> . -> 1',
+                   test_fdn_empty, 0, 1),
+       run_test_r0('file_directory_name(42, _) fails -> 1',
+                   test_fdn_bad_arg, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds path-component split builtins, both pure scan-for-last-slash so cross-platform without `target_os` branching:

- `file_base_name/2` (op id 133) — basename(1) semantics
- `file_directory_name/2` (op id 134) — dirname(1) semantics

## Semantics

| Input | `file_base_name` | `file_directory_name` |
|---|---|---|
| `/usr/bin/swipl` | `swipl` | `/usr/bin` |
| `swipl` | `swipl` | `.` |
| `/` | `''` | `/` |
| `/etc` | `etc` | `/` |
| `/usr/bin/` | `''` | `/usr/bin` |
| `''` | `''` | `.` |

Both type-guard `Path` as Atom; non-atom fails. Result is allocated on the arena, null-terminated, interned via `wam_intern_atom`, and unified with reg 1.

## Implementation

Single backwards scan from `len-1` looking for byte 47 (`/`):
- `file_base_name`: found → suffix `[i+1..len)`; not found → whole path; empty → `''`.
- `file_directory_name`: found at `i == 0` → `/`; found at `i > 0` → prefix `[0..i)`; not found or empty → `.`.

No libc beyond `strlen` — runs identically on Linux, BSD, macOS, WASI.

## Three-site registration

- Dispatch switch entries 133, 134
- `builtin_op_to_id`
- `is_builtin_pred` in `wam_target.pl`

## Tests

13 execution tests, all PASS:
- `file_base_name`: simple, no-slash, root, trailing-slash, empty, deep nested with extension, non-atom bad arg
- `file_directory_name`: simple, no-slash, root, root-child, trailing-slash, empty, non-atom bad arg

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — dispatch entries, `builtin_file_base_name`, `builtin_file_directory_name`, op-id table.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred` entries.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 13 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke) ✓
- [x] All 13 M118 tests PASS individually ✓
- [ ] Full suite regression check

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_