### PR TITLE
Grow WAM assoc i64 tables

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -256,8 +256,9 @@ the native streaming loop.
 Scalar counters lower through an explicit codegen state plan that keeps
 source-level state recognition separate from LLVM slot numbering. The current
 associative-count surface now allocates the reusable WAM/LLVM
-interned-atom-keyed `i64` table primitive (`wam_assoc_i64_*`), increments it in
-the native streaming loop, and performs `END` lookups through the same table.
+interned-atom-keyed growable `i64` table primitive (`wam_assoc_i64_*`),
+increments it in the native streaming loop, and performs `END` lookups through
+the same table.
 
 **Success:** a user-written awk-style program parses, lowers, compiles, and
 produces correct output on standard awk test cases.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -83,7 +83,7 @@ compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple
 guarded rules can update shared scalar slots before an `END` print. The first
 associative-count surface, `{ counts[$1]++ } END { print counts["ERROR"], counts["WARN"] }`,
 now uses the WAM/LLVM runtime's interned-atom-keyed `i64` table rather than
-specializing the `END` keys to fixed slots.
+specializing the `END` keys to fixed slots; the table grows and rehashes as needed.
 
 For a walkthrough of the current Prolog-core syntax and how it maps to awk
 concepts like `$0`, `$1`, `NR`, `NF`, `FS`, `OFS`, and `print`, see

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -160,7 +160,8 @@ END { print counts["ERROR"], counts["WARN"] }
 ```
 
 PLAWK interns the `$1` slice for each record and updates a native WAM/LLVM
-`i64` table keyed by that atom id. The `END` action looks up the printed keys:
+growable `i64` table keyed by that atom id. The `END` action looks up the
+printed keys:
 
 ```text
 2 1

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4006,6 +4006,120 @@ new.fail:
   ret %WamAssocI64Table* null
 }
 
+define i1 @wam_assoc_i64_resize(%WamAssocI64Table* %table) {
+entry:
+  %table_null = icmp eq %WamAssocI64Table* %table, null
+  br i1 %table_null, label %resize.fail, label %resize.load
+
+resize.load:
+  %old_cap_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 1
+  %old_cap = load i64, i64* %old_cap_slot
+  %old_cap_zero = icmp eq i64 %old_cap, 0
+  br i1 %old_cap_zero, label %resize.fail, label %resize.load_entries
+
+resize.load_entries:
+  %old_entries_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 2
+  %old_entries = load %WamAssocI64Entry*, %WamAssocI64Entry** %old_entries_slot
+  %old_entries_null = icmp eq %WamAssocI64Entry* %old_entries, null
+  br i1 %old_entries_null, label %resize.fail, label %resize.calc_cap
+
+resize.calc_cap:
+  %new_cap = mul i64 %old_cap, 2
+  %cap_grew = icmp ugt i64 %new_cap, %old_cap
+  br i1 %cap_grew, label %resize.alloc, label %resize.fail
+
+resize.alloc:
+  %entry_size = ptrtoint %WamAssocI64Entry* getelementptr (%WamAssocI64Entry, %WamAssocI64Entry* null, i32 1) to i64
+  %new_entries_size = mul i64 %new_cap, %entry_size
+  %new_entries_mem = call i8* @malloc(i64 %new_entries_size)
+  %new_entries_null = icmp eq i8* %new_entries_mem, null
+  br i1 %new_entries_null, label %resize.fail, label %resize.init
+
+resize.init:
+  %new_entries = bitcast i8* %new_entries_mem to %WamAssocI64Entry*
+  br label %resize.zero_loop
+
+resize.zero_loop:
+  %zi = phi i64 [ 0, %resize.init ], [ %zi.next, %resize.zero_body ]
+  %zi.done = icmp uge i64 %zi, %new_cap
+  br i1 %zi.done, label %resize.rehash_loop, label %resize.zero_body
+
+resize.zero_body:
+  %zero_entry = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %new_entries, i64 %zi
+  %zero_key_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %zero_entry, i32 0, i32 0
+  store i64 0, i64* %zero_key_slot
+  %zero_value_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %zero_entry, i32 0, i32 1
+  store i64 0, i64* %zero_value_slot
+  %zero_occupied_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %zero_entry, i32 0, i32 2
+  store i1 false, i1* %zero_occupied_slot
+  %zi.next = add i64 %zi, 1
+  br label %resize.zero_loop
+
+resize.rehash_loop:
+  %ri = phi i64 [ 0, %resize.zero_loop ], [ %ri.next, %resize.rehash_next ]
+  %ri.done = icmp uge i64 %ri, %old_cap
+  br i1 %ri.done, label %resize.install, label %resize.rehash_check
+
+resize.rehash_check:
+  %old_entry = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %old_entries, i64 %ri
+  %old_occupied_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %old_entry, i32 0, i32 2
+  %old_occupied = load i1, i1* %old_occupied_slot
+  br i1 %old_occupied, label %resize.rehash_key, label %resize.rehash_next
+
+resize.rehash_key:
+  %old_key_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %old_entry, i32 0, i32 0
+  %old_key = load i64, i64* %old_key_slot
+  %old_value_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %old_entry, i32 0, i32 1
+  %old_value = load i64, i64* %old_value_slot
+  %rehash_start = urem i64 %old_key, %new_cap
+  br label %resize.probe
+
+resize.probe:
+  %probe_idx = phi i64 [ %rehash_start, %resize.rehash_key ], [ %probe_next_idx, %resize.probe_next ]
+  %probe_count = phi i64 [ 0, %resize.rehash_key ], [ %probe_next_count, %resize.probe_next ]
+  %new_entry = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %new_entries, i64 %probe_idx
+  %new_occupied_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %new_entry, i32 0, i32 2
+  %new_occupied = load i1, i1* %new_occupied_slot
+  br i1 %new_occupied, label %resize.probe_check, label %resize.rehash_store
+
+resize.rehash_store:
+  %new_key_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %new_entry, i32 0, i32 0
+  store i64 %old_key, i64* %new_key_slot
+  %new_value_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %new_entry, i32 0, i32 1
+  store i64 %old_value, i64* %new_value_slot
+  store i1 true, i1* %new_occupied_slot
+  br label %resize.rehash_next
+
+resize.probe_check:
+  %probe_next_count = add i64 %probe_count, 1
+  %probe_full = icmp uge i64 %probe_next_count, %new_cap
+  br i1 %probe_full, label %resize.free_new_fail, label %resize.probe_next
+
+resize.probe_next:
+  %probe_idx_plus = add i64 %probe_idx, 1
+  %probe_wrap = icmp uge i64 %probe_idx_plus, %new_cap
+  %probe_next_idx = select i1 %probe_wrap, i64 0, i64 %probe_idx_plus
+  br label %resize.probe
+
+resize.rehash_next:
+  %ri.next = add i64 %ri, 1
+  br label %resize.rehash_loop
+
+resize.install:
+  store i64 %new_cap, i64* %old_cap_slot
+  store %WamAssocI64Entry* %new_entries, %WamAssocI64Entry** %old_entries_slot
+  %old_entries_i8 = bitcast %WamAssocI64Entry* %old_entries to i8*
+  call void @free(i8* %old_entries_i8)
+  ret i1 true
+
+resize.free_new_fail:
+  call void @free(i8* %new_entries_mem)
+  ret i1 false
+
+resize.fail:
+  ret i1 false
+}
+
 define i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 %key) {
 entry:
   %table_null = icmp eq %WamAssocI64Table* %table, null
@@ -4104,14 +4218,23 @@ inc.update:
   ret i64 %new_value
 
 inc.insert:
+  %count_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 0
+  %old_count = load i64, i64* %count_slot
+  %new_count = add i64 %old_count, 1
+  %half_cap = lshr i64 %cap, 1
+  %needs_grow = icmp ugt i64 %new_count, %half_cap
+  br i1 %needs_grow, label %inc.grow, label %inc.insert_store
+
+inc.grow:
+  %grew = call i1 @wam_assoc_i64_resize(%WamAssocI64Table* %table)
+  br i1 %grew, label %inc.load, label %inc.insert_store
+
+inc.insert_store:
   %insert_key_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 0
   store i64 %key, i64* %insert_key_slot
   %insert_value_slot = getelementptr %WamAssocI64Entry, %WamAssocI64Entry* %assoc_entry, i32 0, i32 1
   store i64 %delta, i64* %insert_value_slot
   store i1 true, i1* %occupied_slot
-  %count_slot = getelementptr %WamAssocI64Table, %WamAssocI64Table* %table, i32 0, i32 0
-  %old_count = load i64, i64* %count_slot
-  %new_count = add i64 %old_count, 1
   store i64 %new_count, i64* %count_slot
   ret i64 %delta
 

--- a/tests/core/test_wam_llvm_assoc_i64_runtime.pl
+++ b/tests/core/test_wam_llvm_assoc_i64_runtime.pl
@@ -21,11 +21,16 @@ clang_available :-
 :- begin_tests(wam_llvm_assoc_i64_runtime, [condition(clang_available)]).
 
 test(assoc_i64_counts_colliding_keys_and_missing_key) :-
-    run_assoc_i64_smoke.
+    assoc_i64_collision_driver_ir(DriverIR),
+    run_assoc_i64_smoke('uw_wam_assoc_i64_runtime', DriverIR).
 
-run_assoc_i64_smoke :-
+test(assoc_i64_resizes_across_many_numeric_keys) :-
+    assoc_i64_resize_stress_driver_ir(DriverIR),
+    run_assoc_i64_smoke('uw_wam_assoc_i64_resize_stress', DriverIR).
+
+run_assoc_i64_smoke(Name, DriverIR) :-
     tmp_root(Root),
-    directory_file_path(Root, 'uw_wam_assoc_i64_runtime', Dir),
+    directory_file_path(Root, Name, Dir),
     clean_dir(Dir),
     make_directory_path(Dir),
     directory_file_path(Dir, 'assoc_i64_runtime.ll', LLPath),
@@ -33,7 +38,6 @@ run_assoc_i64_smoke :-
         [ user:assoc_i64_marker/0 ],
         [ module_name('assoc_i64_runtime') ],
         LLPath),
-    assoc_i64_driver_ir(DriverIR),
     setup_call_cleanup(
         open(LLPath, append, Out, [encoding(utf8)]),
         ( nl(Out), write(Out, DriverIR) ),
@@ -53,7 +57,7 @@ run_assoc_i64_smoke :-
     ),
     !.
 
-assoc_i64_driver_ir('
+assoc_i64_collision_driver_ir('
 define i32 @main() {
 entry:
   %table = call %WamAssocI64Table* @wam_assoc_i64_new(i64 4)
@@ -61,18 +65,68 @@ entry:
   br i1 %table_null, label %alloc_fail, label %exercise
 
 exercise:
-  ; 1 and 5 collide when capacity is 4, so this also covers probing.
+  ; 1, 5, and 9 collide when capacity is 4. The third unique key also crosses
+  ; the table growth threshold, so subsequent lookups prove resize rehashing.
   %a1 = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 1, i64 1)
   %a2 = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 1, i64 1)
   %b1 = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 5, i64 1)
+  %c1 = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 9, i64 1)
   %got_a = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 1)
   %got_b = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 5)
-  %got_missing = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 9)
+  %got_c = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 9)
+  %got_missing = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 13)
   %a_ok = icmp eq i64 %got_a, 2
   %b_ok = icmp eq i64 %got_b, 1
+  %c_ok = icmp eq i64 %got_c, 1
   %missing_ok = icmp eq i64 %got_missing, 0
   %ab_ok = and i1 %a_ok, %b_ok
-  %all_ok = and i1 %ab_ok, %missing_ok
+  %abc_ok = and i1 %ab_ok, %c_ok
+  %all_ok = and i1 %abc_ok, %missing_ok
+  call void @wam_assoc_i64_free(%WamAssocI64Table* %table)
+  br i1 %all_ok, label %ok, label %bad_counts
+
+ok:
+  ret i32 0
+
+alloc_fail:
+  ret i32 90
+
+bad_counts:
+  ret i32 91
+}
+').
+
+assoc_i64_resize_stress_driver_ir('
+define i32 @main() {
+entry:
+  %table = call %WamAssocI64Table* @wam_assoc_i64_new(i64 4)
+  %table_null = icmp eq %WamAssocI64Table* %table, null
+  br i1 %table_null, label %alloc_fail, label %insert_loop
+
+insert_loop:
+  %i = phi i64 [ 0, %entry ], [ %i_next, %insert_step ]
+  %done = icmp uge i64 %i, 3000
+  br i1 %done, label %check_counts, label %insert_body
+
+insert_body:
+  %inserted = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 %i, i64 1)
+  %insert_ok = icmp eq i64 %inserted, 1
+  br i1 %insert_ok, label %insert_step, label %bad_counts
+
+insert_step:
+  %i_next = add i64 %i, 1
+  br label %insert_loop
+
+check_counts:
+  %zero_again = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %table, i64 0, i64 1)
+  %got_zero = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 0)
+  %got_last = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 2999)
+  %got_missing = call i64 @wam_assoc_i64_get(%WamAssocI64Table* %table, i64 4000)
+  %zero_ok = icmp eq i64 %got_zero, 2
+  %last_ok = icmp eq i64 %got_last, 1
+  %missing_ok = icmp eq i64 %got_missing, 0
+  %zl_ok = and i1 %zero_ok, %last_ok
+  %all_ok = and i1 %zl_ok, %missing_ok
   call void @wam_assoc_i64_free(%WamAssocI64Table* %table)
   br i1 %all_ok, label %ok, label %bad_counts
 

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -198,6 +198,7 @@ test(full_runtime_generation) :-
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamSlice @wam_atom_field_slice_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_prefix_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamAssocI64Table* @wam_assoc_i64_new')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_assoc_i64_resize')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_assoc_i64_inc')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_assoc_i64_get')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define void @wam_assoc_i64_free')).


### PR DESCRIPTION
## Summary

- Add `@wam_assoc_i64_resize` to double and rehash interned-atom-keyed `i64` tables.
- Grow tables before inserts cross the 50% load threshold while preserving the existing `wam_assoc_i64_inc/get/free` API.
- Extend low-level LLVM runtime smokes to cover resize rehashing and thousands of numeric keys.
- Update PLAWK docs to describe the associative-count table as growable.

## Validation

- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `git diff --cached --check`
- `git diff --check`

Note: `tests/test_wam_llvm_target.pl` still reports existing SWI choicepoint warnings, but exits successfully.

## Follow-up

While trying to add a PLAWK high-cardinality smoke, ASAN showed an unrelated `wam_stream_read_line_value` arena issue: the reader allocates a 65 KiB arena buffer per line and does not handle arena exhaustion. The backend assoc table resize is covered directly here; the stream-reader memory behavior should be the next separate slice.