### PR TITLE
[codex] Add minimal PLAWK prefix-print surface

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -236,6 +236,15 @@ atom names without the outer WAM token quotes.
 
 Parser/codegen land in `examples/plawk/{parser,codegen}/`.
 
+**Current slice:** `examples/plawk/parser/plawk_parser.pl` parses the first
+surface form, `/^PREFIX/ { print $0 }`, to
+`program([], [rule(prefix(Prefix), [print(field(0))])], [])`.
+`examples/plawk/codegen/plawk_native_codegen.pl` lowers that AST to a native
+streaming WAM/LLVM driver using `llvm_emit_atom_prefix_guard/5`, and
+`tests/test_plawk_surface_prefix_print.pl` proves that the generated binary
+prints matching records from a text file without calling `run_loop` in the hot
+record loop.
+
 **Success:** a user-written awk-style program parses, lowers, compiles, and
 produces correct output on standard awk test cases.
 

--- a/docs/design/PLAWK_SPECIFICATION.md
+++ b/docs/design/PLAWK_SPECIFICATION.md
@@ -114,12 +114,11 @@ Reader variants:
   `record(term, Term)`; the compiled equivalent of `read/1`.
 - **DCG-based reader** — applies a DCG grammar to the stream.
 
-> **Implementation note (gap).** The LLVM target currently has **no streaming
-> input builtin** — only whole-file `read_file_to_atom/2`. The text line reader
-> therefore requires a new buffered builtin (`stream_open`/`read_line`/
-> `stream_close`). See Implementation Plan § Codebase reconciliation for the
-> sketch. A Phase-0 shortcut is to slurp the whole input and `split_string/4` on
-> newlines, iterating in Prolog (correct, but not unbounded-stream-safe).
+> **Implementation note.** The LLVM target now exposes buffered stream builtins
+> (`stream_open`/`read_line`/`stream_close`) plus native helper calls for stream
+> loops. The original Phase-0 whole-file `read_file_to_atom/2` shortcut remains
+> useful for simple Prolog-core tests, but compiled PLAWK smokes should prefer
+> the target-side streaming path.
 
 ---
 

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -55,8 +55,8 @@ are complementary.
 plawk/
   README.md          this file
   core/              process_all/4, reader/handler/writer, item_field/3   (Phase 0)
-  parser/            awk-like surface -> AST -> Prolog core               (Phase 2)
-  codegen/           AST -> Prolog-core source emission                   (Phase 2)
+  parser/            awk-like surface -> AST                              (Phase 2)
+  codegen/           AST -> native WAM/LLVM driver fragments              (Phase 2)
 ```
 
 ## Run the Phase 0 prototype
@@ -71,9 +71,12 @@ swipl -q -s tests/test_plawk_native_stream_loop_driver.pl -g "setenv('UW_SMOKE_T
 swipl -q -s tests/test_plawk_native_counter_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_native_output_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 swipl -q -s tests/test_plawk_native_lowered_handler_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
+swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/mnt/c/Users/johnc/Scratch'),run_tests" -t halt
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
+The first Phase 2 surface smoke parses `/^ERROR/ { print $0 }`, emits a native
+streaming WAM/LLVM driver, and prints matching records from a text file.
 
 For a walkthrough of the current Prolog-core syntax and how it maps to awk
 concepts like `$0`, `$1`, `NR`, `NF`, `FS`, `OFS`, and `print`, see
@@ -86,6 +89,7 @@ concepts like `$0`, `$1`, `NR`, `NF`, `FS`, `OFS`, and `print`, see
 - [`docs/design/PLAWK_IMPLEMENTATION_PLAN.md`](../../docs/design/PLAWK_IMPLEMENTATION_PLAN.md)
 
 The implementation plan's **Codebase reconciliation** section captures the
-three audit findings: modes are already consumed by codegen, `:- det` is not,
-and a buffered streaming reader is the one builtin that must be added before the
-awk loop is real.
+original audit findings and the current compiled-stream boundary. The buffered
+streaming reader now exists in the WAM/LLVM target; the remaining work is to
+grow the surface parser/codegen until ordinary awk-like programs lower through
+the same native streaming path.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1,0 +1,118 @@
+% SPDX-License-Identifier: MIT
+% Copyright (c) 2026 John William Creighton (s243a)
+
+:- module(plawk_native_codegen, [
+    plawk_program_native_driver_ir/3
+]).
+
+:- use_module('../../../src/unifyweaver/targets/wam_llvm_target',
+    [llvm_emit_atom_prefix_guard/5]).
+
+%% plawk_program_native_driver_ir(+Program, +InputPath, -DriverIR) is semidet.
+%
+%  Emit the first native Phase-2 PLAWK driver shape:
+%
+%      /^PREFIX/ { print $0 }
+%
+%  The surrounding runtime still comes from write_wam_llvm_project/3. This
+%  function emits the target-specific native main that streams the file, lowers
+%  the deterministic prefix guard, and prints matching records.
+plawk_program_native_driver_ir(
+    program([], [rule(prefix(Prefix), [print(field(0))])], []),
+    InputPath,
+    DriverIR
+) :-
+    atom_codes(InputPath, PathCodes),
+    length(PathCodes, PathLen),
+    BytesLen is PathLen + 1,
+    llvm_c_bytes(PathCodes, PathBytes),
+    llvm_emit_atom_prefix_guard(plawk_surface_prefix, '%line', Prefix,
+        '%is_match', PrefixGuardGlobalIR-PrefixGuardCallIR),
+    format(atom(DriverIR),
+'@.plawk_surface_path = private constant [~w x i8] c"~w\\00"
+@.plawk_surface_eof = private constant [12 x i8] c"end_of_file\\00"
+@.plawk_surface_print_line = private constant [4 x i8] c"%s\\0A\\00"
+~w
+
+define i32 @main() {
+entry:
+  %path_ptr = getelementptr [~w x i8], [~w x i8]* @.plawk_surface_path, i32 0, i32 0
+  %path_id = call i64 @wam_intern_atom(i8* %path_ptr, i64 ~w)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+  %handle = call %Value @wam_stream_open_value(%Value %path)
+  %handle_tag = extractvalue %Value %handle, 0
+  %handle_is_int = icmp eq i32 %handle_tag, 1
+  br i1 %handle_is_int, label %check_handle_value, label %fail_open
+
+check_handle_value:
+  %handle_payload = extractvalue %Value %handle, 1
+  %handle_ok = icmp sgt i64 %handle_payload, 0
+  br i1 %handle_ok, label %loop, label %fail_open
+
+loop:
+  %line = call %Value @wam_stream_read_line_value(%Value %handle)
+  %line_tag = extractvalue %Value %line, 0
+  %line_payload = extractvalue %Value %line, 1
+  %line_is_int = icmp eq i32 %line_tag, 1
+  %line_bad_payload = icmp slt i64 %line_payload, 0
+  %line_bad = and i1 %line_is_int, %line_bad_payload
+  br i1 %line_bad, label %fail_read, label %check_line_atom
+
+check_line_atom:
+  %line_is_atom = icmp eq i32 %line_tag, 0
+  br i1 %line_is_atom, label %check_eof, label %fail_line_tag
+
+check_eof:
+  %line_s = call i8* @wam_atom_to_string(i64 %line_payload)
+  %eof_s = getelementptr [12 x i8], [12 x i8]* @.plawk_surface_eof, i32 0, i32 0
+  %eof_cmp = call i32 @strcmp(i8* %line_s, i8* %eof_s)
+  %is_eof = icmp eq i32 %eof_cmp, 0
+  br i1 %is_eof, label %close_stream, label %lowered_match
+
+lowered_match:
+~w
+  br i1 %is_match, label %print_line, label %continue_loop
+
+print_line:
+  %fmt = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_line, i32 0, i32 0
+  %printed = call i32 (i8*, ...) @printf(i8* %fmt, i8* %line_s)
+  br label %continue_loop
+
+continue_loop:
+  br label %loop
+
+close_stream:
+  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %close_ok, label %success, label %fail_close
+
+success:
+  ret i32 0
+
+fail_open:
+  ret i32 10
+
+fail_read:
+  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 11
+
+fail_line_tag:
+  %close_ignore_line_tag = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 12
+
+fail_close:
+  ret i32 16
+}
+',
+        [BytesLen, PathBytes,
+         PrefixGuardGlobalIR,
+         BytesLen, BytesLen, PathLen, PrefixGuardCallIR]).
+
+llvm_c_bytes([], '').
+llvm_c_bytes([Code | Rest], Bytes) :-
+    llvm_c_byte(Code, Byte),
+    llvm_c_bytes(Rest, Tail),
+    atom_concat(Byte, Tail, Bytes).
+
+llvm_c_byte(Code, Byte) :-
+    format(atom(Byte), '\\~|~`0t~16r~2+', [Code]).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -1,0 +1,78 @@
+% SPDX-License-Identifier: MIT
+% Copyright (c) 2026 John William Creighton (s243a)
+
+:- module(plawk_parser, [
+    plawk_parse_string/2
+]).
+
+%% plawk_parse_string(+Source, -Program) is semidet.
+%
+%  Parse the first Phase-2 surface slice:
+%
+%      /^PREFIX/ { print $0 }
+%
+%  The AST is deliberately small and explicit so later syntax can extend it
+%  without changing the native codegen contract.
+plawk_parse_string(Source, Program) :-
+    string(Source),
+    string_codes(Source, Codes),
+    phrase(plawk_program(Program), Codes).
+
+plawk_program(program([], [rule(prefix(Prefix), [print(field(0))])], [])) -->
+    ws,
+    prefix_pattern(Prefix),
+    ws,
+    "{",
+    ws,
+    print_field_zero,
+    ws,
+    "}",
+    ws,
+    eos.
+
+prefix_pattern(Prefix) -->
+    "/^",
+    prefix_codes(Codes),
+    "/",
+    { Codes \== [],
+      string_codes(Prefix, Codes)
+    }.
+
+prefix_codes([Code | Codes]) -->
+    [Code],
+    { Code =\= 0'/,
+      Code =\= 0'\n,
+      Code =\= 0'\r
+    },
+    prefix_codes_rest(Codes).
+
+prefix_codes_rest([Code | Codes]) -->
+    [Code],
+    { Code =\= 0'/,
+      Code =\= 0'\n,
+      Code =\= 0'\r
+    },
+    !,
+    prefix_codes_rest(Codes).
+prefix_codes_rest([]) -->
+    [].
+
+print_field_zero -->
+    "print",
+    required_ws,
+    "$0".
+
+required_ws -->
+    [Code],
+    { code_type(Code, space) },
+    ws.
+
+ws -->
+    [Code],
+    { code_type(Code, space) },
+    !,
+    ws.
+ws -->
+    [].
+
+eos([], []).

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -1,0 +1,65 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(process)).
+:- use_module('helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../src/unifyweaver/targets/wam_llvm_target').
+:- use_module('../examples/plawk/parser/plawk_parser').
+:- use_module('../examples/plawk/codegen/plawk_native_codegen').
+
+:- dynamic user:plawk_surface_marker/0.
+
+user:plawk_surface_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(plawk_surface_prefix_print, [condition(clang_available)]).
+
+test(parses_prefix_print_rule) :-
+    plawk_parse_string("/^ERROR/ { print $0 }\n", Program),
+    assertion(Program == program([], [rule(prefix("ERROR"), [print(field(0))])], [])).
+
+test(surface_prefix_prints_matching_records) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_plawk_surface_prefix_print', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, 'INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n', []),
+        close(In)),
+    plawk_parse_string("/^ERROR/ { print $0 }\n", Program),
+    plawk_program_native_driver_ir(Program, InputPath, DriverIR),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    directory_file_path(Dir, 'plawk_surface_prefix_print.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:plawk_surface_marker/0 ],
+        [module_name('plawk_surface_prefix_print')], LLPath),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'plawk_surface_prefix_print_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> assertion(OutStr == "ERROR disk full\nERROR net down\n")
+    ;  format(user_error, "~n[plawk surface prefix print output]~n~w~n",
+              [OutStr]),
+       throw(plawk_surface_prefix_print_failed(Status))
+    ),
+    !.
+
+:- end_tests(plawk_surface_prefix_print).


### PR DESCRIPTION
## Summary

- Add the first PLAWK Phase 2 parser slice for `/^PREFIX/ { print $0 }`.
- Add native WAM/LLVM codegen for that AST shape, using the reusable `llvm_emit_atom_prefix_guard/5` helper and the existing stream runtime.
- Add an end-to-end smoke that parses source, emits native LLVM, compiles it with clang, streams a text file, and prints matching records.
- Update PLAWK docs to reflect that WAM/LLVM streaming builtins now exist and document the current parser/codegen boundary.

## Validation

- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_native_lowered_handler_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `git diff --check`
- `git diff --cached --check`