### PR TITLE
Document distribution cache benchmark future directions

### DIFF
--- a/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
+++ b/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
@@ -325,6 +325,8 @@ This scoped mode is the bridge between graph search and global fixed-point evalu
 
 The next implementation-facing work is a parity harness:
 
+The benchmark plan in `DISTRIBUTION_CACHE_BENCHMARK_PLAN.md` defines the first shallow precompute/search-budget grid for this work.
+
 1. exact parent-only histogram on tiny fixtures;
 2. exact parent-only histogram on simplewiki samples;
 3. fitted truncated-tail representation over the same nodes;

--- a/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
+++ b/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
@@ -87,7 +87,62 @@ representation_policy(...)
 metric_functional(...)
 ```
 
-## 4. User override surface
+## 4. Cumulative bases are acceleration layers
+
+A cumulative distribution function is useful, but it is not a replacement for
+the distribution state. It accelerates budgeted queries whose weighting function
+has been chosen in advance.
+
+The basic mass CDF is:
+
+```prolog
+cumulative_basis(mass).
+F0_v[B] = sum_{S <= B} P_v[S]
+```
+
+With that basis, reachability mass and interval mass are cheap:
+
+```prolog
+mass(S <= B) = F0_v[B]
+mass(B1 < S <= B2) = F0_v[B2] - F0_v[B1]
+```
+
+Other expectation forms need their own cumulative basis:
+
+```prolog
+cumulative_basis(moment(1)).
+F1_v[B] = sum_{S <= B} S * P_v[S]
+
+cumulative_basis(weighted_power(N)).
+FN_v[B] = sum_{S <= B} (S + 1)^(-N) * P_v[S]
+
+cumulative_basis(custom(Name)).
+FG_v[B] = sum_{S <= B} g_Name(S) * P_v[S]
+```
+
+This makes common functionals constant-time or interval-difference lookups, but
+each stored basis costs memory or storage. The representation policy should
+therefore decide which bases to materialise:
+
+```prolog
+cached_distribution(
+    raw_state(DistributionState),
+    cumulative_basis([mass, moment(1), weighted_power(N)]),
+    storage_policy(StoragePolicy)).
+```
+
+The default should be conservative: always expose mass when the support is wide
+enough to make repeated scans expensive; store first moments or weighted-power
+bases only when the workload asks for those functionals often enough to justify
+the space. For exact histograms with small support, scanning bins may be cheaper
+than storing cumulative arrays.
+
+For an arbitrary function `g(S)`, a CDF alone is insufficient. The runtime must
+either scan the exact bins, use an analytic integral supplied by the parametric
+family, evaluate a stored `custom(Name)` basis, approximate numerically, or emit
+a diagnostic that the requested functional has no supported cumulative basis.
+
+## 5. User override surface
 
 The long-term design goal is that users can modify the policy without rewriting target code. The compiler should expose a predicate hook that selects or overrides the representation policy.
 
@@ -134,7 +189,7 @@ default_distribution_policy(Node, Summary, Functional, Signals, Choice)
 
 User predicates can call the default and override only selected cases. This keeps the policy extensible without making target adapters depend on project-specific Prolog code.
 
-## 5. Cost and diagnostics
+## 6. Cost and diagnostics
 
 The representation switch should be driven by both cost and value:
 
@@ -152,13 +207,15 @@ Diagnostics should be emitted into the recurrence strategy trace:
 - exact support size;
 - chosen family;
 - fitted finite support range;
+- materialised cumulative bases;
 - estimated error for the selected functional;
 - fallback reason if no family passed the threshold;
+- fallback reason if a requested functional has no matching cumulative basis;
 - whether a user selection predicate overrode the default.
 
 The important invariant is that approximation is not silent. A query that uses a closed-form tail should leave a trace explaining why the representation changed.
 
-## 6. Cached distributions as search boundary conditions
+## 7. Cached distributions as search boundary conditions
 
 A cached distribution can act as a boundary condition for later path search. During a per-query path aggregate, if the traversal reaches a node `N` with a valid distribution state for the same root and statistic, the search does not need to enumerate below `N`. It can integrate the cached distribution over the remaining path budget and add that contribution to the aggregate.
 
@@ -172,7 +229,7 @@ contribution = integrate_distribution(
     remaining_budget)
 ```
 
-This is expectation-like, but the integration is specific to the functional being computed. For a bounded average it contributes weighted mass and weighted length. For reachability mass it contributes the CDF up to the remaining budget. For `weighted_power_mean(N, Budget)` it contributes the weighted power sum over the admissible support. For entropy it contributes the entropy term of the admissible finite slice.
+This is expectation-like, but the integration is specific to the functional being computed. For reachability mass it can use the mass CDF up to the remaining budget. For a bounded average it needs both mass and first-moment cumulative bases. For `weighted_power_mean(N, Budget)` it needs the matching weighted-power basis. For entropy it needs either a raw distribution scan, an analytic family-specific entropy calculation over the finite slice, or a stored custom basis.
 
 The cache hit is valid only when the cached state was built under compatible semantics:
 
@@ -181,9 +238,9 @@ The cache hit is valid only when the cached state was built under compatible sem
 - compatible cycle policy and path admissibility rules;
 - compatible representation policy, or a representation with known error bounds for the requested functional.
 
-This turns exact or approximated distribution tables into reusable suffix summaries. Search remains exact when the cached distribution is exact; it becomes a controlled approximation when the cached distribution is a fitted representation.
+This turns exact or approximated distribution tables into reusable suffix summaries. Search remains exact when the cached distribution is exact and the requested functional can be evaluated exactly from the stored state. It becomes a controlled approximation when the cached distribution is a fitted representation, or when the requested functional is evaluated through an approximate basis.
 
-## 7. Scoped fixed-point generation
+## 8. Scoped fixed-point generation
 
 Fixed-point distribution generation does not need to materialise the whole graph for a single node query. For a target node `V`, first restrict work to the ancestor cone relevant to `V`: all nodes that can reach the root by parent edges and can also reach `V` by reversing the parent relation. Then compute distributions from the root outward only inside that scoped subgraph, stopping when the target node's distribution has been produced or the configured depth/horizon is exhausted.
 
@@ -208,7 +265,7 @@ Three execution modes fall out:
 
 This scoped mode is the bridge between graph search and global fixed-point evaluation. It preserves the recurrence form, but its worklist is cut down by the query's ancestor cone and by cached boundary distributions encountered during evaluation.
 
-## 8. Open validation work
+## 9. Open validation work
 
 The next implementation-facing work is a parity harness:
 
@@ -216,6 +273,7 @@ The next implementation-facing work is a parity harness:
 2. exact parent-only histogram on simplewiki samples;
 3. fitted truncated-tail representation over the same nodes;
 4. functional-level error checks for `min_support`, `bounded_average`, `reachability_mass`, `tail_mass`, `entropy`, and `weighted_power_mean`;
-5. policy-selection tests showing that a user predicate can override the default without changing target code.
+5. cumulative-basis tests showing mass, interval, moment, and weighted-power lookups agree with raw histogram scans;
+6. policy-selection tests showing that a user predicate can override the default without changing target code.
 
 Only after those checks pass should the policy be used for enwiki-scale materialisation.

--- a/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
+++ b/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
@@ -240,7 +240,63 @@ The cache hit is valid only when the cached state was built under compatible sem
 
 This turns exact or approximated distribution tables into reusable suffix summaries. Search remains exact when the cached distribution is exact and the requested functional can be evaluated exactly from the stored state. It becomes a controlled approximation when the cached distribution is a fitted representation, or when the requested functional is evaluated through an approximate basis.
 
-## 8. Scoped fixed-point generation
+## 8. Cache admission and eviction
+
+Distribution caches should not use blind overwrite-on-collision. A collided insert
+is a policy decision: keeping a root-near, high-reuse suffix summary may be more
+valuable than admitting a newly computed deep node.
+
+The cache should score both the incumbent and the candidate:
+
+```prolog
+cache_score(Node, Entry, Score) :-
+    Score is expected_reuse(Node)
+          * recompute_cost_saved(Entry)
+          * root_proximity_bonus(Node)
+          * accuracy_value(Entry)
+          / storage_cost(Entry).
+```
+
+Useful score signals:
+
+- parent distance to root, with a bonus for nodes closer to the root;
+- estimated descendant or query-reuse count;
+- observed hit frequency and recency;
+- cost to recompute the distribution or scoped fixed-point cone;
+- representation quality, with exact states usually worth more than fitted ones;
+- cumulative-basis storage cost, since each materialised basis consumes space;
+- semantic compatibility width, meaning how many likely queries can reuse the
+  same root/statistic/cycle-policy/budget-horizon entry.
+
+On collision, admit only if the candidate is meaningfully better:
+
+```prolog
+admit_candidate if candidate_score > incumbent_score * hysteresis
+```
+
+The hysteresis factor prevents churn when two similarly useful entries map to the
+same slot. If the candidate loses, the runtime can still return the just-computed
+value to the current query; it simply does not install it in the shared cache.
+
+Eviction should also be layered. Raw exact distributions are expensive to
+recompute and should generally outlive derived cumulative bases. Cumulative
+bases can be evicted first because they can be rebuilt from raw state. Parametric
+tail parameters are compact and may be worth retaining if their error bounds are
+still valid. A practical eviction order is:
+
+```prolog
+1. cold custom cumulative bases
+2. cold moment / weighted-power bases
+3. cold mass CDFs when raw state is still available
+4. approximate fitted states with weak reuse
+5. exact raw states, especially near-root entries, only under pressure
+```
+
+For Wikipedia-style root-anchored metrics, the default bias should be: retain
+near-root exact distributions, retain high-reuse ancestor nodes, and evict deep
+low-hit cumulative bases before overwriting root-proximal entries.
+
+## 9. Scoped fixed-point generation
 
 Fixed-point distribution generation does not need to materialise the whole graph for a single node query. For a target node `V`, first restrict work to the ancestor cone relevant to `V`: all nodes that can reach the root by parent edges and can also reach `V` by reversing the parent relation. Then compute distributions from the root outward only inside that scoped subgraph, stopping when the target node's distribution has been produced or the configured depth/horizon is exhausted.
 
@@ -265,7 +321,7 @@ Three execution modes fall out:
 
 This scoped mode is the bridge between graph search and global fixed-point evaluation. It preserves the recurrence form, but its worklist is cut down by the query's ancestor cone and by cached boundary distributions encountered during evaluation.
 
-## 9. Open validation work
+## 10. Open validation work
 
 The next implementation-facing work is a parity harness:
 
@@ -274,6 +330,7 @@ The next implementation-facing work is a parity harness:
 3. fitted truncated-tail representation over the same nodes;
 4. functional-level error checks for `min_support`, `bounded_average`, `reachability_mass`, `tail_mass`, `entropy`, and `weighted_power_mean`;
 5. cumulative-basis tests showing mass, interval, moment, and weighted-power lookups agree with raw histogram scans;
-6. policy-selection tests showing that a user predicate can override the default without changing target code.
+6. cache-admission tests showing near-root/high-reuse entries survive collisions against lower-score entries;
+7. policy-selection tests showing that a user predicate can override the default without changing target code.
 
 Only after those checks pass should the policy be used for enwiki-scale materialisation.

--- a/docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md
+++ b/docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md
@@ -203,7 +203,32 @@ Do not introduce child-direction paths until parent-only exact cache semantics
 and admission policy are measured. Parent-only distributions can later bound or
 prioritize child-inclusive searches.
 
-## 9. Output artifacts
+## 9. Future directions
+
+The first benchmark deliberately measures exact parent-only histograms. Later
+passes can test cheaper summaries and approximations once exact-cache semantics
+are stable.
+
+One future direction is to compute scalar support bounds before deciding whether
+to build a full distribution:
+
+```text
+L_min(v) = shortest parent-only path length from v to root
+L_max(v) = longest parent-only path length from v to root, under the active cycle policy
+support(P_v) <= [L_min(v), L_max(v)]
+```
+
+Those bounds give fast budget edge cases and may help initialise finite-support
+approximations. If real parent-path distributions tend toward a recognisable
+family, such as a binomial-like, truncated-normal, or truncated-geometric shape,
+the benchmark can add approximation modes that compare fitted distributions
+against exact SimpleWiki histograms before trying enwiki-scale runs.
+
+Treat this as a later phase, not part of the first parity harness. The first
+requirement remains exact agreement between full enumeration, cached exact
+histograms, and cumulative bases.
+
+## 10. Output artifacts
 
 Each benchmark run should emit machine-readable records and one summary table:
 
@@ -221,7 +246,7 @@ The summary should include:
 - exactness failures, if any;
 - best observed policy under a fixed storage budget.
 
-## 10. Decision criteria
+## 11. Decision criteria
 
 Use the benchmark to choose defaults:
 

--- a/docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md
+++ b/docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md
@@ -1,0 +1,245 @@
+# Distribution Cache Benchmark Plan
+
+This plan turns `DISTRIBUTIONAL_FIT_POLICY.md` into an executable benchmark. The
+goal is to measure when shallow precomputed path-statistic distributions pay for
+themselves during budgeted path aggregate search.
+
+The first experiment is deliberately parent-only and exact. Fitted tails,
+child-direction paths, and approximate cumulative bases come later. The immediate
+question is simpler:
+
+> If we precompute exact parent-only distributions for nodes near the root, how
+> much search work disappears when later path aggregate queries can stop at those
+> cached nodes?
+
+## 1. Hypothesis
+
+For a fixed root, shallow exact distributions should have high reuse because many
+deeper paths pass through a small set of root-near ancestors. A search with
+budget `B_search` can stop when it reaches a cached ancestor `N` and evaluate the
+cached suffix distribution over the remaining budget.
+
+Expected pattern:
+
+```text
+D_pre = 0: no suffix cache; full exact path enumeration
+D_pre = 1..2: small cache, high-value root-near suffix summaries
+D_pre = 3..4: larger cache, higher hit rate, diminishing marginal returns
+D_pre > 4: useful on enwiki only if high-reuse nodes continue to dominate
+```
+
+The main curve is marginal speedup per cached byte or per cached node.
+
+## 2. Baseline scope
+
+Start with the simplest semantics:
+
+- graph: SimpleWiki category graph first, enwiki later;
+- root: `Category:Main_topic_classifications` or the canonical root used by the
+  existing tree-likeness fixtures;
+- edge direction: parent-only paths toward the root;
+- path statistic: hop count `L`;
+- distribution representation: exact histogram, plus optional exact cumulative
+  bases derived from that histogram;
+- cycle policy: use the same bounded/visited policy as the exact search oracle;
+- approximation: none.
+
+Under those constraints, cached-distribution search should be semantically exact.
+Any discrepancy against full exact search is a bug in orientation, budget
+accounting, normalization, cycle policy, or path-statistic handling.
+
+## 3. Experiment matrix
+
+Run a grid over precompute depth and search budget:
+
+```text
+D_pre:    0, 1, 2, 3, 4, 5
+B_search: 2, 4, 6, 8, 10
+```
+
+`D_pre` is root-outward parent distance. A node is cache-eligible when its
+minimum parent distance from the root is `<= D_pre`.
+
+`B_search` is the path aggregate budget from a queried node toward the root. In
+the first experiment, the budget is hop count. Later versions may use weighted
+parent cost or tuple statistics.
+
+For each `(D_pre, B_search)` cell, run the same sampled target set under:
+
+| Mode | Description |
+|------|-------------|
+| `full_exact` | Enumerate/aggregate parent-only paths with no distribution cache |
+| `cached_histogram` | Stop at cached nodes and scan exact histogram bins up to remaining budget |
+| `cached_mass_cdf` | Stop at cached nodes and use mass CDF for reachability-mass queries |
+| `cached_basis` | Use mass + selected cumulative bases for bounded average or weighted power |
+
+The first pass may implement only `full_exact` and `cached_histogram`. Add CDF
+modes once the raw suffix-cutoff semantics are verified.
+
+## 4. Query sets
+
+Use multiple target sets so the cache is not tuned to one workload:
+
+| Set | Purpose |
+|-----|---------|
+| `near_root` | Nodes at parent distance 1-4; should hit shallow cache frequently |
+| `mid_depth` | Nodes below main-topic layers; tests practical reuse |
+| `deep_tail` | Deep category nodes; tests whether shallow cache still cuts work |
+| `high_indegree` | Multi-parent nodes likely to have many root paths |
+| `random_reachable` | Unbiased reachable sample for aggregate reporting |
+
+For SimpleWiki, exact runs should be tractable enough to use larger samples. For
+enwiki, start with small samples and carry forward only the modes that passed
+SimpleWiki parity.
+
+## 5. Measurements
+
+Record per query:
+
+```text
+target_node
+D_pre
+B_search
+mode
+runtime_ms
+nodes_expanded
+edges_examined
+paths_enumerated_or_aggregated
+cache_hits
+first_cache_hit_depth_from_target
+remaining_budget_at_hit
+histogram_bins_scanned
+cumulative_basis_lookups
+result_mass
+result_first_moment
+result_weighted_power
+result_entropy_if_available
+exact_result_reference
+absolute_error
+relative_error
+```
+
+Record per cache build:
+
+```text
+root
+D_pre
+eligible_nodes
+cached_nodes
+cache_bytes_raw_histogram
+cache_bytes_cumulative_bases
+build_runtime_ms
+max_support_size
+mean_support_size
+p95_support_size
+total_distribution_mass
+```
+
+Derived metrics:
+
+```text
+speedup = runtime_full_exact / runtime_cached
+work_reduction = 1 - nodes_expanded_cached / nodes_expanded_full_exact
+hit_rate = queries_with_cache_hit / total_queries
+bytes_per_ms_saved = cache_bytes / (runtime_full_exact - runtime_cached)
+marginal_speedup_per_depth = speedup(D_pre=n) - speedup(D_pre=n-1)
+```
+
+## 6. Correctness checks
+
+For exact parent-only histograms, require zero semantic error against the full
+exact oracle for all supported functionals:
+
+- reachability mass under `B_search`;
+- bounded average when mass is nonzero;
+- tail mass within the finite horizon;
+- weighted-power sum for configured `N`;
+- entropy when computed from the exact histogram.
+
+CDF and cumulative-basis modes must also match raw histogram scans exactly,
+within floating-point tolerance:
+
+```text
+mass_cdf(B) == sum_{L <= B} histogram[L]
+moment_cdf(B) == sum_{L <= B} L * histogram[L]
+weighted_power_cdf(B) == sum_{L <= B} (L + 1)^(-N) * histogram[L]
+interval_mass(B1, B2) == mass_cdf(B2) - mass_cdf(B1)
+```
+
+If any exact-cache mode differs from `full_exact`, fail the benchmark cell and
+emit the path-statistic trace needed to diagnose the mismatch.
+
+## 7. Cache admission variants
+
+After the full-cache grid is working, test admission pressure. Instead of storing
+all eligible nodes within `D_pre`, cap the cache by bytes or entries and compare:
+
+| Policy | Expected behavior |
+|--------|-------------------|
+| `store_all` | Upper-bound speedup and storage cost |
+| `overwrite_on_collision` | Baseline to demonstrate why blind overwrite loses useful root-near entries |
+| `root_proximity` | Prefer lower parent distance to root |
+| `reuse_score` | Prefer root proximity, descendant count, observed hits, and recompute cost |
+| `score_with_hysteresis` | Same as `reuse_score`, but avoids churn on close scores |
+
+The benchmark should report when a candidate loses admission but still serves the
+current query. Admission policy affects shared-cache reuse, not correctness of
+the current result.
+
+## 8. Expansion protocol
+
+Run the work in layers:
+
+1. Tiny hand-checkable DAG fixtures.
+2. SimpleWiki parent-only exact histograms.
+3. SimpleWiki cached search cutoffs over the `(D_pre, B_search)` grid.
+4. SimpleWiki cumulative-basis modes.
+5. SimpleWiki admission-pressure policies.
+6. Enwiki sampled parent-only runs.
+7. Enwiki admission-pressure runs.
+8. Fitted finite-support tails only after exact-cache behavior is stable.
+
+Do not introduce child-direction paths until parent-only exact cache semantics
+and admission policy are measured. Parent-only distributions can later bound or
+prioritize child-inclusive searches.
+
+## 9. Output artifacts
+
+Each benchmark run should emit machine-readable records and one summary table:
+
+```text
+distribution_cache_benchmark_<graph>_<timestamp>.jsonl
+distribution_cache_summary_<graph>_<timestamp>.md
+```
+
+The summary should include:
+
+- speedup vs `D_pre` for each `B_search`;
+- cache bytes vs `D_pre`;
+- hit rate vs `D_pre`;
+- marginal speedup per additional precompute depth;
+- exactness failures, if any;
+- best observed policy under a fixed storage budget.
+
+## 10. Decision criteria
+
+Use the benchmark to choose defaults:
+
+```text
+D_pre_default = smallest D_pre where marginal speedup falls below threshold
+B_search_default = largest budget where exact cache cutoffs remain tractable
+cache_policy_default = highest speedup under storage budget with no churn spike
+cumulative_basis_default = bases whose lookup savings exceed storage cost
+```
+
+Initial likely defaults:
+
+```text
+D_pre_default: 2 on SimpleWiki, remeasure for enwiki
+B_search_default: 4 or 6 for parent-only exact validation
+cumulative bases: mass first; moment(1) and weighted_power(N) only for hot functionals
+admission: root_proximity + reuse_score with hysteresis
+```
+
+These are hypotheses, not commitments. The benchmark exists to replace intuition
+with measured cutoffs.

--- a/tests/test_distribution_cache_parity.py
+++ b/tests/test_distribution_cache_parity.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Tiny parent-only distribution cache parity fixtures.
+
+These tests exercise the first slice of docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md:
+exact parent-only path histograms, cached suffix cutoffs, and cumulative-basis
+lookups on hand-checkable DAGs. They intentionally do not touch Wikipedia data
+or fitted tails.
+"""
+import math
+import unittest
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+
+ROOT = "R"
+EXPONENT = 2.0
+
+
+FIXTURES = {
+    "chain": {
+        "parents": {
+            "A": [ROOT],
+            "B": ["A"],
+            "C": ["B"],
+        },
+        "targets": [ROOT, "A", "B", "C"],
+        "known": {
+            ROOT: {0: 1},
+            "A": {1: 1},
+            "B": {2: 1},
+            "C": {3: 1},
+        },
+    },
+    "diamond": {
+        "parents": {
+            "A": [ROOT],
+            "B": [ROOT],
+            "C": ["A", "B"],
+        },
+        "targets": [ROOT, "A", "B", "C"],
+        "known": {
+            ROOT: {0: 1},
+            "A": {1: 1},
+            "B": {1: 1},
+            "C": {2: 2},
+        },
+    },
+    "shared_ancestor": {
+        "parents": {
+            "A": [ROOT],
+            "B": ["A"],
+            "C": ["A"],
+            "D": ["B", "C"],
+        },
+        "targets": [ROOT, "A", "B", "C", "D"],
+        "known": {
+            ROOT: {0: 1},
+            "A": {1: 1},
+            "B": {2: 1},
+            "C": {2: 1},
+            "D": {3: 2},
+        },
+    },
+    "shortcut_parent": {
+        "parents": {
+            "A": [ROOT],
+            "B": [ROOT, "A"],
+            "C": ["B"],
+        },
+        "targets": [ROOT, "A", "B", "C"],
+        "known": {
+            ROOT: {0: 1},
+            "A": {1: 1},
+            "B": {1: 1, 2: 1},
+            "C": {2: 1, 3: 1},
+        },
+    },
+    "disconnected": {
+        "parents": {
+            "A": [ROOT],
+            "X": ["Y"],
+            "Y": [],
+        },
+        "targets": [ROOT, "A", "X", "Y", "Z"],
+        "known": {
+            ROOT: {0: 1},
+            "A": {1: 1},
+            "X": {},
+            "Y": {},
+            "Z": {},
+        },
+    },
+}
+
+
+def add_hist(left, right):
+    out = defaultdict(int)
+    for hist in (left, right):
+        for length, count in hist.items():
+            out[length] += count
+    return dict(sorted(out.items()))
+
+
+def shift_hist(hist, step=1):
+    return {length + step: count for length, count in hist.items()}
+
+
+def truncate_hist(hist, budget):
+    return {length: count for length, count in hist.items() if length <= budget}
+
+
+def exact_histogram(node, parents, root=ROOT, memo=None, visiting=None):
+    """Exact parent-only path-length histogram from node to root on a DAG."""
+    if memo is None:
+        memo = {}
+    if visiting is None:
+        visiting = set()
+    if node in memo:
+        return memo[node]
+    if node == root:
+        memo[node] = {0: 1}
+        return memo[node]
+    if node in visiting:
+        raise ValueError(f"cycle detected at {node}")
+    visiting.add(node)
+    out = {}
+    for parent in parents.get(node, []):
+        out = add_hist(out, shift_hist(exact_histogram(parent, parents, root, memo, visiting)))
+    visiting.remove(node)
+    memo[node] = out
+    return out
+
+
+def full_exact_bounded(node, parents, budget, root=ROOT):
+    return truncate_hist(exact_histogram(node, parents, root), budget)
+
+
+def min_parent_distance(node, parents, root=ROOT, memo=None, visiting=None):
+    if memo is None:
+        memo = {}
+    if visiting is None:
+        visiting = set()
+    if node in memo:
+        return memo[node]
+    if node == root:
+        memo[node] = 0
+        return 0
+    if node in visiting:
+        return math.inf
+    visiting.add(node)
+    distances = [min_parent_distance(p, parents, root, memo, visiting) for p in parents.get(node, [])]
+    visiting.remove(node)
+    best = min(distances, default=math.inf)
+    memo[node] = math.inf if best == math.inf else best + 1
+    return memo[node]
+
+
+def all_nodes(parents, root=ROOT):
+    nodes = {root}
+    for child, ps in parents.items():
+        nodes.add(child)
+        nodes.update(ps)
+    return nodes
+
+
+def build_cache(parents, precompute_depth, root=ROOT):
+    cache = {}
+    distance_memo = {}
+    hist_memo = {}
+    for node in all_nodes(parents, root):
+        if min_parent_distance(node, parents, root, distance_memo) <= precompute_depth:
+            cache[node] = exact_histogram(node, parents, root, hist_memo)
+    return cache
+
+
+@dataclass
+class SearchStats:
+    nodes_expanded: int = 0
+    cache_hits: int = 0
+    histogram_bins_scanned: int = 0
+    cumulative_basis_lookups: int = 0
+    hit_remaining_budgets: list = field(default_factory=list)
+
+
+def cached_histogram_search(node, parents, budget, cache, root=ROOT, stats=None):
+    if budget < 0:
+        return {}
+    if stats is None:
+        stats = SearchStats()
+    if node in cache:
+        stats.cache_hits += 1
+        stats.hit_remaining_budgets.append(budget)
+        stats.histogram_bins_scanned += len(cache[node])
+        return truncate_hist(cache[node], budget)
+    stats.nodes_expanded += 1
+    if node == root:
+        return {0: 1}
+    out = {}
+    for parent in parents.get(node, []):
+        out = add_hist(out, shift_hist(cached_histogram_search(parent, parents, budget - 1, cache, root, stats)))
+    return truncate_hist(out, budget)
+
+
+def mass_cdf(hist, budget):
+    return sum(count for length, count in hist.items() if length <= budget)
+
+
+def first_moment_cdf(hist, budget):
+    return sum(length * count for length, count in hist.items() if length <= budget)
+
+
+def weighted_power_cdf(hist, budget, exponent=EXPONENT):
+    return sum(((length + 1) ** (-exponent)) * count for length, count in hist.items() if length <= budget)
+
+
+def interval_mass(hist, low_exclusive, high_inclusive):
+    return mass_cdf(hist, high_inclusive) - mass_cdf(hist, low_exclusive)
+
+
+def entropy(hist, budget):
+    bounded = truncate_hist(hist, budget)
+    total = sum(bounded.values())
+    if total == 0:
+        return 0.0
+    return -sum((count / total) * math.log(count / total) for count in bounded.values())
+
+
+class ParentDistributionCacheParityTests(unittest.TestCase):
+    def test_exact_histograms_match_hand_checked_fixtures(self):
+        for fixture_name, fixture in FIXTURES.items():
+            parents = fixture["parents"]
+            with self.subTest(fixture=fixture_name):
+                for node, expected in fixture["known"].items():
+                    self.assertEqual(exact_histogram(node, parents), expected)
+
+    def test_cached_cutoff_matches_full_exact_for_depth_budget_grid(self):
+        for fixture_name, fixture in FIXTURES.items():
+            parents = fixture["parents"]
+            for precompute_depth in range(0, 4):
+                cache = build_cache(parents, precompute_depth)
+                for budget in range(0, 6):
+                    for target in fixture["targets"]:
+                        with self.subTest(fixture=fixture_name, d_pre=precompute_depth, budget=budget, target=target):
+                            stats = SearchStats()
+                            cached = cached_histogram_search(target, parents, budget, cache, stats=stats)
+                            exact = full_exact_bounded(target, parents, budget)
+                            self.assertEqual(cached, exact)
+
+    def test_cached_search_records_suffix_cache_hits(self):
+        parents = FIXTURES["diamond"]["parents"]
+        cache = build_cache(parents, precompute_depth=1)
+        stats = SearchStats()
+        got = cached_histogram_search("C", parents, budget=2, cache=cache, stats=stats)
+        self.assertEqual(got, {2: 2})
+        self.assertEqual(stats.cache_hits, 2)
+        self.assertEqual(stats.hit_remaining_budgets, [1, 1])
+        self.assertEqual(stats.nodes_expanded, 1)
+
+    def test_cumulative_bases_match_raw_histogram_scans(self):
+        for fixture_name, fixture in FIXTURES.items():
+            parents = fixture["parents"]
+            for target in fixture["targets"]:
+                hist = exact_histogram(target, parents)
+                total_budget = max(hist.keys(), default=0) + 2
+                for budget in range(0, total_budget + 1):
+                    with self.subTest(fixture=fixture_name, target=target, budget=budget):
+                        bounded = truncate_hist(hist, budget)
+                        self.assertEqual(mass_cdf(hist, budget), sum(bounded.values()))
+                        self.assertEqual(first_moment_cdf(hist, budget), sum(k * v for k, v in bounded.items()))
+                        self.assertAlmostEqual(
+                            weighted_power_cdf(hist, budget),
+                            sum(((k + 1) ** (-EXPONENT)) * v for k, v in bounded.items()),
+                            places=12,
+                        )
+                        if budget > 0:
+                            self.assertEqual(
+                                interval_mass(hist, budget - 1, budget),
+                                hist.get(budget, 0),
+                            )
+
+    def test_functionals_are_equal_for_cached_and_full_exact_results(self):
+        parents = FIXTURES["shortcut_parent"]["parents"]
+        cache = build_cache(parents, precompute_depth=1)
+        budget = 3
+        exact = full_exact_bounded("C", parents, budget)
+        cached = cached_histogram_search("C", parents, budget, cache)
+        self.assertEqual(cached, exact)
+        self.assertEqual(mass_cdf(cached, budget), 2)
+        self.assertEqual(first_moment_cdf(cached, budget), 5)
+        self.assertAlmostEqual(weighted_power_cdf(cached, budget), (3 ** -2) + (4 ** -2), places=12)
+        self.assertAlmostEqual(entropy(cached, budget), math.log(2), places=12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds documentation for the next phase of distribution-cache benchmarking.

### Changes
- Adds a future-directions section to `DISTRIBUTION_CACHE_BENCHMARK_PLAN.md`.
- Documents scalar `L_min` / `L_max` parent-path support bounds as a possible cheap pre-pass before full distribution construction.
- Frames fitted finite-support approximations as a later benchmark phase after exact cache semantics are stable.
- Clarifies that the first benchmark requirement remains exact parity between full enumeration, cached exact histograms, and cumulative bases.

### Notes
This PR does not change runtime behavior. It only updates design documentation.