### PR TITLE
feat(wam-llvm): add assoc i64 counter runtime

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -256,6 +256,8 @@ the native streaming loop.
 Scalar counters and the current static associative-count surface now lower
 through an explicit codegen state plan, keeping source-level state recognition
 separate from LLVM slot numbering ahead of a real native hash-table backend.
+The WAM/LLVM runtime now exposes a reusable interned-atom-keyed `i64` counter
+table primitive (`wam_assoc_i64_*`) for that future dynamic associative path.
 
 **Success:** a user-written awk-style program parses, lowers, compiles, and
 produces correct output on standard awk test cases.

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -3952,6 +3952,209 @@ compile_execute_builtin_to_llvm(Options, Code) :-
 
 @.wam_stream_eof_atom = private constant [12 x i8] c"end_of_file\00"
 
+define %WamAssocI64Table* @wam_assoc_i64_new(i64 %requested_cap) {
+entry:
+  %cap_positive = icmp sgt i64 %requested_cap, 0
+  %cap = select i1 %cap_positive, i64 %requested_cap, i64 64
+  %table_size = ptrtoint %WamAssocI64Table* getelementptr (%WamAssocI64Table, %WamAssocI64Table* null, i32 1) to i64
+  %table_mem = call i8* @malloc(i64 %table_size)
+  %table_null = icmp eq i8* %table_mem, null
+  br i1 %table_null, label %new.fail, label %new.alloc_entries
+
+new.alloc_entries:
+  %entry_size = ptrtoint %WamAssocI64Entry* getelementptr (%WamAssocI64Entry, %WamAssocI64Entry* null, i32 1) to i64
+  %entries_size = mul i64 %cap, %entry_size
+  %entries_mem = call i8* @malloc(i64 %entries_size)
+  %entries_null = icmp eq i8* %entries_mem, null
+  br i1 %entries_null, label %new.free_table_fail, label %new.init_table
+
+new.free_table_fail:
+  call void @free(i8* %table_mem)
+  ret %WamAssocI64Table* null
+
+new.init_table:
+  %table = bitcast i8* %table_mem to %WamAssocI64Table*
+  %entries = bitcast i8* %entries_mem to %WamAssocI64Entry*
+  %count_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 0
+  store i64 0, i64* %count_slot
+  %cap_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 1
+  store i64 %cap, i64* %cap_slot
+  %entries_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 2
+  store %WamAssocI64Entry* %entries, %WamAssocI64Entry** %entries_slot
+  br label %new.zero_loop
+
+new.zero_loop:
+  %zi = phi i64 [ 0, %new.init_table ], [ %zi.next, %new.zero_body ]
+  %zi.done = icmp uge i64 %zi, %cap
+  br i1 %zi.done, label %new.done, label %new.zero_body
+
+new.zero_body:
+  %assoc_entry = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %entries, i64 %zi
+  %key_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 0
+  store i64 0, i64* %key_slot
+  %value_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 1
+  store i64 0, i64* %value_slot
+  %occupied_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 2
+  store i1 false, i1* %occupied_slot
+  %zi.next = add i64 %zi, 1
+  br label %new.zero_loop
+
+new.done:
+  ret %WamAssocI64Table* %table
+
+new.fail:
+  ret %WamAssocI64Table* null
+}
+
+define i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 %key) {
+entry:
+  %table_null = icmp eq %WamAssocI64Table* %table, null
+  br i1 %table_null, label %get.miss, label %get.load
+
+get.load:
+  %cap_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 1
+  %cap = load i64, i64* %cap_slot
+  %cap_zero = icmp eq i64 %cap, 0
+  br i1 %cap_zero, label %get.miss, label %get.start
+
+get.start:
+  %entries_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 2
+  %entries = load %WamAssocI64Entry*, %WamAssocI64Entry** %entries_slot
+  %entries_null = icmp eq %WamAssocI64Entry* %entries, null
+  br i1 %entries_null, label %get.miss, label %get.hash
+
+get.hash:
+  %start = urem i64 %key, %cap
+  br label %get.loop
+
+get.loop:
+  %idx = phi i64 [ %start, %get.hash ], [ %next_idx, %get.next ]
+  %probes = phi i64 [ 0, %get.hash ], [ %next_probes, %get.next ]
+  %assoc_entry = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %entries, i64 %idx
+  %occupied_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 2
+  %occupied = load i1, i1* %occupied_slot
+  br i1 %occupied, label %get.check_key, label %get.miss
+
+get.check_key:
+  %key_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 0
+  %found_key = load i64, i64* %key_slot
+  %key_match = icmp eq i64 %found_key, %key
+  br i1 %key_match, label %get.hit, label %get.next_check
+
+get.hit:
+  %value_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 1
+  %value = load i64, i64* %value_slot
+  ret i64 %value
+
+get.next_check:
+  %next_probes = add i64 %probes, 1
+  %full = icmp uge i64 %next_probes, %cap
+  br i1 %full, label %get.miss, label %get.next
+
+get.next:
+  %idx_plus = add i64 %idx, 1
+  %wrap = icmp uge i64 %idx_plus, %cap
+  %next_idx = select i1 %wrap, i64 0, i64 %idx_plus
+  br label %get.loop
+
+get.miss:
+  ret i64 0
+}
+
+define i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 %key, i64 %delta) {
+entry:
+  %table_null = icmp eq %WamAssocI64Table* %table, null
+  br i1 %table_null, label %inc.fail, label %inc.load
+
+inc.load:
+  %cap_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 1
+  %cap = load i64, i64* %cap_slot
+  %cap_zero = icmp eq i64 %cap, 0
+  br i1 %cap_zero, label %inc.fail, label %inc.start
+
+inc.start:
+  %entries_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 2
+  %entries = load %WamAssocI64Entry*, %WamAssocI64Entry** %entries_slot
+  %entries_null = icmp eq %WamAssocI64Entry* %entries, null
+  br i1 %entries_null, label %inc.fail, label %inc.hash
+
+inc.hash:
+  %start = urem i64 %key, %cap
+  br label %inc.loop
+
+inc.loop:
+  %idx = phi i64 [ %start, %inc.hash ], [ %next_idx, %inc.next ]
+  %probes = phi i64 [ 0, %inc.hash ], [ %next_probes, %inc.next ]
+  %assoc_entry = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %entries, i64 %idx
+  %occupied_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 2
+  %occupied = load i1, i1* %occupied_slot
+  br i1 %occupied, label %inc.check_key, label %inc.insert
+
+inc.check_key:
+  %key_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 0
+  %found_key = load i64, i64* %key_slot
+  %key_match = icmp eq i64 %found_key, %key
+  br i1 %key_match, label %inc.update, label %inc.next_check
+
+inc.update:
+  %value_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 1
+  %old_value = load i64, i64* %value_slot
+  %new_value = add i64 %old_value, %delta
+  store i64 %new_value, i64* %value_slot
+  ret i64 %new_value
+
+inc.insert:
+  %insert_key_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 0
+  store i64 %key, i64* %insert_key_slot
+  %insert_value_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 1
+  store i64 %delta, i64* %insert_value_slot
+  store i1 true, i1* %occupied_slot
+  %count_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 0
+  %old_count = load i64, i64* %count_slot
+  %new_count = add i64 %old_count, 1
+  store i64 %new_count, i64* %count_slot
+  ret i64 %delta
+
+inc.next_check:
+  %next_probes = add i64 %probes, 1
+  %full = icmp uge i64 %next_probes, %cap
+  br i1 %full, label %inc.fail, label %inc.next
+
+inc.next:
+  %idx_plus = add i64 %idx, 1
+  %wrap = icmp uge i64 %idx_plus, %cap
+  %next_idx = select i1 %wrap, i64 0, i64 %idx_plus
+  br label %inc.loop
+
+inc.fail:
+  ret i64 0
+}
+
+define void @wam_assoc_i64_free(%WamAssocI64Table* %table) {
+entry:
+  %table_null = icmp eq %WamAssocI64Table* %table, null
+  br i1 %table_null, label %done, label %free.entries
+
+free.entries:
+  %entries_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 2
+  %entries = load %WamAssocI64Entry*, %WamAssocI64Entry** %entries_slot
+  %entries_null = icmp eq %WamAssocI64Entry* %entries, null
+  br i1 %entries_null, label %free.table, label %free.entries_mem
+
+free.entries_mem:
+  %entries_i8 = bitcast %WamAssocI64Entry* %entries to i8*
+  call void @free(i8* %entries_i8)
+  br label %free.table
+
+free.table:
+  %table_i8 = bitcast %WamAssocI64Table* %table to i8*
+  call void @free(i8* %table_i8)
+  br label %done
+
+done:
+  ret void
+}
+
 define %Value @wam_stream_fail_value() alwaysinline nounwind {
 entry:
   %bad = call %Value @value_integer(i64 -1)

--- a/templates/targets/llvm_wam/types.ll.mustache
+++ b/templates/targets/llvm_wam/types.ll.mustache
@@ -16,6 +16,11 @@
 ; === Buffered line reader handle ===
 %WamLineReader = type { i32, i8*, i64, i64, i64 } ; fd, buffer, cap, len, pos
 
+; === Native associative i64 counter table ===
+; Used by streaming/native lowerings for interned-atom keyed counters.
+%WamAssocI64Entry = type { i64, i64, i1 } ; key atom id, count, occupied
+%WamAssocI64Table = type { i64, i64, %WamAssocI64Entry* } ; count, cap, entries
+
 ; === Instruction Tagged Union ===
 ; Tag: 0-7 head unification, 8-15 body construction, 16-21 control, 22-24 choice, 25-27 indexing
 %Instruction = type { i32, i64, i64 }     ; tag, operand1, operand2

--- a/templates/targets/llvm_wam_wasm/types.ll.mustache
+++ b/templates/targets/llvm_wam_wasm/types.ll.mustache
@@ -19,6 +19,11 @@
 ; === Buffered line reader handle ===
 %WamLineReader = type { i32, i8*, i64, i64, i64 } ; fd, buffer, cap, len, pos
 
+; === Native associative i64 counter table ===
+; Used by streaming/native lowerings for interned-atom keyed counters.
+%WamAssocI64Entry = type { i64, i64, i1 } ; key atom id, count, occupied
+%WamAssocI64Table = type { i64, i64, %WamAssocI64Entry* } ; count, cap, entries
+
 ; === Instruction Tagged Union ===
 %Instruction = type { i32, i64, i64 }     ; tag, operand1, operand2
 

--- a/tests/core/test_wam_llvm_assoc_i64_runtime.pl
+++ b/tests/core/test_wam_llvm_assoc_i64_runtime.pl
@@ -1,0 +1,92 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2026 John William Creighton (@s243a)
+
+:- use_module(library(filesex), [make_directory_path/1]).
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+:- use_module('../helpers/smoke_paths', [tmp_root/1, clean_dir/1]).
+:- use_module('../../src/unifyweaver/targets/wam_llvm_target',
+    [write_wam_llvm_project/3]).
+
+:- dynamic user:assoc_i64_marker/0.
+
+user:assoc_i64_marker.
+
+clang_available :-
+    catch(( process_create(path(clang), ['--version'],
+                           [stdout(null), stderr(null), process(Pid)]),
+            process_wait(Pid, exit(0)) ), _, fail).
+
+:- begin_tests(wam_llvm_assoc_i64_runtime, [condition(clang_available)]).
+
+test(assoc_i64_counts_colliding_keys_and_missing_key) :-
+    run_assoc_i64_smoke.
+
+run_assoc_i64_smoke :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_wam_assoc_i64_runtime', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'assoc_i64_runtime.ll', LLPath),
+    write_wam_llvm_project(
+        [ user:assoc_i64_marker/0 ],
+        [ module_name('assoc_i64_runtime') ],
+        LLPath),
+    assoc_i64_driver_ir(DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'assoc_i64_runtime_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> assertion(OutStr == "")
+    ;  format(user_error, "~n[assoc i64 runtime output]~n~w~n", [OutStr]),
+       throw(assoc_i64_runtime_failed(Status))
+    ),
+    !.
+
+assoc_i64_driver_ir('
+define i32 @main() {
+entry:
+  %table = call %WamAssocI64Table* @wam_assoc_i64_new(i64 4)
+  %table_null = icmp eq %WamAssocI64Table* %table, null
+  br i1 %table_null, label %alloc_fail, label %exercise
+
+exercise:
+  ; 1 and 5 collide when capacity is 4, so this also covers probing.
+  %a1 = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 1, i64 1)
+  %a2 = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 1, i64 1)
+  %b1 = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 5, i64 1)
+  %got_a = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 1)
+  %got_b = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 5)
+  %got_missing = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 9)
+  %a_ok = icmp eq i64 %got_a, 2
+  %b_ok = icmp eq i64 %got_b, 1
+  %missing_ok = icmp eq i64 %got_missing, 0
+  %ab_ok = and i1 %a_ok, %b_ok
+  %all_ok = and i1 %ab_ok, %missing_ok
+  call void @wam_assoc_i64_free(%WamAssocI64Table* %table)
+  br i1 %all_ok, label %ok, label %bad_counts
+
+ok:
+  ret i32 0
+
+alloc_fail:
+  ret i32 90
+
+bad_counts:
+  ret i32 91
+}
+').
+
+:- end_tests(wam_llvm_assoc_i64_runtime).
+
+:- initialization(run_tests, main).

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -196,7 +196,11 @@ test(full_runtime_generation) :-
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @backtrack')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_field_eq_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamSlice @wam_atom_field_slice_value')),
-    assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_prefix_value')).
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_prefix_value')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamAssocI64Table* @wam_assoc_i64_new')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_assoc_i64_inc')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_assoc_i64_get')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define void @wam_assoc_i64_free')).
 
 test(atom_prefix_guard_emitter) :-
     llvm_emit_atom_prefix_guard(prefix_guard_test, '%line', 'ERROR', '%ok', GlobalIR-CallIR),


### PR DESCRIPTION
# [codex] Add WAM LLVM assoc i64 counter runtime

## Summary
- Add reusable WAM/LLVM runtime types for interned-atom keyed `i64` counter tables
- Implement `wam_assoc_i64_new`, `wam_assoc_i64_inc`, `wam_assoc_i64_get`, and `wam_assoc_i64_free`
- Add a native execution smoke covering colliding keys and missing-key lookup
- Document this as backend infrastructure for PLAWK’s future dynamic associative-array lowering

## Validation
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','.codex/smoke_tmp'),run_tests" -t halt`
- `git diff --cached --check`
- `git diff --check`

Commit: 376b50b9 feat(wam-llvm): add assoc i64 counter runtime