### PR TITLE
LLVM WAM: nice/1 + getpriority/1 + setpriority/1 (M125)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1567,6 +1567,9 @@ declare i32 @mkstemp(i8*)
 declare i32 @mkfifo(i8*, i32)
 declare i32 @close(i32)
 declare i32 @umask(i32)
+declare i32 @nice(i32)
+declare i32 @getpriority(i32, i32)
+declare i32 @setpriority(i32, i32, i32)
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3678,6 +3681,9 @@ entry:
     i32 142, label %builtin_mkfifo
     i32 143, label %builtin_umask
     i32 144, label %builtin_monotonic_time
+    i32 145, label %builtin_nice
+    i32 146, label %builtin_getpriority
+    i32 147, label %builtin_setpriority
   ]
 
 builtin_is:
@@ -6564,6 +6570,56 @@ builtin_monotonic_time:
   %mt.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %mt.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %mt.raw1, %Value %mt.v)
   ret i1 %mt.ok
+
+builtin_nice:
+  ; M125: nice(+Inc) -- libc nice wrapper; adjust process priority
+  ; by Inc (positive = lower priority, negative = higher; requires
+  ; privilege for negative). Always succeeds in Prolog regardless
+  ; of libc''s -1-on-error since we can''t distinguish -1-as-prio
+  ; from -1-as-error without errno. Inc must be Integer.
+  %nic.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %nic.t1 = call i32 @value_tag(%Value %nic.a1)
+  %nic.is_int = icmp eq i32 %nic.t1, 1
+  br i1 %nic.is_int, label %nic.go, label %nic.fail
+nic.fail:
+  ret i1 false
+nic.go:
+  %nic.inc64 = call i64 @value_payload(%Value %nic.a1)
+  %nic.inc = trunc i64 %nic.inc64 to i32
+  call i32 @nice(i32 %nic.inc)
+  ret i1 true
+
+builtin_getpriority:
+  ; M125: getpriority(-Prio) -- libc getpriority(PRIO_PROCESS, 0)
+  ; reads the current process'' niceness. PRIO_PROCESS = 0, who = 0
+  ; (self) on Linux. Returns a signed value in [-20, 19]. We
+  ; always succeed; the libc -1-vs-error ambiguity is benign for
+  ; self-read on a live process.
+  %gpr.p = call i32 @getpriority(i32 0, i32 0)
+  %gpr.p64 = sext i32 %gpr.p to i64
+  %gpr.v = call %Value @value_integer(i64 %gpr.p64)
+  %gpr.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %gpr.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %gpr.raw1, %Value %gpr.v)
+  ret i1 %gpr.ok
+
+builtin_setpriority:
+  ; M125: setpriority(+Prio) -- libc setpriority(PRIO_PROCESS, 0,
+  ; Prio) sets the current process'' niceness. Prio must be
+  ; Integer (typically [-20, 19]; clamped by the kernel).
+  ; Succeeds iff libc returns 0; EPERM (raising priority beyond
+  ; RLIMIT_NICE), EACCES, etc. fail.
+  %spr.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %spr.t1 = call i32 @value_tag(%Value %spr.a1)
+  %spr.is_int = icmp eq i32 %spr.t1, 1
+  br i1 %spr.is_int, label %spr.go, label %spr.fail
+spr.fail:
+  ret i1 false
+spr.go:
+  %spr.p64 = call i64 @value_payload(%Value %spr.a1)
+  %spr.p = trunc i64 %spr.p64 to i32
+  %spr.ret = call i32 @setpriority(i32 0, i32 0, i32 %spr.p)
+  %spr.ok = icmp eq i32 %spr.ret, 0
+  ret i1 %spr.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -13862,6 +13918,9 @@ builtin_op_to_id('tmp_file/2', 141).          % mkstemp-based race-free temp fil
 builtin_op_to_id('mkfifo/2', 142).            % libc mkfifo(path, mode).
 builtin_op_to_id('umask/2', 143).             % libc umask(?Old, +New).
 builtin_op_to_id('monotonic_time/1', 144).    % clock_gettime(CLOCK_MONOTONIC) as Float.
+builtin_op_to_id('nice/1', 145).              % libc nice(inc) -- adjust priority.
+builtin_op_to_id('getpriority/1', 146).       % libc getpriority(PRIO_PROCESS, 0).
+builtin_op_to_id('setpriority/1', 147).       % libc setpriority(PRIO_PROCESS, 0, prio).
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2245,6 +2245,9 @@ is_builtin_pred(tmp_file, 2).           % tmp_file(+Base, -Path) -- mkstemp-base
 is_builtin_pred(mkfifo, 2).             % mkfifo(+Path, +Mode) -- create named pipe.
 is_builtin_pred(umask, 2).              % umask(?Old, +New) -- libc umask.
 is_builtin_pred(monotonic_time, 1).     % monotonic_time(-Seconds) -- CLOCK_MONOTONIC.
+is_builtin_pred(nice, 1).               % nice(+Inc) -- adjust process priority.
+is_builtin_pred(getpriority, 1).        % getpriority(-Prio) -- read self priority.
+is_builtin_pred(setpriority, 1).        % setpriority(+Prio) -- set self priority.
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -2990,6 +2990,52 @@ test_monotonic_elapsed(_, R) :-
     Diff is T1 - T0,
     ( Diff >= 0.04 -> R is 1 ; R is 0 ).   % 1
 
+% M125: nice/1 + getpriority/1 + setpriority/1.
+
+:- dynamic test_getpriority_in_range/2.
+test_getpriority_in_range(_, R) :-
+    % Default priority is typically 0; allow [-20, 19] sanity range.
+    getpriority(P),
+    ( integer(P), P >= -20, P =< 19 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_nice_zero/2.
+test_nice_zero(_, R) :-
+    % nice(0) doesn''t change priority. Always succeeds.
+    getpriority(Before),
+    nice(0),
+    getpriority(After),
+    ( Before =:= After -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_nice_positive_raises/2.
+test_nice_positive_raises(_, R) :-
+    % nice(+5) increases the niceness value (lowers priority).
+    % Unprivileged users can ALWAYS go nicer; only root can become
+    % less nice. Restore by setpriority on the way out.
+    getpriority(Before),
+    nice(5),
+    getpriority(After),
+    setpriority(Before),
+    ( After > Before -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_setpriority_roundtrip/2.
+test_setpriority_roundtrip(_, R) :-
+    % Set to a known nice value (must be >= current to avoid EPERM
+    % for unprivileged), confirm getpriority reflects it, restore.
+    getpriority(Before),
+    Target is Before + 3,
+    setpriority(Target),
+    getpriority(Read),
+    setpriority(Before),
+    ( Read =:= Target -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_nice_bad_arg/2.
+test_nice_bad_arg(_, R) :-
+    ( nice(not_int) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_setpriority_bad_arg/2.
+test_setpriority_bad_arg(_, R) :-
+    ( setpriority(not_int) -> R is 0 ; R is 1 ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -6024,6 +6070,19 @@ test_all :-
                    test_monotonic_advances, 0, 1),
        run_test_r0('monotonic_time elapsed >= 0.04 -> 1',
                    test_monotonic_elapsed, 0, 1),
+       format('--- M125 nice/1 + getpriority/1 + setpriority/1 ---~n'),
+       run_test_r0('getpriority in [-20, 19] -> 1',
+                   test_getpriority_in_range, 0, 1),
+       run_test_r0('nice(0) preserves priority -> 1',
+                   test_nice_zero, 0, 1),
+       run_test_r0('nice(+5) raises niceness -> 1',
+                   test_nice_positive_raises, 0, 1),
+       run_test_r0('setpriority round-trip -> 1',
+                   test_setpriority_roundtrip, 0, 1),
+       run_test_r0('nice(not_int) fails -> 1',
+                   test_nice_bad_arg, 0, 1),
+       run_test_r0('setpriority(not_int) fails -> 1',
+                   test_setpriority_bad_arg, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds the process-priority cluster — three libc one-liners that read or adjust the current process's niceness:

- `nice/1` (op id 145) — libc `nice(int)`
- `getpriority/1` (op id 146) — libc `getpriority(PRIO_PROCESS, 0)`
- `setpriority/1` (op id 147) — libc `setpriority(PRIO_PROCESS, 0, prio)`

## Predicates

### `nice(+Inc)`
Adjusts niceness by `Inc`. Positive = lower priority (always allowed); negative = higher priority (requires `CAP_SYS_NICE`). Always succeeds — libc's -1-on-error vs -1-as-priority ambiguity is benign since we don't return the new value.

### `getpriority(-Prio)`
Returns the current niceness in `[-20, 19]` as Integer. Reads with `PRIO_PROCESS=0, who=0` (self). Always succeeds.

### `setpriority(+Prio)`
Sets the current process's niceness to `Prio`. Succeeds iff libc returns 0. `EPERM` (raising priority beyond `RLIMIT_NICE` for unprivileged callers) maps to Prolog fail.

## libc declarations

```llvm
declare i32 @nice(i32)
declare i32 @getpriority(i32, i32)
declare i32 @setpriority(i32, i32, i32)
```

Prefixes `nic.` / `gpr.` / `spr.` (no collisions).

## Three-site registration

- Dispatch switch entries 145, 146, 147
- `builtin_op_to_id`
- `is_builtin_pred` in `wam_target.pl`

## Tests

6 execution tests, all PASS:

- `getpriority` returns Integer in `[-20, 19]`.
- `nice(0)` preserves priority (`Before =:= After`).
- `nice(+5)` increases niceness: `After > Before`.
- `setpriority` round-trip: `setpriority(Before+3)` then `getpriority(Read)` gives `Read =:= Before+3`. Restored at the end.
- `nice(not_int)` fails type guard.
- `setpriority(not_int)` fails type guard.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — libc declarations, dispatch entries, `builtin_nice`, `builtin_getpriority`, `builtin_setpriority`, op-id table.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred` entries.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 6 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke) ✓
- [x] All 6 M125 tests PASS individually ✓
- [ ] Full suite regression check

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_