### PR TITLE
[codex] Print PLAWK selected fields natively

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -238,14 +238,15 @@ Parser/codegen land in `examples/plawk/{parser,codegen}/`.
 
 **Current slice:** `examples/plawk/parser/plawk_parser.pl` parses the first
 surface forms, `/^PREFIX/ { print $0 }` and
-`$N == "VALUE" { print $0 }`, to explicit pattern/action ASTs.
+`$N == "VALUE" { print $0 }`, plus selected-field actions such as
+`$N == "VALUE" { print $M, $K }`, to explicit pattern/action ASTs.
 `examples/plawk/codegen/plawk_native_codegen.pl` lowers that AST to a native
 streaming WAM/LLVM driver using `llvm_emit_atom_prefix_guard/5` or
 `llvm_emit_atom_field_eq_guard/7`, and
 `tests/test_plawk_surface_prefix_print.pl` proves that the generated binary
 prints matching records from a text file without calling `run_loop` in the hot
 record loop. The field-equality path scans fields in native code without
-allocating substrings.
+allocating substrings; selected-field printing projects byte slices directly.
 
 **Success:** a user-written awk-style program parses, lowers, compiles, and
 produces correct output on standard awk test cases.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -76,8 +76,8 @@ swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR
 
 The demo prints the record count and the lines whose first field is `ERROR`.
 The first Phase 2 surface smokes parse `/^ERROR/ { print $0 }` and
-`$1 == "ERROR" { print $0 }`, emit a native streaming WAM/LLVM driver, and
-print matching records from a text file.
+`$1 == "ERROR" { print $0 }`, plus selected-field actions such as
+`$1 == "ERROR" { print $2, $3 }`.
 
 For a walkthrough of the current Prolog-core syntax and how it maps to awk
 concepts like `$0`, `$1`, `NR`, `NF`, `FS`, `OFS`, and `print`, see

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -7,7 +7,8 @@
 
 :- use_module('../../../src/unifyweaver/targets/wam_llvm_target',
     [llvm_emit_atom_prefix_guard/5,
-     llvm_emit_atom_field_eq_guard/7]).
+     llvm_emit_atom_field_eq_guard/7,
+     llvm_emit_atom_field_slice/5]).
 
 %% plawk_program_native_driver_ir(+Program, +InputPath, -DriverIR) is semidet.
 %
@@ -15,12 +16,13 @@
 %
 %      /^PREFIX/ { print $0 }
 %      $N == "VALUE" { print $0 }
+%      $N == "VALUE" { print $M, $K }
 %
 %  The surrounding runtime still comes from write_wam_llvm_project/3. This
 %  function emits the target-specific native main that streams the file, lowers
 %  the deterministic guard, and prints matching records.
 plawk_program_native_driver_ir(
-    program([], [rule(Pattern, [print(field(0))])], []),
+    program([], [rule(Pattern, [print(Fields)])], []),
     InputPath,
     DriverIR
 ) :-
@@ -29,10 +31,14 @@ plawk_program_native_driver_ir(
     BytesLen is PathLen + 1,
     llvm_c_bytes(PathCodes, PathBytes),
     plawk_pattern_guard_ir(Pattern, GuardGlobalIR-GuardCallIR),
+    plawk_print_action_ir(Fields, PrintActionIR),
     format(atom(DriverIR),
 '@.plawk_surface_path = private constant [~w x i8] c"~w\\00"
 @.plawk_surface_eof = private constant [12 x i8] c"end_of_file\\00"
 @.plawk_surface_print_line = private constant [4 x i8] c"%s\\0A\\00"
+@.plawk_surface_print_slice = private constant [5 x i8] c"%.*s\\00"
+@.plawk_surface_print_space = private constant [2 x i8] c" \\00"
+@.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
 ~w
 
 define i32 @main() {
@@ -76,8 +82,7 @@ lowered_match:
   br i1 %is_match, label %print_line, label %continue_loop
 
 print_line:
-  %fmt = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_line, i32 0, i32 0
-  %printed = call i32 (i8*, ...) @printf(i8* %fmt, i8* %line_s)
+~w
   br label %continue_loop
 
 continue_loop:
@@ -107,7 +112,7 @@ fail_close:
 ',
         [BytesLen, PathBytes,
          GuardGlobalIR,
-         BytesLen, BytesLen, PathLen, GuardCallIR]).
+         BytesLen, BytesLen, PathLen, GuardCallIR, PrintActionIR]).
 
 llvm_c_bytes([], '').
 llvm_c_bytes([Code | Rest], Bytes) :-
@@ -125,3 +130,61 @@ plawk_pattern_guard_ir(prefix(Prefix), GuardIR) :-
 plawk_pattern_guard_ir(field_eq(Index, Value), GuardIR) :-
     llvm_emit_atom_field_eq_guard(plawk_surface_field_eq, '%line', Index, Value,
         32, '%is_match', GuardIR).
+
+plawk_print_action_ir([field(0)], IR) :-
+    !,
+    IR = '  %fmt = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_line, i32 0, i32 0
+  %printed = call i32 (i8*, ...) @printf(i8* %fmt, i8* %line_s)'.
+plawk_print_action_ir(Fields, IR) :-
+    phrase(plawk_print_fields_ir(Fields, 0), Parts),
+    atomic_list_concat(Parts, '\n', IR).
+
+plawk_print_fields_ir([], _) -->
+    ['  %newline_fmt = getelementptr [2 x i8], [2 x i8]* @.plawk_surface_print_newline, i32 0, i32 0',
+     '  %printed_newline = call i32 (i8*, ...) @printf(i8* %newline_fmt)'].
+plawk_print_fields_ir([Field | Rest], Index) -->
+    plawk_print_separator_ir(Index),
+    plawk_print_field_ir(Field, Index),
+    { NextIndex is Index + 1 },
+    plawk_print_fields_ir(Rest, NextIndex).
+
+plawk_print_separator_ir(0) -->
+    !,
+    [].
+plawk_print_separator_ir(Index) -->
+    { format(atom(SpacePtr),
+          '  %space_fmt_~w = getelementptr [2 x i8], [2 x i8]* @.plawk_surface_print_space, i32 0, i32 0',
+          [Index]),
+      format(atom(SpaceCall),
+          '  %printed_space_~w = call i32 (i8*, ...) @printf(i8* %space_fmt_~w)',
+          [Index, Index])
+    },
+    [SpacePtr, SpaceCall].
+
+plawk_print_field_ir(field(0), Index) -->
+    { format(atom(LineLen64),
+          '  %line_len64_~w = call i64 @strlen(i8* %line_s)',
+          [Index]),
+      format(atom(LineLen),
+          '  %line_len_~w = trunc i64 %line_len64_~w to i32',
+          [Index, Index]),
+      format(atom(FmtPtr),
+          '  %line_fmt_~w = getelementptr [5 x i8], [5 x i8]* @.plawk_surface_print_slice, i32 0, i32 0',
+          [Index]),
+      format(atom(PrintCall),
+          '  %printed_line_~w = call i32 (i8*, ...) @printf(i8* %line_fmt_~w, i32 %line_len_~w, i8* %line_s)',
+          [Index, Index, Index])
+    },
+    [LineLen64, LineLen, FmtPtr, PrintCall].
+plawk_print_field_ir(field(FieldIndex), Index) -->
+    { FieldIndex > 0,
+      format(atom(Base), 'plawk_field_~w', [Index]),
+      llvm_emit_atom_field_slice('%line', FieldIndex, 32, Base, SliceIR),
+      format(atom(FmtPtr),
+          '  %slice_fmt_~w = getelementptr [5 x i8], [5 x i8]* @.plawk_surface_print_slice, i32 0, i32 0',
+          [Index]),
+      format(atom(PrintCall),
+          '  %printed_slice_~w = call i32 (i8*, ...) @printf(i8* %slice_fmt_~w, i32 %~w_len, i8* %~w_ptr)',
+          [Index, Index, Base, Base])
+    },
+    [SliceIR, FmtPtr, PrintCall].

--- a/examples/plawk/generated/plawk_core_probe.ll
+++ b/examples/plawk/generated/plawk_core_probe.ll
@@ -14,6 +14,9 @@ target triple = "x86_64-pc-linux-gnu"
 ; Tag: 0=Atom, 1=Integer, 2=Float, 3=Compound, 4=List, 5=Ref, 6=Unbound, 7=Bool
 %Value = type { i32, i64 }
 
+; === Byte slice ===
+%WamSlice = type { i8*, i64 }             ; pointer, length
+
 ; === Compound and List (heap-allocated) ===
 %Compound = type { i8*, i32, %Value* }    ; functor, arity, args
 %List = type { i32, %Value* }             ; length, elements
@@ -6748,6 +6751,76 @@ fe.yes:
 
 fe.no:
   ret i1 false
+}
+
+define %WamSlice @wam_atom_field_slice_value(%Value %atom_value, i64 %field_index, i8 %sep) {
+entry:
+  %fs.empty0 = insertvalue %WamSlice undef, i8* null, 0
+  %fs.empty = insertvalue %WamSlice %fs.empty0, i64 0, 1
+  %fs.t = call i32 @value_tag(%Value %atom_value)
+  %fs.is_atom = icmp eq i32 %fs.t, 0
+  br i1 %fs.is_atom, label %fs.check_index, label %fs.no
+
+fs.check_index:
+  %fs.index_ok = icmp sgt i64 %field_index, 0
+  br i1 %fs.index_ok, label %fs.lookup, label %fs.no
+
+fs.lookup:
+  %fs.aid = call i64 @value_payload(%Value %atom_value)
+  %fs.str = call i8* @wam_atom_to_string(i64 %fs.aid)
+  %fs.null = icmp eq i8* %fs.str, null
+  br i1 %fs.null, label %fs.no, label %fs.find_loop
+
+fs.find_loop:
+  %fs.cur_index = phi i64 [ 1, %fs.lookup ], [ %fs.next_index, %fs.after_sep ]
+  %fs.start_pos = phi i64 [ 0, %fs.lookup ], [ %fs.after_sep_pos, %fs.after_sep ]
+  %fs.index_match = icmp eq i64 %fs.cur_index, %field_index
+  br i1 %fs.index_match, label %fs.end_loop, label %fs.skip_loop
+
+fs.skip_loop:
+  %fs.skip_pos = phi i64 [ %fs.start_pos, %fs.find_loop ], [ %fs.skip_next_pos, %fs.skip_next ]
+  %fs.skip_ptr = getelementptr i8, i8* %fs.str, i64 %fs.skip_pos
+  %fs.skip_ch = load i8, i8* %fs.skip_ptr
+  %fs.skip_nul = icmp eq i8 %fs.skip_ch, 0
+  br i1 %fs.skip_nul, label %fs.no, label %fs.skip_check_sep
+
+fs.skip_check_sep:
+  %fs.skip_is_sep = icmp eq i8 %fs.skip_ch, %sep
+  br i1 %fs.skip_is_sep, label %fs.after_sep, label %fs.skip_next
+
+fs.skip_next:
+  %fs.skip_next_pos = add i64 %fs.skip_pos, 1
+  br label %fs.skip_loop
+
+fs.after_sep:
+  %fs.after_sep_pos = add i64 %fs.skip_pos, 1
+  %fs.next_index = add i64 %fs.cur_index, 1
+  br label %fs.find_loop
+
+fs.end_loop:
+  %fs.end_pos = phi i64 [ %fs.start_pos, %fs.find_loop ], [ %fs.end_next_pos, %fs.end_next ]
+  %fs.end_ptr = getelementptr i8, i8* %fs.str, i64 %fs.end_pos
+  %fs.end_ch = load i8, i8* %fs.end_ptr
+  %fs.end_nul = icmp eq i8 %fs.end_ch, 0
+  br i1 %fs.end_nul, label %fs.yes, label %fs.end_check_sep
+
+fs.end_check_sep:
+  %fs.end_is_sep = icmp eq i8 %fs.end_ch, %sep
+  br i1 %fs.end_is_sep, label %fs.yes, label %fs.end_next
+
+fs.end_next:
+  %fs.end_next_pos = add i64 %fs.end_pos, 1
+  br label %fs.end_loop
+
+fs.yes:
+  %fs.ptr = getelementptr i8, i8* %fs.str, i64 %fs.start_pos
+  %fs.len = sub i64 %fs.end_pos, %fs.start_pos
+  %fs.slice0 = insertvalue %WamSlice undef, i8* %fs.ptr, 0
+  %fs.slice = insertvalue %WamSlice %fs.slice0, i64 %fs.len, 1
+  ret %WamSlice %fs.slice
+
+fs.no:
+  ret %WamSlice %fs.empty
 }
 
 ; Dispatches on integer op codes:

--- a/examples/plawk/generated/plawk_loop_probe.ll
+++ b/examples/plawk/generated/plawk_loop_probe.ll
@@ -14,6 +14,9 @@ target triple = "x86_64-pc-linux-gnu"
 ; Tag: 0=Atom, 1=Integer, 2=Float, 3=Compound, 4=List, 5=Ref, 6=Unbound, 7=Bool
 %Value = type { i32, i64 }
 
+; === Byte slice ===
+%WamSlice = type { i8*, i64 }             ; pointer, length
+
 ; === Compound and List (heap-allocated) ===
 %Compound = type { i8*, i32, %Value* }    ; functor, arity, args
 %List = type { i32, %Value* }             ; length, elements
@@ -6748,6 +6751,76 @@ fe.yes:
 
 fe.no:
   ret i1 false
+}
+
+define %WamSlice @wam_atom_field_slice_value(%Value %atom_value, i64 %field_index, i8 %sep) {
+entry:
+  %fs.empty0 = insertvalue %WamSlice undef, i8* null, 0
+  %fs.empty = insertvalue %WamSlice %fs.empty0, i64 0, 1
+  %fs.t = call i32 @value_tag(%Value %atom_value)
+  %fs.is_atom = icmp eq i32 %fs.t, 0
+  br i1 %fs.is_atom, label %fs.check_index, label %fs.no
+
+fs.check_index:
+  %fs.index_ok = icmp sgt i64 %field_index, 0
+  br i1 %fs.index_ok, label %fs.lookup, label %fs.no
+
+fs.lookup:
+  %fs.aid = call i64 @value_payload(%Value %atom_value)
+  %fs.str = call i8* @wam_atom_to_string(i64 %fs.aid)
+  %fs.null = icmp eq i8* %fs.str, null
+  br i1 %fs.null, label %fs.no, label %fs.find_loop
+
+fs.find_loop:
+  %fs.cur_index = phi i64 [ 1, %fs.lookup ], [ %fs.next_index, %fs.after_sep ]
+  %fs.start_pos = phi i64 [ 0, %fs.lookup ], [ %fs.after_sep_pos, %fs.after_sep ]
+  %fs.index_match = icmp eq i64 %fs.cur_index, %field_index
+  br i1 %fs.index_match, label %fs.end_loop, label %fs.skip_loop
+
+fs.skip_loop:
+  %fs.skip_pos = phi i64 [ %fs.start_pos, %fs.find_loop ], [ %fs.skip_next_pos, %fs.skip_next ]
+  %fs.skip_ptr = getelementptr i8, i8* %fs.str, i64 %fs.skip_pos
+  %fs.skip_ch = load i8, i8* %fs.skip_ptr
+  %fs.skip_nul = icmp eq i8 %fs.skip_ch, 0
+  br i1 %fs.skip_nul, label %fs.no, label %fs.skip_check_sep
+
+fs.skip_check_sep:
+  %fs.skip_is_sep = icmp eq i8 %fs.skip_ch, %sep
+  br i1 %fs.skip_is_sep, label %fs.after_sep, label %fs.skip_next
+
+fs.skip_next:
+  %fs.skip_next_pos = add i64 %fs.skip_pos, 1
+  br label %fs.skip_loop
+
+fs.after_sep:
+  %fs.after_sep_pos = add i64 %fs.skip_pos, 1
+  %fs.next_index = add i64 %fs.cur_index, 1
+  br label %fs.find_loop
+
+fs.end_loop:
+  %fs.end_pos = phi i64 [ %fs.start_pos, %fs.find_loop ], [ %fs.end_next_pos, %fs.end_next ]
+  %fs.end_ptr = getelementptr i8, i8* %fs.str, i64 %fs.end_pos
+  %fs.end_ch = load i8, i8* %fs.end_ptr
+  %fs.end_nul = icmp eq i8 %fs.end_ch, 0
+  br i1 %fs.end_nul, label %fs.yes, label %fs.end_check_sep
+
+fs.end_check_sep:
+  %fs.end_is_sep = icmp eq i8 %fs.end_ch, %sep
+  br i1 %fs.end_is_sep, label %fs.yes, label %fs.end_next
+
+fs.end_next:
+  %fs.end_next_pos = add i64 %fs.end_pos, 1
+  br label %fs.end_loop
+
+fs.yes:
+  %fs.ptr = getelementptr i8, i8* %fs.str, i64 %fs.start_pos
+  %fs.len = sub i64 %fs.end_pos, %fs.start_pos
+  %fs.slice0 = insertvalue %WamSlice undef, i8* %fs.ptr, 0
+  %fs.slice = insertvalue %WamSlice %fs.slice0, i64 %fs.len, 1
+  ret %WamSlice %fs.slice
+
+fs.no:
+  ret %WamSlice %fs.empty
 }
 
 ; Dispatches on integer op codes:

--- a/examples/plawk/generated/plawk_meta_call_probe.ll
+++ b/examples/plawk/generated/plawk_meta_call_probe.ll
@@ -14,6 +14,9 @@ target triple = "x86_64-pc-linux-gnu"
 ; Tag: 0=Atom, 1=Integer, 2=Float, 3=Compound, 4=List, 5=Ref, 6=Unbound, 7=Bool
 %Value = type { i32, i64 }
 
+; === Byte slice ===
+%WamSlice = type { i8*, i64 }             ; pointer, length
+
 ; === Compound and List (heap-allocated) ===
 %Compound = type { i8*, i32, %Value* }    ; functor, arity, args
 %List = type { i32, %Value* }             ; length, elements
@@ -6748,6 +6751,76 @@ fe.yes:
 
 fe.no:
   ret i1 false
+}
+
+define %WamSlice @wam_atom_field_slice_value(%Value %atom_value, i64 %field_index, i8 %sep) {
+entry:
+  %fs.empty0 = insertvalue %WamSlice undef, i8* null, 0
+  %fs.empty = insertvalue %WamSlice %fs.empty0, i64 0, 1
+  %fs.t = call i32 @value_tag(%Value %atom_value)
+  %fs.is_atom = icmp eq i32 %fs.t, 0
+  br i1 %fs.is_atom, label %fs.check_index, label %fs.no
+
+fs.check_index:
+  %fs.index_ok = icmp sgt i64 %field_index, 0
+  br i1 %fs.index_ok, label %fs.lookup, label %fs.no
+
+fs.lookup:
+  %fs.aid = call i64 @value_payload(%Value %atom_value)
+  %fs.str = call i8* @wam_atom_to_string(i64 %fs.aid)
+  %fs.null = icmp eq i8* %fs.str, null
+  br i1 %fs.null, label %fs.no, label %fs.find_loop
+
+fs.find_loop:
+  %fs.cur_index = phi i64 [ 1, %fs.lookup ], [ %fs.next_index, %fs.after_sep ]
+  %fs.start_pos = phi i64 [ 0, %fs.lookup ], [ %fs.after_sep_pos, %fs.after_sep ]
+  %fs.index_match = icmp eq i64 %fs.cur_index, %field_index
+  br i1 %fs.index_match, label %fs.end_loop, label %fs.skip_loop
+
+fs.skip_loop:
+  %fs.skip_pos = phi i64 [ %fs.start_pos, %fs.find_loop ], [ %fs.skip_next_pos, %fs.skip_next ]
+  %fs.skip_ptr = getelementptr i8, i8* %fs.str, i64 %fs.skip_pos
+  %fs.skip_ch = load i8, i8* %fs.skip_ptr
+  %fs.skip_nul = icmp eq i8 %fs.skip_ch, 0
+  br i1 %fs.skip_nul, label %fs.no, label %fs.skip_check_sep
+
+fs.skip_check_sep:
+  %fs.skip_is_sep = icmp eq i8 %fs.skip_ch, %sep
+  br i1 %fs.skip_is_sep, label %fs.after_sep, label %fs.skip_next
+
+fs.skip_next:
+  %fs.skip_next_pos = add i64 %fs.skip_pos, 1
+  br label %fs.skip_loop
+
+fs.after_sep:
+  %fs.after_sep_pos = add i64 %fs.skip_pos, 1
+  %fs.next_index = add i64 %fs.cur_index, 1
+  br label %fs.find_loop
+
+fs.end_loop:
+  %fs.end_pos = phi i64 [ %fs.start_pos, %fs.find_loop ], [ %fs.end_next_pos, %fs.end_next ]
+  %fs.end_ptr = getelementptr i8, i8* %fs.str, i64 %fs.end_pos
+  %fs.end_ch = load i8, i8* %fs.end_ptr
+  %fs.end_nul = icmp eq i8 %fs.end_ch, 0
+  br i1 %fs.end_nul, label %fs.yes, label %fs.end_check_sep
+
+fs.end_check_sep:
+  %fs.end_is_sep = icmp eq i8 %fs.end_ch, %sep
+  br i1 %fs.end_is_sep, label %fs.yes, label %fs.end_next
+
+fs.end_next:
+  %fs.end_next_pos = add i64 %fs.end_pos, 1
+  br label %fs.end_loop
+
+fs.yes:
+  %fs.ptr = getelementptr i8, i8* %fs.str, i64 %fs.start_pos
+  %fs.len = sub i64 %fs.end_pos, %fs.start_pos
+  %fs.slice0 = insertvalue %WamSlice undef, i8* %fs.ptr, 0
+  %fs.slice = insertvalue %WamSlice %fs.slice0, i64 %fs.len, 1
+  ret %WamSlice %fs.slice
+
+fs.no:
+  ret %WamSlice %fs.empty
 }
 
 ; Dispatches on integer op codes:

--- a/examples/plawk/generated/plawk_reader_probe.ll
+++ b/examples/plawk/generated/plawk_reader_probe.ll
@@ -14,6 +14,9 @@ target triple = "x86_64-pc-linux-gnu"
 ; Tag: 0=Atom, 1=Integer, 2=Float, 3=Compound, 4=List, 5=Ref, 6=Unbound, 7=Bool
 %Value = type { i32, i64 }
 
+; === Byte slice ===
+%WamSlice = type { i8*, i64 }             ; pointer, length
+
 ; === Compound and List (heap-allocated) ===
 %Compound = type { i8*, i32, %Value* }    ; functor, arity, args
 %List = type { i32, %Value* }             ; length, elements
@@ -6748,6 +6751,76 @@ fe.yes:
 
 fe.no:
   ret i1 false
+}
+
+define %WamSlice @wam_atom_field_slice_value(%Value %atom_value, i64 %field_index, i8 %sep) {
+entry:
+  %fs.empty0 = insertvalue %WamSlice undef, i8* null, 0
+  %fs.empty = insertvalue %WamSlice %fs.empty0, i64 0, 1
+  %fs.t = call i32 @value_tag(%Value %atom_value)
+  %fs.is_atom = icmp eq i32 %fs.t, 0
+  br i1 %fs.is_atom, label %fs.check_index, label %fs.no
+
+fs.check_index:
+  %fs.index_ok = icmp sgt i64 %field_index, 0
+  br i1 %fs.index_ok, label %fs.lookup, label %fs.no
+
+fs.lookup:
+  %fs.aid = call i64 @value_payload(%Value %atom_value)
+  %fs.str = call i8* @wam_atom_to_string(i64 %fs.aid)
+  %fs.null = icmp eq i8* %fs.str, null
+  br i1 %fs.null, label %fs.no, label %fs.find_loop
+
+fs.find_loop:
+  %fs.cur_index = phi i64 [ 1, %fs.lookup ], [ %fs.next_index, %fs.after_sep ]
+  %fs.start_pos = phi i64 [ 0, %fs.lookup ], [ %fs.after_sep_pos, %fs.after_sep ]
+  %fs.index_match = icmp eq i64 %fs.cur_index, %field_index
+  br i1 %fs.index_match, label %fs.end_loop, label %fs.skip_loop
+
+fs.skip_loop:
+  %fs.skip_pos = phi i64 [ %fs.start_pos, %fs.find_loop ], [ %fs.skip_next_pos, %fs.skip_next ]
+  %fs.skip_ptr = getelementptr i8, i8* %fs.str, i64 %fs.skip_pos
+  %fs.skip_ch = load i8, i8* %fs.skip_ptr
+  %fs.skip_nul = icmp eq i8 %fs.skip_ch, 0
+  br i1 %fs.skip_nul, label %fs.no, label %fs.skip_check_sep
+
+fs.skip_check_sep:
+  %fs.skip_is_sep = icmp eq i8 %fs.skip_ch, %sep
+  br i1 %fs.skip_is_sep, label %fs.after_sep, label %fs.skip_next
+
+fs.skip_next:
+  %fs.skip_next_pos = add i64 %fs.skip_pos, 1
+  br label %fs.skip_loop
+
+fs.after_sep:
+  %fs.after_sep_pos = add i64 %fs.skip_pos, 1
+  %fs.next_index = add i64 %fs.cur_index, 1
+  br label %fs.find_loop
+
+fs.end_loop:
+  %fs.end_pos = phi i64 [ %fs.start_pos, %fs.find_loop ], [ %fs.end_next_pos, %fs.end_next ]
+  %fs.end_ptr = getelementptr i8, i8* %fs.str, i64 %fs.end_pos
+  %fs.end_ch = load i8, i8* %fs.end_ptr
+  %fs.end_nul = icmp eq i8 %fs.end_ch, 0
+  br i1 %fs.end_nul, label %fs.yes, label %fs.end_check_sep
+
+fs.end_check_sep:
+  %fs.end_is_sep = icmp eq i8 %fs.end_ch, %sep
+  br i1 %fs.end_is_sep, label %fs.yes, label %fs.end_next
+
+fs.end_next:
+  %fs.end_next_pos = add i64 %fs.end_pos, 1
+  br label %fs.end_loop
+
+fs.yes:
+  %fs.ptr = getelementptr i8, i8* %fs.str, i64 %fs.start_pos
+  %fs.len = sub i64 %fs.end_pos, %fs.start_pos
+  %fs.slice0 = insertvalue %WamSlice undef, i8* %fs.ptr, 0
+  %fs.slice = insertvalue %WamSlice %fs.slice0, i64 %fs.len, 1
+  ret %WamSlice %fs.slice
+
+fs.no:
+  ret %WamSlice %fs.empty
 }
 
 ; Dispatches on integer op codes:

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -11,6 +11,7 @@
 %
 %      /^PREFIX/ { print $0 }
 %      $N == "VALUE" { print $0 }
+%      $N == "VALUE" { print $M, $K }
 %
 %  The AST is deliberately small and explicit so later syntax can extend it
 %  without changing the native codegen contract.
@@ -19,13 +20,13 @@ plawk_parse_string(Source, Program) :-
     string_codes(Source, Codes),
     phrase(plawk_program(Program), Codes).
 
-plawk_program(program([], [rule(Pattern, [print(field(0))])], [])) -->
+plawk_program(program([], [rule(Pattern, [PrintAction])], [])) -->
     ws,
     pattern(Pattern),
     ws,
     "{",
     ws,
-    print_field_zero,
+    print_action(PrintAction),
     ws,
     "}",
     ws,
@@ -104,10 +105,32 @@ quoted_string_codes([Code | Codes]) -->
 quoted_string_codes([]) -->
     [].
 
-print_field_zero -->
+print_action(print(Fields)) -->
     "print",
     required_ws,
-    "$0".
+    print_fields(Fields).
+
+print_fields([Field | Fields]) -->
+    field_expr(Field),
+    print_fields_rest(Fields).
+
+print_fields_rest([Field | Fields]) -->
+    ws,
+    ",",
+    ws,
+    !,
+    field_expr(Field),
+    print_fields_rest(Fields).
+print_fields_rest([]) -->
+    [].
+
+field_expr(field(Index)) -->
+    "$",
+    integer_codes(IndexCodes),
+    { IndexCodes \== [],
+      number_codes(Index, IndexCodes),
+      Index >= 0
+    }.
 
 required_ws -->
     [Code],

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -46,7 +46,8 @@
     register_functor_string/1,           % +NameStr (assert into functor_string_global table)
     split_functor_arity/3,               % +Str, -Name, -Arity (handles `/` in name)
     llvm_emit_atom_prefix_guard/5,       % +GlobalBase, +ValueIR, +Prefix, +ResultIR, -GlobalIR-CallIR
-    llvm_emit_atom_field_eq_guard/7      % +GlobalBase, +ValueIR, +FieldIndex, +Expected, +SepCode, +ResultIR, -GlobalIR-CallIR
+    llvm_emit_atom_field_eq_guard/7,     % +GlobalBase, +ValueIR, +FieldIndex, +Expected, +SepCode, +ResultIR, -GlobalIR-CallIR
+    llvm_emit_atom_field_slice/5         % +ValueIR, +FieldIndex, +SepCode, +SliceBase, -CallIR
 ]).
 
 :- use_module(library(lists)).
@@ -4307,6 +4308,76 @@ fe.yes:
 
 fe.no:
   ret i1 false
+}
+
+define %WamSlice @wam_atom_field_slice_value(%Value %atom_value, i64 %field_index, i8 %sep) {
+entry:
+  %fs.empty0 = insertvalue %WamSlice undef, i8* null, 0
+  %fs.empty = insertvalue %WamSlice %fs.empty0, i64 0, 1
+  %fs.t = call i32 @value_tag(%Value %atom_value)
+  %fs.is_atom = icmp eq i32 %fs.t, 0
+  br i1 %fs.is_atom, label %fs.check_index, label %fs.no
+
+fs.check_index:
+  %fs.index_ok = icmp sgt i64 %field_index, 0
+  br i1 %fs.index_ok, label %fs.lookup, label %fs.no
+
+fs.lookup:
+  %fs.aid = call i64 @value_payload(%Value %atom_value)
+  %fs.str = call i8* @wam_atom_to_string(i64 %fs.aid)
+  %fs.null = icmp eq i8* %fs.str, null
+  br i1 %fs.null, label %fs.no, label %fs.find_loop
+
+fs.find_loop:
+  %fs.cur_index = phi i64 [ 1, %fs.lookup ], [ %fs.next_index, %fs.after_sep ]
+  %fs.start_pos = phi i64 [ 0, %fs.lookup ], [ %fs.after_sep_pos, %fs.after_sep ]
+  %fs.index_match = icmp eq i64 %fs.cur_index, %field_index
+  br i1 %fs.index_match, label %fs.end_loop, label %fs.skip_loop
+
+fs.skip_loop:
+  %fs.skip_pos = phi i64 [ %fs.start_pos, %fs.find_loop ], [ %fs.skip_next_pos, %fs.skip_next ]
+  %fs.skip_ptr = getelementptr i8, i8* %fs.str, i64 %fs.skip_pos
+  %fs.skip_ch = load i8, i8* %fs.skip_ptr
+  %fs.skip_nul = icmp eq i8 %fs.skip_ch, 0
+  br i1 %fs.skip_nul, label %fs.no, label %fs.skip_check_sep
+
+fs.skip_check_sep:
+  %fs.skip_is_sep = icmp eq i8 %fs.skip_ch, %sep
+  br i1 %fs.skip_is_sep, label %fs.after_sep, label %fs.skip_next
+
+fs.skip_next:
+  %fs.skip_next_pos = add i64 %fs.skip_pos, 1
+  br label %fs.skip_loop
+
+fs.after_sep:
+  %fs.after_sep_pos = add i64 %fs.skip_pos, 1
+  %fs.next_index = add i64 %fs.cur_index, 1
+  br label %fs.find_loop
+
+fs.end_loop:
+  %fs.end_pos = phi i64 [ %fs.start_pos, %fs.find_loop ], [ %fs.end_next_pos, %fs.end_next ]
+  %fs.end_ptr = getelementptr i8, i8* %fs.str, i64 %fs.end_pos
+  %fs.end_ch = load i8, i8* %fs.end_ptr
+  %fs.end_nul = icmp eq i8 %fs.end_ch, 0
+  br i1 %fs.end_nul, label %fs.yes, label %fs.end_check_sep
+
+fs.end_check_sep:
+  %fs.end_is_sep = icmp eq i8 %fs.end_ch, %sep
+  br i1 %fs.end_is_sep, label %fs.yes, label %fs.end_next
+
+fs.end_next:
+  %fs.end_next_pos = add i64 %fs.end_pos, 1
+  br label %fs.end_loop
+
+fs.yes:
+  %fs.ptr = getelementptr i8, i8* %fs.str, i64 %fs.start_pos
+  %fs.len = sub i64 %fs.end_pos, %fs.start_pos
+  %fs.slice0 = insertvalue %WamSlice undef, i8* %fs.ptr, 0
+  %fs.slice = insertvalue %WamSlice %fs.slice0, i64 %fs.len, 1
+  ret %WamSlice %fs.slice
+
+fs.no:
+  ret %WamSlice %fs.empty
 }
 
 ; Dispatches on integer op codes:
@@ -15729,6 +15800,19 @@ llvm_emit_atom_field_eq_guard(GlobalBase, ValueIR, FieldIndex, Expected, SepCode
         '  %~w_ptr = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0~n  ~w = call i1 @wam_atom_field_eq_value(%Value ~w, i64 ~w, i8* %~w_ptr, i64 ~w, i8 ~w)',
         [SafeBase, ArrLen, ArrLen, SafeBase,
          ResultIR, ValueIR, FieldIndex, SafeBase, ExpectedLen, SepCode]).
+
+%% llvm_emit_atom_field_slice(+ValueIR, +FieldIndex, +SepCode, +SliceBase, -CallIR)
+%
+%  Emit a native field projection over an atom-backed text record. The runtime
+%  returns a %WamSlice without allocating a field substring; CallIR defines
+%  %SliceBase, %SliceBase_ptr, and %SliceBase_len.
+llvm_emit_atom_field_slice(ValueIR, FieldIndex, SepCode, SliceBase, CallIR) :-
+    format(atom(CallIR),
+        '  %~w = call %WamSlice @wam_atom_field_slice_value(%Value ~w, i64 ~w, i8 ~w)~n  %~w_ptr = extractvalue %WamSlice %~w, 0~n  %~w_len64 = extractvalue %WamSlice %~w, 1~n  %~w_len = trunc i64 %~w_len64 to i32',
+        [SliceBase, ValueIR, FieldIndex, SepCode,
+         SliceBase, SliceBase,
+         SliceBase, SliceBase,
+         SliceBase, SliceBase]).
 
 escape_llvm_codes([], []).
 escape_llvm_codes([C|Cs], Out) :-

--- a/templates/targets/llvm_wam/types.ll.mustache
+++ b/templates/targets/llvm_wam/types.ll.mustache
@@ -6,6 +6,9 @@
 ; Tag: 0=Atom, 1=Integer, 2=Float, 3=Compound, 4=List, 5=Ref, 6=Unbound, 7=Bool
 %Value = type { i32, i64 }
 
+; === Byte slice ===
+%WamSlice = type { i8*, i64 }             ; pointer, length
+
 ; === Compound and List (heap-allocated) ===
 %Compound = type { i8*, i32, %Value* }    ; functor, arity, args
 %List = type { i32, %Value* }             ; length, elements

--- a/templates/targets/llvm_wam_wasm/types.ll.mustache
+++ b/templates/targets/llvm_wam_wasm/types.ll.mustache
@@ -8,6 +8,9 @@
 ; Note: payload is i64 even on wasm32 — WASM supports i64 natively
 %Value = type { i32, i64 }
 
+; === Byte slice ===
+%WamSlice = type { i8*, i64 }             ; pointer, length
+
 ; === Compound and List (linear memory offsets) ===
 ; On wasm32, pointers are i32 offsets into linear memory
 %Compound = type { i32, i32, i32 }        ; functor offset, arity, args offset

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -23,11 +23,15 @@ clang_available :-
 
 test(parses_prefix_print_rule) :-
     plawk_parse_string("/^ERROR/ { print $0 }\n", Program),
-    assertion(Program == program([], [rule(prefix("ERROR"), [print(field(0))])], [])).
+    assertion(Program == program([], [rule(prefix("ERROR"), [print([field(0)])])], [])).
 
 test(parses_field_eq_print_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { print $0 }\n", Program),
-    assertion(Program == program([], [rule(field_eq(1, "ERROR"), [print(field(0))])], [])).
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"), [print([field(0)])])], [])).
+
+test(parses_field_eq_print_fields_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { print $2, $3 }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"), [print([field(2), field(3)])])], [])).
 
 test(surface_prefix_prints_matching_records) :-
     run_surface_print_smoke("/^ERROR/ { print $0 }\n",
@@ -38,6 +42,11 @@ test(surface_field_eq_prints_matching_records) :-
     run_surface_print_smoke("$1 == \"ERROR\" { print $0 }\n",
         "INFO boot ok\nNOTERROR misleading\nWARN cpu hot\nERROR net down\n",
         "ERROR net down\n").
+
+test(surface_field_eq_prints_selected_fields) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { print $2, $3 }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "disk full\nnet down\n").
 
 run_surface_print_smoke(Source, Input, ExpectedOutput) :-
     tmp_root(Root),

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -195,6 +195,7 @@ test(full_runtime_generation) :-
     % Helpers
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @backtrack')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_field_eq_value')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamSlice @wam_atom_field_slice_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_prefix_value')).
 
 test(atom_prefix_guard_emitter) :-
@@ -210,6 +211,12 @@ test(atom_field_eq_guard_emitter) :-
     assertion(sub_atom(CallIR, _, _, _, '%field_5Feq_5Fguard_5Ftest_ptr = getelementptr')),
     assertion(sub_atom(CallIR, _, _, _, '%ok = call i1 @wam_atom_field_eq_value(%Value %line, i64 1')),
     assertion(sub_atom(CallIR, _, _, _, 'i64 5, i8 32')).
+
+test(atom_field_slice_emitter) :-
+    llvm_emit_atom_field_slice('%line', 2, 32, plawk_f2, CallIR),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_f2 = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 2, i8 32)')),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_f2_ptr = extractvalue %WamSlice %plawk_f2, 0')),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_f2_len = trunc i64 %plawk_f2_len64 to i32')).
 
 % ============================================================================
 % Builtin op ID mapping


### PR DESCRIPTION
## Summary

- Add `%WamSlice` and `@wam_atom_field_slice_value` so WAM/LLVM can project one-based text fields as byte slices without allocating substrings.
- Add `llvm_emit_atom_field_slice/5` for reusable target-side field projection emission.
- Extend the PLAWK parser/action AST from `print $0` to selected-field lists such as `print $2, $3`.
- Extend PLAWK native codegen to print selected field slices using `printf("%.*s")` and the existing stream loop.
- Add an end-to-end smoke for `$1 == "ERROR" { print $2, $3 }`.
- Regenerate tracked PLAWK `.ll` probes so runtime snapshots include `%WamSlice` and the slice helper.

## Validation

- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/test_plawk_native_lowered_handler_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s examples/plawk/probes/generate_core_probe.pl -t halt`
- `swipl -q -s examples/plawk/probes/generate_loop_probe.pl -t halt`
- `swipl -q -s examples/plawk/probes/generate_meta_call_probe.pl -t halt`
- `swipl -q -s examples/plawk/probes/generate_reader_probe.pl -t halt`
- `llvm-as examples/plawk/generated/plawk_core_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_loop_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_meta_call_probe.ll -o /dev/null`
- `llvm-as examples/plawk/generated/plawk_reader_probe.ll -o /dev/null`
- `git diff --check`
- `git diff --cached --check`