### PR TITLE
[codex] Emit native atom prefix guards

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -204,12 +204,13 @@ piece of hot-loop state into LLVM: native code owns the reader, record counter,
 output counter, and fixed output slots, while WAM only returns the deterministic
 handler decision (`yes`/`no`) for each record. The next boundary is lowering
 more deterministic handler logic itself into native code without making the
-target PLAWK-specific. The first general helper for that boundary is now
-`@wam_atom_prefix_value`, which lets native LLVM lower deterministic
-`sub_atom(Line, 0, Len, _, Prefix)` guards without allocating a substring or
-entering `run_loop` for each record. The
+target PLAWK-specific. The first reusable emitter path for that boundary is now
+`llvm_emit_atom_prefix_guard/5`, which emits a prefix global plus a call to the
+general `@wam_atom_prefix_value` runtime helper. That lets native LLVM lower
+deterministic `sub_atom(Line, 0, Len, _, Prefix)` guards without allocating a
+substring or entering `run_loop` for each record. The
 `tests/test_plawk_native_lowered_handler_stream_loop_driver.pl` smoke proves
-that shape in a native stream loop.
+that emitter-backed shape in a native stream loop.
 
 **Compiler note:** WAM/LLVM now normalizes quoted atom tokens before interning.
 Atoms such as `'ERROR disk full'` and `'it\'s bad'` compile to raw runtime

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -44,7 +44,8 @@
     % Shared helpers (used by wam_llvm_lowered_emitter)
     sanitize_functor_for_llvm/2,         % +Name, -SaneName (bijective hex escape)
     register_functor_string/1,           % +NameStr (assert into functor_string_global table)
-    split_functor_arity/3                % +Str, -Name, -Arity (handles `/` in name)
+    split_functor_arity/3,               % +Str, -Name, -Arity (handles `/` in name)
+    llvm_emit_atom_prefix_guard/5        % +GlobalBase, +ValueIR, +Prefix, +ResultIR, -GlobalIR-CallIR
 ]).
 
 :- use_module(library(lists)).
@@ -15609,6 +15610,25 @@ escape_llvm_string(Name, Escaped, ByteLen) :-
     length(Codes, ByteLen),
     escape_llvm_codes(Codes, EscCodes),
     string_codes(Escaped, EscCodes).
+
+%% llvm_emit_atom_prefix_guard(+GlobalBase, +ValueIR, +Prefix, +ResultIR, -GlobalIR-CallIR)
+%
+%  Emit a reusable native prefix guard for deterministic
+%  sub_atom(Value, 0, Len, _, Prefix)-style lowering. ValueIR and
+%  ResultIR are LLVM SSA expressions such as `%line` and `%is_match`.
+%  GlobalIR is top-level module IR; CallIR belongs inside a function body and
+%  calls the general @wam_atom_prefix_value runtime helper.
+llvm_emit_atom_prefix_guard(GlobalBase, ValueIR, Prefix, ResultIR, GlobalIR-CallIR) :-
+    sanitize_functor_for_llvm(GlobalBase, SafeBase),
+    escape_llvm_string(Prefix, EscapedPrefix, PrefixLen),
+    ArrLen is PrefixLen + 1,
+    format(atom(GlobalIR),
+        '@.~w = private constant [~w x i8] c"~w\\00"',
+        [SafeBase, ArrLen, EscapedPrefix]),
+    format(atom(CallIR),
+        '  %~w_ptr = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0~n  ~w = call i1 @wam_atom_prefix_value(%Value ~w, i8* %~w_ptr, i64 ~w)',
+        [SafeBase, ArrLen, ArrLen, SafeBase,
+         ResultIR, ValueIR, SafeBase, PrefixLen]).
 
 escape_llvm_codes([], []).
 escape_llvm_codes([C|Cs], Out) :-

--- a/tests/test_plawk_native_lowered_handler_stream_loop_driver.pl
+++ b/tests/test_plawk_native_lowered_handler_stream_loop_driver.pl
@@ -62,12 +62,14 @@ plawk_native_lowered_handler_stream_loop_driver_ir(InputPath, DriverIR) :-
     length(PathCodes, PathLen),
     BytesLen is PathLen + 1,
     llvm_c_bytes(PathCodes, PathBytes),
+    llvm_emit_atom_prefix_guard(plawk_lowered_prefix, '%line', 'ERROR',
+        '%is_match', PrefixGuardGlobalIR-PrefixGuardCallIR),
     format(atom(DriverIR),
 '@.plawk_lowered_path = private constant [~w x i8] c"~w\\00"
 @.plawk_lowered_eof = private constant [12 x i8] c"end_of_file\\00"
-@.plawk_lowered_prefix = private constant [6 x i8] c"ERROR\\00"
 @.plawk_expect_first = private constant [16 x i8] c"ERROR disk full\\00"
 @.plawk_expect_second = private constant [15 x i8] c"ERROR net down\\00"
+~w
 
 define i32 @main() {
 entry:
@@ -109,8 +111,7 @@ check_eof:
   br i1 %is_eof, label %close_stream, label %lowered_match
 
 lowered_match:
-  %prefix = getelementptr [6 x i8], [6 x i8]* @.plawk_lowered_prefix, i32 0, i32 0
-  %is_match = call i1 @wam_atom_prefix_value(%Value %line, i8* %prefix, i64 5)
+~w
   %record_count_inc = add i64 %record_count, 1
   br i1 %is_match, label %append_output, label %no_output
 
@@ -211,7 +212,8 @@ fail_output_strings:
 }
 ',
         [BytesLen, PathBytes,
-         BytesLen, BytesLen, PathLen]).
+         PrefixGuardGlobalIR,
+         BytesLen, BytesLen, PathLen, PrefixGuardCallIR]).
 
 llvm_c_bytes([], '').
 llvm_c_bytes([Code | Rest], Bytes) :-

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -196,6 +196,13 @@ test(full_runtime_generation) :-
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @backtrack')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_prefix_value')).
 
+test(atom_prefix_guard_emitter) :-
+    llvm_emit_atom_prefix_guard(prefix_guard_test, '%line', 'ERROR', '%ok', GlobalIR-CallIR),
+    assertion(sub_atom(GlobalIR, _, _, _, '@.prefix_5Fguard_5Ftest = private constant [6 x i8] c"ERROR\\00"')),
+    assertion(sub_atom(CallIR, _, _, _, '%prefix_5Fguard_5Ftest_ptr = getelementptr')),
+    assertion(sub_atom(CallIR, _, _, _, '%ok = call i1 @wam_atom_prefix_value(%Value %line')),
+    assertion(sub_atom(CallIR, _, _, _, 'i64 5')).
+
 % ============================================================================
 % Builtin op ID mapping
 % ============================================================================


### PR DESCRIPTION
## Summary

- Add `llvm_emit_atom_prefix_guard/5` as a reusable WAM/LLVM emitter for deterministic prefix checks.
- Emit prefix guard LLVM in two fragments: a top-level constant global and a function-body call to `@wam_atom_prefix_value`.
- Update the PLAWK lowered-handler stream-loop smoke to use the shared emitter instead of hand-written prefix IR.
- Document the emitter-backed native lowering boundary in the PLAWK implementation plan.

## Validation

- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/test_plawk_native_lowered_handler_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_native_output_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_native_counter_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_quoted_atom_literals.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `llvm-as examples/plawk/generated/plawk_core_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_loop_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_reader_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_meta_call_probe.ll -o /dev/null`
- `git diff --check`