### PR TITLE
[codex] Clarify parent-count and path-length priors

### DIFF
--- a/docs/reports/lmdb_depth_planning_prior_calibration_2026-06-12.md
+++ b/docs/reports/lmdb_depth_planning_prior_calibration_2026-06-12.md
@@ -26,6 +26,25 @@ their own table.
 
 The default safety factor is `1.25`.
 
+The calibration uses three distinct statistical objects:
+
+- **parent-count distribution**: the distribution of root-reaching parent counts
+  for nodes in an `L_max` bucket;
+- **path-length distribution**: the node-local histogram of root-reaching parent
+  paths by finite length; and
+- **planning prior**: a depth-conditioned forecast of path-length support and
+  storage cost derived from parent-count statistics.
+
+This distinction matters for enwiki.  Gamma-like or heavier-tailed families may
+be useful for parent-count variation, because the size-biased branching signal
+`E[P^2]/E[P]` can be far above one.  The path-length histogram is a different
+object: it is built by repeated shifted mixtures of parent states, so
+finite-variance cases should drift toward binomial/normal-like behavior as more
+layers are composed.  Skew can persist for shallow depth, dependent parent cones,
+or heavy parent-count tails.  A binomial approximation is still useful in the
+small-`n` regime because it can represent skew, for example at `n=10` with
+small `p`.
+
 ## Smoke Command
 
 ```bash
@@ -99,8 +118,10 @@ gave mean storage ratios of `7.812`, `1.818`, and `4.027` for `L_max` buckets
 The binomial prior remained the cheapest storage predictor in these buckets, but
 its `p` parameter saturated at `1.0` everywhere.  That makes it useful as a
 compact planning proxy, not as evidence that a binomial family captures the
-underlying shape.  The Gamma prior tracked the empirical support more closely in
-the `L_max=24` bucket.
+measured path-length shape in this capped sample.  The Gamma prior tracked the
+empirical support more closely in the `L_max=24` bucket, but that should be read
+as a storage-width diagnostic, not as a claim that Gamma is the right
+path-length family.
 
 All comparable rows were marked `risky_try_capped_or_approx` because all rows
 were cycle-approximate, and five of the fourteen `L_max=24` rows still hit the

--- a/docs/reports/lmdb_parametric_boundary_cache_2026-06-12.md
+++ b/docs/reports/lmdb_parametric_boundary_cache_2026-06-12.md
@@ -9,8 +9,19 @@ This is still a benchmark feature, not production runtime behavior.
 
 ## Approximation Used
 
-The first parametric family is the empirical depth-conditioned prior already used
-by the admission policy.  For each `L_max` bucket:
+The first parametric boundary state uses the empirical depth-conditioned
+path-length prior already used by the admission policy.  This keeps three
+related but different distributions separate:
+
+- the **parent-count distribution** measures how many root-reaching parents a
+  node has;
+- the **path-length distribution** measures how many root-reaching parent paths
+  land in each finite length bin; and
+- the **planning prior** forecasts a path-length distribution from parent-count
+  statistics so the cache can decide whether exact histogram materialization is
+  worth attempting.
+
+For each `L_max` bucket:
 
 1. estimate the depth-prior distribution from root-reaching parent-degree
    signals;
@@ -22,6 +33,15 @@ by the admission policy.  For each `L_max` bucket:
 The scaling step uses measured boundary mass because this benchmark is isolating
 shape/storage effects first.  A later production-oriented pass should replace
 that with an estimated mass model.
+
+Gamma-like fits are plausible for the parent-count or branching variation
+itself, especially in enwiki where `E[P^2]/E[P]` can be several times larger
+than one.  They should not be treated as the default path-length histogram
+family.  The path-length histogram is produced by repeated shifted sums of
+parent states; when enough finite-variance layers mix, binomial or normal-like
+approximations become the natural first candidates.  A binomial approximation
+can still retain visible skew for small trial counts such as `n=10`, so it is
+not only a symmetric large-`n` approximation.
 
 ## Smoke Commands
 

--- a/docs/reports/parent_count_vs_path_length_priors_2026-06-12.md
+++ b/docs/reports/parent_count_vs_path_length_priors_2026-06-12.md
@@ -1,0 +1,115 @@
+# Parent-Count Priors Versus Path-Length Histograms
+
+This note fixes terminology for the parent-only histogram/cache work.  The next
+benchmark passes should keep three objects separate.
+
+## Parent-Count Distribution
+
+The parent-count distribution is over:
+
+```text
+P(v) = number of parents of node v
+```
+
+For root-conditioned planning, the more relevant variant is the number of
+parents that can still reach the chosen root.  Full parent count and
+root-reaching parent count should both be measured, because full count captures
+raw category branching while root-reaching count captures branching that can
+contribute to the current root cone.
+
+For enwiki, this distribution can be substantially wider than the SimpleWiki
+near-chain regime.  The size-biased signal:
+
+```text
+E[P^2] / E[P]
+```
+
+acts like a branching pressure seen by a path that arrives through an edge.  If
+it is close to one, exact sparse histograms may stay cheap deep into the tree.
+If it is around four, as in the stronger enwiki MTC measurements, exact
+histograms can widen much faster and the cache planner should expect more
+pressure.
+
+Gamma-like, lognormal, or heavy-tail fits belong primarily to this
+parent-count/branching object.  They describe variation in local branching, not
+directly the finite path-length histogram for a node.
+
+## Path-Length Distribution
+
+The path-length distribution is over:
+
+```text
+H_v[L] = number of root-reaching parent paths from v with length L
+```
+
+For parent-only recurrence without cycle complications, a child histogram is a
+shifted sum of parent histograms:
+
+```text
+H_v[L] = sum over parents p of H_p[L - 1]
+```
+
+A normalized version can be read as a probability distribution over path length,
+but the unnormalized histogram is usually the operational object because path
+mass matters for aggregate weights.
+
+This path-length distribution is not expected to have the same family as the
+parent-count distribution.  It is produced by repeated shifted sums/mixtures of
+parent states.  With enough finite-variance layers and weak dependence, the
+shape should drift toward binomial or normal-like behavior.  Skew remains
+important when:
+
+- depth is shallow;
+- parent cones are dependent or share many ancestors;
+- shortcuts and hubs dominate;
+- cycle handling removes paths unevenly; or
+- the parent-count tail is heavy enough to keep rare large effects visible.
+
+A binomial approximation is not only a symmetric large-depth approximation.  For
+small trial counts it can carry visible skew; for example, `n=10` with small
+`p` is clearly skewed.  As trial count grows and no rare tail dominates, the
+same family becomes closer to the usual normal approximation.
+
+## Planning Prior
+
+The planning prior is a forecast used to decide whether to compute, cache, or
+approximate a node-local path-length histogram.  It may be derived from
+parent-count statistics, but it is not itself a measured node histogram.
+
+The current depth-conditioned prior uses root-reaching parent-count signals to
+forecast path-length support and storage cost.  This is useful for admission
+decisions:
+
+- exact histogram if predicted and observed storage are cheap;
+- capped histogram when exact recurrence is risky but still useful;
+- parametric boundary state when a histogram is over budget; and
+- skip cache when even the approximate state is not worth the slot.
+
+The latest parametric boundary benchmark deliberately uses oracle mass: it
+aligns a prior shape to a measured `L_min` and scales it by the measured path
+count.  That isolates shape/storage behavior, but it is not a production mass
+model.  A production pass needs to estimate mass separately from shape.
+
+## Benchmark Implications
+
+Future flags and reports should avoid a single ambiguous `family` label.  Better
+names are:
+
+- `parent_count_family` for fits over parent counts or size-biased branching;
+- `path_length_family` for fits over node-local path histograms;
+- `planning_prior_family` for the depth-conditioned forecast used by admission;
+  and
+- `mass_model` for the total path-count estimate used to unnormalize a
+  probability distribution.
+
+The next useful benchmark split is therefore:
+
+```text
+path_length_family = empirical_prior | binomial | normal | histogram
+mass_model         = oracle | depth_prior | recurrence_estimate
+```
+
+Gamma should stay in the candidate set for parent-count or branching variation.
+It may still be used as a sampled continuous approximation when the empirical
+path-length histogram is wide, but it should not be the default claim for
+enwiki path-length histograms unless the measured path-length errors support it.

--- a/scripts/distribution_fit_comparison.py
+++ b/scripts/distribution_fit_comparison.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # Copyright (c) 2026 John William Creighton (s243a)
-"""Compare exact histograms with realized fits and depth-conditioned priors."""
+"""Compare path-length histograms with fits and depth-conditioned priors."""
 
 from __future__ import annotations
 

--- a/scripts/lmdb_depth_planning_prior_probe.py
+++ b/scripts/lmdb_depth_planning_prior_probe.py
@@ -7,6 +7,12 @@ The planning prior is a global or bucketed estimate.  It is not a boundary
 condition for a concrete node.  This probe checks whether the prior predicts the
 shape and storage cost of node-local recurrence histograms well enough to guide
 materialization decisions.
+
+Terminology used here:
+
+- parent-count distribution: counts root-reaching parents per node;
+- path-length distribution: counts root-reaching parent paths by finite length;
+- planning prior: a depth-conditioned forecast used for storage/admission.
 """
 
 from __future__ import annotations
@@ -81,7 +87,7 @@ def gamma_parameters(mean_value, variance):
 
 
 def planning_prior_for_bucket(parent_degrees, depth, tail_epsilon):
-    """Build a depth-conditioned prior from root-reaching parent degrees."""
+    """Build a depth-conditioned path-length prior from parent-count signals."""
     depth = max(0, int(depth))
     base = size_biased_excess_pmf(parent_degrees)
     prior = nfold_convolution(base, depth)

--- a/tests/test_distribution_fit_comparison.py
+++ b/tests/test_distribution_fit_comparison.py
@@ -68,6 +68,8 @@ class DistributionFitComparisonTests(unittest.TestCase):
             parent_degrees=[1, 1, 2],
             depths=[2],
             tail_epsilon=0.001,
+            continuous_sample_points=32,
+            prune_thresholds=[0.001],
         )
         models = {record["model"] for record in records}
         roles = {record["distribution_role"] for record in records}


### PR DESCRIPTION
## Summary

Clarifies the statistical framing for the parent-only histogram/cache work by separating three objects:

- parent-count distributions over root-reaching parent counts;
- path-length histograms over finite root-reaching parent paths; and
- depth-conditioned planning priors used for cache admission and storage forecasting.

Adds a standalone theory note at `docs/reports/parent_count_vs_path_length_priors_2026-06-12.md`, updates the recent depth-prior and parametric-boundary reports, and tightens script docstrings so future benchmark flags do not conflate parent-count families with path-length families.

## Notes

- Gamma-like or heavier-tailed fits are framed as candidates for parent-count / branching variation.
- Binomial or normal-like approximations are framed as natural path-length candidates after repeated shifted mixtures, with the caveat that binomial can still capture visible skew at small `n`.
- The current parametric boundary benchmark is explicitly described as using oracle mass to isolate shape/storage behavior.
- Also fixes a stale unit-test call to `depth_prior_records()` after its signature gained sampling/pruning arguments.

## Validation

```bash
python3 -m unittest tests.test_lmdb_depth_planning_prior_probe tests.test_distribution_fit_comparison
python3 -m py_compile scripts/lmdb_depth_planning_prior_probe.py scripts/distribution_fit_comparison.py tests/test_distribution_fit_comparison.py
git diff --check -- docs/reports/parent_count_vs_path_length_priors_2026-06-12.md docs/reports/lmdb_parametric_boundary_cache_2026-06-12.md docs/reports/lmdb_depth_planning_prior_calibration_2026-06-12.md scripts/lmdb_depth_planning_prior_probe.py scripts/distribution_fit_comparison.py tests/test_distribution_fit_comparison.py
```

## Worktree note

An unrelated local edit remains unstaged in `templates/targets/fsharp_wam/kernel_bidirectional_ancestor.fs.mustache`.