### PR TITLE
WAM C/C++: var-var unification aliasing fix (M143) + LLVM harness tag-check (M142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **WAM C + C++ targets (M143): var-var unification created no
+  alias.** Found by a behavioral sweep of 8 targets with the
+  M139/M140 probe shapes (Rust, Python, Go, Haskell, F#, Scala
+  interpreters: clean). Both runtimes copied one unbound marker over
+  the other when unifying two unbound cells, leaving the variables
+  independent: `X = Y, X = 1, Y = 2` **succeeded** and
+  `X = Y, X = 42, Y =:= 42` failed — in the C++ case in both
+  interpreter and lowered modes, since the bug sat in the shared
+  runtime (`unify_cells`).
+  - **C** (`wam_c_runtime/wam_runtime.h`): the unbound-unbound case
+    now installs a `VAL_REF` from one cell to the other's heap slot
+    (preferring a heap-resident referent; two non-heap cells keep
+    the legacy copy as a last resort).
+  - **C++** (`wam_cpp_target.pl` runtime): the cell model has no Ref
+    tag and 100+ direct payload-read sites, so instead of a
+    forwarding tag the fix records var-var **alias pairs**;
+    `bind_cell` propagates a later real value across the alias graph
+    (each write individually trailed), and `alias_pop` trail entries
+    dissolve pairs on backtrack. All 13 inline trail-unwind loops
+    were routed through the alias-aware `unwind_trail_to` (the
+    first cut left them raw and segfaulted on backtrack over an
+    alias entry).
+  - New gated exec regression tests: `tests/test_wam_c_var_alias.pl`
+    and `tests/test_wam_cpp_var_alias.pl` (chain, conflict-must-fail,
+    3-deep chain, alias-dissolves-on-backtrack).
+- **WAM LLVM test harness (M142): integer tag-check in exec-driver
+  result reads.** Both integer drivers returned the raw payload of
+  the result register — a non-integer result leaked its atom id or
+  heap address as a mystery exit code (a test ending in `X = x`
+  exited 90, the atom id of `x`), producing two red-herring diagnoses
+  during the M138–M141 work. The drivers now deref the result and
+  require an Integer tag: wrong tag exits 254 with an explanatory
+  message, and predicate failure (255) gets one too.
+
+### Known issues (found by the M143 sweep, not yet fixed)
+- **Rust WAM target (interpreter mode):** if-then-else does not
+  commit to the then-branch — `( 1 =:= 1 -> R is 1 ; R is 0 )`
+  queried with R=0 succeeds by backtracking into the else branch.
+  Lowered mode is correct.
+- **Haskell WAM target (ST mode):** `runMutableRegs` writes
+  `GetLevel Yn` register operands (ids 201+) straight into the
+  STArray sized to `maxRegId = 199` — any if-then-else predicate
+  crashes with an index error on the ST path (the pure-`run` path
+  routes Y-regs through env frames and is correct).
+- **Scala WAM target (lowered mode):** the lowered emitter
+  (`wam_scala_lowered_emitter.pl:632`) emits a bare `{ ... }` block
+  after a call statement; scalac parses the brace as an argument
+  list (`Unit does not take parameters`) — `emit_mode(functions)`
+  projects using `put_variable Yn, A1` do not compile.
 - **WAM LLVM target (M141): `is_list/1` never succeeded.** The
   follow-up flagged in M140: `builtin_is_list_check` accepted only
   the legacy tag-4 List value, but the engine builds lists as

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -800,6 +800,33 @@ static inline bool wam_unify(WamState *state, WamValue *v1, WamValue *v2) {
         
         if (d1 == d2) continue;
         
+        if (d1->tag == VAL_UNBOUND && d2->tag == VAL_UNBOUND) {
+            /* M143: var-var unification must ALIAS the two cells, not
+               copy one unbound marker over the other (which left them
+               independent: X = Y, X = 1, Y = 2 succeeded). Install a
+               VAL_REF from one cell to the other's heap slot so a later
+               binding through either is seen by both. Prefer pointing
+               the ref at a heap-resident cell; if only one cell lives
+               in H_array, redirect the non-heap one at it. Two non-heap
+               unbound cells (no heap slot to reference) keep the legacy
+               copy as a last resort. */
+            long i1 = d1 - state->H_array;
+            long i2 = d2 - state->H_array;
+            bool in1 = (i1 >= 0 && i1 < (long)state->H);
+            bool in2 = (i2 >= 0 && i2 < (long)state->H);
+            if (in2) {
+                trail_binding(state, d1);
+                d1->tag = VAL_REF;
+                d1->data.ref_addr = (int)i2;
+            } else if (in1) {
+                trail_binding(state, d2);
+                d2->tag = VAL_REF;
+                d2->data.ref_addr = (int)i1;
+            } else {
+                wam_bind(state, d1, d2);
+            }
+            continue;
+        }
         if (d1->tag == VAL_UNBOUND || d2->tag == VAL_UNBOUND) {
             WamValue *unbound = (d1->tag == VAL_UNBOUND) ? d1 : d2;
             WamValue *other = (d1->tag == VAL_UNBOUND) ? d2 : d1;

--- a/src/unifyweaver/targets/wam_cpp_target.pl
+++ b/src/unifyweaver/targets/wam_cpp_target.pl
@@ -3310,8 +3310,12 @@ public:
 };
 
 struct TrailEntry {
-    CellPtr cell;
+    CellPtr cell;     // null for alias_pop entries
     Value prev;
+    // M143: when true, undo = pop the last alias_pairs entry instead of
+    // restoring a cell value. Recorded by the var-var case of
+    // unify_cells so backtracking dissolves the alias.
+    bool alias_pop = false;
 };
 
 // Environment frame for permanent variables (Y-regs) and continuation
@@ -3538,6 +3542,10 @@ struct WamState {
     std::unordered_map<std::string, std::size_t> labels;
     std::vector<Instruction> instrs;
     std::vector<TrailEntry> trail;
+    // M143: var-var alias pairs recorded by unify_cells; bind_cell
+    // propagates real values across them. Popped on backtrack via
+    // alias_pop trail entries.
+    std::vector<std::pair<CellPtr, CellPtr>> alias_pairs;
     std::vector<ChoicePoint> choice_points;
     std::vector<AggregateFrame> aggregate_frames;
     std::vector<CatcherFrame> catcher_frames;
@@ -3777,6 +3785,7 @@ struct WamState {
     // Used by lowered if-then-else when the condition fails, before the
     // else branch runs.
     void    unwind_trail_to(std::size_t mark);
+    void    propagate_alias(const CellPtr& c, const Value& v);
 
     // T4 (multi_clause_n): capture / restore the clause-entry state a lowered
     // function tries each clause against — see ClauseSnapshot.
@@ -4256,7 +4265,49 @@ void WamState::unwind_trail_to(std::size_t mark) {
     while (trail.size() > mark) {
         TrailEntry t = std::move(trail.back());
         trail.pop_back();
-        *t.cell = std::move(t.prev);
+        if (t.alias_pop) {
+            if (!alias_pairs.empty()) alias_pairs.pop_back();
+        } else {
+            *t.cell = std::move(t.prev);
+        }
+    }
+}
+
+// M143: write v into every cell alias-connected to c that is still
+// unbound. Var-var unification records (a, b) pairs instead of copying
+// one unbound marker over the other (which left the two variables
+// independent: X = Y, X = 1, Y = 2 succeeded). Reads need no changes -
+// aliased cells stay genuinely Unbound until a real value arrives, at
+// which point this propagation makes every member of the alias group
+// see it (each write individually trailed for backtracking).
+void WamState::propagate_alias(const CellPtr& c, const Value& v) {
+    std::vector<const Value*> visited;
+    visited.push_back(c.get());
+    std::vector<CellPtr> frontier;
+    frontier.push_back(c);
+    while (!frontier.empty()) {
+        CellPtr cur = frontier.back();
+        frontier.pop_back();
+        for (const auto& pr : alias_pairs) {
+            CellPtr other;
+            if (pr.first.get() == cur.get()) other = pr.second;
+            else if (pr.second.get() == cur.get()) other = pr.first;
+            else continue;
+            bool seen = false;
+            for (const Value* p : visited) {
+                if (p == other.get()) { seen = true; break; }
+            }
+            if (seen) continue;
+            visited.push_back(other.get());
+            if (other->is_unbound()) {
+                TrailEntry e;
+                e.cell = other;
+                e.prev = *other;
+                trail.push_back(std::move(e));
+                *other = v;
+            }
+            frontier.push_back(other);
+        }
     }
 }
 
@@ -4283,7 +4334,12 @@ void WamState::bind_cell(CellPtr cell, Value v) {
     e.cell = cell;
     e.prev = *cell;
     trail.push_back(std::move(e));
-    *cell = std::move(v);
+    *cell = v;
+    // M143: a real value arriving at an alias-connected cell must reach
+    // every other member of the group. No-op when no aliases exist.
+    if (v.tag != Value::Tag::Unbound && !alias_pairs.empty()) {
+        propagate_alias(cell, v);
+    }
 }
 
 Value WamState::deref(const Value& v) const {
@@ -4299,6 +4355,18 @@ bool WamState::unify_cells(CellPtr a, CellPtr b) {
     if (a.get() == b.get()) return true;
     Value& va = *a;
     Value& vb = *b;
+    if (va.is_unbound() && vb.is_unbound()) {
+        // M143: var-var unification ALIASES the two cells. The old
+        // bind_cell(a, vb) copied the b-side unbound marker into a,
+        // leaving the variables independent. Record the pair (undone
+        // via an alias_pop trail entry on backtrack); bind_cell
+        // propagates a later real value across the pair.
+        alias_pairs.emplace_back(a, b);
+        TrailEntry e;
+        e.alias_pop = true;
+        trail.push_back(std::move(e));
+        return true;
+    }
     if (va.is_unbound()) { bind_cell(a, vb); return true; }
     if (vb.is_unbound()) { bind_cell(b, va); return true; }
     if (va.tag != vb.tag) return false;
@@ -4731,11 +4799,7 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
             if (negation_frames.size() > my_depth) {
                 NegationFrame nf = std::move(negation_frames.back());
                 negation_frames.pop_back();
-                while (trail.size() > nf.trail_mark) {
-                    TrailEntry t = std::move(trail.back());
-                    trail.pop_back();
-                    *t.cell = std::move(t.prev);
-                }
+                unwind_trail_to(nf.trail_mark);
                 while (aggregate_frames.size() > nf.base_agg_count)
                     aggregate_frames.pop_back();
                 while (catcher_frames.size() > nf.base_catcher_count)
@@ -4838,11 +4902,7 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
         std::size_t mark = trail.size();
         bool ok = unify_cells(get_cell("A1"), get_cell("A2"));
         // Roll back any bindings we just made.
-        while (trail.size() > mark) {
-            TrailEntry t = std::move(trail.back());
-            trail.pop_back();
-            *t.cell = std::move(t.prev);
-        }
+        unwind_trail_to(mark);
         if (ok) return false;
         pc += 1; return true;
     }
@@ -5852,11 +5912,7 @@ bool WamState::builtin(const std::string& op, std::int64_t /*arity*/) {
                     CellPtr fresh = deep_copy_term(clause);
                     bool ok = unify_cells(pattern, fresh);
                     // Undo bindings either way.
-                    while (trail.size() > mark) {
-                        TrailEntry te = std::move(trail.back());
-                        trail.pop_back();
-                        *te.cell = std::move(te.prev);
-                    }
+                    unwind_trail_to(mark);
                     return ok;
                 }), vec.end());
         }
@@ -7985,11 +8041,7 @@ bool WamState::step(const Instruction& instr) {
             if (negation_frames.empty()) return false;
             NegationFrame f = std::move(negation_frames.back());
             negation_frames.pop_back();
-            while (trail.size() > f.trail_mark) {
-                TrailEntry t = std::move(trail.back());
-                trail.pop_back();
-                *t.cell = std::move(t.prev);
-            }
+            unwind_trail_to(f.trail_mark);
             while (choice_points.size() > f.base_cp_count)
                 choice_points.pop_back();
             while (aggregate_frames.size() > f.base_agg_count)
@@ -9131,11 +9183,7 @@ bool WamState::current_pred_try_next() {
             cp = 0;
             return true;
         }
-        while (trail.size() > mark) {
-            TrailEntry te = std::move(trail.back());
-            trail.pop_back();
-            *te.cell = std::move(te.prev);
-        }
+        unwind_trail_to(mark);
         ++it.next_idx;
     }
     current_pred_iters.pop_back();
@@ -9223,11 +9271,7 @@ bool WamState::retract_try_next() {
             return true;
         }
         // No match at i — undo any partial bindings and try i+1.
-        while (trail.size() > mark) {
-            TrailEntry te = std::move(trail.back());
-            trail.pop_back();
-            *te.cell = std::move(te.prev);
-        }
+        unwind_trail_to(mark);
         ++i;
     }
     // Exhausted — drop the iterator and fail.
@@ -10199,11 +10243,7 @@ bool WamState::execute_throw() {
         CatcherFrame f = std::move(catcher_frames.back());
         catcher_frames.pop_back();
         // Restore VM state to the frame''s snapshot.
-        while (trail.size() > f.trail_mark) {
-            TrailEntry t = std::move(trail.back());
-            trail.pop_back();
-            *t.cell = std::move(t.prev);
-        }
+        unwind_trail_to(f.trail_mark);
         while (choice_points.size() > f.base_cp_count) choice_points.pop_back();
         while (aggregate_frames.size() > f.base_agg_count) aggregate_frames.pop_back();
         regs = f.saved_regs;
@@ -10219,11 +10259,7 @@ bool WamState::execute_throw() {
         }
         // No match: undo the failed unify attempt and try the next
         // outer frame.
-        while (trail.size() > mark) {
-            TrailEntry t = std::move(trail.back());
-            trail.pop_back();
-            *t.cell = std::move(t.prev);
-        }
+        unwind_trail_to(mark);
     }
     // Uncaught exception. Print it and signal a hard failure.
     std::fprintf(stderr, "uncaught exception: %s\\n",
@@ -10379,11 +10415,7 @@ bool WamState::backtrack() {
         {
             NegationFrame f = std::move(negation_frames.back());
             negation_frames.pop_back();
-            while (trail.size() > f.trail_mark) {
-                TrailEntry t = std::move(trail.back());
-                trail.pop_back();
-                *t.cell = std::move(t.prev);
-            }
+            unwind_trail_to(f.trail_mark);
             while (aggregate_frames.size() > f.base_agg_count)
                 aggregate_frames.pop_back();
             while (catcher_frames.size() > f.base_catcher_count)
@@ -10414,11 +10446,7 @@ bool WamState::backtrack() {
             catcher_frames.pop_back();
             // Unwind trail to the catcher''s mark — failure of the
             // protected goal undoes all bindings it made.
-            while (trail.size() > f.trail_mark) {
-                TrailEntry t = std::move(trail.back());
-                trail.pop_back();
-                *t.cell = std::move(t.prev);
-            }
+            unwind_trail_to(f.trail_mark);
             // Restore regs/env/mode/cp/cut so the world looks exactly
             // as it did at catch entry, then continue backtracking
             // outside the catch.
@@ -10443,11 +10471,7 @@ bool WamState::backtrack() {
         {
             OutputCaptureFrame f = std::move(output_capture_frames.back());
             output_capture_frames.pop_back();
-            while (trail.size() > f.trail_mark) {
-                TrailEntry t = std::move(trail.back());
-                trail.pop_back();
-                *t.cell = std::move(t.prev);
-            }
+            unwind_trail_to(f.trail_mark);
             regs        = std::move(f.saved_regs);
             mode_stack  = std::move(f.saved_mode_stack);
             env_stack   = std::move(f.saved_env_stack);
@@ -10462,11 +10486,7 @@ bool WamState::backtrack() {
             AggregateFrame f = std::move(aggregate_frames.back());
             aggregate_frames.pop_back();
             // Unwind any trail entries added inside the aggregate scope.
-            while (trail.size() > f.trail_mark) {
-                TrailEntry t = std::move(trail.back());
-                trail.pop_back();
-                *t.cell = std::move(t.prev);
-            }
+            unwind_trail_to(f.trail_mark);
             regs        = std::move(f.saved_regs);
             mode_stack  = std::move(f.saved_mode_stack);
             env_stack   = std::move(f.saved_env_stack);
@@ -10567,11 +10587,7 @@ bool WamState::backtrack() {
         // We restore state via COPY so the snapshot remains intact for
         // any subsequent backtracks into this same CP.
         const ChoicePoint& cp_ = choice_points.back();
-        while (trail.size() > cp_.trail_mark) {
-            TrailEntry t = std::move(trail.back());
-            trail.pop_back();
-            *t.cell = std::move(t.prev);
-        }
+        unwind_trail_to(cp_.trail_mark);
         regs        = cp_.saved_regs;
         mode_stack  = cp_.saved_mode_stack;
         env_stack   = cp_.saved_env_stack;

--- a/tests/core/test_wam_llvm_builtin_execution.pl
+++ b/tests/core/test_wam_llvm_builtin_execution.pl
@@ -5727,9 +5727,21 @@ entry:
   %ok = call i1 @run_loop(%WamState* %vm)
   br i1 %ok, label %hit, label %miss
 hit:
-  %r = call i64 @wam_get_reg_payload(%WamState* %vm, i32 1)
+  ; M142: deref the result register and require an Integer. The old
+  ; raw-payload read returned atom ids / heap addresses for non-int
+  ; results, producing confusing "got 90"-style failures (exit code =
+  ; whatever the payload truncated to). Non-Integer results now exit
+  ; 254, matching the float driver''s wrong_tag convention.
+  %rv = call %Value @wam_get_reg_deref(%WamState* %vm, i32 1)
+  %rtag = extractvalue %Value %rv, 0
+  %is_int = icmp eq i32 %rtag, 1
+  br i1 %is_int, label %int_ok, label %wrong_tag
+int_ok:
+  %r = extractvalue %Value %rv, 1
   %r32 = trunc i64 %r to i32
   ret i32 %r32
+wrong_tag:
+  ret i32 254
 miss:
   ret i32 255
 }
@@ -5756,6 +5768,10 @@ miss:
     ),
     ( ExitCode =:= Expected
     -> format('PASS (~w)~n', [ExitCode])
+    ; ExitCode =:= 254
+    -> format('FAIL (result had wrong tag -- ensure the final goal binds R numerically, e.g. via is/2)~n')
+    ; ExitCode =:= 255
+    -> format('FAIL (predicate failed at runtime; expected ~w)~n', [Expected])
     ;  format('FAIL (got ~w, expected ~w)~n', [ExitCode, Expected])
     ),
     catch(delete_file(LLPath), _, true),
@@ -5823,11 +5839,22 @@ hit:
   ; can bind through it; once is/2 binds, reg 0 is a Ref whose
   ; payload is the heap address, NOT the result value. Deref-then-
   ; payload gets the actual integer the test expects.
+  ; M142: require an Integer tag. The raw payload of a non-int
+  ; result (atom id, heap address) used to leak out as a mystery
+  ; exit code -- e.g. a test ending in ``X = x'' exited 90 (the
+  ; atom id of x). Non-Integer results now exit 254; tests must
+  ; stage their result into A1 via a final numeric goal (R is ...).
   %r_raw = call %Value @wam_get_reg(%WamState* %vm, i32 0)
   %r_d = call %Value @wam_deref_value(%WamState* %vm, %Value %r_raw)
+  %r_tag = extractvalue %Value %r_d, 0
+  %r_is_int = icmp eq i32 %r_tag, 1
+  br i1 %r_is_int, label %int_ok, label %wrong_tag
+int_ok:
   %r_pay = extractvalue %Value %r_d, 1
   %r32 = trunc i64 %r_pay to i32
   ret i32 %r32
+wrong_tag:
+  ret i32 254
 miss:
   ret i32 255
 }
@@ -5854,6 +5881,10 @@ miss:
     ),
     ( ExitCode =:= Expected
     -> format('PASS (~w)~n', [ExitCode])
+    ; ExitCode =:= 254
+    -> format('FAIL (result had wrong tag -- ensure the final goal binds R numerically, e.g. via is/2)~n')
+    ; ExitCode =:= 255
+    -> format('FAIL (predicate failed at runtime; expected ~w)~n', [Expected])
     ;  format('FAIL (got ~w, expected ~w)~n', [ExitCode, Expected])
     ),
     catch(delete_file(LLPath), _, true),

--- a/tests/test_wam_c_var_alias.pl
+++ b/tests/test_wam_c_var_alias.pl
@@ -1,0 +1,128 @@
+:- encoding(utf8).
+% Var-var aliasing regression tests for the WAM C target (M143).
+%
+% PR #2976's cross-target sweep found the C runtime's wam_unify copied
+% one unbound cell over the other instead of installing a VAL_REF link,
+% so `X = Y` created no alias: `X = Y, X = 1, Y = 2` SUCCEEDED, and
+% `X = Y, X = 42, Y =:= 42` failed. wam_runtime.h's unbound-unbound
+% case now installs a VAL_REF to the partner's heap slot.
+%
+% Gated on gcc; compiles the probes + runtime with gcc and runs them,
+% mirroring run_real_prolog_builtin_executable_smoke in
+% tests/test_wam_c_target.pl.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_c_target').
+:- use_module('../src/unifyweaver/targets/wam_target').
+
+:- dynamic user:c_alias_chain/1.
+:- dynamic user:c_alias_conflict/1.
+:- dynamic user:c_alias_chain3/1.
+:- dynamic user:c_alias_backtrack/1.
+
+% Binding through a var-var alias must propagate to both.
+user:c_alias_chain(R)    :- X = Y, X = 42, ( Y =:= 42 -> R is 1 ; R is 0 ).
+% Conflicting bindings through an alias must FAIL (the smoking gun:
+% this succeeded before the fix).
+user:c_alias_conflict(R) :- X = Y, X = 1, Y = 2, R is 1.
+% Three-deep chain.
+user:c_alias_chain3(R)   :- X = Y, Y = Z, X = 42, ( Z =:= 42 -> R is 1 ; R is 0 ).
+% Alias must dissolve on backtrack out of the aliasing goal.
+user:c_alias_backtrack(R) :-
+    ( X = Y, X = 1, Y = 2 -> R is 0
+    ; Y = 7, X = 5, ( Y =:= 7, X =:= 5 -> R is 1 ; R is 0 )
+    ).
+
+gcc_available :-
+    catch(( process_create(path(gcc), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_c_var_alias, [condition(gcc_available)]).
+
+test(var_alias_exec_parity) :-
+    Dir = 'output/test_wam_c_var_alias',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    make_directory_path(Dir),
+    Preds = [c_alias_chain, c_alias_conflict, c_alias_chain3, c_alias_backtrack],
+    findall(PredCode,
+            ( member(P, Preds),
+              compile_predicate_to_wam(user:P/1, [], WamCode),
+              compile_wam_predicate_to_c(user:P/1, WamCode, [], PredCode)
+            ),
+            PredCodes),
+    compile_wam_runtime_to_c([], RuntimeCode),
+    atomic_list_concat([Dir, '/runtime.c'], RuntimePath),
+    write_text_file(RuntimePath, RuntimeCode),
+    atomic_list_concat(PredCodes, '\n\n', AllPreds),
+    format(atom(PredTU), '#include "wam_runtime.h"~n~n~w', [AllPreds]),
+    atomic_list_concat([Dir, '/pred.c'], PredPath),
+    write_text_file(PredPath, PredTU),
+    driver_source(DriverSrc),
+    atomic_list_concat([Dir, '/main.c'], MainPath),
+    write_text_file(MainPath, DriverSrc),
+    % Locate the runtime header next to the C target module.
+    absolute_file_name('../src/unifyweaver/targets/wam_c_runtime', HdrDir,
+                       [relative_to('tests/'), file_type(directory)]),
+    atomic_list_concat([Dir, '/alias_bin'], ExePath),
+    format(atom(Cmd),
+        'gcc -O0 -I~w -o ~w ~w/main.c ~w/pred.c ~w/runtime.c -lm 2>&1 && ~w',
+        [HdrDir, ExePath, Dir, Dir, Dir, ExePath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 6 PASS")
+    ->  true
+    ;   format(user_error, "~n[c var-alias test output]~n~w~n", [OutStr]),
+        throw(c_var_alias_test_failed(Status))
+    ).
+
+:- end_tests(wam_c_var_alias).
+
+write_text_file(Path, Content) :-
+    setup_call_cleanup(
+        open(Path, write, Stream, [encoding(utf8)]),
+        format(Stream, '~w', [Content]),
+        close(Stream)).
+
+% C driver: each row is (pred, arg, expected_success). The R=1 / R=0
+% pairs read the actual value of R back through success/failure.
+driver_source('#include <stdio.h>
+#include "wam_runtime.h"
+
+void setup_c_alias_chain_1(WamState* state);
+void setup_c_alias_conflict_1(WamState* state);
+void setup_c_alias_chain3_1(WamState* state);
+void setup_c_alias_backtrack_1(WamState* state);
+
+static int check(WamState *state, const char *pred, int argval, int expect_true) {
+    WamValue args[1] = { val_int(argval) };
+    int rc = wam_run_predicate(state, pred, args, 1);
+    int is_true = (rc == 0 && state->P == WAM_HALT);
+    if (is_true == expect_true) { printf("PASS %s(%d)\\n", pred, argval); return 1; }
+    printf("FAIL %s(%d): got %s\\n", pred, argval, is_true ? "true" : "false");
+    return 0;
+}
+
+int main(void) {
+    WamState state;
+    wam_state_init(&state);
+    setup_c_alias_chain_1(&state);
+    setup_c_alias_conflict_1(&state);
+    setup_c_alias_chain3_1(&state);
+    setup_c_alias_backtrack_1(&state);
+    int n = 0;
+    n += check(&state, "c_alias_chain/1", 1, 1);
+    n += check(&state, "c_alias_chain/1", 0, 0);
+    n += check(&state, "c_alias_conflict/1", 1, 0);
+    n += check(&state, "c_alias_chain3/1", 1, 1);
+    n += check(&state, "c_alias_chain3/1", 0, 0);
+    n += check(&state, "c_alias_backtrack/1", 1, 1);
+    if (n == 6) printf("ALL 6 PASS\\n");
+    wam_free_state(&state);
+    return n == 6 ? 0 : 1;
+}
+').

--- a/tests/test_wam_cpp_var_alias.pl
+++ b/tests/test_wam_cpp_var_alias.pl
@@ -1,0 +1,91 @@
+:- encoding(utf8).
+% Var-var aliasing regression tests for the WAM C++ target (M143).
+%
+% PR #2976's cross-target sweep found unify_cells copied one unbound
+% marker over the other instead of aliasing the cells, so `X = Y`
+% created no link: `X = Y, X = 1, Y = 2` SUCCEEDED, and
+% `X = Y, X = 42, Y =:= 42` failed (in BOTH interpreter and lowered
+% modes — the bug was in the shared runtime). unify_cells now records
+% alias pairs; bind_cell propagates a later real value across them,
+% and alias_pop trail entries dissolve pairs on backtrack.
+%
+% Gated on g++; generates a default-mode project with emit_main(true)
+% and queries via the generated CLI, mirroring
+% tests/test_wam_cpp_lowered_ite_exec.pl.
+
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_cpp_target').
+
+:- dynamic user:cppal_chain/1.
+:- dynamic user:cppal_conflict/1.
+:- dynamic user:cppal_chain3/1.
+:- dynamic user:cppal_backtrack/1.
+
+% Binding through a var-var alias must propagate to both.
+user:cppal_chain(R)    :- X = Y, X = 42, ( Y =:= 42 -> R is 1 ; R is 0 ).
+% Conflicting bindings through an alias must FAIL (the smoking gun:
+% this succeeded before the fix).
+user:cppal_conflict(R) :- X = Y, X = 1, Y = 2, R is 1.
+% Three-deep chain.
+user:cppal_chain3(R)   :- X = Y, Y = Z, X = 42, ( Z =:= 42 -> R is 1 ; R is 0 ).
+% Alias must dissolve on backtrack out of the aliasing goal (this
+% SEGFAULTED with the first-cut fix until every inline trail-unwind
+% loop was routed through alias-aware unwind_trail_to).
+user:cppal_backtrack(R) :-
+    ( X = Y, X = 1, Y = 2 -> R is 0
+    ; Y = 7, X = 5, ( Y =:= 7, X =:= 5 -> R is 1 ; R is 0 )
+    ).
+
+gpp_available :-
+    catch(( process_create(path('g++'), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_cpp_var_alias, [condition(gpp_available)]).
+
+test(var_alias_exec_parity) :-
+    Dir = 'output/test_wam_cpp_var_alias',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_cpp_project(
+        [user:cppal_chain/1, user:cppal_conflict/1,
+         user:cppal_chain3/1, user:cppal_backtrack/1],
+        [module_name(cppalias), emit_main(true)], Dir),
+    atomic_list_concat([Dir, '/cpp'], CppDir),
+    atomic_list_concat([CppDir, '/alias_bin'], ExePath),
+    format(atom(BuildCmd),
+        'g++ -std=c++17 -O0 -o ~w ~w/*.cpp 2>&1', [ExePath, CppDir]),
+    shell_ok(BuildCmd),
+    % (Pred, Arg, ExpectTrue): R=1 / R=0 query pairs read back R's value.
+    Cases = [ 'cppal_chain/1'-1-true,  'cppal_chain/1'-0-false,
+              'cppal_conflict/1'-1-false,
+              'cppal_chain3/1'-1-true, 'cppal_chain3/1'-0-false,
+              'cppal_backtrack/1'-1-true ],
+    forall(member(Pred-Arg-Expect, Cases),
+           run_case(ExePath, Pred, Arg, Expect)).
+
+:- end_tests(wam_cpp_var_alias).
+
+shell_ok(Cmd) :-
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0) -> true
+    ; format(user_error, "~n[cpp var-alias build output]~n~w~n", [OutStr]),
+      throw(cpp_var_alias_build_failed(Status))
+    ).
+
+run_case(ExePath, Pred, Arg, Expect) :-
+    format(atom(Cmd), '~w "~w" ~w', [ExePath, Pred, Arg]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, _Status),
+    ( Expect == true,  sub_string(OutStr, _, _, _, "true")  -> true
+    ; Expect == false, sub_string(OutStr, _, _, _, "false") -> true
+    ; format(user_error, "~n[cpp var-alias] ~w(~w): expected ~w, got: ~w~n",
+             [Pred, Arg, Expect, OutStr]),
+      throw(cpp_var_alias_case_failed(Pred, Arg))
+    ).


### PR DESCRIPTION
## Summary

The two follow-ups from #2978: the exec-harness exit-code footgun (M142), and a behavioral sweep of all WAM targets for the M139/M140 binding-bug classes (M143) — which found and fixed the same var-var aliasing bug in **two more targets: C and C++**.

## M143: the sweep

Eight targets probed end-to-end through their own project writers and toolchains, each with 5 probe shapes (`var`-then-bind, double-`var`, var/nonvar consistency, constant-staging aliasing, var-var chain propagation), with R=1/R=0 discriminator queries so wrong-branch results are distinguishable from failure:

| Target | Verdict |
|---|---|
| Rust, Python, Go, Haskell, F#, Scala | **CLEAN** (interpreter + lowered where applicable) |
| **C** | **BUGGY** — var-var alias (probe 5) |
| **C++** | **BUGGY** — var-var alias (probe 5), both modes |

Both buggy runtimes copied one unbound marker over the other when unifying two unbound cells — no alias was ever created. The smoking gun `X = Y, X = 1, Y = 2` **succeeded** on both. (Unswept for lack of toolchains: Lua, R, Clojure, Kotlin, Elixir, JVM/ILasm/WAT.)

## Fixes

- **C** (`wam_c_runtime/wam_runtime.h`): the unbound-unbound case of `wam_unify` installs a `VAL_REF` from one cell to the other's heap slot (preferring a heap-resident referent; two non-heap cells keep the legacy copy as a last resort).
- **C++** (`wam_cpp_target.pl` runtime): the cell model has no Ref tag and ~100 direct payload-read sites, so a forwarding tag would have been leak-prone. Instead `unify_cells` records var-var **alias pairs**; `bind_cell` propagates a later real value across the alias graph (each write individually trailed); `alias_pop` trail entries dissolve pairs on backtrack. All **13 inline trail-unwind loops** are now routed through the alias-aware `unwind_trail_to` — the first cut left them raw and segfaulted on backtrack over an alias entry, caught by the backtrack regression case.

New gated exec tests: `tests/test_wam_c_var_alias.pl`, `tests/test_wam_cpp_var_alias.pl` (chain, conflict-must-fail, 3-deep chain, alias-dissolves-on-backtrack).

## M142: harness footgun

Both LLVM integer exec drivers returned the **raw payload** of the result register — a non-integer result leaked its atom id / heap address as a mystery exit code (a test ending in `X = x` exited 90, the atom id of `x`). This produced two red-herring diagnoses during the M138–M141 arc. The drivers now deref and tag-check: wrong tag exits 254 with the message *"result had wrong tag — ensure the final goal binds R numerically"*, and failure (255) gets an explanatory message too.

## Known issues recorded (sweep bycatch, in CHANGELOG, not fixed here)

1. **Rust interpreter mode**: if-then-else doesn't commit to the then-branch (lowered mode correct).
2. **Haskell ST mode**: `GetLevel Yn` writes reg ids 201+ into an STArray sized 199 — any ITE predicate crashes the ST path (pure path correct).
3. **Scala lowered mode**: emitter produces a bare `{...}` block scalac parses as an argument list — `put_variable Yn, A1` projects don't compile.

## Test plan

- [x] C: new var-alias test passes; full C suite **119 PASS, 0 FAIL**
- [x] C++: new var-alias test passes; lowered_t4 + lowered_t5 + lowered_ite_exec + generator suite (**388 tests**) all pass
- [x] LLVM with M142 harness change: full suite **870 PASS, 0 FAIL**

https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM)_