### PR TITLE
Support PLAWK scalar terminal next

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -268,7 +268,9 @@ Scalar counters lower through an explicit codegen state plan that keeps
 source-level state recognition separate from LLVM slot numbering. The same
 native slots now support `+=` with integer constants and field lengths, so
 programs such as `$1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }`
-stay in the compiled stream loop. The current
+stay in the compiled stream loop. Scalar native rule chains also support
+terminal `next` by branching directly to the stream-loop continuation and adding
+the early-exit rule's scalar values to the loop phi inputs. The current
 associative-count surface allocates one reusable WAM/LLVM
 interned-atom-keyed growable `i64` table primitive (`wam_assoc_i64_*`) per source
 array, increments those tables in the native streaming loop, and performs `END`

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -88,7 +88,10 @@ Scalar state works with `$1 ==
 compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple
 guarded rules can update shared scalar slots before an `END` print. Scalar slots
 also support native `+=` with integer constants and field lengths, e.g.
-`$1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }`. The first
+`$1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }`.
+Terminal `next` is supported in scalar native rule chains, so `$1 == "DEBUG"
+{ skipped++; next } { total++ } END { print total, skipped }` skips the later
+rule for matching records. The first
 associative-count surface now supports multiple source arrays, e.g.
 `{ counts[$1]++; by_component[$2]++ } END { print counts["ERROR"], by_component["disk"] }`.
 Codegen allocates one WAM/LLVM runtime interned-atom-keyed `i64` table per

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -233,6 +233,14 @@ $1 == "ERROR" { bytes += length($0); hits += 2 }
 END { print bytes, hits }
 ```
 
+A terminal `next` skips the remaining rules for the current record:
+
+```awk
+$1 == "DEBUG" { skipped++; next }
+{ total++ }
+END { print total, skipped }
+```
+
 `BEGIN` can emit literal report headers before the first input record is read:
 
 ```awk

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -119,7 +119,8 @@ plawk_program_native_driver_ir(
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, RuleGlobalIR, RuleChainIR, RuleCount),
     plawk_state_loop_phi_ir(StatePlan, LoopPhiIR),
-    plawk_scalar_next_phi_ir(StatePlan, RuleCount, NextPhiIR),
+    plawk_scalar_rule_controls(Rules, ScalarRuleControls),
+    plawk_scalar_next_phi_ir(StatePlan, RuleCount, ScalarRuleControls, NextPhiIR),
     plawk_scalar_end_print_ir(PrintFields, StatePlan, OutputSeparator, EndPrintIR),
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
         [BeginGlobalIR, StringGlobalIR, RuleGlobalIR]),
@@ -299,6 +300,23 @@ plawk_state_slot_count(StatePlan, Count) :-
 plawk_state_slot_index(StatePlan, Slot, Index) :-
     plawk_state_plan_slots(StatePlan, Slots),
     nth0(Index, Slots, Slot).
+
+plawk_split_terminal_next(Actions, BodyActions, terminal_next) :-
+    append(BodyActions, [next], Actions),
+    !,
+    \+ member(next, BodyActions).
+plawk_split_terminal_next(Actions, Actions, fallthrough) :-
+    \+ member(next, Actions).
+
+plawk_rule_target(fallthrough, NextLabel, NextLabel).
+plawk_rule_target(terminal_next, _NextLabel, continue_loop).
+
+plawk_scalar_rule_controls(Rules, Controls) :-
+    findall(Control,
+        ( member(rule(_Pattern, Actions), Rules),
+          plawk_split_terminal_next(Actions, _BodyActions, Control)
+        ),
+        Controls).
 
 plawk_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
     findall(Name,
@@ -928,16 +946,31 @@ plawk_mixed_end_print_lines([string(Value) | Rest], ScalarPlan, AssocPlan, Outpu
 plawk_scalar_print_expr(var(Name), Name).
 
 plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, GlobalIR, ChainIR, RuleCount) :-
-    length(Rules, RuleCount),
+    plawk_scalar_planned_rules(Rules, PlannedRules, Controls),
+    length(PlannedRules, RuleCount),
     RuleCount > 0,
-    phrase(plawk_scalar_rule_chain_lines(Rules, StatePlan, FieldSeparator, 0), Pairs),
+    phrase(plawk_scalar_rule_chain_lines(PlannedRules, Controls, StatePlan, FieldSeparator, 0), Pairs),
     pairs_keys_values(Pairs, GlobalParts, ChainParts),
     atomic_list_concat(GlobalParts, '\n', GlobalIR),
     atomic_list_concat(ChainParts, '\n', ChainIR).
 
-plawk_scalar_rule_chain_lines([], _StatePlan, _FieldSeparator, _) -->
+plawk_scalar_planned_rules(Rules, PlannedRules, Controls) :-
+    phrase(plawk_scalar_planned_rule_lines(Rules, 0), PlannedRules),
+    findall(Control,
+        member(scalar_rule(_Index, _Pattern, _Actions, Control), PlannedRules),
+        Controls).
+
+plawk_scalar_planned_rule_lines([], _Index) -->
     [].
-plawk_scalar_rule_chain_lines([rule(Pattern, Actions) | Rest], StatePlan, FieldSeparator, Index) -->
+plawk_scalar_planned_rule_lines([rule(Pattern, Actions) | Rest], Index) -->
+    { plawk_split_terminal_next(Actions, BodyActions, Control),
+      NextIndex is Index + 1 },
+    [scalar_rule(Index, Pattern, BodyActions, Control)],
+    plawk_scalar_planned_rule_lines(Rest, NextIndex).
+
+plawk_scalar_rule_chain_lines([], _Controls, _StatePlan, _FieldSeparator, _) -->
+    [].
+plawk_scalar_rule_chain_lines([scalar_rule(Index, Pattern, Actions, Control) | Rest], Controls, StatePlan, FieldSeparator, Index) -->
     { NextIndex is Index + 1,
       ( Rest == []
       -> NextLabel = 'continue_loop'
@@ -950,8 +983,9 @@ plawk_scalar_rule_chain_lines([rule(Pattern, Actions) | Rest], StatePlan, FieldS
       format(atom(MatchValue), '%~w', [MatchVar]),
       plawk_pattern_guard_ir(Pattern, FieldSeparator, GlobalBase, MatchValue,
           GuardGlobalIR-GuardCallIR),
+      plawk_rule_target(Control, NextLabel, RuleTargetLabel),
       include(plawk_scalar_update_action, Actions, ScalarActions),
-      plawk_scalar_rule_input_phi_ir(StatePlan, Index, InputPhiIR),
+      plawk_scalar_rule_input_phi_ir(StatePlan, Index, Controls, InputPhiIR),
       plawk_scalar_match_update_ir(StatePlan, ScalarActions, FieldSeparator, Index, MatchUpdateIR),
       ( Index =:= 0
       -> EntryIR = '  br label %rule_0_match\n\n'
@@ -966,33 +1000,40 @@ plawk_scalar_rule_chain_lines([rule(Pattern, Actions) | Rest], StatePlan, FieldS
 ~w
   br label %~w',
           [EntryIR, RuleLabel, InputPhiIR, GuardCallIR, MatchVar,
-           ApplyLabel, NextLabel, ApplyLabel, MatchUpdateIR, NextLabel]),
+           ApplyLabel, NextLabel, ApplyLabel, MatchUpdateIR, RuleTargetLabel]),
       Pair = GuardGlobalIR-BranchIR
     },
     [Pair],
-    plawk_scalar_rule_chain_lines(Rest, StatePlan, FieldSeparator, NextIndex).
+    plawk_scalar_rule_chain_lines(Rest, Controls, StatePlan, FieldSeparator, NextIndex).
 
-plawk_scalar_rule_input_phi_ir(_StatePlan, 0, '') :-
+plawk_scalar_rule_input_phi_ir(_StatePlan, 0, _Controls, '') :-
     !.
-plawk_scalar_rule_input_phi_ir(StatePlan, RuleIndex, IR) :-
+plawk_scalar_rule_input_phi_ir(StatePlan, RuleIndex, Controls, IR) :-
     plawk_state_plan_slots(StatePlan, Slots),
-    phrase(plawk_scalar_rule_input_phi_lines(Slots, RuleIndex, 0), Lines),
+    phrase(plawk_scalar_rule_input_phi_lines(Slots, RuleIndex, Controls, 0), Lines),
     atomic_list_concat(Lines, '\n', LinesIR),
     format(atom(IR), '~w~n', [LinesIR]).
 
-plawk_scalar_rule_input_phi_lines([], _RuleIndex, _) -->
+plawk_scalar_rule_input_phi_lines([], _RuleIndex, _Controls, _) -->
     [].
-plawk_scalar_rule_input_phi_lines([_Name | Rest], RuleIndex, SlotIndex) -->
+plawk_scalar_rule_input_phi_lines([_Name | Rest], RuleIndex, Controls, SlotIndex) -->
     { PrevRuleIndex is RuleIndex - 1,
       plawk_scalar_rule_input_value(PrevRuleIndex, SlotIndex, PrevFalseValue),
-      format(atom(Line),
-          '  %rule_~w_in_slot_~w = phi i64 [~w, %rule_~w_match], [%rule_~w_slot_~w, %rule_~w_apply]',
-          [RuleIndex, SlotIndex, PrevFalseValue, PrevRuleIndex,
-           PrevRuleIndex, SlotIndex, PrevRuleIndex]),
+      format(atom(FalseIncoming), '[~w, %rule_~w_match]',
+          [PrevFalseValue, PrevRuleIndex]),
+      (   nth0(PrevRuleIndex, Controls, terminal_next)
+      ->  Incomings = [FalseIncoming]
+      ;   format(atom(ApplyIncoming), '[%rule_~w_slot_~w, %rule_~w_apply]',
+              [PrevRuleIndex, SlotIndex, PrevRuleIndex]),
+          Incomings = [FalseIncoming, ApplyIncoming]
+      ),
+      atomic_list_concat(Incomings, ', ', IncomingIR),
+      format(atom(Line), '  %rule_~w_in_slot_~w = phi i64 ~w',
+          [RuleIndex, SlotIndex, IncomingIR]),
       NextSlotIndex is SlotIndex + 1
     },
     [Line],
-    plawk_scalar_rule_input_phi_lines(Rest, RuleIndex, NextSlotIndex).
+    plawk_scalar_rule_input_phi_lines(Rest, RuleIndex, Controls, NextSlotIndex).
 
 plawk_scalar_rule_input_value(0, SlotIndex, Value) :-
     !,
@@ -1087,23 +1128,34 @@ plawk_scalar_dynamic_delta_lines([length(FieldIndex) | Rest], FieldSeparator, Ru
     [LengthCall, AddLine],
     plawk_scalar_dynamic_delta_lines(Rest, FieldSeparator, RuleIndex, SlotIndex, NextDeltaIndex, NextValue, OutputValue).
 
-plawk_scalar_next_phi_ir(StatePlan, RuleCount, IR) :-
+plawk_scalar_next_phi_ir(StatePlan, RuleCount, Controls, IR) :-
     plawk_state_plan_slots(StatePlan, Slots),
-    phrase(plawk_scalar_next_phi_lines(Slots, RuleCount, 0), Lines),
+    phrase(plawk_scalar_next_phi_lines(Slots, RuleCount, Controls, 0), Lines),
     atomic_list_concat(Lines, '\n', IR).
 
-plawk_scalar_next_phi_lines([], _RuleCount, _) -->
+plawk_scalar_next_phi_lines([], _RuleCount, _Controls, _) -->
     [].
-plawk_scalar_next_phi_lines([_Slot | Rest], RuleCount, Index) -->
+plawk_scalar_next_phi_lines([_Slot | Rest], RuleCount, Controls, Index) -->
     { LastRuleIndex is RuleCount - 1,
       plawk_scalar_rule_input_value(LastRuleIndex, Index, FalseValue),
-      format(atom(Line),
-          '  %next_slot_~w = phi i64 [~w, %rule_~w_match], [%rule_~w_slot_~w, %rule_~w_apply]',
-          [Index, FalseValue, LastRuleIndex, LastRuleIndex, Index, LastRuleIndex]),
+      format(atom(FalseIncoming), '[~w, %rule_~w_match]',
+          [FalseValue, LastRuleIndex]),
+      findall(ApplyIncoming,
+          ( between(0, LastRuleIndex, RuleIndex),
+            ( RuleIndex =:= LastRuleIndex
+            ; nth0(RuleIndex, Controls, terminal_next)
+            ),
+            format(atom(ApplyIncoming), '[%rule_~w_slot_~w, %rule_~w_apply]',
+                [RuleIndex, Index, RuleIndex])
+          ),
+          ApplyIncomings),
+      append([FalseIncoming], ApplyIncomings, Incomings),
+      atomic_list_concat(Incomings, ', ', IncomingIR),
+      format(atom(Line), '  %next_slot_~w = phi i64 ~w', [Index, IncomingIR]),
       NextIndex is Index + 1
     },
     [Line],
-    plawk_scalar_next_phi_lines(Rest, RuleCount, NextIndex).
+    plawk_scalar_next_phi_lines(Rest, RuleCount, Controls, NextIndex).
 
 plawk_scalar_end_print_ir(PrintFields, StatePlan, OutputSeparator, IR) :-
     phrase(plawk_scalar_end_print_lines(PrintFields, StatePlan, OutputSeparator, 0), Lines),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -21,6 +21,7 @@
 %      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
 %      { count++ } END { print "count", count }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
+%      $1 == "DEBUG" { skipped++; next } { total++ } END { print total, skipped }
 %
 %  The AST is deliberately small and explicit so later syntax can extend it
 %  without changing the native codegen contract.
@@ -215,6 +216,9 @@ action(Action) -->
     print_action(Action),
     !.
 action(Action) -->
+    next_action(Action),
+    !.
+action(Action) -->
     add_assign_action(Action),
     !.
 action(Action) -->
@@ -234,6 +238,9 @@ increment_action(inc_assoc(var(Name), KeyExpr)) -->
 increment_action(inc(var(Name))) -->
     identifier(Name),
     "++".
+
+next_action(next) -->
+    "next".
 
 add_assign_action(add(var(Name), Delta)) -->
     identifier(Name),

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -81,6 +81,13 @@ test(parses_multi_rule_scalar_end_print_rule) :-
          rule(field_eq(1, "WARN"), [inc(var(warnings))])],
         [end([print([var(errors), var(warnings)])])])).
 
+test(parses_terminal_next_scalar_rule) :-
+    plawk_parse_string("$1 == \"DEBUG\" { skipped++; next } { total++ } END { print total, skipped }\n", Program),
+    assertion(Program == program([],
+        [rule(field_eq(1, "DEBUG"), [inc(var(skipped)), next]),
+         rule(always, [inc(var(total))])],
+        [end([print([var(total), var(skipped)])])])).
+
 test(parses_field_eq_scalar_add_assign_end_print_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { bytes += length($0); hits += 2 } END { print bytes, hits }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
@@ -248,6 +255,11 @@ test(surface_multi_rule_accumulates_overlapping_matches) :-
     run_surface_print_smoke("$1 == \"ERROR\" { hits++ } /^ERROR/ { hits++ } END { print hits }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "4\n").
+
+test(surface_terminal_next_skips_remaining_scalar_rules) :-
+    run_surface_print_smoke("$1 == \"DEBUG\" { skipped++; next } { total++ } END { print total, skipped }\n",
+        "INFO boot ok\nDEBUG trace one\nERROR disk full\nDEBUG trace two\n",
+        "2 2\n").
 
 test(surface_field_eq_scalar_add_assign_accumulates_constants_and_lengths) :-
     run_surface_print_smoke("$1 == \"ERROR\" { bytes += length($0); hits += 2 } END { print bytes, hits }\n",
@@ -450,6 +462,17 @@ test(surface_scalar_add_assign_uses_native_state_and_field_length) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_rule_0_slot_0_delta_0_len = call i64 @wam_atom_field_length_value(%Value %line, i64 2, i8 58)'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_slot_1_const = add i64 %slot_1, 2'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%next_slot_0 = phi i64'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_terminal_next_uses_native_continue_phi) :-
+    plawk_parse_string("$1 == \"DEBUG\" { skipped++; next } { total++ } END { print total, skipped }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_apply:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_1_match:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'br label %continue_loop'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_1_in_slot_0 = phi i64 [%slot_0, %rule_0_match]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%next_slot_0 = phi i64 [%rule_1_in_slot_0, %rule_1_match], [%rule_0_slot_0, %rule_0_apply], [%rule_1_slot_0, %rule_1_apply]'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 


### PR DESCRIPTION
## Summary
- parse `next` actions in PLAWK rule bodies
- lower terminal `next` for scalar native rule chains by branching to the stream-loop continuation
- update scalar phi generation so early-exit rules carry updated slot values into the next loop iteration
- document the current scalar-terminal scope and add parser, compiled-smoke, and IR-shape coverage

## Tests
- `git diff --cached --check`
- `git diff --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`