### PR TITLE
Support PLAWK terminal next for assoc and mixed rules

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -268,9 +268,10 @@ Scalar counters lower through an explicit codegen state plan that keeps
 source-level state recognition separate from LLVM slot numbering. The same
 native slots now support `+=` with integer constants and field lengths, so
 programs such as `$1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }`
-stay in the compiled stream loop. Scalar native rule chains also support
-terminal `next` by branching directly to the stream-loop continuation and adding
-the early-exit rule's scalar values to the loop phi inputs. The current
+stay in the compiled stream loop. Native rule chains also support terminal
+`next` by branching directly to the stream-loop continuation; scalar and mixed
+chains add the early-exit rule's scalar values to the loop phi inputs, while
+assoc-only chains update tables before the continuation branch. The current
 associative-count surface allocates one reusable WAM/LLVM
 interned-atom-keyed growable `i64` table primitive (`wam_assoc_i64_*`) per source
 array, increments those tables in the native streaming loop, and performs `END`

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -89,8 +89,8 @@ compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple
 guarded rules can update shared scalar slots before an `END` print. Scalar slots
 also support native `+=` with integer constants and field lengths, e.g.
 `$1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }`.
-Terminal `next` is supported in scalar native rule chains, so `$1 == "DEBUG"
-{ skipped++; next } { total++ } END { print total, skipped }` skips the later
+Terminal `next` is supported in native rule chains, so `$1 == "DEBUG" {
+skipped++; next } { total++ } END { print total, skipped }` skips the later
 rule for matching records. The first
 associative-count surface now supports multiple source arrays, e.g.
 `{ counts[$1]++; by_component[$2]++ } END { print counts["ERROR"], by_component["disk"] }`.

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -241,6 +241,8 @@ $1 == "DEBUG" { skipped++; next }
 END { print total, skipped }
 ```
 
+The same terminal `next` behavior works for associative arrays and mixed scalar/array rules.
+
 `BEGIN` can emit literal report headers before the first input record is read:
 
 ```awk

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -90,7 +90,8 @@ plawk_program_native_driver_ir(
     plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
     plawk_mixed_rule_chain_ir(MixedPlan, FieldSeparator, RuleGlobalIR, RuleChainIR, RuleCount),
     plawk_state_loop_phi_ir(ScalarPlan, LoopPhiIR),
-    plawk_mixed_scalar_next_phi_ir(ScalarPlan, RuleCount, NextPhiIR),
+    plawk_mixed_rule_controls(MixedPlan, MixedRuleControls),
+    plawk_mixed_scalar_next_phi_ir(ScalarPlan, RuleCount, MixedRuleControls, NextPhiIR),
     plawk_mixed_end_print_ir(PrintFields, ScalarPlan, AssocPlan, OutputSeparator, EndPrintIR),
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
         [BeginGlobalIR, StringGlobalIR, AssocGlobalIR, RuleGlobalIR]),
@@ -380,8 +381,9 @@ plawk_mixed_assoc_count_plan(Rules, PrintFields, assoc_plan(Tables, [])) :-
 plawk_mixed_planned_rules([], _AssocPlan, _Index) -->
     [].
 plawk_mixed_planned_rules([rule(Pattern, Actions) | Rest], assoc_plan(Tables, Actions0), Index) -->
-    { plawk_mixed_rule_actions(Actions, ScalarVars, AssocSpecs),
-      ( ScalarVars == [], AssocSpecs == []
+    { plawk_split_terminal_next(Actions, BodyActions, Control),
+      plawk_mixed_rule_actions(BodyActions, ScalarActions, AssocSpecs),
+      ( ScalarActions == [], AssocSpecs == [], Control == fallthrough
       -> HasActions = false,
          NextIndex = Index,
          PlannedAssocActions = []
@@ -391,14 +393,14 @@ plawk_mixed_planned_rules([rule(Pattern, Actions) | Rest], assoc_plan(Tables, Ac
       )
     },
     ( { HasActions == true }
-    -> [mixed_rule(Index, Pattern, ScalarVars, PlannedAssocActions)]
+    -> [mixed_rule(Index, Pattern, ScalarActions, PlannedAssocActions, Control)]
     ;  []
     ),
     plawk_mixed_planned_rules(Rest, assoc_plan(Tables, Actions0), NextIndex).
 
-plawk_mixed_rule_actions(Actions, ScalarVars, AssocSpecs) :-
+plawk_mixed_rule_actions(Actions, ScalarActions, AssocSpecs) :-
     maplist(plawk_mixed_increment_action, Actions, TypedActions),
-    findall(Name, member(scalar(Name), TypedActions), ScalarVars),
+    findall(Action, member(scalar(Action), TypedActions), ScalarActions),
     findall(Spec, member(assoc(Spec), TypedActions), AssocSpecs).
 
 plawk_mixed_increment_action(Action, scalar(Action)) :-
@@ -406,29 +408,34 @@ plawk_mixed_increment_action(Action, scalar(Action)) :-
 plawk_mixed_increment_action(inc_assoc(var(ArrayName), field(KeyIndex)), assoc(ArrayName-KeyIndex)) :-
     KeyIndex > 0.
 
-plawk_mixed_rule_chain_ir(mixed_plan(ScalarPlan, _AssocPlan, Rules), FieldSeparator, GlobalIR, ChainIR, RuleCount) :-
+plawk_mixed_rule_chain_ir(mixed_plan(ScalarPlan, AssocPlan, Rules), FieldSeparator, GlobalIR, ChainIR, RuleCount) :-
     length(Rules, RuleCount),
     RuleCount > 0,
-    phrase(plawk_mixed_rule_chain_lines(Rules, ScalarPlan, FieldSeparator, 0), Pairs),
+    plawk_mixed_rule_controls(mixed_plan(ScalarPlan, AssocPlan, Rules), Controls),
+    phrase(plawk_mixed_rule_chain_lines(Rules, Controls, ScalarPlan, FieldSeparator, 0), Pairs),
     pairs_keys_values(Pairs, GlobalParts, ChainParts),
     atomic_list_concat(GlobalParts, '\n', GlobalIR),
     atomic_list_concat(ChainParts, '\n', ChainIR).
 
-plawk_mixed_rule_chain_lines([], _ScalarPlan, _FieldSeparator, _) -->
+plawk_mixed_rule_controls(mixed_plan(_ScalarPlan, _AssocPlan, Rules), Controls) :-
+    findall(Control, member(mixed_rule(_Index, _Pattern, _ScalarActions, _AssocActions, Control), Rules), Controls).
+
+plawk_mixed_rule_chain_lines([], _Controls, _ScalarPlan, _FieldSeparator, _) -->
     [].
-plawk_mixed_rule_chain_lines([mixed_rule(Index, Pattern, ScalarVars, AssocActions) | Rest], ScalarPlan, FieldSeparator, Index) -->
+plawk_mixed_rule_chain_lines([mixed_rule(Index, Pattern, ScalarActions, AssocActions, Control) | Rest], Controls, ScalarPlan, FieldSeparator, Index) -->
     { NextIndex is Index + 1,
       ( Rest == []
       -> NextLabel = 'continue_loop'
       ;  format(atom(NextLabel), 'rule_~w_match', [NextIndex])
       ),
+      plawk_rule_target(Control, NextLabel, RuleTargetLabel),
       format(atom(RuleLabel), 'rule_~w_match', [Index]),
       format(atom(ApplyLabel), 'rule_~w_apply', [Index]),
       format(atom(DoneLabel), 'rule_~w_done', [Index]),
-      plawk_mixed_scalar_rule_input_phi_ir(ScalarPlan, Index, InputPhiIR),
+      plawk_mixed_scalar_rule_input_phi_ir(ScalarPlan, Index, Controls, InputPhiIR),
       plawk_mixed_rule_guard_ir(Pattern, Index, RuleLabel, ApplyLabel,
           NextLabel, InputPhiIR, FieldSeparator, GuardGlobalIR-GuardIR),
-      plawk_scalar_match_update_ir(ScalarPlan, ScalarVars, FieldSeparator, Index, ScalarUpdateIR),
+      plawk_scalar_match_update_ir(ScalarPlan, ScalarActions, FieldSeparator, Index, ScalarUpdateIR),
       plawk_mixed_assoc_apply_ir(Index, AssocActions, DoneLabel, FieldSeparator, AssocApplyIR),
       ( Index =:= 0
       -> EntryIR = '  br label %rule_0_match\n\n'
@@ -444,11 +451,11 @@ plawk_mixed_rule_chain_lines([mixed_rule(Index, Pattern, ScalarVars, AssocAction
 ~w:
   br label %~w',
           [EntryIR, GuardIR, ApplyLabel, ScalarUpdateIR, AssocApplyIR,
-           DoneLabel, NextLabel]),
+           DoneLabel, RuleTargetLabel]),
       Pair = GuardGlobalIR-RuleIR
     },
     [Pair],
-    plawk_mixed_rule_chain_lines(Rest, ScalarPlan, FieldSeparator, NextIndex).
+    plawk_mixed_rule_chain_lines(Rest, Controls, ScalarPlan, FieldSeparator, NextIndex).
 
 plawk_mixed_rule_guard_ir(always, Index, RuleLabel, ApplyLabel, NextLabel,
     InputPhiIR, _FieldSeparator, ''-IR) :-
@@ -479,45 +486,63 @@ plawk_mixed_assoc_apply_ir(RuleIndex, AssocActions, DoneLabel, FieldSeparator, I
     phrase(plawk_assoc_rule_action_lines(RuleIndex, AssocActions, DoneLabel, FieldSeparator), Lines),
     atomic_list_concat(Lines, '\n', IR).
 
-plawk_mixed_scalar_rule_input_phi_ir(_StatePlan, 0, '') :-
+plawk_mixed_scalar_rule_input_phi_ir(_StatePlan, 0, _Controls, '') :-
     !.
-plawk_mixed_scalar_rule_input_phi_ir(StatePlan, RuleIndex, IR) :-
+plawk_mixed_scalar_rule_input_phi_ir(StatePlan, RuleIndex, Controls, IR) :-
     plawk_state_plan_slots(StatePlan, Slots),
-    phrase(plawk_mixed_scalar_rule_input_phi_lines(Slots, RuleIndex, 0), Lines),
+    phrase(plawk_mixed_scalar_rule_input_phi_lines(Slots, RuleIndex, Controls, 0), Lines),
     atomic_list_concat(Lines, '\n', LinesIR),
     format(atom(IR), '~w~n', [LinesIR]).
 
-plawk_mixed_scalar_rule_input_phi_lines([], _RuleIndex, _) -->
+plawk_mixed_scalar_rule_input_phi_lines([], _RuleIndex, _Controls, _) -->
     [].
-plawk_mixed_scalar_rule_input_phi_lines([_Slot | Rest], RuleIndex, SlotIndex) -->
+plawk_mixed_scalar_rule_input_phi_lines([_Slot | Rest], RuleIndex, Controls, SlotIndex) -->
     { PrevRuleIndex is RuleIndex - 1,
       plawk_scalar_rule_input_value(PrevRuleIndex, SlotIndex, PrevFalseValue),
-      format(atom(Line),
-          '  %rule_~w_in_slot_~w = phi i64 [~w, %rule_~w_match], [%rule_~w_slot_~w, %rule_~w_done]',
-          [RuleIndex, SlotIndex, PrevFalseValue, PrevRuleIndex,
-           PrevRuleIndex, SlotIndex, PrevRuleIndex]),
+      format(atom(FalseIncoming), '[~w, %rule_~w_match]',
+          [PrevFalseValue, PrevRuleIndex]),
+      (   nth0(PrevRuleIndex, Controls, terminal_next)
+      ->  Incomings = [FalseIncoming]
+      ;   format(atom(ApplyIncoming), '[%rule_~w_slot_~w, %rule_~w_done]',
+              [PrevRuleIndex, SlotIndex, PrevRuleIndex]),
+          Incomings = [FalseIncoming, ApplyIncoming]
+      ),
+      atomic_list_concat(Incomings, ', ', IncomingIR),
+      format(atom(Line), '  %rule_~w_in_slot_~w = phi i64 ~w',
+          [RuleIndex, SlotIndex, IncomingIR]),
       NextSlotIndex is SlotIndex + 1
     },
     [Line],
-    plawk_mixed_scalar_rule_input_phi_lines(Rest, RuleIndex, NextSlotIndex).
+    plawk_mixed_scalar_rule_input_phi_lines(Rest, RuleIndex, Controls, NextSlotIndex).
 
-plawk_mixed_scalar_next_phi_ir(StatePlan, RuleCount, IR) :-
+plawk_mixed_scalar_next_phi_ir(StatePlan, RuleCount, Controls, IR) :-
     plawk_state_plan_slots(StatePlan, Slots),
-    phrase(plawk_mixed_scalar_next_phi_lines(Slots, RuleCount, 0), Lines),
+    phrase(plawk_mixed_scalar_next_phi_lines(Slots, RuleCount, Controls, 0), Lines),
     atomic_list_concat(Lines, '\n', IR).
 
-plawk_mixed_scalar_next_phi_lines([], _RuleCount, _) -->
+plawk_mixed_scalar_next_phi_lines([], _RuleCount, _Controls, _) -->
     [].
-plawk_mixed_scalar_next_phi_lines([_Slot | Rest], RuleCount, Index) -->
+plawk_mixed_scalar_next_phi_lines([_Slot | Rest], RuleCount, Controls, Index) -->
     { LastRuleIndex is RuleCount - 1,
       plawk_scalar_rule_input_value(LastRuleIndex, Index, FalseValue),
-      format(atom(Line),
-          '  %next_slot_~w = phi i64 [~w, %rule_~w_match], [%rule_~w_slot_~w, %rule_~w_done]',
-          [Index, FalseValue, LastRuleIndex, LastRuleIndex, Index, LastRuleIndex]),
+      format(atom(FalseIncoming), '[~w, %rule_~w_match]',
+          [FalseValue, LastRuleIndex]),
+      findall(ApplyIncoming,
+          ( between(0, LastRuleIndex, RuleIndex),
+            ( RuleIndex =:= LastRuleIndex
+            ; nth0(RuleIndex, Controls, terminal_next)
+            ),
+            format(atom(ApplyIncoming), '[%rule_~w_slot_~w, %rule_~w_done]',
+                [RuleIndex, Index, RuleIndex])
+          ),
+          ApplyIncomings),
+      append([FalseIncoming], ApplyIncomings, Incomings),
+      atomic_list_concat(Incomings, ', ', IncomingIR),
+      format(atom(Line), '  %next_slot_~w = phi i64 ~w', [Index, IncomingIR]),
       NextIndex is Index + 1
     },
     [Line],
-    plawk_mixed_scalar_next_phi_lines(Rest, RuleCount, NextIndex).
+    plawk_mixed_scalar_next_phi_lines(Rest, RuleCount, Controls, NextIndex).
 
 plawk_assoc_runtime_count_plan(
     Rules,
@@ -533,7 +558,7 @@ plawk_assoc_runtime_count_plan(
         PrintArrays),
     PrintArrays \== [],
     findall(ArrayName,
-        ( member(rule(_Pattern, ActionSpecs), RuleSpecs),
+        ( member(rule(_Pattern, ActionSpecs, _Control), RuleSpecs),
           member(ArrayName-_KeyIndex, ActionSpecs)
         ),
         ActionArrays),
@@ -541,9 +566,13 @@ plawk_assoc_runtime_count_plan(
     sort(ArrayNames0, Tables),
     phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, 0), PlannedRules).
 
-plawk_assoc_rule_action_specs(rule(Pattern, Actions), rule(Pattern, ActionSpecs)) :-
-    maplist(plawk_assoc_increment_action, Actions, ActionSpecs),
-    ActionSpecs \== [].
+plawk_assoc_rule_action_specs(rule(Pattern, Actions), rule(Pattern, ActionSpecs, Control)) :-
+    plawk_split_terminal_next(Actions, BodyActions, Control),
+    ( BodyActions == []
+    -> ActionSpecs = []
+    ;  maplist(plawk_assoc_increment_action, BodyActions, ActionSpecs)
+    ),
+    ( ActionSpecs \== [] ; Control == terminal_next ).
 
 plawk_assoc_increment_action(inc_assoc(var(ArrayName), field(KeyIndex)), ArrayName-KeyIndex) :-
     KeyIndex > 0.
@@ -552,11 +581,11 @@ plawk_assoc_print_array(assoc(var(ArrayName), string(_Key)), ArrayName).
 
 plawk_assoc_planned_rules([], _Tables, _Index) -->
     [].
-plawk_assoc_planned_rules([rule(Pattern, ActionSpecs) | Rest], Tables, Index) -->
+plawk_assoc_planned_rules([rule(Pattern, ActionSpecs, Control) | Rest], Tables, Index) -->
     { phrase(plawk_assoc_planned_actions(ActionSpecs, Tables, 0), PlannedActions),
       NextIndex is Index + 1
     },
-    [assoc_rule(Index, Pattern, PlannedActions)],
+    [assoc_rule(Index, Pattern, PlannedActions, Control)],
     plawk_assoc_planned_rules(Rest, Tables, NextIndex).
 
 plawk_assoc_planned_actions([], _Tables, _Index) -->
@@ -593,7 +622,7 @@ plawk_assoc_rule_chain_ir(assoc_plan(_Tables, Rules), FieldSeparator, GlobalIR, 
 
 plawk_assoc_rule_chain_lines([], _FieldSeparator, _) -->
     [].
-plawk_assoc_rule_chain_lines([assoc_rule(Index, Pattern, Actions) | Rest], FieldSeparator, Index) -->
+plawk_assoc_rule_chain_lines([assoc_rule(Index, Pattern, Actions, Control) | Rest], FieldSeparator, Index) -->
     { NextIndex is Index + 1,
       ( Rest == []
       -> NextLabel = 'continue_loop'
@@ -601,7 +630,8 @@ plawk_assoc_rule_chain_lines([assoc_rule(Index, Pattern, Actions) | Rest], Field
       ),
       format(atom(RuleLabel), 'assoc_rule_~w_match', [Index]),
       format(atom(ApplyLabel), 'assoc_rule_~w_apply', [Index]),
-      plawk_assoc_rule_apply_ir(Index, Actions, NextLabel, FieldSeparator, ApplyIR),
+      plawk_rule_target(Control, NextLabel, RuleTargetLabel),
+      plawk_assoc_rule_apply_ir(Index, Actions, RuleTargetLabel, FieldSeparator, ApplyIR),
       ( Index =:= 0
       -> EntryIR = '  br label %assoc_rule_0_match\n\n'
       ;  EntryIR = ''
@@ -639,6 +669,9 @@ plawk_assoc_rule_guard_ir(Pattern, Index, RuleLabel, ApplyLabel, NextLabel,
   br i1 %~w, label %~w, label %~w',
         [EntryIR, RuleLabel, GuardCallIR, MatchVar, ApplyLabel, NextLabel]).
 
+plawk_assoc_rule_apply_ir(_RuleIndex, [], NextLabel, _FieldSeparator, IR) :-
+    !,
+    format(atom(IR), '  br label %~w', [NextLabel]).
 plawk_assoc_rule_apply_ir(RuleIndex, Actions, NextLabel, FieldSeparator, IR) :-
     phrase(plawk_assoc_rule_action_lines(RuleIndex, Actions, NextLabel, FieldSeparator), Lines),
     atomic_list_concat(Lines, '\n', IR).

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -88,6 +88,27 @@ test(parses_terminal_next_scalar_rule) :-
          rule(always, [inc(var(total))])],
         [end([print([var(total), var(skipped)])])])).
 
+test(parses_terminal_next_assoc_rule) :-
+    plawk_parse_string("$1 == \"DEBUG\" { skipped[$2]++; next } { counts[$1]++ } END { print skipped[\"trace\"], counts[\"DEBUG\"], counts[\"ERROR\"] }\n", Program),
+    assertion(Program == program([],
+        [rule(field_eq(1, "DEBUG"), [inc_assoc(var(skipped), field(2)), next]),
+         rule(always, [inc_assoc(var(counts), field(1))])],
+        [end([print([
+            assoc(var(skipped), string("trace")),
+            assoc(var(counts), string("DEBUG")),
+            assoc(var(counts), string("ERROR"))
+        ])])])).
+
+test(parses_terminal_next_mixed_rule) :-
+    plawk_parse_string("$1 == \"DEBUG\" { skipped++; by_kind[$2]++; next } { total++; counts[$1]++ } END { print total, skipped, by_kind[\"trace\"], counts[\"DEBUG\"], counts[\"ERROR\"] }\n", Program),
+    assertion(Program == program([],
+        [rule(field_eq(1, "DEBUG"), [inc(var(skipped)), inc_assoc(var(by_kind), field(2)), next]),
+         rule(always, [inc(var(total)), inc_assoc(var(counts), field(1))])],
+        [end([print([
+            var(total), var(skipped), assoc(var(by_kind), string("trace")),
+            assoc(var(counts), string("DEBUG")), assoc(var(counts), string("ERROR"))
+        ])])])).
+
 test(parses_field_eq_scalar_add_assign_end_print_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { bytes += length($0); hits += 2 } END { print bytes, hits }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
@@ -260,6 +281,16 @@ test(surface_terminal_next_skips_remaining_scalar_rules) :-
     run_surface_print_smoke("$1 == \"DEBUG\" { skipped++; next } { total++ } END { print total, skipped }\n",
         "INFO boot ok\nDEBUG trace one\nERROR disk full\nDEBUG trace two\n",
         "2 2\n").
+
+test(surface_terminal_next_skips_remaining_assoc_rules) :-
+    run_surface_print_smoke("$1 == \"DEBUG\" { skipped[$2]++; next } { counts[$1]++ } END { print skipped[\"trace\"], counts[\"DEBUG\"], counts[\"ERROR\"] }\n",
+        "INFO boot ok\nDEBUG trace one\nERROR disk full\nDEBUG trace two\n",
+        "2 0 1\n").
+
+test(surface_terminal_next_skips_remaining_mixed_rules) :-
+    run_surface_print_smoke("$1 == \"DEBUG\" { skipped++; by_kind[$2]++; next } { total++; counts[$1]++ } END { print total, skipped, by_kind[\"trace\"], counts[\"DEBUG\"], counts[\"ERROR\"] }\n",
+        "INFO boot ok\nDEBUG trace one\nERROR disk full\nDEBUG trace two\n",
+        "2 2 2 0 1\n").
 
 test(surface_field_eq_scalar_add_assign_accumulates_constants_and_lengths) :-
     run_surface_print_smoke("$1 == \"ERROR\" { bytes += length($0); hits += 2 } END { print bytes, hits }\n",
@@ -473,6 +504,26 @@ test(surface_terminal_next_uses_native_continue_phi) :-
     assertion(once(sub_atom(DriverIR, _, _, _, 'br label %continue_loop'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%rule_1_in_slot_0 = phi i64 [%slot_0, %rule_0_match]'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%next_slot_0 = phi i64 [%rule_1_in_slot_0, %rule_1_match], [%rule_0_slot_0, %rule_0_apply], [%rule_1_slot_0, %rule_1_apply]'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_assoc_terminal_next_uses_native_rule_chain) :-
+    plawk_parse_string("$1 == \"DEBUG\" { skipped[$2]++; next } { counts[$1]++ } END { print skipped[\"trace\"], counts[\"DEBUG\"], counts[\"ERROR\"] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_rule_0_apply:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_rule_1_match:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'br label %continue_loop'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_mixed_terminal_next_uses_native_continue_phi) :-
+    plawk_parse_string("$1 == \"DEBUG\" { skipped++; by_kind[$2]++; next } { total++; counts[$1]++ } END { print total, skipped, by_kind[\"trace\"], counts[\"DEBUG\"], counts[\"ERROR\"] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_done:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_1_match:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'br label %continue_loop'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_1_in_slot_0 = phi i64 [%slot_0, %rule_0_match]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '[%rule_0_slot_0, %rule_0_done]'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 


### PR DESCRIPTION
## Summary
- extend terminal `next` lowering to assoc-only and mixed scalar/assoc native rule chains
- thread terminal-next control through mixed scalar phi generation so early exits feed the loop continuation correctly
- add parser, compiled smoke, and generated-IR coverage for assoc-only and mixed terminal `next`
- update PLAWK docs now that terminal `next` is native-rule-chain wide

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`