### PR TITLE
[codex] Accumulate PLAWK outputs in native loop

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -199,9 +199,12 @@ compiled PLAWK handler once per record, and thread PLAWK state through WAM.
 The `tests/test_plawk_native_counter_stream_loop_driver.pl` smoke then lowers
 the hot record counter to a native `i64` loop variable while keeping output
 accumulation as ordinary WAM terms via `append_output/3` and `state_outputs/2`.
-The remaining hot-loop boundary is native output accumulation: keep WAM handler
-calls only for logic that still needs WAM, while native reader/counter/output
-state stay in LLVM-owned data.
+The `tests/test_plawk_native_output_stream_loop_driver.pl` smoke moves the next
+piece of hot-loop state into LLVM: native code owns the reader, record counter,
+output counter, and fixed output slots, while WAM only returns the deterministic
+handler decision (`yes`/`no`) for each record. The next boundary is lowering
+more deterministic handler logic itself into native code without making the
+target PLAWK-specific.
 
 **Compiler note:** WAM/LLVM now normalizes quoted atom tokens before interning.
 Atoms such as `'ERROR disk full'` and `'it\'s bad'` compile to raw runtime
@@ -241,6 +244,13 @@ produces correct output on standard awk test cases.
 3. Compile the DCG through UnifyWeaver to LLVM.
 4. Extend `item_field/3` and `select_writer/2` for `record(binary, Type, Payload)`.
 5. Map `State` stream handles to OS file descriptors.
+
+**Associative-array note:** typed/native associative arrays are a high-value
+later feature. AWK associative arrays are string keyed; PLAWK can eventually
+lower common table shapes to binary hash tables keyed by typed values or
+interned IDs. That should preserve awk-like ergonomics while creating a
+plausible performance win over string-centric AWK loops once the basic compiled
+reader/handler/output path is stable.
 
 > **Perf caveat:** DCGs over difference-lists of bytes are correct but can be
 > slow in WAM without first-argument indexing on the byte / partial evaluation.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -69,6 +69,7 @@ swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR
 swipl -q -s tests/test_plawk_native_outer_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_native_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_native_counter_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_native_output_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.

--- a/tests/test_plawk_native_output_stream_loop_driver.pl
+++ b/tests/test_plawk_native_output_stream_loop_driver.pl
@@ -1,0 +1,291 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+:- dynamic user:plawk_native_output_match/2.
+
+user:plawk_native_output_match(Line, yes) :-
+    sub_atom(Line, 0, 5, _, 'ERROR'),
+    !.
+user:plawk_native_output_match(_Line, no).
+
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_native_output_stream_loop_driver, [condition(clang_available)]).
+
+test(native_loop_counts_and_accumulates_outputs) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_native_output_stream_loop_driver', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, 'INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n', []),
+        close(In)),
+    directory_file_path(Dir, 'plawk_native_output_stream_loop.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_native_output_match/2
+        ],
+        [module_name('plawk_native_output_stream_loop')], LLPath),
+    wam_llvm_last_compile_counts(InstrCount, LabelCount),
+    plawk_native_output_stream_loop_driver_ir(InputPath, InstrCount, LabelCount, DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_native_output_stream_loop_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk native output stream loop output]~n~w~n",
+              [OutStr]),
+       throw(plawk_native_output_stream_loop_driver_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_native_output_stream_loop_driver).
+
+plawk_native_output_stream_loop_driver_ir(InputPath, InstrCount, LabelCount, DriverIR) :-
+    atom_codes(InputPath, PathCodes),
+    length(PathCodes, PathLen),
+    BytesLen is PathLen + 1,
+    llvm_c_bytes(PathCodes, PathBytes),
+    format(atom(DriverIR),
+'@.plawk_output_path = private constant [~w x i8] c"~w\\00"
+@.plawk_output_eof = private constant [12 x i8] c"end_of_file\\00"
+@.plawk_output_yes = private constant [4 x i8] c"yes\\00"
+@.plawk_expect_first = private constant [16 x i8] c"ERROR disk full\\00"
+@.plawk_expect_second = private constant [15 x i8] c"ERROR net down\\00"
+
+define i32 @main() {
+entry:
+  %path_ptr = getelementptr [~w x i8], [~w x i8]* @.plawk_output_path, i32 0, i32 0
+  %path_id = call i64 @wam_intern_atom(i8* %path_ptr, i64 ~w)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+  %outputs = alloca [2 x %Value]
+  %vm = call %WamState* @wam_state_new(
+      %Instruction* getelementptr ([~w x %Instruction], [~w x %Instruction]* @module_code, i32 0, i32 0),
+      i32 ~w,
+      i32* getelementptr ([~w x i32], [~w x i32]* @module_labels, i32 0, i32 0),
+      i32 ~w)
+  %match_pc = load i32, i32* @plawk_native_output_match_start_pc
+  %handle = call %Value @wam_stream_open_value(%Value %path)
+  %handle_tag = extractvalue %Value %handle, 0
+  %handle_is_int = icmp eq i32 %handle_tag, 1
+  br i1 %handle_is_int, label %check_handle_value, label %fail_open
+
+check_handle_value:
+  %handle_payload = extractvalue %Value %handle, 1
+  %handle_ok = icmp sgt i64 %handle_payload, 0
+  br i1 %handle_ok, label %loop, label %fail_open
+
+loop:
+  %record_count = phi i64 [ 0, %check_handle_value ], [ %record_count_next, %continue_loop ]
+  %output_count = phi i64 [ 0, %check_handle_value ], [ %output_count_next, %continue_loop ]
+  %line = call %Value @wam_stream_read_line_value(%Value %handle)
+  %line_tag = extractvalue %Value %line, 0
+  %line_payload = extractvalue %Value %line, 1
+  %line_is_int = icmp eq i32 %line_tag, 1
+  %line_bad_payload = icmp slt i64 %line_payload, 0
+  %line_bad = and i1 %line_is_int, %line_bad_payload
+  br i1 %line_bad, label %fail_read, label %check_line_atom
+
+check_line_atom:
+  %line_is_atom = icmp eq i32 %line_tag, 0
+  br i1 %line_is_atom, label %check_eof, label %fail_line_tag
+
+check_eof:
+  %line_s = call i8* @wam_atom_to_string(i64 %line_payload)
+  %eof_s = getelementptr [12 x i8], [12 x i8]* @.plawk_output_eof, i32 0, i32 0
+  %eof_cmp = call i32 @strcmp(i8* %line_s, i8* %eof_s)
+  %is_eof = icmp eq i32 %eof_cmp, 0
+  br i1 %is_eof, label %close_stream, label %call_match
+
+call_match:
+  %decision = call %Value @plawk_call_output_match(%WamState* %vm, i32 %match_pc, %Value %line)
+  %decision_tag = extractvalue %Value %decision, 0
+  %decision_payload = extractvalue %Value %decision, 1
+  %decision_is_int = icmp eq i32 %decision_tag, 1
+  %decision_bad_payload = icmp slt i64 %decision_payload, 0
+  %decision_bad = and i1 %decision_is_int, %decision_bad_payload
+  br i1 %decision_bad, label %fail_match, label %check_decision_atom
+
+check_decision_atom:
+  %decision_is_atom = icmp eq i32 %decision_tag, 0
+  br i1 %decision_is_atom, label %check_decision_yes, label %fail_decision_tag
+
+check_decision_yes:
+  %decision_s = call i8* @wam_atom_to_string(i64 %decision_payload)
+  %yes_s = getelementptr [4 x i8], [4 x i8]* @.plawk_output_yes, i32 0, i32 0
+  %yes_cmp = call i32 @strcmp(i8* %decision_s, i8* %yes_s)
+  %is_yes = icmp eq i32 %yes_cmp, 0
+  %record_count_inc = add i64 %record_count, 1
+  br i1 %is_yes, label %append_output, label %no_output
+
+append_output:
+  switch i64 %output_count, label %fail_output_capacity [
+    i64 0, label %append_first
+    i64 1, label %append_second
+  ]
+
+append_first:
+  %out0 = getelementptr [2 x %Value], [2 x %Value]* %outputs, i32 0, i32 0
+  store %Value %line, %Value* %out0
+  br label %continue_loop
+
+append_second:
+  %out1 = getelementptr [2 x %Value], [2 x %Value]* %outputs, i32 0, i32 1
+  store %Value %line, %Value* %out1
+  br label %continue_loop
+
+no_output:
+  br label %continue_loop
+
+continue_loop:
+  %record_count_next = phi i64 [ %record_count_inc, %append_first ], [ %record_count_inc, %append_second ], [ %record_count_inc, %no_output ]
+  %output_count_next = phi i64 [ 1, %append_first ], [ 2, %append_second ], [ %output_count, %no_output ]
+  br label %loop
+
+close_stream:
+  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %close_ok, label %check_counts, label %fail_close
+
+check_counts:
+  %record_count_ok = icmp eq i64 %record_count, 4
+  br i1 %record_count_ok, label %check_output_count, label %fail_record_count
+
+check_output_count:
+  %output_count_ok = icmp eq i64 %output_count, 2
+  br i1 %output_count_ok, label %check_output_tags, label %fail_output_count
+
+check_output_tags:
+  %first_ptr = getelementptr [2 x %Value], [2 x %Value]* %outputs, i32 0, i32 0
+  %second_ptr = getelementptr [2 x %Value], [2 x %Value]* %outputs, i32 0, i32 1
+  %first_v = load %Value, %Value* %first_ptr
+  %second_v = load %Value, %Value* %second_ptr
+  %first_tag = extractvalue %Value %first_v, 0
+  %second_tag = extractvalue %Value %second_v, 0
+  %first_is_atom = icmp eq i32 %first_tag, 0
+  %second_is_atom = icmp eq i32 %second_tag, 0
+  %tags_ok = and i1 %first_is_atom, %second_is_atom
+  br i1 %tags_ok, label %check_output_strings, label %fail_output_tags
+
+check_output_strings:
+  %first_id = extractvalue %Value %first_v, 1
+  %second_id = extractvalue %Value %second_v, 1
+  %first_s = call i8* @wam_atom_to_string(i64 %first_id)
+  %second_s = call i8* @wam_atom_to_string(i64 %second_id)
+  %expect_first = getelementptr [16 x i8], [16 x i8]* @.plawk_expect_first, i32 0, i32 0
+  %expect_second = getelementptr [15 x i8], [15 x i8]* @.plawk_expect_second, i32 0, i32 0
+  %cmp_first = call i32 @strcmp(i8* %first_s, i8* %expect_first)
+  %cmp_second = call i32 @strcmp(i8* %second_s, i8* %expect_second)
+  %first_ok = icmp eq i32 %cmp_first, 0
+  %second_ok = icmp eq i32 %cmp_second, 0
+  %strings_ok = and i1 %first_ok, %second_ok
+  br i1 %strings_ok, label %success, label %fail_output_strings
+
+success:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 0
+
+fail_open:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 10
+
+fail_read:
+  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 11
+
+fail_line_tag:
+  %close_ignore_line_tag = call i1 @wam_stream_close_value(%Value %handle)
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 12
+
+fail_match:
+  %close_ignore_match = call i1 @wam_stream_close_value(%Value %handle)
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 13
+
+fail_decision_tag:
+  %close_ignore_decision = call i1 @wam_stream_close_value(%Value %handle)
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 14
+
+fail_output_capacity:
+  %close_ignore_capacity = call i1 @wam_stream_close_value(%Value %handle)
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 15
+
+fail_close:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 16
+
+fail_record_count:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 20
+
+fail_output_count:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 21
+
+fail_output_tags:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 30
+
+fail_output_strings:
+  call void @wam_state_free(%WamState* %vm)
+  ret i32 31
+}
+
+define %Value @plawk_call_output_match(%WamState* %vm, i32 %start_pc, %Value %line) {
+entry:
+  %unb = call %Value @value_unbound(i8* null)
+  %decision_addr = call i32 @wam_heap_push(%WamState* %vm, %Value %unb)
+  %decision_ref = call %Value @value_ref(i32 %decision_addr)
+  call void @wam_prepare_call(%WamState* %vm, i32 %start_pc)
+  call void @wam_set_reg(%WamState* %vm, i32 0, %Value %line)
+  call void @wam_set_reg(%WamState* %vm, i32 1, %Value %decision_ref)
+  %ok = call i1 @run_loop(%WamState* %vm)
+  br i1 %ok, label %done, label %failed
+
+done:
+  %decision = call %Value @wam_deref_value(%WamState* %vm, %Value %decision_ref)
+  ret %Value %decision
+
+failed:
+  %bad = call %Value @value_integer(i64 -1)
+  ret %Value %bad
+}
+',
+        [BytesLen, PathBytes,
+         BytesLen, BytesLen, PathLen,
+         InstrCount, InstrCount, InstrCount,
+         LabelCount, LabelCount, LabelCount]).
+
+llvm_c_bytes([], '').
+llvm_c_bytes([Code | Rest], Bytes) :-
+    llvm_c_byte(Code, Byte),
+    llvm_c_bytes(Rest, Tail),
+    atom_concat(Byte, Tail, Bytes).
+
+llvm_c_byte(Code, Byte) :-
+    format(atom(Byte), '\\~|~`0t~16r~2+', [Code]).


### PR DESCRIPTION
## Summary

- Add a PLAWK native-output stream-loop smoke where LLVM owns the reader, record counter, output counter, and fixed output slots.
- Keep WAM responsible only for the deterministic handler decision (`yes`/`no`) per record.
- Document the updated PLAWK hot-loop boundary and capture typed/native associative arrays as a later high-value feature.

## Validation

- `swipl -q -s tests/test_plawk_native_output_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_native_counter_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_native_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_quoted_atom_literals.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `llvm-as examples/plawk/generated/plawk_core_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_loop_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_meta_call_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_reader_probe.ll -o /dev/null`
- `git diff --check`