### PR TITLE
fix(wam-llvm): build compounds in get_structure write mode

### DIFF
--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -2763,13 +2763,31 @@ gs.check_unb:
   br i1 %gs.unb, label %gs.write, label %gs.fail
 
 gs.write:
-  ; Write mode: push functor marker on heap, bind Ai to Ref, push WriteCtx
-  %gs.marker = call %Value @value_atom(i8* null)
-  %gs.addr = call i32 @wam_heap_push(%WamState* %vm, %Value %gs.marker)
-  %gs.ref = call %Value @value_ref(i32 %gs.addr)
+  ; Write mode: allocate a Compound and bind Ai to it.
+  %gs.fn_ptr = inttoptr i64 %op1 to i8*
+  call void @wam_arena_ensure()
+  %gs.cp_size = ptrtoint %Compound* getelementptr (%Compound, %Compound* null, i32 1) to i64
+  %gs.cp_mem = call i8* @wam_arena_alloc(i64 %gs.cp_size)
+  %gs.wcp = bitcast i8* %gs.cp_mem to %Compound*
+  %gs.wfn_slot = getelementptr %Compound, %Compound* %gs.wcp, i32 0, i32 0
+  store i8* %gs.fn_ptr, i8** %gs.wfn_slot
+  %gs.war_slot = getelementptr %Compound, %Compound* %gs.wcp, i32 0, i32 1
+  store i32 %gs.arity, i32* %gs.war_slot
+  %gs.arity64 = zext i32 %gs.arity to i64
+  %gs.args_bytes = shl i64 %gs.arity64, 4
+  %gs.args_mem = call i8* @wam_arena_alloc(i64 %gs.args_bytes)
+  %gs.wargs = bitcast i8* %gs.args_mem to %Value*
+  %gs.wargs_slot = getelementptr %Compound, %Compound* %gs.wcp, i32 0, i32 2
+  store %Value* %gs.wargs, %Value** %gs.wargs_slot
+  %gs.wcp_i64 = ptrtoint %Compound* %gs.wcp to i64
+  %gs.wval0 = insertvalue %Value undef, i32 3, 0
+  %gs.wval = insertvalue %Value %gs.wval0, i64 %gs.wcp_i64, 1
+  %gs.old = call %Value @wam_get_reg(%WamState* %vm, i32 %gs.ai)
   call void @wam_trail_binding(%WamState* %vm, i32 %gs.ai)
-  call void @wam_set_reg(%WamState* %vm, i32 %gs.ai, %Value %gs.ref)
+  call void @wam_set_reg(%WamState* %vm, i32 %gs.ai, %Value %gs.wval)
+  call void @wam_bind_through_if_unbound_ref(%WamState* %vm, %Value %gs.old, %Value %gs.wval)
   call void @wam_push_write_ctx(%WamState* %vm, i32 %gs.arity)
+  call void @wam_write_ctx_set_args(%WamState* %vm, %Value* %gs.wargs)
   call void @wam_inc_pc(%WamState* %vm)
   ret i1 true
 
@@ -14712,7 +14730,16 @@ wam_instruction_to_llvm_literal(get_value(Xn, Ai), Lit) :-
     format(atom(Lit), '{ i32 2, i64 ~w, i64 ~w }', [XnIdx, AiIdx]).
 wam_instruction_to_llvm_literal(get_structure(F, Ai), Lit) :-
     reg_name_to_index(Ai, AiIdx),
-    format(atom(Lit), '{ i32 3, i64 0, i64 ~w } ; get_structure ~w', [AiIdx, F]).
+    atom_string(F, FStr),
+    split_functor_arity(FStr, NameStr, Arity),
+    string_length(NameStr, NameLen),
+    NameLenPlus1 is NameLen + 1,
+    Op2 is (Arity << 16) \/ AiIdx,
+    sanitize_functor_for_llvm(NameStr, SaneName),
+    format(atom(Lit),
+        '{ i32 3, i64 ptrtoint ([~w x i8]* @.fn_~w to i64), i64 ~w } ; get_structure ~w',
+        [NameLenPlus1, SaneName, Op2, F]),
+    register_functor_string(NameStr).
 wam_instruction_to_llvm_literal(get_list(Ai), Lit) :-
     reg_name_to_index(Ai, AiIdx),
     format(atom(Lit), '{ i32 4, i64 ~w, i64 0 }', [AiIdx]).
@@ -16092,6 +16119,20 @@ wam_line_to_llvm_literal(["get_constant", C, Ai], Lit) :-
     % Pack tag into op2 high bits: op2 = (tag << 16) | reg_idx.
     Op2 is (Tag << 16) \/ RegIdx,
     format(atom(Lit), '%Instruction { i32 0, i64 ~w, i64 ~w }', [PackedVal, Op2]).
+wam_line_to_llvm_literal(["get_structure", FN, Ai], Lit) :-
+    clean_comma(FN, CFN), clean_comma(Ai, CAi),
+    atom_string(CAi, CAiAtom),
+    reg_name_to_index(CAiAtom, AiIdx),
+    atom_string(CFN, CFNStr),
+    split_functor_arity(CFNStr, NameStr, Arity),
+    string_length(NameStr, NameLen),
+    NameLenPlus1 is NameLen + 1,
+    Op2 is (Arity << 16) \/ AiIdx,
+    sanitize_functor_for_llvm(NameStr, SaneName),
+    format(atom(Lit),
+        '%Instruction { i32 3, i64 ptrtoint ([~w x i8]* @.fn_~w to i64), i64 ~w }',
+        [NameLenPlus1, SaneName, Op2]),
+    register_functor_string(NameStr).
 wam_line_to_llvm_literal(["get_variable", Xn, Ai], Lit) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
     atom_string(CXn, CXnAtom), atom_string(CAi, CAiAtom),

--- a/tests/test_wam_llvm_meta_call_runtime.pl
+++ b/tests/test_wam_llvm_meta_call_runtime.pl
@@ -1,0 +1,112 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+:- dynamic user:llvm_meta_closure_count/1.
+:- dynamic user:llvm_meta_count_handler/5.
+
+user:llvm_meta_closure_count(Count) :-
+    call(llvm_meta_count_handler(Count),
+         item,
+         state([], [], 0, none),
+         _StateN,
+         no).
+
+user:llvm_meta_count_handler(Count, _Item, State0, StateN, no) :-
+    State0 = state(_InputStreams, OutputStreams, _Counter, UserFields),
+    Count = 1,
+    StateN = state([], OutputStreams, 1, UserFields).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_llvm_meta_call_runtime, [condition(clang_available)]).
+
+test(compound_closure_binds_captured_argument) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_wam_llvm_meta_call_runtime', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'meta_call_runtime.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:llvm_meta_closure_count/1,
+          user:llvm_meta_count_handler/5
+        ],
+        [module_name('meta_call_runtime')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    meta_call_driver_ir(InstrCount, LabelCount, DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'meta_call_runtime_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[wam llvm meta-call runtime output]~n~w~n", [OutStr]),
+       throw(wam_llvm_meta_call_runtime_failed(Status))
+    ),
+    !.
+
+:- end_tests(wam_llvm_meta_call_runtime).
+
+meta_call_driver_ir(InstrCount, LabelCount, DriverIR) :-
+    format(atom(DriverIR),
+'
+define i32 @main() {
+entry:
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @module_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @module_labels, i32 0, i32 0),
+      i32 ~w)
+  %unb = call %Value @value_unbound(i8* null)
+  %count_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %count_ref = call %Value @value_ref(i32 %count_addr)
+  call void @wam_set_pc(%WamState* %vm, i32 0)
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %count_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %check_count, label %fail_run
+
+check_count:
+  %count_v = call %Value @wam_deref_value(%WamState* %vm, %Value %count_ref)
+  %count_tag = extractvalue %Value %count_v, 0
+  %count_is_int = icmp eq i32 %count_tag, 1
+  br i1 %count_is_int, label %check_payload, label %fail_tag
+
+check_payload:
+  %count_payload = extractvalue %Value %count_v, 1
+  %count_ok = icmp eq i64 %count_payload, 1
+  br i1 %count_ok, label %success, label %fail_count
+
+success:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 0
+
+fail_run:
+  ret i32 10
+
+fail_tag:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 20
+
+fail_count:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 30
+}
+',
+        [InstrCount, InstrCount, InstrCount, LabelCount, LabelCount, LabelCount]).

--- a/tests/test_wam_llvm_stream_state_runtime.pl
+++ b/tests/test_wam_llvm_stream_state_runtime.pl
@@ -1,0 +1,163 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+:- dynamic user:llvm_stream_state_two_lines/3.
+:- dynamic user:llvm_stream_state_next/4.
+
+user:llvm_stream_state_two_lines(Path, First, Second) :-
+    llvm_stream_state_next(Path, First, state([], [], 0, none), State1),
+    % Closing a handle recovered from state/4 is a separate target boundary;
+    % this smoke proves the carried handle can be reused for the next read.
+    llvm_stream_state_next(Path, Second, State1, _State2).
+
+user:llvm_stream_state_next(Path, Line,
+                            state([], OutputStreams, Counter, UserFields),
+                            state(Handle, OutputStreams, Counter, UserFields)) :-
+    stream_open(Path, Handle),
+    read_line(Handle, Line).
+
+user:llvm_stream_state_next(_Path, Line,
+                            state(Handle, OutputStreams, Counter, UserFields),
+                            state(Handle, OutputStreams, Counter, UserFields)) :-
+    read_line(Handle, Line).
+
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_llvm_stream_state_runtime, [condition(clang_available)]).
+
+test(native_handle_survives_state_compound) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_wam_llvm_stream_state_runtime', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, 'alpha\nbeta\n', []),
+        close(In)),
+    directory_file_path(Dir, 'stream_state_runtime.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:llvm_stream_state_two_lines/3,
+          user:llvm_stream_state_next/4
+        ],
+        [module_name('stream_state_runtime')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    stream_state_driver_ir(InputPath, InstrCount, LabelCount, DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'stream_state_runtime_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[wam llvm stream-state runtime output]~n~w~n", [OutStr]),
+       throw(wam_llvm_stream_state_runtime_failed(Status))
+    ),
+    !.
+
+:- end_tests(wam_llvm_stream_state_runtime).
+
+stream_state_driver_ir(InputPath, InstrCount, LabelCount, DriverIR) :-
+    atom_codes(InputPath, PathCodes),
+    length(PathCodes, PathLen),
+    BytesLen is PathLen + 1,
+    llvm_c_bytes(PathCodes, PathBytes),
+    format(atom(DriverIR),
+'@.stream_state_path = private constant [~w x i8] c"~w\\00"
+@.stream_state_expect_alpha = private constant [6 x i8] c"alpha\\00"
+@.stream_state_expect_beta = private constant [5 x i8] c"beta\\00"
+
+define i32 @main() {
+entry:
+  %path_ptr = getelementptr [~w x i8], [~w x i8]* @.stream_state_path, i32 0, i32 0
+  %path_id = call i64 @wam_intern_atom(i8* %path_ptr, i64 ~w)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @module_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @module_labels, i32 0, i32 0),
+      i32 ~w)
+  %unb = call %Value @value_unbound(i8* null)
+  %first_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %second_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %first_ref = call %Value @value_ref(i32 %first_addr)
+  %second_ref = call %Value @value_ref(i32 %second_addr)
+  call void @wam_set_pc(%WamState* %vm, i32 0)
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %path)
+  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %first_ref)
+  call void @wam_set_reg(%WamState* %vm, i32 2, %Value %second_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %check_tags, label %fail_run
+
+check_tags:
+  %first_v = call %Value @wam_deref_value(%WamState* %vm, %Value %first_ref)
+  %second_v = call %Value @wam_deref_value(%WamState* %vm, %Value %second_ref)
+  %first_tag = extractvalue %Value %first_v, 0
+  %second_tag = extractvalue %Value %second_v, 0
+  %first_is_atom = icmp eq i32 %first_tag, 0
+  %second_is_atom = icmp eq i32 %second_tag, 0
+  %tags_ok = and i1 %first_is_atom, %second_is_atom
+  br i1 %tags_ok, label %check_strings, label %fail_tags
+
+check_strings:
+  %first_id = extractvalue %Value %first_v, 1
+  %second_id = extractvalue %Value %second_v, 1
+  %first_s = call i8* @wam_atom_to_string(i64 %first_id)
+  %second_s = call i8* @wam_atom_to_string(i64 %second_id)
+  %exp_first = getelementptr [6 x i8], [6 x i8]* @.stream_state_expect_alpha, i32 0, i32 0
+  %exp_second = getelementptr [5 x i8], [5 x i8]* @.stream_state_expect_beta, i32 0, i32 0
+  %cmp_first = call i32 @strcmp(i8* %first_s, i8* %exp_first)
+  %cmp_second = call i32 @strcmp(i8* %second_s, i8* %exp_second)
+  %first_ok = icmp eq i32 %cmp_first, 0
+  %second_ok = icmp eq i32 %cmp_second, 0
+  %strings_ok = and i1 %first_ok, %second_ok
+  br i1 %strings_ok, label %success, label %fail_strings
+
+success:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 0
+
+fail_run:
+  ret i32 10
+
+fail_tags:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 20
+
+fail_strings:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 30
+}
+',
+        [BytesLen, PathBytes,
+         BytesLen, BytesLen, PathLen,
+         InstrCount, InstrCount, InstrCount,
+         LabelCount, LabelCount, LabelCount]).
+
+llvm_c_bytes([], '').
+llvm_c_bytes([Code | Rest], Bytes) :-
+    llvm_c_byte(Code, Byte),
+    llvm_c_bytes(Rest, Tail),
+    atom_concat(Byte, Tail, Bytes).
+
+llvm_c_byte(Code, Byte) :-
+    format(atom(Byte), '\\~|~`0t~16r~2+', [Code]).


### PR DESCRIPTION
# Fix WAM/LLVM get_structure write-mode compounds

## Summary

- Change WAM/LLVM `get_structure` write mode to allocate a real `Compound` instead of a heap marker/ref placeholder.
- Emit `get_structure` instructions with functor pointer and arity so write-mode compounds carry the correct shape.
- Add runtime smokes for:
  - compound meta-call closures binding captured arguments
  - native stream handles carried through `state/4` and reused for a second read

## Verification

- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/test_wam_llvm_stream_runtime.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_meta_call_runtime.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_stream_state_runtime.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`

## Notes

This is the next target-side step toward compiled PLAWK `process_all/4`. It proves native stream handles can now survive through `state/4` and be reused for a later read.

Closing a native stream handle after recovering it from `state/4` still exposes a separate double-free boundary, so that behavior is intentionally not included in this PR.