### PR TITLE
Support PLAWK native NR prints

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -250,10 +250,11 @@ streaming WAM/LLVM driver using `llvm_emit_atom_prefix_guard/5` or
 `tests/test_plawk_surface_prefix_print.pl` proves that the generated binary
 prints matching records from a text file without calling `run_loop` in the hot
 record loop. The field-equality path scans fields in native code without
-allocating substrings; selected-field printing projects byte slices directly;
-the scalar counter path threads a native `i64` loop variable and prints it from
-the `END` action. Multiple scalar counters become parallel `i64` phi slots in
-the native streaming loop.
+allocating substrings; selected-field printing projects byte slices directly.
+Rule prints can include native `NR`, implemented as a record-number `i64` phi in
+the print-only streaming loop. The scalar counter path threads a native `i64`
+loop variable and prints it from the `END` action. Multiple scalar counters
+become parallel `i64` phi slots in the native streaming loop.
 Scalar counters lower through an explicit codegen state plan that keeps
 source-level state recognition separate from LLVM slot numbering. The current
 associative-count surface allocates one reusable WAM/LLVM

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -77,7 +77,8 @@ swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR
 The demo prints the record count and the lines whose first field is `ERROR`.
 The first Phase 2 surface smokes parse `/^ERROR/ { print $0 }` and
 `$1 == "ERROR" { print $0 }`, plus selected-field actions such as
-`$1 == "ERROR" { print $2, $3 }` and scalar state with
+`$1 == "ERROR" { print $2, $3 }`. Rule prints can include native `NR`, e.g.
+`$1 == "ERROR" { print NR, $2, $3 }`, and scalar state with
 `$1 == "ERROR" { count++ } END { print count }`. Multiple scalar increments
 compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple
 guarded rules can update shared scalar slots before an `END` print. The first

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -120,7 +120,8 @@ The Phase 0 examples use the counter as `NR`, collect printed lines in
 
 ## Current surface example: count matching records
 
-The native Phase 2 surface can now compile a scalar counter and an `END` action:
+The native Phase 2 surface can compile rule prints with `NR`, selected fields,
+and `OFS`, matching the first awk-style example above. It can also compile a scalar counter and an `END` action:
 
 ```awk
 $1 == "ERROR" { count++ } END { print count }

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -41,18 +41,21 @@ plawk_program_native_driver_ir(
     plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
     plawk_field_separator(BeginClauses, FieldSeparator),
     plawk_pattern_guard_ir(Pattern, FieldSeparator, GuardGlobalIR-GuardCallIR),
+    plawk_print_record_counter_ir(Fields, LoopPhiIR, RecordCounterIR),
     plawk_print_action_ir(Fields, FieldSeparator, OutputSeparator, PrintActionIR),
     format(atom(RecordIR),
 '~w
+~w
   br i1 %is_match, label %print_line, label %continue_loop
 
 print_line:
 ~w
   br label %continue_loop',
-        [GuardCallIR, PrintActionIR]),
+        [RecordCounterIR, GuardCallIR, PrintActionIR]),
     format(atom(RuntimeGlobals),
 '@.plawk_surface_print_line = private constant [4 x i8] c"%s\\0A\\00"
 @.plawk_surface_print_slice = private constant [5 x i8] c"%.*s\\00"
+@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"
 @.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
 @.plawk_surface_print_string = private constant [3 x i8] c"%s\\00"
 ~w
@@ -60,7 +63,7 @@ print_line:
 ',
         [BeginGlobalIR, GuardGlobalIR]),
     plawk_stream_driver_ir(InputPath,
-        driver_blocks(RuntimeGlobals, BeginIR, '', lowered_match, RecordIR, '',
+        driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR, '',
             success, 'success:\n  ret i32 0'),
         DriverIR).
 
@@ -1143,6 +1146,14 @@ plawk_pattern_guard_ir(field_eq(Index, Value), FieldSeparator, GlobalBase, Match
     llvm_emit_atom_field_eq_guard(GlobalBase, '%line', Index, Value, FieldSeparator,
         MatchValue, GuardIR).
 
+plawk_print_record_counter_ir(Fields, LoopPhiIR, RecordCounterIR) :-
+    (   member(special('NR'), Fields)
+    ->  LoopPhiIR = '  %plawk_nr = phi i64 [0, %check_handle_value], [%current_nr, %continue_loop]',
+        RecordCounterIR = '  %current_nr = add i64 %plawk_nr, 1'
+    ;   LoopPhiIR = '',
+        RecordCounterIR = ''
+    ).
+
 plawk_print_action_ir([field(0)], _FieldSeparator, _OutputSeparator, IR) :-
     !,
     IR = '  %fmt = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_line, i32 0, i32 0
@@ -1169,6 +1180,16 @@ plawk_print_separator_ir(Index, OutputSeparator) -->
           [Index, OutputSeparator])
     },
     [SpaceCall].
+
+plawk_print_field_ir(special('NR'), _FieldSeparator, Index) -->
+    { format(atom(FmtPtr),
+          '  %nr_fmt_~w = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_i64, i32 0, i32 0',
+          [Index]),
+      format(atom(PrintCall),
+          '  %printed_nr_~w = call i32 (i8*, ...) @printf(i8* %nr_fmt_~w, i64 %current_nr)',
+          [Index, Index])
+    },
+    [FmtPtr, PrintCall].
 
 plawk_print_field_ir(field(0), _FieldSeparator, Index) -->
     { format(atom(LineLen64),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -250,6 +250,8 @@ print_fields_rest([Field | Fields]) -->
 print_fields_rest([]) -->
     [].
 
+field_expr(special('NR')) -->
+    "NR".
 field_expr(assoc(var(Name), KeyExpr)) -->
     identifier(Name),
     ws,

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -33,6 +33,11 @@ test(parses_field_eq_print_fields_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { print $2, $3 }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"), [print([field(2), field(3)])])], [])).
 
+test(parses_field_eq_print_nr_fields_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { print NR, $2, $3 }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [print([special('NR'), field(2), field(3)])])], [])).
+
 test(parses_field_eq_increment_end_print_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { count++ } END { print count }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"), [inc(var(count))])],
@@ -147,6 +152,16 @@ test(surface_field_eq_prints_selected_fields) :-
     run_surface_print_smoke("$1 == \"ERROR\" { print $2, $3 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "disk full\nnet down\n").
+
+test(surface_field_eq_prints_nr_and_selected_fields) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { print NR, $2, $3 }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "2 disk full\n4 net down\n").
+
+test(surface_field_eq_prints_nr_with_output_separator) :-
+    run_surface_print_smoke("BEGIN { OFS = \",\" } $1 == \"ERROR\" { print NR, $2, $3 }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "2,disk,full\n4,net,down\n").
 
 test(surface_field_eq_counts_matching_records) :-
     run_surface_print_smoke("$1 == \"ERROR\" { count++ } END { print count }\n",
@@ -353,6 +368,16 @@ test(surface_begin_output_separator_uses_configured_delimiter) :-
     assertion(\+ sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_space')),
     assertion(\+ sub_atom(DriverIR, _, _, _, 'printf(i8* %end_space_fmt')),
     assertion(\+ sub_atom(DriverIR, _, _, _, '%printed_end_space_1')),
+    !.
+
+test(surface_nr_print_uses_native_record_counter) :-
+    plawk_parse_string("$1 == \"ERROR\" { print NR, $2 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_nr = phi i64 [0, %check_handle_value], [%current_nr, %continue_loop]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%current_nr = add i64 %plawk_nr, 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_nr_0 = call i32 (i8*, ...) @printf(i8* %nr_fmt_0, i64 %current_nr)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 
 run_surface_print_smoke(Source, Input, ExpectedOutput) :-


### PR DESCRIPTION
## Summary
- Parse `NR` in PLAWK print field lists as an explicit special expression.
- Thread a native record-number phi through print-only streaming drivers when `NR` is printed.
- Emit `NR` through the native i64 print path and keep selected fields/OFS behavior unchanged.
- Add compiled surface smokes and IR-shape coverage for `print NR, $2, $3`.
- Update PLAWK README, tutorial, and implementation-plan notes for native `NR` rule prints.

## Tests
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `git diff --cached --check`
- `git diff --check`

Note: `tests/test_wam_llvm_target.pl` still reports existing choicepoint warnings while exiting 0.