### PR TITLE
feat(wam-wat): T5 multi-clause first-argument dispatch (clause_chain)

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -107,7 +107,7 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 | python  | ✓ | ✓ T2a | ✓ | `~` hybrid | ✓ | ✗ | ~ | ~ | ✗ | ✗ | ✗ |
 | r       | ✓ | ✓ T2a | ✓ | **✓** | ✗ | ✗ | ✗ | ~ | ✓ | **✓** | ✗ |
 | elixir  | ✓ | ✓ T2b | ✓ | ✓ | ✗ | ✗ | **✓** | ✓ | ✓ | ✗ | ✗ |
-| wat     | ✓ | ✓ T2a | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| wat     | ✓ | ✓ T2a | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 
 Verification notes:
 - **T3** confirmed ✓ for haskell and fsharp (both lower clause 1 and fall
@@ -129,7 +129,17 @@ Verification notes:
   shared `wam_clause_chain` front-end: scala, rust, cpp, go, haskell, fsharp,
   llvm, lua, r (plus python's original `is_ite_block_py` `if/elif/else` form).
   clojure declines T5 (no distinct-first-arg dispatch; it has T4 instead);
-  elixir/wat = ✗. Each has a gated `*_lowered_t5` exec test.
+  elixir = ✗. **wat T5 = ✓** (now): the WAT lowered emitter strips the
+  switch_on_* indexing prefix, runs the same `wam_clause_chain` front-end, and
+  emits one WAT function with an unbound-A1 guard followed by a `do_get_constant`
+  test per discriminator (a pure test when A1 is bound) wrapping each clause
+  body inline — first-solution, matching WAT's lowered model (the exported entry
+  replays the interpreter on failure; an unbound A1 is deferred there too). Each
+  has a gated `*_lowered_t5` exec test; WAT's `test_wam_wat_lowered_t5` injects
+  test-only exports that bind argument registers via `do_put_constant` and call
+  the lowered function directly (WAT exports take no parameters), exercising
+  real per-discriminator dispatch including non-first clauses through wat2wasm +
+  node.
 - **T7**: elixir is the only real implementation (`Task.async_stream` +
   `par_wrap_segment`); clojure/python have `_branch` scaffolds (counted `~`).
   go's clause-parallel goroutines live in the *non-WAM* `go_target.pl` direct
@@ -197,8 +207,9 @@ Reading down the columns (after the T5 and T4 sweeps landed):
   above). Remaining T4/T5 holes are intentional: clojure has no distinct
   first-arg dispatch (T4 only); python now has T3, T4 (`~` hybrid: native
   clause bodies over a retained bytecode dispatch scaffold, to preserve its
-  backtracking-runtime parity) and T5 `if/elif/else`; wat has neither T4 nor
-  T5 yet — the last all-✗ multi-clause column besides its own.
+  backtracking-runtime parity) and T5 `if/elif/else`; wat now has T5
+  (first-arg clause-chain dispatch) and still lacks T4. So T5 is ✓ for every
+  target with distinct-first-arg dispatch, and T4 ✗ remains only for wat.
 - **T6 (first-arg indexing)** — **Rust and C++** now have a *gated* T6 (`~`):
   both reuse the T5 `wam_clause_chain` front-end, but when the discriminators
   are all atoms and there are ≥ `t6_min_clauses` of them (default 8) the

--- a/src/unifyweaver/targets/wam_wat_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_wat_lowered_emitter.pl
@@ -18,12 +18,22 @@
 
 :- use_module(library(lists)).
 :- use_module(wam_ite_structurer, [structure_ite/2]).
+:- use_module(wam_clause_chain, [clause_chain/2]).
 
 %% wam_wat_lowerable(+PI, +WamCode, -Reason) is semidet.
 wam_wat_lowerable(_PI, WamCode, Reason) :-
     parse_wam_text_wat(WamCode, Instrs),
     clause1_instrs_wat(Instrs, C1, MultiClause),
-    (   is_deterministic_pred_wat(C1),
+    (   % T5: multi-clause predicate discriminating on a distinct first-argument
+        % constant lowers to a bound-checked if-cascade over ALL clauses (no
+        % interpreter hop for clauses 2+ when A1 is bound). Tried before
+        % multi_clause_1 since it covers every clause natively. The switch_on_*
+        % indexing prefix (which marks exactly these first-arg-indexable
+        % predicates) is stripped first so clause_chain sees a clean
+        % try/retry/trust chain.
+        wat_clause_chain_lowerable(Instrs, _Guards)
+    ->  Reason = clause_chain
+    ;   is_deterministic_pred_wat(C1),
         forall(member(I, C1), wat_supported(I))
     ->  ( MultiClause == true -> Reason = multi_clause_1 ; Reason = single_clause )
     ;   % Clause-1 has an inner choice point: lower only if it is a pure
@@ -38,6 +48,29 @@ wam_wat_lowerable(_PI, WamCode, Reason) :-
         forall(member(I, Structured), wat_supported_structured(I)),
         Reason = ite_lowered
     ).
+
+%% wat_clause_chain_lowerable(+Instrs, -Guards) is semidet.
+%  T5 gate: strip the switch_on_* indexing prefix, then ask the shared
+%  wam_clause_chain front-end whether the predicate is a clean distinct-first-arg
+%  constant dispatch. Each guard's remainder (clause body minus the leading
+%  first-arg get_constant) must be deterministic and fully supported. ITE
+%  predicates are declined here because their remainders contain cut_ite/jump,
+%  which are not in wat_supported/1.
+wat_clause_chain_lowerable(Instrs0, Guards) :-
+    strip_switch_prefix_wat(Instrs0, Instrs),
+    clause_chain(Instrs, chain(Guards)),
+    forall(member(guard(_, Rem), Guards),
+           ( is_deterministic_pred_wat(Rem),
+             forall(member(I, Rem), wat_supported(I)) )).
+
+%% strip_switch_prefix_wat(+Instrs, -Rest)
+%  Drop a leading run of switch_on_*/switch_entry instructions (first-argument
+%  indexing prefix) so the stream begins at the predicate-level try_me_else.
+strip_switch_prefix_wat([I|Rest], Out) :-
+    functor(I, F, _),
+    sub_atom(F, 0, _, _, switch), !,
+    strip_switch_prefix_wat(Rest, Out).
+strip_switch_prefix_wat(Instrs, Instrs).
 
 %% wat_structured_clause1(+WamCode, -Structured) is semidet.
 %  Re-parse keeping labels (reinserted from the label map), take clause 1, and
@@ -175,7 +208,11 @@ lower_predicate_to_wat(PI, WamCode, _Options, lowered(PredName, FuncName, Code))
     format(atom(PredName), '~w/~w', [Pred, Arity]),
     wat_lowered_func_name(Pred/Arity, FuncName),
     wam_wat_lowerable(PI, WamCode, Reason),
-    (   Reason == ite_lowered
+    (   Reason == clause_chain
+    ->  parse_wam_text_wat(WamCode, ChainInstrs),
+        wat_clause_chain_lowerable(ChainInstrs, Guards),
+        with_output_to(atom(Code), emit_clause_chain_function_wat(FuncName, Guards))
+    ;   Reason == ite_lowered
     ->  wat_structured_clause1(WamCode, Structured),
         with_output_to(atom(Code), emit_lowered_ite_function_wat(FuncName, Structured))
     ;   parse_wam_text_wat(WamCode, Instrs),
@@ -198,6 +235,46 @@ emit_lowered_instrs_wat([Instr|Rest]) :-
     format('  (if (i32.eqz (call $do_~w (i64.const ~w) (i64.const ~w)))~n', [DoName, Op1, Op2]),
     format('    (then (return (i32.const 0))))~n'),
     emit_lowered_instrs_wat(Rest).
+
+% =====================================================================
+% T5: multi-clause first-argument dispatch  (clause_chain → guard cascade)
+% =====================================================================
+%
+%  Distinct-first-arg-constant predicates (color(red). color(green). … or
+%  sz(small,1). sz(medium,2). …) lower to one function that tests A1 against
+%  each clause's discriminator and runs that clause's body inline — every clause
+%  is native, no interpreter hop for clauses 2+ when A1 is bound.
+%
+%  do_get_constant is a *pure test* when A1 is bound (returns 1 on match, 0
+%  otherwise, no binding) and a *bind* when A1 is unbound — so the cascade is
+%  guarded by an unbound check up front: an unbound first argument cannot
+%  discriminate, so we return 0 and let the public entry replay through the
+%  interpreter (which enumerates clauses). Distinct discriminators mean at most
+%  one guard matches a bound A1, so the dispatch is deterministic and agrees
+%  with the bytecode interpreter's (first-solution) result. A matched clause
+%  whose body fails returns 0 (correct: no other clause can match the bound A1);
+%  the entry then replays the interpreter, which fails the same way.
+emit_clause_chain_function_wat(FuncName, Guards) :-
+    format('(func $~w (result i32)~n', [FuncName]),
+    format('  ;; WAM-WAT lowered T5 first-argument dispatch. Unbound A1 (tag 6) or~n'),
+    format('  ;; no matching clause returns 0 so the public entry replays via $run_loop.~n'),
+    format('  (if (i32.eq (call $val_tag (call $deref_reg_addr (i32.const 0))) (i32.const 6))~n'),
+    format('    (then (return (i32.const 0))))~n'),
+    forall(member(guard(V, Rem), Guards), emit_chain_guard_wat(V, Rem)),
+    format('  (i32.const 0)~n'),
+    format(')~n').
+
+%% emit_chain_guard_wat(+Discriminator, +Remainder)
+%  Emit `(if <A1 == V> (then <body> ))`. The guard reuses do_get_constant on the
+%  reconstructed first-arg head match (A1 is register 0); the remainder is the
+%  clause body, emitted exactly like a deterministic clause (proceed → return 1,
+%  a failed instruction → return 0).
+emit_chain_guard_wat(V, Rem) :-
+    wam_wat_target:wam_instruction_to_wat_operands(get_constant(V, 'A1'), [], _Do, Op1, Op2),
+    format('  (if (call $do_get_constant (i64.const ~w) (i64.const ~w))~n', [Op1, Op2]),
+    format('    (then~n'),
+    emit_lowered_instrs_wat(Rem),
+    format('    ))~n').
 
 % =====================================================================
 % T2: if-then-else / negation / once  (structured ite/3)

--- a/tests/test_wam_wat_lowered_t5.pl
+++ b/tests/test_wam_wat_lowered_t5.pl
@@ -1,0 +1,220 @@
+% test_wam_wat_lowered_t5.pl
+%
+% End-to-end test for the WAT T5 lowering — multi-clause first-argument dispatch
+% (lowering type T5 / clause_chain in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md). WAT was the last target
+% with no multi-clause lowering.
+%
+% A predicate that discriminates on a distinct first-argument constant
+% (color(red). color(green). … or sz(small,1). sz(medium,2). …) lowers to ONE
+% WAT function that tests A1 against each clause's discriminator and runs that
+% clause's body inline — every clause is native, no interpreter hop for clauses
+% 2+ when A1 is bound. The switch_on_* indexing prefix (which marks exactly
+% these predicates) is stripped, then the shared wam_clause_chain front-end
+% produces the guard list.
+%
+% WAT's lowered model is first-solution (the exported entry tries the lowered
+% function, replaying the bytecode interpreter on failure; lowered functions are
+% never entered from inside another predicate), so the first-solution cascade is
+% faithful: distinct discriminators + bound A1 => at most one clause matches,
+% deterministically. do_get_constant is a pure test when A1 is bound, so the
+% cascade only binds nothing; an unbound A1 is deferred to the interpreter.
+%
+% Exec strategy: WAT exports take no parameters and wam_init clears the register
+% file, so we cannot pass a bound A1 through the normal entry. Instead we
+% generate the functions-mode project, then INJECT test-only exports that
+% wam_init, bind the argument registers via do_put_constant, and call the
+% lowered function directly. This exercises real per-discriminator dispatch
+% (including non-first clauses) through the actual generated WAT.
+%
+% Skipped automatically when wat2wasm or node is unavailable.
+
+:- use_module(library(lists)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_wat_target').
+:- use_module('../src/unifyweaver/targets/wam_wat_lowered_emitter').
+
+:- dynamic user:color/1, user:sz/2, user:op/2, user:samearg/1.
+
+% facts, distinct first-arg atoms (first-argument indexed)
+user:color(red).
+user:color(green).
+user:color(blue).
+% multi-arg facts, distinct first-arg atoms; remainder is a second head match
+user:sz(small, 1).
+user:sz(medium, 2).
+user:sz(large, 3).
+% distinct first-arg atoms with a builtin body (gate/codegen only — its
+% remainder threads a variable through get_value/put_value, which the WAT
+% runtime's known propagation limitation would bite, so it is not exec-tested)
+user:op(add, R) :- R is 1 + 1.
+user:op(mul, R) :- R is 2 * 3.
+% NON-distinct first arg (variable head): must NOT be T5 (stays multi_clause_1)
+user:samearg(X) :- X = a.
+user:samearg(X) :- X = b.
+
+tool_available(Tool) :-
+    catch(process_create(path(Tool), ['--version'], [stdout(null), stderr(null)]),
+          _, fail).
+
+wat_tools_available :- tool_available(wat2wasm), tool_available(node).
+
+:- begin_tests(wam_wat_lowered_t5, [condition(wat_tools_available)]).
+
+% Distinct-first-arg predicates lower as clause_chain (T5); a variable-first-arg
+% predicate must decline T5 and stay multi_clause_1 (T3).
+test(gate_picks_clause_chain) :-
+    forall(member(PI, [color/1, sz/2, op/2]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_wat_lowerable(PI, W, Reason),
+             assertion(Reason == clause_chain) )),
+    wam_target:compile_predicate_to_wam(samearg/1, [], Ws),
+    wam_wat_lowerable(samearg/1, Ws, RS),
+    assertion(RS == multi_clause_1).
+
+% The emitted WAT: an unbound-A1 guard, one do_get_constant guard per
+% discriminator, and the clause body inline under each.
+test(emits_guard_cascade) :-
+    wam_target:compile_predicate_to_wam(color/1, [], W),
+    lower_predicate_to_wat(user:color/1, W, [], lowered(_, _, Code)),
+    % unbound check (tag 6) up front
+    assertion(sub_atom(Code, _, _, _, 'call $val_tag')),
+    assertion(sub_atom(Code, _, _, _, 'call $deref_reg_addr')),
+    % one guard per clause — three do_get_constant tests
+    findall(_, sub_atom(Code, _, _, _, 'if (call $do_get_constant'), Gs),
+    assertion(length(Gs, 3)).
+
+% Real per-discriminator dispatch through the generated WAT: each clause
+% (including non-first clauses) is reachable natively; a non-matching
+% discriminator returns 0; a remainder head-mismatch returns 0.
+test(t5_exec_discrimination) :-
+    Cases = [ tc_color_red-(color/1)-["red"]-1,
+              tc_color_green-(color/1)-["green"]-1,   % non-first clause, native
+              tc_color_blue-(color/1)-["blue"]-1,     % non-first clause, native
+              tc_color_yellow-(color/1)-["yellow"]-0, % no matching clause
+              tc_sz_small_1-(sz/2)-["small","1"]-1,
+              tc_sz_medium_2-(sz/2)-["medium","2"]-1, % non-first clause, native
+              tc_sz_large_3-(sz/2)-["large","3"]-1,   % non-first clause, native
+              tc_sz_small_2-(sz/2)-["small","2"]-0,   % remainder head mismatch
+              tc_sz_big_1-(sz/2)-["big","1"]-0 ],     % no matching clause
+    build_injected_module([color/1, sz/2, op/2], Cases, Wasm, Harness),
+    findall(Name-Got-Want,
+            ( member(Name-_-_-Want, Cases),
+              run_export(Harness, Wasm, Name, Got),
+              Got =\= Want ),
+            Failures),
+    ( Failures == []
+    ->  true
+    ;   format(user_error, "~n[wat t5 discrimination mismatches]~n~q~n", [Failures]),
+        throw(wam_wat_t5_failed(Failures))
+    ).
+
+:- end_tests(wam_wat_lowered_t5).
+
+% --- build + inject + run helpers (wat2wasm + node) ---
+
+%% build_injected_module(+Preds, +Cases, -WasmFile, -Harness)
+%  Write the functions-mode project, append a test export per case (bind the
+%  argument registers via do_put_constant, call the lowered function), compile.
+build_injected_module(Preds, Cases, WasmFile, Harness) :-
+    Dir = 'output/test_wam_wat_t5',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    make_directory_path(Dir),
+    findall(M:P, (member(P, Preds), M = user), QPreds),
+    atom_concat(Dir, '/t5.wat', WatFile),
+    write_wam_wat_project(QPreds, [module_name(wat_t5), emit_mode(functions)], WatFile),
+    read_file_to_string(WatFile, Src, []),
+    wat_heap_base(Src, Heap),
+    findall(Snip, ( member(C, Cases), case_export_snippet(Heap, C, Snip) ), Snips),
+    atomic_list_concat(Snips, '\n', Injection),
+    inject_before_last_paren(Src, Injection, Src2),
+    atom_concat(Dir, '/t5_inj.wat', InjWat),
+    setup_call_cleanup(open(InjWat, write, S, [encoding(utf8)]),
+                       write(S, Src2), close(S)),
+    atom_concat(Dir, '/t5_inj.wasm', WasmFile),
+    compile_wat(InjWat, WasmFile),
+    ensure_harness(Harness).
+
+%% wat_heap_base(+Src, -Heap) — read the heap base an entry passes to wam_init.
+wat_heap_base(Src, Heap) :-
+    sub_atom(Src, B, _, _, '$wam_init (i32.const '), !,
+    Start is B + 21,
+    sub_atom(Src, Start, 40, _, Tail),
+    atom_codes(Tail, Codes),
+    leading_digits(Codes, DigitCodes),
+    number_codes(Heap, DigitCodes).
+
+leading_digits([C|Cs], [C|Ds]) :- code_type(C, digit), !, leading_digits(Cs, Ds).
+leading_digits(_, []).
+
+%% case_export_snippet(+Heap, +Name-(P/A)-ArgVals-_Want, -Snippet)
+case_export_snippet(Heap, Name-(Pred/Arity)-ArgVals-_Want, Snippet) :-
+    wat_lowered_func_name(Pred/Arity, LoweredName),
+    findall(Bind,
+            ( nth1(K, ArgVals, V),
+              arg_reg_atom(K, RegAtom),
+              wam_wat_target:wam_instruction_to_wat_operands(put_constant(V, RegAtom), [], _, Op1, Op2),
+              format(atom(Bind),
+                     '  (drop (call $do_put_constant (i64.const ~w) (i64.const ~w)))',
+                     [Op1, Op2]) ),
+            Binds),
+    atomic_list_concat(Binds, '\n', BindLines),
+    format(atom(Snippet),
+'(func $~w (export "~w") (result i32)
+  (call $wam_init (i32.const ~w))
+~w
+  (call $~w))',
+        [Name, Name, Heap, BindLines, LoweredName]).
+
+arg_reg_atom(1, 'A1').
+arg_reg_atom(2, 'A2').
+arg_reg_atom(3, 'A3').
+
+%% inject_before_last_paren(+Src, +Injection, -Out)
+inject_before_last_paren(Src, Injection, Out) :-
+    atom_string(SrcA, Src),
+    sub_atom(SrcA, Before, 1, After, ')'),
+    sub_atom(SrcA, _, After, 0, Tail),
+    \+ sub_atom(Tail, _, _, _, ')'), !,   % the LAST ')'
+    sub_atom(SrcA, 0, Before, _, Head),
+    atomic_list_concat([Head, '\n', Injection, '\n)', Tail], Out).
+
+compile_wat(WatFile, WasmFile) :-
+    format(string(Cmd), "wat2wasm ~w -o ~w 2>&1", [WatFile, WasmFile]),
+    process_create(path(sh), ['-c', Cmd], [stdout(pipe(Out)), process(Pid)]),
+    read_string(Out, _, CompileOut), close(Out),
+    process_wait(Pid, Exit),
+    ( Exit == exit(0) -> true
+    ; throw(wam_wat_t5_compile_failed(CompileOut)) ).
+
+run_export(Harness, WasmFile, Export, Result) :-
+    process_create(path(node), [Harness, WasmFile, Export],
+                   [stdout(pipe(Out)), stderr(null), process(Pid)]),
+    read_string(Out, _, RunOut), close(Out),
+    process_wait(Pid, _),
+    ( sub_string(RunOut, _, _, _, "RESULT "),
+      split_string(RunOut, " \n", " \n", Parts),
+      append(_, ["RESULT", RS|_], Parts),
+      number_string(Result, RS)
+    -> true
+    ; throw(wam_wat_t5_run_failed(Export, RunOut)) ).
+
+ensure_harness(Path) :-
+    Path = 'output/test_wam_wat_t5_harness.js',
+    harness_source(Src),
+    setup_call_cleanup(open(Path, write, S, [encoding(utf8)]), write(S, Src), close(S)).
+
+harness_source(Src) :-
+    Src = "const fs=require('fs');\n\c
+const [,,wasmPath,exportName]=process.argv;\n\c
+const bytes=fs.readFileSync(wasmPath);\n\c
+const imports={env:{print_i64:_=>0, print_char:_=>0, print_newline:_=>0}};\n\c
+(async()=>{\n\c
+  try{\n\c
+    const{instance}=await WebAssembly.instantiate(bytes,imports);\n\c
+    const fn=instance.exports[exportName];\n\c
+    if(typeof fn!=='function'){console.log('ERROR export '+exportName+' not found');process.exit(1);}\n\c
+    console.log('RESULT '+fn());\n\c
+  }catch(e){console.log('ERROR '+e.message);process.exit(1);}\n\c
+})();\n".


### PR DESCRIPTION
## Summary

WAT was the **last target with no multi-clause lowering**. This adds **T5** (first-argument clause-chain dispatch): a predicate discriminating on a distinct first-arg constant — `color(red). color(green). color(blue).` or `sz(small,1). sz(medium,2). …` — now lowers to one WAT function that tests `A1` against each clause's discriminator and runs that clause's body inline. Every clause is native; no interpreter hop for clauses 2+ when `A1` is bound.

## How it works

The WAT lowered emitter:
1. **Strips the `switch_on_*` indexing prefix** — which marks exactly these first-arg-indexable predicates. (Notably, they were previously **not lowerable at all** because the prefix blocked clause-1 detection — so this fills a real hole, not just adds a fast path.)
2. Reuses the shared **`wam_clause_chain`** front-end to get the guard list.
3. Emits an **unbound-`A1` guard** (`deref A1`; tag 6 → return 0, deferring to the interpreter) followed by one **`do_get_constant` test per discriminator** wrapping the clause body inline.

`do_get_constant` is a **pure test when `A1` is bound** (returns 1/0, no binding), so the cascade is sound; distinct discriminators mean at most one clause matches a bound `A1`, deterministically. This is **first-solution**, matching WAT's lowered model (the exported entry tries the lowered fn and replays the bytecode interpreter on failure; lowered fns are never entered from inside another predicate, so there's no intra-query backtracking concern — unlike Python's T4). ITE predicates are declined (their remainders contain `cut_ite`/`jump`, not in `wat_supported`); variable-first-arg predicates stay `multi_clause_1` (T3).

## Tests — `test_wam_wat_lowered_t5.pl` (wat2wasm + node)
- **gate**: `color/1`, `sz/2`, `op/2` → `clause_chain`; `samearg/1` (variable head) → `multi_clause_1` (no over-claim).
- **codegen**: unbound-A1 guard + one `do_get_constant` per discriminator.
- **real per-discriminator exec**: WAT exports take no parameters and `wam_init` clears the register file, so the test **injects test-only exports** that bind argument registers via `do_put_constant` and call the lowered function directly. This exercises **non-first clauses natively** (green/blue, medium/large → 1), no-match → 0, and remainder head-mismatch → 0, through the actual generated WAT.

WAT T2 + the WAT target suites still pass.

## Matrix
wat **T5 = ✓**. T5 is now ✓ for every target with distinct-first-arg dispatch; the only remaining multi-clause hole is **wat T4** (its runtime would need the var-propagation fix for clause bodies that thread head vars into goals).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_