### PR TITLE
Extract WAM LLVM stream driver helper

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -249,7 +249,10 @@ streaming WAM/LLVM driver using `llvm_emit_atom_prefix_guard/5` or
 `llvm_emit_atom_field_eq_guard/7`, and
 `tests/test_plawk_surface_prefix_print.pl` proves that the generated binary
 prints matching records from a text file without calling `run_loop` in the hot
-record loop. The field-equality path scans fields in native code without
+record loop. The reusable file open/read/eof/close skeleton now lives in the
+WAM/LLVM target as `llvm_emit_stream_driver_ir/3`, so PLAWK supplies only the
+surface-specific globals, per-record lowering, continuation phis, and close
+block. The field-equality path scans fields in native code without
 allocating substrings; selected-field printing projects byte slices directly.
 Rule prints can include native `NR`, implemented as a record-number `i64` phi in
 the print-only streaming loop, and native `NF`, implemented with the shared

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -19,6 +19,7 @@
      llvm_emit_printf_string/5,
      llvm_emit_printf_string/6,
      llvm_emit_printf0/5,
+     llvm_emit_stream_driver_ir/3,
      llvm_emit_ascii_case_slice_print/5]).
 
 %% plawk_program_native_driver_ir(+Program, +InputPath, -DriverIR) is semidet.
@@ -80,7 +81,7 @@ print_line:
 ~w
 ',
         [BeginGlobalIR, GuardGlobalIR, PrintGlobalIR]),
-    plawk_stream_driver_ir(InputPath,
+    llvm_emit_stream_driver_ir(InputPath,
         driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR, '',
             success, 'success:\n  ret i32 0'),
         DriverIR).
@@ -121,7 +122,7 @@ plawk_program_native_driver_ir(
 ~w~w
   ret i32 0',
         [FinalStatePhiIR, EndPrintIR]),
-    plawk_stream_driver_ir(InputPath,
+    llvm_emit_stream_driver_ir(InputPath,
         driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, LoopPhiIR, lowered_mixed,
             RecordIR, NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
@@ -158,7 +159,7 @@ plawk_program_native_driver_ir(
 ~w~w
   ret i32 0',
         [FinalStatePhiIR, EndPrintIR]),
-    plawk_stream_driver_ir(InputPath,
+    llvm_emit_stream_driver_ir(InputPath,
         driver_blocks(RuntimeGlobals, BeginIR, LoopPhiIR, lowered_match, RecordIR,
             NextPhiIR, BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
@@ -193,7 +194,7 @@ plawk_program_native_driver_ir(
 ~w
   ret i32 0',
         [EndPrintIR]),
-    plawk_stream_driver_ir(InputPath,
+    llvm_emit_stream_driver_ir(InputPath,
         driver_blocks(RuntimeGlobals, CombinedEntrySetupIR, RecordLoopPhiIR, lowered_assoc,
             RecordIR, '', BreakCloseIR, end_print, CloseOkIR),
         DriverIR).
@@ -216,115 +217,6 @@ plawk_i64_end_print_globals(SurfaceGlobals, RuntimeGlobals) :-
 
 ',
         [SurfaceGlobals]).
-
-% Shared native streaming skeleton. Surface-specific lowerers provide globals,
-% loop-carried state phis, the per-record lowered block, continuation phis, an
-% optional terminal-break close block, and the close-success block; file
-% open/read/eof/close stays backend infrastructure.
-plawk_stream_driver_ir(
-    InputPath,
-    driver_blocks(RuntimeGlobals, LoopPhiIR, LoweredLabel, RecordIR,
-        ContinueIR, CloseOkLabel, CloseOkIR),
-    DriverIR
-) :-
-    plawk_stream_driver_ir(InputPath,
-        driver_blocks(RuntimeGlobals, '', LoopPhiIR, LoweredLabel, RecordIR,
-            ContinueIR, CloseOkLabel, CloseOkIR),
-        DriverIR).
-
-plawk_stream_driver_ir(
-    InputPath,
-    driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
-        ContinueIR, CloseOkLabel, CloseOkIR),
-    DriverIR
-) :-
-    plawk_stream_driver_ir(InputPath,
-        driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
-            ContinueIR, '', CloseOkLabel, CloseOkIR),
-        DriverIR).
-
-plawk_stream_driver_ir(
-    InputPath,
-    driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
-        ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR),
-    DriverIR
-) :-
-    llvm_emit_c_string_global(plawk_surface_path, InputPath, PathGlobalIR, PathLen, BytesLen),
-    format(atom(DriverIR),
-'~w
-@.plawk_surface_eof = private constant [12 x i8] c"end_of_file\\00"
-~w
-
-define i32 @main() {
-entry:
-  %path_ptr = getelementptr [~w x i8], [~w x i8]* @.plawk_surface_path, i32 0, i32 0
-  %path_id = call i64 @wam_intern_atom(i8* %path_ptr, i64 ~w)
-  %path0 = insertvalue %Value undef, i32 0, 0
-  %path = insertvalue %Value %path0, i64 %path_id, 1
-~w
-  %handle = call %Value @wam_stream_open_value(%Value %path)
-  %handle_tag = extractvalue %Value %handle, 0
-  %handle_is_int = icmp eq i32 %handle_tag, 1
-  br i1 %handle_is_int, label %check_handle_value, label %fail_open
-
-check_handle_value:
-  %handle_payload = extractvalue %Value %handle, 1
-  %handle_ok = icmp sgt i64 %handle_payload, 0
-  br i1 %handle_ok, label %loop, label %fail_open
-
-loop:
-~w
-  %line = call %Value @wam_stream_read_line_value(%Value %handle)
-  %line_tag = extractvalue %Value %line, 0
-  %line_payload = extractvalue %Value %line, 1
-  %line_is_int = icmp eq i32 %line_tag, 1
-  %line_bad_payload = icmp slt i64 %line_payload, 0
-  %line_bad = and i1 %line_is_int, %line_bad_payload
-  br i1 %line_bad, label %fail_read, label %check_line_atom
-
-check_line_atom:
-  %line_is_atom = icmp eq i32 %line_tag, 0
-  br i1 %line_is_atom, label %check_eof, label %fail_line_tag
-
-check_eof:
-  %line_s = call i8* @wam_atom_to_string(i64 %line_payload)
-  %eof_s = getelementptr [12 x i8], [12 x i8]* @.plawk_surface_eof, i32 0, i32 0
-  %eof_cmp = call i32 @strcmp(i8* %line_s, i8* %eof_s)
-  %is_eof = icmp eq i32 %eof_cmp, 0
-  br i1 %is_eof, label %close_stream, label %~w
-
-~w:
-~w
-
-continue_loop:
-~w
-  br label %loop
-
-~w
-close_stream:
-  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
-  br i1 %close_ok, label %~w, label %fail_close
-
-~w
-
-fail_open:
-  ret i32 10
-
-fail_read:
-  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
-  ret i32 11
-
-fail_line_tag:
-  %close_ignore_line_tag = call i1 @wam_stream_close_value(%Value %handle)
-  ret i32 12
-
-fail_close:
-  ret i32 16
-}
-',
-        [PathGlobalIR, RuntimeGlobals,
-         BytesLen, BytesLen, PathLen, EntrySetupIR, LoopPhiIR, LoweredLabel,
-         LoweredLabel, RecordIR, ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR]).
 
 % State plans keep recognized PLAWK state separate from the LLVM slot numbering.
 % Associative arrays use a separate table plan because they are pointer state.

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -58,6 +58,7 @@
     llvm_emit_printf_string/5,           % +FmtGlobal, +FmtVar, +PrintVar, +PtrIR, -Parts
     llvm_emit_printf_string/6,           % +FmtGlobal, +FmtLen, +FmtVar, +PrintVar, +PtrIR, -Parts
     llvm_emit_printf0/5,                 % +FmtGlobal, +FmtLen, +FmtVar, +PrintVar, -Parts
+    llvm_emit_stream_driver_ir/3,        % +InputPath, +DriverBlocks, -DriverIR
     llvm_emit_ascii_case_slice_print/5   % +Mode, +PtrIR, +LenIR, +PrintBase, -CallIR
 ]).
 
@@ -16758,6 +16759,117 @@ llvm_emit_printf0(FmtGlobal, FmtLen, FmtVar, PrintVar, [FmtPtr, PrintCall]) :-
     format(atom(PrintCall),
         '  %~w = call i32 (i8*, ...) @printf(i8* %~w)',
         [PrintVar, FmtVar]).
+
+%% llvm_emit_stream_driver_ir(+InputPath, +DriverBlocks, -DriverIR)
+%
+%  Emit the reusable native file-stream driver skeleton. Surface-specific
+%  lowerers provide runtime globals, optional entry setup, loop-carried phis,
+%  per-record lowered IR, continuation phis, optional terminal-break close IR,
+%  and the close-success block.
+llvm_emit_stream_driver_ir(
+    InputPath,
+    driver_blocks(RuntimeGlobals, LoopPhiIR, LoweredLabel, RecordIR,
+        ContinueIR, CloseOkLabel, CloseOkIR),
+    DriverIR
+) :-
+    llvm_emit_stream_driver_ir(InputPath,
+        driver_blocks(RuntimeGlobals, '', LoopPhiIR, LoweredLabel, RecordIR,
+            ContinueIR, CloseOkLabel, CloseOkIR),
+        DriverIR).
+
+llvm_emit_stream_driver_ir(
+    InputPath,
+    driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
+        ContinueIR, CloseOkLabel, CloseOkIR),
+    DriverIR
+) :-
+    llvm_emit_stream_driver_ir(InputPath,
+        driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
+            ContinueIR, '', CloseOkLabel, CloseOkIR),
+        DriverIR).
+
+llvm_emit_stream_driver_ir(
+    InputPath,
+    driver_blocks(RuntimeGlobals, EntrySetupIR, LoopPhiIR, LoweredLabel, RecordIR,
+        ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR),
+    DriverIR
+) :-
+    llvm_emit_c_string_global(wam_stream_input_path, InputPath, PathGlobalIR, PathLen, BytesLen),
+    format(atom(DriverIR),
+'~w
+@.wam_stream_eof = private constant [12 x i8] c"end_of_file\\00"
+~w
+
+define i32 @main() {
+entry:
+  %path_ptr = getelementptr [~w x i8], [~w x i8]* @.wam_stream_input_path, i32 0, i32 0
+  %path_id = call i64 @wam_intern_atom(i8* %path_ptr, i64 ~w)
+  %path0 = insertvalue %Value undef, i32 0, 0
+  %path = insertvalue %Value %path0, i64 %path_id, 1
+~w
+  %handle = call %Value @wam_stream_open_value(%Value %path)
+  %handle_tag = extractvalue %Value %handle, 0
+  %handle_is_int = icmp eq i32 %handle_tag, 1
+  br i1 %handle_is_int, label %check_handle_value, label %fail_open
+
+check_handle_value:
+  %handle_payload = extractvalue %Value %handle, 1
+  %handle_ok = icmp sgt i64 %handle_payload, 0
+  br i1 %handle_ok, label %loop, label %fail_open
+
+loop:
+~w
+  %line = call %Value @wam_stream_read_line_value(%Value %handle)
+  %line_tag = extractvalue %Value %line, 0
+  %line_payload = extractvalue %Value %line, 1
+  %line_is_int = icmp eq i32 %line_tag, 1
+  %line_bad_payload = icmp slt i64 %line_payload, 0
+  %line_bad = and i1 %line_is_int, %line_bad_payload
+  br i1 %line_bad, label %fail_read, label %check_line_atom
+
+check_line_atom:
+  %line_is_atom = icmp eq i32 %line_tag, 0
+  br i1 %line_is_atom, label %check_eof, label %fail_line_tag
+
+check_eof:
+  %line_s = call i8* @wam_atom_to_string(i64 %line_payload)
+  %eof_s = getelementptr [12 x i8], [12 x i8]* @.wam_stream_eof, i32 0, i32 0
+  %eof_cmp = call i32 @strcmp(i8* %line_s, i8* %eof_s)
+  %is_eof = icmp eq i32 %eof_cmp, 0
+  br i1 %is_eof, label %close_stream, label %~w
+
+~w:
+~w
+
+continue_loop:
+~w
+  br label %loop
+
+~w
+close_stream:
+  %close_ok = call i1 @wam_stream_close_value(%Value %handle)
+  br i1 %close_ok, label %~w, label %fail_close
+
+~w
+
+fail_open:
+  ret i32 10
+
+fail_read:
+  %close_ignore_read = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 11
+
+fail_line_tag:
+  %close_ignore_line_tag = call i1 @wam_stream_close_value(%Value %handle)
+  ret i32 12
+
+fail_close:
+  ret i32 16
+}
+',
+        [PathGlobalIR, RuntimeGlobals,
+         BytesLen, BytesLen, PathLen, EntrySetupIR, LoopPhiIR, LoweredLabel,
+         LoweredLabel, RecordIR, ContinueIR, BreakCloseIR, CloseOkLabel, CloseOkIR]).
 
 %% llvm_emit_ascii_case_slice_print(+Mode, +PtrIR, +LenIR, +PrintBase, -CallIR)
 %

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -301,6 +301,38 @@ test(printf0_emitter) :-
         '  %printed_newline = call i32 (i8*, ...) @printf(i8* %newline_fmt)'
     ]).
 
+test(stream_driver_emitter_compact_blocks) :-
+    llvm_emit_stream_driver_ir('input.txt',
+        driver_blocks('@.fmt = private constant [2 x i8] c"\\0A\\00"',
+            '', lowered_test, '  br label %continue_loop', '',
+            success, 'success:\n  ret i32 0'),
+        DriverIR),
+    assertion(sub_atom(DriverIR, _, _, _, '@.wam_stream_input_path = private constant [10 x i8]')),
+    assertion(sub_atom(DriverIR, _, _, _, '@.wam_stream_eof = private constant [12 x i8] c"end_of_file\\00"')),
+    assertion(sub_atom(DriverIR, _, _, _, '@.fmt = private constant [2 x i8] c"\\0A\\00"')),
+    assertion(sub_atom(DriverIR, _, _, _, '%line = call %Value @wam_stream_read_line_value(%Value %handle)')),
+    assertion(sub_atom(DriverIR, _, _, _, 'br i1 %is_eof, label %close_stream, label %lowered_test')),
+    assertion(sub_atom(DriverIR, _, _, _, 'success:\n  ret i32 0')),
+    assertion(\+ sub_atom(DriverIR, _, _, _, 'plawk_surface_path')),
+    !.
+
+test(stream_driver_emitter_full_blocks) :-
+    llvm_emit_stream_driver_ir('input.txt',
+        driver_blocks('', '  %setup = add i64 0, 0', '  %slot = phi i64 [0, %check_handle_value], [%slot_next, %continue_loop]',
+            lowered_full, '  %slot_next = add i64 %slot, 1',
+            '  %next_slot = phi i64 [%slot_next, %lowered_full]',
+            'break_close_stream:\n  br label %close_stream\n',
+            end_print, 'end_print:\n  ret i32 0'),
+        DriverIR),
+    assertion(sub_atom(DriverIR, _, _, _, 'entry:\n  %path_ptr')),
+    assertion(sub_atom(DriverIR, _, _, _, '  %setup = add i64 0, 0\n  %handle = call %Value @wam_stream_open_value')),
+    assertion(sub_atom(DriverIR, _, _, _, 'loop:\n  %slot = phi i64 [0, %check_handle_value], [%slot_next, %continue_loop]')),
+    assertion(sub_atom(DriverIR, _, _, _, 'lowered_full:\n  %slot_next = add i64 %slot, 1')),
+    assertion(sub_atom(DriverIR, _, _, _, 'continue_loop:\n  %next_slot = phi i64 [%slot_next, %lowered_full]\n  br label %loop')),
+    assertion(sub_atom(DriverIR, _, _, _, 'break_close_stream:\n  br label %close_stream\n\nclose_stream:')),
+    assertion(sub_atom(DriverIR, _, _, _, 'br i1 %close_ok, label %end_print, label %fail_close')),
+    !.
+
 % ============================================================================
 % Builtin op ID mapping
 % ============================================================================


### PR DESCRIPTION
## Summary
- add a reusable WAM/LLVM native file-stream driver emitter
- refactor PLAWK native codegen to call the shared stream-driver helper
- give the shared helper target-level coverage for compact and full driver block forms
- document that PLAWK now supplies only surface-specific driver fragments

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`
- `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
- `swipl -q -s tests/core/test_wam_llvm_assoc_i64_runtime.pl -t halt`

Note: `tests/test_wam_llvm_target.pl` still reports pre-existing choicepoint warnings in older tests while passing.