### PR TITLE
[codex] Add ancestor cache policy benchmark

### DIFF
--- a/docs/reports/enwiki_mtc_ancestor_cache_policy_smoke_ancestor_cache_policy_summary.json
+++ b/docs/reports/enwiki_mtc_ancestor_cache_policy_smoke_ancestor_cache_policy_summary.json
@@ -1,0 +1,36 @@
+{
+  "admit_l_max": 12,
+  "admit_l_min": 6,
+  "cache_actions": {
+    "insert": 138,
+    "keep_existing": 911,
+    "overwrite_lower_priority": 51,
+    "overwrite_outside_cone": 47,
+    "refresh": 2399
+  },
+  "cache_slots": 256,
+  "capped_queries": 1,
+  "final_cache_entries": 138,
+  "generated_at": "2026-06-12T01:51:13.295034+00:00",
+  "graph": "enwiki_mtc_ancestor_cache_policy_smoke",
+  "mean_admission_candidates": 147.75,
+  "mean_ancestor_nodes": 3626.9166666666665,
+  "mean_cache_hits_before": 102.08333333333333,
+  "p95_admission_candidates": 185.0,
+  "p95_ancestor_nodes": 6918.0,
+  "p95_cache_hits_before": 130.0,
+  "record_type": "ancestor_cache_policy_summary",
+  "root": 7345184,
+  "target_depths": [
+    3,
+    4
+  ],
+  "target_selection_counts": {
+    "0": 1,
+    "1": 35,
+    "2": 800,
+    "3": 800,
+    "4": 800
+  },
+  "targets": 24
+}

--- a/docs/reports/lmdb_ancestor_cache_policy_mtc_smoke_2026-06-12.md
+++ b/docs/reports/lmdb_ancestor_cache_policy_mtc_smoke_2026-06-12.md
@@ -1,0 +1,70 @@
+# LMDB Ancestor Cache Policy MTC Smoke - 2026-06-12
+
+This smoke run exercises fixed-size cache residency for root-anchored ancestor
+histograms on the enwiki `Category:Main_topic_classifications` subtree. The
+cache policy is intentionally separate from histogram path-length budgets:
+targets define an ancestor search space, near-root nodes inside that space are
+eligible for histogram caching, and collisions are resolved using current
+ancestor-cone membership plus root-distance priority.
+
+## Command
+
+```bash
+python3 scripts/lmdb_ancestor_cache_policy_benchmark.py \
+  --lmdb-dir /home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct/lmdb_resident \
+  --root 7345184 \
+  --graph-name enwiki_mtc_ancestor_cache_policy_smoke \
+  --target-depths 3,4 \
+  --children-per-node 64 \
+  --frontier-limit 800 \
+  --targets-per-depth 12 \
+  --max-ancestor-nodes 10000 \
+  --max-ancestor-edges 80000 \
+  --root-distance-cap 32 \
+  --cache-slots 256 \
+  --admit-l-min 6 \
+  --admit-l-max 12 \
+  --seed enwiki-mtc-cache-policy-smoke \
+  --output-dir docs/reports
+```
+
+## Results
+
+- Targets: 24 sampled category nodes at child depths 3 and 4.
+- Ancestor collection caps: 1 capped query after raising the cap to 10,000
+  ancestor nodes and 80,000 ancestor edges.
+- Mean ancestor search-space size: 3,626.92 nodes.
+- P95 ancestor search-space size: 6,918 nodes.
+- Mean admission candidates per query: 147.75 near-root/root-reaching nodes.
+- P95 admission candidates per query: 185 nodes.
+- Fixed cache size: 256 slots.
+- Final occupied cache entries: 138.
+- Mean cache hits before admission updates: 102.08 entries already resident in
+  the current ancestor cone.
+
+Cache actions:
+
+| Action | Count |
+| --- | ---: |
+| `refresh` | 2,399 |
+| `keep_existing` | 911 |
+| `insert` | 138 |
+| `overwrite_lower_priority` | 51 |
+| `overwrite_outside_cone` | 47 |
+
+## Interpretation
+
+The high `refresh` count means near-root ancestor candidates are repeatedly
+encountered across nearby target cones, so fixed-size residency has useful
+reuse even without tying cache admission to a search-length budget.
+
+The collision policy behaved as intended in this run: when both entries were in
+the current cone, most collisions kept the existing nearer-root or otherwise
+higher-priority entry. The `overwrite_outside_cone` count shows the separate
+case where an old colliding entry was not useful for the current target cone and
+could be replaced without sacrificing local reuse.
+
+The remaining capped query says the diagnostic collection bound is still visible
+for a small part of the sampled workload. The next benchmark should sweep cache
+slots and root-distance admission thresholds before treating these numbers as a
+policy recommendation.

--- a/scripts/lmdb_ancestor_cache_policy_benchmark.py
+++ b/scripts/lmdb_ancestor_cache_policy_benchmark.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Benchmark fixed-size cache policy for root-anchored ancestor histograms.
+
+This script models the residency decision separately from bounded path search.
+Each query first collects the parent-only ancestor search space for a sampled
+target.  Cache admission is limited to nodes in that current ancestor cone whose
+root-distance summary is near the root.  A fixed-size direct-mapped cache then
+uses ancestor-cone membership during collisions: entries outside the current
+cone are cheap to replace; entries inside the cone compete by root-distance
+priority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from collections import Counter
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.lmdb_parent_branching_diagnostic import (
+    LmdbCategoryGraph,
+    parse_int_list,
+    root_distances,
+    select_targets_by_child_depth,
+)
+from scripts.lmdb_parent_histogram_benchmark import percentile, safe_graph_name
+
+
+@dataclass
+class AncestorSpace:
+    nodes: set
+    edges_seen: int = 0
+    cycle_edges: int = 0
+    capped: bool = False
+
+
+@dataclass
+class CacheEntry:
+    node: int
+    l_min: object = None
+    l_max: object = None
+    truncated: bool = False
+    hits: int = 0
+    stores: int = 1
+
+
+def mean(values):
+    values = list(values)
+    if not values:
+        return 0.0
+    return statistics.fmean(values)
+
+
+def collect_ancestor_space(parents_func, target, max_nodes, max_edges):
+    """Collect unique nodes reachable by simple parent-only traversal.
+
+    The caps bound diagnostic collection work.  They are not the path-length
+    budget used by histogram search.
+    """
+    nodes = {target}
+    stack = [(target, (target,))]
+    space = AncestorSpace(nodes=nodes)
+
+    while stack:
+        node, path = stack.pop()
+        for parent in parents_func(node):
+            if space.edges_seen >= max_edges:
+                space.capped = True
+                continue
+            space.edges_seen += 1
+            if parent in path:
+                space.cycle_edges += 1
+                continue
+            if parent in nodes:
+                continue
+            if len(nodes) >= max_nodes:
+                space.capped = True
+                continue
+            nodes.add(parent)
+            stack.append((parent, path + (parent,)))
+    return space
+
+
+def slot_for(node, cache_slots):
+    return int(node) % int(cache_slots)
+
+
+def cache_priority(entry):
+    missing_l_max = entry.l_max is None
+    missing_l_min = entry.l_min is None
+    l_max = 10 ** 12 if missing_l_max else int(entry.l_max)
+    l_min = 10 ** 12 if missing_l_min else int(entry.l_min)
+    return (bool(entry.truncated), missing_l_max, l_max, missing_l_min, l_min, -int(entry.hits), int(entry.node))
+
+
+def update_cache(cache, candidate, ancestor_nodes, cache_slots):
+    slot = slot_for(candidate.node, cache_slots)
+    existing = cache.get(slot)
+    if existing is None:
+        cache[slot] = candidate
+        return "insert"
+    if existing.node == candidate.node:
+        existing.hits += 1
+        existing.stores += 1
+        return "refresh"
+    if existing.node not in ancestor_nodes:
+        cache[slot] = candidate
+        return "overwrite_outside_cone"
+    if cache_priority(candidate) < cache_priority(existing):
+        cache[slot] = candidate
+        return "overwrite_lower_priority"
+    return "keep_existing"
+
+
+def candidate_from_distance(node, distance):
+    return CacheEntry(
+        node=int(node),
+        l_min=distance["L_min"],
+        l_max=distance["L_max"],
+        truncated=bool(distance["truncated"]),
+    )
+
+
+def admit_candidate(distance, admit_l_min, admit_l_max):
+    if distance["L_min"] is None or distance["L_max"] is None:
+        return False
+    if int(distance["L_min"]) > admit_l_min:
+        return False
+    if int(distance["L_max"]) > admit_l_max:
+        return False
+    return True
+
+
+def cache_entry_record(graph_name, root, slot, entry):
+    record = asdict(entry)
+    record.update({
+        "record_type": "ancestor_cache_final_entry",
+        "graph": graph_name,
+        "root": root,
+        "slot": slot,
+    })
+    return record
+
+
+def query_record(graph_name, root, target, child_depth, space, candidates, cache_hits_before, cache_occupancy, action_counts):
+    return {
+        "record_type": "ancestor_cache_policy_query",
+        "graph": graph_name,
+        "root": root,
+        "target_node": target,
+        "child_sample_depth": child_depth,
+        "ancestor_nodes": len(space.nodes),
+        "ancestor_edges_seen": space.edges_seen,
+        "cycle_edges_seen": space.cycle_edges,
+        "ancestor_collection_capped": space.capped,
+        "admission_candidates": len(candidates),
+        "candidate_l_min_min": min((candidate.l_min for candidate in candidates), default=None),
+        "candidate_l_max_max": max((candidate.l_max for candidate in candidates), default=None),
+        "cache_hits_before": cache_hits_before,
+        "cache_occupancy_after": cache_occupancy,
+        "cache_actions": dict(action_counts),
+    }
+
+
+def summarize(records, args, target_counts):
+    query_rows = [row for row in records if row["record_type"] == "ancestor_cache_policy_query"]
+    action_counts = Counter()
+    for row in query_rows:
+        action_counts.update(row["cache_actions"])
+    ancestor_nodes = [row["ancestor_nodes"] for row in query_rows]
+    candidates = [row["admission_candidates"] for row in query_rows]
+    hits = [row["cache_hits_before"] for row in query_rows]
+    return {
+        "record_type": "ancestor_cache_policy_summary",
+        "graph": args.graph_name,
+        "root": args.root,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "target_depths": parse_int_list(args.target_depths),
+        "target_selection_counts": target_counts,
+        "targets": len(query_rows),
+        "cache_slots": args.cache_slots,
+        "admit_l_min": args.admit_l_min,
+        "admit_l_max": args.admit_l_max,
+        "final_cache_entries": len([row for row in records if row["record_type"] == "ancestor_cache_final_entry"]),
+        "capped_queries": sum(1 for row in query_rows if row["ancestor_collection_capped"]),
+        "mean_ancestor_nodes": mean(ancestor_nodes),
+        "p95_ancestor_nodes": percentile(ancestor_nodes, 95),
+        "mean_admission_candidates": mean(candidates),
+        "p95_admission_candidates": percentile(candidates, 95),
+        "mean_cache_hits_before": mean(hits),
+        "p95_cache_hits_before": percentile(hits, 95),
+        "cache_actions": dict(action_counts),
+    }
+
+
+def run_benchmark(args):
+    graph = LmdbCategoryGraph(args.lmdb_dir)
+    try:
+        target_depths = parse_int_list(args.target_depths)
+        targets, target_depth_by_node, target_counts = select_targets_by_child_depth(
+            graph,
+            args.root,
+            target_depths,
+            args.children_per_node,
+            args.frontier_limit,
+            args.targets_per_depth,
+            args.seed,
+        )
+
+        records = [{
+            "record_type": "ancestor_cache_policy_selection",
+            "graph": args.graph_name,
+            "root": args.root,
+            "target_depths": target_depths,
+            "target_selection_counts": target_counts,
+            "targets": len(targets),
+            "children_per_node": args.children_per_node,
+            "frontier_limit": args.frontier_limit,
+            "targets_per_depth": args.targets_per_depth,
+            "max_ancestor_nodes": args.max_ancestor_nodes,
+            "max_ancestor_edges": args.max_ancestor_edges,
+            "root_distance_cap": args.root_distance_cap,
+            "cache_slots": args.cache_slots,
+            "admit_l_min": args.admit_l_min,
+            "admit_l_max": args.admit_l_max,
+            "seed": args.seed,
+        }]
+
+        cache = {}
+        distance_memo = {}
+        for target in targets:
+            space = collect_ancestor_space(
+                graph.parents,
+                target,
+                args.max_ancestor_nodes,
+                args.max_ancestor_edges,
+            )
+            cache_hits_before = sum(1 for entry in cache.values() if entry.node in space.nodes)
+            candidates = []
+            for node in sorted(space.nodes):
+                distance = root_distances(node, args.root, graph.parents, args.root_distance_cap, distance_memo)
+                if admit_candidate(distance, args.admit_l_min, args.admit_l_max):
+                    candidates.append(candidate_from_distance(node, distance))
+
+            action_counts = Counter()
+            for candidate in sorted(candidates, key=cache_priority):
+                action_counts[update_cache(cache, candidate, space.nodes, args.cache_slots)] += 1
+
+            records.append(query_record(
+                args.graph_name,
+                args.root,
+                target,
+                target_depth_by_node[target],
+                space,
+                candidates,
+                cache_hits_before,
+                len(cache),
+                action_counts,
+            ))
+
+        for slot in sorted(cache):
+            records.append(cache_entry_record(args.graph_name, args.root, slot, cache[slot]))
+
+        records.append(summarize(records, args, target_counts))
+        return records
+    finally:
+        graph.close()
+
+
+def write_records(records, output_dir, graph_name):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stem = "{}_ancestor_cache_policy".format(safe_graph_name(graph_name))
+    jsonl_path = output_dir / "{}.jsonl".format(stem)
+    summary_path = output_dir / "{}_summary.json".format(stem)
+    with jsonl_path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+    summary = records[-1]
+    with summary_path.open("w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    return jsonl_path, summary_path
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lmdb-dir", type=Path, required=True)
+    parser.add_argument("--root", type=int, required=True)
+    parser.add_argument("--graph-name", default="lmdb_category_graph")
+    parser.add_argument("--target-depths", default="3,4")
+    parser.add_argument("--children-per-node", type=int, default=128)
+    parser.add_argument("--frontier-limit", type=int, default=2000)
+    parser.add_argument("--targets-per-depth", type=int, default=40)
+    parser.add_argument("--max-ancestor-nodes", type=int, default=5000)
+    parser.add_argument("--max-ancestor-edges", type=int, default=25000)
+    parser.add_argument("--root-distance-cap", type=int, default=48)
+    parser.add_argument("--cache-slots", type=int, default=512)
+    parser.add_argument("--admit-l-min", type=int, default=6)
+    parser.add_argument("--admit-l-max", type=int, default=12)
+    parser.add_argument("--seed", default="ancestor-cache-policy-v1")
+    parser.add_argument("--output-dir", type=Path, default=Path("docs/reports"))
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    records = run_benchmark(args)
+    jsonl_path, summary_path = write_records(records, args.output_dir, args.graph_name)
+    print(json.dumps(records[-1], indent=2, sort_keys=True))
+    print("wrote {}".format(jsonl_path))
+    print("wrote {}".format(summary_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_lmdb_ancestor_cache_policy_benchmark.py
+++ b/tests/test_lmdb_ancestor_cache_policy_benchmark.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Tests for fixed-size ancestor cache policy helpers."""
+
+import unittest
+
+from scripts.lmdb_ancestor_cache_policy_benchmark import (
+    CacheEntry,
+    collect_ancestor_space,
+    slot_for,
+    update_cache,
+)
+
+
+class AncestorCachePolicyBenchmarkTests(unittest.TestCase):
+    def test_slot_for_is_direct_mapped_by_node_id(self):
+        self.assertEqual(slot_for(11, 8), 3)
+
+    def test_update_cache_overwrites_existing_entry_outside_current_cone(self):
+        cache = {1: CacheEntry(node=1, l_min=1, l_max=1)}
+        candidate = CacheEntry(node=9, l_min=2, l_max=2)
+
+        action = update_cache(cache, candidate, ancestor_nodes={9}, cache_slots=8)
+
+        self.assertEqual(action, "overwrite_outside_cone")
+        self.assertEqual(cache[1].node, 9)
+
+    def test_update_cache_keeps_better_existing_entry_inside_current_cone(self):
+        cache = {1: CacheEntry(node=1, l_min=1, l_max=2)}
+        candidate = CacheEntry(node=9, l_min=1, l_max=4)
+
+        action = update_cache(cache, candidate, ancestor_nodes={1, 9}, cache_slots=8)
+
+        self.assertEqual(action, "keep_existing")
+        self.assertEqual(cache[1].node, 1)
+
+    def test_update_cache_replaces_lower_priority_existing_entry_inside_current_cone(self):
+        cache = {1: CacheEntry(node=1, l_min=1, l_max=5)}
+        candidate = CacheEntry(node=9, l_min=1, l_max=2)
+
+        action = update_cache(cache, candidate, ancestor_nodes={1, 9}, cache_slots=8)
+
+        self.assertEqual(action, "overwrite_lower_priority")
+        self.assertEqual(cache[1].node, 9)
+
+    def test_update_cache_refreshes_same_node(self):
+        cache = {1: CacheEntry(node=9, l_min=1, l_max=2)}
+
+        action = update_cache(cache, CacheEntry(node=9, l_min=1, l_max=2), ancestor_nodes={9}, cache_slots=8)
+
+        self.assertEqual(action, "refresh")
+        self.assertEqual(cache[1].hits, 1)
+        self.assertEqual(cache[1].stores, 2)
+
+    def test_collect_ancestor_space_skips_cycles_and_reports_caps(self):
+        parents = {
+            "A": ["B", "C"],
+            "B": ["A", "R"],
+            "C": ["R"],
+        }
+
+        space = collect_ancestor_space(lambda node: parents.get(node, []), "A", max_nodes=3, max_edges=10)
+
+        self.assertEqual(space.nodes, {"A", "B", "C"})
+        self.assertEqual(space.cycle_edges, 1)
+        self.assertTrue(space.capped)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `scripts/lmdb_ancestor_cache_policy_benchmark.py` to model fixed-size residency for root-anchored ancestor histogram cache entries.
- Separate cache admission from path-length search budgets: targets define an ancestor search space, near-root/root-reaching nodes become candidates, and collision handling uses current ancestor-cone membership.
- Add unit tests for slot mapping, cone-aware overwrite behavior, priority retention, refresh accounting, and capped/cyclic ancestor-space collection.
- Add an enwiki `Category:Main_topic_classifications` smoke report plus compact summary JSON.

## Benchmark Notes

Smoke command used the local `enwiki_cats_correct/lmdb_resident` database with root id `7345184`, target depths `3,4`, 24 sampled targets, 256 cache slots, and admission thresholds `L_min <= 6`, `L_max <= 12`.

Observed summary:

- Mean ancestor search-space size: `3626.92` nodes
- P95 ancestor search-space size: `6918` nodes
- Mean admission candidates: `147.75`
- Mean cache hits before admission updates: `102.08`
- Final occupied cache entries: `138 / 256`
- Capped queries: `1 / 24`

Cache actions:

- `refresh`: `2399`
- `keep_existing`: `911`
- `insert`: `138`
- `overwrite_lower_priority`: `51`
- `overwrite_outside_cone`: `47`

## Validation

- `python3 -m unittest tests.test_lmdb_ancestor_cache_policy_benchmark`
- `python3 scripts/lmdb_ancestor_cache_policy_benchmark.py --lmdb-dir /home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct/lmdb_resident --root 7345184 --graph-name enwiki_mtc_ancestor_cache_policy_smoke --target-depths 3,4 --children-per-node 64 --frontier-limit 800 --targets-per-depth 12 --max-ancestor-nodes 10000 --max-ancestor-edges 80000 --root-distance-cap 32 --cache-slots 256 --admit-l-min 6 --admit-l-max 12 --seed enwiki-mtc-cache-policy-smoke --output-dir docs/reports`

## Notes

One unrelated unstaged local edit remains in `templates/targets/fsharp_wam/kernel_bidirectional_ancestor.fs.mustache`; it is intentionally not part of this PR.