### PR TITLE
test(wam-cpp): fix stale lowerability_multi_clause_1 assertion (now multi_clause_n)

### DIFF
--- a/tests/test_wam_cpp_generator.pl
+++ b/tests/test_wam_cpp_generator.pl
@@ -3796,9 +3796,11 @@ test(lowerability_clause_chain) :-
 
 % A multi-clause predicate whose head does NOT discriminate on a distinct
 % first-arg constant (here the first argument is bound via get_variable, not
-% get_constant) is not a clause chain, so it still lowers as multi_clause_1
-% (clause 1 inline, clauses 2+ via the interpreter fallback).
-test(lowerability_multi_clause_1) :-
+% get_constant) is not a clause chain (T5). Its clauses are all clean supported
+% deterministic bodies, so it now lowers as T4 (multi_clause_n): every clause is
+% emitted inline, tried in order with a restore between attempts (previously it
+% was multi_clause_1 -- clause 1 inline, clauses 2+ via the interpreter).
+test(lowerability_multi_clause_n) :-
     Instrs = [try_me_else("L2"),
               get_variable("X1", "A1"),
               proceed,
@@ -3806,7 +3808,7 @@ test(lowerability_multi_clause_1) :-
               get_variable("X1", "A1"),
               proceed],
     wam_cpp_lowerable(wam_cpp_choice/1, Instrs, Reason),
-    assertion(Reason == multi_clause_1).
+    assertion(Reason == multi_clause_n).
 
 test(is_deterministic_helper) :-
     assertion(is_deterministic_pred_cpp([proceed])),


### PR DESCRIPTION
## Summary

`test_wam_cpp_generator`'s `lowerability_multi_clause_1` has been **failing on `main`** since the cpp T4 sweep (#2953) — it still asserts the pre-T4 classification.

The predicate it checks (2 clauses, both `get_variable X1 A1` / `proceed` — a **variable** first arg that T5/`clause_chain` declines) is now a clean all-clauses-lowerable body, so #2953 correctly classifies it as **`multi_clause_n`** (every clause emitted inline), not `multi_clause_1`. The test wasn't updated.

It went unnoticed because the cpp T4 PRs ran the lowered `t4`/`t5`/`ite` tests, not the full (slow) `test_wam_cpp_generator` suite. I surfaced it while running that suite end-to-end for the C++ register-file change (#2965).

## Change

Test-only: update the assertion to `multi_clause_n`, rename the test, and fix the now-inaccurate comment. The sibling `lowerability_deterministic` and `lowerability_clause_chain` (already updated for T5) are unaffected.

Verified: all three lowerability tests pass.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_