### PR TITLE
feat(wam-rust): T7 route-1 — parallel aggregates end-to-end (gate→transform→runtime→injection)

### DIFF
--- a/src/unifyweaver/core/parallel_gate.pl
+++ b/src/unifyweaver/core/parallel_gate.pl
@@ -24,10 +24,13 @@
     forkable_aggregate/3,            % +Goal, -Template, -Generator
     aggregate_parallel_decision/3,   % +Goal, +Model, -Decision   (parallel|sequential)
     goal_parallel_decision/3,        % +Generator, +Model, -Decision
+    split_aggregate_generator/5,     % +InnerGoal, +Model, -Enum, -Body, -Frontier
     parallel_worthy_tier/1           % ?Tier   (multifile, overridable policy)
 ]).
 
 :- use_module(cost_analysis).
+:- use_module(library(lists)).
+:- use_module(library(apply)).
 
 :- multifile parallel_worthy_tier/1.
 :- dynamic   parallel_worthy_tier/1.
@@ -68,3 +71,93 @@ worthy(Tier) :- \+ parallel_worthy_tier(_), default_worthy(Tier).
 % (conservative — the benchmark showed moderate per-branch work near break-even).
 default_worthy(expensive).
 default_worthy(recursive).
+
+% ============================================================================
+% Route-1 split analysis: enumerator | body
+% ============================================================================
+%
+% For the compile-time generator/body split (the recommended route for the T7
+% runtime fork), cut a forkable aggregate's inner goal into:
+%
+%   - Enum   — a cheap prefix that produces the fan-out bindings, run once;
+%   - Body   — the expensive per-branch suffix, run on a cloned machine per
+%              Enum solution (the unit `gated_collect` parallelises);
+%   - Frontier — the variables Enum binds that Body reads (each branch's input).
+%
+% This is pure analysis — no codegen, no runtime. It is deliberately
+% conservative: it only splits a plain conjunction of pure goals (no cut, no
+% control constructs, no side effects), and only where there is a non-empty
+% cheap enumerator prefix AND a non-empty body that carries the real work.
+% Anything else fails, and the caller keeps the sequential aggregate.
+
+%% split_aggregate_generator(+InnerGoal, +Model, -Enum, -Body, -Frontier)
+split_aggregate_generator(InnerGoal, Model, Enum, Body, Frontier) :-
+    conj_to_list(InnerGoal, Goals),
+    Goals = [_|_],
+    splittable_goals(Goals),                 % soundness gate
+    split_at_first_expensive(Goals, Model, EnumGs, BodyGs),
+    EnumGs = [_|_],                          % a cheap fan-out prefix exists
+    BodyGs = [_|_],                          % and a body carrying the work
+    list_to_conj(EnumGs, Enum),
+    list_to_conj(BodyGs, Body),
+    term_variables(Enum, EnumVars),
+    term_variables(Body, BodyVars),
+    shared_vars(EnumVars, BodyVars, Frontier).
+
+% --- soundness: only pure, splittable conjunctions ---------------------------
+
+splittable_goals(Goals) :- forall(member(G, Goals), splittable_goal(G)).
+
+splittable_goal(G) :- nonvar(G), \+ unsafe_goal(G).
+
+% Goals that break sound parallel splitting (cut, control flow, side effects).
+unsafe_goal(!).
+unsafe_goal((_ ; _)).
+unsafe_goal((_ -> _)).
+unsafe_goal((_ *-> _)).
+unsafe_goal(\+(_)).
+unsafe_goal(not(_)).
+unsafe_goal(G) :- functor(G, F, A), side_effecting(F/A).
+
+side_effecting(write/1).      side_effecting(writeln/1).
+side_effecting(print/1).      side_effecting(nl/0).
+side_effecting(write/2).      side_effecting(nl/1).
+side_effecting(format/1).     side_effecting(format/2).
+side_effecting(format/3).     side_effecting(read/1).
+side_effecting(read_term/2).  side_effecting(read_term/3).
+side_effecting(assert/1).     side_effecting(asserta/1).
+side_effecting(assertz/1).    side_effecting(retract/1).
+side_effecting(retractall/1). side_effecting(abolish/1).
+side_effecting(tab/1).        side_effecting(put_char/1).
+
+% --- the cut point: cheap enumerator prefix, then the body -------------------
+% Enum = maximal leading run of trivial/cheap goals; Body = the rest, which
+% begins at the first goal that actually does work (moderate/expensive/recursive).
+
+split_at_first_expensive([], _, [], []).
+split_at_first_expensive([G|Gs], Model, Enum, Body) :-
+    ( cheap_goal(G, Model)
+    ->  Enum = [G|Enum1],
+        split_at_first_expensive(Gs, Model, Enum1, Body)
+    ;   Enum = [],
+        Body = [G|Gs]
+    ).
+
+cheap_goal(G, Model) :-
+    goal_cost_tier(G, Model, Tier),
+    ( Tier == trivial ; Tier == cheap ), !.
+
+% --- helpers -----------------------------------------------------------------
+
+conj_to_list(G, [G]) :- var(G), !.
+conj_to_list((A, B), Gs) :- !, conj_to_list(A, GA), conj_to_list(B, GB), append(GA, GB, Gs).
+conj_to_list(G, [G]).
+
+list_to_conj([G], G) :- !.
+list_to_conj([G|Gs], (G, Rest)) :- list_to_conj(Gs, Rest).
+
+% Variables present in both lists, compared by identity (==), order of A.
+shared_vars(As, Bs, Shared) :-
+    include(memberchk_eq(Bs), As, Shared).
+memberchk_eq([X|_], V) :- X == V, !.
+memberchk_eq([_|T], V) :- memberchk_eq(T, V).

--- a/tests/test_parallel_gate.pl
+++ b/tests/test_parallel_gate.pl
@@ -26,6 +26,10 @@ pg_heavy(X, R) :-
     atom_codes(A, S2), atom_concat(A, A, B), sub_atom(B, 0, 3, _, R),
     length(Cs, _), msort(S2, _), reverse(S2, _).
 
+% recursive per-branch work that takes an input from the enumerator
+pg_down(0, []).
+pg_down(N, [N|T]) :- N > 0, M is N - 1, pg_down(M, T).
+
 :- begin_tests(parallel_gate).
 
 build(M) :- build_cost_model(user, M).
@@ -88,5 +92,69 @@ test(policy_override_widens_to_moderate) :-
     % and with the override removed it is sequential again
     aggregate_parallel_decision(findall(Y, (pg_fact(X), pg_cheap(X, Y)), _), M, D2),
     assertion(D2 == sequential).
+
+% --- route-1 split analysis: enumerator | body -----------------------------
+
+% cheap enumerator (fact), heavy body; frontier = the shared var X
+test(split_cheap_enum_heavy_body) :-
+    build(M),
+    I = (pg_fact(X), pg_heavy(X, _R)),
+    split_aggregate_generator(I, M, Enum, Body, Frontier),
+    assertion(Enum =@= pg_fact(_)),
+    assertion(Body =@= pg_heavy(_, _)),
+    assertion(Frontier == [X]).
+
+% cheap enumerator, recursive body taking an input from the enumerator
+test(split_cheap_enum_recursive_body) :-
+    build(M),
+    I = (pg_fact(X), pg_down(X, _L)),
+    split_aggregate_generator(I, M, Enum, Body, Frontier),
+    assertion(Enum =@= pg_fact(_)),
+    assertion(Body =@= pg_down(_, _)),
+    assertion(Frontier == [X]).
+
+% multi-goal cheap prefix; frontier is only the var the body actually reads (Z)
+test(split_multi_goal_prefix_frontier_is_minimal) :-
+    build(M),
+    I = (pg_fact(X), pg_cheap(X, Z), pg_heavy(Z, _R)),
+    split_aggregate_generator(I, M, Enum, Body, Frontier),
+    assertion(Enum =@= (pg_fact(A), pg_cheap(A, _))),   % shared first arg preserved
+    assertion(Body =@= pg_heavy(_, _)),
+    assertion(Frontier == [Z]).         % X stays in Enum only, R in Body only
+
+% a single recursive goal has no cheap fan-out prefix -> no split
+test(no_split_single_recursive_goal) :-
+    build(M),
+    assertion(\+ split_aggregate_generator(pg_down(5, _L), M, _, _, _)).
+
+% all-cheap inner goal has no body carrying work -> no split
+test(no_split_all_cheap) :-
+    build(M),
+    assertion(\+ split_aggregate_generator((pg_fact(X), pg_cheap(X, _Y)), M, _, _, _)).
+
+% soundness: cut, side effects, and disjunction block the split
+test(no_split_with_cut) :-
+    build(M),
+    assertion(\+ split_aggregate_generator((pg_fact(X), !, pg_heavy(X, _R)), M, _, _, _)).
+
+test(no_split_with_side_effect) :-
+    build(M),
+    assertion(\+ split_aggregate_generator((pg_fact(X), writeln(X), pg_heavy(X, _R)), M, _, _, _)).
+
+test(no_split_disjunction) :-
+    build(M),
+    assertion(\+ split_aggregate_generator((pg_fact(X) ; pg_heavy(X, _R)), M, _, _, _)).
+
+% the split round-trips: Enum then Body is exactly the original goal sequence
+test(split_preserves_goals) :-
+    build(M),
+    I = (pg_fact(X), pg_cheap(X, Z), pg_heavy(Z, _R)),
+    split_aggregate_generator(I, M, Enum, Body, _),
+    flatten_conj(Enum, EG), flatten_conj(Body, BG), append(EG, BG, Got),
+    flatten_conj(I, Want),
+    assertion(Got == Want).
+
+flatten_conj((A, B), L) :- !, flatten_conj(A, LA), flatten_conj(B, LB), append(LA, LB, L).
+flatten_conj(G, [G]).
 
 :- end_tests(parallel_gate).


### PR DESCRIPTION
## What

**T7 route-1 — the full parallel-aggregate path, end-to-end and verified.** A user predicate whose body is a parallel-eligible aggregate now compiles (with `parallel_aggregates(true)`) to native parallel execution, automatically. Pure-Prolog analysis + transform (proven result-preserving) → Rust runtime orchestrator (exec-verified) → compile-pipeline injection (exec-verified end-to-end).

### Front-end (pure Prolog, `parallel_gate.pl` + `cost_analysis.pl`)
- **Cost gate** — only `expensive`/`recursive` per-branch work fans out.
- **R1.1 split** `split_aggregate_generator/5` — enumerator | body | frontier, with a soundness gate (cut/control/side-effects/no-fan-out/no-body).
- **R1.2a transform** `parallel_aggregate_transform/5` — aggregate → `__par_enum`/`__par_body` helpers + plan; value-aware frontier; **proven result-preserving** by running the helpers sequentially.

### Runtime (`par_aggregate.rs`, generated into every project)
- **R1.2b** `par_collect` runs the enumerator once, then the body on a **cloned machine per input** across `thread::scope` workers (order-preserved), deref-resolving values. `seq_collect` is the reference. Exec-verified `par_collect == seq_collect`.

### Compile-pipeline injection (`wam_rust_target.pl`)
- **R1.2c** `compile_predicates_for_project` runs `rust_inject_parallel_aggregates`: a predicate whose single clause body is a parallel-eligible aggregate is replaced by its synthesised `__par_enum`/`__par_body` helpers (compiled as ordinary shared-table WAM functions) **plus a native `par_collect` wrapper** that reduces by aggregate type (`collect`→List, `count`→len, `sum`→fold) and unifies the result arg. Gated behind `parallel_aggregates(true)` (default output unchanged).

## Tests (all green)
- Prolog: `test_cost_analysis.pl` (16), `test_parallel_gate.pl` (27: gate+split+transform), `test_wam_rust_parallel_injection.pl` (6: wrapper generation).
- Exec (cargo): `test_wam_rust_par_aggregate_exec.pl` (`par_collect == seq_collect`), **`test_wam_rust_parallel_injection_exec.pl`** — a user `findall` compiles + runs returning `[[1],[2,1],…,[6,5,4,3,2,1]]`, the correct answer computed in parallel.
- Full `test_wam_rust_target.pl` regression still **All tests passed** (compile-pipeline change is no-op when the gate is off).

## Scope / follow-ups (honest)
- Handles a predicate **whose whole body is** a single forkable aggregate. Aggregates **embedded in a larger clause body** still compile sequentially (would need the `par_aggregate` WAM-instruction route, documented in `wam_rust_t7_2b2_fork_analysis.md`).
- Correctness is proven; a **wall-clock speedup benchmark** on a large workload is the natural next measurement (the substrate already showed 2–3.7× on expensive branches in #3025).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_