### PR TITLE
LLVM WAM: is_absolute_file_name/1 + same_file/2 (M122)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3668,6 +3668,8 @@ entry:
     i32 136, label %builtin_read_link
     i32 137, label %builtin_symlink
     i32 138, label %builtin_link
+    i32 139, label %builtin_is_absolute_file_name
+    i32 140, label %builtin_same_file
   ]
 
 builtin_is:
@@ -6314,6 +6316,84 @@ lnk.do:
   %lnk.ret = call i32 @link(i8* %lnk.old, i8* %lnk.new)
   %lnk.ok = icmp eq i32 %lnk.ret, 0
   ret i1 %lnk.ok
+
+builtin_is_absolute_file_name:
+  ; M122: is_absolute_file_name(+Path) -- true iff Path is an
+  ; absolute path (starts with ''/'' on POSIX). Empty atom is NOT
+  ; absolute. Path must be Atom; non-atom fails the type guard.
+  %iaf.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %iaf.t1 = call i32 @value_tag(%Value %iaf.a1)
+  %iaf.is_atom = icmp eq i32 %iaf.t1, 0
+  br i1 %iaf.is_atom, label %iaf.go, label %iaf.fail
+iaf.fail:
+  ret i1 false
+iaf.go:
+  %iaf.aid = call i64 @value_payload(%Value %iaf.a1)
+  %iaf.path = call i8* @wam_atom_to_string(i64 %iaf.aid)
+  %iaf.path_null = icmp eq i8* %iaf.path, null
+  br i1 %iaf.path_null, label %iaf.fail, label %iaf.read
+iaf.read:
+  %iaf.c0 = load i8, i8* %iaf.path
+  %iaf.eq = icmp eq i8 %iaf.c0, 47
+  ret i1 %iaf.eq
+
+builtin_same_file:
+  ; M122: same_file(+Path1, +Path2) -- true iff both paths refer
+  ; to the same underlying file (same st_dev + st_ino). Hard links
+  ; and following-symlink (libc stat() resolves symlinks) both
+  ; produce same_file = true. Both args must be Atom; either stat
+  ; failing maps to Prolog fail. Linux glibc struct stat: st_dev
+  ; at offset 0, st_ino at offset 8 (both i64), matches what
+  ; M76 size_file/2 + M76 time_file/2 already assume.
+  %samf.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %samf.t1 = call i32 @value_tag(%Value %samf.a1)
+  %samf.is_atom1 = icmp eq i32 %samf.t1, 0
+  br i1 %samf.is_atom1, label %samf.check2, label %samf.fail
+samf.fail:
+  ret i1 false
+samf.check2:
+  %samf.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %samf.t2 = call i32 @value_tag(%Value %samf.a2)
+  %samf.is_atom2 = icmp eq i32 %samf.t2, 0
+  br i1 %samf.is_atom2, label %samf.go, label %samf.fail
+samf.go:
+  %samf.aid1 = call i64 @value_payload(%Value %samf.a1)
+  %samf.path1 = call i8* @wam_atom_to_string(i64 %samf.aid1)
+  %samf.p1_null = icmp eq i8* %samf.path1, null
+  br i1 %samf.p1_null, label %samf.fail, label %samf.have1
+samf.have1:
+  %samf.aid2 = call i64 @value_payload(%Value %samf.a2)
+  %samf.path2 = call i8* @wam_atom_to_string(i64 %samf.aid2)
+  %samf.p2_null = icmp eq i8* %samf.path2, null
+  br i1 %samf.p2_null, label %samf.fail, label %samf.stat1
+samf.stat1:
+  %samf.buf1 = alloca [256 x i8]
+  %samf.buf1_ptr = getelementptr [256 x i8], [256 x i8]* %samf.buf1, i32 0, i32 0
+  %samf.ret1 = call i32 @stat(i8* %samf.path1, i8* %samf.buf1_ptr)
+  %samf.stat1_ok = icmp eq i32 %samf.ret1, 0
+  br i1 %samf.stat1_ok, label %samf.stat2, label %samf.fail
+samf.stat2:
+  %samf.buf2 = alloca [256 x i8]
+  %samf.buf2_ptr = getelementptr [256 x i8], [256 x i8]* %samf.buf2, i32 0, i32 0
+  %samf.ret2 = call i32 @stat(i8* %samf.path2, i8* %samf.buf2_ptr)
+  %samf.stat2_ok = icmp eq i32 %samf.ret2, 0
+  br i1 %samf.stat2_ok, label %samf.read, label %samf.fail
+samf.read:
+  ; st_dev at offset 0, st_ino at offset 8.
+  %samf.dev1_ptr = bitcast i8* %samf.buf1_ptr to i64*
+  %samf.dev1 = load i64, i64* %samf.dev1_ptr
+  %samf.dev2_ptr = bitcast i8* %samf.buf2_ptr to i64*
+  %samf.dev2 = load i64, i64* %samf.dev2_ptr
+  %samf.dev_eq = icmp eq i64 %samf.dev1, %samf.dev2
+  %samf.ino1_pi8 = getelementptr i8, i8* %samf.buf1_ptr, i64 8
+  %samf.ino1_ptr = bitcast i8* %samf.ino1_pi8 to i64*
+  %samf.ino1 = load i64, i64* %samf.ino1_ptr
+  %samf.ino2_pi8 = getelementptr i8, i8* %samf.buf2_ptr, i64 8
+  %samf.ino2_ptr = bitcast i8* %samf.ino2_pi8 to i64*
+  %samf.ino2 = load i64, i64* %samf.ino2_ptr
+  %samf.ino_eq = icmp eq i64 %samf.ino1, %samf.ino2
+  %samf.both = and i1 %samf.dev_eq, %samf.ino_eq
+  ret i1 %samf.both
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -13606,6 +13686,8 @@ builtin_op_to_id('file_name_extension/3', 135). % split/join basename at last ''
 builtin_op_to_id('read_link/2', 136).         % libc readlink -- symlink target as atom.
 builtin_op_to_id('symlink/2', 137).           % libc symlink(target, linkpath).
 builtin_op_to_id('link/2', 138).              % libc link(old, new) -- hard link.
+builtin_op_to_id('is_absolute_file_name/1', 139). % true iff first char is ''/''.
+builtin_op_to_id('same_file/2', 140).         % stat both, compare st_dev + st_ino.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2239,6 +2239,8 @@ is_builtin_pred(file_name_extension, 3).% file_name_extension(?Base, ?Ext, ?File
 is_builtin_pred(read_link, 2).          % read_link(+Path, -Target) -- libc readlink.
 is_builtin_pred(symlink, 2).            % symlink(+Target, +LinkPath) -- libc symlink.
 is_builtin_pred(link, 2).               % link(+Old, +New) -- libc link (hard link).
+is_builtin_pred(is_absolute_file_name, 1). % is_absolute_file_name(+Path).
+is_builtin_pred(same_file, 2).          % same_file(+Path1, +Path2) -- inode equality.
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2806,6 +2806,80 @@ test_link_bad_arg(_, R) :-
     ; R is 1
     ).   % 1
 
+% M122: is_absolute_file_name/1 + same_file/2.
+
+:- dynamic test_iaf_absolute/2.
+test_iaf_absolute(_, R) :-
+    ( is_absolute_file_name('/usr/bin/swipl') -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_iaf_relative/2.
+test_iaf_relative(_, R) :-
+    ( is_absolute_file_name('foo/bar') -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_iaf_root/2.
+test_iaf_root(_, R) :-
+    ( is_absolute_file_name('/') -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_iaf_empty/2.
+test_iaf_empty(_, R) :-
+    ( is_absolute_file_name('') -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_iaf_dot/2.
+test_iaf_dot(_, R) :-
+    ( is_absolute_file_name('./foo') -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_iaf_bad_arg/2.
+test_iaf_bad_arg(_, R) :-
+    ( is_absolute_file_name(42) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_samf_same_path/2.
+test_samf_same_path(_, R) :-
+    % Same path -> same file by tautology.
+    shell('touch /tmp/uw_m122_same', _),
+    ( same_file('/tmp/uw_m122_same', '/tmp/uw_m122_same') -> Tmp = 1 ; Tmp = 0 ),
+    shell('rm -f /tmp/uw_m122_same', _),
+    R is Tmp.   % 1
+
+:- dynamic test_samf_hard_link/2.
+test_samf_hard_link(_, R) :-
+    % Hard link shares inode -> same_file should succeed.
+    shell('echo hi > /tmp/uw_m122_orig', _),
+    shell('rm -f /tmp/uw_m122_hl', _),
+    link('/tmp/uw_m122_orig', '/tmp/uw_m122_hl'),
+    ( same_file('/tmp/uw_m122_orig', '/tmp/uw_m122_hl') -> Tmp = 1 ; Tmp = 0 ),
+    shell('rm -f /tmp/uw_m122_orig /tmp/uw_m122_hl', _),
+    R is Tmp.   % 1
+
+:- dynamic test_samf_symlink/2.
+test_samf_symlink(_, R) :-
+    % stat follows symlinks, so symlink -> target -> same_file = true.
+    shell('echo hi > /tmp/uw_m122_target', _),
+    shell('rm -f /tmp/uw_m122_sym', _),
+    symlink('/tmp/uw_m122_target', '/tmp/uw_m122_sym'),
+    ( same_file('/tmp/uw_m122_target', '/tmp/uw_m122_sym') -> Tmp = 1 ; Tmp = 0 ),
+    shell('rm -f /tmp/uw_m122_target /tmp/uw_m122_sym', _),
+    R is Tmp.   % 1
+
+:- dynamic test_samf_different/2.
+test_samf_different(_, R) :-
+    % Distinct files with distinct inodes -> same_file = false.
+    shell('echo a > /tmp/uw_m122_a', _),
+    shell('echo b > /tmp/uw_m122_b', _),
+    ( same_file('/tmp/uw_m122_a', '/tmp/uw_m122_b') -> Tmp = 0 ; Tmp = 1 ),
+    shell('rm -f /tmp/uw_m122_a /tmp/uw_m122_b', _),
+    R is Tmp.   % 1
+
+:- dynamic test_samf_missing/2.
+test_samf_missing(_, R) :-
+    ( same_file('/tmp/uw_m122_does_not_exist', '/etc/hostname') -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_samf_bad_arg/2.
+test_samf_bad_arg(_, R) :-
+    ( same_file(42, '/tmp/x') -> R is 0
+    ; same_file('/etc/hostname', 99) -> R is 0
+    ; R is 1
+    ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -5785,6 +5859,31 @@ test_all :-
                    test_link_exists_new, 0, 1),
        run_test_r0('link with non-atom args fails -> 1',
                    test_link_bad_arg, 0, 1),
+       format('--- M122 is_absolute_file_name/1 + same_file/2 ---~n'),
+       run_test_r0('is_absolute(/usr/bin/swipl) -> 1',
+                   test_iaf_absolute, 0, 1),
+       run_test_r0('is_absolute(foo/bar) fails -> 1',
+                   test_iaf_relative, 0, 1),
+       run_test_r0('is_absolute(/) -> 1',
+                   test_iaf_root, 0, 1),
+       run_test_r0('is_absolute('''') fails -> 1',
+                   test_iaf_empty, 0, 1),
+       run_test_r0('is_absolute(./foo) fails -> 1',
+                   test_iaf_dot, 0, 1),
+       run_test_r0('is_absolute(42) fails -> 1',
+                   test_iaf_bad_arg, 0, 1),
+       run_test_r0('same_file(P, P) -> 1',
+                   test_samf_same_path, 0, 1),
+       run_test_r0('same_file across hard link -> 1',
+                   test_samf_hard_link, 0, 1),
+       run_test_r0('same_file follows symlink -> 1',
+                   test_samf_symlink, 0, 1),
+       run_test_r0('same_file on distinct files fails -> 1',
+                   test_samf_different, 0, 1),
+       run_test_r0('same_file on missing path fails -> 1',
+                   test_samf_missing, 0, 1),
+       run_test_r0('same_file with non-atom args fails -> 1',
+                   test_samf_bad_arg, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds two filesystem predicates that build on the link/symlink work from M120/M121:

- `is_absolute_file_name/1` (op id 139) — pure first-byte `/` check
- `same_file/2` (op id 140) — `stat()`-based inode equality

## Implementation

### `is_absolute_file_name(+Path)`

Trivial: type-guard atom, read byte 0, compare with `47` (`/`). Empty path is not absolute (the read would null-terminate immediately). ~10 lines of IR.

### `same_file(+Path1, +Path2)`

Two `stat()` calls into stack `[256 x i8]` buffers, then `icmp` on `st_dev` (offset 0) and `st_ino` (offset 8) — both `i64`. Equal iff both match. Either stat failing maps to Prolog fail.

Reuses Linux glibc `struct stat` offsets already assumed by M76 `size_file/2` and `time_file/2`.

Three same-file scenarios all produce true:
- Same path (tautology)
- Hard link via `link/2` (M121) — kernel hands out same inode
- Symlink (libc `stat` follows symlinks, so points at the resolved target)

## Three-site registration

- Dispatch switch entries 139, 140
- `builtin_op_to_id`
- `is_builtin_pred` in `wam_target.pl`

## Tests

12 execution tests, all PASS:

`is_absolute_file_name`:
- `/usr/bin/swipl` → true, `foo/bar` → false, `/` → true, `''` → false, `./foo` → false, `42` (bad arg) → false

`same_file`:
- Same path tautology
- Hard link (uses `link/2` from M121 internally)
- Symlink follow-through
- Distinct files with distinct inodes → false
- Missing path → fail (stat fails)
- Non-atom args → fail (type guard)

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — dispatch entries, `builtin_is_absolute_file_name`, `builtin_same_file`, op-id table.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred` entries.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 12 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke) ✓
- [x] All 12 M122 tests PASS individually ✓
- [ ] Full suite regression check

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_