### PR TITLE
feat(wam-wat): T2 if-then-else / negation / once lowering (closes the T2 column)

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -107,7 +107,7 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 | python  | ✓ | ✓ T2a | ✗ | ✗ | **✓** | ✗ | ~ | ~ | ✗ | ✗ | ✗ |
 | r       | ✓ | ✓ T2a | ✓ | **✓** | ✗ | ✗ | ✗ | ~ | ✓ | **✓** | ✗ |
 | elixir  | ✓ | ✓ T2b | ✓ | ✓ | ✗ | ✗ | **✓** | ✓ | ✓ | ✗ | ✗ |
-| wat     | ✓ | **✗** | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| wat     | ✓ | ✓ T2a | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 
 Verification notes:
 - **T3** confirmed ✓ for haskell and fsharp (both lower clause 1 and fall
@@ -181,9 +181,16 @@ Reading down the columns (after the T5 and T4 sweeps landed):
   64, 12.7× at 256 — so it is gated to the many-clause case (see
   `docs/reports/wam_rust_dispatch_alloc_perf.md`); the compiler flattens the
   cascade for few clauses (matching the prior Go array-dispatch result).
-- **T2 (ITE)** — complete everywhere **except WAT** (the one remaining ITE
-  gap; WAT has native `if/then/else` + `block`, so it's tractable). Closing
-  it makes the T2 column fully ✓.
+- **T2 (ITE)** — now **complete across every target**, including WAT: the
+  lowered emitter folds the soft-cut block with the shared `wam_ite_structurer`
+  and emits native WAT (`(block $ite_condK (result i32) …)` for the condition
+  with a `br` on first failure, a saved trail mark, and `$unwind_trail` before
+  the else). `test_wam_wat_lowered_t2` exec-tests branch selection / negation /
+  once / sequential+nested ITE via wat2wasm+node, and asserts the lowered fast
+  path matches the bytecode interpreter on every case. (A pre-existing
+  WAT-runtime limitation — a condition's variable binding is not propagated
+  into the then-branch — is present in BOTH the lowered and interpreter paths,
+  so the lowering is faithful; that runtime fix is tracked separately.)
 - **python T3** — python still lacks the clause-1 fast path (its only
   multi-clause lowering is T5); a small, contained gap.
 - **T10 (mode-driven specialisation)** and **T11 (LCO)** are essentially
@@ -226,8 +233,9 @@ Score each candidate gap on four axes, then sequence:
    (`is_ite_block_py`) to cross-check the shared front-end against. Lands
    behind the existing `emit_mode(functions)` gate with interpreter
    fallback → low risk.
-2. **WAT T2 (ITE).** Closes the last ITE cell; small, gated, exec-testable
-   (`wat2wasm` + `node`). Finishes the T2 column.
+2. **WAT T2 (ITE). — DONE.** Closed the last ITE cell; gated, exec-tested
+   (`wat2wasm` + `node`) with a lowered-vs-interpreter parity check. The T2
+   column is now fully ✓.
 3. **T4 (multi-clause all-clauses)** for the structurer targets, reusing R's
    iter-CP shape as the reference. Removes the interpreter hop for fully
    supported predicates that aren't first-arg-discriminable (so don't get

--- a/src/unifyweaver/targets/wam_wat_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_wat_lowered_emitter.pl
@@ -17,14 +17,79 @@
 ]).
 
 :- use_module(library(lists)).
+:- use_module(wam_ite_structurer, [structure_ite/2]).
 
 %% wam_wat_lowerable(+PI, +WamCode, -Reason) is semidet.
 wam_wat_lowerable(_PI, WamCode, Reason) :-
     parse_wam_text_wat(WamCode, Instrs),
     clause1_instrs_wat(Instrs, C1, MultiClause),
-    is_deterministic_pred_wat(C1),
-    forall(member(I, C1), wat_supported(I)),
-    ( MultiClause == true -> Reason = multi_clause_1 ; Reason = single_clause ).
+    (   is_deterministic_pred_wat(C1),
+        forall(member(I, C1), wat_supported(I))
+    ->  ( MultiClause == true -> Reason = multi_clause_1 ; Reason = single_clause )
+    ;   % Clause-1 has an inner choice point: lower only if it is a pure
+        % (C -> T ; E) / \+ / once block (T2) whose pieces are all supported.
+        % structure_ite folds the soft-cut block into ite(Cond,Then,Else) and
+        % drops the structural markers; we then emit native WAT if/else with a
+        % trail rollback before the else. structure_ite only succeeds for a
+        % genuine single ITE block (its then-path must end in a jump; a real
+        % multi-clause predicate ends each clause in proceed, so it cannot
+        % fold) — so no extra multi-clause guard is needed here.
+        wat_structured_clause1(WamCode, Structured),
+        forall(member(I, Structured), wat_supported_structured(I)),
+        Reason = ite_lowered
+    ).
+
+%% wat_structured_clause1(+WamCode, -Structured) is semidet.
+%  Re-parse keeping labels (reinserted from the label map), take clause 1, and
+%  fold its ITE block(s) into ite/3. Succeeds only when an ite is present and
+%  every block is consumed (no leftover try_me_else/trust_me/retry_me_else).
+wat_structured_clause1(WamCode, Structured) :-
+    wat_labeled_instrs(WamCode, Labeled),
+    take_to_proceed_labeled(Labeled, C1L),
+    % structure_ite can offer more than one fold for clauses with sequential
+    % or nested ITE blocks; commit to the first fully-structured one so the
+    % gate and the emitter agree on a single deterministic result (otherwise
+    % the project writer emits the lowered function once per solution).
+    once(( structure_ite(C1L, Structured),
+           member(ite(_, _, _), Structured),
+           \+ member(try_me_else(_), Structured),
+           \+ member(trust_me, Structured),
+           \+ member(retry_me_else(_), Structured) )).
+
+%% wat_labeled_instrs(+WamCode, -Labeled)
+%  Parse like parse_wam_text_wat but reinsert label(Name) markers inline (at
+%  the instruction index recorded in the label map), so structure_ite can see
+%  the try_me_else/label/trust_me/jump block boundaries it folds on.
+wat_labeled_instrs(WamCode, Labeled) :-
+    (   string(WamCode) -> S = WamCode ; atom_string(WamCode, S) ),
+    split_string(S, "\n", "", Lines),
+    wam_wat_target:wam_lines_to_instrs(Lines, 0, Instrs, Labels),
+    reinsert_labels(Instrs, 0, Labels, Labeled).
+
+% Insert label(Name) before the instruction whose 0-based index matches the
+% label's PC. Pred-name labels (containing '/') are skipped — they are not part
+% of any ITE block and would only add noise.
+reinsert_labels([], _, _, []).
+reinsert_labels([I|Rest], Idx, Labels, Out) :-
+    findall(label(Name),
+            ( member(NameS-Idx, Labels), \+ sub_string(NameS, _, _, _, "/"),
+              atom_string(Name, NameS) ),
+            Here),
+    append(Here, [I|More], Out),
+    Idx1 is Idx + 1,
+    reinsert_labels(Rest, Idx1, Labels, More).
+
+take_to_proceed_labeled([], []).
+take_to_proceed_labeled([proceed|_], [proceed]) :- !.
+take_to_proceed_labeled([I|Rest], [I|More]) :- take_to_proceed_labeled(Rest, More).
+
+%% wat_supported_structured(+StructuredInstr)
+wat_supported_structured(ite(C, T, E)) :- !,
+    forall(member(I, C), wat_supported_structured(I)),
+    forall(member(I, T), wat_supported_structured(I)),
+    forall(member(I, E), wat_supported_structured(I)).
+wat_supported_structured(label(_)) :- !.   % residual head/cont label: skipped on emit
+wat_supported_structured(I) :- wat_supported(I).
 
 parse_wam_text_wat(WamCode, Instrs) :-
     (   string(WamCode) -> S = WamCode
@@ -109,10 +174,14 @@ lower_predicate_to_wat(PI, WamCode, _Options, lowered(PredName, FuncName, Code))
     ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     format(atom(PredName), '~w/~w', [Pred, Arity]),
     wat_lowered_func_name(Pred/Arity, FuncName),
-    wam_wat_lowerable(PI, WamCode, _Reason),
-    parse_wam_text_wat(WamCode, Instrs),
-    clause1_instrs_wat(Instrs, C1, _MultiClause),
-    with_output_to(atom(Code), emit_lowered_function_wat(FuncName, C1)).
+    wam_wat_lowerable(PI, WamCode, Reason),
+    (   Reason == ite_lowered
+    ->  wat_structured_clause1(WamCode, Structured),
+        with_output_to(atom(Code), emit_lowered_ite_function_wat(FuncName, Structured))
+    ;   parse_wam_text_wat(WamCode, Instrs),
+        clause1_instrs_wat(Instrs, C1, _MultiClause),
+        with_output_to(atom(Code), emit_lowered_function_wat(FuncName, C1))
+    ).
 
 emit_lowered_function_wat(FuncName, Instrs) :-
     format('(func $~w (result i32)~n', [FuncName]),
@@ -129,3 +198,70 @@ emit_lowered_instrs_wat([Instr|Rest]) :-
     format('  (if (i32.eqz (call $do_~w (i64.const ~w) (i64.const ~w)))~n', [DoName, Op1, Op2]),
     format('    (then (return (i32.const 0))))~n'),
     emit_lowered_instrs_wat(Rest).
+
+% =====================================================================
+% T2: if-then-else / negation / once  (structured ite/3)
+% =====================================================================
+%
+%  Emit native WAT if/else for each ite(Cond,Then,Else). The condition runs
+%  inside a labeled `(block $condK (result i32) … (i32.const 1))`: each
+%  condition instruction that fails branches out with `(br $condK (i32.const
+%  0))`, otherwise the block yields 1. A trail mark saved before the block lets
+%  the else branch undo any partial bindings the condition made
+%  (`$unwind_trail`), mirroring the bytecode `try_me_else`+`cut_ite` semantics
+%  where the failed condition's choice-point trail mark is unwound. The
+%  then/else branches emit with the ENCLOSING failure continuation (a real
+%  failure there fails the whole lowered clause → the public entry replays via
+%  $run_loop), while the condition emits with the block-local one.
+%
+%  WAT requires all locals declared right after the header, so we count the
+%  ite blocks first and declare one `$ite_markK` per block; the body emit uses
+%  the same monotone K so marks never collide across nesting.
+emit_lowered_ite_function_wat(FuncName, Structured) :-
+    count_ites(Structured, NMarks),
+    format('(func $~w (result i32)~n', [FuncName]),
+    format('  ;; WAM-WAT lowered if-then-else (T2). On failure the public entry replays via $run_loop.~n'),
+    forall(between(1, NMarks, K0),
+           ( K is K0 - 1, format('  (local $ite_mark~w i32)~n', [K]) )),
+    nb_setval(wat_ite_ctr, 0),
+    emit_struct_wat(Structured, '(return (i32.const 0))'),
+    format('  (i32.const 1)~n'),
+    format(')~n').
+
+count_ites(List, N) :- count_ites(List, 0, N).
+count_ites([], N, N).
+count_ites([ite(C,T,E)|Rest], N0, N) :- !,
+    N1 is N0 + 1,
+    count_ites(C, N1, N2), count_ites(T, N2, N3), count_ites(E, N3, N4),
+    count_ites(Rest, N4, N).
+count_ites([_|Rest], N0, N) :- count_ites(Rest, N0, N).
+
+%% emit_struct_wat(+StructuredInstrs, +FailCont)
+%  FailCont is the WAT snippet to run when an instruction fails (either
+%  `(return (i32.const 0))` at clause level, or `(br $condK (i32.const 0))`
+%  inside a condition block).
+emit_struct_wat([], _).
+emit_struct_wat([label(_)|Rest], FailCont) :- !,
+    emit_struct_wat(Rest, FailCont).
+emit_struct_wat([proceed|_], _) :- !,
+    format('  (return (i32.const 1))~n').
+emit_struct_wat([ite(Cond, Then, Else)|Rest], FailCont) :- !,
+    nb_getval(wat_ite_ctr, K), K1 is K + 1, nb_setval(wat_ite_ctr, K1),
+    format('  (local.set $ite_mark~w (call $get_trail_top))~n', [K]),
+    format('  (if (block $ite_cond~w (result i32)~n', [K]),
+    format(atom(CondFail), '(br $ite_cond~w (i32.const 0))', [K]),
+    emit_struct_wat(Cond, CondFail),
+    format('    (i32.const 1))~n'),
+    format('    (then~n'),
+    emit_struct_wat(Then, FailCont),
+    format('    )~n'),
+    format('    (else~n'),
+    format('      (call $unwind_trail (local.get $ite_mark~w))~n', [K]),
+    emit_struct_wat(Else, FailCont),
+    format('    ))~n'),
+    emit_struct_wat(Rest, FailCont).
+emit_struct_wat([Instr|Rest], FailCont) :-
+    wam_wat_target:wam_instruction_to_wat_operands(Instr, [], DoName, Op1, Op2),
+    format('  (if (i32.eqz (call $do_~w (i64.const ~w) (i64.const ~w)))~n', [DoName, Op1, Op2]),
+    format('    (then ~w))~n', [FailCont]),
+    emit_struct_wat(Rest, FailCont).

--- a/tests/test_wam_wat_lowered_t2.pl
+++ b/tests/test_wam_wat_lowered_t2.pl
@@ -1,0 +1,203 @@
+% test_wam_wat_lowered_t2.pl
+%
+% End-to-end execution test for the WAT T2 lowering — if-then-else /
+% negation / once ( ( C -> T ; E ), \+ G, once/1 ) — lowering type T2 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md. This closes the last
+% ✗ in the T2 column (every other hybrid target already lowers ITE).
+%
+% The shared wam_ite_structurer folds the soft-cut block
+% (try_me_else … <cond> cut_ite <then> jump … ; trust_me <else>) into
+% ite(Cond,Then,Else); the WAT emitter then emits native WAT: the condition
+% runs in a `(block $ite_condK (result i32) … (i32.const 1))` that branches out
+% with 0 on the first failing instruction, a trail mark is saved before it, and
+% the else branch is preceded by `$unwind_trail` (mirroring the bytecode
+% try_me_else/cut_ite choice-point trail unwind).
+%
+% Two layers of assertions:
+%   (1) ABSOLUTE correctness, on the cases the WAT runtime executes correctly
+%       (condition truth -> branch selection, then/else body success/failure,
+%       negation, once, and sequential ITE blocks): the lowered export returns
+%       the Prolog-correct 1/0.
+%   (2) PARITY: the lowered (emit_mode(functions)) result equals the bytecode
+%       interpreter (emit_mode(interpreter)) result for EVERY case — the core
+%       property of a faithful lowering. (A few ITE shapes that thread a
+%       variable binding from the condition into the then-branch / continuation
+%       expose a PRE-EXISTING WAT-runtime limitation present in BOTH paths;
+%       parity still holds and is what we assert there.)
+%
+% Skipped automatically when wat2wasm or node is unavailable.
+
+:- use_module(library(lists)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_wat_target').
+:- use_module('../src/unifyweaver/targets/wam_wat_lowered_emitter').
+
+:- dynamic user:ite_then_ok/0, user:ite_then_body_fail/0,
+           user:ite_else_ok/0, user:ite_else_body_fail/0,
+           user:neg_true/0, user:neg_false/0,
+           user:once_true/0, user:once_false/0,
+           user:multi_ite/0, user:nest_ite/0,
+           user:cond_bind/0.
+
+% Branch selection by condition truth; branch body success/failure proves the
+% RIGHT branch ran (not just that some branch succeeded).
+user:ite_then_ok        :- ( 5 > 0 -> true ; fail ).   % then taken, then=true  -> 1
+user:ite_then_body_fail :- ( 5 > 0 -> fail ; true ).   % then taken, then=fail  -> 0
+user:ite_else_ok        :- ( 0 > 5 -> fail ; true ).   % else taken, else=true  -> 1
+user:ite_else_body_fail :- ( 0 > 5 -> true ; fail ).   % else taken, else=fail  -> 0
+% negation / once
+user:neg_true   :- \+ 0 > 5.        % 0>5 false -> \+ succeeds -> 1
+user:neg_false  :- \+ 5 > 0.        % 5>0 true  -> \+ fails    -> 0
+user:once_true  :- once( 5 > 0 ).   % -> 1
+user:once_false :- once( 0 > 5 ).   % -> 0
+% sequential + nested ITE blocks (also guards against the duplicate-function
+% emission that a nondeterministic structuring would cause).
+user:multi_ite  :- ( 5 > 0 -> true ; fail ), ( 0 > 5 -> fail ; true ).         % -> 1
+user:nest_ite   :- ( 5 > 0 -> ( 5 > 10 -> fail ; true ) ; fail ).             % -> 1
+% condition binds a variable used in the then-branch: parity-only (the WAT
+% runtime does not propagate the binding cond->then in EITHER path).
+user:cond_bind  :- ( X = 7 -> X > 5 ; fail ).
+
+% Name-Expected for the absolute-correctness cases.
+correctness_cases([ ite_then_ok-1, ite_then_body_fail-0,
+                    ite_else_ok-1, ite_else_body_fail-0,
+                    neg_true-1, neg_false-0,
+                    once_true-1, once_false-0,
+                    multi_ite-1, nest_ite-1 ]).
+
+% All predicates (correctness + parity-only) for the gate and parity checks.
+all_preds([ ite_then_ok, ite_then_body_fail, ite_else_ok, ite_else_body_fail,
+            neg_true, neg_false, once_true, once_false,
+            multi_ite, nest_ite, cond_bind ]).
+
+tool_available(Tool) :-
+    catch(process_create(path(Tool), ['--version'], [stdout(null), stderr(null)]),
+          _, fail).
+
+wat_tools_available :- tool_available(wat2wasm), tool_available(node).
+
+:- begin_tests(wam_wat_lowered_t2, [condition(wat_tools_available)]).
+
+% Every pin must lower as ite_lowered (the T2 path), not via the interpreter.
+test(gate_picks_ite_lowered) :-
+    all_preds(Ps),
+    forall(member(Name, Ps),
+           ( PI = Name/0,
+             wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_wat_lowerable(PI, W, Reason),
+             assertion(Reason == ite_lowered) )).
+
+% The emitted WAT must contain the native if/else condition block + trail mark
+% + unwind for the ITE.
+test(emits_native_ite) :-
+    wam_target:compile_predicate_to_wam(ite_else_ok/0, [], W),
+    lower_predicate_to_wat(user:ite_else_ok/0, W, [], lowered(_, _, Code)),
+    assertion(sub_atom(Code, _, _, _, 'block $ite_cond0')),
+    assertion(sub_atom(Code, _, _, _, 'call $get_trail_top')),
+    assertion(sub_atom(Code, _, _, _, 'call $unwind_trail')).
+
+% Lowering must be deterministic: exactly one lowered function per predicate
+% (a nondeterministic structuring previously emitted duplicates for sequential
+% / nested ITE blocks, which wat2wasm rejects as a redefinition).
+test(lowering_deterministic) :-
+    forall(member(Name, [multi_ite, nest_ite, cond_bind]),
+           ( PI = Name/0,
+             wam_target:compile_predicate_to_wam(PI, [], W),
+             findall(C, lower_predicate_to_wat(PI, W, [], C), Cs),
+             length(Cs, N),
+             assertion(N == 1) )).
+
+% Absolute correctness: the lowered export returns the Prolog-correct 1/0.
+test(t2_exec_correctness) :-
+    correctness_cases(Cs),
+    findall(Name, member(Name-_, Cs), Names),
+    build_module(functions, Names, WasmFile, Harness),
+    findall(Name-Got-Want,
+            ( member(Name-Want, Cs),
+              format(atom(Export), '~w_0', [Name]),
+              run_export(Harness, WasmFile, Export, Got),
+              Got =\= Want ),
+            Failures),
+    ( Failures == []
+    ->  true
+    ;   format(user_error, "~n[wat t2 correctness mismatches]~n~q~n", [Failures]),
+        throw(wam_wat_t2_failed(Failures))
+    ).
+
+% Parity: the lowered fast path agrees with the bytecode interpreter for EVERY
+% predicate (the defining property of a faithful lowering).
+test(t2_lowered_matches_interpreter) :-
+    all_preds(Names),
+    build_module(functions,   Names, LoweredWasm, Harness),
+    build_module(interpreter, Names, InterpWasm, _),
+    findall(Name-Lo-In,
+            ( member(Name, Names),
+              format(atom(Export), '~w_0', [Name]),
+              run_export(Harness, LoweredWasm, Export, Lo),
+              run_export(Harness, InterpWasm, Export, In),
+              Lo =\= In ),
+            Disagreements),
+    ( Disagreements == []
+    ->  true
+    ;   format(user_error, "~n[wat t2 lowered/interp disagreements]~n~q~n", [Disagreements]),
+        throw(wam_wat_t2_parity_failed(Disagreements))
+    ).
+
+:- end_tests(wam_wat_lowered_t2).
+
+% --- build + run helpers (wat2wasm + node, mirrors test_wam_wat_target.pl) ---
+
+build_module(Mode, Names, WasmFile, Harness) :-
+    format(atom(Dir), 'output/test_wam_wat_t2_~w', [Mode]),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    make_directory_path(Dir),
+    findall(Name/0, member(Name, Names), Preds),
+    format(atom(WatFile), '~w/t2.wat', [Dir]),
+    format(atom(Module), 'wat_t2_~w', [Mode]),
+    write_wam_wat_project(Preds, [module_name(Module), emit_mode(Mode)], WatFile),
+    compile_wat(WatFile, WasmFile),
+    ensure_harness(Harness).
+
+compile_wat(WatFile, WasmFile) :-
+    file_name_extension(Base, _, WatFile),
+    file_name_extension(Base, wasm, WasmFile),
+    format(string(Cmd), "wat2wasm ~w -o ~w 2>&1", [WatFile, WasmFile]),
+    process_create(path(sh), ['-c', Cmd], [stdout(pipe(Out)), process(Pid)]),
+    read_string(Out, _, CompileOut), close(Out),
+    process_wait(Pid, Exit),
+    ( Exit == exit(0) -> true
+    ; throw(wam_wat_t2_compile_failed(CompileOut)) ).
+
+run_export(Harness, WasmFile, Export, Result) :-
+    process_create(path(node), [Harness, WasmFile, Export],
+                   [stdout(pipe(Out)), stderr(null), process(Pid)]),
+    read_string(Out, _, RunOut), close(Out),
+    process_wait(Pid, _),
+    ( sub_string(RunOut, _, _, _, "RESULT "),
+      split_string(RunOut, " \n", " \n", Parts),
+      append(_, ["RESULT", RS|_], Parts),
+      number_string(Result, RS)
+    -> true
+    ; throw(wam_wat_t2_run_failed(Export, RunOut)) ).
+
+ensure_harness(Path) :-
+    Path = 'output/test_wam_wat_t2_harness.js',
+    ( exists_file(Path) -> true
+    ; harness_source(Src),
+      setup_call_cleanup(open(Path, write, S), write(S, Src), close(S)) ).
+
+harness_source(Src) :-
+    Src = "const fs=require('fs');\n\c
+const [,,wasmPath,exportName]=process.argv;\n\c
+const bytes=fs.readFileSync(wasmPath);\n\c
+const imports={env:{\n\c
+  print_i64:_=>0, print_char:_=>0, print_newline:_=>0\n\c
+}};\n\c
+(async()=>{\n\c
+  try{\n\c
+    const{instance}=await WebAssembly.instantiate(bytes,imports);\n\c
+    const fn=instance.exports[exportName];\n\c
+    if(typeof fn!=='function'){console.log('ERROR export '+exportName+' not found');process.exit(1);}\n\c
+    console.log('RESULT '+fn());\n\c
+  }catch(e){console.log('ERROR '+e.message);process.exit(1);}\n\c
+})();\n".


### PR DESCRIPTION
## Summary

Closes the **last ✗ in the T2 (if-then-else / negation / once) column** — WAT was the only hybrid target whose lowered emitter didn't handle ITE (an `( C -> T ; E )` / `\+ G` / `once/1` clause failed the `wat_supported` gate on `cut_ite` and fell back to the interpreter).

The WAT lowered emitter now folds the soft-cut block (`try_me_else … cut_ite … jump … ; trust_me …`) into `ite(Cond,Then,Else)` via the shared `wam_ite_structurer`, and emits native WAT:

- the condition runs in a `(block $ite_condK (result i32) … (i32.const 1))` that branches out with `0` on the first failing instruction;
- a trail mark (`$get_trail_top`) is saved before the condition, and the else branch is preceded by `$unwind_trail` — mirroring the bytecode `try_me_else`/`cut_ite` choice-point trail unwind;
- a "fail continuation" is threaded so a failure **inside the condition** exits the cond block (`br`) while a failure in **then/else** fails the lowered clause (`return 0`); nested ITEs get distinct `$ite_markK` locals (declared up front, as WAT requires).

## Two bugs fixed along the way
- Removed an over-strict `\+ (Instrs = [try_me_else|_])` guard that wrongly excluded **prefix-less single-clause ITEs** (e.g. `\+` over an all-constant goal, which compiles to a body starting directly with `try_me_else`). `structure_ite` already only folds genuine single ITE blocks, so the guard was redundant.
- Made the structuring **deterministic** (`once/1`): sequential/nested ITE blocks previously yielded multiple structurings, so `lower_predicate_to_wat` emitted the **same lowered function more than once** → wat2wasm "redefinition" error.

## Tests — `test_wam_wat_lowered_t2.pl` (wat2wasm + node)
- **gate**: every pin lowers as `ite_lowered`.
- **shape**: emitted WAT contains the cond block + `$get_trail_top` + `$unwind_trail`.
- **determinism**: exactly one lowered function per predicate (regression guard for the duplicate-emit bug).
- **exec correctness**: branch selection (then/else, by both condition truth and branch-body success/failure), negation, once, and sequential+nested ITE all return the Prolog-correct `1`/`0` via the lowered export.
- **parity**: the lowered fast path matches the bytecode interpreter on every case — the defining property of a faithful lowering.

The existing `test_wam_wat_target` suite still passes.

## Pre-existing runtime limitation (out of scope, noted)
A condition's **variable binding is not propagated into the then-branch** by the WAT runtime — but this is true in **both** the lowered and interpreter paths (verified), so the lowering is faithful (parity holds). This is a shared-runtime defect, not introduced here; flagged for a separate fix.

Docs: taxonomy matrix marks `wat` T2 = ✓ (T2 column now fully ✓); narrative + sequencing updated.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_