### PR TITLE
perf(wam-cpp): gated T6 first-argument indexing (map+switch)

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -97,7 +97,7 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 |---------|:------:|:------:|:-------:|:-------:|:----------:|:------:|:------:|:----------:|:--------:|:--------:|:-------:|
 | scala   | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ |
 | rust    | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✗ | ✗ | ✗ |
-| cpp     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| cpp     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✗ | ✗ | ✗ | ✗ |
 | go      | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ |
 | haskell | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ |
 | fsharp  | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ~ | ✗ | ✗ | ✗ |
@@ -169,18 +169,24 @@ Reading down the columns (after the T5 and T4 sweeps landed):
   above). Remaining T4/T5 holes are intentional: clojure has no distinct
   first-arg dispatch (T4 only); python's multi-clause story is its T5
   `if/elif/else`; wat has neither yet.
-- **T6 (first-arg indexing)** — **Rust** now has a *gated* T6 (`~`): it
-  reuses the T5 `wam_clause_chain` front-end, but when the discriminators are
-  all atoms and there are ≥ `t6_min_clauses` of them (default 8) the back-end
-  emits a native two-stage `match` (string switch → integer jump table)
-  instead of the if-cascade. The other targets still drop the `switch_on_*`
-  prefix and try clauses in order. This is the natural next advancement after
-  T5 (same clause-head analysis, switch back-end): shared front-end,
-  per-target back-end — high leverage, and a perf win that's sound behind a
-  gate. Measured on generated Rust: a tie at 4 clauses, 1.55× at 8, 5.7× at
-  64, 12.7× at 256 — so it is gated to the many-clause case (see
-  `docs/reports/wam_rust_dispatch_alloc_perf.md`); the compiler flattens the
-  cascade for few clauses (matching the prior Go array-dispatch result).
+- **T6 (first-arg indexing)** — **Rust and C++** now have a *gated* T6 (`~`):
+  both reuse the T5 `wam_clause_chain` front-end, but when the discriminators
+  are all atoms and there are ≥ `t6_min_clauses` of them (default 8) the
+  back-end replaces the if-cascade with a native indexed dispatch — Rust a
+  two-stage `match` (string switch → integer jump table); C++ a static
+  `std::unordered_map<std::string,int>` (no native string switch) → `switch`.
+  The other targets still drop the `switch_on_*` prefix and try clauses in
+  order. This is the natural next advancement after T5 (same clause-head
+  analysis, switch back-end): shared front-end, per-target back-end — high
+  leverage, and a perf win that's sound behind a gate. Measured on generated
+  code (tie at 4 clauses; then growing with N): Rust 1.55× at 8, 5.7× at 64,
+  12.7× at 256; C++ 2.1× at 8, 11.6× at 64, 40.8× at 256 (see
+  `docs/reports/wam_rust_dispatch_alloc_perf.md`). The compiler flattens the
+  cascade for few clauses (matching the prior Go array-dispatch result), hence
+  the gate. Int-interned targets (go/llvm/haskell/scala/lua) are the remaining
+  candidates but carry the highest "lost to the compiler" risk (an int
+  equality chain is already switch-converted), so each needs a per-target
+  benchmark before shipping.
 - **T2 (ITE)** — complete everywhere **except WAT** (the one remaining ITE
   gap; WAT has native `if/then/else` + `block`, so it's tractable). Closing
   it makes the T2 column fully ✓.

--- a/docs/reports/wam_rust_dispatch_alloc_perf.md
+++ b/docs/reports/wam_rust_dispatch_alloc_perf.md
@@ -120,13 +120,37 @@ Conclusions (validated):
 
 ### Porting to other targets
 
-The gate + front-end are reusable; only the back-end emit differs. **String-atom
-targets** (cpp) get the same string-`match` decision tree. **Int-interned-atom
-targets** (go, llvm, haskell, scala, lua) get a *true* single-stage jump table on
-the interned id — a bigger win and simpler emit — but each must be re-benchmarked
-because, on ints, the compiler more readily converts even the T5 if-cascade into
-a switch (the "lost to the compiler" risk is highest there). Gate on clause
-count and verify per target.
+The gate + front-end are reusable; only the back-end emit differs.
+
+**String-atom targets (cpp — now done).** C++ has no native string `switch`, so
+the T6 back-end uses a `static std::unordered_map<std::string,int>` (built once)
+looked up by the deref'd first-arg atom via a no-copy `match_reg_atom_str`
+(returns a pointer to the cell's `std::string`, no allocation), then a `switch`
+(jump table) on the index. Measured on the *generated* code (g++ -O2, 5M
+dispatches, keys rotated over the whole key space):
+
+| N clauses | T5 cascade | T6 map+switch | speedup |
+|---:|---:|---:|:-:|
+| 4 (gate declines → T5) | 355 ms | 343 ms | 1.0× (tie) |
+| 8 (gate threshold) | 499 ms | 237 ms | **2.1×** |
+| 16 | 707 ms | 259 ms | **2.7×** |
+| 64 | 3096 ms | 266 ms | **11.6×** |
+| 256 | 12310 ms | 302 ms | **40.8×** |
+
+The win is *larger* than Rust's: the C++ T5 cascade is a fully linear chain of
+`match_reg_atom` calls (deref + `std::string` compare per guard, O(N)), while the
+map lookup is ~flat — so at 256 clauses T6 is ~41×. Same gate (default 8), same
+tie at few clauses. `match_reg_atom_str` + the gated emit are in
+`wam_cpp_target.pl` / `wam_cpp_lowered_emitter.pl`; `test_wam_cpp_lowered_t6`
+covers the gate and exec parity.
+
+**Int-interned-atom targets** (go, llvm, haskell, scala, lua) would get a *true*
+single-stage jump table on the interned id — simpler emit — but each must be
+re-benchmarked because, on ints, the compiler more readily converts even the T5
+if-cascade into a switch (the "lost to the compiler" risk is highest there; e.g.
+LLVM's SimplifyCFG turns an `icmp`/`br` chain on one value into a `switch`
+already, so T6 may compile to identical code and show no win). Gate on clause
+count and verify per target before shipping.
 
 ## A second bottleneck (noted for later): T4 `lo_restore_clause`
 

--- a/src/unifyweaver/targets/wam_cpp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_cpp_lowered_emitter.pl
@@ -288,9 +288,9 @@ lower_predicate_to_cpp(PI, WamCode, Options, CppLines) :-
     ;   ForeignPreds = []
     ),
     nb_setval(cpp_ite_ctr, 0),
-    (   % T5 first-argument-constant dispatch takes precedence.
+    (   % T5/T6 first-argument-constant dispatch takes precedence.
         cpp_clause_chain_lowerable(Instrs, Guards)
-    ->  emit_clause_chain_cpp(FuncName, Pred, Arity, Guards, ForeignPreds, CppLines)
+    ->  emit_clause_chain_cpp(FuncName, Pred, Arity, Guards, ForeignPreds, Options, CppLines)
     ;   % T4: a multi-clause predicate whose clauses are all supported
         % deterministic bodies (but not a distinct-first-arg chain) — lower
         % every clause inline, tried in order with a restore between attempts.
@@ -311,16 +311,56 @@ bool ~w(WamState* vm) {', [FuncName, Pred, Arity, FuncName]),
         CppLines = [Header, Body, Footer]
     ).
 
-%% emit_clause_chain_cpp(+FuncName, +Pred, +Arity, +Guards, +FK, -CppLines)
-%  Emit T5: read+deref the first argument once; if it is still unbound, defer
-%  to the entry wrapper's interpreter fallback (the unbound case is genuinely
-%  nondeterministic). Otherwise dispatch with an if-cascade comparing the
-%  bound value against each clause's distinct discriminator and running that
-%  clause's remainder (which self-terminates: its `proceed` emits
-%  `return true`). A bound value matching no clause returns false (the
-%  predicate fails; the wrapper's fresh re-run also fails — sound, since the
-%  discriminators are distinct).
-emit_clause_chain_cpp(FuncName, Pred, Arity, Guards, ForeignPreds, CppLines) :-
+%% emit_clause_chain_cpp(+FuncName, +Pred, +Arity, +Guards, +FK, +Options, -CppLines)
+%  Multi-clause first-argument dispatch with two back-ends sharing the
+%  `wam_clause_chain` front-end's guard list:
+%
+%   * T5 (default) — an if-cascade comparing the first arg against each
+%     clause's distinct discriminator in place (allocation-free
+%     `match_reg_atom`).
+%   * T6 (gated) — when every discriminator is an atom AND there are at least
+%     `t6_min_clauses` of them, replace the linear cascade with a static
+%     `std::unordered_map<std::string,int>` built once, looked up by the
+%     deref'd first-arg atom (via the no-copy `match_reg_atom_str`), then a
+%     `switch` (jump table) on the resulting index. C++ has no native string
+%     switch, so the map IS the indexing structure: one hash + one compare +
+%     a jump, instead of up to N derefs + string compares.
+%
+%  T6 is gated because for few clauses the compiler flattens the if-cascade to
+%  equivalent code (an earlier array-dispatch experiment lost to the compiler),
+%  so the map/switch only pays off once the linear scan is long enough — see
+%  docs/reports/wam_rust_dispatch_alloc_perf.md (the Rust analysis; the same
+%  string-atom shape applies to C++).
+%
+%  Both back-ends treat an unbound / non-matching first arg as a `false`
+%  return, deferring to the entry wrapper's interpreter fallback (sound: the
+%  discriminators are distinct, so a fresh bytecode re-run also fails). Each
+%  clause remainder self-terminates (`proceed` -> `return true`).
+emit_clause_chain_cpp(FuncName, Pred, Arity, Guards, ForeignPreds, Options, CppLines) :-
+    (   cpp_t6_applicable(Guards, Options)
+    ->  emit_clause_chain_map_cpp(FuncName, Pred, Arity, Guards, ForeignPreds, CppLines)
+    ;   emit_clause_chain_cascade_cpp(FuncName, Pred, Arity, Guards, ForeignPreds, CppLines)
+    ).
+
+%% cpp_t6_applicable(+Guards, +Options) is semidet.
+%  True when first-arg indexing (T6 map/switch) should be used instead of the
+%  T5 if-cascade: every discriminator is an atom and the clause count meets the
+%  gate threshold.
+cpp_t6_applicable(Guards, Options) :-
+    cpp_t6_min_clauses(Options, Min),
+    length(Guards, N),
+    N >= Min,
+    forall(member(guard(V, _), Guards), wam_classify_constant_token(V, atom(_))).
+
+%% cpp_t6_min_clauses(+Options, -N)
+%  Clause-count gate for T6. Override with the `t6_min_clauses(N)` option;
+%  defaults to a conservative threshold above which the map/switch beats the
+%  compiler-flattened if-cascade.
+cpp_t6_min_clauses(Options, N) :-
+    ( member(t6_min_clauses(N), Options) -> true ; N = 8 ).
+
+% --- T5 back-end: if-cascade ---
+emit_clause_chain_cascade_cpp(FuncName, Pred, Arity, Guards, ForeignPreds, CppLines) :-
     format(string(Header),
 '// ~w — lowered from ~w/~w (T5 first-argument dispatch)
 bool ~w(WamState* vm) {', [FuncName, Pred, Arity, FuncName]),
@@ -333,6 +373,42 @@ bool ~w(WamState* vm) {', [FuncName, Pred, Arity, FuncName]),
           format("    return false;~n") )),
     format(string(Footer), '}', []),
     CppLines = [Header, Body, Footer].
+
+% --- T6 back-end: static unordered_map -> switch (jump table) ---
+emit_clause_chain_map_cpp(FuncName, Pred, Arity, Guards, ForeignPreds, CppLines) :-
+    format(string(Header),
+'// ~w — lowered from ~w/~w (T6 first-argument indexing / map+switch)
+bool ~w(WamState* vm) {', [FuncName, Pred, Arity, FuncName]),
+    with_output_to(string(Body),
+        ( format("    const std::string* _t6s = vm->match_reg_atom_str(\"A1\");~n"),
+          format("    if (!_t6s) return false;  // unbound (defer to interpreter) or non-atom~n"),
+          format("    static const std::unordered_map<std::string,int> _t6map = {~n"),
+          emit_cpp_t6_map_entries(Guards, 0),
+          format("    };~n"),
+          format("    auto _t6it = _t6map.find(*_t6s);~n"),
+          format("    if (_t6it == _t6map.end()) return false;  // no clause matches~n"),
+          format("    switch (_t6it->second) {  // jump table~n"),
+          emit_cpp_t6_cases(Guards, 0, ForeignPreds),
+          format("    }~n"),
+          format("    return false;~n") )),
+    format(string(Footer), '}', []),
+    CppLines = [Header, Body, Footer].
+
+emit_cpp_t6_map_entries([], _).
+emit_cpp_t6_map_entries([guard(V, _) | Rest], I) :-
+    wam_classify_constant_token(V, atom(Name)),
+    local_escape_cpp_string(Name, Esc),
+    format("        {\"~w\", ~w},~n", [Esc, I]),
+    I1 is I + 1,
+    emit_cpp_t6_map_entries(Rest, I1).
+
+emit_cpp_t6_cases([], _, _).
+emit_cpp_t6_cases([guard(_, Rem) | Rest], I, ForeignPreds) :-
+    format("        case ~w: {~n", [I]),
+    emit_instrs(Rem, "            ", ForeignPreds),
+    format("        } break;~n"),
+    I1 is I + 1,
+    emit_cpp_t6_cases(Rest, I1, ForeignPreds).
 
 emit_cpp_guards([], _).
 emit_cpp_guards([guard(V, Rem) | Rest], ForeignPreds) :-

--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -3752,6 +3752,12 @@ struct WamState {
     // (caller binds). Reads the register cell in place: no Value copy, and no
     // temporary Value::Atom on the right-hand side.
     int     match_reg_atom(const std::string& name, const char* atom) const;
+    // T6 first-argument indexing: deref the register in place and, if it
+    // resolves to a bound atom, return a pointer to its std::string (no copy,
+    // no allocation); return nullptr for unbound / non-atom. The pointee lives
+    // in the register cell, stable for the duration of the lowered call, so the
+    // caller can look it up in a static dispatch map and switch on the result.
+    const std::string* match_reg_atom_str(const std::string& name) const;
     void    put_reg(const std::string& name, Value v);
     CellPtr get_cell(const std::string& name);
     void    set_cell(const std::string& name, CellPtr c);
@@ -4225,6 +4231,24 @@ int WamState::match_reg_atom(const std::string& name, const char* atom) const {
         case Value::Tag::Uninit:  return -1;
         default:                  return 0;
     }
+}
+
+const std::string* WamState::match_reg_atom_str(const std::string& name) const {
+    const Value* v;
+    if (is_y_reg(name)) {
+        if (env_stack.empty()) return nullptr;
+        auto& y = env_stack.back().y_regs;
+        auto it = y.find(name);
+        if (it == y.end()) return nullptr;
+        v = it->second.get();
+    } else {
+        int i = reg_index(name);
+        if (i < 0 || (std::size_t)i >= regs.size() || !regs[i]) return nullptr;
+        v = regs[i].get();
+    }
+    // deref() is a no-op in this cell-mutates-in-place model, so the cell
+    // value is already dereferenced.
+    return v->tag == Value::Tag::Atom ? &v->s : nullptr;
 }
 
 void WamState::put_reg(const std::string& name, Value v) {

--- a/tests/test_wam_cpp_lowered_t6.pl
+++ b/tests/test_wam_cpp_lowered_t6.pl
@@ -1,0 +1,151 @@
+% test_wam_cpp_lowered_t6.pl
+%
+% End-to-end execution test for the C++ T6 lowering — "first-argument
+% indexing" (lowering type T6 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md).
+%
+% T6 shares the wam_clause_chain front-end with T5 but, when the
+% discriminators are all atoms AND the clause count meets the gate
+% (`t6_min_clauses`, default 8), replaces the T5 if-cascade with a static
+% std::unordered_map<std::string,int> looked up by the deref'd first-arg atom
+% (via the no-copy match_reg_atom_str), then a switch (jump table) on the
+% index. C++ has no native string switch, so the map IS the indexing
+% structure: one hash + one compare + a jump instead of up to N derefs +
+% string compares. For few clauses the gate declines (the compiler flattens
+% the cascade), so T6 only fires above the threshold.
+%
+% Pins:
+%   * shade/1 (12 atom facts) — must lower as T6, dispatching correctly for a
+%     first / middle / last clause, a no-match atom, and an unbound / non-atom
+%     first argument (both defer/fail -> false).
+%   * grade/2 (12 atom RULE clauses, each remainder runs an is/2 builtin) —
+%     T6 with a non-trivial remainder.
+%   * few/1 (3 atom facts) — below the gate, must STAY T5 (the cascade).
+%
+% Skipped automatically when no host C++17 compiler is available.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_cpp_target').
+:- use_module('../src/unifyweaver/targets/wam_cpp_lowered_emitter').
+
+:- dynamic user:shade/1.
+:- dynamic user:grade/2.
+:- dynamic user:few/1.
+
+user:shade(s01). user:shade(s02). user:shade(s03). user:shade(s04).
+user:shade(s05). user:shade(s06). user:shade(s07). user:shade(s08).
+user:shade(s09). user:shade(s10). user:shade(s11). user:shade(s12).
+
+user:grade(g01, R) :- R is 1 + 0.
+user:grade(g02, R) :- R is 1 + 1.
+user:grade(g03, R) :- R is 1 + 2.
+user:grade(g04, R) :- R is 1 + 3.
+user:grade(g05, R) :- R is 1 + 4.
+user:grade(g06, R) :- R is 1 + 5.
+user:grade(g07, R) :- R is 1 + 6.
+user:grade(g08, R) :- R is 1 + 7.
+user:grade(g09, R) :- R is 1 + 8.
+user:grade(g10, R) :- R is 1 + 9.
+user:grade(g11, R) :- R is 1 + 10.
+user:grade(g12, R) :- R is 1 + 11.
+
+user:few(a). user:few(b). user:few(c).
+
+cc_ok(CC) :-
+    catch(( process_create(path(CC), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+cpp_compiler(CC) :-
+    ( cc_ok('g++') -> CC = 'g++'
+    ; cc_ok('clang++') -> CC = 'clang++'
+    ; fail ).
+
+:- begin_tests(wam_cpp_lowered_t6, [condition(cpp_compiler(_))]).
+
+% The many-clause atom predicates lower via the clause_chain front-end; few/1
+% does too (it is just gated to the T5 back-end at emit time).
+test(gate_picks_clause_chain) :-
+    forall(member(PI, [shade/1, grade/2, few/1]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_cpp_lowerable(PI, W, Reason),
+             assertion(Reason == clause_chain) )).
+
+% The emitted source must use the map/switch for the many-clause atom
+% predicates and the cascade for the few-clause one.
+test(emits_t6_for_many_t5_for_few) :-
+    Dir = 'output/test_wam_cpp_t6_shape',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_cpp_project(
+        [user:shade/1, user:grade/2, user:few/1],
+        [module_name('t6shape'), wam_fallback(true), emit_mode(functions)], Dir),
+    atomic_list_concat([Dir, '/cpp/generated_program.cpp'], GenPath),
+    read_file_to_string(GenPath, Src, []),
+    assertion(sub_string(Src, _, _, _, "lowered_shade_1")),
+    assertion(sub_string(Src, _, _, _, "(T6 first-argument indexing / map+switch)")),
+    assertion(sub_string(Src, _, _, _, "lowered_grade_2")),
+    % few/1 (3 clauses, below gate) must stay the T5 cascade.
+    assertion(sub_string(Src, _, _, _, "lowered_few_1 — lowered from few/1 (T5 first-argument dispatch)")),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+test(t6_exec_parity) :-
+    cpp_compiler(CC),
+    Dir = 'output/test_wam_cpp_t6_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_cpp_project(
+        [user:shade/1, user:grade/2],
+        [module_name('t6cpp'), wam_fallback(true), emit_mode(functions)], Dir),
+    atomic_list_concat([Dir, '/cpp/generated_program.cpp'], GenPath),
+    ( exists_file(GenPath) -> read_file_to_string(GenPath, GSrc, []) ; GSrc = "" ),
+    assertion(sub_string(GSrc, _, _, _, "T6 first-argument indexing")),
+    atomic_list_concat([Dir, '/cpp/test_t6.cpp'], TestPath),
+    cpp_t6_source(Src),
+    setup_call_cleanup(open(TestPath, write, S), write(S, Src), close(S)),
+    atomic_list_concat([Dir, '/cpp'], CppDir),
+    format(atom(Cmd),
+        '~w -std=c++17 -O0 ~w/test_t6.cpp ~w/generated_program.cpp ~w/wam_runtime.cpp -o ~w/t6_test 2>&1 && ~w/t6_test',
+        [CC, CppDir, CppDir, CppDir, CppDir, CppDir]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 11 PASS")
+    ->  true
+    ;   format(user_error, "~n[cpp t6 test output]~n~w~n", [OutStr]),
+        throw(cpp_t6_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_cpp_lowered_t6).
+
+% Calls each lowered function with a BOUND first argument and asserts the
+% boolean outcome: first / middle / last clause hit, a no-match atom, a
+% non-atom value, and an unbound register (the last two defer/fail -> false).
+cpp_t6_source(
+"#include \"wam_runtime.h\"
+#include <iostream>
+bool lowered_shade_1(WamState*); bool lowered_grade_2(WamState*);
+static int failures = 0;
+static void chk(const char* n, bool g, bool w) {
+    if (g != w) { std::cerr << \"FAIL \" << n << \": got \" << g << \" want \" << w << \"\\n\"; failures++; }
+}
+static Value I(long long n) { return Value::Integer(n); }
+static Value A(const char* s) { return Value::Atom(s); }
+int main() {
+    { WamState v; v.put_reg(\"A1\", A(\"s01\")); chk(\"shade(s01)\", lowered_shade_1(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"s07\")); chk(\"shade(s07)\", lowered_shade_1(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"s12\")); chk(\"shade(s12)\", lowered_shade_1(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"s99\")); chk(\"shade(s99)\", lowered_shade_1(&v), false); }
+    { WamState v; v.put_reg(\"A1\", I(42));     chk(\"shade(42)\",  lowered_shade_1(&v), false); }
+    { WamState v;                              chk(\"shade(_)\",   lowered_shade_1(&v), false); }
+    { WamState v; v.put_reg(\"A1\", A(\"g01\")); v.put_reg(\"A2\", I(1));  chk(\"grade(g01,1)\",  lowered_grade_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"g06\")); v.put_reg(\"A2\", I(6));  chk(\"grade(g06,6)\",  lowered_grade_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"g12\")); v.put_reg(\"A2\", I(12)); chk(\"grade(g12,12)\", lowered_grade_2(&v), true); }
+    { WamState v; v.put_reg(\"A1\", A(\"g06\")); v.put_reg(\"A2\", I(9));  chk(\"grade(g06,9)\",  lowered_grade_2(&v), false); }
+    { WamState v; v.put_reg(\"A1\", A(\"gxx\")); v.put_reg(\"A2\", I(1));  chk(\"grade(gxx,1)\",  lowered_grade_2(&v), false); }
+    if (failures == 0) { std::cout << \"ALL 11 PASS\\n\"; return 0; }
+    std::cerr << failures << \" FAILURES\\n\"; return 1;
+}
+").


### PR DESCRIPTION
## Summary

Ports the gated **T6 first-argument indexing** (just merged for Rust, #2977) to **C++** — the remaining string-atom target, where the proven string-atom win applies. Reuses the existing T5 `wam_clause_chain` front-end; when the discriminators are **all atoms** and there are **≥ `t6_min_clauses`** of them (option, **default 8**), the back-end replaces the T5 if-cascade with:

1. a no-copy `WamState::match_reg_atom_str` (returns a pointer to the deref'd first-arg atom's `std::string` — no allocation), then
2. a `static std::unordered_map<std::string,int>` (built once) → `switch` jump table on the index.

C++ has no native string `switch`, so the map *is* the indexing structure: one hash + one compare + a jump, instead of up to N derefs + `std::string` compares. Below the gate it stays the T5 cascade.

## Verify-it's-a-win (the stated constraint)

Benchmarked the **generated** code — g++ -O2, 5M dispatches, keys rotated over the whole key space:

| N clauses | T5 cascade | T6 map+switch | speedup |
|---:|---:|---:|:-:|
| 4 (gate declines → T5) | 355 ms | 343 ms | 1.0× (tie) |
| 8 (gate threshold) | 499 ms | 237 ms | **2.1×** |
| 16 | 707 ms | 259 ms | **2.7×** |
| 64 | 3096 ms | 266 ms | **11.6×** |
| 256 | 12310 ms | 302 ms | **40.8×** |

The win is *larger* than Rust's (the C++ T5 cascade is a fully linear chain of `std::string` compares, O(N); the map is ~flat). Tie at 4 clauses confirms the gate default (8) is safe — T6 never loses at/above it.

## Tests

New `test_wam_cpp_lowered_t6.pl` (`RESULT_ALL_PASS`):
- **gate**: `shade/1` ×12 and `grade/2` ×12 emit the map+switch; `few/1` (3 clauses) stays the T5 cascade.
- **exec parity**: first / middle / last clause hit, no-match atom, non-atom integer, and unbound first arg (the last two defer/fail → `false`).

## Docs
- `wam_rust_dispatch_alloc_perf.md`: C++ T6 table + `match_reg_atom_str`/map-switch description; notes int-interned targets remain unverified (highest "lost to the compiler" risk — an int equality chain is already switch-converted by the backend compiler).
- Taxonomy matrix: cpp T6 → `~` gated.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_