### PR TITLE
feat(wam-haskell): M17 get_level/cut + enable ite_use_y_level

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -292,7 +292,7 @@ wam_haskell_indicator_in_list(_Mod:Pred/Arity, HotPreds) :-
 
 % Compile WAM code on demand for the lowerability check and emission.
 wam_haskell_predicate_wamcode(PredIndicator, WamCode) :-
-    wam_target:compile_predicate_to_wam(PredIndicator, [], WamCode).
+    wam_target:compile_predicate_to_wam(PredIndicator, [ite_use_y_level(true)], WamCode).
 
 % ============================================================================
 % PHASE F1: FACT PREDICATE CLASSIFICATION
@@ -2295,6 +2295,18 @@ step !ctx s CutIte =
     (_cp : rest) -> Just (s { wsPC = wsPC s + 1, wsCPs = rest, wsCPsLen = wsCPsLen s - 1 })
     [] -> Just (s { wsPC = wsPC s + 1 })  -- no CP to pop (shouldn''t happen)
 
+-- M17 soft cut. GetLevel snapshots the current CP-stack depth into a Y
+-- register (before an if-then-else / negation try_me_else); Cut truncates
+-- the CP stack back to that depth at the commit site, removing the
+-- ITE/negation CP AND any CPs the condition pushed above it.
+step !ctx s (GetLevel reg) =
+  Just (s { wsPC = wsPC s + 1, wsRegs = IM.insert reg (Integer (wsCPsLen s)) (wsRegs s) })
+
+step !ctx s (Cut reg) =
+  case IM.lookup reg (wsRegs s) of
+    Just (Integer n) -> Just (s { wsPC = wsPC s + 1, wsCPs = take n (wsCPs s), wsCPsLen = n })
+    _ -> Just (s { wsPC = wsPC s + 1 })
+
 -- Type-checking builtins
 step !ctx s (BuiltinCall "nonvar/1" _) =
   case derefVar (wsBindings s) <$> IM.lookup 1 (wsRegs s) of
@@ -3206,6 +3218,18 @@ stepST _ _ !pw CutIte =
     (_ : rest) -> return $ Just pw { pwPC = pwPC pw + 1
                                    , pwCPs = rest, pwCPsLen = pwCPsLen pw - 1 }
     [] -> return $ Just pw { pwPC = pwPC pw + 1 }
+
+-- M17 soft cut (see the pure `step` GetLevel/Cut for semantics).
+stepST _ regs !pw (GetLevel reg) = do
+  writeArray regs reg (Integer (pwCPsLen pw))
+  return $ Just pw { pwPC = pwPC pw + 1 }
+
+stepST _ regs !pw (Cut reg) = do
+  v <- readArray regs reg
+  case v of
+    Integer n -> return $ Just pw { pwPC = pwPC pw + 1
+                                  , pwCPs = take n (pwCPs pw), pwCPsLen = n }
+    _ -> return $ Just pw { pwPC = pwPC pw + 1 }
 
 -- Type-checking builtins
 stepST _ regs !pw (BuiltinCall "nonvar/1" _) = do
@@ -5785,6 +5809,8 @@ data Instruction
   | Jump String                         -- unconditional jump to label
   | JumpPc !Int                         -- post-resolution: direct PC jump
   | CutIte                              -- soft cut: pop one CP (if-then-else)
+  | GetLevel !Int                       -- M17: snapshot CP-stack depth into a Y reg
+  | Cut !Int                            -- M17: truncate CP stack to a saved depth
   | Proceed
   | TryMeElsePc !Int                   -- post-resolution: direct PC for else branch
   | RetryMeElsePc !Int                 -- post-resolution: direct PC for next branch
@@ -6008,7 +6034,7 @@ compile_predicates_merged([PredIndicator|Rest], StartPC, Options, AllInstrs, All
 
 compile_predicates_merged_normal(PredIndicator, Pred, Arity, Rest, StartPC, Options,
                                  AllInstrs, AllLabels, AllComments, AllInlineDefs) :-
-    wam_target:compile_predicate_to_wam(PredIndicator, [], WamCode),
+    wam_target:compile_predicate_to_wam(PredIndicator, [ite_use_y_level(true)], WamCode),
     format(user_error, '  ~w/~w: compiled to WAM (PC=~w)~n', [Pred, Arity, StartPC]),
     atom_string(WamCode, WamStr),
     split_string(WamStr, "\n", "", Lines),
@@ -6463,7 +6489,7 @@ compile_single_predicate_to_haskell(PredIndicator, _Options, Code) :-
     (   PredIndicator = _Module:Pred/Arity -> true
     ;   PredIndicator = Pred/Arity
     ),
-    wam_target:compile_predicate_to_wam(PredIndicator, [], WamCode),
+    wam_target:compile_predicate_to_wam(PredIndicator, [ite_use_y_level(true)], WamCode),
     format(user_error, '  ~w/~w: compiled to WAM~n', [Pred, Arity]),
     % Parse WAM text into Haskell instruction list and label map
     atom_string(WamCode, WamStr),
@@ -6634,6 +6660,12 @@ wam_instr_to_haskell(["proceed"], "Proceed").
 wam_instr_to_haskell(["jump", Label], Hs) :-
     format(string(Hs), 'Jump "~w"', [Label]).
 wam_instr_to_haskell(["cut_ite"], "CutIte").
+wam_instr_to_haskell(["get_level", Yn], Hs) :-
+    clean_comma(Yn, CYn), reg_name_to_int(CYn, YnI),
+    format(string(Hs), 'GetLevel ~w', [YnI]).
+wam_instr_to_haskell(["cut", Yn], Hs) :-
+    clean_comma(Yn, CYn), reg_name_to_int(CYn, YnI),
+    format(string(Hs), 'Cut ~w', [YnI]).
 wam_instr_to_haskell(["builtin_call", Op, N], Hs) :-
     clean_comma(Op, COp), clean_comma(N, CN),
     (   number_string(Num, CN) -> true ; Num = 0 ),

--- a/tests/test_wam_haskell_target.pl
+++ b/tests/test_wam_haskell_target.pl
@@ -48,6 +48,40 @@ test_haskell_helper_functions_present :-
     ;   fail_test(Test, 'Missing bindOutput/copyTermWalk/copyTermArgs helpers')
     ).
 
+% M17 soft cut: the runtime must declare GetLevel/Cut instructions and both
+% interpreters (step + stepST) must handle them. Enabled via
+% ite_use_y_level(true) at the compile sites so cuts in negation / forall
+% scope correctly instead of using legacy cut_ite.
+test_haskell_m17_get_level_cut :-
+    Test = 'WAM-Haskell: M17 get_level/cut emitted for negation (no cut_ite)',
+    Dir = 'output/test_haskell_m17_check',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    catch(
+        (   assertz((user:m17chk_g(1))),
+            assertz((user:m17chk :- \+ (m17chk_g(_), !, fail))),
+            write_wam_haskell_project([user:m17chk_g/1, user:m17chk/0],
+                                      [module_name('m17chk'), emit_mode(functions)], Dir),
+            atomic_list_concat([Dir, '/src/Predicates.hs'], PredF),
+            atomic_list_concat([Dir, '/src/WamRuntime.hs'], RtF),
+            read_file_to_string(PredF, PredCode, []),
+            read_file_to_string(RtF, RtCode, []),
+            (   sub_string(PredCode, _, _, _, "GetLevel "),   % instruction emitted (M17, not cut_ite)
+                sub_string(RtCode, _, _, _, "GetLevel reg"),  % step handler present
+                sub_string(RtCode, _, _, _, "Cut reg")
+            ->  Ok = true
+            ;   Ok = false
+            )
+        ),
+        _Err,
+        Ok = error),
+    retractall(user:m17chk_g(_)),
+    retractall(user:m17chk),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    (   Ok == true
+    ->  pass(Test)
+    ;   fail_test(Test, 'get_level not emitted in Predicates.hs or runtime handler missing')
+    ).
+
 test_haskell_functor_builtin_present :-
     Test = 'WAM-Haskell: functor/3 step case generated',
     (   compile_wam_runtime_to_haskell([], [], Code),
@@ -2520,6 +2554,7 @@ run_tests :-
     format('WAM-Haskell target: Phase 5+6+7+8+F1-F4+E2E+B1 codegen tests~n'),
     format('========================================~n~n'),
     test_haskell_helper_functions_present,
+    test_haskell_m17_get_level_cut,
     test_haskell_functor_builtin_present,
     test_haskell_arg_builtin_present,
     test_haskell_univ_builtin_present,


### PR DESCRIPTION
  Ports M17 soft-cut to the Haskell hybrid WAM so cuts in negation/forall scope correctly (previously
  only legacy cut_ite, which mishandles inline-cut-in-negation and forall-over-generator).

  - Add GetLevel/Cut to the Instr type.
  - Handle them in both interpreters (step + stepST): GetLevel snapshots the CP-stack depth into a Y
  register; Cut truncates the CP stack to it (mirrors the existing !/0 cut via wsCutBar/pwCutBar).
  - Translate get_level/cut WAM text (wam_instr_to_haskell).
  - Pass ite_use_y_level(true) at all three compile_predicate_to_wam sites (lowerability check +
  merged-interpreter + single-predicate codegen).

  Test plan: codegen-level (no ghc) — Predicates.hs emits GetLevel (not cut_ite), WamRuntime.hs has
  the step handlers; test_haskell_m17_get_level_cut added; cross-target conformance/consistency +
  test_wam_target green; pre-existing structural failures unchanged from baseline. Cut-semantics e2e
  (ghc/cabal) blocked locally by the missing async package (offline) — verify in an env with async.

  🤖 Generated with Claude Code (https://claude.com/claude-code)