### PR TITLE
feat(wam-fsharp): gated T6 first-argument indexing (native string match)

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -100,7 +100,7 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 | cpp     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✗ | ✗ | ✗ | ✗ |
 | go      | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ |
 | haskell | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ |
-| fsharp  | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ~ | ✗ | ✗ | ✗ |
+| fsharp  | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ~ | ✗ | ✗ | ✗ |
 | clojure | ✓ | ✓ T2a | ✓ | ✓ | ✗ | ✗ | ~ | ~ | ✗ | ✗ | ✗ |
 | llvm    | ✓ | ✓ T2a | ✓ (c1) | ✓ | ✓ | ✗ | ✗ | ~ | ✗ | ✗ | ~ |
 | lua     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ |
@@ -216,24 +216,31 @@ Reading down the columns (after the T5 and T4 sweeps landed):
   argument-register + trail snapshot/restore between attempts, first-solution).
   So **every multi-clause column (T3/T4/T5) is now closed** across the targets
   that support each shape — no plain ✗ remains in T3/T4/T5.
-- **T6 (first-arg indexing)** — **Rust and C++** now have a *gated* T6 (`~`):
-  both reuse the T5 `wam_clause_chain` front-end, but when the discriminators
-  are all atoms and there are ≥ `t6_min_clauses` of them (default 8) the
-  back-end replaces the if-cascade with a native indexed dispatch — Rust a
-  two-stage `match` (string switch → integer jump table); C++ a static
-  `std::unordered_map<std::string,int>` (no native string switch) → `switch`.
-  The other targets still drop the `switch_on_*` prefix and try clauses in
-  order. This is the natural next advancement after T5 (same clause-head
-  analysis, switch back-end): shared front-end, per-target back-end — high
-  leverage, and a perf win that's sound behind a gate. Measured on generated
-  code (tie at 4 clauses; then growing with N): Rust 1.55× at 8, 5.7× at 64,
-  12.7× at 256; C++ 2.1× at 8, 11.6× at 64, 40.8× at 256 (see
+- **T6 (first-arg indexing)** — **Rust, C++ and F#** now have a *gated* T6
+  (`~`): all reuse the T5 `wam_clause_chain` front-end, but when the
+  discriminators are all atoms and there are ≥ `t6_min_clauses` of them
+  (default 8) the back-end replaces the if-cascade with a native indexed
+  dispatch — Rust a two-stage `match` (string switch → integer jump table); C++
+  a static `std::unordered_map<std::string,int>` (no native string switch) →
+  `switch`; **F# a native many-branch `match` on the atom's string** (`Atom of
+  string`, so the discriminator is already a string — the F# compiler lowers a
+  many-case string match to a hash/jump dispatch). These three are the
+  **atom-keyed** targets — atoms are compared as strings at dispatch, so a
+  string switch is a real win. The other targets still drop the `switch_on_*`
+  prefix and try clauses in order. This is the natural next advancement after
+  T5 (same clause-head analysis, switch back-end): shared front-end, per-target
+  back-end — high leverage, and a perf win that's sound behind a gate. Measured
+  on generated code (tie at 4 clauses; then growing with N): Rust 1.55× at 8,
+  5.7× at 64, 12.7× at 256; C++ 2.1× at 8, 11.6× at 64, 40.8× at 256 (see
   `docs/reports/wam_rust_dispatch_alloc_perf.md`). The compiler flattens the
   cascade for few clauses (matching the prior Go array-dispatch result), hence
-  the gate. Int-interned targets (go/llvm/haskell/scala/lua) are the remaining
-  candidates but carry the highest "lost to the compiler" risk (an int
-  equality chain is already switch-converted), so each needs a per-target
-  benchmark before shipping.
+  the gate. The remaining T5 targets (go/llvm/haskell/scala/lua) are
+  **int-interned** — atoms become integers at codegen, so the first-arg
+  comparison is already an integer-equality chain the host compiler
+  switch-converts; T6 there carries the highest "lost to the compiler" risk and
+  needs a per-target benchmark before shipping. (F# is excluded from that group:
+  it keeps atoms as strings, which is why it took the atom-keyed back-end
+  cleanly.)
 - **T2 (ITE)** — now **complete across every target**, including WAT: the
   lowered emitter folds the soft-cut block with the shared `wam_ite_structurer`
   and emits native WAT (`(block $ite_condK (result i32) …)` for the condition
@@ -307,7 +314,11 @@ Score each candidate gap on four axes, then sequence:
    could layer in front later). Remaining structurer-column hole: none — only
    **wat** lacks T4 now (its runtime has no lowered multi-clause path yet).
 4. **T6 (first-arg indexing)** — same clause-head front-end as T5 with a
-   `switch` back-end instead of an `->` cascade.
+   `switch` back-end instead of an `->` cascade. Done for the atom-keyed
+   targets: rust, cpp, **fsharp** (native string `match`). The int-interned
+   targets (go/llvm/haskell/scala/lua) still need a per-target benchmark first
+   (their atom-as-int comparison is already switch-converted by the host
+   compiler).
 5. Treat **T7/T10/T11** as research spikes (one target each) before any
    sweep.
 

--- a/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_fsharp_lowered_emitter.pl
@@ -221,7 +221,7 @@ lower_predicate_to_fsharp(PI, WamCode, Opts, lowered(PredName, FuncName, Code)) 
     offset_pcs_fs(PCInstrs, Offset, GlobalPCInstrs),
     offset_labels_fs(LabelMap, Offset, GlobalLabelMap),
     with_output_to(string(Code),
-        emit_func_fs(FuncName, GlobalPCInstrs, GlobalLabelMap, ForeignPreds)).
+        emit_func_fs(FuncName, GlobalPCInstrs, GlobalLabelMap, ForeignPreds, Opts)).
 
 offset_pcs_fs([], _, []).
 offset_pcs_fs([pc(PC, I)|Rest], Off, [pc(GPC, I)|Rest2]) :-
@@ -237,14 +237,14 @@ offset_labels_fs([L-PC|Rest], Off, [L-GPC|Rest2]) :-
 % Function emission
 % ============================================================================
 
-emit_func_fs(FN, PCInstrs, LabelMap, ForeignPreds) :-
+emit_func_fs(FN, PCInstrs, LabelMap, ForeignPreds, Opts) :-
     format("/// Lowered: ~w~n", [FN]),
     format("let ~w (ctx: WamContext) (s_init: WamState) : WamState option =~n", [FN]),
     % Skip all switch_on_constant* prefixes before deciding whether this is
     % a multi-clause or single-clause lowered body.
     strip_switch_prefixes_fs(PCInstrs, PCInstrs1),
-    (   emit_func_t5_fs(PCInstrs1, LabelMap, ForeignPreds)
-    ->  true   % T5 first-argument dispatch (all clauses lowered natively)
+    (   emit_func_t5_fs(PCInstrs1, LabelMap, ForeignPreds, Opts)
+    ->  true   % T5/T6 first-argument dispatch (all clauses lowered natively)
     ;   emit_func_t4_fs(PCInstrs1, LabelMap, ForeignPreds)
     ->  true   % T4 all-clauses inline (every clause native, no interpreter hop)
     ;   PCInstrs1 = [pc(_, try_me_else(LStr))|BodyPCs]
@@ -305,7 +305,7 @@ take_to_proceed_pc_fs([H|T], [H|R]) :- take_to_proceed_pc_fs(T, R).
 %  the predicate is not a distinct-first-argument constant chain. All checks
 %  run before any output, so a failure leaves the stream untouched for the
 %  caller's ordinary multi/single-clause emission.
-emit_func_t5_fs(PCInstrs1, LabelMap, FP) :-
+emit_func_t5_fs(PCInstrs1, LabelMap, FP, Opts) :-
     PCInstrs1 = [pc(_, try_me_else(L2Str))|_],
     maplist(t5_strip_pc_fs, PCInstrs1, PlainInstrs),
     clause_chain(PlainInstrs, chain(_Guards)),
@@ -313,6 +313,7 @@ emit_func_t5_fs(PCInstrs1, LabelMap, FP) :-
     Slices = [_, _ | _],
     forall(( member(Sl, Slices), member(pc(_, In), Sl) ), supported_fs(In)),
     maplist(t5_slice_discriminator_fs, Slices, Discrs),
+    maplist(t5_slice_discr_token_fs, Slices, Tokens),
     % All checks passed — emit.
     atom_string(L2Atom, L2Str),
     ( member(L2Atom-AltPC, LabelMap) -> true ; AltPC = 0 ),
@@ -337,14 +338,74 @@ emit_func_t5_fs(PCInstrs1, LabelMap, FP) :-
     format("        | Some result -> Some result~n"),
     format("        | None ->~n"),
     format("            backtrack s_cp |> Option.bind (fun s_bt -> run ctx { s_bt with WsPC = s_bt.WsPC + 1 })~n"),
-    % Dispatch: deref the first argument once, then select.
-    format("    match (getReg 1 s_init |> Option.map (derefVar s_init.WsBindings)) with~n"),
-    format("    | Some (Unbound _) -> t5fallback ()~n"),
-    format("    | Some v ->~n"),
-    t5_emit_dispatch_arms_fs(Discrs, 1),
-    format("    | None -> t5fallback ()~n").
+    % Dispatch: deref the first argument once, then select. When the
+    % discriminators are all atoms and there are enough of them (the T6 gate),
+    % emit a native F# string `match` (which the F# compiler lowers to an
+    % efficient hash/jump dispatch) instead of the linear if/elif cascade.
+    (   fsharp_t6_applicable(Tokens, Opts)
+    ->  t6_emit_dispatch_fs(Tokens)
+    ;   format("    // T5 first-argument dispatch (if/elif cascade)~n"),
+        format("    match (getReg 1 s_init |> Option.map (derefVar s_init.WsBindings)) with~n"),
+        format("    | Some (Unbound _) -> t5fallback ()~n"),
+        format("    | Some v ->~n"),
+        t5_emit_dispatch_arms_fs(Discrs, 1),
+        format("    | None -> t5fallback ()~n")
+    ).
 
 t5_strip_pc_fs(pc(_, I), I).
+
+%% t5_slice_discr_token_fs(+Slice, -VStr) — the raw first-arg constant token.
+t5_slice_discr_token_fs([pc(_, get_constant(VStr, _A1))|_], VStr).
+
+% ============================================================================
+% T6: first-argument indexing (native string match), gated above T5
+%
+%  When every clause discriminates on a distinct ATOM and there are at least
+%  t6_min_clauses of them (default 8), the linear if/elif cascade is replaced by
+%  a native F# `match` on the atom's string. F# compiles a many-branch string
+%  match to a hash/jump dispatch, so this is O(1) where the cascade is O(n);
+%  below the threshold the compiler would just flatten the match back to a
+%  cascade, so it is gated. The gate ties its atom test to val_fs (the same
+%  detector the T5 cascade uses), so the two paths agree on what an atom is.
+% ============================================================================
+
+%% fsharp_t6_applicable(+Tokens, +Opts) is semidet.
+fsharp_t6_applicable(Tokens, Opts) :-
+    fsharp_t6_min_clauses(Opts, Min),
+    length(Tokens, N), N >= Min,
+    forall(member(T, Tokens), t6_atom_token_fs(T, _)).
+
+%% fsharp_t6_min_clauses(+Opts, -N) — threshold (default 8).
+fsharp_t6_min_clauses(Opts, N) :-
+    ( member(t6_min_clauses(N), Opts) -> true ; N = 8 ).
+
+%% t6_atom_token_fs(+VStr, -EscStr) is semidet.
+%  Succeeds only when VStr is an ATOM (val_fs renders it `Atom "EscStr"`), with
+%  EscStr the F#-escaped name used in the string match arm — exactly the literal
+%  the T5 cascade would compare against, so dispatch is identical.
+t6_atom_token_fs(VStr, EscStr) :-
+    val_fs(VStr, FS),
+    atom_concat('Atom "', Rest, FS),
+    atom_concat(EscStr, '"', Rest).
+
+%% t6_emit_dispatch_fs(+Tokens)
+t6_emit_dispatch_fs(Tokens) :-
+    format("    // T6 first-argument indexing (native string match)~n"),
+    format("    match (getReg 1 s_init |> Option.map (derefVar s_init.WsBindings)) with~n"),
+    format("    | Some (Unbound _) -> t5fallback ()~n"),
+    format("    | Some (Atom t6s) ->~n"),
+    format("        (match t6s with~n"),
+    t6_emit_match_arms_fs(Tokens, 1),
+    format("         | _ -> None)~n"),
+    format("    | Some _ -> None~n"),
+    format("    | None -> t5fallback ()~n").
+
+t6_emit_match_arms_fs([], _).
+t6_emit_match_arms_fs([T|Rest], N) :-
+    t6_atom_token_fs(T, EscStr),
+    format("         | \"~w\" -> t5clause_~w s_init~n", [EscStr, N]),
+    N1 is N + 1,
+    t6_emit_match_arms_fs(Rest, N1).
 
 % ============================================================================
 % T4: multi-clause, all clauses inline (multi_clause_n)

--- a/tests/test_wam_fsharp_lowered_t6.pl
+++ b/tests/test_wam_fsharp_lowered_t6.pl
@@ -1,0 +1,161 @@
+% test_wam_fsharp_lowered_t6.pl
+%
+% End-to-end test for the F# T6 lowering — first-argument indexing (native
+% string match), lowering type T6 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md. F# is the third atom-keyed
+% target to get the gated T6 back-end (after Rust and C++); it represents atoms
+% as plain strings (`Atom of string`), so a many-branch F# `match` on the atom's
+% string compiles to an efficient hash/jump dispatch — O(1) where the T5
+% if/elif cascade is O(n).
+%
+% Gated like Rust/C++: T6 fires only when every clause discriminates on a
+% distinct ATOM and there are at least t6_min_clauses of them (default 8). Below
+% the threshold the F# compiler would just flatten the match back to a cascade,
+% so the few-clause predicate must STAY T5.
+%
+% Predicates:
+%   * shade/1 (10 atom facts) — must lower as T6; dispatch correctly including a
+%     non-first clause reached through the native match.
+%   * grade/2 (10 atom RULE clauses, each remainder runs an is/2 builtin) — must
+%     lower as T6 and run the clause body under the matched arm.
+%   * few/1 (3 atom facts) — below the gate, must STAY T5 (the cascade).
+%
+% Skipped automatically when `dotnet` is not on PATH.
+
+:- use_module(library(lists)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_fsharp_target').
+:- use_module('../src/unifyweaver/targets/wam_fsharp_lowered_emitter').
+
+:- dynamic user:shade/1, user:grade/2, user:few/1.
+
+user:shade(s01). user:shade(s02). user:shade(s03). user:shade(s04).
+user:shade(s05). user:shade(s06). user:shade(s07). user:shade(s08).
+user:shade(s09). user:shade(s10).
+
+user:grade(g01, R) :- R is 1 + 0.
+user:grade(g02, R) :- R is 1 + 1.
+user:grade(g03, R) :- R is 1 + 2.
+user:grade(g04, R) :- R is 1 + 3.
+user:grade(g05, R) :- R is 1 + 4.
+user:grade(g06, R) :- R is 1 + 5.
+user:grade(g07, R) :- R is 1 + 6.
+user:grade(g08, R) :- R is 1 + 7.
+user:grade(g09, R) :- R is 1 + 8.
+user:grade(g10, R) :- R is 1 + 9.
+
+user:few(a). user:few(b). user:few(c).
+
+dotnet_available :-
+    catch(( process_create(path(dotnet), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_fsharp_lowered_t6, [condition(dotnet_available)]).
+
+% Codegen gate: the many-clause atom predicates emit the native string match
+% (T6); the few-clause one stays the if/elif cascade (T5). The threshold is
+% configurable.
+test(gate_picks_t6_for_many_t5_for_few) :-
+    wam_target:compile_predicate_to_wam(shade/1, [], Ws),
+    lower_predicate_to_fsharp(shade/1, Ws, [], lowered(_, _, ShadeCode)),
+    assertion(sub_string(ShadeCode, _, _, _, "T6 first-argument indexing")),
+    assertion(sub_string(ShadeCode, _, _, _, "match t6s with")),
+    wam_target:compile_predicate_to_wam(grade/2, [], Wg),
+    lower_predicate_to_fsharp(grade/2, Wg, [], lowered(_, _, GradeCode)),
+    assertion(sub_string(GradeCode, _, _, _, "T6 first-argument indexing")),
+    wam_target:compile_predicate_to_wam(few/1, [], Wf),
+    lower_predicate_to_fsharp(few/1, Wf, [], lowered(_, _, FewCode)),
+    assertion(sub_string(FewCode, _, _, _, "T5 first-argument dispatch")),
+    assertion(\+ sub_string(FewCode, _, _, _, "T6 first-argument indexing")),
+    % threshold override: few/1 lowers as T6 when the gate is lowered to 3.
+    lower_predicate_to_fsharp(few/1, Wf, [t6_min_clauses(3)], lowered(_, _, FewT6)),
+    assertion(sub_string(FewT6, _, _, _, "T6 first-argument indexing")).
+
+% Build + run: the T6 native-match dispatch returns the Prolog-correct result
+% for clause hits (including non-first clauses), no-match, and a remainder
+% (guard-body) mismatch.
+test(t6_exec) :-
+    Dir = 'output/test_wam_fsharp_t6_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_fsharp_project(
+        [user:shade/1, user:grade/2, user:few/1],
+        [module_name('t6proj'), emit_mode(functions)], Dir),
+    atomic_list_concat([Dir, '/Lowered.fs'], LoweredPath),
+    read_file_to_string(LoweredPath, LSrc, []),
+    assertion(sub_string(LSrc, _, _, _, "T6 first-argument indexing")),
+    atomic_list_concat([Dir, '/Program.fs'], ProgPath),
+    fsharp_t6_source(Src),
+    setup_call_cleanup(open(ProgPath, write, S), write(S, Src), close(S)),
+    format(atom(Cmd),
+        'cd ~w && DOTNET_CLI_TELEMETRY_OPTOUT=1 DOTNET_NOLOGO=1 dotnet run --project t6proj.fsproj -c Release 2>&1',
+        [Dir]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 11 PASS")
+    ->  true
+    ;   format(user_error, "~n[fsharp t6 test output]~n~w~n", [OutStr]),
+        throw(fsharp_t6_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_fsharp_lowered_t6).
+
+% Harness: bound first arg, call each lowered function, check Some/None. Cases
+% cover clause-1, several non-first clauses (the native-match payoff), no-match,
+% and a grade remainder mismatch. few/1 (T5) is exercised too as a control.
+fsharp_t6_source(
+"module Program
+
+open WamTypes
+open WamRuntime
+open Lowered
+
+let testEmptyState =
+    { WsPC = 0; WsRegs = Array.create MaxRegs (Unbound -1); WsStack = []
+      WsHeap = []; WsHeapLen = 0; WsTrail = []; WsTrailLen = 0
+      WsCP = 0; WsCPs = []; WsCPsLen = 0; WsBindings = Map.empty
+      WsCutBar = 0; WsVarCounter = 0; WsBuilder = None; WsBuilderStack = []
+      WsAggAccum = []; WsB0Stack = []; WsCatchers = [] }
+
+let testCtx : WamContext =
+    { WcCode = [||]; WcLabels = Map.empty; WcForeignFacts = Map.empty
+      WcFfiFacts = Map.empty; WcFfiWeightedFacts = Map.empty
+      WcAtomIntern = Map.empty; WcAtomDeintern = Map.empty
+      WcForeignConfig = Map.empty; WcLoweredPredicates = loweredPredicates
+      WcLookupSources = Map.empty; WcCancellationToken = None }
+
+let runP (f: WamContext -> WamState -> WamState option) (regs: (int * Value) list) : bool =
+    let arr = Array.create MaxRegs (Unbound -1)
+    regs |> List.iter (fun (idx, v) -> arr.[idx] <- v)
+    let s0 = { testEmptyState with WsRegs = arr }
+    match f testCtx s0 with Some _ -> true | None -> false
+
+let i (n: int) : Value = Integer n
+let a (s: string) : Value = Atom s
+
+[<EntryPoint>]
+let main _argv =
+    let cases : (string * bool * bool) list =
+        [ (\"shade(s01)\",   runP lowered_shade_1 [(1, a \"s01\")], true)
+          (\"shade(s05)\",   runP lowered_shade_1 [(1, a \"s05\")], true)
+          (\"shade(s10)\",   runP lowered_shade_1 [(1, a \"s10\")], true)
+          (\"shade(zz)\",    runP lowered_shade_1 [(1, a \"zz\")],  false)
+          (\"grade(g01,1)\", runP lowered_grade_2 [(1, a \"g01\"); (2, i 1)],  true)
+          (\"grade(g05,5)\", runP lowered_grade_2 [(1, a \"g05\"); (2, i 5)],  true)
+          (\"grade(g10,10)\",runP lowered_grade_2 [(1, a \"g10\"); (2, i 10)], true)
+          (\"grade(g05,9)\", runP lowered_grade_2 [(1, a \"g05\"); (2, i 9)],  false)
+          (\"grade(zz,1)\",  runP lowered_grade_2 [(1, a \"zz\"); (2, i 1)],   false)
+          (\"few(b)\",       runP lowered_few_1 [(1, a \"b\")], true)
+          (\"few(z)\",       runP lowered_few_1 [(1, a \"z\")], false) ]
+    let mutable fails = 0
+    for (name, got, want) in cases do
+        if got <> want then
+            fails <- fails + 1
+            printfn \"FAIL %s got %b want %b\" name got want
+    if fails = 0 then printfn \"ALL %d PASS\" (List.length cases)
+    else printfn \"%d FAILURES\" fails
+    0
+").


### PR DESCRIPTION
## Summary

F# is the **third atom-keyed target** to get the gated T6 back-end, after Rust and C++. It represents atoms as plain strings (`Atom of string`), so a many-branch F# `match` on the atom's string compiles to an efficient hash/jump dispatch — **O(1) where the T5 if/elif cascade is O(n)**.

## Why F# (and why not the others)

The survey of the remaining T5 targets was decisive: **F# is the only remaining string-atom-keyed target.** The int-interned targets (go/llvm/haskell/scala/lua) compare atoms as *integers* the host compiler already switch-converts, so T6 there carries the "lost to the compiler" risk and needs a per-target benchmark first. F# keeps atoms as strings at dispatch — exactly the case where a string switch is a real win — so it took the Rust/C++ pattern cleanly.

## Gating (identical to Rust/C++)

T6 fires only when every clause discriminates on a distinct **atom** and there are ≥ `t6_min_clauses` of them (default 8; override via the `t6_min_clauses(N)` option). The gate ties its atom test to `val_fs` (the same detector the T5 cascade uses), so the two paths agree on what an atom is. Below the threshold the F# compiler would just flatten the match back to a cascade, so the few-clause predicate stays T5.

## Implementation

Reuses the shared `wam_clause_chain` front-end and the existing T5 clause emission — only the **dispatch tail** changes:

```fsharp
match (deref A1) with
| Some (Unbound _) -> t5fallback ()
| Some (Atom t6s) ->
    (match t6s with
     | "s01" -> t5clause_1 s_init
     | ...
     | _ -> None)
| Some _ -> None
| None -> t5fallback ()
```

Options are threaded through `emit_func_fs`/`emit_func_t5_fs` (which previously didn't receive `Opts`).

## Tests — `test_wam_fsharp_lowered_t6.pl` (dotnet)
- **codegen gate**: `shade/1` and `grade/2` (≥8 atom clauses) → T6 native match; `few/1` (3) → T5 cascade; `t6_min_clauses(3)` override flips `few/1` to T6.
- **build + run** via `dotnet`: Prolog-correct dispatch including **non-first clauses reached through the native match**, no-match (`shade(zz)`→false), and a `grade` remainder/guard-body mismatch.

F# T5/T4 and the fsharp target suite still pass.

## Matrix

fsharp **T6 = `~` gated**. The atom-keyed T6 set is now complete (rust/cpp/fsharp); the int-interned targets remain benchmark-gated.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_