### PR TITLE
Fix Lua ITE lowering for the M17 Y-level soft cut (cut Yn)

### DIFF
--- a/src/unifyweaver/targets/wam_lua_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_lua_lowered_emitter.pl
@@ -99,6 +99,13 @@ lua_line_term(["try_me_else", L], try_me_else(L)) :- !.
 lua_line_term(["trust_me"], trust_me) :- !.
 lua_line_term(["jump", L], jump(L)) :- !.
 lua_line_term(["cut_ite"], cut_ite) :- !.
+% M17 Y-level soft cut (ite_use_y_level(true), which the Lua target enables):
+% `cut Yn` is the if-then-else commit (the structurer drops it; the if/else
+% structure provides the commit semantics), and `get_level Yn` snapshots the
+% cut level in the clause prefix. Without parsing `cut Yn` into cut(Yn) the
+% shared structurer's is_commit/1 never matched, so the block was not folded
+% and the predicate fell back to the interpreter.
+lua_line_term(["cut", Yn], cut(Yn)) :- !.
 lua_line_term(["builtin_call", Op, Ar], builtin_call(Op, Ar)) :- !.
 lua_line_term(Parts, line(Parts)).
 
@@ -215,6 +222,10 @@ line_supported(Line) :-
 
 parts_supported(["allocate"]).
 parts_supported(["deallocate"]).
+% M17 cut-level snapshot, emitted in the clause prefix of a Y-level
+% if-then-else / negation / once. Rendered verbatim (the Lua runtime's
+% I.GetLevel handles it); the paired `cut Yn` is folded away by the structurer.
+parts_supported(["get_level", _]).
 parts_supported(["proceed"]).
 parts_supported(["fail"]).
 parts_supported(["get_constant", _, _]).


### PR DESCRIPTION
## Summary

`test_wam_lua_lowered_ite` was failing (one of the three pre-existing ITE-exec failures flagged during the T4 sweep). The four if-then-else / negation / once predicates fell back to the bytecode interpreter instead of being lowered to native if/else, so the test's "must be lowered" assertion failed.

## Root cause

The Lua target enables `ite_use_y_level(true)`, so the WAM compiler emits the **M17 Y-level soft cut** — `get_level Yn` in the clause prefix + `cut Yn` as the if-then-else commit — instead of the legacy `cut_ite`. The Lua lowered emitter's term parser (`lua_line_term/2`) left `cut Yn` as an opaque `line(["cut", Yn])` leaf, so the shared structurer's `is_commit/1` (which already recognises `cut(Yn)`) never matched, the block was not folded into `ite(Cond,Then,Else)`, and the predicate declined lowering.

The systems sibling **C++ already handles this** because it parses through the shared `wam_text_to_items` (which yields `cut(Yn)` / `get_level(Yn)`) and supports both — that's why `test_wam_cpp_lowered_ite_exec` passes while Lua/Haskell/LLVM don't.

## Fix (emitter-only, mirrors C++)

- `lua_line_term` parses `cut Yn` into `cut(Yn)` so the structurer folds the block and drops the commit (the native if/else provides the commit semantics).
- `parts_supported` accepts `get_level Yn`; it is rendered verbatim and the Lua runtime's `I.GetLevel` handles it (a harmless cut-level snapshot — the paired cut is folded away, so `Yn` is never read).

## Verification

- `test_wam_lua_lowered_ite` now passes (ALL 15 PASS).
- No regression: `test_wam_lua_lowered_t4`, `test_wam_lua_lowered_t5` still pass.

First of the three ITE-exec fixes (Lua done; Haskell and LLVM have the same root cause and are next).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_