### PR TITLE
LLVM WAM: umask/2 + monotonic_time/1 (M124)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1566,6 +1566,7 @@ declare i32 @link(i8*, i8*)
 declare i32 @mkstemp(i8*)
 declare i32 @mkfifo(i8*, i32)
 declare i32 @close(i32)
+declare i32 @umask(i32)
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3675,6 +3676,8 @@ entry:
     i32 140, label %builtin_same_file
     i32 141, label %builtin_tmp_file
     i32 142, label %builtin_mkfifo
+    i32 143, label %builtin_umask
+    i32 144, label %builtin_monotonic_time
   ]
 
 builtin_is:
@@ -6508,6 +6511,59 @@ mkf.do:
   %mkf.ret = call i32 @mkfifo(i8* %mkf.path, i32 %mkf.mode)
   %mkf.ok = icmp eq i32 %mkf.ret, 0
   ret i1 %mkf.ok
+
+builtin_umask:
+  ; M124: umask(?Old, +New) -- libc umask wrapper. Sets the
+  ; process file-creation mask to New and unifies Old with the
+  ; previous mask. New must be Integer (the permission bits to
+  ; mask out, e.g. 0o022 means group/other writes are masked).
+  ; To READ the umask without changing it: umask(Old, Old) --
+  ; libc has no read-only call so we set-and-restore would be
+  ; needed, but unifying Old with itself after the libc call
+  ; gives the same effect when New equals the previous value.
+  ; Non-int New fails the type guard.
+  %um.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %um.t2 = call i32 @value_tag(%Value %um.a2)
+  %um.is_int = icmp eq i32 %um.t2, 1
+  br i1 %um.is_int, label %um.go, label %um.fail
+um.fail:
+  ret i1 false
+um.go:
+  %um.new64 = call i64 @value_payload(%Value %um.a2)
+  %um.new = trunc i64 %um.new64 to i32
+  %um.prev = call i32 @umask(i32 %um.new)
+  %um.prev64 = zext i32 %um.prev to i64
+  %um.v = call %Value @value_integer(i64 %um.prev64)
+  %um.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %um.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %um.raw1, %Value %um.v)
+  ret i1 %um.ok
+
+builtin_monotonic_time:
+  ; M124: monotonic_time(?Time) -- monotonically increasing seconds
+  ; since an unspecified epoch (typically boot) as Float, via
+  ; clock_gettime(CLOCK_MONOTONIC, &ts). Unlike get_time/1
+  ; (CLOCK_REALTIME), this is immune to wall-clock adjustments
+  ; (NTP slew, daylight saving, manual settimeofday) -- ideal
+  ; for measuring elapsed time. CLOCK_MONOTONIC numeric value 1
+  ; on Linux. Same struct timespec layout as get_time.
+  %mt.ts_buf = alloca [16 x i8]
+  %mt.ts_ptr = getelementptr [16 x i8], [16 x i8]* %mt.ts_buf, i32 0, i32 0
+  %mt.cg_ret = call i32 @clock_gettime(i32 1, i8* %mt.ts_ptr)
+  %mt.sec_ptr = bitcast i8* %mt.ts_ptr to i64*
+  %mt.sec = load i64, i64* %mt.sec_ptr
+  %mt.nsec_ptr_i8 = getelementptr i8, i8* %mt.ts_ptr, i64 8
+  %mt.nsec_ptr = bitcast i8* %mt.nsec_ptr_i8 to i64*
+  %mt.nsec = load i64, i64* %mt.nsec_ptr
+  %mt.sec_d = sitofp i64 %mt.sec to double
+  %mt.nsec_d = sitofp i64 %mt.nsec to double
+  %mt.frac = fdiv double %mt.nsec_d, 1.000000e+09
+  %mt.t_d = fadd double %mt.sec_d, %mt.frac
+  %mt.t_bits = bitcast double %mt.t_d to i64
+  %mt.v0 = insertvalue %Value undef, i32 2, 0
+  %mt.v = insertvalue %Value %mt.v0, i64 %mt.t_bits, 1
+  %mt.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %mt.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %mt.raw1, %Value %mt.v)
+  ret i1 %mt.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -13804,6 +13860,8 @@ builtin_op_to_id('is_absolute_file_name/1', 139). % true iff first char is ''/''
 builtin_op_to_id('same_file/2', 140).         % stat both, compare st_dev + st_ino.
 builtin_op_to_id('tmp_file/2', 141).          % mkstemp-based race-free temp file.
 builtin_op_to_id('mkfifo/2', 142).            % libc mkfifo(path, mode).
+builtin_op_to_id('umask/2', 143).             % libc umask(?Old, +New).
+builtin_op_to_id('monotonic_time/1', 144).    % clock_gettime(CLOCK_MONOTONIC) as Float.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2243,6 +2243,8 @@ is_builtin_pred(is_absolute_file_name, 1). % is_absolute_file_name(+Path).
 is_builtin_pred(same_file, 2).          % same_file(+Path1, +Path2) -- inode equality.
 is_builtin_pred(tmp_file, 2).           % tmp_file(+Base, -Path) -- mkstemp-based.
 is_builtin_pred(mkfifo, 2).             % mkfifo(+Path, +Mode) -- create named pipe.
+is_builtin_pred(umask, 2).              % umask(?Old, +New) -- libc umask.
+is_builtin_pred(monotonic_time, 1).     % monotonic_time(-Seconds) -- CLOCK_MONOTONIC.
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2942,6 +2942,54 @@ test_mkfifo_bad_path(_, R) :-
 test_mkfifo_bad_mode(_, R) :-
     ( mkfifo('/tmp/uw_m123_bm', not_int) -> R is 0 ; R is 1 ).   % 1
 
+% M124: umask/2 + monotonic_time/1.
+
+:- dynamic test_umask_set_and_restore/2.
+test_umask_set_and_restore(_, R) :-
+    % Set umask to 0o077, capture old value; immediately restore.
+    umask(Old, 0o077),
+    umask(_, Old),
+    % Old should be a non-negative integer.
+    ( integer(Old), Old >= 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_umask_round_trip/2.
+test_umask_round_trip(_, R) :-
+    % Set umask to a known value, read it back, restore original.
+    umask(Save, 0o022),
+    umask(Read, 0o022),
+    umask(_, Save),
+    % After setting to 0o022, the next umask should read 0o022.
+    ( Read =:= 0o022 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_umask_bad_new/2.
+test_umask_bad_new(_, R) :-
+    ( umask(_, not_int) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_monotonic_nonneg/2.
+test_monotonic_nonneg(_, R) :-
+    monotonic_time(T),
+    ( T >= 0.0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_monotonic_advances/2.
+test_monotonic_advances(_, R) :-
+    % Two calls with a tiny sleep between -- the second must be
+    % strictly greater than (or equal to) the first; CLOCK_MONOTONIC
+    % never goes backwards.
+    monotonic_time(T0),
+    sleep(0.01),
+    monotonic_time(T1),
+    ( T1 >= T0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_monotonic_elapsed/2.
+test_monotonic_elapsed(_, R) :-
+    % After sleep(0.05), elapsed >= 0.04 -- same floor as M88's
+    % sleep_elapsed_float test.
+    monotonic_time(T0),
+    sleep(0.05),
+    monotonic_time(T1),
+    Diff is T1 - T0,
+    ( Diff >= 0.04 -> R is 1 ; R is 0 ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -5963,6 +6011,19 @@ test_all :-
                    test_mkfifo_bad_path, 0, 1),
        run_test_r0('mkfifo(_, not_int) fails -> 1',
                    test_mkfifo_bad_mode, 0, 1),
+       format('--- M124 umask/2 + monotonic_time/1 ---~n'),
+       run_test_r0('umask set and restore -> 1',
+                   test_umask_set_and_restore, 0, 1),
+       run_test_r0('umask round-trip -> 1',
+                   test_umask_round_trip, 0, 1),
+       run_test_r0('umask(_, not_int) fails -> 1',
+                   test_umask_bad_new, 0, 1),
+       run_test_r0('monotonic_time >= 0 -> 1',
+                   test_monotonic_nonneg, 0, 1),
+       run_test_r0('monotonic_time advances -> 1',
+                   test_monotonic_advances, 0, 1),
+       run_test_r0('monotonic_time elapsed >= 0.04 -> 1',
+                   test_monotonic_elapsed, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds two libc wrappers in different domains — process security and high-precision timing:

- `umask/2` (op id 143) — process file-creation mask
- `monotonic_time/1` (op id 144) — `CLOCK_MONOTONIC` epoch as Float

## `umask(?Old, +New)`

Thin wrapper on libc `umask(int)`. Sets the process file-creation mask to `New` (integer, permission bits) and unifies `Old` with the previous value returned by libc.

`New` is required and must be Integer; non-int fails the type guard. To **read without changing**: call `umask(Old, Old)` after setting once — libc has no read-only API.

## `monotonic_time(?Time)`

Wraps `clock_gettime(CLOCK_MONOTONIC, &ts)`. Same `struct timespec` layout (16 bytes; `tv_sec` + `tv_nsec` as `i64` each) and `tv_sec + tv_nsec/1e9 → Float` assembly as M87 `get_time/1`. `CLOCK_MONOTONIC` has numeric value `1` on Linux.

Unlike `get_time/1` (`CLOCK_REALTIME`), this is **immune to wall-clock adjustments** — NTP slew, manual `settimeofday`, DST transitions. Ideal for measuring elapsed time on long-running processes.

## libc declaration

```llvm
declare i32 @umask(i32)
```

`clock_gettime` was already declared (used by `get_time/1`).

## Three-site registration

- Dispatch switch entries 143, 144
- `builtin_op_to_id`
- `is_builtin_pred` in `wam_target.pl`

## Tests

6 execution tests, all PASS:

`umask`:
- Set then immediately restore — `Old` is a non-negative integer.
- Round-trip — after `umask(_, 0o022)`, next `umask(Read, _)` reads back `0o022`.
- `umask(_, not_int)` fails type guard.

`monotonic_time`:
- Returns `Time >= 0.0` (positive epoch).
- Two calls in sequence: `T1 >= T0` — `CLOCK_MONOTONIC` never goes backwards.
- After `sleep(0.05)`, elapsed `>= 0.04` (same floor as M88 `sleep_elapsed_float` test).

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `umask` declaration, dispatch entries, `builtin_umask`, `builtin_monotonic_time`, op-id table.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred` entries.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 6 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke) ✓
- [x] All 6 M124 tests PASS individually ✓
- [ ] Full suite regression check

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_