### PR TITLE
feat(wam-fsharp): parameterise Program.fs benchmark loop on kernel_kind

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_target.pl
+++ b/src/unifyweaver/targets/wam_fsharp_target.pl
@@ -5134,6 +5134,16 @@ generate_program_fs(_Predicates, DetectedKernels, Options, Code) :-
         option(graph_dimensionality(Dimensionality), Options, 5.0)
     ;   HasBidir = false, BranchFactor = 15.0, Dimensionality = 5.0
     ),
+    %% Determine the kernel_kind for the benchmark-loop {{match}}
+    %% block in program.fs.mustache. The benchmark loop targets a
+    %% single primary kernel; if multiple kernels are detected,
+    %% the first one wins (matches the prior hardcoded behaviour
+    %% which assumed category_ancestor). Empty list -> unknown,
+    %% which triggers the {{default}} stub case.
+    (   DetectedKernels = [_-recursive_kernel(FirstKernelKind, _, _) | _]
+    ->  KernelKind = FirstKernelKind
+    ;   KernelKind = unknown
+    ),
     Dict = [
         foreign_preds = ForeignPredsStr,
         lookup_sources_expr = LookupSourcesExpr,
@@ -5141,6 +5151,7 @@ generate_program_fs(_Predicates, DetectedKernels, Options, Code) :-
         has_csr_kernel = HasCsrKernel,
         has_lmdb = HasLmdb,
         has_bidirectional = HasBidir,
+        kernel_kind = KernelKind,
         branch_factor = BranchFactor,
         dimensionality = Dimensionality,
         materialisation = Materialisation,

--- a/templates/targets/fsharp_wam/program.fs.mustache
+++ b/templates/targets/fsharp_wam/program.fs.mustache
@@ -341,9 +341,36 @@ let main argv =
     for rep = 1 to numReps do
         let querySw = Stopwatch.StartNew()
         let mutable repSolutions = 0
+{{match kernel_kind}}
+{{case category_ancestor}}
+        // category_ancestor native benchmark loop (LMDB fast path)
         for cat in seedInts do
             let hits = nativeKernel_category_ancestor lookupFn cat rootInt maxDepthCfg 1 [ cat ]
             if not (List.isEmpty hits) then repSolutions <- repSolutions + 1
+{{case bidirectional_ancestor}}
+        // bidirectional_ancestor: LMDB fast path not yet wired in this template.
+        //
+        // The bidirectional kernel takes (lookupParents, lookupChildren, cat,
+        // root, parentCost, childCost, budget) — different signature than
+        // category_ancestor. Setting up lookupChildren requires CSR cursor
+        // resolution that's currently scoped inside WamRuntime.fs's
+        // executeForeign / resolveFactLookup path. Mirroring that setup into
+        // Program.fs's benchmark scope is tracked as future work.
+        //
+        // In the meantime, the bidirectional kernel still runs correctly via
+        // the WAM dispatch path (WamRuntime.fs) when invoked through normal
+        // predicate-call infrastructure. The benchmark loop here emits zero
+        // stats so the project builds without referencing nativeKernel_*
+        // mismatched signatures.
+        for _cat in seedInts do
+            // TODO: implement bidirectional native benchmark loop with
+            // lookupParents + lookupChildren + cost configuration
+            ()
+{{default}}
+        // Unknown kernel kind: skip the native benchmark loop.
+        for _cat in seedInts do
+            ()
+{{/match}}
         querySw.Stop()
         lastQueryMs <- querySw.ElapsedMilliseconds
         totalSolutions <- totalSolutions + repSolutions

--- a/tests/core/test_wam_fsharp_bidirectional_e2e.pl
+++ b/tests/core/test_wam_fsharp_bidirectional_e2e.pl
@@ -77,14 +77,12 @@ main :-
     make_directory_path(ProjectDir),
     %% NOTE: allow_bidirectional_kernel_swap(true) is required as of the
     %% bidirectional-not-default fix. Without it, the F# WAM target
-    %% emits category_ancestor by default (see Step 5 of the safety
-    %% rationale: program.fs.mustache has a hardcoded benchmark loop
-    %% that matches category_ancestor's signature; the bidirectional
-    %% emission breaks the build until the template is parameterised).
-    %% Setting the flag opts into the bidirectional emission, which
-    %% this test specifically verifies. The dotnet build step below
-    %% is therefore SKIPPED — the build will fail until program.fs.mustache
-    %% is updated to emit kernel-specific benchmark loops.
+    %% would emit category_ancestor by default. Setting the flag opts
+    %% into the bidirectional emission, which this test specifically
+    %% verifies. program.fs.mustache is now parameterised on
+    %% kernel_kind via {{match}} so the dotnet build succeeds — the
+    %% bidirectional benchmark loop is currently a stub (TODO: full
+    %% lookupParents/lookupChildren native benchmark).
     write_wam_fsharp_project(
         [category_ancestor/4],
         [
@@ -133,26 +131,36 @@ main :-
     ;   format('  effectiveDistanceWeighted: MISSING~n'), halt(1)
     ),
 
-    %% Step 7: Build — INTENTIONALLY SKIPPED.
-    %%
-    %% templates/targets/fsharp_wam/program.fs.mustache has a
-    %% hardcoded call to nativeKernel_category_ancestor with the
-    %% unidirectional 6-argument signature. When the kernel is
-    %% upgraded to bidirectional (this test's whole point), Program.fs
-    %% still emits the hardcoded category_ancestor call which doesn't
-    %% match the upgraded kernel's signature, and dotnet build fails
-    %% with FS0039.
-    %%
-    %% Fixing this requires parameterising program.fs.mustache to
-    %% emit kernel-specific benchmark loops. The template-system
-    %% supports conditional rendering (see TEMPLATE_ENGINE.md and
-    %% WAM_TEMPLATE_MATCH_CASE_TESTING.md); the fix is tracked
-    %% future work but is independent of the strategy-selector
-    %% pipeline this test covers.
-    format('Step 5: Build SKIPPED — known pre-existing program.fs.mustache bug~n'),
-    format('       (track: parameterise template for kernel-specific benchmark loop)~n'),
+    %% Step 7: Verify Program.fs has the parameterised benchmark loop
+    %% — it should reference the bidirectional stub (zero-stat loop)
+    %% and must NOT reference nativeKernel_category_ancestor (which
+    %% would mean the {{match}} block fell back to category_ancestor
+    %% or didn't render).
+    (   sub_string(ProgCode, _, _, _, "bidirectional_ancestor")
+    ->  format('  Program.fs references bidirectional_ancestor (parameterised loop): OK~n')
+    ;   format('  Program.fs missing bidirectional_ancestor reference~n'), halt(1)
+    ),
+    (   sub_string(ProgCode, _, _, _, "nativeKernel_category_ancestor")
+    ->  format('  Program.fs still references nativeKernel_category_ancestor — wrong branch!~n'), halt(1)
+    ;   format('  Program.fs does NOT reference nativeKernel_category_ancestor (correct): OK~n')
+    ),
+
+    %% Step 8: Run dotnet build — should now succeed thanks to the
+    %% parameterised {{match kernel_kind}} block in program.fs.mustache.
+    %% The bidirectional benchmark loop is a stub (zero-stat) until a
+    %% follow-up PR wires lookupParents/lookupChildren into the
+    %% benchmark scope; the build verification here proves the
+    %% kernel-kind parameterisation produced compilable F#.
+    format('Step 5: Running dotnet build (should succeed with parameterised template)...~n'),
+    run_cmd(dotnet,
+            ['build', '--nologo', '-v', 'minimal', '-c', 'Release'],
+            ProjectDir, BuildExit, BuildOut),
+    (   BuildExit == 0
+    ->  format('  dotnet build succeeded — bidirectional kernel emission is buildable: OK~n')
+    ;   format('  dotnet build FAILED:~n~w~n', [BuildOut]), halt(1)
+    ),
 
     format('~n=== All checks passed ===~n'),
     format('Bidirectional kernel E2E: kernel detection, template rendering,~n'),
-    format('calibration, A* pruning, weighted metric — all generated valid F#.~n'),
-    format('Build verification skipped pending program.fs.mustache parameterisation.~n').
+    format('calibration, A* pruning, weighted metric, parameterised Program.fs,~n'),
+    format('and dotnet build — all verified.~n').


### PR DESCRIPTION
  ## Summary
  - Replace the hardcoded `nativeKernel_category_ancestor` call in `program.fs.mustache` with `{{match
  kernel_kind}}…{{/match}}` dispatch
  - `generate_program_fs/4` now plumbs the first detected kernel's kind into the template context
  - `test_wam_fsharp_bidirectional_e2e` re-enables dotnet build verification (was previously skipped pending this fix)

  This fixes the pre-existing FS0039 `'nativeKernel_category_ancestor' is not defined` build error that surfaced whenever the strategy selector upgraded `category_ancestor` to `bidirectional_ancestor` — Program.fs would still emit the unidirectional 6-arg signature against the bidirectional kernel.

  The bidirectional benchmark loop is currently a zero-stat stub with a TODO; correctness still flows through the standard WAM dispatch path. A follow-up can wire `lookupParents`/`lookupChildren` + cost configuration into Program.fs for true native-loop bidirectional benchmarks.

  ## Test plan
  - [x] All 168 RES + recurrence_inputs unit tests pass
  - [x] `test_wam_fsharp_strategy_autoselect_e2e` — safe-default path → `{{case category_ancestor}}` → dotnet build
  succeeds
  - [x] `test_wam_fsharp_bidirectional_e2e` — opt-in upgrade → `{{case bidirectional_ancestor}}` → dotnet build succeeds