### PR TITLE
WAM Scala/Haskell: tokenizer empty-token + silent intern failure (M150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **WAM Scala target (M150): any format string containing a space
+  wrong-failed its predicate.** `tokenize_wam_line`'s quote-aware
+  tokenizer left a residual empty token when a quoted operand was
+  followed by the operand comma (`put_constant '~a is ~w!', A1`), so
+  the parts list never matched the 3-arg `put_constant` clause and
+  the instruction fell to the failing fallback. Empty tokens are now
+  filtered. Fixes the pre-existing `builtin_format` failure in the
+  runtime smoke (`wam_format_combo/2`).
+- **WAM Haskell target (M150): silent lowering failure on an
+  uninitialized intern table.** `intern_atom/2` failed silently
+  (failed `retract`) when called before `init_atom_intern_table` —
+  standalone callers of the exported `lower_predicate_to_haskell`
+  API (e.g. the phase-4 suite's `put_structure` test) failed without
+  a message for months. Now self-initializing. Also fixed the
+  phase-4 `escape_dq` test, whose atom-vs-string `==` comparison
+  could never have succeeded. `test_wam_haskell_lowered_phase4` now
+  exits 0 with all tests passing (the last ledger "exits false
+  despite all-PASS output" mystery).
 - **WAM ILasm target (M149): full repair campaign — the target now
   assembles, runs, and executes correctly end-to-end.** All 13
   structural defects documented by the sweep are fixed in the

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -135,6 +135,13 @@ init_atom_intern_table :-
 %% intern_atom(+AtomStr, -Id) is det.
 %  Assigns a stable integer ID to the given atom string. Idempotent.
 intern_atom(AtomStr, Id) :-
+    % M150: self-initialize. Standalone callers of the exported
+    % lowering API (e.g. tests calling lower_predicate_to_haskell
+    % without a full project generation) hit an empty intern table;
+    % the retract below then fails SILENTLY and the whole lowering
+    % fails with it -- the phase-4 suite's put_structure test failed
+    % this way for months without a message.
+    (   atom_intern_next(_) -> true ; init_atom_intern_table ),
     atom_string(AtomStr, Str),
     (   atom_intern_id(Str, Id0)
     ->  Id = Id0

--- a/src/unifyweaver/targets/wam_scala_target.pl
+++ b/src/unifyweaver/targets/wam_scala_target.pl
@@ -144,7 +144,14 @@ wam_line_to_scala_literal(Line, Literal) :-
 %  would shred into multiple tokens.
 tokenize_wam_line(Line, Tokens) :-
     string_chars(Line, Chars),
-    tokenize_wam_chars(Chars, [], [], outside, Tokens).
+    tokenize_wam_chars(Chars, [], [], outside, Tokens0),
+    % M150: a quoted operand followed by an operand comma (e.g.
+    % put_constant '~a is ~w!', A1) left a residual empty token after
+    % comma-stripping, so the parts list never matched the 3-arg
+    % put_constant clause and the instruction fell to the failing
+    % fallback - any format string containing a space wrong-failed
+    % its whole predicate.
+    exclude(==(""), Tokens0, Tokens).
 
 % tokenize_wam_chars(+Chars, +CurReversed, +TokensReversedAcc, +State, -Tokens)
 tokenize_wam_chars([], [], Acc, _, Tokens) :- !,

--- a/tests/test_wam_haskell_lowered_phase4.pl
+++ b/tests/test_wam_haskell_lowered_phase4.pl
@@ -301,7 +301,10 @@ test_fresh_sv_no_shadowing :-
 test_escape_dq_handles_both :-
     Test = 'Phase 4: escape_dq escapes both backslash and double-quote',
     wam_haskell_lowered_emitter:escape_dq("foo\\bar\"baz", Esc),
-    (   Esc == "foo\\\\bar\\\"baz"
+    % M150: escape_dq returns an ATOM (it ends in atomic_list_concat);
+    % the original string-literal == comparison could never succeed.
+    atom_string(Esc, EscS),
+    (   EscS == "foo\\\\bar\\\"baz"
     ->  pass(Test)
     ;   fail_test(Test, ['expected foo\\\\bar\\\"baz got ', Esc])
     ).


### PR DESCRIPTION
## Summary

Two of the three verified-pre-existing failures from the campaign ledger (`docs/handoff/wam_correctness_campaign_handoff.md` §5), root-caused and fixed.

## Scala: any format string containing a space wrong-failed its predicate

The runtime smoke's `builtin_format` failure (`wam_format_combo/2` → "false"). Root cause was nowhere near `format/2` itself: `tokenize_wam_line`'s quote-aware tokenizer left a **residual empty token** when a quoted operand was followed by the operand comma — `put_constant '~a is ~w!', A1` tokenized into *four* parts (`put_constant`, `'~a is ~w!'`, ``""``, `A1`), so the 3-arg `put_constant` clause never matched and the instruction fell to the failing fallback. One-word format strings tokenized fine, which is why only the multi-word test failed. Empty tokens are now filtered after tokenization.

## Haskell: `lowered_phase4` "exits false despite all-PASS output"

Two stacked causes:
1. **`intern_atom/2` failed silently** (a failed `retract`) when called before `init_atom_intern_table` — standalone callers of the exported `lower_predicate_to_haskell` API (the phase-4 `put_structure` test) failed without any message. Now self-initializing; project generation (which inits explicitly) is unaffected.
2. The phase-4 `escape_dq` test compared `escape_dq`'s **atom** result against a **string** literal with `==` — it had never once passed; the suite's silent-failure pattern hid both. Now compares via `atom_string`.

## Test plan

- [x] Full Scala runtime smoke: **51/51 passed** (was 50/51 with `builtin_format` failing) — the broad regression gate for the tokenizer change, since it touches every instruction line the Scala target parses
- [x] `test_wam_haskell_lowered_phase4`: exits 0, all tests passing (previously exit-false)
- [x] Haskell phase1/phase3/lowered_t5 spot-checks pass (intern self-init regression check)

## Remaining ledger item

`test_wam_rust_runtime` e2e (output mismatch in a 26-predicate project) is the last of the three small pre-existing failures — still open.

https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM)_