### PR TITLE
test(wam-clojure): cover t4 smoke semantics

### DIFF
--- a/tests/test_wam_clojure_runtime_smoke.pl
+++ b/tests/test_wam_clojure_runtime_smoke.pl
@@ -11,6 +11,8 @@
 :- dynamic user:wam_execute_caller/1.
 :- dynamic user:wam_call_caller/1.
 :- dynamic user:wam_choice_fact/1.
+:- dynamic user:wam_t4_color/1.
+:- dynamic user:wam_t4_pair/2.
 :- dynamic user:wam_choice_caller/1.
 :- dynamic user:wam_choice_or_z/1.
 :- dynamic user:wam_bind_then_fact/1.
@@ -398,6 +400,12 @@ user:wam_call_caller(X) :- user:wam_fact(X), user:wam_fact(X).
 user:wam_choice_fact(a).
 user:wam_choice_fact(b).
 user:wam_choice_fact(c).
+user:wam_t4_color(red).
+user:wam_t4_color(green).
+user:wam_t4_color(blue).
+user:wam_t4_pair(a, x).
+user:wam_t4_pair(a, y).
+user:wam_t4_pair(b, z).
 user:wam_choice_caller(X) :- user:wam_choice_fact(X).
 user:wam_choice_or_z(X) :- user:wam_choice_fact(X).
 user:wam_choice_or_z(z).
@@ -792,6 +800,8 @@ run_smoke :-
           user:wam_foreign_stream_pair_query/1,
           user:wam_foreign_stream_pair/2,
           user:wam_choice_fact/1,
+          user:wam_t4_color/1,
+          user:wam_t4_pair/2,
           user:wam_choice_caller/1,
           user:wam_choice_or_z/1,
           user:wam_bind_then_fact/1,
@@ -1248,6 +1258,15 @@ smoke_cases([
     case('wam_choice_caller/1', 'b', "true"),
     case('wam_choice_caller/1', 'c', "true"),
     case('wam_choice_caller/1', 'd', "false"),
+    case('wam_t4_color/1', red, "true"),
+    case('wam_t4_color/1', green, "true"),
+    case('wam_t4_color/1', blue, "true"),
+    case('wam_t4_color/1', yellow, "false"),
+    case('wam_t4_pair/2', args(a, x), "true"),
+    case('wam_t4_pair/2', args(a, y), "true"),
+    case('wam_t4_pair/2', args(b, z), "true"),
+    case('wam_t4_pair/2', args(a, z), "false"),
+    case('wam_t4_pair/2', args(c, x), "false"),
     case('wam_choice_or_z/1', 'z', "true"),
     case('wam_bind_then_fact/1', 'a', "true"),
     case('wam_bind_then_fact/1', 'b', "false"),
@@ -2277,6 +2296,10 @@ assert_multiclause_lowering_contracts(ProjectDir) :-
     directory_file_path(ProjectDir, 'src/generated/wam_exec_test/core.clj', CorePath),
     read_file_to_string(CorePath, CoreCode, []),
     assert_t4_multiclause_wrapper(CoreCode, "lowered-wam-choice-fact-1"),
+    assert_t4_multiclause_wrapper(CoreCode, "lowered-wam-t4-color-1"),
+    assert_t4_multiclause_wrapper(CoreCode, "lowered-wam-t4-pair-2"),
+    has(CoreCode, "get-constant red, A1"),
+    has(CoreCode, "get-constant y, A2"),
     assert_empty_lowered_wrapper(CoreCode, "lowered-wam-choice-or-z-1"),
     assert_empty_lowered_wrapper(CoreCode, "lowered-wam-trail-choice-1").
 
@@ -2456,7 +2479,12 @@ prolog_term_string_to_edn(b, "\"b\"") :- !.
 prolog_term_string_to_edn(c, "\"c\"") :- !.
 prolog_term_string_to_edn(d, "\"d\"") :- !.
 prolog_term_string_to_edn(x, "\"x\"") :- !.
+prolog_term_string_to_edn(y, "\"y\"") :- !.
 prolog_term_string_to_edn(z, "\"z\"") :- !.
+prolog_term_string_to_edn(red, "\"red\"") :- !.
+prolog_term_string_to_edn(green, "\"green\"") :- !.
+prolog_term_string_to_edn(blue, "\"blue\"") :- !.
+prolog_term_string_to_edn(yellow, "\"yellow\"") :- !.
 prolog_term_string_to_edn('<', "\"<\"") :- !.
 prolog_term_string_to_edn('=', "\"=\"") :- !.
 prolog_term_string_to_edn('>', "\">\"") :- !.


### PR DESCRIPTION
## Summary

- Add dedicated Clojure WAM smoke fixtures for clean T4 all-clause lowering.
- Cover direct runtime success and failure cases for a 3-clause unary fact predicate.
- Cover direct runtime success and failure cases for a 3-clause binary fact predicate.
- Assert the generated Clojure code emits T4 all-clause wrappers for the new smoke predicates.

## Why

Recent Clojure WAM work aligned the smoke assertion with T4 all-clause lowering, but the runtime smoke coverage still leaned on existing choice predicates. This adds explicit positive and negative semantic checks for direct T4-lowered predicates, including a multi-argument case.

## Testing

- `git diff --check`
- `timeout 240 swipl -q -s tests/test_wam_clojure_runtime_smoke.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_lowered_emitter.pl`
- `swipl -q -g run_tests -t halt tests/test_wam_clojure_generator.pl`
