### PR TITLE
Support PLAWK END string literal printing

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -268,6 +268,8 @@ and table increments without per-record WAM dispatch for the supported surface.
 Mixed scalar/associative programs use a combined native state plan: scalar
 counters remain `i64` phi slots, assoc arrays remain runtime table pointers, and
 `END` printing can interleave scalar variables with associative lookups.
+`END` printing also supports string literal fields for report labels; codegen
+emits indexed string globals and prints them with the same separator rules.
 
 **Success:** a user-written awk-style program parses, lowers, compiles, and
 produces correct output on standard awk test cases.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -90,7 +90,8 @@ counters, so `$1 == "ERROR" { by_component[$2]++ }` only updates on matches. Eac
 grows and rehashes as needed, and the native stream reader grows its line buffer
 without consuming WAM arena space per record. Mixed scalar/associative state is
 supported in the same native loop, e.g. `{ total++; counts[$1]++ }` with an
-`END` print of both `total` and `counts["ERROR"]`.
+`END` print of both `total` and `counts["ERROR"]`. `END` print fields can also
+include literal labels such as `print "total", total, "errors", counts["ERROR"]`.
 
 For a walkthrough of the current Prolog-core syntax and how it maps to awk
 concepts like `$0`, `$1`, `NR`, `NF`, `FS`, `OFS`, and `print`, see

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -210,6 +210,19 @@ associative arrays in runtime tables. For the sample input, that prints:
 4 2 1 1
 ```
 
+`END` print fields can include literal labels:
+
+```awk
+{ total++; counts[$1]++ }
+END { print "total", total, "errors", counts["ERROR"] }
+```
+
+That prints:
+
+```text
+total 4 errors 2
+```
+
 This path keeps the streaming loop native while the WAM runtime supplies the
 reader, atom helpers, and reusable associative table primitive.
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -23,6 +23,7 @@
 %      { counts[$1]++ } END { print counts["ERROR"], counts["WARN"] }
 %      $N == "VALUE" { counts[$M]++ } END { print counts["KEY"] }
 %      { total++; counts[$1]++ } END { print total, counts["ERROR"] }
+%      { total++ } END { print "total", total }
 %
 %  The surrounding runtime still comes from write_wam_llvm_project/3. This
 %  function emits the target-specific native main that streams the file, lowers
@@ -62,13 +63,15 @@ plawk_program_native_driver_ir(
 ) :-
     plawk_mixed_state_plan(Rules, PrintFields, MixedPlan),
     MixedPlan = mixed_plan(ScalarPlan, AssocPlan, _PlannedRules),
+    plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_assoc_print_key_globals(PrintFields, AssocGlobalIR),
     plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
     plawk_mixed_rule_chain_ir(MixedPlan, RuleGlobalIR, RuleChainIR, RuleCount),
     plawk_state_loop_phi_ir(ScalarPlan, LoopPhiIR),
     plawk_mixed_scalar_next_phi_ir(ScalarPlan, RuleCount, NextPhiIR),
     plawk_mixed_end_print_ir(PrintFields, ScalarPlan, AssocPlan, EndPrintIR),
-    format(atom(SurfaceGlobalIR), '~w~n~w', [AssocGlobalIR, RuleGlobalIR]),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
+        [StringGlobalIR, AssocGlobalIR, RuleGlobalIR]),
     plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
@@ -86,11 +89,13 @@ plawk_program_native_driver_ir(
     DriverIR
 ) :-
     plawk_scalar_state_plan(Rules, PrintFields, StatePlan),
+    plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_scalar_rule_chain_ir(Rules, StatePlan, RuleGlobalIR, RuleChainIR, RuleCount),
     plawk_state_loop_phi_ir(StatePlan, LoopPhiIR),
     plawk_scalar_next_phi_ir(StatePlan, RuleCount, NextPhiIR),
     plawk_scalar_end_print_ir(PrintFields, StatePlan, EndPrintIR),
-    plawk_i64_end_print_globals(RuleGlobalIR, RuntimeGlobals),
+    format(atom(SurfaceGlobalIR), '~w~n~w', [StringGlobalIR, RuleGlobalIR]),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
 ~w
@@ -107,11 +112,13 @@ plawk_program_native_driver_ir(
     DriverIR
 ) :-
     plawk_assoc_runtime_count_plan(Rules, PrintFields, AssocPlan),
+    plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_assoc_print_key_globals(PrintFields, AssocGlobalIR),
     plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
     plawk_assoc_rule_chain_ir(AssocPlan, AssocRuleGlobalIR, AssocChainIR),
     plawk_assoc_end_print_ir(PrintFields, AssocPlan, EndPrintIR),
-    format(atom(SurfaceGlobalIR), '~w~n~w', [AssocGlobalIR, AssocRuleGlobalIR]),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
+        [StringGlobalIR, AssocGlobalIR, AssocRuleGlobalIR]),
     plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
@@ -128,6 +135,7 @@ plawk_i64_end_print_globals(SurfaceGlobals, RuntimeGlobals) :-
 '@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"
 @.plawk_surface_print_space = private constant [2 x i8] c" \\00"
 @.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
+@.plawk_surface_print_string = private constant [3 x i8] c"%s\\00"
 ~w
 
 ',
@@ -261,7 +269,11 @@ plawk_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
         ),
         ActionVars),
     ActionVars \== [],
-    maplist(plawk_scalar_print_expr, PrintFields, PrintVars),
+    findall(Name,
+        ( member(Field, PrintFields),
+          plawk_scalar_print_expr(Field, Name)
+        ),
+        PrintVars),
     append(ActionVars, PrintVars, Names0),
     sort(Names0, Names),
     maplist(plawk_scalar_state_slot, Names, Slots).
@@ -456,7 +468,11 @@ plawk_assoc_runtime_count_plan(
 ) :-
     maplist(plawk_assoc_rule_action_specs, Rules, RuleSpecs),
     RuleSpecs \== [],
-    maplist(plawk_assoc_print_array, PrintFields, PrintArrays),
+    findall(ArrayName,
+        ( member(Field, PrintFields),
+          plawk_assoc_print_array(Field, ArrayName)
+        ),
+        PrintArrays),
     PrintArrays \== [],
     findall(ArrayName,
         ( member(rule(_Pattern, ActionSpecs), RuleSpecs),
@@ -620,6 +636,30 @@ plawk_assoc_print_key_globals(PrintFields, GlobalIR) :-
     phrase(plawk_assoc_print_key_global_lines(PrintFields, 0), Lines),
     atomic_list_concat(Lines, '\n', GlobalIR).
 
+plawk_end_print_string_globals(PrintFields, GlobalIR) :-
+    phrase(plawk_end_print_string_global_lines(PrintFields, 0), Lines),
+    atomic_list_concat(Lines, '\n', GlobalIR).
+
+plawk_end_print_string_global_lines([], _) -->
+    [].
+plawk_end_print_string_global_lines([string(Value) | Rest], Index) -->
+    { string_codes(Value, Codes),
+      length(Codes, StringLen),
+      BytesLen is StringLen + 1,
+      llvm_c_bytes(Codes, Bytes),
+      format(atom(Line),
+          '@.plawk_end_print_string_~w = private constant [~w x i8] c"~w\\00"',
+          [Index, BytesLen, Bytes]),
+      NextIndex is Index + 1
+    },
+    [Line],
+    plawk_end_print_string_global_lines(Rest, NextIndex).
+plawk_end_print_string_global_lines([Field | Rest], Index) -->
+    { \+ Field = string(_),
+      NextIndex is Index + 1
+    },
+    plawk_end_print_string_global_lines(Rest, NextIndex).
+
 plawk_assoc_print_key_global_lines([], _) -->
     [].
 plawk_assoc_print_key_global_lines([assoc(var(_ArrayName), string(Key)) | Rest], Index) -->
@@ -678,6 +718,11 @@ plawk_assoc_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], AssocPl
       NextPrintIndex is PrintIndex + 1
     },
     [KeyPtr, KeyId, Value, FmtPtr, PrintCall],
+    plawk_assoc_end_print_lines(Rest, AssocPlan, NextPrintIndex).
+plawk_assoc_end_print_lines([string(Value) | Rest], AssocPlan, PrintIndex) -->
+    plawk_scalar_end_separator_lines(PrintIndex),
+    plawk_end_string_print_lines(Value, PrintIndex),
+    { NextPrintIndex is PrintIndex + 1 },
     plawk_assoc_end_print_lines(Rest, AssocPlan, NextPrintIndex).
 
 plawk_assoc_table_index(assoc_plan(Tables, _Actions), ArrayName, TableIndex) :-
@@ -742,6 +787,11 @@ plawk_mixed_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], ScalarP
       NextPrintIndex is PrintIndex + 1
     },
     [KeyPtr, KeyId, Value, FmtPtr, PrintCall],
+    plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, NextPrintIndex).
+plawk_mixed_end_print_lines([string(Value) | Rest], ScalarPlan, AssocPlan, PrintIndex) -->
+    plawk_scalar_end_separator_lines(PrintIndex),
+    plawk_end_string_print_lines(Value, PrintIndex),
+    { NextPrintIndex is PrintIndex + 1 },
     plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, NextPrintIndex).
 
 plawk_scalar_increment_action(inc(var(Name)), Name).
@@ -903,6 +953,27 @@ plawk_scalar_end_print_lines([var(Name) | Rest], StatePlan, PrintIndex) -->
     },
     [FmtPtr, PrintCall],
     plawk_scalar_end_print_lines(Rest, StatePlan, NextPrintIndex).
+plawk_scalar_end_print_lines([string(Value) | Rest], StatePlan, PrintIndex) -->
+    plawk_scalar_end_separator_lines(PrintIndex),
+    plawk_end_string_print_lines(Value, PrintIndex),
+    { NextPrintIndex is PrintIndex + 1 },
+    plawk_scalar_end_print_lines(Rest, StatePlan, NextPrintIndex).
+
+plawk_end_string_print_lines(Value, PrintIndex) -->
+    { string_codes(Value, Codes),
+      length(Codes, StringLen),
+      BytesLen is StringLen + 1,
+      format(atom(StringPtr),
+          '  %end_string_~w_ptr = getelementptr [~w x i8], [~w x i8]* @.plawk_end_print_string_~w, i32 0, i32 0',
+          [PrintIndex, BytesLen, BytesLen, PrintIndex]),
+      format(atom(FmtPtr),
+          '  %end_string_fmt_~w = getelementptr [3 x i8], [3 x i8]* @.plawk_surface_print_string, i32 0, i32 0',
+          [PrintIndex]),
+      format(atom(PrintCall),
+          '  %printed_end_string_~w = call i32 (i8*, ...) @printf(i8* %end_string_fmt_~w, i8* %end_string_~w_ptr)',
+          [PrintIndex, PrintIndex, PrintIndex])
+    },
+    [StringPtr, FmtPtr, PrintCall].
 
 plawk_scalar_end_separator_lines(0) -->
     !,
@@ -917,6 +988,9 @@ plawk_scalar_end_separator_lines(PrintIndex) -->
     },
     [SpacePtr, SpaceCall].
 
+plawk_pattern_guard_ir(always, GuardIR) :-
+    GuardIR = ''-'  %is_match = icmp eq i1 true, true'.
+
 plawk_pattern_guard_ir(prefix(Prefix), GuardIR) :-
     llvm_emit_atom_prefix_guard(plawk_surface_prefix, '%line', Prefix,
         '%is_match', GuardIR).
@@ -924,6 +998,10 @@ plawk_pattern_guard_ir(prefix(Prefix), GuardIR) :-
 plawk_pattern_guard_ir(field_eq(Index, Value), GuardIR) :-
     llvm_emit_atom_field_eq_guard(plawk_surface_field_eq, '%line', Index, Value,
         32, '%is_match', GuardIR).
+
+plawk_pattern_guard_ir(always, _GlobalBase, MatchValue, GuardIR) :-
+    format(atom(GuardCallIR), '  ~w = icmp eq i1 true, true', [MatchValue]),
+    GuardIR = ''-GuardCallIR.
 
 plawk_pattern_guard_ir(prefix(Prefix), GlobalBase, MatchValue, GuardIR) :-
     llvm_emit_atom_prefix_guard(GlobalBase, '%line', Prefix, MatchValue,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -16,6 +16,7 @@
 %      $N == "VALUE" { errors++; matches++ } END { print errors, matches }
 %      $N == "ERROR" { errors++ } $N == "WARN" { warnings++ } END { print errors, warnings }
 %      { counts[$1]++ } END { print counts["ERROR"], counts["WARN"] }
+%      { count++ } END { print "count", count }
 %
 %  The AST is deliberately small and explicit so later syntax can extend it
 %  without changing the native codegen contract.
@@ -213,6 +214,10 @@ field_expr(field(Index)) -->
     { IndexCodes \== [],
       number_codes(Index, IndexCodes),
       Index >= 0
+    }.
+field_expr(string(Value)) -->
+    quoted_string(ValueCodes),
+    { string_codes(Value, ValueCodes)
     }.
 field_expr(var(Name)) -->
     identifier(Name).

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -88,6 +88,22 @@ test(parses_mixed_scalar_assoc_end_print_rule) :-
             assoc(var(by_component), string("disk"))
         ])])])).
 
+test(parses_end_print_string_literal_fields) :-
+    plawk_parse_string("{ total++ } END { print \"total\", total }\n", Program),
+    assertion(Program == program([], [rule(always, [inc(var(total))])],
+        [end([print([string("total"), var(total)])])])).
+
+test(parses_mixed_end_print_string_literal_fields) :-
+    plawk_parse_string("{ total++; counts[$1]++ } END { print \"total\", total, \"errors\", counts[\"ERROR\"] }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [inc(var(total)), inc_assoc(var(counts), field(1))])],
+        [end([print([
+            string("total"),
+            var(total),
+            string("errors"),
+            assoc(var(counts), string("ERROR"))
+        ])])])).
+
 test(surface_prefix_prints_matching_records) :-
     run_surface_print_smoke("/^ERROR/ { print $0 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -123,6 +139,11 @@ test(surface_multi_rule_accumulates_overlapping_matches) :-
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "4\n").
 
+test(surface_scalar_end_prints_string_literals) :-
+    run_surface_print_smoke("{ total++ } END { print \"total\", total }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "total 4\n").
+
 test(surface_assoc_counts_requested_keys) :-
     run_surface_print_smoke("{ counts[$1]++ } END { print counts[\"ERROR\"], counts[\"WARN\"] }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -142,6 +163,16 @@ test(surface_mixed_scalar_assoc_counts) :-
     run_surface_print_smoke("{ total++; counts[$1]++ } $1 == \"ERROR\" { errors++; by_component[$2]++ } END { print total, errors, counts[\"WARN\"], by_component[\"disk\"] }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "4 2 1 1\n").
+
+test(surface_assoc_end_prints_string_literals) :-
+    run_surface_print_smoke("{ counts[$1]++ } END { print \"errors\", counts[\"ERROR\"], \"warnings\", counts[\"WARN\"] }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "errors 2 warnings 1\n").
+
+test(surface_mixed_end_prints_string_literals) :-
+    run_surface_print_smoke("{ total++; counts[$1]++ } END { print \"total\", total, \"errors\", counts[\"ERROR\"] }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "total 4 errors 2\n").
 
 test(surface_assoc_counts_resize_runtime_table) :-
     findall(Line,
@@ -208,6 +239,17 @@ test(surface_mixed_scalar_assoc_uses_native_state_and_tables) :-
     assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_rule_0_action_0:'))),
     assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_rule_1_action_0:'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_end_string_literals_use_indexed_globals) :-
+    plawk_parse_string("{ total++; counts[$1]++ } END { print \"total\", total, \"errors\", counts[\"ERROR\"] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_string = private constant [3 x i8] c"%s\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_end_print_string_0 = private constant [6 x i8]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_end_print_string_2 = private constant [7 x i8]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_end_string_0 = call i32'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_end_string_2 = call i32'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_assoc_print_key_3 = private constant [6 x i8]'))),
     !.
 
 run_surface_print_smoke(Source, Input, ExpectedOutput) :-


### PR DESCRIPTION
## Summary
- Parse quoted string literals as `print` fields.
- Emit indexed LLVM globals for `END` string literal labels and print them with existing separator rules.
- Support string literals across scalar-only, assoc-only, and mixed scalar/assoc `END` printing paths.
- Ignore string literal fields during scalar/assoc state planning so they can be interleaved with counters and table lookups.
- Add native `always` guard lowering for scalar-only always-rule counters surfaced by `{ total++ } END { ... }`.
- Update PLAWK docs/tutorial examples for labeled reports.

## Tests
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `git diff --cached --check`
- `git diff --check`

Note: `tests/test_wam_llvm_target.pl` still reports existing choicepoint warnings while exiting 0.