### PR TITLE
docs: define distribution boundary policy

### DIFF
--- a/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
+++ b/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
@@ -29,6 +29,27 @@ distribution_state(parametric(
 
 `Bins` and `ExactPrefix` are finite maps from statistic value to mass. The statistic may be a hop count, weighted length, or a tuple such as `(parent_hops, child_hops)`.
 
+Every stored distribution also has an anchoring key. A node's distribution is
+not just "the distribution for node `V`"; it is the distribution for `V`
+relative to a root, boundary node, direction, statistic, and admissibility
+policy:
+
+```prolog
+distribution_anchor(
+    RootOrBoundary,
+    Direction,
+    PathStatistic,
+    CyclePolicy,
+    Horizon,
+    ScopeKey).
+```
+
+For a global root table, `ScopeKey` can be `global(Root)`. For a per-query
+calculation, `ScopeKey` may identify the ancestor cone of the target node. This
+matters because a deeper query may only need the distribution induced by the
+ancestors of the node of interest, not the distribution obtained by
+materialising the whole graph.
+
 For parent-only paths to a fixed root, the support is finite. Tail fits should therefore be finite-support fits, not infinite asymptotic tails:
 
 ```prolog
@@ -236,9 +257,20 @@ The cache hit is valid only when the cached state was built under compatible sem
 - same root or an explicitly compatible boundary;
 - same edge direction and path statistic;
 - compatible cycle policy and path admissibility rules;
+- compatible horizon or a horizon at least as wide as the remaining budget;
+- compatible target scope, unless the cached entry is a global table that
+  dominates the query's scoped ancestor cone;
 - compatible representation policy, or a representation with known error bounds for the requested functional.
 
 This turns exact or approximated distribution tables into reusable suffix summaries. Search remains exact when the cached distribution is exact and the requested functional can be evaluated exactly from the stored state. It becomes a controlled approximation when the cached distribution is a fitted representation, or when the requested functional is evaluated through an approximate basis.
+
+For target-scoped evaluation, the boundary condition is ancestor-relative. If a
+query asks for node `V`, a cached state for ancestor `A` is reusable only for the
+portion of `V`'s parent-path search that reaches `A` under the same constraints.
+The contribution is then the aggregate from `A` to the root, sliced by the
+remaining budget. This is exact for exact states when `A`'s stored distribution
+was computed over the same admissible ancestor cone, or over a broader global
+cone whose extra paths cannot be reached from `V` through `A`.
 
 ## 8. Cache admission and eviction
 
@@ -320,6 +352,43 @@ Three execution modes fall out:
 | `global_materialized` | Fixed root and high query volume justify whole-graph precomputation |
 
 This scoped mode is the bridge between graph search and global fixed-point evaluation. It preserves the recurrence form, but its worklist is cut down by the query's ancestor cone and by cached boundary distributions encountered during evaluation.
+
+At deeper layers, full distribution materialisation is not always the right
+first state. The planner should be allowed to compute scalar support bounds
+before deciding whether to construct an exact histogram, fit a tail, or stop at
+a cached boundary:
+
+```prolog
+support_bounds(
+    min_path_stat(Min),
+    max_path_stat(Max),
+    exact_under_policy(Boolean),
+    horizon(Horizon)).
+```
+
+For min-only or max-only functionals, these scalar recurrences are sufficient:
+
+```prolog
+Min_v = 1 + min(Min_parent)
+Max_v = 1 + max(Max_parent)
+```
+
+with the obvious weighted-step variant for non-unit parent costs and the same
+cycle/admissibility policy as the search oracle. For bounded aggregate
+functionals, the bounds are not a replacement for the distribution, but they are
+valuable pruning signals:
+
+- if `Min_v > remaining_budget`, the whole suffix contributes zero;
+- if `Max_v <= remaining_budget`, the whole suffix is within budget and can use
+  a total-mass or total-functional summary when available;
+- if `[Min_v, Max_v]` is narrow, exact histogram materialisation may be cheap;
+- if the interval is wide, the policy can prefer a fitted representation or a
+  deeper cached boundary.
+
+This gives the planner a cheap intermediate representation for deep nodes. It
+can carry min/max bounds through large parts of the graph, then materialise full
+distributions only where the query workload, error budget, or cache score makes
+the extra state worthwhile.
 
 ## 10. Open validation work
 

--- a/docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md
+++ b/docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md
@@ -95,6 +95,14 @@ For each `(D_pre, B_search)` cell, run the same sampled target set under:
 | `cached_mass_cdf` | Stop at cached nodes and use mass CDF for reachability-mass queries |
 | `cached_basis` | Use mass + selected cumulative bases for bounded average or weighted power |
 
+The cached node is a boundary condition, not merely a lookup table. For a target
+node `V`, a hit at ancestor `A` replaces the suffix search from `A` to the root
+only when the cached distribution has a compatible root, horizon, statistic,
+admissibility policy, and target scope. Global root tables are reusable as broad
+boundary conditions; per-query tables are reusable only inside the ancestor cone
+they were computed for. The benchmark should therefore count cache hits by both
+node and boundary compatibility, not just by node id.
+
 The first pass may implement only `full_exact` and `cached_histogram`. Add CDF
 modes once the raw suffix-cutoff semantics are verified.
 
@@ -231,8 +239,8 @@ The first benchmark deliberately measures exact parent-only histograms. Later
 passes can test cheaper summaries and approximations once exact-cache semantics
 are stable.
 
-One future direction is to compute scalar support bounds before deciding whether
-to build a full distribution:
+One near-term extension is to compute scalar support bounds before deciding
+whether to build a full distribution:
 
 ```text
 L_min(v) = shortest parent-only path length from v to root
@@ -240,15 +248,35 @@ L_max(v) = longest parent-only path length from v to root, under the active cycl
 support(P_v) <= [L_min(v), L_max(v)]
 ```
 
-Those bounds give fast budget edge cases and may help initialise finite-support
-approximations. If real parent-path distributions tend toward a recognisable
-family, such as a binomial-like, truncated-normal, or truncated-geometric shape,
-the benchmark can add approximation modes that compare fitted distributions
-against exact SimpleWiki histograms before trying enwiki-scale runs.
+When the requested functional is only `min_support` or `max_support`, these are
+not approximations; the scalar recurrence is the whole computation. When the
+requested functional is a bounded aggregate, the bounds are pruning and planning
+state rather than a replacement for `P_v`:
 
-Treat this as a later phase, not part of the first parity harness. The first
-requirement remains exact agreement between full enumeration, cached exact
-histograms, and cumulative bases.
+```text
+if L_min(v) > remaining_budget: suffix contributes zero
+if L_max(v) <= remaining_budget: suffix is fully inside the budget
+if L_max(v) - L_min(v) is small: exact histogram is likely cheap
+if L_max(v) - L_min(v) is large: prefer a cached boundary or fitted tail candidate
+```
+
+This lets deeper layers carry cheap min/max summaries while the planner decides
+where full histograms are still worth materialising.
+
+Another future direction is approximation from bounds plus low-order statistics.
+The min/max interval gives finite support, while observed branching and second
+moment estimates can help choose a candidate family. If real parent-path
+distributions tend toward a recognisable finite-support form, such as
+binomial-like, truncated-normal, or truncated-geometric, the benchmark can add
+approximation modes that compare fitted distributions against exact SimpleWiki
+histograms before trying enwiki-scale runs. The fitted state must still be
+anchored to the same root/boundary, horizon, path statistic, and target scope as
+the exact state it replaces.
+
+Treat fitted distributions as a later phase, not part of the first parity
+harness. Scalar min/max bounds are safe to introduce earlier because they can be
+validated directly against the exact oracle and used only for pruning decisions
+until the approximation policy is measured.
 
 ## 10. Output artifacts
 


### PR DESCRIPTION
## Summary

Documents the next distribution-cache planning policy for root-anchored graph metrics.

## Changes

- Defines distribution anchoring by root/boundary, direction, statistic, horizon, cycle policy, and target scope.
- Clarifies that cached node distributions act as ancestor-relative boundary conditions during bounded path aggregate search.
- Updates the benchmark plan so cache hits must be compatible by boundary semantics, not just node id.
- Documents scalar `min` / `max` support bounds as exact recurrences for min/max functionals and as cheap pruning/planning state for bounded aggregates.
- Keeps fitted distribution families as a later phase after exact parent-only parity is stable.

## Verification

Docs-only change. No tests run.