### PR TITLE
feat(wam-clojure): lower intersection/3 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -428,6 +428,10 @@ clojure_direct_builtin("subtract/3", "3").
 clojure_direct_builtin("subtract/3", 3).
 clojure_direct_builtin('subtract/3', "3").
 clojure_direct_builtin('subtract/3', 3).
+clojure_direct_builtin("intersection/3", "3").
+clojure_direct_builtin("intersection/3", 3).
+clojure_direct_builtin('intersection/3', "3").
+clojure_direct_builtin('intersection/3', 3).
 clojure_direct_builtin("list_to_set/2", "2").
 clojure_direct_builtin("list_to_set/2", 2).
 clojure_direct_builtin('list_to_set/2', "2").
@@ -855,6 +859,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "subtract/3" ; Op == 'subtract/3'),
     !,
     format(atom(Expr), '(runtime/apply-subtract-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "intersection/3" ; Op == 'intersection/3'),
+    !,
+    format(atom(Expr), '(runtime/apply-intersection-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "list_to_set/2" ; Op == 'list_to_set/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1222,6 +1222,29 @@
           (backtrack state)))
       (backtrack state))))
 
+(defn list-intersection-items [state left right]
+  (filter (fn [item]
+            (some #(term-identical? state item %) right))
+          left))
+
+(defn apply-intersection-solution [state]
+  (let [left-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        right-value (deref-value (:bindings state)
+                                 (or (reg-get-raw state "A2") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A3") ::unbound))
+        left-items (proper-list-items state left-value)
+        right-items (proper-list-items state right-value)]
+    (if (and (some? left-items) (some? right-items))
+      (let [result-term (list->term (:intern-context state)
+                                    (list-intersection-items state left-items right-items))
+            [ok next-state] (unify-values state out result-term)]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+      (backtrack state))))
+
 (defn list-to-set-items [state items]
   (reduce (fn [out item]
             (if (some #(term-identical? state % item) out)
@@ -2675,6 +2698,9 @@
 
           "subtract/3"
           (apply-subtract-solution state)
+
+          "intersection/3"
+          (apply-intersection-solution state)
 
           "list_to_set/2"
           (apply-list-to-set-solution state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -130,6 +130,11 @@
 :- dynamic user:wam_subtract_duplicates/0.
 :- dynamic user:wam_subtract_bad_left/1.
 :- dynamic user:wam_subtract_bad_right/1.
+:- dynamic user:wam_intersection_guard/3.
+:- dynamic user:wam_intersection_empty_left/0.
+:- dynamic user:wam_intersection_duplicates/0.
+:- dynamic user:wam_intersection_bad_left/1.
+:- dynamic user:wam_intersection_bad_right/1.
 :- dynamic user:wam_list_to_set_guard/2.
 :- dynamic user:wam_list_to_set_empty/0.
 :- dynamic user:wam_list_to_set_singleton/0.
@@ -466,6 +471,11 @@ user:wam_subtract_empty_left :- subtract([], [a], Diff), Diff = [].
 user:wam_subtract_duplicates :- subtract([a,a,b,c], [b], Diff), Diff = [a,a,c].
 user:wam_subtract_bad_left(_) :- subtract([a|b], [a], _).
 user:wam_subtract_bad_right(_) :- subtract([a], [a|b], _).
+user:wam_intersection_guard(Left, Right, Common) :- intersection(Left, Right, Common).
+user:wam_intersection_empty_left :- intersection([], [a], Common), Common = [].
+user:wam_intersection_duplicates :- intersection([a,a,b,c], [a,c], Common), Common = [a,a,c].
+user:wam_intersection_bad_left(_) :- intersection([a|b], [a], _).
+user:wam_intersection_bad_right(_) :- intersection([a], [a|b], _).
 user:wam_list_to_set_guard(List, Set) :- list_to_set(List, Set).
 user:wam_list_to_set_empty :- list_to_set([], Set), Set = [].
 user:wam_list_to_set_singleton :- list_to_set([x], Set), Set = [x].
@@ -807,6 +817,11 @@ run_smoke :-
           user:wam_subtract_duplicates/0,
           user:wam_subtract_bad_left/1,
           user:wam_subtract_bad_right/1,
+          user:wam_intersection_guard/3,
+          user:wam_intersection_empty_left/0,
+          user:wam_intersection_duplicates/0,
+          user:wam_intersection_bad_left/1,
+          user:wam_intersection_bad_right/1,
           user:wam_list_to_set_guard/2,
           user:wam_list_to_set_empty/0,
           user:wam_list_to_set_singleton/0,
@@ -1054,6 +1069,7 @@ run_smoke :-
     assert_lowered_numlist_builtin_emitted(TmpDir),
     assert_lowered_delete_builtin_emitted(TmpDir),
     assert_lowered_subtract_builtin_emitted(TmpDir),
+    assert_lowered_intersection_builtin_emitted(TmpDir),
     assert_lowered_list_to_set_builtin_emitted(TmpDir),
     assert_lowered_sort_builtin_emitted(TmpDir),
     assert_lowered_msort_builtin_emitted(TmpDir),
@@ -1299,6 +1315,12 @@ smoke_cases([
     case('wam_subtract_duplicates/0', no_args, "true"),
     case('wam_subtract_bad_left/1', a, "false"),
     case('wam_subtract_bad_right/1', a, "false"),
+    case('wam_intersection_guard/3', args('[a,b,c]', '[a,c]', '[a,c]'), "true"),
+    case('wam_intersection_guard/3', args('[a,b,c]', '[a,c]', '[a,b]'), "false"),
+    case('wam_intersection_empty_left/0', no_args, "true"),
+    case('wam_intersection_duplicates/0', no_args, "true"),
+    case('wam_intersection_bad_left/1', a, "false"),
+    case('wam_intersection_bad_right/1', a, "false"),
     case('wam_list_to_set_guard/2', args('[a,b,c,a,b,d,a]', '[a,b,c,d]'), "true"),
     case('wam_list_to_set_guard/2', args('[a,b,c,a,b,d,a]', '[a,b,c,a]'), "false"),
     case('wam_list_to_set_empty/0', no_args, "true"),
@@ -1822,6 +1844,15 @@ assert_lowered_subtract_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-subtract-bad-left-1"),
     has(CoreCode, "defn lowered-wam-subtract-bad-right-1"),
     has(CoreCode, "runtime/apply-subtract-solution").
+
+assert_lowered_intersection_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-intersection-guard-3"),
+    has(CoreCode, "defn lowered-wam-intersection-duplicates-0"),
+    has(CoreCode, "defn lowered-wam-intersection-bad-left-1"),
+    has(CoreCode, "defn lowered-wam-intersection-bad-right-1"),
+    has(CoreCode, "runtime/apply-intersection-solution").
 
 assert_lowered_list_to_set_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM direct-lowered support for `intersection/3`.
- Implements the runtime helper for deterministic list intersection.
- Extends the Clojure runtime smoke fixture with success, mismatch, empty-left, duplicate-preservation, and malformed-list cases.

## Why

This continues Clojure WAM list/set builtin parity after `list_to_set/2` and `subtract/3`. Go and LLVM already cover the `subtract/3`, `intersection/3`, `union/3`, and `list_to_set/2` family; this PR adds the next adjacent Clojure runtime piece.

## Behavior

- Requires both input lists to be proper bound lists.
- Preserves left-list order.
- Preserves duplicates from the left list when the value matches an item in the right list.
- Fails deterministically for malformed input lists or output unification mismatch.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
