### PR TITLE
Compare distribution fits and depth priors

### DIFF
--- a/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
+++ b/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
@@ -436,6 +436,16 @@ The next implementation-facing work is a parity harness:
 
 The benchmark plan in `DISTRIBUTION_CACHE_BENCHMARK_PLAN.md` defines the first shallow precompute/search-budget grid for this work.
 
+The first approximation harness is `scripts/distribution_fit_comparison.py`.
+It keeps two concepts separate:
+
+- realized distribution fits compare binomial and shifted-Gamma-style vectors
+  against exact histograms for already selected nodes;
+- depth-conditioned prior distributions use the size-biased excess-parent
+  distribution to estimate whether histograms at future depths are likely to
+  stay narrow enough to materialize cheaply before observing exact node
+  histograms.
+
 1. exact parent-only histogram on tiny fixtures;
 2. exact parent-only histogram on simplewiki samples;
 3. fitted truncated-tail representation over the same nodes;

--- a/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
+++ b/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
@@ -359,6 +359,11 @@ The next benchmark additions should measure:
 parent_degree_distribution by L_min bucket
 excess_parent_distribution where Y = p - 1
 empirical convolution of Y for small n
+depth-conditioned prior distributions from the size-biased excess-parent law
+expected support width and tail mass as a function of root-distance horizon
+exact path-length histograms versus fitted binomial vectors
+exact path-length histograms versus shifted-Gamma-style vectors
+accuracy/cost tradeoff between binomial and Gamma approximations
 binomial approximation error when max_p <= 2 or 3
 direct convolution versus FFT convolution parity over the same empirical Y
 FFT zero-padding and numerical-noise error bounds for wider supports
@@ -374,3 +379,17 @@ correlation between path_mass and b_p^n
 The pass/fail criterion is functional, not aesthetic: an approximation is useful
 only if it predicts the policy decision made by exact histograms on SimpleWiki
 and small enwiki samples.
+
+`scripts/distribution_fit_comparison.py` is the first executable version of
+that comparison. It intentionally separates two related ideas. A realized
+distribution fit approximates the statistics of a histogram that was actually
+computed for a node. A depth-conditioned prior distribution is a Bayesian prior:
+a forecast based on a root-distance horizon and the size-biased excess-parent
+law before observing the node's exact histogram. This is the object used to
+estimate whether future exact histograms are likely to be cheap enough to store.
+
+The planner should use the prior distribution for admission thresholds such
+as "carry exact histograms to depth `d` while the prior effective support is
+narrow." The realized fit is still needed as validation: if binomial or Gamma
+approximations do not match exact histograms on sampled nodes, then the prior
+depth policy is using the wrong family even if its mean looks plausible.

--- a/scripts/distribution_fit_comparison.py
+++ b/scripts/distribution_fit_comparison.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Compare exact histograms with realized fits and depth-conditioned priors."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.distribution_cache_support_bounds import (  # noqa: E402
+    SIMPLEWIKI_ROOT,
+    load_targets_file,
+    parse_int_list,
+    parse_targets,
+    safe_graph_name,
+)
+from tools.distribution_cache_support import (  # noqa: E402
+    FIXTURES,
+    ROOT,
+    exact_histogram,
+    load_parent_edges_tsv,
+    reachable_nodes_by_parent_distance,
+)
+
+
+DEFAULT_DEPTHS = [2, 4, 8, 16]
+
+
+def clamp_probability(value: float) -> float:
+    if value < 0.0:
+        return 0.0
+    if value > 1.0:
+        return 1.0
+    return value
+
+
+def normalize(weights: list[float]) -> list[float]:
+    total = sum(weights)
+    if total <= 0.0:
+        if not weights:
+            return []
+        out = [0.0 for _ in weights]
+        out[0] = 1.0
+        return out
+    return [weight / total for weight in weights]
+
+
+def exact_excess_distribution(hist: dict[int, int]) -> tuple[list[float], int | None]:
+    """Return P(L - L_min = k) and the shifted origin."""
+    if not hist:
+        return [], None
+    origin = min(hist)
+    width = max(hist) - origin
+    weights = [float(hist.get(origin + k, 0)) for k in range(width + 1)]
+    return normalize(weights), origin
+
+
+def distribution_moments(probabilities: list[float]) -> tuple[float, float]:
+    mean = sum(index * probability for index, probability in enumerate(probabilities))
+    variance = sum(((index - mean) ** 2) * probability for index, probability in enumerate(probabilities))
+    return mean, variance
+
+
+def binomial_pmf(trials: int, probability: float) -> list[float]:
+    if trials <= 0:
+        return [1.0]
+    probability = clamp_probability(probability)
+    if probability == 0.0:
+        return [1.0] + [0.0 for _ in range(trials)]
+    if probability == 1.0:
+        return [0.0 for _ in range(trials)] + [1.0]
+
+    q = 1.0 - probability
+    values = [0.0 for _ in range(trials + 1)]
+    values[0] = q**trials
+    for k in range(trials):
+        values[k + 1] = values[k] * (trials - k) / (k + 1) * probability / q
+    return normalize(values)
+
+
+def fitted_binomial_pmf(empirical: list[float]) -> tuple[list[float], dict[str, float | int]]:
+    trials = max(0, len(empirical) - 1)
+    mean, variance = distribution_moments(empirical)
+    probability = 0.0 if trials == 0 else clamp_probability(mean / trials)
+    return binomial_pmf(trials, probability), {
+        "trials": trials,
+        "probability": probability,
+        "mean": mean,
+        "variance": variance,
+    }
+
+
+def degenerate_pmf(index: int, bins: int) -> list[float]:
+    bins = max(1, bins)
+    index = min(max(0, index), bins - 1)
+    out = [0.0 for _ in range(bins)]
+    out[index] = 1.0
+    return out
+
+
+def gamma_midpoint_pmf(mean: float, variance: float, bins: int) -> tuple[list[float], dict[str, float | int | str]]:
+    """Discretise a Gamma fit over integer excess bins by midpoint sampling."""
+    bins = max(1, bins)
+    if mean <= 0.0:
+        return degenerate_pmf(0, bins), {
+            "family": "degenerate",
+            "shape": 0.0,
+            "scale": 0.0,
+            "mean": mean,
+            "variance": variance,
+        }
+    if variance <= 1e-12:
+        return degenerate_pmf(round(mean), bins), {
+            "family": "degenerate",
+            "shape": "inf",
+            "scale": 0.0,
+            "mean": mean,
+            "variance": variance,
+        }
+
+    shape = (mean * mean) / variance
+    scale = variance / mean
+    log_norm = math.lgamma(shape) + shape * math.log(scale)
+    weights = []
+    for k in range(bins):
+        x = k + 0.5
+        log_density = (shape - 1.0) * math.log(x) - (x / scale) - log_norm
+        weights.append(math.exp(log_density))
+    return normalize(weights), {
+        "family": "gamma_midpoint",
+        "shape": shape,
+        "scale": scale,
+        "mean": mean,
+        "variance": variance,
+    }
+
+
+def fitted_gamma_pmf(empirical: list[float]) -> tuple[list[float], dict[str, float | int | str]]:
+    mean, variance = distribution_moments(empirical)
+    return gamma_midpoint_pmf(mean, variance, len(empirical))
+
+
+def convolve(left: list[float], right: list[float]) -> list[float]:
+    if not left or not right:
+        return []
+    out = [0.0 for _ in range(len(left) + len(right) - 1)]
+    for i, left_value in enumerate(left):
+        if left_value == 0.0:
+            continue
+        for j, right_value in enumerate(right):
+            if right_value:
+                out[i + j] += left_value * right_value
+    return normalize(out)
+
+
+def nfold_convolution(base: list[float], depth: int) -> list[float]:
+    if depth <= 0:
+        return [1.0]
+    out = [1.0]
+    for _ in range(depth):
+        out = convolve(out, base)
+    return out
+
+
+def size_biased_excess_pmf(parent_degrees: list[int]) -> list[float]:
+    """Distribution of Y=p-1 seen after arriving through a parent edge."""
+    weights: dict[int, float] = {}
+    total_weight = 0.0
+    for degree in parent_degrees:
+        if degree <= 0:
+            continue
+        excess = degree - 1
+        weights[excess] = weights.get(excess, 0.0) + degree
+        total_weight += degree
+    if total_weight <= 0.0:
+        return [1.0]
+    max_excess = max(weights)
+    return [weights.get(excess, 0.0) / total_weight for excess in range(max_excess + 1)]
+
+
+def pad_to(left: list[float], right: list[float]) -> tuple[list[float], list[float]]:
+    size = max(len(left), len(right))
+    return left + [0.0] * (size - len(left)), right + [0.0] * (size - len(right))
+
+
+def l1_error(empirical: list[float], model: list[float]) -> float:
+    empirical, model = pad_to(empirical, model)
+    return sum(abs(a - b) for a, b in zip(empirical, model))
+
+
+def max_cdf_error(empirical: list[float], model: list[float]) -> float:
+    empirical, model = pad_to(empirical, model)
+    empirical_total = 0.0
+    model_total = 0.0
+    worst = 0.0
+    for empirical_value, model_value in zip(empirical, model):
+        empirical_total += empirical_value
+        model_total += model_value
+        worst = max(worst, abs(empirical_total - model_total))
+    return worst
+
+
+def mean_absolute_error(empirical: list[float], model: list[float]) -> float:
+    empirical, model = pad_to(empirical, model)
+    if not empirical:
+        return 0.0
+    return sum(abs(a - b) for a, b in zip(empirical, model)) / len(empirical)
+
+
+def effective_support_bins(probabilities: list[float], tail_epsilon: float) -> int:
+    tail_epsilon = max(0.0, tail_epsilon)
+    cumulative = 0.0
+    for index, probability in enumerate(probabilities):
+        cumulative += probability
+        if 1.0 - cumulative <= tail_epsilon:
+            return index + 1
+    return len(probabilities)
+
+
+def compare_models(empirical: list[float], model_builders) -> list[dict[str, object]]:
+    records = []
+    for model_name, builder in model_builders:
+        started = time.perf_counter_ns()
+        model, params = builder(empirical)
+        build_time_ns = time.perf_counter_ns() - started
+        model_mean, model_variance = distribution_moments(model)
+        records.append({
+            "model": model_name,
+            "l1_error": l1_error(empirical, model),
+            "max_cdf_error": max_cdf_error(empirical, model),
+            "mean_absolute_error": mean_absolute_error(empirical, model),
+            "model_mean_excess": model_mean,
+            "model_variance_excess": model_variance,
+            "model_support_bins": len(model),
+            "build_time_ns": build_time_ns,
+            "fit_params": params,
+        })
+    return records
+
+
+def realized_model_builders():
+    return [
+        ("binomial_fit", fitted_binomial_pmf),
+        ("shifted_gamma_fit", fitted_gamma_pmf),
+    ]
+
+
+def prior_model_builders(depth: int):
+    def build_binomial(empirical: list[float]):
+        mean, variance = distribution_moments(empirical)
+        probability = 0.0 if depth <= 0 else clamp_probability(mean / depth)
+        return binomial_pmf(depth, probability), {
+            "trials": depth,
+            "probability": probability,
+            "mean": mean,
+            "variance": variance,
+        }
+
+    def build_gamma(empirical: list[float]):
+        mean, variance = distribution_moments(empirical)
+        return gamma_midpoint_pmf(mean, variance, len(empirical))
+
+    return [
+        ("binomial_prior", build_binomial),
+        ("shifted_gamma_prior", build_gamma),
+    ]
+
+
+def target_fit_records(graph_name, graph_label, parents, root, target, hist_memo, tail_epsilon):
+    started = time.perf_counter_ns()
+    hist = exact_histogram(target, parents, root, hist_memo)
+    exact_time_ns = time.perf_counter_ns() - started
+    empirical, origin = exact_excess_distribution(hist)
+    if not empirical or origin is None:
+        return []
+
+    mean, variance = distribution_moments(empirical)
+    records = []
+    for model_record in compare_models(empirical, realized_model_builders()):
+        records.append({
+            "record_type": "distribution_fit",
+            "distribution_role": "realized_fit",
+            "graph": graph_name,
+            "fixture": graph_label,
+            "root": root,
+            "target_node": target,
+            "L_min": origin,
+            "L_max": origin + len(empirical) - 1,
+            "support_width": len(empirical) - 1,
+            "support_bins": len(empirical),
+            "effective_support_bins": effective_support_bins(empirical, tail_epsilon),
+            "path_count": sum(hist.values()),
+            "mean_excess": mean,
+            "variance_excess": variance,
+            "exact_histogram_time_ns": exact_time_ns,
+            "parent_degree": len(parents.get(target, [])),
+            **model_record,
+        })
+    return records
+
+
+def depth_prior_records(graph_name, graph_label, parent_degrees, depths, tail_epsilon):
+    base = size_biased_excess_pmf(parent_degrees)
+    base_mean, base_variance = distribution_moments(base)
+    records = []
+    for depth in depths:
+        started = time.perf_counter_ns()
+        empirical = nfold_convolution(base, depth)
+        exact_time_ns = time.perf_counter_ns() - started
+        mean, variance = distribution_moments(empirical)
+        for model_record in compare_models(empirical, prior_model_builders(depth)):
+            records.append({
+                "record_type": "distribution_fit",
+                "distribution_role": "depth_prior",
+                "graph": graph_name,
+                "fixture": graph_label,
+                "root_distance_horizon": depth,
+                "support_width": len(empirical) - 1,
+                "support_bins": len(empirical),
+                "effective_support_bins": effective_support_bins(empirical, tail_epsilon),
+                "mean_excess": mean,
+                "variance_excess": variance,
+                "base_mean_excess": base_mean,
+                "base_variance_excess": base_variance,
+                "base_support_bins": len(base),
+                "exact_histogram_time_ns": exact_time_ns,
+                **model_record,
+            })
+    return records
+
+
+def run_graph_fit_comparison(graph_name, graph_label, parents, targets, root, depths=None, tail_epsilon=0.001):
+    records = []
+    hist_memo = {}
+    for target in targets:
+        try:
+            records.extend(target_fit_records(graph_name, graph_label, parents, root, target, hist_memo, tail_epsilon))
+        except ValueError as exc:
+            records.append({
+                "record_type": "distribution_fit_error",
+                "graph": graph_name,
+                "fixture": graph_label,
+                "root": root,
+                "target_node": target,
+                "error": str(exc),
+            })
+    parent_degrees = [len(parents.get(target, [])) for target in targets]
+    records.extend(depth_prior_records(graph_name, graph_label, parent_degrees, depths or DEFAULT_DEPTHS, tail_epsilon))
+    return records
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, round((pct / 100.0) * (len(ordered) - 1))))
+    return float(ordered[index])
+
+
+def summarize(records: list[dict[str, object]]) -> str:
+    fit_records = [record for record in records if record.get("record_type") == "distribution_fit"]
+    error_records = [record for record in records if record.get("record_type") == "distribution_fit_error"]
+    realized_records = [record for record in fit_records if record.get("distribution_role") == "realized_fit"]
+    prior_records = [record for record in fit_records if record.get("distribution_role") == "depth_prior"]
+    lines = [
+        "# Distribution Fit Comparison Summary",
+        "",
+        "| realized_targets | prior_depth_rows | model_rows | errors |",
+        "|------------------|---------------------|------------|--------|",
+        "| {targets} | {depth_rows} | {rows} | {errors} |".format(
+            targets=len({record["target_node"] for record in realized_records}),
+            depth_rows=len(prior_records),
+            rows=len(fit_records),
+            errors=len(error_records),
+        ),
+        "",
+        "## Realized Histogram Fits",
+        "",
+        "| model | rows | mean_l1 | p95_l1 | max_l1 | mean_cdf_error | mean_build_ns | mean_exact_hist_ns |",
+        "|-------|------|---------|--------|--------|----------------|---------------|--------------------|",
+    ]
+    append_model_table(lines, realized_records)
+    lines.extend([
+        "",
+        "## Depth-Conditioned Prior Distributions",
+        "",
+        "| model | rows | mean_l1 | p95_l1 | max_l1 | mean_cdf_error | mean_build_ns | mean_exact_hist_ns |",
+        "|-------|------|---------|--------|--------|----------------|---------------|--------------------|",
+    ])
+    append_model_table(lines, prior_records)
+
+    if prior_records:
+        lines.extend([
+            "",
+            "## Prior Support By Depth",
+            "",
+            "| depth | rows | mean_bins | mean_effective_bins | max_effective_bins | mean_excess |",
+            "|-------|------|-----------|---------------------|--------------------|-------------|",
+        ])
+        by_depth = {}
+        for record in prior_records:
+            by_depth.setdefault(record["root_distance_horizon"], []).append(record)
+        for depth in sorted(by_depth):
+            rows = by_depth[depth]
+            lines.append(
+                "| {depth} | {rows} | {mean_bins:.3f} | {mean_eff:.3f} | {max_eff} | {mean_excess:.6f} |".format(
+                    depth=depth,
+                    rows=len(rows),
+                    mean_bins=statistics.mean(int(row["support_bins"]) for row in rows),
+                    mean_eff=statistics.mean(int(row["effective_support_bins"]) for row in rows),
+                    max_eff=max(int(row["effective_support_bins"]) for row in rows),
+                    mean_excess=statistics.mean(float(row["mean_excess"]) for row in rows),
+                )
+            )
+
+    if error_records:
+        lines.extend(["", "## Errors", ""])
+        for record in error_records[:10]:
+            lines.append(f"- {record['target_node']}: {record['error']}")
+    return "\n".join(lines) + "\n"
+
+
+def append_model_table(lines: list[str], rows: list[dict[str, object]]) -> None:
+    by_model = {}
+    for record in rows:
+        by_model.setdefault(record["model"], []).append(record)
+    for model in sorted(by_model):
+        model_rows = by_model[model]
+        l1_values = [float(row["l1_error"]) for row in model_rows]
+        cdf_values = [float(row["max_cdf_error"]) for row in model_rows]
+        build_times = [int(row["build_time_ns"]) for row in model_rows]
+        exact_times = [int(row["exact_histogram_time_ns"]) for row in model_rows]
+        lines.append(
+            "| {model} | {rows} | {mean_l1:.6f} | {p95_l1:.6f} | {max_l1:.6f} | {mean_cdf:.6f} | {mean_build:.1f} | {mean_exact:.1f} |".format(
+                model=model,
+                rows=len(model_rows),
+                mean_l1=statistics.mean(l1_values) if l1_values else 0.0,
+                p95_l1=percentile(l1_values, 95),
+                max_l1=max(l1_values, default=0.0),
+                mean_cdf=statistics.mean(cdf_values) if cdf_values else 0.0,
+                mean_build=statistics.mean(build_times) if build_times else 0.0,
+                mean_exact=statistics.mean(exact_times) if exact_times else 0.0,
+            )
+        )
+
+
+def select_file_targets(parents, root, explicit_targets, targets_file, max_target_depth, target_limit):
+    if explicit_targets:
+        targets = parse_targets(explicit_targets)
+    elif targets_file:
+        targets = load_targets_file(targets_file)
+    else:
+        targets = reachable_nodes_by_parent_distance(parents, root, max_target_depth)
+    if target_limit is not None:
+        targets = targets[:target_limit]
+    if not targets:
+        raise SystemExit("no distribution-fit targets selected")
+    return targets
+
+
+def write_outputs(records, summary, output_dir, graph_name):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    safe_name = safe_graph_name(graph_name)
+    jsonl_path = output_dir / f"distribution_fit_comparison_{safe_name}_{timestamp}.jsonl"
+    summary_path = output_dir / f"distribution_fit_comparison_summary_{safe_name}_{timestamp}.md"
+    with jsonl_path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+    summary_path.write_text(summary, encoding="utf-8")
+    return jsonl_path, summary_path
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixtures", default="all", help="Comma-separated fixture names or all. Ignored when --edge-file is set.")
+    parser.add_argument("--edge-file", type=Path, help="Optional TSV edge list with child<TAB>parent rows.")
+    parser.add_argument("--graph-name", help="Graph label used in records and output filenames.")
+    parser.add_argument("--root", help="Root node. Defaults to R for fixtures and Category:Articles for edge files.")
+    parser.add_argument("--targets", help="Comma-separated target nodes for edge-file mode.")
+    parser.add_argument("--targets-file", type=Path, help="Optional newline-delimited target list for edge-file mode.")
+    parser.add_argument("--max-target-depth", type=int, help="Select reachable edge-file targets within this parent distance from root.")
+    parser.add_argument("--target-limit", type=int, help="Limit selected edge-file targets after sorting/filtering.")
+    parser.add_argument("--depths", default=",".join(map(str, DEFAULT_DEPTHS)), help="Depth horizons for prior distributions.")
+    parser.add_argument("--tail-epsilon", type=float, default=0.001, help="Tail mass allowed outside effective support.")
+    parser.add_argument("--output-dir", type=Path, help="Optional directory for JSONL and markdown output.")
+    args = parser.parse_args(argv)
+
+    depths = parse_int_list(args.depths)
+    records = []
+    if args.edge_file:
+        root = args.root or SIMPLEWIKI_ROOT
+        parents = load_parent_edges_tsv(args.edge_file)
+        graph_name = args.graph_name or args.edge_file.stem
+        targets = select_file_targets(
+            parents,
+            root,
+            args.targets,
+            args.targets_file,
+            args.max_target_depth,
+            args.target_limit,
+        )
+        records.extend(run_graph_fit_comparison(graph_name, graph_name, parents, targets, root, depths, args.tail_epsilon))
+    else:
+        root = args.root or ROOT
+        if root != ROOT:
+            raise SystemExit("--root is only supported with --edge-file; fixtures use root R")
+        fixture_names = sorted(FIXTURES) if args.fixtures == "all" else [name.strip() for name in args.fixtures.split(",")]
+        graph_name = args.graph_name or "tiny_fixture"
+        for fixture_name in fixture_names:
+            if fixture_name not in FIXTURES:
+                raise SystemExit(f"unknown fixture: {fixture_name}")
+            fixture = FIXTURES[fixture_name]
+            records.extend(run_graph_fit_comparison(graph_name, fixture_name, fixture["parents"], fixture["targets"], root, depths, args.tail_epsilon))
+
+    summary = summarize(records)
+    print(summary, end="")
+    if args.output_dir:
+        jsonl_path, summary_path = write_outputs(records, summary, args.output_dir, graph_name)
+        print(f"\nwrote {jsonl_path}")
+        print(f"wrote {summary_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_distribution_fit_comparison.py
+++ b/tests/test_distribution_fit_comparison.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Tests for distribution fit comparison helpers."""
+
+import unittest
+
+from scripts.distribution_fit_comparison import (
+    binomial_pmf,
+    convolve,
+    exact_excess_distribution,
+    depth_prior_records,
+    fitted_binomial_pmf,
+    fitted_gamma_pmf,
+    l1_error,
+    max_cdf_error,
+    nfold_convolution,
+    run_graph_fit_comparison,
+    size_biased_excess_pmf,
+    summarize,
+)
+from tools.distribution_cache_support import FIXTURES, ROOT
+
+
+class DistributionFitComparisonTests(unittest.TestCase):
+    def test_exact_excess_distribution_shifts_to_minimum_length(self):
+        distribution, origin = exact_excess_distribution({2: 2, 4: 2})
+
+        self.assertEqual(origin, 2)
+        self.assertEqual(distribution, [0.5, 0.0, 0.5])
+
+    def test_binomial_pmf_handles_bernoulli_case(self):
+        self.assertEqual(binomial_pmf(1, 0.25), [0.75, 0.25])
+
+    def test_fitted_binomial_matches_one_step_bernoulli_histogram(self):
+        model, params = fitted_binomial_pmf([0.75, 0.25])
+
+        self.assertEqual(params["trials"], 1)
+        self.assertAlmostEqual(params["probability"], 0.25)
+        self.assertLess(l1_error([0.75, 0.25], model), 1e-12)
+        self.assertLess(max_cdf_error([0.75, 0.25], model), 1e-12)
+
+    def test_fitted_gamma_degenerates_for_one_point_histogram(self):
+        model, params = fitted_gamma_pmf([1.0])
+
+        self.assertEqual(model, [1.0])
+        self.assertEqual(params["family"], "degenerate")
+
+    def test_size_biased_excess_pmf_weights_by_parent_degree(self):
+        pmf = size_biased_excess_pmf([0, 1, 2, 2])
+
+        self.assertEqual(pmf, [0.2, 0.8])
+
+    def test_nfold_convolution_matches_binomial_for_bernoulli_base(self):
+        empirical = nfold_convolution([0.75, 0.25], 2)
+
+        self.assertEqual(len(empirical), 3)
+        self.assertAlmostEqual(empirical[0], 0.5625)
+        self.assertAlmostEqual(empirical[1], 0.375)
+        self.assertAlmostEqual(empirical[2], 0.0625)
+        self.assertEqual(convolve([1.0], [0.75, 0.25]), [0.75, 0.25])
+
+    def test_depth_prior_records_report_binomial_and_gamma_models(self):
+        records = depth_prior_records(
+            "tiny_fixture",
+            "synthetic",
+            parent_degrees=[1, 1, 2],
+            depths=[2],
+            tail_epsilon=0.001,
+        )
+        models = {record["model"] for record in records}
+        roles = {record["distribution_role"] for record in records}
+
+        self.assertEqual(models, {"binomial_prior", "shifted_gamma_prior"})
+        self.assertEqual(roles, {"depth_prior"})
+        self.assertTrue(all(record["effective_support_bins"] >= 1 for record in records))
+
+    def test_fixture_comparison_reports_both_roles(self):
+        fixture = FIXTURES["shortcut_parent"]
+        records = run_graph_fit_comparison(
+            "tiny_fixture",
+            "shortcut_parent",
+            fixture["parents"],
+            fixture["targets"],
+            ROOT,
+            depths=[2],
+        )
+        fit_records = [record for record in records if record["record_type"] == "distribution_fit"]
+        realized_models = {record["model"] for record in fit_records if record["distribution_role"] == "realized_fit"}
+        prior_models = {record["model"] for record in fit_records if record["distribution_role"] == "depth_prior"}
+        summary = summarize(records)
+
+        self.assertEqual(realized_models, {"binomial_fit", "shifted_gamma_fit"})
+        self.assertEqual(prior_models, {"binomial_prior", "shifted_gamma_prior"})
+        self.assertIn("Realized Histogram Fits", summary)
+        self.assertIn("Depth-Conditioned Prior Distributions", summary)
+        self.assertIn("Prior Support By Depth", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `scripts/distribution_fit_comparison.py` to compare exact parent-path histograms against binomial and shifted-Gamma approximations.
- Separate realized histogram fits from depth-conditioned prior distributions, so cache-depth decisions use the prior while sampled exact histograms validate the family choice.
- Document the prior-vs-fit distinction in the distributional fit policy and parent-branching theory notes.
- Add focused tests for PMF helpers, size-biased excess priors, convolution, and summary output.

## Validation

- `python3 -m unittest tests/test_distribution_fit_comparison.py tests/test_distribution_cache_support_bounds.py tests/test_distribution_cache_benchmark.py tests/test_distribution_cache_parity.py tests/test_distribution_cache_subtree_sampler.py tests/test_export_distribution_cache_edges.py`
- `python3 scripts/distribution_fit_comparison.py --fixtures shortcut_parent --depths 2,4 --tail-epsilon 0.001`
- `git diff --check --cached`