### PR TITLE
Add T5 first-argument clause-chain lowering for C++

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_cpp_lowered_emitter.pl
@@ -28,6 +28,7 @@
 :- use_module(library(lists)).
 :- use_module(wam_ite_structurer, [structure_ite/2, split_commit/3, is_commit/1]).
 :- use_module(wam_text_parser, [wam_text_to_items/2, wam_classify_constant_token/2]).
+:- use_module(wam_clause_chain, [clause_chain/2]).
 % Inlined escape helper to avoid a circular import with wam_cpp_target.
 % Keeps this module standalone-loadable.
 
@@ -91,11 +92,18 @@ cpp_supported_structured(I) :- cpp_supported(I).
 
 %% wam_cpp_lowerable(+Pred/Arity, +WamCode, -Reason)
 %  True if the predicate can be lowered to a direct C++ function.
-%  Reason is `deterministic` or `multi_clause_1`.
+%  Reason is `clause_chain`, `deterministic`, `multi_clause_1` or
+%  `ite_lowered`.
 wam_cpp_lowerable(PI, WamCode, Reason) :-
     cpp_base_instrs(WamCode, Instrs),
     clause1_instrs(Instrs, C1),
-    (   % No internal ITE: existing deterministic / multi-clause path.
+    (   % T5: multi-clause predicate discriminating on a distinct
+        % first-argument constant lowers to a bound-checked if-cascade over
+        % ALL clauses (no interpreter hop for clauses 2+ when A1 is bound).
+        % Takes precedence over multi_clause_1.
+        cpp_clause_chain_lowerable(Instrs, _Guards)
+    ->  Reason = clause_chain
+    ;   % No internal ITE: existing deterministic / multi-clause path.
         \+ member(try_me_else(_), C1),
         forall(member(I, C1), cpp_supported(I))
     ->  ( is_deterministic_pred_cpp(Instrs) -> Reason = deterministic
@@ -108,6 +116,25 @@ wam_cpp_lowerable(PI, WamCode, Reason) :-
         Reason = ite_lowered
     ),
     ( PI = _M:_P/_A -> true ; PI = _/_A2 -> true ; true ).
+
+%% cpp_clause_chain_lowerable(+Instrs, -Guards) is semidet.
+%  True when the predicate is a distinct-first-argument-constant clause chain
+%  (T5) and every clause's remainder is a supported deterministic body. The
+%  C++ parser keeps a leading switch_on_* indexing prefix, so strip it before
+%  handing the try_me_else/retry_me_else/trust_me chain to the shared
+%  front-end. Guards is the front-end's guard(Const, Remainder) list.
+cpp_clause_chain_lowerable(Instrs, Guards) :-
+    cpp_strip_switch_prefix(Instrs, Stripped),
+    clause_chain(Stripped, chain(Guards)),
+    forall(member(guard(_, Rem), Guards),
+           ( is_deterministic_pred_cpp(Rem),
+             forall(member(I, Rem), cpp_supported(I)) )).
+
+cpp_strip_switch_prefix([switch_on_constant(_)|Rest], S) :- !, cpp_strip_switch_prefix(Rest, S).
+cpp_strip_switch_prefix([switch_on_constant_a2(_)|Rest], S) :- !, cpp_strip_switch_prefix(Rest, S).
+cpp_strip_switch_prefix([switch_on_structure(_)|Rest], S) :- !, cpp_strip_switch_prefix(Rest, S).
+cpp_strip_switch_prefix([switch_on_term(_)|Rest], S) :- !, cpp_strip_switch_prefix(Rest, S).
+cpp_strip_switch_prefix(L, L).
 
 clause1_instrs([], []).
 % Strip leading indexing instructions (switch_on_*) — they are dispatch
@@ -214,19 +241,52 @@ lower_predicate_to_cpp(PI, WamCode, Options, CppLines) :-
     ->  maplist(foreign_key_string, ForeignPreds0, ForeignPreds)
     ;   ForeignPreds = []
     ),
-    % Emit the plain clause-1 when it has no inner choice point; otherwise
-    % fold its ITE block(s) into structured form (ite/3) first.
-    (   \+ member(try_me_else(_), C1Instrs)
-    ->  EmitInstrs = C1Instrs
-    ;   cpp_structured_clause1(WamCode, EmitInstrs)
-    ),
     nb_setval(cpp_ite_ctr, 0),
-    with_output_to(string(Body), emit_instrs(EmitInstrs, "    ", ForeignPreds)),
-    format(string(Header),
+    (   % T5 first-argument-constant dispatch takes precedence.
+        cpp_clause_chain_lowerable(Instrs, Guards)
+    ->  emit_clause_chain_cpp(FuncName, Pred, Arity, Guards, ForeignPreds, CppLines)
+    ;   % Emit the plain clause-1 when it has no inner choice point; otherwise
+        % fold its ITE block(s) into structured form (ite/3) first.
+        (   \+ member(try_me_else(_), C1Instrs)
+        ->  EmitInstrs = C1Instrs
+        ;   cpp_structured_clause1(WamCode, EmitInstrs)
+        ),
+        with_output_to(string(Body), emit_instrs(EmitInstrs, "    ", ForeignPreds)),
+        format(string(Header),
 '// ~w — lowered from ~w/~w
 bool ~w(WamState* vm) {', [FuncName, Pred, Arity, FuncName]),
+        format(string(Footer), '}', []),
+        CppLines = [Header, Body, Footer]
+    ).
+
+%% emit_clause_chain_cpp(+FuncName, +Pred, +Arity, +Guards, +FK, -CppLines)
+%  Emit T5: read+deref the first argument once; if it is still unbound, defer
+%  to the entry wrapper's interpreter fallback (the unbound case is genuinely
+%  nondeterministic). Otherwise dispatch with an if-cascade comparing the
+%  bound value against each clause's distinct discriminator and running that
+%  clause's remainder (which self-terminates: its `proceed` emits
+%  `return true`). A bound value matching no clause returns false (the
+%  predicate fails; the wrapper's fresh re-run also fails — sound, since the
+%  discriminators are distinct).
+emit_clause_chain_cpp(FuncName, Pred, Arity, Guards, ForeignPreds, CppLines) :-
+    format(string(Header),
+'// ~w — lowered from ~w/~w (T5 first-argument dispatch)
+bool ~w(WamState* vm) {', [FuncName, Pred, Arity, FuncName]),
+    with_output_to(string(Body),
+        ( format("    Value t5a1 = vm->get_reg(\"A1\");~n"),
+          format("    if (t5a1.is_unbound()) return false;  // unbound first arg: defer to interpreter (enumerates all clauses)~n"),
+          emit_cpp_guards(Guards, ForeignPreds),
+          format("    return false;~n") )),
     format(string(Footer), '}', []),
     CppLines = [Header, Body, Footer].
+
+emit_cpp_guards([], _).
+emit_cpp_guards([guard(V, Rem) | Rest], ForeignPreds) :-
+    cpp_val_literal(V, CppVal),
+    format("    if (t5a1 == ~w) {~n", [CppVal]),
+    emit_instrs(Rem, "        ", ForeignPreds),
+    format("    }~n"),
+    emit_cpp_guards(Rest, ForeignPreds).
 
 %% emit_instrs(+Instrs, +Indent, +ForeignPreds)
 emit_instrs([], _, _).

--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -3781,12 +3781,29 @@ test(lowerability_deterministic) :-
     wam_cpp_lowerable(wam_cpp_fact/1, Instrs, Reason),
     assertion(Reason == deterministic).
 
-test(lowerability_multi_clause_1) :-
+% A multi-clause predicate that discriminates on a DISTINCT first-argument
+% constant now lowers as T5 (clause_chain): ALL clauses are emitted as a
+% bound-checked first-arg dispatch, taking precedence over multi_clause_1.
+test(lowerability_clause_chain) :-
     Instrs = [try_me_else("L2"),
               get_constant("a", "A1"),
               proceed,
               trust_me,
               get_constant("b", "A1"),
+              proceed],
+    wam_cpp_lowerable(wam_cpp_choice/1, Instrs, Reason),
+    assertion(Reason == clause_chain).
+
+% A multi-clause predicate whose head does NOT discriminate on a distinct
+% first-arg constant (here the first argument is bound via get_variable, not
+% get_constant) is not a clause chain, so it still lowers as multi_clause_1
+% (clause 1 inline, clauses 2+ via the interpreter fallback).
+test(lowerability_multi_clause_1) :-
+    Instrs = [try_me_else("L2"),
+              get_variable("X1", "A1"),
+              proceed,
+              trust_me,
+              get_variable("X1", "A1"),
               proceed],
     wam_cpp_lowerable(wam_cpp_choice/1, Instrs, Reason),
     assertion(Reason == multi_clause_1).

--- a/tests/test_wam_cpp_lowered_t5.pl
+++ b/tests/test_wam_cpp_lowered_t5.pl
@@ -1,0 +1,132 @@
+% test_wam_cpp_lowered_t5.pl
+%
+% End-to-end execution test for the C++ T5 lowering — "multi-clause as an
+% if-then-else chain" (lowering type T5 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md), ported from the
+% Scala/Rust/Go/Haskell/F#/LLVM emitters via the shared wam_clause_chain
+% front-end.
+%
+% A predicate whose clauses discriminate on a DISTINCT first-argument
+% constant now lowers to a bound-checked first-arg dispatch over ALL clauses
+% (non-first clauses become fast-path too when A1 is bound), instead of
+% multi_clause_1 (clause 1 inline, clauses 2+ via the interpreter fallback).
+% An unbound first argument returns false and defers to the entry wrapper's
+% interpreter fallback.
+%
+% Pins (the harness preloads a BOUND first arg, exercising every clause incl.
+% the non-first ones — the T5 payoff):
+%   * color/1 — fact chain, atom discriminators;
+%   * sz/2    — fact chain with a second head match in each remainder;
+%   * op/2    — RULE chain (each remainder runs an is/2 builtin).
+%
+% Skipped automatically when no host C++17 compiler is available.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_cpp_target').
+:- use_module('../src/unifyweaver/targets/wam_cpp_lowered_emitter').
+
+:- dynamic user:color/1.
+:- dynamic user:sz/2.
+:- dynamic user:op/2.
+
+user:color(red).
+user:color(green).
+user:color(blue).
+
+user:sz(small, 1).
+user:sz(medium, 2).
+user:sz(large, 3).
+
+user:op(add, R) :- R is 1 + 1.
+user:op(mul, R) :- R is 2 * 3.
+user:op(neg, R) :- R is 0 - 1.
+
+cc_ok(CC) :-
+    catch(( process_create(path(CC), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+cpp_compiler(CC) :-
+    ( cc_ok('g++') -> CC = 'g++'
+    ; cc_ok('clang++') -> CC = 'clang++'
+    ; fail ).
+
+:- begin_tests(wam_cpp_lowered_t5, [condition(cpp_compiler(_))]).
+
+% The three predicates must lower as T5 (clause_chain), not multi_clause_1.
+test(gate_picks_clause_chain) :-
+    forall(member(PI, [color/1, sz/2, op/2]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_cpp_lowerable(PI, W, Reason),
+             assertion(Reason == clause_chain) )).
+
+test(t5_exec_parity) :-
+    cpp_compiler(CC),
+    Dir = 'output/test_wam_cpp_t5_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    % 1. Generate the WAM C++ project with the lowered emitter enabled.
+    write_wam_cpp_project(
+        [user:color/1, user:sz/2, user:op/2],
+        [module_name('t5cpp'), wam_fallback(true), emit_mode(functions)], Dir),
+    % Sanity: the generated lowered code must be the T5 dispatch.
+    atomic_list_concat([Dir, '/cpp/generated_program.cpp'], GenPath),
+    ( exists_file(GenPath) -> read_file_to_string(GenPath, GSrc, []) ; GSrc = "" ),
+    assertion(sub_string(GSrc, _, _, _, "T5 first-argument dispatch")),
+    % 2. Test harness alongside the generated sources.
+    atomic_list_concat([Dir, '/cpp/test_t5.cpp'], TestPath),
+    cpp_t5_source(Src),
+    setup_call_cleanup(open(TestPath, write, S), write(S, Src), close(S)),
+    % 3. Compile + run.
+    atomic_list_concat([Dir, '/cpp'], CppDir),
+    format(atom(Cmd),
+        '~w -std=c++17 -O0 ~w/test_t5.cpp ~w/generated_program.cpp ~w/wam_runtime.cpp -o ~w/t5_test 2>&1 && ~w/t5_test',
+        [CC, CppDir, CppDir, CppDir, CppDir, CppDir]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 14 PASS")
+    ->  true
+    ;   format(user_error, "~n[cpp t5 test output]~n~w~n", [OutStr]),
+        throw(cpp_t5_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_cpp_lowered_t5).
+
+% Calls each lowered function with a BOUND first argument and asserts the
+% boolean outcome. Exercises every clause including the non-first ones
+% (green/blue, medium/large, mul/neg) — the T5 payoff — plus the no-match
+% cases (yellow, sz big, op div). C++ atoms are plain strings, so no atom-id
+% coordination is needed.
+cpp_t5_source(
+"#include \"wam_runtime.h\"
+#include <iostream>
+bool lowered_color_1(WamState*); bool lowered_sz_2(WamState*); bool lowered_op_2(WamState*);
+static int failures = 0;
+static void chk(const char* n, bool g, bool w) {
+    if (g != w) { std::cerr << \"FAIL \" << n << \": got \" << g << \" want \" << w << \"\\n\"; failures++; }
+}
+static Value I(long long n) { return Value::Integer(n); }
+static Value A(const char* s) { return Value::Atom(s); }
+int main() {
+    { WamState v; v.put_reg(\"A1\", A(\"red\"));    chk(\"color(red)\",    lowered_color_1(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"green\"));  chk(\"color(green)\",  lowered_color_1(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"blue\"));   chk(\"color(blue)\",   lowered_color_1(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"yellow\")); chk(\"color(yellow)\", lowered_color_1(&v), false); }
+    { WamState v; v.put_reg(\"A1\", A(\"small\"));  v.put_reg(\"A2\", I(1)); chk(\"sz(small,1)\",  lowered_sz_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"medium\")); v.put_reg(\"A2\", I(2)); chk(\"sz(medium,2)\", lowered_sz_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"large\"));  v.put_reg(\"A2\", I(3)); chk(\"sz(large,3)\",  lowered_sz_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"small\"));  v.put_reg(\"A2\", I(2)); chk(\"sz(small,2)\",  lowered_sz_2(&v), false); }
+    { WamState v; v.put_reg(\"A1\", A(\"big\"));    v.put_reg(\"A2\", I(1)); chk(\"sz(big,1)\",    lowered_sz_2(&v), false); }
+    { WamState v; v.put_reg(\"A1\", A(\"add\")); v.put_reg(\"A2\", I(2));  chk(\"op(add,2)\",  lowered_op_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"mul\")); v.put_reg(\"A2\", I(6));  chk(\"op(mul,6)\",  lowered_op_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"neg\")); v.put_reg(\"A2\", I(-1)); chk(\"op(neg,-1)\", lowered_op_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"add\")); v.put_reg(\"A2\", I(3));  chk(\"op(add,3)\",  lowered_op_2(&v), false); }
+    { WamState v; v.put_reg(\"A1\", A(\"div\")); v.put_reg(\"A2\", I(1));  chk(\"op(div,1)\",  lowered_op_2(&v), false); }
+    if (failures == 0) { std::cout << \"ALL 14 PASS\\n\"; return 0; }
+    std::cerr << failures << \" FAILURES\\n\"; return 1;
+}
+").


### PR DESCRIPTION
## Summary

Ports the shared `wam_clause_chain` front-end (lowering type **T5**) to the **C++** lowered emitter — completing the **term-based** targets: Scala (#2901), Rust (#2907), Go (#2920, #2925), Haskell (#2930), F# (#2934), LLVM (#2935).

A multi-clause predicate whose clauses discriminate on a **distinct first-argument constant** now lowers to a bound-checked `if`-cascade over **all** clauses, instead of `multi_clause_1` (clause 1 inline, clauses 2+ via the interpreter fallback). Non-first clauses become fast-path too when A1 is bound; an unbound first argument returns `false` and defers to the entry wrapper's interpreter fallback.

```cpp
bool lowered_color_1(WamState* vm) {
    Value t5a1 = vm->get_reg("A1");
    if (t5a1.is_unbound()) return false;  // unbound: defer to interpreter
    if (t5a1 == Value::Atom("red"))   { return true; }
    if (t5a1 == Value::Atom("green")) { return true; }
    if (t5a1 == Value::Atom("blue"))  { return true; }
    return false;
}
```

## Changes

- **`wam_cpp_lowered_emitter.pl`**
  - Import `clause_chain/2`; gate `clause_chain` ahead of the deterministic / multi-clause / ITE path in `wam_cpp_lowerable` (Reason precedence).
  - `cpp_clause_chain_lowerable/2` strips the C++ parser's leading `switch_on_*` indexing prefix (which the other targets' parsers drop) before handing the try/retry/trust chain to the shared front-end, then requires every clause remainder to be deterministic + supported.
  - Dispatch to `emit_clause_chain_cpp/6` + `emit_cpp_guards/2`.
  - The C++ target consumes the `Reason` uniformly (it's ignored at the call site), so `clause_chain` gets exactly the same entry-wrapper / interpreter-fallback wiring `multi_clause_1` always had — no dispatch changes needed.

- **`tests/test_wam_cpp_lowered_t5.pl`** — gated exec test (g++/clang++). color/1 (fact chain), sz/2 (head-match remainder), op/2 (`is/2` rule chain) gate as `clause_chain` and compile+run; **14 ground queries** (bound first arg) exercise every clause incl. the non-first ones plus no-match cases. **(op/2 works here — C++ is cell-based like Rust, no `is/2` codegen bug.)**

- **`tests/test_wam_cpp_generator.pl`** — the existing `lowerability_multi_clause_1` unit test pinned the OLD behaviour for the `choice(a)/choice(b)` shape, which is exactly a distinct-first-arg chain → now `clause_chain`. Updated to `lowerability_clause_chain` and added a fresh `lowerability_multi_clause_1` (a `get_variable`-headed multi-clause predicate that is *not* a clause chain) so both paths stay covered.

## Verification

- New `test_wam_cpp_lowered_t5`: gate + **ALL 14 PASS** exec (g++).
- `test_wam_cpp_generator`: the affected unit tests (`lowerability_clause_chain`, `lowerability_multi_clause_1`) and the `cpp_e2e_choice_backtracking` e2e test pass. The full generator suite is pre-existingly slow (it compiles many C++ programs) and times out under the local 9-min cap — unrelated to this change; its e2e tests run in `emit_main(true)` interpreter mode and don't touch lowering.
- `test_wam_cpp_lowered_ite_exec` still passes (the gate leaves single-clause / ITE / non-distinct-first-arg predicates on their existing paths).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_