### PR TITLE
Support PLAWK branch NR prints

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -279,9 +279,10 @@ increments or selected-field `print` as branch-local side effects. Scalar,
 mixed, and assoc-only branch bodies now share the same rule-body action walker;
 branch phis use each branch's actual exit block, including assoc side-effect
 `_done` blocks. Branch-local `print` uses prefixed SSA names so multiple branch
-prints do not collide. Branch-local `next` and `break` still need a broader
-intra-rule CFG; branch-local `NR` printing also waits on carrying the record
-counter through stateful native loops. Native rule chains also support terminal
+prints do not collide; branch-local `NR` printing uses the same native record
+counter threaded through the stream loop as top-level `print NR`. Branch-local
+`next` and `break` still need a broader intra-rule CFG. Native rule chains also
+support terminal
 `next` by branching directly to the stream-loop continuation; scalar and mixed
 chains add the early-exit rule's scalar values to the loop phi inputs, while
 assoc-only chains update tables before the continuation branch. Terminal

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -97,11 +97,11 @@ Scalar slot updates can also sit behind native `if/else` guards, e.g.
 `{ if ($1 == "ERROR") { errors++; last_len = length($0) } else { non_errors++ } }
 END { print errors, non_errors, last_len }`. The first branch slice supports
 field-equality conditions, scalar updates, field-key associative increments,
-and selected-field `print` inside branches. The native lowering evaluates each
-source `if` guard once, threads every scalar slot through the then/else bodies,
-emits associative table increments and branch-local prints only on the selected
-branch, and rejoins scalar slots with per-slot LLVM phis. Branch-local `next`,
-`break`, and `NR` printing remain outside this boundary.
+and selected-field `print` including `NR` inside branches. The native lowering
+evaluates each source `if` guard once, threads every scalar slot through the
+then/else bodies, emits associative table increments and branch-local prints
+only on the selected branch, and rejoins scalar slots with per-slot LLVM phis.
+Branch-local `next` and `break` remain outside this boundary.
 Terminal `next` is supported in native rule chains, so `$1 == "DEBUG" {
 skipped++; next } { total++ } END { print total, skipped }` skips the later
 rule for matching records. Terminal `break` is supported in the same native

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -255,8 +255,8 @@ END { print total, errors, non_errors, last_len }
 ```
 
 For now, branch bodies support scalar updates, field-key associative increments,
-selected-field `print`, and combinations of those actions. Branch-local `next`,
-`break`, and `NR` printing are rejected by native codegen.
+selected-field `print` including `NR`, and combinations of those actions.
+Branch-local `next` and `break` are rejected by native codegen.
 The generated native code evaluates the `if` condition once, runs the selected
 branch, and rejoins all scalar slots through LLVM phi nodes before later actions
 or rules continue.
@@ -275,7 +275,7 @@ Branches can also print selected fields:
 
 ```awk
 {
-  if ($1 == "ERROR") { print $2, $3 }
+  if ($1 == "ERROR") { print NR, $2, $3 }
   else { counts[$1]++ }
 }
 END { print counts["WARN"] }

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -93,7 +93,12 @@ plawk_program_native_driver_ir(
     plawk_assoc_print_key_globals(PrintFields, AssocGlobalIR),
     plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
     plawk_mixed_rule_chain_ir(MixedPlan, FieldSeparator, OutputSeparator, RuleGlobalIR, RuleChainIR, RuleCount),
-    plawk_state_loop_phi_ir(ScalarPlan, LoopPhiIR),
+    plawk_rules_body_print_fields(Rules, BodyPrintFields),
+    append(PrintFields, BodyPrintFields, AllPrintFields),
+    plawk_print_record_counter_ir(AllPrintFields, RecordLoopPhiIR, RecordCounterIR),
+    plawk_state_loop_phi_ir(ScalarPlan, StateLoopPhiIR),
+    plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
+    plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
     plawk_mixed_rule_controls(MixedPlan, MixedRuleControls),
     plawk_mixed_scalar_next_phi_ir(ScalarPlan, RuleCount, MixedRuleControls, NextPhiIR),
     plawk_break_close_ir(ScalarPlan, RuleCount, MixedRuleControls, done,
@@ -110,7 +115,7 @@ plawk_program_native_driver_ir(
         [FinalStatePhiIR, EndPrintIR]),
     plawk_stream_driver_ir(InputPath,
         driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, LoopPhiIR, lowered_mixed,
-            RuleChainIR, NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
+            RecordIR, NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
 plawk_program_native_driver_ir(
@@ -125,7 +130,12 @@ plawk_program_native_driver_ir(
     plawk_field_separator(BeginClauses, FieldSeparator),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, OutputSeparator, RuleGlobalIR, RuleChainIR, RuleCount),
-    plawk_state_loop_phi_ir(StatePlan, LoopPhiIR),
+    plawk_rules_body_print_fields(Rules, BodyPrintFields),
+    append(PrintFields, BodyPrintFields, AllPrintFields),
+    plawk_print_record_counter_ir(AllPrintFields, RecordLoopPhiIR, RecordCounterIR),
+    plawk_state_loop_phi_ir(StatePlan, StateLoopPhiIR),
+    plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
+    plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
     plawk_scalar_rule_controls(Rules, ScalarRuleControls),
     plawk_scalar_next_phi_ir(StatePlan, RuleCount, ScalarRuleControls, NextPhiIR),
     plawk_break_close_ir(StatePlan, RuleCount, ScalarRuleControls, done,
@@ -140,7 +150,7 @@ plawk_program_native_driver_ir(
   ret i32 0',
         [FinalStatePhiIR, EndPrintIR]),
     plawk_stream_driver_ir(InputPath,
-        driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RuleChainIR,
+        driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR,
             NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
@@ -158,6 +168,10 @@ plawk_program_native_driver_ir(
     plawk_assoc_print_key_globals(PrintFields, AssocGlobalIR),
     plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
     plawk_assoc_rule_chain_ir(AssocPlan, FieldSeparator, AssocRuleGlobalIR, AssocChainIR),
+    plawk_rules_body_print_fields(Rules, BodyPrintFields),
+    append(PrintFields, BodyPrintFields, AllPrintFields),
+    plawk_print_record_counter_ir(AllPrintFields, RecordLoopPhiIR, RecordCounterIR),
+    plawk_join_nonempty_ir([RecordCounterIR, AssocChainIR], RecordIR),
     plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
     plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
     plawk_assoc_end_print_ir(PrintFields, AssocPlan, OutputSeparator, EndPrintIR),
@@ -171,8 +185,8 @@ plawk_program_native_driver_ir(
   ret i32 0',
         [EndPrintIR]),
     plawk_stream_driver_ir(InputPath,
-        driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, '', lowered_assoc,
-            AssocChainIR, '', BreakCloseIR, end_print, CloseOkIR),
+        driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, RecordLoopPhiIR, lowered_assoc,
+            RecordIR, '', BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
 
 plawk_combine_entry_ir('', IR, IR) :-
@@ -507,6 +521,24 @@ plawk_actions_have_conditional(Actions) :-
     plawk_action_has_conditional(Action).
 
 plawk_action_has_conditional(if(_Pattern, _ThenActions, _ElseActions)).
+
+plawk_rules_body_print_fields(Rules, Fields) :-
+    findall(Field,
+        ( member(rule(_Pattern, Actions), Rules),
+          plawk_actions_body_print_field(Actions, Field)
+        ),
+        Fields).
+
+plawk_actions_body_print_field(Actions, Field) :-
+    member(Action, Actions),
+    plawk_action_body_print_field(Action, Field).
+
+plawk_action_body_print_field(print(Fields), Field) :-
+    member(Field, Fields).
+plawk_action_body_print_field(if(_Pattern, ThenActions, ElseActions), Field) :-
+    (   plawk_actions_body_print_field(ThenActions, Field)
+    ;   plawk_actions_body_print_field(ElseActions, Field)
+    ).
 
 plawk_mixed_planned_rules([], _AssocPlan, _Index) -->
     [].
@@ -1326,6 +1358,7 @@ plawk_rule_body_print_action(print(Fields)) :-
     maplist(plawk_rule_body_print_field, Fields).
 
 plawk_rule_body_print_field(field(_)).
+plawk_rule_body_print_field(special('NR')).
 plawk_rule_body_print_field(special('NF')).
 plawk_rule_body_print_field(length(field(_))).
 plawk_rule_body_print_field(substr(field(_), _Start, _Len)).
@@ -1803,6 +1836,10 @@ plawk_emit_print_expr_ir(field(FieldIndex), FieldSeparator, Index,
     llvm_emit_atom_field_slice('%line', FieldIndex, FieldSeparator, Base, SliceIR),
     format(atom(LenIR), '%~w_len', [Base]),
     format(atom(PtrIR), '%~w_ptr', [Base]).
+
+plawk_emit_prefixed_print_expr_ir(special('NR'), _FieldSeparator, Prefix, Index,
+        i64(Base, Base, '%current_nr'), [], []) :-
+    format(atom(Base), '~w_nr_~w', [Prefix, Index]).
 
 plawk_emit_prefixed_print_expr_ir(special('NF'), FieldSeparator, Prefix, Index,
         i64(Base, Base, ValueIR), [], [CountIR]) :-

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -490,6 +490,11 @@ test(surface_scalar_if_else_prints_selected_branch) :-
         "ERROR disk full\nWARN cpu hot\nERROR net down\n",
         "3 disk\n3 net\n4\n").
 
+test(surface_scalar_if_else_prints_branch_nr) :-
+    run_surface_print_smoke("{ total++; if ($1 == \"ERROR\") { print NR, $2 } else { total++ } } END { print total }\n",
+        "ERROR disk full\nWARN cpu hot\nERROR net down\n",
+        "1 disk\n3 net\n4\n").
+
 test(surface_scalar_end_prints_string_literals) :-
     run_surface_print_smoke("{ total++ } END { print \"total\", total }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -728,9 +733,15 @@ test(surface_if_else_branch_print_uses_prefixed_native_prints) :-
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 
-test(surface_if_else_rejects_branch_nr_print, [fail]) :-
+test(surface_if_else_branch_nr_print_uses_native_record_counter) :-
     plawk_parse_string("{ total++; if ($1 == \"ERROR\") { print NR, $0 } else { total++ } } END { print total }\n", Program),
-    plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_nr = phi i64 [0, %check_handle_value], [%current_nr, %continue_loop]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%current_nr = add i64 %plawk_nr, 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_1_then_print_0_nr_0_fmt_0 = getelementptr'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_rule_0_body_if_1_then_print_0_nr_0_0 = call i32 (i8*, ...) @printf(i8* %rule_0_body_if_1_then_print_0_nr_0_fmt_0, i64 %current_nr)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
 
 test(surface_terminal_next_uses_native_continue_phi) :-
     plawk_parse_string("$1 == \"DEBUG\" { skipped++; next } { total++ } END { print total, skipped }\n", Program),


### PR DESCRIPTION
## Summary
- support `print NR` inside PLAWK `if/else` branch bodies
- scan rule-body print fields so stateful native loops enable the `%current_nr` counter when `NR` appears only inside a branch
- reuse the prefixed branch-print emitter for native `NR` output without SSA name collisions
- update PLAWK docs and tests so the remaining branch-local gaps are `next` and `break`

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`