### PR TITLE
WAM Rust: ISO catch/throw + succ/2, and a latent PutStructure bind-through fix (parity P4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **WAM Rust target: ISO catch/3, throw/1 and succ/2 (parity P4).**
+  Completes the F#-parity control-flow milestone. Mechanism (mutable
+  WamState in place of F#'s exception + immutable-snapshot design): a
+  `thrown_ball: Option<Value>` field set by `throw/1`; the run loop
+  treats a failing step with a ball in flight as an abort (no
+  backtracking — alternatives are discarded until a catch consumes the
+  ball); `catch/3` snapshots regs/trail/heap/stack/choice-point depth,
+  meta-calls the goal (builtin dispatch first, then labelled-predicate
+  sub-run — the negation architecture), and on a ball restores the
+  snapshot, unifies the catcher (rethrowing on mismatch for an outer
+  catch), and runs the recovery goal. First-solution semantics, like
+  the F# port. Since the shared WAM compiler emits these as
+  Call/Execute (no `is_builtin_pred` entry), the Call and Execute arms
+  gained an ISO meta-builtin fallback (`is_iso_meta_builtin`,
+  mirroring F#'s `isIsoMetaBuiltin` routing) — which also delivers the
+  previously deferred bidirectional `succ/2`. 8 new cargo-built tests:
+  matching/non-matching catchers, propagation through nested predicate
+  calls, nested catch rethrow, transparency without a throw,
+  plain-goal-failure, and succ both modes + edge cases.
+
+### Fixed
+- **WAM Rust target: PutStructure bound A-register old occupants
+  through to the new cell (M139/M140 bind-through class, latent).**
+  Building a goal structure into an A register whose old occupant was
+  a still-live variable (e.g. `p(X) :- catch(member(X, L), ...)` —
+  X in A1, then the goal structure built into A1 with X as an
+  argument) bound X to the structure's own heap cell, creating a
+  cyclic term (`X = member(X, L)`) on which `deref_heap` recursed to
+  stack overflow. Same defect class the LLVM target fixed in M140;
+  same fix: the bind-through (needed for top-down structure chaining
+  placeholders, which only live in X/Y registers) is now conditioned
+  on the register class — A registers are argument staging and never
+  bind. Exposed by the catch/3 tests; all existing suites pass
+  unchanged.
 - **WAM Rust target: builtin parity sweep (F# parity campaign P3).**
   New `execute_ext_builtin` dispatch tier closes the largest
   builtin-coverage gap vs the F# target — every op below was already

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -337,9 +337,21 @@ wam_instruction_arm('Instruction::PutStructure(fn_str, ai)', Body) :-
                 // new structure so the embedded copy resolves here. The compiler
                 // builds nested terms outer-first — +(+(A,B),C), or a list tail
                 // cell — leaving a placeholder a later put_structure must fill.
-                if let Some(cur) = self.get_reg_raw(ai) {
-                    if let Value::Unbound(name) = self.deref_var(&cur) {
-                        self.bind_var(&name, Value::Ref(addr));
+                //
+                // A-REGISTER EXCEPTION (M139/M140 bind-through class): A
+                // registers are argument STAGING — their old occupant is an
+                // unrelated variable (often a clause-head argument), and
+                // binding it to the new cell creates a cyclic term
+                // (X = f(X), then deref_heap recurses forever). Top-down
+                // chaining placeholders only ever live in X/Y registers
+                // (set_variable Xn), so the bind-through is conditioned on
+                // the register class — the same design the LLVM target
+                // adopted in M140 after the identical bug.
+                if ai.as_bytes().first() != Some(&b''A'') {
+                    if let Some(cur) = self.get_reg_raw(ai) {
+                        if let Value::Unbound(name) = self.deref_var(&cur) {
+                            self.bind_var(&name, Value::Ref(addr));
+                        }
                     }
                 }
                 self.set_reg_str(ai, Value::Ref(addr));
@@ -660,6 +672,12 @@ wam_instruction_arm('Instruction::Call(p, _arity)', Body) :-
                         self.pc = self.cp;
                         true
                     } else { false }
+                } else if Self::is_iso_meta_builtin(p) {
+                    // ISO meta-builtins (catch/3, throw/1, succ/2) are
+                    // emitted by the shared WAM compiler as Call rather
+                    // than BuiltinCall; route them through the builtin
+                    // dispatch (mirrors the F# isIsoMetaBuiltin arm).
+                    self.execute_builtin(p, *_arity)
                 } else { false }'.
 
 wam_instruction_arm('Instruction::CallPc(target_pc, _arity)', Body) :-
@@ -712,6 +730,15 @@ wam_instruction_arm('Instruction::Execute(p)', Body) :-
                     true
                 } else if self.foreign_predicates.contains(p) {
                     self.execute_foreign_predicate(p, 0)
+                } else if Self::is_iso_meta_builtin(p) {
+                    // Tail-position ISO meta-builtin: dispatch, then honor
+                    // return semantics by jumping to the continuation.
+                    let arity: usize = p.rsplit(\'/\').next()
+                        .and_then(|a| a.parse().ok()).unwrap_or(0);
+                    if self.execute_builtin(p, arity) {
+                        self.pc = self.cp;
+                        true
+                    } else { false }
                 } else { false }'.
 
 wam_instruction_arm('Instruction::ExecutePc(target_pc)', Body) :-
@@ -1056,6 +1083,10 @@ compile_run_loop_to_rust(Code) :-
             }
             if let Some(instr) = self.fetch().cloned() {
                 if !self.step(&instr) {
+                    // ISO throw in flight: abort instead of backtracking —
+                    // alternatives are discarded until a catch/3 frame
+                    // (in a caller) consumes the ball.
+                    if self.thrown_ball.is_some() { return false; }
                     if !self.backtrack() { return false; }
                 }
                 self.step_count += 1;
@@ -3549,6 +3580,25 @@ compile_execute_ext_builtin_to_rust(Code) :-
                     _ => false,
                 }
             }
+            "succ/2" => {
+                // Bidirectional natural-number successor: succ(X, Y) iff
+                // Y = X + 1, X >= 0, Y >= 1. Reached via the ISO
+                // meta-builtin Call fallback (the shared compiler emits
+                // call succ/2, not builtin_call).
+                let v1 = self.get_reg_raw("A1").map(|v| self.deref_var(&v)).unwrap_or(Value::Uninit);
+                let v2 = self.get_reg_raw("A2").map(|v| self.deref_var(&v)).unwrap_or(Value::Uninit);
+                match (&v1, &v2) {
+                    (Value::Integer(x), _) if *x >= 0 => {
+                        let y = Value::Integer(x + 1);
+                        if self.unify(&v2, &y) { self.pc += 1; true } else { false }
+                    }
+                    (Value::Unbound(_), Value::Integer(y)) if *y >= 1 => {
+                        let x = Value::Integer(y - 1);
+                        if self.unify(&v1, &x) { self.pc += 1; true } else { false }
+                    }
+                    _ => false,
+                }
+            }
             "plus/3" => {
                 let vals: Vec<Value> = ["A1", "A2", "A3"].iter()
                     .map(|r| self.get_reg_raw(r).map(|v| self.deref_var(&v)).unwrap_or(Value::Uninit))
@@ -3826,8 +3876,146 @@ compile_execute_meta_builtin_to_rust(Code) :-
                     _ => false,
                 }
             }
+            "throw/1" => {
+                // ISO throw/1: deep-deref the ball and put it in flight.
+                // The run loop sees the failing step with a pending ball
+                // and aborts instead of backtracking; the nearest catch/3
+                // whose catcher unifies consumes it.
+                let ball = self.get_reg_raw("A1")
+                    .map(|v| self.deref_heap(&self.deref_var(&v)))
+                    .unwrap_or(Value::Atom("instantiation_error".to_string()));
+                self.thrown_ball = Some(ball);
+                false
+            }
+            "catch/3" => {
+                // ISO catch/3 (first-solution semantics, like the F# port):
+                // snapshot, meta-call the goal; on a thrown ball restore
+                // the snapshot, unify the catcher, and run recovery —
+                // rethrowing when the catcher does not unify. Mirrors the
+                // F# CatcherFrame shape with mutable-state restoration in
+                // place of immutable snapshots.
+                let catch_pc = self.pc;
+                let goal = self.get_reg_raw("A1")
+                    .map(|v| self.deref_heap(&self.deref_var(&v)))
+                    .unwrap_or(Value::Uninit);
+                let catcher_raw = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+                let recovery_raw = self.get_reg_raw("A3").unwrap_or(Value::Uninit);
+                let saved_regs = self.save_regs();
+                let trail_mark = self.trail.len();
+                let heap_mark = self.heap.len();
+                let stack_snapshot = self.stack.clone();
+                let cp_depth = self.choice_points.len();
+                let saved_cp = self.cp;
+                let saved_cut = self.cut_barrier;
+                if self.call_goal_value(&goal) {
+                    // Goal succeeded: commit to its first solution
+                    // (bindings carry forward) and advance past catch/3.
+                    self.choice_points.truncate(cp_depth);
+                    self.cp = saved_cp;
+                    self.cut_barrier = saved_cut;
+                    self.pc = catch_pc + 1;
+                    return true;
+                }
+                match self.thrown_ball.take() {
+                    None => {
+                        // Plain goal failure: catch/3 fails. Restore the
+                        // pre-goal view so partial bindings do not leak.
+                        if self.choice_points.len() > cp_depth {
+                            self.choice_points.truncate(cp_depth);
+                        }
+                        self.unwind_trail_to(trail_mark);
+                        self.heap.truncate(heap_mark);
+                        self.stack = stack_snapshot;
+                        self.restore_regs(&saved_regs);
+                        self.cp = saved_cp;
+                        self.cut_barrier = saved_cut;
+                        false
+                    }
+                    Some(ball) => {
+                        if self.choice_points.len() > cp_depth {
+                            self.choice_points.truncate(cp_depth);
+                        }
+                        self.unwind_trail_to(trail_mark);
+                        self.heap.truncate(heap_mark);
+                        self.stack = stack_snapshot;
+                        self.restore_regs(&saved_regs);
+                        self.cp = saved_cp;
+                        self.cut_barrier = saved_cut;
+                        let mark2 = self.trail.len();
+                        if self.unify(&catcher_raw, &ball) {
+                            let recovery = self.deref_heap(&self.deref_var(&recovery_raw));
+                            if self.call_goal_value(&recovery) {
+                                self.pc = catch_pc + 1;
+                                true
+                            } else { false }
+                        } else {
+                            // Catcher does not unify: rethrow for an
+                            // outer catch frame.
+                            self.unwind_trail_to(mark2);
+                            self.thrown_ball = Some(ball);
+                            false
+                        }
+                    }
+                }
+            }
             _ => false,
         }
+    }
+
+    /// Predicates the shared WAM compiler emits as Call/Execute (no
+    /// is_builtin_pred entry) but that this runtime implements as
+    /// builtins. Mirrors the F# isIsoMetaBuiltin routing.
+    fn is_iso_meta_builtin(pred: &str) -> bool {
+        matches!(pred, "catch/3" | "throw/1" | "succ/2")
+    }
+
+    /// Meta-call a goal VALUE (catch/3 goal and recovery, callable
+    /// terms). Atoms true/fail are inlined; other goals dispatch to the
+    /// builtin table first, then to a labelled predicate via a sub-run
+    /// (the same architecture as the general negation path). Returns
+    /// the first solution; on a thrown ball it returns false with the
+    /// ball left in flight for the caller to inspect.
+    fn call_goal_value(&mut self, goal: &Value) -> bool {
+        match goal {
+            Value::Atom(name) if name == "true" => true,
+            Value::Atom(name) if name == "fail" || name == "false" => false,
+            Value::Atom(name) => {
+                let key = format!("{}/0", name);
+                self.call_goal_key(&key, 0, &[])
+            }
+            Value::Str(functor, args) => {
+                let arity = args.len();
+                let name = Self::display_functor_name(functor, arity);
+                let key = format!("{}/{}", name, arity);
+                let dargs: Vec<Value> = args.iter().map(|a| self.deref_var(a)).collect();
+                self.call_goal_key(&key, arity, &dargs)
+            }
+            _ => false,
+        }
+    }
+
+    fn call_goal_key(&mut self, key: &str, arity: usize, args: &[Value]) -> bool {
+        for (i, arg) in args.iter().enumerate() {
+            self.set_reg(&format!("A{}", i + 1), arg.clone());
+        }
+        let saved_pc = self.pc;
+        if self.execute_builtin(key, arity) {
+            self.pc = saved_pc;
+            return true;
+        }
+        if self.thrown_ball.is_some() {
+            return false;
+        }
+        if let Some(&target_pc) = self.labels.get(key) {
+            let saved_cp = self.cp;
+            self.pc = target_pc;
+            self.cp = 0; // halt sentinel for the sub-run
+            let ok = self.run();
+            self.cp = saved_cp;
+            self.pc = saved_pc;
+            return ok;
+        }
+        false
     }'.
 
 compile_resume_naf_to_rust(Code) :-

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -429,6 +429,11 @@ pub struct WamState {
     pub aggregate_acc: Vec<Value>,
     /// Return PC stored by end_aggregate for aggregate-frame finalization.
     pub aggregate_return_pc: usize,
+    /// ISO exception ball: set by throw/1, propagated by the run loop
+    /// (a failing step with a ball pending aborts instead of
+    /// backtracking), consumed by the nearest catch/3 whose catcher
+    /// unifies. None = no exception in flight.
+    pub thrown_ball: Option<Value>,
 }
 
 /// T7 prerequisite: the WAM machine must be `Clone` (fork a machine per parallel
@@ -499,6 +504,7 @@ impl WamState {
             backtrack_count: 0,
             aggregate_acc: Vec::new(),
             aggregate_return_pc: 0,
+            thrown_ball: None,
         }
     }
 
@@ -987,6 +993,7 @@ impl WamState {
         self.backtrack_count = 0;
         self.aggregate_acc.clear();
         self.aggregate_return_pc = 0;
+        self.thrown_ball = None;
     }
 
     /// Get a register value. Yi registers are read from the environment frame.

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -44,6 +44,39 @@ t_concat_split(A, B) :- atom_concat(A, B, abc).
 :- dynamic t_select/2.
 t_select(X, R) :- select(X, [a, b, c], R).
 
+%% catch/throw + succ predicates (ISO meta-builtin Call fallback path).
+:- dynamic t_thrower/0.
+t_thrower :- throw(oops(42)).
+
+:- dynamic t_deep/0.
+:- dynamic t_mid/0.
+t_deep :- t_mid.
+t_mid :- t_thrower.
+
+:- dynamic t_catch_match/1.
+t_catch_match(R) :- catch(t_thrower, oops(X), R = caught(X)).
+
+:- dynamic t_catch_deep/1.
+t_catch_deep(R) :- catch(t_deep, oops(X), R = X).
+
+:- dynamic t_catch_nomatch/0.
+t_catch_nomatch :- catch(t_thrower, other(_), true).
+
+:- dynamic t_catch_nothrow/1.
+t_catch_nothrow(X) :- catch(member(X, [a]), _Any, fail).
+
+:- dynamic t_catch_failgoal/0.
+t_catch_failgoal :- catch(fail, _Any, true).
+
+:- dynamic t_catch_nested/1.
+t_catch_nested(R) :- catch(catch(t_thrower, nomatch(_), fail), oops(X), R = X).
+
+:- dynamic t_succ_fwd/1.
+t_succ_fwd(Y) :- succ(2, Y).
+
+:- dynamic t_succ_rev/1.
+t_succ_rev(X) :- succ(X, 3).
+
 cargo_available :-
     catch(
         (process_create(path(cargo), ['--version'],
@@ -60,7 +93,12 @@ test_builtin_parity_execution :-
     ;   (exists_directory(TmpDir) -> delete_directory_and_contents(TmpDir) ; true),
         write_wam_rust_project(
             [user:t_between/1, user:t_msort/1, user:t_sort/1,
-             user:t_concat_split/2, user:t_select/2],
+             user:t_concat_split/2, user:t_select/2,
+             user:t_thrower/0, user:t_deep/0, user:t_mid/0,
+             user:t_catch_match/1, user:t_catch_deep/1,
+             user:t_catch_nomatch/0, user:t_catch_nothrow/1,
+             user:t_catch_failgoal/0, user:t_catch_nested/1,
+             user:t_succ_fwd/1, user:t_succ_rev/1],
             [module_name('builtin_parity_test'), wam_fallback(true)],
             TmpDir),
         directory_file_path(TmpDir, 'tests', TestsDir),
@@ -69,7 +107,9 @@ test_builtin_parity_execution :-
         TestContent = '
 use builtin_parity_test::state::WamState;
 use builtin_parity_test::value::Value;
-use builtin_parity_test::{t_between_1, t_msort_1, t_sort_1, t_concat_split_2, t_select_2};
+use builtin_parity_test::{t_between_1, t_msort_1, t_sort_1, t_concat_split_2, t_select_2,
+    t_catch_match_1, t_catch_deep_1, t_catch_nomatch_0, t_catch_nothrow_1,
+    t_catch_failgoal_0, t_catch_nested_1, t_succ_fwd_1, t_succ_rev_1};
 use std::collections::HashMap;
 
 fn vmnew() -> WamState {
@@ -157,6 +197,77 @@ fn test_select_enumeration_compiled() {
         ("b".to_string(), "a,c".to_string()),
         ("c".to_string(), "a,b".to_string()),
     ]);
+}
+
+#[test]
+fn test_catch_matching_catcher_runs_recovery() {
+    let mut vm = vmnew();
+    assert!(t_catch_match_1(&mut vm, ub("R")),
+        "catch(throw(oops(42)), oops(X), R = caught(X)) must succeed");
+    assert_eq!(read_var(&vm, "R"),
+        Value::Str("caught".to_string(), vec![i(42)]));
+    assert!(vm.thrown_ball.is_none(), "ball consumed");
+}
+
+#[test]
+fn test_catch_propagates_through_calls() {
+    let mut vm = vmnew();
+    assert!(t_catch_deep_1(&mut vm, ub("R")),
+        "throw two predicate calls deep must reach the catcher");
+    assert_eq!(read_var(&vm, "R"), i(42));
+}
+
+#[test]
+fn test_catch_nonmatching_catcher_rethrows() {
+    let mut vm = vmnew();
+    assert!(!t_catch_nomatch_0(&mut vm),
+        "non-unifying catcher must rethrow (uncaught at top = failure)");
+    assert!(vm.thrown_ball.is_some(), "ball still in flight after rethrow");
+}
+
+#[test]
+fn test_catch_transparent_when_no_throw() {
+    let mut vm = vmnew();
+    assert!(t_catch_nothrow_1(&mut vm, ub("X")));
+    assert_eq!(read_var(&vm, "X"), a("a"));
+    assert!(vm.thrown_ball.is_none());
+}
+
+#[test]
+fn test_catch_plain_goal_failure_fails() {
+    let mut vm = vmnew();
+    assert!(!t_catch_failgoal_0(&mut vm),
+        "catch(fail, _, true) fails — recovery only runs on throw");
+    assert!(vm.thrown_ball.is_none());
+}
+
+#[test]
+fn test_catch_nested_inner_rethrows_outer_catches() {
+    let mut vm = vmnew();
+    assert!(t_catch_nested_1(&mut vm, ub("R")));
+    assert_eq!(read_var(&vm, "R"), i(42));
+    assert!(vm.thrown_ball.is_none());
+}
+
+#[test]
+fn test_succ_both_modes_compiled() {
+    let mut vm = vmnew();
+    assert!(t_succ_fwd_1(&mut vm, ub("Y")));
+    assert_eq!(read_var(&vm, "Y"), i(3));
+    let mut vm2 = vmnew();
+    assert!(t_succ_rev_1(&mut vm2, ub("X")));
+    assert_eq!(read_var(&vm2, "X"), i(2));
+}
+
+#[test]
+fn test_succ_direct_edge_cases() {
+    let (ok, vm) = call2("succ/2", i(0), ub("Y"));
+    assert!(ok);
+    assert_eq!(read_var(&vm, "Y"), i(1));
+    assert!(!call2("succ/2", ub("X"), i(0)).0, "succ(X, 0) has no natural X");
+    assert!(!call2("succ/2", i(-1), ub("Y")).0, "negative X fails");
+    assert!(call2("succ/2", i(2), i(3)).0);
+    assert!(!call2("succ/2", i(2), i(4)).0);
 }
 
 // ---- layer 2: direct execute_builtin coverage ------------------------


### PR DESCRIPTION
## Summary

Rust⇄F# parity campaign P4: ISO `catch/3`, `throw/1`, and `succ/2` — completing the control-flow parity milestone — plus a **latent correctness fix** the new tests exposed.

### catch/throw (mutable-state port of the F# design)

F# implements catch/throw with .NET exceptions and immutable state snapshots; the Rust runtime is mutable, so the port uses:

- A `thrown_ball: Option<Value>` field on `WamState`. `throw/1` deep-derefs the ball and puts it in flight; **the run loop treats a failing step with a pending ball as an abort** — no backtracking, alternatives discarded until a catch consumes the ball.
- `catch/3` snapshots regs/trail/heap/stack/choice-point depth, meta-calls the goal (builtin dispatch first, then labelled-predicate sub-run — the same architecture as the general negation path); on a ball it restores the snapshot, unifies the catcher (**rethrowing on mismatch** so an outer catch can try), and runs the recovery goal. First-solution semantics, matching the F# port.
- The shared WAM compiler emits these as `Call`/`Execute` (they have no `is_builtin_pred` entry), so the Call and Execute instruction arms gained an ISO meta-builtin fallback mirroring F#'s `isIsoMetaBuiltin` routing — which also delivers the previously deferred bidirectional **`succ/2`**.

### Latent bug fix: PutStructure A-register bind-through (M139/M140 class)

The catch tests exposed a pre-existing defect: building a goal structure into an A register whose old occupant was a still-live variable (e.g. `p(X) :- catch(member(X, L), ...)` — X staged in A1, then the goal structure built into A1 with X as an argument) **bound X to the structure's own heap cell**, creating a cyclic term (`X = member(X, L)`) on which `deref_heap` recursed to stack overflow. This is the same bind-through class the LLVM target fixed in M140, with the same fix: bind-through (needed for top-down structure-chaining placeholders, which only live in X/Y registers) is now conditioned on register class — **A registers are argument staging and never bind**. All existing suites pass unchanged.

## Test plan

- [x] 8 new cargo-built tests in `tests/test_wam_rust_builtin_parity.pl` (21 total): matching catcher runs recovery with bindings; throw propagates through nested predicate calls; non-matching catcher rethrows (ball still in flight); nested catch — inner rethrows, outer catches; catch transparent when no throw; `catch(fail,_,true)` fails; `succ/2` both modes + edge cases (`succ(X,0)` fails, negative fails)
- [x] `test_wam_rust_target.pl`, `test_wam_rust_runtime.pl` (cargo e2e) — all pass
- [x] `test_wam_rust_lowered_t4/t5/t6`, `ite_exec`, `save_regs` — all pass
- [x] `test_wam_rust_par_aggregate.pl` + `test_wam_rust_parallel_aggregate_gate.pl` (the new parallel suites from main; the added field keeps `WamState: Clone + Send`) — all pass
- [x] `test_wam_rust_bidirectional_e2e.pl` — 4/4

https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM)_