### PR TITLE
feat(wam): gated T6 for int-interned targets (Haskell/Scala/Lua); LLVM declined on benchmark

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -95,15 +95,15 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 
 | Target  | T1 det | T2 ITE | T3 mc-1 | T4 mc-n | T5 mc→`->` | T6 idx | T7 par | T8 kernels | T9 facts | T10 mode | T11 LCO |
 |---------|:------:|:------:|:-------:|:-------:|:----------:|:------:|:------:|:----------:|:--------:|:--------:|:-------:|
-| scala   | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ |
+| scala   | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✓ | ✗ | ✗ |
 | rust    | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✗ | ✗ | ✗ |
 | cpp     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✗ | ✗ | ✗ | ✗ |
 | go      | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✗ | ✗ | ✗ |
-| haskell | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ |
+| haskell | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✓ | ✗ | ✗ |
 | fsharp  | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ~ | ✗ | ✗ | ✗ |
 | clojure | ✓ | ✓ T2a | ✓ | ✓ | ✗ | ✗ | ~ | ~ | ✗ | ✗ | ✗ |
 | llvm    | ✓ | ✓ T2a | ✓ (c1) | ✓ | ✓ | ✗ | ✗ | ~ | ✗ | ✗ | ~ |
-| lua     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ |
+| lua     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✗ | ✓ | ✗ | ✗ |
 | python  | ✓ | ✓ T2a | ✓ | `~` hybrid | ✓ | ✗ | ~ | ~ | ✗ | ✗ | ✗ |
 | r       | ✓ | ✓ T2a | ✓ | **✓** | ✗ | ✗ | ✗ | ~ | ✓ | **✓** | ✗ |
 | elixir  | ✓ | ✓ T2b | ✓ | ✓ | ✗ | ✗ | **✓** | ✓ | ✓ | ✗ | ✗ |
@@ -216,9 +216,9 @@ Reading down the columns (after the T5 and T4 sweeps landed):
   argument-register + trail snapshot/restore between attempts, first-solution).
   So **every multi-clause column (T3/T4/T5) is now closed** across the targets
   that support each shape — no plain ✗ remains in T3/T4/T5.
-- **T6 (first-arg indexing)** — **Rust, C++ and Go** now have a *gated* T6
-  (`~`): all reuse the T5 `wam_clause_chain` front-end, but when the
-  discriminators are all atoms and there are ≥ `t6_min_clauses` of them
+- **T6 (first-arg indexing)** — **Rust, C++, Go, Haskell, Scala and Lua** now
+  have a *gated* T6 (`~`): all reuse the T5 `wam_clause_chain` front-end, but
+  when the discriminators are all atoms and there are ≥ `t6_min_clauses` of them
   (default 8) the back-end replaces the if-cascade with a native indexed
   dispatch — Rust a two-stage `match` (string switch → integer jump table);
   C++ a static `std::unordered_map<std::string,int>` (no native string switch)
@@ -236,10 +236,19 @@ Reading down the columns (after the T5 and T4 sweeps landed):
   interface-call chain the compiler does not rewrite, so the switch wins big.
   The compiler flattens the cascade for few clauses, hence the gate. NOTE: Go
   was previously mislabelled int-interned — its atoms are `&Atom{Name string}`
-  interned by name, i.e. string-keyed. The genuinely **int-interned** remaining
-  targets (llvm/haskell/scala/lua — atoms become integers at codegen) carry the
-  highest "lost to the compiler" risk (an int-equality chain the host compiler
-  switch-converts anyway), so each needs a per-target benchmark before shipping.
+  interned by name, i.e. string-keyed.
+  The genuinely **int-interned** targets (haskell/scala/lua/llvm — atoms become
+  integers at codegen) were the "lost to the compiler" question; each was
+  benchmarked (`docs/reports/wam_int_interned_t6_perf.md`). Verdict: **haskell,
+  scala and lua now have a gated T6 too** — a `case` on the interned id (GHC →
+  jump table), a `match` on it (scalac → JVM `tableswitch`), and a hash table of
+  per-clause closures built once (interpreted Lua). Measured wins: Lua 1.7×/8.2×/
+  29.7×, Haskell 1.4×/2.5×/4.5×, Scala 1.3×/3.1×/≫ at N=8/64/256. **LLVM
+  declines on benchmark evidence**: at `-O2`, SimplifyCFG already turns an
+  int-equality if-chain into a `switch` (the if-chain and an explicit switch
+  compile to identical assembly), so an explicit T6 there is redundant — the one
+  genuine "lost to the compiler" case. So every T5 target now either has a gated
+  T6 or a measured reason not to.
 - **T2 (ITE)** — now **complete across every target**, including WAT: the
   lowered emitter folds the soft-cut block with the shared `wam_ite_structurer`
   and emits native WAT (`(block $ite_condK (result i32) …)` for the condition
@@ -313,7 +322,12 @@ Score each candidate gap on four axes, then sequence:
    could layer in front later). Remaining structurer-column hole: none — only
    **wat** lacks T4 now (its runtime has no lowered multi-clause path yet).
 4. **T6 (first-arg indexing)** — same clause-head front-end as T5 with a
-   `switch` back-end instead of an `->` cascade.
+   `switch` back-end instead of an `->` cascade. **DONE / closed out:** gated
+   T6 ships for every T5 target whose host dispatch benefits — the atom-keyed
+   set (rust/cpp/fsharp/go, string switch) and the int-interned set that wins
+   (haskell/scala/lua). **llvm declines** on benchmark evidence (its `-O2`
+   already converts the int if-chain to a switch). See
+   `docs/reports/wam_int_interned_t6_perf.md`.
 5. Treat **T7/T10/T11** as research spikes (one target each) before any
    sweep.
 

--- a/docs/reports/wam_int_interned_t6_perf.md
+++ b/docs/reports/wam_int_interned_t6_perf.md
@@ -1,0 +1,59 @@
+# T6 first-argument indexing for the int-interned WAM targets
+
+The atom-keyed targets (Rust/C++/F#/Go) compare the first-argument discriminator
+as a **string**, so a string switch/map is an obvious win. The remaining T5
+targets — **Lua, Haskell, Scala, LLVM** — are **int-interned**: an atom becomes
+an integer id at codegen, so the T5 dispatch is an *integer*-equality chain. The
+open question (the "lost to the compiler" risk) was whether the host compiler
+already turns that chain into a jump table, making an explicit T6 switch
+redundant.
+
+This report records the triage micro-benchmarks that answered it, and the
+verdict per target. Each measurement is the average dispatch cost over **all N
+keys plus one miss** (the T5 chain's worst case is the last clause / the miss).
+
+## Method
+
+For each target, two functions are generated for a predicate with **N** distinct
+single-atom clauses and timed in a tight loop:
+
+- **T5** — the linear discriminator chain (`v == Atom n` / `t5a1.id == n` / …).
+- **T6** — a native indexed dispatch on the interned id (host `switch` /
+  `case` / `match` / hash table).
+
+Tools: `lua` (5.4), `ghc -O2`, `scalac` + `java`, `clang -O2` / `opt`.
+
+## Results (ns/op, lower is better)
+
+| Target  | N=8        | N=64        | N=256        | T6 form |
+|---------|-----------:|------------:|-------------:|---------|
+| **Lua**     | 1.7× | 8.2×  | 29.7× | hash table of per-clause closures (built once) |
+| **Haskell** | 1.4× | 2.5×  | 4.5×  | `case` on the interned id (GHC jump table) |
+| **Scala**   | 1.3× | 3.1×  | ≫ (alloc/JIT-inflated) | `match` on the id → JVM `tableswitch` |
+| **LLVM**    |  —   |  —    |  —    | **declined** — see below |
+
+(Lua: 102.7→59.6, 482→58.8, 1822→61.3 ns. Haskell: 10.4→7.6, 24.9→9.9, 85.3→19.0.
+Scala: 9.08→7.12, 24.7→8.02, 6619→18.0 — the case-class `==` cascade both
+allocates an `Atom(n)` per comparison and grows linearly, and the giant 256-way
+method is past HotSpot's inlining/compile thresholds; the `tableswitch` is O(1).)
+
+## Verdict
+
+- **Lua, Haskell, Scala — implemented** (gated T6, default `t6_min_clauses=8`).
+  All three show a real, growing win; none is "lost to the compiler":
+  - **Lua** is interpreted, so there is no optimiser to recover the table — the
+    linear chain stays linear. Biggest win.
+  - **Haskell**'s guard chain is only partly optimised; GHC compiles a dense
+    `case` on `Int#` to a jump table, so the explicit `case` still wins.
+  - **Scala**'s `==` cascade allocates per comparison and is not rewritten to a
+    `tableswitch`; the explicit `match` is.
+- **LLVM — declined.** At `-O2`, clang/LLVM's SimplifyCFG already converts an
+  int-equality if-chain into a `switch`: the if-chain and an explicit switch
+  compile to **identical** assembly. An explicit T6 switch in the generated IR
+  would be redundant — the genuine "lost to the compiler" case the matrix warned
+  about. (If the LLVM target ever emits unoptimised IR for the lowered path, T6
+  would help there; under the standard optimised pipeline it does not.)
+
+So **3 of the 4 int-interned targets keep a gated T6; LLVM declines on
+benchmark evidence.** Combined with the atom-keyed set (Rust/C++/F#/Go), every
+T5 target now either has a gated T6 or has a benchmark-backed reason not to.

--- a/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_haskell_lowered_emitter.pl
@@ -207,7 +207,7 @@ lower_predicate_to_haskell(PI, WamCode, Opts, lowered(PredName, FuncName, Code))
     offset_pcs(PCInstrs, Offset, GlobalPCInstrs),
     offset_labels(LabelMap, Offset, GlobalLabelMap),
     with_output_to(string(Code),
-        emit_func(FuncName, GlobalPCInstrs, GlobalLabelMap, ForeignPreds)).
+        emit_func(FuncName, GlobalPCInstrs, GlobalLabelMap, ForeignPreds, Opts)).
 
 offset_pcs([], _, []).
 offset_pcs([pc(PC, I)|Rest], Off, [pc(GPC, I)|Rest2]) :-
@@ -219,13 +219,13 @@ offset_labels([L-PC|Rest], Off, [L-GPC|Rest2]) :-
     GPC is PC + Off,
     offset_labels(Rest, Off, Rest2).
 
-emit_func(FN, PCInstrs, LabelMap, ForeignPreds) :-
+emit_func(FN, PCInstrs, LabelMap, ForeignPreds, Opts) :-
     format("-- | Lowered: ~w~n", [FN]),
     format("~w :: WamContext -> WamState -> Maybe WamState~n", [FN]),
     % Skip switch_on_constant* prefixes before deciding multi/single-clause.
     strip_switch_prefixes(PCInstrs, PCInstrs1),
-    (   emit_func_t5(FN, PCInstrs1, LabelMap, ForeignPreds)
-    ->  true   % T5 first-argument dispatch (all clauses lowered natively)
+    (   emit_func_t5(FN, PCInstrs1, LabelMap, ForeignPreds, Opts)
+    ->  true   % T5/T6 first-argument dispatch (all clauses lowered natively)
     ;   emit_func_t4(FN, PCInstrs1, LabelMap, ForeignPreds)
     ->  true   % T4 all-clauses inline (every clause native, no interpreter hop)
     ;   PCInstrs1 = [pc(_, try_me_else(LStr))|BodyPCs]
@@ -282,7 +282,7 @@ take_to_proceed_pc([H|T], [H|R]) :- take_to_proceed_pc(T, R).
 %  predicate is not a distinct-first-argument constant chain. All checks run
 %  before any output so a failure leaves the stream untouched for the caller's
 %  fallback emission.
-emit_func_t5(FN, PCInstrs1, LabelMap, FP) :-
+emit_func_t5(FN, PCInstrs1, LabelMap, FP, Opts) :-
     PCInstrs1 = [pc(_, try_me_else(L2Str))|_],
     maplist(t5_strip_pc, PCInstrs1, PlainInstrs),
     clause_chain(PlainInstrs, chain(_Guards)),
@@ -290,16 +290,32 @@ emit_func_t5(FN, PCInstrs1, LabelMap, FP) :-
     Slices = [_, _ | _],
     forall(( member(Sl, Slices), member(pc(_, I), Sl) ), supported(I)),
     maplist(t5_slice_discriminator, Slices, Discrs),
+    maplist(t5_slice_discr_token, Slices, Tokens),
     % All checks passed — emit.
     atom_string(L2Atom, L2Str),
     ( member(L2Atom-AltPC, LabelMap) -> true ; AltPC = 0 ),
     format("~w !ctx s_init =~n", [FN]),
-    format("  case derefVar (wsBindings s_init) <$> IM.lookup 1 (wsRegs s_init) of~n"),
-    format("    Just (Unbound _) -> t5fallback~n"),
-    format("    Just v~n"),
-    t5_emit_dispatch_guards(Discrs, 1),
-    format("      | otherwise -> Nothing~n"),
-    format("    _ -> t5fallback~n"),
+    % T6 first-argument indexing: when the discriminators are all atoms and
+    % there are enough of them, dispatch with a `case` on the interned atom id
+    % (GHC compiles a dense Int case to a jump table) instead of the linear
+    % `v == Atom n` guard chain. Gated like Rust/C++/F#/Go.
+    (   hs_t6_applicable(Tokens, Opts)
+    ->  format("  -- T6 first-argument indexing (case on interned atom id)~n"),
+        format("  case derefVar (wsBindings s_init) <$> IM.lookup 1 (wsRegs s_init) of~n"),
+        format("    Just (Unbound _) -> t5fallback~n"),
+        format("    Just (Atom t6i) ->~n"),
+        format("      case t6i of~n"),
+        hs_emit_t6_arms(Tokens, 1),
+        format("        _ -> Nothing~n"),
+        format("    Just _ -> Nothing~n"),
+        format("    _ -> t5fallback~n")
+    ;   format("  case derefVar (wsBindings s_init) <$> IM.lookup 1 (wsRegs s_init) of~n"),
+        format("    Just (Unbound _) -> t5fallback~n"),
+        format("    Just v~n"),
+        t5_emit_dispatch_guards(Discrs, 1),
+        format("      | otherwise -> Nothing~n"),
+        format("    _ -> t5fallback~n")
+    ),
     format("  where~n"),
     % Interpreter fallback for the unbound/unset first-argument case: push a
     % choice point at clause 2's label, try clause 1 natively, and on failure
@@ -357,6 +373,37 @@ t5_emit_dispatch_guards([HC|Rest], N) :-
     format("      | v == (~w) -> t5clause_~w s_init~n", [HC, N]),
     N1 is N + 1,
     t5_emit_dispatch_guards(Rest, N1).
+
+%% t5_slice_discr_token(+Slice, -VStr) — the raw first-arg constant token.
+t5_slice_discr_token([pc(_, get_constant(VStr, _A1))|_], VStr).
+
+%% hs_t6_applicable(+Tokens, +Opts) is semidet.
+%  Every discriminator is an atom (val_hs renders it `Atom <id>`) and there are
+%  at least t6_min_clauses of them (default 8).
+hs_t6_applicable(Tokens, Opts) :-
+    hs_t6_min_clauses(Opts, Min),
+    length(Tokens, N), N >= Min,
+    forall(member(T, Tokens), hs_atom_id(T, _)).
+
+hs_t6_min_clauses(Opts, N) :-
+    ( member(t6_min_clauses(N), Opts) -> true ; N = 8 ).
+
+%% hs_atom_id(+VStr, -Id) is semidet.
+%  The interned integer atom id, recovered from val_hs's `Atom <id>` rendering
+%  (succeeds only for atoms — integers/floats render Integer/Float). Ties the
+%  T6 case key to the exact same id the T5 guard would compare against.
+hs_atom_id(VStr, Id) :-
+    val_hs(VStr, Hs),
+    atom_concat('Atom ', IdAtom, Hs),
+    atom_number(IdAtom, Id).
+
+%% hs_emit_t6_arms(+Tokens, +Index) — `<id> -> t5clause_N s_init` per clause.
+hs_emit_t6_arms([], _).
+hs_emit_t6_arms([T|Rest], N) :-
+    hs_atom_id(T, Id),
+    format("        ~w -> t5clause_~w s_init~n", [Id, N]),
+    N1 is N + 1,
+    hs_emit_t6_arms(Rest, N1).
 
 %% t5_emit_clause_defs(+Slices, +Index, +LabelMap, +FP)
 t5_emit_clause_defs([], _, _, _).

--- a/src/unifyweaver/targets/wam_lua_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_lua_lowered_emitter.pl
@@ -263,7 +263,7 @@ lua_safe_code(C, C) :-
     (C >= 0'a, C =< 0'z ; C >= 0'A, C =< 0'Z ; C >= 0'0, C =< 0'9 ; C =:= 0'_), !.
 lua_safe_code(_, 0'_).
 
-lower_predicate_to_lua(PI, WamCode, _Options, lowered(PredName, FuncName, Code)) :-
+lower_predicate_to_lua(PI, WamCode, Options, lowered(PredName, FuncName, Code)) :-
     (PI = _M:Pred/Arity -> true ; PI = Pred/Arity),
     format(atom(PredName), '~w/~w', [Pred, Arity]),
     lua_lowered_func_name(Pred/Arity, FuncName),
@@ -274,7 +274,7 @@ lower_predicate_to_lua(PI, WamCode, _Options, lowered(PredName, FuncName, Code))
     ->  emit_ite_function(PredName, FuncName, Payload, Code)
     ;   Mode == clause_chain
     ->  Payload = chain_payload(Guards, Clause1Lines),
-        emit_clause_chain_function(PredName, FuncName, AltLabel, Guards, Clause1Lines, Code)
+        emit_clause_chain_function(PredName, FuncName, AltLabel, Guards, Clause1Lines, Options, Code)
     ;   Mode == multi_clause_n
     ->  emit_multi_clause_n_function(PredName, FuncName, Payload, Code)
     ;   emit_multi_clause_function(PredName, FuncName, AltLabel, Payload, Code)
@@ -390,7 +390,50 @@ end
 % nondeterministic, so it falls back to the multi_clause_1 path (clause 1
 % inline + array fallback from the clause-2 label), which enumerates every
 % clause exactly as before.
-emit_clause_chain_function(PredName, FuncName, AltLabel, Guards, Clause1Lines, Code) :-
+emit_clause_chain_function(PredName, FuncName, AltLabel, Guards, Clause1Lines, Options, Code) :-
+    lua_t6_applicable(Guards, Options), !,
+    % T6 first-argument indexing: dispatch a bound atom through a hash table keyed
+    % by the interned atom id (built ONCE at module load inside the `do` block,
+    % so there is no per-call allocation) instead of the linear if-cascade.
+    with_output_to(string(Table), lua_emit_t6_table(Guards, "    ")),
+    with_output_to(string(Clause1Body), emit_lines(Clause1Lines, "      ")),
+    wam_lua_target:lua_string_literal(AltLabel, AltQ),
+    format(string(Code),
+'-- Lowered: ~w (T6 first-argument indexing)
+local ~w
+do
+  local _t6 = {
+~w  }
+  ~w = function(program, state)
+    local t5a1 = Runtime.deref(state, Runtime.get_reg(state, 1))
+    if type(t5a1) == "table" and t5a1.tag == "atom" then
+      local _f = _t6[t5a1.id]
+      if _f ~~= nil then return _f(program, state) end
+      return false
+    end
+    if type(t5a1) == "table" and t5a1.tag ~~= "unbound" then return false end
+    -- unbound first argument: enumerate all clauses via the interpreter
+    local alt_pc = program.labels[~w]
+    if alt_pc == nil then return false end
+    table.insert(state.cps, {
+      next_pc = alt_pc,
+      regs = Runtime.copy_table(state.regs),
+      cp = state.cp,
+      trail_len = #state.trail,
+      var_counter = state.var_counter
+    })
+    local ok = (function()
+~w      return false
+    end)()
+    if ok == true then return true end
+    if Runtime.backtrack(state) ~~= true then return false end
+    state.pc = state.pc + 1
+    state.halt = false
+    return Runtime.run(program, state) == true
+  end
+end
+', [PredName, FuncName, Table, FuncName, AltQ, Clause1Body]).
+emit_clause_chain_function(PredName, FuncName, AltLabel, Guards, Clause1Lines, _Options, Code) :-
     with_output_to(string(Dispatch), lua_emit_chain_guards(Guards, "    ")),
     with_output_to(string(Clause1Body), emit_lines(Clause1Lines, "    ")),
     wam_lua_target:lua_string_literal(AltLabel, AltQ),
@@ -421,6 +464,33 @@ local function ~w(program, state)
   return Runtime.run(program, state) == true
 end
 ', [PredName, FuncName, Dispatch, AltQ, Clause1Body]).
+
+%% lua_t6_applicable(+Guards, +Options) is semidet.
+lua_t6_applicable(Guards, Options) :-
+    lua_t6_min_clauses(Options, Min),
+    length(Guards, N), N >= Min,
+    forall(member(guard(V, _), Guards), lua_t6_atom_id(V, _)).
+
+lua_t6_min_clauses(Options, N) :-
+    ( member(t6_min_clauses(N), Options) -> true ; N = 8 ).
+
+%% lua_t6_atom_id(+V, -Id) is semidet — the interned atom id (atoms only).
+lua_t6_atom_id(V, Id) :-
+    wam_classify_constant_token(V, atom(Name)),
+    wam_lua_target:intern_lua_atom(Name, Id).
+
+%% lua_emit_t6_table(+Guards, +Indent) — one `[id] = function(program, state) … end`
+%  per clause; the remainder self-terminates (proceed → return true, a failed
+%  head match → return false).
+lua_emit_t6_table([], _).
+lua_emit_t6_table([guard(V, Rem)|Rest], Ind) :-
+    lua_t6_atom_id(V, Id),
+    format("~w[~w] = function(program, state)~n", [Ind, Id]),
+    string_concat(Ind, "  ", Ind2),
+    lua_emit_chain_rem(Rem, Ind2),
+    format("~w  return false~n", [Ind]),
+    format("~wend,~n", [Ind]),
+    lua_emit_t6_table(Rest, Ind).
 
 lua_emit_chain_guards([], _).
 lua_emit_chain_guards([guard(V, Rem)|Rest], Ind) :-

--- a/src/unifyweaver/targets/wam_scala_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_scala_lowered_emitter.pl
@@ -435,7 +435,7 @@ lower_predicate_to_scala(PI, WamCode, Options, lowered(PredName, FuncName, Code)
     (   MultiClause == true,
         scala_clause_chain_lowerable(Instrs, Guards)
     ->  with_output_to(string(Code),
-            emit_clause_chain_scala(FuncName, Guards, ForeignKeys))
+            emit_clause_chain_scala(FuncName, Guards, ForeignKeys, Options))
     ;   MultiClause == true,
         is_deterministic_pred_scala(C1),
         forall(member(I, C1), scala_supported(I)),
@@ -503,18 +503,70 @@ emit_clause_dispatch_scala([_ | Rest], N) :-
 %  bound value against each clause's distinct discriminator and running that
 %  clause's remainder. A bound value matching no clause returns false (the
 %  predicate fails; the wrapper's fresh re-run also fails — sound).
-emit_clause_chain_scala(FuncName, Guards, FK) :-
+emit_clause_chain_scala(FuncName, Guards, FK, Options) :-
     nb_setval(scala_ite_ctr, 0),
-    format("  /** ~w — T5 first-argument dispatch (generated); entry wrapper handles the unbound-A1 fallback. */~n", [FuncName]),
+    % T6 first-argument indexing: when the discriminators are all atoms and there
+    % are enough of them, dispatch with a `match` on the interned atom id (which
+    % scalac compiles to a JVM `tableswitch`) instead of the linear `==` cascade.
+    ( scala_t6_applicable(Guards, Options)
+    ->  TagComment = 'T6 first-argument indexing (match on interned atom id)'
+    ;   TagComment = 'T5 first-argument dispatch' ),
+    format("  /** ~w — ~w (generated); entry wrapper handles the unbound-A1 fallback. */~n", [FuncName, TagComment]),
     format("  def ~w(s: WamState, program: WamProgram): Boolean = {~n", [FuncName]),
     format("    val t5a1 = WamRuntime.deref(s.bindings, WamRuntime.getReg(s, 1))~n", []),
     format("    t5a1 match {~n", []),
     format("      case Ref(_) => return false  // unbound first arg: defer to interpreter (enumerates all clauses)~n", []),
     format("      case _ => ()~n", []),
     format("    }~n", []),
-    emit_guards_scala(Guards, FK),
+    (   scala_t6_applicable(Guards, Options)
+    ->  emit_t6_match_scala(Guards, FK)
+    ;   emit_guards_scala(Guards, FK)
+    ),
     format("    false~n", []),
     format("  }~n", []).
+
+%% scala_t6_applicable(+Guards, +Options) is semidet.
+scala_t6_applicable(Guards, Options) :-
+    scala_t6_min_clauses(Options, Min),
+    length(Guards, N), N >= Min,
+    forall(member(guard(V, _), Guards), scala_t6_atom_id(V, _)).
+
+scala_t6_min_clauses(Options, N) :-
+    ( member(t6_min_clauses(N), Options) -> true ; N = 8 ).
+
+%% scala_t6_atom_id(+V, -Id) is semidet.
+%  The interned atom id, recovered from scala_lowered_constant_term's `Atom(id)`
+%  rendering (succeeds only for atoms), so the T6 case key is exactly the id the
+%  T5 cascade would compare against.
+scala_t6_atom_id(V, Id) :-
+    scala_lowered_constant_term(V, Term),
+    ( atom(Term) -> TermA = Term ; atom_string(TermA, Term) ),
+    atom_concat('Atom(', Rest, TermA),
+    atom_concat(IdA, ')', Rest),
+    atom_number(IdA, Id).
+
+%% emit_t6_match_scala(+Guards, +FK) — nested match: extract the atom id, then a
+%  tableswitch over the per-clause ids into each clause's remainder.
+emit_t6_match_scala(Guards, FK) :-
+    format("    t5a1 match {~n", []),
+    format("      case Atom(t6i) => t6i match {~n", []),
+    emit_t6_cases_scala(Guards, FK),
+    format("        case _ => ()~n", []),
+    format("      }~n", []),
+    format("      case _ => ()~n", []),
+    format("    }~n", []).
+
+emit_t6_cases_scala([], _).
+emit_t6_cases_scala([guard(V, Rem) | Rest], FK) :-
+    scala_t6_atom_id(V, Id),
+    format("        case ~w => {~n", [Id]),
+    emit_body_scala(Rem, "          ", FK),
+    (   body_falls_through(Rem)
+    ->  format("          return true~n", [])
+    ;   true
+    ),
+    format("        }~n", []),
+    emit_t6_cases_scala(Rest, FK).
 
 emit_guards_scala([], _).
 emit_guards_scala([guard(V, Rem) | Rest], FK) :-

--- a/tests/test_wam_haskell_lowered_t6.pl
+++ b/tests/test_wam_haskell_lowered_t6.pl
@@ -1,0 +1,137 @@
+% test_wam_haskell_lowered_t6.pl
+%
+% End-to-end test for the Haskell T6 lowering — first-argument indexing via a
+% `case` on the interned atom id (GHC compiles a dense Int case to a jump
+% table), lowering type T6 in docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md.
+%
+% Haskell is int-interned: atoms render as `Atom <id>` (val_hs), so the T5 guard
+% chain compares `v == Atom n`. T6 replaces that linear chain with a single
+% `case t6i of n -> clauseK`. Benchmarked 1.4x at 8, 2.5x at 64, 4.5x at 256
+% (GHC -O2; the guard chain is partly optimised but the Int case still wins).
+%
+% Gated like Rust/C++/F#/Go: T6 fires only when every clause discriminates on a
+% distinct ATOM and there are >= t6_min_clauses of them (default 8). Below the
+% threshold the few-clause predicate stays the T5 guard chain.
+%
+% Skipped automatically when `ghc` is not on PATH.
+
+:- use_module(library(lists)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_haskell_target').
+:- use_module('../src/unifyweaver/targets/wam_haskell_lowered_emitter').
+
+:- dynamic user:shade/1, user:grade/2, user:few/1.
+
+user:shade(s01). user:shade(s02). user:shade(s03). user:shade(s04).
+user:shade(s05). user:shade(s06). user:shade(s07). user:shade(s08).
+user:shade(s09). user:shade(s10).
+
+user:grade(g01, R) :- R is 1 + 0.
+user:grade(g02, R) :- R is 1 + 1.
+user:grade(g03, R) :- R is 1 + 2.
+user:grade(g04, R) :- R is 1 + 3.
+user:grade(g05, R) :- R is 1 + 4.
+user:grade(g06, R) :- R is 1 + 5.
+user:grade(g07, R) :- R is 1 + 6.
+user:grade(g08, R) :- R is 1 + 7.
+user:grade(g09, R) :- R is 1 + 8.
+user:grade(g10, R) :- R is 1 + 9.
+
+user:few(a). user:few(b). user:few(c).
+
+ghc_available :-
+    catch(( process_create(path(ghc), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_haskell_lowered_t6, [condition(ghc_available)]).
+
+% Codegen gate: the many-clause atom predicates emit the case-on-id (T6); the
+% few-clause one stays the guard chain (T5). Threshold is configurable.
+test(gate_picks_t6_for_many_t5_for_few) :-
+    wam_target:compile_predicate_to_wam(shade/1, [], Ws),
+    lower_predicate_to_haskell(shade/1, Ws, [], lowered(_, _, ShadeCode)),
+    assertion(sub_string(ShadeCode, _, _, _, "T6 first-argument indexing")),
+    assertion(sub_string(ShadeCode, _, _, _, "case t6i of")),
+    wam_target:compile_predicate_to_wam(grade/2, [], Wg),
+    lower_predicate_to_haskell(grade/2, Wg, [], lowered(_, _, GradeCode)),
+    assertion(sub_string(GradeCode, _, _, _, "T6 first-argument indexing")),
+    wam_target:compile_predicate_to_wam(few/1, [], Wf),
+    lower_predicate_to_haskell(few/1, Wf, [], lowered(_, _, FewCode)),
+    assertion(\+ sub_string(FewCode, _, _, _, "T6 first-argument indexing")),
+    lower_predicate_to_haskell(few/1, Wf, [t6_min_clauses(3)], lowered(_, _, FewT6)),
+    assertion(sub_string(FewT6, _, _, _, "T6 first-argument indexing")).
+
+% Build + run: the T6 case dispatch returns the Prolog-correct result for clause
+% hits (incl. non-first clauses), no-match, and a grade remainder mismatch.
+test(t6_exec) :-
+    Dir = 'output/test_wam_haskell_t6_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_haskell_project(
+        [user:shade/1, user:grade/2, user:few/1],
+        [module_name('t6proj'), emit_mode(functions)], Dir),
+    atomic_list_concat([Dir, '/src/Lowered.hs'], LoweredPath),
+    read_file_to_string(LoweredPath, LSrc, []),
+    assertion(sub_string(LSrc, _, _, _, "T6 first-argument indexing")),
+    atomic_list_concat([Dir, '/src/TestMain.hs'], TestPath),
+    haskell_t6_source(Src),
+    setup_call_cleanup(open(TestPath, write, S, [encoding(utf8)]), write(S, Src), close(S)),
+    atomic_list_concat([Dir, '/src'], SrcDir),
+    atomic_list_concat([Dir, '/t6_test'], Bin),
+    format(atom(Cmd),
+        'ghc --make -i~w ~w/TestMain.hs -o ~w -main-is Main 2>&1 && ~w',
+        [SrcDir, SrcDir, Bin, Bin]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 11 PASS")
+    ->  true
+    ;   format(user_error, "~n[haskell t6 test output]~n~w~n", [OutStr]),
+        throw(haskell_t6_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_haskell_lowered_t6).
+
+haskell_t6_source(
+"module Main where
+import qualified Data.HashMap.Strict as Map
+import qualified Data.IntMap.Strict as IM
+import WamTypes
+import WamRuntime ()
+import Lowered
+import Predicates (compileTimeAtomTable)
+
+runP :: (WamContext -> WamState -> Maybe WamState) -> [(Int, Value)] -> Bool
+runP f regs =
+  let ctx = (mkContext [] Map.empty)
+              { wcLoweredPredicates = loweredPredicates
+              , wcInternTable = compileTimeAtomTable }
+      s0  = emptyState { wsRegs = IM.fromList regs }
+  in case f ctx s0 of { Just _ -> True; Nothing -> False }
+
+i :: Int -> Value
+i = Integer . fromIntegral
+a :: String -> Value
+a s = Atom (internAtomPure compileTimeAtomTable s)
+
+main :: IO ()
+main = do
+  let cases =
+        [ (\"shade(s01)\", runP lowered_shade_1 [(1,a \"s01\")], True)
+        , (\"shade(s05)\", runP lowered_shade_1 [(1,a \"s05\")], True)
+        , (\"shade(s10)\", runP lowered_shade_1 [(1,a \"s10\")], True)
+        , (\"shade(zz)\", runP lowered_shade_1 [(1,a \"zz\")], False)
+        , (\"grade(g01,1)\", runP lowered_grade_2 [(1,a \"g01\"),(2,i 1)], True)
+        , (\"grade(g05,5)\", runP lowered_grade_2 [(1,a \"g05\"),(2,i 5)], True)
+        , (\"grade(g10,10)\", runP lowered_grade_2 [(1,a \"g10\"),(2,i 10)], True)
+        , (\"grade(g05,9)\", runP lowered_grade_2 [(1,a \"g05\"),(2,i 9)], False)
+        , (\"grade(zz,1)\", runP lowered_grade_2 [(1,a \"zz\"),(2,i 1)], False)
+        , (\"few(b)\", runP lowered_few_1 [(1,a \"b\")], True)
+        , (\"few(z)\", runP lowered_few_1 [(1,a \"z\")], False)
+        ]
+      fails = [ n | (n,got,want) <- cases, got /= want ]
+  mapM_ (\\(n,got,want) -> if got/=want then putStrLn (\"FAIL \" ++ n ++ \": got \" ++ show got ++ \" want \" ++ show want) else return ()) cases
+  if null fails then putStrLn (\"ALL \" ++ show (length cases) ++ \" PASS\") else putStrLn (show (length fails) ++ \" FAILURES\")
+").

--- a/tests/test_wam_lua_lowered_t6.pl
+++ b/tests/test_wam_lua_lowered_t6.pl
@@ -1,0 +1,119 @@
+% test_wam_lua_lowered_t6.pl
+%
+% End-to-end test for the Lua T6 lowering — first-argument indexing via a hash
+% table keyed by the interned atom id, lowering type T6 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md.
+%
+% Lua is int-interned: an atom is {tag="atom", id=<int>}, so the T5 cascade is
+% `if t5a1.tag=="atom" and t5a1.id==n then …`. T6 replaces the linear cascade
+% with a dispatch table `_t6[t5a1.id]` of per-clause closures, built ONCE at
+% module load inside a `do` block (no per-call allocation). Benchmarked 1.7x at
+% 8, 8.2x at 64, 29.7x at 256 (interpreted Lua: the table lookup is O(1), the
+% if-cascade O(n)).
+%
+% Gated like Rust/C++/F#/Go: T6 fires only when every clause discriminates on a
+% distinct ATOM and there are >= t6_min_clauses of them (default 8). Below the
+% threshold the few-clause predicate stays the T5 cascade.
+%
+% Skipped automatically when no lua interpreter is on PATH.
+
+:- use_module(library(lists)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_lua_target').
+:- use_module('../src/unifyweaver/targets/wam_lua_lowered_emitter').
+
+:- dynamic user:shade/1, user:grade/2, user:few/1.
+
+user:shade(s01). user:shade(s02). user:shade(s03). user:shade(s04).
+user:shade(s05). user:shade(s06). user:shade(s07). user:shade(s08).
+user:shade(s09). user:shade(s10).
+
+user:grade(g01, R) :- R is 1 + 0.
+user:grade(g02, R) :- R is 1 + 1.
+user:grade(g03, R) :- R is 1 + 2.
+user:grade(g04, R) :- R is 1 + 3.
+user:grade(g05, R) :- R is 1 + 4.
+user:grade(g06, R) :- R is 1 + 5.
+user:grade(g07, R) :- R is 1 + 6.
+user:grade(g08, R) :- R is 1 + 7.
+user:grade(g09, R) :- R is 1 + 8.
+user:grade(g10, R) :- R is 1 + 9.
+
+user:few(a). user:few(b). user:few(c).
+
+lua_interpreter(Exe) :-
+    member(Exe, ['lua5.4', 'lua5.3', 'lua', 'luajit']),
+    catch(( process_create(path(Exe), ['-v'], [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, _) ), _, fail), !.
+
+:- begin_tests(wam_lua_lowered_t6, [condition(lua_interpreter(_))]).
+
+% Codegen gate: shade/grade (>=8 atoms) emit the table dispatch (T6); few stays
+% the cascade (T5). Threshold configurable.
+test(gate_picks_t6_for_many_t5_for_few) :-
+    wam_target:compile_predicate_to_wam(shade/1, [], Ws),
+    lower_predicate_to_lua(shade/1, Ws, [], lowered(_, _, ShadeCode)),
+    assertion(sub_string(ShadeCode, _, _, _, "T6 first-argument indexing")),
+    assertion(sub_string(ShadeCode, _, _, _, "_t6[t5a1.id]")),
+    wam_target:compile_predicate_to_wam(grade/2, [], Wg),
+    lower_predicate_to_lua(grade/2, Wg, [], lowered(_, _, GradeCode)),
+    assertion(sub_string(GradeCode, _, _, _, "T6 first-argument indexing")),
+    wam_target:compile_predicate_to_wam(few/1, [], Wf),
+    lower_predicate_to_lua(few/1, Wf, [], lowered(_, _, FewCode)),
+    assertion(\+ sub_string(FewCode, _, _, _, "T6 first-argument indexing")),
+    lower_predicate_to_lua(few/1, Wf, [t6_min_clauses(3)], lowered(_, _, FewT6)),
+    assertion(sub_string(FewT6, _, _, _, "T6 first-argument indexing")).
+
+% Build + run: the T6 table dispatch returns the Prolog-correct result for
+% clause hits (incl. non-first clauses) and a no-match.
+test(t6_exec) :-
+    lua_interpreter(Lua),
+    Dir = 'output/test_wam_lua_t6_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    write_wam_lua_project(
+        [user:shade/1, user:grade/2, user:few/1],
+        [module_name('t6proj'), emit_mode(functions)], Dir),
+    atomic_list_concat([Dir, '/lua/generated_program.lua'], ProgPath),
+    read_file_to_string(ProgPath, ProgSrc, []),
+    assertion(sub_string(ProgSrc, _, _, _, "T6 first-argument indexing")),
+    atomic_list_concat([Dir, '/lua/harness.lua'], HPath),
+    lua_t6_harness(Src),
+    setup_call_cleanup(open(HPath, write, S, [encoding(utf8)]), write(S, Src), close(S)),
+    atomic_list_concat([Dir, '/lua'], LuaDir),
+    format(atom(Cmd), 'cd ~w && ~w harness.lua 2>&1', [LuaDir, Lua]),
+    process_create(path(sh), ['-c', Cmd], [stdout(pipe(Out)), stderr(std), process(Pid)]),
+    read_string(Out, _, OutStr), close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutStr, _, _, _, "ALL 8 PASS")
+    ->  true
+    ;   format(user_error, "~n[lua t6 test output]~n~w~n", [OutStr]),
+        throw(lua_t6_test_failed(Status))
+    ),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- end_tests(wam_lua_lowered_t6).
+
+lua_t6_harness(
+"package.path = \"./?.lua;\" .. package.path
+local M = require(\"generated_program\")
+local R = M.Runtime
+local function A(s) return M.V.Atom(R.intern(M.program.intern_table, s)) end
+local fails, total = 0, 0
+local function chk(name, got, want)
+  total = total + 1
+  if got ~= want then
+    fails = fails + 1
+    print(\"FAIL\", name, \"got\", tostring(got), \"want\", tostring(want))
+  end
+end
+chk(\"shade(s01)\", M.shade(A(\"s01\")), true)
+chk(\"shade(s05)\", M.shade(A(\"s05\")), true)
+chk(\"shade(s10)\", M.shade(A(\"s10\")), true)
+chk(\"shade(zz)\",  M.shade(A(\"zz\")),  false)
+chk(\"few(a)\",     M.few(A(\"a\")),     true)
+chk(\"few(b)\",     M.few(A(\"b\")),     true)
+chk(\"few(c)\",     M.few(A(\"c\")),     true)
+chk(\"few(z)\",     M.few(A(\"z\")),     false)
+if fails == 0 then print(\"ALL \" .. total .. \" PASS\") else print(fails .. \" FAILURES\") end
+os.exit(fails == 0 and 0 or 1)
+").

--- a/tests/test_wam_scala_lowered_t6.pl
+++ b/tests/test_wam_scala_lowered_t6.pl
@@ -1,0 +1,126 @@
+% test_wam_scala_lowered_t6.pl
+%
+% End-to-end test for the Scala T6 lowering — first-argument indexing via a
+% `match` on the interned atom id (scalac compiles a dense Int match to a JVM
+% `tableswitch`), lowering type T6 in
+% docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md.
+%
+% Scala is int-interned: atoms render as `Atom(id)`, so the T5 cascade compares
+% `t5a1 == Atom(n)`. T6 replaces the linear cascade with a nested
+% `t5a1 match { case Atom(t6i) => t6i match { case n => clauseK } }`. Benchmarked
+% 1.3x at 8, 3.1x at 64, and far more at 256 (the case-class `==` cascade both
+% allocates per comparison and grows linearly; the tableswitch is O(1)).
+%
+% Gated like Rust/C++/F#/Go: T6 fires only when every clause discriminates on a
+% distinct ATOM and there are >= t6_min_clauses of them (default 8). Below the
+% threshold the few-clause predicate stays the T5 cascade.
+%
+% Gated on `scalac` + `scala` being on PATH.
+
+:- use_module(library(lists)).
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/wam_target').
+:- use_module('../src/unifyweaver/targets/wam_scala_target').
+:- use_module('../src/unifyweaver/targets/wam_scala_lowered_emitter').
+
+:- dynamic user:shade/1, user:grade/2, user:few/1.
+
+user:shade(s01). user:shade(s02). user:shade(s03). user:shade(s04).
+user:shade(s05). user:shade(s06). user:shade(s07). user:shade(s08).
+user:shade(s09). user:shade(s10).
+
+user:grade(g01, R) :- R is 1 + 0.
+user:grade(g02, R) :- R is 1 + 1.
+user:grade(g03, R) :- R is 1 + 2.
+user:grade(g04, R) :- R is 1 + 3.
+user:grade(g05, R) :- R is 1 + 4.
+user:grade(g06, R) :- R is 1 + 5.
+user:grade(g07, R) :- R is 1 + 6.
+user:grade(g08, R) :- R is 1 + 7.
+user:grade(g09, R) :- R is 1 + 8.
+user:grade(g10, R) :- R is 1 + 9.
+
+user:few(a). user:few(b). user:few(c).
+
+scala_available :-
+    catch(( process_create(path(scalac), ['-version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, _) ), _, fail).
+
+:- begin_tests(wam_scala_lowered_t6, [condition(scala_available)]).
+
+test(t6_exec) :-
+    Dir = 'output/test_wam_scala_t6_exec',
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ),
+    make_directory_path(Dir),
+    write_wam_scala_project(
+        [user:shade/1, user:grade/2, user:few/1],
+        [package('generated.t6.core'), runtime_package('generated.t6.core'),
+         module_name('t6'), emit_mode(functions)], Dir),
+    directory_file_path(Dir, 'src/main/scala/generated/t6/core/GeneratedProgram.scala', ProgPath),
+    read_file_to_string(ProgPath, ProgSrc, []),
+    assertion(sub_string(ProgSrc, _, _, _, "T6 first-argument indexing")),
+    assertion(sub_string(ProgSrc, _, _, _, "case Atom(t6i)")),
+    % few/1 (3 clauses, below the gate) must stay the T5 cascade.
+    assertion(sub_string(ProgSrc, _, _, _, "lowered_few_1 — T5 first-argument dispatch")),
+    t6_compile(Dir),
+    % shade/1 — atom fact chain incl. non-first clauses + a miss.
+    t6_check(Dir, 'shade/1', [s01], "true"),
+    t6_check(Dir, 'shade/1', [s05], "true"),
+    t6_check(Dir, 'shade/1', [s10], "true"),
+    t6_check(Dir, 'shade/1', [zz],  "false"),
+    % grade/2 — rule chain, each remainder runs is/2.
+    t6_check(Dir, 'grade/2', [g01, 1],  "true"),
+    t6_check(Dir, 'grade/2', [g05, 5],  "true"),
+    t6_check(Dir, 'grade/2', [g10, 10], "true"),
+    t6_check(Dir, 'grade/2', [g05, 9],  "false"),
+    t6_check(Dir, 'grade/2', [zz, 1],   "false"),
+    % few/1 — the T5 control still works.
+    t6_check(Dir, 'few/1', [b], "true"),
+    t6_check(Dir, 'few/1', [z], "false"),
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+% Codegen gate (no toolchain needed beyond compile-to-WAM).
+test(gate_threshold_override) :-
+    wam_target:compile_predicate_to_wam(few/1, [], Wf),
+    lower_predicate_to_scala(few/1, Wf, [], lowered(_, _, FewT5)),
+    assertion(\+ sub_string(FewT5, _, _, _, "T6 first-argument indexing")),
+    lower_predicate_to_scala(few/1, Wf, [t6_min_clauses(3)], lowered(_, _, FewT6)),
+    assertion(sub_string(FewT6, _, _, _, "T6 first-argument indexing")).
+
+:- end_tests(wam_scala_lowered_t6).
+
+% --- compile + run harness (mirrors test_wam_scala_lowered_t5) -------
+
+t6_compile(ProjectDir) :-
+    absolute_file_name(ProjectDir, AbsDir),
+    directory_file_path(AbsDir, 'classes', ClassDir),
+    make_directory_path(ClassDir),
+    directory_file_path(AbsDir, 'src', SrcDir),
+    findall(F,
+        ( directory_member(SrcDir, RelF, [extensions([scala]), recursive(true)]),
+          directory_file_path(SrcDir, RelF, F) ),
+        Sources),
+    Sources \= [],
+    process_create(path(scalac), ['-d', ClassDir | Sources],
+                   [cwd(AbsDir), stdout(pipe(O)), stderr(pipe(E)), process(Pid)]),
+    read_string(O, _, _), read_string(E, _, ErrStr), close(O), close(E),
+    process_wait(Pid, exit(Code)),
+    ( Code =:= 0 -> true ; throw(error(scala_compile_failed(Code, ErrStr), _)) ).
+
+t6_check(ProjectDir, PredKey, Args, Expected) :-
+    absolute_file_name(ProjectDir, AbsDir),
+    directory_file_path(AbsDir, 'classes', ClassDir),
+    atom_string(PredKey, PredStr),
+    maplist([A, S]>>atom_string(A, S), Args, ArgStrs),
+    append(['-classpath', ClassDir, 'generated.t6.core.GeneratedProgram', PredStr],
+           ArgStrs, ProcArgs),
+    process_create(path(scala), ProcArgs,
+                   [cwd(AbsDir), stdout(pipe(O)), stderr(pipe(E)), process(Pid)]),
+    read_string(O, _, Out0), read_string(E, _, ErrStr), close(O), close(E),
+    process_wait(Pid, exit(Code)),
+    normalize_space(string(Actual), Out0),
+    ( Code =:= 0 -> true ; throw(error(scala_run_failed(Code, PredKey, Args, ErrStr), _)) ),
+    ( Actual == Expected
+    -> true
+    ;  throw(error(t6_assertion(PredKey, Args, Expected, Actual), _)) ).


### PR DESCRIPTION
## Summary

Closes out the **T6 column for the int-interned targets** — benchmark-gated, as requested ("with benchmarks to see if it's worth it").

These targets (haskell/scala/lua/llvm) intern atoms to integers, so the T5 discriminator chain is an *integer*-equality chain — the "lost to the compiler" question. I triaged each with micro-benchmarks (`docs/reports/wam_int_interned_t6_perf.md`), then implemented the winners and declined LLVM on the evidence.

## Benchmark verdict (ns/op speedup, N=8/64/256)

| Target | N=8 | N=64 | N=256 | Decision |
|---|---|---|---|---|
| **Lua** | 1.7× | 8.2× | 29.7× | **implement** — hash table of per-clause closures (built once in a `do` block); interpreted Lua has no optimiser to recover the table |
| **Haskell** | 1.4× | 2.5× | 4.5× | **implement** — `case` on the interned id → GHC jump table |
| **Scala** | 1.3× | 3.1× | ≫ | **implement** — `match` on the id → JVM `tableswitch`; the case-class `==` cascade allocates per comparison |
| **LLVM** | — | — | — | **decline** — at `-O2`, SimplifyCFG already turns the int if-chain into a `switch` (if-chain ≡ switch in the emitted assembly); explicit T6 is redundant — the one genuine "lost to the compiler" case |

## Implementation

All three reuse the shared `wam_clause_chain` front-end and the existing per-clause body emission; only the **dispatch tail** changes, gated exactly like Rust/C++/F#/Go (all-atom discriminators AND ≥ `t6_min_clauses`, default 8). `Options` are now threaded through the respective `lower_predicate_to_*` / `emit` chains (previously `_Options` was ignored for go/lua, and `emit_func`/`emit_func_t5` didn't receive `Opts` for haskell).

## Tests
`test_wam_{haskell,scala,lua}_lowered_t6` — codegen gate (T6 for `shade/1`+`grade/2` ≥8 atoms, T5 for `few/1`, threshold override) and a build+run exec test through **ghc / scalac+scala / lua** asserting Prolog-correct dispatch including non-first clauses through the native switch/table and a no-match. T5/T4 for all three still pass.

## Matrix

T6 is now closed out: every T5 target has a gated T6 (rust/cpp/fsharp/go atom-keyed; haskell/scala/lua int-interned) **or** a measured reason not to (llvm).

Note: builds on `main` after Go T6 (#3008); F# T6 (#3007) touches the same T6 matrix note, so expect a small doc conflict to resolve at merge.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_