### PR TITLE
Document distribution precompute break-even policy

### DIFF
--- a/docs/design/DISTRIBUTIONAL_COMPRESSION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/DISTRIBUTIONAL_COMPRESSION_IMPLEMENTATION_PLAN.md
@@ -159,6 +159,45 @@ The default candidate order should be conservative and discrete-first.  Users
 can opt into Gaussian mixtures or learned smoothers, but those should not be the
 first default while simpler bounded discrete families pass the error gate.
 
+Add a precompute-depth estimator before wiring the policy into production
+materialisation.  The estimator should report, per root-distance bucket and per
+candidate representation:
+
+```text
+expected_hits
+hits_to_break_even
+uncached_suffix_cost
+cached_suffix_eval_cost
+build_cost
+fit_cost
+storage_cost
+amortized_decode_cost
+size_biased_parent_branching
+```
+
+The initial `expected_hits` prior can use
+`b = E[p^2] / E[p]`: if query traffic is broadly spread across a layer, the
+per-node expected hit rate should fall by roughly `1 / b` for each step away
+from the root.  The implementation should keep this as a replaceable prior,
+because observed query frequencies, subtree-specific branching, and sampled
+parent-reference counts are better signals when available.
+
+Do not use the number of points in an approximation as the break-even hit count.
+A 50-point sampled distribution is a representation cost, not a direct claim
+that 50 hits are required.  One hit may avoid many path expansions and LMDB
+lookups, so the threshold can be much smaller; a cheap narrow exact histogram or
+expensive fit can make it larger.  Compute the threshold in measured units:
+
+```text
+hits_to_break_even =
+    (build_cost + fit_cost + storage_cost + amortized_decode_cost)
+    / max(epsilon, uncached_suffix_cost - cached_suffix_eval_cost)
+```
+
+When decode caching is active, charge decode cost at the batch or parent-payload
+level.  A decoded parent distribution reused by many child queries should not
+be charged as if every path decoded it independently.
+
 ## Phase 7: Learned smoothers
 
 Gaussian-mixture smoothing or a tiny convolutional smoother can be evaluated

--- a/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
+++ b/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
@@ -487,6 +487,49 @@ defer_full_distribution(node) when
     and expected_reuse(node) is low
 ```
 
+The reuse term should be amortized over the expected query workload, not treated
+as a local depth constant.  For a workload with `Q` expected queries:
+
+```text
+expected_hits(v) =
+    Q * probability_that_a_query_reaches_v_before_a_cached_boundary
+
+materialize_or_fit(v) when
+    expected_hits(v) * (uncached_suffix_cost(v) - cached_suffix_eval_cost(v))
+      >
+    build_cost(v) + fit_cost(v) + storage_cost(v) + amortized_decode_cost(v)
+```
+
+`E[p^2] / E[p]` gives the first prior for the hit probability.  If parent path
+mass expands by a factor `b = E[p^2] / E[p]` per layer and the workload is
+broadly distributed across that layer, then the per-node traffic one layer
+farther from the root drops by roughly `1 / b`.  Near-root distributions are
+therefore disproportionately valuable: many query paths cross them, while the
+same aggregate traffic is spread over more nodes deeper in the tree.  This is a
+planning prior, not a correctness rule.  The estimator should replace it with
+observed query frequencies, subtree-specific branch factors, or sampled parent
+reference counts when those measurements are available.
+
+The apparent "50 point model means 50 hits to break even" rule is only a rough
+mnemonic and should not be encoded literally.  A 50-point sampled distribution
+has about 50 stored/evaluated states, but one cached hit can replace hundreds or
+thousands of DFS expansions, several LMDB parent lookups, and repeated cycle
+checks.  In that case the break-even hit count can be far below 50.  Conversely,
+if the suffix is already narrow, the uncached recurrence is cheap, or fitting a
+closed form costs more than packing the exact histogram, the threshold can be
+well above 50.  The planner should compute:
+
+```text
+hits_to_break_even(v) =
+    (build_cost + fit_cost + storage_cost + amortized_decode_cost)
+    / max(epsilon, uncached_suffix_cost - cached_suffix_eval_cost)
+```
+
+and use the point count only as an input to the build/storage/evaluation cost
+model.  Decode cost is also workload-dependent: if a parent payload is decoded
+once and memoised for a batch, it should be charged once per batch or divided
+across expected hits, not charged independently to every query path.
+
 For SimpleWiki, the current measurements suggest the first condition dominates.
 For enwiki, the parent-branching moment should be measured by root-distance
 bucket before deciding how far exact histograms should be propagated.


### PR DESCRIPTION
## Summary
- document amortized precompute admission using expected query hits and suffix work saved
- describe the E[p^2] / E[p] depth prior and the approximate 1 / b per-node traffic decay
- clarify that a 50-point model is a representation cost, not a literal 50-hit break-even rule
- add estimator fields for future precompute-depth planning

## Tests
- git diff --check