### PR TITLE
LLVM WAM: getrlimit/2 + setrlimit/2 (M126)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1570,6 +1570,8 @@ declare i32 @umask(i32)
 declare i32 @nice(i32)
 declare i32 @getpriority(i32, i32)
 declare i32 @setpriority(i32, i32, i32)
+declare i32 @getrlimit(i32, i8*)
+declare i32 @setrlimit(i32, i8*)
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3684,6 +3686,8 @@ entry:
     i32 145, label %builtin_nice
     i32 146, label %builtin_getpriority
     i32 147, label %builtin_setpriority
+    i32 148, label %builtin_getrlimit
+    i32 149, label %builtin_setrlimit
   ]
 
 builtin_is:
@@ -6620,6 +6624,77 @@ spr.go:
   %spr.ret = call i32 @setpriority(i32 0, i32 0, i32 %spr.p)
   %spr.ok = icmp eq i32 %spr.ret, 0
   ret i1 %spr.ok
+
+builtin_getrlimit:
+  ; M126: getrlimit(+Resource, -SoftLimit) -- libc getrlimit wrapper.
+  ; Reads the current soft limit for Resource (an Integer naming
+  ; the POSIX rlimit constant: RLIMIT_CPU=0, RLIMIT_FSIZE=1,
+  ; RLIMIT_DATA=2, RLIMIT_STACK=3, RLIMIT_CORE=4). Higher-numbered
+  ; resources (RLIMIT_RSS, RLIMIT_NOFILE, RLIMIT_AS) vary across
+  ; OSes, but 0--4 are POSIX-portable. SoftLimit is the rlim_cur
+  ; field (offset 0, i64). RLIM_INFINITY (typically u64 max)
+  ; passes through unchanged. Fails if Resource is not an Integer
+  ; or libc returns -1 (EINVAL for unknown resource).
+  %grl.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %grl.t1 = call i32 @value_tag(%Value %grl.a1)
+  %grl.is_int = icmp eq i32 %grl.t1, 1
+  br i1 %grl.is_int, label %grl.go, label %grl.fail
+grl.fail:
+  ret i1 false
+grl.go:
+  %grl.res64 = call i64 @value_payload(%Value %grl.a1)
+  %grl.res = trunc i64 %grl.res64 to i32
+  ; struct rlimit on Linux/macOS: { rlim_t rlim_cur; rlim_t rlim_max; }
+  ; with rlim_t = u64. Total 16 bytes.
+  %grl.buf = alloca [16 x i8]
+  %grl.buf_ptr = getelementptr [16 x i8], [16 x i8]* %grl.buf, i32 0, i32 0
+  %grl.ret = call i32 @getrlimit(i32 %grl.res, i8* %grl.buf_ptr)
+  %grl.call_ok = icmp eq i32 %grl.ret, 0
+  br i1 %grl.call_ok, label %grl.read, label %grl.fail
+grl.read:
+  %grl.cur_ptr = bitcast i8* %grl.buf_ptr to i64*
+  %grl.cur = load i64, i64* %grl.cur_ptr
+  %grl.v = call %Value @value_integer(i64 %grl.cur)
+  %grl.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %grl.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %grl.raw2, %Value %grl.v)
+  ret i1 %grl.ok
+
+builtin_setrlimit:
+  ; M126: setrlimit(+Resource, +SoftLimit) -- libc setrlimit wrapper.
+  ; Sets the soft limit for Resource to SoftLimit, leaving the
+  ; hard limit unchanged. Implementation: getrlimit first to
+  ; capture the current hard limit, overwrite rlim_cur with
+  ; SoftLimit, then setrlimit. Both args must be Integer; either
+  ; libc call returning -1 (typically EPERM when raising soft
+  ; above hard for unprivileged callers, or EINVAL for an unknown
+  ; resource) maps to Prolog fail.
+  %srl.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %srl.t1 = call i32 @value_tag(%Value %srl.a1)
+  %srl.is_int1 = icmp eq i32 %srl.t1, 1
+  br i1 %srl.is_int1, label %srl.check2, label %srl.fail
+srl.fail:
+  ret i1 false
+srl.check2:
+  %srl.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %srl.t2 = call i32 @value_tag(%Value %srl.a2)
+  %srl.is_int2 = icmp eq i32 %srl.t2, 1
+  br i1 %srl.is_int2, label %srl.go, label %srl.fail
+srl.go:
+  %srl.res64 = call i64 @value_payload(%Value %srl.a1)
+  %srl.res = trunc i64 %srl.res64 to i32
+  %srl.new = call i64 @value_payload(%Value %srl.a2)
+  %srl.buf = alloca [16 x i8]
+  %srl.buf_ptr = getelementptr [16 x i8], [16 x i8]* %srl.buf, i32 0, i32 0
+  ; Read current to preserve rlim_max.
+  %srl.get = call i32 @getrlimit(i32 %srl.res, i8* %srl.buf_ptr)
+  %srl.get_ok = icmp eq i32 %srl.get, 0
+  br i1 %srl.get_ok, label %srl.write, label %srl.fail
+srl.write:
+  %srl.cur_ptr = bitcast i8* %srl.buf_ptr to i64*
+  store i64 %srl.new, i64* %srl.cur_ptr
+  %srl.set = call i32 @setrlimit(i32 %srl.res, i8* %srl.buf_ptr)
+  %srl.ok = icmp eq i32 %srl.set, 0
+  ret i1 %srl.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -13921,6 +13996,8 @@ builtin_op_to_id('monotonic_time/1', 144).    % clock_gettime(CLOCK_MONOTONIC) a
 builtin_op_to_id('nice/1', 145).              % libc nice(inc) -- adjust priority.
 builtin_op_to_id('getpriority/1', 146).       % libc getpriority(PRIO_PROCESS, 0).
 builtin_op_to_id('setpriority/1', 147).       % libc setpriority(PRIO_PROCESS, 0, prio).
+builtin_op_to_id('getrlimit/2', 148).         % libc getrlimit(Res, &rlim) -- soft limit.
+builtin_op_to_id('setrlimit/2', 149).         % libc setrlimit(Res, &rlim) -- soft limit only.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2248,6 +2248,8 @@ is_builtin_pred(monotonic_time, 1).     % monotonic_time(-Seconds) -- CLOCK_MONO
 is_builtin_pred(nice, 1).               % nice(+Inc) -- adjust process priority.
 is_builtin_pred(getpriority, 1).        % getpriority(-Prio) -- read self priority.
 is_builtin_pred(setpriority, 1).        % setpriority(+Prio) -- set self priority.
+is_builtin_pred(getrlimit, 2).          % getrlimit(+Resource, -SoftLimit).
+is_builtin_pred(setrlimit, 2).          % setrlimit(+Resource, +SoftLimit).
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -3036,6 +3036,61 @@ test_nice_bad_arg(_, R) :-
 test_setpriority_bad_arg(_, R) :-
     ( setpriority(not_int) -> R is 0 ; R is 1 ).   % 1
 
+% M126: getrlimit/2 + setrlimit/2.
+
+:- dynamic test_grl_fsize/2.
+test_grl_fsize(_, R) :-
+    % RLIMIT_FSIZE = 1. Default is usually RLIM_INFINITY, which is
+    % the rlim_t-max sentinel -- (u64)-1 on Linux/macOS, surfaces as
+    % -1 in signed Prolog Integer space. Just sanity-check it's
+    % an Integer; the actual value depends on environment.
+    getrlimit(1, L),
+    ( integer(L) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_grl_core/2.
+test_grl_core(_, R) :-
+    % RLIMIT_CORE = 4. Often 0 (no core dumps) but can also be
+    % RLIM_INFINITY; either is a valid Integer.
+    getrlimit(4, L),
+    ( integer(L) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_srl_round_trip/2.
+test_srl_round_trip(_, R) :-
+    % Set RLIMIT_CORE soft limit to a known value, read back, restore.
+    getrlimit(4, Before),
+    setrlimit(4, 0),
+    getrlimit(4, Read),
+    setrlimit(4, Before),
+    ( Read =:= 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_srl_lower_ok/2.
+test_srl_lower_ok(_, R) :-
+    % Lowering the soft limit is always allowed for unprivileged.
+    getrlimit(1, Before),
+    NewLow is Before - 1,
+    ( NewLow > 0
+    -> ( setrlimit(1, NewLow) -> Set = 1 ; Set = 0 ),
+       setrlimit(1, Before)
+    ;  Set = 1
+    ),
+    R is Set.   % 1
+
+:- dynamic test_grl_bad_resource/2.
+test_grl_bad_resource(_, R) :-
+    % Resource 999 is way out of range -> EINVAL -> fail.
+    ( getrlimit(999, _) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_grl_bad_arg/2.
+test_grl_bad_arg(_, R) :-
+    ( getrlimit(not_int, _) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_srl_bad_args/2.
+test_srl_bad_args(_, R) :-
+    ( setrlimit(not_int, 0) -> R is 0
+    ; setrlimit(1, not_int) -> R is 0
+    ; R is 1
+    ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -6083,6 +6138,21 @@ test_all :-
                    test_nice_bad_arg, 0, 1),
        run_test_r0('setpriority(not_int) fails -> 1',
                    test_setpriority_bad_arg, 0, 1),
+       format('--- M126 getrlimit/2 + setrlimit/2 ---~n'),
+       run_test_r0('getrlimit FSIZE non-negative -> 1',
+                   test_grl_fsize, 0, 1),
+       run_test_r0('getrlimit CORE non-negative -> 1',
+                   test_grl_core, 0, 1),
+       run_test_r0('setrlimit CORE round-trip -> 1',
+                   test_srl_round_trip, 0, 1),
+       run_test_r0('setrlimit lower FSIZE OK -> 1',
+                   test_srl_lower_ok, 0, 1),
+       run_test_r0('getrlimit unknown resource fails -> 1',
+                   test_grl_bad_resource, 0, 1),
+       run_test_r0('getrlimit non-int fails -> 1',
+                   test_grl_bad_arg, 0, 1),
+       run_test_r0('setrlimit non-int args fail -> 1',
+                   test_srl_bad_args, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds POSIX resource-limit accessors as ops 148, 149. Both operate on `rlim_cur` (soft limit); the hard limit `rlim_max` is preserved across `setrlimit` by reading first.

- `getrlimit/2` (op id 148) — `getrlimit(+Resource, -SoftLimit)`
- `setrlimit/2` (op id 149) — `setrlimit(+Resource, +SoftLimit)`

## Resource constants

POSIX-portable values for `Resource`:

| Constant | Value | What |
|---|---|---|
| `RLIMIT_CPU` | 0 | CPU time (seconds) |
| `RLIMIT_FSIZE` | 1 | Max file size (bytes) |
| `RLIMIT_DATA` | 2 | Max data segment size |
| `RLIMIT_STACK` | 3 | Max stack size |
| `RLIMIT_CORE` | 4 | Max core dump size |

Higher-numbered resources (`RLIMIT_RSS`, `RLIMIT_NOFILE`, `RLIMIT_AS`, etc.) vary across OSes.

## Implementation

`struct rlimit { i64 rlim_cur; i64 rlim_max; }` — 16 bytes, same on Linux glibc, BSDs, macOS. Stack `alloca [16 x i8]` covers it.

`setrlimit/2` reads the current rlimit first to preserve the hard limit, then overwrites `rlim_cur` with the new value, then calls libc `setrlimit`.

## RLIM_INFINITY note

`RLIM_INFINITY` on Linux/macOS is `(rlim_t)-1` = `u64-max`, which surfaces in signed Prolog Integer space as `-1`. The tests just check `integer(L)` rather than `L >= 0` to handle this gracefully.

## libc declarations

```llvm
declare i32 @getrlimit(i32, i8*)
declare i32 @setrlimit(i32, i8*)
```

Prefixes `grl.` / `srl.` (no collisions).

## Three-site registration

- Dispatch switch entries 148, 149
- `builtin_op_to_id`
- `is_builtin_pred` in `wam_target.pl`

## Tests

7 execution tests, all PASS:

- `getrlimit(FSIZE)` returns Integer
- `getrlimit(CORE)` returns Integer
- `setrlimit(CORE, 0)` round-trip: reads back as 0, restored at end
- Lowering `RLIMIT_FSIZE` by 1 always succeeds for unprivileged callers
- `getrlimit(999, _)` fails (EINVAL)
- Non-int `Resource` fails type guard (both predicates)
- Non-int `SoftLimit` fails `setrlimit` type guard

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — libc declarations, dispatch entries, `builtin_getrlimit`, `builtin_setrlimit`, op-id table.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred` entries.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 7 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke) ✓
- [x] All 7 M126 tests PASS individually ✓
- [ ] Full suite regression check

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_