### PR TITLE
feat(wam-rust): T7 route 2 — parallelize aggregates embedded in larger clause bodies

### DIFF
--- a/docs/reports/wam_rust_t7_NEXT.md
+++ b/docs/reports/wam_rust_t7_NEXT.md
@@ -17,12 +17,23 @@ aggregates stay sequential (no fork regression).
 - **Merge PR #3138** — matrix doc update (`rust T7 ✗ → ~ gated`). The code PRs
   (#3123 route-1, #3135 reduce types) are already merged.
 
-## The one substantial T7 item left
+## The one substantial T7 item left — DONE (2026-06-14)
 
-**Aggregates embedded in a *larger* clause body** (not the whole body). Today
-those still compile sequentially. The native-wrapper trick only works when a
-predicate's whole body IS the aggregate; an embedded aggregate has to run
-mid-clause inside the WAM, which needs a real instruction.
+**Aggregates embedded in a *larger* clause body** (not the whole body), via the
+`par_aggregate` WAM-instruction route below, are now **implemented and
+exec-verified**. A clause with a guard goal before an embedded `findall`
+compiles, with `parallel_aggregates(true)`, to synthesised `__par_enum`/
+`__par_body` helpers (ordinary shared-table WAM predicates) plus a single
+`par_aggregate(AggType, EnumLabel, BodyLabel, ResultReg)` instruction spliced
+over the `begin_aggregate..end_aggregate` block. The handler drives the helpers
+by entry-PC label (`par_collect_labels`, the label-based sibling of
+`par_collect`), reduces by agg type (collect/count/sum/max/min — mirrors the
+sequential `aggregate_frame`), and binds the result in place. Verified by
+`tests/test_wam_rust_par_aggregate_embedded_exec.pl` (parallel result == known
+sequential answer) with the full `test_wam_rust_target.pl` (174) and
+`test_parallel_gate.pl` (25) regressions green and route-1 unaffected.
+
+The original design is retained below for reference.
 
 ### Plan — the `par_aggregate` WAM-instruction route
 

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -819,6 +819,79 @@ wam_instruction_arm('Instruction::EndAggregate(value_reg)', Body) :-
                     self.backtrack()
                 } else { false }'.
 
+% T7 route 2: parallel aggregate embedded in a larger clause body. Drives the
+% __par_enum/__par_body helper predicates by their entry-PC labels, reduces by
+% agg_type (mirrors the aggregate_frame finalisation), binds result_reg in
+% place, and advances to the next instruction (no choice point left behind, so
+% the surrounding clause keeps running normally).
+wam_instruction_arm('Instruction::ParAggregate(agg_type, enum_label, body_label, result_reg)', Body) :-
+    Body = '                let __base = self.clone();
+                let __vals = crate::par_aggregate::par_collect_labels(&__base, enum_label, body_label);
+                let __result = match agg_type.as_str() {
+                    "count" => Value::Integer(__vals.len() as i64),
+                    "sum" => {
+                        let mut sum_i: i64 = 0;
+                        let mut sum_f: f64 = 0.0;
+                        let mut saw_float = false;
+                        for val in &__vals {
+                            match self.deref_var(&self.deref_heap(val)) {
+                                Value::Integer(n) => { sum_i += n; sum_f += n as f64; }
+                                Value::Float(f) => { saw_float = true; sum_f += f; }
+                                _ => {}
+                            }
+                        }
+                        if saw_float { Value::Float(sum_f) } else { Value::Integer(sum_i) }
+                    }
+                    "max" => {
+                        let mut best: Option<Value> = None;
+                        for val in &__vals {
+                            let current = self.deref_var(&self.deref_heap(val));
+                            best = match best {
+                                None => Some(current),
+                                Some(ref prev) => match (&current, prev) {
+                                    (Value::Integer(a), Value::Integer(b)) if a > b => Some(current),
+                                    (Value::Float(a), Value::Float(b)) if a > b => Some(current),
+                                    (Value::Integer(a), Value::Float(b)) if (*a as f64) > *b => Some(current),
+                                    (Value::Float(a), Value::Integer(b)) if *a > (*b as f64) => Some(current),
+                                    _ => Some(prev.clone()),
+                                },
+                            };
+                        }
+                        best.unwrap_or(Value::List(vec![]))
+                    }
+                    "min" => {
+                        let mut best: Option<Value> = None;
+                        for val in &__vals {
+                            let current = self.deref_var(&self.deref_heap(val));
+                            best = match best {
+                                None => Some(current),
+                                Some(ref prev) => match (&current, prev) {
+                                    (Value::Integer(a), Value::Integer(b)) if a < b => Some(current),
+                                    (Value::Float(a), Value::Float(b)) if a < b => Some(current),
+                                    (Value::Integer(a), Value::Float(b)) if (*a as f64) < *b => Some(current),
+                                    (Value::Float(a), Value::Integer(b)) if *a < (*b as f64) => Some(current),
+                                    _ => Some(prev.clone()),
+                                },
+                            };
+                        }
+                        best.unwrap_or(Value::List(vec![]))
+                    }
+                    _ => Value::List(__vals),
+                };
+                let __lhs = self.get_reg_raw(result_reg).map(|v| self.deref_var(&v));
+                let __ok = match __lhs {
+                    Some(Value::Unbound(ref __vn)) => {
+                        self.trail_binding(result_reg);
+                        self.set_reg_str(result_reg, __result.clone());
+                        self.bind_var(__vn, __result);
+                        true
+                    }
+                    Some(__existing) => __existing == __result,
+                    None => { self.set_reg_str(result_reg, __result); true }
+                };
+                if __ok { self.pc += 1; }
+                __ok'.
+
 % --- Choice Point Instructions ---
 
 wam_instruction_arm('Instruction::TryMeElse(label)', Body) :-
@@ -4590,6 +4663,98 @@ rust_assert_helper(Module, (Head :- Body), Module:Name/Arity) :-
     copy_term((Head :- Body), (H :- B)),
     assertz(Module:(H :- B)).
 
+% --- T7 route 2: aggregates EMBEDDED in a larger clause body ----------------
+%
+% Unlike route 1 (whole-body aggregate -> native par_collect wrapper), an
+% embedded aggregate must run mid-clause inside the WAM. This pass keeps the
+% containing predicate as a WAM predicate but (a) synthesises the same
+% enum/body helpers as route 1 (added to the compile set so they get entry
+% labels) and (b) records a rewrite so the containing predicate's
+% begin_aggregate..end_aggregate block is replaced by a single par_aggregate
+% instruction referencing those helper labels. Gated by parallel_aggregates(true)
+% and the same cost gate as route 1 (only expensive/recursive inner bodies).
+
+rust_inject_embedded_par_aggregates(Preds0, Options, Preds, Rewrites) :-
+    (   option(parallel_aggregates(true), Options)
+    ->  rust_partition_embedded(Preds0, Options, HelperPIs, Rewrites),
+        append(Preds0, HelperPIs, Preds)
+    ;   Preds = Preds0, Rewrites = []
+    ).
+
+rust_partition_embedded([], _, [], []).
+rust_partition_embedded([PI|Rest], Options, HelperPIs, Rewrites) :-
+    (   catch(rust_embedded_par_aggregate(PI, Options, MyHelpers, Rewrite), _, fail)
+    ->  rust_pi_module(PI, Module),
+        maplist(rust_assert_helper(Module), MyHelpers, MyHelperPIs),
+        rust_partition_embedded(Rest, Options, RestHelperPIs, RestRewrites),
+        append(MyHelperPIs, RestHelperPIs, HelperPIs),
+        Rewrites = [Rewrite|RestRewrites]
+    ;   rust_partition_embedded(Rest, Options, HelperPIs, Rewrites)
+    ).
+
+% Succeeds for a single-clause predicate whose body contains (but is not
+% itself) a forkable aggregate that the cost gate sends parallel and whose
+% reduce type the par_aggregate handler supports.
+rust_embedded_par_aggregate(QPI, _Options, Helpers,
+        rewrite(Pred/Arity, EnumName, BodyName)) :-
+    ( QPI = Module:Pred/Arity -> true ; QPI = Pred/Arity, Module = user ),
+    functor(Head, Pred, Arity),
+    findall(t, clause(Module:Head, _), [t]),     % exactly one clause
+    clause(Module:Head, Body),
+    \+ forkable_aggregate(Body, _, _),           % not whole-body (that is route 1)
+    rust_body_embedded_aggregate(Body, AggGoal),
+    build_cost_model(Module, CM),
+    parallel_aggregate_transform(AggGoal, CM, Pred, Helpers,
+        par_aggregate(AggType, EnumName/1, BodyName/2, _Result)),
+    rust_supported_par_agg_type(AggType),
+    !.
+
+% Find the first forkable aggregate goal inside a (possibly nested) conjunction.
+rust_body_embedded_aggregate((A, B), Agg) :-
+    !,
+    (   forkable_aggregate(A, _, _)
+    ->  Agg = A
+    ;   rust_body_embedded_aggregate(B, Agg)
+    ).
+rust_body_embedded_aggregate(Goal, Goal) :-
+    forkable_aggregate(Goal, _, _).
+
+% Reduce types the ParAggregate handler implements (must match the sequential
+% aggregate_frame finalisation so par == seq).
+rust_supported_par_agg_type(T) :- memberchk(T, [collect, count, sum, max, min]).
+
+% Rewrite the WAM text lines of a predicate flagged for embedded parallelism:
+% splice a single `par_aggregate` line over its begin_aggregate..end_aggregate
+% block. No-op (Lines unchanged) when there is no matching rewrite directive.
+rust_rewrite_embedded_aggregate(Lines0, PI, Rewrites, Lines) :-
+    memberchk(rewrite(PI, EnumName, BodyName), Rewrites),
+    !,
+    rust_splice_par_aggregate(Lines0, EnumName, BodyName, Lines).
+rust_rewrite_embedded_aggregate(Lines, _, _, Lines).
+
+rust_splice_par_aggregate(Lines0, EnumName, BodyName, Lines) :-
+    rust_find_begin_agg(Lines0, Before, Type, ResultReg, AfterBegin),
+    rust_drop_to_end_agg(AfterBegin, AfterEnd),
+    format(string(ParLine), '    par_aggregate ~w, ~w/1, ~w/2, ~w',
+           [Type, EnumName, BodyName, ResultReg]),
+    append(Before, [ParLine|AfterEnd], Lines).
+
+rust_find_begin_agg([Line|Rest], [], Type, ResultReg, Rest) :-
+    wam_tokenize_line(Line, Parts),
+    Parts = ["begin_aggregate", Type0, _ValueReg, ResultReg0|_],
+    clean_comma(Type0, Type),
+    clean_comma(ResultReg0, ResultReg),
+    !.
+rust_find_begin_agg([Line|Rest], [Line|Before], Type, ResultReg, After) :-
+    rust_find_begin_agg(Rest, Before, Type, ResultReg, After).
+
+rust_drop_to_end_agg([Line|Rest], Rest) :-
+    wam_tokenize_line(Line, Parts),
+    Parts = ["end_aggregate"|_],
+    !.
+rust_drop_to_end_agg([_|Rest], After) :-
+    rust_drop_to_end_agg(Rest, After).
+
 % --- T9 fact-table inline: detection + row extraction ----------------------
 %
 % Recognise a predicate whose every clause is a ground unit clause (a fact) and
@@ -4851,6 +5016,17 @@ wam_line_to_rust_instr(["end_aggregate", ValueReg], _, _, Rust) :-
     clean_comma(ValueReg, CValueReg),
     format(string(Rust),
         'Instruction::EndAggregate("~w".to_string())', [CValueReg]).
+% T7 route 2: par_aggregate AggType, EnumLabel, BodyLabel, ResultReg
+% (EnumLabel/BodyLabel are predicate-indicator entry labels, e.g.
+% __par_enum_foo/1). Emitted by rust_rewrite_embedded_aggregates.
+wam_line_to_rust_instr(["par_aggregate", Type, EnumLabel, BodyLabel, ResultReg], _, _, Rust) :-
+    clean_comma(Type, CType),
+    clean_comma(EnumLabel, CEnumLabel),
+    clean_comma(BodyLabel, CBodyLabel),
+    clean_comma(ResultReg, CResultReg),
+    format(string(Rust),
+        'Instruction::ParAggregate("~w".to_string(), "~w".to_string(), "~w".to_string(), "~w".to_string())',
+        [CType, CEnumLabel, CBodyLabel, CResultReg]).
 wam_line_to_rust_instr(["try_me_else", Label], _, _, Rust) :-
     format(string(Rust),
         'Instruction::TryMeElse("~w".to_string())', [Label]).
@@ -5436,11 +5612,15 @@ compile_predicates_for_project(Predicates0, Options, Code) :-
     % aggregate — synthesise their enum/body helpers (added to the compile set)
     % and emit a native par_collect wrapper for each. No-op unless
     % parallel_aggregates(true).
-    rust_inject_parallel_aggregates(Predicates0, Options, Predicates, ParWrappers),
+    rust_inject_parallel_aggregates(Predicates0, Options, Predicates1, ParWrappers),
+    % Pass 0.5 (T7 route-2): aggregates EMBEDDED in larger clause bodies —
+    % synthesise their enum/body helpers (added to the compile set) and record a
+    % rewrite to splice a par_aggregate instruction over the begin/end block.
+    rust_inject_embedded_par_aggregates(Predicates1, Options, Predicates, EmbeddedRewrites),
     % Pass 1: classify each predicate as native, wam, or failed
     classify_predicates(Predicates, Options, Classified),
     % Pass 2: collect WAM entries with cumulative PCs, build shared table
-    collect_wam_entries(Classified, 1, WamEntries, AllInstrParts, AllLabelParts),
+    collect_wam_entries(Classified, 1, EmbeddedRewrites, WamEntries, AllInstrParts, AllLabelParts),
     % Generate shared WAM table if any WAM predicates exist
     (   WamEntries \== []
     ->  atomic_list_concat(AllInstrParts, '\n', AllInstrs),
@@ -5606,32 +5786,34 @@ classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
 %% collect_wam_entries(+Classified, +StartPC, -WamEntries, -AllInstrParts, -AllLabelParts)
 %  Iterates over classified predicates, collecting WAM code with cumulative PCs.
 %  WamEntries is a list of wam_entry(Pred, Arity, StartPC) terms.
-collect_wam_entries([], _, [], [], []).
-collect_wam_entries([classified(_, Pred, Arity, wam, WamCode)|Rest], PC,
+collect_wam_entries([], _, _, [], [], []).
+collect_wam_entries([classified(_, Pred, Arity, wam, WamCode)|Rest], PC, Rewrites,
                     [wam_entry(Pred, Arity, PC)|RestEntries],
                     AllInstrs, AllLabels) :-
     atom_string(WamCode, WamStr),
-    split_string(WamStr, "\n", "", Lines),
+    split_string(WamStr, "\n", "", Lines0),
+    rust_rewrite_embedded_aggregate(Lines0, Pred/Arity, Rewrites, Lines),
     wam_lines_to_rust(Lines, PC, Pred/Arity, [], InstrParts, LabelParts),
     % Count instructions to compute next PC
     length(InstrParts, InstrCount),
     NextPC is PC + InstrCount,
-    collect_wam_entries(Rest, NextPC, RestEntries, RestInstrs, RestLabels),
+    collect_wam_entries(Rest, NextPC, Rewrites, RestEntries, RestInstrs, RestLabels),
     append(InstrParts, RestInstrs, AllInstrs),
     append(LabelParts, RestLabels, AllLabels).
-collect_wam_entries([classified(_, Pred, Arity, lowered, lowered_code(_, WamCode))|Rest], PC,
+collect_wam_entries([classified(_, Pred, Arity, lowered, lowered_code(_, WamCode))|Rest], PC, Rewrites,
                     [wam_entry(Pred, Arity, PC)|RestEntries],
                     AllInstrs, AllLabels) :-
     atom_string(WamCode, WamStr),
-    split_string(WamStr, "\n", "", Lines),
+    split_string(WamStr, "\n", "", Lines0),
+    rust_rewrite_embedded_aggregate(Lines0, Pred/Arity, Rewrites, Lines),
     wam_lines_to_rust(Lines, PC, Pred/Arity, [], InstrParts, LabelParts),
     length(InstrParts, InstrCount),
     NextPC is PC + InstrCount,
-    collect_wam_entries(Rest, NextPC, RestEntries, RestInstrs, RestLabels),
+    collect_wam_entries(Rest, NextPC, Rewrites, RestEntries, RestInstrs, RestLabels),
     append(InstrParts, RestInstrs, AllInstrs),
     append(LabelParts, RestLabels, AllLabels).
-collect_wam_entries([_|Rest], PC, Entries, Instrs, Labels) :-
-    collect_wam_entries(Rest, PC, Entries, Instrs, Labels).
+collect_wam_entries([_|Rest], PC, Rewrites, Entries, Instrs, Labels) :-
+    collect_wam_entries(Rest, PC, Rewrites, Entries, Instrs, Labels).
 
 %% generate_predicate_codes(+Classified, +WamEntries, +Options, -PredCodes)
 %  Generates Rust code for each classified predicate. Options is threaded so the

--- a/templates/targets/rust_wam/instructions.rs.mustache
+++ b/templates/targets/rust_wam/instructions.rs.mustache
@@ -107,6 +107,11 @@ pub enum Instruction {
     BeginAggregate(String, String, String),
     /// Record one aggregate solution and force backtracking.
     EndAggregate(String),
+    /// T7 route 2: parallel aggregate embedded in a larger clause body.
+    /// (agg_type, enum_entry_label, body_entry_label, result_reg). Drives the
+    /// `__par_enum`/`__par_body` helper predicates by label and reduces by
+    /// agg_type, binding result_reg in place (no choice point left behind).
+    ParAggregate(String, String, String, String),
 
     // === Choice Points ===
     /// Create choice point, try current clause, alternative at Label.

--- a/templates/targets/rust_wam/par_aggregate.rs.mustache
+++ b/templates/targets/rust_wam/par_aggregate.rs.mustache
@@ -142,3 +142,116 @@ pub fn seq_collect(
     }
     out
 }
+
+// ---------------------------------------------------------------------------
+// Route 2: label-based collection for aggregates EMBEDDED in a larger clause
+// body. `par_collect`/`seq_collect` above take the generated predicate `fn`
+// pointers, which only exist when the whole predicate body IS the aggregate.
+// An embedded aggregate runs mid-clause inside the WAM interpreter (the
+// `ParAggregate` instruction), so it drives the enum/body helper predicates by
+// their entry-PC labels via `self.run()` instead.
+//
+// Isolation: `base` is a clone of the live interpreter machine, so it carries
+// the container clause's choice points. Each enumeration clears them on its own
+// clone before running, so a `backtrack()` past the helper's own choice points
+// stops (returns false) instead of escaping into the container clause.
+
+fn collect_inputs_labeled(base: &WamState, enum_pc: usize) -> Vec<Value> {
+    let mut vm = base.clone();
+    vm.choice_points.clear();
+    vm.aggregate_acc.clear();
+    vm.pc = enum_pc;
+    vm.set_reg("A1", Value::Unbound(IN_VAR.to_string()));
+    let mut out = Vec::new();
+    if vm.run() {
+        loop {
+            if let Some(raw) = vm.bindings.get(IN_VAR).cloned() {
+                out.push(vm.deref_var(&vm.deref_heap(&raw)));
+            }
+            if !vm.backtrack() || !vm.run() {
+                break;
+            }
+        }
+    }
+    out
+}
+
+fn run_body_labeled(base: &WamState, m: &mut WamState, body_pc: usize, input: Value) -> Vec<Value> {
+    *m = base.clone();
+    m.choice_points.clear();
+    m.aggregate_acc.clear();
+    m.pc = body_pc;
+    m.set_reg("A1", input);
+    m.set_reg("A2", Value::Unbound(VAL_VAR.to_string()));
+    let mut vals = Vec::new();
+    if m.run() {
+        loop {
+            if let Some(raw) = m.bindings.get(VAL_VAR).cloned() {
+                vals.push(m.deref_var(&m.deref_heap(&raw)));
+            }
+            if !m.backtrack() || !m.run() {
+                break;
+            }
+        }
+    }
+    vals
+}
+
+fn map_bodies_labeled(base: &WamState, inputs: &[Value], body_pc: usize) -> Vec<Value> {
+    let n = inputs.len();
+    let cores = thread::available_parallelism().map(|p| p.get()).unwrap_or(1).min(n);
+    if n < 2 || cores < 2 {
+        let mut out = Vec::new();
+        let mut m = base.clone();
+        for inp in inputs {
+            out.extend(run_body_labeled(base, &mut m, body_pc, inp.clone()));
+        }
+        return out;
+    }
+    let chunk = (n + cores - 1) / cores;
+    let mut results: Vec<(usize, Vec<Value>)> = thread::scope(|s| {
+        let mut handles = Vec::new();
+        for c in 0..cores {
+            let lo = c * chunk;
+            let hi = ((c + 1) * chunk).min(n);
+            if lo >= hi {
+                continue;
+            }
+            let slice = &inputs[lo..hi];
+            handles.push(s.spawn(move || {
+                let mut m = base.clone();
+                let mut local = Vec::new();
+                for inp in slice {
+                    local.extend(run_body_labeled(base, &mut m, body_pc, inp.clone()));
+                }
+                (lo, local)
+            }));
+        }
+        handles.into_iter().map(|h| h.join().unwrap()).collect()
+    });
+    results.sort_by_key(|(lo, _)| *lo);
+    let mut out = Vec::new();
+    for (_, mut v) in results {
+        out.append(&mut v);
+    }
+    out
+}
+
+/// Label-based `collect` for an embedded aggregate: enumerate inputs from the
+/// `__par_enum` helper's entry PC, then run the `__par_body` helper per input
+/// (parallel when worthwhile). Returns the ordered body-value sequence; the
+/// `ParAggregate` instruction handler reduces it by aggregate type. Returns an
+/// empty vec if either label is unknown (the handler then reduces an empty set,
+/// matching an aggregate over no solutions).
+pub fn par_collect_labels(base: &WamState, enum_label: &str, body_label: &str) -> Vec<Value> {
+    let enum_pc = match base.labels.get(enum_label) {
+        Some(p) => *p,
+        None => return Vec::new(),
+    };
+    let body_pc = match base.labels.get(body_label) {
+        Some(p) => *p,
+        None => return Vec::new(),
+    };
+    let inputs = collect_inputs_labeled(base, enum_pc);
+    map_bodies_labeled(base, &inputs, body_pc)
+}

--- a/tests/test_wam_rust_par_aggregate_embedded_exec.pl
+++ b/tests/test_wam_rust_par_aggregate_embedded_exec.pl
@@ -1,0 +1,99 @@
+% test_wam_rust_par_aggregate_embedded_exec.pl
+%
+% T7 route 2 end-to-end: an aggregate EMBEDDED in a larger clause body (a guard
+% goal before the findall) is compiled with parallel_aggregates(true). The
+% containing predicate stays a WAM predicate, but its begin_aggregate..
+% end_aggregate block is rewritten to a single `par_aggregate` instruction that
+% drives synthesised __par_enum/__par_body helpers in parallel. Builds and RUNS
+% the project, asserting the user predicate returns the correct collected result
+% (== the known sequential answer).
+%
+% cargo-gated.
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+
+:- dynamic eemb_ready/0.
+:- dynamic eemb_fact/1.
+eemb_ready.
+eemb_fact(1). eemb_fact(2). eemb_fact(3). eemb_fact(4). eemb_fact(5). eemb_fact(6).
+eemb_down(0, []).
+eemb_down(N, [N|T]) :- N > 0, M is N - 1, eemb_down(M, T).
+
+% Embedded aggregate: the findall is NOT the whole body (eemb_ready guards it),
+% so route-1 (whole-body native wrapper) does not apply; route-2 must.
+eemb_collect(L) :- eemb_ready, findall(D, (eemb_fact(X), eemb_down(X, D)), L).
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- begin_tests(wam_rust_par_aggregate_embedded_exec).
+
+test(embedded_findall_compiles_to_par_aggregate_and_runs,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_paragg_embed_exec'))]) :-
+    Dir = 'output/test_paragg_embed_exec',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project(
+        [user:eemb_collect/1, user:eemb_ready/0, user:eemb_fact/1, user:eemb_down/2],
+        [module_name(pemb), parallel_aggregates(true)], Dir)),
+    % the rewrite must have spliced a ParAggregate instruction into the shared
+    % WAM table, with the synthesised helper predicates present.
+    atom_concat(Dir, '/src/lib.rs', LibRs),
+    read_file_to_string(LibRs, Src, []),
+    assertion(sub_string(Src, _, _, _, "ParAggregate")),
+    assertion(sub_string(Src, _, _, _, "__par_enum_eemb_collect/1")),
+    assertion(sub_string(Src, _, _, _, "__par_body_eemb_collect/2")),
+    % embed an integration test that runs the user predicate
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/pemb_test.rs', TestPath),
+    % NOTE on result reading: this predicate''s result var L is *permanent* (it
+    % is the head arg and survives the eemb_ready call), so the aggregate binds
+    % it in a Y register. This WAM copies registers by value rather than
+    % aliasing, so a permanent result is not surfaced back through A1/bindings
+    % (the same is true of the sequential begin/end aggregate — not specific to
+    % par_aggregate). The collected list therefore lives in a register; the test
+    % finds it among the registers. The point is parallel result == the known
+    % sequential answer.
+    TestSrc = '
+use pemb::value::Value;
+use pemb::state::WamState;
+use pemb::eemb_collect_1;
+
+fn ints(v: &Value) -> Vec<i64> {
+    match v { Value::List(xs) => xs.iter().filter_map(|e| match e {
+        Value::Integer(n) => Some(*n), _ => None }).collect(), _ => vec![] }
+}
+
+#[test]
+fn user_embedded_findall_parallel() {
+    let mut vm = WamState::new(vec![], std::collections::HashMap::new());
+    assert!(eemb_collect_1(&mut vm, Value::Unbound("L".to_string())), "eemb_collect should succeed");
+    let res = vm.regs.iter().find(|v| matches!(v, Value::List(xs) if xs.len() == 6)).cloned();
+    match res {
+        Some(Value::List(items)) => {
+            assert_eq!(items.len(), 6, "one list per fact");
+            assert_eq!(ints(&items[0]), vec![1], "first = [1]");
+            assert_eq!(ints(items.last().unwrap()), vec![6,5,4,3,2,1], "last = [6..1]");
+        }
+        _ => panic!("expected 6-element result list in registers, regs={:?}", vm.regs),
+    }
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    format(atom(Cmd), 'cd "~w" && cargo test --test pemb_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[embedded exec FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_par_aggregate_embedded_exec).


### PR DESCRIPTION
## Summary

Completes **"the one substantial T7 item left"** (per `docs/reports/wam_rust_t7_NEXT.md`): parallelizing aggregates **embedded in a larger clause body**, not just whole-body aggregates. The route-1 native-wrapper trick can't handle these because the aggregate must run *mid-clause inside the WAM*, so this adds the planned `par_aggregate` WAM-instruction route.

## How it works

- **Runtime** (`par_aggregate.rs.mustache`): `par_collect_labels` — a label/PC-based sibling of `par_collect`. Clones the live interpreter machine, **clears the container clause's choice points** to isolate enumeration, drives `__par_enum` by entry-PC label (`run()`/`backtrack()` loop) to gather inputs, then parallel-maps `__par_body` per input over the same `thread::scope` fan-out as route 1.
- **Instruction** (`instructions.rs.mustache` + arm in `wam_rust_target.pl`): `ParAggregate(agg_type, enum_label, body_label, result_reg)`. The handler reduces collected values by agg type — mirroring the sequential `aggregate_frame` finalization (`collect`/`count`/`sum`/`max`/`min`) — binds `result_reg` in place, advances `pc += 1`, leaves no choice point.
- **WAM-line parser**: a `par_aggregate` text line → that instruction.
- **Compile-time** (`wam_rust_target.pl`): `rust_inject_embedded_par_aggregates` detects a single-clause predicate whose body *contains* (but isn't) a forkable aggregate the cost gate sends parallel; synthesises the same `__par_enum`/`__par_body` helpers as route 1 (added to the shared table so they get entry labels) and records a rewrite. `collect_wam_entries` then splices a `par_aggregate` line over the predicate's `begin_aggregate..end_aggregate` block.

Gated behind `parallel_aggregates(true)` — **default output unchanged**.

## Validation (this environment: SWI-Prolog 9.0.4, cargo/rustc 1.94)

- **New exec test** `tests/test_wam_rust_par_aggregate_embedded_exec.pl`: a user predicate with a guard goal before an embedded `findall` over a recursive body compiles, builds, runs, and the **parallel result equals the known sequential answer** (6-element list, first `[1]`, last `[6,5,4,3,2,1]`). **PASS.**
- Built and inspected the generated crate: `ParAggregate("collect", "__par_enum_…/1", "__par_body_…/2", "Y1")` spliced into the shared table with valid helper entry labels; `cargo build` clean.
- **No regressions**: `test_wam_rust_target.pl` (174 PASS / 0 FAIL), `test_parallel_gate.pl` (25), and the route-1 whole-body injection exec test all green.

## Note on result surfacing

The embedded result var is *permanent* (it's the head arg and survives the guard call), so the aggregate binds it in a `Y` register. This WAM copies registers by value rather than aliasing, so a permanent result isn't surfaced back through `A1`/`bindings` — **this is pre-existing and identical for the sequential `begin/end` aggregate**, not introduced by `par_aggregate` (the test reads the result from the registers). Improving permanent-var output surfacing is a separate WAM concern, out of scope here.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_