### PR TITLE
Lower distinct-first-arg clause-parallel Go predicates to a T5 switch

### DIFF
--- a/src/unifyweaver/targets/go_target.pl
+++ b/src/unifyweaver/targets/go_target.pl
@@ -6199,6 +6199,21 @@ go_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
 go_render_classified_last(_, _, [], []).
 
 %% go_output_goal_last(+Goal, +VarMap, -Lines)
+go_output_goal_last(_Module:Goal, VarMap, Lines) :-
+    !, go_output_goal_last(Goal, VarMap, Lines).
+% A final goal that computes the output variable directly (R is Expr / R =
+% Expr) must `return Expr`, not `argN = Expr; return argN`: when the output
+% head var is pre-registered in the VarMap (build_head_varmap names it after
+% its head position, e.g. arg2), go_output_goal would emit an `=` assignment
+% to a name that was never declared as a Go local. Mirror the /4 variant.
+go_output_goal_last(is(Var, Expr), VarMap, [Line]) :-
+    var(Var), !,
+    go_expr(Expr, VarMap, GoExpr),
+    format(string(Line), '\t\treturn ~w', [GoExpr]).
+go_output_goal_last(=(Var, Expr), VarMap, [Line]) :-
+    var(Var), !,
+    go_expr(Expr, VarMap, GoExpr),
+    format(string(Line), '\t\treturn ~w', [GoExpr]).
 go_output_goal_last(Goal, VarMap, [Line]) :-
     go_output_goal(Goal, VarMap, AssignLine, VarMapOut),
     (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMapOut, OutName)
@@ -21332,10 +21347,33 @@ go_expr_wrapper(VarMap, Arg, GoExpr) :- go_expr(Arg, VarMap, GoExpr).
 % ============================================================================
 
 %% compile_clause_parallel_to_go(+PredSpec, +Clauses, -Code)
-%  Compile an order-independent multi-clause predicate into concurrent
-%  clause exploration via goroutines and a results channel.
-%  Each clause runs in its own goroutine; results are collected on a
-%  buffered channel. The caller receives all solutions.
+%  Compile an order-independent multi-clause predicate.
+%
+%  T5 fast path (first): when the clauses discriminate on a DISTINCT
+%  first-argument constant, at most one clause can ever match, so the
+%  clause-parallel goroutine fan-out is pure overhead — emit a deterministic
+%  first-argument `switch` instead. This is the native-path analogue of the
+%  WAM-lowered T5 dispatch (wam_clause_chain) and also avoids the unused-`ctx`
+%  / undeclared-output-variable codegen the goroutine path produced for these
+%  shapes.
+%
+%  Decline (second): if NO clause compiles natively (e.g. arity-1 boolean
+%  facts, which the value-returning native model — zero input params,
+%  last-arg-as-output — cannot represent), fail so the caller routes the
+%  predicate to WAM lowering instead of emitting an all-empty goroutine body
+%  with an unused `ctx`.
+%
+%  Default (third): concurrent clause exploration via goroutines and a
+%  results channel. Each clause runs in its own goroutine; results are
+%  collected on a buffered channel; the caller receives the first solution.
+compile_clause_parallel_to_go(PredSpec, Clauses, Code) :-
+    go_native_t5_dispatch(PredSpec, Clauses, Code),
+    !.
+compile_clause_parallel_to_go(PredSpec, Clauses, _Code) :-
+    \+ ( member(Head-Body, Clauses),
+         native_go_clause(PredSpec, Head, Body, _, _) ),
+    !,
+    fail.
 compile_clause_parallel_to_go(PredSpec, Clauses, Code) :-
     PredSpec = Pred/Arity,
     atom_string(Pred, PredStr),
@@ -21373,6 +21411,52 @@ compile_clause_parallel_to_go(PredSpec, Clauses, Code) :-
 \t\treturn r
 \t}
 \tpanic("No matching clause for ~w")', [NumClauses, CaptureComment, NumClauses, NumClauses, BranchesBlock, PredStr]).
+
+%% go_native_t5_dispatch(+PredSpec, +Clauses, -Code) is semidet.
+%  Emit a deterministic first-argument `switch` when every clause
+%  discriminates on a distinct first-argument constant and on nothing else
+%  (the only guard native_go_clause produces is `arg1 == <const>`). At most
+%  one case can match, so this is sound for an order-independent predicate and
+%  needs no goroutines. Requires arity >= 2 so arg1 is an input parameter (an
+%  arity-1 predicate has zero input params under the native last-arg-as-output
+%  model, so its first argument is not available to switch on — those decline
+%  and route to WAM lowering).
+go_native_t5_dispatch(Pred/Arity, Clauses, Code) :-
+    Arity >= 2,
+    Clauses = [_,_|_],
+    go_native_t5_cases(Pred/Arity, Clauses, Cases),
+    findall(Lit, member(case(Lit, _), Cases), Lits),
+    sort(Lits, Distinct),
+    length(Lits, N), length(Distinct, N),   % all first-arg constants distinct
+    atom_string(Pred, PredStr),
+    maplist(go_native_t5_case_block, Cases, CaseBlocks),
+    atomic_list_concat(CaseBlocks, '\n', CasesBlock),
+    format(string(Code),
+'\t// T5 first-argument dispatch: clauses discriminate on a distinct
+\t// first-argument constant, so at most one matches — emitted as a
+\t// deterministic switch (no clause-parallel goroutines required).
+\tswitch arg1 {
+~w
+\t}
+\tpanic("No matching clause for ~w")', [CasesBlock, PredStr]).
+
+%% go_native_t5_cases(+PredSpec, +Clauses, -Cases)
+%  Each clause must compile via native_go_clause with a guard that is exactly
+%  the first-argument constant test (no further conditions), and its first
+%  head argument must be that atomic constant.
+go_native_t5_cases(_, [], []).
+go_native_t5_cases(PredSpec, [Head-Body|Rest], [case(Lit, ClauseCode)|RestCases]) :-
+    Head =.. [_Pred, FirstArg|_],
+    atomic(FirstArg),
+    go_literal(FirstArg, Lit),
+    native_go_clause(PredSpec, Head, Body, Condition, ClauseCode),
+    format(string(FirstArgCond), 'arg1 == ~w', [Lit]),
+    Condition == FirstArgCond,
+    go_native_t5_cases(PredSpec, Rest, RestCases).
+
+%% go_native_t5_case_block(+Case, -Block)
+go_native_t5_case_block(case(Lit, ClauseCode), Block) :-
+    format(string(Block), '\tcase ~w:\n~w', [Lit, ClauseCode]).
 
 %% compile_clause_parallel_branches(+PredSpec, +Clauses, +Idx, -BranchCodes)
 compile_clause_parallel_branches(_, [], _, []).

--- a/tests/test_wam_go_native_t5_parallel.pl
+++ b/tests/test_wam_go_native_t5_parallel.pl
@@ -1,0 +1,135 @@
+% test_wam_go_native_t5_parallel.pl
+%
+% T5 first-argument dispatch in the NATIVE clause-parallel Go path.
+%
+% An order-independent multi-clause predicate whose clauses discriminate on a
+% DISTINCT first-argument constant used to compile to a goroutine fan-out
+% (one goroutine per clause, a results channel, context cancellation). Because
+% at most one such clause can ever match, that parallelism is pure overhead —
+% and the goroutine codegen was additionally broken for these shapes (an
+% unused `ctx` for arg-less predicates, an undeclared output variable for rule
+% clauses). It now lowers to a deterministic `switch arg1 { ... }`, the
+% native-path analogue of the WAM-lowered T5 dispatch (wam_clause_chain).
+%
+% Pins:
+%   * sz/2 — fact chain, returns the second argument;
+%   * op/2 — RULE chain, each clause computes its output with is/2;
+%   * boundary: a body-discriminated order-independent predicate (the
+%     first head arg is a variable) still uses the goroutine fan-out.
+%
+% The exec portion is skipped automatically when `go` is not on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_go_target').
+:- use_module('../src/unifyweaver/targets/wam_go_lowered_emitter').
+:- use_module('../src/unifyweaver/targets/go_target').
+:- use_module('../src/unifyweaver/core/clause_body_analysis').
+
+:- dynamic user:sz/2.
+:- dynamic user:op/2.
+
+user:sz(small, 1).
+user:sz(medium, 2).
+user:sz(large, 3).
+
+user:op(add, R) :- R is 1 + 1.
+user:op(mul, R) :- R is 2 * 3.
+user:op(neg, R) :- R is 0 - 1.
+
+go_available :-
+    catch(
+        ( process_create(path(go), ['version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          process_wait(Pid, exit(0)) ),
+        _, fail).
+
+:- begin_tests(wam_go_native_t5_parallel).
+
+% Distinct first-arg constants -> deterministic switch, no goroutines.
+test(sz_lowers_to_switch) :-
+    Clauses = [ (sz(small, 1)  - true),
+                (sz(medium, 2) - true),
+                (sz(large, 3)  - true) ],
+    go_target:compile_clause_parallel_to_go(sz/2, Clauses, Code),
+    assertion(sub_string(Code, _, _, _, "switch arg1")),
+    assertion(sub_string(Code, _, _, _, "case \"small\":")),
+    assertion(\+ sub_string(Code, _, _, _, "go func()")),
+    assertion(\+ sub_string(Code, _, _, _, "sync.WaitGroup")).
+
+% Rule clauses computing the output must return the expression directly
+% (regression: previously emitted `arg2 = (1 + 1)` against an undeclared var).
+test(op_lowers_to_switch_with_return_expr) :-
+    Clauses = [ (op(add, A) - (A is 1 + 1)),
+                (op(mul, B) - (B is 2 * 3)),
+                (op(neg, C) - (C is 0 - 1)) ],
+    go_target:compile_clause_parallel_to_go(op/2, Clauses, Code),
+    assertion(sub_string(Code, _, _, _, "switch arg1")),
+    assertion(sub_string(Code, _, _, _, "return (1 + 1)")),
+    assertion(\+ sub_string(Code, _, _, _, "arg2 = ")),
+    assertion(\+ sub_string(Code, _, _, _, "go func()")).
+
+% Boundary: a body-discriminated predicate (variable first head arg) is not
+% T5-eligible and keeps the goroutine fan-out.
+test(body_discriminated_stays_goroutine) :-
+    assertz(clause_body_analysis:order_independent(nc/2)),
+    Clauses = [ (nc(X, Y) - (X = red,  Y = 1)),
+                (nc(X, Y) - (X = blue, Y = 2)) ],
+    go_target:compile_clause_parallel_to_go(nc/2, Clauses, Code),
+    retract(clause_body_analysis:order_independent(nc/2)),
+    assertion(sub_string(Code, _, _, _, "go func()")),
+    assertion(sub_string(Code, _, _, _, "sync.WaitGroup")),
+    assertion(\+ sub_string(Code, _, _, _, "switch arg1")).
+
+% End-to-end: the whole native project compiles (the T5 switch is valid Go,
+% unlike the goroutine fan-out it replaces) and the functions return the
+% right values.
+test(t5_native_exec, [condition(go_available)]) :-
+    Dir = 'output/test_wam_go_native_t5_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    make_directory_path(Dir),
+    write_wam_go_project(
+        [user:sz/2, user:op/2],
+        [module_name('nt5'), wam_fallback(true)], Dir),
+    atomic_list_concat([Dir, '/lib.go'], LibPath),
+    read_file_to_string(LibPath, LibSrc, []),
+    assertion(sub_string(LibSrc, _, _, _, "T5 first-argument dispatch")),
+    write_native_t5_test(Dir),
+    format(atom(Cmd), 'cd ~w && go test ./... 2>&1', [Dir]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    ->  true
+    ;   format(user_error, "~n[go test output]~n~w~n", [OutStr]),
+        throw(go_native_t5_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_go_native_t5_parallel).
+
+write_native_t5_test(Dir) :-
+    atomic_list_concat([Dir, '/t5_native_test.go'], Path),
+    Src =
+"package wam
+
+import \"testing\"
+
+func TestNativeT5Parallel(t *testing.T) {
+	if got := sz(\"small\"); got != 1 { t.Errorf(\"sz(small)=%v want 1\", got) }
+	if got := sz(\"medium\"); got != 2 { t.Errorf(\"sz(medium)=%v want 2\", got) }
+	if got := sz(\"large\"); got != 3 { t.Errorf(\"sz(large)=%v want 3\", got) }
+	if got := op(\"add\"); got != 2 { t.Errorf(\"op(add)=%v want 2\", got) }
+	if got := op(\"mul\"); got != 6 { t.Errorf(\"op(mul)=%v want 6\", got) }
+	if got := op(\"neg\"); got != -1 { t.Errorf(\"op(neg)=%v want -1\", got) }
+	func() {
+		defer func() {
+			if r := recover(); r == nil { t.Errorf(\"sz(big) should panic\") }
+		}()
+		sz(\"big\")
+	}()
+}
+",
+    setup_call_cleanup(open(Path, write, S, [encoding(utf8)]), write(S, Src), close(S)).


### PR DESCRIPTION
## Summary

Brings the **T5 first-argument dispatch** (the `wam_clause_chain` idea already in the WAM-lowered Go/Scala/Rust emitters — #2901, #2907, #2920) to the **native clause-parallel** Go path.

When an `order_independent` multi-clause predicate's clauses discriminate on a **distinct first-argument constant**, at most one clause can ever match, so the goroutine fan-out (one goroutine per clause + results channel + context cancellation) is pure overhead. It now lowers to a deterministic `switch arg1 { ... }`.

This also removes two pre-existing codegen defects the goroutine path emitted for exactly these shapes (the ones that made the `lib.go` in #2920 fail to build):

- an **unused `ctx`** when no clause body referenced it;
- an **undeclared output variable** (`arg2 = (1 + 1)`) for rule clauses that compute their result — the output head var is pre-registered in the VarMap under its head-position name (`arg2`), so the body assignment used `=` against a name that was never declared as a Go local.

### Before (goroutine fan-out — did not compile)
```go
func op(arg1 interface{}) interface{} {
	ctx, cancel := context.WithCancel(context.Background())  // ctx unused for some preds
	...
	go func() { // clause 1
		if arg1 == "add" {
			arg2 = (1 + 1)   // undefined: arg2
			return arg2, true
		}
	}()
	...
}
```
### After (T5 switch)
```go
func op(arg1 interface{}) interface{} {
	// T5 first-argument dispatch: clauses discriminate on a distinct
	// first-argument constant, so at most one matches — emitted as a
	// deterministic switch (no clause-parallel goroutines required).
	switch arg1 {
	case "add":
		return (1 + 1)
	case "mul":
		return (2 * 3)
	case "neg":
		return (0 - 1)
	}
	panic("No matching clause for op")
}
```

## Changes (`go_target.pl`)

- `compile_clause_parallel_to_go`: try `go_native_t5_dispatch` first; if **no** clause compiles natively (e.g. arity-1 boolean facts, which the value-returning native model — zero input params, last-arg-as-output — cannot represent), **decline** so the caller routes the predicate to WAM lowering instead of emitting an all-empty goroutine body; otherwise fall back to the existing goroutine fan-out.
- `go_native_t5_dispatch` / `go_native_t5_cases` / `go_native_t5_case_block`: require arity ≥ 2 (so `arg1` is an input parameter), every clause's first head arg a **distinct atomic constant**, and the only guard exactly `arg1 == <const>`; emit the switch.
- `go_output_goal_last/3`: a final goal computing the output var directly (`R is Expr` / `R = Expr`) now `return`s the expression, mirroring the `/4` variant — fixes the undeclared-`arg2` emission for rule clauses (benefits the sequential native path too).

## Test — `tests/test_wam_go_native_t5_parallel.pl`

- `sz/2` (fact chain) and `op/2` (`is/2` rule chain) lower to a `switch` with **no** goroutines.
- Regression pin: `op/2` emits `return (1 + 1)`, not `arg2 = ...`.
- Boundary pin: a body-discriminated predicate (variable first head arg) **still** uses the goroutine fan-out.
- Exec: builds the whole native project (now valid Go) and checks `sz`/`op` return the right values; no-match panics.

## Verification

- New `test_wam_go_native_t5_parallel`: all 4 tests pass (`go test` green).
- No regression: `test_go_goal_parallel` (the existing goroutine clause-parallel tests), `test_wam_go_lowered_phase1/2/3`, `test_wam_go_lowered_t5`, `test_wam_go_lowered_ite_exec`, `test_wam_go_generator`, `test_wam_go_negation_cut` all pass.

## Note

Pure-fact arity-1 predicates like `color/1` go through a *separate* "facts" strategy (not the clause-parallel path) which emits its own (independently broken, package-level) snippet; that's out of scope here and is already handled correctly by the WAM-lowered T5 path (#2920).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_