### PR TITLE
Support PLAWK scalar if else

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -271,8 +271,12 @@ programs such as `$1 == "ERROR" { bytes += length($0); hits += 2 } END { print b
 stay in the compiled stream loop. Plain scalar assignment to integer literals or
 field lengths uses the same native slot path and is folded in source order with
 later `++`/`+=` updates, so programs such as `$1 == "ERROR" { last_len =
-length($0); hits++ } END { print hits, last_len }` also stay native. Native rule
-chains also support terminal
+length($0); hits++ } END { print hits, last_len }` also stay native. The first
+native `if/else` action slice lowers field-equality conditions around scalar
+slot updates, emits per-slot branch phis, and joins scalar rules through an
+explicit `rule_N_done` label so downstream loop phis have stable predecessors.
+Branch-local associative updates, `print`, `next`, and `break` still need a
+broader intra-rule CFG. Native rule chains also support terminal
 `next` by branching directly to the stream-loop continuation; scalar and mixed
 chains add the early-exit rule's scalar values to the loop phi inputs, while
 assoc-only chains update tables before the continuation branch. Terminal

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -93,6 +93,11 @@ Plain scalar assignment uses the same native slot path and preserves source
 order with later updates, e.g. `$1 == "ERROR" { last_len = length($0); hits++ }
 END { print hits, last_len }`. The current assignment expression subset is
 integer literals and `length($N)`.
+Scalar slot updates can also sit behind native `if/else` guards, e.g.
+`{ if ($1 == "ERROR") { errors++; last_len = length($0) } else { non_errors++ } }
+END { print errors, non_errors, last_len }`. The first branch slice supports
+field-equality conditions and scalar update actions inside branches; branch-local
+`print`, associative updates, `next`, and `break` remain outside this boundary.
 Terminal `next` is supported in native rule chains, so `$1 == "DEBUG" {
 skipped++; next } { total++ } END { print total, skipped }` skips the later
 rule for matching records. Terminal `break` is supported in the same native

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -243,6 +243,20 @@ END { print hits, last_len }
 
 The current assignment expression subset is integer literals and `length($N)`.
 
+The first `if/else` surface lowers scalar updates behind field-equality guards:
+
+```awk
+{
+  total++
+  if ($1 == "ERROR") { errors++; last_len = length($0) }
+  else { non_errors++ }
+}
+END { print total, errors, non_errors, last_len }
+```
+
+For now, branch bodies support scalar updates only; branch-local `print`,
+associative updates, `next`, and `break` are rejected by native codegen.
+
 A terminal `next` skips the remaining rules for the current record:
 
 ```awk

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -35,6 +35,7 @@
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
 %      $1 == "ERROR" { last_len = length($0); hits++ } END { print hits, last_len }
+%      { if ($1 == "ERROR") { errors++ } else { warnings++ } } END { print errors, warnings }
 %
 %  The surrounding runtime still comes from write_wam_llvm_project/3. This
 %  function emits the target-specific native main that streams the file, lowers
@@ -126,7 +127,7 @@ plawk_program_native_driver_ir(
     plawk_state_loop_phi_ir(StatePlan, LoopPhiIR),
     plawk_scalar_rule_controls(Rules, ScalarRuleControls),
     plawk_scalar_next_phi_ir(StatePlan, RuleCount, ScalarRuleControls, NextPhiIR),
-    plawk_break_close_ir(StatePlan, RuleCount, ScalarRuleControls, apply,
+    plawk_break_close_ir(StatePlan, RuleCount, ScalarRuleControls, done,
         BreakCloseIR, FinalStatePhiIR),
     plawk_scalar_end_print_ir(PrintFields, StatePlan, OutputSeparator, EndPrintIR),
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
@@ -326,16 +327,24 @@ plawk_state_slot_index(StatePlan, Slot, Index) :-
 plawk_split_terminal_control(Actions, BodyActions, terminal_next) :-
     append(BodyActions, [next], Actions),
     !,
-    \+ member(next, BodyActions),
-    \+ member(break, BodyActions).
+    \+ plawk_actions_have_control(BodyActions).
 plawk_split_terminal_control(Actions, BodyActions, terminal_break) :-
     append(BodyActions, [break], Actions),
     !,
-    \+ member(next, BodyActions),
-    \+ member(break, BodyActions).
+    \+ plawk_actions_have_control(BodyActions).
 plawk_split_terminal_control(Actions, Actions, fallthrough) :-
-    \+ member(next, Actions),
-    \+ member(break, Actions).
+    \+ plawk_actions_have_control(Actions).
+
+plawk_actions_have_control(Actions) :-
+    member(Action, Actions),
+    plawk_action_has_control(Action).
+
+plawk_action_has_control(next).
+plawk_action_has_control(break).
+plawk_action_has_control(if(_Pattern, ThenActions, ElseActions)) :-
+    ( plawk_actions_have_control(ThenActions)
+    ; plawk_actions_have_control(ElseActions)
+    ).
 
 plawk_rule_target(fallthrough, NextLabel, NextLabel).
 plawk_rule_target(terminal_next, _NextLabel, continue_loop).
@@ -511,8 +520,18 @@ plawk_mixed_rule_actions(Actions, ScalarActions, AssocSpecs) :-
 
 plawk_mixed_update_action(Action, scalar(Action)) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
+plawk_mixed_update_action(Action, scalar(Action)) :-
+    plawk_scalar_conditional_action(Action).
 plawk_mixed_update_action(inc_assoc(var(ArrayName), field(KeyIndex)), assoc(ArrayName-KeyIndex)) :-
     KeyIndex > 0.
+
+plawk_scalar_conditional_action(if(_Pattern, ThenActions, ElseActions)) :-
+    append(ThenActions, ElseActions, Actions),
+    Actions \== [],
+    maplist(plawk_scalar_plain_update_action, Actions).
+
+plawk_scalar_plain_update_action(Action) :-
+    plawk_scalar_action_update(Action, _Name, _Operation).
 
 plawk_mixed_rule_chain_ir(mixed_plan(ScalarPlan, AssocPlan, Rules), FieldSeparator, GlobalIR, ChainIR, RuleCount) :-
     length(Rules, RuleCount),
@@ -541,7 +560,8 @@ plawk_mixed_rule_chain_lines([mixed_rule(Index, Pattern, ScalarActions, AssocAct
       plawk_mixed_scalar_rule_input_phi_ir(ScalarPlan, Index, Controls, InputPhiIR),
       plawk_mixed_rule_guard_ir(Pattern, Index, RuleLabel, ApplyLabel,
           NextLabel, InputPhiIR, FieldSeparator, GuardGlobalIR-GuardIR),
-      plawk_scalar_match_update_ir(ScalarPlan, ScalarActions, FieldSeparator, Index, ScalarUpdateIR),
+      plawk_scalar_match_update_ir(ScalarPlan, ScalarActions, FieldSeparator, Index,
+          ScalarUpdateGlobalIR-ScalarUpdateIR),
       plawk_mixed_assoc_apply_ir(Index, AssocActions, DoneLabel, FieldSeparator, AssocApplyIR),
       ( Index =:= 0
       -> EntryIR = '  br label %rule_0_match\n\n'
@@ -558,7 +578,8 @@ plawk_mixed_rule_chain_lines([mixed_rule(Index, Pattern, ScalarActions, AssocAct
   br label %~w',
           [EntryIR, GuardIR, ApplyLabel, ScalarUpdateIR, AssocApplyIR,
            DoneLabel, RuleTargetLabel]),
-      Pair = GuardGlobalIR-RuleIR
+      format(atom(CombinedGlobalIR), '~w~n~w', [GuardGlobalIR, ScalarUpdateGlobalIR]),
+      Pair = CombinedGlobalIR-RuleIR
     },
     [Pair],
     plawk_mixed_rule_chain_lines(Rest, Controls, ScalarPlan, FieldSeparator, NextIndex).
@@ -1122,6 +1143,7 @@ plawk_scalar_rule_chain_lines([scalar_rule(Index, Pattern, Actions, Control) | R
       ),
       format(atom(RuleLabel), 'rule_~w_match', [Index]),
       format(atom(ApplyLabel), 'rule_~w_apply', [Index]),
+      format(atom(DoneLabel), 'rule_~w_done', [Index]),
       format(atom(MatchVar), 'rule_~w_is_match', [Index]),
       format(atom(GlobalBase), 'plawk_surface_rule_~w', [Index]),
       format(atom(MatchValue), '%~w', [MatchVar]),
@@ -1130,7 +1152,8 @@ plawk_scalar_rule_chain_lines([scalar_rule(Index, Pattern, Actions, Control) | R
       plawk_rule_target(Control, NextLabel, RuleTargetLabel),
       include(plawk_scalar_update_action, Actions, ScalarActions),
       plawk_scalar_rule_input_phi_ir(StatePlan, Index, Controls, InputPhiIR),
-      plawk_scalar_match_update_ir(StatePlan, ScalarActions, FieldSeparator, Index, MatchUpdateIR),
+      plawk_scalar_match_update_ir(StatePlan, ScalarActions, FieldSeparator, Index,
+          MatchUpdateGlobalIR-MatchUpdateIR),
       ( Index =:= 0
       -> EntryIR = '  br label %rule_0_match\n\n'
       ;  EntryIR = ''
@@ -1142,10 +1165,15 @@ plawk_scalar_rule_chain_lines([scalar_rule(Index, Pattern, Actions, Control) | R
 
 ~w:
 ~w
+  br label %~w
+
+~w:
   br label %~w',
           [EntryIR, RuleLabel, InputPhiIR, GuardCallIR, MatchVar,
-           ApplyLabel, NextLabel, ApplyLabel, MatchUpdateIR, RuleTargetLabel]),
-      Pair = GuardGlobalIR-BranchIR
+           ApplyLabel, NextLabel, ApplyLabel, MatchUpdateIR, DoneLabel,
+           DoneLabel, RuleTargetLabel]),
+      format(atom(CombinedGlobalIR), '~w~n~w', [GuardGlobalIR, MatchUpdateGlobalIR]),
+      Pair = CombinedGlobalIR-BranchIR
     },
     [Pair],
     plawk_scalar_rule_chain_lines(Rest, Controls, StatePlan, FieldSeparator, NextIndex).
@@ -1167,7 +1195,7 @@ plawk_scalar_rule_input_phi_lines([_Name | Rest], RuleIndex, Controls, SlotIndex
           [PrevFalseValue, PrevRuleIndex]),
       (   plawk_terminal_control_skips_next_rule(Controls, PrevRuleIndex)
       ->  Incomings = [FalseIncoming]
-      ;   format(atom(ApplyIncoming), '[%rule_~w_slot_~w, %rule_~w_apply]',
+      ;   format(atom(ApplyIncoming), '[%rule_~w_slot_~w, %rule_~w_done]',
               [PrevRuleIndex, SlotIndex, PrevRuleIndex]),
           Incomings = [FalseIncoming, ApplyIncoming]
       ),
@@ -1211,31 +1239,43 @@ plawk_scalar_loop_phi_lines([_Slot | Rest], Index) -->
     [Line],
     plawk_scalar_loop_phi_lines(Rest, NextIndex).
 
-plawk_scalar_match_update_ir(StatePlan, Actions, FieldSeparator, RuleIndex, IR) :-
+plawk_scalar_match_update_ir(StatePlan, Actions, FieldSeparator, RuleIndex, GlobalIR-IR) :-
     plawk_state_plan_slots(StatePlan, Slots),
-    phrase(plawk_scalar_match_update_lines(Slots, Actions, FieldSeparator, RuleIndex, 0), Lines),
-    atomic_list_concat(Lines, '\n', IR).
+    phrase(plawk_scalar_match_update_pairs(Slots, Actions, FieldSeparator, RuleIndex, 0), Pairs),
+    pairs_keys_values(Pairs, GlobalParts, LineParts),
+    atomic_list_concat(GlobalParts, '\n', GlobalIR),
+    atomic_list_concat(LineParts, '\n', IR).
 
-plawk_scalar_match_update_lines([], _Actions, _FieldSeparator, _RuleIndex, _) -->
+plawk_scalar_match_update_pairs([], _Actions, _FieldSeparator, _RuleIndex, _) -->
     [].
-plawk_scalar_match_update_lines([scalar_counter(Name) | Rest], Actions, FieldSeparator, RuleIndex, SlotIndex) -->
+plawk_scalar_match_update_pairs([scalar_counter(Name) | Rest], Actions, FieldSeparator, RuleIndex, SlotIndex) -->
     { plawk_scalar_action_operations(Name, Actions, Operations),
       plawk_scalar_rule_slot_input(RuleIndex, SlotIndex, InputValue),
-      phrase(plawk_scalar_update_operation_lines(Operations, FieldSeparator, RuleIndex,
-          SlotIndex, 0, InputValue, OutputValue), OperationLines),
+      phrase(plawk_scalar_update_operation_pairs(Operations, FieldSeparator, RuleIndex,
+          SlotIndex, 0, InputValue, OutputValue), OperationPairs),
+      pairs_keys_values(OperationPairs, GlobalParts, OperationLines),
+      atomic_list_concat(GlobalParts, '\n', OperationGlobalIR),
+      atomic_list_concat(OperationLines, '\n', OperationIR),
       format(atom(Line),
           '  %rule_~w_slot_~w = add i64 ~w, 0',
           [RuleIndex, SlotIndex, OutputValue]),
+      format(atom(SlotIR), '~w~n~w', [OperationIR, Line]),
       NextIndex is SlotIndex + 1
     },
-    OperationLines,
-    [Line],
-    plawk_scalar_match_update_lines(Rest, Actions, FieldSeparator, RuleIndex, NextIndex).
+    [OperationGlobalIR-SlotIR],
+    plawk_scalar_match_update_pairs(Rest, Actions, FieldSeparator, RuleIndex, NextIndex).
 
 plawk_scalar_update_action(Action) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
+plawk_scalar_update_action(Action) :-
+    plawk_scalar_conditional_action(Action).
 
 plawk_scalar_update_action_name(Action, Name) :-
+    plawk_scalar_action_update(Action, Name, _Operation).
+plawk_scalar_update_action_name(if(_Pattern, ThenActions, ElseActions), Name) :-
+    ( member(Action, ThenActions)
+    ; member(Action, ElseActions)
+    ),
     plawk_scalar_action_update(Action, Name, _Operation).
 
 plawk_scalar_action_update(inc(var(Name)), Name, add(const(1))).
@@ -1253,44 +1293,134 @@ plawk_scalar_action_update(set(var(Name), length(field(FieldIndex))), Name, set(
 plawk_scalar_action_operations(Name, Actions, Operations) :-
     findall(Operation,
         ( member(Action, Actions),
+          plawk_scalar_action_operation(Name, Action, Operation)
+        ),
+        Operations).
+
+plawk_scalar_action_operation(Name, Action, Operation) :-
+    plawk_scalar_action_update(Action, Name, Operation).
+plawk_scalar_action_operation(Name, if(Pattern, ThenActions, ElseActions),
+        if(Pattern, ThenOperations, ElseOperations)) :-
+    plawk_scalar_branch_action_operations(Name, ThenActions, ThenOperations),
+    plawk_scalar_branch_action_operations(Name, ElseActions, ElseOperations),
+    ( ThenOperations \== [] -> true ; ElseOperations \== [] ).
+
+plawk_scalar_branch_action_operations(Name, Actions, Operations) :-
+    findall(Operation,
+        ( member(Action, Actions),
           plawk_scalar_action_update(Action, Name, Operation)
         ),
         Operations).
 
-plawk_scalar_update_operation_lines([], _FieldSeparator, _RuleIndex, _SlotIndex, _OpIndex, Value, Value) -->
+plawk_scalar_update_operation_pairs([], _FieldSeparator, _RuleIndex, _SlotIndex, _OpIndex, Value, Value) -->
     [].
-plawk_scalar_update_operation_lines([add(const(Value)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, InputValue, OutputValue) -->
+plawk_scalar_update_operation_pairs([add(const(Value)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, InputValue, OutputValue) -->
     { format(atom(NextValue), '%rule_~w_slot_~w_op_~w', [RuleIndex, SlotIndex, OpIndex]),
       format(atom(AddLine), '  ~w = add i64 ~w, ~w', [NextValue, InputValue, Value]),
       NextOpIndex is OpIndex + 1
     },
-    [AddLine],
-    plawk_scalar_update_operation_lines(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
-plawk_scalar_update_operation_lines([add(length(FieldIndex)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, InputValue, OutputValue) -->
+    [''-AddLine],
+    plawk_scalar_update_operation_pairs(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
+plawk_scalar_update_operation_pairs([add(length(FieldIndex)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, InputValue, OutputValue) -->
     { format(atom(LengthBase), 'plawk_rule_~w_slot_~w_op_~w_len', [RuleIndex, SlotIndex, OpIndex]),
       llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, LengthCall),
       format(atom(NextValue), '%rule_~w_slot_~w_op_~w', [RuleIndex, SlotIndex, OpIndex]),
       format(atom(AddLine), '  ~w = add i64 ~w, %~w', [NextValue, InputValue, LengthBase]),
+      format(atom(IR), '~w~n~w', [LengthCall, AddLine]),
       NextOpIndex is OpIndex + 1
     },
-    [LengthCall, AddLine],
-    plawk_scalar_update_operation_lines(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
-plawk_scalar_update_operation_lines([set(const(Value)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, _InputValue, OutputValue) -->
+    [''-IR],
+    plawk_scalar_update_operation_pairs(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
+plawk_scalar_update_operation_pairs([set(const(Value)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, _InputValue, OutputValue) -->
     { format(atom(NextValue), '%rule_~w_slot_~w_op_~w', [RuleIndex, SlotIndex, OpIndex]),
       format(atom(SetLine), '  ~w = add i64 0, ~w', [NextValue, Value]),
       NextOpIndex is OpIndex + 1
     },
-    [SetLine],
-    plawk_scalar_update_operation_lines(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
-plawk_scalar_update_operation_lines([set(length(FieldIndex)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, _InputValue, OutputValue) -->
+    [''-SetLine],
+    plawk_scalar_update_operation_pairs(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
+plawk_scalar_update_operation_pairs([set(length(FieldIndex)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, _InputValue, OutputValue) -->
     { format(atom(LengthBase), 'plawk_rule_~w_slot_~w_op_~w_len', [RuleIndex, SlotIndex, OpIndex]),
       llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, LengthCall),
       format(atom(NextValue), '%rule_~w_slot_~w_op_~w', [RuleIndex, SlotIndex, OpIndex]),
       format(atom(SetLine), '  ~w = add i64 %~w, 0', [NextValue, LengthBase]),
+      format(atom(IR), '~w~n~w', [LengthCall, SetLine]),
+      NextOpIndex is OpIndex + 1
+    },
+    [''-IR],
+    plawk_scalar_update_operation_pairs(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
+plawk_scalar_update_operation_pairs([if(Pattern, ThenOperations, ElseOperations) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, InputValue, OutputValue) -->
+    { format(atom(GlobalBase), 'plawk_rule_~w_slot_~w_if_~w', [RuleIndex, SlotIndex, OpIndex]),
+      format(atom(CondValue), '%rule_~w_slot_~w_if_~w_cond', [RuleIndex, SlotIndex, OpIndex]),
+      plawk_pattern_guard_ir(Pattern, FieldSeparator, GlobalBase, CondValue, GuardGlobalIR-GuardIR),
+      format(atom(ThenLabel), 'rule_~w_slot_~w_if_~w_then', [RuleIndex, SlotIndex, OpIndex]),
+      format(atom(ElseLabel), 'rule_~w_slot_~w_if_~w_else', [RuleIndex, SlotIndex, OpIndex]),
+      format(atom(DoneLabel), 'rule_~w_slot_~w_if_~w_done', [RuleIndex, SlotIndex, OpIndex]),
+      format(atom(ThenPrefix), 'rule_~w_slot_~w_if_~w_then', [RuleIndex, SlotIndex, OpIndex]),
+      format(atom(ElsePrefix), 'rule_~w_slot_~w_if_~w_else', [RuleIndex, SlotIndex, OpIndex]),
+      phrase(plawk_scalar_branch_operation_lines(ThenOperations, FieldSeparator,
+          ThenPrefix, 0, InputValue, ThenValue), ThenLines),
+      phrase(plawk_scalar_branch_operation_lines(ElseOperations, FieldSeparator,
+          ElsePrefix, 0, InputValue, ElseValue), ElseLines),
+      atomic_list_concat(ThenLines, '\n', ThenIR),
+      atomic_list_concat(ElseLines, '\n', ElseIR),
+      format(atom(NextValue), '%rule_~w_slot_~w_op_~w', [RuleIndex, SlotIndex, OpIndex]),
+      format(atom(IR),
+'~w
+  br i1 ~w, label %~w, label %~w
+
+~w:
+~w
+  br label %~w
+
+~w:
+~w
+  br label %~w
+
+~w:
+  ~w = phi i64 [~w, %~w], [~w, %~w]',
+          [GuardIR, CondValue, ThenLabel, ElseLabel,
+           ThenLabel, ThenIR, DoneLabel,
+           ElseLabel, ElseIR, DoneLabel,
+           DoneLabel, NextValue, ThenValue, ThenLabel, ElseValue, ElseLabel]),
+      NextOpIndex is OpIndex + 1
+    },
+    [GuardGlobalIR-IR],
+    plawk_scalar_update_operation_pairs(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
+
+plawk_scalar_branch_operation_lines([], _FieldSeparator, _Prefix, _OpIndex, Value, Value) -->
+    [].
+plawk_scalar_branch_operation_lines([add(const(Value)) | Rest], FieldSeparator, Prefix, OpIndex, InputValue, OutputValue) -->
+    { format(atom(NextValue), '%~w_op_~w', [Prefix, OpIndex]),
+      format(atom(Line), '  ~w = add i64 ~w, ~w', [NextValue, InputValue, Value]),
+      NextOpIndex is OpIndex + 1
+    },
+    [Line],
+    plawk_scalar_branch_operation_lines(Rest, FieldSeparator, Prefix, NextOpIndex, NextValue, OutputValue).
+plawk_scalar_branch_operation_lines([add(length(FieldIndex)) | Rest], FieldSeparator, Prefix, OpIndex, InputValue, OutputValue) -->
+    { format(atom(LengthBase), '~w_op_~w_len', [Prefix, OpIndex]),
+      llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, LengthCall),
+      format(atom(NextValue), '%~w_op_~w', [Prefix, OpIndex]),
+      format(atom(AddLine), '  ~w = add i64 ~w, %~w', [NextValue, InputValue, LengthBase]),
+      NextOpIndex is OpIndex + 1
+    },
+    [LengthCall, AddLine],
+    plawk_scalar_branch_operation_lines(Rest, FieldSeparator, Prefix, NextOpIndex, NextValue, OutputValue).
+plawk_scalar_branch_operation_lines([set(const(Value)) | Rest], FieldSeparator, Prefix, OpIndex, _InputValue, OutputValue) -->
+    { format(atom(NextValue), '%~w_op_~w', [Prefix, OpIndex]),
+      format(atom(Line), '  ~w = add i64 0, ~w', [NextValue, Value]),
+      NextOpIndex is OpIndex + 1
+    },
+    [Line],
+    plawk_scalar_branch_operation_lines(Rest, FieldSeparator, Prefix, NextOpIndex, NextValue, OutputValue).
+plawk_scalar_branch_operation_lines([set(length(FieldIndex)) | Rest], FieldSeparator, Prefix, OpIndex, _InputValue, OutputValue) -->
+    { format(atom(LengthBase), '~w_op_~w_len', [Prefix, OpIndex]),
+      llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, LengthCall),
+      format(atom(NextValue), '%~w_op_~w', [Prefix, OpIndex]),
+      format(atom(SetLine), '  ~w = add i64 %~w, 0', [NextValue, LengthBase]),
       NextOpIndex is OpIndex + 1
     },
     [LengthCall, SetLine],
-    plawk_scalar_update_operation_lines(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
+    plawk_scalar_branch_operation_lines(Rest, FieldSeparator, Prefix, NextOpIndex, NextValue, OutputValue).
 
 plawk_scalar_next_phi_ir(StatePlan, RuleCount, Controls, IR) :-
     plawk_state_plan_slots(StatePlan, Slots),
@@ -1311,7 +1441,7 @@ plawk_scalar_next_phi_lines([_Slot | Rest], RuleCount, Controls, Index) -->
               )
             ; nth0(RuleIndex, Controls, terminal_next)
             ),
-            format(atom(ApplyIncoming), '[%rule_~w_slot_~w, %rule_~w_apply]',
+            format(atom(ApplyIncoming), '[%rule_~w_slot_~w, %rule_~w_done]',
                 [RuleIndex, Index, RuleIndex])
           ),
           ApplyIncomings),

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -24,6 +24,7 @@
 %      $1 == "DEBUG" { skipped++; next } { total++ } END { print total, skipped }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
 %      $1 == "ERROR" { last_len = length($0); hits++ } END { print hits, last_len }
+%      { if ($1 == "ERROR") { errors++ } else { warnings++ } } END { print errors, warnings }
 %
 %  The AST is deliberately small and explicit so later syntax can extend it
 %  without changing the native codegen contract.
@@ -215,6 +216,9 @@ actions_rest([]) -->
     [].
 
 action(Action) -->
+    if_action(Action),
+    !.
+action(Action) -->
     print_action(Action),
     !.
 action(Action) -->
@@ -232,6 +236,20 @@ action(Action) -->
 action(Action) -->
     increment_action(Action),
     !.
+
+if_action(if(Pattern, ThenActions, ElseActions)) -->
+    "if",
+    ws,
+    "(",
+    ws,
+    field_eq_pattern(Pattern),
+    ws,
+    ")",
+    ws,
+    action_block(ThenActions),
+    "else",
+    required_ws,
+    action_block(ElseActions).
 
 increment_action(inc_assoc(var(Name), KeyExpr)) -->
     identifier(Name),

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -181,6 +181,21 @@ test(parses_scalar_integer_assignment_end_print_rule) :-
         [set(var(current), int(7)), add(var(current), int(2))])],
         [end([print([var(current)])])])).
 
+test(parses_scalar_if_else_end_print_rule) :-
+    plawk_parse_string("{ total++; if ($1 == \"ERROR\") { errors++; last_len = length($0) } else { non_errors++ } } END { print total, errors, non_errors, last_len }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [inc(var(total)),
+         if(field_eq(1, "ERROR"),
+            [inc(var(errors)), set(var(last_len), length(field(0)))],
+            [inc(var(non_errors))])])],
+        [end([print([var(total), var(errors), var(non_errors), var(last_len)])])])).
+
+test(parses_scalar_if_else_without_keyword_space) :-
+    plawk_parse_string("{ if($1 == \"ERROR\") { errors++ } else { non_errors++ } } END { print errors, non_errors }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [if(field_eq(1, "ERROR"), [inc(var(errors))], [inc(var(non_errors))])])],
+        [end([print([var(errors), var(non_errors)])])])).
+
 test(parses_assoc_count_end_print_rule) :-
     plawk_parse_string("{ counts[$1]++ } END { print counts[\"ERROR\"], counts[\"WARN\"] }\n", Program),
     assertion(Program == program([], [rule(always, [inc_assoc(var(counts), field(1))])],
@@ -423,6 +438,21 @@ test(surface_mixed_scalar_assignment_and_assoc_counts) :-
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "14 2\n").
 
+test(surface_scalar_if_else_updates_native_slots) :-
+    run_surface_print_smoke("{ total++; if ($1 == \"ERROR\") { errors++; last_len = length($0) } else { non_errors++ } } END { print total, errors, non_errors, last_len }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR network down\n",
+        "4 2 2 18\n").
+
+test(surface_scalar_if_else_preserves_surrounding_update_order) :-
+    run_surface_print_smoke("{ state = 1; if ($1 == \"ERROR\") { state += 10 } else { state += 100 }; state++ } END { print state }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\n",
+        "102\n").
+
+test(surface_mixed_scalar_if_else_and_assoc_counts) :-
+    run_surface_print_smoke("{ if ($1 == \"ERROR\") { errors++ } else { non_errors++ }; counts[$1]++ } END { print errors, non_errors, counts[\"ERROR\"], counts[\"WARN\"] }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "2 2 2 1\n").
+
 test(surface_scalar_end_prints_string_literals) :-
     run_surface_print_smoke("{ total++ } END { print \"total\", total }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -622,6 +652,25 @@ test(surface_scalar_assignment_uses_ordered_native_state_ops) :-
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 
+test(surface_scalar_if_else_uses_native_branch_phi) :-
+    plawk_parse_string("{ if ($1 == \"ERROR\") { errors++; last_len = length($0) } else { non_errors++ } } END { print errors, non_errors, last_len }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_slot_0_if_0_then:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_slot_0_if_0_else:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_slot_0_if_0_done:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= phi i64'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_eq_value'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_if_else_rejects_nested_next, [fail]) :-
+    plawk_parse_string("{ if ($1 == \"ERROR\") { next } else { total++ } } END { print total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
+
+test(surface_if_else_rejects_assoc_branch_updates, [fail]) :-
+    plawk_parse_string("{ if ($1 == \"ERROR\") { counts[$1]++ } else { counts[$2]++ } } END { print counts[\"ERROR\"] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
+
 test(surface_terminal_next_uses_native_continue_phi) :-
     plawk_parse_string("$1 == \"DEBUG\" { skipped++; next } { total++ } END { print total, skipped }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
@@ -629,7 +678,7 @@ test(surface_terminal_next_uses_native_continue_phi) :-
     assertion(once(sub_atom(DriverIR, _, _, _, 'rule_1_match:'))),
     assertion(once(sub_atom(DriverIR, _, _, _, 'br label %continue_loop'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%rule_1_in_slot_0 = phi i64 [%slot_0, %rule_0_match]'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, '%next_slot_0 = phi i64 [%rule_1_in_slot_0, %rule_1_match], [%rule_0_slot_0, %rule_0_apply], [%rule_1_slot_0, %rule_1_apply]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%next_slot_0 = phi i64 [%rule_1_in_slot_0, %rule_1_match], [%rule_0_slot_0, %rule_0_done], [%rule_1_slot_0, %rule_1_done]'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 
@@ -679,7 +728,7 @@ test(surface_terminal_break_uses_close_path_and_final_state_phi) :-
     plawk_parse_string("$1 == \"ERROR\" { hits++; break } { total++ } END { print hits, total }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
     assertion(once(sub_atom(DriverIR, _, _, _, 'break_close_stream:'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, '%break_slot_0 = phi i64 [%rule_0_slot_0, %rule_0_apply]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%break_slot_0 = phi i64 [%rule_0_slot_0, %rule_0_done]'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%final_slot_0 = phi i64 [%slot_0, %close_stream], [%break_slot_0, %break_close_stream]'))),
     assertion(once(sub_atom(DriverIR, _, _, _, 'i64 %final_slot_0'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),


### PR DESCRIPTION
## Summary
- parse `if ($N == "VALUE") { ... } else { ... }` actions in the PLAWK surface
- lower scalar slot updates inside branch bodies to native LLVM control flow with per-slot phis
- add scalar `rule_N_done` join labels so loop/break phis use stable predecessors when rule bodies contain internal branches
- reject nested `next`/`break` and branch-local associative updates for this first slice
- document the current scalar-only native branch boundary

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`