### PR TITLE
Phase 4: materialise + serve max_dist_to_root (max,+ semiring)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,10 @@ jobs:
         run: |
           python3 -m unittest tests.test_effective_distance_nodedp
 
+      - name: Run max-distance node-DP test
+        run: |
+          python3 -m unittest tests.test_max_distance_nodedp
+
       - name: Run WAM Rust matrix-bench demand-flag codegen test
         run: |
           python3 -m unittest tests.test_wam_rust_matrix_demand_flag

--- a/examples/benchmark/build_max_distance.py
+++ b/examples/benchmark/build_max_distance.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+"""
+build_max_distance.py — materialise max_dist_to_root via a length-bucketed
+node-DP (ROOT_ANCHORED_METRICS Phase 4, the (max,+) longest-walk semiring).
+
+max_dist_to_root(Root, Node, D) is the length of the *longest* walk in parent
+hops from Node up to Root, under the depth bound. It is the (max,+) companion
+of min_dist_to_root (min,+, materialised by build_scoped_subtree_lmdb.py) and
+effective_distance (sum,×decay, by build_effective_distance.py): one recurrence
+skeleton, three semirings.
+
+    layer[0]    = {root}
+    layer[L]    = { child | (child -> parent) edge, parent in layer[L-1] }   (L >= 1)
+    max_dist(N) = max { L | N in layer[L] }                                  (root -> 0)
+
+A node stays active in every later layer it can still be extended to, so the
+final overwrite of max_dist(N) = L lands on the largest depth it appears at —
+exactly count[N][L] > 0 for the largest L of the effective-distance DP, but
+tracked as set membership instead of a float count. Only two layers are held at
+once, so memory is O(reachable nodes).
+
+SEMANTICS (spec §4.1): this is the longest *walk* (cycles(bounded)). On a DAG it
+equals the longest simple path; on a cyclic graph the depth bound makes it
+finite and the value saturates at max_depth.
+
+Output: a `metric_max_dist_to_root` sub-db (int32_le node -> int32_le distance)
++ meta provenance. Querying it is then a single keyed get (query_root_metric.py).
+
+Usage:
+  python3 build_max_distance.py --lmdb <scoped_dir> [--root ID] [--max-depth D]
+      [--map-size-gib G]
+Root / max_depth default to the scoped DB's stored meta (scoped_root / _max_depth).
+"""
+import argparse
+import struct
+import sys
+import time
+from pathlib import Path
+
+import lmdb
+
+I32 = struct.Struct("<i")
+
+
+def enc_i32(i):
+    return I32.pack(i)
+
+
+def dec_i32(b):
+    return I32.unpack(b)[0]
+
+
+def load_edges(env, cp_db):
+    """Load category_parent (child -> parent) as parent -> [children]."""
+    children = []
+    parents = []
+    with env.begin() as txn:
+        for k, v in txn.cursor(db=cp_db):
+            children.append(dec_i32(k))
+            parents.append(dec_i32(v))
+    return children, parents
+
+
+def max_distance(children, parents, root, max_depth):
+    """Length-bucketed node-DP. Returns {node: max_dist(node)}, root -> 0."""
+    layer = {root}                 # nodes reachable by a walk of `depth-1` steps
+    maxd = {root: 0}
+    n_edges = len(children)
+    for depth in range(1, max_depth + 1):
+        nxt = set()
+        for i in range(n_edges):
+            if parents[i] in layer:
+                nxt.add(children[i])
+        if not nxt:
+            break                  # no longer walks possible
+        for node in nxt:
+            maxd[node] = depth     # monotone depth -> ends at the largest
+        layer = nxt
+    return maxd
+
+
+def read_meta(env, key, default=None):
+    try:
+        meta = env.open_db(b"meta", create=False)
+    except lmdb.NotFoundError:
+        return default
+    with env.begin() as txn:
+        v = txn.get(key, db=meta)
+    return v.decode() if v is not None else default
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--lmdb", required=True, help="scoped LMDB dir (has category_parent + meta)")
+    ap.add_argument("--root", type=int, default=None, help="root id (default: meta scoped_root)")
+    ap.add_argument("--max-depth", type=int, default=None, help="default: meta scoped_max_depth")
+    ap.add_argument("--map-size-gib", type=float, default=4.0)
+    args = ap.parse_args()
+
+    t0 = time.time()
+    env = lmdb.open(str(args.lmdb), max_dbs=16, subdir=True,
+                    map_size=int(args.map_size_gib * 1024 ** 3))
+    cp_db = env.open_db(b"category_parent", dupsort=True, create=False)
+
+    root = args.root if args.root is not None else int(read_meta(env, b"scoped_root", "-1"))
+    max_depth = args.max_depth if args.max_depth is not None else int(read_meta(env, b"scoped_max_depth", "10"))
+    if root < 0:
+        sys.stderr.write("error: no root (pass --root or build the scoped DB with a meta marker)\n")
+        return 1
+
+    children, parents = load_edges(env, cp_db)
+    sys.stderr.write(f"loaded {len(children)} edges in {time.time()-t0:.1f}s\n")
+
+    maxd = max_distance(children, parents, root, max_depth)
+    sys.stderr.write(f"node-DP: {len(maxd)} nodes (root={root}, max_depth={max_depth}) "
+                     f"in {time.time()-t0:.1f}s\n")
+
+    metric_db = env.open_db(b"metric_max_dist_to_root", create=True)
+    meta_db = env.open_db(b"meta", create=True)
+    with env.begin(write=True) as txn:
+        for node, val in maxd.items():
+            txn.put(enc_i32(node), enc_i32(val), db=metric_db)
+        txn.put(b"metric_max_dist_to_root.root", str(root).encode(), db=meta_db)
+        txn.put(b"metric_max_dist_to_root.max_depth", str(max_depth).encode(), db=meta_db)
+        txn.put(b"metric_max_dist_to_root.aggregate", b"max", db=meta_db)
+    env.sync()
+    env.close()
+    sys.stderr.write(f"wrote metric_max_dist_to_root ({len(maxd)} entries) in {time.time()-t0:.1f}s\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/benchmark/query_root_metric.py
+++ b/examples/benchmark/query_root_metric.py
@@ -92,6 +92,31 @@ def recompute_min_dist(env, cc_db, root, max_depth):
     return dist
 
 
+def recompute_max_dist(env, cp_db, root, max_depth):
+    """Independent oracle for max_dist_to_root: length-bucketed node-DP over
+    category_parent (matches build_max_distance.py). max_dist(N) = largest L
+    with N reachable from root by a walk of L parent-hops, capped at max_depth;
+    root -> 0."""
+    children, parents = [], []
+    with env.begin() as txn:
+        for k, v in txn.cursor(db=cp_db):
+            children.append(dec(k))
+            parents.append(dec(v))
+    layer = {root}
+    maxd = {root: 0}
+    for depth in range(1, max_depth + 1):
+        nxt = set()
+        for i in range(len(children)):
+            if parents[i] in layer:
+                nxt.add(children[i])
+        if not nxt:
+            break
+        for node in nxt:
+            maxd[node] = depth
+        layer = nxt
+    return maxd
+
+
 def recompute_effective_distance(env, cp_db, root, max_depth, exponent):
     """Independent node-DP recompute (matches build_effective_distance.py):
     S(N) = Σ_L count[N][L]·(L+1)^(-exponent), count over walks up category_parent.
@@ -210,6 +235,11 @@ def main():
             oracle = recompute_min_dist(env, cc_db, root, max_depth)
             def matches(stored, want):
                 return want == stored
+        elif args.metric == "max_dist_to_root":
+            cp_db = env.open_db(b"category_parent", dupsort=True, create=False)
+            oracle = recompute_max_dist(env, cp_db, root, max_depth)
+            def matches(stored, want):
+                return want == stored
         elif args.metric == "effective_distance":
             exponent = float(meta.get("exponent", 5))
             cp_db = env.open_db(b"category_parent", dupsort=True, create=False)
@@ -217,8 +247,8 @@ def main():
             def matches(stored, want):
                 return abs(want - stored) <= 1e-6 * max(1.0, abs(want))
         else:
-            sys.stderr.write(f"--verify supports min_dist_to_root and "
-                             f"effective_distance (got {args.metric})\n")
+            sys.stderr.write(f"--verify supports min_dist_to_root, max_dist_to_root "
+                             f"and effective_distance (got {args.metric})\n")
             return 2
         mismatches = 0
         checked = 0

--- a/tests/test_max_distance_nodedp.py
+++ b/tests/test_max_distance_nodedp.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+"""Equivalence test for examples/benchmark/build_max_distance.py.
+
+max_dist_to_root is the (max,+) longest-walk-to-root metric. On a DAG it must
+equal the longest simple path (in parent hops) to the root. Builds a tiny
+diamond DAG where the longest and shortest paths differ, runs the tool, and
+compares the materialised metric_max_dist_to_root against an independent
+longest-path oracle.
+
+Skips gracefully if python-lmdb is not installed.
+"""
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    import lmdb
+    HAVE_LMDB = True
+except ImportError:
+    HAVE_LMDB = False
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOL = REPO_ROOT / "examples" / "benchmark" / "build_max_distance.py"
+I32 = struct.Struct("<i")
+
+
+def enc(i):
+    return I32.pack(i)
+
+
+# child -> [parents]; root = 1. Diamond: 4 reaches root both directly (len 1)
+# and via 3->2->1 (len 3). Longest walk to root: 2->1, 3->2, 4->3.
+ADJ = {2: [1], 3: [2], 4: [1, 3]}
+ROOT = 1
+MAX_DEPTH = 10
+
+
+def brute_max(seed):
+    """Longest simple path seed->root in parent hops (per-path visited set)."""
+    best = -1
+
+    def dfs(node, depth, visited):
+        nonlocal best
+        if node == ROOT:
+            best = max(best, depth)
+            return
+        if len(visited) >= MAX_DEPTH:
+            return
+        for p in ADJ.get(node, []):
+            if p in visited:
+                continue
+            dfs(p, depth + 1, visited | {p})
+
+    dfs(seed, 0, {seed})
+    return best
+
+
+@unittest.skipUnless(HAVE_LMDB, "python-lmdb not installed")
+class TestMaxDistanceNodeDP(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.lmdb = Path(self.tmp.name) / "scoped"
+        env = lmdb.open(str(self.lmdb), max_dbs=16, map_size=10 * 1024 * 1024, subdir=True)
+        cp = env.open_db(b"category_parent", dupsort=True, create=True)
+        meta = env.open_db(b"meta", create=True)
+        with env.begin(write=True) as txn:
+            for child, ps in ADJ.items():
+                for p in ps:
+                    txn.put(enc(child), enc(p), db=cp, dupdata=True)
+            txn.put(b"scoped_root", str(ROOT).encode(), db=meta)
+            txn.put(b"scoped_max_depth", str(MAX_DEPTH).encode(), db=meta)
+        env.sync()
+        env.close()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run_tool(self):
+        env = dict(os.environ)
+        env.setdefault("LANG", "C.UTF-8")
+        proc = subprocess.run(
+            [sys.executable, str(TOOL), "--lmdb", str(self.lmdb),
+             "--root", str(ROOT), "--max-depth", str(MAX_DEPTH)],
+            capture_output=True, text=True, env=env)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def _read_metric(self):
+        env = lmdb.open(str(self.lmdb), max_dbs=16, readonly=True, subdir=True, lock=False)
+        m = env.open_db(b"metric_max_dist_to_root", create=False)
+        out = {}
+        with env.begin() as txn:
+            for k, v in txn.cursor(db=m):
+                out[I32.unpack(k)[0]] = I32.unpack(v)[0]
+        env.close()
+        return out
+
+    def test_nodedp_equals_longest_path(self):
+        self._run_tool()
+        got = self._read_metric()
+        for node in (2, 3, 4):
+            self.assertEqual(got.get(node), brute_max(node),
+                             msg=f"max_dist({node}) node-DP {got.get(node)} != oracle {brute_max(node)}")
+        self.assertEqual(got.get(ROOT), 0)
+
+    def test_known_values(self):
+        # 2->1 (len 1); 3->2->1 (len 2); 4->3->2->1 (len 3, the long arm).
+        self._run_tool()
+        got = self._read_metric()
+        self.assertEqual(got[2], 1)
+        self.assertEqual(got[3], 2)
+        self.assertEqual(got[4], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_query_root_metric.py
+++ b/tests/test_query_root_metric.py
@@ -26,6 +26,7 @@ except ImportError:
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BUILDER = REPO_ROOT / "examples" / "benchmark" / "build_scoped_subtree_lmdb.py"
 EFFDIST = REPO_ROOT / "examples" / "benchmark" / "build_effective_distance.py"
+MAXDIST = REPO_ROOT / "examples" / "benchmark" / "build_max_distance.py"
 QUERY = REPO_ROOT / "examples" / "benchmark" / "query_root_metric.py"
 I32 = struct.Struct("<i")
 
@@ -134,6 +135,32 @@ class TestQueryRootMetric(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stderr)
         rows = dict(line.split("\t") for line in proc.stdout.splitlines() if "\t" in line)
         self.assertEqual(rows.get("count"), "3")  # nodes 3,4,5
+
+    def _build_max_distance(self):
+        env_os = dict(os.environ)
+        env_os.setdefault("LANG", "C.UTF-8")
+        proc = subprocess.run(
+            [sys.executable, str(MAXDIST), "--lmdb", str(self.out)],
+            capture_output=True, text=True, env=env_os)
+        self.assertEqual(proc.returncode, 0, f"build_max_distance failed:\n{proc.stderr}")
+
+    def test_max_distance_lookup(self):
+        # Scoped graph is a tree (3->2, 4->2, 5->3) so longest walk == shortest:
+        #   root 2 -> 0, 3 -> 1, 4 -> 1, 5 -> 2.
+        self._build_max_distance()
+        proc = self._query("--metric", "max_dist_to_root", "2", "3", "4", "5")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        rows = dict(line.split("\t") for line in proc.stdout.splitlines() if "\t" in line)
+        self.assertEqual(rows["2"], "0")
+        self.assertEqual(rows["3"], "1")
+        self.assertEqual(rows["4"], "1")
+        self.assertEqual(rows["5"], "2")
+
+    def test_max_distance_verify(self):
+        self._build_max_distance()
+        proc = self._query("--metric", "max_dist_to_root", "--verify")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("verify: OK", proc.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary

  Completes the root-anchored-metrics arc (`docs/design/ROOT_ANCHORED_METRICS_*`):
  one recurrence skeleton, three semirings. This adds the last one,
  **max_dist_to_root** (the (max,+) longest-walk-to-root metric), joining the
  already-shipped `min_dist_to_root` (min,+) and `effective_distance` (sum,×decay).
  All three are now O(1) ingest-materialised keyed lookups served by
  `query_root_metric.py`, each with an independent `--verify` oracle.

  `max_dist_to_root(Root, Node, D)` is the length, in parent hops, of the longest
  walk from `Node` up to `Root` under the depth bound — the (max,+) companion of
  the (min,+) shortest distance.

  ## What changed

  - **`examples/benchmark/build_max_distance.py`** (new) — length-bucketed node-DP
    over `category_parent`: a node stays active in every layer it can extend to,
    and `max_dist(N)` is the largest depth at which it appears. Same DP skeleton
    as `build_effective_distance.py`, with set membership in place of float
    counts. On a DAG this is the longest simple path; on a cyclic graph the depth
    bound makes it a finite, saturating walk length (spec §4.1). Writes
    `metric_max_dist_to_root` (int32→int32) + meta provenance
    (`root` / `max_depth` / `aggregate=max`).
  - **`examples/benchmark/query_root_metric.py`** — `max_dist_to_root` is already
    an INT metric, so lookup and `--histogram` worked unchanged; add a
    `recompute_max_dist` oracle and a `--verify` dispatch branch for it.
  - **Tests** — `tests/test_max_distance_nodedp.py` (new): a diamond DAG where the
    longest and shortest paths differ, checked against a brute-force longest-path
    oracle (validates the overwrite-to-max behaviour). Plus `max_dist`
    lookup/`--verify` cases in `tests/test_query_root_metric.py`.
  - **CI** — `.github/workflows/test.yml` runs the new node-DP test.

  ## Verification

  $ python3 -m unittest tests.test_max_distance_nodedp
      tests.test_effective_distance_nodedp tests.test_query_root_metric
  Ran 12 tests — OK

  No production codegen touched; ingest tool + query tool + tests only.