### PR TITLE
Add SimpleWiki exact sparse depth sweep

### DIFF
--- a/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
+++ b/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
@@ -547,6 +547,18 @@ compact support but enough path mass for recurrence materialization to matter.
 The enwiki profile is capped smoke evidence, not a full-root-cone
 characterization.
 
+`docs/reports/lmdb_exact_sparse_depth_sweep_simplewiki_articles_exact_sparse_depth_sweep_b10_20_20260614T163104Z.md`
+checks the SimpleWiki side more directly by sweeping root-reachable
+`Category:Articles` targets at child depths `1`, `2`, and `3` with parent-path
+budgets `10` and `20`.  All sampled rows were exact sparse rows: recurrence
+matched simple-path DFS, no cycle approximation was needed, and every effective
+support stayed below the 50-point cap.  The deepest sampled layer had mean path
+mass `1.277`, max path mass `3`, mean effective support `1.447`, and max
+effective support `3`.  At this scale Python wall-clock timings are mostly
+overhead, but the state model still estimates break-even near one cache hit.
+This supports carrying exact sparse histograms deeper on SimpleWiki before
+trying binomial, Gamma, or sampled approximations.
+
 `PARENT_BRANCHING_DISTRIBUTION_THEORY.md` gives the statistical interpretation:
 small excess parent branching is binomial-like, while larger parent branching is
 better treated as a compound/convolution model before fitting a closed form.

--- a/docs/reports/lmdb_exact_sparse_depth_sweep_simplewiki_articles_exact_sparse_depth_sweep_b10_20_20260614T163104Z.json
+++ b/docs/reports/lmdb_exact_sparse_depth_sweep_simplewiki_articles_exact_sparse_depth_sweep_b10_20_20260614T163104Z.json
@@ -1,0 +1,2575 @@
+{
+  "buckets": [
+    {
+      "budget": 10,
+      "child_sample_depth": 1,
+      "cycle_approximation_rows": 0,
+      "dfs_capped_rows": 0,
+      "exact_match_rows": 50,
+      "exact_sparse_under_point_cap_rows": 50,
+      "max_effective_support_bins": 2,
+      "max_path_count": 2,
+      "max_support_bins": 2,
+      "mean_dfs_nodes_expanded": 5.38,
+      "mean_effective_support_bins": 1.02,
+      "mean_exact_histogram_bytes": 289.12,
+      "mean_hits_to_break_even_states": 1.0,
+      "mean_path_count": 1.02,
+      "mean_recurrence_states_evaluated": 4.36,
+      "mean_state_expansion_ratio": 0.7910779220779222,
+      "mean_support_bins": 1.02,
+      "mean_time_ratio": 1.608417694590683,
+      "p95_effective_support_bins": 1.0,
+      "p95_hits_to_break_even_states": 1.0,
+      "p95_path_count": 1.0,
+      "p95_support_bins": 1.0,
+      "pct_effective_bins_le_point_cap": 100.0,
+      "point_cap": 50,
+      "reachable_rows": 50,
+      "record_type": "exact_sparse_depth_sweep_summary_bucket",
+      "recurrence_capped_rows": 0,
+      "rows": 50
+    },
+    {
+      "budget": 20,
+      "child_sample_depth": 1,
+      "cycle_approximation_rows": 0,
+      "dfs_capped_rows": 0,
+      "exact_match_rows": 50,
+      "exact_sparse_under_point_cap_rows": 50,
+      "max_effective_support_bins": 2,
+      "max_path_count": 2,
+      "max_support_bins": 2,
+      "mean_dfs_nodes_expanded": 5.38,
+      "mean_effective_support_bins": 1.02,
+      "mean_exact_histogram_bytes": 289.12,
+      "mean_hits_to_break_even_states": 1.0,
+      "mean_path_count": 1.02,
+      "mean_recurrence_states_evaluated": 4.36,
+      "mean_state_expansion_ratio": 0.7910779220779222,
+      "mean_support_bins": 1.02,
+      "mean_time_ratio": 1.5911995046282252,
+      "p95_effective_support_bins": 1.0,
+      "p95_hits_to_break_even_states": 1.0,
+      "p95_path_count": 1.0,
+      "p95_support_bins": 1.0,
+      "pct_effective_bins_le_point_cap": 100.0,
+      "point_cap": 50,
+      "reachable_rows": 50,
+      "record_type": "exact_sparse_depth_sweep_summary_bucket",
+      "recurrence_capped_rows": 0,
+      "rows": 50
+    },
+    {
+      "budget": 10,
+      "child_sample_depth": 2,
+      "cycle_approximation_rows": 0,
+      "dfs_capped_rows": 0,
+      "exact_match_rows": 50,
+      "exact_sparse_under_point_cap_rows": 50,
+      "max_effective_support_bins": 2,
+      "max_path_count": 2,
+      "max_support_bins": 2,
+      "mean_dfs_nodes_expanded": 10.62,
+      "mean_effective_support_bins": 1.14,
+      "mean_exact_histogram_bytes": 295.84,
+      "mean_hits_to_break_even_states": 1.0,
+      "mean_path_count": 1.14,
+      "mean_recurrence_states_evaluated": 9.48,
+      "mean_state_expansion_ratio": 0.8853203463203464,
+      "mean_support_bins": 1.14,
+      "mean_time_ratio": 2.128644948390093,
+      "p95_effective_support_bins": 2.0,
+      "p95_hits_to_break_even_states": 1.0,
+      "p95_path_count": 2.0,
+      "p95_support_bins": 2.0,
+      "pct_effective_bins_le_point_cap": 100.0,
+      "point_cap": 50,
+      "reachable_rows": 50,
+      "record_type": "exact_sparse_depth_sweep_summary_bucket",
+      "recurrence_capped_rows": 0,
+      "rows": 50
+    },
+    {
+      "budget": 20,
+      "child_sample_depth": 2,
+      "cycle_approximation_rows": 0,
+      "dfs_capped_rows": 0,
+      "exact_match_rows": 50,
+      "exact_sparse_under_point_cap_rows": 50,
+      "max_effective_support_bins": 2,
+      "max_path_count": 2,
+      "max_support_bins": 2,
+      "mean_dfs_nodes_expanded": 10.62,
+      "mean_effective_support_bins": 1.14,
+      "mean_exact_histogram_bytes": 295.84,
+      "mean_hits_to_break_even_states": 1.0,
+      "mean_path_count": 1.14,
+      "mean_recurrence_states_evaluated": 9.48,
+      "mean_state_expansion_ratio": 0.8853203463203464,
+      "mean_support_bins": 1.14,
+      "mean_time_ratio": 1.941387796038225,
+      "p95_effective_support_bins": 2.0,
+      "p95_hits_to_break_even_states": 1.0,
+      "p95_path_count": 2.0,
+      "p95_support_bins": 2.0,
+      "pct_effective_bins_le_point_cap": 100.0,
+      "point_cap": 50,
+      "reachable_rows": 50,
+      "record_type": "exact_sparse_depth_sweep_summary_bucket",
+      "recurrence_capped_rows": 0,
+      "rows": 50
+    },
+    {
+      "budget": 10,
+      "child_sample_depth": 3,
+      "cycle_approximation_rows": 0,
+      "dfs_capped_rows": 0,
+      "exact_match_rows": 47,
+      "exact_sparse_under_point_cap_rows": 47,
+      "max_effective_support_bins": 3,
+      "max_path_count": 3,
+      "max_support_bins": 3,
+      "mean_dfs_nodes_expanded": 12.46808510638298,
+      "mean_effective_support_bins": 1.446808510638298,
+      "mean_exact_histogram_bytes": 303.48936170212767,
+      "mean_hits_to_break_even_states": 1.021629219063512,
+      "mean_path_count": 1.2765957446808511,
+      "mean_recurrence_states_evaluated": 11.170212765957446,
+      "mean_state_expansion_ratio": 0.8905826676671811,
+      "mean_support_bins": 1.2765957446808511,
+      "mean_time_ratio": 2.0242827797016787,
+      "p95_effective_support_bins": 3.0,
+      "p95_hits_to_break_even_states": 1.1428571428571428,
+      "p95_path_count": 2.0,
+      "p95_support_bins": 2.0,
+      "pct_effective_bins_le_point_cap": 100.0,
+      "point_cap": 50,
+      "reachable_rows": 47,
+      "record_type": "exact_sparse_depth_sweep_summary_bucket",
+      "recurrence_capped_rows": 0,
+      "rows": 47
+    },
+    {
+      "budget": 20,
+      "child_sample_depth": 3,
+      "cycle_approximation_rows": 0,
+      "dfs_capped_rows": 0,
+      "exact_match_rows": 47,
+      "exact_sparse_under_point_cap_rows": 47,
+      "max_effective_support_bins": 3,
+      "max_path_count": 3,
+      "max_support_bins": 3,
+      "mean_dfs_nodes_expanded": 12.46808510638298,
+      "mean_effective_support_bins": 1.446808510638298,
+      "mean_exact_histogram_bytes": 303.48936170212767,
+      "mean_hits_to_break_even_states": 1.021629219063512,
+      "mean_path_count": 1.2765957446808511,
+      "mean_recurrence_states_evaluated": 11.170212765957446,
+      "mean_state_expansion_ratio": 0.8905826676671811,
+      "mean_support_bins": 1.2765957446808511,
+      "mean_time_ratio": 2.2567680207411267,
+      "p95_effective_support_bins": 3.0,
+      "p95_hits_to_break_even_states": 1.1428571428571428,
+      "p95_path_count": 2.0,
+      "p95_support_bins": 2.0,
+      "pct_effective_bins_le_point_cap": 100.0,
+      "point_cap": 50,
+      "reachable_rows": 47,
+      "record_type": "exact_sparse_depth_sweep_summary_bucket",
+      "recurrence_capped_rows": 0,
+      "rows": 47
+    }
+  ],
+  "generated_at": "2026-06-14T16:31:04.038385+00:00",
+  "graph": "simplewiki_articles_exact_sparse_depth_sweep_b10_20",
+  "point_cap": 50,
+  "record_type": "exact_sparse_depth_sweep_summary",
+  "root": 2,
+  "selection": {
+    "budgets": [
+      10,
+      20
+    ],
+    "children_per_node": 50000,
+    "expansion_cap": 250000,
+    "filtered_targets": [],
+    "frontier_limit": 50000,
+    "graph": "simplewiki_articles_exact_sparse_depth_sweep_b10_20",
+    "max_parent_depth": 48,
+    "path_cap": 100000,
+    "record_type": "exact_sparse_depth_sweep_selection",
+    "root": 2,
+    "root_reachable_targets": [
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 137
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 534
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 814
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 1493
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 2409
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 3555
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 6326
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 6342
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 6780
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 7252
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 7630
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 7705
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 8114
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 9370
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 9939
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 10495
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 10735
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 11458
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 12481
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 13588
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 15273
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 16289
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 17018
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 17556
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 17935
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 18139
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 21208
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 21851
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 23053
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 25473
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 25630
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 26623
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 31129
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 38715
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 39087
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 39859
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 40072
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 43198
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 44206
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 46253
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 47449
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 47899
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 51548
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 54358
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 54366
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 73459
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 74033
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 90739
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 95047
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 95705
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 1374
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 1944
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 5156
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 7139
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 10967
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 17961
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 24765
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 25738
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 27350
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 27840
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 34961
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 37274
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 37870
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 42575
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 56784
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 57333
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 58634
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 60193
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 60879
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 61826
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 63170
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 63549
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 65268
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 65274
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 65362
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 65405
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 65574
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 65840
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 67795
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 75651
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 75714
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 81607
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 83657
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 84405
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 86621
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 91800
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 105831
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 108509
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 112604
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 118703
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 118941
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 119272
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 121566
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 124331
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 125341
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 126855
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 127105
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 128379
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 129423
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 130440
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 3515
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 2251
+      },
+      {
+        "L_max": 3,
+        "L_min": 2,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 40399
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 101973
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 58899
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 65403
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 59803
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 108670
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 108682
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 85924
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 101886
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 105998
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 106061
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 112490
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 129704
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 106178
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 22312
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 85400
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 40160
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 93725
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 28966
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 24382
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 37954
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 8011
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 35665
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 116317
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 8866
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 38325
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 38340
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 102873
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 8441
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 69649
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 69651
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 111643
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 69667
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 123192
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 70247
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 14201
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 112004
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 112005
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 106394
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 69587
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 117235
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 107743
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 101379
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 61857
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 18211
+      }
+    ],
+    "selected_targets": [
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 137
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 534
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 814
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 1493
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 2409
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 3555
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 6326
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 6342
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 6780
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 7252
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 7630
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 7705
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 8114
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 9370
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 9939
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 10495
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 10735
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 11458
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 12481
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 13588
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 15273
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 16289
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 17018
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 17556
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 17935
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 18139
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 21208
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 21851
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 23053
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 25473
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 25630
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 26623
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 31129
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 38715
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 39087
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 39859
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 40072
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 43198
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 44206
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 46253
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 47449
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 47899
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 51548
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 54358
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 54366
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 73459
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 74033
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 90739
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 95047
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 95705
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 1374
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 1944
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 5156
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 7139
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 10967
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 17961
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 24765
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 25738
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 27350
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 27840
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 34961
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 37274
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 37870
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 42575
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 56784
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 57333
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 58634
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 60193
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 60879
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 61826
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 63170
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 63549
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 65268
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 65274
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 65362
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 65405
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 65574
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 65840
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 67795
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 75651
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 75714
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 81607
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 83657
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 84405
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 86621
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 91800
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 105831
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 108509
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 112604
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 118703
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 118941
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 119272
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 121566
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 124331
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 125341
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 126855
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 127105
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 128379
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 129423
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 130440
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 3515
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 2251
+      },
+      {
+        "L_max": 3,
+        "L_min": 2,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 40399
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 101973
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 58899
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 65403
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 59803
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 108670
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 108682
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 85924
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 101886
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 105998
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 106061
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 112490
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 129704
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 106178
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 22312
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 85400
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 40160
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 93725
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 28966
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 24382
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 37954
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 8011
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 35665
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 116317
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 8866
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 38325
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 38340
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 102873
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 8441
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 69649
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 69651
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 111643
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 69667
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 123192
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 70247
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 14201
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 112004
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 112005
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 106394
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 69587
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 117235
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 107743
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 101379
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 61857
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "target_node": 18211
+      }
+    ],
+    "selection_counts": {
+      "0": 1,
+      "1": 13720,
+      "2": 1106,
+      "3": 47,
+      "4": 0
+    },
+    "target_depths": [
+      1,
+      2,
+      3,
+      4
+    ],
+    "targets_per_depth": 50
+  },
+  "tail_epsilon": 0.01
+}

--- a/docs/reports/lmdb_exact_sparse_depth_sweep_simplewiki_articles_exact_sparse_depth_sweep_b10_20_20260614T163104Z.md
+++ b/docs/reports/lmdb_exact_sparse_depth_sweep_simplewiki_articles_exact_sparse_depth_sweep_b10_20_20260614T163104Z.md
@@ -1,0 +1,36 @@
+# LMDB Exact Sparse Depth Sweep
+
+Graph: `simplewiki_articles_exact_sparse_depth_sweep_b10_20`
+
+Root: `2`
+
+Point cap: `50`
+
+Tail epsilon: `0.01`
+
+## Selection
+
+| child_depth | sampled_frontier_nodes | selected_targets | root_reachable_targets | filtered_targets |
+|------------:|-----------------------:|-----------------:|-----------------------:|-----------------:|
+| 0 | 1 | 0 | 0 | 0 |
+| 1 | 13720 | 50 | 50 | 0 |
+| 2 | 1106 | 50 | 50 | 0 |
+| 3 | 47 | 47 | 47 | 0 |
+| 4 | 0 | 0 | 0 | 0 |
+
+## Depth And Budget Buckets
+
+| child_depth | budget | rows | exact_sparse | exact_matches | mean_paths | max_paths | mean_eff_bins | max_eff_bins | pct_eff_bins_le_cap | mean_dfs_nodes | mean_rec_states | mean_state_ratio | mean_time_ratio | mean_break_even_hits |
+|------------:|-------:|-----:|-------------:|--------------:|-----------:|----------:|--------------:|-------------:|--------------------:|---------------:|----------------:|-----------------:|----------------:|---------------------:|
+| 1 | 10 | 50 | 50 | 50 | 1.020 | 2 | 1.020 | 2 | 100.000 | 5.380 | 4.360 | 0.791 | 1.608 | 1.000 |
+| 1 | 20 | 50 | 50 | 50 | 1.020 | 2 | 1.020 | 2 | 100.000 | 5.380 | 4.360 | 0.791 | 1.591 | 1.000 |
+| 2 | 10 | 50 | 50 | 50 | 1.140 | 2 | 1.140 | 2 | 100.000 | 10.620 | 9.480 | 0.885 | 2.129 | 1.000 |
+| 2 | 20 | 50 | 50 | 50 | 1.140 | 2 | 1.140 | 2 | 100.000 | 10.620 | 9.480 | 0.885 | 1.941 | 1.000 |
+| 3 | 10 | 47 | 47 | 47 | 1.277 | 3 | 1.447 | 3 | 100.000 | 12.468 | 11.170 | 0.891 | 2.024 | 1.022 |
+| 3 | 20 | 47 | 47 | 47 | 1.277 | 3 | 1.447 | 3 | 100.000 | 12.468 | 11.170 | 0.891 | 2.257 | 1.022 |
+
+## Interpretation
+
+- `exact_sparse` counts reachable, uncapped rows where recurrence matched DFS, no cycle approximation was needed, and the effective support stayed under the point cap.
+- `mean_break_even_hits` is state based: recurrence build states divided by saved states per cached hit, using effective bins as the cached evaluation cost.  It is a planning estimate, not a wall-clock guarantee.
+- If mean effective bins stay far below the point cap, the cap is not the paid storage cost; exact sparse histograms remain the first representation to consider.

--- a/scripts/lmdb_exact_sparse_depth_sweep.py
+++ b/scripts/lmdb_exact_sparse_depth_sweep.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Sweep exact sparse parent histograms by child depth on an LMDB graph.
+
+This probe answers a narrower question than the boundary-cache benchmarks:
+given root-reachable targets at increasing child-depths, how expensive is it to
+keep the parent-path histogram exact and sparse?
+
+For each sampled target and path-length budget it compares:
+
+* full simple-path DFS enumeration, which is exact under the budget; and
+* shifted-parent recurrence, which is exact on acyclic cones and reports cycle
+  approximation when a node-only recurrence cannot preserve simple-path state.
+
+The summary treats a point cap such as 50 as an upper bound, not a cost paid by
+every histogram.  The observed support, tail-pruned support, path mass, DFS
+expansions, recurrence states, and state-based break-even hits are reported by
+target child-depth and path-length budget.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.distribution_fit_comparison import (  # noqa: E402
+    effective_support_bins,
+    exact_excess_distribution,
+    histogram_bytes,
+    tail_pruning_summary,
+)
+from scripts.lmdb_parent_branching_diagnostic import (  # noqa: E402
+    LmdbCategoryGraph,
+    parse_int_list,
+    root_distances,
+    select_targets_by_child_depth,
+)
+from scripts.lmdb_parent_histogram_benchmark import (  # noqa: E402
+    bounded_parent_histogram,
+    percentile,
+    safe_graph_name,
+)
+from scripts.parent_histogram_recurrence import recurrence_parent_histogram  # noqa: E402
+
+
+DEFAULT_TARGET_DEPTHS = "1,2,3,4"
+DEFAULT_BUDGETS = "10,20"
+
+
+def mean(values):
+    values = [float(value) for value in values if value is not None]
+    return 0.0 if not values else statistics.fmean(values)
+
+
+def max_or_zero(values):
+    values = [value for value in values if value is not None]
+    return 0 if not values else max(values)
+
+
+def safe_ratio(numerator, denominator):
+    denominator = float(denominator or 0.0)
+    if denominator <= 0.0:
+        return None
+    return float(numerator or 0.0) / denominator
+
+
+def histogram_metrics(hist, tail_epsilon, prune_thresholds):
+    if not hist:
+        return {
+            "reachable": False,
+            "path_count": 0,
+            "L_min": None,
+            "L_max": None,
+            "support_bins": 0,
+            "support_width": None,
+            "effective_support_bins": 0,
+            "tail_pruning": {},
+            "histogram_bytes": 0,
+        }
+    probabilities, origin = exact_excess_distribution(hist)
+    l_min = min(hist)
+    l_max = max(hist)
+    return {
+        "reachable": True,
+        "path_count": sum(int(value) for value in hist.values()),
+        "L_min": l_min,
+        "L_max": l_max,
+        "support_bins": len(hist),
+        "support_width": l_max - l_min,
+        "effective_support_bins": effective_support_bins(probabilities, tail_epsilon),
+        "tail_pruning": tail_pruning_summary(probabilities, prune_thresholds, origin or 0),
+        "histogram_bytes": histogram_bytes(hist),
+    }
+
+
+def break_even_hits(build_states, uncached_states, eval_bins):
+    saved_states = max(0.0, float(uncached_states or 0) - float(eval_bins or 0))
+    if saved_states <= 0.0:
+        return None
+    return float(build_states or 0) / saved_states
+
+
+def select_root_reachable_targets(graph, root, target_depths, args):
+    targets, child_depth_by_node, selection_counts = select_targets_by_child_depth(
+        graph,
+        root,
+        target_depths,
+        args.children_per_node,
+        args.frontier_limit,
+        args.targets_per_depth,
+        args.seed,
+    )
+    distance_memo = {}
+    kept = []
+    filtered = []
+    for target in targets:
+        distances = root_distances(target, root, graph.parents, args.max_parent_depth, distance_memo)
+        row = {
+            "target_node": target,
+            "child_sample_depth": child_depth_by_node[target],
+            "L_min": distances["L_min"],
+            "L_max": distances["L_max"],
+            "distance_truncated": distances["truncated"],
+            "distance_cycle_skipped": distances["cycle_skipped"],
+        }
+        if distances["L_min"] is not None and not distances["truncated"]:
+            kept.append(row)
+        else:
+            filtered.append(row)
+    return kept, filtered, selection_counts
+
+
+def comparison_record(args, target_row, budget, dfs_hist, dfs_stats, dfs_time_ns, recurrence_hist, recurrence_stats, recurrence_time_ns):
+    dfs_metrics = histogram_metrics(dfs_hist, args.tail_epsilon, args.prune_thresholds)
+    recurrence_metrics = histogram_metrics(recurrence_hist, args.tail_epsilon, args.prune_thresholds)
+    exact_match = dfs_hist == recurrence_hist
+    support_bins = dfs_metrics["support_bins"]
+    effective_bins = dfs_metrics["effective_support_bins"]
+    return {
+        "record_type": "exact_sparse_depth_sweep_row",
+        "graph": args.graph_name,
+        "root": args.root,
+        "target_node": target_row["target_node"],
+        "child_sample_depth": target_row["child_sample_depth"],
+        "budget": int(budget),
+        "target_L_min": target_row["L_min"],
+        "target_L_max": target_row["L_max"],
+        "target_distance_cycle_skipped": target_row["distance_cycle_skipped"],
+        "dfs_histogram": dfs_hist,
+        "recurrence_histogram": recurrence_hist,
+        "exact_match": exact_match,
+        "reachable": dfs_metrics["reachable"],
+        "path_count": dfs_metrics["path_count"],
+        "L_min": dfs_metrics["L_min"],
+        "L_max": dfs_metrics["L_max"],
+        "support_bins": support_bins,
+        "support_width": dfs_metrics["support_width"],
+        "effective_support_bins": effective_bins,
+        "tail_pruning": dfs_metrics["tail_pruning"],
+        "exact_histogram_bytes": dfs_metrics["histogram_bytes"],
+        "recurrence_path_count": recurrence_metrics["path_count"],
+        "recurrence_support_bins": recurrence_metrics["support_bins"],
+        "dfs_nodes_expanded": dfs_stats.nodes_expanded,
+        "dfs_edges_examined": dfs_stats.edges_examined,
+        "dfs_cycle_skips": dfs_stats.cycle_skips,
+        "dfs_budget_cutoffs": dfs_stats.budget_cutoffs,
+        "dfs_path_cap_hit": dfs_stats.path_cap_hit,
+        "dfs_expansion_cap_hit": dfs_stats.expansion_cap_hit,
+        "recurrence_states_evaluated": recurrence_stats.states_evaluated,
+        "recurrence_memo_hits": recurrence_stats.memo_hits,
+        "recurrence_edges_examined": recurrence_stats.edges_examined,
+        "recurrence_cycle_edges": recurrence_stats.cycle_edges,
+        "recurrence_cycle_approximation": recurrence_stats.cycle_approximation,
+        "recurrence_path_cap_hit": recurrence_stats.path_cap_hit,
+        "recurrence_expansion_cap_hit": recurrence_stats.expansion_cap_hit,
+        "state_expansion_ratio": safe_ratio(recurrence_stats.states_evaluated, dfs_stats.nodes_expanded),
+        "time_ratio": safe_ratio(recurrence_time_ns, dfs_time_ns),
+        "dfs_time_ns": dfs_time_ns,
+        "recurrence_time_ns": recurrence_time_ns,
+        "exact_sparse_under_point_cap": exact_match and effective_bins <= args.point_cap,
+        "hits_to_break_even_states": break_even_hits(
+            recurrence_stats.states_evaluated,
+            dfs_stats.nodes_expanded,
+            max(1, effective_bins),
+        ),
+    }
+
+
+def summary_row(key, rows, point_cap):
+    depth, budget = key
+    reachable = [row for row in rows if row["reachable"]]
+    exact_sparse = [
+        row for row in reachable
+        if row["exact_sparse_under_point_cap"]
+        and not row["dfs_path_cap_hit"]
+        and not row["dfs_expansion_cap_hit"]
+        and not row["recurrence_path_cap_hit"]
+        and not row["recurrence_expansion_cap_hit"]
+        and not row["recurrence_cycle_approximation"]
+    ]
+    break_even = [
+        row["hits_to_break_even_states"]
+        for row in reachable
+        if row["hits_to_break_even_states"] is not None
+    ]
+    return {
+        "record_type": "exact_sparse_depth_sweep_summary_bucket",
+        "child_sample_depth": depth,
+        "budget": budget,
+        "rows": len(rows),
+        "reachable_rows": len(reachable),
+        "exact_match_rows": sum(1 for row in reachable if row["exact_match"]),
+        "exact_sparse_under_point_cap_rows": len(exact_sparse),
+        "cycle_approximation_rows": sum(1 for row in reachable if row["recurrence_cycle_approximation"]),
+        "dfs_capped_rows": sum(1 for row in reachable if row["dfs_path_cap_hit"] or row["dfs_expansion_cap_hit"]),
+        "recurrence_capped_rows": sum(1 for row in reachable if row["recurrence_path_cap_hit"] or row["recurrence_expansion_cap_hit"]),
+        "mean_path_count": mean(row["path_count"] for row in reachable),
+        "p95_path_count": percentile([row["path_count"] for row in reachable], 95),
+        "max_path_count": max_or_zero(row["path_count"] for row in reachable),
+        "mean_support_bins": mean(row["support_bins"] for row in reachable),
+        "p95_support_bins": percentile([row["support_bins"] for row in reachable], 95),
+        "max_support_bins": max_or_zero(row["support_bins"] for row in reachable),
+        "mean_effective_support_bins": mean(row["effective_support_bins"] for row in reachable),
+        "p95_effective_support_bins": percentile([row["effective_support_bins"] for row in reachable], 95),
+        "max_effective_support_bins": max_or_zero(row["effective_support_bins"] for row in reachable),
+        "point_cap": point_cap,
+        "pct_effective_bins_le_point_cap": 0.0 if not reachable else 100.0 * sum(1 for row in reachable if row["effective_support_bins"] <= point_cap) / len(reachable),
+        "mean_exact_histogram_bytes": mean(row["exact_histogram_bytes"] for row in reachable),
+        "mean_dfs_nodes_expanded": mean(row["dfs_nodes_expanded"] for row in reachable),
+        "mean_recurrence_states_evaluated": mean(row["recurrence_states_evaluated"] for row in reachable),
+        "mean_state_expansion_ratio": mean(row["state_expansion_ratio"] for row in reachable),
+        "mean_time_ratio": mean(row["time_ratio"] for row in reachable),
+        "mean_hits_to_break_even_states": mean(break_even),
+        "p95_hits_to_break_even_states": percentile(break_even, 95),
+    }
+
+
+def build_summary(records, args):
+    rows = [row for row in records if row.get("record_type") == "exact_sparse_depth_sweep_row"]
+    by_key = {}
+    for row in rows:
+        by_key.setdefault((row["child_sample_depth"], row["budget"]), []).append(row)
+    buckets = [summary_row(key, by_key[key], args.point_cap) for key in sorted(by_key)]
+    selection = next(row for row in records if row.get("record_type") == "exact_sparse_depth_sweep_selection")
+    return {
+        "record_type": "exact_sparse_depth_sweep_summary",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "graph": args.graph_name,
+        "root": args.root,
+        "point_cap": args.point_cap,
+        "tail_epsilon": args.tail_epsilon,
+        "selection": selection,
+        "buckets": buckets,
+    }
+
+
+def markdown_summary(summary):
+    selection = summary["selection"]
+    lines = [
+        "# LMDB Exact Sparse Depth Sweep",
+        "",
+        "Graph: `{}`".format(summary["graph"]),
+        "",
+        "Root: `{}`".format(summary["root"]),
+        "",
+        "Point cap: `{}`".format(summary["point_cap"]),
+        "",
+        "Tail epsilon: `{}`".format(summary["tail_epsilon"]),
+        "",
+        "## Selection",
+        "",
+        "| child_depth | sampled_frontier_nodes | selected_targets | root_reachable_targets | filtered_targets |",
+        "|------------:|-----------------------:|-----------------:|-----------------------:|-----------------:|",
+    ]
+    selected_by_depth = Counter(row["child_sample_depth"] for row in selection["selected_targets"])
+    kept_by_depth = Counter(row["child_sample_depth"] for row in selection["root_reachable_targets"])
+    filtered_by_depth = Counter(row["child_sample_depth"] for row in selection["filtered_targets"])
+    for depth in sorted(set(selection["selection_counts"]) | set(selected_by_depth) | set(kept_by_depth) | set(filtered_by_depth), key=int):
+        depth_int = int(depth)
+        lines.append("| {depth} | {frontier} | {selected} | {kept} | {filtered} |".format(
+            depth=depth_int,
+            frontier=selection["selection_counts"].get(str(depth), selection["selection_counts"].get(depth, 0)),
+            selected=selected_by_depth.get(depth_int, 0),
+            kept=kept_by_depth.get(depth_int, 0),
+            filtered=filtered_by_depth.get(depth_int, 0),
+        ))
+    lines.extend([
+        "",
+        "## Depth And Budget Buckets",
+        "",
+        "| child_depth | budget | rows | exact_sparse | exact_matches | mean_paths | max_paths | mean_eff_bins | max_eff_bins | pct_eff_bins_le_cap | mean_dfs_nodes | mean_rec_states | mean_state_ratio | mean_time_ratio | mean_break_even_hits |",
+        "|------------:|-------:|-----:|-------------:|--------------:|-----------:|----------:|--------------:|-------------:|--------------------:|---------------:|----------------:|-----------------:|----------------:|---------------------:|",
+    ])
+    for row in summary["buckets"]:
+        lines.append(
+            "| {depth} | {budget} | {rows} | {exact_sparse} | {exact} | {mean_paths:.3f} | {max_paths} | {mean_bins:.3f} | {max_bins} | {pct_bins:.3f} | {dfs_nodes:.3f} | {rec_states:.3f} | {state_ratio:.3f} | {time_ratio:.3f} | {break_even:.3f} |".format(
+                depth=row["child_sample_depth"],
+                budget=row["budget"],
+                rows=row["rows"],
+                exact_sparse=row["exact_sparse_under_point_cap_rows"],
+                exact=row["exact_match_rows"],
+                mean_paths=row["mean_path_count"],
+                max_paths=row["max_path_count"],
+                mean_bins=row["mean_effective_support_bins"],
+                max_bins=row["max_effective_support_bins"],
+                pct_bins=row["pct_effective_bins_le_point_cap"],
+                dfs_nodes=row["mean_dfs_nodes_expanded"],
+                rec_states=row["mean_recurrence_states_evaluated"],
+                state_ratio=row["mean_state_expansion_ratio"],
+                time_ratio=row["mean_time_ratio"],
+                break_even=row["mean_hits_to_break_even_states"],
+            )
+        )
+    lines.extend([
+        "",
+        "## Interpretation",
+        "",
+        "- `exact_sparse` counts reachable, uncapped rows where recurrence matched DFS, no cycle approximation was needed, and the effective support stayed under the point cap.",
+        "- `mean_break_even_hits` is state based: recurrence build states divided by saved states per cached hit, using effective bins as the cached evaluation cost.  It is a planning estimate, not a wall-clock guarantee.",
+        "- If mean effective bins stay far below the point cap, the cap is not the paid storage cost; exact sparse histograms remain the first representation to consider.",
+    ])
+    return "\n".join(lines) + "\n"
+
+
+def run_sweep(args):
+    graph = LmdbCategoryGraph(args.lmdb_dir)
+    try:
+        target_depths = parse_int_list(args.target_depths)
+        budgets = parse_int_list(args.budgets)
+        root_reachable_targets, filtered_targets, selection_counts = select_root_reachable_targets(
+            graph,
+            args.root,
+            target_depths,
+            args,
+        )
+        records = [{
+            "record_type": "exact_sparse_depth_sweep_selection",
+            "graph": args.graph_name,
+            "root": args.root,
+            "target_depths": target_depths,
+            "budgets": budgets,
+            "selection_counts": selection_counts,
+            "selected_targets": root_reachable_targets + filtered_targets,
+            "root_reachable_targets": root_reachable_targets,
+            "filtered_targets": filtered_targets,
+            "children_per_node": args.children_per_node,
+            "frontier_limit": args.frontier_limit,
+            "targets_per_depth": args.targets_per_depth,
+            "max_parent_depth": args.max_parent_depth,
+            "path_cap": args.path_cap,
+            "expansion_cap": args.expansion_cap,
+        }]
+        for target_row in root_reachable_targets:
+            for budget in budgets:
+                started = time.perf_counter_ns()
+                dfs_hist, dfs_stats = bounded_parent_histogram(
+                    graph.parents,
+                    target_row["target_node"],
+                    args.root,
+                    budget,
+                    args.path_cap,
+                    args.expansion_cap,
+                )
+                dfs_time_ns = time.perf_counter_ns() - started
+                started = time.perf_counter_ns()
+                recurrence_hist, recurrence_stats = recurrence_parent_histogram(
+                    graph.parents,
+                    target_row["target_node"],
+                    args.root,
+                    budget,
+                    args.path_cap,
+                    args.expansion_cap,
+                )
+                recurrence_time_ns = time.perf_counter_ns() - started
+                records.append(comparison_record(
+                    args,
+                    target_row,
+                    budget,
+                    dfs_hist,
+                    dfs_stats,
+                    dfs_time_ns,
+                    recurrence_hist,
+                    recurrence_stats,
+                    recurrence_time_ns,
+                ))
+        summary = build_summary(records, args)
+        return records, summary
+    finally:
+        graph.close()
+
+
+def write_outputs(records, summary, output_dir, graph_name, write_jsonl=False):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    safe_name = safe_graph_name(graph_name)
+    summary_json = output_dir / "lmdb_exact_sparse_depth_sweep_{}_{}.json".format(safe_name, timestamp)
+    summary_md = output_dir / "lmdb_exact_sparse_depth_sweep_{}_{}.md".format(safe_name, timestamp)
+    summary_json.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary_md.write_text(markdown_summary(summary), encoding="utf-8")
+    jsonl_path = None
+    if write_jsonl:
+        jsonl_path = output_dir / "lmdb_exact_sparse_depth_sweep_{}_{}.jsonl".format(safe_name, timestamp)
+        with jsonl_path.open("w", encoding="utf-8") as handle:
+            for record in records:
+                handle.write(json.dumps(record, sort_keys=True) + "\n")
+    return summary_json, summary_md, jsonl_path
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lmdb-dir", type=Path, required=True, help="Numeric-keyed category LMDB directory.")
+    parser.add_argument("--root", type=int, required=True, help="Numeric root id.")
+    parser.add_argument("--graph-name", default="lmdb_exact_sparse_depth_sweep", help="Graph label used in output filenames.")
+    parser.add_argument("--target-depths", default=DEFAULT_TARGET_DEPTHS, help="Child depths to sample, e.g. `1,2,3,4`.")
+    parser.add_argument("--children-per-node", type=int, default=50000, help="Child sample cap per frontier node.")
+    parser.add_argument("--frontier-limit", type=int, default=50000, help="Depth frontier sample cap.")
+    parser.add_argument("--targets-per-depth", type=int, default=12, help="Targets sampled per requested child depth.")
+    parser.add_argument("--budgets", default=DEFAULT_BUDGETS, help="Parent path-length budgets, e.g. `10,20`.")
+    parser.add_argument("--max-parent-depth", type=int, default=48, help="Root-reachable filtering horizon.")
+    parser.add_argument("--path-cap", type=int, default=100000, help="Maximum root-reaching paths before capping one row.")
+    parser.add_argument("--expansion-cap", type=int, default=250000, help="Maximum DFS/recurrence states before capping one row.")
+    parser.add_argument("--point-cap", type=int, default=50, help="Exact sparse support cap used for classification.")
+    parser.add_argument("--tail-epsilon", type=float, default=0.01, help="Allowed CDF tail mass for effective support bins.")
+    parser.add_argument("--prune-thresholds", default="0.01,0.001,0.0001", help="Tail pruning thresholds recorded per row.")
+    parser.add_argument("--seed", default="simplewiki-exact-sparse-depth-sweep", help="Deterministic sampling seed.")
+    parser.add_argument("--write-jsonl", action="store_true", help="Also write full row-level JSONL.")
+    parser.add_argument("--output-dir", type=Path, default=Path("docs/reports"), help="Output directory.")
+    args = parser.parse_args(argv)
+    args.prune_thresholds = [float(value) for value in args.prune_thresholds.split(",") if value.strip()]
+    if args.children_per_node <= 0:
+        raise SystemExit("--children-per-node must be positive")
+    if args.frontier_limit <= 0:
+        raise SystemExit("--frontier-limit must be positive")
+    if args.targets_per_depth <= 0:
+        raise SystemExit("--targets-per-depth must be positive")
+    if args.max_parent_depth <= 0:
+        raise SystemExit("--max-parent-depth must be positive")
+    if args.point_cap <= 0:
+        raise SystemExit("--point-cap must be positive")
+    return args
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    records, summary = run_sweep(args)
+    summary_json, summary_md, jsonl_path = write_outputs(records, summary, args.output_dir, args.graph_name, args.write_jsonl)
+    print(markdown_summary(summary), end="")
+    print("summary_json={}".format(summary_json))
+    print("summary_md={}".format(summary_md))
+    if jsonl_path is not None:
+        print("jsonl={}".format(jsonl_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_lmdb_exact_sparse_depth_sweep.py
+++ b/tests/test_lmdb_exact_sparse_depth_sweep.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""Tests for exact sparse depth sweep helpers."""
+
+import unittest
+
+from scripts.lmdb_exact_sparse_depth_sweep import (
+    break_even_hits,
+    histogram_metrics,
+    markdown_summary,
+    summary_row,
+)
+
+
+class ExactSparseDepthSweepTests(unittest.TestCase):
+    def test_histogram_metrics_reports_effective_support_and_tail_pruning(self):
+        metrics = histogram_metrics({2: 100, 3: 1}, 0.01, [0.01])
+
+        self.assertTrue(metrics["reachable"])
+        self.assertEqual(metrics["path_count"], 101)
+        self.assertEqual(metrics["support_bins"], 2)
+        self.assertEqual(metrics["effective_support_bins"], 1)
+        self.assertEqual(metrics["tail_pruning"]["0.01"]["kept_bins"], 1)
+
+    def test_break_even_hits_uses_cached_bins_as_eval_cost(self):
+        self.assertAlmostEqual(break_even_hits(5, 20, 10), 0.5)
+        self.assertIsNone(break_even_hits(5, 10, 10))
+
+    def test_summary_bucket_classifies_exact_sparse_rows(self):
+        row = {
+            "reachable": True,
+            "exact_match": True,
+            "exact_sparse_under_point_cap": True,
+            "recurrence_cycle_approximation": False,
+            "dfs_path_cap_hit": False,
+            "dfs_expansion_cap_hit": False,
+            "recurrence_path_cap_hit": False,
+            "recurrence_expansion_cap_hit": False,
+            "path_count": 2,
+            "support_bins": 1,
+            "effective_support_bins": 1,
+            "exact_histogram_bytes": 16,
+            "dfs_nodes_expanded": 10,
+            "recurrence_states_evaluated": 3,
+            "state_expansion_ratio": 0.3,
+            "time_ratio": 0.4,
+            "hits_to_break_even_states": 3 / 9,
+        }
+
+        summary = summary_row((2, 10), [row], 50)
+
+        self.assertEqual(summary["exact_sparse_under_point_cap_rows"], 1)
+        self.assertEqual(summary["exact_match_rows"], 1)
+        self.assertEqual(summary["max_effective_support_bins"], 1)
+        self.assertAlmostEqual(summary["mean_hits_to_break_even_states"], 3 / 9)
+
+    def test_markdown_summary_mentions_break_even_and_point_cap(self):
+        summary = {
+            "graph": "fixture",
+            "root": 1,
+            "point_cap": 50,
+            "tail_epsilon": 0.01,
+            "selection": {
+                "selection_counts": {0: 1, 2: 1},
+                "selected_targets": [{"child_sample_depth": 2}],
+                "root_reachable_targets": [{"child_sample_depth": 2}],
+                "filtered_targets": [],
+            },
+            "buckets": [
+                {
+                    "child_sample_depth": 2,
+                    "budget": 10,
+                    "rows": 1,
+                    "exact_sparse_under_point_cap_rows": 1,
+                    "exact_match_rows": 1,
+                    "mean_path_count": 1.0,
+                    "max_path_count": 1,
+                    "mean_effective_support_bins": 1.0,
+                    "max_effective_support_bins": 1,
+                    "pct_effective_bins_le_point_cap": 100.0,
+                    "mean_dfs_nodes_expanded": 3.0,
+                    "mean_recurrence_states_evaluated": 1.0,
+                    "mean_state_expansion_ratio": 0.333,
+                    "mean_time_ratio": 0.5,
+                    "mean_hits_to_break_even_states": 0.5,
+                }
+            ],
+        }
+
+        markdown = markdown_summary(summary)
+
+        self.assertIn("Point cap: `50`", markdown)
+        self.assertIn("mean_break_even_hits", markdown)
+        self.assertIn("exact_sparse", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `scripts/lmdb_exact_sparse_depth_sweep.py` for root-reachable child-depth sweeps comparing simple-path DFS enumeration against shifted-parent recurrence.
- Generates a SimpleWiki `Category:Articles` sweep for budgets 10 and 20 across child depths 1, 2, and 3.
- Updates the distribution fit policy with the measured exact-sparse result: all sampled rows matched DFS, stayed under the 50-point cap, and needed no cycle approximation.

## Report highlights
- Depth 3, budget 20: 47/47 exact sparse rows, max effective support 3, max path mass 3.
- Mean effective support at depth 3 was 1.447 and mean path mass was 1.277.
- State-based break-even estimate stayed near one cached hit; Python wall-clock timing is noted as overhead-dominated at this scale.

## Validation
- `python3 -m unittest tests.test_lmdb_exact_sparse_depth_sweep tests.test_lmdb_parent_recurrence_histogram_benchmark tests.test_lmdb_parent_histogram_benchmark tests.test_lmdb_materialization_regime_report tests.test_lmdb_root_conditioned_branching_profile tests.test_distribution_precompute_depth_estimator`
- `python3 -m py_compile scripts/lmdb_exact_sparse_depth_sweep.py tests/test_lmdb_exact_sparse_depth_sweep.py`
- `git diff --check`