### PR TITLE
Add distribution calibration cost signals

### DIFF
--- a/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
+++ b/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
@@ -398,6 +398,22 @@ can carry min/max bounds through large parts of the graph, then materialise full
 distributions only where the query workload, error budget, or cache score makes
 the extra state worthwhile.
 
+Ancestor-cone size is a separate admission signal. A node can be fairly deep in
+root distance but still have a small target-scoped ancestor cone. In that case,
+exact histograms may remain cheap because the planner only materialises the
+distributions needed by the node of interest, not a global table. The first
+calibration pass should therefore record both support_width and ancestor_cone_nodes;
+a deep node with a small cone and narrow support is a
+good exact-histogram candidate even when a global depth rule would reject it.
+
+Continuous or sampled approximations should be charged as computation, not just
+as storage. For example, a Gamma-like continuous approximation can be sampled
+onto a finite grid before FFT convolution, but good accuracy may require tens or
+hundreds of sample points. If the exact ancestor-scoped histogram has only a few
+bins, sampling 100 points is unlikely to save compute. Its main value is then a
+compact reusable representation, not avoiding the initial exact or sampled
+construction.
+
 Support width should be paired with a parent-branching signal before choosing
 how deep to carry exact histograms. Let `p_v` be the number of parent choices for
 node `v` under the active graph/filter/root policy. Then:

--- a/docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md
+++ b/docs/design/DISTRIBUTION_CACHE_BENCHMARK_PLAN.md
@@ -140,6 +140,13 @@ first_cache_hit_depth_from_target
 remaining_budget_at_hit
 histogram_bins_scanned
 cumulative_basis_lookups
+ancestor_cone_nodes
+ancestor_cone_edges
+exact_histogram_bytes
+parametric_state_bytes_estimate
+continuous_sample_points
+continuous_sample_bytes_estimate
+compression_ratio_estimate
 result_mass
 result_first_moment
 result_weighted_power
@@ -262,6 +269,14 @@ if L_max(v) - L_min(v) is large: prefer a cached boundary or fitted tail candida
 
 This lets deeper layers carry cheap min/max summaries while the planner decides
 where full histograms are still worth materialising.
+
+When the target-scoped ancestor cone is small, full histograms may remain cheap
+even for nodes that are deep by root distance. The benchmark should therefore
+separate global precompute depth from per-query ancestor-cone cost. A continuous
+fit sampled onto a fixed grid, such as 100 points before FFT convolution, should
+beat exact histograms only when the exact support or reuse pattern justifies
+that grid cost. Otherwise it is primarily a storage/compression option after an
+exact or sampled distribution has already been validated.
 
 The same run should report parent-degree moments over the selected reachable
 nodes:

--- a/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
+++ b/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
@@ -277,6 +277,15 @@ about the final closed-form family. It should be validated against exact
 histograms on SimpleWiki and sampled enwiki subgraphs before being used for
 policy decisions.
 
+A continuous fit can also be sampled onto a discrete grid before FFT
+composition. That is sometimes useful when the fitted family is easier to store
+or compose analytically than the empirical histogram. It is not automatically a
+compute win: a 100-point sampled Gamma grid is more work than a three-bin exact
+ancestor-scoped histogram. The benchmark should therefore record sampled grid
+size, exact support bins, and ancestor-cone size separately. If the sample grid
+is larger than the exact histogram, the fit may still be useful as compression
+after validation, but not as evidence that exact construction can be skipped.
+
 ## 6. Shifted exponential / Gamma tail approximation
 
 For larger branching, the discrete convolution may become expensive or too noisy

--- a/scripts/distribution_fit_comparison.py
+++ b/scripts/distribution_fit_comparison.py
@@ -29,6 +29,7 @@ from tools.distribution_cache_support import (  # noqa: E402
     FIXTURES,
     ROOT,
     exact_histogram,
+    histogram_bytes,
     load_parent_edges_tsv,
     reachable_nodes_by_parent_distance,
 )
@@ -70,6 +71,44 @@ def distribution_moments(probabilities: list[float]) -> tuple[float, float]:
     mean = sum(index * probability for index, probability in enumerate(probabilities))
     variance = sum(((index - mean) ** 2) * probability for index, probability in enumerate(probabilities))
     return mean, variance
+
+
+def distribution_skewness(probabilities: list[float]) -> float | None:
+    mean, variance = distribution_moments(probabilities)
+    if variance <= 0.0:
+        return None
+    stddev = math.sqrt(variance)
+    third = sum(((index - mean) ** 3) * probability for index, probability in enumerate(probabilities))
+    return third / (stddev**3)
+
+
+def ancestor_cone_size(node, parents) -> tuple[int, int]:
+    """Count the parent-reachable cone for a single target node."""
+    seen = set()
+    stack = [node]
+    edges = 0
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        for parent in parents.get(current, []):
+            edges += 1
+            if parent not in seen:
+                stack.append(parent)
+    return len(seen), edges
+
+
+def parametric_state_bytes_estimate(params: dict[str, object]) -> int:
+    """Estimate stored family id, support, parameters, and error metadata."""
+    scalar_count = 4
+    scalar_count += sum(1 for value in params.values() if isinstance(value, (int, float)))
+    scalar_count += 2
+    return scalar_count * 8
+
+
+def dense_sample_bytes(sample_points: int) -> int:
+    return max(0, sample_points) * 8
 
 
 def binomial_pmf(trials: int, probability: float) -> list[float]:
@@ -277,7 +316,7 @@ def prior_model_builders(depth: int):
     ]
 
 
-def target_fit_records(graph_name, graph_label, parents, root, target, hist_memo, tail_epsilon):
+def target_fit_records(graph_name, graph_label, parents, root, target, hist_memo, tail_epsilon, continuous_sample_points):
     started = time.perf_counter_ns()
     hist = exact_histogram(target, parents, root, hist_memo)
     exact_time_ns = time.perf_counter_ns() - started
@@ -286,8 +325,12 @@ def target_fit_records(graph_name, graph_label, parents, root, target, hist_memo
         return []
 
     mean, variance = distribution_moments(empirical)
+    exact_bytes = histogram_bytes(hist)
+    dense_sample_estimate = dense_sample_bytes(continuous_sample_points)
+    cone_nodes, cone_edges = ancestor_cone_size(target, parents)
     records = []
     for model_record in compare_models(empirical, realized_model_builders()):
+        parametric_bytes = parametric_state_bytes_estimate(model_record["fit_params"])
         records.append({
             "record_type": "distribution_fit",
             "distribution_role": "realized_fit",
@@ -303,14 +346,23 @@ def target_fit_records(graph_name, graph_label, parents, root, target, hist_memo
             "path_count": sum(hist.values()),
             "mean_excess": mean,
             "variance_excess": variance,
+            "skewness_excess": distribution_skewness(empirical),
             "exact_histogram_time_ns": exact_time_ns,
+            "ancestor_cone_nodes": cone_nodes,
+            "ancestor_cone_edges": cone_edges,
+            "exact_histogram_bytes": exact_bytes,
+            "parametric_state_bytes_estimate": parametric_bytes,
+            "compression_ratio_estimate": 0.0 if parametric_bytes == 0 else exact_bytes / parametric_bytes,
+            "continuous_sample_points": continuous_sample_points,
+            "continuous_sample_bytes_estimate": dense_sample_estimate,
+            "sample_storage_ratio_estimate": 0.0 if dense_sample_estimate == 0 else exact_bytes / dense_sample_estimate,
             "parent_degree": len(parents.get(target, [])),
             **model_record,
         })
     return records
 
 
-def depth_prior_records(graph_name, graph_label, parent_degrees, depths, tail_epsilon):
+def depth_prior_records(graph_name, graph_label, parent_degrees, depths, tail_epsilon, continuous_sample_points):
     base = size_biased_excess_pmf(parent_degrees)
     base_mean, base_variance = distribution_moments(base)
     records = []
@@ -319,7 +371,10 @@ def depth_prior_records(graph_name, graph_label, parent_degrees, depths, tail_ep
         empirical = nfold_convolution(base, depth)
         exact_time_ns = time.perf_counter_ns() - started
         mean, variance = distribution_moments(empirical)
+        dense_sample_estimate = dense_sample_bytes(continuous_sample_points)
+        dense_prior_estimate = dense_sample_bytes(len(empirical))
         for model_record in compare_models(empirical, prior_model_builders(depth)):
+            parametric_bytes = parametric_state_bytes_estimate(model_record["fit_params"])
             records.append({
                 "record_type": "distribution_fit",
                 "distribution_role": "depth_prior",
@@ -331,21 +386,48 @@ def depth_prior_records(graph_name, graph_label, parent_degrees, depths, tail_ep
                 "effective_support_bins": effective_support_bins(empirical, tail_epsilon),
                 "mean_excess": mean,
                 "variance_excess": variance,
+                "skewness_excess": distribution_skewness(empirical),
                 "base_mean_excess": base_mean,
                 "base_variance_excess": base_variance,
                 "base_support_bins": len(base),
                 "exact_histogram_time_ns": exact_time_ns,
+                "dense_prior_bytes_estimate": dense_prior_estimate,
+                "parametric_state_bytes_estimate": parametric_bytes,
+                "compression_ratio_estimate": 0.0 if parametric_bytes == 0 else dense_prior_estimate / parametric_bytes,
+                "continuous_sample_points": continuous_sample_points,
+                "continuous_sample_bytes_estimate": dense_sample_estimate,
+                "sample_storage_ratio_estimate": 0.0 if dense_sample_estimate == 0 else dense_prior_estimate / dense_sample_estimate,
                 **model_record,
             })
     return records
 
 
-def run_graph_fit_comparison(graph_name, graph_label, parents, targets, root, depths=None, tail_epsilon=0.001):
+def run_graph_fit_comparison(
+    graph_name,
+    graph_label,
+    parents,
+    targets,
+    root,
+    depths=None,
+    tail_epsilon=0.001,
+    continuous_sample_points=100,
+):
     records = []
     hist_memo = {}
     for target in targets:
         try:
-            records.extend(target_fit_records(graph_name, graph_label, parents, root, target, hist_memo, tail_epsilon))
+            records.extend(
+                target_fit_records(
+                    graph_name,
+                    graph_label,
+                    parents,
+                    root,
+                    target,
+                    hist_memo,
+                    tail_epsilon,
+                    continuous_sample_points,
+                )
+            )
         except ValueError as exc:
             records.append({
                 "record_type": "distribution_fit_error",
@@ -356,7 +438,16 @@ def run_graph_fit_comparison(graph_name, graph_label, parents, targets, root, de
                 "error": str(exc),
             })
     parent_degrees = [len(parents.get(target, [])) for target in targets]
-    records.extend(depth_prior_records(graph_name, graph_label, parent_degrees, depths or DEFAULT_DEPTHS, tail_epsilon))
+    records.extend(
+        depth_prior_records(
+            graph_name,
+            graph_label,
+            parent_degrees,
+            depths or DEFAULT_DEPTHS,
+            tail_epsilon,
+            continuous_sample_points,
+        )
+    )
     return records
 
 
@@ -387,8 +478,8 @@ def summarize(records: list[dict[str, object]]) -> str:
         "",
         "## Realized Histogram Fits",
         "",
-        "| model | rows | mean_l1 | p95_l1 | max_l1 | mean_cdf_error | mean_build_ns | mean_exact_hist_ns |",
-        "|-------|------|---------|--------|--------|----------------|---------------|--------------------|",
+        "| model | rows | mean_l1 | p95_l1 | max_l1 | mean_cdf_error | mean_build_ns | mean_exact_hist_ns | mean_compression |",
+        "|-------|------|---------|--------|--------|----------------|---------------|--------------------|------------------|",
     ]
     append_model_table(lines, realized_records)
     if realized_records:
@@ -404,8 +495,8 @@ def summarize(records: list[dict[str, object]]) -> str:
         "",
         "## Depth-Conditioned Prior Distributions",
         "",
-        "| model | rows | mean_l1 | p95_l1 | max_l1 | mean_cdf_error | mean_build_ns | mean_exact_hist_ns |",
-        "|-------|------|---------|--------|--------|----------------|---------------|--------------------|",
+        "| model | rows | mean_l1 | p95_l1 | max_l1 | mean_cdf_error | mean_build_ns | mean_exact_hist_ns | mean_compression |",
+        "|-------|------|---------|--------|--------|----------------|---------------|--------------------|------------------|",
     ])
     append_model_table(lines, prior_records)
 
@@ -486,7 +577,7 @@ def append_model_table(lines: list[str], rows: list[dict[str, object]]) -> None:
         build_times = [int(row["build_time_ns"]) for row in model_rows]
         exact_times = [int(row["exact_histogram_time_ns"]) for row in model_rows]
         lines.append(
-            "| {model} | {rows} | {mean_l1:.6f} | {p95_l1:.6f} | {max_l1:.6f} | {mean_cdf:.6f} | {mean_build:.1f} | {mean_exact:.1f} |".format(
+            "| {model} | {rows} | {mean_l1:.6f} | {p95_l1:.6f} | {max_l1:.6f} | {mean_cdf:.6f} | {mean_build:.1f} | {mean_exact:.1f} | {mean_compression:.3f} |".format(
                 model=model,
                 rows=len(model_rows),
                 mean_l1=statistics.mean(l1_values) if l1_values else 0.0,
@@ -495,6 +586,7 @@ def append_model_table(lines: list[str], rows: list[dict[str, object]]) -> None:
                 mean_cdf=statistics.mean(cdf_values) if cdf_values else 0.0,
                 mean_build=statistics.mean(build_times) if build_times else 0.0,
                 mean_exact=statistics.mean(exact_times) if exact_times else 0.0,
+                mean_compression=statistics.mean(float(row.get("compression_ratio_estimate", 0.0)) for row in model_rows),
             )
         )
 
@@ -538,6 +630,12 @@ def main(argv=None):
     parser.add_argument("--target-limit", type=int, help="Limit selected edge-file targets after sorting/filtering.")
     parser.add_argument("--depths", default=",".join(map(str, DEFAULT_DEPTHS)), help="Depth horizons for prior distributions.")
     parser.add_argument("--tail-epsilon", type=float, default=0.001, help="Tail mass allowed outside effective support.")
+    parser.add_argument(
+        "--continuous-sample-points",
+        type=int,
+        default=100,
+        help="Point count for estimating sampled-continuous representation cost.",
+    )
     parser.add_argument("--output-dir", type=Path, help="Optional directory for JSONL and markdown output.")
     args = parser.parse_args(argv)
 
@@ -555,7 +653,18 @@ def main(argv=None):
             args.max_target_depth,
             args.target_limit,
         )
-        records.extend(run_graph_fit_comparison(graph_name, graph_name, parents, targets, root, depths, args.tail_epsilon))
+        records.extend(
+            run_graph_fit_comparison(
+                graph_name,
+                graph_name,
+                parents,
+                targets,
+                root,
+                depths,
+                args.tail_epsilon,
+                args.continuous_sample_points,
+            )
+        )
     else:
         root = args.root or ROOT
         if root != ROOT:
@@ -566,7 +675,18 @@ def main(argv=None):
             if fixture_name not in FIXTURES:
                 raise SystemExit(f"unknown fixture: {fixture_name}")
             fixture = FIXTURES[fixture_name]
-            records.extend(run_graph_fit_comparison(graph_name, fixture_name, fixture["parents"], fixture["targets"], root, depths, args.tail_epsilon))
+            records.extend(
+                run_graph_fit_comparison(
+                    graph_name,
+                    fixture_name,
+                    fixture["parents"],
+                    fixture["targets"],
+                    root,
+                    depths,
+                    args.tail_epsilon,
+                    args.continuous_sample_points,
+                )
+            )
 
     summary = summarize(records)
     print(summary, end="")


### PR DESCRIPTION
## Summary

- Extend `scripts/distribution_fit_comparison.py` with calibration signals that distinguish compute savings from storage/compression savings:
  - target ancestor-cone node/edge counts
  - exact histogram byte estimate
  - parametric state byte estimate
  - sampled-continuous grid byte estimate via `--continuous-sample-points`
  - compression ratio estimate
  - excess-distribution skewness
- Update generated fit summaries with a `mean_compression` column.
- Document that deep nodes can still be cheap when their target-scoped ancestor cone and histogram support are small.
- Document that sampling a continuous fit before FFT can help representation/storage, but is not automatically a compute win when exact histograms have few bins.

## Validation

- `python3 scripts/distribution_fit_comparison.py --fixtures all --depths 2,4 --continuous-sample-points 100`
- `python3 -m py_compile scripts/distribution_fit_comparison.py`
- `git diff --check`