### PR TITLE
LLVM WAM: read_link/2 + symlink/2 (M120)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1560,6 +1560,8 @@ declare i8* @realpath(i8*, i8*)
 declare i32 @kill(i32, i32)
 declare i32 @truncate(i8*, i64)
 declare i32 @chown(i8*, i32, i32)
+declare i64 @readlink(i8*, i8*, i64)
+declare i32 @symlink(i8*, i8*)
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3662,6 +3664,8 @@ entry:
     i32 133, label %builtin_file_base_name
     i32 134, label %builtin_file_directory_name
     i32 135, label %builtin_file_name_extension
+    i32 136, label %builtin_read_link
+    i32 137, label %builtin_symlink
   ]
 
 builtin_is:
@@ -6198,6 +6202,81 @@ fne.join_unify:
   %fne.j_raw3 = call %Value @wam_get_reg(%WamState* %vm, i32 2)
   %fne.j_ok = call i1 @wam_unify_value(%WamState* %vm, %Value %fne.j_raw3, %Value %fne.j_v)
   ret i1 %fne.j_ok
+
+builtin_read_link:
+  ; M120: read_link(+Path, -Target) -- libc readlink wrapper.
+  ; Reads the target of a symbolic link. Path must be Atom. Fails
+  ; if Path is not a symlink (EINVAL), doesn''t exist (ENOENT),
+  ; or any other libc error. Returns the link target as an atom
+  ; (not null-terminated by libc, so we null-terminate ourselves).
+  ; PATH_MAX-sized stack buffer (4096) covers any portable path.
+  %rl.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %rl.t1 = call i32 @value_tag(%Value %rl.a1)
+  %rl.is_atom = icmp eq i32 %rl.t1, 0
+  br i1 %rl.is_atom, label %rl.go, label %rl.fail
+rl.fail:
+  ret i1 false
+rl.go:
+  %rl.aid = call i64 @value_payload(%Value %rl.a1)
+  %rl.path = call i8* @wam_atom_to_string(i64 %rl.aid)
+  %rl.path_null = icmp eq i8* %rl.path, null
+  br i1 %rl.path_null, label %rl.fail, label %rl.do
+rl.do:
+  %rl.buf = alloca [4096 x i8]
+  %rl.buf_ptr = getelementptr [4096 x i8], [4096 x i8]* %rl.buf, i32 0, i32 0
+  %rl.n = call i64 @readlink(i8* %rl.path, i8* %rl.buf_ptr, i64 4096)
+  %rl.ok = icmp sgt i64 %rl.n, -1
+  br i1 %rl.ok, label %rl.intern, label %rl.fail
+rl.intern:
+  ; readlink does NOT null-terminate. n is the byte count actually
+  ; written (clamped at bufsiz). Copy into the arena and add a
+  ; null. n may legitimately be 0 (empty target -- rare but legal).
+  call void @wam_arena_ensure()
+  %rl.bufsize = add i64 %rl.n, 1
+  %rl.arena = call i8* @wam_arena_alloc(i64 %rl.bufsize)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %rl.arena, i8* %rl.buf_ptr, i64 %rl.n, i1 false)
+  %rl.term = getelementptr i8, i8* %rl.arena, i64 %rl.n
+  store i8 0, i8* %rl.term
+  %rl.atom_id = call i64 @wam_intern_atom(i8* %rl.arena, i64 %rl.n)
+  %rl.v0 = insertvalue %Value undef, i32 0, 0
+  %rl.v = insertvalue %Value %rl.v0, i64 %rl.atom_id, 1
+  %rl.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %rl.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %rl.raw2, %Value %rl.v)
+  ret i1 %rl.uok
+
+builtin_symlink:
+  ; M120: symlink(+Target, +LinkPath) -- libc symlink wrapper.
+  ; Creates LinkPath as a symbolic link pointing to Target.
+  ; Both args must be Atom; any non-atom fails the type guard.
+  ; Succeeds iff libc returns 0; EEXIST (LinkPath already exists),
+  ; EACCES, ENOENT (parent dir missing) etc. all map to Prolog fail.
+  ; Target is stored verbatim -- libc does not resolve it; a
+  ; dangling symlink is permitted.
+  %sym.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %sym.t1 = call i32 @value_tag(%Value %sym.a1)
+  %sym.is_atom1 = icmp eq i32 %sym.t1, 0
+  br i1 %sym.is_atom1, label %sym.check2, label %sym.fail
+sym.fail:
+  ret i1 false
+sym.check2:
+  %sym.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %sym.t2 = call i32 @value_tag(%Value %sym.a2)
+  %sym.is_atom2 = icmp eq i32 %sym.t2, 0
+  br i1 %sym.is_atom2, label %sym.go, label %sym.fail
+sym.go:
+  %sym.tgt_aid = call i64 @value_payload(%Value %sym.a1)
+  %sym.tgt = call i8* @wam_atom_to_string(i64 %sym.tgt_aid)
+  %sym.tgt_null = icmp eq i8* %sym.tgt, null
+  br i1 %sym.tgt_null, label %sym.fail, label %sym.have_tgt
+sym.have_tgt:
+  %sym.lnk_aid = call i64 @value_payload(%Value %sym.a2)
+  %sym.lnk = call i8* @wam_atom_to_string(i64 %sym.lnk_aid)
+  %sym.lnk_null = icmp eq i8* %sym.lnk, null
+  br i1 %sym.lnk_null, label %sym.fail, label %sym.do
+sym.do:
+  %sym.ret = call i32 @symlink(i8* %sym.tgt, i8* %sym.lnk)
+  %sym.ok = icmp eq i32 %sym.ret, 0
+  ret i1 %sym.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -13487,6 +13566,8 @@ builtin_op_to_id('ground/1', 132).            % succeeds iff term has no unbound
 builtin_op_to_id('file_base_name/2', 133).    % basename(1): part after last ''/''.
 builtin_op_to_id('file_directory_name/2', 134). % dirname(1): prefix before last ''/'' (or ''.'').
 builtin_op_to_id('file_name_extension/3', 135). % split/join basename at last ''.'' (basename-scoped).
+builtin_op_to_id('read_link/2', 136).         % libc readlink -- symlink target as atom.
+builtin_op_to_id('symlink/2', 137).           % libc symlink(target, linkpath).
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2236,6 +2236,8 @@ is_builtin_pred(ground, 1).             % ground(+Term) -- true iff no unbound v
 is_builtin_pred(file_base_name, 2).     % file_base_name(+Path, -Base).
 is_builtin_pred(file_directory_name, 2).% file_directory_name(+Path, -Dir).
 is_builtin_pred(file_name_extension, 3).% file_name_extension(?Base, ?Ext, ?File).
+is_builtin_pred(read_link, 2).          % read_link(+Path, -Target) -- libc readlink.
+is_builtin_pred(symlink, 2).            % symlink(+Target, +LinkPath) -- libc symlink.
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2707,6 +2707,61 @@ test_fne_insufficient(_, R) :-
     % All vars: insufficient instantiation, fails.
     ( file_name_extension(_, _, _) -> R is 0 ; R is 1 ).   % 1
 
+% M120: read_link/2 + symlink/2 -- libc symlink ops.
+
+:- dynamic test_symlink_create_and_read/2.
+test_symlink_create_and_read(_, R) :-
+    % Clean any leftover, create a symlink, read it back.
+    shell('rm -f /tmp/uw_m120_link', _),
+    symlink('/etc/hostname', '/tmp/uw_m120_link'),
+    read_link('/tmp/uw_m120_link', T),
+    shell('rm -f /tmp/uw_m120_link', _),
+    ( T == '/etc/hostname' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_symlink_dangling/2.
+test_symlink_dangling(_, R) :-
+    % Dangling symlink (target doesn''t exist) is legal; libc
+    % stores the path verbatim. read_link still returns the
+    % literal target string.
+    shell('rm -f /tmp/uw_m120_dangling', _),
+    symlink('/this/does/not/exist', '/tmp/uw_m120_dangling'),
+    read_link('/tmp/uw_m120_dangling', T),
+    shell('rm -f /tmp/uw_m120_dangling', _),
+    ( T == '/this/does/not/exist' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_read_link_not_symlink/2.
+test_read_link_not_symlink(_, R) :-
+    % read_link on a regular file fails (EINVAL).
+    shell('touch /tmp/uw_m120_regular', _),
+    ( read_link('/tmp/uw_m120_regular', _) -> Tmp = 0 ; Tmp = 1 ),
+    shell('rm -f /tmp/uw_m120_regular', _),
+    R is Tmp.   % 1
+
+:- dynamic test_read_link_missing/2.
+test_read_link_missing(_, R) :-
+    % read_link on a non-existent path fails (ENOENT).
+    ( read_link('/tmp/uw_m120_never_existed', _) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_symlink_exists_fail/2.
+test_symlink_exists_fail(_, R) :-
+    % Creating a symlink at an already-existing path fails (EEXIST).
+    shell('rm -f /tmp/uw_m120_busy', _),
+    symlink('/etc/hostname', '/tmp/uw_m120_busy'),
+    ( symlink('/another/target', '/tmp/uw_m120_busy') -> Tmp = 0 ; Tmp = 1 ),
+    shell('rm -f /tmp/uw_m120_busy', _),
+    R is Tmp.   % 1
+
+:- dynamic test_read_link_bad_arg/2.
+test_read_link_bad_arg(_, R) :-
+    ( read_link(42, _) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_symlink_bad_arg/2.
+test_symlink_bad_arg(_, R) :-
+    ( symlink(42, '/tmp/x') -> R is 0
+    ; symlink('/etc/hostname', 99) -> R is 0
+    ; R is 1
+    ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -5660,6 +5715,21 @@ test_all :-
                    test_fne_join_check_disagree, 0, 1),
        run_test_r0('all vars fails (insufficient instantiation) -> 1',
                    test_fne_insufficient, 0, 1),
+       format('--- M120 read_link/2 + symlink/2 ---~n'),
+       run_test_r0('symlink + read_link round-trip -> 1',
+                   test_symlink_create_and_read, 0, 1),
+       run_test_r0('dangling symlink read_link -> 1',
+                   test_symlink_dangling, 0, 1),
+       run_test_r0('read_link on regular file fails -> 1',
+                   test_read_link_not_symlink, 0, 1),
+       run_test_r0('read_link on missing path fails -> 1',
+                   test_read_link_missing, 0, 1),
+       run_test_r0('symlink at existing path fails -> 1',
+                   test_symlink_exists_fail, 0, 1),
+       run_test_r0('read_link(42, _) fails -> 1',
+                   test_read_link_bad_arg, 0, 1),
+       run_test_r0('symlink with non-atom args fails -> 1',
+                   test_symlink_bad_arg, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds the libc symlink cluster:

- `read_link/2` (op id 136) — `readlink(2)`, returns target as atom
- `symlink/2` (op id 137) — `symlink(2)`, creates symbolic link

## Implementation

`read_link(+Path, -Target)`:
- Stack `[4096 x i8]` buffer (PATH_MAX), call `readlink`, sign-check return
- `readlink` doesn't null-terminate; we copy `n` bytes into the arena and store the null ourselves
- Intern as atom, unify with reg 1

`symlink(+Target, +LinkPath)`:
- Both args must be Atom (type guards)
- `symlink(target, linkpath)`; success iff `== 0`
- Target stored verbatim — libc doesn't resolve it, dangling symlinks allowed

Both bodies use prefix `sym.` / `rl.` (cannot use `sl.` — collides with M42 `sum_list`).

## libc declarations

```llvm
declare i64 @readlink(i8*, i8*, i64)
declare i32 @symlink(i8*, i8*)
```

## Three-site registration

- Dispatch switch entries 136, 137
- `builtin_op_to_id`
- `is_builtin_pred` in `wam_target.pl`

## Tests

7 execution tests, all PASS:

| Test | What |
|---|---|
| create_and_read | round-trip: `symlink` then `read_link` returns same target |
| dangling | dangling symlink (target doesn't exist) — `read_link` still returns the literal target |
| not_symlink | `read_link` on a regular file → EINVAL → fail |
| missing | `read_link` on non-existent path → ENOENT → fail |
| exists_fail | `symlink` at already-existing path → EEXIST → fail |
| read_link_bad_arg | `read_link(42, _)` fails type guard |
| symlink_bad_arg | `symlink(42, ...)` and `symlink(..., 99)` fail type guards |

### Driver gotcha

The `run_test_r0` driver reads from reg 0 to get `R`. Side effects with output args (e.g. `shell(Cmd, _)`) write to reg 0 with the command atom's id, so any cleanup `shell` call **must come before** the final `R is X` — otherwise the test returns the atom id of the rm command (which is whatever id the atom table happened to assign, e.g. 99).

Two tests originally placed `shell rm` after `R is X` and returned the atom id; fixed by introducing a `Tmp = N` intermediate and binding `R is Tmp` after cleanup.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — libc declarations, dispatch entries, `builtin_read_link`, `builtin_symlink`, op-id table.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred` entries.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 7 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke) ✓
- [x] All 7 M120 tests PASS individually ✓
- [ ] Full suite regression check

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_