### PR TITLE
perf(wam-cpp): allocation-free atom head-match in lowered dispatch

### DIFF
--- a/docs/reports/wam_rust_dispatch_alloc_perf.md
+++ b/docs/reports/wam_rust_dispatch_alloc_perf.md
@@ -108,3 +108,37 @@ That dominates the allocation cost for many-clause T4. It is a less common shape
 `clauses × reg-file-size` and would be the thing to optimise (e.g. restore only
 the trail + the actually-written A-registers) before pushing T4 to wide
 predicates.
+
+## Sweep to other targets
+
+The per-comparison atom allocation is **representation-specific**. Survey of the
+lowered targets:
+
+| target | atom repr | per-cmp alloc? | action |
+|---|---|---|---|
+| rust | `Value::Atom(String)` | yes (get_reg clone + RHS temp) | fixed (`match_reg_atom`) |
+| cpp  | `Value{std::string s}` | yes (get_reg copy + RHS temp) | fixed (`match_reg_atom`) |
+| go   | interned `*Atom` (cached ref) | no | clean |
+| llvm | interned i32 atom id | no | clean |
+| haskell | interned `Atom Int` | no | clean |
+| scala | interned int (atom table) | no | clean |
+| lua  | interned (intern_table) | no | clean |
+| clojure | interned via `normalize-literal-term` / `interned-equal?` | no (a hash lookup, not an alloc) | clean |
+| fsharp | `Atom of string`, but `get_constant` **delegates to `step`** (.NET interns string literals) | not the inline hot-alloc shape | left as is |
+
+### C++ result
+
+Same fix as Rust (`WamState::match_reg_atom` reads the register cell in place —
+no `Value` copy, no temporary `Value::Atom`; `deref` is a no-op in C++'s
+cell-mutates-in-place model). Measured (g++ -O2, 5M iters):
+
+| benchmark | before | after | speedup |
+|---|---:|---:|:-:|
+| single-clause `wide/20` | 5821 ms | 3351 ms | **1.74×** |
+| `d64/1` T5 dispatch, 64 atoms, worst case | 8446 ms | 6266 ms | **1.35×** |
+
+The win is smaller than Rust's because **C++ stores the register file as
+`std::unordered_map<std::string, CellPtr>`** — every register access also pays a
+string-keyed hash lookup that the allocation fix does not touch. That hash-map
+register file (vs Rust/Go's flat `Vec`/array indexed by an int) is the **next**
+C++ bottleneck and a bigger structural change; noted here for later.

--- a/src/unifyweaver/targets/wam_cpp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_cpp_lowered_emitter.pl
@@ -325,8 +325,10 @@ emit_clause_chain_cpp(FuncName, Pred, Arity, Guards, ForeignPreds, CppLines) :-
 '// ~w — lowered from ~w/~w (T5 first-argument dispatch)
 bool ~w(WamState* vm) {', [FuncName, Pred, Arity, FuncName]),
     with_output_to(string(Body),
-        ( format("    Value t5a1 = vm->get_reg(\"A1\");~n"),
-          format("    if (t5a1.is_unbound()) return false;  // unbound first arg: defer to interpreter (enumerates all clauses)~n"),
+        ( % Per-guard dispatch compares the first argument in place (no
+          % `Value t5a1 = get_reg(...)` copy, no temporary Value::Atom per
+          % guard). An unbound / non-matching first arg matches no guard and
+          % returns false, deferring to the interpreter fallback as before.
           emit_cpp_guards(Guards, ForeignPreds),
           format("    return false;~n") )),
     format(string(Footer), '}', []),
@@ -334,8 +336,13 @@ bool ~w(WamState* vm) {', [FuncName, Pred, Arity, FuncName]),
 
 emit_cpp_guards([], _).
 emit_cpp_guards([guard(V, Rem) | Rest], ForeignPreds) :-
-    cpp_val_literal(V, CppVal),
-    format("    if (t5a1 == ~w) {~n", [CppVal]),
+    wam_classify_constant_token(V, Class),
+    ( Class = atom(Name)
+    ->  local_escape_cpp_string(Name, Esc),
+        format("    if (vm->match_reg_atom(\"A1\", \"~w\") == 1) {~n", [Esc])
+    ;   cpp_val_literal(V, CppVal),
+        format("    if (vm->get_reg(\"A1\") == ~w) {~n", [CppVal])
+    ),
     emit_instrs(Rem, "        ", ForeignPreds),
     format("    }~n"),
     emit_cpp_guards(Rest, ForeignPreds).
@@ -428,19 +435,38 @@ emit_one(fail, I) :-
 
 % --- Head unification (get_*) ---
 
+% get_constant — the hot head-match. An ATOM constant is compared against the
+% register in place (vm->match_reg_atom), avoiding the per-comparison std::string
+% allocations the old `get_reg() == Value::Atom("...")` form paid (the get_reg
+% Value copy and the temporary Value::Atom). Integer/float keep the Value
+% comparison (no allocation).
 emit_one(get_constant(CStr, AiStr), I) :-
     cpp_reg_name(AiStr, Ai),
-    cpp_val_literal(CStr, CppVal),
-    format("~w// get_constant ~w, ~w~n", [I, CStr, AiStr]),
-    format("~w{~n", [I]),
-    format("~w    Value _a = vm->get_reg(\"~w\");~n", [I, Ai]),
-    format("~w    if (_a.is_unbound()) {~n", [I]),
-    format("~w        vm->trail_binding(\"~w\");~n", [I, Ai]),
-    format("~w        vm->put_reg(\"~w\", ~w);~n", [I, Ai, CppVal]),
-    format("~w    } else if (!(_a == ~w)) {~n", [I, CppVal]),
-    format("~w        return false;~n", [I]),
-    format("~w    }~n", [I]),
-    format("~w}~n", [I]).
+    wam_classify_constant_token(CStr, Class),
+    ( Class = atom(Name)
+    ->  local_escape_cpp_string(Name, Esc),
+        format("~w// get_constant ~w, ~w~n", [I, CStr, AiStr]),
+        format("~w{~n", [I]),
+        format("~w    int _m = vm->match_reg_atom(\"~w\", \"~w\");~n", [I, Ai, Esc]),
+        format("~w    if (_m < 0) {~n", [I]),
+        format("~w        vm->trail_binding(\"~w\");~n", [I, Ai]),
+        format("~w        vm->put_reg(\"~w\", Value::Atom(\"~w\"));~n", [I, Ai, Esc]),
+        format("~w    } else if (_m == 0) {~n", [I]),
+        format("~w        return false;~n", [I]),
+        format("~w    }~n", [I]),
+        format("~w}~n", [I])
+    ;   cpp_val_literal(CStr, CppVal),
+        format("~w// get_constant ~w, ~w~n", [I, CStr, AiStr]),
+        format("~w{~n", [I]),
+        format("~w    Value _a = vm->get_reg(\"~w\");~n", [I, Ai]),
+        format("~w    if (_a.is_unbound()) {~n", [I]),
+        format("~w        vm->trail_binding(\"~w\");~n", [I, Ai]),
+        format("~w        vm->put_reg(\"~w\", ~w);~n", [I, Ai, CppVal]),
+        format("~w    } else if (!(_a == ~w)) {~n", [I, CppVal]),
+        format("~w        return false;~n", [I]),
+        format("~w    }~n", [I]),
+        format("~w}~n", [I])
+    ).
 
 emit_one(get_integer(NStr, AiStr), I) :-
     cpp_reg_name(AiStr, Ai),
@@ -459,11 +485,11 @@ emit_one(get_nil(AiStr), I) :-
     cpp_reg_name(AiStr, Ai),
     format("~w// get_nil ~w~n", [I, AiStr]),
     format("~w{~n", [I]),
-    format("~w    Value _a = vm->get_reg(\"~w\");~n", [I, Ai]),
-    format("~w    if (_a.is_unbound()) {~n", [I]),
+    format("~w    int _m = vm->match_reg_atom(\"~w\", \"[]\");~n", [I, Ai]),
+    format("~w    if (_m < 0) {~n", [I]),
     format("~w        vm->trail_binding(\"~w\");~n", [I, Ai]),
     format("~w        vm->put_reg(\"~w\", Value::Atom(\"[]\"));~n", [I, Ai]),
-    format("~w    } else if (!(_a == Value::Atom(\"[]\"))) {~n", [I]),
+    format("~w    } else if (_m == 0) {~n", [I]),
     format("~w        return false;~n", [I]),
     format("~w    }~n", [I]),
     format("~w}~n", [I]).

--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -3740,6 +3740,11 @@ struct WamState {
     // so existing lowered code keeps compiling; get_cell exposes the cell
     // for instructions that need sharing semantics.
     Value   get_reg(const std::string& name) const;
+    // Allocation-free get_constant head match: 1 = bound atom equal to the
+    // argument, 0 = bound but not an equal atom (clause fails), -1 = unbound
+    // (caller binds). Reads the register cell in place: no Value copy, and no
+    // temporary Value::Atom on the right-hand side.
+    int     match_reg_atom(const std::string& name, const char* atom) const;
     void    put_reg(const std::string& name, Value v);
     CellPtr get_cell(const std::string& name);
     void    set_cell(const std::string& name, CellPtr c);
@@ -4171,6 +4176,29 @@ Value WamState::get_reg(const std::string& name) const {
     auto it = regs.find(name);
     if (it == regs.end()) return Value{};
     return *it->second;
+}
+
+int WamState::match_reg_atom(const std::string& name, const char* atom) const {
+    const Value* v;
+    if (is_y_reg(name)) {
+        if (env_stack.empty()) return -1;
+        auto& y = env_stack.back().y_regs;
+        auto it = y.find(name);
+        if (it == y.end()) return -1;
+        v = it->second.get();
+    } else {
+        auto it = regs.find(name);
+        if (it == regs.end()) return -1;
+        v = it->second.get();
+    }
+    // deref() is a no-op in this cell-mutates-in-place model, so the cell
+    // value is already the dereferenced value.
+    switch (v->tag) {
+        case Value::Tag::Atom:    return v->s == atom ? 1 : 0;
+        case Value::Tag::Unbound:
+        case Value::Tag::Uninit:  return -1;
+        default:                  return 0;
+    }
 }
 
 void WamState::put_reg(const std::string& name, Value v) {


### PR DESCRIPTION
## Summary

Sweep the Rust allocation fix (#2962) to **C++**, which has the same shape. Atoms are `Value{std::string s}`, so `get_constant` emitted

```cpp
Value _a = vm->get_reg(name);          // copies the stored Value::Atom (std::string alloc)
... else if (!(_a == Value::Atom("name")))   // temporary Value::Atom (another alloc)
```

paying **two `std::string` allocations per comparison**. The T5 per-guard dispatch was the same.

I surveyed all lowered targets first (in the perf doc): **rust + cpp** use `String` atoms and have this; **go/llvm/haskell/scala/lua** intern atoms to ints (clean); **clojure** interns via `interned-equal?` (a hash lookup, not an alloc); **fsharp** delegates `get_constant` to `step` (.NET interns literals). So C++ is the one remaining target with the inline hot-allocation shape.

## Fix (allocation removal only — no semantic change)

- **`wam_cpp_target.pl`**: `WamState::match_reg_atom(name, const char*) -> int` (`1`=bound atom equal, `0`=bound unequal, `-1`=unbound). Reads the register cell **in place** (no `Value` copy) and compares `std::string s` against the `const char*` (no temporary `Value::Atom`). `deref()` is a no-op in C++'s cell-mutates-in-place model, so the cell value is already dereferenced.
- **`wam_cpp_lowered_emitter.pl`**: emit `int _m = vm->match_reg_atom(Ai, "name"); if (_m < 0) {bind} else if (_m == 0) return false;` for atom `get_constant`/`get_nil`, and `vm->match_reg_atom("A1","v") == 1` for each T5 guard (dropping the per-call `Value t5a1 = get_reg(...)` copy + `is_unbound()` check, which the guards subsume). Integer/float keep the `Value` comparison.

## Measured (g++ -O2, 5M iters)

| benchmark | before | after | speedup |
|---|---:|---:|:-:|
| single-clause `wide/20` | 5821 ms | 3351 ms | **1.74×** |
| `d64/1` T5 dispatch, 64 atoms, worst case | 8446 ms | 6266 ms | **1.35×** |

The win is smaller than Rust's (7.6×) because **C++ stores the register file as `std::unordered_map<std::string, CellPtr>`** — every access also pays a string-keyed hash lookup the allocation fix doesn't touch. That hash-map register file (vs Rust/Go's flat array indexed by int) is the **next** C++ bottleneck — a bigger structural change, noted in the perf doc for later.

`test_wam_cpp_lowered_{t4,t5,ite_exec}` still pass.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_