### PR TITLE
WAM R: lowered-dispatch dynamic guard (M152) + WAM Rust: bidirectional ancestor kernel (parity P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **WAM R target (M152): lowered fast path shadowed runtime-asserted
+  clauses.** Review finding from the Tn-lowering-vs-fact-sources
+  audit: `dispatch_call`/`Call`/`Execute` consulted
+  `program$lowered_dispatch` before the dynamic-clause tier, and a
+  lowered fn returns TRUE/FALSE definitively — so a predicate lowered
+  at codegen that later gained `assertz/1` clauses would have them
+  silently invisible. New `WamRuntime$lowered_path_ok` guard skips
+  the fast path whenever dynamic clauses exist for the key (the
+  interpreter path unions compiled + dynamic correctly). External
+  fact sources (LMDB/CSV) were audited SAFE by construction across
+  Scala/R/Rust: they compile to CallForeign stubs that fail lowering
+  gates (Scala), or the lowered path delegates foreign calls to step
+  (R), and runtime-built fact indexes are shared by both paths.
 - **WAM Rust target (M151): all-native/kernel projects generated
   uncompilable crates.** The long-standing `test_wam_rust_runtime`
   e2e failure (last item of the campaign ledger's small fixes) was

--- a/docs/handoff/rust_fsharp_parity_campaign.md
+++ b/docs/handoff/rust_fsharp_parity_campaign.md
@@ -1,0 +1,76 @@
+# Rust ⇄ F# Parity Campaign — Brief & Session State
+
+Written 2026-06-11 at the end of the M137–M152 correctness session
+(session: claude/jolly-ride-8ccdh7), to survive context compaction.
+Read together with `wam_correctness_campaign_handoff.md` (bug classes,
+probe battery, methodology, container toolchain map — do not duplicate
+that knowledge here).
+
+## Mission (owner's words, distilled)
+
+1. Inventory what the **F# hybrid WAM target** has that the **Rust
+   hybrid WAM target** lacks — *especially kernels and graph-search
+   algorithms* — and port the valuable parts to Rust.
+2. Once Rust reaches parity with F#, look at what *else* should be
+   implemented in Rust (graph-search related) based on the latest
+   commits, theory, and design documentation.
+3. Non-graph-search feature gaps between the two targets are also in
+   scope.
+
+## Starting pointers (verified to exist as of writing)
+
+- `docs/WAM_TARGET_ROADMAP.md` — per-target feature matrix. Known rows:
+  Rust = "hand-tuned FFI kernel route; effective-distance matrix FFI
+  kernel; port the kernel pattern to other targets; add layout
+  policies / FactSource generalisation; LMDB via lmdb-zero (R1)".
+  Check the F# row freshly — recent F# PRs added ISO arith-compare
+  sweep, succ/2 family, reverse-append builtins, lowered-emitter
+  Phase-I coverage, query smoke work.
+- `docs/handoff/wam_rust_simplewiki_blocker.md` — a documented Rust
+  graph-workload blocker; read FIRST, it may gate everything.
+- `docs/handoff/wam_haskell_enwiki_benchmark_handoff.md` — benchmark
+  shapes used for large-graph work (Haskell, but the data pipeline and
+  workload definitions transfer).
+- Graph-search theory/design recency: `docs/reports/` (reverse_csr_*,
+  bidirectional_kernel_simplewiki_benchmark, depth_likeness_budget,
+  topical_geometric_regime, distribution_cache_simplewiki_depth_grid
+  2026-06-10), `docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md`,
+  `docs/design/QUERY_PLAN_RUNTIME_PHILOSOPHY.md`.
+  Canonical simplewiki data: `examples/benchmark/parse_simplewiki_dump.py`
+  → SQLite → `data/benchmark/simplewiki_articles/category_parent.tsv`
+  (+ `root_categories.tsv`); sampling via
+  `scripts/sample_distribution_cache_subtree.py`.
+- Rust already has SOME kernels (don't re-port): the M151 e2e exercises
+  `tc_ancestor/2`, `tc_distance/3`, `tc_parent_distance/4`,
+  `tri_sum/2`, `weighted_path/3`, `astar_weighted_path/4`,
+  `min_semantic_dist` variants (FFI-kernel classified, wrappers added
+  in M151). F#'s comparative advantage is likely in builtins coverage,
+  intra-query machinery, and reverse-index/CSR work — verify.
+- Method that worked all session: fan out read-only inventory agents
+  (one for F# features, one for Rust features, one for theory-docs
+  recency), then diff, then implement in priority order with
+  per-feature exec tests + full-suite gates.
+
+## Session state at handoff
+
+- **Open PR**: #3015 (M152 R lowered-dispatch dynamic guard) — awaiting
+  owner merge. This handoff doc rides on the same branch.
+- **Flag for the T-tier agent / next session**:
+  `test_wam_r_generator:negation_meta_call_e2e_rscript` fails on
+  current main (`\+` meta-call e2e prints "true", expects "false") —
+  pre-existing before M152, verified by parent-commit run; likely from
+  a recent T-tier merge. Bisect per the campaign handoff discipline.
+- **Sub-agent quota**: exhausted around 2026-06-11 01:00 UTC; resets
+  4am UTC. Launch fan-out agents after that.
+- **Owner's standing preferences** (granted during this session):
+  create PRs without asking when work is verified; hold merge only
+  until full-suite gates are posted; Kotlin target = low investment
+  ("easy fixes only"); JVM ground-up + ILasm compound terms + WAT
+  read-mode are deliberately deferred (campaign-scoped); the
+  ILasm compound-terms campaign is "mine to resume" if chosen.
+- **Reviews delivered this session** (conclusions, no need to redo):
+  Tn lowering does NOT interfere with external fact sources (LMDB/CSV)
+  in Scala/R/Rust — safe by construction; the one real hazard
+  (R lowered_dispatch shadowing runtime assertz) is fixed by M152.
+  The graph-search agent's simplewiki work correctly used the
+  canonical category_parent.tsv artifact chain.

--- a/templates/targets/r_wam/runtime.R.mustache
+++ b/templates/targets/r_wam/runtime.R.mustache
@@ -1371,8 +1371,7 @@ WamRuntime$step <- function(program, state, instr) {
       # Lowered fast path (kernel / fact-table) wins over the WAM
       # array. The lowered fn pushes any iter CPs it needs and
       # returns TRUE/FALSE, so we just advance PC on success.
-      if (!is.null(program$lowered_dispatch) &&
-          exists(key, envir = program$lowered_dispatch, inherits = FALSE)) {
+      if (WamRuntime$lowered_path_ok(program, key)) {
         fn <- get(key, envir = program$lowered_dispatch, inherits = FALSE)
         ok <- isTRUE(fn(program, state))
         if (!ok) return(FALSE)
@@ -1405,8 +1404,7 @@ WamRuntime$step <- function(program, state, instr) {
       # Lowered fast path (kernel / fact-table) wins over the WAM
       # array. Tail-call: hand control back to the caller's CP via
       # the same path the dynamic-store branch uses on success.
-      if (!is.null(program$lowered_dispatch) &&
-          exists(key, envir = program$lowered_dispatch, inherits = FALSE)) {
+      if (WamRuntime$lowered_path_ok(program, key)) {
         fn <- get(key, envir = program$lowered_dispatch, inherits = FALSE)
         ok <- isTRUE(fn(program, state))
         if (!ok) return(FALSE)
@@ -4078,13 +4076,27 @@ WamRuntime$call_goal <- function(program, state, goal_term) {
   WamRuntime$dispatch_call(program, state, pred, arity)
 }
 
+# M152: a lowered fast path (kernel / fact-table / multi_clause_n)
+# returns TRUE/FALSE definitively and never consults the dynamic
+# clause store -- so a predicate that was lowered at codegen AND
+# later receives assertz/1 clauses at runtime would have those
+# clauses silently shadowed. Skip the fast path the moment dynamic
+# clauses exist for the key; the interpreter path unions compiled
+# and dynamic clauses correctly.
+WamRuntime$lowered_path_ok <- function(program, key) {
+  if (is.null(program$lowered_dispatch)) return(FALSE)
+  if (!exists(key, envir = program$lowered_dispatch, inherits = FALSE)) return(FALSE)
+  if (!is.null(program$dynamic) &&
+      exists(key, envir = program$dynamic, inherits = FALSE)) return(FALSE)
+  TRUE
+}
+
 WamRuntime$dispatch_call <- function(program, state, pred, arity) {
   key <- paste0(pred, "/", arity)
   # Lowered fast path (kernel / fact-table) wins over the WAM
   # array; the lowered fn manages its own iter CPs and returns
   # TRUE/FALSE.
-  if (!is.null(program$lowered_dispatch) &&
-      exists(key, envir = program$lowered_dispatch, inherits = FALSE)) {
+  if (WamRuntime$lowered_path_ok(program, key)) {
     fn <- get(key, envir = program$lowered_dispatch, inherits = FALSE)
     return(isTRUE(fn(program, state)))
   }


### PR DESCRIPTION
## Summary

Independent, individually-gated changes share this branch (plus the campaign handoff doc and a main-sync merge):

### 1. WAM R (M152): lowered fast path must not shadow runtime-asserted clauses

Concrete outcome of the Tn-lowering-vs-fact-sources review: external fact sources (LMDB/CSV) were audited **SAFE by construction** across Scala/R/Rust — they compile to `CallForeign` stubs that fail the lowering gates (Scala), or the lowered path delegates foreign calls to `step` (R), and fact indexes are built at runtime init and shared by both paths. The one real interference pattern found was adjacent: **R's lowered fast path shadowed runtime-asserted clauses.** New `WamRuntime$lowered_path_ok(program, key)` guard at all three dispatch sites: the fast path is taken only when **no** dynamic clauses exist for the key; otherwise dispatch falls back to the interpreter path, which unions compiled and dynamic clauses correctly.

### 2. WAM Rust: bidirectional ancestor kernel — F# parity port (P1) + bench harness (P1.5)

First implementation milestone of the Rust⇄F# parity campaign (brief: `docs/handoff/rust_fsharp_parity_campaign.md`, also on this branch). `kernel_mode(bidirectional)` upgrades a detected `category_ancestor` kernel to the 5-ary `bidirectional_ancestor` interface (`Pred(Cat, Root, TotalHops, ParentHops, ChildHops)`), streaming one solution per budget-feasible path — a faithful port of the F# kernel template:

- **Calibration**: BFS `min_dist` from root via child edges (the A* lower bound) + degree-moment calibration (dimensionality `D = E[d_child]`, branch ratio with routing-correction probe)
- **Exploration**: direction-cost search (`parent_step_cost`/`child_step_cost`/`cost_budget` f64 configs, defaults 1.0/3.0/10.0 as in F# and C) with A*-style lower-bound elimination
- **Child edges**: registered `child_pred` source (default `category_child`, e.g. the LMDB DUPSORT sub-db) or derived once by reversing the eager parent table
- **Bench harness** (P1.5): `main.rs.mustache` gains a `{{#bidirectional_kernel}}` branch — calibration hoisted out of the seed loop, per-seed direction-weighted power mean (F# `effectiveDistanceWeighted`). First numbers in `docs/reports/wam_rust_bidirectional_kernel_synthetic_bench.md`: tuple_count parity with the upward-only kernel at 1k/10k (462 @ 10k); ~6.5× query cost at 10k from enumerating both directions (same shape as the F# simplewiki report)
- Opt-in only, mirroring Haskell/F#'s `maybe_upgrade_bidirectional`; default emission unchanged (regression-guarded)

## Test plan

- [x] `test_wam_r_lowered_ite`, `test_wam_r_lowered_t5`, `test_wam_r_generator` (78 passed; the 1 failure, `negation_meta_call_e2e_rscript`, fails identically on the parent commit — pre-existing on main, flagged for the T-tier stream)
- [x] New `tests/test_wam_rust_bidirectional_e2e.pl`: codegen assertions, default-mode guard, and a **cargo-built execution test** with hand-checked path enumerations (two pure-parent paths; a mixed child+parent route that exists only because the A* bound prunes the upward detour; unreachable-root failure)
- [x] `test_wam_rust_target.pl` — all pass
- [x] `test_wam_rust_runtime.pl` — all pass incl. the cargo e2e (re-run after the harness change)
- [x] `test_wam_rust_lowered_t4/t5/t6`, `ite_exec`, `save_regs` — all pass
- [x] Default-mode generated project `cargo check` clean (inverted-section branch of the harness)

https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM)_