### PR TITLE
feat(wam-rust): T7 embedded aggregates — lift transform + live wiring (steps 1–2a)

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -29,7 +29,7 @@
 :- use_module('../bindings/rust_wam_bindings').
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
 % T7 compile-time parallel-aggregate gate (consumer of the cost machinery).
-:- use_module('../core/parallel_gate', [forkable_aggregate/3, goal_parallel_decision/3, parallel_aggregate_transform/5]).
+:- use_module('../core/parallel_gate', [forkable_aggregate/3, goal_parallel_decision/3, parallel_aggregate_transform/5, lift_embedded_aggregate/6]).
 :- use_module('../core/cost_analysis', [build_cost_model/2, goal_cost_tier/3]).
 :- use_module('../targets/wam_text_parser', [
     wam_classify_constant_token/2,
@@ -4617,6 +4617,42 @@ rust_fact_clause(Head, Body) :-
 
 rust_t9_min_rows(Options, N) :-
     ( member(t9_min_rows(N), Options) -> true ; N = 64 ).
+
+% --- T7 embedded-aggregate wiring, step 1: pure clause-lifting pass ----------
+%
+% Apply lift_embedded_aggregate across a predicate's clauses, lifting every
+% embedded parallel-eligible aggregate into a whole-body helper predicate and
+% replacing it in-place with a call. Returns the rewritten clauses + the
+% synthesised helper clauses. Pure/read-only: it reads clauses via clause/2 and
+% builds terms; it does NOT assert/retract, so the user's module is untouched.
+% Succeeds only if at least one aggregate was lifted (else the predicate is
+% compiled by the existing path). Each lift gets a unique Seed (Pred_Arity_N).
+
+rust_lift_predicate_clauses(QPI, Model, Rewritten, Helpers) :-
+    ( QPI = Module:Pred/Arity -> true ; QPI = Pred/Arity, Module = user ),
+    functor(Tmpl, Pred, Arity),
+    findall((Tmpl :- B), clause(Module:Tmpl, B), Clauses),
+    Clauses = [_|_],
+    rust_lift_clauses(Clauses, Model, Pred, Arity, 0, Rewritten, Helpers, Changed),
+    Changed == true.
+
+rust_lift_clauses([], _, _, _, _, [], [], false).
+rust_lift_clauses([(H :- B)|Cs], Model, P, A, Seed0,
+                  [(H :- NB)|RR], Helpers, Changed) :-
+    rust_lift_clause_fully(H, B, Model, P, A, Seed0, NB, MyHelpers, Seed1),
+    rust_lift_clauses(Cs, Model, P, A, Seed1, RR, RestHelpers, ChangedRest),
+    append(MyHelpers, RestHelpers, Helpers),
+    ( ( MyHelpers \== [] ; ChangedRest == true ) -> Changed = true ; Changed = false ).
+
+% Lift every embedded aggregate in one clause body (iterate until none remain).
+rust_lift_clause_fully(H, B, Model, P, A, Seed0, NB, Helpers, SeedN) :-
+    format(atom(Seed), '~w_~w_~w', [P, A, Seed0]),
+    ( lift_embedded_aggregate(H, B, Model, Seed, NB1, Helper)
+    ->  Seed1 is Seed0 + 1,
+        rust_lift_clause_fully(H, NB1, Model, P, A, Seed1, NB, RestHelpers, SeedN),
+        Helpers = [Helper|RestHelpers]
+    ;   NB = B, Helpers = [], SeedN = Seed0
+    ).
 
 foreign_wrapper_setup(Pred/Arity, WamCode, Options, InstrSetup, Setup, RunExpr) :-
     (   option(foreign_lowering(ForeignSpec), Options),

--- a/tests/test_wam_rust_embedded_wiring.pl
+++ b/tests/test_wam_rust_embedded_wiring.pl
@@ -1,0 +1,79 @@
+% test_wam_rust_embedded_wiring.pl
+%
+% T7 embedded-aggregate wiring, step 1 (pure clause-lifting pass):
+% wam_rust_target:rust_lift_predicate_clauses/4 lifts every embedded
+% parallel-eligible aggregate in a predicate's clauses into whole-body helper
+% predicates + in-place calls, WITHOUT mutating the user's module. Pure Prolog.
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target').
+:- use_module('../src/unifyweaver/core/cost_analysis').
+
+% ---- fixtures --------------------------------------------------------------
+ew_base(1, 10). ew_base(2, 20).
+ew_link(10, 1). ew_link(10, 2). ew_link(20, 3).
+ew_down(0, []).
+ew_down(N, [N|T]) :- N > 0, M is N - 1, ew_down(M, T).
+ew_cheap(X, Y) :- Y is X * 2.
+
+% predicate with an EMBEDDED parallel-eligible aggregate
+ew_pred(X, Result) :- ew_base(X, Y), findall(D, (ew_link(Y, Z), ew_down(Z, D)), Result).
+% predicate with NO embedded aggregate (plain rule)
+ew_plain(X, Y) :- ew_base(X, Y).
+% predicate whose embedded aggregate is cheap (not eligible)
+ew_cheapagg(X, R) :- ew_base(X, Y), findall(V, (ew_link(Y, _), ew_cheap(Y, V)), R).
+
+build(M) :- build_cost_model(user, M).
+lift(PI, Rew, Helpers) :-
+    wam_rust_target:rust_lift_predicate_clauses(user:PI, _Model, Rew, Helpers).
+lift(PI, M, Rew, Helpers) :-
+    wam_rust_target:rust_lift_predicate_clauses(user:PI, M, Rew, Helpers).
+
+:- begin_tests(wam_rust_embedded_wiring).
+
+test(lifts_embedded_aggregate) :-
+    build(M),
+    lift(ew_pred/2, M, Rewritten, Helpers),
+    % one clause rewritten, one helper synthesised
+    assertion(Rewritten = [(_ :- _)]),
+    assertion(Helpers = [(_ :- _)]),
+    Rewritten = [(_Head :- NewBody)],
+    Helpers = [(HelperHead :- HelperBody)],
+    % rewritten body: ew_base(X,Y), __lift_agg_...(Y, Result)
+    assertion(NewBody = (ew_base(_, _), _Call)),
+    % helper is the whole-body aggregate (Z link<->down, D tmpl<->down preserved)
+    assertion(HelperBody =@= findall(DD, (ew_link(_, ZZ), ew_down(ZZ, DD)), _)),
+    functor(HelperHead, HN, _), assertion(sub_atom(HN, 0, _, _, '__lift_agg')).
+
+test(does_not_mutate_user_module) :-
+    build(M),
+    % snapshot ew_pred's clauses, lift, snapshot again -> unchanged
+    findall(B0, clause(ew_pred(_, _), B0), Before),
+    lift(ew_pred/2, M, _, _),
+    findall(B1, clause(ew_pred(_, _), B1), After),
+    assertion(Before =@= After),
+    % and no __lift_agg_* predicate leaked into the DB
+    assertion(\+ ( current_predicate(N/_), sub_atom(N, 0, _, _, '__lift_agg') )).
+
+test(declines_no_embedded_aggregate) :-
+    build(M),
+    assertion(\+ lift(ew_plain/2, M, _, _)).
+
+test(declines_cheap_embedded_aggregate) :-
+    build(M),
+    assertion(\+ lift(ew_cheapagg/2, M, _, _)).
+
+% rewritten clause + helper, run sequentially, reproduce the original solutions
+test(lifted_predicate_preserves_solutions) :-
+    build(M),
+    findall(X-R, ew_pred(X, R), Orig),
+    lift(ew_pred/2, M, [(Head :- NewBody)], [Helper]),
+    copy_term(Helper, HC), assertz(user:HC),
+    findall(QX-QR,
+            ( member(QX, [1, 2]),
+              copy_term(Head-NewBody, ew_pred(QX, QR)-Goal),
+              call(user:Goal) ),
+            New),
+    Helper = (HH :- _), functor(HH, HN, HA), functor(Clean, HN, HA), retractall(user:Clean),
+    assertion(New == Orig).
+
+:- end_tests(wam_rust_embedded_wiring).


### PR DESCRIPTION
**Closing as superseded.** `main` now has a working embedded-aggregate implementation via the `ParAggregate` WAM-instruction route (`Instruction::ParAggregate` + `par_collect_labels` + `rust_embedded_par_aggregate` + `test_wam_rust_par_aggregate_embedded_exec.pl`). That's the cleaner route the fork-analysis doc originally proposed, so this lift-to-helper branch (route 1) is redundant.

The genuinely-open item this branch surfaced — `par_collect`/`par_collect_labels` not threading head-arg **inputs** into the aggregate enumerator (latent in both the whole-body wrapper and the route-2 embedded path) — is being addressed separately.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_