### PR TITLE
test(wam-llvm): add reentrant run-loop helper

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -192,7 +192,10 @@ lines — identical behaviour to Phase 0, running as compiled LLVM.
 stdin, and `state/4` remains represented as ordinary WAM terms rather than a
 specialized LLVM aggregate. The bounded output helper has been retired from the
 compiled stream smoke; generic output accumulation now goes through
-`append_output/3` and `state_outputs/2`.
+`append_output/3` and `state_outputs/2`. WAM/LLVM now also has a
+`@wam_prepare_call` runtime helper plus a reentrant run-loop smoke, which is
+the first general bridge for native deterministic outer loops that call WAM
+handlers repeatedly.
 
 ---
 

--- a/docs/design/WAM_LLVM_TRANSPILATION_SPECIFICATION.md
+++ b/docs/design/WAM_LLVM_TRANSPILATION_SPECIFICATION.md
@@ -467,7 +467,7 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8*, i8*, i64, i1)
 `@value_is_unbound`, `@value_equals`), boxing/unboxing bridge
 (`@box_integer`, `@unbox_integer`, etc.).
 
-**`state.ll.mustache`:** `@wam_state_new`, `@wam_set_reg`,
+**`state.ll.mustache`:** `@wam_state_new`, `@wam_prepare_call`, `@wam_set_reg`,
 `@wam_get_reg`, `@wam_inc_pc`, `@wam_push_trail`, `@wam_push_cp`,
 `@wam_heap_alloc`.
 
@@ -478,6 +478,12 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8*, i8*, i64, i1)
 ## Interop Calling Convention
 
 ### Native calls WAM-compiled predicate:
+
+For repeated calls from a native deterministic loop, reuse the same `%WamState`
+and call `@wam_prepare_call(VM, StartPC)` before setting argument registers and
+entering `@run_loop` again. The helper clears `halted`, resets `CP` to zero,
+and installs the requested compiled predicate start PC.
+
 
 ```llvm
 define i1 @query_ancestor(i8* %a, i8* %b) {

--- a/examples/plawk/generated/plawk_core_probe.ll
+++ b/examples/plawk/generated/plawk_core_probe.ll
@@ -694,6 +694,16 @@ define void @wam_set_pc(%WamState* %vm, i32 %pc) alwaysinline nounwind {
   ret void
 }
 
+; Prepare an existing VM for a reentrant call into compiled WAM code.
+; Native outer loops use this before each @run_loop invocation when they
+; dispatch repeatedly into WAM handlers from the same %WamState.
+define void @wam_prepare_call(%WamState* %vm, i32 %start_pc) alwaysinline nounwind {
+  call void @wam_set_halted(%WamState* %vm, i1 false)
+  call void @wam_set_cp(%WamState* %vm, i32 0)
+  call void @wam_set_pc(%WamState* %vm, i32 %start_pc)
+  ret void
+}
+
 ; M5: Doubling-realloc grow for the trail. Called by @wam_trail_binding
 ; (and @wam_trail_heap_binding) when the size hits the current cap.
 ; CPs hold trail indices, not pointers, so post-realloc indices remain

--- a/examples/plawk/generated/plawk_loop_probe.ll
+++ b/examples/plawk/generated/plawk_loop_probe.ll
@@ -694,6 +694,16 @@ define void @wam_set_pc(%WamState* %vm, i32 %pc) alwaysinline nounwind {
   ret void
 }
 
+; Prepare an existing VM for a reentrant call into compiled WAM code.
+; Native outer loops use this before each @run_loop invocation when they
+; dispatch repeatedly into WAM handlers from the same %WamState.
+define void @wam_prepare_call(%WamState* %vm, i32 %start_pc) alwaysinline nounwind {
+  call void @wam_set_halted(%WamState* %vm, i1 false)
+  call void @wam_set_cp(%WamState* %vm, i32 0)
+  call void @wam_set_pc(%WamState* %vm, i32 %start_pc)
+  ret void
+}
+
 ; M5: Doubling-realloc grow for the trail. Called by @wam_trail_binding
 ; (and @wam_trail_heap_binding) when the size hits the current cap.
 ; CPs hold trail indices, not pointers, so post-realloc indices remain

--- a/examples/plawk/generated/plawk_meta_call_probe.ll
+++ b/examples/plawk/generated/plawk_meta_call_probe.ll
@@ -694,6 +694,16 @@ define void @wam_set_pc(%WamState* %vm, i32 %pc) alwaysinline nounwind {
   ret void
 }
 
+; Prepare an existing VM for a reentrant call into compiled WAM code.
+; Native outer loops use this before each @run_loop invocation when they
+; dispatch repeatedly into WAM handlers from the same %WamState.
+define void @wam_prepare_call(%WamState* %vm, i32 %start_pc) alwaysinline nounwind {
+  call void @wam_set_halted(%WamState* %vm, i1 false)
+  call void @wam_set_cp(%WamState* %vm, i32 0)
+  call void @wam_set_pc(%WamState* %vm, i32 %start_pc)
+  ret void
+}
+
 ; M5: Doubling-realloc grow for the trail. Called by @wam_trail_binding
 ; (and @wam_trail_heap_binding) when the size hits the current cap.
 ; CPs hold trail indices, not pointers, so post-realloc indices remain

--- a/examples/plawk/generated/plawk_reader_probe.ll
+++ b/examples/plawk/generated/plawk_reader_probe.ll
@@ -694,6 +694,16 @@ define void @wam_set_pc(%WamState* %vm, i32 %pc) alwaysinline nounwind {
   ret void
 }
 
+; Prepare an existing VM for a reentrant call into compiled WAM code.
+; Native outer loops use this before each @run_loop invocation when they
+; dispatch repeatedly into WAM handlers from the same %WamState.
+define void @wam_prepare_call(%WamState* %vm, i32 %start_pc) alwaysinline nounwind {
+  call void @wam_set_halted(%WamState* %vm, i1 false)
+  call void @wam_set_cp(%WamState* %vm, i32 0)
+  call void @wam_set_pc(%WamState* %vm, i32 %start_pc)
+  ret void
+}
+
 ; M5: Doubling-realloc grow for the trail. Called by @wam_trail_binding
 ; (and @wam_trail_heap_binding) when the size hits the current cap.
 ; CPs hold trail indices, not pointers, so post-realloc indices remain

--- a/templates/targets/llvm_wam/state.ll.mustache
+++ b/templates/targets/llvm_wam/state.ll.mustache
@@ -299,6 +299,16 @@ define void @wam_set_pc(%WamState* %vm, i32 %pc) alwaysinline nounwind {
   ret void
 }
 
+; Prepare an existing VM for a reentrant call into compiled WAM code.
+; Native outer loops use this before each @run_loop invocation when they
+; dispatch repeatedly into WAM handlers from the same %WamState.
+define void @wam_prepare_call(%WamState* %vm, i32 %start_pc) alwaysinline nounwind {
+  call void @wam_set_halted(%WamState* %vm, i1 false)
+  call void @wam_set_cp(%WamState* %vm, i32 0)
+  call void @wam_set_pc(%WamState* %vm, i32 %start_pc)
+  ret void
+}
+
 ; M5: Doubling-realloc grow for the trail. Called by @wam_trail_binding
 ; (and @wam_trail_heap_binding) when the size hits the current cap.
 ; CPs hold trail indices, not pointers, so post-realloc indices remain

--- a/tests/test_wam_llvm_reentrant_run_loop.pl
+++ b/tests/test_wam_llvm_reentrant_run_loop.pl
@@ -1,0 +1,115 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+:- dynamic user:uw_native_loop_step/3.
+
+user:uw_native_loop_step(_Item, Count0, CountN) :-
+    CountN is Count0 + 1.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_llvm_reentrant_run_loop, [condition(clang_available)]).
+
+test(native_driver_reuses_vm_for_repeated_wam_handler_calls) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_wam_llvm_reentrant_run_loop', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'reentrant_run_loop.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:uw_native_loop_step/3 ],
+        [module_name('reentrant_run_loop')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    reentrant_run_loop_driver_ir(InstrCount, LabelCount, DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'reentrant_run_loop_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[wam llvm reentrant run-loop output]~n~w~n",
+              [OutStr]),
+       throw(wam_llvm_reentrant_run_loop_failed(Status))
+    ),
+    !.
+
+:- end_tests(wam_llvm_reentrant_run_loop).
+
+reentrant_run_loop_driver_ir(InstrCount, LabelCount, DriverIR) :-
+    format(atom(DriverIR),
+'define i32 @main() {
+entry:
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @module_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @module_labels, i32 0, i32 0),
+      i32 ~w)
+  %step_pc = load i32, i32* @uw_native_loop_step_start_pc
+  %item = call %Value @value_integer(i64 0)
+  %zero = call %Value @value_integer(i64 0)
+  %one = call %Value @wam_call_count_step(%WamState* %vm, i32 %step_pc, %Value %item, %Value %zero)
+  %two = call %Value @wam_call_count_step(%WamState* %vm, i32 %step_pc, %Value %item, %Value %one)
+  %three = call %Value @wam_call_count_step(%WamState* %vm, i32 %step_pc, %Value %item, %Value %two)
+  %tag = extractvalue %Value %three, 0
+  %is_int = icmp eq i32 %tag, 1
+  br i1 %is_int, label %check_value, label %fail_tag
+
+check_value:
+  %payload = extractvalue %Value %three, 1
+  %ok = icmp eq i64 %payload, 3
+  br i1 %ok, label %success, label %fail_value
+
+success:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 0
+
+fail_tag:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 20
+
+fail_value:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 30
+}
+
+define %Value @wam_call_count_step(%WamState* %vm, i32 %start_pc, %Value %item, %Value %count0) {
+entry:
+  %unb = call %Value @value_unbound(i8* null)
+  %out_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %out_ref = call %Value @value_ref(i32 %out_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %start_pc)
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %item)
+  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %count0)
+  call void @wam_set_reg(%WamState* %vm, i32 2, %Value %out_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %done, label %failed
+
+done:
+  %out = call %Value @wam_deref_value(%WamState* %vm, %Value %out_ref)
+  ret %Value %out
+
+failed:
+  %bad = call %Value @value_integer(i64 -1)
+  ret %Value %bad
+}
+',
+        [InstrCount, InstrCount, InstrCount,
+         LabelCount, LabelCount, LabelCount]).


### PR DESCRIPTION
## Summary
- Add `@wam_prepare_call(%WamState*, StartPC)` for reusing one WAM VM across repeated native-driver calls into compiled WAM predicates.
- Add a native LLVM smoke proving a driver can call the same compiled WAM handler three times through `@run_loop`.
- Regenerate PLAWK LLVM probes and document the new native-loop bridge.

## Tests
- `swipl -q -s tests/test_wam_llvm_reentrant_run_loop.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_choicepoint_stack_restore.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `llvm-as examples/plawk/generated/plawk_core_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_loop_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_meta_call_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_reader_probe.ll -o /dev/null`