### PR TITLE
[codex] Add blended support-binomial mean models

### DIFF
--- a/docs/reports/lmdb_blended_support_binomial_mean_2026-06-12.md
+++ b/docs/reports/lmdb_blended_support_binomial_mean_2026-06-12.md
@@ -1,0 +1,141 @@
+# LMDB Blended Support-Binomial Mean
+
+This pass separates the finite-support binomial shape from the rule used to
+choose its mean.  The previous support-binomial variants were hard-coded:
+
+- `support-binomial` used the prior mean clipped to the support interval; and
+- `support-binomial-midpoint` used the midpoint of the support interval.
+
+The prior-clipped rule often saturated at `L_max`, while midpoint worked better
+as a support-placement baseline.  This pass adds an explicit mean rule so the
+benchmark can test whether small amounts of prior skew help.
+
+## Script Changes
+
+`scripts/lmdb_parent_boundary_cache_benchmark.py` now accepts:
+
+```text
+--parametric-mean-model prior-clipped|midpoint|blend
+--parametric-mean-blend <alpha>
+```
+
+For `support-binomial`, the mean rules are:
+
+```text
+prior-clipped: mean = clamp(prior_mean, 0, width)
+midpoint:      mean = width / 2
+blend:         mean = clamp(alpha * prior_mean + (1 - alpha) * midpoint, 0, width)
+```
+
+The older `support-binomial-midpoint` shape remains as a compatibility alias for
+the midpoint rule.
+
+Boundary rows now carry the selected mean model, blend alpha, chosen binomial
+mean excess, and chosen binomial probability.
+
+## Smoke Commands
+
+All runs used the same d1 enwiki MTC setup:
+
+```bash
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py \
+  --lmdb-dir /home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct/lmdb_resident \
+  --root 7345184 \
+  --boundary-depths 1 \
+  --target-depths 3 \
+  --children-per-node 64 \
+  --frontier-limit 600 \
+  --boundaries-per-depth 24 \
+  --targets-per-depth 8 \
+  --boundary-budget 6 \
+  --budgets 6,8 \
+  --path-cap 50000 \
+  --expansion-cap 100000 \
+  --seed enwiki-mtc-parametric-boundary-v1 \
+  --admission-policy depth-prior \
+  --safety-factor 1.25 \
+  --max-histogram-bytes 64 \
+  --parametric-bytes 64 \
+  --parametric-shape-model support-binomial \
+  --parametric-mass-model oracle \
+  --parametric-mass-cap 100000 \
+  --tail-epsilon 0.001 \
+  --max-parent-depth 24 \
+  --output-dir /mnt/c/Users/johnc/Scratch/blended-support-binomial-mean
+```
+
+The compared mean models were:
+
+```text
+prior-clipped
+midpoint
+blend alpha = 0.05
+blend alpha = 0.10
+blend alpha = 0.25
+blend alpha = 0.50
+blend alpha = 0.75
+```
+
+All runs selected:
+
+| boundary_nodes | histogram_cached | parametric_cached | targets | boundary_budget |
+|---------------:|-----------------:|------------------:|--------:|----------------:|
+| 24 | 6 | 18 | 8 | 6 |
+
+## Results
+
+Budget 6:
+
+| mean_model | alpha | mean_l1 | mean_cdf | mean_path_count_relative_error | mean_abs_path_delta | mean_param_bins_spliced |
+|------------|------:|--------:|---------:|-------------------------------:|--------------------:|------------------------:|
+| prior-clipped | n/a | 1.139211 | 0.694605 | 0.562386 | 12.250 | 0.000 |
+| midpoint | n/a | 1.048619 | 0.524309 | 0.258724 | 5.750 | 7.375 |
+| blend | 0.05 | 1.064968 | 0.529012 | 0.204151 | 3.750 | 5.500 |
+| blend | 0.10 | 1.238579 | 0.619289 | 0.301660 | 6.750 | 3.250 |
+| blend | 0.25 | 1.139211 | 0.694605 | 0.562386 | 12.250 | 0.000 |
+| blend | 0.50 | 1.139211 | 0.694605 | 0.562386 | 12.250 | 0.000 |
+| blend | 0.75 | 1.139211 | 0.694605 | 0.562386 | 12.250 | 0.000 |
+
+Budget 8:
+
+| mean_model | alpha | mean_l1 | mean_cdf | mean_path_count_relative_error | mean_abs_path_delta | mean_param_bins_spliced |
+|------------|------:|--------:|---------:|-------------------------------:|--------------------:|------------------------:|
+| prior-clipped | n/a | 1.002190 | 0.501026 | 0.290814 | 16.000 | 0.250 |
+| midpoint | n/a | 0.957091 | 0.477349 | 0.159200 | 6.000 | 8.625 |
+| blend | 0.05 | 1.004725 | 0.498352 | 0.184026 | 7.000 | 7.125 |
+| blend | 0.10 | 1.040822 | 0.520411 | 0.232611 | 11.000 | 3.750 |
+| blend | 0.25 | 1.002576 | 0.501026 | 0.286303 | 15.625 | 0.750 |
+| blend | 0.50 | 1.002190 | 0.501026 | 0.290814 | 16.000 | 0.250 |
+| blend | 0.75 | 1.002190 | 0.501026 | 0.290814 | 16.000 | 0.250 |
+
+## Interpretation
+
+The blend knob works, but this sample says the raw prior mean is too large to
+mix aggressively.  At alpha `0.25` and above, the blended mean is effectively
+back near the saturated `L_max` regime.  Very small prior weights are usable,
+but midpoint remains the strongest simple baseline overall:
+
+- midpoint gives the best normalized L1/CDF on both budgets;
+- alpha `0.05` gives the best budget-6 path-count relative error, but worse
+  normalized shape than midpoint; and
+- alpha `0.10` already loses much of the splice benefit.
+
+The next refinement should not simply tune alpha globally.  A better rule would
+normalize the prior mean relative to support width first, or learn a bucketed
+alpha from boundary histograms.  For now, `midpoint` is the conservative default
+candidate for finite-support binomial comparisons, and `blend` is useful as a
+sweep knob.
+
+## Validation
+
+```bash
+python3 -m unittest tests.test_lmdb_parent_boundary_cache_benchmark tests.test_lmdb_depth_planning_prior_probe tests.test_lmdb_parent_histogram_benchmark tests.test_lmdb_parent_branching_diagnostic
+python3 -m py_compile scripts/lmdb_parent_boundary_cache_benchmark.py tests/test_lmdb_parent_boundary_cache_benchmark.py
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --parametric-mean-model prior-clipped
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --parametric-mean-model midpoint
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --parametric-mean-model blend --parametric-mean-blend 0.05
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --parametric-mean-model blend --parametric-mean-blend 0.10
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --parametric-mean-model blend --parametric-mean-blend 0.25
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --parametric-mean-model blend --parametric-mean-blend 0.50
+python3 scripts/lmdb_parent_boundary_cache_benchmark.py ... --parametric-mean-model blend --parametric-mean-blend 0.75
+```

--- a/scripts/lmdb_parent_boundary_cache_benchmark.py
+++ b/scripts/lmdb_parent_boundary_cache_benchmark.py
@@ -127,22 +127,52 @@ def estimate_parametric_total_count(row, prior, mass_model, mass_cap=None):
     }
 
 
-def parametric_shape_distribution(row, prior, shape_model):
+def support_binomial_mean(width, prior_mean_excess, mean_model, mean_blend):
+    """Choose a bounded binomial mean over a finite support width."""
+    width = max(0, int(width))
+    prior_mean = max(0.0, float(prior_mean_excess))
+    midpoint = width / 2.0
+    if mean_model == "prior-clipped":
+        mean = prior_mean
+    elif mean_model == "midpoint":
+        mean = midpoint
+    elif mean_model == "blend":
+        alpha = max(0.0, min(1.0, float(mean_blend)))
+        mean = alpha * prior_mean + (1.0 - alpha) * midpoint
+    else:
+        raise ValueError("unknown parametric mean model: {}".format(mean_model))
+    return max(0.0, min(float(width), mean))
+
+
+def parametric_shape_distribution(row, prior, shape_model, mean_model="prior-clipped", mean_blend=0.5):
     """Return a compact probability vector and origin for a boundary state."""
     origin = row.get("histogram_L_min")
     if origin is None:
-        return [], None
+        return [], None, {}
     if shape_model == "empirical-prior":
-        return prior["prior_distribution"], int(origin)
+        return prior["prior_distribution"], int(origin), {
+            "shape_model": shape_model,
+            "mean_model": None,
+            "support_width": len(prior["prior_distribution"]) - 1,
+            "mean_excess": prior.get("prior_mean_excess"),
+            "probability": None,
+        }
     if shape_model in {"support-binomial", "support-binomial-midpoint"}:
         lmax = row.get("histogram_L_max")
         width = 0 if lmax is None else max(0, int(lmax) - int(origin))
+        selected_mean_model = "midpoint" if shape_model == "support-binomial-midpoint" else mean_model
         if shape_model == "support-binomial-midpoint":
-            mean_excess = width / 2.0
+            mean_excess = support_binomial_mean(width, prior.get("prior_mean_excess", 0.0), "midpoint", mean_blend)
         else:
-            mean_excess = max(0.0, float(prior.get("prior_mean_excess", 0.0)))
+            mean_excess = support_binomial_mean(width, prior.get("prior_mean_excess", 0.0), mean_model, mean_blend)
         probability = 0.0 if width <= 0 else max(0.0, min(1.0, mean_excess / width))
-        return binomial_pmf(width, probability), int(origin)
+        return binomial_pmf(width, probability), int(origin), {
+            "shape_model": shape_model,
+            "mean_model": selected_mean_model,
+            "support_width": width,
+            "mean_excess": mean_excess,
+            "probability": probability,
+        }
     raise ValueError("unknown parametric shape model: {}".format(shape_model))
 
 
@@ -248,6 +278,8 @@ def build_boundary_cache(
     max_histogram_bytes=1024,
     parametric_bytes=64,
     parametric_shape_model="empirical-prior",
+    parametric_mean_model="prior-clipped",
+    parametric_mean_blend=0.5,
     parametric_mass_model="oracle",
     parametric_mass_cap=1000000,
     tail_epsilon=0.001,
@@ -356,6 +388,10 @@ def build_boundary_cache(
         row["parametric_path_count"] = 0
         row["parametric_oracle_path_count"] = row["path_count"]
         row["parametric_shape_model"] = parametric_shape_model
+        row["parametric_mean_model"] = parametric_mean_model
+        row["parametric_mean_blend"] = parametric_mean_blend
+        row["parametric_shape_mean_excess"] = None
+        row["parametric_shape_probability"] = None
         row["parametric_mass_model"] = parametric_mass_model
         row["parametric_mass_delta"] = None
         row["parametric_mass_ratio"] = None
@@ -372,10 +408,12 @@ def build_boundary_cache(
                 parametric_mass_model,
                 parametric_mass_cap,
             )
-            probabilities, origin = parametric_shape_distribution(
+            probabilities, origin, shape_params = parametric_shape_distribution(
                 row,
                 priors[lmax],
                 parametric_shape_model,
+                parametric_mean_model,
+                parametric_mean_blend,
             )
             approx_hist = scaled_distribution_histogram(
                 probabilities,
@@ -388,6 +426,9 @@ def build_boundary_cache(
                 row["parametric_histogram"] = approx_hist
                 row["parametric_path_count"] = sum(approx_hist.values())
                 row["parametric_oracle_path_count"] = mass_estimate["oracle_path_count"]
+                row["parametric_mean_model"] = shape_params["mean_model"]
+                row["parametric_shape_mean_excess"] = shape_params["mean_excess"]
+                row["parametric_shape_probability"] = shape_params["probability"]
                 row["parametric_mass_delta"] = mass_estimate["mass_delta"]
                 row["parametric_mass_ratio"] = mass_estimate["mass_ratio"]
                 row["parametric_mass_capped"] = mass_estimate["mass_capped"]
@@ -479,6 +520,8 @@ def run_benchmark(args):
             args.max_histogram_bytes,
             args.parametric_bytes,
             args.parametric_shape_model,
+            args.parametric_mean_model,
+            args.parametric_mean_blend,
             args.parametric_mass_model,
             args.parametric_mass_cap,
             args.tail_epsilon,
@@ -501,6 +544,8 @@ def run_benchmark(args):
             "max_histogram_bytes": args.max_histogram_bytes,
             "parametric_bytes": args.parametric_bytes,
             "parametric_shape_model": args.parametric_shape_model,
+            "parametric_mean_model": args.parametric_mean_model,
+            "parametric_mean_blend": args.parametric_mean_blend,
             "parametric_mass_model": args.parametric_mass_model,
             "parametric_mass_cap": args.parametric_mass_cap,
         }]
@@ -583,14 +628,16 @@ def summarize(records):
         "",
         "## Admission Policy",
         "",
-        "| policy | safety_factor | max_histogram_bytes | parametric_bytes | parametric_shape_model | parametric_mass_model | parametric_mass_cap |",
-        "|--------|--------------:|--------------------:|-----------------:|------------------------|-----------------------|--------------------:|",
-        "| {} | {} | {} | {} | {} | {} | {} |".format(
+        "| policy | safety_factor | max_histogram_bytes | parametric_bytes | parametric_shape_model | parametric_mean_model | parametric_mean_blend | parametric_mass_model | parametric_mass_cap |",
+        "|--------|--------------:|--------------------:|-----------------:|------------------------|-----------------------|----------------------:|-----------------------|--------------------:|",
+        "| {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
             selection.get("admission_policy", "baseline"),
             selection.get("safety_factor", "n/a"),
             selection.get("max_histogram_bytes", "n/a"),
             selection.get("parametric_bytes", "n/a"),
             selection.get("parametric_shape_model", "empirical-prior"),
+            selection.get("parametric_mean_model", "prior-clipped"),
+            selection.get("parametric_mean_blend", "n/a"),
             selection.get("parametric_mass_model", "oracle"),
             selection.get("parametric_mass_cap", "n/a"),
         ),
@@ -735,6 +782,8 @@ def main(argv=None):
     parser.add_argument("--max-histogram-bytes", type=int, default=1024, help="Maximum bytes allowed for exact or capped boundary histograms under depth-prior admission.")
     parser.add_argument("--parametric-bytes", type=int, default=64, help="Estimated bytes for a parametric prior state.")
     parser.add_argument("--parametric-shape-model", choices=["empirical-prior", "support-binomial", "support-binomial-midpoint"], default="empirical-prior", help="Shape used for parametric boundary states.")
+    parser.add_argument("--parametric-mean-model", choices=["prior-clipped", "midpoint", "blend"], default="prior-clipped", help="Mean rule for support-binomial parametric shape states.")
+    parser.add_argument("--parametric-mean-blend", type=float, default=0.5, help="Prior weight for --parametric-mean-model blend; midpoint gets the remaining weight.")
     parser.add_argument("--parametric-mass-model", choices=["oracle", "unit", "depth-prior"], default="oracle", help="Mass used to unnormalize parametric boundary states.")
     parser.add_argument("--parametric-mass-cap", type=int, default=1000000, help="Maximum estimated path mass for non-oracle parametric states; non-positive disables the cap.")
     parser.add_argument("--tail-epsilon", type=float, default=0.001, help="Tail epsilon used when estimating depth-prior effective support.")

--- a/tests/test_lmdb_parent_boundary_cache_benchmark.py
+++ b/tests/test_lmdb_parent_boundary_cache_benchmark.py
@@ -12,6 +12,7 @@ from scripts.lmdb_parent_boundary_cache_benchmark import (
     histogram_distribution_error,
     parametric_shape_distribution,
     scaled_distribution_histogram,
+    support_binomial_mean,
 )
 from scripts.lmdb_parent_histogram_benchmark import bounded_parent_histogram
 
@@ -142,7 +143,7 @@ class BoundaryCacheBenchmarkTests(unittest.TestCase):
         self.assertAlmostEqual(rows[0]["parametric_mass_ratio"], 0.5)
 
     def test_support_binomial_shape_stays_inside_boundary_support(self):
-        probabilities, origin = parametric_shape_distribution(
+        probabilities, origin, params = parametric_shape_distribution(
             {"histogram_L_min": 2, "histogram_L_max": 5},
             {"prior_mean_excess": 1.5},
             "support-binomial",
@@ -151,8 +152,10 @@ class BoundaryCacheBenchmarkTests(unittest.TestCase):
         self.assertEqual(origin, 2)
         self.assertEqual(len(probabilities), 4)
         self.assertAlmostEqual(sum(probabilities), 1.0)
+        self.assertEqual(params["mean_model"], "prior-clipped")
+        self.assertAlmostEqual(params["mean_excess"], 1.5)
 
-        midpoint, midpoint_origin = parametric_shape_distribution(
+        midpoint, midpoint_origin, midpoint_params = parametric_shape_distribution(
             {"histogram_L_min": 2, "histogram_L_max": 5},
             {"prior_mean_excess": 99.0},
             "support-binomial-midpoint",
@@ -160,6 +163,12 @@ class BoundaryCacheBenchmarkTests(unittest.TestCase):
         self.assertEqual(midpoint_origin, 2)
         self.assertEqual(len(midpoint), 4)
         self.assertGreater(midpoint[1], 0.0)
+        self.assertEqual(midpoint_params["mean_model"], "midpoint")
+
+    def test_support_binomial_mean_blends_prior_and_midpoint(self):
+        self.assertEqual(support_binomial_mean(4, 99.0, "prior-clipped", 0.5), 4.0)
+        self.assertEqual(support_binomial_mean(4, 99.0, "midpoint", 0.5), 2.0)
+        self.assertEqual(support_binomial_mean(4, 4.0, "blend", 0.25), 2.5)
 
     def test_support_binomial_boundary_cache_records_support_interval(self):
         graph = DictGraph({"A": ["R"], "B": ["A", "R"]})
@@ -176,6 +185,8 @@ class BoundaryCacheBenchmarkTests(unittest.TestCase):
             max_histogram_bytes=24,
             parametric_bytes=8,
             parametric_shape_model="support-binomial",
+            parametric_mean_model="blend",
+            parametric_mean_blend=0.25,
             parametric_mass_model="oracle",
             max_parent_depth=4,
         )
@@ -183,6 +194,8 @@ class BoundaryCacheBenchmarkTests(unittest.TestCase):
         self.assertEqual(cache, {})
         self.assertTrue(rows[0]["parametric_cached"])
         self.assertEqual(rows[0]["parametric_shape_model"], "support-binomial")
+        self.assertEqual(rows[0]["parametric_mean_model"], "blend")
+        self.assertEqual(rows[0]["parametric_mean_blend"], 0.25)
         self.assertGreaterEqual(rows[0]["parametric_support_min"], rows[0]["histogram_L_min"])
         self.assertLessEqual(rows[0]["parametric_support_max"], rows[0]["histogram_L_max"])
         self.assertEqual(sum(parametric_cache["B"].values()), rows[0]["path_count"])


### PR DESCRIPTION
## Summary

Adds explicit mean rules for finite-support binomial parametric boundary states:

```text
--parametric-mean-model prior-clipped|midpoint|blend
--parametric-mean-blend <alpha>
```

For `support-binomial`, the mean can now be prior-clipped, support midpoint, or a blend of prior mean and midpoint. The old `support-binomial-midpoint` shape remains as a compatibility alias for midpoint.

Boundary rows now record the selected mean rule, blend alpha, chosen mean excess, and binomial probability.

## Key result

The d1 enwiki MTC oracle-mass sweep shows the raw prior mean is too large to mix aggressively. Midpoint remains the best simple baseline overall, while tiny prior weights are usable but not clearly better.

Budget 6:

| mean_model | alpha | mean_l1 | mean_cdf | mean_path_count_relative_error | mean_abs_path_delta | mean_param_bins_spliced |
|------------|------:|--------:|---------:|-------------------------------:|--------------------:|------------------------:|
| prior-clipped | n/a | 1.139211 | 0.694605 | 0.562386 | 12.250 | 0.000 |
| midpoint | n/a | 1.048619 | 0.524309 | 0.258724 | 5.750 | 7.375 |
| blend | 0.05 | 1.064968 | 0.529012 | 0.204151 | 3.750 | 5.500 |
| blend | 0.10 | 1.238579 | 0.619289 | 0.301660 | 6.750 | 3.250 |
| blend | 0.25 | 1.139211 | 0.694605 | 0.562386 | 12.250 | 0.000 |

Budget 8:

| mean_model | alpha | mean_l1 | mean_cdf | mean_path_count_relative_error | mean_abs_path_delta | mean_param_bins_spliced |
|------------|------:|--------:|---------:|-------------------------------:|--------------------:|------------------------:|
| prior-clipped | n/a | 1.002190 | 0.501026 | 0.290814 | 16.000 | 0.250 |
| midpoint | n/a | 0.957091 | 0.477349 | 0.159200 | 6.000 | 8.625 |
| blend | 0.05 | 1.004725 | 0.498352 | 0.184026 | 7.000 | 7.125 |
| blend | 0.10 | 1.040822 | 0.520411 | 0.232611 | 11.000 | 3.750 |
| blend | 0.25 | 1.002576 | 0.501026 | 0.286303 | 15.625 | 0.750 |

Alpha `0.50` and `0.75` collapse back to the prior-clipped behavior on this sample.

## Interpretation

The blend knob is useful for future sweeps, but a global alpha is not enough. A better next step is to normalize the prior mean relative to support width, or learn a bucketed alpha from boundary histograms.

## Validation

```bash
python3 -m unittest tests.test_lmdb_parent_boundary_cache_benchmark tests.test_lmdb_depth_planning_prior_probe tests.test_lmdb_parent_histogram_benchmark tests.test_lmdb_parent_branching_diagnostic
python3 -m py_compile scripts/lmdb_parent_boundary_cache_benchmark.py tests/test_lmdb_parent_boundary_cache_benchmark.py
git diff --check -- scripts/lmdb_parent_boundary_cache_benchmark.py tests/test_lmdb_parent_boundary_cache_benchmark.py docs/reports/lmdb_blended_support_binomial_mean_2026-06-12.md
```

Smoke outputs were written under:

```text
/mnt/c/Users/johnc/Scratch/blended-support-binomial-mean
```

## Worktree note

An unrelated local edit remains unstaged in `templates/targets/fsharp_wam/kernel_bidirectional_ancestor.fs.mustache`.