### PR TITLE
Expand WAM-C call/N meta-goal dispatch

### DIFF
--- a/WAM_C_TARGET_NEXT_STEPS.md
+++ b/WAM_C_TARGET_NEXT_STEPS.md
@@ -4,15 +4,15 @@ Status date: 2026-06-07
 
 Latest branch verification:
 
-- `investigate/wam-c-meta-goal-ite` based on `main` at `28ac3536`
-  (`Merge pull request #2881 from
-  s243a/investigate/wam-c-meta-goal-disjunction`)
+- `investigate/wam-c-meta-goal-call-n` based on `main` at `08b21f86`
+  (`Merge pull request #2916 from
+  s243a/investigate/wam-c-meta-goal-ite`)
 - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
 - `git diff --check`
 
 Active branch:
 
-- `investigate/wam-c-meta-goal-ite`
+- `investigate/wam-c-meta-goal-call-n`
 
 This file replaces the older implementation plan. The four original C follow-up
 items are now complete on `main`; the remaining work is feature parity with the
@@ -91,6 +91,7 @@ more mature hybrid WAM targets, especially Haskell and Rust.
 | Runtime conjunction goal-term dispatch | Done | C preserves `,/2` functors in WAM-to-C parsing, dispatches conjunction goal terms through a synthetic continuation frame, snapshots frame depth in choicepoints, and covers non-inline aggregate bodies with conjunction in `bagof/3` and `setof/3` |
 | Runtime disjunction goal-term dispatch | Done | C dispatches `;/2` goal terms by placing the right branch behind a synthetic choicepoint, snapshots disjunction-frame depth in choicepoints, and covers non-inline aggregate bodies with disjunction in `bagof/3` and `setof/3` |
 | Runtime if-then-else goal-term dispatch | Done | C recognizes `;(->(If, Then), Else)` goal terms, commits on the first condition success by pruning condition alternatives and the else fallback, and covers non-inline aggregate bodies with if-then-else in `bagof/3` and `setof/3` |
+| Runtime `call/N` goal-term expansion | Done | C expands `call/1` through `call/N` goal terms by appending extra arguments to atom or partial-structure callables before reusing normal meta-goal dispatch, and covers non-inline aggregate bodies with `call/N` in `bagof/3` and `setof/3` |
 
 ## Current C Target Baseline
 
@@ -151,7 +152,7 @@ The C target is now a credible small WAM backend:
   existential `^/2` suppression plus unbound witness group enumeration inside
   inline `bagof/3` / `setof/3` bodies. It also has runtime meta-call dispatch
   for non-inline aggregate calls over simple callable goal terms and
-  conjunction/disjunction/if-then-else goal terms.
+  conjunction/disjunction/if-then-else/`call/N` goal terms.
 - Has an executable smoke for a generated multi-recursive Fibonacci-style
   arithmetic program.
 
@@ -174,7 +175,7 @@ missing important target features; `Missing` = no comparable C path yet.
 | Second-arg indexing | Partial | Partial/Done | Partial/Done | C has constant A2 dispatch; broaden tests if this becomes hot. |
 | Predicate dispatch map | Done | Done | Done | C now uses open-addressing hash table. |
 | Builtin calls | Partial | Broader | Broader | C has a growing builtin set, including generated-Prolog coverage over `functor/3`, `arg/3`, and `atom_concat/3`; next builtin gaps should be chosen from concrete benchmark demand. |
-| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness, caller-bound witness, existential `^/2`, and unbound witness group enumeration for inline `bagof/3` / `setof/3`; runtime meta-call aggregate dispatch now covers simple callable, conjunction, disjunction, and if-then-else goals, while `call/N` and broader meta-goal forms remain gaps. |
+| Aggregates (`findall`/`bagof`/`setof`) | Partial | Present in hybrid/lowered paths | Present in interpreter/lowered paths | C now has simple, helper-nested, templated, and direct inline nested `findall/3` collect support plus no-witness, caller-bound witness, existential `^/2`, and unbound witness group enumeration for inline `bagof/3` / `setof/3`; runtime meta-call aggregate dispatch now covers simple callable, conjunction, disjunction, if-then-else, and `call/N` goals, while broader meta-goal forms remain gaps. |
 | Negation / control builtins | Partial/Done | Broader | Broader | C now executes shared WAM control opcodes for `\+/1`, legacy `cut_ite` if-then-else, precise `get_level`/`cut` if-then-else, explicit `!/0` scoped to the current predicate call barrier, and generated `forall/2` soft-cut rewrites; residual work should be driven by concrete meta-control demand. |
 | Foreign predicate instruction (`CallForeign`) | Partial/Done | Done | Done | C has deterministic handler dispatch plus integer result collection for native kernels. |
 | Native recursive kernels | Partial/Done | Done | Done | C has detected `category_ancestor/4` setup, all-hop collection for that kernel, native transitive closure/distance/parent-distance/step-parent-distance handlers, weighted shortest path, and A* shortest path with integer and fractional result coverage; remaining parity gaps are broader integration details. |
@@ -188,6 +189,27 @@ missing important target features; `Missing` = no comparable C path yet.
 | Instruction layout efficiency | Done | N/A | N/A | C now packs instruction fields into tag-specific payload arms; benchmark larger generated programs if layout becomes performance-sensitive. |
 
 ## Recommended Next Branches
+
+### Completed: `investigate/wam-c-meta-goal-call-n`
+
+Goal: extend C aggregate meta-call goal dispatch to `call/N` goal expansion.
+
+Evidence:
+
+- C recognizes `call/1` through `call/N` goal terms before normal predicate
+  lookup.
+- `call/1` invokes the callable directly.
+- `call/N` expands atom callables and partial-structure callables by appending
+  extra arguments into a temporary heap goal term, then reuses normal meta-goal
+  dispatch.
+- The executable smoke covers non-inline `bagof/3` and `setof/3` bodies with
+  `call/2`, `call/3`, partial-structure `call/2`, and sorted/deduplicated set
+  output.
+
+Remaining gaps:
+
+- Broader meta-goal parity should now be driven by concrete benchmark or user
+  programs rather than the aggregate `call/N` sequence.
 
 ### Completed: `investigate/wam-c-meta-goal-ite`
 
@@ -213,8 +235,8 @@ Evidence:
 
 Remaining gaps:
 
-- General `call/N` composition still needs runtime goal expansion before the
-  C meta-call path reaches full goal-term parity.
+- Later branches closed the aggregate `call/N` gap; remaining meta-goal parity
+  work should be driven by concrete benchmark or user programs.
 
 ### Completed: `investigate/wam-c-meta-goal-disjunction`
 
@@ -237,8 +259,9 @@ Evidence:
 
 Remaining gaps:
 
-- General `call/N` composition still needs runtime goal expansion before the C
-  meta-call path reaches full goal-term parity.
+- Later branches closed the aggregate if-then-else and `call/N` gaps; remaining
+  meta-goal parity work should be driven by concrete benchmark or user
+  programs.
 
 ### Completed: `investigate/wam-c-meta-goal-composition`
 
@@ -263,8 +286,9 @@ Evidence:
 
 Remaining gaps:
 
-- General `call/N` composition still needs runtime goal expansion before the C
-  meta-call path reaches full goal-term parity.
+- Later branches closed the aggregate disjunction, if-then-else, and `call/N`
+  gaps; remaining meta-goal parity work should be driven by concrete benchmark
+  or user programs.
 
 ### Completed: `investigate/wam-c-meta-aggregate-dispatch`
 
@@ -290,9 +314,9 @@ Evidence:
 
 Remaining gaps:
 
-- The first meta-call implementation invokes atoms, module-qualified simple
-  predicate terms, `^/2`, direct builtins, and nested aggregate terms. It does
-  not yet cover general `call/N` goal composition in the C runtime.
+- Later branches extended the first meta-call implementation through
+  conjunction, disjunction, if-then-else, and `call/N` goal terms. Remaining
+  parity work should be driven by concrete benchmark or user programs.
 
 ### Completed: `investigate/wam-c-bagof-setof-unbound-witness-groups`
 
@@ -1290,11 +1314,14 @@ Evidence:
 
 The aggregate parity sequence now has inline no-witness, caller-bound witness,
 existential `^/2`, unbound witness group enumeration, runtime meta-call
-aggregate dispatch for simple callable goals, and conjunction goal-term
-dispatch, disjunction goal-term dispatch, and if-then-else goal-term dispatch
-inside meta aggregate bodies. The next aggregate feature worth considering is
-`call/N` composition because it changes general meta-call goal expansion, not
-just aggregate frame finalization.
+aggregate dispatch for simple callable goals, conjunction goal-term dispatch,
+disjunction goal-term dispatch, if-then-else goal-term dispatch, and `call/N`
+goal expansion inside meta aggregate bodies. The next aggregate/meta-goal work
+should be driven by concrete generated programs or benchmark demand rather than
+another obvious core meta-call form. For C parity, the next narrow candidate is
+likely broader classic-program stress coverage or project-generator/test
+scaffolding depth, unless a benchmark exposes a specific builtin or control
+gap.
 
 For the effective-distance/CSR line, result-capped and sampled runs already
 confirm child-CSR variants agree, and parent plus child reachability prefilters

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -2871,6 +2871,80 @@ static bool wam_dispatch_if_then_else(WamState *state,
     return wam_invoke_goal_as_call(state, if_goal, WAM_META_ITE_THEN);
 }
 
+static bool wam_functor_with_arity(WamState *state,
+                                   const char *functor,
+                                   int arity,
+                                   char *out,
+                                   size_t out_size) {
+    const char *slash = strrchr(functor, 47);
+    if (!slash) return false;
+    size_t name_len = (size_t)(slash - functor);
+    if (name_len == 0 || name_len >= out_size) return false;
+    int written = snprintf(out, out_size, "%.*s/%d",
+                           (int)name_len, functor, arity);
+    if (written <= 0 || written >= (int)out_size) return false;
+    (void)state;
+    return true;
+}
+
+static bool wam_dispatch_call_n(WamState *state,
+                                int base,
+                                int arity,
+                                int return_pc) {
+    if (arity < 1) return false;
+    WamValue callable = state->H_array[base + 1];
+    if (arity == 1) {
+        return wam_invoke_goal_as_call(state, callable, return_pc);
+    }
+
+    int extra_count = arity - 1;
+    WamValue args[WAM_MAX_REGS];
+    int goal_arity = 0;
+    char functor_buf[256];
+
+    WamValue *callable_cell = wam_deref_ptr(state, &callable);
+    if (callable_cell->tag == VAL_ATOM) {
+        goal_arity = extra_count;
+        int written = snprintf(functor_buf, sizeof(functor_buf), "%s/%d",
+                               callable_cell->data.atom, goal_arity);
+        if (written <= 0 || written >= (int)sizeof(functor_buf)) return false;
+    } else {
+        const char *callable_functor = NULL;
+        int callable_base = -1;
+        if (!wam_goal_structure(state, callable, &callable_functor,
+                                &callable_base)) return false;
+        int callable_arity = 0;
+        if (!wam_parse_functor_arity(callable_functor,
+                                     &callable_arity)) return false;
+        if (callable_arity > WAM_MAX_REGS - extra_count) return false;
+        goal_arity = callable_arity + extra_count;
+        if (!wam_functor_with_arity(state, callable_functor, goal_arity,
+                                    functor_buf, sizeof(functor_buf))) {
+            return false;
+        }
+        for (int i = 0; i < callable_arity; i++) {
+            args[i] = state->H_array[callable_base + 1 + i];
+        }
+    }
+
+    if (goal_arity > WAM_MAX_REGS) return false;
+    int existing_args = goal_arity - extra_count;
+    for (int i = 0; i < extra_count; i++) {
+        args[existing_args + i] = state->H_array[base + 2 + i];
+    }
+
+    if (!wam_ensure_heap_slots(state, goal_arity + 1)) return false;
+    int goal_base = state->H;
+    state->H_array[state->H++] = val_atom(wam_intern_atom(state, functor_buf));
+    for (int i = 0; i < goal_arity; i++) {
+        state->H_array[state->H++] = args[i];
+    }
+    WamValue expanded_goal;
+    expanded_goal.tag = VAL_STR;
+    expanded_goal.data.ref_addr = goal_base;
+    return wam_invoke_goal_as_call(state, expanded_goal, return_pc);
+}
+
 static bool wam_invoke_goal_as_call(WamState *state, WamValue goal,
                                     int return_pc) {
     WamValue *cell = wam_deref_ptr(state, &goal);
@@ -2897,6 +2971,9 @@ static bool wam_invoke_goal_as_call(WamState *state, WamValue goal,
     int arity = 0;
     if (!wam_parse_functor_arity(functor, &arity)) return false;
     if (arity > WAM_MAX_REGS) return false;
+    if (strncmp(functor, "call/", 5) == 0 && arity >= 1) {
+        return wam_dispatch_call_n(state, base, arity, return_pc);
+    }
     if (strcmp(functor, ",/2") == 0 && arity == 2) {
         if (state->conj_top >= WAM_META_GOAL_STACK_SIZE) return false;
         WamConjFrame *frame = &state->conj_frames[state->conj_top++];

--- a/tests/test_wam_c_target.pl
+++ b/tests/test_wam_c_target.pl
@@ -3174,6 +3174,13 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
     assertz((user:wam_c_meta_ite_set_then(b) :- true)),
     assertz((user:wam_c_meta_ite_set_then(a) :- true)),
     assertz((user:wam_c_meta_ite_set_then(b) :- true)),
+    assertz((user:wam_c_meta_call_item(a) :- true)),
+    assertz((user:wam_c_meta_call_item(b) :- true)),
+    assertz((user:wam_c_meta_call_pair(a, k) :- true)),
+    assertz((user:wam_c_meta_call_pair(b, k) :- true)),
+    assertz((user:wam_c_meta_call_dup(b) :- true)),
+    assertz((user:wam_c_meta_call_dup(a) :- true)),
+    assertz((user:wam_c_meta_call_dup(b) :- true)),
     assertz((user:wam_c_meta_bag(L) :-
         bagof(X, wam_c_meta_item(X), L))),
     assertz((user:wam_c_meta_set(L) :-
@@ -3214,6 +3221,14 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
                -> wam_c_meta_ite_set_then(X)
                ;  wam_c_meta_ite_else(X)),
               L))),
+    assertz((user:wam_c_meta_call_bag(L) :-
+        bagof(X, call(wam_c_meta_call_item, X), L))),
+    assertz((user:wam_c_meta_call_pair_bag(L) :-
+        bagof(X, call(wam_c_meta_call_pair, X, k), L))),
+    assertz((user:wam_c_meta_call_partial_bag(L) :-
+        bagof(X, call(wam_c_meta_call_pair(X), k), L))),
+    assertz((user:wam_c_meta_call_set(L) :-
+        setof(X, call(wam_c_meta_call_dup, X), L))),
     (   compile_predicate_to_wam(user:wam_c_meta_item/1, [], WamItem),
         compile_predicate_to_wam(user:wam_c_meta_dup/1, [], WamDup),
         compile_predicate_to_wam(user:wam_c_meta_none/1, [], WamNone),
@@ -3230,6 +3245,9 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
         compile_predicate_to_wam(user:wam_c_meta_ite_fail_cond/1, [], WamIteFailCond),
         compile_predicate_to_wam(user:wam_c_meta_ite_else/1, [], WamIteElse),
         compile_predicate_to_wam(user:wam_c_meta_ite_set_then/1, [], WamIteSetThen),
+        compile_predicate_to_wam(user:wam_c_meta_call_item/1, [], WamCallItem),
+        compile_predicate_to_wam(user:wam_c_meta_call_pair/2, [], WamCallPair),
+        compile_predicate_to_wam(user:wam_c_meta_call_dup/1, [], WamCallDup),
         compile_predicate_to_wam(user:wam_c_meta_bag/1, [], WamBag),
         compile_predicate_to_wam(user:wam_c_meta_set/1, [], WamSet),
         compile_predicate_to_wam(user:wam_c_meta_empty_bag/1, [], WamEmptyBag),
@@ -3240,6 +3258,10 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
         compile_predicate_to_wam(user:wam_c_meta_ite_bag/1, [], WamIteBag),
         compile_predicate_to_wam(user:wam_c_meta_ite_else_bag/1, [], WamIteElseBag),
         compile_predicate_to_wam(user:wam_c_meta_ite_set/1, [], WamIteSet),
+        compile_predicate_to_wam(user:wam_c_meta_call_bag/1, [], WamCallBag),
+        compile_predicate_to_wam(user:wam_c_meta_call_pair_bag/1, [], WamCallPairBag),
+        compile_predicate_to_wam(user:wam_c_meta_call_partial_bag/1, [], WamCallPartialBag),
+        compile_predicate_to_wam(user:wam_c_meta_call_set/1, [], WamCallSet),
         sub_string(WamBag, _, _, _, 'execute bagof/3'),
         \+ sub_string(WamBag, _, _, _, 'begin_aggregate bagof'),
         sub_string(WamSet, _, _, _, 'execute setof/3'),
@@ -3266,6 +3288,19 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
         sub_string(WamIteSet, _, _, _, 'put_structure ->/2'),
         sub_string(WamIteSet, _, _, _, 'execute setof/3'),
         \+ sub_string(WamIteSet, _, _, _, 'begin_aggregate setof'),
+        sub_string(WamCallBag, _, _, _, 'put_structure call/2'),
+        sub_string(WamCallBag, _, _, _, 'execute bagof/3'),
+        \+ sub_string(WamCallBag, _, _, _, 'begin_aggregate bagof'),
+        sub_string(WamCallPairBag, _, _, _, 'put_structure call/3'),
+        sub_string(WamCallPairBag, _, _, _, 'execute bagof/3'),
+        \+ sub_string(WamCallPairBag, _, _, _, 'begin_aggregate bagof'),
+        sub_string(WamCallPartialBag, _, _, _, 'put_structure call/2'),
+        sub_string(WamCallPartialBag, _, _, _, 'put_structure wam_c_meta_call_pair/1'),
+        sub_string(WamCallPartialBag, _, _, _, 'execute bagof/3'),
+        \+ sub_string(WamCallPartialBag, _, _, _, 'begin_aggregate bagof'),
+        sub_string(WamCallSet, _, _, _, 'put_structure call/2'),
+        sub_string(WamCallSet, _, _, _, 'execute setof/3'),
+        \+ sub_string(WamCallSet, _, _, _, 'begin_aggregate setof'),
         compile_wam_predicate_to_c(user:wam_c_meta_item/1, WamItem, [], ItemCode),
         compile_wam_predicate_to_c(user:wam_c_meta_dup/1, WamDup, [], DupCode),
         compile_wam_predicate_to_c(user:wam_c_meta_none/1, WamNone, [], NoneCode),
@@ -3282,6 +3317,9 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
         compile_wam_predicate_to_c(user:wam_c_meta_ite_fail_cond/1, WamIteFailCond, [], IteFailCondCode),
         compile_wam_predicate_to_c(user:wam_c_meta_ite_else/1, WamIteElse, [], IteElseCode),
         compile_wam_predicate_to_c(user:wam_c_meta_ite_set_then/1, WamIteSetThen, [], IteSetThenCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_call_item/1, WamCallItem, [], CallItemCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_call_pair/2, WamCallPair, [], CallPairCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_call_dup/1, WamCallDup, [], CallDupCode),
         compile_wam_predicate_to_c(user:wam_c_meta_bag/1, WamBag, [], BagCode),
         compile_wam_predicate_to_c(user:wam_c_meta_set/1, WamSet, [], SetCode),
         compile_wam_predicate_to_c(user:wam_c_meta_empty_bag/1, WamEmptyBag, [], EmptyBagCode),
@@ -3292,6 +3330,10 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
         compile_wam_predicate_to_c(user:wam_c_meta_ite_bag/1, WamIteBag, [], IteBagCode),
         compile_wam_predicate_to_c(user:wam_c_meta_ite_else_bag/1, WamIteElseBag, [], IteElseBagCode),
         compile_wam_predicate_to_c(user:wam_c_meta_ite_set/1, WamIteSet, [], IteSetCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_call_bag/1, WamCallBag, [], CallBagCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_call_pair_bag/1, WamCallPairBag, [], CallPairBagCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_call_partial_bag/1, WamCallPartialBag, [], CallPartialBagCode),
+        compile_wam_predicate_to_c(user:wam_c_meta_call_set/1, WamCallSet, [], CallSetCode),
         atomic_list_concat([ItemCode, DupCode, NoneCode,
                             ConjItemCode, ConjKeepCode, ConjDupCode,
                             ConjSetKeepCode,
@@ -3299,10 +3341,13 @@ run_real_prolog_bagof_setof_meta_call_smoke :-
                             DisjSetLeftCode, DisjSetRightCode,
                             IteCondCode, IteThenCode, IteFailCondCode,
                             IteElseCode, IteSetThenCode,
+                            CallItemCode, CallPairCode, CallDupCode,
                             BagCode, SetCode, EmptyBagCode,
                             ConjBagCode, ConjSetCode,
                             DisjBagCode, DisjSetCode,
-                            IteBagCode, IteElseBagCode, IteSetCode],
+                            IteBagCode, IteElseBagCode, IteSetCode,
+                            CallBagCode, CallPairBagCode,
+                            CallPartialBagCode, CallSetCode],
                            '\n\n',
                            PredCode),
         compile_wam_runtime_to_c([], RuntimeCode),
@@ -3342,6 +3387,9 @@ cleanup_wam_c_bagof_setof_meta_call_smoke :-
     retractall(user:wam_c_meta_ite_fail_cond(_)),
     retractall(user:wam_c_meta_ite_else(_)),
     retractall(user:wam_c_meta_ite_set_then(_)),
+    retractall(user:wam_c_meta_call_item(_)),
+    retractall(user:wam_c_meta_call_pair(_, _)),
+    retractall(user:wam_c_meta_call_dup(_)),
     retractall(user:wam_c_meta_bag(_)),
     retractall(user:wam_c_meta_set(_)),
     retractall(user:wam_c_meta_empty_bag(_)),
@@ -3351,7 +3399,11 @@ cleanup_wam_c_bagof_setof_meta_call_smoke :-
     retractall(user:wam_c_meta_disj_set(_)),
     retractall(user:wam_c_meta_ite_bag(_)),
     retractall(user:wam_c_meta_ite_else_bag(_)),
-    retractall(user:wam_c_meta_ite_set(_)).
+    retractall(user:wam_c_meta_ite_set(_)),
+    retractall(user:wam_c_meta_call_bag(_)),
+    retractall(user:wam_c_meta_call_pair_bag(_)),
+    retractall(user:wam_c_meta_call_partial_bag(_)),
+    retractall(user:wam_c_meta_call_set(_)).
 
 run_real_prolog_classic_recursive_executable_smoke :-
     assertz((user:wam_c_classic_fib(0, 0) :- true)),
@@ -6896,6 +6948,9 @@ void setup_wam_c_meta_ite_then_1(WamState* state);
 void setup_wam_c_meta_ite_fail_cond_1(WamState* state);
 void setup_wam_c_meta_ite_else_1(WamState* state);
 void setup_wam_c_meta_ite_set_then_1(WamState* state);
+void setup_wam_c_meta_call_item_1(WamState* state);
+void setup_wam_c_meta_call_pair_2(WamState* state);
+void setup_wam_c_meta_call_dup_1(WamState* state);
 void setup_wam_c_meta_bag_1(WamState* state);
 void setup_wam_c_meta_set_1(WamState* state);
 void setup_wam_c_meta_empty_bag_1(WamState* state);
@@ -6906,6 +6961,10 @@ void setup_wam_c_meta_disj_set_1(WamState* state);
 void setup_wam_c_meta_ite_bag_1(WamState* state);
 void setup_wam_c_meta_ite_else_bag_1(WamState* state);
 void setup_wam_c_meta_ite_set_1(WamState* state);
+void setup_wam_c_meta_call_bag_1(WamState* state);
+void setup_wam_c_meta_call_pair_bag_1(WamState* state);
+void setup_wam_c_meta_call_partial_bag_1(WamState* state);
+void setup_wam_c_meta_call_set_1(WamState* state);
 
 static bool wam_c_meta_expect_atom_list2(WamState *state, WamValue value,
                                          const char *first,
@@ -6970,6 +7029,9 @@ int main(void) {
     setup_wam_c_meta_ite_fail_cond_1(&state);
     setup_wam_c_meta_ite_else_1(&state);
     setup_wam_c_meta_ite_set_then_1(&state);
+    setup_wam_c_meta_call_item_1(&state);
+    setup_wam_c_meta_call_pair_2(&state);
+    setup_wam_c_meta_call_dup_1(&state);
     setup_wam_c_meta_bag_1(&state);
     setup_wam_c_meta_set_1(&state);
     setup_wam_c_meta_empty_bag_1(&state);
@@ -6980,6 +7042,10 @@ int main(void) {
     setup_wam_c_meta_ite_bag_1(&state);
     setup_wam_c_meta_ite_else_bag_1(&state);
     setup_wam_c_meta_ite_set_1(&state);
+    setup_wam_c_meta_call_bag_1(&state);
+    setup_wam_c_meta_call_pair_bag_1(&state);
+    setup_wam_c_meta_call_partial_bag_1(&state);
+    setup_wam_c_meta_call_set_1(&state);
 
     WamValue bag_args[1] = { val_unbound("Bag") };
     int bag_rc = wam_run_predicate(&state, "wam_c_meta_bag/1", bag_args, 1);
@@ -7107,6 +7173,60 @@ int main(void) {
         state.ite_top != 0) {
         wam_free_state(&state);
         return 100;
+    }
+
+    WamValue call_bag_args[1] = { val_unbound("CallBag") };
+    int call_bag_rc = wam_run_predicate(&state, "wam_c_meta_call_bag/1",
+                                        call_bag_args, 1);
+    if (call_bag_rc != 0 || state.P != WAM_HALT ||
+        !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "b") ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
+        state.conj_top != 0 || state.disj_top != 0 ||
+        state.ite_top != 0) {
+        wam_free_state(&state);
+        return 110;
+    }
+
+    WamValue call_pair_bag_args[1] = { val_unbound("CallPairBag") };
+    int call_pair_bag_rc = wam_run_predicate(&state,
+                                             "wam_c_meta_call_pair_bag/1",
+                                             call_pair_bag_args, 1);
+    if (call_pair_bag_rc != 0 || state.P != WAM_HALT ||
+        !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "b") ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
+        state.conj_top != 0 || state.disj_top != 0 ||
+        state.ite_top != 0) {
+        wam_free_state(&state);
+        return 120;
+    }
+
+    WamValue call_partial_bag_args[1] = { val_unbound("CallPartialBag") };
+    int call_partial_bag_rc =
+        wam_run_predicate(&state, "wam_c_meta_call_partial_bag/1",
+                          call_partial_bag_args, 1);
+    if (call_partial_bag_rc != 0 || state.P != WAM_HALT ||
+        !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "b") ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
+        state.conj_top != 0 || state.disj_top != 0 ||
+        state.ite_top != 0) {
+        wam_free_state(&state);
+        return 130;
+    }
+
+    WamValue call_set_args[1] = { val_unbound("CallSet") };
+    int call_set_rc = wam_run_predicate(&state, "wam_c_meta_call_set/1",
+                                        call_set_args, 1);
+    if (call_set_rc != 0 || state.P != WAM_HALT ||
+        !wam_c_meta_expect_atom_list2(&state, state.A[0], "a", "b") ||
+        state.B != 0 || state.call_base_top != 0 ||
+        state.aggregate_top != 0 || state.aggregate_group_top != 0 ||
+        state.conj_top != 0 || state.disj_top != 0 ||
+        state.ite_top != 0) {
+        wam_free_state(&state);
+        return 140;
     }
 
     wam_free_state(&state);


### PR DESCRIPTION
  ## Summary

  - Adds WAM-C runtime expansion for `call/1` through `call/N` goal terms.
  - Supports atom callables and partial-structure callables by appending extra arguments before reusing normal meta-goal
  dispatch.
  - Extends non-inline `bagof/3` and `setof/3` executable smoke coverage for `call/2`, `call/3`, partial callable
  expansion, and sorted/deduplicated set output.
  - Updates `WAM_C_TARGET_NEXT_STEPS.md` to mark the call/N meta-goal branch complete.

  ## Tests

  - `swipl -q -g run_tests -t halt tests/test_wam_c_target.pl`
  - `git diff --check`