### PR TITLE
WAM sweep round 2: Elixir interpreter repairs + ILasm builtin table (M147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **WAM Elixir target (M147): interpreter mode entirely broken; type
+  checks missing in all modes.** Round 2 of the cross-target sweep
+  (Lua, R, Clojure, WAT: clean) found four layered defects:
+  (1) interpreter-mode predicate modules were emitted with raw
+  lowercase names (`defmodule WamPred.probe1`) — an Elixir
+  `CompileError`, so such projects never loaded (now camelized);
+  (2) the WAM compiler emits bare `allocate`, but the converter only
+  knew `allocate N`, so it fell to the `{:raw, ...}` fallback and the
+  runtime step catch-all turned it into `:fail` — every predicate
+  with an environment frame wrong-failed (now `{:allocate, 0}`);
+  (3) `cut_ite` and `jump` had no converter clauses or step arms, so
+  if-then-else could never commit and a failing then-branch
+  backtracked into the else (the M144 bug class; both now
+  implemented); (4) the type-check builtins (`var/1`, `nonvar/1`,
+  `atom/1`, `integer/1`, `number/1`, `atomic/1`) were absent from
+  `execute_builtin` and crashed with `{:unknown_builtin, ...}` in
+  every emit mode (all six added). All 12 probe queries now pass in
+  both interpreter and lowered modes.
 - **WAM Haskell target (M145): ST-mode crash on every if-then-else
   predicate.** The sweep-found known issue: `stepST`'s
   `GetLevel`/`Cut` handlers used raw `writeArray`/`readArray` on the
@@ -27,6 +45,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failed to compile. Now emitted as `locally { ... }`, forcing
   statement position. Lowered projects compile and the sweep probes
   pass with R=1/R=0 discriminators.
+- **WAM ILasm target: builtin opcode table never matched.**
+  Sweep round 2 finding: `atom_string/2` arguments were reversed in
+  `wam_line_to_cil_literal` for `builtin_call`, so the lookup key
+  stayed a string and never matched the atom-keyed
+  `builtin_op_to_cil_id/2` table — every builtin compiled to the
+  unknown-op fallback and unconditionally failed. Fixed (with an
+  explicit op-99 fallback instead of falling through to the `// TODO`
+  comment, which produced null instruction slots). NOTE: this is one
+  of 14 defects the sweep documented in this target — see Known
+  issues; the target does not yet assemble end-to-end.
+
+### Known issues (sweep round 2, 2026-06-11)
+- **WAM JVM target: structurally non-executable.** The generated
+  assembly is rejected by a real Krakatau v2 assembler: runtime
+  emitted as method-less code fragments at class level, predicate
+  files lack class headers, instruction operands are lost into `;`
+  comments, and the harmful `ldc` catch-all (flagged in
+  `docs/WAM_SWITCH_INDEXING_CROSS_TARGET.md`) is confirmed. No engine
+  exists to host correctness probes — needs a ground-up
+  implementation campaign, not fixes.
+- **WAM ILasm target: 13 further structural defects** beyond the
+  fixed builtin-table bug (mis-spelled `tail.` directive, uncallable
+  `.cctor_probeN` initializers, C# pseudo-code spliced into IL,
+  label-table indexing, nested-vs-top-level type references, missing
+  ctors, swapped IL operand order in 7+ sites, concrete generic
+  memberrefs, placeholder `deallocate`/`call` bodies, swapped
+  List.Add receiver, run_loop stack imbalance, `cut_ite`/`jump`
+  dropped to null slots, `var/nonvar/atom/=` unmapped). The shipped
+  default emit has never been assemblable; the sweep agent's
+  defect ladder is preserved in its report for a future repair
+  campaign.
 - **WAM Rust target (M144): if-then-else never committed.** The
   sweep-found known issue: `cut_ite` was translated to
   `Instruction::NoOp`, so a then-branch failure backtracked into the

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -348,6 +348,25 @@ wam_elixir_case(deallocate,
 
 % --- Choice Point Instructions ---
 
+% M147: if-then-else commit. cut_ite pops the ITE guard choice point
+% pushed by the condition's try_me_else; previously this instruction
+% reached the step/2 catch-all (:fail), so the condition never
+% committed and a failing then-branch backtracked into the else
+% branch (the M144 bug class). jump transfers to the continuation
+% label after the then-branch.
+wam_elixir_case(cut_ite,
+'      :cut_ite ->
+        case state.choice_points do
+          [_guard | rest] -> %{state | choice_points: rest, pc: state.pc + 1}
+          [] -> %{state | pc: state.pc + 1}
+        end').
+
+wam_elixir_case(jump,
+'      {:jump, target} when is_integer(target) ->
+        %{state | pc: target}
+      {:jump, label} when is_binary(label) ->
+        %{state | pc: resolve_label(state, label)}').
+
 wam_elixir_case(try_me_else,
 '      # Fast path: label pre-resolved at codegen to integer PC.
       {:try_me_else, target} when is_integer(target) ->
@@ -1132,6 +1151,37 @@ compile_utility_helpers_to_elixir(Code) :-
         # hardening reasoning as fail/0 above.
         new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
         %{state | pc: new_pc}
+      # M147: type-check builtins. These were absent from this table,
+      # so any predicate calling var/1, nonvar/1, atom/1, etc. crashed
+      # with {:unknown_builtin, ...} in every emit mode.
+      {"var/1", 1} ->
+        v = get_reg(state, 1)
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        if match?({:unbound, _}, v), do: %{state | pc: new_pc}, else: :fail
+      {"nonvar/1", 1} ->
+        v = get_reg(state, 1)
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        if match?({:unbound, _}, v), do: :fail, else: %{state | pc: new_pc}
+      {"atom/1", 1} ->
+        v = get_reg(state, 1)
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        if is_binary(v) or v == [], do: %{state | pc: new_pc}, else: :fail
+      {"integer/1", 1} ->
+        v = get_reg(state, 1)
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        if is_integer(v), do: %{state | pc: new_pc}, else: :fail
+      {"number/1", 1} ->
+        v = get_reg(state, 1)
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        if is_number(v), do: %{state | pc: new_pc}, else: :fail
+      {"atomic/1", 1} ->
+        v = get_reg(state, 1)
+        new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+        cond do
+          match?({:unbound, _}, v) -> :fail
+          is_binary(v) or is_number(v) or v == [] -> %{state | pc: new_pc}
+          true -> :fail
+        end
       # PR #5: arith compares — default form + _lax alias share one
       # arm per operator. eval_arith wrapped in try/catch so bad
       # input silently fails per ISO lax semantics (matches the
@@ -4965,6 +5015,10 @@ end', []).
 %% compile_wam_predicate_to_elixir(+Pred/Arity, +WamCode, +Options, -Code)
 compile_wam_predicate_to_elixir(Pred/Arity, WamCode, _Options, Code) :-
     atom_string(Pred, PredStr),
+    % M147: Elixir module names must be capitalized. The raw lowercase
+    % predicate name (WamPred.probe1) is a CompileError, so interpreter-
+    % mode projects never even loaded.
+    camel_case(PredStr, ModStr),
     wam_code_to_elixir_instructions(WamCode, InstrLiterals, LabelLiterals),
     format(string(Code),
 'defmodule WamPred.~w do
@@ -5008,7 +5062,7 @@ compile_wam_predicate_to_elixir(Pred/Arity, WamCode, _Options, Code) :-
         :fail
     end
   end
-end', [PredStr, PredStr, Arity, InstrLiterals, LabelLiterals]).
+end', [ModStr, PredStr, Arity, InstrLiterals, LabelLiterals]).
 
 %% wam_code_to_elixir_instructions(+WamCodeStr, -InstrLiterals, -LabelLiterals)
 %  Two-pass: pass 1 collects labels → PC map; pass 2 emits instructions
@@ -5248,6 +5302,23 @@ wam_line_to_elixir_instr(["execute", P], LabelsList, Instr) :-
 wam_line_to_elixir_instr(["allocate", N], _, Instr) :-
     clean_comma(N, CN),
     format(string(Instr), '{:allocate, ~w}', [CN]).
+% M147: the WAM compiler emits bare `allocate` (no frame-size operand).
+% This previously fell to the {:raw, ...} fallback, and the runtime
+% step/2 catch-all turned EVERY such instruction into :fail - so every
+% interpreter-mode predicate with an environment frame wrong-failed.
+wam_line_to_elixir_instr(["allocate"], _, '{:allocate, 0}').
+% M147: if-then-else control. cut_ite and jump had no converter clauses,
+% so the ITE commit fell to {:raw, ...} -> :fail: the condition could
+% never commit and execution always backtracked into the else branch
+% (wrong SUCCESS for then-branch failures - the M144 bug class).
+wam_line_to_elixir_instr(["cut_ite"], _, ':cut_ite').
+wam_line_to_elixir_instr(["jump", L], LabelsList, Instr) :-
+    clean_comma(L, CL),
+    resolve_label(CL, LabelsList, R),
+    (   integer(R)
+    ->  format(string(Instr), '{:jump, ~w}', [R])
+    ;   format(string(Instr), '{:jump, "~w"}', [R])
+    ).
 wam_line_to_elixir_instr(["deallocate"], _, ':deallocate').
 wam_line_to_elixir_instr(["builtin_call", Op, Ar], _, Instr) :-
     clean_comma(Op, COp), clean_comma(Ar, CAr),

--- a/src/unifyweaver/targets/wam_ilasm_target.pl
+++ b/src/unifyweaver/targets/wam_ilasm_target.pl
@@ -1632,8 +1632,12 @@ wam_line_to_cil_literal(["trust_me"], 'new Instruction(24, 0L, 0L)').
 wam_line_to_cil_literal(["builtin_call", Op, N], Lit) :-
     clean_comma_cil(Op, COp), clean_comma_cil(N, CN),
     (   number_string(Num, CN) -> true ; Num = 0 ),
-    atom_string(COp, COpAtom),
-    builtin_op_to_cil_id(COpAtom, OpId),
+    % M147 sweep finding: atom_string/2 args were reversed, so COpAtom
+    % stayed a string and never matched the atom-keyed
+    % builtin_op_to_cil_id/2 table - every builtin compiled to the
+    % unknown-op fallback id and unconditionally failed at runtime.
+    atom_string(COpAtom, COp),
+    ( builtin_op_to_cil_id(COpAtom, OpId) -> true ; OpId = 99 ),
     format(atom(Lit), 'new Instruction(21, ~wL, ~wL)', [OpId, Num]).
 wam_line_to_cil_literal(Parts, Lit) :-
     atomic_list_concat(Parts, " ", Line),


### PR DESCRIPTION
## Summary

Round 2 of the cross-target sweep — the seven targets that lacked toolchains in round 1 (#2985), now probed end-to-end with the 6 bug-shape probes (the 5 binding probes plus the M144 ITE-commit check). Fixes for what it found.

## Sweep results

| Target | Verdict |
|---|---|
| Lua, R, Clojure, WAT | **CLEAN** — all 6 probes, interpreter + lowered modes |
| **Elixir** | **BUGGY** — 4 layered defects, all fixed here (M147) |
| **ILasm** | **BUGGY** — 14 defects; 1 genuine codegen bug fixed here, 13 documented |
| **JVM** | **INCONCLUSIVE** — structurally non-executable; documented |

(Kotlin remains unswept — no kotlinc in the container.)

## Elixir fixes (M147)

The default interpreter mode was entirely broken, in layers — each empirically confirmed before fixing:

1. **Predicate modules didn't compile**: emitted as `defmodule WamPred.probe1` (raw lowercase = Elixir `CompileError`). Now camelized.
2. **Every framed predicate wrong-failed**: the WAM compiler emits bare `allocate`, the converter only knew `allocate N`, and the `{:raw, ...}` fallback hit the step catch-all (`:fail`). Now `{:allocate, 0}`.
3. **ITE never committed** (the M144 class, third target found with it): `cut_ite`/`jump` had no converter clauses or step arms — a failing then-branch backtracked into the else, inverting probe results. Both implemented.
4. **Type-check builtins crashed in every mode**: `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `number/1`, `atomic/1` were absent from `execute_builtin` (`{:unknown_builtin, ...}`). All six added.

All 12 probe queries now pass in **both** interpreter and lowered modes.

## ILasm fix

`atom_string/2` arguments were reversed in the `builtin_call` literal emitter — the lookup key stayed a string and never matched the atom-keyed opcode table, so **every builtin** compiled to the unknown-op fallback. Fixed, plus unknown builtins now emit an explicit op instead of falling to a `// TODO` comment (null instruction slots). Note: the target still doesn't assemble end-to-end — the sweep documented 13 further structural defects (recorded as a known issue with the agent's full defect ladder preserved); this fix is a prerequisite for that future repair campaign, verified via the structural suite.

## JVM finding (documented, not fixed)

The sweep agent built the Krakatau v2 assembler from source to prove it: the generated assembly is method-less code fragments at class level, predicate files lack class headers, instruction operands are lost into `;` comments, and the harmful `ldc` catch-all from `docs/WAM_SWITCH_INDEXING_CROSS_TARGET.md` is confirmed. There is no engine to host correctness probes — this needs a ground-up implementation campaign. Recorded in the CHANGELOG known issues.

## Test plan

- [x] Elixir: 12/12 probe queries pass in both modes (previously: interpreter projects failed to compile; lowered crashed 4/6 probes)
- [x] Elixir suites: classic_programs (**50/50**), lowered_ite, utils, target, phase3, phase4c, phase4d — all pass
- [x] ILasm structural suite: **45/45**
- [x] Lua/R/Clojure/WAT: clean sweep reports, no changes needed

https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM)_