### PR TITLE
LLVM WAM: fix permanent-variable corruption via put-instruction bind-through (M139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **WAM LLVM target (M139): permanent-variable corruption via the
+  put-instruction bind-through.** The pre-existing bug noted in the
+  M138 test comments: top-level fresh-variable goals mis-executed —
+  `var(X), X = done` failed, and `var(X)` followed by `nonvar(X)`
+  BOTH succeeded on the same unbound variable. Root cause:
+  `put_variable Yn, Ai` places the same `Ref{addr}` into both
+  registers, and the later `put_value`/`put_variable` over `Ai`
+  called `@wam_bind_through_if_unbound_ref(old_Ai, val)`, which
+  either (a) wrote the Ref back into its own cell — a
+  self-referential cell that derefs to itself, so `var/1` saw the
+  variable as bound and every later unification corrupted — or
+  (b) bound the live unbound variable previously occupying `Ai` to
+  the incoming value, silently aliasing two unrelated variables
+  (e.g. in `var(X), R0 is 1, X = x` the `put_variable` staging `R0`
+  bound `X` to `R0`, so `X = x` then failed against `1`). Fixed
+  three ways: a self-reference guard in
+  `@wam_bind_through_if_unbound_ref` (never store a Ref into its own
+  cell), `put_value` is now a pure register copy per standard WAM,
+  and `put_variable` no longer binds `Ai`'s previous occupant. The
+  remaining bind-through callers (`put_constant`, `put_structure`,
+  `put_list`, `get_list`) are unchanged but now protected by the
+  self-reference guard. Five regression tests in the new
+  `--- M139 put_value Y-reg aliasing ---` section.
 - **WAM LLVM target (M138): `@value_equals` call-site audit** — the
   follow-up flagged in the M137 (#2929) review. Three bound-bound
   compare sites used shallow equality where WAM semantics require

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -2830,30 +2830,41 @@ wam_llvm_case('put_variable',
   ; value via deref. Without this aliasing, binding Ai leaves Xn
   ; stuck on a stale Unbound sentinel — the bug that caused
   ; sum_ints / fib / term_depth to compute wrong results.
+  ; M139: no bind-through of Ai''s previous occupant. Two put_variable
+  ; in a row over the same Ai (e.g. staging args for consecutive
+  ; builtin calls) left the first variable''s unbound Ref in Ai; the
+  ; old @wam_bind_through_if_unbound_ref(old_Ai, fresh_ref) then bound
+  ; that LIVE variable to the new fresh one, silently aliasing two
+  ; unrelated variables. Overwriting an argument register must never
+  ; bind what it previously held.
   %pv.xn = trunc i64 %op1 to i32
   %pv.ai = trunc i64 %op2 to i32
   %pv.unb = call %Value @value_unbound(i8* null)
   %pv.addr = call i32 @wam_heap_push(%WamState* %vm, %Value %pv.unb)
   %pv.ref = call %Value @value_ref(i32 %pv.addr)
-  %pv.old = call %Value @wam_get_reg(%WamState* %vm, i32 %pv.ai)
   call void @wam_trail_binding(%WamState* %vm, i32 %pv.xn)
   call void @wam_trail_binding(%WamState* %vm, i32 %pv.ai)
   call void @wam_set_reg(%WamState* %vm, i32 %pv.xn, %Value %pv.ref)
   call void @wam_set_reg(%WamState* %vm, i32 %pv.ai, %Value %pv.ref)
-  call void @wam_bind_through_if_unbound_ref(%WamState* %vm, %Value %pv.old, %Value %pv.ref)
   call void @wam_inc_pc(%WamState* %vm)
   ret i1 true').
 
 
 wam_llvm_case('put_value',
 '  ; op1 = Xn index, op2 = Ai index
+  ; M139: pure register copy, per standard WAM. This previously also
+  ; called @wam_bind_through_if_unbound_ref(old_Ai, val), which BOUND
+  ; whatever unbound variable happened to occupy Ai before the copy --
+  ; aliasing two unrelated variables. E.g. in
+  ;   var(X), R is 1, X = x
+  ; the put_value Y2, A1 staging R for is/2 found A1 still holding
+  ; X''s Ref and bound X to R, so X = x then saw 1. Overwriting an
+  ; argument register must never bind its previous occupant.
   %pvl.xn = trunc i64 %op1 to i32
   %pvl.ai = trunc i64 %op2 to i32
   %pvl.val = call %Value @wam_get_reg(%WamState* %vm, i32 %pvl.xn)
-  %pvl.old = call %Value @wam_get_reg(%WamState* %vm, i32 %pvl.ai)
   call void @wam_trail_binding(%WamState* %vm, i32 %pvl.ai)
   call void @wam_set_reg(%WamState* %vm, i32 %pvl.ai, %Value %pvl.val)
-  call void @wam_bind_through_if_unbound_ref(%WamState* %vm, %Value %pvl.old, %Value %pvl.val)
   call void @wam_inc_pc(%WamState* %vm)
   ret i1 true').
 

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -624,6 +624,20 @@ entry:
 check:
   %addr_i64 = extractvalue %Value %ref_val, 1
   %addr = trunc i64 %addr_i64 to i32
+  ; M139: never write a Ref back into its own cell. put_variable
+  ; places the SAME Ref{addr} into both Xn and Ai; a later
+  ; put_value Xn, Ai then arrives here with ref_val = new_val =
+  ; Ref{addr}, and binding would store Ref{addr} INTO cell addr --
+  ; a self-referential cell that derefs to itself, so var/1 sees
+  ; the variable as bound and every later unification corrupts.
+  ; The registers already alias through this cell; skip.
+  %nv_tag = extractvalue %Value %new_val, 0
+  %nv_is_ref = icmp eq i32 %nv_tag, 5
+  %nv_addr_i64 = extractvalue %Value %new_val, 1
+  %same_addr = icmp eq i64 %nv_addr_i64, %addr_i64
+  %self_ref = and i1 %nv_is_ref, %same_addr
+  br i1 %self_ref, label %done, label %check_cell
+check_cell:
   %old = call %Value @wam_heap_get(%WamState* %vm, i32 %addr)
   %is_unb = call i1 @value_is_unbound(%Value %old)
   br i1 %is_unb, label %bind, label %done

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -3708,7 +3708,48 @@ test_m138_var_neq_distinct(_, R) :-
     % Compared through compounds because bare top-level fresh-var
     % goals (put_variable Yn + builtin_call) mis-execute even for
     % var/1 on unmodified main -- a separate pre-existing bug.
+    % (Fixed in M139 -- see the M139 section -- but this test keeps
+    % the compound shape since it targets ==/2 identity, not the
+    % put_value aliasing bug.)
     ( f(X) \== f(Y) -> R is 1 ; R is 0 ).   % 1
+
+% M139: permanent-variable (Y-reg) corruption via put_value's
+% bind-through. put_variable Yn, Ai places the SAME Ref into both
+% registers; a later put_value over Ai called
+% @wam_bind_through_if_unbound_ref(old_Ai, val) which either (a) wrote
+% the Ref back into its own cell (self-reference: var/1 then saw the
+% variable as bound, unification corrupted), or (b) bound the live
+% unbound variable that previously occupied Ai to the incoming value
+% (aliasing two unrelated variables). Fixed by a self-reference guard
+% in the helper plus making put_value a pure register copy.
+
+:- dynamic test_m139_var_then_bind/2.
+test_m139_var_then_bind(_, R) :-
+    % The original failing shape: var(X) on a permanent, bound later.
+    var(X), X = done, R is 1.   % 1 (failed: exit 255)
+
+:- dynamic test_m139_var_twice/2.
+test_m139_var_twice(_, R) :-
+    % No binding at all -- the second var/1 saw the self-referential
+    % cell as bound.
+    var(X), var(X), R is 1.   % 1 (failed: exit 255)
+
+:- dynamic test_m139_var_nonvar_consistent/2.
+test_m139_var_nonvar_consistent(_, R) :-
+    % The smoking gun: var(X) and nonvar(X) both succeeded on the
+    % same unbound variable.
+    ( var(X), nonvar(X) -> R is 0 ; R is 1 ).   % 1 (got 0)
+
+:- dynamic test_m139_no_alias_on_put_value/2.
+test_m139_no_alias_on_put_value(_, R) :-
+    % put_value staging R0 for is/2 found X's Ref still in A1 and
+    % bound X to R0 -- so X = x then failed against 1.
+    var(X), R0 is 1, X = x, R is R0.   % 1
+
+:- dynamic test_m139_ite_var_bind/2.
+test_m139_ite_var_bind(_, R) :-
+    % Same shape inside an if-then-else condition.
+    ( var(X), X = done -> R is 1 ; R is 0 ).   % 1 (got 0)
 
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
@@ -6950,6 +6991,17 @@ test_all :-
                    test_m138_var_eq_self, 0, 1),
        run_test_r0('X \\== Y distinct fresh vars -> 1',
                    test_m138_var_neq_distinct, 0, 1),
+       format('--- M139 put_value Y-reg aliasing ---~n'),
+       run_test_r0('var(X), X=done -> 1',
+                   test_m139_var_then_bind, 0, 1),
+       run_test_r0('var(X), var(X) -> 1',
+                   test_m139_var_twice, 0, 1),
+       run_test_r0('var/nonvar consistent on same var -> 1',
+                   test_m139_var_nonvar_consistent, 0, 1),
+       run_test_r0('put_value must not alias old occupant -> 1',
+                   test_m139_no_alias_on_put_value, 0, 1),
+       run_test_r0('ITE: var(X), X=done -> 1',
+                   test_m139_ite_var_bind, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Fixes the pre-existing engine bug documented in the M138 (#2964) test comments: **top-level fresh-variable goals mis-executed** — `var(X), X = done` failed outright, and the smoking-gun probe showed `var(X)` and `nonvar(X)` **both succeeding on the same unbound variable**.

## Root cause

`put_variable Yn, Ai` places the same `Ref{addr}` into both registers (the put_variable aliasing design). A later `put_value`/`put_variable` over `Ai` then called `@wam_bind_through_if_unbound_ref(old_Ai, val)` on the register's previous occupant, producing two distinct corruptions:

**(a) Self-referential cells.** `put_value Y1, A1` right after `put_variable Y1, A1` arrives with `old_Ai = val = Ref{addr}` — the helper stored the Ref **into its own cell**. Deref then chases the cell to itself until the hop limit and returns the Ref, so `value_is_unbound` says bound: `var(X)` false, `nonvar(X)` true, and every later unification against the variable corrupts (`X = done` → predicate fails).

**(b) Variable aliasing.** Overwriting `Ai` bound the live unbound variable that *used to be* there to the incoming value. In `var(X), R0 is 1, X = x`, the `put_variable Y3, A1` staging `R0` found `X`'s Ref still in `A1` and bound `X` to `R0` — so after `R0 is 1`, `X = x` failed against `1`.

The bind-first shapes (`X = done, ...`) always worked because a bound cell skips the helper — which is why this never surfaced in the existing 850+ tests: they bind variables before reusing registers.

## Fix (three parts)

1. **Self-reference guard** in `@wam_bind_through_if_unbound_ref`: never store a Ref into its own cell (`templates/llvm_wam/state.ll.mustache`).
2. **`put_value` is a pure register copy**, per standard WAM — overwriting an argument register must never bind its previous occupant.
3. **`put_variable` no longer binds `Ai`'s previous occupant** (same rule).

The remaining bind-through callers (`put_constant`, `put_structure`, `put_list`, `get_list`) are unchanged — plausibly load-bearing for result-passing patterns — but all now protected by the guard. Auditing them is a follow-up candidate.

## Diagnosis trail

11 bisection probes narrowed the trigger: Y-reg variable whose **first use is while still unbound** (`var(X)` first fails; `X = done` first passes), then `( var(X), nonvar(X) -> ... )` taking the *then*-branch pinpointed cell corruption between the two builtin calls, and reading `put_value` found the bind-through on the old occupant. Two red herrings confirmed as harness conventions, not bugs: results must flow through a final `is/2`, and the exec driver reads A2's raw payload as the exit code.

## Tests

5 regression tests in the new `--- M139 put_value Y-reg aliasing ---` section: var-then-bind, var-twice (no binding at all), var/nonvar consistency, no-alias-on-put_value, and the ITE-condition shape.

## Test plan

- [x] All 5 M139 tests PASS
- [x] Full `test_wam_llvm_builtin_execution` suite: **858 PASS, 0 FAIL** (853 prior + 5 new; clang 18.1.3 + llc 18) — confirms removing the `put_value`/`put_variable` bind-throughs breaks no existing pattern, and the M137/M138 sections stay green

https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM)_