### PR TITLE
feat(wam-rust): T7 slice 2a — cost gate drives aggregate codegen annotation

### DIFF
--- a/docs/reports/cost_analysis_machinery.md
+++ b/docs/reports/cost_analysis_machinery.md
@@ -66,7 +66,8 @@ builtin_cost/2, cost_tier_threshold/2          % overridable tuning
 
 ## How the gates consume it
 
-- **T7 (parallel aggregate) — built (`parallel_gate.pl`).**
+- **T7 (parallel aggregate) — gate built (`parallel_gate.pl`) AND wired into Rust
+  codegen (slice 2a).**
   `aggregate_parallel_decision(+Goal, +Model, -Decision)` recognises a forkable
   aggregate (`findall`/`aggregate_all`/`bagof`/`setof`) and returns `parallel`
   vs `sequential` from the generator's cost tier. Key simplification: an
@@ -79,6 +80,17 @@ builtin_cost/2, cost_tier_threshold/2          % overridable tuning
   that never regresses. This is the *compile-time* decision the
   `par_aggregate.rs` substrate's `ParConfig` was built pluggable for — the
   runtime probe becomes a cheap confirmation rather than the decision.
+  **Slice 2a (`wam_rust_target.pl`):** `compile_wam_predicate_to_rust` now
+  consults this gate (per predicate, over its clause bodies' forkable
+  aggregates) and annotates the generated function — `/// T7: parallel-eligible
+  aggregate (cost gate tier: …)` — when a generator is parallel-worthy. This is
+  the first time the cost machinery drives real codegen. Decision-only, no
+  semantics change; gated behind `parallel_aggregates(true)` so default output
+  is byte-identical. Tested end-to-end (`test_wam_rust_parallel_aggregate_gate.pl`):
+  recursive/heavy generators get the annotation, cheap/no-aggregate/feature-off
+  do not. **Slice 2b (next):** make `WamMachine: Clone + Send` and have the
+  annotated path actually call `gated_collect`, with an exec harness proving
+  parallel result-set == sequential + speedup.
 - **T6 — *not* a fit (deliberately not wired).** `t6_min_clauses` gates on
   clause **count**, not body cost; first-argument indexing helps regardless of
   per-clause work, so cost analysis adds nothing there. Documented so the

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -3814,7 +3814,7 @@ pub fn shared_wam_program() -> (Vec<Instruction>, HashMap<String, usize>) {
 }'
     ),
     % Pass 3: generate code for each predicate
-    generate_predicate_codes(Classified, WamEntries, PredCodes),
+    generate_predicate_codes(Classified, WamEntries, Options, PredCodes),
     % Combine shared table + predicate code
     (   SharedCode == ""
     ->  atomic_list_concat(PredCodes, '\n\n', Code)
@@ -3957,69 +3957,75 @@ collect_wam_entries([classified(_, Pred, Arity, lowered, lowered_code(_, WamCode
 collect_wam_entries([_|Rest], PC, Entries, Instrs, Labels) :-
     collect_wam_entries(Rest, PC, Entries, Instrs, Labels).
 
-%% generate_predicate_codes(+Classified, +WamEntries, -PredCodes)
-%  Generates Rust code for each classified predicate.
-generate_predicate_codes([], _, []).
+%% generate_predicate_codes(+Classified, +WamEntries, +Options, -PredCodes)
+%  Generates Rust code for each classified predicate. Options is threaded so the
+%  shared-table WAM path can consult the T7 parallel-aggregate gate.
+generate_predicate_codes([], _, _, []).
 generate_predicate_codes([classified(_, Pred, Arity, ffi_kernel,
                                      kernel_with_wrapper(Kernel, WrapperCode))|Rest],
-                         WamEntries, [Code|RestCodes]) :-
+                         WamEntries, Options, [Code|RestCodes]) :-
     !,
     Kernel = recursive_kernel(Kind, _, _),
     format(string(Code),
         "// Strategy: ffi_kernel (~w)\n// ~w/~w dispatched via CallForeign → execute_foreign_predicate\n~w",
         [Kind, Pred, Arity, WrapperCode]),
-    generate_predicate_codes(Rest, WamEntries, RestCodes).
+    generate_predicate_codes(Rest, WamEntries, Options, RestCodes).
 generate_predicate_codes([classified(_, Pred, Arity, ffi_kernel, Kernel)|Rest],
-                         WamEntries, [Code|RestCodes]) :-
+                         WamEntries, Options, [Code|RestCodes]) :-
     % FFI kernel — no WAM code needed; handled by setup_foreign_predicates
     % and execute_foreign_predicate at runtime via CallForeign dispatch.
     Kernel = recursive_kernel(Kind, _, _),
     format(string(Code),
         "// Strategy: ffi_kernel (~w)\n// ~w/~w dispatched via CallForeign → execute_foreign_predicate",
         [Kind, Pred, Arity]),
-    generate_predicate_codes(Rest, WamEntries, RestCodes).
+    generate_predicate_codes(Rest, WamEntries, Options, RestCodes).
 generate_predicate_codes([classified(_, _Pred, _Arity, native, PredCode)|Rest],
-                         WamEntries, [Code|RestCodes]) :-
+                         WamEntries, Options, [Code|RestCodes]) :-
     format(string(Code), "// Strategy: native\n~w", [PredCode]),
-    generate_predicate_codes(Rest, WamEntries, RestCodes).
+    generate_predicate_codes(Rest, WamEntries, Options, RestCodes).
 generate_predicate_codes([classified(_, _Pred, _Arity, wam_foreign, PredCode)|Rest],
-                         WamEntries, [Code|RestCodes]) :-
+                         WamEntries, Options, [Code|RestCodes]) :-
     format(string(Code), "// Strategy: wam\n~w", [PredCode]),
-    generate_predicate_codes(Rest, WamEntries, RestCodes).
+    generate_predicate_codes(Rest, WamEntries, Options, RestCodes).
 generate_predicate_codes([classified(_, _Pred, _Arity, lowered, lowered_code(PredCode, _))|Rest],
-                         WamEntries, [Code|RestCodes]) :-
+                         WamEntries, Options, [Code|RestCodes]) :-
     format(string(Code), "// Strategy: lowered\n~w", [PredCode]),
-    generate_predicate_codes(Rest, WamEntries, RestCodes).
+    generate_predicate_codes(Rest, WamEntries, Options, RestCodes).
 generate_predicate_codes([classified(_, Pred, Arity, wam, _WamCode)|Rest],
-                         WamEntries, [Code|RestCodes]) :-
+                         WamEntries, Options, [Code|RestCodes]) :-
     % Look up this predicate's start PC in the shared table
     member(wam_entry(Pred, Arity, StartPC), WamEntries),
-    compile_wam_predicate_to_rust_shared(Pred/Arity, StartPC, Code),
-    generate_predicate_codes(Rest, WamEntries, RestCodes).
+    compile_wam_predicate_to_rust_shared(Pred/Arity, StartPC, Options, Code),
+    generate_predicate_codes(Rest, WamEntries, Options, RestCodes).
 generate_predicate_codes([classified(_, _Pred, _Arity, failed, PredCode)|Rest],
-                         WamEntries, [Code|RestCodes]) :-
+                         WamEntries, Options, [Code|RestCodes]) :-
     format(string(Code), "// Strategy: failed\n~w", [PredCode]),
-    generate_predicate_codes(Rest, WamEntries, RestCodes).
+    generate_predicate_codes(Rest, WamEntries, Options, RestCodes).
 
-%% compile_wam_predicate_to_rust_shared(+Pred/Arity, +StartPC, -RustCode)
+%% compile_wam_predicate_to_rust_shared(+Pred/Arity, +StartPC, +Options, -RustCode)
 %  Generates a thin WAM predicate wrapper that references the shared code table.
-compile_wam_predicate_to_rust_shared(Pred/Arity, StartPC, RustCode) :-
+%  Consults the T7 parallel-aggregate gate (cost machinery) so project-mode
+%  codegen carries the same parallel-eligibility annotation as the standalone
+%  path; gated behind parallel_aggregates(true), so default output is unchanged.
+compile_wam_predicate_to_rust_shared(Pred/Arity, StartPC, Options, RustCode) :-
     atom_string(Pred, PredStr),
     rust_safe_function_name(Pred/Arity, FuncName),
     build_rust_wam_arg_list(Arity, ArgList),
     build_rust_wam_arg_setup(Arity, ArgSetup),
+    rust_predicate_parallel_decision(Pred/Arity, Options, ParDecision),
+    rust_parallel_annotation(ParDecision, AggAnno),
     format(string(RustCode),
 '// Strategy: wam
 /// WAM-compiled predicate: ~w/~w (shared table, pc=~w)
 /// Compiled via WAM for predicates that resist native lowering.
-pub fn ~w(~w) -> bool {
+~wpub fn ~w(~w) -> bool {
     let (code, labels) = get_shared_wam();
     vm.code = code.clone();
     vm.labels = labels.clone();
     vm.pc = ~w;
 ~w
     vm.run()
-}', [PredStr, Arity, StartPC, FuncName, ArgList, StartPC, ArgSetup]).
+}', [PredStr, Arity, StartPC, AggAnno, FuncName, ArgList, StartPC, ArgSetup]).
 
 %% write_file(+Path, +Content)
 write_file(Path, Content) :-

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -28,6 +28,9 @@
 :- use_module('../core/template_system').
 :- use_module('../bindings/rust_wam_bindings').
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
+% T7 compile-time parallel-aggregate gate (consumer of the cost machinery).
+:- use_module('../core/parallel_gate', [forkable_aggregate/3, goal_parallel_decision/3]).
+:- use_module('../core/cost_analysis', [build_cost_model/2, goal_cost_tier/3]).
 :- use_module('../targets/wam_text_parser', [
     wam_classify_constant_token/2,
     wam_tokenize_line/2
@@ -2996,16 +2999,79 @@ compile_wam_predicate_to_rust(Pred/Arity, WamCode, Options, RustCode) :-
     build_rust_wam_arg_list(Arity, ArgList),
     build_rust_wam_arg_setup(Arity, ArgSetup),
     foreign_wrapper_setup(Pred/Arity, WamCode, Options, InstrSetup, ForeignSetup, RunExpr),
+    % T7: consult the compile-time parallel-aggregate gate (cost machinery).
+    % Gated behind parallel_aggregates(true); otherwise AggAnno = '' and output
+    % is byte-identical to before.
+    rust_predicate_parallel_decision(Pred/Arity, Options, ParDecision),
+    rust_parallel_annotation(ParDecision, AggAnno),
     format(string(RustCode),
 '/// WAM-compiled predicate: ~w/~w
 /// Compiled via WAM for predicates that resist native lowering.
-pub fn ~w(~w) -> bool {
+~wpub fn ~w(~w) -> bool {
     use std::collections::HashMap;
 ~w
 ~w
 ~w
     ~w
-}', [PredStr, Arity, FuncName, ArgList, InstrSetup, ForeignSetup, ArgSetup, RunExpr]).
+}', [PredStr, Arity, AggAnno, FuncName, ArgList, InstrSetup, ForeignSetup, ArgSetup, RunExpr]).
+
+% --- T7 compile-time parallel-aggregate gate --------------------------------
+%
+% First codegen consumer of the cost machinery: decide, per predicate, whether
+% any forkable aggregate (findall/aggregate_all/bagof/setof) in its clause
+% bodies is worth parallelising, and annotate the generated function so the
+% phase-2 runtime can dispatch on it. Decision-only here — no semantics change.
+% Feature-gated by parallel_aggregates(true) (default off → no output change).
+% Fully defensive: any failure (module not loaded, no source, no aggregate)
+% degrades to `sequential` and emits nothing.
+
+rust_predicate_parallel_decision(Pred/Arity, Options, Decision) :-
+    (   option(parallel_aggregates(true), Options),
+        catch(rust_pred_par_decision(Pred/Arity, Options, D), _, fail)
+    ->  Decision = D
+    ;   Decision = sequential
+    ).
+
+rust_pred_par_decision(Pred/Arity, Options, Decision) :-
+    option(module_name(Mod0), Options, user),
+    ( atom(Mod0) -> Module = Mod0 ; Module = user ),
+    functor(Head, Pred, Arity),
+    findall(Body, clause(Module:Head, Body), Bodies),
+    Bodies \== [],
+    collect_forkable_generators(Bodies, Gens),
+    Gens \== [],
+    build_cost_model(Module, Model),
+    (   member(Gen, Gens),
+        goal_parallel_decision(Gen, Model, parallel)
+    ->  goal_cost_tier(Gen, Model, Tier),
+        Decision = parallel(Tier)
+    ;   Decision = sequential
+    ).
+
+% Collect the generator goals of every forkable aggregate appearing anywhere in
+% the given clause bodies.
+collect_forkable_generators(Bodies, Gens) :-
+    findall(Gen,
+            ( member(B, Bodies),
+              body_subgoal(B, G),
+              nonvar(G),
+              forkable_aggregate(G, _Tmpl, Gen) ),
+            Gens0),
+    sort(Gens0, Gens).
+
+% Enumerate sub-goals of a body, descending through control constructs.
+body_subgoal(G, _) :- var(G), !, fail.
+body_subgoal((A, B), S) :- !, ( body_subgoal(A, S) ; body_subgoal(B, S) ).
+body_subgoal((A ; B), S) :- !, ( body_subgoal(A, S) ; body_subgoal(B, S) ).
+body_subgoal((A -> B), S) :- !, ( body_subgoal(A, S) ; body_subgoal(B, S) ).
+body_subgoal((A *-> B), S) :- !, ( body_subgoal(A, S) ; body_subgoal(B, S) ).
+body_subgoal(\+ A, S) :- !, body_subgoal(A, S).
+body_subgoal(G, G).
+
+rust_parallel_annotation(parallel(Tier), Anno) :- !,
+    format(atom(Anno),
+           '/// T7: parallel-eligible aggregate (cost gate tier: ~w)~n', [Tier]).
+rust_parallel_annotation(_, '').
 
 foreign_wrapper_setup(Pred/Arity, WamCode, Options, InstrSetup, Setup, RunExpr) :-
     (   option(foreign_lowering(ForeignSpec), Options),

--- a/tests/test_wam_rust_parallel_aggregate_gate.pl
+++ b/tests/test_wam_rust_parallel_aggregate_gate.pl
@@ -11,7 +11,9 @@
 % (parallel_gate.aggregate_parallel_decision via the cost model) reaches codegen.
 
 :- use_module('../src/unifyweaver/targets/wam_target', [compile_predicate_to_wam/3]).
-:- use_module('../src/unifyweaver/targets/wam_rust_target', [compile_wam_predicate_to_rust/4]).
+:- use_module('../src/unifyweaver/targets/wam_rust_target',
+              [compile_wam_predicate_to_rust/4, write_wam_rust_project/3]).
+:- use_module(library(readutil), [read_file_to_string/3]).
 
 % ---- fixture program (asserted into user) ----------------------------------
 :- dynamic tpa_fact/1.
@@ -76,5 +78,21 @@ test(annotated_code_still_well_formed) :-
     rust_of(tpa_rec_agg/1, R),
     assertion(sub_string(R, _, _, _, "pub fn")),
     assertion(sub_string(R, _, _, _, "-> bool")).
+
+% Project mode goes through the *shared-table* wrapper path (a different code
+% path than the standalone compile above); the annotation must reach it too,
+% else real generated projects miss it.
+test(project_mode_shared_path_annotated, [cleanup(safe_rmdir('output/test_t7_gate_project'))]) :-
+    Dir = 'output/test_t7_gate_project',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project([user:tpa_rec_agg/1, user:tpa_rec/1, user:tpa_fact/1],
+        [module_name(user), parallel_aggregates(true)], Dir)),
+    atom_concat(Dir, '/src/lib.rs', LibRs),
+    read_file_to_string(LibRs, S, []),
+    assertion(sub_string(S, _, _, _, "parallel-eligible")),
+    assertion(sub_string(S, _, _, _, "pub fn tpa_rec_agg_1")).
+
+safe_rmdir(Dir) :-
+    ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
 
 :- end_tests(wam_rust_parallel_aggregate_gate).

--- a/tests/test_wam_rust_parallel_aggregate_gate.pl
+++ b/tests/test_wam_rust_parallel_aggregate_gate.pl
@@ -1,0 +1,80 @@
+% test_wam_rust_parallel_aggregate_gate.pl
+%
+% Slice 2a: the cost machinery driving real Rust codegen. Compiles predicates
+% containing forkable aggregates through the WAM->Rust pipeline with the T7 gate
+% enabled (parallel_aggregates(true)) and asserts the generated function carries
+% a "parallel-eligible" annotation exactly when the aggregate's generator is in a
+% parallel-worthy cost tier (recursive / expensive) — and not for cheap
+% generators, predicates without aggregates, or when the feature is off.
+%
+% No interpreter semantics change here: this proves the compile-time decision
+% (parallel_gate.aggregate_parallel_decision via the cost model) reaches codegen.
+
+:- use_module('../src/unifyweaver/targets/wam_target', [compile_predicate_to_wam/3]).
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [compile_wam_predicate_to_rust/4]).
+
+% ---- fixture program (asserted into user) ----------------------------------
+:- dynamic tpa_fact/1.
+tpa_fact(1). tpa_fact(2). tpa_fact(3).
+
+tpa_double(X, Y) :- Y is X * 2.                         % cheap per-branch
+
+tpa_rec([]).                                            % recursive generator
+tpa_rec([_|T]) :- tpa_rec(T).
+
+tpa_heavy(X, R) :-                                      % heavy bounded per-branch
+    atom_codes(X, Cs), msort(Cs, S1), reverse(S1, S2),
+    atom_codes(A, S2), atom_concat(A, A, B), sub_atom(B, 0, 1, _, R),
+    msort(S2, _), reverse(S2, _), atom_length(A, _).
+
+% predicates under test
+tpa_cheap_agg(Xs)  :- findall(Y, (tpa_fact(X), tpa_double(X, Y)), Xs).
+tpa_rec_agg(Ls)    :- findall(L, (tpa_fact(_), tpa_rec(L)), Ls).
+tpa_heavy_agg(Rs)  :- findall(R, (tpa_fact(X), tpa_heavy(X, R)), Rs).
+tpa_plain(X, Y)    :- tpa_double(X, Y).                 % no aggregate
+
+:- begin_tests(wam_rust_parallel_aggregate_gate).
+
+% Compile a predicate to Rust with the T7 gate enabled.
+rust_of(Name/Arity, RustCode) :-
+    once(( compile_predicate_to_wam(user:Name/Arity, [], WamCode),
+           compile_wam_predicate_to_rust(Name/Arity, WamCode,
+               [parallel_aggregates(true), module_name(user)], RustCode) )).
+
+rust_of_default(Name/Arity, RustCode) :-
+    once(( compile_predicate_to_wam(user:Name/Arity, [], WamCode),
+           compile_wam_predicate_to_rust(Name/Arity, WamCode, [module_name(user)], RustCode) )).
+
+has_anno(RustCode) :- sub_string(RustCode, _, _, _, "parallel-eligible").
+
+test(recursive_generator_annotated) :-
+    rust_of(tpa_rec_agg/1, R),
+    assertion(has_anno(R)),
+    assertion(sub_string(R, _, _, _, "recursive")).
+
+test(heavy_generator_annotated_expensive) :-
+    rust_of(tpa_heavy_agg/1, R),
+    assertion(has_anno(R)),
+    assertion(sub_string(R, _, _, _, "expensive")).
+
+test(cheap_generator_not_annotated) :-
+    rust_of(tpa_cheap_agg/1, R),
+    assertion(\+ has_anno(R)).
+
+test(no_aggregate_not_annotated) :-
+    rust_of(tpa_plain/2, R),
+    assertion(\+ has_anno(R)).
+
+% Feature gate: with the option absent, output carries no annotation (so default
+% codegen is unchanged) even for a parallel-worthy generator.
+test(feature_off_no_annotation) :-
+    rust_of_default(tpa_rec_agg/1, R),
+    assertion(\+ has_anno(R)).
+
+% The gated decision still produces a valid Rust function either way.
+test(annotated_code_still_well_formed) :-
+    rust_of(tpa_rec_agg/1, R),
+    assertion(sub_string(R, _, _, _, "pub fn")),
+    assertion(sub_string(R, _, _, _, "-> bool")).
+
+:- end_tests(wam_rust_parallel_aggregate_gate).


### PR DESCRIPTION
## What

First time the cost machinery (merged in #3034) drives **real Rust codegen**. `compile_wam_predicate_to_rust` now consults the T7 compile-time gate (`parallel_gate.aggregate_parallel_decision`, backed by `cost_analysis`) per predicate, over the forkable aggregates in its clause bodies, and annotates the generated function when a generator is parallel-worthy:

```rust
/// T7: parallel-eligible aggregate (cost gate tier: recursive)
pub fn tpa_rec_agg_1(...) -> bool { ... }
```

## How
- **`rust_predicate_parallel_decision/3`** — builds the cost model from the source module (`module_name` option), walks clause bodies for `findall`/`aggregate_all`/`bagof`/`setof` generators, returns `parallel(Tier)` iff one is in a parallel-worthy tier (`recursive`/`expensive`). Fully defensive — module not loaded / no source / no aggregate all degrade to `sequential`.
- **Decision-only, no interpreter semantics change.** Gated behind `parallel_aggregates(true)`; with the option absent `AggAnno = ''`, so default codegen is **byte-identical** — verified: the full existing `test_wam_rust_target.pl` suite still passes.

## Tests
`tests/test_wam_rust_parallel_aggregate_gate.pl` — 6 tests, all green, end-to-end through the real WAM→Rust pipeline: recursive generator annotated `recursive`, heavy bounded generator annotated `expensive`, cheap generator / no-aggregate / feature-off all unannotated, annotated code still well-formed.

## Context
This is slice **2a** of T7-on-Rust. The runtime substrate (`par_aggregate.rs`, #3025) and the cost machinery + gate (#3034) are already on `main`; this wires the gate into codegen. **Slice 2b (next):** make `WamMachine: Clone + Send` and have the annotated path actually call `gated_collect`, with an exec harness proving parallel result-set == sequential + speedup.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_