### PR TITLE
feat(r): lower if-then-else / negation / once; fix lowered env-frame layout

### DIFF
--- a/src/unifyweaver/targets/wam_r_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_r_lowered_emitter.pl
@@ -41,6 +41,7 @@
 :- use_module(library(lists)).
 :- use_module('../core/binding_state_analysis').
 :- use_module('../core/demand_analysis').
+:- use_module(wam_ite_structurer, [structure_ite/2]).
 
 % =====================================================================
 % Emission plan
@@ -88,7 +89,44 @@ skippable_prefix_line(["switch_on_structure"|_]).
 classify_clause_shape([FirstLine|Rest], plan(multi_clause_n, none, Clauses)) :-
     wam_r_target:tokenize_wam_line(FirstLine, ["try_me_else", _AltStr]), !,
     take_multi_clause_lines(Rest, Clauses).
+% Soft-cut block: a single-clause if-then-else / negation / once. Its
+% try_me_else is internal (preceded by the shared head-arg setup), not a
+% clause separator, so the first real instruction is NOT try_me_else and
+% the multi_clause_n clause above does not fire. Fold it through the shared
+% structurer into ite(Cond,Then,Else) terms.
+classify_clause_shape(Lines, plan(ite, none, Structured)) :-
+    r_parse_terms(Lines, Terms),
+    structure_ite(Terms, Structured),
+    member(ite(_, _, _), Structured),
+    \+ member(try_me_else(_), Structured),
+    \+ member(trust_me, Structured),
+    !.
 classify_clause_shape(Lines, plan(deterministic, none, Lines)).
+
+% --- Label-preserving term parse (for the shared structurer) -------------
+% Each WAM line becomes a structural term the structurer understands
+% (try_me_else/trust_me/jump/cut_ite/label and the !/0-commit builtin_call),
+% or an opaque line(Parts) leaf that emit_line_parts/2 renders unchanged.
+r_parse_terms([], []).
+r_parse_terms([Line|Rest], Terms) :-
+    wam_r_target:tokenize_wam_line(Line, Parts),
+    (   Parts == []
+    ->  r_parse_terms(Rest, Terms)
+    ;   Parts = [First|_], sub_string(First, _, 1, 0, ":")
+    ->  sub_string(First, 0, _, 1, LabelName),
+        Terms = [label(LabelName)|More],
+        r_parse_terms(Rest, More)
+    ;   r_line_term(Parts, T),
+        Terms = [T|More],
+        r_parse_terms(Rest, More)
+    ).
+
+r_line_term(["try_me_else", L], try_me_else(L)) :- !.
+r_line_term(["trust_me"], trust_me) :- !.
+r_line_term(["jump", L], jump(L)) :- !.
+r_line_term(["cut_ite"], cut_ite) :- !.
+r_line_term(["builtin_call", Op, Ar], builtin_call(Op, Ar)) :- !.
+r_line_term(Parts, line(Parts)).
 
 % Multi-clause WAM emitted by the shared compiler has the shape:
 %   try_me_else L2, clause1..., L2:, retry_me_else L3, clause2...,
@@ -157,13 +195,27 @@ terminal_clause_parts(["execute", _, _]).
 %  is decided against the emission-plan's clause lines.
 wam_r_lowerable(_PI, WamCode, Reason) :-
     catch(build_emission_plan(WamCode, plan(Mode, _, ClauseData)), _, fail),
-    emission_plan_lines(Mode, ClauseData, Lines),
-    forall(member(Line, Lines), line_supported(Line)),
+    (   Mode == ite
+    ->  forall(member(I, ClauseData), r_struct_supported(I))
+    ;   emission_plan_lines(Mode, ClauseData, Lines),
+        forall(member(Line, Lines), line_supported(Line))
+    ),
     Reason = Mode.
 
 emission_plan_lines(deterministic, Lines, Lines).
 emission_plan_lines(multi_clause_n, Clauses, Lines) :-
     append(Clauses, Lines).
+
+%% r_struct_supported(+StructuredInstr) -- recurse through ite/3; each leaf
+%  must be an instruction emit_struct_r/2 can render.
+r_struct_supported(ite(C, T, E)) :- !,
+    forall(member(I, C), r_struct_supported(I)),
+    forall(member(I, T), r_struct_supported(I)),
+    forall(member(I, E), r_struct_supported(I)).
+r_struct_supported(builtin_call(_, _)) :- !.
+r_struct_supported(line(Parts)) :- !,
+    ( Parts == [] -> true ; parts_supported(Parts) ).
+r_struct_supported(_) :- fail.
 
 line_supported(Line) :-
     wam_r_target:tokenize_wam_line(Line, Parts),
@@ -260,11 +312,61 @@ lower_predicate_to_r(PI, WamCode, Opts,
     (   Mode == deterministic
     ->  emit_deterministic_function(PredName, FuncName, ClauseLines,
                                     ModeHeader, Code)
+    ;   Mode == ite
+    ->  emit_ite_function(PredName, FuncName, ClauseLines, ModeHeader, Code)
     ;   Mode == multi_clause_n
     ->  emit_multi_clause_function(PredName, FuncName, ClauseLines,
                                    ModeHeader, Code)
     ),
     clear_lowered_mode_context.
+
+% If-then-else / negation / once. Same wrapper as the deterministic case,
+% but the body is the structured term list rendered by emit_struct_r/2.
+% R's bind always trails, so undoing the trail to the pre-condition mark
+% before the else branch restores any partial bindings the condition made
+% (no register snapshot needed; mirrors the Rust/Lua emitters). R `{}`
+% blocks do not introduce a scope, so each ite uses a counter-suffixed
+% mark/cond variable to stay safe under nesting and sequencing.
+emit_ite_function(PredName, FuncName, Structured, ModeHeader, Code) :-
+    reset_x_reg_states,
+    b_setval(wam_r_ite_ctr, 0),
+    with_output_to(string(Body), emit_struct_r(Structured, "  ")),
+    format(string(Code),
+'~w# Lowered: ~w  (if-then-else / negation / once)
+~w <- function(program, state) {
+~w  invisible(TRUE)
+}', [ModeHeader, PredName, FuncName, Body]).
+
+fresh_r_ite(N) :-
+    ( catch(b_getval(wam_r_ite_ctr, N0), _, N0 = 0) -> true ; N0 = 0 ),
+    N is N0 + 1,
+    b_setval(wam_r_ite_ctr, N).
+
+emit_struct_r([], _).
+emit_struct_r([Item|Rest], Ind) :-
+    emit_struct_item_r(Item, Ind),
+    emit_struct_r(Rest, Ind).
+
+emit_struct_item_r(ite(Cond, Then, Else), Ind) :- !,
+    fresh_r_ite(N),
+    string_concat(Ind, "  ", I2),
+    format("~w{~n", [Ind]),
+    format("~w  ite_mark_~w <- length(state$trail)~n", [Ind, N]),
+    format("~w  ite_cond_~w <- (function() {~n", [Ind, N]),
+    emit_struct_r(Cond, I2),
+    format("~w    TRUE~n", [Ind]),
+    format("~w  })()~n", [Ind]),
+    format("~w  if (isTRUE(ite_cond_~w)) {~n", [Ind, N]),
+    emit_struct_r(Then, I2),
+    format("~w  } else {~n", [Ind]),
+    format("~w    WamRuntime$undo_trail_to(state, ite_mark_~w)~n", [Ind, N]),
+    emit_struct_r(Else, I2),
+    format("~w  }~n", [Ind]),
+    format("~w}~n", [Ind]).
+emit_struct_item_r(builtin_call(Op, Ar), Ind) :- !,
+    emit_line_parts(["builtin_call", Op, Ar], Ind).
+emit_struct_item_r(line(Parts), Ind) :- !,
+    emit_line_parts(Parts, Ind).
 
 %% set_lowered_mode_context(+Records, +Opts) is det.
 %  Stashes clause 1's `:- mode/1` declaration on a non-backtrackable
@@ -601,10 +703,20 @@ emit_line_parts(["execute", Pred, ArityStr], I) :- !,
 % heap-build state machine, no deref, no unify. The R generated for
 % them is the same code WamRuntime$step would have run, just inline.
 
+% allocate / deallocate must mirror the interpreter's frame layout: Y
+% registers (idx >= 201) live in the frame's `ys` environment, which
+% WamRuntime$put_reg/get_reg read/write, and cut consults `cps_barrier`.
+% The previous emit used a `locals` field with no `ys`, so any lowered
+% predicate with an environment frame (every if-then-else, and any
+% deterministic clause with permanent vars) crashed on the first Y-register
+% access. Deallocate retains the popped frame as `shadow_frame` so a Y read
+% after deallocate (the SWI emit's Call;Deallocate;PutValue Y_n;... shape)
+% still sees the body's writes — matching the interpreter's Deallocate.
 emit_line_parts(["allocate"], I) :- !,
-    format("~wstate$stack <- c(state$stack, list(list(cp = state$cp, locals = new.env(parent = emptyenv()))))~n", [I]).
+    format("~wstate$stack <- c(state$stack, list(list(cp = state$cp, ys = new.env(parent = emptyenv(), hash = TRUE), cps_barrier = state$pending_call_barrier)))~n", [I]),
+    format("~wstate$shadow_frame <- NULL~n", [I]).
 emit_line_parts(["deallocate"], I) :- !,
-    format("~w{ n_ <- length(state$stack); if (n_ > 0L) { state$cp <- state$stack[[n_]]$cp; state$stack <- state$stack[-n_] } }~n", [I]).
+    format("~w{ n_ <- length(state$stack); if (n_ > 0L) { frame_ <- state$stack[[n_]]; state$cp <- frame_$cp; state$shadow_frame <- frame_; state$stack <- state$stack[-n_] } }~n", [I]).
 emit_line_parts(["put_constant", CStr, RegStr], I) :- !,
     wam_r_target:reg_to_int(RegStr, RegIdx),
     wam_r_target:constant_to_r_term(CStr, CTerm),

--- a/src/unifyweaver/targets/wam_r_target.pl
+++ b/src/unifyweaver/targets/wam_r_target.pl
@@ -2010,8 +2010,12 @@ r_predicate_clause(Name/Arity, Head, Body) :-
 % ============================================================================
 
 write_file(Path, Content) :-
+    % UTF-8 so the runtime/generated sources (which contain non-ASCII
+    % characters) write correctly regardless of the process locale
+    % (POSIX/ASCII in many CI containers); otherwise write/2 raises an
+    % encoding error.
     setup_call_cleanup(
-        open(Path, write, Stream),
+        open(Path, write, Stream, [encoding(utf8)]),
         write(Stream, Content),
         close(Stream)
     ).

--- a/tests/test_wam_r_lowered_ite.pl
+++ b/tests/test_wam_r_lowered_ite.pl
@@ -1,0 +1,127 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% test_wam_r_lowered_ite.pl
+%
+% End-to-end execution test for WAM-R if-then-else / negation / once
+% lowering (emit_mode(functions)). Final backend of the lowered-ITE parity
+% sweep; counterpart to the Go / Rust / C++ / Haskell / F# / Clojure / LLVM
+% / Elixir / Python / Lua exec tests. Pins:
+%
+%   * simple ITE         — rite/2;
+%   * negation (\+)       — rneg/1 (commit is the !/0 builtin: then = fail/0,
+%                          else = true/0, run after a trail rollback);
+%   * sequential ITEs    — rseqite/3 (two sibling blocks);
+%   * nested ITEs         — rnestite/2 (inner block in the then-arm).
+%
+% R previously declined any predicate whose lowered body contained the
+% soft-cut block's try_me_else / cut_ite / jump / trust_me (not in
+% parts_supported/1), so such predicates fell back to the WAM interpreter —
+% sound but not lowered. Folding clause 1 through wam_ite_structurer emits
+% native R if/else. R's bind always trails, so undoing the trail to the
+% pre-condition mark before the else branch restores the condition's
+% bindings (WamRuntime$undo_trail_to).
+%
+% This also guards a prerequisite fix: the lowered `allocate` emit created
+% the call frame with a `locals` field instead of the `ys` environment that
+% WamRuntime$put_reg/get_reg use for Y registers, so any lowered predicate
+% with an environment frame (every ITE here) crashed on the first
+% Y-register access. Now it mirrors the interpreter's frame (ys +
+% cps_barrier), and deallocate retains the popped frame as shadow_frame.
+%
+% Generates a lowered R project and calls the per-predicate entry points
+% (pred_rite, pred_rneg, ...) asserting the boolean outcome. Skipped unless
+% `Rscript` is on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module(library(process)).
+:- use_module('../src/unifyweaver/targets/wam_r_target').
+
+:- dynamic user:rite/2.
+:- dynamic user:rneg/1.
+:- dynamic user:rseqite/3.
+:- dynamic user:rnestite/2.
+
+user:rite(X, Y)       :- ( X > 0 -> Y = pos ; Y = nonpos ).
+user:rneg(X)          :- \+ X > 0.
+user:rseqite(X, Y, Z) :- ( X > 0 -> Y = pos ; Y = nonpos ),
+                         ( X > 5 -> Z = big ; Z = small ).
+user:rnestite(X, Y)   :- ( X > 0 -> ( X > 10 -> Y = big ; Y = small ) ; Y = neg ).
+
+rscript_available :-
+    catch(( process_create(path('Rscript'), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_r_lowered_ite, [condition(rscript_available)]).
+
+test(ite_exec_parity) :-
+    Dir = 'output/test_wam_r_ite_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    % 1. Generate the lowered R project.
+    write_wam_r_project(
+        [user:rite/2, user:rneg/1, user:rseqite/3, user:rnestite/2],
+        [module_name('iteproj'), emit_mode(functions)], Dir),
+    % Sanity: predicates must be lowered as native if/else (not the
+    % interpreter fallback), else the test would pass vacuously.
+    atomic_list_concat([Dir, '/R/generated_program.R'], ProgPath),
+    read_file_to_string(ProgPath, ProgSrc, []),
+    forall(member(F, ["lowered_rite_2", "lowered_rneg_1",
+                      "lowered_rseqite_3", "lowered_rnestite_2"]),
+           assertion(sub_string(ProgSrc, _, _, _, F))),
+    assertion(sub_string(ProgSrc, _, _, _, "if-then-else / negation / once")),
+    % 2. Write the harness next to the generated module.
+    atomic_list_concat([Dir, '/R/harness.R'], HPath),
+    harness_source(Src),
+    setup_call_cleanup(open(HPath, write, S, [encoding(utf8)]),
+                       write(S, Src), close(S)),
+    % 3. Run it.
+    atomic_list_concat([Dir, '/R'], RDir),
+    format(atom(Cmd), 'cd ~w && Rscript harness.R 2>&1', [RDir]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 15 PASS")
+    ->  true
+    ;   format(user_error, "~n[r ite test output]~n~w~n", [OutStr]),
+        throw(r_ite_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_r_lowered_ite).
+
+% Sources the generated program (its CLI driver is guarded by
+% sys.nframe() == 0L, so source/1 skips it) and calls each per-predicate
+% entry. Atoms are built through the shared intern table so the ids match
+% the constants the lowered functions compare against.
+harness_source(
+"source(\"generated_program.R\")
+A <- function(s) Atom(WamRuntime$intern(intern_table, s))
+I <- function(n) IntTerm(n)
+fails <- 0L; total <- 0L
+chk <- function(name, got, want) {
+  total <<- total + 1L
+  if (!identical(isTRUE(got), want)) {
+    fails <<- fails + 1L
+    cat(\"FAIL\", name, \"got\", isTRUE(got), \"want\", want, \"\\n\")
+  }
+}
+chk(\"rite(5,pos)\",     pred_rite(I(5),  A(\"pos\")),    TRUE)
+chk(\"rite(5,nonpos)\",  pred_rite(I(5),  A(\"nonpos\")), FALSE)
+chk(\"rite(-1,nonpos)\", pred_rite(I(-1), A(\"nonpos\")), TRUE)
+chk(\"rite(-1,pos)\",    pred_rite(I(-1), A(\"pos\")),    FALSE)
+chk(\"rneg(5)\",  pred_rneg(I(5)),  FALSE)
+chk(\"rneg(-1)\", pred_rneg(I(-1)), TRUE)
+chk(\"rneg(0)\",  pred_rneg(I(0)),  TRUE)
+chk(\"rseqite(10,pos,big)\",      pred_rseqite(I(10), A(\"pos\"),    A(\"big\")),   TRUE)
+chk(\"rseqite(10,pos,small)\",    pred_rseqite(I(10), A(\"pos\"),    A(\"small\")), FALSE)
+chk(\"rseqite(3,pos,small)\",     pred_rseqite(I(3),  A(\"pos\"),    A(\"small\")), TRUE)
+chk(\"rseqite(-1,nonpos,small)\", pred_rseqite(I(-1), A(\"nonpos\"), A(\"small\")), TRUE)
+chk(\"rnestite(20,big)\",   pred_rnestite(I(20), A(\"big\")),   TRUE)
+chk(\"rnestite(5,small)\",  pred_rnestite(I(5),  A(\"small\")), TRUE)
+chk(\"rnestite(-1,neg)\",   pred_rnestite(I(-1), A(\"neg\")),   TRUE)
+chk(\"rnestite(20,small)\", pred_rnestite(I(20), A(\"small\")), FALSE)
+if (fails == 0L) cat(\"ALL\", total, \"PASS\\n\") else cat(fails, \"FAILURES\\n\")
+").


### PR DESCRIPTION
## Summary

**Final backend** of the WAM if-then-else / negation / once lowering parity sweep. Two changes for the WAM-R target.

### 1. if-then-else / negation / once lowering

`( Cond -> Then ; Else )`, `\+ Goal` and `once/1` compile to a `try_me_else` soft-cut block; the lowered emitter declined them (`try_me_else` / `cut_ite` / `jump` / `trust_me` aren't in `parts_supported/1`), so they fell back to the interpreter — sound but not lowered. Clause 1 now folds through the shared `wam_ite_structurer` and emits native R if/else:

```r
{
  ite_mark_N <- length(state$trail)
  ite_cond_N <- (function() { <cond>; TRUE })()
  if (isTRUE(ite_cond_N)) { <then> }
  else {
    WamRuntime$undo_trail_to(state, ite_mark_N)   # roll back cond bindings
    <else>
  }
}
```

R derefs registers through the binding table and `WamRuntime$bind` always trails, so undoing the trail to the pre-condition mark before the else restores the condition's partial bindings (no register snapshot — same model as the Rust/Lua emitters). R `{}` blocks don't introduce a scope, so each ite uses a counter-suffixed `mark`/`cond` variable to stay safe under nesting/sequencing. Nested ITEs recurse; the `cut_ite`/`!/0` commit is structural.

### 2. Pre-existing lowered env-frame layout bug

The interpreter's `Allocate` builds a call frame with a `ys` environment (where `WamRuntime$put_reg`/`get_reg` store Y registers, idx ≥ 201) plus a `cps_barrier` for cut. The lowered `allocate` emit instead created a `locals` field with **no `ys`**, so any lowered predicate with an environment frame (every if-then-else, and any deterministic clause with permanent variables) crashed on the first Y-register access (`use of NULL environment is defunct`). The lowered `allocate` now mirrors the interpreter's frame and clears `shadow_frame`; `deallocate` retains the popped frame as `shadow_frame` so a Y read after deallocate still sees the body's writes. This was latent because no lowered-with-frame predicate was exercised end-to-end before — it's independent of the lowering above, and necessary for it.

(Also: `write_wam_r_project` opens output files as UTF-8 for POSIX/ASCII-locale CI.)

## Tests

- `tests/test_wam_r_lowered_ite.pl` — gated on `Rscript`; generates a lowered project with simple, sequential, nested ITE and negation and runs them through the per-predicate entries. **15/15 correct.**
- `test_r_target` still passes; non-ITE no-frame predicates emit byte-identical R (verified).
- `test_wam_r_generator`'s `*_e2e_rscript` failures (bagof/setof, catch/throw, DCG, enumerable builtins, fact ranges) are **pre-existing** — they fail identically on main, are unrelated to if-then-else, and only become visible once `Rscript` is installed (they're gated on `rscript_available`, so they were dormant in CI).

## Sweep complete 🎉

ITE / negation / once lowering now spans **all eleven** lowered backends: **Go, Rust, C++, Haskell, F#, Clojure, LLVM, Elixir, Python, Lua, R**.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_