### PR TITLE
WAM Rust P5 (maplist/atomic_list_concat/char_type + put_list fix) + cross-target bind-through sweep (6 targets fixed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Cross-target sweep: PutStructure A-register bind-through
+  (M139/M140 class) fixed in Go, Scala, Kotlin, Haskell, C, and WAT.**
+  After the Rust P4 fix, behavioral probes through every other
+  target's real project writer and toolchain found the same ancestral
+  defect in six runtimes: put_structure (and sometimes put_list)
+  bound the target register's old occupant to the freshly built term,
+  so any clause shaped `p(X, ...) :- q(f(X), ...), use(X)` created a
+  cyclic term `X = f(X)` and wrong-failed (in C the bind was also
+  UNTRAILED — a backtracking corruption hazard). The fix everywhere:
+  condition the bind-through on the register class (A registers are
+  argument staging and never bind; X/Y keep the top-down
+  structure-chaining placeholder bind). Kotlin additionally had a
+  put-as-get defect (put_structure/put_list routed through the
+  get-style `beginStructure`, wrong-failing on any stale constant
+  occupant — fixed with a write-mode `beginStructurePut`) and gained
+  `==/2`/`\==/2` builtin arms. C++, LLVM (M140 regression-verified),
+  F# (cycle-check-guarded), and Rust are clean; class 2 (non-atom
+  list heads, the Rust P5 put_list bug) is clean on all probed
+  targets; ILasm is blocked by a newly pinned structural defect
+  (cross-predicate calls resolve against the local label table and
+  self-loop); Python/Lua/R/Clojure/Elixir probes are pending (agent
+  quota). Full verdicts, per-target evidence, verification
+  methodology, and side findings (missing `==/2` in C/Haskell, the
+  Kotlin env-restore defect, an F# theoretical aliasing divergence)
+  in `docs/reports/wam_bindthrough_cross_target_sweep.md`. New
+  regression test `tests/test_wam_go_bindthrough.pl`; gated by the
+  cross-target conformance suite (go/scala/haskell/c/wat) plus
+  per-target suites.
+
 ### Added
 - **WAM Rust target: maplist family, atomic_list_concat, char_type
   (parity P5 — closes the builtin ledger).** Built on the P4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **WAM Rust target: maplist family, atomic_list_concat, char_type
+  (parity P5 — closes the builtin ledger).** Built on the P4
+  meta-call machinery (`call_goal_value` + per-element first-solution
+  commit): `maplist/2..5` (unbound list arguments unified with
+  fresh-variable lists), `include/3`, `exclude/3` (trial calls,
+  bindings unwound per element), `partition/4`, `foldl/4`, `foldl/5`
+  (accumulator threaded through fresh variables). Plus
+  `atomic_list_concat/2`, `atomic_list_concat/3` (join + split modes;
+  empty-separator split rejected), and `char_type/2` (+Char mode:
+  alpha/alnum/csym/csymf/space/white/punct/graph/ascii/upper/lower/
+  end_of_line/newline, parameterized digit(W)/to_lower/to_upper/
+  upper(L)/lower(U)). 7 new cargo-built tests (28 total), incl.
+  compiled-predicate paths calling user-defined goals per element
+  through label sub-runs.
+
+### Fixed
+- **WAM Rust target: put_list never completed lists with non-atom
+  heads (latent).** `set_heap_or_list` keyed list-completion on the
+  head cell being a non-placeholder *atom*, so a literal list whose
+  first element was an integer/float/compound (e.g.
+  `maplist(double, [1,2,3], L)`) never materialised — the second
+  value fell through to a plain heap push and the register kept the
+  put_list scratch marker (`Integer(0)`). All earlier list tests
+  happened to use atom heads. List mode is now identified by the
+  tail sentinel at marker+1, independent of the head value. Exposed
+  by the P5 maplist tests; all existing suites pass unchanged.
 - **WAM Rust target: ISO catch/3, throw/1 and succ/2 (parity P4).**
   Completes the F#-parity control-flow milestone. Mechanism (mutable
   WamState in place of F#'s exception + immutable-snapshot design): a

--- a/docs/reports/wam_bindthrough_cross_target_sweep.md
+++ b/docs/reports/wam_bindthrough_cross_target_sweep.md
@@ -1,0 +1,93 @@
+# Cross-target sweep: PutStructure A-register bind-through + non-atom list heads
+
+Date: 2026-06-12. Follow-up to the two latent bugs found in the Rust
+target during the parity campaign (P4/P5): the M139/M140-class
+PutStructure bind-through (cyclic `X = f(X)` when a goal structure
+embedding a live head variable is built into the same A register) and
+the put_list completion keyed on the head cell being an atom. All 15
+other WAM targets were probed behaviorally through their real project
+writers and toolchains (R=1/R=0 discriminator convention; hangs
+time-boxed and counted as positive class-1 signals).
+
+Probes:
+
+```prolog
+mk1(T, T).
+bindthrough(X, W) :- mk1(f(X), W), X = 1.
+p_bind(R) :- bindthrough(_X, W), W == f(1), R is 1.   % class 1
+lhead([H|_], H).
+p_list(R) :- lhead([7,8], V), V =:= 7, R is 1.        % class 2
+p_listatom(R) :- lhead([a,b], V), V == a, R is 1.     % class-2 control
+```
+
+(Where a target lacks `==/2`, equivalent `=`/`nonvar` variants carried
+the verdict; several targets ALSO turned out to be missing `==/2` —
+see side findings.)
+
+## Verdicts and actions
+
+| Target | Class 1 (bind-through) | Class 2 (list heads) | Action |
+|---|---|---|---|
+| Go | **BUGGY** → fixed | clean | guard `i.Ai >= 100` in `wam_go_case('PutStructure')`; regression test `tests/test_wam_go_bindthrough.pl` |
+| Scala | **BUGGY** → fixed | clean | guard `top.targetReg >= 100` in `finalizeBuild` (`runtime.scala.mustache`); verified via probe battery (8/8) |
+| Kotlin | **BUGGY** → fixed (+ put-as-get defect → fixed) | clean | `bindTarget` A-guard; new `beginStructurePut` (put_structure/put_list were routed through get-style dispatch and wrong-failed on stale constants); `==/2`, `\==/2` added to the builtin table |
+| Haskell | **BUGGY** → fixed | clean | guard `ai >= 100` in `addToBuilder` BuildStruct AND BuildList finalize arms (covers both pure and ST interpreters) |
+| C | **BUGGY** (and UNTRAILED — backtracking hazard) → fixed | clean | guard `instr->as.functor.is_y_reg != 0` in `INSTR_PUT_STRUCTURE` |
+| WAT | **BUGGY** → fixed | clean | guard `$ai >= 32` in `put_structure` and `put_list` cases (A = 0–31) |
+| C++ | clean | clean | — |
+| LLVM | clean (M140 fix regression-verified on this probe shape) | clean (distinct from ledger item 4) | — |
+| F# | clean (cycle-check-guarded bind-through) | clean | see theoretical divergence below |
+| Rust | fixed in P4/P5 (origin of the sweep) | fixed in P5 | — |
+| ILasm | BLOCKED | BLOCKED | newly pinned structural defect: cross-predicate `call` self-loops (below) |
+| Python, Lua, R, Clojure, Elixir | **PENDING** | **PENDING** | probe agents hit the session quota; re-run the sweep prompt for these five |
+
+Verification: every fixed target re-probed through the same harness
+(the bug-shape probe flips to the ISO answer; all controls — including
+the legitimate X-register placeholder chaining the guard must preserve
+— unchanged). Gates: cross-target conformance suite
+(`CONFORMANCE_TARGETS=go,scala,haskell,c,wat` — all pass),
+`test_wam_c_var_alias`, WAT lowered t4/t6, Kotlin target suite (9/9),
+Go negcut + lowered t4/t5/t6/ite suites.
+
+## The defect, once
+
+Every buggy runtime shared the same ancestral pattern: put_structure
+(and sometimes put_list) "helpfully" binds the target register's old
+occupant when it derefs to an unbound variable, to support top-down
+nested-term construction (`set_variable Xn` placeholder, then
+`put_structure F, Xn`). That bind is correct ONLY for X/Y registers,
+where placeholders live. A registers are argument staging: their old
+occupant is an unrelated live variable (typically a clause-head
+argument), and binding it to the structure being built — which often
+embeds that same variable — creates a cyclic term. The canonical
+trigger is any clause shaped like `p(X, ...) :- q(f(X), ...), use(X)`.
+The fix is identical everywhere: condition the bind-through on the
+register class.
+
+## Side findings (filed here, not fixed in this sweep)
+
+1. **`==/2` (and the `@<` family / `\==`) missing from several
+   runtimes**: C (`wam_execute_builtin` falls through to false),
+   Haskell (no `BuiltinCall "==/2"` arm; falls to `step _ _ _ =
+   Nothing`), Kotlin (fixed for `==`/`\==` in this sweep). The shared
+   compiler emits these as `builtin_call`; they fail closed — the same
+   class-7 gap the Rust P3 sweep closed. A Rust-P3-style builtin
+   parity sweep applies to each.
+2. **Kotlin: callee bindings wiped on return** —
+   `returnFromPredicate` restores the environment from the call-time
+   snapshot, discarding bindings the callee made to caller variables
+   (`mk1(7, V)` leaves V unbound). Structural; beyond the
+   low-investment budget for Kotlin, needs its own campaign.
+3. **ILasm: cross-predicate `call` self-loops** — each predicate gets
+   its own code/label arrays, `call other/N` resolves against the
+   LOCAL label table, and unknown labels default to index 0, so any
+   cross-predicate call jumps to the calling predicate's own start
+   (infinite loop at runtime, no generation-time warning). Distinct
+   from the documented compound-term stubs; pin for the ILasm
+   campaign resumption.
+4. **F# theoretical divergence**: F# guards its bind-through with a
+   cycle check (`containsVid`) rather than a register-class condition.
+   A NON-cyclic variant — building a goal structure that does not
+   contain X into an A register whose occupant is the live head var X
+   — would still alias X to that structure. Not exercised by these
+   probes; worth one targeted probe in the F# stream.

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -2389,10 +2389,24 @@ compile_step_wam_to_c(_Options, CCode) :-
                    +(+(A,B),C)), bind that cell to the new structure as well —
                    otherwise the enclosing structure keeps pointing at the
                    still-unbound placeholder and eval/unify never see this
-                   subterm. */
-                WamValue *placeholder = wam_deref_ptr(state, cell);
-                if (placeholder != cell && placeholder->tag == VAL_UNBOUND) {
-                    *placeholder = s;
+                   subterm.
+
+                   A-REGISTER EXCEPTION (M139/M140 bind-through class): A
+                   registers (is_y_reg == 0; X == 2, Y == 1) are argument
+                   STAGING — their old occupant is an unrelated variable
+                   (often a clause-head argument), and writing the new
+                   structure into its heap cell creates a cyclic term
+                   (X = f(X)) — and did so UNTRAILED, a backtracking
+                   corruption hazard on top of the wrong-fail. set_variable
+                   placeholders only ever live in X/Y registers, so the
+                   bind-through is conditioned on the register class — the
+                   same fix the Rust, Go, Scala, Kotlin, Haskell and LLVM
+                   targets carry. */
+                if (instr->as.functor.is_y_reg != 0) {
+                    WamValue *placeholder = wam_deref_ptr(state, cell);
+                    if (placeholder != cell && placeholder->tag == VAL_UNBOUND) {
+                        *placeholder = s;
+                    }
                 }
                 *cell = s;
 

--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -1894,9 +1894,20 @@ wam_go_case('PutStructure', '        addr := vm.heapPush(nil)
         // list tail cell [|]/2 — leaving a placeholder in the arg slot that
         // a later put_structure into the same register must fill. Trailing
         // via bindUnbound keeps it backtrack-safe.
-        if cur := vm.Regs[i.Ai]; cur != nil {
-            if u, ok := vm.deref(cur).(*Unbound); ok {
-                vm.bindUnbound(u, ref)
+        //
+        // A-REGISTER EXCEPTION (M139/M140 bind-through class): A registers
+        // (index < 100) are argument STAGING — their old occupant is an
+        // unrelated variable (often a clause-head argument), and binding it
+        // to the new cell creates a cyclic term (X = f(X)), making a later
+        // X = 1 wrong-fail. Top-down chaining placeholders only ever live
+        // in X/Y registers (set_variable Xn), so the bind-through is
+        // conditioned on the register class — the same fix the Rust and
+        // LLVM targets carry.
+        if i.Ai >= 100 {
+            if cur := vm.Regs[i.Ai]; cur != nil {
+                if u, ok := vm.deref(cur).(*Unbound); ok {
+                    vm.bindUnbound(u, ref)
+                }
             }
         }
         vm.Regs[i.Ai] = ref

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -5227,9 +5227,21 @@ addToBuilder val s = case wsBuilder s of
                 -- must ALSO bind the var ai currently holds, or the outer
                 -- term keeps an unbound tail -- the multi-element list bug
                 -- that made reverse/append wrong on lists of length >= 2.
-                sBound = case IM.lookup ai (wsRegs s) of
-                  Just (Unbound vid) -> bindUnbound vid term s
-                  _ -> s
+                --
+                -- A-REGISTER EXCEPTION (M139/M140 bind-through class):
+                -- A registers (ai < 100; X = 101+, Y = 201+) are argument
+                -- STAGING -- their old occupant is an unrelated variable
+                -- (often a clause-head argument), and binding it to the
+                -- freshly built term creates a cyclic term (X = f(X)),
+                -- wrong-failing a later X = 1. The set_variable
+                -- placeholders only ever live in X/Y registers, so the
+                -- bind-through is conditioned on the register class --
+                -- the same fix the Rust, Go, Scala and Kotlin targets carry.
+                sBound = if ai >= 100
+                  then case IM.lookup ai (wsRegs s) of
+                    Just (Unbound vid) -> bindUnbound vid term s
+                    _ -> s
+                  else s
             in Just (sBound { wsPC = wsPC s + 1
                             , wsRegs = IM.insert ai term (wsRegs sBound)
                             , wsBuilder = NoBuilder
@@ -5253,10 +5265,13 @@ addToBuilder val s = case wsBuilder s of
                   _           -> Str atomDot [hd, tl]
                 -- Same placeholder-var binding as BuildStruct: a list built
                 -- into a register that holds a set_variable placeholder must
-                -- bind that var so an enclosing term sees the list.
-                sBound = case IM.lookup ai (wsRegs s) of
-                  Just (Unbound vid) -> bindUnbound vid list s
-                  _ -> s
+                -- bind that var so an enclosing term sees the list. Same
+                -- A-register exception as BuildStruct (M139/M140 class).
+                sBound = if ai >= 100
+                  then case IM.lookup ai (wsRegs s) of
+                    Just (Unbound vid) -> bindUnbound vid list s
+                    _ -> s
+                  else s
             in Just (sBound { wsPC = wsPC s + 1
                        , wsRegs = IM.insert ai list (wsRegs sBound)
                        , wsBuilder = NoBuilder

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -3780,6 +3780,124 @@ compile_execute_ext_builtin_to_rust(Code) :-
                     }
                 }
             }
+            "atomic_list_concat/2" => {
+                let items = match self.get_reg_raw("A1").map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::List(items)) => items,
+                    _ => return false,
+                };
+                let mut text = String::new();
+                for item in &items {
+                    match Self::value_atomic_text(&self.deref_var(item)) {
+                        Some(t) => text.push_str(&t),
+                        None => return false,
+                    }
+                }
+                let a2 = self.get_reg_raw("A2").unwrap_or(Value::Uninit);
+                if self.unify(&a2, &Value::Atom(text)) { self.pc += 1; true } else { false }
+            }
+            "atomic_list_concat/3" => {
+                // Join mode (+List, +Sep, ?Atom) or split mode
+                // (?List, +Sep nonempty, +Atom).
+                let sep = match self.get_reg_raw("A2").map(|v| self.deref_var(&v))
+                    .as_ref().and_then(Self::value_atomic_text) {
+                    Some(s) => s,
+                    None => return false,
+                };
+                let v1 = self.get_reg_raw("A1").map(|v| self.deref_heap(&self.deref_var(&v))).unwrap_or(Value::Uninit);
+                match v1 {
+                    Value::List(items) => {
+                        let mut parts: Vec<String> = Vec::with_capacity(items.len());
+                        for item in &items {
+                            match Self::value_atomic_text(&self.deref_var(item)) {
+                                Some(t) => parts.push(t),
+                                None => return false,
+                            }
+                        }
+                        let joined = Value::Atom(parts.join(&sep));
+                        let a3 = self.get_reg_raw("A3").unwrap_or(Value::Uninit);
+                        if self.unify(&a3, &joined) { self.pc += 1; true } else { false }
+                    }
+                    Value::Unbound(_) => {
+                        if sep.is_empty() { return false; }
+                        let whole = match self.get_reg_raw("A3").map(|v| self.deref_var(&v))
+                            .as_ref().and_then(Self::value_atomic_text) {
+                            Some(t) => t,
+                            None => return false,
+                        };
+                        let parts: Vec<Value> = whole.split(&sep as &str)
+                            .map(|p| Value::Atom(p.to_string()))
+                            .collect();
+                        let a1 = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
+                        if self.unify(&a1, &Value::List(parts)) { self.pc += 1; true } else { false }
+                    }
+                    _ => false,
+                }
+            }
+            "char_type/2" => {
+                // +Char mode only; the common type terms. Parameterized
+                // forms unify their argument (digit weight, case pairs).
+                let ch = match self.get_reg_raw("A1").map(|v| self.deref_var(&v)) {
+                    Some(Value::Atom(s)) if s.chars().count() == 1 => s.chars().next().unwrap(),
+                    _ => return false,
+                };
+                let ty = self.get_reg_raw("A2").map(|v| self.deref_heap(&self.deref_var(&v))).unwrap_or(Value::Uninit);
+                match &ty {
+                    Value::Atom(t) => {
+                        let ok = match t.as_str() {
+                            "alpha" => ch.is_alphabetic(),
+                            "alnum" => ch.is_alphanumeric(),
+                            "csym" => ch.is_alphanumeric() || ch == ''_'',
+                            "csymf" => ch.is_alphabetic() || ch == ''_'',
+                            "space" | "white" => ch.is_whitespace(),
+                            "punct" => ch.is_ascii_punctuation(),
+                            "graph" => !ch.is_whitespace() && !ch.is_control(),
+                            "ascii" => ch.is_ascii(),
+                            "upper" => ch.is_uppercase(),
+                            "lower" => ch.is_lowercase(),
+                            "end_of_line" => (ch as u32) == 10 || (ch as u32) == 13,
+                            "newline" => (ch as u32) == 10,
+                            _ => return false,
+                        };
+                        if ok { self.pc += 1; true } else { false }
+                    }
+                    Value::Str(f, args) if args.len() == 1 => {
+                        let name = Self::display_functor_name(f, 1);
+                        let arg = args[0].clone();
+                        match name.as_str() {
+                            "digit" => {
+                                match ch.to_digit(10) {
+                                    Some(w) => {
+                                        if self.unify(&arg, &Value::Integer(w as i64)) {
+                                            self.pc += 1; true
+                                        } else { false }
+                                    }
+                                    None => false,
+                                }
+                            }
+                            "to_lower" => {
+                                let lo = ch.to_lowercase().next().unwrap_or(ch);
+                                if self.unify(&arg, &Value::Atom(lo.to_string())) { self.pc += 1; true } else { false }
+                            }
+                            "to_upper" => {
+                                let up = ch.to_uppercase().next().unwrap_or(ch);
+                                if self.unify(&arg, &Value::Atom(up.to_string())) { self.pc += 1; true } else { false }
+                            }
+                            "upper" => {
+                                if !ch.is_uppercase() { return false; }
+                                let lo = ch.to_lowercase().next().unwrap_or(ch);
+                                if self.unify(&arg, &Value::Atom(lo.to_string())) { self.pc += 1; true } else { false }
+                            }
+                            "lower" => {
+                                if !ch.is_lowercase() { return false; }
+                                let up = ch.to_uppercase().next().unwrap_or(ch);
+                                if self.unify(&arg, &Value::Atom(up.to_string())) { self.pc += 1; true } else { false }
+                            }
+                            _ => false,
+                        }
+                    }
+                    _ => false,
+                }
+            }
             "ground/1" => {
                 let v = self.get_reg_raw("A1").unwrap_or(Value::Uninit);
                 if self.value_is_ground(&v) { self.pc += 1; true } else { false }
@@ -3958,8 +4076,188 @@ compile_execute_meta_builtin_to_rust(Code) :-
                     }
                 }
             }
+            "maplist/2" | "maplist/3" | "maplist/4" | "maplist/5" => {
+                // maplist(Goal, L1, ..., Lk): call Goal extended with the
+                // i-th element of every list, for every i. Unbound list
+                // arguments are unified with fresh-variable lists of the
+                // length determined by the first bound list. Each element
+                // call commits to its first solution.
+                let nlists = _arity - 1;
+                let goal = self.get_reg_raw("A1")
+                    .map(|v| self.deref_heap(&self.deref_var(&v)))
+                    .unwrap_or(Value::Uninit);
+                let raw_lists: Vec<Value> = (0..nlists)
+                    .map(|j| self.get_reg_raw(&format!("A{}", j + 2)).unwrap_or(Value::Uninit))
+                    .collect();
+                let mut elems: Vec<Option<Vec<Value>>> = Vec::with_capacity(nlists);
+                let mut n: Option<usize> = None;
+                for raw in &raw_lists {
+                    match self.deref_heap(&self.deref_var(raw)) {
+                        Value::List(items) => {
+                            match n {
+                                Some(len) if len != items.len() => return false,
+                                _ => n = Some(items.len()),
+                            }
+                            elems.push(Some(items));
+                        }
+                        Value::Unbound(_) => elems.push(None),
+                        _ => return false,
+                    }
+                }
+                let n = match n {
+                    Some(n) => n,
+                    None => return false, // all lists unbound: unbounded
+                };
+                for j in 0..nlists {
+                    if elems[j].is_none() {
+                        let fresh: Vec<Value> = (0..n).map(|_| self.fresh_meta_var()).collect();
+                        if !self.unify(&raw_lists[j], &Value::List(fresh.clone())) {
+                            return false;
+                        }
+                        elems[j] = Some(fresh);
+                    }
+                }
+                for i in 0..n {
+                    let extra: Vec<Value> = (0..nlists)
+                        .map(|j| self.deref_var(&elems[j].as_ref().unwrap()[i]))
+                        .collect();
+                    let g = match self.extend_goal(&goal, &extra) {
+                        Some(g) => g,
+                        None => return false,
+                    };
+                    if !self.call_goal_once(&g) { return false; }
+                }
+                self.pc += 1; true
+            }
+            "include/3" | "exclude/3" => {
+                // Filter: keep elements for which the test call succeeds
+                // (include) or fails (exclude). Test-call bindings are
+                // trial-only and unwound after each element.
+                let goal = self.get_reg_raw("A1")
+                    .map(|v| self.deref_heap(&self.deref_var(&v)))
+                    .unwrap_or(Value::Uninit);
+                let items = match self.get_reg_raw("A2").map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::List(items)) => items,
+                    _ => return false,
+                };
+                let keep_on = op == "include/3";
+                let mut kept: Vec<Value> = Vec::new();
+                for item in &items {
+                    let g = match self.extend_goal(&goal, &[self.deref_var(item)]) {
+                        Some(g) => g,
+                        None => return false,
+                    };
+                    let mark = self.trail.len();
+                    let ok = self.call_goal_once(&g);
+                    self.unwind_trail_to(mark);
+                    if !ok && self.thrown_ball.is_some() { return false; }
+                    if ok == keep_on { kept.push(item.clone()); }
+                }
+                let a3 = self.get_reg_raw("A3").unwrap_or(Value::Uninit);
+                if self.unify(&a3, &Value::List(kept)) { self.pc += 1; true } else { false }
+            }
+            "partition/4" => {
+                let goal = self.get_reg_raw("A1")
+                    .map(|v| self.deref_heap(&self.deref_var(&v)))
+                    .unwrap_or(Value::Uninit);
+                let items = match self.get_reg_raw("A2").map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::List(items)) => items,
+                    _ => return false,
+                };
+                let mut incl: Vec<Value> = Vec::new();
+                let mut excl: Vec<Value> = Vec::new();
+                for item in &items {
+                    let g = match self.extend_goal(&goal, &[self.deref_var(item)]) {
+                        Some(g) => g,
+                        None => return false,
+                    };
+                    let mark = self.trail.len();
+                    let ok = self.call_goal_once(&g);
+                    self.unwind_trail_to(mark);
+                    if !ok && self.thrown_ball.is_some() { return false; }
+                    if ok { incl.push(item.clone()); } else { excl.push(item.clone()); }
+                }
+                let a3 = self.get_reg_raw("A3").unwrap_or(Value::Uninit);
+                let a4 = self.get_reg_raw("A4").unwrap_or(Value::Uninit);
+                if self.unify(&a3, &Value::List(incl)) && self.unify(&a4, &Value::List(excl)) {
+                    self.pc += 1; true
+                } else { false }
+            }
+            "foldl/4" | "foldl/5" => {
+                // foldl(Goal, L1[, L2], V0, V): thread an accumulator
+                // through per-element calls Goal(X1[, X2], Acc0, Acc1).
+                let two_lists = op == "foldl/5";
+                let goal = self.get_reg_raw("A1")
+                    .map(|v| self.deref_heap(&self.deref_var(&v)))
+                    .unwrap_or(Value::Uninit);
+                let l1 = match self.get_reg_raw("A2").map(|v| self.deref_heap(&self.deref_var(&v))) {
+                    Some(Value::List(items)) => items,
+                    _ => return false,
+                };
+                let l2: Option<Vec<Value>> = if two_lists {
+                    match self.get_reg_raw("A3").map(|v| self.deref_heap(&self.deref_var(&v))) {
+                        Some(Value::List(items)) if items.len() == l1.len() => Some(items),
+                        _ => return false,
+                    }
+                } else { None };
+                let acc0_reg = if two_lists { "A4" } else { "A3" };
+                let out_reg = if two_lists { "A5" } else { "A4" };
+                let mut acc = self.get_reg_raw(acc0_reg)
+                    .map(|v| self.deref_var(&v))
+                    .unwrap_or(Value::Uninit);
+                for i in 0..l1.len() {
+                    let next = self.fresh_meta_var();
+                    let mut extra: Vec<Value> = vec![self.deref_var(&l1[i])];
+                    if let Some(ref l2v) = l2 {
+                        extra.push(self.deref_var(&l2v[i]));
+                    }
+                    extra.push(acc.clone());
+                    extra.push(next.clone());
+                    let g = match self.extend_goal(&goal, &extra) {
+                        Some(g) => g,
+                        None => return false,
+                    };
+                    if !self.call_goal_once(&g) { return false; }
+                    acc = self.deref_var(&next);
+                }
+                let out = self.get_reg_raw(out_reg).unwrap_or(Value::Uninit);
+                if self.unify(&out, &acc) { self.pc += 1; true } else { false }
+            }
             _ => false,
         }
+    }
+
+    /// Append arguments to a callable (call/N semantics for the
+    /// maplist/include/foldl family). Atoms become compounds; compound
+    /// goals get the extra arguments appended after their own.
+    fn extend_goal(&self, base: &Value, extra: &[Value]) -> Option<Value> {
+        match base {
+            Value::Atom(name) => Some(Value::Str(name.clone(), extra.to_vec())),
+            Value::Str(f, args) => {
+                let name = Self::display_functor_name(f, args.len());
+                let mut all = args.clone();
+                all.extend_from_slice(extra);
+                Some(Value::Str(name, all))
+            }
+            _ => None,
+        }
+    }
+
+    fn fresh_meta_var(&mut self) -> Value {
+        self.var_counter += 1;
+        Value::Unbound(format!("_M{}", self.var_counter))
+    }
+
+    /// First-solution meta-call used by the maplist family: any choice
+    /// points the sub-call leaves behind are discarded (deterministic
+    /// commit per element).
+    fn call_goal_once(&mut self, goal: &Value) -> bool {
+        let cp_depth = self.choice_points.len();
+        let ok = self.call_goal_value(goal);
+        if self.choice_points.len() > cp_depth {
+            self.choice_points.truncate(cp_depth);
+        }
+        ok
     }
 
     /// Predicates the shared WAM compiler emits as Call/Execute (no

--- a/src/unifyweaver/targets/wam_wat_target.pl
+++ b/src/unifyweaver/targets/wam_wat_target.pl
@@ -1852,8 +1852,18 @@ wam_wat_case(put_structure,
   ;; set_variable), bind through the Ref chain so the heap cell is
   ;; updated — this links nested compounds correctly (e.g. +(*(1000,3),7)).
   ;; Otherwise, just overwrite the register directly.
+  ;;
+  ;; A-REGISTER EXCEPTION (M139/M140 bind-through class): A registers
+  ;; (index < 32; X = 32+, Y = 64+) are argument STAGING — their old
+  ;; occupant is an unrelated variable (often a clause-head argument),
+  ;; and binding it to the new compound creates a cyclic term
+  ;; (X = f(X)), wrong-failing a later X = 1. set_variable placeholders
+  ;; only ever live in X/Y registers, so the bind-through is gated on
+  ;; the register class — the same fix the Rust, Go, Scala, Kotlin,
+  ;; Haskell, C and LLVM targets carry.
   (local.set $d_addr (call $deref_reg_addr (local.get $ai)))
-  (if (i32.eq (call $val_tag (local.get $d_addr)) (i32.const 6))
+  (if (i32.and (i32.ge_u (local.get $ai) (i32.const 32))
+               (i32.eq (call $val_tag (local.get $d_addr)) (i32.const 6)))
     (then
       (call $trail_binding_at (local.get $d_addr))
       (call $val_store (local.get $d_addr) (i32.const 5) (i64.extend_i32_u (local.get $addr))))
@@ -1867,8 +1877,11 @@ wam_wat_case(put_list,
 '  (local $ai i32) (local $addr i32) (local $d_addr i32)
   (local.set $ai (i32.wrap_i64 (local.get $op1)))
   (local.set $addr (call $heap_push_val (i32.const 4) (i64.const 0)))
+  ;; Same A-register bind-through exception as put_structure
+  ;; (M139/M140 class): only X/Y registers keep the placeholder bind.
   (local.set $d_addr (call $deref_reg_addr (local.get $ai)))
-  (if (i32.eq (call $val_tag (local.get $d_addr)) (i32.const 6))
+  (if (i32.and (i32.ge_u (local.get $ai) (i32.const 32))
+               (i32.eq (call $val_tag (local.get $d_addr)) (i32.const 6)))
     (then
       (call $trail_binding_at (local.get $d_addr))
       (call $val_store (local.get $d_addr) (i32.const 5) (i64.extend_i32_u (local.get $addr))))

--- a/templates/targets/kotlin_wam/WamRuntime.kt.mustache
+++ b/templates/targets/kotlin_wam/WamRuntime.kt.mustache
@@ -138,9 +138,19 @@ class WamState(
     }
 
     fun bindTarget(register: String, value: Value?) {
-        val current = deref(readRegister(register))
-        if (current is Value.Var) {
-            bind(current.name, value)
+        // A-REGISTER EXCEPTION (M139/M140 bind-through class): A
+        // registers are argument staging — their old occupant is an
+        // unrelated variable (often a clause-head argument), and
+        // binding it to the freshly built term creates a cyclic term
+        // (X = f(X)), wrong-failing a later X = 1. Top-down
+        // structure-chaining placeholders only ever live in X/Y
+        // registers, so the bind-through is conditioned on the register
+        // class — the same fix the Rust, Go, Scala and LLVM targets carry.
+        if (!register.startsWith("A")) {
+            val current = deref(readRegister(register))
+            if (current is Value.Var) {
+                bind(current.name, value)
+            }
         }
         bind(register, value)
     }
@@ -185,6 +195,18 @@ class WamState(
             return true
         }
         return false
+    }
+
+    fun beginStructurePut(functor: String, register: String): Boolean {
+        // put-family structure start: WRITE mode unconditionally. The
+        // target register is being OVERWRITTEN, so its stale occupant
+        // must not be consulted — routing put_structure/put_list through
+        // beginStructure (get-style dispatch) wrong-failed them whenever
+        // the register still held a constant, e.g. a clause-head
+        // argument about to be replaced by the goal argument.
+        val arity = functorArity(functor) ?: return false
+        context = WamContext.Write(register, functor, arity)
+        return true
     }
 
     fun pushWriteArg(value: Value?): Boolean {
@@ -449,13 +471,13 @@ class WamRuntime(private val program: WamProgram) {
             "put_structure" -> {
                 val functor = instruction.args.getOrNull(0) as? String ?: return false
                 val register = instruction.args.getOrNull(1) as? String ?: return false
-                if (!state.beginStructure(functor, register)) return false
+                if (!state.beginStructurePut(functor, register)) return false
                 state.pc += 1
                 return true
             }
             "put_list" -> {
                 val register = instruction.args.getOrNull(0) as? String ?: return false
-                if (!state.beginStructure("[|]/2", register)) return false
+                if (!state.beginStructurePut("[|]/2", register)) return false
                 state.pc += 1
                 return true
             }
@@ -595,6 +617,14 @@ class WamRuntime(private val program: WamProgram) {
                 // closed, so no type check or arithmetic ever ran.
                 when (op) {
                     "true/0" -> { state.pc += 1; return true }
+                    "==/2" -> {
+                        if (state.resolve(state.readRegister("A1")) != state.resolve(state.readRegister("A2"))) return false
+                        state.pc += 1; return true
+                    }
+                    "\\==/2" -> {
+                        if (state.resolve(state.readRegister("A1")) == state.resolve(state.readRegister("A2"))) return false
+                        state.pc += 1; return true
+                    }
                     "var/1" -> {
                         if (state.deref(state.readRegister("A1")) !is Value.Var) return false
                         state.pc += 1; return true

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -1036,48 +1036,54 @@ impl WamState {
     /// and pops the WriteCtx.
     pub fn set_heap_or_list(&mut self, val: Value) {
         if let Some(StackEntry::WriteCtx(marker)) = self.stack.last().cloned() {
-            // Find the next unfilled slot after the header at heap[marker]
-            let header = self.heap[marker].clone();
-            match &header {
-                Value::Atom(s) if s == "__list_head__" => {
-                    // PutList mode: heap[marker]=head, heap[marker+1]=tail
+            // PutList mode is identified by the TAIL SENTINEL at
+            // marker+1 — not by the head cell type. Keying list mode on
+            // "head is a non-placeholder atom" meant a list whose head
+            // was an integer/float/compound never completed: the second
+            // value fell through to the plain heap push and the register
+            // kept the put_list scratch marker (maplist over [1,2,3] saw
+            // Integer(0) where the list should be).
+            let list_tail_pending = matches!(
+                self.heap.get(marker + 1),
+                Some(Value::Atom(t)) if t == "__list_tail__"
+            );
+            if list_tail_pending {
+                if matches!(&self.heap[marker], Value::Atom(h) if h == "__list_head__") {
+                    // First value: fill the head slot.
                     self.heap[marker] = val;
                     return;
                 }
-                Value::Atom(s) if s != "__list_head__" && s != "__list_tail__" && s != "__struct_arg__" => {
-                    // Head already filled (not a placeholder) -- fill tail
-                    if let Value::Atom(ref ts) = self.heap[marker + 1] {
-                        if ts == "__list_tail__" {
-                            self.heap[marker + 1] = val;
-                            let head = self.heap[marker].clone();
-                            let tail = self.heap[marker + 1].clone();
-                            let list = match tail {
-                                Value::List(mut items) => { items.insert(0, head); Value::List(items) }
-                                Value::Atom(ref s) if s == "[]" => Value::List(vec![head]),
-                                // Partial list: the tail is still an unbound
-                                // variable (or a ref/cons) that a later
-                                // put_structure will fill — e.g. building
-                                // [a|X2] then X2=[b|X3]. Materialising this as
-                                // Value::List([head, tail]) would treat the
-                                // tail var as a SECOND ELEMENT (so [a|X] looked
-                                // like the 2-list [a,X]); get_list then peeled
-                                // a wrong tail and member(z,...) bound the var
-                                // and wrongly succeeded. Keep it as a cons cell
-                                // so the tail var derefs to the rest of the
-                                // list. get_list/unify already alias [|]/2.
-                                _ => Value::Str("[|]/2".to_string(), vec![head, tail]),
-                            };
-                            // Update the register holding Ref(marker) or Integer(marker)
-                            let ref_val = Value::Ref(marker);
-                            let int_val = Value::Integer(marker as i64);
-                            if let Some(idx) = self.regs.iter().position(|v| *v == ref_val || *v == int_val) {
-                                self.regs[idx] = list;
-                            }
-                            self.smut().pop();
-                            return;
-                        }
-                    }
+                // Second value: fill the tail and build the list.
+                self.heap[marker + 1] = val;
+                let head = self.heap[marker].clone();
+                let tail = self.heap[marker + 1].clone();
+                let list = match tail {
+                    Value::List(mut items) => { items.insert(0, head); Value::List(items) }
+                    Value::Atom(ref s) if s == "[]" => Value::List(vec![head]),
+                    // Partial list: the tail is still an unbound
+                    // variable (or a ref/cons) that a later
+                    // put_structure will fill — e.g. building
+                    // [a|X2] then X2=[b|X3]. Materialising this as
+                    // Value::List([head, tail]) would treat the
+                    // tail var as a SECOND ELEMENT (so [a|X] looked
+                    // like the 2-list [a,X]); get_list then peeled
+                    // a wrong tail and member(z,...) bound the var
+                    // and wrongly succeeded. Keep it as a cons cell
+                    // so the tail var derefs to the rest of the
+                    // list. get_list/unify already alias [|]/2.
+                    _ => Value::Str("[|]/2".to_string(), vec![head, tail]),
+                };
+                // Update the register holding Ref(marker) or Integer(marker)
+                let ref_val = Value::Ref(marker);
+                let int_val = Value::Integer(marker as i64);
+                if let Some(idx) = self.regs.iter().position(|v| *v == ref_val || *v == int_val) {
+                    self.regs[idx] = list;
                 }
+                self.smut().pop();
+                return;
+            }
+            let header = self.heap[marker].clone();
+            match &header {
                 Value::Str(functor, _) => {
                     // PutStructure mode: fill next __struct_arg__ slot
                     let arity: usize = functor.split('/').last()

--- a/templates/targets/scala_wam/runtime.scala.mustache
+++ b/templates/targets/scala_wam/runtime.scala.mustache
@@ -917,13 +917,24 @@ object WamRuntime {
       // arithmetic), bind that Ref so any other build frame that
       // captured the same Ref as one of its args sees the new struct
       // through deref.
-      val current = s.regs(top.targetReg)
-      val derefedRef = if (current == null) None
-                       else deref(s.bindings, current) match {
-                         case r: Ref => Some(r)
-                         case _      => None
-                       }
-      derefedRef.foreach(r => bindVar(s, r, built))
+      //
+      // A-REGISTER EXCEPTION (M139/M140 bind-through class): A registers
+      // (index < 100; X = +100, Y = +200) are argument STAGING — their
+      // old occupant is an unrelated variable (often a clause-head
+      // argument), and binding it to the freshly built term creates a
+      // cyclic term (X = f(X)), wrong-failing a later X = 1. The
+      // set_variable threading placeholders only ever live in X/Y
+      // registers, so the bind-through is conditioned on the register
+      // class — the same fix the Rust, Go, and LLVM targets carry.
+      if (top.targetReg >= 100) {
+        val current = s.regs(top.targetReg)
+        val derefedRef = if (current == null) None
+                         else deref(s.bindings, current) match {
+                           case r: Ref => Some(r)
+                           case _      => None
+                         }
+        derefedRef.foreach(r => bindVar(s, r, built))
+      }
       setReg(s, top.targetReg, built)
       if (s.buildStack.nonEmpty && s.buildStack.head.args.length == s.buildStack.head.sArity)
         finalizeBuild(s)

--- a/tests/test_wam_go_bindthrough.pl
+++ b/tests/test_wam_go_bindthrough.pl
@@ -1,0 +1,85 @@
+% test_wam_go_bindthrough.pl
+%
+% Regression test for the M139/M140 PutStructure A-register bind-through
+% class on the Go WAM target: building a goal structure that embeds a
+% still-live head variable into the same A register must NOT bind that
+% variable to the structure's own cell (cyclic X = f(X), which wrong-fails
+% a later X = 1). Found by the cross-target probe sweep after the same
+% bug was fixed in Rust; the fix conditions the bind-through on the
+% register class (A regs < 100 are staging and never bind; X/Y keep the
+% top-down structure-chaining bind-through).
+%
+% gbt exercises the bug shape; glist guards the class-2 (non-atom list
+% head) pattern, which was verified CLEAN on Go and must stay that way;
+% glist_chain guards the legitimate X-register bind-through (nested term
+% built via set_variable placeholder) that the fix must NOT break.
+%
+% Skipped automatically when `go` is not on PATH.
+
+:- use_module(library(plunit)).
+:- use_module(library(filesex)).
+:- use_module(library(process)).
+:- use_module('../src/unifyweaver/targets/wam_go_target').
+
+:- dynamic user:mk1/2.
+:- dynamic user:bindthrough/2.
+:- dynamic user:gbt/0.
+:- dynamic user:lhead/2.
+:- dynamic user:glist/0.
+:- dynamic user:glist_chain/0.
+
+user:mk1(T, T).
+user:bindthrough(X, W) :- mk1(f(X), W), X = 1.
+user:gbt :- bindthrough(_X, W), W == f(1).
+user:lhead([H|_], H).
+user:glist :- lhead([7,8], V), V =:= 7.
+user:glist_chain :- mk1(g(f(1), 2), W), W == g(f(1), 2).
+
+go_available :-
+    catch(
+        ( process_create(path(go), ['version'],
+                         [stdout(null), stderr(null), process(Pid)]),
+          process_wait(Pid, exit(0)) ),
+        _, fail).
+
+:- begin_tests(wam_go_bindthrough, [condition(go_available)]).
+
+test(a_register_bind_through_and_list_heads) :-
+    Proj = 'output/test_wam_go_bindthrough_gen',
+    ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ),
+    write_wam_go_project([user:mk1/2, user:bindthrough/2, user:gbt/0,
+                          user:lhead/2, user:glist/0, user:glist_chain/0],
+                         [module_name(bindthrough), prefer_wam(true)], Proj),
+    directory_file_path(Proj, 'cmd', CmdDir),
+    directory_file_path(CmdDir, 'run', RunDir),
+    make_directory_path(RunDir),
+    directory_file_path(RunDir, 'main.go', MainPath),
+    setup_call_cleanup(
+        open(MainPath, write, MS),
+        write(MS,
+'package main\n\nimport (\n\t"fmt"\n\twam "bindthrough"\n)\n\nfunc run(code []wam.Instruction, labels map[string]int, pc int) bool {\n\tvm := wam.NewWamState(code, labels)\n\tvm.PC = pc\n\treturn vm.Run()\n}\n\nfunc main() {\n\tfmt.Printf("GBT=%v\\n", run(wam.GbtCode, wam.GbtLabels, wam.GbtStartPC))\n\tfmt.Printf("GLIST=%v\\n", run(wam.GlistCode, wam.GlistLabels, wam.GlistStartPC))\n\tfmt.Printf("GCHAIN=%v\\n", run(wam.Glist_chainCode, wam.Glist_chainLabels, wam.Glist_chainStartPC))\n}\n'),
+        close(MS)),
+    directory_file_path(Proj, 'go.mod', GoModPath),
+    read_file_to_string(GoModPath, GoModOld, []),
+    atomic_list_concat([GoModOld, "\nreplace bindthrough => ../../\n"], GoModNew),
+    setup_call_cleanup(
+        open(GoModPath, write, GS),
+        write(GS, GoModNew),
+        close(GS)),
+    format(atom(RunCmd), 'cd ~w && timeout 120 go run main.go 2>&1', [RunDir]),
+    process_create(path(sh), ['-c', RunCmd],
+                   [stdout(pipe(Out)), process(Pid)]),
+    read_string(Out, _, OutStr),
+    close(Out),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    ->  true
+    ;   format(user_error, "~n[go run output]~n~w~n", [OutStr]),
+        throw(go_run_failed(Status))
+    ),
+    assertion(sub_string(OutStr, _, _, _, "GBT=true")),
+    assertion(sub_string(OutStr, _, _, _, "GLIST=true")),
+    assertion(sub_string(OutStr, _, _, _, "GCHAIN=true")),
+    ( exists_directory(Proj) -> delete_directory_and_contents(Proj) ; true ).
+
+:- end_tests(wam_go_bindthrough).

--- a/tests/test_wam_rust_builtin_parity.pl
+++ b/tests/test_wam_rust_builtin_parity.pl
@@ -77,6 +77,44 @@ t_succ_fwd(Y) :- succ(2, Y).
 :- dynamic t_succ_rev/1.
 t_succ_rev(X) :- succ(X, 3).
 
+%% maplist family (P5): user-defined goals called per element through
+%% the call_goal_value meta-call machinery.
+:- dynamic double/2.
+double(X, Y) :- Y is X * 2.
+
+:- dynamic pos/1.
+pos(X) :- X > 0.
+
+:- dynamic acc_add/3.
+acc_add(X, A0, A) :- A is A0 + X.
+
+:- dynamic t_maplist/1.
+t_maplist(L) :- maplist(double, [1, 2, 3], L).
+
+:- dynamic t_maplist_check/0.
+t_maplist_check :- maplist(pos, [1, 2, 3]).
+
+:- dynamic t_maplist_fail/0.
+t_maplist_fail :- maplist(pos, [1, -2, 3]).
+
+:- dynamic t_include/1.
+t_include(I) :- include(pos, [1, -2, 3], I).
+
+:- dynamic t_exclude/1.
+t_exclude(E) :- exclude(pos, [1, -2, 3], E).
+
+:- dynamic t_partition/2.
+t_partition(I, E) :- partition(pos, [1, -2, 3], I, E).
+
+:- dynamic t_foldl/1.
+t_foldl(S) :- foldl(acc_add, [1, 2, 3], 0, S).
+
+:- dynamic t_alc_join/1.
+t_alc_join(A) :- atomic_list_concat([a, b, c], '-', A).
+
+:- dynamic t_alc_split/1.
+t_alc_split(L) :- atomic_list_concat(L, '-', 'x-y-z').
+
 cargo_available :-
     catch(
         (process_create(path(cargo), ['--version'],
@@ -98,7 +136,11 @@ test_builtin_parity_execution :-
              user:t_catch_match/1, user:t_catch_deep/1,
              user:t_catch_nomatch/0, user:t_catch_nothrow/1,
              user:t_catch_failgoal/0, user:t_catch_nested/1,
-             user:t_succ_fwd/1, user:t_succ_rev/1],
+             user:t_succ_fwd/1, user:t_succ_rev/1,
+             user:double/2, user:pos/1, user:acc_add/3,
+             user:t_maplist/1, user:t_maplist_check/0, user:t_maplist_fail/0,
+             user:t_include/1, user:t_exclude/1, user:t_partition/2,
+             user:t_foldl/1, user:t_alc_join/1, user:t_alc_split/1],
             [module_name('builtin_parity_test'), wam_fallback(true)],
             TmpDir),
         directory_file_path(TmpDir, 'tests', TestsDir),
@@ -109,7 +151,9 @@ use builtin_parity_test::state::WamState;
 use builtin_parity_test::value::Value;
 use builtin_parity_test::{t_between_1, t_msort_1, t_sort_1, t_concat_split_2, t_select_2,
     t_catch_match_1, t_catch_deep_1, t_catch_nomatch_0, t_catch_nothrow_1,
-    t_catch_failgoal_0, t_catch_nested_1, t_succ_fwd_1, t_succ_rev_1};
+    t_catch_failgoal_0, t_catch_nested_1, t_succ_fwd_1, t_succ_rev_1,
+    t_maplist_1, t_maplist_check_0, t_maplist_fail_0, t_include_1, t_exclude_1,
+    t_partition_2, t_foldl_1, t_alc_join_1, t_alc_split_1};
 use std::collections::HashMap;
 
 fn vmnew() -> WamState {
@@ -268,6 +312,94 @@ fn test_succ_direct_edge_cases() {
     assert!(!call2("succ/2", i(-1), ub("Y")).0, "negative X fails");
     assert!(call2("succ/2", i(2), i(3)).0);
     assert!(!call2("succ/2", i(2), i(4)).0);
+}
+
+#[test]
+fn test_maplist_transform_compiled() {
+    let mut vm = vmnew();
+    assert!(t_maplist_1(&mut vm, ub("L")),
+        "maplist(double, [1,2,3], L) must succeed");
+    assert_eq!(read_var(&vm, "L"), Value::List(vec![i(2), i(4), i(6)]));
+}
+
+#[test]
+fn test_maplist_check_and_fail_compiled() {
+    let mut vm = vmnew();
+    assert!(t_maplist_check_0(&mut vm), "all elements positive");
+    let mut vm2 = vmnew();
+    assert!(!t_maplist_fail_0(&mut vm2), "one negative element fails maplist");
+}
+
+#[test]
+fn test_include_exclude_partition_compiled() {
+    let mut vm = vmnew();
+    assert!(t_include_1(&mut vm, ub("I")));
+    assert_eq!(read_var(&vm, "I"), Value::List(vec![i(1), i(3)]));
+    let mut vm2 = vmnew();
+    assert!(t_exclude_1(&mut vm2, ub("E")));
+    assert_eq!(read_var(&vm2, "E"), Value::List(vec![i(-2)]));
+    let mut vm3 = vmnew();
+    assert!(t_partition_2(&mut vm3, ub("I"), ub("E")));
+    assert_eq!(read_var(&vm3, "I"), Value::List(vec![i(1), i(3)]));
+    assert_eq!(read_var(&vm3, "E"), Value::List(vec![i(-2)]));
+}
+
+#[test]
+fn test_foldl_compiled() {
+    let mut vm = vmnew();
+    assert!(t_foldl_1(&mut vm, ub("S")),
+        "foldl(acc_add, [1,2,3], 0, S) must succeed");
+    assert_eq!(read_var(&vm, "S"), i(6));
+}
+
+#[test]
+fn test_atomic_list_concat_compiled() {
+    let mut vm = vmnew();
+    assert!(t_alc_join_1(&mut vm, ub("A")));
+    assert_eq!(read_var(&vm, "A"), a("a-b-c"));
+    let mut vm2 = vmnew();
+    assert!(t_alc_split_1(&mut vm2, ub("L")));
+    assert_eq!(read_var(&vm2, "L"), Value::List(vec![a("x"), a("y"), a("z")]));
+}
+
+#[test]
+fn test_atomic_list_concat_direct() {
+    let (ok, vm) = call2("atomic_list_concat/2",
+        Value::List(vec![a("foo"), i(7), a("bar")]), ub("A"));
+    assert!(ok);
+    assert_eq!(read_var(&vm, "A"), a("foo7bar"));
+    assert!(call3("atomic_list_concat/3",
+        Value::List(vec![a("x"), a("y")]), a(","), a("x,y")).0);
+    assert!(!call3("atomic_list_concat/3",
+        Value::List(vec![a("x"), a("y")]), a(","), a("x;y")).0);
+    // Split with empty separator must fail (would not terminate).
+    assert!(!call3("atomic_list_concat/3", ub("L"), a(""), a("xyz")).0);
+}
+
+#[test]
+fn test_char_type_direct() {
+    assert!(call2("char_type/2", a("x"), a("alpha")).0);
+    assert!(!call2("char_type/2", a("1"), a("alpha")).0);
+    assert!(call2("char_type/2", a("1"), a("alnum")).0);
+    assert!(call2("char_type/2", a("_"), a("csym")).0);
+    assert!(call2("char_type/2", a(" "), a("space")).0);
+    assert!(call2("char_type/2", a("!"), a("punct")).0);
+    assert!(call2("char_type/2", a("A"), a("upper")).0);
+    assert!(!call2("char_type/2", a("a"), a("upper")).0);
+    let (ok, vm) = call2("char_type/2", a("7"),
+        Value::Str("digit/1".to_string(), vec![ub("W")]));
+    assert!(ok);
+    assert_eq!(read_var(&vm, "W"), i(7));
+    let (ok2, vm2) = call2("char_type/2", a("B"),
+        Value::Str("to_lower/1".to_string(), vec![ub("L")]));
+    assert!(ok2);
+    assert_eq!(read_var(&vm2, "L"), a("b"));
+    let (ok3, vm3) = call2("char_type/2", a("Q"),
+        Value::Str("upper/1".to_string(), vec![ub("L")]));
+    assert!(ok3);
+    assert_eq!(read_var(&vm3, "L"), a("q"));
+    assert!(!call2("char_type/2", a("q"),
+        Value::Str("upper/1".to_string(), vec![ub("L")])).0);
 }
 
 // ---- layer 2: direct execute_builtin coverage ------------------------


### PR DESCRIPTION
## Summary

Two pieces share this branch (both individually gated):

### 1. Rust parity P5 — closes the builtin ledger

- **Meta-predicate family** built on P4's meta-call machinery: `maplist/2..5` (unbound lists unified with fresh-variable lists; first-solution commit per element), `include/3`, `exclude/3` (trial calls, bindings unwound per element), `partition/4`, `foldl/4,5` (accumulator threaded through fresh variables)
- **Text ops**: `atomic_list_concat/2,3` (join + split modes), `char_type/2` (+Char mode, class atoms + parameterized `digit(W)`/case forms)
- **Latent bug fix**: `put_list` never completed lists with non-atom heads (`maplist(double, [1,2,3], L)` saw the scratch marker `Integer(0)` instead of the list) — completion now keys on the tail sentinel, not the head's type. 7 new cargo tests (28 total); all Rust gates green.

### 2. Cross-target sweep: PutStructure A-register bind-through fixed in Go, Scala, Kotlin, Haskell, C, WAT

Behavioral probes (R=1/R=0 battery through each target's **real project writer and toolchain**) over the 15 non-Rust targets found the M139/M140 bind-through class in six more runtimes: `put_structure` bound the target register's old occupant to the freshly built term, so any clause shaped `p(X, ...) :- q(f(X), ...), use(X)` created a cyclic `X = f(X)` and wrong-failed. **In C the bind was also untrailed** (backtracking corruption hazard). Fix everywhere: condition the bind-through on register class — A registers are argument staging and never bind; X/Y keep the legitimate placeholder chaining.

| Target | Class 1 (bind-through) | Class 2 (non-atom list heads) |
|---|---|---|
| Go, Scala, Kotlin, Haskell, C, WAT | **BUGGY → fixed** | clean |
| C++, LLVM (M140 regression-verified), F# (cycle-check-guarded), Rust | clean | clean |
| ILasm | blocked — newly pinned: cross-predicate calls resolve against the local label table and self-loop | blocked |
| Python, Lua, R, Clojure, Elixir | pending (probe agents hit session quota) | pending |

Kotlin additionally had a **put-as-get defect** (put_structure/put_list routed through get-style dispatch, wrong-failing on stale constant occupants — fixed with write-mode `beginStructurePut`) and gained `==/2`/`\==/2` arms. Side findings (missing `==/2` in C/Haskell, Kotlin env-restore defect, F# theoretical aliasing divergence) are filed in `docs/reports/wam_bindthrough_cross_target_sweep.md`, not silently fixed.

## Test plan

- [x] P5: 28 cargo-built tests in `test_wam_rust_builtin_parity.pl`; full Rust gate set (codegen, runtime e2e, t4/t5/t6, save_regs, par_aggregate, bidirectional 4/4)
- [x] Sweep: every fix re-probed through its harness (bug probes flipped to ISO answers; X-chaining controls unchanged); new `tests/test_wam_go_bindthrough.pl`
- [x] Cross-target conformance `CONFORMANCE_TARGETS=go,scala,haskell,c,wat` — all pass
- [x] `test_wam_c_var_alias`, WAT lowered t4/t6, Kotlin suite 9/9, Go negcut + lowered suites — all pass

https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM)_