### PR TITLE
Refactor PLAWK scalar if lowering

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -272,8 +272,9 @@ stay in the compiled stream loop. Plain scalar assignment to integer literals or
 field lengths uses the same native slot path and is folded in source order with
 later `++`/`+=` updates, so programs such as `$1 == "ERROR" { last_len =
 length($0); hits++ } END { print hits, last_len }` also stay native. The first
-native `if/else` action slice lowers field-equality conditions around scalar
-slot updates, emits per-slot branch phis, and joins scalar rules through an
+native `if/else` action slice lowers field-equality conditions once at rule-body
+scope, threads the whole scalar slot vector through then/else action sequences,
+emits per-slot phis at the branch join, and joins scalar rules through an
 explicit `rule_N_done` label so downstream loop phis have stable predecessors.
 Branch-local associative updates, `print`, `next`, and `break` still need a
 broader intra-rule CFG. Native rule chains also support terminal

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -96,7 +96,9 @@ integer literals and `length($N)`.
 Scalar slot updates can also sit behind native `if/else` guards, e.g.
 `{ if ($1 == "ERROR") { errors++; last_len = length($0) } else { non_errors++ } }
 END { print errors, non_errors, last_len }`. The first branch slice supports
-field-equality conditions and scalar update actions inside branches; branch-local
+field-equality conditions and scalar update actions inside branches. The native
+lowering evaluates each source `if` guard once, threads every scalar slot through
+the then/else bodies, and rejoins them with per-slot LLVM phis; branch-local
 `print`, associative updates, `next`, and `break` remain outside this boundary.
 Terminal `next` is supported in native rule chains, so `$1 == "DEBUG" {
 skipped++; next } { total++ } END { print total, skipped }` skips the later

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -256,6 +256,9 @@ END { print total, errors, non_errors, last_len }
 
 For now, branch bodies support scalar updates only; branch-local `print`,
 associative updates, `next`, and `break` are rejected by native codegen.
+The generated native code evaluates the `if` condition once, runs the selected
+branch, and rejoins all scalar slots through LLVM phi nodes before later actions
+or rules continue.
 
 A terminal `next` skips the remaining rules for the current record:
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1241,29 +1241,34 @@ plawk_scalar_loop_phi_lines([_Slot | Rest], Index) -->
 
 plawk_scalar_match_update_ir(StatePlan, Actions, FieldSeparator, RuleIndex, GlobalIR-IR) :-
     plawk_state_plan_slots(StatePlan, Slots),
-    phrase(plawk_scalar_match_update_pairs(Slots, Actions, FieldSeparator, RuleIndex, 0), Pairs),
+    phrase(plawk_scalar_initial_slot_values(RuleIndex, Slots, 0), InitialValues),
+    format(atom(Prefix), 'rule_~w_body', [RuleIndex]),
+    phrase(plawk_scalar_action_sequence_pairs(Actions, Slots, FieldSeparator,
+        Prefix, RuleIndex, 0, InitialValues, FinalValues, _NextOpIndex), Pairs0),
+    phrase(plawk_scalar_final_slot_pairs(FinalValues, RuleIndex, 0), FinalPairs),
+    append(Pairs0, FinalPairs, Pairs),
     pairs_keys_values(Pairs, GlobalParts, LineParts),
     atomic_list_concat(GlobalParts, '\n', GlobalIR),
     atomic_list_concat(LineParts, '\n', IR).
 
-plawk_scalar_match_update_pairs([], _Actions, _FieldSeparator, _RuleIndex, _) -->
+plawk_scalar_initial_slot_values(_RuleIndex, [], _) -->
     [].
-plawk_scalar_match_update_pairs([scalar_counter(Name) | Rest], Actions, FieldSeparator, RuleIndex, SlotIndex) -->
-    { plawk_scalar_action_operations(Name, Actions, Operations),
-      plawk_scalar_rule_slot_input(RuleIndex, SlotIndex, InputValue),
-      phrase(plawk_scalar_update_operation_pairs(Operations, FieldSeparator, RuleIndex,
-          SlotIndex, 0, InputValue, OutputValue), OperationPairs),
-      pairs_keys_values(OperationPairs, GlobalParts, OperationLines),
-      atomic_list_concat(GlobalParts, '\n', OperationGlobalIR),
-      atomic_list_concat(OperationLines, '\n', OperationIR),
-      format(atom(Line),
-          '  %rule_~w_slot_~w = add i64 ~w, 0',
-          [RuleIndex, SlotIndex, OutputValue]),
-      format(atom(SlotIR), '~w~n~w', [OperationIR, Line]),
+plawk_scalar_initial_slot_values(RuleIndex, [_Slot | Rest], SlotIndex) -->
+    { plawk_scalar_rule_slot_input(RuleIndex, SlotIndex, Value),
       NextIndex is SlotIndex + 1
     },
-    [OperationGlobalIR-SlotIR],
-    plawk_scalar_match_update_pairs(Rest, Actions, FieldSeparator, RuleIndex, NextIndex).
+    [Value],
+    plawk_scalar_initial_slot_values(RuleIndex, Rest, NextIndex).
+
+plawk_scalar_final_slot_pairs([], _RuleIndex, _) -->
+    [].
+plawk_scalar_final_slot_pairs([Value | Rest], RuleIndex, SlotIndex) -->
+    { format(atom(Line), '  %rule_~w_slot_~w = add i64 ~w, 0',
+          [RuleIndex, SlotIndex, Value]),
+      NextSlotIndex is SlotIndex + 1
+    },
+    [''-Line],
+    plawk_scalar_final_slot_pairs(Rest, RuleIndex, NextSlotIndex).
 
 plawk_scalar_update_action(Action) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
@@ -1290,80 +1295,45 @@ plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) 
 plawk_scalar_action_update(set(var(Name), length(field(FieldIndex))), Name, set(length(FieldIndex))) :-
     FieldIndex >= 0.
 
-plawk_scalar_action_operations(Name, Actions, Operations) :-
-    findall(Operation,
-        ( member(Action, Actions),
-          plawk_scalar_action_operation(Name, Action, Operation)
-        ),
-        Operations).
-
-plawk_scalar_action_operation(Name, Action, Operation) :-
-    plawk_scalar_action_update(Action, Name, Operation).
-plawk_scalar_action_operation(Name, if(Pattern, ThenActions, ElseActions),
-        if(Pattern, ThenOperations, ElseOperations)) :-
-    plawk_scalar_branch_action_operations(Name, ThenActions, ThenOperations),
-    plawk_scalar_branch_action_operations(Name, ElseActions, ElseOperations),
-    ( ThenOperations \== [] -> true ; ElseOperations \== [] ).
-
-plawk_scalar_branch_action_operations(Name, Actions, Operations) :-
-    findall(Operation,
-        ( member(Action, Actions),
-          plawk_scalar_action_update(Action, Name, Operation)
-        ),
-        Operations).
-
-plawk_scalar_update_operation_pairs([], _FieldSeparator, _RuleIndex, _SlotIndex, _OpIndex, Value, Value) -->
+plawk_scalar_action_sequence_pairs([], _Slots, _FieldSeparator, _Prefix, _RuleIndex,
+        OpIndex, Values, Values, OpIndex) -->
     [].
-plawk_scalar_update_operation_pairs([add(const(Value)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, InputValue, OutputValue) -->
-    { format(atom(NextValue), '%rule_~w_slot_~w_op_~w', [RuleIndex, SlotIndex, OpIndex]),
-      format(atom(AddLine), '  ~w = add i64 ~w, ~w', [NextValue, InputValue, Value]),
+plawk_scalar_action_sequence_pairs([Action | Rest], Slots, FieldSeparator, Prefix, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex) -->
+    { plawk_scalar_action_update(Action, Name, Operation),
+      nth0(SlotIndex, Slots, scalar_counter(Name)),
+      nth0(SlotIndex, Values0, InputValue),
+      plawk_scalar_update_operation_ir(Operation, FieldSeparator, Prefix, SlotIndex,
+          OpIndex, InputValue, NextValue, Pair),
+      replace_nth0(SlotIndex, Values0, NextValue, Values1),
       NextOpIndex is OpIndex + 1
     },
-    [''-AddLine],
-    plawk_scalar_update_operation_pairs(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
-plawk_scalar_update_operation_pairs([add(length(FieldIndex)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, InputValue, OutputValue) -->
-    { format(atom(LengthBase), 'plawk_rule_~w_slot_~w_op_~w_len', [RuleIndex, SlotIndex, OpIndex]),
-      llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, LengthCall),
-      format(atom(NextValue), '%rule_~w_slot_~w_op_~w', [RuleIndex, SlotIndex, OpIndex]),
-      format(atom(AddLine), '  ~w = add i64 ~w, %~w', [NextValue, InputValue, LengthBase]),
-      format(atom(IR), '~w~n~w', [LengthCall, AddLine]),
-      NextOpIndex is OpIndex + 1
-    },
-    [''-IR],
-    plawk_scalar_update_operation_pairs(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
-plawk_scalar_update_operation_pairs([set(const(Value)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, _InputValue, OutputValue) -->
-    { format(atom(NextValue), '%rule_~w_slot_~w_op_~w', [RuleIndex, SlotIndex, OpIndex]),
-      format(atom(SetLine), '  ~w = add i64 0, ~w', [NextValue, Value]),
-      NextOpIndex is OpIndex + 1
-    },
-    [''-SetLine],
-    plawk_scalar_update_operation_pairs(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
-plawk_scalar_update_operation_pairs([set(length(FieldIndex)) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, _InputValue, OutputValue) -->
-    { format(atom(LengthBase), 'plawk_rule_~w_slot_~w_op_~w_len', [RuleIndex, SlotIndex, OpIndex]),
-      llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, LengthCall),
-      format(atom(NextValue), '%rule_~w_slot_~w_op_~w', [RuleIndex, SlotIndex, OpIndex]),
-      format(atom(SetLine), '  ~w = add i64 %~w, 0', [NextValue, LengthBase]),
-      format(atom(IR), '~w~n~w', [LengthCall, SetLine]),
-      NextOpIndex is OpIndex + 1
-    },
-    [''-IR],
-    plawk_scalar_update_operation_pairs(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
-plawk_scalar_update_operation_pairs([if(Pattern, ThenOperations, ElseOperations) | Rest], FieldSeparator, RuleIndex, SlotIndex, OpIndex, InputValue, OutputValue) -->
-    { format(atom(GlobalBase), 'plawk_rule_~w_slot_~w_if_~w', [RuleIndex, SlotIndex, OpIndex]),
-      format(atom(CondValue), '%rule_~w_slot_~w_if_~w_cond', [RuleIndex, SlotIndex, OpIndex]),
+    [Pair],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, FieldSeparator, Prefix, RuleIndex,
+        NextOpIndex, Values1, Values, FinalOpIndex).
+plawk_scalar_action_sequence_pairs([if(Pattern, ThenActions, ElseActions) | Rest],
+        Slots, FieldSeparator, Prefix, RuleIndex, OpIndex, Values0, Values, FinalOpIndex) -->
+    { format(atom(GlobalBase), '~w_if_~w', [Prefix, OpIndex]),
+      format(atom(CondValue), '%~w_if_~w_cond', [Prefix, OpIndex]),
       plawk_pattern_guard_ir(Pattern, FieldSeparator, GlobalBase, CondValue, GuardGlobalIR-GuardIR),
-      format(atom(ThenLabel), 'rule_~w_slot_~w_if_~w_then', [RuleIndex, SlotIndex, OpIndex]),
-      format(atom(ElseLabel), 'rule_~w_slot_~w_if_~w_else', [RuleIndex, SlotIndex, OpIndex]),
-      format(atom(DoneLabel), 'rule_~w_slot_~w_if_~w_done', [RuleIndex, SlotIndex, OpIndex]),
-      format(atom(ThenPrefix), 'rule_~w_slot_~w_if_~w_then', [RuleIndex, SlotIndex, OpIndex]),
-      format(atom(ElsePrefix), 'rule_~w_slot_~w_if_~w_else', [RuleIndex, SlotIndex, OpIndex]),
-      phrase(plawk_scalar_branch_operation_lines(ThenOperations, FieldSeparator,
-          ThenPrefix, 0, InputValue, ThenValue), ThenLines),
-      phrase(plawk_scalar_branch_operation_lines(ElseOperations, FieldSeparator,
-          ElsePrefix, 0, InputValue, ElseValue), ElseLines),
-      atomic_list_concat(ThenLines, '\n', ThenIR),
-      atomic_list_concat(ElseLines, '\n', ElseIR),
-      format(atom(NextValue), '%rule_~w_slot_~w_op_~w', [RuleIndex, SlotIndex, OpIndex]),
+      format(atom(ThenLabel), '~w_if_~w_then', [Prefix, OpIndex]),
+      format(atom(ElseLabel), '~w_if_~w_else', [Prefix, OpIndex]),
+      format(atom(DoneLabel), '~w_if_~w_done', [Prefix, OpIndex]),
+      phrase(plawk_scalar_action_sequence_pairs(ThenActions, Slots, FieldSeparator,
+          ThenLabel, RuleIndex, 0, Values0, ThenValues, _ThenOpIndex), ThenPairs),
+      phrase(plawk_scalar_action_sequence_pairs(ElseActions, Slots, FieldSeparator,
+          ElseLabel, RuleIndex, 0, Values0, ElseValues, _ElseOpIndex), ElsePairs),
+      pairs_keys_values(ThenPairs, ThenGlobalParts, ThenLineParts),
+      pairs_keys_values(ElsePairs, ElseGlobalParts, ElseLineParts),
+      atomic_list_concat(ThenGlobalParts, '\n', ThenGlobalIR),
+      atomic_list_concat(ElseGlobalParts, '\n', ElseGlobalIR),
+      atomic_list_concat(ThenLineParts, '\n', ThenIR),
+      atomic_list_concat(ElseLineParts, '\n', ElseIR),
+      phrase(plawk_scalar_if_phi_lines(ThenValues, ElseValues, Prefix, OpIndex,
+          ThenLabel, ElseLabel, 0), PhiPairs),
+      pairs_keys_values(PhiPairs, _PhiGlobalParts, PhiLineParts),
+      atomic_list_concat(PhiLineParts, '\n', PhiIR),
+      pairs_keys(PhiPairs, Values1),
       format(atom(IR),
 '~w
   br i1 ~w, label %~w, label %~w
@@ -1377,50 +1347,59 @@ plawk_scalar_update_operation_pairs([if(Pattern, ThenOperations, ElseOperations)
   br label %~w
 
 ~w:
-  ~w = phi i64 [~w, %~w], [~w, %~w]',
+~w',
           [GuardIR, CondValue, ThenLabel, ElseLabel,
            ThenLabel, ThenIR, DoneLabel,
            ElseLabel, ElseIR, DoneLabel,
-           DoneLabel, NextValue, ThenValue, ThenLabel, ElseValue, ElseLabel]),
+           DoneLabel, PhiIR]),
+      atomic_list_concat([GuardGlobalIR, ThenGlobalIR, ElseGlobalIR], '\n', GlobalIR),
       NextOpIndex is OpIndex + 1
     },
-    [GuardGlobalIR-IR],
-    plawk_scalar_update_operation_pairs(Rest, FieldSeparator, RuleIndex, SlotIndex, NextOpIndex, NextValue, OutputValue).
+    [GlobalIR-IR],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, FieldSeparator, Prefix, RuleIndex,
+        NextOpIndex, Values1, Values, FinalOpIndex).
 
-plawk_scalar_branch_operation_lines([], _FieldSeparator, _Prefix, _OpIndex, Value, Value) -->
+plawk_scalar_update_operation_ir(add(const(Value)), _FieldSeparator, Prefix, SlotIndex,
+        OpIndex, InputValue, NextValue, ''-Line) :-
+    format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
+    format(atom(Line), '  ~w = add i64 ~w, ~w', [NextValue, InputValue, Value]).
+plawk_scalar_update_operation_ir(add(length(FieldIndex)), FieldSeparator, Prefix, SlotIndex,
+        OpIndex, InputValue, NextValue, ''-IR) :-
+    format(atom(LengthBase), '~w_slot_~w_op_~w_len', [Prefix, SlotIndex, OpIndex]),
+    llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, LengthCall),
+    format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
+    format(atom(AddLine), '  ~w = add i64 ~w, %~w', [NextValue, InputValue, LengthBase]),
+    format(atom(IR), '~w~n~w', [LengthCall, AddLine]).
+plawk_scalar_update_operation_ir(set(const(Value)), _FieldSeparator, Prefix, SlotIndex,
+        OpIndex, _InputValue, NextValue, ''-Line) :-
+    format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
+    format(atom(Line), '  ~w = add i64 0, ~w', [NextValue, Value]).
+plawk_scalar_update_operation_ir(set(length(FieldIndex)), FieldSeparator, Prefix, SlotIndex,
+        OpIndex, _InputValue, NextValue, ''-IR) :-
+    format(atom(LengthBase), '~w_slot_~w_op_~w_len', [Prefix, SlotIndex, OpIndex]),
+    llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, LengthCall),
+    format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
+    format(atom(SetLine), '  ~w = add i64 %~w, 0', [NextValue, LengthBase]),
+    format(atom(IR), '~w~n~w', [LengthCall, SetLine]).
+
+plawk_scalar_if_phi_lines([], [], _Prefix, _OpIndex, _ThenLabel, _ElseLabel, _) -->
     [].
-plawk_scalar_branch_operation_lines([add(const(Value)) | Rest], FieldSeparator, Prefix, OpIndex, InputValue, OutputValue) -->
-    { format(atom(NextValue), '%~w_op_~w', [Prefix, OpIndex]),
-      format(atom(Line), '  ~w = add i64 ~w, ~w', [NextValue, InputValue, Value]),
-      NextOpIndex is OpIndex + 1
+plawk_scalar_if_phi_lines([ThenValue | ThenRest], [ElseValue | ElseRest],
+        Prefix, OpIndex, ThenLabel, ElseLabel, SlotIndex) -->
+    { format(atom(PhiValue), '%~w_if_~w_slot_~w', [Prefix, OpIndex, SlotIndex]),
+      format(atom(Line), '  ~w = phi i64 [~w, %~w], [~w, %~w]',
+          [PhiValue, ThenValue, ThenLabel, ElseValue, ElseLabel]),
+      NextSlotIndex is SlotIndex + 1
     },
-    [Line],
-    plawk_scalar_branch_operation_lines(Rest, FieldSeparator, Prefix, NextOpIndex, NextValue, OutputValue).
-plawk_scalar_branch_operation_lines([add(length(FieldIndex)) | Rest], FieldSeparator, Prefix, OpIndex, InputValue, OutputValue) -->
-    { format(atom(LengthBase), '~w_op_~w_len', [Prefix, OpIndex]),
-      llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, LengthCall),
-      format(atom(NextValue), '%~w_op_~w', [Prefix, OpIndex]),
-      format(atom(AddLine), '  ~w = add i64 ~w, %~w', [NextValue, InputValue, LengthBase]),
-      NextOpIndex is OpIndex + 1
-    },
-    [LengthCall, AddLine],
-    plawk_scalar_branch_operation_lines(Rest, FieldSeparator, Prefix, NextOpIndex, NextValue, OutputValue).
-plawk_scalar_branch_operation_lines([set(const(Value)) | Rest], FieldSeparator, Prefix, OpIndex, _InputValue, OutputValue) -->
-    { format(atom(NextValue), '%~w_op_~w', [Prefix, OpIndex]),
-      format(atom(Line), '  ~w = add i64 0, ~w', [NextValue, Value]),
-      NextOpIndex is OpIndex + 1
-    },
-    [Line],
-    plawk_scalar_branch_operation_lines(Rest, FieldSeparator, Prefix, NextOpIndex, NextValue, OutputValue).
-plawk_scalar_branch_operation_lines([set(length(FieldIndex)) | Rest], FieldSeparator, Prefix, OpIndex, _InputValue, OutputValue) -->
-    { format(atom(LengthBase), '~w_op_~w_len', [Prefix, OpIndex]),
-      llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, LengthCall),
-      format(atom(NextValue), '%~w_op_~w', [Prefix, OpIndex]),
-      format(atom(SetLine), '  ~w = add i64 %~w, 0', [NextValue, LengthBase]),
-      NextOpIndex is OpIndex + 1
-    },
-    [LengthCall, SetLine],
-    plawk_scalar_branch_operation_lines(Rest, FieldSeparator, Prefix, NextOpIndex, NextValue, OutputValue).
+    [PhiValue-Line],
+    plawk_scalar_if_phi_lines(ThenRest, ElseRest, Prefix, OpIndex, ThenLabel, ElseLabel, NextSlotIndex).
+
+replace_nth0(0, [_Old | Rest], Value, [Value | Rest]) :-
+    !.
+replace_nth0(Index, [Head | Rest], Value, [Head | NewRest]) :-
+    Index > 0,
+    NextIndex is Index - 1,
+    replace_nth0(NextIndex, Rest, Value, NewRest).
 
 plawk_scalar_next_phi_ir(StatePlan, RuleCount, Controls, IR) :-
     plawk_state_plan_slots(StatePlan, Slots),

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -635,9 +635,9 @@ test(surface_scalar_add_assign_uses_native_state_and_field_length) :-
     plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
     assertion(once(sub_atom(DriverIR, _, _, _, 'lowered_match:'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%slot_0 = phi i64'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_rule_0_slot_0_op_0_len = call i64 @wam_atom_field_length_value(%Value %line, i64 2, i8 58)'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_slot_0_op_0 = add i64 %slot_0, %plawk_rule_0_slot_0_op_0_len'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_slot_1_op_0 = add i64 %slot_1, 2'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_0_len = call i64 @wam_atom_field_length_value(%Value %line, i64 2, i8 58)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_0 = add i64 %slot_0, %rule_0_body_slot_0_op_0_len'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_1_op_1 = add i64 %slot_1, 2'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%next_slot_0 = phi i64'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
@@ -645,9 +645,9 @@ test(surface_scalar_add_assign_uses_native_state_and_field_length) :-
 test(surface_scalar_assignment_uses_ordered_native_state_ops) :-
     plawk_parse_string("$1 == \"ERROR\" { last_len = length($0); last_len += 2 } END { print last_len }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
-    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_rule_0_slot_0_op_0_len = call i64 @wam_atom_field_length_value(%Value %line, i64 0'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_slot_0_op_0 = add i64 %plawk_rule_0_slot_0_op_0_len, 0'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_slot_0_op_1 = add i64 %rule_0_slot_0_op_0, 2'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_0_len = call i64 @wam_atom_field_length_value(%Value %line, i64 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_0 = add i64 %rule_0_body_slot_0_op_0_len, 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_1 = add i64 %rule_0_body_slot_0_op_0, 2'))),
     assertion(once(sub_atom(DriverIR, _, _, _, 'i64 %final_slot_0'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
@@ -655,11 +655,12 @@ test(surface_scalar_assignment_uses_ordered_native_state_ops) :-
 test(surface_scalar_if_else_uses_native_branch_phi) :-
     plawk_parse_string("{ if ($1 == \"ERROR\") { errors++; last_len = length($0) } else { non_errors++ } } END { print errors, non_errors, last_len }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
-    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_slot_0_if_0_then:'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_slot_0_if_0_else:'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_slot_0_if_0_done:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_body_if_0_then:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_body_if_0_else:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_body_if_0_done:'))),
+    findall(guard, sub_atom(DriverIR, _, _, _, '@wam_atom_field_eq_value'), Guards),
+    assertion(Guards == [guard]),
     assertion(once(sub_atom(DriverIR, _, _, _, '= phi i64'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_eq_value'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 


### PR DESCRIPTION
## Summary
- refactor scalar action lowering to thread the whole native scalar slot vector through rule-body actions
- lower each PLAWK scalar `if/else` through one shared branch guard and join phis for all scalar slots
- keep branch-local assoc updates, prints, and nested loop control rejected at this boundary
- update generated-IR checks to cover the shared branch shape
- document the rule-body CFG boundary

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`