### PR TITLE
Add distribution cache benchmark runner

### DIFF
--- a/docs/reports/distribution_cache_benchmark_runner_2026-06-10.md
+++ b/docs/reports/distribution_cache_benchmark_runner_2026-06-10.md
@@ -1,0 +1,59 @@
+# Distribution Cache Benchmark Runner Smoke Report
+
+Date: 2026-06-10
+
+Branch: `codex/distribution-cache-benchmark-runner`
+
+## Scope
+
+This smoke report covers the first executable slice of
+`docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md`: tiny parent-only DAG
+fixtures, exact full search, exact cached histogram cutoffs, and benchmark
+summary output.
+
+The run does not cover SimpleWiki, enwiki, child-direction paths, admission
+pressure, or fitted distribution tails.
+
+## Unit Tests
+
+Command:
+
+```text
+python3 -m unittest tests/test_distribution_cache_parity.py tests/test_distribution_cache_benchmark.py
+```
+
+Result:
+
+```text
+.......
+----------------------------------------------------------------------
+Ran 7 tests in 0.012s
+
+OK
+```
+
+## CLI Smoke Run
+
+Command:
+
+```text
+python3 scripts/distribution_cache_benchmark.py --fixtures diamond --precompute-depths 0,1 --budgets 2 --output-dir /mnt/c/Users/johnc/Scratch/distribution-cache-benchmark --fail-on-error
+```
+
+Summary:
+
+| fixture | D_pre | B_search | cache_nodes | cache_bytes | full_ms | cached_ms | speedup | hit_rate | exact_failures |
+|---------|-------|----------|-------------|-------------|---------|-----------|---------|----------|----------------|
+| diamond | 0 | 2 | 1 | 566 | 0.023077 | 0.021932 | 1.052 | 1.000 | 0 |
+| diamond | 1 | 2 | 3 | 1242 | 0.019335 | 0.009459 | 2.044 | 1.000 | 0 |
+
+The CLI emitted JSONL and markdown artifacts under:
+
+```text
+/mnt/c/Users/johnc/Scratch/distribution-cache-benchmark
+```
+
+## Result
+
+Cached histogram mode matched full exact search for the tested fixture grid.
+The smoke run reported zero exactness failures.

--- a/scripts/distribution_cache_benchmark.py
+++ b/scripts/distribution_cache_benchmark.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Benchmark exact parent-only distribution cache cutoffs on tiny fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.distribution_cache_support import (  # noqa: E402
+    EXPONENT,
+    FIXTURES,
+    SearchStats,
+    build_cache,
+    cache_bytes,
+    cached_histogram_search,
+    entropy,
+    first_moment_cdf,
+    full_exact_search,
+    histogram_bytes,
+    mass_cdf,
+    support_sizes,
+    weighted_power_cdf,
+)
+
+
+DEFAULT_DEPTHS = [0, 1, 2, 3]
+DEFAULT_BUDGETS = [2, 4, 6]
+
+
+def parse_int_list(text: str) -> list[int]:
+    values: list[int] = []
+    for part in text.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            lo_text, hi_text = part.split("-", 1)
+            lo = int(lo_text)
+            hi = int(hi_text)
+            step = 1 if hi >= lo else -1
+            values.extend(range(lo, hi + step, step))
+        else:
+            values.append(int(part))
+    return values
+
+
+def timed_call(fn, *args, **kwargs):
+    started = time.perf_counter_ns()
+    result = fn(*args, **kwargs)
+    elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+    return result, elapsed_ms
+
+
+def percentile(values: list[int], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, round((pct / 100) * (len(ordered) - 1))))
+    return float(ordered[index])
+
+
+def histogram_record(hist, budget):
+    mass = mass_cdf(hist, budget)
+    return {
+        "result_histogram": hist,
+        "result_mass": mass,
+        "result_first_moment": first_moment_cdf(hist, budget),
+        "result_weighted_power": weighted_power_cdf(hist, budget, EXPONENT),
+        "result_entropy_if_available": entropy(hist, budget),
+    }
+
+
+def query_record(fixture_name, precompute_depth, budget, target, mode, hist, runtime_ms, stats, exact_hist):
+    exact_mass = mass_cdf(exact_hist, budget)
+    result_mass = mass_cdf(hist, budget)
+    absolute_error = abs(result_mass - exact_mass)
+    relative_error = 0.0 if exact_mass == 0 else absolute_error / exact_mass
+    return {
+        "record_type": "query",
+        "graph": "tiny_fixture",
+        "fixture": fixture_name,
+        "target_node": target,
+        "D_pre": precompute_depth,
+        "B_search": budget,
+        "mode": mode,
+        "runtime_ms": runtime_ms,
+        "nodes_expanded": stats.nodes_expanded,
+        "edges_examined": stats.edges_examined,
+        "paths_enumerated_or_aggregated": result_mass,
+        "cache_hits": stats.cache_hits,
+        "first_cache_hit_depth_from_target": min(stats.hit_depths_from_target, default=None),
+        "remaining_budget_at_hit": list(stats.hit_remaining_budgets),
+        "histogram_bins_scanned": stats.histogram_bins_scanned,
+        "cumulative_basis_lookups": stats.cumulative_basis_lookups,
+        "exact_result_reference": exact_hist,
+        "absolute_error": absolute_error,
+        "relative_error": relative_error,
+        "histogram_exact_match": hist == exact_hist,
+        **histogram_record(hist, budget),
+    }
+
+
+def cache_record(fixture_name, precompute_depth, cache, build_runtime_ms):
+    sizes = support_sizes(cache)
+    total_mass = sum(sum(hist.values()) for hist in cache.values())
+    raw_hist_bytes = sum(histogram_bytes(hist) for hist in cache.values())
+    return {
+        "record_type": "cache_build",
+        "graph": "tiny_fixture",
+        "fixture": fixture_name,
+        "root": "R",
+        "D_pre": precompute_depth,
+        "eligible_nodes": len(cache),
+        "cached_nodes": len(cache),
+        "cache_bytes_raw_histogram": raw_hist_bytes,
+        "cache_bytes_cumulative_bases": 0,
+        "cache_bytes_total_estimate": cache_bytes(cache),
+        "build_runtime_ms": build_runtime_ms,
+        "max_support_size": max(sizes, default=0),
+        "mean_support_size": statistics.mean(sizes) if sizes else 0.0,
+        "p95_support_size": percentile(sizes, 95),
+        "total_distribution_mass": total_mass,
+    }
+
+
+def run_fixture_benchmark(fixture_name, fixture, depths, budgets):
+    parents = fixture["parents"]
+    targets = fixture["targets"]
+    records = []
+    for precompute_depth in depths:
+        cache, build_runtime_ms = timed_call(build_cache, parents, precompute_depth)
+        records.append(cache_record(fixture_name, precompute_depth, cache, build_runtime_ms))
+        for budget in budgets:
+            for target in targets:
+                full_stats = SearchStats()
+                full_hist, full_runtime_ms = timed_call(full_exact_search, target, parents, budget, stats=full_stats)
+                records.append(
+                    query_record(
+                        fixture_name,
+                        precompute_depth,
+                        budget,
+                        target,
+                        "full_exact",
+                        full_hist,
+                        full_runtime_ms,
+                        full_stats,
+                        full_hist,
+                    )
+                )
+
+                cached_stats = SearchStats()
+                cached_hist, cached_runtime_ms = timed_call(
+                    cached_histogram_search,
+                    target,
+                    parents,
+                    budget,
+                    cache,
+                    stats=cached_stats,
+                )
+                records.append(
+                    query_record(
+                        fixture_name,
+                        precompute_depth,
+                        budget,
+                        target,
+                        "cached_histogram",
+                        cached_hist,
+                        cached_runtime_ms,
+                        cached_stats,
+                        full_hist,
+                    )
+                )
+    return records
+
+
+def summarize(records):
+    query_records = [r for r in records if r["record_type"] == "query"]
+    cache_records = [r for r in records if r["record_type"] == "cache_build"]
+    cache_by_key = {(r["fixture"], r["D_pre"]): r for r in cache_records}
+    groups = {}
+    for record in query_records:
+        key = (record["fixture"], record["D_pre"], record["B_search"])
+        groups.setdefault(key, []).append(record)
+
+    lines = [
+        "# Distribution Cache Benchmark Summary",
+        "",
+        "| fixture | D_pre | B_search | cache_nodes | cache_bytes | full_ms | cached_ms | speedup | hit_rate | exact_failures |",
+        "|---------|-------|----------|-------------|-------------|---------|-----------|---------|----------|----------------|",
+    ]
+    for key in sorted(groups):
+        fixture, precompute_depth, budget = key
+        rows = groups[key]
+        full_rows = [r for r in rows if r["mode"] == "full_exact"]
+        cached_rows = [r for r in rows if r["mode"] == "cached_histogram"]
+        full_ms = sum(r["runtime_ms"] for r in full_rows)
+        cached_ms = sum(r["runtime_ms"] for r in cached_rows)
+        speedup = 0.0 if cached_ms == 0 else full_ms / cached_ms
+        hit_rate = 0.0 if not cached_rows else sum(1 for r in cached_rows if r["cache_hits"] > 0) / len(cached_rows)
+        failures = sum(1 for r in cached_rows if not r["histogram_exact_match"])
+        cache = cache_by_key[(fixture, precompute_depth)]
+        lines.append(
+            "| {fixture} | {depth} | {budget} | {nodes} | {bytes} | {full:.6f} | {cached:.6f} | {speedup:.3f} | {hit_rate:.3f} | {failures} |".format(
+                fixture=fixture,
+                depth=precompute_depth,
+                budget=budget,
+                nodes=cache["cached_nodes"],
+                bytes=cache["cache_bytes_total_estimate"],
+                full=full_ms,
+                cached=cached_ms,
+                speedup=speedup,
+                hit_rate=hit_rate,
+                failures=failures,
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(records, summary, output_dir, graph_name):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    jsonl_path = output_dir / f"distribution_cache_benchmark_{graph_name}_{timestamp}.jsonl"
+    summary_path = output_dir / f"distribution_cache_summary_{graph_name}_{timestamp}.md"
+    with jsonl_path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+    summary_path.write_text(summary, encoding="utf-8")
+    return jsonl_path, summary_path
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixtures", default="all", help="Comma-separated fixture names or 'all'.")
+    parser.add_argument("--precompute-depths", default=",".join(map(str, DEFAULT_DEPTHS)))
+    parser.add_argument("--budgets", default=",".join(map(str, DEFAULT_BUDGETS)))
+    parser.add_argument("--output-dir", type=Path, help="Optional directory for JSONL and markdown output.")
+    parser.add_argument("--fail-on-error", action="store_true", help="Exit nonzero if cached histograms differ.")
+    args = parser.parse_args(argv)
+
+    fixture_names = sorted(FIXTURES) if args.fixtures == "all" else [name.strip() for name in args.fixtures.split(",")]
+    depths = parse_int_list(args.precompute_depths)
+    budgets = parse_int_list(args.budgets)
+
+    records = []
+    for fixture_name in fixture_names:
+        if fixture_name not in FIXTURES:
+            raise SystemExit(f"unknown fixture: {fixture_name}")
+        records.extend(run_fixture_benchmark(fixture_name, FIXTURES[fixture_name], depths, budgets))
+
+    summary = summarize(records)
+    print(summary, end="")
+    if args.output_dir:
+        jsonl_path, summary_path = write_outputs(records, summary, args.output_dir, "tiny_fixture")
+        print(f"\nwrote {jsonl_path}")
+        print(f"wrote {summary_path}")
+
+    failures = [r for r in records if r.get("record_type") == "query" and not r.get("histogram_exact_match", True)]
+    if failures and args.fail_on_error:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_distribution_cache_benchmark.py
+++ b/tests/test_distribution_cache_benchmark.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Smoke tests for the distribution cache benchmark runner."""
+
+import unittest
+
+from scripts.distribution_cache_benchmark import run_fixture_benchmark, summarize
+from tools.distribution_cache_support import FIXTURES
+
+
+class DistributionCacheBenchmarkTests(unittest.TestCase):
+    def test_tiny_fixture_benchmark_records_exact_cached_parity(self):
+        records = run_fixture_benchmark("diamond", FIXTURES["diamond"], depths=[0, 1], budgets=[2])
+        query_records = [record for record in records if record["record_type"] == "query"]
+        cache_records = [record for record in records if record["record_type"] == "cache_build"]
+
+        self.assertEqual(len(cache_records), 2)
+        self.assertTrue(query_records)
+        self.assertTrue(all(record["histogram_exact_match"] for record in query_records))
+        self.assertTrue(any(record["mode"] == "cached_histogram" and record["cache_hits"] > 0 for record in query_records))
+
+    def test_summary_reports_grid_cells_and_exact_failures(self):
+        records = run_fixture_benchmark("shortcut_parent", FIXTURES["shortcut_parent"], depths=[0, 1], budgets=[2, 4])
+        summary = summarize(records)
+
+        self.assertIn("| fixture | D_pre | B_search |", summary)
+        self.assertIn("shortcut_parent", summary)
+        self.assertIn("| 0 |", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/distribution_cache_support.py
+++ b/tools/distribution_cache_support.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Shared parent-only distribution cache fixtures and exact semantics."""
+
+from __future__ import annotations
+
+import math
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+
+ROOT = "R"
+EXPONENT = 2.0
+
+
+FIXTURES = {
+    "chain": {
+        "parents": {
+            "A": [ROOT],
+            "B": ["A"],
+            "C": ["B"],
+        },
+        "targets": [ROOT, "A", "B", "C"],
+        "known": {
+            ROOT: {0: 1},
+            "A": {1: 1},
+            "B": {2: 1},
+            "C": {3: 1},
+        },
+    },
+    "diamond": {
+        "parents": {
+            "A": [ROOT],
+            "B": [ROOT],
+            "C": ["A", "B"],
+        },
+        "targets": [ROOT, "A", "B", "C"],
+        "known": {
+            ROOT: {0: 1},
+            "A": {1: 1},
+            "B": {1: 1},
+            "C": {2: 2},
+        },
+    },
+    "shared_ancestor": {
+        "parents": {
+            "A": [ROOT],
+            "B": ["A"],
+            "C": ["A"],
+            "D": ["B", "C"],
+        },
+        "targets": [ROOT, "A", "B", "C", "D"],
+        "known": {
+            ROOT: {0: 1},
+            "A": {1: 1},
+            "B": {2: 1},
+            "C": {2: 1},
+            "D": {3: 2},
+        },
+    },
+    "shortcut_parent": {
+        "parents": {
+            "A": [ROOT],
+            "B": [ROOT, "A"],
+            "C": ["B"],
+        },
+        "targets": [ROOT, "A", "B", "C"],
+        "known": {
+            ROOT: {0: 1},
+            "A": {1: 1},
+            "B": {1: 1, 2: 1},
+            "C": {2: 1, 3: 1},
+        },
+    },
+    "disconnected": {
+        "parents": {
+            "A": [ROOT],
+            "X": ["Y"],
+            "Y": [],
+        },
+        "targets": [ROOT, "A", "X", "Y", "Z"],
+        "known": {
+            ROOT: {0: 1},
+            "A": {1: 1},
+            "X": {},
+            "Y": {},
+            "Z": {},
+        },
+    },
+}
+
+
+@dataclass
+class SearchStats:
+    nodes_expanded: int = 0
+    edges_examined: int = 0
+    cache_hits: int = 0
+    histogram_bins_scanned: int = 0
+    cumulative_basis_lookups: int = 0
+    hit_remaining_budgets: list[int] = field(default_factory=list)
+    hit_depths_from_target: list[int] = field(default_factory=list)
+
+
+def add_hist(left, right):
+    out = defaultdict(int)
+    for hist in (left, right):
+        for length, count in hist.items():
+            out[length] += count
+    return dict(sorted(out.items()))
+
+
+def shift_hist(hist, step=1):
+    return {length + step: count for length, count in hist.items()}
+
+
+def truncate_hist(hist, budget):
+    return {length: count for length, count in hist.items() if length <= budget}
+
+
+def exact_histogram(node, parents, root=ROOT, memo=None, visiting=None):
+    """Exact unbounded parent-only path-length histogram from node to root."""
+    if memo is None:
+        memo = {}
+    if visiting is None:
+        visiting = set()
+    if node in memo:
+        return memo[node]
+    if node == root:
+        memo[node] = {0: 1}
+        return memo[node]
+    if node in visiting:
+        raise ValueError(f"cycle detected at {node}")
+    visiting.add(node)
+    out = {}
+    for parent in parents.get(node, []):
+        out = add_hist(out, shift_hist(exact_histogram(parent, parents, root, memo, visiting)))
+    visiting.remove(node)
+    memo[node] = out
+    return out
+
+
+def full_exact_bounded(node, parents, budget, root=ROOT):
+    return truncate_hist(exact_histogram(node, parents, root), budget)
+
+
+def full_exact_search(node, parents, budget, root=ROOT, stats=None):
+    """Budgeted parent-only search with no distribution cache."""
+    if budget < 0:
+        return {}
+    if stats is None:
+        stats = SearchStats()
+    stats.nodes_expanded += 1
+    if node == root:
+        return {0: 1}
+    if budget == 0:
+        return {}
+    out = {}
+    for parent in parents.get(node, []):
+        stats.edges_examined += 1
+        out = add_hist(out, shift_hist(full_exact_search(parent, parents, budget - 1, root, stats)))
+    return truncate_hist(out, budget)
+
+
+def min_parent_distance(node, parents, root=ROOT, memo=None, visiting=None):
+    if memo is None:
+        memo = {}
+    if visiting is None:
+        visiting = set()
+    if node in memo:
+        return memo[node]
+    if node == root:
+        memo[node] = 0
+        return 0
+    if node in visiting:
+        return math.inf
+    visiting.add(node)
+    distances = [min_parent_distance(p, parents, root, memo, visiting) for p in parents.get(node, [])]
+    visiting.remove(node)
+    best = min(distances, default=math.inf)
+    memo[node] = math.inf if best == math.inf else best + 1
+    return memo[node]
+
+
+def all_nodes(parents, root=ROOT):
+    nodes = {root}
+    for child, ps in parents.items():
+        nodes.add(child)
+        nodes.update(ps)
+    return nodes
+
+
+def build_cache(parents, precompute_depth, root=ROOT):
+    cache = {}
+    distance_memo = {}
+    hist_memo = {}
+    for node in sorted(all_nodes(parents, root)):
+        if min_parent_distance(node, parents, root, distance_memo) <= precompute_depth:
+            cache[node] = exact_histogram(node, parents, root, hist_memo)
+    return cache
+
+
+def cached_histogram_search(node, parents, budget, cache, root=ROOT, stats=None, depth_from_target=0):
+    if budget < 0:
+        return {}
+    if stats is None:
+        stats = SearchStats()
+    if node in cache:
+        stats.cache_hits += 1
+        stats.hit_remaining_budgets.append(budget)
+        stats.hit_depths_from_target.append(depth_from_target)
+        stats.histogram_bins_scanned += len(cache[node])
+        return truncate_hist(cache[node], budget)
+    stats.nodes_expanded += 1
+    if node == root:
+        return {0: 1}
+    if budget == 0:
+        return {}
+    out = {}
+    for parent in parents.get(node, []):
+        stats.edges_examined += 1
+        out = add_hist(
+            out,
+            shift_hist(
+                cached_histogram_search(parent, parents, budget - 1, cache, root, stats, depth_from_target + 1)
+            ),
+        )
+    return truncate_hist(out, budget)
+
+
+def mass_cdf(hist, budget):
+    return sum(count for length, count in hist.items() if length <= budget)
+
+
+def first_moment_cdf(hist, budget):
+    return sum(length * count for length, count in hist.items() if length <= budget)
+
+
+def weighted_power_cdf(hist, budget, exponent=EXPONENT):
+    return sum(((length + 1) ** (-exponent)) * count for length, count in hist.items() if length <= budget)
+
+
+def interval_mass(hist, low_exclusive, high_inclusive):
+    return mass_cdf(hist, high_inclusive) - mass_cdf(hist, low_exclusive)
+
+
+def entropy(hist, budget):
+    bounded = truncate_hist(hist, budget)
+    total = sum(bounded.values())
+    if total == 0:
+        return 0.0
+    return -sum((count / total) * math.log(count / total) for count in bounded.values())
+
+
+def histogram_bytes(hist):
+    return sys.getsizeof(hist) + sum(sys.getsizeof(length) + sys.getsizeof(count) for length, count in hist.items())
+
+
+def cache_bytes(cache):
+    return sys.getsizeof(cache) + sum(sys.getsizeof(node) + histogram_bytes(hist) for node, hist in cache.items())
+
+
+def support_sizes(cache):
+    return [len(hist) for hist in cache.values()]


### PR DESCRIPTION
Adds the first executable benchmark slice for exact parent-only distribution cache evaluation.

### Changes
- Adds shared parent-only DAG fixture/cache/search semantics in `tools/distribution_cache_support.py`.
- Adds `scripts/distribution_cache_benchmark.py` to run tiny-fixture `(D_pre, B_search)` benchmark grids.
- Adds runner smoke tests in `tests/test_distribution_cache_benchmark.py`.
- Adds a tracked smoke report in `docs/reports/distribution_cache_benchmark_runner_2026-06-10.md`.

### Verification
- `python3 -m unittest tests/test_distribution_cache_parity.py tests/test_distribution_cache_benchmark.py`
- CLI smoke run on the `diamond` fixture with zero exactness failures.

### Notes
This is intentionally limited to tiny exact parent-only fixtures. It does not yet cover SimpleWiki/enwiki ingestion, child-direction paths, cache admission pressure, or fitted distribution tails.