### PR TITLE
Add T4 (multi_clause_n) all-clauses lowering for Scala

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -95,7 +95,7 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 
 | Target  | T1 det | T2 ITE | T3 mc-1 | T4 mc-n | T5 mc→`->` | T6 idx | T7 par | T8 kernels | T9 facts | T10 mode | T11 LCO |
 |---------|:------:|:------:|:-------:|:-------:|:----------:|:------:|:------:|:----------:|:--------:|:--------:|:-------:|
-| scala   | ✓ | ✓ T2a | ✓ | ✗ | **✗** | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ |
+| scala   | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ |
 | rust    | ✓ | ✓ T2a | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ |
 | cpp     | ✓ | ✓ T2a | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | go      | ✓ | ✓ T2a | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ |
@@ -135,6 +135,15 @@ Verification notes:
   no target does general recursion→loop.
 - elixir's T3/T4 use the choice-point model (genuine CPs + cut barrier), not
   R's closure-per-clause shape — counted ✓ but architecturally distinct.
+- **scala T4** (added later): every clause is emitted inline as a sibling
+  `Boolean` closure, tried in order with a trail/register restore between
+  attempts (`WamRuntime.loRestoreClause`); the entry has no `runPredicate`
+  fallback, so the interpreter is never entered for the predicate. Scala's
+  lowered runtime only ever takes a predicate's first solution (`loCall` /
+  `loExecute` — deterministic-prefix), so unlike R/elixir it needs no
+  retry/iter choice point for clauses 2+; gated below T5 (clause_chain) and
+  above multi_clause_1, so only multi-clause predicates that don't
+  discriminate on a distinct first-arg constant take this path.
 
 ---
 

--- a/src/unifyweaver/targets/wam_scala_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_scala_lowered_emitter.pl
@@ -248,7 +248,16 @@ wam_scala_lowerable(_PI, WamCode, Reason) :-
     ->  Reason = clause_chain
     ;   is_deterministic_pred_scala(C1),
         forall(member(I, C1), scala_supported(I))
-    ->  ( MultiClause == true -> Reason = multi_clause_1 ; Reason = single_clause )
+    ->  ( MultiClause == false
+        ->  Reason = single_clause
+        ;   % T4: every clause is a clean supported deterministic body, so
+            % lower them ALL inline (tried in order with restore-between) and
+            % never enter the interpreter for the predicate. Takes precedence
+            % over multi_clause_1 (clause-1 only + interpreter fallback).
+            scala_all_clauses_lowerable(Instrs)
+        ->  Reason = multi_clause_n
+        ;   Reason = multi_clause_1
+        )
     ;   % Clause-1 has an inner choice point. Lower it only if that point is
         % a pure (C -> T ; E) / \+ / once block whose pieces are all
         % supported; otherwise decline (interpreter fallback).
@@ -280,6 +289,47 @@ take_to_proceed_scala([], []).
 take_to_proceed_scala([proceed|_], [proceed]) :- !.
 take_to_proceed_scala([fail|_], [fail]) :- !.
 take_to_proceed_scala([I|Rest], [I|More]) :- take_to_proceed_scala(Rest, More).
+
+%% scala_split_clauses(+Instrs, -Clauses) is semidet.
+%  Split a multi-clause predicate's instruction list (opens with try_me_else)
+%  at the choice-point separators (retry_me_else / trust_me) into per-clause
+%  instruction lists. Used by T4 (multi_clause_n) to emit every clause as a
+%  sibling closure.
+scala_split_clauses([try_me_else(_)|Rest], [Clause|More]) :-
+    scala_collect_clause(Rest, Clause, After),
+    scala_split_more(After, More).
+
+scala_split_more([], []).
+scala_split_more([retry_me_else(_)|Rest], [Clause|More]) :- !,
+    scala_collect_clause(Rest, Clause, After),
+    scala_split_more(After, More).
+scala_split_more([trust_me|Rest], [Clause|More]) :- !,
+    scala_collect_clause(Rest, Clause, After),
+    scala_split_more(After, More).
+
+scala_collect_clause([], [], []).
+scala_collect_clause([retry_me_else(L)|Rest], [], [retry_me_else(L)|Rest]) :- !.
+scala_collect_clause([trust_me|Rest], [], [trust_me|Rest]) :- !.
+scala_collect_clause([I|Rest], [I|More], After) :-
+    scala_collect_clause(Rest, More, After).
+
+%% scala_all_clauses_lowerable(+Instrs) is semidet.
+%  True when EVERY clause of a multi-clause predicate is a clean, supported,
+%  deterministic-prefix body (no inner choice point, ends in a terminal). Such
+%  a predicate lowers as T4 (multi_clause_n): all clauses inline, tried in
+%  order with a trail/register restore between attempts, so the interpreter is
+%  never entered for the predicate.
+scala_all_clauses_lowerable(Instrs) :-
+    scala_split_clauses(Instrs, Clauses),
+    Clauses = [_, _ | _],
+    forall(member(Cl, Clauses),
+           ( \+ member(try_me_else(_), Cl),   % no inner ITE block
+             forall(member(I, Cl), scala_supported(I)),
+             last(Cl, Last), scala_clause_terminal(Last) )).
+
+scala_clause_terminal(proceed).
+scala_clause_terminal(fail).
+scala_clause_terminal(execute(_, _)).
 
 %% is_deterministic_pred_scala(+Instrs)
 %  True if the clause-1 instruction list has no choice-point ops.
@@ -382,9 +432,16 @@ lower_predicate_to_scala(PI, WamCode, Options, lowered(PredName, FuncName, Code)
     % T5 first-argument-constant clause chain takes precedence; otherwise
     % emit from the plain clause-1 when fully supported, else fold its inner
     % ITE block(s) into structured form first.
-    (   scala_clause_chain_lowerable(Instrs, Guards)
+    (   MultiClause == true,
+        scala_clause_chain_lowerable(Instrs, Guards)
     ->  with_output_to(string(Code),
             emit_clause_chain_scala(FuncName, Guards, ForeignKeys))
+    ;   MultiClause == true,
+        is_deterministic_pred_scala(C1),
+        forall(member(I, C1), scala_supported(I)),
+        scala_all_clauses_lowerable(Instrs)
+    ->  with_output_to(string(Code),
+            emit_multi_clause_n_scala(FuncName, Instrs, ForeignKeys))
     ;   (   is_deterministic_pred_scala(C1),
             forall(member(I, C1), scala_supported(I))
         ->  EmitBody = C1
@@ -393,6 +450,51 @@ lower_predicate_to_scala(PI, WamCode, Options, lowered(PredName, FuncName, Code)
         with_output_to(string(Code),
             emit_function_scala(FuncName, EmitBody, MultiClause, ForeignKeys))
     ).
+
+%% emit_multi_clause_n_scala(+FuncName, +Instrs, +ForeignKeys)
+%  Emit T4: capture the clause-entry state, then emit every clause as a
+%  sibling `Boolean` closure and try them in order, restoring the entry state
+%  between attempts. Returns the first clause that succeeds, or false if all
+%  fail — first-solution / deterministic-prefix semantics (matching loCall),
+%  so the interpreter is never entered for the predicate. Sound because the
+%  Scala lowered runtime only ever takes a predicate's first solution (loCall
+%  / loExecute), so no retry choice point is needed for clauses 2+.
+emit_multi_clause_n_scala(FuncName, Instrs, FK) :-
+    scala_split_clauses(Instrs, Clauses),
+    nb_setval(scala_ite_ctr, 0),
+    format("  /** ~w — T4 all-clauses inline (generated); tries each clause natively with a~n", [FuncName]),
+    format("   *  trail/register restore between attempts, so the interpreter is never entered. */~n", []),
+    format("  def ~w(s: WamState, program: WamProgram): Boolean = {~n", [FuncName]),
+    format("    val _t4Regs  = WamRuntime.snapshotRegs(s)~n", []),
+    format("    val _t4Trail = s.trail.length~n", []),
+    format("    val _t4Env   = s.envStack~n", []),
+    format("    val _t4Cut   = s.cutBar~n", []),
+    format("    val _t4Var   = s.nextVarId~n", []),
+    emit_clause_defs_scala(Clauses, 1, FK),
+    emit_clause_dispatch_scala(Clauses, 1),
+    format("    false~n", []),
+    format("  }~n", []).
+
+%% emit_clause_defs_scala(+Clauses, +Index, +FK)
+%  Emit one `def _t4clause<N>(): Boolean = { <body> }` per clause. A body that
+%  can fall off the end (ends in proceed) returns true; failures emit
+%  `return false`; a tail-call (execute) emits its own return.
+emit_clause_defs_scala([], _, _).
+emit_clause_defs_scala([Cl | Rest], N, FK) :-
+    format("    def _t4clause~w(): Boolean = {~n", [N]),
+    emit_body_scala(Cl, "      ", FK),
+    ( body_falls_through(Cl) -> format("      true~n", []) ; true ),
+    format("    }~n", []),
+    N1 is N + 1,
+    emit_clause_defs_scala(Rest, N1, FK).
+
+%% emit_clause_dispatch_scala(+Clauses, +Index)
+emit_clause_dispatch_scala([], _).
+emit_clause_dispatch_scala([_ | Rest], N) :-
+    format("    if (_t4clause~w()) return true~n", [N]),
+    format("    WamRuntime.loRestoreClause(s, _t4Regs, _t4Trail, _t4Env, _t4Cut, _t4Var)~n", []),
+    N1 is N + 1,
+    emit_clause_dispatch_scala(Rest, N1).
 
 %% emit_clause_chain_scala(+FuncName, +Guards, +ForeignKeys)
 %  Emit T5: deref the first argument once; if it is still unbound, defer to

--- a/src/unifyweaver/targets/wam_scala_target.pl
+++ b/src/unifyweaver/targets/wam_scala_target.pl
@@ -1336,13 +1336,21 @@ scala_lower_each([], [], []).
 scala_lower_each([P|Rest], [Code|Cs], [Entry|Es]) :-
     scala_predicate_wamcode(P, WamCode),
     lower_predicate_to_scala(P, WamCode, [], lowered(PredKey, FuncName, Code)),
-    % Entry wrapper: try the lowered clause-1 fast path; on failure fall
-    % back to a fresh interpreter run of the same predicate. This keeps
-    % results identical to the pure interpreter (a lowered `false` defers
-    % to the complete step loop) while taking the fast path on success.
-    format(string(Entry),
-        '    "~w" -> ((prog: WamProgram, args: Array[WamTerm]) => { val startPc = prog.dispatch("~w"); if (~w(WamRuntime.newState(startPc, args), prog)) true else WamRuntime.runPredicate(prog, startPc, args) })',
-        [PredKey, PredKey, FuncName]),
+    (   % T4 (multi_clause_n): the lowered function lowers EVERY clause and is
+        % complete (first-solution, deterministic-prefix), so it never needs
+        % the interpreter fallback — emit a direct entry. This is what makes
+        % "the interpreter is never entered for the predicate" hold.
+        catch(wam_scala_lowerable(P, WamCode, multi_clause_n), _, fail)
+    ->  format(string(Entry),
+            '    "~w" -> ((prog: WamProgram, args: Array[WamTerm]) => ~w(WamRuntime.newState(prog.dispatch("~w"), args), prog))',
+            [PredKey, FuncName, PredKey])
+    ;   % All other shapes: try the lowered fast path; on failure fall back to
+        % a fresh interpreter run (a lowered `false` defers to the complete
+        % step loop — e.g. T5's unbound-A1 case, or clause-2+ of multi_clause_1).
+        format(string(Entry),
+            '    "~w" -> ((prog: WamProgram, args: Array[WamTerm]) => { val startPc = prog.dispatch("~w"); if (~w(WamRuntime.newState(startPc, args), prog)) true else WamRuntime.runPredicate(prog, startPc, args) })',
+            [PredKey, PredKey, FuncName])
+    ),
     scala_lower_each(Rest, Cs, Es).
 
 % ============================================================================

--- a/templates/targets/scala_wam/runtime.scala.mustache
+++ b/templates/targets/scala_wam/runtime.scala.mustache
@@ -725,6 +725,23 @@ object WamRuntime {
 
   def snapshotRegs(s: WamState): Array[WamTerm] = s.regs.clone()
 
+  /** T4 (multi_clause_n): restore `s` to a clause-entry snapshot the lowered
+   *  function captured before trying the next clause. The lowered function
+   *  enumerates ALL its clauses itself (first-solution / deterministic-prefix
+   *  semantics, like loCall), so the interpreter is never entered for the
+   *  predicate. Mirrors backtrack's WamCP restore, minus the pc (the lowered
+   *  function controls its own control flow). */
+  def loRestoreClause(s: WamState, regs: Array[WamTerm], trailLen: Int,
+                       env: List[EnvFrame], cutBar: Int, varId: Int): Unit = {
+    unwindTrail(s, trailLen)
+    System.arraycopy(regs, 0, s.regs, 0, REG_ARRAY_SIZE)
+    s.envStack   = env
+    s.cutBar     = cutBar
+    s.nextVarId  = varId
+    s.unifyQueue = Nil
+    s.buildStack = Nil
+  }
+
   def pushChoicePoint(s: WamState, targetPc: Int): Unit = {
     val cp = ChoicePoint(
       pc        = targetPc,

--- a/tests/test_wam_scala_lowered_t4.pl
+++ b/tests/test_wam_scala_lowered_t4.pl
@@ -1,0 +1,133 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+%
+% test_wam_scala_lowered_t4.pl
+%
+% End-to-end execution test for the Scala T4 lowering — "multi-clause, all
+% clauses" (lowering type T4 / multi_clause_n in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md).
+%
+% A multi-clause predicate whose clauses are all supported deterministic
+% bodies but do NOT discriminate on a distinct first-argument constant (so T5
+% declines) now lowers (emit_mode(functions)) to ALL clauses inline: each
+% clause is a sibling Boolean closure, tried in order with a trail/register
+% restore between attempts. The first clause that succeeds wins
+% (first-solution / deterministic-prefix semantics, matching loCall), and the
+% interpreter is NEVER entered for the predicate — the entry has no
+% runPredicate fallback (unlike the multi_clause_1 / T3 shape, which lowers
+% only clause 1 and defers clauses 2+ to the bytecode interpreter).
+%
+% Pins (the GeneratedProgram CLI passes ground args; the payoff is that the
+% non-first clauses run natively):
+%   * grade/2 — fact chain with a REPEATED first arg (alice in clauses 1 & 3),
+%               so it is not a distinct-first-arg chain; grade(alice,c) needs
+%               clause 3, grade(bob,b) needs clause 2;
+%   * rel/2   — RULE chain with a VARIABLE first arg (=/2 in each body);
+%               rel(q,two) needs clause 2.
+%
+% Gated on `scalac` + `scala` being on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module(library(process)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_scala_target').
+:- use_module('../src/unifyweaver/targets/wam_scala_lowered_emitter').
+
+:- dynamic user:grade/2.
+:- dynamic user:rel/2.
+
+user:grade(alice, a).
+user:grade(bob,   b).
+user:grade(alice, c).
+
+user:rel(X, one) :- X = p.
+user:rel(X, two) :- X = q.
+
+scala_available :-
+    catch(( process_create(path(scalac), ['-version'],
+                           [stdout(null), stderr(null), process(P1)]),
+            process_wait(P1, _) ), _, fail),
+    catch(( process_create(path(scala), ['-version'],
+                           [stdout(null), stderr(null), process(P2)]),
+            process_wait(P2, _) ), _, fail).
+
+:- begin_tests(wam_scala_lowered_t4, [condition(scala_available)]).
+
+% Both predicates must lower as T4 (multi_clause_n), not multi_clause_1.
+test(gate_picks_multi_clause_n) :-
+    forall(member(PI, [grade/2, rel/2]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_scala_lowerable(PI, W, Reason),
+             assertion(Reason == multi_clause_n) )).
+
+test(t4_exec_parity) :-
+    Dir = 'output/test_wam_scala_t4_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    make_directory_path(Dir),
+    write_wam_scala_project(
+        [user:grade/2, user:rel/2],
+        [package('generated.t4.core'), runtime_package('generated.t4.core'),
+         module_name('t4'), emit_mode(functions)], Dir),
+    directory_file_path(Dir, 'src/main/scala/generated/t4/core/GeneratedProgram.scala', ProgPath),
+    read_file_to_string(ProgPath, ProgSrc, []),
+    % Sanity: both predicates lowered as T4 (all clauses inline).
+    forall(member(F, ["lowered_grade_2", "lowered_rel_2", "T4 all-clauses inline"]),
+           assertion(sub_string(ProgSrc, _, _, _, F))),
+    % The entry must be the direct form (no runPredicate fallback): this is
+    % what makes "the interpreter is never entered for the predicate" hold.
+    assertion(sub_string(ProgSrc, _, _, _,
+        "=> lowered_grade_2(WamRuntime.newState(prog.dispatch(\"grade/2\"), args), prog))")),
+    assertion(sub_string(ProgSrc, _, _, _,
+        "=> lowered_rel_2(WamRuntime.newState(prog.dispatch(\"rel/2\"), args), prog))")),
+    t4_compile(Dir),
+    % grade/2 — repeated first arg; clauses 2 and 3 are the payoff.
+    t4_check(Dir, 'grade/2', [alice, a], "true"),
+    t4_check(Dir, 'grade/2', [bob,   b], "true"),
+    t4_check(Dir, 'grade/2', [alice, c], "true"),
+    t4_check(Dir, 'grade/2', [alice, b], "false"),
+    t4_check(Dir, 'grade/2', [carol, a], "false"),
+    t4_check(Dir, 'grade/2', [bob,   c], "false"),
+    % rel/2 — variable first arg, =/2 body; clause 2 is the payoff.
+    t4_check(Dir, 'rel/2', [p, one], "true"),
+    t4_check(Dir, 'rel/2', [q, two], "true"),
+    t4_check(Dir, 'rel/2', [p, two], "false"),
+    t4_check(Dir, 'rel/2', [q, one], "false"),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_scala_lowered_t4).
+
+% --- compile + run harness (mirrors test_wam_scala_lowered_t5) -------------
+
+t4_compile(ProjectDir) :-
+    absolute_file_name(ProjectDir, AbsDir),
+    directory_file_path(AbsDir, 'classes', ClassDir),
+    make_directory_path(ClassDir),
+    directory_file_path(AbsDir, 'src', SrcDir),
+    findall(F,
+        ( directory_member(SrcDir, RelF, [extensions([scala]), recursive(true)]),
+          directory_file_path(SrcDir, RelF, F) ),
+        Sources),
+    Sources \= [],
+    process_create(path(scalac), ['-d', ClassDir | Sources],
+                   [cwd(AbsDir), stdout(pipe(O)), stderr(pipe(E)), process(Pid)]),
+    read_string(O, _, _), read_string(E, _, ErrStr), close(O), close(E),
+    process_wait(Pid, exit(Code)),
+    ( Code =:= 0 -> true ; throw(error(scala_compile_failed(Code, ErrStr), _)) ).
+
+t4_check(ProjectDir, PredKey, Args, Expected) :-
+    absolute_file_name(ProjectDir, AbsDir),
+    directory_file_path(AbsDir, 'classes', ClassDir),
+    atom_string(PredKey, PredStr),
+    maplist([A, S]>>atom_string(A, S), Args, ArgStrs),
+    append(['-classpath', ClassDir, 'generated.t4.core.GeneratedProgram', PredStr],
+           ArgStrs, ProcArgs),
+    process_create(path(scala), ProcArgs,
+                   [cwd(AbsDir), stdout(pipe(O)), stderr(pipe(E)), process(Pid)]),
+    read_string(O, _, Out0), read_string(E, _, ErrStr), close(O), close(E),
+    process_wait(Pid, exit(Code)),
+    normalize_space(string(Actual), Out0),
+    ( Code =:= 0 -> true ; throw(error(scala_run_failed(Code, PredKey, Args, ErrStr), _)) ),
+    ( Actual == Expected
+    -> true
+    ;  throw(error(t4_assertion(PredKey, Args, Expected, Actual), _)) ).


### PR DESCRIPTION
## Summary

Closes the first **T4** gap (Scala). A multi-clause predicate whose clauses are all supported deterministic bodies but do **not** discriminate on a distinct first-argument constant (so T5/`clause_chain` declines) now lowers with **every clause inline**, instead of `multi_clause_1` (clause 1 inline, clauses 2+ via the bytecode interpreter). **The interpreter is never entered for the predicate** — T4's defining property.

```scala
def lowered_grade_2(s: WamState, program: WamProgram): Boolean = {
  val _t4Regs = WamRuntime.snapshotRegs(s); val _t4Trail = s.trail.length; ...
  def _t4clause1(): Boolean = { ...alice,a...; true }
  def _t4clause2(): Boolean = { ...bob,b...;   true }
  def _t4clause3(): Boolean = { ...alice,c...; true }
  if (_t4clause1()) return true
  WamRuntime.loRestoreClause(s, _t4Regs, _t4Trail, _t4Env, _t4Cut, _t4Var)
  if (_t4clause2()) return true
  WamRuntime.loRestoreClause(...)
  if (_t4clause3()) return true
  WamRuntime.loRestoreClause(...)
  false
}
```

## Approach — no choice-point-model change

The investigation in #2939's follow-up established that full T4 ("never enter the interpreter") needs the lowered code to participate in backtracking. R/elixir do this with **closure/retry choice points**. But Scala's lowered runtime **only ever takes a predicate's first solution** (`loCall`/`loExecute` — deterministic-prefix semantics); it never enumerates a lowered predicate's clauses 2+ on backtrack. So the retry/iter CP would be **dead machinery** here.

The faithful T4 for Scala's first-solution model is therefore: emit each clause as a sibling `Boolean` closure, try them in order with a **trail/register restore** between attempts, return the first that succeeds. This removes the interpreter hop entirely while matching the existing first-solution contract — no CP-model change, lower risk.

## Changes

- **`runtime.scala.mustache`**: add `WamRuntime.loRestoreClause/6` — restore a clause-entry snapshot between attempts (mirrors `backtrack`'s `WamCP` restore, minus pc).
- **`wam_scala_lowered_emitter.pl`**: `scala_split_clauses/2` + `scala_all_clauses_lowerable/1` (every clause a clean supported deterministic body); gate `multi_clause_n` between `clause_chain` (T5) and `multi_clause_1`; `emit_multi_clause_n_scala` + `emit_clause_defs_scala` + `emit_clause_dispatch_scala`.
- **`wam_scala_target.pl`**: `scala_lower_each` emits a **direct entry** (no `runPredicate` fallback) for `multi_clause_n` — this is what makes "the interpreter is never entered" hold. Other shapes keep the fallback (T5's unbound-A1 case, multi_clause_1's clauses 2+).
- **`tests/test_wam_scala_lowered_t4.pl`**: gated scalac/scala exec test. `grade/2` (fact chain, repeated first arg `alice`) and `rel/2` (rule chain, variable first arg, `=/2` body) gate as `multi_clause_n`, emit the direct entry, compile and run; pins exercise the **non-first clauses natively** (`grade(alice,c)`=clause 3, `grade(bob,b)`/`rel(q,two)`=clause 2) plus no-match cases.
- **taxonomy doc**: scala T4 ✗ → ✓ with a verification note.

## Verification

- New `test_wam_scala_lowered_t4`: gate (both `multi_clause_n`) + exec parity (all 10 ground queries) pass under real scalac/scala.
- No regression: `test_wam_scala_lowered_t5` and `test_wam_scala_lowered_emitter` pass (`lp_edge` stays `clause_chain` and keeps the fallback; `lp_fact` lowers all clauses). No CP-model change, so the interpreter and other lowering shapes are unaffected.

## Note on the sweep

This is Scala-first (the breadth anchor), establishing the pattern. The same first-solution-model reasoning applies to the other imperative/functional lowered targets (rust/go/cpp/haskell/fsharp/clojure/llvm/lua), so the per-target back-end should port like the T5 sweep did — but I'd suggest landing this one first to confirm the approach before sweeping.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_