### PR TITLE
Support PLAWK native NF prints

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -252,8 +252,10 @@ prints matching records from a text file without calling `run_loop` in the hot
 record loop. The field-equality path scans fields in native code without
 allocating substrings; selected-field printing projects byte slices directly.
 Rule prints can include native `NR`, implemented as a record-number `i64` phi in
-the print-only streaming loop. The scalar counter path threads a native `i64`
-loop variable and prints it from the `END` action. Multiple scalar counters
+the print-only streaming loop, and native `NF`, implemented with the shared
+`@wam_atom_field_count_value` helper over the active single-byte `FS`. The scalar
+counter path threads a native `i64` loop variable and prints it from the `END`
+action. Multiple scalar counters
 become parallel `i64` phi slots in the native streaming loop.
 Scalar counters lower through an explicit codegen state plan that keeps
 source-level state recognition separate from LLVM slot numbering. The current

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -77,8 +77,8 @@ swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR
 The demo prints the record count and the lines whose first field is `ERROR`.
 The first Phase 2 surface smokes parse `/^ERROR/ { print $0 }` and
 `$1 == "ERROR" { print $0 }`, plus selected-field actions such as
-`$1 == "ERROR" { print $2, $3 }`. Rule prints can include native `NR`, e.g.
-`$1 == "ERROR" { print NR, $2, $3 }`, and scalar state with
+`$1 == "ERROR" { print $2, $3 }`. Rule prints can include native `NR` and
+`NF`, e.g. `$1 == "ERROR" { print NR, NF, $2, $3 }`, and scalar state with
 `$1 == "ERROR" { count++ } END { print count }`. Multiple scalar increments
 compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple
 guarded rules can update shared scalar slots before an `END` print. The first

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -120,8 +120,9 @@ The Phase 0 examples use the counter as `NR`, collect printed lines in
 
 ## Current surface example: count matching records
 
-The native Phase 2 surface can compile rule prints with `NR`, selected fields,
-and `OFS`, matching the first awk-style example above. It can also compile a scalar counter and an `END` action:
+The native Phase 2 surface can compile rule prints with `NR`, `NF`, selected
+fields, and `OFS`, matching the first awk-style example above. It can also
+compile a scalar counter and an `END` action:
 
 ```awk
 $1 == "ERROR" { count++ } END { print count }

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -8,7 +8,8 @@
 :- use_module('../../../src/unifyweaver/targets/wam_llvm_target',
     [llvm_emit_atom_prefix_guard/5,
      llvm_emit_atom_field_eq_guard/7,
-     llvm_emit_atom_field_slice/5]).
+     llvm_emit_atom_field_slice/5,
+     llvm_emit_atom_field_count/4]).
 
 %% plawk_program_native_driver_ir(+Program, +InputPath, -DriverIR) is semidet.
 %
@@ -1190,6 +1191,18 @@ plawk_print_field_ir(special('NR'), _FieldSeparator, Index) -->
           [Index, Index])
     },
     [FmtPtr, PrintCall].
+
+plawk_print_field_ir(special('NF'), FieldSeparator, Index) -->
+    { format(atom(Base), 'plawk_nf_~w', [Index]),
+      llvm_emit_atom_field_count('%line', FieldSeparator, Base, CountIR),
+      format(atom(FmtPtr),
+          '  %nf_fmt_~w = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_i64, i32 0, i32 0',
+          [Index]),
+      format(atom(PrintCall),
+          '  %printed_nf_~w = call i32 (i8*, ...) @printf(i8* %nf_fmt_~w, i64 %~w)',
+          [Index, Index, Base])
+    },
+    [CountIR, FmtPtr, PrintCall].
 
 plawk_print_field_ir(field(0), _FieldSeparator, Index) -->
     { format(atom(LineLen64),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -252,6 +252,8 @@ print_fields_rest([]) -->
 
 field_expr(special('NR')) -->
     "NR".
+field_expr(special('NF')) -->
+    "NF".
 field_expr(assoc(var(Name), KeyExpr)) -->
     identifier(Name),
     ws,

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -47,7 +47,8 @@
     split_functor_arity/3,               % +Str, -Name, -Arity (handles `/` in name)
     llvm_emit_atom_prefix_guard/5,       % +GlobalBase, +ValueIR, +Prefix, +ResultIR, -GlobalIR-CallIR
     llvm_emit_atom_field_eq_guard/7,     % +GlobalBase, +ValueIR, +FieldIndex, +Expected, +SepCode, +ResultIR, -GlobalIR-CallIR
-    llvm_emit_atom_field_slice/5         % +ValueIR, +FieldIndex, +SepCode, +SliceBase, -CallIR
+    llvm_emit_atom_field_slice/5,        % +ValueIR, +FieldIndex, +SepCode, +SliceBase, -CallIR
+    llvm_emit_atom_field_count/4         % +ValueIR, +SepCode, +CountBase, -CallIR
 ]).
 
 :- use_module(library(lists)).
@@ -4726,6 +4727,48 @@ fs.yes:
 
 fs.no:
   ret %WamSlice %fs.empty
+}
+
+define i64 @wam_atom_field_count_value(%Value %atom_value, i8 %sep) {
+entry:
+  %fc.t = call i32 @value_tag(%Value %atom_value)
+  %fc.is_atom = icmp eq i32 %fc.t, 0
+  br i1 %fc.is_atom, label %fc.lookup, label %fc.zero
+
+fc.lookup:
+  %fc.aid = call i64 @value_payload(%Value %atom_value)
+  %fc.str = call i8* @wam_atom_to_string(i64 %fc.aid)
+  %fc.null = icmp eq i8* %fc.str, null
+  br i1 %fc.null, label %fc.zero, label %fc.check_empty
+
+fc.check_empty:
+  %fc.first = load i8, i8* %fc.str
+  %fc.empty = icmp eq i8 %fc.first, 0
+  br i1 %fc.empty, label %fc.zero, label %fc.loop
+
+fc.loop:
+  %fc.pos = phi i64 [ 0, %fc.check_empty ], [ %fc.next_pos, %fc.step ]
+  %fc.count = phi i64 [ 1, %fc.check_empty ], [ %fc.next_count, %fc.step ]
+  %fc.ptr = getelementptr i8, i8* %fc.str, i64 %fc.pos
+  %fc.ch = load i8, i8* %fc.ptr
+  %fc.nul = icmp eq i8 %fc.ch, 0
+  br i1 %fc.nul, label %fc.done, label %fc.check_sep
+
+fc.check_sep:
+  %fc.is_sep = icmp eq i8 %fc.ch, %sep
+  br label %fc.step
+
+fc.step:
+  %fc.sep_i64 = zext i1 %fc.is_sep to i64
+  %fc.next_count = add i64 %fc.count, %fc.sep_i64
+  %fc.next_pos = add i64 %fc.pos, 1
+  br label %fc.loop
+
+fc.done:
+  ret i64 %fc.count
+
+fc.zero:
+  ret i64 0
 }
 
 ; Dispatches on integer op codes:
@@ -16161,6 +16204,16 @@ llvm_emit_atom_field_slice(ValueIR, FieldIndex, SepCode, SliceBase, CallIR) :-
          SliceBase, SliceBase,
          SliceBase, SliceBase,
          SliceBase, SliceBase]).
+
+%% llvm_emit_atom_field_count(+ValueIR, +SepCode, +CountBase, -CallIR)
+%
+%  Emit a native field-count operation over an atom-backed text record. The
+%  runtime returns the split_string/4-style field count for the single-byte
+%  separator without allocating field substrings.
+llvm_emit_atom_field_count(ValueIR, SepCode, CountBase, CallIR) :-
+    format(atom(CallIR),
+        '  %~w = call i64 @wam_atom_field_count_value(%Value ~w, i8 ~w)',
+        [CountBase, ValueIR, SepCode]).
 
 escape_llvm_codes([], []).
 escape_llvm_codes([C|Cs], Out) :-

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -38,6 +38,11 @@ test(parses_field_eq_print_nr_fields_rule) :-
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
         [print([special('NR'), field(2), field(3)])])], [])).
 
+test(parses_field_eq_print_nr_nf_fields_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { print NR, NF, $2, $3 }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [print([special('NR'), special('NF'), field(2), field(3)])])], [])).
+
 test(parses_field_eq_increment_end_print_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { count++ } END { print count }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"), [inc(var(count))])],
@@ -158,6 +163,11 @@ test(surface_field_eq_prints_nr_and_selected_fields) :-
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "2 disk full\n4 net down\n").
 
+test(surface_field_eq_prints_nr_nf_and_selected_fields) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { print NR, NF, $2, $3 }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down now\n",
+        "2 3 disk full\n4 4 net down\n").
+
 test(surface_field_eq_prints_nr_with_output_separator) :-
     run_surface_print_smoke("BEGIN { OFS = \",\" } $1 == \"ERROR\" { print NR, $2, $3 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -242,6 +252,11 @@ test(surface_begin_output_separator_drives_selected_field_printing) :-
     run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print $2, $3 }\n",
         "ERROR:disk:full\nWARN:cpu:hot\nERROR:net:down\n",
         "disk,full\nnet,down\n").
+
+test(surface_begin_field_separator_drives_nf_printing) :-
+    run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print NR, NF, $2, $3 }\n",
+        "ERROR:disk:full\nWARN:cpu:hot\nERROR:net:down:now\n",
+        "1,3,disk,full\n3,4,net,down\n").
 
 test(surface_begin_output_separator_drives_end_printing) :-
     run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { counts[$2]++ } END { print \"disk\", counts[\"disk\"], \"net\", counts[\"net\"] }\n",
@@ -376,6 +391,15 @@ test(surface_nr_print_uses_native_record_counter) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_nr = phi i64 [0, %check_handle_value], [%current_nr, %continue_loop]'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%current_nr = add i64 %plawk_nr, 1'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%printed_nr_0 = call i32 (i8*, ...) @printf(i8* %nr_fmt_0, i64 %current_nr)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_nf_print_uses_native_field_count) :-
+    plawk_parse_string("BEGIN { FS = \":\" } $1 == \"ERROR\" { print NF, $2 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_nf_0 = call i64 @wam_atom_field_count_value(%Value %line, i8 58)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_nf_0 = call i32 (i8*, ...) @printf(i8* %nf_fmt_0, i64 %plawk_nf_0)'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -196,6 +196,7 @@ test(full_runtime_generation) :-
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @backtrack')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_field_eq_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamSlice @wam_atom_field_slice_value')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_atom_field_count_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_prefix_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamAssocI64Table* @wam_assoc_i64_new')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_assoc_i64_resize')),
@@ -222,6 +223,10 @@ test(atom_field_slice_emitter) :-
     assertion(sub_atom(CallIR, _, _, _, '%plawk_f2 = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 2, i8 32)')),
     assertion(sub_atom(CallIR, _, _, _, '%plawk_f2_ptr = extractvalue %WamSlice %plawk_f2, 0')),
     assertion(sub_atom(CallIR, _, _, _, '%plawk_f2_len = trunc i64 %plawk_f2_len64 to i32')).
+
+test(atom_field_count_emitter) :-
+    llvm_emit_atom_field_count('%line', 58, plawk_nf, CallIR),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_nf = call i64 @wam_atom_field_count_value(%Value %line, i8 58)')).
 
 % ============================================================================
 % Builtin op ID mapping


### PR DESCRIPTION
## Summary
- Add a shared WAM/LLVM `@wam_atom_field_count_value` helper plus `llvm_emit_atom_field_count/4`.
- Parse `NF` in PLAWK print fields as an explicit special expression.
- Emit `NF` through the native field-count helper using the active single-byte `FS`.
- Add compiled surface smokes for default-space and colon-separated `NF` printing.
- Add IR-shape and WAM target emitter/runtime-definition tests.
- Update PLAWK README, tutorial, and implementation-plan notes.

## Tests
- `git diff --cached --check`
- `git diff --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`

Note: `tests/test_wam_llvm_target.pl` still reports existing choicepoint warnings while exiting 0.