### PR TITLE
Calibrate SimpleWiki distribution priors

### DIFF
--- a/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
+++ b/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
@@ -446,6 +446,12 @@ It keeps two concepts separate:
   stay narrow enough to materialize cheaply before observing exact node
   histograms.
 
+The current prior is stationary within the selected calibration set. A later
+variant should allow layer-conditioned priors, where the excess-parent law
+changes with root-distance bucket. That would handle cases where the average
+parent branching signal declines as nodes move farther from the root, but it
+should wait for deeper SimpleWiki and enwiki measurements.
+
 1. exact parent-only histogram on tiny fixtures;
 2. exact parent-only histogram on simplewiki samples;
 3. fitted truncated-tail representation over the same nodes;

--- a/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
+++ b/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
@@ -393,3 +393,12 @@ as "carry exact histograms to depth `d` while the prior effective support is
 narrow." The realized fit is still needed as validation: if binomial or Gamma
 approximations do not match exact histograms on sampled nodes, then the prior
 depth policy is using the wrong family even if its mean looks plausible.
+
+The first prior model is stationary within the selected calibration set: the
+same excess-parent law is convolved at each depth. A future non-stationary
+variant can use a different law per root-distance layer,
+`P(Y_i | L_min = i)`, and compose those layer priors. This would account for
+the empirical pattern where the size-biased parent-branching signal can decline
+farther from the root. That refinement is planner-relevant, but should be held
+until deeper SimpleWiki and enwiki samples show that the stationary prior is
+materially miscalibrated.

--- a/docs/reports/distribution_fit_simplewiki_prior_calibration_2026-06-11.md
+++ b/docs/reports/distribution_fit_simplewiki_prior_calibration_2026-06-11.md
@@ -1,0 +1,148 @@
+# SimpleWiki Distribution Fit Prior Calibration
+
+Date: 2026-06-11
+
+Branch: `codex/simplewiki-prior-calibration`
+
+## Scope
+
+This report calibrates the parent-path distribution approximation harness on the
+local SimpleWiki Articles numeric artifact:
+
+```text
+/home/s243a/Projects/UnifyWeaver/data/benchmark/simplewiki_articles/category_parent.tsv
+```
+
+The artifact uses numeric category ids. The prior SimpleWiki reports identify
+category id `2` as the Articles root, so all commands below use `--root 2`.
+
+Generated TSVs, target lists, JSONL, and generated markdown summaries were
+written under Scratch and are not committed:
+
+```text
+/mnt/c/Users/johnc/Scratch/distribution-prior-calibration
+```
+
+## Sampling
+
+Depth 3 command:
+
+```text
+python3 scripts/sample_distribution_cache_subtree.py --edge-file /home/s243a/Projects/UnifyWeaver/data/benchmark/simplewiki_articles/category_parent.tsv --root 2 --max-depth 3 --output /mnt/c/Users/johnc/Scratch/distribution-prior-calibration/simplewiki_articles_root2_depth3.tsv --targets-output /mnt/c/Users/johnc/Scratch/distribution-prior-calibration/simplewiki_articles_root2_depth3_targets.txt
+```
+
+Depth 3 result:
+
+```text
+selected_nodes=14680
+sampled_edges=14887
+```
+
+Depth 4 command:
+
+```text
+python3 scripts/sample_distribution_cache_subtree.py --edge-file /home/s243a/Projects/UnifyWeaver/data/benchmark/simplewiki_articles/category_parent.tsv --root 2 --max-depth 4 --output /mnt/c/Users/johnc/Scratch/distribution-prior-calibration/simplewiki_articles_root2_depth4.tsv --targets-output /mnt/c/Users/johnc/Scratch/distribution-prior-calibration/simplewiki_articles_root2_depth4_targets.txt
+```
+
+Depth 4 result:
+
+```text
+selected_nodes=14680
+sampled_edges=14887
+```
+
+The depth-4 sample is identical to depth 3 for this filtered Articles artifact,
+so the calibration run uses the depth-3 graph.
+
+## Fit/Prior Comparison
+
+Command:
+
+```text
+python3 scripts/distribution_fit_comparison.py --edge-file /mnt/c/Users/johnc/Scratch/distribution-prior-calibration/simplewiki_articles_root2_depth3.tsv --graph-name simplewiki_articles_root2_depth3_prior_calibration --root 2 --targets-file /mnt/c/Users/johnc/Scratch/distribution-prior-calibration/simplewiki_articles_root2_depth3_targets.txt --depths 1,2,3,4,6,8,10,12 --tail-epsilon 0.001 --output-dir /mnt/c/Users/johnc/Scratch/distribution-prior-calibration
+```
+
+Generated outputs:
+
+```text
+/mnt/c/Users/johnc/Scratch/distribution-prior-calibration/distribution_fit_comparison_simplewiki_articles_root2_depth3_prior_calibration_20260611T041620Z.jsonl
+/mnt/c/Users/johnc/Scratch/distribution-prior-calibration/distribution_fit_comparison_summary_simplewiki_articles_root2_depth3_prior_calibration_20260611T041620Z.md
+```
+
+### Realized Histogram Fits
+
+| model | rows | mean_l1 | p95_l1 | max_l1 | mean_cdf_error | mean_build_ns | mean_exact_hist_ns |
+|-------|------|---------|--------|--------|----------------|---------------|--------------------|
+| binomial_fit | 14680 | 0.000590 | 0.000000 | 1.000000 | 0.000148 | 1890.9 | 4835.7 |
+| shifted_gamma_fit | 14680 | 0.010107 | 0.000000 | 1.073430 | 0.005054 | 2288.8 | 4835.7 |
+
+### Realized Support By Root Distance
+
+| L_min | targets | mean_bins | p95_bins | max_bins | mean_effective_bins | mean_path_count | mean_parent_degree |
+|-------|---------|-----------|----------|----------|---------------------|-----------------|--------------------|
+| 0 | 1 | 1.000 | 1.000 | 1 | 1.000 | 1.000 | 0.000000 |
+| 1 | 13720 | 1.015 | 1.000 | 3 | 1.015 | 1.015 | 1.014359 |
+| 2 | 923 | 1.001 | 1.000 | 2 | 1.001 | 1.013 | 1.011918 |
+| 3 | 36 | 1.000 | 1.000 | 1 | 1.000 | 1.000 | 1.000000 |
+
+### Depth-Conditioned Prior Distributions
+
+| model | rows | mean_l1 | p95_l1 | max_l1 | mean_cdf_error | mean_build_ns | mean_exact_hist_ns |
+|-------|------|---------|--------|--------|----------------|---------------|--------------------|
+| binomial_prior | 8 | 0.020596 | 0.035789 | 0.035789 | 0.005698 | 5844.6 | 24371.5 |
+| shifted_gamma_prior | 8 | 0.143635 | 0.227540 | 0.227540 | 0.066402 | 69489.2 | 24371.5 |
+
+### Prior Support By Depth
+
+| depth | rows | mean_bins | mean_effective_bins | max_effective_bins | mean_excess |
+|-------|------|-----------|---------------------|--------------------|-------------|
+| 1 | 2 | 3.000 | 3.000 | 3 | 0.028750 |
+| 2 | 2 | 5.000 | 3.000 | 3 | 0.057500 |
+| 3 | 2 | 7.000 | 3.000 | 3 | 0.086250 |
+| 4 | 2 | 9.000 | 3.000 | 3 | 0.115000 |
+| 6 | 2 | 13.000 | 4.000 | 4 | 0.172499 |
+| 8 | 2 | 17.000 | 4.000 | 4 | 0.229999 |
+| 10 | 2 | 21.000 | 4.000 | 4 | 0.287499 |
+| 12 | 2 | 25.000 | 4.000 | 4 | 0.344999 |
+
+## Interpretation
+
+The realized histograms are extremely narrow. Across `14,680` targets, the mean
+support is nearly one bin, the 95th percentile is one bin, and the maximum is
+only three bins. This supports carrying exact sparse histograms for this
+SimpleWiki parent-only Articles subtree: the representation cost is dominated by
+the number of cached nodes rather than by per-node histogram width.
+
+The depth-conditioned prior tells the same story. With `epsilon_tail=0.001`,
+the effective prior support stays at three bins through depth `4` and only rises
+to four bins through depth `12`. The full algebraic support width grows with the
+horizon, but most prior mass stays in the first few excess-parent bins.
+
+For this near-chain SimpleWiki regime, binomial is the better approximation
+family. It has much lower realized-fit and prior-fit error than the
+shifted-Gamma approximation, and it is cheaper to build in the prior comparison.
+Gamma remains useful as a candidate for wider enwiki-style branching, not as
+the default for this SimpleWiki sample.
+
+The root-distance table shows the depth-varying signal that motivates a future
+non-stationary prior: mean parent degree declines from `1.014359` at `L_min=1`
+to `1.011918` at `L_min=2` and `1.000000` at `L_min=3`. The current stationary
+prior is conservative enough here, but a future planner could use
+layer-conditioned priors `P(Y_i | L_min=i)` once deeper samples show the
+difference matters.
+
+## Policy Implication
+
+A reasonable first SimpleWiki policy is:
+
+```text
+if realized_support_width <= 3:
+    store exact sparse histogram
+elif prior_effective_support_bins(depth, epsilon_tail=0.001) <= 4:
+    prefer exact sparse histogram when reuse is non-trivial
+else:
+    compare exact histogram, scalar min/max bounds, and fitted state by cost
+```
+
+This is intentionally SimpleWiki-specific. Enwiki should be recalibrated rather
+than inheriting these thresholds.

--- a/scripts/distribution_fit_comparison.py
+++ b/scripts/distribution_fit_comparison.py
@@ -391,6 +391,15 @@ def summarize(records: list[dict[str, object]]) -> str:
         "|-------|------|---------|--------|--------|----------------|---------------|--------------------|",
     ]
     append_model_table(lines, realized_records)
+    if realized_records:
+        lines.extend([
+            "",
+            "## Realized Support By Root Distance",
+            "",
+            "| L_min | targets | mean_bins | p95_bins | max_bins | mean_effective_bins | mean_path_count | mean_parent_degree |",
+            "|-------|---------|-----------|----------|----------|---------------------|-----------------|--------------------|",
+        ])
+        append_realized_support_table(lines, realized_records)
     lines.extend([
         "",
         "## Depth-Conditioned Prior Distributions",
@@ -429,6 +438,41 @@ def summarize(records: list[dict[str, object]]) -> str:
         for record in error_records[:10]:
             lines.append(f"- {record['target_node']}: {record['error']}")
     return "\n".join(lines) + "\n"
+
+
+def unique_realized_target_records(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    by_target = {}
+    for record in rows:
+        target = record.get("target_node")
+        if target is not None and target not in by_target:
+            by_target[target] = record
+    return list(by_target.values())
+
+
+def append_realized_support_table(lines: list[str], rows: list[dict[str, object]]) -> None:
+    by_distance = {}
+    for record in unique_realized_target_records(rows):
+        l_min = record.get("L_min")
+        if l_min is not None:
+            by_distance.setdefault(l_min, []).append(record)
+    for l_min in sorted(by_distance):
+        distance_rows = by_distance[l_min]
+        support_bins = [int(row["support_bins"]) for row in distance_rows]
+        effective_bins = [int(row["effective_support_bins"]) for row in distance_rows]
+        path_counts = [int(row["path_count"]) for row in distance_rows]
+        parent_degrees = [int(row["parent_degree"]) for row in distance_rows]
+        lines.append(
+            "| {l_min} | {targets} | {mean_bins:.3f} | {p95_bins:.3f} | {max_bins} | {mean_effective:.3f} | {mean_paths:.3f} | {mean_parent:.6f} |".format(
+                l_min=l_min,
+                targets=len(distance_rows),
+                mean_bins=statistics.mean(support_bins) if support_bins else 0.0,
+                p95_bins=percentile([float(value) for value in support_bins], 95),
+                max_bins=max(support_bins, default=0),
+                mean_effective=statistics.mean(effective_bins) if effective_bins else 0.0,
+                mean_paths=statistics.mean(path_counts) if path_counts else 0.0,
+                mean_parent=statistics.mean(parent_degrees) if parent_degrees else 0.0,
+            )
+        )
 
 
 def append_model_table(lines: list[str], rows: list[dict[str, object]]) -> None:

--- a/tests/test_distribution_fit_comparison.py
+++ b/tests/test_distribution_fit_comparison.py
@@ -15,6 +15,7 @@ from scripts.distribution_fit_comparison import (
     l1_error,
     max_cdf_error,
     nfold_convolution,
+    append_realized_support_table,
     run_graph_fit_comparison,
     size_biased_excess_pmf,
     summarize,
@@ -75,6 +76,29 @@ class DistributionFitComparisonTests(unittest.TestCase):
         self.assertEqual(roles, {"depth_prior"})
         self.assertTrue(all(record["effective_support_bins"] >= 1 for record in records))
 
+    def test_realized_support_table_counts_targets_once(self):
+        lines = []
+        rows = [
+            {
+                "target_node": "A",
+                "L_min": 1,
+                "support_bins": 2,
+                "effective_support_bins": 2,
+                "path_count": 2,
+                "parent_degree": 1,
+            },
+            {
+                "target_node": "A",
+                "L_min": 1,
+                "support_bins": 2,
+                "effective_support_bins": 2,
+                "path_count": 2,
+                "parent_degree": 1,
+            },
+        ]
+        append_realized_support_table(lines, rows)
+        self.assertEqual(lines[0].split("|")[2].strip(), "1")
+
     def test_fixture_comparison_reports_both_roles(self):
         fixture = FIXTURES["shortcut_parent"]
         records = run_graph_fit_comparison(
@@ -94,6 +118,7 @@ class DistributionFitComparisonTests(unittest.TestCase):
         self.assertEqual(prior_models, {"binomial_prior", "shifted_gamma_prior"})
         self.assertIn("Realized Histogram Fits", summary)
         self.assertIn("Depth-Conditioned Prior Distributions", summary)
+        self.assertIn("Realized Support By Root Distance", summary)
         self.assertIn("Prior Support By Depth", summary)
 
 


### PR DESCRIPTION
## Summary

- Add root-distance realized-support summaries to `scripts/distribution_fit_comparison.py` so calibration reports show exact histogram width by `L_min` bucket.
- Document the future non-stationary prior variant where `P(Y_i | L_min=i)` changes by layer instead of using one stationary excess-parent law.
- Add a SimpleWiki Articles prior calibration report using the local numeric artifact rooted at category id `2`.
- Add test coverage to ensure realized support summaries count each target once even though each target has multiple model rows.

## Calibration result

On the SimpleWiki Articles depth-3/4-equivalent sample:

- `14,680` realized targets, `14,887` sampled parent edges, no fit errors.
- Realized histograms are extremely narrow: mean bins near `1`, p95 bins `1`, max bins `3`.
- Depth-conditioned prior effective support stays at `3` bins through depth `4` and `4` bins through depth `12` with `epsilon_tail=0.001`.
- Binomial is the better near-chain family here; shifted-Gamma remains a candidate for wider enwiki-style branching.

## Validation

- `python3 -m unittest tests/test_distribution_fit_comparison.py tests/test_distribution_cache_support_bounds.py tests/test_distribution_cache_benchmark.py tests/test_distribution_cache_parity.py tests/test_distribution_cache_subtree_sampler.py tests/test_export_distribution_cache_edges.py`
- `python3 scripts/distribution_fit_comparison.py --edge-file /mnt/c/Users/johnc/Scratch/distribution-prior-calibration/simplewiki_articles_root2_depth3.tsv --graph-name simplewiki_articles_root2_depth3_prior_calibration --root 2 --targets-file /mnt/c/Users/johnc/Scratch/distribution-prior-calibration/simplewiki_articles_root2_depth3_targets.txt --depths 1,2,3,4,6,8,10,12 --tail-epsilon 0.001`
- `git diff --check origin/main..HEAD`