### PR TITLE
[codex] Lower PLAWK field equality guards

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -237,13 +237,15 @@ atom names without the outer WAM token quotes.
 Parser/codegen land in `examples/plawk/{parser,codegen}/`.
 
 **Current slice:** `examples/plawk/parser/plawk_parser.pl` parses the first
-surface form, `/^PREFIX/ { print $0 }`, to
-`program([], [rule(prefix(Prefix), [print(field(0))])], [])`.
+surface forms, `/^PREFIX/ { print $0 }` and
+`$N == "VALUE" { print $0 }`, to explicit pattern/action ASTs.
 `examples/plawk/codegen/plawk_native_codegen.pl` lowers that AST to a native
-streaming WAM/LLVM driver using `llvm_emit_atom_prefix_guard/5`, and
+streaming WAM/LLVM driver using `llvm_emit_atom_prefix_guard/5` or
+`llvm_emit_atom_field_eq_guard/7`, and
 `tests/test_plawk_surface_prefix_print.pl` proves that the generated binary
 prints matching records from a text file without calling `run_loop` in the hot
-record loop.
+record loop. The field-equality path scans fields in native code without
+allocating substrings.
 
 **Success:** a user-written awk-style program parses, lowers, compiles, and
 produces correct output on standard awk test cases.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -75,8 +75,9 @@ swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR
 ```
 
 The demo prints the record count and the lines whose first field is `ERROR`.
-The first Phase 2 surface smoke parses `/^ERROR/ { print $0 }`, emits a native
-streaming WAM/LLVM driver, and prints matching records from a text file.
+The first Phase 2 surface smokes parse `/^ERROR/ { print $0 }` and
+`$1 == "ERROR" { print $0 }`, emit a native streaming WAM/LLVM driver, and
+print matching records from a text file.
 
 For a walkthrough of the current Prolog-core syntax and how it maps to awk
 concepts like `$0`, `$1`, `NR`, `NF`, `FS`, `OFS`, and `print`, see

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -6,19 +6,21 @@
 ]).
 
 :- use_module('../../../src/unifyweaver/targets/wam_llvm_target',
-    [llvm_emit_atom_prefix_guard/5]).
+    [llvm_emit_atom_prefix_guard/5,
+     llvm_emit_atom_field_eq_guard/7]).
 
 %% plawk_program_native_driver_ir(+Program, +InputPath, -DriverIR) is semidet.
 %
 %  Emit the first native Phase-2 PLAWK driver shape:
 %
 %      /^PREFIX/ { print $0 }
+%      $N == "VALUE" { print $0 }
 %
 %  The surrounding runtime still comes from write_wam_llvm_project/3. This
 %  function emits the target-specific native main that streams the file, lowers
-%  the deterministic prefix guard, and prints matching records.
+%  the deterministic guard, and prints matching records.
 plawk_program_native_driver_ir(
-    program([], [rule(prefix(Prefix), [print(field(0))])], []),
+    program([], [rule(Pattern, [print(field(0))])], []),
     InputPath,
     DriverIR
 ) :-
@@ -26,8 +28,7 @@ plawk_program_native_driver_ir(
     length(PathCodes, PathLen),
     BytesLen is PathLen + 1,
     llvm_c_bytes(PathCodes, PathBytes),
-    llvm_emit_atom_prefix_guard(plawk_surface_prefix, '%line', Prefix,
-        '%is_match', PrefixGuardGlobalIR-PrefixGuardCallIR),
+    plawk_pattern_guard_ir(Pattern, GuardGlobalIR-GuardCallIR),
     format(atom(DriverIR),
 '@.plawk_surface_path = private constant [~w x i8] c"~w\\00"
 @.plawk_surface_eof = private constant [12 x i8] c"end_of_file\\00"
@@ -105,8 +106,8 @@ fail_close:
 }
 ',
         [BytesLen, PathBytes,
-         PrefixGuardGlobalIR,
-         BytesLen, BytesLen, PathLen, PrefixGuardCallIR]).
+         GuardGlobalIR,
+         BytesLen, BytesLen, PathLen, GuardCallIR]).
 
 llvm_c_bytes([], '').
 llvm_c_bytes([Code | Rest], Bytes) :-
@@ -116,3 +117,11 @@ llvm_c_bytes([Code | Rest], Bytes) :-
 
 llvm_c_byte(Code, Byte) :-
     format(atom(Byte), '\\~|~`0t~16r~2+', [Code]).
+
+plawk_pattern_guard_ir(prefix(Prefix), GuardIR) :-
+    llvm_emit_atom_prefix_guard(plawk_surface_prefix, '%line', Prefix,
+        '%is_match', GuardIR).
+
+plawk_pattern_guard_ir(field_eq(Index, Value), GuardIR) :-
+    llvm_emit_atom_field_eq_guard(plawk_surface_field_eq, '%line', Index, Value,
+        32, '%is_match', GuardIR).

--- a/examples/plawk/generated/plawk_core_probe.ll
+++ b/examples/plawk/generated/plawk_core_probe.ll
@@ -6632,6 +6632,124 @@ sch.close:
   ret i1 %sch.ok
 }
 
+define i1 @wam_atom_prefix_value(%Value %atom_value, i8* %prefix, i64 %prefix_len) {
+entry:
+  %ap.t = call i32 @value_tag(%Value %atom_value)
+  %ap.is_atom = icmp eq i32 %ap.t, 0
+  br i1 %ap.is_atom, label %ap.lookup, label %ap.no
+
+ap.lookup:
+  %ap.aid = call i64 @value_payload(%Value %atom_value)
+  %ap.str = call i8* @wam_atom_to_string(i64 %ap.aid)
+  %ap.null = icmp eq i8* %ap.str, null
+  br i1 %ap.null, label %ap.no, label %ap.loop
+
+ap.loop:
+  %ap.i = phi i64 [ 0, %ap.lookup ], [ %ap.next, %ap.step_ok ]
+  %ap.done = icmp uge i64 %ap.i, %prefix_len
+  br i1 %ap.done, label %ap.yes, label %ap.step
+
+ap.step:
+  %ap.sp = getelementptr i8, i8* %ap.str, i64 %ap.i
+  %ap.pp = getelementptr i8, i8* %prefix, i64 %ap.i
+  %ap.sc = load i8, i8* %ap.sp
+  %ap.pc = load i8, i8* %ap.pp
+  %ap.nonzero = icmp ne i8 %ap.sc, 0
+  %ap.eq = icmp eq i8 %ap.sc, %ap.pc
+  %ap.match = and i1 %ap.nonzero, %ap.eq
+  br i1 %ap.match, label %ap.step_ok, label %ap.no
+
+ap.step_ok:
+  %ap.next = add i64 %ap.i, 1
+  br label %ap.loop
+
+ap.yes:
+  ret i1 true
+
+ap.no:
+  ret i1 false
+}
+
+define i1 @wam_atom_field_eq_value(%Value %atom_value, i64 %field_index, i8* %expected, i64 %expected_len, i8 %sep) {
+entry:
+  %fe.t = call i32 @value_tag(%Value %atom_value)
+  %fe.is_atom = icmp eq i32 %fe.t, 0
+  br i1 %fe.is_atom, label %fe.check_index, label %fe.no
+
+fe.check_index:
+  %fe.index_ok = icmp sgt i64 %field_index, 0
+  br i1 %fe.index_ok, label %fe.lookup, label %fe.no
+
+fe.lookup:
+  %fe.aid = call i64 @value_payload(%Value %atom_value)
+  %fe.str = call i8* @wam_atom_to_string(i64 %fe.aid)
+  %fe.null = icmp eq i8* %fe.str, null
+  br i1 %fe.null, label %fe.no, label %fe.find_loop
+
+fe.find_loop:
+  %fe.cur_index = phi i64 [ 1, %fe.lookup ], [ %fe.next_index, %fe.after_sep ]
+  %fe.start_pos = phi i64 [ 0, %fe.lookup ], [ %fe.after_sep_pos, %fe.after_sep ]
+  %fe.index_match = icmp eq i64 %fe.cur_index, %field_index
+  br i1 %fe.index_match, label %fe.compare_loop, label %fe.skip_loop
+
+fe.skip_loop:
+  %fe.skip_pos = phi i64 [ %fe.start_pos, %fe.find_loop ], [ %fe.skip_next_pos, %fe.skip_next ]
+  %fe.skip_ptr = getelementptr i8, i8* %fe.str, i64 %fe.skip_pos
+  %fe.skip_ch = load i8, i8* %fe.skip_ptr
+  %fe.skip_nul = icmp eq i8 %fe.skip_ch, 0
+  br i1 %fe.skip_nul, label %fe.no, label %fe.skip_check_sep
+
+fe.skip_check_sep:
+  %fe.skip_is_sep = icmp eq i8 %fe.skip_ch, %sep
+  br i1 %fe.skip_is_sep, label %fe.after_sep, label %fe.skip_next
+
+fe.skip_next:
+  %fe.skip_next_pos = add i64 %fe.skip_pos, 1
+  br label %fe.skip_loop
+
+fe.after_sep:
+  %fe.after_sep_pos = add i64 %fe.skip_pos, 1
+  %fe.next_index = add i64 %fe.cur_index, 1
+  br label %fe.find_loop
+
+fe.compare_loop:
+  %fe.i = phi i64 [ 0, %fe.find_loop ], [ %fe.next_i, %fe.compare_step ]
+  %fe.pos = phi i64 [ %fe.start_pos, %fe.find_loop ], [ %fe.next_pos, %fe.compare_step ]
+  %fe.done = icmp uge i64 %fe.i, %expected_len
+  br i1 %fe.done, label %fe.check_end, label %fe.compare_char
+
+fe.compare_char:
+  %fe.line_ptr = getelementptr i8, i8* %fe.str, i64 %fe.pos
+  %fe.exp_ptr = getelementptr i8, i8* %expected, i64 %fe.i
+  %fe.line_ch = load i8, i8* %fe.line_ptr
+  %fe.exp_ch = load i8, i8* %fe.exp_ptr
+  %fe.line_nonzero = icmp ne i8 %fe.line_ch, 0
+  %fe.line_not_sep = icmp ne i8 %fe.line_ch, %sep
+  %fe.eq = icmp eq i8 %fe.line_ch, %fe.exp_ch
+  %fe.live = and i1 %fe.line_nonzero, %fe.line_not_sep
+  %fe.match = and i1 %fe.live, %fe.eq
+  br i1 %fe.match, label %fe.compare_step, label %fe.no
+
+fe.compare_step:
+  %fe.next_i = add i64 %fe.i, 1
+  %fe.next_pos = add i64 %fe.pos, 1
+  br label %fe.compare_loop
+
+fe.check_end:
+  %fe.end_ptr = getelementptr i8, i8* %fe.str, i64 %fe.pos
+  %fe.end_ch = load i8, i8* %fe.end_ptr
+  %fe.end_nul = icmp eq i8 %fe.end_ch, 0
+  %fe.end_sep = icmp eq i8 %fe.end_ch, %sep
+  %fe.end_ok = or i1 %fe.end_nul, %fe.end_sep
+  br i1 %fe.end_ok, label %fe.yes, label %fe.no
+
+fe.yes:
+  ret i1 true
+
+fe.no:
+  ret i1 false
+}
+
 ; Dispatches on integer op codes:
 ;   0 = is/2, 1 = >/2, 2 = </2, 3 = >=/2, 4 = =</2
 ;   5 = =:=/2, 6 = =\=/2, 7 = ==/2, 8 = true/0, 9 = fail/0

--- a/examples/plawk/generated/plawk_loop_probe.ll
+++ b/examples/plawk/generated/plawk_loop_probe.ll
@@ -6632,6 +6632,124 @@ sch.close:
   ret i1 %sch.ok
 }
 
+define i1 @wam_atom_prefix_value(%Value %atom_value, i8* %prefix, i64 %prefix_len) {
+entry:
+  %ap.t = call i32 @value_tag(%Value %atom_value)
+  %ap.is_atom = icmp eq i32 %ap.t, 0
+  br i1 %ap.is_atom, label %ap.lookup, label %ap.no
+
+ap.lookup:
+  %ap.aid = call i64 @value_payload(%Value %atom_value)
+  %ap.str = call i8* @wam_atom_to_string(i64 %ap.aid)
+  %ap.null = icmp eq i8* %ap.str, null
+  br i1 %ap.null, label %ap.no, label %ap.loop
+
+ap.loop:
+  %ap.i = phi i64 [ 0, %ap.lookup ], [ %ap.next, %ap.step_ok ]
+  %ap.done = icmp uge i64 %ap.i, %prefix_len
+  br i1 %ap.done, label %ap.yes, label %ap.step
+
+ap.step:
+  %ap.sp = getelementptr i8, i8* %ap.str, i64 %ap.i
+  %ap.pp = getelementptr i8, i8* %prefix, i64 %ap.i
+  %ap.sc = load i8, i8* %ap.sp
+  %ap.pc = load i8, i8* %ap.pp
+  %ap.nonzero = icmp ne i8 %ap.sc, 0
+  %ap.eq = icmp eq i8 %ap.sc, %ap.pc
+  %ap.match = and i1 %ap.nonzero, %ap.eq
+  br i1 %ap.match, label %ap.step_ok, label %ap.no
+
+ap.step_ok:
+  %ap.next = add i64 %ap.i, 1
+  br label %ap.loop
+
+ap.yes:
+  ret i1 true
+
+ap.no:
+  ret i1 false
+}
+
+define i1 @wam_atom_field_eq_value(%Value %atom_value, i64 %field_index, i8* %expected, i64 %expected_len, i8 %sep) {
+entry:
+  %fe.t = call i32 @value_tag(%Value %atom_value)
+  %fe.is_atom = icmp eq i32 %fe.t, 0
+  br i1 %fe.is_atom, label %fe.check_index, label %fe.no
+
+fe.check_index:
+  %fe.index_ok = icmp sgt i64 %field_index, 0
+  br i1 %fe.index_ok, label %fe.lookup, label %fe.no
+
+fe.lookup:
+  %fe.aid = call i64 @value_payload(%Value %atom_value)
+  %fe.str = call i8* @wam_atom_to_string(i64 %fe.aid)
+  %fe.null = icmp eq i8* %fe.str, null
+  br i1 %fe.null, label %fe.no, label %fe.find_loop
+
+fe.find_loop:
+  %fe.cur_index = phi i64 [ 1, %fe.lookup ], [ %fe.next_index, %fe.after_sep ]
+  %fe.start_pos = phi i64 [ 0, %fe.lookup ], [ %fe.after_sep_pos, %fe.after_sep ]
+  %fe.index_match = icmp eq i64 %fe.cur_index, %field_index
+  br i1 %fe.index_match, label %fe.compare_loop, label %fe.skip_loop
+
+fe.skip_loop:
+  %fe.skip_pos = phi i64 [ %fe.start_pos, %fe.find_loop ], [ %fe.skip_next_pos, %fe.skip_next ]
+  %fe.skip_ptr = getelementptr i8, i8* %fe.str, i64 %fe.skip_pos
+  %fe.skip_ch = load i8, i8* %fe.skip_ptr
+  %fe.skip_nul = icmp eq i8 %fe.skip_ch, 0
+  br i1 %fe.skip_nul, label %fe.no, label %fe.skip_check_sep
+
+fe.skip_check_sep:
+  %fe.skip_is_sep = icmp eq i8 %fe.skip_ch, %sep
+  br i1 %fe.skip_is_sep, label %fe.after_sep, label %fe.skip_next
+
+fe.skip_next:
+  %fe.skip_next_pos = add i64 %fe.skip_pos, 1
+  br label %fe.skip_loop
+
+fe.after_sep:
+  %fe.after_sep_pos = add i64 %fe.skip_pos, 1
+  %fe.next_index = add i64 %fe.cur_index, 1
+  br label %fe.find_loop
+
+fe.compare_loop:
+  %fe.i = phi i64 [ 0, %fe.find_loop ], [ %fe.next_i, %fe.compare_step ]
+  %fe.pos = phi i64 [ %fe.start_pos, %fe.find_loop ], [ %fe.next_pos, %fe.compare_step ]
+  %fe.done = icmp uge i64 %fe.i, %expected_len
+  br i1 %fe.done, label %fe.check_end, label %fe.compare_char
+
+fe.compare_char:
+  %fe.line_ptr = getelementptr i8, i8* %fe.str, i64 %fe.pos
+  %fe.exp_ptr = getelementptr i8, i8* %expected, i64 %fe.i
+  %fe.line_ch = load i8, i8* %fe.line_ptr
+  %fe.exp_ch = load i8, i8* %fe.exp_ptr
+  %fe.line_nonzero = icmp ne i8 %fe.line_ch, 0
+  %fe.line_not_sep = icmp ne i8 %fe.line_ch, %sep
+  %fe.eq = icmp eq i8 %fe.line_ch, %fe.exp_ch
+  %fe.live = and i1 %fe.line_nonzero, %fe.line_not_sep
+  %fe.match = and i1 %fe.live, %fe.eq
+  br i1 %fe.match, label %fe.compare_step, label %fe.no
+
+fe.compare_step:
+  %fe.next_i = add i64 %fe.i, 1
+  %fe.next_pos = add i64 %fe.pos, 1
+  br label %fe.compare_loop
+
+fe.check_end:
+  %fe.end_ptr = getelementptr i8, i8* %fe.str, i64 %fe.pos
+  %fe.end_ch = load i8, i8* %fe.end_ptr
+  %fe.end_nul = icmp eq i8 %fe.end_ch, 0
+  %fe.end_sep = icmp eq i8 %fe.end_ch, %sep
+  %fe.end_ok = or i1 %fe.end_nul, %fe.end_sep
+  br i1 %fe.end_ok, label %fe.yes, label %fe.no
+
+fe.yes:
+  ret i1 true
+
+fe.no:
+  ret i1 false
+}
+
 ; Dispatches on integer op codes:
 ;   0 = is/2, 1 = >/2, 2 = </2, 3 = >=/2, 4 = =</2
 ;   5 = =:=/2, 6 = =\=/2, 7 = ==/2, 8 = true/0, 9 = fail/0

--- a/examples/plawk/generated/plawk_meta_call_probe.ll
+++ b/examples/plawk/generated/plawk_meta_call_probe.ll
@@ -6632,6 +6632,124 @@ sch.close:
   ret i1 %sch.ok
 }
 
+define i1 @wam_atom_prefix_value(%Value %atom_value, i8* %prefix, i64 %prefix_len) {
+entry:
+  %ap.t = call i32 @value_tag(%Value %atom_value)
+  %ap.is_atom = icmp eq i32 %ap.t, 0
+  br i1 %ap.is_atom, label %ap.lookup, label %ap.no
+
+ap.lookup:
+  %ap.aid = call i64 @value_payload(%Value %atom_value)
+  %ap.str = call i8* @wam_atom_to_string(i64 %ap.aid)
+  %ap.null = icmp eq i8* %ap.str, null
+  br i1 %ap.null, label %ap.no, label %ap.loop
+
+ap.loop:
+  %ap.i = phi i64 [ 0, %ap.lookup ], [ %ap.next, %ap.step_ok ]
+  %ap.done = icmp uge i64 %ap.i, %prefix_len
+  br i1 %ap.done, label %ap.yes, label %ap.step
+
+ap.step:
+  %ap.sp = getelementptr i8, i8* %ap.str, i64 %ap.i
+  %ap.pp = getelementptr i8, i8* %prefix, i64 %ap.i
+  %ap.sc = load i8, i8* %ap.sp
+  %ap.pc = load i8, i8* %ap.pp
+  %ap.nonzero = icmp ne i8 %ap.sc, 0
+  %ap.eq = icmp eq i8 %ap.sc, %ap.pc
+  %ap.match = and i1 %ap.nonzero, %ap.eq
+  br i1 %ap.match, label %ap.step_ok, label %ap.no
+
+ap.step_ok:
+  %ap.next = add i64 %ap.i, 1
+  br label %ap.loop
+
+ap.yes:
+  ret i1 true
+
+ap.no:
+  ret i1 false
+}
+
+define i1 @wam_atom_field_eq_value(%Value %atom_value, i64 %field_index, i8* %expected, i64 %expected_len, i8 %sep) {
+entry:
+  %fe.t = call i32 @value_tag(%Value %atom_value)
+  %fe.is_atom = icmp eq i32 %fe.t, 0
+  br i1 %fe.is_atom, label %fe.check_index, label %fe.no
+
+fe.check_index:
+  %fe.index_ok = icmp sgt i64 %field_index, 0
+  br i1 %fe.index_ok, label %fe.lookup, label %fe.no
+
+fe.lookup:
+  %fe.aid = call i64 @value_payload(%Value %atom_value)
+  %fe.str = call i8* @wam_atom_to_string(i64 %fe.aid)
+  %fe.null = icmp eq i8* %fe.str, null
+  br i1 %fe.null, label %fe.no, label %fe.find_loop
+
+fe.find_loop:
+  %fe.cur_index = phi i64 [ 1, %fe.lookup ], [ %fe.next_index, %fe.after_sep ]
+  %fe.start_pos = phi i64 [ 0, %fe.lookup ], [ %fe.after_sep_pos, %fe.after_sep ]
+  %fe.index_match = icmp eq i64 %fe.cur_index, %field_index
+  br i1 %fe.index_match, label %fe.compare_loop, label %fe.skip_loop
+
+fe.skip_loop:
+  %fe.skip_pos = phi i64 [ %fe.start_pos, %fe.find_loop ], [ %fe.skip_next_pos, %fe.skip_next ]
+  %fe.skip_ptr = getelementptr i8, i8* %fe.str, i64 %fe.skip_pos
+  %fe.skip_ch = load i8, i8* %fe.skip_ptr
+  %fe.skip_nul = icmp eq i8 %fe.skip_ch, 0
+  br i1 %fe.skip_nul, label %fe.no, label %fe.skip_check_sep
+
+fe.skip_check_sep:
+  %fe.skip_is_sep = icmp eq i8 %fe.skip_ch, %sep
+  br i1 %fe.skip_is_sep, label %fe.after_sep, label %fe.skip_next
+
+fe.skip_next:
+  %fe.skip_next_pos = add i64 %fe.skip_pos, 1
+  br label %fe.skip_loop
+
+fe.after_sep:
+  %fe.after_sep_pos = add i64 %fe.skip_pos, 1
+  %fe.next_index = add i64 %fe.cur_index, 1
+  br label %fe.find_loop
+
+fe.compare_loop:
+  %fe.i = phi i64 [ 0, %fe.find_loop ], [ %fe.next_i, %fe.compare_step ]
+  %fe.pos = phi i64 [ %fe.start_pos, %fe.find_loop ], [ %fe.next_pos, %fe.compare_step ]
+  %fe.done = icmp uge i64 %fe.i, %expected_len
+  br i1 %fe.done, label %fe.check_end, label %fe.compare_char
+
+fe.compare_char:
+  %fe.line_ptr = getelementptr i8, i8* %fe.str, i64 %fe.pos
+  %fe.exp_ptr = getelementptr i8, i8* %expected, i64 %fe.i
+  %fe.line_ch = load i8, i8* %fe.line_ptr
+  %fe.exp_ch = load i8, i8* %fe.exp_ptr
+  %fe.line_nonzero = icmp ne i8 %fe.line_ch, 0
+  %fe.line_not_sep = icmp ne i8 %fe.line_ch, %sep
+  %fe.eq = icmp eq i8 %fe.line_ch, %fe.exp_ch
+  %fe.live = and i1 %fe.line_nonzero, %fe.line_not_sep
+  %fe.match = and i1 %fe.live, %fe.eq
+  br i1 %fe.match, label %fe.compare_step, label %fe.no
+
+fe.compare_step:
+  %fe.next_i = add i64 %fe.i, 1
+  %fe.next_pos = add i64 %fe.pos, 1
+  br label %fe.compare_loop
+
+fe.check_end:
+  %fe.end_ptr = getelementptr i8, i8* %fe.str, i64 %fe.pos
+  %fe.end_ch = load i8, i8* %fe.end_ptr
+  %fe.end_nul = icmp eq i8 %fe.end_ch, 0
+  %fe.end_sep = icmp eq i8 %fe.end_ch, %sep
+  %fe.end_ok = or i1 %fe.end_nul, %fe.end_sep
+  br i1 %fe.end_ok, label %fe.yes, label %fe.no
+
+fe.yes:
+  ret i1 true
+
+fe.no:
+  ret i1 false
+}
+
 ; Dispatches on integer op codes:
 ;   0 = is/2, 1 = >/2, 2 = </2, 3 = >=/2, 4 = =</2
 ;   5 = =:=/2, 6 = =\=/2, 7 = ==/2, 8 = true/0, 9 = fail/0

--- a/examples/plawk/generated/plawk_reader_probe.ll
+++ b/examples/plawk/generated/plawk_reader_probe.ll
@@ -6632,6 +6632,124 @@ sch.close:
   ret i1 %sch.ok
 }
 
+define i1 @wam_atom_prefix_value(%Value %atom_value, i8* %prefix, i64 %prefix_len) {
+entry:
+  %ap.t = call i32 @value_tag(%Value %atom_value)
+  %ap.is_atom = icmp eq i32 %ap.t, 0
+  br i1 %ap.is_atom, label %ap.lookup, label %ap.no
+
+ap.lookup:
+  %ap.aid = call i64 @value_payload(%Value %atom_value)
+  %ap.str = call i8* @wam_atom_to_string(i64 %ap.aid)
+  %ap.null = icmp eq i8* %ap.str, null
+  br i1 %ap.null, label %ap.no, label %ap.loop
+
+ap.loop:
+  %ap.i = phi i64 [ 0, %ap.lookup ], [ %ap.next, %ap.step_ok ]
+  %ap.done = icmp uge i64 %ap.i, %prefix_len
+  br i1 %ap.done, label %ap.yes, label %ap.step
+
+ap.step:
+  %ap.sp = getelementptr i8, i8* %ap.str, i64 %ap.i
+  %ap.pp = getelementptr i8, i8* %prefix, i64 %ap.i
+  %ap.sc = load i8, i8* %ap.sp
+  %ap.pc = load i8, i8* %ap.pp
+  %ap.nonzero = icmp ne i8 %ap.sc, 0
+  %ap.eq = icmp eq i8 %ap.sc, %ap.pc
+  %ap.match = and i1 %ap.nonzero, %ap.eq
+  br i1 %ap.match, label %ap.step_ok, label %ap.no
+
+ap.step_ok:
+  %ap.next = add i64 %ap.i, 1
+  br label %ap.loop
+
+ap.yes:
+  ret i1 true
+
+ap.no:
+  ret i1 false
+}
+
+define i1 @wam_atom_field_eq_value(%Value %atom_value, i64 %field_index, i8* %expected, i64 %expected_len, i8 %sep) {
+entry:
+  %fe.t = call i32 @value_tag(%Value %atom_value)
+  %fe.is_atom = icmp eq i32 %fe.t, 0
+  br i1 %fe.is_atom, label %fe.check_index, label %fe.no
+
+fe.check_index:
+  %fe.index_ok = icmp sgt i64 %field_index, 0
+  br i1 %fe.index_ok, label %fe.lookup, label %fe.no
+
+fe.lookup:
+  %fe.aid = call i64 @value_payload(%Value %atom_value)
+  %fe.str = call i8* @wam_atom_to_string(i64 %fe.aid)
+  %fe.null = icmp eq i8* %fe.str, null
+  br i1 %fe.null, label %fe.no, label %fe.find_loop
+
+fe.find_loop:
+  %fe.cur_index = phi i64 [ 1, %fe.lookup ], [ %fe.next_index, %fe.after_sep ]
+  %fe.start_pos = phi i64 [ 0, %fe.lookup ], [ %fe.after_sep_pos, %fe.after_sep ]
+  %fe.index_match = icmp eq i64 %fe.cur_index, %field_index
+  br i1 %fe.index_match, label %fe.compare_loop, label %fe.skip_loop
+
+fe.skip_loop:
+  %fe.skip_pos = phi i64 [ %fe.start_pos, %fe.find_loop ], [ %fe.skip_next_pos, %fe.skip_next ]
+  %fe.skip_ptr = getelementptr i8, i8* %fe.str, i64 %fe.skip_pos
+  %fe.skip_ch = load i8, i8* %fe.skip_ptr
+  %fe.skip_nul = icmp eq i8 %fe.skip_ch, 0
+  br i1 %fe.skip_nul, label %fe.no, label %fe.skip_check_sep
+
+fe.skip_check_sep:
+  %fe.skip_is_sep = icmp eq i8 %fe.skip_ch, %sep
+  br i1 %fe.skip_is_sep, label %fe.after_sep, label %fe.skip_next
+
+fe.skip_next:
+  %fe.skip_next_pos = add i64 %fe.skip_pos, 1
+  br label %fe.skip_loop
+
+fe.after_sep:
+  %fe.after_sep_pos = add i64 %fe.skip_pos, 1
+  %fe.next_index = add i64 %fe.cur_index, 1
+  br label %fe.find_loop
+
+fe.compare_loop:
+  %fe.i = phi i64 [ 0, %fe.find_loop ], [ %fe.next_i, %fe.compare_step ]
+  %fe.pos = phi i64 [ %fe.start_pos, %fe.find_loop ], [ %fe.next_pos, %fe.compare_step ]
+  %fe.done = icmp uge i64 %fe.i, %expected_len
+  br i1 %fe.done, label %fe.check_end, label %fe.compare_char
+
+fe.compare_char:
+  %fe.line_ptr = getelementptr i8, i8* %fe.str, i64 %fe.pos
+  %fe.exp_ptr = getelementptr i8, i8* %expected, i64 %fe.i
+  %fe.line_ch = load i8, i8* %fe.line_ptr
+  %fe.exp_ch = load i8, i8* %fe.exp_ptr
+  %fe.line_nonzero = icmp ne i8 %fe.line_ch, 0
+  %fe.line_not_sep = icmp ne i8 %fe.line_ch, %sep
+  %fe.eq = icmp eq i8 %fe.line_ch, %fe.exp_ch
+  %fe.live = and i1 %fe.line_nonzero, %fe.line_not_sep
+  %fe.match = and i1 %fe.live, %fe.eq
+  br i1 %fe.match, label %fe.compare_step, label %fe.no
+
+fe.compare_step:
+  %fe.next_i = add i64 %fe.i, 1
+  %fe.next_pos = add i64 %fe.pos, 1
+  br label %fe.compare_loop
+
+fe.check_end:
+  %fe.end_ptr = getelementptr i8, i8* %fe.str, i64 %fe.pos
+  %fe.end_ch = load i8, i8* %fe.end_ptr
+  %fe.end_nul = icmp eq i8 %fe.end_ch, 0
+  %fe.end_sep = icmp eq i8 %fe.end_ch, %sep
+  %fe.end_ok = or i1 %fe.end_nul, %fe.end_sep
+  br i1 %fe.end_ok, label %fe.yes, label %fe.no
+
+fe.yes:
+  ret i1 true
+
+fe.no:
+  ret i1 false
+}
+
 ; Dispatches on integer op codes:
 ;   0 = is/2, 1 = >/2, 2 = </2, 3 = >=/2, 4 = =</2
 ;   5 = =:=/2, 6 = =\=/2, 7 = ==/2, 8 = true/0, 9 = fail/0

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -10,6 +10,7 @@
 %  Parse the first Phase-2 surface slice:
 %
 %      /^PREFIX/ { print $0 }
+%      $N == "VALUE" { print $0 }
 %
 %  The AST is deliberately small and explicit so later syntax can extend it
 %  without changing the native codegen contract.
@@ -18,9 +19,9 @@ plawk_parse_string(Source, Program) :-
     string_codes(Source, Codes),
     phrase(plawk_program(Program), Codes).
 
-plawk_program(program([], [rule(prefix(Prefix), [print(field(0))])], [])) -->
+plawk_program(program([], [rule(Pattern, [print(field(0))])], [])) -->
     ws,
-    prefix_pattern(Prefix),
+    pattern(Pattern),
     ws,
     "{",
     ws,
@@ -30,12 +31,32 @@ plawk_program(program([], [rule(prefix(Prefix), [print(field(0))])], [])) -->
     ws,
     eos.
 
-prefix_pattern(Prefix) -->
+pattern(Pattern) -->
+    prefix_pattern(Pattern),
+    !.
+pattern(Pattern) -->
+    field_eq_pattern(Pattern).
+
+prefix_pattern(prefix(Prefix)) -->
     "/^",
     prefix_codes(Codes),
     "/",
     { Codes \== [],
       string_codes(Prefix, Codes)
+    }.
+
+field_eq_pattern(field_eq(Index, Value)) -->
+    "$",
+    integer_codes(IndexCodes),
+    ws,
+    "==",
+    ws,
+    quoted_string(ValueCodes),
+    { IndexCodes \== [],
+      number_codes(Index, IndexCodes),
+      Index > 0,
+      ValueCodes \== [],
+      string_codes(Value, ValueCodes)
     }.
 
 prefix_codes([Code | Codes]) -->
@@ -55,6 +76,32 @@ prefix_codes_rest([Code | Codes]) -->
     !,
     prefix_codes_rest(Codes).
 prefix_codes_rest([]) -->
+    [].
+
+integer_codes([Code | Codes]) -->
+    [Code],
+    { code_type(Code, digit) },
+    integer_codes_rest(Codes).
+
+integer_codes_rest([Code | Codes]) -->
+    [Code],
+    { code_type(Code, digit) },
+    !,
+    integer_codes_rest(Codes).
+integer_codes_rest([]) -->
+    [].
+
+quoted_string(Codes) -->
+    "\"",
+    quoted_string_codes(Codes),
+    "\"".
+
+quoted_string_codes([Code | Codes]) -->
+    [Code],
+    { Code =\= 0'", Code =\= 0'\n, Code =\= 0'\r },
+    !,
+    quoted_string_codes(Codes).
+quoted_string_codes([]) -->
     [].
 
 print_field_zero -->

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -45,7 +45,8 @@
     sanitize_functor_for_llvm/2,         % +Name, -SaneName (bijective hex escape)
     register_functor_string/1,           % +NameStr (assert into functor_string_global table)
     split_functor_arity/3,               % +Str, -Name, -Arity (handles `/` in name)
-    llvm_emit_atom_prefix_guard/5        % +GlobalBase, +ValueIR, +Prefix, +ResultIR, -GlobalIR-CallIR
+    llvm_emit_atom_prefix_guard/5,       % +GlobalBase, +ValueIR, +Prefix, +ResultIR, -GlobalIR-CallIR
+    llvm_emit_atom_field_eq_guard/7      % +GlobalBase, +ValueIR, +FieldIndex, +Expected, +SepCode, +ResultIR, -GlobalIR-CallIR
 ]).
 
 :- use_module(library(lists)).
@@ -4225,6 +4226,86 @@ ap.yes:
   ret i1 true
 
 ap.no:
+  ret i1 false
+}
+
+define i1 @wam_atom_field_eq_value(%Value %atom_value, i64 %field_index, i8* %expected, i64 %expected_len, i8 %sep) {
+entry:
+  %fe.t = call i32 @value_tag(%Value %atom_value)
+  %fe.is_atom = icmp eq i32 %fe.t, 0
+  br i1 %fe.is_atom, label %fe.check_index, label %fe.no
+
+fe.check_index:
+  %fe.index_ok = icmp sgt i64 %field_index, 0
+  br i1 %fe.index_ok, label %fe.lookup, label %fe.no
+
+fe.lookup:
+  %fe.aid = call i64 @value_payload(%Value %atom_value)
+  %fe.str = call i8* @wam_atom_to_string(i64 %fe.aid)
+  %fe.null = icmp eq i8* %fe.str, null
+  br i1 %fe.null, label %fe.no, label %fe.find_loop
+
+fe.find_loop:
+  %fe.cur_index = phi i64 [ 1, %fe.lookup ], [ %fe.next_index, %fe.after_sep ]
+  %fe.start_pos = phi i64 [ 0, %fe.lookup ], [ %fe.after_sep_pos, %fe.after_sep ]
+  %fe.index_match = icmp eq i64 %fe.cur_index, %field_index
+  br i1 %fe.index_match, label %fe.compare_loop, label %fe.skip_loop
+
+fe.skip_loop:
+  %fe.skip_pos = phi i64 [ %fe.start_pos, %fe.find_loop ], [ %fe.skip_next_pos, %fe.skip_next ]
+  %fe.skip_ptr = getelementptr i8, i8* %fe.str, i64 %fe.skip_pos
+  %fe.skip_ch = load i8, i8* %fe.skip_ptr
+  %fe.skip_nul = icmp eq i8 %fe.skip_ch, 0
+  br i1 %fe.skip_nul, label %fe.no, label %fe.skip_check_sep
+
+fe.skip_check_sep:
+  %fe.skip_is_sep = icmp eq i8 %fe.skip_ch, %sep
+  br i1 %fe.skip_is_sep, label %fe.after_sep, label %fe.skip_next
+
+fe.skip_next:
+  %fe.skip_next_pos = add i64 %fe.skip_pos, 1
+  br label %fe.skip_loop
+
+fe.after_sep:
+  %fe.after_sep_pos = add i64 %fe.skip_pos, 1
+  %fe.next_index = add i64 %fe.cur_index, 1
+  br label %fe.find_loop
+
+fe.compare_loop:
+  %fe.i = phi i64 [ 0, %fe.find_loop ], [ %fe.next_i, %fe.compare_step ]
+  %fe.pos = phi i64 [ %fe.start_pos, %fe.find_loop ], [ %fe.next_pos, %fe.compare_step ]
+  %fe.done = icmp uge i64 %fe.i, %expected_len
+  br i1 %fe.done, label %fe.check_end, label %fe.compare_char
+
+fe.compare_char:
+  %fe.line_ptr = getelementptr i8, i8* %fe.str, i64 %fe.pos
+  %fe.exp_ptr = getelementptr i8, i8* %expected, i64 %fe.i
+  %fe.line_ch = load i8, i8* %fe.line_ptr
+  %fe.exp_ch = load i8, i8* %fe.exp_ptr
+  %fe.line_nonzero = icmp ne i8 %fe.line_ch, 0
+  %fe.line_not_sep = icmp ne i8 %fe.line_ch, %sep
+  %fe.eq = icmp eq i8 %fe.line_ch, %fe.exp_ch
+  %fe.live = and i1 %fe.line_nonzero, %fe.line_not_sep
+  %fe.match = and i1 %fe.live, %fe.eq
+  br i1 %fe.match, label %fe.compare_step, label %fe.no
+
+fe.compare_step:
+  %fe.next_i = add i64 %fe.i, 1
+  %fe.next_pos = add i64 %fe.pos, 1
+  br label %fe.compare_loop
+
+fe.check_end:
+  %fe.end_ptr = getelementptr i8, i8* %fe.str, i64 %fe.pos
+  %fe.end_ch = load i8, i8* %fe.end_ptr
+  %fe.end_nul = icmp eq i8 %fe.end_ch, 0
+  %fe.end_sep = icmp eq i8 %fe.end_ch, %sep
+  %fe.end_ok = or i1 %fe.end_nul, %fe.end_sep
+  br i1 %fe.end_ok, label %fe.yes, label %fe.no
+
+fe.yes:
+  ret i1 true
+
+fe.no:
   ret i1 false
 }
 
@@ -15629,6 +15710,25 @@ llvm_emit_atom_prefix_guard(GlobalBase, ValueIR, Prefix, ResultIR, GlobalIR-Call
         '  %~w_ptr = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0~n  ~w = call i1 @wam_atom_prefix_value(%Value ~w, i8* %~w_ptr, i64 ~w)',
         [SafeBase, ArrLen, ArrLen, SafeBase,
          ResultIR, ValueIR, SafeBase, PrefixLen]).
+
+%% llvm_emit_atom_field_eq_guard(+GlobalBase, +ValueIR, +FieldIndex, +Expected, +SepCode, +ResultIR, -GlobalIR-CallIR)
+%
+%  Emit a reusable native field-equality guard for deterministic
+%  item_field(Index, Item, Expected)-style lowering over atom-backed text
+%  records. FieldIndex is one-based, SepCode is the single-byte field
+%  separator, and Expected is emitted as an LLVM constant without allocating
+%  substrings in the hot loop.
+llvm_emit_atom_field_eq_guard(GlobalBase, ValueIR, FieldIndex, Expected, SepCode, ResultIR, GlobalIR-CallIR) :-
+    sanitize_functor_for_llvm(GlobalBase, SafeBase),
+    escape_llvm_string(Expected, EscapedExpected, ExpectedLen),
+    ArrLen is ExpectedLen + 1,
+    format(atom(GlobalIR),
+        '@.~w = private constant [~w x i8] c"~w\\00"',
+        [SafeBase, ArrLen, EscapedExpected]),
+    format(atom(CallIR),
+        '  %~w_ptr = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0~n  ~w = call i1 @wam_atom_field_eq_value(%Value ~w, i64 ~w, i8* %~w_ptr, i64 ~w, i8 ~w)',
+        [SafeBase, ArrLen, ArrLen, SafeBase,
+         ResultIR, ValueIR, FieldIndex, SafeBase, ExpectedLen, SepCode]).
 
 escape_llvm_codes([], []).
 escape_llvm_codes([C|Cs], Out) :-

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -25,7 +25,21 @@ test(parses_prefix_print_rule) :-
     plawk_parse_string("/^ERROR/ { print $0 }\n", Program),
     assertion(Program == program([], [rule(prefix("ERROR"), [print(field(0))])], [])).
 
+test(parses_field_eq_print_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { print $0 }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"), [print(field(0))])], [])).
+
 test(surface_prefix_prints_matching_records) :-
+    run_surface_print_smoke("/^ERROR/ { print $0 }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "ERROR disk full\nERROR net down\n").
+
+test(surface_field_eq_prints_matching_records) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { print $0 }\n",
+        "INFO boot ok\nNOTERROR misleading\nWARN cpu hot\nERROR net down\n",
+        "ERROR net down\n").
+
+run_surface_print_smoke(Source, Input, ExpectedOutput) :-
     tmp_root(Root),
     directory_file_path(Root, 'uw_plawk_surface_prefix_print', Dir),
     clean_dir(Dir),
@@ -33,9 +47,9 @@ test(surface_prefix_prints_matching_records) :-
     directory_file_path(Dir, 'input.txt', InputPath),
     setup_call_cleanup(
         open(InputPath, write, In, [type(binary)]),
-        format(In, 'INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n', []),
+        format(In, '~s', [Input]),
         close(In)),
-    plawk_parse_string("/^ERROR/ { print $0 }\n", Program),
+    plawk_parse_string(Source, Program),
     plawk_program_native_driver_ir(Program, InputPath, DriverIR),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     directory_file_path(Dir, 'plawk_surface_prefix_print.ll', LLPath),
@@ -55,7 +69,7 @@ test(surface_prefix_prints_matching_records) :-
     close(Stdout),
     process_wait(Pid, Status),
     ( Status == exit(0)
-    -> assertion(OutStr == "ERROR disk full\nERROR net down\n")
+    -> assertion(OutStr == ExpectedOutput)
     ;  format(user_error, "~n[plawk surface prefix print output]~n~w~n",
               [OutStr]),
        throw(plawk_surface_prefix_print_failed(Status))

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -194,6 +194,7 @@ test(full_runtime_generation) :-
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @step')),
     % Helpers
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @backtrack')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_field_eq_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_prefix_value')).
 
 test(atom_prefix_guard_emitter) :-
@@ -202,6 +203,13 @@ test(atom_prefix_guard_emitter) :-
     assertion(sub_atom(CallIR, _, _, _, '%prefix_5Fguard_5Ftest_ptr = getelementptr')),
     assertion(sub_atom(CallIR, _, _, _, '%ok = call i1 @wam_atom_prefix_value(%Value %line')),
     assertion(sub_atom(CallIR, _, _, _, 'i64 5')).
+
+test(atom_field_eq_guard_emitter) :-
+    llvm_emit_atom_field_eq_guard(field_eq_guard_test, '%line', 1, 'ERROR', 32, '%ok', GlobalIR-CallIR),
+    assertion(sub_atom(GlobalIR, _, _, _, '@.field_5Feq_5Fguard_5Ftest = private constant [6 x i8] c"ERROR\\00"')),
+    assertion(sub_atom(CallIR, _, _, _, '%field_5Feq_5Fguard_5Ftest_ptr = getelementptr')),
+    assertion(sub_atom(CallIR, _, _, _, '%ok = call i1 @wam_atom_field_eq_value(%Value %line, i64 1')),
+    assertion(sub_atom(CallIR, _, _, _, 'i64 5, i8 32')).
 
 % ============================================================================
 % Builtin op ID mapping


### PR DESCRIPTION
## Summary

- Add `@wam_atom_field_eq_value` as a native WAM/LLVM runtime helper for one-based field equality over atom-backed text records.
- Add `llvm_emit_atom_field_eq_guard/7` so deterministic field equality guards can be emitted without allocating field substrings.
- Extend the PLAWK surface parser/codegen from `/^PREFIX/ { print $0 }` to also support `$N == "VALUE" { print $0 }`.
- Extend the PLAWK surface smoke to compile and run `$1 == "ERROR" { print $0 }`, proving the generated native stream loop filters fields without calling `run_loop` in the hot record path.
- Regenerate tracked PLAWK `.ll` probes so the runtime snapshot includes the new helper.

## Notes

- The new field guard currently uses a single-byte field separator; the PLAWK surface codegen passes ASCII space (`i8 32`) for the current default field split.

## Validation

- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/test_plawk_native_lowered_handler_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s examples/plawk/probes/generate_core_probe.pl -t halt`
- `swipl -q -s examples/plawk/probes/generate_loop_probe.pl -t halt`
- `swipl -q -s examples/plawk/probes/generate_meta_call_probe.pl -t halt`
- `swipl -q -s examples/plawk/probes/generate_reader_probe.pl -t halt`
- `llvm-as examples/plawk/generated/plawk_core_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_loop_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_meta_call_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_reader_probe.ll -o /dev/null`
- `git diff --check`
- `git diff --cached --check`