### PR TITLE
LLVM WAM: copy_file/2 (M128) -- libc open/read/write/close loop

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1574,6 +1574,9 @@ declare i32 @getrlimit(i32, i8*)
 declare i32 @setrlimit(i32, i8*)
 declare i8* @getlogin()
 declare i32 @uname(i8*)
+declare i32 @open(i8*, i32, i32)
+declare i64 @read(i32, i8*, i64)
+declare i64 @write(i32, i8*, i64)
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3693,6 +3696,7 @@ entry:
     i32 150, label %builtin_getlogin
     i32 151, label %builtin_uname_sysname
     i32 152, label %builtin_uname_machine
+    i32 153, label %builtin_copy_file
   ]
 
 builtin_is:
@@ -6783,6 +6787,76 @@ unm.intern:
   %unm.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %unm.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %unm.raw1, %Value %unm.v)
   ret i1 %unm.uok
+
+builtin_copy_file:
+  ; M128: copy_file(+Src, +Dst) -- file copy via libc open / read /
+  ; write / close. Both args must be Atom. Source is opened O_RDONLY;
+  ; destination is opened O_WRONLY|O_CREAT|O_TRUNC (flags = 577 on
+  ; Linux) with mode 0644 (= 420 decimal). Loop reads 4 KB at a
+  ; time and writes them through; succeeds when read returns 0,
+  ; fails (after closing both fds) on read error, short write, or
+  ; either open returning -1. Open flags are Linux glibc constants;
+  ; macOS and BSDs use different O_CREAT (= 512) and O_TRUNC
+  ; (= 1024) values, so a portable version would need to dispatch
+  ; through the M113 target_os framework -- documented limitation.
+  %cpf.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %cpf.t1 = call i32 @value_tag(%Value %cpf.a1)
+  %cpf.is_atom1 = icmp eq i32 %cpf.t1, 0
+  br i1 %cpf.is_atom1, label %cpf.check2, label %cpf.fail
+cpf.fail:
+  ret i1 false
+cpf.check2:
+  %cpf.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %cpf.t2 = call i32 @value_tag(%Value %cpf.a2)
+  %cpf.is_atom2 = icmp eq i32 %cpf.t2, 0
+  br i1 %cpf.is_atom2, label %cpf.have_args, label %cpf.fail
+cpf.have_args:
+  %cpf.src_aid = call i64 @value_payload(%Value %cpf.a1)
+  %cpf.src_path = call i8* @wam_atom_to_string(i64 %cpf.src_aid)
+  %cpf.src_path_null = icmp eq i8* %cpf.src_path, null
+  br i1 %cpf.src_path_null, label %cpf.fail, label %cpf.have_src_path
+cpf.have_src_path:
+  %cpf.dst_aid = call i64 @value_payload(%Value %cpf.a2)
+  %cpf.dst_path = call i8* @wam_atom_to_string(i64 %cpf.dst_aid)
+  %cpf.dst_path_null = icmp eq i8* %cpf.dst_path, null
+  br i1 %cpf.dst_path_null, label %cpf.fail, label %cpf.open_src
+cpf.open_src:
+  ; O_RDONLY = 0; mode arg is ignored when not creating.
+  %cpf.src_fd = call i32 @open(i8* %cpf.src_path, i32 0, i32 0)
+  %cpf.src_ok = icmp sge i32 %cpf.src_fd, 0
+  br i1 %cpf.src_ok, label %cpf.open_dst, label %cpf.fail
+cpf.open_dst:
+  ; O_WRONLY (1) | O_CREAT (64) | O_TRUNC (512) = 577 (Linux glibc).
+  ; mode 0o644 = 420 decimal -- typical rw-r--r-- for new files.
+  %cpf.dst_fd = call i32 @open(i8* %cpf.dst_path, i32 577, i32 420)
+  %cpf.dst_ok = icmp sge i32 %cpf.dst_fd, 0
+  br i1 %cpf.dst_ok, label %cpf.loop_init, label %cpf.close_src_then_fail
+cpf.close_src_then_fail:
+  call i32 @close(i32 %cpf.src_fd)
+  ret i1 false
+cpf.loop_init:
+  %cpf.buf = alloca [4096 x i8]
+  %cpf.buf_ptr = getelementptr [4096 x i8], [4096 x i8]* %cpf.buf, i32 0, i32 0
+  br label %cpf.loop
+cpf.loop:
+  %cpf.n = call i64 @read(i32 %cpf.src_fd, i8* %cpf.buf_ptr, i64 4096)
+  %cpf.n_zero = icmp eq i64 %cpf.n, 0
+  br i1 %cpf.n_zero, label %cpf.success, label %cpf.check_neg
+cpf.check_neg:
+  %cpf.n_neg = icmp slt i64 %cpf.n, 0
+  br i1 %cpf.n_neg, label %cpf.close_both_fail, label %cpf.do_write
+cpf.do_write:
+  %cpf.wn = call i64 @write(i32 %cpf.dst_fd, i8* %cpf.buf_ptr, i64 %cpf.n)
+  %cpf.wn_ok = icmp eq i64 %cpf.wn, %cpf.n
+  br i1 %cpf.wn_ok, label %cpf.loop, label %cpf.close_both_fail
+cpf.success:
+  call i32 @close(i32 %cpf.src_fd)
+  call i32 @close(i32 %cpf.dst_fd)
+  ret i1 true
+cpf.close_both_fail:
+  call i32 @close(i32 %cpf.src_fd)
+  call i32 @close(i32 %cpf.dst_fd)
+  ret i1 false
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -14089,6 +14163,7 @@ builtin_op_to_id('setrlimit/2', 149).         % libc setrlimit(Res, &rlim) -- so
 builtin_op_to_id('getlogin/1', 150).          % libc getlogin() as atom.
 builtin_op_to_id('uname_sysname/1', 151).     % libc uname() sysname field as atom.
 builtin_op_to_id('uname_machine/1', 152).     % libc uname() machine field as atom.
+builtin_op_to_id('copy_file/2', 153).         % open + read/write loop + close.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2253,6 +2253,7 @@ is_builtin_pred(setrlimit, 2).          % setrlimit(+Resource, +SoftLimit).
 is_builtin_pred(getlogin, 1).           % getlogin(-Name) -- libc getlogin.
 is_builtin_pred(uname_sysname, 1).      % uname_sysname(-Sysname).
 is_builtin_pred(uname_machine, 1).      % uname_machine(-Machine).
+is_builtin_pred(copy_file, 2).          % copy_file(+Src, +Dst) -- open/read/write/close.
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -3133,6 +3133,65 @@ test_uname_known_linux_or_darwin(_, R) :-
     !,
     R is 1.   % 1
 
+% M128: copy_file/2 -- libc open/read/write/close.
+
+:- dynamic test_copy_file_basic/2.
+test_copy_file_basic(_, R) :-
+    % Create a tiny source file, copy it, diff to confirm bytes match.
+    shell('echo hello > /tmp/uw_m128_src', _),
+    shell('rm -f /tmp/uw_m128_dst', _),
+    copy_file('/tmp/uw_m128_src', '/tmp/uw_m128_dst'),
+    shell('diff -q /tmp/uw_m128_src /tmp/uw_m128_dst', St),
+    shell('rm -f /tmp/uw_m128_src /tmp/uw_m128_dst', _),
+    ( St =:= 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_copy_file_empty/2.
+test_copy_file_empty(_, R) :-
+    % Copying an empty file produces an empty dest (read returns 0
+    % immediately, loop exits successfully).
+    shell('rm -f /tmp/uw_m128_empty_src /tmp/uw_m128_empty_dst', _),
+    shell('touch /tmp/uw_m128_empty_src', _),
+    copy_file('/tmp/uw_m128_empty_src', '/tmp/uw_m128_empty_dst'),
+    size_file('/tmp/uw_m128_empty_dst', Sz),
+    shell('rm -f /tmp/uw_m128_empty_src /tmp/uw_m128_empty_dst', _),
+    ( Sz =:= 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_copy_file_large/2.
+test_copy_file_large(_, R) :-
+    % Copy a file larger than the 4 KB buffer -- exercises the
+    % loop. yes | head produces ~3 KB per 1500 lines, so generate
+    % 20 KB by repeating ~10000 lines.
+    shell('rm -f /tmp/uw_m128_large_src /tmp/uw_m128_large_dst', _),
+    shell('seq 1 5000 > /tmp/uw_m128_large_src', _),
+    copy_file('/tmp/uw_m128_large_src', '/tmp/uw_m128_large_dst'),
+    shell('diff -q /tmp/uw_m128_large_src /tmp/uw_m128_large_dst', St),
+    shell('rm -f /tmp/uw_m128_large_src /tmp/uw_m128_large_dst', _),
+    ( St =:= 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_copy_file_missing_src/2.
+test_copy_file_missing_src(_, R) :-
+    % Source doesn''t exist -> open fails -> copy_file fails.
+    ( copy_file('/tmp/uw_m128_never_existed', '/tmp/uw_m128_x') -> R is 0
+    ; R is 1
+    ).   % 1
+
+:- dynamic test_copy_file_overwrite/2.
+test_copy_file_overwrite(_, R) :-
+    % O_TRUNC: copying over an existing dest replaces its content.
+    shell('echo old > /tmp/uw_m128_ow_dst', _),
+    shell('echo new > /tmp/uw_m128_ow_src', _),
+    copy_file('/tmp/uw_m128_ow_src', '/tmp/uw_m128_ow_dst'),
+    shell('diff -q /tmp/uw_m128_ow_src /tmp/uw_m128_ow_dst', St),
+    shell('rm -f /tmp/uw_m128_ow_src /tmp/uw_m128_ow_dst', _),
+    ( St =:= 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_copy_file_bad_args/2.
+test_copy_file_bad_args(_, R) :-
+    ( copy_file(42, '/tmp/x') -> R is 0
+    ; copy_file('/tmp/x', 99) -> R is 0
+    ; R is 1
+    ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -6206,6 +6265,19 @@ test_all :-
                    test_uname_sysname_stable, 0, 1),
        run_test_r0('uname_sysname known OS -> 1',
                    test_uname_known_linux_or_darwin, 0, 1),
+       format('--- M128 copy_file/2 ---~n'),
+       run_test_r0('copy_file basic round-trip + diff -> 1',
+                   test_copy_file_basic, 0, 1),
+       run_test_r0('copy_file empty source -> empty dst -> 1',
+                   test_copy_file_empty, 0, 1),
+       run_test_r0('copy_file large (multi-loop) round-trip -> 1',
+                   test_copy_file_large, 0, 1),
+       run_test_r0('copy_file missing source fails -> 1',
+                   test_copy_file_missing_src, 0, 1),
+       run_test_r0('copy_file O_TRUNC overwrite -> 1',
+                   test_copy_file_overwrite, 0, 1),
+       run_test_r0('copy_file with non-atom args fails -> 1',
+                   test_copy_file_bad_args, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds `copy_file(+Src, +Dst)` as op id 153 — file copy via libc `open`/`read`/`write`/`close`. **First** M-milestone with a proper read-loop instead of a single libc one-liner.

## Algorithm

1. Type-guard both args as Atom; non-atom → fail.
2. `open(Src, O_RDONLY=0, 0)` — fail if `< 0`.
3. `open(Dst, O_WRONLY|O_CREAT|O_TRUNC=577, 0o644=420)` — if `< 0`, close src and fail.
4. 4 KB stack `alloca` buffer. Loop:
   - `read(src) → n`
   - `n == 0` → close both, succeed
   - `n  < 0` → close both, fail
   - `write(dst, n) → wn`
   - `wn != n` → close both, fail (short write)
   - else: loop

## Cleanup branching

Three error paths each close the right number of fds:

| When | What's closed |
|---|---|
| Type / open-src fails | nothing |
| open-dst fails | src only |
| read/write fails during loop | both |
| Read returns 0 (success) | both |

SSA values for `src_fd` / `dst_fd` / `buf_ptr` dominate every block that uses them, so no phi nodes needed.

## Portability note

Open flags are Linux glibc constants:
- `O_RDONLY = 0`
- `O_WRONLY = 1`
- `O_CREAT = 64`
- `O_TRUNC = 512`
- combined dst flags = `577`

macOS / BSDs use different `O_CREAT` (= 512) and `O_TRUNC` (= 1024) values. Documented as a known limitation; portable handling would dispatch through the M113 `target_os` framework.

## libc declarations

```llvm
declare i32 @open(i8*, i32, i32)
declare i64 @read(i32, i8*, i64)
declare i64 @write(i32, i8*, i64)
```

`close` was already declared (M123).

Prefix `cpf.` (no collisions).

## Three-site registration

- Dispatch switch entry 153
- `builtin_op_to_id('copy_file/2', 153).`
- `is_builtin_pred(copy_file, 2).`

## Tests

6 execution tests, all PASS:

| Test | What |
|---|---|
| `basic` | 5-byte source → `diff -q` confirms byte-identical copy |
| `empty` | Empty source → empty dest (read returns 0 first iteration) |
| `large` | 5000-line source (~25 KB) — multi-iteration loop past the 4 KB buffer |
| `missing_src` | Source doesn't exist → `open` fails → `copy_file` fails |
| `overwrite` | `O_TRUNC` — existing dest is replaced with new content |
| `bad_args` | Non-atom args fail type guards |

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — libc declarations, dispatch entry, `builtin_copy_file` body, op-id table.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 6 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke) ✓
- [x] All 6 M128 tests PASS individually ✓
- [ ] Full suite regression check

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_