### PR TITLE
feat(wam-go): gated T6 first-argument indexing (native string switch, benchmarked)

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -98,7 +98,7 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 | scala   | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ |
 | rust    | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✗ | ✗ | ✗ |
 | cpp     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✗ | ✗ | ✗ | ✗ |
-| go      | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ |
+| go      | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✗ | ✗ | ✗ |
 | haskell | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ |
 | fsharp  | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ~ | ✗ | ✗ | ✗ |
 | clojure | ✓ | ✓ T2a | ✓ | ✓ | ✗ | ✗ | ~ | ~ | ✗ | ✗ | ✗ |
@@ -216,24 +216,30 @@ Reading down the columns (after the T5 and T4 sweeps landed):
   argument-register + trail snapshot/restore between attempts, first-solution).
   So **every multi-clause column (T3/T4/T5) is now closed** across the targets
   that support each shape — no plain ✗ remains in T3/T4/T5.
-- **T6 (first-arg indexing)** — **Rust and C++** now have a *gated* T6 (`~`):
-  both reuse the T5 `wam_clause_chain` front-end, but when the discriminators
-  are all atoms and there are ≥ `t6_min_clauses` of them (default 8) the
-  back-end replaces the if-cascade with a native indexed dispatch — Rust a
-  two-stage `match` (string switch → integer jump table); C++ a static
-  `std::unordered_map<std::string,int>` (no native string switch) → `switch`.
-  The other targets still drop the `switch_on_*` prefix and try clauses in
-  order. This is the natural next advancement after T5 (same clause-head
-  analysis, switch back-end): shared front-end, per-target back-end — high
-  leverage, and a perf win that's sound behind a gate. Measured on generated
-  code (tie at 4 clauses; then growing with N): Rust 1.55× at 8, 5.7× at 64,
-  12.7× at 256; C++ 2.1× at 8, 11.6× at 64, 40.8× at 256 (see
-  `docs/reports/wam_rust_dispatch_alloc_perf.md`). The compiler flattens the
-  cascade for few clauses (matching the prior Go array-dispatch result), hence
-  the gate. Int-interned targets (go/llvm/haskell/scala/lua) are the remaining
-  candidates but carry the highest "lost to the compiler" risk (an int
-  equality chain is already switch-converted), so each needs a per-target
-  benchmark before shipping.
+- **T6 (first-arg indexing)** — **Rust, C++ and Go** now have a *gated* T6
+  (`~`): all reuse the T5 `wam_clause_chain` front-end, but when the
+  discriminators are all atoms and there are ≥ `t6_min_clauses` of them
+  (default 8) the back-end replaces the if-cascade with a native indexed
+  dispatch — Rust a two-stage `match` (string switch → integer jump table);
+  C++ a static `std::unordered_map<std::string,int>` (no native string switch)
+  → `switch`; **Go a native `switch t6atom.Name` (string switch)**. These are
+  the **atom-keyed** targets — atoms are compared as strings at dispatch, so a
+  string switch is a real win the host compiler does not already perform. The
+  other targets still drop the `switch_on_*` prefix and try clauses in order.
+  This is the natural next advancement after T5 (same clause-head analysis,
+  switch back-end): shared front-end, per-target back-end — high leverage, and a
+  perf win that's sound behind a gate. Measured on generated code (tie at 4
+  clauses; then growing with N): Rust 1.55× at 8, 5.7× at 64, 12.7× at 256; C++
+  2.1× at 8, 11.6× at 64, 40.8× at 256 (`docs/reports/wam_rust_dispatch_alloc_perf.md`);
+  **Go 4.8× at 8, 31.7× at 64, 58.8× at 256**
+  (`docs/reports/wam_go_dispatch_t6_perf.md`) — Go's `valueEquals` cascade is an
+  interface-call chain the compiler does not rewrite, so the switch wins big.
+  The compiler flattens the cascade for few clauses, hence the gate. NOTE: Go
+  was previously mislabelled int-interned — its atoms are `&Atom{Name string}`
+  interned by name, i.e. string-keyed. The genuinely **int-interned** remaining
+  targets (llvm/haskell/scala/lua — atoms become integers at codegen) carry the
+  highest "lost to the compiler" risk (an int-equality chain the host compiler
+  switch-converts anyway), so each needs a per-target benchmark before shipping.
 - **T2 (ITE)** — now **complete across every target**, including WAT: the
   lowered emitter folds the soft-cut block with the shared `wam_ite_structurer`
   and emits native WAT (`(block $ite_condK (result i32) …)` for the condition

--- a/docs/reports/wam_go_dispatch_t6_perf.md
+++ b/docs/reports/wam_go_dispatch_t6_perf.md
@@ -1,0 +1,44 @@
+# Go WAM lowered dispatch: T5 cascade vs T6 string switch
+
+Benchmark backing the gated **T6 first-argument indexing** back-end for the Go
+WAM target (`wam_go_lowered_emitter.pl`). Companion to
+`docs/reports/wam_rust_dispatch_alloc_perf.md` (Rust/C++).
+
+## What is measured
+
+A predicate `shade/1` with **N** distinct single-atom facts is lowered two ways:
+
+- **T5** — the linear `if valueEquals(t5a1, atomK) { … }` cascade (forced with
+  `t6_min_clauses(999999)`).
+- **T6** — a single type-assertion to `*Atom` then a native Go
+  `switch t6atom.Name { case "…": … }` (the default, gate fires at ≥ 8 atoms).
+
+The benchmark loops over **all N keys plus one miss**, so each measurement is the
+average dispatch cost across every clause position (the cascade's worst case is
+the last clause / the miss; its average is ~N/2 comparisons).
+
+`go test -bench`, `go1.24.7 linux/amd64`, Intel Xeon @ 2.10 GHz, `-benchtime=1s`.
+
+## Results (ns/op, lower is better)
+
+| N (clauses) | T5 cascade | T6 string switch | speedup |
+|------------:|-----------:|-----------------:|--------:|
+|           8 |      22.08 |            4.594 |   4.81× |
+|          64 |      150.9 |            4.760 |  31.70× |
+|         256 |      513.0 |            8.721 |  58.82× |
+
+## Reading the result
+
+- The T5 cascade is **O(N)** — each clause is a `valueEquals` call (an interface
+  type-assertion plus a comparison), so cost grows linearly: 22 → 151 → 513 ns.
+- The T6 switch is **O(1)** — one type-assertion, then a Go string `switch` the
+  compiler lowers to a length/hash jump: ~4.6–8.7 ns, essentially flat.
+- Unlike an *integer* equality chain (which Go and most backends would
+  switch-convert anyway — the "lost to the compiler" case), Go does **not**
+  rewrite the `valueEquals` interface-call chain, so the explicit switch is a
+  real win. Go atoms are `&Atom{Name string}` interned by name, i.e. the
+  discriminator is string-keyed — Go is an **atom-keyed** target (like
+  Rust/C++/F#), not int-interned.
+- The win already pays off at the default gate of 8 clauses (4.8×) and is large
+  by 64 (32×); below the gate the cascade is fine and the compiler would just
+  flatten a small switch back to comparisons, so T6 stays gated.

--- a/src/unifyweaver/targets/wam_go_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_go_lowered_emitter.pl
@@ -324,14 +324,14 @@ capitalize_first(Str, Cap) :-
 
 %% lower_predicate_to_go(+Pred/Arity, +WamCode, +Options, -GoLines)
 %  Emit a Go method on *WamState for the predicate.
-lower_predicate_to_go(PI, WamCode, _Options, GoLines) :-
+lower_predicate_to_go(PI, WamCode, Options, GoLines) :-
     ( PI = _M:Pred/Arity -> true ; PI = Pred/Arity ),
     go_func_name(Pred/Arity, FuncName),
     go_base_instrs(WamCode, Instrs),
     clause1_instrs(Instrs, C1Instrs),
     (   % T5 first-argument-constant dispatch takes precedence.
         go_clause_chain_lowerable(Instrs, Guards)
-    ->  emit_clause_chain_go(FuncName, Pred, Arity, Guards, GoLines)
+    ->  emit_clause_chain_go(FuncName, Pred, Arity, Guards, Options, GoLines)
     ;   % T4: a multi-clause predicate whose clauses are all supported
         % deterministic bodies (but not a distinct-first-arg chain) — lower
         % every clause inline, tried in order with a restore between attempts.
@@ -386,16 +386,26 @@ emit_go_clauses([Cl | Rest]) :-
 %  clause's remainder (which self-terminates: its `proceed` emits
 %  `return true`). A bound value matching no clause returns false (the
 %  predicate fails; the wrapper's fresh re-run also fails — sound).
-emit_clause_chain_go(FuncName, Pred, Arity, Guards, GoLines) :-
+emit_clause_chain_go(FuncName, Pred, Arity, Guards, Options, GoLines) :-
     go_reg_idx("A1", A1Idx),
+    % T6 first-argument indexing: when every discriminator is an atom and there
+    % are enough of them, dispatch with a native Go `switch` on the atom's name
+    % (a string switch the Go compiler lowers to a hash/length jump) instead of
+    % the linear valueEquals if-cascade. Gated like Rust/C++: below the threshold
+    % the cascade is fine (and the switch would just be flattened back).
+    (   go_t6_applicable(Guards, Options)
+    ->  TagComment = 'T6 first-argument indexing (native string switch)',
+        with_output_to(string(Body), emit_go_t6_dispatch(A1Idx, Guards))
+    ;   TagComment = 'T5 first-argument dispatch',
+        with_output_to(string(Body),
+            ( format("    t5a1 := vm.deref(vm.Regs[~w])~n", [A1Idx]),
+              format("    if _, ok := t5a1.(*Unbound); ok { return false }  // unbound first arg: defer to interpreter (enumerates all clauses)~n"),
+              emit_go_guards(Guards),
+              format("    return false~n") ))
+    ),
     format(string(Header),
-'// ~w — lowered from ~w/~w (T5 first-argument dispatch)
-func (vm *WamState) ~w() bool {', [FuncName, Pred, Arity, FuncName]),
-    with_output_to(string(Body),
-        ( format("    t5a1 := vm.deref(vm.Regs[~w])~n", [A1Idx]),
-          format("    if _, ok := t5a1.(*Unbound); ok { return false }  // unbound first arg: defer to interpreter (enumerates all clauses)~n"),
-          emit_go_guards(Guards),
-          format("    return false~n") )),
+'// ~w — lowered from ~w/~w (~w)
+func (vm *WamState) ~w() bool {', [FuncName, Pred, Arity, TagComment, FuncName]),
     format(string(Footer), '}', []),
     GoLines = [Header, Body, Footer].
 
@@ -406,6 +416,37 @@ emit_go_guards([guard(V, Rem) | Rest]) :-
     emit_instrs(Rem, "        "),
     format("    }~n"),
     emit_go_guards(Rest).
+
+%% go_t6_applicable(+Guards, +Options) is semidet.
+%  T6 gate: every discriminator is an atom and there are at least
+%  t6_min_clauses of them (default 8, override via t6_min_clauses(N)).
+go_t6_applicable(Guards, Options) :-
+    go_t6_min_clauses(Options, Min),
+    length(Guards, N), N >= Min,
+    forall(member(guard(V, _), Guards), wam_classify_constant_token(V, atom(_))).
+
+go_t6_min_clauses(Options, N) :-
+    ( member(t6_min_clauses(N), Options) -> true ; N = 8 ).
+
+%% emit_go_t6_dispatch(+A1Idx, +Guards) — deref A1 once, single type assertion
+%  to *Atom, then a native string switch on the atom name into the clause body.
+emit_go_t6_dispatch(A1Idx, Guards) :-
+    format("    t5a1 := vm.deref(vm.Regs[~w])~n", [A1Idx]),
+    format("    if _, ok := t5a1.(*Unbound); ok { return false }  // unbound first arg: defer to interpreter (enumerates all clauses)~n"),
+    format("    t6atom, t6ok := t5a1.(*Atom)~n"),
+    format("    if !t6ok { return false }  // bound non-atom: no clause matches~n"),
+    format("    switch t6atom.Name {~n"),
+    emit_go_t6_cases(Guards),
+    format("    }~n"),
+    format("    return false~n").
+
+emit_go_t6_cases([]).
+emit_go_t6_cases([guard(V, Rem) | Rest]) :-
+    wam_classify_constant_token(V, atom(Name)),
+    escape_go_string(Name, Esc),
+    format("    case \"~w\":~n", [Esc]),
+    emit_instrs(Rem, "        "),
+    emit_go_t6_cases(Rest).
 
 %% emit_instrs(+Instrs, +Indent)
 %  Emit Go code for a list of instructions. Detects the WAM if-then-else

--- a/tests/test_wam_go_lowered_t6.pl
+++ b/tests/test_wam_go_lowered_t6.pl
@@ -1,0 +1,169 @@
+% test_wam_go_lowered_t6.pl
+%
+% End-to-end test for the Go T6 lowering — first-argument indexing (native Go
+% string `switch`), lowering type T6 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md.
+%
+% Go represents atoms as `&Atom{Name: "..."}` interned BY NAME, so the
+% discriminator is keyed by string — Go is an ATOM-KEYED target (like Rust/C++/
+% F#), not int-interned. Its T6 back-end is a native Go `switch t6atom.Name`
+% (which the Go compiler lowers to a hash/length jump) replacing the linear
+% `valueEquals` if-cascade. Benchmarked O(1) vs the cascade's O(n): 4.8x at 8
+% clauses, 31x at 64, 59x at 256 (see docs/reports/wam_go_dispatch_t6_perf.md).
+%
+% Gated like Rust/C++/F#: T6 fires only when every clause discriminates on a
+% distinct ATOM and there are >= t6_min_clauses of them (default 8). Below the
+% threshold the few-clause predicate stays the T5 cascade.
+%
+% The build drops lib.go — the older native clause-parallel strategy, which is
+% independently broken for these predicate shapes (a pre-existing go_target
+% native-codegen bug unrelated to WAM lowering). The T6 deliverable lives
+% entirely in lowered.go, mirroring how the Go T5 test isolates lowered.go.
+%
+% Skipped automatically when `go` is not on PATH.
+
+:- use_module(library(lists)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_go_target').
+:- use_module('../src/unifyweaver/targets/wam_go_lowered_emitter').
+
+:- dynamic user:shade/1, user:grade/2, user:few/1.
+
+user:shade(s01). user:shade(s02). user:shade(s03). user:shade(s04).
+user:shade(s05). user:shade(s06). user:shade(s07). user:shade(s08).
+user:shade(s09). user:shade(s10).
+
+user:grade(g01, R) :- R is 1 + 0.
+user:grade(g02, R) :- R is 1 + 1.
+user:grade(g03, R) :- R is 1 + 2.
+user:grade(g04, R) :- R is 1 + 3.
+user:grade(g05, R) :- R is 1 + 4.
+user:grade(g06, R) :- R is 1 + 5.
+user:grade(g07, R) :- R is 1 + 6.
+user:grade(g08, R) :- R is 1 + 7.
+user:grade(g09, R) :- R is 1 + 8.
+user:grade(g10, R) :- R is 1 + 9.
+
+user:few(a). user:few(b). user:few(c).
+
+go_available :-
+    catch(( process_create(path(go), ['version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_go_lowered_t6, [condition(go_available)]).
+
+% The many-clause atom predicates emit the native string switch (T6); the
+% few-clause one stays the if-cascade (T5). Threshold is configurable.
+test(gate_picks_t6_for_many_t5_for_few) :-
+    wam_target:compile_predicate_to_wam(shade/1, [], Ws),
+    lower_predicate_to_go(shade/1, Ws, [], ShadeLines),
+    atomic_list_concat(ShadeLines, '\n', ShadeCode),
+    assertion(sub_string(ShadeCode, _, _, _, "T6 first-argument indexing")),
+    assertion(sub_string(ShadeCode, _, _, _, "switch t6atom.Name")),
+    wam_target:compile_predicate_to_wam(grade/2, [], Wg),
+    lower_predicate_to_go(grade/2, Wg, [], GradeLines),
+    atomic_list_concat(GradeLines, '\n', GradeCode),
+    assertion(sub_string(GradeCode, _, _, _, "T6 first-argument indexing")),
+    wam_target:compile_predicate_to_wam(few/1, [], Wf),
+    lower_predicate_to_go(few/1, Wf, [], FewLines),
+    atomic_list_concat(FewLines, '\n', FewCode),
+    assertion(sub_string(FewCode, _, _, _, "T5 first-argument dispatch")),
+    assertion(\+ sub_string(FewCode, _, _, _, "T6 first-argument indexing")),
+    % threshold override: few/1 lowers as T6 when the gate is lowered to 3.
+    lower_predicate_to_go(few/1, Wf, [t6_min_clauses(3)], FewT6Lines),
+    atomic_list_concat(FewT6Lines, '\n', FewT6Code),
+    assertion(sub_string(FewT6Code, _, _, _, "T6 first-argument indexing")).
+
+% Build + run: the T6 native-switch dispatch returns the Prolog-correct result
+% for clause hits (including non-first clauses), no-match, and a grade remainder
+% (guard-body) mismatch.
+test(t6_exec) :-
+    Proj = 'output/test_wam_go_t6_gen',
+    Dir = 'output/test_wam_go_t6_exec',
+    ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    make_directory_path(Dir),
+    write_wam_go_project(
+        [user:shade/1, user:grade/2, user:few/1],
+        [module_name('t6exec'), wam_fallback(true)], Proj),
+    atomic_list_concat([Proj, '/lowered.go'], LoweredPath),
+    read_file_to_string(LoweredPath, LSrc, []),
+    assertion(sub_string(LSrc, _, _, _, "T6 first-argument indexing")),
+    % Build lowered.go + runtime in isolation (drop the broken lib.go).
+    atomic_list_concat(['cp ', Proj, '/*.go ', Dir, '/ && rm -f ', Dir, '/lib.go'], CpCmd),
+    shell_ok_t6(CpCmd),
+    write_file_t6(Dir/'go.mod', "module t6exec\n\ngo 1.21\n"),
+    go_t6_source(Src),
+    write_file_t6(Dir/'t6_exec_test.go', Src),
+    format(atom(TestCmd), 'cd ~w && go test ./... 2>&1', [Dir]),
+    process_create(path(sh), ['-c', TestCmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    ->  true
+    ;   format(user_error, "~n[go t6 test output]~n~w~n", [OutStr]),
+        throw(go_t6_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ).
+
+:- end_tests(wam_go_lowered_t6).
+
+shell_ok_t6(Cmd) :-
+    process_create(path(sh), ['-c', Cmd], [process(Pid)]),
+    process_wait(Pid, exit(0)).
+
+write_file_t6(PathSpec, Text) :-
+    ( atom(PathSpec) -> Path = PathSpec ; PathSpec = D/F, atomic_list_concat([D, '/', F], Path) ),
+    setup_call_cleanup(open(Path, write, S, [encoding(utf8)]), write(S, Text), close(S)).
+
+% Harness: bound first arg loaded into Regs[0..], call each lowered method.
+% Cases cover clause-1, several non-first clauses (the native-switch payoff),
+% no-match, a grade remainder mismatch, and few/1 (the T5 control).
+go_t6_source(
+"package wam
+
+import \"testing\"
+
+func callPredT6(setup func(vm *WamState), pred func(vm *WamState) bool) bool {
+	vm := NewWamState(nil, nil)
+	setup(vm)
+	return pred(vm)
+}
+
+func TestT6Dispatch(t *testing.T) {
+	I := func(n int64) Value { return &Integer{Val: n} }
+	A := func(s string) Value { return internAtom(s) }
+	set := func(vals ...Value) func(vm *WamState) {
+		return func(vm *WamState) {
+			for i, v := range vals {
+				vm.Regs[i] = v
+			}
+		}
+	}
+	cases := []struct {
+		name string
+		got  bool
+		want bool
+	}{
+		{\"shade(s01)\", callPredT6(set(A(\"s01\")), (*WamState).PredShade1), true},
+		{\"shade(s05)\", callPredT6(set(A(\"s05\")), (*WamState).PredShade1), true},
+		{\"shade(s10)\", callPredT6(set(A(\"s10\")), (*WamState).PredShade1), true},
+		{\"shade(zz)\", callPredT6(set(A(\"zz\")), (*WamState).PredShade1), false},
+		{\"grade(g01,1)\", callPredT6(set(A(\"g01\"), I(1)), (*WamState).PredGrade2), true},
+		{\"grade(g05,5)\", callPredT6(set(A(\"g05\"), I(5)), (*WamState).PredGrade2), true},
+		{\"grade(g10,10)\", callPredT6(set(A(\"g10\"), I(10)), (*WamState).PredGrade2), true},
+		{\"grade(g05,9)\", callPredT6(set(A(\"g05\"), I(9)), (*WamState).PredGrade2), false},
+		{\"grade(zz,1)\", callPredT6(set(A(\"zz\"), I(1)), (*WamState).PredGrade2), false},
+		{\"few(b)\", callPredT6(set(A(\"b\")), (*WamState).PredFew1), true},
+		{\"few(z)\", callPredT6(set(A(\"z\")), (*WamState).PredFew1), false},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf(\"%s: got %v want %v\", c.name, c.got, c.want)
+		}
+	}
+}
+").


### PR DESCRIPTION
## Summary

Go gets the gated T6 first-arg indexing back-end — and a benchmark that makes the case decisively.

**Key finding:** Go was **mis-classified as int-interned** in the matrix. Its atoms are `&Atom{Name string}` interned *by name*, so the T5 discriminator comparison is **string-keyed** — Go is an **atom-keyed** target (like Rust/C++/F#). Its T6 back-end is a native Go `switch t6atom.Name` (the compiler lowers it to a length/hash jump), replacing the linear `valueEquals` if-cascade.

## Benchmark (the deliverable the issue asked for)

`go test -bench`, go1.24.7, averaged over all keys + 1 miss (see `docs/reports/wam_go_dispatch_t6_perf.md`):

| N (clauses) | T5 cascade | T6 switch | speedup |
|---:|---:|---:|---:|
| 8 | 22.1 ns | 4.6 ns | **4.8×** |
| 64 | 151 ns | 4.8 ns | **31.7×** |
| 256 | 513 ns | 8.7 ns | **58.8×** |

The T5 `valueEquals` cascade is **O(N)** — an interface-call chain the Go compiler does **not** rewrite — while the T6 switch is **O(1)**. So this is *not* the "lost to the compiler" case; it's a large, real win (bigger than Rust/C++).

## Gating & implementation

Gated like Rust/C++/F#: fires only when every discriminator is a distinct atom and there are ≥ `t6_min_clauses` (default 8, override via the option). Reuses the shared `wam_clause_chain` front-end and the existing clause-body emission; only the dispatch changes (deref A1 once, one `*Atom` type assertion, then the string switch). `Options` are now threaded through `lower_predicate_to_go`/`emit_clause_chain_go` (previously `_Options` was ignored).

## Tests — `test_wam_go_lowered_t6.pl` (go)
Codegen gate (T6 for `shade/1`+`grade/2` ≥8 atoms, T5 for `few/1`, threshold override) and a build+run exec test asserting Prolog-correct dispatch including non-first clauses through the native switch, no-match, and a `grade` remainder mismatch. Builds `lowered.go` in isolation (drops the pre-existing-broken `lib.go`, as the Go T5 test does). Go T5/T4 still pass.

## Status of the T6 column

Atom-keyed targets with T6: **rust, cpp, fsharp** (PR #3007), **go** (this PR). The genuinely **int-interned** remaining targets (llvm/haskell/scala/lua — atoms become integers) carry the "lost to the compiler" risk and each need their own per-target benchmark; those are next.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_