### PR TITLE
WAM Rust: all-native/kernel projects generated uncompilable crates (M151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **WAM Rust target (M151): all-native/kernel projects generated
+  uncompilable crates.** The long-standing `test_wam_rust_runtime`
+  e2e failure (last item of the campaign ledger's small fixes) was
+  not a wrong answer — the generated crate never compiled. Three
+  interacting generator defects: (1) `shared_wam_program()` was not
+  emitted when no predicate used the shared-WAM strategy, but the
+  main template imports/calls it unconditionally (now emits an empty
+  stub); (2) FFI-kernel predicates emitted only a `// dispatched via
+  CallForeign` comment with no public symbol for library consumers
+  (now also emit a self-registering wrapper); (3) the runtime-parser
+  era arity-suffix rename (`tc_descendant` → `tc_descendant_2`)
+  leaked into foreign-lowered entry points, breaking the documented
+  import contract (kernel wrappers now use the bare name; generic
+  WAM wrappers keep the suffix).
 - **WAM Scala target (M150): any format string containing a space
   wrong-failed its predicate.** `tokenize_wam_line`'s quote-aware
   tokenizer left a residual empty token when a quoted operand was

--- a/docs/handoff/wam_correctness_campaign_handoff.md
+++ b/docs/handoff/wam_correctness_campaign_handoff.md
@@ -101,10 +101,11 @@ modes separately. Generation generally needs `LC_ALL=C.UTF-8`.
    differ (heap-marker vs Compound) — `is_list([a])` standalone was
    fixed in M141, but `L = [11,22,33], L = [H|_]` cross-representation
    unification remains the known limitation from the M104-era notes.
-5. **Pre-existing failures verified unrelated to this campaign:**
-   `test_wam_rust_runtime` e2e (output mismatch), Scala runtime
-   smoke `builtin_format` (`wam_format_combo/2`), Haskell
-   `lowered_phase4` exits false despite all-PASS output.
+5. ~~Pre-existing failures verified unrelated to this campaign~~ —
+   all three fixed: `test_wam_rust_runtime` e2e (M151: uncompilable
+   generated crate), Scala `builtin_format` (M150: tokenizer
+   empty-token), Haskell `lowered_phase4` (M150: silent intern
+   failure + never-passing test comparison).
 6. **LLVM `@value_equals` call-site audit follow-on:** sort dedup and
    strict-eq now deep-compare, but `==`-style var identity for bare
    (non-Ref) register sentinels remains identity-less (degenerate

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -2982,7 +2982,17 @@ compile_wam_runtime_to_rust(Options, RustCode) :-
 %  that creates instruction data and executes it via the WAM runtime.
 compile_wam_predicate_to_rust(Pred/Arity, WamCode, Options, RustCode) :-
     atom_string(Pred, PredStr),
-    rust_safe_function_name(Pred/Arity, FuncName),
+    % Foreign-lowered kernel wrappers keep the bare predicate name: they are
+    % the project's public entry points (imported as `use crate::pred;` by
+    % consumers, e.g. tests/test_wam_rust_runtime.pl's integration test).
+    % Generic WAM wrappers keep the arity-suffixed name so same-name
+    % predicates of different arities (read_term_from_atom/2 vs /3 in
+    % runtime-parser mode) don't collide.
+    (   option(foreign_lowering(ForeignSpecForName), Options),
+        rust_foreign_spec(Pred/Arity, ForeignSpecForName, _, _)
+    ->  rust_safe_function_name(Pred, FuncName)
+    ;   rust_safe_function_name(Pred/Arity, FuncName)
+    ),
     build_rust_wam_arg_list(Arity, ArgList),
     build_rust_wam_arg_setup(Arity, ArgSetup),
     foreign_wrapper_setup(Pred/Arity, WamCode, Options, InstrSetup, ForeignSetup, RunExpr),
@@ -3727,7 +3737,15 @@ pub fn shared_wam_program() -> (Vec<Instruction>, HashMap<String, usize>) {
     let (code, labels) = get_shared_wam();
     (code.clone(), labels.clone())
 }', [AllLabels, AllInstrs])
-    ;   SharedCode = ""
+    ;   % No shared-WAM predicates in this project. Still emit
+        % shared_wam_program/0: templates/targets/rust_wam/main.rs.mustache
+        % (and materialisation_setup.rs.mustache) import and call it
+        % unconditionally, so omitting it breaks compilation of every
+        % all-native/all-kernel project.
+        SharedCode =
+'pub fn shared_wam_program() -> (Vec<Instruction>, HashMap<String, usize>) {
+    (Vec::new(), HashMap::new())
+}'
     ),
     % Pass 3: generate code for each predicate
     generate_predicate_codes(Classified, WamEntries, PredCodes),
@@ -3778,7 +3796,20 @@ classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
         KClauses \= [],
         detect_recursive_kernel(Pred, Arity, KClauses, Kernel)
     ->  format(user_error, '  ~w/~w: ffi kernel (~w)~n', [Pred, Arity, Kernel]),
-        Entry = classified(Module, Pred, Arity, ffi_kernel, Kernel)
+        % Besides the CallForeign dispatch route, emit a public Rust wrapper
+        % function (bare predicate name) so library consumers can call the
+        % kernel directly: `use crate::pred; pred(&mut vm, args...)`.
+        % Without this, ffi_kernel predicates had no callable symbol at all.
+        (   catch(rust_target:rust_foreign_lowering_spec(Pred, Arity, KClauses,
+                                                          ForeignSpec),
+                  _, fail),
+            catch(compile_wam_predicate_to_rust(Pred/Arity, '',
+                      [foreign_lowering(ForeignSpec)|Options], WrapperCode),
+                  _, fail)
+        ->  Entry = classified(Module, Pred, Arity, ffi_kernel,
+                               kernel_with_wrapper(Kernel, WrapperCode))
+        ;   Entry = classified(Module, Pred, Arity, ffi_kernel, Kernel)
+        )
     ;   % Try native Rust lowering (disable WAM fallback inside rust_target
         % so we can distinguish truly-native from WAM-needing predicates).
         % Decline native for backtracking control constructs (\+, ->, ;,
@@ -3863,6 +3894,15 @@ collect_wam_entries([_|Rest], PC, Entries, Instrs, Labels) :-
 %% generate_predicate_codes(+Classified, +WamEntries, -PredCodes)
 %  Generates Rust code for each classified predicate.
 generate_predicate_codes([], _, []).
+generate_predicate_codes([classified(_, Pred, Arity, ffi_kernel,
+                                     kernel_with_wrapper(Kernel, WrapperCode))|Rest],
+                         WamEntries, [Code|RestCodes]) :-
+    !,
+    Kernel = recursive_kernel(Kind, _, _),
+    format(string(Code),
+        "// Strategy: ffi_kernel (~w)\n// ~w/~w dispatched via CallForeign → execute_foreign_predicate\n~w",
+        [Kind, Pred, Arity, WrapperCode]),
+    generate_predicate_codes(Rest, WamEntries, RestCodes).
 generate_predicate_codes([classified(_, Pred, Arity, ffi_kernel, Kernel)|Rest],
                          WamEntries, [Code|RestCodes]) :-
     % FFI kernel — no WAM code needed; handled by setup_foreign_predicates


### PR DESCRIPTION
## Summary

The last item on the campaign ledger's small-fixes list: the long-standing `test_wam_rust_runtime` e2e failure. The headline finding: it was never an output mismatch — **the generated crate never compiled** (10+ `E0432` unresolved imports). Three interacting generator defects in `wam_rust_target.pl`:

1. **`shared_wam_program()` not emitted for all-native/kernel projects.** The function was only generated when some predicate used the shared-WAM strategy, but `main.rs.mustache` imports and calls it unconditionally — any project where every predicate went native or FFI-kernel (like this test's 26) produced an uncompilable crate. Now emits an empty stub in that case.

2. **FFI-kernel predicates had no public symbol.** Auto-detected kernels (`tc_ancestor/2`, `weighted_path/3`, `astar_weighted_path/4`, ...) emitted only a `// dispatched via CallForeign` comment — correct for in-WAM dispatch, but no `pub fn` existed for library consumers, and this branch preempts the native-lowering branch that used to produce wrappers. The classifier now also builds a self-registering public wrapper via the rust-side foreign-lowering spec (comment-only fallback when no spec exists).

3. **The arity-suffix rename leaked into foreign-lowered entry points.** The runtime-parser-era `rust_safe_function_name` rename (`tc_descendant` → `tc_descendant_2`, needed so `read_term_from_atom/2` vs `/3` don't collide) broke the documented bare-name import contract for kernel wrappers. Kernel wrappers now use the bare predicate name; generic WAM wrappers keep the suffix (preserving the `read_term_from_atom_2`/`_3` expectations).

Also retires the handoff ledger's §5 — **all three pre-existing failures are now fixed** (this + the M150 pair in #3005).

## Test plan

- [x] `test_wam_rust_runtime`: **PASS** — all ~72 runtime assertions including backtracking enumerations and float aggregates (independently re-verified)
- [x] `test_wam_rust_target`: 174 PASS / 0 FAIL
- [x] `lowered_ite_exec`, `lowered_t4` (2/2), `lowered_t5` (2/2), `lowered_t6` (3/3), `save_regs` — all pass

https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM)_