### PR TITLE
refactor(plawk): share native streaming driver

### DIFF
--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -30,93 +30,28 @@ plawk_program_native_driver_ir(
     InputPath,
     DriverIR
 ) :-
-    atom_codes(InputPath, PathCodes),
-    length(PathCodes, PathLen),
-    BytesLen is PathLen + 1,
-    llvm_c_bytes(PathCodes, PathBytes),
     plawk_pattern_guard_ir(Pattern, GuardGlobalIR-GuardCallIR),
     plawk_print_action_ir(Fields, PrintActionIR),
-    format(atom(DriverIR),
-'@.plawk_surface_path = private constant [~w x i8] c"~w\\00"
-@.plawk_surface_eof = private constant [12 x i8] c"end_of_file\\00"
-@.plawk_surface_print_line = private constant [4 x i8] c"%s\\0A\\00"
-@.plawk_surface_print_slice = private constant [5 x i8] c"%.*s\\00"
-@.plawk_surface_print_space = private constant [2 x i8] c" \\00"
-@.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
-~w
-
-define i32 @main() {
-entry:
-  %path_ptr = getelementptr [~w x i8], [~w x i8]* @.plawk_surface_path, i32 0, i32 0
-  %path_id = call i64 @wam_intern_atom(i8* %path_ptr, i64 ~w)
-  %path0 = insertvalue %Value undef, i32 0, 0
-  %path = insertvalue %Value %path0, i64 %path_id, 1
-  %handle = call %Value @wam_stream_open_value(%Value %path)
-  %handle_tag = extractvalue %Value %handle, 0
-  %handle_is_int = icmp eq i32 %handle_tag, 1
-  br i1 %handle_is_int, label %check_handle_value, label %fail_open
-
-check_handle_value:
-  %handle_payload = extractvalue %Value %handle, 1
-  %handle_ok = icmp sgt i64 %handle_payload, 0
-  br i1 %handle_ok, label %loop, label %fail_open
-
-loop:
-  %line = call %Value @wam_stream_read_line_value(%Value %handle)
-  %line_tag = extractvalue %Value %line, 0
-  %line_payload = extractvalue %Value %line, 1
-  %line_is_int = icmp eq i32 %line_tag, 1
-  %line_bad_payload = icmp slt i64 %line_payload, 0
-  %line_bad = and i1 %line_is_int, %line_bad_payload
-  br i1 %line_bad, label %fail_read, label %check_line_atom
-
-check_line_atom:
-  %line_is_atom = icmp eq i32 %line_tag, 0
-  br i1 %line_is_atom, label %check_eof, label %fail_line_tag
-
-check_eof:
-  %line_s = call i8* @wam_atom_to_string(i64 %line_payload)
-  %eof_s = getelementptr [12 x i8], [12 x i8]* @.plawk_surface_eof, i32 0, i32 0
-  %eof_cmp = call i32 @strcmp(i8* %line_s, i8* %eof_s)
-  %is_eof = icmp eq i32 %eof_cmp, 0
-  br i1 %is_eof, label %close_stream, label %lowered_match
-
-lowered_match:
-~w
+    format(atom(RecordIR),
+'~w
   br i1 %is_match, label %print_line, label %continue_loop
 
 print_line:
 ~w
-  br label %continue_loop
-
-continue_loop:
-  br label %loop
-
-close_stream:
-  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
-  br i1 %close_ok, label %success, label %fail_close
-
-success:
-  ret i32 0
-
-fail_open:
-  ret i32 10
-
-fail_read:
-  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
-  ret i32 11
-
-fail_line_tag:
-  %close_ignore_line_tag = call i1 @wam_stream_close_value(%Value %handle)
-  ret i32 12
-
-fail_close:
-  ret i32 16
-}
+  br label %continue_loop',
+        [GuardCallIR, PrintActionIR]),
+    format(atom(RuntimeGlobals),
+'@.plawk_surface_print_line = private constant [4 x i8] c"%s\\0A\\00"
+@.plawk_surface_print_slice = private constant [5 x i8] c"%.*s\\00"
+@.plawk_surface_print_space = private constant [2 x i8] c" \\00"
+@.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
+~w
 ',
-        [BytesLen, PathBytes,
-         GuardGlobalIR,
-         BytesLen, BytesLen, PathLen, GuardCallIR, PrintActionIR]).
+        [GuardGlobalIR]),
+    plawk_stream_driver_ir(InputPath,
+        driver_blocks(RuntimeGlobals, '', lowered_match, RecordIR, '',
+            success, 'success:\n  ret i32 0'),
+        DriverIR).
 
 plawk_program_native_driver_ir(
     program([], Rules, [end([print(PrintFields)])]),
@@ -124,93 +59,20 @@ plawk_program_native_driver_ir(
     DriverIR
 ) :-
     plawk_scalar_state_slots(Rules, PrintFields, Slots),
-    atom_codes(InputPath, PathCodes),
-    length(PathCodes, PathLen),
-    BytesLen is PathLen + 1,
-    llvm_c_bytes(PathCodes, PathBytes),
     plawk_scalar_rule_chain_ir(Rules, Slots, RuleGlobalIR, RuleChainIR, RuleCount),
     plawk_scalar_loop_phi_ir(Slots, LoopPhiIR),
     plawk_scalar_next_phi_ir(Slots, RuleCount, NextPhiIR),
     plawk_scalar_end_print_ir(PrintFields, Slots, EndPrintIR),
-    format(atom(DriverIR),
-'@.plawk_surface_path = private constant [~w x i8] c"~w\\00"
-@.plawk_surface_eof = private constant [12 x i8] c"end_of_file\\00"
-@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"
-@.plawk_surface_print_space = private constant [2 x i8] c" \\00"
-@.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
+    plawk_i64_end_print_globals(RuleGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
 ~w
-
-define i32 @main() {
-entry:
-  %path_ptr = getelementptr [~w x i8], [~w x i8]* @.plawk_surface_path, i32 0, i32 0
-  %path_id = call i64 @wam_intern_atom(i8* %path_ptr, i64 ~w)
-  %path0 = insertvalue %Value undef, i32 0, 0
-  %path = insertvalue %Value %path0, i64 %path_id, 1
-  %handle = call %Value @wam_stream_open_value(%Value %path)
-  %handle_tag = extractvalue %Value %handle, 0
-  %handle_is_int = icmp eq i32 %handle_tag, 1
-  br i1 %handle_is_int, label %check_handle_value, label %fail_open
-
-check_handle_value:
-  %handle_payload = extractvalue %Value %handle, 1
-  %handle_ok = icmp sgt i64 %handle_payload, 0
-  br i1 %handle_ok, label %loop, label %fail_open
-
-loop:
-~w
-  %line = call %Value @wam_stream_read_line_value(%Value %handle)
-  %line_tag = extractvalue %Value %line, 0
-  %line_payload = extractvalue %Value %line, 1
-  %line_is_int = icmp eq i32 %line_tag, 1
-  %line_bad_payload = icmp slt i64 %line_payload, 0
-  %line_bad = and i1 %line_is_int, %line_bad_payload
-  br i1 %line_bad, label %fail_read, label %check_line_atom
-
-check_line_atom:
-  %line_is_atom = icmp eq i32 %line_tag, 0
-  br i1 %line_is_atom, label %check_eof, label %fail_line_tag
-
-check_eof:
-  %line_s = call i8* @wam_atom_to_string(i64 %line_payload)
-  %eof_s = getelementptr [12 x i8], [12 x i8]* @.plawk_surface_eof, i32 0, i32 0
-  %eof_cmp = call i32 @strcmp(i8* %line_s, i8* %eof_s)
-  %is_eof = icmp eq i32 %eof_cmp, 0
-  br i1 %is_eof, label %close_stream, label %lowered_match
-
-lowered_match:
-~w
-
-continue_loop:
-~w
-  br label %loop
-
-close_stream:
-  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
-  br i1 %close_ok, label %end_print, label %fail_close
-
-end_print:
-~w
-  ret i32 0
-
-fail_open:
-  ret i32 10
-
-fail_read:
-  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
-  ret i32 11
-
-fail_line_tag:
-  %close_ignore_line_tag = call i1 @wam_stream_close_value(%Value %handle)
-  ret i32 12
-
-fail_close:
-  ret i32 16
-}
-',
-        [BytesLen, PathBytes,
-         RuleGlobalIR,
-         BytesLen, BytesLen, PathLen, LoopPhiIR, RuleChainIR,
-         NextPhiIR, EndPrintIR]).
+  ret i32 0',
+        [EndPrintIR]),
+    plawk_stream_driver_ir(InputPath,
+        driver_blocks(RuntimeGlobals, LoopPhiIR, lowered_match, RuleChainIR,
+            NextPhiIR, end_print, CloseOkIR),
+        DriverIR).
 
 plawk_program_native_driver_ir(
     program([], Rules, [end([print(PrintFields)])]),
@@ -218,20 +80,47 @@ plawk_program_native_driver_ir(
     DriverIR
 ) :-
     plawk_assoc_static_count_spec(Rules, PrintFields, KeyIndex, PrintKeys, Slots),
-    atom_codes(InputPath, PathCodes),
-    length(PathCodes, PathLen),
-    BytesLen is PathLen + 1,
-    llvm_c_bytes(PathCodes, PathBytes),
     plawk_assoc_count_chain_ir(KeyIndex, Slots, AssocGlobalIR, AssocChainIR),
     plawk_scalar_loop_phi_ir(Slots, LoopPhiIR),
     plawk_assoc_next_phi_ir(Slots, NextPhiIR),
     plawk_assoc_end_print_ir(PrintKeys, Slots, EndPrintIR),
+    plawk_i64_end_print_globals(AssocGlobalIR, RuntimeGlobals),
+    format(atom(CloseOkIR),
+'end_print:
+~w
+  ret i32 0',
+        [EndPrintIR]),
+    plawk_stream_driver_ir(InputPath,
+        driver_blocks(RuntimeGlobals, LoopPhiIR, lowered_assoc, AssocChainIR,
+            NextPhiIR, end_print, CloseOkIR),
+        DriverIR).
+
+plawk_i64_end_print_globals(SurfaceGlobals, RuntimeGlobals) :-
+    format(atom(RuntimeGlobals),
+'@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"
+@.plawk_surface_print_space = private constant [2 x i8] c" \\00"
+@.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
+~w
+
+',
+        [SurfaceGlobals]).
+
+% Shared native streaming skeleton. Surface-specific lowerers provide globals,
+% loop-carried state phis, the per-record lowered block, continuation phis, and
+% the close-success block; file open/read/eof/close stays backend infrastructure.
+plawk_stream_driver_ir(
+    InputPath,
+    driver_blocks(RuntimeGlobals, LoopPhiIR, LoweredLabel, RecordIR,
+        ContinueIR, CloseOkLabel, CloseOkIR),
+    DriverIR
+) :-
+    atom_codes(InputPath, PathCodes),
+    length(PathCodes, PathLen),
+    BytesLen is PathLen + 1,
+    llvm_c_bytes(PathCodes, PathBytes),
     format(atom(DriverIR),
 '@.plawk_surface_path = private constant [~w x i8] c"~w\\00"
 @.plawk_surface_eof = private constant [12 x i8] c"end_of_file\\00"
-@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"
-@.plawk_surface_print_space = private constant [2 x i8] c" \\00"
-@.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
 ~w
 
 define i32 @main() {
@@ -269,9 +158,9 @@ check_eof:
   %eof_s = getelementptr [12 x i8], [12 x i8]* @.plawk_surface_eof, i32 0, i32 0
   %eof_cmp = call i32 @strcmp(i8* %line_s, i8* %eof_s)
   %is_eof = icmp eq i32 %eof_cmp, 0
-  br i1 %is_eof, label %close_stream, label %lowered_assoc
+  br i1 %is_eof, label %close_stream, label %~w
 
-lowered_assoc:
+~w:
 ~w
 
 continue_loop:
@@ -280,11 +169,9 @@ continue_loop:
 
 close_stream:
   %close_ok = call i1 @wam_stream_close_value(%Value %handle)
-  br i1 %close_ok, label %end_print, label %fail_close
+  br i1 %close_ok, label %~w, label %fail_close
 
-end_print:
 ~w
-  ret i32 0
 
 fail_open:
   ret i32 10
@@ -301,10 +188,9 @@ fail_close:
   ret i32 16
 }
 ',
-        [BytesLen, PathBytes,
-         AssocGlobalIR,
-         BytesLen, BytesLen, PathLen, LoopPhiIR, AssocChainIR,
-         NextPhiIR, EndPrintIR]).
+        [BytesLen, PathBytes, RuntimeGlobals,
+         BytesLen, BytesLen, PathLen, LoopPhiIR, LoweredLabel, LoweredLabel,
+         RecordIR, ContinueIR, CloseOkLabel, CloseOkIR]).
 
 llvm_c_bytes([], '').
 llvm_c_bytes([Code | Rest], Bytes) :-


### PR DESCRIPTION
# [codex] Share PLAWK native streaming driver

## Summary
- Extract the repeated PLAWK native file open/read/eof/close loop into one shared streaming-driver emitter
- Keep surface-specific lowering focused on globals, loop state phis, per-record logic, continuation phis, and close-success behavior
- Preserve existing scalar counter and static associative-count behavior

## Validation
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `git diff --cached --check`
- `git diff --check`