### PR TITLE
[codex] Add parametric boundary mass models

### DIFF
--- a/docs/reports/lmdb_parametric_boundary_mass_models_2026-06-12.md
+++ b/docs/reports/lmdb_parametric_boundary_mass_models_2026-06-12.md
@@ -1,0 +1,133 @@
+# LMDB Parametric Boundary Mass Models
+
+This pass separates parametric boundary-state shape from path-count mass.  The
+previous benchmark always used oracle mass: it aligned the empirical
+depth-conditioned prior shape to a boundary node and scaled it by that node's
+measured path count.  That is useful for isolating shape/storage behavior, but a
+production cache needs an estimated mass model.
+
+## Script Changes
+
+`scripts/lmdb_parent_boundary_cache_benchmark.py` now accepts:
+
+```text
+--parametric-mass-model oracle|unit|depth-prior
+--parametric-mass-cap
+```
+
+The modes are:
+
+- `oracle`: current behavior, using measured boundary `path_count`;
+- `unit`: normalized lower baseline with total mass `1`; and
+- `depth-prior`: non-oracle branching-pressure estimate
+  `(1 + base_mean_excess) ^ L_max`, capped by `--parametric-mass-cap`.
+
+Boundary rows now record:
+
+- `parametric_oracle_path_count`;
+- `parametric_path_count`;
+- `parametric_mass_delta`;
+- `parametric_mass_ratio`; and
+- whether the mass estimate was capped.
+
+Comparison rows now also report unnormalized path-count error:
+
+- `abs_path_count_delta`;
+- `path_count_relative_error`; and
+- histogram versus parametric bins actually spliced.
+
+## Smoke Commands
+
+All d1 comparison runs used:
+
+```bash
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py \
+  --lmdb-dir /home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct/lmdb_resident \
+  --root 7345184 \
+  --boundary-depths 1 \
+  --target-depths 3 \
+  --children-per-node 64 \
+  --frontier-limit 600 \
+  --boundaries-per-depth 24 \
+  --targets-per-depth 8 \
+  --boundary-budget 6 \
+  --budgets 6,8 \
+  --path-cap 50000 \
+  --expansion-cap 100000 \
+  --seed enwiki-mtc-parametric-boundary-v1 \
+  --admission-policy depth-prior \
+  --safety-factor 1.25 \
+  --max-histogram-bytes 64 \
+  --parametric-bytes 64 \
+  --parametric-mass-cap 100000 \
+  --tail-epsilon 0.001 \
+  --max-parent-depth 24 \
+  --output-dir /mnt/c/Users/johnc/Scratch/parametric-boundary-mass-models
+```
+
+The three runs changed only:
+
+```text
+--graph-name enwiki_mtc_parametric_mass_oracle_d1_smoke --parametric-mass-model oracle
+--graph-name enwiki_mtc_parametric_mass_unit_d1_smoke --parametric-mass-model unit
+--graph-name enwiki_mtc_parametric_mass_depth_prior_d1_smoke --parametric-mass-model depth-prior
+```
+
+## Results
+
+All three runs selected the same nodes:
+
+| boundary_nodes | histogram_cached | parametric_cached | targets | boundary_budget |
+|---------------:|-----------------:|------------------:|--------:|----------------:|
+| 24 | 6 | 18 | 8 | 6 |
+
+Boundary-state mass differed sharply:
+
+| mass_model | mean_parametric_paths | mean_parametric_mass_ratio | mean_parametric_bins |
+|------------|----------------------:|----------------------------:|---------------------:|
+| oracle | 8.000 | 1.000 | 5.722 |
+| unit | 1.000 | 0.190 | 1.000 |
+| depth-prior | 609.833 | 100.812 | 13.167 |
+
+Target-search comparison was identical across these three mass models:
+
+| budget | mean_l1 | mean_cdf | mean_path_count_relative_error | mean_abs_path_delta | mean_hist_hits | mean_param_hits | mean_hist_bins_spliced | mean_param_bins_spliced |
+|-------:|--------:|---------:|-------------------------------:|--------------------:|---------------:|----------------:|-----------------------:|------------------------:|
+| 6 | 1.139211 | 0.694605 | 0.562386 | 12.250 | 4.000 | 17.625 | 1.500 | 0.000 |
+| 8 | 1.070372 | 0.535117 | 0.293339 | 16.125 | 9.500 | 35.125 | 3.000 | 0.000 |
+
+The equal target-search rows are not evidence that mass does not matter.  They
+show that the current empirical depth-prior shape has a support-placement
+problem for boundary splicing: target search reaches parametric boundary nodes,
+but no parametric bins are actually spliced because the approximate suffix bins
+are outside the remaining path budget.  In the d1 smoke, `mean_param_hits` is
+large while `mean_param_bins_spliced` is exactly zero.
+
+## Interpretation
+
+The benchmark now separates boundary-state mass from shape and exposes mass
+diagnostics in the JSONL and markdown summaries.  On this enwiki MTC smoke:
+
+- `oracle` remains the shape-isolation control;
+- `unit` gives a normalized lower mass baseline;
+- `depth-prior` strongly overestimates boundary mass from branching pressure;
+  and
+- downstream target error is currently dominated by support placement, not mass.
+
+The next fix should address the path-length support model before treating
+target-level mass-model comparisons as meaningful.  Two likely options are:
+
+- condition the empirical prior on the measured or estimated support interval
+  `(L_min, L_max)` before scaling; or
+- add a path-length family such as binomial over the known support, then compare
+  `oracle`, `unit`, and `depth-prior` mass again.
+
+## Validation
+
+```bash
+python3 -m unittest tests.test_lmdb_parent_boundary_cache_benchmark tests.test_lmdb_depth_planning_prior_probe tests.test_lmdb_parent_histogram_benchmark tests.test_lmdb_parent_branching_diagnostic
+python3 -m py_compile scripts/lmdb_parent_boundary_cache_benchmark.py tests/test_lmdb_parent_boundary_cache_benchmark.py
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --parametric-mass-model oracle
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --parametric-mass-model unit
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --parametric-mass-model depth-prior
+```

--- a/scripts/lmdb_parent_boundary_cache_benchmark.py
+++ b/scripts/lmdb_parent_boundary_cache_benchmark.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import statistics
 import sys
 import time
@@ -82,6 +83,48 @@ def scaled_distribution_histogram(probabilities, origin, total_count):
         for index, _value in ranked[:remainder]:
             floors[origin + index] = floors.get(origin + index, 0) + 1
     return dict(sorted((length, count) for length, count in floors.items() if count > 0))
+
+
+def estimate_parametric_total_count(row, prior, mass_model, mass_cap=None):
+    """Estimate unnormalized mass for a parametric boundary histogram."""
+    oracle_count = int(row.get("path_count", 0))
+    mass_cap = None if mass_cap is None or int(mass_cap) <= 0 else int(mass_cap)
+    capped = False
+
+    if mass_model == "oracle":
+        estimated = oracle_count
+    elif mass_model == "unit":
+        estimated = 1 if oracle_count > 0 else 0
+    elif mass_model == "depth-prior":
+        lmax = row.get("histogram_L_max")
+        depth = 0 if lmax is None else max(0, int(lmax))
+        branching_pressure = max(0.0, 1.0 + float(prior.get("base_mean_excess", 0.0)))
+        if oracle_count <= 0:
+            estimated = 0
+        elif branching_pressure <= 1.0 or depth == 0:
+            estimated = 1
+        else:
+            log_estimate = depth * math.log(branching_pressure)
+            if mass_cap is not None and log_estimate >= math.log(mass_cap):
+                estimated = mass_cap
+                capped = True
+            else:
+                estimated = max(1, int(round(math.exp(log_estimate))))
+    else:
+        raise ValueError("unknown parametric mass model: {}".format(mass_model))
+
+    if mass_cap is not None and estimated > mass_cap:
+        estimated = mass_cap
+        capped = True
+
+    return {
+        "mass_model": mass_model,
+        "estimated_path_count": estimated,
+        "oracle_path_count": oracle_count,
+        "mass_delta": estimated - oracle_count,
+        "mass_ratio": None if oracle_count <= 0 else estimated / oracle_count,
+        "mass_capped": capped,
+    }
 
 
 def add_shifted_hist(out, suffix_hist, prefix_depth, remaining):
@@ -185,6 +228,8 @@ def build_boundary_cache(
     safety_factor=1.25,
     max_histogram_bytes=1024,
     parametric_bytes=64,
+    parametric_mass_model="oracle",
+    parametric_mass_cap=1000000,
     tail_epsilon=0.001,
     max_parent_depth=24,
 ):
@@ -289,20 +334,35 @@ def build_boundary_cache(
         row["parametric_cached"] = False
         row["parametric_histogram"] = {}
         row["parametric_path_count"] = 0
+        row["parametric_oracle_path_count"] = row["path_count"]
+        row["parametric_mass_model"] = parametric_mass_model
+        row["parametric_mass_delta"] = None
+        row["parametric_mass_ratio"] = None
+        row["parametric_mass_capped"] = False
         row["parametric_support_bins"] = 0
         if cached:
             cache[row["node"]] = hist
         elif policy["action"] == "use_parametric_prior" and lmax in priors and hist:
+            mass_estimate = estimate_parametric_total_count(
+                row,
+                priors[lmax],
+                parametric_mass_model,
+                parametric_mass_cap,
+            )
             approx_hist = scaled_distribution_histogram(
                 priors[lmax]["prior_distribution"],
                 row["histogram_L_min"],
-                row["path_count"],
+                mass_estimate["estimated_path_count"],
             )
             if approx_hist:
                 parametric_cache[row["node"]] = approx_hist
                 row["parametric_cached"] = True
                 row["parametric_histogram"] = approx_hist
                 row["parametric_path_count"] = sum(approx_hist.values())
+                row["parametric_oracle_path_count"] = mass_estimate["oracle_path_count"]
+                row["parametric_mass_delta"] = mass_estimate["mass_delta"]
+                row["parametric_mass_ratio"] = mass_estimate["mass_ratio"]
+                row["parametric_mass_capped"] = mass_estimate["mass_capped"]
                 row["parametric_support_bins"] = len(approx_hist)
     return cache, parametric_cache, rows
 
@@ -323,6 +383,8 @@ def comparison_record(graph_name, root, target, child_depth, budget, full_hist, 
         "full_path_count": full_paths,
         "cached_path_count": cached_paths,
         "path_count_delta": cached_paths - full_paths,
+        "abs_path_count_delta": abs(cached_paths - full_paths),
+        "path_count_relative_error": 0.0 if full_paths == 0 else abs(cached_paths - full_paths) / full_paths,
         "full_L_min": min(full_hist) if full_hist else None,
         "cached_L_min": min(cached_hist) if cached_hist else None,
         "full_L_max": max(full_hist) if full_hist else None,
@@ -386,6 +448,8 @@ def run_benchmark(args):
             args.safety_factor,
             args.max_histogram_bytes,
             args.parametric_bytes,
+            args.parametric_mass_model,
+            args.parametric_mass_cap,
             args.tail_epsilon,
             args.max_parent_depth,
         )
@@ -405,6 +469,8 @@ def run_benchmark(args):
             "safety_factor": args.safety_factor,
             "max_histogram_bytes": args.max_histogram_bytes,
             "parametric_bytes": args.parametric_bytes,
+            "parametric_mass_model": args.parametric_mass_model,
+            "parametric_mass_cap": args.parametric_mass_cap,
         }]
         records.extend(cache_rows)
         for target in targets:
@@ -485,13 +551,15 @@ def summarize(records):
         "",
         "## Admission Policy",
         "",
-        "| policy | safety_factor | max_histogram_bytes | parametric_bytes |",
-        "|--------|--------------:|--------------------:|-----------------:|",
-        "| {} | {} | {} | {} |".format(
+        "| policy | safety_factor | max_histogram_bytes | parametric_bytes | parametric_mass_model | parametric_mass_cap |",
+        "|--------|--------------:|--------------------:|-----------------:|-----------------------|--------------------:|",
+        "| {} | {} | {} | {} | {} | {} |".format(
             selection.get("admission_policy", "baseline"),
             selection.get("safety_factor", "n/a"),
             selection.get("max_histogram_bytes", "n/a"),
             selection.get("parametric_bytes", "n/a"),
+            selection.get("parametric_mass_model", "oracle"),
+            selection.get("parametric_mass_cap", "n/a"),
         ),
         "",
         "## Boundary Admission Outcomes",
@@ -533,18 +601,20 @@ def summarize(records):
         "",
         "## Boundary Cache Build",
         "",
-        "| entries | histogram_cached | parametric_cached | mean_hist_paths | mean_hist_bins | mean_parametric_bins | mean_nodes_expanded | capped_entries |",
-        "|---------|-----------------:|------------------:|----------------:|---------------:|---------------------:|--------------------:|---------------:|",
+        "| entries | histogram_cached | parametric_cached | mean_hist_paths | mean_hist_bins | mean_parametric_paths | mean_parametric_mass_ratio | mean_parametric_bins | mean_nodes_expanded | capped_entries |",
+        "|---------|-----------------:|------------------:|----------------:|---------------:|----------------------:|----------------------------:|---------------------:|--------------------:|---------------:|",
     ])
     cached_entries = [row for row in cache_rows if row.get("cached")]
     parametric_entries = [row for row in cache_rows if row.get("parametric_cached")]
     lines.append(
-        "| {entries} | {cached} | {parametric} | {mean_paths:.3f} | {mean_bins:.3f} | {mean_parametric_bins:.3f} | {mean_expanded:.1f} | {capped} |".format(
+        "| {entries} | {cached} | {parametric} | {mean_paths:.3f} | {mean_bins:.3f} | {mean_parametric_paths:.3f} | {mean_parametric_mass_ratio:.3f} | {mean_parametric_bins:.3f} | {mean_expanded:.1f} | {capped} |".format(
             entries=len(cache_rows),
             cached=len(cached_entries),
             parametric=len(parametric_entries),
             mean_paths=statistics.mean(int(row["path_count"]) for row in cached_entries) if cached_entries else 0.0,
             mean_bins=statistics.mean(int(row["support_bins"]) for row in cached_entries) if cached_entries else 0.0,
+            mean_parametric_paths=statistics.mean(int(row["parametric_path_count"]) for row in parametric_entries) if parametric_entries else 0.0,
+            mean_parametric_mass_ratio=statistics.mean(float(row["parametric_mass_ratio"]) for row in parametric_entries if row.get("parametric_mass_ratio") is not None) if any(row.get("parametric_mass_ratio") is not None for row in parametric_entries) else 0.0,
             mean_parametric_bins=statistics.mean(int(row["parametric_support_bins"]) for row in parametric_entries) if parametric_entries else 0.0,
             mean_expanded=statistics.mean(int(row["nodes_expanded"]) for row in cache_rows) if cache_rows else 0.0,
             capped=sum(1 for row in cache_rows if row.get("path_cap_hit") or row.get("expansion_cap_hit")),
@@ -554,8 +624,8 @@ def summarize(records):
         "",
         "## Full Search Versus Boundary Cache",
         "",
-        "| budget | rows | mean_l1 | p95_l1 | max_l1 | mean_cdf | mean_node_ratio | mean_hist_hits | mean_param_hits | full_capped | cached_capped |",
-        "|--------|------|---------|--------|--------|----------|-----------------|---------------:|----------------:|-------------|---------------|",
+        "| budget | rows | mean_l1 | p95_l1 | max_l1 | mean_cdf | mean_path_count_relative_error | mean_abs_path_delta | mean_node_ratio | mean_hist_hits | mean_param_hits | mean_hist_bins_spliced | mean_param_bins_spliced | full_capped | cached_capped |",
+        "|--------|------|---------|--------|--------|----------|-------------------------------:|--------------------:|-----------------|---------------:|----------------:|-----------------------:|------------------------:|-------------|---------------|",
     ])
     by_budget = {}
     for row in comparison_rows:
@@ -564,20 +634,28 @@ def summarize(records):
         rows = by_budget[budget]
         l1 = [float(row["l1_error"]) for row in rows]
         cdf = [float(row["max_cdf_error"]) for row in rows]
+        path_relative = [float(row["path_count_relative_error"]) for row in rows]
+        path_delta = [int(row["abs_path_count_delta"]) for row in rows]
         ratios = [float(row["node_expansion_ratio"]) for row in rows]
         histogram_hits = [int(row["histogram_cache_hits"]) for row in rows]
         parametric_hits = [int(row["parametric_cache_hits"]) for row in rows]
+        histogram_bins_spliced = [int(row["histogram_bins_spliced"]) for row in rows]
+        parametric_bins_spliced = [int(row["parametric_bins_spliced"]) for row in rows]
         lines.append(
-            "| {budget} | {rows} | {mean_l1:.6f} | {p95_l1:.6f} | {max_l1:.6f} | {mean_cdf:.6f} | {mean_ratio:.3f} | {mean_hist_hits:.3f} | {mean_param_hits:.3f} | {full_capped} | {cached_capped} |".format(
+            "| {budget} | {rows} | {mean_l1:.6f} | {p95_l1:.6f} | {max_l1:.6f} | {mean_cdf:.6f} | {mean_path_relative:.6f} | {mean_path_delta:.3f} | {mean_ratio:.3f} | {mean_hist_hits:.3f} | {mean_param_hits:.3f} | {mean_hist_bins:.3f} | {mean_param_bins:.3f} | {full_capped} | {cached_capped} |".format(
                 budget=budget,
                 rows=len(rows),
                 mean_l1=statistics.mean(l1) if l1 else 0.0,
                 p95_l1=percentile(l1, 95),
                 max_l1=max(l1, default=0.0),
                 mean_cdf=statistics.mean(cdf) if cdf else 0.0,
+                mean_path_relative=statistics.mean(path_relative) if path_relative else 0.0,
+                mean_path_delta=statistics.mean(path_delta) if path_delta else 0.0,
                 mean_ratio=statistics.mean(ratios) if ratios else 0.0,
                 mean_hist_hits=statistics.mean(histogram_hits) if histogram_hits else 0.0,
                 mean_param_hits=statistics.mean(parametric_hits) if parametric_hits else 0.0,
+                mean_hist_bins=statistics.mean(histogram_bins_spliced) if histogram_bins_spliced else 0.0,
+                mean_param_bins=statistics.mean(parametric_bins_spliced) if parametric_bins_spliced else 0.0,
                 full_capped=sum(1 for row in rows if row.get("full_path_cap_hit") or row.get("full_expansion_cap_hit")),
                 cached_capped=sum(1 for row in rows if row.get("cached_path_cap_hit") or row.get("cached_expansion_cap_hit")),
             )
@@ -623,6 +701,8 @@ def main(argv=None):
     parser.add_argument("--safety-factor", type=float, default=1.25, help="Multiplier for depth-prior predicted histogram bytes.")
     parser.add_argument("--max-histogram-bytes", type=int, default=1024, help="Maximum bytes allowed for exact or capped boundary histograms under depth-prior admission.")
     parser.add_argument("--parametric-bytes", type=int, default=64, help="Estimated bytes for a parametric prior state.")
+    parser.add_argument("--parametric-mass-model", choices=["oracle", "unit", "depth-prior"], default="oracle", help="Mass used to unnormalize parametric boundary states.")
+    parser.add_argument("--parametric-mass-cap", type=int, default=1000000, help="Maximum estimated path mass for non-oracle parametric states; non-positive disables the cap.")
     parser.add_argument("--tail-epsilon", type=float, default=0.001, help="Tail epsilon used when estimating depth-prior effective support.")
     parser.add_argument("--max-parent-depth", type=int, default=24, help="Parent depth cap for root-reaching parent degree signals.")
     parser.add_argument("--path-cap", type=int, default=100000, help="Stop a row after this many root paths.")

--- a/tests/test_lmdb_parent_boundary_cache_benchmark.py
+++ b/tests/test_lmdb_parent_boundary_cache_benchmark.py
@@ -8,6 +8,7 @@ import unittest
 from scripts.lmdb_parent_boundary_cache_benchmark import (
     build_boundary_cache,
     cached_parent_histogram,
+    estimate_parametric_total_count,
     histogram_distribution_error,
     scaled_distribution_histogram,
 )
@@ -112,6 +113,43 @@ class BoundaryCacheBenchmarkTests(unittest.TestCase):
         self.assertEqual(rows[0]["cache_admission_action"], "use_parametric_prior")
         self.assertFalse(rows[0]["cached"])
         self.assertTrue(rows[0]["parametric_cached"])
+
+    def test_parametric_unit_mass_model_records_mass_error(self):
+        graph = DictGraph({"A": ["R"], "B": ["A", "R"]})
+
+        cache, parametric_cache, rows = build_boundary_cache(
+            graph,
+            "R",
+            ["B"],
+            2,
+            None,
+            None,
+            admission_policy="depth-prior",
+            safety_factor=2.0,
+            max_histogram_bytes=24,
+            parametric_bytes=8,
+            parametric_mass_model="unit",
+            max_parent_depth=4,
+        )
+
+        self.assertEqual(cache, {})
+        self.assertEqual(sum(parametric_cache["B"].values()), 1)
+        self.assertEqual(rows[0]["path_count"], 2)
+        self.assertEqual(rows[0]["parametric_path_count"], 1)
+        self.assertEqual(rows[0]["parametric_mass_model"], "unit")
+        self.assertEqual(rows[0]["parametric_mass_delta"], -1)
+        self.assertAlmostEqual(rows[0]["parametric_mass_ratio"], 0.5)
+
+    def test_depth_prior_mass_model_caps_branching_pressure(self):
+        estimate = estimate_parametric_total_count(
+            {"path_count": 2, "histogram_L_max": 5},
+            {"base_mean_excess": 3.0},
+            "depth-prior",
+            mass_cap=10,
+        )
+
+        self.assertEqual(estimate["estimated_path_count"], 10)
+        self.assertTrue(estimate["mass_capped"])
 
     def test_scaled_distribution_histogram_preserves_total_count(self):
         hist = scaled_distribution_histogram([0.2, 0.3, 0.5], 4, 11)


### PR DESCRIPTION
## Summary

Adds explicit mass-model support to the LMDB parent boundary-cache benchmark so parametric boundary states no longer have to use only oracle path mass.

New CLI options:

```text
--parametric-mass-model oracle|unit|depth-prior
--parametric-mass-cap
```

The benchmark now records boundary-level mass diagnostics (`parametric_oracle_path_count`, `parametric_path_count`, mass delta/ratio/cap) and target-level unnormalized path-count error (`abs_path_count_delta`, `path_count_relative_error`). It also reports histogram and parametric bins actually spliced, separately from hit counts.

## Key result

The d1 enwiki MTC smoke shows mass models are wired in and differ sharply at the boundary-state level:

| mass_model | mean_parametric_paths | mean_parametric_mass_ratio | mean_parametric_bins |
|------------|----------------------:|----------------------------:|---------------------:|
| oracle | 8.000 | 1.000 | 5.722 |
| unit | 1.000 | 0.190 | 1.000 |
| depth-prior | 609.833 | 100.812 | 13.167 |

However, target-level rows are identical across mass models in this smoke because parametric hits have `mean_param_bins_spliced = 0.000`. The current empirical depth-prior support is shifted outside the remaining path budget, so the next benchmark fix should address path-length support placement before treating downstream mass-model comparisons as meaningful.

## Validation

```bash
python3 -m unittest tests.test_lmdb_parent_boundary_cache_benchmark tests.test_lmdb_depth_planning_prior_probe tests.test_lmdb_parent_histogram_benchmark tests.test_lmdb_parent_branching_diagnostic
python3 -m py_compile scripts/lmdb_parent_boundary_cache_benchmark.py tests/test_lmdb_parent_boundary_cache_benchmark.py
git diff --check -- scripts/lmdb_parent_boundary_cache_benchmark.py tests/test_lmdb_parent_boundary_cache_benchmark.py docs/reports/lmdb_parametric_boundary_mass_models_2026-06-12.md
```

Smoke outputs were written under:

```text
/mnt/c/Users/johnc/Scratch/parametric-boundary-mass-models
```

## Worktree note

An unrelated local edit remains unstaged in `templates/targets/fsharp_wam/kernel_bidirectional_ancestor.fs.mustache`.