### PR TITLE
Support PLAWK native substr prints

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -255,8 +255,9 @@ Rule prints can include native `NR`, implemented as a record-number `i64` phi in
 the print-only streaming loop, and native `NF`, implemented with the shared
 `@wam_atom_field_count_value` helper over the active single-byte `FS`. Rule
 prints can also call native `length($N)` through the shared
-`@wam_atom_field_length_value` helper. The scalar counter path threads a native
-`i64` loop variable and prints it from the `END` action. Multiple scalar counters
+`@wam_atom_field_length_value` helper and native `substr($N, Start, Len)` through
+the allocation-free `@wam_atom_field_subslice_value` helper. The scalar counter
+path threads a native `i64` loop variable and prints it from the `END` action. Multiple scalar counters
 become parallel `i64` phi slots in the native streaming loop.
 Scalar counters lower through an explicit codegen state plan that keeps
 source-level state recognition separate from LLVM slot numbering. The current

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -79,8 +79,9 @@ The first Phase 2 surface smokes parse `/^ERROR/ { print $0 }` and
 `$1 == "ERROR" { print $0 }`, plus selected-field actions such as
 `$1 == "ERROR" { print $2, $3 }`. Rule prints can include native `NR` and
 `NF`, e.g. `$1 == "ERROR" { print NR, NF, $2, $3 }`, plus native field lengths
-such as `$1 == "ERROR" { print length($2), $2 }`. Scalar state works with
-`$1 == "ERROR" { count++ } END { print count }`. Multiple scalar increments
+such as `$1 == "ERROR" { print length($2), $2 }` and native byte substrings such
+as `$1 == "ERROR" { print substr($2, 1, 3) }`. Scalar state works with `$1 ==
+"ERROR" { count++ } END { print count }`. Multiple scalar increments
 compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple
 guarded rules can update shared scalar slots before an `END` print. The first
 associative-count surface now supports multiple source arrays, e.g.

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -120,9 +120,10 @@ The Phase 0 examples use the counter as `NR`, collect printed lines in
 
 ## Current surface example: count matching records
 
-The native Phase 2 surface can compile rule prints with `NR`, `NF`, selected fields,
-native field lengths such as `length($2)`, and `OFS`, matching the first awk-style
-example above. It can also compile a scalar counter and an `END` action:
+The native Phase 2 surface can compile rule prints with `NR`, `NF`, selected
+fields, native field lengths such as `length($2)`, native byte substrings such as
+`substr($2, 1, 3)`, and `OFS`, matching the first awk-style example above. It can
+also compile a scalar counter and an `END` action:
 
 ```awk
 $1 == "ERROR" { count++ } END { print count }
@@ -242,6 +243,8 @@ total 4
 
 By default, `FS=" "` uses AWK-style whitespace splitting: leading and trailing
 whitespace is ignored, and whitespace runs do not create empty fields.
+
+The first `substr` surface uses AWK-style 1-based starts and byte counts.
 
 `BEGIN` can also set an explicit single-byte field separator for the native field helpers:
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -10,7 +10,8 @@
      llvm_emit_atom_field_eq_guard/7,
      llvm_emit_atom_field_slice/5,
      llvm_emit_atom_field_count/4,
-     llvm_emit_atom_field_length/5]).
+     llvm_emit_atom_field_length/5,
+     llvm_emit_atom_field_subslice/7]).
 
 %% plawk_program_native_driver_ir(+Program, +InputPath, -DriverIR) is semidet.
 %
@@ -1216,6 +1217,18 @@ plawk_print_field_ir(length(field(FieldIndex)), FieldSeparator, Index) -->
           [Index, Index, Base])
     },
     [LengthIR, FmtPtr, PrintCall].
+
+plawk_print_field_ir(substr(field(FieldIndex), Start, Len), FieldSeparator, Index) -->
+    { format(atom(Base), 'plawk_substr_~w', [Index]),
+      llvm_emit_atom_field_subslice('%line', FieldIndex, FieldSeparator, Start, Len, Base, SliceIR),
+      format(atom(FmtPtr),
+          '  %substr_fmt_~w = getelementptr [5 x i8], [5 x i8]* @.plawk_surface_print_slice, i32 0, i32 0',
+          [Index]),
+      format(atom(PrintCall),
+          '  %printed_substr_~w = call i32 (i8*, ...) @printf(i8* %substr_fmt_~w, i32 %~w_len, i8* %~w_ptr)',
+          [Index, Index, Base, Base])
+    },
+    [SliceIR, FmtPtr, PrintCall].
 
 plawk_print_field_ir(field(0), _FieldSeparator, Index) -->
     { format(atom(LineLen64),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -263,6 +263,26 @@ field_expr(length(Field)) -->
     ws,
     ")",
     { Field = field(_) }.
+field_expr(substr(Field, Start, Len)) -->
+    "substr",
+    ws,
+    "(",
+    ws,
+    field_expr(Field),
+    ws,
+    ",",
+    ws,
+    integer_codes(StartCodes),
+    ws,
+    ",",
+    ws,
+    integer_codes(LenCodes),
+    ws,
+    ")",
+    { Field = field(_),
+      StartCodes \== [], LenCodes \== [],
+      number_codes(Start, StartCodes), Start >= 1,
+      number_codes(Len, LenCodes), Len >= 0 }.
 field_expr(assoc(var(Name), KeyExpr)) -->
     identifier(Name),
     ws,

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -49,7 +49,8 @@
     llvm_emit_atom_field_eq_guard/7,     % +GlobalBase, +ValueIR, +FieldIndex, +Expected, +SepCode, +ResultIR, -GlobalIR-CallIR
     llvm_emit_atom_field_slice/5,        % +ValueIR, +FieldIndex, +SepCode, +SliceBase, -CallIR
     llvm_emit_atom_field_count/4,        % +ValueIR, +SepCode, +CountBase, -CallIR
-    llvm_emit_atom_field_length/5        % +ValueIR, +FieldIndex, +SepCode, +LengthBase, -CallIR
+    llvm_emit_atom_field_length/5,       % +ValueIR, +FieldIndex, +SepCode, +LengthBase, -CallIR
+    llvm_emit_atom_field_subslice/7      % +ValueIR, +FieldIndex, +SepCode, +Start, +Len, +SliceBase, -CallIR
 ]).
 
 :- use_module(library(lists)).
@@ -4969,6 +4970,81 @@ fl.field:
 
 fl.zero:
   ret i64 0
+}
+
+define %WamSlice @wam_subslice_value(i8* %source_ptr, i64 %source_len, i64 %start, i64 %max_len) {
+entry:
+  %ss.empty0 = insertvalue %WamSlice undef, i8* null, 0
+  %ss.empty = insertvalue %WamSlice %ss.empty0, i64 0, 1
+  %ss.null = icmp eq i8* %source_ptr, null
+  br i1 %ss.null, label %ss.no, label %ss.check_start
+
+ss.check_start:
+  %ss.start_ok = icmp sgt i64 %start, 0
+  br i1 %ss.start_ok, label %ss.check_len, label %ss.no
+
+ss.check_len:
+  %ss.len_ok = icmp sge i64 %max_len, 0
+  br i1 %ss.len_ok, label %ss.compute, label %ss.no
+
+ss.compute:
+  %ss.offset = sub i64 %start, 1
+  %ss.in_range = icmp ult i64 %ss.offset, %source_len
+  br i1 %ss.in_range, label %ss.make_slice, label %ss.no
+
+ss.make_slice:
+  %ss.available = sub i64 %source_len, %ss.offset
+  %ss.len_fits = icmp ule i64 %max_len, %ss.available
+  %ss.out_len = select i1 %ss.len_fits, i64 %max_len, i64 %ss.available
+  %ss.ptr = getelementptr i8, i8* %source_ptr, i64 %ss.offset
+  %ss.slice0 = insertvalue %WamSlice undef, i8* %ss.ptr, 0
+  %ss.slice = insertvalue %WamSlice %ss.slice0, i64 %ss.out_len, 1
+  ret %WamSlice %ss.slice
+
+ss.no:
+  ret %WamSlice %ss.empty
+}
+
+define %WamSlice @wam_atom_field_subslice_value(%Value %atom_value, i64 %field_index, i8 %sep, i64 %start, i64 %max_len) {
+entry:
+  %afs.empty0 = insertvalue %WamSlice undef, i8* null, 0
+  %afs.empty = insertvalue %WamSlice %afs.empty0, i64 0, 1
+  %afs.whole = icmp eq i64 %field_index, 0
+  br i1 %afs.whole, label %afs.whole_record, label %afs.field
+
+afs.whole_record:
+  %afs.t = call i32 @value_tag(%Value %atom_value)
+  %afs.is_atom = icmp eq i32 %afs.t, 0
+  br i1 %afs.is_atom, label %afs.lookup, label %afs.no
+
+afs.lookup:
+  %afs.aid = call i64 @value_payload(%Value %atom_value)
+  %afs.str = call i8* @wam_atom_to_string(i64 %afs.aid)
+  %afs.null = icmp eq i8* %afs.str, null
+  br i1 %afs.null, label %afs.no, label %afs.measure
+
+afs.measure:
+  %afs.len = call i64 @strlen(i8* %afs.str)
+  %afs.whole_slice = call %WamSlice @wam_subslice_value(i8* %afs.str, i64 %afs.len, i64 %start, i64 %max_len)
+  ret %WamSlice %afs.whole_slice
+
+afs.field:
+  %afs.index_ok = icmp sgt i64 %field_index, 0
+  br i1 %afs.index_ok, label %afs.field_slice, label %afs.no
+
+afs.field_slice:
+  %afs.source = call %WamSlice @wam_atom_field_slice_value(%Value %atom_value, i64 %field_index, i8 %sep)
+  %afs.source_ptr = extractvalue %WamSlice %afs.source, 0
+  %afs.source_len = extractvalue %WamSlice %afs.source, 1
+  %afs.source_has_ptr = icmp ne i8* %afs.source_ptr, null
+  br i1 %afs.source_has_ptr, label %afs.subslice, label %afs.no
+
+afs.subslice:
+  %afs.slice = call %WamSlice @wam_subslice_value(i8* %afs.source_ptr, i64 %afs.source_len, i64 %start, i64 %max_len)
+  ret %WamSlice %afs.slice
+
+afs.no:
+  ret %WamSlice %afs.empty
 }
 
 ; Dispatches on integer op codes:
@@ -16424,6 +16500,19 @@ llvm_emit_atom_field_length(ValueIR, FieldIndex, SepCode, LengthBase, CallIR) :-
     format(atom(CallIR),
         '  %~w = call i64 @wam_atom_field_length_value(%Value ~w, i64 ~w, i8 ~w)',
         [LengthBase, ValueIR, FieldIndex, SepCode]).
+
+%% llvm_emit_atom_field_subslice(+ValueIR, +FieldIndex, +SepCode, +Start, +Len, +SliceBase, -CallIR)
+%
+%  Emit a native AWK-style substr/3 projection over an atom-backed text record.
+%  Start is 1-based and Len is a byte count. Field 0 slices the whole record;
+%  positive fields slice the projected field without allocating substrings.
+llvm_emit_atom_field_subslice(ValueIR, FieldIndex, SepCode, Start, Len, SliceBase, CallIR) :-
+    format(atom(CallIR),
+        '  %~w = call %WamSlice @wam_atom_field_subslice_value(%Value ~w, i64 ~w, i8 ~w, i64 ~w, i64 ~w)~n  %~w_ptr = extractvalue %WamSlice %~w, 0~n  %~w_len64 = extractvalue %WamSlice %~w, 1~n  %~w_len = trunc i64 %~w_len64 to i32',
+        [SliceBase, ValueIR, FieldIndex, SepCode, Start, Len,
+         SliceBase, SliceBase,
+         SliceBase, SliceBase,
+         SliceBase, SliceBase]).
 
 escape_llvm_codes([], []).
 escape_llvm_codes([C|Cs], Out) :-

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -48,6 +48,11 @@ test(parses_field_eq_print_length_field_rule) :-
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
         [print([special('NR'), special('NF'), length(field(2)), field(2)])])], [])).
 
+test(parses_field_eq_print_substr_field_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { print substr($2, 1, 3), substr($0, 7, 4) }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [print([substr(field(2), 1, 3), substr(field(0), 7, 4)])])], [])).
+
 test(parses_field_eq_increment_end_print_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { count++ } END { print count }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"), [inc(var(count))])],
@@ -183,6 +188,11 @@ test(surface_default_space_fs_collapses_whitespace_runs) :-
         "  INFO   boot ok\n\tERROR   disk   full  \nWARN cpu hot\n  ERROR\tnetwork  down now\n",
         "3 disk 4\n4 network 7\n").
 
+test(surface_field_eq_prints_native_substrings) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { print substr($2, 1, 3), substr($0, 7, 4) }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR network down now\n",
+        "dis disk\nnet netw\n").
+
 test(surface_field_eq_prints_nr_with_output_separator) :-
     run_surface_print_smoke("BEGIN { OFS = \",\" } $1 == \"ERROR\" { print NR, $2, $3 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -277,6 +287,11 @@ test(surface_begin_field_separator_drives_length_printing) :-
     run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print length($0), length($2), $2 }\n",
         "ERROR:disk:full\nWARN:cpu:hot\nERROR:network:down:now\n",
         "15,4,disk\n22,7,network\n").
+
+test(surface_begin_field_separator_drives_substr_printing) :-
+    run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print substr($2, 1, 3), substr($0, 7, 4) }\n",
+        "ERROR:disk:full\nWARN:cpu:hot\nERROR:network:down:now\n",
+        "dis,disk\nnet,netw\n").
 
 test(surface_begin_output_separator_drives_end_printing) :-
     run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { counts[$2]++ } END { print \"disk\", counts[\"disk\"], \"net\", counts[\"net\"] }\n",
@@ -441,6 +456,16 @@ test(surface_default_space_fs_uses_native_whitespace_helpers) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_count_value(%Value %line, i8 32)'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value(%Value %line, i64 2, i8 32)'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_length_value(%Value %line, i64 2, i8 32)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_substr_print_uses_native_subslice) :-
+    plawk_parse_string("BEGIN { FS = \":\" } $1 == \"ERROR\" { print substr($2, 1, 3), substr($0, 7, 4) }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_substr_0 = call %WamSlice @wam_atom_field_subslice_value(%Value %line, i64 2, i8 58, i64 1, i64 3)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_substr_1 = call %WamSlice @wam_atom_field_subslice_value(%Value %line, i64 0, i8 58, i64 7, i64 4)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_substr_0 = call i32 (i8*, ...) @printf(i8* %substr_fmt_0, i32 %plawk_substr_0_len, i8* %plawk_substr_0_ptr)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_slice = private constant [5 x i8] c"%.*s\\00"'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -199,6 +199,8 @@ test(full_runtime_generation) :-
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_atom_field_count_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_is_field_whitespace')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_atom_field_length_value')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamSlice @wam_subslice_value')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamSlice @wam_atom_field_subslice_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_prefix_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamAssocI64Table* @wam_assoc_i64_new')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_assoc_i64_resize')),
@@ -233,6 +235,12 @@ test(atom_field_count_emitter) :-
 test(atom_field_length_emitter) :-
     llvm_emit_atom_field_length('%line', 2, 58, plawk_len, CallIR),
     assertion(sub_atom(CallIR, _, _, _, '%plawk_len = call i64 @wam_atom_field_length_value(%Value %line, i64 2, i8 58)')).
+
+test(atom_field_subslice_emitter) :-
+    llvm_emit_atom_field_subslice('%line', 2, 58, 1, 3, plawk_substr, CallIR),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_substr = call %WamSlice @wam_atom_field_subslice_value(%Value %line, i64 2, i8 58, i64 1, i64 3)')),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_substr_ptr = extractvalue %WamSlice %plawk_substr, 0')),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_substr_len = trunc i64 %plawk_substr_len64 to i32')).
 
 % ============================================================================
 % Builtin op ID mapping


### PR DESCRIPTION
## Summary
- Add shared WAM/LLVM `%WamSlice` subslice helpers for allocation-free byte slicing.
- Add `llvm_emit_atom_field_subslice/7` for field or whole-record `substr` lowering.
- Parse `substr($N, Start, Len)` and `substr($0, Start, Len)` as explicit PLAWK print expressions.
- Emit native substr print fields through the existing `%.*s` slice print path.
- Add compiled smokes for default whitespace `FS` and explicit colon `FS` substr printing.
- Update PLAWK README, tutorial, and implementation-plan notes.

## Tests
- `git diff --cached --check`
- `git diff --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`

Note: `tests/test_wam_llvm_target.pl` still reports existing choicepoint warnings while exiting 0.