### PR TITLE
Add recurrence boundary builder

### DIFF
--- a/docs/reports/lmdb_recurrence_boundary_builder_2026-06-12.md
+++ b/docs/reports/lmdb_recurrence_boundary_builder_2026-06-12.md
@@ -1,0 +1,41 @@
+# LMDB Recurrence Boundary Builder Smoke
+
+Date: 2026-06-12
+
+This smoke compares boundary-cache precomputation with the existing bounded
+parent-path search builder and the shifted parent-histogram recurrence builder.
+The recurrence builder keeps histograms unnormalized: every bin stores path
+count mass.  If a future storage layer uses normalized distributions, each
+shifted parent distribution must be multiplied by its parent path mass `N_p`
+before summing, and the resulting `N_v` must be stored separately.
+
+Common setup:
+
+```text
+--lmdb-dir /home/s243a/Projects/UnifyWeaver/data/benchmark/enwiki_cats_correct/lmdb_resident
+--root 7345184
+--boundary-depths 1
+--target-depths 2
+--children-per-node 32
+--frontier-limit 256
+--boundaries-per-depth 12
+--targets-per-depth 6
+--boundary-budget 6
+--budgets 6
+--path-cap 20000
+--expansion-cap 50000
+--seed enwiki-mtc-recurrence-boundary-v1
+--admission-policy baseline
+```
+
+| boundary_builder | boundary_nodes | cached_boundary_nodes | mean_hist_paths | mean_hist_bins | mean_nodes_or_states | mean_edges_examined | cycle_approximation | mean_l1 | mean_cdf | mean_path_relative_error |
+|------------------|---------------:|----------------------:|----------------:|---------------:|---------------------:|--------------------:|--------------------:|--------:|---------:|-------------------------:|
+| search | 12 | 12 | 7.750 | 3.667 | 14502.250 | 18762.250 | 0 | 0.000000 | 0.000000 | 0.000000 |
+| recurrence | 12 | 12 | 7.750 | 3.667 | 171.500 | 792.917 | 11 | 0.000000 | 0.000000 | 0.000000 |
+
+On this sample the recurrence-built boundary cache produced the same downstream
+target-search histograms as the search-built boundary cache while reducing the
+boundary precompute work by roughly two orders of magnitude.  The recurrence
+builder reported cycle approximation on 11 of 12 boundary rows; this is expected
+for enwiki category cones and should remain visible in reports because a
+node-only recurrence cannot encode the full simple-path visited set.

--- a/scripts/lmdb_parent_boundary_cache_benchmark.py
+++ b/scripts/lmdb_parent_boundary_cache_benchmark.py
@@ -46,6 +46,7 @@ from scripts.lmdb_parent_histogram_benchmark import (
     percentile,
     safe_graph_name,
 )
+from scripts.parent_histogram_recurrence import recurrence_parent_histogram
 
 
 DEFAULT_BUDGETS = [6, 8]
@@ -65,6 +66,47 @@ class CachedSearchStats:
     parametric_bins_spliced: int = 0
     path_cap_hit: bool = False
     expansion_cap_hit: bool = False
+
+
+@dataclass
+class BoundaryBuildResult:
+    histogram: dict
+    nodes_expanded: int
+    edges_examined: int
+    cycle_skips: int
+    path_cap_hit: bool
+    expansion_cap_hit: bool
+    recurrence_cycle_approximation: bool = False
+    recurrence_states_evaluated: int | None = None
+    recurrence_memo_hits: int | None = None
+
+
+def build_boundary_histogram(parents_func, node, root, budget, path_cap, expansion_cap, boundary_builder):
+    """Build one boundary histogram by search or shifted parent recurrence."""
+    if boundary_builder == "search":
+        hist, stats = bounded_parent_histogram(parents_func, node, root, budget, path_cap, expansion_cap)
+        return BoundaryBuildResult(
+            histogram=hist,
+            nodes_expanded=stats.nodes_expanded,
+            edges_examined=stats.edges_examined,
+            cycle_skips=stats.cycle_skips,
+            path_cap_hit=stats.path_cap_hit,
+            expansion_cap_hit=stats.expansion_cap_hit,
+        )
+    if boundary_builder == "recurrence":
+        hist, stats = recurrence_parent_histogram(parents_func, node, root, budget, path_cap, expansion_cap)
+        return BoundaryBuildResult(
+            histogram=hist,
+            nodes_expanded=stats.states_evaluated,
+            edges_examined=stats.edges_examined,
+            cycle_skips=stats.cycle_edges,
+            path_cap_hit=stats.path_cap_hit,
+            expansion_cap_hit=stats.expansion_cap_hit,
+            recurrence_cycle_approximation=stats.cycle_approximation,
+            recurrence_states_evaluated=stats.states_evaluated,
+            recurrence_memo_hits=stats.memo_hits,
+        )
+    raise ValueError("unknown boundary builder: {}".format(boundary_builder))
 
 
 def scaled_distribution_histogram(probabilities, origin, total_count):
@@ -343,6 +385,7 @@ def build_boundary_cache(
     parametric_mass_cap=1000000,
     tail_epsilon=0.001,
     max_parent_depth=24,
+    boundary_builder="search",
 ):
     cache = {}
     parametric_cache = {}
@@ -350,8 +393,9 @@ def build_boundary_cache(
     distance_memo = {}
     for node in boundary_nodes:
         started = time.perf_counter_ns()
-        hist, stats = bounded_parent_histogram(graph.parents, node, root, boundary_budget, path_cap, expansion_cap)
+        built = build_boundary_histogram(graph.parents, node, root, boundary_budget, path_cap, expansion_cap, boundary_builder)
         elapsed = time.perf_counter_ns() - started
+        hist = built.histogram
         distances = root_distances(node, root, graph.parents, max_parent_depth, distance_memo)
         rows.append({
             "record_type": "boundary_cache_entry",
@@ -374,12 +418,16 @@ def build_boundary_cache(
                 max_parent_depth,
                 distance_memo,
             ),
-            "nodes_expanded": stats.nodes_expanded,
-            "edges_examined": stats.edges_examined,
-            "cycle_skips": stats.cycle_skips,
-            "path_cap_hit": stats.path_cap_hit,
-            "expansion_cap_hit": stats.expansion_cap_hit,
+            "boundary_builder": boundary_builder,
+            "nodes_expanded": built.nodes_expanded,
+            "edges_examined": built.edges_examined,
+            "cycle_skips": built.cycle_skips,
+            "path_cap_hit": built.path_cap_hit,
+            "expansion_cap_hit": built.expansion_cap_hit,
             "histogram_time_ns": elapsed,
+            "recurrence_cycle_approximation": built.recurrence_cycle_approximation,
+            "recurrence_states_evaluated": built.recurrence_states_evaluated,
+            "recurrence_memo_hits": built.recurrence_memo_hits,
         })
 
     priors = {}
@@ -398,8 +446,12 @@ def build_boundary_cache(
         lmax = row["histogram_L_max"]
         if admission_policy == "baseline":
             cached = bool(hist) and not row["path_cap_hit"] and not row["expansion_cap_hit"]
-            action = "materialize_exact" if cached else "skip_cache"
-            reason = "baseline_uncapped_histogram" if cached else "baseline_empty_or_capped"
+            if cached and row["recurrence_cycle_approximation"]:
+                action = "materialize_capped"
+                reason = "baseline_recurrence_cycle_approximation"
+            else:
+                action = "materialize_exact" if cached else "skip_cache"
+                reason = "baseline_uncapped_histogram" if cached else "baseline_empty_or_capped"
             policy = {
                 "action": action,
                 "reason": reason,
@@ -419,7 +471,7 @@ def build_boundary_cache(
                 safety_factor,
                 max_histogram_bytes,
                 recurrence_capped=row["path_cap_hit"] or row["expansion_cap_hit"],
-                recurrence_cycle_approximation=row["cycle_skips"] > 0,
+                recurrence_cycle_approximation=row["recurrence_cycle_approximation"],
                 realized_histogram_bytes=row["histogram_bytes"],
                 parametric_bytes=parametric_bytes,
             )
@@ -618,6 +670,7 @@ def run_benchmark(args):
             args.parametric_mass_cap,
             args.tail_epsilon,
             args.max_parent_depth,
+            args.boundary_builder,
         )
         records = [{
             "record_type": "boundary_cache_selection",
@@ -632,6 +685,7 @@ def run_benchmark(args):
             "budgets": budgets,
             "boundary_budget": args.boundary_budget,
             "admission_policy": args.admission_policy,
+            "boundary_builder": args.boundary_builder,
             "safety_factor": args.safety_factor,
             "max_histogram_bytes": args.max_histogram_bytes,
             "parametric_bytes": args.parametric_bytes,
@@ -709,14 +763,15 @@ def summarize(records):
         lines.append("| target | {} | {} |".format(depth, count))
     lines.extend([
         "",
-        "| boundary_nodes | cached_boundary_nodes | parametric_boundary_nodes | targets | boundary_budget |",
-        "|----------------|-----------------------|---------------------------|---------|-----------------|",
-        "| {} | {} | {} | {} | {} |".format(
+        "| boundary_nodes | cached_boundary_nodes | parametric_boundary_nodes | targets | boundary_budget | boundary_builder |",
+        "|----------------|-----------------------|---------------------------|---------|-----------------|------------------|",
+        "| {} | {} | {} | {} | {} | {} |".format(
             selection.get("boundary_nodes", 0),
             selection.get("cached_boundary_nodes", 0),
             selection.get("parametric_boundary_nodes", 0),
             selection.get("targets", 0),
             selection.get("boundary_budget", 0),
+            selection.get("boundary_builder", "search"),
         ),
         "",
         "## Admission Policy",
@@ -797,6 +852,27 @@ def summarize(records):
                 statistics.mean(max_delta) if max_delta else 0.0,
                 sum(1 for row in rows if row.get("parametric_support_truncated")),
                 sum(1 for row in rows if row.get("parametric_support_cycle_skipped")),
+            ))
+    builder_rows = {}
+    for row in cache_rows:
+        builder_rows.setdefault(row.get("boundary_builder", "search"), []).append(row)
+    if builder_rows:
+        lines.extend([
+            "",
+            "## Boundary Builders",
+            "",
+            "| builder | rows | mean_nodes_or_states | mean_edges_examined | cycle_approximation | capped |",
+            "|---------|-----:|---------------------:|--------------------:|--------------------:|-------:|",
+        ])
+        for builder in sorted(builder_rows):
+            rows = builder_rows[builder]
+            lines.append("| {} | {} | {:.3f} | {:.3f} | {} | {} |".format(
+                builder,
+                len(rows),
+                statistics.mean(int(row["nodes_expanded"]) for row in rows) if rows else 0.0,
+                statistics.mean(int(row["edges_examined"]) for row in rows) if rows else 0.0,
+                sum(1 for row in rows if row.get("recurrence_cycle_approximation")),
+                sum(1 for row in rows if row.get("path_cap_hit") or row.get("expansion_cap_hit")),
             ))
     lines.extend([
         "",
@@ -897,6 +973,7 @@ def main(argv=None):
     parser.add_argument("--boundaries-per-depth", type=int, default=100, help="Boundary cache candidates per requested boundary depth.")
     parser.add_argument("--targets-per-depth", type=int, default=30, help="Targets per requested target depth.")
     parser.add_argument("--boundary-budget", type=int, default=6, help="Path budget used to precompute boundary histograms.")
+    parser.add_argument("--boundary-builder", choices=["search", "recurrence"], default="search", help="Method used to build boundary histograms before admission.")
     parser.add_argument("--budgets", default=",".join(map(str, DEFAULT_BUDGETS)), help="Comma-separated target path budgets.")
     parser.add_argument("--admission-policy", choices=["baseline", "depth-prior"], default="baseline", help="Policy used to decide whether measured boundary histograms enter the cache.")
     parser.add_argument("--safety-factor", type=float, default=1.25, help="Multiplier for depth-prior predicted histogram bytes.")

--- a/scripts/parent_histogram_recurrence.py
+++ b/scripts/parent_histogram_recurrence.py
@@ -8,6 +8,11 @@ For a parent-only DAG the recurrence is exact:
     H_root[0] = 1
     H_v[d] = sum(H_parent[d - 1] for parent in parents(v))
 
+The helpers use unnormalized histograms: every bin stores path-count mass.  If
+callers store normalized parent distributions instead, each shifted parent
+distribution must be multiplied by its path count N_p before the sum, and N_v
+must be stored separately.
+
 This avoids enumerating every path from a target to root.  In cyclic graphs a
 per-node histogram cannot enforce a unique-node visited set, so cycle encounters
 are reported through `cycle_approximation`.

--- a/tests/test_lmdb_parent_boundary_cache_benchmark.py
+++ b/tests/test_lmdb_parent_boundary_cache_benchmark.py
@@ -7,6 +7,7 @@ import unittest
 
 from scripts.lmdb_parent_boundary_cache_benchmark import (
     build_boundary_cache,
+    build_boundary_histogram,
     cached_parent_histogram,
     estimate_parametric_total_count,
     histogram_distribution_error,
@@ -291,6 +292,60 @@ class BoundaryCacheBenchmarkTests(unittest.TestCase):
         self.assertEqual(stats.cache_hits, 1)
         self.assertEqual(stats.histogram_cache_hits, 0)
         self.assertEqual(stats.parametric_cache_hits, 1)
+
+    def test_recurrence_boundary_builder_matches_search_on_dag(self):
+        parents = {
+            "A": ["R"],
+            "B": ["R"],
+            "C": ["A", "B"],
+            "D": ["C", "A"],
+        }
+        graph = DictGraph(parents)
+
+        search = build_boundary_histogram(graph.parents, "D", "R", 4, None, None, "search")
+        recurrence = build_boundary_histogram(graph.parents, "D", "R", 4, None, None, "recurrence")
+        cache, _parametric_cache, rows = build_boundary_cache(
+            graph,
+            "R",
+            ["D"],
+            4,
+            None,
+            None,
+            boundary_builder="recurrence",
+        )
+
+        self.assertEqual(search.histogram, {2: 1, 3: 2})
+        self.assertEqual(recurrence.histogram, search.histogram)
+        self.assertEqual(sum(recurrence.histogram.values()), 3)
+        self.assertEqual(cache["D"], {2: 1, 3: 2})
+        self.assertEqual(rows[0]["boundary_builder"], "recurrence")
+        self.assertEqual(rows[0]["path_count"], 3)
+        self.assertFalse(rows[0]["recurrence_cycle_approximation"])
+
+    def test_recurrence_boundary_builder_records_cycle_approximation(self):
+        parents = {
+            "A": ["R", "C"],
+            "B": ["A"],
+            "C": ["B"],
+        }
+        graph = DictGraph(parents)
+
+        cache, _parametric_cache, rows = build_boundary_cache(
+            graph,
+            "R",
+            ["C"],
+            4,
+            None,
+            None,
+            boundary_builder="recurrence",
+        )
+
+        self.assertEqual(cache["C"], {3: 1})
+        self.assertEqual(rows[0]["boundary_builder"], "recurrence")
+        self.assertTrue(rows[0]["recurrence_cycle_approximation"])
+        self.assertEqual(rows[0]["cycle_skips"], 1)
+        self.assertEqual(rows[0]["cache_admission_action"], "materialize_capped")
+        self.assertEqual(rows[0]["cache_admission_reason"], "baseline_recurrence_cycle_approximation")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `--boundary-builder search|recurrence` to the LMDB parent boundary-cache benchmark.
- Wire recurrence-built boundary histograms into the existing cache admission and splice flow.
- Record builder diagnostics, including recurrence states, memo hits, and cycle-approximation flags.
- Document that recurrence histograms are unnormalized path-count histograms; normalized distribution storage would require a separate `N` mass.

## Validation

- `python3 -m unittest tests.test_parent_histogram_recurrence tests.test_lmdb_parent_boundary_cache_benchmark`
- `git diff --cached --check`
- Small enwiki MTC smoke comparing `--boundary-builder search` and `--boundary-builder recurrence`

## Smoke Result

On the small enwiki MTC sample, recurrence-built boundary rows produced zero downstream histogram error against full search while reducing boundary precompute work from about 14,502 DFS node expansions per row to about 171 recurrence states per row.

The recurrence builder still reported cycle approximation on 11 of 12 rows, so those rows are labeled as approximate/capped rather than exact. The next policy step is to add thresholds for recurrence state count and post-tail-trim effective bins, then fall back to a fitted distribution before recurrence materialization gets too expensive.