### PR TITLE
test(plawk): add compiled stream core smoke

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -150,14 +150,20 @@ The first WAM/LLVM probes now live under `examples/plawk/probes/`.
 - **Meta-call probe:** atom and compound closure meta-calls now emit IR and
   verify with `llvm-as` in `examples/plawk/generated/plawk_meta_call_probe.ll`.
 - **Reader probe:** the WAM/LLVM target now has general buffered stream builtins
-  `stream_open/2`, `read_line/2`, and `stream_close/1`. Handles are
-  malloc-backed `%WamLineReader` values carrying fd, buffer, length, and
-  position state; `read_line/2` reads through a 4 KB buffer, returns line atoms
-  without the trailing newline, and unifies `end_of_file` at EOF rather than
-  failing. The reader probe emits
+  `stream_open/2`, `read_line/2`, and `stream_close/1`. Handles are numeric
+  IDs into a target-owned `%WamLineReader` table carrying fd, buffer, length,
+  and position state; `read_line/2` reads through a 4 KB buffer, returns line
+  atoms without the trailing newline, and unifies `end_of_file` at EOF rather
+  than failing. The reader probe emits
   `examples/plawk/generated/plawk_reader_probe.ll` and verifies with `llvm-as`.
   Current limitation: line atoms are capped at 64 KiB until the output buffer is
   made growable.
+- **Compiled stream-core smoke:** `tests/test_plawk_compiled_stream_core.pl`
+  builds a native LLVM binary that streams a text file, splits records with
+  `atom_split/3`, runs a PLAWK-style handler over `record(text, Line, Fields)`,
+  counts records via `state/4`, and collects the two `ERROR` lines. It uses a
+  bounded output accumulator in the test; the generic `append_output/3` path is
+  still a separate compiled-list boundary.
 
 ---
 
@@ -180,6 +186,12 @@ The first WAM/LLVM probes now live under `examples/plawk/probes/`.
 
 **Success:** a native binary that reads stdin, counts records, prints matching
 lines — identical behaviour to Phase 0, running as compiled LLVM.
+
+**Current boundary:** the first native smoke reads from a file path rather than
+stdin and uses a bounded output accumulator. The next Phase-1 work is to lower
+deterministic `state/4` threading and generic output/list accumulation more
+directly, then replace the bounded helper with the normal `append_output/3`
+path.
 
 ---
 

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -65,6 +65,7 @@ plawk/
 swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt
 swipl -q -s examples/plawk/demo/count_errors.pl -t halt
 swipl -q -s examples/plawk/demo/print_error_fields.pl -t halt
+swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -93,8 +93,11 @@ Reader = text_file_reader(Path, FieldSeparator)
 ```
 
 The reader converts each line into a `record(text, Line, Fields)` item. Phase 0
-uses a whole-file SWI reader for convenience; the implementation plan tracks the
-target-side streaming reader needed for compiled unbounded input.
+uses a whole-file SWI reader for convenience. The compiled smoke in
+`tests/test_plawk_compiled_stream_core.pl` now exercises the target-side
+streaming reader: it opens a file with `stream_open/2`, reads lines with
+`read_line/2`, splits fields with `atom_split/3`, and runs a PLAWK-style
+handler in a native LLVM binary.
 
 ### Handler
 

--- a/examples/plawk/probes/README.md
+++ b/examples/plawk/probes/README.md
@@ -74,6 +74,6 @@ swipl -q -s examples/plawk/probes/generate_reader_probe.pl -t halt
 Result: emits `examples/plawk/generated/plawk_reader_probe.ll` and verifies
 with `llvm-as`. This probe uses the hybrid LLVM WAM builtins
 `stream_open/2`, `read_line/2`, and `stream_close/1`. The builtins are general
-runtime primitives, not PLAWK-specific code: handles are malloc-backed buffered
-readers, `read_line/2` unifies `end_of_file` at EOF, and line atoms exclude the
-record newline.
+runtime primitives, not PLAWK-specific code: handles are numeric IDs into a
+target-owned buffered-reader table, `read_line/2` unifies `end_of_file` at EOF,
+and line atoms exclude the record newline.

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -15756,7 +15756,7 @@ builtin_op_to_id('path_join/3', 162).         % join paths with '/' separator (a
 builtin_op_to_id('system_to_atom/2', 163).    % popen(cmd, "r") + fread + pclose -> atom.
 builtin_op_to_id('atom_to_system/2', 164).    % popen(cmd, "w") + fwrite + pclose, succeed iff status 0.
 builtin_op_to_id('atom_split/3', 165).        % split atom on single-char sep -> list of substring atoms.
-builtin_op_to_id('stream_open/2', 166).       % open + malloc-backed buffered line-reader handle.
+builtin_op_to_id('stream_open/2', 166).       % open + table-backed buffered line-reader handle.
 builtin_op_to_id('read_line/2', 167).         % buffered line read; EOF unifies end_of_file.
 builtin_op_to_id('stream_close/1', 168).      % close + free line-reader handle.
 % Catch-all for builtin names with no dedicated dispatch entry. Must

--- a/tests/test_plawk_compiled_stream_core.pl
+++ b/tests/test_plawk_compiled_stream_core.pl
@@ -1,0 +1,207 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/core/plawk_core').
+
+:- dynamic user:plawk_stream_count_errors/4.
+:- dynamic user:plawk_stream_loop/3.
+:- dynamic user:plawk_stream_error_handler/4.
+:- dynamic user:plawk_add_error/3.
+
+user:plawk_stream_count_errors(Path, Count, FirstError, SecondError) :-
+    stream_open(Path, Handle),
+    plawk_stream_loop(Handle, state([], [], 0, none), StateN),
+    stream_close(Handle),
+    state_counter(StateN, Count),
+    StateN = state(_InputStreams, outputs([FirstError, SecondError]), _Counter, _UserFields).
+
+user:plawk_stream_loop(Handle, State0, StateN) :-
+    read_line(Handle, Line),
+    (   Line == end_of_file
+    ->  StateN = State0
+    ;   atom_split(Line, ' ', Fields),
+        Item = record(text, Line, Fields),
+        plawk_stream_error_handler(Item, State0, State1, yes),
+        plawk_stream_loop(Handle, State1, StateN)
+    ).
+
+user:plawk_stream_error_handler(Item, State0, StateN, yes) :-
+    increment_counter(State0, State1),
+    (   item_field(1, Item, 'ERROR')
+    ->  item_field(0, Item, Line),
+        plawk_add_error(Line, State1, StateN)
+    ;   StateN = State1
+    ).
+
+user:plawk_add_error(Line,
+                     state(InputStreams, [], Counter, UserFields),
+                     state(InputStreams, outputs([Line]), Counter, UserFields)).
+
+user:plawk_add_error(Line,
+                     state(InputStreams, outputs([First]), Counter, UserFields),
+                     state(InputStreams, outputs([First, Line]), Counter, UserFields)).
+
+user:plawk_add_error(_Line, State, State).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_compiled_stream_core, [condition(clang_available)]).
+
+test(compiled_stream_counts_and_collects_error_lines) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_compiled_stream_core', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, 'INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n', []),
+        close(In)),
+    directory_file_path(Dir, 'plawk_stream_core.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_stream_count_errors/4,
+          user:plawk_stream_loop/3,
+          user:plawk_stream_error_handler/4,
+          user:plawk_add_error/3
+        ],
+        [module_name('plawk_stream_core')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    plawk_stream_driver_ir(InputPath, InstrCount, LabelCount, DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_stream_core_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk compiled stream core output]~n~w~n", [OutStr]),
+       throw(plawk_compiled_stream_core_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_compiled_stream_core).
+
+plawk_stream_driver_ir(InputPath, InstrCount, LabelCount, DriverIR) :-
+    atom_codes(InputPath, PathCodes),
+    length(PathCodes, PathLen),
+    BytesLen is PathLen + 1,
+    llvm_c_bytes(PathCodes, PathBytes),
+    format(atom(DriverIR),
+'@.plawk_stream_path = private constant [~w x i8] c"~w\\00"
+@.plawk_expect_first = private constant [16 x i8] c"ERROR disk full\\00"
+@.plawk_expect_second = private constant [15 x i8] c"ERROR net down\\00"
+
+define i32 @main() {
+entry:
+  %path_ptr = getelementptr [~w x i8], [~w x i8]* @.plawk_stream_path, i32 0, i32 0
+  %path_id = call i64 @wam_intern_atom(i8* %path_ptr, i64 ~w)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @module_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @module_labels, i32 0, i32 0),
+      i32 ~w)
+  %unb = call %Value @value_unbound(i8* null)
+  %count_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %first_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %second_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %count_ref = call %Value @value_ref(i32 %count_addr)
+  %first_ref = call %Value @value_ref(i32 %first_addr)
+  %second_ref = call %Value @value_ref(i32 %second_addr)
+  call void @wam_set_pc(%WamState* %vm, i32 0)
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %path)
+  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %count_ref)
+  call void @wam_set_reg(%WamState* %vm, i32 2, %Value %first_ref)
+  call void @wam_set_reg(%WamState* %vm, i32 3, %Value %second_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %check_count, label %fail_run
+
+check_count:
+  %count_v = call %Value @wam_deref_value(%WamState* %vm, %Value %count_ref)
+  %count_tag = extractvalue %Value %count_v, 0
+  %count_is_int = icmp eq i32 %count_tag, 1
+  br i1 %count_is_int, label %check_count_value, label %fail_count_tag
+
+check_count_value:
+  %count_payload = extractvalue %Value %count_v, 1
+  %count_ok = icmp eq i64 %count_payload, 4
+  br i1 %count_ok, label %check_output_tags, label %fail_count_value
+
+check_output_tags:
+  %first_v = call %Value @wam_deref_value(%WamState* %vm, %Value %first_ref)
+  %second_v = call %Value @wam_deref_value(%WamState* %vm, %Value %second_ref)
+  %first_tag = extractvalue %Value %first_v, 0
+  %second_tag = extractvalue %Value %second_v, 0
+  %first_is_atom = icmp eq i32 %first_tag, 0
+  %second_is_atom = icmp eq i32 %second_tag, 0
+  %tags_ok = and i1 %first_is_atom, %second_is_atom
+  br i1 %tags_ok, label %check_output_strings, label %fail_output_tags
+
+check_output_strings:
+  %first_id = extractvalue %Value %first_v, 1
+  %second_id = extractvalue %Value %second_v, 1
+  %first_s = call i8* @wam_atom_to_string(i64 %first_id)
+  %second_s = call i8* @wam_atom_to_string(i64 %second_id)
+  %expect_first = getelementptr [16 x i8], [16 x i8]* @.plawk_expect_first, i32 0, i32 0
+  %expect_second = getelementptr [15 x i8], [15 x i8]* @.plawk_expect_second, i32 0, i32 0
+  %cmp_first = call i32 @strcmp(i8* %first_s, i8* %expect_first)
+  %cmp_second = call i32 @strcmp(i8* %second_s, i8* %expect_second)
+  %first_ok = icmp eq i32 %cmp_first, 0
+  %second_ok = icmp eq i32 %cmp_second, 0
+  %strings_ok = and i1 %first_ok, %second_ok
+  br i1 %strings_ok, label %success, label %fail_output_strings
+
+success:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 0
+
+fail_run:
+  ret i32 10
+
+fail_count_tag:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 20
+
+fail_count_value:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 21
+
+fail_output_tags:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 30
+
+fail_output_strings:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 31
+}
+',
+        [BytesLen, PathBytes,
+         BytesLen, BytesLen, PathLen,
+         InstrCount, InstrCount, InstrCount,
+         LabelCount, LabelCount, LabelCount]).
+
+llvm_c_bytes([], '').
+llvm_c_bytes([Code | Rest], Bytes) :-
+    llvm_c_byte(Code, Byte),
+    llvm_c_bytes(Rest, Tail),
+    atom_concat(Byte, Tail, Bytes).
+
+llvm_c_byte(Code, Byte) :-
+    format(atom(Byte), '\\~|~`0t~16r~2+', [Code]).


### PR DESCRIPTION
## Summary
- Add a native WAM/LLVM smoke test for PLAWK-style stream processing.
- The smoke opens a text file, reads records with `read_line/2`, splits fields with `atom_split/3`, runs a handler over `record(text, Line, Fields)`, counts records, and verifies the collected `ERROR` lines.
- Update PLAWK docs to reflect table-backed stream handles and document the new compiled boundary.

## Notes
- This intentionally uses a bounded output accumulator in the smoke.
- Generic `append_output/3` / list accumulation remains the next compiled-output boundary.

## Verification
- `swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/test_wam_llvm_stream_runtime.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_stream_state_runtime.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `git diff --cached --check`