### PR TITLE
Add T5 first-argument clause-chain lowering for F#

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
@@ -30,6 +30,7 @@
 
 :- use_module(library(lists)).
 :- use_module(wam_ite_structurer, [structure_ite/2]).
+:- use_module(wam_clause_chain, [clause_chain/2]).
 
 % ============================================================================
 % Parsing — identical to Haskell emitter (WAM text format is target-agnostic)
@@ -242,7 +243,9 @@ emit_func_fs(FN, PCInstrs, LabelMap, ForeignPreds) :-
     % Skip all switch_on_constant* prefixes before deciding whether this is
     % a multi-clause or single-clause lowered body.
     strip_switch_prefixes_fs(PCInstrs, PCInstrs1),
-    (   PCInstrs1 = [pc(_, try_me_else(LStr))|BodyPCs]
+    (   emit_func_t5_fs(PCInstrs1, LabelMap, ForeignPreds)
+    ->  true   % T5 first-argument dispatch (all clauses lowered natively)
+    ;   PCInstrs1 = [pc(_, try_me_else(LStr))|BodyPCs]
     ->  % Multi-clause: push CP for clause-2+ backtrack, try clause 1
         atom_string(LAtom, LStr),
         (   member(LAtom-AltPC, LabelMap) -> true ; AltPC = 0 ),
@@ -276,6 +279,121 @@ take_to_proceed_pc_fs([], []).
 take_to_proceed_pc_fs([pc(PC, proceed)|_], [pc(PC, proceed)]) :- !.
 take_to_proceed_pc_fs([pc(PC, fail)|_], [pc(PC, fail)]) :- !.
 take_to_proceed_pc_fs([H|T], [H|R]) :- take_to_proceed_pc_fs(T, R).
+
+% ============================================================================
+% T5: multi-clause as a first-argument dispatch (wam_clause_chain)
+%
+%  When the clauses discriminate on a DISTINCT first-argument constant
+%  (lowering type T5 in docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md)
+%  ALL clauses are lowered to native F# and selected by a deref-and-match
+%  cascade, instead of lowering only clause 1 and reaching clauses 2+ through
+%  the interpreter on backtrack. When the first argument is BOUND this is
+%  deterministic dispatch with no interpreter hop; when it is UNBOUND (or the
+%  register is unset) we defer to the interpreter via the same choice-point /
+%  backtrack / run fallback the ordinary multi-clause path uses.
+%
+%  Each clause body is emitted in FULL (the leading `get_constant V, A1` is
+%  kept): on the bound fast path it harmlessly re-matches the already-bound
+%  first argument, and on the unbound fallback it is exactly what binds the
+%  variable. Mirrors the Haskell emitter's emit_func_t5/4.
+% ============================================================================
+
+%% emit_func_t5_fs(+PCInstrs1, +LabelMap, +FP) is semidet.
+%  Emits the T5 dispatch body and succeeds, or fails (emitting nothing) when
+%  the predicate is not a distinct-first-argument constant chain. All checks
+%  run before any output, so a failure leaves the stream untouched for the
+%  caller's ordinary multi/single-clause emission.
+emit_func_t5_fs(PCInstrs1, LabelMap, FP) :-
+    PCInstrs1 = [pc(_, try_me_else(L2Str))|_],
+    maplist(t5_strip_pc_fs, PCInstrs1, PlainInstrs),
+    clause_chain(PlainInstrs, chain(_Guards)),
+    t5_split_clauses_pc_fs(PCInstrs1, Slices),
+    Slices = [_, _ | _],
+    forall(( member(Sl, Slices), member(pc(_, In), Sl) ), supported_fs(In)),
+    maplist(t5_slice_discriminator_fs, Slices, Discrs),
+    % All checks passed — emit.
+    atom_string(L2Atom, L2Str),
+    ( member(L2Atom-AltPC, LabelMap) -> true ; AltPC = 0 ),
+    t5_emit_clause_defs_fs(Slices, 1, LabelMap, FP),
+    % Interpreter fallback for the unbound/unset first-argument case.
+    format("    let t5fallback () : WamState option =~n"),
+    format("        let s_cp =~n"),
+    format("            { s_init with~n"),
+    format("                WsCPs    = { CpNextPC   = ~w~n", [AltPC]),
+    format("                             CpRegs     = s_init.WsRegs~n"),
+    format("                             CpStack    = s_init.WsStack~n"),
+    format("                             CpCP       = s_init.WsCP~n"),
+    format("                             CpTrailLen = s_init.WsTrailLen~n"),
+    format("                             CpHeapLen  = s_init.WsHeapLen~n"),
+    format("                             CpBindings = s_init.WsBindings~n"),
+    format("                             CpCutBar   = s_init.WsCutBar~n"),
+    format("                             CpB0StackLen = List.length s_init.WsB0Stack~n"),
+    format("                             CpAggFrame = None~n"),
+    format("                             CpBuiltin  = None } :: s_init.WsCPs~n"),
+    format("                WsCPsLen = s_init.WsCPsLen + 1 }~n"),
+    format("        match t5clause_1 s_cp with~n"),
+    format("        | Some result -> Some result~n"),
+    format("        | None ->~n"),
+    format("            backtrack s_cp |> Option.bind (fun s_bt -> run ctx { s_bt with WsPC = s_bt.WsPC + 1 })~n"),
+    % Dispatch: deref the first argument once, then select.
+    format("    match (getReg 1 s_init |> Option.map (derefVar s_init.WsBindings)) with~n"),
+    format("    | Some (Unbound _) -> t5fallback ()~n"),
+    format("    | Some v ->~n"),
+    t5_emit_dispatch_arms_fs(Discrs, 1),
+    format("    | None -> t5fallback ()~n").
+
+t5_strip_pc_fs(pc(_, I), I).
+
+%% t5_split_clauses_pc_fs(+PCInstrs1, -Slices)
+%  Split the switch-stripped pc-instruction list (opens with try_me_else) at
+%  the choice-point separators into per-clause slices, each trimmed to its
+%  terminal proceed/fail. Mirrors wam_clause_chain's split_clauses but keeps
+%  the pc(PC,Instr) wrappers for emission.
+t5_split_clauses_pc_fs([pc(_, try_me_else(_))|Rest], [Slice|More]) :-
+    t5_collect_clause_pc_fs(Rest, Clause, After),
+    take_to_proceed_pc_fs(Clause, Slice),
+    t5_split_more_pc_fs(After, More).
+
+t5_split_more_pc_fs([], []).
+t5_split_more_pc_fs([pc(_, retry_me_else(_))|Rest], [Slice|More]) :- !,
+    t5_collect_clause_pc_fs(Rest, Clause, After),
+    take_to_proceed_pc_fs(Clause, Slice),
+    t5_split_more_pc_fs(After, More).
+t5_split_more_pc_fs([pc(_, trust_me)|Rest], [Slice|More]) :- !,
+    t5_collect_clause_pc_fs(Rest, Clause, After),
+    take_to_proceed_pc_fs(Clause, Slice),
+    t5_split_more_pc_fs(After, More).
+
+t5_collect_clause_pc_fs([], [], []).
+t5_collect_clause_pc_fs([pc(P, retry_me_else(L))|Rest], [], [pc(P, retry_me_else(L))|Rest]) :- !.
+t5_collect_clause_pc_fs([pc(P, trust_me)|Rest], [], [pc(P, trust_me)|Rest]) :- !.
+t5_collect_clause_pc_fs([Item|Rest], [Item|More], After) :-
+    t5_collect_clause_pc_fs(Rest, More, After).
+
+%% t5_slice_discriminator_fs(+Slice, -FSharpValueExpr)
+t5_slice_discriminator_fs([pc(_, get_constant(VStr, _A1))|_], FC) :-
+    val_fs(VStr, FC).
+
+%% t5_emit_clause_defs_fs(+Slices, +Index, +LabelMap, +FP)
+t5_emit_clause_defs_fs([], _, _, _).
+t5_emit_clause_defs_fs([Slice|Rest], N, LabelMap, FP) :-
+    format("    let t5clause_~w (s_c~w: WamState) : WamState option =~n", [N, N]),
+    format(atom(SV), 's_c~w', [N]),
+    emit_clause_struct_fs(Slice, LabelMap, SV, "        ", FP),
+    N1 is N + 1,
+    t5_emit_clause_defs_fs(Rest, N1, LabelMap, FP).
+
+%% t5_emit_dispatch_arms_fs(+Discrs, +Index)
+%  Emit the bound-value if/elif cascade inside the `| Some v ->` arm.
+t5_emit_dispatch_arms_fs([FC|Rest], 1) :- !,
+    format("        if v = (~w) then t5clause_1 s_init~n", [FC]),
+    t5_emit_dispatch_arms_fs(Rest, 2).
+t5_emit_dispatch_arms_fs([], _) :- !,
+    format("        else None~n").
+t5_emit_dispatch_arms_fs([FC|Rest], N) :-
+    format("        elif v = (~w) then t5clause_~w s_init~n", [FC, N]),
+    N1 is N + 1,
+    t5_emit_dispatch_arms_fs(Rest, N1).
 
 % ============================================================================
 % Instruction emission — F# binding chain style

--- a/tests/test_wam_fsharp_lowered_t5.pl
+++ b/tests/test_wam_fsharp_lowered_t5.pl
@@ -1,0 +1,140 @@
+% test_wam_fsharp_lowered_t5.pl
+%
+% End-to-end execution test for the F# T5 lowering — "multi-clause as a
+% first-argument dispatch" (lowering type T5 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md), ported from the
+% Scala/Rust/Go/Haskell emitters via the shared wam_clause_chain front-end.
+%
+% A predicate whose clauses discriminate on a DISTINCT first-argument
+% constant now lowers ALL of its clauses to native F#, selected by a
+% deref-and-match cascade, instead of lowering only clause 1 and reaching
+% clauses 2+ through the interpreter on backtrack. When the first argument is
+% bound this is deterministic dispatch with no interpreter hop; when it is
+% unbound it defers to the interpreter via the same choice-point / backtrack /
+% run fallback the ordinary multi-clause path uses.
+%
+% Pins (the cases preload a BOUND first arg, exercising every clause incl. the
+% non-first ones — the T5 payoff):
+%   * color/1 — fact chain, atom discriminators;
+%   * sz/2    — fact chain with a second head match in each remainder;
+%   * op/2    — RULE chain (each remainder runs an is/2 builtin).
+%
+% Skipped automatically when `dotnet` is not on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_fsharp_target').
+
+:- dynamic user:color/1.
+:- dynamic user:sz/2.
+:- dynamic user:op/2.
+
+user:color(red).
+user:color(green).
+user:color(blue).
+
+user:sz(small, 1).
+user:sz(medium, 2).
+user:sz(large, 3).
+
+user:op(add, R) :- R is 1 + 1.
+user:op(mul, R) :- R is 2 * 3.
+user:op(neg, R) :- R is 0 - 1.
+
+dotnet_available :-
+    catch(( process_create(path(dotnet), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_fsharp_lowered_t5, [condition(dotnet_available)]).
+
+test(t5_exec_parity) :-
+    Dir = 'output/test_wam_fsharp_t5_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    % 1. Generate the WAM F# project with the lowered emitter enabled.
+    write_wam_fsharp_project(
+        [user:color/1, user:sz/2, user:op/2],
+        [module_name('t5proj'), emit_mode(functions)], Dir),
+    % Sanity: the generated lowered code must be the T5 dispatch.
+    atomic_list_concat([Dir, '/Lowered.fs'], LoweredPath),
+    ( exists_file(LoweredPath) -> read_file_to_string(LoweredPath, LSrc, []) ; LSrc = "" ),
+    assertion(sub_string(LSrc, _, _, _, "t5fallback")),
+    % 2. Replace the generated bench Program.fs with a harness calling the
+    %    lowered functions directly (bound first arg).
+    atomic_list_concat([Dir, '/Program.fs'], ProgPath),
+    fsharp_t5_source(Src),
+    setup_call_cleanup(open(ProgPath, write, S), write(S, Src), close(S)),
+    % 3. Compile + run.
+    format(atom(Cmd),
+        'cd ~w && DOTNET_CLI_TELEMETRY_OPTOUT=1 DOTNET_NOLOGO=1 dotnet run --project t5proj.fsproj -c Release 2>&1',
+        [Dir]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 14 PASS")
+    ->  true
+    ;   format(user_error, "~n[fsharp t5 test output]~n~w~n", [OutStr]),
+        throw(fsharp_t5_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_fsharp_lowered_t5).
+
+% Builds a minimal WamContext/WamState, sets the A-registers with a BOUND
+% first arg, calls each lowered function, and checks Some/None. F# atoms are
+% plain strings (Atom of string), so no atom-id coordination is needed. The
+% cases exercise every clause including the non-first ones (green/blue,
+% medium/large, mul/neg) — the T5 payoff — plus the no-match cases.
+fsharp_t5_source(
+"module Program
+
+open WamTypes
+open WamRuntime
+open Lowered
+
+let testEmptyState =
+    { WsPC = 0; WsRegs = Array.create MaxRegs (Unbound -1); WsStack = []
+      WsHeap = []; WsHeapLen = 0; WsTrail = []; WsTrailLen = 0
+      WsCP = 0; WsCPs = []; WsCPsLen = 0; WsBindings = Map.empty
+      WsCutBar = 0; WsVarCounter = 0; WsBuilder = None; WsBuilderStack = []
+      WsAggAccum = []; WsB0Stack = []; WsCatchers = [] }
+
+let testCtx : WamContext =
+    { WcCode = [||]; WcLabels = Map.empty; WcForeignFacts = Map.empty
+      WcFfiFacts = Map.empty; WcFfiWeightedFacts = Map.empty
+      WcAtomIntern = Map.empty; WcAtomDeintern = Map.empty
+      WcForeignConfig = Map.empty; WcLoweredPredicates = loweredPredicates
+      WcLookupSources = Map.empty; WcCancellationToken = None }
+
+let runP (f: WamContext -> WamState -> WamState option) (regs: (int * Value) list) : bool =
+    let arr = Array.create MaxRegs (Unbound -1)
+    regs |> List.iter (fun (idx, v) -> arr.[idx] <- v)
+    let s0 = { testEmptyState with WsRegs = arr }
+    match f testCtx s0 with Some _ -> true | None -> false
+
+let i (n: int) : Value = Integer n
+let a (s: string) : Value = Atom s
+
+[<EntryPoint>]
+let main _argv =
+    let cases : (string * bool * bool) list =
+        [ (\"color(red)\", runP lowered_color_1 [(1, a \"red\")], true)
+          (\"color(green)\", runP lowered_color_1 [(1, a \"green\")], true)
+          (\"color(blue)\", runP lowered_color_1 [(1, a \"blue\")], true)
+          (\"color(yellow)\", runP lowered_color_1 [(1, a \"yellow\")], false)
+          (\"sz(small,1)\", runP lowered_sz_2 [(1, a \"small\"); (2, i 1)], true)
+          (\"sz(medium,2)\", runP lowered_sz_2 [(1, a \"medium\"); (2, i 2)], true)
+          (\"sz(large,3)\", runP lowered_sz_2 [(1, a \"large\"); (2, i 3)], true)
+          (\"sz(small,2)\", runP lowered_sz_2 [(1, a \"small\"); (2, i 2)], false)
+          (\"sz(big,1)\", runP lowered_sz_2 [(1, a \"big\"); (2, i 1)], false)
+          (\"op(add,2)\", runP lowered_op_2 [(1, a \"add\"); (2, i 2)], true)
+          (\"op(mul,6)\", runP lowered_op_2 [(1, a \"mul\"); (2, i 6)], true)
+          (\"op(neg,-1)\", runP lowered_op_2 [(1, a \"neg\"); (2, i -1)], true)
+          (\"op(add,3)\", runP lowered_op_2 [(1, a \"add\"); (2, i 3)], false)
+          (\"op(div,1)\", runP lowered_op_2 [(1, a \"div\"); (2, i 1)], false) ]
+    let fails = cases |> List.filter (fun (_, got, want) -> got <> want)
+    fails |> List.iter (fun (n, got, want) -> printfn \"FAIL %s: got %b want %b\" n got want)
+    if List.isEmpty fails then printfn \"ALL %d PASS\" (List.length cases); 0
+    else printfn \"%d FAILURES\" (List.length fails); 1
+").


### PR DESCRIPTION
## Summary

Ports the shared `wam_clause_chain` front-end (lowering type **T5**) to the **F#** lowered emitter, following Scala (#2901), Rust (#2907), Go (#2920, #2925) and Haskell (#2930).

A multi-clause predicate whose clauses discriminate on a **distinct first-argument constant** now lowers **all** of its clauses to native F#, selected by a deref-and-match cascade, instead of lowering only clause 1 and reaching clauses 2+ through the interpreter on backtrack. When the first argument is **bound** this is deterministic dispatch with no interpreter hop; when it is **unbound** it defers to the interpreter via the same choice-point / backtrack / run fallback the ordinary multi-clause path already uses.

```fsharp
let lowered_color_1 (ctx: WamContext) (s_init: WamState) : WamState option =
    let t5clause_1 (s_c1: WamState) = ...   // FULL clause body (leading get_constant kept)
    let t5clause_2 ...
    let t5fallback () = ...                 // push CP at clause 2, try clause 1, backtrack into run
    match (getReg 1 s_init |> Option.map (derefVar s_init.WsBindings)) with
    | Some (Unbound _) -> t5fallback ()
    | Some v ->
        if v = (Atom "red") then t5clause_1 s_init
        elif v = (Atom "green") then t5clause_2 s_init
        elif v = (Atom "blue") then t5clause_3 s_init
        else None
    | None -> t5fallback ()
```

Each clause body is emitted in **full** (its leading `get_constant` is kept), so it re-matches harmlessly on the bound fast path and is exactly what binds the variable on the unbound fallback.

## Changes

- **`wam_fsharp_lowered_emitter.pl`**
  - Import `clause_chain/2`.
  - `emit_func_t5_fs/3`, hooked ahead of the ordinary multi/single-clause emit in `emit_func_fs`. All checks run **before** any output, so a non-T5 predicate leaves the stream untouched for the existing emission path.
  - Helpers: `t5_split_clauses_pc_fs` / `t5_collect_clause_pc_fs` / `t5_slice_discriminator_fs` / `t5_emit_clause_defs_fs` / `t5_emit_dispatch_arms_fs` (mirror the Haskell emitter's T5 helpers).
  - **No functor-interning fix needed here** (unlike Haskell #2930): F# represents structure functors as plain name strings (`Str (fn, args)`), shared by the interpreter codegen, the `put_structure` builder and `evalArith` (which matches bare `"+"`). So op/2's `is/2` rule chain works without any id coordination.

- **`tests/test_wam_fsharp_lowered_t5.pl`** — `dotnet` exec test:
  - `color/1` (fact chain), `sz/2` (head-match remainder), `op/2` (`is/2` rule chain) compile and run.
  - 14 ground queries with a **bound** first arg exercise every clause incl. the non-first ones (green/blue, medium/large, mul/neg) plus no-match cases.

## Verification

- New `test_wam_fsharp_lowered_t5`: **ALL 14 PASS** under real `dotnet` (8.0).
- No regression: `test_wam_fsharp_lowered_ite`, `test_wam_fsharp_lowered_ite_exec`, `test_wam_fsharp_target`, `test_wam_fsharp_iso_unit` all pass — the gate correctly leaves single-clause / ITE predicates on the existing path.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_