### PR TITLE
Add T5 first-argument clause-chain lowering for LLVM

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_llvm_lowered_emitter.pl
@@ -71,6 +71,7 @@
 :- use_module(library(option)).
 :- use_module('../bindings/llvm_wam_bindings', [reg_name_to_index/2]).
 :- use_module(wam_ite_structurer, [structure_ite/2]).
+:- use_module(wam_clause_chain, [clause_chain/2]).
 
 % NB: we DO NOT `:- use_module(wam_llvm_target, ...)` here, because
 % wam_llvm_target.pl `:- use_module`s this file in turn. The two
@@ -201,6 +202,21 @@ parse_lines_labeled([Line|Rest], Instrs) :-
 %                       bytecode (all clauses) through @run_loop.
 %                       Mirrors the F# emitter's multi-clause
 %                       approach (see wam_fsharp_lowered_emitter.pl).
+%
+%    clause_chain    — the clauses discriminate on a DISTINCT
+%                      first-argument constant (lowering type T5). ALL
+%                      clauses are lowered into one function as a
+%                      first-argument dispatch; an unbound first argument
+%                      defers to the full bytecode (which enumerates), so
+%                      this is wired up exactly like multi_clause_c1
+%                      (hybrid: native fast path + bytecode fallback).
+%                      Takes precedence over multi_clause_c1.
+wam_llvm_lowerable(_PI, WamCode, clause_chain) :-
+    (   is_list(WamCode) -> Instrs = WamCode
+    ;   atom(WamCode) -> parse_wam_text(WamCode, Instrs)
+    ;   parse_wam_text(WamCode, Instrs)
+    ),
+    llvm_clause_chain_lowerable(Instrs).
 wam_llvm_lowerable(_PI, WamCode, Shape) :-
     (   is_list(WamCode) -> Instrs = WamCode
     ;   atom(WamCode) -> parse_wam_text(WamCode, Instrs)
@@ -213,6 +229,7 @@ wam_llvm_lowerable(_PI, WamCode, Shape) :-
     -> Shape = multi_clause_c1
     ;  Shape = single_clause
     ).
+
 % ITE / negation / once: clause 1 contains an internal choice point
 % (try_me_else) that is NOT a multi-clause separator but a soft-cut block
 % emitted for ( Cond -> Then ; Else ) / \+ Goal / once/1. The base path
@@ -224,6 +241,15 @@ wam_llvm_lowerable(_PI, WamCode, Shape) :-
 wam_llvm_lowerable(_PI, WamCode, single_clause) :-
     llvm_structured_clause1(WamCode, Structured),
     forall(member(I, Structured), llvm_supported_structured(I)).
+
+%% llvm_clause_chain_lowerable(+Instrs) is semidet.
+%  True when the predicate is a distinct-first-argument-constant clause chain
+%  (T5) and every clause's remainder is a deterministic, supported body.
+llvm_clause_chain_lowerable(Instrs) :-
+    clause_chain(Instrs, chain(Guards)),
+    forall(member(guard(_, Rem), Guards),
+           ( is_deterministic_pred_llvm(Rem),
+             forall(member(I, Rem), supported(I)) )).
 
 %% llvm_structured_clause1(+WamCode, -Structured) is semidet.
 %
@@ -322,14 +348,15 @@ take_to_proceed([I|Rest], [I|Out]) :- take_to_proceed(Rest, Out).
 %  wam_llvm_lowerable/3.
 wam_llvm_lowerable_with_closure(PI, WamCode, ClosureSet, Shape) :-
     wam_llvm_lowerable(PI, WamCode, Shape),
-    % Extract the clause-1 body's call/execute targets and verify all
-    % are in the closure set.
+    % Extract the lowered body's call/execute targets and verify all are in
+    % the closure set. clause_chain lowers ALL clauses, so its closure must
+    % cover every clause's targets; the other shapes lower only clause 1.
     (   is_list(WamCode) -> Instrs = WamCode
     ;   atom(WamCode) -> parse_wam_text(WamCode, Instrs)
     ;   parse_wam_text(WamCode, Instrs)
     ),
-    clause1_instrs(Instrs, C1),
-    call_execute_targets(C1, Targets),
+    ( Shape == clause_chain -> Body = Instrs ; clause1_instrs(Instrs, Body) ),
+    call_execute_targets(Body, Targets),
     forall(member(T, Targets), memberchk(T, ClosureSet)).
 
 %% call_execute_targets(+Instrs, -Targets) is det.
@@ -430,6 +457,12 @@ llvm_safe_code(_, 0'_).
 % else takes the straight-line clause-1 path below, which is byte-for-byte
 % unchanged.
 lower_predicate_to_llvm(PI, WamCode, _Options, LLVMCode) :-
+    (   is_list(WamCode) -> CCInstrs = WamCode
+    ;   parse_wam_text(WamCode, CCInstrs)
+    ),
+    llvm_clause_chain_lowerable(CCInstrs), !,
+    lower_clause_chain_to_llvm(PI, CCInstrs, LLVMCode).
+lower_predicate_to_llvm(PI, WamCode, _Options, LLVMCode) :-
     llvm_structured_clause1(WamCode, Structured), !,
     lower_ite_predicate_to_llvm(PI, Structured, LLVMCode).
 lower_predicate_to_llvm(PI, WamCode, _Options, LLVMCode) :-
@@ -468,6 +501,109 @@ lowered_fail:
   ret i1 false
 }',
         [Pred, Arity, Arity, FuncName, BodyStr]).
+
+% ============================================================================
+% T5: multi-clause as a first-argument dispatch (wam_clause_chain)
+%
+%  The clauses discriminate on a DISTINCT first-argument constant, so at most
+%  one matches a *bound* first argument. We deref A1 once: if it is unbound we
+%  branch to %lowered_fail (the hybrid wrapper then re-runs the full bytecode,
+%  which enumerates every clause, binding A1 in turn). If it is bound, control
+%  flows through each clause's head get_constant — a mismatch branches to the
+%  NEXT clause's first block, a match runs that clause's body. A leaf failure
+%  or a fall-through past the last clause returns false (sound: distinct
+%  discriminators mean no other clause could have matched anyway, and the
+%  bytecode fallback then also fails).
+%
+%  Each clause is emitted in FULL (its leading get_constant is kept): on the
+%  matching fast path it re-confirms the already-bound value, and its mismatch
+%  edge is exactly what chains to the next clause. Block numbering is shared
+%  and monotonic across clauses (pc_<N>), so no labels collide.
+% ============================================================================
+
+%% lower_clause_chain_to_llvm(+PI, +Instrs, -LLVMCode) is det.
+lower_clause_chain_to_llvm(PI, Instrs, LLVMCode) :-
+    ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
+    llvm_lowered_func_name(Pred/Arity, FuncName),
+    parse_reg('A1', A1Idx),
+    llvm_split_clauses(Instrs, Clauses),
+    emit_clause_chain_blocks(Clauses, 0, ClauseBlocksList),
+    atomic_list_concat(ClauseBlocksList, '\n\n', BodyStr),
+    format(atom(LLVMCode),
+'; === lowered kernel (T5 first-argument dispatch): ~w/~w ===
+; All clauses are lowered into one function. The dispatcher derefs A1 once;
+; an unbound first argument branches to %lowered_fail so the hybrid wrapper
+; re-runs the full bytecode (which enumerates every clause). A bound A1 flows
+; through a chain of get_constant heads: a non-matching head branches to the
+; next clause, the matching head runs its body.
+define i1 @~w(%WamState* %vm) {
+entry:
+  br label %t5_dispatch
+
+t5_dispatch:
+  %t5.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 ~w)
+  %t5.unb = call i1 @value_is_unbound(%Value %t5.a1)
+  br i1 %t5.unb, label %lowered_fail, label %pc_0
+
+~w
+
+lowered_succeed:
+  ret i1 true
+
+lowered_fail:
+  ret i1 false
+}',
+        [Pred, Arity, FuncName, A1Idx, BodyStr]).
+
+%% emit_clause_chain_blocks(+Clauses, +StartN, -BlocksList) is det.
+%  Emit each clause's basic blocks. The clause's leading instruction (its head
+%  get_constant) is emitted via emit_instr_f so its failure edge points at the
+%  next clause's first block (pc_<NextStartN>) instead of %lowered_fail; the
+%  rest of the clause body emits normally (failures → %lowered_fail). Block
+%  numbers run monotonically across clauses so nothing collides.
+emit_clause_chain_blocks([], _, []).
+emit_clause_chain_blocks([Clause|Rest], StartN, [ClauseStr|More]) :-
+    Clause = [First|RestInstrs],
+    length(Clause, Len),
+    NextStartN is StartN + Len,
+    ( Rest == []
+    ->  FailLabel = lowered_fail
+    ;   format(atom(FailLabel), 'pc_~w', [NextStartN])
+    ),
+    ( RestInstrs == []
+    ->  NextWithin = lowered_succeed
+    ;   N1 is StartN + 1, format(atom(NextWithin), 'pc_~w', [N1])
+    ),
+    emit_instr_f(First, StartN, NextWithin, FailLabel, FirstBlock),
+    N2 is StartN + 1,
+    emit_all_instrs(RestInstrs, N2, RestBlocks),
+    atomic_list_concat([FirstBlock|RestBlocks], '\n', ClauseStr),
+    emit_clause_chain_blocks(Rest, NextStartN, More).
+
+%% llvm_split_clauses(+Instrs, -Clauses) is semidet.
+%  Split the parsed instruction list (which opens with try_me_else) at the
+%  choice-point separators into per-clause instruction lists, each trimmed to
+%  its terminal proceed/fail. Mirrors wam_clause_chain's split_clauses.
+llvm_split_clauses([try_me_else(_)|Rest], [Clause|More]) :-
+    llvm_collect_clause(Rest, C, After),
+    take_to_proceed(C, Clause),
+    llvm_split_more(After, More).
+
+llvm_split_more([], []).
+llvm_split_more([retry_me_else(_)|Rest], [Clause|More]) :- !,
+    llvm_collect_clause(Rest, C, After),
+    take_to_proceed(C, Clause),
+    llvm_split_more(After, More).
+llvm_split_more([trust_me|Rest], [Clause|More]) :- !,
+    llvm_collect_clause(Rest, C, After),
+    take_to_proceed(C, Clause),
+    llvm_split_more(After, More).
+
+llvm_collect_clause([], [], []).
+llvm_collect_clause([retry_me_else(L)|Rest], [], [retry_me_else(L)|Rest]) :- !.
+llvm_collect_clause([trust_me|Rest], [], [trust_me|Rest]) :- !.
+llvm_collect_clause([I|Rest], [I|More], After) :-
+    llvm_collect_clause(Rest, More, After).
 
 % ============================================================================
 % Structured (if-then-else / negation / once) emission

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1928,13 +1928,21 @@ pass1_classify_predicates([PredIndicator|Rest], Options, StartPC,
                BundledCode),
            Record = native(PredIndicator, Arity, BundledCode),
            NextPC = StartPC
-        ;  LowerShape == multi_clause_c1
-        -> format(user_error,
-            '  ~w/~w: lowered LLVM emission (hybrid clause-1 + bytecode)~n',
-            [Pred, Arity]),
+        ;  ( LowerShape == multi_clause_c1 ; LowerShape == clause_chain )
+        -> ( LowerShape == clause_chain
+           ->  format(user_error,
+                 '  ~w/~w: lowered LLVM emission (hybrid T5 first-arg dispatch + bytecode)~n',
+                 [Pred, Arity])
+           ;   format(user_error,
+                 '  ~w/~w: lowered LLVM emission (hybrid clause-1 + bytecode)~n',
+                 [Pred, Arity])
+           ),
            % Parse the WAM bytecode (all clauses) into the merge so the
            % dispatcher's slow path can run it. The dispatcher entry
            % is emitted in pass2 via emit_hybrid_dispatcher.
+           % clause_chain lowers ALL clauses as the fast path; the bytecode is
+           % still emitted so the unbound-first-arg case (which the lowered fn
+           % declines by returning false) is enumerated by @run_loop.
            %
            % Hybrid records use the bare Pred/Arity form (matching the
            % wam-record convention) so partition / resolve / dispatch

--- a/tests/test_wam_llvm_lowered_t5.pl
+++ b/tests/test_wam_llvm_lowered_t5.pl
@@ -1,0 +1,152 @@
+% test_wam_llvm_lowered_t5.pl
+%
+% End-to-end execution test for the LLVM T5 lowering — "multi-clause as a
+% first-argument dispatch" (lowering type T5 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md), ported from the
+% Scala/Rust/Go/Haskell/F# emitters via the shared wam_clause_chain front-end.
+%
+% A predicate whose clauses discriminate on a DISTINCT first-argument
+% constant now lowers ALL of its clauses into one LLVM function as a
+% first-argument dispatch, instead of lowering only clause 1 (multi_clause_c1)
+% and reaching clauses 2+ through the bytecode interpreter on backtrack. When
+% the first argument is bound this is deterministic dispatch with no
+% interpreter hop; when it is unbound the kernel returns false and the hybrid
+% wrapper re-runs the full bytecode (which enumerates every clause).
+%
+% Pins (the harness preloads a BOUND first arg, exercising every clause incl.
+% the non-first ones — the T5 payoff):
+%   * color/1 — fact chain, atom discriminators;
+%   * sz/2    — fact chain with a second head match in each remainder.
+%
+% op/2 (a RULE chain whose remainders run an is/2 over a built +/2 structure)
+% also lowers as the T5 dispatch — the test asserts @lowered_op_2 is emitted —
+% but it is NOT exercised at runtime: the LLVM lowered emitter's
+% put_structure/set_constant -> is/2 path is independently broken (a
+% single-clause `d(X,R):-R is X+X` lowered kernel also returns the wrong
+% result), a pre-existing limitation unrelated to T5. So op/2 is pinned for
+% EMISSION, while color/1 and sz/2 are pinned for EXECUTION.
+%
+% The C harness calls each lowered_<pred>_<arity>(%WamState*) kernel directly
+% on a fresh state with the argument registers set. Atom ids are read back
+% from the generated module's intern table via parse_constant/3, so the test
+% does not hard-code interning offsets. Skipped unless clang is on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../src/unifyweaver/targets/wam_llvm_lowered_emitter').
+
+:- dynamic user:color/1.
+:- dynamic user:sz/2.
+:- dynamic user:op/2.
+
+user:color(red).
+user:color(green).
+user:color(blue).
+
+user:sz(small, 1).
+user:sz(medium, 2).
+user:sz(large, 3).
+
+user:op(add, R) :- R is 1 + 1.
+user:op(mul, R) :- R is 2 * 3.
+user:op(neg, R) :- R is 0 - 1.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_llvm_lowered_t5, [condition(clang_available)]).
+
+test(t5_exec_parity) :-
+    Dir = 'output/test_wam_llvm_t5_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    make_directory_path(Dir),
+    atomic_list_concat([Dir, '/t5proj.ll'], LLPath),
+    % 1. Generate the WAM LLVM module with the lowered emitter enabled.
+    write_wam_llvm_project(
+        [user:color/1, user:sz/2, user:op/2],
+        [module_name('t5proj'), emit_mode(functions)], LLPath),
+    % Sanity: the three predicates must be lowered as the T5 dispatch.
+    read_file_to_string(LLPath, LLSrc, []),
+    forall(member(F, ['@lowered_color_1(', '@lowered_sz_2(', '@lowered_op_2(']),
+           assertion(sub_string(LLSrc, _, _, _, F))),
+    assertion(sub_string(LLSrc, _, _, _, "T5 first-argument dispatch")),
+    % 2. Read the interned atom ids the kernels compare against (color + sz;
+    %    op/2 is emission-only, see file header).
+    maplist(disc_id, [red, green, blue, small, medium, large],
+            [R, G, B, Sm, Md, Lg]),
+    % 3. Write the C harness.
+    atomic_list_concat([Dir, '/harness.c'], HPath),
+    harness_source(R, G, B, Sm, Md, Lg, HSrc),
+    setup_call_cleanup(open(HPath, write, S), write(S, HSrc), close(S)),
+    % 4. Compile + run.
+    atomic_list_concat([Dir, '/t5_test'], ExePath),
+    format(atom(Cmd),
+        'clang -w ~w ~w -o ~w -lm 2>&1 && ~w',
+        [HPath, LLPath, ExePath, ExePath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 9 PASS")
+    ->  true
+    ;   format(user_error, "~n[llvm t5 test output]~n~w~n", [OutStr]),
+        throw(llvm_t5_test_failed(Status))
+    ).
+
+:- end_tests(wam_llvm_lowered_t5).
+
+%% disc_id(+Atom, -Id) — the interned id the generated kernel compares against.
+disc_id(Atom, Id) :-
+    wam_llvm_lowered_emitter:parse_constant(Atom, 0, Id).
+
+% Calls each lowered kernel directly on a fresh %WamState with a BOUND first
+% argument. Exercises every clause incl. the non-first ones (green/blue,
+% medium/large) — the T5 payoff — plus the no-match cases (the no-match atom
+% id 999999 is never interned, so it matches no clause).
+harness_source(R, G, B, Sm, Md, Lg, Src) :-
+    format(atom(Src),
+"#include <stdio.h>
+typedef struct WamState WamState;
+extern WamState* wam_state_new(void* code, int n, int* labels, int nl);
+extern void wam_set_reg_int(WamState*, int, long);
+extern void wam_set_reg_atom_id(WamState*, int, long);
+extern unsigned char lowered_color_1(WamState*);
+extern unsigned char lowered_sz_2(WamState*);
+
+#define RED ~w
+#define GREEN ~w
+#define BLUE ~w
+#define SMALL ~w
+#define MEDIUM ~w
+#define LARGE ~w
+#define NOMATCH 999999
+
+static int fails = 0, total = 0;
+static WamState* mk(void){ return wam_state_new(0,0,0,0); }
+static int b(unsigned char r){ return r & 1; }
+static void check(const char* name, int got, int want){
+  total++;
+  if(got != want){ fails++; printf(\"FAIL %s: got %d want %d\\n\", name, got, want); }
+}
+
+int main(void){
+  WamState* s;
+  s=mk(); wam_set_reg_atom_id(s,0,RED);     check(\"color(red)\",    b(lowered_color_1(s)), 1);
+  s=mk(); wam_set_reg_atom_id(s,0,GREEN);   check(\"color(green)\",  b(lowered_color_1(s)), 1);
+  s=mk(); wam_set_reg_atom_id(s,0,BLUE);    check(\"color(blue)\",   b(lowered_color_1(s)), 1);
+  s=mk(); wam_set_reg_atom_id(s,0,NOMATCH); check(\"color(yellow)\", b(lowered_color_1(s)), 0);
+  s=mk(); wam_set_reg_atom_id(s,0,SMALL);  wam_set_reg_int(s,1,1); check(\"sz(small,1)\",  b(lowered_sz_2(s)), 1);
+  s=mk(); wam_set_reg_atom_id(s,0,MEDIUM); wam_set_reg_int(s,1,2); check(\"sz(medium,2)\", b(lowered_sz_2(s)), 1);
+  s=mk(); wam_set_reg_atom_id(s,0,LARGE);  wam_set_reg_int(s,1,3); check(\"sz(large,3)\",  b(lowered_sz_2(s)), 1);
+  s=mk(); wam_set_reg_atom_id(s,0,SMALL);  wam_set_reg_int(s,1,2); check(\"sz(small,2)\",  b(lowered_sz_2(s)), 0);
+  s=mk(); wam_set_reg_atom_id(s,0,NOMATCH);wam_set_reg_int(s,1,1); check(\"sz(big,1)\",    b(lowered_sz_2(s)), 0);
+
+  if(fails==0) printf(\"ALL %d PASS\\n\", total);
+  else printf(\"%d FAILURES\\n\", fails);
+  return fails ? 1 : 0;
+}
+",
+    [R, G, B, Sm, Md, Lg]).


### PR DESCRIPTION
## Summary

Ports the shared `wam_clause_chain` front-end (lowering type **T5**) to the **LLVM** lowered emitter, following Scala (#2901), Rust (#2907), Go (#2920, #2925), Haskell (#2930) and F# (#2934).

A multi-clause predicate whose clauses discriminate on a **distinct first-argument constant** now lowers **all** of its clauses into one LLVM function as a first-argument dispatch, instead of lowering only clause 1 (`multi_clause_c1`) and reaching clauses 2+ through the bytecode interpreter on backtrack.

```llvm
define i1 @lowered_color_1(%WamState* %vm) {
entry:
  br label %t5_dispatch
t5_dispatch:
  %t5.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
  %t5.unb = call i1 @value_is_unbound(%Value %t5.a1)
  br i1 %t5.unb, label %lowered_fail, label %pc_0   ; unbound → bytecode fallback
pc_0:    ; get_constant red ... mismatch → pc_2 (next clause), match → pc_1
pc_2:    ; get_constant green ... mismatch → pc_4
pc_4:    ; get_constant blue ... mismatch → lowered_fail
lowered_succeed: ret i1 true
lowered_fail:    ret i1 false
}
```

When the first argument is **bound** this is deterministic dispatch with no interpreter hop (clauses 2+ run natively — the T5 payoff); when it is **unbound** the kernel returns false and the existing **hybrid** wrapper re-runs the full bytecode, which enumerates every clause.

## Changes

- **`wam_llvm_lowered_emitter.pl`**
  - Import `clause_chain/2`; new Shape `clause_chain`, gated ahead of `multi_clause_c1` via `llvm_clause_chain_lowerable/1`.
  - `wam_llvm_lowerable_with_closure/4` checks call/execute targets across **all** clauses for `clause_chain` (it lowers every clause).
  - `lower_clause_chain_to_llvm/3` + `emit_clause_chain_blocks/3` + `llvm_split_clauses/2`: each clause is emitted in FULL, its head `get_constant` emitted via `emit_instr_f` so the mismatch edge chains to the next clause's first block; block numbers run monotonically across clauses so nothing collides. Reuses the existing per-instruction emitters verbatim.

- **`wam_llvm_target.pl`**: route `clause_chain` through the **same hybrid path** as `multi_clause_c1` (T5 kernel = native fast path + full bytecode for the `@run_loop` unbound-arg fallback).

- **`tests/test_wam_llvm_lowered_t5.pl`** — clang exec test. `color/1` and `sz/2` compile and run (9 ground queries, every clause incl. non-first, plus no-match). Atom ids are read back via `parse_constant/3` (no hard-coded interning offsets).

## Note on op/2

`op/2` (an `is/2` rule chain) is asserted to **emit** as the T5 dispatch but is **not executed**: the LLVM lowered `put_structure`/`set_constant` → `is/2` path is independently broken — a single-clause `d(X,R):-R is X+X` lowered kernel also returns the wrong result — a **pre-existing** limitation unrelated to T5 (it delegates to the C `@execute_builtin`). So op/2 is pinned for emission, color/1 and sz/2 for execution.

## Verification

- New `test_wam_llvm_lowered_t5`: **ALL 9 PASS** under real clang 18.
- No regression: `test_wam_llvm_lowered_ite`, `ite_exec`, `wam_llvm_target`, `llvm_target` all pass — the gate leaves single-clause / ITE / non-distinct-first-arg predicates on their existing paths.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_