### PR TITLE
[codex] Add cache policy benchmark controls

### DIFF
--- a/docs/reports/lmdb_ancestor_cache_policy_controls_2026-06-12.md
+++ b/docs/reports/lmdb_ancestor_cache_policy_controls_2026-06-12.md
@@ -1,0 +1,88 @@
+# LMDB Ancestor Cache Policy Resource Controls - 2026-06-12
+
+This update makes the ancestor-cache policy benchmark cheaper by default and adds
+a summary-only sweep driver.
+
+## Changes
+
+- The single-config benchmark now writes only `*_summary.json` by default.
+- Full per-query/per-entry JSONL traces require `--write-jsonl`.
+- The default sample and traversal caps are smaller:
+  - `children_per_node`: 64
+  - `frontier_limit`: 800
+  - `targets_per_depth`: 12
+  - `max_ancestor_nodes`: 1500
+  - `max_ancestor_edges`: 8000
+  - `root_distance_cap`: 32
+  - `cache_slots`: 256
+- `scripts/lmdb_ancestor_cache_policy_sweep.py` samples targets once, collects
+  ancestor cones once, computes root-distance summaries once, then replays cache
+  policy for each cache/admission setting.
+
+## Validation
+
+Unit tests:
+
+```bash
+python3 -m unittest tests.test_lmdb_ancestor_cache_policy_benchmark
+```
+
+Result: 8 tests passed.
+
+Tiny sweep smoke:
+
+```bash
+python3 scripts/lmdb_ancestor_cache_policy_sweep.py \
+  --lmdb-dir /home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct/lmdb_resident \
+  --root 7345184 \
+  --graph-name enwiki_mtc_cache_policy_tiny_sweep \
+  --target-depths 3 \
+  --children-per-node 32 \
+  --frontier-limit 200 \
+  --targets-per-depth 4 \
+  --max-ancestor-nodes 500 \
+  --max-ancestor-edges 2000 \
+  --root-distance-cap 24 \
+  --cache-slots 64 \
+  --admit-l-min 6 \
+  --admit-l-max 12 \
+  --sweep-cache-slots 64,128 \
+  --sweep-admit-l-max 8,12 \
+  --seed enwiki-mtc-cache-policy-tiny-sweep \
+  --output-dir /mnt/c/Users/johnc/Scratch/ancestor-cache-controls
+```
+
+Result: 4 summary rows, no JSONL trace. The deliberately low caps produced a
+`capped_query_rate` of 0.75, which is useful for resource-control validation but
+not a policy recommendation.
+
+Single-config summary-only smoke:
+
+```bash
+python3 scripts/lmdb_ancestor_cache_policy_benchmark.py \
+  --lmdb-dir /home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct/lmdb_resident \
+  --root 7345184 \
+  --graph-name enwiki_mtc_cache_policy_single_summary_smoke \
+  --target-depths 3 \
+  --children-per-node 16 \
+  --frontier-limit 80 \
+  --targets-per-depth 2 \
+  --max-ancestor-nodes 250 \
+  --max-ancestor-edges 1000 \
+  --root-distance-cap 20 \
+  --cache-slots 64 \
+  --admit-l-min 6 \
+  --admit-l-max 10 \
+  --seed enwiki-mtc-cache-policy-single-summary \
+  --output-dir /mnt/c/Users/johnc/Scratch/ancestor-cache-controls
+```
+
+Result: one summary JSON and no JSONL trace. The smoke reported
+`capped_query_rate = 0.5`, `mean_ancestor_nodes = 243.0`, and final occupancy
+`40 / 64` cache slots.
+
+## Next Use
+
+Use the sweep script for first-pass policy scans. If a setting has an acceptable
+capped rate and stable reuse metrics, rerun the single-config benchmark with
+larger caps and `--write-jsonl` only when per-query diagnostics are needed.

--- a/scripts/lmdb_ancestor_cache_policy_benchmark.py
+++ b/scripts/lmdb_ancestor_cache_policy_benchmark.py
@@ -172,6 +172,13 @@ def query_record(graph_name, root, target, child_depth, space, candidates, cache
     }
 
 
+def action_rates(action_counts):
+    total = sum(action_counts.values())
+    if total == 0:
+        return {}
+    return {key: value / total for key, value in sorted(action_counts.items())}
+
+
 def summarize(records, args, target_counts):
     query_rows = [row for row in records if row["record_type"] == "ancestor_cache_policy_query"]
     action_counts = Counter()
@@ -180,6 +187,12 @@ def summarize(records, args, target_counts):
     ancestor_nodes = [row["ancestor_nodes"] for row in query_rows]
     candidates = [row["admission_candidates"] for row in query_rows]
     hits = [row["cache_hits_before"] for row in query_rows]
+    hit_rates = [
+        0.0 if row["admission_candidates"] == 0 else row["cache_hits_before"] / row["admission_candidates"]
+        for row in query_rows
+    ]
+    capped_queries = sum(1 for row in query_rows if row["ancestor_collection_capped"])
+    final_cache_entries = len([row for row in records if row["record_type"] == "ancestor_cache_final_entry"])
     return {
         "record_type": "ancestor_cache_policy_summary",
         "graph": args.graph_name,
@@ -191,15 +204,19 @@ def summarize(records, args, target_counts):
         "cache_slots": args.cache_slots,
         "admit_l_min": args.admit_l_min,
         "admit_l_max": args.admit_l_max,
-        "final_cache_entries": len([row for row in records if row["record_type"] == "ancestor_cache_final_entry"]),
-        "capped_queries": sum(1 for row in query_rows if row["ancestor_collection_capped"]),
+        "final_cache_entries": final_cache_entries,
+        "cache_occupancy_rate": 0.0 if args.cache_slots == 0 else final_cache_entries / args.cache_slots,
+        "capped_queries": capped_queries,
+        "capped_query_rate": 0.0 if not query_rows else capped_queries / len(query_rows),
         "mean_ancestor_nodes": mean(ancestor_nodes),
         "p95_ancestor_nodes": percentile(ancestor_nodes, 95),
         "mean_admission_candidates": mean(candidates),
         "p95_admission_candidates": percentile(candidates, 95),
         "mean_cache_hits_before": mean(hits),
         "p95_cache_hits_before": percentile(hits, 95),
+        "mean_cache_hits_before_per_candidate": mean(hit_rates),
         "cache_actions": dict(action_counts),
+        "cache_action_rates": action_rates(action_counts),
     }
 
 
@@ -277,14 +294,16 @@ def run_benchmark(args):
         graph.close()
 
 
-def write_records(records, output_dir, graph_name):
+def write_records(records, output_dir, graph_name, write_jsonl=False):
     output_dir.mkdir(parents=True, exist_ok=True)
     stem = "{}_ancestor_cache_policy".format(safe_graph_name(graph_name))
-    jsonl_path = output_dir / "{}.jsonl".format(stem)
+    jsonl_path = None
     summary_path = output_dir / "{}_summary.json".format(stem)
-    with jsonl_path.open("w", encoding="utf-8") as handle:
-        for record in records:
-            handle.write(json.dumps(record, sort_keys=True) + "\n")
+    if write_jsonl:
+        jsonl_path = output_dir / "{}.jsonl".format(stem)
+        with jsonl_path.open("w", encoding="utf-8") as handle:
+            for record in records:
+                handle.write(json.dumps(record, sort_keys=True) + "\n")
     summary = records[-1]
     with summary_path.open("w", encoding="utf-8") as handle:
         json.dump(summary, handle, indent=2, sort_keys=True)
@@ -298,15 +317,17 @@ def parse_args():
     parser.add_argument("--root", type=int, required=True)
     parser.add_argument("--graph-name", default="lmdb_category_graph")
     parser.add_argument("--target-depths", default="3,4")
-    parser.add_argument("--children-per-node", type=int, default=128)
-    parser.add_argument("--frontier-limit", type=int, default=2000)
-    parser.add_argument("--targets-per-depth", type=int, default=40)
-    parser.add_argument("--max-ancestor-nodes", type=int, default=5000)
-    parser.add_argument("--max-ancestor-edges", type=int, default=25000)
-    parser.add_argument("--root-distance-cap", type=int, default=48)
-    parser.add_argument("--cache-slots", type=int, default=512)
+    parser.add_argument("--children-per-node", type=int, default=64)
+    parser.add_argument("--frontier-limit", type=int, default=800)
+    parser.add_argument("--targets-per-depth", type=int, default=12)
+    parser.add_argument("--max-ancestor-nodes", type=int, default=1500)
+    parser.add_argument("--max-ancestor-edges", type=int, default=8000)
+    parser.add_argument("--root-distance-cap", type=int, default=32)
+    parser.add_argument("--cache-slots", type=int, default=256)
     parser.add_argument("--admit-l-min", type=int, default=6)
     parser.add_argument("--admit-l-max", type=int, default=12)
+    parser.add_argument("--write-jsonl", action="store_true", help="write the full per-query/per-entry JSONL trace")
+    parser.add_argument("--summary-only", action="store_true", help="accepted for clarity; summaries are the default output")
     parser.add_argument("--seed", default="ancestor-cache-policy-v1")
     parser.add_argument("--output-dir", type=Path, default=Path("docs/reports"))
     return parser.parse_args()
@@ -315,9 +336,10 @@ def parse_args():
 def main():
     args = parse_args()
     records = run_benchmark(args)
-    jsonl_path, summary_path = write_records(records, args.output_dir, args.graph_name)
+    jsonl_path, summary_path = write_records(records, args.output_dir, args.graph_name, write_jsonl=args.write_jsonl)
     print(json.dumps(records[-1], indent=2, sort_keys=True))
-    print("wrote {}".format(jsonl_path))
+    if jsonl_path is not None:
+        print("wrote {}".format(jsonl_path))
     print("wrote {}".format(summary_path))
 
 

--- a/scripts/lmdb_ancestor_cache_policy_sweep.py
+++ b/scripts/lmdb_ancestor_cache_policy_sweep.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Sweep ancestor-cache policy settings with one shared cone collection.
+
+The single-config benchmark can emit a full JSONL trace when explicitly asked.
+This sweep driver is intentionally summary-only: it samples targets once,
+collects each target's ancestor cone once, computes root-distance summaries once,
+then replays cache residency for each cache/admission configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from itertools import product
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.lmdb_ancestor_cache_policy_benchmark import (
+    admit_candidate,
+    cache_priority,
+    candidate_from_distance,
+    collect_ancestor_space,
+    update_cache,
+)
+from scripts.lmdb_parent_branching_diagnostic import (
+    LmdbCategoryGraph,
+    parse_int_list,
+    root_distances,
+    select_targets_by_child_depth,
+)
+from scripts.lmdb_parent_histogram_benchmark import percentile, safe_graph_name
+
+
+@dataclass
+class QueryInput:
+    target: int
+    child_depth: int
+    space: object
+
+
+@dataclass
+class CacheConfig:
+    cache_slots: int
+    admit_l_min: int
+    admit_l_max: int
+
+
+def mean(values):
+    values = list(values)
+    if not values:
+        return 0.0
+    return statistics.fmean(values)
+
+
+def parse_grid(text, default):
+    if text is None or str(text).strip() == "":
+        return [default]
+    return parse_int_list(text)
+
+
+def sweep_configs(args):
+    cache_slots_values = parse_grid(args.sweep_cache_slots, args.cache_slots)
+    l_min_values = parse_grid(args.sweep_admit_l_min, args.admit_l_min)
+    l_max_values = parse_grid(args.sweep_admit_l_max, args.admit_l_max)
+    return [
+        CacheConfig(cache_slots=cache_slots, admit_l_min=l_min, admit_l_max=l_max)
+        for cache_slots, l_min, l_max in product(cache_slots_values, l_min_values, l_max_values)
+    ]
+
+
+def action_rates(action_counts):
+    total = sum(action_counts.values())
+    if total == 0:
+        return {}
+    return {key: value / total for key, value in sorted(action_counts.items())}
+
+
+def collect_query_inputs(graph, args):
+    target_depths = parse_int_list(args.target_depths)
+    targets, target_depth_by_node, target_counts = select_targets_by_child_depth(
+        graph,
+        args.root,
+        target_depths,
+        args.children_per_node,
+        args.frontier_limit,
+        args.targets_per_depth,
+        args.seed,
+    )
+    query_inputs = []
+    for target in targets:
+        query_inputs.append(QueryInput(
+            target=target,
+            child_depth=target_depth_by_node[target],
+            space=collect_ancestor_space(
+                graph.parents,
+                target,
+                args.max_ancestor_nodes,
+                args.max_ancestor_edges,
+            ),
+        ))
+    return targets, target_counts, query_inputs
+
+
+def collect_distances(graph, args, query_inputs):
+    distance_memo = {}
+    distances = {}
+    for query in query_inputs:
+        for node in query.space.nodes:
+            if node not in distances:
+                distances[node] = root_distances(node, args.root, graph.parents, args.root_distance_cap, distance_memo)
+    return distances
+
+
+def simulate_config(args, target_counts, query_inputs, distances, config):
+    cache = {}
+    action_counts = Counter()
+    ancestor_nodes = []
+    ancestor_edges = []
+    admission_candidates = []
+    cache_hits_before = []
+    hit_rates = []
+    capped_queries = 0
+    cycle_edges = 0
+
+    for query in query_inputs:
+        space = query.space
+        if space.capped:
+            capped_queries += 1
+        cycle_edges += space.cycle_edges
+        ancestor_nodes.append(len(space.nodes))
+        ancestor_edges.append(space.edges_seen)
+        hits_before = sum(1 for entry in cache.values() if entry.node in space.nodes)
+        candidates = []
+        for node in sorted(space.nodes):
+            distance = distances[node]
+            if admit_candidate(distance, config.admit_l_min, config.admit_l_max):
+                candidates.append(candidate_from_distance(node, distance))
+
+        for candidate in sorted(candidates, key=cache_priority):
+            action_counts[update_cache(cache, candidate, space.nodes, config.cache_slots)] += 1
+
+        admission_candidates.append(len(candidates))
+        cache_hits_before.append(hits_before)
+        hit_rates.append(0.0 if not candidates else hits_before / len(candidates))
+
+    final_cache_entries = len(cache)
+    return {
+        "record_type": "ancestor_cache_policy_sweep_summary",
+        "graph": args.graph_name,
+        "root": args.root,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "target_depths": parse_int_list(args.target_depths),
+        "target_selection_counts": target_counts,
+        "targets": len(query_inputs),
+        "cache_slots": config.cache_slots,
+        "admit_l_min": config.admit_l_min,
+        "admit_l_max": config.admit_l_max,
+        "final_cache_entries": final_cache_entries,
+        "cache_occupancy_rate": 0.0 if config.cache_slots == 0 else final_cache_entries / config.cache_slots,
+        "capped_queries": capped_queries,
+        "capped_query_rate": 0.0 if not query_inputs else capped_queries / len(query_inputs),
+        "cycle_edges_seen": cycle_edges,
+        "mean_ancestor_nodes": mean(ancestor_nodes),
+        "p95_ancestor_nodes": percentile(ancestor_nodes, 95),
+        "mean_ancestor_edges": mean(ancestor_edges),
+        "p95_ancestor_edges": percentile(ancestor_edges, 95),
+        "mean_admission_candidates": mean(admission_candidates),
+        "p95_admission_candidates": percentile(admission_candidates, 95),
+        "mean_cache_hits_before": mean(cache_hits_before),
+        "p95_cache_hits_before": percentile(cache_hits_before, 95),
+        "mean_cache_hits_before_per_candidate": mean(hit_rates),
+        "cache_actions": dict(action_counts),
+        "cache_action_rates": action_rates(action_counts),
+    }
+
+
+def run_sweep(args):
+    graph = LmdbCategoryGraph(args.lmdb_dir)
+    try:
+        _targets, target_counts, query_inputs = collect_query_inputs(graph, args)
+        distances = collect_distances(graph, args, query_inputs)
+        return [
+            simulate_config(args, target_counts, query_inputs, distances, config)
+            for config in sweep_configs(args)
+        ]
+    finally:
+        graph.close()
+
+
+def write_sweep(records, output_dir, graph_name):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "{}_ancestor_cache_policy_sweep_summary.json".format(safe_graph_name(graph_name))
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(records, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    return path
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lmdb-dir", type=Path, required=True)
+    parser.add_argument("--root", type=int, required=True)
+    parser.add_argument("--graph-name", default="lmdb_category_graph")
+    parser.add_argument("--target-depths", default="3,4")
+    parser.add_argument("--children-per-node", type=int, default=64)
+    parser.add_argument("--frontier-limit", type=int, default=800)
+    parser.add_argument("--targets-per-depth", type=int, default=12)
+    parser.add_argument("--max-ancestor-nodes", type=int, default=1500)
+    parser.add_argument("--max-ancestor-edges", type=int, default=8000)
+    parser.add_argument("--root-distance-cap", type=int, default=32)
+    parser.add_argument("--cache-slots", type=int, default=256)
+    parser.add_argument("--admit-l-min", type=int, default=6)
+    parser.add_argument("--admit-l-max", type=int, default=12)
+    parser.add_argument("--sweep-cache-slots", default="128,256,512")
+    parser.add_argument("--sweep-admit-l-min", default=None)
+    parser.add_argument("--sweep-admit-l-max", default="8,10,12")
+    parser.add_argument("--seed", default="ancestor-cache-policy-sweep-v1")
+    parser.add_argument("--output-dir", type=Path, default=Path("docs/reports"))
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    records = run_sweep(args)
+    path = write_sweep(records, args.output_dir, args.graph_name)
+    print(json.dumps(records, indent=2, sort_keys=True))
+    print("wrote {}".format(path))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_lmdb_ancestor_cache_policy_benchmark.py
+++ b/tests/test_lmdb_ancestor_cache_policy_benchmark.py
@@ -11,6 +11,12 @@ from scripts.lmdb_ancestor_cache_policy_benchmark import (
     slot_for,
     update_cache,
 )
+from scripts.lmdb_ancestor_cache_policy_sweep import (
+    CacheConfig,
+    QueryInput,
+    parse_grid,
+    simulate_config,
+)
 
 
 class AncestorCachePolicyBenchmarkTests(unittest.TestCase):
@@ -65,6 +71,31 @@ class AncestorCachePolicyBenchmarkTests(unittest.TestCase):
         self.assertEqual(space.nodes, {"A", "B", "C"})
         self.assertEqual(space.cycle_edges, 1)
         self.assertTrue(space.capped)
+
+    def test_parse_grid_defaults_or_expands_ranges(self):
+        self.assertEqual(parse_grid(None, 7), [7])
+        self.assertEqual(parse_grid("2,4-6", 7), [2, 4, 5, 6])
+
+    def test_sweep_simulates_config_without_trace_records(self):
+        class Args:
+            graph_name = "tiny"
+            root = 0
+            target_depths = "1"
+
+        space = collect_ancestor_space(lambda node: {3: [1, 2], 2: [0], 1: [0]}.get(node, []), 3, 10, 20)
+        distances = {
+            0: {"L_min": 0, "L_max": 0, "truncated": False},
+            1: {"L_min": 1, "L_max": 1, "truncated": False},
+            2: {"L_min": 1, "L_max": 1, "truncated": False},
+            3: {"L_min": 2, "L_max": 2, "truncated": False},
+        }
+
+        summary = simulate_config(Args(), {0: 1, 1: 1}, [QueryInput(3, 1, space)], distances, CacheConfig(8, 2, 2))
+
+        self.assertEqual(summary["record_type"], "ancestor_cache_policy_sweep_summary")
+        self.assertEqual(summary["targets"], 1)
+        self.assertEqual(summary["final_cache_entries"], 4)
+        self.assertEqual(summary["cache_actions"]["insert"], 4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Make `scripts/lmdb_ancestor_cache_policy_benchmark.py` summary-first by default so it no longer writes full JSONL traces unless `--write-jsonl` is passed.
- Lower the default sample/traversal caps for cheaper exploratory runs and add capped-rate/cache-rate metrics to the summary.
- Add `scripts/lmdb_ancestor_cache_policy_sweep.py`, a summary-only sweep driver that collects target ancestor cones and root-distance summaries once, then replays cache/admission configurations.
- Add a report documenting the resource-control changes and smoke validation.

## Why

The previous cache-policy benchmark could consume more resources than necessary for first-pass exploration. This PR makes the cheap path the default and reserves full traces or larger caps for follow-up diagnostics.

## Validation

- `python3 -m unittest tests.test_lmdb_ancestor_cache_policy_benchmark`
- Tiny summary-only sweep against local enwiki MTC LMDB, writing only Scratch summary JSON:
  - 4 sweep rows
  - no JSONL trace
  - deliberately low caps surfaced `capped_query_rate = 0.75`
- Single-config summary-only smoke against local enwiki MTC LMDB:
  - wrote one summary JSON
  - no JSONL trace
  - reported `capped_query_rate = 0.5`, `mean_ancestor_nodes = 243.0`, final occupancy `40 / 64`

## Notes

One unrelated unstaged local edit remains in `templates/targets/fsharp_wam/kernel_bidirectional_ancestor.fs.mustache`; it is intentionally not part of this PR.