### PR TITLE
feat(wam-rust): T7 2b foundations — forkable machine + aggregate exec harness

### DIFF
--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -318,6 +318,14 @@ pub enum StackEntry {
 /// WAM virtual machine state.
 /// Mirrors wam_state(PC, Regs, Stack, Heap, Trail, CP, ChoicePoints, Code, Labels)
 /// from wam_runtime.pl.
+///
+/// `Clone` (every field is Clone: Arc/Vec/HashMap/FxMap/Option/scalars) enables
+/// the T7 parallel-aggregate substrate to fork an independent machine per worker
+/// — a WAM machine is mutable shared state, so each branch must run on its own
+/// clone (see rust_runtime/par_aggregate.rs). The static assertion below pins
+/// both `Clone` and `Send` (the `stack: Arc<…>` field, not `Rc`, is what keeps
+/// the machine `Send`).
+#[derive(Clone)]
 pub struct WamState {
     /// Program counter (1-indexed, 0 = halt).
     pub pc: usize,
@@ -419,6 +427,19 @@ pub struct WamState {
     /// Return PC stored by end_aggregate for aggregate-frame finalization.
     pub aggregate_return_pc: usize,
 }
+
+/// T7 prerequisite: the WAM machine must be `Clone` (fork a machine per parallel
+/// worker) and `Send` (move clones to worker threads). Compile-time assertion —
+/// if a future field breaks either, the generated project fails to compile here
+/// with a clear pointer rather than deep inside the parallel substrate.
+const _: () = {
+    fn _assert_send<T: Send>() {}
+    fn _assert_clone<T: Clone>() {}
+    fn _wam_state_is_forkable() {
+        _assert_send::<WamState>();
+        _assert_clone::<WamState>();
+    }
+};
 
 /// Resolved edge accessor. The category-edge predicate is a CONSTANT for a
 /// whole query, so it is resolved ONCE (`resolve_edge_accessor`) and the

--- a/tests/test_wam_rust_machine_forkable.pl
+++ b/tests/test_wam_rust_machine_forkable.pl
@@ -1,0 +1,54 @@
+% test_wam_rust_machine_forkable.pl
+%
+% Slice 2b, sub-step 1: the generated WAM machine (WamState) must be Clone + Send
+% so the T7 parallel substrate (rust_runtime/par_aggregate.rs) can fork an
+% independent machine per worker thread. state.rs.mustache now derives Clone and
+% carries a compile-time `_wam_state_is_forkable` assertion pinning Clone + Send.
+%
+% This test proves it two ways: a fast structural check that the derive +
+% assertion are emitted, and (when cargo is present) that a generated project
+% actually compiles — a successful build means the static Send+Clone assertion
+% held, i.e. the machine is genuinely forkable.
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target',
+              [write_wam_rust_project/3, cargo_check_project/2]).
+:- use_module(library(readutil), [read_file_to_string/3]).
+
+:- dynamic mf_fact/1.
+mf_fact(1). mf_fact(2). mf_fact(3).
+mf_q(X) :- mf_fact(X).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+gen(Dir) :-
+    safe_rmdir(Dir),
+    once(write_wam_rust_project([user:mf_q/1, user:mf_fact/1], [module_name(user)], Dir)).
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+:- begin_tests(wam_rust_machine_forkable).
+
+% Structural: the machine derives Clone and the Send+Clone assertion is emitted.
+test(state_derives_clone_and_asserts_forkable,
+     [cleanup(safe_rmdir('output/test_mf_struct'))]) :-
+    Dir = 'output/test_mf_struct',
+    gen(Dir),
+    atom_concat(Dir, '/src/state.rs', StateRs),
+    read_file_to_string(StateRs, S, []),
+    assertion(sub_string(S, _, _, _, "#[derive(Clone)]\npub struct WamState")),
+    assertion(sub_string(S, _, _, _, "_wam_state_is_forkable")),
+    assertion(sub_string(S, _, _, _, "_assert_send::<WamState>")),
+    assertion(sub_string(S, _, _, _, "_assert_clone::<WamState>")).
+
+% Compile: a generated project builds, so the static Clone+Send assertion held.
+test(generated_project_compiles_with_forkable_machine,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_mf_cargo'))]) :-
+    Dir = 'output/test_mf_cargo',
+    gen(Dir),
+    cargo_check_project(Dir, Result),
+    assertion(memberchk(Result, [ok, not_available])).
+
+:- end_tests(wam_rust_machine_forkable).


### PR DESCRIPTION
## What

The two **foundations** for T7 phase 2's runtime fork, plus an honest scoping of the fork itself.

### 1. `WamState: Clone + Send` (2b.1)
`templates/targets/rust_wam/state.rs.mustache`:
- **`#[derive(Clone)]`** on `WamState` — every field is already Clone (`Arc`/`Vec`/`HashMap`/`FxMap`/`Option`/scalars). The stack is `Arc<…>` not `Rc` *precisely so the machine stays `Send`*.
- A **compile-time assertion** (`_wam_state_is_forkable`) pinning `Clone + Send`; a future non-forkable field fails the generated build with a clear pointer.

A WAM machine is mutable shared state — it can't be shared across threads, only cloned. This makes the machine forkable, the prerequisite for the parallel substrate.

### 2. Aggregate exec acceptance harness (2b.2, test-first)
`tests/test_wam_rust_aggregate_exec.pl` — builds and **runs** a generated project's aggregates and asserts correct results: `aggregate_all(count)`→3, `aggregate_all(sum)`→6, `findall`→`[1,2,3]`, via `cargo test`. First exec coverage of the WAM-Rust aggregate path, and the baseline any fork must preserve (**parallel result-set == sequential**).

### 3. Fork analysis (`docs/reports/wam_rust_t7_2b2_fork_analysis.md`)
Reading the interpreter showed 2b.2 is a **VM-level change**, not a "wire `gated_collect` in" call: the expensive per-branch work happens *inside* the backtracking search, interleaved between `BeginAggregate`/`EndAggregate`, with no clean runtime seam to run "outer-branch k only" on a clone (outer alternatives are discovered sequentially via a try/retry/trust CP chain; `(Enum,Body)` compiles to one undivided block). Two routes documented — **recommended:** compile-time generator/body split (enumerate `Enum`→bindings, `gated_collect`-map `Body` over clones, mapping directly onto the substrate's `run_branch`); **not recommended:** fragile interpreter choice-point stride partition.

## Tests
`test_wam_rust_machine_forkable.pl` (structural + cargo-compile) and `test_wam_rust_aggregate_exec.pl` (cargo-run) both green; existing `test_wam_rust_target.pl` suite still all-pass.

## Why land this now
Foundations are correct, tested, and reversible. The work-split is a focused, test-first follow-up along route 1 — and this harness is already its acceptance test: the fork is done when the same harness passes with the parallel driver forced on.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_