### PR TITLE
Add SimpleWiki distribution cache subtree sampler

### DIFF
--- a/docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md
+++ b/docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md
@@ -54,6 +54,12 @@ Start with the simplest semantics:
 - cycle policy: use the same bounded/visited policy as the exact search oracle;
 - approximation: none.
 
+Use `scripts/sample_distribution_cache_subtree.py` to turn a resolved
+`child<TAB>parent` category edge list into a bounded benchmark subtree and
+target list before passing it to `scripts/distribution_cache_benchmark.py`.
+The sampler owns root selection, depth capping, and admin/container filtering;
+the benchmark runner owns measurement over the resulting TSV.
+
 Under those constraints, cached-distribution search should be semantically exact.
 Any discrepancy against full exact search is a bug in orientation, budget
 accounting, normalization, cycle policy, or path-statistic handling.

--- a/docs/reports/distribution_cache_subtree_sampler_2026-06-10.md
+++ b/docs/reports/distribution_cache_subtree_sampler_2026-06-10.md
@@ -1,0 +1,74 @@
+# Distribution Cache Subtree Sampler Smoke Report
+
+Date: 2026-06-10
+
+Branch: `codex/simplewiki-distribution-subtree-sampler`
+
+## Scope
+
+This report covers the offline subtree sampler for distribution-cache
+benchmarks. The sampler consumes a resolved category edge TSV with
+`child<TAB>parent` rows, selects a bounded child-distance subtree from a
+benchmark root, applies admin/container filters, and emits a sampled TSV plus
+optional target list for `scripts/distribution_cache_benchmark.py`.
+
+The smoke run uses the checked-in SimpleWiki-shaped sample rooted at
+`Category:Articles`. It does not require the full SimpleWiki dump.
+
+## Unit Tests
+
+Command:
+
+```text
+python3 -m unittest tests/test_distribution_cache_parity.py tests/test_distribution_cache_benchmark.py tests/test_distribution_cache_subtree_sampler.py
+```
+
+Result:
+
+```text
+..........
+----------------------------------------------------------------------
+Ran 10 tests in 0.013s
+
+OK
+```
+
+## Sampler Smoke Run
+
+Command:
+
+```text
+python3 scripts/sample_distribution_cache_subtree.py --edge-file tests/fixtures/simplewiki_articles_parent_sample.tsv --root Category:Articles --max-depth 2 --output /mnt/c/Users/johnc/Scratch/distribution-cache-subtree-sampler/simplewiki_articles_depth2.tsv --targets-output /mnt/c/Users/johnc/Scratch/distribution-cache-subtree-sampler/simplewiki_articles_depth2_targets.txt
+```
+
+Result:
+
+```text
+root=Category:Articles
+selected_nodes=6
+sampled_edges=5
+max_depth=2
+wrote_edges=/mnt/c/Users/johnc/Scratch/distribution-cache-subtree-sampler/simplewiki_articles_depth2.tsv
+wrote_targets=/mnt/c/Users/johnc/Scratch/distribution-cache-subtree-sampler/simplewiki_articles_depth2_targets.txt
+```
+
+## Downstream Benchmark Smoke Run
+
+Command:
+
+```text
+python3 scripts/distribution_cache_benchmark.py --edge-file /mnt/c/Users/johnc/Scratch/distribution-cache-subtree-sampler/simplewiki_articles_depth2.tsv --graph-name simplewiki_articles_depth2_sampled --targets-file /mnt/c/Users/johnc/Scratch/distribution-cache-subtree-sampler/simplewiki_articles_depth2_targets.txt --precompute-depths 0,1,2 --budgets 2,4 --output-dir /mnt/c/Users/johnc/Scratch/distribution-cache-subtree-sampler --fail-on-error
+```
+
+Summary:
+
+| fixture | D_pre | B_search | cache_nodes | cache_bytes | full_ms | cached_ms | speedup | hit_rate | exact_failures |
+|---------|-------|----------|-------------|-------------|---------|-----------|---------|----------|----------------|
+| simplewiki_articles_depth2_sampled | 0 | 2 | 1 | 582 | 0.043441 | 0.040083 | 1.084 | 1.000 | 0 |
+| simplewiki_articles_depth2_sampled | 0 | 4 | 1 | 582 | 0.024808 | 0.028276 | 0.877 | 1.000 | 0 |
+| simplewiki_articles_depth2_sampled | 1 | 2 | 3 | 1308 | 0.022641 | 0.014949 | 1.515 | 1.000 | 0 |
+| simplewiki_articles_depth2_sampled | 1 | 4 | 3 | 1308 | 0.029033 | 0.017334 | 1.675 | 1.000 | 0 |
+| simplewiki_articles_depth2_sampled | 2 | 2 | 6 | 2493 | 0.023183 | 0.008233 | 2.816 | 1.000 | 0 |
+| simplewiki_articles_depth2_sampled | 2 | 4 | 6 | 2493 | 0.020583 | 0.008666 | 2.375 | 1.000 | 0 |
+
+Result: sampled file-backed benchmark completed with zero exactness failures.

--- a/scripts/sample_distribution_cache_subtree.py
+++ b/scripts/sample_distribution_cache_subtree.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Sample a rooted category subtree for distribution-cache benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict, deque
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.distribution_cache_support import load_parent_edges_tsv  # noqa: E402
+
+
+SIMPLEWIKI_ARTICLES_ROOT = "Category:Articles"
+
+DEFAULT_EXCLUDE_PATTERNS = [
+    r"^Category:Categories$",
+    r"^Category:Container_categories$",
+    r"^Category:Wikipedia",
+    r"^Category:Template",
+    r"^Category:User",
+    r"^Category:Hidden_categories$",
+    r"^Category:Tracking_categories$",
+    r"(?i)maintenance",
+    r"(?i)admin",
+    r"(?i)template",
+]
+
+
+def compile_patterns(patterns: list[str]) -> list[re.Pattern[str]]:
+    return [re.compile(pattern) for pattern in patterns]
+
+
+def is_excluded(node: str, root: str, exclude_patterns: list[re.Pattern[str]]) -> bool:
+    if node == root:
+        return False
+    return any(pattern.search(node) for pattern in exclude_patterns)
+
+
+def build_children_index(parents: dict[str, list[str]], exclude_patterns: list[re.Pattern[str]], root: str):
+    children = defaultdict(list)
+    for child, parent_nodes in parents.items():
+        if is_excluded(child, root, exclude_patterns):
+            continue
+        for parent in parent_nodes:
+            if is_excluded(parent, root, exclude_patterns):
+                continue
+            children[parent].append(child)
+    return {parent: sorted(set(child_nodes)) for parent, child_nodes in children.items()}
+
+
+def select_subtree_nodes(children: dict[str, list[str]], root: str, max_depth: int, node_limit: int | None = None):
+    selected = set()
+    distances = {}
+    queue = deque([(root, 0)])
+    while queue:
+        node, depth = queue.popleft()
+        if node in selected:
+            continue
+        selected.add(node)
+        distances[node] = depth
+        if node_limit is not None and len(selected) >= node_limit:
+            break
+        if depth >= max_depth:
+            continue
+        for child in children.get(node, []):
+            queue.append((child, depth + 1))
+    return selected, distances
+
+
+def sample_edges(parents, selected_nodes: set[str]):
+    rows = []
+    for child in sorted(selected_nodes):
+        for parent in parents.get(child, []):
+            if parent in selected_nodes:
+                rows.append((child, parent))
+    return rows
+
+
+def write_edges(path: Path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write("child\tparent\n")
+        for child, parent in rows:
+            handle.write(f"{child}\t{parent}\n")
+
+
+def write_targets(path: Path, distances: dict[str, int]):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for node, _distance in sorted(distances.items(), key=lambda item: (item[1], item[0])):
+            handle.write(f"{node}\n")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--edge-file", required=True, type=Path, help="Input TSV with child<TAB>parent category edges.")
+    parser.add_argument("--output", required=True, type=Path, help="Output sampled TSV with child<TAB>parent rows.")
+    parser.add_argument("--targets-output", type=Path, help="Optional newline-delimited selected target nodes.")
+    parser.add_argument("--root", default=SIMPLEWIKI_ARTICLES_ROOT, help="Benchmark subtree root.")
+    parser.add_argument("--max-depth", type=int, default=3, help="Maximum child distance from the root to include.")
+    parser.add_argument("--node-limit", type=int, help="Optional cap on selected nodes after BFS ordering.")
+    parser.add_argument("--exclude-regex", action="append", default=[], help="Additional regex for nodes to exclude.")
+    parser.add_argument("--no-default-excludes", action="store_true", help="Disable built-in admin/container filters.")
+    args = parser.parse_args(argv)
+
+    if args.max_depth < 0:
+        raise SystemExit("--max-depth must be non-negative")
+
+    patterns = [] if args.no_default_excludes else list(DEFAULT_EXCLUDE_PATTERNS)
+    patterns.extend(args.exclude_regex)
+    exclude_patterns = compile_patterns(patterns)
+
+    parents = load_parent_edges_tsv(args.edge_file)
+    children = build_children_index(parents, exclude_patterns, args.root)
+    selected_nodes, distances = select_subtree_nodes(children, args.root, args.max_depth, args.node_limit)
+    rows = sample_edges(parents, selected_nodes)
+    write_edges(args.output, rows)
+    if args.targets_output:
+        write_targets(args.targets_output, distances)
+
+    print(f"root={args.root}")
+    print(f"selected_nodes={len(selected_nodes)}")
+    print(f"sampled_edges={len(rows)}")
+    print(f"max_depth={args.max_depth}")
+    print(f"wrote_edges={args.output}")
+    if args.targets_output:
+        print(f"wrote_targets={args.targets_output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_distribution_cache_subtree_sampler.py
+++ b/tests/test_distribution_cache_subtree_sampler.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Tests for distribution-cache subtree sampling."""
+
+import unittest
+from pathlib import Path
+
+from scripts.sample_distribution_cache_subtree import (
+    DEFAULT_EXCLUDE_PATTERNS,
+    build_children_index,
+    compile_patterns,
+    sample_edges,
+    select_subtree_nodes,
+)
+from tools.distribution_cache_support import load_parent_edges_tsv
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SIMPLEWIKI_SAMPLE = REPO_ROOT / "tests" / "fixtures" / "simplewiki_articles_parent_sample.tsv"
+SIMPLEWIKI_ROOT = "Category:Articles"
+
+
+class DistributionCacheSubtreeSamplerTests(unittest.TestCase):
+    def test_selects_shallow_articles_subtree(self):
+        parents = load_parent_edges_tsv(SIMPLEWIKI_SAMPLE)
+        children = build_children_index(parents, [], SIMPLEWIKI_ROOT)
+        selected, distances = select_subtree_nodes(children, SIMPLEWIKI_ROOT, max_depth=2)
+        rows = sample_edges(parents, selected)
+
+        self.assertEqual(distances[SIMPLEWIKI_ROOT], 0)
+        self.assertEqual(distances["Category:Science"], 2)
+        self.assertIn(("Category:Science", "Category:Main_topic_classifications"), rows)
+        self.assertNotIn("Category:Physics", selected)
+
+    def test_default_filters_exclude_registry_and_admin_regions(self):
+        parents = {
+            "Category:Container_categories": [SIMPLEWIKI_ROOT],
+            "Category:Topic_container": ["Category:Container_categories"],
+            "Category:Wikipedia_maintenance": [SIMPLEWIKI_ROOT],
+            "Category:Science": [SIMPLEWIKI_ROOT],
+        }
+        patterns = compile_patterns(DEFAULT_EXCLUDE_PATTERNS)
+        children = build_children_index(parents, patterns, SIMPLEWIKI_ROOT)
+        selected, _distances = select_subtree_nodes(children, SIMPLEWIKI_ROOT, max_depth=2)
+
+        self.assertIn("Category:Science", selected)
+        self.assertNotIn("Category:Container_categories", selected)
+        self.assertNotIn("Category:Topic_container", selected)
+        self.assertNotIn("Category:Wikipedia_maintenance", selected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds an offline subtree sampler for distribution-cache benchmarks. The sampler takes a resolved `child<TAB>parent` category edge TSV, selects a bounded subtree from a configurable root, applies admin/container filters, and emits benchmark-ready TSV plus optional target lists.

### Changes
- Adds `scripts/sample_distribution_cache_subtree.py`.
- Defaults the sampler root to `Category:Articles` for SimpleWiki content-subtree experiments.
- Adds built-in filters for broad admin/template/container regions.
- Treats `Category:Container_categories` as a high-branching registry outlier while still allowing individual container categories as valid roots.
- Adds sampler unit tests in `tests/test_distribution_cache_subtree_sampler.py`.
- Updates the benchmark plan to point from the design doc to the sampler.
- Adds a tracked smoke report at `docs/reports/distribution_cache_subtree_sampler_2026-06-10.md`.

### Verification
```text
python3 -m unittest tests/test_distribution_cache_parity.py tests/test_distribution_cache_benchmark.py tests/test_distribution_cache_subtree_sampler.py
Ran 10 tests in 0.013s
OK