### PR TITLE
Support PLAWK branch print actions

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -275,11 +275,13 @@ length($0); hits++ } END { print hits, last_len }` also stay native. The first
 native `if/else` action slice lowers field-equality conditions once at rule-body
 scope, threads the whole scalar slot vector through then/else action sequences,
 emits per-slot phis at the branch join, and can run field-key associative
-increments as branch-local side effects. Scalar, mixed, and assoc-only branch
-bodies now share the same rule-body action walker; branch phis use each branch's
-actual exit block, including assoc side-effect `_done` blocks. Branch-local
-`print`, `next`, and `break` still need a broader intra-rule CFG. Native rule
-chains also support terminal
+increments or selected-field `print` as branch-local side effects. Scalar,
+mixed, and assoc-only branch bodies now share the same rule-body action walker;
+branch phis use each branch's actual exit block, including assoc side-effect
+`_done` blocks. Branch-local `print` uses prefixed SSA names so multiple branch
+prints do not collide. Branch-local `next` and `break` still need a broader
+intra-rule CFG; branch-local `NR` printing also waits on carrying the record
+counter through stateful native loops. Native rule chains also support terminal
 `next` by branching directly to the stream-loop continuation; scalar and mixed
 chains add the early-exit rule's scalar values to the loop phi inputs, while
 assoc-only chains update tables before the continuation branch. Terminal

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -96,12 +96,12 @@ integer literals and `length($N)`.
 Scalar slot updates can also sit behind native `if/else` guards, e.g.
 `{ if ($1 == "ERROR") { errors++; last_len = length($0) } else { non_errors++ } }
 END { print errors, non_errors, last_len }`. The first branch slice supports
-field-equality conditions, scalar updates, and field-key associative increments
-inside branches. The native lowering evaluates each source `if` guard once,
-threads every scalar slot through the then/else bodies, emits associative table
-increments only on the selected branch, and rejoins scalar slots with per-slot
-LLVM phis. Branch-local `print`, `next`, and `break` remain outside this
-boundary.
+field-equality conditions, scalar updates, field-key associative increments,
+and selected-field `print` inside branches. The native lowering evaluates each
+source `if` guard once, threads every scalar slot through the then/else bodies,
+emits associative table increments and branch-local prints only on the selected
+branch, and rejoins scalar slots with per-slot LLVM phis. Branch-local `next`,
+`break`, and `NR` printing remain outside this boundary.
 Terminal `next` is supported in native rule chains, so `$1 == "DEBUG" {
 skipped++; next } { total++ } END { print total, skipped }` skips the later
 rule for matching records. Terminal `break` is supported in the same native

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -255,8 +255,8 @@ END { print total, errors, non_errors, last_len }
 ```
 
 For now, branch bodies support scalar updates, field-key associative increments,
-and combinations of the two. Branch-local `print`, `next`, and `break` are
-rejected by native codegen.
+selected-field `print`, and combinations of those actions. Branch-local `next`,
+`break`, and `NR` printing are rejected by native codegen.
 The generated native code evaluates the `if` condition once, runs the selected
 branch, and rejoins all scalar slots through LLVM phi nodes before later actions
 or rules continue.
@@ -269,6 +269,16 @@ Associative increments can live inside the selected branch:
   else { by_kind[$1]++ }
 }
 END { print by_component["disk"], by_kind["WARN"] }
+```
+
+Branches can also print selected fields:
+
+```awk
+{
+  if ($1 == "ERROR") { print $2, $3 }
+  else { counts[$1]++ }
+}
+END { print counts["WARN"] }
 ```
 
 A terminal `next` skips the remaining rules for the current record:

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -36,6 +36,7 @@
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
 %      $1 == "ERROR" { last_len = length($0); hits++ } END { print hits, last_len }
 %      { if ($1 == "ERROR") { errors++ } else { warnings++ } } END { print errors, warnings }
+%      { if ($1 == "ERROR") { print $2, $3 } else { counts[$1]++ } } END { print counts["WARN"] }
 %
 %  The surrounding runtime still comes from write_wam_llvm_project/3. This
 %  function emits the target-specific native main that streams the file, lowers
@@ -91,7 +92,7 @@ plawk_program_native_driver_ir(
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_assoc_print_key_globals(PrintFields, AssocGlobalIR),
     plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
-    plawk_mixed_rule_chain_ir(MixedPlan, FieldSeparator, RuleGlobalIR, RuleChainIR, RuleCount),
+    plawk_mixed_rule_chain_ir(MixedPlan, FieldSeparator, OutputSeparator, RuleGlobalIR, RuleChainIR, RuleCount),
     plawk_state_loop_phi_ir(ScalarPlan, LoopPhiIR),
     plawk_mixed_rule_controls(MixedPlan, MixedRuleControls),
     plawk_mixed_scalar_next_phi_ir(ScalarPlan, RuleCount, MixedRuleControls, NextPhiIR),
@@ -123,7 +124,7 @@ plawk_program_native_driver_ir(
     plawk_begin_print_ir(BeginClauses, OutputSeparator, BeginIR),
     plawk_field_separator(BeginClauses, FieldSeparator),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
-    plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, RuleGlobalIR, RuleChainIR, RuleCount),
+    plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, OutputSeparator, RuleGlobalIR, RuleChainIR, RuleCount),
     plawk_state_loop_phi_ir(StatePlan, LoopPhiIR),
     plawk_scalar_rule_controls(Rules, ScalarRuleControls),
     plawk_scalar_next_phi_ir(StatePlan, RuleCount, ScalarRuleControls, NextPhiIR),
@@ -184,6 +185,8 @@ plawk_combine_entry_ir(FirstIR, SecondIR, CombinedIR) :-
 plawk_i64_end_print_globals(SurfaceGlobals, RuntimeGlobals) :-
     format(atom(RuntimeGlobals),
 '@.plawk_surface_print_i64 = private constant [4 x i8] c"%ld\\00"
+@.plawk_surface_print_line = private constant [4 x i8] c"%s\\0A\\00"
+@.plawk_surface_print_slice = private constant [5 x i8] c"%.*s\\00"
 @.plawk_surface_print_newline = private constant [2 x i8] c"\\0A\\00"
 @.plawk_surface_print_string = private constant [3 x i8] c"%s\\00"
 ~w
@@ -535,6 +538,8 @@ plawk_mixed_update_action(Action) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
 plawk_mixed_update_action(Action) :-
     plawk_assoc_update_action(Action).
+plawk_mixed_update_action(Action) :-
+    plawk_rule_body_print_action(Action).
 plawk_mixed_update_action(if(_Pattern, ThenActions, ElseActions)) :-
     append(ThenActions, ElseActions, Actions),
     Actions \== [],
@@ -565,11 +570,11 @@ plawk_assoc_increment_spec_in_action(if(_Pattern, ThenActions, ElseActions), Spe
     ; plawk_assoc_increment_spec_in_actions(ElseActions, Spec)
     ).
 
-plawk_mixed_rule_chain_ir(mixed_plan(ScalarPlan, AssocPlan, Rules), FieldSeparator, GlobalIR, ChainIR, RuleCount) :-
+plawk_mixed_rule_chain_ir(mixed_plan(ScalarPlan, AssocPlan, Rules), FieldSeparator, OutputSeparator, GlobalIR, ChainIR, RuleCount) :-
     length(Rules, RuleCount),
     RuleCount > 0,
     plawk_mixed_rule_controls(mixed_plan(ScalarPlan, AssocPlan, Rules), Controls),
-    phrase(plawk_mixed_rule_chain_lines(Rules, Controls, ScalarPlan, AssocPlan, FieldSeparator, 0), Pairs),
+    phrase(plawk_mixed_rule_chain_lines(Rules, Controls, ScalarPlan, AssocPlan, FieldSeparator, OutputSeparator, 0), Pairs),
     pairs_keys_values(Pairs, GlobalParts, ChainParts),
     atomic_list_concat(GlobalParts, '\n', GlobalIR),
     atomic_list_concat(ChainParts, '\n', ChainIR).
@@ -577,9 +582,9 @@ plawk_mixed_rule_chain_ir(mixed_plan(ScalarPlan, AssocPlan, Rules), FieldSeparat
 plawk_mixed_rule_controls(mixed_plan(_ScalarPlan, _AssocPlan, Rules), Controls) :-
     findall(Control, member(mixed_rule(_Index, _Pattern, _ScalarActions, _AssocActions, Control), Rules), Controls).
 
-plawk_mixed_rule_chain_lines([], _Controls, _ScalarPlan, _AssocPlan, _FieldSeparator, _) -->
+plawk_mixed_rule_chain_lines([], _Controls, _ScalarPlan, _AssocPlan, _FieldSeparator, _OutputSeparator, _) -->
     [].
-plawk_mixed_rule_chain_lines([mixed_rule(Index, Pattern, Actions, _AssocActions, Control) | Rest], Controls, ScalarPlan, AssocPlan, FieldSeparator, Index) -->
+plawk_mixed_rule_chain_lines([mixed_rule(Index, Pattern, Actions, _AssocActions, Control) | Rest], Controls, ScalarPlan, AssocPlan, FieldSeparator, OutputSeparator, Index) -->
     { NextIndex is Index + 1,
       ( Rest == []
       -> NextLabel = 'continue_loop'
@@ -592,7 +597,7 @@ plawk_mixed_rule_chain_lines([mixed_rule(Index, Pattern, Actions, _AssocActions,
       plawk_mixed_scalar_rule_input_phi_ir(ScalarPlan, Index, Controls, InputPhiIR),
       plawk_mixed_rule_guard_ir(Pattern, Index, RuleLabel, ApplyLabel,
           NextLabel, InputPhiIR, FieldSeparator, GuardGlobalIR-GuardIR),
-      plawk_native_match_update_ir(ScalarPlan, AssocPlan, Actions, FieldSeparator, Index,
+      plawk_native_match_update_ir(ScalarPlan, AssocPlan, Actions, FieldSeparator, OutputSeparator, Index,
           ActionGlobalIR-ActionIR),
       ( Index =:= 0
       -> EntryIR = '  br label %rule_0_match\n\n'
@@ -612,7 +617,7 @@ plawk_mixed_rule_chain_lines([mixed_rule(Index, Pattern, Actions, _AssocActions,
       Pair = CombinedGlobalIR-RuleIR
     },
     [Pair],
-    plawk_mixed_rule_chain_lines(Rest, Controls, ScalarPlan, AssocPlan, FieldSeparator, NextIndex).
+    plawk_mixed_rule_chain_lines(Rest, Controls, ScalarPlan, AssocPlan, FieldSeparator, OutputSeparator, NextIndex).
 
 plawk_mixed_rule_guard_ir(always, Index, RuleLabel, ApplyLabel, NextLabel,
     InputPhiIR, _FieldSeparator, ''-IR) :-
@@ -1133,11 +1138,11 @@ plawk_mixed_end_print_lines([string(Value) | Rest], ScalarPlan, AssocPlan, Outpu
 
 plawk_scalar_print_expr(var(Name), Name).
 
-plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, GlobalIR, ChainIR, RuleCount) :-
+plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, OutputSeparator, GlobalIR, ChainIR, RuleCount) :-
     plawk_scalar_planned_rules(Rules, PlannedRules, Controls),
     length(PlannedRules, RuleCount),
     RuleCount > 0,
-    phrase(plawk_scalar_rule_chain_lines(PlannedRules, Controls, StatePlan, FieldSeparator, 0), Pairs),
+    phrase(plawk_scalar_rule_chain_lines(PlannedRules, Controls, StatePlan, FieldSeparator, OutputSeparator, 0), Pairs),
     pairs_keys_values(Pairs, GlobalParts, ChainParts),
     atomic_list_concat(GlobalParts, '\n', GlobalIR),
     atomic_list_concat(ChainParts, '\n', ChainIR).
@@ -1156,9 +1161,9 @@ plawk_scalar_planned_rule_lines([rule(Pattern, Actions) | Rest], Index) -->
     [scalar_rule(Index, Pattern, BodyActions, Control)],
     plawk_scalar_planned_rule_lines(Rest, NextIndex).
 
-plawk_scalar_rule_chain_lines([], _Controls, _StatePlan, _FieldSeparator, _) -->
+plawk_scalar_rule_chain_lines([], _Controls, _StatePlan, _FieldSeparator, _OutputSeparator, _) -->
     [].
-plawk_scalar_rule_chain_lines([scalar_rule(Index, Pattern, Actions, Control) | Rest], Controls, StatePlan, FieldSeparator, Index) -->
+plawk_scalar_rule_chain_lines([scalar_rule(Index, Pattern, Actions, Control) | Rest], Controls, StatePlan, FieldSeparator, OutputSeparator, Index) -->
     { NextIndex is Index + 1,
       ( Rest == []
       -> NextLabel = 'continue_loop'
@@ -1173,9 +1178,10 @@ plawk_scalar_rule_chain_lines([scalar_rule(Index, Pattern, Actions, Control) | R
       plawk_pattern_guard_ir(Pattern, FieldSeparator, GlobalBase, MatchValue,
           GuardGlobalIR-GuardCallIR),
       plawk_rule_target(Control, NextLabel, RuleTargetLabel),
-      include(plawk_scalar_update_action, Actions, ScalarActions),
+      maplist(plawk_scalar_rule_body_action, Actions),
+      BodyActions = Actions,
       plawk_scalar_rule_input_phi_ir(StatePlan, Index, Controls, InputPhiIR),
-      plawk_scalar_match_update_ir(StatePlan, ScalarActions, FieldSeparator, Index,
+      plawk_scalar_match_update_ir(StatePlan, BodyActions, FieldSeparator, OutputSeparator, Index,
           MatchUpdateGlobalIR-MatchUpdateIR),
       ( Index =:= 0
       -> EntryIR = '  br label %rule_0_match\n\n'
@@ -1199,7 +1205,7 @@ plawk_scalar_rule_chain_lines([scalar_rule(Index, Pattern, Actions, Control) | R
       Pair = CombinedGlobalIR-BranchIR
     },
     [Pair],
-    plawk_scalar_rule_chain_lines(Rest, Controls, StatePlan, FieldSeparator, NextIndex).
+    plawk_scalar_rule_chain_lines(Rest, Controls, StatePlan, FieldSeparator, OutputSeparator, NextIndex).
 
 plawk_scalar_rule_input_phi_ir(_StatePlan, 0, _Controls, '') :-
     !.
@@ -1262,14 +1268,14 @@ plawk_scalar_loop_phi_lines([_Slot | Rest], Index) -->
     [Line],
     plawk_scalar_loop_phi_lines(Rest, NextIndex).
 
-plawk_scalar_match_update_ir(StatePlan, Actions, FieldSeparator, RuleIndex, GlobalIR-IR) :-
-    plawk_native_match_update_ir(StatePlan, none, Actions, FieldSeparator, RuleIndex, GlobalIR-IR).
+plawk_scalar_match_update_ir(StatePlan, Actions, FieldSeparator, OutputSeparator, RuleIndex, GlobalIR-IR) :-
+    plawk_native_match_update_ir(StatePlan, none, Actions, FieldSeparator, OutputSeparator, RuleIndex, GlobalIR-IR).
 
-plawk_native_match_update_ir(StatePlan, AssocPlan, Actions, FieldSeparator, RuleIndex, GlobalIR-IR) :-
+plawk_native_match_update_ir(StatePlan, AssocPlan, Actions, FieldSeparator, OutputSeparator, RuleIndex, GlobalIR-IR) :-
     plawk_state_plan_slots(StatePlan, Slots),
     phrase(plawk_scalar_initial_slot_values(RuleIndex, Slots, 0), InitialValues),
     format(atom(Prefix), 'rule_~w_body', [RuleIndex]),
-    phrase(plawk_scalar_action_sequence_pairs(Actions, Slots, AssocPlan, FieldSeparator,
+    phrase(plawk_scalar_action_sequence_pairs(Actions, Slots, AssocPlan, FieldSeparator, OutputSeparator,
         Prefix, Prefix, RuleIndex, 0, InitialValues, FinalValues, _NextOpIndex, _ExitLabel), Pairs0),
     phrase(plawk_scalar_final_slot_pairs(FinalValues, RuleIndex, 0), FinalPairs),
     append(Pairs0, FinalPairs, Pairs),
@@ -1301,6 +1307,32 @@ plawk_scalar_update_action(Action) :-
 plawk_scalar_update_action(Action) :-
     plawk_scalar_conditional_action(Action).
 
+plawk_scalar_rule_body_action(Action) :-
+    plawk_scalar_action_update(Action, _Name, _Operation).
+plawk_scalar_rule_body_action(Action) :-
+    plawk_rule_body_print_action(Action).
+plawk_scalar_rule_body_action(if(_Pattern, ThenActions, ElseActions)) :-
+    append(ThenActions, ElseActions, Actions),
+    Actions \== [],
+    maplist(plawk_scalar_rule_body_plain_action, Actions).
+
+plawk_scalar_rule_body_plain_action(Action) :-
+    plawk_scalar_action_update(Action, _Name, _Operation).
+plawk_scalar_rule_body_plain_action(Action) :-
+    plawk_rule_body_print_action(Action).
+
+plawk_rule_body_print_action(print(Fields)) :-
+    Fields = [_ | _],
+    maplist(plawk_rule_body_print_field, Fields).
+
+plawk_rule_body_print_field(field(_)).
+plawk_rule_body_print_field(special('NF')).
+plawk_rule_body_print_field(length(field(_))).
+plawk_rule_body_print_field(substr(field(_), _Start, _Len)).
+plawk_rule_body_print_field(index(field(_), string(_))).
+plawk_rule_body_print_field(tolower(field(_))).
+plawk_rule_body_print_field(toupper(field(_))).
+
 plawk_scalar_update_action_name(Action, Name) :-
     plawk_scalar_action_update(Action, Name, _Operation).
 plawk_scalar_update_action_name(if(_Pattern, ThenActions, ElseActions), Name) :-
@@ -1321,10 +1353,10 @@ plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) 
 plawk_scalar_action_update(set(var(Name), length(field(FieldIndex))), Name, set(length(FieldIndex))) :-
     FieldIndex >= 0.
 
-plawk_scalar_action_sequence_pairs([], _Slots, _AssocPlan, _FieldSeparator, _Prefix, CurrentLabel, _RuleIndex,
+plawk_scalar_action_sequence_pairs([], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
         OpIndex, Values, Values, OpIndex, CurrentLabel) -->
     [].
-plawk_scalar_action_sequence_pairs([Action | Rest], Slots, AssocPlan, FieldSeparator, Prefix, CurrentLabel, RuleIndex,
+plawk_scalar_action_sequence_pairs([Action | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
         OpIndex, Values0, Values, FinalOpIndex, ExitLabel) -->
     { plawk_scalar_action_update(Action, Name, Operation),
       nth0(SlotIndex, Slots, scalar_counter(Name)),
@@ -1335,9 +1367,9 @@ plawk_scalar_action_sequence_pairs([Action | Rest], Slots, AssocPlan, FieldSepar
       NextOpIndex is OpIndex + 1
     },
     [Pair],
-    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, Prefix, CurrentLabel, RuleIndex,
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
         NextOpIndex, Values1, Values, FinalOpIndex, ExitLabel).
-plawk_scalar_action_sequence_pairs([Action | Rest], Slots, AssocPlan, FieldSeparator, Prefix, _CurrentLabel, RuleIndex,
+plawk_scalar_action_sequence_pairs([Action | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, _CurrentLabel, RuleIndex,
         OpIndex, Values0, Values, FinalOpIndex, ExitLabel) -->
     { plawk_assoc_increment_action(Action, ArrayName-KeyIndex),
       plawk_assoc_table_index(AssocPlan, ArrayName, TableIndex),
@@ -1346,19 +1378,29 @@ plawk_scalar_action_sequence_pairs([Action | Rest], Slots, AssocPlan, FieldSepar
       NextOpIndex is OpIndex + 1
     },
     [Pair],
-    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, Prefix, AssocExitLabel, RuleIndex,
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, AssocExitLabel, RuleIndex,
+        NextOpIndex, Values0, Values, FinalOpIndex, ExitLabel).
+plawk_scalar_action_sequence_pairs([print(Fields) | Rest], Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
+        OpIndex, Values0, Values, FinalOpIndex, ExitLabel) -->
+    { plawk_rule_body_print_action(print(Fields)),
+      format(atom(PrintPrefix), '~w_print_~w', [Prefix, OpIndex]),
+      plawk_prefixed_print_action_ir(Fields, FieldSeparator, OutputSeparator, PrintPrefix, Pair),
+      NextOpIndex is OpIndex + 1
+    },
+    [Pair],
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, CurrentLabel, RuleIndex,
         NextOpIndex, Values0, Values, FinalOpIndex, ExitLabel).
 plawk_scalar_action_sequence_pairs([if(Pattern, ThenActions, ElseActions) | Rest],
-        Slots, AssocPlan, FieldSeparator, Prefix, _CurrentLabel, RuleIndex, OpIndex, Values0, Values, FinalOpIndex, ExitLabel) -->
+        Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, _CurrentLabel, RuleIndex, OpIndex, Values0, Values, FinalOpIndex, ExitLabel) -->
     { format(atom(GlobalBase), '~w_if_~w', [Prefix, OpIndex]),
       format(atom(CondValue), '%~w_if_~w_cond', [Prefix, OpIndex]),
       plawk_pattern_guard_ir(Pattern, FieldSeparator, GlobalBase, CondValue, GuardGlobalIR-GuardIR),
       format(atom(ThenLabel), '~w_if_~w_then', [Prefix, OpIndex]),
       format(atom(ElseLabel), '~w_if_~w_else', [Prefix, OpIndex]),
       format(atom(DoneLabel), '~w_if_~w_done', [Prefix, OpIndex]),
-      phrase(plawk_scalar_action_sequence_pairs(ThenActions, Slots, AssocPlan, FieldSeparator,
+      phrase(plawk_scalar_action_sequence_pairs(ThenActions, Slots, AssocPlan, FieldSeparator, OutputSeparator,
           ThenLabel, ThenLabel, RuleIndex, 0, Values0, ThenValues, _ThenOpIndex, ThenExitLabel), ThenPairs),
-      phrase(plawk_scalar_action_sequence_pairs(ElseActions, Slots, AssocPlan, FieldSeparator,
+      phrase(plawk_scalar_action_sequence_pairs(ElseActions, Slots, AssocPlan, FieldSeparator, OutputSeparator,
           ElseLabel, ElseLabel, RuleIndex, 0, Values0, ElseValues, _ElseOpIndex, ElseExitLabel), ElsePairs),
       pairs_keys_values(ThenPairs, ThenGlobalParts, ThenLineParts),
       pairs_keys_values(ElsePairs, ElseGlobalParts, ElseLineParts),
@@ -1393,7 +1435,7 @@ plawk_scalar_action_sequence_pairs([if(Pattern, ThenActions, ElseActions) | Rest
       NextOpIndex is OpIndex + 1
     },
     [GlobalIR-IR],
-    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, Prefix, DoneLabel, RuleIndex,
+    plawk_scalar_action_sequence_pairs(Rest, Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, DoneLabel, RuleIndex,
         NextOpIndex, Values1, Values, FinalOpIndex, ExitLabel).
 
 plawk_scalar_update_operation_ir(add(const(Value)), _FieldSeparator, Prefix, SlotIndex,
@@ -1617,6 +1659,17 @@ plawk_print_action_ir(Fields, FieldSeparator, OutputSeparator, GlobalIR-IR) :-
     plawk_join_nonempty_ir(GlobalParts, GlobalIR),
     atomic_list_concat(BodyParts, '\n', IR).
 
+plawk_prefixed_print_action_ir([field(0)], _FieldSeparator, _OutputSeparator, Prefix, ''-IR) :-
+    !,
+    format(atom(IR),
+        '  %~w_line_fmt = getelementptr [4 x i8], [4 x i8]* @.plawk_surface_print_line, i32 0, i32 0~n  %~w_printed_line = call i32 (i8*, ...) @printf(i8* %~w_line_fmt, i8* %line_s)',
+        [Prefix, Prefix, Prefix]).
+plawk_prefixed_print_action_ir(Fields, FieldSeparator, OutputSeparator, Prefix, GlobalIR-IR) :-
+    phrase(plawk_prefixed_print_fields_ir(Fields, FieldSeparator, OutputSeparator, Prefix, 0), Pairs),
+    plawk_print_ir_parts(Pairs, GlobalParts, BodyParts),
+    plawk_join_nonempty_ir(GlobalParts, GlobalIR),
+    atomic_list_concat(BodyParts, '\n', IR).
+
 plawk_print_ir_parts([], [], []).
 plawk_print_ir_parts([GlobalIR-BodyIR | Parts], [GlobalIR | GlobalParts], [BodyIR | BodyParts]) :-
     plawk_print_ir_parts(Parts, GlobalParts, BodyParts).
@@ -1637,6 +1690,21 @@ plawk_print_fields_ir([Field | Rest], FieldSeparator, OutputSeparator, Index) --
     { NextIndex is Index + 1 },
     plawk_print_fields_ir(Rest, FieldSeparator, OutputSeparator, NextIndex).
 
+plawk_prefixed_print_fields_ir([], _FieldSeparator, _OutputSeparator, Prefix, _) -->
+    { format(atom(NewlineFmt),
+          '  %~w_newline_fmt = getelementptr [2 x i8], [2 x i8]* @.plawk_surface_print_newline, i32 0, i32 0',
+          [Prefix]),
+      format(atom(NewlineCall),
+          '  %~w_printed_newline = call i32 (i8*, ...) @printf(i8* %~w_newline_fmt)',
+          [Prefix, Prefix])
+    },
+    [''-NewlineFmt, ''-NewlineCall].
+plawk_prefixed_print_fields_ir([Field | Rest], FieldSeparator, OutputSeparator, Prefix, Index) -->
+    plawk_prefixed_print_separator_ir(Index, OutputSeparator, Prefix),
+    plawk_prefixed_print_field_ir(Field, FieldSeparator, Prefix, Index),
+    { NextIndex is Index + 1 },
+    plawk_prefixed_print_fields_ir(Rest, FieldSeparator, OutputSeparator, Prefix, NextIndex).
+
 plawk_print_separator_ir(0, _OutputSeparator) -->
     !,
     [].
@@ -1647,9 +1715,29 @@ plawk_print_separator_ir(Index, OutputSeparator) -->
     },
     [''-SpaceCall].
 
+plawk_prefixed_print_separator_ir(0, _OutputSeparator, _Prefix) -->
+    !,
+    [].
+plawk_prefixed_print_separator_ir(Index, OutputSeparator, Prefix) -->
+    { format(atom(SpaceCall),
+          '  %~w_printed_separator_~w = call i32 @putchar(i32 ~w)',
+          [Prefix, Index, OutputSeparator])
+    },
+    [''-SpaceCall].
+
 plawk_print_field_ir(Field, FieldSeparator, Index) -->
     { plawk_emit_print_expr_ir(Field, FieldSeparator, Index, Type, GlobalParts, SetupParts),
       plawk_print_expr_output_ir(Type, Index, PrintParts),
+      plawk_join_nonempty_ir(GlobalParts, GlobalIR),
+      append(SetupParts, PrintParts, BodyParts),
+      atomic_list_concat(BodyParts, '\n', BodyIR)
+    },
+    [GlobalIR-BodyIR].
+
+plawk_prefixed_print_field_ir(Field, FieldSeparator, Prefix, Index) -->
+    { plawk_emit_prefixed_print_expr_ir(Field, FieldSeparator, Prefix, Index,
+          Type, GlobalParts, SetupParts),
+      plawk_prefixed_print_expr_output_ir(Type, Prefix, Index, PrintParts),
       plawk_join_nonempty_ir(GlobalParts, GlobalIR),
       append(SetupParts, PrintParts, BodyParts),
       atomic_list_concat(BodyParts, '\n', BodyIR)
@@ -1716,6 +1804,64 @@ plawk_emit_print_expr_ir(field(FieldIndex), FieldSeparator, Index,
     format(atom(LenIR), '%~w_len', [Base]),
     format(atom(PtrIR), '%~w_ptr', [Base]).
 
+plawk_emit_prefixed_print_expr_ir(special('NF'), FieldSeparator, Prefix, Index,
+        i64(Base, Base, ValueIR), [], [CountIR]) :-
+    format(atom(Base), '~w_nf_~w', [Prefix, Index]),
+    llvm_emit_atom_field_count('%line', FieldSeparator, Base, CountIR),
+    format(atom(ValueIR), '%~w', [Base]).
+
+plawk_emit_prefixed_print_expr_ir(length(field(FieldIndex)), FieldSeparator, Prefix, Index,
+        i64(Base, Base, ValueIR), [], [LengthIR]) :-
+    format(atom(Base), '~w_length_~w', [Prefix, Index]),
+    llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, Base, LengthIR),
+    format(atom(ValueIR), '%~w', [Base]).
+
+plawk_emit_prefixed_print_expr_ir(substr(field(FieldIndex), Start, Len), FieldSeparator, Prefix, Index,
+        slice(Base, Base, LenIR, PtrIR), [], [SliceIR]) :-
+    format(atom(Base), '~w_substr_~w', [Prefix, Index]),
+    llvm_emit_atom_field_subslice('%line', FieldIndex, FieldSeparator, Start, Len, Base, SliceIR),
+    format(atom(LenIR), '%~w_len', [Base]),
+    format(atom(PtrIR), '%~w_ptr', [Base]).
+
+plawk_emit_prefixed_print_expr_ir(index(field(FieldIndex), string(Needle)), FieldSeparator, Prefix, Index,
+        i64(Base, Base, ValueIR), [GlobalIR], [CallIR]) :-
+    format(atom(Base), '~w_index_~w', [Prefix, Index]),
+    format(atom(GlobalBase), '~w_index_needle_~w', [Prefix, Index]),
+    llvm_emit_atom_field_index(GlobalBase, '%line', FieldIndex, Needle, FieldSeparator,
+        Base, GlobalIR-CallIR),
+    format(atom(ValueIR), '%~w', [Base]).
+
+plawk_emit_prefixed_print_expr_ir(tolower(field(FieldIndex)), FieldSeparator, Prefix, Index,
+        case_slice(lower, LowerBase, LenIR, PtrIR), [], SetupParts) :-
+    format(atom(LowerBase), '~w_tolower_~w', [Prefix, Index]),
+    plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, LowerBase, LenIR, PtrIR,
+        SetupParts).
+
+plawk_emit_prefixed_print_expr_ir(toupper(field(FieldIndex)), FieldSeparator, Prefix, Index,
+        case_slice(upper, UpperBase, LenIR, PtrIR), [], SetupParts) :-
+    format(atom(UpperBase), '~w_toupper_~w', [Prefix, Index]),
+    plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, UpperBase, LenIR, PtrIR,
+        SetupParts).
+
+plawk_emit_prefixed_print_expr_ir(field(0), _FieldSeparator, Prefix, Index,
+        slice(Base, Base, LenIR, '%line_s'), [], [LineLen64, LineLen]) :-
+    format(atom(Base), '~w_line_~w', [Prefix, Index]),
+    format(atom(LineLen64),
+        '  %~w_len64 = call i64 @strlen(i8* %line_s)',
+        [Base]),
+    format(atom(LineLen),
+        '  %~w_len = trunc i64 %~w_len64 to i32',
+        [Base, Base]),
+    format(atom(LenIR), '%~w_len', [Base]).
+
+plawk_emit_prefixed_print_expr_ir(field(FieldIndex), FieldSeparator, Prefix, Index,
+        slice(Base, Base, LenIR, PtrIR), [], [SliceIR]) :-
+    FieldIndex > 0,
+    format(atom(Base), '~w_field_~w', [Prefix, Index]),
+    llvm_emit_atom_field_slice('%line', FieldIndex, FieldSeparator, Base, SliceIR),
+    format(atom(LenIR), '%~w_len', [Base]),
+    format(atom(PtrIR), '%~w_ptr', [Base]).
+
 plawk_emit_case_source_slice_ir(0, _FieldSeparator, Base, LenIR, '%line_s', [LineLen64]) :-
     format(atom(LineLen64),
         '  %~w_len64 = call i64 @strlen(i8* %line_s)',
@@ -1744,4 +1890,13 @@ plawk_print_expr_output_ir(slice(FmtPrefix, PrintPrefix, LenIR, PtrIR), Index, [
         [PrintPrefix, Index, FmtPrefix, Index, LenIR, PtrIR]).
 
 plawk_print_expr_output_ir(case_slice(Mode, PrintBase, LenIR, PtrIR), _Index, [PrintCall]) :-
+    llvm_emit_ascii_case_slice_print(Mode, PtrIR, LenIR, PrintBase, PrintCall).
+
+plawk_prefixed_print_expr_output_ir(i64(FmtPrefix, PrintPrefix, ValueIR), _Prefix, Index, Parts) :-
+    plawk_print_expr_output_ir(i64(FmtPrefix, PrintPrefix, ValueIR), Index, Parts).
+
+plawk_prefixed_print_expr_output_ir(slice(FmtPrefix, PrintPrefix, LenIR, PtrIR), _Prefix, Index, Parts) :-
+    plawk_print_expr_output_ir(slice(FmtPrefix, PrintPrefix, LenIR, PtrIR), Index, Parts).
+
+plawk_prefixed_print_expr_output_ir(case_slice(Mode, PrintBase, LenIR, PtrIR), _Prefix, _Index, [PrintCall]) :-
     llvm_emit_ascii_case_slice_print(Mode, PtrIR, LenIR, PrintBase, PrintCall).

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -205,6 +205,14 @@ test(parses_assoc_if_else_count_rule) :-
         [end([print([assoc(var(counts), string("disk")),
                      assoc(var(counts), string("WARN"))])])])).
 
+test(parses_branch_print_if_else_rule) :-
+    plawk_parse_string("{ if ($1 == \"ERROR\") { print $2, $3 } else { counts[$1]++ } } END { print counts[\"WARN\"] }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [if(field_eq(1, "ERROR"),
+            [print([field(2), field(3)])],
+            [inc_assoc(var(counts), field(1))])])],
+        [end([print([assoc(var(counts), string("WARN"))])])])).
+
 test(parses_assoc_count_end_print_rule) :-
     plawk_parse_string("{ counts[$1]++ } END { print counts[\"ERROR\"], counts[\"WARN\"] }\n", Program),
     assertion(Program == program([], [rule(always, [inc_assoc(var(counts), field(1))])],
@@ -472,6 +480,16 @@ test(surface_mixed_if_else_updates_scalar_slots_and_native_tables) :-
         "ERROR disk full\nWARN cpu hot\nERROR net down\n",
         "3 2 1 1\n").
 
+test(surface_assoc_if_else_prints_selected_branch) :-
+    run_surface_print_smoke("{ if ($1 == \"ERROR\") { print $2, $3 } else { counts[$1]++ } } END { print counts[\"WARN\"] }\n",
+        "ERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "disk full\nnet down\n1\n").
+
+test(surface_scalar_if_else_prints_selected_branch) :-
+    run_surface_print_smoke("{ total++; if ($1 == \"ERROR\") { print NF, $2 } else { total++ } } END { print total }\n",
+        "ERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "3 disk\n3 net\n4\n").
+
 test(surface_scalar_end_prints_string_literals) :-
     run_surface_print_smoke("{ total++ } END { print \"total\", total }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -698,8 +716,20 @@ test(surface_if_else_assoc_branch_updates_use_native_tables) :-
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 
-test(surface_if_else_rejects_branch_print, [fail]) :-
+test(surface_if_else_branch_print_uses_prefixed_native_prints) :-
     plawk_parse_string("{ if ($1 == \"ERROR\") { print $0 } else { counts[$1]++ } } END { print counts[\"ERROR\"] }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_body_if_0_then:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_0_then_print_0_line_fmt = getelementptr'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_0_then_print_0_printed_line = call i32'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_body_if_0_else_assoc_0:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_body_if_0_done:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_line = private constant [4 x i8] c"%s\\0A\\00"'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_if_else_rejects_branch_nr_print, [fail]) :-
+    plawk_parse_string("{ total++; if ($1 == \"ERROR\") { print NR, $0 } else { total++ } } END { print total }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
 
 test(surface_terminal_next_uses_native_continue_phi) :-


### PR DESCRIPTION
## Summary
- support selected-field `print` actions inside PLAWK `if/else` branches
- add a prefixed branch-print emitter so branch-local print SSA names do not collide
- require scalar rule bodies to reject unsupported branch actions instead of silently filtering them
- keep branch-local `next`, `break`, and `NR` printing rejected at this boundary
- update PLAWK docs and surface tests for branch-local print

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`