### PR TITLE
feat(wam-fsharp): wire bidirectional native benchmark loop end-to-end

### DIFF
--- a/templates/targets/fsharp_wam/program.fs.mustache
+++ b/templates/targets/fsharp_wam/program.fs.mustache
@@ -338,6 +338,37 @@ let main argv =
     // depth=1) so the result matches the dispatched path exactly.
     let maxDepthCfg = Map.tryFind "max_depth" ctx.WcForeignConfig |> Option.defaultValue 10
     let lookupFn = lmdbLookupFn
+{{match kernel_kind}}
+{{case bidirectional_ancestor}}
+    // Bidirectional kernel setup (hoisted out of the rep loop):
+    //   lookupParents = lmdbLookupFn (the LMDB category_parent fast path
+    //     already configured for the selected materialisation mode above)
+    //   lookupChildren = CSR cursor over category_child (the bidir kernel
+    //     walks DOWN as well as up; without it the descent direction is
+    //     dead and bidirectional degenerates to upward-only)
+    //   parentStepCost / childStepCost / costBudget = mirror the hardcoded
+    //     dispatch defaults in WamRuntime.fs's executeForeign
+    //     "category_ancestor/4" branch (parent=1.0, child=3.0, budget=10.0)
+    //     so the native benchmark loop's timing is directly comparable to
+    //     the WAM-dispatched path.
+{{#has_csr}}
+    let csrChildBidir =
+        CsrReader.CsrLookupSource(System.IO.Path.Combine(factsDir, "csr"), "category_child")
+        :> ILookupSource
+    let lookupChildrenBidir (k: int) : int list = csrChildBidir.Lookup k
+{{/has_csr}}
+{{^has_csr}}
+    // No CSR artifact present: downward direction is dead.  The kernel
+    // will still run but will only explore upward edges — i.e. degenerates
+    // to category_ancestor-shaped traversal.  Documented degradation,
+    // not a build failure.
+    let lookupChildrenBidir (_: int) : int list = []
+{{/has_csr}}
+    let lookupParentsBidir : int -> int list = lmdbLookupFn
+    let parentStepCost = 1.0
+    let childStepCost = 3.0
+    let costBudget = 10.0
+{{/match}}
     for rep = 1 to numReps do
         let querySw = Stopwatch.StartNew()
         let mutable repSolutions = 0
@@ -348,24 +379,16 @@ let main argv =
             let hits = nativeKernel_category_ancestor lookupFn cat rootInt maxDepthCfg 1 [ cat ]
             if not (List.isEmpty hits) then repSolutions <- repSolutions + 1
 {{case bidirectional_ancestor}}
-        // bidirectional_ancestor: LMDB fast path not yet wired in this template.
-        //
-        // The bidirectional kernel takes (lookupParents, lookupChildren, cat,
-        // root, parentCost, childCost, budget) — different signature than
-        // category_ancestor. Setting up lookupChildren requires CSR cursor
-        // resolution that's currently scoped inside WamRuntime.fs's
-        // executeForeign / resolveFactLookup path. Mirroring that setup into
-        // Program.fs's benchmark scope is tracked as future work.
-        //
-        // In the meantime, the bidirectional kernel still runs correctly via
-        // the WAM dispatch path (WamRuntime.fs) when invoked through normal
-        // predicate-call infrastructure. The benchmark loop here emits zero
-        // stats so the project builds without referencing nativeKernel_*
-        // mismatched signatures.
-        for _cat in seedInts do
-            // TODO: implement bidirectional native benchmark loop with
-            // lookupParents + lookupChildren + cost configuration
-            ()
+        // bidirectional_ancestor native benchmark loop (LMDB parents + CSR children).
+        // Mirrors WamRuntime.fs executeForeign's "category_ancestor/4"
+        // bidirectional dispatch; setup is hoisted above the rep loop.
+        for cat in seedInts do
+            let hits =
+                nativeKernel_bidirectional_ancestor
+                    lookupParentsBidir lookupChildrenBidir
+                    cat rootInt
+                    parentStepCost childStepCost costBudget
+            if not (List.isEmpty hits) then repSolutions <- repSolutions + 1
 {{default}}
         // Unknown kernel kind: skip the native benchmark loop.
         for _cat in seedInts do

--- a/tests/core/test_wam_fsharp_bidirectional_e2e.pl
+++ b/tests/core/test_wam_fsharp_bidirectional_e2e.pl
@@ -18,9 +18,16 @@
 :- use_module(library(process)).
 
 run_cmd(Prog, Args, Dir, ExitCode, OutText) :-
+    run_cmd_env(Prog, Args, Dir, [], ExitCode, OutText).
+
+%% run_cmd_env/6: like run_cmd but with environment variable overrides
+%% (used to set DOTNET_ROLL_FORWARD=Major for the dotnet run step
+%% so a host with only net9 installed can still execute a net8 binary).
+run_cmd_env(Prog, Args, Dir, EnvOverrides, ExitCode, OutText) :-
     setup_call_cleanup(
         process_create(path(Prog), Args,
                        [cwd(Dir),
+                        environment(EnvOverrides),
                         stdout(pipe(Out)),
                         stderr(pipe(Err)),
                         process(PID)]),
@@ -49,12 +56,18 @@ run_cmd(Prog, Args, Dir, ExitCode, OutText) :-
 :- assertz(user:max_depth(10)).
 
 main :-
-    LmdbDir = '/tmp/uw_fsharp_bidir_e2e_lmdb',
-    CsrDir  = '/tmp/uw_fsharp_bidir_e2e_csr',
+    %% Layout: factsRoot/{lmdb,csr,article_category.tsv,root_ids.txt}
+    %% is what the generated Program.fs expects (factsDir/lmdb,
+    %% factsDir/csr subdirs + TSV bridge files at the root).  We
+    %% generate LMDB and CSR directly into the right subdirectories
+    %% so no symlinking is needed.
+    FactsRoot  = '/tmp/uw_fsharp_bidir_e2e_facts',
+    LmdbDir    = '/tmp/uw_fsharp_bidir_e2e_facts/lmdb',
+    CsrDir     = '/tmp/uw_fsharp_bidir_e2e_facts/csr',
     ProjectDir = '/tmp/uw_fsharp_bidir_e2e_proj',
-    catch(delete_directory_and_contents(LmdbDir), _, true),
-    catch(delete_directory_and_contents(CsrDir), _, true),
+    catch(delete_directory_and_contents(FactsRoot), _, true),
     catch(delete_directory_and_contents(ProjectDir), _, true),
+    make_directory_path(FactsRoot),
 
     %% Step 1: Generate LMDB fixture (small scale for fast test)
     format('Step 1: Generating LMDB fixture (50 parents x 4 children)...~n'),
@@ -145,12 +158,8 @@ main :-
     ;   format('  Program.fs does NOT reference nativeKernel_category_ancestor (correct): OK~n')
     ),
 
-    %% Step 8: Run dotnet build — should now succeed thanks to the
-    %% parameterised {{match kernel_kind}} block in program.fs.mustache.
-    %% The bidirectional benchmark loop is a stub (zero-stat) until a
-    %% follow-up PR wires lookupParents/lookupChildren into the
-    %% benchmark scope; the build verification here proves the
-    %% kernel-kind parameterisation produced compilable F#.
+    %% Step 8: Run dotnet build — succeeds thanks to the parameterised
+    %% {{match kernel_kind}} block in program.fs.mustache.
     format('Step 5: Running dotnet build (should succeed with parameterised template)...~n'),
     run_cmd(dotnet,
             ['build', '--nologo', '-v', 'minimal', '-c', 'Release'],
@@ -160,7 +169,64 @@ main :-
     ;   format('  dotnet build FAILED:~n~w~n', [BuildOut]), halt(1)
     ),
 
+    %% Step 9: Write the TSV bridge files Program.fs needs at runtime.
+    %% The synthetic Phase-1 generator only populates LMDB; Program.fs
+    %% reads seeds from article_category.tsv (col2 = LMDB int id) and
+    %% the root from root_ids.txt.  The synthetic fixture's id
+    %% convention is: parents 1..50, children 51..250 (4 children per
+    %% parent: children 51..54 -> parent 1, 55..58 -> parent 2, ...).
+    %% Seed 5 distinct child ids; pick parent 1 as the root.  Expected:
+    %% the first 4 seeds (children of parent 1) find parent 1 via the
+    %% upward direction; the 5th (child of parent 2) reaches parent 1
+    %% only if the descent direction connects parent-2's subtree to
+    %% parent 1's subtree, which it doesn't in this disjoint synthetic
+    %% topology.  Expected solutions=4.
+    format('Step 6: Writing TSV bridge files (article_category.tsv, root_ids.txt)...~n'),
+    directory_file_path(FactsRoot, 'article_category.tsv', AcTsv),
+    setup_call_cleanup(
+        open(AcTsv, write, AcOut, [encoding(utf8)]),
+        format(AcOut, 'a1\t51~na2\t52~na3\t53~na4\t54~na5\t55~n', []),
+        close(AcOut)),
+    directory_file_path(FactsRoot, 'root_ids.txt', RootTxt),
+    setup_call_cleanup(
+        open(RootTxt, write, RootOut, [encoding(utf8)]),
+        format(RootOut, '1~n', []),
+        close(RootOut)),
+
+    %% Step 10: Run the binary against the staged factsRoot.  Use
+    %% DOTNET_ROLL_FORWARD=Major so a host with only net9 installed
+    %% can still execute the net8-targeted binary (which is what the
+    %% generated .fsproj currently asks for).
+    format('Step 7: Running dotnet run (binary executes bidirectional native benchmark)...~n'),
+    run_cmd_env(dotnet,
+                ['run', '--no-build', '-c', 'Release', '--',
+                 FactsRoot, '2'],
+                ProjectDir,
+                ['DOTNET_ROLL_FORWARD'='Major'],
+                RunExit, RunOut),
+    format('  --- run output ---~n~w~n  --- end ---~n', [RunOut]),
+    (   RunExit == 0
+    ->  format('  binary exited cleanly: OK~n')
+    ;   format('  binary FAILED (exit ~w)~n', [RunExit]), halt(1)
+    ),
+
+    %% Step 11: Assert the benchmark loop actually produced solutions
+    %% via the native bidirectional kernel.  A zero-solutions result
+    %% would mean either the {{case}} fell through to a stub, the
+    %% lookupChildren wasn't wired correctly, or the kernel's
+    %% upward direction wasn't being called at all.
+    (   sub_string(RunOut, _, _, _, "solutions=4")
+    ->  format('  bidirectional kernel produced 4 solutions (expected 4 of 5 seeds): OK~n')
+    ;   sub_string(RunOut, _, _, _, "solutions=0")
+    ->  format('  bidirectional kernel produced 0 solutions — wiring is broken~n'),
+        halt(1)
+    ;   %% Some other non-zero count — log it but accept it as a
+        %% non-regression signal (e.g. if the synthetic fixture changes
+        %% topology, the exact count may drift).
+        format('  bidirectional kernel produced non-zero solutions (count differs from 4 — re-check fixture topology)~n')
+    ),
+
     format('~n=== All checks passed ===~n'),
     format('Bidirectional kernel E2E: kernel detection, template rendering,~n'),
     format('calibration, A* pruning, weighted metric, parameterised Program.fs,~n'),
-    format('and dotnet build — all verified.~n').
+    format('dotnet build, AND dotnet run with non-zero solutions — all verified.~n').


### PR DESCRIPTION
  ## Summary
  - Replace the zero-stat bidirectional stub in `program.fs.mustache` with a real `nativeKernel_bidirectional_ancestor`
  call (setup hoisted above the rep loop)
  - `test_wam_fsharp_bidirectional_e2e.pl` now exercises `dotnet run` against a staged factsRoot and asserts non-zero
  solutions, not just `dotnet build`
  - `run_cmd_env/6` added so the run step can set `DOTNET_ROLL_FORWARD=Major` on hosts without net8

  ## Test plan
  - [x] 168 RES + recurrence_inputs unit tests pass
  - [x] `test_wam_fsharp_strategy_autoselect_e2e` (safe default + dotnet build): pass
  - [x] `test_wam_fsharp_bidirectional_e2e` (codegen + build + `dotnet run` with `solutions=4` on synthetic): pass

  ## Notes for book-18 ch9/ch10 follow-up
  - `calibrateGraph` runs per kernel call in both WAM-dispatch and native paths — no per-benchmark calibration cache
  - Cost defaults (parent=1, child=3, budget=10) are hardcoded in the dispatch template, not selector-driven — if
  chapters claim selector-driven costs, this gap should be acknowledged or closed