### PR TITLE
[codex] Add support-conditioned parametric boundaries

### DIFF
--- a/docs/reports/lmdb_support_conditioned_parametric_boundaries_2026-06-12.md
+++ b/docs/reports/lmdb_support_conditioned_parametric_boundaries_2026-06-12.md
@@ -1,0 +1,140 @@
+# LMDB Support-Conditioned Parametric Boundaries
+
+This pass adds finite-support parametric boundary shapes to the LMDB parent
+boundary-cache benchmark.  The previous empirical-prior shape could be hit many
+times without contributing any suffix bins, because its support was shifted
+outside the remaining target path budget.
+
+## Script Changes
+
+`scripts/lmdb_parent_boundary_cache_benchmark.py` now accepts:
+
+```text
+--parametric-shape-model empirical-prior|support-binomial|support-binomial-midpoint
+```
+
+The shape models are:
+
+- `empirical-prior`: previous behavior, using the depth-conditioned empirical
+  prior distribution and aligning it to the boundary `L_min`;
+- `support-binomial`: finite-support binomial over
+  `[histogram_L_min, histogram_L_max]`, with `p` derived from the prior mean;
+  and
+- `support-binomial-midpoint`: finite-support binomial over the same interval,
+  with midpoint mean `p=0.5`.
+
+The midpoint variant is intentionally simple.  It is a support-placement
+baseline that answers whether target-level mass comparisons become meaningful
+once approximate suffix bins actually fall inside the remaining path budget.
+
+## Smoke Commands
+
+All runs used:
+
+```bash
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py \
+  --lmdb-dir /home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct/lmdb_resident \
+  --root 7345184 \
+  --boundary-depths 1 \
+  --target-depths 3 \
+  --children-per-node 64 \
+  --frontier-limit 600 \
+  --boundaries-per-depth 24 \
+  --targets-per-depth 8 \
+  --boundary-budget 6 \
+  --budgets 6,8 \
+  --path-cap 50000 \
+  --expansion-cap 100000 \
+  --seed enwiki-mtc-parametric-boundary-v1 \
+  --admission-policy depth-prior \
+  --safety-factor 1.25 \
+  --max-histogram-bytes 64 \
+  --parametric-bytes 64 \
+  --parametric-mass-cap 100000 \
+  --tail-epsilon 0.001 \
+  --max-parent-depth 24 \
+  --output-dir /mnt/c/Users/johnc/Scratch/support-conditioned-parametric-boundaries
+```
+
+The compared modes were:
+
+```text
+--parametric-shape-model empirical-prior --parametric-mass-model oracle
+--parametric-shape-model support-binomial --parametric-mass-model oracle
+--parametric-shape-model support-binomial-midpoint --parametric-mass-model oracle
+--parametric-shape-model support-binomial-midpoint --parametric-mass-model unit
+--parametric-shape-model support-binomial-midpoint --parametric-mass-model depth-prior
+```
+
+All runs selected the same cache shape:
+
+| boundary_nodes | histogram_cached | parametric_cached | targets | boundary_budget |
+|---------------:|-----------------:|------------------:|--------:|----------------:|
+| 24 | 6 | 18 | 8 | 6 |
+
+## Results
+
+### Oracle Mass Shape Comparison
+
+| shape_model | budget | mean_l1 | mean_cdf | mean_path_count_relative_error | mean_abs_path_delta | mean_param_hits | mean_param_bins_spliced |
+|-------------|-------:|--------:|---------:|-------------------------------:|--------------------:|----------------:|------------------------:|
+| empirical-prior | 6 | 1.139211 | 0.694605 | 0.562386 | 12.250 | 17.625 | 0.000 |
+| empirical-prior | 8 | 1.070372 | 0.535117 | 0.293339 | 16.125 | 35.125 | 0.000 |
+| support-binomial | 6 | 1.139211 | 0.694605 | 0.562386 | 12.250 | 17.625 | 0.000 |
+| support-binomial | 8 | 1.002190 | 0.501026 | 0.290814 | 16.000 | 35.125 | 0.250 |
+| support-binomial-midpoint | 6 | 1.048619 | 0.524309 | 0.258724 | 5.750 | 17.625 | 7.375 |
+| support-binomial-midpoint | 8 | 0.957091 | 0.477349 | 0.159200 | 6.000 | 35.125 | 8.625 |
+
+The empirical-prior baseline reproduces the previous failure mode: many
+parametric hits, but zero parametric bins spliced.  The prior-derived
+support-binomial keeps bins inside the boundary support, but its prior mean
+saturates at the support maximum on this sample, so it only weakly improves
+splicing.  The midpoint support-binomial is the first useful target-level
+baseline: it turns parametric hits into actual suffix bins and reduces
+path-count error.
+
+### Midpoint Shape Mass Comparison
+
+| mass_model | budget | mean_l1 | mean_cdf | mean_path_count_relative_error | mean_abs_path_delta | mean_param_bins_spliced | mean_parametric_mass_ratio |
+|------------|-------:|--------:|---------:|-------------------------------:|--------------------:|------------------------:|----------------------------:|
+| oracle | 6 | 1.048619 | 0.524309 | 0.258724 | 5.750 | 7.375 | 1.000 |
+| oracle | 8 | 0.957091 | 0.477349 | 0.159200 | 6.000 | 8.625 | 1.000 |
+| unit | 6 | 1.307544 | 0.653772 | 0.466544 | 10.125 | 2.125 | 0.190 |
+| unit | 8 | 1.056345 | 0.528172 | 0.253051 | 14.125 | 2.000 | 0.190 |
+| depth-prior | 6 | 0.472906 | 0.207411 | 58.352015 | 1261.875 | 14.500 | 100.812 |
+| depth-prior | 8 | 0.390058 | 0.183098 | 29.090730 | 1344.875 | 20.000 | 100.812 |
+
+This is the expected split.  The depth-prior mass model can improve normalized
+shape metrics while catastrophically overcounting unnormalized path mass.  Unit
+mass undercounts.  Oracle mass remains the control for shape behavior.
+
+## Interpretation
+
+Support conditioning fixed the immediate benchmark issue: target search can now
+splice parametric suffix bins, so mass-model choices become visible at the
+target level.
+
+The midpoint support-binomial is not a final model.  It is a useful finite
+support baseline.  The prior-derived support-binomial shows why a naive prior
+mean is not enough: when the prior mean exceeds the observed support width, the
+binomial saturates and places nearly all mass at `L_max`.
+
+Next useful work:
+
+- add a bounded mean rule that blends prior mean with support midpoint instead
+  of hard-clipping at `p=1`;
+- compare skewed small-`n` binomials against measured boundary histograms; and
+- replace oracle support intervals with estimated `(L_min, L_max)` once the
+  finite-support family behaves well under measured support.
+
+## Validation
+
+```bash
+python3 -m unittest tests.test_lmdb_parent_boundary_cache_benchmark tests.test_lmdb_depth_planning_prior_probe tests.test_lmdb_parent_histogram_benchmark tests.test_lmdb_parent_branching_diagnostic
+python3 -m py_compile scripts/lmdb_parent_boundary_cache_benchmark.py tests/test_lmdb_parent_boundary_cache_benchmark.py
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --parametric-shape-model empirical-prior --parametric-mass-model oracle
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --parametric-shape-model support-binomial --parametric-mass-model oracle
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --parametric-shape-model support-binomial-midpoint --parametric-mass-model oracle
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --parametric-shape-model support-binomial-midpoint --parametric-mass-model unit
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --parametric-shape-model support-binomial-midpoint --parametric-mass-model depth-prior
+```

--- a/scripts/lmdb_parent_boundary_cache_benchmark.py
+++ b/scripts/lmdb_parent_boundary_cache_benchmark.py
@@ -28,7 +28,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.distribution_fit_comparison import exact_excess_distribution, l1_error, max_cdf_error
+from scripts.distribution_fit_comparison import binomial_pmf, exact_excess_distribution, l1_error, max_cdf_error
 from scripts.lmdb_parent_branching_diagnostic import (
     LmdbCategoryGraph,
     parse_int_list,
@@ -125,6 +125,25 @@ def estimate_parametric_total_count(row, prior, mass_model, mass_cap=None):
         "mass_ratio": None if oracle_count <= 0 else estimated / oracle_count,
         "mass_capped": capped,
     }
+
+
+def parametric_shape_distribution(row, prior, shape_model):
+    """Return a compact probability vector and origin for a boundary state."""
+    origin = row.get("histogram_L_min")
+    if origin is None:
+        return [], None
+    if shape_model == "empirical-prior":
+        return prior["prior_distribution"], int(origin)
+    if shape_model in {"support-binomial", "support-binomial-midpoint"}:
+        lmax = row.get("histogram_L_max")
+        width = 0 if lmax is None else max(0, int(lmax) - int(origin))
+        if shape_model == "support-binomial-midpoint":
+            mean_excess = width / 2.0
+        else:
+            mean_excess = max(0.0, float(prior.get("prior_mean_excess", 0.0)))
+        probability = 0.0 if width <= 0 else max(0.0, min(1.0, mean_excess / width))
+        return binomial_pmf(width, probability), int(origin)
+    raise ValueError("unknown parametric shape model: {}".format(shape_model))
 
 
 def add_shifted_hist(out, suffix_hist, prefix_depth, remaining):
@@ -228,6 +247,7 @@ def build_boundary_cache(
     safety_factor=1.25,
     max_histogram_bytes=1024,
     parametric_bytes=64,
+    parametric_shape_model="empirical-prior",
     parametric_mass_model="oracle",
     parametric_mass_cap=1000000,
     tail_epsilon=0.001,
@@ -335,11 +355,14 @@ def build_boundary_cache(
         row["parametric_histogram"] = {}
         row["parametric_path_count"] = 0
         row["parametric_oracle_path_count"] = row["path_count"]
+        row["parametric_shape_model"] = parametric_shape_model
         row["parametric_mass_model"] = parametric_mass_model
         row["parametric_mass_delta"] = None
         row["parametric_mass_ratio"] = None
         row["parametric_mass_capped"] = False
         row["parametric_support_bins"] = 0
+        row["parametric_support_min"] = None
+        row["parametric_support_max"] = None
         if cached:
             cache[row["node"]] = hist
         elif policy["action"] == "use_parametric_prior" and lmax in priors and hist:
@@ -349,9 +372,14 @@ def build_boundary_cache(
                 parametric_mass_model,
                 parametric_mass_cap,
             )
+            probabilities, origin = parametric_shape_distribution(
+                row,
+                priors[lmax],
+                parametric_shape_model,
+            )
             approx_hist = scaled_distribution_histogram(
-                priors[lmax]["prior_distribution"],
-                row["histogram_L_min"],
+                probabilities,
+                origin,
                 mass_estimate["estimated_path_count"],
             )
             if approx_hist:
@@ -364,6 +392,8 @@ def build_boundary_cache(
                 row["parametric_mass_ratio"] = mass_estimate["mass_ratio"]
                 row["parametric_mass_capped"] = mass_estimate["mass_capped"]
                 row["parametric_support_bins"] = len(approx_hist)
+                row["parametric_support_min"] = min(approx_hist)
+                row["parametric_support_max"] = max(approx_hist)
     return cache, parametric_cache, rows
 
 
@@ -448,6 +478,7 @@ def run_benchmark(args):
             args.safety_factor,
             args.max_histogram_bytes,
             args.parametric_bytes,
+            args.parametric_shape_model,
             args.parametric_mass_model,
             args.parametric_mass_cap,
             args.tail_epsilon,
@@ -469,6 +500,7 @@ def run_benchmark(args):
             "safety_factor": args.safety_factor,
             "max_histogram_bytes": args.max_histogram_bytes,
             "parametric_bytes": args.parametric_bytes,
+            "parametric_shape_model": args.parametric_shape_model,
             "parametric_mass_model": args.parametric_mass_model,
             "parametric_mass_cap": args.parametric_mass_cap,
         }]
@@ -551,13 +583,14 @@ def summarize(records):
         "",
         "## Admission Policy",
         "",
-        "| policy | safety_factor | max_histogram_bytes | parametric_bytes | parametric_mass_model | parametric_mass_cap |",
-        "|--------|--------------:|--------------------:|-----------------:|-----------------------|--------------------:|",
-        "| {} | {} | {} | {} | {} | {} |".format(
+        "| policy | safety_factor | max_histogram_bytes | parametric_bytes | parametric_shape_model | parametric_mass_model | parametric_mass_cap |",
+        "|--------|--------------:|--------------------:|-----------------:|------------------------|-----------------------|--------------------:|",
+        "| {} | {} | {} | {} | {} | {} | {} |".format(
             selection.get("admission_policy", "baseline"),
             selection.get("safety_factor", "n/a"),
             selection.get("max_histogram_bytes", "n/a"),
             selection.get("parametric_bytes", "n/a"),
+            selection.get("parametric_shape_model", "empirical-prior"),
             selection.get("parametric_mass_model", "oracle"),
             selection.get("parametric_mass_cap", "n/a"),
         ),
@@ -701,6 +734,7 @@ def main(argv=None):
     parser.add_argument("--safety-factor", type=float, default=1.25, help="Multiplier for depth-prior predicted histogram bytes.")
     parser.add_argument("--max-histogram-bytes", type=int, default=1024, help="Maximum bytes allowed for exact or capped boundary histograms under depth-prior admission.")
     parser.add_argument("--parametric-bytes", type=int, default=64, help="Estimated bytes for a parametric prior state.")
+    parser.add_argument("--parametric-shape-model", choices=["empirical-prior", "support-binomial", "support-binomial-midpoint"], default="empirical-prior", help="Shape used for parametric boundary states.")
     parser.add_argument("--parametric-mass-model", choices=["oracle", "unit", "depth-prior"], default="oracle", help="Mass used to unnormalize parametric boundary states.")
     parser.add_argument("--parametric-mass-cap", type=int, default=1000000, help="Maximum estimated path mass for non-oracle parametric states; non-positive disables the cap.")
     parser.add_argument("--tail-epsilon", type=float, default=0.001, help="Tail epsilon used when estimating depth-prior effective support.")

--- a/tests/test_lmdb_parent_boundary_cache_benchmark.py
+++ b/tests/test_lmdb_parent_boundary_cache_benchmark.py
@@ -10,6 +10,7 @@ from scripts.lmdb_parent_boundary_cache_benchmark import (
     cached_parent_histogram,
     estimate_parametric_total_count,
     histogram_distribution_error,
+    parametric_shape_distribution,
     scaled_distribution_histogram,
 )
 from scripts.lmdb_parent_histogram_benchmark import bounded_parent_histogram
@@ -139,6 +140,52 @@ class BoundaryCacheBenchmarkTests(unittest.TestCase):
         self.assertEqual(rows[0]["parametric_mass_model"], "unit")
         self.assertEqual(rows[0]["parametric_mass_delta"], -1)
         self.assertAlmostEqual(rows[0]["parametric_mass_ratio"], 0.5)
+
+    def test_support_binomial_shape_stays_inside_boundary_support(self):
+        probabilities, origin = parametric_shape_distribution(
+            {"histogram_L_min": 2, "histogram_L_max": 5},
+            {"prior_mean_excess": 1.5},
+            "support-binomial",
+        )
+
+        self.assertEqual(origin, 2)
+        self.assertEqual(len(probabilities), 4)
+        self.assertAlmostEqual(sum(probabilities), 1.0)
+
+        midpoint, midpoint_origin = parametric_shape_distribution(
+            {"histogram_L_min": 2, "histogram_L_max": 5},
+            {"prior_mean_excess": 99.0},
+            "support-binomial-midpoint",
+        )
+        self.assertEqual(midpoint_origin, 2)
+        self.assertEqual(len(midpoint), 4)
+        self.assertGreater(midpoint[1], 0.0)
+
+    def test_support_binomial_boundary_cache_records_support_interval(self):
+        graph = DictGraph({"A": ["R"], "B": ["A", "R"]})
+
+        cache, parametric_cache, rows = build_boundary_cache(
+            graph,
+            "R",
+            ["B"],
+            2,
+            None,
+            None,
+            admission_policy="depth-prior",
+            safety_factor=2.0,
+            max_histogram_bytes=24,
+            parametric_bytes=8,
+            parametric_shape_model="support-binomial",
+            parametric_mass_model="oracle",
+            max_parent_depth=4,
+        )
+
+        self.assertEqual(cache, {})
+        self.assertTrue(rows[0]["parametric_cached"])
+        self.assertEqual(rows[0]["parametric_shape_model"], "support-binomial")
+        self.assertGreaterEqual(rows[0]["parametric_support_min"], rows[0]["histogram_L_min"])
+        self.assertLessEqual(rows[0]["parametric_support_max"], rows[0]["histogram_L_max"])
+        self.assertEqual(sum(parametric_cache["B"].values()), rows[0]["path_count"])
 
     def test_depth_prior_mass_model_caps_branching_pressure(self):
         estimate = estimate_parametric_total_count(


### PR DESCRIPTION
## Summary

Adds support-conditioned shape models to the LMDB parent boundary-cache benchmark:

```text
--parametric-shape-model empirical-prior|support-binomial|support-binomial-midpoint
```

The new finite-support binomial shapes use the measured boundary support interval `[histogram_L_min, histogram_L_max]`, so approximate suffix bins can land inside the target search's remaining path budget. Existing `empirical-prior` behavior remains the default.

## Key result

The previous empirical-prior shape reproduced the failure mode from the mass-model PR: many parametric hits but zero parametric bins spliced.

With oracle mass on the d1 enwiki MTC smoke:

| shape_model | budget | mean_l1 | mean_cdf | mean_path_count_relative_error | mean_abs_path_delta | mean_param_hits | mean_param_bins_spliced |
|-------------|-------:|--------:|---------:|-------------------------------:|--------------------:|----------------:|------------------------:|
| empirical-prior | 6 | 1.139211 | 0.694605 | 0.562386 | 12.250 | 17.625 | 0.000 |
| empirical-prior | 8 | 1.070372 | 0.535117 | 0.293339 | 16.125 | 35.125 | 0.000 |
| support-binomial-midpoint | 6 | 1.048619 | 0.524309 | 0.258724 | 5.750 | 17.625 | 7.375 |
| support-binomial-midpoint | 8 | 0.957091 | 0.477349 | 0.159200 | 6.000 | 35.125 | 8.625 |

The prior-derived `support-binomial` variant stayed finite-support but often saturated at `L_max`, so it only weakly improved splicing. The midpoint variant is a simple baseline showing that support placement is the missing piece.

## Mass-model visibility

With `support-binomial-midpoint`, mass models now affect target-level behavior:

- `oracle` gives the best path-count error on this smoke.
- `unit` undercounts.
- `depth-prior` improves normalized shape metrics but badly overcounts unnormalized path mass.

That validates why both normalized shape error and path-count error must be tracked.

## Validation

```bash
python3 -m unittest tests.test_lmdb_parent_boundary_cache_benchmark tests.test_lmdb_depth_planning_prior_probe tests.test_lmdb_parent_histogram_benchmark tests.test_lmdb_parent_branching_diagnostic
python3 -m py_compile scripts/lmdb_parent_boundary_cache_benchmark.py tests/test_lmdb_parent_boundary_cache_benchmark.py
git diff --check -- scripts/lmdb_parent_boundary_cache_benchmark.py tests/test_lmdb_parent_boundary_cache_benchmark.py docs/reports/lmdb_support_conditioned_parametric_boundaries_2026-06-12.md
```

Smoke outputs were written under:

```text
/mnt/c/Users/johnc/Scratch/support-conditioned-parametric-boundaries
```

## Worktree note

An unrelated local edit remains unstaged in `templates/targets/fsharp_wam/kernel_bidirectional_ancestor.fs.mustache`.