### PR TITLE
perf(wam-rust): gated T6 first-argument indexing (native match)

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -96,7 +96,7 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 | Target  | T1 det | T2 ITE | T3 mc-1 | T4 mc-n | T5 mc→`->` | T6 idx | T7 par | T8 kernels | T9 facts | T10 mode | T11 LCO |
 |---------|:------:|:------:|:-------:|:-------:|:----------:|:------:|:------:|:----------:|:--------:|:--------:|:-------:|
 | scala   | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ |
-| rust    | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ |
+| rust    | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✗ | ✗ | ✗ |
 | cpp     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | go      | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ |
 | haskell | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ |
@@ -169,12 +169,18 @@ Reading down the columns (after the T5 and T4 sweeps landed):
   above). Remaining T4/T5 holes are intentional: clojure has no distinct
   first-arg dispatch (T4 only); python's multi-clause story is its T5
   `if/elif/else`; wat has neither yet.
-- **T6 (first-arg indexing)** — *nobody* lowers it; all targets drop the
-  `switch_on_*` prefix and try clauses in order. This is the natural next
-  advancement after T5: the same clause-head analysis, but the back-end
-  emits a native `switch`/jump-table on the first argument's principal
-  functor instead of an if-cascade. Shared front-end, per-target back-end —
-  high leverage, and a perf win that's sound behind a gate.
+- **T6 (first-arg indexing)** — **Rust** now has a *gated* T6 (`~`): it
+  reuses the T5 `wam_clause_chain` front-end, but when the discriminators are
+  all atoms and there are ≥ `t6_min_clauses` of them (default 8) the back-end
+  emits a native two-stage `match` (string switch → integer jump table)
+  instead of the if-cascade. The other targets still drop the `switch_on_*`
+  prefix and try clauses in order. This is the natural next advancement after
+  T5 (same clause-head analysis, switch back-end): shared front-end,
+  per-target back-end — high leverage, and a perf win that's sound behind a
+  gate. Measured on generated Rust: a tie at 4 clauses, 1.55× at 8, 5.7× at
+  64, 12.7× at 256 — so it is gated to the many-clause case (see
+  `docs/reports/wam_rust_dispatch_alloc_perf.md`); the compiler flattens the
+  cascade for few clauses (matching the prior Go array-dispatch result).
 - **T2 (ITE)** — complete everywhere **except WAT** (the one remaining ITE
   gap; WAT has native `if/then/else` + `block`, so it's tractable). Closing
   it makes the T2 column fully ✓.

--- a/docs/reports/wam_rust_dispatch_alloc_perf.md
+++ b/docs/reports/wam_rust_dispatch_alloc_perf.md
@@ -66,11 +66,11 @@ scan comparing `Value::Atom(k.clone())` ran at 2899 ms vs 323 ms comparing
 All Rust lowered tests (`t4`, `t5`, `ite_exec`, `save_regs`) still pass, so the
 change is purely an allocation removal — no semantic change.
 
-## Where T6 (first-arg indexing / native `match`) will win — for later
+## Where T6 (first-arg indexing / native `match`) wins — now implemented (gated) for Rust
 
-We benchmarked T6 (`match` on the first arg) **before** doing T6, to check it is
-actually a win (compilers optimise dispatch aggressively; an earlier Go
-array-dispatch experiment *lost* to the compiler). Findings, on the 64-key
+We benchmarked T6 (`match` on the first arg) **before** building it, to check it
+is actually a win (compilers optimise dispatch aggressively; an earlier Go
+array-dispatch experiment *lost* to the compiler). The initial 64-key
 micro-benchmark:
 
 | dispatch (64 keys, worst case) | time |
@@ -80,23 +80,53 @@ micro-benchmark:
 | `match(&str)` (T6 native switch) | 118 ms |
 | `HashMap` (array/map dispatch) | 110 ms |
 
-Conclusions for a future T6:
+T6 is now **implemented for the Rust lowered emitter, behind a clause-count
+gate** (`emit_clause_chain_match_rust`). When the `wam_clause_chain` guards are
+**all atoms** and there are at least `t6_min_clauses` of them (option, **default
+8**), the emitter replaces the T5 if-cascade with a native **two-stage `match`**:
+a string `match` mapping the first arg's atom to a `Copy` selector index (the
+immutable borrow of the register ends there, via `WamState::match_reg_atom_str`,
+so the clause body can take `&mut vm`), then an integer `match` — a jump table —
+dispatching to the clause remainder. Below the gate it stays the T5 cascade.
+
+### Measured on the *generated* code (release + lto, 5M dispatches, keys rotated over the whole key space)
+
+| N clauses | T5 cascade | T6 `match` | speedup |
+|---:|---:|---:|:-:|
+| 4 (gate declines → stays T5) | 126 ms | 129 ms | 1.0× (tie) |
+| 8 (gate threshold) | 157 ms | 101 ms | **1.55×** |
+| 16 | 260 ms | 101 ms | **2.6×** |
+| 64 | 876 ms | 153 ms | **5.7×** |
+| 256 | 2991 ms | 236 ms | **12.7×** |
+
+This is the *generated* code (not a micro-benchmark): the T5 cascade is O(N)
+(average ≈ N/2 string compares), while T6 is roughly flat (a string-match
+decision tree → integer jump table). The crossover is below the gate — at N=8
+T6 already wins 1.55×, and the win grows with clause count.
+
+Conclusions (validated):
 
 1. **For few clauses (the typical 2–5), dispatch shape is noise** — the
-   compiler flattens `match` / if-cascade / map to the same thing. T6 is **not**
-   worth it there. (Matches the prior Go result; do **not** sweep blindly.)
-2. **For many clauses, a native `match` is a real ~3–6× over the (now
-   allocation-free) linear scan** — `match(&str)` 118 ms vs linear `&str`
-   679 ms at 64 keys. So T6 has a genuine niche: **first-arg-indexed predicates
-   with many clauses.** It must be **gated to a clause-count threshold** and
-   re-benchmarked per target (string-atom targets get a comparison-tree `match`;
-   int-interned-atom targets get a true jump table → bigger win).
+   compiler flattens `match` / if-cascade / map to the same thing (confirmed:
+   N=4 is a tie). T6 is **not** worth it there, so the gate declines and emits
+   the T5 cascade. (Matches the prior Go result; do **not** sweep blindly.)
+2. **For many clauses, a native `match` is a real 1.5–12.7× over the (now
+   allocation-free) linear scan**, growing with N. So T6's niche is
+   **first-arg-indexed predicates with many atom clauses**, and it is gated to
+   the clause-count threshold accordingly.
 3. **Map/array dispatch is not a win** (110 ms ≈ `match` 118 ms but with more
-   machinery) — consistent with the earlier Go experience. Prefer the host's
-   native `switch`/`match` over an explicit table.
+   machinery) — consistent with the earlier Go experience. We use the host's
+   native `match`, not an explicit table.
 
-So: revisit T6 only for the many-clause case, gated on clause count, verified
-per target — the allocation fix above is the universal win and lands first.
+### Porting to other targets
+
+The gate + front-end are reusable; only the back-end emit differs. **String-atom
+targets** (cpp) get the same string-`match` decision tree. **Int-interned-atom
+targets** (go, llvm, haskell, scala, lua) get a *true* single-stage jump table on
+the interned id — a bigger win and simpler emit — but each must be re-benchmarked
+because, on ints, the compiler more readily converts even the T5 if-cascade into
+a switch (the "lost to the compiler" risk is highest there). Gate on clause
+count and verify per target.
 
 ## A second bottleneck (noted for later): T4 `lo_restore_clause`
 

--- a/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
@@ -321,9 +321,9 @@ lower_predicate_to_rust(PI, WamCode, Options, RustLines) :-
     ;   ForeignPreds = []
     ),
     nb_setval(rust_ite_ctr, 0),
-    (   % T5 first-argument-constant dispatch takes precedence.
+    (   % T5/T6 first-argument-constant dispatch takes precedence.
         rust_clause_chain_lowerable(Instrs, Guards)
-    ->  emit_clause_chain_rust(FuncName, Pred, Arity, Guards, ForeignPreds, RustLines)
+    ->  emit_clause_chain_rust(FuncName, Pred, Arity, Guards, ForeignPreds, Options, RustLines)
     ;   % T4: a multi-clause predicate whose clauses are all supported
         % deterministic bodies (but not a distinct-first-arg chain) — lower
         % every clause inline, tried in order with a restore between attempts.
@@ -344,15 +344,54 @@ pub fn ~w(vm: &mut WamState) -> bool {', [FuncName, Pred, Arity, FuncName]),
         RustLines = [Header, Body, Footer]
     ).
 
-%% emit_clause_chain_rust(+FuncName, +Pred, +Arity, +Guards, +FK, -RustLines)
-%  Emit T5: deref the first argument once; if it is still unbound, defer to
-%  the entry wrapper's interpreter fallback (the unbound case is genuinely
-%  nondeterministic). Otherwise dispatch with an if-cascade comparing the
-%  bound value against each clause's distinct discriminator and running that
-%  clause's remainder (which self-terminates: its `proceed` emits
-%  `return true`). A bound value matching no clause returns false (the
-%  predicate fails; the wrapper's fresh re-run also fails — sound).
-emit_clause_chain_rust(FuncName, Pred, Arity, Guards, ForeignPreds, RustLines) :-
+%% emit_clause_chain_rust(+FuncName, +Pred, +Arity, +Guards, +FK, +Options, -RustLines)
+%  Multi-clause first-argument dispatch with two back-ends sharing the
+%  `wam_clause_chain` front-end's guard list:
+%
+%   * T5 (default) — an if-cascade comparing the first arg against each
+%     clause's distinct discriminator in place (allocation-free
+%     `match_reg_atom`).
+%   * T6 (gated) — when every discriminator is an atom AND there are at least
+%     `t6_min_clauses` of them, emit a native two-stage `match`: a string
+%     `match` that maps the first arg's atom to a `Copy` selector index (the
+%     immutable borrow ends there, so the clause body can take `&mut vm`),
+%     then an integer `match` (a jump table) dispatching to the remainder.
+%
+%  T6 is gated because for few clauses the compiler flattens the if-cascade to
+%  equivalent code (an earlier array-dispatch experiment lost to the compiler),
+%  so the native switch only pays off once the linear scan is long enough — see
+%  docs/reports/wam_rust_dispatch_alloc_perf.md.
+%
+%  Both back-ends treat an unbound / non-matching first arg as a `false`
+%  return, deferring to the entry wrapper's interpreter fallback (sound: the
+%  wrapper's fresh re-run enumerates clauses, and a genuine no-match also
+%  fails there). Each clause remainder self-terminates (`proceed` -> `return
+%  true`).
+emit_clause_chain_rust(FuncName, Pred, Arity, Guards, ForeignPreds, Options, RustLines) :-
+    (   rust_t6_applicable(Guards, Options)
+    ->  emit_clause_chain_match_rust(FuncName, Pred, Arity, Guards, ForeignPreds, RustLines)
+    ;   emit_clause_chain_cascade_rust(FuncName, Pred, Arity, Guards, ForeignPreds, RustLines)
+    ).
+
+%% rust_t6_applicable(+Guards, +Options) is semidet.
+%  True when first-arg indexing (T6 native match) should be used instead of the
+%  T5 if-cascade: every discriminator is an atom (so a string `match` applies)
+%  and the clause count meets the gate threshold.
+rust_t6_applicable(Guards, Options) :-
+    rust_t6_min_clauses(Options, Min),
+    length(Guards, N),
+    N >= Min,
+    forall(member(guard(V, _), Guards), wam_classify_constant_token(V, atom(_))).
+
+%% rust_t6_min_clauses(+Options, -N)
+%  Clause-count gate for T6. Override with the `t6_min_clauses(N)` option;
+%  defaults to a conservative threshold above which the native `match` beats
+%  the compiler-flattened if-cascade (see the perf report).
+rust_t6_min_clauses(Options, N) :-
+    ( member(t6_min_clauses(N), Options) -> true ; N = 8 ).
+
+% --- T5 back-end: if-cascade ---
+emit_clause_chain_cascade_rust(FuncName, Pred, Arity, Guards, ForeignPreds, RustLines) :-
     format(string(Header),
 '// ~w — lowered from ~w/~w (T5 first-argument dispatch)
 pub fn ~w(vm: &mut WamState) -> bool {', [FuncName, Pred, Arity, FuncName]),
@@ -366,6 +405,41 @@ pub fn ~w(vm: &mut WamState) -> bool {', [FuncName, Pred, Arity, FuncName]),
           format("    false~n") )),
     format(string(Footer), '}', []),
     RustLines = [Header, Body, Footer].
+
+% --- T6 back-end: native two-stage match (string switch -> jump table) ---
+emit_clause_chain_match_rust(FuncName, Pred, Arity, Guards, ForeignPreds, RustLines) :-
+    format(string(Header),
+'// ~w — lowered from ~w/~w (T6 first-argument indexing / native match)
+pub fn ~w(vm: &mut WamState) -> bool {', [FuncName, Pred, Arity, FuncName]),
+    with_output_to(string(Body),
+        ( format("    // String switch -> Copy selector (immutable borrow ends here).~n"),
+          format("    let _t6sel: i64 = match vm.match_reg_atom_str(\"A1\") {~n"),
+          emit_rust_t6_selectors(Guards, 0),
+          format("        _ => return false,  // unbound (defer to interpreter) or no clause matches~n"),
+          format("    };~n"),
+          format("    match _t6sel {  // integer jump table~n"),
+          emit_rust_t6_arms(Guards, 0, ForeignPreds),
+          format("        _ => {}~n"),
+          format("    }~n"),
+          format("    false~n") )),
+    format(string(Footer), '}', []),
+    RustLines = [Header, Body, Footer].
+
+emit_rust_t6_selectors([], _).
+emit_rust_t6_selectors([guard(V, _) | Rest], I) :-
+    wam_classify_constant_token(V, atom(Name)),
+    escape_rust_string(Name, Esc),
+    format("        Some(\"~w\") => ~w,~n", [Esc, I]),
+    I1 is I + 1,
+    emit_rust_t6_selectors(Rest, I1).
+
+emit_rust_t6_arms([], _, _).
+emit_rust_t6_arms([guard(_, Rem) | Rest], I, ForeignPreds) :-
+    format("        ~w => {~n", [I]),
+    emit_instrs(Rem, "            ", ForeignPreds),
+    format("        }~n"),
+    I1 is I + 1,
+    emit_rust_t6_arms(Rest, I1, ForeignPreds).
 
 emit_rust_guards([], _).
 emit_rust_guards([guard(V, Rem) | Rest], ForeignPreds) :-

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -832,6 +832,32 @@ impl WamState {
         }
     }
 
+    /// Allocation-free first-argument indexing (T6) read: deref the register
+    /// (by reference, following the binding chain) and, if it resolves to a
+    /// bound atom, borrow its `&str`. Returns `None` for an unbound register or
+    /// a bound non-atom value. The caller `match`es the returned `&str` against
+    /// the clause discriminators (a native string `switch`), so neither this
+    /// read nor the dispatch allocates. The borrow is confined to producing a
+    /// `Copy` selector, so the matched clause body can take `&mut self` freely.
+    #[inline]
+    pub fn match_reg_atom_str<'a>(&'a self, name: &str) -> Option<&'a str> {
+        match self.get_reg_ref(name) {
+            None => None,
+            Some(v) => self.deref_atom_str(v),
+        }
+    }
+
+    fn deref_atom_str<'a>(&'a self, val: &'a Value) -> Option<&'a str> {
+        match val {
+            Value::Unbound(name) => match self.bindings.get(name) {
+                Some(bound) => self.deref_atom_str(bound),
+                None => None,
+            },
+            Value::Atom(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
     /// Bind an unbound variable name to a value in the binding table.
     /// Also records a trail entry so that backtracking can undo this binding.
     pub fn bind_var(&mut self, var_name: &str, val: Value) {

--- a/tests/test_wam_rust_lowered_t6.pl
+++ b/tests/test_wam_rust_lowered_t6.pl
@@ -1,0 +1,156 @@
+% test_wam_rust_lowered_t6.pl
+%
+% End-to-end execution test for the Rust T6 lowering — "first-argument
+% indexing / native match" (lowering type T6 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md).
+%
+% T6 shares the wam_clause_chain front-end with T5 but, when the
+% discriminators are all atoms AND the clause count meets the gate
+% (`t6_min_clauses`, default 8), emits a native two-stage `match` — a string
+% switch mapping the first arg's atom to a Copy selector index, then an
+% integer jump table dispatching to the clause remainder — instead of the T5
+% if-cascade. For many clauses this is ~2.6-12.7x over the linear cascade
+% (measured, generated code; see docs/reports/wam_rust_dispatch_alloc_perf.md);
+% for few clauses the gate declines (the compiler flattens the cascade to the
+% same code), so T6 only fires above the threshold.
+%
+% Pins:
+%   * shade/1 (12 atom facts) — must lower as T6, and dispatch correctly for a
+%     first clause, a middle clause, the last clause, a no-match atom, and an
+%     unbound / non-atom first argument (both defer/fail -> false).
+%   * grade/2 (12 atom RULE clauses, each remainder runs an is/2 builtin) —
+%     T6 with a non-trivial remainder.
+%   * few/1 (3 atom facts) — below the gate, must STAY T5 (the cascade).
+%
+% Skipped automatically when `cargo` is not on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_rust_target').
+:- use_module('../src/unifyweaver/targets/wam_rust_lowered_emitter').
+
+:- dynamic user:shade/1.
+:- dynamic user:grade/2.
+:- dynamic user:few/1.
+
+user:shade(s01). user:shade(s02). user:shade(s03). user:shade(s04).
+user:shade(s05). user:shade(s06). user:shade(s07). user:shade(s08).
+user:shade(s09). user:shade(s10). user:shade(s11). user:shade(s12).
+
+user:grade(g01, R) :- R is 1 + 0.
+user:grade(g02, R) :- R is 1 + 1.
+user:grade(g03, R) :- R is 1 + 2.
+user:grade(g04, R) :- R is 1 + 3.
+user:grade(g05, R) :- R is 1 + 4.
+user:grade(g06, R) :- R is 1 + 5.
+user:grade(g07, R) :- R is 1 + 6.
+user:grade(g08, R) :- R is 1 + 7.
+user:grade(g09, R) :- R is 1 + 8.
+user:grade(g10, R) :- R is 1 + 9.
+user:grade(g11, R) :- R is 1 + 10.
+user:grade(g12, R) :- R is 1 + 11.
+
+user:few(a). user:few(b). user:few(c).
+
+cargo_available :-
+    catch(
+        ( process_create(path(cargo), ['--version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          process_wait(Pid, exit(0)) ),
+        _, fail).
+
+:- begin_tests(wam_rust_lowered_t6, [condition(cargo_available)]).
+
+% The many-clause atom predicates lower as T6 (clause_chain front-end + the
+% gated native-match back-end); the few-clause one stays T5.
+test(gate_picks_clause_chain) :-
+    forall(member(PI, [shade/1, grade/2, few/1]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_rust_lowerable(PI, W, Reason),
+             assertion(Reason == clause_chain) )).
+
+% The emitted source must use the native match for the many-clause atom
+% predicates and the cascade for the few-clause one.
+test(emits_t6_for_many_t5_for_few) :-
+    Dir = 'output/test_wam_rust_t6_shape',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_rust_project(
+        [user:shade/1, user:grade/2, user:few/1],
+        [module_name('t6shape'), wam_fallback(true), emit_mode(functions)], Dir),
+    atomic_list_concat([Dir, '/src/lib.rs'], LibPath),
+    read_file_to_string(LibPath, Src, []),
+    assertion(sub_string(Src, _, _, _, "lowered_shade_1") ),
+    assertion(sub_string(Src, _, _, _, "(T6 first-argument indexing / native match)") ),
+    assertion(sub_string(Src, _, _, _, "lowered_grade_2") ),
+    % few/1 (3 clauses, below gate) must stay the T5 cascade.
+    assertion(sub_string(Src, _, _, _, "lowered_few_1 — lowered from few/1 (T5 first-argument dispatch)") ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+test(t6_exec_parity) :-
+    Dir = 'output/test_wam_rust_t6_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_rust_project(
+        [user:shade/1, user:grade/2],
+        [module_name('t6rust'), wam_fallback(true), emit_mode(functions)], Dir),
+    atomic_list_concat([Dir, '/tests'], TestsDir),
+    make_directory_path(TestsDir),
+    atomic_list_concat([Dir, '/tests/t6_exec.rs'], TestPath),
+    rust_t6_source(RustSrc),
+    write_file_t6(TestPath, RustSrc),
+    format(atom(TestCmd), 'cd ~w && cargo test --test t6_exec 2>&1', [Dir]),
+    process_create(path(sh), ['-c', TestCmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    ->  true
+    ;   format(user_error, "~n[cargo test output]~n~w~n", [OutStr]),
+        throw(rust_t6_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_rust_lowered_t6).
+
+write_file_t6(Path, Text) :-
+    setup_call_cleanup(open(Path, write, S, [encoding(utf8)]), write(S, Text), close(S)).
+
+% Calls each lowered function with the first arg preloaded and asserts the
+% boolean outcome: first / middle / last clause hit, a no-match atom, a
+% non-atom value, and an unbound register (the last two defer/fail -> false).
+rust_t6_source(
+"use t6rust::state::WamState;
+use t6rust::value::Value;
+use t6rust::{lowered_shade_1, lowered_grade_2};
+use std::collections::HashMap;
+
+fn call(setup: &dyn Fn(&mut WamState), f: fn(&mut WamState) -> bool) -> bool {
+    let mut vm = WamState::new(vec![], HashMap::new());
+    setup(&mut vm);
+    f(&mut vm)
+}
+fn i(n: i64) -> Value { Value::Integer(n) }
+fn a(s: &str) -> Value { Value::Atom(s.to_string()) }
+
+#[test]
+fn t6_parity() {
+    let cases: Vec<(&str, bool, bool)> = vec![
+        (\"shade(s01)\",  call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"s01\")); }, lowered_shade_1), true),
+        (\"shade(s07)\",  call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"s07\")); }, lowered_shade_1), true),
+        (\"shade(s12)\",  call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"s12\")); }, lowered_shade_1), true),
+        (\"shade(s99)\",  call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"s99\")); }, lowered_shade_1), false),
+        (\"shade(42)\",   call(&|vm: &mut WamState| { vm.set_reg(\"A1\", i(42)); },     lowered_shade_1), false),
+        (\"shade(_)\",    call(&|_vm: &mut WamState| {},                               lowered_shade_1), false),
+        (\"grade(g01,1)\",  call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"g01\")); vm.set_reg(\"A2\", i(1)); },  lowered_grade_2), true),
+        (\"grade(g06,6)\",  call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"g06\")); vm.set_reg(\"A2\", i(6)); },  lowered_grade_2), true),
+        (\"grade(g12,12)\", call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"g12\")); vm.set_reg(\"A2\", i(12)); }, lowered_grade_2), true),
+        (\"grade(g06,9)\",  call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"g06\")); vm.set_reg(\"A2\", i(9)); },  lowered_grade_2), false),
+        (\"grade(gxx,1)\",  call(&|vm: &mut WamState| { vm.set_reg(\"A1\", a(\"gxx\")); vm.set_reg(\"A2\", i(1)); },  lowered_grade_2), false),
+    ];
+    let mut failures = Vec::new();
+    for (name, got, want) in cases {
+        if got != want { failures.push(format!(\"{}: got {}, want {}\", name, got, want)); }
+    }
+    assert!(failures.is_empty(), \"failures: {:?}\", failures);
+}
+").


### PR DESCRIPTION
## Summary

Implements **task 3** (gated many-clause T6 `match`) from the dispatch-perf investigation, and folds the measured result into the perf doc (closing out **task 1**, "document where T6 wins").

Adds **T6 first-argument indexing** to the Rust lowered emitter, reusing the existing T5 `wam_clause_chain` front-end. When the clause discriminators are **all atoms** and there are **≥ `t6_min_clauses`** of them (option, **default 8**), the emitter swaps the T5 if-cascade for a native **two-stage `match`**:

1. a string `match` mapping the first arg's atom to a `Copy` selector index — via the new allocation-free `WamState::match_reg_atom_str`, whose immutable borrow ends at the selector so the clause body can take `&mut vm`; then
2. an integer `match` — a jump table — dispatching to the clause remainder.

Below the gate it stays the T5 cascade.

## Verify-it's-a-win (the stated constraint)

Compilers flatten short if-cascades to equivalent code (the earlier Go array-dispatch experiment *lost* to the compiler), so T6 is **gated on clause count**. I benchmarked the **generated** code (not a micro-benchmark) — release + lto, 5M dispatches, keys rotated over the whole key space:

| N clauses | T5 cascade | T6 `match` | speedup |
|---:|---:|---:|:-:|
| 4 (gate declines → T5) | 126 ms | 129 ms | 1.0× (tie) |
| 8 (gate threshold) | 157 ms | 101 ms | **1.55×** |
| 16 | 260 ms | 101 ms | **2.6×** |
| 64 | 876 ms | 153 ms | **5.7×** |
| 256 | 2991 ms | 236 ms | **12.7×** |

T5 is O(N) (avg ≈ N/2 string compares); T6 is roughly flat (string decision-tree → jump table). The crossover is below the gate, so the default 8 is conservative and T6 never loses at/above it.

## Tests

New `test_wam_rust_lowered_t6.pl`:
- **gate**: many atom clauses (`shade/1` ×12, `grade/2` ×12) lower to T6; `few/1` (3 clauses) stays T5.
- **exec parity**: first / middle / last clause hit, no-match atom, non-atom integer, and unbound first arg (the last two defer/fail → `false`).

`test_wam_rust_lowered_{t4,t5}` still pass (3-clause T5 preds stay T5; `state.rs` change is purely additive).

## Docs
- `wam_rust_dispatch_alloc_perf.md`: replaced the "for later" T6 section with the implemented gated design + the generated-code crossover table + per-target porting notes (int-interned targets get a true single-stage jump table but must be re-benchmarked — the "lost to the compiler" risk is highest on ints).
- Taxonomy matrix: rust T6 → `~` gated.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_