### PR TITLE
LLVM WAM: link/2 (M121) -- libc hard link

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1562,6 +1562,7 @@ declare i32 @truncate(i8*, i64)
 declare i32 @chown(i8*, i32, i32)
 declare i64 @readlink(i8*, i8*, i64)
 declare i32 @symlink(i8*, i8*)
+declare i32 @link(i8*, i8*)
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3666,6 +3667,7 @@ entry:
     i32 135, label %builtin_file_name_extension
     i32 136, label %builtin_read_link
     i32 137, label %builtin_symlink
+    i32 138, label %builtin_link
   ]
 
 builtin_is:
@@ -6277,6 +6279,41 @@ sym.do:
   %sym.ret = call i32 @symlink(i8* %sym.tgt, i8* %sym.lnk)
   %sym.ok = icmp eq i32 %sym.ret, 0
   ret i1 %sym.ok
+
+builtin_link:
+  ; M121: link(+OldPath, +NewPath) -- libc link wrapper, creates a
+  ; hard link at NewPath that refers to the same inode as OldPath.
+  ; Both args must be Atom. Succeeds iff libc returns 0; EXDEV
+  ; (cross-device), EEXIST (NewPath already exists), ENOENT
+  ; (OldPath missing or NewPath''s parent missing), EPERM (not
+  ; allowed on this fs) etc. all map to Prolog fail. Unlike
+  ; symlink, OldPath must exist (no dangling-hardlink concept --
+  ; the kernel bumps the inode''s link count immediately).
+  %lnk.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %lnk.t1 = call i32 @value_tag(%Value %lnk.a1)
+  %lnk.is_atom1 = icmp eq i32 %lnk.t1, 0
+  br i1 %lnk.is_atom1, label %lnk.check2, label %lnk.fail
+lnk.fail:
+  ret i1 false
+lnk.check2:
+  %lnk.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %lnk.t2 = call i32 @value_tag(%Value %lnk.a2)
+  %lnk.is_atom2 = icmp eq i32 %lnk.t2, 0
+  br i1 %lnk.is_atom2, label %lnk.go, label %lnk.fail
+lnk.go:
+  %lnk.old_aid = call i64 @value_payload(%Value %lnk.a1)
+  %lnk.old = call i8* @wam_atom_to_string(i64 %lnk.old_aid)
+  %lnk.old_null = icmp eq i8* %lnk.old, null
+  br i1 %lnk.old_null, label %lnk.fail, label %lnk.have_old
+lnk.have_old:
+  %lnk.new_aid = call i64 @value_payload(%Value %lnk.a2)
+  %lnk.new = call i8* @wam_atom_to_string(i64 %lnk.new_aid)
+  %lnk.new_null = icmp eq i8* %lnk.new, null
+  br i1 %lnk.new_null, label %lnk.fail, label %lnk.do
+lnk.do:
+  %lnk.ret = call i32 @link(i8* %lnk.old, i8* %lnk.new)
+  %lnk.ok = icmp eq i32 %lnk.ret, 0
+  ret i1 %lnk.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -13568,6 +13605,7 @@ builtin_op_to_id('file_directory_name/2', 134). % dirname(1): prefix before last
 builtin_op_to_id('file_name_extension/3', 135). % split/join basename at last ''.'' (basename-scoped).
 builtin_op_to_id('read_link/2', 136).         % libc readlink -- symlink target as atom.
 builtin_op_to_id('symlink/2', 137).           % libc symlink(target, linkpath).
+builtin_op_to_id('link/2', 138).              % libc link(old, new) -- hard link.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2238,6 +2238,7 @@ is_builtin_pred(file_directory_name, 2).% file_directory_name(+Path, -Dir).
 is_builtin_pred(file_name_extension, 3).% file_name_extension(?Base, ?Ext, ?File).
 is_builtin_pred(read_link, 2).          % read_link(+Path, -Target) -- libc readlink.
 is_builtin_pred(symlink, 2).            % symlink(+Target, +LinkPath) -- libc symlink.
+is_builtin_pred(link, 2).               % link(+Old, +New) -- libc link (hard link).
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2762,6 +2762,50 @@ test_symlink_bad_arg(_, R) :-
     ; R is 1
     ).   % 1
 
+% M121: link/2 -- libc hard link wrapper.
+
+:- dynamic test_link_create/2.
+test_link_create(_, R) :-
+    % Create a source file via shell, hard-link it via libc link/2,
+    % verify the link exists, clean up.
+    shell('echo hello > /tmp/uw_m121_src', _),
+    shell('rm -f /tmp/uw_m121_link', _),
+    link('/tmp/uw_m121_src', '/tmp/uw_m121_link'),
+    shell('test -f /tmp/uw_m121_link', St),
+    shell('rm -f /tmp/uw_m121_src /tmp/uw_m121_link', _),
+    ( St =:= 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_link_same_inode/2.
+test_link_same_inode(_, R) :-
+    % Hard links share the same inode. Compare via "stat -c %i".
+    shell('echo data > /tmp/uw_m121_orig', _),
+    shell('rm -f /tmp/uw_m121_hard', _),
+    link('/tmp/uw_m121_orig', '/tmp/uw_m121_hard'),
+    shell('test "$(stat -c %i /tmp/uw_m121_orig)" = "$(stat -c %i /tmp/uw_m121_hard)"', St),
+    shell('rm -f /tmp/uw_m121_orig /tmp/uw_m121_hard', _),
+    ( St =:= 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_link_missing_old/2.
+test_link_missing_old(_, R) :-
+    % link from non-existent source fails (ENOENT).
+    ( link('/tmp/uw_m121_never_existed', '/tmp/uw_m121_new') -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_link_exists_new/2.
+test_link_exists_new(_, R) :-
+    % link to a path that already exists fails (EEXIST).
+    shell('echo a > /tmp/uw_m121_a', _),
+    shell('echo b > /tmp/uw_m121_b', _),
+    ( link('/tmp/uw_m121_a', '/tmp/uw_m121_b') -> Tmp = 0 ; Tmp = 1 ),
+    shell('rm -f /tmp/uw_m121_a /tmp/uw_m121_b', _),
+    R is Tmp.   % 1
+
+:- dynamic test_link_bad_arg/2.
+test_link_bad_arg(_, R) :-
+    ( link(42, '/tmp/x') -> R is 0
+    ; link('/etc/hostname', 99) -> R is 0
+    ; R is 1
+    ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -5730,6 +5774,17 @@ test_all :-
                    test_read_link_bad_arg, 0, 1),
        run_test_r0('symlink with non-atom args fails -> 1',
                    test_symlink_bad_arg, 0, 1),
+       format('--- M121 link/2 ---~n'),
+       run_test_r0('link + test -f -> 1',
+                   test_link_create, 0, 1),
+       run_test_r0('hard link shares inode -> 1',
+                   test_link_same_inode, 0, 1),
+       run_test_r0('link from missing path fails -> 1',
+                   test_link_missing_old, 0, 1),
+       run_test_r0('link to existing path fails -> 1',
+                   test_link_exists_new, 0, 1),
+       run_test_r0('link with non-atom args fails -> 1',
+                   test_link_bad_arg, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds `link/2` (op id 138) — libc hard link wrapper. Completes the hard-link / symlink / read_link trio (M120 + M121).

## Implementation

Same atom-as-path + thin libc wrapper pattern as M120's `symlink/2`:

- Both args type-guarded as Atom; non-atom fails.
- Succeeds iff `link()` returns 0; `EXDEV` (cross-device), `EEXIST` (NewPath already exists), `ENOENT` (OldPath missing), `EPERM` (fs disallows) all map to Prolog fail.
- Unlike `symlink`, OldPath **must** exist — the kernel bumps the inode's link count immediately, so there's no dangling-hard-link concept.

Prefix `lnk.` (cannot use `ln.` — collides with `length/2`).

## libc declaration

```llvm
declare i32 @link(i8*, i8*)
```

## Three-site registration

- Dispatch switch entry 138
- `builtin_op_to_id('link/2', 138).`
- `is_builtin_pred(link, 2).`

## Tests

5 execution tests, all PASS:

| Test | What |
|---|---|
| `link_create` | create link + `test -f` confirms the new path exists |
| `link_same_inode` | `stat -c %i` confirms both paths point at the same inode |
| `link_missing_old` | source doesn't exist → ENOENT → fail |
| `link_exists_new` | destination already exists → EEXIST → fail |
| `link_bad_arg` | non-atom args fail type guards |

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — libc declaration, dispatch entry, `builtin_link`, op-id table entry.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 5 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke) ✓
- [x] All 5 M121 tests PASS individually ✓
- [ ] Full suite regression check

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_