### PR TITLE
[codex] Split PLAWK native counter from WAM outputs

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -188,25 +188,25 @@ The first WAM/LLVM probes now live under `examples/plawk/probes/`.
 **Success:** a native binary that reads stdin, counts records, prints matching
 lines — identical behaviour to Phase 0, running as compiled LLVM.
 
-**Current boundary:** the compiled stream smoke still reads from a file path
-rather than stdin, and `state/4` remains represented as ordinary WAM terms
-rather than a specialized LLVM aggregate. Generic output accumulation now goes
-through `append_output/3` and `state_outputs/2`. WAM/LLVM now exposes general
-stream helpers (`@wam_stream_open_value`, `@wam_stream_read_line_value`, and
+**Current boundary:** the compiled and native stream smokes still read from file
+paths rather than stdin. WAM/LLVM exposes general stream helpers
+(`@wam_stream_open_value`, `@wam_stream_read_line_value`, and
 `@wam_stream_close_value`) that native LLVM code can call directly, alongside
 the existing `stream_open/2`, `read_line/2`, and `stream_close/1` builtins.
 The `tests/test_plawk_native_stream_loop_driver.pl` smoke proves a native LLVM
 loop can open a runtime file path, read lines until `end_of_file`, call a
-compiled PLAWK handler once per record, thread PLAWK state across those calls,
-and read the final count and outputs back through WAM. The remaining hot-loop
-boundary is lowering state fields such as `state/4` counter/output data to
-native aggregates rather than ordinary WAM terms.
+compiled PLAWK handler once per record, and thread PLAWK state through WAM.
+The `tests/test_plawk_native_counter_stream_loop_driver.pl` smoke then lowers
+the hot record counter to a native `i64` loop variable while keeping output
+accumulation as ordinary WAM terms via `append_output/3` and `state_outputs/2`.
+The remaining hot-loop boundary is native output accumulation: keep WAM handler
+calls only for logic that still needs WAM, while native reader/counter/output
+state stay in LLVM-owned data.
 
-**Compiler note:** this smoke detects matching lines by `sub_atom(Line, 0, 5, _, 'ERROR')`
-instead of full-line facts such as `'ERROR disk full'`. The current WAM/LLVM
-atom-literal path serializes quoted atoms with spaces including their quote
-characters, while native/runtime-created line atoms are raw text. That is a
-separate atom-literal normalization issue, not a native-loop requirement.
+**Compiler note:** WAM/LLVM now normalizes quoted atom tokens before interning.
+Atoms such as `'ERROR disk full'` and `'it\'s bad'` compile to raw runtime
+atom names without the outer WAM token quotes.
+`tests/test_wam_llvm_quoted_atom_literals.pl` covers that regression.
 
 ---
 

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -68,6 +68,7 @@ swipl -q -s examples/plawk/demo/print_error_fields.pl -t halt
 swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_native_outer_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_native_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_native_counter_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -15836,13 +15836,20 @@ target_struct_tm_gmtoff_offset(_, 40).
 
 % --- Value packing helpers ---
 
-llvm_pack_value(atom(A), Packed) :- !,
+llvm_pack_value(atom(A0), Packed) :- !,
+    llvm_normalize_atom_token(A0, A),
     intern_atom(A, Packed).
 llvm_pack_value(integer(I), I) :- !.
 llvm_pack_value(N, N) :- integer(N), !.
 llvm_pack_value(N, Packed) :- float(N), !, Packed is truncate(N).
-llvm_pack_value(A, Packed) :- atom(A), !, intern_atom(A, Packed).
+llvm_pack_value(A0, Packed) :- atom(A0), !,
+    llvm_normalize_atom_token(A0, A),
+    intern_atom(A, Packed).
 llvm_pack_value(_, 0).
+llvm_normalize_atom_token(A0, A) :-
+    atom_string(A0, S0),
+    strip_quoted_atom(S0, S),
+    atom_string(A, S).
 
 % --- Builtin op name → integer ID mapping ---
 
@@ -16308,6 +16315,10 @@ qa_quoted([Q|Cs], AccIn, AccOut, RestOut) :-
     Q = 0'',
     qa_quoted_body(Cs, [Q|AccIn], AccOut, RestOut).
 
+qa_quoted_body([92, 39 | Cs], Acc, AccOut, RestOut) :- !,
+    qa_quoted_body(Cs, [39, 92 | Acc], AccOut, RestOut).
+qa_quoted_body([92, 92 | Cs], Acc, AccOut, RestOut) :- !,
+    qa_quoted_body(Cs, [92, 92 | Acc], AccOut, RestOut).
 qa_quoted_body([], Acc, Acc, []).
 qa_quoted_body([0'', 0''|Cs], Acc, AccOut, RestOut) :- !,
     % Escaped apostrophe: keep both in the accumulator.
@@ -16781,9 +16792,8 @@ llvm_pack_value_str(Str, Packed) :-
 
 %% strip_quoted_atom(+S, -Inner)
 %
-%  If S is a single-quoted atom representation `'...'`, return the
-%  inner string with `''` un-escaped to `'`. Otherwise return S
-%  unchanged.
+%  If S is a single-quoted atom representation, return the inner string
+%  with WAM quote escapes un-escaped. Otherwise return S unchanged.
 strip_quoted_atom(Str, Inner) :-
     string_length(Str, L),
     ( L >= 2,
@@ -16791,20 +16801,22 @@ strip_quoted_atom(Str, Inner) :-
       sub_string(Str, _, 1, 0, "'")
     -> InnerLen is L - 2,
        sub_string(Str, 1, InnerLen, 1, Body),
-       % Un-escape `''` (Prolog''s quoted-atom escape for `'`).
-       % Most format strings don''t contain `'`, so this is a no-op
-       % in the common path.
+       % WAM quoting uses backslash escapes; accept doubled apostrophes
+       % as a legacy tokenizer convention too.
        string_codes(Body, BodyCodes),
-       unescape_quotes(BodyCodes, UnescCodes),
+       unescape_wam_quoted_codes(BodyCodes, UnescCodes),
        string_codes(Inner, UnescCodes)
     ;  Inner = Str
     ).
-
-unescape_quotes([], []).
-unescape_quotes([0'', 0''|Cs], [0''|Rest]) :- !,
-    unescape_quotes(Cs, Rest).
-unescape_quotes([C|Cs], [C|Rest]) :-
-    unescape_quotes(Cs, Rest).
+unescape_wam_quoted_codes([], []).
+unescape_wam_quoted_codes([92, 92 | Cs], [92 | Rest]) :- !,
+    unescape_wam_quoted_codes(Cs, Rest).
+unescape_wam_quoted_codes([92, 39 | Cs], [39 | Rest]) :- !,
+    unescape_wam_quoted_codes(Cs, Rest).
+unescape_wam_quoted_codes([39, 39 | Cs], [39 | Rest]) :- !,
+    unescape_wam_quoted_codes(Cs, Rest).
+unescape_wam_quoted_codes([C | Cs], [C | Rest]) :-
+    unescape_wam_quoted_codes(Cs, Rest).
 
 % NOTE: we don't take a %WamState param — the function creates its own vm
 % via wam_state_new() in the entry block. Taking %vm as a param conflicted

--- a/tests/test_plawk_native_counter_stream_loop_driver.pl
+++ b/tests/test_plawk_native_counter_stream_loop_driver.pl
@@ -1,0 +1,293 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/core/plawk_core').
+
+:- dynamic user:plawk_native_counter_initial_outputs/1.
+:- dynamic user:plawk_native_counter_output_handler/3.
+:- dynamic user:plawk_native_counter_error_line/1.
+:- dynamic user:plawk_native_counter_readout/3.
+
+user:plawk_native_counter_initial_outputs(state([], [], 0, none)).
+
+user:plawk_native_counter_output_handler(Line, State0, StateN) :-
+    (   plawk_native_counter_error_line(Line)
+    ->  append_output(Line, State0, StateN)
+    ;   StateN = State0
+    ).
+
+user:plawk_native_counter_error_line(Line) :-
+    sub_atom(Line, 0, 5, _, 'ERROR').
+
+user:plawk_native_counter_readout(State, FirstError, SecondError) :-
+    state_outputs(State, [FirstError, SecondError]).
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_native_counter_stream_loop_driver, [condition(clang_available)]).
+
+test(native_loop_counts_records_while_wam_threads_outputs) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_native_counter_stream_loop_driver', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, 'INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n', []),
+        close(In)),
+    directory_file_path(Dir, 'plawk_native_counter_stream_loop.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_native_counter_initial_outputs/1,
+          user:plawk_native_counter_output_handler/3,
+          user:plawk_native_counter_error_line/1,
+          user:plawk_native_counter_readout/3,
+          plawk_core:normalize_outputs/2
+        ],
+        [module_name('plawk_native_counter_stream_loop')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    plawk_native_counter_stream_loop_driver_ir(InputPath, InstrCount, LabelCount, DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_native_counter_stream_loop_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk native counter stream loop output]~n~w~n",
+              [OutStr]),
+       throw(plawk_native_counter_stream_loop_driver_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_native_counter_stream_loop_driver).
+
+plawk_native_counter_stream_loop_driver_ir(InputPath, InstrCount, LabelCount, DriverIR) :-
+    atom_codes(InputPath, PathCodes),
+    length(PathCodes, PathLen),
+    BytesLen is PathLen + 1,
+    llvm_c_bytes(PathCodes, PathBytes),
+    format(atom(DriverIR),
+'@.plawk_counter_path = private constant [~w x i8] c"~w\\00"
+@.plawk_counter_eof = private constant [12 x i8] c"end_of_file\\00"
+@.plawk_expect_first = private constant [16 x i8] c"ERROR disk full\\00"
+@.plawk_expect_second = private constant [15 x i8] c"ERROR net down\\00"
+
+define i32 @main() {
+entry:
+  %path_ptr = getelementptr [~w x i8], [~w x i8]* @.plawk_counter_path, i32 0, i32 0
+  %path_id = call i64 @wam_intern_atom(i8* %path_ptr, i64 ~w)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @module_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @module_labels, i32 0, i32 0),
+      i32 ~w)
+  %init_pc = load i32, i32* @plawk_native_counter_initial_outputs_start_pc
+  %handler_pc = load i32, i32* @plawk_native_counter_output_handler_start_pc
+  %readout_pc = load i32, i32* @plawk_native_counter_readout_start_pc
+  %handle = call %Value @wam_stream_open_value(%Value %path)
+  %handle_tag = extractvalue %Value %handle, 0
+  %handle_is_int = icmp eq i32 %handle_tag, 1
+  br i1 %handle_is_int, label %check_handle_value, label %fail_open
+
+check_handle_value:
+  %handle_payload = extractvalue %Value %handle, 1
+  %handle_ok = icmp sgt i64 %handle_payload, 0
+  br i1 %handle_ok, label %init_outputs, label %fail_open
+
+init_outputs:
+  %outputs0 = call %Value @plawk_call_initial_outputs(%WamState* %vm, i32 %init_pc)
+  br label %loop
+
+loop:
+  %count = phi i64 [ 0, %init_outputs ], [ %count_next, %call_handler ]
+  %outputs = phi %Value [ %outputs0, %init_outputs ], [ %outputs_next, %call_handler ]
+  %line = call %Value @wam_stream_read_line_value(%Value %handle)
+  %line_tag = extractvalue %Value %line, 0
+  %line_payload = extractvalue %Value %line, 1
+  %line_is_int = icmp eq i32 %line_tag, 1
+  %line_bad_payload = icmp slt i64 %line_payload, 0
+  %line_bad = and i1 %line_is_int, %line_bad_payload
+  br i1 %line_bad, label %fail_read, label %check_line_atom
+
+check_line_atom:
+  %line_is_atom = icmp eq i32 %line_tag, 0
+  br i1 %line_is_atom, label %check_eof, label %fail_line_tag
+
+check_eof:
+  %line_s = call i8* @wam_atom_to_string(i64 %line_payload)
+  %eof_s = getelementptr [12 x i8], [12 x i8]* @.plawk_counter_eof, i32 0, i32 0
+  %eof_cmp = call i32 @strcmp(i8* %line_s, i8* %eof_s)
+  %is_eof = icmp eq i32 %eof_cmp, 0
+  br i1 %is_eof, label %close_stream, label %call_handler
+
+call_handler:
+  %outputs_next = call %Value @plawk_call_output_handler(%WamState* %vm, i32 %handler_pc, %Value %line, %Value %outputs)
+  %count_next = add i64 %count, 1
+  %next_tag = extractvalue %Value %outputs_next, 0
+  %next_payload = extractvalue %Value %outputs_next, 1
+  %next_is_int = icmp eq i32 %next_tag, 1
+  %next_is_bad_payload = icmp slt i64 %next_payload, 0
+  %next_is_bad = and i1 %next_is_int, %next_is_bad_payload
+  br i1 %next_is_bad, label %fail_handler, label %loop
+
+close_stream:
+  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %close_ok, label %check_count, label %fail_close
+
+check_count:
+  %count_ok = icmp eq i64 %count, 4
+  br i1 %count_ok, label %prepare_readout, label %fail_count_value
+
+prepare_readout:
+  %unb = call %Value @value_unbound(i8* null)
+  %first_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %second_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %first_ref = call %Value @value_ref(i32 %first_addr)
+  %second_ref = call %Value @value_ref(i32 %second_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %readout_pc)
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %outputs)
+  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %first_ref)
+  call void @wam_set_reg(%WamState* %vm, i32 2, %Value %second_ref)
+  %readout_ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %readout_ok, label %check_output_tags, label %fail_readout
+
+check_output_tags:
+  %first_v = call %Value @wam_deref_value(%WamState* %vm, %Value %first_ref)
+  %second_v = call %Value @wam_deref_value(%WamState* %vm, %Value %second_ref)
+  %first_tag = extractvalue %Value %first_v, 0
+  %second_tag = extractvalue %Value %second_v, 0
+  %first_is_atom = icmp eq i32 %first_tag, 0
+  %second_is_atom = icmp eq i32 %second_tag, 0
+  %tags_ok = and i1 %first_is_atom, %second_is_atom
+  br i1 %tags_ok, label %check_output_strings, label %fail_output_tags
+
+check_output_strings:
+  %first_id = extractvalue %Value %first_v, 1
+  %second_id = extractvalue %Value %second_v, 1
+  %first_s = call i8* @wam_atom_to_string(i64 %first_id)
+  %second_s = call i8* @wam_atom_to_string(i64 %second_id)
+  %expect_first = getelementptr [16 x i8], [16 x i8]* @.plawk_expect_first, i32 0, i32 0
+  %expect_second = getelementptr [15 x i8], [15 x i8]* @.plawk_expect_second, i32 0, i32 0
+  %cmp_first = call i32 @strcmp(i8* %first_s, i8* %expect_first)
+  %cmp_second = call i32 @strcmp(i8* %second_s, i8* %expect_second)
+  %first_ok = icmp eq i32 %cmp_first, 0
+  %second_ok = icmp eq i32 %cmp_second, 0
+  %strings_ok = and i1 %first_ok, %second_ok
+  br i1 %strings_ok, label %success, label %fail_output_strings
+
+success:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 0
+
+fail_open:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 10
+
+fail_read:
+  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 11
+
+fail_line_tag:
+  %close_ignore_line_tag = call i1 @wam_stream_close_value(%Value %handle)
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 12
+
+fail_handler:
+  %close_ignore_handler = call i1 @wam_stream_close_value(%Value %handle)
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 13
+
+fail_close:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 14
+
+fail_count_value:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 20
+
+fail_readout:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 30
+
+fail_output_tags:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 40
+
+fail_output_strings:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 41
+}
+
+define %Value @plawk_call_initial_outputs(%WamState* %vm, i32 %start_pc) {
+entry:
+  %unb = call %Value @value_unbound(i8* null)
+  %outputs_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %outputs_ref = call %Value @value_ref(i32 %outputs_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %start_pc)
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %outputs_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %done, label %failed
+
+done:
+  %outputs = call %Value @wam_deref_value(%WamState* %vm, %Value %outputs_ref)
+  ret %Value %outputs
+
+failed:
+  %bad = call %Value @value_integer(i64 -1)
+  ret %Value %bad
+}
+
+define %Value @plawk_call_output_handler(%WamState* %vm, i32 %start_pc, %Value %line, %Value %outputs0) {
+entry:
+  %unb = call %Value @value_unbound(i8* null)
+  %outputs_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %outputs_ref = call %Value @value_ref(i32 %outputs_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %start_pc)
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %line)
+  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %outputs0)
+  call void @wam_set_reg(%WamState* %vm, i32 2, %Value %outputs_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %done, label %failed
+
+done:
+  %outputs = call %Value @wam_deref_value(%WamState* %vm, %Value %outputs_ref)
+  ret %Value %outputs
+
+failed:
+  %bad = call %Value @value_integer(i64 -1)
+  ret %Value %bad
+}
+',
+        [BytesLen, PathBytes,
+         BytesLen, BytesLen, PathLen,
+         InstrCount, InstrCount, InstrCount,
+         LabelCount, LabelCount, LabelCount]).
+
+llvm_c_bytes([], '').
+llvm_c_bytes([Code | Rest], Bytes) :-
+    llvm_c_byte(Code, Byte),
+    llvm_c_bytes(Rest, Tail),
+    atom_concat(Byte, Tail, Bytes).
+
+llvm_c_byte(Code, Byte) :-
+    format(atom(Byte), '\\~|~`0t~16r~2+', [Code]).

--- a/tests/test_wam_llvm_quoted_atom_literals.pl
+++ b/tests/test_wam_llvm_quoted_atom_literals.pl
@@ -1,0 +1,121 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+:- dynamic user:uw_quoted_atoms/2.
+
+user:uw_quoted_atoms('ERROR disk full', 'it''s bad').
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_llvm_quoted_atom_literals, [condition(clang_available)]).
+
+test(quoted_atom_tokens_intern_without_outer_quotes) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_wam_llvm_quoted_atom_literals', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'quoted_atom_literals.ll', LLPath),
+    write_wam_llvm_project(
+        [user:uw_quoted_atoms/2],
+        [module_name('quoted_atom_literals')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    quoted_atom_driver_ir(InstrCount, LabelCount, DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'quoted_atom_literals_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[wam llvm quoted atom literal output]~n~w~n",
+              [OutStr]),
+       throw(wam_llvm_quoted_atom_literals_failed(Status))
+    ),
+    !.
+
+:- end_tests(wam_llvm_quoted_atom_literals).
+
+quoted_atom_driver_ir(InstrCount, LabelCount, DriverIR) :-
+    format(atom(DriverIR),
+'@.expect_spaced = private constant [16 x i8] c"ERROR disk full\\00"
+@.expect_escaped = private constant [9 x i8] c"it\\27s bad\\00"
+
+define i32 @main() {
+entry:
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @module_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @module_labels, i32 0, i32 0),
+      i32 ~w)
+  %start_pc = load i32, i32* @uw_quoted_atoms_start_pc
+  %unb = call %Value @value_unbound(i8* null)
+  %a_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %b_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %a_ref = call %Value @value_ref(i32 %a_addr)
+  %b_ref = call %Value @value_ref(i32 %b_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %start_pc)
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %a_ref)
+  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %b_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %check_tags, label %fail_run
+
+check_tags:
+  %a_v = call %Value @wam_deref_value(%WamState* %vm, %Value %a_ref)
+  %b_v = call %Value @wam_deref_value(%WamState* %vm, %Value %b_ref)
+  %a_tag = extractvalue %Value %a_v, 0
+  %b_tag = extractvalue %Value %b_v, 0
+  %a_is_atom = icmp eq i32 %a_tag, 0
+  %b_is_atom = icmp eq i32 %b_tag, 0
+  %tags_ok = and i1 %a_is_atom, %b_is_atom
+  br i1 %tags_ok, label %check_strings, label %fail_tags
+
+check_strings:
+  %a_id = extractvalue %Value %a_v, 1
+  %b_id = extractvalue %Value %b_v, 1
+  %a_s = call i8* @wam_atom_to_string(i64 %a_id)
+  %b_s = call i8* @wam_atom_to_string(i64 %b_id)
+  %expect_a = getelementptr [16 x i8], [16 x i8]* @.expect_spaced, i32 0, i32 0
+  %expect_b = getelementptr [9 x i8], [9 x i8]* @.expect_escaped, i32 0, i32 0
+  %cmp_a = call i32 @strcmp(i8* %a_s, i8* %expect_a)
+  %cmp_b = call i32 @strcmp(i8* %b_s, i8* %expect_b)
+  %a_ok = icmp eq i32 %cmp_a, 0
+  %b_ok = icmp eq i32 %cmp_b, 0
+  %strings_ok = and i1 %a_ok, %b_ok
+  br i1 %strings_ok, label %success, label %fail_strings
+
+success:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 0
+
+fail_run:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 10
+
+fail_tags:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 20
+
+fail_strings:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 30
+}
+',
+        [InstrCount, InstrCount, InstrCount,
+         LabelCount, LabelCount, LabelCount]).


### PR DESCRIPTION
## Summary

- add a PLAWK native-counter stream-loop smoke where the LLVM loop owns the hot record counter as an `i64` while WAM still handles conditional output accumulation
- normalize WAM/LLVM quoted atom tokens before interning so atoms with spaces or escaped apostrophes become raw runtime atom names
- add a quoted atom literal regression covering `'ERROR disk full'` and `'it\'s bad'`
- update PLAWK docs/README to mark the native-counter boundary and identify native output accumulation as the next hot-loop step

## Validation

- `swipl -q -s tests/test_plawk_native_counter_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_quoted_atom_literals.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_native_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_native_outer_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_stream_runtime.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `llvm-as examples/plawk/generated/plawk_core_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_loop_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_meta_call_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_reader_probe.ll -o /dev/null`
- `git diff --check`

This is not a draft PR. I think it is ready to merge after normal review; I do not see a known blocker or a specific need for external Perplexity review on this boundary.