### PR TITLE
feat(wam-clojure): add lowered `between/3` builtin

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -518,6 +518,10 @@ clojure_direct_builtin("select/3", "3").
 clojure_direct_builtin("select/3", 3).
 clojure_direct_builtin('select/3', "3").
 clojure_direct_builtin('select/3', 3).
+clojure_direct_builtin("between/3", "3").
+clojure_direct_builtin("between/3", 3).
+clojure_direct_builtin('between/3', "3").
+clojure_direct_builtin('between/3', 3).
 clojure_direct_builtin("numlist/3", "3").
 clojure_direct_builtin("numlist/3", 3).
 clojure_direct_builtin('numlist/3', "3").
@@ -974,6 +978,11 @@ emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     (Op == "select/3" ; Op == 'select/3'),
     !,
     format(atom(Expr), '(runtime/apply-select-solution ~w (inc (:pc ~w)))', [S, S]).
+emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
+    clojure_direct_builtin(Op, Arity),
+    (Op == "between/3" ; Op == 'between/3'),
+    !,
+    format(atom(Expr), '(runtime/apply-between-solution ~w (inc (:pc ~w)))', [S, S]).
 emit_lowered_expr(builtin_call(Op, Arity), S, Expr) :-
     clojure_direct_builtin(Op, Arity),
     (Op == "numlist/3" ; Op == 'numlist/3'),

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -1136,6 +1136,38 @@
        (= (last ints) high)
        (= ints (vec (range (first ints) (inc high))))))
 
+(defn between-results [low high]
+  (mapv (fn [value] {:bindings {3 value}})
+        (range low (inc high))))
+
+(defn apply-between-solution [state resume-pc]
+  (let [low (deref-value (:bindings state)
+                         (or (reg-get-raw state "A1") ::unbound))
+        high (deref-value (:bindings state)
+                          (or (reg-get-raw state "A2") ::unbound))
+        value (deref-value (:bindings state)
+                           (or (reg-get-raw state "A3") ::unbound))
+        low-int (numlist-int-value state low)
+        high-int (numlist-int-value state high)
+        value-int (numlist-int-value state value)]
+    (cond
+      (not (and (integer? low-int) (integer? high-int)))
+      (backtrack state)
+
+      (> low-int high-int)
+      (backtrack state)
+
+      (integer? value-int)
+      (if (and (<= low-int value-int) (<= value-int high-int))
+        (advance state)
+        (backtrack state))
+
+      (logic-var? value)
+      (apply-first-foreign-solution state resume-pc (between-results low-int high-int))
+
+      :else
+      (backtrack state))))
+
 (defn apply-numlist-solution [state]
   (let [low (deref-value (:bindings state)
                          (or (reg-get-raw state "A1") ::unbound))
@@ -2836,6 +2868,9 @@
 
           "select/3"
           (apply-select-solution state (inc (:pc state)))
+
+          "between/3"
+          (apply-between-solution state (inc (:pc state)))
 
           "numlist/3"
           (apply-numlist-solution state)

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -119,6 +119,12 @@
 :- dynamic user:wam_select_backtrack/2.
 :- dynamic user:wam_select_bad_list/1.
 :- dynamic user:wam_select_unbound_list/1.
+:- dynamic user:wam_between_guard/3.
+:- dynamic user:wam_between_high_before_low/0.
+:- dynamic user:wam_between_generate_first/0.
+:- dynamic user:wam_between_singleton/0.
+:- dynamic user:wam_between_unbound_low/1.
+:- dynamic user:wam_between_unbound_high/1.
 :- dynamic user:wam_numlist_guard/3.
 :- dynamic user:wam_numlist_high_before_low/1.
 :- dynamic user:wam_numlist_unbound_low/1.
@@ -500,6 +506,12 @@ user:wam_select_guard(Elem, List, Rest) :- select(Elem, List, Rest).
 user:wam_select_backtrack(Elem, Rest) :- select(Elem, [a,b,c], Rest), Elem = b.
 user:wam_select_bad_list(Rest) :- select(a, [a|b], Rest).
 user:wam_select_unbound_list(Rest) :- select(a, L, Rest), is_list(L).
+user:wam_between_guard(Low, High, Value) :- between(Low, High, Value).
+user:wam_between_high_before_low :- between(5, 3, _).
+user:wam_between_generate_first :- between(2, 5, X), X =:= 2.
+user:wam_between_singleton :- between(7, 7, X), X =:= 7.
+user:wam_between_unbound_low(_) :- user:wam_unbound_arg(Low), between(Low, 3, _).
+user:wam_between_unbound_high(_) :- user:wam_unbound_arg(High), between(1, High, _).
 user:wam_numlist_guard(Low, High, List) :- numlist(Low, High, List).
 user:wam_numlist_high_before_low(List) :- numlist(3, 1, List).
 user:wam_numlist_unbound_low(List) :- numlist(Low, 3, List), integer(Low).
@@ -886,6 +898,12 @@ run_smoke :-
           user:wam_select_backtrack/2,
           user:wam_select_bad_list/1,
           user:wam_select_unbound_list/1,
+          user:wam_between_guard/3,
+          user:wam_between_high_before_low/0,
+          user:wam_between_generate_first/0,
+          user:wam_between_singleton/0,
+          user:wam_between_unbound_low/1,
+          user:wam_between_unbound_high/1,
           user:wam_numlist_guard/3,
           user:wam_numlist_high_before_low/1,
           user:wam_numlist_unbound_low/1,
@@ -1186,6 +1204,7 @@ run_smoke :-
     assert_lowered_nth0_builtin_emitted(TmpDir),
     assert_lowered_nth1_builtin_emitted(TmpDir),
     assert_lowered_select_builtin_emitted(TmpDir),
+    assert_lowered_between_builtin_emitted(TmpDir),
     assert_lowered_numlist_builtin_emitted(TmpDir),
     assert_lowered_numeric_list_reducers_emitted(TmpDir),
     assert_lowered_delete_builtin_emitted(TmpDir),
@@ -1416,6 +1435,15 @@ smoke_cases([
     case('wam_select_backtrack/2', args(b, '[a,c]'), "true"),
     case('wam_select_bad_list/1', '[b,c]', "false"),
     case('wam_select_unbound_list/1', '[b,c]', "true"),
+    case('wam_between_guard/3', args(1, 3, 1), "true"),
+    case('wam_between_guard/3', args(1, 3, 3), "true"),
+    case('wam_between_guard/3', args(1, 3, 4), "false"),
+    case('wam_between_guard/3', args(1, 3, 0), "false"),
+    case('wam_between_high_before_low/0', no_args, "false"),
+    case('wam_between_generate_first/0', no_args, "true"),
+    case('wam_between_singleton/0', no_args, "true"),
+    case('wam_between_unbound_low/1', a, "false"),
+    case('wam_between_unbound_high/1', a, "false"),
     case('wam_numlist_guard/3', args(1, 3, '[1,2,3]'), "true"),
     case('wam_numlist_guard/3', args(2, 2, '[2]'), "true"),
     case('wam_numlist_guard/3', args(1, 3, '[1,3]'), "false"),
@@ -1992,6 +2020,14 @@ assert_lowered_select_builtin_emitted(ProjectDir) :-
     has(CoreCode, "defn lowered-wam-select-unbound-list-1"),
     has(CoreCode, "runtime/apply-select-solution").
 
+assert_lowered_between_builtin_emitted(ProjectDir) :-
+    directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
+    read_file_to_string(CorePath, CoreCode, []),
+    has(CoreCode, "defn lowered-wam-between-guard-3"),
+    has(CoreCode, "defn lowered-wam-between-unbound-low-1"),
+    has(CoreCode, "defn lowered-wam-between-unbound-high-1"),
+    has(CoreCode, "runtime/apply-between-solution").
+
 assert_lowered_numlist_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
@@ -2414,6 +2450,9 @@ prolog_term_string_to_edn(0, "0") :- !.
 prolog_term_string_to_edn(1, "1") :- !.
 prolog_term_string_to_edn(2, "2") :- !.
 prolog_term_string_to_edn(3, "3") :- !.
+prolog_term_string_to_edn(4, "4") :- !.
+prolog_term_string_to_edn(5, "5") :- !.
+prolog_term_string_to_edn(7, "7") :- !.
 prolog_term_string_to_edn(2.5, "2.5") :- !.
 prolog_term_string_to_edn(3.5, "3.5") :- !.
 prolog_term_string_to_edn(11, "11") :- !.


### PR DESCRIPTION
## Summary

- Adds Clojure lowered-emitter recognition for `between/3` as a direct builtin.
- Implements `runtime/apply-between-solution` for bound range checks and unbound third-argument enumeration.
- Adds Clojure WAM smoke coverage for success, failure, high-before-low, singleton, and unbound low/high guard cases.

## Why

`between/3` is a common numeric generator and guard predicate. Supporting it in the Clojure lowered WAM path improves parity with the other hybrid WAM targets and avoids routing simple range checks through the generic fallback path.

## Implementation Notes

- The runtime reuses the existing numeric normalization helper used by `numlist/3`.
- Bound third-argument mode succeeds only when the value is an integer inside the inclusive `[Low, High]` range.
- Unbound third-argument mode produces foreign-style solution bindings for register `A3`, matching the existing enumerating builtin infrastructure.
- Unbound or non-integer lower/upper bounds fail conservatively.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl` passed `97/97`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl` passed `15/15`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl` passed with `wam_clojure_runtime_smoke: ok`

## Scope Note

This PR does not attempt to fix the broader lowered straightline continuation limitation for filters after enumerating direct builtins. A temporary exploratory fixture showed that a failing post-generator instruction can expose that separate control-flow issue. The committed coverage stays within the currently supported lowered execution shape for this builtin.
