### PR TITLE
fix(wam-wat): unify must copy scalars, not Ref a transient register cell

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -234,10 +234,16 @@ Reading down the columns (after the T5 and T4 sweeps landed):
   with a `br` on first failure, a saved trail mark, and `$unwind_trail` before
   the else). `test_wam_wat_lowered_t2` exec-tests branch selection / negation /
   once / sequential+nested ITE via wat2wasm+node, and asserts the lowered fast
-  path matches the bytecode interpreter on every case. (A pre-existing
-  WAT-runtime limitation — a condition's variable binding is not propagated
-  into the then-branch — is present in BOTH the lowered and interpreter paths,
-  so the lowering is faithful; that runtime fix is tracked separately.)
+  path matches the bytecode interpreter on every case. (A previously documented
+  WAT-runtime limitation — a condition's variable binding not propagating into
+  the then-branch — is now **FIXED**: `unify_addrs` bound a variable to a Ref
+  into a transient argument-register cell, so the variable silently changed when
+  a later goal reused that register, breaking *every* arithmetic comparison in
+  the `X = V, X <cmp> K` guard pattern, on both paths — some forms even spun a
+  Ref cycle and hung. The fix copies scalars by value into the variable's heap
+  cell (only compounds/cons/unbound cells, which live on the heap, are bound as
+  a Ref). `test_wam_wat_unify_propagation` guards it, and the `cond_bind` cases
+  in `test_wam_wat_lowered_t2` are now absolute-correctness assertions.)
 - **python T3** — **DONE.** Python now lowers a multi-clause predicate's
   clause 1 (fast path) with interpreter fallback for clauses 2+ (see the T3
   verification note above), so the T3 column is ✓ for every target that has a

--- a/src/unifyweaver/targets/wam_wat_target.pl
+++ b/src/unifyweaver/targets/wam_wat_target.pl
@@ -4123,18 +4123,30 @@ compile_wam_helpers_to_wat(_Options, WatCode) :-
   (if (i32.eq (local.get $a) (local.get $b)) (then (return (i32.const 1))))
   (local.set $ta (call $val_tag (local.get $a)))
   (local.set $tb (call $val_tag (local.get $b)))
-  ;; Unbound on either side: bind it to the other cell via a Ref (tag 5).
+  ;; Bind an unbound cell to the other. A SCALAR (atom/int/float, tag < 3) is
+  ;; copied BY VALUE rather than bound as Ref(other): the other side may be a
+  ;; transient argument-register cell (e.g. put_constant 7, A2) that a later
+  ;; goal reuses, and a Ref into it would silently change the variable when the
+  ;; register is overwritten (the classic WAM "never bind a variable to a
+  ;; transient cell" rule). Compounds/cons/unbound cells live on the heap, so a
+  ;; Ref to them is stable and preserves structure sharing.
   (if (i32.eq (local.get $ta) (i32.const 6))
     (then
       (call $trail_binding_at (local.get $a))
-      (call $val_store (local.get $a) (i32.const 5)
-        (i64.extend_i32_u (local.get $b)))
+      (if (i32.lt_u (local.get $tb) (i32.const 3))
+        (then (call $val_store (local.get $a) (local.get $tb)
+                (call $val_payload (local.get $b))))
+        (else (call $val_store (local.get $a) (i32.const 5)
+                (i64.extend_i32_u (local.get $b)))))
       (return (i32.const 1))))
   (if (i32.eq (local.get $tb) (i32.const 6))
     (then
       (call $trail_binding_at (local.get $b))
-      (call $val_store (local.get $b) (i32.const 5)
-        (i64.extend_i32_u (local.get $a)))
+      (if (i32.lt_u (local.get $ta) (i32.const 3))
+        (then (call $val_store (local.get $b) (local.get $ta)
+                (call $val_payload (local.get $a))))
+        (else (call $val_store (local.get $b) (i32.const 5)
+                (i64.extend_i32_u (local.get $a)))))
       (return (i32.const 1))))
   ;; Both cons (in either spelling): unify head (+12) then tail (+24).
   (if (i32.and (call $is_cons_cell (local.get $a))

--- a/tests/test_wam_wat_lowered_t2.pl
+++ b/tests/test_wam_wat_lowered_t2.pl
@@ -20,10 +20,15 @@
 %       the Prolog-correct 1/0.
 %   (2) PARITY: the lowered (emit_mode(functions)) result equals the bytecode
 %       interpreter (emit_mode(interpreter)) result for EVERY case — the core
-%       property of a faithful lowering. (A few ITE shapes that thread a
-%       variable binding from the condition into the then-branch / continuation
-%       expose a PRE-EXISTING WAT-runtime limitation present in BOTH paths;
-%       parity still holds and is what we assert there.)
+%       property of a faithful lowering.
+%
+% The cond_bind* cases thread a variable binding from the condition into the
+% then-branch ( ( X = 7 -> X > 5 ; … ) ). These previously exposed a WAT-runtime
+% bug — unify bound a variable to a Ref into a transient argument-register cell,
+% so the variable silently changed when a later goal reused that register — and
+% were asserted parity-only. That bug is now fixed in unify_addrs (scalars are
+% copied by value, never bound as a Ref to a register), so they are absolute
+% correctness cases and guard the fix against regression.
 %
 % Skipped automatically when wat2wasm or node is unavailable.
 
@@ -37,7 +42,7 @@
            user:neg_true/0, user:neg_false/0,
            user:once_true/0, user:once_false/0,
            user:multi_ite/0, user:nest_ite/0,
-           user:cond_bind/0.
+           user:cond_bind/0, user:cond_bind_false/0.
 
 % Branch selection by condition truth; branch body success/failure proves the
 % RIGHT branch ran (not just that some branch succeeded).
@@ -54,21 +59,23 @@ user:once_false :- once( 0 > 5 ).   % -> 0
 % emission that a nondeterministic structuring would cause).
 user:multi_ite  :- ( 5 > 0 -> true ; fail ), ( 0 > 5 -> fail ; true ).         % -> 1
 user:nest_ite   :- ( 5 > 0 -> ( 5 > 10 -> fail ; true ) ; fail ).             % -> 1
-% condition binds a variable used in the then-branch: parity-only (the WAT
-% runtime does not propagate the binding cond->then in EITHER path).
-user:cond_bind  :- ( X = 7 -> X > 5 ; fail ).
+% condition binds a variable used (compared) in the then-branch — regression
+% guard for the unify scalar-propagation fix. The then-branch must see X = 7.
+user:cond_bind        :- ( X = 7 -> X > 5 ; fail ).   % then: 7 > 5 -> 1
+user:cond_bind_false  :- ( X = 7 -> X > 9 ; fail ).   % then: 7 > 9 -> 0 (not stale)
 
 % Name-Expected for the absolute-correctness cases.
 correctness_cases([ ite_then_ok-1, ite_then_body_fail-0,
                     ite_else_ok-1, ite_else_body_fail-0,
                     neg_true-1, neg_false-0,
                     once_true-1, once_false-0,
-                    multi_ite-1, nest_ite-1 ]).
+                    multi_ite-1, nest_ite-1,
+                    cond_bind-1, cond_bind_false-0 ]).
 
-% All predicates (correctness + parity-only) for the gate and parity checks.
+% All predicates for the gate and parity checks.
 all_preds([ ite_then_ok, ite_then_body_fail, ite_else_ok, ite_else_body_fail,
             neg_true, neg_false, once_true, once_false,
-            multi_ite, nest_ite, cond_bind ]).
+            multi_ite, nest_ite, cond_bind, cond_bind_false ]).
 
 tool_available(Tool) :-
     catch(process_create(path(Tool), ['--version'], [stdout(null), stderr(null)]),

--- a/tests/test_wam_wat_unify_propagation.pl
+++ b/tests/test_wam_wat_unify_propagation.pl
@@ -1,0 +1,122 @@
+% test_wam_wat_unify_propagation.pl
+%
+% Regression test for the WAT unify scalar-propagation fix (in $unify_addrs,
+% wam_wat_target.pl).
+%
+% THE BUG: when unify bound an unbound variable to a bound cell, it always
+% stored Ref(other-cell) — even when the other cell was a SCALAR sitting in a
+% transient argument register (e.g. `put_constant 7, A2` for `X = 7`). The
+% variable then aliased that register; when a LATER goal reused the register
+% (e.g. `put_constant 5, A2` for `X > 5`), the variable silently changed to the
+% new value. So `X = 7, X > 5` evaluated as `5 > 5` (or `7 > 7`, depending on
+% layout) → wrong result, and some forms (`X = 7, 5 < X`) span a Ref cycle and
+% HUNG. `write(X)` looked fine only because it ran before the register was
+% reused. This affected EVERY arithmetic comparison in the classic guard
+% pattern `X = V, X <cmp> K`, on BOTH the interpreter and lowered paths.
+%
+% THE FIX: a scalar (atom/integer/float, tag < 3) is copied BY VALUE into the
+% variable's heap cell; only compounds/cons/unbound cells (which live on the
+% heap) are bound as a Ref. This is the standard WAM "never bind a variable to a
+% transient cell" rule.
+%
+% These cases run the bytecode interpreter (the bug was in the shared runtime,
+% so it manifests identically in interpreter and lowered modes). All would
+% return wrong answers (or hang) before the fix.
+%
+% Skipped automatically when wat2wasm or node is unavailable.
+
+:- use_module(library(lists)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_wat_target').
+
+:- dynamic user:gt_true/0, user:gt_false/0, user:eq_true/0, user:eq_false/0,
+           user:lt_a2/0, user:ge_eq/0, user:both_vars/0, user:alias_chain/0,
+           user:atom_keep/0.
+
+% arithmetic comparison reads the live value of X, not the stale register
+user:gt_true   :- X = 7, X > 3.        % 7 > 3 -> 1
+user:gt_false  :- X = 7, X > 9.        % 7 > 9 -> 0
+user:eq_true   :- X = 7, X =:= 7.      % -> 1
+user:eq_false  :- X = 7, X =:= 3.      % 7 =:= 3 -> 0 (was wrongly 1: stale 7=:=7)
+% X in the second argument position (this form HUNG before the fix)
+user:lt_a2     :- X = 7, 5 < X.        % 5 < 7 -> 1
+user:ge_eq     :- X = 7, X >= 7.       % -> 1
+% both operands variables
+user:both_vars :- X = 7, Y = 5, X > Y. % 7 > 5 -> 1
+% variable-to-variable alias then compare (HUNG before the fix)
+user:alias_chain :- X = 7, Y = X, Y =:= 7.   % -> 1
+% atom binding must still propagate (scalar copy covers atoms too)
+user:atom_keep :- X = foo, Y = 5, X == foo.  % -> 1
+
+cases([ gt_true-1, gt_false-0, eq_true-1, eq_false-0,
+        lt_a2-1, ge_eq-1, both_vars-1, alias_chain-1, atom_keep-1 ]).
+
+tool_available(Tool) :-
+    catch(process_create(path(Tool), ['--version'], [stdout(null), stderr(null)]),
+          _, fail).
+wat_tools_available :- tool_available(wat2wasm), tool_available(node).
+
+:- begin_tests(wam_wat_unify_propagation, [condition(wat_tools_available)]).
+
+test(scalar_propagates_through_goals) :-
+    cases(Cs),
+    findall(N, member(N-_, Cs), Names),
+    build_module(Names, Wasm, Harness),
+    findall(Name-Got-Want,
+            ( member(Name-Want, Cs),
+              format(atom(Export), '~w_0', [Name]),
+              run_export(Harness, Wasm, Export, Got),
+              Got =\= Want ),
+            Failures),
+    ( Failures == []
+    ->  true
+    ;   format(user_error, "~n[wat unify propagation mismatches]~n~q~n", [Failures]),
+        throw(wam_wat_unify_failed(Failures))
+    ).
+
+:- end_tests(wam_wat_unify_propagation).
+
+build_module(Names, WasmFile, Harness) :-
+    Dir = 'output/test_wam_wat_unify',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    make_directory_path(Dir),
+    findall(user:N/0, member(N, Names), Preds),
+    atom_concat(Dir, '/u.wat', WatFile),
+    write_wam_wat_project(Preds, [module_name(wat_unify), emit_mode(interpreter)], WatFile),
+    file_name_extension(Base, _, WatFile),
+    file_name_extension(Base, wasm, WasmFile),
+    format(string(Cmd), "wat2wasm ~w -o ~w 2>&1", [WatFile, WasmFile]),
+    process_create(path(sh), ['-c', Cmd], [stdout(pipe(Out)), process(Pid)]),
+    read_string(Out, _, CompileOut), close(Out),
+    process_wait(Pid, Exit),
+    ( Exit == exit(0) -> true ; throw(wam_wat_unify_compile_failed(CompileOut)) ),
+    ensure_harness(Harness).
+
+run_export(Harness, WasmFile, Export, Result) :-
+    process_create(path(node), [Harness, WasmFile, Export],
+                   [stdout(pipe(Out)), stderr(null), process(Pid)]),
+    read_string(Out, _, RunOut), close(Out),
+    process_wait(Pid, _),
+    ( sub_string(RunOut, _, _, _, "RESULT "),
+      split_string(RunOut, " \n", " \n", Parts),
+      append(_, ["RESULT", RS|_], Parts),
+      number_string(Result, RS)
+    -> true
+    ; throw(wam_wat_unify_run_failed(Export, RunOut)) ).
+
+ensure_harness(Path) :-
+    Path = 'output/test_wam_wat_unify_harness.js',
+    Src = "const fs=require('fs');\n\c
+const [,,wasmPath,exportName]=process.argv;\n\c
+const bytes=fs.readFileSync(wasmPath);\n\c
+const imports={env:{print_i64:_=>0, print_char:_=>0, print_newline:_=>0}};\n\c
+(async()=>{\n\c
+  try{\n\c
+    const{instance}=await WebAssembly.instantiate(bytes,imports);\n\c
+    const fn=instance.exports[exportName];\n\c
+    if(typeof fn!=='function'){console.log('ERROR export '+exportName+' not found');process.exit(1);}\n\c
+    console.log('RESULT '+fn());\n\c
+  }catch(e){console.log('ERROR '+e.message);process.exit(1);}\n\c
+})();\n",
+    setup_call_cleanup(open(Path, write, S, [encoding(utf8)]), write(S, Src), close(S)).


### PR DESCRIPTION
## Summary

Fixes a **serious, broad WAT-runtime correctness bug** — the "variable binding not propagated" limitation that was previously documented as parity-only (`cond_bind` in `test_wam_wat_lowered_t2`). The fix is a single change in `$unify_addrs`.

## The bug

When unify bound an unbound variable to a bound cell, it **always** stored `Ref(other-cell)` — even when the other cell was a **scalar sitting in a transient argument register** (e.g. `put_constant 7, A2` for `X = 7`). The variable then aliased that register; when a **later goal reused** it (`put_constant 5, A2` for `X > 5`), the variable **silently changed**.

So the classic guard pattern `X = V, X <cmp> K` evaluated against a stale/overwritten value:
- **Every** arithmetic comparison (`>`, `<`, `>=`, `=<`, `=:=`, `=\=`) returned wrong answers when an operand was a bound variable, on **both** the interpreter and lowered paths.
- Some forms (`X = 7, 5 < X`; `X = 7, Y = X, Y =:= 7`) spun a Ref cycle and **hung**.
- `write(X)` looked correct only because it ran *before* the register was reused.

Root-caused by instrumenting `builtin_arith_cmp`: `X = 7, X > 3` read operands `[3,3]` — `X` had followed its `Ref` into A2, which by then held the comparison constant.

## The fix

A **scalar** (atom/integer/float, tag `< 3`) is **copied by value** into the variable's heap cell; only compounds/cons/unbound cells — which live on the heap — are bound as a `Ref`. This is the standard WAM *"never bind a variable to a transient cell"* rule. One change fixes the wrong-answer cases, the equality cases, **and** the hangs.

## Tests
- **`test_wam_wat_unify_propagation.pl`** (new): exec-tests `X = V, X <cmp> K` across `>`, `<`, `>=`, `=:=` (true and false), the A2-position and alias-chain forms that hung, and atom propagation.
- **`test_wam_wat_lowered_t2.pl`**: `cond_bind` / `cond_bind_false` promoted from parity-only to **absolute-correctness** assertions.

WAT T2, T5, and the WAT target suites all pass.

## Why this matters

Beyond fixing comparisons everywhere, this unblocks the path to **wat T4** (clause bodies that thread head variables into goals were hitting exactly this bug). It's the last open correctness item flagged in the taxonomy doc, now closed.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_