### PR TITLE
feat(RES): Phase 5a — F# WAM integration + recurrence_inputs helper

### DIFF
--- a/src/unifyweaver/core/recurrence_inputs.pl
+++ b/src/unifyweaver/core/recurrence_inputs.pl
@@ -1,0 +1,241 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+%
+% recurrence_inputs.pl — target-agnostic helpers for constructing
+% the Recurrence + Workload inputs to recurrence_evaluation_strategy:
+% select_evaluation_strategy/3.
+%
+% This module is used by every WAM target (F#, Haskell, C, ...) to
+% turn (detected kernel, caller options, manifest, relation-policy)
+% into the structured inputs the strategy selector expects.
+%
+% TARGET-AGNOSTIC INVARIANT: this module must NOT import or reference
+% any target-specific module or atom (no 'fsharp', 'haskell', 'c_target',
+% etc.). Enforced by two layers:
+%   - tests/core/test_recurrence_inputs_isolated.pl — load isolation
+%   - tests/core/test_recurrence_inputs_grep.pl     — grep tripwire
+%
+% Cross-references:
+%   - docs/design/RECURRENCE_EVALUATION_STRATEGY_SPECIFICATION.md
+%     §Helper module for input construction
+%   - docs/design/RECURRENCE_EVALUATION_STRATEGY_IMPLEMENTATION_PLAN.md
+%     §Phase 5
+
+:- module(recurrence_inputs, [
+    build_recurrence_term/3,             % +DetectedKernel, +ExtraProperties,
+                                         %   -Recurrence
+    build_workload_signals/2,            % +CallerOptions, -Workload
+
+    %% Introspection
+    kernel_kind_default_properties/2     % +KernelKind, -DefaultProperties
+]).
+
+:- use_module(library(error), [must_be/2]).
+:- use_module(library(lists), [member/2, append/3, memberchk/2]).
+:- use_module(library(apply), [foldl/4, maplist/3]).
+
+%% ============================================================
+%% build_recurrence_term(+DetectedKernel, +ExtraProperties,
+%%                       -Recurrence)
+%%
+%% DetectedKernel is `recursive_kernel(KernelKind, Pred/Arity,
+%% ConfigOps)` per recursive_kernel_detection.pl.
+%%
+%% ExtraProperties is a list of recurrence-property terms that
+%% override the defaults from kernel_kind_default_properties/2.
+%% Typically populated from algorithm_manifest:manifest_optimization_options/2
+%% by the target adapter; pass [] when none.
+%%
+%% Result Recurrence is `recurrence(KernelKind, Pred/Arity, Properties)`.
+%%
+%% Removed-from-spec keys are dropped: directions_admissible was
+%% explicitly removed from the SPEC's properties table and is now
+%% derived internally by the selector. If a ConfigOps entry uses
+%% that key, it is silently dropped here (this matches the SPEC's
+%% "build_recurrence_term/3 drops directions_admissible" note).
+%% ============================================================
+
+build_recurrence_term(recursive_kernel(KernelKind, Pred/Arity, ConfigOps),
+                      ExtraProperties,
+                      recurrence(KernelKind, Pred/Arity, Properties)) :-
+    must_be(atom, KernelKind),
+    must_be(atom, Pred),
+    must_be(nonneg, Arity),
+    must_be(list, ConfigOps),
+    must_be(list, ExtraProperties),
+    kernel_kind_default_properties(KernelKind, Defaults),
+    %% Merge: ExtraProperties take precedence over Defaults; drop
+    %% removed-from-spec keys (directions_admissible).
+    merge_properties(ExtraProperties, Defaults, Merged0),
+    drop_removed_properties(Merged0, Properties).
+
+%% merge_properties(+Override, +Defaults, -Merged)
+%
+% For each property functor in Override, replace the same-functor
+% entry from Defaults. Override entries with no Defaults counterpart
+% are appended.
+merge_properties(Overrides, Defaults, Merged) :-
+    foldl(merge_one_property, Overrides, Defaults, Merged0),
+    %% Add any Override entries whose functor wasn't in Defaults.
+    findall(O,
+            ( member(O, Overrides),
+              functor(O, F, A),
+              \+ ( member(D, Merged0), functor(D, F, A) )
+            ),
+            NewOverrides),
+    append(Merged0, NewOverrides, Merged).
+
+merge_one_property(Override, Defaults0, Defaults) :-
+    functor(Override, F, A),
+    (   select_same_functor(F, A, Defaults0, _, Rest)
+    ->  Defaults = [Override | Rest]
+    ;   Defaults = Defaults0
+    ).
+
+select_same_functor(F, A, [P|Rest], P, Rest) :-
+    functor(P, F, A), !.
+select_same_functor(F, A, [P|Rest], Found, [P|NewRest]) :-
+    select_same_functor(F, A, Rest, Found, NewRest).
+
+%% drop_removed_properties(+Properties0, -Properties)
+%
+% Drop properties whose keys were removed from the SPEC.
+drop_removed_properties(Properties0, Properties) :-
+    findall(P,
+            ( member(P, Properties0),
+              functor(P, F, _),
+              \+ removed_property(F)
+            ),
+            Properties).
+
+removed_property(directions_admissible).
+removed_property(expected_cardinality).  % duplicated cardinality(C); see SPEC
+
+%% ============================================================
+%% kernel_kind_default_properties(+KernelKind, -DefaultProperties)
+%%
+%% Per-kernel default Recurrence properties. Most kernels are
+%% combinatorial monotone(true) with combinatorial loop-breaking
+%% (visited-set in clause body). Numeric kernels override the
+%% value_domain. Future Bellman-Ford-style kernels would override
+%% with iteration_bound(N) once that property is added (see
+%% philosophy doc gap notes).
+%%
+%% MAINTENANCE NOTE: keep these defaults aligned with the kernel
+%% definitions in recursive_kernel_detection.pl. When a new
+%% detector is added there, add a defaults entry here.
+%% ============================================================
+
+%% Combinatorial Datalog-shape kernels
+kernel_kind_default_properties(category_ancestor,
+    [value_domain(combinatorial), monotone(true),
+     has_combinatorial_loop_break(true)]).
+kernel_kind_default_properties(transitive_closure2,
+    [value_domain(combinatorial), monotone(true),
+     has_combinatorial_loop_break(true)]).
+kernel_kind_default_properties(transitive_distance3,
+    [value_domain(combinatorial), monotone(true),
+     has_combinatorial_loop_break(true)]).
+kernel_kind_default_properties(transitive_parent_distance4,
+    [value_domain(combinatorial), monotone(true),
+     has_combinatorial_loop_break(true)]).
+kernel_kind_default_properties(transitive_step_parent_distance5,
+    [value_domain(combinatorial), monotone(true),
+     has_combinatorial_loop_break(true)]).
+
+%% bidirectional_ancestor (upgrade target from category_ancestor) —
+%% same defaults as category_ancestor.
+kernel_kind_default_properties(bidirectional_ancestor,
+    [value_domain(combinatorial), monotone(true),
+     has_combinatorial_loop_break(true)]).
+
+%% Numeric weighted kernels — value_domain(numeric). Dijkstra's
+%% safety on cyclic graphs comes from priority-queue monotonicity,
+%% NOT from visited-set; has_combinatorial_loop_break is omitted
+%% per the SPEC's "absent vs false" distinction.
+kernel_kind_default_properties(weighted_shortest_path3,
+    [value_domain(numeric), monotone(true)]).
+kernel_kind_default_properties(astar_shortest_path4,
+    [value_domain(numeric), monotone(true)]).
+
+%% Catch-all: any unknown KernelKind gets minimal defaults
+%% (combinatorial + monotone). Safer than failing — lets the
+%% selector compute admissibility from kernel_kind_strategies/2
+%% (which will return [] for truly unknown kernels and throw).
+kernel_kind_default_properties(_,
+    [value_domain(combinatorial), monotone(true)]).
+
+%% ============================================================
+%% build_workload_signals(+CallerOptions, -Workload)
+%%
+%% Translates a flat list of caller-provided Options into a
+%% Workload signal list per the SPEC's signal vocabulary.
+%%
+%% Caller-option key → workload-signal mapping:
+%%   kernel_mode(M)                   → kernel_mode(M)
+%%   strategy(S)                      → strategy(S)
+%%   force_search_algorithm(A)        → force_search_algorithm(A)
+%%   csr_path(P)                      → csr_path(P) + csr_available(true)
+%%                                      (csr_path implies CSR is present)
+%%   csr_available(B)                 → csr_available(B)
+%%   cardinality(C)                   → cardinality(C)
+%%   determinism(D)                   → determinism(D)
+%%   unique(B)                        → unique(B)
+%%   query_pattern(P)                 → query_pattern(P)
+%%   query_frequency(F)               → query_frequency(F)
+%%   graph_mutability(M)              → graph_mutability(M)
+%%   heuristic_predicate(P/A)         → heuristic_predicate_available(true)
+%%                                      + heuristic_predicate(P/A)
+%%   heuristic_predicate_available(B) → heuristic_predicate_available(B)
+%%   b_eff(F), branching_d(F),
+%%       contraction_r(F)             → passed through
+%%   csr_buildable(B)                 → csr_buildable(B)
+%%
+%% Other options (target-specific, unrecognised) are silently dropped
+%% from the workload — they're not signals the selector knows about
+%% and would pollute classify_signals/4 with unknown_signal warnings.
+%% ============================================================
+
+build_workload_signals(CallerOptions, Workload) :-
+    must_be(list, CallerOptions),
+    foldl(translate_option, CallerOptions, [], WorkloadReversed),
+    reverse(WorkloadReversed, Workload).
+
+reverse([], []).
+reverse([H|T], R) :- reverse_acc(T, [H], R).
+reverse_acc([], Acc, Acc).
+reverse_acc([H|T], Acc, R) :- reverse_acc(T, [H|Acc], R).
+
+%% translate_option(+Option, +Acc, -NewAcc)
+translate_option(kernel_mode(M),                 Acc, [kernel_mode(M) | Acc]).
+translate_option(strategy(S),                    Acc, [strategy(S) | Acc]).
+translate_option(force_search_algorithm(A),      Acc, [force_search_algorithm(A) | Acc]).
+
+%% csr_path implies csr_available(true) — add both signals.
+translate_option(csr_path(P), Acc, [csr_available(true), csr_path(P) | Acc]).
+translate_option(csr_available(B),               Acc, [csr_available(B) | Acc]).
+
+translate_option(cardinality(C),                 Acc, [cardinality(C) | Acc]).
+translate_option(determinism(D),                 Acc, [determinism(D) | Acc]).
+translate_option(unique(B),                      Acc, [unique(B) | Acc]).
+translate_option(query_pattern(P),               Acc, [query_pattern(P) | Acc]).
+translate_option(query_frequency(F),             Acc, [query_frequency(F) | Acc]).
+translate_option(graph_mutability(M),            Acc, [graph_mutability(M) | Acc]).
+
+%% heuristic_predicate(P/A) implies heuristic_predicate_available(true).
+translate_option(heuristic_predicate(PA),
+                 Acc,
+                 [heuristic_predicate_available(true), heuristic_predicate(PA) | Acc]).
+translate_option(heuristic_predicate_available(B),
+                 Acc,
+                 [heuristic_predicate_available(B) | Acc]).
+
+translate_option(b_eff(F),                       Acc, [b_eff(F) | Acc]).
+translate_option(branching_d(F),                 Acc, [branching_d(F) | Acc]).
+translate_option(contraction_r(F),               Acc, [contraction_r(F) | Acc]).
+translate_option(csr_buildable(B),               Acc, [csr_buildable(B) | Acc]).
+
+%% Catch-all: silently drop unrecognised options (target-specific
+%% keys that the selector doesn't model).
+translate_option(_, Acc, Acc).

--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -73,6 +73,10 @@
 :- use_module(library(option)).
 :- use_module(library(filesex), [make_directory_path/1, directory_file_path/3]).
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../core/recurrence_evaluation_strategy',
+              [select_evaluation_strategy/3]).
+:- use_module('../core/recurrence_inputs',
+              [build_recurrence_term/3, build_workload_signals/2]).
 :- use_module('../core/recursive_kernel_detection',
              [detect_recursive_kernel/4, kernel_metadata/4, kernel_config/2,
               kernel_register_layout/2, kernel_native_call/2, kernel_template_file/2]).
@@ -4595,6 +4599,50 @@ maybe_upgrade_bidirectional(Key-recursive_kernel(category_ancestor, PI, Config),
                             Key-recursive_kernel(bidirectional_ancestor, PI, Config)) :- !.
 maybe_upgrade_bidirectional(KV, KV).
 
+%% wam_fsharp_apply_strategy_selector(+ResWorkload, +KV0, -KV)
+%
+%  Phase 5a: per-kernel strategy-selector decision. Builds a
+%  Recurrence from the detected kernel, calls
+%  recurrence_evaluation_strategy:select_evaluation_strategy/3,
+%  then applies the resulting Strategy as a kernel upgrade if
+%  appropriate.
+%
+%  Currently the only auto-upgrade is category_ancestor →
+%  bidirectional_ancestor when the selector returns
+%  per_query(bidirectional). All other Strategy values leave the
+%  kernel unchanged. Phase 5b will additionally extract the
+%  Trace for the generated-F# comment header.
+%
+%  ResWorkload is the workload signal list built once per compile
+%  via recurrence_inputs:build_workload_signals/2.
+wam_fsharp_apply_strategy_selector(ResWorkload,
+                                   Key-DetectedKernel,
+                                   Key-MaybeUpgraded) :-
+    recurrence_inputs:build_recurrence_term(DetectedKernel, [], Recurrence),
+    recurrence_evaluation_strategy:select_evaluation_strategy(
+        Recurrence, ResWorkload,
+        strategy_choice(Strategy, _Trace)),
+    wam_fsharp_apply_strategy_choice(Strategy, DetectedKernel, MaybeUpgraded).
+
+%% wam_fsharp_apply_strategy_choice(+Strategy, +DetectedKernel, -UpgradedKernel)
+%
+%  Apply the selector's chosen strategy as a kernel-kind transformation.
+%
+%  Only one transformation is currently wired:
+%    per_query(bidirectional) + category_ancestor → bidirectional_ancestor
+%
+%  All other (Strategy, KernelKind) combinations leave the kernel
+%  unchanged (the kernel's existing per_query(unidirectional)
+%  template handles them).
+wam_fsharp_apply_strategy_choice(strategy(per_query(bidirectional)),
+                                 recursive_kernel(category_ancestor, PI, Config),
+                                 recursive_kernel(bidirectional_ancestor, PI, Config)) :-
+    !,
+    format(user_error,
+           '[WAM-FSharp] strategy-selector upgraded category_ancestor -> bidirectional_ancestor (~w)~n',
+           [PI]).
+wam_fsharp_apply_strategy_choice(_, Kernel, Kernel).
+
 %% =====================================================================
 %% Cost-based auto-resolvers for F# WAM target
 %% =====================================================================
@@ -4779,14 +4827,18 @@ write_wam_fsharp_project(Predicates, Options0, ProjectDir) :-
     ->  DetectedKernels = [],
         format(user_error, '[WAM-FSharp] kernel detection suppressed~n', [])
     ;   detect_kernels_fs(ProjectPredicates, DetectedKernels0),
-        % Upgrade category_ancestor to bidirectional when CSR child
-        % lookup is available (csr_path provides category_child).
-        (   option(kernel_mode(bidirectional), Options),
-            option(csr_path(_), Options)
-        ->  maplist(maybe_upgrade_bidirectional, DetectedKernels0, DetectedKernels),
-            format(user_error, '[WAM-FSharp] bidirectional kernel upgrade enabled~n', [])
-        ;   DetectedKernels = DetectedKernels0
-        ),
+        % Phase 5a: replace the option-driven upgrade gate with the
+        % recurrence-evaluation-strategy selector. Caller options flow
+        % into the workload; the selector decides per-kernel whether
+        % to upgrade. Backwards-compatible: when caller passes
+        % kernel_mode(bidirectional) + csr_path(_) explicitly, the
+        % selector resolves to per_query(bidirectional) via either
+        % step_third_option (search admissible) or step_caller_wins
+        % (fallback). When the caller passes neither but workload
+        % signals support bidirectional, the selector auto-selects.
+        recurrence_inputs:build_workload_signals(Options, ResWorkload),
+        maplist(wam_fsharp_apply_strategy_selector(ResWorkload),
+                DetectedKernels0, DetectedKernels),
         (   DetectedKernels \= []
         ->  pairs_keys(DetectedKernels, DetectedKeys),
             format(user_error, '[WAM-FSharp] detected kernels: ~w~n', [DetectedKeys])

--- a/tests/core/test_recurrence_inputs.pl
+++ b/tests/core/test_recurrence_inputs.pl
@@ -1,0 +1,287 @@
+:- encoding(utf8).
+%% Unit tests for recurrence_inputs.pl:
+%%   build_recurrence_term/3 + build_workload_signals/2 +
+%%   kernel_kind_default_properties/2.
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_recurrence_inputs.pl
+
+:- use_module('../../src/unifyweaver/core/recurrence_inputs').
+:- use_module(library(lists)).
+
+%% ========================================================================
+%% Test runner
+%% ========================================================================
+
+run_tests :-
+    format("~n========================================~n"),
+    format("recurrence_inputs Unit Tests~n"),
+    format("========================================~n~n"),
+    findall(Test, test(Test), Tests),
+    length(Tests, Total),
+    run_all(Tests, 0, Passed),
+    format("~n========================================~n"),
+    (   Passed =:= Total
+    ->  format("All ~w tests passed~n", [Total])
+    ;   Failed is Total - Passed,
+        format("~w of ~w tests FAILED~n", [Failed, Total]),
+        format("Tests FAILED~n"),
+        halt(1)
+    ),
+    format("========================================~n").
+
+run_all([], Passed, Passed).
+run_all([Test|Rest], Acc, Passed) :-
+    (   catch(call(Test), Error,
+            (format("[FAIL] ~w: ~w~n", [Test, Error]), fail))
+    ->  format("[PASS] ~w~n", [Test]),
+        Acc1 is Acc + 1,
+        run_all(Rest, Acc1, Passed)
+    ;   run_all(Rest, Acc, Passed)
+    ).
+
+%% ========================================================================
+%% Test declarations
+%% ========================================================================
+
+%% build_recurrence_term
+test(test_build_recurrence_term_combinatorial_kernel).
+test(test_build_recurrence_term_numeric_kernel).
+test(test_build_recurrence_term_unknown_kernel_defaults).
+test(test_build_recurrence_term_with_extra_properties).
+test(test_build_recurrence_term_extra_overrides_defaults).
+test(test_build_recurrence_term_drops_directions_admissible).
+test(test_build_recurrence_term_drops_expected_cardinality).
+
+%% kernel_kind_default_properties
+test(test_default_properties_category_ancestor).
+test(test_default_properties_weighted_shortest_path3).
+test(test_default_properties_unknown_kernel).
+
+%% build_workload_signals — intent options
+test(test_workload_kernel_mode).
+test(test_workload_strategy).
+test(test_workload_force_search_algorithm).
+
+%% build_workload_signals — declared-data options
+test(test_workload_csr_path_implies_csr_available).
+test(test_workload_csr_available).
+test(test_workload_cardinality).
+test(test_workload_determinism).
+test(test_workload_unique).
+test(test_workload_query_pattern).
+test(test_workload_query_frequency).
+test(test_workload_graph_mutability).
+test(test_workload_heuristic_predicate_implies_available).
+test(test_workload_heuristic_predicate_available).
+test(test_workload_calibration_signals).
+
+%% build_workload_signals — inferred-data options
+test(test_workload_csr_buildable).
+
+%% build_workload_signals — edge cases
+test(test_workload_empty).
+test(test_workload_drops_unknown_options).
+test(test_workload_mixed_intents_data).
+
+%% ========================================================================
+%% Tests: build_recurrence_term
+%% ========================================================================
+
+test_build_recurrence_term_combinatorial_kernel :-
+    build_recurrence_term(
+        recursive_kernel(transitive_closure2, my_pred/2, []),
+        [],
+        Recurrence),
+    Recurrence = recurrence(transitive_closure2, my_pred/2, Props),
+    member(value_domain(combinatorial), Props),
+    member(monotone(true), Props).
+
+test_build_recurrence_term_numeric_kernel :-
+    build_recurrence_term(
+        recursive_kernel(weighted_shortest_path3, my_pred/3, []),
+        [],
+        Recurrence),
+    Recurrence = recurrence(weighted_shortest_path3, my_pred/3, Props),
+    member(value_domain(numeric), Props),
+    member(monotone(true), Props).
+
+test_build_recurrence_term_unknown_kernel_defaults :-
+    build_recurrence_term(
+        recursive_kernel(quantum_kernel, my_pred/2, []),
+        [],
+        Recurrence),
+    Recurrence = recurrence(quantum_kernel, my_pred/2, Props),
+    %% Catch-all defaults: combinatorial + monotone(true).
+    member(value_domain(combinatorial), Props),
+    member(monotone(true), Props).
+
+test_build_recurrence_term_with_extra_properties :-
+    build_recurrence_term(
+        recursive_kernel(transitive_closure2, my_pred/2, []),
+        [numeric_contraction_rate(0.04)],
+        Recurrence),
+    Recurrence = recurrence(_, _, Props),
+    member(numeric_contraction_rate(0.04), Props),
+    %% Defaults still present alongside the extra.
+    member(value_domain(combinatorial), Props).
+
+test_build_recurrence_term_extra_overrides_defaults :-
+    %% Override the default monotone(true) with monotone(false).
+    build_recurrence_term(
+        recursive_kernel(transitive_closure2, my_pred/2, []),
+        [monotone(false)],
+        Recurrence),
+    Recurrence = recurrence(_, _, Props),
+    member(monotone(false), Props),
+    %% Original monotone(true) should NOT be present.
+    \+ member(monotone(true), Props).
+
+test_build_recurrence_term_drops_directions_admissible :-
+    %% Even if extra properties include directions_admissible, it
+    %% should be dropped per the SPEC's removed-property note.
+    build_recurrence_term(
+        recursive_kernel(transitive_closure2, my_pred/2, []),
+        [directions_admissible([forward, backward])],
+        Recurrence),
+    Recurrence = recurrence(_, _, Props),
+    \+ member(directions_admissible(_), Props).
+
+test_build_recurrence_term_drops_expected_cardinality :-
+    %% expected_cardinality duplicates cardinality(C) workload signal;
+    %% SPEC says drop it.
+    build_recurrence_term(
+        recursive_kernel(transitive_closure2, my_pred/2, []),
+        [expected_cardinality(large)],
+        Recurrence),
+    Recurrence = recurrence(_, _, Props),
+    \+ member(expected_cardinality(_), Props).
+
+%% ========================================================================
+%% Tests: kernel_kind_default_properties
+%% ========================================================================
+
+test_default_properties_category_ancestor :-
+    kernel_kind_default_properties(category_ancestor, Props),
+    member(value_domain(combinatorial), Props),
+    member(monotone(true), Props),
+    member(has_combinatorial_loop_break(true), Props).
+
+test_default_properties_weighted_shortest_path3 :-
+    kernel_kind_default_properties(weighted_shortest_path3, Props),
+    member(value_domain(numeric), Props),
+    member(monotone(true), Props),
+    %% Dijkstra: no visited-set, has_combinatorial_loop_break absent.
+    \+ member(has_combinatorial_loop_break(_), Props).
+
+test_default_properties_unknown_kernel :-
+    kernel_kind_default_properties(definitely_not_a_kernel, Props),
+    member(value_domain(combinatorial), Props),
+    member(monotone(true), Props).
+
+%% ========================================================================
+%% Tests: build_workload_signals — intent options
+%% ========================================================================
+
+test_workload_kernel_mode :-
+    build_workload_signals([kernel_mode(bidirectional)], W),
+    W == [kernel_mode(bidirectional)].
+
+test_workload_strategy :-
+    build_workload_signals([strategy(per_query(unidirectional))], W),
+    W == [strategy(per_query(unidirectional))].
+
+test_workload_force_search_algorithm :-
+    build_workload_signals([force_search_algorithm(bfs)], W),
+    W == [force_search_algorithm(bfs)].
+
+%% ========================================================================
+%% Tests: build_workload_signals — declared-data options
+%% ========================================================================
+
+%% csr_path implies BOTH csr_path AND csr_available(true).
+test_workload_csr_path_implies_csr_available :-
+    build_workload_signals([csr_path('/foo/bar.lmdb')], W),
+    member(csr_path('/foo/bar.lmdb'), W),
+    member(csr_available(true), W).
+
+test_workload_csr_available :-
+    build_workload_signals([csr_available(true)], W),
+    W == [csr_available(true)].
+
+test_workload_cardinality :-
+    build_workload_signals([cardinality(large)], W),
+    W == [cardinality(large)].
+
+test_workload_determinism :-
+    build_workload_signals([determinism(semidet)], W),
+    W == [determinism(semidet)].
+
+test_workload_unique :-
+    build_workload_signals([unique(true)], W),
+    W == [unique(true)].
+
+test_workload_query_pattern :-
+    build_workload_signals([query_pattern(single_pair)], W),
+    W == [query_pattern(single_pair)].
+
+test_workload_query_frequency :-
+    build_workload_signals([query_frequency(high)], W),
+    W == [query_frequency(high)].
+
+test_workload_graph_mutability :-
+    build_workload_signals([graph_mutability(static)], W),
+    W == [graph_mutability(static)].
+
+%% heuristic_predicate implies heuristic_predicate_available(true).
+test_workload_heuristic_predicate_implies_available :-
+    build_workload_signals([heuristic_predicate(my_heuristic/2)], W),
+    member(heuristic_predicate(my_heuristic/2), W),
+    member(heuristic_predicate_available(true), W).
+
+test_workload_heuristic_predicate_available :-
+    build_workload_signals([heuristic_predicate_available(true)], W),
+    W == [heuristic_predicate_available(true)].
+
+test_workload_calibration_signals :-
+    build_workload_signals([b_eff(15.0), branching_d(4.5), contraction_r(0.04)], W),
+    member(b_eff(15.0), W),
+    member(branching_d(4.5), W),
+    member(contraction_r(0.04), W).
+
+%% ========================================================================
+%% Tests: build_workload_signals — inferred-data options
+%% ========================================================================
+
+test_workload_csr_buildable :-
+    build_workload_signals([csr_buildable(true)], W),
+    W == [csr_buildable(true)].
+
+%% ========================================================================
+%% Tests: build_workload_signals — edge cases
+%% ========================================================================
+
+test_workload_empty :-
+    build_workload_signals([], W),
+    W == [].
+
+%% Unknown options (target-specific keys) are silently dropped.
+test_workload_drops_unknown_options :-
+    build_workload_signals([
+        lmdb_path('/some/path'),
+        target(fsharp_wam),
+        no_kernels(false),
+        kernel_mode(bidirectional)       % this one IS recognised
+    ], W),
+    W == [kernel_mode(bidirectional)].
+
+test_workload_mixed_intents_data :-
+    build_workload_signals([
+        kernel_mode(bidirectional),
+        cardinality(large),
+        query_pattern(single_pair),
+        csr_buildable(true)
+    ], W),
+    %% Order is preserved per the translate_option order.
+    W = [kernel_mode(bidirectional), cardinality(large),
+         query_pattern(single_pair), csr_buildable(true)].

--- a/tests/core/test_recurrence_inputs_grep.pl
+++ b/tests/core/test_recurrence_inputs_grep.pl
@@ -1,0 +1,75 @@
+:- encoding(utf8).
+%% Grep tripwire for recurrence_inputs.pl: asserts the module body
+%% contains no target-specific atoms (fsharp / haskell / c_target etc).
+%%
+%% This is the faster, less robust of the two target-agnosticism
+%% enforcement layers. The stronger layer is the load-isolation test
+%% (test_recurrence_inputs_isolated.pl). Both are kept because grep
+%% is cheap and catches direct violations even when load-isolation
+%% would also catch them transitively.
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_recurrence_inputs_grep.pl
+
+:- use_module(library(lists)).
+:- use_module(library(readutil), [read_file_to_string/3]).
+:- use_module(library(filesex), [directory_file_path/3]).
+
+%% Capture this test file's directory at load time so we can build
+%% an absolute path to the helper module.
+:- prolog_load_context(directory, Dir),
+   asserta(test_file_directory(Dir)).
+
+run_tests :-
+    format("~n========================================~n"),
+    format("recurrence_inputs Grep Tripwire~n"),
+    format("========================================~n~n"),
+    test_file_directory(Dir),
+    directory_file_path(Dir, '../../src/unifyweaver/core/recurrence_inputs.pl',
+                        HelperPath),
+    read_file_to_string(HelperPath, Source, []),
+    %% Strip comments first so module references in design-note
+    %% comments don't trigger false positives.
+    strip_prolog_comments(Source, CodeOnly),
+    Forbidden = [
+        "fsharp",
+        "wam_fsharp",
+        "wam_haskell",
+        "wam_c_",
+        "haskell_target",
+        "c_target",
+        "csharp_target"
+    ],
+    findall(F,
+            ( member(F, Forbidden),
+              sub_string(CodeOnly, _, _, _, F)
+            ),
+            Violations),
+    (   Violations == []
+    ->  format("[PASS] no target-specific atoms in module body (comments stripped)~n"),
+        format("Checked forbidden tokens: ~w~n", [Forbidden]),
+        format("~nAll tests passed~n"),
+        format("========================================~n")
+    ;   format("[FAIL] target-specific atoms found in module body:~n"),
+        forall(member(V, Violations),
+               format("  - ~w~n", [V])),
+        format("Tests FAILED~n"),
+        halt(1)
+    ).
+
+%% strip_prolog_comments(+Source, -CodeOnly)
+%
+% Naive comment stripper: removes everything between `%` and end of
+% line on each line. Good enough for the grep check; doesn't handle
+% string-literal % correctly but no string in this module contains
+% the forbidden substrings.
+strip_prolog_comments(Source, CodeOnly) :-
+    split_string(Source, "\n", "", Lines),
+    maplist(strip_line_comment, Lines, StrippedLines),
+    atomics_to_string(StrippedLines, "\n", CodeOnly).
+
+strip_line_comment(Line, Stripped) :-
+    (   sub_string(Line, Idx, _, _, "%")
+    ->  sub_string(Line, 0, Idx, _, Stripped)
+    ;   Stripped = Line
+    ).

--- a/tests/core/test_recurrence_inputs_isolated.pl
+++ b/tests/core/test_recurrence_inputs_isolated.pl
@@ -1,0 +1,54 @@
+:- encoding(utf8).
+%% Load-isolation test for recurrence_inputs.pl.
+%%
+%% Spawns a FRESH swipl process that loads ONLY the helper module
+%% (plus its core dependencies). If the helper transitively depends
+%% on any target module, the fresh load will fail with a missing-source
+%% error and the spawned process exits non-zero.
+%%
+%% This is the stronger of the two target-agnosticism enforcement
+%% layers (the other is the grep tripwire). Catches the failure
+%% mode where a helper-of-a-helper accidentally imports a target
+%% module that grep would miss.
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_recurrence_inputs_isolated.pl
+
+:- use_module(library(lists)).
+:- use_module(library(process), [process_create/3, process_wait/2]).
+:- use_module(library(filesex), [directory_file_path/3]).
+
+%% Capture this test file's directory at load time so we can build
+%% an absolute path to the helper module.
+:- prolog_load_context(directory, Dir),
+   asserta(test_file_directory(Dir)).
+
+run_tests :-
+    format("~n========================================~n"),
+    format("recurrence_inputs Load-Isolation Test~n"),
+    format("========================================~n~n"),
+    test_file_directory(Dir),
+    directory_file_path(Dir, '../../src/unifyweaver/core/recurrence_inputs.pl',
+                        HelperPath),
+    %% Spawn a fresh swipl that loads ONLY the helper and tries the
+    %% basic predicates. If any transitive dependency on a target
+    %% module exists, the fresh load fails.
+    %%
+    %% The goal: load the module, run a smoke check, halt with the
+    %% smoke result's status.
+    format(atom(Goal), "use_module('~w'), recurrence_inputs:build_workload_signals([], []), recurrence_inputs:build_recurrence_term(recursive_kernel(transitive_closure2, foo/2, []), [], _)",
+           [HelperPath]),
+    process_create(path(swipl),
+                   ['-g', Goal, '-t', 'halt'],
+                   [process(PID)]),
+    process_wait(PID, exit(ExitCode)),
+    (   ExitCode =:= 0
+    ->  format("[PASS] recurrence_inputs loaded + smoke-tested in a fresh swipl with no target modules pre-loaded~n"),
+        format("~nAll tests passed~n"),
+        format("========================================~n")
+    ;   format("[FAIL] fresh-swipl load isolation failed (exit ~w)~n", [ExitCode]),
+        format("  This means recurrence_inputs.pl has a transitive dependency on a target~n"),
+        format("  module that prevented it from loading in isolation.~n"),
+        format("Tests FAILED~n"),
+        halt(1)
+    ).

--- a/tests/core/test_recurrence_inputs_mock_caller.pl
+++ b/tests/core/test_recurrence_inputs_mock_caller.pl
@@ -1,0 +1,166 @@
+:- encoding(utf8).
+%% Mock-second-caller test for recurrence_inputs.pl.
+%%
+%% Exercises build_recurrence_term/3 and build_workload_signals/2
+%% with workload signals that have no F# semantics. Acts as a
+%% stand-in for the eventual Haskell-WAM or C-WAM target integration:
+%% if the helpers had been silently shaped by F# WAM as the only
+%% first-iteration caller, this mock would catch the
+%% F#-shape-calcification.
+%%
+%% Per the SPEC's concrete signal list: cardinality(large),
+%% query_frequency(high), query_pattern(single_pair), b_eff(15.0),
+%% branching_d(4.5), contraction_r(0.04), heuristic_predicate_available(true),
+%% heuristic_predicate(my_heuristic/2). Critically excludes csr_path
+%% (most-commonly F#-WAM-specific per SPEC's signal table).
+%%
+%% Usage:
+%%   swipl -g run_tests -t halt tests/core/test_recurrence_inputs_mock_caller.pl
+
+:- use_module('../../src/unifyweaver/core/recurrence_inputs').
+:- use_module('../../src/unifyweaver/core/recurrence_evaluation_strategy',
+              [select_evaluation_strategy/3]).
+:- use_module(library(lists)).
+
+%% ========================================================================
+%% Test runner
+%% ========================================================================
+
+run_tests :-
+    format("~n========================================~n"),
+    format("recurrence_inputs Mock-Second-Caller Test~n"),
+    format("========================================~n~n"),
+    findall(Test, test(Test), Tests),
+    length(Tests, Total),
+    run_all(Tests, 0, Passed),
+    format("~n========================================~n"),
+    (   Passed =:= Total
+    ->  format("All ~w tests passed~n", [Total])
+    ;   Failed is Total - Passed,
+        format("~w of ~w tests FAILED~n", [Failed, Total]),
+        format("Tests FAILED~n"),
+        halt(1)
+    ),
+    format("========================================~n").
+
+run_all([], Passed, Passed).
+run_all([Test|Rest], Acc, Passed) :-
+    (   catch(call(Test), Error,
+            (format("[FAIL] ~w: ~w~n", [Test, Error]), fail))
+    ->  format("[PASS] ~w~n", [Test]),
+        Acc1 is Acc + 1,
+        run_all(Rest, Acc1, Passed)
+    ;   run_all(Rest, Acc, Passed)
+    ).
+
+%% ========================================================================
+%% Test fixtures — non-F# scenario shaping
+%% ========================================================================
+
+%% A Haskell-WAM-style detected kernel (uses transitive_closure2,
+%% the kernel kind any WAM target would consume).
+mock_detected_kernel(recursive_kernel(transitive_closure2, my_pred/2, [])).
+
+%% Non-F# workload options: NO csr_path (most-commonly F#-WAM-
+%% specific). Uses generic vocabulary the SPEC covers.
+non_fsharp_options([
+    cardinality(large),
+    query_frequency(high),
+    query_pattern(single_pair),
+    b_eff(15.0),
+    branching_d(4.5),
+    contraction_r(0.04),
+    heuristic_predicate_available(true),
+    heuristic_predicate(my_heuristic/2)
+]).
+
+%% ========================================================================
+%% Test declarations
+%% ========================================================================
+
+test(test_build_recurrence_term_with_mock_kernel).
+test(test_build_workload_signals_no_fsharp_specific).
+test(test_workload_contains_no_csr_path).
+test(test_workload_contains_all_expected_signals).
+test(test_helpers_dont_import_target_modules).
+test(test_end_to_end_with_mock_caller_workload).
+
+%% ========================================================================
+%% Tests
+%% ========================================================================
+
+%% Helper builds a well-formed Recurrence from the mock detected
+%% kernel without erroring. Doesn't assume F#-specific config.
+test_build_recurrence_term_with_mock_kernel :-
+    mock_detected_kernel(K),
+    build_recurrence_term(K, [], Recurrence),
+    Recurrence = recurrence(transitive_closure2, my_pred/2, Props),
+    is_list(Props),
+    member(value_domain(combinatorial), Props),
+    member(monotone(true), Props).
+
+%% Helper builds a well-formed Workload from the non-F# options
+%% without erroring or implicitly adding F#-specific signals.
+test_build_workload_signals_no_fsharp_specific :-
+    non_fsharp_options(Options),
+    build_workload_signals(Options, Workload),
+    is_list(Workload),
+    Workload \== [].
+
+%% Critical: csr_path is most-commonly F#-WAM-specific (per SPEC's
+%% signal table). The mock options don't include it; the workload
+%% should not contain it either.
+test_workload_contains_no_csr_path :-
+    non_fsharp_options(Options),
+    build_workload_signals(Options, Workload),
+    \+ member(csr_path(_), Workload),
+    \+ member(csr_available(_), Workload).  % csr_path implies csr_available
+
+%% All expected vocabulary signals from non_fsharp_options should
+%% appear in the workload.
+test_workload_contains_all_expected_signals :-
+    non_fsharp_options(Options),
+    build_workload_signals(Options, Workload),
+    member(cardinality(large), Workload),
+    member(query_frequency(high), Workload),
+    member(query_pattern(single_pair), Workload),
+    member(b_eff(15.0), Workload),
+    member(branching_d(4.5), Workload),
+    member(contraction_r(0.04), Workload),
+    member(heuristic_predicate_available(true), Workload),
+    member(heuristic_predicate(my_heuristic/2), Workload).
+
+%% Verify recurrence_inputs.pl doesn't import target-specific
+%% modules. Reads the :- use_module/1 directives via the module's
+%% predicate_property/2 mechanism.
+test_helpers_dont_import_target_modules :-
+    %% This test relies on the module being already loaded by the
+    %% use_module directive at the top of this file.
+    findall(M,
+            ( predicate_property(recurrence_inputs:_, imported_from(M))
+            ),
+            Imports),
+    sort(Imports, UniqueImports),
+    forall(member(I, UniqueImports),
+           ( atom(I),
+             atom_string(I, IStr),
+             \+ sub_string(IStr, _, _, _, "fsharp"),
+             \+ sub_string(IStr, _, _, _, "haskell"),
+             \+ sub_string(IStr, _, _, _, "c_target"),
+             \+ sub_string(IStr, _, _, _, "csharp")
+           )).
+
+%% End-to-end: mock caller exercises the full pipeline (build
+%% inputs → call selector → get strategy). Verifies the helpers
+%% interoperate with the selector for a non-F# workload.
+test_end_to_end_with_mock_caller_workload :-
+    mock_detected_kernel(K),
+    non_fsharp_options(Options),
+    build_recurrence_term(K, [], Recurrence),
+    build_workload_signals(Options, Workload),
+    select_evaluation_strategy(Recurrence, Workload,
+                               strategy_choice(Strategy, trace(_Steps))),
+    %% Strategy should be SOME valid per_query or fixed_point variant.
+    %% Don't assert a specific value — the assertion that the call
+    %% succeeded without erroring is the point.
+    Strategy = strategy(_Mode).


### PR DESCRIPTION
  ## Summary

  Implements **Phase 5a** of the recurrence-evaluation-strategy implementation plan — first time the selector touches production target code. Wires the strategy selector into `wam_fsharp_target.pl` as the first consumer; introduces the target-agnostic `recurrence_inputs.pl` helper module.

  **Phase 5b deferred** to a follow-up: trace comment in generated F# code + full F# WAM e2e auto-select test with LMDB+.NET fixture (the existing 50-node fixture runs in seconds, so 5b should be fast).

  This is the sixth of seven phases. Builds on Phases 0–4. Only Phase 5b (full F# e2e) and Phase 7 (book-18 chapter updates) remain.

  ## What this PR delivers

  ### NEW: `src/unifyweaver/core/recurrence_inputs.pl` (241 lines)

  The target-agnostic helper module per the SPEC's "Helper module for input construction" section.

  - **`build_recurrence_term/3`** (`+DetectedKernel, +ExtraProperties, -Recurrence`) — constructs a Recurrence from a detected kernel using kernel-kind defaults with optional overrides. Drops removed-from-spec keys  (`directions_admissible`, `expected_cardinality`).
  - **`build_workload_signals/2`** (`+CallerOptions, -Workload`) — translates caller-option list into workload signals
  per the SPEC vocabulary. Implicit-adds: `csr_path` → also `csr_available(true)`; `heuristic_predicate` → also
  `heuristic_predicate_available(true)`. Unrecognised options silently dropped.
  - **`kernel_kind_default_properties/2`** for every detector in `recursive_kernel_detection.pl` +
  `bidirectional_ancestor`. Defaults aligned with SPEC's value-domain table.
  - **Target-agnostic by design** — enforced by two test layers (below).

  ### MODIFIED: `src/unifyweaver/targets/wam_fsharp_target.pl`

  Surgical change at lines ~4784–4789 replacing the option-driven upgrade gate with selector-driven per-kernel decision:

  ```prolog
  % BEFORE:
  (   option(kernel_mode(bidirectional), Options),
      option(csr_path(_), Options)
  ->  maplist(maybe_upgrade_bidirectional, DetectedKernels0, DetectedKernels), ...
  ;   DetectedKernels = DetectedKernels0
  )

  % AFTER:
  recurrence_inputs:build_workload_signals(Options, ResWorkload),
  maplist(wam_fsharp_apply_strategy_selector(ResWorkload),
          DetectedKernels0, DetectedKernels)
  ```

  Plus the new wam_fsharp_apply_strategy_selector/3 + wam_fsharp_apply_strategy_choice/3 helpers (~30 lines near existing maybe_upgrade_bidirectional/2).

  Backwards-compatible by design. When the caller passes kernel_mode(bidirectional) + csr_path(_) explicitly,  build_workload_signals translates them to workload signals; the selector resolves to per_query(bidirectional) via
  either step_third_option (search admissible) or step_caller_wins (fallback); the existing kernel upgrade fires exactly
  as before.

  NEW test files

  - test_recurrence_inputs.pl (28 tests) — unit tests for build_recurrence_term/3, build_workload_signals/2,
  kernel_kind_default_properties/2
  - test_recurrence_inputs_isolated.pl (load-isolation test) — spawns a FRESH swipl process that loads only recurrence_inputs.pl + runs smoke checks; if any transitive target dependency exists, the fresh load fails. Stronger than grep.
  - test_recurrence_inputs_grep.pl (grep tripwire) — reads the module source, strips Prolog comments, asserts no
  forbidden target-specific tokens (fsharp, wam_fsharp, wam_haskell, wam_c_, haskell_target, c_target, csharp_target).
  Faster than load-isolation; cheap.
  - test_recurrence_inputs_mock_caller.pl (6 tests) — Acts as a stand-in for a hypothetical Haskell-WAM integration.
  Exercises the helpers with the SPEC's concrete non-F# signal list (cardinality, query_frequency, calibration triple,
  heuristic_predicate). Asserts the workload contains no F#-specific signals; verifies predicate_property/2 shows no
  F#-target imports; end-to-end pipeline succeeds.

  Test plan

  | File | Tests | Status |
| :--- | :---: | :---: |
| test_recurrence_inputs.pl | 28 | ✅ |
| test_recurrence_inputs_isolated.pl | 1 | ✅ |
| test_recurrence_inputs_grep.pl | 1 | ✅ |
| test_recurrence_inputs_mock_caller.pl | 6 | ✅ |
| test_res_skeleton.pl (prior) | 12 | ✅ |
| test_res_signals.pl (prior) | 29 | ✅ |
| test_res_cost_model.pl (prior) | 34 | ✅ |
| test_res_conflict.pl (prior) | 32 | ✅ |
| test_res_trace.pl (prior) | 27 | ✅ |
| Total | 170 | ✅ |

  wam_fsharp_target.pl loads cleanly with the new imports; tests/core/test_wam_fsharp_bidirectional_e2e.pl file loads
  cleanly (running the e2e itself requires LMDB + .NET 8 fixtures — deferred to Phase 5b for the auto-select variant).

  What's NOT in this PR (Phase 5b scope)

  - Trace comment in generated F# code: format_trace_for_comment(Trace, "// ", Comment) exists (Phase 4) but isn't yet inserted into the generated F# source. Requires understanding where the kernel call site lives in wam_fsharp_target.pl's code-gen path.
  - test_wam_fsharp_strategy_autoselect_e2e.pl: the new auto-select e2e variant. Needs the existing LMDB+.NET fixture
  pattern from test_wam_fsharp_bidirectional_e2e.pl. Per user note, the small 50-node fixture runs in seconds — so this  is fast follow-up, not a heavy lift.

  Effort

  ~2 hours (Phase 5a alone, per the implementation plan's ~3 hours for full Phase 5).

  Files

  src/unifyweaver/core/recurrence_inputs.pl              (NEW, 241 lines)
  src/unifyweaver/targets/wam_fsharp_target.pl           (+68 -8: surgical change)
  tests/core/test_recurrence_inputs.pl                   (NEW, 287 lines, 28 tests)
  tests/core/test_recurrence_inputs_isolated.pl          (NEW, 54 lines, 1 test)
  tests/core/test_recurrence_inputs_grep.pl              (NEW, 75 lines, 1 test)
  tests/core/test_recurrence_inputs_mock_caller.pl       (NEW, 166 lines, 6 tests)

  Total: 6 files changed, +883 / −8.