### PR TITLE
feat(wam-python): T4 multi-clause all-clauses lowering (hybrid)

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -104,7 +104,7 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 | clojure | ✓ | ✓ T2a | ✓ | ✓ | ✗ | ✗ | ~ | ~ | ✗ | ✗ | ✗ |
 | llvm    | ✓ | ✓ T2a | ✓ (c1) | ✓ | ✓ | ✗ | ✗ | ~ | ✗ | ✗ | ~ |
 | lua     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ |
-| python  | ✓ | ✓ T2a | ✓ | ✗ | ✓ | ✗ | ~ | ~ | ✗ | ✗ | ✗ |
+| python  | ✓ | ✓ T2a | ✓ | `~` hybrid | ✓ | ✗ | ~ | ~ | ✗ | ✗ | ✗ |
 | r       | ✓ | ✓ T2a | ✓ | **✓** | ✗ | ✗ | ✗ | ~ | ✓ | **✓** | ✗ |
 | elixir  | ✓ | ✓ T2b | ✓ | ✓ | ✗ | ✗ | **✓** | ✓ | ✓ | ✗ | ✗ |
 | wat     | ✓ | ✓ T2a | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -166,6 +166,25 @@ Verification notes:
   exec test using a non-distinct-first-arg predicate that exercises the
   non-first clauses natively. T4 is gated below T5 (clause_chain) and above
   multi_clause_1/c1.
+- **python T4 = `~` (hybrid).** Python's runtime is a genuine backtracking WAM
+  (choice points + `fail()`), and `run_wam` backtracks *intra-query*, so the
+  imperative first-solution shape above would diverge from the interpreter on a
+  conjunction like `p(X), q(X)` (it would commit to clause 1) — failing the
+  lowered-vs-interpreter parity standard. Python therefore lowers every clause
+  *body* to a native `pred_*_cK` function but RETAINS the try/retry/trust
+  dispatch scaffold in the bytecode (`py_multi_clause_n` + `multi_clause_n_registrar`),
+  replacing only each clause body with a `call_lowered`. The runtime's proven
+  choice-point machinery drives clause dispatch and backtracking unchanged, so
+  every clause body is native while parity is preserved by construction. It is
+  marked `~` rather than ✓ because the T4 headline ("interpreter never entered
+  for clause dispatch") is not met — the O(n) dispatch stays in the (tiny)
+  bytecode scaffold. T4 is tried before T3 and falls back to it when a later
+  clause cannot be lowered (e.g. ends in a tail-call `execute`). A future
+  full-native dispatch (R's genuine-CP closure model over the runtime's
+  callable choice points) could slot in *front* of this hybrid for shapes that
+  admit it. Gated exec test `test_wam_python_lowered_t4` covers clause hits,
+  the backtracking-critical conjunctions (`color(X), want_green(X)` must redo
+  into a non-first clause), and a lowered-vs-interpreter parity battery.
 
 ---
 
@@ -176,8 +195,10 @@ Reading down the columns (after the T5 and T4 sweeps landed):
 - **T5 (multi-clause → first-arg dispatch)** and **T4 (multi-clause all
   clauses)** are now ✓ across the hybrid targets (see the verification notes
   above). Remaining T4/T5 holes are intentional: clojure has no distinct
-  first-arg dispatch (T4 only); python's multi-clause story is its T5
-  `if/elif/else`; wat has neither yet.
+  first-arg dispatch (T4 only); python now has T3, T4 (`~` hybrid: native
+  clause bodies over a retained bytecode dispatch scaffold, to preserve its
+  backtracking-runtime parity) and T5 `if/elif/else`; wat has neither T4 nor
+  T5 yet — the last all-✗ multi-clause column besides its own.
 - **T6 (first-arg indexing)** — **Rust and C++** now have a *gated* T6 (`~`):
   both reuse the T5 `wam_clause_chain` front-end, but when the discriminators
   are all atoms and there are ≥ `t6_min_clauses` of them (default 8) the
@@ -257,7 +278,11 @@ Score each candidate gap on four axes, then sequence:
 3. **T4 (multi-clause all-clauses)** for the structurer targets, reusing R's
    iter-CP shape as the reference. Removes the interpreter hop for fully
    supported predicates that aren't first-arg-discriminable (so don't get
-   T5).
+   T5). **python DONE** (`~` hybrid — native clause bodies over a retained
+   bytecode dispatch scaffold, since python's backtracking runtime makes the
+   first-solution imperative shape unsound; a full-native R-style dispatch
+   could layer in front later). Remaining structurer-column hole: none — only
+   **wat** lacks T4 now (its runtime has no lowered multi-clause path yet).
 4. **T6 (first-arg indexing)** — same clause-head front-end as T5 with a
    `switch` back-end instead of an `->` cascade.
 5. Treat **T7/T10/T11** as research spikes (one target each) before any

--- a/src/unifyweaver/targets/wam_python_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_python_lowered_emitter.pl
@@ -31,6 +31,9 @@
 	emit_ite_block_py/5,             % +FuncName, +Blocks, +Indent, +Opts, -Lines
 	py_structured_clause1/2,         % +WamCode, -StructuredInstrs (soft-cut ITE)
 	py_multi_clause_1/2,             % +WamCode, -Clause1Instrs (T3 clause-1 slice)
+	py_multi_clause_n/2,             % +WamCode, -Clauses (T4 per-clause slices)
+	py_clause_func_name/3,           % +Functor/Arity, +K, -Name (T4 clause fn name)
+	emit_multi_clause_n_python/4,    % +Functor/Arity, +Clauses, +Opts, -Lines (T4)
 	emit_structured_python/4         % +FunctorArity, +Structured, +Opts, -Lines
 ]).
 
@@ -241,6 +244,91 @@ take_to_proceed_py([], []).
 take_to_proceed_py([proceed|_], [proceed]) :- !.
 take_to_proceed_py([fail|_], [fail]) :- !.
 take_to_proceed_py([I|Rest], [I|Out]) :- take_to_proceed_py(Rest, Out).
+
+%% py_multi_clause_n(+WamCode, -Clauses) is semidet.
+%  T4 — multi-clause, ALL clauses lowered. True when the predicate is genuinely
+%  multi-clause (parsed stream opens with the predicate-level try_me_else after
+%  any dropped switch_on_* prefix) and EVERY clause is a clean deterministic,
+%  fully-supported body ending in proceed/fail. Clauses is the ordered list of
+%  per-clause instruction slices (each choice-point marker stripped, up to and
+%  including its terminator), one lowered pred_*_cK function per clause.
+%
+%  Python's runtime is a genuine backtracking WAM (choice points + fail()), so
+%  unlike the imperative first-solution T4 targets (lua/rust/…) we must NOT
+%  collapse the clauses into a commit-to-first-match function — that would lose
+%  intra-query backtracking into later clauses and diverge from the bytecode
+%  interpreter. The registrar in wam_python_target.pl therefore keeps the
+%  try_me_else / retry_me_else / trust_me dispatch scaffold (which drives the
+%  runtime's proven choice-point machinery) and replaces only each clause BODY
+%  with a call_lowered to that clause's native function. So every clause body is
+%  native, the per-predicate clause dispatch stays in the (tiny) bytecode
+%  scaffold, and backtracking is preserved by construction — a hybrid of native
+%  bodies over the interpreter's CP dispatch. (A future full-native dispatch
+%  path could be slotted in front of this hybrid for shapes that admit it.)
+py_multi_clause_n(WamCode, Clauses) :-
+	( is_list(WamCode) -> Instrs0 = WamCode ; parse_wam_text_py(WamCode, Instrs0) ),
+	once(append(_Prefix, [try_me_else(M)|Rest], Instrs0)),
+	py_split_clauses_n([try_me_else(M)|Rest], Clauses),
+	Clauses = [_, _ | _],                       % at least two clauses
+	forall(member(Cl, Clauses),
+	       ( \+ has_choice_point_instr(Cl),     % each clause body is deterministic
+	         \+ member(cut_ite, Cl),            % not an ITE clause (defensive)
+	         \+ member(jump(_), Cl),
+	         last(Cl, Last), ( Last == proceed ; Last == fail ),
+	         forall(member(I, Cl), py_supported_structured(I)) )).
+
+%% py_split_clauses_n(+Instrs, -Clauses)
+%  Split a predicate-level try/retry/trust chain into per-clause bodies: drop
+%  each leading choice-point marker, take the following instructions up to and
+%  including the terminator (proceed/fail) as one clause, and recurse. A leading
+%  non-marker prefix (e.g. a switch the parser did not drop) is skipped.
+py_split_clauses_n([], []).
+py_split_clauses_n([M|Rest], [Clause|More]) :-
+	clause_start_marker_py(M), !,
+	py_take_clause(Rest, Clause, After),
+	py_split_clauses_n(After, More).
+py_split_clauses_n([_|Rest], Clauses) :-
+	py_split_clauses_n(Rest, Clauses).
+
+clause_start_marker_py(try_me_else(_)).
+clause_start_marker_py(retry_me_else(_)).
+clause_start_marker_py(trust_me).
+
+%% py_take_clause(+Instrs, -Clause, -After) — take up to and including the first
+%  proceed/fail; After is what follows (the next clause's marker onward).
+py_take_clause([proceed|Rest], [proceed], Rest) :- !.
+py_take_clause([fail|Rest], [fail], Rest) :- !.
+py_take_clause([I|Rest], [I|Cs], After) :- py_take_clause(Rest, Cs, After).
+
+%% py_clause_func_name(+Functor/Arity, +K, -Name)
+%  Per-clause lowered function name: pred_<sanitised>_<arity>_c<K>.
+py_clause_func_name(FunctorArity, K, Name) :-
+	python_func_name(FunctorArity, Base),
+	format(atom(Name), '~w_c~w', [Base, K]).
+
+%% emit_multi_clause_n_python(+Functor/Arity, +Clauses, +Options, -Lines)
+%  Emit one lowered `def pred_*_cK(state)` per clause, concatenated. Each clause
+%  body is rendered exactly like a deterministic single-clause lowering
+%  (proceed -> return True, a failed head match -> return False), so the
+%  call_lowered scaffold can try it and fall through / backtrack accordingly.
+emit_multi_clause_n_python(FunctorArity, Clauses, _Options, Lines) :-
+	FunctorArity = Functor/Arity,
+	atom_string(Functor, FStr),
+	emit_clause_defs_py(Clauses, FunctorArity, FStr, Arity, 1, DefList),
+	atomic_list_concat(DefList, '\n\n', Lines).
+
+emit_clause_defs_py([], _, _, _, _, []).
+emit_clause_defs_py([Cl|Rest], FunctorArity, FStr, Arity, K, [Def|More]) :-
+	py_clause_func_name(FunctorArity, K, FuncName),
+	maplist(emit_instr_py, Cl, InstrLines),
+	atomic_list_concat(InstrLines, '\n', Body),
+	format(string(Def),
+'def ~w(state):
+    """Lowered clause ~w of ~w/~w (T4)"""
+~w', [FuncName, K, FStr, Arity, Body]),
+	K1 is K + 1,
+	emit_clause_defs_py(Rest, FunctorArity, FStr, Arity, K1, More).
+
 
 %% py_supported_structured(+StructuredInstr) — recurse through ite/3; each
 %  leaf must be an instruction emit_instr_py/2 can render.

--- a/src/unifyweaver/targets/wam_python_target.pl
+++ b/src/unifyweaver/targets/wam_python_target.pl
@@ -69,6 +69,8 @@
 	python_func_name/2,
 	py_structured_clause1/2,
 	py_multi_clause_1/2,
+	py_multi_clause_n/2,
+	emit_multi_clause_n_python/4,
 	emit_structured_python/4
 ]).
 :- use_module('../targets/wam_text_parser',
@@ -1622,9 +1624,11 @@ format_python_wam_registrar(Pred/Arity, Options, InstrLiterals, PythonCode) :-
 %  a name collision with the pred_* lowered function itself.
 compile_lowered_wam_predicate_to_python(Pred/Arity, WamCode, Options, PythonCode) :-
 	% Soft-cut if-then-else / negation / once lowers via the shared
-	% structurer; single deterministic predicates take the straight-line path;
-	% multi-clause predicates lower clause 1 (T3) and keep clauses 2+ in the
-	% bytecode interpreter, reached by backtracking when clause 1 fails.
+	% structurer; single deterministic predicates take the straight-line path.
+	% Multi-clause predicates prefer T4 (every clause body lowered, the
+	% try/retry/trust dispatch scaffold retained so the runtime's choice-point
+	% machinery drives backtracking) and fall back to T3 (clause-1 fast path,
+	% clauses 2+ left as full bytecode) when some later clause is unsupported.
 	(   py_structured_clause1(WamCode, Structured)
 	->  emit_structured_python(Pred/Arity, Structured, Options, LoweredFn),
 	    stub_lowered_registrar(Pred/Arity, Registrar)
@@ -1632,6 +1636,9 @@ compile_lowered_wam_predicate_to_python(Pred/Arity, WamCode, Options, PythonCode
 	    is_deterministic_pred_py(Instrs)
 	->  emit_lowered_python(Pred/Arity, Instrs, Options, LoweredFn),
 	    stub_lowered_registrar(Pred/Arity, Registrar)
+	;   py_multi_clause_n(WamCode, Clauses)
+	->  emit_multi_clause_n_python(Pred/Arity, Clauses, Options, LoweredFn),
+	    multi_clause_n_registrar(Pred/Arity, WamCode, Registrar)
 	;   py_multi_clause_1(WamCode, Clause1Instrs)
 	->  emit_lowered_python(Pred/Arity, Clause1Instrs, Options, LoweredFn),
 	    multi_clause_1_registrar(Pred/Arity, WamCode, Registrar)
@@ -1683,6 +1690,68 @@ multi_clause_1_registrar(Pred/Arity, WamCode, Registrar) :-
 ~w
     )
 ', [RegistrarName, PredStr, Arity, LabelKey, Body]).
+
+%% multi_clause_n_registrar(+Pred/Arity, +WamCode, -Registrar)
+%  T4 registrar (hybrid): keep the FULL predicate bytecode but replace EVERY
+%  clause's body with a call_lowered to that clause's native function
+%  (pred_*_cK). The try_me_else / retry_me_else / trust_me dispatch scaffold and
+%  all labels are retained verbatim, so the runtime's choice-point machinery
+%  still drives clause dispatch and backtracking exactly as for the bytecode
+%  interpreter — but each clause body now runs as native Python. On a clause's
+%  call_lowered SUCCESS the scaffold falls through to that clause's proceed
+%  (later-clause choice points left for backtracking); on FAILURE the runtime
+%  calls fail(), popping to the next clause's retry_me_else / trust_me. Labels
+%  stay inline ("__label__", Name), so load_program recomputes PCs after the
+%  per-clause body collapse.
+multi_clause_n_registrar(Pred/Arity, WamCode, Registrar) :-
+	wam_code_to_python_instructions(WamCode, Pred/Arity, FullInstrLiterals, _Labels),
+	split_string(FullInstrLiterals, "\n", "", Lines0),
+	python_func_name(Pred/Arity, FuncBase),
+	rewrite_clauses_to_call_lowered(Lines0, FuncBase, Arity, 0, Lines),
+	atomic_list_concat(Lines, '\n', Body),
+	atom_string(Pred, PredStr),
+	atom_concat(register_, FuncBase, RegistrarName),
+	format(atom(LabelKey), '~w/~w', [PredStr, Arity]),
+	format(string(Registrar),
+'def ~w(raw_program):
+    """Register T4 all-clauses lowering for ~w/~w (native bodies, bytecode dispatch)."""
+    raw_program["~w"] = (
+~w
+    )
+', [RegistrarName, PredStr, Arity, LabelKey, Body]).
+
+%% rewrite_clauses_to_call_lowered(+Lines, +FuncBase, +Arity, +K, -Out)
+%  Walk the predicate's instruction literals, replacing each clause body with a
+%  single call_lowered to pred_*_c<K> (K = 1-based clause index, incremented at
+%  each proceed/fail terminator). Labels, the try/retry/trust dispatch markers,
+%  and switch SKIP comments are passed through unchanged; body instruction
+%  literals are dropped (their work moves into the per-clause function).
+rewrite_clauses_to_call_lowered([], _FuncBase, _Arity, _K, []).
+rewrite_clauses_to_call_lowered([L|Ls], FuncBase, Arity, K, Out) :-
+	(   clause_terminal_literal(L)
+	->  K1 is K + 1,
+	    format(atom(FN), '~w_c~w', [FuncBase, K1]),
+	    format(string(CallLowered), '        ("call_lowered", ~w, ~w),', [FN, Arity]),
+	    Out = [CallLowered, L | Rest],
+	    rewrite_clauses_to_call_lowered(Ls, FuncBase, Arity, K1, Rest)
+	;   clause_passthrough_literal(L)
+	->  Out = [L | Rest],
+	    rewrite_clauses_to_call_lowered(Ls, FuncBase, Arity, K, Rest)
+	;   % body instruction literal — drop (folded into the per-clause function)
+	    rewrite_clauses_to_call_lowered(Ls, FuncBase, Arity, K, Out)
+	).
+
+clause_terminal_literal(L) :-
+	( sub_string(L, _, _, _, '("proceed",)')
+	; sub_string(L, _, _, _, '("fail",)') ).
+
+clause_passthrough_literal(L) :-
+	( sub_string(L, _, _, _, '("__label__"')
+	; sub_string(L, _, _, _, '("try_me_else"')
+	; sub_string(L, _, _, _, '("retry_me_else"')
+	; sub_string(L, _, _, _, '("trust_me",)')
+	; sub_string(L, _, _, _, "# SKIP")
+	).
 
 %% rewrite_clause1_to_call_lowered(+Lines, +FuncName, +Arity, -Out)
 %  Replace the clause-1 body literals — those strictly between the predicate's
@@ -2208,6 +2277,7 @@ lowered_candidate_wam(Wam) :-
 	(   parse_wam_text_py(WamText, Instrs),
 	    is_deterministic_pred_py(Instrs)
 	;   py_structured_clause1(WamText, _)    % soft-cut if-then-else / \+ / once
+	;   py_multi_clause_n(WamText, _)        % T4: multi-clause, all clauses lowered
 	;   py_multi_clause_1(WamText, _)        % T3: multi-clause clause-1 fast path
 	).
 

--- a/tests/test_wam_python_lowered_t3.pl
+++ b/tests/test_wam_python_lowered_t3.pl
@@ -27,7 +27,7 @@
 :- use_module('../src/unifyweaver/targets/wam_python_target').
 :- use_module('../src/unifyweaver/targets/wam_python_lowered_emitter').
 
-:- dynamic user:color/1, user:pq/1, user:classify/2.
+:- dynamic user:color/1, user:pq/1, user:classify/2, user:foo/1, user:bar/1.
 
 % facts (first-argument indexed)
 user:color(red).
@@ -40,8 +40,16 @@ user:pq(X) :- X = b.
 user:classify(0, zero).
 user:classify(N, pos) :- N > 0.
 user:classify(_, neg).
+% T3-FALLBACK predicate: clause 2 ends in `execute bar/1` (a tail call, not a
+% proceed), so T4 (py_multi_clause_n) DECLINES and the predicate genuinely
+% routes through T3 — clause 1 lowered to a fast path, clause 2 kept as
+% bytecode. color/pq/classify above now route through T4 (all clauses lowered);
+% foo/1 is what keeps the T3 path exercised.
+user:foo(a).
+user:foo(X) :- user:bar(X).
+user:bar(b).
 
-preds([user:color/1, user:pq/1, user:classify/2]).
+preds([user:color/1, user:pq/1, user:classify/2, user:foo/1, user:bar/1]).
 
 python3_available :-
     catch(( process_create(path(python3), ['--version'],
@@ -51,28 +59,36 @@ python3_available :-
 :- begin_tests(wam_python_lowered_t3, [condition(python3_available)]).
 
 % Each multi-clause predicate must be recognised as a T3 clause-1 candidate,
-% with clause 1 being a clean deterministic slice.
+% with clause 1 being a clean deterministic slice. (color/pq/classify are also
+% T4-eligible and route through T4 at compile time; they remain valid T3
+% candidates. foo/1 is the genuine T3 case: T4 declines it.)
 test(gate_picks_multi_clause_1) :-
-    forall(member(_:PI, [user:color/1, user:pq/1, user:classify/2]),
+    forall(member(_:PI, [user:color/1, user:pq/1, user:classify/2, user:foo/1]),
            ( wam_target:compile_predicate_to_wam(PI, [], W),
              ( py_multi_clause_1(W, C1)
              -> assertion(\+ member(try_me_else(_), C1)),
                 assertion(last(C1, proceed))
-             ;  throw(not_multi_clause_1(PI)) ) )).
+             ;  throw(not_multi_clause_1(PI)) ) )),
+    % foo/1 has a clause (clause 2 ends in execute) that T4 cannot lower, so it
+    % must fall back to T3 rather than being claimed by T4.
+    wam_target:compile_predicate_to_wam(foo/1, [], Wf),
+    assertion(\+ py_multi_clause_n(Wf, _)).
 
-% The emitted code: a lowered pred_* function, a call_lowered into clause 1,
-% and the clause-2+ bytecode retained (so the interpreter can run them).
+% The emitted T3 code (foo/1, which T4 declines): a single lowered clause-1
+% pred_* function, a call_lowered into clause 1, and the clause-2 bytecode
+% retained (so the interpreter runs it on backtracking).
 test(emits_call_lowered_and_retains_later_clauses) :-
-    wam_target:compile_predicate_to_wam(color/1, [], W),
-    wam_python_target:compile_lowered_wam_predicate_to_python(color/1, W, [emit_mode(lowered)], Code),
-    assertion(sub_string(Code, _, _, _, "def pred_color_1(state)")),
-    assertion(sub_string(Code, _, _, _, '("call_lowered", pred_color_1, 1)')),
+    wam_target:compile_predicate_to_wam(foo/1, [], W),
+    wam_python_target:compile_lowered_wam_predicate_to_python(foo/1, W, [emit_mode(lowered)], Code),
+    assertion(sub_string(Code, _, _, _, "def pred_foo_1(state)")),
+    assertion(sub_string(Code, _, _, _, '("call_lowered", pred_foo_1, 1)')),
     assertion(sub_string(Code, _, _, _, "try_me_else")),
-    % clause 2 / clause 3 bytecode retained (green & blue still matched in interp)
-    assertion(sub_string(Code, _, _, _, '("get_constant", Atom("green"), A1)')),
-    assertion(sub_string(Code, _, _, _, '("get_constant", Atom("blue"), A1)')),
-    % clause-1 body collapsed: red is matched by the lowered fn, not the bytecode
-    assertion(\+ sub_string(Code, _, _, _, '("get_constant", Atom("red")')).
+    % clause 2 bytecode retained (the tail call into bar/1 runs in the interpreter)
+    assertion(sub_string(Code, _, _, _, "bar/1")),
+    % clause-1 body collapsed: 'a' is matched by the lowered fn, not the bytecode
+    assertion(\+ sub_string(Code, _, _, _, '("get_constant", Atom("a")')),
+    % single clause-1 function, not the per-clause T4 functions
+    assertion(\+ sub_string(Code, _, _, _, "def pred_foo_1_c1(state)")).
 
 % Correctness through the interpreter (lowered mode): clause-1 fast path,
 % clause-2 fallback, clause-3 fallback, and no-match.
@@ -107,7 +123,11 @@ battery([
     'classify/2'-[reg(1, 'I(5)'), reg(2, 'A("pos")')]-true,
     'classify/2'-[reg(1, 'I(5)'), reg(2, 'A("neg")')]-true,
     'classify/2'-[reg(1, 'I(-2)'), reg(2, 'A("neg")')]-true,
-    'classify/2'-[reg(1, 'I(-2)'), reg(2, 'A("pos")')]-false
+    'classify/2'-[reg(1, 'I(-2)'), reg(2, 'A("pos")')]-false,
+    % foo/1 routes through T3 (clause 2 = execute bar/1 declines T4):
+    'foo/1'-[reg(1, 'A("a")')]-true,    % clause 1 lowered fast path
+    'foo/1'-[reg(1, 'A("b")')]-true,    % clause 1 fails -> clause 2 bytecode -> bar(b)
+    'foo/1'-[reg(1, 'A("z")')]-false
 ]).
 
 assert_expected(Results) :-

--- a/tests/test_wam_python_lowered_t4.pl
+++ b/tests/test_wam_python_lowered_t4.pl
@@ -1,0 +1,193 @@
+% test_wam_python_lowered_t4.pl
+%
+% End-to-end test for the Python T4 lowering — multi-clause, ALL clauses
+% (lowering type T4 / multi_clause_n in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md).
+%
+% Python's runtime is a genuine backtracking WAM, so — unlike the imperative
+% first-solution T4 targets (lua/rust/…) which commit to the first matching
+% clause — Python T4 must preserve intra-query backtracking into later clauses
+% or it would diverge from the bytecode interpreter. We use the HYBRID
+% realisation: every clause BODY is lowered to a native pred_*_cK function, but
+% the try_me_else / retry_me_else / trust_me dispatch scaffold is kept in the
+% bytecode so the runtime's proven choice-point machinery drives clause
+% dispatch and backtracking. Each clause's body is replaced by a call_lowered
+% to its native function.
+%
+% The decisive checks below are bt_green/1 and bt_blue/1: a conjunctive query
+% `color(X), want_green(X)` only succeeds if, after the lowered clause 1 binds
+% X=red and want_green(red) fails, the engine backtracks into color's lowered
+% clause 2 (green). A first-solution T4 would commit to red and fail. We also
+% run a full lowered-vs-interpreter parity battery.
+%
+% Skipped automatically when python3 is unavailable.
+
+:- use_module(library(lists)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_python_target').
+:- use_module('../src/unifyweaver/targets/wam_python_lowered_emitter').
+
+:- dynamic user:color/1, user:want_green/1, user:want_blue/1,
+           user:bt_green/1, user:bt_blue/1, user:classify/2.
+
+user:color(red).
+user:color(green).
+user:color(blue).
+user:want_green(green).
+user:want_blue(blue).
+% conjunctive predicates that force backtracking into a non-first clause of color/1
+user:bt_green(X) :- user:color(X), user:want_green(X).
+user:bt_blue(X)  :- user:color(X), user:want_blue(X).
+% mixed: fact, guarded rule (clause 2 runs a builtin), catch-all
+user:classify(0, zero).
+user:classify(N, pos) :- N > 0.
+user:classify(_, neg).
+
+preds([user:color/1, user:want_green/1, user:want_blue/1,
+       user:bt_green/1, user:bt_blue/1, user:classify/2]).
+
+python3_available :-
+    catch(( process_create(path(python3), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_python_lowered_t4, [condition(python3_available)]).
+
+% Every multi-clause predicate where all clauses are clean deterministic bodies
+% must be recognised as a T4 candidate with the right clause count.
+test(gate_picks_multi_clause_n) :-
+    wam_target:compile_predicate_to_wam(color/1, [], Wc),
+    assertion(( py_multi_clause_n(Wc, Cs), length(Cs, 3),
+                forall(member(C, Cs), last(C, proceed)) )),
+    wam_target:compile_predicate_to_wam(classify/2, [], Wcl),
+    assertion(( py_multi_clause_n(Wcl, Cs2), length(Cs2, 3) )).
+
+% The emitted code: one native pred_*_cK per clause, plus a registrar that keeps
+% the try/retry/trust dispatch scaffold and replaces each clause body with a
+% call_lowered to its clause function.
+test(emits_per_clause_functions_and_scaffold) :-
+    wam_target:compile_predicate_to_wam(color/1, [], W),
+    wam_python_target:compile_lowered_wam_predicate_to_python(color/1, W, [emit_mode(lowered)], Code),
+    forall(member(F, ["def pred_color_1_c1(state)",
+                      "def pred_color_1_c2(state)",
+                      "def pred_color_1_c3(state)"]),
+           assertion(sub_string(Code, _, _, _, F))),
+    % dispatch scaffold retained
+    assertion(sub_string(Code, _, _, _, '("try_me_else", "L_color_1_2")')),
+    assertion(sub_string(Code, _, _, _, '("retry_me_else", "L_color_1_3")')),
+    assertion(sub_string(Code, _, _, _, '("trust_me",)')),
+    % every clause body is a call_lowered, none left as a get_constant in bytecode
+    assertion(sub_string(Code, _, _, _, '("call_lowered", pred_color_1_c2, 1)')),
+    assertion(sub_string(Code, _, _, _, '("call_lowered", pred_color_1_c3, 1)')),
+    assertion(\+ sub_string(Code, _, _, _, '("get_constant", Atom("green"), A1)')),
+    assertion(\+ sub_string(Code, _, _, _, '("get_constant", Atom("blue"), A1)')).
+
+% Correctness through the interpreter (lowered mode), including the
+% backtracking-critical conjunctions bt_green/bt_blue.
+test(t4_exec_lowered) :-
+    run_battery(lowered, Results),
+    assert_expected(Results).
+
+% Parity: the all-clauses-native lowering agrees with the pure bytecode
+% interpreter on every query — the defining property of a faithful lowering,
+% and the guard that the native clause bodies preserve backtracking.
+test(t4_parity_lowered_vs_interpreter) :-
+    run_battery(lowered, Lowered),
+    run_battery(interpreter, Interp),
+    ( Lowered == Interp
+    -> true
+    ;  format(user_error, "~n[python t4 lowered vs interpreter]~nlowered=~q~ninterp =~q~n",
+              [Lowered, Interp]),
+       throw(python_t4_parity_failed) ).
+
+:- end_tests(wam_python_lowered_t4).
+
+% Name-Args-Expected battery. Args is a list of py-value strings, or the atom
+% `var` for a fresh unbound argument register.
+battery([
+    'color/1'-['A("red")']-true,
+    'color/1'-['A("green")']-true,
+    'color/1'-['A("blue")']-true,
+    'color/1'-['A("pink")']-false,
+    % backtracking-critical: must redo color into clause 2 (green) / clause 3 (blue)
+    'bt_green/1'-[var]-true,
+    'bt_blue/1'-[var]-true,
+    'classify/2'-['I(0)', 'A("zero")']-true,
+    'classify/2'-['I(0)', 'A("wrong")']-false,
+    'classify/2'-['I(5)', 'A("pos")']-true,
+    'classify/2'-['I(5)', 'A("neg")']-true,
+    'classify/2'-['I(-2)', 'A("neg")']-true,
+    'classify/2'-['I(-2)', 'A("pos")']-false
+]).
+
+assert_expected(Results) :-
+    battery(B),
+    findall(Name-Got-Want,
+            ( nth0(I, B, Name-_Args-Want), nth0(I, Results, Got), Got \== Want ),
+            Bad),
+    ( Bad == [] -> true
+    ; format(user_error, "~n[python t4 wrong results] ~q~n", [Bad]),
+      throw(python_t4_wrong(Bad)) ).
+
+%% run_battery(+Mode, -Results) — generate a project in Mode, run the battery
+%  through the interpreter, unify Results with the list of booleans (in order).
+run_battery(Mode, Results) :-
+    preds(Preds),
+    battery(B),
+    format(atom(Dir), 'output/test_wam_python_t4_~w', [Mode]),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    ( Mode == lowered -> Opts = [module_name(t4proj), emit_mode(lowered)]
+    ;                    Opts = [module_name(t4proj)] ),
+    write_wam_python_project(Preds, Opts, Dir),
+    build_harness(B, HarnessSrc),
+    atomic_list_concat([Dir, '/t4_harness.py'], HPath),
+    setup_call_cleanup(open(HPath, write, S, [encoding(utf8)]),
+                       write(S, HarnessSrc), close(S)),
+    format(atom(Cmd), 'cd ~w && python3 t4_harness.py 2>&1', [Dir]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), split_string(OutStr, "\n", " \n", LinesAll),
+      ( member(RLine, LinesAll), sub_string(RLine, 0, _, _, "RESULTS ")
+      -> sub_string(RLine, 8, _, 0, CSV),
+         split_string(CSV, ",", "", Toks),
+         maplist(tok_bool, Toks, Results)
+      ;  throw(python_t4_no_results(OutStr)) )
+    ; format(user_error, "~n[python t4 harness ~w output]~n~w~n", [Mode, OutStr]),
+      throw(python_t4_harness_failed(Mode, Status)) ).
+
+tok_bool("1", true).
+tok_bool("0", false).
+
+%% build_harness(+Battery, -Src) — python harness that runs each query through
+%  the interpreter and prints "RESULTS b,b,b,..." (1=success, 0=fail). Unbound
+%  argument positions (`var`) become fresh logic variables.
+build_harness(Battery, Src) :-
+    findall(Line, ( member(Name-Args-_, Battery), query_line(Name, Args, Line) ), Lines),
+    atomic_list_concat(Lines, '\n', Body),
+    format(string(Src),
+"import sys\n\c
+sys.path.insert(0, '.')\n\c
+from wam_runtime import *\n\c
+from predicates import build_program\n\c
+A = Atom\n\c
+I = Int\n\c
+_code, _labels = load_program(build_program())\n\c
+def q(entry, vals):\n\c
+\s\s\s\ss = WamState()\n\c
+\s\s\s\sfor i, v in enumerate(vals, 1):\n\c
+\s\s\s\s\s\s\s\sset_reg(s, i, v if v is not None else s.fresh_var())\n\c
+\s\s\s\sreturn 1 if run_wam(_code, _labels, entry, s) else 0\n\c
+_res = []\n\c
+~w\n\c
+print('RESULTS ' + ','.join(str(x) for x in _res))\n",
+        [Body]).
+
+query_line(Name, Args, Line) :-
+    maplist(arg_py, Args, ArgStrs),
+    atomic_list_concat(ArgStrs, ', ', ArgList),
+    format(atom(Line), '_res.append(q("~w", [~w]))', [Name, ArgList]).
+
+arg_py(var, "None") :- !.
+arg_py(V, V).

--- a/tests/test_wam_python_target.pl
+++ b/tests/test_wam_python_target.pl
@@ -192,22 +192,40 @@ test(compile_lowered_mode_direct_predicate) :-
 	assertion(sub_string(S, _, _, _, "def register_pred_foo_1(raw_program)")),
 	assertion(sub_string(S, _, _, _, '("call_lowered", pred_foo_1, 1)')).
 
-test(compile_lowered_mode_multi_clause_t3) :-
-	% T3: a multi-clause predicate lowers clause 1 to a fast-path function and
-	% keeps clauses 2+ in the bytecode, with clause 1's body replaced by a
-	% call_lowered. The leading try_me_else (which pushes the choice point onto
-	% clause 2) is retained, so a failed clause-1 fast path backtracks into the
-	% clause-2 bytecode through the runtime's call_lowered fallback.
+test(compile_lowered_mode_multi_clause_t4) :-
+	% T4: when EVERY clause is a clean deterministic body, each clause body is
+	% lowered to its own pred_*_cK function and the try/retry/trust dispatch
+	% scaffold is retained (so the runtime's choice-point machinery drives
+	% clause dispatch and backtracking). Every clause body becomes a call_lowered.
 	WamCode = 'choice/1:\n  try_me_else choice_2\n  get_constant a, 1\n  proceed\nchoice_2:\n  trust_me\n  get_constant b, 1\n  proceed',
 	wam_python_target:compile_one_predicate([emit_mode(lowered)], choice/1-WamCode, PythonCode),
 	atom_string(PythonCode, S),
-	assertion(sub_string(S, _, _, _, "def pred_choice_1(state)")),
+	assertion(sub_string(S, _, _, _, "def pred_choice_1_c1(state)")),
+	assertion(sub_string(S, _, _, _, "def pred_choice_1_c2(state)")),
 	assertion(sub_string(S, _, _, _, "def register_pred_choice_1(raw_program)")),
-	assertion(sub_string(S, _, _, _, '("call_lowered", pred_choice_1, 1)')),
 	assertion(sub_string(S, _, _, _, '("try_me_else", "choice_2")')),
-	% clause 2 bytecode retained (matched by the interpreter on fallback)
-	assertion(sub_string(S, _, _, _, '("get_constant", Atom("b"), 1)')),
-	% clause-1 body collapsed: 'a' is matched by the lowered fn, not the bytecode
+	assertion(sub_string(S, _, _, _, '("trust_me",)')),
+	assertion(sub_string(S, _, _, _, '("call_lowered", pred_choice_1_c1, 1)')),
+	assertion(sub_string(S, _, _, _, '("call_lowered", pred_choice_1_c2, 1)')),
+	% both clause bodies collapsed: neither get_constant survives in the bytecode
+	assertion(\+ sub_string(S, _, _, _, '("get_constant", Atom("a"), 1)')),
+	assertion(\+ sub_string(S, _, _, _, '("get_constant", Atom("b"), 1)')).
+
+test(compile_lowered_mode_multi_clause_t3_fallback) :-
+	% T3 fallback: when a non-first clause cannot be lowered (here clause 2 ends
+	% in a tail call `execute`, not proceed), T4 declines and the predicate
+	% routes through T3 — a single clause-1 fast-path function, with clause 2
+	% kept verbatim in the bytecode.
+	WamCode = 'mix/1:\n  try_me_else mix_2\n  get_constant a, 1\n  proceed\nmix_2:\n  trust_me\n  get_variable X1, 1\n  execute other/1',
+	wam_python_target:compile_one_predicate([emit_mode(lowered)], mix/1-WamCode, PythonCode),
+	atom_string(PythonCode, S),
+	assertion(sub_string(S, _, _, _, "def pred_mix_1(state)")),
+	assertion(\+ sub_string(S, _, _, _, "def pred_mix_1_c1(state)")),
+	assertion(sub_string(S, _, _, _, '("call_lowered", pred_mix_1, 1)')),
+	assertion(sub_string(S, _, _, _, '("try_me_else", "mix_2")')),
+	% clause 2 kept as bytecode (the tail call into other/1)
+	assertion(sub_string(S, _, _, _, "other/1")),
+	% clause-1 body collapsed
 	assertion(\+ sub_string(S, _, _, _, '("get_constant", Atom("a"), 1)')).
 
 test(compile_all_lowered_mode_build_program_uses_registrars, [nondet]) :-


### PR DESCRIPTION
## Summary

Python was the structurer-column target lacking **T4** (multi-clause, all clauses lowered). This adds it as a **hybrid**: every clause *body* is lowered to a native `pred_*_cK` function, but the `try/retry/trust` dispatch scaffold is retained in the bytecode.

## Why hybrid, not the imperative first-solution shape

The other structurer targets (Lua/Rust/C++/Go/LLVM) ship T4 as *first-solution-only* — snapshot regs, try each clause, restore between, **no choice point**. That's sound for their "deterministic-prefix" runtimes. **Python's runtime is a genuine backtracking WAM** (choice points + `fail()`), and `run_wam` backtracks *intra-query*. A first-solution T4 would diverge from the interpreter on a conjunction like `p(X), q(X)` — committing to clause 1 — **failing the lowered-vs-interpreter parity standard** the T3 work established.

So `py_multi_clause_n` + `multi_clause_n_registrar` lower each clause body to native code and replace only the body with a `call_lowered`, **keeping the dispatch scaffold**. The runtime's proven choice-point machinery drives clause dispatch and backtracking unchanged → all clause bodies native, parity preserved by construction. **Emitter-only, no runtime change** (labels stay inline `("__label__", …)` so `load_program` recomputes PCs).

The decisive test: `bt_green(X) :- color(X), want_green(X)` only succeeds (binding `X=green`) if, after the lowered clause 1 binds `X=red` and `want_green(red)` fails, the engine backtracks into color's **native** clause 2. ✅

## Layering (per the discussion)

Dispatch order: structured-ITE → deterministic → **T4** → **T3** (fallback when a later clause can't be lowered, e.g. ends in a tail-call `execute`). Full-native and hybrid aren't mutually exclusive — a future full-native dispatch (R's genuine-CP closures over the runtime's callable choice points) can slot **in front** of this hybrid for shapes that admit it, with hybrid as the universal sound fallback.

## Matrix marking

Marked **`~` (hybrid)**, not ✓: the T4 headline ("interpreter never entered for clause dispatch") isn't met — the O(n) dispatch stays in the tiny bytecode scaffold. Every clause *body* is native, though, and parity holds.

## Tests
- **`test_wam_python_lowered_t4.pl`** (python3): gate, per-clause-function + scaffold shape, exec correctness, the **backtracking-critical** conjunctions, and a **lowered-vs-interpreter parity battery**.
- **`test_wam_python_lowered_t3.pl`**: kept genuine T3 coverage via a `foo/1` fallback (clause 2 ends in `execute`, so T4 declines).
- **`test_wam_python_target.pl`**: updated the codegen shape tests (`choice/1` now routes T4; added a `mix/1` T3-fallback test).

The one unrelated failure in the suite (`runtime_parser_compiled_read_term_prefix_naf`) fails on `main` too (pre-existing).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_