### PR TITLE
[codex] Add policy cache runtime and materialization probes

### DIFF
--- a/docs/reports/lmdb_policy_cache_materialization_probe_2026-06-12.md
+++ b/docs/reports/lmdb_policy_cache_materialization_probe_2026-06-12.md
@@ -1,0 +1,91 @@
+# LMDB Policy Cache Materialization Probe - 2026-06-12
+
+This probe separates cache residency from exact histogram materialization cost.
+A policy-resident node can be useful enough to keep, but still too expensive to
+materialize exactly.  When exact materialization hits a cap, the probe classifies
+that node as a closed-form approximation candidate.  The initial fallback model
+is a compact `binomial_support_prior` over the known root-distance support.
+
+## Short-Budget Smoke
+
+```bash
+python3 scripts/lmdb_policy_cache_materialization_probe.py \
+  --lmdb-dir /home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct/lmdb_resident \
+  --root 7345184 \
+  --graph-name enwiki_mtc_policy_cache_materialization_smoke \
+  --target-depths 3 \
+  --children-per-node 16 \
+  --frontier-limit 80 \
+  --targets-per-depth 2 \
+  --max-ancestor-nodes 1500 \
+  --max-ancestor-edges 8000 \
+  --root-distance-cap 32 \
+  --cache-slots 128 \
+  --admit-l-min 6 \
+  --admit-l-max 8 \
+  --sweep-cache-slots 128 \
+  --sweep-admit-l-max 8 \
+  --boundary-budgets 1,2,3,4 \
+  --path-cap 10000 \
+  --expansion-cap 50000 \
+  --seed enwiki-mtc-policy-cache-materialization-smoke \
+  --output-dir /mnt/c/Users/johnc/Scratch/policy-cache-runtime
+```
+
+| boundary_budget | resident | exact | closed_form | too_short | unresolved | expansion_capped | mean_nodes |
+|----------------:|---------:|------:|------------:|----------:|-----------:|-----------------:|-----------:|
+| 1 | 48 | 9 | 0 | 39 | 0 | 0 | 4.4 |
+| 2 | 48 | 25 | 0 | 23 | 0 | 0 | 21.6 |
+| 3 | 48 | 34 | 0 | 14 | 0 | 0 | 117.3 |
+| 4 | 48 | 46 | 0 | 2 | 0 | 0 | 625.5 |
+
+Short suffix budgets are cheap, but many resident nodes are simply too far from
+root to be useful at the smallest budgets.  By budget 4 almost all resident
+nodes materialize exactly without caps on this tiny sample.
+
+## Expensive-Materialization Smoke
+
+```bash
+python3 scripts/lmdb_policy_cache_materialization_probe.py \
+  --lmdb-dir /home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct/lmdb_resident \
+  --root 7345184 \
+  --graph-name enwiki_mtc_policy_cache_materialization_budget8_smoke \
+  --target-depths 3 \
+  --children-per-node 16 \
+  --frontier-limit 80 \
+  --targets-per-depth 1 \
+  --max-ancestor-nodes 1500 \
+  --max-ancestor-edges 8000 \
+  --root-distance-cap 32 \
+  --cache-slots 128 \
+  --admit-l-min 6 \
+  --admit-l-max 8 \
+  --sweep-cache-slots 128 \
+  --sweep-admit-l-max 8 \
+  --boundary-budgets 8 \
+  --path-cap 10000 \
+  --expansion-cap 50000 \
+  --seed enwiki-mtc-policy-cache-runtime-debug \
+  --output-dir /mnt/c/Users/johnc/Scratch/policy-cache-runtime
+```
+
+| boundary_budget | resident | exact | closed_form | too_short | unresolved | expansion_capped | mean_nodes | mean_fallback_width |
+|----------------:|---------:|------:|------------:|----------:|-----------:|-----------------:|-----------:|--------------------:|
+| 8 | 52 | 1 | 51 | 0 | 0 | 51 | 49038.5 | 2.1 |
+
+This validates the fallback framing: deeper exact materialization can become
+expensive even for near-root resident nodes.  Those capped nodes are not useless;
+they are candidates for compact closed-form state.  The current probe records a
+`binomial_support_prior` with support from `(L_min, min(L_max, boundary_budget))`
+and either a partial-histogram estimate of `p` or a support-midpoint default.
+
+## Next Step
+
+Use this probe to choose a mixed materialization policy:
+
+- exact histogram when a short suffix budget materializes without caps;
+- no cache entry when the suffix budget is shorter than `L_min`;
+- closed-form approximation when exact materialization hits caps but support
+  metadata is available;
+- unresolved only when neither exact materialization nor support metadata is
+  available.

--- a/docs/reports/lmdb_policy_cache_materialization_probe_2026-06-12.md
+++ b/docs/reports/lmdb_policy_cache_materialization_probe_2026-06-12.md
@@ -79,6 +79,11 @@ they are candidates for compact closed-form state.  The current probe records a
 `binomial_support_prior` with support from `(L_min, min(L_max, boundary_budget))`
 and either a partial-histogram estimate of `p` or a support-midpoint default.
 
+The closed-form fallback is stored as a normalized distribution family plus an
+explicit `normalization_count` field when a partial count is available.  That
+keeps the compact distribution reusable while still allowing an unnormalized
+histogram estimate to be reconstructed as `N * P(k)`.
+
 ## Next Step
 
 Use this probe to choose a mixed materialization policy:

--- a/docs/reports/lmdb_policy_cache_runtime_smoke_2026-06-12.md
+++ b/docs/reports/lmdb_policy_cache_runtime_smoke_2026-06-12.md
@@ -1,0 +1,58 @@
+# LMDB Policy Cache Runtime Smoke - 2026-06-12
+
+This smoke connects the ancestor-cache residency policy to actual bounded parent
+histogram runtime.  Policy-selected resident nodes are materialized as boundary
+histograms, then full bounded search is compared with cached search on the same
+targets.
+
+## Command
+
+```bash
+python3 scripts/lmdb_policy_cache_runtime_benchmark.py \
+  --lmdb-dir /home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct/lmdb_resident \
+  --root 7345184 \
+  --graph-name enwiki_mtc_policy_cache_runtime_budget3_smoke \
+  --target-depths 3 \
+  --children-per-node 16 \
+  --frontier-limit 80 \
+  --targets-per-depth 2 \
+  --max-ancestor-nodes 1500 \
+  --max-ancestor-edges 8000 \
+  --root-distance-cap 32 \
+  --cache-slots 128 \
+  --admit-l-min 6 \
+  --admit-l-max 8 \
+  --sweep-cache-slots 128 \
+  --sweep-admit-l-max 8 \
+  --boundary-budget 3 \
+  --budgets 4,6 \
+  --path-cap 10000 \
+  --expansion-cap 50000 \
+  --seed enwiki-mtc-policy-cache-runtime-budget3 \
+  --output-dir /mnt/c/Users/johnc/Scratch/policy-cache-runtime
+```
+
+## Results
+
+| slots | L_min | L_max | boundary_budget | targets | capped_cones | resident | materialized | mean_nodes | budget | mean_l1 | mean_node_ratio | mean_time_ratio | mean_cache_hits |
+|------:|------:|------:|----------------:|--------:|-------------:|---------:|-------------:|-----------:|-------:|--------:|----------------:|----------------:|----------------:|
+| 128 | 6 | 8 | 3 | 2 | 1 | 52 | 37 | 1077.5 | 4 | 0.000000 | 0.971 | 1.050 | 1.500 |
+| 128 | 6 | 8 | 3 | 2 | 1 | 52 | 37 | 1077.5 | 6 | 0.115385 | 0.966 | 0.982 | 10.500 |
+
+## Interpretation
+
+The policy-selected cache can produce real cache hits once boundary histogram
+materialization is capped to a short suffix budget.  With `boundary_budget=3`,
+37 of 52 policy-resident entries materialized and cached search hit those
+entries during target searches.
+
+The result also shows the next constraint clearly: cache residency is not enough.
+A prior diagnostic with `boundary_budget=8` materialized only the root entry
+because most boundary histograms hit the expansion cap.  That means the policy
+needs a materialization-cost gate, or separate exact/partial-cache modes.
+
+The budget-4 row remained exact on this tiny sample but did not improve wall time.
+The budget-6 row had more cache hits and a slight time improvement, but introduced
+histogram error.  The next benchmark should sweep `boundary_budget` and admission
+thresholds together, then reject settings with too much error or capped boundary
+materialization.

--- a/scripts/lmdb_policy_cache_materialization_probe.py
+++ b/scripts/lmdb_policy_cache_materialization_probe.py
@@ -78,6 +78,9 @@ def binomial_support_prior(entry, hist, boundary_budget):
         "trials": trials,
         "probability": probability,
         "storage_scalars": 5,
+        "distribution_normalized": True,
+        "normalization_count": sum(hist.values()) if hist else None,
+        "normalization_count_source": "partial_histogram_lower_bound" if hist else "unknown",
         "storage_bytes_estimate": 40,
     }
 

--- a/scripts/lmdb_policy_cache_materialization_probe.py
+++ b/scripts/lmdb_policy_cache_materialization_probe.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Probe exact versus closed-form cache materialization candidates.
+
+Policy residency says a node is useful enough to keep.  It does not say that an
+exact boundary histogram is cheap enough to compute.  This probe classifies
+policy-resident nodes by suffix budget:
+
+- `exact_histogram`: exact bounded histogram materialized without caps.
+- `budget_too_short`: root distance is known but exceeds the suffix budget.
+- `closed_form_candidate`: exact materialization hit a cap; store a compact
+  closed-form approximation candidate instead, initially a binomial support prior.
+- `unresolved`: no exact histogram and no usable support metadata.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.distribution_fit_comparison import distribution_moments, exact_excess_distribution
+from scripts.lmdb_ancestor_cache_policy_sweep import (
+    CacheConfig,
+    collect_distances,
+    collect_query_inputs,
+    sweep_configs,
+)
+from scripts.lmdb_parent_branching_diagnostic import LmdbCategoryGraph, parse_int_list
+from scripts.lmdb_parent_histogram_benchmark import bounded_parent_histogram, percentile, safe_graph_name
+from scripts.lmdb_policy_cache_runtime_benchmark import policy_cache_entries
+
+
+def mean(values):
+    values = list(values)
+    if not values:
+        return 0.0
+    return statistics.fmean(values)
+
+
+def binomial_support_prior(entry, hist, boundary_budget):
+    if entry.l_min is None:
+        return None
+    support_min = int(entry.l_min)
+    support_max = boundary_budget
+    if entry.l_max is not None:
+        support_max = min(int(entry.l_max), boundary_budget)
+    if support_max < support_min:
+        return None
+    trials = support_max - support_min
+
+    probability = 0.5
+    source = "support_midpoint"
+    empirical, origin = exact_excess_distribution(hist)
+    if empirical and origin is not None and trials > 0:
+        partial_mean, partial_variance = distribution_moments(empirical)
+        shifted_mean = (origin - support_min) + partial_mean
+        probability = max(0.0, min(1.0, shifted_mean / trials))
+        source = "partial_histogram"
+    elif trials == 0:
+        probability = 0.0
+
+    return {
+        "family": "binomial_support_prior",
+        "source": source,
+        "support_min": support_min,
+        "support_max": support_max,
+        "trials": trials,
+        "probability": probability,
+        "storage_scalars": 5,
+        "storage_bytes_estimate": 40,
+    }
+
+
+def classify_materialization(entry, hist, stats, boundary_budget):
+    if hist and not stats.path_cap_hit and not stats.expansion_cap_hit:
+        return "exact_histogram", None
+    if entry.l_min is not None and int(entry.l_min) > boundary_budget:
+        return "budget_too_short", None
+    if stats.path_cap_hit or stats.expansion_cap_hit:
+        model = binomial_support_prior(entry, hist, boundary_budget)
+        if model is not None:
+            return "closed_form_candidate", model
+    if hist:
+        model = binomial_support_prior(entry, hist, boundary_budget)
+        if model is not None:
+            return "closed_form_candidate", model
+    return "unresolved", None
+
+
+def probe_entry(parents_func, root, slot, entry, boundary_budget, path_cap, expansion_cap):
+    started = time.perf_counter_ns()
+    hist, stats = bounded_parent_histogram(
+        parents_func,
+        entry.node,
+        root,
+        boundary_budget,
+        path_cap,
+        expansion_cap,
+    )
+    elapsed = time.perf_counter_ns() - started
+    classification, fallback = classify_materialization(entry, hist, stats, boundary_budget)
+    return {
+        "record_type": "policy_cache_materialization_probe",
+        "slot": slot,
+        "node": entry.node,
+        "boundary_budget": boundary_budget,
+        "classification": classification,
+        "fallback_model": fallback,
+        "l_min": entry.l_min,
+        "l_max": entry.l_max,
+        "distance_truncated": entry.truncated,
+        "path_count": sum(hist.values()),
+        "support_bins": len(hist),
+        "nodes_expanded": stats.nodes_expanded,
+        "edges_examined": stats.edges_examined,
+        "cycle_skips": stats.cycle_skips,
+        "path_cap_hit": stats.path_cap_hit,
+        "expansion_cap_hit": stats.expansion_cap_hit,
+        "histogram_time_ns": elapsed,
+    }
+
+
+def summarize_records(args, target_counts, query_inputs, config, policy_actions, rows):
+    by_budget = {}
+    for row in rows:
+        by_budget.setdefault(row["boundary_budget"], []).append(row)
+    budget_rows = []
+    for boundary_budget in sorted(by_budget):
+        bucket = by_budget[boundary_budget]
+        classifications = Counter(row["classification"] for row in bucket)
+        fallback_rows = [row for row in bucket if row["fallback_model"]]
+        support_widths = [
+            row["fallback_model"]["support_max"] - row["fallback_model"]["support_min"]
+            for row in fallback_rows
+        ]
+        budget_rows.append({
+            "boundary_budget": boundary_budget,
+            "resident_entries": len(bucket),
+            "classification_counts": dict(classifications),
+            "exact_rate": 0.0 if not bucket else classifications.get("exact_histogram", 0) / len(bucket),
+            "closed_form_candidate_rate": 0.0 if not bucket else classifications.get("closed_form_candidate", 0) / len(bucket),
+            "budget_too_short_rate": 0.0 if not bucket else classifications.get("budget_too_short", 0) / len(bucket),
+            "unresolved_rate": 0.0 if not bucket else classifications.get("unresolved", 0) / len(bucket),
+            "path_cap_entries": sum(1 for row in bucket if row["path_cap_hit"]),
+            "expansion_cap_entries": sum(1 for row in bucket if row["expansion_cap_hit"]),
+            "mean_nodes_expanded": mean(row["nodes_expanded"] for row in bucket),
+            "p95_nodes_expanded": percentile([row["nodes_expanded"] for row in bucket], 95),
+            "mean_histogram_time_ns": mean(row["histogram_time_ns"] for row in bucket),
+            "fallback_models": Counter(row["fallback_model"]["family"] for row in fallback_rows),
+            "mean_fallback_support_width": mean(support_widths),
+            "p95_fallback_support_width": percentile(support_widths, 95),
+        })
+    ancestor_nodes = [len(query.space.nodes) for query in query_inputs]
+    capped_queries = sum(1 for query in query_inputs if query.space.capped)
+    return {
+        "record_type": "policy_cache_materialization_summary",
+        "graph": args.graph_name,
+        "root": args.root,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "target_depths": parse_int_list(args.target_depths),
+        "target_selection_counts": target_counts,
+        "targets": len(query_inputs),
+        "ancestor_capped_queries": capped_queries,
+        "ancestor_capped_query_rate": 0.0 if not query_inputs else capped_queries / len(query_inputs),
+        "mean_ancestor_nodes": mean(ancestor_nodes),
+        "p95_ancestor_nodes": percentile(ancestor_nodes, 95),
+        "cache_slots": config.cache_slots,
+        "admit_l_min": config.admit_l_min,
+        "admit_l_max": config.admit_l_max,
+        "path_cap": args.path_cap,
+        "expansion_cap": args.expansion_cap,
+        "policy_actions": dict(policy_actions),
+        "policy_resident_entries": len(set(row["node"] for row in rows)),
+        "budget_rows": budget_rows,
+    }
+
+
+def markdown_summary(summaries):
+    lines = [
+        "# Policy Cache Materialization Probe",
+        "",
+        "| slots | L_min | L_max | boundary_budget | resident | exact | closed_form | too_short | unresolved | expansion_capped | mean_nodes | mean_fallback_width |",
+        "|------:|------:|------:|----------------:|---------:|------:|------------:|----------:|-----------:|-----------------:|-----------:|--------------------:|",
+    ]
+    for summary in summaries:
+        for row in summary["budget_rows"]:
+            counts = row["classification_counts"]
+            lines.append(
+                "| {slots} | {l_min} | {l_max} | {budget} | {resident} | {exact} | {closed} | {short} | {unresolved} | {capped} | {mean_nodes:.1f} | {width:.1f} |".format(
+                    slots=summary["cache_slots"],
+                    l_min=summary["admit_l_min"],
+                    l_max=summary["admit_l_max"],
+                    budget=row["boundary_budget"],
+                    resident=row["resident_entries"],
+                    exact=counts.get("exact_histogram", 0),
+                    closed=counts.get("closed_form_candidate", 0),
+                    short=counts.get("budget_too_short", 0),
+                    unresolved=counts.get("unresolved", 0),
+                    capped=row["expansion_cap_entries"],
+                    mean_nodes=row["mean_nodes_expanded"],
+                    width=row["mean_fallback_support_width"],
+                )
+            )
+    return "\n".join(lines) + "\n"
+
+
+def run_probe(args):
+    graph = LmdbCategoryGraph(args.lmdb_dir)
+    try:
+        _targets, target_counts, query_inputs = collect_query_inputs(graph, args)
+        distances = collect_distances(graph, args, query_inputs)
+        summaries = []
+        records = []
+        for config in sweep_configs(args):
+            policy_cache, policy_actions = policy_cache_entries(query_inputs, distances, config)
+            rows = []
+            for boundary_budget in parse_int_list(args.boundary_budgets):
+                for slot, entry in sorted(policy_cache.items()):
+                    rows.append(probe_entry(
+                        graph.parents,
+                        args.root,
+                        slot,
+                        entry,
+                        boundary_budget,
+                        args.path_cap,
+                        args.expansion_cap,
+                    ))
+            summary = summarize_records(args, target_counts, query_inputs, config, policy_actions, rows)
+            summaries.append(summary)
+            records.append(summary)
+            if args.write_jsonl:
+                records.extend(rows)
+        return records, summaries
+    finally:
+        graph.close()
+
+
+def write_outputs(records, summaries, output_dir, graph_name, write_jsonl=False):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    safe_name = safe_graph_name(graph_name)
+    summary_json = output_dir / "{}_policy_cache_materialization_summary.json".format(safe_name)
+    summary_md = output_dir / "{}_policy_cache_materialization_summary.md".format(safe_name)
+    summary_json.write_text(json.dumps(summaries, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary_md.write_text(markdown_summary(summaries), encoding="utf-8")
+    jsonl_path = None
+    if write_jsonl:
+        jsonl_path = output_dir / "{}_policy_cache_materialization.jsonl".format(safe_name)
+        with jsonl_path.open("w", encoding="utf-8") as handle:
+            for record in records:
+                handle.write(json.dumps(record, sort_keys=True) + "\n")
+    return summary_json, summary_md, jsonl_path
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lmdb-dir", type=Path, required=True)
+    parser.add_argument("--root", type=int, required=True)
+    parser.add_argument("--graph-name", default="lmdb_policy_cache_materialization")
+    parser.add_argument("--target-depths", default="3")
+    parser.add_argument("--children-per-node", type=int, default=32)
+    parser.add_argument("--frontier-limit", type=int, default=200)
+    parser.add_argument("--targets-per-depth", type=int, default=4)
+    parser.add_argument("--max-ancestor-nodes", type=int, default=1000)
+    parser.add_argument("--max-ancestor-edges", type=int, default=6000)
+    parser.add_argument("--root-distance-cap", type=int, default=32)
+    parser.add_argument("--cache-slots", type=int, default=128)
+    parser.add_argument("--admit-l-min", type=int, default=6)
+    parser.add_argument("--admit-l-max", type=int, default=12)
+    parser.add_argument("--sweep-cache-slots", default="128")
+    parser.add_argument("--sweep-admit-l-min", default=None)
+    parser.add_argument("--sweep-admit-l-max", default="8,12")
+    parser.add_argument("--boundary-budgets", default="1,2,3,4")
+    parser.add_argument("--path-cap", type=int, default=10000)
+    parser.add_argument("--expansion-cap", type=int, default=50000)
+    parser.add_argument("--write-jsonl", action="store_true")
+    parser.add_argument("--seed", default="policy-cache-materialization-v1")
+    parser.add_argument("--output-dir", type=Path, default=Path("docs/reports"))
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    records, summaries = run_probe(args)
+    summary_json, summary_md, jsonl_path = write_outputs(
+        records,
+        summaries,
+        args.output_dir,
+        args.graph_name,
+        write_jsonl=args.write_jsonl,
+    )
+    print(markdown_summary(summaries), end="")
+    print("summary_json={}".format(summary_json))
+    print("summary_md={}".format(summary_md))
+    if jsonl_path is not None:
+        print("jsonl={}".format(jsonl_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lmdb_policy_cache_runtime_benchmark.py
+++ b/scripts/lmdb_policy_cache_runtime_benchmark.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Measure bounded parent-histogram runtime using policy-selected cache nodes.
+
+The policy sweep tells us which root-near ancestor nodes would remain resident
+under a fixed-size cache.  This benchmark uses those resident nodes as the
+boundary-cache set, precomputes bounded histograms for them, then compares full
+bounded parent search with cached search on the sampled targets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.lmdb_ancestor_cache_policy_benchmark import (
+    admit_candidate,
+    cache_priority,
+    candidate_from_distance,
+    update_cache,
+)
+from scripts.lmdb_ancestor_cache_policy_sweep import (
+    CacheConfig,
+    collect_distances,
+    collect_query_inputs,
+    parse_grid,
+    sweep_configs,
+)
+from scripts.lmdb_parent_boundary_cache_benchmark import (
+    cached_parent_histogram,
+    comparison_record,
+)
+from scripts.lmdb_parent_branching_diagnostic import LmdbCategoryGraph, parse_int_list
+from scripts.lmdb_parent_histogram_benchmark import bounded_parent_histogram, percentile, safe_graph_name
+
+
+def mean(values):
+    values = list(values)
+    if not values:
+        return 0.0
+    return statistics.fmean(values)
+
+
+def action_rates(action_counts):
+    total = sum(action_counts.values())
+    if total == 0:
+        return {}
+    return {key: value / total for key, value in sorted(action_counts.items())}
+
+
+def policy_cache_entries(query_inputs, distances, config):
+    cache = {}
+    action_counts = Counter()
+    for query in query_inputs:
+        candidates = []
+        for node in sorted(query.space.nodes):
+            distance = distances[node]
+            if admit_candidate(distance, config.admit_l_min, config.admit_l_max):
+                candidates.append(candidate_from_distance(node, distance))
+        for candidate in sorted(candidates, key=cache_priority):
+            action_counts[update_cache(cache, candidate, query.space.nodes, config.cache_slots)] += 1
+    return cache, action_counts
+
+
+def build_policy_boundary_cache(parents_func, root, cache_entries, boundary_budget, path_cap, expansion_cap):
+    boundary_cache = {}
+    rows = []
+    for slot, entry in sorted(cache_entries.items()):
+        started = time.perf_counter_ns()
+        hist, stats = bounded_parent_histogram(
+            parents_func,
+            entry.node,
+            root,
+            boundary_budget,
+            path_cap,
+            expansion_cap,
+        )
+        elapsed = time.perf_counter_ns() - started
+        cached = bool(hist) and not stats.path_cap_hit and not stats.expansion_cap_hit
+        if cached:
+            boundary_cache[entry.node] = hist
+        rows.append({
+            "record_type": "policy_boundary_cache_entry",
+            "slot": slot,
+            "node": entry.node,
+            "l_min": entry.l_min,
+            "l_max": entry.l_max,
+            "truncated": entry.truncated,
+            "cached": cached,
+            "histogram": hist,
+            "path_count": sum(hist.values()),
+            "support_bins": len(hist),
+            "nodes_expanded": stats.nodes_expanded,
+            "edges_examined": stats.edges_examined,
+            "cycle_skips": stats.cycle_skips,
+            "path_cap_hit": stats.path_cap_hit,
+            "expansion_cap_hit": stats.expansion_cap_hit,
+            "histogram_time_ns": elapsed,
+        })
+    return boundary_cache, rows
+
+
+def compare_targets(graph, args, query_inputs, boundary_cache):
+    rows = []
+    for query in query_inputs:
+        for budget in parse_int_list(args.budgets):
+            full_started = time.perf_counter_ns()
+            full_hist, full_stats = bounded_parent_histogram(
+                graph.parents,
+                query.target,
+                args.root,
+                budget,
+                args.path_cap,
+                args.expansion_cap,
+            )
+            full_time = time.perf_counter_ns() - full_started
+            cached_started = time.perf_counter_ns()
+            cached_hist, cached_stats = cached_parent_histogram(
+                graph.parents,
+                query.target,
+                args.root,
+                budget,
+                boundary_cache,
+                args.path_cap,
+                args.expansion_cap,
+            )
+            cached_time = time.perf_counter_ns() - cached_started
+            rows.append(comparison_record(
+                args.graph_name,
+                args.root,
+                query.target,
+                query.child_depth,
+                budget,
+                full_hist,
+                full_stats,
+                full_time,
+                cached_hist,
+                cached_stats,
+                cached_time,
+            ))
+    return rows
+
+
+def summarize_runtime(args, target_counts, query_inputs, config, policy_actions, cache_rows, comparison_rows):
+    by_budget = {}
+    for row in comparison_rows:
+        by_budget.setdefault(row["budget"], []).append(row)
+    budget_rows = []
+    for budget in sorted(by_budget):
+        rows = by_budget[budget]
+        l1 = [float(row["l1_error"]) for row in rows]
+        cdf = [float(row["max_cdf_error"]) for row in rows]
+        ratios = [float(row["node_expansion_ratio"]) for row in rows]
+        hits = [int(row["cache_hits"]) for row in rows]
+        full_times = [int(row["full_time_ns"]) for row in rows]
+        cached_times = [int(row["cached_time_ns"]) for row in rows]
+        time_ratios = [
+            0.0 if int(row["full_time_ns"]) == 0 else int(row["cached_time_ns"]) / int(row["full_time_ns"])
+            for row in rows
+        ]
+        budget_rows.append({
+            "budget": budget,
+            "rows": len(rows),
+            "mean_l1_error": mean(l1),
+            "p95_l1_error": percentile(l1, 95),
+            "max_l1_error": max(l1, default=0.0),
+            "mean_max_cdf_error": mean(cdf),
+            "mean_node_expansion_ratio": mean(ratios),
+            "mean_time_ratio": mean(time_ratios),
+            "mean_full_time_ns": mean(full_times),
+            "mean_cached_time_ns": mean(cached_times),
+            "mean_cache_hits": mean(hits),
+            "full_capped": sum(1 for row in rows if row.get("full_path_cap_hit") or row.get("full_expansion_cap_hit")),
+            "cached_capped": sum(1 for row in rows if row.get("cached_path_cap_hit") or row.get("cached_expansion_cap_hit")),
+        })
+    cached_rows = [row for row in cache_rows if row["cached"]]
+    ancestor_nodes = [len(query.space.nodes) for query in query_inputs]
+    capped_queries = sum(1 for query in query_inputs if query.space.capped)
+    return {
+        "record_type": "policy_cache_runtime_summary",
+        "graph": args.graph_name,
+        "root": args.root,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "target_depths": parse_int_list(args.target_depths),
+        "target_selection_counts": target_counts,
+        "targets": len(query_inputs),
+        "ancestor_capped_queries": capped_queries,
+        "ancestor_capped_query_rate": 0.0 if not query_inputs else capped_queries / len(query_inputs),
+        "mean_ancestor_nodes": mean(ancestor_nodes),
+        "p95_ancestor_nodes": percentile(ancestor_nodes, 95),
+        "cache_slots": config.cache_slots,
+        "admit_l_min": config.admit_l_min,
+        "admit_l_max": config.admit_l_max,
+        "boundary_budget": args.boundary_budget,
+        "path_cap": args.path_cap,
+        "expansion_cap": args.expansion_cap,
+        "policy_actions": dict(policy_actions),
+        "policy_action_rates": action_rates(policy_actions),
+        "policy_resident_entries": len(cache_rows),
+        "materialized_boundary_entries": len(cached_rows),
+        "materialized_boundary_rate": 0.0 if not cache_rows else len(cached_rows) / len(cache_rows),
+        "mean_boundary_nodes_expanded": mean(row["nodes_expanded"] for row in cache_rows),
+        "boundary_capped_entries": sum(1 for row in cache_rows if row["path_cap_hit"] or row["expansion_cap_hit"]),
+        "budget_rows": budget_rows,
+    }
+
+
+def markdown_summary(summaries):
+    lines = [
+        "# Policy Cache Runtime Benchmark",
+        "",
+        "| slots | L_min | L_max | boundary_budget | targets | capped_cones | resident | materialized | mean_nodes | budget | mean_l1 | mean_node_ratio | mean_time_ratio | mean_cache_hits | full_capped | cached_capped |",
+        "|------:|------:|------:|----------------:|--------:|-------------:|---------:|-------------:|-----------:|-------:|--------:|----------------:|----------------:|----------------:|------------:|--------------:|",
+    ]
+    for summary in summaries:
+        for budget in summary["budget_rows"]:
+            lines.append(
+                "| {slots} | {l_min} | {l_max} | {boundary_budget} | {targets} | {capped} | {resident} | {materialized} | {mean_nodes:.1f} | {budget} | {mean_l1:.6f} | {node_ratio:.3f} | {time_ratio:.3f} | {hits:.3f} | {full_capped} | {cached_capped} |".format(
+                    slots=summary["cache_slots"],
+                    l_min=summary["admit_l_min"],
+                    l_max=summary["admit_l_max"],
+                    boundary_budget=summary["boundary_budget"],
+                    targets=summary["targets"],
+                    capped=summary["ancestor_capped_queries"],
+                    resident=summary["policy_resident_entries"],
+                    materialized=summary["materialized_boundary_entries"],
+                    mean_nodes=summary["mean_ancestor_nodes"],
+                    budget=budget["budget"],
+                    mean_l1=budget["mean_l1_error"],
+                    node_ratio=budget["mean_node_expansion_ratio"],
+                    time_ratio=budget["mean_time_ratio"],
+                    hits=budget["mean_cache_hits"],
+                    full_capped=budget["full_capped"],
+                    cached_capped=budget["cached_capped"],
+                )
+            )
+    return "\n".join(lines) + "\n"
+
+
+def run_benchmark(args):
+    graph = LmdbCategoryGraph(args.lmdb_dir)
+    try:
+        _targets, target_counts, query_inputs = collect_query_inputs(graph, args)
+        distances = collect_distances(graph, args, query_inputs)
+        records = []
+        summaries = []
+        for config in sweep_configs(args):
+            policy_cache, policy_actions = policy_cache_entries(query_inputs, distances, config)
+            boundary_cache, cache_rows = build_policy_boundary_cache(
+                graph.parents,
+                args.root,
+                policy_cache,
+                args.boundary_budget,
+                args.path_cap,
+                args.expansion_cap,
+            )
+            comparison_rows = compare_targets(graph, args, query_inputs, boundary_cache)
+            summary = summarize_runtime(args, target_counts, query_inputs, config, policy_actions, cache_rows, comparison_rows)
+            summaries.append(summary)
+            records.append(summary)
+            if args.write_jsonl:
+                records.extend(cache_rows)
+                records.extend(comparison_rows)
+        return records, summaries
+    finally:
+        graph.close()
+
+
+def write_outputs(records, summaries, output_dir, graph_name, write_jsonl=False):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    safe_name = safe_graph_name(graph_name)
+    summary_json = output_dir / "{}_policy_cache_runtime_summary.json".format(safe_name)
+    summary_md = output_dir / "{}_policy_cache_runtime_summary.md".format(safe_name)
+    summary_json.write_text(json.dumps(summaries, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary_md.write_text(markdown_summary(summaries), encoding="utf-8")
+    jsonl_path = None
+    if write_jsonl:
+        jsonl_path = output_dir / "{}_policy_cache_runtime.jsonl".format(safe_name)
+        with jsonl_path.open("w", encoding="utf-8") as handle:
+            for record in records:
+                handle.write(json.dumps(record, sort_keys=True) + "\n")
+    return summary_json, summary_md, jsonl_path
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lmdb-dir", type=Path, required=True)
+    parser.add_argument("--root", type=int, required=True)
+    parser.add_argument("--graph-name", default="lmdb_policy_cache_runtime")
+    parser.add_argument("--target-depths", default="3")
+    parser.add_argument("--children-per-node", type=int, default=32)
+    parser.add_argument("--frontier-limit", type=int, default=200)
+    parser.add_argument("--targets-per-depth", type=int, default=4)
+    parser.add_argument("--max-ancestor-nodes", type=int, default=1000)
+    parser.add_argument("--max-ancestor-edges", type=int, default=6000)
+    parser.add_argument("--root-distance-cap", type=int, default=32)
+    parser.add_argument("--cache-slots", type=int, default=128)
+    parser.add_argument("--admit-l-min", type=int, default=6)
+    parser.add_argument("--admit-l-max", type=int, default=12)
+    parser.add_argument("--sweep-cache-slots", default="128,256")
+    parser.add_argument("--sweep-admit-l-min", default=None)
+    parser.add_argument("--sweep-admit-l-max", default="8,12")
+    parser.add_argument("--boundary-budget", type=int, default=8)
+    parser.add_argument("--budgets", default="4,6")
+    parser.add_argument("--path-cap", type=int, default=10000)
+    parser.add_argument("--expansion-cap", type=int, default=50000)
+    parser.add_argument("--write-jsonl", action="store_true")
+    parser.add_argument("--seed", default="policy-cache-runtime-v1")
+    parser.add_argument("--output-dir", type=Path, default=Path("docs/reports"))
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    records, summaries = run_benchmark(args)
+    summary_json, summary_md, jsonl_path = write_outputs(
+        records,
+        summaries,
+        args.output_dir,
+        args.graph_name,
+        write_jsonl=args.write_jsonl,
+    )
+    print(markdown_summary(summaries), end="")
+    print("summary_json={}".format(summary_json))
+    print("summary_md={}".format(summary_md))
+    if jsonl_path is not None:
+        print("jsonl={}".format(jsonl_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_lmdb_policy_cache_materialization_probe.py
+++ b/tests/test_lmdb_policy_cache_materialization_probe.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Tests for policy-cache materialization classification helpers."""
+
+import unittest
+
+from scripts.lmdb_ancestor_cache_policy_benchmark import CacheEntry
+from scripts.lmdb_parent_histogram_benchmark import bounded_parent_histogram
+from scripts.lmdb_policy_cache_materialization_probe import (
+    binomial_support_prior,
+    classify_materialization,
+    markdown_summary,
+    probe_entry,
+)
+
+
+class PolicyCacheMaterializationProbeTests(unittest.TestCase):
+    def test_classifies_exact_histogram(self):
+        entry = CacheEntry(node=1, l_min=1, l_max=1)
+        hist, stats = bounded_parent_histogram(lambda node: {1: [0]}.get(node, []), 1, 0, 2)
+
+        classification, fallback = classify_materialization(entry, hist, stats, 2)
+
+        self.assertEqual(classification, "exact_histogram")
+        self.assertIsNone(fallback)
+
+    def test_classifies_budget_too_short(self):
+        entry = CacheEntry(node=2, l_min=3, l_max=5)
+        hist, stats = bounded_parent_histogram(lambda node: {}, 2, 0, 2)
+
+        classification, fallback = classify_materialization(entry, hist, stats, 2)
+
+        self.assertEqual(classification, "budget_too_short")
+        self.assertIsNone(fallback)
+
+    def test_capped_histogram_becomes_binomial_candidate(self):
+        entry = CacheEntry(node=2, l_min=1, l_max=3)
+        hist, stats = bounded_parent_histogram(lambda node: {2: [1], 1: [0]}.get(node, []), 2, 0, 3, expansion_cap=1)
+
+        classification, fallback = classify_materialization(entry, hist, stats, 3)
+
+        self.assertEqual(classification, "closed_form_candidate")
+        self.assertEqual(fallback["family"], "binomial_support_prior")
+        self.assertEqual(fallback["support_min"], 1)
+        self.assertEqual(fallback["support_max"], 3)
+
+    def test_binomial_prior_uses_partial_histogram_when_present(self):
+        entry = CacheEntry(node=2, l_min=1, l_max=3)
+        fallback = binomial_support_prior(entry, {1: 1, 3: 1}, 3)
+
+        self.assertEqual(fallback["source"], "partial_histogram")
+        self.assertEqual(fallback["probability"], 0.5)
+
+    def test_probe_entry_reports_classification(self):
+        entry = CacheEntry(node=1, l_min=1, l_max=1)
+        row = probe_entry(lambda node: {1: [0]}.get(node, []), 0, 7, entry, 2, None, None)
+
+        self.assertEqual(row["classification"], "exact_histogram")
+        self.assertEqual(row["slot"], 7)
+
+    def test_markdown_summary_contains_closed_form_column(self):
+        summary = {
+            "cache_slots": 8,
+            "admit_l_min": 2,
+            "admit_l_max": 4,
+            "budget_rows": [{
+                "boundary_budget": 2,
+                "resident_entries": 3,
+                "classification_counts": {"exact_histogram": 1, "closed_form_candidate": 2},
+                "expansion_cap_entries": 2,
+                "mean_nodes_expanded": 10.0,
+                "mean_fallback_support_width": 2.0,
+            }],
+        }
+
+        self.assertIn("closed_form", markdown_summary([summary]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lmdb_policy_cache_materialization_probe.py
+++ b/tests/test_lmdb_policy_cache_materialization_probe.py
@@ -51,6 +51,9 @@ class PolicyCacheMaterializationProbeTests(unittest.TestCase):
 
         self.assertEqual(fallback["source"], "partial_histogram")
         self.assertEqual(fallback["probability"], 0.5)
+        self.assertTrue(fallback["distribution_normalized"])
+        self.assertEqual(fallback["normalization_count"], 2)
+        self.assertEqual(fallback["normalization_count_source"], "partial_histogram_lower_bound")
 
     def test_probe_entry_reports_classification(self):
         entry = CacheEntry(node=1, l_min=1, l_max=1)

--- a/tests/test_lmdb_policy_cache_runtime_benchmark.py
+++ b/tests/test_lmdb_policy_cache_runtime_benchmark.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Tests for policy-selected boundary-cache runtime helpers."""
+
+import unittest
+
+from scripts.lmdb_ancestor_cache_policy_benchmark import AncestorSpace
+from scripts.lmdb_ancestor_cache_policy_sweep import CacheConfig, QueryInput
+from scripts.lmdb_policy_cache_runtime_benchmark import (
+    build_policy_boundary_cache,
+    markdown_summary,
+    policy_cache_entries,
+    summarize_runtime,
+)
+
+
+class PolicyCacheRuntimeBenchmarkTests(unittest.TestCase):
+    def test_policy_cache_entries_retains_admitted_nodes(self):
+        query = QueryInput(target=3, child_depth=1, space=AncestorSpace(nodes={0, 1, 2, 3}))
+        distances = {
+            0: {"L_min": 0, "L_max": 0, "truncated": False},
+            1: {"L_min": 1, "L_max": 1, "truncated": False},
+            2: {"L_min": 1, "L_max": 1, "truncated": False},
+            3: {"L_min": 2, "L_max": 2, "truncated": False},
+        }
+
+        cache, actions = policy_cache_entries([query], distances, CacheConfig(8, 2, 2))
+
+        self.assertEqual({entry.node for entry in cache.values()}, {0, 1, 2, 3})
+        self.assertEqual(actions["insert"], 4)
+
+    def test_build_policy_boundary_cache_materializes_histograms(self):
+        query = QueryInput(target=3, child_depth=1, space=AncestorSpace(nodes={0, 1, 2, 3}))
+        distances = {
+            0: {"L_min": 0, "L_max": 0, "truncated": False},
+            1: {"L_min": 1, "L_max": 1, "truncated": False},
+            2: {"L_min": 1, "L_max": 1, "truncated": False},
+            3: {"L_min": 2, "L_max": 2, "truncated": False},
+        }
+        cache, _actions = policy_cache_entries([query], distances, CacheConfig(8, 2, 2))
+        parents = {3: [1, 2], 2: [0], 1: [0]}
+
+        boundary_cache, rows = build_policy_boundary_cache(
+            lambda node: parents.get(node, []),
+            0,
+            cache,
+            boundary_budget=3,
+            path_cap=None,
+            expansion_cap=None,
+        )
+
+        self.assertEqual(len(rows), 4)
+        self.assertEqual(boundary_cache[3], {2: 2})
+        self.assertEqual(boundary_cache[1], {1: 1})
+
+    def test_summarize_runtime_reports_budget_rows(self):
+        class Args:
+            graph_name = "tiny"
+            root = 0
+            target_depths = "1"
+            boundary_budget = 2
+            path_cap = 100
+            expansion_cap = 1000
+
+        query = QueryInput(target=3, child_depth=1, space=AncestorSpace(nodes={0, 1, 2, 3}))
+        cache_rows = [
+            {
+                "cached": True,
+                "nodes_expanded": 1,
+                "path_cap_hit": False,
+                "expansion_cap_hit": False,
+            }
+        ]
+        comparison_rows = [
+            {
+                "budget": 2,
+                "l1_error": 0.0,
+                "max_cdf_error": 0.0,
+                "node_expansion_ratio": 0.5,
+                "cache_hits": 1,
+                "full_time_ns": 100,
+                "cached_time_ns": 50,
+                "full_path_cap_hit": False,
+                "full_expansion_cap_hit": False,
+                "cached_path_cap_hit": False,
+                "cached_expansion_cap_hit": False,
+            }
+        ]
+
+        summary = summarize_runtime(
+            Args(),
+            {0: 1, 1: 1},
+            [query],
+            CacheConfig(8, 2, 2),
+            {"insert": 1},
+            cache_rows,
+            comparison_rows,
+        )
+
+        self.assertEqual(summary["materialized_boundary_entries"], 1)
+        self.assertEqual(summary["budget_rows"][0]["mean_node_expansion_ratio"], 0.5)
+        self.assertEqual(summary["budget_rows"][0]["mean_time_ratio"], 0.5)
+        self.assertIn("| slots |", markdown_summary([summary]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `scripts/lmdb_policy_cache_runtime_benchmark.py` to connect ancestor-cache policy residency to actual bounded parent histogram runtime.
- Add `scripts/lmdb_policy_cache_materialization_probe.py` to classify policy-resident nodes as exact histograms, too-short-budget cases, closed-form candidates, or unresolved.
- Materialize policy-resident nodes as boundary histograms, then compare full bounded search with cached search for sampled targets.
- Report materialization rates, boundary caps, histogram error, node-expansion ratio, time ratio, and cache hits by budget.
- Add focused unit tests and smoke reports for enwiki `Category:Main_topic_classifications`.

## Key Findings

Residency policy alone is not enough. With `boundary_budget=8`, most policy-resident nodes hit the materialization expansion cap, leaving only the root usable as an exact cached boundary in the runtime smoke. With `boundary_budget=3`, 37 of 52 resident entries materialized and cached search produced hits.

Observed `boundary_budget=3` runtime smoke:

| budget | mean_l1 | mean_node_ratio | mean_time_ratio | mean_cache_hits |
| ---: | ---: | ---: | ---: | ---: |
| 4 | 0.000000 | 0.971 | 1.050 | 1.500 |
| 6 | 0.115385 | 0.966 | 0.982 | 10.500 |

The materialization probe makes the closed-form fallback explicit. In a budget-8 materialization smoke, 51 of 52 resident entries became `closed_form_candidate` because exact materialization hit the expansion cap. The fallback model is currently a `binomial_support_prior` over `(L_min, min(L_max, boundary_budget))`.

Per your note, the fallback stores a normalized distribution family plus a separate `normalization_count` when a partial count is available. That lets a caller reconstruct an unnormalized histogram estimate as `N * P(k)`.

## Validation

- `python3 -m unittest tests.test_lmdb_policy_cache_materialization_probe tests.test_lmdb_policy_cache_runtime_benchmark tests.test_lmdb_parent_boundary_cache_benchmark tests.test_lmdb_ancestor_cache_policy_benchmark`
- Constrained enwiki MTC runtime smoke against local LMDB, output to Scratch, no JSONL trace:
  - root id `7345184`
  - target depth `3`
  - 2 sampled targets
  - `boundary_budget=3`
  - budgets `4,6`
- Constrained enwiki MTC materialization probe:
  - short budgets `1,2,3,4`
  - budget `8` smoke showing closed-form candidates under expansion caps

## Notes

One unrelated unstaged local edit remains in `templates/targets/fsharp_wam/kernel_bidirectional_ancestor.fs.mustache`; it is intentionally not part of this PR.