### PR TITLE
feat(wam-rust): T7 2b.2 acceptance harness + fork analysis (re-land)

### DIFF
--- a/docs/reports/wam_rust_t7_2b2_fork_analysis.md
+++ b/docs/reports/wam_rust_t7_2b2_fork_analysis.md
@@ -1,0 +1,72 @@
+# T7 2b.2 — fork analysis (why the work-split is a VM-level change)
+
+**Status:** acceptance harness built + green (`tests/test_wam_rust_aggregate_exec.pl`);
+the work-splitting fork itself is scoped here as the next, larger step — it is a
+VM-level change, not a "wire `gated_collect` in" call, and this report records why.
+
+## What 2b.2 looked like vs. what it is
+
+From the outside, 2b.2 reads as "have the parallel-eligible path call
+`gated_collect`." Reading the generated interpreter (the `BeginAggregate` /
+`EndAggregate` arms, `backtrack()`, and the `aggregate_frame` finalisation in
+`wam_rust_target.pl`) shows the real shape:
+
+- `BeginAggregate` clears `aggregate_acc` and pushes an `aggregate_frame` choice
+  point.
+- The generator runs; **each solution reaches `EndAggregate`, which pushes the
+  value into `aggregate_acc` and calls `backtrack()`** to get the next.
+- When the generator is exhausted, `backtrack` pops the `aggregate_frame` CP and
+  finalises (sum/count/collect/max/min over `aggregate_acc`).
+
+So the per-branch work (the expensive part the cost gate flags) happens **inside
+the backtracking search, interleaved** between Begin and End. `gated_collect`
+needs a `run_branch(&mut clone, k)` that runs *only* outer-branch k on a clone —
+but the interpreter has **no clean seam** between "produce the next outer branch"
+and "run the body for it":
+
+- Outer alternatives are discovered **sequentially via backtracking** (a
+  `try/retry/trust`-style CP chain), not known up front, so you cannot hand
+  worker *k* "branch k" without first walking branches `0..k`.
+- Skipping a non-assigned branch *before* its body runs would require
+  identifying the generator/body boundary at runtime — which the WAM doesn't
+  expose; the conjunction `(Enum, Body)` is compiled to one undivided block
+  (`compile_aggregate_all` in `wam_target.pl`).
+
+Doing it at the choice-point level (a per-worker stride filter on the outer CP)
+is possible but **fragile**: it depends on exact CP-depth bookkeeping across
+nested body choice points, trail/stack restoration across the clone boundary,
+and order-preserving merge for `collect`. High risk of subtly-wrong generated
+code — the one place not to rush.
+
+## The two real implementation routes
+
+1. **Compile-time generator/body split (recommended).** At
+   `compile_aggregate_all`, split `InnerGoal` into `(Enum, Body)`, compile each
+   as its own entry, and for parallel-eligible aggregates emit: enumerate `Enum`
+   → `Vec<binding>` (cheap), then `gated_collect` mapping `Body` over the
+   bindings on cloned machines, merging into `aggregate_acc`. This maps directly
+   onto the substrate's `run_branch(&mut clone, k)` and keeps the parallelism out
+   of the core step-loop. Cost: real compile-time work (split detection — only
+   sound when `Enum` and `Body` share a clean variable frontier; two sub-programs;
+   binding collection) and a Rust-side parallel driver. Order is recoverable by
+   tagging bindings with their index.
+
+2. **Interpreter choice-point partition (not recommended).** Keep one block;
+   give each cloned worker a stride filter on the outer CP. Less compile-time
+   work, but the fragile VM bookkeeping above.
+
+## Recommendation
+
+Land the foundations now — the **forkable machine** (`WamState: Clone + Send`,
+2b.1) and this **exec acceptance harness** (the baseline `parallel == sequential`
+any fork must preserve) — and do the work-split as a **focused, test-first
+follow-up** along route 1. The harness is already the acceptance test: it builds
+and runs count/sum/collect end-to-end and asserts the exact results; the fork is
+done when the same harness passes with the parallel driver forced on.
+
+## What is green today
+
+- `WamState: Clone + Send`, compile-asserted in generated projects (2b.1, #3041).
+- The aggregate path executes correctly on Rust: `aggregate_all(count)` → 3,
+  `aggregate_all(sum)` → 6, `findall` → `[1,2,3]`, verified via `cargo test`
+  (`tests/test_wam_rust_aggregate_exec.pl`).

--- a/tests/test_wam_rust_aggregate_exec.pl
+++ b/tests/test_wam_rust_aggregate_exec.pl
@@ -1,0 +1,86 @@
+% test_wam_rust_aggregate_exec.pl
+%
+% T7 slice 2b.2 — acceptance harness (test-first). Builds and RUNS a generated
+% Rust project containing aggregate predicates (findall/aggregate_all) and
+% asserts the collected results are correct end-to-end. This is the first exec
+% coverage of the WAM-Rust aggregate path, and the baseline any parallel fork
+% must preserve: parallel result-set == this sequential result-set.
+%
+% cargo-gated (skips cleanly if cargo is absent).
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+
+:- dynamic agf/1.
+agf(1). agf(2). agf(3).
+
+ag_count(N)   :- aggregate_all(count, agf(_), N).      % -> 3
+ag_sum(S)     :- aggregate_all(sum(X), agf(X), S).     % -> 6
+ag_collect(L) :- findall(X, agf(X), L).                % -> [1,2,3]
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- begin_tests(wam_rust_aggregate_exec).
+
+test(aggregate_path_executes_correctly,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_agg_exec'))]) :-
+    Dir = 'output/test_agg_exec',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project(
+        [user:ag_count/1, user:ag_sum/1, user:ag_collect/1, user:agf/1],
+        [module_name(agg_exec), parallel_aggregates(true)], Dir)),
+    % embed an integration test that runs each aggregate and checks the result
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/agg_test.rs', TestPath),
+    TestSrc = '
+use agg_exec::value::Value;
+use agg_exec::state::WamState;
+use agg_exec::{ag_count_1, ag_sum_1, ag_collect_1};
+
+fn fresh() -> WamState { WamState::new(vec![], std::collections::HashMap::new()) }
+
+#[test]
+fn aggregates_execute() {
+    // count -> 3
+    let mut vm = fresh();
+    assert!(ag_count_1(&mut vm, Value::Unbound("N".to_string())), "ag_count should succeed");
+    assert_eq!(vm.bindings.get("N").cloned(), Some(Value::Integer(3)), "count");
+
+    // sum -> 6
+    let mut vm = fresh();
+    assert!(ag_sum_1(&mut vm, Value::Unbound("S".to_string())), "ag_sum should succeed");
+    assert_eq!(vm.bindings.get("S").cloned(), Some(Value::Integer(6)), "sum");
+
+    // collect -> [1,2,3]
+    let mut vm = fresh();
+    assert!(ag_collect_1(&mut vm, Value::Unbound("L".to_string())), "ag_collect should succeed");
+    match vm.bindings.get("L").cloned() {
+        Some(Value::List(xs)) => {
+            let got: Vec<i64> = xs.iter().filter_map(|v| match v {
+                Value::Integer(n) => Some(*n), _ => None }).collect();
+            assert_eq!(got, vec![1, 2, 3], "collect order/contents");
+        }
+        other => panic!("expected list in L, got {:?}", other),
+    }
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    % run it
+    format(atom(Cmd), 'cd "~w" && cargo test --test agg_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[aggregate exec FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_aggregate_exec).


### PR DESCRIPTION
## Why

These two files were authored alongside the forkable-machine change but **didn't make it into the merged #3041**, which landed only its first commit (`Clone+Send`). Re-landing them so `main` carries the exec acceptance baseline and the fork-scoping record.

## What
- **`tests/test_wam_rust_aggregate_exec.pl`** (cargo-gated) — builds and **runs** a generated project's aggregates: `aggregate_all(count)`→3, `aggregate_all(sum)`→6, `findall`→`[1,2,3]`, via `cargo test`. First exec coverage of the WAM-Rust aggregate path, and the baseline any parallel fork must preserve (**parallel result-set == sequential**). Green against current `main`.
- **`docs/reports/wam_rust_t7_2b2_fork_analysis.md`** — records why 2b.2 (the work-split fork) is a **VM-level change**, not a "wire `gated_collect` in" call: per-branch work happens inside the backtracking search, interleaved between `BeginAggregate`/`EndAggregate`, with no clean runtime seam to run "outer-branch k only" on a clone. Two routes documented — recommended: compile-time generator/body split; not recommended: fragile interpreter choice-point stride partition.

No production code change — a test + a report.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_