### PR TITLE
Add payload parent recurrence helper

### DIFF
--- a/scripts/parent_histogram_recurrence.py
+++ b/scripts/parent_histogram_recurrence.py
@@ -22,6 +22,9 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import dataclass
+import time
+
+from scripts.distribution_serialization import decode_distribution_payload, encode_selected_distribution
 
 
 @dataclass
@@ -34,6 +37,19 @@ class RecurrenceHistogramStats:
     path_cap_hit: bool = False
     expansion_cap_hit: bool = False
     cycle_approximation: bool = False
+
+
+@dataclass
+class PayloadParentRecurrenceStats:
+    parent_payloads: int = 0
+    payloads_decoded: int = 0
+    payload_bytes_read: int = 0
+    decode_ns: int = 0
+    decoded_bins: int = 0
+    output_bins: int = 0
+    output_path_count: int = 0
+    output_payload_bytes: int = 0
+    path_cap_hit: bool = False
 
 
 def shifted_add(out, parent_hist, remaining, path_cap, stats):
@@ -96,3 +112,91 @@ def recurrence_parent_histogram(parents_func, target, root, budget, path_cap=Non
         return memo[key]
 
     return dict(sorted(rec(target, int(budget)).items())), stats
+
+
+def scaled_distribution_histogram(probabilities, origin, total_count):
+    """Convert a normalized finite distribution payload back to count mass."""
+    if origin is None or total_count <= 0:
+        return {}
+    weighted = [(index, max(0.0, float(probability)) * int(total_count)) for index, probability in enumerate(probabilities)]
+    floors = {int(origin) + index: int(value) for index, value in weighted if int(value) > 0}
+    remainder = int(total_count) - sum(floors.values())
+    if remainder > 0 and weighted:
+        ranked = sorted(
+            weighted,
+            key=lambda item: (item[1] - int(item[1]), item[1], -item[0]),
+            reverse=True,
+        )
+        for index, _value in ranked[:remainder]:
+            floors[int(origin) + index] = floors.get(int(origin) + index, 0) + 1
+    return dict(sorted((length, count) for length, count in floors.items() if count > 0))
+
+
+def histogram_distribution(hist):
+    if not hist:
+        return [], 0, 0
+    origin = min(hist)
+    max_length = max(hist)
+    total_count = sum(int(value) for value in hist.values())
+    if total_count <= 0:
+        return [], origin, 0
+    probabilities = [
+        int(hist.get(length, 0)) / total_count
+        for length in range(origin, max_length + 1)
+    ]
+    return probabilities, origin, total_count
+
+
+def payload_to_histogram(payload):
+    """Decode one stored finite-distribution payload into count bins."""
+    payload_bytes = getattr(payload, "payload", payload)
+    started = time.perf_counter_ns()
+    probabilities, metadata = decode_distribution_payload(payload_bytes)
+    decode_ns = time.perf_counter_ns() - started
+    total_count = int(round(float(metadata.get("total_mass", 0.0))))
+    hist = scaled_distribution_histogram(probabilities, int(metadata.get("origin", 0)), total_count)
+    return hist, metadata, decode_ns, len(payload_bytes)
+
+
+def shifted_parent_payload_histogram(parent_payloads, remaining=None, path_cap=None):
+    """Build a child histogram by summing shifted decoded parent payloads.
+
+    This is the one-layer recurrence:
+
+        H_child[d] = sum(H_parent[d - 1] for parent in parents(child))
+
+    Payloads are decoded once each, shifted right by one, and summed as
+    unnormalized path-count mass.  `remaining` is the optional finite horizon
+    for the child histogram.
+    """
+    payloads = list(parent_payloads)
+    stats = PayloadParentRecurrenceStats(parent_payloads=len(payloads))
+    out = Counter()
+    horizon = None if remaining is None else int(remaining)
+    for payload in payloads:
+        parent_hist, _metadata, decode_ns, payload_bytes = payload_to_histogram(payload)
+        stats.payloads_decoded += 1
+        stats.payload_bytes_read += payload_bytes
+        stats.decode_ns += decode_ns
+        stats.decoded_bins += len(parent_hist)
+        for length, count in parent_hist.items():
+            shifted = int(length) + 1
+            if horizon is None or shifted <= horizon:
+                out[shifted] += int(count)
+                if path_cap is not None and sum(out.values()) >= path_cap:
+                    stats.path_cap_hit = True
+                    break
+        if stats.path_cap_hit:
+            break
+    hist = dict(sorted(out.items()))
+    stats.output_bins = len(hist)
+    stats.output_path_count = sum(hist.values())
+    return hist, stats
+
+
+def serialize_shifted_parent_payload_histogram(parent_payloads, representation="packed_sparse_histogram", remaining=None, path_cap=None, cdf_bits=16):
+    hist, stats = shifted_parent_payload_histogram(parent_payloads, remaining, path_cap)
+    probabilities, origin, total_count = histogram_distribution(hist)
+    payload, metadata = encode_selected_distribution(probabilities, representation, origin=origin, total_mass=total_count, cdf_bits=cdf_bits)
+    stats.output_payload_bytes = metadata["payload_bytes"]
+    return payload, metadata, hist, stats

--- a/tests/test_parent_histogram_recurrence.py
+++ b/tests/test_parent_histogram_recurrence.py
@@ -5,8 +5,16 @@
 
 import unittest
 
+from scripts.distribution_serialization import decode_distribution_payload, encode_selected_distribution
 from scripts.lmdb_parent_histogram_benchmark import bounded_parent_histogram
-from scripts.parent_histogram_recurrence import recurrence_parent_histogram
+from scripts.parent_histogram_recurrence import (
+    histogram_distribution,
+    payload_to_histogram,
+    recurrence_parent_histogram,
+    serialize_shifted_parent_payload_histogram,
+    shifted_parent_payload_histogram,
+)
+
 
 
 class ParentHistogramRecurrenceTests(unittest.TestCase):
@@ -61,6 +69,45 @@ class ParentHistogramRecurrenceTests(unittest.TestCase):
 
         self.assertTrue(rec_stats.path_cap_hit)
         self.assertEqual(sum(rec_hist.values()), 1)
+
+    def test_payload_to_histogram_restores_unnormalized_mass(self):
+        probabilities, origin, total_count = histogram_distribution({2: 1, 3: 2})
+        payload, _meta = encode_selected_distribution(probabilities, "packed_sparse_histogram", origin=origin, total_mass=total_count)
+
+        hist, decoded_meta, decode_ns, payload_bytes = payload_to_histogram(payload)
+
+        self.assertEqual(hist, {2: 1, 3: 2})
+        self.assertEqual(decoded_meta["total_mass"], 3)
+        self.assertGreaterEqual(decode_ns, 0)
+        self.assertEqual(payload_bytes, len(payload))
+
+    def test_shifted_parent_payload_histogram_sums_parent_distributions(self):
+        left_prob, left_origin, left_count = histogram_distribution({1: 1, 2: 2})
+        right_prob, right_origin, right_count = histogram_distribution({1: 3})
+        left_payload, _left_meta = encode_selected_distribution(left_prob, "packed_sparse_histogram", origin=left_origin, total_mass=left_count)
+        right_payload, _right_meta = encode_selected_distribution(right_prob, "packed_sparse_histogram", origin=right_origin, total_mass=right_count)
+
+        hist, stats = shifted_parent_payload_histogram([left_payload, right_payload], remaining=4)
+
+        self.assertEqual(hist, {2: 4, 3: 2})
+        self.assertEqual(stats.parent_payloads, 2)
+        self.assertEqual(stats.payloads_decoded, 2)
+        self.assertEqual(stats.output_path_count, 6)
+        self.assertGreater(stats.payload_bytes_read, 0)
+
+    def test_serialize_shifted_parent_payload_histogram_round_trips_child(self):
+        probabilities, origin, total_count = histogram_distribution({1: 2, 3: 1})
+        parent_payload, _parent_meta = encode_selected_distribution(probabilities, "packed_sparse_histogram", origin=origin, total_mass=total_count)
+
+        child_payload, child_meta, child_hist, stats = serialize_shifted_parent_payload_histogram([parent_payload])
+        child_probabilities, decoded_meta = decode_distribution_payload(child_payload)
+        decoded_hist, _decoded_meta, _decode_ns, _payload_bytes = payload_to_histogram(child_payload)
+
+        self.assertEqual(child_hist, {2: 2, 4: 1})
+        self.assertEqual(decoded_hist, child_hist)
+        self.assertEqual(decoded_meta["origin"], 2)
+        self.assertAlmostEqual(sum(child_probabilities), 1.0)
+        self.assertEqual(child_meta["payload_bytes"], stats.output_payload_bytes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add helpers to decode stored distribution payloads back into unnormalized histograms
- add a one-layer parent recurrence that shifts and sums decoded parent payloads
- add child serialization for the shifted parent-payload recurrence result
- add tests covering mass restoration, shifted parent summation, and child payload round-trip

## Notes
- this implements the core recurrence boundary-condition step: decode each stored parent distribution once, shift by one, sum path-count mass, and reserialize the child distribution
- the existing recursive recurrence and DFS paths are unchanged

## Validation
- python3 -m unittest tests.test_parent_histogram_recurrence tests.test_distribution_serialization tests.test_lmdb_parent_boundary_cache_benchmark tests.test_lmdb_parent_recurrence_histogram_benchmark tests.test_lmdb_policy_cache_runtime_benchmark
- git diff --cached --check

Note: direct py_compile for scripts/parent_histogram_recurrence.py was rejected by the local command launcher, but the module imports and executes through the focused unit suite.