### PR TITLE
LLVM WAM: @value_equals call-site audit — unify-vs-equality fixes + variable identity (M138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **WAM LLVM target (M138): `@value_equals` call-site audit** — the
+  follow-up flagged in the M137 (#2929) review. Three bound-bound
+  compare sites used shallow equality where WAM semantics require
+  unification, and one equality site inherited the M137 nested-Ref bug:
+  - `get_value` now routes its bound-bound case through
+    `@wam_unify_value` — `p(X, X)` heads called with unifiable
+    compounds like `p(f(A), f(B))` previously failed instead of
+    binding `A = B`.
+  - `unify_value` (read mode) both-bound case likewise unifies; it
+    also never dereffed either side, so Ref-wrapped values compared
+    by heap address.
+  - `arg/3` with bound A3 now unifies with the extracted argument
+    (ISO behavior); the argument slot may hold a Ref the old compare
+    saw as an address. `arg(1, h(f(a)), f(a))` previously failed.
+  - `sort/2` dedup now uses `@wam_strict_eq` (dedup is `==/2`
+    equality — it must not bind, so unification would be wrong):
+    duplicate compounds with Ref-stored args survived dedup
+    (`sort([f(g(a)), f(g(a))], L)` kept both).
+  - `@wam_strict_eq` now derefs via a new `@wam_deref_keep_var`
+    helper that stops at the last Ref when the target cell is
+    unbound, so variable identity is the cell address: `X == X` is
+    true, `X == Y` (distinct fresh vars) is false, and sort/2 keeps
+    `f(X)` / `f(Y)` distinct without binding them. Previously every
+    unbound var collapsed to the shared `{tag 6, payload 0}`
+    sentinel and compared equal.
 - **WAM LLVM target: undefined `@wam_dispatch_meta_call` when every
   predicate is fully lowered.** With `emit_mode(functions)` and all
   predicates natively lowered, no bytecode records exist, so the merged

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -2566,7 +2566,13 @@ gval.bind_x:
   ret i1 true
 
 gval.check_eq:
-  %gval.eq = call i1 @value_equals(%Value %gval.va, %Value %gval.vx)
+  ; M138: get_value is a unify instruction, not an equality test.
+  ; Both sides are bound here, so @wam_unify_value runs its both_bound
+  ; path: identical payload compare for atomics, deep unification for
+  ; compounds (binding any unbound args, with trailing). The previous
+  ; @value_equals wrongly failed p(X, X) heads called with unifiable
+  ; compounds like p(f(A), f(B)).
+  %gval.eq = call i1 @wam_unify_value(%WamState* %vm, %Value %gval.va, %Value %gval.vx)
   br i1 %gval.eq, label %gval.match, label %gval.fail
 
 gval.match:
@@ -2722,16 +2728,22 @@ wam_llvm_case('unify_value',
   br i1 %uvl.is_read, label %uvl.read, label %uvl.write
 
 uvl.read:
-  ; Read mode: get expected arg, compare with register
+  ; Read mode: get expected arg, unify with register
   %uvl.expected = call %Value @wam_unify_ctx_next(%WamState* %vm)
   %uvl.actual = call %Value @wam_get_reg(%WamState* %vm, i32 %uvl.xn)
-  ; Succeed if equal, or if either is unbound (bind the unbound one)
-  %uvl.eq = call i1 @value_equals(%Value %uvl.expected, %Value %uvl.actual)
   %uvl.exp_unb = call i1 @value_is_unbound(%Value %uvl.expected)
   %uvl.act_unb = call i1 @value_is_unbound(%Value %uvl.actual)
-  %uvl.ok1 = or i1 %uvl.eq, %uvl.exp_unb
-  %uvl.ok = or i1 %uvl.ok1, %uvl.act_unb
-  br i1 %uvl.ok, label %uvl.read_ok, label %uvl.fail
+  ; If either side is directly unbound, keep the original bind-the-
+  ; unbound-one logic below. M138: when BOTH are bound, this is a
+  ; unification (the old @value_equals wrongly failed bound-bound
+  ; compounds with unifiable args, and compared Ref-wrapped values
+  ; by address since neither side is dereffed here).
+  %uvl.any_unb = or i1 %uvl.exp_unb, %uvl.act_unb
+  br i1 %uvl.any_unb, label %uvl.read_ok, label %uvl.both_bound
+
+uvl.both_bound:
+  %uvl.eq = call i1 @wam_unify_value(%WamState* %vm, %Value %uvl.expected, %Value %uvl.actual)
+  br i1 %uvl.eq, label %uvl.read_done, label %uvl.fail
 
 uvl.read_ok:
   ; If actual is unbound, bind it to expected
@@ -4387,7 +4399,11 @@ srt.d_step:
   %srt.d_out_prev_idx = sub i32 %srt.d_out, 1
   %srt.d_out_prev_slot = getelementptr %Value, %Value* %srt.arr, i32 %srt.d_out_prev_idx
   %srt.d_out_prev = load %Value, %Value* %srt.d_out_prev_slot
-  %srt.d_eq = call i1 @value_equals(%Value %srt.d_in_val, %Value %srt.d_out_prev)
+  ; M138: dedup is ==/2 equality (NOT unification — sort/2 must keep
+  ; f(X) and f(Y) distinct and never bind), and adjacent elements can
+  ; be compounds whose args are heap Refs that @value_equals compared
+  ; by address — sort([f(g(a)), f(g(a))], L) kept both duplicates.
+  %srt.d_eq = call i1 @wam_strict_eq(%WamState* %vm, %Value %srt.d_in_val, %Value %srt.d_out_prev)
   br i1 %srt.d_eq, label %srt.d_after, label %srt.d_keep
 srt.d_keep:
   %srt.d_out_slot = getelementptr %Value, %Value* %srt.arr, i32 %srt.d_out
@@ -8033,7 +8049,10 @@ ag.a3_bind:
   ret i1 true
 
 ag.a3_check:
-  %ag.a3_eq = call i1 @value_equals(%Value %ag.a3, %Value %ag.arg_val)
+  ; M138: bound A3 must UNIFY with the extracted arg (ISO arg/3), and
+  ; the arg slot may hold a Ref that @value_equals compared by address.
+  ; @wam_unify_value derefs both sides and deep-unifies compounds.
+  %ag.a3_eq = call i1 @wam_unify_value(%WamState* %vm, %Value %ag.a3, %Value %ag.arg_val)
   ret i1 %ag.a3_eq
 
 ag.fail:
@@ -13765,10 +13784,46 @@ ig.false:
 ;
 ; This helper derefs on entry AND inside the recursive arg loop so
 ; structural equality holds regardless of how nested args are stored.
+;
+; M138: deref via @wam_deref_keep_var, NOT @wam_deref_value. The full
+; deref collapses a Ref-to-unbound-cell into the shared Unbound
+; sentinel { tag 6, payload 0 }, which erases variable identity --
+; X == Y would be true for two DISTINCT fresh vars (and sort/2 dedup
+; would merge f(X) with f(Y)). Stopping at the last Ref keeps the
+; variable represented as Ref{cell}, so the tag-5 shallow payload
+; compare becomes cell-address identity: X == X true, X == Y false.
+
+; Chase Ref chains but stop at the final Ref when the referenced cell
+; is unbound -- the Ref IS the variable''s identity. Bound cells chase
+; through as usual. Hop-limited like @wam_deref_value.
+define %Value @wam_deref_keep_var(%WamState* %vm, %Value %v) alwaysinline nounwind {
+entry:
+  br label %dkv.loop
+dkv.loop:
+  %dkv.cur = phi %Value [ %v, %entry ], [ %dkv.cell, %dkv.follow ]
+  %dkv.i = phi i32 [ 0, %entry ], [ %dkv.i_next, %dkv.follow ]
+  %dkv.tag = extractvalue %Value %dkv.cur, 0
+  %dkv.is_ref = icmp eq i32 %dkv.tag, 5
+  %dkv.hop_ok = icmp slt i32 %dkv.i, 64
+  %dkv.cont = and i1 %dkv.is_ref, %dkv.hop_ok
+  br i1 %dkv.cont, label %dkv.peek, label %dkv.done
+dkv.peek:
+  %dkv.addr_i64 = extractvalue %Value %dkv.cur, 1
+  %dkv.addr = trunc i64 %dkv.addr_i64 to i32
+  %dkv.cell = call %Value @wam_heap_get(%WamState* %vm, i32 %dkv.addr)
+  %dkv.cell_unb = call i1 @value_is_unbound(%Value %dkv.cell)
+  br i1 %dkv.cell_unb, label %dkv.done, label %dkv.follow
+dkv.follow:
+  %dkv.i_next = add i32 %dkv.i, 1
+  br label %dkv.loop
+dkv.done:
+  ret %Value %dkv.cur
+}
+
 define i1 @wam_strict_eq(%WamState* %vm, %Value %a, %Value %b) {
 entry:
-  %seq.da = call %Value @wam_deref_value(%WamState* %vm, %Value %a)
-  %seq.db = call %Value @wam_deref_value(%WamState* %vm, %Value %b)
+  %seq.da = call %Value @wam_deref_keep_var(%WamState* %vm, %Value %a)
+  %seq.db = call %Value @wam_deref_keep_var(%WamState* %vm, %Value %b)
   %seq.tag_a = extractvalue %Value %seq.da, 0
   %seq.tag_b = extractvalue %Value %seq.db, 0
   %seq.tags_eq = icmp eq i32 %seq.tag_a, %seq.tag_b

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -3640,6 +3640,76 @@ test_seq_atom_eq_still_works(_, R) :-
 test_seq_int_eq_still_works(_, R) :-
     ( 42 == 42 -> R is 1 ; R is 0 ).   % 1
 
+% M138: audit of the remaining @value_equals call sites after M137.
+% get_value / unify_value(read) / arg-3 are unify instructions and now
+% route bound-bound compares through @wam_unify_value; sort/2 dedup is
+% ==/2 equality over possibly-Ref-arg compounds and now uses
+% @wam_strict_eq.
+
+:- dynamic test_m138_gv_ground/2.
+:- dynamic m138_dup/2.
+m138_dup(X, X).
+test_m138_gv_ground(_, R) :-
+    % get_value bound-bound with structurally-equal ground compounds.
+    ( m138_dup(f(a), f(a)) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_m138_gv_unifies/2.
+test_m138_gv_unifies(_, R) :-
+    % get_value must UNIFY, not test equality: f(X) ~ f(Y) binds X = Y.
+    % Failed under the old @value_equals comparison.
+    ( m138_dup(f(X), f(Y)), X == Y -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_m138_gv_mismatch_rejects/2.
+test_m138_gv_mismatch_rejects(_, R) :-
+    % Non-unifiable compounds must still fail.
+    ( m138_dup(f(a), f(b)) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_m138_arg_bound_compound/2.
+test_m138_arg_bound_compound(_, R) :-
+    % arg/3 with bound compound A3: the extracted arg slot may hold a
+    % Ref that the old @value_equals compared by heap address.
+    ( arg(1, h(f(a)), f(a)) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_m138_arg_bound_rejects/2.
+test_m138_arg_bound_rejects(_, R) :-
+    ( arg(1, h(f(a)), f(b)) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_m138_sort_dedup_nested/2.
+test_m138_sort_dedup_nested(_, R) :-
+    % Duplicate compounds with Ref-stored args survived dedup under
+    % the old shallow @value_equals.
+    sort([f(g(a)), f(g(a))], L),
+    length(L, N), R is N.   % 1
+
+:- dynamic test_m138_sort_dedup_lists/2.
+test_m138_sort_dedup_lists(_, R) :-
+    % Multi-cons-cell list duplicates (the original M137 shape).
+    sort([[a, b], [a, b]], L),
+    length(L, N), R is N.   % 1
+
+:- dynamic test_m138_sort_keeps_distinct/2.
+test_m138_sort_keeps_distinct(_, R) :-
+    % sort/2 must NOT merge f(X) with f(Y) (== distinct) nor bind them:
+    % dedup is equality, not unification.
+    sort([f(X), f(Y)], L),
+    length(L, N),
+    ( var(X), var(Y), X \== Y -> R is N ; R is 0 ).   % 2
+
+:- dynamic test_m138_var_eq_self/2.
+test_m138_var_eq_self(_, R) :-
+    % Variable identity under ==/2: X == X via the same cell.
+    ( X == X -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_m138_var_neq_distinct/2.
+test_m138_var_neq_distinct(_, R) :-
+    % Distinct fresh vars are NOT ==-equal. Before the M138
+    % @wam_deref_keep_var fix, both X and Y collapsed to the shared
+    % Unbound sentinel { tag 6, payload 0 } and compared equal.
+    % Compared through compounds because bare top-level fresh-var
+    % goals (put_variable Yn + builtin_call) mis-execute even for
+    % var/1 on unmodified main -- a separate pre-existing bug.
+    ( f(X) \== f(Y) -> R is 1 ; R is 0 ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -6859,6 +6929,27 @@ test_all :-
                    test_seq_atom_eq_still_works, 0, 1),
        run_test_r0('42 == 42 still works -> 1',
                    test_seq_int_eq_still_works, 0, 1),
+       format('--- M138 value_equals call-site audit ---~n'),
+       run_test_r0('get_value f(a)=f(a) -> 1',
+                   test_m138_gv_ground + [m138_dup/2], 0, 1),
+       run_test_r0('get_value f(X)~f(Y) unifies -> 1',
+                   test_m138_gv_unifies + [m138_dup/2], 0, 1),
+       run_test_r0('get_value f(a)~f(b) rejects -> 1',
+                   test_m138_gv_mismatch_rejects + [m138_dup/2], 0, 1),
+       run_test_r0('arg(1,h(f(a)),f(a)) -> 1',
+                   test_m138_arg_bound_compound, 0, 1),
+       run_test_r0('arg(1,h(f(a)),f(b)) rejects -> 1',
+                   test_m138_arg_bound_rejects, 0, 1),
+       run_test_r0('sort dedup nested compounds -> 1',
+                   test_m138_sort_dedup_nested, 0, 1),
+       run_test_r0('sort dedup list elements -> 1',
+                   test_m138_sort_dedup_lists, 0, 1),
+       run_test_r0('sort keeps f(X),f(Y) distinct unbound -> 2',
+                   test_m138_sort_keeps_distinct, 0, 2),
+       run_test_r0('X == X -> 1',
+                   test_m138_var_eq_self, 0, 1),
+       run_test_r0('X \\== Y distinct fresh vars -> 1',
+                   test_m138_var_neq_distinct, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

The follow-up flagged in the #2929 (M137) review: an audit of the 19 remaining `@value_equals` call sites in the LLVM WAM target for the same shallow-compare bug class. **Four real bugs found and fixed**, plus one deeper variable-identity fix the audit surfaced. The other 15 sites were audited and confirmed safe (they compare numbers/atoms where tag mismatch short-circuits before any deep traversal matters).

## Bugs fixed

### 1. `get_value` tested equality instead of unifying
`get_value` is a unify instruction, but its bound-bound case called `@value_equals`. A `p(X, X)` head called as `p(f(A), f(B))` **failed** instead of binding `A = B`. Now routed through `@wam_unify_value` (both sides are known bound at that point, so it lands in the helper's `both_bound` path: identical payload compare for atomics, deep unification for compounds, with trailing).

### 2. `unify_value` (read mode), same class — plus no deref
The both-bound case used `@value_equals` on **raw** register/ctx values (neither side dereffed), so Ref-wrapped values compared by heap address. Restructured: the unbound-side binding logic is preserved byte-for-byte; only the both-bound case changes, to `@wam_unify_value`.

### 3. `arg/3` with bound A3 failed on compounds
`arg(1, h(f(a)), f(a))` returned **false** — the extracted argument slot holds a Ref that `@value_equals` compared by address, and ISO `arg/3` should unify anyway. Now unifies.

### 4. `sort/2` dedup kept duplicate compounds
`sort([f(g(a)), f(g(a))], L)` returned **both** elements — the M137 nested-Ref shape, in the dedup pass. Fixed with `@wam_strict_eq`, deliberately **not** the unifier: dedup is `==/2` equality and must never bind, so `sort([f(X), f(Y)], L)` keeps both elements with X, Y unbound (covered by a test).

### 5. Variable identity under `==/2` (surfaced by #4)
Every unbound variable dereffed to the shared `{ tag 6, payload 0 }` sentinel, so `X == Y` was **true for two distinct fresh vars** — engine-wide and pre-existing. New `@wam_deref_keep_var` helper chases Ref chains but stops at the **last Ref** when the target cell is unbound, so a variable's identity is its cell address. `@wam_strict_eq` now derefs through it: `X == X` true, `X == Y` false, sort keeps `f(X)` / `f(Y)` distinct.

## Out of scope (documented for follow-up)

- **Top-level fresh-var goals mis-execute** (`put_variable Yn` + `builtin_call` — even `var(X), X = done` fails) on unmodified `main`. Verified pre-existing by stashing; noted in the M138 test comments. Good next-task candidate.
- Test-harness convention: results must flow through `is/2` to reach the result register (direct `length/2` binding doesn't) — caused an initial false positive against sort.

## Tests

10 new execution tests in the `--- M138 value_equals call-site audit ---` section: get_value ground/unifies/rejects, arg bound/rejects, sort dedup nested/lists/keeps-distinct, `X == X`, `f(X) \== f(Y)`.

## Test plan

- [x] All 10 M138 tests PASS
- [x] Full `test_wam_llvm_builtin_execution` suite: **853 PASS, 0 FAIL** (843 pre-existing + 10 new; clang 18.1.3 + llc 18)

https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM)_