### PR TITLE
LLVM WAM: atom_to_system/2 (M135) -- popen + fwrite + pclose

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1583,6 +1583,7 @@ declare i32 @getrusage(i32, i8*)
 declare i8* @popen(i8*, i8*)
 declare i32 @pclose(i8*)
 declare i64 @fread(i8*, i64, i64, i8*)
+declare i64 @fwrite(i8*, i64, i64, i8*)
 declare i32 @usleep(i32)
 declare i32 @gethostname(i8*, i64)
 declare double @drand48()
@@ -3713,6 +3714,7 @@ entry:
     i32 161, label %builtin_process_system_time
     i32 162, label %builtin_path_join
     i32 163, label %builtin_system_to_atom
+    i32 164, label %builtin_atom_to_system
   ]
 
 builtin_is:
@@ -7351,6 +7353,70 @@ sta.close:
   %sta.raw2 = call %Value @wam_get_reg(%WamState* %vm, i32 1)
   %sta.ok = call i1 @wam_unify_value(%WamState* %vm, %Value %sta.raw2, %Value %sta.v)
   ret i1 %sta.ok
+
+builtin_atom_to_system:
+  ; M135: atom_to_system(+Cmd, +Content) -- input-side companion
+  ; to M134 system_to_atom/2. Opens a pipe to Cmd via popen(cmd,
+  ; "w") and writes Content''s bytes as the command''s stdin, then
+  ; pclose to flush + wait. Succeeds iff pclose returns 0 (subprocess
+  ; exited cleanly with status 0). Both args must be Atom.
+  ;
+  ; Useful for piping data through filters. Short writes are
+  ; retried (fwrite normally handles this internally but we
+  ; double-check by tracking offset).
+  %ats.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
+  %ats.t1 = call i32 @value_tag(%Value %ats.a1)
+  %ats.is_atom1 = icmp eq i32 %ats.t1, 0
+  br i1 %ats.is_atom1, label %ats.check2, label %ats.fail
+ats.fail:
+  ret i1 false
+ats.check2:
+  %ats.a2 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %ats.t2 = call i32 @value_tag(%Value %ats.a2)
+  %ats.is_atom2 = icmp eq i32 %ats.t2, 0
+  br i1 %ats.is_atom2, label %ats.have_args, label %ats.fail
+ats.have_args:
+  %ats.cmd_aid = call i64 @value_payload(%Value %ats.a1)
+  %ats.cmd = call i8* @wam_atom_to_string(i64 %ats.cmd_aid)
+  %ats.cmd_null = icmp eq i8* %ats.cmd, null
+  br i1 %ats.cmd_null, label %ats.fail, label %ats.have_cmd
+ats.have_cmd:
+  %ats.body_aid = call i64 @value_payload(%Value %ats.a2)
+  %ats.body = call i8* @wam_atom_to_string(i64 %ats.body_aid)
+  %ats.body_null = icmp eq i8* %ats.body, null
+  br i1 %ats.body_null, label %ats.fail, label %ats.open
+ats.open:
+  ; "w\0" mode string on stack.
+  %ats.mode = alloca [2 x i8]
+  %ats.mode_ptr = getelementptr [2 x i8], [2 x i8]* %ats.mode, i32 0, i32 0
+  store i8 119, i8* %ats.mode_ptr
+  %ats.mode_t = getelementptr i8, i8* %ats.mode_ptr, i64 1
+  store i8 0, i8* %ats.mode_t
+  %ats.fp = call i8* @popen(i8* %ats.cmd, i8* %ats.mode_ptr)
+  %ats.fp_null = icmp eq i8* %ats.fp, null
+  br i1 %ats.fp_null, label %ats.fail, label %ats.size
+ats.size:
+  %ats.len = call i64 @strlen(i8* %ats.body)
+  %ats.empty = icmp eq i64 %ats.len, 0
+  br i1 %ats.empty, label %ats.close, label %ats.loop
+ats.loop:
+  %ats.off = phi i64 [ 0, %ats.size ], [ %ats.off_next, %ats.advance ]
+  %ats.remain = sub i64 %ats.len, %ats.off
+  %ats.src = getelementptr i8, i8* %ats.body, i64 %ats.off
+  %ats.n = call i64 @fwrite(i8* %ats.src, i64 1, i64 %ats.remain, i8* %ats.fp)
+  %ats.n_zero = icmp eq i64 %ats.n, 0
+  br i1 %ats.n_zero, label %ats.close_fail, label %ats.advance
+ats.advance:
+  %ats.off_next = add i64 %ats.off, %ats.n
+  %ats.done = icmp eq i64 %ats.off_next, %ats.len
+  br i1 %ats.done, label %ats.close, label %ats.loop
+ats.close_fail:
+  call i32 @pclose(i8* %ats.fp)
+  ret i1 false
+ats.close:
+  %ats.ret = call i32 @pclose(i8* %ats.fp)
+  %ats.ok = icmp eq i32 %ats.ret, 0
+  ret i1 %ats.ok
 
 builtin_nl:
   ; nl/0: print newline via printf.
@@ -14668,6 +14734,7 @@ builtin_op_to_id('process_user_time/1', 160). % getrusage ru_utime as Float seco
 builtin_op_to_id('process_system_time/1', 161). % getrusage ru_stime as Float seconds.
 builtin_op_to_id('path_join/3', 162).         % join paths with '/' separator (absolute Rel wins).
 builtin_op_to_id('system_to_atom/2', 163).    % popen(cmd, "r") + fread + pclose -> atom.
+builtin_op_to_id('atom_to_system/2', 164).    % popen(cmd, "w") + fwrite + pclose, succeed iff status 0.
 % Catch-all for builtin names with no dedicated dispatch entry. Must
 % be a value that no real builtin uses AND that the switch in
 % @execute_builtin has no case for, so dispatch falls through to the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -2264,6 +2264,7 @@ is_builtin_pred(process_user_time, 1).  % process_user_time(-Seconds) -- ru_utim
 is_builtin_pred(process_system_time, 1).% process_system_time(-Seconds) -- ru_stime.
 is_builtin_pred(path_join, 3).          % path_join(+Base, +Rel, -Full).
 is_builtin_pred(system_to_atom, 2).     % system_to_atom(+Cmd, -Output) -- capture stdout.
+is_builtin_pred(atom_to_system, 2).     % atom_to_system(+Cmd, +Content) -- write to stdin.
 is_builtin_pred(sleep, 1).              % sleep(+Seconds).
 is_builtin_pred(gethostname, 1).        % gethostname(-Name).
 is_builtin_pred(cpu_time, 1).           % cpu_time(-Seconds).

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -3473,6 +3473,48 @@ test_sta_pipe(_, R) :-
 test_sta_bad_arg(_, R) :-
     ( system_to_atom(42, _) -> R is 0 ; R is 1 ).   % 1
 
+% M135: atom_to_system/2 -- pipe atom to a command via popen('w').
+
+:- dynamic test_ats_basic/2.
+test_ats_basic(_, R) :-
+    % Pipe 'hello' to wc -c via stdin, file gets just the length.
+    shell('rm -f /tmp/uw_m135_out', _),
+    atom_to_system('cat > /tmp/uw_m135_out', 'hello'),
+    size_file('/tmp/uw_m135_out', Sz),
+    shell('rm -f /tmp/uw_m135_out', _),
+    ( Sz =:= 5 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_ats_empty/2.
+test_ats_empty(_, R) :-
+    % Empty content -> 0-byte file (loop skipped via empty fast path).
+    shell('rm -f /tmp/uw_m135_empty', _),
+    atom_to_system('cat > /tmp/uw_m135_empty', ''),
+    size_file('/tmp/uw_m135_empty', Sz),
+    shell('rm -f /tmp/uw_m135_empty', _),
+    ( Sz =:= 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_ats_pipeline/2.
+test_ats_pipeline(_, R) :-
+    % Pipeline: write a single-line atom, count its bytes via wc -c.
+    shell('rm -f /tmp/uw_m135_count', _),
+    atom_to_system('wc -c > /tmp/uw_m135_count', 'hello'),
+    size_file('/tmp/uw_m135_count', Sz),
+    shell('rm -f /tmp/uw_m135_count', _),
+    ( Sz > 0 -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_ats_failing_cmd/2.
+test_ats_failing_cmd(_, R) :-
+    % Command that exits non-zero -> pclose returns non-zero ->
+    % atom_to_system fails. "false" always exits 1.
+    ( atom_to_system('false', anything) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_ats_bad_args/2.
+test_ats_bad_args(_, R) :-
+    ( atom_to_system(42, abc) -> R is 0
+    ; atom_to_system('cat > /dev/null', 99) -> R is 0
+    ; R is 1
+    ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -6641,6 +6683,17 @@ test_all :-
                    test_sta_pipe, 0, 1),
        run_test_r0('system_to_atom(42, _) fails -> 1',
                    test_sta_bad_arg, 0, 1),
+       format('--- M135 atom_to_system/2 ---~n'),
+       run_test_r0('cat <- 5 bytes -> size 5 -> 1',
+                   test_ats_basic, 0, 1),
+       run_test_r0('cat <- empty -> size 0 -> 1',
+                   test_ats_empty, 0, 1),
+       run_test_r0('sort -u | wc -l pipeline -> 1',
+                   test_ats_pipeline, 0, 1),
+       run_test_r0('false command fails -> 1',
+                   test_ats_failing_cmd, 0, 1),
+       run_test_r0('atom_to_system with non-atom args fails -> 1',
+                   test_ats_bad_args, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Adds `atom_to_system(+Cmd, +Content)` as op id 164 — the **input-side companion** to M134 `system_to_atom/2`. Opens a pipe to `Cmd` via `popen(cmd, "w")` and writes `Content` as the command's stdin, then closes via `pclose`. Succeeds iff pclose returns 0 (subprocess exited cleanly).

## Useful for piping data through filters

```prolog
atom_to_system('sort -u > /tmp/uniq.txt', SomeAtom).
atom_to_system('logger -t myapp', LogLine).
atom_to_system('wc -c > /tmp/count', Content).
```

## Algorithm

1. Both args type-guarded as Atom.
2. `popen(cmd, "w")` — mode string `"w\0"` built on stack.
3. `strlen(Content)`; empty-content fast path skips the loop.
4. Loop:
   - `n = fwrite(content+offset, 1, len-offset, fp)`
   - `n == 0` → `pclose(fp)`, fail (write error)
   - else `offset += n`; if `offset == len` → close path
5. Close: `pclose(fp)` returns subprocess exit status; succeed iff 0.

Short writes are retried by tracking offset (`fwrite` normally handles this internally, but the offset loop is also short-write-safe).

## libc

```llvm
declare i64 @fwrite(i8*, i64, i64, i8*)
```

`popen` / `pclose` already imported by M134. Prefix `ats.` (no collisions).

## Three-site registration

- Dispatch switch entry 164
- `builtin_op_to_id('atom_to_system/2', 164).`
- `is_builtin_pred(atom_to_system, 2).`

## Tests

5 execution tests, all PASS:

| Test | What |
|---|---|
| `ats_basic` | `atom_to_system('cat > /tmp/...', 'hello')` → 5-byte file |
| `ats_empty` | Empty Content → 0-byte file (empty-content fast path) |
| `ats_pipeline` | `atom_to_system('wc -c > /tmp/...', 'hello')` → non-empty output |
| `ats_failing_cmd` | `atom_to_system('false', _)` → pclose != 0 → fail |
| `ats_bad_args` | Non-atom args fail type guards |

## Files

- `src/unifyweaver/targets/wam_llvm_target.pl` — `fwrite` declaration, dispatch entry, `builtin_atom_to_system` body, op-id table.
- `src/unifyweaver/targets/wam_target.pl` — `is_builtin_pred`.
- `tests/core/test_wam_llvm_builtin_execution.pl` — 5 tests + `test_all` invocations.

## Test plan

- [x] Module loads (smoke) ✓
- [x] All 5 M135 tests PASS individually ✓
- [ ] Full suite regression check

https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim

---
_Generated by [Claude Code](https://claude.ai/code/session_012T8pkULrkmsMf91SSCvzim)_