### PR TITLE
Feat/wam go default char input

### DIFF
--- a/PR_go_wam_default_char_input.md
+++ b/PR_go_wam_default_char_input.md
@@ -1,0 +1,24 @@
+# PR Title
+
+Add Go WAM default character input builtins
+
+# PR Description
+
+## Summary
+
+- Adds direct Go WAM lowering for `get_char/1`, `peek_char/1`, and `get_code/1`.
+- Adds state-local default stdin reader support for the Go WAM runtime.
+- Implements EOF behavior matching the bounded Python default-input surface: `end_of_file` for character reads and `-1` for code reads.
+- Extends the generated Go WAM builtin E2E test with deterministic stdin pipe coverage for peek, consume, and EOF behavior.
+- Updates the Go WAM parity audit to record the new default character input parity slice.
+
+## Tests
+
+```sh
+swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
+swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
+```

--- a/docs/design/WAM_GO_PARITY_AUDIT.md
+++ b/docs/design/WAM_GO_PARITY_AUDIT.md
@@ -21,7 +21,7 @@ current cross-target builtin/runtime baseline.
 | Univ | `=../2` compose/decompose | `=../2` compose/decompose | Present |
 | Copying | `copy_term/2` with fresh variables and preserved sharing | `copy_term/2` with fresh variables and preserved sharing | Present |
 | Control | `true/0`, `fail/0`, `!/0`, `\+/1`, `CutIte` | Same baseline, with broader isolated-goal NAF in Haskell/Python | Present for current baseline, including isolated user-goal NAF and race-to-true over multi-clause WAM targets |
-| IO | `write/1`, `display/1`, `writeln/1`, `print/1`, `write_canonical/1`, `put_char/1`, `put_code/1`, `format/1`, `format/2`, `nl/0`, `tab/1`, `getenv/2`, `setenv/2` | `write/1`, `display/1`, `nl/0`; Python/C++ also cover `write_canonical/1`; Python/C++/LLVM also cover `put_char/1` and `put_code/1`; R/C++/Python also cover `format/N`; R/C++ also cover `writeln/1`, `print/1`, and `tab/1`; LLVM covers `getenv/2` and `setenv/2` | Present for current baseline plus simple output aliases, bounded canonical output, single-character output, bounded format output, tab output, and bounded environment access |
+| IO | `write/1`, `display/1`, `writeln/1`, `print/1`, `write_canonical/1`, `put_char/1`, `put_code/1`, `get_char/1`, `peek_char/1`, `get_code/1`, `format/1`, `format/2`, `nl/0`, `tab/1`, `getenv/2`, `setenv/2` | `write/1`, `display/1`, `nl/0`; Python/C++ also cover `write_canonical/1`; Python/C++/LLVM also cover `put_char/1` and `put_code/1`; Python also covers default-stream `get_char/1`, `peek_char/1`, and `get_code/1`; R/C++/Python also cover `format/N`; R/C++ also cover `writeln/1`, `print/1`, and `tab/1`; LLVM covers `getenv/2` and `setenv/2` | Present for current baseline plus simple output aliases, bounded canonical output, single-character output, default character input, bounded format output, tab output, and bounded environment access |
 
 ## Immediate Findings
 
@@ -72,6 +72,11 @@ current cross-target builtin/runtime baseline.
   Go WAM builtins and are covered by the generated builtin E2E test for stdout
   emission plus invalid argument failure, matching the bounded Python/C++/LLVM
   single-character output surface without adding stream-aware variants.
+- Default character input builtins `get_char/1`, `peek_char/1`, and
+  `get_code/1` are now direct Go WAM builtins and are covered by the generated
+  builtin E2E test for consume/peek behavior plus EOF conversion to
+  `end_of_file` and `-1`, matching the bounded Python default-input surface
+  without adding stream-aware variants.
 - Bounded `format/1` and `format/2` are now direct Go WAM builtins and are
   covered by the generated builtin E2E test for literal `~~`, newline `~n`,
   `~w`, `~a`, `~d`, `~p`, `~q`, and `~s` argument substitution, and

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -564,6 +564,15 @@ wam_go_direct_builtin("put_char/1", 1, 'put_char/1').
 wam_go_direct_builtin(put_code/1, 1, 'put_code/1').
 wam_go_direct_builtin('put_code/1', 1, 'put_code/1').
 wam_go_direct_builtin("put_code/1", 1, 'put_code/1').
+wam_go_direct_builtin(get_char/1, 1, 'get_char/1').
+wam_go_direct_builtin('get_char/1', 1, 'get_char/1').
+wam_go_direct_builtin("get_char/1", 1, 'get_char/1').
+wam_go_direct_builtin(peek_char/1, 1, 'peek_char/1').
+wam_go_direct_builtin('peek_char/1', 1, 'peek_char/1').
+wam_go_direct_builtin("peek_char/1", 1, 'peek_char/1').
+wam_go_direct_builtin(get_code/1, 1, 'get_code/1').
+wam_go_direct_builtin('get_code/1', 1, 'get_code/1').
+wam_go_direct_builtin("get_code/1", 1, 'get_code/1').
 wam_go_direct_builtin(format/1, 1, 'format/1').
 wam_go_direct_builtin('format/1', 1, 'format/1').
 wam_go_direct_builtin("format/1", 1, 'format/1').

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1,7 +1,9 @@
 package {{package_name}}
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"runtime"
@@ -230,6 +232,9 @@ type WamState struct {
 	// stack down past it. peekEnvFrame is now O(1) via this index
 	// instead of an O(stack) reverse scan.
 	E int
+	// Input is the default input stream used by get_char/1, peek_char/1,
+	// and get_code/1. Stream-aware variants remain outside this runtime slice.
+	Input *bufio.Reader
 }
 
 // allocVarId returns a fresh, globally-unique Idx for a new logical
@@ -265,11 +270,11 @@ func NewWamContext(code []Instruction, labels map[string]int) *WamContext {
 
 func NewWamState(code []Instruction, labels map[string]int) *WamState {
 	ctx := NewWamContext(code, labels)
-	return &WamState{Ctx: ctx, Bindings: make([]Value, 4096), E: -1}
+	return &WamState{Ctx: ctx, Bindings: make([]Value, 4096), E: -1, Input: bufio.NewReader(os.Stdin)}
 }
 
 func NewWamStateFromCtx(ctx *WamContext) *WamState {
-	return &WamState{Ctx: ctx, Bindings: make([]Value, 4096), E: -1}
+	return &WamState{Ctx: ctx, Bindings: make([]Value, 4096), E: -1, Input: bufio.NewReader(os.Stdin)}
 }
 
 // RunParallel executes multiple seeds in parallel, each with their own
@@ -602,6 +607,7 @@ func (vm *WamState) Clone() *WamState {
 		// every solution.
 		NextVarId:    vm.NextVarId,
 		E:            vm.E,
+		Input:        vm.Input,
 		// Carry MaxYReg so the sub-VM's snapshotAllRegs sees the
 		// same Y-reg high-water mark as the parent (sub.Regs is a
 		// value-copy of parent.Regs and therefore *contains* those
@@ -1048,6 +1054,53 @@ func outputCodeText(value Value) (string, bool) {
 		return "", false
 	}
 	return string(rune(integer.Val)), true
+}
+
+func (vm *WamState) inputReader() *bufio.Reader {
+	if vm.Input == nil {
+		vm.Input = bufio.NewReader(os.Stdin)
+	}
+	return vm.Input
+}
+
+func (vm *WamState) readDefaultInputRune() (rune, bool, bool) {
+	r, _, err := vm.inputReader().ReadRune()
+	if err == io.EOF {
+		return 0, true, true
+	}
+	if err != nil {
+		return 0, false, false
+	}
+	return r, false, true
+}
+
+func (vm *WamState) peekDefaultInputRune() (rune, bool, bool) {
+	reader := vm.inputReader()
+	r, _, err := reader.ReadRune()
+	if err == io.EOF {
+		return 0, true, true
+	}
+	if err != nil {
+		return 0, false, false
+	}
+	if err := reader.UnreadRune(); err != nil {
+		return 0, false, false
+	}
+	return r, false, true
+}
+
+func inputCharValue(r rune, eof bool) Value {
+	if eof {
+		return internAtom("end_of_file")
+	}
+	return internAtom(string(r))
+}
+
+func inputCodeValue(r rune, eof bool) Value {
+	if eof {
+		return &Integer{Val: -1}
+	}
+	return &Integer{Val: int64(r)}
 }
 
 func (vm *WamState) canonicalTermString(value Value) string {
@@ -1602,6 +1655,24 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 		}
 		fmt.Print(text)
 		return true
+	case "get_char/1":
+		r, eof, ok := vm.readDefaultInputRune()
+		if !ok {
+			return false
+		}
+		return vm.Unify(arg1, inputCharValue(r, eof))
+	case "peek_char/1":
+		r, eof, ok := vm.peekDefaultInputRune()
+		if !ok {
+			return false
+		}
+		return vm.Unify(arg1, inputCharValue(r, eof))
+	case "get_code/1":
+		r, eof, ok := vm.readDefaultInputRune()
+		if !ok {
+			return false
+		}
+		return vm.Unify(arg1, inputCodeValue(r, eof))
 	case "writeln/1":
 		fmt.Println(vm.deref(arg1).String())
 		return true

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -697,6 +697,14 @@ test(builtins_execution) :-
                 \+ put_code(-1),
                 \+ put_code(1114112)
             )),
+          assertz(user:test_char_input_builtin :-
+            (   peek_char(C0), C0 = a,
+                get_char(C1), C1 = a,
+                get_code(Code), Code =:= 98,
+                peek_char(E0), E0 = end_of_file,
+                get_char(E1), E1 = end_of_file,
+                get_code(ECode), ECode =:= -1
+            )),
           assertz(user:test_format_builtin :-
             (   format('fmt_one ~~ ok~n'),
                 format('fmt_two ~w ~w~~~n', [go, 42]),
@@ -767,6 +775,7 @@ test(builtins_execution) :-
           retractall(user:test_number_list_builtin),
           retractall(user:test_atom_string_builtin),
           retractall(user:test_output_builtin),
+          retractall(user:test_char_input_builtin),
           retractall(user:test_format_builtin),
           retractall(user:test_set_aggregate),
           retractall(user:test_unify_builtin),
@@ -777,7 +786,7 @@ test(builtins_execution) :-
     ).
 
 run_builtins_test(TmpDir) :-
-    Predicates = [test_builtins/1, test_arithmetic_expr_builtin/0, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_append_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_output_builtin/0, test_format_builtin/0, test_tab_builtin/0, test_env_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
+    Predicates = [test_builtins/1, test_arithmetic_expr_builtin/0, test_term_builtins/0, test_member_collect/0, test_memberchk_builtin/0, test_select_builtin/0, test_delete_builtin/0, test_append_builtin/0, test_subtract_builtin/0, test_intersection_builtin/0, test_union_builtin/0, test_permutation_builtin/0, test_reverse_builtin/0, test_last_builtin/0, test_nth_builtin/0, test_numlist_builtin/0, test_between_builtin/0, test_list_numeric_builtin/0, test_list_to_set_builtin/0, test_sort_builtin/0, test_keysort_builtin/0, test_term_order_builtin/0, test_ground_builtin/0, test_sub_atom_builtin/0, test_char_type_builtin/0, test_string_code_builtin/0, test_split_string_builtin/0, test_output_builtin/0, test_char_input_builtin/0, test_format_builtin/0, test_tab_builtin/0, test_env_builtin/0, test_succ_builtin/0, test_atom_number_builtin/0, test_atom_case_builtin/0, test_atom_concat_builtin/0, test_atom_string_length_builtin/0, test_char_code_builtin/0, test_atom_codes_builtin/0, test_atom_chars_builtin/0, test_string_list_builtin/0, test_number_list_builtin/0, test_atom_string_builtin/0, test_set_aggregate/0, test_unify_builtin/0, test_neg_fact/1, test_neg_goal/0, test_neg_goal_fail/0],
     Options = [module_name(builtin_test), prefer_wam(true)],
 
     write_wam_go_project(Predicates, Options, TmpDir),
@@ -848,6 +857,9 @@ run_builtins_test(TmpDir) :-
     assertion(sub_string(LibCode, _, _, _, 'Op: "write_canonical/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "put_char/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "put_code/1"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "get_char/1"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "peek_char/1"')),
+    assertion(sub_string(LibCode, _, _, _, 'Op: "get_code/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "format/1"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "format/2"')),
     assertion(sub_string(LibCode, _, _, _, 'Op: "succ/2"')),
@@ -879,6 +891,7 @@ run_builtins_test(TmpDir) :-
 
 import (
 	"fmt"
+	"os"
 	wam "builtin_test"
 )
 
@@ -1215,6 +1228,28 @@ func main() {
 		fmt.Println("OUTPUT_FAILURE")
 	}
 
+	oldStdin := os.Stdin
+	readPipe, writePipe, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		panic(pipeErr)
+	}
+	if _, writeErr := writePipe.WriteString("ab"); writeErr != nil {
+		panic(writeErr)
+	}
+	if closeErr := writePipe.Close(); closeErr != nil {
+		panic(closeErr)
+	}
+	os.Stdin = readPipe
+	inputVM := wam.NewWamState(wam.Test_char_input_builtinCode, wam.Test_char_input_builtinLabels)
+	inputVM.PC = wam.Test_char_input_builtinStartPC
+	if inputVM.Run() {
+		fmt.Println("CHAR_INPUT_SUCCESS")
+	} else {
+		fmt.Println("CHAR_INPUT_FAILURE")
+	}
+	os.Stdin = oldStdin
+	_ = readPipe.Close()
+
 	formatVM := wam.NewWamState(wam.Test_format_builtinCode, wam.Test_format_builtinLabels)
 	formatVM.PC = wam.Test_format_builtinStartPC
 	if formatVM.Run() {
@@ -1313,6 +1348,7 @@ func main() {
         assertion(sub_string(FullOutput, _, _, _, "NUMBER_LIST_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "ATOM_STRING_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "OUTPUT_SUCCESS")),
+        assertion(sub_string(FullOutput, _, _, _, "CHAR_INPUT_SUCCESS")),
         assertion(sub_string(FullOutput, _, _, _, "'Hello World'")),
         assertion(sub_string(FullOutput, _, _, _, "[a, 'two words', 42]")),
         assertion(sub_string(FullOutput, _, _, _, "pair('two words', 7)")),


### PR DESCRIPTION
# Add Go WAM default character input builtins

## Summary

- Adds direct Go WAM lowering for `get_char/1`, `peek_char/1`, and `get_code/1`.
- Adds state-local default stdin reader support for the Go WAM runtime.
- Implements EOF behavior matching the bounded Python default-input surface: `end_of_file` for character reads and `-1` for code reads.
- Extends the generated Go WAM builtin E2E test with deterministic stdin pipe coverage for peek, consume, and EOF behavior.
- Updates the Go WAM parity audit to record the new default character input parity slice.

## Tests

```sh
swipl -q -g run_tests -t halt tests/test_go_wam_builtins.pl
swipl -q -g run_tests -t halt tests/test_wam_go_generator.pl
swipl -q -g run_tests -t halt tests/test_wam_go_foreign_lowering.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase1.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase2.pl
swipl -q -g run_tests -t halt tests/test_wam_go_lowered_phase3.pl
```
