### PR TITLE
feat(lua): lower if-then-else / negation / once; fix nested-ITE compile hang

### DIFF
--- a/src/unifyweaver/targets/wam_lua_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_lua_lowered_emitter.pl
@@ -8,6 +8,7 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(wam_ite_structurer, [structure_ite/2]).
 
 build_emission_plan(WamCode, plan(Mode, AltLabel, ClauseLines)) :-
     atom_string(WamCode, S),
@@ -32,7 +33,42 @@ classify_clause_shape([FirstLine|Rest], plan(multi_clause_1, AltAtom, ClauseLine
     wam_lua_target:tokenize_wam_line(FirstLine, ["try_me_else", AltStr]), !,
     atom_string(AltAtom, AltStr),
     take_clause1_lines(Rest, ClauseLines).
+% Soft-cut block: an if-then-else / negation / once whose try_me_else is
+% internal (preceded by the shared head-arg setup), not a clause separator.
+% Fold it through the shared structurer into ite(Cond,Then,Else) terms.
+classify_clause_shape(Lines, plan(ite, none, Structured)) :-
+    lua_parse_terms(Lines, Terms),
+    structure_ite(Terms, Structured),
+    member(ite(_, _, _), Structured),
+    \+ member(try_me_else(_), Structured),
+    \+ member(trust_me, Structured),
+    !.
 classify_clause_shape(Lines, plan(deterministic, none, Lines)).
+
+% --- Label-preserving term parse (for the shared structurer) -------------
+% Each WAM line becomes a structural term the structurer understands
+% (try_me_else/trust_me/jump/cut_ite/label and the !/0-commit builtin_call),
+% or an opaque line(Parts) leaf that emit_line_parts/2 renders unchanged.
+lua_parse_terms([], []).
+lua_parse_terms([Line|Rest], Terms) :-
+    wam_lua_target:tokenize_wam_line(Line, Parts),
+    (   Parts == []
+    ->  lua_parse_terms(Rest, Terms)
+    ;   Parts = [First|_], sub_string(First, _, 1, 0, ":")
+    ->  sub_string(First, 0, _, 1, LabelName),
+        Terms = [label(LabelName)|More],
+        lua_parse_terms(Rest, More)
+    ;   lua_line_term(Parts, T),
+        Terms = [T|More],
+        lua_parse_terms(Rest, More)
+    ).
+
+lua_line_term(["try_me_else", L], try_me_else(L)) :- !.
+lua_line_term(["trust_me"], trust_me) :- !.
+lua_line_term(["jump", L], jump(L)) :- !.
+lua_line_term(["cut_ite"], cut_ite) :- !.
+lua_line_term(["builtin_call", Op, Ar], builtin_call(Op, Ar)) :- !.
+lua_line_term(Parts, line(Parts)).
 
 take_clause1_lines([], []).
 take_clause1_lines([Line|Rest], Out) :-
@@ -44,8 +80,22 @@ take_clause1_lines([Line|Rest], Out) :-
     ).
 
 wam_lua_lowerable(_PI, WamCode, Reason) :-
-    catch(build_emission_plan(WamCode, plan(Reason, _, Lines)), _, fail),
-    forall(member(Line, Lines), line_supported(Line)).
+    catch(build_emission_plan(WamCode, plan(Reason, _, Payload)), _, fail),
+    (   Reason == ite
+    ->  forall(member(I, Payload), lua_struct_supported(I))
+    ;   forall(member(Line, Payload), line_supported(Line))
+    ).
+
+%% lua_struct_supported(+StructuredInstr) — recurse through ite/3; each leaf
+%  must be an instruction emit_struct_lua/2 can render.
+lua_struct_supported(ite(C, T, E)) :- !,
+    forall(member(I, C), lua_struct_supported(I)),
+    forall(member(I, T), lua_struct_supported(I)),
+    forall(member(I, E), lua_struct_supported(I)).
+lua_struct_supported(builtin_call(_, _)) :- !.
+lua_struct_supported(line(Parts)) :- !,
+    ( Parts == [] -> true ; parts_supported(Parts) ).
+lua_struct_supported(_) :- fail.
 
 line_supported(Line) :-
     wam_lua_target:tokenize_wam_line(Line, Parts),
@@ -94,11 +144,52 @@ lower_predicate_to_lua(PI, WamCode, _Options, lowered(PredName, FuncName, Code))
     (PI = _M:Pred/Arity -> true ; PI = Pred/Arity),
     format(atom(PredName), '~w/~w', [Pred, Arity]),
     lua_lowered_func_name(Pred/Arity, FuncName),
-    build_emission_plan(WamCode, plan(Mode, AltLabel, Lines)),
+    build_emission_plan(WamCode, plan(Mode, AltLabel, Payload)),
     (   Mode == deterministic
-    ->  emit_deterministic_function(PredName, FuncName, Lines, Code)
-    ;   emit_multi_clause_function(PredName, FuncName, AltLabel, Lines, Code)
+    ->  emit_deterministic_function(PredName, FuncName, Payload, Code)
+    ;   Mode == ite
+    ->  emit_ite_function(PredName, FuncName, Payload, Code)
+    ;   emit_multi_clause_function(PredName, FuncName, AltLabel, Payload, Code)
     ).
+
+% If-then-else / negation / once. Same wrapper as the deterministic case,
+% but the body is the structured term list rendered by emit_struct_lua/2.
+% lua's bind_var always trails, so undoing the trail to the pre-condition
+% mark before the else branch restores any partial bindings the condition
+% made (no register snapshot needed; mirrors the Rust emitter).
+emit_ite_function(PredName, FuncName, Structured, Code) :-
+    with_output_to(string(Body), emit_struct_lua(Structured, "  ")),
+    format(string(Code),
+'-- Lowered: ~w (if-then-else / negation / once)
+local function ~w(program, state)
+~w  return true
+end
+', [PredName, FuncName, Body]).
+
+emit_struct_lua([], _).
+emit_struct_lua([Item|Rest], Ind) :-
+    emit_struct_item_lua(Item, Ind),
+    emit_struct_lua(Rest, Ind).
+
+emit_struct_item_lua(ite(Cond, Then, Else), Ind) :- !,
+    string_concat(Ind, "    ", Ind4),
+    format("~wdo~n", [Ind]),
+    format("~w  local _ite_mark = #state.trail~n", [Ind]),
+    format("~w  local _ite_cond = (function()~n", [Ind]),
+    emit_struct_lua(Cond, Ind4),
+    format("~w    return true~n", [Ind]),
+    format("~w  end)()~n", [Ind]),
+    format("~w  if _ite_cond then~n", [Ind]),
+    emit_struct_lua(Then, Ind4),
+    format("~w  else~n", [Ind]),
+    format("~w    while #state.trail > _ite_mark do state.bindings[table.remove(state.trail)] = nil end~n", [Ind]),
+    emit_struct_lua(Else, Ind4),
+    format("~w  end~n", [Ind]),
+    format("~wend~n", [Ind]).
+emit_struct_item_lua(builtin_call(Op, Ar), Ind) :- !,
+    emit_line_parts(["builtin_call", Op, Ar], Ind).
+emit_struct_item_lua(line(Parts), Ind) :- !,
+    emit_line_parts(Parts, Ind).
 
 emit_deterministic_function(PredName, FuncName, Lines, Code) :-
     with_output_to(string(Body), emit_lines(Lines, "  ")),

--- a/src/unifyweaver/targets/wam_lua_target.pl
+++ b/src/unifyweaver/targets/wam_lua_target.pl
@@ -579,7 +579,15 @@ lua_wam_segments([_|Rest], Segments) :-
 lua_segment_instrs([], [], []).
 lua_segment_instrs([label(_)|Rest], [], [label(_)|Rest]) :- !.
 lua_segment_instrs([Item|Rest], [Parts|More], Remaining) :-
-    wam_item_parts(Item, Parts),
+    % once/1: wam_item_parts/2 has a catch-all clause that overlaps every
+    % specific clause, so each item yields multiple solutions. Without
+    % committing to the first (specific) one, lua_inline_fact_tuples
+    % backtracks through every item's choicepoint when a segment turns out
+    % not to be fact-only (any predicate containing a builtin_call), which
+    % is exponential in the number of segments — a nested if-then-else
+    % (5 segments) effectively hangs. The first solution is always the
+    % intended one, so the segmentation is unchanged.
+    once(wam_item_parts(Item, Parts)),
     lua_segment_instrs(Rest, More, Remaining).
 
 lua_fact_only_segments(Segments) :-
@@ -809,7 +817,12 @@ lua_predicate_clause(Name/Arity, Head, Body) :-
     clause(user:Head, Body).
 
 write_file(Path, Content) :-
-    setup_call_cleanup(open(Path, write, Stream), write(Stream, Content), close(Stream)).
+    % UTF-8 so the runtime/generated sources (which contain non-ASCII
+    % characters) write correctly regardless of the process locale
+    % (POSIX/ASCII in many CI containers); otherwise write/2 raises an
+    % encoding error.
+    setup_call_cleanup(open(Path, write, Stream, [encoding(utf8)]),
+                       write(Stream, Content), close(Stream)).
 
 find_template(RelPath, Template) :-
     (   source_file(wam_lua_target, SrcFile)

--- a/tests/test_wam_lua_lowered_ite.pl
+++ b/tests/test_wam_lua_lowered_ite.pl
@@ -1,0 +1,123 @@
+% test_wam_lua_lowered_ite.pl
+%
+% End-to-end execution test for WAM-Lua if-then-else / negation / once
+% lowering (emit_mode(functions)). Counterpart to the Go / Rust / C++ /
+% Haskell / F# / Clojure / LLVM / Elixir / Python lowered-ITE exec tests.
+% Pins:
+%
+%   * simple ITE         — lite/2;
+%   * negation (\+)       — lneg/1 (commit is the !/0 builtin: then = fail/0,
+%                          else = true/0, run after a trail rollback);
+%   * sequential ITEs    — lseqite/3 (two sibling blocks);
+%   * nested ITEs         — lnestite/2 (inner block in the then-arm).
+%
+% Lua previously declined any predicate whose lowered body contained the
+% soft-cut block's try_me_else / cut_ite / jump / trust_me (they were not in
+% parts_supported/1), so such predicates fell back to the WAM interpreter —
+% sound but not lowered. Folding clause 1 through wam_ite_structurer emits
+% native Lua if/else. lua's bind_var always trails, so undoing the trail to
+% the pre-condition mark before the else restores the condition's bindings.
+%
+% Generates a lowered Lua project and calls the per-predicate module entry
+% points (M.lite, M.lneg, ...) asserting the boolean outcome. Skipped unless
+% a Lua interpreter (lua5.4 / lua5.3 / lua / luajit) is on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module(library(process)).
+:- use_module('../src/unifyweaver/targets/wam_lua_target').
+
+:- dynamic user:lite/2.
+:- dynamic user:lneg/1.
+:- dynamic user:lseqite/3.
+:- dynamic user:lnestite/2.
+
+user:lite(X, Y)       :- ( X > 0 -> Y = pos ; Y = nonpos ).
+user:lneg(X)          :- \+ X > 0.
+user:lseqite(X, Y, Z) :- ( X > 0 -> Y = pos ; Y = nonpos ),
+                         ( X > 5 -> Z = big ; Z = small ).
+user:lnestite(X, Y)   :- ( X > 0 -> ( X > 10 -> Y = big ; Y = small ) ; Y = neg ).
+
+lua_interpreter(Exe) :-
+    member(Exe, ['lua5.4', 'lua5.3', 'lua', 'luajit']),
+    % Use -e 'os.exit(0)' (not -v): a bare `lua -v` with no script enters
+    % the interactive REPL and blocks reading stdin. Redirect stdin to null
+    % as belt-and-braces.
+    catch(( process_create(path(Exe), ['-e', 'os.exit(0)'],
+                           [stdin(null), stdout(null), stderr(null),
+                            process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail), !.
+
+:- begin_tests(wam_lua_lowered_ite, [condition(lua_interpreter(_))]).
+
+test(ite_exec_parity) :-
+    lua_interpreter(Lua),
+    Dir = 'output/test_wam_lua_ite_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    % 1. Generate the lowered Lua project.
+    write_wam_lua_project(
+        [user:lite/2, user:lneg/1, user:lseqite/3, user:lnestite/2],
+        [module_name('iteproj'), emit_mode(functions)], Dir),
+    % Sanity: the predicates must actually be lowered as native if/else
+    % (not the interpreter fallback), else the test would pass vacuously.
+    atomic_list_concat([Dir, '/lua/generated_program.lua'], ProgPath),
+    read_file_to_string(ProgPath, ProgSrc, []),
+    forall(member(F, ["lowered_lite_2", "lowered_lneg_1",
+                      "lowered_lseqite_3", "lowered_lnestite_2"]),
+           assertion(sub_string(ProgSrc, _, _, _, F))),
+    assertion(sub_string(ProgSrc, _, _, _, "if-then-else / negation / once")),
+    % 2. Write the harness next to the generated module.
+    atomic_list_concat([Dir, '/lua/harness.lua'], HPath),
+    harness_source(Src),
+    setup_call_cleanup(open(HPath, write, S, [encoding(utf8)]),
+                       write(S, Src), close(S)),
+    % 3. Run it.
+    atomic_list_concat([Dir, '/lua'], LuaDir),
+    format(atom(Cmd), 'cd ~w && ~w harness.lua 2>&1', [LuaDir, Lua]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 15 PASS")
+    ->  true
+    ;   format(user_error, "~n[lua ite test output]~n~w~n", [OutStr]),
+        throw(lua_ite_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_lua_lowered_ite).
+
+% Calls each per-predicate module entry. Atoms are built through the shared
+% intern table (Runtime.intern), so the ids match the constants the lowered
+% functions compare against.
+harness_source(
+"package.path = \"./?.lua;\" .. package.path
+local M = require(\"generated_program\")
+local R = M.Runtime
+local function A(s) return M.V.Atom(R.intern(M.program.intern_table, s)) end
+local function I(n) return M.V.Int(n) end
+local fails, total = 0, 0
+local function chk(name, got, want)
+  total = total + 1
+  if got ~= want then
+    fails = fails + 1
+    print(\"FAIL\", name, \"got\", tostring(got), \"want\", tostring(want))
+  end
+end
+chk(\"lite(5,pos)\",     M.lite(I(5),  A(\"pos\")),    true)
+chk(\"lite(5,nonpos)\",  M.lite(I(5),  A(\"nonpos\")), false)
+chk(\"lite(-1,nonpos)\", M.lite(I(-1), A(\"nonpos\")), true)
+chk(\"lite(-1,pos)\",    M.lite(I(-1), A(\"pos\")),    false)
+chk(\"lneg(5)\",  M.lneg(I(5)),  false)
+chk(\"lneg(-1)\", M.lneg(I(-1)), true)
+chk(\"lneg(0)\",  M.lneg(I(0)),  true)
+chk(\"lseqite(10,pos,big)\",      M.lseqite(I(10), A(\"pos\"),    A(\"big\")),   true)
+chk(\"lseqite(10,pos,small)\",    M.lseqite(I(10), A(\"pos\"),    A(\"small\")), false)
+chk(\"lseqite(3,pos,small)\",     M.lseqite(I(3),  A(\"pos\"),    A(\"small\")), true)
+chk(\"lseqite(-1,nonpos,small)\", M.lseqite(I(-1), A(\"nonpos\"), A(\"small\")), true)
+chk(\"lnestite(20,big)\",   M.lnestite(I(20), A(\"big\")),   true)
+chk(\"lnestite(5,small)\",  M.lnestite(I(5),  A(\"small\")), true)
+chk(\"lnestite(-1,neg)\",   M.lnestite(I(-1), A(\"neg\")),   true)
+chk(\"lnestite(20,small)\", M.lnestite(I(20), A(\"small\")), false)
+if fails == 0 then print(\"ALL \" .. total .. \" PASS\") else print(fails .. \" FAILURES\") end
+").


### PR DESCRIPTION
## Summary

Continues the WAM if-then-else / negation / once parity sweep with the **Lua** backend. Two changes — the ITE lowering, plus a **pre-existing compile hang** that lowering exposed.

### 1. if-then-else / negation / once lowering

`( Cond -> Then ; Else )`, `\+ Goal` and `once/1` compile to a `try_me_else` soft-cut block; the lowered emitter declined them (`try_me_else` / `cut_ite` / `jump` / `trust_me` aren't in `parts_supported/1`), so they fell back to the interpreter — sound but not lowered. Clause 1 now folds through the shared `wam_ite_structurer` (a label-preserving term parse maps each line to a structural term or an opaque `line(Parts)` leaf) and emits native Lua if/else:

```lua
do
  local _ite_mark = #state.trail
  local _ite_cond = (function() <cond>; return true end)()
  if _ite_cond then <then>
  else
    while #state.trail > _ite_mark do
      state.bindings[table.remove(state.trail)] = nil end   -- rollback
    <else>
  end
end
```

Lua derefs registers through the binding table and `bind_var` always trails, so undoing the trail to the pre-condition mark before the else restores the condition's partial bindings (no register snapshot — same model as the Rust emitter). Nested ITEs recurse; the `cut_ite` / `!/0` commit is structural. Non-ITE predicates take the unchanged deterministic / multi-clause paths.

### 2. Pre-existing compile hang on nested / multi-segment predicates

While building the test I found `write_wam_lua_project` **hangs** on a nested if-then-else — and it reproduces in plain `interpreter` mode, so it's **independent of the lowering**. Root cause: `lua_inline_fact_tuples/2` (the arity-2 inline-fact optimisation) segments the WAM via `lua_segment_instrs/3`, which builds each item's token list with `wam_item_parts/2` — and `wam_item_parts/2` has a catch-all clause overlapping every specific clause, so each item has multiple solutions. When a segment turns out not to be fact-only (any predicate with a `builtin_call`, i.e. every ITE), the caller backtracks through every item's choicepoint and re-segments — exponential in the segment count. A nested ITE (5 segments) effectively hangs; simple ITE (cite) was fast enough to mask it.

Fixed by committing `wam_item_parts/2` to its first (specific) solution with `once/1`. The segmentation result is unchanged — **inline-fact detection is byte-identical** (verified) — but a non-fact predicate now fails fast instead of backtracking.

(Also: `write_wam_lua_project` opens output files as UTF-8 for POSIX/ASCII-locale CI.)

## Tests

- `tests/test_wam_lua_lowered_ite.pl` — gated on a Lua interpreter (`lua5.4`/`lua5.3`/`lua`/`luajit`); generates a lowered project with simple, sequential, nested ITE and negation and runs them through the per-predicate module entries. **15/15 correct.** Because the project mixes a nested ITE with other ITE predicates, it's also the **regression test for the hang fix**.
- Existing `test_wam_lua_generator` still passes.

## Sweep status

ITE parity now spans **Go, Rust, C++, Haskell, F#, Clojure, LLVM, Elixir, Python, Lua**. Only **r** remains (sound-but-unlowered; `Rscript` isn't installed in this environment).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_