### PR TITLE
LLVM WAM: system_to_atom/2 (M134) -- popen + fread + pclose

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1580,6 +1580,9 @@ declare i64 @write(i32, i8*, i64)
 declare i32* @__errno_location()
 declare i8* @strerror(i32)
 declare i32 @getrusage(i32, i8*)
+declare i8* @popen(i8*, i8*)
+declare i32 @pclose(i8*)
+declare i64 @fread(i8*, i64, i64, i8*)
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3709,6 +3712,7 @@ entry:
     i32 160, label %builtin_process_user_time
     i32 161, label %builtin_process_system_time
     i32 162, label %builtin_path_join
+    i32 163, label %builtin_system_to_atom
   ]
 
 builtin_is:
@@ -7280,6 +7284,73 @@ pj.unify:
   %pj.raw3 = call %Value @wam_get_reg(%WamState* %vm, i32 2)
   %pj.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %pj.raw3, %Value %pj.v)
   ret i1 %pj.ok
+
+builtin_system_to_atom:
+  ; M134: system_to_atom(+Cmd, -Output) -- runs Cmd through a
+  ; shell via libc popen(cmd, "r"), captures stdout into an atom,
+  ; then closes the pipe with pclose. Output trailing newline is
+  ; preserved verbatim (callers can sub_atom-trim if they want
+  ; chomped output).
+  ;
+  ; Buffer: 64 KB single arena allocation, read with the buffer''s
+  ; remaining length as the per-call fread limit. Output > 64 KB
+  ; causes failure (no growable buffer in the current arena).
+  ; Cmd must be Atom; non-atom or popen failure (fork/exec out
+  ; of resources) maps to Prolog fail.
+  %sta.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %sta.t1 = call i32 @value_tag(%Value %sta.a1)
+  %sta.is_atom = icmp eq i32 %sta.t1, 0
+  br i1 %sta.is_atom, label %sta.go, label %sta.fail
+sta.fail:
+  ret i1 false
+sta.go:
+  %sta.aid = call i64 @value_payload(%Value %sta.a1)
+  %sta.cmd = call i8* @wam_atom_to_string(i64 %sta.aid)
+  %sta.cmd_null = icmp eq i8* %sta.cmd, null
+  br i1 %sta.cmd_null, label %sta.fail, label %sta.open
+sta.open:
+  ; Build the "r\0" mode string on the stack.
+  %sta.mode = alloca [2 x i8]
+  %sta.mode_ptr = getelementptr [2 x i8], [2 x i8]* %sta.mode, i32 0, i32 0
+  store i8 114, i8* %sta.mode_ptr
+  %sta.mode_t = getelementptr i8, i8* %sta.mode_ptr, i64 1
+  store i8 0, i8* %sta.mode_t
+  %sta.fp = call i8* @popen(i8* %sta.cmd, i8* %sta.mode_ptr)
+  %sta.fp_null = icmp eq i8* %sta.fp, null
+  br i1 %sta.fp_null, label %sta.fail, label %sta.alloc
+sta.alloc:
+  call void @wam_arena_ensure()
+  %sta.buf = call i8* @wam_arena_alloc(i64 65537)
+  br label %sta.loop
+sta.loop:
+  %sta.off = phi i64 [ 0, %sta.alloc ], [ %sta.off_next, %sta.advance ]
+  %sta.remain = sub i64 65536, %sta.off
+  ; If buffer is full, stop reading -- 1 MB cap.
+  %sta.has_room = icmp sgt i64 %sta.remain, 0
+  br i1 %sta.has_room, label %sta.read, label %sta.overflow
+sta.read:
+  %sta.dst = getelementptr i8, i8* %sta.buf, i64 %sta.off
+  %sta.n = call i64 @fread(i8* %sta.dst, i64 1, i64 %sta.remain, i8* %sta.fp)
+  %sta.eof = icmp eq i64 %sta.n, 0
+  br i1 %sta.eof, label %sta.close, label %sta.advance
+sta.advance:
+  %sta.off_next = add i64 %sta.off, %sta.n
+  br label %sta.loop
+sta.overflow:
+  ; Output exceeded 64 KB -- pclose and fail rather than truncate
+  ; silently.
+  call i32 @pclose(i8* %sta.fp)
+  ret i1 false
+sta.close:
+  call i32 @pclose(i8* %sta.fp)
+  %sta.term = getelementptr i8, i8* %sta.buf, i64 %sta.off
+  store i8 0, i8* %sta.term
+  %sta.atom_id = call i64 @wam_intern_atom(i8* %sta.buf, i64 %sta.off)
+  %sta.v0 = insertvalue %Value undef, i32 0, 0
+  %sta.v = insertvalue %Value %sta.v0, i64 %sta.atom_id, 1
+  %sta.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
+  %sta.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %sta.raw2, %Value %sta.v)
+  ret i1 %sta.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -14596,6 +14667,7 @@ builtin_op_to_id('process_max_rss/1', 159).   % getrusage ru_maxrss (KB on Linux
 builtin_op_to_id('process_user_time/1', 160). % getrusage ru_utime as Float seconds.
 builtin_op_to_id('process_system_time/1', 161). % getrusage ru_stime as Float seconds.
 builtin_op_to_id('path_join/3', 162).         % join paths with '/' separator (absolute Rel wins).
+builtin_op_to_id('system_to_atom/2', 163).    % popen(cmd, "r") + fread + pclose -> atom.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2263,6 +2263,7 @@ is_builtin_pred(process_max_rss, 1).    % process_max_rss(-KB) -- getrusage ru_m
 is_builtin_pred(process_user_time, 1).  % process_user_time(-Seconds) -- ru_utime.
 is_builtin_pred(process_system_time, 1).% process_system_time(-Seconds) -- ru_stime.
 is_builtin_pred(path_join, 3).          % path_join(+Base, +Rel, -Full).
+is_builtin_pred(system_to_atom, 2).     % system_to_atom(+Cmd, -Output) -- capture stdout.
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -3433,6 +3433,46 @@ test_pj_bad_args(_, R) :-
     ; R is 1
     ).   % 1
 
+% M134: system_to_atom/2 -- shell stdout capture.
+
+:- dynamic test_sta_echo/2.
+test_sta_echo(_, R) :-
+    % "echo hi" produces "hi\n" -- 3 bytes.
+    system_to_atom('echo hi', O),
+    atom_length(O, L),
+    ( L =:= 3 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_sta_empty/2.
+test_sta_empty(_, R) :-
+    % "true" produces no output -> empty atom.
+    system_to_atom('true', O),
+    ( O == '' -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_sta_pwd/2.
+test_sta_pwd(_, R) :-
+    % "pwd" produces the cwd + "\n". Just check non-empty atom.
+    system_to_atom('pwd', O),
+    atom_length(O, L),
+    ( L > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_sta_multiline/2.
+test_sta_multiline(_, R) :-
+    % "seq 1 5" produces "1\n2\n3\n4\n5\n" = 10 bytes.
+    system_to_atom('seq 1 5', O),
+    atom_length(O, L),
+    ( L =:= 10 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_sta_pipe/2.
+test_sta_pipe(_, R) :-
+    % Shell pipeline: "echo hello | wc -c" -> "6\n" (5 chars + nl).
+    system_to_atom('echo hello | wc -c', O),
+    atom_length(O, L),
+    ( L > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_sta_bad_arg/2.
+test_sta_bad_arg(_, R) :-
+    ( system_to_atom(42, _) -> R is 0 ; R is 1 ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -6588,6 +6628,19 @@ test_all :-
                    test_pj_nested, 0, 1),
        run_test_r0('path_join with non-atom args fails -> 1',
                    test_pj_bad_args, 0, 1),
+       format('--- M134 system_to_atom/2 ---~n'),
+       run_test_r0('echo hi -> 3-byte atom -> 1',
+                   test_sta_echo, 0, 1),
+       run_test_r0('true -> empty atom -> 1',
+                   test_sta_empty, 0, 1),
+       run_test_r0('pwd -> non-empty atom -> 1',
+                   test_sta_pwd, 0, 1),
+       run_test_r0('seq 1 5 -> 10-byte atom -> 1',
+                   test_sta_multiline, 0, 1),
+       run_test_r0('shell pipeline captures stdout -> 1',
+                   test_sta_pipe, 0, 1),
+       run_test_r0('system_to_atom(42, _) fails -> 1',
+                   test_sta_bad_arg, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds `system_to_atom(+Cmd, -Output)` as op id 163 — runs a shell command and **captures its stdout** as an atom. The natural pair with `shell/2`, which only returns exit status.

## Algorithm

1. Type-guard `Cmd` as Atom.
2. `popen(cmd, "r")` — mode string `"r\0"` built on stack via `alloca`.
3. `arena_alloc(64 KB + 1)` for the output buffer.
4. Loop:
   - `n = fread(buf+off, 1, 65536-off, fp)`
   - `n == 0` (EOF) → close path
   - else `off += n`, continue
   - `off == 65536` (buffer full) → overflow path
5. EOF → `pclose(fp)`, null-terminate, intern as atom, unify.
6. Overflow → `pclose(fp)`, fail (no silent truncation).

Trailing newline preserved verbatim — callers can strip with `sub_atom` if they need chomped output.

## Buffer size constraint (learned the hard way)

Initial attempt used a 1 MB buffer. The test binary **segfaulted** because the arena allocator can't hand out a single 1 MB chunk in the current runtime. Reduced to 64 KB which fits in the existing arena pool.

64 KB is the documented limit for now. For larger outputs, callers can:
```prolog
shell('long_command > /tmp/out', 0),
read_file_to_atom('/tmp/out', O).
```

This roundabout is good enough until we have a growable runtime allocator.

## libc declarations

```llvm
declare i8* @popen(i8*, i8*)
declare i32 @pclose(i8*)
declare i64 @fread(i8*, i64, i64, i8*)
```

`FILE*` is treated as opaque `i8*`. Prefix `sta.` (no collisions).

## Three-site registration

- Dispatch switch entry 163
- `builtin_op_to_id('system_to_atom/2', 163).`
- `is_builtin_pred(system_to_atom, 2).`

## Tests

6 execution tests, all PASS:

| Test | Command | Expected |
|---|---|---|
| `sta_echo` | `echo hi` | 3-byte atom (`hi\n`) |
| `sta_empty` | `true` | empty atom (EOF on first fread) |
| `sta_pwd` | `pwd` | non-empty atom |
| `sta_multiline` | `seq 1 5` | 10-byte atom (`1\n2\n3\n4\n5\n`) |
| `sta_pipe` | `echo hello \| wc -c` | non-empty atom (shell pipeline works) |
| `sta_bad_arg` | non-atom Cmd | type guard fails |

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — 3 libc declarations, dispatch entry, `builtin_system_to_atom` body, op-id table.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 6 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke) ✓
- [x] All 6 M134 tests PASS individually ✓
- [ ] Full suite regression check

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_