### PR TITLE
Make effective_distance queryable via query_root_metric.py

### DIFF
--- a/examples/benchmark/query_root_metric.py
+++ b/examples/benchmark/query_root_metric.py
@@ -19,9 +19,14 @@ Usage:
   python3 query_root_metric.py --lmdb <dir> --histogram
   python3 query_root_metric.py --lmdb <dir> --verify [--sample N]
 
-`--verify` recomputes the metric from scratch (BFS over category_child from the
-stored root) and asserts every materialised value matches — an independent check
-that the lookup table is correct, separate from the builder that wrote it.
+`--verify` recomputes the metric from scratch and asserts every materialised
+value matches — an independent check that the lookup table is correct, separate
+from the builder that wrote it. min_dist_to_root is recomputed by BFS over
+category_child; effective_distance by the length-bucketed node-DP over
+category_parent (float comparison with 1e-6 relative tolerance).
+
+Use `--metric effective_distance` to serve the materialised effective-distance
+table (f64 values); the default metric is min_dist_to_root.
 """
 import argparse
 import collections
@@ -33,6 +38,11 @@ from pathlib import Path
 import lmdb
 
 I32 = struct.Struct("<i")
+F64 = struct.Struct("<d")
+
+# Metrics whose stored value is an int32 (distance). Everything else (e.g.
+# effective_distance) is an f64.
+INT_METRICS = {"min_dist_to_root", "max_dist_to_root"}
 
 
 def enc(i):
@@ -43,11 +53,18 @@ def dec(b):
     return I32.unpack(b)[0]
 
 
+def decode_value(metric, b):
+    """Decode a stored metric value: int32 for distance metrics, else f64."""
+    if metric in INT_METRICS:
+        return I32.unpack(b)[0]
+    return F64.unpack(b)[0]
+
+
 def metric_meta(env, meta_db, name):
     """Read the stored provenance for metric `name` (root, max_depth, aggregate)."""
     out = {}
     with env.begin() as txn:
-        for field in ("root", "max_depth", "aggregate"):
+        for field in ("root", "max_depth", "aggregate", "exponent"):
             v = txn.get(f"metric_{name}.{field}".encode(), db=meta_db)
             if v is not None:
                 out[field] = v.decode()
@@ -73,6 +90,34 @@ def recompute_min_dist(env, cc_db, root, max_depth):
             frontier = nxt
             depth += 1
     return dist
+
+
+def recompute_effective_distance(env, cp_db, root, max_depth, exponent):
+    """Independent node-DP recompute (matches build_effective_distance.py):
+    S(N) = Σ_L count[N][L]·(L+1)^(-exponent), count over walks up category_parent.
+    Used as the --verify oracle for effective_distance (catches storage
+    corruption / a stale table; algorithm correctness is proven on a DAG by
+    tests/test_effective_distance_nodedp.py)."""
+    children, parents = [], []
+    with env.begin() as txn:
+        for k, v in txn.cursor(db=cp_db):
+            children.append(dec(k))
+            parents.append(dec(v))
+    prev = {root: 1.0}
+    s = collections.defaultdict(float)
+    for depth in range(1, max_depth + 1):
+        cur = collections.defaultdict(float)
+        for i in range(len(children)):
+            c = prev.get(parents[i])
+            if c:
+                cur[children[i]] += c
+        if not cur:
+            break
+        factor = (depth + 1) ** (-exponent)
+        for node, cnt in cur.items():
+            s[node] += cnt * factor
+        prev = cur
+    return s
 
 
 def main():
@@ -119,42 +164,74 @@ def main():
                 if v is None:
                     print(f"{nid}\tunreachable")
                 else:
-                    print(f"{nid}\t{dec(v)}")
+                    print(f"{nid}\t{decode_value(args.metric, v)}")
         dt = time.perf_counter() - t0
         sys.stderr.write(f"{len(ids)} lookups in {dt*1e3:.3f} ms "
                          f"({len(ids)/dt:,.0f} lookups/s)\n")
 
     if args.histogram:
-        hist = collections.Counter()
-        with env.begin() as txn:
-            for _k, v in txn.cursor(db=metric_db):
-                hist[dec(v)] += 1
-        total = sum(hist.values())
-        sys.stderr.write(f"value histogram over {total} nodes:\n")
-        for val in sorted(hist):
-            print(f"{val}\t{hist[val]}")
+        if args.metric in INT_METRICS:
+            hist = collections.Counter()
+            with env.begin() as txn:
+                for _k, v in txn.cursor(db=metric_db):
+                    hist[dec(v)] += 1
+            total = sum(hist.values())
+            sys.stderr.write(f"value histogram over {total} nodes:\n")
+            for val in sorted(hist):
+                print(f"{val}\t{hist[val]}")
+        else:
+            # Continuous metric (f64): print summary stats rather than a
+            # value/count histogram (every value is effectively unique).
+            vals = []
+            with env.begin() as txn:
+                for _k, v in txn.cursor(db=metric_db):
+                    vals.append(decode_value(args.metric, v))
+            n = len(vals)
+            if n:
+                vals.sort()
+                mean = sum(vals) / n
+                sys.stderr.write(f"summary over {n} nodes:\n")
+                print(f"count\t{n}")
+                print(f"min\t{vals[0]:.6g}")
+                print(f"max\t{vals[-1]:.6g}")
+                print(f"mean\t{mean:.6g}")
+                print(f"median\t{vals[n // 2]:.6g}")
+            else:
+                sys.stderr.write("summary: table is empty\n")
 
     rc = 0
     if args.verify:
-        if args.metric != "min_dist_to_root":
-            sys.stderr.write(f"--verify only supports min_dist_to_root (got {args.metric})\n")
-            return 2
         if not meta.get("root"):
             sys.stderr.write("error: no stored root for this metric; cannot verify\n")
             return 2
-        cc_db = env.open_db(b"category_child", dupsort=True, create=False)
-        oracle = recompute_min_dist(env, cc_db, int(meta["root"]), int(meta["max_depth"]))
+        root, max_depth = int(meta["root"]), int(meta["max_depth"])
+        if args.metric == "min_dist_to_root":
+            cc_db = env.open_db(b"category_child", dupsort=True, create=False)
+            oracle = recompute_min_dist(env, cc_db, root, max_depth)
+            def matches(stored, want):
+                return want == stored
+        elif args.metric == "effective_distance":
+            exponent = float(meta.get("exponent", 5))
+            cp_db = env.open_db(b"category_parent", dupsort=True, create=False)
+            oracle = recompute_effective_distance(env, cp_db, root, max_depth, exponent)
+            def matches(stored, want):
+                return abs(want - stored) <= 1e-6 * max(1.0, abs(want))
+        else:
+            sys.stderr.write(f"--verify supports min_dist_to_root and "
+                             f"effective_distance (got {args.metric})\n")
+            return 2
         mismatches = 0
         checked = 0
         with env.begin() as txn:
             cur = txn.cursor(db=metric_db)
             for k, v in cur:
-                node, stored = dec(k), dec(v)
-                if oracle.get(node) != stored:
+                node, stored = dec(k), decode_value(args.metric, v)
+                want = oracle.get(node)
+                if want is None or not matches(stored, want):
                     mismatches += 1
                     if mismatches <= 10:
                         sys.stderr.write(f"  mismatch node {node}: stored {stored} "
-                                         f"oracle {oracle.get(node)}\n")
+                                         f"oracle {want}\n")
                 checked += 1
                 if args.sample and checked >= args.sample:
                     break
@@ -168,7 +245,7 @@ def main():
         sys.stderr.write(f"verify: checked {checked} entries, {mismatches} mismatches, "
                          f"{missing} oracle nodes missing from table\n")
         if mismatches == 0 and missing == 0:
-            sys.stderr.write("verify: OK — materialised metric matches the BFS oracle\n")
+            sys.stderr.write("verify: OK — materialised metric matches the recompute oracle\n")
         else:
             sys.stderr.write("verify: FAILED\n")
             rc = 1

--- a/tests/test_query_root_metric.py
+++ b/tests/test_query_root_metric.py
@@ -25,6 +25,7 @@ except ImportError:
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BUILDER = REPO_ROOT / "examples" / "benchmark" / "build_scoped_subtree_lmdb.py"
+EFFDIST = REPO_ROOT / "examples" / "benchmark" / "build_effective_distance.py"
 QUERY = REPO_ROOT / "examples" / "benchmark" / "query_root_metric.py"
 I32 = struct.Struct("<i")
 
@@ -97,6 +98,42 @@ class TestQueryRootMetric(unittest.TestCase):
         self.assertEqual(hist.get("0"), "1")
         self.assertEqual(hist.get("1"), "2")
         self.assertEqual(hist.get("2"), "1")
+
+    def _build_effective_distance(self, exponent="5"):
+        env_os = dict(os.environ)
+        env_os.setdefault("LANG", "C.UTF-8")
+        proc = subprocess.run(
+            [sys.executable, str(EFFDIST), "--lmdb", str(self.out),
+             "--exponent", exponent],
+            capture_output=True, text=True, env=env_os)
+        self.assertEqual(proc.returncode, 0, f"build_effective_distance failed:\n{proc.stderr}")
+
+    def test_effective_distance_lookup(self):
+        # Scoped category_parent: 3->2, 4->2, 5->3. With root 2 and exponent 5:
+        #   S(3) = S(4) = 2^-5 = 0.03125 ; S(5) = 3^-5 = 1/243.
+        self._build_effective_distance("5")
+        proc = self._query("--metric", "effective_distance", "3", "4", "5", "2")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        rows = dict(line.split("\t") for line in proc.stdout.splitlines() if "\t" in line)
+        self.assertAlmostEqual(float(rows["3"]), 2 ** -5, places=12)
+        self.assertAlmostEqual(float(rows["4"]), 2 ** -5, places=12)
+        self.assertAlmostEqual(float(rows["5"]), 3 ** -5, places=12)
+        # root has no path to itself in this DAG -> absent
+        self.assertEqual(rows["2"], "unreachable")
+
+    def test_effective_distance_verify(self):
+        self._build_effective_distance("5")
+        proc = self._query("--metric", "effective_distance", "--verify")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("verify: OK", proc.stderr)
+
+    def test_effective_distance_histogram_is_summary(self):
+        # f64 metric -> summary stats, not a value/count histogram.
+        self._build_effective_distance("5")
+        proc = self._query("--metric", "effective_distance", "--histogram")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        rows = dict(line.split("\t") for line in proc.stdout.splitlines() if "\t" in line)
+        self.assertEqual(rows.get("count"), "3")  # nodes 3,4,5
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary

  Extends `query_root_metric.py` — the query surface for the ingest-materialised
  path of `docs/design/ROOT_ANCHORED_METRICS_*` — to serve the
  `metric_effective_distance` table (f64 values) alongside the existing
  `min_dist_to_root` (int32). This completes the marquee root-anchored metric
  end-to-end: once `build_effective_distance.py` has written the sub-db,
  answering effective-distance for a node is a single keyed `get` — no graph
  traversal at query time.

  ## What changed

  `examples/benchmark/query_root_metric.py`:
  - **`decode_value(metric, b)`** — decodes int32 for distance metrics
    (`min_dist_to_root`, `max_dist_to_root`) and f64 for everything else.
  - **`metric_meta`** now also reads the stored `exponent` provenance field
    (written by `build_effective_distance.py`).
  - **`--histogram` is metric-aware** — a value/count histogram for the int
    metrics; for the continuous f64 metric it prints summary stats
    (count / min / max / mean / median), since every value is effectively unique.
  - **`--verify` dispatches by metric** — `min_dist_to_root` is recomputed by BFS
    over `category_child`; `effective_distance` by an independent length-bucketed
    node-DP over `category_parent`, compared with a 1e-6 relative tolerance. This
    is an independent oracle separate from the builder that wrote the table.

  `tests/test_query_root_metric.py`:
  - 3 new tests on the existing tiny scoped DAG (root 2, parents 3→2, 4→2, 5→3):
    effective_distance **lookup** (S(3)=S(4)=2⁻⁵, S(5)=3⁻⁵, root absent),
    **`--verify`** passes, and **`--histogram`** emits summary stats.

  ## Verification

  $ python3 -m unittest tests.test_query_root_metric tests.test_effective_distance_nodedp
  ........
  Ran 8 tests in ~0.7s — OK

  No production codegen touched; query-tool + test only.

  The query_root_metric.py + test changes are committed on feat/effective-distance-queryable (commit fae22610). Both metrics —
  min_dist_to_root and effective_distance — are now served as O(1) lookups with independent --verify oracles. The untracked
  data/benchmark/ and examples/sci-repl/prototype were left alone as instructed.