### PR TITLE
Add T4 (multi_clause_n) all-clauses lowering for Haskell

### DIFF
--- a/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
@@ -224,6 +224,8 @@ emit_func(FN, PCInstrs, LabelMap, ForeignPreds) :-
     strip_switch_prefixes(PCInstrs, PCInstrs1),
     (   emit_func_t5(FN, PCInstrs1, LabelMap, ForeignPreds)
     ->  true   % T5 first-argument dispatch (all clauses lowered natively)
+    ;   emit_func_t4(FN, PCInstrs1, LabelMap, ForeignPreds)
+    ->  true   % T4 all-clauses inline (every clause native, no interpreter hop)
     ;   PCInstrs1 = [pc(_, try_me_else(LStr))|BodyPCs]
     ->  atom_string(LAtom, LStr),
         (   member(LAtom-AltPC, LabelMap) -> true ; AltPC = 0 ),
@@ -362,6 +364,69 @@ t5_emit_clause_defs([Slice|Rest], N, LabelMap, FP) :-
     emit_clause_struct(Slice, LabelMap, SV, "      ", FP),
     N1 is N + 1,
     t5_emit_clause_defs(Rest, N1, LabelMap, FP).
+
+%% =====================================================================
+%% T4: multi-clause, all clauses inline (multi_clause_n)
+%% =====================================================================
+%
+%  When the clauses do NOT discriminate on a distinct first-argument constant
+%  (so T5 declines) but every clause is a fully-supported deterministic body,
+%  lower them ALL: each clause becomes a `WamState -> Maybe WamState` do-block,
+%  and the function tries them in order on the SAME input state, taking the
+%  first Just. Haskell's immutability gives a free per-clause restore (each
+%  clause runs against the unchanged s_init), so — unlike the imperative
+%  targets — no snapshot/restore is needed and no choice point is pushed: the
+%  interpreter is never entered for the predicate. First-solution /
+%  deterministic-prefix semantics, strictly more than multi_clause_1.
+
+%% emit_func_t4(+FN, +PCInstrs1, +LabelMap, +FP) is semidet.
+%  Emits the T4 all-clauses chain and succeeds, or fails (emitting nothing)
+%  when the predicate is not a multi-clause predicate whose every clause is a
+%  supported deterministic body. All checks run before any output.
+emit_func_t4(FN, PCInstrs1, LabelMap, FP) :-
+    PCInstrs1 = [pc(_, try_me_else(_))|_],
+    t5_split_clauses_pc(PCInstrs1, Slices),
+    Slices = [_, _ | _],
+    forall(member(Sl, Slices),
+           ( % Reject an if-then-else soft-cut block masquerading as a
+             % multi-clause head: it also opens with try_me_else and uses
+             % trust_me as its else-separator, but its slices carry the
+             % cut_ite / jump markers. A genuine clean multi-clause body has
+             % none of these (nor a nested try_me_else), and is fully
+             % supported. ITE blocks fall through to the multi_clause_1 path,
+             % which folds them via emit_clause_struct.
+             \+ member(pc(_, try_me_else(_)), Sl),
+             \+ member(pc(_, cut_ite), Sl),
+             \+ member(pc(_, jump(_)), Sl),
+             forall(member(pc(_, I), Sl), supported(I)) )),
+    % All checks passed — emit.
+    format("~w !ctx s_init =~n", [FN]),
+    format("  -- T4 all-clauses inline (generated): try each clause on the input~n"),
+    format("  -- state; first Just wins. Immutability gives a free per-clause~n"),
+    format("  -- restore, so the interpreter is never entered for the predicate.~n"),
+    format("  "),
+    emit_t4_calls(Slices, 1),
+    format("~n  where~n"),
+    format("    orElse (Just r) _ = Just r~n"),
+    format("    orElse Nothing  k = k~n"),
+    t4_emit_clause_defs(Slices, 1, LabelMap, FP).
+
+%% emit_t4_calls(+Slices, +Index) — emit the `orElse`-chained clause calls.
+emit_t4_calls([_], N) :- !,
+    format("t4clause_~w s_init", [N]).
+emit_t4_calls([_|Rest], N) :-
+    format("t4clause_~w s_init `orElse` ", [N]),
+    N1 is N + 1,
+    emit_t4_calls(Rest, N1).
+
+%% t4_emit_clause_defs(+Slices, +Index, +LabelMap, +FP)
+t4_emit_clause_defs([], _, _, _).
+t4_emit_clause_defs([Slice|Rest], N, LabelMap, FP) :-
+    format("    t4clause_~w s_c~w = do~n", [N, N]),
+    format(atom(SV), 's_c~w', [N]),
+    emit_clause_struct(Slice, LabelMap, SV, "      ", FP),
+    N1 is N + 1,
+    t4_emit_clause_defs(Rest, N1, LabelMap, FP).
 
 %% =====================================================================
 %% emit_instrs_lm — LabelMap-aware top-level emission

--- a/tests/test_wam_haskell_lowered_t4.pl
+++ b/tests/test_wam_haskell_lowered_t4.pl
@@ -1,0 +1,115 @@
+% test_wam_haskell_lowered_t4.pl
+%
+% End-to-end execution test for the Haskell T4 lowering — "multi-clause, all
+% clauses" (lowering type T4 / multi_clause_n in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md), ported from
+% Scala/Rust/Go/C++.
+%
+% A multi-clause predicate whose clauses are all supported deterministic
+% bodies but do NOT discriminate on a distinct first-argument constant (so T5
+% declines) now lowers to ALL clauses inline: each clause becomes a
+% `WamState -> Maybe WamState` do-block and the function tries them in order on
+% the SAME input state (`c1 s_init `orElse` c2 s_init `orElse` ...`), taking
+% the first Just. Haskell's immutability gives a free per-clause restore, so —
+% unlike the imperative targets — no snapshot/restore and no choice point are
+% needed; the interpreter is never entered for the predicate.
+%
+% Pins (BOUND first arg; the payoff is the non-first clauses running natively):
+%   * grade/2 — fact chain with a REPEATED first arg (alice in clauses 1 & 3);
+%   * rel/2   — RULE chain with a VARIABLE first arg (=/2 body).
+%
+% Skipped automatically when `ghc` is not on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_haskell_target').
+
+:- dynamic user:grade/2.
+:- dynamic user:rel/2.
+
+user:grade(alice, a).
+user:grade(bob,   b).
+user:grade(alice, c).
+
+user:rel(X, one) :- X = p.
+user:rel(X, two) :- X = q.
+
+ghc_available :-
+    catch(( process_create(path(ghc), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_haskell_lowered_t4, [condition(ghc_available)]).
+
+test(t4_exec_parity) :-
+    Dir = 'output/test_wam_haskell_t4_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_haskell_project(
+        [user:grade/2, user:rel/2],
+        [module_name('t4proj'), emit_mode(functions)], Dir),
+    atomic_list_concat([Dir, '/src/Lowered.hs'], LoweredPath),
+    ( exists_file(LoweredPath) -> read_file_to_string(LoweredPath, LSrc, []) ; LSrc = "" ),
+    assertion(sub_string(LSrc, _, _, _, "T4 all-clauses inline")),
+    atomic_list_concat([Dir, '/src/TestMain.hs'], TestPath),
+    haskell_t4_source(Src),
+    setup_call_cleanup(open(TestPath, write, S), write(S, Src), close(S)),
+    atomic_list_concat([Dir, '/src'], SrcDir),
+    atomic_list_concat([Dir, '/t4_test'], Bin),
+    format(atom(Cmd),
+        'ghc --make -i~w ~w/TestMain.hs -o ~w -main-is Main 2>&1 && ~w',
+        [SrcDir, SrcDir, Bin, Bin]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 10 PASS")
+    ->  true
+    ;   format(user_error, "~n[haskell t4 test output]~n~w~n", [OutStr]),
+        throw(haskell_t4_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_haskell_lowered_t4).
+
+% Calls each lowered function with the query args preloaded (first arg bound)
+% and checks Just (success) / Nothing (failure). Exercises the non-first
+% clauses (grade clauses 2 & 3, rel clause 2) — the T4 payoff — plus no-match
+% cases.
+haskell_t4_source(
+"module Main where
+import qualified Data.HashMap.Strict as Map
+import qualified Data.IntMap.Strict as IM
+import WamTypes
+import WamRuntime ()
+import Lowered
+import Predicates (compileTimeAtomTable)
+
+runP :: (WamContext -> WamState -> Maybe WamState) -> [(Int, Value)] -> Bool
+runP f regs =
+  let ctx = (mkContext [] Map.empty)
+              { wcLoweredPredicates = loweredPredicates
+              , wcInternTable = compileTimeAtomTable }
+      s0  = emptyState { wsRegs = IM.fromList regs }
+  in case f ctx s0 of { Just _ -> True; Nothing -> False }
+
+a :: String -> Value
+a s = Atom (internAtomPure compileTimeAtomTable s)
+
+main :: IO ()
+main = do
+  let cases =
+        [ (\"grade(alice,a)\", runP lowered_grade_2 [(1,a \"alice\"),(2,a \"a\")], True)
+        , (\"grade(bob,b)\",   runP lowered_grade_2 [(1,a \"bob\"),(2,a \"b\")], True)
+        , (\"grade(alice,c)\", runP lowered_grade_2 [(1,a \"alice\"),(2,a \"c\")], True)
+        , (\"grade(alice,b)\", runP lowered_grade_2 [(1,a \"alice\"),(2,a \"b\")], False)
+        , (\"grade(carol,a)\", runP lowered_grade_2 [(1,a \"carol\"),(2,a \"a\")], False)
+        , (\"grade(bob,c)\",   runP lowered_grade_2 [(1,a \"bob\"),(2,a \"c\")], False)
+        , (\"rel(p,one)\", runP lowered_rel_2 [(1,a \"p\"),(2,a \"one\")], True)
+        , (\"rel(q,two)\", runP lowered_rel_2 [(1,a \"q\"),(2,a \"two\")], True)
+        , (\"rel(p,two)\", runP lowered_rel_2 [(1,a \"p\"),(2,a \"two\")], False)
+        , (\"rel(q,one)\", runP lowered_rel_2 [(1,a \"q\"),(2,a \"one\")], False)
+        ]
+      fails = [ n | (n,got,want) <- cases, got /= want ]
+  mapM_ (\\(n,got,want) -> if got/=want then putStrLn (\"FAIL \" ++ n ++ \": got \" ++ show got ++ \" want \" ++ show want) else return ()) cases
+  if null fails then putStrLn (\"ALL \" ++ show (length cases) ++ \" PASS\") else putStrLn (show (length fails) ++ \" FAILURES\")
+").


### PR DESCRIPTION
## Summary

Fifth target in the **T4 sweep** (after Scala #2941, Rust #2942, Go #2952, C++ #2953) and the **first functional target**. A multi-clause predicate whose clauses are all supported deterministic bodies but do **not** discriminate on a distinct first-argument constant (so T5 declines) now lowers with **every clause inline**, instead of `multi_clause_1`. The interpreter is never entered for the predicate.

Unlike the imperative targets (which snapshot/restore mutable state between clause attempts), Haskell's lowered functions are `WamState -> Maybe WamState`, so **immutability gives a free per-clause restore**: each clause runs against the unchanged input state and the function takes the first `Just`. No snapshot, no choice point, **no runtime change**.

```haskell
lowered_grade_2 !ctx s_init =
  t4clause_1 s_init `orElse` t4clause_2 s_init `orElse` t4clause_3 s_init
  where
    orElse (Just r) _ = Just r
    orElse Nothing  k = k
    t4clause_1 s_c1 = do { ... alice,a ... }
    t4clause_2 s_c2 = do { ... bob,b  ... }
    t4clause_3 s_c3 = do { ... alice,c ... }
```

## Changes

- **`wam_haskell_lowered_emitter.pl`**: `emit_func_t4`, emitted between `emit_func_t5` and the `multi_clause_1` path. Splits the clauses (reusing `t5_split_clauses_pc`), emits each as `t4clause_N s_cN = do <body>` (reusing `emit_clause_struct`), and chains them with a local lazy `orElse` (Maybe's `<|>`, defined in the `where`-clause so **no new import** is needed). Rejects an **if-then-else soft-cut block** masquerading as a multi-clause head (it also opens with `try_me_else` + uses `trust_me` as its else-separator) by checking for the `cut_ite` / `jump` markers a clean clause never carries — those fall through to `multi_clause_1` as before.
- **`tests/test_wam_haskell_lowered_t4.pl`**: gated `ghc` exec test. `grade/2` (fact chain, repeated first arg) and `rel/2` (rule chain, variable first arg, `=/2` body) emit the T4 chain, compile and run; pins exercise the non-first clauses natively (`grade(alice,c)`=clause 3, `grade(bob,b)`/`rel(q,two)`=clause 2) plus no-match cases.

## Verification

- New `test_wam_haskell_lowered_t4`: marker assertion + `ghc` exec parity (10 queries, "ALL 10 PASS") pass.
- `test_wam_haskell_lowered_t5` still passes.
- ⚠️ `test_wam_haskell_lowered_ite_exec` fails **identically on unmodified `main`** — a pre-existing, unrelated failure (verified by stashing this branch's changes).

Sweep so far: ✅ Scala (#2941), ✅ Rust (#2942), ✅ Go (#2952), ✅ C++ (#2953), ✅ Haskell (this). Remaining: fsharp, clojure, llvm, lua.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_