### PR TITLE
test: add file-backed distribution cache benchmark inputs

### DIFF
--- a/docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md
+++ b/docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md
@@ -35,9 +35,19 @@ The main curve is marginal speedup per cached byte or per cached node.
 Start with the simplest semantics:
 
 - graph: SimpleWiki category graph first, enwiki later;
-- root: `Category:Main_topic_classifications` or the canonical root used by the
-  existing tree-likeness fixtures;
-- edge direction: parent-only paths toward the root;
+- SimpleWiki subtree root: `Category:Articles`;
+- enwiki-oriented root: `Category:Main_topic_classifications`, or the canonical
+  root used by the existing tree-likeness fixtures;
+- broader category roots: `Category:Container_categories` and
+  `Category:Categories` need filtering before benchmark use because they include
+  massive container/admin/template regions;
+- individual container categories can still be valid subtree roots, but
+  `Category:Container_categories` itself should be treated as a high-branching
+  registry outlier rather than part of the same global branch-factor population;
+- edge direction: parent-only paths toward the selected benchmark root;
+- avoid mixing content and admin/container regions in one benchmark population;
+  once admin categories enter the sample, branch-factor and support-width
+  statistics are no longer globally homogeneous;
 - path statistic: hop count `L`;
 - distribution representation: exact histogram, plus optional exact cumulative
   bases derived from that histogram;

--- a/docs/reports/distribution_cache_file_inputs_2026-06-10.md
+++ b/docs/reports/distribution_cache_file_inputs_2026-06-10.md
@@ -1,0 +1,74 @@
+# Distribution Cache File Input Smoke Report
+
+Date: 2026-06-10
+
+Branch: `codex/distribution-cache-file-inputs`
+
+## Scope
+
+This report covers the first file-backed benchmark input path for
+`scripts/distribution_cache_benchmark.py`.
+
+The benchmark now accepts a TSV edge list with `child<TAB>parent` rows and can
+select shallow reachable targets from a configurable benchmark root. The
+checked-in sample uses `Category:Articles` as a SimpleWiki content-subtree root.
+
+`Category:Articles` is not the universal root of all SimpleWiki categories. It
+is a useful content subtree for early statistics. Broader roots such as
+`Category:Categories` and `Category:Container_categories` require filtering:
+admin/template/container regions create an inhomogeneous benchmark population,
+and `Category:Container_categories` itself is a high-branching registry outlier
+even though individual container categories may be valid subtree roots.
+
+## Unit Tests
+
+Command:
+
+```text
+python3 -m unittest tests/test_distribution_cache_parity.py tests/test_distribution_cache_benchmark.py
+```
+
+Result:
+
+```text
+........
+----------------------------------------------------------------------
+Ran 8 tests in 0.011s
+
+OK
+```
+
+## File-Backed CLI Smoke Run
+
+Command:
+
+```text
+python3 scripts/distribution_cache_benchmark.py --edge-file tests/fixtures/simplewiki_articles_parent_sample.tsv --graph-name simplewiki_articles_parent_sample --max-target-depth 2 --precompute-depths 0,1,2 --budgets 2,4 --output-dir /mnt/c/Users/johnc/Scratch/distribution-cache-file-inputs --fail-on-error
+```
+
+Summary:
+
+| fixture | D_pre | B_search | cache_nodes | cache_bytes | full_ms | cached_ms | speedup | hit_rate | exact_failures |
+|---------|-------|----------|-------------|-------------|---------|-----------|---------|----------|----------------|
+| simplewiki_articles_parent_sample | 0 | 2 | 1 | 582 | 0.031429 | 0.041384 | 0.759 | 1.000 | 0 |
+| simplewiki_articles_parent_sample | 0 | 4 | 1 | 582 | 0.022509 | 0.024272 | 0.927 | 1.000 | 0 |
+| simplewiki_articles_parent_sample | 1 | 2 | 3 | 1308 | 0.023338 | 0.017010 | 1.372 | 1.000 | 0 |
+| simplewiki_articles_parent_sample | 1 | 4 | 3 | 1308 | 0.026759 | 0.014937 | 1.791 | 1.000 | 0 |
+| simplewiki_articles_parent_sample | 2 | 2 | 6 | 2493 | 0.023025 | 0.006952 | 3.312 | 1.000 | 0 |
+| simplewiki_articles_parent_sample | 2 | 4 | 6 | 2493 | 0.022094 | 0.006121 | 3.610 | 1.000 | 0 |
+
+The CLI emitted JSONL and markdown artifacts under:
+
+```text
+/mnt/c/Users/johnc/Scratch/distribution-cache-file-inputs
+```
+
+## Fixture-Mode CLI Smoke Run
+
+Command:
+
+```text
+python3 scripts/distribution_cache_benchmark.py --fixtures diamond --precompute-depths 0,1 --budgets 2 --fail-on-error
+```
+
+Result: fixture mode completed with zero exactness failures.

--- a/scripts/distribution_cache_benchmark.py
+++ b/scripts/distribution_cache_benchmark.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # Copyright (c) 2026 John William Creighton (s243a)
-"""Benchmark exact parent-only distribution cache cutoffs on tiny fixtures."""
+"""Benchmark exact parent-only distribution cache cutoffs."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import re
 import statistics
 import sys
 import time
@@ -20,6 +21,7 @@ if str(REPO_ROOT) not in sys.path:
 from tools.distribution_cache_support import (  # noqa: E402
     EXPONENT,
     FIXTURES,
+    ROOT,
     SearchStats,
     build_cache,
     cache_bytes,
@@ -28,12 +30,15 @@ from tools.distribution_cache_support import (  # noqa: E402
     first_moment_cdf,
     full_exact_search,
     histogram_bytes,
+    load_parent_edges_tsv,
     mass_cdf,
+    reachable_nodes_by_parent_distance,
     support_sizes,
     weighted_power_cdf,
 )
 
 
+SIMPLEWIKI_ROOT = "Category:Articles"
 DEFAULT_DEPTHS = [0, 1, 2, 3]
 DEFAULT_BUDGETS = [2, 4, 6]
 
@@ -55,6 +60,20 @@ def parse_int_list(text: str) -> list[int]:
     return values
 
 
+def parse_targets(text: str) -> list[str]:
+    return [part.strip() for part in text.split(",") if part.strip()]
+
+
+def load_targets_file(path: Path) -> list[str]:
+    targets = []
+    with path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if line and not line.startswith("#"):
+                targets.append(line)
+    return targets
+
+
 def timed_call(fn, *args, **kwargs):
     started = time.perf_counter_ns()
     result = fn(*args, **kwargs)
@@ -70,6 +89,10 @@ def percentile(values: list[int], pct: float) -> float:
     return float(ordered[index])
 
 
+def safe_graph_name(name: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", name).strip("_") or "graph"
+
+
 def histogram_record(hist, budget):
     mass = mass_cdf(hist, budget)
     return {
@@ -81,15 +104,16 @@ def histogram_record(hist, budget):
     }
 
 
-def query_record(fixture_name, precompute_depth, budget, target, mode, hist, runtime_ms, stats, exact_hist):
+def query_record(graph_name, graph_label, root, precompute_depth, budget, target, mode, hist, runtime_ms, stats, exact_hist):
     exact_mass = mass_cdf(exact_hist, budget)
     result_mass = mass_cdf(hist, budget)
     absolute_error = abs(result_mass - exact_mass)
     relative_error = 0.0 if exact_mass == 0 else absolute_error / exact_mass
     return {
         "record_type": "query",
-        "graph": "tiny_fixture",
-        "fixture": fixture_name,
+        "graph": graph_name,
+        "fixture": graph_label,
+        "root": root,
         "target_node": target,
         "D_pre": precompute_depth,
         "B_search": budget,
@@ -111,15 +135,15 @@ def query_record(fixture_name, precompute_depth, budget, target, mode, hist, run
     }
 
 
-def cache_record(fixture_name, precompute_depth, cache, build_runtime_ms):
+def cache_record(graph_name, graph_label, root, precompute_depth, cache, build_runtime_ms):
     sizes = support_sizes(cache)
     total_mass = sum(sum(hist.values()) for hist in cache.values())
     raw_hist_bytes = sum(histogram_bytes(hist) for hist in cache.values())
     return {
         "record_type": "cache_build",
-        "graph": "tiny_fixture",
-        "fixture": fixture_name,
-        "root": "R",
+        "graph": graph_name,
+        "fixture": graph_label,
+        "root": root,
         "D_pre": precompute_depth,
         "eligible_nodes": len(cache),
         "cached_nodes": len(cache),
@@ -134,20 +158,20 @@ def cache_record(fixture_name, precompute_depth, cache, build_runtime_ms):
     }
 
 
-def run_fixture_benchmark(fixture_name, fixture, depths, budgets):
-    parents = fixture["parents"]
-    targets = fixture["targets"]
+def run_graph_benchmark(graph_name, graph_label, parents, targets, depths, budgets, root):
     records = []
     for precompute_depth in depths:
-        cache, build_runtime_ms = timed_call(build_cache, parents, precompute_depth)
-        records.append(cache_record(fixture_name, precompute_depth, cache, build_runtime_ms))
+        cache, build_runtime_ms = timed_call(build_cache, parents, precompute_depth, root=root)
+        records.append(cache_record(graph_name, graph_label, root, precompute_depth, cache, build_runtime_ms))
         for budget in budgets:
             for target in targets:
                 full_stats = SearchStats()
-                full_hist, full_runtime_ms = timed_call(full_exact_search, target, parents, budget, stats=full_stats)
+                full_hist, full_runtime_ms = timed_call(full_exact_search, target, parents, budget, root=root, stats=full_stats)
                 records.append(
                     query_record(
-                        fixture_name,
+                        graph_name,
+                        graph_label,
+                        root,
                         precompute_depth,
                         budget,
                         target,
@@ -166,11 +190,14 @@ def run_fixture_benchmark(fixture_name, fixture, depths, budgets):
                     parents,
                     budget,
                     cache,
+                    root=root,
                     stats=cached_stats,
                 )
                 records.append(
                     query_record(
-                        fixture_name,
+                        graph_name,
+                        graph_label,
+                        root,
                         precompute_depth,
                         budget,
                         target,
@@ -182,6 +209,32 @@ def run_fixture_benchmark(fixture_name, fixture, depths, budgets):
                     )
                 )
     return records
+
+
+def run_fixture_benchmark(fixture_name, fixture, depths, budgets):
+    return run_graph_benchmark(
+        "tiny_fixture",
+        fixture_name,
+        fixture["parents"],
+        fixture["targets"],
+        depths,
+        budgets,
+        ROOT,
+    )
+
+
+def select_file_targets(parents, root, explicit_targets, targets_file, max_target_depth, target_limit):
+    if explicit_targets:
+        targets = parse_targets(explicit_targets)
+    elif targets_file:
+        targets = load_targets_file(targets_file)
+    else:
+        targets = reachable_nodes_by_parent_distance(parents, root, max_target_depth)
+    if target_limit is not None:
+        targets = targets[:target_limit]
+    if not targets:
+        raise SystemExit("no benchmark targets selected")
+    return targets
 
 
 def summarize(records):
@@ -230,8 +283,9 @@ def summarize(records):
 def write_outputs(records, summary, output_dir, graph_name):
     output_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    jsonl_path = output_dir / f"distribution_cache_benchmark_{graph_name}_{timestamp}.jsonl"
-    summary_path = output_dir / f"distribution_cache_summary_{graph_name}_{timestamp}.md"
+    safe_name = safe_graph_name(graph_name)
+    jsonl_path = output_dir / f"distribution_cache_benchmark_{safe_name}_{timestamp}.jsonl"
+    summary_path = output_dir / f"distribution_cache_summary_{safe_name}_{timestamp}.md"
     with jsonl_path.open("w", encoding="utf-8") as handle:
         for record in records:
             handle.write(json.dumps(record, sort_keys=True) + "\n")
@@ -241,27 +295,52 @@ def write_outputs(records, summary, output_dir, graph_name):
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--fixtures", default="all", help="Comma-separated fixture names or 'all'.")
+    parser.add_argument("--fixtures", default="all", help="Comma-separated fixture names or all. Ignored when --edge-file is set.")
+    parser.add_argument("--edge-file", type=Path, help="Optional TSV edge list with child<TAB>parent rows.")
+    parser.add_argument("--graph-name", help="Graph label used in records and output filenames.")
+    parser.add_argument("--root", help="Root node. Defaults to R for fixtures and Category:Articles for edge files.")
+    parser.add_argument("--targets", help="Comma-separated target nodes for edge-file mode.")
+    parser.add_argument("--targets-file", type=Path, help="Optional newline-delimited target list for edge-file mode.")
+    parser.add_argument("--max-target-depth", type=int, help="Select reachable edge-file targets within this parent distance from root.")
+    parser.add_argument("--target-limit", type=int, help="Limit selected edge-file targets after sorting/filtering.")
     parser.add_argument("--precompute-depths", default=",".join(map(str, DEFAULT_DEPTHS)))
     parser.add_argument("--budgets", default=",".join(map(str, DEFAULT_BUDGETS)))
     parser.add_argument("--output-dir", type=Path, help="Optional directory for JSONL and markdown output.")
     parser.add_argument("--fail-on-error", action="store_true", help="Exit nonzero if cached histograms differ.")
     args = parser.parse_args(argv)
 
-    fixture_names = sorted(FIXTURES) if args.fixtures == "all" else [name.strip() for name in args.fixtures.split(",")]
     depths = parse_int_list(args.precompute_depths)
     budgets = parse_int_list(args.budgets)
-
     records = []
-    for fixture_name in fixture_names:
-        if fixture_name not in FIXTURES:
-            raise SystemExit(f"unknown fixture: {fixture_name}")
-        records.extend(run_fixture_benchmark(fixture_name, FIXTURES[fixture_name], depths, budgets))
+
+    if args.edge_file:
+        root = args.root or SIMPLEWIKI_ROOT
+        parents = load_parent_edges_tsv(args.edge_file)
+        graph_name = args.graph_name or args.edge_file.stem
+        targets = select_file_targets(
+            parents,
+            root,
+            args.targets,
+            args.targets_file,
+            args.max_target_depth,
+            args.target_limit,
+        )
+        records.extend(run_graph_benchmark(graph_name, graph_name, parents, targets, depths, budgets, root))
+    else:
+        root = args.root or ROOT
+        if root != ROOT:
+            raise SystemExit("--root is only supported with --edge-file; fixtures use root R")
+        fixture_names = sorted(FIXTURES) if args.fixtures == "all" else [name.strip() for name in args.fixtures.split(",")]
+        graph_name = args.graph_name or "tiny_fixture"
+        for fixture_name in fixture_names:
+            if fixture_name not in FIXTURES:
+                raise SystemExit(f"unknown fixture: {fixture_name}")
+            records.extend(run_fixture_benchmark(fixture_name, FIXTURES[fixture_name], depths, budgets))
 
     summary = summarize(records)
     print(summary, end="")
     if args.output_dir:
-        jsonl_path, summary_path = write_outputs(records, summary, args.output_dir, "tiny_fixture")
+        jsonl_path, summary_path = write_outputs(records, summary, args.output_dir, graph_name)
         print(f"\nwrote {jsonl_path}")
         print(f"wrote {summary_path}")
 

--- a/tests/fixtures/simplewiki_articles_parent_sample.tsv
+++ b/tests/fixtures/simplewiki_articles_parent_sample.tsv
@@ -1,0 +1,17 @@
+child	parent
+Category:Contents	Category:Articles
+Category:Main_topic_classifications	Category:Articles
+Category:People	Category:Main_topic_classifications
+Category:Places	Category:Main_topic_classifications
+Category:Science	Category:Main_topic_classifications
+Category:Physics	Category:Science
+Category:Biology	Category:Science
+Category:Chemistry	Category:Science
+Category:Scientists	Category:People
+Category:British_people	Category:People
+Category:Cities	Category:Places
+Category:Countries	Category:Places
+Category:Quantum_mechanics	Category:Physics
+Category:Classical_mechanics	Category:Physics
+Category:Genetics	Category:Biology
+Category:Organic_chemistry	Category:Chemistry

--- a/tests/test_distribution_cache_benchmark.py
+++ b/tests/test_distribution_cache_benchmark.py
@@ -4,9 +4,15 @@
 """Smoke tests for the distribution cache benchmark runner."""
 
 import unittest
+from pathlib import Path
 
-from scripts.distribution_cache_benchmark import run_fixture_benchmark, summarize
-from tools.distribution_cache_support import FIXTURES
+from scripts.distribution_cache_benchmark import run_fixture_benchmark, run_graph_benchmark, summarize
+from tools.distribution_cache_support import FIXTURES, load_parent_edges_tsv, reachable_nodes_by_parent_distance
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SIMPLEWIKI_SAMPLE = REPO_ROOT / "tests" / "fixtures" / "simplewiki_articles_parent_sample.tsv"
+SIMPLEWIKI_ROOT = "Category:Articles"
 
 
 class DistributionCacheBenchmarkTests(unittest.TestCase):
@@ -27,6 +33,27 @@ class DistributionCacheBenchmarkTests(unittest.TestCase):
         self.assertIn("| fixture | D_pre | B_search |", summary)
         self.assertIn("shortcut_parent", summary)
         self.assertIn("| 0 |", summary)
+
+    def test_file_backed_simplewiki_subtree_sample_records_exact_parity(self):
+        parents = load_parent_edges_tsv(SIMPLEWIKI_SAMPLE)
+        targets = reachable_nodes_by_parent_distance(parents, SIMPLEWIKI_ROOT, max_depth=2)
+        records = run_graph_benchmark(
+            "simplewiki_articles_parent_sample",
+            "simplewiki_articles_parent_sample",
+            parents,
+            targets,
+            depths=[0, 1, 2],
+            budgets=[2],
+            root=SIMPLEWIKI_ROOT,
+        )
+        query_records = [record for record in records if record["record_type"] == "query"]
+
+        self.assertIn("Category:Articles", targets)
+        self.assertIn("Category:Science", targets)
+        self.assertNotIn("Category:Physics", targets)
+        self.assertTrue(query_records)
+        self.assertTrue(all(record["root"] == SIMPLEWIKI_ROOT for record in query_records))
+        self.assertTrue(all(record["histogram_exact_match"] for record in query_records))
 
 
 if __name__ == "__main__":

--- a/tools/distribution_cache_support.py
+++ b/tools/distribution_cache_support.py
@@ -191,6 +191,40 @@ def all_nodes(parents, root=ROOT):
     return nodes
 
 
+def reachable_nodes_by_parent_distance(parents, root=ROOT, max_depth=None):
+    distance_memo = {}
+    nodes = []
+    for node in sorted(all_nodes(parents, root)):
+        distance = min_parent_distance(node, parents, root, distance_memo)
+        if distance == math.inf:
+            continue
+        if max_depth is not None and distance > max_depth:
+            continue
+        nodes.append(node)
+    return nodes
+
+
+def load_parent_edges_tsv(path):
+    """Load a child-to-parents mapping from a TSV edge list."""
+    parents = defaultdict(list)
+    with open(path, "r", encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.rstrip("\n")
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("\t")
+            if len(parts) < 2:
+                raise ValueError(f"{path}:{line_number}: expected child<TAB>parent")
+            child = parts[0].strip()
+            parent = parts[1].strip()
+            if line_number == 1 and child.lower() == "child" and parent.lower() == "parent":
+                continue
+            if not child or not parent:
+                raise ValueError(f"{path}:{line_number}: child and parent must be non-empty")
+            parents[child].append(parent)
+    return {child: sorted(set(ps)) for child, ps in parents.items()}
+
+
 def build_cache(parents, precompute_depth, root=ROOT):
     cache = {}
     distance_memo = {}


### PR DESCRIPTION
## Title
Add file-backed distribution cache benchmark inputs

## Description
Adds TSV-backed graph input support to the distribution cache benchmark runner, so the benchmark can move beyond tiny in-memory fixtures toward small SimpleWiki-style category subtrees.

### Changes
- Adds `--edge-file` support for `child<TAB>parent` TSV inputs.
- Defaults file-backed runs to `Category:Articles` as the SimpleWiki content-subtree root.
- Adds configurable benchmark root support via `--root`.
- Adds shallow target selection with `--max-target-depth`.
- Adds a checked-in SimpleWiki-shaped sample fixture at `tests/fixtures/simplewiki_articles_parent_sample.tsv`.
- Extends benchmark tests to cover file-backed graph input and exact cached/full parity.
- Updates the benchmark plan to clarify:
  - `Category:Articles` is a useful SimpleWiki content subtree root, not the universal category root.
  - `Category:Main_topic_classifications` is enwiki-oriented.
  - broad admin/container regions need filtering before global branch-factor statistics are meaningful.
  - individual container categories can be valid subtree roots, while `Category:Container_categories` itself is a high-branching registry outlier.
- Adds a tracked smoke report at `docs/reports/distribution_cache_file_inputs_2026-06-10.md`.

### Verification
```text
python3 -m unittest tests/test_distribution_cache_parity.py tests/test_distribution_cache_benchmark.py
Ran 8 tests in 0.012s
OK

File-backed CLI smoke run:
python3 scripts/distribution_cache_benchmark.py --edge-file tests/fixtures/simplewiki_articles_parent_sample.tsv --graph-name simplewiki_articles_parent_sample --max-target-depth 2 --precompute-depths 0,1,2 --budgets 2,4 --output-dir /mnt/c/Users/johnc/Scratch/distribution-cache-file-inputs --fail-on-error

