### PR TITLE
fix(wam-rust): surface aggregate results bound to permanent (Y) result registers

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -878,16 +878,20 @@ wam_instruction_arm('Instruction::ParAggregate(agg_type, enum_label, body_label,
                     }
                     _ => Value::List(__vals),
                 };
-                let __lhs = self.get_reg_raw(result_reg).map(|v| self.deref_var(&v));
+                // Bind through the Y-aware accessors (get_reg/put_reg): an
+                // embedded aggregate''s result register is a permanent (Y)
+                // variable in the environment frame, so get_reg_raw/set_reg_str
+                // would miss it. Mirrors the aggregate_frame finalisation.
+                let __lhs = self.get_reg(result_reg);
                 let __ok = match __lhs {
                     Some(Value::Unbound(ref __vn)) => {
                         self.trail_binding(result_reg);
-                        self.set_reg_str(result_reg, __result.clone());
+                        self.put_reg(result_reg, __result.clone());
                         self.bind_var(__vn, __result);
                         true
                     }
                     Some(__existing) => __existing == __result,
-                    None => { self.set_reg_str(result_reg, __result); true }
+                    None => { self.put_reg(result_reg, __result); true }
                 };
                 if __ok { self.pc += 1; }
                 __ok'.
@@ -3062,17 +3066,23 @@ compile_resume_builtin_to_rust(Code) :-
                 };
 
                 self.aggregate_acc.clear();
-                let lhs = self.get_reg_raw(&result_reg).map(|v| self.deref_var(&v));
+                // Bind through the Y-aware accessors. An aggregate embedded in a
+                // larger clause body has a *permanent* (Y) result register, which
+                // lives in the environment frame, not the flat regs array, so
+                // get_reg_raw/set_reg_str would read/write a dead slot (Uninit)
+                // and never surface the result to the clause variable. get_reg/
+                // put_reg handle both temporary (A/X) and permanent (Y) registers.
+                let lhs = self.get_reg(&result_reg);
                 match lhs {
                     Some(Value::Unbound(ref var_name)) => {
                         self.trail_binding(&result_reg);
-                        self.set_reg_str(&result_reg, result.clone());
+                        self.put_reg(&result_reg, result.clone());
                         self.bind_var(var_name, result);
                     }
                     Some(existing) if existing == result => {}
                     Some(_) => return false,
                     None => {
-                        self.set_reg_str(&result_reg, result);
+                        self.put_reg(&result_reg, result);
                     }
                 }
                 self.pc = self.aggregate_return_pc;

--- a/tests/test_wam_rust_par_aggregate_embedded_exec.pl
+++ b/tests/test_wam_rust_par_aggregate_embedded_exec.pl
@@ -50,14 +50,11 @@ test(embedded_findall_compiles_to_par_aggregate_and_runs,
     atom_concat(Dir, '/tests', TestsDir),
     make_directory_path(TestsDir),
     atom_concat(Dir, '/tests/pemb_test.rs', TestPath),
-    % NOTE on result reading: this predicate''s result var L is *permanent* (it
-    % is the head arg and survives the eemb_ready call), so the aggregate binds
-    % it in a Y register. This WAM copies registers by value rather than
-    % aliasing, so a permanent result is not surfaced back through A1/bindings
-    % (the same is true of the sequential begin/end aggregate — not specific to
-    % par_aggregate). The collected list therefore lives in a register; the test
-    % finds it among the registers. The point is parallel result == the known
-    % sequential answer.
+    % The result var L is permanent (head arg surviving the eemb_ready call), so
+    % the aggregate binds it in a Y register. The aggregate finalisation binds
+    % through the Y-aware accessors, so the collected list surfaces to the clause
+    % variable in bindings["L"] — same as a whole-body aggregate. The point of the
+    % test is parallel result == the known sequential answer.
     TestSrc = '
 use pemb::value::Value;
 use pemb::state::WamState;
@@ -72,14 +69,13 @@ fn ints(v: &Value) -> Vec<i64> {
 fn user_embedded_findall_parallel() {
     let mut vm = WamState::new(vec![], std::collections::HashMap::new());
     assert!(eemb_collect_1(&mut vm, Value::Unbound("L".to_string())), "eemb_collect should succeed");
-    let res = vm.regs.iter().find(|v| matches!(v, Value::List(xs) if xs.len() == 6)).cloned();
-    match res {
+    match vm.bindings.get("L").cloned() {
         Some(Value::List(items)) => {
             assert_eq!(items.len(), 6, "one list per fact");
             assert_eq!(ints(&items[0]), vec![1], "first = [1]");
             assert_eq!(ints(items.last().unwrap()), vec![6,5,4,3,2,1], "last = [6..1]");
         }
-        _ => panic!("expected 6-element result list in registers, regs={:?}", vm.regs),
+        other => panic!("expected list in bindings[L], got {:?}", other),
     }
 }',
     setup_call_cleanup(open(TestPath, write, S),


### PR DESCRIPTION
## Summary

Fixes the bug flagged in the T7 route-2 PR (#3160): aggregate results bound to a **permanent (`Y`) result register** never reached the clause variable.

## Root cause

`Y` (permanent) variables are stored in the environment frame (`StackEntry::Env`), written/read by the `Y`-aware `put_reg`/`get_reg`. But the aggregate finalization — both the sequential `aggregate_frame` resume and the T7 route-2 `par_aggregate` handler — bound the result register with `get_reg_raw`/`set_reg_str`, which use `reg_index` into the **flat `regs` array**.

So when an aggregate's result var is permanent — e.g. an aggregate **embedded** in a larger clause body, where the result is the head arg surviving an earlier call — `get_reg_raw("Yn")` read a dead `Uninit` slot, took the `None` branch, and wrote the result to that dead slot, **never running `bind_var`**. The collected value never surfaced to the clause variable (`bindings["L"]` stayed empty; the caller saw the arg unbound).

Whole-body aggregates were unaffected because their result register is temporary (`A`/`X`), which the flat-array accessors handle.

## Fix

Bind through the `Y`-aware accessors `get_reg`/`put_reg` in both the sequential `aggregate_frame` finalization and the `par_aggregate` arm. They delegate to the flat array for `A`/`X` registers (whole-body unchanged) and to the environment frame for `Y` registers, so the result surfaces correctly in both cases.

## Validation

- The embedded exec test (`test_wam_rust_par_aggregate_embedded_exec.pl`) now reads the result from `bindings["L"]` — the proper path — for both the **sequential** and **parallel** builds; both yield the correct list (`[[1],[2,1],…,[6,5,4,3,2,1]]`). Direct before/after probe confirmed: pre-fix `bindings[L]=None`, post-fix `bindings[L]=Some(List([...]))`.
- **No regressions**: `test_wam_rust_target.pl` (174), `test_wam_rust_aggregate_exec.pl` (whole-body count/sum/collect), route-1 whole-body injection exec, `par_aggregate` substrate exec, and `test_wam_rust_embedded_wiring.pl` (5) all green.

Note: this is a fix to the shared aggregate finalization, so it also corrects any whole-body aggregate that happened to land its result in a `Y` register, not just the embedded case.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_