### PR TITLE
Add PLAWK numeric field guards

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -264,6 +264,9 @@ the allocation-free `@wam_atom_field_subslice_value` helper, and native
 Print-only `tolower($N)` and `toupper($N)` lower through shared
 `@wam_print_ascii_lower_slice` and `@wam_print_ascii_upper_slice` helpers, so
 case mapping streams bytes without allocating a transformed atom.
+Numeric field guards such as `$3 > 100` lower through the shared
+`@wam_atom_field_i64_cmp_value` helper, which parses the projected field slice
+as a strict signed decimal `i64` and compares with numeric op codes.
 The scalar counter
 path threads a native `i64` loop variable and prints it from the `END` action. Multiple scalar counters
 become parallel `i64` phi slots in the native streaming loop.
@@ -301,8 +304,8 @@ associative-count surface allocates one reusable WAM/LLVM
 interned-atom-keyed growable `i64` table primitive (`wam_assoc_i64_*`) per source
 array, increments those tables in the native streaming loop, and performs `END`
 lookups through the matching source-array table. Multiple associative increments
-in one always-rule are planned as sequential native action blocks, so no WAM
-dispatch is needed per record for those count updates.
+in one rule lower as sequential native action blocks, so no WAM dispatch is
+needed per record for those count updates.
 Guarded associative-count rules now reuse the same native guard emitters and
 rule-chain structure as scalar counters, so the loop can run field/prefix checks
 and table increments without per-record WAM dispatch for the supported surface.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -83,6 +83,9 @@ such as `$1 == "ERROR" { print length($2), $2 }` and native byte substrings such
 as `$1 == "ERROR" { print substr($2, 1, 3) }`, and native byte searches such as
 `$1 == "ERROR" { print index($2, "sk") }`. Rule prints can also emit ASCII
 case-mapped field slices such as `$1 == "ERROR" { print tolower($2), toupper($0) }`.
+Numeric field guards use the shared WAM/LLVM `i64` comparison helper, so forms
+such as `$3 > 100 { print $1, $3 }` and `$2 <= -5 { cold++ }` stay in the native
+streaming loop.
 Scalar state works with `$1 ==
 "ERROR" { count++ } END { print count }`. Multiple scalar increments
 compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -243,7 +243,18 @@ END { print hits, last_len }
 
 The current assignment expression subset is integer literals and `length($N)`.
 
-The first `if/else` surface lowers scalar updates behind field-equality guards:
+Numeric field guards are also native:
+
+```awk
+$3 >= 100 { big++ }
+END { print big }
+```
+
+The selected field is parsed as a signed decimal `i64`; missing or non-numeric
+fields simply do not match the guard.
+
+The first `if/else` surface lowers scalar updates behind field-equality and
+numeric field guards:
 
 ```awk
 {

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -13,6 +13,7 @@
      llvm_emit_atom_field_length/5,
      llvm_emit_atom_field_subslice/7,
      llvm_emit_atom_field_index/7,
+     llvm_emit_atom_field_i64_cmp_guard/7,
      llvm_emit_c_string_global/5,
      llvm_emit_printf_i64/5,
      llvm_emit_printf_slice/6,
@@ -39,6 +40,7 @@
 %      BEGIN { print "kind", "count" } { total++ } END { print "total", total }
 %      BEGIN { FS = ":" } $1 == "ERROR" { counts[$2]++ } END { print counts["disk"] }
 %      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
+%      $3 > 100 { big++ } END { print big }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
 %      $1 == "ERROR" { last_len = length($0); hits++ } END { print hits, last_len }
@@ -1634,6 +1636,8 @@ plawk_pattern_guard_ir(prefix(Prefix), GuardIR) :-
 
 plawk_pattern_guard_ir(field_eq(Index, Value), GuardIR) :-
     plawk_pattern_guard_ir(field_eq(Index, Value), 32, GuardIR).
+plawk_pattern_guard_ir(field_cmp(Index, Op, Value), GuardIR) :-
+    plawk_pattern_guard_ir(field_cmp(Index, Op, Value), 32, GuardIR).
 
 plawk_pattern_guard_ir(always, _FieldSeparator, GuardIR) :-
     plawk_pattern_guard_ir(always, GuardIR).
@@ -1642,6 +1646,10 @@ plawk_pattern_guard_ir(prefix(Prefix), _FieldSeparator, GuardIR) :-
 plawk_pattern_guard_ir(field_eq(Index, Value), FieldSeparator, GuardIR) :-
     llvm_emit_atom_field_eq_guard(plawk_surface_field_eq, '%line', Index, Value,
         FieldSeparator, '%is_match', GuardIR).
+plawk_pattern_guard_ir(field_cmp(Index, Op, Value), FieldSeparator, ''-GuardCallIR) :-
+    plawk_field_cmp_op_code(Op, OpCode),
+    llvm_emit_atom_field_i64_cmp_guard('%line', Index, OpCode, Value,
+        FieldSeparator, '%is_match', GuardCallIR).
 
 plawk_pattern_guard_ir(always, _GlobalBase, MatchValue, GuardIR) :-
     format(atom(GuardCallIR), '  ~w = icmp eq i1 true, true', [MatchValue]),
@@ -1654,6 +1662,9 @@ plawk_pattern_guard_ir(prefix(Prefix), GlobalBase, MatchValue, GuardIR) :-
 plawk_pattern_guard_ir(field_eq(Index, Value), GlobalBase, MatchValue, GuardIR) :-
     plawk_pattern_guard_ir(field_eq(Index, Value), 32, GlobalBase, MatchValue,
         GuardIR).
+plawk_pattern_guard_ir(field_cmp(Index, Op, Value), GlobalBase, MatchValue, GuardIR) :-
+    plawk_pattern_guard_ir(field_cmp(Index, Op, Value), 32, GlobalBase,
+        MatchValue, GuardIR).
 
 plawk_pattern_guard_ir(always, _FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
     plawk_pattern_guard_ir(always, GlobalBase, MatchValue, GuardIR).
@@ -1662,6 +1673,17 @@ plawk_pattern_guard_ir(prefix(Prefix), _FieldSeparator, GlobalBase, MatchValue, 
 plawk_pattern_guard_ir(field_eq(Index, Value), FieldSeparator, GlobalBase, MatchValue, GuardIR) :-
     llvm_emit_atom_field_eq_guard(GlobalBase, '%line', Index, Value, FieldSeparator,
         MatchValue, GuardIR).
+plawk_pattern_guard_ir(field_cmp(Index, Op, Value), FieldSeparator, _GlobalBase, MatchValue, ''-GuardCallIR) :-
+    plawk_field_cmp_op_code(Op, OpCode),
+    llvm_emit_atom_field_i64_cmp_guard('%line', Index, OpCode, Value,
+        FieldSeparator, MatchValue, GuardCallIR).
+
+plawk_field_cmp_op_code(eq, 0).
+plawk_field_cmp_op_code(ne, 1).
+plawk_field_cmp_op_code(lt, 2).
+plawk_field_cmp_op_code(le, 3).
+plawk_field_cmp_op_code(gt, 4).
+plawk_field_cmp_op_code(ge, 5).
 
 plawk_print_record_counter_ir(Fields, LoopPhiIR, RecordCounterIR) :-
     (   member(special('NR'), Fields)

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -20,6 +20,7 @@
 %      BEGIN { FS = ":" } $1 == "ERROR" { counts[$2]++ } END { print counts["disk"] }
 %      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
 %      { count++ } END { print "count", count }
+%      $3 > 100 { big++ } END { print big }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %      $1 == "DEBUG" { skipped++; next } { total++ } END { print total, skipped }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
@@ -72,6 +73,9 @@ pattern(Pattern) -->
     prefix_pattern(Pattern),
     !.
 pattern(Pattern) -->
+    field_i64_cmp_pattern(Pattern),
+    !.
+pattern(Pattern) -->
     field_eq_pattern(Pattern).
 
 prefix_pattern(prefix(Prefix)) -->
@@ -95,6 +99,31 @@ field_eq_pattern(field_eq(Index, Value)) -->
       ValueCodes \== [],
       string_codes(Value, ValueCodes)
     }.
+
+field_i64_cmp_pattern(field_cmp(Index, Op, Value)) -->
+    "$",
+    integer_codes(IndexCodes),
+    ws,
+    numeric_cmp_op(Op),
+    ws,
+    signed_integer_value(Value),
+    { IndexCodes \== [],
+      number_codes(Index, IndexCodes),
+      Index > 0
+    }.
+
+numeric_cmp_op(eq) -->
+    "==".
+numeric_cmp_op(ne) -->
+    "!=".
+numeric_cmp_op(le) -->
+    "<=".
+numeric_cmp_op(ge) -->
+    ">=".
+numeric_cmp_op(lt) -->
+    "<".
+numeric_cmp_op(gt) -->
+    ">".
 
 prefix_codes([Code | Codes]) -->
     [Code],
@@ -127,6 +156,27 @@ integer_codes_rest([Code | Codes]) -->
     integer_codes_rest(Codes).
 integer_codes_rest([]) -->
     [].
+
+signed_integer_value(Value) -->
+    "-",
+    !,
+    integer_codes(Digits),
+    { Digits \== [],
+      number_codes(Magnitude, Digits),
+      Value is -Magnitude
+    }.
+signed_integer_value(Value) -->
+    "+",
+    !,
+    integer_codes(Digits),
+    { Digits \== [],
+      number_codes(Value, Digits)
+    }.
+signed_integer_value(Value) -->
+    integer_codes(Digits),
+    { Digits \== [],
+      number_codes(Value, Digits)
+    }.
 
 quoted_string(Codes) -->
     "\"",
@@ -242,7 +292,7 @@ if_action(if(Pattern, ThenActions, ElseActions)) -->
     ws,
     "(",
     ws,
-    field_eq_pattern(Pattern),
+    condition_pattern(Pattern),
     ws,
     ")",
     ws,
@@ -250,6 +300,12 @@ if_action(if(Pattern, ThenActions, ElseActions)) -->
     "else",
     required_ws,
     action_block(ElseActions).
+
+condition_pattern(Pattern) -->
+    field_i64_cmp_pattern(Pattern),
+    !.
+condition_pattern(Pattern) -->
+    field_eq_pattern(Pattern).
 
 increment_action(inc_assoc(var(Name), KeyExpr)) -->
     identifier(Name),

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -52,6 +52,7 @@
     llvm_emit_atom_field_length/5,       % +ValueIR, +FieldIndex, +SepCode, +LengthBase, -CallIR
     llvm_emit_atom_field_subslice/7,     % +ValueIR, +FieldIndex, +SepCode, +Start, +Len, +SliceBase, -CallIR
     llvm_emit_atom_field_index/7,        % +GlobalBase, +ValueIR, +FieldIndex, +Needle, +SepCode, +IndexBase, -GlobalIR-CallIR
+    llvm_emit_atom_field_i64_cmp_guard/7,% +ValueIR, +FieldIndex, +OpCode, +Expected, +SepCode, +ResultIR, -CallIR
     llvm_emit_c_string_global/5,         % +GlobalName, +Value, -GlobalIR, -StringLen, -BytesLen
     llvm_emit_printf_i64/5,              % +FmtGlobal, +FmtVar, +PrintVar, +ValueIR, -Parts
     llvm_emit_printf_slice/6,            % +FmtGlobal, +FmtVar, +PrintVar, +LenIR, +PtrIR, -Parts
@@ -5153,6 +5154,129 @@ afi.index:
 
 afi.zero:
   ret i64 0
+}
+
+define i1 @wam_slice_i64_cmp_value(i8* %source_ptr, i64 %source_len, i64 %expected, i32 %op) {
+entry:
+  %si64.null = icmp eq i8* %source_ptr, null
+  br i1 %si64.null, label %si64.no, label %si64.check_len
+
+si64.check_len:
+  %si64.empty = icmp eq i64 %source_len, 0
+  br i1 %si64.empty, label %si64.no, label %si64.first
+
+si64.first:
+  %si64.first_ch = load i8, i8* %source_ptr
+  %si64.is_minus = icmp eq i8 %si64.first_ch, 45
+  %si64.is_plus = icmp eq i8 %si64.first_ch, 43
+  %si64.has_sign = or i1 %si64.is_minus, %si64.is_plus
+  %si64.start = select i1 %si64.has_sign, i64 1, i64 0
+  %si64.sign = select i1 %si64.is_minus, i64 -1, i64 1
+  %si64.only_sign = icmp uge i64 %si64.start, %source_len
+  br i1 %si64.only_sign, label %si64.no, label %si64.loop
+
+si64.loop:
+  %si64.pos = phi i64 [ %si64.start, %si64.first ], [ %si64.next_pos, %si64.digit_step ]
+  %si64.acc = phi i64 [ 0, %si64.first ], [ %si64.next_acc, %si64.digit_step ]
+  %si64.done = icmp uge i64 %si64.pos, %source_len
+  br i1 %si64.done, label %si64.compare, label %si64.read_digit
+
+si64.read_digit:
+  %si64.ch_ptr = getelementptr i8, i8* %source_ptr, i64 %si64.pos
+  %si64.ch = load i8, i8* %si64.ch_ptr
+  %si64.ge_0 = icmp uge i8 %si64.ch, 48
+  %si64.le_9 = icmp ule i8 %si64.ch, 57
+  %si64.is_digit = and i1 %si64.ge_0, %si64.le_9
+  br i1 %si64.is_digit, label %si64.digit_step, label %si64.no
+
+si64.digit_step:
+  %si64.ch_i64 = zext i8 %si64.ch to i64
+  %si64.digit = sub i64 %si64.ch_i64, 48
+  %si64.scaled = mul i64 %si64.acc, 10
+  %si64.next_acc = add i64 %si64.scaled, %si64.digit
+  %si64.next_pos = add i64 %si64.pos, 1
+  br label %si64.loop
+
+si64.compare:
+  %si64.value = mul i64 %si64.acc, %si64.sign
+  switch i32 %op, label %si64.no [
+    i32 0, label %si64.cmp_eq
+    i32 1, label %si64.cmp_ne
+    i32 2, label %si64.cmp_lt
+    i32 3, label %si64.cmp_le
+    i32 4, label %si64.cmp_gt
+    i32 5, label %si64.cmp_ge
+  ]
+
+si64.cmp_eq:
+  %si64.eq = icmp eq i64 %si64.value, %expected
+  br i1 %si64.eq, label %si64.yes, label %si64.no
+
+si64.cmp_ne:
+  %si64.ne = icmp ne i64 %si64.value, %expected
+  br i1 %si64.ne, label %si64.yes, label %si64.no
+
+si64.cmp_lt:
+  %si64.lt = icmp slt i64 %si64.value, %expected
+  br i1 %si64.lt, label %si64.yes, label %si64.no
+
+si64.cmp_le:
+  %si64.le = icmp sle i64 %si64.value, %expected
+  br i1 %si64.le, label %si64.yes, label %si64.no
+
+si64.cmp_gt:
+  %si64.gt = icmp sgt i64 %si64.value, %expected
+  br i1 %si64.gt, label %si64.yes, label %si64.no
+
+si64.cmp_ge:
+  %si64.ge = icmp sge i64 %si64.value, %expected
+  br i1 %si64.ge, label %si64.yes, label %si64.no
+
+si64.yes:
+  ret i1 true
+
+si64.no:
+  ret i1 false
+}
+
+define i1 @wam_atom_field_i64_cmp_value(%Value %atom_value, i64 %field_index, i8 %sep, i64 %expected, i32 %op) {
+entry:
+  %afc.whole = icmp eq i64 %field_index, 0
+  br i1 %afc.whole, label %afc.whole_record, label %afc.field
+
+afc.whole_record:
+  %afc.t = call i32 @value_tag(%Value %atom_value)
+  %afc.is_atom = icmp eq i32 %afc.t, 0
+  br i1 %afc.is_atom, label %afc.lookup, label %afc.no
+
+afc.lookup:
+  %afc.aid = call i64 @value_payload(%Value %atom_value)
+  %afc.str = call i8* @wam_atom_to_string(i64 %afc.aid)
+  %afc.null = icmp eq i8* %afc.str, null
+  br i1 %afc.null, label %afc.no, label %afc.measure
+
+afc.measure:
+  %afc.len = call i64 @strlen(i8* %afc.str)
+  %afc.whole_ok = call i1 @wam_slice_i64_cmp_value(i8* %afc.str, i64 %afc.len, i64 %expected, i32 %op)
+  ret i1 %afc.whole_ok
+
+afc.field:
+  %afc.index_ok = icmp sgt i64 %field_index, 0
+  br i1 %afc.index_ok, label %afc.field_slice, label %afc.no
+
+afc.field_slice:
+  %afc.source = call %WamSlice @wam_atom_field_slice_value(%Value %atom_value, i64 %field_index, i8 %sep)
+  %afc.source_ptr = extractvalue %WamSlice %afc.source, 0
+  %afc.source_len = extractvalue %WamSlice %afc.source, 1
+  %afc.source_has_ptr = icmp ne i8* %afc.source_ptr, null
+  br i1 %afc.source_has_ptr, label %afc.compare, label %afc.no
+
+afc.compare:
+  %afc.field_ok = call i1 @wam_slice_i64_cmp_value(i8* %afc.source_ptr, i64 %afc.source_len, i64 %expected, i32 %op)
+  ret i1 %afc.field_ok
+
+afc.no:
+  ret i1 false
 }
 
 define void @wam_print_ascii_lower_slice(i8* %source_ptr, i64 %source_len) {
@@ -16693,6 +16817,21 @@ llvm_emit_atom_field_index(GlobalBase, ValueIR, FieldIndex, Needle, SepCode, Ind
         '  %~w_ptr = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0~n  %~w = call i64 @wam_atom_field_index_value(%Value ~w, i64 ~w, i8 ~w, i8* %~w_ptr, i64 ~w)',
         [SafeGlobalBase, ArrLen, ArrLen, SafeGlobalBase,
          IndexBase, ValueIR, FieldIndex, SepCode, SafeGlobalBase, NeedleLen]).
+
+%% llvm_emit_atom_field_i64_cmp_guard(+ValueIR, +FieldIndex, +OpCode, +Expected, +SepCode, +ResultIR, -CallIR)
+%
+%  Emit a native numeric field comparison over an atom-backed text record.
+%  OpCode is numeric for the generated hot path: 0 ==, 1 !=, 2 <, 3 <=,
+%  4 >, and 5 >=. The runtime parses the selected field slice as a strict
+%  signed decimal i64 and returns false for missing or non-numeric fields.
+llvm_emit_atom_field_i64_cmp_guard(ValueIR, FieldIndex, OpCode, Expected, SepCode, ResultIR, CallIR) :-
+    integer(FieldIndex),
+    integer(OpCode),
+    between(0, 5, OpCode),
+    integer(Expected),
+    format(atom(CallIR),
+        '  ~w = call i1 @wam_atom_field_i64_cmp_value(%Value ~w, i64 ~w, i8 ~w, i64 ~w, i32 ~w)',
+        [ResultIR, ValueIR, FieldIndex, SepCode, Expected, OpCode]).
 
 %% llvm_emit_c_string_global(+GlobalName, +Value, -GlobalIR, -StringLen, -BytesLen)
 %

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -29,6 +29,23 @@ test(parses_field_eq_print_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { print $0 }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"), [print([field(0)])])], [])).
 
+test(parses_field_numeric_cmp_print_rule) :-
+    plawk_parse_string("$3 > 100 { print $1, $3 }\n", Program),
+    assertion(Program == program([], [rule(field_cmp(3, gt, 100),
+        [print([field(1), field(3)])])], [])).
+
+test(parses_field_numeric_cmp_negative_rule) :-
+    plawk_parse_string("$2 <= -5 { cold++ } END { print cold }\n", Program),
+    assertion(Program == program([], [rule(field_cmp(2, le, -5), [inc(var(cold))])],
+        [end([print([var(cold)])])])).
+
+test(parses_field_numeric_eq_and_ne_rules) :-
+    plawk_parse_string("$2 == 0 { zeros++ } $2 != 0 { nonzeros++ } END { print zeros, nonzeros }\n", Program),
+    assertion(Program == program([],
+        [rule(field_cmp(2, eq, 0), [inc(var(zeros))]),
+         rule(field_cmp(2, ne, 0), [inc(var(nonzeros))])],
+        [end([print([var(zeros), var(nonzeros)])])])).
+
 test(parses_field_eq_print_fields_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { print $2, $3 }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"), [print([field(2), field(3)])])], [])).
@@ -190,6 +207,14 @@ test(parses_scalar_if_else_end_print_rule) :-
             [inc(var(non_errors))])])],
         [end([print([var(total), var(errors), var(non_errors), var(last_len)])])])).
 
+test(parses_numeric_if_else_scalar_rule) :-
+    plawk_parse_string("{ if ($3 >= 100) { big++ } else { small++ } } END { print big, small }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [if(field_cmp(3, ge, 100),
+            [inc(var(big))],
+            [inc(var(small))])])],
+        [end([print([var(big), var(small)])])])).
+
 test(parses_scalar_if_else_without_keyword_space) :-
     plawk_parse_string("{ if($1 == \"ERROR\") { errors++ } else { non_errors++ } } END { print errors, non_errors }\n", Program),
     assertion(Program == program([], [rule(always,
@@ -318,6 +343,11 @@ test(surface_field_eq_prints_selected_fields) :-
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "disk full\nnet down\n").
 
+test(surface_field_numeric_cmp_prints_matching_records) :-
+    run_surface_print_smoke("$3 > 100 { print $1, $3 }\n",
+        "disk used 95\ncpu used 101\nnet used 120\nbad used nope\nmem used -3\n",
+        "cpu 101\nnet 120\n").
+
 test(surface_field_eq_prints_nr_and_selected_fields) :-
     run_surface_print_smoke("$1 == \"ERROR\" { print NR, $2, $3 }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -362,6 +392,21 @@ test(surface_field_eq_counts_matching_records) :-
     run_surface_print_smoke("$1 == \"ERROR\" { count++ } END { print count }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
         "2\n").
+
+test(surface_field_numeric_cmp_counts_matching_records) :-
+    run_surface_print_smoke("$3 >= 100 { big++ } END { print big }\n",
+        "disk used 95\ncpu used 100\nnet used 120\nbad used nope\nmem used -3\n",
+        "2\n").
+
+test(surface_field_numeric_cmp_handles_negative_values) :-
+    run_surface_print_smoke("$2 < -5 { cold++ } END { print cold }\n",
+        "a -6\nb -5\nc 0\nd -10\n",
+        "2\n").
+
+test(surface_field_numeric_eq_and_ne_counts) :-
+    run_surface_print_smoke("$2 == 0 { zeros++ } $2 != 0 { nonzeros++ } END { print zeros, nonzeros }\n",
+        "a 0\nb 1\nc nope\nd -1\n",
+        "1 2\n").
 
 test(surface_field_eq_counts_multiple_scalar_slots) :-
     run_surface_print_smoke("$1 == \"ERROR\" { errors++; matches++ } END { print errors, matches }\n",
@@ -932,6 +977,23 @@ test(surface_begin_field_separator_uses_configured_delimiter) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value(%Value %line, i64 2, i8 58)'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value(%Value %line, i64 3, i8 58)'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value(%Value %line, i64 2, i8 32)')),
+    !.
+
+test(surface_numeric_guard_uses_native_i64_field_cmp) :-
+    plawk_parse_string("BEGIN { FS = \":\" } $3 >= 100 { print $1, $3 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_i64_cmp_value(%Value %line, i64 3, i8 58, i64 100, i32 5)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value(%Value %line, i64 1, i8 58)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_slice_value(%Value %line, i64 3, i8 58)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_numeric_eq_ne_guards_use_numeric_op_codes) :-
+    plawk_parse_string("$2 == 0 { zeros++ } $2 != 0 { nonzeros++ } END { print zeros, nonzeros }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_i64_cmp_value(%Value %line, i64 2, i8 32, i64 0, i32 0)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_i64_cmp_value(%Value %line, i64 2, i8 32, i64 0, i32 1)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 
 test(surface_begin_output_separator_uses_configured_delimiter) :-

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -203,6 +203,8 @@ test(full_runtime_generation) :-
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamSlice @wam_atom_field_subslice_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_slice_index_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_atom_field_index_value')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_slice_i64_cmp_value')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_field_i64_cmp_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define void @wam_print_ascii_lower_slice')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define void @wam_print_ascii_upper_slice')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_prefix_value')),
@@ -252,6 +254,10 @@ test(atom_field_index_emitter) :-
     assertion(sub_atom(CallIR, _, _, _, '%plawk_5Findex_5Fneedle_ptr = getelementptr')),
     assertion(sub_atom(CallIR, _, _, _, '%plawk_index = call i64 @wam_atom_field_index_value(%Value %line, i64 2, i8 58')),
     assertion(sub_atom(CallIR, _, _, _, 'i64 4')).
+
+test(atom_field_i64_cmp_guard_emitter) :-
+    llvm_emit_atom_field_i64_cmp_guard('%line', 3, 4, 100, 32, '%ok', CallIR),
+    assertion(CallIR == '  %ok = call i1 @wam_atom_field_i64_cmp_value(%Value %line, i64 3, i8 32, i64 100, i32 4)').
 
 test(ascii_case_slice_print_emitter) :-
     llvm_emit_ascii_case_slice_print(lower, '%ptr', '%len', plawk_lower, LowerIR),


### PR DESCRIPTION
## Summary
- add shared WAM/LLVM helpers for strict signed-decimal `i64` field comparisons using numeric op codes
- extend PLAWK parsing/codegen for numeric field guards such as `$3 > 100`, `$2 <= -5`, `$2 == 0`, and `$2 != 0`
- cover numeric guards in print, scalar count, branch condition, configured-`FS`, and generated-IR tests
- update PLAWK docs for numeric guards and the implemented multi-assoc-increment boundary

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`

Note: `tests/test_wam_llvm_target.pl` still reports pre-existing choicepoint warnings in older tests while passing.