### PR TITLE
Support PLAWK branch string prints

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -275,7 +275,7 @@ length($0); hits++ } END { print hits, last_len }` also stay native. The first
 native `if/else` action slice lowers field-equality conditions once at rule-body
 scope, threads the whole scalar slot vector through then/else action sequences,
 emits per-slot phis at the branch join, and can run field-key associative
-increments or selected-field `print` as branch-local side effects. Scalar,
+increments or selected-field/string-literal `print` as branch-local side effects. Scalar,
 mixed, and assoc-only branch bodies now share the same rule-body action walker;
 branch phis use each branch's actual exit block, including assoc side-effect
 `_done` blocks. Branch-local `print` uses prefixed SSA names so multiple branch

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -97,7 +97,7 @@ Scalar slot updates can also sit behind native `if/else` guards, e.g.
 `{ if ($1 == "ERROR") { errors++; last_len = length($0) } else { non_errors++ } }
 END { print errors, non_errors, last_len }`. The first branch slice supports
 field-equality conditions, scalar updates, field-key associative increments,
-selected-field `print` including `NR`, and terminal `next`/`break` inside
+selected-field and string-literal `print` including `NR`, and terminal `next`/`break` inside
 branches. The native lowering evaluates each source `if` guard once, threads
 every scalar slot through the then/else bodies, emits associative table
 increments and branch-local prints only on the selected branch, rejoins scalar

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -255,7 +255,7 @@ END { print total, errors, non_errors, last_len }
 ```
 
 For now, branch bodies support scalar updates, field-key associative increments,
-selected-field `print` including `NR`, terminal `next`/`break`, and
+selected-field and string-literal `print` including `NR`, terminal `next`/`break`, and
 combinations of those actions. The generated native code evaluates the `if`
 condition once, runs the selected branch, rejoins normal scalar slots through
 LLVM phi nodes, routes selected branch-local `next` paths to the next input
@@ -272,11 +272,11 @@ Associative increments can live inside the selected branch:
 END { print by_component["disk"], by_kind["WARN"] }
 ```
 
-Branches can also print selected fields:
+Branches can also print selected fields and string literals:
 
 ```awk
 {
-  if ($1 == "ERROR") { print NR, $2, $3 }
+  if ($1 == "ERROR") { print "error", NR, $2, $3 }
   else { counts[$1]++ }
 }
 END { print counts["WARN"] }

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -37,6 +37,7 @@
 %      $1 == "ERROR" { last_len = length($0); hits++ } END { print hits, last_len }
 %      { if ($1 == "ERROR") { errors++ } else { warnings++ } } END { print errors, warnings }
 %      { if ($1 == "ERROR") { print $2, $3 } else { counts[$1]++ } } END { print counts["WARN"] }
+%      { if ($1 == "ERROR") { print "error", $2 } else { print "ok", $1 } } END { print "done" }
 %
 %  The surrounding runtime still comes from write_wam_llvm_project/3. This
 %  function emits the target-specific native main that streams the file, lowers
@@ -485,7 +486,8 @@ plawk_scalar_state_plan(Rules, PrintFields, state_plan(Slots)) :-
           plawk_scalar_update_action_name(Action, Name)
         ),
         ActionVars),
-    ActionVars \== [],
+    plawk_rules_body_print_fields(Rules, BodyPrintFields),
+    ( ActionVars \== [] ; BodyPrintFields \== [] ),
     findall(Name,
         ( member(Field, PrintFields),
           plawk_scalar_print_expr(Field, Name)
@@ -1416,6 +1418,7 @@ plawk_rule_body_print_action(print(Fields)) :-
     maplist(plawk_rule_body_print_field, Fields).
 
 plawk_rule_body_print_field(field(_)).
+plawk_rule_body_print_field(string(_)).
 plawk_rule_body_print_field(special('NR')).
 plawk_rule_body_print_field(special('NF')).
 plawk_rule_body_print_field(length(field(_))).
@@ -1952,6 +1955,21 @@ plawk_emit_prefixed_print_expr_ir(special('NR'), _FieldSeparator, Prefix, Index,
         i64(Base, Base, '%current_nr'), [], []) :-
     format(atom(Base), '~w_nr_~w', [Prefix, Index]).
 
+plawk_emit_prefixed_print_expr_ir(string(Value), _FieldSeparator, Prefix, Index,
+        string(Base, PtrIR), [GlobalIR], [StringPtr]) :-
+    string_codes(Value, Codes),
+    length(Codes, StringLen),
+    BytesLen is StringLen + 1,
+    llvm_c_bytes(Codes, Bytes),
+    format(atom(Base), '~w_string_~w', [Prefix, Index]),
+    format(atom(GlobalIR),
+        '@.~w = private constant [~w x i8] c"~w\\00"',
+        [Base, BytesLen, Bytes]),
+    format(atom(StringPtr),
+        '  %~w_ptr = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0',
+        [Base, BytesLen, BytesLen, Base]),
+    format(atom(PtrIR), '%~w_ptr', [Base]).
+
 plawk_emit_prefixed_print_expr_ir(special('NF'), FieldSeparator, Prefix, Index,
         i64(Base, Base, ValueIR), [], [CountIR]) :-
     format(atom(Base), '~w_nf_~w', [Prefix, Index]),
@@ -2048,3 +2066,11 @@ plawk_prefixed_print_expr_output_ir(slice(FmtPrefix, PrintPrefix, LenIR, PtrIR),
 
 plawk_prefixed_print_expr_output_ir(case_slice(Mode, PrintBase, LenIR, PtrIR), _Prefix, _Index, [PrintCall]) :-
     llvm_emit_ascii_case_slice_print(Mode, PtrIR, LenIR, PrintBase, PrintCall).
+
+plawk_prefixed_print_expr_output_ir(string(Base, PtrIR), _Prefix, Index, [FmtPtr, PrintCall]) :-
+    format(atom(FmtPtr),
+        '  %~w_fmt_~w = getelementptr [3 x i8], [3 x i8]* @.plawk_surface_print_string, i32 0, i32 0',
+        [Base, Index]),
+    format(atom(PrintCall),
+        '  %printed_~w_~w = call i32 (i8*, ...) @printf(i8* %~w_fmt_~w, i8* ~w)',
+        [Base, Index, Base, Index, PtrIR]).

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -213,6 +213,14 @@ test(parses_branch_print_if_else_rule) :-
             [inc_assoc(var(counts), field(1))])])],
         [end([print([assoc(var(counts), string("WARN"))])])])).
 
+test(parses_branch_string_print_if_else_rule) :-
+    plawk_parse_string("{ if ($1 == \"ERROR\") { print \"error\", NR, $2 } else { print \"ok\", $1 } } END { print \"done\" }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [if(field_eq(1, "ERROR"),
+            [print([string("error"), special('NR'), field(2)])],
+            [print([string("ok"), field(1)])])])],
+        [end([print([string("done")])])])).
+
 test(parses_assoc_count_end_print_rule) :-
     plawk_parse_string("{ counts[$1]++ } END { print counts[\"ERROR\"], counts[\"WARN\"] }\n", Program),
     assertion(Program == program([], [rule(always, [inc_assoc(var(counts), field(1))])],
@@ -495,6 +503,11 @@ test(surface_scalar_if_else_prints_branch_nr) :-
         "ERROR disk full\nWARN cpu hot\nERROR net down\n",
         "1 disk\n3 net\n4\n").
 
+test(surface_if_else_branch_prints_string_literals) :-
+    run_surface_print_smoke("{ if ($1 == \"ERROR\") { print \"error\", NR, $2 } else { print \"ok\", $1 } } END { print \"done\" }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\n",
+        "ok INFO\nerror 2 disk\nok WARN\ndone\n").
+
 test(surface_scalar_if_else_branch_next_skips_later_actions) :-
     run_surface_print_smoke("{ if ($1 == \"DEBUG\") { skipped++; next } else { seen++ }; total++ } END { print total, seen, skipped }\n",
         "INFO boot ok\nDEBUG trace skip\nERROR disk full\nDEBUG trace drop\n",
@@ -765,6 +778,17 @@ test(surface_if_else_branch_nr_print_uses_native_record_counter) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '%current_nr = add i64 %plawk_nr, 1'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_1_then_print_0_nr_0_fmt_0 = getelementptr'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%printed_rule_0_body_if_1_then_print_0_nr_0_0 = call i32 (i8*, ...) @printf(i8* %rule_0_body_if_1_then_print_0_nr_0_fmt_0, i64 %current_nr)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_if_else_branch_string_print_uses_prefixed_globals) :-
+    plawk_parse_string("{ if ($1 == \"ERROR\") { print \"error\", $2 } else { print \"ok\", $1 } } END { print \"done\" }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.plawk_surface_print_string = private constant [3 x i8] c"%s\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.rule_0_body_if_0_then_print_0_string_0 = private constant [6 x i8]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.rule_0_body_if_0_else_print_0_string_0 = private constant [3 x i8]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_0_then_print_0_string_0_ptr = getelementptr [6 x i8], [6 x i8]* @.rule_0_body_if_0_then_print_0_string_0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_rule_0_body_if_0_then_print_0_string_0_0 = call i32 (i8*, ...) @printf'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 


### PR DESCRIPTION
## Summary
- support string literals in PLAWK `print` actions inside `if/else` branch bodies
- emit prefixed branch string globals so branch-local string prints do not collide
- allow the scalar native rule chain to handle branch-print programs without scalar state slots
- add parser, IR, and runtime coverage for branch string prints
- update PLAWK docs and tutorial examples for string-literal branch prints

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests([plawk_surface_prefix_print:parses_branch_string_print_if_else_rule,plawk_surface_prefix_print:surface_if_else_branch_prints_string_literals,plawk_surface_prefix_print:surface_if_else_branch_string_print_uses_prefixed_globals])" -t halt`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`