### PR TITLE
[codex] Lower deterministic prefix handlers in native LLVM loops

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -204,7 +204,12 @@ piece of hot-loop state into LLVM: native code owns the reader, record counter,
 output counter, and fixed output slots, while WAM only returns the deterministic
 handler decision (`yes`/`no`) for each record. The next boundary is lowering
 more deterministic handler logic itself into native code without making the
-target PLAWK-specific.
+target PLAWK-specific. The first general helper for that boundary is now
+`@wam_atom_prefix_value`, which lets native LLVM lower deterministic
+`sub_atom(Line, 0, Len, _, Prefix)` guards without allocating a substring or
+entering `run_loop` for each record. The
+`tests/test_plawk_native_lowered_handler_stream_loop_driver.pl` smoke proves
+that shape in a native stream loop.
 
 **Compiler note:** WAM/LLVM now normalizes quoted atom tokens before interning.
 Atoms such as `'ERROR disk full'` and `'it\'s bad'` compile to raw runtime

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -70,6 +70,7 @@ swipl -q -s tests/test_plawk_native_outer_loop_driver.pl -g "setenv('UW_SMOKE_TM
 swipl -q -s tests/test_plawk_native_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_native_counter_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_native_output_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_native_lowered_handler_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4189,6 +4189,44 @@ sch.close:
   ret i1 %sch.ok
 }
 
+define i1 @wam_atom_prefix_value(%Value %atom_value, i8* %prefix, i64 %prefix_len) {
+entry:
+  %ap.t = call i32 @value_tag(%Value %atom_value)
+  %ap.is_atom = icmp eq i32 %ap.t, 0
+  br i1 %ap.is_atom, label %ap.lookup, label %ap.no
+
+ap.lookup:
+  %ap.aid = call i64 @value_payload(%Value %atom_value)
+  %ap.str = call i8* @wam_atom_to_string(i64 %ap.aid)
+  %ap.null = icmp eq i8* %ap.str, null
+  br i1 %ap.null, label %ap.no, label %ap.loop
+
+ap.loop:
+  %ap.i = phi i64 [ 0, %ap.lookup ], [ %ap.next, %ap.step_ok ]
+  %ap.done = icmp uge i64 %ap.i, %prefix_len
+  br i1 %ap.done, label %ap.yes, label %ap.step
+
+ap.step:
+  %ap.sp = getelementptr i8, i8* %ap.str, i64 %ap.i
+  %ap.pp = getelementptr i8, i8* %prefix, i64 %ap.i
+  %ap.sc = load i8, i8* %ap.sp
+  %ap.pc = load i8, i8* %ap.pp
+  %ap.nonzero = icmp ne i8 %ap.sc, 0
+  %ap.eq = icmp eq i8 %ap.sc, %ap.pc
+  %ap.match = and i1 %ap.nonzero, %ap.eq
+  br i1 %ap.match, label %ap.step_ok, label %ap.no
+
+ap.step_ok:
+  %ap.next = add i64 %ap.i, 1
+  br label %ap.loop
+
+ap.yes:
+  ret i1 true
+
+ap.no:
+  ret i1 false
+}
+
 ; Dispatches on integer op codes:
 ;   0 = is/2, 1 = >/2, 2 = </2, 3 = >=/2, 4 = =</2
 ;   5 = =:=/2, 6 = =\\=/2, 7 = ==/2, 8 = true/0, 9 = fail/0

--- a/tests/test_plawk_native_lowered_handler_stream_loop_driver.pl
+++ b/tests/test_plawk_native_lowered_handler_stream_loop_driver.pl
@@ -1,0 +1,223 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+
+:- dynamic user:plawk_native_lowered_marker/0.
+
+user:plawk_native_lowered_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_native_lowered_handler_stream_loop_driver, [condition(clang_available)]).
+
+test(native_loop_lowers_prefix_handler_without_wam_call) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_native_lowered_handler_stream_loop_driver', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, 'INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n', []),
+        close(In)),
+    directory_file_path(Dir, 'plawk_native_lowered_handler_stream_loop.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_native_lowered_marker/0 ],
+        [module_name('plawk_native_lowered_handler_stream_loop')], LLPath),
+    plawk_native_lowered_handler_stream_loop_driver_ir(InputPath, DriverIR),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_native_lowered_handler_stream_loop_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[plawk native lowered handler stream loop output]~n~w~n",
+              [OutStr]),
+       throw(plawk_native_lowered_handler_stream_loop_driver_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_native_lowered_handler_stream_loop_driver).
+
+plawk_native_lowered_handler_stream_loop_driver_ir(InputPath, DriverIR) :-
+    atom_codes(InputPath, PathCodes),
+    length(PathCodes, PathLen),
+    BytesLen is PathLen + 1,
+    llvm_c_bytes(PathCodes, PathBytes),
+    format(atom(DriverIR),
+'@.plawk_lowered_path = private constant [~w x i8] c"~w\\00"
+@.plawk_lowered_eof = private constant [12 x i8] c"end_of_file\\00"
+@.plawk_lowered_prefix = private constant [6 x i8] c"ERROR\\00"
+@.plawk_expect_first = private constant [16 x i8] c"ERROR disk full\\00"
+@.plawk_expect_second = private constant [15 x i8] c"ERROR net down\\00"
+
+define i32 @main() {
+entry:
+  %path_ptr = getelementptr [~w x i8], [~w x i8]* @.plawk_lowered_path, i32 0, i32 0
+  %path_id = call i64 @wam_intern_atom(i8* %path_ptr, i64 ~w)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+  %outputs = alloca [2 x %Value]
+  %handle = call %Value @wam_stream_open_value(%Value %path)
+  %handle_tag = extractvalue %Value %handle, 0
+  %handle_is_int = icmp eq i32 %handle_tag, 1
+  br i1 %handle_is_int, label %check_handle_value, label %fail_open
+
+check_handle_value:
+  %handle_payload = extractvalue %Value %handle, 1
+  %handle_ok = icmp sgt i64 %handle_payload, 0
+  br i1 %handle_ok, label %loop, label %fail_open
+
+loop:
+  %record_count = phi i64 [ 0, %check_handle_value ], [ %record_count_next, %continue_loop ]
+  %output_count = phi i64 [ 0, %check_handle_value ], [ %output_count_next, %continue_loop ]
+  %line = call %Value @wam_stream_read_line_value(%Value %handle)
+  %line_tag = extractvalue %Value %line, 0
+  %line_payload = extractvalue %Value %line, 1
+  %line_is_int = icmp eq i32 %line_tag, 1
+  %line_bad_payload = icmp slt i64 %line_payload, 0
+  %line_bad = and i1 %line_is_int, %line_bad_payload
+  br i1 %line_bad, label %fail_read, label %check_line_atom
+
+check_line_atom:
+  %line_is_atom = icmp eq i32 %line_tag, 0
+  br i1 %line_is_atom, label %check_eof, label %fail_line_tag
+
+check_eof:
+  %line_s = call i8* @wam_atom_to_string(i64 %line_payload)
+  %eof_s = getelementptr [12 x i8], [12 x i8]* @.plawk_lowered_eof, i32 0, i32 0
+  %eof_cmp = call i32 @strcmp(i8* %line_s, i8* %eof_s)
+  %is_eof = icmp eq i32 %eof_cmp, 0
+  br i1 %is_eof, label %close_stream, label %lowered_match
+
+lowered_match:
+  %prefix = getelementptr [6 x i8], [6 x i8]* @.plawk_lowered_prefix, i32 0, i32 0
+  %is_match = call i1 @wam_atom_prefix_value(%Value %line, i8* %prefix, i64 5)
+  %record_count_inc = add i64 %record_count, 1
+  br i1 %is_match, label %append_output, label %no_output
+
+append_output:
+  switch i64 %output_count, label %fail_output_capacity [
+    i64 0, label %append_first
+    i64 1, label %append_second
+  ]
+
+append_first:
+  %out0 = getelementptr [2 x %Value], [2 x %Value]* %outputs, i32 0, i32 0
+  store %Value %line, %Value* %out0
+  br label %continue_loop
+
+append_second:
+  %out1 = getelementptr [2 x %Value], [2 x %Value]* %outputs, i32 0, i32 1
+  store %Value %line, %Value* %out1
+  br label %continue_loop
+
+no_output:
+  br label %continue_loop
+
+continue_loop:
+  %record_count_next = phi i64 [ %record_count_inc, %append_first ], [ %record_count_inc, %append_second ], [ %record_count_inc, %no_output ]
+  %output_count_next = phi i64 [ 1, %append_first ], [ 2, %append_second ], [ %output_count, %no_output ]
+  br label %loop
+
+close_stream:
+  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %close_ok, label %check_counts, label %fail_close
+
+check_counts:
+  %record_count_ok = icmp eq i64 %record_count, 4
+  br i1 %record_count_ok, label %check_output_count, label %fail_record_count
+
+check_output_count:
+  %output_count_ok = icmp eq i64 %output_count, 2
+  br i1 %output_count_ok, label %check_output_tags, label %fail_output_count
+
+check_output_tags:
+  %first_ptr = getelementptr [2 x %Value], [2 x %Value]* %outputs, i32 0, i32 0
+  %second_ptr = getelementptr [2 x %Value], [2 x %Value]* %outputs, i32 0, i32 1
+  %first_v = load %Value, %Value* %first_ptr
+  %second_v = load %Value, %Value* %second_ptr
+  %first_tag = extractvalue %Value %first_v, 0
+  %second_tag = extractvalue %Value %second_v, 0
+  %first_is_atom = icmp eq i32 %first_tag, 0
+  %second_is_atom = icmp eq i32 %second_tag, 0
+  %tags_ok = and i1 %first_is_atom, %second_is_atom
+  br i1 %tags_ok, label %check_output_strings, label %fail_output_tags
+
+check_output_strings:
+  %first_id = extractvalue %Value %first_v, 1
+  %second_id = extractvalue %Value %second_v, 1
+  %first_s = call i8* @wam_atom_to_string(i64 %first_id)
+  %second_s = call i8* @wam_atom_to_string(i64 %second_id)
+  %expect_first = getelementptr [16 x i8], [16 x i8]* @.plawk_expect_first, i32 0, i32 0
+  %expect_second = getelementptr [15 x i8], [15 x i8]* @.plawk_expect_second, i32 0, i32 0
+  %cmp_first = call i32 @strcmp(i8* %first_s, i8* %expect_first)
+  %cmp_second = call i32 @strcmp(i8* %second_s, i8* %expect_second)
+  %first_ok = icmp eq i32 %cmp_first, 0
+  %second_ok = icmp eq i32 %cmp_second, 0
+  %strings_ok = and i1 %first_ok, %second_ok
+  br i1 %strings_ok, label %success, label %fail_output_strings
+
+success:
+  ret i32 0
+
+fail_open:
+  ret i32 10
+
+fail_read:
+  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 11
+
+fail_line_tag:
+  %close_ignore_line_tag = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 12
+
+fail_output_capacity:
+  %close_ignore_capacity = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 15
+
+fail_close:
+  ret i32 16
+
+fail_record_count:
+  ret i32 20
+
+fail_output_count:
+  ret i32 21
+
+fail_output_tags:
+  ret i32 30
+
+fail_output_strings:
+  ret i32 31
+}
+',
+        [BytesLen, PathBytes,
+         BytesLen, BytesLen, PathLen]).
+
+llvm_c_bytes([], '').
+llvm_c_bytes([Code | Rest], Bytes) :-
+    llvm_c_byte(Code, Byte),
+    llvm_c_bytes(Rest, Tail),
+    atom_concat(Byte, Tail, Bytes).
+
+llvm_c_byte(Code, Byte) :-
+    format(atom(Byte), '\\~|~`0t~16r~2+', [Code]).

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -193,7 +193,8 @@ test(full_runtime_generation) :-
     % Step function
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @step')),
     % Helpers
-    assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @backtrack')).
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @backtrack')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_prefix_value')).
 
 % ============================================================================
 % Builtin op ID mapping


### PR DESCRIPTION
## Summary

- Add a general WAM/LLVM runtime helper, `@wam_atom_prefix_value`, for native prefix checks against atom `%Value`s.
- Add a native stream-loop smoke that lowers the `sub_atom(Line, 0, Len, _, Prefix)` handler shape into LLVM and verifies the driver IR does not call `@run_loop` per record.
- Document the new deterministic-handler boundary and add the smoke command to the PLAWK README.

## Validation

- `swipl -q -s tests/test_plawk_native_lowered_handler_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_native_output_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_native_counter_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/test_wam_llvm_quoted_atom_literals.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `llvm-as examples/plawk/generated/plawk_core_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_loop_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_reader_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_meta_call_probe.ll -o /dev/null`
- `git diff --check`