### PR TITLE
feat(wam-python): allow native items ir override

### DIFF
--- a/docs/design/WAM_REPRESENTATION_MODES.md
+++ b/docs/design/WAM_REPRESENTATION_MODES.md
@@ -49,6 +49,13 @@ conservative:
 WAM-specific targets may reject `direct_target`; callers should use the ordinary
 non-WAM target when they want direct target-native code.
 
+Python also accepts an explicit `wam_ir(wam_items_native)` override for
+interpreter-mode predicate emission. Today that target path consumes the common
+structured WAM items directly and is output-equivalent to `wam_items_bridge`;
+the shared `compile_predicate_to_wam_items/3` producer is still implemented as a
+text-to-items bridge. Once the shared producer becomes native, this explicit
+mode will skip WAM text end-to-end without changing the Python emitter.
+
 Lua, R, and Elixir follow the same partial migration shape as Python:
 interpreter-mode generated predicates consume common WAM items through the
 bridge, while lowered emission keeps the text path because lowerability analysis

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -2104,7 +2104,7 @@ python_plan_compile_predicate(Options, PredIndicator, Wam) :-
 	(   IrMode = wam_text
 	->  compile_predicate_to_wam_text(PredIndicator, [ite_use_y_level(true)], WamText),
 	    python_wam_text_plan(WamText, Wam)
-	;   IrMode = wam_items_bridge
+	;   (IrMode = wam_items_bridge ; IrMode = wam_items_native)
 	->  compile_predicate_to_wam_items(PredIndicator, [ite_use_y_level(true)], Items),
 	    python_wam_items_plan(Items, Wam)
 	).
@@ -2117,9 +2117,6 @@ python_wam_emit_ir_mode(Options, IrMode) :-
 	wam_ir_mode(wam_python, EmitMode, Options, IrMode),
 	(   IrMode == direct_target
 	->  throw(error(domain_error(wam_python_ir_mode, direct_target),
-	                python_plan_compile_predicate/3))
-	;   IrMode == wam_items_native
-	->  throw(error(existence_error(wam_ir_mode, wam_items_native),
 	                python_plan_compile_predicate/3))
 	;   true
 	).

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -402,10 +402,20 @@ test(compile_all_generated_predicate_rejects_direct_target_ir,
     wam_python_target:compile_all_predicates([user:py_items_api_demo/0],
         [wam_ir(direct_target)], _).
 
-test(compile_all_generated_predicate_rejects_native_items_until_available,
-     [throws(error(existence_error(wam_ir_mode, wam_items_native), _))]) :-
+test(compile_all_generated_predicate_accepts_native_items_ir) :-
     wam_python_target:compile_all_predicates([user:py_items_api_demo/0],
-        [wam_ir(wam_items_native)], _).
+        [wam_ir(wam_items_native)], Code),
+    sub_string(Code, _, _, _, 'def pred_py_items_api_demo_0(raw_program):'),
+    sub_string(Code, _, _, _, 'raw_program["py_items_api_demo/0"] = ('),
+    sub_string(Code, _, _, _, '("proceed",)'),
+    !.
+
+test(compile_all_generated_predicate_native_items_matches_bridge) :-
+    wam_python_target:compile_all_predicates([user:py_items_api_demo/0],
+        [wam_ir(wam_items_bridge)], BridgeCode),
+    wam_python_target:compile_all_predicates([user:py_items_api_demo/0],
+        [wam_ir(wam_items_native)], NativeCode),
+    assertion(NativeCode == BridgeCode).
 :- end_tests(wam_python_items_mode_audit).
 
 % ============================================================================


### PR DESCRIPTION
This enables the Python WAM target to accept an explicit `wam_ir(wam_items_native)` override for interpreter-mode predicate emission.

### Changes

- Routes `wam_items_native` through Python's existing structured WAM items emitter instead of rejecting it.
- Keeps `direct_target` rejected for WAM-Python, since direct target-native generation remains separate from the WAM target path.
- Adds tests that `wam_ir(wam_items_native)` compiles a generated predicate and is currently output-equivalent to `wam_items_bridge`.
- Updates the representation-mode design doc to note that Python now accepts the explicit native-items override, while the shared `compile_predicate_to_wam_items/3` producer still bridges through WAM text until the common producer becomes native.

### Verification

- `swipl -q -t halt -s tests/test_wam_python_target.pl`
- `swipl -q -t halt -s tests/test_wam_ir_mode.pl`
- `swipl -q -t halt -s src/unifyweaver/targets/wam_python_target.pl`

