### PR TITLE
Support AWK-style default PLAWK field splitting

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -276,10 +276,13 @@ counters remain `i64` phi slots, assoc arrays remain runtime table pointers, and
 emits indexed string globals and prints them with the same separator rules.
 The first `BEGIN` slices emit literal `print` headers before stream setup, using
 separate indexed string globals so they do not collide with `END` literals, and
-thread single-byte `FS` assignments through native field-equality, selected-field
-print, and associative-key extraction helpers. Single-byte `OFS` assignments now
-configure the separator used by comma-separated `print` fields in `BEGIN`, rule,
-and `END` actions. Native separator emission uses direct byte output rather than
+thread `FS` assignments through native field-equality, selected-field print, and
+associative-key extraction helpers. The default space `FS` follows AWK-style
+whitespace splitting by ignoring leading/trailing whitespace and treating runs of
+space, tab, CR, or LF as one separator; explicit non-space `FS` values still use
+the single-byte literal path. Single-byte `OFS` assignments now configure the
+separator used by comma-separated `print` fields in `BEGIN`, rule, and `END`
+actions. Native separator emission uses direct byte output rather than
 passing the separator through `printf` as a format string.
 
 **Success:** a user-written awk-style program parses, lowers, compiles, and

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -91,9 +91,11 @@ associative count rules lower through the same native rule-chain shape as scalar
 counters, so `$1 == "ERROR" { by_component[$2]++ }` only updates on matches. Each table
 grows and rehashes as needed, and the native stream reader grows its line buffer
 without consuming WAM arena space per record. `BEGIN` print clauses can emit
-literal report headers before the stream opens, and the first `BEGIN` assignment
-slice supports single-byte `FS` values such as `BEGIN { FS = ":" }` for native
-field equality, selected-field printing, and associative key extraction. Single-byte
+literal report headers before the stream opens. The default space `FS` uses
+AWK-style whitespace splitting, so leading whitespace is ignored and whitespace
+runs do not create empty fields. The first `BEGIN` assignment slice supports
+explicit single-byte `FS` values such as `BEGIN { FS = ":" }` for native field
+equality, selected-field printing, and associative key extraction. Single-byte
 `OFS` values such as `BEGIN { OFS = "," }` drive comma-separated `print` fields;
 the native path emits separator bytes directly, so values such as `%` are data,
 not `printf` formats. Mixed scalar/associative state is

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -240,7 +240,10 @@ kind count
 total 4
 ```
 
-`BEGIN` can also set a single-byte field separator for the native field helpers:
+By default, `FS=" "` uses AWK-style whitespace splitting: leading and trailing
+whitespace is ignored, and whitespace runs do not create empty fields.
+
+`BEGIN` can also set an explicit single-byte field separator for the native field helpers:
 
 ```awk
 BEGIN { FS = ":" }

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -4580,8 +4580,52 @@ ap.no:
   ret i1 false
 }
 
+define i1 @wam_is_field_whitespace(i8 %ch) {
+entry:
+  %ws.space = icmp eq i8 %ch, 32
+  %ws.tab = icmp eq i8 %ch, 9
+  %ws.lf = icmp eq i8 %ch, 10
+  %ws.cr = icmp eq i8 %ch, 13
+  %ws.a = or i1 %ws.space, %ws.tab
+  %ws.b = or i1 %ws.lf, %ws.cr
+  %ws.r = or i1 %ws.a, %ws.b
+  ret i1 %ws.r
+}
+
 define i1 @wam_atom_field_eq_value(%Value %atom_value, i64 %field_index, i8* %expected, i64 %expected_len, i8 %sep) {
 entry:
+  %fe.default_sep = icmp eq i8 %sep, 32
+  br i1 %fe.default_sep, label %fe.slice_compare, label %fe.literal_entry
+
+fe.slice_compare:
+  %fe.slice = call %WamSlice @wam_atom_field_slice_value(%Value %atom_value, i64 %field_index, i8 %sep)
+  %fe.slice_ptr = extractvalue %WamSlice %fe.slice, 0
+  %fe.slice_len = extractvalue %WamSlice %fe.slice, 1
+  %fe.slice_has_ptr = icmp ne i8* %fe.slice_ptr, null
+  br i1 %fe.slice_has_ptr, label %fe.slice_len_check, label %fe.no
+
+fe.slice_len_check:
+  %fe.slice_len_ok = icmp eq i64 %fe.slice_len, %expected_len
+  br i1 %fe.slice_len_ok, label %fe.slice_compare_loop, label %fe.no
+
+fe.slice_compare_loop:
+  %fe.slice_i = phi i64 [ 0, %fe.slice_len_check ], [ %fe.slice_next_i, %fe.slice_compare_step ]
+  %fe.slice_done = icmp uge i64 %fe.slice_i, %expected_len
+  br i1 %fe.slice_done, label %fe.yes, label %fe.slice_compare_char
+
+fe.slice_compare_char:
+  %fe.slice_line_ptr = getelementptr i8, i8* %fe.slice_ptr, i64 %fe.slice_i
+  %fe.slice_exp_ptr = getelementptr i8, i8* %expected, i64 %fe.slice_i
+  %fe.slice_line_ch = load i8, i8* %fe.slice_line_ptr
+  %fe.slice_exp_ch = load i8, i8* %fe.slice_exp_ptr
+  %fe.slice_eq = icmp eq i8 %fe.slice_line_ch, %fe.slice_exp_ch
+  br i1 %fe.slice_eq, label %fe.slice_compare_step, label %fe.no
+
+fe.slice_compare_step:
+  %fe.slice_next_i = add i64 %fe.slice_i, 1
+  br label %fe.slice_compare_loop
+
+fe.literal_entry:
   %fe.t = call i32 @value_tag(%Value %atom_value)
   %fe.is_atom = icmp eq i32 %fe.t, 0
   br i1 %fe.is_atom, label %fe.check_index, label %fe.no
@@ -4664,6 +4708,10 @@ define %WamSlice @wam_atom_field_slice_value(%Value %atom_value, i64 %field_inde
 entry:
   %fs.empty0 = insertvalue %WamSlice undef, i8* null, 0
   %fs.empty = insertvalue %WamSlice %fs.empty0, i64 0, 1
+  %fs.default_sep = icmp eq i8 %sep, 32
+  br i1 %fs.default_sep, label %fs.ws_atom_check, label %fs.literal_entry
+
+fs.literal_entry:
   %fs.t = call i32 @value_tag(%Value %atom_value)
   %fs.is_atom = icmp eq i32 %fs.t, 0
   br i1 %fs.is_atom, label %fs.check_index, label %fs.no
@@ -4726,12 +4774,97 @@ fs.yes:
   %fs.slice = insertvalue %WamSlice %fs.slice0, i64 %fs.len, 1
   ret %WamSlice %fs.slice
 
+fs.ws_atom_check:
+  %fs.ws.t = call i32 @value_tag(%Value %atom_value)
+  %fs.ws.is_atom = icmp eq i32 %fs.ws.t, 0
+  br i1 %fs.ws.is_atom, label %fs.ws_check_index, label %fs.no
+
+fs.ws_check_index:
+  %fs.ws.index_ok = icmp sgt i64 %field_index, 0
+  br i1 %fs.ws.index_ok, label %fs.ws_lookup, label %fs.no
+
+fs.ws_lookup:
+  %fs.ws.aid = call i64 @value_payload(%Value %atom_value)
+  %fs.ws.str = call i8* @wam_atom_to_string(i64 %fs.ws.aid)
+  %fs.ws.null = icmp eq i8* %fs.ws.str, null
+  br i1 %fs.ws.null, label %fs.no, label %fs.ws_start
+
+fs.ws_start:
+  %fs.ws.cur_index = phi i64 [ 1, %fs.ws_lookup ], [ %fs.ws.next_index, %fs.ws_after_field ]
+  %fs.ws.pos0 = phi i64 [ 0, %fs.ws_lookup ], [ %fs.ws.after_field_pos, %fs.ws_after_field ]
+  br label %fs.ws_skip_ws
+
+fs.ws_skip_ws:
+  %fs.ws.skip_pos = phi i64 [ %fs.ws.pos0, %fs.ws_start ], [ %fs.ws.skip_next_pos, %fs.ws_skip_next ]
+  %fs.ws.skip_ptr = getelementptr i8, i8* %fs.ws.str, i64 %fs.ws.skip_pos
+  %fs.ws.skip_ch = load i8, i8* %fs.ws.skip_ptr
+  %fs.ws.skip_nul = icmp eq i8 %fs.ws.skip_ch, 0
+  br i1 %fs.ws.skip_nul, label %fs.no, label %fs.ws_skip_check
+
+fs.ws_skip_check:
+  %fs.ws.skip_is_ws = call i1 @wam_is_field_whitespace(i8 %fs.ws.skip_ch)
+  br i1 %fs.ws.skip_is_ws, label %fs.ws_skip_next, label %fs.ws_field_start
+
+fs.ws_skip_next:
+  %fs.ws.skip_next_pos = add i64 %fs.ws.skip_pos, 1
+  br label %fs.ws_skip_ws
+
+fs.ws_field_start:
+  %fs.ws.index_match = icmp eq i64 %fs.ws.cur_index, %field_index
+  br i1 %fs.ws.index_match, label %fs.ws_end_loop, label %fs.ws_scan_field
+
+fs.ws_scan_field:
+  %fs.ws.scan_pos = phi i64 [ %fs.ws.skip_pos, %fs.ws_field_start ], [ %fs.ws.scan_next_pos, %fs.ws_scan_next ]
+  %fs.ws.scan_ptr = getelementptr i8, i8* %fs.ws.str, i64 %fs.ws.scan_pos
+  %fs.ws.scan_ch = load i8, i8* %fs.ws.scan_ptr
+  %fs.ws.scan_nul = icmp eq i8 %fs.ws.scan_ch, 0
+  br i1 %fs.ws.scan_nul, label %fs.no, label %fs.ws_scan_check
+
+fs.ws_scan_check:
+  %fs.ws.scan_is_ws = call i1 @wam_is_field_whitespace(i8 %fs.ws.scan_ch)
+  br i1 %fs.ws.scan_is_ws, label %fs.ws_after_field, label %fs.ws_scan_next
+
+fs.ws_scan_next:
+  %fs.ws.scan_next_pos = add i64 %fs.ws.scan_pos, 1
+  br label %fs.ws_scan_field
+
+fs.ws_after_field:
+  %fs.ws.after_field_pos = add i64 %fs.ws.scan_pos, 1
+  %fs.ws.next_index = add i64 %fs.ws.cur_index, 1
+  br label %fs.ws_start
+
+fs.ws_end_loop:
+  %fs.ws.end_pos = phi i64 [ %fs.ws.skip_pos, %fs.ws_field_start ], [ %fs.ws.end_next_pos, %fs.ws_end_next ]
+  %fs.ws.end_ptr = getelementptr i8, i8* %fs.ws.str, i64 %fs.ws.end_pos
+  %fs.ws.end_ch = load i8, i8* %fs.ws.end_ptr
+  %fs.ws.end_nul = icmp eq i8 %fs.ws.end_ch, 0
+  br i1 %fs.ws.end_nul, label %fs.ws_yes, label %fs.ws_end_check
+
+fs.ws_end_check:
+  %fs.ws.end_is_ws = call i1 @wam_is_field_whitespace(i8 %fs.ws.end_ch)
+  br i1 %fs.ws.end_is_ws, label %fs.ws_yes, label %fs.ws_end_next
+
+fs.ws_end_next:
+  %fs.ws.end_next_pos = add i64 %fs.ws.end_pos, 1
+  br label %fs.ws_end_loop
+
+fs.ws_yes:
+  %fs.ws.ptr = getelementptr i8, i8* %fs.ws.str, i64 %fs.ws.skip_pos
+  %fs.ws.len = sub i64 %fs.ws.end_pos, %fs.ws.skip_pos
+  %fs.ws.slice0 = insertvalue %WamSlice undef, i8* %fs.ws.ptr, 0
+  %fs.ws.slice = insertvalue %WamSlice %fs.ws.slice0, i64 %fs.ws.len, 1
+  ret %WamSlice %fs.ws.slice
+
 fs.no:
   ret %WamSlice %fs.empty
 }
 
 define i64 @wam_atom_field_count_value(%Value %atom_value, i8 %sep) {
 entry:
+  %fc.default_sep = icmp eq i8 %sep, 32
+  br i1 %fc.default_sep, label %fc.ws_atom_check, label %fc.literal_entry
+
+fc.literal_entry:
   %fc.t = call i32 @value_tag(%Value %atom_value)
   %fc.is_atom = icmp eq i32 %fc.t, 0
   br i1 %fc.is_atom, label %fc.lookup, label %fc.zero
@@ -4767,6 +4900,43 @@ fc.step:
 
 fc.done:
   ret i64 %fc.count
+
+fc.ws_atom_check:
+  %fc.ws.t = call i32 @value_tag(%Value %atom_value)
+  %fc.ws.is_atom = icmp eq i32 %fc.ws.t, 0
+  br i1 %fc.ws.is_atom, label %fc.ws_lookup, label %fc.zero
+
+fc.ws_lookup:
+  %fc.ws.aid = call i64 @value_payload(%Value %atom_value)
+  %fc.ws.str = call i8* @wam_atom_to_string(i64 %fc.ws.aid)
+  %fc.ws.null = icmp eq i8* %fc.ws.str, null
+  br i1 %fc.ws.null, label %fc.zero, label %fc.ws_loop
+
+fc.ws_loop:
+  %fc.ws.pos = phi i64 [ 0, %fc.ws_lookup ], [ %fc.ws.next_pos, %fc.ws_step ]
+  %fc.ws.count = phi i64 [ 0, %fc.ws_lookup ], [ %fc.ws.next_count, %fc.ws_step ]
+  %fc.ws.in_field = phi i1 [ false, %fc.ws_lookup ], [ %fc.ws.next_in_field, %fc.ws_step ]
+  %fc.ws.ptr = getelementptr i8, i8* %fc.ws.str, i64 %fc.ws.pos
+  %fc.ws.ch = load i8, i8* %fc.ws.ptr
+  %fc.ws.nul = icmp eq i8 %fc.ws.ch, 0
+  br i1 %fc.ws.nul, label %fc.ws_done, label %fc.ws_check
+
+fc.ws_check:
+  %fc.ws.is_ws = call i1 @wam_is_field_whitespace(i8 %fc.ws.ch)
+  %fc.ws.not_ws = xor i1 %fc.ws.is_ws, true
+  %fc.ws.not_in_field = xor i1 %fc.ws.in_field, true
+  %fc.ws.new_field = and i1 %fc.ws.not_ws, %fc.ws.not_in_field
+  %fc.ws.inc = zext i1 %fc.ws.new_field to i64
+  %fc.ws.next_count = add i64 %fc.ws.count, %fc.ws.inc
+  %fc.ws.next_in_field = select i1 %fc.ws.is_ws, i1 false, i1 true
+  br label %fc.ws_step
+
+fc.ws_step:
+  %fc.ws.next_pos = add i64 %fc.ws.pos, 1
+  br label %fc.ws_loop
+
+fc.ws_done:
+  ret i64 %fc.ws.count
 
 fc.zero:
   ret i64 0

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -178,6 +178,11 @@ test(surface_field_eq_prints_native_field_lengths) :-
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR network down now\n",
         "2 3 4 disk\n4 4 7 network\n").
 
+test(surface_default_space_fs_collapses_whitespace_runs) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { print NF, $2, length($2) }\n",
+        "  INFO   boot ok\n\tERROR   disk   full  \nWARN cpu hot\n  ERROR\tnetwork  down now\n",
+        "3 disk 4\n4 network 7\n").
+
 test(surface_field_eq_prints_nr_with_output_separator) :-
     run_surface_print_smoke("BEGIN { OFS = \",\" } $1 == \"ERROR\" { print NR, $2, $3 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -426,6 +431,16 @@ test(surface_length_print_uses_native_field_length) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_length_1 = call i64 @wam_atom_field_length_value(%Value %line, i64 2, i8 58)'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%printed_length_1 = call i32 (i8*, ...) @printf(i8* %length_fmt_1, i64 %plawk_length_1)'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_default_space_fs_uses_native_whitespace_helpers) :-
+    plawk_parse_string("$1 == \"ERROR\" { print NF, $2, length($2) }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_eq_value(%Value %line, i64 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_count_value(%Value %line, i8 32)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value(%Value %line, i64 2, i8 32)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_length_value(%Value %line, i64 2, i8 32)'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -197,6 +197,7 @@ test(full_runtime_generation) :-
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_field_eq_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamSlice @wam_atom_field_slice_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_atom_field_count_value')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_is_field_whitespace')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_atom_field_length_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_prefix_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamAssocI64Table* @wam_assoc_i64_new')),


### PR DESCRIPTION
## Summary
- Add shared WAM/LLVM whitespace classification for native field helpers.
- Make default `FS=" "` collapse whitespace runs and ignore leading/trailing whitespace for field equality, selected fields, `NF`, `length($N)`, and associative-key extraction.
- Keep explicit non-space `FS` values on the existing single-byte literal separator path.
- Add compiled PLAWK smokes for leading whitespace, tabs, repeated spaces, `NF`, `$2`, and `length($2)`.
- Update PLAWK README, tutorial, and implementation-plan notes.

## Tests
- `git diff --cached --check`
- `git diff --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`

Note: `tests/test_wam_llvm_target.pl` still reports existing choicepoint warnings while exiting 0.