### PR TITLE
Support guarded PLAWK associative counts

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -262,6 +262,9 @@ array, increments those tables in the native streaming loop, and performs `END`
 lookups through the matching source-array table. Multiple associative increments
 in one always-rule are planned as sequential native action blocks, so no WAM
 dispatch is needed per record for those count updates.
+Guarded associative-count rules now reuse the same native guard emitters and
+rule-chain structure as scalar counters, so the loop can run field/prefix checks
+and table increments without per-record WAM dispatch for the supported surface.
 
 **Success:** a user-written awk-style program parses, lowers, compiles, and
 produces correct output on standard awk test cases.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -84,7 +84,9 @@ guarded rules can update shared scalar slots before an `END` print. The first
 associative-count surface now supports multiple source arrays, e.g.
 `{ counts[$1]++; by_component[$2]++ } END { print counts["ERROR"], by_component["disk"] }`.
 Codegen allocates one WAM/LLVM runtime interned-atom-keyed `i64` table per
-source array rather than specializing the `END` keys to fixed slots; each table
+source array rather than specializing the `END` keys to fixed slots. Guarded
+associative count rules lower through the same native rule-chain shape as scalar
+counters, so `$1 == "ERROR" { by_component[$2]++ }` only updates on matches. Each table
 grows and rehashes as needed, and the native stream reader grows its line buffer
 without consuming WAM
 arena space per record.

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -180,6 +180,21 @@ For the sample input above, that prints:
 2 1 1
 ```
 
+Associative counts can also be guarded:
+
+```awk
+$1 == "ERROR" { by_component[$2]++ }
+$1 == "WARN"  { warnings[$2]++ }
+END { print by_component["disk"], warnings["cpu"] }
+```
+
+The generated native loop checks each rule's guard before entering its table
+increment block. For the sample input, that prints:
+
+```text
+1 1
+```
+
 This path keeps the streaming loop native while the WAM runtime supplies the
 reader, atom helpers, and reusable associative table primitive.
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -21,6 +21,7 @@
 %      $N == "VALUE" { errors++; matches++ } END { print errors, matches }
 %      $N == "ERROR" { errors++ } $N == "WARN" { warnings++ } END { print errors, warnings }
 %      { counts[$1]++ } END { print counts["ERROR"], counts["WARN"] }
+%      $N == "VALUE" { counts[$M]++ } END { print counts["KEY"] }
 %
 %  The surrounding runtime still comes from write_wam_llvm_project/3. This
 %  function emits the target-specific native main that streams the file, lowers
@@ -82,9 +83,10 @@ plawk_program_native_driver_ir(
     plawk_assoc_runtime_count_plan(Rules, PrintFields, AssocPlan),
     plawk_assoc_print_key_globals(PrintFields, AssocGlobalIR),
     plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
-    plawk_assoc_count_chain_ir(AssocPlan, AssocChainIR),
+    plawk_assoc_rule_chain_ir(AssocPlan, AssocRuleGlobalIR, AssocChainIR),
     plawk_assoc_end_print_ir(PrintFields, AssocPlan, EndPrintIR),
-    plawk_i64_end_print_globals(AssocGlobalIR, RuntimeGlobals),
+    format(atom(SurfaceGlobalIR), '~w~n~w', [AssocGlobalIR, AssocRuleGlobalIR]),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
 ~w
@@ -241,23 +243,40 @@ plawk_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
 plawk_scalar_state_slot(Name, scalar_counter(Name)).
 
 plawk_assoc_runtime_count_plan(
-    [rule(always, Actions)],
+    Rules,
     PrintFields,
-    assoc_plan(Tables, PlannedActions)
+    assoc_plan(Tables, PlannedRules)
 ) :-
-    maplist(plawk_assoc_increment_action, Actions, ActionSpecs),
-    ActionSpecs \== [],
+    maplist(plawk_assoc_rule_action_specs, Rules, RuleSpecs),
+    RuleSpecs \== [],
     maplist(plawk_assoc_print_array, PrintFields, PrintArrays),
     PrintArrays \== [],
-    findall(ArrayName, member(ArrayName-_KeyIndex, ActionSpecs), ActionArrays),
+    findall(ArrayName,
+        ( member(rule(_Pattern, ActionSpecs), RuleSpecs),
+          member(ArrayName-_KeyIndex, ActionSpecs)
+        ),
+        ActionArrays),
     append(ActionArrays, PrintArrays, ArrayNames0),
     sort(ArrayNames0, Tables),
-    phrase(plawk_assoc_planned_actions(ActionSpecs, Tables, 0), PlannedActions).
+    phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, 0), PlannedRules).
+
+plawk_assoc_rule_action_specs(rule(Pattern, Actions), rule(Pattern, ActionSpecs)) :-
+    maplist(plawk_assoc_increment_action, Actions, ActionSpecs),
+    ActionSpecs \== [].
 
 plawk_assoc_increment_action(inc_assoc(var(ArrayName), field(KeyIndex)), ArrayName-KeyIndex) :-
     KeyIndex > 0.
 
 plawk_assoc_print_array(assoc(var(ArrayName), string(_Key)), ArrayName).
+
+plawk_assoc_planned_rules([], _Tables, _Index) -->
+    [].
+plawk_assoc_planned_rules([rule(Pattern, ActionSpecs) | Rest], Tables, Index) -->
+    { phrase(plawk_assoc_planned_actions(ActionSpecs, Tables, 0), PlannedActions),
+      NextIndex is Index + 1
+    },
+    [assoc_rule(Index, Pattern, PlannedActions)],
+    plawk_assoc_planned_rules(Rest, Tables, NextIndex).
 
 plawk_assoc_planned_actions([], _Tables, _Index) -->
     [].
@@ -283,52 +302,112 @@ plawk_assoc_entry_setup_lines([_ArrayName | Rest], Index) -->
     [Line],
     plawk_assoc_entry_setup_lines(Rest, NextIndex).
 
-plawk_assoc_count_chain_ir(assoc_plan(_Tables, Actions), ChainIR) :-
-    phrase(plawk_assoc_count_action_lines(Actions), Lines),
-    atomic_list_concat(Lines, '\n', ChainIR).
+plawk_assoc_rule_chain_ir(assoc_plan(_Tables, Rules), GlobalIR, ChainIR) :-
+    length(Rules, RuleCount),
+    RuleCount > 0,
+    phrase(plawk_assoc_rule_chain_lines(Rules, 0), Pairs),
+    pairs_keys_values(Pairs, GlobalParts, ChainParts),
+    atomic_list_concat(GlobalParts, '\n', GlobalIR),
+    atomic_list_concat(ChainParts, '\n', ChainIR).
 
-plawk_assoc_count_action_lines([]) -->
-    ['  br label %continue_loop'].
-plawk_assoc_count_action_lines([Action | Rest]) -->
-    ['  br label %assoc_action_0', ''],
-    plawk_assoc_count_action_blocks([Action | Rest]).
-
-plawk_assoc_count_action_blocks([]) -->
+plawk_assoc_rule_chain_lines([], _) -->
     [].
-plawk_assoc_count_action_blocks([assoc_action(Index, _ArrayName, TableIndex, KeyIndex) | Rest]) -->
-    { ( Rest == []
+plawk_assoc_rule_chain_lines([assoc_rule(Index, Pattern, Actions) | Rest], Index) -->
+    { NextIndex is Index + 1,
+      ( Rest == []
       -> NextLabel = 'continue_loop'
-      ;  NextIndex is Index + 1,
-         format(atom(NextLabel), 'assoc_action_~w', [NextIndex])
+      ;  format(atom(NextLabel), 'assoc_rule_~w_match', [NextIndex])
       ),
-      format(atom(Label), 'assoc_action_~w:', [Index]),
-      format(atom(HaveLabel), 'assoc_action_~w_have_key:', [Index]),
-      format(atom(HaveLabelName), 'assoc_action_~w_have_key', [Index]),
+      format(atom(RuleLabel), 'assoc_rule_~w_match', [Index]),
+      format(atom(ApplyLabel), 'assoc_rule_~w_apply', [Index]),
+      plawk_assoc_rule_apply_ir(Index, Actions, NextLabel, ApplyIR),
+      ( Index =:= 0
+      -> EntryIR = '  br label %assoc_rule_0_match\n\n'
+      ;  EntryIR = ''
+      ),
+      plawk_assoc_rule_guard_ir(Pattern, Index, RuleLabel, ApplyLabel,
+          NextLabel, EntryIR, GuardGlobalIR, BranchIR),
+      format(atom(RuleIR),
+'~w
+
+~w:
+~w',
+          [BranchIR, ApplyLabel, ApplyIR]),
+      Pair = GuardGlobalIR-RuleIR
+    },
+    [Pair],
+    plawk_assoc_rule_chain_lines(Rest, NextIndex).
+
+plawk_assoc_rule_guard_ir(always, _Index, RuleLabel, ApplyLabel, _NextLabel,
+    EntryIR, '', IR) :-
+    !,
+    format(atom(IR),
+'~w~w:
+  br label %~w',
+        [EntryIR, RuleLabel, ApplyLabel]).
+plawk_assoc_rule_guard_ir(Pattern, Index, RuleLabel, ApplyLabel, NextLabel,
+    EntryIR, GuardGlobalIR, IR) :-
+    format(atom(MatchVar), 'assoc_rule_~w_is_match', [Index]),
+    format(atom(GlobalBase), 'plawk_assoc_rule_~w', [Index]),
+    format(atom(MatchValue), '%~w', [MatchVar]),
+    plawk_pattern_guard_ir(Pattern, GlobalBase, MatchValue,
+        GuardGlobalIR-GuardCallIR),
+    format(atom(IR),
+'~w~w:
+~w
+  br i1 %~w, label %~w, label %~w',
+        [EntryIR, RuleLabel, GuardCallIR, MatchVar, ApplyLabel, NextLabel]).
+
+plawk_assoc_rule_apply_ir(RuleIndex, Actions, NextLabel, IR) :-
+    phrase(plawk_assoc_rule_action_lines(RuleIndex, Actions, NextLabel), Lines),
+    atomic_list_concat(Lines, '\n', IR).
+
+plawk_assoc_rule_action_lines(RuleIndex, Actions, NextLabel) -->
+    { Actions = [_ | _],
+      format(atom(FirstBranch), '  br label %assoc_rule_~w_action_0', [RuleIndex])
+    },
+    [FirstBranch, ''],
+    plawk_assoc_rule_action_blocks(RuleIndex, Actions, NextLabel).
+
+plawk_assoc_rule_action_blocks(_RuleIndex, [], _NextLabel) -->
+    [].
+plawk_assoc_rule_action_blocks(RuleIndex, [assoc_action(Index, _ArrayName, TableIndex, KeyIndex) | Rest], NextLabel) -->
+    { ( Rest == []
+      -> ActionNextLabel = NextLabel
+      ;  NextIndex is Index + 1,
+         format(atom(ActionNextLabel), 'assoc_rule_~w_action_~w',
+             [RuleIndex, NextIndex])
+      ),
+      format(atom(Label), 'assoc_rule_~w_action_~w:', [RuleIndex, Index]),
+      format(atom(HaveLabel), 'assoc_rule_~w_action_~w_have_key:',
+          [RuleIndex, Index]),
+      format(atom(HaveLabelName), 'assoc_rule_~w_action_~w_have_key',
+          [RuleIndex, Index]),
       format(atom(Slice),
-          '  %assoc_action_~w_key_slice = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 ~w, i8 32)',
-          [Index, KeyIndex]),
+          '  %assoc_rule_~w_action_~w_key_slice = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 ~w, i8 32)',
+          [RuleIndex, Index, KeyIndex]),
       format(atom(Ptr),
-          '  %assoc_action_~w_key_ptr = extractvalue %WamSlice %assoc_action_~w_key_slice, 0',
-          [Index, Index]),
+          '  %assoc_rule_~w_action_~w_key_ptr = extractvalue %WamSlice %assoc_rule_~w_action_~w_key_slice, 0',
+          [RuleIndex, Index, RuleIndex, Index]),
       format(atom(Len),
-          '  %assoc_action_~w_key_len = extractvalue %WamSlice %assoc_action_~w_key_slice, 1',
-          [Index, Index]),
+          '  %assoc_rule_~w_action_~w_key_len = extractvalue %WamSlice %assoc_rule_~w_action_~w_key_slice, 1',
+          [RuleIndex, Index, RuleIndex, Index]),
       format(atom(Missing),
-          '  %assoc_action_~w_key_missing = icmp eq i8* %assoc_action_~w_key_ptr, null',
-          [Index, Index]),
+          '  %assoc_rule_~w_action_~w_key_missing = icmp eq i8* %assoc_rule_~w_action_~w_key_ptr, null',
+          [RuleIndex, Index, RuleIndex, Index]),
       format(atom(Branch),
-          '  br i1 %assoc_action_~w_key_missing, label %~w, label %~w',
-          [Index, NextLabel, HaveLabelName]),
+          '  br i1 %assoc_rule_~w_action_~w_key_missing, label %~w, label %~w',
+          [RuleIndex, Index, ActionNextLabel, HaveLabelName]),
       format(atom(KeyId),
-          '  %assoc_action_~w_key_id = call i64 @wam_intern_atom(i8* %assoc_action_~w_key_ptr, i64 %assoc_action_~w_key_len)',
-          [Index, Index, Index]),
+          '  %assoc_rule_~w_action_~w_key_id = call i64 @wam_intern_atom(i8* %assoc_rule_~w_action_~w_key_ptr, i64 %assoc_rule_~w_action_~w_key_len)',
+          [RuleIndex, Index, RuleIndex, Index, RuleIndex, Index]),
       format(atom(Inc),
-          '  %assoc_action_~w_count = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %assoc_action_~w_key_id, i64 1)',
-          [Index, TableIndex, Index]),
-      format(atom(Next), '  br label %~w', [NextLabel])
+          '  %assoc_rule_~w_action_~w_count = call i64 @wam_assoc_i64_inc(%WamAssocI64Table* %plawk_assoc_table_~w, i64 %assoc_rule_~w_action_~w_key_id, i64 1)',
+          [RuleIndex, Index, TableIndex, RuleIndex, Index]),
+      format(atom(Next), '  br label %~w', [ActionNextLabel])
     },
     [Label, Slice, Ptr, Len, Missing, Branch, '', HaveLabel, KeyId, Inc, Next, ''],
-    plawk_assoc_count_action_blocks(Rest).
+    plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel).
 
 plawk_assoc_print_key_globals(PrintFields, GlobalIR) :-
     phrase(plawk_assoc_print_key_global_lines(PrintFields, 0), Lines),

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -65,6 +65,16 @@ test(parses_multi_assoc_count_end_print_rule) :-
         [end([print([assoc(var(counts), string("ERROR")),
                      assoc(var(by_component), string("disk"))])])])).
 
+test(parses_guarded_assoc_count_end_print_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { by_component[$2]++ } $1 == \"WARN\" { warnings[$2]++ } END { print by_component[\"disk\"], warnings[\"cpu\"] }\n", Program),
+    assertion(Program == program([],
+        [rule(field_eq(1, "ERROR"), [inc_assoc(var(by_component), field(2))]),
+         rule(field_eq(1, "WARN"), [inc_assoc(var(warnings), field(2))])],
+        [end([print([
+            assoc(var(by_component), string("disk")),
+            assoc(var(warnings), string("cpu"))
+        ])])])).
+
 test(surface_prefix_prints_matching_records) :-
     run_surface_print_smoke("/^ERROR/ { print $0 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -110,6 +120,11 @@ test(surface_assoc_counts_multiple_arrays) :-
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "2 1 1\n").
 
+test(surface_guarded_assoc_counts_multiple_arrays) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { by_component[$2]++ } $1 == \"WARN\" { warnings[$2]++ } END { print by_component[\"disk\"], by_component[\"net\"], warnings[\"cpu\"], warnings[\"disk\"] }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\nWARN disk alert\n",
+        "1 1 1 1\n").
+
 test(surface_assoc_counts_resize_runtime_table) :-
     findall(Line,
         ( between(0, 2050, Index), format(atom(Line), 'K~w payload\n', [Index]) ),
@@ -134,18 +149,32 @@ test(surface_assoc_counts_use_runtime_table) :-
     assertion(sub_atom(DriverIR, _, _, _, '@wam_assoc_i64_free')),
     assertion(\+ sub_atom(DriverIR, _, _, _, 'assoc_check_0')),
     assertion(\+ sub_atom(DriverIR, _, _, _, '%assoc_inc_slot_')),
-    assertion(\+ sub_atom(DriverIR, _, _, _, '%slot_0 = phi')).
+    assertion(\+ sub_atom(DriverIR, _, _, _, '%slot_0 = phi')),
+    !.
 
 test(surface_assoc_counts_multiple_arrays_use_distinct_runtime_tables) :-
     plawk_parse_string("{ counts[$1]++; by_component[$2]++ } END { print counts[\"ERROR\"], by_component[\"disk\"] }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_assoc_table_0 = call %WamAssocI64Table* @wam_assoc_i64_new'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_assoc_table_1 = call %WamAssocI64Table* @wam_assoc_i64_new'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_action_0:'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_action_1:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_rule_0_action_0:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_rule_0_action_1:'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '@wam_assoc_i64_inc'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '@wam_assoc_i64_get'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '%plawk_assoc_table = call')),
+    !.
+
+test(surface_guarded_assoc_counts_use_native_rule_chain) :-
+    plawk_parse_string("$1 == \"ERROR\" { by_component[$2]++ } $1 == \"WARN\" { warnings[$2]++ } END { print by_component[\"disk\"], warnings[\"cpu\"] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_rule_0_match:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_rule_0_apply:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_rule_1_match:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_rule_1_apply:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_5Fassoc_5Frule_5F0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_5Fassoc_5Frule_5F1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_eq_value'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 
 run_surface_print_smoke(Source, Input, ExpectedOutput) :-


### PR DESCRIPTION
## Summary
- Generalize PLAWK associative count lowering from a single always-rule action chain to a native guarded rule chain.
- Reuse existing native field/prefix guard emitters before entering assoc table increment blocks.
- Keep one runtime `wam_assoc_i64_*` table per source array and route `END` lookups through the matching table.
- Add parser, IR-shape, and compiled smoke coverage for guarded associative count rules.
- Update PLAWK README, tutorial, and implementation plan docs.

## Tests
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `git diff --cached --check`
- `git diff --check`

Note: `tests/test_wam_llvm_target.pl` still reports existing choicepoint warnings while exiting 0.