### PR TITLE
[codex] Add depth prior cache admission policy

### DIFF
--- a/docs/reports/lmdb_cache_admission_policy_probe_2026-06-12.md
+++ b/docs/reports/lmdb_cache_admission_policy_probe_2026-06-12.md
@@ -1,0 +1,93 @@
+# LMDB Cache Admission Policy Probe
+
+This pass turns the depth prior calibration output into an explicit cache
+admission policy.  The policy is still wired only into the probe/report path,
+not the production cache materializer.
+
+## Policy Actions
+
+The helper returns one of four actions:
+
+| action | meaning |
+|--------|---------|
+| `materialize_exact` | Build and cache the exact recurrence histogram. |
+| `materialize_capped` | Build/cache a capped or cycle-approximate histogram because exactness is not guaranteed, but predicted storage is within budget. |
+| `use_parametric_prior` | Store a compact closed-form/parametric prior instead of a histogram. |
+| `skip_cache` | Do not cache this distribution under the current byte budget. |
+
+The inputs are:
+
+- empirical-prior predicted bytes;
+- safety factor;
+- recurrence cap/cycle flags;
+- max allowed histogram bytes;
+- realized histogram bytes when available; and
+- estimated parametric-state bytes.
+
+When realized histogram bytes are available, the policy uses them as an
+under-prediction guard by comparing the byte budget against the larger of the
+safety-adjusted prior estimate and the realized histogram size.
+
+## Smoke Command
+
+```bash
+python3 scripts/lmdb_depth_planning_prior_probe.py \
+  --lmdb-dir /home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct/lmdb_resident \
+  --root 7345184 \
+  --graph-name enwiki_mtc_cache_admission_policy_smoke \
+  --target-depths 1,2,3,4 \
+  --children-per-node 24 \
+  --frontier-limit 180 \
+  --targets-per-depth 4 \
+  --max-parent-depth 24 \
+  --max-prior-depth 24 \
+  --tail-epsilon 0.001 \
+  --safety-factor 1.25 \
+  --max-histogram-bytes 1024 \
+  --parametric-bytes 64 \
+  --path-cap 50000 \
+  --expansion-cap 50000 \
+  --seed enwiki-mtc-depth-prior-calibration-v1 \
+  --output-dir /mnt/c/Users/johnc/Scratch/depth-planning-prior-admission
+```
+
+Outputs:
+
+```text
+/mnt/c/Users/johnc/Scratch/depth-planning-prior-admission/enwiki_mtc_cache_admission_policy_smoke_depth_planning_prior_summary.json
+/mnt/c/Users/johnc/Scratch/depth-planning-prior-admission/enwiki_mtc_cache_admission_policy_smoke_depth_planning_prior_summary.md
+```
+
+## Results
+
+The smoke used the same bounded enwiki MTC sampling shape as the calibration
+pass and covered `16` comparable targets across `L_max` buckets `12`, `15`, and
+`24`.
+
+Cache admission actions:
+
+| action | rows |
+|--------|-----:|
+| `materialize_capped` | 2 |
+| `use_parametric_prior` | 14 |
+
+Cache admission reasons:
+
+| reason | rows |
+|--------|-----:|
+| `recurrence_not_exact_and_histogram_over_budget` | 14 |
+| `recurrence_not_exact_but_within_budget` | 2 |
+
+The result matches the intended policy framing.  All comparable recurrence rows
+were cycle-approximate, and five rows in the `L_max=24` bucket still hit a cap.
+With `--max-histogram-bytes 1024`, the shallow `L_max=12` and `L_max=15` rows
+fit as capped materializations, while the deeper `L_max=24` rows fall back to a
+parametric prior.
+
+## Validation
+
+```bash
+python3 -m unittest tests.test_lmdb_depth_planning_prior_probe tests.test_parent_histogram_recurrence tests.test_lmdb_parent_branching_diagnostic
+python3 -m py_compile scripts/lmdb_depth_planning_prior_probe.py tests/test_lmdb_depth_planning_prior_probe.py
+python3 scripts/lmdb_depth_planning_prior_probe.py ... --graph-name enwiki_mtc_cache_admission_policy_smoke
+```

--- a/scripts/lmdb_depth_planning_prior_probe.py
+++ b/scripts/lmdb_depth_planning_prior_probe.py
@@ -131,16 +131,83 @@ def planning_ratios(predicted_bytes, realized_bytes):
     }
 
 
-def admission_decision(row, prior, comparison, safety_factor):
+def cache_admission_policy(
+    predicted_prior_bytes,
+    safety_factor,
+    max_histogram_bytes,
+    recurrence_capped=False,
+    recurrence_cycle_approximation=False,
+    realized_histogram_bytes=None,
+    parametric_bytes=None,
+):
+    """Choose how aggressively to materialize a cached distribution."""
+    predicted_prior_bytes = max(0, int(predicted_prior_bytes))
+    max_histogram_bytes = max(0, int(max_histogram_bytes))
+    parametric_bytes = parametric_distribution_bytes() if parametric_bytes is None else max(0, int(parametric_bytes))
+    safety_prediction_bytes = int(math.ceil(float(safety_factor) * predicted_prior_bytes))
+    observed_or_predicted_bytes = safety_prediction_bytes
+    if realized_histogram_bytes is not None:
+        observed_or_predicted_bytes = max(safety_prediction_bytes, max(0, int(realized_histogram_bytes)))
+
+    if max_histogram_bytes <= 0:
+        return {
+            "action": "skip_cache",
+            "reason": "histogram_budget_disabled",
+            "safety_prediction_bytes": safety_prediction_bytes,
+            "observed_or_predicted_bytes": observed_or_predicted_bytes,
+            "max_histogram_bytes": max_histogram_bytes,
+            "parametric_bytes": parametric_bytes,
+        }
+
+    if recurrence_capped or recurrence_cycle_approximation:
+        if observed_or_predicted_bytes <= max_histogram_bytes:
+            action = "materialize_capped"
+            reason = "recurrence_not_exact_but_within_budget"
+        elif parametric_bytes <= max_histogram_bytes:
+            action = "use_parametric_prior"
+            reason = "recurrence_not_exact_and_histogram_over_budget"
+        else:
+            action = "skip_cache"
+            reason = "recurrence_not_exact_and_all_representations_over_budget"
+    elif observed_or_predicted_bytes <= max_histogram_bytes:
+        action = "materialize_exact"
+        reason = "exact_histogram_within_budget"
+    elif parametric_bytes <= max_histogram_bytes:
+        action = "use_parametric_prior"
+        reason = "exact_histogram_over_budget"
+    else:
+        action = "skip_cache"
+        reason = "all_representations_over_budget"
+
+    return {
+        "action": action,
+        "reason": reason,
+        "safety_prediction_bytes": safety_prediction_bytes,
+        "observed_or_predicted_bytes": observed_or_predicted_bytes,
+        "max_histogram_bytes": max_histogram_bytes,
+        "parametric_bytes": parametric_bytes,
+    }
+
+
+def admission_decision(row, prior, comparison, safety_factor, max_histogram_bytes, parametric_bytes):
     if not comparison.get("comparable"):
-        return "skip_no_recurrence"
-    if row.get("recurrence_capped") or row.get("recurrence_cycle_approximation"):
-        return "risky_try_capped_or_approx"
-    if comparison["safety_storage_prediction_ratio"] is not None and comparison["safety_storage_prediction_ratio"] <= 2.0:
-        return "exact_recurrence_likely_cheap"
-    if int(prior["prior_effective_bins"]) <= 32:
-        return "exact_recurrence_likely_cheap"
-    return "approximation_first"
+        return {
+            "action": "skip_cache",
+            "reason": "no_recurrence_histogram",
+            "safety_prediction_bytes": None,
+            "observed_or_predicted_bytes": None,
+            "max_histogram_bytes": max_histogram_bytes,
+            "parametric_bytes": parametric_bytes,
+        }
+    return cache_admission_policy(
+        prior["prior_pruned_histogram_bytes"],
+        safety_factor,
+        max_histogram_bytes,
+        recurrence_capped=row.get("recurrence_capped", False),
+        recurrence_cycle_approximation=row.get("recurrence_cycle_approximation", False),
+        realized_histogram_bytes=comparison.get("histogram_bytes"),
+        parametric_bytes=parametric_bytes,
+    )
 
 
 def compare_prior_to_hist(hist, prior, tail_epsilon, safety_factor=1.0):
@@ -261,6 +328,8 @@ def build_records(args, target_rows, selection_counts):
         "tail_epsilon": args.tail_epsilon,
         "max_prior_depth": args.max_prior_depth,
         "safety_factor": args.safety_factor,
+        "max_histogram_bytes": args.max_histogram_bytes,
+        "parametric_bytes": args.parametric_bytes,
     }]
     buckets = {}
     for row in target_rows:
@@ -319,7 +388,21 @@ def build_records(args, target_rows, selection_counts):
                 args.safety_factor,
             )
             record.update(comparison)
-            record["admission_decision"] = admission_decision(row, priors[key], comparison, args.safety_factor)
+            policy = admission_decision(
+                row,
+                priors[key],
+                comparison,
+                args.safety_factor,
+                args.max_histogram_bytes,
+                args.parametric_bytes,
+            )
+            record["cache_admission_action"] = policy["action"]
+            record["cache_admission_reason"] = policy["reason"]
+            record["cache_admission_safety_prediction_bytes"] = policy["safety_prediction_bytes"]
+            record["cache_admission_observed_or_predicted_bytes"] = policy["observed_or_predicted_bytes"]
+            record["cache_admission_max_histogram_bytes"] = policy["max_histogram_bytes"]
+            record["cache_admission_parametric_bytes"] = policy["parametric_bytes"]
+            record["admission_decision"] = policy["action"]
         records.append(record)
     return records
 
@@ -426,16 +509,31 @@ def summarize(records):
 
     lines.extend([
         "",
-        "## Admission Decisions",
+        "## Cache Admission Policy",
         "",
-        "| decision | rows |",
-        "|----------|-----:|",
+        "| action | rows |",
+        "|--------|-----:|",
     ])
     decision_counts = {}
     for row in comparable:
-        decision_counts[row.get("admission_decision", "unknown")] = decision_counts.get(row.get("admission_decision", "unknown"), 0) + 1
+        action = row.get("cache_admission_action", row.get("admission_decision", "unknown"))
+        decision_counts[action] = decision_counts.get(action, 0) + 1
     for decision in sorted(decision_counts):
         lines.append("| {} | {} |".format(decision, decision_counts[decision]))
+
+    lines.extend([
+        "",
+        "## Cache Admission Reasons",
+        "",
+        "| reason | rows |",
+        "|--------|-----:|",
+    ])
+    reason_counts = {}
+    for row in comparable:
+        reason = row.get("cache_admission_reason", "unknown")
+        reason_counts[reason] = reason_counts.get(reason, 0) + 1
+    for reason in sorted(reason_counts):
+        lines.append("| {} | {} |".format(reason, reason_counts[reason]))
 
     skipped = [row for row in target_rows if not row.get("comparable")]
     lines.extend([
@@ -497,6 +595,8 @@ def parse_args(argv=None):
     parser.add_argument("--max-prior-depth", type=int, default=8)
     parser.add_argument("--tail-epsilon", type=float, default=0.001)
     parser.add_argument("--safety-factor", type=float, default=1.25, help="Multiplier for empirical prior bytes in admission planning.")
+    parser.add_argument("--max-histogram-bytes", type=int, default=1024, help="Maximum cache bytes allowed for exact or capped histogram materialization.")
+    parser.add_argument("--parametric-bytes", type=int, default=64, help="Estimated cache bytes for a closed-form/parametric prior state.")
     parser.add_argument("--path-cap", type=int, default=10000)
     parser.add_argument("--expansion-cap", type=int, default=50000)
     parser.add_argument("--write-jsonl", action="store_true")

--- a/tests/test_lmdb_depth_planning_prior_probe.py
+++ b/tests/test_lmdb_depth_planning_prior_probe.py
@@ -9,6 +9,7 @@ import unittest
 from scripts.lmdb_depth_planning_prior_probe import (
     admission_decision,
     build_records,
+    cache_admission_policy,
     compare_prior_to_hist,
     planning_prior_for_bucket,
 )
@@ -41,14 +42,80 @@ class LmdbDepthPlanningPriorProbeTests(unittest.TestCase):
         prior = planning_prior_for_bucket([1, 1, 1], 3, 0.001)
         comparison = compare_prior_to_hist({3: 7}, prior, 0.001)
 
-        decision = admission_decision(
+        policy = admission_decision(
             {"recurrence_capped": True, "recurrence_cycle_approximation": False},
             prior,
             comparison,
             1.25,
+            1024,
+            64,
         )
 
-        self.assertEqual(decision, "risky_try_capped_or_approx")
+        self.assertEqual(policy["action"], "materialize_capped")
+
+    def test_cache_admission_policy_materializes_exact_when_cheap(self):
+        policy = cache_admission_policy(
+            predicted_prior_bytes=128,
+            safety_factor=1.25,
+            max_histogram_bytes=256,
+            realized_histogram_bytes=160,
+            parametric_bytes=64,
+        )
+
+        self.assertEqual(policy["action"], "materialize_exact")
+
+    def test_cache_admission_policy_uses_parametric_when_histogram_over_budget(self):
+        policy = cache_admission_policy(
+            predicted_prior_bytes=2048,
+            safety_factor=1.25,
+            max_histogram_bytes=512,
+            realized_histogram_bytes=2048,
+            parametric_bytes=64,
+        )
+
+        self.assertEqual(policy["action"], "use_parametric_prior")
+
+    def test_cache_admission_policy_uses_realized_bytes_as_underprediction_guard(self):
+        policy = cache_admission_policy(
+            predicted_prior_bytes=128,
+            safety_factor=1.0,
+            max_histogram_bytes=256,
+            realized_histogram_bytes=512,
+            parametric_bytes=64,
+        )
+
+        self.assertEqual(policy["action"], "use_parametric_prior")
+        self.assertEqual(policy["observed_or_predicted_bytes"], 512)
+
+    def test_cache_admission_policy_skips_when_every_representation_over_budget(self):
+        policy = cache_admission_policy(
+            predicted_prior_bytes=2048,
+            safety_factor=1.25,
+            max_histogram_bytes=32,
+            realized_histogram_bytes=2048,
+            parametric_bytes=64,
+        )
+
+        self.assertEqual(policy["action"], "skip_cache")
+
+    def test_cache_admission_policy_safety_factor_changes_decision(self):
+        exact_policy = cache_admission_policy(
+            predicted_prior_bytes=160,
+            safety_factor=1.0,
+            max_histogram_bytes=200,
+            realized_histogram_bytes=None,
+            parametric_bytes=64,
+        )
+        parametric_policy = cache_admission_policy(
+            predicted_prior_bytes=160,
+            safety_factor=1.5,
+            max_histogram_bytes=200,
+            realized_histogram_bytes=None,
+            parametric_bytes=64,
+        )
+
+        self.assertEqual(exact_policy["action"], "materialize_exact")
+        self.assertEqual(parametric_policy["action"], "use_parametric_prior")
 
     def test_build_records_adds_family_ratios_and_decision(self):
         args = argparse.Namespace(
@@ -57,6 +124,8 @@ class LmdbDepthPlanningPriorProbeTests(unittest.TestCase):
             tail_epsilon=0.001,
             max_prior_depth=3,
             safety_factor=1.25,
+            max_histogram_bytes=1024,
+            parametric_bytes=64,
         )
         target_rows = [{
             "target_node": "A",
@@ -76,7 +145,8 @@ class LmdbDepthPlanningPriorProbeTests(unittest.TestCase):
         records = build_records(args, target_rows, {0: 1, 1: 1})
         target_record = next(row for row in records if row["record_type"] == "depth_planning_prior_target")
 
-        self.assertEqual(target_record["admission_decision"], "exact_recurrence_likely_cheap")
+        self.assertEqual(target_record["admission_decision"], "materialize_exact")
+        self.assertEqual(target_record["cache_admission_action"], "materialize_exact")
         self.assertIn("binomial_storage_prediction_ratio", target_record)
         self.assertIn("gamma_storage_prediction_ratio", target_record)
         self.assertIn("safety_storage_prediction_ratio", target_record)


### PR DESCRIPTION
## Summary

- Add an explicit `cache_admission_policy` helper to the depth-prior probe.
- Return one of `materialize_exact`, `materialize_capped`, `use_parametric_prior`, or `skip_cache`.
- Wire policy action/reason fields into target records and markdown summaries.
- Add CLI controls for `--max-histogram-bytes` and `--parametric-bytes`.
- Add tests for exact materialization, capped/cycle handling, parametric fallback, skip behavior, safety-factor sensitivity, and realized-byte underprediction guarding.
- Add a bounded enwiki MTC policy smoke report.

## Smoke Findings

With `--max-histogram-bytes 1024`, `--parametric-bytes 64`, and `--safety-factor 1.25`, the bounded enwiki MTC smoke produced:

| action | rows |
|--------|-----:|
| `materialize_capped` | 2 |
| `use_parametric_prior` | 14 |

The policy uses realized histogram bytes, when available, as an underprediction guard by comparing against the larger of the safety-adjusted prior estimate and the realized sparse histogram size.

## Validation

```bash
python3 -m unittest tests.test_lmdb_depth_planning_prior_probe tests.test_parent_histogram_recurrence tests.test_lmdb_parent_branching_diagnostic
python3 -m py_compile scripts/lmdb_depth_planning_prior_probe.py tests/test_lmdb_depth_planning_prior_probe.py
python3 scripts/lmdb_depth_planning_prior_probe.py ... --graph-name enwiki_mtc_cache_admission_policy_smoke
```

## Local-only changes

An unrelated unstaged edit remains in `templates/targets/fsharp_wam/kernel_bidirectional_ancestor.fs.mustache`; it is intentionally not part of this PR.