### PR TITLE
Add T4 (multi_clause_n) all-clauses lowering for Clojure

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -119,14 +119,79 @@ wam_clojure_lowerable(PI, WamCode, Reason) :-
     forall(member(I, C1), clojure_supported(I)),
     (   is_deterministic_pred_clojure(Instrs)
     ->  Reason = deterministic
+    ;   % T4: every clause is a clean supported deterministic body — lower them
+        % ALL inline (tried in order; immutability gives a free per-clause
+        % restore), so the predicate runs natively instead of stubbing out to
+        % the run-wam interpreter. Otherwise keep the multi_clause_1 stub.
+        clojure_all_clauses_lowerable(Instrs)
+    ->  Reason = multi_clause_n
     ;   Reason = multi_clause_1
     ),
     ( PI = _M:_P/_A -> true ; PI = _/_A2 -> true ; true ).
 
+%% clojure_split_clauses(+Instrs, -Clauses) is semidet.
+%  Split a multi-clause predicate (opens with try_me_else) at the choice-point
+%  separators into per-clause instruction lists (T4 / multi_clause_n).
+clojure_split_clauses([try_me_else(_)|Rest], [Clause|More]) :-
+    clojure_collect_clause(Rest, Clause, After),
+    clojure_split_more(After, More).
+
+clojure_split_more([], []).
+clojure_split_more([retry_me_else(_)|Rest], [Clause|More]) :- !,
+    clojure_collect_clause(Rest, Clause, After),
+    clojure_split_more(After, More).
+clojure_split_more([trust_me|Rest], [Clause|More]) :- !,
+    clojure_collect_clause(Rest, Clause, After),
+    clojure_split_more(After, More).
+
+clojure_collect_clause([], [], []).
+clojure_collect_clause([retry_me_else(L)|Rest], [], [retry_me_else(L)|Rest]) :- !.
+clojure_collect_clause([trust_me|Rest], [], [trust_me|Rest]) :- !.
+clojure_collect_clause([I|Rest], [I|More], After) :-
+    clojure_collect_clause(Rest, More, After).
+
+%% clojure_all_clauses_lowerable(+Instrs) is semidet.
+%  True when EVERY clause is a clean supported deterministic body (no inner
+%  choice point or ITE marker, ends in a terminal) — the T4 condition.
+clojure_all_clauses_lowerable(Instrs0) :-
+    clojure_strip_switch_prefix(Instrs0, Instrs),
+    clojure_split_clauses(Instrs, Clauses),
+    Clauses = [_, _ | _],
+    forall(member(Cl, Clauses),
+           ( \+ member(try_me_else(_), Cl),
+             \+ member(cut_ite, Cl),
+             \+ member(jump(_), Cl),
+             % call / execute / call_foreign only set the pc to a sub-predicate
+             % and rely on run-wam to actually execute it; the inline threading
+             % would skip straight past to proceed and wrongly succeed. Keep
+             % such clauses on the multi_clause_1 (run-wam) path.
+             \+ member(call(_, _), Cl),
+             \+ member(execute(_), Cl),
+             \+ member(call_foreign(_, _), Cl),
+             forall(member(I, Cl), clojure_supported(I)),
+             last(Cl, Last), clojure_clause_terminal(Last) )).
+
+clojure_clause_terminal(proceed).
+clojure_clause_terminal(fail).
+
 clause1_instrs([], []).
+% Strip leading first-argument indexing instructions (switch_on_*) — they are
+% dispatch helpers ahead of try_me_else, not part of any clause body.
+clause1_instrs([switch_on_constant(_)|Rest], C1) :- !, clause1_instrs(Rest, C1).
+clause1_instrs([switch_on_constant_a2(_)|Rest], C1) :- !, clause1_instrs(Rest, C1).
+clause1_instrs([switch_on_structure(_)|Rest], C1) :- !, clause1_instrs(Rest, C1).
+clause1_instrs([switch_on_term(_)|Rest], C1) :- !, clause1_instrs(Rest, C1).
 clause1_instrs([try_me_else(_)|Rest], C1) :- !,
     take_to_terminal(Rest, C1).
 clause1_instrs(Instrs, Instrs).
+
+%% clojure_strip_switch_prefix(+Instrs, -Stripped) — drop a leading switch_on_*
+%  indexing prefix so the try_me_else/retry_me_else/trust_me chain is exposed.
+clojure_strip_switch_prefix([switch_on_constant(_)|Rest], S) :- !, clojure_strip_switch_prefix(Rest, S).
+clojure_strip_switch_prefix([switch_on_constant_a2(_)|Rest], S) :- !, clojure_strip_switch_prefix(Rest, S).
+clojure_strip_switch_prefix([switch_on_structure(_)|Rest], S) :- !, clojure_strip_switch_prefix(Rest, S).
+clojure_strip_switch_prefix([switch_on_term(_)|Rest], S) :- !, clojure_strip_switch_prefix(Rest, S).
+clojure_strip_switch_prefix(L, L).
 
 take_to_terminal([], []).
 take_to_terminal([proceed|_], [proceed]) :- !.
@@ -209,6 +274,11 @@ lower_predicate_to_clojure(PI, WamCode, _Options, ClojureCode) :-
     (   is_deterministic_pred_clojure(Instrs)
     ->  lowered_direct_prefix(C1Instrs0, allow_control, C1Instrs),
         with_output_to(string(Body), emit_instrs(C1Instrs, "  "))
+    ;   clojure_all_clauses_lowerable(Instrs)
+    ->  % T4: lower every clause inline; try them in order on the same input
+        % state (immutable, so a free per-clause restore), taking the first
+        % whose threaded body reaches :succeeded. No run-wam interpretation.
+        with_output_to(string(Body), emit_multi_clause_n_clj(Instrs, "  "))
     ;   clojure_structured_clause1(WamCode, Structured)
     ->  % Single-clause if-then-else / negation / once: emit native
         % branching instead of the no-op stub (which delegated to run-wam).
@@ -222,6 +292,32 @@ lower_predicate_to_clojure(PI, WamCode, _Options, ClojureCode) :-
 (defn ~w [state]
 ~w)
 ', [FuncName, Pred, Arity, FuncName, Body]).
+
+%% emit_multi_clause_n_clj(+Instrs, +Indent)
+%  T4: emit every clause inline as a threaded (let [s0 state ...] sN) body and
+%  try them in order on the SAME input `state`, taking the first whose body
+%  reaches :succeeded. Immutability makes each clause start from the unchanged
+%  `state`, so no restore is needed; run-wam then short-circuits on the
+%  returned :succeeded / :failed status without interpreting any bytecode.
+emit_multi_clause_n_clj(Instrs0, Indent) :-
+    clojure_strip_switch_prefix(Instrs0, Instrs),
+    clojure_split_clauses(Instrs, Clauses),
+    format("~w;; T4 all-clauses inline (generated): try each clause on the same input~n", [Indent]),
+    format("~w;; state; first :succeeded wins (immutable state = free per-clause restore).~n", [Indent]),
+    emit_clj_cascade(Clauses, 1, Indent).
+
+emit_clj_cascade([Clause], _N, Indent) :- !,
+    emit_instrs(Clause, Indent).
+emit_clj_cascade([Clause|Rest], N, Indent) :-
+    N1 is N + 1,
+    atom_concat(Indent, "      ", Indent2),
+    format("~w(let [c~w~n", [Indent, N]),
+    emit_instrs(Clause, Indent2),
+    format("~w     ]~n", [Indent]),
+    format("~w  (if (= :succeeded (:status c~w))~n", [Indent, N]),
+    format("~w    c~w~n", [Indent, N]),
+    emit_clj_cascade(Rest, N1, Indent2),
+    format("~w))~n", [Indent]).
 
 emit_instrs([], Indent) :-
     format("~wstate~n", [Indent]).

--- a/tests/test_wam_clojure_lowered_emitter.pl
+++ b/tests/test_wam_clojure_lowered_emitter.pl
@@ -18,10 +18,13 @@ test(deterministic_predicate_is_lowerable) :-
     wam_clojure_lowerable(test_fact/1, WamCode, Reason),
     assertion(Reason == deterministic).
 
-test(multi_clause_clause1_is_lowerable) :-
+test(multi_clause_all_clauses_lowerable) :-
+    % A multi-clause predicate whose every clause is a clean supported
+    % deterministic body now lowers as T4 (multi_clause_n) — all clauses
+    % inline — instead of the old multi_clause_1 run-wam stub.
     multi_clause_wam(WamCode),
     wam_clojure_lowerable(test_choice/1, WamCode, Reason),
-    assertion(Reason == multi_clause_1).
+    assertion(Reason == multi_clause_n).
 
 test(multi_clause_emits_empty_lowered_prefix) :-
     once((
@@ -35,9 +38,14 @@ test(multi_clause_emits_empty_lowered_prefix) :-
         assertion(\+ has(Code, "runtime/step"))
     )).
 
-test(switch_on_constant_not_yet_lowerable, [fail]) :-
+test(switch_on_constant_prefix_is_stripped) :-
+    % A leading switch_on_constant indexing prefix is now stripped before
+    % lowerability is decided (so multi-clause predicates with first-argument
+    % indexing reach the T4 path). Here only `proceed` remains after the
+    % prefix, so the degenerate body lowers as deterministic.
     unsupported_wam(WamCode),
-    wam_clojure_lowerable(test_switch/1, WamCode, _).
+    wam_clojure_lowerable(test_switch/1, WamCode, Reason),
+    assertion(Reason == deterministic).
 
 test(determinism_detection) :-
     simple_fact_wam(Simple),
@@ -63,13 +71,17 @@ test(lower_predicate_to_clojure_emits_function) :-
         has(Code, "runtime/interned-equal?")
     )).
 
-test(lowered_multi_clause_stays_runtime_mediated) :-
+test(lowered_multi_clause_emits_t4_all_clauses) :-
+    % T4: a multi-clause predicate whose clauses are all clean deterministic
+    % bodies now emits EVERY clause inline (not the old no-op run-wam stub).
     once((
         multi_clause_wam(WamCode),
         lower_predicate_to_clojure(test_choice/1, WamCode, [], Code),
         has(Code, "defn lowered-test-choice-1 [state]"),
-        assertion(\+ has(Code, "get-constant a, A1")),
-        assertion(\+ has(Code, "get-constant b, A1")),
+        has(Code, "T4 all-clauses inline"),
+        has(Code, "get-constant a, A1"),     % clause 1 inline
+        has(Code, "get-constant b, A1"),     % clause 2 inline
+        has(Code, ":succeeded (:status"),     % first-succeeded cascade
         assertion(\+ has(Code, "runtime/step"))
     )).
 

--- a/tests/test_wam_clojure_lowered_t4.pl
+++ b/tests/test_wam_clojure_lowered_t4.pl
@@ -1,0 +1,104 @@
+% test_wam_clojure_lowered_t4.pl
+%
+% End-to-end execution test for the Clojure T4 lowering — "multi-clause, all
+% clauses" (lowering type T4 / multi_clause_n in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md), ported from
+% Scala/Rust/Go/C++/Haskell/F#.
+%
+% Clojure had NO multi-clause lowering: a try_me_else predicate emitted a
+% no-op stub and the run-wam interpreter executed it from start-pc. T4 is its
+% first real multi-clause lowering: when every clause is a supported
+% deterministic body, all clauses are emitted inline as threaded
+% `(let [s0 state ...] sN)` bodies and tried in order on the SAME input state,
+% taking the first whose body reaches :succeeded. Clojure's immutable state
+% gives a free per-clause restore, so no choice point is pushed and run-wam
+% short-circuits on the returned :succeeded / :failed status without
+% interpreting any bytecode.
+%
+% Pins (BOUND first arg; the payoff is the non-first clauses running natively):
+%   * grade/2 — fact chain with a REPEATED first arg (alice in clauses 1 & 3);
+%   * rel/2   — RULE chain with a VARIABLE first arg (=/2 body).
+%
+% Skipped automatically when no Clojure jar is found on the usual paths.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_clojure_target').
+:- use_module('../src/unifyweaver/targets/wam_clojure_lowered_emitter').
+
+:- dynamic user:grade/2.
+:- dynamic user:rel/2.
+
+user:grade(alice, a).
+user:grade(bob,   b).
+user:grade(alice, c).
+
+user:rel(X, one) :- X = p.
+user:rel(X, two) :- X = q.
+
+clojure_jar('/usr/share/java/clojure.jar').
+clojure_jar('/usr/share/java/clojure-1.11.jar').
+clojure_jar('/usr/share/java/clojure-1.11.1.jar').
+
+clojure_runnable(Jar) :-
+    clojure_jar(Jar), exists_file(Jar), !.
+
+:- begin_tests(wam_clojure_lowered_t4, [condition(clojure_runnable(_))]).
+
+% Both predicates must lower as T4 (multi_clause_n), not multi_clause_1.
+test(gate_picks_multi_clause_n) :-
+    forall(member(PI, [grade/2, rel/2]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_clojure_lowerable(PI, W, Reason),
+             assertion(Reason == multi_clause_n) )).
+
+test(t4_exec_parity) :-
+    clojure_runnable(Jar),
+    Dir = 'output/test_wam_clojure_t4_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_clojure_project(
+        [user:grade/2, user:rel/2],
+        [module_name('t4proj')], Dir),
+    atomic_list_concat([Dir, '/test_t4.clj'], TestPath),
+    clojure_t4_source(Src),
+    setup_call_cleanup(open(TestPath, write, S), write(S, Src), close(S)),
+    atomic_list_concat([Dir, '/src'], SrcDir),
+    format(atom(Cmd),
+        'java -cp "~w:~w" clojure.main ~w 2>&1',
+        [Jar, SrcDir, TestPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 10 PASS")
+    ->  true
+    ;   format(user_error, "~n[clojure t4 test output]~n~w~n", [OutStr]),
+        throw(clojure_t4_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_clojure_lowered_t4).
+
+% Calls each lowered predicate wrapper; run-wam returns a boolean. The cases
+% exercise the non-first clauses (grade clauses 2 & 3, rel clause 2) — the T4
+% payoff — plus no-match cases.
+clojure_t4_source(
+"(require '[generated.wam.core :as core])
+(require '[generated.wam.runtime :as runtime])
+(defn a [s] (runtime/normalize-literal-term core/atom-intern-context s))
+(def cases
+  [[\"grade(alice,a)\" (core/grade (a \"alice\") (a \"a\")) true]
+   [\"grade(bob,b)\"   (core/grade (a \"bob\")   (a \"b\")) true]
+   [\"grade(alice,c)\" (core/grade (a \"alice\") (a \"c\")) true]
+   [\"grade(alice,b)\" (core/grade (a \"alice\") (a \"b\")) false]
+   [\"grade(carol,a)\" (core/grade (a \"carol\") (a \"a\")) false]
+   [\"grade(bob,c)\"   (core/grade (a \"bob\")   (a \"c\")) false]
+   [\"rel(p,one)\" (core/rel (a \"p\") (a \"one\")) true]
+   [\"rel(q,two)\" (core/rel (a \"q\") (a \"two\")) true]
+   [\"rel(p,two)\" (core/rel (a \"p\") (a \"two\")) false]
+   [\"rel(q,one)\" (core/rel (a \"q\") (a \"one\")) false]])
+(let [fails (filter (fn [[_ got want]] (not= (boolean got) want)) cases)]
+  (doseq [[n got want] fails] (println \"FAIL\" n \"got\" (boolean got) \"want\" want))
+  (if (empty? fails) (println \"ALL\" (count cases) \"PASS\")
+      (println (count fails) \"FAILURES\")))
+").


### PR DESCRIPTION
## Summary

Seventh target in the **T4 sweep** (after Scala #2941, Rust #2942, Go #2952, C++ #2953, Haskell #2954, F# #2955). Clojure had **no** multi-clause lowering: a `try_me_else` predicate emitted a no-op stub and the `run-wam` interpreter executed it from start-pc. **T4 is Clojure's first real multi-clause lowering.**

When every clause is a clean supported deterministic body, all clauses are emitted inline as threaded `(let [s0 state ...] sN)` bodies and tried in order on the **same** input `state`, taking the first whose body reaches `:succeeded`. Clojure's **immutable state gives a free per-clause restore**, so no choice point is pushed and the wrapping `run-wam` short-circuits on the returned `:succeeded`/`:failed` status without interpreting any bytecode.

```clojure
(defn lowered-grade-2 [state]
  ;; T4 all-clauses inline (generated)
  (let [c1 (let [s0 state ... s3] s3)]      ; alice,a
    (if (= :succeeded (:status c1)) c1
      (let [c2 (let [s0 state ... s3] s3)]  ; bob,b
        (if (= :succeeded (:status c2)) c2
          (let [s0 state ... s3] s3))))))   ; alice,c
```

## Changes

- **`wam_clojure_lowered_emitter.pl`**: `clojure_split_clauses/2` + `clojure_all_clauses_lowerable/1` (every clause clean + supported + ends in `proceed`/`fail`, with **no** inner ITE marker and **no** `call`/`execute`/`call_foreign` — those only set the pc and rely on `run-wam` to execute the sub-predicate, so inline threading would skip past them and wrongly succeed; they keep the `multi_clause_1` stub). `clause1_instrs` + a new `clojure_strip_switch_prefix/2` strip a leading `switch_on_*` indexing prefix (the Clojure parser keeps it). `wam_clojure_lowerable` reports `multi_clause_n`; `lower_predicate_to_clojure` emits the all-clauses cascade (`emit_multi_clause_n_clj`).
- **`tests/test_wam_clojure_lowered_t4.pl`**: gated JVM exec test. `grade/2` (fact chain, repeated first arg, switch-indexed) and `rel/2` (rule chain, variable first arg, `=/2` body) gate as `multi_clause_n` and run; pins exercise the non-first clauses natively (`grade(alice,c)`=clause 3, `grade(bob,b)`/`rel(q,two)`=clause 2) plus no-match cases.
- **`tests/test_wam_clojure_lowered_emitter.pl`**: update three tests that encoded the old "multi-clause stays a run-wam stub" contract, which T4 supersedes (clean fact-chain → `multi_clause_n` + inline clauses; `switch_on_constant` prefix now stripped → degenerate body lowers as `deterministic`). The call-bearing multi-clause test still asserts `multi_clause_1`.

## Verification

- New `test_wam_clojure_lowered_t4`: gate (both `multi_clause_n`) + JVM exec parity (10 queries, "ALL 10 PASS") pass.
- No regression: `test_wam_clojure_lowered_emitter` (updated) and `test_wam_clojure_lowered_ite_exec` pass.

Sweep so far: ✅ Scala (#2941), ✅ Rust (#2942), ✅ Go (#2952), ✅ C++ (#2953), ✅ Haskell (#2954), ✅ F# (#2955), ✅ Clojure (this). Remaining: llvm, lua.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_