### PR TITLE
Support PLAWK branch break actions

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -282,17 +282,18 @@ branch phis use each branch's actual exit block, including assoc side-effect
 prints do not collide; branch-local `NR` printing uses the same native record
 counter threaded through the stream loop as top-level `print NR`. Terminal
 branch-local `next` branches directly to the stream-loop continuation and adds
-the selected branch's scalar values to the loop phi inputs. Branch-local
-`break` still needs the broader close/end-print CFG. Native rule chains also
-support terminal `next` by branching directly to the stream-loop continuation;
-scalar and mixed chains add the early-exit rule's scalar values to the loop phi
-inputs, while assoc-only chains update tables before the continuation branch.
-Terminal
-`break` uses the sibling path: matching rules branch to a dedicated stream-close
-block and scalar/mixed programs feed `END` through final-state phis. This native
-slice deliberately supports terminal `next`/`break` only; non-terminal loop
-control needs a future intra-rule control-flow lowering rather than implicit
-fall-through after the skipped or final record. The current
+the selected branch's scalar values to the loop phi inputs. Terminal
+branch-local `break` branches to the same dedicated stream-close block as
+rule-level `break` and feeds the selected branch's scalar values through
+final-state phis. Native rule chains also support terminal `next` by branching
+directly to the stream-loop continuation; scalar and mixed chains add the
+early-exit rule's scalar values to the loop phi inputs, while assoc-only chains
+update tables before the continuation branch. Terminal `break` uses the sibling
+path: matching rules branch to a dedicated stream-close block and scalar/mixed
+programs feed `END` through final-state phis. This native slice deliberately
+supports terminal `next`/`break` only; non-terminal loop control needs a future
+intra-rule control-flow lowering rather than implicit fall-through after the
+skipped or final record. The current
 associative-count surface allocates one reusable WAM/LLVM
 interned-atom-keyed growable `i64` table primitive (`wam_assoc_i64_*`) per source
 array, increments those tables in the native streaming loop, and performs `END`

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -97,19 +97,20 @@ Scalar slot updates can also sit behind native `if/else` guards, e.g.
 `{ if ($1 == "ERROR") { errors++; last_len = length($0) } else { non_errors++ } }
 END { print errors, non_errors, last_len }`. The first branch slice supports
 field-equality conditions, scalar updates, field-key associative increments,
-selected-field `print` including `NR`, and terminal `next` inside branches. The
-native lowering evaluates each source `if` guard once, threads every scalar slot
-through the then/else bodies, emits associative table increments and
-branch-local prints only on the selected branch, rejoins scalar slots with
-per-slot LLVM phis, and routes selected branch-local `next` paths to the stream
-loop continuation. Branch-local `break` remains outside this boundary.
+selected-field `print` including `NR`, and terminal `next`/`break` inside
+branches. The native lowering evaluates each source `if` guard once, threads
+every scalar slot through the then/else bodies, emits associative table
+increments and branch-local prints only on the selected branch, rejoins scalar
+slots with per-slot LLVM phis, routes selected branch-local `next` paths to the
+stream loop continuation, and routes selected branch-local `break` paths to the
+stream close path before `END`.
 Terminal `next` is supported in native rule chains, so `$1 == "DEBUG" {
 skipped++; next } { total++ } END { print total, skipped }` skips the later
 rule for matching records. Terminal `break` is supported in the same native
 rule-chain shape and closes the stream before running `END`, e.g. `$1 == "ERROR"
 { hits++; break } { total++ } END { print hits, total }`. In the current surface
 slice, `next` and `break` must be the last action in their rule body; branch
-`next` must also be terminal in that branch. Non-terminal loop control is
+`next`/`break` must also be terminal in that branch. Non-terminal loop control is
 intentionally rejected by the native codegen boundary. The first
 associative-count surface now supports multiple source arrays, e.g.
 `{ counts[$1]++; by_component[$2]++ } END { print counts["ERROR"], by_component["disk"] }`.

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -255,11 +255,12 @@ END { print total, errors, non_errors, last_len }
 ```
 
 For now, branch bodies support scalar updates, field-key associative increments,
-selected-field `print` including `NR`, terminal `next`, and combinations of
-those actions. Branch-local `break` is rejected by native codegen. The generated
-native code evaluates the `if` condition once, runs the selected branch, rejoins
-normal scalar slots through LLVM phi nodes, and routes selected branch-local
-`next` paths to the next input record.
+selected-field `print` including `NR`, terminal `next`/`break`, and
+combinations of those actions. The generated native code evaluates the `if`
+condition once, runs the selected branch, rejoins normal scalar slots through
+LLVM phi nodes, routes selected branch-local `next` paths to the next input
+record, and routes selected branch-local `break` paths to the stream close path
+before `END`.
 
 Associative increments can live inside the selected branch:
 
@@ -293,6 +294,16 @@ current record:
 END { print total, seen, skipped }
 ```
 
+Branches can also use terminal `break` to stop the input stream before `END`:
+
+```awk
+{
+  if ($1 == "ERROR") { hits++; break }
+  else { total++ }
+}
+END { print hits, total }
+```
+
 A terminal `next` skips the remaining rules for the current record:
 
 ```awk
@@ -310,8 +321,8 @@ $1 == "ERROR" { hits++; break }
 END { print hits, total }
 ```
 
-For now, `next` and `break` must be the last action in the rule body, and
-branch-local `next` must be the last action in its branch.
+For now, `next` and `break` must be the last action in the rule body. Inside a
+branch, `next` or `break` must be the last action in that branch.
 
 `BEGIN` can emit literal report headers before the first input record is read:
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -93,7 +93,7 @@ plawk_program_native_driver_ir(
     plawk_assoc_print_key_globals(PrintFields, AssocGlobalIR),
     plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
     plawk_mixed_rule_chain_ir(MixedPlan, FieldSeparator, OutputSeparator,
-        RuleGlobalIR, RuleChainIR, RuleCount, BranchNextExits),
+        RuleGlobalIR, RuleChainIR, RuleCount, BranchControlExits),
     plawk_rules_body_print_fields(Rules, BodyPrintFields),
     append(PrintFields, BodyPrintFields, AllPrintFields),
     plawk_print_record_counter_ir(AllPrintFields, RecordLoopPhiIR, RecordCounterIR),
@@ -101,8 +101,8 @@ plawk_program_native_driver_ir(
     plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
     plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
     plawk_mixed_rule_controls(MixedPlan, MixedRuleControls),
-    plawk_mixed_scalar_next_phi_ir(ScalarPlan, RuleCount, MixedRuleControls, BranchNextExits, NextPhiIR),
-    plawk_break_close_ir(ScalarPlan, RuleCount, MixedRuleControls, done,
+    plawk_mixed_scalar_next_phi_ir(ScalarPlan, RuleCount, MixedRuleControls, BranchControlExits, NextPhiIR),
+    plawk_break_close_ir(ScalarPlan, RuleCount, MixedRuleControls, BranchControlExits, done,
         BreakCloseIR, FinalStatePhiIR),
     plawk_mixed_end_print_ir(PrintFields, ScalarPlan, AssocPlan, OutputSeparator, EndPrintIR),
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w~n~w',
@@ -131,7 +131,7 @@ plawk_program_native_driver_ir(
     plawk_field_separator(BeginClauses, FieldSeparator),
     plawk_end_print_string_globals(PrintFields, StringGlobalIR),
     plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, OutputSeparator,
-        RuleGlobalIR, RuleChainIR, RuleCount, BranchNextExits),
+        RuleGlobalIR, RuleChainIR, RuleCount, BranchControlExits),
     plawk_rules_body_print_fields(Rules, BodyPrintFields),
     append(PrintFields, BodyPrintFields, AllPrintFields),
     plawk_print_record_counter_ir(AllPrintFields, RecordLoopPhiIR, RecordCounterIR),
@@ -139,8 +139,8 @@ plawk_program_native_driver_ir(
     plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
     plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
     plawk_scalar_rule_controls(Rules, ScalarRuleControls),
-    plawk_scalar_next_phi_ir(StatePlan, RuleCount, ScalarRuleControls, BranchNextExits, NextPhiIR),
-    plawk_break_close_ir(StatePlan, RuleCount, ScalarRuleControls, done,
+    plawk_scalar_next_phi_ir(StatePlan, RuleCount, ScalarRuleControls, BranchControlExits, NextPhiIR),
+    plawk_break_close_ir(StatePlan, RuleCount, ScalarRuleControls, BranchControlExits, done,
         BreakCloseIR, FinalStatePhiIR),
     plawk_scalar_end_print_ir(PrintFields, StatePlan, OutputSeparator, EndPrintIR),
     format(atom(SurfaceGlobalIR), '~w~n~w~n~w',
@@ -368,6 +368,8 @@ plawk_action_has_control(if(_Pattern, ThenActions, ElseActions)) :-
 plawk_branch_actions_have_unsupported_control(Actions) :-
     (   append(BodyActions, [next], Actions)
     ->  plawk_actions_have_control(BodyActions)
+    ;   append(BodyActions, [break], Actions)
+    ->  plawk_actions_have_control(BodyActions)
     ;   plawk_actions_have_control(Actions)
     ).
 
@@ -388,32 +390,38 @@ plawk_assoc_break_close_ir(Controls, IR) :-
     ;   IR = ''
     ).
 
-plawk_break_close_ir(StatePlan, RuleCount, Controls, BreakPredKind, BreakCloseIR, FinalStatePhiIR) :-
+plawk_break_close_ir(StatePlan, RuleCount, Controls, BranchControlExits, BreakPredKind, BreakCloseIR, FinalStatePhiIR) :-
     plawk_state_plan_slots(StatePlan, Slots),
     (   plawk_controls_have_break(Controls)
-    ->  phrase(plawk_break_slot_phi_lines(Slots, RuleCount, Controls, BreakPredKind, 0), BreakSlotPhiLines),
-        atomic_list_concat(BreakSlotPhiLines, '\n', BreakSlotPhiIR),
-        format(atom(BreakCloseIR),
+    ;   member(branch_break(_Label, _Values), BranchControlExits)
+    ),
+    !,
+    phrase(plawk_break_slot_phi_lines(Slots, RuleCount, Controls, BranchControlExits, BreakPredKind, 0), BreakSlotPhiLines),
+    atomic_list_concat(BreakSlotPhiLines, '\n', BreakSlotPhiIR),
+    format(atom(BreakCloseIR),
 'break_close_stream:
 ~w
   %break_close_ok = call i1 @wam_stream_close_value(%Value %handle)
   br i1 %break_close_ok, label %end_print, label %fail_close
 ',
-            [BreakSlotPhiIR]),
-        HasBreak = true
-    ;   BreakCloseIR = '',
-        HasBreak = false
-    ),
-    phrase(plawk_final_state_phi_lines(Slots, HasBreak, 0), FinalStatePhiLines),
+        [BreakSlotPhiIR]),
+    phrase(plawk_final_state_phi_lines(Slots, true, 0), FinalStatePhiLines),
     atomic_list_concat(FinalStatePhiLines, '\n', FinalStatePhiIR0),
     ( FinalStatePhiIR0 == ''
     -> FinalStatePhiIR = ''
     ;  format(atom(FinalStatePhiIR), '~w~n', [FinalStatePhiIR0])
     ).
-
-plawk_break_slot_phi_lines([], _RuleCount, _Controls, _BreakPredKind, _) -->
+plawk_break_close_ir(StatePlan, _RuleCount, _Controls, _BranchControlExits, _BreakPredKind, '', FinalStatePhiIR) :-
+    plawk_state_plan_slots(StatePlan, Slots),
+    phrase(plawk_final_state_phi_lines(Slots, false, 0), FinalStatePhiLines),
+    atomic_list_concat(FinalStatePhiLines, '\n', FinalStatePhiIR0),
+    ( FinalStatePhiIR0 == ''
+    -> FinalStatePhiIR = ''
+    ;  format(atom(FinalStatePhiIR), '~w~n', [FinalStatePhiIR0])
+    ).
+plawk_break_slot_phi_lines([], _RuleCount, _Controls, _BranchControlExits, _BreakPredKind, _) -->
     [].
-plawk_break_slot_phi_lines([_Slot | Rest], RuleCount, Controls, BreakPredKind, SlotIndex) -->
+plawk_break_slot_phi_lines([_Slot | Rest], RuleCount, Controls, BranchControlExits, BreakPredKind, SlotIndex) -->
     { LastRuleIndex is RuleCount - 1,
       findall(Incoming,
           ( between(0, LastRuleIndex, RuleIndex),
@@ -422,14 +430,25 @@ plawk_break_slot_phi_lines([_Slot | Rest], RuleCount, Controls, BreakPredKind, S
             format(atom(Incoming), '[%rule_~w_slot_~w, %~w]',
                 [RuleIndex, SlotIndex, PredLabel])
           ),
-          Incomings),
+          RuleIncomings),
+      plawk_branch_break_phi_incomings(BranchControlExits, SlotIndex, BranchIncomings),
+      append(RuleIncomings, BranchIncomings, Incomings),
       Incomings \== [],
       atomic_list_concat(Incomings, ', ', IncomingIR),
       format(atom(Line), '  %break_slot_~w = phi i64 ~w', [SlotIndex, IncomingIR]),
       NextSlotIndex is SlotIndex + 1
     },
     [Line],
-    plawk_break_slot_phi_lines(Rest, RuleCount, Controls, BreakPredKind, NextSlotIndex).
+    plawk_break_slot_phi_lines(Rest, RuleCount, Controls, BranchControlExits, BreakPredKind, NextSlotIndex).
+
+plawk_branch_break_phi_incomings([], _SlotIndex, []).
+plawk_branch_break_phi_incomings([branch_break(Label, Values) | Rest], SlotIndex, [Incoming | Incomings]) :-
+    !,
+    nth0(SlotIndex, Values, Value),
+    format(atom(Incoming), '[~w, %~w]', [Value, Label]),
+    plawk_branch_break_phi_incomings(Rest, SlotIndex, Incomings).
+plawk_branch_break_phi_incomings([_Exit | Rest], SlotIndex, Incomings) :-
+    plawk_branch_break_phi_incomings(Rest, SlotIndex, Incomings).
 
 plawk_break_predecessor_label(apply, RuleIndex, Label) :-
     format(atom(Label), 'rule_~w_apply', [RuleIndex]).
@@ -587,7 +606,7 @@ plawk_mixed_update_action(if(_Pattern, ThenActions, ElseActions)) :-
     plawk_mixed_branch_body_actions(ElseActions).
 
 plawk_mixed_branch_body_actions(Actions) :-
-    plawk_split_branch_next_control(Actions, BodyActions, _Control),
+    plawk_split_branch_control(Actions, BodyActions, _Control),
     maplist(plawk_mixed_update_action, BodyActions).
 
 plawk_assoc_update_action(inc_assoc(var(_ArrayName), field(KeyIndex))) :-
@@ -602,11 +621,15 @@ plawk_scalar_conditional_action(if(_Pattern, ThenActions, ElseActions)) :-
 plawk_scalar_plain_update_action(Action) :-
     plawk_scalar_action_update(Action, _Name, _Operation).
 
-plawk_split_branch_next_control(Actions, BodyActions, branch_next) :-
+plawk_split_branch_control(Actions, BodyActions, branch_next) :-
     append(BodyActions, [next], Actions),
     !,
     \+ plawk_actions_have_control(BodyActions).
-plawk_split_branch_next_control(Actions, Actions, fallthrough) :-
+plawk_split_branch_control(Actions, BodyActions, branch_break) :-
+    append(BodyActions, [break], Actions),
+    !,
+    \+ plawk_actions_have_control(BodyActions).
+plawk_split_branch_control(Actions, Actions, fallthrough) :-
     \+ plawk_actions_have_control(Actions).
 
 plawk_assoc_increment_spec_in_actions(Actions, Spec) :-
@@ -1380,7 +1403,7 @@ plawk_scalar_rule_body_action(if(_Pattern, ThenActions, ElseActions)) :-
     plawk_scalar_branch_body_actions(ElseActions).
 
 plawk_scalar_branch_body_actions(Actions) :-
-    plawk_split_branch_next_control(Actions, BodyActions, _Control),
+    plawk_split_branch_control(Actions, BodyActions, _Control),
     maplist(plawk_scalar_rule_body_plain_action, BodyActions).
 
 plawk_scalar_rule_body_plain_action(Action) :-
@@ -1461,6 +1484,9 @@ plawk_scalar_action_sequence_pairs([print(Fields) | Rest], Slots, AssocPlan, Fie
 plawk_scalar_action_sequence_pairs([next], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
         OpIndex, Values, Values, OpIndex, none, [branch_next(CurrentLabel, Values)]) -->
     [].
+plawk_scalar_action_sequence_pairs([break], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
+        OpIndex, Values, Values, OpIndex, break, [branch_break(CurrentLabel, Values)]) -->
+    [].
 plawk_scalar_action_sequence_pairs([if(Pattern, ThenActions, ElseActions) | Rest],
         Slots, AssocPlan, FieldSeparator, OutputSeparator, Prefix, _CurrentLabel, RuleIndex, OpIndex, Values0, Values, FinalOpIndex, ExitLabel, NextExits) -->
     { format(atom(GlobalBase), '~w_if_~w', [Prefix, OpIndex]),
@@ -1538,17 +1564,27 @@ plawk_scalar_update_operation_ir(set(length(FieldIndex)), FieldSeparator, Prefix
 
 plawk_branch_to_done_ir(none, _DoneLabel, '  br label %continue_loop') :-
     !.
+plawk_branch_to_done_ir(break, _DoneLabel, '  br label %break_close_stream') :-
+    !.
 plawk_branch_to_done_ir(ExitLabel, DoneLabel, IR) :-
     ExitLabel \== none,
+    ExitLabel \== break,
     format(atom(IR), '  br label %~w', [DoneLabel]).
 
-plawk_scalar_if_join_pairs(none, _ThenValues, none, _ElseValues, _Prefix, _OpIndex, _Pairs) :-
+plawk_branch_terminal_exit(none).
+plawk_branch_terminal_exit(break).
+
+plawk_scalar_if_join_pairs(ThenExitLabel, _ThenValues, ElseExitLabel, _ElseValues, _Prefix, _OpIndex, _Pairs) :-
+    plawk_branch_terminal_exit(ThenExitLabel),
+    plawk_branch_terminal_exit(ElseExitLabel),
     !,
     fail.
-plawk_scalar_if_join_pairs(none, _ThenValues, _ElseExitLabel, ElseValues, _Prefix, _OpIndex, Pairs) :-
+plawk_scalar_if_join_pairs(ThenExitLabel, _ThenValues, _ElseExitLabel, ElseValues, _Prefix, _OpIndex, Pairs) :-
+    plawk_branch_terminal_exit(ThenExitLabel),
     !,
     plawk_scalar_if_passthrough_pairs(ElseValues, Pairs).
-plawk_scalar_if_join_pairs(_ThenExitLabel, ThenValues, none, _ElseValues, _Prefix, _OpIndex, Pairs) :-
+plawk_scalar_if_join_pairs(_ThenExitLabel, ThenValues, ElseExitLabel, _ElseValues, _Prefix, _OpIndex, Pairs) :-
+    plawk_branch_terminal_exit(ElseExitLabel),
     !,
     plawk_scalar_if_passthrough_pairs(ThenValues, Pairs).
 plawk_scalar_if_join_pairs(ThenExitLabel, ThenValues, ElseExitLabel, ElseValues, Prefix, OpIndex, Pairs) :-
@@ -1652,8 +1688,11 @@ plawk_scalar_next_phi_lines([_Slot | Rest], RuleCount, Controls, BranchNextExits
 
 plawk_branch_next_phi_incomings([], _SlotIndex, []).
 plawk_branch_next_phi_incomings([branch_next(Label, Values) | Rest], SlotIndex, [Incoming | Incomings]) :-
+    !,
     nth0(SlotIndex, Values, Value),
     format(atom(Incoming), '[~w, %~w]', [Value, Label]),
+    plawk_branch_next_phi_incomings(Rest, SlotIndex, Incomings).
+plawk_branch_next_phi_incomings([_Exit | Rest], SlotIndex, Incomings) :-
     plawk_branch_next_phi_incomings(Rest, SlotIndex, Incomings).
 
 plawk_scalar_end_print_ir(PrintFields, StatePlan, OutputSeparator, IR) :-

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -505,6 +505,16 @@ test(surface_mixed_if_else_branch_next_skips_later_rules) :-
         "INFO boot ok\nDEBUG trace skip\nERROR disk full\nDEBUG trace drop\n",
         "2 2 2 2 0 1\n").
 
+test(surface_scalar_if_else_branch_break_stops_stream) :-
+    run_surface_print_smoke("{ if ($1 == \"ERROR\") { hits++; break } else { total++ } } END { print hits, total }\n",
+        "INFO boot ok\nWARN cpu hot\nERROR disk full\nINFO after break\n",
+        "1 2\n").
+
+test(surface_mixed_if_else_branch_break_stops_stream) :-
+    run_surface_print_smoke("{ if ($1 == \"ERROR\") { hits++; seen[$2]++; break } else { total++; counts[$1]++ } } END { print hits, total, seen[\"disk\"], counts[\"INFO\"], counts[\"WARN\"] }\n",
+        "INFO boot ok\nWARN cpu hot\nERROR disk full\nINFO after break\n",
+        "1 2 1 1 1\n").
+
 test(surface_scalar_end_prints_string_literals) :-
     run_surface_print_smoke("{ total++ } END { print \"total\", total }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -813,6 +823,20 @@ test(surface_nonterminal_next_mixed_rejected_by_native_codegen, [fail]) :-
 
 test(surface_branch_nonterminal_next_rejected_by_native_codegen, [fail]) :-
     plawk_parse_string("{ if ($1 == \"DEBUG\") { next; skipped++ } else { total++ } } END { print total, skipped }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
+
+test(surface_if_else_branch_break_uses_native_close_path) :-
+    plawk_parse_string("{ if ($1 == \"ERROR\") { hits++; break } else { total++ } } END { print hits, total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'rule_0_body_if_0_then:'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'br label %break_close_stream'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%break_slot_0 = phi i64 [%rule_0_body_if_0_then_slot_0_op_0, %rule_0_body_if_0_then]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%final_slot_0 = phi i64 [%slot_0, %close_stream], [%break_slot_0, %break_close_stream]'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_branch_nonterminal_break_rejected_by_native_codegen, [fail]) :-
+    plawk_parse_string("{ if ($1 == \"ERROR\") { break; hits++ } else { total++ } } END { print hits, total }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.txt', _DriverIR).
 
 test(surface_terminal_break_uses_close_path_and_final_state_phi) :-


### PR DESCRIPTION
## Summary
- support terminal `break` inside PLAWK `if/else` branch bodies
- carry branch-local break exits into the native break-close path and final-state phis
- keep non-terminal branch `break` rejected by native codegen
- update PLAWK docs and tutorial examples for terminal branch `next`/`break`

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`