### PR TITLE
Add T4 (multi_clause_n) all-clauses lowering for C++

### DIFF
--- a/src/unifyweaver/targets/wam_cpp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_cpp_lowered_emitter.pl
@@ -106,8 +106,16 @@ wam_cpp_lowerable(PI, WamCode, Reason) :-
     ;   % No internal ITE: existing deterministic / multi-clause path.
         \+ member(try_me_else(_), C1),
         forall(member(I, C1), cpp_supported(I))
-    ->  ( is_deterministic_pred_cpp(Instrs) -> Reason = deterministic
-        ; Reason = multi_clause_1 )
+    ->  ( is_deterministic_pred_cpp(Instrs)
+        ->  Reason = deterministic
+        ;   % T4: every clause is a clean supported deterministic body — lower
+            % them ALL inline (tried in order with restore-between), so the
+            % function never returns to the interpreter for clauses 2+. Takes
+            % precedence over multi_clause_1 (clause-1 only).
+            cpp_all_clauses_lowerable(Instrs)
+        ->  Reason = multi_clause_n
+        ;   Reason = multi_clause_1
+        )
     ;   % Clause-1 has an inner choice point: lower only if it is a pure
         % (C -> T ; E) / \+ / once block whose pieces are all supported.
         \+ ( Instrs = [try_me_else(_)|_] ),   % single-clause predicate
@@ -150,6 +158,44 @@ clause1_instrs(Instrs, Instrs).
 take_to_proceed([], []).
 take_to_proceed([proceed|_], [proceed]) :- !.
 take_to_proceed([I|Rest], [I|More]) :- take_to_proceed(Rest, More).
+
+%% cpp_split_clauses(+Instrs, -Clauses) is semidet.
+%  Split a multi-clause predicate (opens with try_me_else) at the choice-point
+%  separators into per-clause instruction lists (T4 / multi_clause_n).
+cpp_split_clauses([try_me_else(_)|Rest], [Clause|More]) :-
+    cpp_collect_clause(Rest, Clause, After),
+    cpp_split_more(After, More).
+
+cpp_split_more([], []).
+cpp_split_more([retry_me_else(_)|Rest], [Clause|More]) :- !,
+    cpp_collect_clause(Rest, Clause, After),
+    cpp_split_more(After, More).
+cpp_split_more([trust_me|Rest], [Clause|More]) :- !,
+    cpp_collect_clause(Rest, Clause, After),
+    cpp_split_more(After, More).
+
+cpp_collect_clause([], [], []).
+cpp_collect_clause([retry_me_else(L)|Rest], [], [retry_me_else(L)|Rest]) :- !.
+cpp_collect_clause([trust_me|Rest], [], [trust_me|Rest]) :- !.
+cpp_collect_clause([I|Rest], [I|More], After) :-
+    cpp_collect_clause(Rest, More, After).
+
+%% cpp_all_clauses_lowerable(+Instrs) is semidet.
+%  True when EVERY clause is a clean supported deterministic body (no inner
+%  choice point, ends in a terminal) — the T4 (multi_clause_n) condition. The
+%  C++ parser keeps a leading switch_on_* indexing prefix, so strip it first.
+cpp_all_clauses_lowerable(Instrs0) :-
+    cpp_strip_switch_prefix(Instrs0, Instrs),
+    cpp_split_clauses(Instrs, Clauses),
+    Clauses = [_, _ | _],
+    forall(member(Cl, Clauses),
+           ( \+ member(try_me_else(_), Cl),
+             forall(member(I, Cl), cpp_supported(I)),
+             last(Cl, Last), cpp_clause_terminal(Last) )).
+
+cpp_clause_terminal(proceed).
+cpp_clause_terminal(fail).
+cpp_clause_terminal(execute(_)).
 
 %% is_deterministic_pred_cpp(+Instrs)
 %  True if the instruction list has no choice point instructions.
@@ -245,6 +291,12 @@ lower_predicate_to_cpp(PI, WamCode, Options, CppLines) :-
     (   % T5 first-argument-constant dispatch takes precedence.
         cpp_clause_chain_lowerable(Instrs, Guards)
     ->  emit_clause_chain_cpp(FuncName, Pred, Arity, Guards, ForeignPreds, CppLines)
+    ;   % T4: a multi-clause predicate whose clauses are all supported
+        % deterministic bodies (but not a distinct-first-arg chain) — lower
+        % every clause inline, tried in order with a restore between attempts.
+        \+ is_deterministic_pred_cpp(Instrs),
+        cpp_all_clauses_lowerable(Instrs)
+    ->  emit_multi_clause_n_cpp(FuncName, Pred, Arity, Instrs, ForeignPreds, CppLines)
     ;   % Emit the plain clause-1 when it has no inner choice point; otherwise
         % fold its ITE block(s) into structured form (ite/3) first.
         (   \+ member(try_me_else(_), C1Instrs)
@@ -287,6 +339,33 @@ emit_cpp_guards([guard(V, Rem) | Rest], ForeignPreds) :-
     emit_instrs(Rem, "        ", ForeignPreds),
     format("    }~n"),
     emit_cpp_guards(Rest, ForeignPreds).
+
+%% emit_multi_clause_n_cpp(+FuncName, +Pred, +Arity, +Instrs, +FK, -CppLines)
+%  Emit T4: capture the clause-entry state, then try every clause inline as an
+%  immediately-invoked lambda (its `proceed` returns true, failures return
+%  false), restoring the entry state between attempts. The first clause that
+%  succeeds wins (first-solution / deterministic-prefix); the function never
+%  returns to the interpreter for clauses 2+, unlike multi_clause_1.
+emit_multi_clause_n_cpp(FuncName, Pred, Arity, Instrs0, ForeignPreds, CppLines) :-
+    cpp_strip_switch_prefix(Instrs0, Instrs),
+    cpp_split_clauses(Instrs, Clauses),
+    format(string(Header),
+'// ~w — lowered from ~w/~w (T4 all-clauses inline)
+bool ~w(WamState* vm) {', [FuncName, Pred, Arity, FuncName]),
+    with_output_to(string(Body),
+        ( format("    auto _t4 = vm->lo_clause_snapshot();~n"),
+          emit_cpp_clauses(Clauses, ForeignPreds),
+          format("    return false;~n") )),
+    format(string(Footer), '}', []),
+    CppLines = [Header, Body, Footer].
+
+emit_cpp_clauses([], _).
+emit_cpp_clauses([Cl | Rest], ForeignPreds) :-
+    format("    if ([&]() -> bool {~n"),
+    emit_instrs(Cl, "        ", ForeignPreds),
+    format("    }()) return true;~n"),
+    format("    vm->lo_restore_clause(_t4);~n"),
+    emit_cpp_clauses(Rest, ForeignPreds).
 
 %% emit_instrs(+Instrs, +Indent, +ForeignPreds)
 emit_instrs([], _, _).

--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -3512,6 +3512,20 @@ struct AggregateGroupIterator {
     std::size_t return_pc = 0;
 };
 
+// T4 (multi_clause_n): clause-entry snapshot a lowered function restores
+// between clause attempts. The lowered function enumerates every clause
+// itself (first-solution / deterministic-prefix), so the interpreter is never
+// entered for the predicate. Mirrors the ChoicePoint reg/trail/env/cut
+// restore; var_counter is monotonic (unique unbound names) and intentionally
+// not restored.
+struct ClauseSnapshot {
+    std::unordered_map<std::string, CellPtr> saved_regs;
+    std::size_t trail_mark = 0;
+    std::size_t cut_barrier = 0;
+    std::vector<EnvFrame> saved_env_stack;
+    std::size_t cp_count = 0;
+};
+
 struct WamState {
     std::unordered_map<std::string, CellPtr> regs;
     std::unordered_map<std::string, std::size_t> labels;
@@ -3751,6 +3765,11 @@ struct WamState {
     // Used by lowered if-then-else when the condition fails, before the
     // else branch runs.
     void    unwind_trail_to(std::size_t mark);
+
+    // T4 (multi_clause_n): capture / restore the clause-entry state a lowered
+    // function tries each clause against — see ClauseSnapshot.
+    ClauseSnapshot lo_clause_snapshot() const;
+    void           lo_restore_clause(const ClauseSnapshot& snap);
 
     // Unification: takes Cell pointers so binding works correctly.
     bool    unify_cells(CellPtr a, CellPtr b);
@@ -4183,6 +4202,24 @@ void WamState::unwind_trail_to(std::size_t mark) {
         trail.pop_back();
         *t.cell = std::move(t.prev);
     }
+}
+
+ClauseSnapshot WamState::lo_clause_snapshot() const {
+    ClauseSnapshot s;
+    s.saved_regs      = regs;
+    s.trail_mark      = trail.size();
+    s.cut_barrier     = cut_barrier;
+    s.saved_env_stack = env_stack;
+    s.cp_count        = choice_points.size();
+    return s;
+}
+
+void WamState::lo_restore_clause(const ClauseSnapshot& snap) {
+    unwind_trail_to(snap.trail_mark);
+    regs        = snap.saved_regs;
+    cut_barrier = snap.cut_barrier;
+    env_stack   = snap.saved_env_stack;
+    if (choice_points.size() > snap.cp_count) choice_points.resize(snap.cp_count);
 }
 
 void WamState::bind_cell(CellPtr cell, Value v) {

--- a/tests/test_wam_cpp_lowered_t4.pl
+++ b/tests/test_wam_cpp_lowered_t4.pl
@@ -1,0 +1,114 @@
+% test_wam_cpp_lowered_t4.pl
+%
+% End-to-end execution test for the C++ T4 lowering — "multi-clause, all
+% clauses" (lowering type T4 / multi_clause_n in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md), ported from
+% Scala/Rust/Go.
+%
+% A multi-clause predicate whose clauses are all supported deterministic
+% bodies but do NOT discriminate on a distinct first-argument constant (so T5
+% declines) now lowers to ALL clauses inline: each clause is an
+% immediately-invoked lambda, tried in order with a trail/register/env/cut
+% restore (vm->lo_restore_clause) between attempts. The first clause that
+% succeeds wins (first-solution / deterministic-prefix); the function never
+% returns to the interpreter for clauses 2+, unlike multi_clause_1.
+%
+% Pins (BOUND first arg; the payoff is the non-first clauses running natively):
+%   * grade/2 — fact chain with a REPEATED first arg (alice in clauses 1 & 3);
+%   * rel/2   — RULE chain with a VARIABLE first arg (=/2 body; clause 1
+%               clobbers A2, which the restore must undo).
+%
+% Skipped automatically when no host C++17 compiler is available.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_cpp_target').
+:- use_module('../src/unifyweaver/targets/wam_cpp_lowered_emitter').
+
+:- dynamic user:grade/2.
+:- dynamic user:rel/2.
+
+user:grade(alice, a).
+user:grade(bob,   b).
+user:grade(alice, c).
+
+user:rel(X, one) :- X = p.
+user:rel(X, two) :- X = q.
+
+cc_ok(CC) :-
+    catch(( process_create(path(CC), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+cpp_compiler(CC) :-
+    ( cc_ok('g++') -> CC = 'g++'
+    ; cc_ok('clang++') -> CC = 'clang++'
+    ; fail ).
+
+:- begin_tests(wam_cpp_lowered_t4, [condition(cpp_compiler(_))]).
+
+% Both predicates must lower as T4 (multi_clause_n), not multi_clause_1.
+test(gate_picks_multi_clause_n) :-
+    forall(member(PI, [grade/2, rel/2]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_cpp_lowerable(PI, W, Reason),
+             assertion(Reason == multi_clause_n) )).
+
+test(t4_exec_parity) :-
+    cpp_compiler(CC),
+    Dir = 'output/test_wam_cpp_t4_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_cpp_project(
+        [user:grade/2, user:rel/2],
+        [module_name('t4cpp'), wam_fallback(true), emit_mode(functions)], Dir),
+    atomic_list_concat([Dir, '/cpp/generated_program.cpp'], GenPath),
+    ( exists_file(GenPath) -> read_file_to_string(GenPath, GSrc, []) ; GSrc = "" ),
+    assertion(sub_string(GSrc, _, _, _, "T4 all-clauses inline")),
+    atomic_list_concat([Dir, '/cpp/test_t4.cpp'], TestPath),
+    cpp_t4_source(Src),
+    setup_call_cleanup(open(TestPath, write, S), write(S, Src), close(S)),
+    atomic_list_concat([Dir, '/cpp'], CppDir),
+    format(atom(Cmd),
+        '~w -std=c++17 -O0 ~w/test_t4.cpp ~w/generated_program.cpp ~w/wam_runtime.cpp -o ~w/t4_test 2>&1 && ~w/t4_test',
+        [CC, CppDir, CppDir, CppDir, CppDir, CppDir]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 10 PASS")
+    ->  true
+    ;   format(user_error, "~n[cpp t4 test output]~n~w~n", [OutStr]),
+        throw(cpp_t4_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_cpp_lowered_t4).
+
+% Calls each lowered function with a BOUND first argument and asserts the
+% boolean outcome. Exercises the non-first clauses (grade clauses 2 & 3, rel
+% clause 2) — the T4 payoff — plus the no-match cases.
+cpp_t4_source(
+"#include \"wam_runtime.h\"
+#include <iostream>
+bool lowered_grade_2(WamState*); bool lowered_rel_2(WamState*);
+static int failures = 0;
+static void chk(const char* n, bool g, bool w) {
+    if (g != w) { std::cerr << \"FAIL \" << n << \": got \" << g << \" want \" << w << \"\\n\"; failures++; }
+}
+static Value A(const char* s) { return Value::Atom(s); }
+int main() {
+    { WamState v; v.put_reg(\"A1\", A(\"alice\")); v.put_reg(\"A2\", A(\"a\")); chk(\"grade(alice,a)\", lowered_grade_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"bob\"));   v.put_reg(\"A2\", A(\"b\")); chk(\"grade(bob,b)\",   lowered_grade_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"alice\")); v.put_reg(\"A2\", A(\"c\")); chk(\"grade(alice,c)\", lowered_grade_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"alice\")); v.put_reg(\"A2\", A(\"b\")); chk(\"grade(alice,b)\", lowered_grade_2(&v), false); }
+    { WamState v; v.put_reg(\"A1\", A(\"carol\")); v.put_reg(\"A2\", A(\"a\")); chk(\"grade(carol,a)\", lowered_grade_2(&v), false); }
+    { WamState v; v.put_reg(\"A1\", A(\"bob\"));   v.put_reg(\"A2\", A(\"c\")); chk(\"grade(bob,c)\",   lowered_grade_2(&v), false); }
+    { WamState v; v.put_reg(\"A1\", A(\"p\")); v.put_reg(\"A2\", A(\"one\")); chk(\"rel(p,one)\", lowered_rel_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"q\")); v.put_reg(\"A2\", A(\"two\")); chk(\"rel(q,two)\", lowered_rel_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"p\")); v.put_reg(\"A2\", A(\"two\")); chk(\"rel(p,two)\", lowered_rel_2(&v), false); }
+    { WamState v; v.put_reg(\"A1\", A(\"q\")); v.put_reg(\"A2\", A(\"one\")); chk(\"rel(q,one)\", lowered_rel_2(&v), false); }
+    if (failures == 0) { std::cout << \"ALL 10 PASS\\n\"; return 0; }
+    std::cerr << failures << \" FAILURES\\n\"; return 1;
+}
+").


### PR DESCRIPTION
## Summary

Fourth target in the **T4 sweep** (after Scala #2941, Rust #2942, Go #2952). A multi-clause predicate whose clauses are all supported deterministic bodies but do **not** discriminate on a distinct first-argument constant (so T5 declines) now lowers with **every clause inline**, instead of `multi_clause_1`. The lowered function never returns to the interpreter for the predicate.

As with Scala/Rust/Go, **no choice-point-model change** is needed: C++'s lowered functions are self-contained, so all-clauses-inline is achieved by trying each clause as an immediately-invoked lambda with a trail/register/env/cut restore between attempts.

```cpp
bool lowered_grade_2(WamState* vm) {
    auto _t4 = vm->lo_clause_snapshot();
    if ([&]() -> bool { /* alice,a */ return true; }()) return true;
    vm->lo_restore_clause(_t4);
    if ([&]() -> bool { /* bob,b  */ return true; }()) return true;
    vm->lo_restore_clause(_t4);
    if ([&]() -> bool { /* alice,c */ return true; }()) return true;
    vm->lo_restore_clause(_t4);
    return false;
}
```

## Changes

- **`wam_cpp_target.pl`** (inline runtime): `struct ClauseSnapshot` + `WamState::lo_clause_snapshot` / `lo_restore_clause` — capture/restore the clause-entry state (regs map, trail via `unwind_trail_to`, `env_stack`, `cut_barrier`, `choice_points` depth), mirroring the `ChoicePoint` restore minus the resume pc. `var_counter` is monotonic and intentionally not restored.
- **`wam_cpp_lowered_emitter.pl`**: `cpp_split_clauses/2` + `cpp_all_clauses_lowerable/1`, both stripping the C++ parser's leading `switch_on_*` indexing prefix first (the C++ parser keeps it, unlike Scala/Rust/Go — reuses `cpp_strip_switch_prefix`); gate `multi_clause_n` between `clause_chain` (T5) and `multi_clause_1`; `emit_multi_clause_n_cpp` (snapshot typed `auto` so the generated code needs no namespace qualification; per-clause lambdas + `lo_restore_clause` between attempts).
- **`tests/test_wam_cpp_lowered_t4.pl`**: gated g++/clang++ exec test. `grade/2` (fact chain, repeated first arg) and `rel/2` (rule chain, variable first arg — clause 1 clobbers A2, exercising the restore) gate as `multi_clause_n`, compile and run; pins exercise the non-first clauses natively (`grade(alice,c)`=clause 3, `grade(bob,b)`/`rel(q,two)`=clause 2) plus no-match cases.

## Verification

- New `test_wam_cpp_lowered_t4`: gate (both `multi_clause_n`) + compiled exec parity (10 queries, "ALL 10 PASS") pass.
- No regression: `test_wam_cpp_lowered_t5`, `test_wam_cpp_lowered_ite_exec` pass.

Sweep so far: ✅ Scala (#2941), ✅ Rust (#2942), ✅ Go (#2952), ✅ C++ (this). Remaining: haskell, fsharp, clojure, llvm, lua.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_