### PR TITLE
[codex] Add parametric boundary cache benchmark

### DIFF
--- a/docs/reports/lmdb_parametric_boundary_cache_2026-06-12.md
+++ b/docs/reports/lmdb_parametric_boundary_cache_2026-06-12.md
@@ -1,0 +1,135 @@
+# LMDB Parametric Boundary Cache Benchmark
+
+This pass adds an approximate boundary-cache path for `use_parametric_prior`
+admission decisions.  Histogram-backed actions still splice histograms exactly as
+before.  Parametric actions now store a compact approximate suffix distribution
+and splice it through a separate parametric cache.
+
+This is still a benchmark feature, not production runtime behavior.
+
+## Approximation Used
+
+The first parametric family is the empirical depth-conditioned prior already used
+by the admission policy.  For each `L_max` bucket:
+
+1. estimate the depth-prior distribution from root-reaching parent-degree
+   signals;
+2. align it to the measured boundary histogram's `L_min`;
+3. scale it to the measured boundary path count; and
+4. store the resulting compact approximate suffix histogram as the parametric
+   boundary state.
+
+The scaling step uses measured boundary mass because this benchmark is isolating
+shape/storage effects first.  A later production-oriented pass should replace
+that with an estimated mass model.
+
+## Smoke Commands
+
+All runs used:
+
+```text
+--boundary-depths 2
+--target-depths 3
+--children-per-node 64
+--frontier-limit 600
+--boundaries-per-depth 24
+--targets-per-depth 8
+--boundary-budget 6
+--budgets 6,8
+--path-cap 50000
+--expansion-cap 100000
+--seed enwiki-mtc-parametric-boundary-v1
+```
+
+The compared modes were:
+
+```text
+--admission-policy baseline
+
+--admission-policy depth-prior
+--max-histogram-bytes 1024
+--parametric-bytes 64
+
+--admission-policy depth-prior
+--max-histogram-bytes 64
+--parametric-bytes 64
+```
+
+Outputs were written under:
+
+```text
+/mnt/c/Users/johnc/Scratch/parametric-boundary-cache
+```
+
+## Results
+
+All runs sampled the same shape:
+
+| role | child_depth | sampled_frontier_nodes |
+|------|-------------|------------------------|
+| boundary | 0 | 1 |
+| boundary | 1 | 35 |
+| boundary | 2 | 600 |
+| target | 0 | 1 |
+| target | 1 | 35 |
+| target | 2 | 600 |
+| target | 3 | 600 |
+
+Admission outcomes:
+
+| run | histogram_cached | parametric_cached | action |
+|-----|-----------------:|------------------:|--------|
+| baseline | 24 | 0 | `materialize_exact`: 24 |
+| depth-prior, 1024 bytes | 24 | 0 | `materialize_capped`: 24 |
+| depth-prior, 64 bytes | 0 | 24 | `use_parametric_prior`: 24 |
+
+Boundary build:
+
+| run | mean_hist_paths | mean_hist_bins | mean_parametric_bins | mean_nodes_expanded |
+|-----|----------------:|---------------:|---------------------:|--------------------:|
+| baseline | 17.000 | 4.167 | 0.000 | 15227.5 |
+| depth-prior, 1024 bytes | 17.000 | 4.167 | 0.000 | 15227.5 |
+| depth-prior, 64 bytes | 0.000 | 0.000 | 8.792 | 15227.5 |
+
+Search comparison:
+
+| run | budget | rows | mean_l1 | max_l1 | mean_cdf | mean_node_ratio | mean_hist_hits | mean_param_hits |
+|-----|-------:|-----:|--------:|-------:|---------:|----------------:|---------------:|----------------:|
+| baseline | 6 | 8 | 0.000000 | 0.000000 | 0.000000 | 0.997 | 6.500 | 0.000 |
+| baseline | 8 | 8 | 0.000000 | 0.000000 | 0.000000 | 1.000 | 8.500 | 0.000 |
+| depth-prior, 1024 bytes | 6 | 8 | 0.000000 | 0.000000 | 0.000000 | 0.997 | 6.500 | 0.000 |
+| depth-prior, 1024 bytes | 8 | 8 | 0.000000 | 0.000000 | 0.000000 | 1.000 | 8.500 | 0.000 |
+| depth-prior, 64 bytes | 6 | 8 | 0.027796 | 0.139037 | 0.009887 | 0.997 | 0.000 | 6.500 |
+| depth-prior, 64 bytes | 8 | 8 | 0.033983 | 0.259740 | 0.016613 | 1.000 | 0.000 | 8.500 |
+
+## Interpretation
+
+The permissive `1024` byte policy matches baseline behavior: all 24 boundaries
+enter as histogram states, and target search uses histogram hits only.
+
+The strict `64` byte policy now gets approximate boundary hits instead of falling
+back to uncached traversal.  It records 24 parametric boundary states, with mean
+parametric support around `8.8` bins.  The target searches see the same hit
+rates as the histogram-backed runs, but the hits are approximate and introduce
+small distribution error on this sample.
+
+The node expansion ratio remains near the histogram-backed runs because the
+parametric states are installed at the same boundary nodes.  The useful
+difference is now measurable accuracy versus representation choice:
+
+- exact/capped histograms: no observed error in this smoke;
+- parametric prior states: mean L1 around `0.028` to `0.034`, max L1 up to
+  `0.260`.
+
+This creates the benchmark surface needed for the next step: compare multiple
+parametric families and mass-estimation rules.
+
+## Validation
+
+```bash
+python3 -m unittest tests.test_lmdb_parent_boundary_cache_benchmark tests.test_lmdb_depth_planning_prior_probe tests.test_lmdb_parent_histogram_benchmark tests.test_lmdb_parent_branching_diagnostic
+python3 -m py_compile scripts/lmdb_parent_boundary_cache_benchmark.py tests/test_lmdb_parent_boundary_cache_benchmark.py
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --admission-policy baseline
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --admission-policy depth-prior --max-histogram-bytes 1024
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --admission-policy depth-prior --max-histogram-bytes 64
+```

--- a/scripts/lmdb_parent_boundary_cache_benchmark.py
+++ b/scripts/lmdb_parent_boundary_cache_benchmark.py
@@ -57,9 +57,31 @@ class CachedSearchStats:
     cycle_skips: int = 0
     budget_cutoffs: int = 0
     cache_hits: int = 0
+    histogram_cache_hits: int = 0
+    parametric_cache_hits: int = 0
     cache_bins_spliced: int = 0
+    histogram_bins_spliced: int = 0
+    parametric_bins_spliced: int = 0
     path_cap_hit: bool = False
     expansion_cap_hit: bool = False
+
+
+def scaled_distribution_histogram(probabilities, origin, total_count):
+    """Convert a compact probability vector into deterministic integer mass."""
+    if origin is None or total_count <= 0:
+        return {}
+    weighted = [(index, max(0.0, float(probability)) * int(total_count)) for index, probability in enumerate(probabilities)]
+    floors = {origin + index: int(value) for index, value in weighted if int(value) > 0}
+    remainder = int(total_count) - sum(floors.values())
+    if remainder > 0 and weighted:
+        ranked = sorted(
+            weighted,
+            key=lambda item: (item[1] - int(item[1]), item[1], -item[0]),
+            reverse=True,
+        )
+        for index, _value in ranked[:remainder]:
+            floors[origin + index] = floors.get(origin + index, 0) + 1
+    return dict(sorted((length, count) for length, count in floors.items() if count > 0))
 
 
 def add_shifted_hist(out, suffix_hist, prefix_depth, remaining):
@@ -71,7 +93,17 @@ def add_shifted_hist(out, suffix_hist, prefix_depth, remaining):
     return added
 
 
-def cached_parent_histogram(parents_func, target, root, budget, boundary_cache, path_cap=None, expansion_cap=None):
+def cached_parent_histogram(
+    parents_func,
+    target,
+    root,
+    budget,
+    boundary_cache,
+    path_cap=None,
+    expansion_cap=None,
+    parametric_boundary_cache=None,
+):
+    parametric_boundary_cache = parametric_boundary_cache or {}
     hist = Counter()
     stats = CachedSearchStats()
 
@@ -87,7 +119,19 @@ def cached_parent_histogram(parents_func, target, root, budget, boundary_cache, 
             return
         if node in boundary_cache:
             stats.cache_hits += 1
-            stats.cache_bins_spliced += add_shifted_hist(hist, boundary_cache[node], depth, remaining)
+            stats.histogram_cache_hits += 1
+            added = add_shifted_hist(hist, boundary_cache[node], depth, remaining)
+            stats.cache_bins_spliced += added
+            stats.histogram_bins_spliced += added
+            if path_cap is not None and sum(hist.values()) >= path_cap:
+                stats.path_cap_hit = True
+            return
+        if node in parametric_boundary_cache:
+            stats.cache_hits += 1
+            stats.parametric_cache_hits += 1
+            added = add_shifted_hist(hist, parametric_boundary_cache[node], depth, remaining)
+            stats.cache_bins_spliced += added
+            stats.parametric_bins_spliced += added
             if path_cap is not None and sum(hist.values()) >= path_cap:
                 stats.path_cap_hit = True
             return
@@ -145,6 +189,7 @@ def build_boundary_cache(
     max_parent_depth=24,
 ):
     cache = {}
+    parametric_cache = {}
     rows = []
     distance_memo = {}
     for node in boundary_nodes:
@@ -241,9 +286,25 @@ def build_boundary_cache(
         row["cache_admission_max_histogram_bytes"] = policy["max_histogram_bytes"]
         row["cache_admission_parametric_bytes"] = policy["parametric_bytes"]
         row["cached"] = cached
+        row["parametric_cached"] = False
+        row["parametric_histogram"] = {}
+        row["parametric_path_count"] = 0
+        row["parametric_support_bins"] = 0
         if cached:
             cache[row["node"]] = hist
-    return cache, rows
+        elif policy["action"] == "use_parametric_prior" and lmax in priors and hist:
+            approx_hist = scaled_distribution_histogram(
+                priors[lmax]["prior_distribution"],
+                row["histogram_L_min"],
+                row["path_count"],
+            )
+            if approx_hist:
+                parametric_cache[row["node"]] = approx_hist
+                row["parametric_cached"] = True
+                row["parametric_histogram"] = approx_hist
+                row["parametric_path_count"] = sum(approx_hist.values())
+                row["parametric_support_bins"] = len(approx_hist)
+    return cache, parametric_cache, rows
 
 
 def comparison_record(graph_name, root, target, child_depth, budget, full_hist, full_stats, full_time, cached_hist, cached_stats, cached_time):
@@ -276,7 +337,11 @@ def comparison_record(graph_name, root, target, child_depth, budget, full_hist, 
         "full_cycle_skips": full_stats.cycle_skips,
         "cached_cycle_skips": cached_stats.cycle_skips,
         "cache_hits": cached_stats.cache_hits,
+        "histogram_cache_hits": cached_stats.histogram_cache_hits,
+        "parametric_cache_hits": cached_stats.parametric_cache_hits,
         "cache_bins_spliced": cached_stats.cache_bins_spliced,
+        "histogram_bins_spliced": cached_stats.histogram_bins_spliced,
+        "parametric_bins_spliced": cached_stats.parametric_bins_spliced,
         "full_path_cap_hit": full_stats.path_cap_hit,
         "full_expansion_cap_hit": full_stats.expansion_cap_hit,
         "cached_path_cap_hit": cached_stats.path_cap_hit,
@@ -310,7 +375,7 @@ def run_benchmark(args):
             args.targets_per_depth,
             args.seed + ":target",
         )
-        cache, cache_rows = build_boundary_cache(
+        cache, parametric_cache, cache_rows = build_boundary_cache(
             graph,
             args.root,
             boundary_nodes,
@@ -332,6 +397,7 @@ def run_benchmark(args):
             "target_counts": target_counts,
             "boundary_nodes": len(boundary_nodes),
             "cached_boundary_nodes": len(cache),
+            "parametric_boundary_nodes": len(parametric_cache),
             "targets": len(targets),
             "budgets": budgets,
             "boundary_budget": args.boundary_budget,
@@ -362,6 +428,7 @@ def run_benchmark(args):
                     cache,
                     args.path_cap,
                     args.expansion_cap,
+                    parametric_cache,
                 )
                 cached_time = time.perf_counter_ns() - cached_started
                 records.append(
@@ -406,11 +473,12 @@ def summarize(records):
         lines.append("| target | {} | {} |".format(depth, count))
     lines.extend([
         "",
-        "| boundary_nodes | cached_boundary_nodes | targets | boundary_budget |",
-        "|----------------|-----------------------|---------|-----------------|",
-        "| {} | {} | {} | {} |".format(
+        "| boundary_nodes | cached_boundary_nodes | parametric_boundary_nodes | targets | boundary_budget |",
+        "|----------------|-----------------------|---------------------------|---------|-----------------|",
+        "| {} | {} | {} | {} | {} |".format(
             selection.get("boundary_nodes", 0),
             selection.get("cached_boundary_nodes", 0),
+            selection.get("parametric_boundary_nodes", 0),
             selection.get("targets", 0),
             selection.get("boundary_budget", 0),
         ),
@@ -428,18 +496,26 @@ def summarize(records):
         "",
         "## Boundary Admission Outcomes",
         "",
-        "| action | rows | cached |",
-        "|--------|-----:|-------:|",
+        "| action | rows | histogram_cached | parametric_cached |",
+        "|--------|-----:|-----------------:|------------------:|",
     ])
     action_counts = {}
     cached_by_action = {}
+    parametric_by_action = {}
     for row in cache_rows:
         action = row.get("cache_admission_action", "unknown")
         action_counts[action] = action_counts.get(action, 0) + 1
         if row.get("cached"):
             cached_by_action[action] = cached_by_action.get(action, 0) + 1
+        if row.get("parametric_cached"):
+            parametric_by_action[action] = parametric_by_action.get(action, 0) + 1
     for action in sorted(action_counts):
-        lines.append("| {} | {} | {} |".format(action, action_counts[action], cached_by_action.get(action, 0)))
+        lines.append("| {} | {} | {} | {} |".format(
+            action,
+            action_counts[action],
+            cached_by_action.get(action, 0),
+            parametric_by_action.get(action, 0),
+        ))
     lines.extend([
         "",
         "## Boundary Admission Reasons",
@@ -457,16 +533,19 @@ def summarize(records):
         "",
         "## Boundary Cache Build",
         "",
-        "| entries | cached | mean_paths | mean_bins | mean_nodes_expanded | capped_entries |",
-        "|---------|--------|------------|-----------|---------------------|----------------|",
+        "| entries | histogram_cached | parametric_cached | mean_hist_paths | mean_hist_bins | mean_parametric_bins | mean_nodes_expanded | capped_entries |",
+        "|---------|-----------------:|------------------:|----------------:|---------------:|---------------------:|--------------------:|---------------:|",
     ])
     cached_entries = [row for row in cache_rows if row.get("cached")]
+    parametric_entries = [row for row in cache_rows if row.get("parametric_cached")]
     lines.append(
-        "| {entries} | {cached} | {mean_paths:.3f} | {mean_bins:.3f} | {mean_expanded:.1f} | {capped} |".format(
+        "| {entries} | {cached} | {parametric} | {mean_paths:.3f} | {mean_bins:.3f} | {mean_parametric_bins:.3f} | {mean_expanded:.1f} | {capped} |".format(
             entries=len(cache_rows),
             cached=len(cached_entries),
+            parametric=len(parametric_entries),
             mean_paths=statistics.mean(int(row["path_count"]) for row in cached_entries) if cached_entries else 0.0,
             mean_bins=statistics.mean(int(row["support_bins"]) for row in cached_entries) if cached_entries else 0.0,
+            mean_parametric_bins=statistics.mean(int(row["parametric_support_bins"]) for row in parametric_entries) if parametric_entries else 0.0,
             mean_expanded=statistics.mean(int(row["nodes_expanded"]) for row in cache_rows) if cache_rows else 0.0,
             capped=sum(1 for row in cache_rows if row.get("path_cap_hit") or row.get("expansion_cap_hit")),
         )
@@ -475,8 +554,8 @@ def summarize(records):
         "",
         "## Full Search Versus Boundary Cache",
         "",
-        "| budget | rows | mean_l1 | p95_l1 | max_l1 | mean_cdf | mean_node_ratio | mean_cache_hits | full_capped | cached_capped |",
-        "|--------|------|---------|--------|--------|----------|-----------------|-----------------|-------------|---------------|",
+        "| budget | rows | mean_l1 | p95_l1 | max_l1 | mean_cdf | mean_node_ratio | mean_hist_hits | mean_param_hits | full_capped | cached_capped |",
+        "|--------|------|---------|--------|--------|----------|-----------------|---------------:|----------------:|-------------|---------------|",
     ])
     by_budget = {}
     for row in comparison_rows:
@@ -486,9 +565,10 @@ def summarize(records):
         l1 = [float(row["l1_error"]) for row in rows]
         cdf = [float(row["max_cdf_error"]) for row in rows]
         ratios = [float(row["node_expansion_ratio"]) for row in rows]
-        hits = [int(row["cache_hits"]) for row in rows]
+        histogram_hits = [int(row["histogram_cache_hits"]) for row in rows]
+        parametric_hits = [int(row["parametric_cache_hits"]) for row in rows]
         lines.append(
-            "| {budget} | {rows} | {mean_l1:.6f} | {p95_l1:.6f} | {max_l1:.6f} | {mean_cdf:.6f} | {mean_ratio:.3f} | {mean_hits:.3f} | {full_capped} | {cached_capped} |".format(
+            "| {budget} | {rows} | {mean_l1:.6f} | {p95_l1:.6f} | {max_l1:.6f} | {mean_cdf:.6f} | {mean_ratio:.3f} | {mean_hist_hits:.3f} | {mean_param_hits:.3f} | {full_capped} | {cached_capped} |".format(
                 budget=budget,
                 rows=len(rows),
                 mean_l1=statistics.mean(l1) if l1 else 0.0,
@@ -496,7 +576,8 @@ def summarize(records):
                 max_l1=max(l1, default=0.0),
                 mean_cdf=statistics.mean(cdf) if cdf else 0.0,
                 mean_ratio=statistics.mean(ratios) if ratios else 0.0,
-                mean_hits=statistics.mean(hits) if hits else 0.0,
+                mean_hist_hits=statistics.mean(histogram_hits) if histogram_hits else 0.0,
+                mean_param_hits=statistics.mean(parametric_hits) if parametric_hits else 0.0,
                 full_capped=sum(1 for row in rows if row.get("full_path_cap_hit") or row.get("full_expansion_cap_hit")),
                 cached_capped=sum(1 for row in rows if row.get("cached_path_cap_hit") or row.get("cached_expansion_cap_hit")),
             )

--- a/tests/test_lmdb_parent_boundary_cache_benchmark.py
+++ b/tests/test_lmdb_parent_boundary_cache_benchmark.py
@@ -9,6 +9,7 @@ from scripts.lmdb_parent_boundary_cache_benchmark import (
     build_boundary_cache,
     cached_parent_histogram,
     histogram_distribution_error,
+    scaled_distribution_histogram,
 )
 from scripts.lmdb_parent_histogram_benchmark import bounded_parent_histogram
 
@@ -60,16 +61,17 @@ class BoundaryCacheBenchmarkTests(unittest.TestCase):
     def test_baseline_boundary_cache_materializes_uncapped_histogram(self):
         graph = DictGraph({"A": ["R"]})
 
-        cache, rows = build_boundary_cache(graph, "R", ["A"], 1, None, None)
+        cache, parametric_cache, rows = build_boundary_cache(graph, "R", ["A"], 1, None, None)
 
         self.assertEqual(cache, {"A": {1: 1}})
+        self.assertEqual(parametric_cache, {})
         self.assertEqual(rows[0]["cache_admission_action"], "materialize_exact")
         self.assertEqual(rows[0]["cache_admission_reason"], "baseline_uncapped_histogram")
 
     def test_depth_prior_boundary_policy_materializes_within_budget(self):
         graph = DictGraph({"A": ["R"]})
 
-        cache, rows = build_boundary_cache(
+        cache, parametric_cache, rows = build_boundary_cache(
             graph,
             "R",
             ["A"],
@@ -84,13 +86,14 @@ class BoundaryCacheBenchmarkTests(unittest.TestCase):
         )
 
         self.assertEqual(cache, {"A": {1: 1}})
+        self.assertEqual(parametric_cache, {})
         self.assertEqual(rows[0]["cache_admission_action"], "materialize_exact")
         self.assertEqual(rows[0]["predicted_prior_bytes"], 16)
 
     def test_depth_prior_boundary_policy_records_parametric_without_cache_hit(self):
         graph = DictGraph({"A": ["R"]})
 
-        cache, rows = build_boundary_cache(
+        cache, parametric_cache, rows = build_boundary_cache(
             graph,
             "R",
             ["A"],
@@ -105,8 +108,37 @@ class BoundaryCacheBenchmarkTests(unittest.TestCase):
         )
 
         self.assertEqual(cache, {})
+        self.assertEqual(parametric_cache, {"A": {1: 1}})
         self.assertEqual(rows[0]["cache_admission_action"], "use_parametric_prior")
         self.assertFalse(rows[0]["cached"])
+        self.assertTrue(rows[0]["parametric_cached"])
+
+    def test_scaled_distribution_histogram_preserves_total_count(self):
+        hist = scaled_distribution_histogram([0.2, 0.3, 0.5], 4, 11)
+
+        self.assertEqual(sum(hist.values()), 11)
+        self.assertEqual(min(hist), 4)
+
+    def test_parametric_cache_hit_splices_approximate_histogram(self):
+        parents = {
+            "A": ["R"],
+            "B": ["A"],
+            "C": ["B"],
+        }
+
+        hist, stats = cached_parent_histogram(
+            lambda node: parents.get(node, []),
+            "C",
+            "R",
+            3,
+            {},
+            parametric_boundary_cache={"B": {2: 3}},
+        )
+
+        self.assertEqual(hist, {3: 3})
+        self.assertEqual(stats.cache_hits, 1)
+        self.assertEqual(stats.histogram_cache_hits, 0)
+        self.assertEqual(stats.parametric_cache_hits, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a parametric-boundary path to `scripts/lmdb_parent_boundary_cache_benchmark.py` so `use_parametric_prior` decisions now install approximate boundary states instead of only recording that exact histogram materialization was rejected.

The benchmark now tracks histogram-backed and parametric-backed cache hits separately, reports separate splice counts, and documents the enwiki MTC smoke comparison in `docs/reports/lmdb_parametric_boundary_cache_2026-06-12.md`.

## Notes

- Exact and capped histogram cache behavior remains unchanged.
- Parametric boundary states currently use the depth-conditioned prior shape aligned to the measured boundary `L_min` and scaled by measured boundary path mass.
- That scaling is intentionally benchmark-only: a production path still needs an estimated mass model rather than measured suffix mass.
- In the strict `64` byte smoke, all 24 boundary states became parametric, with mean L1 around `0.028` for budget 6 and `0.034` for budget 8.

## Validation

```bash
python3 -m unittest tests.test_lmdb_parent_boundary_cache_benchmark tests.test_lmdb_depth_planning_prior_probe tests.test_lmdb_parent_histogram_benchmark tests.test_lmdb_parent_branching_diagnostic
python3 -m py_compile scripts/lmdb_parent_boundary_cache_benchmark.py tests/test_lmdb_parent_boundary_cache_benchmark.py
git diff --check -- scripts/lmdb_parent_boundary_cache_benchmark.py tests/test_lmdb_parent_boundary_cache_benchmark.py docs/reports/lmdb_parametric_boundary_cache_2026-06-12.md
```

Smoke runs completed for baseline, depth-prior with `1024` byte histogram admission, and depth-prior with strict `64` byte parametric admission. Outputs are under `/mnt/c/Users/johnc/Scratch/parametric-boundary-cache`.

## Worktree note

An unrelated local edit remains unstaged in `templates/targets/fsharp_wam/kernel_bidirectional_ancestor.fs.mustache`.