### PR TITLE
Add T4 (multi_clause_n) all-clauses lowering for LLVM

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_llvm_lowered_emitter.pl
@@ -73,6 +73,11 @@
 :- use_module(wam_ite_structurer, [structure_ite/2]).
 :- use_module(wam_clause_chain, [clause_chain/2]).
 
+% wam_llvm_lowerable/3's clauses are interleaved with the T4 helper
+% llvm_all_clauses_lowerable/1 (kept next to the multi_clause_n gate it
+% serves); declare it discontiguous so SWI does not warn.
+:- discontiguous wam_llvm_lowerable/3.
+
 % NB: we DO NOT `:- use_module(wam_llvm_target, ...)` here, because
 % wam_llvm_target.pl `:- use_module`s this file in turn. The two
 % predicates we borrow from the target — wam_instruction_to_llvm_literal/2
@@ -226,9 +231,32 @@ wam_llvm_lowerable(_PI, WamCode, Shape) :-
     is_deterministic_pred_llvm(C1),
     forall(member(I, C1), supported(I)),
     ( has_choice_point_instrs(Instrs)
-    -> Shape = multi_clause_c1
+    -> ( llvm_all_clauses_lowerable(Instrs)
+       -> Shape = multi_clause_n   % T4: every clause lowered inline
+       ;  Shape = multi_clause_c1  % T3: clause 1 inline, bytecode for 2+
+       )
     ;  Shape = single_clause
     ).
+
+%% llvm_all_clauses_lowerable(+Instrs) is semidet.
+%  True when EVERY clause of a multi-clause predicate is a clean supported
+%  deterministic body (no inner ITE / call / execute, ends in a terminal) —
+%  the T4 (multi_clause_n) condition. Such a predicate lowers all clauses
+%  inline (tried in order with a register/trail restore between attempts), so
+%  the interpreter is never entered for the predicate. Clauses containing a
+%  call / execute keep the multi_clause_c1 path (their callees may not be
+%  lowered in this module).
+llvm_all_clauses_lowerable(Instrs) :-
+    llvm_split_clauses(Instrs, Clauses),
+    Clauses = [_, _ | _],
+    forall(member(Cl, Clauses),
+           ( \+ member(try_me_else(_), Cl),
+             \+ member(cut_ite, Cl),
+             \+ member(jump(_), Cl),
+             \+ member(call(_, _), Cl),
+             \+ member(execute(_), Cl),
+             forall(member(I, Cl), supported(I)),
+             last(Cl, Last), ( Last == proceed ; Last == fail ) )).
 
 % ITE / negation / once: clause 1 contains an internal choice point
 % (try_me_else) that is NOT a multi-clause separator but a soft-cut block
@@ -466,6 +494,10 @@ lower_predicate_to_llvm(PI, WamCode, _Options, LLVMCode) :-
     llvm_structured_clause1(WamCode, Structured), !,
     lower_ite_predicate_to_llvm(PI, Structured, LLVMCode).
 lower_predicate_to_llvm(PI, WamCode, _Options, LLVMCode) :-
+    ( is_list(WamCode) -> MCInstrs = WamCode ; parse_wam_text(WamCode, MCInstrs) ),
+    llvm_all_clauses_lowerable(MCInstrs), !,
+    lower_multi_clause_n_to_llvm(PI, MCInstrs, LLVMCode).
+lower_predicate_to_llvm(PI, WamCode, _Options, LLVMCode) :-
     ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     llvm_lowered_func_name(Pred/Arity, FuncName),
     (   is_list(WamCode) -> Instrs = WamCode
@@ -579,6 +611,101 @@ emit_clause_chain_blocks([Clause|Rest], StartN, [ClauseStr|More]) :-
     emit_all_instrs(RestInstrs, N2, RestBlocks),
     atomic_list_concat([FirstBlock|RestBlocks], '\n', ClauseStr),
     emit_clause_chain_blocks(Rest, NextStartN, More).
+
+% ============================================================================
+% T4: multi-clause, all clauses inline (multi_clause_n)
+%
+%  Generalises the T5 clause-chain emit to predicates that do NOT discriminate
+%  on a distinct first-argument constant: every clause is lowered inline and
+%  tried in order, but — unlike T5, where only the head get_constant decides
+%  the clause — ANY instruction failure rolls back to the next clause. Because
+%  a partially-run clause may have clobbered the A-registers (put_* / get_value)
+%  and bound variables (trailed), each retry first restores the entry register
+%  snapshot (memcpy, exactly as a bytecode try_me_else choice point saves them)
+%  and unwinds the trail to the entry mark. The first clause runs on the fresh
+%  entry state; clause K (K>1) is preceded by a clause_K_restore block. The
+%  last clause's failures go to %lowered_fail (the hybrid wrapper then re-runs
+%  the bytecode, which also fails — sound). First-solution / deterministic-
+%  prefix semantics, strictly more than multi_clause_c1.
+% ============================================================================
+
+%% lower_multi_clause_n_to_llvm(+PI, +Instrs, -LLVMCode) is det.
+lower_multi_clause_n_to_llvm(PI, Instrs, LLVMCode) :-
+    ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
+    llvm_lowered_func_name(Pred/Arity, FuncName),
+    llvm_split_clauses(Instrs, Clauses),
+    emit_t4_clauses(Clauses, 0, 1, ClauseBlocks),
+    atomic_list_concat(ClauseBlocks, '\n', ClauseStr),
+    format(atom(LLVMCode),
+'; === lowered kernel (T4 all-clauses inline): ~w/~w ===
+; Every clause is lowered; any instruction failure restores the entry
+; register snapshot + trail mark and falls through to the next clause.
+define i1 @~w(%WamState* %vm) {
+entry:
+  %t4.regbuf = alloca [64 x %Value]
+  %t4.regbuf_raw = bitcast [64 x %Value]* %t4.regbuf to i8*
+  %t4.src_regs = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 0
+  %t4.src_raw = bitcast %Value* %t4.src_regs to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %t4.regbuf_raw, i8* %t4.src_raw, i64 1024, i1 false)
+  %t4.tm_ptr = getelementptr %WamState, %WamState* %vm, i32 0, i32 9
+  %t4.tmv = load i32, i32* %t4.tm_ptr
+  br label %pc_0
+
+~w
+
+lowered_succeed:
+  ret i1 true
+
+lowered_fail:
+  ret i1 false
+}',
+        [Pred, Arity, FuncName, ClauseStr]).
+
+%% emit_t4_clauses(+Clauses, +StartN, +Idx, -Blocks) is det.
+%  Emit each clause's blocks. Clause Idx (1-based) starts at block pc_<StartN>;
+%  every instruction's failure edge points at the next clause's restore block
+%  (clause_<Idx+1>_restore), or %lowered_fail for the last clause. Clauses 2+
+%  are preceded by a restore block that re-snapshots the registers + unwinds
+%  the trail before re-entering at pc_<StartN>.
+emit_t4_clauses([], _, _, []).
+emit_t4_clauses([Cl | Rest], StartN, Idx, [Block | More]) :-
+    length(Cl, Len),
+    NextStartN is StartN + Len,
+    NextIdx is Idx + 1,
+    ( Rest == []
+    ->  FailLabel = lowered_fail
+    ;   format(atom(FailLabel), 'clause_~w_restore', [NextIdx])
+    ),
+    emit_all_instrs_f(Cl, StartN, FailLabel, InstrBlocks),
+    atomic_list_concat(InstrBlocks, '\n', InstrStr),
+    ( Idx =:= 1
+    ->  Block = InstrStr
+    ;   t4_restore_block(Idx, StartN, RestoreStr),
+        atomic_list_concat([RestoreStr, InstrStr], '\n', Block)
+    ),
+    emit_t4_clauses(Rest, NextStartN, NextIdx, More).
+
+%% emit_all_instrs_f(+Instrs, +StartN, +FailLabel, -Blocks) is det.
+%  Like emit_all_instrs, but every instruction's failure edge is redirected to
+%  FailLabel (instead of the default %lowered_fail).
+emit_all_instrs_f([], _, _, []).
+emit_all_instrs_f([I | Rest], N, FailLabel, [Block | More]) :-
+    next_label(Rest, N, NextLabel),
+    emit_instr_f(I, N, NextLabel, FailLabel, Block),
+    N1 is N + 1,
+    emit_all_instrs_f(Rest, N1, FailLabel, More).
+
+%% t4_restore_block(+Idx, +StartN, -Str) — restore the entry register snapshot
+%  and trail mark, then branch into clause Idx at pc_<StartN>.
+t4_restore_block(Idx, StartN, Str) :-
+    format(atom(Str),
+'clause_~w_restore:
+  %t4.dst~w = getelementptr %WamState, %WamState* %vm, i32 0, i32 1, i32 0
+  %t4.dst~w_raw = bitcast %Value* %t4.dst~w to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %t4.dst~w_raw, i8* %t4.regbuf_raw, i64 1024, i1 false)
+  call void @unwind_trail(%WamState* %vm, i32 %t4.tmv)
+  br label %pc_~w',
+        [Idx, Idx, Idx, Idx, Idx, StartN]).
 
 %% llvm_split_clauses(+Instrs, -Clauses) is semidet.
 %  Split the parsed instruction list (which opens with try_me_else) at the

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1928,10 +1928,15 @@ pass1_classify_predicates([PredIndicator|Rest], Options, StartPC,
                BundledCode),
            Record = native(PredIndicator, Arity, BundledCode),
            NextPC = StartPC
-        ;  ( LowerShape == multi_clause_c1 ; LowerShape == clause_chain )
+        ;  ( LowerShape == multi_clause_c1 ; LowerShape == clause_chain
+           ; LowerShape == multi_clause_n )
         -> ( LowerShape == clause_chain
            ->  format(user_error,
                  '  ~w/~w: lowered LLVM emission (hybrid T5 first-arg dispatch + bytecode)~n',
+                 [Pred, Arity])
+           ;   LowerShape == multi_clause_n
+           ->  format(user_error,
+                 '  ~w/~w: lowered LLVM emission (hybrid T4 all-clauses inline + bytecode)~n',
                  [Pred, Arity])
            ;   format(user_error,
                  '  ~w/~w: lowered LLVM emission (hybrid clause-1 + bytecode)~n',

--- a/tests/test_wam_llvm_lowered_t4.pl
+++ b/tests/test_wam_llvm_lowered_t4.pl
@@ -1,0 +1,139 @@
+% test_wam_llvm_lowered_t4.pl
+%
+% End-to-end execution test for the LLVM T4 lowering — "multi-clause, all
+% clauses" (lowering type T4 / multi_clause_n in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md), ported from
+% Scala/Rust/Go/C++/Haskell/F#/Clojure/Lua.
+%
+% A multi-clause predicate whose clauses are all supported deterministic
+% bodies but do NOT discriminate on a distinct first-argument constant (so T5
+% declines) now lowers ALL of its clauses into one LLVM function, instead of
+% lowering only clause 1 (multi_clause_c1) and reaching clauses 2+ through the
+% bytecode interpreter on backtrack. Each clause is tried in order; ANY
+% instruction failure restores the entry register snapshot (memcpy, exactly as
+% a bytecode try_me_else choice point saves the registers) and the trail mark,
+% then falls through to the next clause. First-solution / deterministic-prefix
+% semantics; the interpreter is never entered for the predicate.
+%
+% Pins (FACT chains with a REPEATED first-argument constant, so they are not
+% distinct-first-arg (T5) chains; the get_constant-only bodies avoid the
+% emitter's known-broken put_structure/is/2 path):
+%   * grade/2 — alice in clauses 1 & 3; grade(alice,c) needs clause 3;
+%   * dup/2   — first arg `a` in both clauses; dup(a,2) needs clause 2.
+%
+% The C harness calls each lowered_<pred>_<arity>(%WamState*) kernel directly
+% on a fresh state with the argument registers set, exercising the non-first
+% clauses (the T4 payoff) and the restore/fall-through across clauses. Skipped
+% unless clang is on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../src/unifyweaver/targets/wam_llvm_lowered_emitter').
+
+:- dynamic user:grade/2.
+:- dynamic user:dup/2.
+
+user:grade(alice, a).
+user:grade(bob,   b).
+user:grade(alice, c).
+
+user:dup(a, 1).
+user:dup(a, 2).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_llvm_lowered_t4, [condition(clang_available)]).
+
+test(gate_picks_multi_clause_n) :-
+    forall(member(PI, [grade/2, dup/2]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_llvm_lowerable(PI, W, Shape),
+             assertion(Shape == multi_clause_n) )).
+
+test(t4_exec_parity) :-
+    Dir = 'output/test_wam_llvm_t4_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    make_directory_path(Dir),
+    atomic_list_concat([Dir, '/t4proj.ll'], LLPath),
+    write_wam_llvm_project(
+        [user:grade/2, user:dup/2],
+        [module_name('t4proj'), emit_mode(functions)], LLPath),
+    read_file_to_string(LLPath, LLSrc, []),
+    forall(member(F, ['@lowered_grade_2(', '@lowered_dup_2(',
+                      "T4 all-clauses inline"]),
+           assertion(sub_string(LLSrc, _, _, _, F))),
+    maplist(disc_id, [alice, bob, a, b, c], [Alice, Bob, AId, BId, CId]),
+    atomic_list_concat([Dir, '/harness.c'], HPath),
+    harness_source_t4(Alice, Bob, AId, BId, CId, HSrc),
+    setup_call_cleanup(open(HPath, write, S), write(S, HSrc), close(S)),
+    atomic_list_concat([Dir, '/t4_test'], ExePath),
+    format(atom(Cmd),
+        'clang -w ~w ~w -o ~w -lm 2>&1 && ~w',
+        [HPath, LLPath, ExePath, ExePath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 10 PASS")
+    ->  true
+    ;   format(user_error, "~n[llvm t4 test output]~n~w~n", [OutStr]),
+        throw(llvm_t4_test_failed(Status))
+    ).
+
+:- end_tests(wam_llvm_lowered_t4).
+
+disc_id(Atom, Id) :-
+    wam_llvm_lowered_emitter:parse_constant(Atom, 0, Id).
+
+% Calls each lowered kernel directly on a fresh %WamState with the argument
+% registers set. Exercises the non-first clauses (grade clauses 2 & 3, dup
+% clause 2) — the T4 payoff, reached via the restore/fall-through — plus
+% no-match cases (the no-match atom id 999999 is never interned).
+harness_source_t4(Alice, Bob, AId, BId, CId, Src) :-
+    format(atom(Src),
+"#include <stdio.h>
+typedef struct WamState WamState;
+extern WamState* wam_state_new(void* code, int n, int* labels, int nl);
+extern void wam_set_reg_int(WamState*, int, long);
+extern void wam_set_reg_atom_id(WamState*, int, long);
+extern unsigned char lowered_grade_2(WamState*);
+extern unsigned char lowered_dup_2(WamState*);
+
+#define ALICE ~w
+#define BOB ~w
+#define A ~w
+#define B ~w
+#define C ~w
+#define NOMATCH 999999
+
+static int fails = 0, total = 0;
+static WamState* mk(void){ return wam_state_new(0,0,0,0); }
+static int b(unsigned char r){ return r & 1; }
+static void check(const char* name, int got, int want){
+  total++;
+  if(got != want){ fails++; printf(\"FAIL %s: got %d want %d\\n\", name, got, want); }
+}
+
+int main(void){
+  WamState* s;
+  s=mk(); wam_set_reg_atom_id(s,0,ALICE); wam_set_reg_atom_id(s,1,A); check(\"grade(alice,a)\", b(lowered_grade_2(s)), 1);
+  s=mk(); wam_set_reg_atom_id(s,0,BOB);   wam_set_reg_atom_id(s,1,B); check(\"grade(bob,b)\",   b(lowered_grade_2(s)), 1);
+  s=mk(); wam_set_reg_atom_id(s,0,ALICE); wam_set_reg_atom_id(s,1,C); check(\"grade(alice,c)\", b(lowered_grade_2(s)), 1);
+  s=mk(); wam_set_reg_atom_id(s,0,ALICE); wam_set_reg_atom_id(s,1,B); check(\"grade(alice,b)\", b(lowered_grade_2(s)), 0);
+  s=mk(); wam_set_reg_atom_id(s,0,NOMATCH);wam_set_reg_atom_id(s,1,A);check(\"grade(carol,a)\", b(lowered_grade_2(s)), 0);
+  s=mk(); wam_set_reg_atom_id(s,0,BOB);   wam_set_reg_atom_id(s,1,C); check(\"grade(bob,c)\",   b(lowered_grade_2(s)), 0);
+  s=mk(); wam_set_reg_atom_id(s,0,A); wam_set_reg_int(s,1,1); check(\"dup(a,1)\", b(lowered_dup_2(s)), 1);
+  s=mk(); wam_set_reg_atom_id(s,0,A); wam_set_reg_int(s,1,2); check(\"dup(a,2)\", b(lowered_dup_2(s)), 1);
+  s=mk(); wam_set_reg_atom_id(s,0,A); wam_set_reg_int(s,1,3); check(\"dup(a,3)\", b(lowered_dup_2(s)), 0);
+  s=mk(); wam_set_reg_atom_id(s,0,B); wam_set_reg_int(s,1,1); check(\"dup(b,1)\", b(lowered_dup_2(s)), 0);
+
+  if(fails==0) printf(\"ALL %d PASS\\n\", total);
+  else printf(\"%d FAILURES\\n\", fails);
+  return fails ? 1 : 0;
+}
+",
+        [Alice, Bob, AId, BId, CId]).


### PR DESCRIPTION
## Summary

**Ninth and final** target in the **T4 sweep** (after Scala #2941, Rust #2942, Go #2952, C++ #2953, Haskell #2954, F# #2955, Clojure #2956, Lua #2957). A multi-clause predicate whose clauses are all supported deterministic bodies but do **not** discriminate on a distinct first-argument constant (so T5/`clause_chain` declines) now lowers **all** of its clauses into one LLVM function, instead of lowering only clause 1 (`multi_clause_c1`) and reaching clauses 2+ through the bytecode interpreter on backtrack.

Generalises the T5 clause-chain emit: every clause is lowered inline and tried in order, but where T5 lets only the head `get_constant` decide the clause, T4 routes **any** instruction failure to the next clause. Because a partially-run clause may have clobbered the A-registers (`put_*`/`get_value`) and bound variables (trailed), each retry first **restores the entry register snapshot** (an `alloca [64 x %Value]` filled by `memcpy`, exactly as a bytecode `try_me_else` choice point saves the 64-register file) and **unwinds the trail** to the entry mark, then re-enters the next clause. The interpreter is never entered for the predicate.

```llvm
define i1 @lowered_grade_2(%WamState* %vm) {
entry:
  %t4.regbuf = alloca [64 x %Value]
  ; memcpy regs -> regbuf ; load trail mark -> %t4.tmv
  br label %pc_0
  ; clause 1 (pc_0..): any failure -> clause_2_restore
clause_2_restore:
  ; memcpy regbuf -> regs ; @unwind_trail(%vm, %t4.tmv) ; br %pc_<c2>
  ; clause 2 ...: any failure -> clause_3_restore ; last clause -> %lowered_fail
lowered_succeed: ret i1 true
lowered_fail:    ret i1 false
}
```

## Changes

- **`wam_llvm_lowered_emitter.pl`**: `llvm_all_clauses_lowerable/1`; `wam_llvm_lowerable` reports `multi_clause_n` (between `clause_chain` and `multi_clause_c1`). `lower_multi_clause_n_to_llvm` + `emit_t4_clauses` + `emit_all_instrs_f` (reuses `emit_instr_f`'s failure-redirect so every instruction's failure edge points at the next clause's restore block) + `t4_restore_block`.
- **`wam_llvm_target.pl`**: route `multi_clause_n` through the same hybrid record as `clause_chain` (all clauses lowered as the fast path; bytecode still emitted for the fallback).
- **`tests/test_wam_llvm_lowered_t4.pl`**: gated `clang` exec test. `grade/2` (fact chain, repeated first arg) and `dup/2` (fact chain, repeated first arg) gate as `multi_clause_n`, compile and run; the C harness exercises the non-first clauses via the restore/fall-through (`grade(alice,c)`=clause 3, `dup(a,2)`=clause 2) plus no-match cases. **Fact** (get_constant-only) clauses are used because the emitter's `put_structure`/`is/2` path is independently broken (noted in the T5 test header).

## Verification

- New `test_wam_llvm_lowered_t4`: gate (both `multi_clause_n`) + `clang` exec parity (10 queries, "ALL 10 PASS") pass.
- `test_wam_llvm_lowered_t5` still passes.
- ⚠️ `test_wam_llvm_lowered_ite_exec` fails **identically on unmodified `main`** — a pre-existing, unrelated failure (verified by stashing this branch's changes).

## 🏁 T4 sweep complete

✅ Scala (#2941, merged) · ✅ Rust (#2942) · ✅ Go (#2952) · ✅ C++ (#2953) · ✅ Haskell (#2954) · ✅ F# (#2955) · ✅ Clojure (#2956) · ✅ Lua (#2957) · ✅ LLVM (this). Combined with R and elixir (which already had T4), **every lowered target now implements T4**.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_