### PR TITLE
feat(plawk): add scalar end count surface

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -239,14 +239,18 @@ Parser/codegen land in `examples/plawk/{parser,codegen}/`.
 **Current slice:** `examples/plawk/parser/plawk_parser.pl` parses the first
 surface forms, `/^PREFIX/ { print $0 }` and
 `$N == "VALUE" { print $0 }`, plus selected-field actions such as
-`$N == "VALUE" { print $M, $K }`, to explicit pattern/action ASTs.
+`$N == "VALUE" { print $M, $K }`, and the first scalar state form,
+`$N == "VALUE" { count++ } END { print count }`, to explicit pattern/action
+ASTs.
 `examples/plawk/codegen/plawk_native_codegen.pl` lowers that AST to a native
 streaming WAM/LLVM driver using `llvm_emit_atom_prefix_guard/5` or
 `llvm_emit_atom_field_eq_guard/7`, and
 `tests/test_plawk_surface_prefix_print.pl` proves that the generated binary
 prints matching records from a text file without calling `run_loop` in the hot
 record loop. The field-equality path scans fields in native code without
-allocating substrings; selected-field printing projects byte slices directly.
+allocating substrings; selected-field printing projects byte slices directly;
+the scalar counter path threads a native `i64` loop variable and prints it from
+the `END` action.
 
 **Success:** a user-written awk-style program parses, lowers, compiles, and
 produces correct output on standard awk test cases.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -77,7 +77,8 @@ swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR
 The demo prints the record count and the lines whose first field is `ERROR`.
 The first Phase 2 surface smokes parse `/^ERROR/ { print $0 }` and
 `$1 == "ERROR" { print $0 }`, plus selected-field actions such as
-`$1 == "ERROR" { print $2, $3 }`.
+`$1 == "ERROR" { print $2, $3 }` and scalar state with
+`$1 == "ERROR" { count++ } END { print count }`.
 
 For a walkthrough of the current Prolog-core syntax and how it maps to awk
 concepts like `$0`, `$1`, `NR`, `NF`, `FS`, `OFS`, and `print`, see

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -118,6 +118,23 @@ state(InputStreams, OutputStreams, Counter, UserFields)
 The Phase 0 examples use the counter as `NR`, collect printed lines in
 `OutputStreams`, and store `FS`/`OFS` in `UserFields` as `plawk_options(FS, OFS)`.
 
+## Current surface example: count matching records
+
+The native Phase 2 surface can now compile a scalar counter and an `END` action:
+
+```awk
+$1 == "ERROR" { count++ } END { print count }
+```
+
+For the sample input above, it prints:
+
+```text
+2
+```
+
+This path lowers the field comparison and the counter to native LLVM code. The
+WAM runtime still supplies the streaming reader and atom helpers.
+
 ## Another example: count and print matching lines
 
 The demo in `examples/plawk/demo/count_errors.pl` is equivalent to:

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -17,6 +17,7 @@
 %      /^PREFIX/ { print $0 }
 %      $N == "VALUE" { print $0 }
 %      $N == "VALUE" { print $M, $K }
+%      $N == "VALUE" { count++ } END { print count }
 %
 %  The surrounding runtime still comes from write_wam_llvm_project/3. This
 %  function emits the target-specific native main that streams the file, lowers
@@ -113,6 +114,102 @@ fail_close:
         [BytesLen, PathBytes,
          GuardGlobalIR,
          BytesLen, BytesLen, PathLen, GuardCallIR, PrintActionIR]).
+
+plawk_program_native_driver_ir(
+    program([], [rule(Pattern, [inc(var(Name))])], [end([print([var(Name)])])]),
+    InputPath,
+    DriverIR
+) :-
+    atom_codes(InputPath, PathCodes),
+    length(PathCodes, PathLen),
+    BytesLen is PathLen + 1,
+    llvm_c_bytes(PathCodes, PathBytes),
+    plawk_pattern_guard_ir(Pattern, GuardGlobalIR-GuardCallIR),
+    format(atom(DriverIR),
+'@.plawk_surface_path = private constant [~w x i8] c"~w\\00"
+@.plawk_surface_eof = private constant [12 x i8] c"end_of_file\\00"
+@.plawk_surface_print_i64 = private constant [5 x i8] c"%ld\\0A\\00"
+~w
+
+define i32 @main() {
+entry:
+  %path_ptr = getelementptr [~w x i8], [~w x i8]* @.plawk_surface_path, i32 0, i32 0
+  %path_id = call i64 @wam_intern_atom(i8* %path_ptr, i64 ~w)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+  %handle = call %Value @wam_stream_open_value(%Value %path)
+  %handle_tag = extractvalue %Value %handle, 0
+  %handle_is_int = icmp eq i32 %handle_tag, 1
+  br i1 %handle_is_int, label %check_handle_value, label %fail_open
+
+check_handle_value:
+  %handle_payload = extractvalue %Value %handle, 1
+  %handle_ok = icmp sgt i64 %handle_payload, 0
+  br i1 %handle_ok, label %loop, label %fail_open
+
+loop:
+  %count = phi i64 [0, %check_handle_value], [%next_count, %continue_loop]
+  %line = call %Value @wam_stream_read_line_value(%Value %handle)
+  %line_tag = extractvalue %Value %line, 0
+  %line_payload = extractvalue %Value %line, 1
+  %line_is_int = icmp eq i32 %line_tag, 1
+  %line_bad_payload = icmp slt i64 %line_payload, 0
+  %line_bad = and i1 %line_is_int, %line_bad_payload
+  br i1 %line_bad, label %fail_read, label %check_line_atom
+
+check_line_atom:
+  %line_is_atom = icmp eq i32 %line_tag, 0
+  br i1 %line_is_atom, label %check_eof, label %fail_line_tag
+
+check_eof:
+  %line_s = call i8* @wam_atom_to_string(i64 %line_payload)
+  %eof_s = getelementptr [12 x i8], [12 x i8]* @.plawk_surface_eof, i32 0, i32 0
+  %eof_cmp = call i32 @strcmp(i8* %line_s, i8* %eof_s)
+  %is_eof = icmp eq i32 %eof_cmp, 0
+  br i1 %is_eof, label %close_stream, label %lowered_match
+
+lowered_match:
+~w
+  br i1 %is_match, label %increment_counter, label %keep_counter
+
+increment_counter:
+  %incremented_count = add i64 %count, 1
+  br label %continue_loop
+
+keep_counter:
+  br label %continue_loop
+
+continue_loop:
+  %next_count = phi i64 [%incremented_count, %increment_counter], [%count, %keep_counter]
+  br label %loop
+
+close_stream:
+  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %close_ok, label %end_print, label %fail_close
+
+end_print:
+  %count_fmt = getelementptr [5 x i8], [5 x i8]* @.plawk_surface_print_i64, i32 0, i32 0
+  %printed_count = call i32 (i8*, ...) @printf(i8* %count_fmt, i64 %count)
+  ret i32 0
+
+fail_open:
+  ret i32 10
+
+fail_read:
+  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 11
+
+fail_line_tag:
+  %close_ignore_line_tag = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 12
+
+fail_close:
+  ret i32 16
+}
+',
+        [BytesLen, PathBytes,
+         GuardGlobalIR,
+         BytesLen, BytesLen, PathLen, GuardCallIR]).
 
 llvm_c_bytes([], '').
 llvm_c_bytes([Code | Rest], Bytes) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -12,6 +12,7 @@
 %      /^PREFIX/ { print $0 }
 %      $N == "VALUE" { print $0 }
 %      $N == "VALUE" { print $M, $K }
+%      $N == "VALUE" { count++ } END { print count }
 %
 %  The AST is deliberately small and explicit so later syntax can extend it
 %  without changing the native codegen contract.
@@ -20,16 +21,17 @@ plawk_parse_string(Source, Program) :-
     string_codes(Source, Codes),
     phrase(plawk_program(Program), Codes).
 
-plawk_program(program([], [rule(Pattern, [PrintAction])], [])) -->
+plawk_program(program([], [rule(Pattern, [Action])], EndClauses)) -->
     ws,
     pattern(Pattern),
     ws,
     "{",
     ws,
-    print_action(PrintAction),
+    action(Action),
     ws,
     "}",
     ws,
+    end_clauses(EndClauses),
     eos.
 
 pattern(Pattern) -->
@@ -105,6 +107,29 @@ quoted_string_codes([Code | Codes]) -->
 quoted_string_codes([]) -->
     [].
 
+end_clauses([end([PrintAction])]) -->
+    "END",
+    ws,
+    "{",
+    ws,
+    print_action(PrintAction),
+    ws,
+    "}",
+    ws,
+    !.
+end_clauses([]) -->
+    [].
+
+action(Action) -->
+    print_action(Action),
+    !.
+action(Action) -->
+    increment_action(Action).
+
+increment_action(inc(var(Name))) -->
+    identifier(Name),
+    "++".
+
 print_action(print(Fields)) -->
     "print",
     required_ws,
@@ -131,6 +156,25 @@ field_expr(field(Index)) -->
       number_codes(Index, IndexCodes),
       Index >= 0
     }.
+field_expr(var(Name)) -->
+    identifier(Name).
+
+identifier(Name) -->
+    identifier_start(Start),
+    identifier_rest(Rest),
+    { atom_codes(Name, [Start | Rest]) }.
+
+identifier_start(Code) -->
+    [Code],
+    { code_type(Code, alpha) -> true ; Code =:= 0'_ }.
+
+identifier_rest([Code | Codes]) -->
+    [Code],
+    { code_type(Code, alnum) -> true ; Code =:= 0'_ },
+    !,
+    identifier_rest(Codes).
+identifier_rest([]) -->
+    [].
 
 required_ws -->
     [Code],

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -33,6 +33,11 @@ test(parses_field_eq_print_fields_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { print $2, $3 }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"), [print([field(2), field(3)])])], [])).
 
+test(parses_field_eq_increment_end_print_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { count++ } END { print count }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"), [inc(var(count))])],
+        [end([print([var(count)])])])).
+
 test(surface_prefix_prints_matching_records) :-
     run_surface_print_smoke("/^ERROR/ { print $0 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -47,6 +52,11 @@ test(surface_field_eq_prints_selected_fields) :-
     run_surface_print_smoke("$1 == \"ERROR\" { print $2, $3 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "disk full\nnet down\n").
+
+test(surface_field_eq_counts_matching_records) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { count++ } END { print count }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "2\n").
 
 run_surface_print_smoke(Source, Input, ExpectedOutput) :-
     tmp_root(Root),


### PR DESCRIPTION
## Summary
- parse the first scalar-state PLAWK surface form: `$1 == "ERROR" { count++ } END { print count }`
- lower that form to a native streaming LLVM driver with an `i64` loop counter and EOF-time print
- document the new surface example in the PLAWK README, tutorial, and implementation plan

## Validation
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `git diff --cached --check`
- `git diff --check`