### PR TITLE
Measure enwiki main-topic parent branching from LMDB

### DIFF
--- a/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
+++ b/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
@@ -528,3 +528,47 @@ the empirical pattern where the size-biased parent-branching signal can decline
 farther from the root. That refinement is planner-relevant, but should be held
 until deeper SimpleWiki and enwiki samples show that the stationary prior is
 materially miscalibrated.
+
+For LMDB exports, a sampled TSV is not enough to estimate parent branching.
+If the TSV was produced by a capped rooted child traversal, then `parents(v)`
+inside that TSV means "parents retained in the sample", not "parents of `v` in
+the full category graph". That can make a category with three, five, or more
+real parent categories look like a one-parent node simply because the other
+parents were outside the sampled subtree.
+
+The prior calibration therefore needs two parent-degree statistics:
+
+```text
+full_parent_degree(v)          = number of category_parent entries in LMDB
+root_reaching_parent_degree(v) = number of those parents with a parent-only
+                                 path back to the chosen root under the active
+                                 filter and depth/cycle policy
+```
+
+The first statistic measures raw Wikipedia category branching. The second is
+the admissible degree for a root-anchored parent-path histogram, because parents
+that cannot reach the root do not contribute to `H_v`. Both are useful: the
+full degree tells us how much branching the graph contains, while the
+root-reaching degree tells us how much of that branching is relevant to a
+specific root and category filter.
+
+The useful prior bucket is also not the child-BFS sampling depth. It is the
+scalar support upper bound:
+
+```text
+L_max(v) = maximum parent-only traversal distance from v back to root
+```
+
+`L_max` is the conservative horizon for the binomial or compound prior. In a
+near-chain region, `L_min` and `L_max` are close and either horizon gives a
+similar estimate. In enwiki, shortcut parents and side paths can make them
+diverge, so `L_max` is the safer admission signal for deciding how large the
+exact histogram might become before materialising it.
+
+`scripts/lmdb_parent_branching_diagnostic.py` is the corresponding full-graph
+diagnostic for numeric-keyed LMDB artifacts. It samples targets from the LMDB
+child index, measures parent degrees from the full LMDB parent index, computes
+bounded `L_min/L_max` by parent traversal, and reports size-biased parent
+branching by `L_max` bucket. The next enwiki run should use this diagnostic to
+decide whether a distribution-fit run needs a deeper ancestor-cone export
+rather than another capped subtree TSV.

--- a/docs/reports/lmdb_parent_branching_enwiki_numeric_root_2026-06-12.md
+++ b/docs/reports/lmdb_parent_branching_enwiki_numeric_root_2026-06-12.md
@@ -1,0 +1,120 @@
+# Enwiki Main Topic Parent Branching Diagnostic
+
+Date: 2026-06-12
+
+Branch: codex/full-parent-branching-diagnostic
+
+## Scope
+
+This diagnostic follows up on the numeric-root enwiki tail-pruning pilot. The previous pilot measured parent degree from a sampled TSV, so parent degree meant parents retained inside the sampled subtree. That undercounts Wikipedia category branching when a target has parents outside the capped subtree.
+
+The important correction is that the earlier numeric root 97688913 was not the named Category:Main_topic_classifications root. The title-resolved enwiki_cats_correct artifact identifies the relevant root as:
+
+    artifact=/home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct
+    root_title=Main_topic_classifications
+    root_id=7345184
+    root_child_count=35
+    edge_count=9927768
+
+Definitions:
+
+    full_parent_degree          = all LMDB category_parent entries for the target
+    root_reaching_parent_degree = direct parents that can reach the selected root
+                                  by parent-only traversal within the search cap
+
+The first statistic describes raw enwiki category branching. The second is the admissible branching for a root-anchored parent-path histogram.
+
+## Main Topic Classifications Sample
+
+Command:
+
+    python3 scripts/lmdb_parent_branching_diagnostic.py --lmdb-dir /home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct/lmdb_resident --root 7345184 --graph-name enwiki_mtc_full_parent_branching --child-depths 1,2,3,4 --children-per-node 256 --frontier-limit 5000 --targets-per-depth 200 --max-parent-depth 48 --seed enwiki-mtc-parent-branching-v1 --output-dir /mnt/c/Users/johnc/Scratch/full-parent-branching-diagnostic
+
+Generated outputs:
+
+    /mnt/c/Users/johnc/Scratch/full-parent-branching-diagnostic/lmdb_parent_branching_diagnostic_enwiki_mtc_full_parent_branching_20260612T003149Z.jsonl
+    /mnt/c/Users/johnc/Scratch/full-parent-branching-diagnostic/lmdb_parent_branching_diagnostic_summary_enwiki_mtc_full_parent_branching_20260612T003149Z.md
+
+Selection:
+
+| child_depth | sampled_frontier_nodes |
+|-------------|------------------------|
+| 0 | 1 |
+| 1 | 35 |
+| 2 | 1023 |
+| 3 | 5000 |
+| 4 | 5000 |
+
+Target summary:
+
+| targets | root_reachable | truncated | cycle_skipped |
+|---------|----------------|-----------|---------------|
+| 633 | 633 | 632 | 632 |
+
+Most sampled targets hit the max_parent_depth=48 cap or a skipped cycle while searching parent paths. Buckets at L_max = 48 are therefore censored lower bounds, not exact maximum root distances.
+
+## MTC Parent Degree By L_max
+
+| L_max | targets | mean_full_p | p95_full_p | max_full_p | b_full | mean_excess_full | mean_root_p | p95_root_p | max_root_p | b_root | mean_excess_root |
+|-------|---------|-------------|------------|------------|--------|------------------|-------------|------------|------------|--------|------------------|
+| 1 | 5 | 2.400 | 4.000 | 4 | 2.833333 | 1.833333 | 1.000 | 1.000 | 1 | 1.000000 | 0.000000 |
+| 2 | 6 | 2.833 | 4.000 | 4 | 3.000000 | 2.000000 | 1.500 | 2.000 | 2 | 1.666667 | 0.666667 |
+| 3 | 4 | 3.250 | 5.000 | 5 | 3.769231 | 2.769231 | 1.500 | 2.000 | 2 | 1.666667 | 0.666667 |
+| 4 | 4 | 3.500 | 4.000 | 4 | 3.714286 | 2.714286 | 1.750 | 3.000 | 3 | 2.142857 | 1.142857 |
+| 6 | 1 | 5.000 | 5.000 | 5 | 5.000000 | 4.000000 | 3.000 | 3.000 | 3 | 3.000000 | 2.000000 |
+| 7 | 2 | 4.000 | 4.000 | 4 | 4.000000 | 3.000000 | 1.500 | 2.000 | 2 | 1.666667 | 0.666667 |
+| 8 | 1 | 5.000 | 5.000 | 5 | 5.000000 | 4.000000 | 4.000 | 4.000 | 4 | 4.000000 | 3.000000 |
+| 9 | 5 | 4.400 | 5.000 | 5 | 4.454545 | 3.454545 | 2.000 | 3.000 | 3 | 2.200000 | 1.200000 |
+| 19 | 5 | 4.600 | 6.000 | 6 | 4.826087 | 3.826087 | 2.200 | 3.000 | 3 | 2.272727 | 1.272727 |
+| 20 | 10 | 4.100 | 6.000 | 6 | 4.414634 | 3.414634 | 1.800 | 3.000 | 3 | 2.000000 | 1.000000 |
+| 21 | 1 | 7.000 | 7.000 | 7 | 7.000000 | 6.000000 | 4.000 | 4.000 | 4 | 4.000000 | 3.000000 |
+| 22 | 20 | 3.850 | 7.000 | 7 | 4.272727 | 3.272727 | 2.150 | 3.000 | 3 | 2.348837 | 1.348837 |
+| 30 | 7 | 2.857 | 4.000 | 4 | 3.000000 | 2.000000 | 2.143 | 3.000 | 3 | 2.200000 | 1.200000 |
+| 34 | 50 | 4.240 | 7.000 | 8 | 4.764151 | 3.764151 | 2.560 | 5.000 | 6 | 2.968750 | 1.968750 |
+| 41 | 19 | 3.316 | 6.000 | 9 | 4.333333 | 3.333333 | 2.421 | 4.000 | 5 | 2.695652 | 1.695652 |
+| 42 | 1 | 2.000 | 2.000 | 2 | 2.000000 | 1.000000 | 2.000 | 2.000 | 2 | 2.000000 | 1.000000 |
+| 48 | 492 | 4.142 | 8.000 | 26 | 5.290481 | 4.290481 | 3.299 | 6.000 | 24 | 4.255699 | 3.255699 |
+
+This is the more relevant enwiki result. The MTC sample reaches substantial frontiers at depths 2-4, and both full and root-reaching parent branching are well above the earlier TSV-local estimate. In the censored L_max = 48 bucket, mean full parent degree is 4.142, p95 full degree is 8, and the largest sampled full parent degree is 26. The root-reaching signal remains large: mean root-reaching parent degree is 3.299, p95 is 6, and the largest sampled root-reaching parent degree is 24.
+
+## Numeric-Root Contrast
+
+The older numeric root 97688913 came from the separate enwiki_cats/lmdb_resident artifact metadata, not from the MTC title-resolved artifact. It still usefully demonstrated the difference between full parent degree and sampled-TSV degree, but it should not be treated as representative of the MTC subtree.
+
+Numeric-root parent degree by L_max:
+
+| L_max | targets | mean_full_p | p95_full_p | max_full_p | b_full | mean_excess_full | mean_root_p | p95_root_p | max_root_p | b_root | mean_excess_root |
+|-------|---------|-------------|------------|------------|--------|------------------|-------------|------------|------------|--------|------------------|
+| 1 | 145 | 5.469 | 9.000 | 10 | 6.157629 | 5.157629 | 1.000 | 1.000 | 1 | 1.000000 | 0.000000 |
+| 2 | 18 | 6.556 | 10.000 | 12 | 7.254237 | 6.254237 | 1.556 | 2.000 | 2 | 1.714286 | 0.714286 |
+
+This confirms that enwiki categories in the numeric-root sample have much more raw parent branching than the previous TSV-local estimate showed. The earlier mean near 1.01 was not a credible estimate of full category parent degree; it was mostly a measure of how many sampled-subtree parent edges survived the capped export.
+
+## Interpretation
+
+Both parent-degree signals are needed:
+
+    full_parent_degree          -> graph complexity / raw Wikipedia branching
+    root_reaching_parent_degree -> admissible branching for this root and filter
+
+The distribution prior for root-anchored parent paths should use root_reaching_parent_degree, bucketed by L_max, because parents that cannot reach the selected root do not contribute paths to the root histogram. The full degree should still be reported because it tells us when the category graph has substantial side branching that a different root, broader filter, or child-inclusive search may admit.
+
+This also explains why user-provided examples such as categories with three or five parent categories do not contradict a low root-reaching estimate under a specific root. They do contradict the previous TSV-local degree estimate, and they show why the full LMDB parent-degree column must be carried separately.
+
+## Next Sampling Step
+
+The MTC run shows enough branching that the next enwiki run should move from degree diagnostics to bounded exact histograms over selected ancestor cones. Because many targets hit the depth cap or cycle policy, the next run should select deeper MTC targets, export their bounded parent ancestor cones, and then compare:
+
+    1. exact root-reaching histograms;
+    2. L_min/L_max scalar bounds;
+    3. priors bucketed by capped or exact L_max;
+    4. full versus root-reaching parent-degree moments.
+
+That deeper-target approach is the right place to recompute exact histograms, because it will let the prior use L_max and root_reaching_parent_degree for the actual nodes whose distributions we care about.
+
+## Validation
+
+- python3 -m unittest tests.test_lmdb_parent_branching_diagnostic
+- python3 scripts/lmdb_parent_branching_diagnostic.py ... --graph-name enwiki_mtc_full_parent_branching
+- python3 scripts/lmdb_parent_branching_diagnostic.py ... --graph-name enwiki_root97688913_full_parent_branching
+- python3 scripts/lmdb_parent_branching_diagnostic.py ... --graph-name enwiki_root97688913_full_parent_branching_wide

--- a/scripts/lmdb_parent_branching_diagnostic.py
+++ b/scripts/lmdb_parent_branching_diagnostic.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Diagnose full parent branching for numeric-keyed category LMDB exports.
+
+Sampled TSVs only contain parents retained by the sampling procedure.  This
+script samples targets from an LMDB child index, but measures parent degree from
+the full LMDB parent index and buckets the signal by maximum parent-only
+distance to the chosen root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import random
+import struct
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+DEFAULT_DEPTHS = [1, 2, 3, 4]
+
+
+def parse_int_list(text):
+    values = []
+    for part in text.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            lo_text, hi_text = part.split("-", 1)
+            lo = int(lo_text)
+            hi = int(hi_text)
+            step = 1 if hi >= lo else -1
+            values.extend(range(lo, hi + step, step))
+        else:
+            values.append(int(part))
+    return values
+
+
+def percentile(values, pct):
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, round((pct / 100.0) * (len(ordered) - 1))))
+    return float(ordered[index])
+
+
+def size_biased_branching(degrees):
+    degrees = [int(degree) for degree in degrees if degree is not None and degree > 0]
+    if not degrees:
+        return {
+            "nodes": 0,
+            "mean_parent_degree": 0.0,
+            "second_parent_degree_moment": 0.0,
+            "size_biased_parent_branching": None,
+            "mean_excess": None,
+            "max_parent_degree": 0,
+            "p95_parent_degree": 0.0,
+        }
+    mean = sum(degrees) / len(degrees)
+    second = sum(degree * degree for degree in degrees) / len(degrees)
+    branching = None if mean == 0.0 else second / mean
+    return {
+        "nodes": len(degrees),
+        "mean_parent_degree": mean,
+        "second_parent_degree_moment": second,
+        "size_biased_parent_branching": branching,
+        "mean_excess": None if branching is None else branching - 1.0,
+        "max_parent_degree": max(degrees),
+        "p95_parent_degree": percentile(degrees, 95),
+    }
+
+
+def deterministic_sample(values, limit, seed_text):
+    values = list(dict.fromkeys(values))
+    if limit is None or len(values) <= limit:
+        return values
+    digest = hashlib.blake2b(seed_text.encode("utf-8"), digest_size=16).hexdigest()
+    rng = random.Random(digest)
+    return sorted(rng.sample(values, limit))
+
+
+def encode_key(value):
+    return struct.pack("<i", int(value))
+
+
+def decode_value(value):
+    return struct.unpack("<i", value)[0]
+
+
+def iter_dups(txn, db, key):
+    cursor = txn.cursor(db=db)
+    if not cursor.set_key(encode_key(key)):
+        return []
+    return [decode_value(value) for value in cursor.iternext_dup()]
+
+
+class LmdbCategoryGraph:
+    def __init__(self, lmdb_dir):
+        try:
+            import lmdb
+        except ImportError as exc:
+            raise SystemExit("python-lmdb is required for LMDB diagnostics") from exc
+
+        self.env = lmdb.open(str(lmdb_dir), readonly=True, lock=False, max_dbs=32)
+        self.txn = self.env.begin()
+        self.category_parent = self.env.open_db(b"category_parent", txn=self.txn)
+        self.category_child = self.env.open_db(b"category_child", txn=self.txn)
+        self._parents = {}
+        self._children = {}
+
+    def close(self):
+        self.txn.abort()
+        self.env.close()
+
+    def parents(self, node):
+        if node not in self._parents:
+            self._parents[node] = iter_dups(self.txn, self.category_parent, node)
+        return self._parents[node]
+
+    def children(self, node):
+        if node not in self._children:
+            self._children[node] = iter_dups(self.txn, self.category_child, node)
+        return self._children[node]
+
+
+def select_targets_by_child_depth(graph, root, depths, children_per_node, frontier_limit, targets_per_depth, seed):
+    max_depth = max(depths) if depths else 0
+    depth_nodes = {0: [root]}
+    frontier = [root]
+    for depth in range(1, max_depth + 1):
+        next_nodes = []
+        for node in frontier:
+            children = deterministic_sample(
+                graph.children(node),
+                children_per_node,
+                "{}:children:{}:{}".format(seed, depth, node),
+            )
+            next_nodes.extend(children)
+        next_nodes = deterministic_sample(
+            list(dict.fromkeys(next_nodes)),
+            frontier_limit,
+            "{}:frontier:{}".format(seed, depth),
+        )
+        depth_nodes[depth] = next_nodes
+        frontier = next_nodes
+
+    targets = []
+    target_child_depth = {}
+    for depth in depths:
+        sampled = deterministic_sample(
+            depth_nodes.get(depth, []),
+            targets_per_depth,
+            "{}:targets:{}".format(seed, depth),
+        )
+        for node in sampled:
+            if node not in target_child_depth:
+                targets.append(node)
+                target_child_depth[node] = depth
+    return targets, target_child_depth, {depth: len(nodes) for depth, nodes in depth_nodes.items()}
+
+
+def root_distances(node, root, parents_func, max_parent_depth, memo=None, visiting=None):
+    if memo is None:
+        memo = {}
+    if visiting is None:
+        visiting = set()
+    key = (node, max_parent_depth)
+    if key in memo:
+        return memo[key]
+    if node == root:
+        memo[key] = {"L_min": 0, "L_max": 0, "truncated": False, "cycle_skipped": False}
+        return memo[key]
+    if max_parent_depth <= 0:
+        return {"L_min": None, "L_max": None, "truncated": True, "cycle_skipped": False}
+    if node in visiting:
+        return {"L_min": None, "L_max": None, "truncated": False, "cycle_skipped": True}
+
+    visiting.add(node)
+    mins = []
+    maxes = []
+    truncated = False
+    cycle_skipped = False
+    for parent in parents_func(node):
+        result = root_distances(parent, root, parents_func, max_parent_depth - 1, memo, visiting)
+        truncated = truncated or bool(result["truncated"])
+        cycle_skipped = cycle_skipped or bool(result["cycle_skipped"])
+        if result["L_min"] is not None:
+            mins.append(int(result["L_min"]) + 1)
+        if result["L_max"] is not None:
+            maxes.append(int(result["L_max"]) + 1)
+    visiting.remove(node)
+    memo[key] = {
+        "L_min": min(mins) if mins else None,
+        "L_max": max(maxes) if maxes else None,
+        "truncated": truncated,
+        "cycle_skipped": cycle_skipped,
+    }
+    return memo[key]
+
+
+def target_record(graph_name, root, target, child_depth, parents, distances, parent_distances):
+    root_reaching_parent_degree = 0
+    for parent in parents:
+        if parent_distances(parent)["L_min"] is not None:
+            root_reaching_parent_degree += 1
+    return {
+        "record_type": "lmdb_parent_branching_target",
+        "graph": graph_name,
+        "root": root,
+        "target_node": target,
+        "child_sample_depth": child_depth,
+        "L_min": distances["L_min"],
+        "L_max": distances["L_max"],
+        "distance_truncated": distances["truncated"],
+        "cycle_skipped": distances["cycle_skipped"],
+        "full_parent_degree": len(parents),
+        "root_reaching_parent_degree": root_reaching_parent_degree,
+    }
+
+
+def bucket_records(records):
+    buckets = {}
+    for record in records:
+        if record["record_type"] != "lmdb_parent_branching_target":
+            continue
+        key = "unreachable_or_truncated" if record.get("L_max") is None else int(record["L_max"])
+        buckets.setdefault(key, []).append(record)
+
+    out = []
+    for key in sorted(buckets, key=lambda value: (isinstance(value, str), value)):
+        rows = buckets[key]
+        out.append({
+            "record_type": "lmdb_parent_branching_bucket",
+            "L_max_bucket": key,
+            "targets": len(rows),
+            "full_parent_degree": size_biased_branching([row["full_parent_degree"] for row in rows]),
+            "root_reaching_parent_degree": size_biased_branching([row["root_reaching_parent_degree"] for row in rows]),
+            "truncated_targets": sum(1 for row in rows if row["distance_truncated"]),
+            "cycle_skipped_targets": sum(1 for row in rows if row["cycle_skipped"]),
+        })
+    return out
+
+
+def format_none(value):
+    return "n/a" if value is None else str(value)
+
+
+def format_optional(value):
+    return "n/a" if value is None else "{:.6f}".format(float(value))
+
+
+def summarize(records, graph_name, root, selection_counts):
+    target_rows = [row for row in records if row["record_type"] == "lmdb_parent_branching_target"]
+    bucket_rows = [row for row in records if row["record_type"] == "lmdb_parent_branching_bucket"]
+    reachable_rows = [row for row in target_rows if row["L_max"] is not None]
+    lines = [
+        "# LMDB Parent Branching Diagnostic",
+        "",
+        "Graph: `{}`".format(graph_name),
+        "",
+        "Root: `{}`".format(root),
+        "",
+        "## Selection",
+        "",
+        "| child_depth | sampled_frontier_nodes |",
+        "|-------------|------------------------|",
+    ]
+    for depth in sorted(selection_counts):
+        lines.append("| {} | {} |".format(depth, selection_counts[depth]))
+    lines.extend([
+        "",
+        "## Target Summary",
+        "",
+        "| targets | root_reachable | truncated | cycle_skipped |",
+        "|---------|----------------|-----------|---------------|",
+        "| {} | {} | {} | {} |".format(
+            len(target_rows),
+            len(reachable_rows),
+            sum(1 for row in target_rows if row["distance_truncated"]),
+            sum(1 for row in target_rows if row["cycle_skipped"]),
+        ),
+        "",
+        "## Parent Degree By Maximum Parent Distance To Root",
+        "",
+        "| L_max | targets | mean_full_p | p95_full_p | max_full_p | b_full | mean_excess_full | mean_root_p | p95_root_p | max_root_p | b_root | mean_excess_root |",
+        "|-------|---------|-------------|------------|------------|--------|------------------|-------------|------------|------------|--------|------------------|",
+    ])
+    for row in bucket_rows:
+        full = row["full_parent_degree"]
+        reachable = row["root_reaching_parent_degree"]
+        lines.append(
+            "| {bucket} | {targets} | {mean_full:.3f} | {p95_full:.3f} | {max_full} | {b_full} | {excess_full} | {mean_root:.3f} | {p95_root:.3f} | {max_root} | {b_root} | {excess_root} |".format(
+                bucket=row["L_max_bucket"],
+                targets=row["targets"],
+                mean_full=full["mean_parent_degree"],
+                p95_full=full["p95_parent_degree"],
+                max_full=full["max_parent_degree"],
+                b_full=format_optional(full["size_biased_parent_branching"]),
+                excess_full=format_optional(full["mean_excess"]),
+                mean_root=reachable["mean_parent_degree"],
+                p95_root=reachable["p95_parent_degree"],
+                max_root=reachable["max_parent_degree"],
+                b_root=format_optional(reachable["size_biased_parent_branching"]),
+                excess_root=format_optional(reachable["mean_excess"]),
+            )
+        )
+    lines.extend([
+        "",
+        "## Highest Parent-Degree Sampled Targets",
+        "",
+        "| target | child_depth | L_min | L_max | full_parent_degree | root_reaching_parent_degree |",
+        "|--------|-------------|-------|-------|--------------------|-----------------------------|",
+    ])
+    for row in sorted(target_rows, key=lambda item: (item["full_parent_degree"], item["root_reaching_parent_degree"]), reverse=True)[:20]:
+        lines.append(
+            "| {target} | {child_depth} | {lmin} | {lmax} | {full} | {root_p} |".format(
+                target=row["target_node"],
+                child_depth=row["child_sample_depth"],
+                lmin=format_none(row["L_min"]),
+                lmax=format_none(row["L_max"]),
+                full=row["full_parent_degree"],
+                root_p=row["root_reaching_parent_degree"],
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(records, summary, output_dir, graph_name):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    safe_graph = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in graph_name).strip("_") or "graph"
+    jsonl_path = output_dir / "lmdb_parent_branching_diagnostic_{}_{}.jsonl".format(safe_graph, timestamp)
+    summary_path = output_dir / "lmdb_parent_branching_diagnostic_summary_{}_{}.md".format(safe_graph, timestamp)
+    with jsonl_path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+    summary_path.write_text(summary, encoding="utf-8")
+    return jsonl_path, summary_path
+
+
+def run_lmdb_diagnostic(args):
+    graph = LmdbCategoryGraph(args.lmdb_dir)
+    try:
+        depths = parse_int_list(args.child_depths)
+        targets, child_depths, selection_counts = select_targets_by_child_depth(
+            graph,
+            args.root,
+            depths,
+            args.children_per_node,
+            args.frontier_limit,
+            args.targets_per_depth,
+            args.seed,
+        )
+        distance_memo = {}
+
+        def distances(node):
+            return root_distances(node, args.root, graph.parents, args.max_parent_depth, distance_memo)
+
+        records = []
+        for target in targets:
+            records.append(
+                target_record(
+                    args.graph_name,
+                    args.root,
+                    target,
+                    child_depths[target],
+                    graph.parents(target),
+                    distances(target),
+                    distances,
+                )
+            )
+        records.extend(bucket_records(records))
+        summary = summarize(records, args.graph_name, args.root, selection_counts)
+        return records, summary
+    finally:
+        graph.close()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lmdb-dir", required=True, type=Path, help="Numeric-keyed category LMDB directory.")
+    parser.add_argument("--root", required=True, type=int, help="Numeric root id.")
+    parser.add_argument("--graph-name", default="lmdb_parent_branching", help="Graph label used in output filenames.")
+    parser.add_argument("--child-depths", default=",".join(map(str, DEFAULT_DEPTHS)), help="Child-sampling depths to target.")
+    parser.add_argument("--children-per-node", type=int, default=64, help="Deterministic sample cap for children per frontier node.")
+    parser.add_argument("--frontier-limit", type=int, default=5000, help="Deterministic cap for each sampled child-depth frontier.")
+    parser.add_argument("--targets-per-depth", type=int, default=200, help="Deterministic target cap per requested child depth.")
+    parser.add_argument("--max-parent-depth", type=int, default=48, help="Maximum parent hops to search when computing L_min/L_max.")
+    parser.add_argument("--seed", default="0", help="Deterministic sampling seed.")
+    parser.add_argument("--output-dir", type=Path, help="Optional directory for JSONL and markdown output.")
+    args = parser.parse_args(argv)
+
+    if args.children_per_node <= 0:
+        raise SystemExit("--children-per-node must be positive")
+    if args.frontier_limit <= 0:
+        raise SystemExit("--frontier-limit must be positive")
+    if args.targets_per_depth <= 0:
+        raise SystemExit("--targets-per-depth must be positive")
+    if args.max_parent_depth <= 0:
+        raise SystemExit("--max-parent-depth must be positive")
+
+    records, summary = run_lmdb_diagnostic(args)
+    if args.output_dir:
+        jsonl_path, summary_path = write_outputs(records, summary, args.output_dir, args.graph_name)
+        print(summary, end="")
+        print("jsonl={}".format(jsonl_path))
+        print("summary={}".format(summary_path))
+    else:
+        print(summary, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_lmdb_parent_branching_diagnostic.py
+++ b/tests/test_lmdb_parent_branching_diagnostic.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Tests for LMDB parent-branching diagnostic helpers."""
+
+import unittest
+
+from scripts.lmdb_parent_branching_diagnostic import (
+    bucket_records,
+    deterministic_sample,
+    root_distances,
+    size_biased_branching,
+)
+
+
+class LmdbParentBranchingDiagnosticTests(unittest.TestCase):
+    def test_size_biased_branching_reports_excess(self):
+        stats = size_biased_branching([1, 3, 5])
+
+        self.assertAlmostEqual(stats["mean_parent_degree"], 3.0)
+        self.assertAlmostEqual(stats["second_parent_degree_moment"], 35.0 / 3.0)
+        self.assertAlmostEqual(stats["size_biased_parent_branching"], 35.0 / 9.0)
+        self.assertAlmostEqual(stats["mean_excess"], 35.0 / 9.0 - 1.0)
+
+    def test_root_distances_tracks_maximum_parent_distance(self):
+        parents = {
+            "A": ["R"],
+            "B": ["A"],
+            "C": ["R", "B"],
+        }
+
+        result = root_distances("C", "R", lambda node: parents.get(node, []), 8)
+
+        self.assertEqual(result["L_min"], 1)
+        self.assertEqual(result["L_max"], 3)
+        self.assertFalse(result["truncated"])
+
+    def test_bucket_records_uses_l_max_bucket(self):
+        records = [
+            {
+                "record_type": "lmdb_parent_branching_target",
+                "L_max": 2,
+                "full_parent_degree": 1,
+                "root_reaching_parent_degree": 1,
+                "distance_truncated": False,
+                "cycle_skipped": False,
+            },
+            {
+                "record_type": "lmdb_parent_branching_target",
+                "L_max": 2,
+                "full_parent_degree": 4,
+                "root_reaching_parent_degree": 3,
+                "distance_truncated": False,
+                "cycle_skipped": False,
+            },
+        ]
+
+        buckets = bucket_records(records)
+
+        self.assertEqual(len(buckets), 1)
+        self.assertEqual(buckets[0]["L_max_bucket"], 2)
+        self.assertEqual(buckets[0]["full_parent_degree"]["max_parent_degree"], 4)
+        self.assertEqual(buckets[0]["root_reaching_parent_degree"]["max_parent_degree"], 3)
+
+    def test_deterministic_sample_is_stable(self):
+        values = list(range(100))
+
+        self.assertEqual(
+            deterministic_sample(values, 10, "seed"),
+            deterministic_sample(values, 10, "seed"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `scripts/lmdb_parent_branching_diagnostic.py` to sample numeric-keyed category LMDB targets while measuring parent degree from the full `category_parent` index.
- Separates `full_parent_degree` from `root_reaching_parent_degree`, so TSV-local undercounting is no longer confused with actual Wikipedia category branching.
- Updates `PARENT_BRANCHING_DISTRIBUTION_THEORY.md` to document why sampled TSV parent degree is insufficient and why priors should be bucketed by `L_max`.
- Adds an enwiki report using the title-resolved `enwiki_cats_correct` artifact: `Category:Main_topic_classifications` is `root_id=7345184`, not the older numeric best-root `97688913`.
- Records the MTC diagnostic result: frontier sizes `0:1, 1:35, 2:1023, 3:5000, 4:5000`; in the censored `L_max=48` bucket, mean full parent degree is `4.142`, p95 full degree is `8`, max full degree is `26`, mean root-reaching degree is `3.299`, p95 root-reaching degree is `6`, and max root-reaching degree is `24`.

## Notes

The MTC run is capped at `max_parent_depth=48`, and most sampled targets hit the cap or a skipped cycle. The report treats `L_max=48` as censored rather than exact. The older `97688913` numeric-root run remains only as a contrast showing why the previous TSV-local estimate looked too shallow.

## Validation

- `python3 -m unittest tests.test_lmdb_parent_branching_diagnostic`
- `python3 scripts/lmdb_parent_branching_diagnostic.py ... --graph-name enwiki_mtc_full_parent_branching`
- `python3 scripts/lmdb_parent_branching_diagnostic.py ... --graph-name enwiki_root97688913_full_parent_branching`
- `python3 scripts/lmdb_parent_branching_diagnostic.py ... --graph-name enwiki_root97688913_full_parent_branching_wide`
- `git diff --check`