### PR TITLE
feat(wam-clojure): lower permutation/2 builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -550,6 +550,10 @@ clojure_direct_builtin("union/3", "3").
 clojure_direct_builtin("union/3", 3).
 clojure_direct_builtin('union/3', "3").
 clojure_direct_builtin('union/3', 3).
+clojure_direct_builtin("permutation/2", "2").
+clojure_direct_builtin("permutation/2", 2).
+clojure_direct_builtin('permutation/2', "2").
+clojure_direct_builtin('permutation/2', 2).
 clojure_direct_builtin("list_to_set/2", "2").
 clojure_direct_builtin("list_to_set/2", 2).
 clojure_direct_builtin('list_to_set/2', "2").
@@ -995,6 +999,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "union/3" ; Op == 'union/3'),
     !,
     format(atom(Expr), '(runtime/apply-union-solution ~w)', [S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "permutation/2" ; Op == 'permutation/2'),
+    !,
+    format(atom(Expr), '(runtime/apply-permutation-solution ~w)', [S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "list_to_set/2" ; Op == 'list_to_set/2'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1295,6 +1295,35 @@
           (backtrack state)))
       (backtrack state))))
 
+(defn same-permutation-items? [state left right]
+  (and (= (count left) (count right))
+       (every? zero?
+               (map #(term-compare state %1 %2)
+                    (sort #(term-compare state %1 %2) left)
+                    (sort #(term-compare state %1 %2) right)))))
+
+(defn apply-permutation-solution [state]
+  (let [left-value (deref-value (:bindings state)
+                                (or (reg-get-raw state "A1") ::unbound))
+        out-raw (or (reg-get-raw state "A2") ::unbound)
+        out (deref-value (:bindings state) out-raw)]
+    (if-let [left-items (proper-list-items state left-value)]
+      (cond
+        (logic-var? out)
+        (let [identity-term (list->term (:intern-context state) left-items)
+              [ok next-state] (unify-values state out-raw identity-term)]
+          (if ok
+            (advance next-state)
+            (backtrack state)))
+
+        :else
+        (if-let [right-items (proper-list-items state out)]
+          (if (same-permutation-items? state left-items right-items)
+            (advance state)
+            (backtrack state))
+          (backtrack state)))
+      (backtrack state))))
+
 (defn list-to-set-items [state items]
   (reduce (fn [out item]
             (if (some #(term-identical? state % item) out)
@@ -2763,6 +2792,9 @@
 
           "union/3"
           (apply-union-solution state)
+
+          "permutation/2"
+          (apply-permutation-solution state)
 
           "list_to_set/2"
           (apply-list-to-set-solution state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -152,6 +152,11 @@
 :- dynamic user:wam_union_duplicates/0.
 :- dynamic user:wam_union_bad_left/1.
 :- dynamic user:wam_union_bad_right/1.
+:- dynamic user:wam_permutation_guard/2.
+:- dynamic user:wam_permutation_identity/0.
+:- dynamic user:wam_permutation_duplicates/0.
+:- dynamic user:wam_permutation_bad_left/1.
+:- dynamic user:wam_permutation_bad_right/1.
 :- dynamic user:wam_list_to_set_guard/2.
 :- dynamic user:wam_list_to_set_empty/0.
 :- dynamic user:wam_list_to_set_singleton/0.
@@ -510,6 +515,11 @@ user:wam_union_empty_left :- union([], [a,b], Union), Union = [a,b].
 user:wam_union_duplicates :- union([a,a], [a,b], Union), Union = [a,a,b].
 user:wam_union_bad_left(_) :- union([a|b], [a], _).
 user:wam_union_bad_right(_) :- union([a], [a|b], _).
+user:wam_permutation_guard(Left, Right) :- permutation(Left, Right).
+user:wam_permutation_identity :- permutation([a,b,c], P), P = [a,b,c].
+user:wam_permutation_duplicates :- permutation([a,a,b], [a,b,a]).
+user:wam_permutation_bad_left(_) :- permutation([a|b], _).
+user:wam_permutation_bad_right(_) :- permutation([a], [a|b]).
 user:wam_list_to_set_guard(List, Set) :- list_to_set(List, Set).
 user:wam_list_to_set_empty :- list_to_set([], Set), Set = [].
 user:wam_list_to_set_singleton :- list_to_set([x], Set), Set = [x].
@@ -873,6 +883,11 @@ run_smoke :-
           user:wam_union_duplicates/0,
           user:wam_union_bad_left/1,
           user:wam_union_bad_right/1,
+          user:wam_permutation_guard/2,
+          user:wam_permutation_identity/0,
+          user:wam_permutation_duplicates/0,
+          user:wam_permutation_bad_left/1,
+          user:wam_permutation_bad_right/1,
           user:wam_list_to_set_guard/2,
           user:wam_list_to_set_empty/0,
           user:wam_list_to_set_singleton/0,
@@ -1123,6 +1138,7 @@ run_smoke :-
     assert_lowered_subtract_builtin_emitted(TmpDir),
     assert_lowered_intersection_builtin_emitted(TmpDir),
     assert_lowered_union_builtin_emitted(TmpDir),
+    assert_lowered_permutation_builtin_emitted(TmpDir),
     assert_lowered_list_to_set_builtin_emitted(TmpDir),
     assert_lowered_sort_builtin_emitted(TmpDir),
     assert_lowered_msort_builtin_emitted(TmpDir),
@@ -1395,6 +1411,12 @@ smoke_cases([
     case('wam_union_duplicates/0', no_args, "true"),
     case('wam_union_bad_left/1', a, "false"),
     case('wam_union_bad_right/1', a, "false"),
+    case('wam_permutation_guard/2', args('[a,b,c]', '[c,b,a]'), "true"),
+    case('wam_permutation_guard/2', args('[a,b,c]', '[a,b]'), "false"),
+    case('wam_permutation_identity/0', no_args, "true"),
+    case('wam_permutation_duplicates/0', no_args, "true"),
+    case('wam_permutation_bad_left/1', a, "false"),
+    case('wam_permutation_bad_right/1', a, "false"),
     case('wam_list_to_set_guard/2', args('[a,b,c,a,b,d,a]', '[a,b,c,d]'), "true"),
     case('wam_list_to_set_guard/2', args('[a,b,c,a,b,d,a]', '[a,b,c,a]'), "false"),
     case('wam_list_to_set_empty/0', no_args, "true"),
@@ -1945,6 +1967,14 @@ assert_lowered_union_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-union-bad-left-1"),
     has(CoreCode, "defn lowered-wam-union-bad-right-1"),
     has(CoreCode, "runtime/apply-union-solution").
+
+assert_lowered_permutation_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-permutation-guard-2"),
+    has(CoreCode, "defn lowered-wam-permutation-identity-0"),
+    has(CoreCode, "defn lowered-wam-permutation-duplicates-0"),
+    has(CoreCode, "runtime/apply-permutation-solution").
 
 assert_lowered_list_to_set_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),


### PR DESCRIPTION
## Summary

- Adds Clojure WAM direct-lowered support for `permutation/2`.
- Implements conservative runtime parity for supported modes:
  - `(+,+)` multiset/permutation check over proper lists.
  - `(+,-)` identity generation by unifying the second argument with the first list.
- Extends the Clojure runtime smoke fixture with bound-check, identity, duplicate, malformed-left, and malformed-right cases.

## Why

This continues Clojure WAM structural list builtin parity after the list-set and numeric reducer work. Go and R already support a conservative `permutation/2` slice; this PR adds the same practical Clojure runtime behavior without introducing factorial multi-solution enumeration.

## Behavior

- Requires the first argument to be a proper bound list.
- If the second argument is unbound, unifies it with the original list.
- If the second argument is bound, requires a proper list of the same multiset, compared with existing term ordering.
- Fails for malformed lists and length/multiset mismatches.

## Non-goal

Full nondeterministic permutation enumeration is not implemented in this PR.

## Verification

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
