### PR TITLE
fix(wam-rust): compile control-construct predicates (native-lowering guard) + unbreak ite_exec e2e

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -3375,6 +3375,31 @@ pub fn shared_wam_program() -> (Vec<Instruction>, HashMap<String, usize>) {
         format(string(Code), "~w\n\n~w", [SharedCode, PredCodesStr])
     ).
 
+%% rust_pred_has_control_constructs(+Module:Pred/Arity)
+%  True if any clause body uses a backtracking-driven control construct
+%  (\+, ->, ;, once, forall, or a cut). The native Rust emitter
+%  (rust_target.pl) targets deterministic shapes (tail-recursion kernels,
+%  fact lookups) and does NOT model these: it mis-lowers them into a whole
+%  stdin-driven program whose body, under include_main(false), dangles at
+%  module level (syntax error). Mirrors go_pred_has_control_constructs/1;
+%  used to decline native and route such predicates to the lowered/WAM path.
+rust_pred_has_control_constructs(Module:Pred/Arity) :-
+    functor(Head, Pred, Arity),
+    clause(Module:Head, Body),
+    rust_body_has_control(Body),
+    !.
+
+rust_body_has_control(G) :- var(G), !, fail.
+rust_body_has_control((_ -> _)) :- !.
+rust_body_has_control((_ ; _)) :- !.
+rust_body_has_control(\+ _) :- !.
+rust_body_has_control(not(_)) :- !.
+rust_body_has_control(once(_)) :- !.
+rust_body_has_control(forall(_, _)) :- !.
+rust_body_has_control(!) :- !.
+rust_body_has_control((A , B)) :- !, ( rust_body_has_control(A) -> true ; rust_body_has_control(B) ).
+rust_body_has_control(_) :- fail.
+
 %% classify_predicates(+Predicates, +Options, -Classified)
 %  Returns list of classify(Module, Pred, Arity, Strategy, ExtraData) terms.
 classify_predicates([], _, []).
@@ -3392,7 +3417,12 @@ classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
     ->  format(user_error, '  ~w/~w: ffi kernel (~w)~n', [Pred, Arity, Kernel]),
         Entry = classified(Module, Pred, Arity, ffi_kernel, Kernel)
     ;   % Try native Rust lowering (disable WAM fallback inside rust_target
-        % so we can distinguish truly-native from WAM-needing predicates)
+        % so we can distinguish truly-native from WAM-needing predicates).
+        % Decline native for backtracking control constructs (\+, ->, ;,
+        % once, forall, cut): the native emitter mis-lowers them (see
+        % rust_pred_has_control_constructs/1), so route them to the
+        % lowered/WAM path which models choicepoints correctly.
+        \+ rust_pred_has_control_constructs(Module:Pred/Arity),
         catch(
             rust_target:compile_predicate_to_rust(Module:Pred/Arity,
                 [include_main(false), wam_fallback(false)|Options], PredCode),

--- a/tests/test_wam_rust_lowered_ite_exec.pl
+++ b/tests/test_wam_rust_lowered_ite_exec.pl
@@ -83,9 +83,9 @@ write_file(Path, Text) :-
 % A-registers and asserts the boolean outcome. rseqite(10,pos,small)=false
 % and rundoite(c,els)=true are the discriminating cases.
 rust_test_source(
-"use wam_lib::state::WamState;
-use wam_lib::value::Value;
-use wam_lib::{lowered_rite_2, lowered_rneg_1, lowered_rseqite_3, lowered_rnestite_2, lowered_rundoite_2};
+"use iterust::state::WamState;
+use iterust::value::Value;
+use iterust::{lowered_rite_2, lowered_rneg_1, lowered_rseqite_3, lowered_rnestite_2, lowered_rundoite_2};
 use std::collections::HashMap;
 
 fn call(setup: &dyn Fn(&mut WamState), f: fn(&mut WamState) -> bool) -> bool {


### PR DESCRIPTION
  Two fixes for the Rust WAM target's handling of backtracking control constructs.

  1. Decline native lowering for control constructs (65a1c5f5).
  The Rust classifier tried native lowering (rust_target.pl) first and only fell back to lowered/WAM on failure. But the  native emitter targets deterministic shapes (tail-recursion kernels, fact lookups) and doesn't model backtracking-driven control flow: for \+ / -> / ; / once / forall / cut it emitted a whole stdin-driven program whose  body — under include_main(false) — dangled at module level, producing invalid Rust (expected item, found keyword  'let'). Any project containing such a predicate failed to compile.

  Adds rust_pred_has_control_constructs/1 (mirrors Go's go_pred_has_control_constructs/1) and requires it to be absent before attempting native, routing control predicates to the lowered emitter / WAM interpreter, which model choicepoints correctly.

  Verified: a \+/forall project now cargo builds cleanly (was a hard syntax error); test_wam_rust_target,
  test_rust_target, test_wam_rust_save_regs all pass.

  2. Fix ite_exec crate name (1490fbee).
  The lowered ITE/negation e2e test imported crate wam_lib, but the generated lib crate is named after module_name (here iterust; the runtime test likewise uses runtime_test). The stale wam_lib made all imports unresolved, so the test  never compiled. Corrected to iterust — the test now passes, confirming the lowered emitter handles ->, \+, sequential
  + nested ITEs, and a binding-then-fail condition correctly.

  Test plan: test_wam_rust_lowered_ite_exec now passes; test_wam_rust_target, test_rust_target, test_wam_rust_save_regs  green; a control-construct project compiles via cargo build.

  🤖 Generated with Claude Code (https://claude.com/claude-code)