### PR TITLE
Add T5 first-argument clause-chain lowering for Lua

### DIFF
--- a/src/unifyweaver/targets/wam_lua_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_lua_lowered_emitter.pl
@@ -9,6 +9,8 @@
 
 :- use_module(library(lists)).
 :- use_module(wam_ite_structurer, [structure_ite/2]).
+:- use_module(wam_clause_chain, [clause_chain/2]).
+:- use_module(wam_text_parser, [wam_classify_constant_token/2]).
 
 build_emission_plan(WamCode, plan(Mode, AltLabel, ClauseLines)) :-
     atom_string(WamCode, S),
@@ -29,6 +31,20 @@ skippable_prefix_line([First|_]) :- sub_string(First, _, 1, 0, ":").
 skippable_prefix_line(["switch_on_constant"|_]).
 skippable_prefix_line(["switch_on_structure"|_]).
 
+% T5: the clauses discriminate on a DISTINCT first-argument constant
+% (lowering type T5). ALL clauses become a bound-checked first-arg dispatch;
+% an unbound first argument falls back to the multi_clause_1 path (clause 1
+% inline + array fallback), which enumerates every clause. Takes precedence
+% over multi_clause_1. The payload carries both the front-end guards (for the
+% bound dispatch) and clause 1's lines + alt label (for the unbound fallback).
+classify_clause_shape([FirstLine|Rest], plan(clause_chain, AltAtom, chain_payload(Guards, ClauseLines))) :-
+    wam_lua_target:tokenize_wam_line(FirstLine, ["try_me_else", AltStr]),
+    lua_chain_terms([FirstLine|Rest], Terms),
+    clause_chain(Terms, chain(Guards)),
+    forall(member(guard(_, Rem), Guards), lua_chain_rem_supported(Rem)),
+    !,
+    atom_string(AltAtom, AltStr),
+    take_clause1_lines(Rest, ClauseLines).
 classify_clause_shape([FirstLine|Rest], plan(multi_clause_1, AltAtom, ClauseLines)) :-
     wam_lua_target:tokenize_wam_line(FirstLine, ["try_me_else", AltStr]), !,
     atom_string(AltAtom, AltStr),
@@ -70,6 +86,38 @@ lua_line_term(["cut_ite"], cut_ite) :- !.
 lua_line_term(["builtin_call", Op, Ar], builtin_call(Op, Ar)) :- !.
 lua_line_term(Parts, line(Parts)).
 
+% --- T5 clause-chain term parse (for the shared wam_clause_chain front-end) -
+% Convert WAM lines into just the terms clause_chain inspects: the choice-point
+% separators, the head get_constant(V, A1), and an opaque line(Parts) leaf for
+% everything else (which lua_emit_chain_term/2 renders unchanged). Label lines
+% and blanks are dropped.
+lua_chain_terms([], []).
+lua_chain_terms([Line|Rest], Terms) :-
+    wam_lua_target:tokenize_wam_line(Line, Parts),
+    (   Parts == []
+    ->  lua_chain_terms(Rest, Terms)
+    ;   Parts = [First|_], sub_string(First, _, 1, 0, ":")
+    ->  lua_chain_terms(Rest, Terms)            % drop label lines
+    ;   lua_chain_term(Parts, T),
+        Terms = [T|More],
+        lua_chain_terms(Rest, More)
+    ).
+
+lua_chain_term(["try_me_else", L], try_me_else(L)) :- !.
+lua_chain_term(["retry_me_else", L], retry_me_else(L)) :- !.
+lua_chain_term(["trust_me"], trust_me) :- !.
+lua_chain_term(["get_constant", V, A], get_constant(V, A)) :- !.
+lua_chain_term(Parts, line(Parts)).
+
+% Each clause remainder (everything after the head get_constant) must be a
+% line(Parts) leaf this emitter can render, or a further get_constant.
+lua_chain_rem_supported([]).
+lua_chain_rem_supported([T|Rest]) :-
+    ( T = get_constant(_, _) -> true
+    ; T = line(Parts) -> parts_supported(Parts)
+    ),
+    lua_chain_rem_supported(Rest).
+
 take_clause1_lines([], []).
 take_clause1_lines([Line|Rest], Out) :-
     wam_lua_target:tokenize_wam_line(Line, Parts),
@@ -83,6 +131,10 @@ wam_lua_lowerable(_PI, WamCode, Reason) :-
     catch(build_emission_plan(WamCode, plan(Reason, _, Payload)), _, fail),
     (   Reason == ite
     ->  forall(member(I, Payload), lua_struct_supported(I))
+    ;   Reason == clause_chain
+    ->  Payload = chain_payload(Guards, ClauseLines),
+        forall(member(guard(_, Rem), Guards), lua_chain_rem_supported(Rem)),
+        forall(member(Line, ClauseLines), line_supported(Line))
     ;   forall(member(Line, Payload), line_supported(Line))
     ).
 
@@ -149,6 +201,9 @@ lower_predicate_to_lua(PI, WamCode, _Options, lowered(PredName, FuncName, Code))
     ->  emit_deterministic_function(PredName, FuncName, Payload, Code)
     ;   Mode == ite
     ->  emit_ite_function(PredName, FuncName, Payload, Code)
+    ;   Mode == clause_chain
+    ->  Payload = chain_payload(Guards, Clause1Lines),
+        emit_clause_chain_function(PredName, FuncName, AltLabel, Guards, Clause1Lines, Code)
     ;   emit_multi_clause_function(PredName, FuncName, AltLabel, Payload, Code)
     ).
 
@@ -225,6 +280,76 @@ local function ~w(program, state)
   return Runtime.run(program, state) == true
 end
 ', [PredName, FuncName, AltQ, Body]).
+
+% T5 first-argument dispatch. A BOUND first argument is matched against each
+% clause's distinct discriminator and that clause's remainder runs natively
+% (the non-first clauses are fast-path too — no interpreter hop); a bound
+% value matching no clause fails. An UNBOUND first argument is genuinely
+% nondeterministic, so it falls back to the multi_clause_1 path (clause 1
+% inline + array fallback from the clause-2 label), which enumerates every
+% clause exactly as before.
+emit_clause_chain_function(PredName, FuncName, AltLabel, Guards, Clause1Lines, Code) :-
+    with_output_to(string(Dispatch), lua_emit_chain_guards(Guards, "    ")),
+    with_output_to(string(Clause1Body), emit_lines(Clause1Lines, "    ")),
+    wam_lua_target:lua_string_literal(AltLabel, AltQ),
+    format(string(Code),
+'-- Lowered: ~w (T5 first-argument dispatch)
+local function ~w(program, state)
+  local t5a1 = Runtime.deref(state, Runtime.get_reg(state, 1))
+  if type(t5a1) == "table" and t5a1.tag ~~= "unbound" then
+~w    return false
+  end
+  -- unbound first argument: enumerate all clauses via the interpreter
+  local alt_pc = program.labels[~w]
+  if alt_pc == nil then return false end
+  table.insert(state.cps, {
+    next_pc = alt_pc,
+    regs = Runtime.copy_table(state.regs),
+    cp = state.cp,
+    trail_len = #state.trail,
+    var_counter = state.var_counter
+  })
+  local ok = (function()
+~w    return false
+  end)()
+  if ok == true then return true end
+  if Runtime.backtrack(state) ~~= true then return false end
+  state.pc = state.pc + 1
+  state.halt = false
+  return Runtime.run(program, state) == true
+end
+', [PredName, FuncName, Dispatch, AltQ, Clause1Body]).
+
+lua_emit_chain_guards([], _).
+lua_emit_chain_guards([guard(V, Rem)|Rest], Ind) :-
+    lua_chain_eq_expr(V, "t5a1", Eq),
+    format("~wif ~w then~n", [Ind, Eq]),
+    string_concat(Ind, "  ", Ind2),
+    lua_emit_chain_rem(Rem, Ind2),
+    format("~wend~n", [Ind]),
+    lua_emit_chain_guards(Rest, Ind).
+
+lua_emit_chain_rem([], _).
+lua_emit_chain_rem([T|Rest], Ind) :-
+    lua_emit_chain_term(T, Ind),
+    lua_emit_chain_rem(Rest, Ind).
+
+lua_emit_chain_term(get_constant(C, R), Ind) :- !, emit_line_parts(["get_constant", C, R], Ind).
+lua_emit_chain_term(line(Parts), Ind) :- !, emit_line_parts(Parts, Ind).
+
+%% lua_chain_eq_expr(+ConstToken, +LuaVar, -BoolExpr)
+%  A non-binding equality test of the (already-derefed, known-bound) value in
+%  LuaVar against the clause discriminator. Mirrors the runtime's same_atomic.
+lua_chain_eq_expr(VStr, Var, Expr) :-
+    wam_classify_constant_token(VStr, Class),
+    (   Class = integer(N)
+    ->  format(string(Expr), '~w.tag == "int" and ~w.val == ~w', [Var, Var, N])
+    ;   Class = float(F)
+    ->  format(string(Expr), '~w.tag == "float" and ~w.val == ~w', [Var, Var, F])
+    ;   Class = atom(Name),
+        wam_lua_target:intern_lua_atom(Name, Id),
+        format(string(Expr), '~w.tag == "atom" and ~w.id == ~w', [Var, Var, Id])
+    ).
 
 emit_lines([], _).
 emit_lines([Line|Rest], Ind) :-

--- a/tests/test_wam_lua_lowered_t5.pl
+++ b/tests/test_wam_lua_lowered_t5.pl
@@ -1,0 +1,134 @@
+% test_wam_lua_lowered_t5.pl
+%
+% End-to-end execution test for the Lua T5 lowering — "multi-clause as a
+% first-argument dispatch" (lowering type T5 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md). Lua is line-based, so
+% the shared wam_clause_chain front-end is fed a minimal term view of the
+% tokenized lines (separators + head get_constant + opaque line(Parts) leaves);
+% emission renders each clause's remainder back through the line emitter.
+%
+% A predicate whose clauses discriminate on a DISTINCT first-argument constant
+% now lowers to a bound-checked first-arg dispatch over ALL clauses (non-first
+% clauses become fast-path too when A1 is bound), instead of multi_clause_1
+% (clause 1 inline, clauses 2+ via the array fallback). An unbound first
+% argument falls back to that same multi_clause_1 path, which enumerates.
+%
+% Pins (the harness preloads a BOUND first arg, exercising every clause incl.
+% the non-first ones — the T5 payoff):
+%   * color/1 — fact chain, atom discriminators;
+%   * pick/2  — RULE chain; each remainder binds the second argument via =/2,
+%               exercising a non-trivial multi-instruction clause body.
+%
+% Two predicate shapes are deliberately NOT used here, for Lua-specific
+% reasons unrelated to T5:
+%   - arity-2 fact chains (e.g. sz(small,1)) are compiled to an indexed FACT
+%     STREAM by wam_lua_target and never reach the lowered function;
+%   - is/2 over a built compound (e.g. R is 1+1) is unsupported by the Lua
+%     runtime's number_value (it evaluates only int/float, not a +/2 struct),
+%     so such a clause fails in the interpreter too.
+% A rule chain with =/2 remainders (pick/2) covers the multi-instruction
+% clause body without hitting either.
+%
+% Skipped automatically when no Lua interpreter is on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_lua_target').
+:- use_module('../src/unifyweaver/targets/wam_lua_lowered_emitter').
+
+:- dynamic user:color/1.
+:- dynamic user:pick/2.
+
+user:color(red).
+user:color(green).
+user:color(blue).
+
+user:pick(a, X) :- X = apple.
+user:pick(b, X) :- X = banana.
+user:pick(c, X) :- X = cherry.
+
+lua_interpreter(Exe) :-
+    member(Exe, ['lua5.4', 'lua5.3', 'lua', 'luajit']),
+    catch(( process_create(path(Exe), ['-e', 'os.exit(0)'],
+                           [stdin(null), stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail), !.
+
+:- begin_tests(wam_lua_lowered_t5, [condition(lua_interpreter(_))]).
+
+% Both predicates must lower as T5 (clause_chain), not multi_clause_1.
+test(gate_picks_clause_chain) :-
+    forall(member(PI, [color/1, pick/2]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_lua_lowerable(PI, W, Reason),
+             assertion(Reason == clause_chain) )).
+
+test(t5_exec_parity) :-
+    lua_interpreter(Lua),
+    Dir = 'output/test_wam_lua_t5_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    % 1. Generate the lowered Lua project.
+    write_wam_lua_project(
+        [user:color/1, user:pick/2],
+        [module_name('t5proj'), emit_mode(functions)], Dir),
+    % Sanity: the predicates must be lowered as the T5 dispatch and routed
+    % through the lowered function (not the array/fact-stream fallback).
+    atomic_list_concat([Dir, '/lua/generated_program.lua'], ProgPath),
+    read_file_to_string(ProgPath, ProgSrc, []),
+    forall(member(F, ["lowered_color_1", "lowered_pick_2",
+                      "T5 first-argument dispatch",
+                      "return lowered_color_1", "return lowered_pick_2"]),
+           assertion(sub_string(ProgSrc, _, _, _, F))),
+    % 2. Write the harness next to the generated module.
+    atomic_list_concat([Dir, '/lua/harness.lua'], HPath),
+    harness_source(Src),
+    setup_call_cleanup(open(HPath, write, S, [encoding(utf8)]),
+                       write(S, Src), close(S)),
+    % 3. Run it.
+    atomic_list_concat([Dir, '/lua'], LuaDir),
+    format(atom(Cmd), 'cd ~w && ~w harness.lua 2>&1', [LuaDir, Lua]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 9 PASS")
+    ->  true
+    ;   format(user_error, "~n[lua t5 test output]~n~w~n", [OutStr]),
+        throw(lua_t5_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_lua_lowered_t5).
+
+% Calls each per-predicate module entry with a BOUND first argument and checks
+% the boolean. color exercises atom discriminators incl. the non-first clauses
+% (green/blue) and a no-match (yellow). pick exercises a multi-instruction
+% remainder: the matching clause binds/checks the second argument via =/2, so
+% pick(a,banana) is false (clause a yields apple) while pick(b,banana) is true
+% (the non-first clause runs natively — the T5 payoff). Atoms are built through
+% the shared intern table so the ids match the lowered functions.
+harness_source(
+"package.path = \"./?.lua;\" .. package.path
+local M = require(\"generated_program\")
+local R = M.Runtime
+local function A(s) return M.V.Atom(R.intern(M.program.intern_table, s)) end
+local fails, total = 0, 0
+local function chk(name, got, want)
+  total = total + 1
+  if got ~= want then
+    fails = fails + 1
+    print(\"FAIL\", name, \"got\", tostring(got), \"want\", tostring(want))
+  end
+end
+chk(\"color(red)\",    M.color(A(\"red\")),    true)
+chk(\"color(green)\",  M.color(A(\"green\")),  true)
+chk(\"color(blue)\",   M.color(A(\"blue\")),   true)
+chk(\"color(yellow)\", M.color(A(\"yellow\")), false)
+chk(\"pick(a,apple)\",  M.pick(A(\"a\"), A(\"apple\")),  true)
+chk(\"pick(a,banana)\", M.pick(A(\"a\"), A(\"banana\")), false)
+chk(\"pick(b,banana)\", M.pick(A(\"b\"), A(\"banana\")), true)
+chk(\"pick(c,cherry)\", M.pick(A(\"c\"), A(\"cherry\")), true)
+chk(\"pick(d,x)\",      M.pick(A(\"d\"), A(\"x\")),      false)
+if fails == 0 then print(\"ALL \" .. total .. \" PASS\") else print(fails .. \" FAILURES\") end
+os.exit(fails == 0 and 0 or 1)
+").


### PR DESCRIPTION
## Summary

Ports the shared `wam_clause_chain` front-end (lowering type **T5**) to the **Lua** lowered emitter — the first **line-based** target (Scala/Rust/Go/Haskell/F#/LLVM/C++ are term-based).

A multi-clause predicate whose clauses discriminate on a **distinct first-argument constant** now lowers to a bound-checked first-arg dispatch over **all** clauses, instead of `multi_clause_1` (clause 1 inline + array fallback). An unbound first argument falls back to that same `multi_clause_1` path, which enumerates every clause.

```lua
local function lowered_color_1(program, state)
  local t5a1 = Runtime.deref(state, Runtime.get_reg(state, 1))
  if type(t5a1) == "table" and t5a1.tag ~= "unbound" then
    if t5a1.tag == "atom" and t5a1.id == 6 then do return true end end   -- red
    if t5a1.tag == "atom" and t5a1.id == 7 then do return true end end   -- green
    if t5a1.tag == "atom" and t5a1.id == 8 then do return true end end   -- blue
    return false
  end
  -- unbound first argument: enumerate all clauses via the interpreter
  ... multi_clause_1 fallback (CP to clause 2, run clause 1, backtrack→run) ...
end
```

## The line-based adaptation

Lua tokenizes each WAM line into a `Parts` list rather than parsing instruction *terms*, so the term-based `clause_chain/2` doesn't apply directly. `lua_chain_terms/2` builds a **minimal term view** of the lines — just the choice-point separators, the head `get_constant(V, A1)`, and an opaque `line(Parts)` leaf for everything else — and hands that to `clause_chain/2`. Emission renders each clause's remainder back through the existing line emitter (`emit_line_parts/2`), so no instruction logic is duplicated.

## Changes (`wam_lua_lowered_emitter.pl`)

- Import `clause_chain/2` and `wam_classify_constant_token/2`.
- `classify_clause_shape/2`: new `clause_chain` plan gated ahead of `multi_clause_1`; payload carries the front-end guards (bound dispatch) + clause 1's lines + alt label (unbound fallback).
- `lua_chain_terms/2`, `lua_chain_rem_supported/1`; `wam_lua_lowerable/3` accepts `clause_chain`.
- `emit_clause_chain_function/6`: bound A1 → if-cascade with a non-binding tag/id/val test (mirrors the runtime's `same_atomic`) running each clause's remainder natively; unbound A1 → the `multi_clause_1` body.

## Test — `tests/test_wam_lua_lowered_t5.pl`

`color/1` (fact chain, atom discriminators) and `pick/2` (rule chain whose remainders bind the second arg via `=/2`) gate as `clause_chain`, route through the lowered function, and run — **9 ground queries** (bound first arg) exercise every clause incl. the non-first ones plus no-match cases.

**Predicate-choice note:** arity-2 fact chains (e.g. `sz(small,1)`) are compiled by `wam_lua_target` to an indexed **fact stream** and never reach the lowered function; and `is/2` over a built compound is unsupported by the Lua runtime's `number_value` (int/float only, not a `+/2` struct — fails in the interpreter too). So the multi-instruction remainder is demonstrated with a `=/2` rule chain (`pick/2`) that hits neither.

## Verification

- New `test_wam_lua_lowered_t5`: gate + **ALL 9 PASS** under real `lua` 5.4.
- `test_wam_lua_generator`: passes.
- `test_wam_lua_lowered_ite`: fails **identically on clean main** (its ITE predicates route to `run_predicate` in the multi-predicate project, so the lowered-fn sanity assertions fail) — a pre-existing issue, unrelated to this change.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_