### PR TITLE
Use malloc buffer for streamed lines

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -156,8 +156,9 @@ The first WAM/LLVM probes now live under `examples/plawk/probes/`.
   atoms without the trailing newline, and unifies `end_of_file` at EOF rather
   than failing. The reader probe emits
   `examples/plawk/generated/plawk_reader_probe.ll` and verifies with `llvm-as`.
-  Current limitation: line atoms are capped at 64 KiB until the output buffer is
-  made growable.
+  `read_line/2` builds each output line in a malloc-owned temporary buffer before
+  interning, so long streams do not consume WAM arena space per record. Current
+  limitation: line atoms are capped at 64 KiB until the output buffer is growable.
 - **Compiled stream-core smoke:** `tests/test_plawk_compiled_stream_core.pl`
   builds a native LLVM binary that streams a text file, splits records with
   `atom_split/3`, runs a PLAWK-style handler over `record(text, Line, Fields)`,

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -83,7 +83,8 @@ compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple
 guarded rules can update shared scalar slots before an `END` print. The first
 associative-count surface, `{ counts[$1]++ } END { print counts["ERROR"], counts["WARN"] }`,
 now uses the WAM/LLVM runtime's interned-atom-keyed `i64` table rather than
-specializing the `END` keys to fixed slots; the table grows and rehashes as needed.
+specializing the `END` keys to fixed slots; the table grows and rehashes as
+needed, and the native stream reader no longer consumes WAM arena space per line.
 
 For a walkthrough of the current Prolog-core syntax and how it maps to awk
 concepts like `$0`, `$1`, `NR`, `NF`, `FS`, `OFS`, and `print`, see

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4388,9 +4388,9 @@ rhv.have_handle:
   br i1 %rhv.fd_ok, label %rhv.alloc_out, label %rhv.fail
 
 rhv.alloc_out:
-  call void @wam_arena_ensure()
-  %rhv.out = call i8* @wam_arena_alloc(i64 65537)
-  br label %rhv.loop
+  %rhv.out = call i8* @malloc(i64 65537)
+  %rhv.out_null = icmp eq i8* %rhv.out, null
+  br i1 %rhv.out_null, label %rhv.fail, label %rhv.loop
 
 rhv.loop:
   %rhv.out_len = phi i64 [ 0, %rhv.alloc_out ], [ %rhv.out_len, %rhv.after_read ], [ %rhv.next_out_len, %rhv.append_store ]
@@ -4408,7 +4408,7 @@ rhv.fill:
   %rhv.cap = load i64, i64* %rhv.cap_slot
   %rhv.n = call i64 @read(i32 %rhv.fd, i8* %rhv.buf, i64 %rhv.cap)
   %rhv.n_neg = icmp slt i64 %rhv.n, 0
-  br i1 %rhv.n_neg, label %rhv.fail, label %rhv.check_eof
+  br i1 %rhv.n_neg, label %rhv.free_out_fail, label %rhv.check_eof
 
 rhv.check_eof:
   %rhv.n_zero = icmp eq i64 %rhv.n, 0
@@ -4433,7 +4433,7 @@ rhv.consume:
 
 rhv.append:
   %rhv.has_room = icmp ult i64 %rhv.out_len, 65536
-  br i1 %rhv.has_room, label %rhv.append_store, label %rhv.fail
+  br i1 %rhv.has_room, label %rhv.append_store, label %rhv.free_out_fail
 
 rhv.append_store:
   %rhv.out_ptr = getelementptr i8, i8* %rhv.out, i64 %rhv.out_len
@@ -4463,14 +4463,20 @@ rhv.intern:
   %rhv.aid = call i64 @wam_intern_atom(i8* %rhv.out, i64 %rhv.final_len)
   %rhv.v0 = insertvalue %Value undef, i32 0, 0
   %rhv.v = insertvalue %Value %rhv.v0, i64 %rhv.aid, 1
+  call void @free(i8* %rhv.out)
   ret %Value %rhv.v
 
 rhv.eof:
+  call void @free(i8* %rhv.out)
   %rhv.eof_ptr = getelementptr [12 x i8], [12 x i8]* @.wam_stream_eof_atom, i32 0, i32 0
   %rhv.eof_aid = call i64 @wam_intern_atom(i8* %rhv.eof_ptr, i64 11)
   %rhv.eof_v0 = insertvalue %Value undef, i32 0, 0
   %rhv.eof_v = insertvalue %Value %rhv.eof_v0, i64 %rhv.eof_aid, 1
   ret %Value %rhv.eof_v
+
+rhv.free_out_fail:
+  call void @free(i8* %rhv.out)
+  br label %rhv.fail
 }
 
 define i1 @wam_stream_close_value(%Value %handle_value) {

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -97,6 +97,15 @@ test(surface_assoc_counts_requested_keys) :-
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "2 1\n").
 
+test(surface_assoc_counts_resize_runtime_table) :-
+    findall(Line,
+        ( between(0, 2050, Index), format(atom(Line), 'K~w payload\n', [Index]) ),
+        Lines),
+    atomic_list_concat(Lines, '', Input0),
+    format(string(Input), '~wK0 duplicate~n', [Input0]),
+    run_surface_print_smoke("{ counts[$1]++ } END { print counts[\"K0\"], counts[\"K2050\"], counts[\"MISSING\"] }\n",
+        Input, "2 1 0\n").
+
 test(surface_assoc_counts_use_runtime_table) :-
     plawk_parse_string("{ counts[$1]++ } END { print counts[\"ERROR\"], counts[\"WARN\"] }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),


### PR DESCRIPTION
## Summary

- Change `wam_stream_read_line_value` to build each output line in a malloc-owned temporary buffer instead of allocating 65 KiB from the WAM arena per record.
- Free the temporary buffer after interning, at EOF, and on read/line-length failure paths.
- Restore the high-cardinality PLAWK associative-count smoke that previously crashed after enough streamed records.
- Update PLAWK docs to note that native stream reads no longer consume WAM arena space per line.

## Validation

- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests([plawk_surface_prefix_print:surface_assoc_counts_resize_runtime_table])" -t halt`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s tests/test_plawk_native_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- ASAN rebuild/run of the generated high-cardinality PLAWK binary now exits 0 and prints `2 1 0`.
- `git diff --cached --check`
- `git diff --check`

Note: `tests/test_wam_llvm_target.pl` still reports existing SWI choicepoint warnings, but exits successfully.