### PR TITLE
LLVM WAM: getlogin/1 + uname_sysname/1 + uname_machine/1 (M127)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1572,6 +1572,8 @@ declare i32 @getpriority(i32, i32)
 declare i32 @setpriority(i32, i32, i32)
 declare i32 @getrlimit(i32, i8*)
 declare i32 @setrlimit(i32, i8*)
+declare i8* @getlogin()
+declare i32 @uname(i8*)
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3688,6 +3690,9 @@ entry:
     i32 147, label %builtin_setpriority
     i32 148, label %builtin_getrlimit
     i32 149, label %builtin_setrlimit
+    i32 150, label %builtin_getlogin
+    i32 151, label %builtin_uname_sysname
+    i32 152, label %builtin_uname_machine
   ]
 
 builtin_is:
@@ -6695,6 +6700,89 @@ srl.write:
   %srl.set = call i32 @setrlimit(i32 %srl.res, i8* %srl.buf_ptr)
   %srl.ok = icmp eq i32 %srl.set, 0
   ret i1 %srl.ok
+
+builtin_getlogin:
+  ; M127: getlogin(-Name) -- libc getlogin wrapper. Returns the
+  ; login name associated with the controlling terminal as an
+  ; atom. Fails if not running under a terminal (e.g. cron, CI
+  ; containers without a tty) -- libc returns NULL in that case.
+  %gln.s = call i8* @getlogin()
+  %gln.null = icmp eq i8* %gln.s, null
+  br i1 %gln.null, label %gln.fail, label %gln.intern
+gln.fail:
+  ret i1 false
+gln.intern:
+  %gln.len = call i64 @strlen(i8* %gln.s)
+  call void @wam_arena_ensure()
+  %gln.bufsize = add i64 %gln.len, 1
+  %gln.arena = call i8* @wam_arena_alloc(i64 %gln.bufsize)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %gln.arena, i8* %gln.s, i64 %gln.len, i1 false)
+  %gln.term = getelementptr i8, i8* %gln.arena, i64 %gln.len
+  store i8 0, i8* %gln.term
+  %gln.aid = call i64 @wam_intern_atom(i8* %gln.arena, i64 %gln.len)
+  %gln.v0 = insertvalue %Value undef, i32 0, 0
+  %gln.v = insertvalue %Value %gln.v0, i64 %gln.aid, 1
+  %gln.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %gln.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %gln.raw1, %Value %gln.v)
+  ret i1 %gln.ok
+
+builtin_uname_sysname:
+  ; M127: uname_sysname(-Sysname) -- returns the kernel name
+  ; (typically ''Linux'', ''Darwin'', ''FreeBSD'') from libc uname.
+  ; struct utsname on Linux glibc: 6 fields of 65 bytes each
+  ; (sysname/nodename/release/version/machine/domainname). Offsets
+  ; on other POSIX OSes differ (macOS uses 256-byte fields) -- a
+  ; 512-byte buffer covers Linux/glibc; portable handling would
+  ; need target_os routing (see M113).
+  %uns.buf = alloca [512 x i8]
+  %uns.buf_ptr = getelementptr [512 x i8], [512 x i8]* %uns.buf, i32 0, i32 0
+  %uns.ret = call i32 @uname(i8* %uns.buf_ptr)
+  %uns.ok_call = icmp eq i32 %uns.ret, 0
+  br i1 %uns.ok_call, label %uns.intern, label %uns.fail
+uns.fail:
+  ret i1 false
+uns.intern:
+  ; sysname at offset 0.
+  %uns.len = call i64 @strlen(i8* %uns.buf_ptr)
+  call void @wam_arena_ensure()
+  %uns.bufsize = add i64 %uns.len, 1
+  %uns.arena = call i8* @wam_arena_alloc(i64 %uns.bufsize)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %uns.arena, i8* %uns.buf_ptr, i64 %uns.len, i1 false)
+  %uns.term = getelementptr i8, i8* %uns.arena, i64 %uns.len
+  store i8 0, i8* %uns.term
+  %uns.aid = call i64 @wam_intern_atom(i8* %uns.arena, i64 %uns.len)
+  %uns.v0 = insertvalue %Value undef, i32 0, 0
+  %uns.v = insertvalue %Value %uns.v0, i64 %uns.aid, 1
+  %uns.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %uns.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %uns.raw1, %Value %uns.v)
+  ret i1 %uns.uok
+
+builtin_uname_machine:
+  ; M127: uname_machine(-Machine) -- returns the hardware arch
+  ; (typically ''x86_64'', ''aarch64'', ''arm64'') from libc uname.
+  ; machine field is at offset 4*65 = 260 on Linux glibc.
+  %unm.buf = alloca [512 x i8]
+  %unm.buf_ptr = getelementptr [512 x i8], [512 x i8]* %unm.buf, i32 0, i32 0
+  %unm.ret = call i32 @uname(i8* %unm.buf_ptr)
+  %unm.ok_call = icmp eq i32 %unm.ret, 0
+  br i1 %unm.ok_call, label %unm.intern, label %unm.fail
+unm.fail:
+  ret i1 false
+unm.intern:
+  %unm.field = getelementptr i8, i8* %unm.buf_ptr, i64 260
+  %unm.len = call i64 @strlen(i8* %unm.field)
+  call void @wam_arena_ensure()
+  %unm.bufsize = add i64 %unm.len, 1
+  %unm.arena = call i8* @wam_arena_alloc(i64 %unm.bufsize)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %unm.arena, i8* %unm.field, i64 %unm.len, i1 false)
+  %unm.term = getelementptr i8, i8* %unm.arena, i64 %unm.len
+  store i8 0, i8* %unm.term
+  %unm.aid = call i64 @wam_intern_atom(i8* %unm.arena, i64 %unm.len)
+  %unm.v0 = insertvalue %Value undef, i32 0, 0
+  %unm.v = insertvalue %Value %unm.v0, i64 %unm.aid, 1
+  %unm.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %unm.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %unm.raw1, %Value %unm.v)
+  ret i1 %unm.uok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -13998,6 +14086,9 @@ builtin_op_to_id('getpriority/1', 146).       % libc getpriority(PRIO_PROCESS, 0
 builtin_op_to_id('setpriority/1', 147).       % libc setpriority(PRIO_PROCESS, 0, prio).
 builtin_op_to_id('getrlimit/2', 148).         % libc getrlimit(Res, &rlim) -- soft limit.
 builtin_op_to_id('setrlimit/2', 149).         % libc setrlimit(Res, &rlim) -- soft limit only.
+builtin_op_to_id('getlogin/1', 150).          % libc getlogin() as atom.
+builtin_op_to_id('uname_sysname/1', 151).     % libc uname() sysname field as atom.
+builtin_op_to_id('uname_machine/1', 152).     % libc uname() machine field as atom.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2250,6 +2250,9 @@ is_builtin_pred(getpriority, 1).        % getpriority(-Prio) -- read self priori
 is_builtin_pred(setpriority, 1).        % setpriority(+Prio) -- set self priority.
 is_builtin_pred(getrlimit, 2).          % getrlimit(+Resource, -SoftLimit).
 is_builtin_pred(setrlimit, 2).          % setrlimit(+Resource, +SoftLimit).
+is_builtin_pred(getlogin, 1).           % getlogin(-Name) -- libc getlogin.
+is_builtin_pred(uname_sysname, 1).      % uname_sysname(-Sysname).
+is_builtin_pred(uname_machine, 1).      % uname_machine(-Machine).
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -3091,6 +3091,48 @@ test_srl_bad_args(_, R) :-
     ; R is 1
     ).   % 1
 
+% M127: getlogin/1 + uname_sysname/1 + uname_machine/1.
+
+:- dynamic test_getlogin_or_fail/2.
+test_getlogin_or_fail(_, R) :-
+    % Either getlogin succeeds with a non-empty atom (interactive
+    % terminal), or it fails (CI / cron / no tty). Both are
+    % acceptable; we just check the result shape if it succeeds.
+    ( getlogin(N), atom(N), atom_length(N, L), L > 0
+    -> R is 1
+    ;  % Fail path is also acceptable in CI.
+       R is 1
+    ).   % 1
+
+:- dynamic test_uname_sysname_nonempty/2.
+test_uname_sysname_nonempty(_, R) :-
+    uname_sysname(S),
+    atom_length(S, L),
+    ( atom(S), L > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_uname_machine_nonempty/2.
+test_uname_machine_nonempty(_, R) :-
+    uname_machine(M),
+    atom_length(M, L),
+    ( atom(M), L > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_uname_sysname_stable/2.
+test_uname_sysname_stable(_, R) :-
+    % Two calls in the same process must return the same atom.
+    uname_sysname(S1),
+    uname_sysname(S2),
+    ( S1 == S2 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_uname_known_linux_or_darwin/2.
+test_uname_known_linux_or_darwin(_, R) :-
+    % Smoke check: sysname should be Linux, Darwin, or FreeBSD on
+    % the platforms we actually run on. Anything else just doesn''t
+    % fail the test -- accept any non-empty atom.
+    uname_sysname(S),
+    ( S == 'Linux' ; S == 'Darwin' ; S == 'FreeBSD' ; atom(S) ),
+    !,
+    R is 1.   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -6153,6 +6195,17 @@ test_all :-
                    test_grl_bad_arg, 0, 1),
        run_test_r0('setrlimit non-int args fail -> 1',
                    test_srl_bad_args, 0, 1),
+       format('--- M127 getlogin/1 + uname_sysname/1 + uname_machine/1 ---~n'),
+       run_test_r0('getlogin or no-tty fail accepted -> 1',
+                   test_getlogin_or_fail, 0, 1),
+       run_test_r0('uname_sysname non-empty -> 1',
+                   test_uname_sysname_nonempty, 0, 1),
+       run_test_r0('uname_machine non-empty -> 1',
+                   test_uname_machine_nonempty, 0, 1),
+       run_test_r0('uname_sysname stable across calls -> 1',
+                   test_uname_sysname_stable, 0, 1),
+       run_test_r0('uname_sysname known OS -> 1',
+                   test_uname_known_linux_or_darwin, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds the env-detection cluster — three libc identity/system wrappers useful for cross-platform code paths:

- `getlogin/1` (op id 150) — login name via libc `getlogin()`
- `uname_sysname/1` (op id 151) — kernel name (`'Linux'`, `'Darwin'`, ...)
- `uname_machine/1` (op id 152) — hardware arch (`'x86_64'`, `'aarch64'`, ...)

## Predicates

### `getlogin(-Name)`
Returns the login name associated with the controlling terminal as an atom. **Fails** (libc returns NULL) when no tty is attached — CI containers, cron, daemons, etc. This is expected POSIX behaviour; don't rely on `getlogin` in non-interactive contexts.

### `uname_sysname(-Sysname)` / `uname_machine(-Machine)`
Both call libc `uname()` into a 512-byte stack buffer and read the relevant field at its Linux glibc offset:
- `sysname` at offset 0
- `machine` at offset `4 * 65 = 260`

(each `utsname` field is 65 bytes including null on glibc)

## Portability note

macOS uses 256-byte `utsname` fields. A fully portable version would dispatch through the M113 `target_os` framework; the current 65-byte assumption is Linux/glibc-only. Documented in the IR comments.

## libc declarations

```llvm
declare i8* @getlogin()
declare i32 @uname(i8*)
```

Prefixes `gln.` / `uns.` / `unm.` (no collisions).

## Three-site registration

- Dispatch switch entries 150, 151, 152
- `builtin_op_to_id`
- `is_builtin_pred` in `wam_target.pl`

## Tests

5 execution tests, all PASS:

- `getlogin`: succeeds with non-empty atom OR fails (both accepted — varies by CI vs interactive)
- `uname_sysname` returns non-empty Atom
- `uname_machine` returns non-empty Atom
- `uname_sysname` is stable across calls in the same process
- `uname_sysname` is one of Linux/Darwin/FreeBSD on common targets (graceful any-atom fallback)

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — libc declarations, dispatch entries, three new builtin bodies, op-id table.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred` entries.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 5 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke) ✓
- [x] All 5 M127 tests PASS individually ✓
- [ ] Full suite regression check

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_