### PR TITLE
Support PLAWK terminal break

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -271,10 +271,12 @@ programs such as `$1 == "ERROR" { bytes += length($0); hits += 2 } END { print b
 stay in the compiled stream loop. Native rule chains also support terminal
 `next` by branching directly to the stream-loop continuation; scalar and mixed
 chains add the early-exit rule's scalar values to the loop phi inputs, while
-assoc-only chains update tables before the continuation branch. This native
-slice deliberately supports terminal `next` only; non-terminal `next` needs a
-future control-flow lowering rather than implicit fall-through after the skipped
-record. The current
+assoc-only chains update tables before the continuation branch. Terminal
+`break` uses the sibling path: matching rules branch to a dedicated stream-close
+block and scalar/mixed programs feed `END` through final-state phis. This native
+slice deliberately supports terminal `next`/`break` only; non-terminal loop
+control needs a future intra-rule control-flow lowering rather than implicit
+fall-through after the skipped or final record. The current
 associative-count surface allocates one reusable WAM/LLVM
 interned-atom-keyed growable `i64` table primitive (`wam_assoc_i64_*`) per source
 array, increments those tables in the native streaming loop, and performs `END`

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -91,9 +91,12 @@ also support native `+=` with integer constants and field lengths, e.g.
 `$1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }`.
 Terminal `next` is supported in native rule chains, so `$1 == "DEBUG" {
 skipped++; next } { total++ } END { print total, skipped }` skips the later
-rule for matching records. In the current surface slice, `next` must be the
-last action in its rule body; non-terminal `next` is intentionally rejected by
-the native codegen boundary. The first
+rule for matching records. Terminal `break` is supported in the same native
+rule-chain shape and closes the stream before running `END`, e.g. `$1 == "ERROR"
+{ hits++; break } { total++ } END { print hits, total }`. In the current surface
+slice, `next` and `break` must be the last action in their rule body;
+non-terminal loop control is intentionally rejected by the native codegen
+boundary. The first
 associative-count surface now supports multiple source arrays, e.g.
 `{ counts[$1]++; by_component[$2]++ } END { print counts["ERROR"], by_component["disk"] }`.
 Codegen allocates one WAM/LLVM runtime interned-atom-keyed `i64` table per

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -242,7 +242,15 @@ END { print total, skipped }
 ```
 
 The same terminal `next` behavior works for associative arrays and mixed scalar/array rules.
-For now, `next` must be the last action in the rule body.
+Terminal `break` stops the input stream before running `END`:
+
+```awk
+$1 == "ERROR" { hits++; break }
+{ total++ }
+END { print hits, total }
+```
+
+For now, `next` and `break` must be the last action in the rule body.
 
 `BEGIN` can emit literal report headers before the first input record is read:
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -33,6 +33,7 @@
 %      BEGIN { FS = ":" } $1 == "ERROR" { counts[$2]++ } END { print counts["disk"] }
 %      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
+%      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
 %
 %  The surrounding runtime still comes from write_wam_llvm_project/3. This
 %  function emits the target-specific native main that streams the file, lowers
@@ -92,6 +93,8 @@ plawk_program_native_driver_ir(
     plawk_state_loop_phi_ir(ScalarPlan, LoopPhiIR),
     plawk_mixed_rule_controls(MixedPlan, MixedRuleControls),
     plawk_mixed_scalar_next_phi_ir(ScalarPlan, RuleCount, MixedRuleControls, NextPhiIR),
+    plawk_break_close_ir(ScalarPlan, RuleCount, MixedRuleControls, done,
+        BreakCloseIR, FinalStatePhiIR),
     plawk_mixed_end_print_ir(PrintFields, ScalarPlan, AssocPlan, OutputSeparator, EndPrintIR),
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
         [BeginGlobalIR, StringGlobalIR, AssocGlobalIR, RuleGlobalIR]),
@@ -99,12 +102,12 @@ plawk_program_native_driver_ir(
     plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
-~w
+~w~w
   ret i32 0',
-        [EndPrintIR]),
+        [FinalStatePhiIR, EndPrintIR]),
     plawk_stream_driver_ir(InputPath,
         driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, LoopPhiIR, lowered_mixed,
-            RuleChainIR, NextPhiIR, end_print, CloseOkIR),
+            RuleChainIR, NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
 plawk_program_native_driver_ir(
@@ -122,18 +125,20 @@ plawk_program_native_driver_ir(
     plawk_state_loop_phi_ir(StatePlan, LoopPhiIR),
     plawk_scalar_rule_controls(Rules, ScalarRuleControls),
     plawk_scalar_next_phi_ir(StatePlan, RuleCount, ScalarRuleControls, NextPhiIR),
+    plawk_break_close_ir(StatePlan, RuleCount, ScalarRuleControls, apply,
+        BreakCloseIR, FinalStatePhiIR),
     plawk_scalar_end_print_ir(PrintFields, StatePlan, OutputSeparator, EndPrintIR),
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
         [BeginGlobalIR, StringGlobalIR, RuleGlobalIR]),
     plawk_i64_end_print_globals(SurfaceGlobalIR, RuntimeGlobals),
     format(atom(CloseOkIR),
 'end_print:
-~w
+~w~w
   ret i32 0',
-        [EndPrintIR]),
+        [FinalStatePhiIR, EndPrintIR]),
     plawk_stream_driver_ir(InputPath,
         driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RuleChainIR,
-            NextPhiIR, end_print, CloseOkIR),
+            NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
 plawk_program_native_driver_ir(
@@ -150,6 +155,8 @@ plawk_program_native_driver_ir(
     plawk_assoc_print_key_globals(PrintFields, AssocGlobalIR),
     plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
     plawk_assoc_rule_chain_ir(AssocPlan, FieldSeparator, AssocRuleGlobalIR, AssocChainIR),
+    plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
+    plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
     plawk_assoc_end_print_ir(PrintFields, AssocPlan, OutputSeparator, EndPrintIR),
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
         [BeginGlobalIR, StringGlobalIR, AssocGlobalIR, AssocRuleGlobalIR]),
@@ -162,7 +169,7 @@ plawk_program_native_driver_ir(
         [EndPrintIR]),
     plawk_stream_driver_ir(InputPath,
         driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, '', lowered_assoc,
-            AssocChainIR, '', end_print, CloseOkIR),
+            AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
 plawk_combine_entry_ir('', IR, IR) :-
@@ -183,8 +190,9 @@ plawk_i64_end_print_globals(SurfaceGlobals, RuntimeGlobals) :-
         [SurfaceGlobals]).
 
 % Shared native streaming skeleton. Surface-specific lowerers provide globals,
-% loop-carried state phis, the per-record lowered block, continuation phis, and
-% the close-success block; file open/read/eof/close stays backend infrastructure.
+% loop-carried state phis, the per-record lowered block, continuation phis, an
+% optional terminal-break close block, and the close-success block; file
+% open/read/eof/close stays backend infrastructure.
 plawk_stream_driver_ir(
     InputPath,
     driver_blocks(RuntimeGlobals, LoopPhiIR, LoweredLabel, RecordIR,
@@ -200,6 +208,17 @@ plawk_stream_driver_ir(
     InputPath,
     driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
         ContinueIR, CloseOkLabel, CloseOkIR),
+    DriverIR
+) :-
+    plawk_stream_driver_ir(InputPath,
+        driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
+            ContinueIR, '', CloseOkLabel, CloseOkIR),
+        DriverIR).
+
+plawk_stream_driver_ir(
+    InputPath,
+    driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
+        ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR),
     DriverIR
 ) :-
     atom_codes(InputPath, PathCodes),
@@ -256,6 +275,7 @@ continue_loop:
 ~w
   br label %loop
 
+~w
 close_stream:
   %close_ok = call i1 @wam_stream_close_value(%Value %handle)
   br i1 %close_ok, label %~w, label %fail_close
@@ -279,7 +299,7 @@ fail_close:
 ',
         [BytesLen, PathBytes, RuntimeGlobals,
          BytesLen, BytesLen, PathLen, EntrySetupIR, LoopPhiIR, LoweredLabel,
-         LoweredLabel, RecordIR, ContinueIR, CloseOkLabel, CloseOkIR]).
+         LoweredLabel, RecordIR, ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR]).
 
 llvm_c_bytes([], '').
 llvm_c_bytes([Code | Rest], Bytes) :-
@@ -302,20 +322,105 @@ plawk_state_slot_index(StatePlan, Slot, Index) :-
     plawk_state_plan_slots(StatePlan, Slots),
     nth0(Index, Slots, Slot).
 
-plawk_split_terminal_next(Actions, BodyActions, terminal_next) :-
+plawk_split_terminal_control(Actions, BodyActions, terminal_next) :-
     append(BodyActions, [next], Actions),
     !,
-    \+ member(next, BodyActions).
-plawk_split_terminal_next(Actions, Actions, fallthrough) :-
-    \+ member(next, Actions).
+    \+ member(next, BodyActions),
+    \+ member(break, BodyActions).
+plawk_split_terminal_control(Actions, BodyActions, terminal_break) :-
+    append(BodyActions, [break], Actions),
+    !,
+    \+ member(next, BodyActions),
+    \+ member(break, BodyActions).
+plawk_split_terminal_control(Actions, Actions, fallthrough) :-
+    \+ member(next, Actions),
+    \+ member(break, Actions).
 
 plawk_rule_target(fallthrough, NextLabel, NextLabel).
 plawk_rule_target(terminal_next, _NextLabel, continue_loop).
+plawk_rule_target(terminal_break, _NextLabel, break_close_stream).
+
+
+plawk_controls_have_break(Controls) :-
+    member(terminal_break, Controls).
+
+plawk_assoc_break_close_ir(Controls, IR) :-
+    (   plawk_controls_have_break(Controls)
+    ->  IR = 'break_close_stream:
+  %break_close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %break_close_ok, label %end_print, label %fail_close
+'
+    ;   IR = ''
+    ).
+
+plawk_break_close_ir(StatePlan, RuleCount, Controls, BreakPredKind, BreakCloseIR, FinalStatePhiIR) :-
+    plawk_state_plan_slots(StatePlan, Slots),
+    (   plawk_controls_have_break(Controls)
+    ->  phrase(plawk_break_slot_phi_lines(Slots, RuleCount, Controls, BreakPredKind, 0), BreakSlotPhiLines),
+        atomic_list_concat(BreakSlotPhiLines, '\n', BreakSlotPhiIR),
+        format(atom(BreakCloseIR),
+'break_close_stream:
+~w
+  %break_close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %break_close_ok, label %end_print, label %fail_close
+',
+            [BreakSlotPhiIR]),
+        HasBreak = true
+    ;   BreakCloseIR = '',
+        HasBreak = false
+    ),
+    phrase(plawk_final_state_phi_lines(Slots, HasBreak, 0), FinalStatePhiLines),
+    atomic_list_concat(FinalStatePhiLines, '\n', FinalStatePhiIR0),
+    ( FinalStatePhiIR0 == ''
+    -> FinalStatePhiIR = ''
+    ;  format(atom(FinalStatePhiIR), '~w~n', [FinalStatePhiIR0])
+    ).
+
+plawk_break_slot_phi_lines([], _RuleCount, _Controls, _BreakPredKind, _) -->
+    [].
+plawk_break_slot_phi_lines([_Slot | Rest], RuleCount, Controls, BreakPredKind, SlotIndex) -->
+    { LastRuleIndex is RuleCount - 1,
+      findall(Incoming,
+          ( between(0, LastRuleIndex, RuleIndex),
+            nth0(RuleIndex, Controls, terminal_break),
+            plawk_break_predecessor_label(BreakPredKind, RuleIndex, PredLabel),
+            format(atom(Incoming), '[%rule_~w_slot_~w, %~w]',
+                [RuleIndex, SlotIndex, PredLabel])
+          ),
+          Incomings),
+      Incomings \== [],
+      atomic_list_concat(Incomings, ', ', IncomingIR),
+      format(atom(Line), '  %break_slot_~w = phi i64 ~w', [SlotIndex, IncomingIR]),
+      NextSlotIndex is SlotIndex + 1
+    },
+    [Line],
+    plawk_break_slot_phi_lines(Rest, RuleCount, Controls, BreakPredKind, NextSlotIndex).
+
+plawk_break_predecessor_label(apply, RuleIndex, Label) :-
+    format(atom(Label), 'rule_~w_apply', [RuleIndex]).
+plawk_break_predecessor_label(done, RuleIndex, Label) :-
+    format(atom(Label), 'rule_~w_done', [RuleIndex]).
+
+plawk_final_state_phi_lines([], _HasBreak, _) -->
+    [].
+plawk_final_state_phi_lines([_Slot | Rest], HasBreak, SlotIndex) -->
+    { format(atom(EofIncoming), '[%slot_~w, %close_stream]', [SlotIndex]),
+      ( HasBreak == true
+      -> format(atom(BreakIncoming), '[%break_slot_~w, %break_close_stream]', [SlotIndex]),
+         Incomings = [EofIncoming, BreakIncoming]
+      ;  Incomings = [EofIncoming]
+      ),
+      atomic_list_concat(Incomings, ', ', IncomingIR),
+      format(atom(Line), '  %final_slot_~w = phi i64 ~w', [SlotIndex, IncomingIR]),
+      NextSlotIndex is SlotIndex + 1
+    },
+    [Line],
+    plawk_final_state_phi_lines(Rest, HasBreak, NextSlotIndex).
 
 plawk_scalar_rule_controls(Rules, Controls) :-
     findall(Control,
         ( member(rule(_Pattern, Actions), Rules),
-          plawk_split_terminal_next(Actions, _BodyActions, Control)
+          plawk_split_terminal_control(Actions, _BodyActions, Control)
         ),
         Controls).
 
@@ -381,7 +486,7 @@ plawk_mixed_assoc_count_plan(Rules, PrintFields, assoc_plan(Tables, [])) :-
 plawk_mixed_planned_rules([], _AssocPlan, _Index) -->
     [].
 plawk_mixed_planned_rules([rule(Pattern, Actions) | Rest], assoc_plan(Tables, Actions0), Index) -->
-    { plawk_split_terminal_next(Actions, BodyActions, Control),
+    { plawk_split_terminal_control(Actions, BodyActions, Control),
       plawk_mixed_rule_actions(BodyActions, ScalarActions, AssocSpecs),
       ( ScalarActions == [], AssocSpecs == [], Control == fallthrough
       -> HasActions = false,
@@ -501,7 +606,7 @@ plawk_mixed_scalar_rule_input_phi_lines([_Slot | Rest], RuleIndex, Controls, Slo
       plawk_scalar_rule_input_value(PrevRuleIndex, SlotIndex, PrevFalseValue),
       format(atom(FalseIncoming), '[~w, %rule_~w_match]',
           [PrevFalseValue, PrevRuleIndex]),
-      (   nth0(PrevRuleIndex, Controls, terminal_next)
+      (   plawk_terminal_control_skips_next_rule(Controls, PrevRuleIndex)
       ->  Incomings = [FalseIncoming]
       ;   format(atom(ApplyIncoming), '[%rule_~w_slot_~w, %rule_~w_done]',
               [PrevRuleIndex, SlotIndex, PrevRuleIndex]),
@@ -529,7 +634,9 @@ plawk_mixed_scalar_next_phi_lines([_Slot | Rest], RuleCount, Controls, Index) --
           [FalseValue, LastRuleIndex]),
       findall(ApplyIncoming,
           ( between(0, LastRuleIndex, RuleIndex),
-            ( RuleIndex =:= LastRuleIndex
+            ( ( RuleIndex =:= LastRuleIndex,
+                \+ nth0(RuleIndex, Controls, terminal_break)
+              )
             ; nth0(RuleIndex, Controls, terminal_next)
             ),
             format(atom(ApplyIncoming), '[%rule_~w_slot_~w, %rule_~w_done]',
@@ -566,13 +673,16 @@ plawk_assoc_runtime_count_plan(
     sort(ArrayNames0, Tables),
     phrase(plawk_assoc_planned_rules(RuleSpecs, Tables, 0), PlannedRules).
 
+plawk_assoc_rule_controls(assoc_plan(_Tables, Rules), Controls) :-
+    findall(Control, member(assoc_rule(_Index, _Pattern, _Actions, Control), Rules), Controls).
+
 plawk_assoc_rule_action_specs(rule(Pattern, Actions), rule(Pattern, ActionSpecs, Control)) :-
-    plawk_split_terminal_next(Actions, BodyActions, Control),
+    plawk_split_terminal_control(Actions, BodyActions, Control),
     ( BodyActions == []
     -> ActionSpecs = []
     ;  maplist(plawk_assoc_increment_action, BodyActions, ActionSpecs)
     ),
-    ( ActionSpecs \== [] ; Control == terminal_next ).
+    ( ActionSpecs \== [] ; memberchk(Control, [terminal_next, terminal_break]) ).
 
 plawk_assoc_increment_action(inc_assoc(var(ArrayName), field(KeyIndex)), ArrayName-KeyIndex) :-
     KeyIndex > 0.
@@ -939,7 +1049,7 @@ plawk_mixed_end_print_lines([var(Name) | Rest], ScalarPlan, AssocPlan, OutputSep
           '  %end_i64_fmt_~w = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_i64, i32 0, i32 0',
           [PrintIndex]),
       format(atom(PrintCall),
-          '  %printed_end_i64_~w = call i32 (i8*, ...) @printf(i8* %end_i64_fmt_~w, i64 %slot_~w)',
+          '  %printed_end_i64_~w = call i32 (i8*, ...) @printf(i8* %end_i64_fmt_~w, i64 %final_slot_~w)',
           [PrintIndex, PrintIndex, SlotIndex]),
       NextPrintIndex is PrintIndex + 1
     },
@@ -996,7 +1106,7 @@ plawk_scalar_planned_rules(Rules, PlannedRules, Controls) :-
 plawk_scalar_planned_rule_lines([], _Index) -->
     [].
 plawk_scalar_planned_rule_lines([rule(Pattern, Actions) | Rest], Index) -->
-    { plawk_split_terminal_next(Actions, BodyActions, Control),
+    { plawk_split_terminal_control(Actions, BodyActions, Control),
       NextIndex is Index + 1 },
     [scalar_rule(Index, Pattern, BodyActions, Control)],
     plawk_scalar_planned_rule_lines(Rest, NextIndex).
@@ -1054,7 +1164,7 @@ plawk_scalar_rule_input_phi_lines([_Name | Rest], RuleIndex, Controls, SlotIndex
       plawk_scalar_rule_input_value(PrevRuleIndex, SlotIndex, PrevFalseValue),
       format(atom(FalseIncoming), '[~w, %rule_~w_match]',
           [PrevFalseValue, PrevRuleIndex]),
-      (   nth0(PrevRuleIndex, Controls, terminal_next)
+      (   plawk_terminal_control_skips_next_rule(Controls, PrevRuleIndex)
       ->  Incomings = [FalseIncoming]
       ;   format(atom(ApplyIncoming), '[%rule_~w_slot_~w, %rule_~w_apply]',
               [PrevRuleIndex, SlotIndex, PrevRuleIndex]),
@@ -1067,6 +1177,10 @@ plawk_scalar_rule_input_phi_lines([_Name | Rest], RuleIndex, Controls, SlotIndex
     },
     [Line],
     plawk_scalar_rule_input_phi_lines(Rest, RuleIndex, Controls, NextSlotIndex).
+
+plawk_terminal_control_skips_next_rule(Controls, RuleIndex) :-
+    nth0(RuleIndex, Controls, Control),
+    memberchk(Control, [terminal_next, terminal_break]).
 
 plawk_scalar_rule_input_value(0, SlotIndex, Value) :-
     !,
@@ -1175,7 +1289,9 @@ plawk_scalar_next_phi_lines([_Slot | Rest], RuleCount, Controls, Index) -->
           [FalseValue, LastRuleIndex]),
       findall(ApplyIncoming,
           ( between(0, LastRuleIndex, RuleIndex),
-            ( RuleIndex =:= LastRuleIndex
+            ( ( RuleIndex =:= LastRuleIndex,
+                \+ nth0(RuleIndex, Controls, terminal_break)
+              )
             ; nth0(RuleIndex, Controls, terminal_next)
             ),
             format(atom(ApplyIncoming), '[%rule_~w_slot_~w, %rule_~w_apply]',
@@ -1204,7 +1320,7 @@ plawk_scalar_end_print_lines([var(Name) | Rest], StatePlan, OutputSeparator, Pri
           '  %end_i64_fmt_~w = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_i64, i32 0, i32 0',
           [PrintIndex]),
       format(atom(PrintCall),
-          '  %printed_end_i64_~w = call i32 (i8*, ...) @printf(i8* %end_i64_fmt_~w, i64 %slot_~w)',
+          '  %printed_end_i64_~w = call i32 (i8*, ...) @printf(i8* %end_i64_fmt_~w, i64 %final_slot_~w)',
           [PrintIndex, PrintIndex, SlotIndex]),
       NextPrintIndex is PrintIndex + 1
     },

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -22,6 +22,7 @@
 %      { count++ } END { print "count", count }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %      $1 == "DEBUG" { skipped++; next } { total++ } END { print total, skipped }
+%      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
 %
 %  The AST is deliberately small and explicit so later syntax can extend it
 %  without changing the native codegen contract.
@@ -219,6 +220,9 @@ action(Action) -->
     next_action(Action),
     !.
 action(Action) -->
+    break_action(Action),
+    !.
+action(Action) -->
     add_assign_action(Action),
     !.
 action(Action) -->
@@ -241,6 +245,9 @@ increment_action(inc(var(Name))) -->
 
 next_action(next) -->
     "next".
+
+break_action(break) -->
+    "break".
 
 add_assign_action(add(var(Name), Delta)) -->
     identifier(Name),

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -123,6 +123,41 @@ test(parses_nonterminal_next_rule) :-
          rule(always, [inc(var(total))])],
         [end([print([var(total), var(skipped)])])])).
 
+test(parses_terminal_break_scalar_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { hits++; break } { total++ } END { print hits, total }\n", Program),
+    assertion(Program == program([],
+        [rule(field_eq(1, "ERROR"), [inc(var(hits)), break]),
+         rule(always, [inc(var(total))])],
+        [end([print([var(hits), var(total)])])])).
+
+test(parses_terminal_break_assoc_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { seen[$2]++; break } { counts[$1]++ } END { print seen[\"disk\"], counts[\"ERROR\"], counts[\"WARN\"] }\n", Program),
+    assertion(Program == program([],
+        [rule(field_eq(1, "ERROR"), [inc_assoc(var(seen), field(2)), break]),
+         rule(always, [inc_assoc(var(counts), field(1))])],
+        [end([print([
+            assoc(var(seen), string("disk")),
+            assoc(var(counts), string("ERROR")),
+            assoc(var(counts), string("WARN"))
+        ])])])).
+
+test(parses_terminal_break_mixed_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { hits++; seen[$2]++; break } { total++; counts[$1]++ } END { print hits, total, seen[\"disk\"], counts[\"ERROR\"], counts[\"WARN\"] }\n", Program),
+    assertion(Program == program([],
+        [rule(field_eq(1, "ERROR"), [inc(var(hits)), inc_assoc(var(seen), field(2)), break]),
+         rule(always, [inc(var(total)), inc_assoc(var(counts), field(1))])],
+        [end([print([
+            var(hits), var(total), assoc(var(seen), string("disk")),
+            assoc(var(counts), string("ERROR")), assoc(var(counts), string("WARN"))
+        ])])])).
+
+test(parses_nonterminal_break_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { break; hits++ } { total++ } END { print hits, total }\n", Program),
+    assertion(Program == program([],
+        [rule(field_eq(1, "ERROR"), [break, inc(var(hits))]),
+         rule(always, [inc(var(total))])],
+        [end([print([var(hits), var(total)])])])).
+
 test(parses_field_eq_scalar_add_assign_end_print_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { bytes += length($0); hits += 2 } END { print bytes, hits }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
@@ -320,6 +355,26 @@ test(surface_terminal_next_only_skips_remaining_mixed_rules) :-
     run_surface_print_smoke("$1 == \"DEBUG\" { next } { total++; counts[$1]++ } END { print total, counts[\"DEBUG\"], counts[\"ERROR\"] }\n",
         "INFO boot ok\nDEBUG trace one\nERROR disk full\nDEBUG trace two\n",
         "2 0 1\n").
+
+test(surface_terminal_break_stops_scalar_rule_chain_and_runs_end) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { hits++; break } { total++ } END { print hits, total }\n",
+        "INFO boot ok\nWARN cpu hot\nERROR disk full\nERROR net down\n",
+        "1 2\n").
+
+test(surface_terminal_break_stops_assoc_rule_chain_and_runs_end) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { seen[$2]++; break } { counts[$1]++ } END { print seen[\"disk\"], counts[\"ERROR\"], counts[\"WARN\"] }\n",
+        "WARN cpu hot\nERROR disk full\nERROR net down\n",
+        "1 0 1\n").
+
+test(surface_terminal_break_stops_mixed_rule_chain_and_runs_end) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { hits++; seen[$2]++; break } { total++; counts[$1]++ } END { print hits, total, seen[\"disk\"], counts[\"ERROR\"], counts[\"WARN\"] }\n",
+        "WARN cpu hot\nERROR disk full\nERROR net down\n",
+        "1 1 1 0 1\n").
+
+test(surface_terminal_break_as_last_rule_keeps_continue_phi_valid) :-
+    run_surface_print_smoke("{ total++ } $1 == \"ERROR\" { hits++; break } END { print hits, total }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\n",
+        "1 2\n").
 
 test(surface_field_eq_scalar_add_assign_accumulates_constants_and_lengths) :-
     run_surface_print_smoke("$1 == \"ERROR\" { bytes += length($0); hits += 2 } END { print bytes, hits }\n",
@@ -576,6 +631,46 @@ test(surface_nonterminal_next_assoc_rejected_by_native_codegen, [fail]) :-
 
 test(surface_nonterminal_next_mixed_rejected_by_native_codegen, [fail]) :-
     plawk_parse_string("$1 == \"DEBUG\" { next; skipped++; by_kind[$2]++ } { total++; counts[$1]++ } END { print total, skipped, by_kind[\"trace\"], counts[\"ERROR\"] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
+
+test(surface_terminal_break_uses_close_path_and_final_state_phi) :-
+    plawk_parse_string("$1 == \"ERROR\" { hits++; break } { total++ } END { print hits, total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'break_close_stream:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%break_slot_0 = phi i64 [%rule_0_slot_0, %rule_0_apply]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%final_slot_0 = phi i64 [%slot_0, %close_stream], [%break_slot_0, %break_close_stream]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i64 %final_slot_0'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_assoc_terminal_break_uses_native_close_path) :-
+    plawk_parse_string("$1 == \"ERROR\" { seen[$2]++; break } { counts[$1]++ } END { print seen[\"disk\"], counts[\"ERROR\"] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'break_close_stream:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'assoc_rule_0_apply:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'br label %break_close_stream'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_mixed_terminal_break_uses_close_path_and_final_state_phi) :-
+    plawk_parse_string("$1 == \"ERROR\" { hits++; seen[$2]++; break } { total++; counts[$1]++ } END { print hits, total, seen[\"disk\"], counts[\"ERROR\"] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'break_close_stream:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%break_slot_0 = phi i64 [%rule_0_slot_0, %rule_0_done]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%final_slot_0 = phi i64 [%slot_0, %close_stream], [%break_slot_0, %break_close_stream]'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_nonterminal_break_scalar_rejected_by_native_codegen, [fail]) :-
+    plawk_parse_string("$1 == \"ERROR\" { break; hits++ } { total++ } END { print hits, total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
+
+test(surface_nonterminal_break_assoc_rejected_by_native_codegen, [fail]) :-
+    plawk_parse_string("$1 == \"ERROR\" { break; seen[$2]++ } { counts[$1]++ } END { print seen[\"disk\"], counts[\"ERROR\"] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
+
+test(surface_nonterminal_break_mixed_rejected_by_native_codegen, [fail]) :-
+    plawk_parse_string("$1 == \"ERROR\" { break; hits++; seen[$2]++ } { total++; counts[$1]++ } END { print hits, total, seen[\"disk\"], counts[\"ERROR\"] }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
 
 test(surface_end_string_literals_use_indexed_globals) :-


### PR DESCRIPTION
## Summary
- parse terminal `break` in PLAWK rule bodies
- lower terminal `break` in scalar, assoc-only, and mixed native rule chains through a stream-close path
- preserve scalar/mixed END state with final-state phis fed by EOF or break
- add compiled smokes and generated-IR checks for terminal and non-terminal break boundaries
- document terminal-only `next`/`break` loop-control support

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`