### PR TITLE
Add Go WAM put_char/1 and put_code/1 builtins

### DIFF
--- a/PR_go_wam_put_char_code.md
+++ b/PR_go_wam_put_char_code.md
@@ -1,0 +1,23 @@
+# PR Title
+
+Add Go WAM put_char/1 and put_code/1 builtins
+
+# PR Description
+
+## Summary
+
+- Adds direct Go WAM lowering for `put_char/1` and `put_code/1`.
+- Implements runtime stdout dispatch for single-character atom output and integer character-code output.
+- Extends the generated Go WAM builtin E2E test to cover successful output plus invalid argument failure.
+- Updates the Go WAM parity audit to record the new Python/C++/LLVM single-character output parity slice.
+
+## Tests
+
+```sh
+swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
+```

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -21,7 +21,7 @@ current cross-target builtin/runtime baseline.
 | Univ | `=../2` compose/decompose | `=../2` compose/decompose | Present |
 | Copying | `copy_term/2` with fresh variables and preserved sharing | `copy_term/2` with fresh variables and preserved sharing | Present |
 | Control | `true/0`, `fail/0`, `!/0`, `\+/1`, `CutIte` | Same baseline, with broader isolated-goal NAF in Haskell/Python | Present for current baseline, including isolated user-goal NAF and race-to-true over multi-clause WAM targets |
-| IO | `write/1`, `display/1`, `writeln/1`, `print/1`, `write_canonical/1`, `format/1`, `format/2`, `nl/0`, `tab/1`, `getenv/2`, `setenv/2` | `write/1`, `display/1`, `nl/0`; Python/C++ also cover `write_canonical/1`; R/C++/Python also cover `format/N`; R/C++ also cover `writeln/1`, `print/1`, and `tab/1`; LLVM covers `getenv/2` and `setenv/2` | Present for current baseline plus simple output aliases, bounded canonical output, bounded format output, tab output, and bounded environment access |
+| IO | `write/1`, `display/1`, `writeln/1`, `print/1`, `write_canonical/1`, `put_char/1`, `put_code/1`, `format/1`, `format/2`, `nl/0`, `tab/1`, `getenv/2`, `setenv/2` | `write/1`, `display/1`, `nl/0`; Python/C++ also cover `write_canonical/1`; Python/C++/LLVM also cover `put_char/1` and `put_code/1`; R/C++/Python also cover `format/N`; R/C++ also cover `writeln/1`, `print/1`, and `tab/1`; LLVM covers `getenv/2` and `setenv/2` | Present for current baseline plus simple output aliases, bounded canonical output, single-character output, bounded format output, tab output, and bounded environment access |
 
 ## Immediate Findings
 
@@ -68,6 +68,10 @@ current cross-target builtin/runtime baseline.
   the generated builtin E2E test for quoted atoms, proper lists, and compound
   terms, matching the Python/C++ canonical-output surface without adding
   stream capture.
+- Single-character output builtins `put_char/1` and `put_code/1` are now direct
+  Go WAM builtins and are covered by the generated builtin E2E test for stdout
+  emission plus invalid argument failure, matching the bounded Python/C++/LLVM
+  single-character output surface without adding stream-aware variants.
 - Bounded `format/1` and `format/2` are now direct Go WAM builtins and are
   covered by the generated builtin E2E test for literal `~~`, newline `~n`,
   `~w`, `~a`, `~d`, `~p`, `~q`, and `~s` argument substitution, and

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -558,6 +558,12 @@ wam_go_direct_builtin("print/1", 1, 'print/1').
 wam_go_direct_builtin(write_canonical/1, 1, 'write_canonical/1').
 wam_go_direct_builtin('write_canonical/1', 1, 'write_canonical/1').
 wam_go_direct_builtin("write_canonical/1", 1, 'write_canonical/1').
+wam_go_direct_builtin(put_char/1, 1, 'put_char/1').
+wam_go_direct_builtin('put_char/1', 1, 'put_char/1').
+wam_go_direct_builtin("put_char/1", 1, 'put_char/1').
+wam_go_direct_builtin(put_code/1, 1, 'put_code/1').
+wam_go_direct_builtin('put_code/1', 1, 'put_code/1').
+wam_go_direct_builtin("put_code/1", 1, 'put_code/1').
 wam_go_direct_builtin(format/1, 1, 'format/1').
 wam_go_direct_builtin('format/1', 1, 'format/1').
 wam_go_direct_builtin("format/1", 1, 'format/1').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -987,6 +987,25 @@ func (vm *WamState) formatStringDirective(value Value) (string, bool) {
 	return b.String(), true
 }
 
+func outputAtomCharText(value Value) (string, bool) {
+	atom, ok := value.(*Atom)
+	if !ok {
+		return "", false
+	}
+	if len([]rune(atom.Name)) != 1 {
+		return "", false
+	}
+	return atom.Name, true
+}
+
+func outputCodeText(value Value) (string, bool) {
+	integer, ok := value.(*Integer)
+	if !ok || integer.Val < 0 || integer.Val > int64(unicode.MaxRune) {
+		return "", false
+	}
+	return string(rune(integer.Val)), true
+}
+
 func (vm *WamState) canonicalTermString(value Value) string {
 	value = vm.deref(value)
 	if isEmptyListValue(value) {
@@ -1524,6 +1543,20 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 		return true
 	case "write_canonical/1":
 		fmt.Print(vm.canonicalTermString(arg1))
+		return true
+	case "put_char/1":
+		text, ok := outputAtomCharText(vm.deref(arg1))
+		if !ok {
+			return false
+		}
+		fmt.Print(text)
+		return true
+	case "put_code/1":
+		text, ok := outputCodeText(vm.deref(arg1))
+		if !ok {
+			return false
+		}
+		fmt.Print(text)
 		return true
 	case "writeln/1":
 		fmt.Println(vm.deref(arg1).String())

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -689,7 +689,13 @@ test(builtins_execution) :-
                 write_canonical([a, 'two words', 42]),
                 nl,
                 write_canonical(pair('two words', 7)),
-                nl
+                nl,
+                put_char(g),
+                put_code(111),
+                nl,
+                \+ put_char(go),
+                \+ put_code(-1),
+                \+ put_code(1114112)
             )),
           assertz(user:test_format_builtin :-
             (   format('fmt_one ~~ ok~n'),
@@ -840,6 +846,8 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "writeln/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "print/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "write_canonical/1"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "put_char/1"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "put_code/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "format/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "format/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "succ/2"')),
@@ -1308,6 +1316,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "'Hello World'")),
         assertion(sub_string(FullOutput, _, _, _, "[a, 'two words', 42]")),
         assertion(sub_string(FullOutput, _, _, _, "pair('two words', 7)")),
+        assertion(sub_string(FullOutput, _, _, _, "pair('two words', 7)\ngo\n")),
         assertion(sub_string(FullOutput, _, _, _, "fmt_one ~ ok")),
         assertion(sub_string(FullOutput, _, _, _, "fmt_two go 42~")),
         assertion(sub_string(FullOutput, _, _, _, "fmt_more atom_arg 17 pair/2/2 quoted_atom")),


### PR DESCRIPTION
## Summary

- Adds direct Go WAM lowering for `put_char/1` and `put_code/1`.
- Implements runtime stdout dispatch for single-character atom output and integer character-code output.
- Extends the generated Go WAM builtin E2E test to cover successful output plus invalid argument failure.
- Updates the Go WAM parity audit to record the new Python/C++/LLVM single-character output parity slice.

## Tests

```sh
swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
```
