### PR TITLE
LLVM WAM: ISO is_list/1 cons-chain walk + project-root normalization (M141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deref, false for atoms, partial lists (`[a|_]`), and unbound
   variables. Six tests in the new
   `--- M141 is_list/1 cons-chain walk ---` section.
+- **WAM LLVM target (M141): duplicate predicate compilation with
+  unqualified root specs.** `expand_wam_llvm_project_predicates`
+  discovers call targets in qualified form (`user:node/1`), but the
+  seen-set dedup compared them against the raw root list — an
+  unqualified root (`node/1`) never matched, so the predicate was
+  compiled into the merged module twice and `llc` rejected the
+  duplicate `@<pred>_switch_N` globals (`redefinition of global`).
+  Roots are now normalized to `Module:Pred/Arity` before seeding the
+  expansion. Surfaced by `test_sum_float` failing in isolation;
+  previously masked by in-suite test ordering.
 - **WAM LLVM target (M140): remaining put-instruction bind-throughs**
   — completes the M139 audit. `put_constant`, `put_structure`, and
   `put_list` called `@wam_bind_through_if_unbound_ref(old, val)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **WAM LLVM target (M141): `is_list/1` never succeeded.** The
+  follow-up flagged in M140: `builtin_is_list_check` accepted only
+  the legacy tag-4 List value, but the engine builds lists as
+  `[|]/2` compounds and `[]` as an atom — so `is_list/1` failed on
+  every list the engine actually produces, including `is_list([])`.
+  Replaced with a proper ISO cons-chain walk: true at the `[]` atom
+  (or a legacy tag-4 List), steps through `[|]/2` tails with full
+  deref, false for atoms, partial lists (`[a|_]`), and unbound
+  variables. Six tests in the new
+  `--- M141 is_list/1 cons-chain walk ---` section.
 - **WAM LLVM target (M140): remaining put-instruction bind-throughs**
   — completes the M139 audit. `put_constant`, `put_structure`, and
   `put_list` called `@wam_bind_through_if_unbound_ref(old, val)`

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -1783,7 +1783,16 @@ compile_predicates_for_llvm(Predicates, Options, NativeCode, WamCode) :-
 %  the same project batch as their roots. Builtins and predicates without local
 %  clauses remain on the existing builtin/external paths.
 expand_wam_llvm_project_predicates(Roots, Options, Expanded) :-
-    expand_wam_llvm_project_predicates_(Roots, Options, Roots, Expanded0),
+    % M141: normalize roots to Module:Pred/Arity BEFORE seeding the
+    % seen-set. Discovered call targets are always emitted qualified
+    % (user:node/1), so an unqualified root (node/1) never matched
+    % the memberchk dedup and its predicate was compiled into the
+    % merged module TWICE -- llc then rejected the duplicate
+    % @<pred>_switch_N globals ("redefinition of global").
+    maplist([PI, M:P/A]>>normalize_project_predicate_indicator(PI, M, P, A),
+            Roots, NormRoots0),
+    list_to_set(NormRoots0, NormRoots),
+    expand_wam_llvm_project_predicates_(NormRoots, Options, NormRoots, Expanded0),
     list_to_set(Expanded0, Expanded).
 
 expand_wam_llvm_project_predicates_([], _, Seen, Seen).

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4309,11 +4309,62 @@ builtin_compound_check:
   ret i1 %cc.r
 
 builtin_is_list_check:
-  ; is_list/1: true if list (tag=4) or the empty list atom []
+  ; M141: proper ISO is_list/1. The engine builds lists as tag-3
+  ; Compounds with the [|]/2 functor and the empty list as the []
+  ; atom, but this check only accepted the legacy tag-4 List value,
+  ; so is_list/1 NEVER succeeded -- not even for [] -- on every
+  ; list the engine actually produces. Walk the cons chain: true at
+  ; the [] atom (or a legacy tag-4 List), step through [|]/2 tails,
+  ; false at anything else (unbound tail = partial list = false).
   %ilc.a1 = call %Value @wam_get_reg_deref(%WamState* %vm, i32 0)
-  %ilc.tag = call i32 @value_tag(%Value %ilc.a1)
-  %ilc.r = icmp eq i32 %ilc.tag, 4
-  ret i1 %ilc.r
+  br label %ilc.loop
+
+ilc.loop:
+  %ilc.cur = phi %Value [ %ilc.a1, %builtin_is_list_check ], [ %ilc.next_d, %ilc.step ]
+  %ilc.tag = call i32 @value_tag(%Value %ilc.cur)
+  %ilc.is_listv = icmp eq i32 %ilc.tag, 4
+  br i1 %ilc.is_listv, label %ilc.true, label %ilc.chk_nil
+
+ilc.chk_nil:
+  %ilc.is_atom = icmp eq i32 %ilc.tag, 0
+  br i1 %ilc.is_atom, label %ilc.nil_test, label %ilc.chk_cons
+
+ilc.nil_test:
+  %ilc.pay = extractvalue %Value %ilc.cur, 1
+  %ilc.nil_id = load i64, i64* @wam_empty_list_atom_id
+  %ilc.is_nil = icmp eq i64 %ilc.pay, %ilc.nil_id
+  ret i1 %ilc.is_nil
+
+ilc.chk_cons:
+  %ilc.is_comp = icmp eq i32 %ilc.tag, 3
+  br i1 %ilc.is_comp, label %ilc.cons_test, label %ilc.false
+
+ilc.cons_test:
+  %ilc.pay2 = extractvalue %Value %ilc.cur, 1
+  %ilc.cp = inttoptr i64 %ilc.pay2 to %Compound*
+  %ilc.fn_slot = getelementptr %Compound, %Compound* %ilc.cp, i32 0, i32 0
+  %ilc.fn = load i8*, i8** %ilc.fn_slot
+  %ilc.cons_fn = getelementptr [4 x i8], [4 x i8]* @.fn__5B_7C_5D, i32 0, i32 0
+  %ilc.fn_eq = icmp eq i8* %ilc.fn, %ilc.cons_fn
+  %ilc.ar_slot = getelementptr %Compound, %Compound* %ilc.cp, i32 0, i32 1
+  %ilc.ar = load i32, i32* %ilc.ar_slot
+  %ilc.ar2 = icmp eq i32 %ilc.ar, 2
+  %ilc.is_cons = and i1 %ilc.fn_eq, %ilc.ar2
+  br i1 %ilc.is_cons, label %ilc.step, label %ilc.false
+
+ilc.step:
+  %ilc.args_slot = getelementptr %Compound, %Compound* %ilc.cp, i32 0, i32 2
+  %ilc.args = load %Value*, %Value** %ilc.args_slot
+  %ilc.tail_ptr = getelementptr %Value, %Value* %ilc.args, i32 1
+  %ilc.tail = load %Value, %Value* %ilc.tail_ptr
+  %ilc.next_d = call %Value @wam_deref_value(%WamState* %vm, %Value %ilc.tail)
+  br label %ilc.loop
+
+ilc.true:
+  ret i1 true
+
+ilc.false:
+  ret i1 false
 
 builtin_neq:
   ; Structurally not equal (op id 21). M137: route through

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -3805,6 +3805,36 @@ test_m140_deep_chain_propagates(_, R) :-
     X = Y, Y = Z, X = 42,
     ( Z =:= 42 -> R is 1 ; R is 0 ).   % 1
 
+% M141: is_list/1 never succeeded. The check accepted only the legacy
+% tag-4 List value, but the engine builds lists as [|]/2 compounds and
+% [] as an atom -- so even is_list([]) failed. Now a proper ISO
+% cons-chain walk.
+
+:- dynamic test_m141_is_list_nonempty/2.
+test_m141_is_list_nonempty(_, R) :-
+    is_list([a, b, c]), R is 1.   % 1 (failed before: exit 255)
+
+:- dynamic test_m141_is_list_singleton/2.
+test_m141_is_list_singleton(_, R) :-
+    is_list([a]), R is 1.   % 1
+
+:- dynamic test_m141_is_list_nil/2.
+test_m141_is_list_nil(_, R) :-
+    is_list([]), R is 1.   % 1 (even [] failed before)
+
+:- dynamic test_m141_is_list_atom_rejects/2.
+test_m141_is_list_atom_rejects(_, R) :-
+    ( is_list(foo) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_m141_is_list_partial_rejects/2.
+test_m141_is_list_partial_rejects(_, R) :-
+    % Partial list (unbound tail) is NOT a list per ISO.
+    ( is_list([a|_]) -> R is 0 ; R is 1 ).   % 1
+
+:- dynamic test_m141_is_list_var_rejects/2.
+test_m141_is_list_var_rejects(_, R) :-
+    ( is_list(_) -> R is 0 ; R is 1 ).   % 1
+
 % M112: truncate/2 -- libc truncate wrapper for file resizing.
 
 :- dynamic test_truncate_grow/2.
@@ -7069,6 +7099,19 @@ test_all :-
                    test_m140_get_list_write + [m140_mklist/1], 0, 1),
        run_test_r0('X=Y, Y=Z, X=42, Z=:=42 (deep chain) -> 1',
                    test_m140_deep_chain_propagates, 0, 1),
+       format('--- M141 is_list/1 cons-chain walk ---~n'),
+       run_test_r0('is_list([a,b,c]) -> 1',
+                   test_m141_is_list_nonempty, 0, 1),
+       run_test_r0('is_list([a]) -> 1',
+                   test_m141_is_list_singleton, 0, 1),
+       run_test_r0('is_list([]) -> 1',
+                   test_m141_is_list_nil, 0, 1),
+       run_test_r0('is_list(foo) rejects -> 1',
+                   test_m141_is_list_atom_rejects, 0, 1),
+       run_test_r0('is_list([a|_]) partial rejects -> 1',
+                   test_m141_is_list_partial_rejects, 0, 1),
+       run_test_r0('is_list(_) var rejects -> 1',
+                   test_m141_is_list_var_rejects, 0, 1),
        format('--- M112 truncate/2 ---~n'),
        run_test_r0('touch + truncate 100 + size_file -> 1',
                    test_truncate_grow, 0, 1),


### PR DESCRIPTION
## Summary

Two LLVM WAM engine fixes, both root-caused from the `is_list` follow-up flagged in #2976. Two commits.

## Fix 1: `is_list/1` never succeeded

`builtin_is_list_check` accepted only the legacy tag-4 List value, but the engine builds every actual list as `[|]/2` compounds with `[]` as an atom — so `is_list/1` failed on **every list the engine produces, including `is_list([])`**. The old comment even promised the `[]` check ("true if list (tag=4) or the empty list atom []"); it was never implemented.

Replaced with a proper ISO cons-chain walk: true at the `[]` atom (legacy tag-4 List still accepted), steps through `[|]/2` tails with full deref, false for atoms, partial lists (`[a|_]`), and unbound variables. The needed infrastructure (`@wam_empty_list_atom_id`, the interned `[|]` functor global) is pre-registered in every module by the M9 machinery, so the walk is self-contained.

## Fix 2: duplicate predicate compilation with unqualified root specs

The full-suite gate for fix 1 caught `test_sum_float` exiting 127 — the test binary was never produced because `llc` rejected the module: `redefinition of global '@node_switch_0'`. The `node/1` predicate was compiled into the merged module **twice**.

Root cause: `expand_wam_llvm_project_predicates` discovers call targets in qualified form (`user:node/1`), but the seen-set `memberchk` compared against the raw root list — and `run_pow_test` passes helper predicates **unqualified** (`[node/1]`), so the explicit root and the discovered dependency both compiled. Reproduced identically on the parent commit: pre-existing, masked by in-suite test ordering until M141's test additions shifted the schedule. Roots are now normalized to `Module:Pred/Arity` (and deduped) before seeding the expansion.

## Tests

6 tests in the new `--- M141 is_list/1 cons-chain walk ---` section: `[a,b,c]` / `[a]` / `[]` accept; `foo` / `[a|_]` (partial) / unbound var reject — per ISO. Fix 2 is covered by the existing `test_sum_float`/`test_sum_int` (unqualified-helper) tests, which now also pass **in isolation**, not just in suite order.

## Test plan

- [x] All 6 M141 tests PASS
- [x] `test_sum_float` passes in isolation (was exit 127)
- [x] Full `test_wam_llvm_builtin_execution` suite: **870 PASS, 0 FAIL** (clang 18.1.3 + llc 18)

https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM