### PR TITLE
feat(wam-rust): surface cache attribution in the matrix benchmark main

### DIFF
--- a/docs/reports/wam_rust_cached_runtime_attribution_2026-06-14.md
+++ b/docs/reports/wam_rust_cached_runtime_attribution_2026-06-14.md
@@ -1,0 +1,66 @@
+# WAM-Rust Cached Runtime Attribution — Wiring Validation (2026-06-14)
+
+Rust-side analog of the Python boundary-cache attribution from PR #3120
+(`scripts/lmdb_parent_boundary_cache_benchmark.py`). That benchmark found cached
+search dominated by *residual cached traversal / interpreter overhead*. The
+compiled Rust WAM kernel removes the interpreter, so this work instruments what
+remains on the cached path so the same question can be asked on the Rust target.
+
+## What landed
+
+- `CacheAttribution` in the Rust runtime (`templates/targets/rust_wam/state.rs.mustache`):
+  atomic L1-hit / L2-hit / miss counters plus nanoseconds spent in the inner LMDB
+  cursor seek, recorded inside `CachedLookup::lookup_parents`. Opt-in via
+  `UW_WAM_CACHE_ATTRIBUTION`; behind an `Option<Arc<…>>` branch so the default
+  cached path takes no extra timer calls. (Merged in PR #3127.)
+- Surfacing in the **matrix benchmark** main (`examples/benchmark/generate_wam_rust_matrix_benchmark.pl`,
+  LMDB-resident main): reads back the process-global sink and prints `cache_attr_*`
+  lines alongside the existing `eprintln!` diagnostics. This closes the gap where
+  the matrix bench (the actual cached graph-search harness) emits its own main and
+  did not surface attribution.
+
+## Smoke run (tiny int-native fixture)
+
+Built with `tests/helpers/build_tiny_int_native_lmdb.py` (7 nodes, 5 edges,
+root=2, seeds {10,11,12,20}); cached crate generated with `materialisation=cached`,
+built `--release`, run with `UW_WAM_CACHE_ATTRIBUTION=1`:
+
+```text
+cache_attr_lookups=4
+cache_attr_l1_hits=0
+cache_attr_l2_hits=0
+cache_attr_misses=4
+cache_attr_hit_rate=0.0000
+cache_attr_inner_lookup_ms=0.026
+```
+
+This is a **wiring validation, not a performance result**: a 5-edge graph with
+four distinct seed parent-lookups and no repeated traversal yields four cold
+misses and zero reuse by construction. It confirms the counters record, the inner
+LMDB seek is timed, and the report surfaces in the real cached binary. With the
+env var unset (or `=0`) no `cache_attr_*` lines are emitted.
+
+## Reproduce
+
+```bash
+# 1. Generate + build a cached crate
+cd examples/benchmark
+swipl -q -s generate_wam_rust_matrix_benchmark.pl -- \
+    effective_distance.pl /tmp/cached_bench accumulated functions kernels_on \
+    cursor auto cached 297283
+cd /tmp/cached_bench && cargo build --release
+
+# 2. Build a fixture (tiny here; use a real lmdb_resident fixture for reuse numbers)
+python3 <repo>/tests/helpers/build_tiny_int_native_lmdb.py /tmp/wam_fixture
+
+# 3. Run with attribution
+UW_WAM_CACHE_ATTRIBUTION=1 ./target/release/bench /tmp/wam_fixture
+```
+
+## Next
+
+Real hit-rate / inner-lookup numbers — the actual Rust-vs-#3120 comparison —
+require a fixture with genuine ancestor reuse (a SimpleWiki/enwiki
+`lmdb_resident` fixture), where root-near ancestors are hit repeatedly across
+seeds. The instrumentation is now in place to measure it; only the fixture is
+outstanding.

--- a/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
+++ b/examples/benchmark/generate_wam_rust_matrix_benchmark.pl
@@ -1655,5 +1655,14 @@ fn main() {
     eprintln!("tuple_count={}", seed_weight_sums.len());
     eprintln!("total_steps={}", total_steps);
     eprintln!("total_backtracks={}", total_backtracks);
+
+    // Cached-side runtime attribution (PR #3120 analog), opt-in via
+    // UW_WAM_CACHE_ATTRIBUTION. Reads back the same Arc that CachedLookup
+    // recorded into; in lazy (uncached) mode this reports zeros.
+    if let Some(attr) = wam_lib::state::cache_attribution() {
+        for line in attr.report_lines() {
+            eprintln!("{}", line);
+        }
+    }
 }
 ').

--- a/tests/test_wam_rust_matrix_demand_flag.py
+++ b/tests/test_wam_rust_matrix_demand_flag.py
@@ -70,6 +70,16 @@ class TestMatrixDemandFlag(unittest.TestCase):
         self.assertIn("CachedLookup", src)
         self.assertIn("set_demand_set", src)
 
+    def test_cached_surfaces_cache_attribution(self):
+        # The cached/LMDB bench main reads back the process-global attribution
+        # sink and prints cache_attr_* lines (opt-in via
+        # UW_WAM_CACHE_ATTRIBUTION). Rust-side analog of PR #3120; a drop here
+        # would silently stop the cached graph-search bench from reporting
+        # cache hit/miss attribution.
+        src = self._generate("cached")
+        self.assertIn("wam_lib::state::cache_attribution()", src)
+        self.assertIn("report_lines()", src)
+
     def test_auto_branch_and_is_scoped(self):
         # WAM_DEMAND=auto consults the DB scoped marker via is_scoped().
         src = self._generate("lazy")


### PR DESCRIPTION
## Summary

Follow-up to #3127. That PR added the `CacheAttribution` sink in the Rust runtime (`state.rs`) and surfaced it from `main.rs.mustache` — but the **matrix benchmark**, which is the actual cached graph-search harness, emits its *own* `main` from `examples/benchmark/generate_wam_rust_matrix_benchmark.pl` (note `eprintln!("mode=wam_rust_matrix_…")` vs the mustache harness's `writeln!(err, "mode=wam_rust_bench")`). So the cached bench could *record* attribution but never *report* it. This closes that gap.

## Changes

- **`examples/benchmark/generate_wam_rust_matrix_benchmark.pl`** — append `cache_attr_*` surfacing to the LMDB-resident matrix `main`'s diagnostics block, reading back the same process-global sink `CachedLookup` records into (`wam_lib::state::cache_attribution()` → `report_lines()`). Added to the cursor-mode (lazy/cached) main only; the in-memory eager main never constructs `CachedLookup`.
- **`tests/test_wam_rust_matrix_demand_flag.py`** — `test_cached_surfaces_cache_attribution`, a swipl-only codegen guard (no cargo) asserting the cached main reads the sink and prints the report.
- **`docs/reports/wam_rust_cached_runtime_attribution_2026-06-14.md`** — documents the end-to-end smoke run and the reproduce recipe.

Opt-in via `UW_WAM_CACHE_ATTRIBUTION`; default output unchanged.

## Validation (end-to-end, this environment)

Installed SWI-Prolog 9.0.4 + Python `lmdb`; cargo/rustc 1.94.

1. Generated a cached crate (`materialisation=cached`), `cargo build --release` — **builds clean** (`lmdb-zero 0.4` compiles), and the generated `main.rs` now contains `wam_lib::state::cache_attribution()`.
2. Built a tiny int-native fixture (`tests/helpers/build_tiny_int_native_lmdb.py`: 7 nodes, 5 edges, root=2) and ran the binary with `UW_WAM_CACHE_ATTRIBUTION=1`:
   ```
   cache_attr_lookups=4
   cache_attr_l1_hits=0
   cache_attr_l2_hits=0
   cache_attr_misses=4
   cache_attr_hit_rate=0.0000
   cache_attr_inner_lookup_ms=0.026
   ```
   Sensible for a 5-edge graph with four distinct seed lookups and no reuse (four cold misses). With the env var unset or `=0`, **no `cache_attr_*` lines emit**.
3. `python3 -m unittest tests.test_wam_rust_matrix_demand_flag` — **6 passed** (incl. the new guard).

## Notes

- This is a **wiring validation, not a performance result** — the tiny fixture has no ancestor reuse by construction. Real hit-rate / inner-lookup numbers (the actual Rust-vs-#3120 comparison) need a fixture with genuine root-near reuse (SimpleWiki/enwiki `lmdb_resident`). The instrumentation is now in place to measure it; only the fixture is outstanding.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_