### PR TITLE
Add T4 (multi_clause_n) all-clauses lowering for Go

### DIFF
--- a/src/unifyweaver/targets/wam_go_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_go_lowered_emitter.pl
@@ -172,8 +172,16 @@ wam_go_lowerable(PI, WamCode, Reason) :-
     ;   % No internal ITE: existing deterministic / multi-clause path.
         \+ member(try_me_else(_), C1),
         forall(member(I, C1), go_supported(I))
-    ->  ( is_deterministic_pred_go(Instrs) -> Reason = deterministic
-        ; Reason = multi_clause_1 )
+    ->  ( is_deterministic_pred_go(Instrs)
+        ->  Reason = deterministic
+        ;   % T4: every clause is a clean supported deterministic body — lower
+            % them ALL inline (tried in order with restore-between), so the
+            % method never returns to the interpreter for clauses 2+. Takes
+            % precedence over multi_clause_1 (clause-1 only).
+            go_all_clauses_lowerable(Instrs)
+        ->  Reason = multi_clause_n
+        ;   Reason = multi_clause_1
+        )
     ;   % Clause-1 has an inner choice point: lower only if it is a pure
         % (C -> T ; E) / \+ / once block whose pieces are all supported.
         \+ ( Instrs = [try_me_else(_)|_] ),   % single-clause predicate
@@ -187,6 +195,42 @@ clause1_instrs([], []).
 clause1_instrs([try_me_else(_)|Rest], C1) :- !,
     take_to_proceed(Rest, C1).
 clause1_instrs(Instrs, Instrs).
+
+%% go_split_clauses(+Instrs, -Clauses) is semidet.
+%  Split a multi-clause predicate (opens with try_me_else) at the choice-point
+%  separators into per-clause instruction lists (T4 / multi_clause_n).
+go_split_clauses([try_me_else(_)|Rest], [Clause|More]) :-
+    go_collect_clause(Rest, Clause, After),
+    go_split_more(After, More).
+
+go_split_more([], []).
+go_split_more([retry_me_else(_)|Rest], [Clause|More]) :- !,
+    go_collect_clause(Rest, Clause, After),
+    go_split_more(After, More).
+go_split_more([trust_me|Rest], [Clause|More]) :- !,
+    go_collect_clause(Rest, Clause, After),
+    go_split_more(After, More).
+
+go_collect_clause([], [], []).
+go_collect_clause([retry_me_else(L)|Rest], [], [retry_me_else(L)|Rest]) :- !.
+go_collect_clause([trust_me|Rest], [], [trust_me|Rest]) :- !.
+go_collect_clause([I|Rest], [I|More], After) :-
+    go_collect_clause(Rest, More, After).
+
+%% go_all_clauses_lowerable(+Instrs) is semidet.
+%  True when EVERY clause is a clean supported deterministic body (no inner
+%  choice point, ends in a terminal) — the T4 (multi_clause_n) condition.
+go_all_clauses_lowerable(Instrs) :-
+    go_split_clauses(Instrs, Clauses),
+    Clauses = [_, _ | _],
+    forall(member(Cl, Clauses),
+           ( \+ member(try_me_else(_), Cl),
+             forall(member(I, Cl), go_supported(I)),
+             last(Cl, Last), go_clause_terminal(Last) )).
+
+go_clause_terminal(proceed).
+go_clause_terminal(fail).
+go_clause_terminal(execute(_)).
 
 take_to_proceed([], []).
 take_to_proceed([proceed|_], [proceed]) :- !.
@@ -288,6 +332,12 @@ lower_predicate_to_go(PI, WamCode, _Options, GoLines) :-
     (   % T5 first-argument-constant dispatch takes precedence.
         go_clause_chain_lowerable(Instrs, Guards)
     ->  emit_clause_chain_go(FuncName, Pred, Arity, Guards, GoLines)
+    ;   % T4: a multi-clause predicate whose clauses are all supported
+        % deterministic bodies (but not a distinct-first-arg chain) — lower
+        % every clause inline, tried in order with a restore between attempts.
+        \+ is_deterministic_pred_go(Instrs),
+        go_all_clauses_lowerable(Instrs)
+    ->  emit_multi_clause_n_go(FuncName, Pred, Arity, Instrs, GoLines)
     ;   % Emit the plain clause-1 when it has no inner choice point;
         % otherwise fold its ITE block(s) into structured form (ite/3).
         (   \+ member(try_me_else(_), C1Instrs)
@@ -301,6 +351,32 @@ func (vm *WamState) ~w() bool {', [FuncName, Pred, Arity, FuncName]),
         format(string(Footer), '}', []),
         GoLines = [Header, Body, Footer]
     ).
+
+%% emit_multi_clause_n_go(+FuncName, +Pred, +Arity, +Instrs, -GoLines)
+%  Emit T4: capture the clause-entry state, then try every clause inline as an
+%  immediately-invoked func() bool (its `proceed` returns true, failures return
+%  false), restoring the entry state between attempts. The first clause that
+%  succeeds wins (first-solution / deterministic-prefix); the method never
+%  returns to the interpreter for clauses 2+, unlike multi_clause_1.
+emit_multi_clause_n_go(FuncName, Pred, Arity, Instrs, GoLines) :-
+    go_split_clauses(Instrs, Clauses),
+    format(string(Header),
+'// ~w — lowered from ~w/~w (T4 all-clauses inline)
+func (vm *WamState) ~w() bool {', [FuncName, Pred, Arity, FuncName]),
+    with_output_to(string(Body),
+        ( format("    _t4 := vm.LoClauseSnapshot()~n"),
+          emit_go_clauses(Clauses),
+          format("    return false~n") )),
+    format(string(Footer), '}', []),
+    GoLines = [Header, Body, Footer].
+
+emit_go_clauses([]).
+emit_go_clauses([Cl | Rest]) :-
+    format("    if func() bool {~n"),
+    emit_instrs(Cl, "        "),
+    format("    }() { return true }~n"),
+    format("    vm.LoRestoreClause(_t4)~n"),
+    emit_go_clauses(Rest).
 
 %% emit_clause_chain_go(+FuncName, +Pred, +Arity, +Guards, -GoLines)
 %  Emit T5: deref the first argument once; if it is still unbound, defer to

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -462,6 +462,50 @@ func (vm *WamState) restoreSavedRegs(saved []Value) {
 	}
 }
 
+// ClauseSnapshot is the clause-entry state a T4 (multi_clause_n) lowered
+// method restores between clause attempts. The lowered method enumerates
+// EVERY clause itself (first-solution / deterministic-prefix), so the
+// interpreter is never entered for the predicate. Mirrors the ChoicePoint
+// snapshot, minus the resume PC; NextVarId is monotonic (unique ids) and is
+// intentionally not restored.
+type ClauseSnapshot struct {
+	savedRegs []Value
+	trailMark int
+	heapTop   int
+	stackLen  int
+	cp        int
+	e         int
+}
+
+// LoClauseSnapshot captures the clause-entry state for LoRestoreClause.
+func (vm *WamState) LoClauseSnapshot() ClauseSnapshot {
+	return ClauseSnapshot{
+		savedRegs: vm.snapshotAllRegs(),
+		trailMark: vm.TrailLen,
+		heapTop:   vm.HeapLen,
+		stackLen:  len(vm.Stack),
+		cp:        vm.CP,
+		e:         vm.E,
+	}
+}
+
+// LoRestoreClause restores vm to a clause-entry snapshot before the next
+// clause attempt (mirrors backtrack's WamCP restore, minus the PC).
+func (vm *WamState) LoRestoreClause(snap ClauseSnapshot) {
+	vm.unwindTrailTo(snap.trailMark)
+	vm.restoreSavedRegs(snap.savedRegs)
+	if snap.stackLen <= len(vm.Stack) {
+		vm.Stack = vm.Stack[:snap.stackLen]
+	}
+	vm.E = snap.e
+	if snap.heapTop >= 0 && snap.heapTop <= vm.HeapLen {
+		vm.heapTrimTo(snap.heapTop)
+	}
+	vm.CP = snap.cp
+	vm.CurrentStruct = nil
+	vm.CurrentList = nil
+}
+
 func (vm *WamState) pushChoicePoint(nextPC int, arity int) {
 	_ = arity
 	vm.ChoicePoints = append(vm.ChoicePoints, ChoicePoint{

--- a/tests/test_wam_go_lowered_t4.pl
+++ b/tests/test_wam_go_lowered_t4.pl
@@ -1,0 +1,141 @@
+% test_wam_go_lowered_t4.pl
+%
+% End-to-end execution test for the Go T4 lowering — "multi-clause, all
+% clauses" (lowering type T4 / multi_clause_n in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md), ported from Scala/Rust.
+%
+% A multi-clause predicate whose clauses are all supported deterministic
+% bodies but do NOT discriminate on a distinct first-argument constant (so T5
+% declines) now lowers to ALL clauses inline: each clause is an
+% immediately-invoked func() bool, tried in order with a
+% trail/register/heap/stack restore (vm.LoRestoreClause) between attempts. The
+% first clause that succeeds wins (first-solution / deterministic-prefix); the
+% method never returns to the interpreter for clauses 2+, unlike multi_clause_1.
+%
+% Pins (BOUND first arg; the payoff is the non-first clauses running natively):
+%   * grade/2 — fact chain with a REPEATED first arg (alice in clauses 1 & 3);
+%   * rel/2   — RULE chain with a VARIABLE first arg (=/2 body; clause 1
+%               clobbers A2, which the restore must undo).
+%
+% Like the T5 test, the older native clause-parallel lib.go is dropped from
+% the build (it is independently broken for these shapes — a pre-existing
+% go_target bug unrelated to WAM lowering); the T4 deliverable lives in
+% lowered.go. Skipped automatically when `go` is not on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_go_target').
+:- use_module('../src/unifyweaver/targets/wam_go_lowered_emitter').
+
+:- dynamic user:grade/2.
+:- dynamic user:rel/2.
+
+user:grade(alice, a).
+user:grade(bob,   b).
+user:grade(alice, c).
+
+user:rel(X, one) :- X = p.
+user:rel(X, two) :- X = q.
+
+go_available :-
+    catch(
+        ( process_create(path(go), ['version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          process_wait(Pid, exit(0)) ),
+        _, fail).
+
+:- begin_tests(wam_go_lowered_t4, [condition(go_available)]).
+
+test(gate_picks_multi_clause_n) :-
+    forall(member(PI, [grade/2, rel/2]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_go_lowerable(PI, W, Reason),
+             assertion(Reason == multi_clause_n) )).
+
+test(t4_exec_parity) :-
+    Dir  = 'output/test_wam_go_t4_exec',
+    Proj = 'output/test_wam_go_t4_exec_gen',
+    ( exists_directory(Dir)  -> delete_directory_and_contents(Dir)  ; true ),
+    ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ),
+    make_directory_path(Dir),
+    write_wam_go_project(
+        [user:grade/2, user:rel/2],
+        [module_name('t4exec'), wam_fallback(true)], Proj),
+    atomic_list_concat([Proj, '/lowered.go'], LoweredPath),
+    ( exists_file(LoweredPath) -> read_file_to_string(LoweredPath, LSrc, []) ; LSrc = "" ),
+    assertion(sub_string(LSrc, _, _, _, "T4 all-clauses inline")),
+    atomic_list_concat(['cp ', Proj, '/*.go ', Dir, '/ && rm -f ', Dir, '/lib.go'], CpCmd),
+    shell_ok_t4(CpCmd),
+    write_file_t4(Dir/'go.mod', "module t4exec\n\ngo 1.21\n"),
+    go_t4_source(Src),
+    write_file_t4(Dir/'t4_exec_test.go', Src),
+    format(atom(TestCmd), 'cd ~w && go test ./... 2>&1', [Dir]),
+    process_create(path(sh), ['-c', TestCmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    ->  true
+    ;   format(user_error, "~n[go test output]~n~w~n", [OutStr]),
+        throw(go_t4_test_failed(Status))
+    ),
+    ( exists_directory(Dir)  -> delete_directory_and_contents(Dir)  ; true ),
+    ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ).
+
+:- end_tests(wam_go_lowered_t4).
+
+shell_ok_t4(Cmd) :-
+    process_create(path(sh), ['-c', Cmd], [process(Pid)]),
+    process_wait(Pid, exit(0)).
+
+write_file_t4(PathSpec, Text) :-
+    ( atom(PathSpec) -> Path = PathSpec ; PathSpec = D/F, atomic_list_concat([D, '/', F], Path) ),
+    setup_call_cleanup(open(Path, write, S, [encoding(utf8)]), write(S, Text), close(S)).
+
+% Calls each lowered method with the query args loaded into Regs[0..] (first
+% arg bound). Exercises the non-first clauses (grade clauses 2 & 3, rel clause
+% 2) — the T4 payoff — plus no-match cases.
+go_t4_source(
+"package wam
+
+import \"testing\"
+
+func callPredT4(setup func(vm *WamState), pred func(vm *WamState) bool) bool {
+	vm := NewWamState(nil, nil)
+	setup(vm)
+	return pred(vm)
+}
+
+func TestT4MultiClause(t *testing.T) {
+	A := func(s string) Value { return internAtom(s) }
+	set := func(vals ...Value) func(vm *WamState) {
+		return func(vm *WamState) {
+			for i, v := range vals {
+				vm.Regs[i] = v
+			}
+		}
+	}
+	cases := []struct {
+		name string
+		got  bool
+		want bool
+	}{
+		{\"grade(alice,a)\", callPredT4(set(A(\"alice\"), A(\"a\")), (*WamState).PredGrade2), true},
+		{\"grade(bob,b)\",   callPredT4(set(A(\"bob\"),   A(\"b\")), (*WamState).PredGrade2), true},
+		{\"grade(alice,c)\", callPredT4(set(A(\"alice\"), A(\"c\")), (*WamState).PredGrade2), true},
+		{\"grade(alice,b)\", callPredT4(set(A(\"alice\"), A(\"b\")), (*WamState).PredGrade2), false},
+		{\"grade(carol,a)\", callPredT4(set(A(\"carol\"), A(\"a\")), (*WamState).PredGrade2), false},
+		{\"grade(bob,c)\",   callPredT4(set(A(\"bob\"),   A(\"c\")), (*WamState).PredGrade2), false},
+		{\"rel(p,one)\", callPredT4(set(A(\"p\"), A(\"one\")), (*WamState).PredRel2), true},
+		{\"rel(q,two)\", callPredT4(set(A(\"q\"), A(\"two\")), (*WamState).PredRel2), true},
+		{\"rel(p,two)\", callPredT4(set(A(\"p\"), A(\"two\")), (*WamState).PredRel2), false},
+		{\"rel(q,one)\", callPredT4(set(A(\"q\"), A(\"one\")), (*WamState).PredRel2), false},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf(\"%s: got %v want %v\", c.name, c.got, c.want)
+		}
+	}
+}
+").


### PR DESCRIPTION
## Summary

Third target in the **T4 sweep** (after Scala #2941, Rust #2942). A multi-clause predicate whose clauses are all supported deterministic bodies but do **not** discriminate on a distinct first-argument constant (so T5/`clause_chain` declines) now lowers with **every clause inline**, instead of `multi_clause_1` (clause 1 inline, clauses 2+ via the bytecode interpreter). The lowered method never returns to the interpreter for the predicate.

As with Scala/Rust, **no choice-point-model change** is needed: Go's lowered methods are self-contained, so all-clauses-inline is achieved by trying each clause as an immediately-invoked `func() bool` with a trail/register/heap/stack restore between attempts.

```go
func (vm *WamState) PredGrade2() bool {
    _t4 := vm.LoClauseSnapshot()
    if func() bool { /* alice,a */ return true }() { return true }
    vm.LoRestoreClause(_t4)
    if func() bool { /* bob,b  */ return true }() { return true }
    vm.LoRestoreClause(_t4)
    if func() bool { /* alice,c */ return true }() { return true }
    vm.LoRestoreClause(_t4)
    return false
}
```

## Changes

- **`state.go.mustache`**: `ClauseSnapshot` + `(*WamState).LoClauseSnapshot` / `LoRestoreClause` — capture/restore the clause-entry state (regs via `snapshotAllRegs`/`restoreSavedRegs`, trail via `unwindTrailTo`, heap trim, stack, CP, E), mirroring the `ChoicePoint` snapshot minus the resume PC. `NextVarId` is monotonic (unique ids) and intentionally not restored.
- **`wam_go_lowered_emitter.pl`**: `go_split_clauses/2` + `go_all_clauses_lowerable/1`; gate `multi_clause_n` between `clause_chain` (T5) and `multi_clause_1`; `emit_multi_clause_n_go` (per-clause closures + `LoRestoreClause` between attempts).
- **`tests/test_wam_go_lowered_t4.pl`**: gated `go test` exec test. `grade/2` (fact chain, repeated first arg) and `rel/2` (rule chain, variable first arg — clause 1 clobbers A2, exercising the restore) gate as `multi_clause_n`, compile and run; pins exercise the non-first clauses natively (`grade(alice,c)`=clause 3, `grade(bob,b)`/`rel(q,two)`=clause 2) plus no-match cases. Like the T5 test it drops the older native clause-parallel `lib.go` (independently broken for these shapes, unrelated to WAM lowering).

## Verification

- New `test_wam_go_lowered_t4`: gate (both `multi_clause_n`) + `go test` exec parity (10 queries) pass.
- No regression: `test_wam_go_lowered_t5`, `test_wam_go_lowered_ite_exec` pass (the `state.go` additions are new exported methods; no existing path changed).

Sweep so far: ✅ Scala (#2941), ✅ Rust (#2942), ✅ Go (this). Remaining: cpp, haskell, fsharp, clojure, llvm, lua.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_