### PR TITLE
perf(wam-rust): allocation-free atom head-match in lowered dispatch

### DIFF
--- a/docs/reports/wam_rust_dispatch_alloc_perf.md
+++ b/docs/reports/wam_rust_dispatch_alloc_perf.md
@@ -1,0 +1,110 @@
+# WAM-Rust lowered dispatch: per-comparison atom allocation (and where T6 wins)
+
+This note records a perf bottleneck found in the Rust lowered emitter, the fix,
+the measured wins, and — for later — the conditions under which **T6
+first-argument indexing (native `match`)** would add a further win on top.
+
+## The bottleneck
+
+Every `get_constant` (the hot head-match instruction, used by single-clause
+facts, T3/T4 multi-clause head matching, and T5 clause-chain remainders) was
+emitted as:
+
+```rust
+let _a = vm.get_reg("A1").unwrap_or(Value::Uninit);   // (1) clones the stored Value::Atom(String)
+if _a.is_unbound() { /* bind */ }
+else if _a != Value::Atom("alice".to_string()) { return false; }   // (2) allocates a String to compare
+```
+
+So a bound atom head-match paid **two heap allocations per comparison** — the
+`get_reg` clone of the stored `Value::Atom(String)`, and the freshly-built
+`Value::Atom("alice".to_string())` right-hand side. The T5 dispatch had the
+same shape (`t5a1 == Value::Atom("...")` per guard). `get_integer` was already
+allocation-free (`Value::Integer` is `Copy`).
+
+## The fix
+
+A borrowing, allocation-free comparison on `WamState`
+(`templates/targets/rust_wam/state.rs.mustache`):
+
+```rust
+pub fn get_reg_ref(&self, name: &str) -> Option<&Value>      // borrow the register, no clone
+pub fn match_reg_atom(&self, name: &str, atom: &str) -> Option<bool>
+//   Some(true)  = bound & equal      (clause continues)
+//   Some(false) = bound & not equal  (clause fails)
+//   None        = unbound            (clause binds)
+```
+
+`match_reg_atom` derefs the register through the binding chain **by reference**
+(mirroring `deref_var`) and compares the inner atom against the `&str` literal,
+so neither side allocates on the bound path. The unbound path still builds the
+`Value::Atom(String)` to bind (rare; only when actually binding).
+
+The emitter (`wam_rust_lowered_emitter.pl`) now emits, for an atom `get_constant`
+/ `get_nil` and for each T5 guard:
+
+```rust
+match vm.match_reg_atom("A1", "alice") {
+    Some(true)  => {}
+    Some(false) => return false,
+    None        => { vm.trail_binding("A1"); vm.put_reg("A1", Value::Atom("alice".to_string())); }
+}
+```
+
+Integer/float constants keep the (already allocation-free) `Value` comparison.
+
+## Measured wins (release, lto, 5M iterations)
+
+| Benchmark | before | after | speedup |
+|-----------|-------:|------:|:-------:|
+| single-clause `wide/20` (20 `get_constant`, all bound) | 7501 ms | 992 ms | **7.6×** |
+| `d64/1` T5 dispatch, 64 distinct atoms, worst case (last clause) | 7381 ms | 1521 ms | **4.85×** |
+
+A standalone micro-benchmark isolating the comparison agreed: a 64-way linear
+scan comparing `Value::Atom(k.clone())` ran at 2899 ms vs 323 ms comparing
+`&str` — i.e. **one heap allocation per comparison is the whole ~9× penalty.**
+All Rust lowered tests (`t4`, `t5`, `ite_exec`, `save_regs`) still pass, so the
+change is purely an allocation removal — no semantic change.
+
+## Where T6 (first-arg indexing / native `match`) will win — for later
+
+We benchmarked T6 (`match` on the first arg) **before** doing T6, to check it is
+actually a win (compilers optimise dispatch aggressively; an earlier Go
+array-dispatch experiment *lost* to the compiler). Findings, on the 64-key
+micro-benchmark:
+
+| dispatch (64 keys, worst case) | time |
+|---|---:|
+| linear, alloc per cmp (old generated) | 5802 ms |
+| linear, `&str` (post-fix generated) | 679 ms |
+| `match(&str)` (T6 native switch) | 118 ms |
+| `HashMap` (array/map dispatch) | 110 ms |
+
+Conclusions for a future T6:
+
+1. **For few clauses (the typical 2–5), dispatch shape is noise** — the
+   compiler flattens `match` / if-cascade / map to the same thing. T6 is **not**
+   worth it there. (Matches the prior Go result; do **not** sweep blindly.)
+2. **For many clauses, a native `match` is a real ~3–6× over the (now
+   allocation-free) linear scan** — `match(&str)` 118 ms vs linear `&str`
+   679 ms at 64 keys. So T6 has a genuine niche: **first-arg-indexed predicates
+   with many clauses.** It must be **gated to a clause-count threshold** and
+   re-benchmarked per target (string-atom targets get a comparison-tree `match`;
+   int-interned-atom targets get a true jump table → bigger win).
+3. **Map/array dispatch is not a win** (110 ms ≈ `match` 118 ms but with more
+   machinery) — consistent with the earlier Go experience. Prefer the host's
+   native `switch`/`match` over an explicit table.
+
+So: revisit T6 only for the many-clause case, gated on clause count, verified
+per target — the allocation fix above is the universal win and lands first.
+
+## A second bottleneck (noted for later): T4 `lo_restore_clause`
+
+A 64-clause **non-distinct** T4 (`multi_clause_n`) worst case ran at ~35 µs/call
+even after the allocation fix, because `lo_clause_snapshot` / `lo_restore_clause`
+clear and restore ~200 register slots **per failed clause** (≈64× per call).
+That dominates the allocation cost for many-clause T4. It is a less common shape
+(many same-first-arg clauses), but the restore cost scales with
+`clauses × reg-file-size` and would be the thing to optimise (e.g. restore only
+the trail + the actually-written A-registers) before pushing T4 to wide
+predicates.

--- a/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
@@ -357,8 +357,11 @@ emit_clause_chain_rust(FuncName, Pred, Arity, Guards, ForeignPreds, RustLines) :
 '// ~w — lowered from ~w/~w (T5 first-argument dispatch)
 pub fn ~w(vm: &mut WamState) -> bool {', [FuncName, Pred, Arity, FuncName]),
     with_output_to(string(Body),
-        ( format("    let t5a1 = vm.get_reg(\"A1\").unwrap_or(Value::Uninit);~n"),
-          format("    if t5a1.is_unbound() { return false; }  // unbound first arg: defer to interpreter (enumerates all clauses)~n"),
+        ( % The per-guard dispatch compares the first argument in place (no
+          % `let t5a1 = get_reg(...)` clone, no `Value::Atom("...")` per guard).
+          % An unbound / non-matching first arg matches no guard and returns
+          % false, deferring to the entry wrapper's interpreter fallback exactly
+          % as the old explicit is_unbound() check did.
           emit_rust_guards(Guards, ForeignPreds),
           format("    false~n") )),
     format(string(Footer), '}', []),
@@ -366,8 +369,13 @@ pub fn ~w(vm: &mut WamState) -> bool {', [FuncName, Pred, Arity, FuncName]),
 
 emit_rust_guards([], _).
 emit_rust_guards([guard(V, Rem) | Rest], ForeignPreds) :-
-    rust_val_literal(V, RustVal),
-    format("    if t5a1 == ~w {~n", [RustVal]),
+    wam_classify_constant_token(V, Class),
+    ( Class = atom(Name)
+    ->  escape_rust_string(Name, Esc),
+        format("    if vm.match_reg_atom(\"A1\", \"~w\") == Some(true) {~n", [Esc])
+    ;   rust_val_literal(V, RustVal),
+        format("    if vm.get_reg(\"A1\").map_or(false, |__v| __v == ~w) {~n", [RustVal])
+    ),
     emit_instrs(Rem, "        ", ForeignPreds),
     format("    }~n"),
     emit_rust_guards(Rest, ForeignPreds).
@@ -458,19 +466,39 @@ emit_one(fail, I) :-
 
 % --- Head unification (get_*) ---
 
+% get_constant — the hot head-match. For an ATOM constant we compare the
+% register against the &str in place (vm.match_reg_atom), avoiding the two heap
+% allocations the old `get_reg() != Value::Atom("...".to_string())` form paid
+% per comparison. Integer/other constants keep the (allocation-free, Copy)
+% Value comparison.
 emit_one(get_constant(CStr, AiStr), I) :-
     rust_reg_name(AiStr, Ai),
-    rust_val_literal(CStr, RustVal),
-    format("~w// get_constant ~w, ~w~n", [I, CStr, AiStr]),
-    format("~w{~n", [I]),
-    format("~w    let _a = vm.get_reg(\"~w\").unwrap_or(Value::Uninit);~n", [I, Ai]),
-    format("~w    if _a.is_unbound() {~n", [I]),
-    format("~w        vm.trail_binding(\"~w\");~n", [I, Ai]),
-    format("~w        vm.put_reg(\"~w\", ~w);~n", [I, Ai, RustVal]),
-    format("~w    } else if _a != ~w {~n", [I, RustVal]),
-    format("~w        return false;~n", [I]),
-    format("~w    }~n", [I]),
-    format("~w}~n", [I]).
+    wam_classify_constant_token(CStr, Class),
+    ( Class = atom(Name)
+    ->  escape_rust_string(Name, Esc),
+        format("~w// get_constant ~w, ~w~n", [I, CStr, AiStr]),
+        format("~w{~n", [I]),
+        format("~w    match vm.match_reg_atom(\"~w\", \"~w\") {~n", [I, Ai, Esc]),
+        format("~w        Some(true) => {}~n", [I]),
+        format("~w        Some(false) => return false,~n", [I]),
+        format("~w        None => {~n", [I]),
+        format("~w            vm.trail_binding(\"~w\");~n", [I, Ai]),
+        format("~w            vm.put_reg(\"~w\", Value::Atom(\"~w\".to_string()));~n", [I, Ai, Esc]),
+        format("~w        }~n", [I]),
+        format("~w    }~n", [I]),
+        format("~w}~n", [I])
+    ;   rust_val_literal(CStr, RustVal),
+        format("~w// get_constant ~w, ~w~n", [I, CStr, AiStr]),
+        format("~w{~n", [I]),
+        format("~w    let _a = vm.get_reg(\"~w\").unwrap_or(Value::Uninit);~n", [I, Ai]),
+        format("~w    if _a.is_unbound() {~n", [I]),
+        format("~w        vm.trail_binding(\"~w\");~n", [I, Ai]),
+        format("~w        vm.put_reg(\"~w\", ~w);~n", [I, Ai, RustVal]),
+        format("~w    } else if _a != ~w {~n", [I, RustVal]),
+        format("~w        return false;~n", [I]),
+        format("~w    }~n", [I]),
+        format("~w}~n", [I])
+    ).
 
 emit_one(get_integer(NStr, AiStr), I) :-
     rust_reg_name(AiStr, Ai),
@@ -489,12 +517,13 @@ emit_one(get_nil(AiStr), I) :-
     rust_reg_name(AiStr, Ai),
     format("~w// get_nil ~w~n", [I, AiStr]),
     format("~w{~n", [I]),
-    format("~w    let _a = vm.get_reg(\"~w\").unwrap_or(Value::Uninit);~n", [I, Ai]),
-    format("~w    if _a.is_unbound() {~n", [I]),
-    format("~w        vm.trail_binding(\"~w\");~n", [I, Ai]),
-    format("~w        vm.put_reg(\"~w\", Value::Atom(\"[]\".to_string()));~n", [I, Ai]),
-    format("~w    } else if _a != Value::Atom(\"[]\".to_string()) {~n", [I]),
-    format("~w        return false;~n", [I]),
+    format("~w    match vm.match_reg_atom(\"~w\", \"[]\") {~n", [I, Ai]),
+    format("~w        Some(true) => {}~n", [I]),
+    format("~w        Some(false) => return false,~n", [I]),
+    format("~w        None => {~n", [I]),
+    format("~w            vm.trail_binding(\"~w\");~n", [I, Ai]),
+    format("~w            vm.put_reg(\"~w\", Value::Atom(\"[]\".to_string()));~n", [I, Ai]),
+    format("~w        }~n", [I]),
     format("~w    }~n", [I]),
     format("~w}~n", [I]).
 

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -779,6 +779,59 @@ impl WamState {
         }
     }
 
+    /// Borrow a register's raw value (no Y-register routing for A/X regs; the
+    /// topmost env frame for Y regs). Returns `None` for an uninitialised or
+    /// missing slot. Unlike `get_reg`/`get_reg_raw` this does NOT clone, so the
+    /// hot head-match path can compare in place.
+    #[inline]
+    pub fn get_reg_ref(&self, name: &str) -> Option<&Value> {
+        if name.starts_with('Y') && name.len() > 1
+            && name[1..].chars().next().map_or(false, |c| c.is_ascii_digit())
+        {
+            for entry in self.stack.iter().rev() {
+                if let StackEntry::Env(_, y_regs) = entry {
+                    return match y_regs.get(name) {
+                        Some(Value::Uninit) | None => None,
+                        Some(v) => Some(v),
+                    };
+                }
+            }
+            None
+        } else {
+            let idx = Self::reg_index(name);
+            match self.regs.get(idx) {
+                Some(Value::Uninit) | None => None,
+                Some(v) => Some(v),
+            }
+        }
+    }
+
+    /// Allocation-free `get_constant`-style head match: deref the register (by
+    /// reference, following the binding chain like `deref_var`) and compare its
+    /// atom against `atom` without building a `Value::Atom(String)` on either
+    /// side. Returns `Some(true)` (bound & equal), `Some(false)` (bound but not
+    /// an equal atom — the caller fails the clause), or `None` (unbound — the
+    /// caller binds). Mirrors the old `get_reg() != Value::Atom("...")` path,
+    /// minus its two per-comparison heap allocations.
+    #[inline]
+    pub fn match_reg_atom(&self, name: &str, atom: &str) -> Option<bool> {
+        match self.get_reg_ref(name) {
+            None => Some(false),
+            Some(v) => self.deref_match_atom(v, atom),
+        }
+    }
+
+    fn deref_match_atom(&self, val: &Value, atom: &str) -> Option<bool> {
+        match val {
+            Value::Unbound(name) => match self.bindings.get(name) {
+                Some(bound) => self.deref_match_atom(bound, atom),
+                None => None,
+            },
+            Value::Atom(s) => Some(s == atom),
+            _ => Some(false),
+        }
+    }
+
     /// Bind an unbound variable name to a value in the binding table.
     /// Also records a trail entry so that backtracking can undo this binding.
     pub fn bind_var(&mut self, var_name: &str, val: Value) {


### PR DESCRIPTION
## Summary

While scoping a T6 first-arg-indexing sweep, benchmarking surfaced a much bigger, more universal bottleneck than dispatch *shape*: the hot `get_constant` head-match (and the T5 per-guard dispatch) compared the register against a constant via

```rust
get_reg() != Value::Atom("alice".to_string())
```

paying **two heap allocations per comparison** — the `get_reg` clone of the stored `Value::Atom(String)`, and the freshly-built right-hand-side `String`. A micro-benchmark pinned this as the whole **~9×** penalty (a 64-way scan comparing `Value::Atom(k.clone())` = 2899 ms vs comparing `&str` = 323 ms).

## Fix (allocation removal only — no semantic change)

- **`state.rs`**: `WamState::get_reg_ref` (borrow a register, no clone) + `match_reg_atom(name, &str) -> Option<bool>` — derefs the register through the binding chain **by reference** (mirroring `deref_var`) and compares the inner atom against the `&str` literal, so neither side allocates on the bound path. (`Some(true)`=bound&equal, `Some(false)`=bound&unequal, `None`=unbound; the unbound path still builds the `Value::Atom` to bind — rare.)
- **`wam_rust_lowered_emitter.pl`**: emit `match vm.match_reg_atom(Ai, "name") { ... }` for atom `get_constant`/`get_nil`, and `vm.match_reg_atom("A1", "v") == Some(true)` for each T5 guard (dropping the per-call `let t5a1 = get_reg(...)` clone + explicit `is_unbound()` check, which the guards subsume). Integer/float constants keep the allocation-free `Value` comparison.

## Measured (release + lto, 5M iterations)

| Benchmark | before | after | speedup |
|---|---:|---:|:-:|
| single-clause `wide/20` (20 `get_constant`, all bound) | 7501 ms | 992 ms | **7.6×** |
| `d64/1` T5 dispatch, 64 distinct atoms, worst case | 7381 ms | 1521 ms | **4.85×** |

`test_wam_rust_lowered_{t4,t5,ite_exec}` and `test_wam_rust_save_regs` still pass.

## Where a future T6 would still win (documented in `docs/reports/wam_rust_dispatch_alloc_perf.md`)

Per your steer, I benchmarked T6 (`match` on the first arg) **before** building it:
- **Few clauses (typical 2–5): dispatch shape is noise** — compiler-flattened; T6 not worth it. (Matches the prior Go array-dispatch result.)
- **Many clauses: native `match` is ~3–6× over the now-alloc-free linear scan** (`match(&str)` 118 ms vs linear `&str` 679 ms at 64 keys) — a genuine niche, but **gate on clause count and verify per target**.
- **Map/array dispatch is not a win** (110 ms ≈ `match`), consistent with the Go experience.

Also noted: a **second** bottleneck for many-clause T4 — `lo_restore_clause` clears ~200 register slots per failed clause.

## Next options

The allocation pattern is per-target (Rust uses `String` atoms). This lands the Rust fix + the measurement methodology; the same check can be swept to the other lowered targets, and T6 revisited for the many-clause niche.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_