### PR TITLE
Dispatch WAM-C if-then-else meta goals

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -1,18 +1,18 @@
 # WAM C Target - Status And Next Steps
 
-Status date: 2026-06-06
+Status date: 2026-06-07
 
 Latest branch verification:
 
-- `investigate/wam-c-meta-goal-disjunction` based on `main` at `db579a6f`
-  (`Merge pull request #2878 from
-  s243a/investigate/wam-c-meta-goal-composition`)
+- `investigate/wam-c-meta-goal-ite` based on `main` at `28ac3536`
+  (`Merge pull request #2881 from
+  s243a/investigate/wam-c-meta-goal-disjunction`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-meta-goal-disjunction`
+- `investigate/wam-c-meta-goal-ite`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -90,6 +90,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Runtime aggregate meta-call dispatch | Done | C dispatches non-inline runtime `findall/3`, `bagof/3`, and `setof/3` calls through meta aggregate frames, invokes simple callable goal terms, and covers non-inline `bagof/3` / `setof/3` executable smoke without `inline_bagof_setof(true)` |
 | Runtime conjunction goal-term dispatch | Done | C preserves `,/2` functors in WAM-to-C parsing, dispatches conjunction goal terms through a synthetic continuation frame, snapshots frame depth in choicepoints, and covers non-inline aggregate bodies with conjunction in `bagof/3` and `setof/3` |
 | Runtime disjunction goal-term dispatch | Done | C dispatches `;/2` goal terms by placing the right branch behind a synthetic choicepoint, snapshots disjunction-frame depth in choicepoints, and covers non-inline aggregate bodies with disjunction in `bagof/3` and `setof/3` |
+| Runtime if-then-else goal-term dispatch | Done | C recognizes `;(->(If, Then), Else)` goal terms, commits on the first condition success by pruning condition alternatives and the else fallback, and covers non-inline aggregate bodies with if-then-else in `bagof/3` and `setof/3` |
 
 ## Current C Target Baseline
 
@@ -150,7 +151,7 @@ The C target is now a credible small WAM backend:
   existential `^/2` suppression plus unbound witness group enumeration inside
   inline `bagof/3` / `setof/3` bodies. It also has runtime meta-call dispatch
   for non-inline aggregate calls over simple callable goal terms and
-  conjunction/disjunction goal terms.
+  conjunction/disjunction/if-then-else goal terms.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -173,7 +174,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Second-arg indexing | Partial | Partial/Done | Partial/Done | C has constant A2 dispatch; broaden tests if this becomes hot. |
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
 | Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
-| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness, caller-bound witness, existential `^/2`, and unbound witness group enumeration for inline `bagof/3` / `setof/3`; runtime meta-call aggregate dispatch now covers simple callable, conjunction, and disjunction goals, while if-then-else and broader meta-goal forms remain gaps. |
+| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness, caller-bound witness, existential `^/2`, and unbound witness group enumeration for inline `bagof/3` / `setof/3`; runtime meta-call aggregate dispatch now covers simple callable, conjunction, disjunction, and if-then-else goals, while `call/N` and broader meta-goal forms remain gaps. |
 | Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, precise `get_level`/`cut` if-then-else, explicit `!/0` scoped to the current predicate call barrier, and generated `forall/2` soft-cut rewrites; residual work should be driven by concrete meta-control demand. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
@@ -187,6 +188,33 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-meta-goal-ite`
+
+Goal: extend C aggregate meta-call goal dispatch from conjunction and
+disjunction to if-then-else goal terms in aggregate bodies.
+
+Evidence:
+
+- The C runtime now has a small if-then-else frame stack plus synthetic
+  condition-success and else-fallback continuations.
+- Choicepoint snapshots preserve if-then-else frame depth, and restore/prune
+  paths trim frames with the rest of runtime backtracking state.
+- Runtime `;(->(If, Then), Else)` goal terms push an else fallback before
+  evaluating `If`; on the first condition success, C prunes condition
+  alternatives and the else fallback before invoking `Then`.
+- The same continuation path also handles deterministic `true` conditions and
+  deterministic builtin condition success instead of leaving negative synthetic
+  continuations in `state->P`.
+- The real-Prolog executable smoke compiles non-inline `bagof/3` and
+  `setof/3` bodies containing if-then-else, verifies the generated WAM still
+  uses `execute bagof/3` / `execute setof/3`, and checks condition-commit,
+  else-fallback, and sorted/deduplicated set output.
+
+Remaining gaps:
+
+- General `call/N` composition still needs runtime goal expansion before the
+  C meta-call path reaches full goal-term parity.
 
 ### Completed: `investigate/wam-c-meta-goal-disjunction`
 
@@ -209,8 +237,8 @@ Evidence:
 
 Remaining gaps:
 
-- If-then-else goal terms and general `call/N` composition still need their
-  own runtime continuation machinery.
+- General `call/N` composition still needs runtime goal expansion before the C
+  meta-call path reaches full goal-term parity.
 
 ### Completed: `investigate/wam-c-meta-goal-composition`
 
@@ -235,8 +263,8 @@ Evidence:
 
 Remaining gaps:
 
-- If-then-else goal terms and general `call/N` composition still need their own
-  runtime continuation machinery.
+- General `call/N` composition still needs runtime goal expansion before the C
+  meta-call path reaches full goal-term parity.
 
 ### Completed: `investigate/wam-c-meta-aggregate-dispatch`
 
@@ -264,8 +292,7 @@ Remaining gaps:
 
 - The first meta-call implementation invokes atoms, module-qualified simple
   predicate terms, `^/2`, direct builtins, and nested aggregate terms. It does
-  not yet cover disjunction, if-then-else, or general `call/N` goal
-  composition in the C runtime.
+  not yet cover general `call/N` goal composition in the C runtime.
 
 ### Completed: `investigate/wam-c-bagof-setof-unbound-witness-groups`
 
@@ -1264,10 +1291,10 @@ Evidence:
 The aggregate parity sequence now has inline no-witness, caller-bound witness,
 existential `^/2`, unbound witness group enumeration, runtime meta-call
 aggregate dispatch for simple callable goals, and conjunction goal-term
-dispatch plus disjunction goal-term dispatch inside meta aggregate bodies. The
-next aggregate feature worth considering is if-then-else goal-term dispatch,
-followed by `call/N` composition. Keep those separate because they change
-general meta-call control flow, not just aggregate frame finalization.
+dispatch, disjunction goal-term dispatch, and if-then-else goal-term dispatch
+inside meta aggregate bodies. The next aggregate feature worth considering is
+`call/N` composition because it changes general meta-call goal expansion, not
+just aggregate frame finalization.
 
 For the effective-distance/CSR line, result-capped and sampled runs already
 confirm child-CSR variants agree, and parent plus child reachability prefilters

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -31,6 +31,8 @@
 #define WAM_AGGREGATE_META_DONE -5
 #define WAM_META_CONJ_RETURN -6
 #define WAM_META_DISJ_RIGHT -7
+#define WAM_META_ITE_THEN -8
+#define WAM_META_ITE_ELSE -9
 
 typedef struct WamState WamState;
 typedef bool (*WamForeignHandler)(WamState *state, const char *pred, int arity);
@@ -69,6 +71,7 @@ typedef struct {
     int aggregate_group_top;
     int conj_top;
     int disj_top;
+    int ite_top;
     int arity;
     WamValue a_regs[32]; // Reduced from MAX_REGS to save memory (typical max arity)
 } ChoicePoint;
@@ -133,6 +136,13 @@ typedef struct {
     WamValue right_goal;
     int return_pc;
 } WamDisjFrame;
+
+typedef struct {
+    WamValue then_goal;
+    WamValue else_goal;
+    int return_pc;
+    int base_b;
+} WamIteFrame;
 
 /* Environment Frame */
 typedef struct {
@@ -403,6 +413,8 @@ struct WamState {
     int conj_top;
     WamDisjFrame disj_frames[WAM_META_GOAL_STACK_SIZE];
     int disj_top;
+    WamIteFrame ite_frames[WAM_META_GOAL_STACK_SIZE];
+    int ite_top;
 
     /* Native category_ancestor kernel data */
     CategoryEdge *category_edges;
@@ -894,6 +906,14 @@ static inline void wam_trim_disj_frames(WamState *state, int target_top) {
     state->disj_top = target_top;
 }
 
+static inline void wam_trim_ite_frames(WamState *state, int target_top) {
+    if (target_top < 0) target_top = 0;
+    if (target_top > state->ite_top) {
+        target_top = state->ite_top;
+    }
+    state->ite_top = target_top;
+}
+
 static inline void push_choice_point(WamState *state, int next_pc, int arity) {
     if (state->B >= state->B_cap) {
         state->B_cap = state->B_cap ? state->B_cap * 2 : WAM_INITIAL_CAP;
@@ -909,6 +929,7 @@ static inline void push_choice_point(WamState *state, int next_pc, int arity) {
     cp->aggregate_group_top = state->aggregate_group_top;
     cp->conj_top = state->conj_top;
     cp->disj_top = state->disj_top;
+    cp->ite_top = state->ite_top;
     
     int save_arity = arity < 32 ? arity : 32;
     cp->arity = save_arity;
@@ -931,6 +952,7 @@ static inline void restore_choice_point(WamState *state, ChoicePoint *cp) {
     wam_trim_aggregate_group_iters(state, cp->aggregate_group_top);
     wam_trim_conj_frames(state, cp->conj_top);
     wam_trim_disj_frames(state, cp->disj_top);
+    wam_trim_ite_frames(state, cp->ite_top);
     unwind_trail(state, cp->trail_size);
     memcpy(state->A, cp->a_regs, sizeof(WamValue) * cp->arity);
 }
@@ -948,10 +970,12 @@ static inline void wam_prune_choice_points(WamState *state, int target_b) {
     int target_group_top = 0;
     int target_conj_top = 0;
     int target_disj_top = 0;
+    int target_ite_top = 0;
     if (target_b > 0 && target_b <= state->B) {
         target_group_top = state->B_array[target_b - 1].aggregate_group_top;
         target_conj_top = state->B_array[target_b - 1].conj_top;
         target_disj_top = state->B_array[target_b - 1].disj_top;
+        target_ite_top = state->B_array[target_b - 1].ite_top;
     }
     while (state->B > target_b) {
         pop_choice_point(state);
@@ -959,6 +983,7 @@ static inline void wam_prune_choice_points(WamState *state, int target_b) {
     wam_trim_aggregate_group_iters(state, target_group_top);
     wam_trim_conj_frames(state, target_conj_top);
     wam_trim_disj_frames(state, target_disj_top);
+    wam_trim_ite_frames(state, target_ite_top);
 }
 static inline void update_choice_point(WamState *state, int next_pc) {
     if (state->B > 0) {

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -2142,6 +2142,9 @@ compile_step_wam_to_c(_Options, CCode) :-
                 if (continuation == WAM_META_CONJ_RETURN) {
                     return wam_continue_conjunction(state);
                 }
+                if (continuation == WAM_META_ITE_THEN) {
+                    return wam_continue_if_then_else(state);
+                }
                 if (continuation != WAM_HALT && state->call_base_top > 0) {
                     int barrier_index = --state->call_base_top;
                     int target_b = state->call_bases[barrier_index];
@@ -2564,6 +2567,8 @@ compile_step_wam_to_c(_Options, CCode) :-
                         recovered = wam_finalize_meta_aggregate(state);
                     } else if (next_pc == WAM_META_DISJ_RIGHT) {
                         recovered = wam_resume_disjunction(state);
+                    } else if (next_pc == WAM_META_ITE_ELSE) {
+                        recovered = wam_resume_if_then_else(state);
                     } else {
                         state->P = next_pc; // Explicitly jump to alternative
                         recovered = true;
@@ -2596,6 +2601,8 @@ static bool wam_collect_meta_aggregate_success(WamState *state);
 static bool wam_finalize_meta_aggregate(WamState *state);
 static bool wam_continue_conjunction(WamState *state);
 static bool wam_resume_disjunction(WamState *state);
+static bool wam_continue_if_then_else(WamState *state);
+static bool wam_resume_if_then_else(WamState *state);
 
 static bool wam_ensure_heap_slots(WamState *state, int additional) {
     if (additional <= 0) return true;
@@ -2834,16 +2841,42 @@ static bool wam_goal_structure(WamState *state, WamValue goal,
     return false;
 }
 
+static bool wam_complete_goal_success(WamState *state, int return_pc) {
+    if (return_pc == WAM_AGGREGATE_META_COLLECT) {
+        return wam_collect_meta_aggregate_success(state);
+    }
+    if (return_pc == WAM_META_CONJ_RETURN) {
+        return wam_continue_conjunction(state);
+    }
+    if (return_pc == WAM_META_ITE_THEN) {
+        return wam_continue_if_then_else(state);
+    }
+    state->P = return_pc;
+    return true;
+}
+
+static bool wam_dispatch_if_then_else(WamState *state,
+                                      WamValue if_goal,
+                                      WamValue then_goal,
+                                      WamValue else_goal,
+                                      int return_pc) {
+    if (state->ite_top >= WAM_META_GOAL_STACK_SIZE) return false;
+    int base_b = state->B;
+    WamIteFrame *frame = &state->ite_frames[state->ite_top++];
+    frame->then_goal = then_goal;
+    frame->else_goal = else_goal;
+    frame->return_pc = return_pc;
+    frame->base_b = base_b;
+    push_choice_point(state, WAM_META_ITE_ELSE, 32);
+    return wam_invoke_goal_as_call(state, if_goal, WAM_META_ITE_THEN);
+}
+
 static bool wam_invoke_goal_as_call(WamState *state, WamValue goal,
                                     int return_pc) {
     WamValue *cell = wam_deref_ptr(state, &goal);
     if (cell->tag == VAL_ATOM) {
         if (strcmp(cell->data.atom, "true") == 0) {
-            if (return_pc == WAM_AGGREGATE_META_COLLECT) {
-                return wam_collect_meta_aggregate_success(state);
-            }
-            state->P = return_pc;
-            return true;
+            return wam_complete_goal_success(state, return_pc);
         }
         if (strcmp(cell->data.atom, "fail") == 0 ||
             strcmp(cell->data.atom, "false") == 0) {
@@ -2873,6 +2906,17 @@ static bool wam_invoke_goal_as_call(WamState *state, WamValue goal,
                                        WAM_META_CONJ_RETURN);
     }
     if (strcmp(functor, ";/2") == 0 && arity == 2) {
+        const char *left_functor = NULL;
+        int left_base = -1;
+        if (wam_goal_structure(state, state->H_array[base + 1],
+                               &left_functor, &left_base) &&
+            strcmp(left_functor, "->/2") == 0) {
+            return wam_dispatch_if_then_else(state,
+                                             state->H_array[left_base + 1],
+                                             state->H_array[left_base + 2],
+                                             state->H_array[base + 2],
+                                             return_pc);
+        }
         if (state->disj_top >= WAM_META_GOAL_STACK_SIZE) return false;
         WamDisjFrame *frame = &state->disj_frames[state->disj_top++];
         frame->right_goal = state->H_array[base + 2];
@@ -2880,6 +2924,13 @@ static bool wam_invoke_goal_as_call(WamState *state, WamValue goal,
         push_choice_point(state, WAM_META_DISJ_RIGHT, 32);
         return wam_invoke_goal_as_call(state, state->H_array[base + 1],
                                        return_pc);
+    }
+    if (strcmp(functor, "->/2") == 0 && arity == 2) {
+        return wam_dispatch_if_then_else(state,
+                                         state->H_array[base + 1],
+                                         state->H_array[base + 2],
+                                         val_atom("fail"),
+                                         return_pc);
     }
     if (strcmp(functor, "^/2") == 0 && arity == 2) {
         return wam_invoke_goal_as_call(state, state->H_array[base + 2],
@@ -2904,11 +2955,7 @@ static bool wam_invoke_goal_as_call(WamState *state, WamValue goal,
         return true;
     }
     if (wam_execute_builtin(state, functor, arity)) {
-        if (return_pc == WAM_AGGREGATE_META_COLLECT) {
-            return wam_collect_meta_aggregate_success(state);
-        }
-        state->P = return_pc;
-        return true;
+        return wam_complete_goal_success(state, return_pc);
     }
     return false;
 }
@@ -2928,6 +2975,27 @@ static bool wam_resume_disjunction(WamState *state) {
     state->disj_top--;
     pop_choice_point(state);
     return wam_invoke_goal_as_call(state, right_goal, return_pc);
+}
+
+static bool wam_continue_if_then_else(WamState *state) {
+    if (state->ite_top <= 0) return false;
+    WamIteFrame *frame = &state->ite_frames[state->ite_top - 1];
+    WamValue then_goal = frame->then_goal;
+    int return_pc = frame->return_pc;
+    int base_b = frame->base_b;
+    state->ite_top--;
+    wam_prune_choice_points(state, base_b);
+    return wam_invoke_goal_as_call(state, then_goal, return_pc);
+}
+
+static bool wam_resume_if_then_else(WamState *state) {
+    if (state->ite_top <= 0 || state->B <= 0) return false;
+    WamIteFrame *frame = &state->ite_frames[state->ite_top - 1];
+    WamValue else_goal = frame->else_goal;
+    int return_pc = frame->return_pc;
+    state->ite_top--;
+    pop_choice_point(state);
+    return wam_invoke_goal_as_call(state, else_goal, return_pc);
 }
 
 static bool wam_copy_term_to_stored(WamState *state,

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -3164,6 +3164,16 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
     assertz((user:wam_c_meta_disj_set_left(a) :- true)),
     assertz((user:wam_c_meta_disj_set_right(b) :- true)),
     assertz((user:wam_c_meta_disj_set_right(c) :- true)),
+    assertz((user:wam_c_meta_ite_cond(a) :- true)),
+    assertz((user:wam_c_meta_ite_cond(b) :- true)),
+    assertz((user:wam_c_meta_ite_then(a) :- true)),
+    assertz((user:wam_c_meta_ite_then(a) :- true)),
+    assertz((user:wam_c_meta_ite_fail_cond(_) :- fail)),
+    assertz((user:wam_c_meta_ite_else(c) :- true)),
+    assertz((user:wam_c_meta_ite_else(d) :- true)),
+    assertz((user:wam_c_meta_ite_set_then(b) :- true)),
+    assertz((user:wam_c_meta_ite_set_then(a) :- true)),
+    assertz((user:wam_c_meta_ite_set_then(b) :- true)),
     assertz((user:wam_c_meta_bag(L) :-
         bagof(X, wam_c_meta_item(X), L))),
     assertz((user:wam_c_meta_set(L) :-
@@ -3186,6 +3196,24 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
         setof(X,
               (wam_c_meta_disj_set_left(X); wam_c_meta_disj_set_right(X)),
               L))),
+    assertz((user:wam_c_meta_ite_bag(L) :-
+        bagof(X,
+              (wam_c_meta_ite_cond(X)
+               -> wam_c_meta_ite_then(X)
+               ;  wam_c_meta_ite_else(X)),
+              L))),
+    assertz((user:wam_c_meta_ite_else_bag(L) :-
+        bagof(X,
+              (wam_c_meta_ite_fail_cond(X)
+               -> wam_c_meta_ite_then(X)
+               ;  wam_c_meta_ite_else(X)),
+              L))),
+    assertz((user:wam_c_meta_ite_set(L) :-
+        setof(X,
+              (true
+               -> wam_c_meta_ite_set_then(X)
+               ;  wam_c_meta_ite_else(X)),
+              L))),
     (   compile_predicate_to_wam(user:wam_c_meta_item/1, [], WamItem),
         compile_predicate_to_wam(user:wam_c_meta_dup/1, [], WamDup),
         compile_predicate_to_wam(user:wam_c_meta_none/1, [], WamNone),
@@ -3197,6 +3225,11 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
         compile_predicate_to_wam(user:wam_c_meta_disj_right/1, [], WamDisjRight),
         compile_predicate_to_wam(user:wam_c_meta_disj_set_left/1, [], WamDisjSetLeft),
         compile_predicate_to_wam(user:wam_c_meta_disj_set_right/1, [], WamDisjSetRight),
+        compile_predicate_to_wam(user:wam_c_meta_ite_cond/1, [], WamIteCond),
+        compile_predicate_to_wam(user:wam_c_meta_ite_then/1, [], WamIteThen),
+        compile_predicate_to_wam(user:wam_c_meta_ite_fail_cond/1, [], WamIteFailCond),
+        compile_predicate_to_wam(user:wam_c_meta_ite_else/1, [], WamIteElse),
+        compile_predicate_to_wam(user:wam_c_meta_ite_set_then/1, [], WamIteSetThen),
         compile_predicate_to_wam(user:wam_c_meta_bag/1, [], WamBag),
         compile_predicate_to_wam(user:wam_c_meta_set/1, [], WamSet),
         compile_predicate_to_wam(user:wam_c_meta_empty_bag/1, [], WamEmptyBag),
@@ -3204,6 +3237,9 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
         compile_predicate_to_wam(user:wam_c_meta_conj_set/1, [], WamConjSet),
         compile_predicate_to_wam(user:wam_c_meta_disj_bag/1, [], WamDisjBag),
         compile_predicate_to_wam(user:wam_c_meta_disj_set/1, [], WamDisjSet),
+        compile_predicate_to_wam(user:wam_c_meta_ite_bag/1, [], WamIteBag),
+        compile_predicate_to_wam(user:wam_c_meta_ite_else_bag/1, [], WamIteElseBag),
+        compile_predicate_to_wam(user:wam_c_meta_ite_set/1, [], WamIteSet),
         sub_string(WamBag, _, _, _, 'execute bagof/3'),
         \+ sub_string(WamBag, _, _, _, 'begin_aggregate bagof'),
         sub_string(WamSet, _, _, _, 'execute setof/3'),
@@ -3220,6 +3256,16 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
         sub_string(WamDisjSet, _, _, _, 'put_structure ;/2'),
         sub_string(WamDisjSet, _, _, _, 'execute setof/3'),
         \+ sub_string(WamDisjSet, _, _, _, 'begin_aggregate setof'),
+        sub_string(WamIteBag, _, _, _, 'put_structure ;/2'),
+        sub_string(WamIteBag, _, _, _, 'put_structure ->/2'),
+        sub_string(WamIteBag, _, _, _, 'execute bagof/3'),
+        \+ sub_string(WamIteBag, _, _, _, 'begin_aggregate bagof'),
+        sub_string(WamIteElseBag, _, _, _, 'put_structure ->/2'),
+        sub_string(WamIteElseBag, _, _, _, 'execute bagof/3'),
+        \+ sub_string(WamIteElseBag, _, _, _, 'begin_aggregate bagof'),
+        sub_string(WamIteSet, _, _, _, 'put_structure ->/2'),
+        sub_string(WamIteSet, _, _, _, 'execute setof/3'),
+        \+ sub_string(WamIteSet, _, _, _, 'begin_aggregate setof'),
         compile_wam_predicate_to_c(user:wam_c_meta_item/1, WamItem, [], ItemCode),
         compile_wam_predicate_to_c(user:wam_c_meta_dup/1, WamDup, [], DupCode),
         compile_wam_predicate_to_c(user:wam_c_meta_none/1, WamNone, [], NoneCode),
@@ -3231,6 +3277,11 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
         compile_wam_predicate_to_c(user:wam_c_meta_disj_right/1, WamDisjRight, [], DisjRightCode),
         compile_wam_predicate_to_c(user:wam_c_meta_disj_set_left/1, WamDisjSetLeft, [], DisjSetLeftCode),
         compile_wam_predicate_to_c(user:wam_c_meta_disj_set_right/1, WamDisjSetRight, [], DisjSetRightCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_ite_cond/1, WamIteCond, [], IteCondCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_ite_then/1, WamIteThen, [], IteThenCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_ite_fail_cond/1, WamIteFailCond, [], IteFailCondCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_ite_else/1, WamIteElse, [], IteElseCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_ite_set_then/1, WamIteSetThen, [], IteSetThenCode),
         compile_wam_predicate_to_c(user:wam_c_meta_bag/1, WamBag, [], BagCode),
         compile_wam_predicate_to_c(user:wam_c_meta_set/1, WamSet, [], SetCode),
         compile_wam_predicate_to_c(user:wam_c_meta_empty_bag/1, WamEmptyBag, [], EmptyBagCode),
@@ -3238,14 +3289,20 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
         compile_wam_predicate_to_c(user:wam_c_meta_conj_set/1, WamConjSet, [], ConjSetCode),
         compile_wam_predicate_to_c(user:wam_c_meta_disj_bag/1, WamDisjBag, [], DisjBagCode),
         compile_wam_predicate_to_c(user:wam_c_meta_disj_set/1, WamDisjSet, [], DisjSetCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_ite_bag/1, WamIteBag, [], IteBagCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_ite_else_bag/1, WamIteElseBag, [], IteElseBagCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_ite_set/1, WamIteSet, [], IteSetCode),
         atomic_list_concat([ItemCode, DupCode, NoneCode,
                             ConjItemCode, ConjKeepCode, ConjDupCode,
                             ConjSetKeepCode,
                             DisjLeftCode, DisjRightCode,
                             DisjSetLeftCode, DisjSetRightCode,
+                            IteCondCode, IteThenCode, IteFailCondCode,
+                            IteElseCode, IteSetThenCode,
                             BagCode, SetCode, EmptyBagCode,
                             ConjBagCode, ConjSetCode,
-                            DisjBagCode, DisjSetCode],
+                            DisjBagCode, DisjSetCode,
+                            IteBagCode, IteElseBagCode, IteSetCode],
                            '\n\n',
                            PredCode),
         compile_wam_runtime_to_c([], RuntimeCode),
@@ -3280,13 +3337,21 @@ cleanup_wam_c_bagof_setof_meta_call_smoke :-
     retractall(user:wam_c_meta_disj_right(_)),
     retractall(user:wam_c_meta_disj_set_left(_)),
     retractall(user:wam_c_meta_disj_set_right(_)),
+    retractall(user:wam_c_meta_ite_cond(_)),
+    retractall(user:wam_c_meta_ite_then(_)),
+    retractall(user:wam_c_meta_ite_fail_cond(_)),
+    retractall(user:wam_c_meta_ite_else(_)),
+    retractall(user:wam_c_meta_ite_set_then(_)),
     retractall(user:wam_c_meta_bag(_)),
     retractall(user:wam_c_meta_set(_)),
     retractall(user:wam_c_meta_empty_bag(_)),
     retractall(user:wam_c_meta_conj_bag(_)),
     retractall(user:wam_c_meta_conj_set(_)),
     retractall(user:wam_c_meta_disj_bag(_)),
-    retractall(user:wam_c_meta_disj_set(_)).
+    retractall(user:wam_c_meta_disj_set(_)),
+    retractall(user:wam_c_meta_ite_bag(_)),
+    retractall(user:wam_c_meta_ite_else_bag(_)),
+    retractall(user:wam_c_meta_ite_set(_)).
 
 run_real_prolog_classic_recursive_executable_smoke :-
     assertz((user:wam_c_classic_fib(0, 0) :- true)),
@@ -6826,6 +6891,11 @@ void setup_wam_c_meta_disj_left_1(WamState* state);
 void setup_wam_c_meta_disj_right_1(WamState* state);
 void setup_wam_c_meta_disj_set_left_1(WamState* state);
 void setup_wam_c_meta_disj_set_right_1(WamState* state);
+void setup_wam_c_meta_ite_cond_1(WamState* state);
+void setup_wam_c_meta_ite_then_1(WamState* state);
+void setup_wam_c_meta_ite_fail_cond_1(WamState* state);
+void setup_wam_c_meta_ite_else_1(WamState* state);
+void setup_wam_c_meta_ite_set_then_1(WamState* state);
 void setup_wam_c_meta_bag_1(WamState* state);
 void setup_wam_c_meta_set_1(WamState* state);
 void setup_wam_c_meta_empty_bag_1(WamState* state);
@@ -6833,6 +6903,9 @@ void setup_wam_c_meta_conj_bag_1(WamState* state);
 void setup_wam_c_meta_conj_set_1(WamState* state);
 void setup_wam_c_meta_disj_bag_1(WamState* state);
 void setup_wam_c_meta_disj_set_1(WamState* state);
+void setup_wam_c_meta_ite_bag_1(WamState* state);
+void setup_wam_c_meta_ite_else_bag_1(WamState* state);
+void setup_wam_c_meta_ite_set_1(WamState* state);
 
 static bool wam_c_meta_expect_atom_list2(WamState *state, WamValue value,
                                          const char *first,
@@ -6892,6 +6965,11 @@ int main(void) {
     setup_wam_c_meta_disj_right_1(&state);
     setup_wam_c_meta_disj_set_left_1(&state);
     setup_wam_c_meta_disj_set_right_1(&state);
+    setup_wam_c_meta_ite_cond_1(&state);
+    setup_wam_c_meta_ite_then_1(&state);
+    setup_wam_c_meta_ite_fail_cond_1(&state);
+    setup_wam_c_meta_ite_else_1(&state);
+    setup_wam_c_meta_ite_set_then_1(&state);
     setup_wam_c_meta_bag_1(&state);
     setup_wam_c_meta_set_1(&state);
     setup_wam_c_meta_empty_bag_1(&state);
@@ -6899,6 +6977,9 @@ int main(void) {
     setup_wam_c_meta_conj_set_1(&state);
     setup_wam_c_meta_disj_bag_1(&state);
     setup_wam_c_meta_disj_set_1(&state);
+    setup_wam_c_meta_ite_bag_1(&state);
+    setup_wam_c_meta_ite_else_bag_1(&state);
+    setup_wam_c_meta_ite_set_1(&state);
 
     WamValue bag_args[1] = { val_unbound("Bag") };
     int bag_rc = wam_run_predicate(&state, "wam_c_meta_bag/1", bag_args, 1);
@@ -6906,7 +6987,8 @@ int main(void) {
         !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "b") ||
         state.B != 0 || state.call_base_top != 0 ||
         state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
-        state.conj_top != 0 || state.disj_top != 0) {
+        state.conj_top != 0 || state.disj_top != 0 ||
+        state.ite_top != 0) {
         wam_free_state(&state);
         return 10;
     }
@@ -6917,7 +6999,8 @@ int main(void) {
         !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "b") ||
         state.B != 0 || state.call_base_top != 0 ||
         state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
-        state.conj_top != 0 || state.disj_top != 0) {
+        state.conj_top != 0 || state.disj_top != 0 ||
+        state.ite_top != 0) {
         wam_free_state(&state);
         return 20;
     }
@@ -6928,7 +7011,8 @@ int main(void) {
     if (empty_rc != WAM_HALT ||
         state.B != 0 || state.call_base_top != 0 ||
         state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
-        state.conj_top != 0 || state.disj_top != 0) {
+        state.conj_top != 0 || state.disj_top != 0 ||
+        state.ite_top != 0) {
         wam_free_state(&state);
         return 30;
     }
@@ -6940,7 +7024,8 @@ int main(void) {
         !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "c") ||
         state.B != 0 || state.call_base_top != 0 ||
         state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
-        state.conj_top != 0 || state.disj_top != 0) {
+        state.conj_top != 0 || state.disj_top != 0 ||
+        state.ite_top != 0) {
         wam_free_state(&state);
         return 40;
     }
@@ -6952,7 +7037,8 @@ int main(void) {
         !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "b") ||
         state.B != 0 || state.call_base_top != 0 ||
         state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
-        state.conj_top != 0 || state.disj_top != 0) {
+        state.conj_top != 0 || state.disj_top != 0 ||
+        state.ite_top != 0) {
         wam_free_state(&state);
         return 50;
     }
@@ -6964,7 +7050,8 @@ int main(void) {
         !wam_c_meta_expect_atom_list3(&state, state.A[0], "a", "b", "c") ||
         state.B != 0 || state.call_base_top != 0 ||
         state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
-        state.conj_top != 0 || state.disj_top != 0) {
+        state.conj_top != 0 || state.disj_top != 0 ||
+        state.ite_top != 0) {
         wam_free_state(&state);
         return 60;
     }
@@ -6976,9 +7063,50 @@ int main(void) {
         !wam_c_meta_expect_atom_list3(&state, state.A[0], "a", "b", "c") ||
         state.B != 0 || state.call_base_top != 0 ||
         state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
-        state.conj_top != 0 || state.disj_top != 0) {
+        state.conj_top != 0 || state.disj_top != 0 ||
+        state.ite_top != 0) {
         wam_free_state(&state);
         return 70;
+    }
+
+    WamValue ite_bag_args[1] = { val_unbound("IteBag") };
+    int ite_bag_rc = wam_run_predicate(&state, "wam_c_meta_ite_bag/1",
+                                       ite_bag_args, 1);
+    if (ite_bag_rc != 0 || state.P != WAM_HALT ||
+        !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "a") ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
+        state.conj_top != 0 || state.disj_top != 0 ||
+        state.ite_top != 0) {
+        wam_free_state(&state);
+        return 80;
+    }
+
+    WamValue ite_else_bag_args[1] = { val_unbound("IteElseBag") };
+    int ite_else_bag_rc = wam_run_predicate(&state,
+                                            "wam_c_meta_ite_else_bag/1",
+                                            ite_else_bag_args, 1);
+    if (ite_else_bag_rc != 0 || state.P != WAM_HALT ||
+        !wam_c_meta_expect_atom_list2(&state, state.A[0], "c", "d") ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
+        state.conj_top != 0 || state.disj_top != 0 ||
+        state.ite_top != 0) {
+        wam_free_state(&state);
+        return 90;
+    }
+
+    WamValue ite_set_args[1] = { val_unbound("IteSet") };
+    int ite_set_rc = wam_run_predicate(&state, "wam_c_meta_ite_set/1",
+                                       ite_set_args, 1);
+    if (ite_set_rc != 0 || state.P != WAM_HALT ||
+        !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "b") ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
+        state.conj_top != 0 || state.disj_top != 0 ||
+        state.ite_top != 0) {
+        wam_free_state(&state);
+        return 100;
     }
 
     wam_free_state(&state);


### PR DESCRIPTION
  ## Summary

  - Add C WAM runtime support for if-then-else goal terms in meta aggregate bodies.
  - Recognize `;(->(If, Then), Else)` and commit on the first condition success by pruning condition alternatives plus
  the else fallback before invoking `Then`.
  - Extend non-inline `bagof/3` and `setof/3` executable smoke coverage for condition-commit, else-fallback, and sorted/
  deduplicated set output.
  - Update the WAM-C next-steps doc; the remaining meta-goal gap is `call/N`.

  ## Verification

  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `git diff --check HEAD~1..HEAD`