### PR TITLE
feat(wam-clojure): lower union/3 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -534,6 +534,10 @@ clojure_direct_builtin("intersection/3", "3").
 clojure_direct_builtin("intersection/3", 3).
 clojure_direct_builtin('intersection/3', "3").
 clojure_direct_builtin('intersection/3', 3).
+clojure_direct_builtin("union/3", "3").
+clojure_direct_builtin("union/3", 3).
+clojure_direct_builtin('union/3', "3").
+clojure_direct_builtin('union/3', 3).
 clojure_direct_builtin("list_to_set/2", "2").
 clojure_direct_builtin("list_to_set/2", 2).
 clojure_direct_builtin('list_to_set/2', "2").
@@ -966,6 +970,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "intersection/3" ; Op == 'intersection/3'),
     !,
     format(atom(Expr), '(runtime/apply-intersection-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "union/3" ; Op == 'union/3'),
+    !,
+    format(atom(Expr), '(runtime/apply-union-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "list_to_set/2" ; Op == 'list_to_set/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1245,6 +1245,32 @@
           (backtrack state)))
       (backtrack state))))
 
+(defn list-union-items [state left right]
+  (reduce (fn [out item]
+            (if (some #(term-identical? state item %) left)
+              out
+              (conj out item)))
+          (vec left)
+          right))
+
+(defn apply-union-solution [state]
+  (let [left-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        right-value (deref-value (:bindings state)
+                                 (or (reg-get-raw state "A2") ::unbound))
+        out (deref-value (:bindings state)
+                         (or (reg-get-raw state "A3") ::unbound))
+        left-items (proper-list-items state left-value)
+        right-items (proper-list-items state right-value)]
+    (if (and (some? left-items) (some? right-items))
+      (let [result-term (list->term (:intern-context state)
+                                    (list-union-items state left-items right-items))
+            [ok next-state] (unify-values state out result-term)]
+        (if ok
+          (advance next-state)
+          (backtrack state)))
+      (backtrack state))))
+
 (defn list-to-set-items [state items]
   (reduce (fn [out item]
             (if (some #(term-identical? state % item) out)
@@ -2701,6 +2727,9 @@
 
           "intersection/3"
           (apply-intersection-solution state)
+
+          "union/3"
+          (apply-union-solution state)
 
           "list_to_set/2"
           (apply-list-to-set-solution state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -135,6 +135,11 @@
 :- dynamic user:wam_intersection_duplicates/0.
 :- dynamic user:wam_intersection_bad_left/1.
 :- dynamic user:wam_intersection_bad_right/1.
+:- dynamic user:wam_union_guard/3.
+:- dynamic user:wam_union_empty_left/0.
+:- dynamic user:wam_union_duplicates/0.
+:- dynamic user:wam_union_bad_left/1.
+:- dynamic user:wam_union_bad_right/1.
 :- dynamic user:wam_list_to_set_guard/2.
 :- dynamic user:wam_list_to_set_empty/0.
 :- dynamic user:wam_list_to_set_singleton/0.
@@ -476,6 +481,11 @@ user:wam_intersection_empty_left :- intersection([], [a], Common), Common = [].
 user:wam_intersection_duplicates :- intersection([a,a,b,c], [a,c], Common), Common = [a,a,c].
 user:wam_intersection_bad_left(_) :- intersection([a|b], [a], _).
 user:wam_intersection_bad_right(_) :- intersection([a], [a|b], _).
+user:wam_union_guard(Left, Right, Union) :- union(Left, Right, Union).
+user:wam_union_empty_left :- union([], [a,b], Union), Union = [a,b].
+user:wam_union_duplicates :- union([a,a], [a,b], Union), Union = [a,a,b].
+user:wam_union_bad_left(_) :- union([a|b], [a], _).
+user:wam_union_bad_right(_) :- union([a], [a|b], _).
 user:wam_list_to_set_guard(List, Set) :- list_to_set(List, Set).
 user:wam_list_to_set_empty :- list_to_set([], Set), Set = [].
 user:wam_list_to_set_singleton :- list_to_set([x], Set), Set = [x].
@@ -822,6 +832,11 @@ run_smoke :-
           user:wam_intersection_duplicates/0,
           user:wam_intersection_bad_left/1,
           user:wam_intersection_bad_right/1,
+          user:wam_union_guard/3,
+          user:wam_union_empty_left/0,
+          user:wam_union_duplicates/0,
+          user:wam_union_bad_left/1,
+          user:wam_union_bad_right/1,
           user:wam_list_to_set_guard/2,
           user:wam_list_to_set_empty/0,
           user:wam_list_to_set_singleton/0,
@@ -1070,6 +1085,7 @@ run_smoke :-
     assert_lowered_delete_builtin_emitted(TmpDir),
     assert_lowered_subtract_builtin_emitted(TmpDir),
     assert_lowered_intersection_builtin_emitted(TmpDir),
+    assert_lowered_union_builtin_emitted(TmpDir),
     assert_lowered_list_to_set_builtin_emitted(TmpDir),
     assert_lowered_sort_builtin_emitted(TmpDir),
     assert_lowered_msort_builtin_emitted(TmpDir),
@@ -1321,6 +1337,12 @@ smoke_cases([
     case('wam_intersection_duplicates/0', no_args, "true"),
     case('wam_intersection_bad_left/1', a, "false"),
     case('wam_intersection_bad_right/1', a, "false"),
+    case('wam_union_guard/3', args('[a,b]', '[b,c]', '[a,b,c]'), "true"),
+    case('wam_union_guard/3', args('[a,b]', '[b,c]', '[b,c]'), "false"),
+    case('wam_union_empty_left/0', no_args, "true"),
+    case('wam_union_duplicates/0', no_args, "true"),
+    case('wam_union_bad_left/1', a, "false"),
+    case('wam_union_bad_right/1', a, "false"),
     case('wam_list_to_set_guard/2', args('[a,b,c,a,b,d,a]', '[a,b,c,d]'), "true"),
     case('wam_list_to_set_guard/2', args('[a,b,c,a,b,d,a]', '[a,b,c,a]'), "false"),
     case('wam_list_to_set_empty/0', no_args, "true"),
@@ -1853,6 +1875,15 @@ assert_lowered_intersection_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-intersection-bad-left-1"),
     has(CoreCode, "defn lowered-wam-intersection-bad-right-1"),
     has(CoreCode, "runtime/apply-intersection-solution").
+
+assert_lowered_union_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-union-guard-3"),
+    has(CoreCode, "defn lowered-wam-union-duplicates-0"),
+    has(CoreCode, "defn lowered-wam-union-bad-left-1"),
+    has(CoreCode, "defn lowered-wam-union-bad-right-1"),
+    has(CoreCode, "runtime/apply-union-solution").
 
 assert_lowered_list_to_set_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM direct-lowered support for `union/3`.
- Implements the runtime helper for deterministic list union.
- Extends the Clojure runtime smoke fixture with success, mismatch, empty-left, duplicate-preservation, and malformed-list cases.

## Why

This completes the Clojure WAM `subtract/3`, `intersection/3`, `union/3`, and `list_to_set/2` list-set family. Go and LLVM already cover this group, and this PR brings Clojure WAM parity for the remaining `union/3` builtin.

## Behavior

- Requires both input lists to be proper bound lists.
- Preserves the full left-list order, including duplicates.
- Appends right-list items only when they are not identical to any item in the original left list.
- Fails deterministically for malformed input lists or output unification mismatch.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
