### PR TITLE
bench: Measure parent-path support bounds for cache planning

### DIFF
--- a/docs/reports/distribution_support_bounds_simplewiki_depth3_2026-06-10.md
+++ b/docs/reports/distribution_support_bounds_simplewiki_depth3_2026-06-10.md
@@ -1,0 +1,99 @@
+# SimpleWiki Parent Support Bounds Benchmark
+
+Date: 2026-06-10
+
+## Purpose
+
+This run validates the scalar support-bounds idea from
+`docs/design/DISTRIBUTIONAL_FIT_POLICY.md` and
+`docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md` against the same shallow
+SimpleWiki Articles sample used by the distribution-cache depth grid.
+
+The question is whether parent-only path support bounds are exact enough to use
+as a cheap planner state before materialising full path-length distributions:
+
+```text
+L_min(v) = shortest parent-only path length from v to root
+L_max(v) = longest parent-only path length from v to root
+support_width(v) = L_max(v) - L_min(v)
+```
+
+For min-only and max-only functionals, those scalar recurrences are the result.
+For bounded aggregate functionals, they are pruning and planning signals:
+
+```text
+if L_min(v) > remaining_budget: suffix contributes zero
+if L_max(v) <= remaining_budget: suffix is fully inside the budget
+otherwise: exact histogram, cached boundary, or fitted state is still needed
+```
+
+## Input
+
+The run used the prior sampled depth-3 SimpleWiki Articles artifact:
+
+```text
+/mnt/c/Users/johnc/Scratch/distribution-cache-depth-grid/simplewiki_articles_root2_depth3.tsv
+```
+
+The root was numeric category id `2`, matching the previous SimpleWiki Articles
+artifact sidecar. The sampled graph contains `14680` reachable target nodes and
+`14887` parent edges.
+
+## Command
+
+```sh
+python3 scripts/distribution_cache_support_bounds.py \
+  --edge-file /mnt/c/Users/johnc/Scratch/distribution-cache-depth-grid/simplewiki_articles_root2_depth3.tsv \
+  --graph-name simplewiki_articles_root2_depth3 \
+  --root 2 \
+  --budgets 2,4,6 \
+  --output-dir /mnt/c/Users/johnc/Scratch/distribution-cache-support-bounds \
+  --fail-on-error
+```
+
+Raw generated outputs were written to:
+
+```text
+/mnt/c/Users/johnc/Scratch/distribution-cache-support-bounds/distribution_support_bounds_simplewiki_articles_root2_depth3_20260610T231212Z.jsonl
+/mnt/c/Users/johnc/Scratch/distribution-cache-support-bounds/distribution_support_bounds_summary_simplewiki_articles_root2_depth3_20260610T231212Z.md
+```
+
+## Results
+
+### Target Bounds
+
+| targets | validated | unreachable | exact_errors | bounds_failures | mean_width | p95_width | max_width | mean_path_count |
+|---------|-----------|-------------|--------------|-----------------|------------|-----------|-----------|-----------------|
+| 14680 | 14680 | 0 | 0 | 0 | 0.014 | 0.000 | 2 | 1.014 |
+
+### Budget Signals
+
+| B_search | targets | zero_by_min | fully_covered_by_max | partial_by_bounds | narrow_support | wide_support |
+|----------|---------|-------------|----------------------|-------------------|----------------|--------------|
+| 2 | 14680 | 36 | 14633 | 11 | 14680 | 0 |
+| 4 | 14680 | 0 | 14680 | 0 | 14680 | 0 |
+| 6 | 14680 | 0 | 14680 | 0 | 14680 | 0 |
+
+### Root-Distance Buckets
+
+| L_min | targets | mean_width | max_width | mean_path_count |
+|-------|---------|------------|-----------|-----------------|
+| 0 | 1 | 0.000 | 0 | 1.000 |
+| 1 | 13720 | 0.015 | 2 | 1.015 |
+| 2 | 923 | 0.001 | 1 | 1.013 |
+| 3 | 36 | 0.000 | 0 | 1.000 |
+
+## Interpretation
+
+For this shallow SimpleWiki Articles sample, scalar bounds are exact against the
+full parent-path histograms and are strong enough to classify almost every
+budgeted query without looking at the full distribution. At `B_search=2`, bounds
+prove `36` targets contribute zero and `14633` targets are fully covered, leaving
+only `11` partial cases. At `B_search=4` and `B_search=6`, every sampled target is
+fully covered by `L_max`.
+
+This confirms that min/max support bounds are a good early planner layer for the
+SimpleWiki parent-only subtree. The next useful stress case is a deeper target
+sample or an enwiki sample where support widths and shortcut paths should be
+larger. Full histograms and fitted distribution states should be reserved for
+the partial/wide-support region rather than materialised uniformly.

--- a/scripts/distribution_cache_support_bounds.py
+++ b/scripts/distribution_cache_support_bounds.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Benchmark scalar parent-path support bounds for cache planning."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import statistics
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.distribution_cache_support import (  # noqa: E402
+    FIXTURES,
+    ROOT,
+    exact_histogram,
+    load_parent_edges_tsv,
+    mass_cdf,
+    reachable_nodes_by_parent_distance,
+    support_bounds,
+)
+
+
+SIMPLEWIKI_ROOT = "Category:Articles"
+DEFAULT_BUDGETS = [2, 4, 6]
+
+
+def parse_int_list(text: str) -> list[int]:
+    values: list[int] = []
+    for part in text.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            lo_text, hi_text = part.split("-", 1)
+            lo = int(lo_text)
+            hi = int(hi_text)
+            step = 1 if hi >= lo else -1
+            values.extend(range(lo, hi + step, step))
+        else:
+            values.append(int(part))
+    return values
+
+
+def parse_targets(text: str) -> list[str]:
+    return [part.strip() for part in text.split(",") if part.strip()]
+
+
+def load_targets_file(path: Path) -> list[str]:
+    targets = []
+    with path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if line and not line.startswith("#"):
+                targets.append(line)
+    return targets
+
+
+def safe_graph_name(name: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", name).strip("_") or "graph"
+
+
+def percentile(values: list[int], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, round((pct / 100) * (len(ordered) - 1))))
+    return float(ordered[index])
+
+
+def select_file_targets(parents, root, explicit_targets, targets_file, max_target_depth, target_limit):
+    if explicit_targets:
+        targets = parse_targets(explicit_targets)
+    elif targets_file:
+        targets = load_targets_file(targets_file)
+    else:
+        targets = reachable_nodes_by_parent_distance(parents, root, max_target_depth)
+    if target_limit is not None:
+        targets = targets[:target_limit]
+    if not targets:
+        raise SystemExit("no support-bounds targets selected")
+    return targets
+
+
+def support_width(l_min, l_max):
+    if l_min is None or l_max is None:
+        return None
+    return l_max - l_min
+
+
+def target_bounds_record(graph_name, graph_label, root, target, hist, l_min, l_max, exact_error=None):
+    hist_min = min(hist) if hist else None
+    hist_max = max(hist) if hist else None
+    width = support_width(l_min, l_max)
+    hist_width = support_width(hist_min, hist_max)
+    return {
+        "record_type": "target_bounds",
+        "graph": graph_name,
+        "fixture": graph_label,
+        "root": root,
+        "target_node": target,
+        "L_min": l_min,
+        "L_max": l_max,
+        "support_width": width,
+        "hist_support_min": hist_min,
+        "hist_support_max": hist_max,
+        "hist_support_width": hist_width,
+        "path_count": sum(hist.values()),
+        "support_bins": len(hist),
+        "bounds_match_histogram": exact_error is None and (l_min, l_max) == (hist_min, hist_max),
+        "exact_histogram_error": exact_error,
+    }
+
+
+def budget_signal_record(graph_name, graph_label, root, target, budget, hist, l_min, l_max, narrow_width, wide_width):
+    width = support_width(l_min, l_max)
+    zero_by_min = l_min is None or l_min > budget
+    fully_covered_by_max = l_max is not None and l_max <= budget
+    return {
+        "record_type": "budget_signal",
+        "graph": graph_name,
+        "fixture": graph_label,
+        "root": root,
+        "target_node": target,
+        "B_search": budget,
+        "L_min": l_min,
+        "L_max": l_max,
+        "support_width": width,
+        "zero_by_min_budget": zero_by_min,
+        "fully_covered_by_max_budget": fully_covered_by_max,
+        "partial_by_bounds": not zero_by_min and not fully_covered_by_max,
+        "narrow_support": width is not None and width <= narrow_width,
+        "wide_support": width is not None and width >= wide_width,
+        "bounded_mass": mass_cdf(hist, budget),
+        "total_mass": sum(hist.values()),
+    }
+
+
+def run_graph_support_bounds(
+    graph_name,
+    graph_label,
+    parents,
+    targets,
+    budgets,
+    root,
+    narrow_width=2,
+    wide_width=10,
+):
+    records = []
+    min_memo = {}
+    max_memo = {}
+    hist_memo = {}
+    for target in targets:
+        exact_error = None
+        hist = {}
+        try:
+            hist = exact_histogram(target, parents, root, hist_memo)
+            l_min, l_max = support_bounds(target, parents, root, min_memo, max_memo)
+        except ValueError as exc:
+            l_min, l_max = None, None
+            exact_error = str(exc)
+
+        records.append(target_bounds_record(graph_name, graph_label, root, target, hist, l_min, l_max, exact_error))
+        for budget in budgets:
+            records.append(
+                budget_signal_record(
+                    graph_name,
+                    graph_label,
+                    root,
+                    target,
+                    budget,
+                    hist,
+                    l_min,
+                    l_max,
+                    narrow_width,
+                    wide_width,
+                )
+            )
+    return records
+
+
+def run_fixture_support_bounds(fixture_name, fixture, budgets, narrow_width=2, wide_width=10):
+    return run_graph_support_bounds(
+        "tiny_fixture",
+        fixture_name,
+        fixture["parents"],
+        fixture["targets"],
+        budgets,
+        ROOT,
+        narrow_width,
+        wide_width,
+    )
+
+
+def summarize(records):
+    target_records = [r for r in records if r["record_type"] == "target_bounds"]
+    signal_records = [r for r in records if r["record_type"] == "budget_signal"]
+    validated = [r for r in target_records if r["exact_histogram_error"] is None]
+    widths = [r["support_width"] for r in validated if r["support_width"] is not None]
+    path_counts = [r["path_count"] for r in validated]
+    failures = [r for r in validated if not r["bounds_match_histogram"]]
+
+    lines = [
+        "# Parent Support Bounds Benchmark Summary",
+        "",
+        "## Target Bounds",
+        "",
+        "| targets | validated | unreachable | exact_errors | bounds_failures | mean_width | p95_width | max_width | mean_path_count |",
+        "|---------|-----------|-------------|--------------|-----------------|------------|-----------|-----------|-----------------|",
+        "| {targets} | {validated} | {unreachable} | {errors} | {failures} | {mean_width:.3f} | {p95_width:.3f} | {max_width} | {mean_paths:.3f} |".format(
+            targets=len(target_records),
+            validated=len(validated),
+            unreachable=sum(1 for r in validated if r["L_min"] is None),
+            errors=sum(1 for r in target_records if r["exact_histogram_error"] is not None),
+            failures=len(failures),
+            mean_width=statistics.mean(widths) if widths else 0.0,
+            p95_width=percentile(widths, 95),
+            max_width=max(widths, default=0),
+            mean_paths=statistics.mean(path_counts) if path_counts else 0.0,
+        ),
+        "",
+        "## Budget Signals",
+        "",
+        "| B_search | targets | zero_by_min | fully_covered_by_max | partial_by_bounds | narrow_support | wide_support |",
+        "|----------|---------|-------------|----------------------|-------------------|----------------|--------------|",
+    ]
+
+    by_budget = {}
+    for record in signal_records:
+        by_budget.setdefault(record["B_search"], []).append(record)
+    for budget in sorted(by_budget):
+        rows = by_budget[budget]
+        lines.append(
+            "| {budget} | {targets} | {zero} | {full} | {partial} | {narrow} | {wide} |".format(
+                budget=budget,
+                targets=len(rows),
+                zero=sum(1 for r in rows if r["zero_by_min_budget"]),
+                full=sum(1 for r in rows if r["fully_covered_by_max_budget"]),
+                partial=sum(1 for r in rows if r["partial_by_bounds"]),
+                narrow=sum(1 for r in rows if r["narrow_support"]),
+                wide=sum(1 for r in rows if r["wide_support"]),
+            )
+        )
+
+    bucket_rows = {}
+    for record in validated:
+        if record["L_min"] is None:
+            continue
+        bucket_rows.setdefault(record["L_min"], []).append(record)
+    lines.extend([
+        "",
+        "## Root-Distance Buckets",
+        "",
+        "| L_min | targets | mean_width | max_width | mean_path_count |",
+        "|-------|---------|------------|-----------|-----------------|",
+    ])
+    for l_min in sorted(bucket_rows):
+        rows = bucket_rows[l_min]
+        row_widths = [r["support_width"] for r in rows if r["support_width"] is not None]
+        row_paths = [r["path_count"] for r in rows]
+        lines.append(
+            "| {l_min} | {targets} | {mean_width:.3f} | {max_width} | {mean_paths:.3f} |".format(
+                l_min=l_min,
+                targets=len(rows),
+                mean_width=statistics.mean(row_widths) if row_widths else 0.0,
+                max_width=max(row_widths, default=0),
+                mean_paths=statistics.mean(row_paths) if row_paths else 0.0,
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(records, summary, output_dir, graph_name):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    safe_name = safe_graph_name(graph_name)
+    jsonl_path = output_dir / f"distribution_support_bounds_{safe_name}_{timestamp}.jsonl"
+    summary_path = output_dir / f"distribution_support_bounds_summary_{safe_name}_{timestamp}.md"
+    with jsonl_path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+    summary_path.write_text(summary, encoding="utf-8")
+    return jsonl_path, summary_path
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixtures", default="all", help="Comma-separated fixture names or all. Ignored when --edge-file is set.")
+    parser.add_argument("--edge-file", type=Path, help="Optional TSV edge list with child<TAB>parent rows.")
+    parser.add_argument("--graph-name", help="Graph label used in records and output filenames.")
+    parser.add_argument("--root", help="Root node. Defaults to R for fixtures and Category:Articles for edge files.")
+    parser.add_argument("--targets", help="Comma-separated target nodes for edge-file mode.")
+    parser.add_argument("--targets-file", type=Path, help="Optional newline-delimited target list for edge-file mode.")
+    parser.add_argument("--max-target-depth", type=int, help="Select reachable edge-file targets within this parent distance from root.")
+    parser.add_argument("--target-limit", type=int, help="Limit selected edge-file targets after sorting/filtering.")
+    parser.add_argument("--budgets", default=",".join(map(str, DEFAULT_BUDGETS)))
+    parser.add_argument("--narrow-width", type=int, default=2, help="Support width considered cheap for exact histogram planning.")
+    parser.add_argument("--wide-width", type=int, default=10, help="Support width considered wide enough to prefer a boundary or fit.")
+    parser.add_argument("--output-dir", type=Path, help="Optional directory for JSONL and markdown output.")
+    parser.add_argument("--fail-on-error", action="store_true", help="Exit nonzero if bounds differ from exact histogram support.")
+    args = parser.parse_args(argv)
+
+    budgets = parse_int_list(args.budgets)
+    records = []
+
+    if args.edge_file:
+        root = args.root or SIMPLEWIKI_ROOT
+        parents = load_parent_edges_tsv(args.edge_file)
+        graph_name = args.graph_name or args.edge_file.stem
+        targets = select_file_targets(
+            parents,
+            root,
+            args.targets,
+            args.targets_file,
+            args.max_target_depth,
+            args.target_limit,
+        )
+        records.extend(
+            run_graph_support_bounds(
+                graph_name,
+                graph_name,
+                parents,
+                targets,
+                budgets,
+                root,
+                args.narrow_width,
+                args.wide_width,
+            )
+        )
+    else:
+        root = args.root or ROOT
+        if root != ROOT:
+            raise SystemExit("--root is only supported with --edge-file; fixtures use root R")
+        fixture_names = sorted(FIXTURES) if args.fixtures == "all" else [name.strip() for name in args.fixtures.split(",")]
+        for fixture_name in fixture_names:
+            if fixture_name not in FIXTURES:
+                raise SystemExit(f"unknown fixture: {fixture_name}")
+            records.extend(
+                run_fixture_support_bounds(
+                    fixture_name,
+                    FIXTURES[fixture_name],
+                    budgets,
+                    args.narrow_width,
+                    args.wide_width,
+                )
+            )
+        graph_name = args.graph_name or "tiny_fixture"
+
+    summary = summarize(records)
+    print(summary, end="")
+    if args.output_dir:
+        jsonl_path, summary_path = write_outputs(records, summary, args.output_dir, graph_name)
+        print(f"\nwrote {jsonl_path}")
+        print(f"wrote {summary_path}")
+
+    failures = [
+        r
+        for r in records
+        if r.get("record_type") == "target_bounds"
+        and (r.get("exact_histogram_error") is not None or not r.get("bounds_match_histogram", True))
+    ]
+    if failures and args.fail_on_error:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_distribution_cache_support_bounds.py
+++ b/tests/test_distribution_cache_support_bounds.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Smoke tests for scalar parent-path support bounds."""
+
+import unittest
+from pathlib import Path
+
+from scripts.distribution_cache_support_bounds import run_graph_support_bounds, summarize
+from tools.distribution_cache_support import (
+    FIXTURES,
+    ROOT,
+    load_parent_edges_tsv,
+    max_parent_distance,
+    reachable_nodes_by_parent_distance,
+    support_bounds,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SIMPLEWIKI_SAMPLE = REPO_ROOT / "tests" / "fixtures" / "simplewiki_articles_parent_sample.tsv"
+SIMPLEWIKI_ROOT = "Category:Articles"
+
+
+class DistributionCacheSupportBoundsTests(unittest.TestCase):
+    def test_support_bounds_match_fixture_histogram_support(self):
+        for fixture_name, fixture in FIXTURES.items():
+            parents = fixture["parents"]
+            with self.subTest(fixture=fixture_name):
+                for node, hist in fixture["known"].items():
+                    expected = (min(hist), max(hist)) if hist else (None, None)
+                    self.assertEqual(support_bounds(node, parents), expected)
+
+    def test_max_parent_distance_keeps_shortcut_width(self):
+        parents = FIXTURES["shortcut_parent"]["parents"]
+
+        self.assertEqual(support_bounds("B", parents), (1, 2))
+        self.assertEqual(max_parent_distance("C", parents), 3)
+
+    def test_support_bounds_runner_reports_budget_pruning_categories(self):
+        records = run_graph_support_bounds(
+            "tiny_fixture",
+            "chain",
+            FIXTURES["chain"]["parents"],
+            FIXTURES["chain"]["targets"],
+            budgets=[1, 3],
+            root=ROOT,
+            narrow_width=0,
+            wide_width=2,
+        )
+        target_records = [record for record in records if record["record_type"] == "target_bounds"]
+        signal_records = [record for record in records if record["record_type"] == "budget_signal"]
+
+        self.assertTrue(all(record["bounds_match_histogram"] for record in target_records))
+        self.assertTrue(any(record["target_node"] == "C" and record["zero_by_min_budget"] for record in signal_records))
+        self.assertTrue(any(record["target_node"] == "A" and record["fully_covered_by_max_budget"] for record in signal_records))
+
+        summary = summarize(records)
+        self.assertIn("# Parent Support Bounds Benchmark Summary", summary)
+        self.assertIn("zero_by_min", summary)
+        self.assertIn("Root-Distance Buckets", summary)
+
+    def test_file_backed_simplewiki_sample_bounds_match_exact_histograms(self):
+        parents = load_parent_edges_tsv(SIMPLEWIKI_SAMPLE)
+        targets = reachable_nodes_by_parent_distance(parents, SIMPLEWIKI_ROOT, max_depth=2)
+        records = run_graph_support_bounds(
+            "simplewiki_articles_parent_sample",
+            "simplewiki_articles_parent_sample",
+            parents,
+            targets,
+            budgets=[2],
+            root=SIMPLEWIKI_ROOT,
+        )
+        target_records = [record for record in records if record["record_type"] == "target_bounds"]
+
+        self.assertTrue(target_records)
+        self.assertTrue(all(record["bounds_match_histogram"] for record in target_records))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/distribution_cache_support.py
+++ b/tools/distribution_cache_support.py
@@ -183,6 +183,35 @@ def min_parent_distance(node, parents, root=ROOT, memo=None, visiting=None):
     return memo[node]
 
 
+def max_parent_distance(node, parents, root=ROOT, memo=None, visiting=None):
+    if memo is None:
+        memo = {}
+    if visiting is None:
+        visiting = set()
+    if node in memo:
+        return memo[node]
+    if node == root:
+        memo[node] = 0
+        return 0
+    if node in visiting:
+        raise ValueError(f"cycle detected at {node}")
+    visiting.add(node)
+    distances = [max_parent_distance(p, parents, root, memo, visiting) for p in parents.get(node, [])]
+    visiting.remove(node)
+    reachable = [distance for distance in distances if distance != -math.inf]
+    best = max(reachable, default=-math.inf)
+    memo[node] = -math.inf if best == -math.inf else best + 1
+    return memo[node]
+
+
+def support_bounds(node, parents, root=ROOT, min_memo=None, max_memo=None):
+    min_distance = min_parent_distance(node, parents, root, min_memo)
+    max_distance = max_parent_distance(node, parents, root, max_memo)
+    if min_distance == math.inf or max_distance == -math.inf:
+        return None, None
+    return int(min_distance), int(max_distance)
+
+
 def all_nodes(parents, root=ROOT):
     nodes = {root}
     for child, ps in parents.items():


### PR DESCRIPTION
## Summary

Adds a scalar parent-path support-bounds benchmark for distribution-cache planning.

## Changes

- Adds `max_parent_distance` and `support_bounds` helpers.
- Adds `scripts/distribution_cache_support_bounds.py`.
- Adds tests for fixture parity, shortcut support width, budget pruning signals, and SimpleWiki sample behavior.
- Adds a SimpleWiki depth-3 report showing scalar bounds match exact histogram support with zero failures.

## Result

On the sampled SimpleWiki Articles depth-3 artifact:

- `14680 / 14680` targets validated
- `0` bounds failures
- mean support width: `0.014`
- p95 support width: `0`
- max support width: `2`

At `B_search=2`, bounds classify almost everything:
- `36` zero by min bound
- `14633` fully covered by max bound
- `11` partial cases

At `B_search=4` and `6`, every sampled target is fully covered by `L_max`.

## Verification

```sh
python3 -m unittest tests/test_distribution_cache_support_bounds.py tests/test_distribution_cache_benchmark.py tests/test_distribution_cache_parity.py tests/test_distribution_cache_subtree_sampler.py tests/test_export_distribution_cache_edges.py