### PR TITLE
[codex] Add parent histogram recurrence benchmark

### DIFF
--- a/docs/reports/lmdb_parent_recurrence_histogram_smoke_2026-06-12.md
+++ b/docs/reports/lmdb_parent_recurrence_histogram_smoke_2026-06-12.md
@@ -1,0 +1,82 @@
+# LMDB Parent Histogram Recurrence Smoke - 2026-06-12
+
+This smoke tests the recurrence formulation for parent-path histograms:
+
+```text
+H_root[0] = 1
+H_v[d] = sum over parents p of H_p[d - 1]
+```
+
+The recurrence shifts each direct parent distribution by one path step and sums
+the shifted histograms.  On a parent-only DAG this is exact and avoids explicit
+path enumeration.  On cyclic category cones, a node-only histogram cannot carry
+the visited-set state required for exact unique-node path semantics, so cycle
+encounters are flagged as `cycle_approximation`.
+
+## Command
+
+```bash
+python3 scripts/lmdb_parent_recurrence_histogram_benchmark.py \
+  --lmdb-dir /home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct/lmdb_resident \
+  --root 7345184 \
+  --graph-name enwiki_mtc_parent_recurrence_smoke \
+  --target-depths 3 \
+  --children-per-node 16 \
+  --frontier-limit 80 \
+  --targets-per-depth 3 \
+  --budgets 4,6,8 \
+  --path-cap 10000 \
+  --expansion-cap 50000 \
+  --seed enwiki-mtc-parent-recurrence-smoke \
+  --output-dir /mnt/c/Users/johnc/Scratch/parent-recurrence
+```
+
+## Results
+
+| budget | rows | exact_matches | cycle_approx | mean_l1 | mean_cdf | mean_state_ratio | mean_time_ratio | dfs_capped | recurrence_capped |
+|-------:|-----:|--------------:|-------------:|--------:|---------:|-----------------:|----------------:|-----------:|------------------:|
+| 4 | 3 | 3 | 3 | 0.000000 | 0.000000 | 0.133 | 0.060 | 0 | 0 |
+| 6 | 3 | 3 | 3 | 0.000000 | 0.000000 | 0.027 | 0.299 | 0 | 0 |
+| 8 | 3 | 1 | 3 | 0.890547 | 0.611940 | 0.010 | 9.502 | 2 | 0 |
+
+## Interpretation
+
+For budgets 4 and 6, recurrence matched the DFS simple-path histograms exactly
+on this small sample while evaluating far fewer states.  The cycle flag was set,
+so these rows should be read as "matched despite cycle encounters", not as a
+proof that the recurrence enforces unique-node path semantics.
+
+The budget-8 row is a warning case.  DFS enumeration hit caps on 2 of 3 rows,
+while recurrence continued as a finite shifted-sum computation.  The high error
+there is not a clean recurrence-vs-exact comparison; it says that deeper budgets
+need better validation and cycle handling.
+
+## Update Rules
+
+The recurrence can also be viewed as an incremental boundary-condition update:
+when a parent distribution changes, child distributions can be updated by
+subtracting the old shifted parent contribution and adding the new shifted
+contribution.  A conservative propagation gate is:
+
+```text
+update child only when the changed parent support can extend or change the
+child support under the child path horizon
+```
+
+One variant we discussed is to re-update a child only when the parent's maximum
+root path length is greater than the child's current maximum root path length.
+Other variants could use support overlap, tail mass, peak-relative tail
+thresholds, or expected downstream cache hits.
+
+## Refinement Direction
+
+The recurrence should become the first materialization path for cached boundary
+distributions.  DFS enumeration should remain as a validator for small cones and
+as a residual source for calibration.
+
+A later refinement can treat recurrence histograms as priors and use sampled or
+bounded path enumeration residuals to adjust them.  That could be framed as a
+Monte Carlo correction or gradient-style optimization: compare enumerated path
+mass to predicted mass, then adjust local distributions where the residual is
+large.  This is not cheap, but it is a plausible way to improve recurrence
+states without enumerating all paths.

--- a/scripts/lmdb_parent_recurrence_histogram_benchmark.py
+++ b/scripts/lmdb_parent_recurrence_histogram_benchmark.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Compare DFS path enumeration with parent-histogram recurrence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.distribution_fit_comparison import exact_excess_distribution, l1_error, max_cdf_error
+from scripts.lmdb_parent_branching_diagnostic import LmdbCategoryGraph, parse_int_list, select_targets_by_child_depth
+from scripts.lmdb_parent_histogram_benchmark import bounded_parent_histogram, percentile, safe_graph_name
+from scripts.parent_histogram_recurrence import recurrence_parent_histogram
+
+
+def mean(values):
+    values = list(values)
+    if not values:
+        return 0.0
+    return statistics.fmean(values)
+
+
+def histogram_error(left_hist, right_hist):
+    left, _left_origin = exact_excess_distribution(left_hist)
+    right, _right_origin = exact_excess_distribution(right_hist)
+    if not left and not right:
+        return 0.0, 0.0
+    if not left or not right:
+        return 1.0, 1.0
+    return l1_error(left, right), max_cdf_error(left, right)
+
+
+def comparison_record(args, target, child_depth, budget, dfs_hist, dfs_stats, dfs_time, recurrence_hist, recurrence_stats, recurrence_time):
+    l1, cdf = histogram_error(dfs_hist, recurrence_hist)
+    dfs_paths = sum(dfs_hist.values())
+    recurrence_paths = sum(recurrence_hist.values())
+    return {
+        "record_type": "parent_recurrence_histogram_comparison",
+        "graph": args.graph_name,
+        "root": args.root,
+        "target_node": target,
+        "child_sample_depth": child_depth,
+        "budget": budget,
+        "dfs_histogram": dfs_hist,
+        "recurrence_histogram": recurrence_hist,
+        "dfs_path_count": dfs_paths,
+        "recurrence_path_count": recurrence_paths,
+        "path_count_delta": recurrence_paths - dfs_paths,
+        "l1_error": l1,
+        "max_cdf_error": cdf,
+        "dfs_nodes_expanded": dfs_stats.nodes_expanded,
+        "recurrence_states_evaluated": recurrence_stats.states_evaluated,
+        "state_expansion_ratio": 0.0 if dfs_stats.nodes_expanded == 0 else recurrence_stats.states_evaluated / dfs_stats.nodes_expanded,
+        "dfs_edges_examined": dfs_stats.edges_examined,
+        "recurrence_edges_examined": recurrence_stats.edges_examined,
+        "dfs_cycle_skips": dfs_stats.cycle_skips,
+        "recurrence_cycle_edges": recurrence_stats.cycle_edges,
+        "recurrence_cycle_approximation": recurrence_stats.cycle_approximation,
+        "dfs_path_cap_hit": dfs_stats.path_cap_hit,
+        "dfs_expansion_cap_hit": dfs_stats.expansion_cap_hit,
+        "recurrence_path_cap_hit": recurrence_stats.path_cap_hit,
+        "recurrence_expansion_cap_hit": recurrence_stats.expansion_cap_hit,
+        "dfs_time_ns": dfs_time,
+        "recurrence_time_ns": recurrence_time,
+        "time_ratio": 0.0 if dfs_time == 0 else recurrence_time / dfs_time,
+    }
+
+
+def summarize(records):
+    rows = [row for row in records if row.get("record_type") == "parent_recurrence_histogram_comparison"]
+    by_budget = {}
+    for row in rows:
+        by_budget.setdefault(row["budget"], []).append(row)
+    out = [{
+        "record_type": "parent_recurrence_histogram_summary",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "graph": records[0].get("graph") if records else None,
+        "budgets": sorted(by_budget),
+        "rows": len(rows),
+        "budget_rows": [],
+    }]
+    for budget in sorted(by_budget):
+        bucket = by_budget[budget]
+        out[0]["budget_rows"].append({
+            "budget": budget,
+            "rows": len(bucket),
+            "exact_match_rows": sum(1 for row in bucket if row["dfs_histogram"] == row["recurrence_histogram"]),
+            "cycle_approximation_rows": sum(1 for row in bucket if row["recurrence_cycle_approximation"]),
+            "mean_l1_error": mean(row["l1_error"] for row in bucket),
+            "p95_l1_error": percentile([row["l1_error"] for row in bucket], 95),
+            "mean_max_cdf_error": mean(row["max_cdf_error"] for row in bucket),
+            "mean_state_expansion_ratio": mean(row["state_expansion_ratio"] for row in bucket),
+            "mean_time_ratio": mean(row["time_ratio"] for row in bucket),
+            "dfs_capped_rows": sum(1 for row in bucket if row["dfs_path_cap_hit"] or row["dfs_expansion_cap_hit"]),
+            "recurrence_capped_rows": sum(1 for row in bucket if row["recurrence_path_cap_hit"] or row["recurrence_expansion_cap_hit"]),
+        })
+    return out[0]
+
+
+def markdown_summary(summary):
+    lines = [
+        "# Parent Histogram Recurrence Benchmark",
+        "",
+        "| budget | rows | exact_matches | cycle_approx | mean_l1 | mean_cdf | mean_state_ratio | mean_time_ratio | dfs_capped | recurrence_capped |",
+        "|-------:|-----:|--------------:|-------------:|--------:|---------:|-----------------:|----------------:|-----------:|------------------:|",
+    ]
+    for row in summary["budget_rows"]:
+        lines.append(
+            "| {budget} | {rows} | {exact} | {cycle} | {l1:.6f} | {cdf:.6f} | {state_ratio:.3f} | {time_ratio:.3f} | {dfs_capped} | {rec_capped} |".format(
+                budget=row["budget"],
+                rows=row["rows"],
+                exact=row["exact_match_rows"],
+                cycle=row["cycle_approximation_rows"],
+                l1=row["mean_l1_error"],
+                cdf=row["mean_max_cdf_error"],
+                state_ratio=row["mean_state_expansion_ratio"],
+                time_ratio=row["mean_time_ratio"],
+                dfs_capped=row["dfs_capped_rows"],
+                rec_capped=row["recurrence_capped_rows"],
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def run_benchmark(args):
+    graph = LmdbCategoryGraph(args.lmdb_dir)
+    try:
+        budgets = parse_int_list(args.budgets)
+        targets, target_child_depth, selection_counts = select_targets_by_child_depth(
+            graph,
+            args.root,
+            parse_int_list(args.target_depths),
+            args.children_per_node,
+            args.frontier_limit,
+            args.targets_per_depth,
+            args.seed,
+        )
+        records = [{
+            "record_type": "parent_recurrence_histogram_selection",
+            "graph": args.graph_name,
+            "root": args.root,
+            "target_selection_counts": selection_counts,
+            "targets": len(targets),
+            "budgets": budgets,
+        }]
+        for target in targets:
+            for budget in budgets:
+                dfs_started = time.perf_counter_ns()
+                dfs_hist, dfs_stats = bounded_parent_histogram(
+                    graph.parents,
+                    target,
+                    args.root,
+                    budget,
+                    args.path_cap,
+                    args.expansion_cap,
+                )
+                dfs_time = time.perf_counter_ns() - dfs_started
+                rec_started = time.perf_counter_ns()
+                recurrence_hist, recurrence_stats = recurrence_parent_histogram(
+                    graph.parents,
+                    target,
+                    args.root,
+                    budget,
+                    args.path_cap,
+                    args.expansion_cap,
+                )
+                recurrence_time = time.perf_counter_ns() - rec_started
+                records.append(comparison_record(
+                    args,
+                    target,
+                    target_child_depth[target],
+                    budget,
+                    dfs_hist,
+                    dfs_stats,
+                    dfs_time,
+                    recurrence_hist,
+                    recurrence_stats,
+                    recurrence_time,
+                ))
+        return records, summarize(records)
+    finally:
+        graph.close()
+
+
+def write_outputs(records, summary, output_dir, graph_name, write_jsonl=False):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    safe_name = safe_graph_name(graph_name)
+    summary_json = output_dir / "{}_parent_recurrence_summary.json".format(safe_name)
+    summary_md = output_dir / "{}_parent_recurrence_summary.md".format(safe_name)
+    summary_json.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary_md.write_text(markdown_summary(summary), encoding="utf-8")
+    jsonl_path = None
+    if write_jsonl:
+        jsonl_path = output_dir / "{}_parent_recurrence.jsonl".format(safe_name)
+        with jsonl_path.open("w", encoding="utf-8") as handle:
+            for record in records:
+                handle.write(json.dumps(record, sort_keys=True) + "\n")
+    return summary_json, summary_md, jsonl_path
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lmdb-dir", type=Path, required=True)
+    parser.add_argument("--root", type=int, required=True)
+    parser.add_argument("--graph-name", default="lmdb_parent_recurrence")
+    parser.add_argument("--target-depths", default="3")
+    parser.add_argument("--children-per-node", type=int, default=32)
+    parser.add_argument("--frontier-limit", type=int, default=200)
+    parser.add_argument("--targets-per-depth", type=int, default=4)
+    parser.add_argument("--budgets", default="4,6,8")
+    parser.add_argument("--path-cap", type=int, default=10000)
+    parser.add_argument("--expansion-cap", type=int, default=50000)
+    parser.add_argument("--write-jsonl", action="store_true")
+    parser.add_argument("--seed", default="parent-recurrence-v1")
+    parser.add_argument("--output-dir", type=Path, default=Path("docs/reports"))
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    records, summary = run_benchmark(args)
+    summary_json, summary_md, jsonl_path = write_outputs(records, summary, args.output_dir, args.graph_name, args.write_jsonl)
+    print(markdown_summary(summary), end="")
+    print("summary_json={}".format(summary_json))
+    print("summary_md={}".format(summary_md))
+    if jsonl_path is not None:
+        print("jsonl={}".format(jsonl_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/parent_histogram_recurrence.py
+++ b/scripts/parent_histogram_recurrence.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Parent-path histogram recurrence helpers.
+
+For a parent-only DAG the recurrence is exact:
+
+    H_root[0] = 1
+    H_v[d] = sum(H_parent[d - 1] for parent in parents(v))
+
+This avoids enumerating every path from a target to root.  In cyclic graphs a
+per-node histogram cannot enforce a unique-node visited set, so cycle encounters
+are reported through `cycle_approximation`.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+
+
+@dataclass
+class RecurrenceHistogramStats:
+    states_evaluated: int = 0
+    memo_hits: int = 0
+    edges_examined: int = 0
+    cycle_edges: int = 0
+    budget_cutoffs: int = 0
+    path_cap_hit: bool = False
+    expansion_cap_hit: bool = False
+    cycle_approximation: bool = False
+
+
+def shifted_add(out, parent_hist, remaining, path_cap, stats):
+    for length, count in parent_hist.items():
+        shifted = int(length) + 1
+        if shifted <= remaining:
+            out[shifted] += int(count)
+            if path_cap is not None and sum(out.values()) >= path_cap:
+                stats.path_cap_hit = True
+                return
+
+
+def recurrence_parent_histogram(parents_func, target, root, budget, path_cap=None, expansion_cap=None):
+    """Compute a finite-horizon parent histogram by shifted parent sums.
+
+    The returned histogram counts root-reaching walks under the recurrence.  It
+    is exact for DAG parent cones.  If a cycle is encountered, the cyclic edge is
+    skipped and `cycle_approximation` is set because a node-only recurrence does
+    not carry the visited-set state required for exact simple-path semantics.
+    """
+    stats = RecurrenceHistogramStats()
+    memo = {}
+    visiting = set()
+
+    def rec(node, remaining):
+        key = (node, remaining)
+        if key in memo:
+            stats.memo_hits += 1
+            return memo[key]
+        if node == root:
+            memo[key] = {0: 1}
+            return memo[key]
+        if remaining <= 0:
+            stats.budget_cutoffs += 1
+            memo[key] = {}
+            return memo[key]
+        if node in visiting:
+            stats.cycle_edges += 1
+            stats.cycle_approximation = True
+            return {}
+        if expansion_cap is not None and stats.states_evaluated >= expansion_cap:
+            stats.expansion_cap_hit = True
+            return {}
+
+        visiting.add(node)
+        stats.states_evaluated += 1
+        out = Counter()
+        for parent in parents_func(node):
+            stats.edges_examined += 1
+            if parent in visiting:
+                stats.cycle_edges += 1
+                stats.cycle_approximation = True
+                continue
+            parent_hist = rec(parent, remaining - 1)
+            shifted_add(out, parent_hist, remaining, path_cap, stats)
+            if stats.path_cap_hit or stats.expansion_cap_hit:
+                break
+        visiting.remove(node)
+        memo[key] = dict(sorted(out.items()))
+        return memo[key]
+
+    return dict(sorted(rec(target, int(budget)).items())), stats

--- a/tests/test_parent_histogram_recurrence.py
+++ b/tests/test_parent_histogram_recurrence.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Tests for parent histogram recurrence helpers."""
+
+import unittest
+
+from scripts.lmdb_parent_histogram_benchmark import bounded_parent_histogram
+from scripts.parent_histogram_recurrence import recurrence_parent_histogram
+
+
+class ParentHistogramRecurrenceTests(unittest.TestCase):
+    def test_recurrence_matches_dag_path_histogram(self):
+        parents = {
+            "A": ["R"],
+            "B": ["R", "A"],
+            "C": ["A", "B"],
+        }
+
+        dfs_hist, _dfs_stats = bounded_parent_histogram(lambda node: parents.get(node, []), "C", "R", 3)
+        rec_hist, rec_stats = recurrence_parent_histogram(lambda node: parents.get(node, []), "C", "R", 3)
+
+        self.assertEqual(dfs_hist, {2: 2, 3: 1})
+        self.assertEqual(rec_hist, dfs_hist)
+        self.assertFalse(rec_stats.cycle_approximation)
+
+    def test_recurrence_respects_budget_horizon(self):
+        parents = {
+            "A": ["R"],
+            "B": ["A"],
+            "C": ["B"],
+        }
+
+        rec_hist, rec_stats = recurrence_parent_histogram(lambda node: parents.get(node, []), "C", "R", 2)
+
+        self.assertEqual(rec_hist, {})
+        self.assertGreater(rec_stats.budget_cutoffs, 0)
+
+    def test_recurrence_marks_cycles_as_approximate(self):
+        parents = {
+            "A": ["R"],
+            "B": ["A", "C"],
+            "C": ["B"],
+        }
+
+        rec_hist, rec_stats = recurrence_parent_histogram(lambda node: parents.get(node, []), "C", "R", 4)
+        dfs_hist, _dfs_stats = bounded_parent_histogram(lambda node: parents.get(node, []), "C", "R", 4)
+
+        self.assertEqual(rec_hist, dfs_hist)
+        self.assertTrue(rec_stats.cycle_approximation)
+        self.assertGreater(rec_stats.cycle_edges, 0)
+
+    def test_path_cap_marks_recurrence_truncated(self):
+        parents = {
+            "A": ["R"],
+            "B": ["R"],
+            "C": ["A", "B"],
+        }
+
+        rec_hist, rec_stats = recurrence_parent_histogram(lambda node: parents.get(node, []), "C", "R", 2, path_cap=1)
+
+        self.assertTrue(rec_stats.path_cap_hit)
+        self.assertEqual(sum(rec_hist.values()), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a parent-histogram recurrence helper that builds root-distance histograms by shifting and summing parent histograms instead of enumerating every parent path.
- Add an LMDB benchmark that compares the recurrence against bounded DFS parent-path enumeration on sampled category nodes.
- Document the enwiki Main topic classifications smoke results, cycle semantics, incremental child-update variants, and the Monte Carlo / gradient-style residual refinement direction.

## Notes

The recurrence is exact on DAG parent cones. When it encounters a cycle it skips the cyclic edge and reports `cycle_approximation=true`; this keeps the recurrence usable as a cheap boundary-condition prior while making clear that per-node histograms do not by themselves enforce unique-node simple-path semantics.

The smoke report shows budgets 4 and 6 matching DFS exactly on the sampled rows with fewer recurrence states. Budget 8 is intentionally called out as a warning case because DFS capped on 2 of 3 rows while recurrence remained uncapped but cycle-approximate.

## Validation

```bash
python3 -m unittest tests.test_parent_histogram_recurrence tests.test_lmdb_parent_histogram_benchmark tests.test_lmdb_policy_cache_materialization_probe
```

14 tests passed.

## Local-only changes

There is an unrelated unstaged edit in `templates/targets/fsharp_wam/kernel_bidirectional_ancestor.fs.mustache`; it was intentionally left out of this PR.