### PR TITLE
Support PLAWK native length prints

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -253,9 +253,10 @@ record loop. The field-equality path scans fields in native code without
 allocating substrings; selected-field printing projects byte slices directly.
 Rule prints can include native `NR`, implemented as a record-number `i64` phi in
 the print-only streaming loop, and native `NF`, implemented with the shared
-`@wam_atom_field_count_value` helper over the active single-byte `FS`. The scalar
-counter path threads a native `i64` loop variable and prints it from the `END`
-action. Multiple scalar counters
+`@wam_atom_field_count_value` helper over the active single-byte `FS`. Rule
+prints can also call native `length($N)` through the shared
+`@wam_atom_field_length_value` helper. The scalar counter path threads a native
+`i64` loop variable and prints it from the `END` action. Multiple scalar counters
 become parallel `i64` phi slots in the native streaming loop.
 Scalar counters lower through an explicit codegen state plan that keeps
 source-level state recognition separate from LLVM slot numbering. The current

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -78,7 +78,8 @@ The demo prints the record count and the lines whose first field is `ERROR`.
 The first Phase 2 surface smokes parse `/^ERROR/ { print $0 }` and
 `$1 == "ERROR" { print $0 }`, plus selected-field actions such as
 `$1 == "ERROR" { print $2, $3 }`. Rule prints can include native `NR` and
-`NF`, e.g. `$1 == "ERROR" { print NR, NF, $2, $3 }`, and scalar state with
+`NF`, e.g. `$1 == "ERROR" { print NR, NF, $2, $3 }`, plus native field lengths
+such as `$1 == "ERROR" { print length($2), $2 }`. Scalar state works with
 `$1 == "ERROR" { count++ } END { print count }`. Multiple scalar increments
 compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple
 guarded rules can update shared scalar slots before an `END` print. The first

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -120,9 +120,9 @@ The Phase 0 examples use the counter as `NR`, collect printed lines in
 
 ## Current surface example: count matching records
 
-The native Phase 2 surface can compile rule prints with `NR`, `NF`, selected
-fields, and `OFS`, matching the first awk-style example above. It can also
-compile a scalar counter and an `END` action:
+The native Phase 2 surface can compile rule prints with `NR`, `NF`, selected fields,
+native field lengths such as `length($2)`, and `OFS`, matching the first awk-style
+example above. It can also compile a scalar counter and an `END` action:
 
 ```awk
 $1 == "ERROR" { count++ } END { print count }

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -9,7 +9,8 @@
     [llvm_emit_atom_prefix_guard/5,
      llvm_emit_atom_field_eq_guard/7,
      llvm_emit_atom_field_slice/5,
-     llvm_emit_atom_field_count/4]).
+     llvm_emit_atom_field_count/4,
+     llvm_emit_atom_field_length/5]).
 
 %% plawk_program_native_driver_ir(+Program, +InputPath, -DriverIR) is semidet.
 %
@@ -1203,6 +1204,18 @@ plawk_print_field_ir(special('NF'), FieldSeparator, Index) -->
           [Index, Index, Base])
     },
     [CountIR, FmtPtr, PrintCall].
+
+plawk_print_field_ir(length(field(FieldIndex)), FieldSeparator, Index) -->
+    { format(atom(Base), 'plawk_length_~w', [Index]),
+      llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, Base, LengthIR),
+      format(atom(FmtPtr),
+          '  %length_fmt_~w = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_i64, i32 0, i32 0',
+          [Index]),
+      format(atom(PrintCall),
+          '  %printed_length_~w = call i32 (i8*, ...) @printf(i8* %length_fmt_~w, i64 %~w)',
+          [Index, Index, Base])
+    },
+    [LengthIR, FmtPtr, PrintCall].
 
 plawk_print_field_ir(field(0), _FieldSeparator, Index) -->
     { format(atom(LineLen64),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -254,6 +254,15 @@ field_expr(special('NR')) -->
     "NR".
 field_expr(special('NF')) -->
     "NF".
+field_expr(length(Field)) -->
+    "length",
+    ws,
+    "(",
+    ws,
+    field_expr(Field),
+    ws,
+    ")",
+    { Field = field(_) }.
 field_expr(assoc(var(Name), KeyExpr)) -->
     identifier(Name),
     ws,

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -48,7 +48,8 @@
     llvm_emit_atom_prefix_guard/5,       % +GlobalBase, +ValueIR, +Prefix, +ResultIR, -GlobalIR-CallIR
     llvm_emit_atom_field_eq_guard/7,     % +GlobalBase, +ValueIR, +FieldIndex, +Expected, +SepCode, +ResultIR, -GlobalIR-CallIR
     llvm_emit_atom_field_slice/5,        % +ValueIR, +FieldIndex, +SepCode, +SliceBase, -CallIR
-    llvm_emit_atom_field_count/4         % +ValueIR, +SepCode, +CountBase, -CallIR
+    llvm_emit_atom_field_count/4,        % +ValueIR, +SepCode, +CountBase, -CallIR
+    llvm_emit_atom_field_length/5        % +ValueIR, +FieldIndex, +SepCode, +LengthBase, -CallIR
 ]).
 
 :- use_module(library(lists)).
@@ -4768,6 +4769,35 @@ fc.done:
   ret i64 %fc.count
 
 fc.zero:
+  ret i64 0
+}
+
+define i64 @wam_atom_field_length_value(%Value %atom_value, i64 %field_index, i8 %sep) {
+entry:
+  %fl.whole = icmp eq i64 %field_index, 0
+  br i1 %fl.whole, label %fl.whole_record, label %fl.field
+
+fl.whole_record:
+  %fl.t = call i32 @value_tag(%Value %atom_value)
+  %fl.is_atom = icmp eq i32 %fl.t, 0
+  br i1 %fl.is_atom, label %fl.lookup, label %fl.zero
+
+fl.lookup:
+  %fl.aid = call i64 @value_payload(%Value %atom_value)
+  %fl.str = call i8* @wam_atom_to_string(i64 %fl.aid)
+  %fl.null = icmp eq i8* %fl.str, null
+  br i1 %fl.null, label %fl.zero, label %fl.measure
+
+fl.measure:
+  %fl.len = call i64 @strlen(i8* %fl.str)
+  ret i64 %fl.len
+
+fl.field:
+  %fl.slice = call %WamSlice @wam_atom_field_slice_value(%Value %atom_value, i64 %field_index, i8 %sep)
+  %fl.field_len = extractvalue %WamSlice %fl.slice, 1
+  ret i64 %fl.field_len
+
+fl.zero:
   ret i64 0
 }
 
@@ -16214,6 +16244,16 @@ llvm_emit_atom_field_count(ValueIR, SepCode, CountBase, CallIR) :-
     format(atom(CallIR),
         '  %~w = call i64 @wam_atom_field_count_value(%Value ~w, i8 ~w)',
         [CountBase, ValueIR, SepCode]).
+
+%% llvm_emit_atom_field_length(+ValueIR, +FieldIndex, +SepCode, +LengthBase, -CallIR)
+%
+%  Emit a native byte-length operation over an atom-backed text record. Field 0
+%  measures the whole record; positive fields measure the projected field slice
+%  without allocating a field substring.
+llvm_emit_atom_field_length(ValueIR, FieldIndex, SepCode, LengthBase, CallIR) :-
+    format(atom(CallIR),
+        '  %~w = call i64 @wam_atom_field_length_value(%Value ~w, i64 ~w, i8 ~w)',
+        [LengthBase, ValueIR, FieldIndex, SepCode]).
 
 escape_llvm_codes([], []).
 escape_llvm_codes([C|Cs], Out) :-

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -43,6 +43,11 @@ test(parses_field_eq_print_nr_nf_fields_rule) :-
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
         [print([special('NR'), special('NF'), field(2), field(3)])])], [])).
 
+test(parses_field_eq_print_length_field_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { print NR, NF, length($2), $2 }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [print([special('NR'), special('NF'), length(field(2)), field(2)])])], [])).
+
 test(parses_field_eq_increment_end_print_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { count++ } END { print count }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"), [inc(var(count))])],
@@ -168,6 +173,11 @@ test(surface_field_eq_prints_nr_nf_and_selected_fields) :-
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down now\n",
         "2 3 disk full\n4 4 net down\n").
 
+test(surface_field_eq_prints_native_field_lengths) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { print NR, NF, length($2), $2 }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR network down now\n",
+        "2 3 4 disk\n4 4 7 network\n").
+
 test(surface_field_eq_prints_nr_with_output_separator) :-
     run_surface_print_smoke("BEGIN { OFS = \",\" } $1 == \"ERROR\" { print NR, $2, $3 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -257,6 +267,11 @@ test(surface_begin_field_separator_drives_nf_printing) :-
     run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print NR, NF, $2, $3 }\n",
         "ERROR:disk:full\nWARN:cpu:hot\nERROR:net:down:now\n",
         "1,3,disk,full\n3,4,net,down\n").
+
+test(surface_begin_field_separator_drives_length_printing) :-
+    run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print length($0), length($2), $2 }\n",
+        "ERROR:disk:full\nWARN:cpu:hot\nERROR:network:down:now\n",
+        "15,4,disk\n22,7,network\n").
 
 test(surface_begin_output_separator_drives_end_printing) :-
     run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { counts[$2]++ } END { print \"disk\", counts[\"disk\"], \"net\", counts[\"net\"] }\n",
@@ -400,6 +415,16 @@ test(surface_nf_print_uses_native_field_count) :-
     plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_nf_0 = call i64 @wam_atom_field_count_value(%Value %line, i8 58)'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%printed_nf_0 = call i32 (i8*, ...) @printf(i8* %nf_fmt_0, i64 %plawk_nf_0)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_length_print_uses_native_field_length) :-
+    plawk_parse_string("BEGIN { FS = \":\" } $1 == \"ERROR\" { print length($0), length($2), $2 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_length_0 = call i64 @wam_atom_field_length_value(%Value %line, i64 0, i8 58)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_length_1 = call i64 @wam_atom_field_length_value(%Value %line, i64 2, i8 58)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_length_1 = call i32 (i8*, ...) @printf(i8* %length_fmt_1, i64 %plawk_length_1)'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -197,6 +197,7 @@ test(full_runtime_generation) :-
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_field_eq_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamSlice @wam_atom_field_slice_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_atom_field_count_value')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_atom_field_length_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_prefix_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamAssocI64Table* @wam_assoc_i64_new')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_assoc_i64_resize')),
@@ -227,6 +228,10 @@ test(atom_field_slice_emitter) :-
 test(atom_field_count_emitter) :-
     llvm_emit_atom_field_count('%line', 58, plawk_nf, CallIR),
     assertion(sub_atom(CallIR, _, _, _, '%plawk_nf = call i64 @wam_atom_field_count_value(%Value %line, i8 58)')).
+
+test(atom_field_length_emitter) :-
+    llvm_emit_atom_field_length('%line', 2, 58, plawk_len, CallIR),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_len = call i64 @wam_atom_field_length_value(%Value %line, i64 2, i8 58)')).
 
 % ============================================================================
 % Builtin op ID mapping


### PR DESCRIPTION
## Summary
- Add shared WAM/LLVM `@wam_atom_field_length_value` support plus `llvm_emit_atom_field_length/5`.
- Parse `length($N)`/`length($0)` in PLAWK print fields as explicit `length(field(N))` AST nodes.
- Emit rule-print field lengths through the native helper using the active single-byte `FS`.
- Add compiled surface smokes for default-space and colon-separated length printing.
- Add IR-shape and WAM target emitter/runtime-definition tests.
- Update PLAWK README, tutorial, and implementation-plan notes.

## Tests
- `git diff --cached --check`
- `git diff --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`

Note: `tests/test_wam_llvm_target.pl` still reports existing choicepoint warnings while exiting 0.