### PR TITLE
WAM sweep completion: Lua bind-through fix, C/Haskell ==/2 gap, final 16-target verdicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in `docs/reports/wam_bindthrough_cross_target_sweep.md`. New
   regression test `tests/test_wam_go_bindthrough.pl`; gated by the
   cross-target conformance suite (go/scala/haskell/c/wat) plus
-  per-target suites.
+  per-target suites. SWEEP COMPLETION: the five pending script
+  targets are now probed — Python, R, Clojure clean (guards already
+  present; R uses the F#-style cycle check), **Lua BUGGY and fixed**
+  (the worst variant: no register-class guard AND no deref, so the
+  bind-through clobbered already-bound variables too; fixed in
+  `push_built_term` with guard + deref, gated by the Lua generator
+  suite 37/37 + lowered ite/t4/t5), Elixir interpreter mode BLOCKED
+  (structurally cannot cross-call — module-local label maps; lowered
+  mode clean on both classes). Also fixed from the side findings:
+  **missing `==/2`/`\==/2` in the C and Haskell runtimes**
+  (fail-closed class-7 gap; C gains a read-only
+  `wam_term_strict_equal` traversal, Haskell `derefDeep`-based
+  BuiltinCall arms — both verified against the previously confounded
+  probe batteries and the conformance gate). Newly filed: Lua
+  Y-registers not frame-local, Elixir interpreter cross-call defect,
+  Clojure lowered numeric-literals-as-atoms defect, Elixir lowered
+  `==/2` gap.
 
 ### Added
 - **WAM Rust target: maplist family, atomic_list_concat, char_type

--- a/docs/reports/wam_bindthrough_cross_target_sweep.md
+++ b/docs/reports/wam_bindthrough_cross_target_sweep.md
@@ -39,7 +39,11 @@ see side findings.)
 | F# | clean (cycle-check-guarded bind-through) | clean | see theoretical divergence below |
 | Rust | fixed in P4/P5 (origin of the sweep) | fixed in P5 | — |
 | ILasm | BLOCKED | BLOCKED | newly pinned structural defect: cross-predicate `call` self-loops (below) |
-| Python, Lua, R, Clojure, Elixir | **PENDING** | **PENDING** | probe agents hit the session quota; re-run the sweep prompt for these five |
+| Python | clean (A-reg guard already present, both interpreter loops) | clean | — |
+| Lua | **BUGGY** (worst variant: no guard AND no deref — clobbered already-BOUND variables too) → fixed | clean | guard `top.target >= 101` + deref in `push_built_term` (`runtime.lua.mustache`); controls verified flipped; gates: lua generator suite (37/37) + lowered ite/t4/t5 |
+| R | clean (F#-style cycle-check guard) | clean | inherits the F# theoretical divergence (side finding 4) |
+| Clojure | clean (`a-slot?` register-class guard already present) | clean | side defect found in the opportunistic-lowering path (side finding 7) |
+| Elixir | BLOCKED (interpreter mode) / clean (lowered mode) | BLOCKED / clean | interpreter mode structurally cannot cross-call (side finding 5) |
 
 Verification: every fixed target re-probed through the same harness
 (the bug-shape probe flips to the ISO answer; all controls — including
@@ -90,4 +94,32 @@ register class.
    A NON-cyclic variant — building a goal structure that does not
    contain X into an A register whose occupant is the live head var X
    — would still alias X to that structure. Not exercised by these
-   probes; worth one targeted probe in the F# stream.
+   probes; worth one targeted probe in the F# stream. **R shares this
+   exact shape** (`wam_term_contains_var` cycle check in
+   `runtime.R.mustache:426-443`).
+5. **Elixir interpreter mode structurally cannot cross-call**: each
+   predicate module embeds only its own code/labels, and the
+   call/execute fallbacks resolve against the module-local map and
+   fail on miss (`wam_elixir_target.pl:296/:322`). Any clause calling
+   another predicate wrong-fails; only lowered mode (WamDispatcher) is
+   multi-predicate-capable. ILasm-family finding (clean fail rather
+   than self-loop).
+6. **Lua Y registers are not environment-local**: `get_reg`/`put_reg`
+   index a single flat `state.regs` while `Allocate` pushes a `locals`
+   table nothing uses — a callee's Y1 clobbers the caller's Y1. This
+   keeps Lua's cross-call probes (p_bind/p_bind2) failing even after
+   the class-1 fix; the fix's verification rests on the single-call
+   controls (p_bindctl2 flipped false→true). Kotlin-finding-#2 family;
+   needs its own campaign.
+7. **Clojure: numeric literals interned as atoms in the
+   opportunistically-lowered path** — default mode silently lowers
+   eligible (incl. all zero-arity) predicates, and the lowered
+   `put-constant` routes literals through `normalize-literal-atom`,
+   which interns numerals as atoms; a subsequent `R is 1` compares
+   atom-"1" to integer 1 and wrong-fails. The interpreter path is
+   correct. (`wam_clojure_target.pl:208-210`,
+   `wam_clojure_lowered_emitter.pl:1284`,
+   `runtime.clj.mustache:52-54`.)
+8. **Elixir lowered mode: `==/2` fails closed** — same class-7 gap
+   fixed for C and Haskell in this sweep; Rust-P3-style builtin parity
+   sweep applies.

--- a/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
+++ b/src/unifyweaver/targets/wam_c_runtime/wam_runtime.h
@@ -869,13 +869,73 @@ static inline bool wam_unify(WamState *state, WamValue *v1, WamValue *v2) {
             WamValue *f2 = &state->H_array[d2->data.ref_addr];
             if (f1->tag != VAL_ATOM || f2->tag != VAL_ATOM) return false;
             if (strcmp(f1->data.atom, f2->data.atom) != 0) return false;
-            
+
             const char *slash = strchr(f1->data.atom, '/');
             assert(slash != NULL && "Functor missing arity suffix");
             int arity = strtol(slash + 1, NULL, 10);
-            
+
             if (pdl_top + arity * 2 > 256) return false; // PDL overflow
             // Push right-to-left so arguments are popped and unified left-to-right
+            for (int i = arity - 1; i >= 0; i--) {
+                pdl[pdl_top++] = &state->H_array[d2->data.ref_addr + 1 + i];
+                pdl[pdl_top++] = &state->H_array[d1->data.ref_addr + 1 + i];
+            }
+        } else {
+            return false;
+        }
+    }
+    return true;
+}
+
+/* Strict structural equality (==/2): the wam_unify traversal made
+   READ-ONLY — it never binds, and any unbound cell makes the terms
+   unequal unless both sides deref to the very same cell. Cons-cell
+   spelling aliasing (VAL_LIST vs "[|]/2" VAL_STR) matches unify. */
+static inline bool wam_term_strict_equal(WamState *state, WamValue *v1, WamValue *v2) {
+    WamValue *pdl[256];
+    int pdl_top = 0;
+
+    pdl[pdl_top++] = v2;
+    pdl[pdl_top++] = v1;
+
+    while (pdl_top > 0) {
+        WamValue *d1 = wam_deref_ptr(state, pdl[--pdl_top]);
+        WamValue *d2 = wam_deref_ptr(state, pdl[--pdl_top]);
+
+        if (d1 == d2) continue;
+        if (d1->tag == VAL_UNBOUND || d2->tag == VAL_UNBOUND) return false;
+
+        {
+            int c1 = wam_cons_head_addr(state, d1);
+            int c2 = wam_cons_head_addr(state, d2);
+            if (c1 >= 0 && c2 >= 0) {
+                if (pdl_top + 4 > 256) return false;
+                pdl[pdl_top++] = &state->H_array[c2 + 1];
+                pdl[pdl_top++] = &state->H_array[c1 + 1];
+                pdl[pdl_top++] = &state->H_array[c2];
+                pdl[pdl_top++] = &state->H_array[c1];
+                continue;
+            }
+            if (c1 >= 0 || c2 >= 0) return false;
+        }
+
+        if (d1->tag != d2->tag) return false;
+
+        if (d1->tag == VAL_INT) {
+            if (d1->data.integer != d2->data.integer) return false;
+        } else if (d1->tag == VAL_FLOAT) {
+            if (d1->data.floating != d2->data.floating) return false;
+        } else if (d1->tag == VAL_ATOM) {
+            if (strcmp(d1->data.atom, d2->data.atom) != 0) return false;
+        } else if (d1->tag == VAL_STR) {
+            WamValue *f1 = &state->H_array[d1->data.ref_addr];
+            WamValue *f2 = &state->H_array[d2->data.ref_addr];
+            if (f1->tag != VAL_ATOM || f2->tag != VAL_ATOM) return false;
+            if (strcmp(f1->data.atom, f2->data.atom) != 0) return false;
+            const char *slash = strchr(f1->data.atom, '/');
+            if (slash == NULL) return false;
+            int arity = strtol(slash + 1, NULL, 10);
+            if (pdl_top + arity * 2 > 256) return false;
             for (int i = arity - 1; i >= 0; i--) {
                 pdl[pdl_top++] = &state->H_array[d2->data.ref_addr + 1 + i];
                 pdl[pdl_top++] = &state->H_array[d1->data.ref_addr + 1 + i];

--- a/src/unifyweaver/targets/wam_c_target.pl
+++ b/src/unifyweaver/targets/wam_c_target.pl
@@ -4235,6 +4235,15 @@ bool wam_execute_builtin(WamState *state, const char *op, int arity) {
         return wam_unify(state, &state->A[0], &state->A[1]);
     }
 
+    /* Strict (in)equality: previously missing from the table entirely,
+       so the shared compiler emitted builtin_call ==/2 and it failed
+       closed (even X = a, X == a was false) -- the class-7 gap found
+       by the bind-through probe sweep. */
+    if ((strcmp(op, "==/2") == 0 || strcmp(op, "\\\\==/2") == 0) && arity == 2) {
+        bool eq = wam_term_strict_equal(state, &state->A[0], &state->A[1]);
+        return (strcmp(op, "==/2") == 0) ? eq : !eq;
+    }
+
     if (arity == 1) {
         WamValue *a1 = wam_deref_ptr(state, &state->A[0]);
         if (strcmp(op, "atom/1") == 0) return a1->tag == VAL_ATOM;

--- a/src/unifyweaver/targets/wam_haskell_target.pl
+++ b/src/unifyweaver/targets/wam_haskell_target.pl
@@ -2369,6 +2369,28 @@ step !ctx s (BuiltinCall "=/2" _) =
       unifyVal (derefVar (wsBindings s) a) (derefVar (wsBindings s) b) s
     _ -> Nothing
 
+-- Strict (in)equality. Previously missing from the table entirely, so
+-- the shared compiler emitted BuiltinCall ==/2 and it fell through to
+-- the catch-all Nothing (even X = a, X == a failed) -- the class-7 gap
+-- found by the bind-through probe sweep. derefDeep makes the compare
+-- structural through the binding table; distinct unbound vids stay
+-- unequal, matching ISO ==/2. (Cons-spelling caveat: a VList and an
+-- equivalent Str cons chain do not compare equal -- same limitation as
+-- unifyVal had before its aliasing arms; acceptable for the guard use.)
+step !ctx s (BuiltinCall "==/2" _) =
+  case (IM.lookup 1 (wsRegs s), IM.lookup 2 (wsRegs s)) of
+    (Just a, Just b)
+      | derefDeep (wsBindings s) a == derefDeep (wsBindings s) b ->
+          Just (s { wsPC = wsPC s + 1 })
+    _ -> Nothing
+
+step !ctx s (BuiltinCall "\\\\==/2" _) =
+  case (IM.lookup 1 (wsRegs s), IM.lookup 2 (wsRegs s)) of
+    (Just a, Just b)
+      | derefDeep (wsBindings s) a /= derefDeep (wsBindings s) b ->
+          Just (s { wsPC = wsPC s + 1 })
+    _ -> Nothing
+
 step !ctx s (BuiltinCall "length/2" _) =
   let listVal = derefVar (wsBindings s) $ fromMaybe (VList []) (IM.lookup 1 (wsRegs s))
   in case listVal of

--- a/templates/targets/lua_wam/runtime.lua.mustache
+++ b/templates/targets/lua_wam/runtime.lua.mustache
@@ -220,9 +220,28 @@ local function push_built_term(state, term)
       table.insert(parent.args, built)
       top = parent
     else
-      local target_val = Runtime.get_reg(state, top.target)
-      if type(target_val) == "table" and target_val.tag == "unbound" then
-        bind_var(state, target_val, built)
+      -- Bind-through of the register old occupant supports top-down
+      -- structure chaining (a set_variable placeholder filled by a later
+      -- put_structure into the same register).
+      --
+      -- A-REGISTER EXCEPTION (M139/M140 bind-through class): A registers
+      -- (index < 101; X = 101+, Y = 201+) are argument STAGING -- their
+      -- old occupant is an unrelated variable (often a clause-head
+      -- argument), and binding it to the freshly built term creates a
+      -- cyclic term (X = f(X)), wrong-failing a later X = 1. Placeholders
+      -- only ever live in X/Y registers, so the bind-through is gated on
+      -- the register class -- the same fix as Rust/Go/Scala/Kotlin/
+      -- Haskell/C/WAT. The deref is also new: the cell carries
+      -- tag == "unbound" even after a binding lands in state.bindings,
+      -- so binding without deref clobbered already-bound variables.
+      if top.target >= 101 then
+        local target_val = Runtime.get_reg(state, top.target)
+        if type(target_val) == "table" and target_val.tag == "unbound" then
+          local d = Runtime.deref(state, target_val)
+          if type(d) == "table" and d.tag == "unbound" then
+            bind_var(state, d, built)
+          end
+        end
       end
       Runtime.put_reg(state, top.target, built)
       state.mode = nil


### PR DESCRIPTION
## Summary

Completes the cross-target bind-through sweep started in #3048. Two fix commits plus the final verdict table.

### 1. C + Haskell: missing `==/2`/`\==/2` (class-7 fail-closed gap)

The shared compiler emits `builtin_call ==/2` but neither runtime had a handler — even `X = a, X == a` was false, silently wrong-failing any guard using strict (in)equality (this had confounded the sweep's own probes). C gains a read-only `wam_term_strict_equal` PDL traversal (the `wam_unify` walk minus binding; distinct unbound cells unequal; cons-spelling aliasing preserved); Haskell gains `derefDeep`-based BuiltinCall arms. Both verified against the previously confounded probe batteries — all flip to ISO answers.

### 2. Lua: the worst variant of the bind-through class — fixed

The five pending script targets are now probed. Lua's `push_built_term` had **no register-class guard AND no deref**, so the bind-through not only created cyclic terms but **clobbered already-bound variables** (even the `=`-based control wrong-failed). Fix: gate on `top.target >= 101` + deref before binding. The clobber control flipped false→true; the remaining cross-call probe failures are a *separate*, newly filed structural defect (Y registers not frame-local).

### Final verdict table (all 16 targets)

| Verdict | Targets |
|---|---|
| Buggy → fixed | Rust (origin), Go, Scala, Kotlin, Haskell, C (untrailed!), WAT, **Lua** (unguarded + un-dereffed) |
| Clean | C++, LLVM (M140 regression-verified), F# + R (cycle-check guards — shared theoretical divergence filed), **Python**, **Clojure** (guards already present) |
| Blocked, structural defects pinned | ILasm (cross-pred calls self-loop), **Elixir interpreter mode** (module-local label maps cannot cross-call; lowered mode clean on both classes) |

Class 2 (non-atom list heads): clean everywhere outside Rust (fixed in P5).

Newly filed side findings (diagnosed, not fixed): Lua Y-registers not frame-local, Elixir interpreter cross-call defect, Clojure lowered-path numeric-literals-interned-as-atoms, Elixir lowered `==/2` gap. Full evidence: `docs/reports/wam_bindthrough_cross_target_sweep.md`.

## Test plan

- [x] C/Haskell: previously confounded probe batteries re-run — all ISO answers; conformance gate `CONFORMANCE_TARGETS=c,haskell`; `test_wam_c_var_alias`
- [x] Lua: probe battery re-run (clobber control flipped, list/atom controls stable); generator suite 37/37; lowered ite/t4/t5 suites
- [x] No behavior change for clean targets (report-only)

https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM)_