### PR TITLE
Feat/wam go format s directive

### DIFF
--- a/PR_go_wam_format_s_directive.md
+++ b/PR_go_wam_format_s_directive.md
@@ -1,0 +1,28 @@
+# PR Title
+
+Add Go WAM format string directive
+
+# PR Description
+
+## Summary
+
+- Add bounded `~s` support for Go WAM `format/1` and `format/2`.
+- Render atom arguments directly as text for `~s`.
+- Render proper integer code lists as string output for `~s`.
+- Fail malformed code lists instead of falling back silently.
+- Add generated Go WAM E2E coverage and update the Go WAM parity audit.
+
+## Scope
+
+This keeps `format/3`, stream capture, `with_output_to/2`, tab directives, and richer canonical quoting out of scope.
+
+## Validation
+
+- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
+- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`
+
+Existing non-fatal choicepoint warnings still appear in the same Go WAM tests.

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -66,10 +66,10 @@ current cross-target builtin/runtime baseline.
   parsing.
 - Bounded `format/1` and `format/2` are now direct Go WAM builtins and are
   covered by the generated builtin E2E test for literal `~~`, newline `~n`,
-  `~w`, `~a`, `~d`, `~p`, and `~q` argument substitution, and
+  `~w`, `~a`, `~d`, `~p`, `~q`, and `~s` argument substitution, and
   missing-argument failure. Stream capture, destination-aware `format/3`,
-  `~s`, tab directives, and richer canonical quoting remain separate from
-  this small R/C++/Python output-parity slice.
+  tab directives, and richer canonical quoting remain separate from this
+  small R/C++/Python output-parity slice.
 - Deterministic `subtract/3` is now covered by the generated Go WAM builtin
   E2E test for filtering all right-list matches from the left list, preserving
   left-list order, empty-list behavior, all-removed results, duplicate removal,

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -918,10 +918,42 @@ func (vm *WamState) formatTemplate(template string, args []Value) (string, bool)
 				b.WriteString(value.String())
 			}
 			argIdx++
+		case 's':
+			if argIdx >= len(args) {
+				return "", false
+			}
+			text, ok := vm.formatStringDirective(vm.deref(args[argIdx]))
+			if !ok {
+				return "", false
+			}
+			b.WriteString(text)
+			argIdx++
 		default:
 			b.WriteByte('~')
 			b.WriteByte(template[i])
 		}
+	}
+	return b.String(), true
+}
+
+func (vm *WamState) formatStringDirective(value Value) (string, bool) {
+	if isEmptyListValue(value) {
+		return "", true
+	}
+	if atom, ok := value.(*Atom); ok {
+		return atom.Name, true
+	}
+	items, ok := vm.listToSlice(value)
+	if !ok {
+		return "", false
+	}
+	var b strings.Builder
+	for _, item := range items {
+		code, ok := vm.deref(item).(*Integer)
+		if !ok || code.Val < 0 || code.Val > 0x10ffff {
+			return "", false
+		}
+		b.WriteRune(rune(code.Val))
 	}
 	return b.String(), true
 }

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -690,6 +690,8 @@ test(builtins_execution) :-
             (   format('fmt_one ~~ ok~n'),
                 format('fmt_two ~w ~w~~~n', [go, 42]),
                 format('fmt_more ~a ~d ~p ~q~n', [atom_arg, 17, pair(a,b), quoted_atom]),
+                format('fmt_string ~s ~s~n', [atom_text, [111,107]]),
+                \+ format('fmt_bad_string ~s', [[111,bad]]),
                 \+ format('fmt_missing ~w', [])
             )),
           assertz(user:test_set_aggregate :-
@@ -1300,6 +1302,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "fmt_one ~ ok")),
         assertion(sub_string(FullOutput, _, _, _, "fmt_two go 42~")),
         assertion(sub_string(FullOutput, _, _, _, "fmt_more atom_arg 17 pair/2/2 quoted_atom")),
+        assertion(sub_string(FullOutput, _, _, _, "fmt_string atom_text ok")),
         assertion(sub_string(FullOutput, _, _, _, "FORMAT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "SET_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "UNIFY_SUCCESS")),


### PR DESCRIPTION
# Add Go WAM format string directive

## Summary

- Add bounded `~s` support for Go WAM `format/1` and `format/2`.
- Render atom arguments directly as text for `~s`.
- Render proper integer code lists as string output for `~s`.
- Fail malformed code lists instead of falling back silently.
- Add generated Go WAM E2E coverage and update the Go WAM parity audit.

## Scope

This keeps `format/3`, stream capture, `with_output_to/2`, tab directives, and richer canonical quoting out of scope.

## Validation

- `swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl`

Existing non-fatal choicepoint warnings still appear in the same Go WAM tests.
