### PR TITLE
Add T5 first-argument clause-chain lowering for Haskell

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
@@ -30,6 +30,7 @@
 :- use_module(library(lists)).
 :- use_module(wam_text_parser, [wam_classify_constant_token/2]).
 :- use_module(wam_ite_structurer, [structure_ite/2]).
+:- use_module(wam_clause_chain, [clause_chain/2]).
 
 %% =====================================================================
 %% Parsing
@@ -221,7 +222,9 @@ emit_func(FN, PCInstrs, LabelMap, ForeignPreds) :-
     format("~w :: WamContext -> WamState -> Maybe WamState~n", [FN]),
     % Skip switch_on_constant* prefixes before deciding multi/single-clause.
     strip_switch_prefixes(PCInstrs, PCInstrs1),
-    (   PCInstrs1 = [pc(_, try_me_else(LStr))|BodyPCs]
+    (   emit_func_t5(FN, PCInstrs1, LabelMap, ForeignPreds)
+    ->  true   % T5 first-argument dispatch (all clauses lowered natively)
+    ;   PCInstrs1 = [pc(_, try_me_else(LStr))|BodyPCs]
     ->  atom_string(LAtom, LStr),
         (   member(LAtom-AltPC, LabelMap) -> true ; AltPC = 0 ),
         format("~w !ctx s_init =~n", [FN]),
@@ -249,6 +252,116 @@ take_to_proceed_pc([], []).
 take_to_proceed_pc([pc(PC, proceed)|_], [pc(PC, proceed)]) :- !.
 take_to_proceed_pc([pc(PC, fail)|_], [pc(PC, fail)]) :- !.
 take_to_proceed_pc([H|T], [H|R]) :- take_to_proceed_pc(T, R).
+
+%% =====================================================================
+%% T5: multi-clause as a first-argument dispatch (wam_clause_chain)
+%% =====================================================================
+%
+%  When the clauses discriminate on a DISTINCT first-argument constant
+%  (lowering type T5 in docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md)
+%  ALL clauses are lowered to native Haskell and selected by a deref-and-match
+%  cascade, instead of lowering only clause 1 and reaching clauses 2+ through
+%  the interpreter on backtrack. When the first argument is BOUND this is
+%  deterministic dispatch with no interpreter hop; when it is UNBOUND (or the
+%  register is unset) we defer to the interpreter via the same choice-point /
+%  backtrack / run fallback the ordinary multi-clause path uses — that path
+%  enumerates every clause, binding the variable in turn.
+%
+%  Each clause body is emitted in FULL (the leading `get_constant V, A1` is
+%  kept): on the bound fast path it harmlessly re-matches the already-bound
+%  first argument, and on the unbound fallback it is exactly what binds the
+%  variable. So the only thing T5 changes is HOW the matching clause is
+%  reached, never what a clause does.
+
+%% emit_func_t5(+FN, +PCInstrs1, +LabelMap, +FP) is semidet.
+%  Emits the T5 dispatch and succeeds, or fails (emitting nothing) when the
+%  predicate is not a distinct-first-argument constant chain. All checks run
+%  before any output so a failure leaves the stream untouched for the caller's
+%  fallback emission.
+emit_func_t5(FN, PCInstrs1, LabelMap, FP) :-
+    PCInstrs1 = [pc(_, try_me_else(L2Str))|_],
+    maplist(t5_strip_pc, PCInstrs1, PlainInstrs),
+    clause_chain(PlainInstrs, chain(_Guards)),
+    t5_split_clauses_pc(PCInstrs1, Slices),
+    Slices = [_, _ | _],
+    forall(( member(Sl, Slices), member(pc(_, I), Sl) ), supported(I)),
+    maplist(t5_slice_discriminator, Slices, Discrs),
+    % All checks passed — emit.
+    atom_string(L2Atom, L2Str),
+    ( member(L2Atom-AltPC, LabelMap) -> true ; AltPC = 0 ),
+    format("~w !ctx s_init =~n", [FN]),
+    format("  case derefVar (wsBindings s_init) <$> IM.lookup 1 (wsRegs s_init) of~n"),
+    format("    Just (Unbound _) -> t5fallback~n"),
+    format("    Just v~n"),
+    t5_emit_dispatch_guards(Discrs, 1),
+    format("      | otherwise -> Nothing~n"),
+    format("    _ -> t5fallback~n"),
+    format("  where~n"),
+    % Interpreter fallback for the unbound/unset first-argument case: push a
+    % choice point at clause 2's label, try clause 1 natively, and on failure
+    % backtrack into the interpreter to enumerate the remaining clauses.
+    format("    t5fallback =~n"),
+    format("      let s_cp = s_init { wsCPs = ChoicePoint~n"),
+    format("            { cpNextPC = ~w, cpRegs = wsRegs s_init, cpStack = wsStack s_init~n", [AltPC]),
+    format("            , cpCP = wsCP s_init, cpTrailLen = wsTrailLen s_init~n"),
+    format("            , cpHeapLen = wsHeapLen s_init, cpBindings = wsBindings s_init~n"),
+    format("            , cpCutBar = wsCutBar s_init, cpAggFrame = Nothing, cpBuiltin = Nothing~n"),
+    format("            } : wsCPs s_init~n"),
+    format("            , wsCPsLen = wsCPsLen s_init + 1 }~n"),
+    format("      in case t5clause_1 s_cp of~n"),
+    format("           Just result -> Just result~n"),
+    format("           Nothing -> backtrack s_cp >>= \\s_bt -> run ctx (s_bt { wsPC = wsPC s_bt + 1 })~n"),
+    t5_emit_clause_defs(Slices, 1, LabelMap, FP).
+
+t5_strip_pc(pc(_, I), I).
+
+%% t5_split_clauses_pc(+PCInstrs1, -Slices)
+%  Split the switch-stripped pc-instruction list (which opens with
+%  try_me_else) at the choice-point separators into per-clause slices, each
+%  trimmed to its terminal proceed/fail. Mirrors wam_clause_chain's
+%  split_clauses but keeps the pc(PC,Instr) wrappers for emission.
+t5_split_clauses_pc([pc(_, try_me_else(_))|Rest], [Slice|More]) :-
+    t5_collect_clause_pc(Rest, Clause, After),
+    take_to_proceed_pc(Clause, Slice),
+    t5_split_more_pc(After, More).
+
+t5_split_more_pc([], []).
+t5_split_more_pc([pc(_, retry_me_else(_))|Rest], [Slice|More]) :- !,
+    t5_collect_clause_pc(Rest, Clause, After),
+    take_to_proceed_pc(Clause, Slice),
+    t5_split_more_pc(After, More).
+t5_split_more_pc([pc(_, trust_me)|Rest], [Slice|More]) :- !,
+    t5_collect_clause_pc(Rest, Clause, After),
+    take_to_proceed_pc(Clause, Slice),
+    t5_split_more_pc(After, More).
+
+t5_collect_clause_pc([], [], []).
+t5_collect_clause_pc([pc(P, retry_me_else(L))|Rest], [], [pc(P, retry_me_else(L))|Rest]) :- !.
+t5_collect_clause_pc([pc(P, trust_me)|Rest], [], [pc(P, trust_me)|Rest]) :- !.
+t5_collect_clause_pc([Item|Rest], [Item|More], After) :-
+    t5_collect_clause_pc(Rest, More, After).
+
+%% t5_slice_discriminator(+Slice, -HaskellValueExpr)
+%  Each lowerable clause opens with `get_constant V, A1`; render V as its
+%  Haskell Value constructor.
+t5_slice_discriminator([pc(_, get_constant(VStr, _A1))|_], HC) :-
+    val_hs(VStr, HC).
+
+%% t5_emit_dispatch_guards(+Discrs, +Index)
+t5_emit_dispatch_guards([], _).
+t5_emit_dispatch_guards([HC|Rest], N) :-
+    format("      | v == (~w) -> t5clause_~w s_init~n", [HC, N]),
+    N1 is N + 1,
+    t5_emit_dispatch_guards(Rest, N1).
+
+%% t5_emit_clause_defs(+Slices, +Index, +LabelMap, +FP)
+t5_emit_clause_defs([], _, _, _).
+t5_emit_clause_defs([Slice|Rest], N, LabelMap, FP) :-
+    format("    t5clause_~w s_c~w = do~n", [N, N]),
+    format(atom(SV), 's_c~w', [N]),
+    emit_clause_struct(Slice, LabelMap, SV, "      ", FP),
+    N1 is N + 1,
+    t5_emit_clause_defs(Rest, N1, LabelMap, FP).
 
 %% =====================================================================
 %% emit_instrs_lm — LabelMap-aware top-level emission
@@ -662,8 +775,13 @@ emit_one(get_value(XnStr, AiStr), _PC, SV, SVout, I, _FP) :-
 % ---- GetStructure F Ai — delegate to step ----
 emit_one(get_structure(FnStr, AiStr), PC, SV, SVout, I, _FP) :-
     reg_to_int(AiStr, Ai),
-    parse_functor(FnStr, FuncName, Arity),
-    wam_haskell_target:intern_struct_functor(FuncName, FnId),
+    % Intern the FULL functor string (e.g. "+/2"), matching the interpreter
+    % codegen (wam_haskell_target's get_structure/put_structure rules). The
+    % lowered and interpreted paths share one runtime intern table, so a bare
+    % "+" here would get a different id than the table's "+/2" and evalArith /
+    % unification would look up the wrong name.
+    parse_functor(FnStr, _FuncName, Arity),
+    wam_haskell_target:intern_struct_functor(FnStr, FnId),
     fresh_sv(SV, SVout),
     format("~w~w <- step ctx (~w { wsPC = ~w }) (GetStructure ~w ~w ~w)~n",
            [I, SVout, SV, PC, FnId, Ai, Arity]).
@@ -739,8 +857,10 @@ emit_one(put_constant(CStr, AiStr), _, SV, SVout, I, _FP) :-
 % Directly sets wsBuilder, matching step's PutStructure semantics.
 emit_one(put_structure(FnStr, AiStr), _PC, SV, SVout, I, _FP) :-
     reg_to_int(AiStr, Ai),
-    parse_functor(FnStr, FuncName, Arity),
-    wam_haskell_target:intern_struct_functor(FuncName, FnId),
+    % Intern the FULL functor string (see get_structure above) so the
+    % builder's functor id matches the shared runtime intern table.
+    parse_functor(FnStr, _FuncName, Arity),
+    wam_haskell_target:intern_struct_functor(FnStr, FnId),
     fresh_sv(SV, SVout),
     format("~wlet ~w = ~w { wsBuilder = BuildStruct ~w ~w ~w [] }~n",
            [I, SVout, SV, FnId, Ai, Arity]).

--- a/tests/test_wam_haskell_lowered_t5.pl
+++ b/tests/test_wam_haskell_lowered_t5.pl
@@ -1,0 +1,136 @@
+% test_wam_haskell_lowered_t5.pl
+%
+% End-to-end execution test for the Haskell T5 lowering — "multi-clause as a
+% first-argument dispatch" (lowering type T5 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md), ported from the
+% Scala/Rust/Go emitters via the shared wam_clause_chain front-end.
+%
+% A predicate whose clauses discriminate on a DISTINCT first-argument
+% constant now lowers ALL of its clauses to native Haskell, selected by a
+% deref-and-match cascade, instead of lowering only clause 1 and reaching
+% clauses 2+ through the interpreter on backtrack. When the first argument is
+% bound this is deterministic dispatch with no interpreter hop; when it is
+% unbound it defers to the interpreter via the same choice-point / backtrack /
+% run fallback the ordinary multi-clause path uses (which enumerates every
+% clause, binding the variable in turn).
+%
+% Pins (the cases preload a BOUND first arg, exercising every clause incl. the
+% non-first ones — the T5 payoff):
+%   * color/1 — fact chain, atom discriminators;
+%   * sz/2    — fact chain with a second head match in each remainder;
+%   * op/2    — RULE chain (each remainder runs an is/2 builtin).
+%
+% Skipped automatically when `ghc` is not on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_haskell_target').
+
+:- dynamic user:color/1.
+:- dynamic user:sz/2.
+:- dynamic user:op/2.
+
+user:color(red).
+user:color(green).
+user:color(blue).
+
+user:sz(small, 1).
+user:sz(medium, 2).
+user:sz(large, 3).
+
+user:op(add, R) :- R is 1 + 1.
+user:op(mul, R) :- R is 2 * 3.
+user:op(neg, R) :- R is 0 - 1.
+
+ghc_available :-
+    catch(( process_create(path(ghc), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_haskell_lowered_t5, [condition(ghc_available)]).
+
+test(t5_exec_parity) :-
+    Dir = 'output/test_wam_haskell_t5_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    % 1. Generate the WAM Haskell project with the lowered emitter enabled.
+    write_wam_haskell_project(
+        [user:color/1, user:sz/2, user:op/2],
+        [module_name('t5proj'), emit_mode(functions)], Dir),
+    % Sanity: the generated lowered code must be the T5 dispatch.
+    atomic_list_concat([Dir, '/src/Lowered.hs'], LoweredPath),
+    ( exists_file(LoweredPath) -> read_file_to_string(LoweredPath, LSrc, []) ; LSrc = "" ),
+    assertion(sub_string(LSrc, _, _, _, "t5fallback")),
+    % 2. Test harness calling the lowered functions directly (bound first arg).
+    atomic_list_concat([Dir, '/src/TestMain.hs'], TestPath),
+    haskell_t5_source(Src),
+    setup_call_cleanup(open(TestPath, write, S), write(S, Src), close(S)),
+    % 3. Compile + run.
+    atomic_list_concat([Dir, '/src'], SrcDir),
+    atomic_list_concat([Dir, '/t5_test'], Bin),
+    format(atom(Cmd),
+        'ghc --make -i~w ~w/TestMain.hs -o ~w -main-is Main 2>&1 && ~w',
+        [SrcDir, SrcDir, Bin, Bin]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 14 PASS")
+    ->  true
+    ;   format(user_error, "~n[haskell t5 test output]~n~w~n", [OutStr]),
+        throw(haskell_t5_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_haskell_lowered_t5).
+
+% Calls each lowered function (WamContext -> WamState -> Maybe WamState) with
+% a BOUND first argument and checks Just (success) / Nothing (failure). The
+% cases exercise every clause including the non-first ones (green/blue,
+% medium/large, mul/neg) — the T5 payoff — plus the no-match cases.
+haskell_t5_source(
+"module Main where
+import qualified Data.HashMap.Strict as Map
+import qualified Data.IntMap.Strict as IM
+import WamTypes
+import WamRuntime ()
+import Lowered
+import Predicates (compileTimeAtomTable)
+
+runP :: (WamContext -> WamState -> Maybe WamState) -> [(Int, Value)] -> Bool
+runP f regs =
+  let ctx = (mkContext [] Map.empty)
+              { wcLoweredPredicates = loweredPredicates
+              -- op/2's clause bodies run an is/2 over a +/2 structure, and
+              -- evalArith resolves the operator name through the context
+              -- intern table — so it must hold the compile-time atom table.
+              , wcInternTable = compileTimeAtomTable }
+      s0  = emptyState { wsRegs = IM.fromList regs }
+  in case f ctx s0 of { Just _ -> True; Nothing -> False }
+
+i :: Int -> Value
+i = Integer . fromIntegral
+a :: String -> Value
+a s = Atom (internAtomPure compileTimeAtomTable s)
+
+main :: IO ()
+main = do
+  let cases =
+        [ (\"color(red)\", runP lowered_color_1 [(1,a \"red\")], True)
+        , (\"color(green)\", runP lowered_color_1 [(1,a \"green\")], True)
+        , (\"color(blue)\", runP lowered_color_1 [(1,a \"blue\")], True)
+        , (\"color(yellow)\", runP lowered_color_1 [(1,a \"yellow\")], False)
+        , (\"sz(small,1)\", runP lowered_sz_2 [(1,a \"small\"),(2,i 1)], True)
+        , (\"sz(medium,2)\", runP lowered_sz_2 [(1,a \"medium\"),(2,i 2)], True)
+        , (\"sz(large,3)\", runP lowered_sz_2 [(1,a \"large\"),(2,i 3)], True)
+        , (\"sz(small,2)\", runP lowered_sz_2 [(1,a \"small\"),(2,i 2)], False)
+        , (\"sz(big,1)\", runP lowered_sz_2 [(1,a \"big\"),(2,i 1)], False)
+        , (\"op(add,2)\", runP lowered_op_2 [(1,a \"add\"),(2,i 2)], True)
+        , (\"op(mul,6)\", runP lowered_op_2 [(1,a \"mul\"),(2,i 6)], True)
+        , (\"op(neg,-1)\", runP lowered_op_2 [(1,a \"neg\"),(2,i (-1))], True)
+        , (\"op(add,3)\", runP lowered_op_2 [(1,a \"add\"),(2,i 3)], False)
+        , (\"op(div,1)\", runP lowered_op_2 [(1,a \"div\"),(2,i 1)], False)
+        ]
+      fails = [ n | (n,got,want) <- cases, got /= want ]
+  mapM_ (\\(n,got,want) -> if got/=want then putStrLn (\"FAIL \" ++ n ++ \": got \" ++ show got ++ \" want \" ++ show want) else return ()) cases
+  if null fails then putStrLn (\"ALL \" ++ show (length cases) ++ \" PASS\") else putStrLn (show (length fails) ++ \" FAILURES\")
+").


### PR DESCRIPTION
## Summary

Ports the shared `wam_clause_chain` front-end (lowering type **T5**) to the **Haskell** lowered emitter, following Scala (#2901), Rust (#2907) and Go (#2920, #2925).

A multi-clause predicate whose clauses discriminate on a **distinct first-argument constant** now lowers **all** of its clauses to native Haskell, selected by a deref-and-match cascade, instead of lowering only clause 1 and reaching clauses 2+ through the interpreter on backtrack. When the first argument is **bound** this is deterministic dispatch with no interpreter hop; when it is **unbound** it defers to the interpreter via the same choice-point / backtrack / run fallback the ordinary multi-clause path already uses (which enumerates every clause, binding the variable in turn).

```haskell
lowered_color_1 !ctx s_init =
  case derefVar (wsBindings s_init) <$> IM.lookup 1 (wsRegs s_init) of
    Just (Unbound _) -> t5fallback
    Just v
      | v == (Atom 16) -> t5clause_1 s_init
      | v == (Atom 17) -> t5clause_2 s_init
      | v == (Atom 18) -> t5clause_3 s_init
      | otherwise -> Nothing
    _ -> t5fallback
  where
    t5fallback = ...   -- push CP at clause 2, try clause 1, backtrack into run
    t5clause_1 s_c1 = do ...   -- FULL clause body (leading get_constant kept)
    ...
```

Each clause body is emitted in **full** (its leading `get_constant` is kept), so it re-matches harmlessly on the bound fast path and is exactly what binds the variable on the unbound fallback — the only thing T5 changes is *how* the matching clause is reached.

## Changes

- **`wam_haskell_lowered_emitter.pl`**
  - Import `clause_chain/2`.
  - `emit_func_t5/4`, hooked ahead of the ordinary multi/single-clause emit in `emit_func`. All checks run **before** any output, so a non-T5 predicate leaves the stream untouched for the existing emission path.
  - Helpers: `t5_split_clauses_pc` / `t5_collect_clause_pc` / `t5_slice_discriminator` / `t5_emit_dispatch_guards` / `t5_emit_clause_defs`.
  - **Bug fix (get_structure / put_structure functor interning):** intern the **full** functor string (e.g. `"+/2"`), matching the interpreter codegen in `wam_haskell_target`. The lowered and interpreted paths share one runtime intern table, so interning the bare `"+"` gave the built structure a *different* id than the table's `"+/2"` — `evalArith`'s `lookupAtom` then resolved the wrong name and `is/2` over a built structure always failed. This is what lets op/2's rule chain work end-to-end; it also fixes single-clause arithmetic predicates that build a structure.

- **`tests/test_wam_haskell_lowered_t5.pl`** — GHC exec test:
  - `color/1` (fact chain), `sz/2` (head-match remainder), `op/2` (`is/2` rule chain) compile and run.
  - 14 ground queries with a **bound** first arg exercise every clause incl. the non-first ones (green/blue, medium/large, mul/neg) plus no-match cases.
  - The harness builds the context with `wcInternTable = compileTimeAtomTable` so `evalArith` can resolve the `+/2` operator (`mkContext` defaults the table to empty).

## Verification

- New `test_wam_haskell_lowered_t5`: **ALL 14 PASS** under real `ghc`.
- No regression: `test_wam_haskell_lowered_phase1/2/3`, `test_wam_haskell_lowered_ite_exec`, `test_haskell_target`, `test_wam_haskell_csr_smoke`, `test_wam_haskell_iso_smoke` all pass.
- `test_wam_haskell_lowered_phase4` and `test_wam_haskell_target` report the **same result as on clean main** (a harness-invocation artifact when run via `-g run_tests` — their internal assertions pass, e.g. phase4 is 12 PASS / 0 FAIL — not a code regression).

## Note

Generated code only ever sets the context intern table to `emptyInternTable` (`mkContext`), so structure-based `is/2` arithmetic needs the *driver* to supply the atom table — in both interpreter and lowered modes. That's a pre-existing gap in the generated bench harness (its predicates avoid structure-arithmetic); this PR's test wires the table itself, the correct way to drive the lowered functions.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_