### PR TITLE
LLVM WAM: read_file_to_atom/2 (M129) -- stat + open + read-loop

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3697,6 +3697,7 @@ entry:
     i32 151, label %builtin_uname_sysname
     i32 152, label %builtin_uname_machine
     i32 153, label %builtin_copy_file
+    i32 154, label %builtin_read_file_to_atom
   ]
 
 builtin_is:
@@ -6857,6 +6858,73 @@ cpf.close_both_fail:
   call i32 @close(i32 %cpf.src_fd)
   call i32 @close(i32 %cpf.dst_fd)
   ret i1 false
+
+builtin_read_file_to_atom:
+  ; M129: read_file_to_atom(+Path, -Atom) -- reads the entire file
+  ; at Path into an atom. Uses stat() to size the destination
+  ; buffer up front (st_size at offset 48, same as M76 size_file)
+  ; then arena_alloc(size+1) and a read-loop that handles short
+  ; reads (signal interruption etc) by tracking the offset and
+  ; reading remain bytes each iteration. Fails on stat error,
+  ; open error, premature EOF (read returns 0 with bytes still
+  ; outstanding -- e.g. file shrunk underneath us), or read error.
+  ; Bytes are interned verbatim including any embedded nulls;
+  ; the trailing null is added so the arena-backed atom remains
+  ; valid as a C string for downstream consumers.
+  %rfta.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %rfta.t1 = call i32 @value_tag(%Value %rfta.a1)
+  %rfta.is_atom = icmp eq i32 %rfta.t1, 0
+  br i1 %rfta.is_atom, label %rfta.go, label %rfta.fail
+rfta.fail:
+  ret i1 false
+rfta.go:
+  %rfta.aid = call i64 @value_payload(%Value %rfta.a1)
+  %rfta.path = call i8* @wam_atom_to_string(i64 %rfta.aid)
+  %rfta.path_null = icmp eq i8* %rfta.path, null
+  br i1 %rfta.path_null, label %rfta.fail, label %rfta.stat
+rfta.stat:
+  %rfta.statbuf = alloca [256 x i8]
+  %rfta.statbuf_ptr = getelementptr [256 x i8], [256 x i8]* %rfta.statbuf, i32 0, i32 0
+  %rfta.stat_ret = call i32 @stat(i8* %rfta.path, i8* %rfta.statbuf_ptr)
+  %rfta.stat_ok = icmp eq i32 %rfta.stat_ret, 0
+  br i1 %rfta.stat_ok, label %rfta.read_size, label %rfta.fail
+rfta.read_size:
+  %rfta.size_ptr_i8 = getelementptr i8, i8* %rfta.statbuf_ptr, i64 48
+  %rfta.size_ptr = bitcast i8* %rfta.size_ptr_i8 to i64*
+  %rfta.size = load i64, i64* %rfta.size_ptr
+  %rfta.fd = call i32 @open(i8* %rfta.path, i32 0, i32 0)
+  %rfta.open_ok = icmp sge i32 %rfta.fd, 0
+  br i1 %rfta.open_ok, label %rfta.alloc, label %rfta.fail
+rfta.alloc:
+  call void @wam_arena_ensure()
+  %rfta.bufsize = add i64 %rfta.size, 1
+  %rfta.arena = call i8* @wam_arena_alloc(i64 %rfta.bufsize)
+  %rfta.empty = icmp eq i64 %rfta.size, 0
+  br i1 %rfta.empty, label %rfta.finalize, label %rfta.loop
+rfta.loop:
+  %rfta.off = phi i64 [ 0, %rfta.alloc ], [ %rfta.off_next, %rfta.advance ]
+  %rfta.remain = sub i64 %rfta.size, %rfta.off
+  %rfta.read_at = getelementptr i8, i8* %rfta.arena, i64 %rfta.off
+  %rfta.n = call i64 @read(i32 %rfta.fd, i8* %rfta.read_at, i64 %rfta.remain)
+  %rfta.n_le_zero = icmp sle i64 %rfta.n, 0
+  br i1 %rfta.n_le_zero, label %rfta.close_fail, label %rfta.advance
+rfta.advance:
+  %rfta.off_next = add i64 %rfta.off, %rfta.n
+  %rfta.done = icmp eq i64 %rfta.off_next, %rfta.size
+  br i1 %rfta.done, label %rfta.finalize, label %rfta.loop
+rfta.close_fail:
+  call i32 @close(i32 %rfta.fd)
+  ret i1 false
+rfta.finalize:
+  call i32 @close(i32 %rfta.fd)
+  %rfta.term = getelementptr i8, i8* %rfta.arena, i64 %rfta.size
+  store i8 0, i8* %rfta.term
+  %rfta.atom_id = call i64 @wam_intern_atom(i8* %rfta.arena, i64 %rfta.size)
+  %rfta.v0 = insertvalue %Value undef, i32 0, 0
+  %rfta.v = insertvalue %Value %rfta.v0, i64 %rfta.atom_id, 1
+  %rfta.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %rfta.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %rfta.raw2, %Value %rfta.v)
+  ret i1 %rfta.uok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -14164,6 +14232,7 @@ builtin_op_to_id('getlogin/1', 150).          % libc getlogin() as atom.
 builtin_op_to_id('uname_sysname/1', 151).     % libc uname() sysname field as atom.
 builtin_op_to_id('uname_machine/1', 152).     % libc uname() machine field as atom.
 builtin_op_to_id('copy_file/2', 153).         % open + read/write loop + close.
+builtin_op_to_id('read_file_to_atom/2', 154). % stat + open + read loop -> intern as atom.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2254,6 +2254,7 @@ is_builtin_pred(getlogin, 1).           % getlogin(-Name) -- libc getlogin.
 is_builtin_pred(uname_sysname, 1).      % uname_sysname(-Sysname).
 is_builtin_pred(uname_machine, 1).      % uname_machine(-Machine).
 is_builtin_pred(copy_file, 2).          % copy_file(+Src, +Dst) -- open/read/write/close.
+is_builtin_pred(read_file_to_atom, 2).  % read_file_to_atom(+Path, -Atom).
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -3192,6 +3192,54 @@ test_copy_file_bad_args(_, R) :-
     ; R is 1
     ).   % 1
 
+% M129: read_file_to_atom/2 -- stat + open + read loop -> atom.
+
+:- dynamic test_rfta_short/2.
+test_rfta_short(_, R) :-
+    % Write a known short string, read it back, compare.
+    shell('printf hello > /tmp/uw_m129_short', _),
+    read_file_to_atom('/tmp/uw_m129_short', A),
+    shell('rm -f /tmp/uw_m129_short', _),
+    ( A == hello -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_rfta_empty/2.
+test_rfta_empty(_, R) :-
+    % Empty file -> empty atom (size=0 branch, skip read loop).
+    shell('rm -f /tmp/uw_m129_empty', _),
+    shell('touch /tmp/uw_m129_empty', _),
+    read_file_to_atom('/tmp/uw_m129_empty', A),
+    shell('rm -f /tmp/uw_m129_empty', _),
+    ( A == '' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_rfta_large/2.
+test_rfta_large(_, R) :-
+    % File larger than typical read chunks -- verifies the read
+    % loop handles multiple iterations to fill the buffer.
+    shell('seq 1 5000 > /tmp/uw_m129_large', _),
+    read_file_to_atom('/tmp/uw_m129_large', A),
+    atom_length(A, L),
+    size_file('/tmp/uw_m129_large', Sz),
+    shell('rm -f /tmp/uw_m129_large', _),
+    ( L =:= Sz, L > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_rfta_missing/2.
+test_rfta_missing(_, R) :-
+    % stat fails on missing path -> read_file_to_atom fails.
+    ( read_file_to_atom('/tmp/uw_m129_never_existed', _) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_rfta_bad_arg/2.
+test_rfta_bad_arg(_, R) :-
+    ( read_file_to_atom(42, _) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_rfta_size_matches/2.
+test_rfta_size_matches(_, R) :-
+    % atom_length of the read content must equal stat''s st_size.
+    shell('printf "hello world" > /tmp/uw_m129_sz', _),
+    read_file_to_atom('/tmp/uw_m129_sz', A),
+    atom_length(A, L),
+    shell('rm -f /tmp/uw_m129_sz', _),
+    ( L =:= 11 -> R is 1 ; R is 0 ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -6278,6 +6326,19 @@ test_all :-
                    test_copy_file_overwrite, 0, 1),
        run_test_r0('copy_file with non-atom args fails -> 1',
                    test_copy_file_bad_args, 0, 1),
+       format('--- M129 read_file_to_atom/2 ---~n'),
+       run_test_r0('read_file_to_atom short ascii -> 1',
+                   test_rfta_short, 0, 1),
+       run_test_r0('read_file_to_atom empty -> '''' -> 1',
+                   test_rfta_empty, 0, 1),
+       run_test_r0('read_file_to_atom large file (loop) -> 1',
+                   test_rfta_large, 0, 1),
+       run_test_r0('read_file_to_atom missing path fails -> 1',
+                   test_rfta_missing, 0, 1),
+       run_test_r0('read_file_to_atom non-atom arg fails -> 1',
+                   test_rfta_bad_arg, 0, 1),
+       run_test_r0('read_file_to_atom length matches stat size -> 1',
+                   test_rfta_size_matches, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds `read_file_to_atom(+Path, -Atom)` as op id 154 — the **read-side companion** to M128's `copy_file/2`. Reads the entire file at `Path` into a single atom (preserving embedded null bytes), using `stat` to size the destination buffer up front and a read-loop that handles short reads.

## Algorithm

1. Type-guard `Path` as Atom.
2. `stat(path, &statbuf)` — fail on stat error (e.g. ENOENT).
3. `size = i64` at offset 48 (`st_size`; same as M76 `size_file`).
4. `open(path, O_RDONLY=0, 0)` — fail on open error.
5. `arena_alloc(size + 1)` for content + trailing null.
6. **Empty file**: skip the read loop, jump to finalize with size=0.
7. Otherwise loop:
   - `n = read(fd, arena+offset, size-offset)`
   - `n <= 0` with bytes still outstanding → close fd, fail
   - else `offset += n`; if `offset == size` → finalize
8. **Finalize**: close fd, store `'\0'` at `arena+size`, `intern_atom`, unify with reg 1.

Phi node tracks `offset` across loop iterations. Trailing null keeps the arena-backed atom valid as a C string for downstream consumers (`wam_atom_to_string` etc.).

## Failure modes

| Cause | Outcome |
|---|---|
| Non-atom Path | fail (type guard) |
| `stat` fails (missing path, EACCES) | fail |
| `open` fails | fail (after stat succeeded) |
| Read returns 0 with bytes outstanding (file shrunk) | fail, fd closed |
| Read returns -1 (EIO etc.) | fail, fd closed |

## libc

All needed declarations (`stat`, `open`, `read`, `close`, `llvm.memcpy`, `wam_intern_atom`) already imported by earlier milestones. No new declarations.

Prefix `rfta.` (no collisions).

## Three-site registration

- Dispatch switch entry 154
- `builtin_op_to_id('read_file_to_atom/2', 154).`
- `is_builtin_pred(read_file_to_atom, 2).`

## Tests

6 execution tests, all PASS:

| Test | What |
|---|---|
| `rfta_short` | `'hello'` file → atom `hello` |
| `rfta_empty` | empty file → `''` (size=0 fast path) |
| `rfta_large` | `seq 1..5000` (~25 KB) → `atom_length` matches `size_file` |
| `rfta_missing` | non-existent path → stat fails → graceful fail |
| `rfta_bad_arg` | non-atom Path → type guard fails |
| `rfta_size_matches` | 11-byte file → `atom_length =:= 11` |

## Known M108 counter quirk (workaround applied)

The initial round-trip test combined `copy_file` followed by two `read_file_to_atom` calls in a single body. That trips the module-level instruction-counter side-channel (M108) by 2 — `llc` rejects the array literal as `[36 x %Instruction]` declared as `[38 x %Instruction]`. Workaround: split such complex tests across smaller bodies. Documented in the commit message; the underlying counter bug is a separate issue.

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — dispatch entry, `builtin_read_file_to_atom` body, op-id table.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 6 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke) ✓
- [x] All 6 M129 tests PASS individually ✓
- [ ] Full suite regression check

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_