### PR TITLE
WAM Clojure/Elixir: lowered numeric-literal interning + lowered ==/2 gap (sweep follow-ups)

### DIFF
--- a/docs/reports/wam_bindthrough_cross_target_sweep.md
+++ b/docs/reports/wam_bindthrough_cross_target_sweep.md
@@ -112,7 +112,11 @@ register class.
    controls (p_bindctl2 flipped false→true). Kotlin-finding-#2 family;
    needs its own campaign.
 7. **Clojure: numeric literals interned as atoms in the
-   opportunistically-lowered path** — default mode silently lowers
+   opportunistically-lowered path** — FIXED in the follow-up commit
+   (`clj_lowered_literal` now emits bare numeric tokens as numbers;
+   the WAM compiler quotes-and-marks atoms that merely look numeric,
+   so an unquoted numeral is a real number; all 12 previously
+   wrong-failing zero-arity probe wrappers verified correct) — default mode silently lowers
    eligible (incl. all zero-arity) predicates, and the lowered
    `put-constant` routes literals through `normalize-literal-atom`,
    which interns numerals as atoms; a subsequent `R is 1` compares
@@ -120,6 +124,13 @@ register class.
    correct. (`wam_clojure_target.pl:208-210`,
    `wam_clojure_lowered_emitter.pl:1284`,
    `runtime.clj.mustache:52-54`.)
-8. **Elixir lowered mode: `==/2` fails closed** — same class-7 gap
-   fixed for C and Haskell in this sweep; Rust-P3-style builtin parity
-   sweep applies.
+8. **Elixir lowered mode: `==/2` fails closed** — FIXED in the
+   follow-up commit (`==/2`/`\==/2` arms via `deep_copy_value`
+   structural comparison; the previously confounded probe battery now
+   passes in full). The broader Rust-P3-style builtin parity sweep
+   still applies to Elixir.
+9. **Elixir target suite: 6 pre-existing failures on main**
+   (unify/3 compound-clause check, LMDB e2e via :elmdb, three
+   atom-interning literal checks, cons-tag aliasing) — verified
+   identical on the unmodified parent tree; flag to the Elixir
+   stream.

--- a/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
+++ b/src/unifyweaver/targets/wam_clojure_lowered_emitter.pl
@@ -1329,9 +1329,28 @@ emit_lowered_expr(_Instr, S, Expr) :-
 clj_lowered_literal(Value, Literal) :-
     (   number(Value)
     ->  format(atom(Literal), '~w', [Value])
+    ;   clj_lowered_unquoted_number(Value, Num)
+    ->  % Bare numeric TOKEN from the WAM text. The compiler quotes
+        % atoms that merely look numeric (and marks them with the
+        % \x01 prefix), so an unquoted numeral is a real number.
+        % Previously this fell to the string branch and
+        % normalize-literal-term interned it as an ATOM, so the
+        % opportunistically-lowered path compared atom-"1" against
+        % integer 1 and wrong-failed (every zero-arity wrapper ending
+        % in `R is 1` — found by the bind-through probe sweep).
+        format(atom(Literal), '~w', [Num])
     ;   clj_lowered_atom_text(Value, Text),
         clj_lowered_string_literal(Text, Literal)
     ).
+
+clj_lowered_unquoted_number(Value, Num) :-
+    (   string(Value) -> S = Value
+    ;   atom(Value) -> atom_string(Value, S)
+    ;   fail
+    ),
+    \+ sub_string(S, 0, 1, _, "'"),
+    \+ string_codes(S, [1|_]),
+    catch(number_string(Num, S), _, fail).
 
 clj_lowered_atom_text(Value, Text) :-
     (   string(Value) -> S0 = Value ; atom_string(Value, S0) ),

--- a/src/unifyweaver/targets/wam_elixir_target.pl
+++ b/src/unifyweaver/targets/wam_elixir_target.pl
@@ -1138,6 +1138,30 @@ compile_utility_helpers_to_elixir(Code) :-
             new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
             %{state | pc: new_pc}
         end
+      {"==/2", 2} ->
+        # Strict equality. Previously missing -- the shared compiler
+        # emits builtin_call ==/2 and it failed closed (the class-7 gap
+        # found by the bind-through probe sweep; same fix as C and
+        # Haskell). deep_copy_value resolves both sides to
+        # self-contained terms through the heap and bindings; distinct
+        # unbound variables stay unequal, matching ISO ==/2.
+        v1 = deep_copy_value(state, get_reg(state, 1))
+        v2 = deep_copy_value(state, get_reg(state, 2))
+        if v1 == v2 do
+          new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+          %{state | pc: new_pc}
+        else
+          :fail
+        end
+      {"\\\\==/2", 2} ->
+        v1 = deep_copy_value(state, get_reg(state, 1))
+        v2 = deep_copy_value(state, get_reg(state, 2))
+        if v1 == v2 do
+          :fail
+        else
+          new_pc = if is_integer(state.pc), do: state.pc + 1, else: state.pc
+          %{state | pc: new_pc}
+        end
       {"fail/0", 0} ->
         # Explicit Prolog fail. The default-arm hardening below throws
         # {:unknown_builtin, ...} for un-handled ops; without an


### PR DESCRIPTION
## Summary

Two precisely-pinned side findings from the bind-through sweep report, both fixed and probe-verified:

### Clojure: numeric literals interned as atoms in the opportunistically-lowered path

`clj_lowered_literal` only recognized Prolog-number *values*, so bare numeric *tokens* from the WAM text fell to the string branch and `normalize-literal-term` interned them as atoms — the silently-lowered path (which includes all zero-arity predicates) then compared atom-`"1"` against integer `1` and wrong-failed anything ending in `R is 1`. The WAM compiler quotes-and-marks atoms that merely look numeric, so an unquoted numeral is provably a real number — now emitted as one. **Verified: all 12 previously wrong-failing zero-arity probe wrappers now produce correct R=1/R=0 results.**

### Elixir lowered mode: missing `==/2`/`\==/2`

Same class-7 fail-closed gap fixed for C and Haskell in #3056. New arms via `deep_copy_value` structural comparison (distinct unbound variables stay unequal, per ISO). **Verified: the previously confounded probe battery passes in full.**

The sweep report is updated (side findings 7 and 8 marked fixed; a new finding 9 records 6 pre-existing `test_wam_elixir_target` failures verified identical on the unmodified parent tree — flagged for the Elixir stream).

## Test plan

- [x] Clojure: 12/12 zero-arity probe wrappers correct (were 0/12); generator suite 15/15 (after installing `liblmdb-dev` for its pre-existing LMDB JNI tests); `lowered_emitter` 97/97; lowered `ite_exec` + `t4`
- [x] Elixir: lowered probe battery in full (incl. `==`-based probes); `elixir_lowered_ite`; the 6 failures in `test_wam_elixir_target` reproduced identically on the unmodified tree (pre-existing, documented)

https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMFtZtCH9eMqTn6FToPmM)_