### PR TITLE
Support PLAWK BEGIN output separator

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -273,7 +273,9 @@ emits indexed string globals and prints them with the same separator rules.
 The first `BEGIN` slices emit literal `print` headers before stream setup, using
 separate indexed string globals so they do not collide with `END` literals, and
 thread single-byte `FS` assignments through native field-equality, selected-field
-print, and associative-key extraction helpers.
+print, and associative-key extraction helpers. Single-byte `OFS` assignments now
+configure the separator used by comma-separated `print` fields in `BEGIN`, rule,
+and `END` actions.
 
 **Success:** a user-written awk-style program parses, lowers, compiles, and
 produces correct output on standard awk test cases.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -91,7 +91,8 @@ grows and rehashes as needed, and the native stream reader grows its line buffer
 without consuming WAM arena space per record. `BEGIN` print clauses can emit
 literal report headers before the stream opens, and the first `BEGIN` assignment
 slice supports single-byte `FS` values such as `BEGIN { FS = ":" }` for native
-field equality, selected-field printing, and associative key extraction. Mixed scalar/associative state is
+field equality, selected-field printing, and associative key extraction. Single-byte
+`OFS` values such as `BEGIN { OFS = "," }` drive comma-separated `print` fields. Mixed scalar/associative state is
 supported in the same native loop, e.g. `{ total++; counts[$1]++ }` with an
 `END` print of both `total` and `counts["ERROR"]`. `END` print fields can also
 include literal labels such as `print "total", total, "errors", counts["ERROR"]`.

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -261,6 +261,20 @@ that prints:
 disk 2 net 1
 ```
 
+`BEGIN` can set the output field separator too:
+
+```awk
+BEGIN { FS = ":"; OFS = "," }
+$1 == "ERROR" { print $2, $3 }
+```
+
+For the same colon-separated input, that prints:
+
+```text
+disk,full
+net,down
+```
+
 This path keeps the streaming loop native while the WAM runtime supplies the
 reader, atom helpers, and reusable associative table primitive.
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -26,6 +26,7 @@
 %      { total++ } END { print "total", total }
 %      BEGIN { print "kind", "count" } { total++ } END { print "total", total }
 %      BEGIN { FS = ":" } $1 == "ERROR" { counts[$2]++ } END { print counts["disk"] }
+%      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
 %
 %  The surrounding runtime still comes from write_wam_llvm_project/3. This
 %  function emits the target-specific native main that streams the file, lowers
@@ -38,6 +39,7 @@ plawk_program_native_driver_ir(
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
     plawk_begin_print_ir(BeginClauses, BeginIR),
     plawk_field_separator(BeginClauses, FieldSeparator),
+    plawk_output_separator_global(BeginClauses, OutputSeparatorGlobalIR),
     plawk_pattern_guard_ir(Pattern, FieldSeparator, GuardGlobalIR-GuardCallIR),
     plawk_print_action_ir(Fields, FieldSeparator, PrintActionIR),
     format(atom(RecordIR),
@@ -51,13 +53,13 @@ print_line:
     format(atom(RuntimeGlobals),
 '@.plawk_surface_print_line = private constant [4 x i8] c"%s\\0A\\00"
 @.plawk_surface_print_slice = private constant [5 x i8] c"%.*s\\00"
-@.plawk_surface_print_space = private constant [2 x i8] c" \\00"
+~w
 @.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
 @.plawk_surface_print_string = private constant [3 x i8] c"%s\\00"
 ~w
 ~w
 ',
-        [BeginGlobalIR, GuardGlobalIR]),
+        [OutputSeparatorGlobalIR, BeginGlobalIR, GuardGlobalIR]),
     plawk_stream_driver_ir(InputPath,
         driver_blocks(RuntimeGlobals, BeginIR, '', lowered_match, RecordIR, '',
             success, 'success:\n  ret i32 0'),
@@ -83,7 +85,7 @@ plawk_program_native_driver_ir(
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
         [BeginGlobalIR, StringGlobalIR, AssocGlobalIR, RuleGlobalIR]),
     plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
-    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    plawk_i64_end_print_globals(BeginClauses, SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
 ~w
@@ -110,7 +112,7 @@ plawk_program_native_driver_ir(
     plawk_scalar_end_print_ir(PrintFields, StatePlan, EndPrintIR),
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
         [BeginGlobalIR, StringGlobalIR, RuleGlobalIR]),
-    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    plawk_i64_end_print_globals(BeginClauses, SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
 ~w
@@ -138,7 +140,7 @@ plawk_program_native_driver_ir(
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
         [BeginGlobalIR, StringGlobalIR, AssocGlobalIR, AssocRuleGlobalIR]),
     plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
-    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
+    plawk_i64_end_print_globals(BeginClauses, SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
 ~w
@@ -156,16 +158,17 @@ plawk_combine_entry_ir(IR, '', IR) :-
 plawk_combine_entry_ir(FirstIR, SecondIR, CombinedIR) :-
     format(atom(CombinedIR), '~w~n~w', [FirstIR, SecondIR]).
 
-plawk_i64_end_print_globals(SurfaceGlobals, RuntimeGlobals) :-
+plawk_i64_end_print_globals(BeginClauses, SurfaceGlobals, RuntimeGlobals) :-
+    plawk_output_separator_global(BeginClauses, OutputSeparatorGlobalIR),
     format(atom(RuntimeGlobals),
 '@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"
-@.plawk_surface_print_space = private constant [2 x i8] c" \\00"
+~w
 @.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
 @.plawk_surface_print_string = private constant [3 x i8] c"%s\\00"
 ~w
 
 ',
-        [SurfaceGlobals]).
+        [OutputSeparatorGlobalIR, SurfaceGlobals]).
 
 % Shared native streaming skeleton. Surface-specific lowerers provide globals,
 % loop-carried state phis, the per-record lowered block, continuation phis, and
@@ -664,6 +667,17 @@ plawk_field_separator(BeginClauses, FieldSeparator) :-
     ->  string_codes(Value, [FieldSeparator])
     ;   FieldSeparator = 32
     ).
+
+plawk_output_separator_global(BeginClauses, GlobalIR) :-
+    (   member(begin(Actions), BeginClauses),
+        member(set(var('OFS'), string(Value)), Actions)
+    ->  string_codes(Value, [OutputSeparator])
+    ;   OutputSeparator = 32
+    ),
+    llvm_c_byte(OutputSeparator, OutputSeparatorByte),
+    format(atom(GlobalIR),
+        '@.plawk_surface_print_space = private constant [2 x i8] c"~w\\00"',
+        [OutputSeparatorByte]).
 
 plawk_begin_print_string_globals(BeginClauses, GlobalIR) :-
     plawk_begin_print_fields(BeginClauses, Fields),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -18,6 +18,7 @@
 %      { counts[$1]++ } END { print counts["ERROR"], counts["WARN"] }
 %      BEGIN { print "kind", "count" } { count++ } END { print "count", count }
 %      BEGIN { FS = ":" } $1 == "ERROR" { counts[$2]++ } END { print counts["disk"] }
+%      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
 %      { count++ } END { print "count", count }
 %
 %  The AST is deliberately small and explicit so later syntax can extend it
@@ -163,19 +164,24 @@ begin_actions_rest([]) -->
     [].
 
 begin_action(Action) -->
-    field_separator_assignment(Action),
+    begin_assignment(Action),
     !.
 begin_action(Action) -->
     print_action(Action),
     !.
 
-field_separator_assignment(set(var('FS'), string(Value))) -->
-    "FS",
+begin_assignment(set(var(Name), string(Value))) -->
+    begin_assignment_name(Name),
     ws,
     "=",
     ws,
     quoted_string(ValueCodes),
     { string_codes(Value, ValueCodes) }.
+
+begin_assignment_name('FS') -->
+    "FS".
+begin_assignment_name('OFS') -->
+    "OFS".
 
 end_clauses([end([PrintAction])]) -->
     "END",

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -127,6 +127,12 @@ test(parses_begin_field_separator_with_header) :-
         [rule(always, [inc_assoc(var(counts), field(1))])],
         [end([print([assoc(var(counts), string("ERROR"))])])])).
 
+test(parses_begin_output_separator_assignment) :-
+    plawk_parse_string("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print $2, $3 }\n", Program),
+    assertion(Program == program([begin([set(var('FS'), string(":")), set(var('OFS'), string(","))])],
+        [rule(field_eq(1, "ERROR"), [print([field(2), field(3)])])],
+        [])).
+
 test(surface_prefix_prints_matching_records) :-
     run_surface_print_smoke("/^ERROR/ { print $0 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -216,6 +222,21 @@ test(surface_begin_field_separator_prints_header) :-
     run_surface_print_smoke("BEGIN { FS = \":\"; print \"kind\", \"count\" } { counts[$1]++ } END { print \"ERROR\", counts[\"ERROR\"] }\n",
         "ERROR:disk:full\nWARN:cpu:hot\nERROR:net:down\n",
         "kind count\nERROR 2\n").
+
+test(surface_begin_output_separator_drives_selected_field_printing) :-
+    run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print $2, $3 }\n",
+        "ERROR:disk:full\nWARN:cpu:hot\nERROR:net:down\n",
+        "disk,full\nnet,down\n").
+
+test(surface_begin_output_separator_drives_end_printing) :-
+    run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { counts[$2]++ } END { print \"disk\", counts[\"disk\"], \"net\", counts[\"net\"] }\n",
+        "ERROR:disk:full\nWARN:cpu:hot\nERROR:net:down\nERROR:disk:again\n",
+        "disk,2,net,1\n").
+
+test(surface_begin_output_separator_drives_begin_printing) :-
+    run_surface_print_smoke("BEGIN { OFS = \",\"; print \"kind\", \"count\" } { total++ } END { print \"total\", total }\n",
+        "INFO boot ok\nERROR disk full\n",
+        "kind,count\ntotal,2\n").
 
 test(surface_assoc_counts_resize_runtime_table) :-
     findall(Line,
@@ -313,6 +334,14 @@ test(surface_begin_field_separator_uses_configured_delimiter) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value(%Value %line, i64 2, i8 58)'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value(%Value %line, i64 3, i8 58)'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value(%Value %line, i64 2, i8 32)')),
+    !.
+
+test(surface_begin_output_separator_uses_configured_delimiter) :-
+    plawk_parse_string("BEGIN { OFS = \",\" } { total++ } END { print \"total\", total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_space = private constant [2 x i8] c"\\2c\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_end_space_1 = call i32'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_space = private constant [2 x i8] c" \\00"')),
     !.
 
 run_surface_print_smoke(Source, Input, ExpectedOutput) :-


### PR DESCRIPTION
## Summary
- Parse `BEGIN { OFS = "x" }` into the PLAWK surface AST as a `set(var('OFS'), string(...))` action.
- Allow `BEGIN` action lists to combine `FS`, `OFS`, and literal `print` headers.
- Emit the native print separator global from the configured single-byte `OFS`, defaulting to space.
- Apply the configured separator to comma-separated `print` fields in BEGIN, rule, and END actions.
- Add compiled surface smokes and IR-shape checks for comma-separated output.
- Update PLAWK README, tutorial, and implementation plan notes.

## Tests
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `git diff --cached --check`
- `git diff --check`

Note: `tests/test_wam_llvm_target.pl` still reports existing choicepoint warnings while exiting 0.