### PR TITLE
Add T5 first-argument clause-chain lowering for Go

### DIFF
--- a/src/unifyweaver/targets/wam_go_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_go_lowered_emitter.pl
@@ -24,6 +24,7 @@
 
 :- use_module(library(lists)).
 :- use_module(wam_ite_structurer, [structure_ite/2, split_commit/3, is_commit/1]).
+:- use_module(wam_clause_chain, [clause_chain/2]).
 :- use_module(wam_text_parser, [wam_classify_constant_token/2]).
 :- use_module(wam_go_target, [
     escape_go_string/2,
@@ -163,7 +164,12 @@ go_supported_structured(I) :- go_supported(I).
 wam_go_lowerable(PI, WamCode, Reason) :-
     go_base_instrs(WamCode, Instrs),
     clause1_instrs(Instrs, C1),
-    (   % No internal ITE: existing deterministic / multi-clause path.
+    (   % T5: multi-clause predicate discriminating on a distinct
+        % first-argument constant lowers to a bound-checked if-cascade over
+        % ALL clauses (no interpreter hop for clauses 2+ when A1 is bound).
+        go_clause_chain_lowerable(Instrs, _Guards)
+    ->  Reason = clause_chain
+    ;   % No internal ITE: existing deterministic / multi-clause path.
         \+ member(try_me_else(_), C1),
         forall(member(I, C1), go_supported(I))
     ->  ( is_deterministic_pred_go(Instrs) -> Reason = deterministic
@@ -185,6 +191,16 @@ clause1_instrs(Instrs, Instrs).
 take_to_proceed([], []).
 take_to_proceed([proceed|_], [proceed]) :- !.
 take_to_proceed([I|Rest], [I|More]) :- take_to_proceed(Rest, More).
+
+%% go_clause_chain_lowerable(+Instrs, -Guards) is semidet.
+%  True when the predicate is a distinct-first-argument-constant clause
+%  chain (T5) and every clause's remainder is a supported deterministic
+%  body. Guards is the shared front-end's guard(Const, Remainder) list.
+go_clause_chain_lowerable(Instrs, Guards) :-
+    clause_chain(Instrs, chain(Guards)),
+    forall(member(guard(_, Rem), Guards),
+           ( is_deterministic_pred_go(Rem),
+             forall(member(I, Rem), go_supported(I)) )).
 
 %% is_deterministic_pred_go(+Instrs)
 %  True if the instruction list has no choice point instructions.
@@ -269,18 +285,51 @@ lower_predicate_to_go(PI, WamCode, _Options, GoLines) :-
     go_func_name(Pred/Arity, FuncName),
     go_base_instrs(WamCode, Instrs),
     clause1_instrs(Instrs, C1Instrs),
-    % Emit the plain clause-1 when it has no inner choice point; otherwise
-    % fold its ITE block(s) into structured form (ite/3) first.
-    (   \+ member(try_me_else(_), C1Instrs)
-    ->  EmitInstrs = C1Instrs
-    ;   go_structured_clause1(WamCode, EmitInstrs)
-    ),
-    with_output_to(string(Body), emit_instrs(EmitInstrs, "    ")),
-    format(string(Header),
+    (   % T5 first-argument-constant dispatch takes precedence.
+        go_clause_chain_lowerable(Instrs, Guards)
+    ->  emit_clause_chain_go(FuncName, Pred, Arity, Guards, GoLines)
+    ;   % Emit the plain clause-1 when it has no inner choice point;
+        % otherwise fold its ITE block(s) into structured form (ite/3).
+        (   \+ member(try_me_else(_), C1Instrs)
+        ->  EmitInstrs = C1Instrs
+        ;   go_structured_clause1(WamCode, EmitInstrs)
+        ),
+        with_output_to(string(Body), emit_instrs(EmitInstrs, "    ")),
+        format(string(Header),
 '// ~w — lowered from ~w/~w
 func (vm *WamState) ~w() bool {', [FuncName, Pred, Arity, FuncName]),
+        format(string(Footer), '}', []),
+        GoLines = [Header, Body, Footer]
+    ).
+
+%% emit_clause_chain_go(+FuncName, +Pred, +Arity, +Guards, -GoLines)
+%  Emit T5: deref the first argument once; if it is still unbound, defer to
+%  the entry wrapper's interpreter fallback (the unbound case is genuinely
+%  nondeterministic). Otherwise dispatch with an if-cascade comparing the
+%  bound value against each clause's distinct discriminator and running that
+%  clause's remainder (which self-terminates: its `proceed` emits
+%  `return true`). A bound value matching no clause returns false (the
+%  predicate fails; the wrapper's fresh re-run also fails — sound).
+emit_clause_chain_go(FuncName, Pred, Arity, Guards, GoLines) :-
+    go_reg_idx("A1", A1Idx),
+    format(string(Header),
+'// ~w — lowered from ~w/~w (T5 first-argument dispatch)
+func (vm *WamState) ~w() bool {', [FuncName, Pred, Arity, FuncName]),
+    with_output_to(string(Body),
+        ( format("    t5a1 := vm.deref(vm.Regs[~w])~n", [A1Idx]),
+          format("    if _, ok := t5a1.(*Unbound); ok { return false }  // unbound first arg: defer to interpreter (enumerates all clauses)~n"),
+          emit_go_guards(Guards),
+          format("    return false~n") )),
     format(string(Footer), '}', []),
     GoLines = [Header, Body, Footer].
+
+emit_go_guards([]).
+emit_go_guards([guard(V, Rem) | Rest]) :-
+    go_val_literal(V, GoVal),
+    format("    if valueEquals(t5a1, ~w) {~n", [GoVal]),
+    emit_instrs(Rem, "        "),
+    format("    }~n"),
+    emit_go_guards(Rest).
 
 %% emit_instrs(+Instrs, +Indent)
 %  Emit Go code for a list of instructions. Detects the WAM if-then-else

--- a/tests/test_wam_go_lowered_t5.pl
+++ b/tests/test_wam_go_lowered_t5.pl
@@ -1,0 +1,156 @@
+% test_wam_go_lowered_t5.pl
+%
+% End-to-end execution test for the Go T5 lowering — "multi-clause as an
+% if-then-else chain" (lowering type T5 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md), ported from Scala/Rust
+% via the shared wam_clause_chain front-end.
+%
+% A predicate whose clauses discriminate on a DISTINCT first-argument
+% constant now lowers to a bound-checked first-arg dispatch over ALL clauses
+% (non-first clauses become fast-path too when A1 is bound); an unbound first
+% argument returns false and defers to the entry wrapper's interpreter
+% fallback. Pins (BOUND first arg, exercising every clause incl. non-first):
+%   * color/1 — fact chain;
+%   * sz/2    — second head match in each remainder;
+%   * op/2    — RULE chain (each remainder runs an is/2 builtin).
+%
+% Skipped automatically when `go` is not on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_go_target').
+:- use_module('../src/unifyweaver/targets/wam_go_lowered_emitter').
+
+:- dynamic user:color/1.
+:- dynamic user:sz/2.
+:- dynamic user:op/2.
+
+user:color(red).
+user:color(green).
+user:color(blue).
+
+user:sz(small, 1).
+user:sz(medium, 2).
+user:sz(large, 3).
+
+user:op(add, R) :- R is 1 + 1.
+user:op(mul, R) :- R is 2 * 3.
+user:op(neg, R) :- R is 0 - 1.
+
+go_available :-
+    catch(
+        ( process_create(path(go), ['version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          process_wait(Pid, exit(0)) ),
+        _, fail).
+
+:- begin_tests(wam_go_lowered_t5, [condition(go_available)]).
+
+test(gate_picks_clause_chain) :-
+    forall(member(PI, [color/1, sz/2, op/2]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_go_lowerable(PI, W, Reason),
+             assertion(Reason == clause_chain) )).
+
+test(t5_exec_parity) :-
+    Dir = 'output/test_wam_go_t5_exec',
+    Proj = 'output/test_wam_go_t5_exec_gen',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ),
+    make_directory_path(Dir),
+    write_wam_go_project(
+        [user:color/1, user:sz/2, user:op/2],
+        [module_name('t5exec'), wam_fallback(true)], Proj),
+    % Sanity: the lowered code must be the T5 first-argument dispatch (not the
+    % old multi_clause_1 fast path).
+    atomic_list_concat([Proj, '/lowered.go'], LoweredPath),
+    ( exists_file(LoweredPath) -> read_file_to_string(LoweredPath, LSrc, []) ; LSrc = "" ),
+    assertion(sub_string(LSrc, _, _, _, "T5 first-argument dispatch")),
+    % Copy the runtime + lowered sources into a clean module and DROP lib.go.
+    % lib.go is the older native clause-parallel strategy (goroutines), which
+    % is independently broken for these predicate shapes (it emits `arg2 = ...`
+    % against an undeclared variable for rule clauses, and an unused `ctx` for
+    % arg-less fact predicates) — a pre-existing go_target native-codegen bug
+    % unrelated to WAM lowering. The T5 deliverable lives entirely in
+    % lowered.go, so we build and exercise that in isolation, mirroring how the
+    % Rust/Scala T5 tests target their lowered functions.
+    atomic_list_concat(['cp ', Proj, '/*.go ', Dir, '/ && rm -f ', Dir, '/lib.go'], CpCmd),
+    shell_ok_t5(CpCmd),
+    write_file_t5(Dir/'go.mod', "module t5exec\n\ngo 1.21\n"),
+    go_t5_source(Src),
+    write_file_t5(Dir/'t5_exec_test.go', Src),
+    format(atom(TestCmd), 'cd ~w && go test ./... 2>&1', [Dir]),
+    process_create(path(sh), ['-c', TestCmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    ->  true
+    ;   format(user_error, "~n[go test output]~n~w~n", [OutStr]),
+        throw(go_t5_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ).
+
+:- end_tests(wam_go_lowered_t5).
+
+shell_ok_t5(Cmd) :-
+    process_create(path(sh), ['-c', Cmd], [process(Pid)]),
+    process_wait(Pid, exit(0)).
+
+write_file_t5(PathSpec, Text) :-
+    ( atom(PathSpec) -> Path = PathSpec ; PathSpec = D/F, atomic_list_concat([D, '/', F], Path) ),
+    setup_call_cleanup(open(Path, write, S, [encoding(utf8)]), write(S, Text), close(S)).
+
+% Calls each lowered method with the query args loaded into Regs[0..] (first
+% arg bound). Exercises every clause incl. non-first (green/blue, medium/
+% large, mul/neg) — the T5 payoff — plus the no-match cases.
+go_t5_source(
+"package wam
+
+import \"testing\"
+
+func callPredT5(setup func(vm *WamState), pred func(vm *WamState) bool) bool {
+	vm := NewWamState(nil, nil)
+	setup(vm)
+	return pred(vm)
+}
+
+func TestT5Dispatch(t *testing.T) {
+	I := func(n int64) Value { return &Integer{Val: n} }
+	A := func(s string) Value { return internAtom(s) }
+	set := func(vals ...Value) func(vm *WamState) {
+		return func(vm *WamState) {
+			for i, v := range vals {
+				vm.Regs[i] = v
+			}
+		}
+	}
+	cases := []struct {
+		name string
+		got  bool
+		want bool
+	}{
+		{\"color(red)\", callPredT5(set(A(\"red\")), (*WamState).PredColor1), true},
+		{\"color(green)\", callPredT5(set(A(\"green\")), (*WamState).PredColor1), true},
+		{\"color(blue)\", callPredT5(set(A(\"blue\")), (*WamState).PredColor1), true},
+		{\"color(yellow)\", callPredT5(set(A(\"yellow\")), (*WamState).PredColor1), false},
+		{\"sz(small,1)\", callPredT5(set(A(\"small\"), I(1)), (*WamState).PredSz2), true},
+		{\"sz(medium,2)\", callPredT5(set(A(\"medium\"), I(2)), (*WamState).PredSz2), true},
+		{\"sz(large,3)\", callPredT5(set(A(\"large\"), I(3)), (*WamState).PredSz2), true},
+		{\"sz(small,2)\", callPredT5(set(A(\"small\"), I(2)), (*WamState).PredSz2), false},
+		{\"sz(big,1)\", callPredT5(set(A(\"big\"), I(1)), (*WamState).PredSz2), false},
+		{\"op(add,2)\", callPredT5(set(A(\"add\"), I(2)), (*WamState).PredOp2), true},
+		{\"op(mul,6)\", callPredT5(set(A(\"mul\"), I(6)), (*WamState).PredOp2), true},
+		{\"op(neg,-1)\", callPredT5(set(A(\"neg\"), I(-1)), (*WamState).PredOp2), true},
+		{\"op(add,3)\", callPredT5(set(A(\"add\"), I(3)), (*WamState).PredOp2), false},
+		{\"op(div,1)\", callPredT5(set(A(\"div\"), I(1)), (*WamState).PredOp2), false},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf(\"%s: got %v want %v\", c.name, c.got, c.want)
+		}
+	}
+}
+").


### PR DESCRIPTION
## Summary

Ports the shared `wam_clause_chain` front-end (lowering type **T5** in `docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md`) to the **Go** lowered emitter, following the Scala (#2901) and Rust (#2907) implementations. The shared front-end is reused unchanged — this is purely a Go back-end + gate + test.

A multi-clause predicate whose clauses discriminate on a **distinct first-argument constant** now lowers to a bound-checked `if`-cascade over **all** clauses, instead of `multi_clause_1` (clause 1 inline, clauses 2+ via the interpreter fallback). Non-first clauses become fast-path too when the first argument is bound; an unbound first argument returns `false` and defers to the entry wrapper's interpreter fallback (which enumerates) — sound because the chain is only deterministic when A1 is bound.

## Changes

- **`wam_go_lowered_emitter.pl`**
  - Import `clause_chain/2`.
  - `go_clause_chain_lowerable/2`: `clause_chain` succeeds **and** every clause remainder is a supported deterministic body.
  - Gate it ahead of the deterministic / multi-clause branch in `wam_go_lowerable` (`Reason = clause_chain`).
  - `emit_clause_chain_go/5` + `emit_go_guards/1`: emit `t5a1 := vm.deref(vm.Regs[0])`, return false on an unbound first arg, then a `valueEquals` `if`-cascade whose clause bodies self-terminate via `proceed`.
  - Non-T5 output paths are untouched (byte-identical).

- **`tests/test_wam_go_lowered_t5.pl`** — gated exec test:
  - `color/1` (fact chain), `sz/2` (head-match remainder), `op/2` (`is/2` rule chain) all gate as `clause_chain`.
  - Asserts `lowered.go` contains the T5 dispatch, then builds and runs the lowered module against 14 ground queries exercising every clause incl. the non-first ones (green/blue, medium/large, mul/neg) plus no-match cases.

## Note on the dropped `lib.go`

The exec test drops the older native clause-parallel `lib.go` from the build. That path is **independently broken** for these predicate shapes — it emits `arg2 = (...)` against an undeclared variable for rule clauses, and an unused `ctx` for arg-less fact predicates. This is a pre-existing `go_target` native-codegen bug, **unrelated to WAM lowering**; the T5 deliverable lives entirely in `lowered.go`, which builds and runs cleanly. (Mirrors how the Rust/Scala T5 tests target their lowered functions.)

## Verification

- New `test_wam_go_lowered_t5`: gate + 14-case exec parity pass (`go test` green).
- No regression: `test_wam_go_lowered_phase1/2/3`, `test_wam_go_generator`, `test_wam_go_negation_cut` all pass.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_