### PR TITLE
LLVM WAM: errno/1 + strerror/2 (M131) -- libc-failure diagnostics

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1577,6 +1577,8 @@ declare i32 @uname(i8*)
 declare i32 @open(i8*, i32, i32)
 declare i64 @read(i32, i8*, i64)
 declare i64 @write(i32, i8*, i64)
+declare i32* @__errno_location()
+declare i8* @strerror(i32)
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3700,6 +3702,8 @@ entry:
     i32 154, label %builtin_read_file_to_atom
     i32 155, label %builtin_write_atom_to_file
     i32 156, label %builtin_append_atom_to_file
+    i32 157, label %builtin_errno
+    i32 158, label %builtin_strerror
   ]
 
 builtin_is:
@@ -7037,6 +7041,56 @@ afa.close_fail:
 afa.success:
   call i32 @close(i32 %afa.fd)
   ret i1 true
+
+builtin_errno:
+  ; M131: errno(-N) -- reads the thread-local errno value via
+  ; __errno_location(). Useful right after a failing libc-wrapper
+  ; predicate to find out WHY: a typical pattern is
+  ;     ( delete_file(P) ; errno(E), strerror(E, M), format(...) )
+  ; Note that any libc call between the failure and errno/1 will
+  ; clobber the value -- so call errno BEFORE any other diagnostic
+  ; predicate. Always succeeds (returns 0 when no error pending).
+  %ern.loc = call i32* @__errno_location()
+  %ern.val32 = load i32, i32* %ern.loc
+  %ern.val64 = sext i32 %ern.val32 to i64
+  %ern.v = call %Value @value_integer(i64 %ern.val64)
+  %ern.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
+  %ern.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %ern.raw1, %Value %ern.v)
+  ret i1 %ern.ok
+
+builtin_strerror:
+  ; M131: strerror(+Errno, -Message) -- libc strerror wrapper.
+  ; Returns the human-readable description of Errno as an atom
+  ; ("No such file or directory", "Permission denied", etc.).
+  ; Errno must be Integer; non-int fails type guard. libc returns
+  ; a pointer into static thread-local storage that''s safe to
+  ; intern immediately.
+  %ser.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %ser.t1 = call i32 @value_tag(%Value %ser.a1)
+  %ser.is_int = icmp eq i32 %ser.t1, 1
+  br i1 %ser.is_int, label %ser.go, label %ser.fail
+ser.fail:
+  ret i1 false
+ser.go:
+  %ser.e64 = call i64 @value_payload(%Value %ser.a1)
+  %ser.e = trunc i64 %ser.e64 to i32
+  %ser.s = call i8* @strerror(i32 %ser.e)
+  %ser.s_null = icmp eq i8* %ser.s, null
+  br i1 %ser.s_null, label %ser.fail, label %ser.intern
+ser.intern:
+  %ser.len = call i64 @strlen(i8* %ser.s)
+  call void @wam_arena_ensure()
+  %ser.bufsize = add i64 %ser.len, 1
+  %ser.arena = call i8* @wam_arena_alloc(i64 %ser.bufsize)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %ser.arena, i8* %ser.s, i64 %ser.len, i1 false)
+  %ser.term = getelementptr i8, i8* %ser.arena, i64 %ser.len
+  store i8 0, i8* %ser.term
+  %ser.aid = call i64 @wam_intern_atom(i8* %ser.arena, i64 %ser.len)
+  %ser.v0 = insertvalue %Value undef, i32 0, 0
+  %ser.v = insertvalue %Value %ser.v0, i64 %ser.aid, 1
+  %ser.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %ser.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %ser.raw2, %Value %ser.v)
+  ret i1 %ser.uok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -14347,6 +14401,8 @@ builtin_op_to_id('copy_file/2', 153).         % open + read/write loop + close.
 builtin_op_to_id('read_file_to_atom/2', 154). % stat + open + read loop -> intern as atom.
 builtin_op_to_id('write_atom_to_file/2', 155). % open(O_TRUNC) + write loop + close.
 builtin_op_to_id('append_atom_to_file/2', 156). % open(O_APPEND) + write loop + close.
+builtin_op_to_id('errno/1', 157).             % thread-local errno via __errno_location.
+builtin_op_to_id('strerror/2', 158).          % libc strerror(errno) as atom.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2257,6 +2257,8 @@ is_builtin_pred(copy_file, 2).          % copy_file(+Src, +Dst) -- open/read/wri
 is_builtin_pred(read_file_to_atom, 2).  % read_file_to_atom(+Path, -Atom).
 is_builtin_pred(write_atom_to_file, 2). % write_atom_to_file(+Path, +Content) -- O_TRUNC.
 is_builtin_pred(append_atom_to_file, 2). % append_atom_to_file(+Path, +Content) -- O_APPEND.
+is_builtin_pred(errno, 1).              % errno(-N) -- thread-local errno.
+is_builtin_pred(strerror, 2).           % strerror(+Errno, -Message).
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -3310,6 +3310,48 @@ test_afa_bad_args(_, R) :-
     ; R is 1
     ).   % 1
 
+% M131: errno/1 + strerror/2 -- diagnostics for libc-wrapper failures.
+
+:- dynamic test_errno_returns_int/2.
+test_errno_returns_int(_, R) :-
+    % errno/1 always succeeds and returns an Integer (often 0).
+    errno(E),
+    ( integer(E) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_errno_after_open_fail/2.
+test_errno_after_open_fail(_, R) :-
+    % After a deliberately-failing open (via delete_file on missing
+    % path), errno should be set to a non-zero value (ENOENT = 2).
+    ( delete_file('/tmp/uw_m131_never_existed') -> R is 0
+    ; errno(E),
+      ( E =\= 0 -> R is 1 ; R is 0 )
+    ).   % 1
+
+:- dynamic test_strerror_known_errno/2.
+test_strerror_known_errno(_, R) :-
+    % ENOENT = 2 -> "No such file or directory".
+    strerror(2, M),
+    ( atom(M), atom_length(M, L), L > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_strerror_zero/2.
+test_strerror_zero(_, R) :-
+    % strerror(0) is typically "Success".
+    strerror(0, M),
+    ( atom(M), atom_length(M, L), L > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_strerror_round_trip/2.
+test_strerror_round_trip(_, R) :-
+    % errno -> strerror should yield a non-empty atom even for
+    % errno=0 ("Success" / "No error").
+    errno(E),
+    strerror(E, M),
+    atom_length(M, L),
+    ( L > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_strerror_bad_arg/2.
+test_strerror_bad_arg(_, R) :-
+    ( strerror(not_int, _) -> R is 0 ; R is 1 ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -6426,6 +6468,19 @@ test_all :-
                    test_afa_extends, 0, 1),
        run_test_r0('append with non-atom args fails -> 1',
                    test_afa_bad_args, 0, 1),
+       format('--- M131 errno/1 + strerror/2 ---~n'),
+       run_test_r0('errno returns Integer -> 1',
+                   test_errno_returns_int, 0, 1),
+       run_test_r0('errno after failing delete_file != 0 -> 1',
+                   test_errno_after_open_fail, 0, 1),
+       run_test_r0('strerror(2) non-empty atom -> 1',
+                   test_strerror_known_errno, 0, 1),
+       run_test_r0('strerror(0) non-empty atom -> 1',
+                   test_strerror_zero, 0, 1),
+       run_test_r0('errno -> strerror round-trip non-empty -> 1',
+                   test_strerror_round_trip, 0, 1),
+       run_test_r0('strerror(not_int, _) fails -> 1',
+                   test_strerror_bad_arg, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds **diagnostic** predicates so callers can find out *why* a libc-wrapper predicate failed:

- `errno/1` (op id 157) — thread-local `errno` value
- `strerror/2` (op id 158) — libc `strerror()` as atom

With ~30 libc one-liners across M86..M130 each silently mapping `-1` to Prolog `fail`, this fills a real visibility gap.

## Typical usage

```prolog
( delete_file(P)
; errno(E), strerror(E, M),
  format('delete_file failed: ~w~n', [M])
)
```

## `errno(-N)`

Reads the thread-local `errno` via libc `__errno_location()` and returns it as Integer. Always succeeds (`errno = 0` when no pending error).

**Caveat**: any libc call between the failing predicate and `errno/1` clobbers the value. Call `errno` **before** any further diagnostic predicate.

## `strerror(+Errno, -Message)`

Wraps libc `strerror(int)`. Returns the human-readable description as an atom:
- `strerror(2)` → `'No such file or directory'` (ENOENT)
- `strerror(13)` → `'Permission denied'` (EACCES)
- `strerror(0)` → `'Success'`

`Errno` must be Integer; non-int fails type guard. libc returns a pointer into static thread-local storage that's safe to intern immediately.

## libc declarations

```llvm
declare i32* @__errno_location()
declare i8* @strerror(i32)
```

(`strlen`, `llvm.memcpy`, `wam_intern_atom` already imported.)

Prefixes `ern.` / `ser.` (no collisions).

## Three-site registration

- Dispatch switch entries 157, 158
- `builtin_op_to_id` × 2
- `is_builtin_pred` × 2

## Tests

6 execution tests, all PASS:

| Test | What |
|---|---|
| `errno_returns_int` | `errno/1` always succeeds with Integer (typically 0) |
| `errno_after_open_fail` | After failing `delete_file` on missing path → `errno != 0` (ENOENT = 2) |
| `strerror_known_errno` | `strerror(2)` returns non-empty atom (`'No such file or directory'`) |
| `strerror_zero` | `strerror(0)` returns non-empty atom (`'Success'`) |
| `strerror_round_trip` | `errno` → `strerror` yields non-empty atom |
| `strerror_bad_arg` | Non-int Errno fails type guard |

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — libc declarations, dispatch entries, two new builtin bodies, op-id table.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred` × 2.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 6 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke) ✓
- [x] All 6 M131 tests PASS individually ✓
- [ ] Full suite regression check

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_