### PR TITLE
Grow streamed line output buffers

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -157,8 +157,8 @@ The first WAM/LLVM probes now live under `examples/plawk/probes/`.
   than failing. The reader probe emits
   `examples/plawk/generated/plawk_reader_probe.ll` and verifies with `llvm-as`.
   `read_line/2` builds each output line in a malloc-owned temporary buffer before
-  interning, so long streams do not consume WAM arena space per record. Current
-  limitation: line atoms are capped at 64 KiB until the output buffer is growable.
+  interning, growing the buffer as needed, so long streams do not consume WAM
+  arena space per record and individual line atoms are not capped at 64 KiB.
 - **Compiled stream-core smoke:** `tests/test_plawk_compiled_stream_core.pl`
   builds a native LLVM binary that streams a text file, splits records with
   `atom_split/3`, runs a PLAWK-style handler over `record(text, Line, Fields)`,

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -84,7 +84,8 @@ guarded rules can update shared scalar slots before an `END` print. The first
 associative-count surface, `{ counts[$1]++ } END { print counts["ERROR"], counts["WARN"] }`,
 now uses the WAM/LLVM runtime's interned-atom-keyed `i64` table rather than
 specializing the `END` keys to fixed slots; the table grows and rehashes as
-needed, and the native stream reader no longer consumes WAM arena space per line.
+needed, and the native stream reader grows its line buffer without consuming WAM
+arena space per record.
 
 For a walkthrough of the current Prolog-core syntax and how it maps to awk
 concepts like `$0`, `$1`, `NR`, `NF`, `FS`, `OFS`, and `print`, see

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4388,12 +4388,14 @@ rhv.have_handle:
   br i1 %rhv.fd_ok, label %rhv.alloc_out, label %rhv.fail
 
 rhv.alloc_out:
-  %rhv.out = call i8* @malloc(i64 65537)
+  %rhv.out = call i8* @malloc(i64 4096)
   %rhv.out_null = icmp eq i8* %rhv.out, null
   br i1 %rhv.out_null, label %rhv.fail, label %rhv.loop
 
 rhv.loop:
   %rhv.out_len = phi i64 [ 0, %rhv.alloc_out ], [ %rhv.out_len, %rhv.after_read ], [ %rhv.next_out_len, %rhv.append_store ]
+  %rhv.out_cur = phi i8* [ %rhv.out, %rhv.alloc_out ], [ %rhv.out_cur, %rhv.after_read ], [ %rhv.append_out, %rhv.append_store ]
+  %rhv.out_cap = phi i64 [ 4096, %rhv.alloc_out ], [ %rhv.out_cap, %rhv.after_read ], [ %rhv.append_cap, %rhv.append_store ]
   %rhv.buf_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 1
   %rhv.buf = load i8*, i8** %rhv.buf_slot
   %rhv.len_slot = getelementptr %WamLineReader, %WamLineReader* %rhv.reader, i32 0, i32 3
@@ -4432,11 +4434,24 @@ rhv.consume:
   br i1 %rhv.is_lf, label %rhv.finalize, label %rhv.append
 
 rhv.append:
-  %rhv.has_room = icmp ult i64 %rhv.out_len, 65536
-  br i1 %rhv.has_room, label %rhv.append_store, label %rhv.free_out_fail
+  %rhv.next_out_len_pre = add i64 %rhv.out_len, 1
+  %rhv.has_room = icmp ult i64 %rhv.next_out_len_pre, %rhv.out_cap
+  br i1 %rhv.has_room, label %rhv.append_store, label %rhv.grow_out
+
+rhv.grow_out:
+  %rhv.new_out_cap = shl i64 %rhv.out_cap, 1
+  %rhv.cap_grew = icmp ugt i64 %rhv.new_out_cap, %rhv.out_cap
+  br i1 %rhv.cap_grew, label %rhv.grow_alloc, label %rhv.free_out_fail
+
+rhv.grow_alloc:
+  %rhv.grown_out = call i8* @realloc(i8* %rhv.out_cur, i64 %rhv.new_out_cap)
+  %rhv.grown_null = icmp eq i8* %rhv.grown_out, null
+  br i1 %rhv.grown_null, label %rhv.free_out_fail, label %rhv.append_store
 
 rhv.append_store:
-  %rhv.out_ptr = getelementptr i8, i8* %rhv.out, i64 %rhv.out_len
+  %rhv.append_out = phi i8* [ %rhv.out_cur, %rhv.append ], [ %rhv.grown_out, %rhv.grow_alloc ]
+  %rhv.append_cap = phi i64 [ %rhv.out_cap, %rhv.append ], [ %rhv.new_out_cap, %rhv.grow_alloc ]
+  %rhv.out_ptr = getelementptr i8, i8* %rhv.append_out, i64 %rhv.out_len
   store i8 %rhv.ch, i8* %rhv.out_ptr
   %rhv.next_out_len = add i64 %rhv.out_len, 1
   br label %rhv.loop
@@ -4447,7 +4462,7 @@ rhv.finalize:
 
 rhv.check_cr:
   %rhv.last_idx = sub i64 %rhv.out_len, 1
-  %rhv.last_ptr = getelementptr i8, i8* %rhv.out, i64 %rhv.last_idx
+  %rhv.last_ptr = getelementptr i8, i8* %rhv.out_cur, i64 %rhv.last_idx
   %rhv.last = load i8, i8* %rhv.last_ptr
   %rhv.last_is_cr = icmp eq i8 %rhv.last, 13
   %rhv.trim_len = select i1 %rhv.last_is_cr, i64 %rhv.last_idx, i64 %rhv.out_len
@@ -4458,16 +4473,16 @@ rhv.intern_empty:
 
 rhv.intern:
   %rhv.final_len = phi i64 [ %rhv.trim_len, %rhv.check_cr ], [ 0, %rhv.intern_empty ]
-  %rhv.term = getelementptr i8, i8* %rhv.out, i64 %rhv.final_len
+  %rhv.term = getelementptr i8, i8* %rhv.out_cur, i64 %rhv.final_len
   store i8 0, i8* %rhv.term
-  %rhv.aid = call i64 @wam_intern_atom(i8* %rhv.out, i64 %rhv.final_len)
+  %rhv.aid = call i64 @wam_intern_atom(i8* %rhv.out_cur, i64 %rhv.final_len)
   %rhv.v0 = insertvalue %Value undef, i32 0, 0
   %rhv.v = insertvalue %Value %rhv.v0, i64 %rhv.aid, 1
-  call void @free(i8* %rhv.out)
+  call void @free(i8* %rhv.out_cur)
   ret %Value %rhv.v
 
 rhv.eof:
-  call void @free(i8* %rhv.out)
+  call void @free(i8* %rhv.out_cur)
   %rhv.eof_ptr = getelementptr [12 x i8], [12 x i8]* @.wam_stream_eof_atom, i32 0, i32 0
   %rhv.eof_aid = call i64 @wam_intern_atom(i8* %rhv.eof_ptr, i64 11)
   %rhv.eof_v0 = insertvalue %Value undef, i32 0, 0
@@ -4475,7 +4490,8 @@ rhv.eof:
   ret %Value %rhv.eof_v
 
 rhv.free_out_fail:
-  call void @free(i8* %rhv.out)
+  %rhv.fail_out = phi i8* [ %rhv.out_cur, %rhv.fill ], [ %rhv.out_cur, %rhv.grow_out ], [ %rhv.out_cur, %rhv.grow_alloc ]
+  call void @free(i8* %rhv.fail_out)
   br label %rhv.fail
 }
 

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -106,6 +106,12 @@ test(surface_assoc_counts_resize_runtime_table) :-
     run_surface_print_smoke("{ counts[$1]++ } END { print counts[\"K0\"], counts[\"K2050\"], counts[\"MISSING\"] }\n",
         Input, "2 1 0\n").
 
+test(surface_assoc_counts_long_record_first_field) :-
+    plawk_long_payload_string(70000, Payload),
+    format(string(Input), 'KEY ~w~n', [Payload]),
+    run_surface_print_smoke("{ counts[$1]++ } END { print counts[\"KEY\"] }\n",
+        Input, "1\n").
+
 test(surface_assoc_counts_use_runtime_table) :-
     plawk_parse_string("{ counts[$1]++ } END { print counts[\"ERROR\"], counts[\"WARN\"] }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
@@ -153,5 +159,10 @@ run_surface_print_smoke(Source, Input, ExpectedOutput) :-
        throw(plawk_surface_prefix_print_failed(Status))
     ),
     !.
+
+plawk_long_payload_string(Length, String) :-
+    length(Codes, Length),
+    maplist(=(0'a), Codes),
+    string_codes(String, Codes).
 
 :- end_tests(plawk_surface_prefix_print).

--- a/tests/test_wam_llvm_stream_runtime.pl
+++ b/tests/test_wam_llvm_stream_runtime.pl
@@ -62,7 +62,47 @@ test(stream_open_read_line_close_executes) :-
     ),
     !.
 
+test(stream_read_line_value_grows_output_buffer) :-
+    tmp_root(Root),
+    directory_file_path(Root, 'uw_wam_llvm_stream_runtime_long_line', Dir),
+    clean_dir(Dir),
+    make_directory_path(Dir),
+    directory_file_path(Dir, 'input.txt', InputPath),
+    long_line_string(70000, LongLine),
+    setup_call_cleanup(
+        open(InputPath, write, In, [type(binary)]),
+        format(In, '~s\n', [LongLine]),
+        close(In)),
+    directory_file_path(Dir, 'stream_long_line.ll', LLPath),
+    write_wam_llvm_project(
+        [user:llvm_stream_reader_probe/4],
+        [module_name('stream_long_line')], LLPath),
+    stream_long_line_driver_ir(InputPath, 70000, DriverIR),
+    setup_call_cleanup(
+        open(LLPath, append, Out, [encoding(utf8)]),
+        ( nl(Out), write(Out, DriverIR) ),
+        close(Out)),
+    directory_file_path(Dir, 'stream_long_line_bin', BinPath),
+    format(atom(Cmd), 'clang -w ~w -o ~w -lm 2>&1 && ~w',
+        [LLPath, BinPath, BinPath]),
+    process_create(path(sh), ['-c', Cmd],
+                   [stdout(pipe(Stdout)), stderr(std), process(Pid)]),
+    read_string(Stdout, _, OutStr),
+    close(Stdout),
+    process_wait(Pid, Status),
+    ( Status == exit(0)
+    -> true
+    ;  format(user_error, "~n[llvm stream long-line output]~n~w~n", [OutStr]),
+       throw(llvm_stream_long_line_failed(Status))
+    ),
+    !.
+
 :- end_tests(wam_llvm_stream_runtime).
+
+long_line_string(Length, String) :-
+    length(Codes, Length),
+    maplist(=(0'a), Codes),
+    string_codes(String, Codes).
 
 stream_driver_ir(InputPath, DriverIR) :-
     atom_codes(InputPath, PathCodes),
@@ -167,6 +207,76 @@ fail_eof:
 ',
         [BytesLen, PathBytes,
          BytesLen, BytesLen, PathLen]).
+
+stream_long_line_driver_ir(InputPath, ExpectedLen, DriverIR) :-
+    atom_codes(InputPath, PathCodes),
+    length(PathCodes, PathLen),
+    BytesLen is PathLen + 1,
+    llvm_c_bytes(PathCodes, PathBytes),
+    format(atom(DriverIR),
+'@.stream_long_line_path = private constant [~w x i8] c"~w\\00"
+
+define i32 @main() {
+entry:
+  %path_ptr = getelementptr [~w x i8], [~w x i8]* @.stream_long_line_path, i32 0, i32 0
+  %path_id = call i64 @wam_intern_atom(i8* %path_ptr, i64 ~w)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+  %handle = call %Value @wam_stream_open_value(%Value %path)
+  %handle_tag = extractvalue %Value %handle, 0
+  %handle_is_int = icmp eq i32 %handle_tag, 1
+  br i1 %handle_is_int, label %check_handle_value, label %fail_open
+
+check_handle_value:
+  %handle_payload = extractvalue %Value %handle, 1
+  %handle_ok = icmp sgt i64 %handle_payload, 0
+  br i1 %handle_ok, label %read_line, label %fail_open
+
+read_line:
+  %line = call %Value @wam_stream_read_line_value(%Value %handle)
+  %line_tag = extractvalue %Value %line, 0
+  %line_is_atom = icmp eq i32 %line_tag, 0
+  br i1 %line_is_atom, label %check_length, label %fail_line_tag
+
+check_length:
+  %line_payload = extractvalue %Value %line, 1
+  %line_s = call i8* @wam_atom_to_string(i64 %line_payload)
+  %line_null = icmp eq i8* %line_s, null
+  br i1 %line_null, label %fail_line_null, label %strlen_line
+
+strlen_line:
+  %line_len = call i64 @strlen(i8* %line_s)
+  %len_ok = icmp eq i64 %line_len, ~w
+  br i1 %len_ok, label %close_stream, label %fail_length
+
+close_stream:
+  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %close_ok, label %success, label %fail_close
+
+success:
+  ret i32 0
+
+fail_open:
+  ret i32 10
+
+fail_line_tag:
+  %close_ignore_line_tag = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 11
+
+fail_line_null:
+  %close_ignore_line_null = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 12
+
+fail_length:
+  %close_ignore_length = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 13
+
+fail_close:
+  ret i32 14
+}
+',
+        [BytesLen, PathBytes,
+         BytesLen, BytesLen, PathLen, ExpectedLen]).
 
 llvm_c_bytes([], '').
 llvm_c_bytes([Code | Rest], Bytes) :-


### PR DESCRIPTION
## Summary

- Make `wam_stream_read_line_value` grow its malloc-owned output buffer with `realloc` instead of using a fixed 64 KiB line buffer.
- Preserve null-termination space while appending bytes and continue freeing buffers on success, EOF, and failure paths.
- Add a native stream smoke for a 70,000-byte line and a PLAWK smoke that extracts `$1` from a long record.
- Update PLAWK docs to remove the 64 KiB line-cap note.

## Validation

- `swipl -q -s tests/test_wam_llvm_stream_runtime.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests([wam_llvm_stream_runtime:stream_read_line_value_grows_output_buffer])" -t halt`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests([plawk_surface_prefix_print:surface_assoc_counts_long_record_first_field])" -t halt`
- `swipl -q -s tests/test_wam_llvm_stream_runtime.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_native_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- ASAN rebuild/run of the generated long-line stream binary exits 0.
- `git diff --cached --check`
- `git diff --check`

Note: `tests/test_wam_llvm_target.pl` still reports existing SWI choicepoint warnings, but exits successfully.