### PR TITLE
Tree-likeness V3: read max_dist_to_root from the materialised metri

### DIFF
--- a/examples/prototypes/tree_likeness_index_depth_likeness_probes/README.md
+++ b/examples/prototypes/tree_likeness_index_depth_likeness_probes/README.md
@@ -25,6 +25,37 @@ The fourth row (B = 15 fixed) was an earlier intermediate result captured
 in the same script `v1_v3_root_targeted_depth_probe.py` (commented config
 toggle); the corresponding results file is preserved separately.
 
+### V3 budget from the materialised `max_dist_to_root` metric
+
+V3's budget `B` (max acyclic parent distance to root) *is* the
+`max_dist_to_root` root-anchored metric (docs/design/ROOT_ANCHORED_METRICS_*).
+`scripts/max_dist_budget.py` holds that quantity as two cross-checked
+implementations, and V3 can now read the **ingest-materialised** lookup instead
+of recomputing it:
+
+```bash
+# 1. build a Phase-1 scoped LMDB rooted at the V3 root, then materialise the
+#    metric UNBOUNDED (max_depth >= graph diameter so it isn't truncated):
+python3 examples/benchmark/build_scoped_subtree_lmdb.py --src <phase1_lmdb> \
+    --root 137597 --out /tmp/sw_scoped --max-depth 100
+python3 benchmarks/root-metrics/prototype/build_max_distance.py \
+    --lmdb /tmp/sw_scoped --max-depth 100
+# 2. point V3 at it:
+python3 scripts/v3_max_parent_distance_probe.py --max-dist-metric /tmp/sw_scoped
+```
+
+**Finding (characterised by `max_dist_budget.py`'s self-check):** the metric and
+the probe's original in-line DP compute *different* budgets. The DP assumed
+"every parent has a smaller BFS depth" and so only follows shortest-depth-
+decreasing parents — it **undercounts** any node that has a near-root shortcut
+parent *and* a longer ancestor chain through a deeper parent. On a diamond
+(`4->{1,3}`, `3->2`, `2->1`) the DP gives `max_dist[4]=1` while the true longest
+acyclic path `4->3->2->1` is `3` (what the metric gives). So `--max-dist-metric`
+is **not** a drop-in: it grows `B` and changes V3's results. The default still
+runs the original DP, so committed results stay reproducible; the materialised
+path is the corrected (true-longest) budget. Run
+`python3 scripts/max_dist_budget.py` to see the divergence.
+
 ## Headline empirical findings
 
 See `docs/reports/depth_likeness_budget_variants.md` for the full

--- a/examples/prototypes/tree_likeness_index_depth_likeness_probes/scripts/max_dist_budget.py
+++ b/examples/prototypes/tree_likeness_index_depth_likeness_probes/scripts/max_dist_budget.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Shared definition of the V3 "max acyclic parent distance to root" budget.
+
+The V3 probe's budget B is the longest acyclic parent-hop distance from a node
+to the root — which is exactly the `max_dist_to_root` root-anchored metric
+(docs/design/ROOT_ANCHORED_METRICS_*). This module holds TWO implementations of
+that one quantity, kept side by side so they cross-check:
+
+  - `dp_max_dist(min_dist, parents_of)` — the in-probe DP (BFS-depth
+    topological order), unbounded. This is what V3 used inline.
+  - `load_metric_max_dist(lmdb_dir, ...)` — read the ingest-materialised
+    `metric_max_dist_to_root` table written by
+    benchmarks/root-metrics/prototype/build_max_distance.py, so the budget
+    becomes a precomputed lookup instead of a per-run recompute.
+
+On a DAG the two agree EXACTLY when the materialised metric was built with
+`max_depth >= graph diameter` (i.e. effectively unbounded). build_max_distance
+bounds the walk at `max_depth`; the DP here is unbounded, so a too-small
+max_depth truncates deep nodes and the two diverge. `load_metric_max_dist`
+warns when the stored table looks bounded or rooted differently.
+
+Run `python3 max_dist_budget.py` for a synthetic equivalence self-check.
+"""
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import lmdb
+
+I32 = struct.Struct("<i")
+
+
+def dp_max_dist(min_dist, parents_of):
+    """The V3 probe's original budget DP (BFS-depth-monotone longest path).
+
+    `min_dist` maps node -> BFS depth from root (depth 0 == root). Nodes are
+    processed in ascending depth, and only parents already resolved (i.e. at a
+    strictly smaller BFS depth) contribute. Returns {node: max_dist}, root -> 0.
+
+    CAVEAT — this is NOT the true longest acyclic parent path. A node can have a
+    parent at a *greater* BFS depth (a node with a near-root shortcut parent AND
+    a deeper ancestor chain via another parent); this DP skips that deeper
+    parent and so UNDERCOUNTS. On a diamond 4->{1,3}, 3->2, 2->1 it returns
+    max_dist[4]=1, while the true longest acyclic path 4->3->2->1 is 3. The
+    materialised `max_dist_to_root` metric (load_metric_max_dist) computes the
+    true value; see this module's self-check. Kept as-is so the probe's existing
+    committed results remain reproducible; pass --max-dist-metric to the probe to
+    use the corrected (true-longest) budget instead.
+    """
+    nodes_at_depth = {}
+    for n, d in min_dist.items():
+        nodes_at_depth.setdefault(d, []).append(n)
+    if not nodes_at_depth:
+        return {}
+    max_dist = {n: 0 for n in nodes_at_depth.get(0, [])}
+    for d in range(1, max(nodes_at_depth) + 1):
+        for n in nodes_at_depth.get(d, []):
+            cand = [max_dist[p] for p in parents_of.get(n, ()) if p in max_dist]
+            if cand:
+                max_dist[n] = 1 + max(cand)
+    return max_dist
+
+
+def load_metric_max_dist(lmdb_dir, expected_root=None, warn=sys.stderr):
+    """Read the materialised `metric_max_dist_to_root` table (int32 -> int32)
+    from a Phase-1 scoped LMDB. Returns {node: max_dist}.
+
+    Emits a warning (to `warn`, or None to silence) when the stored root differs
+    from `expected_root` (node ids may not correspond) or when the values reach
+    the stored max_depth (the table is bounded and will disagree with the
+    unbounded DP on deep nodes — rebuild with a larger --max-depth).
+    """
+    env = lmdb.open(str(lmdb_dir), max_dbs=16, readonly=True, subdir=True, lock=False)
+    try:
+        m = env.open_db(b"metric_max_dist_to_root", create=False)
+        meta = env.open_db(b"meta", create=False)
+        out = {}
+        with env.begin() as txn:
+            r = txn.get(b"metric_max_dist_to_root.root", db=meta)
+            md = txn.get(b"metric_max_dist_to_root.max_depth", db=meta)
+            stored_root = int(r) if r is not None else None
+            stored_md = int(md) if md is not None else None
+            for k, v in txn.cursor(db=m):
+                out[I32.unpack(k)[0]] = I32.unpack(v)[0]
+    finally:
+        env.close()
+    if warn is not None:
+        if (expected_root is not None and stored_root is not None
+                and stored_root != expected_root):
+            warn.write(f"WARNING: metric root {stored_root} != probe root "
+                       f"{expected_root}; node ids may not correspond\n")
+        if stored_md is not None and out and max(out.values()) >= stored_md:
+            warn.write(f"WARNING: metric max value reaches stored max_depth="
+                       f"{stored_md}; the materialised max_dist is likely BOUNDED "
+                       f"and will disagree with the unbounded DP on deep nodes. "
+                       f"Rebuild build_max_distance.py with a larger --max-depth.\n")
+    return out
+
+
+# Path to the materialiser, for the self-check and for callers that want to
+# (re)build a metric before loading it.
+BUILD_MAX_DISTANCE = (Path(__file__).resolve().parents[4]
+                      / "benchmarks" / "root-metrics" / "prototype"
+                      / "build_max_distance.py")
+
+
+def _self_check():
+    """Build a synthetic diamond Phase-1 LMDB, materialise max_dist_to_root with
+    an unbounded depth, and pin BOTH budgets — characterising the difference
+    between the materialised metric (true longest acyclic path) and the probe's
+    BFS-depth-monotone DP (which undercounts node 4: 1 vs 3)."""
+    import tempfile
+    from collections import deque
+
+    # child -> [parents]; root = 1. Diamond: 4 reaches root via 4->1 (len 1)
+    # and 4->3->2->1 (len 3); longest acyclic = 3.
+    adj = {2: [1], 3: [2], 4: [1, 3]}
+    root, max_depth = 1, 50
+    with tempfile.TemporaryDirectory() as tmp:
+        lmdb_dir = Path(tmp) / "scoped"
+        env = lmdb.open(str(lmdb_dir), max_dbs=16, map_size=10 * 1024 * 1024, subdir=True)
+        cp = env.open_db(b"category_parent", dupsort=True, create=True)
+        meta = env.open_db(b"meta", create=True)
+        with env.begin(write=True) as txn:
+            for c, ps in adj.items():
+                for p in ps:
+                    txn.put(I32.pack(c), I32.pack(p), db=cp, dupdata=True)
+            txn.put(b"scoped_root", str(root).encode(), db=meta)
+            txn.put(b"scoped_max_depth", str(max_depth).encode(), db=meta)
+        env.sync(); env.close()
+
+        rc = subprocess.run(
+            [sys.executable, str(BUILD_MAX_DISTANCE), "--lmdb", str(lmdb_dir),
+             "--root", str(root), "--max-depth", str(max_depth)],
+            capture_output=True, text=True)
+        assert rc.returncode == 0, rc.stderr
+
+        # in-probe DP over the same graph
+        parents_of = {c: ps for c, ps in adj.items()}
+        children_of = {}
+        for c, ps in adj.items():
+            for p in ps:
+                children_of.setdefault(p, []).append(c)
+        min_dist = {root: 0}
+        q = deque([root])
+        while q:
+            n = q.popleft()
+            for c in children_of.get(n, ()):
+                if c not in min_dist:
+                    min_dist[c] = min_dist[n] + 1
+                    q.append(c)
+        dp = dp_max_dist(min_dist, parents_of)
+        loaded = load_metric_max_dist(lmdb_dir, expected_root=root)
+
+        # Materialised metric = true longest acyclic parent path (root -> 0).
+        assert loaded == {1: 0, 2: 1, 3: 2, 4: 3}, loaded
+        # Probe DP undercounts node 4 (1, not 3): it skips parent 3, which is at
+        # a greater BFS depth than 4 (4 has a near-root shortcut 4->1).
+        assert dp == {1: 0, 2: 1, 4: 1, 3: 2}, dp
+        assert loaded[4] == 3 and dp[4] == 1, "expected the documented divergence"
+    print("max_dist_budget self-check OK: metric=true-longest {2:1,3:2,4:3}; "
+          "probe-DP undercounts node 4 (1 vs 3) — divergence characterised")
+
+
+if __name__ == "__main__":
+    _self_check()

--- a/examples/prototypes/tree_likeness_index_depth_likeness_probes/scripts/v3_max_parent_distance_probe.py
+++ b/examples/prototypes/tree_likeness_index_depth_likeness_probes/scripts/v3_max_parent_distance_probe.py
@@ -22,8 +22,18 @@ What this should show:
 - If d_wPow ≈ avg + 1: metric averages over chains (depth-like-on-average)
 - If d_wPow < min_dist + 1: shortcuts dominate even at this looser budget
 """
-import lmdb, math, random, time, sys
+import argparse, lmdb, math, os, random, time, sys
 from collections import defaultdict, deque
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from max_dist_budget import dp_max_dist, load_metric_max_dist
+
+_ap = argparse.ArgumentParser(add_help=False)
+_ap.add_argument("--max-dist-metric", default=None,
+                 help="Phase-1 scoped LMDB dir holding metric_max_dist_to_root; "
+                      "use the materialised true-longest budget instead of the "
+                      "in-probe DP (which undercounts — see max_dist_budget.py)")
+MAX_DIST_METRIC = _ap.parse_known_args()[0].max_dist_metric
 
 LMDB_PATH = '/tmp/sw_post_fix_lmdb'
 ROOT_ID = 137597
@@ -82,20 +92,32 @@ print(f"  Reachable: {len(reachable):,}")
 # DP for max acyclic parent distance to root
 # ============================================================
 
-print("[3/6] DP for max acyclic parent distance to root...", flush=True)
-# Build nodes_at_depth (sorted by BFS depth ascending)
+print("[3/6] max acyclic parent distance to root...", flush=True)
+# Build nodes_at_depth (sorted by BFS depth ascending) — used by the sampler.
 nodes_at_depth = defaultdict(list)
 for n, d in min_dist.items():
     nodes_at_depth[d].append(n)
-max_dist = {ROOT_ID: 0}
-max_depth = max(nodes_at_depth.keys())
-for d in range(1, max_depth + 1):
-    for n in nodes_at_depth[d]:
-        # parents of n with smaller BFS depth (acyclic guarantee in topological order)
-        candidate_parents = [p for p in parents_of.get(n, ()) if p in max_dist]
-        if not candidate_parents:
-            continue
-        max_dist[n] = 1 + max(max_dist[p] for p in candidate_parents)
+
+if MAX_DIST_METRIC:
+    # Use the ingest-materialised budget (true longest acyclic parent path).
+    print(f"  using materialised max_dist_to_root from {MAX_DIST_METRIC}", flush=True)
+    max_dist = load_metric_max_dist(MAX_DIST_METRIC, expected_root=ROOT_ID)
+    missing = [n for n in reachable if n not in max_dist]
+    if missing:
+        # Node ids absent from the metric (e.g. metric scoped to a subtree) fall
+        # back to the in-probe DP so the sampler still has a budget for them.
+        print(f"  WARNING: {len(missing):,} reachable nodes absent from metric; "
+              f"falling back to DP for those", flush=True)
+        dp = dp_max_dist(min_dist, parents_of)
+        for n in missing:
+            if n in dp:
+                max_dist[n] = dp[n]
+else:
+    # Default: the probe's original BFS-depth-monotone DP. NOTE this undercounts
+    # nodes whose longest ancestor chain runs through a deeper-BFS parent; pass
+    # --max-dist-metric for the corrected (true-longest) budget. See
+    # max_dist_budget.py for the characterised divergence.
+    max_dist = dp_max_dist(min_dist, parents_of)
 
 # Stats on max_dist vs min_dist
 ratios = []


### PR DESCRIPTION
  ## Summary

  Wires the root-anchored `max_dist_to_root` metric into the tree-likeness V3
  depth-likeness probe. V3's budget `B` (max acyclic parent distance to root) *is*
  that metric, so the probe can now read the ingest-materialised lookup instead of
  recomputing it per run.

  ## Changes

  - **`scripts/max_dist_budget.py`** (new): the budget as two cross-checked
    implementations — `dp_max_dist` (the probe's in-line DP) and
    `load_metric_max_dist` (reader for the materialised `metric_max_dist_to_root`
    table from `benchmarks/root-metrics/prototype/build_max_distance.py`), with
    root / bounded-depth guards. `__main__` runs a synthetic-diamond self-check.
  - **V3 probe**: opt-in `--max-dist-metric DIR`; default behaviour unchanged.
  - **README**: build steps + the finding below.

  ## Finding — the two budgets differ (opt-in, not drop-in)

  The probe's DP assumes every parent has a smaller BFS depth and only follows
  shortest-depth-decreasing parents, so it **undercounts** nodes with a near-root
  shortcut parent plus a deeper ancestor chain. On a diamond it gives
  `max_dist[4]=1` vs the true longest path `4→3→2→1 = 3` (the metric). So
  `--max-dist-metric` grows `B` and **changes** V3's results — it's the corrected
  budget, not a drop-in. Default stays on the original DP so committed results
  remain reproducible.

  ## Verification

  `python3 scripts/max_dist_budget.py` → self-check OK (characterises the
  divergence). Probe syntax + sibling-import checks pass. Not run end-to-end on
  simplewiki (needs `/tmp/sw_post_fix_lmdb`, absent here) — synthetic-validated
  only; an at-scale re-run is the follow-up.

  Given the finding, the highest-value follow-up is the at-scale re-run: build the unbounded metric on the simplewiki post-fix
  LMDB and re-run V3 with --max-dist-metric to measure how much the MIN/AVG/SHORTCUT split actually shifts — that quantifies
  whether the original V3 conclusion holds. Want that next (I'd need the simplewiki fixture available), or something else?