### PR TITLE
bench(wam-rust): real-graph cached attribution measurement + repro script

### DIFF
--- a/docs/reports/wam_rust_cached_runtime_attribution_2026-06-14.md
+++ b/docs/reports/wam_rust_cached_runtime_attribution_2026-06-14.md
@@ -40,27 +40,80 @@ misses and zero reuse by construction. It confirms the counters record, the inne
 LMDB seek is timed, and the report surfaces in the real cached binary. With the
 env var unset (or `=0`) no `cache_attr_*` lines are emitted.
 
+## Real-graph measurement (10x fixture)
+
+Ingested `data/benchmark/10x` (3932 category-parent edges, 1768 atoms, 250 seeds
+converging on a single root) into an `lmdb_resident` fixture with
+`examples/benchmark/ingest_resident_lmdb_fixture.py`, then ran the cached crate
+against it with `UW_WAM_CACHE_ATTRIBUTION=1`. A `lazy` (uncached) crate is the
+control.
+
+| metric | cached | lazy (control) |
+|--------|--------|----------------|
+| `cache_attr_lookups` | 16337 | 0 |
+| `cache_attr_l1_hits` | 15840 (1 thread) / ~15656 (N threads) | 0 |
+| `cache_attr_l2_hits` | 0 (1 thread) / ~181 (N threads) | 0 |
+| `cache_attr_misses` | 497 | 0 |
+| `cache_attr_hit_rate` | **0.9696** | 0.0000 |
+| `cache_attr_inner_lookup_ms` | ~0.23–0.30 | 0.000 |
+
+Reading the numbers:
+
+- **96.96% hit rate.** Of 16337 parent lookups, only 497 (3%) reach LMDB; the
+  rest are served from cache. This quantifies the root-near ancestor reuse the
+  benchmark plan hypothesised — 250 seeds share a small set of ancestors near the
+  single root.
+- **Inner LMDB time is tiny** (~0.25 ms total across the 497 misses), i.e. the
+  cursor seeks are no longer the cost centre once the cache is warm — the direct
+  counter to the PR #3120 Python finding where cached time was dominated by
+  residual traversal/interpreter overhead.
+- **Tier split behaves as designed.** Single-threaded, the one per-thread L1
+  absorbs every hit (L2=0). Multi-threaded, each worker's cold L1 pushes ~181
+  lookups to the shared L2; cold misses tick up slightly (497→~500) but the hit
+  rate is unchanged (~0.9695). `cache_attr_lookups=16337` is deterministic.
+- **Lazy is a clean control:** it never constructs `CachedLookup`, so all
+  counters read zero — the attribution is specific to the cached path.
+
+Correctness was verified end-to-end: the cached output is an **exact match** to
+`data/benchmark/10x/reference_output.tsv` (183 rows), and cached and lazy produce
+identical output.
+
+This is a reuse-and-correctness result, not a wall-clock speedup claim: at this
+fixture size total runtime is ~7 ms for both cached and lazy, dominated by costs
+other than LMDB seeks, so the two are timing-indistinguishable here. A wall-clock
+cache win is expected only on a graph large enough for cold LMDB seeks to
+dominate (enwiki scale), which the high hit rate and small inner-lookup time
+above suggest the cache would capture.
+
 ## Reproduce
 
+`examples/benchmark/run_wam_rust_cached_attribution.sh <fixture_dir> <out_dir>`
+automates ingest → generate (cached + lazy) → build → run with attribution. By
+hand:
+
 ```bash
-# 1. Generate + build a cached crate
+# 1. Ingest a graph (dir with category_parent.tsv + article_category.tsv +
+#    root_categories.tsv) into an lmdb_resident fixture.
+BENCH=/tmp/wam_real
+python3 examples/benchmark/ingest_resident_lmdb_fixture.py \
+    data/benchmark/10x "$BENCH/lmdb_resident"
+cp data/benchmark/10x/article_category.tsv "$BENCH/"   # root_ids.txt is written by the ingester
+
+# 2. Generate + build a cached crate
 cd examples/benchmark
 swipl -q -s generate_wam_rust_matrix_benchmark.pl -- \
-    effective_distance.pl /tmp/cached_bench accumulated functions kernels_on \
-    cursor auto cached 297283
-cd /tmp/cached_bench && cargo build --release
-
-# 2. Build a fixture (tiny here; use a real lmdb_resident fixture for reuse numbers)
-python3 <repo>/tests/helpers/build_tiny_int_native_lmdb.py /tmp/wam_fixture
+    effective_distance.pl /tmp/bench_cached accumulated functions kernels_on \
+    cursor auto cached 3932
+( cd /tmp/bench_cached && cargo build --release )
 
 # 3. Run with attribution
-UW_WAM_CACHE_ATTRIBUTION=1 ./target/release/bench /tmp/wam_fixture
+UW_WAM_CACHE_ATTRIBUTION=1 /tmp/bench_cached/target/release/bench "$BENCH"
 ```
 
 ## Next
 
-Real hit-rate / inner-lookup numbers — the actual Rust-vs-#3120 comparison —
-require a fixture with genuine ancestor reuse (a SimpleWiki/enwiki
-`lmdb_resident` fixture), where root-near ancestors are hit repeatedly across
-seeds. The instrumentation is now in place to measure it; only the fixture is
-outstanding.
+The instrumentation and the reuse measurement are now both in place. The
+remaining step toward the full PR #3120 comparison is to run the same recipe on
+an enwiki-scale `lmdb_resident` fixture, where cold LMDB seeks dominate and the
+96.96% hit rate should translate into a wall-clock cache win — turning this reuse
+result into a head-to-head cached-vs-lazy runtime comparison.

--- a/examples/benchmark/run_wam_rust_cached_attribution.sh
+++ b/examples/benchmark/run_wam_rust_cached_attribution.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+#
+# run_wam_rust_cached_attribution.sh — end-to-end cached-side runtime
+# attribution for the WAM-Rust graph-search bench (PR #3120 Rust analog).
+#
+# Ingests a graph fixture into an lmdb_resident database, generates and builds
+# both a `cached` crate and a `lazy` control crate, runs them with
+# UW_WAM_CACHE_ATTRIBUTION=1, and prints the cache_attr_* report for each.
+#
+# Usage:
+#   examples/benchmark/run_wam_rust_cached_attribution.sh <fixture_src_dir> [work_dir]
+#
+#   <fixture_src_dir>  dir with category_parent.tsv + article_category.tsv
+#                      + root_categories.tsv (e.g. data/benchmark/10x)
+#   [work_dir]         scratch dir for the lmdb fixture + generated crates
+#                      (default: a fresh mktemp dir)
+#
+# Requires: swipl, cargo, python3 with the `lmdb` package.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FIXTURE_SRC="${1:?usage: run_wam_rust_cached_attribution.sh <fixture_src_dir> [work_dir]}"
+WORK_DIR="${2:-$(mktemp -d)}"
+export LC_ALL="${LC_ALL:-C.UTF-8}" LANG="${LANG:-C.UTF-8}"
+
+FIXTURE_SRC="$(cd "$FIXTURE_SRC" && pwd)"
+EDGES=$(($(wc -l < "$FIXTURE_SRC/category_parent.tsv") - 1))
+BENCH="$WORK_DIR/fixture"
+mkdir -p "$BENCH"
+
+echo "== ingest $FIXTURE_SRC ($EDGES edges) -> lmdb_resident =="
+python3 "$REPO_ROOT/examples/benchmark/ingest_resident_lmdb_fixture.py" \
+    "$FIXTURE_SRC" "$BENCH/lmdb_resident"
+cp "$FIXTURE_SRC/article_category.tsv" "$BENCH/"   # root_ids.txt written by ingester
+
+for mode in cached lazy; do
+    OUT="$WORK_DIR/bench_$mode"
+    echo "== generate + build ($mode) =="
+    rm -rf "$OUT"
+    swipl -q -s "$REPO_ROOT/examples/benchmark/generate_wam_rust_matrix_benchmark.pl" -- \
+        "$REPO_ROOT/examples/benchmark/effective_distance.pl" \
+        "$OUT" accumulated functions kernels_on cursor auto "$mode" "$EDGES" >/dev/null 2>&1
+    ( cd "$OUT" && cargo build --release >/dev/null 2>&1 )
+
+    echo "== run ($mode) with attribution =="
+    UW_WAM_CACHE_ATTRIBUTION=1 "$OUT/target/release/bench" "$BENCH" \
+        >"$WORK_DIR/out_$mode.tsv" 2>"$WORK_DIR/err_$mode.txt"
+    grep -E 'total_ms|cache_attr_' "$WORK_DIR/err_$mode.txt" | sed 's/^/  /'
+done
+
+REF="$FIXTURE_SRC/reference_output.tsv"
+if [[ -f "$REF" ]]; then
+    if diff -q <(sort "$WORK_DIR/out_cached.tsv") <(sort "$REF") >/dev/null; then
+        echo "== correctness: cached output EXACT MATCH vs reference_output.tsv =="
+    else
+        echo "== correctness: cached output DIFFERS from reference_output.tsv ==" >&2
+        exit 1
+    fi
+fi
+
+echo "work dir: $WORK_DIR"


### PR DESCRIPTION
## Summary

Follow-up to #3127 and #3140 — produces the **real-graph reuse measurement** the cached-attribution instrumentation was built for, and adds a one-command repro.

PR #3120 (Python) found cached graph search dominated by *residual cached traversal / interpreter overhead*. The compiled Rust kernel removes the interpreter; this measures what's left on the cached path.

## Measurement (10x fixture: 3932 edges, 250 seeds → 1 root)

Ingested `data/benchmark/10x` into an `lmdb_resident` fixture and ran the cached crate with `UW_WAM_CACHE_ATTRIBUTION=1`, with a `lazy` crate as the uncached control:

| metric | cached | lazy (control) |
|--------|--------|----------------|
| `cache_attr_lookups` | 16337 | 0 |
| `cache_attr_l1_hits` | 15638–15840 | 0 |
| `cache_attr_l2_hits` | 0 (1 thread) / ~200 (N threads) | 0 |
| `cache_attr_misses` | ~497 | 0 |
| `cache_attr_hit_rate` | **0.9695** | 0.0000 |
| `cache_attr_inner_lookup_ms` | ~0.3 | 0.000 |

- **96.95% hit rate** — only ~3% of lookups reach LMDB once warm; total inner seek time is sub-millisecond. The direct counter to #3120's residual-overhead finding.
- **Tier split as designed**: single-threaded the one L1 absorbs every hit (L2=0); multi-threaded, cold per-thread L1s push ~200 lookups to the shared L2. `cache_attr_lookups=16337` is deterministic.
- **Lazy is a clean control**: never constructs `CachedLookup`, so all counters read zero.
- **Correctness**: cached output is an **exact match** to `reference_output.tsv` (183 rows); cached == lazy output.

Honest scope: this is a **reuse + correctness** result, not a wall-clock win — at 3932 edges total runtime (~7 ms) is the same for cached and lazy. A timing win is expected only at enwiki scale where cold seeks dominate.

## Changes

- `docs/reports/wam_rust_cached_runtime_attribution_2026-06-14.md` — add the real-graph measurement, tier-split reading, and scope caveat.
- `examples/benchmark/run_wam_rust_cached_attribution.sh` — one-command repro: ingest → generate cached+lazy → build → run with attribution → verify vs reference. Validated end-to-end in this environment (exit 0, exact-match correctness).

## Validation

Installed SWI-Prolog 9.0.4 + Python `lmdb`; cargo/rustc 1.94. Ran the orchestration script end-to-end on `data/benchmark/10x` — both crates build, both run, cached reports the numbers above, and the cached-vs-reference correctness check passes.

## Next

Run the same recipe on an enwiki-scale `lmdb_resident` fixture to turn this into a head-to-head cached-vs-lazy wall-clock comparison.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_