### PR TITLE
LLVM WAM: path_join/3 (M133) -- smart path concat

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3708,6 +3708,7 @@ entry:
     i32 159, label %builtin_process_max_rss
     i32 160, label %builtin_process_user_time
     i32 161, label %builtin_process_system_time
+    i32 162, label %builtin_path_join
   ]
 
 builtin_is:
@@ -7180,6 +7181,105 @@ pst.read:
   %pst.raw1 = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %pst.uok = call i1 @wam_unify_value(%WamState* %vm, %Value %pst.raw1, %Value %pst.v)
   ret i1 %pst.uok
+
+builtin_path_join:
+  ; M133: path_join(+Base, +Rel, -Full) -- joins Base and Rel into
+  ; Full, inserting exactly one ''/'' between them (skipping the
+  ; insertion if Base already ends with one). If Rel is absolute
+  ; (first char is ''/''), Full = Rel and Base is ignored -- matches
+  ; the standard ''absolute path overrides'' semantics of os.path.join,
+  ; Path/, and pathjoin in major languages. Empty-Base / empty-Rel
+  ; fast paths skip the slash logic.
+  %pj.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %pj.t1 = call i32 @value_tag(%Value %pj.a1)
+  %pj.is_atom1 = icmp eq i32 %pj.t1, 0
+  br i1 %pj.is_atom1, label %pj.check2, label %pj.fail
+pj.fail:
+  ret i1 false
+pj.check2:
+  %pj.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %pj.t2 = call i32 @value_tag(%Value %pj.a2)
+  %pj.is_atom2 = icmp eq i32 %pj.t2, 0
+  br i1 %pj.is_atom2, label %pj.have_args, label %pj.fail
+pj.have_args:
+  %pj.b_aid = call i64 @value_payload(%Value %pj.a1)
+  %pj.b = call i8* @wam_atom_to_string(i64 %pj.b_aid)
+  %pj.b_null = icmp eq i8* %pj.b, null
+  br i1 %pj.b_null, label %pj.fail, label %pj.have_b
+pj.have_b:
+  %pj.r_aid = call i64 @value_payload(%Value %pj.a2)
+  %pj.r = call i8* @wam_atom_to_string(i64 %pj.r_aid)
+  %pj.r_null = icmp eq i8* %pj.r, null
+  br i1 %pj.r_null, label %pj.fail, label %pj.measure
+pj.measure:
+  %pj.blen = call i64 @strlen(i8* %pj.b)
+  %pj.rlen = call i64 @strlen(i8* %pj.r)
+  ; If Rel starts with ''/'', it''s absolute -- return Rel verbatim.
+  %pj.r_has = icmp sgt i64 %pj.rlen, 0
+  br i1 %pj.r_has, label %pj.check_abs, label %pj.use_base
+pj.check_abs:
+  %pj.r0 = load i8, i8* %pj.r
+  %pj.is_abs = icmp eq i8 %pj.r0, 47
+  br i1 %pj.is_abs, label %pj.use_rel, label %pj.check_base
+pj.use_rel:
+  ; Full = Rel.
+  call void @wam_arena_ensure()
+  %pj.rel_buflen = add i64 %pj.rlen, 1
+  %pj.rel_buf = call i8* @wam_arena_alloc(i64 %pj.rel_buflen)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %pj.rel_buf, i8* %pj.r, i64 %pj.rlen, i1 false)
+  %pj.rel_term = getelementptr i8, i8* %pj.rel_buf, i64 %pj.rlen
+  store i8 0, i8* %pj.rel_term
+  %pj.rel_aid = call i64 @wam_intern_atom(i8* %pj.rel_buf, i64 %pj.rlen)
+  br label %pj.unify
+pj.use_base:
+  ; Rel is empty -> Full = Base.
+  call void @wam_arena_ensure()
+  %pj.base_buflen = add i64 %pj.blen, 1
+  %pj.base_buf = call i8* @wam_arena_alloc(i64 %pj.base_buflen)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %pj.base_buf, i8* %pj.b, i64 %pj.blen, i1 false)
+  %pj.base_term = getelementptr i8, i8* %pj.base_buf, i64 %pj.blen
+  store i8 0, i8* %pj.base_term
+  %pj.base_aid = call i64 @wam_intern_atom(i8* %pj.base_buf, i64 %pj.blen)
+  br label %pj.unify
+pj.check_base:
+  ; Both non-empty; decide whether to insert ''/'' based on whether
+  ; Base already ends with one. Base of length 0 -> just use Rel.
+  %pj.b_has = icmp sgt i64 %pj.blen, 0
+  br i1 %pj.b_has, label %pj.measure_slash, label %pj.use_rel
+pj.measure_slash:
+  %pj.last_idx = sub i64 %pj.blen, 1
+  %pj.last_ptr = getelementptr i8, i8* %pj.b, i64 %pj.last_idx
+  %pj.last_c = load i8, i8* %pj.last_ptr
+  %pj.has_slash = icmp eq i8 %pj.last_c, 47
+  %pj.sep_len = select i1 %pj.has_slash, i64 0, i64 1
+  ; total = blen + sep_len + rlen
+  %pj.t1_tmp = add i64 %pj.blen, %pj.sep_len
+  %pj.total = add i64 %pj.t1_tmp, %pj.rlen
+  call void @wam_arena_ensure()
+  %pj.full_buflen = add i64 %pj.total, 1
+  %pj.full_buf = call i8* @wam_arena_alloc(i64 %pj.full_buflen)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %pj.full_buf, i8* %pj.b, i64 %pj.blen, i1 false)
+  ; Insert ''/'' if needed.
+  br i1 %pj.has_slash, label %pj.copy_rel, label %pj.insert_slash
+pj.insert_slash:
+  %pj.slash_pos = getelementptr i8, i8* %pj.full_buf, i64 %pj.blen
+  store i8 47, i8* %pj.slash_pos
+  br label %pj.copy_rel
+pj.copy_rel:
+  %pj.rel_off = add i64 %pj.blen, %pj.sep_len
+  %pj.rel_dst = getelementptr i8, i8* %pj.full_buf, i64 %pj.rel_off
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %pj.rel_dst, i8* %pj.r, i64 %pj.rlen, i1 false)
+  %pj.full_term = getelementptr i8, i8* %pj.full_buf, i64 %pj.total
+  store i8 0, i8* %pj.full_term
+  %pj.full_aid = call i64 @wam_intern_atom(i8* %pj.full_buf, i64 %pj.total)
+  br label %pj.unify
+pj.unify:
+  %pj.final_aid = phi i64 [ %pj.rel_aid, %pj.use_rel ], [ %pj.base_aid, %pj.use_base ], [ %pj.full_aid, %pj.copy_rel ]
+  %pj.v0 = insertvalue %Value undef, i32 0, 0
+  %pj.v = insertvalue %Value %pj.v0, i64 %pj.final_aid, 1
+  %pj.raw3 = call %Value @wam_get_reg(%WamState* %vm, i32 2)
+  %pj.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %pj.raw3, %Value %pj.v)
+  ret i1 %pj.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -14495,6 +14595,7 @@ builtin_op_to_id('strerror/2', 158).          % libc strerror(errno) as atom.
 builtin_op_to_id('process_max_rss/1', 159).   % getrusage ru_maxrss (KB on Linux).
 builtin_op_to_id('process_user_time/1', 160). % getrusage ru_utime as Float seconds.
 builtin_op_to_id('process_system_time/1', 161). % getrusage ru_stime as Float seconds.
+builtin_op_to_id('path_join/3', 162).         % join paths with '/' separator (absolute Rel wins).
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2262,6 +2262,7 @@ is_builtin_pred(strerror, 2).           % strerror(+Errno, -Message).
 is_builtin_pred(process_max_rss, 1).    % process_max_rss(-KB) -- getrusage ru_maxrss.
 is_builtin_pred(process_user_time, 1).  % process_user_time(-Seconds) -- ru_utime.
 is_builtin_pred(process_system_time, 1).% process_system_time(-Seconds) -- ru_stime.
+is_builtin_pred(path_join, 3).          % path_join(+Base, +Rel, -Full).
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -3387,6 +3387,52 @@ test_max_rss_monotonic(_, R) :-
     process_max_rss(K1),
     ( K1 >= K0 -> R is 1 ; R is 0 ).   % 1
 
+% M133: path_join/3 -- join two paths with single '/' separator.
+
+:- dynamic test_pj_simple/2.
+test_pj_simple(_, R) :-
+    path_join('/usr/bin', swipl, F),
+    ( F == '/usr/bin/swipl' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_pj_trailing_slash/2.
+test_pj_trailing_slash(_, R) :-
+    % Base already has trailing slash -> don''t double up.
+    path_join('/usr/bin/', swipl, F),
+    ( F == '/usr/bin/swipl' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_pj_absolute_rel/2.
+test_pj_absolute_rel(_, R) :-
+    % Absolute Rel overrides Base entirely.
+    path_join('/usr/bin', '/etc/hosts', F),
+    ( F == '/etc/hosts' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_pj_empty_base/2.
+test_pj_empty_base(_, R) :-
+    % Empty Base + non-empty Rel: with non-absolute Rel, we keep
+    % the Rel verbatim (no leading '/').
+    path_join('', foo, F),
+    ( F == foo -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_pj_empty_rel/2.
+test_pj_empty_rel(_, R) :-
+    % Empty Rel: Full = Base.
+    path_join('/tmp', '', F),
+    ( F == '/tmp' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_pj_nested/2.
+test_pj_nested(_, R) :-
+    % Building deeper paths via repeated calls.
+    path_join('/var', log, A),
+    path_join(A, 'syslog', F),
+    ( F == '/var/log/syslog' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_pj_bad_args/2.
+test_pj_bad_args(_, R) :-
+    ( path_join(42, foo, _) -> R is 0
+    ; path_join('/tmp', 99, _) -> R is 0
+    ; R is 1
+    ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -6527,6 +6573,21 @@ test_all :-
                    test_user_time_monotonic, 0, 1),
        run_test_r0('max_rss non-decreasing -> 1',
                    test_max_rss_monotonic, 0, 1),
+       format('--- M133 path_join/3 ---~n'),
+       run_test_r0('path_join /usr/bin + swipl -> 1',
+                   test_pj_simple, 0, 1),
+       run_test_r0('path_join /usr/bin/ + swipl (no double slash) -> 1',
+                   test_pj_trailing_slash, 0, 1),
+       run_test_r0('path_join /usr/bin + /etc/hosts -> Rel wins -> 1',
+                   test_pj_absolute_rel, 0, 1),
+       run_test_r0('path_join '''' + foo -> foo -> 1',
+                   test_pj_empty_base, 0, 1),
+       run_test_r0('path_join /tmp + '''' -> /tmp -> 1',
+                   test_pj_empty_rel, 0, 1),
+       run_test_r0('path_join nested chain -> 1',
+                   test_pj_nested, 0, 1),
+       run_test_r0('path_join with non-atom args fails -> 1',
+                   test_pj_bad_args, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds `path_join(+Base, +Rel, -Full)` as op id 162. Smart path concat that:
- Inserts exactly one `/` between `Base` and `Rel`
- Skips the insertion if `Base` already ends with `/` (no double slashes)
- Returns `Rel` verbatim if it's absolute (first char is `/`)

Matches the semantics of `os.path.join` (Python), `filepath.Join` (Go), `PathBuf::join` (Rust), and `Path./` (Scala) across mainstream languages.

## Examples

| Base | Rel | Full |
|---|---|---|
| `/usr/bin` | `swipl` | `/usr/bin/swipl` |
| `/usr/bin/` | `swipl` | `/usr/bin/swipl` (no double slash) |
| `/usr/bin` | `/etc/hosts` | `/etc/hosts` (abs Rel wins) |
| `''` | `foo` | `foo` |
| `/tmp` | `''` | `/tmp` |

## Algorithm

1. Both args type-guarded as Atom.
2. Get path strings and lengths via `strlen`.
3. Empty Rel → `Full = Base` (verbatim copy).
4. Rel starts with `/` → `Full = Rel` (absolute override).
5. Empty Base → `Full = Rel`.
6. Otherwise: load last byte of Base, decide `sep_len = 0` or `1`, allocate `total = blen + sep_len + rlen + 1`, memcpy Base, optionally store `'/'`, memcpy Rel, null-terminate, intern atom.

Three result paths (`use_rel`, `use_base`, `copy_rel`) converge at `pj.unify` via a 3-way phi node on the atom_id. Pure scan + arena alloc, no libc beyond `strlen` / `memcpy` / `wam_intern_atom`.

Prefix `pj.` (no collisions).

## Fills a real gap

We already had `file_base_name/2`, `file_directory_name/2`, `file_name_extension/3`, `is_absolute_file_name/1`, `same_file/2`, `realpath/2` (M118–M122). `path_join/3` was the missing piece for building paths up programmatically.

## Three-site registration

- Dispatch switch entry 162
- `builtin_op_to_id('path_join/3', 162).`
- `is_builtin_pred(path_join, 3).`

## Tests

7 execution tests, all PASS:

| Test | What |
|---|---|
| `pj_simple` | `/usr/bin + swipl` → `/usr/bin/swipl` |
| `pj_trailing_slash` | `/usr/bin/ + swipl` → no double slash |
| `pj_absolute_rel` | Absolute Rel overrides Base |
| `pj_empty_base` | `'' + foo` → `foo` |
| `pj_empty_rel` | `/tmp + ''` → `/tmp` |
| `pj_nested` | Chained: `path_join('/var', log, A), path_join(A, 'syslog', F)` → `/var/log/syslog` |
| `pj_bad_args` | Non-atom args fail type guards |

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — dispatch entry, `builtin_path_join` body, op-id table.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 7 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke) ✓
- [x] All 7 M133 tests PASS individually ✓
- [ ] Full suite regression check

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_