### PR TITLE
fix(wam-rust): execute compiled runtime parser bridge

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -28,6 +28,10 @@
 :- use_module('../core/template_system').
 :- use_module('../bindings/rust_wam_bindings').
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../targets/wam_text_parser', [
+    wam_classify_constant_token/2,
+    wam_tokenize_line/2
+]).
 :- use_module('../targets/wam_rust_lowered_emitter', [
     wam_rust_lowerable/3,
     lower_predicate_to_rust/4,
@@ -47,6 +51,10 @@
     kernel_native_call/2
 ]).
 
+rust_safe_function_name(Pred/Arity, FuncName) :-
+    !,
+    rust_safe_function_name(Pred, BaseName),
+    format(atom(FuncName), '~w_~w', [BaseName, Arity]).
 rust_safe_function_name(Pred, FuncName) :-
     atom_string(Pred, PredStr),
     string_codes(PredStr, Codes),
@@ -144,17 +152,23 @@ wam_instruction_arm('Instruction::GetStructure(fn_str, ai)', Body) :-
                     if val.is_unbound() {
                         // Write mode
                         let addr = self.heap.len();
-                        self.heap.push(Value::Str(format!("str({})", fn_str), vec![]));
-                        self.trail_binding(ai);
-                        self.set_reg_str(ai, Value::Ref(addr));
                         let arity = fn_str.split(\'/\').nth(1)
                             .and_then(|s| s.parse::<usize>().ok()).unwrap_or(0);
-                        self.smut().push(StackEntry::WriteCtx(arity));
+                        self.heap.push(Value::Str(fn_str.clone(), vec![]));
+                        for _ in 0..arity {
+                            self.heap.push(Value::Atom("__struct_arg__".to_string()));
+                        }
+                        self.trail_binding(ai);
+                        if let Value::Unbound(ref name) = val {
+                            self.bind_var(name, Value::Ref(addr));
+                        }
+                        self.set_reg_str(ai, Value::Ref(addr));
+                        self.smut().push(StackEntry::WriteCtx(addr));
                         self.pc += 1; true
                     } else if let Value::Ref(addr) = &val {
                         // Read mode on heap ref
                         if let Some(Value::Str(s, _)) = self.heap.get(*addr) {
-                            if s == &format!("str({})", fn_str) {
+                            if s == fn_str || s == &format!("str({})", fn_str) {
                                 let arity = fn_str.split(\'/\').nth(1)
                                     .and_then(|s| s.parse::<usize>().ok()).unwrap_or(0);
                                 let args = self.heap_subargs(addr + 1, arity);
@@ -180,13 +194,15 @@ wam_instruction_arm('Instruction::GetList(ai)', Body) :-
                     let val = self.deref_var(&raw);
                     if val.is_unbound() {
                         let addr = self.heap.len();
-                        self.heap.push(Value::Str("str(./2)".to_string(), vec![]));
+                        self.heap.push(Value::Str("./2".to_string(), vec![]));
+                        self.heap.push(Value::Atom("__struct_arg__".to_string()));
+                        self.heap.push(Value::Atom("__struct_arg__".to_string()));
                         self.trail_binding(ai);
                         if let Value::Unbound(ref name) = val {
                             self.bind_var(name, Value::Ref(addr));
                         }
                         self.set_reg_str(ai, Value::Ref(addr));
-                        self.smut().push(StackEntry::WriteCtx(2));
+                        self.smut().push(StackEntry::WriteCtx(addr));
                         self.pc += 1; true
                     } else if let Value::List(items) = &val {
                         if let Some((head, tail)) = items.split_first() {
@@ -223,16 +239,12 @@ wam_instruction_arm('Instruction::UnifyVariable(xn)', Body) :-
                         self.put_reg(xn, arg);
                         self.pc += 1; true
                     } else { false }
-                } else if let Some(StackEntry::WriteCtx(n)) = self.stack.last().cloned() {
-                    if n > 0 {
-                        let addr = self.heap.len();
-                        let var = Value::Unbound(format!("_H{}", addr));
-                        self.heap.push(var.clone());
-                        self.smut().pop();
-                        if n - 1 > 0 { self.smut().push(StackEntry::WriteCtx(n - 1)); }
-                        self.put_reg(xn, var);
-                        self.pc += 1; true
-                    } else { false }
+                } else if let Some(StackEntry::WriteCtx(_marker)) = self.stack.last().cloned() {
+                    let var = Value::Unbound(format!("_H{}", self.var_counter));
+                    self.var_counter += 1;
+                    self.set_heap_or_list(var.clone());
+                    self.put_reg(xn, var);
+                    self.pc += 1; true
                 } else { false }'.
 
 wam_instruction_arm('Instruction::UnifyValue(xn)', Body) :-
@@ -258,14 +270,10 @@ wam_instruction_arm('Instruction::UnifyValue(xn)', Body) :-
                             self.pc += 1; true
                         } else { false }
                     } else { false }
-                } else if let Some(StackEntry::WriteCtx(n)) = self.stack.last().cloned() {
-                    if n > 0 {
-                        if let Some(val) = self.get_reg(xn) {
-                            self.heap.push(val);
-                            self.smut().pop();
-                            if n - 1 > 0 { self.smut().push(StackEntry::WriteCtx(n - 1)); }
-                            self.pc += 1; true
-                        } else { false }
+                } else if let Some(StackEntry::WriteCtx(_marker)) = self.stack.last().cloned() {
+                    if let Some(val) = self.get_reg(xn) {
+                        self.set_heap_or_list(val);
+                        self.pc += 1; true
                     } else { false }
                 } else { false }'.
 
@@ -281,13 +289,9 @@ wam_instruction_arm('Instruction::UnifyConstant(c)', Body) :-
                             self.pc += 1; true
                         } else { false }
                     } else { false }
-                } else if let Some(StackEntry::WriteCtx(n)) = self.stack.last().cloned() {
-                    if n > 0 {
-                        self.heap.push(c.clone());
-                        self.smut().pop();
-                        if n - 1 > 0 { self.smut().push(StackEntry::WriteCtx(n - 1)); }
-                        self.pc += 1; true
-                    } else { false }
+                } else if let Some(StackEntry::WriteCtx(_marker)) = self.stack.last().cloned() {
+                    self.set_heap_or_list(c.clone());
+                    self.pc += 1; true
                 } else { false }'.
 
 % --- Body Construction Instructions ---
@@ -352,8 +356,8 @@ wam_instruction_arm('Instruction::PutList(ai)', Body) :-
                 self.pc += 1; true'.
 
 wam_instruction_arm('Instruction::SetVariable(xn)', Body) :-
-    Body = '                let addr = self.heap.len();
-                let var = Value::Unbound(format!("_H{}", addr));
+    Body = '                let var = Value::Unbound(format!("_H{}", self.var_counter));
+                self.var_counter += 1;
                 self.put_reg(xn, var.clone());
                 // Write the fresh variable into the current structure/list arg
                 // slot, exactly as set_value/set_constant do. Without this the
@@ -629,7 +633,9 @@ wam_instruction_arm('Instruction::ReturnAdd1(out_reg, in_reg)', Body) :-
 
 wam_instruction_arm('Instruction::Allocate', Body) :-
     Body = '                use std::collections::HashMap;
-                self.cut_barrier = self.choice_points.len();
+                self.cut_barrier = self.pending_cut_barrier
+                    .take()
+                    .unwrap_or(self.choice_points.len());
                 let saved_cp = self.cp;
                 self.smut().push(StackEntry::Env(saved_cp, HashMap::new()));
                 self.pc += 1; true'.
@@ -715,6 +721,12 @@ wam_instruction_arm('Instruction::Proceed', Body) :-
                 self.pc = ret;
                 true'.
 
+wam_instruction_arm('Instruction::Jump(label)', Body) :-
+    Body = '                if let Some(&target_pc) = self.labels.get(label) {
+                    self.pc = target_pc;
+                    true
+                } else { false }'.
+
 wam_instruction_arm('Instruction::NoOp', Body) :-
     Body = '                self.pc += 1; true'.
 
@@ -754,6 +766,7 @@ wam_instruction_arm('Instruction::EndAggregate(value_reg)', Body) :-
 
 wam_instruction_arm('Instruction::TryMeElse(label)', Body) :-
     Body = '                if let Some(&next_pc) = self.labels.get(label) {
+                    let clause_barrier = self.choice_points.len();
                     self.choice_points.push(ChoicePoint {
                         next_pc,
                         saved_args: self.save_regs(),
@@ -764,11 +777,17 @@ wam_instruction_arm('Instruction::TryMeElse(label)', Body) :-
                         builtin_state: None,
                         cut_barrier: self.cut_barrier,
                     });
+                    if label.starts_with("L_ite_else_") {
+                        self.pending_cut_barrier = None;
+                    } else {
+                        self.pending_cut_barrier = Some(clause_barrier);
+                    }
                     self.pc += 1; true
                 } else { false }'.
 
 wam_instruction_arm('Instruction::TryMeElsePc(next_pc)', Body) :-
-    Body = '                self.choice_points.push(ChoicePoint {
+    Body = '                let clause_barrier = self.choice_points.len();
+                self.choice_points.push(ChoicePoint {
                     next_pc: *next_pc,
                     saved_args: self.save_regs(),
                     cp: self.cp,
@@ -778,6 +797,7 @@ wam_instruction_arm('Instruction::TryMeElsePc(next_pc)', Body) :-
                     builtin_state: None,
                     cut_barrier: self.cut_barrier,
                 });
+                self.pending_cut_barrier = Some(clause_barrier);
                 self.pc += 1; true'.
 
 wam_instruction_arm('Instruction::TrustMe', Body) :-
@@ -789,6 +809,7 @@ wam_instruction_arm('Instruction::RetryMeElse(label)', Body) :-
                     if let Some(cp) = self.choice_points.last_mut() {
                         cp.next_pc = next_pc;
                     }
+                    self.pending_cut_barrier = Some(self.choice_points.len().saturating_sub(1));
                     self.pc += 1; true
                 } else { false }'.
 
@@ -796,6 +817,7 @@ wam_instruction_arm('Instruction::RetryMeElsePc(next_pc)', Body) :-
     Body = '                if let Some(cp) = self.choice_points.last_mut() {
                     cp.next_pc = *next_pc;
                 }
+                self.pending_cut_barrier = Some(self.choice_points.len().saturating_sub(1));
                 self.pc += 1; true'.
 
 % --- Indexing Instructions ---
@@ -1029,6 +1051,7 @@ compile_backtrack_to_rust(Code0) :-
             self.restore_regs(&cp.saved_args);
             self.cp = cp.cp;
             self.cut_barrier = cp.cut_barrier;
+            self.pending_cut_barrier = None;
 
             if let Some(state) = cp.builtin_state {
                 self.choice_points.pop();
@@ -1130,8 +1153,10 @@ compile_execute_arith_builtin_to_rust(Code) :-
                 } else { false }
             }
             "==/2" => {
-                let v1 = self.get_reg_raw("A1");
-                let v2 = self.get_reg_raw("A2");
+                let v1 = self.get_reg_raw("A1")
+                    .map(|v| self.deref_heap(&self.deref_var(&v)));
+                let v2 = self.get_reg_raw("A2")
+                    .map(|v| self.deref_heap(&self.deref_var(&v)));
                 if v1 == v2 { self.pc += 1; true } else { false }
             }
             _ => false,
@@ -1229,8 +1254,17 @@ compile_execute_term_builtin_to_rust(Code) :-
                 }
             }
             "append/3" => {
-                eprintln!("Warning: append/3 is not yet implemented in WAM-Rust runtime");
-                false
+                let a1 = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+                let a2 = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+                let a3 = self.get_reg_raw("A3").unwrap_or(Value::Uninit);
+                match (self.value_as_list(&a1), self.value_as_list(&a2)) {
+                    (Some(mut left), Some(right)) => {
+                        left.extend(right);
+                        if self.unify(&a3, &Value::List(left)) { self.pc += 1; true }
+                        else { false }
+                    }
+                    _ => false,
+                }
             }
             "functor/3" => {
                 let t = self.get_reg_raw("A1")
@@ -1387,6 +1421,12 @@ compile_execute_term_builtin_to_rust(Code) :-
                     } else { false }
                 } else { false }
             }
+            "reverse/2" => { self.execute_reverse_builtin() }
+            "atom_codes/2" => { self.execute_atom_codes_builtin() }
+            "number_codes/2" => { self.execute_number_codes_builtin() }
+            "term_to_atom/2" => { self.execute_term_to_atom_builtin() }
+            "read_term_from_atom/2" => { self.execute_read_term_from_atom_builtin(2) }
+            "read_term_from_atom/3" => { self.execute_read_term_from_atom_builtin(3) }
             _ => false,
         }
     }
@@ -1425,6 +1465,268 @@ compile_execute_term_builtin_to_rust(Code) :-
             }
             _ => v.clone(),
         }
+    }
+
+    fn execute_reverse_builtin(&mut self) -> bool {
+        let src = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+        let dst = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+        match self.value_as_list(&src) {
+            Some(mut items) => {
+                items.reverse();
+                if self.unify(&dst, &Value::List(items)) { self.pc += 1; true }
+                else { false }
+            }
+            None => false,
+        }
+    }
+
+    fn execute_atom_codes_builtin(&mut self) -> bool {
+        let atom_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+        let codes_raw = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+        let atom = self.deref_heap(&self.deref_var(&atom_raw));
+        let codes = self.deref_heap(&self.deref_var(&codes_raw));
+        match (atom, codes) {
+            (Value::Atom(text), _) => {
+                let list = Self::string_to_codes_value(&text);
+                if self.unify(&codes_raw, &list) { self.pc += 1; true }
+                else { false }
+            }
+            (Value::Unbound(_), Value::List(items)) => {
+                match self.code_list_to_string(&items) {
+                    Some(text) => {
+                        if self.unify(&atom_raw, &Value::Atom(text)) { self.pc += 1; true }
+                        else { false }
+                    }
+                    None => false,
+                }
+            }
+            _ => false,
+        }
+    }
+
+    fn execute_number_codes_builtin(&mut self) -> bool {
+        let num_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+        let codes_raw = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+        let num = self.deref_heap(&self.deref_var(&num_raw));
+        let codes = self.deref_heap(&self.deref_var(&codes_raw));
+        match (num, codes) {
+            (Value::Integer(n), _) => {
+                let list = Self::string_to_codes_value(&n.to_string());
+                if self.unify(&codes_raw, &list) { self.pc += 1; true }
+                else { false }
+            }
+            (Value::Float(f), _) => {
+                let list = Self::string_to_codes_value(&f.to_string());
+                if self.unify(&codes_raw, &list) { self.pc += 1; true }
+                else { false }
+            }
+            (Value::Unbound(_), Value::List(items)) => {
+                match self.code_list_to_string(&items) {
+                    Some(text) => {
+                        let parsed = if let Ok(n) = text.parse::<i64>() {
+                            Some(Value::Integer(n))
+                        } else if let Ok(f) = text.parse::<f64>() {
+                            Some(Value::Float(f))
+                        } else {
+                            None
+                        };
+                        match parsed {
+                            Some(v) => {
+                                if self.unify(&num_raw, &v) { self.pc += 1; true }
+                                else { false }
+                            }
+                            None => false,
+                        }
+                    }
+                    None => false,
+                }
+            }
+            _ => false,
+        }
+    }
+
+    fn execute_term_to_atom_builtin(&mut self) -> bool {
+        let term_raw = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+        let atom_raw = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+        let term = self.deref_heap(&self.deref_var(&term_raw));
+        if matches!(term, Value::Unbound(_)) {
+            let atom = self.deref_heap(&self.deref_var(&atom_raw));
+            match atom {
+                Value::Atom(text) => {
+                    if self.bind_compiled_parse_atom(&text, "A1") { self.pc += 1; true }
+                    else { false }
+                }
+                _ => false,
+            }
+        } else {
+            let rendered = self.term_to_atom_text(&term);
+            if self.unify(&atom_raw, &Value::Atom(rendered)) { self.pc += 1; true }
+            else { false }
+        }
+    }
+
+    fn execute_read_term_from_atom_builtin(&mut self, _arity: usize) -> bool {
+        let atom = self.get_reg_raw("A1")
+            .map(|v| self.deref_heap(&self.deref_var(&v)));
+        match atom {
+            Some(Value::Atom(text)) => {
+                if self.bind_compiled_parse_atom(&text, "A2") { self.pc += 1; true }
+                else { false }
+            }
+            _ => false,
+        }
+    }
+
+    fn bind_compiled_parse_atom(&mut self, atom_text: &str, target_reg: &str) -> bool {
+        if !self.labels.contains_key("canonical_op_table/1") ||
+           !self.labels.contains_key("parse_term_from_atom/3") {
+            return false;
+        }
+        let mut parser = WamState::new(self.code.clone(), self.labels.clone());
+
+        let ops_var = Value::Unbound("_RP_ops".to_string());
+        parser.set_reg_str("A1", ops_var.clone());
+        if !parser.run_named_label("canonical_op_table/1") {
+            return false;
+        }
+        let ops = parser.deref_heap(&parser.deref_var(&ops_var));
+
+        parser.reset_query();
+        let parsed_var = Value::Unbound("_RP_term".to_string());
+        parser.set_reg_str("A1", Value::Atom(atom_text.to_string()));
+        parser.set_reg_str("A2", ops);
+        parser.set_reg_str("A3", parsed_var.clone());
+        if !parser.run_named_label("parse_term_from_atom/3") {
+            return false;
+        }
+
+        let parsed = parser.deref_heap(&parser.deref_var(&parsed_var));
+        let mut var_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let copied = self.copy_external_term_from(&parser, &parsed, &mut var_map);
+        match self.get_reg_raw(target_reg) {
+            Some(target) => self.unify(&target, &copied),
+            None => false,
+        }
+    }
+
+    fn run_named_label(&mut self, label: &str) -> bool {
+        match self.labels.get(label).copied() {
+            Some(pc) => {
+                self.pc = pc;
+                self.cp = 0;
+                self.step_count = 0;
+                self.run()
+            }
+            None => false,
+        }
+    }
+
+    fn copy_external_term_from(
+        &mut self,
+        source: &WamState,
+        value: &Value,
+        var_map: &mut std::collections::HashMap<String, String>,
+    ) -> Value {
+        let derefed_var = source.deref_var(value);
+        let derefed = source.deref_heap(&derefed_var);
+        match derefed {
+            Value::Unbound(name) => {
+                if let Some(new_name) = var_map.get(&name) {
+                    Value::Unbound(new_name.clone())
+                } else {
+                    self.var_counter += 1;
+                    let new_name = format!("_RP{}", self.var_counter);
+                    var_map.insert(name, new_name.clone());
+                    Value::Unbound(new_name)
+                }
+            }
+            Value::Str(f, args) => {
+                let copied_args: Vec<Value> = args.iter()
+                    .map(|a| self.copy_external_term_from(source, a, var_map))
+                    .collect();
+                Value::Str(Self::display_functor_name(&f, copied_args.len()), copied_args)
+            }
+            Value::List(items) => {
+                let copied_items: Vec<Value> = items.iter()
+                    .map(|i| self.copy_external_term_from(source, i, var_map))
+                    .collect();
+                Value::List(copied_items)
+            }
+            other => other,
+        }
+    }
+
+    fn value_as_list(&self, value: &Value) -> Option<Vec<Value>> {
+        let derefed = self.deref_heap(&self.deref_var(value));
+        match derefed {
+            Value::List(items) => Some(items),
+            Value::Atom(s) if s == "[]" => Some(Vec::new()),
+            Value::Str(f, args) if self.is_cons_functor(&f) && args.len() == 2 => {
+                let mut tail = self.value_as_list(&args[1])?;
+                tail.insert(0, args[0].clone());
+                Some(tail)
+            }
+            _ => None,
+        }
+    }
+
+    fn string_to_codes_value(text: &str) -> Value {
+        Value::List(text.chars()
+            .map(|c| Value::Integer(c as i64))
+            .collect())
+    }
+
+    fn code_list_to_string(&self, items: &[Value]) -> Option<String> {
+        let mut out = String::new();
+        for item in items {
+            let derefed = self.deref_heap(&self.deref_var(item));
+            match derefed {
+                Value::Integer(code) if code >= 0 => {
+                    out.push(char::from_u32(code as u32)?);
+                }
+                _ => return None,
+            }
+        }
+        Some(out)
+    }
+
+    fn term_to_atom_text(&self, value: &Value) -> String {
+        let derefed = self.deref_heap(&self.deref_var(value));
+        match derefed {
+            Value::Atom(s) => s,
+            Value::Integer(n) => n.to_string(),
+            Value::Float(f) => f.to_string(),
+            Value::Bool(b) => b.to_string(),
+            Value::Unbound(name) => name,
+            Value::List(items) => {
+                let rendered: Vec<String> = items.iter()
+                    .map(|i| self.term_to_atom_text(i))
+                    .collect();
+                format!("[{}]", rendered.join(", "))
+            }
+            Value::Str(f, args) => {
+                let name = Self::display_functor_name(&f, args.len());
+                let rendered: Vec<String> = args.iter()
+                    .map(|a| self.term_to_atom_text(a))
+                    .collect();
+                format!("{}({})", name, rendered.join(", "))
+            }
+            Value::Ref(_) => format!("{}", derefed),
+            Value::Uninit => "_".to_string(),
+        }
+    }
+
+    fn display_functor_name(functor: &str, arity: usize) -> String {
+        let mut name = functor
+            .strip_prefix("str(")
+            .and_then(|s| s.strip_suffix(")"))
+            .unwrap_or(functor);
+        if let Some((base, ar)) = name.rsplit_once(''/'') {
+            if ar.parse::<usize>().ok() == Some(arity) {
+                name = base;
+            }
+        }
+        name.to_string()
     }'.
 
 compile_execute_foreign_predicate_to_rust(Code) :-
@@ -2636,7 +2938,7 @@ compile_wam_runtime_to_rust(Options, RustCode) :-
 %  that creates instruction data and executes it via the WAM runtime.
 compile_wam_predicate_to_rust(Pred/Arity, WamCode, Options, RustCode) :-
     atom_string(Pred, PredStr),
-    rust_safe_function_name(Pred, FuncName),
+    rust_safe_function_name(Pred/Arity, FuncName),
     build_rust_wam_arg_list(Arity, ArgList),
     build_rust_wam_arg_setup(Arity, ArgSetup),
     foreign_wrapper_setup(Pred/Arity, WamCode, Options, InstrSetup, ForeignSetup, RunExpr),
@@ -2753,8 +3055,7 @@ wam_code_to_rust_instructions(WamCode, PredIndicator, Options, InstrLiterals, La
 
 wam_lines_to_rust([], _, _, _, [], []).
 wam_lines_to_rust([Line|Rest], PC, PredIndicator, Options, Instrs, Labels) :-
-    split_string(Line, " \t,", " \t,", Parts),
-    delete(Parts, "", CleanParts),
+    wam_tokenize_line(Line, CleanParts),
     (   CleanParts == []
     ->  wam_lines_to_rust(Rest, PC, PredIndicator, Options, Instrs, Labels)
     ;   CleanParts = [First|_],
@@ -2811,12 +3112,8 @@ wam_line_to_rust_instr(["unify_value", Xn], _, _, Rust) :-
     format(string(Rust),
         'Instruction::UnifyValue("~w".to_string())', [Xn]).
 wam_line_to_rust_instr(["unify_constant", C], _, _, Rust) :-
-    (   number_string(N, C)
-    ->  format(string(Rust),
-            'Instruction::UnifyConstant(Value::Integer(~w))', [N])
-    ;   format(string(Rust),
-            'Instruction::UnifyConstant(Value::Atom("~w".to_string()))', [C])
-    ).
+    rust_const_value(C, VExpr),
+    format(string(Rust), 'Instruction::UnifyConstant(~w)', [VExpr]).
 wam_line_to_rust_instr(["put_constant", C, Ai], _, _, Rust) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),
     rust_const_value(CC, VExpr),
@@ -2849,12 +3146,8 @@ wam_line_to_rust_instr(["set_value", Xn], _, _, Rust) :-
     format(string(Rust),
         'Instruction::SetValue("~w".to_string())', [Xn]).
 wam_line_to_rust_instr(["set_constant", C], _, _, Rust) :-
-    (   number_string(N, C)
-    ->  format(string(Rust),
-            'Instruction::SetConstant(Value::Integer(~w))', [N])
-    ;   format(string(Rust),
-            'Instruction::SetConstant(Value::Atom("~w".to_string()))', [C])
-    ).
+    rust_const_value(C, VExpr),
+    format(string(Rust), 'Instruction::SetConstant(~w)', [VExpr]).
 wam_line_to_rust_instr(["allocate"], _, _, "Instruction::Allocate").
 wam_line_to_rust_instr(["deallocate"], _, _, "Instruction::Deallocate").
 wam_line_to_rust_instr(["call", P, N], Pred/Arity, Options, Rust) :-
@@ -2896,10 +3189,21 @@ wam_line_to_rust_instr(["end_aggregate", ValueReg], _, _, Rust) :-
 wam_line_to_rust_instr(["try_me_else", Label], _, _, Rust) :-
     format(string(Rust),
         'Instruction::TryMeElse("~w".to_string())', [Label]).
+wam_line_to_rust_instr(["try", Label], _, _, Rust) :-
+    format(string(Rust),
+        'Instruction::TryMeElse("~w".to_string())', [Label]).
 wam_line_to_rust_instr(["trust_me"], _, _, "Instruction::TrustMe").
+wam_line_to_rust_instr(["trust", _Label], _, _, "Instruction::TrustMe").
 wam_line_to_rust_instr(["retry_me_else", Label], _, _, Rust) :-
     format(string(Rust),
         'Instruction::RetryMeElse("~w".to_string())', [Label]).
+wam_line_to_rust_instr(["retry", Label], _, _, Rust) :-
+    format(string(Rust),
+        'Instruction::RetryMeElse("~w".to_string())', [Label]).
+wam_line_to_rust_instr(["jump", Label], _, _, Rust) :-
+    format(string(Rust),
+        'Instruction::Jump("~w".to_string())', [Label]).
+wam_line_to_rust_instr(["cut_ite"], _, _, "Instruction::NoOp").
 % Indexing instructions
 wam_line_to_rust_instr(["switch_on_constant"|Entries], _, _, Rust) :-
     maplist(parse_index_entry_constant, Entries, RustEntries),
@@ -2944,11 +3248,14 @@ wam_line_to_rust_instr(Parts, _, _, Rust) :-
 %  unify_constant already did this; this routes the remaining two through
 %  the same rule.
 rust_const_value(C, Expr) :-
-    (   number_string(N, C), integer(N)
+    wam_classify_constant_token(C, Class),
+    (   Class = integer(N)
     ->  format(string(Expr), 'Value::Integer(~w)', [N])
-    ;   number_string(N, C), float(N)
+    ;   Class = float(N)
     ->  format(string(Expr), 'Value::Float(~w)', [N])
-    ;   format(string(Expr), 'Value::Atom("~w".to_string())', [C])
+    ;   Class = atom(A)
+    ->  escape_rust_string(A, Escaped),
+        format(string(Expr), 'Value::Atom("~w".to_string())', [Escaped])
     ).
 
 rust_foreign_rewrite_call(Options, CurrentPred, TargetPredArity, Num, ForeignPred, ForeignArity) :-
@@ -3496,7 +3803,7 @@ generate_predicate_codes([classified(_, _Pred, _Arity, failed, PredCode)|Rest],
 %  Generates a thin WAM predicate wrapper that references the shared code table.
 compile_wam_predicate_to_rust_shared(Pred/Arity, StartPC, RustCode) :-
     atom_string(Pred, PredStr),
-    rust_safe_function_name(Pred, FuncName),
+    rust_safe_function_name(Pred/Arity, FuncName),
     build_rust_wam_arg_list(Arity, ArgList),
     build_rust_wam_arg_setup(Arity, ArgSetup),
     format(string(RustCode),

--- a/templates/targets/rust_wam/instructions.rs.mustache
+++ b/templates/targets/rust_wam/instructions.rs.mustache
@@ -80,6 +80,8 @@ pub enum Instruction {
     ExecutePc(usize),
     /// Return from predicate (jump to CP).
     Proceed,
+    /// Unconditional jump to a label.
+    Jump(String),
     /// No-op: advances the program counter by one. Emitted for WAM
     /// instructions the Rust backend does not (yet) translate — chiefly the
     /// first-argument indexing hints (switch_on_term, ...). Indexing is only

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -377,6 +377,10 @@ pub struct WamState {
     /// Cut barrier: choice point stack depth at the most recent neck/Allocate.
     /// !/0 truncates choice_points to this depth instead of clearing all.
     pub cut_barrier: usize,
+    /// Pending barrier captured before a predicate clause choice point was
+    /// pushed. The following Allocate consumes it so neck cuts commit to the
+    /// current clause instead of leaving the predicate alternative alive.
+    pub pending_cut_barrier: Option<usize>,
     /// Step counter for limiting exploration on dense cyclic graphs.
     pub step_count: u64,
     /// Maximum steps per query (0 = unlimited).
@@ -436,6 +440,7 @@ impl WamState {
             bindings: HashMap::new(),
             var_counter: 0,
             cut_barrier: 0,
+            pending_cut_barrier: None,
             step_count: 0,
             step_limit: 0,
             backtrack_count: 0,
@@ -789,6 +794,7 @@ impl WamState {
         self.cp = 0;
         self.var_counter = 0;
         self.cut_barrier = 0;
+        self.pending_cut_barrier = None;
         self.step_count = 0;
         self.backtrack_count = 0;
         self.aggregate_acc.clear();
@@ -1028,6 +1034,44 @@ impl WamState {
                 }
                 val.clone()
             }
+            Value::Str(full_str, args) => {
+                let derefed: Vec<Value> = args.iter()
+                    .map(|a| self.deref_heap(&self.deref_var(a)))
+                    .collect();
+                let inner = if full_str.starts_with("str(") && full_str.ends_with(')') {
+                    &full_str[4..full_str.len() - 1]
+                } else {
+                    full_str
+                };
+                let functor = if let Some(slash) = inner.rfind('/') {
+                    match inner[slash + 1..].parse::<usize>() {
+                        Ok(arity) if arity == derefed.len() => &inner[..slash],
+                        _ => inner,
+                    }
+                } else {
+                    inner
+                };
+                if self.is_cons_functor(functor) && derefed.len() == 2 {
+                    let head = derefed[0].clone();
+                    let tail = derefed[1].clone();
+                    match tail {
+                        Value::List(mut items) => {
+                            items.insert(0, head);
+                            return Value::List(items);
+                        }
+                        Value::Atom(ref s) if s == "[]" => {
+                            return Value::List(vec![head]);
+                        }
+                        _ => return Value::Str("[|]/2".to_string(), vec![head, tail]),
+                    }
+                }
+                Value::Str(functor.to_string(), derefed)
+            }
+            Value::List(items) => {
+                Value::List(items.iter()
+                    .map(|i| self.deref_heap(&self.deref_var(i)))
+                    .collect())
+            }
             Value::Ref(addr) => {
                 if let Some(Value::Str(full_str, _)) = self.heap.get(*addr) {
                     // Parse functor/arity from str(F/N) format
@@ -1056,7 +1100,7 @@ impl WamState {
                                         Value::Atom(ref s) if s == "[]" => {
                                             return Value::List(vec![head]);
                                         }
-                                        _ => return Value::List(vec![head, tail]),
+                                        _ => return Value::Str("[|]/2".to_string(), vec![head, tail]),
                                     }
                                 }
                             }
@@ -1258,6 +1302,8 @@ impl WamState {
             "execute" if args.len() == 1 =>
                 Some(Instruction::Execute(args[0].clone())),
             "proceed" => Some(Instruction::Proceed),
+            "jump" if args.len() == 1 =>
+                Some(Instruction::Jump(args[0].clone())),
             "builtin_call" if args.len() == 2 => {
                 let arity = args[1].parse::<usize>().ok()?;
                 Some(Instruction::BuiltinCall(args[0].clone(), arity))

--- a/tests/test_wam_rust_target.pl
+++ b/tests/test_wam_rust_target.pl
@@ -281,6 +281,45 @@ fail_test(Test, Reason) :-
     format('[FAIL] ~w: ~w~n', [Test, Reason]),
     (   test_failed -> true ; assert(test_failed) ).
 
+cargo_available :-
+    catch(
+        (   process_create(path(cargo), ['--version'],
+                [stdout(pipe(S)), stderr(pipe(_)), process(Pid)]),
+            read_string(S, _, _),
+            close(S),
+            process_wait(Pid, exit(0))
+        ),
+        _,
+        fail).
+
+cargo_test_project(ProjectDir, TestName, Result) :-
+    (   cargo_available
+    ->  format(atom(Cmd), 'cd "~w" && cargo test --test ~w 2>&1',
+            [ProjectDir, TestName]),
+        catch(
+            (   process_create(path(sh), ['-c', Cmd],
+                    [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+                read_string(Out, _, OutStr),
+                close(Out),
+                read_string(Err, _, ErrStr),
+                close(Err),
+                process_wait(Pid, exit(ExitCode))
+            ),
+            E,
+            (   format(user_error, 'cargo test error: ~w~n', [E]),
+                ExitCode = -1,
+                OutStr = "",
+                ErrStr = ""
+            )
+        ),
+        (   ExitCode == 0
+        ->  Result = ok
+        ;   atomic_list_concat([OutStr, ErrStr], '\n', FullOutput),
+            Result = error(ExitCode, FullOutput)
+        )
+    ;   Result = not_available
+    ).
+
 check_brace_balance(String) :-
     string_chars(String, Chars),
     count_chars(Chars, '{', Open),
@@ -417,14 +456,19 @@ test_builtin_dispatch :-
         sub_string(S, _, _, _, 'number/1'),
         sub_string(S, _, _, _, 'member/2'),
         sub_string(S, _, _, _, 'builtin_state'),
-        sub_string(S, _, _, _, 'eprintln!'),
         %% Phase 4: Group A term inspection builtins are present.
         sub_string(S, _, _, _, '"functor/3"'),
         sub_string(S, _, _, _, '"arg/3"'),
         sub_string(S, _, _, _, '"=../2"'),
         sub_string(S, _, _, _, '"copy_term/2"'),
         %% copy_term_walk helper (sharing-preserving recursive copy).
-        sub_string(S, _, _, _, 'copy_term_walk')
+        sub_string(S, _, _, _, 'copy_term_walk'),
+        %% Runtime-parser bridge support and the parser-required text/list builtins.
+        sub_string(S, _, _, _, '"atom_codes/2"'),
+        sub_string(S, _, _, _, '"number_codes/2"'),
+        sub_string(S, _, _, _, '"reverse/2"'),
+        sub_string(S, _, _, _, '"term_to_atom/2"'),
+        sub_string(S, _, _, _, 'bind_compiled_parse_atom')
     ->  pass(Test)
     ;   fail_test(Test, 'Missing builtin dispatch cases')
     ).
@@ -1777,6 +1821,166 @@ test_runtime_parser_compiled_includes_parser_and_wrappers :-
         fail_test(Test, 'runtime_parser(compiled) did not include parser/wrapper labels')
     ).
 
+test_runtime_parser_compiled_arity_qualified_wrappers :-
+    Test = 'WAM-Rust: compiled runtime parser wrappers are arity-qualified',
+    TmpDir = 'output/test_wam_rust_runtime_parser_arity_wrappers',
+    (   exists_directory(TmpDir)
+    ->  catch(delete_directory_and_contents(TmpDir), _, true)
+    ;   true
+    ),
+    (   write_wam_rust_project(
+            [cpp_runtime_parser_wrappers:parse_atom_to_term/2],
+            [module_name('rust_parser_arity_wrappers'),
+             runtime_parser(compiled), no_kernels(true)],
+            TmpDir),
+        directory_file_path(TmpDir, 'src', SrcDir),
+        directory_file_path(SrcDir, 'lib.rs', LibPath),
+        read_file_to_string(LibPath, LibStr, []),
+        sub_string(LibStr, _, _, _, 'pub fn read_term_from_atom_2'),
+        sub_string(LibStr, _, _, _, 'pub fn read_term_from_atom_3'),
+        sub_string(LibStr, _, _, _, 'pub fn parse_term_from_atom_3'),
+        sub_string(LibStr, _, _, _, 'pub fn parse_term_from_atom_4')
+    ->  catch(delete_directory_and_contents(TmpDir), _, true),
+        pass(Test)
+    ;   catch(delete_directory_and_contents(TmpDir), _, true),
+        fail_test(Test, 'runtime_parser(compiled) emitted duplicate non-arity-qualified wrapper names')
+    ).
+
+test_runtime_parser_compiled_cargo_checks_wrappers :-
+    Test = 'WAM-Rust: compiled runtime parser support crate cargo-checks',
+    TmpDir = 'output/test_wam_rust_runtime_parser_cargo_check',
+    (   exists_directory(TmpDir)
+    ->  catch(delete_directory_and_contents(TmpDir), _, true)
+    ;   true
+    ),
+    (   write_wam_rust_project(
+            [cpp_runtime_parser_wrappers:parse_atom_to_term/2],
+            [module_name('rust_parser_cargo_check'),
+             runtime_parser(compiled), no_kernels(true)],
+            TmpDir),
+        cargo_check_project(TmpDir, Result),
+        (   Result = ok
+        ;   Result = not_available
+        )
+    ->  catch(delete_directory_and_contents(TmpDir), _, true),
+        pass(Test)
+    ;   catch(delete_directory_and_contents(TmpDir), _, true),
+        fail_test(Test, 'runtime_parser(compiled) support crate failed cargo check')
+    ).
+
+write_runtime_parser_bridge_test(ProjectDir) :-
+    directory_file_path(ProjectDir, 'tests', TestsDir),
+    make_directory_path(TestsDir),
+    directory_file_path(TestsDir, 'parser_bridge.rs', TestPath),
+    setup_call_cleanup(
+        open(TestPath, write, S),
+        write(S, 'use std::collections::HashMap;
+
+use rust_parser_bridge_e2e::state::WamState;
+use rust_parser_bridge_e2e::value::Value;
+use rust_parser_bridge_e2e::{
+    canonical_op_table_1, parse_atom_to_term_2, parse_term_from_atom_3,
+    parse_term_from_codes_3,
+};
+
+fn empty_vm() -> WamState {
+    WamState::new(Vec::new(), HashMap::new())
+}
+
+fn deref_named(vm: &WamState, name: &str) -> Value {
+    vm.deref_heap(&vm.deref_var(&Value::Unbound(name.to_string())))
+}
+
+fn op_table(vm: &mut WamState) -> Value {
+    assert!(canonical_op_table_1(vm, Value::Unbound("Ops".to_string())));
+    deref_named(vm, "Ops")
+}
+
+#[test]
+fn compiled_runtime_parser_parses_public_entries() {
+    let mut vm = empty_vm();
+    let ops = op_table(&mut vm);
+    vm.reset_query();
+    assert!(parse_term_from_atom_3(
+        &mut vm,
+        Value::Atom("p(a)".to_string()),
+        ops,
+        Value::Unbound("T".to_string()),
+    ));
+    assert_eq!(format!("{}", deref_named(&vm, "T")), "p(a)");
+
+    let mut vm = empty_vm();
+    let ops = op_table(&mut vm);
+    vm.reset_query();
+    let codes = Value::List("p(a)".chars().map(|c| Value::Integer(c as i64)).collect());
+    assert!(parse_term_from_codes_3(
+        &mut vm,
+        codes,
+        ops,
+        Value::Unbound("T".to_string()),
+    ));
+    assert_eq!(format!("{}", deref_named(&vm, "T")), "p(a)");
+}
+
+#[test]
+fn compiled_runtime_parser_bridge_parses_atom() {
+    let mut vm = empty_vm();
+    assert!(parse_atom_to_term_2(
+        &mut vm,
+        Value::Atom("p(a)".to_string()),
+        Value::Unbound("T".to_string()),
+    ));
+    assert_eq!(format!("{}", deref_named(&vm, "T")), "p(a)");
+}
+'),
+        close(S)
+    ).
+
+test_runtime_parser_compiled_executes_parser_bridge :-
+    Test = 'WAM-Rust: compiled runtime parser bridge executes parser',
+    TmpDir = 'output/test_wam_rust_runtime_parser_bridge_e2e',
+    (   exists_directory(TmpDir)
+    ->  catch(delete_directory_and_contents(TmpDir), _, true)
+    ;   true
+    ),
+    (   write_wam_rust_project(
+            [cpp_runtime_parser_wrappers:parse_atom_to_term/2],
+            [module_name('rust_parser_bridge_e2e'),
+             runtime_parser(compiled), no_kernels(true)],
+            TmpDir),
+        write_runtime_parser_bridge_test(TmpDir),
+        cargo_test_project(TmpDir, parser_bridge, Result)
+    ->  (   (Result = ok ; Result = not_available)
+        ->  catch(delete_directory_and_contents(TmpDir), _, true),
+            pass(Test)
+        ;   (   Result = error(_, Output)
+            ->  format(user_error,
+                    'runtime parser bridge cargo test failed:~n~w~n',
+                    [Output])
+            ;   true
+            ),
+            catch(delete_directory_and_contents(TmpDir), _, true),
+            fail_test(Test,
+                'runtime_parser(compiled) parser bridge did not execute')
+        )
+    ;   catch(delete_directory_and_contents(TmpDir), _, true),
+        fail_test(Test,
+            'runtime_parser(compiled) parser bridge did not generate')
+    ).
+
+test_rust_wam_constant_tokens_strip_quotes :-
+    Test = 'WAM-Rust: WAM constant tokens preserve quoted atoms as atoms',
+    (   wam_rust_target:wam_line_to_rust_instr(
+            ["unify_constant", "':-'"], user:test/0, [], R1),
+        wam_rust_target:wam_line_to_rust_instr(
+            ["set_constant", "'42'"], user:test/0, [], R2),
+        sub_string(R1, _, _, _, 'Value::Atom(":-".to_string())'),
+        sub_string(R2, _, _, _, 'Value::Atom("42".to_string())'),
+        \+ sub_string(R2, _, _, _, 'Value::Integer(42)')
+    ->  pass(Test)
+    ;   fail_test(Test, 'quoted WAM constants were rendered with quotes or numeric type')
+    ).
+
 test_runtime_parser_default_excludes_wrappers :-
     Test = 'WAM-Rust: runtime_parser(auto) does not bundle parser wrappers',
     TmpDir = 'output/test_wam_rust_runtime_parser_default',
@@ -2119,6 +2323,10 @@ run_tests :-
     test_runtime_parser_off_rejects_read,
     test_runtime_parser_off_allows_forward_term_to_atom,
     test_runtime_parser_compiled_includes_parser_and_wrappers,
+    test_runtime_parser_compiled_arity_qualified_wrappers,
+    test_runtime_parser_compiled_cargo_checks_wrappers,
+    test_runtime_parser_compiled_executes_parser_bridge,
+    test_rust_wam_constant_tokens_strip_quotes,
     test_runtime_parser_default_excludes_wrappers,
     test_parser_resilience,
     test_cross_predicate_shared_wam,


### PR DESCRIPTION
## PR Description

This fixes WAM-Rust `runtime_parser(compiled)` so the generated portable parser can actually execute parser entry points such as `parse_atom_to_term/2`, `parse_term_from_atom/3`, and `parse_term_from_codes/3`.

### Changes

- Uses the shared WAM text tokenizer when lowering WAM text to Rust instructions, preserving quoted constants like `','` and quoted numeric atoms.
- Emits arity-qualified Rust wrapper names for overloaded parser predicates such as `read_term_from_atom/2,3` and `parse_term_from_atom/3,4`.
- Adds missing runtime support needed by the compiled parser bridge, including `Jump`, parser text/list builtins, `append/3`, and dereferenced `==/2`.
- Fixes Rust WAM list and structure write-mode handling so reserved heap slots are filled correctly and fresh variables do not collide.
- Preserves open cons cells during `deref_heap` instead of flattening partial lists into incorrect proper-list values.
- Fixes neck-cut barriers for predicate clause choicepoints while avoiding barrier leakage from generated if-then-else choicepoints.
- Adds an executable Rust integration test generated from the Prolog suite to verify the compiled parser bridge parses `p(a)` through public parser wrapper entry points.

### Verification

- `swipl -q -t halt -s src/unifyweaver/targets/wam_rust_target.pl`
- `swipl -q -t halt -s tests/test_wam_rust_target.pl`

