### PR TITLE
Add T4 (multi_clause_n) all-clauses lowering for Rust

### DIFF
--- a/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
@@ -166,8 +166,16 @@ wam_rust_lowerable(PI, WamCode, Reason) :-
     ;   % No internal ITE: existing deterministic / multi-clause path.
         \+ member(try_me_else(_), C1),
         forall(member(I, C1), rust_supported(I))
-    ->  ( is_deterministic_pred_rust(Instrs) -> Reason = deterministic
-        ; Reason = multi_clause_1 )
+    ->  ( is_deterministic_pred_rust(Instrs)
+        ->  Reason = deterministic
+        ;   % T4: every clause is a clean supported deterministic body — lower
+            % them ALL inline (tried in order with restore-between), so the
+            % function never returns to the interpreter for clauses 2+. Takes
+            % precedence over multi_clause_1 (clause-1 only).
+            rust_all_clauses_lowerable(Instrs)
+        ->  Reason = multi_clause_n
+        ;   Reason = multi_clause_1
+        )
     ;   % Clause-1 has an inner choice point: lower only if it is a pure
         % (C -> T ; E) / \+ / once block whose pieces are all supported.
         \+ ( Instrs = [try_me_else(_)|_] ),   % single-clause predicate
@@ -185,6 +193,42 @@ clause1_instrs(Instrs, Instrs).
 take_to_proceed([], []).
 take_to_proceed([proceed|_], [proceed]) :- !.
 take_to_proceed([I|Rest], [I|More]) :- take_to_proceed(Rest, More).
+
+%% rust_split_clauses(+Instrs, -Clauses) is semidet.
+%  Split a multi-clause predicate (opens with try_me_else) at the choice-point
+%  separators into per-clause instruction lists (T4 / multi_clause_n).
+rust_split_clauses([try_me_else(_)|Rest], [Clause|More]) :-
+    rust_collect_clause(Rest, Clause, After),
+    rust_split_more(After, More).
+
+rust_split_more([], []).
+rust_split_more([retry_me_else(_)|Rest], [Clause|More]) :- !,
+    rust_collect_clause(Rest, Clause, After),
+    rust_split_more(After, More).
+rust_split_more([trust_me|Rest], [Clause|More]) :- !,
+    rust_collect_clause(Rest, Clause, After),
+    rust_split_more(After, More).
+
+rust_collect_clause([], [], []).
+rust_collect_clause([retry_me_else(L)|Rest], [], [retry_me_else(L)|Rest]) :- !.
+rust_collect_clause([trust_me|Rest], [], [trust_me|Rest]) :- !.
+rust_collect_clause([I|Rest], [I|More], After) :-
+    rust_collect_clause(Rest, More, After).
+
+%% rust_all_clauses_lowerable(+Instrs) is semidet.
+%  True when EVERY clause is a clean supported deterministic body (no inner
+%  choice point, ends in a terminal) — the T4 (multi_clause_n) condition.
+rust_all_clauses_lowerable(Instrs) :-
+    rust_split_clauses(Instrs, Clauses),
+    Clauses = [_, _ | _],
+    forall(member(Cl, Clauses),
+           ( \+ member(try_me_else(_), Cl),
+             forall(member(I, Cl), rust_supported(I)),
+             last(Cl, Last), rust_clause_terminal(Last) )).
+
+rust_clause_terminal(proceed).
+rust_clause_terminal(fail).
+rust_clause_terminal(execute(_)).
 
 %% rust_clause_chain_lowerable(+Instrs, -Guards) is semidet.
 %  True when the predicate is a distinct-first-argument-constant clause
@@ -280,6 +324,12 @@ lower_predicate_to_rust(PI, WamCode, Options, RustLines) :-
     (   % T5 first-argument-constant dispatch takes precedence.
         rust_clause_chain_lowerable(Instrs, Guards)
     ->  emit_clause_chain_rust(FuncName, Pred, Arity, Guards, ForeignPreds, RustLines)
+    ;   % T4: a multi-clause predicate whose clauses are all supported
+        % deterministic bodies (but not a distinct-first-arg chain) — lower
+        % every clause inline, tried in order with a restore between attempts.
+        \+ is_deterministic_pred_rust(Instrs),
+        rust_all_clauses_lowerable(Instrs)
+    ->  emit_multi_clause_n_rust(FuncName, Pred, Arity, Instrs, ForeignPreds, RustLines)
     ;   % Emit the plain clause-1 when it has no inner choice point;
         % otherwise fold its ITE block(s) into structured form (ite/3).
         (   \+ member(try_me_else(_), C1Instrs)
@@ -321,6 +371,33 @@ emit_rust_guards([guard(V, Rem) | Rest], ForeignPreds) :-
     emit_instrs(Rem, "        ", ForeignPreds),
     format("    }~n"),
     emit_rust_guards(Rest, ForeignPreds).
+
+%% emit_multi_clause_n_rust(+FuncName, +Pred, +Arity, +Instrs, +FK, -RustLines)
+%  Emit T4: capture the clause-entry state, then try every clause inline as an
+%  immediately-invoked closure (its `proceed` returns true, its failures return
+%  false), restoring the entry state between attempts. The first clause that
+%  succeeds wins (first-solution / deterministic-prefix semantics); on total
+%  failure it returns false. The interpreter is never entered for the
+%  predicate — clauses 2+ run natively, unlike multi_clause_1.
+emit_multi_clause_n_rust(FuncName, Pred, Arity, Instrs, ForeignPreds, RustLines) :-
+    rust_split_clauses(Instrs, Clauses),
+    format(string(Header),
+'// ~w — lowered from ~w/~w (T4 all-clauses inline)
+pub fn ~w(vm: &mut WamState) -> bool {', [FuncName, Pred, Arity, FuncName]),
+    with_output_to(string(Body),
+        ( format("    let _t4 = vm.lo_clause_snapshot();~n"),
+          emit_rust_clauses(Clauses, ForeignPreds),
+          format("    false~n") )),
+    format(string(Footer), '}', []),
+    RustLines = [Header, Body, Footer].
+
+emit_rust_clauses([], _).
+emit_rust_clauses([Cl | Rest], ForeignPreds) :-
+    format("    if (|vm: &mut WamState| -> bool {~n"),
+    emit_instrs(Cl, "        ", ForeignPreds),
+    format("    })(vm) { return true; }~n"),
+    format("    vm.lo_restore_clause(&_t4);~n"),
+    emit_rust_clauses(Rest, ForeignPreds).
 
 %% emit_instrs(+Instrs, +Indent, +ForeignPreds)
 %  Emit Rust code for a list of instructions.

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -287,6 +287,22 @@ pub struct BuiltinState {
     pub data: Vec<Value>,
 }
 
+/// T4 (multi_clause_n): a clause-entry snapshot captured by a lowered
+/// function so it can restore between clause attempts. The lowered function
+/// enumerates EVERY clause itself (first-solution / deterministic-prefix, like
+/// the interpreter's first-solution call path), so the interpreter is never
+/// entered for the predicate. Mirrors the ChoicePoint reg/trail/heap/stack/cut
+/// snapshot, minus the resume pc (the lowered function controls its own flow).
+#[derive(Clone, Debug)]
+pub struct ClauseSnapshot {
+    saved_args:  Vec<(usize, Value)>,
+    trail_len:   usize,
+    heap_len:    usize,
+    stack:       Arc<Vec<StackEntry>>,
+    cut_barrier: usize,
+    var_counter: usize,
+}
+
 
 /// Stack entry: environment frames and unification contexts.
 #[derive(Clone, Debug)]
@@ -965,6 +981,29 @@ impl WamState {
                 self.regs[*i] = v.clone();
             }
         }
+    }
+
+    /// T4 (multi_clause_n): capture the clause-entry state a lowered function
+    /// restores between clause attempts (see ClauseSnapshot).
+    pub fn lo_clause_snapshot(&self) -> ClauseSnapshot {
+        ClauseSnapshot {
+            saved_args:  self.save_regs(),
+            trail_len:   self.trail.len(),
+            heap_len:    self.heap.len(),
+            stack:       Arc::clone(&self.stack),
+            cut_barrier: self.cut_barrier,
+            var_counter: self.var_counter,
+        }
+    }
+
+    /// Restore `self` to a clause-entry snapshot before trying the next clause.
+    pub fn lo_restore_clause(&mut self, snap: &ClauseSnapshot) {
+        self.unwind_trail_to(snap.trail_len);
+        self.restore_regs(&snap.saved_args);
+        self.heap.truncate(snap.heap_len);
+        self.stack = Arc::clone(&snap.stack);
+        self.cut_barrier = snap.cut_barrier;
+        self.var_counter = snap.var_counter;
     }
 
 

--- a/tests/test_wam_rust_lowered_t4.pl
+++ b/tests/test_wam_rust_lowered_t4.pl
@@ -1,0 +1,126 @@
+% test_wam_rust_lowered_t4.pl
+%
+% End-to-end execution test for the Rust T4 lowering — "multi-clause, all
+% clauses" (lowering type T4 / multi_clause_n in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md), ported from Scala.
+%
+% A multi-clause predicate whose clauses are all supported deterministic
+% bodies but do NOT discriminate on a distinct first-argument constant (so T5
+% declines) now lowers (emit_mode(functions)) to ALL clauses inline: each
+% clause is an immediately-invoked closure, tried in order with a
+% trail/register/heap/stack restore (vm.lo_restore_clause) between attempts.
+% The first clause that succeeds wins (first-solution / deterministic-prefix
+% semantics); the function never returns to the interpreter for clauses 2+,
+% unlike the multi_clause_1 (clause-1 only) shape.
+%
+% Pins (the cases preload a BOUND first arg; the payoff is the non-first
+% clauses running natively):
+%   * grade/2 — fact chain with a REPEATED first arg (alice in clauses 1 & 3),
+%               so not a distinct-first-arg chain; grade(alice,c) needs clause
+%               3, grade(bob,b) needs clause 2;
+%   * rel/2   — RULE chain with a VARIABLE first arg (=/2 body); rel(q,two)
+%               needs clause 2 (and clause 1 clobbers A2 via put_constant,
+%               which the restore must undo).
+%
+% Skipped automatically when `cargo` is not on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_rust_target').
+:- use_module('../src/unifyweaver/targets/wam_rust_lowered_emitter').
+
+:- dynamic user:grade/2.
+:- dynamic user:rel/2.
+
+user:grade(alice, a).
+user:grade(bob,   b).
+user:grade(alice, c).
+
+user:rel(X, one) :- X = p.
+user:rel(X, two) :- X = q.
+
+cargo_available :-
+    catch(
+        ( process_create(path(cargo), ['--version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          process_wait(Pid, exit(0)) ),
+        _, fail).
+
+:- begin_tests(wam_rust_lowered_t4, [condition(cargo_available)]).
+
+% Both predicates must lower as T4 (multi_clause_n), not multi_clause_1.
+test(gate_picks_multi_clause_n) :-
+    forall(member(PI, [grade/2, rel/2]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_rust_lowerable(PI, W, Reason),
+             assertion(Reason == multi_clause_n) )).
+
+test(t4_exec_parity) :-
+    Dir = 'output/test_wam_rust_t4_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_rust_project(
+        [user:grade/2, user:rel/2],
+        [module_name('t4rust'), wam_fallback(true), emit_mode(functions)], Dir),
+    atomic_list_concat([Dir, '/src/lib.rs'], LibPath),
+    ( exists_file(LibPath) -> read_file_to_string(LibPath, LibSrc, []) ; LibSrc = "" ),
+    assertion(sub_string(LibSrc, _, _, _, "T4 all-clauses inline")),
+    atomic_list_concat([Dir, '/tests'], TestsDir),
+    make_directory_path(TestsDir),
+    atomic_list_concat([Dir, '/tests/t4_exec.rs'], TestPath),
+    rust_t4_source(RustSrc),
+    write_file_t4(TestPath, RustSrc),
+    format(atom(TestCmd), 'cd ~w && cargo test --test t4_exec 2>&1', [Dir]),
+    process_create(path(sh), ['-c', TestCmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    ->  true
+    ;   format(user_error, "~n[cargo test output]~n~w~n", [OutStr]),
+        throw(rust_t4_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_rust_lowered_t4).
+
+write_file_t4(Path, Text) :-
+    setup_call_cleanup(open(Path, write, S, [encoding(utf8)]), write(S, Text), close(S)).
+
+% Calls each lowered function with the query arguments preloaded (first arg
+% bound) and asserts the boolean outcome. Exercises the non-first clauses
+% (grade clauses 2 & 3, rel clause 2) — the T4 payoff — plus no-match cases.
+rust_t4_source(
+"use t4rust::state::WamState;
+use t4rust::value::Value;
+use t4rust::{lowered_grade_2, lowered_rel_2};
+use std::collections::HashMap;
+
+fn call(setup: &dyn Fn(&mut WamState), f: fn(&mut WamState) -> bool) -> bool {
+    let mut vm = WamState::new(vec![], HashMap::new());
+    setup(&mut vm);
+    f(&mut vm)
+}
+fn a(s: &str) -> Value { Value::Atom(s.to_string()) }
+
+#[test]
+fn t4_parity() {
+    let cases: Vec<(&str, bool, bool)> = vec![
+        (\"grade(alice,a)\", call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"alice\")); vm.set_reg(\"A2\", a(\"a\")); }, lowered_grade_2), true),
+        (\"grade(bob,b)\",   call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"bob\"));   vm.set_reg(\"A2\", a(\"b\")); }, lowered_grade_2), true),
+        (\"grade(alice,c)\", call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"alice\")); vm.set_reg(\"A2\", a(\"c\")); }, lowered_grade_2), true),
+        (\"grade(alice,b)\", call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"alice\")); vm.set_reg(\"A2\", a(\"b\")); }, lowered_grade_2), false),
+        (\"grade(carol,a)\", call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"carol\")); vm.set_reg(\"A2\", a(\"a\")); }, lowered_grade_2), false),
+        (\"grade(bob,c)\",   call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"bob\"));   vm.set_reg(\"A2\", a(\"c\")); }, lowered_grade_2), false),
+        (\"rel(p,one)\", call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"p\")); vm.set_reg(\"A2\", a(\"one\")); }, lowered_rel_2), true),
+        (\"rel(q,two)\", call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"q\")); vm.set_reg(\"A2\", a(\"two\")); }, lowered_rel_2), true),
+        (\"rel(p,two)\", call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"p\")); vm.set_reg(\"A2\", a(\"two\")); }, lowered_rel_2), false),
+        (\"rel(q,one)\", call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"q\")); vm.set_reg(\"A2\", a(\"one\")); }, lowered_rel_2), false),
+    ];
+    let mut failures = Vec::new();
+    for (name, got, want) in cases {
+        if got != want { failures.push(format!(\"{}: got {}, want {}\", name, got, want)); }
+    }
+    assert!(failures.is_empty(), \"failures: {:?}\", failures);
+}
+").


### PR DESCRIPTION
## Summary

Second target in the **T4 sweep** (after Scala #2941). A multi-clause predicate whose clauses are all supported deterministic bodies but do **not** discriminate on a distinct first-argument constant (so T5/`clause_chain` declines) now lowers with **every clause inline**, instead of `multi_clause_1` (clause 1 inline, clauses 2+ via the bytecode interpreter). The lowered function never returns to the interpreter for the predicate.

Like Scala, **no choice-point-model change** is needed: Rust's lowered functions are self-contained (the tests call them directly, first-solution semantics), so all-clauses-inline is achieved by trying each clause as an immediately-invoked closure with a trail/register/heap/stack restore between attempts.

```rust
pub fn lowered_grade_2(vm: &mut WamState) -> bool {
    let _t4 = vm.lo_clause_snapshot();
    if (|vm: &mut WamState| -> bool { /* alice,a */ return true; })(vm) { return true; }
    vm.lo_restore_clause(&_t4);
    if (|vm: &mut WamState| -> bool { /* bob,b  */ return true; })(vm) { return true; }
    vm.lo_restore_clause(&_t4);
    if (|vm: &mut WamState| -> bool { /* alice,c */ return true; })(vm) { return true; }
    vm.lo_restore_clause(&_t4);
    false
}
```

## Changes

- **`state.rs.mustache`**: `ClauseSnapshot` + `WamState::lo_clause_snapshot` / `lo_restore_clause` — capture/restore the clause-entry state (regs via `save_regs`/`restore_regs`, trail via `unwind_trail_to`, heap truncate, stack `Arc`, `cut_barrier`, `var_counter`), mirroring the `ChoicePoint` snapshot minus the resume pc.
- **`wam_rust_lowered_emitter.pl`**: `rust_split_clauses/2` + `rust_all_clauses_lowerable/1`; gate `multi_clause_n` between `clause_chain` (T5) and `multi_clause_1`; `emit_multi_clause_n_rust` (per-clause closures + `lo_restore_clause` between attempts).
- **`tests/test_wam_rust_lowered_t4.pl`**: gated cargo exec test. `grade/2` (fact chain, repeated first arg) and `rel/2` (rule chain, variable first arg — clause 1 clobbers A2 via `put_constant`, exercising the restore) gate as `multi_clause_n`, compile and run; pins exercise the non-first clauses natively (`grade(alice,c)`=clause 3, `grade(bob,b)`/`rel(q,two)`=clause 2) plus no-match cases.

## Verification

- New `test_wam_rust_lowered_t4`: gate (both `multi_clause_n`) + cargo exec parity (10 queries) pass.
- No regression: `test_wam_rust_lowered_t5`, `test_wam_rust_lowered_ite_exec`, `test_wam_rust_save_regs` pass (the `state.rs` additions are new public methods; no existing path changed).

Sweep so far: ✅ Scala (#2941), ✅ Rust (this). Remaining: go, cpp, haskell, fsharp, clojure, llvm, lua.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_