### PR TITLE
feat(wam-wat): T4 multi-clause all-clauses lowering (multi_clause_n)

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -107,7 +107,7 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 | python  | ✓ | ✓ T2a | ✓ | `~` hybrid | ✓ | ✗ | ~ | ~ | ✗ | ✗ | ✗ |
 | r       | ✓ | ✓ T2a | ✓ | **✓** | ✗ | ✗ | ✗ | ~ | ✓ | **✓** | ✗ |
 | elixir  | ✓ | ✓ T2b | ✓ | ✓ | ✗ | ✗ | **✓** | ✓ | ✓ | ✗ | ✗ |
-| wat     | ✓ | ✓ T2a | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| wat     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 
 Verification notes:
 - **T3** confirmed ✓ for haskell and fsharp (both lower clause 1 and fall
@@ -159,15 +159,19 @@ Verification notes:
 - elixir's T3/T4 use the choice-point model (genuine CPs + cut barrier), not
   R's closure-per-clause shape — counted ✓ but architecturally distinct.
 - **T4** (multi_clause_n) is now implemented across the hybrid targets:
-  scala, rust, cpp, go, haskell, fsharp, clojure, llvm, lua (plus r and
-  elixir's prior CP-model versions). Every clause is lowered inline and tried
-  in order; the interpreter is never entered for the predicate's own clause
-  dispatch. Two families:
-  - **imperative** (scala/rust/cpp/go/lua/llvm): snapshot the registers +
+  scala, rust, cpp, go, haskell, fsharp, clojure, llvm, lua, wat (plus r and
+  elixir's prior CP-model versions; python's `~` hybrid). Every clause is
+  lowered inline and tried in order; the interpreter is never entered for the
+  predicate's own clause dispatch. Two families:
+  - **imperative** (scala/rust/cpp/go/lua/llvm/wat): snapshot the registers +
     trail at entry, restore between clause attempts (e.g. `loRestoreClause`,
-    `ClauseSnapshot`, a `[64 x %Value]` memcpy in LLVM IR). These runtimes
-    take a predicate's first solution (deterministic-prefix), so — unlike
-    R/elixir — no retry/iter choice point is needed.
+    `ClauseSnapshot`, a `[64 x %Value]` memcpy in LLVM IR; wat snapshots each
+    argument-register cell + the trail top into locals and `val_store`s them
+    back between per-clause blocks). These runtimes take a predicate's first
+    solution (deterministic-prefix), so — unlike R/elixir — no retry/iter
+    choice point is needed. (wat was unblocked here by the unify
+    scalar-propagation fix, which a clause body threading a head variable into a
+    goal would otherwise hit.)
   - **functional** (haskell/fsharp): immutability gives a free per-clause
     restore — each clause runs against the unchanged input state, chained
     with `mplus` / `Option.orElseWith`; no runtime change.
@@ -208,8 +212,10 @@ Reading down the columns (after the T5 and T4 sweeps landed):
   first-arg dispatch (T4 only); python now has T3, T4 (`~` hybrid: native
   clause bodies over a retained bytecode dispatch scaffold, to preserve its
   backtracking-runtime parity) and T5 `if/elif/else`; wat now has T5
-  (first-arg clause-chain dispatch) and still lacks T4. So T5 is ✓ for every
-  target with distinct-first-arg dispatch, and T4 ✗ remains only for wat.
+  (first-arg clause-chain dispatch) AND T4 (all clauses inline with
+  argument-register + trail snapshot/restore between attempts, first-solution).
+  So **every multi-clause column (T3/T4/T5) is now closed** across the targets
+  that support each shape — no plain ✗ remains in T3/T4/T5.
 - **T6 (first-arg indexing)** — **Rust and C++** now have a *gated* T6 (`~`):
   both reuse the T5 `wam_clause_chain` front-end, but when the discriminators
   are all atoms and there are ≥ `t6_min_clauses` of them (default 8) the

--- a/src/unifyweaver/targets/wam_wat_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_wat_lowered_emitter.pl
@@ -33,6 +33,14 @@ wam_wat_lowerable(_PI, WamCode, Reason) :-
         % try/retry/trust chain.
         wat_clause_chain_lowerable(Instrs, _Guards)
     ->  Reason = clause_chain
+    ;   % T4: multi-clause predicate (not first-arg-discriminable, so clause_chain
+        % declined) whose EVERY clause is deterministic + supported. Lower all
+        % clauses inline; between attempts snapshot/restore the argument
+        % registers + trail (WAT's lowered model is first-solution — the public
+        % entry replays the interpreter on failure). Tried before multi_clause_1
+        % (which lowers only clause 1).
+        wat_multi_clause_n_lowerable(Instrs, _Clauses)
+    ->  Reason = multi_clause_n
     ;   is_deterministic_pred_wat(C1),
         forall(member(I, C1), wat_supported(I))
     ->  ( MultiClause == true -> Reason = multi_clause_1 ; Reason = single_clause )
@@ -71,6 +79,36 @@ strip_switch_prefix_wat([I|Rest], Out) :-
     sub_atom(F, 0, _, _, switch), !,
     strip_switch_prefix_wat(Rest, Out).
 strip_switch_prefix_wat(Instrs, Instrs).
+
+%% wat_multi_clause_n_lowerable(+Instrs, -Clauses) is semidet.
+%  T4 gate: split the predicate's try/retry/trust chain into per-clause
+%  instruction slices (each ending in proceed) and require at least two clauses,
+%  every one deterministic and fully supported. ITE predicates are declined
+%  (their clause slices contain cut_ite/jump, not in wat_supported/1); single
+%  clauses fall through (no predicate-level try_me_else).
+wat_multi_clause_n_lowerable(Instrs, Clauses) :-
+    wat_split_clauses_n(Instrs, Clauses),
+    Clauses = [_, _ | _],
+    forall(member(Cl, Clauses),
+           ( is_deterministic_pred_wat(Cl),
+             forall(member(I, Cl), wat_supported(I)) )).
+
+%% wat_split_clauses_n(+Instrs, -Clauses)
+%  Strip the switch prefix and the predicate-level try_me_else, then cut the
+%  remaining stream into clauses at each retry_me_else / trust_me boundary. Each
+%  clause keeps its trailing proceed.
+wat_split_clauses_n(Instrs0, Clauses) :-
+    strip_switch_prefix_wat(Instrs0, [try_me_else(_)|Rest]),
+    wat_take_clauses(Rest, Clauses).
+
+wat_take_clauses(Instrs, [Clause|More]) :-
+    wat_take_one_clause(Instrs, Clause, Rest),
+    ( Rest == [] -> More = [] ; wat_take_clauses(Rest, More) ).
+
+wat_take_one_clause([], [], []).
+wat_take_one_clause([retry_me_else(_)|Rest], [], Rest) :- !.
+wat_take_one_clause([trust_me|Rest], [], Rest) :- !.
+wat_take_one_clause([I|Rest], [I|Cs], After) :- wat_take_one_clause(Rest, Cs, After).
 
 %% wat_structured_clause1(+WamCode, -Structured) is semidet.
 %  Re-parse keeping labels (reinserted from the label map), take clause 1, and
@@ -212,6 +250,10 @@ lower_predicate_to_wat(PI, WamCode, _Options, lowered(PredName, FuncName, Code))
     ->  parse_wam_text_wat(WamCode, ChainInstrs),
         wat_clause_chain_lowerable(ChainInstrs, Guards),
         with_output_to(atom(Code), emit_clause_chain_function_wat(FuncName, Guards))
+    ;   Reason == multi_clause_n
+    ->  parse_wam_text_wat(WamCode, NInstrs),
+        wat_multi_clause_n_lowerable(NInstrs, Clauses),
+        with_output_to(atom(Code), emit_multi_clause_n_function_wat(FuncName, Arity, Clauses))
     ;   Reason == ite_lowered
     ->  wat_structured_clause1(WamCode, Structured),
         with_output_to(atom(Code), emit_lowered_ite_function_wat(FuncName, Structured))
@@ -275,6 +317,75 @@ emit_chain_guard_wat(V, Rem) :-
     format('    (then~n'),
     emit_lowered_instrs_wat(Rem),
     format('    ))~n').
+
+% =====================================================================
+% T4: multi-clause, all clauses inline  (multi_clause_n)
+% =====================================================================
+%
+%  A multi-clause predicate that is NOT first-argument-discriminable (so the T5
+%  guard cascade declined) but whose every clause is deterministic + supported
+%  lowers to one function that tries each clause in order, committing to the
+%  first that succeeds (WAT's lowered model is first-solution; the public entry
+%  replays the interpreter on a 0 return).
+%
+%  Between clause attempts the argument registers A1..A_arity and the trail must
+%  be restored to their predicate-entry state, exactly as the bytecode
+%  interpreter's choice point does: a clause body can overwrite an argument
+%  register (e.g. put_constant 50, A2 for `N >= 50`) before failing, and trail
+%  unwinding alone does not undo a direct register overwrite. So we snapshot the
+%  argument-register cells (tag + payload) and the trail top on entry, and
+%  before each later clause unwind the trail and val_store the saved cells back.
+%
+%  Each clause runs in its own block; a failing instruction `br`s out of the
+%  block (to the restore-then-next-clause code), a proceed returns 1. After the
+%  last clause the function returns 0.
+emit_multi_clause_n_function_wat(FuncName, Arity, Clauses) :-
+    format('(func $~w (result i32)~n', [FuncName]),
+    format('  ;; WAM-WAT lowered T4 (all clauses inline, first-solution). On a 0~n'),
+    format('  ;; return the public entry replays via $run_loop.~n'),
+    % locals: per-arg snapshot (tag i32 + payload i64) and the trail mark
+    forall(between(1, Arity, I),
+           ( I0 is I - 1,
+             format('  (local $t~w i32) (local $p~w i64)~n', [I0, I0]) )),
+    format('  (local $mark i32)~n'),
+    % snapshot entry state
+    format('  (local.set $mark (call $get_trail_top))~n'),
+    forall(between(1, Arity, I),
+           ( I0 is I - 1,
+             format('  (local.set $t~w (call $val_tag (call $reg_offset (i32.const ~w))))~n', [I0, I0]),
+             format('  (local.set $p~w (call $val_payload (call $reg_offset (i32.const ~w))))~n', [I0, I0]) )),
+    emit_t4_clauses_wat(Clauses, Arity, 1),
+    format('  (i32.const 0)~n'),
+    format(')~n').
+
+%% emit_t4_clauses_wat(+Clauses, +Arity, +K)
+emit_t4_clauses_wat([], _Arity, _K).
+emit_t4_clauses_wat([Clause|Rest], Arity, K) :-
+    format('  (block $c~w~n', [K]),
+    emit_t4_clause_instrs_wat(Clause, K),
+    format('  )~n'),
+    ( Rest == [] -> true ; emit_t4_restore_wat(Arity) ),
+    K1 is K + 1,
+    emit_t4_clauses_wat(Rest, Arity, K1).
+
+%% emit_t4_clause_instrs_wat(+Instrs, +K) — proceed returns 1; a failing
+%  instruction brs out of the clause's block $cK.
+emit_t4_clause_instrs_wat([proceed|_], _K) :- !,
+    format('    (return (i32.const 1))~n').
+emit_t4_clause_instrs_wat([Instr|Rest], K) :-
+    wam_wat_target:wam_instruction_to_wat_operands(Instr, [], DoName, Op1, Op2),
+    format('    (if (i32.eqz (call $do_~w (i64.const ~w) (i64.const ~w))) (then (br $c~w)))~n',
+           [DoName, Op1, Op2, K]),
+    emit_t4_clause_instrs_wat(Rest, K).
+
+%% emit_t4_restore_wat(+Arity) — restore the trail and argument registers to
+%  the snapshotted predicate-entry state before the next clause attempt.
+emit_t4_restore_wat(Arity) :-
+    format('  (call $unwind_trail (local.get $mark))~n'),
+    forall(between(1, Arity, I),
+           ( I0 is I - 1,
+             format('  (call $val_store (call $reg_offset (i32.const ~w)) (local.get $t~w) (local.get $p~w))~n',
+                    [I0, I0, I0]) )).
 
 % =====================================================================
 % T2: if-then-else / negation / once  (structured ite/3)

--- a/tests/test_wam_wat_lowered_t4.pl
+++ b/tests/test_wam_wat_lowered_t4.pl
@@ -1,0 +1,205 @@
+% test_wam_wat_lowered_t4.pl
+%
+% End-to-end test for the WAT T4 lowering — multi-clause, ALL clauses inline
+% (lowering type T4 / multi_clause_n in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md). This closes the last
+% multi-clause cell in the matrix.
+%
+% A multi-clause predicate that is NOT first-argument-discriminable (so the T5
+% guard cascade declines) but whose every clause is deterministic + supported
+% lowers to one WAT function that tries each clause in order and commits to the
+% first that succeeds (WAT's lowered model is first-solution; the public entry
+% replays the bytecode interpreter on a 0 return).
+%
+% Between clause attempts the argument registers A1..A_arity and the trail are
+% restored to their predicate-entry state, exactly as the bytecode interpreter's
+% choice point does — a clause body can overwrite an argument register (e.g.
+% put_constant 100, A2) before failing, and trail unwinding alone does not undo
+% a direct register overwrite. The qq/2 case below is the decisive register-
+% restore test: clause 1 clobbers A2 then fails, and clause 2 only succeeds if
+% A2 has been restored to its entry value.
+%
+% Exec strategy mirrors test_wam_wat_lowered_t5: WAT exports take no parameters
+% and wam_init clears the register file, so we generate the functions-mode
+% project, then INJECT test-only exports that wam_init, bind the argument
+% registers via do_put_constant, and call the lowered function directly.
+%
+% Skipped automatically when wat2wasm or node is unavailable.
+
+:- use_module(library(lists)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_wat_target').
+:- use_module('../src/unifyweaver/targets/wam_wat_lowered_emitter').
+
+:- dynamic user:samearg/1, user:grade/2, user:qq/2, user:color/1.
+
+% variable first argument -> NOT first-arg-discriminable -> T4, not T5
+user:samearg(X) :- X = a.
+user:samearg(X) :- X = b.
+% guard bodies (a builtin per clause); variable first arg
+user:grade(N, pass) :- N >= 50.
+user:grade(N, fail) :- N < 50.
+% register-restore case: clause 1 overwrites A2 (put_constant 100) before
+% failing; clause 2 needs A2 restored to its entry value (50).
+user:qq(X, 50) :- X > 100.
+user:qq(_Y, 50) :- true.
+% distinct first-arg atoms -> T5 (clause_chain), NOT T4 (over-claim guard)
+user:color(red).
+user:color(green).
+user:color(blue).
+
+tool_available(Tool) :-
+    catch(process_create(path(Tool), ['--version'], [stdout(null), stderr(null)]),
+          _, fail).
+wat_tools_available :- tool_available(wat2wasm), tool_available(node).
+
+:- begin_tests(wam_wat_lowered_t4, [condition(wat_tools_available)]).
+
+% Non-first-arg-discriminable multi-clause predicates lower as multi_clause_n
+% (T4); a distinct-first-arg predicate must stay clause_chain (T5).
+test(gate_picks_multi_clause_n) :-
+    forall(member(PI, [samearg/1, grade/2, qq/2]),
+           ( wam_target:compile_predicate_to_wam(PI, [], W),
+             wam_wat_lowerable(PI, W, Reason),
+             assertion(Reason == multi_clause_n) )),
+    wam_target:compile_predicate_to_wam(color/1, [], Wc),
+    wam_wat_lowerable(color/1, Wc, Rc),
+    assertion(Rc == clause_chain).
+
+% The emitted WAT: argument-register snapshot, a per-clause block with a `br`
+% out on failure, and the trail/register restore between clauses.
+test(emits_snapshot_and_restore) :-
+    wam_target:compile_predicate_to_wam(grade/2, [], W),
+    lower_predicate_to_wat(user:grade/2, W, [], lowered(_, _, Code)),
+    assertion(sub_atom(Code, _, _, _, 'call $get_trail_top')),
+    assertion(sub_atom(Code, _, _, _, 'block $c1')),
+    assertion(sub_atom(Code, _, _, _, 'block $c2')),
+    assertion(sub_atom(Code, _, _, _, 'br $c1')),
+    assertion(sub_atom(Code, _, _, _, 'call $unwind_trail')),
+    assertion(sub_atom(Code, _, _, _, 'call $val_store (call $reg_offset')).
+
+% Real execution through the generated WAT: discrimination across clauses, a
+% non-first clause reached natively, and the decisive register-restore case.
+test(t4_exec) :-
+    Cases = [ tc_grade_70_pass-(grade/2)-["70","pass"]-1,    % clause 1
+              tc_grade_30_pass-(grade/2)-["30","pass"]-0,    % neither matches
+              tc_grade_30_fail-(grade/2)-["30","fail"]-1,    % clause 2, native
+              tc_grade_70_fail-(grade/2)-["70","fail"]-0,
+              tc_samearg_a-(samearg/1)-["a"]-1,              % clause 1
+              tc_samearg_b-(samearg/1)-["b"]-1,              % clause 2, native
+              tc_samearg_c-(samearg/1)-["c"]-0,
+              tc_qq_30_50-(qq/2)-["30","50"]-1,              % REGISTER RESTORE
+              tc_qq_200_50-(qq/2)-["200","50"]-1,            % clause 1
+              tc_qq_30_99-(qq/2)-["30","99"]-0 ],            % arg2 mismatch
+    build_injected_module([samearg/1, grade/2, qq/2], Cases, Wasm, Harness),
+    findall(Name-Got-Want,
+            ( member(Name-_-_-Want, Cases),
+              run_export(Harness, Wasm, Name, Got),
+              Got =\= Want ),
+            Failures),
+    ( Failures == []
+    ->  true
+    ;   format(user_error, "~n[wat t4 mismatches]~n~q~n", [Failures]),
+        throw(wam_wat_t4_failed(Failures))
+    ).
+
+:- end_tests(wam_wat_lowered_t4).
+
+% --- build + inject + run helpers (wat2wasm + node) ---
+
+build_injected_module(Preds, Cases, WasmFile, Harness) :-
+    Dir = 'output/test_wam_wat_t4',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    make_directory_path(Dir),
+    findall(user:P, member(P, Preds), QPreds),
+    atom_concat(Dir, '/t4.wat', WatFile),
+    write_wam_wat_project(QPreds, [module_name(wat_t4), emit_mode(functions)], WatFile),
+    read_file_to_string(WatFile, Src, []),
+    wat_heap_base(Src, Heap),
+    findall(Snip, ( member(C, Cases), case_export_snippet(Heap, C, Snip) ), Snips),
+    atomic_list_concat(Snips, '\n', Injection),
+    inject_before_last_paren(Src, Injection, Src2),
+    atom_concat(Dir, '/t4_inj.wat', InjWat),
+    setup_call_cleanup(open(InjWat, write, S, [encoding(utf8)]),
+                       write(S, Src2), close(S)),
+    atom_concat(Dir, '/t4_inj.wasm', WasmFile),
+    compile_wat(InjWat, WasmFile),
+    ensure_harness(Harness).
+
+wat_heap_base(Src, Heap) :-
+    sub_atom(Src, B, _, _, '$wam_init (i32.const '), !,
+    Start is B + 21,
+    sub_atom(Src, Start, 40, _, Tail),
+    atom_codes(Tail, Codes),
+    leading_digits(Codes, DigitCodes),
+    number_codes(Heap, DigitCodes).
+
+leading_digits([C|Cs], [C|Ds]) :- code_type(C, digit), !, leading_digits(Cs, Ds).
+leading_digits(_, []).
+
+case_export_snippet(Heap, Name-(Pred/Arity)-ArgVals-_Want, Snippet) :-
+    wat_lowered_func_name(Pred/Arity, LoweredName),
+    findall(Bind,
+            ( nth1(K, ArgVals, V),
+              arg_reg_atom(K, RegAtom),
+              wam_wat_target:wam_instruction_to_wat_operands(put_constant(V, RegAtom), [], _, Op1, Op2),
+              format(atom(Bind),
+                     '  (drop (call $do_put_constant (i64.const ~w) (i64.const ~w)))',
+                     [Op1, Op2]) ),
+            Binds),
+    atomic_list_concat(Binds, '\n', BindLines),
+    format(atom(Snippet),
+'(func $~w (export "~w") (result i32)
+  (call $wam_init (i32.const ~w))
+~w
+  (call $~w))',
+        [Name, Name, Heap, BindLines, LoweredName]).
+
+arg_reg_atom(1, 'A1').
+arg_reg_atom(2, 'A2').
+arg_reg_atom(3, 'A3').
+
+inject_before_last_paren(Src, Injection, Out) :-
+    atom_string(SrcA, Src),
+    sub_atom(SrcA, Before, 1, After, ')'),
+    sub_atom(SrcA, _, After, 0, Tail),
+    \+ sub_atom(Tail, _, _, _, ')'), !,
+    sub_atom(SrcA, 0, Before, _, Head),
+    atomic_list_concat([Head, '\n', Injection, '\n)', Tail], Out).
+
+compile_wat(WatFile, WasmFile) :-
+    format(string(Cmd), "wat2wasm ~w -o ~w 2>&1", [WatFile, WasmFile]),
+    process_create(path(sh), ['-c', Cmd], [stdout(pipe(Out)), process(Pid)]),
+    read_string(Out, _, CompileOut), close(Out),
+    process_wait(Pid, Exit),
+    ( Exit == exit(0) -> true
+    ; throw(wam_wat_t4_compile_failed(CompileOut)) ).
+
+run_export(Harness, WasmFile, Export, Result) :-
+    process_create(path(node), [Harness, WasmFile, Export],
+                   [stdout(pipe(Out)), stderr(null), process(Pid)]),
+    read_string(Out, _, RunOut), close(Out),
+    process_wait(Pid, _),
+    ( sub_string(RunOut, _, _, _, "RESULT "),
+      split_string(RunOut, " \n", " \n", Parts),
+      append(_, ["RESULT", RS|_], Parts),
+      number_string(Result, RS)
+    -> true
+    ; throw(wam_wat_t4_run_failed(Export, RunOut)) ).
+
+ensure_harness(Path) :-
+    Path = 'output/test_wam_wat_t4_harness.js',
+    Src = "const fs=require('fs');\n\c
+const [,,wasmPath,exportName]=process.argv;\n\c
+const bytes=fs.readFileSync(wasmPath);\n\c
+const imports={env:{print_i64:_=>0, print_char:_=>0, print_newline:_=>0}};\n\c
+(async()=>{\n\c
+  try{\n\c
+    const{instance}=await WebAssembly.instantiate(bytes,imports);\n\c
+    const fn=instance.exports[exportName];\n\c
+    if(typeof fn!=='function'){console.log('ERROR export '+exportName+' not found');process.exit(1);}\n\c
+    console.log('RESULT '+fn());\n\c
+  }catch(e){console.log('ERROR '+e.message);process.exit(1);}\n\c
+})();\n",
+    setup_call_cleanup(open(Path, write, S, [encoding(utf8)]), write(S, Src), close(S)).

--- a/tests/test_wam_wat_lowered_t5.pl
+++ b/tests/test_wam_wat_lowered_t5.pl
@@ -63,7 +63,7 @@ wat_tools_available :- tool_available(wat2wasm), tool_available(node).
 :- begin_tests(wam_wat_lowered_t5, [condition(wat_tools_available)]).
 
 % Distinct-first-arg predicates lower as clause_chain (T5); a variable-first-arg
-% predicate must decline T5 and stay multi_clause_1 (T3).
+% predicate declines T5 and lowers as multi_clause_n (T4, all clauses inline).
 test(gate_picks_clause_chain) :-
     forall(member(PI, [color/1, sz/2, op/2]),
            ( wam_target:compile_predicate_to_wam(PI, [], W),
@@ -71,7 +71,7 @@ test(gate_picks_clause_chain) :-
              assertion(Reason == clause_chain) )),
     wam_target:compile_predicate_to_wam(samearg/1, [], Ws),
     wam_wat_lowerable(samearg/1, Ws, RS),
-    assertion(RS == multi_clause_1).
+    assertion(RS == multi_clause_n).
 
 % The emitted WAT: an unbound-A1 guard, one do_get_constant guard per
 % discriminator, and the clause body inline under each.


### PR DESCRIPTION
## Summary

Closes the **last multi-clause cell** in the matrix. A multi-clause predicate that is *not* first-argument-discriminable (so the T5 clause-chain declines) but whose every clause is deterministic + supported now lowers to one WAT function that tries each clause in order and commits to the first that succeeds. WAT's lowered model is first-solution (the public entry replays the interpreter on a `0` return), so this is the **imperative first-solution family** (like Rust/Lua).

## Register + trail restore between clauses

The decisive correctness requirement: a clause body can **overwrite an argument register** (e.g. `put_constant 100, A2` for `X > 100`) *before* failing, and trail-unwinding alone does **not** undo a direct register overwrite. So the emitted function — exactly as the bytecode interpreter's choice point does — snapshots each argument-register cell (tag + payload) and the trail top into locals on entry, runs each clause in its own block (a failing instruction `br`s out, a `proceed` returns 1), and `unwind_trail` + `val_store`s the saved cells back before each later clause.

## Gating

`multi_clause_n` is gated **after** `clause_chain` (T5) and **before** `multi_clause_1` (T3). The clause splitter strips the switch prefix and cuts at `try`/`retry`/`trust` boundaries. ITE predicates decline (`cut_ite`/`jump` aren't supported); single clauses fall through (no predicate-level `try_me_else`).

This was **unblocked by the prior unify scalar-propagation fix** (#3003) — clause bodies that thread a head variable into a goal would otherwise hit that bug.

## Tests — `test_wam_wat_lowered_t4.pl` (wat2wasm + node)
- **gate**: `samearg/1`, `grade/2`, `qq/2` → `multi_clause_n`; `color/1` (distinct first arg) → `clause_chain` (no over-claim).
- **codegen**: snapshot + per-clause block + `br`-on-fail + `unwind_trail`/`val_store` restore.
- **real exec** via injected test exports: discrimination across clauses, **non-first clauses reached natively** (`samearg(b)`, `grade(30,fail)`), and the **decisive register-restore case** `qq(30,50)` — clause 1 clobbers A2 then fails, clause 2 only succeeds if A2 was restored to `50`.

Also updated `test_wam_wat_lowered_t5`'s gate assertion: `samearg/1` (a fully-supported multi-clause) now lowers as `multi_clause_n` (T4), not `multi_clause_1` (T3) — a better lowering. WAT T2/T5/unify + target suites all pass.

## Matrix

wat **T4 = ✓**. **Every multi-clause column (T3/T4/T5) is now closed** across the targets that support each shape — no plain ✗ remains in T3/T4/T5.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_