### PR TITLE
Support PLAWK native case prints

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -258,6 +258,9 @@ prints can also call native `length($N)` through the shared
 `@wam_atom_field_length_value` helper, native `substr($N, Start, Len)` through
 the allocation-free `@wam_atom_field_subslice_value` helper, and native
 `index($N, "literal")` through the shared `@wam_atom_field_index_value` helper.
+Print-only `tolower($N)` and `toupper($N)` lower through shared
+`@wam_print_ascii_lower_slice` and `@wam_print_ascii_upper_slice` helpers, so
+case mapping streams bytes without allocating a transformed atom.
 The scalar counter
 path threads a native `i64` loop variable and prints it from the `END` action. Multiple scalar counters
 become parallel `i64` phi slots in the native streaming loop.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -81,7 +81,9 @@ The first Phase 2 surface smokes parse `/^ERROR/ { print $0 }` and
 `NF`, e.g. `$1 == "ERROR" { print NR, NF, $2, $3 }`, plus native field lengths
 such as `$1 == "ERROR" { print length($2), $2 }` and native byte substrings such
 as `$1 == "ERROR" { print substr($2, 1, 3) }`, and native byte searches such as
-`$1 == "ERROR" { print index($2, "sk") }`. Scalar state works with `$1 ==
+`$1 == "ERROR" { print index($2, "sk") }`. Rule prints can also emit ASCII
+case-mapped field slices such as `$1 == "ERROR" { print tolower($2), toupper($0) }`.
+Scalar state works with `$1 ==
 "ERROR" { count++ } END { print count }`. Multiple scalar increments
 compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple
 guarded rules can update shared scalar slots before an `END` print. The first

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -253,6 +253,13 @@ present:
 $1 == "ERROR" { print index($2, "sk"), index($0, "disk") }
 ```
 
+`tolower` and `toupper` can print ASCII case-mapped field bytes without
+allocating transformed field strings:
+
+```awk
+$1 == "ERROR" { print tolower($2), toupper($0) }
+```
+
 `BEGIN` can also set an explicit single-byte field separator for the native field helpers:
 
 ```awk

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -12,7 +12,8 @@
      llvm_emit_atom_field_count/4,
      llvm_emit_atom_field_length/5,
      llvm_emit_atom_field_subslice/7,
-     llvm_emit_atom_field_index/7]).
+     llvm_emit_atom_field_index/7,
+     llvm_emit_ascii_case_slice_print/5]).
 
 %% plawk_program_native_driver_ir(+Program, +InputPath, -DriverIR) is semidet.
 %
@@ -1238,6 +1239,18 @@ plawk_emit_print_expr_ir(index(field(FieldIndex), string(Needle)), FieldSeparato
         Base, GlobalIR-CallIR),
     format(atom(ValueIR), '%~w', [Base]).
 
+plawk_emit_print_expr_ir(tolower(field(FieldIndex)), FieldSeparator, Index,
+        case_slice(lower, LowerBase, LenIR, PtrIR), [], SetupParts) :-
+    format(atom(LowerBase), 'plawk_tolower_~w', [Index]),
+    plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, LowerBase, LenIR, PtrIR,
+        SetupParts).
+
+plawk_emit_print_expr_ir(toupper(field(FieldIndex)), FieldSeparator, Index,
+        case_slice(upper, UpperBase, LenIR, PtrIR), [], SetupParts) :-
+    format(atom(UpperBase), 'plawk_toupper_~w', [Index]),
+    plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, UpperBase, LenIR, PtrIR,
+        SetupParts).
+
 plawk_emit_print_expr_ir(field(0), _FieldSeparator, Index,
         slice(line, line, LenIR, '%line_s'), [], [LineLen64, LineLen]) :-
     format(atom(LineLen64),
@@ -1256,6 +1269,17 @@ plawk_emit_print_expr_ir(field(FieldIndex), FieldSeparator, Index,
     format(atom(LenIR), '%~w_len', [Base]),
     format(atom(PtrIR), '%~w_ptr', [Base]).
 
+plawk_emit_case_source_slice_ir(0, _FieldSeparator, Base, LenIR, '%line_s', [LineLen64]) :-
+    format(atom(LineLen64),
+        '  %~w_len64 = call i64 @strlen(i8* %line_s)',
+        [Base]),
+    format(atom(LenIR), '%~w_len64', [Base]).
+plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, Base, LenIR, PtrIR, [SliceIR]) :-
+    FieldIndex > 0,
+    llvm_emit_atom_field_slice('%line', FieldIndex, FieldSeparator, Base, SliceIR),
+    format(atom(LenIR), '%~w_len64', [Base]),
+    format(atom(PtrIR), '%~w_ptr', [Base]).
+
 plawk_print_expr_output_ir(i64(FmtPrefix, PrintPrefix, ValueIR), Index, [FmtPtr, PrintCall]) :-
     format(atom(FmtPtr),
         '  %~w_fmt_~w = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_i64, i32 0, i32 0',
@@ -1271,3 +1295,6 @@ plawk_print_expr_output_ir(slice(FmtPrefix, PrintPrefix, LenIR, PtrIR), Index, [
     format(atom(PrintCall),
         '  %printed_~w_~w = call i32 (i8*, ...) @printf(i8* %~w_fmt_~w, i32 ~w, i8* ~w)',
         [PrintPrefix, Index, FmtPrefix, Index, LenIR, PtrIR]).
+
+plawk_print_expr_output_ir(case_slice(Mode, PrintBase, LenIR, PtrIR), _Index, [PrintCall]) :-
+    llvm_emit_ascii_case_slice_print(Mode, PtrIR, LenIR, PrintBase, PrintCall).

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -298,6 +298,24 @@ field_expr(index(Field, string(Needle))) -->
     { Field = field(_),
       NeedleCodes \== [],
       string_codes(Needle, NeedleCodes) }.
+field_expr(tolower(Field)) -->
+    "tolower",
+    ws,
+    "(",
+    ws,
+    field_expr(Field),
+    ws,
+    ")",
+    { Field = field(_) }.
+field_expr(toupper(Field)) -->
+    "toupper",
+    ws,
+    "(",
+    ws,
+    field_expr(Field),
+    ws,
+    ")",
+    { Field = field(_) }.
 field_expr(assoc(var(Name), KeyExpr)) -->
     identifier(Name),
     ws,

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -51,7 +51,8 @@
     llvm_emit_atom_field_count/4,        % +ValueIR, +SepCode, +CountBase, -CallIR
     llvm_emit_atom_field_length/5,       % +ValueIR, +FieldIndex, +SepCode, +LengthBase, -CallIR
     llvm_emit_atom_field_subslice/7,     % +ValueIR, +FieldIndex, +SepCode, +Start, +Len, +SliceBase, -CallIR
-    llvm_emit_atom_field_index/7         % +GlobalBase, +ValueIR, +FieldIndex, +Needle, +SepCode, +IndexBase, -GlobalIR-CallIR
+    llvm_emit_atom_field_index/7,        % +GlobalBase, +ValueIR, +FieldIndex, +Needle, +SepCode, +IndexBase, -GlobalIR-CallIR
+    llvm_emit_ascii_case_slice_print/5   % +Mode, +PtrIR, +LenIR, +PrintBase, -CallIR
 ]).
 
 :- use_module(library(lists)).
@@ -5145,6 +5146,60 @@ afi.index:
 
 afi.zero:
   ret i64 0
+}
+
+define void @wam_print_ascii_lower_slice(i8* %source_ptr, i64 %source_len) {
+entry:
+  %lsp.null = icmp eq i8* %source_ptr, null
+  br i1 %lsp.null, label %lsp.done, label %lsp.loop
+
+lsp.loop:
+  %lsp.pos = phi i64 [ 0, %entry ], [ %lsp.next_pos, %lsp.step ]
+  %lsp.finished = icmp uge i64 %lsp.pos, %source_len
+  br i1 %lsp.finished, label %lsp.done, label %lsp.step
+
+lsp.step:
+  %lsp.ptr = getelementptr i8, i8* %source_ptr, i64 %lsp.pos
+  %lsp.ch = load i8, i8* %lsp.ptr
+  %lsp.ge_a = icmp uge i8 %lsp.ch, 65
+  %lsp.le_z = icmp ule i8 %lsp.ch, 90
+  %lsp.is_upper = and i1 %lsp.ge_a, %lsp.le_z
+  %lsp.lower_ch = add i8 %lsp.ch, 32
+  %lsp.out_ch = select i1 %lsp.is_upper, i8 %lsp.lower_ch, i8 %lsp.ch
+  %lsp.out_i32 = zext i8 %lsp.out_ch to i32
+  %lsp.printed = call i32 @putchar(i32 %lsp.out_i32)
+  %lsp.next_pos = add i64 %lsp.pos, 1
+  br label %lsp.loop
+
+lsp.done:
+  ret void
+}
+
+define void @wam_print_ascii_upper_slice(i8* %source_ptr, i64 %source_len) {
+entry:
+  %usp.null = icmp eq i8* %source_ptr, null
+  br i1 %usp.null, label %usp.done, label %usp.loop
+
+usp.loop:
+  %usp.pos = phi i64 [ 0, %entry ], [ %usp.next_pos, %usp.step ]
+  %usp.finished = icmp uge i64 %usp.pos, %source_len
+  br i1 %usp.finished, label %usp.done, label %usp.step
+
+usp.step:
+  %usp.ptr = getelementptr i8, i8* %source_ptr, i64 %usp.pos
+  %usp.ch = load i8, i8* %usp.ptr
+  %usp.ge_a = icmp uge i8 %usp.ch, 97
+  %usp.le_z = icmp ule i8 %usp.ch, 122
+  %usp.is_lower = and i1 %usp.ge_a, %usp.le_z
+  %usp.upper_ch = sub i8 %usp.ch, 32
+  %usp.out_ch = select i1 %usp.is_lower, i8 %usp.upper_ch, i8 %usp.ch
+  %usp.out_i32 = zext i8 %usp.out_ch to i32
+  %usp.printed = call i32 @putchar(i32 %usp.out_i32)
+  %usp.next_pos = add i64 %usp.pos, 1
+  br label %usp.loop
+
+usp.done:
+  ret void
 }
 
 ; Dispatches on integer op codes:
@@ -16631,6 +16686,22 @@ llvm_emit_atom_field_index(GlobalBase, ValueIR, FieldIndex, Needle, SepCode, Ind
         '  %~w_ptr = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0~n  %~w = call i64 @wam_atom_field_index_value(%Value ~w, i64 ~w, i8 ~w, i8* %~w_ptr, i64 ~w)',
         [SafeGlobalBase, ArrLen, ArrLen, SafeGlobalBase,
          IndexBase, ValueIR, FieldIndex, SepCode, SafeGlobalBase, NeedleLen]).
+
+%% llvm_emit_ascii_case_slice_print(+Mode, +PtrIR, +LenIR, +PrintBase, -CallIR)
+%
+%  Emit an allocation-free ASCII case-mapped slice printer. This is intentionally
+%  a print helper, not a value materializer; callers that need a transformed atom
+%  should use a separate interning/materialization helper.
+llvm_emit_ascii_case_slice_print(lower, PtrIR, LenIR, PrintBase, CallIR) :-
+    nonvar(PrintBase),
+    format(atom(CallIR),
+        '  call void @wam_print_ascii_lower_slice(i8* ~w, i64 ~w)',
+        [PtrIR, LenIR]).
+llvm_emit_ascii_case_slice_print(upper, PtrIR, LenIR, PrintBase, CallIR) :-
+    nonvar(PrintBase),
+    format(atom(CallIR),
+        '  call void @wam_print_ascii_upper_slice(i8* ~w, i64 ~w)',
+        [PtrIR, LenIR]).
 
 escape_llvm_codes([], []).
 escape_llvm_codes([C|Cs], Out) :-

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -58,6 +58,11 @@ test(parses_field_eq_print_index_field_rule) :-
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
         [print([index(field(2), string("sk")), index(field(0), string("disk"))])])], [])).
 
+test(parses_field_eq_print_case_field_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { print tolower($2), toupper($0) }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [print([tolower(field(2)), toupper(field(0))])])], [])).
+
 test(parses_field_eq_increment_end_print_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { count++ } END { print count }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"), [inc(var(count))])],
@@ -203,6 +208,11 @@ test(surface_field_eq_prints_native_index_values) :-
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR network down now\n",
         "3 7\n0 0\n").
 
+test(surface_field_eq_prints_native_case_values) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { print tolower($2), toupper($0) }\n",
+        "INFO boot ok\nERROR Disk Full\nWARN cpu hot\nERROR network Down\n",
+        "disk ERROR DISK FULL\nnetwork ERROR NETWORK DOWN\n").
+
 test(surface_field_eq_prints_nr_with_output_separator) :-
     run_surface_print_smoke("BEGIN { OFS = \",\" } $1 == \"ERROR\" { print NR, $2, $3 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -307,6 +317,11 @@ test(surface_begin_field_separator_drives_index_printing) :-
     run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print index($2, \"work\"), index($0, \"network\") }\n",
         "ERROR:disk:full\nWARN:cpu:hot\nERROR:network:down:now\n",
         "0,0\n4,7\n").
+
+test(surface_begin_field_separator_drives_case_printing) :-
+    run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print tolower($2), toupper($3) }\n",
+        "ERROR:Disk:Full\nWARN:cpu:hot\nERROR:network:Down\n",
+        "disk,FULL\nnetwork,DOWN\n").
 
 test(surface_begin_output_separator_drives_end_printing) :-
     run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { counts[$2]++ } END { print \"disk\", counts[\"disk\"], \"net\", counts[\"net\"] }\n",
@@ -492,6 +507,16 @@ test(surface_index_print_uses_native_field_index) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_5Findex_5Fneedle_5F0_ptr = getelementptr [5 x i8], [5 x i8]* @.plawk_5Findex_5Fneedle_5F0'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_index_0 = call i64 @wam_atom_field_index_value(%Value %line, i64 2, i8 58'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%printed_index_1 = call i32 (i8*, ...) @printf(i8* %index_fmt_1, i64 %plawk_index_1)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_case_print_uses_native_case_helpers) :-
+    plawk_parse_string("BEGIN { FS = \":\" } $1 == \"ERROR\" { print tolower($2), toupper($0) }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_tolower_0 = call %WamSlice @wam_atom_field_slice_value(%Value %line, i64 2, i8 58)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'call void @wam_print_ascii_lower_slice(i8* %plawk_tolower_0_ptr, i64 %plawk_tolower_0_len64)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_toupper_1_len64 = call i64 @strlen(i8* %line_s)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'call void @wam_print_ascii_upper_slice(i8* %line_s, i64 %plawk_toupper_1_len64)'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -203,6 +203,8 @@ test(full_runtime_generation) :-
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamSlice @wam_atom_field_subslice_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_slice_index_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_atom_field_index_value')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define void @wam_print_ascii_lower_slice')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define void @wam_print_ascii_upper_slice')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_prefix_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamAssocI64Table* @wam_assoc_i64_new')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_assoc_i64_resize')),
@@ -250,6 +252,12 @@ test(atom_field_index_emitter) :-
     assertion(sub_atom(CallIR, _, _, _, '%plawk_5Findex_5Fneedle_ptr = getelementptr')),
     assertion(sub_atom(CallIR, _, _, _, '%plawk_index = call i64 @wam_atom_field_index_value(%Value %line, i64 2, i8 58')),
     assertion(sub_atom(CallIR, _, _, _, 'i64 4')).
+
+test(ascii_case_slice_print_emitter) :-
+    llvm_emit_ascii_case_slice_print(lower, '%ptr', '%len', plawk_lower, LowerIR),
+    llvm_emit_ascii_case_slice_print(upper, '%ptr', '%len', plawk_upper, UpperIR),
+    assertion(LowerIR == '  call void @wam_print_ascii_lower_slice(i8* %ptr, i64 %len)'),
+    assertion(UpperIR == '  call void @wam_print_ascii_upper_slice(i8* %ptr, i64 %len)').
 
 % ============================================================================
 % Builtin op ID mapping


### PR DESCRIPTION
## Summary
- add shared WAM/LLVM ASCII lower/upper slice print helpers
- parse and lower PLAWK `tolower($N)` / `toupper($N)` rule-print expressions
- document the print-only case-mapping surface and add default/custom FS smokes

## Tests
- `git diff --cached --check`
- `git diff --check`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`