### PR TITLE
Document root path sample estimators

### DIFF
--- a/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
+++ b/docs/design/PARENT_BRANCHING_DISTRIBUTION_THEORY.md
@@ -73,6 +73,17 @@ epsilon = 0.028750
 That is close to a chain: most visited nodes have one parent, with rare extra
 parent choices.
 
+For sampling estimators, `b_p` is a prior and cost-planning statistic rather
+than the per-path sample correction.  A simple random parent walk has proposal
+probability `q(pi) = product_i 1/d_i` and inverse correction
+`c(pi) = product_i d_i`, where `d_i` is the eligible parent count actually seen
+on the sampled path.  The stationary approximation `d_i ~= b_p` gives
+`q(pi) ~= b_p^(-L)` and `c(pi) ~= b_p^L`, which is useful for expected search
+cost and cache-depth planning.  It should not replace the branch-product
+correction in a concrete random-walk estimator.  A path-length kernel such as
+`b_p^(-L)` is a separate metric choice; see
+`ROOT_PATH_SAMPLE_ESTIMATOR_THEORY.md`.
+
 ## 3. Small-branching approximation
 
 When parent degree is mostly `1`, sometimes `2`, and rarely larger, the excess

--- a/docs/design/ROOT_ANCHORED_METRICS_SPECIFICATION.md
+++ b/docs/design/ROOT_ANCHORED_METRICS_SPECIFICATION.md
@@ -233,7 +233,9 @@ Query semantics against a materialised table:
   aggregate reaches a node with a compatible cached path-statistic distribution,
   the traversal can integrate that distribution over the remaining budget instead
   of enumerating the suffix. See `DISTRIBUTIONAL_FIT_POLICY.md` for the
-  compatibility and error-bound rules.
+  compatibility and error-bound rules, and
+  `ROOT_PATH_SAMPLE_ESTIMATOR_THEORY.md` for the sampling and boundary-splice
+  estimator used by the coverage probes.
 
 A materialised table is only valid for the root it was built against; a different
 root needs either its own table or the `kernel` mode.
@@ -268,4 +270,4 @@ convenience in the plan.
 
 `ROOT_ANCHORED_METRICS_PHILOSOPHY.md`, `ROOT_ANCHORED_METRICS_IMPLEMENTATION_PLAN.md`,
 `ALGORITHM_MANIFEST_SPECIFICATION.md`, `KERNEL_SHAPE_RECOGNITION.md`,
-`WAM_DEMAND_FILTER_SPECIFICATION.md`.
+`ROOT_PATH_SAMPLE_ESTIMATOR_THEORY.md`, `WAM_DEMAND_FILTER_SPECIFICATION.md`.

--- a/docs/design/ROOT_PATH_SAMPLE_ESTIMATOR_THEORY.md
+++ b/docs/design/ROOT_PATH_SAMPLE_ESTIMATOR_THEORY.md
@@ -1,0 +1,243 @@
+# Root Path Sample Estimator Theory
+
+This note specifies the sampling estimator used by
+`scripts/lmdb_boundary_coverage_probe.py` and its relationship to cached
+root-path histograms.  It complements `ROOT_ANCHORED_METRICS_SPECIFICATION.md`,
+`DISTRIBUTIONAL_COMPRESSION_THEORY.md`, and
+`PARENT_BRANCHING_DISTRIBUTION_THEORY.md`.
+
+The main distinction is between:
+
+1. the **proposal correction** needed because a random walk does not sample all
+   paths uniformly, and
+2. the **path-value kernel** that says which quantity the query wants to sum.
+
+Both may be called a "weight" in informal discussion, but they are different
+objects and should stay separate in code and reports.
+
+## 1. Admissible parent paths
+
+Fix a target node `v0`, root `r`, and path-length budget `B`.  A sampled
+parent path is:
+
+```text
+pi = (v0, v1, ..., vL)
+```
+
+where each `v_{i+1}` is an eligible parent of `v_i`.  Eligibility is defined by
+the active traversal policy:
+
+```text
+A_i = parents(v_i)
+      minus nodes already visited on this path
+      minus parents rejected by the root-cone or reachability filter
+      minus any other active parent filter
+d_i = |A_i|
+```
+
+The simple-path rule is per path: a node cannot appear twice in the same sampled
+path.  The path terminates when it reaches the root, hits a cache boundary, runs
+out of budget, or has no eligible parents.
+
+## 2. Proposal correction
+
+The current sampler chooses uniformly from the eligible parent set at each
+step.  For a complete sampled prefix of length `L`, the proposal probability is:
+
+```text
+q(pi) = product_{i=0}^{L-1} 1 / d_i
+```
+
+The inverse-proposal correction is therefore:
+
+```text
+c(pi) = 1 / q(pi) = product_{i=0}^{L-1} d_i
+```
+
+This is the branch-product value currently reported by the probe as the sample
+"weight".  It is not a path-length preference.  It only corrects for the fact
+that high-branching prefixes are less likely to be sampled by a one-parent
+random walk.
+
+If a future sampler enumerates all prefixes exactly, or samples complete paths
+uniformly from the admissible path set, this correction changes.  In the exact
+enumeration case it disappears because every path is already counted once.
+
+## 3. Path-value kernels
+
+Let `g(pi)` be the value the query wants to sum over root-reaching paths.  Common
+examples are:
+
+```text
+path count:              g(pi) = 1
+path length numerator:   g(pi) = L
+decayed length kernel:   g(pi) = b_p^(-L)
+weighted power:          g(pi) = (L + 1)^(-n)
+```
+
+The unbiased Monte Carlo estimator for the path-space sum is:
+
+```text
+S_hat_g = (1 / N) * sum_{samples j} c(pi_j) * g(pi_j) * I[pi_j reaches r]
+```
+
+For a mean property `f(pi)` over root-reaching paths, estimate the numerator and
+denominator separately:
+
+```text
+Num_hat = (1 / N) * sum_j c(pi_j) * f(pi_j) * I[root]
+Den_hat = (1 / N) * sum_j c(pi_j) * I[root]
+Mean_hat = Num_hat / Den_hat
+```
+
+For a weighted mean under a kernel `g`, use:
+
+```text
+Num_hat_g = (1 / N) * sum_j c(pi_j) * g(pi_j) * f(pi_j) * I[root]
+Den_hat_g = (1 / N) * sum_j c(pi_j) * g(pi_j) * I[root]
+Mean_hat_g = Num_hat_g / Den_hat_g
+```
+
+The ratio form has finite-sample bias but is consistent.  Reports should carry
+standard errors, confidence intervals, and eventually effective sample size so
+that high-variance branch products are visible.
+
+## 4. Relationship to `b_p = E[P^2] / E[P]`
+
+The parent-branching prior `b_p` is a planning statistic, not the per-path
+proposal correction.  In a stationary approximation where every eligible parent
+count is close to `b_p`:
+
+```text
+q(pi) ~= b_p^(-L)
+c(pi) ~= b_p^L
+```
+
+This explains why `b_p^L` estimates search-space growth and why
+`b_p^(-L)` estimates the probability of one particular length-`L` path under a
+constant-branching random walk.  The actual unbiased sample correction is still
+`product_i d_i`, because the real path sees local branch counts, not the global
+average.
+
+It is valid to choose a metric kernel:
+
+```text
+g_bp(pi) = b_p^(-L)
+```
+
+This is a decay or de-multiplication choice: it makes long paths contribute less
+by the expected branching pressure.  Under the constant-branching approximation,
+the sampled contribution becomes:
+
+```text
+c(pi) * g_bp(pi) ~= b_p^L * b_p^(-L) = 1
+```
+
+That cancellation is an intuition for why equal path scoring can be reasonable
+after an explicit path-length decay.  It is not a replacement for the
+branch-product correction when the sampler is a local random walk.
+
+## 5. Boundary splice estimator
+
+Boundary sampling stops at the first compatible cached boundary node `b` instead
+of walking all the way to the root.  Suppose the sampled prefix is `rho`, length
+`ell`, with remaining budget `R = B - ell`.  Its proposal correction is:
+
+```text
+c(rho) = product_{i=0}^{ell-1} d_i
+```
+
+Let the boundary cache store an unnormalised suffix histogram:
+
+```text
+H_b[k] = number of admissible suffix paths from b to r of length k
+```
+
+For root-path count under the remaining budget, the suffix value is the CDF
+mass:
+
+```text
+M_b(R) = sum_{k <= R} H_b[k]
+```
+
+The boundary-hit contribution to the estimated root-path search space is:
+
+```text
+c(rho) * M_b(R)
+```
+
+For a path-length kernel `g(L) = b_p^(-L)`, the suffix cache needs the matching
+cumulative basis:
+
+```text
+G_b(R) = sum_{k <= R} H_b[k] * b_p^(-k)
+```
+
+and the boundary contribution is:
+
+```text
+c(rho) * b_p^(-ell) * G_b(R)
+```
+
+The same pattern applies to `weighted_power(n)`, first moments, entropy-like
+queries, or any custom functional: the boundary cache must store enough suffix
+mass or suffix numerator state for that functional.  A plain mass CDF is enough
+for reachability/count queries, but not for arbitrary functions of the suffix.
+
+## 6. Compatibility requirements
+
+A boundary splice is exact only when the suffix histogram was built under the
+same semantics as the prefix traversal:
+
+```text
+same root
+same edge direction
+same budget or horizon convention
+same parent filters and root-cone restrictions
+same cycle/simple-path policy
+same path statistic and cumulative basis
+```
+
+The simple-path condition is the hardest one.  A cached `H_b` that only forbids
+repeating nodes inside the suffix can overcount full paths if the suffix returns
+to a node already visited in the prefix.  Exact splicing for cyclic graphs would
+need a suffix state conditioned on the prefix visited set, or a structural proof
+that the boundary lies in an acyclic/root-monotone cone where suffixes cannot
+return to the prefix.  In practical Wikipedia category cones, those violations
+may be rare, but they should be reported as an approximation assumption rather
+than hidden.
+
+The current probe therefore treats filtered suffix splicing conservatively:
+when a runtime reachability filter is active, it reports boundary hits but does
+not report spliced suffix totals unless compatible suffix histograms are being
+measured with the same filter semantics.
+
+## 7. Validation plan
+
+The next validation should compare exact enumeration and sample estimates on
+small graphs where all paths are tractable:
+
+```text
+exact root path count
+sampled root path count using c(pi)
+exact mean root path length
+sampled mean root path length
+exact boundary-spliced mass for acyclic fixtures
+sampled boundary-spliced mass
+path-length kernels such as b_p^(-L) and (L + 1)^(-n)
+```
+
+For larger enwiki cones, reports should separate:
+
+```text
+proposal correction variance
+path-value kernel variance
+boundary hit probability
+remaining-budget suffix mass
+effective sample size
+root-cone/filter compatibility
+```
+
+This keeps the sampling question independent from the cache-admission question:
+`b_p^L` remains useful for planning expected search cost, while `product_i d_i`
+is the estimator correction for the random-walk proposal actually used.

--- a/scripts/lmdb_boundary_coverage_probe.py
+++ b/scripts/lmdb_boundary_coverage_probe.py
@@ -8,10 +8,12 @@ probe measures the shape of the path space that the cache can actually cover.
 In exact mode it enumerates all simple parent-prefixes until root, boundary, or
 the path-length budget is reached, subject only to optional safety caps.  In
 sample mode it samples simple random parent walks and uses branch-product
-weights to estimate path-prefix counts; those estimates are statistical and
-depend on the random-walk proposal distribution.  Boundary-terminating sampling
-is the cache-boundary estimator: after a boundary hit, the remaining suffix can
-be supplied by the boundary histogram.  Root-walk sampling is the no-boundary
+proposal corrections to estimate path-prefix counts; those estimates are
+statistical and depend on the random-walk proposal distribution.  A separate
+path-value kernel, if any, belongs to the measured functional rather than to the
+proposal correction.  Boundary-terminating sampling is the cache-boundary
+estimator: after a boundary hit, the remaining suffix can be supplied by the
+boundary histogram.  Root-walk sampling is the no-boundary
 search-space estimator: it ignores boundaries and walks to root, budget
 exhaustion, or dead end.  The default parent filter is root-cone: a bounded
 child-reachable cone is precomputed from the root, then a parent edge is
@@ -377,7 +379,12 @@ def sample_boundary_coverage(
     parent_filter_name="all",
     measure_suffix_mass=True,
 ):
-    """Sample simple random parent walks and estimate prefix counts by weights."""
+    """Sample random parent walks and estimate prefix counts by proposal correction.
+
+    The branch product corrects for the local random-walk proposal.  Boundary
+    suffix mass is a value supplied by the cached histogram for the remaining
+    budget; metric-specific kernels require matching suffix bases.
+    """
     budget = int(budget)
     boundary_nodes = set(boundary_nodes)
     rng = random.Random(str(seed))
@@ -541,7 +548,7 @@ def sample_root_path_space(
     """Sample full simple parent walks and estimate root-path search space.
 
     For a uniformly sampled simple parent walk, the product of eligible branch
-    counts along the walk is an unbiased contribution for the size of the
+    counts along the walk is the inverse-proposal correction for the size of the
     sampled path space.  Path length is the first concrete mean reported here;
     arbitrary property means need their property-specific numerator derived
     before adding them to this probe.

--- a/tests/test_lmdb_boundary_coverage_probe.py
+++ b/tests/test_lmdb_boundary_coverage_probe.py
@@ -180,6 +180,31 @@ class BoundaryCoverageProbeTests(unittest.TestCase):
         self.assertEqual(record["estimated_boundary_spliced_root_paths"], 1.0)
         self.assertEqual(record["estimated_spliced_total_root_paths"], 1.0)
 
+    def test_sample_boundary_coverage_disables_suffix_splice_with_filter(self):
+        graph = DictGraph({
+            "A": ["R"],
+            "B": ["A"],
+            "C": ["B"],
+        })
+
+        record = sample_boundary_coverage(
+            graph.parents,
+            "C",
+            "R",
+            3,
+            {"B"},
+            samples=10,
+            seed="fixture",
+            reachability_filter=lambda _node, _remaining: True,
+            parent_filter_name="test-filter",
+        )
+
+        self.assertEqual(record["boundary_hit_prefixes"], 10)
+        self.assertEqual(record["estimated_boundary_hit_prefixes"], 1.0)
+        self.assertIsNone(record["estimated_boundary_spliced_root_paths"])
+        self.assertIsNone(record["estimated_spliced_total_root_paths"])
+        self.assertFalse(record["boundary_suffix_mass_measured"])
+
     def test_sample_root_path_space_estimates_root_count_and_mean_length(self):
         graph = DictGraph({
             "A": ["R"],


### PR DESCRIPTION
## Summary

- Add `ROOT_PATH_SAMPLE_ESTIMATOR_THEORY.md` to separate random-walk proposal correction from path-value kernels.
- Clarify that `b_p = E[P^2] / E[P]` is a planning prior: `b_p^L` is an expected search-growth estimate, while concrete samples still use `product_i d_i` as the inverse-proposal correction.
- Document boundary splice formulas for mass CDFs and metric-specific suffix bases such as `b_p^{-L}` or weighted-power kernels.
- Tighten probe comments and add a unit test that filtered sampling leaves suffix spliced totals unset when compatible suffix histograms are unavailable.

## Validation

- `python3 -m unittest tests.test_lmdb_boundary_coverage_probe tests.test_lmdb_parent_boundary_cache_benchmark tests.test_distribution_precompute_depth_estimator`
- `python3 -m py_compile scripts/lmdb_boundary_coverage_probe.py tests/test_lmdb_boundary_coverage_probe.py`
- `git diff --check`
- `git diff --cached --check`