### PR TITLE
LLVM WAM: write_atom_to_file/2 + append_atom_to_file/2 (M130)

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3698,6 +3698,8 @@ entry:
     i32 152, label %builtin_uname_machine
     i32 153, label %builtin_copy_file
     i32 154, label %builtin_read_file_to_atom
+    i32 155, label %builtin_write_atom_to_file
+    i32 156, label %builtin_append_atom_to_file
   ]
 
 builtin_is:
@@ -6925,6 +6927,116 @@ rfta.finalize:
   %rfta.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
   %rfta.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %rfta.raw2, %Value %rfta.v)
   ret i1 %rfta.uok
+
+builtin_write_atom_to_file:
+  ; M130: write_atom_to_file(+Path, +Content) -- writes Content
+  ; (atom) to Path (atom), truncating any existing file. Uses
+  ; O_WRONLY|O_CREAT|O_TRUNC (= 577 on Linux glibc) with mode 0644
+  ; (= 420 decimal). Write-loop handles short writes by tracking
+  ; how many bytes are still outstanding. Closes the fd in both
+  ; success and failure paths.
+  %wfa.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %wfa.t1 = call i32 @value_tag(%Value %wfa.a1)
+  %wfa.is_atom1 = icmp eq i32 %wfa.t1, 0
+  br i1 %wfa.is_atom1, label %wfa.check2, label %wfa.fail
+wfa.fail:
+  ret i1 false
+wfa.check2:
+  %wfa.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %wfa.t2 = call i32 @value_tag(%Value %wfa.a2)
+  %wfa.is_atom2 = icmp eq i32 %wfa.t2, 0
+  br i1 %wfa.is_atom2, label %wfa.have_args, label %wfa.fail
+wfa.have_args:
+  %wfa.path_aid = call i64 @value_payload(%Value %wfa.a1)
+  %wfa.path = call i8* @wam_atom_to_string(i64 %wfa.path_aid)
+  %wfa.path_null = icmp eq i8* %wfa.path, null
+  br i1 %wfa.path_null, label %wfa.fail, label %wfa.have_path
+wfa.have_path:
+  %wfa.content_aid = call i64 @value_payload(%Value %wfa.a2)
+  %wfa.content = call i8* @wam_atom_to_string(i64 %wfa.content_aid)
+  %wfa.content_null = icmp eq i8* %wfa.content, null
+  br i1 %wfa.content_null, label %wfa.fail, label %wfa.open
+wfa.open:
+  ; O_WRONLY (1) | O_CREAT (64) | O_TRUNC (512) = 577 on Linux glibc.
+  %wfa.fd = call i32 @open(i8* %wfa.path, i32 577, i32 420)
+  %wfa.open_ok = icmp sge i32 %wfa.fd, 0
+  br i1 %wfa.open_ok, label %wfa.size, label %wfa.fail
+wfa.size:
+  %wfa.len = call i64 @strlen(i8* %wfa.content)
+  %wfa.empty = icmp eq i64 %wfa.len, 0
+  br i1 %wfa.empty, label %wfa.success, label %wfa.loop
+wfa.loop:
+  %wfa.off = phi i64 [ 0, %wfa.size ], [ %wfa.off_next, %wfa.advance ]
+  %wfa.remain = sub i64 %wfa.len, %wfa.off
+  %wfa.write_at = getelementptr i8, i8* %wfa.content, i64 %wfa.off
+  %wfa.n = call i64 @write(i32 %wfa.fd, i8* %wfa.write_at, i64 %wfa.remain)
+  %wfa.n_le_zero = icmp sle i64 %wfa.n, 0
+  br i1 %wfa.n_le_zero, label %wfa.close_fail, label %wfa.advance
+wfa.advance:
+  %wfa.off_next = add i64 %wfa.off, %wfa.n
+  %wfa.done = icmp eq i64 %wfa.off_next, %wfa.len
+  br i1 %wfa.done, label %wfa.success, label %wfa.loop
+wfa.close_fail:
+  call i32 @close(i32 %wfa.fd)
+  ret i1 false
+wfa.success:
+  call i32 @close(i32 %wfa.fd)
+  ret i1 true
+
+builtin_append_atom_to_file:
+  ; M130: append_atom_to_file(+Path, +Content) -- writes Content
+  ; to Path, creating it if it doesn''t exist and appending to
+  ; any existing contents. Uses O_WRONLY|O_CREAT|O_APPEND
+  ; (= 1089 on Linux glibc: 1|64|1024) with mode 0644. Same
+  ; short-write loop as write_atom_to_file -- only the open
+  ; flags differ.
+  %afa.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %afa.t1 = call i32 @value_tag(%Value %afa.a1)
+  %afa.is_atom1 = icmp eq i32 %afa.t1, 0
+  br i1 %afa.is_atom1, label %afa.check2, label %afa.fail
+afa.fail:
+  ret i1 false
+afa.check2:
+  %afa.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %afa.t2 = call i32 @value_tag(%Value %afa.a2)
+  %afa.is_atom2 = icmp eq i32 %afa.t2, 0
+  br i1 %afa.is_atom2, label %afa.have_args, label %afa.fail
+afa.have_args:
+  %afa.path_aid = call i64 @value_payload(%Value %afa.a1)
+  %afa.path = call i8* @wam_atom_to_string(i64 %afa.path_aid)
+  %afa.path_null = icmp eq i8* %afa.path, null
+  br i1 %afa.path_null, label %afa.fail, label %afa.have_path
+afa.have_path:
+  %afa.content_aid = call i64 @value_payload(%Value %afa.a2)
+  %afa.content = call i8* @wam_atom_to_string(i64 %afa.content_aid)
+  %afa.content_null = icmp eq i8* %afa.content, null
+  br i1 %afa.content_null, label %afa.fail, label %afa.open
+afa.open:
+  ; O_WRONLY (1) | O_CREAT (64) | O_APPEND (1024) = 1089 on Linux glibc.
+  %afa.fd = call i32 @open(i8* %afa.path, i32 1089, i32 420)
+  %afa.open_ok = icmp sge i32 %afa.fd, 0
+  br i1 %afa.open_ok, label %afa.size, label %afa.fail
+afa.size:
+  %afa.len = call i64 @strlen(i8* %afa.content)
+  %afa.empty = icmp eq i64 %afa.len, 0
+  br i1 %afa.empty, label %afa.success, label %afa.loop
+afa.loop:
+  %afa.off = phi i64 [ 0, %afa.size ], [ %afa.off_next, %afa.advance ]
+  %afa.remain = sub i64 %afa.len, %afa.off
+  %afa.write_at = getelementptr i8, i8* %afa.content, i64 %afa.off
+  %afa.n = call i64 @write(i32 %afa.fd, i8* %afa.write_at, i64 %afa.remain)
+  %afa.n_le_zero = icmp sle i64 %afa.n, 0
+  br i1 %afa.n_le_zero, label %afa.close_fail, label %afa.advance
+afa.advance:
+  %afa.off_next = add i64 %afa.off, %afa.n
+  %afa.done = icmp eq i64 %afa.off_next, %afa.len
+  br i1 %afa.done, label %afa.success, label %afa.loop
+afa.close_fail:
+  call i32 @close(i32 %afa.fd)
+  ret i1 false
+afa.success:
+  call i32 @close(i32 %afa.fd)
+  ret i1 true
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -14233,6 +14345,8 @@ builtin_op_to_id('uname_sysname/1', 151).     % libc uname() sysname field as at
 builtin_op_to_id('uname_machine/1', 152).     % libc uname() machine field as atom.
 builtin_op_to_id('copy_file/2', 153).         % open + read/write loop + close.
 builtin_op_to_id('read_file_to_atom/2', 154). % stat + open + read loop -> intern as atom.
+builtin_op_to_id('write_atom_to_file/2', 155). % open(O_TRUNC) + write loop + close.
+builtin_op_to_id('append_atom_to_file/2', 156). % open(O_APPEND) + write loop + close.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2255,6 +2255,8 @@ is_builtin_pred(uname_sysname, 1).      % uname_sysname(-Sysname).
 is_builtin_pred(uname_machine, 1).      % uname_machine(-Machine).
 is_builtin_pred(copy_file, 2).          % copy_file(+Src, +Dst) -- open/read/write/close.
 is_builtin_pred(read_file_to_atom, 2).  % read_file_to_atom(+Path, -Atom).
+is_builtin_pred(write_atom_to_file, 2). % write_atom_to_file(+Path, +Content) -- O_TRUNC.
+is_builtin_pred(append_atom_to_file, 2). % append_atom_to_file(+Path, +Content) -- O_APPEND.
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -3240,6 +3240,76 @@ test_rfta_size_matches(_, R) :-
     shell('rm -f /tmp/uw_m129_sz', _),
     ( L =:= 11 -> R is 1 ; R is 0 ).   % 1
 
+% M130: write_atom_to_file/2 + append_atom_to_file/2.
+
+:- dynamic test_wfa_basic/2.
+test_wfa_basic(_, R) :-
+    % Write a known atom, read it back via shell + diff.
+    shell('rm -f /tmp/uw_m130_w', _),
+    write_atom_to_file('/tmp/uw_m130_w', 'hello world'),
+    size_file('/tmp/uw_m130_w', Sz),
+    shell('rm -f /tmp/uw_m130_w', _),
+    ( Sz =:= 11 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_wfa_empty/2.
+test_wfa_empty(_, R) :-
+    % Empty content -> 0-byte file (size=0 fast path skips loop).
+    shell('rm -f /tmp/uw_m130_we', _),
+    write_atom_to_file('/tmp/uw_m130_we', ''),
+    size_file('/tmp/uw_m130_we', Sz),
+    shell('rm -f /tmp/uw_m130_we', _),
+    ( Sz =:= 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_wfa_truncates/2.
+test_wfa_truncates(_, R) :-
+    % O_TRUNC: existing larger file gets replaced with shorter.
+    shell('printf "lots_of_old_content_here" > /tmp/uw_m130_wt', _),
+    write_atom_to_file('/tmp/uw_m130_wt', new),
+    size_file('/tmp/uw_m130_wt', Sz),
+    shell('rm -f /tmp/uw_m130_wt', _),
+    ( Sz =:= 3 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_wfa_round_trip/2.
+test_wfa_round_trip(_, R) :-
+    % Write then read returns the same atom.
+    shell('rm -f /tmp/uw_m130_rt', _),
+    write_atom_to_file('/tmp/uw_m130_rt', 'abcdefghij'),
+    read_file_to_atom('/tmp/uw_m130_rt', A),
+    shell('rm -f /tmp/uw_m130_rt', _),
+    ( A == 'abcdefghij' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_wfa_bad_args/2.
+test_wfa_bad_args(_, R) :-
+    ( write_atom_to_file(42, abc) -> R is 0
+    ; write_atom_to_file('/tmp/x', 99) -> R is 0
+    ; R is 1
+    ).   % 1
+
+:- dynamic test_afa_creates/2.
+test_afa_creates(_, R) :-
+    % Append to a non-existent file -> creates it (O_CREAT).
+    shell('rm -f /tmp/uw_m130_ac', _),
+    append_atom_to_file('/tmp/uw_m130_ac', start),
+    size_file('/tmp/uw_m130_ac', Sz),
+    shell('rm -f /tmp/uw_m130_ac', _),
+    ( Sz =:= 5 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_afa_extends/2.
+test_afa_extends(_, R) :-
+    % Append to an existing file -> total length is sum.
+    shell('printf "abc" > /tmp/uw_m130_ae', _),
+    append_atom_to_file('/tmp/uw_m130_ae', defg),
+    size_file('/tmp/uw_m130_ae', Sz),
+    shell('rm -f /tmp/uw_m130_ae', _),
+    ( Sz =:= 7 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_afa_bad_args/2.
+test_afa_bad_args(_, R) :-
+    ( append_atom_to_file(42, abc) -> R is 0
+    ; append_atom_to_file('/tmp/x', 99) -> R is 0
+    ; R is 1
+    ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -6339,6 +6409,23 @@ test_all :-
                    test_rfta_bad_arg, 0, 1),
        run_test_r0('read_file_to_atom length matches stat size -> 1',
                    test_rfta_size_matches, 0, 1),
+       format('--- M130 write_atom_to_file/2 + append_atom_to_file/2 ---~n'),
+       run_test_r0('write 11-byte atom -> size 11 -> 1',
+                   test_wfa_basic, 0, 1),
+       run_test_r0('write empty atom -> size 0 -> 1',
+                   test_wfa_empty, 0, 1),
+       run_test_r0('write O_TRUNC shrinks existing file -> 1',
+                   test_wfa_truncates, 0, 1),
+       run_test_r0('write then read round-trip -> 1',
+                   test_wfa_round_trip, 0, 1),
+       run_test_r0('write with non-atom args fails -> 1',
+                   test_wfa_bad_args, 0, 1),
+       run_test_r0('append creates new file -> 1',
+                   test_afa_creates, 0, 1),
+       run_test_r0('append extends existing file -> 1',
+                   test_afa_extends, 0, 1),
+       run_test_r0('append with non-atom args fails -> 1',
+                   test_afa_bad_args, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds the write-side companions to M129 `read_file_to_atom/2`:

- `write_atom_to_file/2` (op id 155) — `open(O_TRUNC) + write loop + close`
- `append_atom_to_file/2` (op id 156) — `open(O_APPEND) + write loop + close`

Together with M128 `copy_file/2` and M129 `read_file_to_atom/2`, the LLVM target now has a complete read/write/copy/append set for file content as atoms.

## Algorithm (shared by both)

1. Type-guard `Path` and `Content` as Atom.
2. `open(Path, flags, 0o644)` — fail if `< 0`.
3. `strlen(Content)`.
4. **Empty content fast path**: skip the loop, jump to success.
5. Otherwise loop:
   - `n = write(fd, content+offset, len-offset)`
   - `n <= 0` → close fd, fail (short-write/EINTR rolled into the retry path naturally because we offset by `n`, but `n == 0` or `< 0` is treated as failure)
   - else `offset += n`; if `offset == len` → success
6. close fd in both success and failure paths.

## Open flags (Linux glibc)

| Predicate | Flags | Value |
|---|---|---|
| `write_atom_to_file/2` | `O_WRONLY \| O_CREAT \| O_TRUNC` | `1 \| 64 \| 512 = 577` |
| `append_atom_to_file/2` | `O_WRONLY \| O_CREAT \| O_APPEND` | `1 \| 64 \| 1024 = 1089` |

Both use mode `0o644` (= 420 decimal) for newly-created files.

`O_APPEND` makes each `write(2)` atomic with respect to other writers — no race even from concurrent processes.

## Portability

macOS / BSDs use different `O_CREAT` (= 512), `O_TRUNC` (= 1024), `O_APPEND` (= 8) values. Documented as a known limitation; portable handling would dispatch through the M113 `target_os` framework.

## Three-site registration

- Dispatch switch entries 155, 156
- `builtin_op_to_id` × 2
- `is_builtin_pred` × 2 in `wam_target.pl`

Prefixes `wfa.` / `afa.` (no collisions).

## Tests

8 execution tests, all PASS:

`write_atom_to_file`:
- Write 11-byte `'hello world'` → `size_file` reports 11
- Empty atom → 0-byte file (empty-content fast path)
- O_TRUNC: existing 24-byte file replaced with 3-byte content → size 3
- Write then read round-trip returns the same atom
- Non-atom args fail type guards

`append_atom_to_file`:
- Append to non-existent path → creates 5-byte file
- Append to existing 3-byte file → 7 bytes (3 + 4)
- Non-atom args fail

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — dispatch entries, two new builtin bodies, op-id table.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred` × 2.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 8 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke) ✓
- [x] All 8 M130 tests PASS individually ✓
- [ ] Full suite regression check

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_