### PR TITLE
[codex] Wire admission policy into boundary cache benchmark

### DIFF
--- a/docs/reports/lmdb_boundary_cache_admission_policy_2026-06-12.md
+++ b/docs/reports/lmdb_boundary_cache_admission_policy_2026-06-12.md
@@ -1,0 +1,144 @@
+# LMDB Boundary Cache Admission Policy
+
+This pass wires the depth-prior cache admission policy into the boundary-cache
+benchmark.  It does not add production cache behavior.  The benchmark still
+precomputes boundary histograms for measurement, then the policy decides whether
+each measured boundary distribution would enter the cache.
+
+Parametric decisions are recorded, but they are not treated as cache hits.  If a
+boundary is classified as `use_parametric_prior` or `skip_cache`, the later
+target search falls back to the normal uncached traversal when it reaches that
+node.
+
+## Script Changes
+
+`scripts/lmdb_parent_boundary_cache_benchmark.py` now accepts:
+
+```text
+--admission-policy baseline|depth-prior
+--safety-factor
+--max-histogram-bytes
+--parametric-bytes
+--tail-epsilon
+--max-parent-depth
+```
+
+For `depth-prior`, boundary candidates are bucketed by measured histogram
+`L_max`, a depth-conditioned prior is estimated from root-reaching parent degree
+signals, and `cache_admission_policy` decides one of:
+
+- `materialize_exact`
+- `materialize_capped`
+- `use_parametric_prior`
+- `skip_cache`
+
+Only `materialize_exact` and `materialize_capped` insert a histogram into the
+boundary cache.
+
+## Smoke Commands
+
+Baseline:
+
+```bash
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py \
+  --lmdb-dir /home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct/lmdb_resident \
+  --root 7345184 \
+  --graph-name enwiki_mtc_boundary_cache_policy_baseline_smoke \
+  --boundary-depths 2 \
+  --target-depths 3 \
+  --children-per-node 64 \
+  --frontier-limit 600 \
+  --boundaries-per-depth 24 \
+  --targets-per-depth 8 \
+  --boundary-budget 6 \
+  --budgets 6,8 \
+  --path-cap 50000 \
+  --expansion-cap 100000 \
+  --seed enwiki-mtc-boundary-policy-v1 \
+  --admission-policy baseline \
+  --output-dir /mnt/c/Users/johnc/Scratch/boundary-cache-policy
+```
+
+Depth-prior, permissive byte cap:
+
+```bash
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... \
+  --graph-name enwiki_mtc_boundary_cache_policy_depth_prior_smoke \
+  --admission-policy depth-prior \
+  --safety-factor 1.25 \
+  --max-histogram-bytes 1024 \
+  --parametric-bytes 64
+```
+
+Depth-prior, strict byte cap:
+
+```bash
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... \
+  --graph-name enwiki_mtc_boundary_cache_policy_depth_prior_64b_smoke \
+  --admission-policy depth-prior \
+  --safety-factor 1.25 \
+  --max-histogram-bytes 64 \
+  --parametric-bytes 64
+```
+
+## Results
+
+All three runs used the same sampled boundary and target sets:
+
+| role | child_depth | sampled_frontier_nodes |
+|------|-------------|------------------------|
+| boundary | 0 | 1 |
+| boundary | 1 | 35 |
+| boundary | 2 | 600 |
+| target | 0 | 1 |
+| target | 1 | 35 |
+| target | 2 | 600 |
+| target | 3 | 600 |
+
+Admission outcomes:
+
+| run | boundary_nodes | cached_boundary_nodes | actions |
+|-----|---------------:|----------------------:|---------|
+| baseline | 24 | 24 | `materialize_exact`: 24 |
+| depth-prior, 1024 bytes | 24 | 24 | `materialize_capped`: 24 |
+| depth-prior, 64 bytes | 24 | 0 | `use_parametric_prior`: 24 |
+
+Search comparison:
+
+| run | budget | rows | mean_l1 | mean_node_ratio | mean_cache_hits | full_capped | cached_capped |
+|-----|-------:|-----:|--------:|----------------:|----------------:|------------:|--------------:|
+| baseline | 6 | 8 | 0.000000 | 0.999 | 4.875 | 0 | 0 |
+| baseline | 8 | 8 | 0.000845 | 1.000 | 3.625 | 8 | 8 |
+| depth-prior, 1024 bytes | 6 | 8 | 0.000000 | 0.999 | 4.875 | 0 | 0 |
+| depth-prior, 1024 bytes | 8 | 8 | 0.000845 | 1.000 | 3.625 | 8 | 8 |
+| depth-prior, 64 bytes | 6 | 8 | 0.000000 | 1.000 | 0.000 | 0 | 0 |
+| depth-prior, 64 bytes | 8 | 8 | 0.000000 | 1.000 | 0.000 | 8 | 8 |
+
+## Interpretation
+
+With a permissive `1024` byte histogram budget, the depth-prior policy admits the
+same 24 boundary histograms as the baseline.  They are labeled
+`materialize_capped` rather than `materialize_exact` because the policy treats
+cycle-skipped boundary histograms as not guaranteed exact boundary conditions.
+Benchmark behavior is therefore identical to baseline.
+
+With a strict `64` byte histogram budget, the policy records all 24 boundaries
+as `use_parametric_prior` and inserts none into the histogram cache.  Because
+the benchmark does not yet simulate parametric boundary hits, target search falls
+back to uncached traversal and reports zero cache hits.  This is intentional: the
+first integration measures admission decisions without pretending a parametric
+state is an exact histogram.
+
+The next benchmark step is to add a separate approximate-boundary path for
+parametric priors, then compare accuracy and runtime against exact/capped
+histogram materialization.
+
+## Validation
+
+```bash
+python3 -m unittest tests.test_lmdb_parent_boundary_cache_benchmark tests.test_lmdb_depth_planning_prior_probe tests.test_lmdb_parent_histogram_benchmark tests.test_lmdb_parent_branching_diagnostic
+python3 -m py_compile scripts/lmdb_parent_boundary_cache_benchmark.py tests/test_lmdb_parent_boundary_cache_benchmark.py
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --admission-policy baseline
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --admission-policy depth-prior --max-histogram-bytes 1024
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --admission-policy depth-prior --max-histogram-bytes 64
+```

--- a/scripts/lmdb_parent_boundary_cache_benchmark.py
+++ b/scripts/lmdb_parent_boundary_cache_benchmark.py
@@ -31,7 +31,13 @@ from scripts.distribution_fit_comparison import exact_excess_distribution, l1_er
 from scripts.lmdb_parent_branching_diagnostic import (
     LmdbCategoryGraph,
     parse_int_list,
+    root_distances,
     select_targets_by_child_depth,
+)
+from scripts.lmdb_depth_planning_prior_probe import (
+    cache_admission_policy,
+    histogram_storage_bytes,
+    planning_prior_for_bucket,
 )
 from scripts.lmdb_parent_histogram_benchmark import (
     HistogramStats,
@@ -117,22 +123,51 @@ def histogram_distribution_error(full_hist, cached_hist):
     return l1_error(full_dist, cached_dist), max_cdf_error(full_dist, cached_dist)
 
 
-def build_boundary_cache(graph, root, boundary_nodes, boundary_budget, path_cap, expansion_cap):
+def root_reaching_parent_degree(graph, root, node, max_parent_depth, distance_memo):
+    def distances(candidate):
+        return root_distances(candidate, root, graph.parents, max_parent_depth, distance_memo)
+
+    return sum(1 for parent in graph.parents(node) if distances(parent)["L_min"] is not None)
+
+
+def build_boundary_cache(
+    graph,
+    root,
+    boundary_nodes,
+    boundary_budget,
+    path_cap,
+    expansion_cap,
+    admission_policy="baseline",
+    safety_factor=1.25,
+    max_histogram_bytes=1024,
+    parametric_bytes=64,
+    tail_epsilon=0.001,
+    max_parent_depth=24,
+):
     cache = {}
     rows = []
+    distance_memo = {}
     for node in boundary_nodes:
         started = time.perf_counter_ns()
         hist, stats = bounded_parent_histogram(graph.parents, node, root, boundary_budget, path_cap, expansion_cap)
         elapsed = time.perf_counter_ns() - started
-        if hist and not stats.path_cap_hit and not stats.expansion_cap_hit:
-            cache[node] = hist
         rows.append({
             "record_type": "boundary_cache_entry",
             "node": node,
-            "cached": node in cache,
+            "cached": False,
             "histogram": hist,
             "path_count": sum(hist.values()),
             "support_bins": len(hist),
+            "histogram_L_min": min(hist) if hist else None,
+            "histogram_L_max": max(hist) if hist else None,
+            "histogram_bytes": histogram_storage_bytes(hist),
+            "root_reaching_parent_degree": root_reaching_parent_degree(
+                graph,
+                root,
+                node,
+                max_parent_depth,
+                distance_memo,
+            ),
             "nodes_expanded": stats.nodes_expanded,
             "edges_examined": stats.edges_examined,
             "cycle_skips": stats.cycle_skips,
@@ -140,6 +175,74 @@ def build_boundary_cache(graph, root, boundary_nodes, boundary_budget, path_cap,
             "expansion_cap_hit": stats.expansion_cap_hit,
             "histogram_time_ns": elapsed,
         })
+
+    priors = {}
+    if admission_policy == "depth-prior":
+        degrees_by_lmax = {}
+        for row in rows:
+            lmax = row["histogram_L_max"]
+            degree = row["root_reaching_parent_degree"]
+            if lmax is not None and degree > 0:
+                degrees_by_lmax.setdefault(int(lmax), []).append(int(degree))
+        for lmax, degrees in degrees_by_lmax.items():
+            priors[lmax] = planning_prior_for_bucket(degrees, lmax, tail_epsilon)
+
+    for row in rows:
+        hist = row["histogram"]
+        lmax = row["histogram_L_max"]
+        if admission_policy == "baseline":
+            cached = bool(hist) and not row["path_cap_hit"] and not row["expansion_cap_hit"]
+            action = "materialize_exact" if cached else "skip_cache"
+            reason = "baseline_uncapped_histogram" if cached else "baseline_empty_or_capped"
+            policy = {
+                "action": action,
+                "reason": reason,
+                "safety_prediction_bytes": None,
+                "observed_or_predicted_bytes": row["histogram_bytes"],
+                "max_histogram_bytes": None,
+                "parametric_bytes": None,
+            }
+            predicted_prior_bytes = None
+            prior_effective_bins = None
+        elif lmax in priors and hist:
+            prior = priors[lmax]
+            predicted_prior_bytes = int(prior["prior_pruned_histogram_bytes"])
+            prior_effective_bins = int(prior["prior_effective_bins"])
+            policy = cache_admission_policy(
+                predicted_prior_bytes,
+                safety_factor,
+                max_histogram_bytes,
+                recurrence_capped=row["path_cap_hit"] or row["expansion_cap_hit"],
+                recurrence_cycle_approximation=row["cycle_skips"] > 0,
+                realized_histogram_bytes=row["histogram_bytes"],
+                parametric_bytes=parametric_bytes,
+            )
+            cached = policy["action"] in {"materialize_exact", "materialize_capped"}
+        else:
+            predicted_prior_bytes = None
+            prior_effective_bins = None
+            policy = {
+                "action": "skip_cache",
+                "reason": "no_planning_prior_or_histogram",
+                "safety_prediction_bytes": None,
+                "observed_or_predicted_bytes": row["histogram_bytes"],
+                "max_histogram_bytes": max_histogram_bytes,
+                "parametric_bytes": parametric_bytes,
+            }
+            cached = False
+
+        row["admission_policy"] = admission_policy
+        row["predicted_prior_bytes"] = predicted_prior_bytes
+        row["prior_effective_bins"] = prior_effective_bins
+        row["cache_admission_action"] = policy["action"]
+        row["cache_admission_reason"] = policy["reason"]
+        row["cache_admission_safety_prediction_bytes"] = policy["safety_prediction_bytes"]
+        row["cache_admission_observed_or_predicted_bytes"] = policy["observed_or_predicted_bytes"]
+        row["cache_admission_max_histogram_bytes"] = policy["max_histogram_bytes"]
+        row["cache_admission_parametric_bytes"] = policy["parametric_bytes"]
+        row["cached"] = cached
+        if cached:
+            cache[row["node"]] = hist
     return cache, rows
 
 
@@ -214,6 +317,12 @@ def run_benchmark(args):
             args.boundary_budget,
             args.path_cap,
             args.expansion_cap,
+            args.admission_policy,
+            args.safety_factor,
+            args.max_histogram_bytes,
+            args.parametric_bytes,
+            args.tail_epsilon,
+            args.max_parent_depth,
         )
         records = [{
             "record_type": "boundary_cache_selection",
@@ -226,6 +335,10 @@ def run_benchmark(args):
             "targets": len(targets),
             "budgets": budgets,
             "boundary_budget": args.boundary_budget,
+            "admission_policy": args.admission_policy,
+            "safety_factor": args.safety_factor,
+            "max_histogram_bytes": args.max_histogram_bytes,
+            "parametric_bytes": args.parametric_bytes,
         }]
         records.extend(cache_rows)
         for target in targets:
@@ -301,6 +414,46 @@ def summarize(records):
             selection.get("targets", 0),
             selection.get("boundary_budget", 0),
         ),
+        "",
+        "## Admission Policy",
+        "",
+        "| policy | safety_factor | max_histogram_bytes | parametric_bytes |",
+        "|--------|--------------:|--------------------:|-----------------:|",
+        "| {} | {} | {} | {} |".format(
+            selection.get("admission_policy", "baseline"),
+            selection.get("safety_factor", "n/a"),
+            selection.get("max_histogram_bytes", "n/a"),
+            selection.get("parametric_bytes", "n/a"),
+        ),
+        "",
+        "## Boundary Admission Outcomes",
+        "",
+        "| action | rows | cached |",
+        "|--------|-----:|-------:|",
+    ])
+    action_counts = {}
+    cached_by_action = {}
+    for row in cache_rows:
+        action = row.get("cache_admission_action", "unknown")
+        action_counts[action] = action_counts.get(action, 0) + 1
+        if row.get("cached"):
+            cached_by_action[action] = cached_by_action.get(action, 0) + 1
+    for action in sorted(action_counts):
+        lines.append("| {} | {} | {} |".format(action, action_counts[action], cached_by_action.get(action, 0)))
+    lines.extend([
+        "",
+        "## Boundary Admission Reasons",
+        "",
+        "| reason | rows |",
+        "|--------|-----:|",
+    ])
+    reason_counts = {}
+    for row in cache_rows:
+        reason = row.get("cache_admission_reason", "unknown")
+        reason_counts[reason] = reason_counts.get(reason, 0) + 1
+    for reason in sorted(reason_counts):
+        lines.append("| {} | {} |".format(reason, reason_counts[reason]))
+    lines.extend([
         "",
         "## Boundary Cache Build",
         "",
@@ -385,6 +538,12 @@ def main(argv=None):
     parser.add_argument("--targets-per-depth", type=int, default=30, help="Targets per requested target depth.")
     parser.add_argument("--boundary-budget", type=int, default=6, help="Path budget used to precompute boundary histograms.")
     parser.add_argument("--budgets", default=",".join(map(str, DEFAULT_BUDGETS)), help="Comma-separated target path budgets.")
+    parser.add_argument("--admission-policy", choices=["baseline", "depth-prior"], default="baseline", help="Policy used to decide whether measured boundary histograms enter the cache.")
+    parser.add_argument("--safety-factor", type=float, default=1.25, help="Multiplier for depth-prior predicted histogram bytes.")
+    parser.add_argument("--max-histogram-bytes", type=int, default=1024, help="Maximum bytes allowed for exact or capped boundary histograms under depth-prior admission.")
+    parser.add_argument("--parametric-bytes", type=int, default=64, help="Estimated bytes for a parametric prior state.")
+    parser.add_argument("--tail-epsilon", type=float, default=0.001, help="Tail epsilon used when estimating depth-prior effective support.")
+    parser.add_argument("--max-parent-depth", type=int, default=24, help="Parent depth cap for root-reaching parent degree signals.")
     parser.add_argument("--path-cap", type=int, default=100000, help="Stop a row after this many root paths.")
     parser.add_argument("--expansion-cap", type=int, default=250000, help="Stop a row after this many expanded nodes.")
     parser.add_argument("--seed", default="0", help="Deterministic sampling seed.")

--- a/tests/test_lmdb_parent_boundary_cache_benchmark.py
+++ b/tests/test_lmdb_parent_boundary_cache_benchmark.py
@@ -5,8 +5,20 @@
 
 import unittest
 
-from scripts.lmdb_parent_boundary_cache_benchmark import cached_parent_histogram, histogram_distribution_error
+from scripts.lmdb_parent_boundary_cache_benchmark import (
+    build_boundary_cache,
+    cached_parent_histogram,
+    histogram_distribution_error,
+)
 from scripts.lmdb_parent_histogram_benchmark import bounded_parent_histogram
+
+
+class DictGraph:
+    def __init__(self, parents):
+        self._parents = parents
+
+    def parents(self, node):
+        return self._parents.get(node, [])
 
 
 class BoundaryCacheBenchmarkTests(unittest.TestCase):
@@ -44,6 +56,57 @@ class BoundaryCacheBenchmarkTests(unittest.TestCase):
         l1, cdf = histogram_distribution_error(full, cached)
         self.assertGreater(l1, 0.0)
         self.assertGreater(cdf, 0.0)
+
+    def test_baseline_boundary_cache_materializes_uncapped_histogram(self):
+        graph = DictGraph({"A": ["R"]})
+
+        cache, rows = build_boundary_cache(graph, "R", ["A"], 1, None, None)
+
+        self.assertEqual(cache, {"A": {1: 1}})
+        self.assertEqual(rows[0]["cache_admission_action"], "materialize_exact")
+        self.assertEqual(rows[0]["cache_admission_reason"], "baseline_uncapped_histogram")
+
+    def test_depth_prior_boundary_policy_materializes_within_budget(self):
+        graph = DictGraph({"A": ["R"]})
+
+        cache, rows = build_boundary_cache(
+            graph,
+            "R",
+            ["A"],
+            1,
+            None,
+            None,
+            admission_policy="depth-prior",
+            safety_factor=1.25,
+            max_histogram_bytes=1024,
+            parametric_bytes=64,
+            max_parent_depth=4,
+        )
+
+        self.assertEqual(cache, {"A": {1: 1}})
+        self.assertEqual(rows[0]["cache_admission_action"], "materialize_exact")
+        self.assertEqual(rows[0]["predicted_prior_bytes"], 16)
+
+    def test_depth_prior_boundary_policy_records_parametric_without_cache_hit(self):
+        graph = DictGraph({"A": ["R"]})
+
+        cache, rows = build_boundary_cache(
+            graph,
+            "R",
+            ["A"],
+            1,
+            None,
+            None,
+            admission_policy="depth-prior",
+            safety_factor=2.0,
+            max_histogram_bytes=24,
+            parametric_bytes=8,
+            max_parent_depth=4,
+        )
+
+        self.assertEqual(cache, {})
+        self.assertEqual(rows[0]["cache_admission_action"], "use_parametric_prior")
+        self.assertFalse(rows[0]["cached"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add optional `--admission-policy baseline|depth-prior` to `scripts/lmdb_parent_boundary_cache_benchmark.py`.
- Wire `cache_admission_policy` into boundary cache construction after measured boundary histograms are built.
- Record policy actions/reasons per boundary and summarize action counts in the markdown output.
- Add policy flags mirroring the depth-prior probe: `--safety-factor`, `--max-histogram-bytes`, `--parametric-bytes`, `--tail-epsilon`, and `--max-parent-depth`.
- Keep parametric/skip decisions honest: they are counted but do not become fake cache hits.
- Add tests for baseline materialization, depth-prior histogram admission, and parametric-prior fallback.
- Add a bounded enwiki MTC report comparing baseline, permissive depth-prior, and strict depth-prior admission.

## Smoke Findings

All runs used 24 boundary candidates and 8 targets.

| run | cached boundaries | actions |
|-----|------------------:|---------|
| baseline | 24 | `materialize_exact`: 24 |
| depth-prior, 1024 bytes | 24 | `materialize_capped`: 24 |
| depth-prior, 64 bytes | 0 | `use_parametric_prior`: 24 |

With the permissive 1024-byte cap, benchmark behavior matches baseline because all histograms still enter the cache. With the strict 64-byte cap, no histograms enter the cache, so target search falls back to uncached traversal and reports zero cache hits. Parametric decisions are recorded but not simulated as exact cache hits.

## Validation

```bash
python3 -m unittest tests.test_lmdb_parent_boundary_cache_benchmark tests.test_lmdb_depth_planning_prior_probe tests.test_lmdb_parent_histogram_benchmark tests.test_lmdb_parent_branching_diagnostic
python3 -m py_compile scripts/lmdb_parent_boundary_cache_benchmark.py tests/test_lmdb_parent_boundary_cache_benchmark.py
python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --admission-policy baseline
python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --admission-policy depth-prior --max-histogram-bytes 1024
python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --admission-policy depth-prior --max-histogram-bytes 64
```

## Local-only changes

An unrelated unstaged edit remains in `templates/targets/fsharp_wam/kernel_bidirectional_ancestor.fs.mustache`; it is intentionally not part of this PR.