### PR TITLE
feat(wam-rust): T9 fact-table inline — design + detection (step 1)

### DIFF
--- a/docs/proposals/wam_rust_t9_fact_table_design.md
+++ b/docs/proposals/wam_rust_t9_fact_table_design.md
@@ -1,0 +1,132 @@
+# rust T9 — fact-table inline (design)
+
+**Status:** design / spec / implementation plan. Survey of the reference targets
+(R / Haskell / Lua) + the Rust target's current fact handling is folded in.
+
+---
+
+## 1. Philosophy
+
+**What T9 is.** Ground unit-clause predicates (`color(red). color(green). …`,
+`edge(a,b). edge(b,c). …`) compiled to a native data table + an inlined,
+indexed lookup, instead of going through the bytecode WAM interpreter.
+
+**Crucial framing: T9 is an *optimization over the already-correct T4*, not a
+correctness gap.** Rust T4 (`multi_clause_n`) already lowers a fact predicate —
+each fact is just a clause alternative (`get_constant…/proceed`) with an
+iter-style retry choice point — so `color(X)` already enumerates correctly today.
+T9's win is **for large fact sets**: N facts under T4 = N clause branches (linear
+dispatch, large generated code); under T9 = one compact table + an index
+(first-argument `HashMap`), giving O(1)-ish lookup and small code. So T9 should be
+**threshold-gated** (only beat T4 above ~N rows) and must **preserve T4's exact
+observable behaviour** (all query modes, full backtracking enumeration, order).
+
+**Design principles:**
+
+1. **Don't regress correctness.** T9 must produce the same solutions in the same
+   order as the current (T4/WAM) path for every mode: all-ground membership
+   check, partially-bound, fully-unbound enumeration.
+2. **Prolog-level detection.** Unlike R/Haskell/Lua (which parse WAM *bytecode*
+   segments because their pipelines start from WAM text), the Rust target already
+   has the source clauses (it uses `clause/2` for the parallel-aggregate
+   injection). Detecting "all clauses are ground unit clauses" and extracting the
+   tuples is far simpler from source than from bytecode — reuse
+   `wam_fact_table.pl:is_fact_predicate/2` + a tuple extractor.
+3. **Reuse the enumeration protocol.** The generated lookup must integrate with
+   the WAM choice-point/backtrack protocol the same way T4 does (first solution on
+   call; `backtrack()` yields the next), so existing callers and the
+   par_collect/aggregate machinery keep working unchanged.
+4. **Threshold + gate.** Only apply above a row threshold (default ~64–128, like
+   scala's auto-inline cutoff), overridable (`t9_min_rows(N)`); below it, leave T4
+   to handle it. Optionally behind an opt-in flag initially.
+5. **First-argument index.** The common query mode binds A1; index tuples by the
+   first argument's principal functor/value (a `HashMap<Key, Vec<RowIdx>>`), with
+   a full scan fallback when A1 is unbound.
+
+---
+
+## 2. Specification
+
+### 2.1 Detection
+A predicate `p/n` is T9-eligible iff every clause is a **ground unit clause**
+(body `true`, all head args ground). Extract `rows = [[c11,…,c1n], …]` (one
+ground arg-tuple per clause, in source order). `n ≥ 1`. Eligible only when
+`length(rows) ≥ t9_min_rows` (else decline → T4 handles it).
+
+### 2.2 Emission (native function + table)
+For `p/n`, emit:
+- a `static`/`OnceLock` table of the rows (interned atom ids / integers), plus a
+  first-argument index `HashMap<Key, Vec<usize>>`;
+- a `pub fn p_n(vm, a1..an) -> bool` that:
+  - **A1 bound** → look up candidate rows in the index, unify each with `a1..an`;
+  - **A1 unbound** → iterate all rows;
+  - on the first unifying row, bind the args and **push a choice point** that, on
+    `backtrack()`, resumes the scan at the next candidate row (mirroring T4's
+    retry CP — likely a `builtin_state`-style frame with the predicate name + the
+    next row index, handled in `resume_builtin`);
+  - return `true`/`false` accordingly.
+- Order: rows are tried in source order ⇒ same solution order as T4/WAM.
+
+### 2.3 Query-mode correctness (the test matrix)
+For `edge(a,b). edge(a,c). edge(b,d).`:
+- `edge(a, X)` → X = b, c (in order), via backtrack.
+- `edge(X, Y)` → all three pairs, in order.
+- `edge(a, c)` → true; `edge(a, z)` → false.
+- `edge(X, d)` → X = b (A1 unbound, A2 bound — full scan + unify).
+Each must equal the current path's result.
+
+### 2.4 Gating / decline
+- Off unless enabled (`fact_table_inline(true)` initially, or always-on above the
+  threshold once proven); below `t9_min_rows`, decline.
+- Decline for non-ground or non-unit clauses (→ existing path).
+- Default output unchanged when disabled.
+
+---
+
+## 3. Implementation plan
+
+In `wam_rust_target.pl`, with the lowered emitter (`wam_rust_lowered_emitter.pl`)
+and the fact detector (`wam_fact_table.pl`).
+
+### Step 1 — detection + extraction (pure, tested first)
+`rust_fact_table_classify(+Module:Pred/Arity, +Options, -fact_info(Arity, Rows))`:
+reuse `is_fact_predicate/2`; collect ground arg-tuples via `clause/2`; enforce
+`t9_min_rows`. Unit-test: recognises a fact predicate + extracts rows in order;
+declines non-ground / rule-bearing / below-threshold predicates. **No codegen.**
+
+### Step 2 — emission
+`emit_fact_table_rust(+Pred/Arity, +fact_info, +Options, -RustCode)` →
+`static` table + first-arg index + `pub fn p_n` with CP-based enumeration. Model
+the table/index on R's `emit_fact_table/7`; model the choice-point enumeration on
+the Rust T4 retry CP (`wam_rust_lowered_emitter.pl` multi_clause_n) +
+`resume_builtin`. Interning: reuse the machine's `atom_intern`.
+
+### Step 3 — classification seam
+In `classify_predicates/3` (`wam_rust_target.pl` ~line 5560), add the T9 check
+**before** `wam_rust_lowerable` so it takes precedence when eligible:
+```
+( option(fact_table_inline(true), Options),
+  rust_fact_table_classify(Module:Pred/Arity, Options, FInfo)
+-> emit_fact_table_rust(...), Entry = classified(..., fact_table, ...)
+;  ... existing lowered / wam path ... )
+```
+Add a `fact_table` arm to `generate_predicate_codes/4`.
+
+### Step 4 — exec + regression
+`tests/test_wam_rust_fact_table_exec.pl` (cargo): the §2.3 query-mode matrix,
+asserting each mode == the current path. Full `test_wam_rust_target.pl` stays
+green (disabled ⇒ unchanged). Update the matrix: rust T9 `✗ → ✓` (or `~` if
+threshold-gated/opt-in).
+
+### Risk register
+- **Backtracking integration** is the crux — get the CP/`resume_builtin`
+  enumeration exactly right, else later solutions are lost or order changes. The
+  §2.3 matrix is the guard.
+- **Atom interning consistency** between the table and query args.
+- **Index vs scan** for partially-bound modes — when A1 is unbound, must full-scan
+  (don't rely on the A1 index).
+
+### Order of work (each committable)
+1. Step 1 detection/extraction (pure + unit tests).
+2. Step 2+3 emission + seam (cargo-check a generated project).
+3. Step 4 exec query-mode matrix + regression + matrix doc.

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -4590,6 +4590,34 @@ rust_assert_helper(Module, (Head :- Body), Module:Name/Arity) :-
     copy_term((Head :- Body), (H :- B)),
     assertz(Module:(H :- B)).
 
+% --- T9 fact-table inline: detection + row extraction ----------------------
+%
+% Recognise a predicate whose every clause is a ground unit clause (a fact) and
+% extract its rows (one ground arg-tuple per clause, source order). Above the
+% t9_min_rows threshold this is a candidate for a native fact table + indexed
+% lookup (T9), an optimisation over T4 for large fact sets. Pure analysis — no
+% codegen. Fails (predicate handled by the existing T4/WAM path) when any clause
+% is a rule or non-ground, or when there are fewer than t9_min_rows rows.
+
+rust_fact_table_classify(QPI, Options, fact_info(Arity, Rows)) :-
+    ( QPI = Module:Pred/Arity -> true ; QPI = Pred/Arity, Module = user ),
+    functor(Head, Pred, Arity),
+    findall(Head-Body, clause(Module:Head, Body), Clauses),
+    Clauses = [_|_],                                  % at least one clause
+    forall(member(CH-CB, Clauses), rust_fact_clause(CH, CB)),
+    findall(Args, ( member(FH-true, Clauses), FH =.. [_|Args] ), Rows),
+    rust_t9_min_rows(Options, Min),
+    length(Rows, NR), NR >= Min.
+
+% a fact clause: body `true`, head args all ground.
+rust_fact_clause(Head, Body) :-
+    Body == true,
+    Head =.. [_|Args],
+    forall(member(A, Args), ground(A)).
+
+rust_t9_min_rows(Options, N) :-
+    ( member(t9_min_rows(N), Options) -> true ; N = 64 ).
+
 foreign_wrapper_setup(Pred/Arity, WamCode, Options, InstrSetup, Setup, RunExpr) :-
     (   option(foreign_lowering(ForeignSpec), Options),
         rust_foreign_spec(Pred/Arity, ForeignSpec, SetupOps, EntryPred/EntryArity)

--- a/tests/test_wam_rust_fact_table.pl
+++ b/tests/test_wam_rust_fact_table.pl
@@ -1,0 +1,48 @@
+% test_wam_rust_fact_table.pl
+%
+% T9 fact-table inline, step 1 (detection + row extraction):
+% wam_rust_target:rust_fact_table_classify/3 recognises a ground-unit-clause
+% predicate and extracts its rows (source order), gated by t9_min_rows. Declines
+% rule-bearing, non-ground, and below-threshold predicates. Pure Prolog (no cargo).
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target').
+
+% ---- fixtures --------------------------------------------------------------
+ft_color(red). ft_color(green). ft_color(blue).
+ft_edge(a, b). ft_edge(a, c). ft_edge(b, d).
+ft_mixed(1). ft_mixed(2). ft_mixed(X) :- X > 100.   % has a rule -> not a fact table
+ft_nonground(foo). ft_nonground(_).                 % a non-ground unit clause
+ft_small(only).                                     % 1 row -> below threshold
+
+classify(PI, Opts, Info) :-
+    wam_rust_target:rust_fact_table_classify(user:PI, Opts, Info).
+
+:- begin_tests(wam_rust_fact_table).
+
+test(detects_unary_facts_in_order) :-
+    classify(ft_color/1, [t9_min_rows(2)], fact_info(A, Rows)),
+    assertion(A == 1),
+    assertion(Rows == [[red], [green], [blue]]).
+
+test(detects_binary_facts_in_order) :-
+    classify(ft_edge/2, [t9_min_rows(2)], fact_info(A, Rows)),
+    assertion(A == 2),
+    assertion(Rows == [[a, b], [a, c], [b, d]]).
+
+test(declines_predicate_with_a_rule) :-
+    assertion(\+ classify(ft_mixed/1, [t9_min_rows(1)], _)).
+
+test(declines_non_ground_unit_clause) :-
+    assertion(\+ classify(ft_nonground/1, [t9_min_rows(1)], _)).
+
+test(declines_below_threshold) :-
+    % ft_color has 3 rows; threshold 4 -> decline
+    assertion(\+ classify(ft_color/1, [t9_min_rows(4)], _)),
+    % ft_small has 1 row
+    assertion(\+ classify(ft_small/1, [t9_min_rows(2)], _)).
+
+test(default_threshold_is_64) :-
+    % no t9_min_rows option -> default 64 -> ft_color (3 rows) declines
+    assertion(\+ classify(ft_color/1, [], _)).
+
+:- end_tests(wam_rust_fact_table).


### PR DESCRIPTION
## What

Starts **rust T9 (fact-table inline)**: design doc + the pure detection/extraction slice.

**Framing:** T9 is an *optimisation over the already-correct T4* (which lowers each fact as a clause alternative), not a correctness gap. For *large* fact sets, a compact native table + first-arg index beats N clause branches. Threshold-gated; must preserve T4's exact observable behaviour.

- **`docs/proposals/wam_rust_t9_fact_table_design.md`** — philosophy (perf-opt over T4; Prolog-level detection since the Rust target has source clauses; reuse the enumeration protocol; threshold + first-arg index), specification (the query-mode correctness matrix), implementation plan (detection → emission → classification seam → exec/regression), risk register (backtracking integration is the crux).
- **`rust_fact_table_classify/3`** — recognises a predicate whose every clause is a ground unit clause and extracts rows in source order, gated by `t9_min_rows` (default 64). Declines rules / non-ground / below-threshold. Pure analysis.

## Tests
`tests/test_wam_rust_fact_table.pl` — 6, green: unary/binary detection + row order, decline for rule/non-ground/below-threshold, default-threshold-64.

## Next (in the design doc)
Emission (`static` table + first-arg index + `pub fn` with CP-based enumeration) + classification seam + exec query-mode matrix.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_