### PR TITLE
Add T4 (multi_clause_n) all-clauses lowering for Lua

### DIFF
--- a/src/unifyweaver/targets/wam_lua_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_lua_lowered_emitter.pl
@@ -29,7 +29,9 @@ skip_to_first_real_instr([Line|Rest], Out) :-
 skippable_prefix_line([]).
 skippable_prefix_line([First|_]) :- sub_string(First, _, 1, 0, ":").
 skippable_prefix_line(["switch_on_constant"|_]).
+skippable_prefix_line(["switch_on_constant_a2"|_]).
 skippable_prefix_line(["switch_on_structure"|_]).
+skippable_prefix_line(["switch_on_term"|_]).
 
 % T5: the clauses discriminate on a DISTINCT first-argument constant
 % (lowering type T5). ALL clauses become a bound-checked first-arg dispatch;
@@ -45,6 +47,20 @@ classify_clause_shape([FirstLine|Rest], plan(clause_chain, AltAtom, chain_payloa
     !,
     atom_string(AltAtom, AltStr),
     take_clause1_lines(Rest, ClauseLines).
+% T4: a multi-clause predicate whose clauses are all supported deterministic
+% bodies, but which does NOT discriminate on a distinct first-argument constant
+% (so T5/clause_chain declined). Lower EVERY clause inline (tried in order with
+% a trail/register restore between attempts), so the predicate never falls back
+% to the bytecode interpreter. Takes precedence over multi_clause_1. Payload is
+% the list of per-clause line lists.
+classify_clause_shape([FirstLine|Rest], plan(multi_clause_n, none, Clauses)) :-
+    wam_lua_target:tokenize_wam_line(FirstLine, ["try_me_else", _AltStr]),
+    lua_split_clause_lines([FirstLine|Rest], Clauses),
+    Clauses = [_, _ | _],
+    forall(member(Cl, Clauses),
+           ( forall(member(Line, Cl), lua_t4_clause_line_supported(Line)),
+             last(Cl, LastLine), lua_t4_terminal_line(LastLine) )),
+    !.
 classify_clause_shape([FirstLine|Rest], plan(multi_clause_1, AltAtom, ClauseLines)) :-
     wam_lua_target:tokenize_wam_line(FirstLine, ["try_me_else", AltStr]), !,
     atom_string(AltAtom, AltStr),
@@ -127,6 +143,47 @@ take_clause1_lines([Line|Rest], Out) :-
         take_clause1_lines(Rest, More)
     ).
 
+% --- T4 multi-clause line splitting --------------------------------------
+% Drop label / choice-point-separator / switch lines, then split the remaining
+% instruction lines at each proceed/fail terminal into per-clause line lists.
+
+lua_split_clause_lines(AllLines, Clauses) :-
+    include(lua_t4_instr_line, AllLines, InstrLines),
+    lua_split_at_terminal(InstrLines, Clauses).
+
+lua_t4_instr_line(Line) :-
+    wam_lua_target:tokenize_wam_line(Line, Parts),
+    Parts \== [],
+    Parts = [F|_],
+    \+ sub_string(F, _, 1, 0, ":"),     % label line
+    \+ member(F, ["try_me_else", "retry_me_else", "trust_me",
+                  "switch_on_constant", "switch_on_constant_a2",
+                  "switch_on_structure", "switch_on_term"]).
+
+lua_split_at_terminal([], []).
+lua_split_at_terminal([L|Ls], [Clause|Rest]) :-
+    lua_take_to_terminal([L|Ls], Clause, After),
+    ( After == [] -> Rest = [] ; lua_split_at_terminal(After, Rest) ).
+
+lua_take_to_terminal([Line|Rest], [Line], Rest) :-
+    wam_lua_target:tokenize_wam_line(Line, Parts),
+    ( Parts == ["proceed"] ; Parts == ["fail"] ), !.
+lua_take_to_terminal([Line|Rest], [Line|More], After) :-
+    lua_take_to_terminal(Rest, More, After).
+lua_take_to_terminal([], [], []).
+
+%% lua_t4_clause_line_supported(+Line) — a clause line must render directly
+%  (parts_supported rejects cut_ite / jump, so inner-ITE clauses decline T4).
+lua_t4_clause_line_supported(Line) :-
+    wam_lua_target:tokenize_wam_line(Line, Parts),
+    ( Parts == [] -> true ; parts_supported(Parts) ),
+    Parts \= ["cut_ite"|_],
+    Parts \= ["jump"|_].
+
+lua_t4_terminal_line(Line) :-
+    wam_lua_target:tokenize_wam_line(Line, Parts),
+    ( Parts == ["proceed"] ; Parts == ["fail"] ).
+
 wam_lua_lowerable(_PI, WamCode, Reason) :-
     catch(build_emission_plan(WamCode, plan(Reason, _, Payload)), _, fail),
     (   Reason == ite
@@ -135,6 +192,9 @@ wam_lua_lowerable(_PI, WamCode, Reason) :-
     ->  Payload = chain_payload(Guards, ClauseLines),
         forall(member(guard(_, Rem), Guards), lua_chain_rem_supported(Rem)),
         forall(member(Line, ClauseLines), line_supported(Line))
+    ;   Reason == multi_clause_n
+    ->  forall(member(Cl, Payload),
+               forall(member(Line, Cl), line_supported(Line)))
     ;   forall(member(Line, Payload), line_supported(Line))
     ).
 
@@ -204,8 +264,39 @@ lower_predicate_to_lua(PI, WamCode, _Options, lowered(PredName, FuncName, Code))
     ;   Mode == clause_chain
     ->  Payload = chain_payload(Guards, Clause1Lines),
         emit_clause_chain_function(PredName, FuncName, AltLabel, Guards, Clause1Lines, Code)
+    ;   Mode == multi_clause_n
+    ->  emit_multi_clause_n_function(PredName, FuncName, Payload, Code)
     ;   emit_multi_clause_function(PredName, FuncName, AltLabel, Payload, Code)
     ).
+
+%% emit_multi_clause_n_function(+PredName, +FuncName, +Clauses, -Code)
+%  T4: capture the clause-entry trail/register state, then try every clause
+%  inline as an immediately-invoked closure (its `proceed` returns true, a
+%  failed instruction returns false), restoring the entry state between
+%  attempts. The first clause that succeeds wins (first-solution /
+%  deterministic-prefix); the interpreter is never entered for the predicate.
+emit_multi_clause_n_function(PredName, FuncName, Clauses, Code) :-
+    with_output_to(string(ClausesBody), emit_lua_t4_clauses(Clauses)),
+    format(string(Code),
+'-- Lowered: ~w (T4 all-clauses inline)
+local function ~w(program, state)
+  local _t4_trail = #state.trail
+  local _t4_regs = Runtime.copy_table(state.regs)
+  local _t4_vc = state.var_counter
+~w  return false
+end
+', [PredName, FuncName, ClausesBody]).
+
+emit_lua_t4_clauses([]).
+emit_lua_t4_clauses([Clause|Rest]) :-
+    format("  if (function()~n"),
+    emit_lines(Clause, "    "),
+    format("    return false~n"),
+    format("  end)() then return true end~n"),
+    format("  while #state.trail > _t4_trail do state.bindings[table.remove(state.trail)] = nil end~n"),
+    format("  state.regs = Runtime.copy_table(_t4_regs)~n"),
+    format("  state.var_counter = _t4_vc~n"),
+    emit_lua_t4_clauses(Rest).
 
 % If-then-else / negation / once. Same wrapper as the deterministic case,
 % but the body is the structured term list rendered by emit_struct_lua/2.

--- a/tests/test_wam_lua_lowered_t4.pl
+++ b/tests/test_wam_lua_lowered_t4.pl
@@ -1,0 +1,122 @@
+% test_wam_lua_lowered_t4.pl
+%
+% End-to-end execution test for the Lua T4 lowering — "multi-clause, all
+% clauses" (lowering type T4 / multi_clause_n in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md), ported from
+% Scala/Rust/Go/C++/Haskell/F#/Clojure.
+%
+% A multi-clause predicate whose clauses are all supported deterministic
+% bodies but do NOT discriminate on a distinct first-argument constant (so T5
+% declines) now lowers to ALL clauses inline: each clause is an
+% immediately-invoked closure, tried in order with a trail/register restore
+% (state.regs copy + trail unwind) between attempts. The first clause that
+% succeeds wins (first-solution / deterministic-prefix); the predicate never
+% falls back to the bytecode interpreter, unlike multi_clause_1.
+%
+% Pins (BOUND first arg; the payoff is the non-first clauses running natively):
+%   * grade_r/2 — RULE chain with a REPEATED first-arg constant (alice in
+%                 clauses 1 & 3), so it is not a distinct-first-arg (T5) chain;
+%   * rel/2     — RULE chain with a VARIABLE first arg (=/2 body; needs the
+%                 switch_on_constant_a2 prefix skipped to reach try_me_else).
+% (Fact-only predicates are routed to the Lua target's inline fact-table
+% optimisation, not the lowered function, so the T4 path is exercised with
+% rule clauses.)
+%
+% Skipped automatically when no Lua interpreter is on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_lua_target').
+:- use_module('../src/unifyweaver/targets/wam_lua_lowered_emitter').
+
+:- dynamic user:grade_r/2.
+:- dynamic user:rel/2.
+
+% A RULE chain (not facts): fact-only predicates are routed to the Lua
+% target's inline fact-table optimisation instead of the lowered function,
+% so the T4 path is exercised with rule clauses. grade_r mirrors grade but
+% binds the second argument in the body, with a REPEATED first-arg constant
+% (alice in clauses 1 & 3) so it is not a distinct-first-arg (T5) chain.
+user:grade_r(alice, G) :- G = a.
+user:grade_r(bob,   G) :- G = b.
+user:grade_r(alice, G) :- G = c.
+
+user:rel(X, one) :- X = p.
+user:rel(X, two) :- X = q.
+
+lua_interpreter(Exe) :-
+    member(Exe, ['lua5.4', 'lua5.3', 'lua', 'luajit']),
+    catch(( process_create(path(Exe), ['-v'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, _) ), _, fail), !.
+
+:- begin_tests(wam_lua_lowered_t4, [condition(lua_interpreter(_))]).
+
+test(gate_picks_multi_clause_n) :-
+    forall(member(PI, [grade_r/2, rel/2]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_lua_lowerable(PI, W, Reason),
+             assertion(Reason == multi_clause_n) )).
+
+test(t4_exec_parity) :-
+    lua_interpreter(Lua),
+    Dir = 'output/test_wam_lua_t4_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_lua_project(
+        [user:grade_r/2, user:rel/2],
+        [module_name('t4proj'), emit_mode(functions)], Dir),
+    atomic_list_concat([Dir, '/lua/generated_program.lua'], ProgPath),
+    read_file_to_string(ProgPath, ProgSrc, []),
+    forall(member(F, ["lowered_grade_r_2", "lowered_rel_2", "T4 all-clauses inline",
+                      "return lowered_grade_r_2", "return lowered_rel_2"]),
+           assertion(sub_string(ProgSrc, _, _, _, F))),
+    atomic_list_concat([Dir, '/lua/harness.lua'], HPath),
+    harness_source_t4(Src),
+    setup_call_cleanup(open(HPath, write, S, [encoding(utf8)]),
+                       write(S, Src), close(S)),
+    atomic_list_concat([Dir, '/lua'], LuaDir),
+    format(atom(Cmd), 'cd ~w && ~w harness.lua 2>&1', [LuaDir, Lua]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 10 PASS")
+    ->  true
+    ;   format(user_error, "~n[lua t4 test output]~n~w~n", [OutStr]),
+        throw(lua_t4_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_lua_lowered_t4).
+
+% Calls each per-predicate module entry with a BOUND first argument and checks
+% the boolean. Exercises the non-first clauses (grade clauses 2 & 3, rel clause
+% 2) — the T4 payoff — plus no-match cases. Atoms are built through the shared
+% intern table so the ids match the lowered functions.
+harness_source_t4(
+"package.path = \"./?.lua;\" .. package.path
+local M = require(\"generated_program\")
+local R = M.Runtime
+local function A(s) return M.V.Atom(R.intern(M.program.intern_table, s)) end
+local fails, total = 0, 0
+local function chk(name, got, want)
+  total = total + 1
+  if got ~= want then
+    fails = fails + 1
+    print(\"FAIL\", name, \"got\", tostring(got), \"want\", tostring(want))
+  end
+end
+chk(\"grade_r(alice,a)\", M.grade_r(A(\"alice\"), A(\"a\")), true)
+chk(\"grade_r(bob,b)\",   M.grade_r(A(\"bob\"),   A(\"b\")), true)
+chk(\"grade_r(alice,c)\", M.grade_r(A(\"alice\"), A(\"c\")), true)
+chk(\"grade_r(alice,b)\", M.grade_r(A(\"alice\"), A(\"b\")), false)
+chk(\"grade_r(carol,a)\", M.grade_r(A(\"carol\"), A(\"a\")), false)
+chk(\"grade_r(bob,c)\",   M.grade_r(A(\"bob\"),   A(\"c\")), false)
+chk(\"rel(p,one)\", M.rel(A(\"p\"), A(\"one\")), true)
+chk(\"rel(q,two)\", M.rel(A(\"q\"), A(\"two\")), true)
+chk(\"rel(p,two)\", M.rel(A(\"p\"), A(\"two\")), false)
+chk(\"rel(q,one)\", M.rel(A(\"q\"), A(\"one\")), false)
+if fails == 0 then print(\"ALL \" .. total .. \" PASS\") else print(fails .. \" FAILURES\") end
+os.exit(fails == 0 and 0 or 1)
+").


### PR DESCRIPTION
## Summary

Eighth target in the **T4 sweep** (after Scala #2941, Rust #2942, Go #2952, C++ #2953, Haskell #2954, F# #2955, Clojure #2956). A multi-clause predicate whose clauses are all supported deterministic bodies but do **not** discriminate on a distinct first-argument constant (so T5/`clause_chain` declines) now lowers with **every clause inline**, instead of `multi_clause_1` (clause 1 inline + array fallback into the bytecode interpreter for clauses 2+).

Lua's state is mutable (trail + register table), so — like the imperative targets — each clause is an immediately-invoked closure tried in order with a trail/register restore between attempts, returning the first that succeeds. No choice point is pushed and the interpreter is never entered for the predicate.

```lua
local function lowered_grade_r_2(program, state)
  local _t4_trail = #state.trail
  local _t4_regs = Runtime.copy_table(state.regs)
  local _t4_vc = state.var_counter
  if (function() ... return false end)() then return true end   -- clause 1
  while #state.trail > _t4_trail do state.bindings[table.remove(state.trail)] = nil end
  state.regs = Runtime.copy_table(_t4_regs); state.var_counter = _t4_vc
  if (function() ... return false end)() then return true end   -- clause 2
  ...
  return false
end
```

## Changes

- **`wam_lua_lowered_emitter.pl`**: `skip_to_first_real_instr` also skips `switch_on_constant_a2` / `switch_on_term` prefixes (so second-argument-indexed multi-clause predicates reach the classifier). `lua_split_clause_lines/2` drops label/separator/switch lines then splits the remaining instruction lines at each `proceed`/`fail` terminal into per-clause line lists (`lua_t4_clause_line_supported` rejects `cut_ite`/`jump`, so inner-ITE clauses decline T4). New `plan(multi_clause_n, ...)` between `clause_chain` and `multi_clause_1`; `wam_lua_lowerable` + `lower_predicate_to_lua` handle it; `emit_multi_clause_n_function` emits the per-clause closures + restore.
- **`tests/test_wam_lua_lowered_t4.pl`**: gated `lua` exec test. `grade_r/2` (rule chain, repeated first-arg constant) and `rel/2` (rule chain, variable first arg, `=/2` body) gate as `multi_clause_n`, route through the lowered function, and run; pins exercise the non-first clauses natively (`grade_r(alice,c)`=clause 3, `grade_r(bob,b)`/`rel(q,two)`=clause 2) plus no-match cases. **Rule** (not fact) predicates are used because fact-only predicates are routed to the Lua target's inline fact-table optimisation, not the lowered function.

## Verification

- New `test_wam_lua_lowered_t4`: gate (both `multi_clause_n`) + `lua` exec parity (10 queries, "ALL 10 PASS") pass.
- `test_wam_lua_lowered_t5` still passes.
- ⚠️ `test_wam_lua_lowered_ite` fails **identically on unmodified `main`** — a pre-existing, unrelated failure (verified by stashing this branch's changes).

Sweep so far: ✅ Scala (#2941), ✅ Rust (#2942), ✅ Go (#2952), ✅ C++ (#2953), ✅ Haskell (#2954), ✅ F# (#2955), ✅ Clojure (#2956), ✅ Lua (this). Remaining: **llvm**.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_