### PR TITLE
Support PLAWK native index prints

### DIFF
--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -11,7 +11,8 @@
      llvm_emit_atom_field_slice/5,
      llvm_emit_atom_field_count/4,
      llvm_emit_atom_field_length/5,
-     llvm_emit_atom_field_subslice/7]).
+     llvm_emit_atom_field_subslice/7,
+     llvm_emit_atom_field_index/7]).
 
 %% plawk_program_native_driver_ir(+Program, +InputPath, -DriverIR) is semidet.
 %
@@ -45,7 +46,7 @@ plawk_program_native_driver_ir(
     plawk_field_separator(BeginClauses, FieldSeparator),
     plawk_pattern_guard_ir(Pattern, FieldSeparator, GuardGlobalIR-GuardCallIR),
     plawk_print_record_counter_ir(Fields, LoopPhiIR, RecordCounterIR),
-    plawk_print_action_ir(Fields, FieldSeparator, OutputSeparator, PrintActionIR),
+    plawk_print_action_ir(Fields, FieldSeparator, OutputSeparator, PrintGlobalIR-PrintActionIR),
     format(atom(RecordIR),
 '~w
 ~w
@@ -63,8 +64,9 @@ print_line:
 @.plawk_surface_print_string = private constant [3 x i8] c"%s\\00"
 ~w
 ~w
+~w
 ',
-        [BeginGlobalIR, GuardGlobalIR]),
+        [BeginGlobalIR, GuardGlobalIR, PrintGlobalIR]),
     plawk_stream_driver_ir(InputPath,
         driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR, '',
             success, 'success:\n  ret i32 0'),
@@ -1157,17 +1159,30 @@ plawk_print_record_counter_ir(Fields, LoopPhiIR, RecordCounterIR) :-
         RecordCounterIR = ''
     ).
 
-plawk_print_action_ir([field(0)], _FieldSeparator, _OutputSeparator, IR) :-
+plawk_print_action_ir([field(0)], _FieldSeparator, _OutputSeparator, ''-IR) :-
     !,
     IR = '  %fmt = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_line, i32 0, i32 0
   %printed = call i32 (i8*, ...) @printf(i8* %fmt, i8* %line_s)'.
-plawk_print_action_ir(Fields, FieldSeparator, OutputSeparator, IR) :-
-    phrase(plawk_print_fields_ir(Fields, FieldSeparator, OutputSeparator, 0), Parts),
-    atomic_list_concat(Parts, '\n', IR).
+plawk_print_action_ir(Fields, FieldSeparator, OutputSeparator, GlobalIR-IR) :-
+    phrase(plawk_print_fields_ir(Fields, FieldSeparator, OutputSeparator, 0), Pairs),
+    plawk_print_ir_parts(Pairs, GlobalParts, BodyParts),
+    plawk_join_nonempty_ir(GlobalParts, GlobalIR),
+    atomic_list_concat(BodyParts, '\n', IR).
+
+plawk_print_ir_parts([], [], []).
+plawk_print_ir_parts([GlobalIR-BodyIR | Parts], [GlobalIR | GlobalParts], [BodyIR | BodyParts]) :-
+    plawk_print_ir_parts(Parts, GlobalParts, BodyParts).
+
+plawk_join_nonempty_ir(Parts, IR) :-
+    include(plawk_nonempty_ir, Parts, NonEmptyParts),
+    atomic_list_concat(NonEmptyParts, '\n', IR).
+
+plawk_nonempty_ir(IR) :-
+    IR \== ''.
 
 plawk_print_fields_ir([], _FieldSeparator, _OutputSeparator, _) -->
-    ['  %newline_fmt = getelementptr [2 x i8], [2 x i8]* @.plawk_surface_print_newline, i32 0, i32 0',
-     '  %printed_newline = call i32 (i8*, ...) @printf(i8* %newline_fmt)'].
+    [''-'  %newline_fmt = getelementptr [2 x i8], [2 x i8]* @.plawk_surface_print_newline, i32 0, i32 0',
+     ''-'  %printed_newline = call i32 (i8*, ...) @printf(i8* %newline_fmt)'].
 plawk_print_fields_ir([Field | Rest], FieldSeparator, OutputSeparator, Index) -->
     plawk_print_separator_ir(Index, OutputSeparator),
     plawk_print_field_ir(Field, FieldSeparator, Index),
@@ -1182,39 +1197,49 @@ plawk_print_separator_ir(Index, OutputSeparator) -->
           '  %printed_separator_~w = call i32 @putchar(i32 ~w)',
           [Index, OutputSeparator])
     },
-    [SpaceCall].
+    [''-SpaceCall].
 
 plawk_print_field_ir(Field, FieldSeparator, Index) -->
-    { plawk_emit_print_expr_ir(Field, FieldSeparator, Index, Type, SetupParts),
+    { plawk_emit_print_expr_ir(Field, FieldSeparator, Index, Type, GlobalParts, SetupParts),
       plawk_print_expr_output_ir(Type, Index, PrintParts),
-      append(SetupParts, PrintParts, Parts)
+      plawk_join_nonempty_ir(GlobalParts, GlobalIR),
+      append(SetupParts, PrintParts, BodyParts),
+      atomic_list_concat(BodyParts, '\n', BodyIR)
     },
-    Parts.
+    [GlobalIR-BodyIR].
 
 plawk_emit_print_expr_ir(special('NR'), _FieldSeparator, _Index,
-        i64(nr, nr, '%current_nr'), []).
+        i64(nr, nr, '%current_nr'), [], []).
 
 plawk_emit_print_expr_ir(special('NF'), FieldSeparator, Index,
-        i64(nf, nf, ValueIR), [CountIR]) :-
+        i64(nf, nf, ValueIR), [], [CountIR]) :-
     format(atom(Base), 'plawk_nf_~w', [Index]),
     llvm_emit_atom_field_count('%line', FieldSeparator, Base, CountIR),
     format(atom(ValueIR), '%~w', [Base]).
 
 plawk_emit_print_expr_ir(length(field(FieldIndex)), FieldSeparator, Index,
-        i64(length, length, ValueIR), [LengthIR]) :-
+        i64(length, length, ValueIR), [], [LengthIR]) :-
     format(atom(Base), 'plawk_length_~w', [Index]),
     llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, Base, LengthIR),
     format(atom(ValueIR), '%~w', [Base]).
 
 plawk_emit_print_expr_ir(substr(field(FieldIndex), Start, Len), FieldSeparator, Index,
-        slice(substr, substr, LenIR, PtrIR), [SliceIR]) :-
+        slice(substr, substr, LenIR, PtrIR), [], [SliceIR]) :-
     format(atom(Base), 'plawk_substr_~w', [Index]),
     llvm_emit_atom_field_subslice('%line', FieldIndex, FieldSeparator, Start, Len, Base, SliceIR),
     format(atom(LenIR), '%~w_len', [Base]),
     format(atom(PtrIR), '%~w_ptr', [Base]).
 
+plawk_emit_print_expr_ir(index(field(FieldIndex), string(Needle)), FieldSeparator, Index,
+        i64(index, index, ValueIR), [GlobalIR], [CallIR]) :-
+    format(atom(Base), 'plawk_index_~w', [Index]),
+    format(atom(GlobalBase), 'plawk_index_needle_~w', [Index]),
+    llvm_emit_atom_field_index(GlobalBase, '%line', FieldIndex, Needle, FieldSeparator,
+        Base, GlobalIR-CallIR),
+    format(atom(ValueIR), '%~w', [Base]).
+
 plawk_emit_print_expr_ir(field(0), _FieldSeparator, Index,
-        slice(line, line, LenIR, '%line_s'), [LineLen64, LineLen]) :-
+        slice(line, line, LenIR, '%line_s'), [], [LineLen64, LineLen]) :-
     format(atom(LineLen64),
         '  %line_len64_~w = call i64 @strlen(i8* %line_s)',
         [Index]),
@@ -1224,7 +1249,7 @@ plawk_emit_print_expr_ir(field(0), _FieldSeparator, Index,
     format(atom(LenIR), '%line_len_~w', [Index]).
 
 plawk_emit_print_expr_ir(field(FieldIndex), FieldSeparator, Index,
-        slice(slice, slice, LenIR, PtrIR), [SliceIR]) :-
+        slice(slice, slice, LenIR, PtrIR), [], [SliceIR]) :-
     FieldIndex > 0,
     format(atom(Base), 'plawk_field_~w', [Index]),
     llvm_emit_atom_field_slice('%line', FieldIndex, FieldSeparator, Base, SliceIR),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -283,6 +283,21 @@ field_expr(substr(Field, Start, Len)) -->
       StartCodes \== [], LenCodes \== [],
       number_codes(Start, StartCodes), Start >= 1,
       number_codes(Len, LenCodes), Len >= 0 }.
+field_expr(index(Field, string(Needle))) -->
+    "index",
+    ws,
+    "(",
+    ws,
+    field_expr(Field),
+    ws,
+    ",",
+    ws,
+    quoted_string(NeedleCodes),
+    ws,
+    ")",
+    { Field = field(_),
+      NeedleCodes \== [],
+      string_codes(Needle, NeedleCodes) }.
 field_expr(assoc(var(Name), KeyExpr)) -->
     identifier(Name),
     ws,

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -50,7 +50,8 @@
     llvm_emit_atom_field_slice/5,        % +ValueIR, +FieldIndex, +SepCode, +SliceBase, -CallIR
     llvm_emit_atom_field_count/4,        % +ValueIR, +SepCode, +CountBase, -CallIR
     llvm_emit_atom_field_length/5,       % +ValueIR, +FieldIndex, +SepCode, +LengthBase, -CallIR
-    llvm_emit_atom_field_subslice/7      % +ValueIR, +FieldIndex, +SepCode, +Start, +Len, +SliceBase, -CallIR
+    llvm_emit_atom_field_subslice/7,     % +ValueIR, +FieldIndex, +SepCode, +Start, +Len, +SliceBase, -CallIR
+    llvm_emit_atom_field_index/7         % +GlobalBase, +ValueIR, +FieldIndex, +Needle, +SepCode, +IndexBase, -GlobalIR-CallIR
 ]).
 
 :- use_module(library(lists)).
@@ -5045,6 +5046,105 @@ afs.subslice:
 
 afs.no:
   ret %WamSlice %afs.empty
+}
+
+define i64 @wam_slice_index_value(i8* %source_ptr, i64 %source_len, i8* %needle, i64 %needle_len) {
+entry:
+  %si.needle_null = icmp eq i8* %needle, null
+  br i1 %si.needle_null, label %si.zero, label %si.check_empty
+
+si.check_empty:
+  %si.empty_needle = icmp eq i64 %needle_len, 0
+  br i1 %si.empty_needle, label %si.one, label %si.check_source
+
+si.check_source:
+  %si.source_null = icmp eq i8* %source_ptr, null
+  br i1 %si.source_null, label %si.zero, label %si.bounds
+
+si.bounds:
+  %si.too_long = icmp ugt i64 %needle_len, %source_len
+  br i1 %si.too_long, label %si.zero, label %si.outer
+
+si.outer:
+  %si.last_start = sub i64 %source_len, %needle_len
+  br label %si.outer_loop
+
+si.outer_loop:
+  %si.pos = phi i64 [ 0, %si.outer ], [ %si.next_pos, %si.advance ]
+  %si.past = icmp ugt i64 %si.pos, %si.last_start
+  br i1 %si.past, label %si.zero, label %si.inner_loop
+
+si.inner_loop:
+  %si.i = phi i64 [ 0, %si.outer_loop ], [ %si.next_i, %si.match_step ]
+  %si.done = icmp uge i64 %si.i, %needle_len
+  br i1 %si.done, label %si.found, label %si.compare
+
+si.compare:
+  %si.source_offset = add i64 %si.pos, %si.i
+  %si.source_ch_ptr = getelementptr i8, i8* %source_ptr, i64 %si.source_offset
+  %si.needle_ch_ptr = getelementptr i8, i8* %needle, i64 %si.i
+  %si.source_ch = load i8, i8* %si.source_ch_ptr
+  %si.needle_ch = load i8, i8* %si.needle_ch_ptr
+  %si.eq = icmp eq i8 %si.source_ch, %si.needle_ch
+  br i1 %si.eq, label %si.match_step, label %si.advance
+
+si.match_step:
+  %si.next_i = add i64 %si.i, 1
+  br label %si.inner_loop
+
+si.advance:
+  %si.next_pos = add i64 %si.pos, 1
+  br label %si.outer_loop
+
+si.found:
+  %si.result = add i64 %si.pos, 1
+  ret i64 %si.result
+
+si.one:
+  ret i64 1
+
+si.zero:
+  ret i64 0
+}
+
+define i64 @wam_atom_field_index_value(%Value %atom_value, i64 %field_index, i8 %sep, i8* %needle, i64 %needle_len) {
+entry:
+  %afi.whole = icmp eq i64 %field_index, 0
+  br i1 %afi.whole, label %afi.whole_record, label %afi.field
+
+afi.whole_record:
+  %afi.t = call i32 @value_tag(%Value %atom_value)
+  %afi.is_atom = icmp eq i32 %afi.t, 0
+  br i1 %afi.is_atom, label %afi.lookup, label %afi.zero
+
+afi.lookup:
+  %afi.aid = call i64 @value_payload(%Value %atom_value)
+  %afi.str = call i8* @wam_atom_to_string(i64 %afi.aid)
+  %afi.null = icmp eq i8* %afi.str, null
+  br i1 %afi.null, label %afi.zero, label %afi.measure
+
+afi.measure:
+  %afi.len = call i64 @strlen(i8* %afi.str)
+  %afi.whole_index = call i64 @wam_slice_index_value(i8* %afi.str, i64 %afi.len, i8* %needle, i64 %needle_len)
+  ret i64 %afi.whole_index
+
+afi.field:
+  %afi.index_ok = icmp sgt i64 %field_index, 0
+  br i1 %afi.index_ok, label %afi.field_slice, label %afi.zero
+
+afi.field_slice:
+  %afi.source = call %WamSlice @wam_atom_field_slice_value(%Value %atom_value, i64 %field_index, i8 %sep)
+  %afi.source_ptr = extractvalue %WamSlice %afi.source, 0
+  %afi.source_len = extractvalue %WamSlice %afi.source, 1
+  %afi.source_has_ptr = icmp ne i8* %afi.source_ptr, null
+  br i1 %afi.source_has_ptr, label %afi.index, label %afi.zero
+
+afi.index:
+  %afi.field_index_value = call i64 @wam_slice_index_value(i8* %afi.source_ptr, i64 %afi.source_len, i8* %needle, i64 %needle_len)
+  ret i64 %afi.field_index_value
+
+afi.zero:
+  ret i64 0
 }
 
 ; Dispatches on integer op codes:
@@ -16513,6 +16613,24 @@ llvm_emit_atom_field_subslice(ValueIR, FieldIndex, SepCode, Start, Len, SliceBas
          SliceBase, SliceBase,
          SliceBase, SliceBase,
          SliceBase, SliceBase]).
+
+%% llvm_emit_atom_field_index(+GlobalBase, +ValueIR, +FieldIndex, +Needle, +SepCode, +IndexBase, -GlobalIR-CallIR)
+%
+%  Emit a native AWK-style index/2 over an atom-backed text record. The runtime
+%  returns a one-based byte position or zero when the needle is absent. Field 0
+%  searches the whole record; positive fields search the projected field without
+%  allocating substrings.
+llvm_emit_atom_field_index(GlobalBase, ValueIR, FieldIndex, Needle, SepCode, IndexBase, GlobalIR-CallIR) :-
+    sanitize_functor_for_llvm(GlobalBase, SafeGlobalBase),
+    escape_llvm_string(Needle, EscapedNeedle, NeedleLen),
+    ArrLen is NeedleLen + 1,
+    format(atom(GlobalIR),
+        '@.~w = private constant [~w x i8] c"~w\\00"',
+        [SafeGlobalBase, ArrLen, EscapedNeedle]),
+    format(atom(CallIR),
+        '  %~w_ptr = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0~n  %~w = call i64 @wam_atom_field_index_value(%Value ~w, i64 ~w, i8 ~w, i8* %~w_ptr, i64 ~w)',
+        [SafeGlobalBase, ArrLen, ArrLen, SafeGlobalBase,
+         IndexBase, ValueIR, FieldIndex, SepCode, SafeGlobalBase, NeedleLen]).
 
 escape_llvm_codes([], []).
 escape_llvm_codes([C|Cs], Out) :-

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -53,6 +53,11 @@ test(parses_field_eq_print_substr_field_rule) :-
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
         [print([substr(field(2), 1, 3), substr(field(0), 7, 4)])])], [])).
 
+test(parses_field_eq_print_index_field_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { print index($2, \"sk\"), index($0, \"disk\") }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [print([index(field(2), string("sk")), index(field(0), string("disk"))])])], [])).
+
 test(parses_field_eq_increment_end_print_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { count++ } END { print count }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"), [inc(var(count))])],
@@ -193,6 +198,11 @@ test(surface_field_eq_prints_native_substrings) :-
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR network down now\n",
         "dis disk\nnet netw\n").
 
+test(surface_field_eq_prints_native_index_values) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { print index($2, \"sk\"), index($0, \"disk\") }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR network down now\n",
+        "3 7\n0 0\n").
+
 test(surface_field_eq_prints_nr_with_output_separator) :-
     run_surface_print_smoke("BEGIN { OFS = \",\" } $1 == \"ERROR\" { print NR, $2, $3 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -292,6 +302,11 @@ test(surface_begin_field_separator_drives_substr_printing) :-
     run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print substr($2, 1, 3), substr($0, 7, 4) }\n",
         "ERROR:disk:full\nWARN:cpu:hot\nERROR:network:down:now\n",
         "dis,disk\nnet,netw\n").
+
+test(surface_begin_field_separator_drives_index_printing) :-
+    run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print index($2, \"work\"), index($0, \"network\") }\n",
+        "ERROR:disk:full\nWARN:cpu:hot\nERROR:network:down:now\n",
+        "0,0\n4,7\n").
 
 test(surface_begin_output_separator_drives_end_printing) :-
     run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { counts[$2]++ } END { print \"disk\", counts[\"disk\"], \"net\", counts[\"net\"] }\n",
@@ -466,6 +481,17 @@ test(surface_substr_print_uses_native_subslice) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_substr_1 = call %WamSlice @wam_atom_field_subslice_value(%Value %line, i64 0, i8 58, i64 7, i64 4)'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%printed_substr_0 = call i32 (i8*, ...) @printf(i8* %substr_fmt_0, i32 %plawk_substr_0_len, i8* %plawk_substr_0_ptr)'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_slice = private constant [5 x i8] c"%.*s\\00"'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_index_print_uses_native_field_index) :-
+    plawk_parse_string("BEGIN { FS = \":\" } $1 == \"ERROR\" { print index($2, \"work\"), index($0, \"network\") }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_5Findex_5Fneedle_5F0 = private constant [5 x i8] c"work\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_5Findex_5Fneedle_5F1 = private constant [8 x i8] c"network\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_5Findex_5Fneedle_5F0_ptr = getelementptr [5 x i8], [5 x i8]* @.plawk_5Findex_5Fneedle_5F0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_index_0 = call i64 @wam_atom_field_index_value(%Value %line, i64 2, i8 58'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_index_1 = call i32 (i8*, ...) @printf(i8* %index_fmt_1, i64 %plawk_index_1)'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -201,6 +201,8 @@ test(full_runtime_generation) :-
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_atom_field_length_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamSlice @wam_subslice_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamSlice @wam_atom_field_subslice_value')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_slice_index_value')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_atom_field_index_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_prefix_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamAssocI64Table* @wam_assoc_i64_new')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_assoc_i64_resize')),
@@ -241,6 +243,13 @@ test(atom_field_subslice_emitter) :-
     assertion(sub_atom(CallIR, _, _, _, '%plawk_substr = call %WamSlice @wam_atom_field_subslice_value(%Value %line, i64 2, i8 58, i64 1, i64 3)')),
     assertion(sub_atom(CallIR, _, _, _, '%plawk_substr_ptr = extractvalue %WamSlice %plawk_substr, 0')),
     assertion(sub_atom(CallIR, _, _, _, '%plawk_substr_len = trunc i64 %plawk_substr_len64 to i32')).
+
+test(atom_field_index_emitter) :-
+    llvm_emit_atom_field_index(plawk_index_needle, '%line', 2, 'disk', 58, plawk_index, GlobalIR-CallIR),
+    assertion(sub_atom(GlobalIR, _, _, _, '@.plawk_5Findex_5Fneedle = private constant [5 x i8] c"disk\\00"')),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_5Findex_5Fneedle_ptr = getelementptr')),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_index = call i64 @wam_atom_field_index_value(%Value %line, i64 2, i8 58')),
+    assertion(sub_atom(CallIR, _, _, _, 'i64 4')).
 
 % ============================================================================
 % Builtin op ID mapping


### PR DESCRIPTION
## Summary
- add shared WAM/LLVM slice and field index helpers for AWK-style 1-based substring search
- parse and lower PLAWK rule-print `index($N, "literal")` and `index($0, "literal")` expressions through the native i64 print path
- thread print-expression LLVM globals so rule print literals can be emitted safely

## Tests
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `git diff --cached --check`
- `git diff --check`