### PR TITLE
feat(wam-python): T3 multi-clause clause-1 fast path lowering (closes the T3 column)

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -104,7 +104,7 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 | clojure | ✓ | ✓ T2a | ✓ | ✓ | ✗ | ✗ | ~ | ~ | ✗ | ✗ | ✗ |
 | llvm    | ✓ | ✓ T2a | ✓ (c1) | ✓ | ✓ | ✗ | ✗ | ~ | ✗ | ✗ | ~ |
 | lua     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ |
-| python  | ✓ | ✓ T2a | ✗ | ✗ | **✓** | ✗ | ~ | ~ | ✗ | ✗ | ✗ |
+| python  | ✓ | ✓ T2a | ✓ | ✗ | ✓ | ✗ | ~ | ~ | ✗ | ✗ | ✗ |
 | r       | ✓ | ✓ T2a | ✓ | **✓** | ✗ | ✗ | ✗ | ~ | ✓ | **✓** | ✗ |
 | elixir  | ✓ | ✓ T2b | ✓ | ✓ | ✗ | ✗ | **✓** | ✓ | ✓ | ✗ | ✗ |
 | wat     | ✓ | ✓ T2a | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -112,10 +112,19 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 Verification notes:
 - **T3** confirmed ✓ for haskell and fsharp (both lower clause 1 and fall
   back to the interpreter for clauses 2+ — documented in their lowerability
-  gates). **python T3 = ✗**: `is_deterministic_pred_py` rejects *any*
-  `try_me_else`, so a try-chain predicate stays in the interpreter; python's
-  only multi-clause lowering is T5 (its `is_ite_block_py` detection of the
-  switch-indexed, no-`try_me_else` shape → `if/elif/else`).
+  gates). **python T3 = ✓** (now): `py_multi_clause_1` extracts clause 1 of a
+  multi-clause predicate to a lowered `pred_*` function; the registrar keeps
+  the FULL bytecode but replaces clause 1's body with a `call_lowered`,
+  retaining the leading `try_me_else` and clauses 2+ verbatim. On clause-1
+  success the `call_lowered` falls through to `proceed` (the clause-2 choice
+  point is left for backtracking); on failure the runtime's `call_lowered`
+  handler calls `fail()`, popping that choice point (restoring trail + regs)
+  and resuming the interpreter at clause 2 — an emitter-only change, no runtime
+  modification. Because a T3 `pred_*` is clause-1-only (not the whole
+  predicate), a predicate that *directly* calls a T3 predicate is kept in the
+  interpreter (`whole_predicate_lowering/3` gate), so the T3 fallback is always
+  reached through a bytecode call. Python keeps T5 too (its `is_ite_block_py`
+  `if/elif/else` for the switch-indexed, no-`try_me_else` shape).
 - **T5** (clause_chain) is now implemented across the hybrid targets via the
   shared `wam_clause_chain` front-end: scala, rust, cpp, go, haskell, fsharp,
   llvm, lua, r (plus python's original `is_ite_block_py` `if/elif/else` form).
@@ -197,8 +206,11 @@ Reading down the columns (after the T5 and T4 sweeps landed):
   WAT-runtime limitation — a condition's variable binding is not propagated
   into the then-branch — is present in BOTH the lowered and interpreter paths,
   so the lowering is faithful; that runtime fix is tracked separately.)
-- **python T3** — python still lacks the clause-1 fast path (its only
-  multi-clause lowering is T5); a small, contained gap.
+- **python T3** — **DONE.** Python now lowers a multi-clause predicate's
+  clause 1 (fast path) with interpreter fallback for clauses 2+ (see the T3
+  verification note above), so the T3 column is ✓ for every target that has a
+  clause-1 fast path. `test_wam_python_lowered_t3` exec-tests clause-1 hit,
+  clause-2/3 fallback, and a lowered-vs-interpreter parity battery.
 - **T10 (mode-driven specialisation)** and **T11 (LCO)** are essentially
   one-target experiments (R, and LLVM's `musttail`) that could generalise.
 - **T7 (parallel)** is real only in Elixir; Clojure/Python have `_branch`

--- a/src/unifyweaver/targets/wam_python_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_python_lowered_emitter.pl
@@ -30,6 +30,7 @@
 	is_ite_block_py/2,               % +Instrs, -Blocks
 	emit_ite_block_py/5,             % +FuncName, +Blocks, +Indent, +Opts, -Lines
 	py_structured_clause1/2,         % +WamCode, -StructuredInstrs (soft-cut ITE)
+	py_multi_clause_1/2,             % +WamCode, -Clause1Instrs (T3 clause-1 slice)
 	emit_structured_python/4         % +FunctorArity, +Structured, +Opts, -Lines
 ]).
 
@@ -206,6 +207,32 @@ py_structured_clause1(WamCode, Structured) :-
 	\+ member(retry_me_else(_), Structured),
 	\+ member(trust_me, Structured),
 	forall(member(I, Structured), py_supported_structured(I)).
+
+%% py_multi_clause_1(+WamCode, -Clause1Instrs) is semidet.
+%  T3 — multi-clause clause-1 fast path. True when the predicate is genuinely
+%  multi-clause (parse_wam_text_py has dropped any switch_on_* indexing prefix,
+%  so the parsed stream opens with the predicate-level try_me_else, and clauses
+%  2+ begin with retry_me_else / trust_me) AND clause 1 is a clean
+%  deterministic, fully-supported body. Clause1Instrs is the clause-1 slice
+%  (try_me_else stripped, up to and including its proceed/fail), ready for
+%  emit_lowered_python. Clauses 2+ are left to the bytecode interpreter,
+%  reached by backtracking when the lowered clause 1 fails — see the registrar
+%  in wam_python_target.pl, which keeps the leading try_me_else (it pushes the
+%  choice point onto clause 2) and the clause-2+ bytecode, replacing only
+%  clause 1's body with a call_lowered to this function.
+%
+%  Single-clause soft-cut ITE predicates also open with try_me_else, but they
+%  are claimed by py_structured_clause1 first; the cut_ite/jump guards here
+%  decline them defensively.
+py_multi_clause_1(WamCode, Clause1Instrs) :-
+	( is_list(WamCode) -> Instrs0 = WamCode ; parse_wam_text_py(WamCode, Instrs0) ),
+	once(append(_Prefix, [try_me_else(_)|Rest], Instrs0)),
+	( member(retry_me_else(_), Rest) ; member(trust_me, Rest) ),
+	take_to_proceed_py(Rest, Clause1Instrs),
+	\+ has_choice_point_instr(Clause1Instrs),   % clause 1 itself is deterministic
+	\+ member(cut_ite, Clause1Instrs),           % not an ITE clause-1 (py_structured handles those)
+	\+ member(jump(_), Clause1Instrs),
+	forall(member(I, Clause1Instrs), py_supported_structured(I)).
 
 %% take_to_proceed_py(+Instrs, -Clause1) — up to and including the first
 %  proceed / fail terminator (label/1 markers pass through to the

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -68,6 +68,7 @@
 	parse_wam_text_py/2,
 	python_func_name/2,
 	py_structured_clause1/2,
+	py_multi_clause_1/2,
 	emit_structured_python/4
 ]).
 :- use_module('../targets/wam_text_parser',
@@ -1621,14 +1622,27 @@ format_python_wam_registrar(Pred/Arity, Options, InstrLiterals, PythonCode) :-
 %  a name collision with the pred_* lowered function itself.
 compile_lowered_wam_predicate_to_python(Pred/Arity, WamCode, Options, PythonCode) :-
 	% Soft-cut if-then-else / negation / once lowers via the shared
-	% structurer; everything else takes the straight-line deterministic
-	% path (unchanged).
+	% structurer; single deterministic predicates take the straight-line path;
+	% multi-clause predicates lower clause 1 (T3) and keep clauses 2+ in the
+	% bytecode interpreter, reached by backtracking when clause 1 fails.
 	(   py_structured_clause1(WamCode, Structured)
-	->  emit_structured_python(Pred/Arity, Structured, Options, LoweredFn)
+	->  emit_structured_python(Pred/Arity, Structured, Options, LoweredFn),
+	    stub_lowered_registrar(Pred/Arity, Registrar)
 	;   parse_wam_text_py(WamCode, Instrs),
-	    is_deterministic_pred_py(Instrs),
-	    emit_lowered_python(Pred/Arity, Instrs, Options, LoweredFn)
+	    is_deterministic_pred_py(Instrs)
+	->  emit_lowered_python(Pred/Arity, Instrs, Options, LoweredFn),
+	    stub_lowered_registrar(Pred/Arity, Registrar)
+	;   py_multi_clause_1(WamCode, Clause1Instrs)
+	->  emit_lowered_python(Pred/Arity, Clause1Instrs, Options, LoweredFn),
+	    multi_clause_1_registrar(Pred/Arity, WamCode, Registrar)
 	),
+	atomic_list_concat([LoweredFn, '\n\n', Registrar], PythonCode).
+
+%% stub_lowered_registrar(+Pred/Arity, -Registrar)
+%  Whole-predicate replacement: the lowered function captures the COMPLETE
+%  predicate semantics (T1 single clause, or T2 structured if-then-else), so
+%  the registered program is just a call_lowered stub.
+stub_lowered_registrar(Pred/Arity, Registrar) :-
 	atom_string(Pred, PredStr),
 	python_func_name(Pred/Arity, FuncName),
 	atom_concat(register_, FuncName, RegistrarName),
@@ -1640,8 +1654,51 @@ compile_lowered_wam_predicate_to_python(Pred/Arity, WamCode, Options, PythonCode
         ("call_lowered", ~w, ~w),
         ("proceed",),
     )
-', [RegistrarName, PredStr, Arity, LabelKey, FuncName, Arity]),
-	atomic_list_concat([LoweredFn, '\n\n', Registrar], PythonCode).
+', [RegistrarName, PredStr, Arity, LabelKey, FuncName, Arity]).
+
+%% multi_clause_1_registrar(+Pred/Arity, +WamCode, -Registrar)
+%  T3 registrar: keep the FULL predicate bytecode but replace clause 1's body
+%  with a call_lowered to the lowered clause-1 function. The leading
+%  try_me_else (pushing the choice point onto clause 2) and the clause-2+
+%  bytecode are retained verbatim, so on clause-1 SUCCESS the call_lowered
+%  falls through to proceed (the clause-2 choice point is correctly left for
+%  backtracking), and on clause-1 FAILURE the runtime's call_lowered handler
+%  calls fail(), which pops that choice point — restoring trail and registers —
+%  and resumes the interpreter at clause 2. Labels are emitted as inline
+%  ("__label__", Name) markers, so load_program recomputes PCs and no manual
+%  PC arithmetic is needed after the clause-1 collapse.
+multi_clause_1_registrar(Pred/Arity, WamCode, Registrar) :-
+	wam_code_to_python_instructions(WamCode, Pred/Arity, FullInstrLiterals, _Labels),
+	split_string(FullInstrLiterals, "\n", "", Lines0),
+	python_func_name(Pred/Arity, FuncName),
+	rewrite_clause1_to_call_lowered(Lines0, FuncName, Arity, Lines),
+	atomic_list_concat(Lines, '\n', Body),
+	atom_string(Pred, PredStr),
+	atom_concat(register_, FuncName, RegistrarName),
+	format(atom(LabelKey), '~w/~w', [PredStr, Arity]),
+	format(string(Registrar),
+'def ~w(raw_program):
+    """Register T3 clause-1 fast path for ~w/~w (clauses 2+ stay in bytecode)."""
+    raw_program["~w"] = (
+~w
+    )
+', [RegistrarName, PredStr, Arity, LabelKey, Body]).
+
+%% rewrite_clause1_to_call_lowered(+Lines, +FuncName, +Arity, -Out)
+%  Replace the clause-1 body literals — those strictly between the predicate's
+%  first try_me_else literal and the next ("__label__", ...) literal (clause 2)
+%  — with a single call_lowered + proceed. Everything before the try_me_else
+%  (the pred label and any switch_on_* indexing prefix) and from clause 2
+%  onward is preserved verbatim.
+rewrite_clause1_to_call_lowered(Lines, FuncName, Arity, Out) :-
+	nth0(I0, Lines, TmeLine), sub_string(TmeLine, _, _, _, "try_me_else"), !,
+	Skip is I0 + 1,
+	length(Head, Skip), append(Head, AfterTme, Lines),
+	nth0(J, AfterTme, LblLine), sub_string(LblLine, _, _, _, "__label__"), !,
+	length(Clause1Body, J), append(Clause1Body, Clauses2Plus, AfterTme),
+	format(string(CallLowered), '        ("call_lowered", ~w, ~w),', [FuncName, Arity]),
+	Proceed = '        ("proceed",),',
+	append(Head, [CallLowered, Proceed|Clauses2Plus], Out).
 
 %% build_python_wam_arg_list(+Arity, -ArgList)
 %  Build the Python function argument list.
@@ -2151,6 +2208,7 @@ lowered_candidate_wam(Wam) :-
 	(   parse_wam_text_py(WamText, Instrs),
 	    is_deterministic_pred_py(Instrs)
 	;   py_structured_clause1(WamText, _)    % soft-cut if-then-else / \+ / once
+	;   py_multi_clause_1(WamText, _)        % T3: multi-clause clause-1 fast path
 	).
 
 fix_lowered_route_set(Current, Plans, Options, Final) :-
@@ -2168,10 +2226,28 @@ lowered_route_supported(Plans, Options, Current, Pred/Arity) :-
 	findall(CalleePred/CalleeArity, direct_wam_call(Instrs, CalleePred/CalleeArity), Calls0),
 	sort(Calls0, Calls),
 	forall(member(CalleePred/CalleeArity, Calls),
-	    ( member(CalleePred/CalleeArity, Current)
+	    ( whole_predicate_lowering(Plans, Current, CalleePred/CalleeArity)
 	    ; is_ffi_predicate(CalleePred, CalleeArity, Options)
 	    ; \+ planned_predicate(Plans, CalleePred/CalleeArity)
 	    )).
+
+%% whole_predicate_lowering(+Plans, +Current, +Pred/Arity) is semidet.
+%  True when Pred/Arity is lowered as a COMPLETE predicate (T1 deterministic
+%  single clause, or T2 structured if-then-else) — its pred_* function captures
+%  the whole predicate, so a lowered caller may invoke it directly. A T3
+%  predicate (py_multi_clause_1, clause-1 fast path only) is deliberately
+%  excluded: its pred_* runs clause 1 alone, with clauses 2+ reachable only via
+%  the interpreter's call_lowered fallback. So a predicate that directly calls a
+%  T3 predicate must NOT be lowered itself — it stays in the bytecode
+%  interpreter and reaches the T3 predicate (and its fallback) through a normal
+%  bytecode call.
+whole_predicate_lowering(Plans, Current, Pred/Arity) :-
+	member(Pred/Arity, Current),
+	member(pred_plan(Pred, Arity, Wam, wam), Plans),
+	wam_plan_text(Wam, WamText),
+	(   parse_wam_text_py(WamText, Instrs), is_deterministic_pred_py(Instrs)
+	;   py_structured_clause1(WamText, _)
+	).
 
 planned_predicate(Plans, Pred/Arity) :-
 	member(pred_plan(Pred, Arity, _WamCode, Kind), Plans),

--- a/tests/test_wam_python_lowered_t3.pl
+++ b/tests/test_wam_python_lowered_t3.pl
@@ -1,0 +1,182 @@
+% test_wam_python_lowered_t3.pl
+%
+% End-to-end test for the Python T3 lowering — multi-clause clause-1 fast path
+% (lowering type T3 in docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md).
+% Closes the last ✗ in the T3 column: python was the only target that lowered
+% no multi-clause predicate (it rejected any try_me_else; its only multi-clause
+% lowering was the T5 if/elif/else clause-chain).
+%
+% Mechanism (emitter-only — no runtime change): py_multi_clause_1 extracts a
+% genuine multi-clause predicate's clause-1 slice and emits it as a lowered
+% pred_* function; the registrar keeps the FULL predicate bytecode but replaces
+% clause 1's body with a call_lowered to that function, retaining the leading
+% try_me_else and clauses 2+ verbatim. At run time the try_me_else pushes the
+% choice point onto clause 2, then:
+%   - clause-1 SUCCESS  -> call_lowered falls through to proceed (the clause-2
+%     choice point is left for backtracking — correct);
+%   - clause-1 FAILURE  -> the runtime's call_lowered handler calls fail(),
+%     which pops that choice point (restoring trail + registers) and resumes
+%     the interpreter at clause 2.
+% So clauses 2+ are reached exactly as the bytecode interpreter would reach
+% them — this is verified below by a lowered-vs-interpreter parity battery.
+%
+% Skipped automatically when python3 is unavailable.
+
+:- use_module(library(lists)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_python_target').
+:- use_module('../src/unifyweaver/targets/wam_python_lowered_emitter').
+
+:- dynamic user:color/1, user:pq/1, user:classify/2.
+
+% facts (first-argument indexed)
+user:color(red).
+user:color(green).
+user:color(blue).
+% rules, no first-arg index (head var)
+user:pq(X) :- X = a.
+user:pq(X) :- X = b.
+% mixed: a fact, a rule with a guard goal in clause 2, a catch-all clause 3
+user:classify(0, zero).
+user:classify(N, pos) :- N > 0.
+user:classify(_, neg).
+
+preds([user:color/1, user:pq/1, user:classify/2]).
+
+python3_available :-
+    catch(( process_create(path(python3), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_python_lowered_t3, [condition(python3_available)]).
+
+% Each multi-clause predicate must be recognised as a T3 clause-1 candidate,
+% with clause 1 being a clean deterministic slice.
+test(gate_picks_multi_clause_1) :-
+    forall(member(_:PI, [user:color/1, user:pq/1, user:classify/2]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             ( py_multi_clause_1(W, C1)
+             -> assertion(\+ member(try_me_else(_), C1)),
+                assertion(last(C1, proceed))
+             ;  throw(not_multi_clause_1(PI)) ) )).
+
+% The emitted code: a lowered pred_* function, a call_lowered into clause 1,
+% and the clause-2+ bytecode retained (so the interpreter can run them).
+test(emits_call_lowered_and_retains_later_clauses) :-
+    wam_target:compile_predicate_to_wam(color/1, [], W),
+    wam_python_target:compile_lowered_wam_predicate_to_python(color/1, W, [emit_mode(lowered)], Code),
+    assertion(sub_string(Code, _, _, _, "def pred_color_1(state)")),
+    assertion(sub_string(Code, _, _, _, '("call_lowered", pred_color_1, 1)')),
+    assertion(sub_string(Code, _, _, _, "try_me_else")),
+    % clause 2 / clause 3 bytecode retained (green & blue still matched in interp)
+    assertion(sub_string(Code, _, _, _, '("get_constant", Atom("green"), A1)')),
+    assertion(sub_string(Code, _, _, _, '("get_constant", Atom("blue"), A1)')),
+    % clause-1 body collapsed: red is matched by the lowered fn, not the bytecode
+    assertion(\+ sub_string(Code, _, _, _, '("get_constant", Atom("red")')).
+
+% Correctness through the interpreter (lowered mode): clause-1 fast path,
+% clause-2 fallback, clause-3 fallback, and no-match.
+test(t3_exec_lowered) :-
+    run_battery(lowered, Results),
+    assert_expected(Results).
+
+% Parity: the lowered fast path agrees with the pure bytecode interpreter on
+% every query (the defining property of a faithful lowering).
+test(t3_parity_lowered_vs_interpreter) :-
+    run_battery(lowered, Lowered),
+    run_battery(interpreter, Interp),
+    ( Lowered == Interp
+    -> true
+    ;  format(user_error, "~n[python t3 lowered vs interpreter]~nlowered=~q~ninterp =~q~n",
+              [Lowered, Interp]),
+       throw(python_t3_parity_failed) ).
+
+:- end_tests(wam_python_lowered_t3).
+
+% Name-Args-Expected battery. Args is a list of reg(Index, PyValue).
+battery([
+    'color/1'-[reg(1, 'A("red")')]-true,
+    'color/1'-[reg(1, 'A("green")')]-true,
+    'color/1'-[reg(1, 'A("blue")')]-true,
+    'color/1'-[reg(1, 'A("pink")')]-false,
+    'pq/1'-[reg(1, 'A("a")')]-true,
+    'pq/1'-[reg(1, 'A("b")')]-true,
+    'pq/1'-[reg(1, 'A("c")')]-false,
+    'classify/2'-[reg(1, 'I(0)'), reg(2, 'A("zero")')]-true,
+    'classify/2'-[reg(1, 'I(0)'), reg(2, 'A("wrong")')]-false,
+    'classify/2'-[reg(1, 'I(5)'), reg(2, 'A("pos")')]-true,
+    'classify/2'-[reg(1, 'I(5)'), reg(2, 'A("neg")')]-true,
+    'classify/2'-[reg(1, 'I(-2)'), reg(2, 'A("neg")')]-true,
+    'classify/2'-[reg(1, 'I(-2)'), reg(2, 'A("pos")')]-false
+]).
+
+assert_expected(Results) :-
+    battery(B),
+    findall(Name-Got-Want,
+            ( nth0(I, B, _Name-_Args-Want), nth0(I, Results, Got), Got \== Want,
+              nth0(I, B, Name-_-_) ),
+            Bad),
+    ( Bad == [] -> true
+    ; format(user_error, "~n[python t3 wrong results] ~q~n", [Bad]),
+      throw(python_t3_wrong(Bad)) ).
+
+%% run_battery(+Mode, -Results) — generate a project in Mode, run the battery
+%  through the interpreter, unify Results with the list of booleans (one per
+%  battery entry, in order).
+run_battery(Mode, Results) :-
+    preds(Preds),
+    battery(B),
+    format(atom(Dir), 'output/test_wam_python_t3_~w', [Mode]),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    ( Mode == lowered -> Opts = [module_name(t3proj), emit_mode(lowered)]
+    ;                    Opts = [module_name(t3proj)] ),
+    write_wam_python_project(Preds, Opts, Dir),
+    build_harness(B, HarnessSrc),
+    atomic_list_concat([Dir, '/t3_harness.py'], HPath),
+    setup_call_cleanup(open(HPath, write, S, [encoding(utf8)]),
+                       write(S, HarnessSrc), close(S)),
+    format(atom(Cmd), 'cd ~w && python3 t3_harness.py 2>&1', [Dir]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), split_string(OutStr, "\n", " \n", LinesAll),
+      ( member(RLine, LinesAll), sub_string(RLine, 0, _, _, "RESULTS ")
+      -> sub_string(RLine, 8, _, 0, CSV),
+         split_string(CSV, ",", "", Toks),
+         maplist(tok_bool, Toks, Results)
+      ;  throw(python_t3_no_results(OutStr)) )
+    ; format(user_error, "~n[python t3 harness ~w output]~n~w~n", [Mode, OutStr]),
+      throw(python_t3_harness_failed(Mode, Status)) ).
+
+tok_bool("1", true).
+tok_bool("0", false).
+
+%% build_harness(+Battery, -Src) — emit a python harness that runs each query
+%  through the interpreter and prints "RESULTS b,b,b,..." (1=success,0=fail).
+build_harness(Battery, Src) :-
+    findall(Line, ( member(Name-Args-_, Battery), query_line(Name, Args, Line) ), Lines),
+    atomic_list_concat(Lines, '\n', Body),
+    format(string(Src),
+"import sys\n\c
+sys.path.insert(0, '.')\n\c
+from wam_runtime import *\n\c
+from predicates import build_program\n\c
+A = Atom\n\c
+I = Int\n\c
+_raw = build_program()\n\c
+_code, _labels = load_program(_raw)\n\c
+def q(entry, regs):\n\c
+\s\s\s\ss = WamState()\n\c
+\s\s\s\sfor i, v in regs:\n\c
+\s\s\s\s\s\s\s\sset_reg(s, i, v)\n\c
+\s\s\s\sreturn 1 if run_wam(_code, _labels, entry, s) else 0\n\c
+_res = []\n\c
+~w\n\c
+print('RESULTS ' + ','.join(str(x) for x in _res))\n",
+        [Body]).
+
+query_line(Name, Args, Line) :-
+    findall(RegStr, ( member(reg(I, V), Args), format(atom(RegStr), '(~w, ~w)', [I, V]) ), RegStrs),
+    atomic_list_concat(RegStrs, ', ', RegList),
+    format(atom(Line), '_res.append(q("~w", [~w]))', [Name, RegList]).

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -192,13 +192,23 @@ test(compile_lowered_mode_direct_predicate) :-
 	assertion(sub_string(S, _, _, _, "def register_pred_foo_1(raw_program)")),
 	assertion(sub_string(S, _, _, _, '("call_lowered", pred_foo_1, 1)')).
 
-test(compile_lowered_mode_falls_back_for_nondet) :-
+test(compile_lowered_mode_multi_clause_t3) :-
+	% T3: a multi-clause predicate lowers clause 1 to a fast-path function and
+	% keeps clauses 2+ in the bytecode, with clause 1's body replaced by a
+	% call_lowered. The leading try_me_else (which pushes the choice point onto
+	% clause 2) is retained, so a failed clause-1 fast path backtracks into the
+	% clause-2 bytecode through the runtime's call_lowered fallback.
 	WamCode = 'choice/1:\n  try_me_else choice_2\n  get_constant a, 1\n  proceed\nchoice_2:\n  trust_me\n  get_constant b, 1\n  proceed',
 	wam_python_target:compile_one_predicate([emit_mode(lowered)], choice/1-WamCode, PythonCode),
 	atom_string(PythonCode, S),
+	assertion(sub_string(S, _, _, _, "def pred_choice_1(state)")),
 	assertion(sub_string(S, _, _, _, "def register_pred_choice_1(raw_program)")),
+	assertion(sub_string(S, _, _, _, '("call_lowered", pred_choice_1, 1)')),
 	assertion(sub_string(S, _, _, _, '("try_me_else", "choice_2")')),
-	assertion(\+ sub_string(S, _, _, _, "def pred_choice_1(state)")).
+	% clause 2 bytecode retained (matched by the interpreter on fallback)
+	assertion(sub_string(S, _, _, _, '("get_constant", Atom("b"), 1)')),
+	% clause-1 body collapsed: 'a' is matched by the lowered fn, not the bytecode
+	assertion(\+ sub_string(S, _, _, _, '("get_constant", Atom("a"), 1)')).
 
 test(compile_all_lowered_mode_build_program_uses_registrars, [nondet]) :-
 	WamCode = 'foo/1:\n  get_constant a, 1\n  proceed',


### PR DESCRIPTION
## Summary

Closes the **last ✗ in the T3 column**. Python previously lowered *no* multi-clause predicate — `is_deterministic_pred_py` rejects any `try_me_else`, so its only multi-clause lowering was the T5 `if/elif/else` clause chain.

`py_multi_clause_1/2` detects a genuine multi-clause predicate (parsed stream opens with the predicate-level `try_me_else` after any dropped `switch_on_*` prefix; clauses 2+ begin with `retry_me_else`/`trust_me`) whose clause 1 is a clean deterministic, fully-supported body, and returns the clause-1 slice. The emitter lowers that slice to a `pred_*` function via the existing `emit_lowered_python`; the new `multi_clause_1_registrar` keeps the **full** predicate bytecode but replaces clause 1's body with a single `call_lowered`, retaining the leading `try_me_else` and clauses 2+ verbatim.

## Emitter-only — no runtime change

At run time the `try_me_else` pushes the choice point onto clause 2, then:
- **clause-1 success** → `call_lowered` falls through to `proceed` (the clause-2 choice point is correctly left for backtracking);
- **clause-1 failure** → the runtime's existing `call_lowered` handler calls `fail()`, which pops that choice point (restoring trail + registers) and resumes the interpreter at clause 2.

Labels are emitted as inline `("__label__", Name)` markers, so `load_program` recomputes PCs after the clause-1 collapse — no manual PC arithmetic.

## Soundness fix (caught by an existing test)

A T3 `pred_*` runs clause 1 **alone** (clauses 2+ are reachable only via the interpreter's `call_lowered` fallback), so it is **not** a safe direct-call target. The new `whole_predicate_lowering/3` gate requires a lowered predicate's *direct* callees to be **complete**-predicate lowerings (T1/T2); a predicate that directly calls a T3 predicate stays in the interpreter and reaches it (and its fallback) through a normal bytecode call. This keeps `compile_all_lowered_mode_keeps_direct_call_graph_consistent` green.

## Tests — `test_wam_python_lowered_t3.pl` (python3)
- **gate**: `color/1`, `pq/1`, `classify/2` recognised as T3 candidates with a clean clause-1 slice.
- **emitted shape**: `call_lowered` into clause 1, clause-2+ bytecode retained, clause-1 body collapsed.
- **exec correctness** through the interpreter: clause-1 fast path, clause-2 fallback, clause-3 fallback, and no-match — including a guard goal (`N > 0`) run via bytecode after fallback.
- **parity**: lowered fast path agrees with the pure bytecode interpreter on every query.

Updated two `wam_python_target` tests whose premise (multi-clause predicates are never lowered) T3 deliberately changes. The rest of the suite still passes; the one unrelated failure (`runtime_parser_compiled_read_term_prefix_naf`) fails on `main` too (pre-existing).

Docs: taxonomy matrix marks `python` T3 = ✓ (column now complete for every target with a clause-1 fast path); verification note + sequencing updated.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_