### PR TITLE
test(wam-wat): cover is/2 assignment in T4 + correct stale doc note

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -353,8 +353,16 @@ Score each candidate gap on four axes, then sequence:
    T5). **python DONE** (`~` hybrid — native clause bodies over a retained
    bytecode dispatch scaffold, since python's backtracking runtime makes the
    first-solution imperative shape unsound; a full-native R-style dispatch
-   could layer in front later). Remaining structurer-column hole: none — only
-   **wat** lacks T4 now (its runtime has no lowered multi-clause path yet).
+   could layer in front later). **wat DONE** too: its lowered emitter splits the
+   try/retry/trust chain into per-clause WAT slices via
+   `wat_multi_clause_n_lowerable`, emits each as an inline block that snapshots
+   and restores the argument registers + trail between attempts (first-solution,
+   the public entry replays the interpreter on a 0 return). The **T4 column is
+   now complete across every target.** Verified through real `wat2wasm`+`node`
+   exec (`test_wam_wat_lowered_t4`), including arithmetic `is/2` *assignment*
+   bodies — WAT's `put_structure` does not have the aliased-result-register bug
+   that affected the Python interpreter, so an `is`-assignment that binds a local
+   or the head's own arg evaluates correctly in lowered code.
 4. **T6 (first-arg indexing)** — same clause-head front-end as T5 with a
    `switch` back-end instead of an `->` cascade. **DONE / closed out for every
    T5 target:** the atom-keyed set (rust/cpp/fsharp/go, string switch), the

--- a/tests/test_wam_wat_lowered_t4.pl
+++ b/tests/test_wam_wat_lowered_t4.pl
@@ -32,7 +32,8 @@
 :- use_module('../src/unifyweaver/targets/wam_wat_target').
 :- use_module('../src/unifyweaver/targets/wam_wat_lowered_emitter').
 
-:- dynamic user:samearg/1, user:grade/2, user:qq/2, user:color/1.
+:- dynamic user:samearg/1, user:grade/2, user:qq/2, user:color/1,
+           user:dchk/1, user:ddv/2.
 
 % variable first argument -> NOT first-arg-discriminable -> T4, not T5
 user:samearg(X) :- X = a.
@@ -44,6 +45,16 @@ user:grade(N, fail) :- N < 50.
 % failing; clause 2 needs A2 restored to its entry value (50).
 user:qq(X, 50) :- X > 100.
 user:qq(_Y, 50) :- true.
+% Arithmetic is/2 ASSIGNMENT in a multi-clause body (not just comparison): it
+% builds an expression structure and binds an unbound target. dchk/1 binds a
+% LOCAL var M (the bug-prone unbound-target path) and folds the result into a
+% boolean via =:=; ddv/2 binds the head's 2nd arg — the A1=R / A2=structure
+% aliasing pattern that broke the Python interpreter (put_structure clobbering
+% the aliased result register). Both must stay correct through the lowered WAT.
+user:dchk(N) :- N >= 0, M is N + N, M =:= 10.
+user:dchk(N) :- N < 0,  M is 0 - N, M =:= 10.
+user:ddv(N, R) :- N >= 0, R is N + N.
+user:ddv(N, R) :- N < 0,  R is 0 - N.
 % distinct first-arg atoms -> T5 (clause_chain), NOT T4 (over-claim guard)
 user:color(red).
 user:color(green).
@@ -102,6 +113,28 @@ test(t4_exec) :-
     ->  true
     ;   format(user_error, "~n[wat t4 mismatches]~n~q~n", [Failures]),
         throw(wam_wat_t4_failed(Failures))
+    ).
+
+% is/2 ASSIGNMENT (structure construction + binding an unbound target) through
+% the lowered WAT — the case the comparison-only battery above never exercised,
+% and the exact pattern that broke the Python interpreter's put_structure.
+test(t4_exec_is_assignment) :-
+    Cases = [ tc_dchk_5-(dchk/1)-["5"]-1,        % M is 5+5=10, =:=10 -> 1
+              tc_dchk_3-(dchk/1)-["3"]-0,        % M=6, =:=10 -> 0
+              tc_dchk_m10-(dchk/1)-["-10"]-1,    % clause 2: M is 0-(-10)=10 -> 1
+              tc_ddv_5_10-(ddv/2)-["5","10"]-1,  % R is 5+5=10, unify bound 10 -> 1
+              tc_ddv_5_11-(ddv/2)-["5","11"]-0,  % 10 != 11 -> 0
+              tc_ddv_m3_3-(ddv/2)-["-3","3"]-1 ],% clause 2: R is 0-(-3)=3 -> 1
+    build_injected_module([dchk/1, ddv/2], Cases, Wasm, Harness),
+    findall(Name-Got-Want,
+            ( member(Name-_-_-Want, Cases),
+              run_export(Harness, Wasm, Name, Got),
+              Got =\= Want ),
+            Failures),
+    ( Failures == []
+    ->  true
+    ;   format(user_error, "~n[wat t4 is-assignment mismatches]~n~q~n", [Failures]),
+        throw(wam_wat_t4_is_failed(Failures))
     ).
 
 :- end_tests(wam_wat_lowered_t4).


### PR DESCRIPTION
## TL;DR

Investigating "finish WAT T4" found that **WAT T4 was already implemented, tested, and correct** — the matrix cell and verification notes already say so. The only gaps were a **stale sequencing note** (still claiming "only wat lacks T4") and a **test-coverage hole**: the T4 exec battery covered arithmetic *comparisons* but never `is/2` *assignment*. This PR closes both.

## Why `is`-assignment matters here

`is/2` assignment is the bug-prone path — it builds an expression structure and binds an unbound target. For `R is Expr` the compiler leaves the result var aliased into `A1` while `A2` is overwritten with the structure, which is the **exact pattern that broke the Python interpreter** (`put_structure` clobbering the aliased result register, fixed in #3018). WAT's comparison-only battery (`N >= 50`, `X > 100`) never exercised it.

## Verified WAT is clean

Through real `wat2wasm` + `node` exec on lowered code:

```prolog
dchk(N) :- N >= 0, M is N + N, M =:= 10.   % unbound LOCAL target M
dchk(N) :- N <  0, M is 0 - N, M =:= 10.
ddv(N, R) :- N >= 0, R is N + N.            % binds head arg R (aliasing pattern)
ddv(N, R) :- N <  0, R is 0 - N.
```

`dchk(5)=1`, `dchk(3)=0`, `dchk(-10)=1`, `ddv(5,10)=1`, `ddv(5,11)=0`, `ddv(-3,3)=1` — all correct. **WAT does not have the Python aliasing bug.** Added as `test(t4_exec_is_assignment)` so the bug class is guarded on WAT too.

## Doc

Replaced the stale "wat lacks T4" sequencing note with WAT's actual T4 mechanism (per-clause WAT slices with argument-register + trail snapshot/restore between attempts) and noted the **T4 column is now complete across every target**.

## Tests
`test_wam_wat_lowered_t4` passes (gate + snapshot/restore + comparison battery + the new `is`-assignment battery).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_