### PR TITLE
docs: re-land matrix update + NEXT doc (supersedes open #3138)

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -96,7 +96,7 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 | Target  | T1 det | T2 ITE | T3 mc-1 | T4 mc-n | T5 mc→`->` | T6 idx | T7 par | T8 kernels | T9 facts | T10 mode | T11 LCO |
 |---------|:------:|:------:|:-------:|:-------:|:----------:|:------:|:------:|:----------:|:--------:|:--------:|:-------:|
 | scala   | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✓ | ✗ | ✗ |
-| rust    | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✗ | ✗ | ✗ |
+| rust    | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | `~` gated | ✓ | ✗ | ✗ | ✗ |
 | cpp     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✗ | ✗ | ✗ | ✗ |
 | go      | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✗ | ✗ | ✗ |
 | haskell | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✓ | ✗ | ✗ |
@@ -143,17 +143,22 @@ Verification notes:
 - **T7**: elixir is the only real implementation (`Task.async_stream` +
   `par_wrap_segment`); clojure/python have `_branch` scaffolds (counted `~`).
   go's clause-parallel goroutines live in the *non-WAM* `go_target.pl` direct
-  compiler, not the WAM lowered emitter → go T7 = ✗ here. **rust T7 = ✗ (not
-  built) but benchmark-validated as worth building *with a gate***: parallel
-  fan-out of a forkable aggregate is 2–3.7× on 4 cores for expensive per-branch
-  work, but a 5–200× *regression* on cheap branches (each parallel branch must
-  clone its own WAM machine — the cost backtracking avoids), so a model-based
-  adaptive probe (est_seq vs est_par incl. measured pool overhead) is mandatory
-  to pick small-vs-large workloads and recover best-of-both. Design + evidence +
-  a build plan against the existing `BeginAggregate`/`EndAggregate` substrate are
-  in `docs/reports/wam_rust_t7_parallel_perf.md`. (Like the LLVM T6 decline, the
-  benchmark is what gates the decision — here it says "yes, but only behind the
-  probe.")
+  compiler, not the WAM lowered emitter → go T7 = ✗ here. **rust T7 = `~` (built,
+  gated, whole-body aggregates)**: a forkable aggregate that is a predicate's
+  whole body compiles — behind `parallel_aggregates(true)` and a compile-time
+  cost gate — to a generator/body split (`parallel_aggregate_transform`) plus a
+  native `par_collect` wrapper that runs the body on a cloned WAM machine per
+  input across threads, reducing by type (collect/count/sum/max/min/bag/set). The
+  gate is mandatory: fan-out is 2–3.4× on 4 cores for expensive/recursive
+  per-branch work (**3.39× measured end-to-end**) but a 5–200× *regression* on
+  cheap branches (each branch clones its own machine — the cost backtracking
+  avoids), so only expensive/recursive tiers fan out. `~` not ✓ because
+  aggregates *embedded in a larger clause body* still compile sequentially (the
+  `par_aggregate` WAM-instruction route, not yet built). Design/benchmark/handoff:
+  `docs/reports/wam_rust_t7_parallel_perf.md`,
+  `docs/reports/wam_rust_t7_speedup_benchmark.md`,
+  `docs/reports/wam_rust_t7_RESUME.md`. (Like the LLVM T6 decline, the benchmark
+  is what gated the decision — here it said "yes, but only behind the probe.")
 - **T9**: rust and scala's lowered *emitters* emit no fact tables; scala's
   ✓ is the target-level fact-source backend (auto-inline ≤128 rows, then
   CSV/TSV/LMDB) — a different mechanism than lua/r/haskell's emitter-level

--- a/docs/reports/wam_rust_t7_NEXT.md
+++ b/docs/reports/wam_rust_t7_NEXT.md
@@ -1,0 +1,76 @@
+# T7-on-Rust — what to do next
+
+Concise, action-oriented next-steps note. For the full handoff (architecture,
+gotchas, all tests) see `docs/reports/wam_rust_t7_RESUME.md`.
+
+## Where we are (done + on `main`)
+
+Whole-body parallel aggregates are **complete and perf-proven**:
+`cost gate → split → transform → generated `__par_enum`/`__par_body` helpers →
+native `par_collect` wrapper` running the body on a cloned WAM machine per input
+across threads. All common reduce types: **collect / count / sum / max / min /
+bag / set**. **3.39× measured** end-to-end (4 cores). Cost-gated so cheap
+aggregates stay sequential (no fork regression).
+
+## Immediate (housekeeping)
+
+- **Merge PR #3138** — matrix doc update (`rust T7 ✗ → ~ gated`). The code PRs
+  (#3123 route-1, #3135 reduce types) are already merged.
+
+## The one substantial T7 item left
+
+**Aggregates embedded in a *larger* clause body** (not the whole body). Today
+those still compile sequentially. The native-wrapper trick only works when a
+predicate's whole body IS the aggregate; an embedded aggregate has to run
+mid-clause inside the WAM, which needs a real instruction.
+
+### Plan — the `par_aggregate` WAM-instruction route
+
+1. **Detect + rewrite (compile-time).** In the Rust target, when a clause body
+   contains a forkable, parallel-eligible aggregate (reuse `parallel_gate`):
+   synthesise its `__par_enum`/`__par_body` helpers (add to the shared-table
+   compile set, as `rust_inject_parallel_aggregates` already does), and replace
+   that aggregate's `begin_aggregate … end_aggregate` block with a single new
+   WAM line `par_aggregate(AggType, EnumLabel, BodyLabel, ResultReg)`.
+2. **New instruction.** Add `Instruction::ParAggregate(...)` + its text parse
+   (`wam_line_to_rust_instr`, ~`wam_rust_target.pl:3232`) + an interpreter arm
+   (near the `BeginAggregate` arm, ~`wam_rust_target.pl:763`).
+3. **Handler = label-based `par_collect`.** Clone `self`; run the enum from
+   `EnumLabel` collecting input tuples (set `pc`, `A1=Unbound`, `run()`, deref,
+   `backtrack()+run()` loop); parallel-map the body from `BodyLabel` per input
+   (clone, `pc=BodyLabel`, `A1=input`, `A2=Unbound`, `run()`, deref); reduce by
+   `AggType`; bind `ResultReg`; `pc += 1`. Add a `par_collect_labels` variant to
+   `templates/targets/rust_wam/par_aggregate.rs.mustache` (the fn-pointer
+   `par_collect` proves the mechanism; this one uses `self.run()` + labels).
+4. **Exec test.** A clause with an *embedded* `findall` (other goals before/after)
+   compiles + runs == sequential. Pattern: `tests/test_wam_rust_parallel_injection_exec.pl`.
+
+Gate behind `parallel_aggregates(true)` (default output unchanged), as the
+whole-body path already is.
+
+### Gotchas (already learned — don't rediscover)
+
+- WAM solution enumeration needs **`backtrack()` AND `run()`** (backtrack alone
+  loops forever; `tc_ancestor` is a native kernel, enumerates differently).
+- Collected bindings are raw heap `Ref`s → resolve with `deref_var(deref_heap(_))`.
+- `set` ordering uses the runtime's `term_compare` (pub) + `dedup_by`.
+- `lib.rs` is rendered from the **inline `template(rust_wam_lib, …)`** in
+  `template_system.pl`, NOT `lib.rs.mustache`.
+- Real projects use the **shared-table** path (`compile_wam_predicate_to_rust_shared`),
+  not the standalone one.
+- `WamState` is `Clone+Send+Sync`, `Value` is `Send+Sync` (compile-asserted).
+
+## Alternatives to the above
+
+- **Pivot to another matrix gap** (`WAM_LOWERING_TAXONOMY_AND_MATRIX.md`) — e.g.
+  rust **T9 fact-table inline** (✗ today), or **T10/T11**.
+- **Call T7 done** — it's a clean, complete, proven milestone for whole-body
+  aggregates; the embedded case is an enhancement, not a gap in correctness.
+
+## Reference docs
+
+- `docs/reports/wam_rust_t7_RESUME.md` — full handoff (architecture + gotchas).
+- `docs/reports/wam_rust_t7_2b2_fork_analysis.md` — the instruction-route design.
+- `docs/reports/wam_rust_t7_speedup_benchmark.md` — the 3.39× measurement.
+- `docs/reports/wam_rust_t7_parallel_perf.md` — original benchmark + gate design.
+- `docs/reports/cost_analysis_machinery.md` — the cost model the gate uses.


### PR DESCRIPTION
## Why

Re-land of the two doc commits from #3138, which is still open/unmerged (you couldn't see how to re-merge it). Cherry-picked cleanly onto current `main` so this PR is self-contained — merging it lands both, and #3138 can be closed.

## What
- **Matrix update** — `WAM_LOWERING_TAXONOMY_AND_MATRIX.md`: `rust T7 ✗ → \`~\` gated`, with the note rewritten to describe the built whole-body parallel-aggregate path (gate → split → transform → native `par_collect`, all reduce types, **3.39× measured**); `~` not `✓` because embedded-in-larger-body aggregates aren't built yet.
- **NEXT doc** — `docs/reports/wam_rust_t7_NEXT.md`: the concise action-oriented next-steps note (current state, the embedded-aggregate `par_aggregate` route plan, gotchas, alternatives, references).

Docs only. (T9 stays `✗` in the matrix — #3146 added detection only, no emission, so it's not "present" yet.)

Supersedes #3138 (please close that one).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_