### PR TITLE
Add parent-distance exact sparse sweep

### DIFF
--- a/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
+++ b/docs/design/DISTRIBUTIONAL_FIT_POLICY.md
@@ -559,6 +559,16 @@ overhead, but the state model still estimates break-even near one cache hit.
 This supports carrying exact sparse histograms deeper on SimpleWiki before
 trying binomial, Gamma, or sampled approximations.
 
+`docs/reports/lmdb_exact_sparse_depth_sweep_simplewiki_articles_exact_sparse_parent_distance_sweep_b10_20_20260614T165557Z.md`
+reruns the same question using `L_max` parent-distance buckets instead of
+child-depth buckets.  For the full SimpleWiki `Category:Articles` root cone in
+this LMDB (`14,680` nodes, max child depth `3`), buckets `L_max=4..6` had no
+candidates.  Buckets `1`, `2`, and `3` again had all sampled rows exact sparse
+under budgets `10` and `20`.  The `L_max=3` bucket matched the earlier deepest
+child-depth result: max path mass `3`, mean effective support `1.447`, and max
+effective support `3`.  This makes `Category:Articles` a useful low-branching
+validation cone, but not a stress case for deep parent-distance histograms.
+
 `PARENT_BRANCHING_DISTRIBUTION_THEORY.md` gives the statistical interpretation:
 small excess parent branching is binomial-like, while larger parent branching is
 better treated as a compound/convolution model before fitting a closed form.

--- a/docs/reports/lmdb_exact_sparse_depth_sweep_simplewiki_articles_exact_sparse_parent_distance_sweep_b10_20_20260614T165557Z.json
+++ b/docs/reports/lmdb_exact_sparse_depth_sweep_simplewiki_articles_exact_sparse_parent_distance_sweep_b10_20_20260614T165557Z.json
@@ -1,0 +1,2913 @@
+{
+  "buckets": [
+    {
+      "budget": 10,
+      "cycle_approximation_rows": 0,
+      "dfs_capped_rows": 0,
+      "exact_match_rows": 50,
+      "exact_sparse_under_point_cap_rows": 50,
+      "max_effective_support_bins": 1,
+      "max_path_count": 1,
+      "max_support_bins": 1,
+      "mean_child_sample_depth": 1.0,
+      "mean_dfs_nodes_expanded": 5.18,
+      "mean_effective_support_bins": 1.0,
+      "mean_exact_histogram_bytes": 288.0,
+      "mean_hits_to_break_even_states": 1.0,
+      "mean_path_count": 1.0,
+      "mean_recurrence_states_evaluated": 4.18,
+      "mean_state_expansion_ratio": 0.7848008658008658,
+      "mean_support_bins": 1.0,
+      "mean_target_L_max": 1.0,
+      "mean_target_L_min": 1.0,
+      "mean_time_ratio": 1.6251233699480074,
+      "p95_effective_support_bins": 1.0,
+      "p95_hits_to_break_even_states": 1.0,
+      "p95_path_count": 1.0,
+      "p95_support_bins": 1.0,
+      "pct_effective_bins_le_point_cap": 100.0,
+      "point_cap": 50,
+      "reachable_rows": 50,
+      "record_type": "exact_sparse_depth_sweep_summary_bucket",
+      "recurrence_capped_rows": 0,
+      "rows": 50,
+      "selection_bucket": 1
+    },
+    {
+      "budget": 20,
+      "cycle_approximation_rows": 0,
+      "dfs_capped_rows": 0,
+      "exact_match_rows": 50,
+      "exact_sparse_under_point_cap_rows": 50,
+      "max_effective_support_bins": 1,
+      "max_path_count": 1,
+      "max_support_bins": 1,
+      "mean_child_sample_depth": 1.0,
+      "mean_dfs_nodes_expanded": 5.18,
+      "mean_effective_support_bins": 1.0,
+      "mean_exact_histogram_bytes": 288.0,
+      "mean_hits_to_break_even_states": 1.0,
+      "mean_path_count": 1.0,
+      "mean_recurrence_states_evaluated": 4.18,
+      "mean_state_expansion_ratio": 0.7848008658008658,
+      "mean_support_bins": 1.0,
+      "mean_target_L_max": 1.0,
+      "mean_target_L_min": 1.0,
+      "mean_time_ratio": 1.5139738064560484,
+      "p95_effective_support_bins": 1.0,
+      "p95_hits_to_break_even_states": 1.0,
+      "p95_path_count": 1.0,
+      "p95_support_bins": 1.0,
+      "pct_effective_bins_le_point_cap": 100.0,
+      "point_cap": 50,
+      "reachable_rows": 50,
+      "record_type": "exact_sparse_depth_sweep_summary_bucket",
+      "recurrence_capped_rows": 0,
+      "rows": 50,
+      "selection_bucket": 1
+    },
+    {
+      "budget": 10,
+      "cycle_approximation_rows": 0,
+      "dfs_capped_rows": 0,
+      "exact_match_rows": 50,
+      "exact_sparse_under_point_cap_rows": 50,
+      "max_effective_support_bins": 2,
+      "max_path_count": 3,
+      "max_support_bins": 2,
+      "mean_child_sample_depth": 1.68,
+      "mean_dfs_nodes_expanded": 10.54,
+      "mean_effective_support_bins": 1.32,
+      "mean_exact_histogram_bytes": 305.92,
+      "mean_hits_to_break_even_states": 0.9954999999999999,
+      "mean_path_count": 1.36,
+      "mean_recurrence_states_evaluated": 9.18,
+      "mean_state_expansion_ratio": 0.8652753635253636,
+      "mean_support_bins": 1.32,
+      "mean_target_L_max": 2.0,
+      "mean_target_L_min": 1.68,
+      "mean_time_ratio": 1.7786837720491622,
+      "p95_effective_support_bins": 2.0,
+      "p95_hits_to_break_even_states": 1.0,
+      "p95_path_count": 2.0,
+      "p95_support_bins": 2.0,
+      "pct_effective_bins_le_point_cap": 100.0,
+      "point_cap": 50,
+      "reachable_rows": 50,
+      "record_type": "exact_sparse_depth_sweep_summary_bucket",
+      "recurrence_capped_rows": 0,
+      "rows": 50,
+      "selection_bucket": 2
+    },
+    {
+      "budget": 20,
+      "cycle_approximation_rows": 0,
+      "dfs_capped_rows": 0,
+      "exact_match_rows": 50,
+      "exact_sparse_under_point_cap_rows": 50,
+      "max_effective_support_bins": 2,
+      "max_path_count": 3,
+      "max_support_bins": 2,
+      "mean_child_sample_depth": 1.68,
+      "mean_dfs_nodes_expanded": 10.54,
+      "mean_effective_support_bins": 1.32,
+      "mean_exact_histogram_bytes": 305.92,
+      "mean_hits_to_break_even_states": 0.9954999999999999,
+      "mean_path_count": 1.36,
+      "mean_recurrence_states_evaluated": 9.18,
+      "mean_state_expansion_ratio": 0.8652753635253636,
+      "mean_support_bins": 1.32,
+      "mean_target_L_max": 2.0,
+      "mean_target_L_min": 1.68,
+      "mean_time_ratio": 2.3510611179952376,
+      "p95_effective_support_bins": 2.0,
+      "p95_hits_to_break_even_states": 1.0,
+      "p95_path_count": 2.0,
+      "p95_support_bins": 2.0,
+      "pct_effective_bins_le_point_cap": 100.0,
+      "point_cap": 50,
+      "reachable_rows": 50,
+      "record_type": "exact_sparse_depth_sweep_summary_bucket",
+      "recurrence_capped_rows": 0,
+      "rows": 50,
+      "selection_bucket": 2
+    },
+    {
+      "budget": 10,
+      "cycle_approximation_rows": 0,
+      "dfs_capped_rows": 0,
+      "exact_match_rows": 47,
+      "exact_sparse_under_point_cap_rows": 47,
+      "max_effective_support_bins": 3,
+      "max_path_count": 3,
+      "max_support_bins": 3,
+      "mean_child_sample_depth": 2.5531914893617023,
+      "mean_dfs_nodes_expanded": 12.46808510638298,
+      "mean_effective_support_bins": 1.446808510638298,
+      "mean_exact_histogram_bytes": 303.48936170212767,
+      "mean_hits_to_break_even_states": 1.021629219063512,
+      "mean_path_count": 1.2765957446808511,
+      "mean_recurrence_states_evaluated": 11.170212765957446,
+      "mean_state_expansion_ratio": 0.8905826676671811,
+      "mean_support_bins": 1.2765957446808511,
+      "mean_target_L_max": 3.0,
+      "mean_target_L_min": 2.5531914893617023,
+      "mean_time_ratio": 1.8600645751651164,
+      "p95_effective_support_bins": 3.0,
+      "p95_hits_to_break_even_states": 1.1428571428571428,
+      "p95_path_count": 2.0,
+      "p95_support_bins": 2.0,
+      "pct_effective_bins_le_point_cap": 100.0,
+      "point_cap": 50,
+      "reachable_rows": 47,
+      "record_type": "exact_sparse_depth_sweep_summary_bucket",
+      "recurrence_capped_rows": 0,
+      "rows": 47,
+      "selection_bucket": 3
+    },
+    {
+      "budget": 20,
+      "cycle_approximation_rows": 0,
+      "dfs_capped_rows": 0,
+      "exact_match_rows": 47,
+      "exact_sparse_under_point_cap_rows": 47,
+      "max_effective_support_bins": 3,
+      "max_path_count": 3,
+      "max_support_bins": 3,
+      "mean_child_sample_depth": 2.5531914893617023,
+      "mean_dfs_nodes_expanded": 12.46808510638298,
+      "mean_effective_support_bins": 1.446808510638298,
+      "mean_exact_histogram_bytes": 303.48936170212767,
+      "mean_hits_to_break_even_states": 1.021629219063512,
+      "mean_path_count": 1.2765957446808511,
+      "mean_recurrence_states_evaluated": 11.170212765957446,
+      "mean_state_expansion_ratio": 0.8905826676671811,
+      "mean_support_bins": 1.2765957446808511,
+      "mean_target_L_max": 3.0,
+      "mean_target_L_min": 2.5531914893617023,
+      "mean_time_ratio": 2.2911884851485955,
+      "p95_effective_support_bins": 3.0,
+      "p95_hits_to_break_even_states": 1.1428571428571428,
+      "p95_path_count": 2.0,
+      "p95_support_bins": 2.0,
+      "pct_effective_bins_le_point_cap": 100.0,
+      "point_cap": 50,
+      "reachable_rows": 47,
+      "record_type": "exact_sparse_depth_sweep_summary_bucket",
+      "recurrence_capped_rows": 0,
+      "rows": 47,
+      "selection_bucket": 3
+    }
+  ],
+  "generated_at": "2026-06-14T16:55:57.639449+00:00",
+  "graph": "simplewiki_articles_exact_sparse_parent_distance_sweep_b10_20",
+  "point_cap": 50,
+  "record_type": "exact_sparse_depth_sweep_summary",
+  "root": 2,
+  "selection": {
+    "budgets": [
+      10,
+      20
+    ],
+    "children_per_node": 50000,
+    "expansion_cap": 250000,
+    "filtered_targets": [],
+    "frontier_limit": 50000,
+    "graph": "simplewiki_articles_exact_sparse_parent_distance_sweep_b10_20",
+    "max_parent_depth": 48,
+    "parent_distance_buckets": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "path_cap": 100000,
+    "record_type": "exact_sparse_depth_sweep_selection",
+    "root": 2,
+    "root_cone_max_child_depth": 0,
+    "root_cone_max_nodes": 50000,
+    "root_reachable_targets": [
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 851
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 974
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 1307
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 1550
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 1748
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 2191
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 2345
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 2390
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 2775
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 3315
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 3327
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 3374
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 4084
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 4773
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 5214
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 5487
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 5752
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 6152
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 7384
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 7551
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 9740
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 10579
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 10735
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 12494
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 14626
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 14837
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 15668
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 16924
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 17266
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 17776
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 18483
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 20334
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 20414
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 21851
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 21999
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 26631
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 28689
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 35735
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 41089
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 44179
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 49458
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 50117
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 68736
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 80919
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 82120
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 88134
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 93204
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 95079
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 97768
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 104021
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 1155
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 1909
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 1993
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 2403
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 3147
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 3439
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 4636
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 5253
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 5613
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 8814
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 9624
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 10967
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 18939
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 49933
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 57481
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 111225
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 13796
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 14203
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 26061
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 37849
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 38044
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 38058
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 48994
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 52190
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 54842
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 56882
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 60542
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 61263
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 65275
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 67735
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 79396
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 84074
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 84405
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 84448
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 84711
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 86230
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 86330
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 86332
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 91588
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 101070
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 106567
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 112668
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 119097
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 123388
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 124043
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 124278
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 124859
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 127628
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 130345
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 133769
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 2251
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 3515
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 8011
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 8441
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 8866
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 24382
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 28966
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 35665
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 102873
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 116317
+      },
+      {
+        "L_max": 3,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 40399
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 14201
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 18211
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 22312
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 37954
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 38325
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 38340
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 40160
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 58899
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 59803
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 61857
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 65403
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 69587
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 69649
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 69651
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 69667
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 70247
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 85400
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 85924
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 93725
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 101379
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 101886
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 101973
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 105998
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 106061
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 106178
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 106394
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 107743
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 108670
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 108682
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 111643
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 112004
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 112005
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 112490
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 117235
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 123192
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 129704
+      }
+    ],
+    "selected_targets": [
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 851
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 974
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 1307
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 1550
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 1748
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 2191
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 2345
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 2390
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 2775
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 3315
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 3327
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 3374
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 4084
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 4773
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 5214
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 5487
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 5752
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 6152
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 7384
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 7551
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 9740
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 10579
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 10735
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 12494
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 14626
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 14837
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 15668
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 16924
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 17266
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 17776
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 18483
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 20334
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 20414
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 21851
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 21999
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 26631
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 28689
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 35735
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 41089
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 44179
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 49458
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 50117
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 68736
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 80919
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 82120
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 88134
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 93204
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 95079
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 97768
+      },
+      {
+        "L_max": 1,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 1,
+        "target_node": 104021
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 1155
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 1909
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 1993
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 2403
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 3147
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 3439
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 4636
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 5253
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 5613
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 8814
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 9624
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 10967
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 18939
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 49933
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 57481
+      },
+      {
+        "L_max": 2,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 111225
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 13796
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 14203
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 26061
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 37849
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 38044
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 38058
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 48994
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 52190
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 54842
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 56882
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 60542
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 61263
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 65275
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 67735
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 79396
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 84074
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 84405
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 84448
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 84711
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 86230
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 86330
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 86332
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 91588
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 101070
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 106567
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 112668
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 119097
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 123388
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 124043
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 124278
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 124859
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 127628
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 130345
+      },
+      {
+        "L_max": 2,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 2,
+        "target_node": 133769
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 2251
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 3515
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 8011
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 8441
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 8866
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 24382
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 28966
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 35665
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 102873
+      },
+      {
+        "L_max": 3,
+        "L_min": 1,
+        "child_sample_depth": 1,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 116317
+      },
+      {
+        "L_max": 3,
+        "L_min": 2,
+        "child_sample_depth": 2,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 40399
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 14201
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 18211
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 22312
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 37954
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 38325
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 38340
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 40160
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 58899
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 59803
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 61857
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 65403
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 69587
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 69649
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 69651
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 69667
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 70247
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 85400
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 85924
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 93725
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 101379
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 101886
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 101973
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 105998
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 106061
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 106178
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 106394
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 107743
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 108670
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 108682
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 111643
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 112004
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 112005
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 112490
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 117235
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 123192
+      },
+      {
+        "L_max": 3,
+        "L_min": 3,
+        "child_sample_depth": 3,
+        "distance_cycle_skipped": false,
+        "distance_truncated": false,
+        "selection_bucket": 3,
+        "target_node": 129704
+      }
+    ],
+    "selection_counts": {
+      "1": 13529,
+      "2": 1103,
+      "3": 47,
+      "4": 0,
+      "5": 0,
+      "6": 0,
+      "root_cone_child_edges_examined": 14887,
+      "root_cone_max_observed_child_depth": 3,
+      "root_cone_nodes": 14680,
+      "root_cone_truncated_by_depth": false,
+      "root_cone_truncated_by_nodes": false
+    },
+    "target_buckets": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "target_depths": [
+      1,
+      2,
+      3,
+      4
+    ],
+    "target_selection": "parent-distance",
+    "targets_per_depth": 50
+  },
+  "tail_epsilon": 0.01,
+  "target_selection": "parent-distance"
+}

--- a/docs/reports/lmdb_exact_sparse_depth_sweep_simplewiki_articles_exact_sparse_parent_distance_sweep_b10_20_20260614T165557Z.md
+++ b/docs/reports/lmdb_exact_sparse_depth_sweep_simplewiki_articles_exact_sparse_parent_distance_sweep_b10_20_20260614T165557Z.md
@@ -1,0 +1,43 @@
+# LMDB Exact Sparse Depth Sweep
+
+Graph: `simplewiki_articles_exact_sparse_parent_distance_sweep_b10_20`
+
+Root: `2`
+
+Point cap: `50`
+
+Tail epsilon: `0.01`
+
+Target selection: `parent-distance`
+
+## Selection
+
+| L_max_bucket | candidate_nodes | selected_targets | root_reachable_targets | filtered_targets |
+|------------:|-----------------------:|-----------------:|-----------------------:|-----------------:|
+| 1 | 13529 | 50 | 50 | 0 |
+| 2 | 1103 | 50 | 50 | 0 |
+| 3 | 47 | 47 | 47 | 0 |
+| 4 | 0 | 0 | 0 | 0 |
+| 5 | 0 | 0 | 0 | 0 |
+| 6 | 0 | 0 | 0 | 0 |
+
+| root_cone_nodes | max_observed_child_depth | child_edges_examined | truncated_by_depth | truncated_by_nodes |
+|----------------:|-------------------------:|---------------------:|--------------------|--------------------|
+| 14680 | 3 | 14887 | no | no |
+
+## Depth And Budget Buckets
+
+| L_max_bucket | budget | rows | exact_sparse | exact_matches | mean_child_depth | mean_L_min | mean_L_max | mean_paths | max_paths | mean_eff_bins | max_eff_bins | pct_eff_bins_le_cap | mean_dfs_nodes | mean_rec_states | mean_state_ratio | mean_time_ratio | mean_break_even_hits |
+|------------:|-------:|-----:|-------------:|--------------:|-----------------:|-----------:|-----------:|-----------:|----------:|--------------:|-------------:|--------------------:|---------------:|----------------:|-----------------:|----------------:|---------------------:|
+| 1 | 10 | 50 | 50 | 50 | 1.000 | 1.000 | 1.000 | 1.000 | 1 | 1.000 | 1 | 100.000 | 5.180 | 4.180 | 0.785 | 1.625 | 1.000 |
+| 1 | 20 | 50 | 50 | 50 | 1.000 | 1.000 | 1.000 | 1.000 | 1 | 1.000 | 1 | 100.000 | 5.180 | 4.180 | 0.785 | 1.514 | 1.000 |
+| 2 | 10 | 50 | 50 | 50 | 1.680 | 1.680 | 2.000 | 1.360 | 3 | 1.320 | 2 | 100.000 | 10.540 | 9.180 | 0.865 | 1.779 | 0.995 |
+| 2 | 20 | 50 | 50 | 50 | 1.680 | 1.680 | 2.000 | 1.360 | 3 | 1.320 | 2 | 100.000 | 10.540 | 9.180 | 0.865 | 2.351 | 0.995 |
+| 3 | 10 | 47 | 47 | 47 | 2.553 | 2.553 | 3.000 | 1.277 | 3 | 1.447 | 3 | 100.000 | 12.468 | 11.170 | 0.891 | 1.860 | 1.022 |
+| 3 | 20 | 47 | 47 | 47 | 2.553 | 2.553 | 3.000 | 1.277 | 3 | 1.447 | 3 | 100.000 | 12.468 | 11.170 | 0.891 | 2.291 | 1.022 |
+
+## Interpretation
+
+- `exact_sparse` counts reachable, uncapped rows where recurrence matched DFS, no cycle approximation was needed, and the effective support stayed under the point cap.
+- `mean_break_even_hits` is state based: recurrence build states divided by saved states per cached hit, using effective bins as the cached evaluation cost.  It is a planning estimate, not a wall-clock guarantee.
+- If mean effective bins stay far below the point cap, the cap is not the paid storage cost; exact sparse histograms remain the first representation to consider.

--- a/scripts/lmdb_exact_sparse_depth_sweep.py
+++ b/scripts/lmdb_exact_sparse_depth_sweep.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # Copyright (c) 2026 John William Creighton (s243a)
-"""Sweep exact sparse parent histograms by child depth on an LMDB graph.
+"""Sweep exact sparse parent histograms by depth bucket on an LMDB graph.
 
 This probe answers a narrower question than the boundary-cache benchmarks:
-given root-reachable targets at increasing child-depths, how expensive is it to
-keep the parent-path histogram exact and sparse?
+given root-reachable targets at increasing depth buckets, how expensive is it
+to keep the parent-path histogram exact and sparse?
 
 For each sampled target and path-length budget it compares:
 
@@ -16,7 +16,8 @@ For each sampled target and path-length budget it compares:
 The summary treats a point cap such as 50 as an upper bound, not a cost paid by
 every histogram.  The observed support, tail-pruned support, path mass, DFS
 expansions, recurrence states, and state-based break-even hits are reported by
-target child-depth and path-length budget.
+target bucket and path-length budget.  The bucket can be either child-depth
+from the chosen root or maximum parent-path distance `L_max` back to that root.
 """
 
 from __future__ import annotations
@@ -42,6 +43,7 @@ from scripts.distribution_fit_comparison import (  # noqa: E402
 )
 from scripts.lmdb_parent_branching_diagnostic import (  # noqa: E402
     LmdbCategoryGraph,
+    deterministic_sample,
     parse_int_list,
     root_distances,
     select_targets_by_child_depth,
@@ -55,6 +57,7 @@ from scripts.parent_histogram_recurrence import recurrence_parent_histogram  # n
 
 
 DEFAULT_TARGET_DEPTHS = "1,2,3,4"
+DEFAULT_PARENT_DISTANCE_BUCKETS = "1,2,3,4,5,6"
 DEFAULT_BUDGETS = "10,20"
 
 
@@ -111,7 +114,31 @@ def break_even_hits(build_states, uncached_states, eval_bins):
     return float(build_states or 0) / saved_states
 
 
-def select_root_reachable_targets(graph, root, target_depths, args):
+def child_depth_target_row(target, child_depth, distances):
+    return {
+        "target_node": target,
+        "child_sample_depth": child_depth,
+        "selection_bucket": child_depth,
+        "L_min": distances["L_min"],
+        "L_max": distances["L_max"],
+        "distance_truncated": distances["truncated"],
+        "distance_cycle_skipped": distances["cycle_skipped"],
+    }
+
+
+def deterministic_sample_rows(rows, limit, seed):
+    rows = list(rows)
+    if limit is None or len(rows) <= limit:
+        return rows
+    sampled_nodes = set(deterministic_sample(
+        [row["target_node"] for row in rows],
+        limit,
+        seed,
+    ))
+    return [row for row in rows if row["target_node"] in sampled_nodes]
+
+
+def select_root_reachable_child_depth_targets(graph, root, target_depths, args):
     targets, child_depth_by_node, selection_counts = select_targets_by_child_depth(
         graph,
         root,
@@ -126,18 +153,92 @@ def select_root_reachable_targets(graph, root, target_depths, args):
     filtered = []
     for target in targets:
         distances = root_distances(target, root, graph.parents, args.max_parent_depth, distance_memo)
-        row = {
-            "target_node": target,
-            "child_sample_depth": child_depth_by_node[target],
-            "L_min": distances["L_min"],
-            "L_max": distances["L_max"],
-            "distance_truncated": distances["truncated"],
-            "distance_cycle_skipped": distances["cycle_skipped"],
-        }
+        row = child_depth_target_row(target, child_depth_by_node[target], distances)
         if distances["L_min"] is not None and not distances["truncated"]:
             kept.append(row)
         else:
             filtered.append(row)
+    return kept, filtered, selection_counts
+
+
+def collect_child_cone(graph, root, args):
+    """Collect descendants of root for parent-distance sampling."""
+    max_child_depth = int(args.root_cone_max_child_depth or 0)
+    max_nodes = int(args.root_cone_max_nodes or 0)
+    depth_by_node = {root: 0}
+    frontier = [root]
+    truncated_by_depth = False
+    truncated_by_nodes = False
+    child_edges_examined = 0
+    depth = 0
+    while frontier:
+        if max_child_depth > 0 and depth >= max_child_depth:
+            truncated_by_depth = True
+            break
+        next_nodes = []
+        for node in frontier:
+            children = deterministic_sample(
+                graph.children(node),
+                args.children_per_node,
+                "{}:root-cone:children:{}:{}".format(args.seed, depth + 1, node),
+            )
+            child_edges_examined += len(children)
+            next_nodes.extend(children)
+        next_nodes = deterministic_sample(
+            list(dict.fromkeys(next_nodes)),
+            args.frontier_limit,
+            "{}:root-cone:frontier:{}".format(args.seed, depth + 1),
+        )
+        frontier = []
+        for node in next_nodes:
+            if node in depth_by_node:
+                continue
+            if max_nodes > 0 and len(depth_by_node) >= max_nodes:
+                truncated_by_nodes = True
+                continue
+            depth_by_node[node] = depth + 1
+            frontier.append(node)
+        depth += 1
+    return {
+        "depth_by_node": depth_by_node,
+        "child_edges_examined": child_edges_examined,
+        "truncated_by_depth": truncated_by_depth,
+        "truncated_by_nodes": truncated_by_nodes,
+    }
+
+
+def select_root_reachable_parent_distance_targets(graph, root, buckets, args):
+    wanted = set(int(bucket) for bucket in buckets)
+    collection = collect_child_cone(graph, root, args)
+    depth_by_node = collection["depth_by_node"]
+    distance_memo = {}
+    candidates_by_bucket = {bucket: [] for bucket in sorted(wanted)}
+    filtered = []
+    for node, child_depth in sorted(depth_by_node.items(), key=lambda item: (item[1], item[0])):
+        distances = root_distances(node, root, graph.parents, args.max_parent_depth, distance_memo)
+        row = child_depth_target_row(node, child_depth, distances)
+        row["selection_bucket"] = distances["L_max"]
+        if distances["L_min"] is None or distances["truncated"]:
+            filtered.append(row)
+            continue
+        bucket = int(distances["L_max"])
+        if bucket in wanted:
+            candidates_by_bucket.setdefault(bucket, []).append(row)
+    kept = []
+    for bucket in sorted(wanted):
+        kept.extend(deterministic_sample_rows(
+            candidates_by_bucket.get(bucket, []),
+            args.targets_per_depth,
+            "{}:parent-distance-targets:{}".format(args.seed, bucket),
+        ))
+    selection_counts = {str(bucket): len(candidates_by_bucket.get(bucket, [])) for bucket in sorted(wanted)}
+    selection_counts.update({
+        "root_cone_nodes": len(depth_by_node),
+        "root_cone_max_observed_child_depth": max(depth_by_node.values()) if depth_by_node else None,
+        "root_cone_child_edges_examined": collection["child_edges_examined"],
+        "root_cone_truncated_by_depth": collection["truncated_by_depth"],
+        "root_cone_truncated_by_nodes": collection["truncated_by_nodes"],
+    })
     return kept, filtered, selection_counts
 
 
@@ -153,6 +254,7 @@ def comparison_record(args, target_row, budget, dfs_hist, dfs_stats, dfs_time_ns
         "root": args.root,
         "target_node": target_row["target_node"],
         "child_sample_depth": target_row["child_sample_depth"],
+        "selection_bucket": target_row["selection_bucket"],
         "budget": int(budget),
         "target_L_min": target_row["L_min"],
         "target_L_max": target_row["L_max"],
@@ -198,7 +300,7 @@ def comparison_record(args, target_row, budget, dfs_hist, dfs_stats, dfs_time_ns
 
 
 def summary_row(key, rows, point_cap):
-    depth, budget = key
+    bucket, budget = key
     reachable = [row for row in rows if row["reachable"]]
     exact_sparse = [
         row for row in reachable
@@ -216,7 +318,7 @@ def summary_row(key, rows, point_cap):
     ]
     return {
         "record_type": "exact_sparse_depth_sweep_summary_bucket",
-        "child_sample_depth": depth,
+        "selection_bucket": bucket,
         "budget": budget,
         "rows": len(rows),
         "reachable_rows": len(reachable),
@@ -243,6 +345,9 @@ def summary_row(key, rows, point_cap):
         "mean_time_ratio": mean(row["time_ratio"] for row in reachable),
         "mean_hits_to_break_even_states": mean(break_even),
         "p95_hits_to_break_even_states": percentile(break_even, 95),
+        "mean_child_sample_depth": mean(row["child_sample_depth"] for row in reachable),
+        "mean_target_L_min": mean(row["target_L_min"] for row in reachable),
+        "mean_target_L_max": mean(row["target_L_max"] for row in reachable),
     }
 
 
@@ -250,7 +355,7 @@ def build_summary(records, args):
     rows = [row for row in records if row.get("record_type") == "exact_sparse_depth_sweep_row"]
     by_key = {}
     for row in rows:
-        by_key.setdefault((row["child_sample_depth"], row["budget"]), []).append(row)
+        by_key.setdefault((row["selection_bucket"], row["budget"]), []).append(row)
     buckets = [summary_row(key, by_key[key], args.point_cap) for key in sorted(by_key)]
     selection = next(row for row in records if row.get("record_type") == "exact_sparse_depth_sweep_selection")
     return {
@@ -258,6 +363,7 @@ def build_summary(records, args):
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "graph": args.graph_name,
         "root": args.root,
+        "target_selection": args.target_selection,
         "point_cap": args.point_cap,
         "tail_epsilon": args.tail_epsilon,
         "selection": selection,
@@ -267,6 +373,7 @@ def build_summary(records, args):
 
 def markdown_summary(summary):
     selection = summary["selection"]
+    bucket_label = "child_depth" if summary.get("target_selection") == "child-depth" else "L_max_bucket"
     lines = [
         "# LMDB Exact Sparse Depth Sweep",
         "",
@@ -278,38 +385,59 @@ def markdown_summary(summary):
         "",
         "Tail epsilon: `{}`".format(summary["tail_epsilon"]),
         "",
+        "Target selection: `{}`".format(summary.get("target_selection", "child-depth")),
+        "",
         "## Selection",
         "",
-        "| child_depth | sampled_frontier_nodes | selected_targets | root_reachable_targets | filtered_targets |",
+        "| {} | candidate_nodes | selected_targets | root_reachable_targets | filtered_targets |".format(bucket_label),
         "|------------:|-----------------------:|-----------------:|-----------------------:|-----------------:|",
     ]
-    selected_by_depth = Counter(row["child_sample_depth"] for row in selection["selected_targets"])
-    kept_by_depth = Counter(row["child_sample_depth"] for row in selection["root_reachable_targets"])
-    filtered_by_depth = Counter(row["child_sample_depth"] for row in selection["filtered_targets"])
-    for depth in sorted(set(selection["selection_counts"]) | set(selected_by_depth) | set(kept_by_depth) | set(filtered_by_depth), key=int):
-        depth_int = int(depth)
-        lines.append("| {depth} | {frontier} | {selected} | {kept} | {filtered} |".format(
-            depth=depth_int,
-            frontier=selection["selection_counts"].get(str(depth), selection["selection_counts"].get(depth, 0)),
-            selected=selected_by_depth.get(depth_int, 0),
-            kept=kept_by_depth.get(depth_int, 0),
-            filtered=filtered_by_depth.get(depth_int, 0),
+    selected_by_bucket = Counter(row["selection_bucket"] for row in selection["selected_targets"] if row["selection_bucket"] is not None)
+    kept_by_bucket = Counter(row["selection_bucket"] for row in selection["root_reachable_targets"] if row["selection_bucket"] is not None)
+    filtered_by_bucket = Counter(row["selection_bucket"] for row in selection["filtered_targets"] if row["selection_bucket"] is not None)
+    numeric_count_keys = [
+        key for key in selection["selection_counts"]
+        if isinstance(key, int) or (isinstance(key, str) and key.lstrip("-").isdigit())
+    ]
+    for bucket in sorted(set(int(key) for key in numeric_count_keys) | set(selected_by_bucket) | set(kept_by_bucket) | set(filtered_by_bucket)):
+        lines.append("| {bucket} | {frontier} | {selected} | {kept} | {filtered} |".format(
+            bucket=bucket,
+            frontier=selection["selection_counts"].get(str(bucket), selection["selection_counts"].get(bucket, 0)),
+            selected=selected_by_bucket.get(bucket, 0),
+            kept=kept_by_bucket.get(bucket, 0),
+            filtered=filtered_by_bucket.get(bucket, 0),
         ))
+    if summary.get("target_selection") == "parent-distance":
+        lines.extend([
+            "",
+            "| root_cone_nodes | max_observed_child_depth | child_edges_examined | truncated_by_depth | truncated_by_nodes |",
+            "|----------------:|-------------------------:|---------------------:|--------------------|--------------------|",
+            "| {nodes} | {depth} | {edges} | {depth_trunc} | {node_trunc} |".format(
+                nodes=selection["selection_counts"].get("root_cone_nodes", 0),
+                depth=selection["selection_counts"].get("root_cone_max_observed_child_depth", "n/a"),
+                edges=selection["selection_counts"].get("root_cone_child_edges_examined", 0),
+                depth_trunc="yes" if selection["selection_counts"].get("root_cone_truncated_by_depth") else "no",
+                node_trunc="yes" if selection["selection_counts"].get("root_cone_truncated_by_nodes") else "no",
+            ),
+        ])
     lines.extend([
         "",
         "## Depth And Budget Buckets",
         "",
-        "| child_depth | budget | rows | exact_sparse | exact_matches | mean_paths | max_paths | mean_eff_bins | max_eff_bins | pct_eff_bins_le_cap | mean_dfs_nodes | mean_rec_states | mean_state_ratio | mean_time_ratio | mean_break_even_hits |",
-        "|------------:|-------:|-----:|-------------:|--------------:|-----------:|----------:|--------------:|-------------:|--------------------:|---------------:|----------------:|-----------------:|----------------:|---------------------:|",
+        "| {} | budget | rows | exact_sparse | exact_matches | mean_child_depth | mean_L_min | mean_L_max | mean_paths | max_paths | mean_eff_bins | max_eff_bins | pct_eff_bins_le_cap | mean_dfs_nodes | mean_rec_states | mean_state_ratio | mean_time_ratio | mean_break_even_hits |".format(bucket_label),
+        "|------------:|-------:|-----:|-------------:|--------------:|-----------------:|-----------:|-----------:|-----------:|----------:|--------------:|-------------:|--------------------:|---------------:|----------------:|-----------------:|----------------:|---------------------:|",
     ])
     for row in summary["buckets"]:
         lines.append(
-            "| {depth} | {budget} | {rows} | {exact_sparse} | {exact} | {mean_paths:.3f} | {max_paths} | {mean_bins:.3f} | {max_bins} | {pct_bins:.3f} | {dfs_nodes:.3f} | {rec_states:.3f} | {state_ratio:.3f} | {time_ratio:.3f} | {break_even:.3f} |".format(
-                depth=row["child_sample_depth"],
+            "| {bucket} | {budget} | {rows} | {exact_sparse} | {exact} | {mean_child:.3f} | {mean_lmin:.3f} | {mean_lmax:.3f} | {mean_paths:.3f} | {max_paths} | {mean_bins:.3f} | {max_bins} | {pct_bins:.3f} | {dfs_nodes:.3f} | {rec_states:.3f} | {state_ratio:.3f} | {time_ratio:.3f} | {break_even:.3f} |".format(
+                bucket=row["selection_bucket"],
                 budget=row["budget"],
                 rows=row["rows"],
                 exact_sparse=row["exact_sparse_under_point_cap_rows"],
                 exact=row["exact_match_rows"],
+                mean_child=row["mean_child_sample_depth"],
+                mean_lmin=row["mean_target_L_min"],
+                mean_lmax=row["mean_target_L_max"],
                 mean_paths=row["mean_path_count"],
                 max_paths=row["max_path_count"],
                 mean_bins=row["mean_effective_support_bins"],
@@ -337,18 +465,34 @@ def run_sweep(args):
     graph = LmdbCategoryGraph(args.lmdb_dir)
     try:
         target_depths = parse_int_list(args.target_depths)
+        parent_distance_buckets = parse_int_list(args.parent_distance_buckets)
         budgets = parse_int_list(args.budgets)
-        root_reachable_targets, filtered_targets, selection_counts = select_root_reachable_targets(
-            graph,
-            args.root,
-            target_depths,
-            args,
-        )
+        if args.target_selection == "child-depth":
+            root_reachable_targets, filtered_targets, selection_counts = select_root_reachable_child_depth_targets(
+                graph,
+                args.root,
+                target_depths,
+                args,
+            )
+            target_buckets = target_depths
+        elif args.target_selection == "parent-distance":
+            root_reachable_targets, filtered_targets, selection_counts = select_root_reachable_parent_distance_targets(
+                graph,
+                args.root,
+                parent_distance_buckets,
+                args,
+            )
+            target_buckets = parent_distance_buckets
+        else:
+            raise ValueError("unknown target selection: {}".format(args.target_selection))
         records = [{
             "record_type": "exact_sparse_depth_sweep_selection",
             "graph": args.graph_name,
             "root": args.root,
+            "target_selection": args.target_selection,
             "target_depths": target_depths,
+            "target_buckets": target_buckets,
+            "parent_distance_buckets": parent_distance_buckets,
             "budgets": budgets,
             "selection_counts": selection_counts,
             "selected_targets": root_reachable_targets + filtered_targets,
@@ -358,6 +502,8 @@ def run_sweep(args):
             "frontier_limit": args.frontier_limit,
             "targets_per_depth": args.targets_per_depth,
             "max_parent_depth": args.max_parent_depth,
+            "root_cone_max_child_depth": args.root_cone_max_child_depth,
+            "root_cone_max_nodes": args.root_cone_max_nodes,
             "path_cap": args.path_cap,
             "expansion_cap": args.expansion_cap,
         }]
@@ -422,12 +568,16 @@ def parse_args(argv=None):
     parser.add_argument("--lmdb-dir", type=Path, required=True, help="Numeric-keyed category LMDB directory.")
     parser.add_argument("--root", type=int, required=True, help="Numeric root id.")
     parser.add_argument("--graph-name", default="lmdb_exact_sparse_depth_sweep", help="Graph label used in output filenames.")
+    parser.add_argument("--target-selection", choices=["child-depth", "parent-distance"], default="child-depth", help="Target bucket axis.")
     parser.add_argument("--target-depths", default=DEFAULT_TARGET_DEPTHS, help="Child depths to sample, e.g. `1,2,3,4`.")
+    parser.add_argument("--parent-distance-buckets", default=DEFAULT_PARENT_DISTANCE_BUCKETS, help="L_max parent-distance buckets for `--target-selection parent-distance`.")
     parser.add_argument("--children-per-node", type=int, default=50000, help="Child sample cap per frontier node.")
     parser.add_argument("--frontier-limit", type=int, default=50000, help="Depth frontier sample cap.")
     parser.add_argument("--targets-per-depth", type=int, default=12, help="Targets sampled per requested child depth.")
     parser.add_argument("--budgets", default=DEFAULT_BUDGETS, help="Parent path-length budgets, e.g. `10,20`.")
     parser.add_argument("--max-parent-depth", type=int, default=48, help="Root-reachable filtering horizon.")
+    parser.add_argument("--root-cone-max-child-depth", type=int, default=0, help="Parent-distance mode root-cone child-depth cap; 0 means no depth cap.")
+    parser.add_argument("--root-cone-max-nodes", type=int, default=50000, help="Parent-distance mode root-cone node cap; 0 means no node cap.")
     parser.add_argument("--path-cap", type=int, default=100000, help="Maximum root-reaching paths before capping one row.")
     parser.add_argument("--expansion-cap", type=int, default=250000, help="Maximum DFS/recurrence states before capping one row.")
     parser.add_argument("--point-cap", type=int, default=50, help="Exact sparse support cap used for classification.")
@@ -446,6 +596,10 @@ def parse_args(argv=None):
         raise SystemExit("--targets-per-depth must be positive")
     if args.max_parent_depth <= 0:
         raise SystemExit("--max-parent-depth must be positive")
+    if args.root_cone_max_child_depth < 0:
+        raise SystemExit("--root-cone-max-child-depth must be non-negative")
+    if args.root_cone_max_nodes < 0:
+        raise SystemExit("--root-cone-max-nodes must be non-negative")
     if args.point_cap <= 0:
         raise SystemExit("--point-cap must be positive")
     return args

--- a/tests/test_lmdb_exact_sparse_depth_sweep.py
+++ b/tests/test_lmdb_exact_sparse_depth_sweep.py
@@ -4,13 +4,27 @@
 """Tests for exact sparse depth sweep helpers."""
 
 import unittest
+from types import SimpleNamespace
 
 from scripts.lmdb_exact_sparse_depth_sweep import (
     break_even_hits,
     histogram_metrics,
     markdown_summary,
+    select_root_reachable_parent_distance_targets,
     summary_row,
 )
+
+
+class FakeGraph:
+    def __init__(self, children, parents):
+        self._children = children
+        self._parents = parents
+
+    def children(self, node):
+        return self._children.get(node, [])
+
+    def parents(self, node):
+        return self._parents.get(node, [])
 
 
 class ExactSparseDepthSweepTests(unittest.TestCase):
@@ -26,6 +40,35 @@ class ExactSparseDepthSweepTests(unittest.TestCase):
     def test_break_even_hits_uses_cached_bins_as_eval_cost(self):
         self.assertAlmostEqual(break_even_hits(5, 20, 10), 0.5)
         self.assertIsNone(break_even_hits(5, 10, 10))
+
+    def test_parent_distance_selector_buckets_by_lmax(self):
+        graph = FakeGraph(
+            children={"R": ["A", "B"], "A": ["C"], "B": ["C"]},
+            parents={"A": ["R"], "B": ["R"], "C": ["A", "B"]},
+        )
+        args = SimpleNamespace(
+            children_per_node=99,
+            frontier_limit=99,
+            targets_per_depth=10,
+            seed="fixture",
+            max_parent_depth=8,
+            root_cone_max_child_depth=0,
+            root_cone_max_nodes=0,
+        )
+
+        kept, filtered, counts = select_root_reachable_parent_distance_targets(
+            graph,
+            "R",
+            [1, 2],
+            args,
+        )
+
+        by_node = {row["target_node"]: row for row in kept}
+        self.assertEqual(counts["1"], 2)
+        self.assertEqual(counts["2"], 1)
+        self.assertEqual(by_node["A"]["selection_bucket"], 1)
+        self.assertEqual(by_node["C"]["selection_bucket"], 2)
+        self.assertFalse(filtered)
 
     def test_summary_bucket_classifies_exact_sparse_rows(self):
         row = {
@@ -46,10 +89,14 @@ class ExactSparseDepthSweepTests(unittest.TestCase):
             "state_expansion_ratio": 0.3,
             "time_ratio": 0.4,
             "hits_to_break_even_states": 3 / 9,
+            "child_sample_depth": 2,
+            "target_L_min": 2,
+            "target_L_max": 2,
         }
 
         summary = summary_row((2, 10), [row], 50)
 
+        self.assertEqual(summary["selection_bucket"], 2)
         self.assertEqual(summary["exact_sparse_under_point_cap_rows"], 1)
         self.assertEqual(summary["exact_match_rows"], 1)
         self.assertEqual(summary["max_effective_support_bins"], 1)
@@ -59,21 +106,25 @@ class ExactSparseDepthSweepTests(unittest.TestCase):
         summary = {
             "graph": "fixture",
             "root": 1,
+            "target_selection": "parent-distance",
             "point_cap": 50,
             "tail_epsilon": 0.01,
             "selection": {
-                "selection_counts": {0: 1, 2: 1},
-                "selected_targets": [{"child_sample_depth": 2}],
-                "root_reachable_targets": [{"child_sample_depth": 2}],
+                "selection_counts": {2: 1, "root_cone_nodes": 2},
+                "selected_targets": [{"child_sample_depth": 2, "selection_bucket": 2}],
+                "root_reachable_targets": [{"child_sample_depth": 2, "selection_bucket": 2}],
                 "filtered_targets": [],
             },
             "buckets": [
                 {
-                    "child_sample_depth": 2,
+                    "selection_bucket": 2,
                     "budget": 10,
                     "rows": 1,
                     "exact_sparse_under_point_cap_rows": 1,
                     "exact_match_rows": 1,
+                    "mean_child_sample_depth": 2.0,
+                    "mean_target_L_min": 2.0,
+                    "mean_target_L_max": 2.0,
                     "mean_path_count": 1.0,
                     "max_path_count": 1,
                     "mean_effective_support_bins": 1.0,


### PR DESCRIPTION
## Summary
- Adds `--target-selection parent-distance` to `scripts/lmdb_exact_sparse_depth_sweep.py`.
- Buckets sampled targets by `L_max` parent distance while retaining actual child depth and `L_min/L_max` diagnostics.
- Generates a SimpleWiki `Category:Articles` parent-distance sweep for `L_max=1..6` and budgets 10/20.
- Updates the distribution fit policy with the parent-distance result.

## Report highlights
- Full SimpleWiki `Category:Articles` root cone in this LMDB: 14,680 nodes, max observed child depth 3.
- `L_max=4..6` had zero candidates, so this cone is not a deep parent-distance stress case.
- `L_max=1..3` all stayed exact-sparse: recurrence matched DFS, no cycle approximation, no caps, and effective support stayed under 50.
- `L_max=3` matched the prior deepest result: max path mass 3, mean effective support 1.447, max effective support 3.

## Validation
- `python3 -m unittest tests.test_lmdb_exact_sparse_depth_sweep tests.test_lmdb_parent_recurrence_histogram_benchmark tests.test_lmdb_parent_histogram_benchmark tests.test_lmdb_materialization_regime_report tests.test_lmdb_root_conditioned_branching_profile tests.test_distribution_precompute_depth_estimator`
- `python3 -m py_compile scripts/lmdb_exact_sparse_depth_sweep.py tests/test_lmdb_exact_sparse_depth_sweep.py`
- `git diff --check`