### PR TITLE
Document distribution compression policy

### DIFF
--- a/docs/design/DISTRIBUTIONAL_COMPRESSION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/DISTRIBUTIONAL_COMPRESSION_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,152 @@
+# Distributional Compression Implementation Plan
+
+This plan turns `DISTRIBUTIONAL_COMPRESSION_THEORY.md` into staged work for
+the parent-path recurrence and boundary-cache tools.
+
+## Phase 1: Error certificates
+
+Add common helpers for comparing an exact histogram with a candidate
+representation:
+
+- `max_cdf_error`
+- `w1_cdf_error`
+- dropped-tail mass
+- functional-specific error where the functional is known
+
+Persist those certificates on boundary rows and fitted states:
+
+```text
+fit_error_max_cdf
+fit_error_w1_cdf
+fit_error_functional(Name)
+inherited_error_max_cdf
+inherited_error_w1_cdf
+```
+
+The inherited error fields are computed by the shifted parent-error recurrence:
+
+```text
+E_pre_v[L] = sum_p E_p[L - 1]
+```
+
+For normalised parent states:
+
+```text
+E_pre_v_mass[L] = sum_p N_p * (P_p[L - 1] - Q_p[L - 1])
+```
+
+## Phase 2: Cheap exact encodings
+
+Before adding new parametric families, implement packed exact alternatives:
+
+1. tail-pruned exact histogram;
+2. quantised CDF table for prefix-mass workloads;
+3. packed sparse histogram byte model for LMDB;
+4. in-memory runtime byte model for Python/runtime dictionaries.
+
+This phase clarifies the real crossover point.  A 50-float model should be
+compared against packed bytes at equal error tolerance, not against a Python
+dictionary bin count.
+
+## Phase 3: Single-family fits
+
+Implement and gate cheap one-family fits:
+
+1. binomial;
+2. beta-binomial;
+3. discretised normal for deep CLT-like regions.
+
+Binomial and normal approximations are expected to become more reasonable for
+deep nodes where many shifted parent contributions have accumulated.  This is
+the central-limit regime: local irregularities can smooth out, skew often
+shrinks in standardised units, and a compact symmetric or nearly symmetric
+family may be good enough.
+
+The implementation should still gate by measured CDF/W1 error, because deep
+nodes can contain bottlenecks, near-deterministic modes, or topical mixtures
+that violate a single-family fit.
+
+## Phase 4: Mixture fits
+
+Add bounded discrete mixtures before Gaussian mixtures:
+
+1. mixture of binomials with shared support `D`;
+2. discretised Gaussian mixture as an escalation family.
+
+Mixture-of-binomials is preferred first because it is bounded and discrete with
+`2K - 1` parameters.  Gaussian mixtures remain useful when residual error
+concentrates in a narrow sub-binomial-width mode or bottleneck spike.
+
+Each mixture fit must have a capped iteration budget.  EM is acceptable if it
+is bounded and diagnostics report:
+
+```text
+fit_family
+components
+em_iterations
+fit_error_max_cdf
+fit_error_w1_cdf
+fit_rejected_reason
+```
+
+## Phase 5: Policy selection
+
+Replace threshold-only admission with cheapest-representation selection:
+
+```text
+candidates = [
+    tail_pruned_histogram,
+    quantized_cdf_table,
+    binomial,
+    beta_binomial,
+    normal_or_discrete_normal,
+    binomial_mixture,
+    discretized_gmm
+]
+
+choose argmin bytes(candidate)
+where candidate.error <= active_error_budget
+```
+
+`max_recurrence_states` and `max_effective_bins_after_trim` remain useful as
+triggers for trying compression, but acceptance must be error-gated.
+
+## Phase 6: Planner integration
+
+Expose policy options through `distribution_fit_policy`:
+
+```prolog
+distribution_fit_policy(
+    root_path_distribution/3,
+    [ max_recurrence_states(50),
+      max_effective_bins_after_trim(50),
+      max_cdf_error(0.01),
+      max_w1_error(0.05),
+      candidate_families([
+          tail_pruned_histogram,
+          quantized_cdf_table,
+          binomial,
+          beta_binomial,
+          discrete_normal,
+          binomial_mixture,
+          discretized_gmm
+      ]),
+      storage_cost_model(packed_lmdb) ]).
+```
+
+The default candidate order should be conservative and discrete-first.  Users
+can opt into Gaussian mixtures or learned smoothers, but those should not be the
+first default while simpler bounded discrete families pass the error gate.
+
+## Phase 7: Learned smoothers
+
+Gaussian-mixture smoothing or a tiny convolutional smoother can be evaluated
+after deterministic candidates exist.  The key distinction is operational:
+
+- inference may be cheap with a tiny model;
+- training adds separate compute cost;
+- model drift and validation become new responsibilities.
+
+Learned smoothers should therefore be optional candidate families behind the
+same error-certificate interface, not a replacement for the deterministic
+ladder.

--- a/docs/design/DISTRIBUTIONAL_COMPRESSION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/DISTRIBUTIONAL_COMPRESSION_IMPLEMENTATION_PLAN.md
@@ -23,17 +23,21 @@ inherited_error_max_cdf
 inherited_error_w1_cdf
 ```
 
-The inherited error fields are computed by the shifted parent-error recurrence:
+The inherited error fields are scalars computed by the certificate recurrence
+(see "Scalar certificate recurrence" in the theory doc), not by materialising
+signed error vectors — a per-node residual vector would cost as much as the
+exact histogram it certifies:
 
 ```text
-E_pre_v[L] = sum_p E_p[L - 1]
+inherited_error_max_cdf(v) = sum_p (N_p / N_v) * total_error_max_cdf(p)
+inherited_error_w1_cdf(v)  = sum_p (N_p / N_v) * total_error_w1_cdf(p)
+total_error_*(v)           = inherited_error_*(v) + fit_error_*(v)
 ```
 
-For normalised parent states:
-
-```text
-E_pre_v_mass[L] = sum_p N_p * (P_p[L - 1] - Q_p[L - 1])
-```
+The full signed-error vector `E_pre_v[L] = sum_p E_p[L - 1]` (or
+`sum_p N_p * (P_p[L - 1] - Q_p[L - 1])` for normalised parent states) is a
+diagnostic-only computation for inspecting where inherited error concentrates
+after a fit rejection.
 
 ## Phase 2: Cheap exact encodings
 
@@ -76,6 +80,23 @@ Add bounded discrete mixtures before Gaussian mixtures:
 Mixture-of-binomials is preferred first because it is bounded and discrete with
 `2K - 1` parameters.  Gaussian mixtures remain useful when residual error
 concentrates in a narrow sub-binomial-width mode or bottleneck spike.
+
+A binomial mixture with shared `n = D` is identifiable only when
+`D >= 2K - 1`, so the fitter must clamp `K <= (D + 1) / 2`.  On narrow
+supports this binds before the float budget does, and an unclamped fitter
+will chase degenerate component splits.
+
+Fits should be initialised cheaply rather than started cold:
+
+1. binomial: `p = mean / D` (method of moments, closed form);
+2. beta-binomial: method of moments — solve the overdispersion `rho` from
+   `var = D * p * (1 - p) * (1 + (D - 1) * rho)`, then
+   `alpha = p * (1 - rho) / rho` and `beta = (1 - p) * (1 - rho) / rho`;
+   if `rho <= 0` fall back to plain binomial;
+3. mixtures: warm-start from the parent.  Because
+   `H_v = sum_p shift(H_p)`, the mass-weighted union of parent components
+   with means bumped by one step (`p_i <- p_i + 1/D`) is a near-converged
+   initialisation, and parameters drift slowly down ancestor chains.
 
 Each mixture fit must have a capped iteration budget.  EM is acceptable if it
 is bounded and diagnostics report:

--- a/docs/design/DISTRIBUTIONAL_COMPRESSION_THEORY.md
+++ b/docs/design/DISTRIBUTIONAL_COMPRESSION_THEORY.md
@@ -32,8 +32,10 @@ the recurrence becomes:
 
 ```text
 N_v * P_v[L] = sum_{p in parents(v)} N_p * P_p[L - 1]
-N_v = sum_L sum_{p in parents(v)} N_p * P_p[L - 1]
+N_v = sum_{p in parents(v)} N_p
 ```
+
+The mass recurrence collapses to a plain sum because each `P_p` sums to one.
 
 The current benchmark keeps the unnormalised form because cache splicing needs
 path-count mass directly.
@@ -79,6 +81,26 @@ For normalised forms, scale the parent errors by `N_p` before shifting:
 E_pre_v_mass[L] = sum_p N_p * (P_p[L - 1] - Q_p[L - 1])
 ```
 
+### Scalar certificate recurrence
+
+The signed-vector recurrence above is the exact statement, but persisting
+`E_p` per node defeats compression: the residual vector is as large as the
+exact histogram it certifies.  What the cache should persist are scalar
+certificates, and those obey their own recurrence.  The normalised child is
+the mass-weighted mixture of unit-shifted parents, and a unit shift changes
+neither metric, so by the triangle inequality:
+
+```text
+epsilon_K(v)  <= sum_p (N_p / N_v) * epsilon_K(p)  + epsilon_K_local(v)
+epsilon_W1(v) <= sum_p (N_p / N_v) * epsilon_W1(p) + epsilon_W1_local(v)
+```
+
+where the local term is the metric applied to the new compression residual
+`R_v`.  Inherited error therefore propagates as a mass-weighted average of
+parent certificates — one float per metric per node.  The full `E_pre_v`
+vector is only needed as a diagnostic, for example to see where inherited
+error concentrates after a fit rejection.
+
 ## 3. Error metrics
 
 Prefix-mass queries use a CDF:
@@ -113,6 +135,25 @@ The compression gate should therefore be expressed as tolerances over
 `epsilon_K`, `epsilon_W1`, or a functional-specific certificate.  State-count or
 bin-count thresholds are cost triggers; they do not by themselves prove quality.
 
+### Absolute versus relative certificates
+
+The certificates above are absolute, and absolute certificates are the right
+gate for additive aggregates.  When many small tail contributions are summed
+into an `O(1)` total, each term's absolute error is bounded by the
+certificate and products of small errors are second-order — the usual
+justification for dropping higher-order terms in approximations.
+
+The case that needs a different gate is when a product of tail masses is the
+whole quantity, for example ranking two candidates whose scores are each
+products of small survival probabilities.  Relative errors add under
+multiplication: factors with relative errors `delta_i` give a product with
+relative error approximately `sum_i delta_i`.  An absolute certificate
+`epsilon_K = 0.01` on a tail of mass `0.001` is a 10x relative error on that
+factor, easily enough to invert the ranking of two competing small products,
+even though the absolute error of either product is tiny.  Queries of this
+shape should be gated on relative CDF/survival error over the queried tail
+region, not on absolute `epsilon_K`.
+
 ## 4. Fit ladder
 
 The representation ladder should prefer the cheapest encoding that satisfies
@@ -121,7 +162,7 @@ the active error budget.
 | Representation | Parameters / storage | Strength | Weakness |
 |----------------|----------------------|----------|----------|
 | Tail-pruned exact histogram | packed nonzero bins plus dropped-tail certificate | Exact where kept; no fitting | Cost grows with effective support |
-| Quantised CDF table | one monotone fixed-point CDF value per retained point | Direct prefix queries, simple error bound | Less useful for arbitrary PMF functionals |
+| Quantised CDF table | one monotone fixed-point CDF value per retained point | Direct prefix queries; error bounded by the quantisation step (`<= 2^-17` at 16 bits) | Less useful for arbitrary PMF functionals |
 | Binomial | `D`, `p`, mass, support | Very cheap, bounded discrete support | Under/over-dispersion and multimodality fail quickly |
 | Beta-binomial | `D`, `alpha`, `beta`, mass, support | First upgrade for over-dispersion | CDF is a finite sum unless tabulated |
 | Mixture of binomials | `K` weights and `K` probabilities, shared `D` | Bounded, discrete, modes-per-float efficient | Component width tied to location |
@@ -135,7 +176,7 @@ first fallback.
 - The data are bounded integer histograms.  Binomial and beta-binomial families
   encode that support directly.
 - Mixtures of binomials use `2K - 1` parameters when every component shares
-  `D`; a Gaussian mixture needs roughly `3K - 1` parameters.  For equal storage,
+  `D`; a Gaussian mixture needs `3K - 1` parameters.  For equal storage,
   binomial mixtures can represent more natural binomial-width modes.
 - Per-node compression is judged by exact CDF/W1 error, not by sampling
   likelihood.  If a cheaper discrete family meets the error budget, a GMM adds

--- a/docs/design/DISTRIBUTIONAL_COMPRESSION_THEORY.md
+++ b/docs/design/DISTRIBUTIONAL_COMPRESSION_THEORY.md
@@ -1,0 +1,210 @@
+# Distributional Compression Theory
+
+This note records the theory behind compressing exact path-statistic
+histograms into cheaper finite-support representations.  It complements
+`DISTRIBUTIONAL_FIT_POLICY.md`, `PARENT_BRANCHING_DISTRIBUTION_THEORY.md`, and
+`RECURRENCE_EVALUATION_STRATEGY_SPECIFICATION.md`.
+
+The central distinction is that recurrence histograms are exact computed
+objects, not noisy samples.  Choosing a compact representation is therefore a
+lossy-compression problem with explicit error certificates, not a statistical
+model-selection problem in the usual AIC/BIC sense.
+
+## 1. Exact object
+
+For parent-only paths to a fixed root, the unnormalised recurrence is:
+
+```text
+H_root[0] = 1
+H_v[L] = sum_{p in parents(v)} H_p[L - 1]
+```
+
+Equivalently, in generating-function form:
+
+```text
+H_root(z) = 1
+H_v(z) = z * sum_{p in parents(v)} H_p(z)
+```
+
+`H_v[L]` stores path-count mass at length `L`.  If a future storage layer keeps
+normalised distributions `P_v`, it must also store total path mass `N_v`, and
+the recurrence becomes:
+
+```text
+N_v * P_v[L] = sum_{p in parents(v)} N_p * P_p[L - 1]
+N_v = sum_L sum_{p in parents(v)} N_p * P_p[L - 1]
+```
+
+The current benchmark keeps the unnormalised form because cache splicing needs
+path-count mass directly.
+
+## 2. Error recurrence before fitting
+
+Suppose parent `p` has an exact histogram `H_p` and a stored approximation
+`A_p`.  Its signed error is:
+
+```text
+E_p[L] = H_p[L] - A_p[L]
+```
+
+Before fitting any new approximation for child `v`, the propagated parent
+error is already known by the same shifted-sum operator:
+
+```text
+E_pre_v[L] = sum_{p in parents(v)} E_p[L - 1]
+```
+
+The exact child histogram decomposes as:
+
+```text
+H_v = A_pre_v + E_pre_v
+A_pre_v[L] = sum_{p in parents(v)} A_p[L - 1]
+```
+
+If the child is then compressed into `A_v`, the new local compression residual
+is:
+
+```text
+R_v[L] = H_v[L] - A_v[L]
+```
+
+and the stored error certificate for `A_v` should cover both inherited error
+and new fit error.  In exact recurrence materialisation, `E_pre_v = 0`.  In a
+mixed exact/approximate cache, `E_pre_v` allows the planner to reject or tighten
+a fit before spending work on a more expressive family.
+
+For normalised forms, scale the parent errors by `N_p` before shifting:
+
+```text
+E_pre_v_mass[L] = sum_p N_p * (P_p[L - 1] - Q_p[L - 1])
+```
+
+## 3. Error metrics
+
+Prefix-mass queries use a CDF:
+
+```text
+F_H(t) = sum_{L <= t} H[L] / N
+```
+
+For a normalised exact distribution `P` and approximation `Q`, the most useful
+certificates are:
+
+```text
+epsilon_K = max_t |F_P(t) - F_Q(t)|
+epsilon_W1 = sum_t |F_P(t) - F_Q(t)|
+```
+
+`epsilon_K` is the direct per-query absolute error bound for prefix-mass
+queries.  `epsilon_W1` is the one-dimensional Wasserstein-1 distance on integer
+support and bounds Lipschitz aggregate error:
+
+```text
+|E_P[g(L)] - E_Q[g(L)]| <= Lip(g) * epsilon_W1
+```
+
+For bounded-variation step-like costs:
+
+```text
+|E_P[g(L)] - E_Q[g(L)]| <= variation(g) * epsilon_K
+```
+
+The compression gate should therefore be expressed as tolerances over
+`epsilon_K`, `epsilon_W1`, or a functional-specific certificate.  State-count or
+bin-count thresholds are cost triggers; they do not by themselves prove quality.
+
+## 4. Fit ladder
+
+The representation ladder should prefer the cheapest encoding that satisfies
+the active error budget.
+
+| Representation | Parameters / storage | Strength | Weakness |
+|----------------|----------------------|----------|----------|
+| Tail-pruned exact histogram | packed nonzero bins plus dropped-tail certificate | Exact where kept; no fitting | Cost grows with effective support |
+| Quantised CDF table | one monotone fixed-point CDF value per retained point | Direct prefix queries, simple error bound | Less useful for arbitrary PMF functionals |
+| Binomial | `D`, `p`, mass, support | Very cheap, bounded discrete support | Under/over-dispersion and multimodality fail quickly |
+| Beta-binomial | `D`, `alpha`, `beta`, mass, support | First upgrade for over-dispersion | CDF is a finite sum unless tabulated |
+| Mixture of binomials | `K` weights and `K` probabilities, shared `D` | Bounded, discrete, modes-per-float efficient | Component width tied to location |
+| Discretised Gaussian mixture | weights, means, variances, support | Handles sharp/narrow modes; cheap CDF via `erf` | Continuous prior on discrete data; more parameters per mode |
+
+### Why Gaussian mixtures are not the default
+
+Gaussian mixtures are useful but should be an escalation family rather than the
+first fallback.
+
+- The data are bounded integer histograms.  Binomial and beta-binomial families
+  encode that support directly.
+- Mixtures of binomials use `2K - 1` parameters when every component shares
+  `D`; a Gaussian mixture needs roughly `3K - 1` parameters.  For equal storage,
+  binomial mixtures can represent more natural binomial-width modes.
+- Per-node compression is judged by exact CDF/W1 error, not by sampling
+  likelihood.  If a cheaper discrete family meets the error budget, a GMM adds
+  no planner value.
+- Gaussian mixtures are strongest when the residual has a sub-binomial-width
+  spike or a narrow bottleneck mode.  That is an escalation condition, not the
+  common case assumed by the parent-branching recurrence.
+
+The design should therefore test GMMs, but only after tail-pruned histograms,
+CDF tables, binomial, beta-binomial, and binomial mixtures have failed the
+active error budget.
+
+## 5. Deep-node CLT regime
+
+For real deep nodes, binomial or normal approximations become more plausible
+because the recurrence repeatedly sums shifted parent contributions.  When many
+small independent or weakly dependent contributions accumulate, the
+standardised path-length distribution should move toward the central-limit
+regime: skew shrinks, local irregularities smooth out, and a compact
+binomial-like or normal-like representation can be accurate.
+
+This is not the same claim as saying that parent counts themselves are
+binomial or normal.  Parent-degree distributions can be skewed, exponential, or
+heavy-tailed, especially on enwiki.  The CLT argument applies to the path-count
+distribution after repeated shifted sums, and it can fail around bottlenecks,
+topic mixtures, hubs, cycles, or small effective ancestor cones.
+
+The policy consequence is simple: depth and effective-convolution count are
+signals for trying binomial or normal compression earlier in the candidate
+ladder, but the representation still has to pass the CDF/W1 error gate.
+
+## 6. Fit gates
+
+BIC, AIC, chi-square, and held-out likelihood are not the right gate for
+per-node exact recurrence histograms.  The question is not generalisation from
+samples; it is whether a compact representation preserves the exact object
+within a planner tolerance.
+
+The gate should be:
+
+```text
+choose cheapest representation R such that:
+    max_cdf_error(exact, R) <= epsilon_K
+and optional:
+    w1_cdf_error(exact, R) <= epsilon_W1
+and optional:
+    functional_error(exact, R, g) <= epsilon_g
+```
+
+Statistical model selection becomes relevant only for shared priors learned
+across many nodes, or if histograms become sampled/noisy rather than exact.
+
+## 7. Policy consequence
+
+The old question "is this over 50 points?" should be replaced with:
+
+```text
+which representation is cheapest at the requested error tolerance?
+```
+
+For in-memory Python dictionaries, a 10-bin histogram may already be larger
+than a small packed parametric state.  For packed LMDB encodings, the crossover
+point is different.  The policy must compare byte estimates for the target
+storage mode:
+
+```text
+cost_model = packed_lmdb | in_memory_runtime | diagnostic_json
+```
+
+Thresholds such as `max_recurrence_states = 50` remain useful as work triggers:
+they decide when to try compression.  They should not decide whether the
+compressed representation is acceptable; that requires the error certificate.

--- a/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
+++ b/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
@@ -124,7 +124,7 @@ Gaussian mixtures are not deprioritized because they are wrong.  They are
 deprioritized because the primary object is a bounded integer histogram, and
 cheaper discrete encodings usually expose the same planner information with
 fewer parameters.  A mixture of binomials with shared support uses `2K - 1`
-parameters, while a Gaussian mixture needs roughly `3K - 1`.  GMMs should be
+parameters, while a Gaussian mixture needs `3K - 1`.  GMMs should be
 available as an escalation family when the residual error has sub-binomial-width
 spikes, bottleneck modes, or other structure that cheaper discrete candidates
 cannot pass through the CDF/W1 gate.

--- a/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
+++ b/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
@@ -1,6 +1,6 @@
 # Distributional Fit Policy
 
-This note specifies the policy layer between exact path-statistic distributions and closed-form approximations. It is a companion to `ROOT_ANCHORED_METRICS_SPECIFICATION.md` and `RECURRENCE_EVALUATION_STRATEGY_SPECIFICATION.md`.
+This note specifies the policy layer between exact path-statistic distributions and closed-form approximations. It is a companion to `ROOT_ANCHORED_METRICS_SPECIFICATION.md`, `RECURRENCE_EVALUATION_STRATEGY_SPECIFICATION.md`, `DISTRIBUTIONAL_COMPRESSION_THEORY.md`, and `DISTRIBUTIONAL_COMPRESSION_IMPLEMENTATION_PLAN.md`.
 
 The problem: root-anchored metrics such as `d_wPow` often start with an exact finite histogram over path statistics. Near the root, or on small graphs, that histogram is cheap and should be kept exactly. Deeper in the graph, especially on enwiki, the support can grow enough that the runtime should switch to a compact representation. That switch must be explicit, diagnosable, and user-overridable.
 
@@ -88,25 +88,46 @@ remove a large fraction of bins; for skewed or medium/heavy tails, the same rule
 will refuse to prune because the suffix mass or functional contribution remains
 too large.
 
-The first tail family should be `truncated_geometric` or equivalently a discrete exponential over finite support. It is simple, has closed-form CDF/survival functions, and matches the intuition that longer parent-only paths often decay after the high-signal prefix. Do not assume a Poisson family by default: parent path distributions are finite, graph-constrained, and driven by branching structure rather than independent arrival counts.
+After cheap exact encodings are considered, the candidate ladder should stay
+bounded and discrete first.  `truncated_geometric` remains useful for a visible
+finite-support exponential tail, but it should not be the universal first
+fallback.  Do not assume a Poisson family by default: parent path distributions
+are finite, graph-constrained, and driven by branching structure rather than
+independent arrival counts.
 
-Candidate families for later extension:
+Candidate representations:
 
 | Family | Use when |
 |--------|----------|
+| `tail_pruned_histogram` | The retained exact prefix plus dropped-tail certificate meets the error budget |
+| `quantized_cdf_table` | Prefix-mass queries dominate and CDF error is the right certificate |
 | `truncated_geometric` | Tail decays approximately exponentially after the exact prefix |
-| `truncated_discrete_normal` | Large-depth CLT regime after tail/error validation |
 | `binomial` | Bounded excess-event support where mean/variance recover compatible `n,p` |
 | `beta_binomial` | Bounded support with measurable over-dispersion beyond binomial variance |
+| `truncated_discrete_normal` | Large-depth CLT regime after CDF/W1 validation |
+| `mixture(binomial)` | Bounded discrete modes fit better than one family |
+| `discretized_gmm` | Narrow residual spikes or bottleneck modes survive cheaper discrete fits |
 | `empirical_sketch` | No simple family fits but quantile/CDF accuracy is enough |
-| `mixture(Families)` | Topical and administrative regimes visibly mix |
 
 The normal family should be treated as a large-depth approximation, not as the
-default for rare excess-parent events. In near-chain SimpleWiki regimes,
-binomial or empirical discrete priors preserve the skewed finite support more
-directly. If measured parent degrees become scale-free rather than
-Poisson-like, the policy should favor empirical sketches, mixtures, or explicit
-hub handling instead of a single light-tailed count family.
+default for rare excess-parent events.  For real deep nodes, repeated shifted
+sums make binomial or normal approximations increasingly plausible by the
+central limit theorem.  That is a reason to try those families earlier in deep
+ancestor cones, not a reason to accept them without an error certificate.  In
+near-chain SimpleWiki regimes, binomial or empirical discrete priors preserve
+the skewed finite support more directly.  If measured parent degrees become
+scale-free rather than Poisson-like, the policy should favor empirical
+sketches, mixtures, or explicit hub handling instead of a single light-tailed
+count family.
+
+Gaussian mixtures are not deprioritized because they are wrong.  They are
+deprioritized because the primary object is a bounded integer histogram, and
+cheaper discrete encodings usually expose the same planner information with
+fewer parameters.  A mixture of binomials with shared support uses `2K - 1`
+parameters, while a Gaussian mixture needs roughly `3K - 1`.  GMMs should be
+available as an escalation family when the residual error has sub-binomial-width
+spikes, bottleneck modes, or other structure that cheaper discrete candidates
+cannot pass through the CDF/W1 gate.
 
 The family choice should be evidence-driven. Simplewiki is a calibration fixture: compute exact parent-only distributions there, fit candidate tails, and measure error. Enwiki is the stress case where the representation switch is expected to matter.
 
@@ -255,6 +276,9 @@ Diagnostics should be emitted into the recurrence strategy trace:
 - fitted finite support range;
 - materialised cumulative bases;
 - estimated error for the selected functional;
+- inherited parent approximation error before fitting;
+- local fit error after compression;
+- CDF and W1 error certificates when available;
 - fallback reason if no family passed the threshold;
 - fallback reason if a requested functional has no matching cumulative basis;
 - whether a user selection predicate overrode the default.


### PR DESCRIPTION
# [codex] Document distribution compression policy

## Summary
- Add a distributional compression theory doc covering exact parent-histogram recurrence, normalized vs unnormalized mass, propagated parent error, CDF/W1 error certificates, fit gates, and the deep-node CLT regime.
- Add an implementation plan for error certificates, packed exact encodings, binomial/beta-binomial/normal fits, binomial mixtures, GMM escalation, and planner policy integration.
- Update the distributional fit policy to reference the new docs, prefer bounded discrete representations first, explain when GMMs are useful, and include inherited/local fit diagnostics.

## Validation
- Ran typo scan over touched docs.
- Ran `git diff --check`.