### PR TITLE
Support PLAWK scalar add assignment

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -265,7 +265,10 @@ The scalar counter
 path threads a native `i64` loop variable and prints it from the `END` action. Multiple scalar counters
 become parallel `i64` phi slots in the native streaming loop.
 Scalar counters lower through an explicit codegen state plan that keeps
-source-level state recognition separate from LLVM slot numbering. The current
+source-level state recognition separate from LLVM slot numbering. The same
+native slots now support `+=` with integer constants and field lengths, so
+programs such as `$1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }`
+stay in the compiled stream loop. The current
 associative-count surface allocates one reusable WAM/LLVM
 interned-atom-keyed growable `i64` table primitive (`wam_assoc_i64_*`) per source
 array, increments those tables in the native streaming loop, and performs `END`

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -86,7 +86,9 @@ case-mapped field slices such as `$1 == "ERROR" { print tolower($2), toupper($0)
 Scalar state works with `$1 ==
 "ERROR" { count++ } END { print count }`. Multiple scalar increments
 compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple
-guarded rules can update shared scalar slots before an `END` print. The first
+guarded rules can update shared scalar slots before an `END` print. Scalar slots
+also support native `+=` with integer constants and field lengths, e.g.
+`$1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }`. The first
 associative-count surface now supports multiple source arrays, e.g.
 `{ counts[$1]++; by_component[$2]++ } END { print counts["ERROR"], by_component["disk"] }`.
 Codegen allocates one WAM/LLVM runtime interned-atom-keyed `i64` table per

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -226,6 +226,13 @@ That prints:
 total 4 errors 2
 ```
 
+Scalar variables can accumulate native integer deltas and field lengths:
+
+```awk
+$1 == "ERROR" { bytes += length($0); hits += 2 }
+END { print bytes, hits }
+```
+
 `BEGIN` can emit literal report headers before the first input record is read:
 
 ```awk

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -32,6 +32,7 @@
 %      BEGIN { print "kind", "count" } { total++ } END { print "total", total }
 %      BEGIN { FS = ":" } $1 == "ERROR" { counts[$2]++ } END { print counts["disk"] }
 %      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
+%      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %
 %  The surrounding runtime still comes from write_wam_llvm_project/3. This
 %  function emits the target-specific native main that streams the file, lowers
@@ -303,7 +304,7 @@ plawk_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
     findall(Name,
         ( member(rule(_Pattern, Actions), Rules),
           member(Action, Actions),
-          plawk_scalar_increment_action(Action, Name)
+          plawk_scalar_update_action_name(Action, Name)
         ),
         ActionVars),
     ActionVars \== [],
@@ -328,7 +329,7 @@ plawk_mixed_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
     findall(Name,
         ( member(rule(_Pattern, Actions), Rules),
           member(Action, Actions),
-          plawk_scalar_increment_action(Action, Name)
+          plawk_scalar_update_action_name(Action, Name)
         ),
         ActionVars),
     ActionVars \== [],
@@ -382,7 +383,8 @@ plawk_mixed_rule_actions(Actions, ScalarVars, AssocSpecs) :-
     findall(Name, member(scalar(Name), TypedActions), ScalarVars),
     findall(Spec, member(assoc(Spec), TypedActions), AssocSpecs).
 
-plawk_mixed_increment_action(inc(var(Name)), scalar(Name)).
+plawk_mixed_increment_action(Action, scalar(Action)) :-
+    plawk_scalar_action_delta(Action, _Name, _Delta).
 plawk_mixed_increment_action(inc_assoc(var(ArrayName), field(KeyIndex)), assoc(ArrayName-KeyIndex)) :-
     KeyIndex > 0.
 
@@ -408,7 +410,7 @@ plawk_mixed_rule_chain_lines([mixed_rule(Index, Pattern, ScalarVars, AssocAction
       plawk_mixed_scalar_rule_input_phi_ir(ScalarPlan, Index, InputPhiIR),
       plawk_mixed_rule_guard_ir(Pattern, Index, RuleLabel, ApplyLabel,
           NextLabel, InputPhiIR, FieldSeparator, GuardGlobalIR-GuardIR),
-      plawk_scalar_match_update_ir(ScalarPlan, ScalarVars, Index, ScalarUpdateIR),
+      plawk_scalar_match_update_ir(ScalarPlan, ScalarVars, FieldSeparator, Index, ScalarUpdateIR),
       plawk_mixed_assoc_apply_ir(Index, AssocActions, DoneLabel, FieldSeparator, AssocApplyIR),
       ( Index =:= 0
       -> EntryIR = '  br label %rule_0_match\n\n'
@@ -923,8 +925,6 @@ plawk_mixed_end_print_lines([string(Value) | Rest], ScalarPlan, AssocPlan, Outpu
     { NextPrintIndex is PrintIndex + 1 },
     plawk_mixed_end_print_lines(Rest, ScalarPlan, AssocPlan, OutputSeparator, NextPrintIndex).
 
-plawk_scalar_increment_action(inc(var(Name)), Name).
-
 plawk_scalar_print_expr(var(Name), Name).
 
 plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, GlobalIR, ChainIR, RuleCount) :-
@@ -950,9 +950,9 @@ plawk_scalar_rule_chain_lines([rule(Pattern, Actions) | Rest], StatePlan, FieldS
       format(atom(MatchValue), '%~w', [MatchVar]),
       plawk_pattern_guard_ir(Pattern, FieldSeparator, GlobalBase, MatchValue,
           GuardGlobalIR-GuardCallIR),
-      maplist(plawk_scalar_increment_action, Actions, ActionVars),
+      include(plawk_scalar_update_action, Actions, ScalarActions),
       plawk_scalar_rule_input_phi_ir(StatePlan, Index, InputPhiIR),
-      plawk_scalar_match_update_ir(StatePlan, ActionVars, Index, MatchUpdateIR),
+      plawk_scalar_match_update_ir(StatePlan, ScalarActions, FieldSeparator, Index, MatchUpdateIR),
       ( Index =:= 0
       -> EntryIR = '  br label %rule_0_match\n\n'
       ;  EntryIR = ''
@@ -1022,27 +1022,70 @@ plawk_scalar_loop_phi_lines([_Slot | Rest], Index) -->
     [Line],
     plawk_scalar_loop_phi_lines(Rest, NextIndex).
 
-plawk_scalar_match_update_ir(StatePlan, ActionVars, RuleIndex, IR) :-
+plawk_scalar_match_update_ir(StatePlan, Actions, FieldSeparator, RuleIndex, IR) :-
     plawk_state_plan_slots(StatePlan, Slots),
-    phrase(plawk_scalar_match_update_lines(Slots, ActionVars, RuleIndex, 0), Lines),
+    phrase(plawk_scalar_match_update_lines(Slots, Actions, FieldSeparator, RuleIndex, 0), Lines),
     atomic_list_concat(Lines, '\n', IR).
 
-plawk_scalar_match_update_lines([], _ActionVars, _RuleIndex, _) -->
+plawk_scalar_match_update_lines([], _Actions, _FieldSeparator, _RuleIndex, _) -->
     [].
-plawk_scalar_match_update_lines([scalar_counter(Name) | Rest], ActionVars, RuleIndex, SlotIndex) -->
-    { plawk_scalar_increment_count(Name, ActionVars, Count),
+plawk_scalar_match_update_lines([scalar_counter(Name) | Rest], Actions, FieldSeparator, RuleIndex, SlotIndex) -->
+    { plawk_scalar_action_deltas(Name, Actions, Deltas),
+      plawk_scalar_const_delta_sum(Deltas, ConstDelta),
       plawk_scalar_rule_slot_input(RuleIndex, SlotIndex, InputValue),
+      format(atom(BaseValue), '%rule_~w_slot_~w_const', [RuleIndex, SlotIndex]),
+      format(atom(ConstLine),
+          '  ~w = add i64 ~w, ~w',
+          [BaseValue, InputValue, ConstDelta]),
+      phrase(plawk_scalar_dynamic_delta_lines(Deltas, FieldSeparator, RuleIndex,
+          SlotIndex, 0, BaseValue, OutputValue), DynamicLines),
       format(atom(Line),
-          '  %rule_~w_slot_~w = add i64 ~w, ~w',
-          [RuleIndex, SlotIndex, InputValue, Count]),
+          '  %rule_~w_slot_~w = add i64 ~w, 0',
+          [RuleIndex, SlotIndex, OutputValue]),
       NextIndex is SlotIndex + 1
     },
+    [ConstLine],
+    DynamicLines,
     [Line],
-    plawk_scalar_match_update_lines(Rest, ActionVars, RuleIndex, NextIndex).
+    plawk_scalar_match_update_lines(Rest, Actions, FieldSeparator, RuleIndex, NextIndex).
 
-plawk_scalar_increment_count(Name, ActionVars, Count) :-
-    include(==(Name), ActionVars, Matches),
-    length(Matches, Count).
+plawk_scalar_update_action(Action) :-
+    plawk_scalar_action_delta(Action, _Name, _Delta).
+
+plawk_scalar_update_action_name(Action, Name) :-
+    plawk_scalar_action_delta(Action, Name, _Delta).
+
+plawk_scalar_action_delta(inc(var(Name)), Name, const(1)).
+plawk_scalar_action_delta(add(var(Name), int(Value)), Name, const(Value)) :-
+    integer(Value),
+    Value >= 0.
+plawk_scalar_action_delta(add(var(Name), length(field(FieldIndex))), Name, length(FieldIndex)) :-
+    FieldIndex >= 0.
+
+plawk_scalar_action_deltas(Name, Actions, Deltas) :-
+    findall(Delta,
+        ( member(Action, Actions),
+          plawk_scalar_action_delta(Action, Name, Delta)
+        ),
+        Deltas).
+
+plawk_scalar_const_delta_sum(Deltas, Sum) :-
+    findall(Value, member(const(Value), Deltas), Values),
+    sum_list(Values, Sum).
+
+plawk_scalar_dynamic_delta_lines([], _FieldSeparator, _RuleIndex, _SlotIndex, _DeltaIndex, Value, Value) -->
+    [].
+plawk_scalar_dynamic_delta_lines([const(_Value) | Rest], FieldSeparator, RuleIndex, SlotIndex, DeltaIndex, InputValue, OutputValue) -->
+    plawk_scalar_dynamic_delta_lines(Rest, FieldSeparator, RuleIndex, SlotIndex, DeltaIndex, InputValue, OutputValue).
+plawk_scalar_dynamic_delta_lines([length(FieldIndex) | Rest], FieldSeparator, RuleIndex, SlotIndex, DeltaIndex, InputValue, OutputValue) -->
+    { format(atom(LengthBase), 'plawk_rule_~w_slot_~w_delta_~w_len', [RuleIndex, SlotIndex, DeltaIndex]),
+      llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, LengthCall),
+      format(atom(NextValue), '%rule_~w_slot_~w_delta_~w', [RuleIndex, SlotIndex, DeltaIndex]),
+      format(atom(AddLine), '  ~w = add i64 ~w, %~w', [NextValue, InputValue, LengthBase]),
+      NextDeltaIndex is DeltaIndex + 1
+    },
+    [LengthCall, AddLine],
+    plawk_scalar_dynamic_delta_lines(Rest, FieldSeparator, RuleIndex, SlotIndex, NextDeltaIndex, NextValue, OutputValue).
 
 plawk_scalar_next_phi_ir(StatePlan, RuleCount, IR) :-
     plawk_state_plan_slots(StatePlan, Slots),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -20,6 +20,7 @@
 %      BEGIN { FS = ":" } $1 == "ERROR" { counts[$2]++ } END { print counts["disk"] }
 %      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
 %      { count++ } END { print "count", count }
+%      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %
 %  The AST is deliberately small and explicit so later syntax can extend it
 %  without changing the native codegen contract.
@@ -214,6 +215,9 @@ action(Action) -->
     print_action(Action),
     !.
 action(Action) -->
+    add_assign_action(Action),
+    !.
+action(Action) -->
     increment_action(Action),
     !.
 
@@ -230,6 +234,28 @@ increment_action(inc_assoc(var(Name), KeyExpr)) -->
 increment_action(inc(var(Name))) -->
     identifier(Name),
     "++".
+
+add_assign_action(add(var(Name), Delta)) -->
+    identifier(Name),
+    ws,
+    "+=",
+    ws,
+    scalar_delta_expr(Delta).
+
+scalar_delta_expr(int(Value)) -->
+    integer_codes(ValueCodes),
+    { ValueCodes \== [],
+      number_codes(Value, ValueCodes),
+      Value >= 0 }.
+scalar_delta_expr(length(Field)) -->
+    "length",
+    ws,
+    "(",
+    ws,
+    field_expr(Field),
+    ws,
+    ")",
+    { Field = field(_) }.
 
 print_action(print(Fields)) -->
     "print",

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -81,6 +81,17 @@ test(parses_multi_rule_scalar_end_print_rule) :-
          rule(field_eq(1, "WARN"), [inc(var(warnings))])],
         [end([print([var(errors), var(warnings)])])])).
 
+test(parses_field_eq_scalar_add_assign_end_print_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { bytes += length($0); hits += 2 } END { print bytes, hits }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [add(var(bytes), length(field(0))), add(var(hits), int(2))])],
+        [end([print([var(bytes), var(hits)])])])).
+
+test(parses_always_scalar_add_assign_end_print_rule) :-
+    plawk_parse_string("{ total += 3 } END { print total }\n", Program),
+    assertion(Program == program([], [rule(always, [add(var(total), int(3))])],
+        [end([print([var(total)])])])).
+
 test(parses_assoc_count_end_print_rule) :-
     plawk_parse_string("{ counts[$1]++ } END { print counts[\"ERROR\"], counts[\"WARN\"] }\n", Program),
     assertion(Program == program([], [rule(always, [inc_assoc(var(counts), field(1))])],
@@ -238,6 +249,21 @@ test(surface_multi_rule_accumulates_overlapping_matches) :-
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "4\n").
 
+test(surface_field_eq_scalar_add_assign_accumulates_constants_and_lengths) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { bytes += length($0); hits += 2 } END { print bytes, hits }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR network down\n",
+        "33 4\n").
+
+test(surface_always_scalar_add_assign_accumulates_constants) :-
+    run_surface_print_smoke("{ total += 3 } END { print total }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "12\n").
+
+test(surface_mixed_inc_and_add_assign_accumulates_same_slot) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { hits++; hits += 2 } END { print hits }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "6\n").
+
 test(surface_scalar_end_prints_string_literals) :-
     run_surface_print_smoke("{ total++ } END { print \"total\", total }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -262,6 +288,11 @@ test(surface_mixed_scalar_assoc_counts) :-
     run_surface_print_smoke("{ total++; counts[$1]++ } $1 == \"ERROR\" { errors++; by_component[$2]++ } END { print total, errors, counts[\"WARN\"], by_component[\"disk\"] }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "4 2 1 1\n").
+
+test(surface_mixed_scalar_add_assign_and_assoc_counts) :-
+    run_surface_print_smoke("{ bytes += length($0); counts[$1]++ } END { print bytes, counts[\"ERROR\"] }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "53 2\n").
 
 test(surface_assoc_end_prints_string_literals) :-
     run_surface_print_smoke("{ counts[$1]++ } END { print \"errors\", counts[\"ERROR\"], \"warnings\", counts[\"WARN\"] }\n",
@@ -407,6 +438,18 @@ test(surface_mixed_scalar_assoc_uses_native_state_and_tables) :-
     assertion(once(sub_atom(DriverIR, _, _, _, 'rule_1_done:'))),
     assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_rule_0_action_0:'))),
     assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_rule_1_action_0:'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_scalar_add_assign_uses_native_state_and_field_length) :-
+    plawk_parse_string("BEGIN { FS = \":\" } $1 == \"ERROR\" { bytes += length($2); hits += 2 } END { print bytes, hits }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'lowered_match:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%slot_0 = phi i64'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_slot_0_const = add i64 %slot_0, 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_rule_0_slot_0_delta_0_len = call i64 @wam_atom_field_length_value(%Value %line, i64 2, i8 58)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_slot_1_const = add i64 %slot_1, 2'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%next_slot_0 = phi i64'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 


### PR DESCRIPTION
## Summary
- parse PLAWK scalar `+=` actions for integer constants and `length($N)` deltas
- lower scalar add-assignment through the existing native `i64` slot state plan
- cover guarded, always-rule, same-slot, and mixed scalar/associative compiled smokes
- document the new accumulator surface in the PLAWK README, tutorial, and implementation plan

## Tests
- `git diff --cached --check`
- `git diff --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`