### PR TITLE
Support PLAWK BEGIN literal printing

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -270,6 +270,8 @@ counters remain `i64` phi slots, assoc arrays remain runtime table pointers, and
 `END` printing can interleave scalar variables with associative lookups.
 `END` printing also supports string literal fields for report labels; codegen
 emits indexed string globals and prints them with the same separator rules.
+The first `BEGIN` slice emits literal `print` headers before stream setup, using
+separate indexed string globals so it does not collide with `END` literals.
 
 **Success:** a user-written awk-style program parses, lowers, compiles, and
 produces correct output on standard awk test cases.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -88,7 +88,8 @@ source array rather than specializing the `END` keys to fixed slots. Guarded
 associative count rules lower through the same native rule-chain shape as scalar
 counters, so `$1 == "ERROR" { by_component[$2]++ }` only updates on matches. Each table
 grows and rehashes as needed, and the native stream reader grows its line buffer
-without consuming WAM arena space per record. Mixed scalar/associative state is
+without consuming WAM arena space per record. `BEGIN` print clauses can emit
+literal report headers before the stream opens. Mixed scalar/associative state is
 supported in the same native loop, e.g. `{ total++; counts[$1]++ }` with an
 `END` print of both `total` and `counts["ERROR"]`. `END` print fields can also
 include literal labels such as `print "total", total, "errors", counts["ERROR"]`.

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -223,6 +223,21 @@ That prints:
 total 4 errors 2
 ```
 
+`BEGIN` can emit literal report headers before the first input record is read:
+
+```awk
+BEGIN { print "kind", "count" }
+{ total++ }
+END { print "total", total }
+```
+
+For the sample input, that prints:
+
+```text
+kind count
+total 4
+```
+
 This path keeps the streaming loop native while the WAM runtime supplies the
 reader, atom helpers, and reusable associative table primitive.
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -24,15 +24,18 @@
 %      $N == "VALUE" { counts[$M]++ } END { print counts["KEY"] }
 %      { total++; counts[$1]++ } END { print total, counts["ERROR"] }
 %      { total++ } END { print "total", total }
+%      BEGIN { print "kind", "count" } { total++ } END { print "total", total }
 %
 %  The surrounding runtime still comes from write_wam_llvm_project/3. This
 %  function emits the target-specific native main that streams the file, lowers
 %  the deterministic guard, and prints matching records.
 plawk_program_native_driver_ir(
-    program([], [rule(Pattern, [print(Fields)])], []),
+    program(BeginClauses, [rule(Pattern, [print(Fields)])], []),
     InputPath,
     DriverIR
 ) :-
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, BeginIR),
     plawk_pattern_guard_ir(Pattern, GuardGlobalIR-GuardCallIR),
     plawk_print_action_ir(Fields, PrintActionIR),
     format(atom(RecordIR),
@@ -48,21 +51,25 @@ print_line:
 @.plawk_surface_print_slice = private constant [5 x i8] c"%.*s\\00"
 @.plawk_surface_print_space = private constant [2 x i8] c" \\00"
 @.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
+@.plawk_surface_print_string = private constant [3 x i8] c"%s\\00"
+~w
 ~w
 ',
-        [GuardGlobalIR]),
+        [BeginGlobalIR, GuardGlobalIR]),
     plawk_stream_driver_ir(InputPath,
-        driver_blocks(RuntimeGlobals, '', lowered_match, RecordIR, '',
+        driver_blocks(RuntimeGlobals, BeginIR, '', lowered_match, RecordIR, '',
             success, 'success:\n  ret i32 0'),
         DriverIR).
 
 plawk_program_native_driver_ir(
-    program([], Rules, [end([print(PrintFields)])]),
+    program(BeginClauses, Rules, [end([print(PrintFields)])]),
     InputPath,
     DriverIR
 ) :-
     plawk_mixed_state_plan(Rules, PrintFields, MixedPlan),
     MixedPlan = mixed_plan(ScalarPlan, AssocPlan, _PlannedRules),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, BeginIR),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_assoc_print_key_globals(PrintFields, AssocGlobalIR),
     plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
@@ -70,8 +77,9 @@ plawk_program_native_driver_ir(
     plawk_state_loop_phi_ir(ScalarPlan, LoopPhiIR),
     plawk_mixed_scalar_next_phi_ir(ScalarPlan, RuleCount, NextPhiIR),
     plawk_mixed_end_print_ir(PrintFields, ScalarPlan, AssocPlan, EndPrintIR),
-    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
-        [StringGlobalIR, AssocGlobalIR, RuleGlobalIR]),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, AssocGlobalIR, RuleGlobalIR]),
+    plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
     plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
@@ -79,22 +87,25 @@ plawk_program_native_driver_ir(
   ret i32 0',
         [EndPrintIR]),
     plawk_stream_driver_ir(InputPath,
-        driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, lowered_mixed,
+        driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, LoopPhiIR, lowered_mixed,
             RuleChainIR, NextPhiIR, end_print, CloseOkIR),
         DriverIR).
 
 plawk_program_native_driver_ir(
-    program([], Rules, [end([print(PrintFields)])]),
+    program(BeginClauses, Rules, [end([print(PrintFields)])]),
     InputPath,
     DriverIR
 ) :-
     plawk_scalar_state_plan(Rules, PrintFields, StatePlan),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, BeginIR),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_scalar_rule_chain_ir(Rules, StatePlan, RuleGlobalIR, RuleChainIR, RuleCount),
     plawk_state_loop_phi_ir(StatePlan, LoopPhiIR),
     plawk_scalar_next_phi_ir(StatePlan, RuleCount, NextPhiIR),
     plawk_scalar_end_print_ir(PrintFields, StatePlan, EndPrintIR),
-    format(atom(SurfaceGlobalIR), '~w~n~w', [StringGlobalIR, RuleGlobalIR]),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, RuleGlobalIR]),
     plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
@@ -102,23 +113,26 @@ plawk_program_native_driver_ir(
   ret i32 0',
         [EndPrintIR]),
     plawk_stream_driver_ir(InputPath,
-        driver_blocks(RuntimeGlobals, LoopPhiIR, lowered_match, RuleChainIR,
+        driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RuleChainIR,
             NextPhiIR, end_print, CloseOkIR),
         DriverIR).
 
 plawk_program_native_driver_ir(
-    program([], Rules, [end([print(PrintFields)])]),
+    program(BeginClauses, Rules, [end([print(PrintFields)])]),
     InputPath,
     DriverIR
 ) :-
     plawk_assoc_runtime_count_plan(Rules, PrintFields, AssocPlan),
+    plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
+    plawk_begin_print_ir(BeginClauses, BeginIR),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_assoc_print_key_globals(PrintFields, AssocGlobalIR),
     plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
     plawk_assoc_rule_chain_ir(AssocPlan, AssocRuleGlobalIR, AssocChainIR),
     plawk_assoc_end_print_ir(PrintFields, AssocPlan, EndPrintIR),
-    format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
-        [StringGlobalIR, AssocGlobalIR, AssocRuleGlobalIR]),
+    format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
+        [BeginGlobalIR, StringGlobalIR, AssocGlobalIR, AssocRuleGlobalIR]),
+    plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
     plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
@@ -126,9 +140,16 @@ plawk_program_native_driver_ir(
   ret i32 0',
         [EndPrintIR]),
     plawk_stream_driver_ir(InputPath,
-        driver_blocks(RuntimeGlobals, EntrySetupIR, '', lowered_assoc,
+        driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, '', lowered_assoc,
             AssocChainIR, '', end_print, CloseOkIR),
         DriverIR).
+
+plawk_combine_entry_ir('', IR, IR) :-
+    !.
+plawk_combine_entry_ir(IR, '', IR) :-
+    !.
+plawk_combine_entry_ir(FirstIR, SecondIR, CombinedIR) :-
+    format(atom(CombinedIR), '~w~n~w', [FirstIR, SecondIR]).
 
 plawk_i64_end_print_globals(SurfaceGlobals, RuntimeGlobals) :-
     format(atom(RuntimeGlobals),
@@ -631,6 +652,76 @@ plawk_assoc_rule_action_blocks(RuleIndex, [assoc_action(Index, _ArrayName, Table
     },
     [Label, Slice, Ptr, Len, Missing, Branch, '', HaveLabel, KeyId, Inc, Next, ''],
     plawk_assoc_rule_action_blocks(RuleIndex, Rest, NextLabel).
+
+plawk_begin_print_string_globals(BeginClauses, GlobalIR) :-
+    plawk_begin_print_fields(BeginClauses, Fields),
+    phrase(plawk_begin_print_string_global_lines(Fields, 0), Lines),
+    atomic_list_concat(Lines, '\n', GlobalIR).
+
+plawk_begin_print_fields([], []).
+plawk_begin_print_fields([begin([print(Fields)])], Fields).
+
+plawk_begin_print_string_global_lines([], _) -->
+    [].
+plawk_begin_print_string_global_lines([string(Value) | Rest], Index) -->
+    { string_codes(Value, Codes),
+      length(Codes, StringLen),
+      BytesLen is StringLen + 1,
+      llvm_c_bytes(Codes, Bytes),
+      format(atom(Line),
+          '@.plawk_begin_print_string_~w = private constant [~w x i8] c"~w\\00"',
+          [Index, BytesLen, Bytes]),
+      NextIndex is Index + 1
+    },
+    [Line],
+    plawk_begin_print_string_global_lines(Rest, NextIndex).
+
+plawk_begin_print_ir([], '') :-
+    !.
+plawk_begin_print_ir([begin([print(Fields)])], IR) :-
+    maplist(plawk_begin_print_field, Fields),
+    phrase(plawk_begin_print_lines(Fields, 0), Lines),
+    atomic_list_concat(Lines, '\n', IR).
+
+plawk_begin_print_field(string(_)).
+
+plawk_begin_print_lines([], _) -->
+    ['  %begin_newline_fmt = getelementptr [2 x i8], [2 x i8]* @.plawk_surface_print_newline, i32 0, i32 0',
+     '  %printed_begin_newline = call i32 (i8*, ...) @printf(i8* %begin_newline_fmt)'].
+plawk_begin_print_lines([string(Value) | Rest], Index) -->
+    plawk_begin_separator_lines(Index),
+    plawk_begin_string_print_lines(Value, Index),
+    { NextIndex is Index + 1 },
+    plawk_begin_print_lines(Rest, NextIndex).
+
+plawk_begin_separator_lines(0) -->
+    !,
+    [].
+plawk_begin_separator_lines(Index) -->
+    { format(atom(SpacePtr),
+          '  %begin_space_fmt_~w = getelementptr [2 x i8], [2 x i8]* @.plawk_surface_print_space, i32 0, i32 0',
+          [Index]),
+      format(atom(SpaceCall),
+          '  %printed_begin_space_~w = call i32 (i8*, ...) @printf(i8* %begin_space_fmt_~w)',
+          [Index, Index])
+    },
+    [SpacePtr, SpaceCall].
+
+plawk_begin_string_print_lines(Value, Index) -->
+    { string_codes(Value, Codes),
+      length(Codes, StringLen),
+      BytesLen is StringLen + 1,
+      format(atom(StringPtr),
+          '  %begin_string_~w_ptr = getelementptr [~w x i8], [~w x i8]* @.plawk_begin_print_string_~w, i32 0, i32 0',
+          [Index, BytesLen, BytesLen, Index]),
+      format(atom(FmtPtr),
+          '  %begin_string_fmt_~w = getelementptr [3 x i8], [3 x i8]* @.plawk_surface_print_string, i32 0, i32 0',
+          [Index]),
+      format(atom(PrintCall),
+          '  %printed_begin_string_~w = call i32 (i8*, ...) @printf(i8* %begin_string_fmt_~w, i8* %begin_string_~w_ptr)',
+          [Index, Index, Index])
+    },
+    [StringPtr, FmtPtr, PrintCall].
 
 plawk_assoc_print_key_globals(PrintFields, GlobalIR) :-
     phrase(plawk_assoc_print_key_global_lines(PrintFields, 0), Lines),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -16,6 +16,7 @@
 %      $N == "VALUE" { errors++; matches++ } END { print errors, matches }
 %      $N == "ERROR" { errors++ } $N == "WARN" { warnings++ } END { print errors, warnings }
 %      { counts[$1]++ } END { print counts["ERROR"], counts["WARN"] }
+%      BEGIN { print "kind", "count" } { count++ } END { print "count", count }
 %      { count++ } END { print "count", count }
 %
 %  The AST is deliberately small and explicit so later syntax can extend it
@@ -25,8 +26,9 @@ plawk_parse_string(Source, Program) :-
     string_codes(Source, Codes),
     phrase(plawk_program(Program), Codes).
 
-plawk_program(program([], Rules, EndClauses)) -->
+plawk_program(program(BeginClauses, Rules, EndClauses)) -->
     ws,
+    begin_clauses(BeginClauses),
     rules(Rules),
     end_clauses(EndClauses),
     eos.
@@ -130,6 +132,19 @@ quoted_string_codes([Code | Codes]) -->
     !,
     quoted_string_codes(Codes).
 quoted_string_codes([]) -->
+    [].
+
+begin_clauses([begin([PrintAction])]) -->
+    "BEGIN",
+    ws,
+    "{",
+    ws,
+    print_action(PrintAction),
+    ws,
+    "}",
+    ws,
+    !.
+begin_clauses([]) -->
     [].
 
 end_clauses([end([PrintAction])]) -->

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -104,6 +104,15 @@ test(parses_mixed_end_print_string_literal_fields) :-
             assoc(var(counts), string("ERROR"))
         ])])])).
 
+test(parses_begin_print_string_literal_fields) :-
+    plawk_parse_string("BEGIN { print \"kind\", \"count\" } { total++ } END { print \"total\", total }\n", Program),
+    assertion(Program == program([begin([print([string("kind"), string("count")])])],
+        [rule(always, [inc(var(total))])],
+        [end([print([
+            string("total"),
+            var(total)
+        ])])])).
+
 test(surface_prefix_prints_matching_records) :-
     run_surface_print_smoke("/^ERROR/ { print $0 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -173,6 +182,11 @@ test(surface_mixed_end_prints_string_literals) :-
     run_surface_print_smoke("{ total++; counts[$1]++ } END { print \"total\", total, \"errors\", counts[\"ERROR\"] }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "total 4 errors 2\n").
+
+test(surface_begin_prints_string_literals) :-
+    run_surface_print_smoke("BEGIN { print \"kind\", \"count\" } { total++ } END { print \"total\", total }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "kind count\ntotal 4\n").
 
 test(surface_assoc_counts_resize_runtime_table) :-
     findall(Line,
@@ -250,6 +264,17 @@ test(surface_end_string_literals_use_indexed_globals) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '%printed_end_string_0 = call i32'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%printed_end_string_2 = call i32'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_assoc_print_key_3 = private constant [6 x i8]'))),
+    !.
+
+test(surface_begin_string_literals_use_indexed_globals) :-
+    plawk_parse_string("BEGIN { print \"kind\", \"count\" } { total++ } END { print \"total\", total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_begin_print_string_0 = private constant [5 x i8]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_begin_print_string_1 = private constant [6 x i8]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_begin_string_0 = call i32'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_begin_string_1 = call i32'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_begin_newline = call i32'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_end_print_string_0 = private constant [6 x i8]'))),
     !.
 
 run_surface_print_smoke(Source, Input, ExpectedOutput) :-


### PR DESCRIPTION
## Summary
- Parse a first `BEGIN { print ... }` surface clause into the existing `program(Begin, Rules, End)` AST shape.
- Emit indexed native LLVM globals for `BEGIN` string literal fields and print them before stream setup.
- Keep `BEGIN` literals separate from `END` literals so generated globals and SSA names do not collide.
- Cover scalar, assoc, and mixed driver entry setup paths and document the new header-printing example.

## Tests
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `git diff --cached --check`
- `git diff --check`

Note: `tests/test_wam_llvm_target.pl` still reports existing choicepoint warnings while exiting 0.