### PR TITLE
feat(wam-python): enable ite_use_y_level (activate dormant M17 get_level/cut)

### DIFF
--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -2102,10 +2102,10 @@ plan_python_predicate(Options, Pred/Arity, pred_plan(Pred, Arity, Wam, Kind)) :-
 python_plan_compile_predicate(Options, PredIndicator, Wam) :-
 	python_wam_emit_ir_mode(Options, IrMode),
 	(   IrMode = wam_text
-	->  compile_predicate_to_wam_text(PredIndicator, [], WamText),
+	->  compile_predicate_to_wam_text(PredIndicator, [ite_use_y_level(true)], WamText),
 	    python_wam_text_plan(WamText, Wam)
 	;   IrMode = wam_items_bridge
-	->  compile_predicate_to_wam_items(PredIndicator, [], Items),
+	->  compile_predicate_to_wam_items(PredIndicator, [ite_use_y_level(true)], Items),
 	    python_wam_items_plan(Items, Wam)
 	).
 

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -316,7 +316,7 @@ user:py_items_api_demo.
 test(python_planning_uses_common_items_api) :-
     once(source_file(wam_python_target:compile_wam_predicate_to_python(_, _, _, _), Path)),
     read_file_to_string(Path, Content, []),
-    sub_string(Content, _, _, _, "compile_predicate_to_wam_items(PredIndicator, [], Items)"),
+    sub_string(Content, _, _, _, "compile_predicate_to_wam_items(PredIndicator, [ite_use_y_level(true)], Items)"),
     sub_string(Content, _, _, _, "python_wam_items_plan(Items, Wam)"),
     sub_string(Content, _, _, _, "compile_wam_predicate_items_to_python(Pred/Arity, Items, Options, PredCode)"),
     !.
@@ -326,7 +326,7 @@ test(python_lowered_mode_keeps_text_plan) :-
     read_file_to_string(Path, Content, []),
     sub_string(Content, _, _, _, "python_wam_emit_ir_mode(Options, IrMode)"),
     sub_string(Content, _, _, _, "wam_ir_mode(wam_python, EmitMode, Options, IrMode)"),
-    sub_string(Content, _, _, _, "compile_predicate_to_wam_text(PredIndicator, [], WamText)"),
+    sub_string(Content, _, _, _, "compile_predicate_to_wam_text(PredIndicator, [ite_use_y_level(true)], WamText)"),
     sub_string(Content, _, _, _, "wam_plan_text(Wam, WamText)"),
     !.
 
@@ -2181,7 +2181,49 @@ test(static_runtime_io_emits_output, [nondet]) :-
 % Generated-project E2E coverage for packaged static runtime builtins
 % ============================================================================
 
+% Cut / negation / forall predicates (M17 get_level/cut path, enabled via
+% ite_use_y_level). pcut_inline (a cut inside a negated conjunction) and
+% pcut_forall_neg (forall over a multi-solution generator) were wrong under
+% the legacy cut_ite and are fixed by the M17 path.
+:- dynamic user:pcut_acc/3.
+:- dynamic user:pcut_plen/2.
+:- dynamic user:pcut_gen/1.
+:- dynamic user:pcut_partial/0.
+:- dynamic user:pcut_inline/0.
+:- dynamic user:pcut_forall_neg/0.
+:- dynamic user:pcut_forall_pass/0.
+user:pcut_acc(L, _, _) :- var(L), !, fail.
+user:pcut_acc([], N, N) :- !.
+user:pcut_acc([_|T], A, N) :- A1 is A + 1, pcut_acc(T, A1, N).
+user:pcut_plen(L, N) :- pcut_acc(L, 0, N).
+user:pcut_gen(1).
+user:pcut_gen(2).
+user:pcut_gen(3).
+user:pcut_partial :- \+ pcut_plen([a,b|_], _).          % partial list rejected -> true
+user:pcut_inline :- \+ (pcut_gen(_), !, fail).          % inline cut in negation -> true
+user:pcut_forall_neg :- \+ forall(pcut_gen(X), X =:= 1). % not all -> \+ true
+user:pcut_forall_pass :- forall(pcut_gen(X), X >= 1).    % all -> true
+
 :- begin_tests(wam_python_builtin_e2e).
+
+test(generated_project_cut_negation_forall) :-
+	setup_call_cleanup(
+		unique_tmp_dir('tmp_wam_python_cut_e2e', ProjectDir),
+		(   wam_python_target:write_wam_python_project(
+				[user:pcut_acc/3, user:pcut_plen/2, user:pcut_gen/1,
+				 user:pcut_partial/0, user:pcut_inline/0,
+				 user:pcut_forall_neg/0, user:pcut_forall_pass/0],
+				[], ProjectDir),
+			run_generated_query(ProjectDir, 'pcut_partial/0', O1),
+			\+ sub_string(O1, _, _, _, "false."),
+			run_generated_query(ProjectDir, 'pcut_inline/0', O2),
+			\+ sub_string(O2, _, _, _, "false."),
+			run_generated_query(ProjectDir, 'pcut_forall_neg/0', O3),
+			\+ sub_string(O3, _, _, _, "false."),
+			run_generated_query(ProjectDir, 'pcut_forall_pass/0', O4),
+			\+ sub_string(O4, _, _, _, "false.")
+		),
+		cleanup_tmp_dir(ProjectDir)).
 
 test(generated_project_runs_term_builtins) :-
 	setup_call_cleanup(


### PR DESCRIPTION
  WamRuntime.py and the text/items instruction translators already had full M17 get_level/cut
  support, but the compiler never passed ite_use_y_level(true) — so it emitted legacy cut_ite,
  and a cut inside a negated goal (\+ (G, !, fail)) plus forall over a multi-solution
  generator behaved wrongly (cut_ite drops only the topmost choicepoint).

  Pass ite_use_y_level(true) at both python_plan_compile_predicate sites (wam_text and
  wam_items_bridge). This activates the already-present get_level/cut path — no runtime
  change.  cut_ite, and a cut inside a negated goal (\+ (G, !, fail)) plus forall over a
  multi-solution generator behaved wrongly (cut_ite drops only the topmost choicepoint).

  Pass ite_use_y_level(true) at both python_plan_compile_predicate sites (wam_text and
  wam_items_bridge). This activates the already-present get_level/cut path — no runtime

  Pass ite_use_y_level(true) at both python_plan_compile_predicate sites (wam_text and
  wam_items_bridge). This activates the already-present get_level/cut path — no runtime
  change.  get_level/cut support, but the compiler never passed ite_use_y_level(true) — so it
  emitted legacy cut_ite, and a cut inside a negated goal (\+ (G, !, fail)) plus forall
  over a multi-solution generator behaved wrongly (cut_ite drops only the topmost
  choicepoint).

  Pass ite_use_y_level(true) at both python_plan_compile_predicate sites (wam_text and
  wam_items_bridge). This activates the already-present get_level/cut path — no runtime
  change.  get_level/cut support, but the compiler never passed ite_use_y_level(true) — so it
  emitted legacy cut_ite, and a cut inside a negated goal (\+ (G, !, fail)) plus forall
  over a multi-solution generator behaved wrongly (cut_ite drops only the topmost
  choicepoint).

  Pass ite_use_y_level(true) at both python_plan_compile_predicate sites (wam_text and
  wam_items_bridge). This activates the already-present get_level/cut path — no runtime
  change. over a multi-solution generator behaved wrongly (cut_ite drops only the topmost
  choicepoint).

  Pass ite_use_y_level(true) at both python_plan_compile_predicate sites (wam_text and
  Pass ite_use_y_level(true) at both python_plan_compile_predicate sites (wam_text and
  wam_items_bridge). This activates the already-present get_level/cut path — no runtime change.
  drops only the topmost choicepoint).

  Pass ite_use_y_level(true) at both python_plan_compile_predicate sites (wam_text and
  wam_items_bridge). This activates the already-present get_level/cut path — no runtime change.
  Pass ite_use_y_level(true) at both python_plan_compile_predicate sites (wam_text and
  wam_items_bridge). This activates the already-present get_level/cut path — no runtime change.

  Adds generated_project_cut_negation_forall e2e test (runs via python); updates two brittle
  source-text assertions that pinned the [] argument.

  Test plan: baseline probe fails pcut_inline/pcut_forall_neg; with the option all cases pass. 178/178
  test_wam_python_target, test_wam_python_lowered_ite, cross-target conformance/consistency,
  test_wam_target green.

  🤖 Generated with Claude Code (https://claude.com/claude-code)