### PR TITLE
Document PLAWK native index prints

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -255,8 +255,10 @@ Rule prints can include native `NR`, implemented as a record-number `i64` phi in
 the print-only streaming loop, and native `NF`, implemented with the shared
 `@wam_atom_field_count_value` helper over the active single-byte `FS`. Rule
 prints can also call native `length($N)` through the shared
-`@wam_atom_field_length_value` helper and native `substr($N, Start, Len)` through
-the allocation-free `@wam_atom_field_subslice_value` helper. The scalar counter
+`@wam_atom_field_length_value` helper, native `substr($N, Start, Len)` through
+the allocation-free `@wam_atom_field_subslice_value` helper, and native
+`index($N, "literal")` through the shared `@wam_atom_field_index_value` helper.
+The scalar counter
 path threads a native `i64` loop variable and prints it from the `END` action. Multiple scalar counters
 become parallel `i64` phi slots in the native streaming loop.
 Scalar counters lower through an explicit codegen state plan that keeps

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -80,7 +80,8 @@ The first Phase 2 surface smokes parse `/^ERROR/ { print $0 }` and
 `$1 == "ERROR" { print $2, $3 }`. Rule prints can include native `NR` and
 `NF`, e.g. `$1 == "ERROR" { print NR, NF, $2, $3 }`, plus native field lengths
 such as `$1 == "ERROR" { print length($2), $2 }` and native byte substrings such
-as `$1 == "ERROR" { print substr($2, 1, 3) }`. Scalar state works with `$1 ==
+as `$1 == "ERROR" { print substr($2, 1, 3) }`, and native byte searches such as
+`$1 == "ERROR" { print index($2, "sk") }`. Scalar state works with `$1 ==
 "ERROR" { count++ } END { print count }`. Multiple scalar increments
 compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple
 guarded rules can update shared scalar slots before an `END` print. The first

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -246,6 +246,13 @@ whitespace is ignored, and whitespace runs do not create empty fields.
 
 The first `substr` surface uses AWK-style 1-based starts and byte counts.
 
+`index` returns an AWK-style 1-based byte position, or `0` if the literal is not
+present:
+
+```awk
+$1 == "ERROR" { print index($2, "sk"), index($0, "disk") }
+```
+
 `BEGIN` can also set an explicit single-byte field separator for the native field helpers:
 
 ```awk


### PR DESCRIPTION
## Summary
- document native `index($N, "literal")` rule-print support in the PLAWK README
- add a tutorial example showing AWK-style 1-based index output
- update the PLAWK implementation plan to mention the shared `@wam_atom_field_index_value` helper

## Tests
- `git diff --cached --check`
- `git diff --check`

Docs-only change; no runtime tests were run.