### PR TITLE
feat(wam): emit native items for simple goals

### DIFF
--- a/docs/design/WAM_ITEMS_API_SPECIFICATION.md
+++ b/docs/design/WAM_ITEMS_API_SPECIFICATION.md
@@ -12,10 +12,11 @@ The first implementation step is intentionally conservative:
 
 - `compile_predicate_to_wam_text/3` is now the explicit legacy text API.
 - `compile_predicate_to_wam_items/3` is available as the structured API. It now
-  emits single-clause fact predicates and simple one-goal user-predicate tail
-  calls directly as items, and falls back to the existing text generator plus
-  `wam_text_to_items/2` for multi-goal rules, multi-clause predicates,
-  aggregates, indexing, lowered builtins, and other complex shapes.
+  emits single-clause facts, simple user-predicate calls, generic builtin calls,
+  and conjunctions of those simple shapes directly as items. It falls back to
+  the existing text generator plus `wam_text_to_items/2` for multi-clause
+  predicates, aggregates, indexing, lowered builtins, control flow, compound
+  body arguments, and other complex shapes.
 - `compile_predicate_to_wam/3` still returns text by default for compatibility
   with the existing targets. The default-output flip described below remains a
   later migration step after more callers consume items directly.

--- a/docs/design/WAM_REPRESENTATION_MODES.md
+++ b/docs/design/WAM_REPRESENTATION_MODES.md
@@ -53,10 +53,11 @@ Python also accepts an explicit `wam_ir(wam_items_native)` override for
 interpreter-mode predicate emission. Today that target path consumes the common
 structured WAM items directly and is output-equivalent to `wam_items_bridge`;
 the shared `compile_predicate_to_wam_items/3` producer now skips WAM text for
-single-clause facts and simple one-goal user-predicate tail calls, then falls
-back to the text-to-items bridge for more complex predicate shapes. As the
-native producer expands, the same explicit Python mode will skip WAM text for
-more predicates without changing the Python emitter.
+single-clause facts, simple user-predicate calls, generic builtin calls, and
+conjunctions of those simple shapes, then falls back to the text-to-items bridge
+for more complex predicate shapes. As the native producer expands, the same
+explicit Python mode will skip WAM text for more predicates without changing the
+Python emitter.
 
 Lua, R, and Elixir follow the same partial migration shape as Python:
 interpreter-mode generated predicates consume common WAM items through the

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -203,10 +203,11 @@ compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code) :-
     ).
 
 %% compile_clauses_to_wam_items_native(+Pred, +Arity, +Clauses, +Options, -Items)
-%  Direct items path for simple single-clause predicates. This is the first
-%  incremental native producer slice; aggregates, indexing, lowered builtins,
-%  multi-goal rules, and peephole-sensitive shapes intentionally fall back to
-%  the legacy text bridge.
+%  Direct items path for simple single-clause predicates. This incremental
+%  native producer slice covers facts, simple user calls, generic builtin calls,
+%  and conjunctions of those shapes. Aggregates, indexing, lowered builtins,
+%  control flow, compound body arguments, and peephole-sensitive shapes
+%  intentionally fall back to the legacy text bridge.
 compile_clauses_to_wam_items_native(Pred, Arity, [Head-Body], _Options, Items) :-
     normalize_goals(Body, []),
     !,
@@ -217,36 +218,116 @@ compile_clauses_to_wam_items_native(Pred, Arity, [Head-Body], _Options, Items) :
     append(HeadItems, [proceed], InstrItems),
     Items = [label(Label)|InstrItems].
 compile_clauses_to_wam_items_native(Pred, Arity, [Head-Body], _Options, Items) :-
-    normalize_goals(Body, [Goal]),
-    native_simple_execute_goal(Goal),
+    normalize_goals(Body, Goals),
+    Goals = [_|_],
+    native_simple_goal_sequence(Goals),
     !,
     Head =.. [_|Args],
     empty_varmap(V0),
-    pre_assign_permanent_vars([Goal], V0, V0a),
-    compile_head_arguments_items(Args, 1, V0a, V1, HeadItems),
-    compile_goal_execute_items_simple(Goal, V1, _Vf, GoalItems),
+    expand_aggregate_goals_for_perm_vars(Goals, ExpandedGoals),
     format(string(Label), "~w/~w", [Pred, Arity]),
+    (   native_simple_goals_need_env(Goals, ExpandedGoals)
+    ->  pre_assign_permanent_vars(ExpandedGoals, V0, V0a),
+        compile_head_arguments_items(Args, 1, V0a, V1, HeadItems),
+        compile_goals_items_simple(Goals, V1, yes, _Vf, GoalItems),
+        PrefixItems = [label(Label), allocate]
+    ;   compile_head_arguments_items(Args, 1, V0, V1, HeadItems),
+        compile_goals_items_simple(Goals, V1, no, _Vf, GoalItems),
+        PrefixItems = [label(Label)]
+    ),
     append(HeadItems, GoalItems, InstrItems),
-    Items = [label(Label), allocate|InstrItems].
+    append(PrefixItems, InstrItems, Items).
 
-native_simple_execute_goal(Goal) :-
+native_simple_goals_need_env(Goals, ExpandedGoals) :-
+    (   length(ExpandedGoals, N), N > 1
+    ;   goals_contain_call_or_aggregate(Goals)
+    ),
+    !.
+
+native_simple_goal_sequence(Goals) :-
+    forall(member(Goal, Goals), native_simple_goal(Goal)).
+
+native_simple_goal(M:InnerGoal) :-
+    (atom(M) ; string(M)),
+    !,
+    native_simple_goal(InnerGoal).
+native_simple_goal(Goal) :-
     callable(Goal),
-    Goal =.. [GoalPred|Args],
-    length(Args, Arity),
-    \+ is_builtin_pred(GoalPred, Arity),
+    \+ native_special_goal(Goal),
+    Goal =.. [_GoalPred|Args],
+    \+ goal_has_visited_set_arg(Goal),
     forall(member(Arg, Args), native_simple_goal_arg(Arg)).
+
+native_special_goal('!') :- !.
+native_special_goal(Goal) :-
+    nonvar(Goal),
+    (   Goal = aggregate_all(_, _, _)
+    ;   Goal = findall(_, _, _)
+    ;   Goal = bagof(_, _, _)
+    ;   Goal = setof(_, _, _)
+    ;   Goal = (_ -> _ ; _)
+    ;   Goal = (_ -> _)
+    ;   Goal = (_ ; _)
+    ;   Goal = \+(_)
+    ;   Goal = once(_)
+    ;   Goal = forall(_, _)
+    ;   is_term_construction_goal(Goal)
+    ).
 
 native_simple_goal_arg(Arg) :-
     var(Arg), !.
 native_simple_goal_arg(Arg) :-
     atomic(Arg).
 
-compile_goal_execute_items_simple(Goal, V0, Vf, Items) :-
+compile_goals_items_simple([], V, _, V, []).
+compile_goals_items_simple([Goal], V0, HasEnv, Vf, Items) :-
+    !,
+    compile_last_goal_items_simple(Goal, V0, HasEnv, Vf, Items).
+compile_goals_items_simple([Goal|Rest], V0, HasEnv, Vf, Items) :-
+    compile_goal_call_items_simple(Goal, V0, V1, GoalItems),
+    compile_goals_items_simple(Rest, V1, HasEnv, Vf, RestItems),
+    append(GoalItems, RestItems, Items).
+
+compile_goal_call_items_simple(M:InnerGoal, V0, Vf, Items) :-
+    (atom(M) ; string(M)),
+    !,
+    compile_goal_call_items_simple(InnerGoal, V0, Vf, Items).
+compile_goal_call_items_simple(Goal, V0, Vf, Items) :-
     Goal =.. [GoalPred|Args],
     length(Args, Arity),
     compile_put_arguments_items_simple(Args, 1, V0, Vf, PutItems),
     wam_functor_token(GoalPred, Arity, PredTok),
-    append(PutItems, [deallocate, execute(PredTok)], Items).
+    wam_arity_token(Arity, ArityTok),
+    (   is_builtin_pred(GoalPred, Arity)
+    ->  CallItem = builtin_call(PredTok, ArityTok)
+    ;   CallItem = call(PredTok, ArityTok)
+    ),
+    append(PutItems, [CallItem], Items).
+
+compile_last_goal_items_simple(M:InnerGoal, V0, HasEnv, Vf, Items) :-
+    (atom(M) ; string(M)),
+    !,
+    compile_last_goal_items_simple(InnerGoal, V0, HasEnv, Vf, Items).
+compile_last_goal_items_simple(Goal, V0, yes, Vf, Items) :-
+    Goal =.. [GoalPred|Args],
+    length(Args, Arity),
+    compile_put_arguments_items_simple(Args, 1, V0, Vf, PutItems),
+    wam_functor_token(GoalPred, Arity, PredTok),
+    wam_arity_token(Arity, ArityTok),
+    (   is_builtin_pred(GoalPred, Arity)
+    ->  append(PutItems, [builtin_call(PredTok, ArityTok), deallocate, proceed], Items)
+    ;   append(PutItems, [deallocate, execute(PredTok)], Items)
+    ).
+compile_last_goal_items_simple(Goal, V0, no, Vf, Items) :-
+    Goal =.. [GoalPred|Args],
+    length(Args, Arity),
+    compile_put_arguments_items_simple(Args, 1, V0, Vf, PutItems),
+    wam_functor_token(GoalPred, Arity, PredTok),
+    wam_arity_token(Arity, ArityTok),
+    (   is_builtin_pred(GoalPred, Arity)
+    ->  append(PutItems, [builtin_call(PredTok, ArityTok), proceed], Items)
+    ;   append(PutItems, [execute(PredTok)], Items)
+    ).
 
 compile_put_arguments_items_simple([], _, V, V, []).
 compile_put_arguments_items_simple([Arg|Rest], I, V0, Vf, Items) :-
@@ -355,6 +436,9 @@ wam_arg_register(I, Ai) :-
 
 wam_functor_token(F, Arity, Token) :-
     format(string(Token), "~w/~w", [F, Arity]).
+
+wam_arity_token(Arity, Token) :-
+    number_string(Arity, Token).
 
 wam_operand_string(Value, String) :-
     (   string(Value)

--- a/tests/test_wam_lua_generator.pl
+++ b/tests/test_wam_lua_generator.pl
@@ -75,6 +75,7 @@ user:wam_lua_fa_basic :-
     findall(X, user:wam_lua_fa_fact(X), L),
     L = [a, b].
 user:wam_lua_greet(X, hello) :- X = world.
+user:wam_lua_greet(X, goodbye) :- X = moon.
 
 % Cut / negation / forall coverage (M17 get_level/cut path). Mirrors the
 % C++ and Go cut suites: a cut inside a called predicate under \+, a cut
@@ -99,7 +100,6 @@ user:lcut_partial :- \+ lcut_plen([a,b|_], _).          % partial list rejected 
 user:lcut_inline :- \+ (lcut_gen(_), !, fail).          % inline cut in negation -> true
 user:lcut_forall_neg :- \+ forall(lcut_gen(X), X =:= 1). % not all satisfy -> \+ true
 user:lcut_forall_pass :- forall(lcut_gen(X), X >= 1).    % all satisfy -> true
-user:wam_lua_greet(X, goodbye) :- X = moon.
 user:wam_lua_fa_greet :-
     findall(X, user:wam_lua_greet(X, hello), L),
     L = [world].

--- a/tests/test_wam_target.pl
+++ b/tests/test_wam_target.pl
@@ -6,7 +6,8 @@
 :- use_module('../src/unifyweaver/targets/wam_text_parser', [wam_text_to_items/2]).
 
 %% Test data (facts) - MUST BE DYNAMIC for clause/2 to work across modules
-:- dynamic test_parent/2, test_grandparent/2, test_ancestor/2, test_wrap/2, test_alias/2.
+:- dynamic test_parent/2, test_grandparent/2, test_ancestor/2, test_wrap/2,
+           test_alias/2, test_len/2.
 
 test_parent(alice, bob).
 test_parent(bob, charlie).
@@ -16,6 +17,9 @@ test_grandparent(X, Z) :- test_parent(X, Y), test_parent(Y, Z).
 
 %% Simple forwarding rule — exercises native items for a one-goal tail call.
 test_alias(X, Y) :- test_parent(X, Y).
+
+%% Simple builtin rule — exercises native items for generic builtin_call.
+test_len(L, N) :- length(L, N).
 
 %% Recursive ancestor rule
 test_ancestor(X, Y) :- test_parent(X, Y).
@@ -356,18 +360,64 @@ test_wam_items_native_simple_tail_call :-
     ;   fail_test(Test, 'Native simple-tail-call items do not match canonical WAM text shape')
     ).
 
-test_wam_items_api_rule_fallback :-
-    Test = 'WAM: items API rule fallback',
+test_wam_items_native_multi_goal_rule :-
+    Test = 'WAM: native items API for simple multi-goal rule',
+    ExpectedItems = [
+        label("test_grandparent/2"),
+        allocate,
+        get_variable("X3", "A1"),
+        get_variable("Y2", "A2"),
+        put_value("X3", "A1"),
+        put_variable("Y1", "A2"),
+        call("test_parent/2", "2"),
+        put_value("Y1", "A1"),
+        put_value("Y2", "A2"),
+        deallocate,
+        execute("test_parent/2")
+    ],
     (   wam_target:compile_predicate_to_wam(user:test_grandparent/2, [], LegacyCode),
         wam_target:compile_predicate_to_wam_text(user:test_grandparent/2, [], TextCode),
         wam_target:compile_predicate_to_wam_items(user:test_grandparent/2, [], Items),
         LegacyCode == TextCode,
+        Items == ExpectedItems,
+        wam_text_to_items(TextCode, Items),
         member(label("test_grandparent/2"), Items),
         member(allocate, Items),
         member(call("test_parent/2", "2"), Items),
         member(execute("test_parent/2"), Items)
     ->  pass(Test)
     ;   fail_test(Test, 'Explicit text/items APIs do not match legacy WAM output')
+    ).
+
+test_wam_items_native_simple_builtin :-
+    Test = 'WAM: native items API for simple builtin call',
+    ExpectedItems = [
+        label("test_len/2"),
+        get_variable("X1", "A1"),
+        get_variable("X2", "A2"),
+        put_value("X1", "A1"),
+        put_value("X2", "A2"),
+        builtin_call("length/2", "2"),
+        proceed
+    ],
+    (   wam_target:compile_predicate_to_wam_text(user:test_len/2, [], TextCode),
+        wam_text_to_items(TextCode, BridgeItems),
+        wam_target:compile_predicate_to_wam_items(user:test_len/2, [], Items),
+        Items == ExpectedItems,
+        Items == BridgeItems
+    ->  pass(Test)
+    ;   fail_test(Test, 'Native simple-builtin items do not match canonical WAM text shape')
+    ).
+
+test_wam_items_api_compound_arg_fallback :-
+    Test = 'WAM: items API compound body arg fallback',
+    (   wam_target:compile_predicate_to_wam_text(user:test_wrap/1, [], TextCode),
+        wam_text_to_items(TextCode, BridgeItems),
+        wam_target:compile_predicate_to_wam_items(user:test_wrap/1, [], Items),
+        Items == BridgeItems,
+        member(put_structure("pair/2", "A1"), Items)
+    ->  pass(Test)
+    ;   fail_test(Test, 'Compound body arg fallback does not match canonical WAM text shape')
     ).
 
 %% Run all tests
@@ -385,7 +435,9 @@ run_tests :-
     test_wam_module,
     test_wam_items_native_single_fact,
     test_wam_items_native_simple_tail_call,
-    test_wam_items_api_rule_fallback,
+    test_wam_items_native_multi_goal_rule,
+    test_wam_items_native_simple_builtin,
+    test_wam_items_api_compound_arg_fallback,
     test_wam_multi_clause_findall_emits_allocate,
     test_wam_a2_indexing,
     test_wam_mixed_mode_a1_indexing,


### PR DESCRIPTION
## Summary

- expand `compile_predicate_to_wam_items/3` native emission beyond facts and simple tail calls
- emit structured WAM items directly for simple user calls, generic builtin calls, and conjunctions of those simple shapes
- keep complex predicates on the existing WAM text plus `wam_text_to_items/2` fallback path
- document the broader native coverage and remaining fallback boundaries
- reorder one Lua test fixture to remove a discontiguous warning without suppressing it

## Notes

This remains an incremental items-first migration. The direct native path intentionally excludes multi-clause predicates, aggregates, indexing, lowered builtins, control flow, compound body arguments, visited-set rewrites, and other peephole-sensitive shapes. Those still use the compatibility bridge.

## Tests

- `swipl -q -f tests/test_wam_target.pl`
- `swipl -q -f tests/test_wam_ir_mode.pl`
- `swipl -q -f tests/test_wam_text_parser.pl -g run_tests -t halt`
- `swipl -q -f tests/test_wam_python_target.pl`
- `swipl -q -f tests/test_wam_lua_generator.pl`
- `swipl -q -f tests/test_wam_elixir_target.pl`
- `swipl -q -f tests/test_wam_r_generator.pl`
- `git diff --check`
