### PR TITLE
Support PLAWK scalar assignment

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -268,7 +268,11 @@ Scalar counters lower through an explicit codegen state plan that keeps
 source-level state recognition separate from LLVM slot numbering. The same
 native slots now support `+=` with integer constants and field lengths, so
 programs such as `$1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }`
-stay in the compiled stream loop. Native rule chains also support terminal
+stay in the compiled stream loop. Plain scalar assignment to integer literals or
+field lengths uses the same native slot path and is folded in source order with
+later `++`/`+=` updates, so programs such as `$1 == "ERROR" { last_len =
+length($0); hits++ } END { print hits, last_len }` also stay native. Native rule
+chains also support terminal
 `next` by branching directly to the stream-loop continuation; scalar and mixed
 chains add the early-exit rule's scalar values to the loop phi inputs, while
 assoc-only chains update tables before the continuation branch. Terminal

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -89,6 +89,10 @@ compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple
 guarded rules can update shared scalar slots before an `END` print. Scalar slots
 also support native `+=` with integer constants and field lengths, e.g.
 `$1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }`.
+Plain scalar assignment uses the same native slot path and preserves source
+order with later updates, e.g. `$1 == "ERROR" { last_len = length($0); hits++ }
+END { print hits, last_len }`. The current assignment expression subset is
+integer literals and `length($N)`.
 Terminal `next` is supported in native rule chains, so `$1 == "DEBUG" {
 skipped++; next } { total++ } END { print total, skipped }` skips the later
 rule for matching records. Terminal `break` is supported in the same native

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -233,6 +233,16 @@ $1 == "ERROR" { bytes += length($0); hits += 2 }
 END { print bytes, hits }
 ```
 
+They can also be assigned in the native loop. Assignment preserves source order
+with later updates:
+
+```awk
+$1 == "ERROR" { last_len = length($0); hits++ }
+END { print hits, last_len }
+```
+
+The current assignment expression subset is integer literals and `length($N)`.
+
 A terminal `next` skips the remaining rules for the current record:
 
 ```awk

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -34,6 +34,7 @@
 %      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
+%      $1 == "ERROR" { last_len = length($0); hits++ } END { print hits, last_len }
 %
 %  The surrounding runtime still comes from write_wam_llvm_project/3. This
 %  function emits the target-specific native main that streams the file, lowers
@@ -504,13 +505,13 @@ plawk_mixed_planned_rules([rule(Pattern, Actions) | Rest], assoc_plan(Tables, Ac
     plawk_mixed_planned_rules(Rest, assoc_plan(Tables, Actions0), NextIndex).
 
 plawk_mixed_rule_actions(Actions, ScalarActions, AssocSpecs) :-
-    maplist(plawk_mixed_increment_action, Actions, TypedActions),
+    maplist(plawk_mixed_update_action, Actions, TypedActions),
     findall(Action, member(scalar(Action), TypedActions), ScalarActions),
     findall(Spec, member(assoc(Spec), TypedActions), AssocSpecs).
 
-plawk_mixed_increment_action(Action, scalar(Action)) :-
-    plawk_scalar_action_delta(Action, _Name, _Delta).
-plawk_mixed_increment_action(inc_assoc(var(ArrayName), field(KeyIndex)), assoc(ArrayName-KeyIndex)) :-
+plawk_mixed_update_action(Action, scalar(Action)) :-
+    plawk_scalar_action_update(Action, _Name, _Operation).
+plawk_mixed_update_action(inc_assoc(var(ArrayName), field(KeyIndex)), assoc(ArrayName-KeyIndex)) :-
     KeyIndex > 0.
 
 plawk_mixed_rule_chain_ir(mixed_plan(ScalarPlan, AssocPlan, Rules), FieldSeparator, GlobalIR, ChainIR, RuleCount) :-
@@ -1218,62 +1219,78 @@ plawk_scalar_match_update_ir(StatePlan, Actions, FieldSeparator, RuleIndex, IR) 
 plawk_scalar_match_update_lines([], _Actions, _FieldSeparator, _RuleIndex, _) -->
     [].
 plawk_scalar_match_update_lines([scalar_counter(Name) | Rest], Actions, FieldSeparator, RuleIndex, SlotIndex) -->
-    { plawk_scalar_action_deltas(Name, Actions, Deltas),
-      plawk_scalar_const_delta_sum(Deltas, ConstDelta),
+    { plawk_scalar_action_operations(Name, Actions, Operations),
       plawk_scalar_rule_slot_input(RuleIndex, SlotIndex, InputValue),
-      format(atom(BaseValue), '%rule_~w_slot_~w_const', [RuleIndex, SlotIndex]),
-      format(atom(ConstLine),
-          '  ~w = add i64 ~w, ~w',
-          [BaseValue, InputValue, ConstDelta]),
-      phrase(plawk_scalar_dynamic_delta_lines(Deltas, FieldSeparator, RuleIndex,
-          SlotIndex, 0, BaseValue, OutputValue), DynamicLines),
+      phrase(plawk_scalar_update_operation_lines(Operations, FieldSeparator, RuleIndex,
+          SlotIndex, 0, InputValue, OutputValue), OperationLines),
       format(atom(Line),
           '  %rule_~w_slot_~w = add i64 ~w, 0',
           [RuleIndex, SlotIndex, OutputValue]),
       NextIndex is SlotIndex + 1
     },
-    [ConstLine],
-    DynamicLines,
+    OperationLines,
     [Line],
     plawk_scalar_match_update_lines(Rest, Actions, FieldSeparator, RuleIndex, NextIndex).
 
 plawk_scalar_update_action(Action) :-
-    plawk_scalar_action_delta(Action, _Name, _Delta).
+    plawk_scalar_action_update(Action, _Name, _Operation).
 
 plawk_scalar_update_action_name(Action, Name) :-
-    plawk_scalar_action_delta(Action, Name, _Delta).
+    plawk_scalar_action_update(Action, Name, _Operation).
 
-plawk_scalar_action_delta(inc(var(Name)), Name, const(1)).
-plawk_scalar_action_delta(add(var(Name), int(Value)), Name, const(Value)) :-
+plawk_scalar_action_update(inc(var(Name)), Name, add(const(1))).
+plawk_scalar_action_update(add(var(Name), int(Value)), Name, add(const(Value))) :-
     integer(Value),
     Value >= 0.
-plawk_scalar_action_delta(add(var(Name), length(field(FieldIndex))), Name, length(FieldIndex)) :-
+plawk_scalar_action_update(add(var(Name), length(field(FieldIndex))), Name, add(length(FieldIndex))) :-
+    FieldIndex >= 0.
+plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) :-
+    integer(Value),
+    Value >= 0.
+plawk_scalar_action_update(set(var(Name), length(field(FieldIndex))), Name, set(length(FieldIndex))) :-
     FieldIndex >= 0.
 
-plawk_scalar_action_deltas(Name, Actions, Deltas) :-
-    findall(Delta,
+plawk_scalar_action_operations(Name, Actions, Operations) :-
+    findall(Operation,
         ( member(Action, Actions),
-          plawk_scalar_action_delta(Action, Name, Delta)
+          plawk_scalar_action_update(Action, Name, Operation)
         ),
-        Deltas).
+        Operations).
 
-plawk_scalar_const_delta_sum(Deltas, Sum) :-
-    findall(Value, member(const(Value), Deltas), Values),
-    sum_list(Values, Sum).
-
-plawk_scalar_dynamic_delta_lines([], _FieldSeparator, _RuleIndex, _SlotIndex, _DeltaIndex, Value, Value) -->
+plawk_scalar_update_operation_lines([], _FieldSeparator, _RuleIndex, _SlotIndex, _OpIndex, Value, Value) -->
     [].
-plawk_scalar_dynamic_delta_lines([const(_Value) | Rest], FieldSeparator, RuleIndex, SlotIndex, DeltaIndex, InputValue, OutputValue) -->
-    plawk_scalar_dynamic_delta_lines(Rest, FieldSeparator, RuleIndex, SlotIndex, DeltaIndex, InputValue, OutputValue).
-plawk_scalar_dynamic_delta_lines([length(FieldIndex) | Rest], FieldSeparator, RuleIndex, SlotIndex, DeltaIndex, InputValue, OutputValue) -->
-    { format(atom(LengthBase), 'plawk_rule_~w_slot_~w_delta_~w_len', [RuleIndex, SlotIndex, DeltaIndex]),
+plawk_scalar_update_operation_lines([add(const(Value)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, InputValue, OutputValue) -->
+    { format(atom(NextValue), '%rule_~w_slot_~w_op_~w', [RuleIndex, SlotIndex, OpIndex]),
+      format(atom(AddLine), '  ~w = add i64 ~w, ~w', [NextValue, InputValue, Value]),
+      NextOpIndex is OpIndex + 1
+    },
+    [AddLine],
+    plawk_scalar_update_operation_lines(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
+plawk_scalar_update_operation_lines([add(length(FieldIndex)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, InputValue, OutputValue) -->
+    { format(atom(LengthBase), 'plawk_rule_~w_slot_~w_op_~w_len', [RuleIndex, SlotIndex, OpIndex]),
       llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, LengthCall),
-      format(atom(NextValue), '%rule_~w_slot_~w_delta_~w', [RuleIndex, SlotIndex, DeltaIndex]),
+      format(atom(NextValue), '%rule_~w_slot_~w_op_~w', [RuleIndex, SlotIndex, OpIndex]),
       format(atom(AddLine), '  ~w = add i64 ~w, %~w', [NextValue, InputValue, LengthBase]),
-      NextDeltaIndex is DeltaIndex + 1
+      NextOpIndex is OpIndex + 1
     },
     [LengthCall, AddLine],
-    plawk_scalar_dynamic_delta_lines(Rest, FieldSeparator, RuleIndex, SlotIndex, NextDeltaIndex, NextValue, OutputValue).
+    plawk_scalar_update_operation_lines(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
+plawk_scalar_update_operation_lines([set(const(Value)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, _InputValue, OutputValue) -->
+    { format(atom(NextValue), '%rule_~w_slot_~w_op_~w', [RuleIndex, SlotIndex, OpIndex]),
+      format(atom(SetLine), '  ~w = add i64 0, ~w', [NextValue, Value]),
+      NextOpIndex is OpIndex + 1
+    },
+    [SetLine],
+    plawk_scalar_update_operation_lines(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
+plawk_scalar_update_operation_lines([set(length(FieldIndex)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, _InputValue, OutputValue) -->
+    { format(atom(LengthBase), 'plawk_rule_~w_slot_~w_op_~w_len', [RuleIndex, SlotIndex, OpIndex]),
+      llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, LengthCall),
+      format(atom(NextValue), '%rule_~w_slot_~w_op_~w', [RuleIndex, SlotIndex, OpIndex]),
+      format(atom(SetLine), '  ~w = add i64 %~w, 0', [NextValue, LengthBase]),
+      NextOpIndex is OpIndex + 1
+    },
+    [LengthCall, SetLine],
+    plawk_scalar_update_operation_lines(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
 
 plawk_scalar_next_phi_ir(StatePlan, RuleCount, Controls, IR) :-
     plawk_state_plan_slots(StatePlan, Slots),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -23,6 +23,7 @@
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %      $1 == "DEBUG" { skipped++; next } { total++ } END { print total, skipped }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
+%      $1 == "ERROR" { last_len = length($0); hits++ } END { print hits, last_len }
 %
 %  The AST is deliberately small and explicit so later syntax can extend it
 %  without changing the native codegen contract.
@@ -226,6 +227,9 @@ action(Action) -->
     add_assign_action(Action),
     !.
 action(Action) -->
+    assignment_action(Action),
+    !.
+action(Action) -->
     increment_action(Action),
     !.
 
@@ -255,6 +259,16 @@ add_assign_action(add(var(Name), Delta)) -->
     "+=",
     ws,
     scalar_delta_expr(Delta).
+
+assignment_action(set(var(Name), Value)) -->
+    identifier(Name),
+    ws,
+    "=",
+    ws,
+    scalar_value_expr(Value).
+
+scalar_value_expr(Value) -->
+    scalar_delta_expr(Value).
 
 scalar_delta_expr(int(Value)) -->
     integer_codes(ValueCodes),

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -169,6 +169,18 @@ test(parses_always_scalar_add_assign_end_print_rule) :-
     assertion(Program == program([], [rule(always, [add(var(total), int(3))])],
         [end([print([var(total)])])])).
 
+test(parses_scalar_assignment_end_print_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { last_len = length($0); hits++ } END { print hits, last_len }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [set(var(last_len), length(field(0))), inc(var(hits))])],
+        [end([print([var(hits), var(last_len)])])])).
+
+test(parses_scalar_integer_assignment_end_print_rule) :-
+    plawk_parse_string("{ current = 7; current += 2 } END { print current }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [set(var(current), int(7)), add(var(current), int(2))])],
+        [end([print([var(current)])])])).
+
 test(parses_assoc_count_end_print_rule) :-
     plawk_parse_string("{ counts[$1]++ } END { print counts[\"ERROR\"], counts[\"WARN\"] }\n", Program),
     assertion(Program == program([], [rule(always, [inc_assoc(var(counts), field(1))])],
@@ -391,6 +403,26 @@ test(surface_mixed_inc_and_add_assign_accumulates_same_slot) :-
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "6\n").
 
+test(surface_scalar_assignment_tracks_last_matching_record) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { last_len = length($0); hits++ } END { print hits, last_len }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR network down\n",
+        "2 18\n").
+
+test(surface_scalar_assignment_preserves_source_order) :-
+    run_surface_print_smoke("{ current = 7; current++; current += 2 } END { print current }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "10\n").
+
+test(surface_scalar_assignment_overwrites_prior_updates) :-
+    run_surface_print_smoke("{ current++; current = 7 } END { print current }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "7\n").
+
+test(surface_mixed_scalar_assignment_and_assoc_counts) :-
+    run_surface_print_smoke("{ last_len = length($0); counts[$1]++ } END { print last_len, counts[\"ERROR\"] }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "14 2\n").
+
 test(surface_scalar_end_prints_string_literals) :-
     run_surface_print_smoke("{ total++ } END { print \"total\", total }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -573,10 +605,20 @@ test(surface_scalar_add_assign_uses_native_state_and_field_length) :-
     plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
     assertion(once(sub_atom(DriverIR, _, _, _, 'lowered_match:'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%slot_0 = phi i64'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_slot_0_const = add i64 %slot_0, 0'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_rule_0_slot_0_delta_0_len = call i64 @wam_atom_field_length_value(%Value %line, i64 2, i8 58)'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_slot_1_const = add i64 %slot_1, 2'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_rule_0_slot_0_op_0_len = call i64 @wam_atom_field_length_value(%Value %line, i64 2, i8 58)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_slot_0_op_0 = add i64 %slot_0, %plawk_rule_0_slot_0_op_0_len'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_slot_1_op_0 = add i64 %slot_1, 2'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%next_slot_0 = phi i64'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_scalar_assignment_uses_ordered_native_state_ops) :-
+    plawk_parse_string("$1 == \"ERROR\" { last_len = length($0); last_len += 2 } END { print last_len }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_rule_0_slot_0_op_0_len = call i64 @wam_atom_field_length_value(%Value %line, i64 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_slot_0_op_0 = add i64 %plawk_rule_0_slot_0_op_0_len, 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_slot_0_op_1 = add i64 %rule_0_slot_0_op_0, 2'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'i64 %final_slot_0'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 


### PR DESCRIPTION
## Summary
- parse scalar assignment actions in the PLAWK surface
- lower scalar assignment to ordered native slot updates for integer literals and `length($N)`
- preserve source order across `=`, `++`, and `+=` so assignment can overwrite or feed later updates
- cover scalar and mixed scalar/associative assignment smokes plus generated-IR checks
- document the current native assignment boundary

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`