### PR TITLE
Rust/Haskell/Scala WAM: fix the three sweep-found known issues (M144–M146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **WAM Haskell target (M145): ST-mode crash on every if-then-else
+  predicate.** The sweep-found known issue: `stepST`'s
+  `GetLevel`/`Cut` handlers used raw `writeArray`/`readArray` on the
+  register STArray sized `(1, maxRegId=199)`, but their operands are
+  Y registers (ids 201+), which live in env frames on the ST path —
+  any ITE predicate crashed `runMutableRegs` with an index error
+  (the runner the generated default `Main.hs` actually uses). Both
+  handlers now route through the env-frame-aware
+  `putRegST`/`getRegST`. All 5 sweep probes now pass on both the
+  pure and ST runners.
+- **WAM Scala target (M146): lowered mode uncompilable with
+  `put_variable`.** The sweep-found known issue: the lowered emitter
+  emitted a bare `{ val v = ... }` block after a call statement,
+  which scalac parses as an argument list to the preceding
+  expression (`Unit does not take parameters`) — every
+  `emit_mode(functions)` project containing `put_variable Yn, A1`
+  failed to compile. Now emitted as `locally { ... }`, forcing
+  statement position. Lowered projects compile and the sweep probes
+  pass with R=1/R=0 discriminators.
 - **WAM Rust target (M144): if-then-else never committed.** The
   sweep-found known issue: `cut_ite` was translated to
   `Instruction::NoOp`, so a then-branch failure backtracked into the
@@ -56,21 +75,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   require an Integer tag: wrong tag exits 254 with an explanatory
   message, and predicate failure (255) gets one too.
 
-### Known issues (found by the M143 sweep, not yet fixed)
-- **Rust WAM target (interpreter mode):** if-then-else does not
-  commit to the then-branch — `( 1 =:= 1 -> R is 1 ; R is 0 )`
-  queried with R=0 succeeds by backtracking into the else branch.
-  Lowered mode is correct.
-- **Haskell WAM target (ST mode):** `runMutableRegs` writes
-  `GetLevel Yn` register operands (ids 201+) straight into the
-  STArray sized to `maxRegId = 199` — any if-then-else predicate
-  crashes with an index error on the ST path (the pure-`run` path
-  routes Y-regs through env frames and is correct).
-- **Scala WAM target (lowered mode):** the lowered emitter
-  (`wam_scala_lowered_emitter.pl:632`) emits a bare `{ ... }` block
-  after a call statement; scalac parses the brace as an argument
-  list (`Unit does not take parameters`) — `emit_mode(functions)`
-  projects using `put_variable Yn, A1` do not compile.
 - **WAM LLVM target (M141): `is_list/1` never succeeded.** The
   follow-up flagged in M140: `builtin_is_list_check` accepted only
   the legacy tag-4 List value, but the engine builds lists as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **WAM Rust target (M144): if-then-else never committed.** The
+  sweep-found known issue: `cut_ite` was translated to
+  `Instruction::NoOp`, so a then-branch failure backtracked into the
+  else branch (`( 1 =:= 1 -> R is 1 ; R is 0 )` queried with R=0
+  succeeded). The Rust compile path now defaults
+  `ite_use_y_level(true)` and the runtime implements
+  `GetLevel`/`CutTo` (snapshot/truncate the choice-point stack, with
+  the Y-register read going through the env-frame-aware `get_reg`),
+  cutting the guard plus any inner condition choice points exactly.
+  Legacy `cut_ite` maps to a real single-CP `CutIte` rather than
+  NoOp. The lowered emitter accepts the new `get_level`/`cut Yn`
+  bytecode (commit consumed by the shared structurer). Pre-existing
+  unrelated failure noted: `test_wam_rust_runtime` e2e fails
+  identically on unmodified main.
 - **WAM C + C++ targets (M143): var-var unification created no
   alias.** Found by a behavioral sweep of 8 targets with the
   M139/M140 probe shapes (Rust, Python, Go, Haskell, F#, Scala

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -3220,15 +3220,20 @@ stepST _ _ !pw CutIte =
     [] -> return $ Just pw { pwPC = pwPC pw + 1 }
 
 -- M17 soft cut (see the pure `step` GetLevel/Cut for semantics).
+-- M145: route the register access through putRegST/getRegST. GetLevel''s
+-- operand is a Y register (id 201+), which lives in the topmost env
+-- frame on the ST path -- the old raw writeArray/readArray hit the
+-- STArray sized (1, maxRegId=199) and crashed every if-then-else
+-- predicate with an index error.
 stepST _ regs !pw (GetLevel reg) = do
-  writeArray regs reg (Integer (pwCPsLen pw))
-  return $ Just pw { pwPC = pwPC pw + 1 }
+  pw'' <- putRegST regs reg (Integer (pwCPsLen pw)) pw
+  return $ Just pw'' { pwPC = pwPC pw + 1 }
 
 stepST _ regs !pw (Cut reg) = do
-  v <- readArray regs reg
-  case v of
-    Integer n -> return $ Just pw { pwPC = pwPC pw + 1
-                                  , pwCPs = take n (pwCPs pw), pwCPsLen = n }
+  mv <- getRegST regs reg pw
+  case mv of
+    Just (Integer n) -> return $ Just pw { pwPC = pwPC pw + 1
+                                         , pwCPs = take n (pwCPs pw), pwCPsLen = n }
     _ -> return $ Just pw { pwPC = pwPC pw + 1 }
 
 -- Type-checking builtins

--- a/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_rust_lowered_emitter.pl
@@ -83,6 +83,12 @@ instr_from_parts(["retry_me_else", L], retry_me_else(L)).
 instr_from_parts(["trust_me"], trust_me).
 instr_from_parts(["jump", L], jump(L)).
 instr_from_parts(["cut_ite"], cut_ite).
+% M144: Y-level soft cut, now the Rust compile path's default ITE form
+% (ite_use_y_level(true)). The shared structurer's is_commit/1 already
+% accepts cut(Yn); get_level is a no-op in the lowered if/else since
+% the structurer consumes the commit.
+instr_from_parts(["get_level", Y], get_level(Y)).
+instr_from_parts(["cut", Y], cut(Y)).
 
 % =====================================================================
 % Label-preserving parse + if-then-else structuring
@@ -276,6 +282,8 @@ rust_supported(call_foreign(_, _)).
 rust_supported(try_me_else(_)).
 rust_supported(trust_me).
 rust_supported(cut_ite).
+rust_supported(cut(_)).       % M144: Y-level soft cut commit
+rust_supported(get_level(_)). % M144: cut-level capture (no-op when lowered)
 rust_supported(jump(_)).
 
 % =====================================================================
@@ -737,6 +745,8 @@ emit_one(call_foreign(PredStr, ArStr), I) :-
 emit_one(try_me_else(_), _) :- !.
 emit_one(trust_me, _) :- !.
 emit_one(cut_ite, _) :- !.
+emit_one(cut(_), _) :- !.        % M144: commit consumed by the structurer
+emit_one(get_level(_), _) :- !.  % M144: level capture: no-op in lowered if/else
 emit_one(jump(_), _) :- !.
 
 % --- Fallback ---

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -730,6 +730,33 @@ wam_instruction_arm('Instruction::Jump(label)', Body) :-
 wam_instruction_arm('Instruction::NoOp', Body) :-
     Body = '                self.pc += 1; true'.
 
+% M144: if-then-else soft cut. GetLevel snapshots the choice-point
+% depth into a (permanent) register before the condition's try_me_else;
+% CutTo restores it at the commit point, removing the ITE guard CP plus
+% any CPs the condition pushed - regardless of how many that was.
+wam_instruction_arm('Instruction::GetLevel(yn)', Body) :-
+    Body = '                let depth = Value::Integer(self.choice_points.len() as i64);
+                self.trail_binding(yn);
+                self.put_reg(yn, depth);
+                self.pc += 1;
+                true'.
+
+wam_instruction_arm('Instruction::CutTo(yn)', Body) :-
+    Body = '                // get_reg (not get_reg_raw): Y registers live in the
+                // topmost env frame, where GetLevel stored the depth.
+                if let Some(v) = self.get_reg(yn) {
+                    if let Value::Integer(depth) = self.deref_var(&v) {
+                        self.choice_points.truncate(depth as usize);
+                    }
+                }
+                self.pc += 1;
+                true'.
+
+wam_instruction_arm('Instruction::CutIte', Body) :-
+    Body = '                self.choice_points.pop();
+                self.pc += 1;
+                true'.
+
 wam_instruction_arm('Instruction::BuiltinCall(op, arity)', Body) :-
     Body = '                self.execute_builtin(op, *arity)'.
 
@@ -3220,7 +3247,19 @@ wam_line_to_rust_instr(["retry", Label], _, _, Rust) :-
 wam_line_to_rust_instr(["jump", Label], _, _, Rust) :-
     format(string(Rust),
         'Instruction::Jump("~w".to_string())', [Label]).
-wam_line_to_rust_instr(["cut_ite"], _, _, "Instruction::NoOp").
+% M144: legacy cut_ite (only emitted when ite_use_y_level is off) pops
+% the single ITE guard CP. Mis-cuts when the condition pushed inner CPs
+% - the same limitation the LLVM target had pre-M17 - but strictly
+% better than the previous NoOp translation, which never committed at
+% all. The Rust compile path now defaults ite_use_y_level(true), so
+% normal compiles emit get_level/cut instead.
+wam_line_to_rust_instr(["cut_ite"], _, _, "Instruction::CutIte").
+wam_line_to_rust_instr(["get_level", Yn], _, _, Rust) :-
+    clean_comma(Yn, CYn),
+    format(string(Rust), 'Instruction::GetLevel("~w".to_string())', [CYn]).
+wam_line_to_rust_instr(["cut", Yn], _, _, Rust) :-
+    clean_comma(Yn, CYn),
+    format(string(Rust), 'Instruction::CutTo("~w".to_string())', [CYn]).
 % Indexing instructions
 wam_line_to_rust_instr(["switch_on_constant"|Entries], _, _, Rust) :-
     maplist(parse_index_entry_constant, Entries, RustEntries),
@@ -3756,7 +3795,17 @@ classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
     ;   % Fall back to WAM compilation
         option(wam_fallback(WamFB), Options, true),
         WamFB \== false,
-        wam_target:compile_predicate_to_wam(Module:Pred/Arity, Options, WamCode),
+        % M144: emit if-then-else with get_level Yn / cut Yn rather than
+        % the legacy cut_ite. The naive single-CP cut_ite mis-commits
+        % when the condition pushes inner choice points; get_level/cut
+        % snapshots and restores the CP depth exactly (same change the
+        % LLVM target made in M17). The Rust runtime now implements
+        % both instructions.
+        ( memberchk(ite_use_y_level(_), Options)
+        -> WamOptions = Options
+        ;  WamOptions = [ite_use_y_level(true)|Options]
+        ),
+        wam_target:compile_predicate_to_wam(Module:Pred/Arity, WamOptions, WamCode),
         (   option(foreign_lowering(ForeignSpec), Options),
             rust_foreign_spec(Pred/Arity, ForeignSpec, _, _)
         ->  % Foreign-lowered: compile individually (not shared WAM)

--- a/src/unifyweaver/targets/wam_scala_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_scala_lowered_emitter.pl
@@ -629,7 +629,12 @@ emit_one_scala(put_constant(CStr, AiStr), I, _) :-
     format("~wWamRuntime.setReg(s, ~w, ~w)~n", [I, Ai, Term]).
 emit_one_scala(put_variable(XnStr, AiStr), I, _) :-
     scala_lowered_reg_index(XnStr, Xn), scala_lowered_reg_index(AiStr, Ai),
-    format("~w{ val v = WamRuntime.freshVar(s); WamRuntime.setReg(s, ~w, v); s.regs(~w) = v }~n",
+    % M146: `locally { ... }`, not a bare `{ ... }` block. A bare block
+    % on the line after a call statement is parsed by scalac as an
+    % argument list to that call ("Unit does not take parameters"),
+    % so every lowered project containing put_variable failed to
+    % compile. `locally` forces statement position.
+    format("~wlocally { val v = WamRuntime.freshVar(s); WamRuntime.setReg(s, ~w, v); s.regs(~w) = v }~n",
            [I, Xn, Ai]).
 emit_one_scala(put_value(XnStr, AiStr), I, _) :-
     scala_lowered_reg_index(XnStr, Xn), scala_lowered_reg_index(AiStr, Ai),

--- a/templates/targets/rust_wam/instructions.rs.mustache
+++ b/templates/targets/rust_wam/instructions.rs.mustache
@@ -89,6 +89,18 @@ pub enum Instruction {
     /// chain run is correct; emitting a real instruction (rather than a
     /// dropped comment) keeps every later label PC aligned.
     NoOp,
+    /// M144: capture the current choice-point depth into a register
+    /// (the WAM `get_level Yn` half of if-then-else's soft cut).
+    GetLevel(String),
+    /// M144: truncate the choice-point stack to the depth saved by
+    /// GetLevel (the `cut Yn` commit). Previously if-then-else compiled
+    /// its commit to `cut_ite`, which the Rust backend translated to
+    /// NoOp - the condition's success never committed, so a failing
+    /// then-branch backtracked into the else branch.
+    CutTo(String),
+    /// M144: legacy single-CP if-then-else commit (cut_ite). Pops the
+    /// ITE guard choice point; only emitted when ite_use_y_level is off.
+    CutIte,
     /// Evaluate a built-in predicate.
     BuiltinCall(String, usize),
     /// Start collecting solutions for an aggregate.


### PR DESCRIPTION
## Summary

Fixes all three known issues recorded by the #2985 sweep — one per target, each verified end-to-end with the sweep's own probe harnesses plus the target's regression suites. The CHANGELOG's "known issues from the sweep" section is now empty.

## M144: Rust — if-then-else never committed

`cut_ite` was translated to `Instruction::NoOp`, so the ITE commit never happened: a failing then-branch backtracked into the else branch (`( 1 =:= 1 -> R is 1 ; R is 0 )` queried with R=0 **succeeded**).

Fixed with the same design LLVM got in M17: Rust WAM compiles now default `ite_use_y_level(true)`, and the runtime implements `GetLevel` (snapshot choice-point depth into a Y register) and `CutTo` (truncate back to it) — cutting the guard **plus any inner condition choice points** exactly. One debugging catch worth noting: the first `CutTo` cut read the Y register via `get_reg_raw` (flat array) instead of the env-frame-aware `get_reg`, silently skipping the cut — the new test's R=0 discriminators caught it. Legacy `cut_ite` maps to a real single-CP `CutIte` rather than NoOp, and the lowered emitter accepts the new `get_level`/`cut Yn` bytecode.

## M145: Haskell — ST-mode crash on every ITE predicate

`stepST`'s `GetLevel`/`Cut` handlers used raw `writeArray`/`readArray` on the register STArray sized `(1, 199)`, but their operands are Y registers (ids 201+), which live in env frames on the ST path — any ITE predicate crashed `runMutableRegs` (the runner the generated default `Main.hs` actually uses) with an index error. Both handlers now route through the env-frame-aware `putRegST`/`getRegST`.

## M146: Scala — lowered mode uncompilable with `put_variable`

The lowered emitter emitted a bare `{ val v = ... }` block; on the line after a call statement scalac parses the brace as an argument list (`Unit does not take parameters`), so every `emit_mode(functions)` project containing `put_variable Yn, A1` failed to compile. Now emitted as `locally { ... }`, forcing statement position.

## Verification

- **Rust**: new cargo test with 6 assertions (plain ITE commit, alias chain, inner-choice-point condition — all with R=1/R=0 discriminators) passes; `test_wam_rust_target`, `lowered_ite_exec`, `lowered_t4/t5/t6`, `save_regs` all pass. Pre-existing: `test_wam_rust_runtime` e2e fails identically on unmodified main.
- **Haskell**: all 5 sweep probes pass on **both** the pure `run` and `runMutableRegs` runners (ST previously crashed on 3 of 5); `lowered_ite_exec`, `lowered_t4`, `lowered_t5`, `iso_smoke` suites pass.
- **Scala**: `emit_mode(functions)` project with `put_variable` compiles (scalac 2.13.16) and probes pass with discriminators; `lowered_t4`, `lowered_t5` pass; `runtime_smoke` passes except `builtin_format`, which fails **identically on the parent commit** (pre-existing, format-output related, unrelated to ITE/lowering).

https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM)_