### PR TITLE
fix(wam-llvm): lower a2 constant fallthrough switches

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -15970,6 +15970,8 @@ wam_line_to_llvm_literal_resolved(["jump", L], LabelMap, Lit) :- !,
     format(atom(Lit), '%Instruction { i32 32, i64 ~w, i64 0 }', [LabelIdx]).
 wam_line_to_llvm_literal_resolved(["switch_on_constant_fallthrough" | _], _, Lit) :- !,
     Lit = '%Instruction { i32 26, i64 0, i64 0 }'.
+wam_line_to_llvm_literal_resolved(["switch_on_constant_a2_fallthrough" | _], _, Lit) :- !,
+    Lit = '%Instruction { i32 27, i64 0, i64 0 }'.
 % switch_on_constant: defer until compile_wam_predicate_to_llvm can
 % allocate a switch table global. Returns a switch_deferred(_) term.
 wam_line_to_llvm_literal_resolved(["switch_on_constant" | EntryParts], LabelMap,
@@ -16322,6 +16324,8 @@ wam_line_to_llvm_literal(["jump", _], _) :-
 
 wam_line_to_llvm_literal(["switch_on_constant_fallthrough" | _],
     '%Instruction { i32 26, i64 0, i64 0 }') :- !.
+wam_line_to_llvm_literal(["switch_on_constant_a2_fallthrough" | _],
+    '%Instruction { i32 27, i64 0, i64 0 }') :- !.
 
 wam_line_to_llvm_literal(Parts, Lit) :-
     atomic_list_concat(Parts, " ", Line),

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -135,6 +135,14 @@ test(parse_line_proceed) :-
     wam_line_to_llvm_literal(["proceed"], Lit),
     assertion(Lit == '%Instruction { i32 20, i64 0, i64 0 }').
 
+test(parse_line_switch_on_constant_a2_fallthrough) :-
+    wam_line_to_llvm_literal(["switch_on_constant_a2_fallthrough", "end_of_file:default"], Lit),
+    assertion(Lit == '%Instruction { i32 27, i64 0, i64 0 }').
+
+test(resolve_line_switch_on_constant_a2_fallthrough) :-
+    wam_llvm_target:wam_line_to_llvm_literal_resolved(["switch_on_constant_a2_fallthrough", "end_of_file:default"], [], Lit),
+    assertion(Lit == '%Instruction { i32 27, i64 0, i64 0 }').
+
 test(parse_label_and_instr) :-
     WamCode = "parent/2:\n    get_constant john, A1\n    proceed",
     compile_wam_predicate_to_llvm(parent/2, WamCode, [], LLVMCode),


### PR DESCRIPTION
# Fix WAM/LLVM A2 constant fallthrough parsing

## Summary

- Lower `switch_on_constant_a2_fallthrough` to a no-op WAM/LLVM instruction instead of emitting a TODO comment into the LLVM instruction array.
- Add parser regression coverage for both direct and label-resolved WAM text parsing paths.
- Keep the fix target-side and general, rather than adding a PLAWK-specific workaround.

## Verification

- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/test_wam_llvm_stream_runtime.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`

## Notes

This came out of the PLAWK compiled-core smoke work. The broader smoke exposed a separate boundary around recursive `process_all/4`, meta-call dispatch, and native stream handle persistence through `state/4`; that is not included here.