### PR TITLE
Add distribution error certificate helpers

### DIFF
--- a/scripts/distribution_fit_comparison.py
+++ b/scripts/distribution_fit_comparison.py
@@ -295,6 +295,41 @@ def max_cdf_error(empirical: list[float], model: list[float]) -> float:
     return worst
 
 
+def w1_cdf_error(empirical: list[float], model: list[float]) -> float:
+    """Return 1-D Wasserstein distance on integer support via CDF deltas."""
+    empirical, model = pad_to(empirical, model)
+    empirical_total = 0.0
+    model_total = 0.0
+    total = 0.0
+    for empirical_value, model_value in zip(empirical, model):
+        empirical_total += empirical_value
+        model_total += model_value
+        total += abs(empirical_total - model_total)
+    return total
+
+
+def shift_distribution(probabilities: list[float], offset: int = 1) -> list[float]:
+    """Shift probability mass to the right; useful for parent recurrence tests."""
+    if offset <= 0:
+        return list(probabilities)
+    return [0.0 for _ in range(offset)] + list(probabilities)
+
+
+def weighted_parent_certificate(parent_masses: list[float], parent_total_errors: list[float]) -> float:
+    """Propagate scalar parent error certificates by mass-weighted averaging."""
+    if len(parent_masses) != len(parent_total_errors):
+        raise ValueError("parent_masses and parent_total_errors must have the same length")
+    total_mass = sum(parent_masses)
+    if total_mass <= 0.0:
+        return 0.0
+    return sum((mass / total_mass) * error for mass, error in zip(parent_masses, parent_total_errors))
+
+
+def total_error_certificate(inherited_error: float, fit_error: float) -> float:
+    """Combine inherited and local fit certificates using the triangle bound."""
+    return max(0.0, inherited_error) + max(0.0, fit_error)
+
+
 def mean_absolute_error(empirical: list[float], model: list[float]) -> float:
     empirical, model = pad_to(empirical, model)
     if not empirical:
@@ -323,6 +358,7 @@ def compare_models(empirical: list[float], model_builders) -> list[dict[str, obj
             "model": model_name,
             "l1_error": l1_error(empirical, model),
             "max_cdf_error": max_cdf_error(empirical, model),
+            "w1_cdf_error": w1_cdf_error(empirical, model),
             "mean_absolute_error": mean_absolute_error(empirical, model),
             "model_mean_excess": model_mean,
             "model_variance_excess": model_variance,

--- a/scripts/lmdb_parent_recurrence_histogram_benchmark.py
+++ b/scripts/lmdb_parent_recurrence_histogram_benchmark.py
@@ -17,7 +17,14 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.distribution_fit_comparison import exact_excess_distribution, l1_error, max_cdf_error
+from scripts.distribution_fit_comparison import (
+    exact_excess_distribution,
+    l1_error,
+    max_cdf_error,
+    total_error_certificate,
+    w1_cdf_error,
+    weighted_parent_certificate,
+)
 from scripts.lmdb_parent_branching_diagnostic import LmdbCategoryGraph, parse_int_list, select_targets_by_child_depth
 from scripts.lmdb_parent_histogram_benchmark import bounded_parent_histogram, percentile, safe_graph_name
 from scripts.parent_histogram_recurrence import recurrence_parent_histogram
@@ -34,20 +41,25 @@ def histogram_error(left_hist, right_hist):
     left, _left_origin = exact_excess_distribution(left_hist)
     right, _right_origin = exact_excess_distribution(right_hist)
     if not left and not right:
-        return 0.0, 0.0
+        return 0.0, 0.0, 0.0
     if not left or not right:
-        return 1.0, 1.0
-    return l1_error(left, right), max_cdf_error(left, right)
+        return 1.0, 1.0, 1.0
+    return l1_error(left, right), max_cdf_error(left, right), w1_cdf_error(left, right)
 
 
 def comparison_record(args, target, child_depth, budget, dfs_hist, dfs_stats, dfs_time, recurrence_hist, recurrence_stats, recurrence_time):
-    l1, cdf = histogram_error(dfs_hist, recurrence_hist)
+    l1, cdf, w1 = histogram_error(dfs_hist, recurrence_hist)
     dfs_paths = sum(dfs_hist.values())
     recurrence_paths = sum(recurrence_hist.values())
+    inherited_max_cdf = weighted_parent_certificate([], [])
+    inherited_w1 = weighted_parent_certificate([], [])
+    total_max_cdf = total_error_certificate(inherited_max_cdf, cdf)
+    total_w1 = total_error_certificate(inherited_w1, w1)
     return {
         "record_type": "parent_recurrence_histogram_comparison",
         "graph": args.graph_name,
         "root": args.root,
+        "certificate_mode": "observed_recurrence_vs_dfs",
         "target_node": target,
         "child_sample_depth": child_depth,
         "budget": budget,
@@ -58,6 +70,13 @@ def comparison_record(args, target, child_depth, budget, dfs_hist, dfs_stats, df
         "path_count_delta": recurrence_paths - dfs_paths,
         "l1_error": l1,
         "max_cdf_error": cdf,
+        "w1_cdf_error": w1,
+        "inherited_error_max_cdf": inherited_max_cdf,
+        "inherited_error_w1_cdf": inherited_w1,
+        "fit_error_max_cdf": cdf,
+        "fit_error_w1_cdf": w1,
+        "total_error_max_cdf": total_max_cdf,
+        "total_error_w1_cdf": total_w1,
         "dfs_nodes_expanded": dfs_stats.nodes_expanded,
         "recurrence_states_evaluated": recurrence_stats.states_evaluated,
         "state_expansion_ratio": 0.0 if dfs_stats.nodes_expanded == 0 else recurrence_stats.states_evaluated / dfs_stats.nodes_expanded,
@@ -99,6 +118,9 @@ def summarize(records):
             "mean_l1_error": mean(row["l1_error"] for row in bucket),
             "p95_l1_error": percentile([row["l1_error"] for row in bucket], 95),
             "mean_max_cdf_error": mean(row["max_cdf_error"] for row in bucket),
+            "mean_w1_cdf_error": mean(row["w1_cdf_error"] for row in bucket),
+            "mean_total_error_max_cdf": mean(row["total_error_max_cdf"] for row in bucket),
+            "mean_total_error_w1_cdf": mean(row["total_error_w1_cdf"] for row in bucket),
             "mean_state_expansion_ratio": mean(row["state_expansion_ratio"] for row in bucket),
             "mean_time_ratio": mean(row["time_ratio"] for row in bucket),
             "dfs_capped_rows": sum(1 for row in bucket if row["dfs_path_cap_hit"] or row["dfs_expansion_cap_hit"]),
@@ -111,18 +133,19 @@ def markdown_summary(summary):
     lines = [
         "# Parent Histogram Recurrence Benchmark",
         "",
-        "| budget | rows | exact_matches | cycle_approx | mean_l1 | mean_cdf | mean_state_ratio | mean_time_ratio | dfs_capped | recurrence_capped |",
-        "|-------:|-----:|--------------:|-------------:|--------:|---------:|-----------------:|----------------:|-----------:|------------------:|",
+        "| budget | rows | exact_matches | cycle_approx | mean_l1 | mean_cdf | mean_w1 | mean_state_ratio | mean_time_ratio | dfs_capped | recurrence_capped |",
+        "|-------:|-----:|--------------:|-------------:|--------:|---------:|--------:|-----------------:|----------------:|-----------:|------------------:|",
     ]
     for row in summary["budget_rows"]:
         lines.append(
-            "| {budget} | {rows} | {exact} | {cycle} | {l1:.6f} | {cdf:.6f} | {state_ratio:.3f} | {time_ratio:.3f} | {dfs_capped} | {rec_capped} |".format(
+            "| {budget} | {rows} | {exact} | {cycle} | {l1:.6f} | {cdf:.6f} | {w1:.6f} | {state_ratio:.3f} | {time_ratio:.3f} | {dfs_capped} | {rec_capped} |".format(
                 budget=row["budget"],
                 rows=row["rows"],
                 exact=row["exact_match_rows"],
                 cycle=row["cycle_approximation_rows"],
                 l1=row["mean_l1_error"],
                 cdf=row["mean_max_cdf_error"],
+                w1=row["mean_w1_cdf_error"],
                 state_ratio=row["mean_state_expansion_ratio"],
                 time_ratio=row["mean_time_ratio"],
                 dfs_capped=row["dfs_capped_rows"],

--- a/tests/test_distribution_fit_comparison.py
+++ b/tests/test_distribution_fit_comparison.py
@@ -17,8 +17,12 @@ from scripts.distribution_fit_comparison import (
     nfold_convolution,
     append_realized_support_table,
     run_graph_fit_comparison,
+    shift_distribution,
     size_biased_excess_pmf,
     summarize,
+    total_error_certificate,
+    w1_cdf_error,
+    weighted_parent_certificate,
 )
 from tools.distribution_cache_support import FIXTURES, ROOT
 
@@ -40,6 +44,26 @@ class DistributionFitComparisonTests(unittest.TestCase):
         self.assertAlmostEqual(params["probability"], 0.25)
         self.assertLess(l1_error([0.75, 0.25], model), 1e-12)
         self.assertLess(max_cdf_error([0.75, 0.25], model), 1e-12)
+
+    def test_cdf_error_certificates_are_shift_invariant(self):
+        exact = [0.2, 0.3, 0.5]
+        model = [0.1, 0.4, 0.5]
+
+        self.assertAlmostEqual(max_cdf_error(exact, model), max_cdf_error(shift_distribution(exact), shift_distribution(model)))
+        self.assertAlmostEqual(w1_cdf_error(exact, model), w1_cdf_error(shift_distribution(exact), shift_distribution(model)))
+
+    def test_weighted_parent_certificate_uses_mass_weights(self):
+        inherited = weighted_parent_certificate([2.0, 6.0], [0.1, 0.3])
+
+        self.assertAlmostEqual(inherited, 0.25)
+
+    def test_error_certificate_adds_inherited_and_fit_terms(self):
+        self.assertAlmostEqual(total_error_certificate(0.2, 0.05), 0.25)
+        self.assertAlmostEqual(total_error_certificate(-0.2, 0.05), 0.05)
+
+    def test_weighted_parent_certificate_rejects_mismatched_inputs(self):
+        with self.assertRaises(ValueError):
+            weighted_parent_certificate([1.0], [0.1, 0.2])
 
     def test_fitted_gamma_degenerates_for_one_point_histogram(self):
         model, params = fitted_gamma_pmf([1.0])

--- a/tests/test_lmdb_parent_recurrence_histogram_benchmark.py
+++ b/tests/test_lmdb_parent_recurrence_histogram_benchmark.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Tests for parent recurrence histogram benchmark reporting helpers."""
+
+import unittest
+
+from scripts.lmdb_parent_recurrence_histogram_benchmark import histogram_error, markdown_summary, summarize
+
+
+class ParentRecurrenceHistogramBenchmarkTests(unittest.TestCase):
+    def test_histogram_error_reports_l1_cdf_and_w1(self):
+        l1, cdf, w1 = histogram_error({1: 1, 2: 1}, {1: 2})
+
+        self.assertAlmostEqual(l1, 1.0)
+        self.assertAlmostEqual(cdf, 0.5)
+        self.assertAlmostEqual(w1, 0.5)
+
+    def test_summary_reports_w1_and_certificate_fields(self):
+        summary = summarize([
+            {
+                "record_type": "parent_recurrence_histogram_comparison",
+                "graph": "fixture",
+                "budget": 4,
+                "dfs_histogram": {1: 1},
+                "recurrence_histogram": {1: 1},
+                "recurrence_cycle_approximation": False,
+                "l1_error": 0.0,
+                "max_cdf_error": 0.0,
+                "w1_cdf_error": 0.0,
+                "total_error_max_cdf": 0.0,
+                "total_error_w1_cdf": 0.0,
+                "state_expansion_ratio": 0.25,
+                "time_ratio": 0.5,
+                "dfs_path_cap_hit": False,
+                "dfs_expansion_cap_hit": False,
+                "recurrence_path_cap_hit": False,
+                "recurrence_expansion_cap_hit": False,
+            }
+        ])
+
+        row = summary["budget_rows"][0]
+        self.assertEqual(row["mean_w1_cdf_error"], 0.0)
+        self.assertEqual(row["mean_total_error_max_cdf"], 0.0)
+        self.assertEqual(row["mean_total_error_w1_cdf"], 0.0)
+        self.assertIn("mean_w1", markdown_summary(summary))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# [codex] Add distribution error certificate helpers

## Summary
- Add `w1_cdf_error`, shift-invariance support, and scalar parent-certificate propagation helpers.
- Emit W1 and certificate fields from the parent recurrence histogram benchmark.
- Add focused tests for shift invariance, weighted inherited errors, total error certificates, and benchmark reporting.

## Validation
- `python3 -m py_compile scripts/distribution_fit_comparison.py scripts/lmdb_parent_recurrence_histogram_benchmark.py`
- `python3 -m unittest tests.test_distribution_fit_comparison tests.test_lmdb_parent_recurrence_histogram_benchmark`
- `git diff --check`