### PR TITLE
test: export resolved category edges for distribution benchmarks

### DIFF
--- a/docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md
+++ b/docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md
@@ -60,6 +60,12 @@ target list before passing it to `scripts/distribution_cache_benchmark.py`.
 The sampler owns root selection, depth capping, and admin/container filtering;
 the benchmark runner owns measurement over the resulting TSV.
 
+Use `scripts/export_distribution_cache_edges.py` when starting from the
+resolved SimpleWiki SQLite database created by `examples/benchmark/parse_simplewiki_dump.py`.
+Existing benchmark artifacts may already provide numeric `category_parent.tsv`
+files; those can be sampled directly when run with the matching numeric root
+from their `root_categories.tsv` sidecar.
+
 Under those constraints, cached-distribution search should be semantically exact.
 Any discrepancy against full exact search is a bug in orientation, budget
 accounting, normalization, cycle policy, or path-statistic handling.

--- a/docs/reports/distribution_cache_real_simplewiki_artifact_2026-06-10.md
+++ b/docs/reports/distribution_cache_real_simplewiki_artifact_2026-06-10.md
@@ -1,0 +1,84 @@
+# Distribution Cache Real SimpleWiki Artifact Smoke Report
+
+Date: 2026-06-10
+
+Branch: `codex/simplewiki-lmdb-distribution-export`
+
+## Scope
+
+This report covers the first distribution-cache benchmark run against an
+existing local SimpleWiki benchmark artifact.
+
+The local artifact discovered under `~/Projects/UnifyWeaver` was:
+
+```text
+/home/s243a/Projects/UnifyWeaver/data/benchmark/simplewiki_articles/category_parent.tsv
+```
+
+That TSV is numeric-id based rather than human-readable category-title based.
+Its `root_categories.tsv` identifies root id `2`, so the sampler and benchmark
+were run with `--root 2`.
+
+For future human-readable runs, this branch also adds
+`scripts/export_distribution_cache_edges.py`, which exports resolved category
+edges from `data/simplewiki/simplewiki_categories.db` after the existing
+three-dump SimpleWiki parser has joined `categorylinks`, `linktarget`, and
+`page`.
+
+## Unit Tests
+
+Command:
+
+```text
+python3 -m unittest tests/test_distribution_cache_parity.py tests/test_distribution_cache_benchmark.py tests/test_distribution_cache_subtree_sampler.py tests/test_export_distribution_cache_edges.py
+```
+
+Result:
+
+```text
+............
+----------------------------------------------------------------------
+Ran 12 tests in 0.012s
+
+OK
+```
+
+## Sampler Smoke Run
+
+Command:
+
+```text
+python3 scripts/sample_distribution_cache_subtree.py --edge-file /home/s243a/Projects/UnifyWeaver/data/benchmark/simplewiki_articles/category_parent.tsv --root 2 --max-depth 2 --output /mnt/c/Users/johnc/Scratch/distribution-cache-lmdb-export/simplewiki_articles_root2_depth2.tsv --targets-output /mnt/c/Users/johnc/Scratch/distribution-cache-lmdb-export/simplewiki_articles_root2_depth2_targets.txt
+```
+
+Result:
+
+```text
+root=2
+selected_nodes=14644
+sampled_edges=14851
+max_depth=2
+wrote_edges=/mnt/c/Users/johnc/Scratch/distribution-cache-lmdb-export/simplewiki_articles_root2_depth2.tsv
+wrote_targets=/mnt/c/Users/johnc/Scratch/distribution-cache-lmdb-export/simplewiki_articles_root2_depth2_targets.txt
+```
+
+## Benchmark Smoke Run
+
+Command:
+
+```text
+python3 scripts/distribution_cache_benchmark.py --edge-file /mnt/c/Users/johnc/Scratch/distribution-cache-lmdb-export/simplewiki_articles_root2_depth2.tsv --graph-name simplewiki_articles_root2_depth2_numeric --root 2 --targets-file /mnt/c/Users/johnc/Scratch/distribution-cache-lmdb-export/simplewiki_articles_root2_depth2_targets.txt --target-limit 500 --precompute-depths 0,1,2 --budgets 2,4 --output-dir /mnt/c/Users/johnc/Scratch/distribution-cache-lmdb-export --fail-on-error
+```
+
+Summary:
+
+| fixture | D_pre | B_search | cache_nodes | cache_bytes | full_ms | cached_ms | speedup | hit_rate | exact_failures |
+|---------|-------|----------|-------------|-------------|---------|-----------|---------|----------|----------------|
+| simplewiki_articles_root2_depth2_numeric | 0 | 2 | 1 | 566 | 1.602792 | 1.957799 | 0.819 | 1.000 | 0 |
+| simplewiki_articles_root2_depth2_numeric | 0 | 4 | 1 | 566 | 1.553598 | 1.859647 | 0.835 | 1.000 | 0 |
+| simplewiki_articles_root2_depth2_numeric | 1 | 2 | 13721 | 5289038 | 2.197429 | 0.800229 | 2.746 | 1.000 | 0 |
+| simplewiki_articles_root2_depth2_numeric | 1 | 4 | 13721 | 5289038 | 2.854687 | 1.019099 | 2.801 | 1.000 | 0 |
+| simplewiki_articles_root2_depth2_numeric | 2 | 2 | 14644 | 5605061 | 1.669414 | 0.624972 | 2.671 | 1.000 | 0 |
+| simplewiki_articles_root2_depth2_numeric | 2 | 4 | 14644 | 5605061 | 1.722279 | 0.679698 | 2.534 | 1.000 | 0 |
+
+Result: sampled real-artifact benchmark completed with zero exactness failures.

--- a/scripts/export_distribution_cache_edges.py
+++ b/scripts/export_distribution_cache_edges.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Export resolved category edges for distribution-cache benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from pathlib import Path
+
+
+DEFAULT_DB_PATH = Path("data/simplewiki/simplewiki_categories.db")
+
+
+def category_node(title: str) -> str:
+    return title if title.startswith("Category:") else f"Category:{title}"
+
+
+def iter_category_parent_edges(conn: sqlite3.Connection):
+    cursor = conn.execute(
+        """
+        SELECT p.page_title AS child, cl.cl_to AS parent
+        FROM categorylinks cl
+        JOIN page p ON cl.cl_from = p.page_id
+        WHERE cl.cl_type = 'subcat'
+          AND p.page_namespace = 14
+          AND cl.cl_to IS NOT NULL
+          AND cl.cl_to != ''
+        ORDER BY child, parent
+        """
+    )
+    for child, parent in cursor:
+        yield category_node(child), category_node(parent)
+
+
+def write_edges(conn: sqlite3.Connection, output_path: Path) -> int:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    with output_path.open("w", encoding="utf-8") as handle:
+        handle.write("child\tparent\n")
+        for child, parent in iter_category_parent_edges(conn):
+            handle.write(f"{child}\t{parent}\n")
+            count += 1
+    return count
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH, help="Resolved SimpleWiki category SQLite DB.")
+    parser.add_argument("--output", required=True, type=Path, help="Output TSV with child<TAB>parent category edges.")
+    args = parser.parse_args(argv)
+
+    if not args.db.exists():
+        raise SystemExit(
+            f"database not found: {args.db}\n"
+            "Build it with examples/benchmark/parse_simplewiki_dump.py or pass --db."
+        )
+
+    conn = sqlite3.connect(str(args.db))
+    try:
+        count = write_edges(conn, args.output)
+    finally:
+        conn.close()
+
+    print(f"db={args.db}")
+    print(f"edges_written={count}")
+    print(f"output={args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_export_distribution_cache_edges.py
+++ b/tests/test_export_distribution_cache_edges.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Tests for resolved category edge export."""
+
+import sqlite3
+import unittest
+
+from scripts.export_distribution_cache_edges import category_node, iter_category_parent_edges
+
+
+def make_conn():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE page (
+            page_id INTEGER PRIMARY KEY,
+            page_title TEXT,
+            page_namespace INTEGER
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE categorylinks (
+            cl_from INTEGER,
+            cl_to TEXT,
+            cl_type TEXT
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO page (page_id, page_title, page_namespace) VALUES (?, ?, ?)",
+        [
+            (1, "Articles", 14),
+            (2, "Science", 14),
+            (3, "Physics", 14),
+            (4, "Albert_Einstein", 0),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO categorylinks (cl_from, cl_to, cl_type) VALUES (?, ?, ?)",
+        [
+            (2, "Articles", "subcat"),
+            (3, "Science", "subcat"),
+            (4, "Physics", "page"),
+        ],
+    )
+    return conn
+
+
+class ExportDistributionCacheEdgesTests(unittest.TestCase):
+    def test_category_node_adds_prefix_once(self):
+        self.assertEqual(category_node("Science"), "Category:Science")
+        self.assertEqual(category_node("Category:Science"), "Category:Science")
+
+    def test_iter_category_parent_edges_exports_resolved_subcat_edges(self):
+        conn = make_conn()
+        try:
+            rows = list(iter_category_parent_edges(conn))
+        finally:
+            conn.close()
+
+        self.assertEqual(
+            rows,
+            [
+                ("Category:Physics", "Category:Science"),
+                ("Category:Science", "Category:Articles"),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Export resolved SimpleWiki category edges for distribution benchmarks

## Description
Adds a bridge from resolved SimpleWiki category data into the distribution-cache benchmark pipeline.

### Changes
- Adds `scripts/export_distribution_cache_edges.py` to export `child<TAB>parent` category edges from `simplewiki_categories.db`.
- Normalizes exported nodes to `Category:<title>` form for human-readable benchmark inputs.
- Adds unit coverage for resolved category edge export.
- Updates the distribution cache benchmark plan with two supported real-data paths:
  - resolved SQLite export via `examples/benchmark/parse_simplewiki_dump.py`
  - existing numeric `category_parent.tsv` artifacts using the matching numeric root from `root_categories.tsv`
- Adds a tracked smoke report at `docs/reports/distribution_cache_real_simplewiki_artifact_2026-06-10.md`.

### Verification
```text
python3 -m unittest tests/test_distribution_cache_parity.py tests/test_distribution_cache_benchmark.py tests/test_distribution_cache_subtree_sampler.py tests/test_export_distribution_cache_edges.py
Ran 12 tests in 0.012s
OK