### PR TITLE
Add packed distribution serialization

### DIFF
--- a/scripts/distribution_serialization.py
+++ b/scripts/distribution_serialization.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Binary encodings for finite path-statistic distributions."""
+
+from __future__ import annotations
+
+import math
+import struct
+
+
+MAGIC = b"UWDS"
+VERSION = 1
+KIND_PACKED_SPARSE = 1
+KIND_QUANTIZED_CDF = 2
+HEADER = struct.Struct("<4sBBHiId")
+SPARSE_COUNT = struct.Struct("<I")
+SPARSE_ENTRY = struct.Struct("<Id")
+
+
+def normalize(probabilities: list[float]) -> list[float]:
+    total = sum(probabilities)
+    if total <= 0.0:
+        return [1.0] if probabilities else []
+    return [value / total for value in probabilities]
+
+
+def pad_to(left: list[float], right: list[float]) -> tuple[list[float], list[float]]:
+    size = max(len(left), len(right))
+    return left + [0.0] * (size - len(left)), right + [0.0] * (size - len(right))
+
+
+def max_cdf_error(left: list[float], right: list[float]) -> float:
+    left, right = pad_to(left, right)
+    left_total = 0.0
+    right_total = 0.0
+    worst = 0.0
+    for left_value, right_value in zip(left, right):
+        left_total += left_value
+        right_total += right_value
+        worst = max(worst, abs(left_total - right_total))
+    return worst
+
+
+def w1_cdf_error(left: list[float], right: list[float]) -> float:
+    left, right = pad_to(left, right)
+    left_total = 0.0
+    right_total = 0.0
+    total = 0.0
+    for left_value, right_value in zip(left, right):
+        left_total += left_value
+        right_total += right_value
+        total += abs(left_total - right_total)
+    return total
+
+
+def _header(kind: int, bits: int, origin: int, bin_count: int, total_mass: float) -> bytes:
+    return HEADER.pack(MAGIC, VERSION, kind, int(bits), int(origin), int(bin_count), float(total_mass))
+
+
+def _parse_header(payload: bytes) -> tuple[int, int, int, int, float, int]:
+    if len(payload) < HEADER.size:
+        raise ValueError("payload too short for distribution header")
+    magic, version, kind, bits, origin, bin_count, total_mass = HEADER.unpack_from(payload, 0)
+    if magic != MAGIC:
+        raise ValueError("bad distribution payload magic")
+    if version != VERSION:
+        raise ValueError("unsupported distribution payload version")
+    return kind, bits, origin, bin_count, total_mass, HEADER.size
+
+
+def encode_packed_sparse_histogram(probabilities: list[float], origin: int = 0, total_mass: float = 1.0) -> bytes:
+    probabilities = normalize(probabilities)
+    entries = [(index, value) for index, value in enumerate(probabilities) if value != 0.0]
+    out = bytearray(_header(KIND_PACKED_SPARSE, 0, origin, len(probabilities), total_mass))
+    out.extend(SPARSE_COUNT.pack(len(entries)))
+    for index, value in entries:
+        out.extend(SPARSE_ENTRY.pack(index, value))
+    return bytes(out)
+
+
+def decode_packed_sparse_histogram(payload: bytes) -> tuple[list[float], dict[str, float | int | str]]:
+    kind, bits, origin, bin_count, total_mass, offset = _parse_header(payload)
+    if kind != KIND_PACKED_SPARSE:
+        raise ValueError("payload is not a packed sparse histogram")
+    if len(payload) < offset + SPARSE_COUNT.size:
+        raise ValueError("payload too short for sparse entry count")
+    (entry_count,) = SPARSE_COUNT.unpack_from(payload, offset)
+    offset += SPARSE_COUNT.size
+    probabilities = [0.0 for _ in range(bin_count)]
+    for _ in range(entry_count):
+        if len(payload) < offset + SPARSE_ENTRY.size:
+            raise ValueError("payload too short for sparse entry")
+        index, value = SPARSE_ENTRY.unpack_from(payload, offset)
+        offset += SPARSE_ENTRY.size
+        if index >= bin_count:
+            raise ValueError("sparse entry index outside support")
+        probabilities[index] = value
+    return probabilities, {
+        "representation": "packed_sparse_histogram",
+        "origin": origin,
+        "bits": bits,
+        "bin_count": bin_count,
+        "total_mass": total_mass,
+        "payload_bytes": len(payload),
+    }
+
+
+def _integer_format(bits: int) -> tuple[str, int]:
+    if bits <= 8:
+        return "<B", 8
+    if bits <= 16:
+        return "<H", 16
+    if bits <= 32:
+        return "<I", 32
+    raise ValueError("quantized CDF bits must be <= 32")
+
+
+def encode_quantized_cdf_table(probabilities: list[float], origin: int = 0, total_mass: float = 1.0, bits: int = 16) -> bytes:
+    probabilities = normalize(probabilities)
+    fmt, stored_bits = _integer_format(bits)
+    packer = struct.Struct(fmt)
+    levels = (1 << stored_bits) - 1
+    cumulative = 0.0
+    out = bytearray(_header(KIND_QUANTIZED_CDF, stored_bits, origin, len(probabilities), total_mass))
+    previous = 0
+    for index, probability in enumerate(probabilities):
+        cumulative += probability
+        quantized = levels if index == len(probabilities) - 1 else round(cumulative * levels)
+        quantized = min(levels, max(previous, int(quantized)))
+        out.extend(packer.pack(quantized))
+        previous = quantized
+    return bytes(out)
+
+
+def decode_quantized_cdf_table(payload: bytes) -> tuple[list[float], dict[str, float | int | str]]:
+    kind, bits, origin, bin_count, total_mass, offset = _parse_header(payload)
+    if kind != KIND_QUANTIZED_CDF:
+        raise ValueError("payload is not a quantized CDF table")
+    fmt, stored_bits = _integer_format(bits)
+    packer = struct.Struct(fmt)
+    levels = (1 << stored_bits) - 1
+    probabilities = []
+    previous = 0
+    for _ in range(bin_count):
+        if len(payload) < offset + packer.size:
+            raise ValueError("payload too short for quantized CDF point")
+        (quantized,) = packer.unpack_from(payload, offset)
+        offset += packer.size
+        if quantized < previous:
+            raise ValueError("quantized CDF is not monotone")
+        probabilities.append((quantized - previous) / levels)
+        previous = quantized
+    return probabilities, {
+        "representation": "quantized_cdf_table",
+        "origin": origin,
+        "bits": stored_bits,
+        "bin_count": bin_count,
+        "total_mass": total_mass,
+        "payload_bytes": len(payload),
+        "quantization_step": 1.0 / levels,
+    }
+
+
+def encode_selected_distribution(
+    probabilities: list[float],
+    representation: str,
+    origin: int = 0,
+    total_mass: float = 1.0,
+    cdf_bits: int = 16,
+) -> tuple[bytes, dict[str, float | int | str]]:
+    if representation == "quantized_cdf_table":
+        payload = encode_quantized_cdf_table(probabilities, origin, total_mass, cdf_bits)
+        decoded, meta = decode_quantized_cdf_table(payload)
+    elif representation in {"packed_sparse_histogram", "exact_histogram", "tail_pruned_histogram"}:
+        payload = encode_packed_sparse_histogram(probabilities, origin, total_mass)
+        decoded, meta = decode_packed_sparse_histogram(payload)
+    else:
+        raise ValueError("unsupported serializable representation: {}".format(representation))
+    meta = dict(meta)
+    meta["requested_representation"] = representation
+    meta["decoded_max_cdf_error"] = max_cdf_error(normalize(probabilities), decoded)
+    meta["decoded_w1_cdf_error"] = w1_cdf_error(normalize(probabilities), decoded)
+    return payload, meta

--- a/scripts/lmdb_parent_histogram_benchmark.py
+++ b/scripts/lmdb_parent_histogram_benchmark.py
@@ -45,6 +45,7 @@ from scripts.distribution_fit_comparison import (
     realized_model_builders,
     tail_pruning_summary,
 )
+from scripts.distribution_serialization import encode_selected_distribution
 from scripts.lmdb_parent_branching_diagnostic import (
     LmdbCategoryGraph,
     parse_int_list,
@@ -194,6 +195,12 @@ def target_budget_records(
         )
         prefix_selection = choose_distribution_representation(policy_candidates, tail_epsilon, workload="prefix_mass")
         functional_selection = choose_distribution_representation(policy_candidates, tail_epsilon, workload="arbitrary_functional")
+        _prefix_payload, prefix_serialized = encode_selected_distribution(
+            empirical, prefix_selection["selected_representation"], origin=origin, total_mass=sum(hist.values())
+        )
+        _functional_payload, functional_serialized = encode_selected_distribution(
+            empirical, functional_selection["selected_representation"], origin=origin, total_mass=sum(hist.values())
+        )
         model = dict(base)
         model.update({
             "record_type": "lmdb_parent_histogram_fit",
@@ -207,6 +214,10 @@ def target_budget_records(
             "selected_functional_policy": functional_selection,
             "selected_distribution_representation": prefix_selection["selected_representation"],
             "selected_distribution_reason": prefix_selection["selected_reason"],
+            "selected_prefix_serialized": prefix_serialized,
+            "selected_prefix_serialized_bytes": prefix_serialized["payload_bytes"],
+            "selected_functional_serialized": functional_serialized,
+            "selected_functional_serialized_bytes": functional_serialized["payload_bytes"],
             **model_record,
         })
         records.append(model)
@@ -406,8 +417,8 @@ def compact_counts(values):
 
 def append_budget_depth_policy_table(lines, fit_rows):
     lines.extend([
-        "| child_depth | budget | workload | model_rows | parametric_cdf_pass | selected_counts | mean_bins | capped_hist_rows |",
-        "|------------:|-------:|----------|-----------:|--------------------:|-----------------|----------:|-----------------:|",
+        "| child_depth | budget | workload | model_rows | parametric_cdf_pass | selected_counts | mean_bins | mean_serialized_bytes | mean_decoded_cdf | capped_hist_rows |",
+        "|------------:|-------:|----------|-----------:|--------------------:|-----------------|----------:|----------------------:|-----------------:|-----------------:|",
     ])
     by_group = {}
     for row in fit_rows:
@@ -433,14 +444,26 @@ def append_budget_depth_policy_table(lines, fit_rows):
                 row.get(policy_key, {}).get("selected_representation") or "none"
                 for row in rows
             ]
+            serialized_key = "selected_prefix_serialized" if workload == "prefix_mass" else "selected_functional_serialized"
+            byte_key = "selected_prefix_serialized_bytes" if workload == "prefix_mass" else "selected_functional_serialized_bytes"
             parametric_pass = 0
             for row in rows:
                 policy = row.get(policy_key, {})
                 max_cdf = policy.get("policy_max_cdf_error")
                 if max_cdf is not None and float(row.get("max_cdf_error", 1.0)) <= float(max_cdf):
                     parametric_pass += 1
+            serialized_bytes = [
+                int(row[byte_key])
+                for row in rows
+                if row.get(byte_key) is not None
+            ]
+            decoded_cdf = [
+                float(row.get(serialized_key, {}).get("decoded_max_cdf_error", 0.0))
+                for row in rows
+                if row.get(serialized_key)
+            ]
             lines.append(
-                "| {child_depth} | {budget} | {workload} | {model_rows} | {param_pass} | {selected_counts} | {mean_bins:.3f} | {capped} |".format(
+                "| {child_depth} | {budget} | {workload} | {model_rows} | {param_pass} | {selected_counts} | {mean_bins:.3f} | {mean_serialized:.3f} | {mean_decoded:.6f} | {capped} |".format(
                     child_depth=child_depth,
                     budget=budget,
                     workload=workload,
@@ -448,12 +471,14 @@ def append_budget_depth_policy_table(lines, fit_rows):
                     param_pass=parametric_pass,
                     selected_counts=compact_counts(selected),
                     mean_bins=mean_bins,
+                    mean_serialized=statistics.mean(serialized_bytes) if serialized_bytes else 0.0,
+                    mean_decoded=statistics.mean(decoded_cdf) if decoded_cdf else 0.0,
                     capped=len(capped_histogram_keys),
                 )
             )
         if not unique_histogram_keys:
             lines.append(
-                "| {child_depth} | {budget} | none | 0 | 0 | none:0 | 0.000 | 0 |".format(
+                "| {child_depth} | {budget} | none | 0 | 0 | none:0 | 0.000 | 0.000 | 0.000000 | 0 |".format(
                     child_depth=child_depth,
                     budget=budget,
                 )

--- a/tests/test_distribution_serialization.py
+++ b/tests/test_distribution_serialization.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Tests for finite distribution binary encodings."""
+
+import unittest
+
+from scripts.distribution_serialization import (
+    decode_packed_sparse_histogram,
+    decode_quantized_cdf_table,
+    encode_packed_sparse_histogram,
+    encode_quantized_cdf_table,
+    encode_selected_distribution,
+    max_cdf_error,
+)
+
+
+class DistributionSerializationTests(unittest.TestCase):
+    def test_packed_sparse_histogram_round_trips_probabilities(self):
+        payload = encode_packed_sparse_histogram([0.25, 0.0, 0.75], origin=4, total_mass=8)
+        decoded, meta = decode_packed_sparse_histogram(payload)
+
+        self.assertEqual(decoded, [0.25, 0.0, 0.75])
+        self.assertEqual(meta["origin"], 4)
+        self.assertEqual(meta["bin_count"], 3)
+        self.assertEqual(meta["total_mass"], 8)
+        self.assertEqual(meta["payload_bytes"], len(payload))
+
+    def test_quantized_cdf_table_round_trips_with_small_cdf_error(self):
+        exact = [0.2, 0.3, 0.5]
+        payload = encode_quantized_cdf_table(exact, origin=2, total_mass=10, bits=16)
+        decoded, meta = decode_quantized_cdf_table(payload)
+
+        self.assertEqual(meta["representation"], "quantized_cdf_table")
+        self.assertEqual(meta["origin"], 2)
+        self.assertEqual(meta["bin_count"], 3)
+        self.assertAlmostEqual(sum(decoded), 1.0)
+        self.assertLessEqual(max_cdf_error(exact, decoded), meta["quantization_step"])
+
+    def test_selected_prefix_representation_uses_quantized_cdf(self):
+        payload, meta = encode_selected_distribution([0.2, 0.3, 0.5], "quantized_cdf_table", cdf_bits=8)
+
+        self.assertEqual(meta["representation"], "quantized_cdf_table")
+        self.assertEqual(meta["requested_representation"], "quantized_cdf_table")
+        self.assertEqual(meta["payload_bytes"], len(payload))
+        self.assertLessEqual(meta["decoded_max_cdf_error"], meta["quantization_step"])
+
+    def test_selected_functional_representation_uses_sparse_histogram(self):
+        payload, meta = encode_selected_distribution([0.2, 0.0, 0.8], "packed_sparse_histogram")
+
+        self.assertEqual(meta["representation"], "packed_sparse_histogram")
+        self.assertEqual(meta["payload_bytes"], len(payload))
+        self.assertEqual(meta["decoded_max_cdf_error"], 0.0)
+
+    def test_unknown_representation_is_rejected(self):
+        with self.assertRaises(ValueError):
+            encode_selected_distribution([1.0], "parametric:binomial_fit")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lmdb_parent_histogram_benchmark.py
+++ b/tests/test_lmdb_parent_histogram_benchmark.py
@@ -87,8 +87,12 @@ class BoundedParentHistogramTests(unittest.TestCase):
         self.assertTrue(fit_rows)
         self.assertTrue(all(row["selected_prefix_representation"] for row in fit_rows))
         self.assertTrue(all(row["selected_functional_representation"] for row in fit_rows))
+        self.assertTrue(all(row["selected_prefix_serialized_bytes"] > 0 for row in fit_rows))
+        self.assertTrue(all(row["selected_functional_serialized_bytes"] > 0 for row in fit_rows))
+        self.assertTrue(all(row["selected_prefix_serialized"]["decoded_max_cdf_error"] >= 0.0 for row in fit_rows))
         self.assertIn("Representation Policy Selection", summary)
         self.assertIn("Representation Policy By Budget And Depth", summary)
+        self.assertIn("mean_serialized_bytes", summary)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add binary encoders/decoders for packed sparse histograms and quantized CDF tables
- add selected-representation serialization metadata to LMDB parent histogram benchmark rows
- report serialized byte length and decoded CDF error in the budget/depth policy table
- add round-trip and benchmark wiring tests

## Validation
- python3 -m unittest tests.test_distribution_serialization tests.test_lmdb_parent_histogram_benchmark tests.test_distribution_fit_comparison tests.test_lmdb_parent_recurrence_histogram_benchmark
- python3 -m py_compile scripts/distribution_fit_comparison.py
- git diff --check