### PR TITLE
Add T5 first-argument clause-chain lowering for R

### DIFF
--- a/src/unifyweaver/targets/wam_r_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_r_lowered_emitter.pl
@@ -42,6 +42,7 @@
 :- use_module('../core/binding_state_analysis').
 :- use_module('../core/demand_analysis').
 :- use_module(wam_ite_structurer, [structure_ite/2]).
+:- use_module(wam_clause_chain, [clause_chain/2]).
 
 % =====================================================================
 % Emission plan
@@ -86,6 +87,24 @@ skippable_prefix_line(["switch_on_structure"|_]).
 % First-real-instruction discriminates between deterministic and
 % multi_clause_n. A try_me_else here means a standard WAM try-chain
 % follows, which we split into per-clause line groups.
+% T5: the clauses discriminate on a DISTINCT first-argument constant
+% (lowering type T5). Takes precedence over multi_clause_n: a BOUND first
+% argument dispatches in O(1) straight to the matching clause (no try-all
+% loop, no choice point); an UNBOUND first argument falls back to the
+% multi_clause_n try-all loop, which enumerates every clause. The payload
+% carries the per-clause discriminators (for the dispatch) and the same
+% per-clause line groups multi_clause_n uses (for try_clause_).
+classify_clause_shape([FirstLine|Rest],
+                      plan(clause_chain, none, chain_payload(Discriminators, Clauses))) :-
+    wam_r_target:tokenize_wam_line(FirstLine, ["try_me_else", _AltStr]),
+    r_chain_terms([FirstLine|Rest], Terms),
+    clause_chain(Terms, chain(Guards)),
+    findall(V, member(guard(V, _), Guards), Discriminators),
+    take_multi_clause_lines(Rest, Clauses),
+    length(Guards, NClauses),
+    length(Clauses, NClauses),                 % guards align 1:1 with clauses
+    forall(member(guard(_, Rem), Guards), r_chain_rem_supported(Rem)),
+    !.
 classify_clause_shape([FirstLine|Rest], plan(multi_clause_n, none, Clauses)) :-
     wam_r_target:tokenize_wam_line(FirstLine, ["try_me_else", _AltStr]), !,
     take_multi_clause_lines(Rest, Clauses).
@@ -127,6 +146,37 @@ r_line_term(["jump", L], jump(L)) :- !.
 r_line_term(["cut_ite"], cut_ite) :- !.
 r_line_term(["builtin_call", Op, Ar], builtin_call(Op, Ar)) :- !.
 r_line_term(Parts, line(Parts)).
+
+% --- T5 clause-chain term parse (for the shared wam_clause_chain front-end) -
+% Convert WAM lines into just the terms clause_chain inspects: the choice-point
+% separators, the head get_constant(V, A1), and an opaque line(Parts) leaf for
+% everything else. Label lines and blanks are dropped.
+r_chain_terms([], []).
+r_chain_terms([Line|Rest], Terms) :-
+    wam_r_target:tokenize_wam_line(Line, Parts),
+    (   Parts == []
+    ->  r_chain_terms(Rest, Terms)
+    ;   Parts = [First|_], sub_string(First, _, 1, 0, ":")
+    ->  r_chain_terms(Rest, Terms)             % drop label lines
+    ;   r_chain_term(Parts, T),
+        Terms = [T|More],
+        r_chain_terms(Rest, More)
+    ).
+
+r_chain_term(["try_me_else", L], try_me_else(L)) :- !.
+r_chain_term(["retry_me_else", L], retry_me_else(L)) :- !.
+r_chain_term(["trust_me"], trust_me) :- !.
+r_chain_term(["get_constant", V, A], get_constant(V, A)) :- !.
+r_chain_term(Parts, line(Parts)).
+
+% Each clause remainder (everything after the head get_constant) must be a
+% renderable line(Parts) leaf or a further get_constant.
+r_chain_rem_supported([]).
+r_chain_rem_supported([T|Rest]) :-
+    ( T = get_constant(_, _) -> true
+    ; T = line(Parts) -> parts_supported(Parts)
+    ),
+    r_chain_rem_supported(Rest).
 
 % Multi-clause WAM emitted by the shared compiler has the shape:
 %   try_me_else L2, clause1..., L2:, retry_me_else L3, clause2...,
@@ -204,6 +254,8 @@ wam_r_lowerable(_PI, WamCode, Reason) :-
 
 emission_plan_lines(deterministic, Lines, Lines).
 emission_plan_lines(multi_clause_n, Clauses, Lines) :-
+    append(Clauses, Lines).
+emission_plan_lines(clause_chain, chain_payload(_, Clauses), Lines) :-
     append(Clauses, Lines).
 
 %% r_struct_supported(+StructuredInstr) -- recurse through ite/3; each leaf
@@ -316,6 +368,10 @@ lower_predicate_to_r(PI, WamCode, Opts,
     ->  emit_ite_function(PredName, FuncName, ClauseLines, ModeHeader, Code)
     ;   Mode == multi_clause_n
     ->  emit_multi_clause_function(PredName, FuncName, ClauseLines,
+                                   ModeHeader, Code)
+    ;   Mode == clause_chain
+    ->  ClauseLines = chain_payload(Discriminators, Clauses),
+        emit_clause_chain_function(PredName, FuncName, Discriminators, Clauses,
                                    ModeHeader, Code)
     ),
     clear_lowered_mode_context.
@@ -653,6 +709,109 @@ emit_multi_clause_function(PredName, FuncName, Clauses,
   FALSE
 }', [ModeHeader, PredName, FuncName, ClauseCode,
       NClauses, NClauses, NClauses, NClauses]).
+
+% T5 first-argument dispatch. Reuses the multi_clause_n machinery verbatim
+% (per-clause snapshots, try_clause_, restore_clause_entry_, push_next_clause_
+% and the try-all fallback loop) but inserts an O(1) dispatch prologue: a
+% BOUND first argument is matched against each clause's distinct discriminator
+% and the matching clause is run directly via try_clause_(k) — no try-all
+% loop, no choice point (the discriminators are distinct, so it is
+% deterministic). On a clause-body failure the state is restored, matching the
+% loop's contract. An UNBOUND first argument (or a register that is unset)
+% falls through to the multi_clause_n try-all loop, which enumerates every
+% clause exactly as before.
+emit_clause_chain_function(PredName, FuncName, Discriminators, Clauses,
+                           ModeHeader, Code) :-
+    length(Clauses, NClauses),
+    with_output_to(string(ClauseCode), emit_clause_dispatch(Clauses, 1)),
+    with_output_to(string(DispatchCode), emit_chain_dispatch_r(Discriminators, 1)),
+    % The header keeps the multi_clause_n marker — clause_chain IS an
+    % all-clauses-inline lowering (try_clause_ holds every clause) — and adds
+    % the T5 note for the first-argument dispatch prologue.
+    format(string(Code),
+'~w# Lowered: ~w  (multi-clause; all clauses inline; T5 first-argument dispatch)
+~w <- function(program, state) {
+  snap_regs_      <- state$regs2
+  snap_cp_        <- state$cp
+  snap_trail_     <- length(state$trail)
+  snap_var_count_ <- state$var_counter
+  snap_mode_      <- state$mode
+  snap_build_     <- state$build_stack
+  snap_read_      <- state$read_stack
+  snap_stack_len_ <- length(state$stack)
+  snap_barrier_   <- state$pending_call_barrier
+  resume_pc_      <- state$pc + 1L
+  restore_clause_entry_ <- function() {
+    state$regs2 <- snap_regs_
+    WamRuntime$undo_trail_to(state, snap_trail_)
+    state$cp <- snap_cp_
+    state$var_counter <- snap_var_count_
+    state$mode <- snap_mode_
+    state$build_stack <- snap_build_
+    state$read_stack <- snap_read_
+    state$pending_call_barrier <- snap_barrier_
+    if (length(state$stack) > snap_stack_len_) {
+      if (snap_stack_len_ == 0L) state$stack <- list()
+      else state$stack <- state$stack[seq_len(snap_stack_len_)]
+    }
+    state$shadow_frame <- NULL
+  }
+  try_clause_ <- function(idx_) {
+~w    FALSE
+  }
+  push_next_clause_ <- function(next_idx_) {
+    state$cps <- c(state$cps, list(list(
+      kind        = "iter",
+      regs        = snap_regs_,
+      trail_len   = snap_trail_,
+      cp          = snap_cp_,
+      var_counter = snap_var_count_,
+      mode        = snap_mode_,
+      build_stack = snap_build_,
+      read_stack  = snap_read_,
+      call_barrier = snap_barrier_,
+      stack_len   = snap_stack_len_,
+      resume_pc   = resume_pc_,
+      retry       = function(state) {
+        for (idx_ in seq.int(next_idx_, ~wL)) {
+          ok_ <- isTRUE(try_clause_(idx_))
+          if (ok_) {
+            if (idx_ < ~wL) push_next_clause_(idx_ + 1L)
+            return(TRUE)
+          }
+          restore_clause_entry_()
+        }
+        FALSE
+      }
+    )))
+  }
+  # T5 fast path: a bound first argument selects exactly one clause.
+  t5a1_ <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
+  if (!is.null(t5a1_) && !(is.list(t5a1_) && !is.null(t5a1_$tag) && t5a1_$tag == "unbound")) {
+~w    return(FALSE)
+  }
+  # Unbound first argument: enumerate every clause.
+  for (idx_ in seq_len(~wL)) {
+    ok_ <- isTRUE(try_clause_(idx_))
+    if (ok_) {
+      if (idx_ < ~wL) push_next_clause_(idx_ + 1L)
+      return(TRUE)
+    }
+    restore_clause_entry_()
+  }
+  FALSE
+}', [ModeHeader, PredName, FuncName, ClauseCode,
+      NClauses, NClauses, DispatchCode, NClauses, NClauses]).
+
+%% emit_chain_dispatch_r(+Discriminators, +Idx)
+%  One `if (identical(t5a1_, <const>)) { ... try_clause_(idx) ... }` per clause.
+emit_chain_dispatch_r([], _).
+emit_chain_dispatch_r([V|Rest], Idx) :-
+    wam_r_target:constant_to_r_term(V, CTerm),
+    format("    if (identical(t5a1_, ~w)) { ok_ <- isTRUE(try_clause_(~wL)); if (!ok_) restore_clause_entry_(); return(ok_) }~n",
+           [CTerm, Idx]),
+    Idx1 is Idx + 1,
+    emit_chain_dispatch_r(Rest, Idx1).
 
 emit_clause_dispatch([], _).
 emit_clause_dispatch([Lines|Rest], Idx) :-

--- a/tests/test_wam_r_generator.pl
+++ b/tests/test_wam_r_generator.pl
@@ -599,11 +599,14 @@ test(lowered_emitter_phase3) :-
     assertion(current_predicate(wam_r_lowered_emitter:wam_r_lowerable/3)),
     assertion(current_predicate(wam_r_lowered_emitter:lower_predicate_to_r/4)),
     assertion(current_predicate(wam_r_lowered_emitter:r_lowered_func_name/2)),
-    % Multi-clause predicates are now lowerable as multi_clause_n
-    % (all supported clauses inline).
+    % Multi-clause predicates are lowerable with all supported clauses
+    % inline. wam_r_choice_fact/1 discriminates on a distinct first-argument
+    % constant (a/b/c), so it lowers as the T5 clause_chain (all clauses
+    % inline plus an O(1) bound-first-arg dispatch); predicates whose clauses
+    % do not form a distinct-first-arg chain lower as multi_clause_n.
     compile_predicate_to_wam_string(user:wam_r_choice_fact/1, ChoiceWam),
     once(wam_r_lowered_emitter:wam_r_lowerable(user:wam_r_choice_fact/1,
-                                               ChoiceWam, multi_clause_n)),
+                                               ChoiceWam, clause_chain)),
     % Single-clause deterministic rule is lowered with reason
     % `deterministic`.
     compile_predicate_to_wam_string(user:wam_r_caller/1, CallerWam),

--- a/tests/test_wam_r_lowered_t5.pl
+++ b/tests/test_wam_r_lowered_t5.pl
@@ -1,0 +1,116 @@
+% test_wam_r_lowered_t5.pl
+%
+% End-to-end execution test for the R T5 lowering — "multi-clause as a
+% first-argument dispatch" (lowering type T5 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md). R is line-based, so the
+% shared wam_clause_chain front-end is fed a minimal term view of the
+% tokenized lines (separators + head get_constant + opaque line(Parts) leaves).
+%
+% R already lowers ALL clauses (multi_clause_n: a try-all loop with a choice
+% point per success). T5 adds an O(1) bound-first-argument fast path: a bound
+% A1 dispatches straight to the matching clause via try_clause_(k) — no
+% try-all loop, no choice point — while an unbound A1 falls back to the
+% multi_clause_n loop, which enumerates every clause. The per-clause bodies
+% (try_clause_) are shared between both paths.
+%
+% Pins (the harness preloads a BOUND first arg, exercising every clause incl.
+% the non-first ones — the T5 payoff):
+%   * color/1 — fact chain, atom discriminators;
+%   * sz/2    — fact chain with a second head match in each remainder;
+%   * op/2    — RULE chain (each remainder runs an is/2 builtin).
+%
+% Skipped automatically when `Rscript` is not on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_r_target').
+:- use_module('../src/unifyweaver/targets/wam_r_lowered_emitter').
+
+:- dynamic user:color/1.
+:- dynamic user:sz/2.
+:- dynamic user:op/2.
+
+user:color(red).
+user:color(green).
+user:color(blue).
+
+user:sz(small, 1).
+user:sz(medium, 2).
+user:sz(large, 3).
+
+user:op(add, R) :- R is 1 + 1.
+user:op(mul, R) :- R is 2 * 3.
+user:op(neg, R) :- R is 0 - 1.
+
+rscript_available :-
+    catch(( process_create(path('Rscript'), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_r_lowered_t5, [condition(rscript_available)]).
+
+test(gate_picks_clause_chain) :-
+    forall(member(PI, [color/1, sz/2, op/2]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_r_lowerable(PI, W, Reason),
+             assertion(Reason == clause_chain) )).
+
+test(t5_exec_parity) :-
+    Dir = 'output/test_wam_r_t5_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_r_project(
+        [user:color/1, user:sz/2, user:op/2],
+        [module_name('t5proj'), emit_mode(functions)], Dir),
+    atomic_list_concat([Dir, '/R/generated_program.R'], ProgPath),
+    read_file_to_string(ProgPath, ProgSrc, []),
+    forall(member(F, ["lowered_color_1", "lowered_sz_2", "lowered_op_2",
+                      "T5 first-argument dispatch"]),
+           assertion(sub_string(ProgSrc, _, _, _, F))),
+    atomic_list_concat([Dir, '/R/harness.R'], HPath),
+    harness_source(Src),
+    setup_call_cleanup(open(HPath, write, S, [encoding(utf8)]),
+                       write(S, Src), close(S)),
+    atomic_list_concat([Dir, '/R'], RDir),
+    format(atom(Cmd), 'cd ~w && Rscript harness.R 2>&1', [RDir]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 14 PASS")
+    ->  true
+    ;   format(user_error, "~n[r t5 test output]~n~w~n", [OutStr]),
+        throw(r_t5_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_r_lowered_t5).
+
+harness_source(
+"source(\"generated_program.R\")
+A <- function(s) Atom(WamRuntime$intern(intern_table, s))
+I <- function(n) IntTerm(n)
+fails <- 0L; total <- 0L
+chk <- function(name, got, want) {
+  total <<- total + 1L
+  if (!identical(isTRUE(got), want)) {
+    fails <<- fails + 1L
+    cat(\"FAIL\", name, \"got\", isTRUE(got), \"want\", want, \"\\n\")
+  }
+}
+chk(\"color(red)\",    pred_color(A(\"red\")),    TRUE)
+chk(\"color(green)\",  pred_color(A(\"green\")),  TRUE)
+chk(\"color(blue)\",   pred_color(A(\"blue\")),   TRUE)
+chk(\"color(yellow)\", pred_color(A(\"yellow\")), FALSE)
+chk(\"sz(small,1)\",  pred_sz(A(\"small\"),  I(1)), TRUE)
+chk(\"sz(medium,2)\", pred_sz(A(\"medium\"), I(2)), TRUE)
+chk(\"sz(large,3)\",  pred_sz(A(\"large\"),  I(3)), TRUE)
+chk(\"sz(small,2)\",  pred_sz(A(\"small\"),  I(2)), FALSE)
+chk(\"sz(big,1)\",    pred_sz(A(\"big\"),    I(1)), FALSE)
+chk(\"op(add,2)\",  pred_op(A(\"add\"), I(2)),  TRUE)
+chk(\"op(mul,6)\",  pred_op(A(\"mul\"), I(6)),  TRUE)
+chk(\"op(neg,-1)\", pred_op(A(\"neg\"), I(-1)), TRUE)
+chk(\"op(add,3)\",  pred_op(A(\"add\"), I(3)),  FALSE)
+chk(\"op(div,1)\",  pred_op(A(\"div\"), I(1)),  FALSE)
+if (fails == 0L) cat(\"ALL\", total, \"PASS\\n\") else cat(fails, \"FAILURES\\n\")
+").


### PR DESCRIPTION
## Summary

Ports the shared `wam_clause_chain` front-end (lowering type **T5**) to the **R** lowered emitter — **completing the T5 sweep across every structurer/lowered target.**

R is line-based (like Lua), so the front-end is fed a minimal term view of the tokenized lines (separators + head `get_constant` + opaque `line(Parts)` leaves).

R already lowers **all** clauses (`multi_clause_n`: a try-all loop with a choice point per success). T5 adds an **O(1) bound-first-argument fast path**: when A1 is bound it dispatches straight to the matching clause via `try_clause_(k)` — no try-all loop, no choice point (the discriminators are distinct, so it's deterministic) — while an **unbound** A1 falls through to the `multi_clause_n` loop, which enumerates every clause. All the per-clause machinery (`try_clause_`, snapshots, `restore_clause_entry_`, `push_next_clause_`) is shared verbatim, so the unbound enumeration path is unchanged.

```r
  # T5 fast path: a bound first argument selects exactly one clause.
  t5a1_ <- WamRuntime$deref(state, WamRuntime$get_reg(state, 1L))
  if (!is.null(t5a1_) && !(is.list(t5a1_) && !is.null(t5a1_$tag) && t5a1_$tag == "unbound")) {
    if (identical(t5a1_, Atom(6))) { ok_ <- isTRUE(try_clause_(1L)); if (!ok_) restore_clause_entry_(); return(ok_) }
    ...
    return(FALSE)
  }
  # Unbound first argument: enumerate every clause.
  for (idx_ in seq_len(3L)) { ... }
```

## Changes

- **`wam_r_lowered_emitter.pl`**
  - Import `clause_chain/2`.
  - `classify_clause_shape/2`: new `clause_chain` plan gated ahead of `multi_clause_n`; payload carries the per-clause discriminators + the same per-clause line groups.
  - `r_chain_terms/2`, `r_chain_rem_supported/1`; `wam_r_lowerable/3` + `emission_plan_lines/3` accept `clause_chain`.
  - `emit_clause_chain_function/6` reuses the `multi_clause_n` template and inserts the dispatch prologue (`emit_chain_dispatch_r/2`). The header keeps the `multi_clause_n` marker (clause_chain *is* all-clauses-inline) and adds a T5 note.

- **`tests/test_wam_r_lowered_t5.pl`** — gated Rscript exec test. `color/1`, `sz/2` (head-match remainder) and `op/2` (`is/2` rule chain — R's `number_value` evaluates compound arithmetic, so this works, unlike Lua/Haskell) gate as `clause_chain` and run — **14 ground queries** (bound first arg) exercise every clause incl. the non-first ones plus no-match cases.

- **`tests/test_wam_r_generator.pl`** — `wam_r_choice_fact/1` (distinct first-arg facts) now lowers as `clause_chain` rather than `multi_clause_n`; updated the `lowered_emitter_phase3` reason assertion. The structural marker and all `multi_clause_n` machinery assertions (`try_clause_`, `push_next_clause_`, the for-loop, inline `get_constant`/`is`, and the **unbound-enumeration e2e** in `mode_analysis_phase4` → `TRUE:a:TRUE:b`) still hold — `clause_chain` reuses that machinery.

## Verification

- New `test_wam_r_lowered_t5`: gate + **ALL 14 PASS** under real Rscript.
- `test_wam_r_lowered_ite`: passes.
- `test_wam_r_generator`: all 8 tests affected by this change pass (the 2 structural + 6 e2e, including the phase4 unbound-enumeration check). The full suite reports `rc=1` solely from **pre-existing** complex-builtin e2e failures (`negation_meta_call`, `bagof_setof_once_forall`, `enumerable_builtins`, `catch_throw_dyn_aggregator`, `fact_in_range`, `findall_template_in_struct_arg`) that **reproduce identically on clean main** — unrelated to this change.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_