### PR TITLE
test(wam-clojure): align smoke assertion with t4 lowering

### DIFF
--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -1228,7 +1228,7 @@ run_smoke :-
     assert_lowered_univ_builtin_emitted(TmpDir),
     assert_lowered_ground_builtin_emitted(TmpDir),
     assert_lowered_arithmetic_comparison_builtin_emitted(TmpDir),
-    assert_multiclause_wrappers_runtime_mediated(TmpDir),
+    assert_multiclause_lowering_contracts(TmpDir),
     smoke_cases(Cases),
     verify_outputs(TmpDir, Cases),
     delete_directory_and_contents(TmpDir),
@@ -2273,12 +2273,21 @@ assert_lowered_arithmetic_comparison_builtin_emitted(ProjectDir) :-
     has(CoreCode, "runtime/arithmetic-less-or-equal?"),
     has(CoreCode, "runtime/arithmetic-greater-or-equal?").
 
-assert_multiclause_wrappers_runtime_mediated(ProjectDir) :-
+assert_multiclause_lowering_contracts(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
-    assert_empty_lowered_wrapper(CoreCode, "lowered-wam-choice-fact-1"),
+    assert_t4_multiclause_wrapper(CoreCode, "lowered-wam-choice-fact-1"),
     assert_empty_lowered_wrapper(CoreCode, "lowered-wam-choice-or-z-1"),
     assert_empty_lowered_wrapper(CoreCode, "lowered-wam-trail-choice-1").
+
+assert_t4_multiclause_wrapper(CoreCode, FuncName) :-
+    format(string(Header), "(defn ~w [state]", [FuncName]),
+    has(CoreCode, Header),
+    has(CoreCode, "T4 all-clauses inline"),
+    has(CoreCode, ":succeeded (:status"),
+    !.
+assert_t4_multiclause_wrapper(_CoreCode, FuncName) :-
+    throw(error(multiclause_wrapper_not_t4_lowered(FuncName), _)).
 
 assert_empty_lowered_wrapper(CoreCode, FuncName) :-
     (   lowered_wrapper_absent_or_empty(CoreCode, FuncName)


### PR DESCRIPTION
## Summary

- Updates the Clojure WAM runtime smoke assertion for multi-clause lowered wrappers.
- Expects clean multi-clause facts such as `wam_choice_fact/1` to emit T4 all-clause inline lowering.
- Keeps runtime-mediated fallback assertions for multi-clause cases that still require the interpreter path.

## Why

Recent Clojure lowered-emitter work now supports T4 `multi_clause_n` lowering for clean deterministic clause bodies. The smoke suite still expected every multi-clause lowered wrapper to be absent or empty, which made the post-merge local smoke test fail even though the lowerer tests already codified the new T4 contract.

This PR brings the smoke contract in line with the implemented lowering behavior.

## Validation

- `git diff --check`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl` passed `97/97`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl` passed `15/15`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl` passed with `wam_clojure_runtime_smoke: ok`

## Scope

This is a test-only change. It does not alter Clojure code generation or runtime behavior.
