### PR TITLE
feat(wam): emit simple native WAM items

### DIFF
--- a/docs/design/WAM_ITEMS_API_SPECIFICATION.md
+++ b/docs/design/WAM_ITEMS_API_SPECIFICATION.md
@@ -11,14 +11,18 @@ see `WAM_REPRESENTATION_MODES.md`.
 The first implementation step is intentionally conservative:
 
 - `compile_predicate_to_wam_text/3` is now the explicit legacy text API.
-- `compile_predicate_to_wam_items/3` is available as a bridge: it compiles text
-  through the existing generator and normalizes it with `wam_text_to_items/2`.
+- `compile_predicate_to_wam_items/3` is available as the structured API. It now
+  emits single-clause fact predicates and simple one-goal user-predicate tail
+  calls directly as items, and falls back to the existing text generator plus
+  `wam_text_to_items/2` for multi-goal rules, multi-clause predicates,
+  aggregates, indexing, lowered builtins, and other complex shapes.
 - `compile_predicate_to_wam/3` still returns text by default for compatibility
   with the existing targets. The default-output flip described below remains a
   later migration step after more callers consume items directly.
 
 The final API shape below is still the target design; current code deliberately
-lands the low-risk bridge first.
+lands native item emission incrementally, with the compatibility bridge retained
+until the full WAM emitter can become items-first.
 
 ## 1. Public API
 

--- a/docs/design/WAM_REPRESENTATION_MODES.md
+++ b/docs/design/WAM_REPRESENTATION_MODES.md
@@ -52,9 +52,11 @@ non-WAM target when they want direct target-native code.
 Python also accepts an explicit `wam_ir(wam_items_native)` override for
 interpreter-mode predicate emission. Today that target path consumes the common
 structured WAM items directly and is output-equivalent to `wam_items_bridge`;
-the shared `compile_predicate_to_wam_items/3` producer is still implemented as a
-text-to-items bridge. Once the shared producer becomes native, this explicit
-mode will skip WAM text end-to-end without changing the Python emitter.
+the shared `compile_predicate_to_wam_items/3` producer now skips WAM text for
+single-clause facts and simple one-goal user-predicate tail calls, then falls
+back to the text-to-items bridge for more complex predicate shapes. As the
+native producer expands, the same explicit Python mode will skip WAM text for
+more predicates without changing the Python emitter.
 
 Lua, R, and Elixir follow the same partial migration shape as Python:
 interpreter-mode generated predicates consume common WAM items through the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -56,32 +56,49 @@ compile_predicate(PredArity, Options, Code) :-
 compile_predicate_to_wam(PredIndicator, Options, Code) :-
     compile_predicate_to_wam_text(PredIndicator, Options, Code).
 
-%% compile_predicate_to_wam_text(+PredIndicator, +Options, -Code)
-%  Compile a predicate to canonical WAM text.
-compile_predicate_to_wam_text(PredIndicator, Options, Code) :-
-    % Handle module qualification
-    (   PredIndicator = Module:Pred/Arity -> true
-    ;   PredIndicator = Pred/Arity -> option(module(Module), Options, user)
+%% resolve_wam_predicate_indicator(+PredIndicator, +Options,
+%%                                 -Module, -Pred, -Arity) is semidet.
+%  Normalise the supported predicate-indicator forms used by both text and
+%  items producers.
+resolve_wam_predicate_indicator(PredIndicator, Options, Module, Pred, Arity) :-
+    (   PredIndicator = Module:Pred/Arity
+    ->  true
+    ;   PredIndicator = Pred/Arity
+    ->  option(module(Module), Options, user)
     ;   format(user_error, 'WAM target: invalid predicate indicator ~w~n', [PredIndicator]),
         fail
-    ),
+    ).
+
+%% wam_predicate_clauses(+PredIndicator, +Options, -Pred, -Arity, -Clauses)
+%  Fetch clauses once so the text and items entry points share identical
+%  predicate resolution and missing-predicate behaviour.
+wam_predicate_clauses(PredIndicator, Options, Pred, Arity, Clauses) :-
+    resolve_wam_predicate_indicator(PredIndicator, Options, Module, Pred, Arity),
     functor(Head, Pred, Arity),
-    % Find all clauses for the predicate in the specified module
     findall(Head-Body, clause(Module:Head, Body), Clauses),
     (   Clauses = []
     ->  format(user_error, 'WAM target: no clauses for ~w:~w/~w~n', [Module, Pred, Arity]),
         fail
-    ;   compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code)
+    ;   true
     ).
 
+%% compile_predicate_to_wam_text(+PredIndicator, +Options, -Code)
+%  Compile a predicate to canonical WAM text.
+compile_predicate_to_wam_text(PredIndicator, Options, Code) :-
+    wam_predicate_clauses(PredIndicator, Options, Pred, Arity, Clauses),
+    compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code).
+
 %% compile_predicate_to_wam_items(+PredIndicator, +Options, -Items)
-%  Compile a predicate to structured WAM items. This bridge keeps the legacy
-%  text generator as the source of truth for now, then normalizes through the
-%  shared parser. A later generator pass can replace this with direct item
-%  emission without changing target-facing call sites.
+%  Compile a predicate to structured WAM items. Facts and simple one-goal user
+%  tail calls use direct item emission. More complex predicates fall back to the
+%  text generator plus shared parser until the full WAM emitter is items-first.
 compile_predicate_to_wam_items(PredIndicator, Options, Items) :-
-    compile_predicate_to_wam_text(PredIndicator, Options, Code),
-    wam_text_to_items(Code, Items).
+    wam_predicate_clauses(PredIndicator, Options, Pred, Arity, Clauses),
+    (   compile_clauses_to_wam_items_native(Pred, Arity, Clauses, Options, Items)
+    ->  true
+    ;   compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code),
+        wam_text_to_items(Code, Items)
+    ).
 
 %% compile_wam_module(+Predicates, +Options, -Code) is det.
 %
@@ -183,6 +200,170 @@ compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code) :-
     ->  combine_clauses_and_chains(ClausesCode, DispatchChains, ChainedClauses),
         format(string(Code), "~w~n~w~n~w", [Label, IndexHeader, ChainedClauses])
     ;   format(string(Code), "~w~n~w", [Label, ClausesCode])
+    ).
+
+%% compile_clauses_to_wam_items_native(+Pred, +Arity, +Clauses, +Options, -Items)
+%  Direct items path for simple single-clause predicates. This is the first
+%  incremental native producer slice; aggregates, indexing, lowered builtins,
+%  multi-goal rules, and peephole-sensitive shapes intentionally fall back to
+%  the legacy text bridge.
+compile_clauses_to_wam_items_native(Pred, Arity, [Head-Body], _Options, Items) :-
+    normalize_goals(Body, []),
+    !,
+    Head =.. [_|Args],
+    empty_varmap(V0),
+    compile_head_arguments_items(Args, 1, V0, _V1, HeadItems),
+    format(string(Label), "~w/~w", [Pred, Arity]),
+    append(HeadItems, [proceed], InstrItems),
+    Items = [label(Label)|InstrItems].
+compile_clauses_to_wam_items_native(Pred, Arity, [Head-Body], _Options, Items) :-
+    normalize_goals(Body, [Goal]),
+    native_simple_execute_goal(Goal),
+    !,
+    Head =.. [_|Args],
+    empty_varmap(V0),
+    pre_assign_permanent_vars([Goal], V0, V0a),
+    compile_head_arguments_items(Args, 1, V0a, V1, HeadItems),
+    compile_goal_execute_items_simple(Goal, V1, _Vf, GoalItems),
+    format(string(Label), "~w/~w", [Pred, Arity]),
+    append(HeadItems, GoalItems, InstrItems),
+    Items = [label(Label), allocate|InstrItems].
+
+native_simple_execute_goal(Goal) :-
+    callable(Goal),
+    Goal =.. [GoalPred|Args],
+    length(Args, Arity),
+    \+ is_builtin_pred(GoalPred, Arity),
+    forall(member(Arg, Args), native_simple_goal_arg(Arg)).
+
+native_simple_goal_arg(Arg) :-
+    var(Arg), !.
+native_simple_goal_arg(Arg) :-
+    atomic(Arg).
+
+compile_goal_execute_items_simple(Goal, V0, Vf, Items) :-
+    Goal =.. [GoalPred|Args],
+    length(Args, Arity),
+    compile_put_arguments_items_simple(Args, 1, V0, Vf, PutItems),
+    wam_functor_token(GoalPred, Arity, PredTok),
+    append(PutItems, [deallocate, execute(PredTok)], Items).
+
+compile_put_arguments_items_simple([], _, V, V, []).
+compile_put_arguments_items_simple([Arg|Rest], I, V0, Vf, Items) :-
+    compile_put_argument_items_simple(Arg, I, V0, V1, ArgItems),
+    NI is I + 1,
+    compile_put_arguments_items_simple(Rest, NI, V1, Vf, RestItems),
+    append(ArgItems, RestItems, Items).
+
+compile_put_argument_items_simple(Arg, I, V0, V1, Items) :-
+    wam_arg_register(I, Ai),
+    (   var(Arg)
+    ->  (   get_var_reg(Arg, V0, Reg)
+        ->  wam_operand_string(Reg, RegTok),
+            Items = [put_value(RegTok, Ai)],
+            V1 = V0
+        ;   get_yi_alloc(Arg, V0, YReg, V1)
+        ->  wam_operand_string(YReg, YRegTok),
+            Items = [put_variable(YRegTok, Ai)]
+        ;   next_x_reg(V0, XReg, VTemp),
+            bind_var(Arg, XReg, VTemp, V1),
+            wam_operand_string(XReg, XRegTok),
+            Items = [put_variable(XRegTok, Ai)]
+        )
+    ;   atomic(Arg)
+    ->  quote_wam_constant(Arg, ArgTok),
+        Items = [put_constant(ArgTok, Ai)],
+        V1 = V0
+    ).
+
+compile_head_arguments_items([], _, V, V, []).
+compile_head_arguments_items([Arg|Rest], I, V0, Vf, Items) :-
+    compile_head_argument_items(Arg, I, V0, V1, ArgItems),
+    NI is I + 1,
+    compile_head_arguments_items(Rest, NI, V1, Vf, RestItems),
+    append(ArgItems, RestItems, Items).
+
+compile_head_argument_items(Arg, I, V0, V1, Items) :-
+    wam_arg_register(I, Ai),
+    (   var(Arg)
+    ->  (   get_var_reg(Arg, V0, Reg)
+        ->  wam_operand_string(Reg, RegTok),
+            Items = [get_value(RegTok, Ai)],
+            V1 = V0
+        ;   get_yi_alloc(Arg, V0, YReg, V1)
+        ->  wam_operand_string(YReg, YRegTok),
+            Items = [get_variable(YRegTok, Ai)]
+        ;   next_x_reg(V0, XReg, VTemp),
+            bind_var(Arg, XReg, VTemp, V1),
+            wam_operand_string(XReg, XRegTok),
+            Items = [get_variable(XRegTok, Ai)]
+        )
+    ;   atomic(Arg)
+    ->  quote_wam_constant(Arg, ArgTok),
+        Items = [get_constant(ArgTok, Ai)],
+        V1 = V0
+    ;   is_list_term(Arg)
+    ->  Arg = [H|T],
+        compile_unify_arguments_items([H, T], V0, V1, SubItems),
+        Items = [get_list(Ai)|SubItems]
+    ;   compound(Arg)
+    ->  Arg =.. [F|SubArgs],
+        length(SubArgs, SArity),
+        wam_functor_token(F, SArity, FunctorTok),
+        compile_unify_arguments_items(SubArgs, V0, V1, SubItems),
+        Items = [get_structure(FunctorTok, Ai)|SubItems]
+    ).
+
+compile_unify_arguments_items([], V, V, []).
+compile_unify_arguments_items([Arg|Rest], V0, Vf, Items) :-
+    (   var(Arg)
+    ->  (   get_var_reg(Arg, V0, Reg)
+        ->  wam_operand_string(Reg, RegTok),
+            ArgItems = [unify_value(RegTok)],
+            V1 = V0
+        ;   get_yi_alloc(Arg, V0, YReg, V1)
+        ->  wam_operand_string(YReg, YRegTok),
+            ArgItems = [unify_variable(YRegTok)]
+        ;   next_x_reg(V0, XReg, VTemp),
+            bind_var(Arg, XReg, VTemp, V1),
+            wam_operand_string(XReg, XRegTok),
+            ArgItems = [unify_variable(XRegTok)]
+        )
+    ;   atomic(Arg)
+    ->  quote_wam_constant(Arg, ArgTok),
+        ArgItems = [unify_constant(ArgTok)],
+        V1 = V0
+    ;   compound(Arg)
+    ->  Arg =.. [F|NestedArgs],
+        length(NestedArgs, NArity),
+        next_x_reg(V0, XReg, VTemp),
+        bind_var(Arg, XReg, VTemp, V1a),
+        wam_operand_string(XReg, XRegTok),
+        wam_functor_token(F, NArity, FunctorTok),
+        compile_unify_arguments_items(NestedArgs, V1a, V1, NestedItems),
+        ArgItems = [unify_variable(XRegTok), get_structure(FunctorTok, XRegTok)|NestedItems]
+    ;   next_x_reg(V0, XReg, VTemp),
+        bind_var(Arg, XReg, VTemp, V1),
+        wam_operand_string(XReg, XRegTok),
+        ArgItems = [unify_variable(XRegTok)]
+    ),
+    compile_unify_arguments_items(Rest, V1, Vf, RestItems),
+    append(ArgItems, RestItems, Items).
+
+wam_arg_register(I, Ai) :-
+    format(string(Ai), "A~w", [I]).
+
+wam_functor_token(F, Arity, Token) :-
+    format(string(Token), "~w/~w", [F, Arity]).
+
+wam_operand_string(Value, String) :-
+    (   string(Value)
+    ->  String = Value
+    ;   atom(Value)
+    ->  atom_string(Value, String)
+    ;   number(Value)
+    ->  number_string(Value, String)
+    ;   term_string(Value, String)
     ).
 
 combine_clauses_and_chains(ClausesCode, "", ClausesCode) :- !.

--- a/tests/test_wam_target.pl
+++ b/tests/test_wam_target.pl
@@ -3,15 +3,19 @@
 % Usage: swipl -g run_tests -t halt tests/test_wam_target.pl
 
 :- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_text_parser', [wam_text_to_items/2]).
 
 %% Test data (facts) - MUST BE DYNAMIC for clause/2 to work across modules
-:- dynamic test_parent/2, test_grandparent/2, test_ancestor/2, test_wrap/2.
+:- dynamic test_parent/2, test_grandparent/2, test_ancestor/2, test_wrap/2, test_alias/2.
 
 test_parent(alice, bob).
 test_parent(bob, charlie).
 
 %% Grandparent rule
 test_grandparent(X, Z) :- test_parent(X, Y), test_parent(Y, Z).
+
+%% Simple forwarding rule — exercises native items for a one-goal tail call.
+test_alias(X, Y) :- test_parent(X, Y).
 
 %% Recursive ancestor rule
 test_ancestor(X, Y) :- test_parent(X, Y).
@@ -311,8 +315,49 @@ test_wam_mixed_mode_a1_indexing :-
                   'Mixed-mode A1 indexing did not emit the expected pseudo-instruction')
     ).
 
-test_wam_items_api_bridge :-
-    Test = 'WAM: items API bridge',
+test_wam_items_native_single_fact :-
+    Test = 'WAM: native items API for single fact',
+    ExpectedItems = [
+        label("test_color/2"),
+        get_structure("rgb/3", "A1"),
+        unify_constant("255"),
+        unify_constant("0"),
+        unify_constant("0"),
+        get_constant("red", "A2"),
+        proceed
+    ],
+    (   wam_target:compile_predicate_to_wam_text(user:test_color/2, [], TextCode),
+        wam_text_to_items(TextCode, BridgeItems),
+        wam_target:compile_predicate_to_wam_items(user:test_color/2, [], Items),
+        Items == ExpectedItems,
+        Items == BridgeItems
+    ->  pass(Test)
+    ;   fail_test(Test, 'Native fact items do not match canonical WAM text shape')
+    ).
+
+test_wam_items_native_simple_tail_call :-
+    Test = 'WAM: native items API for simple tail call',
+    ExpectedItems = [
+        label("test_alias/2"),
+        allocate,
+        get_variable("X1", "A1"),
+        get_variable("X2", "A2"),
+        put_value("X1", "A1"),
+        put_value("X2", "A2"),
+        deallocate,
+        execute("test_parent/2")
+    ],
+    (   wam_target:compile_predicate_to_wam_text(user:test_alias/2, [], TextCode),
+        wam_text_to_items(TextCode, BridgeItems),
+        wam_target:compile_predicate_to_wam_items(user:test_alias/2, [], Items),
+        Items == ExpectedItems,
+        Items == BridgeItems
+    ->  pass(Test)
+    ;   fail_test(Test, 'Native simple-tail-call items do not match canonical WAM text shape')
+    ).
+
+test_wam_items_api_rule_fallback :-
+    Test = 'WAM: items API rule fallback',
     (   wam_target:compile_predicate_to_wam(user:test_grandparent/2, [], LegacyCode),
         wam_target:compile_predicate_to_wam_text(user:test_grandparent/2, [], TextCode),
         wam_target:compile_predicate_to_wam_items(user:test_grandparent/2, [], Items),
@@ -338,7 +383,9 @@ run_tests :-
     test_wam_nested_put_structure,
     test_wam_compound_head,
     test_wam_module,
-    test_wam_items_api_bridge,
+    test_wam_items_native_single_fact,
+    test_wam_items_native_simple_tail_call,
+    test_wam_items_api_rule_fallback,
     test_wam_multi_clause_findall_emits_allocate,
     test_wam_a2_indexing,
     test_wam_mixed_mode_a1_indexing,


### PR DESCRIPTION
## Summary

- add a direct `compile_predicate_to_wam_items/3` producer path for single-clause facts
- add a direct items path for simple one-goal user-predicate tail calls
- keep complex predicates on the existing WAM text plus shared parser fallback
- update WAM items/mode docs to describe the partial native coverage honestly

## Notes

This is an incremental step toward the items-first WAM producer. It skips serialized WAM text for simple common shapes, while multi-goal rules, multi-clause predicates, aggregates, indexing, lowered builtins, and peephole-sensitive forms still use the compatibility bridge.

## Tests

- `swipl -q -f tests/test_wam_target.pl`
- `swipl -q -f tests/test_wam_ir_mode.pl`
- `swipl -q -f tests/test_wam_python_target.pl`
- `swipl -q -f tests/test_wam_text_parser.pl -g run_tests -t halt`
- `git diff --check`
