### PR TITLE
[codex] Drive PLAWK native loop from stream helpers

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -191,16 +191,16 @@ lines — identical behaviour to Phase 0, running as compiled LLVM.
 **Current boundary:** the compiled stream smoke still reads from a file path
 rather than stdin, and `state/4` remains represented as ordinary WAM terms
 rather than a specialized LLVM aggregate. Generic output accumulation now goes
-through `append_output/3` and `state_outputs/2`. WAM/LLVM also has a
-`@wam_prepare_call` runtime helper for native deterministic outer loops; it
-preserves heap terms that carry state between calls while clearing transient
-stack, trail, choicepoint, and cut bookkeeping at each call boundary. The
-`tests/test_plawk_native_outer_loop_driver.pl` smoke proves the next step:
-a native LLVM loop over static line atoms can call a compiled PLAWK handler once
-per record, thread PLAWK state across those calls, and read the final count and
-outputs back through WAM. The remaining loop boundary is replacing the static
-record atoms with a runtime file/stdin reader loop and then lowering hot state
-fields such as `state/4` to native aggregates.
+through `append_output/3` and `state_outputs/2`. WAM/LLVM now exposes general
+stream helpers (`@wam_stream_open_value`, `@wam_stream_read_line_value`, and
+`@wam_stream_close_value`) that native LLVM code can call directly, alongside
+the existing `stream_open/2`, `read_line/2`, and `stream_close/1` builtins.
+The `tests/test_plawk_native_stream_loop_driver.pl` smoke proves a native LLVM
+loop can open a runtime file path, read lines until `end_of_file`, call a
+compiled PLAWK handler once per record, thread PLAWK state across those calls,
+and read the final count and outputs back through WAM. The remaining hot-loop
+boundary is lowering state fields such as `state/4` counter/output data to
+native aggregates rather than ordinary WAM terms.
 
 **Compiler note:** this smoke detects matching lines by `sub_atom(Line, 0, 5, _, 'ERROR')`
 instead of full-line facts such as `'ERROR disk full'`. The current WAM/LLVM

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -67,6 +67,7 @@ swipl -q -s examples/plawk/demo/count_errors.pl -t halt
 swipl -q -s examples/plawk/demo/print_error_fields.pl -t halt
 swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_native_outer_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_native_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.

--- a/examples/plawk/generated/plawk_core_probe.ll
+++ b/examples/plawk/generated/plawk_core_probe.ll
@@ -6390,6 +6390,248 @@ done:
 @wam_stream_handle_table = internal global [4096 x %WamLineReader*] zeroinitializer
 @wam_stream_handle_count = internal global i32 0
 
+@.wam_stream_eof_atom = private constant [12 x i8] c"end_of_file "
+
+define %Value @wam_stream_fail_value() alwaysinline nounwind {
+entry:
+  %bad = call %Value @value_integer(i64 -1)
+  ret %Value %bad
+}
+
+define %Value @wam_stream_open_value(%Value %path_value) {
+entry:
+  %soh.t = call i32 @value_tag(%Value %path_value)
+  %soh.is_atom = icmp eq i32 %soh.t, 0
+  br i1 %soh.is_atom, label %soh.have_path, label %soh.fail
+
+soh.fail:
+  %soh.bad = call %Value @wam_stream_fail_value()
+  ret %Value %soh.bad
+
+soh.have_path:
+  %soh.aid = call i64 @value_payload(%Value %path_value)
+  %soh.path = call i8* @wam_atom_to_string(i64 %soh.aid)
+  %soh.path_null = icmp eq i8* %soh.path, null
+  br i1 %soh.path_null, label %soh.fail, label %soh.open
+
+soh.open:
+  %soh.fd = call i32 @open(i8* %soh.path, i32 0, i32 0)
+  %soh.open_ok = icmp sge i32 %soh.fd, 0
+  br i1 %soh.open_ok, label %soh.alloc_reader, label %soh.fail
+
+soh.alloc_reader:
+  %soh.reader_size = ptrtoint %WamLineReader* getelementptr (%WamLineReader, %WamLineReader* null, i32 1) to i64
+  %soh.reader_mem = call i8* @malloc(i64 %soh.reader_size)
+  %soh.reader_null = icmp eq i8* %soh.reader_mem, null
+  br i1 %soh.reader_null, label %soh.close_fd_fail, label %soh.alloc_buf
+
+soh.close_fd_fail:
+  call i32 @close(i32 %soh.fd)
+  br label %soh.fail
+
+soh.alloc_buf:
+  %soh.buf = call i8* @malloc(i64 4096)
+  %soh.buf_null = icmp eq i8* %soh.buf, null
+  br i1 %soh.buf_null, label %soh.free_reader_fail, label %soh.init
+
+soh.free_reader_fail:
+  call void @free(i8* %soh.reader_mem)
+  call i32 @close(i32 %soh.fd)
+  br label %soh.fail
+
+soh.init:
+  %soh.reader = bitcast i8* %soh.reader_mem to %WamLineReader*
+  %soh.fd_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 0
+  store i32 %soh.fd, i32* %soh.fd_slot
+  %soh.buf_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 1
+  store i8* %soh.buf, i8** %soh.buf_slot
+  %soh.cap_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 2
+  store i64 4096, i64* %soh.cap_slot
+  %soh.len_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 3
+  store i64 0, i64* %soh.len_slot
+  %soh.pos_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 4
+  store i64 0, i64* %soh.pos_slot
+  %soh.count = load i32, i32* @wam_stream_handle_count
+  %soh.next = add i32 %soh.count, 1
+  %soh.cap_ok = icmp ult i32 %soh.next, 4096
+  br i1 %soh.cap_ok, label %soh.store_handle, label %soh.close_all_fail
+
+soh.store_handle:
+  %soh.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %soh.next
+  store %WamLineReader* %soh.reader, %WamLineReader** %soh.slot
+  store i32 %soh.next, i32* @wam_stream_handle_count
+  %soh.handle = zext i32 %soh.next to i64
+  %soh.v = call %Value @value_integer(i64 %soh.handle)
+  ret %Value %soh.v
+
+soh.close_all_fail:
+  call i32 @close(i32 %soh.fd)
+  call void @free(i8* %soh.buf)
+  call void @free(i8* %soh.reader_mem)
+  br label %soh.fail
+}
+
+define %Value @wam_stream_read_line_value(%Value %handle_value) {
+entry:
+  %rhv.t = call i32 @value_tag(%Value %handle_value)
+  %rhv.is_int = icmp eq i32 %rhv.t, 1
+  br i1 %rhv.is_int, label %rhv.lookup_handle, label %rhv.fail
+
+rhv.fail:
+  %rhv.bad = call %Value @wam_stream_fail_value()
+  ret %Value %rhv.bad
+
+rhv.lookup_handle:
+  %rhv.handle64 = call i64 @value_payload(%Value %handle_value)
+  %rhv.handle = trunc i64 %rhv.handle64 to i32
+  %rhv.handle_min = icmp sgt i32 %rhv.handle, 0
+  %rhv.handle_max = icmp ult i32 %rhv.handle, 4096
+  %rhv.handle_ok = and i1 %rhv.handle_min, %rhv.handle_max
+  br i1 %rhv.handle_ok, label %rhv.load_handle, label %rhv.fail
+
+rhv.load_handle:
+  %rhv.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %rhv.handle
+  %rhv.reader = load %WamLineReader*, %WamLineReader** %rhv.slot
+  %rhv.reader_null = icmp eq %WamLineReader* %rhv.reader, null
+  br i1 %rhv.reader_null, label %rhv.fail, label %rhv.have_handle
+
+rhv.have_handle:
+  %rhv.fd_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 0
+  %rhv.fd = load i32, i32* %rhv.fd_slot
+  %rhv.fd_ok = icmp sge i32 %rhv.fd, 0
+  br i1 %rhv.fd_ok, label %rhv.alloc_out, label %rhv.fail
+
+rhv.alloc_out:
+  call void @wam_arena_ensure()
+  %rhv.out = call i8* @wam_arena_alloc(i64 65537)
+  br label %rhv.loop
+
+rhv.loop:
+  %rhv.out_len = phi i64 [ 0, %rhv.alloc_out ], [ %rhv.out_len, %rhv.after_read ], [ %rhv.next_out_len, %rhv.append_store ]
+  %rhv.buf_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 1
+  %rhv.buf = load i8*, i8** %rhv.buf_slot
+  %rhv.len_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 3
+  %rhv.len = load i64, i64* %rhv.len_slot
+  %rhv.pos_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 4
+  %rhv.pos = load i64, i64* %rhv.pos_slot
+  %rhv.have_byte = icmp slt i64 %rhv.pos, %rhv.len
+  br i1 %rhv.have_byte, label %rhv.consume, label %rhv.fill
+
+rhv.fill:
+  %rhv.cap_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 2
+  %rhv.cap = load i64, i64* %rhv.cap_slot
+  %rhv.n = call i64 @read(i32 %rhv.fd, i8* %rhv.buf, i64 %rhv.cap)
+  %rhv.n_neg = icmp slt i64 %rhv.n, 0
+  br i1 %rhv.n_neg, label %rhv.fail, label %rhv.check_eof
+
+rhv.check_eof:
+  %rhv.n_zero = icmp eq i64 %rhv.n, 0
+  br i1 %rhv.n_zero, label %rhv.eof_or_partial, label %rhv.after_read
+
+rhv.after_read:
+  store i64 %rhv.n, i64* %rhv.len_slot
+  store i64 0, i64* %rhv.pos_slot
+  br label %rhv.loop
+
+rhv.eof_or_partial:
+  %rhv.empty_line = icmp eq i64 %rhv.out_len, 0
+  br i1 %rhv.empty_line, label %rhv.eof, label %rhv.finalize
+
+rhv.consume:
+  %rhv.char_ptr = getelementptr i8, i8* %rhv.buf, i64 %rhv.pos
+  %rhv.ch = load i8, i8* %rhv.char_ptr
+  %rhv.pos_next = add i64 %rhv.pos, 1
+  store i64 %rhv.pos_next, i64* %rhv.pos_slot
+  %rhv.is_lf = icmp eq i8 %rhv.ch, 10
+  br i1 %rhv.is_lf, label %rhv.finalize, label %rhv.append
+
+rhv.append:
+  %rhv.has_room = icmp ult i64 %rhv.out_len, 65536
+  br i1 %rhv.has_room, label %rhv.append_store, label %rhv.fail
+
+rhv.append_store:
+  %rhv.out_ptr = getelementptr i8, i8* %rhv.out, i64 %rhv.out_len
+  store i8 %rhv.ch, i8* %rhv.out_ptr
+  %rhv.next_out_len = add i64 %rhv.out_len, 1
+  br label %rhv.loop
+
+rhv.finalize:
+  %rhv.has_chars = icmp sgt i64 %rhv.out_len, 0
+  br i1 %rhv.has_chars, label %rhv.check_cr, label %rhv.intern_empty
+
+rhv.check_cr:
+  %rhv.last_idx = sub i64 %rhv.out_len, 1
+  %rhv.last_ptr = getelementptr i8, i8* %rhv.out, i64 %rhv.last_idx
+  %rhv.last = load i8, i8* %rhv.last_ptr
+  %rhv.last_is_cr = icmp eq i8 %rhv.last, 13
+  %rhv.trim_len = select i1 %rhv.last_is_cr, i64 %rhv.last_idx, i64 %rhv.out_len
+  br label %rhv.intern
+
+rhv.intern_empty:
+  br label %rhv.intern
+
+rhv.intern:
+  %rhv.final_len = phi i64 [ %rhv.trim_len, %rhv.check_cr ], [ 0, %rhv.intern_empty ]
+  %rhv.term = getelementptr i8, i8* %rhv.out, i64 %rhv.final_len
+  store i8 0, i8* %rhv.term
+  %rhv.aid = call i64 @wam_intern_atom(i8* %rhv.out, i64 %rhv.final_len)
+  %rhv.v0 = insertvalue %Value undef, i32 0, 0
+  %rhv.v = insertvalue %Value %rhv.v0, i64 %rhv.aid, 1
+  ret %Value %rhv.v
+
+rhv.eof:
+  %rhv.eof_ptr = getelementptr [12 x i8], [12 x i8]* @.wam_stream_eof_atom, i32 0, i32 0
+  %rhv.eof_aid = call i64 @wam_intern_atom(i8* %rhv.eof_ptr, i64 11)
+  %rhv.eof_v0 = insertvalue %Value undef, i32 0, 0
+  %rhv.eof_v = insertvalue %Value %rhv.eof_v0, i64 %rhv.eof_aid, 1
+  ret %Value %rhv.eof_v
+}
+
+define i1 @wam_stream_close_value(%Value %handle_value) {
+entry:
+  %sch.t = call i32 @value_tag(%Value %handle_value)
+  %sch.is_int = icmp eq i32 %sch.t, 1
+  br i1 %sch.is_int, label %sch.lookup_handle, label %sch.fail
+
+sch.fail:
+  ret i1 false
+
+sch.lookup_handle:
+  %sch.handle64 = call i64 @value_payload(%Value %handle_value)
+  %sch.handle = trunc i64 %sch.handle64 to i32
+  %sch.handle_min = icmp sgt i32 %sch.handle, 0
+  %sch.handle_max = icmp ult i32 %sch.handle, 4096
+  %sch.handle_ok = and i1 %sch.handle_min, %sch.handle_max
+  br i1 %sch.handle_ok, label %sch.load_handle, label %sch.fail
+
+sch.load_handle:
+  %sch.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %sch.handle
+  %sch.reader = load %WamLineReader*, %WamLineReader** %sch.slot
+  %sch.reader_null = icmp eq %WamLineReader* %sch.reader, null
+  br i1 %sch.reader_null, label %sch.already_closed, label %sch.have_handle
+
+sch.already_closed:
+  ret i1 true
+
+sch.have_handle:
+  %sch.fd_slot = getelementptr %WamLineReader, %WamLineReader* %sch.reader, i32 0, i32 0
+  %sch.fd = load i32, i32* %sch.fd_slot
+  %sch.fd_ok = icmp sge i32 %sch.fd, 0
+  br i1 %sch.fd_ok, label %sch.close, label %sch.already_closed
+
+sch.close:
+  %sch.buf_slot = getelementptr %WamLineReader, %WamLineReader* %sch.reader, i32 0, i32 1
+  %sch.buf = load i8*, i8** %sch.buf_slot
+  %sch.close_ret = call i32 @close(i32 %sch.fd)
+  store i32 -1, i32* %sch.fd_slot
+  call void @free(i8* %sch.buf)
+  %sch.reader_i8 = bitcast %WamLineReader* %sch.reader to i8*
+  call void @free(i8* %sch.reader_i8)
+  store %WamLineReader* null, %WamLineReader** %sch.slot
+  %sch.ok = icmp eq i32 %sch.close_ret, 0
+  ret i1 %sch.ok
+}
+
 ; Dispatches on integer op codes:
 ;   0 = is/2, 1 = >/2, 2 = </2, 3 = >=/2, 4 = =</2
 ;   5 = =:=/2, 6 = =\=/2, 7 = ==/2, 8 = true/0, 9 = fail/0

--- a/examples/plawk/generated/plawk_loop_probe.ll
+++ b/examples/plawk/generated/plawk_loop_probe.ll
@@ -6390,6 +6390,248 @@ done:
 @wam_stream_handle_table = internal global [4096 x %WamLineReader*] zeroinitializer
 @wam_stream_handle_count = internal global i32 0
 
+@.wam_stream_eof_atom = private constant [12 x i8] c"end_of_file "
+
+define %Value @wam_stream_fail_value() alwaysinline nounwind {
+entry:
+  %bad = call %Value @value_integer(i64 -1)
+  ret %Value %bad
+}
+
+define %Value @wam_stream_open_value(%Value %path_value) {
+entry:
+  %soh.t = call i32 @value_tag(%Value %path_value)
+  %soh.is_atom = icmp eq i32 %soh.t, 0
+  br i1 %soh.is_atom, label %soh.have_path, label %soh.fail
+
+soh.fail:
+  %soh.bad = call %Value @wam_stream_fail_value()
+  ret %Value %soh.bad
+
+soh.have_path:
+  %soh.aid = call i64 @value_payload(%Value %path_value)
+  %soh.path = call i8* @wam_atom_to_string(i64 %soh.aid)
+  %soh.path_null = icmp eq i8* %soh.path, null
+  br i1 %soh.path_null, label %soh.fail, label %soh.open
+
+soh.open:
+  %soh.fd = call i32 @open(i8* %soh.path, i32 0, i32 0)
+  %soh.open_ok = icmp sge i32 %soh.fd, 0
+  br i1 %soh.open_ok, label %soh.alloc_reader, label %soh.fail
+
+soh.alloc_reader:
+  %soh.reader_size = ptrtoint %WamLineReader* getelementptr (%WamLineReader, %WamLineReader* null, i32 1) to i64
+  %soh.reader_mem = call i8* @malloc(i64 %soh.reader_size)
+  %soh.reader_null = icmp eq i8* %soh.reader_mem, null
+  br i1 %soh.reader_null, label %soh.close_fd_fail, label %soh.alloc_buf
+
+soh.close_fd_fail:
+  call i32 @close(i32 %soh.fd)
+  br label %soh.fail
+
+soh.alloc_buf:
+  %soh.buf = call i8* @malloc(i64 4096)
+  %soh.buf_null = icmp eq i8* %soh.buf, null
+  br i1 %soh.buf_null, label %soh.free_reader_fail, label %soh.init
+
+soh.free_reader_fail:
+  call void @free(i8* %soh.reader_mem)
+  call i32 @close(i32 %soh.fd)
+  br label %soh.fail
+
+soh.init:
+  %soh.reader = bitcast i8* %soh.reader_mem to %WamLineReader*
+  %soh.fd_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 0
+  store i32 %soh.fd, i32* %soh.fd_slot
+  %soh.buf_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 1
+  store i8* %soh.buf, i8** %soh.buf_slot
+  %soh.cap_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 2
+  store i64 4096, i64* %soh.cap_slot
+  %soh.len_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 3
+  store i64 0, i64* %soh.len_slot
+  %soh.pos_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 4
+  store i64 0, i64* %soh.pos_slot
+  %soh.count = load i32, i32* @wam_stream_handle_count
+  %soh.next = add i32 %soh.count, 1
+  %soh.cap_ok = icmp ult i32 %soh.next, 4096
+  br i1 %soh.cap_ok, label %soh.store_handle, label %soh.close_all_fail
+
+soh.store_handle:
+  %soh.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %soh.next
+  store %WamLineReader* %soh.reader, %WamLineReader** %soh.slot
+  store i32 %soh.next, i32* @wam_stream_handle_count
+  %soh.handle = zext i32 %soh.next to i64
+  %soh.v = call %Value @value_integer(i64 %soh.handle)
+  ret %Value %soh.v
+
+soh.close_all_fail:
+  call i32 @close(i32 %soh.fd)
+  call void @free(i8* %soh.buf)
+  call void @free(i8* %soh.reader_mem)
+  br label %soh.fail
+}
+
+define %Value @wam_stream_read_line_value(%Value %handle_value) {
+entry:
+  %rhv.t = call i32 @value_tag(%Value %handle_value)
+  %rhv.is_int = icmp eq i32 %rhv.t, 1
+  br i1 %rhv.is_int, label %rhv.lookup_handle, label %rhv.fail
+
+rhv.fail:
+  %rhv.bad = call %Value @wam_stream_fail_value()
+  ret %Value %rhv.bad
+
+rhv.lookup_handle:
+  %rhv.handle64 = call i64 @value_payload(%Value %handle_value)
+  %rhv.handle = trunc i64 %rhv.handle64 to i32
+  %rhv.handle_min = icmp sgt i32 %rhv.handle, 0
+  %rhv.handle_max = icmp ult i32 %rhv.handle, 4096
+  %rhv.handle_ok = and i1 %rhv.handle_min, %rhv.handle_max
+  br i1 %rhv.handle_ok, label %rhv.load_handle, label %rhv.fail
+
+rhv.load_handle:
+  %rhv.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %rhv.handle
+  %rhv.reader = load %WamLineReader*, %WamLineReader** %rhv.slot
+  %rhv.reader_null = icmp eq %WamLineReader* %rhv.reader, null
+  br i1 %rhv.reader_null, label %rhv.fail, label %rhv.have_handle
+
+rhv.have_handle:
+  %rhv.fd_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 0
+  %rhv.fd = load i32, i32* %rhv.fd_slot
+  %rhv.fd_ok = icmp sge i32 %rhv.fd, 0
+  br i1 %rhv.fd_ok, label %rhv.alloc_out, label %rhv.fail
+
+rhv.alloc_out:
+  call void @wam_arena_ensure()
+  %rhv.out = call i8* @wam_arena_alloc(i64 65537)
+  br label %rhv.loop
+
+rhv.loop:
+  %rhv.out_len = phi i64 [ 0, %rhv.alloc_out ], [ %rhv.out_len, %rhv.after_read ], [ %rhv.next_out_len, %rhv.append_store ]
+  %rhv.buf_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 1
+  %rhv.buf = load i8*, i8** %rhv.buf_slot
+  %rhv.len_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 3
+  %rhv.len = load i64, i64* %rhv.len_slot
+  %rhv.pos_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 4
+  %rhv.pos = load i64, i64* %rhv.pos_slot
+  %rhv.have_byte = icmp slt i64 %rhv.pos, %rhv.len
+  br i1 %rhv.have_byte, label %rhv.consume, label %rhv.fill
+
+rhv.fill:
+  %rhv.cap_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 2
+  %rhv.cap = load i64, i64* %rhv.cap_slot
+  %rhv.n = call i64 @read(i32 %rhv.fd, i8* %rhv.buf, i64 %rhv.cap)
+  %rhv.n_neg = icmp slt i64 %rhv.n, 0
+  br i1 %rhv.n_neg, label %rhv.fail, label %rhv.check_eof
+
+rhv.check_eof:
+  %rhv.n_zero = icmp eq i64 %rhv.n, 0
+  br i1 %rhv.n_zero, label %rhv.eof_or_partial, label %rhv.after_read
+
+rhv.after_read:
+  store i64 %rhv.n, i64* %rhv.len_slot
+  store i64 0, i64* %rhv.pos_slot
+  br label %rhv.loop
+
+rhv.eof_or_partial:
+  %rhv.empty_line = icmp eq i64 %rhv.out_len, 0
+  br i1 %rhv.empty_line, label %rhv.eof, label %rhv.finalize
+
+rhv.consume:
+  %rhv.char_ptr = getelementptr i8, i8* %rhv.buf, i64 %rhv.pos
+  %rhv.ch = load i8, i8* %rhv.char_ptr
+  %rhv.pos_next = add i64 %rhv.pos, 1
+  store i64 %rhv.pos_next, i64* %rhv.pos_slot
+  %rhv.is_lf = icmp eq i8 %rhv.ch, 10
+  br i1 %rhv.is_lf, label %rhv.finalize, label %rhv.append
+
+rhv.append:
+  %rhv.has_room = icmp ult i64 %rhv.out_len, 65536
+  br i1 %rhv.has_room, label %rhv.append_store, label %rhv.fail
+
+rhv.append_store:
+  %rhv.out_ptr = getelementptr i8, i8* %rhv.out, i64 %rhv.out_len
+  store i8 %rhv.ch, i8* %rhv.out_ptr
+  %rhv.next_out_len = add i64 %rhv.out_len, 1
+  br label %rhv.loop
+
+rhv.finalize:
+  %rhv.has_chars = icmp sgt i64 %rhv.out_len, 0
+  br i1 %rhv.has_chars, label %rhv.check_cr, label %rhv.intern_empty
+
+rhv.check_cr:
+  %rhv.last_idx = sub i64 %rhv.out_len, 1
+  %rhv.last_ptr = getelementptr i8, i8* %rhv.out, i64 %rhv.last_idx
+  %rhv.last = load i8, i8* %rhv.last_ptr
+  %rhv.last_is_cr = icmp eq i8 %rhv.last, 13
+  %rhv.trim_len = select i1 %rhv.last_is_cr, i64 %rhv.last_idx, i64 %rhv.out_len
+  br label %rhv.intern
+
+rhv.intern_empty:
+  br label %rhv.intern
+
+rhv.intern:
+  %rhv.final_len = phi i64 [ %rhv.trim_len, %rhv.check_cr ], [ 0, %rhv.intern_empty ]
+  %rhv.term = getelementptr i8, i8* %rhv.out, i64 %rhv.final_len
+  store i8 0, i8* %rhv.term
+  %rhv.aid = call i64 @wam_intern_atom(i8* %rhv.out, i64 %rhv.final_len)
+  %rhv.v0 = insertvalue %Value undef, i32 0, 0
+  %rhv.v = insertvalue %Value %rhv.v0, i64 %rhv.aid, 1
+  ret %Value %rhv.v
+
+rhv.eof:
+  %rhv.eof_ptr = getelementptr [12 x i8], [12 x i8]* @.wam_stream_eof_atom, i32 0, i32 0
+  %rhv.eof_aid = call i64 @wam_intern_atom(i8* %rhv.eof_ptr, i64 11)
+  %rhv.eof_v0 = insertvalue %Value undef, i32 0, 0
+  %rhv.eof_v = insertvalue %Value %rhv.eof_v0, i64 %rhv.eof_aid, 1
+  ret %Value %rhv.eof_v
+}
+
+define i1 @wam_stream_close_value(%Value %handle_value) {
+entry:
+  %sch.t = call i32 @value_tag(%Value %handle_value)
+  %sch.is_int = icmp eq i32 %sch.t, 1
+  br i1 %sch.is_int, label %sch.lookup_handle, label %sch.fail
+
+sch.fail:
+  ret i1 false
+
+sch.lookup_handle:
+  %sch.handle64 = call i64 @value_payload(%Value %handle_value)
+  %sch.handle = trunc i64 %sch.handle64 to i32
+  %sch.handle_min = icmp sgt i32 %sch.handle, 0
+  %sch.handle_max = icmp ult i32 %sch.handle, 4096
+  %sch.handle_ok = and i1 %sch.handle_min, %sch.handle_max
+  br i1 %sch.handle_ok, label %sch.load_handle, label %sch.fail
+
+sch.load_handle:
+  %sch.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %sch.handle
+  %sch.reader = load %WamLineReader*, %WamLineReader** %sch.slot
+  %sch.reader_null = icmp eq %WamLineReader* %sch.reader, null
+  br i1 %sch.reader_null, label %sch.already_closed, label %sch.have_handle
+
+sch.already_closed:
+  ret i1 true
+
+sch.have_handle:
+  %sch.fd_slot = getelementptr %WamLineReader, %WamLineReader* %sch.reader, i32 0, i32 0
+  %sch.fd = load i32, i32* %sch.fd_slot
+  %sch.fd_ok = icmp sge i32 %sch.fd, 0
+  br i1 %sch.fd_ok, label %sch.close, label %sch.already_closed
+
+sch.close:
+  %sch.buf_slot = getelementptr %WamLineReader, %WamLineReader* %sch.reader, i32 0, i32 1
+  %sch.buf = load i8*, i8** %sch.buf_slot
+  %sch.close_ret = call i32 @close(i32 %sch.fd)
+  store i32 -1, i32* %sch.fd_slot
+  call void @free(i8* %sch.buf)
+  %sch.reader_i8 = bitcast %WamLineReader* %sch.reader to i8*
+  call void @free(i8* %sch.reader_i8)
+  store %WamLineReader* null, %WamLineReader** %sch.slot
+  %sch.ok = icmp eq i32 %sch.close_ret, 0
+  ret i1 %sch.ok
+}
+
 ; Dispatches on integer op codes:
 ;   0 = is/2, 1 = >/2, 2 = </2, 3 = >=/2, 4 = =</2
 ;   5 = =:=/2, 6 = =\=/2, 7 = ==/2, 8 = true/0, 9 = fail/0

--- a/examples/plawk/generated/plawk_meta_call_probe.ll
+++ b/examples/plawk/generated/plawk_meta_call_probe.ll
@@ -6390,6 +6390,248 @@ done:
 @wam_stream_handle_table = internal global [4096 x %WamLineReader*] zeroinitializer
 @wam_stream_handle_count = internal global i32 0
 
+@.wam_stream_eof_atom = private constant [12 x i8] c"end_of_file "
+
+define %Value @wam_stream_fail_value() alwaysinline nounwind {
+entry:
+  %bad = call %Value @value_integer(i64 -1)
+  ret %Value %bad
+}
+
+define %Value @wam_stream_open_value(%Value %path_value) {
+entry:
+  %soh.t = call i32 @value_tag(%Value %path_value)
+  %soh.is_atom = icmp eq i32 %soh.t, 0
+  br i1 %soh.is_atom, label %soh.have_path, label %soh.fail
+
+soh.fail:
+  %soh.bad = call %Value @wam_stream_fail_value()
+  ret %Value %soh.bad
+
+soh.have_path:
+  %soh.aid = call i64 @value_payload(%Value %path_value)
+  %soh.path = call i8* @wam_atom_to_string(i64 %soh.aid)
+  %soh.path_null = icmp eq i8* %soh.path, null
+  br i1 %soh.path_null, label %soh.fail, label %soh.open
+
+soh.open:
+  %soh.fd = call i32 @open(i8* %soh.path, i32 0, i32 0)
+  %soh.open_ok = icmp sge i32 %soh.fd, 0
+  br i1 %soh.open_ok, label %soh.alloc_reader, label %soh.fail
+
+soh.alloc_reader:
+  %soh.reader_size = ptrtoint %WamLineReader* getelementptr (%WamLineReader, %WamLineReader* null, i32 1) to i64
+  %soh.reader_mem = call i8* @malloc(i64 %soh.reader_size)
+  %soh.reader_null = icmp eq i8* %soh.reader_mem, null
+  br i1 %soh.reader_null, label %soh.close_fd_fail, label %soh.alloc_buf
+
+soh.close_fd_fail:
+  call i32 @close(i32 %soh.fd)
+  br label %soh.fail
+
+soh.alloc_buf:
+  %soh.buf = call i8* @malloc(i64 4096)
+  %soh.buf_null = icmp eq i8* %soh.buf, null
+  br i1 %soh.buf_null, label %soh.free_reader_fail, label %soh.init
+
+soh.free_reader_fail:
+  call void @free(i8* %soh.reader_mem)
+  call i32 @close(i32 %soh.fd)
+  br label %soh.fail
+
+soh.init:
+  %soh.reader = bitcast i8* %soh.reader_mem to %WamLineReader*
+  %soh.fd_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 0
+  store i32 %soh.fd, i32* %soh.fd_slot
+  %soh.buf_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 1
+  store i8* %soh.buf, i8** %soh.buf_slot
+  %soh.cap_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 2
+  store i64 4096, i64* %soh.cap_slot
+  %soh.len_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 3
+  store i64 0, i64* %soh.len_slot
+  %soh.pos_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 4
+  store i64 0, i64* %soh.pos_slot
+  %soh.count = load i32, i32* @wam_stream_handle_count
+  %soh.next = add i32 %soh.count, 1
+  %soh.cap_ok = icmp ult i32 %soh.next, 4096
+  br i1 %soh.cap_ok, label %soh.store_handle, label %soh.close_all_fail
+
+soh.store_handle:
+  %soh.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %soh.next
+  store %WamLineReader* %soh.reader, %WamLineReader** %soh.slot
+  store i32 %soh.next, i32* @wam_stream_handle_count
+  %soh.handle = zext i32 %soh.next to i64
+  %soh.v = call %Value @value_integer(i64 %soh.handle)
+  ret %Value %soh.v
+
+soh.close_all_fail:
+  call i32 @close(i32 %soh.fd)
+  call void @free(i8* %soh.buf)
+  call void @free(i8* %soh.reader_mem)
+  br label %soh.fail
+}
+
+define %Value @wam_stream_read_line_value(%Value %handle_value) {
+entry:
+  %rhv.t = call i32 @value_tag(%Value %handle_value)
+  %rhv.is_int = icmp eq i32 %rhv.t, 1
+  br i1 %rhv.is_int, label %rhv.lookup_handle, label %rhv.fail
+
+rhv.fail:
+  %rhv.bad = call %Value @wam_stream_fail_value()
+  ret %Value %rhv.bad
+
+rhv.lookup_handle:
+  %rhv.handle64 = call i64 @value_payload(%Value %handle_value)
+  %rhv.handle = trunc i64 %rhv.handle64 to i32
+  %rhv.handle_min = icmp sgt i32 %rhv.handle, 0
+  %rhv.handle_max = icmp ult i32 %rhv.handle, 4096
+  %rhv.handle_ok = and i1 %rhv.handle_min, %rhv.handle_max
+  br i1 %rhv.handle_ok, label %rhv.load_handle, label %rhv.fail
+
+rhv.load_handle:
+  %rhv.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %rhv.handle
+  %rhv.reader = load %WamLineReader*, %WamLineReader** %rhv.slot
+  %rhv.reader_null = icmp eq %WamLineReader* %rhv.reader, null
+  br i1 %rhv.reader_null, label %rhv.fail, label %rhv.have_handle
+
+rhv.have_handle:
+  %rhv.fd_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 0
+  %rhv.fd = load i32, i32* %rhv.fd_slot
+  %rhv.fd_ok = icmp sge i32 %rhv.fd, 0
+  br i1 %rhv.fd_ok, label %rhv.alloc_out, label %rhv.fail
+
+rhv.alloc_out:
+  call void @wam_arena_ensure()
+  %rhv.out = call i8* @wam_arena_alloc(i64 65537)
+  br label %rhv.loop
+
+rhv.loop:
+  %rhv.out_len = phi i64 [ 0, %rhv.alloc_out ], [ %rhv.out_len, %rhv.after_read ], [ %rhv.next_out_len, %rhv.append_store ]
+  %rhv.buf_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 1
+  %rhv.buf = load i8*, i8** %rhv.buf_slot
+  %rhv.len_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 3
+  %rhv.len = load i64, i64* %rhv.len_slot
+  %rhv.pos_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 4
+  %rhv.pos = load i64, i64* %rhv.pos_slot
+  %rhv.have_byte = icmp slt i64 %rhv.pos, %rhv.len
+  br i1 %rhv.have_byte, label %rhv.consume, label %rhv.fill
+
+rhv.fill:
+  %rhv.cap_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 2
+  %rhv.cap = load i64, i64* %rhv.cap_slot
+  %rhv.n = call i64 @read(i32 %rhv.fd, i8* %rhv.buf, i64 %rhv.cap)
+  %rhv.n_neg = icmp slt i64 %rhv.n, 0
+  br i1 %rhv.n_neg, label %rhv.fail, label %rhv.check_eof
+
+rhv.check_eof:
+  %rhv.n_zero = icmp eq i64 %rhv.n, 0
+  br i1 %rhv.n_zero, label %rhv.eof_or_partial, label %rhv.after_read
+
+rhv.after_read:
+  store i64 %rhv.n, i64* %rhv.len_slot
+  store i64 0, i64* %rhv.pos_slot
+  br label %rhv.loop
+
+rhv.eof_or_partial:
+  %rhv.empty_line = icmp eq i64 %rhv.out_len, 0
+  br i1 %rhv.empty_line, label %rhv.eof, label %rhv.finalize
+
+rhv.consume:
+  %rhv.char_ptr = getelementptr i8, i8* %rhv.buf, i64 %rhv.pos
+  %rhv.ch = load i8, i8* %rhv.char_ptr
+  %rhv.pos_next = add i64 %rhv.pos, 1
+  store i64 %rhv.pos_next, i64* %rhv.pos_slot
+  %rhv.is_lf = icmp eq i8 %rhv.ch, 10
+  br i1 %rhv.is_lf, label %rhv.finalize, label %rhv.append
+
+rhv.append:
+  %rhv.has_room = icmp ult i64 %rhv.out_len, 65536
+  br i1 %rhv.has_room, label %rhv.append_store, label %rhv.fail
+
+rhv.append_store:
+  %rhv.out_ptr = getelementptr i8, i8* %rhv.out, i64 %rhv.out_len
+  store i8 %rhv.ch, i8* %rhv.out_ptr
+  %rhv.next_out_len = add i64 %rhv.out_len, 1
+  br label %rhv.loop
+
+rhv.finalize:
+  %rhv.has_chars = icmp sgt i64 %rhv.out_len, 0
+  br i1 %rhv.has_chars, label %rhv.check_cr, label %rhv.intern_empty
+
+rhv.check_cr:
+  %rhv.last_idx = sub i64 %rhv.out_len, 1
+  %rhv.last_ptr = getelementptr i8, i8* %rhv.out, i64 %rhv.last_idx
+  %rhv.last = load i8, i8* %rhv.last_ptr
+  %rhv.last_is_cr = icmp eq i8 %rhv.last, 13
+  %rhv.trim_len = select i1 %rhv.last_is_cr, i64 %rhv.last_idx, i64 %rhv.out_len
+  br label %rhv.intern
+
+rhv.intern_empty:
+  br label %rhv.intern
+
+rhv.intern:
+  %rhv.final_len = phi i64 [ %rhv.trim_len, %rhv.check_cr ], [ 0, %rhv.intern_empty ]
+  %rhv.term = getelementptr i8, i8* %rhv.out, i64 %rhv.final_len
+  store i8 0, i8* %rhv.term
+  %rhv.aid = call i64 @wam_intern_atom(i8* %rhv.out, i64 %rhv.final_len)
+  %rhv.v0 = insertvalue %Value undef, i32 0, 0
+  %rhv.v = insertvalue %Value %rhv.v0, i64 %rhv.aid, 1
+  ret %Value %rhv.v
+
+rhv.eof:
+  %rhv.eof_ptr = getelementptr [12 x i8], [12 x i8]* @.wam_stream_eof_atom, i32 0, i32 0
+  %rhv.eof_aid = call i64 @wam_intern_atom(i8* %rhv.eof_ptr, i64 11)
+  %rhv.eof_v0 = insertvalue %Value undef, i32 0, 0
+  %rhv.eof_v = insertvalue %Value %rhv.eof_v0, i64 %rhv.eof_aid, 1
+  ret %Value %rhv.eof_v
+}
+
+define i1 @wam_stream_close_value(%Value %handle_value) {
+entry:
+  %sch.t = call i32 @value_tag(%Value %handle_value)
+  %sch.is_int = icmp eq i32 %sch.t, 1
+  br i1 %sch.is_int, label %sch.lookup_handle, label %sch.fail
+
+sch.fail:
+  ret i1 false
+
+sch.lookup_handle:
+  %sch.handle64 = call i64 @value_payload(%Value %handle_value)
+  %sch.handle = trunc i64 %sch.handle64 to i32
+  %sch.handle_min = icmp sgt i32 %sch.handle, 0
+  %sch.handle_max = icmp ult i32 %sch.handle, 4096
+  %sch.handle_ok = and i1 %sch.handle_min, %sch.handle_max
+  br i1 %sch.handle_ok, label %sch.load_handle, label %sch.fail
+
+sch.load_handle:
+  %sch.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %sch.handle
+  %sch.reader = load %WamLineReader*, %WamLineReader** %sch.slot
+  %sch.reader_null = icmp eq %WamLineReader* %sch.reader, null
+  br i1 %sch.reader_null, label %sch.already_closed, label %sch.have_handle
+
+sch.already_closed:
+  ret i1 true
+
+sch.have_handle:
+  %sch.fd_slot = getelementptr %WamLineReader, %WamLineReader* %sch.reader, i32 0, i32 0
+  %sch.fd = load i32, i32* %sch.fd_slot
+  %sch.fd_ok = icmp sge i32 %sch.fd, 0
+  br i1 %sch.fd_ok, label %sch.close, label %sch.already_closed
+
+sch.close:
+  %sch.buf_slot = getelementptr %WamLineReader, %WamLineReader* %sch.reader, i32 0, i32 1
+  %sch.buf = load i8*, i8** %sch.buf_slot
+  %sch.close_ret = call i32 @close(i32 %sch.fd)
+  store i32 -1, i32* %sch.fd_slot
+  call void @free(i8* %sch.buf)
+  %sch.reader_i8 = bitcast %WamLineReader* %sch.reader to i8*
+  call void @free(i8* %sch.reader_i8)
+  store %WamLineReader* null, %WamLineReader** %sch.slot
+  %sch.ok = icmp eq i32 %sch.close_ret, 0
+  ret i1 %sch.ok
+}
+
 ; Dispatches on integer op codes:
 ;   0 = is/2, 1 = >/2, 2 = </2, 3 = >=/2, 4 = =</2
 ;   5 = =:=/2, 6 = =\=/2, 7 = ==/2, 8 = true/0, 9 = fail/0

--- a/examples/plawk/generated/plawk_reader_probe.ll
+++ b/examples/plawk/generated/plawk_reader_probe.ll
@@ -6390,6 +6390,248 @@ done:
 @wam_stream_handle_table = internal global [4096 x %WamLineReader*] zeroinitializer
 @wam_stream_handle_count = internal global i32 0
 
+@.wam_stream_eof_atom = private constant [12 x i8] c"end_of_file "
+
+define %Value @wam_stream_fail_value() alwaysinline nounwind {
+entry:
+  %bad = call %Value @value_integer(i64 -1)
+  ret %Value %bad
+}
+
+define %Value @wam_stream_open_value(%Value %path_value) {
+entry:
+  %soh.t = call i32 @value_tag(%Value %path_value)
+  %soh.is_atom = icmp eq i32 %soh.t, 0
+  br i1 %soh.is_atom, label %soh.have_path, label %soh.fail
+
+soh.fail:
+  %soh.bad = call %Value @wam_stream_fail_value()
+  ret %Value %soh.bad
+
+soh.have_path:
+  %soh.aid = call i64 @value_payload(%Value %path_value)
+  %soh.path = call i8* @wam_atom_to_string(i64 %soh.aid)
+  %soh.path_null = icmp eq i8* %soh.path, null
+  br i1 %soh.path_null, label %soh.fail, label %soh.open
+
+soh.open:
+  %soh.fd = call i32 @open(i8* %soh.path, i32 0, i32 0)
+  %soh.open_ok = icmp sge i32 %soh.fd, 0
+  br i1 %soh.open_ok, label %soh.alloc_reader, label %soh.fail
+
+soh.alloc_reader:
+  %soh.reader_size = ptrtoint %WamLineReader* getelementptr (%WamLineReader, %WamLineReader* null, i32 1) to i64
+  %soh.reader_mem = call i8* @malloc(i64 %soh.reader_size)
+  %soh.reader_null = icmp eq i8* %soh.reader_mem, null
+  br i1 %soh.reader_null, label %soh.close_fd_fail, label %soh.alloc_buf
+
+soh.close_fd_fail:
+  call i32 @close(i32 %soh.fd)
+  br label %soh.fail
+
+soh.alloc_buf:
+  %soh.buf = call i8* @malloc(i64 4096)
+  %soh.buf_null = icmp eq i8* %soh.buf, null
+  br i1 %soh.buf_null, label %soh.free_reader_fail, label %soh.init
+
+soh.free_reader_fail:
+  call void @free(i8* %soh.reader_mem)
+  call i32 @close(i32 %soh.fd)
+  br label %soh.fail
+
+soh.init:
+  %soh.reader = bitcast i8* %soh.reader_mem to %WamLineReader*
+  %soh.fd_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 0
+  store i32 %soh.fd, i32* %soh.fd_slot
+  %soh.buf_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 1
+  store i8* %soh.buf, i8** %soh.buf_slot
+  %soh.cap_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 2
+  store i64 4096, i64* %soh.cap_slot
+  %soh.len_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 3
+  store i64 0, i64* %soh.len_slot
+  %soh.pos_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 4
+  store i64 0, i64* %soh.pos_slot
+  %soh.count = load i32, i32* @wam_stream_handle_count
+  %soh.next = add i32 %soh.count, 1
+  %soh.cap_ok = icmp ult i32 %soh.next, 4096
+  br i1 %soh.cap_ok, label %soh.store_handle, label %soh.close_all_fail
+
+soh.store_handle:
+  %soh.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %soh.next
+  store %WamLineReader* %soh.reader, %WamLineReader** %soh.slot
+  store i32 %soh.next, i32* @wam_stream_handle_count
+  %soh.handle = zext i32 %soh.next to i64
+  %soh.v = call %Value @value_integer(i64 %soh.handle)
+  ret %Value %soh.v
+
+soh.close_all_fail:
+  call i32 @close(i32 %soh.fd)
+  call void @free(i8* %soh.buf)
+  call void @free(i8* %soh.reader_mem)
+  br label %soh.fail
+}
+
+define %Value @wam_stream_read_line_value(%Value %handle_value) {
+entry:
+  %rhv.t = call i32 @value_tag(%Value %handle_value)
+  %rhv.is_int = icmp eq i32 %rhv.t, 1
+  br i1 %rhv.is_int, label %rhv.lookup_handle, label %rhv.fail
+
+rhv.fail:
+  %rhv.bad = call %Value @wam_stream_fail_value()
+  ret %Value %rhv.bad
+
+rhv.lookup_handle:
+  %rhv.handle64 = call i64 @value_payload(%Value %handle_value)
+  %rhv.handle = trunc i64 %rhv.handle64 to i32
+  %rhv.handle_min = icmp sgt i32 %rhv.handle, 0
+  %rhv.handle_max = icmp ult i32 %rhv.handle, 4096
+  %rhv.handle_ok = and i1 %rhv.handle_min, %rhv.handle_max
+  br i1 %rhv.handle_ok, label %rhv.load_handle, label %rhv.fail
+
+rhv.load_handle:
+  %rhv.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %rhv.handle
+  %rhv.reader = load %WamLineReader*, %WamLineReader** %rhv.slot
+  %rhv.reader_null = icmp eq %WamLineReader* %rhv.reader, null
+  br i1 %rhv.reader_null, label %rhv.fail, label %rhv.have_handle
+
+rhv.have_handle:
+  %rhv.fd_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 0
+  %rhv.fd = load i32, i32* %rhv.fd_slot
+  %rhv.fd_ok = icmp sge i32 %rhv.fd, 0
+  br i1 %rhv.fd_ok, label %rhv.alloc_out, label %rhv.fail
+
+rhv.alloc_out:
+  call void @wam_arena_ensure()
+  %rhv.out = call i8* @wam_arena_alloc(i64 65537)
+  br label %rhv.loop
+
+rhv.loop:
+  %rhv.out_len = phi i64 [ 0, %rhv.alloc_out ], [ %rhv.out_len, %rhv.after_read ], [ %rhv.next_out_len, %rhv.append_store ]
+  %rhv.buf_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 1
+  %rhv.buf = load i8*, i8** %rhv.buf_slot
+  %rhv.len_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 3
+  %rhv.len = load i64, i64* %rhv.len_slot
+  %rhv.pos_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 4
+  %rhv.pos = load i64, i64* %rhv.pos_slot
+  %rhv.have_byte = icmp slt i64 %rhv.pos, %rhv.len
+  br i1 %rhv.have_byte, label %rhv.consume, label %rhv.fill
+
+rhv.fill:
+  %rhv.cap_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 2
+  %rhv.cap = load i64, i64* %rhv.cap_slot
+  %rhv.n = call i64 @read(i32 %rhv.fd, i8* %rhv.buf, i64 %rhv.cap)
+  %rhv.n_neg = icmp slt i64 %rhv.n, 0
+  br i1 %rhv.n_neg, label %rhv.fail, label %rhv.check_eof
+
+rhv.check_eof:
+  %rhv.n_zero = icmp eq i64 %rhv.n, 0
+  br i1 %rhv.n_zero, label %rhv.eof_or_partial, label %rhv.after_read
+
+rhv.after_read:
+  store i64 %rhv.n, i64* %rhv.len_slot
+  store i64 0, i64* %rhv.pos_slot
+  br label %rhv.loop
+
+rhv.eof_or_partial:
+  %rhv.empty_line = icmp eq i64 %rhv.out_len, 0
+  br i1 %rhv.empty_line, label %rhv.eof, label %rhv.finalize
+
+rhv.consume:
+  %rhv.char_ptr = getelementptr i8, i8* %rhv.buf, i64 %rhv.pos
+  %rhv.ch = load i8, i8* %rhv.char_ptr
+  %rhv.pos_next = add i64 %rhv.pos, 1
+  store i64 %rhv.pos_next, i64* %rhv.pos_slot
+  %rhv.is_lf = icmp eq i8 %rhv.ch, 10
+  br i1 %rhv.is_lf, label %rhv.finalize, label %rhv.append
+
+rhv.append:
+  %rhv.has_room = icmp ult i64 %rhv.out_len, 65536
+  br i1 %rhv.has_room, label %rhv.append_store, label %rhv.fail
+
+rhv.append_store:
+  %rhv.out_ptr = getelementptr i8, i8* %rhv.out, i64 %rhv.out_len
+  store i8 %rhv.ch, i8* %rhv.out_ptr
+  %rhv.next_out_len = add i64 %rhv.out_len, 1
+  br label %rhv.loop
+
+rhv.finalize:
+  %rhv.has_chars = icmp sgt i64 %rhv.out_len, 0
+  br i1 %rhv.has_chars, label %rhv.check_cr, label %rhv.intern_empty
+
+rhv.check_cr:
+  %rhv.last_idx = sub i64 %rhv.out_len, 1
+  %rhv.last_ptr = getelementptr i8, i8* %rhv.out, i64 %rhv.last_idx
+  %rhv.last = load i8, i8* %rhv.last_ptr
+  %rhv.last_is_cr = icmp eq i8 %rhv.last, 13
+  %rhv.trim_len = select i1 %rhv.last_is_cr, i64 %rhv.last_idx, i64 %rhv.out_len
+  br label %rhv.intern
+
+rhv.intern_empty:
+  br label %rhv.intern
+
+rhv.intern:
+  %rhv.final_len = phi i64 [ %rhv.trim_len, %rhv.check_cr ], [ 0, %rhv.intern_empty ]
+  %rhv.term = getelementptr i8, i8* %rhv.out, i64 %rhv.final_len
+  store i8 0, i8* %rhv.term
+  %rhv.aid = call i64 @wam_intern_atom(i8* %rhv.out, i64 %rhv.final_len)
+  %rhv.v0 = insertvalue %Value undef, i32 0, 0
+  %rhv.v = insertvalue %Value %rhv.v0, i64 %rhv.aid, 1
+  ret %Value %rhv.v
+
+rhv.eof:
+  %rhv.eof_ptr = getelementptr [12 x i8], [12 x i8]* @.wam_stream_eof_atom, i32 0, i32 0
+  %rhv.eof_aid = call i64 @wam_intern_atom(i8* %rhv.eof_ptr, i64 11)
+  %rhv.eof_v0 = insertvalue %Value undef, i32 0, 0
+  %rhv.eof_v = insertvalue %Value %rhv.eof_v0, i64 %rhv.eof_aid, 1
+  ret %Value %rhv.eof_v
+}
+
+define i1 @wam_stream_close_value(%Value %handle_value) {
+entry:
+  %sch.t = call i32 @value_tag(%Value %handle_value)
+  %sch.is_int = icmp eq i32 %sch.t, 1
+  br i1 %sch.is_int, label %sch.lookup_handle, label %sch.fail
+
+sch.fail:
+  ret i1 false
+
+sch.lookup_handle:
+  %sch.handle64 = call i64 @value_payload(%Value %handle_value)
+  %sch.handle = trunc i64 %sch.handle64 to i32
+  %sch.handle_min = icmp sgt i32 %sch.handle, 0
+  %sch.handle_max = icmp ult i32 %sch.handle, 4096
+  %sch.handle_ok = and i1 %sch.handle_min, %sch.handle_max
+  br i1 %sch.handle_ok, label %sch.load_handle, label %sch.fail
+
+sch.load_handle:
+  %sch.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %sch.handle
+  %sch.reader = load %WamLineReader*, %WamLineReader** %sch.slot
+  %sch.reader_null = icmp eq %WamLineReader* %sch.reader, null
+  br i1 %sch.reader_null, label %sch.already_closed, label %sch.have_handle
+
+sch.already_closed:
+  ret i1 true
+
+sch.have_handle:
+  %sch.fd_slot = getelementptr %WamLineReader, %WamLineReader* %sch.reader, i32 0, i32 0
+  %sch.fd = load i32, i32* %sch.fd_slot
+  %sch.fd_ok = icmp sge i32 %sch.fd, 0
+  br i1 %sch.fd_ok, label %sch.close, label %sch.already_closed
+
+sch.close:
+  %sch.buf_slot = getelementptr %WamLineReader, %WamLineReader* %sch.reader, i32 0, i32 1
+  %sch.buf = load i8*, i8** %sch.buf_slot
+  %sch.close_ret = call i32 @close(i32 %sch.fd)
+  store i32 -1, i32* %sch.fd_slot
+  call void @free(i8* %sch.buf)
+  %sch.reader_i8 = bitcast %WamLineReader* %sch.reader to i8*
+  call void @free(i8* %sch.reader_i8)
+  store %WamLineReader* null, %WamLineReader** %sch.slot
+  %sch.ok = icmp eq i32 %sch.close_ret, 0
+  ret i1 %sch.ok
+}
+
 ; Dispatches on integer op codes:
 ;   0 = is/2, 1 = >/2, 2 = </2, 3 = >=/2, 4 = =</2
 ;   5 = =:=/2, 6 = =\=/2, 7 = ==/2, 8 = true/0, 9 = fail/0

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3947,6 +3947,248 @@ compile_execute_builtin_to_llvm(Options, Code) :-
 @wam_stream_handle_table = internal global [4096 x %WamLineReader*] zeroinitializer
 @wam_stream_handle_count = internal global i32 0
 
+@.wam_stream_eof_atom = private constant [12 x i8] c"end_of_file\00"
+
+define %Value @wam_stream_fail_value() alwaysinline nounwind {
+entry:
+  %bad = call %Value @value_integer(i64 -1)
+  ret %Value %bad
+}
+
+define %Value @wam_stream_open_value(%Value %path_value) {
+entry:
+  %soh.t = call i32 @value_tag(%Value %path_value)
+  %soh.is_atom = icmp eq i32 %soh.t, 0
+  br i1 %soh.is_atom, label %soh.have_path, label %soh.fail
+
+soh.fail:
+  %soh.bad = call %Value @wam_stream_fail_value()
+  ret %Value %soh.bad
+
+soh.have_path:
+  %soh.aid = call i64 @value_payload(%Value %path_value)
+  %soh.path = call i8* @wam_atom_to_string(i64 %soh.aid)
+  %soh.path_null = icmp eq i8* %soh.path, null
+  br i1 %soh.path_null, label %soh.fail, label %soh.open
+
+soh.open:
+  %soh.fd = call i32 @open(i8* %soh.path, i32 0, i32 0)
+  %soh.open_ok = icmp sge i32 %soh.fd, 0
+  br i1 %soh.open_ok, label %soh.alloc_reader, label %soh.fail
+
+soh.alloc_reader:
+  %soh.reader_size = ptrtoint %WamLineReader* getelementptr (%WamLineReader, %WamLineReader* null, i32 1) to i64
+  %soh.reader_mem = call i8* @malloc(i64 %soh.reader_size)
+  %soh.reader_null = icmp eq i8* %soh.reader_mem, null
+  br i1 %soh.reader_null, label %soh.close_fd_fail, label %soh.alloc_buf
+
+soh.close_fd_fail:
+  call i32 @close(i32 %soh.fd)
+  br label %soh.fail
+
+soh.alloc_buf:
+  %soh.buf = call i8* @malloc(i64 4096)
+  %soh.buf_null = icmp eq i8* %soh.buf, null
+  br i1 %soh.buf_null, label %soh.free_reader_fail, label %soh.init
+
+soh.free_reader_fail:
+  call void @free(i8* %soh.reader_mem)
+  call i32 @close(i32 %soh.fd)
+  br label %soh.fail
+
+soh.init:
+  %soh.reader = bitcast i8* %soh.reader_mem to %WamLineReader*
+  %soh.fd_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 0
+  store i32 %soh.fd, i32* %soh.fd_slot
+  %soh.buf_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 1
+  store i8* %soh.buf, i8** %soh.buf_slot
+  %soh.cap_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 2
+  store i64 4096, i64* %soh.cap_slot
+  %soh.len_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 3
+  store i64 0, i64* %soh.len_slot
+  %soh.pos_slot = getelementptr %WamLineReader, %WamLineReader* %soh.reader, i32 0, i32 4
+  store i64 0, i64* %soh.pos_slot
+  %soh.count = load i32, i32* @wam_stream_handle_count
+  %soh.next = add i32 %soh.count, 1
+  %soh.cap_ok = icmp ult i32 %soh.next, 4096
+  br i1 %soh.cap_ok, label %soh.store_handle, label %soh.close_all_fail
+
+soh.store_handle:
+  %soh.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %soh.next
+  store %WamLineReader* %soh.reader, %WamLineReader** %soh.slot
+  store i32 %soh.next, i32* @wam_stream_handle_count
+  %soh.handle = zext i32 %soh.next to i64
+  %soh.v = call %Value @value_integer(i64 %soh.handle)
+  ret %Value %soh.v
+
+soh.close_all_fail:
+  call i32 @close(i32 %soh.fd)
+  call void @free(i8* %soh.buf)
+  call void @free(i8* %soh.reader_mem)
+  br label %soh.fail
+}
+
+define %Value @wam_stream_read_line_value(%Value %handle_value) {
+entry:
+  %rhv.t = call i32 @value_tag(%Value %handle_value)
+  %rhv.is_int = icmp eq i32 %rhv.t, 1
+  br i1 %rhv.is_int, label %rhv.lookup_handle, label %rhv.fail
+
+rhv.fail:
+  %rhv.bad = call %Value @wam_stream_fail_value()
+  ret %Value %rhv.bad
+
+rhv.lookup_handle:
+  %rhv.handle64 = call i64 @value_payload(%Value %handle_value)
+  %rhv.handle = trunc i64 %rhv.handle64 to i32
+  %rhv.handle_min = icmp sgt i32 %rhv.handle, 0
+  %rhv.handle_max = icmp ult i32 %rhv.handle, 4096
+  %rhv.handle_ok = and i1 %rhv.handle_min, %rhv.handle_max
+  br i1 %rhv.handle_ok, label %rhv.load_handle, label %rhv.fail
+
+rhv.load_handle:
+  %rhv.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %rhv.handle
+  %rhv.reader = load %WamLineReader*, %WamLineReader** %rhv.slot
+  %rhv.reader_null = icmp eq %WamLineReader* %rhv.reader, null
+  br i1 %rhv.reader_null, label %rhv.fail, label %rhv.have_handle
+
+rhv.have_handle:
+  %rhv.fd_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 0
+  %rhv.fd = load i32, i32* %rhv.fd_slot
+  %rhv.fd_ok = icmp sge i32 %rhv.fd, 0
+  br i1 %rhv.fd_ok, label %rhv.alloc_out, label %rhv.fail
+
+rhv.alloc_out:
+  call void @wam_arena_ensure()
+  %rhv.out = call i8* @wam_arena_alloc(i64 65537)
+  br label %rhv.loop
+
+rhv.loop:
+  %rhv.out_len = phi i64 [ 0, %rhv.alloc_out ], [ %rhv.out_len, %rhv.after_read ], [ %rhv.next_out_len, %rhv.append_store ]
+  %rhv.buf_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 1
+  %rhv.buf = load i8*, i8** %rhv.buf_slot
+  %rhv.len_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 3
+  %rhv.len = load i64, i64* %rhv.len_slot
+  %rhv.pos_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 4
+  %rhv.pos = load i64, i64* %rhv.pos_slot
+  %rhv.have_byte = icmp slt i64 %rhv.pos, %rhv.len
+  br i1 %rhv.have_byte, label %rhv.consume, label %rhv.fill
+
+rhv.fill:
+  %rhv.cap_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 2
+  %rhv.cap = load i64, i64* %rhv.cap_slot
+  %rhv.n = call i64 @read(i32 %rhv.fd, i8* %rhv.buf, i64 %rhv.cap)
+  %rhv.n_neg = icmp slt i64 %rhv.n, 0
+  br i1 %rhv.n_neg, label %rhv.fail, label %rhv.check_eof
+
+rhv.check_eof:
+  %rhv.n_zero = icmp eq i64 %rhv.n, 0
+  br i1 %rhv.n_zero, label %rhv.eof_or_partial, label %rhv.after_read
+
+rhv.after_read:
+  store i64 %rhv.n, i64* %rhv.len_slot
+  store i64 0, i64* %rhv.pos_slot
+  br label %rhv.loop
+
+rhv.eof_or_partial:
+  %rhv.empty_line = icmp eq i64 %rhv.out_len, 0
+  br i1 %rhv.empty_line, label %rhv.eof, label %rhv.finalize
+
+rhv.consume:
+  %rhv.char_ptr = getelementptr i8, i8* %rhv.buf, i64 %rhv.pos
+  %rhv.ch = load i8, i8* %rhv.char_ptr
+  %rhv.pos_next = add i64 %rhv.pos, 1
+  store i64 %rhv.pos_next, i64* %rhv.pos_slot
+  %rhv.is_lf = icmp eq i8 %rhv.ch, 10
+  br i1 %rhv.is_lf, label %rhv.finalize, label %rhv.append
+
+rhv.append:
+  %rhv.has_room = icmp ult i64 %rhv.out_len, 65536
+  br i1 %rhv.has_room, label %rhv.append_store, label %rhv.fail
+
+rhv.append_store:
+  %rhv.out_ptr = getelementptr i8, i8* %rhv.out, i64 %rhv.out_len
+  store i8 %rhv.ch, i8* %rhv.out_ptr
+  %rhv.next_out_len = add i64 %rhv.out_len, 1
+  br label %rhv.loop
+
+rhv.finalize:
+  %rhv.has_chars = icmp sgt i64 %rhv.out_len, 0
+  br i1 %rhv.has_chars, label %rhv.check_cr, label %rhv.intern_empty
+
+rhv.check_cr:
+  %rhv.last_idx = sub i64 %rhv.out_len, 1
+  %rhv.last_ptr = getelementptr i8, i8* %rhv.out, i64 %rhv.last_idx
+  %rhv.last = load i8, i8* %rhv.last_ptr
+  %rhv.last_is_cr = icmp eq i8 %rhv.last, 13
+  %rhv.trim_len = select i1 %rhv.last_is_cr, i64 %rhv.last_idx, i64 %rhv.out_len
+  br label %rhv.intern
+
+rhv.intern_empty:
+  br label %rhv.intern
+
+rhv.intern:
+  %rhv.final_len = phi i64 [ %rhv.trim_len, %rhv.check_cr ], [ 0, %rhv.intern_empty ]
+  %rhv.term = getelementptr i8, i8* %rhv.out, i64 %rhv.final_len
+  store i8 0, i8* %rhv.term
+  %rhv.aid = call i64 @wam_intern_atom(i8* %rhv.out, i64 %rhv.final_len)
+  %rhv.v0 = insertvalue %Value undef, i32 0, 0
+  %rhv.v = insertvalue %Value %rhv.v0, i64 %rhv.aid, 1
+  ret %Value %rhv.v
+
+rhv.eof:
+  %rhv.eof_ptr = getelementptr [12 x i8], [12 x i8]* @.wam_stream_eof_atom, i32 0, i32 0
+  %rhv.eof_aid = call i64 @wam_intern_atom(i8* %rhv.eof_ptr, i64 11)
+  %rhv.eof_v0 = insertvalue %Value undef, i32 0, 0
+  %rhv.eof_v = insertvalue %Value %rhv.eof_v0, i64 %rhv.eof_aid, 1
+  ret %Value %rhv.eof_v
+}
+
+define i1 @wam_stream_close_value(%Value %handle_value) {
+entry:
+  %sch.t = call i32 @value_tag(%Value %handle_value)
+  %sch.is_int = icmp eq i32 %sch.t, 1
+  br i1 %sch.is_int, label %sch.lookup_handle, label %sch.fail
+
+sch.fail:
+  ret i1 false
+
+sch.lookup_handle:
+  %sch.handle64 = call i64 @value_payload(%Value %handle_value)
+  %sch.handle = trunc i64 %sch.handle64 to i32
+  %sch.handle_min = icmp sgt i32 %sch.handle, 0
+  %sch.handle_max = icmp ult i32 %sch.handle, 4096
+  %sch.handle_ok = and i1 %sch.handle_min, %sch.handle_max
+  br i1 %sch.handle_ok, label %sch.load_handle, label %sch.fail
+
+sch.load_handle:
+  %sch.slot = getelementptr [4096 x %WamLineReader*], [4096 x %WamLineReader*]* @wam_stream_handle_table, i32 0, i32 %sch.handle
+  %sch.reader = load %WamLineReader*, %WamLineReader** %sch.slot
+  %sch.reader_null = icmp eq %WamLineReader* %sch.reader, null
+  br i1 %sch.reader_null, label %sch.already_closed, label %sch.have_handle
+
+sch.already_closed:
+  ret i1 true
+
+sch.have_handle:
+  %sch.fd_slot = getelementptr %WamLineReader, %WamLineReader* %sch.reader, i32 0, i32 0
+  %sch.fd = load i32, i32* %sch.fd_slot
+  %sch.fd_ok = icmp sge i32 %sch.fd, 0
+  br i1 %sch.fd_ok, label %sch.close, label %sch.already_closed
+
+sch.close:
+  %sch.buf_slot = getelementptr %WamLineReader, %WamLineReader* %sch.reader, i32 0, i32 1
+  %sch.buf = load i8*, i8** %sch.buf_slot
+  %sch.close_ret = call i32 @close(i32 %sch.fd)
+  store i32 -1, i32* %sch.fd_slot
+  call void @free(i8* %sch.buf)
+  %sch.reader_i8 = bitcast %WamLineReader* %sch.reader to i8*
+  call void @free(i8* %sch.reader_i8)
+  store %WamLineReader* null, %WamLineReader** %sch.slot
+  %sch.ok = icmp eq i32 %sch.close_ret, 0
+  ret i1 %sch.ok
+}
+
 ; Dispatches on integer op codes:
 ;   0 = is/2, 1 = >/2, 2 = </2, 3 = >=/2, 4 = =</2
 ;   5 = =:=/2, 6 = =\\=/2, 7 = ==/2, 8 = true/0, 9 = fail/0

--- a/tests/test_plawk_native_stream_loop_driver.pl
+++ b/tests/test_plawk_native_stream_loop_driver.pl
@@ -1,0 +1,307 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/core/plawk_core').
+
+:- dynamic user:plawk_native_stream_initial_state/1.
+:- dynamic user:plawk_native_stream_line_handler/3.
+:- dynamic user:plawk_native_stream_error_line/1.
+:- dynamic user:plawk_native_stream_readout/4.
+
+user:plawk_native_stream_initial_state(state([], [], 0, none)).
+
+user:plawk_native_stream_line_handler(Line, State0, StateN) :-
+    increment_counter(State0, State1),
+    (   plawk_native_stream_error_line(Line)
+    ->  append_output(Line, State1, StateN)
+    ;   StateN = State1
+    ).
+
+user:plawk_native_stream_error_line(Line) :-
+    sub_atom(Line, 0, 5, _, 'ERROR').
+
+user:plawk_native_stream_readout(State, Count, FirstError, SecondError) :-
+    state_counter(State, Count),
+    state_outputs(State, [FirstError, SecondError]).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_native_stream_loop_driver, [condition(clang_available)]).
+
+test(native_loop_reads_file_and_threads_plawk_state) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_native_stream_loop_driver', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, 'INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n', []),
+        close(In)),
+    directory_file_path(Dir, 'plawk_native_stream_loop.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_native_stream_initial_state/1,
+          user:plawk_native_stream_line_handler/3,
+          user:plawk_native_stream_error_line/1,
+          user:plawk_native_stream_readout/4,
+          plawk_core:normalize_outputs/2
+        ],
+        [module_name('plawk_native_stream_loop')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    plawk_native_stream_loop_driver_ir(InputPath, InstrCount, LabelCount, DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_native_stream_loop_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk native stream loop driver output]~n~w~n",
+              [OutStr]),
+       throw(plawk_native_stream_loop_driver_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_native_stream_loop_driver).
+
+plawk_native_stream_loop_driver_ir(InputPath, InstrCount, LabelCount, DriverIR) :-
+    atom_codes(InputPath, PathCodes),
+    length(PathCodes, PathLen),
+    BytesLen is PathLen + 1,
+    llvm_c_bytes(PathCodes, PathBytes),
+    format(atom(DriverIR),
+'@.plawk_stream_path = private constant [~w x i8] c"~w\\00"
+@.plawk_stream_eof = private constant [12 x i8] c"end_of_file\\00"
+@.plawk_expect_first = private constant [16 x i8] c"ERROR disk full\\00"
+@.plawk_expect_second = private constant [15 x i8] c"ERROR net down\\00"
+
+define i32 @main() {
+entry:
+  %path_ptr = getelementptr [~w x i8], [~w x i8]* @.plawk_stream_path, i32 0, i32 0
+  %path_id = call i64 @wam_intern_atom(i8* %path_ptr, i64 ~w)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @module_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @module_labels, i32 0, i32 0),
+      i32 ~w)
+  %init_pc = load i32, i32* @plawk_native_stream_initial_state_start_pc
+  %handler_pc = load i32, i32* @plawk_native_stream_line_handler_start_pc
+  %readout_pc = load i32, i32* @plawk_native_stream_readout_start_pc
+  %handle = call %Value @wam_stream_open_value(%Value %path)
+  %handle_tag = extractvalue %Value %handle, 0
+  %handle_is_int = icmp eq i32 %handle_tag, 1
+  br i1 %handle_is_int, label %check_handle_value, label %fail_open
+
+check_handle_value:
+  %handle_payload = extractvalue %Value %handle, 1
+  %handle_ok = icmp sgt i64 %handle_payload, 0
+  br i1 %handle_ok, label %init_state, label %fail_open
+
+init_state:
+  %state0 = call %Value @plawk_call_initial_state(%WamState* %vm, i32 %init_pc)
+  br label %loop
+
+loop:
+  %state = phi %Value [ %state0, %init_state ], [ %state_next, %call_handler ]
+  %line = call %Value @wam_stream_read_line_value(%Value %handle)
+  %line_tag = extractvalue %Value %line, 0
+  %line_payload = extractvalue %Value %line, 1
+  %line_is_int = icmp eq i32 %line_tag, 1
+  %line_bad_payload = icmp slt i64 %line_payload, 0
+  %line_bad = and i1 %line_is_int, %line_bad_payload
+  br i1 %line_bad, label %fail_read, label %check_line_atom
+
+check_line_atom:
+  %line_is_atom = icmp eq i32 %line_tag, 0
+  br i1 %line_is_atom, label %check_eof, label %fail_line_tag
+
+check_eof:
+  %line_s = call i8* @wam_atom_to_string(i64 %line_payload)
+  %eof_s = getelementptr [12 x i8], [12 x i8]* @.plawk_stream_eof, i32 0, i32 0
+  %eof_cmp = call i32 @strcmp(i8* %line_s, i8* %eof_s)
+  %is_eof = icmp eq i32 %eof_cmp, 0
+  br i1 %is_eof, label %close_stream, label %call_handler
+
+call_handler:
+  %state_next = call %Value @plawk_call_line_handler(%WamState* %vm, i32 %handler_pc, %Value %line, %Value %state)
+  %next_tag = extractvalue %Value %state_next, 0
+  %next_payload = extractvalue %Value %state_next, 1
+  %next_is_int = icmp eq i32 %next_tag, 1
+  %next_is_bad_payload = icmp slt i64 %next_payload, 0
+  %next_is_bad = and i1 %next_is_int, %next_is_bad_payload
+  br i1 %next_is_bad, label %fail_handler, label %loop
+
+close_stream:
+  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %close_ok, label %prepare_readout, label %fail_close
+
+prepare_readout:
+  %unb = call %Value @value_unbound(i8* null)
+  %count_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %first_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %second_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %count_ref = call %Value @value_ref(i32 %count_addr)
+  %first_ref = call %Value @value_ref(i32 %first_addr)
+  %second_ref = call %Value @value_ref(i32 %second_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %readout_pc)
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %state)
+  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %count_ref)
+  call void @wam_set_reg(%WamState* %vm, i32 2, %Value %first_ref)
+  call void @wam_set_reg(%WamState* %vm, i32 3, %Value %second_ref)
+  %readout_ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %readout_ok, label %check_count, label %fail_readout
+
+check_count:
+  %count_v = call %Value @wam_deref_value(%WamState* %vm, %Value %count_ref)
+  %count_tag = extractvalue %Value %count_v, 0
+  %count_is_int = icmp eq i32 %count_tag, 1
+  br i1 %count_is_int, label %check_count_value, label %fail_count_tag
+
+check_count_value:
+  %count_payload = extractvalue %Value %count_v, 1
+  %count_ok = icmp eq i64 %count_payload, 4
+  br i1 %count_ok, label %check_output_tags, label %fail_count_value
+
+check_output_tags:
+  %first_v = call %Value @wam_deref_value(%WamState* %vm, %Value %first_ref)
+  %second_v = call %Value @wam_deref_value(%WamState* %vm, %Value %second_ref)
+  %first_tag = extractvalue %Value %first_v, 0
+  %second_tag = extractvalue %Value %second_v, 0
+  %first_is_atom = icmp eq i32 %first_tag, 0
+  %second_is_atom = icmp eq i32 %second_tag, 0
+  %tags_ok = and i1 %first_is_atom, %second_is_atom
+  br i1 %tags_ok, label %check_output_strings, label %fail_output_tags
+
+check_output_strings:
+  %first_id = extractvalue %Value %first_v, 1
+  %second_id = extractvalue %Value %second_v, 1
+  %first_s = call i8* @wam_atom_to_string(i64 %first_id)
+  %second_s = call i8* @wam_atom_to_string(i64 %second_id)
+  %expect_first = getelementptr [16 x i8], [16 x i8]* @.plawk_expect_first, i32 0, i32 0
+  %expect_second = getelementptr [15 x i8], [15 x i8]* @.plawk_expect_second, i32 0, i32 0
+  %cmp_first = call i32 @strcmp(i8* %first_s, i8* %expect_first)
+  %cmp_second = call i32 @strcmp(i8* %second_s, i8* %expect_second)
+  %first_ok = icmp eq i32 %cmp_first, 0
+  %second_ok = icmp eq i32 %cmp_second, 0
+  %strings_ok = and i1 %first_ok, %second_ok
+  br i1 %strings_ok, label %success, label %fail_output_strings
+
+success:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 0
+
+fail_open:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 10
+
+fail_read:
+  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 11
+
+fail_line_tag:
+  %close_ignore_line_tag = call i1 @wam_stream_close_value(%Value %handle)
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 12
+
+fail_handler:
+  %close_ignore_handler = call i1 @wam_stream_close_value(%Value %handle)
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 13
+
+fail_close:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 14
+
+fail_readout:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 20
+
+fail_count_tag:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 30
+
+fail_count_value:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 31
+
+fail_output_tags:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 40
+
+fail_output_strings:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 41
+}
+
+define %Value @plawk_call_initial_state(%WamState* %vm, i32 %start_pc) {
+entry:
+  %unb = call %Value @value_unbound(i8* null)
+  %state_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %state_ref = call %Value @value_ref(i32 %state_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %start_pc)
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %state_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %done, label %failed
+
+done:
+  %state = call %Value @wam_deref_value(%WamState* %vm, %Value %state_ref)
+  ret %Value %state
+
+failed:
+  %bad = call %Value @value_integer(i64 -1)
+  ret %Value %bad
+}
+
+define %Value @plawk_call_line_handler(%WamState* %vm, i32 %start_pc, %Value %line, %Value %state0) {
+entry:
+  %unb = call %Value @value_unbound(i8* null)
+  %state_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %state_ref = call %Value @value_ref(i32 %state_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %start_pc)
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %line)
+  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %state0)
+  call void @wam_set_reg(%WamState* %vm, i32 2, %Value %state_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %done, label %failed
+
+done:
+  %state = call %Value @wam_deref_value(%WamState* %vm, %Value %state_ref)
+  ret %Value %state
+
+failed:
+  %bad = call %Value @value_integer(i64 -1)
+  ret %Value %bad
+}
+',
+        [BytesLen, PathBytes,
+         BytesLen, BytesLen, PathLen,
+         InstrCount, InstrCount, InstrCount,
+         LabelCount, LabelCount, LabelCount]).
+
+llvm_c_bytes([], '').
+llvm_c_bytes([Code | Rest], Bytes) :-
+    llvm_c_byte(Code, Byte),
+    llvm_c_bytes(Rest, Tail),
+    atom_concat(Byte, Tail, Bytes).
+
+llvm_c_byte(Code, Byte) :-
+    format(atom(Byte), '\\~|~`0t~16r~2+', [Code]).


### PR DESCRIPTION
## Summary

- add general WAM/LLVM stream helper functions callable from native LLVM (`@wam_stream_open_value`, `@wam_stream_read_line_value`, `@wam_stream_close_value`)
- add a PLAWK native stream-loop smoke that opens a real input file, reads lines until `end_of_file`, calls a compiled PLAWK handler once per record, and validates the final count/output state
- regenerate the checked-in PLAWK LLVM probes and update the PLAWK docs/README to mark the runtime-input native loop boundary

## Validation

- `swipl -q -s tests/test_plawk_native_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_native_outer_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_stream_runtime.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `llvm-as examples/plawk/generated/plawk_core_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_loop_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_meta_call_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_reader_probe.ll -o /dev/null`
- `git diff --check`

This is not a draft PR. I think it is ready to merge after normal review; I do not see a known blocker or a specific need for an external Perplexity review on this boundary.