### PR TITLE
Add T4 (multi_clause_n) all-clauses lowering for F#

### DIFF
--- a/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
@@ -245,6 +245,8 @@ emit_func_fs(FN, PCInstrs, LabelMap, ForeignPreds) :-
     strip_switch_prefixes_fs(PCInstrs, PCInstrs1),
     (   emit_func_t5_fs(PCInstrs1, LabelMap, ForeignPreds)
     ->  true   % T5 first-argument dispatch (all clauses lowered natively)
+    ;   emit_func_t4_fs(PCInstrs1, LabelMap, ForeignPreds)
+    ->  true   % T4 all-clauses inline (every clause native, no interpreter hop)
     ;   PCInstrs1 = [pc(_, try_me_else(LStr))|BodyPCs]
     ->  % Multi-clause: push CP for clause-2+ backtrack, try clause 1
         atom_string(LAtom, LStr),
@@ -343,6 +345,64 @@ emit_func_t5_fs(PCInstrs1, LabelMap, FP) :-
     format("    | None -> t5fallback ()~n").
 
 t5_strip_pc_fs(pc(_, I), I).
+
+% ============================================================================
+% T4: multi-clause, all clauses inline (multi_clause_n)
+%
+%  When the clauses do NOT discriminate on a distinct first-argument constant
+%  (so T5 declines) but every clause is a fully-supported deterministic body,
+%  lower them ALL: each clause becomes a `WamState -> WamState option`, and the
+%  function tries them in order on the SAME input state, taking the first Some.
+%  F#'s immutability gives a free per-clause restore (each clause runs against
+%  the unchanged s_init), so — unlike the imperative targets — no snapshot/
+%  restore is needed and no choice point is pushed: the interpreter is never
+%  entered for the predicate. Mirrors the Haskell emitter's emit_func_t4.
+% ============================================================================
+
+%% emit_func_t4_fs(+PCInstrs1, +LabelMap, +FP) is semidet.
+%  Emits the T4 all-clauses body and succeeds, or fails (emitting nothing)
+%  when the predicate is not a multi-clause predicate whose every clause is a
+%  supported deterministic body. All checks run before any output.
+emit_func_t4_fs(PCInstrs1, LabelMap, FP) :-
+    PCInstrs1 = [pc(_, try_me_else(_))|_],
+    t5_split_clauses_pc_fs(PCInstrs1, Slices),
+    Slices = [_, _ | _],
+    forall(member(Sl, Slices),
+           ( % Reject an if-then-else soft-cut block masquerading as a
+             % multi-clause head: it also opens with try_me_else and uses
+             % trust_me as its else-separator, but its slices carry cut_ite /
+             % jump markers a clean multi-clause body never has. ITE blocks
+             % fall through to the multi_clause_1 path.
+             \+ member(pc(_, try_me_else(_)), Sl),
+             \+ member(pc(_, cut_ite), Sl),
+             \+ member(pc(_, jump(_)), Sl),
+             forall(member(pc(_, In), Sl), supported_fs(In)) )),
+    % All checks passed — emit.
+    format("    // T4 all-clauses inline (generated): try each clause on the input~n"),
+    format("    // state; first Some wins. Immutability gives a free per-clause~n"),
+    format("    // restore, so the interpreter is never entered for the predicate.~n"),
+    t4_emit_clause_defs_fs(Slices, 1, LabelMap, FP),
+    format("    t4clause_1 s_init~n"),
+    t4_emit_chain_tail_fs(Slices, 2).
+
+%% t4_emit_clause_defs_fs(+Slices, +Index, +LabelMap, +FP)
+t4_emit_clause_defs_fs([], _, _, _).
+t4_emit_clause_defs_fs([Slice|Rest], N, LabelMap, FP) :-
+    format("    let t4clause_~w (s_c~w: WamState) : WamState option =~n", [N, N]),
+    format(atom(SV), 's_c~w', [N]),
+    emit_clause_struct_fs(Slice, LabelMap, SV, "        ", FP),
+    N1 is N + 1,
+    t4_emit_clause_defs_fs(Rest, N1, LabelMap, FP).
+
+%% t4_emit_chain_tail_fs(+Slices, +Index) — emit `|> Option.orElseWith` for
+%  clauses 2..N (lazy; clause 1 already emitted as the chain head).
+t4_emit_chain_tail_fs(Slices, N) :-
+    (   nth1(N, Slices, _)
+    ->  format("    |> Option.orElseWith (fun () -> t4clause_~w s_init)~n", [N]),
+        N1 is N + 1,
+        t4_emit_chain_tail_fs(Slices, N1)
+    ;   true
+    ).
 
 %% t5_split_clauses_pc_fs(+PCInstrs1, -Slices)
 %  Split the switch-stripped pc-instruction list (opens with try_me_else) at

--- a/tests/test_wam_fsharp_lowered_t4.pl
+++ b/tests/test_wam_fsharp_lowered_t4.pl
@@ -1,0 +1,123 @@
+% test_wam_fsharp_lowered_t4.pl
+%
+% End-to-end execution test for the F# T4 lowering — "multi-clause, all
+% clauses" (lowering type T4 / multi_clause_n in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md), ported from
+% Scala/Rust/Go/C++/Haskell.
+%
+% A multi-clause predicate whose clauses are all supported deterministic
+% bodies but do NOT discriminate on a distinct first-argument constant (so T5
+% declines) now lowers to ALL clauses inline: each clause becomes a
+% `WamState -> WamState option` and the function tries them in order on the
+% SAME input state (`t4clause_1 s_init |> Option.orElseWith (fun () ->
+% t4clause_2 s_init) |> ...`), taking the first Some. F#'s immutability gives
+% a free per-clause restore, so — unlike the imperative targets — no
+% snapshot/restore and no choice point are needed; the interpreter is never
+% entered for the predicate.
+%
+% Pins (BOUND first arg; the payoff is the non-first clauses running natively):
+%   * grade/2 — fact chain with a REPEATED first arg (alice in clauses 1 & 3);
+%   * rel/2   — RULE chain with a VARIABLE first arg (=/2 body).
+%
+% Skipped automatically when `dotnet` is not on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_fsharp_target').
+
+:- dynamic user:grade/2.
+:- dynamic user:rel/2.
+
+user:grade(alice, a).
+user:grade(bob,   b).
+user:grade(alice, c).
+
+user:rel(X, one) :- X = p.
+user:rel(X, two) :- X = q.
+
+dotnet_available :-
+    catch(( process_create(path(dotnet), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_fsharp_lowered_t4, [condition(dotnet_available)]).
+
+test(t4_exec_parity) :-
+    Dir = 'output/test_wam_fsharp_t4_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_fsharp_project(
+        [user:grade/2, user:rel/2],
+        [module_name('t4proj'), emit_mode(functions)], Dir),
+    atomic_list_concat([Dir, '/Lowered.fs'], LoweredPath),
+    ( exists_file(LoweredPath) -> read_file_to_string(LoweredPath, LSrc, []) ; LSrc = "" ),
+    assertion(sub_string(LSrc, _, _, _, "T4 all-clauses inline")),
+    atomic_list_concat([Dir, '/Program.fs'], ProgPath),
+    fsharp_t4_source(Src),
+    setup_call_cleanup(open(ProgPath, write, S), write(S, Src), close(S)),
+    format(atom(Cmd),
+        'cd ~w && DOTNET_CLI_TELEMETRY_OPTOUT=1 DOTNET_NOLOGO=1 dotnet run --project t4proj.fsproj -c Release 2>&1',
+        [Dir]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 10 PASS")
+    ->  true
+    ;   format(user_error, "~n[fsharp t4 test output]~n~w~n", [OutStr]),
+        throw(fsharp_t4_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_fsharp_lowered_t4).
+
+% Builds a minimal WamContext/WamState, sets the A-registers with a BOUND
+% first arg, calls each lowered function, and checks Some/None. The cases
+% exercise the non-first clauses (grade clauses 2 & 3, rel clause 2) — the T4
+% payoff — plus the no-match cases.
+fsharp_t4_source(
+"module Program
+
+open WamTypes
+open WamRuntime
+open Lowered
+
+let testEmptyState =
+    { WsPC = 0; WsRegs = Array.create MaxRegs (Unbound -1); WsStack = []
+      WsHeap = []; WsHeapLen = 0; WsTrail = []; WsTrailLen = 0
+      WsCP = 0; WsCPs = []; WsCPsLen = 0; WsBindings = Map.empty
+      WsCutBar = 0; WsVarCounter = 0; WsBuilder = None; WsBuilderStack = []
+      WsAggAccum = []; WsB0Stack = []; WsCatchers = [] }
+
+let testCtx : WamContext =
+    { WcCode = [||]; WcLabels = Map.empty; WcForeignFacts = Map.empty
+      WcFfiFacts = Map.empty; WcFfiWeightedFacts = Map.empty
+      WcAtomIntern = Map.empty; WcAtomDeintern = Map.empty
+      WcForeignConfig = Map.empty; WcLoweredPredicates = loweredPredicates
+      WcLookupSources = Map.empty; WcCancellationToken = None }
+
+let runP (f: WamContext -> WamState -> WamState option) (regs: (int * Value) list) : bool =
+    let arr = Array.create MaxRegs (Unbound -1)
+    regs |> List.iter (fun (idx, v) -> arr.[idx] <- v)
+    let s0 = { testEmptyState with WsRegs = arr }
+    match f testCtx s0 with Some _ -> true | None -> false
+
+let a (s: string) : Value = Atom s
+
+[<EntryPoint>]
+let main _argv =
+    let cases : (string * bool * bool) list =
+        [ (\"grade(alice,a)\", runP lowered_grade_2 [(1, a \"alice\"); (2, a \"a\")], true)
+          (\"grade(bob,b)\",   runP lowered_grade_2 [(1, a \"bob\"); (2, a \"b\")], true)
+          (\"grade(alice,c)\", runP lowered_grade_2 [(1, a \"alice\"); (2, a \"c\")], true)
+          (\"grade(alice,b)\", runP lowered_grade_2 [(1, a \"alice\"); (2, a \"b\")], false)
+          (\"grade(carol,a)\", runP lowered_grade_2 [(1, a \"carol\"); (2, a \"a\")], false)
+          (\"grade(bob,c)\",   runP lowered_grade_2 [(1, a \"bob\"); (2, a \"c\")], false)
+          (\"rel(p,one)\", runP lowered_rel_2 [(1, a \"p\"); (2, a \"one\")], true)
+          (\"rel(q,two)\", runP lowered_rel_2 [(1, a \"q\"); (2, a \"two\")], true)
+          (\"rel(p,two)\", runP lowered_rel_2 [(1, a \"p\"); (2, a \"two\")], false)
+          (\"rel(q,one)\", runP lowered_rel_2 [(1, a \"q\"); (2, a \"one\")], false) ]
+    let fails = cases |> List.filter (fun (_, got, want) -> got <> want)
+    fails |> List.iter (fun (n, got, want) -> printfn \"FAIL %s: got %b want %b\" n got want)
+    if List.isEmpty fails then printfn \"ALL %d PASS\" (List.length cases); 0
+    else printfn \"%d FAILURES\" (List.length fails); 1
+").


### PR DESCRIPTION
## Summary

Sixth target in the **T4 sweep** (after Scala #2941, Rust #2942, Go #2952, C++ #2953, Haskell #2954). A multi-clause predicate whose clauses are all supported deterministic bodies but do **not** discriminate on a distinct first-argument constant (so T5 declines) now lowers with **every clause inline**, instead of `multi_clause_1`. The interpreter is never entered for the predicate.

Mirrors the Haskell port: F#'s lowered functions are `WamState -> WamState option`, so **immutability gives a free per-clause restore** (each clause runs against the unchanged input state, first `Some` wins). No snapshot, no choice point, **no runtime change**.

```fsharp
let lowered_grade_2 (ctx: WamContext) (s_init: WamState) : WamState option =
    // T4 all-clauses inline (generated)
    let t4clause_1 (s_c1: WamState) : WamState option = ... // alice,a
    let t4clause_2 (s_c2: WamState) : WamState option = ... // bob,b
    let t4clause_3 (s_c3: WamState) : WamState option = ... // alice,c
    t4clause_1 s_init
    |> Option.orElseWith (fun () -> t4clause_2 s_init)
    |> Option.orElseWith (fun () -> t4clause_3 s_init)
```

## Changes

- **`wam_fsharp_lowered_emitter.pl`**: `emit_func_t4_fs`, emitted between `emit_func_t5_fs` and the `multi_clause_1` path. Splits the clauses (reusing `t5_split_clauses_pc_fs`), emits each as `let t4clause_N (s_cN: WamState) : WamState option = <body>` (reusing `emit_clause_struct_fs`), and chains them lazily with `Option.orElseWith`. Rejects an if-then-else soft-cut block masquerading as a multi-clause head via the `cut_ite` / `jump` markers a clean clause never carries — ITE blocks fall through to `multi_clause_1`.
- **`tests/test_wam_fsharp_lowered_t4.pl`**: gated `dotnet` exec test. `grade/2` (fact chain, repeated first arg) and `rel/2` (rule chain, variable first arg, `=/2` body) emit the T4 chain, compile and run; pins exercise the non-first clauses natively (`grade(alice,c)`=clause 3, `grade(bob,b)`/`rel(q,two)`=clause 2) plus no-match cases.

## Verification

- New `test_wam_fsharp_lowered_t4`: marker assertion + `dotnet` exec parity (10 queries, "ALL 10 PASS") pass.
- No regression: `test_wam_fsharp_lowered_t5` and `test_wam_fsharp_lowered_ite_exec` pass (the ITE exec test confirms the `cut_ite`/`jump` exclusion keeps soft-cut blocks on the `multi_clause_1` path).

Sweep so far: ✅ Scala (#2941), ✅ Rust (#2942), ✅ Go (#2952), ✅ C++ (#2953), ✅ Haskell (#2954), ✅ F# (this). Remaining: clojure, llvm, lua.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_