### PR TITLE
LLVM WAM: A-reg-conditional put bind-throughs + Ref-chain-end binding (M140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (e.g. building `[33, 11, 22]` in `test_msort_head`; full removal
   broke it, caught by the suite). `get_list` keeps its bind-through —
   the legitimate write-mode head binding, guarded by a regression
-  test. Five tests in the new
+  test. Removing the staging bind-throughs unmasked a deeper bug they
+  had been compensating for: **bindings did not follow Ref chains to
+  the end**. `X = Y` aliases `cell1 -> Ref{cell2}`, but a later
+  `X = 42` wrote 42 into `cell1` — the alias link — leaving `cell2`
+  (the cell Y reads) unbound, so `X = Y, X = 42, Y =:= 42` failed.
+  Fixed in both binders: `@wam_bind_reg` now follows the Ref chain
+  via a new `@wam_last_ref` helper and writes at the chain end
+  (one-hop Refs behave exactly as before), and `@wam_unify_value`'s
+  bind-through-Ref paths bind at the chain end, alias to the
+  partner's chain-end Ref (keeping chains depth-bounded), and
+  succeed without writing when both chains already end at the same
+  cell (already-aliased vars; writing would self-reference). Six
+  tests in the new
   `--- M140 remaining put-instruction bind-throughs ---` section.
   Found but out of scope: `is_list([a])` fails standalone (the
   pre-existing put_list heap-marker-representation limitation).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **WAM LLVM target (M140): remaining put-instruction bind-throughs**
+  — completes the M139 audit. `put_constant`, `put_structure`, and
+  `put_list` called `@wam_bind_through_if_unbound_ref(old, val)`
+  unconditionally, binding any live unbound variable whose Ref
+  remained in the target register when staging an argument:
+  `var(X), atom(foo)` bound X to `foo`, `var(X), compound(f(a))`
+  bound X to the compound, and the list variant corrupted X the same
+  way. The bind-through is **conditional on register class** now:
+  A-register writes (index < 16) are pure staging for the next goal
+  and never bind the old occupant; X/Y-register writes keep the
+  bind-through because top-down structure chaining depends on it —
+  `set_variable Xn` leaves a Ref to the parent compound's arg slot
+  in `Xn`, and the following `put_structure [|]/2, Xn` binding
+  through that Ref is what links the nested cell into its parent
+  (e.g. building `[33, 11, 22]` in `test_msort_head`; full removal
+  broke it, caught by the suite). `get_list` keeps its bind-through —
+  the legitimate write-mode head binding, guarded by a regression
+  test. Five tests in the new
+  `--- M140 remaining put-instruction bind-throughs ---` section.
+  Found but out of scope: `is_list([a])` fails standalone (the
+  pre-existing put_list heap-marker-representation limitation).
 - **WAM LLVM target (M139): permanent-variable corruption via the
   put-instruction bind-through.** The pre-existing bug noted in the
   M138 test comments: top-level fresh-variable goals mis-executed —

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -2813,10 +2813,23 @@ wam_llvm_case('put_constant',
   %pc.tag_i32 = lshr i32 %pc.op2_32, 16
   %pc.val = insertvalue %Value undef, i32 %pc.tag_i32, 0
   %pc.val2 = insertvalue %Value %pc.val, i64 %op1, 1
-  %pc.old = call %Value @wam_get_reg(%WamState* %vm, i32 %pc.reg_idx)
+  ; M140: bind-through only for non-argument registers. Writing an
+  ; A register is pure staging for the next goal -- the old
+  ; bind-through bound any live unbound variable whose Ref remained
+  ; there (``var(X), atom(foo)'' bound X to foo). X/Y registers can
+  ; hold set_variable placeholder Refs from top-down structure
+  ; chaining, where binding through IS the linking mechanism.
   call void @wam_trail_binding(%WamState* %vm, i32 %pc.reg_idx)
-  call void @wam_set_reg(%WamState* %vm, i32 %pc.reg_idx, %Value %pc.val2)
+  %pc.is_areg = icmp ult i32 %pc.reg_idx, 16
+  br i1 %pc.is_areg, label %pc.store, label %pc.chain
+
+pc.chain:
+  %pc.old = call %Value @wam_get_reg(%WamState* %vm, i32 %pc.reg_idx)
   call void @wam_bind_through_if_unbound_ref(%WamState* %vm, %Value %pc.old, %Value %pc.val2)
+  br label %pc.store
+
+pc.store:
+  call void @wam_set_reg(%WamState* %vm, i32 %pc.reg_idx, %Value %pc.val2)
   call void @wam_inc_pc(%WamState* %vm)
   ret i1 true').
 
@@ -2896,10 +2909,25 @@ wam_llvm_case('put_structure',
   %ps.cp_i64 = ptrtoint %Compound* %ps.cp to i64
   %ps.val0 = insertvalue %Value undef, i32 3, 0
   %ps.val = insertvalue %Value %ps.val0, i64 %ps.cp_i64, 1
-  %ps.old = call %Value @wam_get_reg(%WamState* %vm, i32 %ps.ai)
+  ; M140: bind-through only for non-argument registers (see
+  ; put_constant). A-reg writes are staging -- the old unconditional
+  ; bind-through bound a live variable left in Ai to the freshly
+  ; built compound (``var(X), compound(f(a))'' bound X to f(a)).
+  ; X/Y-reg writes are top-down structure chaining: set_variable Xn
+  ; left a Ref to the parent''s arg slot in Xn, and binding through
+  ; it links this new cell into the parent (e.g. the [33,11,22]
+  ; build in test_msort_head).
   call void @wam_trail_binding(%WamState* %vm, i32 %ps.ai)
-  call void @wam_set_reg(%WamState* %vm, i32 %ps.ai, %Value %ps.val)
+  %ps.is_areg = icmp ult i32 %ps.ai, 16
+  br i1 %ps.is_areg, label %ps.store, label %ps.chain
+
+ps.chain:
+  %ps.old = call %Value @wam_get_reg(%WamState* %vm, i32 %ps.ai)
   call void @wam_bind_through_if_unbound_ref(%WamState* %vm, %Value %ps.old, %Value %ps.val)
+  br label %ps.store
+
+ps.store:
+  call void @wam_set_reg(%WamState* %vm, i32 %ps.ai, %Value %ps.val)
   call void @wam_push_write_ctx(%WamState* %vm, i32 %ps.arity)
   call void @wam_write_ctx_set_args(%WamState* %vm, %Value* %ps.args)
   call void @wam_inc_pc(%WamState* %vm)
@@ -2938,10 +2966,19 @@ wam_llvm_case('put_list',
   %pl.cp_i64 = ptrtoint %Compound* %pl.cp to i64
   %pl.val0 = insertvalue %Value undef, i32 3, 0
   %pl.val = insertvalue %Value %pl.val0, i64 %pl.cp_i64, 1
-  %pl.old = call %Value @wam_get_reg(%WamState* %vm, i32 %pl.ai)
+  ; M140: bind-through only for non-argument registers (see
+  ; put_structure -- same staging-vs-chaining split).
   call void @wam_trail_binding(%WamState* %vm, i32 %pl.ai)
-  call void @wam_set_reg(%WamState* %vm, i32 %pl.ai, %Value %pl.val)
+  %pl.is_areg = icmp ult i32 %pl.ai, 16
+  br i1 %pl.is_areg, label %pl.store, label %pl.chain
+
+pl.chain:
+  %pl.old = call %Value @wam_get_reg(%WamState* %vm, i32 %pl.ai)
   call void @wam_bind_through_if_unbound_ref(%WamState* %vm, %Value %pl.old, %Value %pl.val)
+  br label %pl.store
+
+pl.store:
+  call void @wam_set_reg(%WamState* %vm, i32 %pl.ai, %Value %pl.val)
   ; WriteCtx writes into args[0..1] via set_constant/set_variable/set_value.
   call void @wam_push_write_ctx(%WamState* %vm, i32 2)
   call void @wam_write_ctx_set_args(%WamState* %vm, %Value* %pl.args)

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -592,9 +592,37 @@ define %Value @wam_get_reg_deref(%WamState* %vm, i32 %idx) alwaysinline nounwind
 ; Bind a register to a value. If the register currently holds a Ref
 ; (put_variable aliasing), write through to the referenced heap cell
 ; AND record a trail entry so a subsequent backtrack unwinds the
-; binding. No Ref-chain following — put_variable creates depth-1 Refs,
-; and more exotic chains would also require the structural-unify path
-; to produce them.
+; binding.
+; M140: follows the Ref CHAIN to its end before writing. =/2 var-var
+; aliasing stores Ref{cell2} into cell1, so a later binding arriving
+; via Ref{cell1} must land in cell2 -- the cell every alias of the
+; variable reads -- not in cell1 (which would leave the partner
+; variable unbound; broke ``X = Y, X = 42, Y =:= 42'').
+; @wam_last_ref returns the last Ref in the chain -- the one whose
+; cell holds a non-Ref (Unbound for fresh chains, or a bound value
+; for the rebinding case, where writing at the chain end matches the
+; old one-hop behavior for depth-1 Refs).
+define %Value @wam_last_ref(%WamState* %vm, %Value %v) alwaysinline nounwind {
+entry:
+  br label %lr.loop
+lr.loop:
+  %lr.cur = phi %Value [ %v, %entry ], [ %lr.cell, %lr.follow ]
+  %lr.i = phi i32 [ 0, %entry ], [ %lr.i_next, %lr.follow ]
+  %lr.addr_i64 = extractvalue %Value %lr.cur, 1
+  %lr.addr = trunc i64 %lr.addr_i64 to i32
+  %lr.cell = call %Value @wam_heap_get(%WamState* %vm, i32 %lr.addr)
+  %lr.cell_tag = extractvalue %Value %lr.cell, 0
+  %lr.cell_is_ref = icmp eq i32 %lr.cell_tag, 5
+  %lr.hop_ok = icmp slt i32 %lr.i, 64
+  %lr.cont = and i1 %lr.cell_is_ref, %lr.hop_ok
+  br i1 %lr.cont, label %lr.follow, label %lr.done
+lr.follow:
+  %lr.i_next = add i32 %lr.i, 1
+  br label %lr.loop
+lr.done:
+  ret %Value %lr.cur
+}
+
 define void @wam_bind_reg(%WamState* %vm, i32 %idx, %Value %val) alwaysinline nounwind {
 entry:
   %cur = call %Value @wam_get_reg(%WamState* %vm, i32 %idx)
@@ -602,7 +630,8 @@ entry:
   %is_ref = icmp eq i32 %tag, 5
   br i1 %is_ref, label %heap_bind, label %reg_bind
 heap_bind:
-  %addr_i64 = extractvalue %Value %cur, 1
+  %last = call %Value @wam_last_ref(%WamState* %vm, %Value %cur)
+  %addr_i64 = extractvalue %Value %last, 1
   %addr = trunc i64 %addr_i64 to i32
   %old = call %Value @wam_heap_get(%WamState* %vm, i32 %addr)
   call void @wam_trail_heap_binding(%WamState* %vm, i32 %addr, %Value %old)
@@ -678,22 +707,48 @@ bind_a:
   br i1 %a_is_ref, label %bind_a_through, label %fail_no_binding
 
 bind_a_through:
-  %a_addr_i64 = extractvalue %Value %a, 1
+  ; M140: bind at the END of a's Ref chain, not its first Ref. After
+  ; X = Y aliases cell1 -> Ref{cell2}, a later X = 42 arrives with
+  ; a = Ref{cell1}; writing 42 into cell1 would leave cell2 -- the
+  ; cell Y reads -- unbound. @wam_deref_keep_var returns the last
+  ; Ref in the chain (the one whose cell is actually Unbound), so
+  ; the write lands where every alias of the variable sees it.
+  %a_last = call %Value @wam_deref_keep_var(%WamState* %vm, %Value %a)
+  %a_addr_i64 = extractvalue %Value %a_last, 1
   %a_addr = trunc i64 %a_addr_i64 to i32
-  %a_old = call %Value @wam_heap_get(%WamState* %vm, i32 %a_addr)
-  call void @wam_trail_heap_binding(%WamState* %vm, i32 %a_addr, %Value %a_old)
-  ; M104: if b is also a Ref to an unbound heap cell, store the
-  ; ORIGINAL b (the Ref) into a's cell rather than the deref'd
-  ; Unbound sentinel. That way a now points at b's cell, and
-  ; subsequent var(a) / var(b) / a == b / etc. all see them as
-  ; the same variable. Previously bind_a_through stored db (=
-  ; Unbound) which left a and b as two distinct unbound cells.
+  ; M104: if b is also a Ref to an unbound heap cell, store b's
+  ; chain-end Ref into a's cell rather than the deref'd Unbound
+  ; sentinel. That way a now points at b's cell, and subsequent
+  ; var(a) / var(b) / a == b / etc. all see them as the same
+  ; variable. (M140: chain-end rather than original b, so chains
+  ; stay depth-bounded; and if both chains already end at the SAME
+  ; cell, the variables are already aliased -- writing would create
+  ; a self-referential cell, so succeed without binding.)
   %ba_b_tag = extractvalue %Value %b, 0
   %ba_b_is_ref = icmp eq i32 %ba_b_tag, 5
   %ba_db_unb = call i1 @value_is_unbound(%Value %db)
   %ba_alias = and i1 %ba_b_is_ref, %ba_db_unb
-  %ba_to_write = select i1 %ba_alias, %Value %b, %Value %db
-  call void @wam_heap_set(%WamState* %vm, i32 %a_addr, %Value %ba_to_write)
+  br i1 %ba_alias, label %bind_a_alias, label %bind_a_value
+
+bind_a_alias:
+  %ba_b_last = call %Value @wam_deref_keep_var(%WamState* %vm, %Value %b)
+  %ba_b_addr_i64 = extractvalue %Value %ba_b_last, 1
+  %ba_same_cell = icmp eq i64 %ba_b_addr_i64, %a_addr_i64
+  br i1 %ba_same_cell, label %bind_a_done, label %bind_a_store_alias
+
+bind_a_store_alias:
+  %baa_old = call %Value @wam_heap_get(%WamState* %vm, i32 %a_addr)
+  call void @wam_trail_heap_binding(%WamState* %vm, i32 %a_addr, %Value %baa_old)
+  call void @wam_heap_set(%WamState* %vm, i32 %a_addr, %Value %ba_b_last)
+  br label %bind_a_done
+
+bind_a_value:
+  %bav_old = call %Value @wam_heap_get(%WamState* %vm, i32 %a_addr)
+  call void @wam_trail_heap_binding(%WamState* %vm, i32 %a_addr, %Value %bav_old)
+  call void @wam_heap_set(%WamState* %vm, i32 %a_addr, %Value %db)
+  br label %bind_a_done
+
+bind_a_done:
   ret i1 true
 
 check_b_unb:
@@ -706,18 +761,36 @@ bind_b:
   br i1 %b_is_ref, label %bind_b_through, label %fail_no_binding
 
 bind_b_through:
-  %b_addr_i64 = extractvalue %Value %b, 1
+  ; M140: symmetric to bind_a_through -- bind at the END of b's Ref
+  ; chain, alias to a's chain-end Ref, skip if already the same cell.
+  %b_last = call %Value @wam_deref_keep_var(%WamState* %vm, %Value %b)
+  %b_addr_i64 = extractvalue %Value %b_last, 1
   %b_addr = trunc i64 %b_addr_i64 to i32
-  %b_old = call %Value @wam_heap_get(%WamState* %vm, i32 %b_addr)
-  call void @wam_trail_heap_binding(%WamState* %vm, i32 %b_addr, %Value %b_old)
-  ; M104: symmetric to bind_a_through -- if a is also an unbound
-  ; Ref, store the original a so they alias.
   %bb_a_tag = extractvalue %Value %a, 0
   %bb_a_is_ref = icmp eq i32 %bb_a_tag, 5
   %bb_da_unb = call i1 @value_is_unbound(%Value %da)
   %bb_alias = and i1 %bb_a_is_ref, %bb_da_unb
-  %bb_to_write = select i1 %bb_alias, %Value %a, %Value %da
-  call void @wam_heap_set(%WamState* %vm, i32 %b_addr, %Value %bb_to_write)
+  br i1 %bb_alias, label %bind_b_alias, label %bind_b_value
+
+bind_b_alias:
+  %bb_a_last = call %Value @wam_deref_keep_var(%WamState* %vm, %Value %a)
+  %bb_a_addr_i64 = extractvalue %Value %bb_a_last, 1
+  %bb_same_cell = icmp eq i64 %bb_a_addr_i64, %b_addr_i64
+  br i1 %bb_same_cell, label %bind_b_done, label %bind_b_store_alias
+
+bind_b_store_alias:
+  %bba_old = call %Value @wam_heap_get(%WamState* %vm, i32 %b_addr)
+  call void @wam_trail_heap_binding(%WamState* %vm, i32 %b_addr, %Value %bba_old)
+  call void @wam_heap_set(%WamState* %vm, i32 %b_addr, %Value %bb_a_last)
+  br label %bind_b_done
+
+bind_b_value:
+  %bbv_old = call %Value @wam_heap_get(%WamState* %vm, i32 %b_addr)
+  call void @wam_trail_heap_binding(%WamState* %vm, i32 %b_addr, %Value %bbv_old)
+  call void @wam_heap_set(%WamState* %vm, i32 %b_addr, %Value %da)
+  br label %bind_b_done
+
+bind_b_done:
   ret i1 true
 
 both_bound:

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -3795,6 +3795,16 @@ test_m140_get_list_write(_, R) :-
     % to the constructed list (the one bind-through kept).
     m140_mklist(L), ( L == [a] -> R is 1 ; R is 0 ).   % 1
 
+:- dynamic test_m140_deep_chain_propagates/2.
+test_m140_deep_chain_propagates(_, R) :-
+    % Removing the staging bind-throughs unmasked this: bindings
+    % wrote at the FIRST Ref of an alias chain, not its end, so
+    % after X = Y the binding X = 42 landed in the alias-link cell
+    % and Y stayed unbound. Three-deep chain to exercise
+    % @wam_last_ref beyond one hop.
+    X = Y, Y = Z, X = 42,
+    ( Z =:= 42 -> R is 1 ; R is 0 ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -7057,6 +7067,8 @@ test_all :-
                    test_m140_put_list, 0, 1),
        run_test_r0('get_list write mode still binds -> 1',
                    test_m140_get_list_write + [m140_mklist/1], 0, 1),
+       run_test_r0('X=Y, Y=Z, X=42, Z=:=42 (deep chain) -> 1',
+                   test_m140_deep_chain_propagates, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -3751,6 +3751,50 @@ test_m139_ite_var_bind(_, R) :-
     % Same shape inside an if-then-else condition.
     ( var(X), X = done -> R is 1 ; R is 0 ).   % 1 (got 0)
 
+% M140: the remaining put-instruction bind-throughs (follow-up to
+% M139). put_constant / put_structure / put_list also bound any live
+% unbound variable whose Ref happened to remain in the target register
+% when staging an argument for the NEXT goal. The bind-through is now
+% conditional on register class: A-register writes (staging) never
+% bind the old occupant; X/Y-register writes keep it because top-down
+% structure chaining (set_variable Xn placeholder, then
+% put_structure/put_list into Xn) depends on the bind-through to link
+% nested cells into their parent -- see test_msort_head's input list
+% build. get_list keeps its bind-through unconditionally: that one is
+% the legitimate write-mode head binding (the register's variable is
+% unbound by definition of entering write mode, and binding it to the
+% fresh cons cell IS the instruction's job).
+
+:- dynamic test_m140_put_constant/2.
+test_m140_put_constant(_, R) :-
+    % put_constant staging foo for atom/1 found X's Ref in A1 and
+    % bound X to foo.
+    var(X), atom(foo), ( var(X) -> R is 1 ; R is 0 ).   % 1 (got 0)
+
+:- dynamic test_m140_put_constant_int/2.
+test_m140_put_constant_int(_, R) :-
+    var(X), integer(7), ( var(X) -> R is 1 ; R is 0 ).   % 1 (got 0)
+
+:- dynamic test_m140_put_structure/2.
+test_m140_put_structure(_, R) :-
+    % put_structure building f(a) bound X to the compound.
+    var(X), compound(f(a)), ( var(X) -> R is 1 ; R is 0 ).   % 1 (got 0)
+
+:- dynamic test_m140_put_list/2.
+test_m140_put_list(_, R) :-
+    % put_list building [a] corrupted X. (compound/1 rather than
+    % is_list/1 because is_list([a]) fails standalone on this engine
+    % -- separate pre-existing put_list-representation bug.)
+    var(X), compound([a]), ( var(X) -> R is 1 ; R is 0 ).   % 1
+
+:- dynamic test_m140_get_list_write/2.
+:- dynamic m140_mklist/1.
+m140_mklist([a]).
+test_m140_get_list_write(_, R) :-
+    % Guard: get_list write mode must STILL bind an unbound call arg
+    % to the constructed list (the one bind-through kept).
+    m140_mklist(L), ( L == [a] -> R is 1 ; R is 0 ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -7002,6 +7046,17 @@ test_all :-
                    test_m139_no_alias_on_put_value, 0, 1),
        run_test_r0('ITE: var(X), X=done -> 1',
                    test_m139_ite_var_bind, 0, 1),
+       format('--- M140 remaining put-instruction bind-throughs ---~n'),
+       run_test_r0('put_constant must not bind old occupant -> 1',
+                   test_m140_put_constant, 0, 1),
+       run_test_r0('put_constant int variant -> 1',
+                   test_m140_put_constant_int, 0, 1),
+       run_test_r0('put_structure must not bind old occupant -> 1',
+                   test_m140_put_structure, 0, 1),
+       run_test_r0('put_list must not bind old occupant -> 1',
+                   test_m140_put_list, 0, 1),
+       run_test_r0('get_list write mode still binds -> 1',
+                   test_m140_get_list_write + [m140_mklist/1], 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Completes the M139 (#2967) audit of `@wam_bind_through_if_unbound_ref` callers — and fixes the deeper Ref-chain bug the audit unmasked. Two commits.

## Commit 1: A-reg-conditional bind-through for `put_constant` / `put_structure` / `put_list`

All three bound any live unbound variable whose Ref happened to remain in the target register when staging an argument — each confirmed with a failing probe on unmodified `main`:

- `var(X), atom(foo)` bound X to `foo` (put_constant)
- `var(X), compound(f(a))` bound X to the compound (put_structure)
- the list variant corrupted X the same way (put_list)

**Full removal turned out to be too aggressive** — the suite caught `test_msort_head` coming back `[33|<unbound>]`. This engine builds nested structures top-down: `set_variable Xn` leaves a Ref to the parent's arg slot in `Xn`, and the following `put_structure [|]/2, Xn` *relies on the bind-through* to link the child cell into the parent. The register class separates the two roles cleanly:

- **A-register writes (index < 16)**: argument staging — never bind the old occupant (fixes the corruptions).
- **X/Y-register writes**: structure chaining — keep the bind-through (preserves nested builds).

`get_list` keeps its bind-through unconditionally: it's the legitimate write-mode head binding (the register's variable is unbound by definition of entering write mode), guarded by a regression test so a future cleanup can't remove it.

## Commit 2: follow Ref chains to the end in `@wam_bind_reg` and `@wam_unify_value`

Removing the staging bind-throughs unmasked the bug they had been compensating for: **bindings wrote at the first Ref of an alias chain, not its end**. `X = Y` aliases `cell1 → Ref{cell2}`; a later `X = 42` wrote 42 into `cell1` (the alias link), leaving `cell2` — the cell Y reads — unbound. `test_unify_then_bind_propagates` (`X = Y, X = 42, Y =:= 42`) caught it; the old put-instruction bind-throughs had been accidentally pre-binding the partner cell, masking this while causing the corruption bugs.

- `@wam_bind_reg`: new `@wam_last_ref` helper follows the chain; the write lands at the chain end. One-hop Refs (the common case) behave exactly as before, including the rebinding-bound-cell path.
- `@wam_unify_value` `bind_a_through`/`bind_b_through`: bind at the chain end, alias to the partner's chain-end Ref (keeps chains depth-bounded), and succeed without writing when both chains already end at the same cell (already-aliased variables — writing would create a self-referential cell).

## Out of scope (documented)

`is_list([a])` fails standalone on this engine — the pre-existing put_list heap-marker representation limitation noted back at the M-series unify commit.

## Tests

6 tests in the new `--- M140 remaining put-instruction bind-throughs ---` section: the three staging-corruption shapes, an integer variant, the get_list write-mode guard, and a three-deep chain (`X = Y, Y = Z, X = 42, Z =:= 42`) exercising `@wam_last_ref` beyond one hop.

## Test plan

- [x] All M140 tests PASS (deep-chain test verified individually; added after the suite launch)
- [x] Full `test_wam_llvm_builtin_execution` suite: **863 PASS, 0 FAIL** (clang 18.1.3 + llc 18) — including msort/sum_list chaining, the var-var aliasing tests, and the M137/M138/M139 sections
- [x] The suite caught both intermediate regressions during development (msort chaining, unify propagation) — evidence it has real teeth for this area

https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM)_