### PR TITLE
feat(scala): T5 — lower multi-clause first-argument-constant dispatch as an ->-chain

### DIFF
--- a/src/unifyweaver/targets/wam_clause_chain.pl
+++ b/src/unifyweaver/targets/wam_clause_chain.pl
@@ -1,0 +1,99 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% wam_clause_chain.pl — shared front-end for "multi-clause as an
+% if-then-else chain" lowering (lowering type T5 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md).
+%
+% A multi-clause predicate whose clauses discriminate on a *distinct*
+% first-argument constant —
+%
+%     p(a) :- B1.   p(b) :- B2.   p(c) :- B3.
+%
+% compiles to a try_me_else / retry_me_else / trust_me chain where each
+% clause body opens with `get_constant V, A1`. When the first argument is
+% *bound* at call time this is deterministic first-argument dispatch, and a
+% target can lower it to a native `->`-style cascade:
+%
+%     deref A1;  if unbound -> defer to the interpreter (enumeration);
+%     else if A1 == a then B1  else if A1 == b then B2  else …  else fail
+%
+% This module is the *target-agnostic* front-end: it recognises the shape
+% and returns the discriminator + per-clause remainder. Each target keeps
+% its own back-end (deref / equality / clause-body emit). It deliberately
+% mirrors how wam_ite_structurer.pl is shared across the T2 (if-then-else)
+% back-ends.
+%
+% Soundness contract. The cascade is sound only because:
+%   1. The discriminators are DISTINCT, so at most one clause matches a
+%      bound first argument — the predicate is deterministic in that mode,
+%      so taking the single matching clause is correct for boolean AND
+%      enumeration queries (no solution is dropped).
+%   2. The UNBOUND first-argument case is NOT handled by the cascade (it is
+%      genuinely nondeterministic — every clause would match by binding
+%      A1) and must be deferred to the full interpreter by the caller.
+% Callers therefore emit the cascade behind a bound-check and rely on their
+% existing interpreter fallback for the unbound case.
+
+:- module(wam_clause_chain, [
+    clause_chain/2          % +ParsedInstrs, -chain(Guards)
+]).
+
+:- use_module(library(lists)).
+
+%% clause_chain(+ParsedInstrs, -chain(Guards)) is semidet.
+%
+%  ParsedInstrs is a predicate's instruction list with the choice-point
+%  separators present (try_me_else/retry_me_else/trust_me) and labels /
+%  switch_on_* already dropped — exactly what the per-target flat parsers
+%  produce. Succeeds iff the predicate is a clean distinct-first-argument
+%  constant discrimination of two or more clauses.
+%
+%  Guards is a list of `guard(Discriminator, Remainder)`:
+%    - Discriminator : the first-argument constant token (the V in
+%      `get_constant V, A1`), as produced by the parser (a string/atom).
+%    - Remainder     : the clause body with that leading discriminator
+%      removed (still ending in its `proceed`/terminal).
+clause_chain(ParsedInstrs, chain(Guards)) :-
+    split_clauses(ParsedInstrs, Clauses),
+    Clauses = [_, _ | _],                       % at least two clauses
+    maplist(clause_guard, Clauses, Guards),
+    findall(V, member(guard(V, _), Guards), Discriminators),
+    all_distinct_chain(Discriminators).
+
+%% split_clauses(+Instrs, -Clauses) is semidet.
+%  Split at the choice-point separators into per-clause instruction lists,
+%  dropping the separators. Requires the list to open with try_me_else
+%  (i.e. a genuine multi-clause predicate).
+split_clauses([try_me_else(_) | Rest], Clauses) :- !,
+    split_clauses_(Rest, [], Clauses).
+split_clauses(_, _) :- fail.
+
+split_clauses_([], Acc, [Clause]) :-
+    reverse(Acc, Clause).
+split_clauses_([retry_me_else(_) | Rest], Acc, [Clause | More]) :- !,
+    reverse(Acc, Clause),
+    split_clauses_(Rest, [], More).
+split_clauses_([trust_me | Rest], Acc, [Clause | More]) :- !,
+    reverse(Acc, Clause),
+    split_clauses_(Rest, [], More).
+split_clauses_([I | Rest], Acc, Clauses) :-
+    split_clauses_(Rest, [I | Acc], Clauses).
+
+%% clause_guard(+ClauseInstrs, -guard(V, Remainder)) is semidet.
+%  A lowerable clause opens with `get_constant V, A1`. The shared compiler
+%  emits get_constant for both atom and integer first arguments (e.g.
+%  `get_constant red, A1` and `get_constant 1, A2`), so this single shape
+%  covers flat constant discrimination. get_structure / get_list first
+%  arguments are out of scope — they discriminate on a functor, not a flat
+%  constant. Anything else fails the whole chain, so the predicate falls
+%  back to the caller's default path.
+clause_guard([get_constant(V, A1) | Remainder], guard(V, Remainder)) :-
+    is_first_arg_reg(A1).
+
+is_first_arg_reg(A1) :- ( A1 == "A1" ; A1 == 'A1' ; A1 == a1 ), !.
+
+%% all_distinct_chain(+List) is semidet.  No two elements are == equal.
+all_distinct_chain(List) :-
+    \+ ( append(_, [X | Rest], List), member(Y, Rest), X == Y ).

--- a/src/unifyweaver/targets/wam_scala_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_scala_lowered_emitter.pl
@@ -55,6 +55,7 @@
 
 :- use_module(library(lists)).
 :- use_module(wam_ite_structurer, [structure_ite/2, split_commit/3, is_commit/1]).
+:- use_module(wam_clause_chain, [clause_chain/2]).
 :- use_module('../targets/wam_scala_target', [
        scala_lowered_constant_term/2,
        scala_lowered_functor_arity/3,
@@ -237,7 +238,15 @@ structured_clause1_scala(WamCode, Structured) :-
 wam_scala_lowerable(_PI, WamCode, Reason) :-
     parse_wam_text_scala(WamCode, Instrs),
     clause1_instrs_scala(Instrs, C1, MultiClause),
-    (   is_deterministic_pred_scala(C1),
+    (   % T5: a multi-clause predicate that discriminates on a distinct
+        % first-argument constant lowers to a bound-checked if/else cascade
+        % over ALL clauses (no interpreter hop for clauses 2+ when A1 is
+        % bound). Takes precedence over multi_clause_1. Each clause's
+        % remainder must itself be a supported deterministic body.
+        MultiClause == true,
+        scala_clause_chain_lowerable(Instrs, _Guards)
+    ->  Reason = clause_chain
+    ;   is_deterministic_pred_scala(C1),
         forall(member(I, C1), scala_supported(I))
     ->  ( MultiClause == true -> Reason = multi_clause_1 ; Reason = single_clause )
     ;   % Clause-1 has an inner choice point. Lower it only if that point is
@@ -249,6 +258,16 @@ wam_scala_lowerable(_PI, WamCode, Reason) :-
         structured_supported_scala(Structured),
         Reason = ite_lowered
     ).
+
+%% scala_clause_chain_lowerable(+Instrs, -Guards) is semidet.
+%  True when the predicate is a distinct-first-argument-constant clause
+%  chain (T5) AND every clause's remainder is a supported deterministic
+%  body. Guards is the chain front-end's guard(Const, Remainder) list.
+scala_clause_chain_lowerable(Instrs, Guards) :-
+    clause_chain(Instrs, chain(Guards)),
+    forall(member(guard(_, Rem), Guards),
+           ( is_deterministic_pred_scala(Rem),
+             forall(member(I, Rem), scala_supported(I)) )).
 
 %% clause1_instrs_scala(+Instrs, -Clause1, -MultiClause)
 %  Extracts clause 1.  MultiClause is `true` when the predicate opens
@@ -360,15 +379,52 @@ lower_predicate_to_scala(PI, WamCode, Options, lowered(PredName, FuncName, Code)
     ->  maplist(foreign_key_atom, FK0, ForeignKeys)
     ;   ForeignKeys = []
     ),
-    % Emit from the plain clause-1 when it is already fully supported;
-    % otherwise fold its inner ITE block(s) into structured form first.
-    (   is_deterministic_pred_scala(C1),
-        forall(member(I, C1), scala_supported(I))
-    ->  EmitBody = C1
-    ;   structured_clause1_scala(WamCode, EmitBody)
+    % T5 first-argument-constant clause chain takes precedence; otherwise
+    % emit from the plain clause-1 when fully supported, else fold its inner
+    % ITE block(s) into structured form first.
+    (   scala_clause_chain_lowerable(Instrs, Guards)
+    ->  with_output_to(string(Code),
+            emit_clause_chain_scala(FuncName, Guards, ForeignKeys))
+    ;   (   is_deterministic_pred_scala(C1),
+            forall(member(I, C1), scala_supported(I))
+        ->  EmitBody = C1
+        ;   structured_clause1_scala(WamCode, EmitBody)
+        ),
+        with_output_to(string(Code),
+            emit_function_scala(FuncName, EmitBody, MultiClause, ForeignKeys))
+    ).
+
+%% emit_clause_chain_scala(+FuncName, +Guards, +ForeignKeys)
+%  Emit T5: deref the first argument once; if it is still unbound, defer to
+%  the entry wrapper's interpreter fallback (the unbound case is genuinely
+%  nondeterministic). Otherwise dispatch with an if-cascade comparing the
+%  bound value against each clause's distinct discriminator and running that
+%  clause's remainder. A bound value matching no clause returns false (the
+%  predicate fails; the wrapper's fresh re-run also fails — sound).
+emit_clause_chain_scala(FuncName, Guards, FK) :-
+    nb_setval(scala_ite_ctr, 0),
+    format("  /** ~w — T5 first-argument dispatch (generated); entry wrapper handles the unbound-A1 fallback. */~n", [FuncName]),
+    format("  def ~w(s: WamState, program: WamProgram): Boolean = {~n", [FuncName]),
+    format("    val t5a1 = WamRuntime.deref(s.bindings, WamRuntime.getReg(s, 1))~n", []),
+    format("    t5a1 match {~n", []),
+    format("      case Ref(_) => return false  // unbound first arg: defer to interpreter (enumerates all clauses)~n", []),
+    format("      case _ => ()~n", []),
+    format("    }~n", []),
+    emit_guards_scala(Guards, FK),
+    format("    false~n", []),
+    format("  }~n", []).
+
+emit_guards_scala([], _).
+emit_guards_scala([guard(V, Rem) | Rest], FK) :-
+    scala_lowered_constant_term(V, Term),
+    format("    if (t5a1 == ~w) {~n", [Term]),
+    emit_body_scala(Rem, "      ", FK),
+    (   body_falls_through(Rem)
+    ->  format("      return true~n", [])
+    ;   true
     ),
-    with_output_to(string(Code),
-        emit_function_scala(FuncName, EmitBody, MultiClause, ForeignKeys)).
+    format("    }~n", []),
+    emit_guards_scala(Rest, FK).
 
 foreign_key_atom(K, A) :- ( atom(K) -> A = K ; atom_string(A, K) ).
 

--- a/src/unifyweaver/targets/wam_scala_target.pl
+++ b/src/unifyweaver/targets/wam_scala_target.pl
@@ -1363,8 +1363,12 @@ make_directory_path_for(FilePath) :-
     make_directory_path(Dir).
 
 write_file(Path, Content) :-
+    % UTF-8 so the runtime/generated sources (which contain non-ASCII
+    % characters) write correctly regardless of the process locale
+    % (POSIX/ASCII in many CI containers); otherwise write/2 raises an
+    % encoding error.
     setup_call_cleanup(
-        open(Path, write, Stream),
+        open(Path, write, Stream, [encoding(utf8)]),
         write(Stream, Content),
         close(Stream)
     ).

--- a/tests/test_wam_scala_lowered_t5.pl
+++ b/tests/test_wam_scala_lowered_t5.pl
@@ -1,0 +1,140 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% test_wam_scala_lowered_t5.pl
+%
+% End-to-end execution test for the Scala T5 lowering — "multi-clause as an
+% if-then-else chain" (lowering type T5 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md).
+%
+% A predicate whose clauses discriminate on a DISTINCT first-argument
+% constant now lowers (emit_mode(functions)) to a bound-checked first-arg
+% dispatch over ALL clauses, instead of the multi_clause_1 shape (clause 1
+% inline, clauses 2+ via the interpreter fallback). The payoff is that
+% non-first clauses become fast-path too when the first argument is bound;
+% an unbound first argument still defers to the interpreter (enumeration).
+%
+% Soundness rests on the discriminators being distinct (so at most one
+% clause matches a bound first arg — deterministic), so the first-solution
+% contract of the lowered entry holds for both boolean and enumeration
+% queries. Predicates with non-distinct or non-constant first-arg heads
+% decline T5 and keep their previous lowering.
+%
+% Pins (the GeneratedProgram CLI passes ground args; first arg is bound, so
+% these exercise the T5 fast-path dispatch including the non-first clauses):
+%   * color/1  — fact chain, atom discriminators;
+%   * sz/2     — fact chain with a second head-match in each remainder;
+%   * op/2     — RULE chain (each remainder runs an is/2 builtin).
+%
+% Gated on `scalac` + `scala` being on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module(library(process)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_scala_target').
+:- use_module('../src/unifyweaver/targets/wam_scala_lowered_emitter').
+
+:- dynamic user:color/1.
+:- dynamic user:sz/2.
+:- dynamic user:op/2.
+
+user:color(red).
+user:color(green).
+user:color(blue).
+
+user:sz(small, 1).
+user:sz(medium, 2).
+user:sz(large, 3).
+
+user:op(add, R) :- R is 1 + 1.
+user:op(mul, R) :- R is 2 * 3.
+user:op(neg, R) :- R is 0 - 1.
+
+scala_available :-
+    catch(( process_create(path(scalac), ['-version'],
+                           [stdout(null), stderr(null), process(P1)]),
+            process_wait(P1, _) ), _, fail),
+    catch(( process_create(path(scala), ['-version'],
+                           [stdout(null), stderr(null), process(P2)]),
+            process_wait(P2, _) ), _, fail).
+
+:- begin_tests(wam_scala_lowered_t5, [condition(scala_available)]).
+
+% The three predicates must lower as T5 (clause_chain), not multi_clause_1.
+test(gate_picks_clause_chain) :-
+    forall(member(PI, [color/1, sz/2, op/2]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_scala_lowerable(PI, W, Reason),
+             assertion(Reason == clause_chain) )).
+
+test(t5_exec_parity) :-
+    Dir = 'output/test_wam_scala_t5_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    make_directory_path(Dir),
+    write_wam_scala_project(
+        [user:color/1, user:sz/2, user:op/2],
+        [package('generated.t5.core'), runtime_package('generated.t5.core'),
+         module_name('t5'), emit_mode(functions)], Dir),
+    % Sanity: the generated program must contain the T5 dispatch for each.
+    directory_file_path(Dir, 'src/main/scala/generated/t5/core/GeneratedProgram.scala', ProgPath),
+    read_file_to_string(ProgPath, ProgSrc, []),
+    forall(member(F, ["lowered_color_1", "lowered_sz_2", "lowered_op_2",
+                      "T5 first-argument dispatch"]),
+           assertion(sub_string(ProgSrc, _, _, _, F))),
+    t5_compile(Dir),
+    % color/1 — atom fact chain (all three clauses + a miss).
+    t5_check(Dir, 'color/1', [red],    "true"),
+    t5_check(Dir, 'color/1', [green],  "true"),
+    t5_check(Dir, 'color/1', [blue],   "true"),
+    t5_check(Dir, 'color/1', [yellow], "false"),
+    % sz/2 — second head match in the remainder.
+    t5_check(Dir, 'sz/2', [small, 1],  "true"),
+    t5_check(Dir, 'sz/2', [medium, 2], "true"),
+    t5_check(Dir, 'sz/2', [large, 3],  "true"),
+    t5_check(Dir, 'sz/2', [small, 2],  "false"),
+    t5_check(Dir, 'sz/2', [big, 1],    "false"),
+    % op/2 — rule chain, each remainder runs is/2.
+    t5_check(Dir, 'op/2', [add, 2],  "true"),
+    t5_check(Dir, 'op/2', [mul, 6],  "true"),
+    t5_check(Dir, 'op/2', [neg, -1], "true"),
+    t5_check(Dir, 'op/2', [add, 3],  "false"),
+    t5_check(Dir, 'op/2', [div, 1],  "false"),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_scala_lowered_t5).
+
+% --- compile + run harness (mirrors test_wam_scala_classic_programs) -------
+
+t5_compile(ProjectDir) :-
+    absolute_file_name(ProjectDir, AbsDir),
+    directory_file_path(AbsDir, 'classes', ClassDir),
+    make_directory_path(ClassDir),
+    directory_file_path(AbsDir, 'src', SrcDir),
+    findall(F,
+        ( directory_member(SrcDir, RelF, [extensions([scala]), recursive(true)]),
+          directory_file_path(SrcDir, RelF, F) ),
+        Sources),
+    Sources \= [],
+    process_create(path(scalac), ['-d', ClassDir | Sources],
+                   [cwd(AbsDir), stdout(pipe(O)), stderr(pipe(E)), process(Pid)]),
+    read_string(O, _, _), read_string(E, _, ErrStr), close(O), close(E),
+    process_wait(Pid, exit(Code)),
+    ( Code =:= 0 -> true ; throw(error(scala_compile_failed(Code, ErrStr), _)) ).
+
+t5_check(ProjectDir, PredKey, Args, Expected) :-
+    absolute_file_name(ProjectDir, AbsDir),
+    directory_file_path(AbsDir, 'classes', ClassDir),
+    atom_string(PredKey, PredStr),
+    maplist([A, S]>>atom_string(A, S), Args, ArgStrs),
+    append(['-classpath', ClassDir, 'generated.t5.core.GeneratedProgram', PredStr],
+           ArgStrs, ProcArgs),
+    process_create(path(scala), ProcArgs,
+                   [cwd(AbsDir), stdout(pipe(O)), stderr(pipe(E)), process(Pid)]),
+    read_string(O, _, Out0), read_string(E, _, ErrStr), close(O), close(E),
+    process_wait(Pid, exit(Code)),
+    normalize_space(string(Actual), Out0),
+    ( Code =:= 0 -> true ; throw(error(scala_run_failed(Code, PredKey, Args, ErrStr), _)) ),
+    ( Actual == Expected
+    -> true
+    ;  throw(error(t5_assertion(PredKey, Args, Expected, Actual), _)) ).


### PR DESCRIPTION
## Summary

First implementation step of the lowering-taxonomy plan (#2898): **lowering type T5 — "multi-clause as an `->`-chain" — for Scala** (the form we tracked down from the earlier "`->` form" discussion).

A predicate whose clauses discriminate on a **distinct first-argument constant** —

```prolog
color(red).  color(green).  color(blue).
```

now lowers (`emit_mode(functions)`) to a bound-checked first-argument dispatch over **all** clauses, instead of `multi_clause_1` (clause 1 inline, clauses 2+ via the interpreter fallback):

```scala
def lowered_color_1(s, program): Boolean = {
  val t5a1 = WamRuntime.deref(s.bindings, WamRuntime.getReg(s, 1))
  t5a1 match { case Ref(_) => return false   // unbound: defer to interpreter
               case _ => () }
  if (t5a1 == Atom(red))   { <remainder1>; return true }
  if (t5a1 == Atom(green)) { <remainder2>; return true }
  if (t5a1 == Atom(blue))  { <remainder3>; return true }
  false
}
```

**Payoff:** non-first clauses (green/blue/…) become fast-path too when the first arg is bound — previously only clause 1 was lowered and clauses 2+ paid the interpreter hop.

## Shared front-end

`wam_clause_chain.pl` (new, target-agnostic — mirrors how `wam_ite_structurer` is shared for T2) recognises the shape and returns the per-clause `guard(Discriminator, Remainder)`. Each target keeps its own back-end; Scala is wired first, and the next targets reuse the front-end.

## Soundness

- **Distinct** discriminators ⇒ at most one clause matches a bound first arg ⇒ the predicate is deterministic in that mode, so the lowered entry's first-solution contract holds for **boolean and enumeration** queries (no solution dropped). Non-distinct / non-constant / variable first-arg heads **decline** T5 and keep their previous lowering.
- **Unbound** first arg → returns false → entry wrapper's interpreter fallback enumerates (genuinely nondeterministic).
- Inter-predicate calls already route through the interpreter (`loCall`/`loExecute` run the step loop), so T5 only optimises the top-level bound query; all other modes are unchanged.

## Verification

- `tests/test_wam_scala_lowered_t5.pl` (gated on `scalac`+`scala`): asserts `color/1`, `sz/2` (second head-match in the remainder), and `op/2` (rule chain running `is/2`) all gate as `clause_chain`, then **compiles and runs 14 ground queries** — every clause incl. non-first, plus no-match cases. All pass.
- **Non-T5 neutral:** single-clause / ITE / non-distinct (`sh/1`) / variable-head (`app/3`) predicates keep identical lowerability reasons and emitted code (verified before/after).
- Existing Scala suites pass (their POSIX-locale failures were the pre-existing encoding issue, also addressed here by opening output as UTF-8).

## Next (per the matrix plan)

Port the `wam_clause_chain` back-end to the other structurer targets, then T4 (all-clauses) and T6 (first-arg indexing — same front-end, `switch` back-end).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_