### PR TITLE
Clarify binomial and tail-family priors

### DIFF
--- a/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
+++ b/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
@@ -79,10 +79,18 @@ Candidate families for later extension:
 | Family | Use when |
 |--------|----------|
 | `truncated_geometric` | Tail decays approximately exponentially after the exact prefix |
-| `truncated_discrete_normal` | Mass is concentrated around a mean with lower variance |
-| `beta_binomial` | Bounded support with measurable over/under-dispersion |
+| `truncated_discrete_normal` | Large-depth CLT regime after tail/error validation |
+| `binomial` | Bounded excess-event support where mean/variance recover compatible `n,p` |
+| `beta_binomial` | Bounded support with measurable over-dispersion beyond binomial variance |
 | `empirical_sketch` | No simple family fits but quantile/CDF accuracy is enough |
 | `mixture(Families)` | Topical and administrative regimes visibly mix |
+
+The normal family should be treated as a large-depth approximation, not as the
+default for rare excess-parent events. In near-chain SimpleWiki regimes,
+binomial or empirical discrete priors preserve the skewed finite support more
+directly. If measured parent degrees become scale-free rather than
+Poisson-like, the policy should favor empirical sketches, mixtures, or explicit
+hub handling instead of a single light-tailed count family.
 
 The family choice should be evidence-driven. Simplewiki is a calibration fixture: compute exact parent-only distributions there, fit candidate tails, and measure error. Enwiki is the stress case where the representation switch is expected to matter.
 

--- a/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
+++ b/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
@@ -102,6 +102,24 @@ horizon: `L_min` gives a lower-bound estimate, `L_max` gives an upper-bound
 estimate, and narrow support makes the difference small. It is useful for
 SimpleWiki-like samples because `epsilon` is small and measured `max_p` is low.
 
+For planner admission, the useful cheap approximation is:
+
+```text
+n_binomial ~= support_width = L_max - L_min
+p_binomial ~= epsilon = E[P^2] / E[P] - 1
+```
+
+The support width comes from scalar min/max difference equations, so it is cheap
+to compute and store without materialising the full histogram. The probability
+proxy comes from the global or bucketed size-biased parent branching statistic.
+This is strongest in the near-chain regime where excess parent count is mostly
+`0` or `1`; then `epsilon` is close to a Bernoulli probability. If parent count
+can jump by more than one, `epsilon` is only a mean excess and the compound
+convolution model is the safer prior. Because SimpleWiki shows the parent
+branching signal declining farther from the root, the global `epsilon` should
+be treated as a first calibration constant until depth-local priors are
+measured.
+
 A binomial prior is compact because it is determined by two parameters,
 `n` and `p`, and therefore by compatible mean and variance:
 

--- a/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
+++ b/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
@@ -136,12 +136,24 @@ If variance is inflated by topical correlation or mixed regimes, a
 beta-binomial or empirical compound prior is a better candidate than forcing a
 binomial fit.
 
-The binomial family is not generally symmetric. It is symmetric only near
-`p = 0.5`; in the SimpleWiki near-chain regime, `p` is small and the mass is
-right-skewed. A normal/Gaussian approximation becomes reasonable only in the
-large-depth central-limit regime where both `n*p` and `n*(1-p)` are large.
-For rare excess-parent events, the intermediate approximation is more
-Poisson-like than Gaussian.
+The binomial family is not generally symmetric. It is exactly symmetric only
+near `p = 0.5`; in the SimpleWiki near-chain regime, `p` is small and the mass
+is right-skewed. The standardized skewness of a binomial is
+
+```text
+skewness = (1 - 2p) / sqrt(n * p * (1 - p))
+```
+
+so convolution does make the shape more symmetric as the effective number of
+independent layers grows, but only at the standardized-distribution level. A
+normal/Gaussian approximation becomes reasonable in the large-depth
+central-limit regime where both `n*p` and `n*(1-p)` are large. A single node or
+shallow subtree can still be strongly right-skewed, especially when `p` is small
+and the lower boundary at zero excess events is close to the mean. For rare
+excess-parent events, the intermediate approximation is more Poisson-like than
+Gaussian. In this sense the binomial approximation supplies a compact
+finite-support prior; it is not a claim that the exact node histogram is
+symmetric.
 
 For `epsilon = 0.028750`:
 

--- a/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
+++ b/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
@@ -102,6 +102,29 @@ horizon: `L_min` gives a lower-bound estimate, `L_max` gives an upper-bound
 estimate, and narrow support makes the difference small. It is useful for
 SimpleWiki-like samples because `epsilon` is small and measured `max_p` is low.
 
+A binomial prior is compact because it is determined by two parameters,
+`n` and `p`, and therefore by compatible mean and variance:
+
+```text
+mu = n * p
+sigma^2 = n * p * (1 - p)
+p = 1 - sigma^2 / mu
+n = mu / p = mu^2 / (mu - sigma^2)
+```
+
+This moment recovery is valid only for binomial-like under-dispersed data where
+`0 < sigma^2 < mu` and the recovered `n` is meaningful for the depth horizon.
+If variance is inflated by topical correlation or mixed regimes, a
+beta-binomial or empirical compound prior is a better candidate than forcing a
+binomial fit.
+
+The binomial family is not generally symmetric. It is symmetric only near
+`p = 0.5`; in the SimpleWiki near-chain regime, `p` is small and the mass is
+right-skewed. A normal/Gaussian approximation becomes reasonable only in the
+large-depth central-limit regime where both `n*p` and `n*(1-p)` are large.
+For rare excess-parent events, the intermediate approximation is more
+Poisson-like than Gaussian.
+
 For `epsilon = 0.028750`:
 
 ```text
@@ -148,6 +171,12 @@ For non-stationary layers, replace the power by a product of per-layer PGFs and
 use `Var(K_n) = sum_i Var(Y_i)` under layer independence. This is the more
 general form we should measure for enwiki. The binomial model is the special
 case where `Y_i` is Bernoulli.
+
+When the per-layer excess variables are not Bernoulli but still have finite
+variance, central-limit reasoning applies to the convolved sum at large depth.
+That supports a continuous normal-like planning approximation only after
+checking support truncation and tail error; it does not replace the discrete
+histogram or compound convolution oracle for shallow or rare-event regimes.
 
 ## 5. FFT convolution route
 
@@ -291,6 +320,26 @@ A provisional regime map is:
 
 The thresholds should be calibrated by SimpleWiki and enwiki samples rather than
 hard-coded from this note.
+
+Tail family choice is a planner-risk decision:
+
+| Tail regime | Candidate prior | Planner meaning |
+|-------------|-----------------|-----------------|
+| Light tail | Poisson-like, binomial | Counts have a characteristic scale; hubs are unlikely |
+| Medium tail | Geometric, exponential, shifted Gamma | Tails decay steadily but allow more long paths than light-tail counts |
+| Heavy tail | Scale-free, power law | Hubs are expected; rare high-parent nodes can dominate cost |
+
+Although Gamma is related to Poisson processes, it is not the continuous form
+of a Poisson count. Poisson models event counts in a fixed interval; Gamma
+models waiting time or accumulated positive mass until repeated events, which
+is why it is a more flexible medium-tail approximation here.
+
+Poisson-like and binomial priors are appropriate only when measured parent
+degrees are concentrated around a characteristic scale. Exponential or
+geometric tails are a middle ground when mass decays quickly but not as tightly
+as a light-tailed count model. If enwiki or unfiltered container/admin
+categories show power-law tails, the planner should prefer empirical sketches,
+mixtures, or hub-aware cutoffs over Poisson/binomial families.
 
 ## 7. Histogram support versus path multiplicity
 

--- a/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
+++ b/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
@@ -155,6 +155,27 @@ Gaussian. In this sense the binomial approximation supplies a compact
 finite-support prior; it is not a claim that the exact node histogram is
 symmetric.
 
+A concrete skewed case is `Binomial(n=10, p=0.1)`. Its mean is `1`,
+variance is `0.9`, and skewness is about `0.843`; the largest masses are
+approximately `P(0)=0.349`, `P(1)=0.387`, `P(2)=0.194`, and `P(3)=0.057`.
+This is visibly right-skewed even though the tail drops quickly. The practical
+lesson is that visual symmetry depends on both `n` and `p`; a symmetric or
+normal approximation should be admitted by skewness and CDF/tail-error gates,
+not by the existence of a binomial fit alone.
+
+Solving the skewness gate gives a useful depth threshold:
+
+```text
+n >= (1 - 2p)^2 / (skew_tol^2 * p * (1 - p))
+```
+
+For example, with `p=0.1`, reaching skewness below `0.5` requires roughly
+`n >= 29`, while below `0.25` requires roughly `n >= 114`. For SimpleWiki-like
+`p ~= 0.028750`, the same thresholds require much larger effective depth.
+Until that point, a binomial fit can still be useful as a compact storage
+representation, but it should not be treated as an obviously symmetric
+approximation.
+
 For `epsilon = 0.028750`:
 
 ```text
@@ -420,6 +441,14 @@ elif b_p_bucket is high and expected_reuse is low:
 else:
     evaluate exact histogram, cached boundary, or fitted distribution by cost
 ```
+
+There are two separate uses for a fitted distribution. As an admission prior,
+the fit can sometimes avoid computing a full histogram, but only under an
+explicit approximation policy with measured error gates. As a compressed
+representation, the fit can save memory or storage after exact or sampled
+distribution data has already been computed. In the second case, a binomial
+record such as `(n, p, error_metadata)` can replace many histogram bins, but it
+does not remove the initial cost needed to validate that compression.
 
 For SimpleWiki, the measured sample has narrow support and `b_p` close to `1`,
 so exact histograms can probably be propagated deeper than a root-distance-only

--- a/docs/reports/distribution_fit_simplewiki_prior_calibration_2026-06-11.md
+++ b/docs/reports/distribution_fit_simplewiki_prior_calibration_2026-06-11.md
@@ -124,6 +124,13 @@ shifted-Gamma approximation, and it is cheaper to build in the prior comparison.
 Gamma remains useful as a candidate for wider enwiki-style branching, not as
 the default for this SimpleWiki sample.
 
+The report therefore suggests a cheap first prior: use scalar support bounds to
+set the candidate binomial support, and use the measured size-biased parent
+branching signal as the Bernoulli excess-parent proxy. In this run, that means
+`n ~= L_max - L_min` and `p ~= E[P^2]/E[P] - 1 = 0.028750` globally, with the
+understanding that the root-distance table already shows why a future
+layer-conditioned `p_i` may be better.
+
 The binomial result should be read as a sparse-event model, not as a symmetric
 Gaussian claim. In this sample, excess-parent probability is small, so the
 binomial prior is right-skewed and compact. A normal approximation would be a

--- a/docs/reports/distribution_fit_simplewiki_prior_calibration_2026-06-11.md
+++ b/docs/reports/distribution_fit_simplewiki_prior_calibration_2026-06-11.md
@@ -145,6 +145,13 @@ difference matters.
 
 ## Policy Implication
 
+The `Binomial(10, 0.1)` example is a useful warning case: it is clearly skewed
+even though the tail falls quickly. For this reason, symmetric approximations
+should wait for a skewness/tail-error gate. Binomial fits can still be useful
+before then as compression: they may reduce storage from many bins to `(n, p,
+error_metadata)`, but that is different from avoiding the initial exact or
+sampled computation needed to validate the fit.
+
 A reasonable first SimpleWiki policy is:
 
 ```text

--- a/docs/reports/distribution_fit_simplewiki_prior_calibration_2026-06-11.md
+++ b/docs/reports/distribution_fit_simplewiki_prior_calibration_2026-06-11.md
@@ -124,6 +124,11 @@ shifted-Gamma approximation, and it is cheaper to build in the prior comparison.
 Gamma remains useful as a candidate for wider enwiki-style branching, not as
 the default for this SimpleWiki sample.
 
+The binomial result should be read as a sparse-event model, not as a symmetric
+Gaussian claim. In this sample, excess-parent probability is small, so the
+binomial prior is right-skewed and compact. A normal approximation would be a
+later large-depth approximation after checking tail error and finite support.
+
 The root-distance table shows the depth-varying signal that motivates a future
 non-stationary prior: mean parent degree declines from `1.014359` at `L_min=1`
 to `1.011918` at `L_min=2` and `1.000000` at `L_min=3`. The current stationary


### PR DESCRIPTION
## Summary

- Clarify that binomial priors are characterized by `n,p`, or by compatible mean/variance, and note when moment recovery is valid.
- Add the cheap Bernoulli-prior approximation: scalar support bounds give candidate `n ~= L_max - L_min`, while `E[P^2]/E[P] - 1` gives the first global or bucketed `p` proxy in near-chain graphs.
- Add the asymmetry and CLT caveat: binomial skewness is `(1 - 2p) / sqrt(n*p*(1-p))`, so convolution becomes more symmetric only as effective depth grows; shallow or low-`p` node histograms can remain strongly right-skewed.
- Add the concrete `Binomial(10, 0.1)` warning case: mean `1`, variance `0.9`, skewness about `0.843`, with visible right skew even though the tail falls quickly.
- Distinguish computation savings from compression savings: a skewed binomial fit may not justify skipping exact or sampled histogram construction, but it can still replace many stored bins with compact `(n,p,error_metadata)` state after validation.
- Add a light/medium/heavy tail taxonomy for planner risk: Poisson/binomial, geometric/exponential/Gamma, and scale-free/power-law.
- Note that Gamma is related to Poisson processes as waiting-time or accumulated-positive-mass modeling, not as the continuous form of a Poisson count.

## Validation

- `git diff --check`