### PR TITLE
fix(wam-clojure): resume lowered direct builtin backtracking

### DIFF
--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -228,6 +228,7 @@ emit_instrs([], Indent) :-
 emit_instrs(Instrs, Indent) :-
     length(Instrs, Len),
     format("~w(let [s0 state~n", [Indent]),
+    format("~w      c0 true~n", [Indent]),
     emit_instr_bindings(Instrs, 0, Indent),
     format("~w      ]~n", [Indent]),
     format("~w  s~w)~n", [Indent, Len]).
@@ -236,11 +237,16 @@ emit_instr_bindings([], _, _).
 emit_instr_bindings([Instr|Rest], Index, Indent) :-
     NextIndex is Index + 1,
     format(atom(InState), 's~w', [Index]),
+    format(atom(InCont), 'c~w', [Index]),
+    format(atom(OutState), 's~w', [NextIndex]),
+    format(atom(OutCont), 'c~w', [NextIndex]),
     emit_lowered_expr(Instr, InState, Expr),
     instr_comment(Instr, Comment),
     format("~w      ;; ~w~n", [Indent, Comment]),
-    format("~w      s~w (if (= :running (:status ~w)) ~w ~w)~n",
-           [Indent, NextIndex, InState, Expr, InState]),
+    format("~w      ~w (if ~w ~w ~w)~n",
+           [Indent, OutState, InCont, Expr, InState]),
+    format("~w      ~w (runtime/lowered-step-advanced? ~w ~w ~w)~n",
+           [Indent, OutCont, InCont, InState, OutState]),
     emit_instr_bindings(Rest, NextIndex, Indent).
 
 % =====================================================================

--- a/templates/targets/clojure_wam/runtime.clj.mustache
+++ b/templates/targets/clojure_wam/runtime.clj.mustache
@@ -210,6 +210,11 @@
 (defn advance [state]
   (update state :pc inc))
 
+(defn lowered-step-advanced? [continue? before after]
+  (and continue?
+       (= :running (:status after))
+       (= (:pc after) (inc (:pc before)))))
+
 (defn fetch-instr [state]
   (get (:code state) (:pc state)))
 

--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -122,6 +122,7 @@
 :- dynamic user:wam_between_guard/3.
 :- dynamic user:wam_between_high_before_low/0.
 :- dynamic user:wam_between_generate_first/0.
+:- dynamic user:wam_between_backtrack/1.
 :- dynamic user:wam_between_singleton/0.
 :- dynamic user:wam_between_unbound_low/1.
 :- dynamic user:wam_between_unbound_high/1.
@@ -509,6 +510,7 @@ user:wam_select_unbound_list(Rest) :- select(a, L, Rest), is_list(L).
 user:wam_between_guard(Low, High, Value) :- between(Low, High, Value).
 user:wam_between_high_before_low :- between(5, 3, _).
 user:wam_between_generate_first :- between(2, 5, X), X =:= 2.
+user:wam_between_backtrack(Value) :- between(1, 3, X), X =:= Value.
 user:wam_between_singleton :- between(7, 7, X), X =:= 7.
 user:wam_between_unbound_low(_) :- user:wam_unbound_arg(Low), between(Low, 3, _).
 user:wam_between_unbound_high(_) :- user:wam_unbound_arg(High), between(1, High, _).
@@ -901,6 +903,7 @@ run_smoke :-
           user:wam_between_guard/3,
           user:wam_between_high_before_low/0,
           user:wam_between_generate_first/0,
+          user:wam_between_backtrack/1,
           user:wam_between_singleton/0,
           user:wam_between_unbound_low/1,
           user:wam_between_unbound_high/1,
@@ -1441,6 +1444,8 @@ smoke_cases([
     case('wam_between_guard/3', args(1, 3, 0), "false"),
     case('wam_between_high_before_low/0', no_args, "false"),
     case('wam_between_generate_first/0', no_args, "true"),
+    case('wam_between_backtrack/1', 2, "true"),
+    case('wam_between_backtrack/1', 4, "false"),
     case('wam_between_singleton/0', no_args, "true"),
     case('wam_between_unbound_low/1', a, "false"),
     case('wam_between_unbound_high/1', a, "false"),
@@ -2024,8 +2029,10 @@ assert_lowered_between_builtin_emitted(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
     has(CoreCode, "defn lowered-wam-between-guard-3"),
+    has(CoreCode, "defn lowered-wam-between-backtrack-1"),
     has(CoreCode, "defn lowered-wam-between-unbound-low-1"),
     has(CoreCode, "defn lowered-wam-between-unbound-high-1"),
+    has(CoreCode, "runtime/lowered-step-advanced?"),
     has(CoreCode, "runtime/apply-between-solution").
 
 assert_lowered_numlist_builtin_emitted(ProjectDir) :-


### PR DESCRIPTION
## Summary

- Stops lowered Clojure straightline emission from continuing stale inlined steps after a direct builtin backtracks to a choicepoint resume PC.
- Adds `runtime/lowered-step-advanced?` so generated lowered functions continue only when the prior step advanced normally.
- Restores a regression fixture for `between(1,3,X), X =:= Value`, including the negative `Value = 4` case.

## Why

Enumerating direct builtins such as `between/3`, `member/2`, `nth0/3`, `nth1/3`, `select/3`, and `sub_atom/5` can install choicepoints. If a later lowered instruction fails, runtime backtracking can restore a state at the builtin's resume PC. The previous straightline lowered function then kept executing the remaining stale bindings instead of yielding to the WAM interpreter to replay from that restored PC.

This made filtered generator patterns unsound in lowered Clojure code.

## Implementation Notes

- Generated lowered functions now thread a continuation boolean alongside `sN` state bindings.
- A lowered step may continue inlined execution only when:
  - the previous continuation flag is true,
  - the resulting state is still `:running`, and
  - the program counter advanced exactly one instruction.
- If a step succeeds terminally, fails, jumps, executes, or backtracks to a restored PC, the remaining inlined lowered bindings no longer run.
- The public wrapper still calls `runtime/run-wam`, so any restored running state resumes through the existing interpreter path.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl` passed `97/97`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl` passed `15/15`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl` passed with `wam_clojure_runtime_smoke: ok`

## Scope

This PR fixes the correctness seam by yielding from lowered straightline execution when PC movement is not a normal one-step advance. It does not attempt to inline replay of generator alternatives inside lowered functions; that can be optimized separately if profiling shows it matters.
