### PR TITLE
Emit PLAWK separators as bytes

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -275,7 +275,8 @@ separate indexed string globals so they do not collide with `END` literals, and
 thread single-byte `FS` assignments through native field-equality, selected-field
 print, and associative-key extraction helpers. Single-byte `OFS` assignments now
 configure the separator used by comma-separated `print` fields in `BEGIN`, rule,
-and `END` actions.
+and `END` actions. Native separator emission uses direct byte output rather than
+passing the separator through `printf` as a format string.
 
 **Success:** a user-written awk-style program parses, lowers, compiles, and
 produces correct output on standard awk test cases.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -92,7 +92,9 @@ without consuming WAM arena space per record. `BEGIN` print clauses can emit
 literal report headers before the stream opens, and the first `BEGIN` assignment
 slice supports single-byte `FS` values such as `BEGIN { FS = ":" }` for native
 field equality, selected-field printing, and associative key extraction. Single-byte
-`OFS` values such as `BEGIN { OFS = "," }` drive comma-separated `print` fields. Mixed scalar/associative state is
+`OFS` values such as `BEGIN { OFS = "," }` drive comma-separated `print` fields;
+the native path emits separator bytes directly, so values such as `%` are data,
+not `printf` formats. Mixed scalar/associative state is
 supported in the same native loop, e.g. `{ total++; counts[$1]++ }` with an
 `END` print of both `total` and `counts["ERROR"]`. `END` print fields can also
 include literal labels such as `print "total", total, "errors", counts["ERROR"]`.

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -275,6 +275,8 @@ disk,full
 net,down
 ```
 
+The native output path writes the single-byte separator directly, so separators
+such as `%` are treated as data rather than `printf` format strings.
 This path keeps the streaming loop native while the WAM runtime supplies the
 reader, atom helpers, and reusable associative table primitive.
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -36,12 +36,12 @@ plawk_program_native_driver_ir(
     InputPath,
     DriverIR
 ) :-
+    plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
-    plawk_begin_print_ir(BeginClauses, BeginIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
     plawk_field_separator(BeginClauses, FieldSeparator),
-    plawk_output_separator_global(BeginClauses, OutputSeparatorGlobalIR),
     plawk_pattern_guard_ir(Pattern, FieldSeparator, GuardGlobalIR-GuardCallIR),
-    plawk_print_action_ir(Fields, FieldSeparator, PrintActionIR),
+    plawk_print_action_ir(Fields, FieldSeparator, OutputSeparator, PrintActionIR),
     format(atom(RecordIR),
 '~w
   br i1 %is_match, label %print_line, label %continue_loop
@@ -53,13 +53,12 @@ print_line:
     format(atom(RuntimeGlobals),
 '@.plawk_surface_print_line = private constant [4 x i8] c"%s\\0A\\00"
 @.plawk_surface_print_slice = private constant [5 x i8] c"%.*s\\00"
-~w
 @.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
 @.plawk_surface_print_string = private constant [3 x i8] c"%s\\00"
 ~w
 ~w
 ',
-        [OutputSeparatorGlobalIR, BeginGlobalIR, GuardGlobalIR]),
+        [BeginGlobalIR, GuardGlobalIR]),
     plawk_stream_driver_ir(InputPath,
         driver_blocks(RuntimeGlobals, BeginIR, '', lowered_match, RecordIR, '',
             success, 'success:\n  ret i32 0'),
@@ -72,8 +71,9 @@ plawk_program_native_driver_ir(
 ) :-
     plawk_mixed_state_plan(Rules, PrintFields, MixedPlan),
     MixedPlan = mixed_plan(ScalarPlan, AssocPlan, _PlannedRules),
+    plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
-    plawk_begin_print_ir(BeginClauses, BeginIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
     plawk_field_separator(BeginClauses, FieldSeparator),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_assoc_print_key_globals(PrintFields, AssocGlobalIR),
@@ -81,11 +81,11 @@ plawk_program_native_driver_ir(
     plawk_mixed_rule_chain_ir(MixedPlan, FieldSeparator, RuleGlobalIR, RuleChainIR, RuleCount),
     plawk_state_loop_phi_ir(ScalarPlan, LoopPhiIR),
     plawk_mixed_scalar_next_phi_ir(ScalarPlan, RuleCount, NextPhiIR),
-    plawk_mixed_end_print_ir(PrintFields, ScalarPlan, AssocPlan, EndPrintIR),
+    plawk_mixed_end_print_ir(PrintFields, ScalarPlan, AssocPlan, OutputSeparator, EndPrintIR),
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
         [BeginGlobalIR, StringGlobalIR, AssocGlobalIR, RuleGlobalIR]),
     plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
-    plawk_i64_end_print_globals(BeginClauses, SurfaceGlobalIR, RuntimeGlobals),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
 ~w
@@ -102,17 +102,18 @@ plawk_program_native_driver_ir(
     DriverIR
 ) :-
     plawk_scalar_state_plan(Rules, PrintFields, StatePlan),
+    plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
-    plawk_begin_print_ir(BeginClauses, BeginIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
     plawk_field_separator(BeginClauses, FieldSeparator),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, RuleGlobalIR, RuleChainIR, RuleCount),
     plawk_state_loop_phi_ir(StatePlan, LoopPhiIR),
     plawk_scalar_next_phi_ir(StatePlan, RuleCount, NextPhiIR),
-    plawk_scalar_end_print_ir(PrintFields, StatePlan, EndPrintIR),
+    plawk_scalar_end_print_ir(PrintFields, StatePlan, OutputSeparator, EndPrintIR),
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
         [BeginGlobalIR, StringGlobalIR, RuleGlobalIR]),
-    plawk_i64_end_print_globals(BeginClauses, SurfaceGlobalIR, RuntimeGlobals),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
 ~w
@@ -129,18 +130,19 @@ plawk_program_native_driver_ir(
     DriverIR
 ) :-
     plawk_assoc_runtime_count_plan(Rules, PrintFields, AssocPlan),
+    plawk_output_separator(BeginClauses, OutputSeparator),
     plawk_begin_print_string_globals(BeginClauses, BeginGlobalIR),
-    plawk_begin_print_ir(BeginClauses, BeginIR),
+    plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
     plawk_field_separator(BeginClauses, FieldSeparator),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_assoc_print_key_globals(PrintFields, AssocGlobalIR),
     plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
     plawk_assoc_rule_chain_ir(AssocPlan, FieldSeparator, AssocRuleGlobalIR, AssocChainIR),
-    plawk_assoc_end_print_ir(PrintFields, AssocPlan, EndPrintIR),
+    plawk_assoc_end_print_ir(PrintFields, AssocPlan, OutputSeparator, EndPrintIR),
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
         [BeginGlobalIR, StringGlobalIR, AssocGlobalIR, AssocRuleGlobalIR]),
     plawk_combine_entry_ir(BeginIR, EntrySetupIR, CombinedEntrySetupIR),
-    plawk_i64_end_print_globals(BeginClauses, SurfaceGlobalIR, RuntimeGlobals),
+    plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
 ~w
@@ -158,17 +160,15 @@ plawk_combine_entry_ir(IR, '', IR) :-
 plawk_combine_entry_ir(FirstIR, SecondIR, CombinedIR) :-
     format(atom(CombinedIR), '~w~n~w', [FirstIR, SecondIR]).
 
-plawk_i64_end_print_globals(BeginClauses, SurfaceGlobals, RuntimeGlobals) :-
-    plawk_output_separator_global(BeginClauses, OutputSeparatorGlobalIR),
+plawk_i64_end_print_globals(SurfaceGlobals, RuntimeGlobals) :-
     format(atom(RuntimeGlobals),
 '@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"
-~w
 @.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
 @.plawk_surface_print_string = private constant [3 x i8] c"%s\\00"
 ~w
 
 ',
-        [OutputSeparatorGlobalIR, SurfaceGlobals]).
+        [SurfaceGlobals]).
 
 % Shared native streaming skeleton. Surface-specific lowerers provide globals,
 % loop-carried state phis, the per-record lowered block, continuation phis, and
@@ -668,16 +668,12 @@ plawk_field_separator(BeginClauses, FieldSeparator) :-
     ;   FieldSeparator = 32
     ).
 
-plawk_output_separator_global(BeginClauses, GlobalIR) :-
+plawk_output_separator(BeginClauses, OutputSeparator) :-
     (   member(begin(Actions), BeginClauses),
         member(set(var('OFS'), string(Value)), Actions)
     ->  string_codes(Value, [OutputSeparator])
     ;   OutputSeparator = 32
-    ),
-    llvm_c_byte(OutputSeparator, OutputSeparatorByte),
-    format(atom(GlobalIR),
-        '@.plawk_surface_print_space = private constant [2 x i8] c"~w\\00"',
-        [OutputSeparatorByte]).
+    ).
 
 plawk_begin_print_string_globals(BeginClauses, GlobalIR) :-
     plawk_begin_print_fields(BeginClauses, Fields),
@@ -709,39 +705,36 @@ plawk_begin_print_string_global_lines([_Field | Rest], Index) -->
     { NextIndex is Index + 1 },
     plawk_begin_print_string_global_lines(Rest, NextIndex).
 
-plawk_begin_print_ir([], '') :-
+plawk_begin_print_ir([], _OutputSeparator, '') :-
     !.
-plawk_begin_print_ir([begin(Actions)], IR) :-
+plawk_begin_print_ir([begin(Actions)], OutputSeparator, IR) :-
     member(print(Fields), Actions),
     !,
     maplist(plawk_begin_print_field, Fields),
-    phrase(plawk_begin_print_lines(Fields, 0), Lines),
+    phrase(plawk_begin_print_lines(Fields, OutputSeparator, 0), Lines),
     atomic_list_concat(Lines, '\n', IR).
-plawk_begin_print_ir([begin(_Actions)], '').
+plawk_begin_print_ir([begin(_Actions)], _OutputSeparator, '').
 
 plawk_begin_print_field(string(_)).
 
-plawk_begin_print_lines([], _) -->
+plawk_begin_print_lines([], _OutputSeparator, _) -->
     ['  %begin_newline_fmt = getelementptr [2 x i8], [2 x i8]* @.plawk_surface_print_newline, i32 0, i32 0',
      '  %printed_begin_newline = call i32 (i8*, ...) @printf(i8* %begin_newline_fmt)'].
-plawk_begin_print_lines([string(Value) | Rest], Index) -->
-    plawk_begin_separator_lines(Index),
+plawk_begin_print_lines([string(Value) | Rest], OutputSeparator, Index) -->
+    plawk_begin_separator_lines(Index, OutputSeparator),
     plawk_begin_string_print_lines(Value, Index),
     { NextIndex is Index + 1 },
-    plawk_begin_print_lines(Rest, NextIndex).
+    plawk_begin_print_lines(Rest, OutputSeparator, NextIndex).
 
-plawk_begin_separator_lines(0) -->
+plawk_begin_separator_lines(0, _OutputSeparator) -->
     !,
     [].
-plawk_begin_separator_lines(Index) -->
-    { format(atom(SpacePtr),
-          '  %begin_space_fmt_~w = getelementptr [2 x i8], [2 x i8]* @.plawk_surface_print_space, i32 0, i32 0',
-          [Index]),
-      format(atom(SpaceCall),
-          '  %printed_begin_space_~w = call i32 (i8*, ...) @printf(i8* %begin_space_fmt_~w)',
-          [Index, Index])
+plawk_begin_separator_lines(Index, OutputSeparator) -->
+    { format(atom(SpaceCall),
+          '  %printed_begin_separator_~w = call i32 @putchar(i32 ~w)',
+          [Index, OutputSeparator])
     },
-    [SpacePtr, SpaceCall].
+    [SpaceCall].
 
 plawk_begin_string_print_lines(Value, Index) -->
     { string_codes(Value, Codes),
@@ -813,16 +806,16 @@ plawk_assoc_key_codes(Key, Codes) :-
 plawk_assoc_key_codes(Key, Codes) :-
     atom_codes(Key, Codes).
 
-plawk_assoc_end_print_ir(PrintFields, AssocPlan, IR) :-
-    phrase(plawk_assoc_end_print_lines(PrintFields, AssocPlan, 0), Lines),
+plawk_assoc_end_print_ir(PrintFields, AssocPlan, OutputSeparator, IR) :-
+    phrase(plawk_assoc_end_print_lines(PrintFields, AssocPlan, OutputSeparator, 0), Lines),
     atomic_list_concat(Lines, '\n', IR).
 
-plawk_assoc_end_print_lines([], AssocPlan, _) -->
+plawk_assoc_end_print_lines([], AssocPlan, _OutputSeparator, _) -->
     ['  %end_newline_fmt = getelementptr [2 x i8], [2 x i8]* @.plawk_surface_print_newline, i32 0, i32 0',
      '  %printed_end_newline = call i32 (i8*, ...) @printf(i8* %end_newline_fmt)'],
     plawk_assoc_free_lines(AssocPlan).
-plawk_assoc_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], AssocPlan, PrintIndex) -->
-    plawk_scalar_end_separator_lines(PrintIndex),
+plawk_assoc_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], AssocPlan, OutputSeparator, PrintIndex) -->
+    plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
     { plawk_assoc_key_codes(Key, Codes),
       length(Codes, KeyLen),
       BytesLen is KeyLen + 1,
@@ -845,12 +838,12 @@ plawk_assoc_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], AssocPl
       NextPrintIndex is PrintIndex + 1
     },
     [KeyPtr, KeyId, Value, FmtPtr, PrintCall],
-    plawk_assoc_end_print_lines(Rest, AssocPlan, NextPrintIndex).
-plawk_assoc_end_print_lines([string(Value) | Rest], AssocPlan, PrintIndex) -->
-    plawk_scalar_end_separator_lines(PrintIndex),
+    plawk_assoc_end_print_lines(Rest, AssocPlan, OutputSeparator, NextPrintIndex).
+plawk_assoc_end_print_lines([string(Value) | Rest], AssocPlan, OutputSeparator, PrintIndex) -->
+    plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
     plawk_end_string_print_lines(Value, PrintIndex),
     { NextPrintIndex is PrintIndex + 1 },
-    plawk_assoc_end_print_lines(Rest, AssocPlan, NextPrintIndex).
+    plawk_assoc_end_print_lines(Rest, AssocPlan, OutputSeparator, NextPrintIndex).
 
 plawk_assoc_table_index(assoc_plan(Tables, _Actions), ArrayName, TableIndex) :-
     nth0(TableIndex, Tables, ArrayName).
@@ -869,16 +862,16 @@ plawk_assoc_free_lines([_ArrayName | Rest], Index) -->
     [Line],
     plawk_assoc_free_lines(Rest, NextIndex).
 
-plawk_mixed_end_print_ir(PrintFields, ScalarPlan, AssocPlan, IR) :-
-    phrase(plawk_mixed_end_print_lines(PrintFields, ScalarPlan, AssocPlan, 0), Lines),
+plawk_mixed_end_print_ir(PrintFields, ScalarPlan, AssocPlan, OutputSeparator, IR) :-
+    phrase(plawk_mixed_end_print_lines(PrintFields, ScalarPlan, AssocPlan, OutputSeparator, 0), Lines),
     atomic_list_concat(Lines, '\n', IR).
 
-plawk_mixed_end_print_lines([], _ScalarPlan, AssocPlan, _) -->
+plawk_mixed_end_print_lines([], _ScalarPlan, AssocPlan, _OutputSeparator, _) -->
     ['  %end_newline_fmt = getelementptr [2 x i8], [2 x i8]* @.plawk_surface_print_newline, i32 0, i32 0',
      '  %printed_end_newline = call i32 (i8*, ...) @printf(i8* %end_newline_fmt)'],
     plawk_assoc_free_lines(AssocPlan).
-plawk_mixed_end_print_lines([var(Name) | Rest], ScalarPlan, AssocPlan, PrintIndex) -->
-    plawk_scalar_end_separator_lines(PrintIndex),
+plawk_mixed_end_print_lines([var(Name) | Rest], ScalarPlan, AssocPlan, OutputSeparator, PrintIndex) -->
+    plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
     { plawk_state_slot_index(ScalarPlan, scalar_counter(Name), SlotIndex),
       format(atom(FmtPtr),
           '  %end_i64_fmt_~w = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_i64, i32 0, i32 0',
@@ -889,9 +882,9 @@ plawk_mixed_end_print_lines([var(Name) | Rest], ScalarPlan, AssocPlan, PrintInde
       NextPrintIndex is PrintIndex + 1
     },
     [FmtPtr, PrintCall],
-    plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, NextPrintIndex).
-plawk_mixed_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], ScalarPlan, AssocPlan, PrintIndex) -->
-    plawk_scalar_end_separator_lines(PrintIndex),
+    plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, OutputSeparator, NextPrintIndex).
+plawk_mixed_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], ScalarPlan, AssocPlan, OutputSeparator, PrintIndex) -->
+    plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
     { plawk_assoc_key_codes(Key, Codes),
       length(Codes, KeyLen),
       BytesLen is KeyLen + 1,
@@ -914,12 +907,12 @@ plawk_mixed_end_print_lines([assoc(var(ArrayName), string(Key)) | Rest], ScalarP
       NextPrintIndex is PrintIndex + 1
     },
     [KeyPtr, KeyId, Value, FmtPtr, PrintCall],
-    plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, NextPrintIndex).
-plawk_mixed_end_print_lines([string(Value) | Rest], ScalarPlan, AssocPlan, PrintIndex) -->
-    plawk_scalar_end_separator_lines(PrintIndex),
+    plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, OutputSeparator, NextPrintIndex).
+plawk_mixed_end_print_lines([string(Value) | Rest], ScalarPlan, AssocPlan, OutputSeparator, PrintIndex) -->
+    plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
     plawk_end_string_print_lines(Value, PrintIndex),
     { NextPrintIndex is PrintIndex + 1 },
-    plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, NextPrintIndex).
+    plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, OutputSeparator, NextPrintIndex).
 
 plawk_scalar_increment_action(inc(var(Name)), Name).
 
@@ -1060,15 +1053,15 @@ plawk_scalar_next_phi_lines([_Slot | Rest], RuleCount, Index) -->
     [Line],
     plawk_scalar_next_phi_lines(Rest, RuleCount, NextIndex).
 
-plawk_scalar_end_print_ir(PrintFields, StatePlan, IR) :-
-    phrase(plawk_scalar_end_print_lines(PrintFields, StatePlan, 0), Lines),
+plawk_scalar_end_print_ir(PrintFields, StatePlan, OutputSeparator, IR) :-
+    phrase(plawk_scalar_end_print_lines(PrintFields, StatePlan, OutputSeparator, 0), Lines),
     atomic_list_concat(Lines, '\n', IR).
 
-plawk_scalar_end_print_lines([], _StatePlan, _) -->
+plawk_scalar_end_print_lines([], _StatePlan, _OutputSeparator, _) -->
     ['  %end_newline_fmt = getelementptr [2 x i8], [2 x i8]* @.plawk_surface_print_newline, i32 0, i32 0',
      '  %printed_end_newline = call i32 (i8*, ...) @printf(i8* %end_newline_fmt)'].
-plawk_scalar_end_print_lines([var(Name) | Rest], StatePlan, PrintIndex) -->
-    plawk_scalar_end_separator_lines(PrintIndex),
+plawk_scalar_end_print_lines([var(Name) | Rest], StatePlan, OutputSeparator, PrintIndex) -->
+    plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
     { plawk_state_slot_index(StatePlan, scalar_counter(Name), SlotIndex),
       format(atom(FmtPtr),
           '  %end_i64_fmt_~w = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_i64, i32 0, i32 0',
@@ -1079,12 +1072,12 @@ plawk_scalar_end_print_lines([var(Name) | Rest], StatePlan, PrintIndex) -->
       NextPrintIndex is PrintIndex + 1
     },
     [FmtPtr, PrintCall],
-    plawk_scalar_end_print_lines(Rest, StatePlan, NextPrintIndex).
-plawk_scalar_end_print_lines([string(Value) | Rest], StatePlan, PrintIndex) -->
-    plawk_scalar_end_separator_lines(PrintIndex),
+    plawk_scalar_end_print_lines(Rest, StatePlan, OutputSeparator, NextPrintIndex).
+plawk_scalar_end_print_lines([string(Value) | Rest], StatePlan, OutputSeparator, PrintIndex) -->
+    plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator),
     plawk_end_string_print_lines(Value, PrintIndex),
     { NextPrintIndex is PrintIndex + 1 },
-    plawk_scalar_end_print_lines(Rest, StatePlan, NextPrintIndex).
+    plawk_scalar_end_print_lines(Rest, StatePlan, OutputSeparator, NextPrintIndex).
 
 plawk_end_string_print_lines(Value, PrintIndex) -->
     { string_codes(Value, Codes),
@@ -1102,18 +1095,15 @@ plawk_end_string_print_lines(Value, PrintIndex) -->
     },
     [StringPtr, FmtPtr, PrintCall].
 
-plawk_scalar_end_separator_lines(0) -->
+plawk_scalar_end_separator_lines(0, _OutputSeparator) -->
     !,
     [].
-plawk_scalar_end_separator_lines(PrintIndex) -->
-    { format(atom(SpacePtr),
-          '  %end_space_fmt_~w = getelementptr [2 x i8], [2 x i8]* @.plawk_surface_print_space, i32 0, i32 0',
-          [PrintIndex]),
-      format(atom(SpaceCall),
-          '  %printed_end_space_~w = call i32 (i8*, ...) @printf(i8* %end_space_fmt_~w)',
-          [PrintIndex, PrintIndex])
+plawk_scalar_end_separator_lines(PrintIndex, OutputSeparator) -->
+    { format(atom(SpaceCall),
+          '  %printed_end_separator_~w = call i32 @putchar(i32 ~w)',
+          [PrintIndex, OutputSeparator])
     },
-    [SpacePtr, SpaceCall].
+    [SpaceCall].
 
 plawk_pattern_guard_ir(always, GuardIR) :-
     GuardIR = ''-'  %is_match = icmp eq i1 true, true'.
@@ -1153,35 +1143,32 @@ plawk_pattern_guard_ir(field_eq(Index, Value), FieldSeparator, GlobalBase, Match
     llvm_emit_atom_field_eq_guard(GlobalBase, '%line', Index, Value, FieldSeparator,
         MatchValue, GuardIR).
 
-plawk_print_action_ir([field(0)], _FieldSeparator, IR) :-
+plawk_print_action_ir([field(0)], _FieldSeparator, _OutputSeparator, IR) :-
     !,
     IR = '  %fmt = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_line, i32 0, i32 0
   %printed = call i32 (i8*, ...) @printf(i8* %fmt, i8* %line_s)'.
-plawk_print_action_ir(Fields, FieldSeparator, IR) :-
-    phrase(plawk_print_fields_ir(Fields, FieldSeparator, 0), Parts),
+plawk_print_action_ir(Fields, FieldSeparator, OutputSeparator, IR) :-
+    phrase(plawk_print_fields_ir(Fields, FieldSeparator, OutputSeparator, 0), Parts),
     atomic_list_concat(Parts, '\n', IR).
 
-plawk_print_fields_ir([], _FieldSeparator, _) -->
+plawk_print_fields_ir([], _FieldSeparator, _OutputSeparator, _) -->
     ['  %newline_fmt = getelementptr [2 x i8], [2 x i8]* @.plawk_surface_print_newline, i32 0, i32 0',
      '  %printed_newline = call i32 (i8*, ...) @printf(i8* %newline_fmt)'].
-plawk_print_fields_ir([Field | Rest], FieldSeparator, Index) -->
-    plawk_print_separator_ir(Index),
+plawk_print_fields_ir([Field | Rest], FieldSeparator, OutputSeparator, Index) -->
+    plawk_print_separator_ir(Index, OutputSeparator),
     plawk_print_field_ir(Field, FieldSeparator, Index),
     { NextIndex is Index + 1 },
-    plawk_print_fields_ir(Rest, FieldSeparator, NextIndex).
+    plawk_print_fields_ir(Rest, FieldSeparator, OutputSeparator, NextIndex).
 
-plawk_print_separator_ir(0) -->
+plawk_print_separator_ir(0, _OutputSeparator) -->
     !,
     [].
-plawk_print_separator_ir(Index) -->
-    { format(atom(SpacePtr),
-          '  %space_fmt_~w = getelementptr [2 x i8], [2 x i8]* @.plawk_surface_print_space, i32 0, i32 0',
-          [Index]),
-      format(atom(SpaceCall),
-          '  %printed_space_~w = call i32 (i8*, ...) @printf(i8* %space_fmt_~w)',
-          [Index, Index])
+plawk_print_separator_ir(Index, OutputSeparator) -->
+    { format(atom(SpaceCall),
+          '  %printed_separator_~w = call i32 @putchar(i32 ~w)',
+          [Index, OutputSeparator])
     },
-    [SpacePtr, SpaceCall].
+    [SpaceCall].
 
 plawk_print_field_ir(field(0), _FieldSeparator, Index) -->
     { format(atom(LineLen64),

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -238,6 +238,16 @@ test(surface_begin_output_separator_drives_begin_printing) :-
         "INFO boot ok\nERROR disk full\n",
         "kind,count\ntotal,2\n").
 
+test(surface_begin_output_separator_treats_rule_percent_as_data) :-
+    run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \"%\" } $1 == \"ERROR\" { print $2, $3 }\n",
+        "ERROR:disk:full\nWARN:cpu:hot\nERROR:net:down\n",
+        "disk%full\nnet%down\n").
+
+test(surface_begin_output_separator_treats_begin_and_end_percent_as_data) :-
+    run_surface_print_smoke("BEGIN { OFS = \"%\"; print \"kind\", \"count\" } { total++ } END { print \"total\", total }\n",
+        "INFO boot ok\nERROR disk full\n",
+        "kind%count\ntotal%2\n").
+
 test(surface_assoc_counts_resize_runtime_table) :-
     findall(Line,
         ( between(0, 2050, Index), format(atom(Line), 'K~w payload\n', [Index]) ),
@@ -339,9 +349,10 @@ test(surface_begin_field_separator_uses_configured_delimiter) :-
 test(surface_begin_output_separator_uses_configured_delimiter) :-
     plawk_parse_string("BEGIN { OFS = \",\" } { total++ } END { print \"total\", total }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
-    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_space = private constant [2 x i8] c"\\2c\\00"'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_end_space_1 = call i32'))),
-    assertion(\+ sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_space = private constant [2 x i8] c" \\00"')),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_end_separator_1 = call i32 @putchar(i32 44)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_space')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'printf(i8* %end_space_fmt')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '%printed_end_space_1')),
     !.
 
 run_surface_print_smoke(Source, Input, ExpectedOutput) :-


### PR DESCRIPTION
## Summary
- Thread the parsed single-byte `OFS` value through PLAWK BEGIN, rule, and END print emitters.
- Replace separator `printf` format-string globals with direct `@putchar(i32 byte)` calls.
- Add runtime coverage proving `%` separators are emitted as data for rule prints, BEGIN prints, and END prints.
- Update PLAWK docs to document direct byte separator emission and the current single-byte boundary.

## Tests
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `git diff --cached --check`
- `git diff --check`

Note: `tests/test_wam_llvm_target.pl` still reports existing choicepoint warnings while exiting 0.