### PR TITLE
Add PLAWK numeric field value updates

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -267,6 +267,10 @@ case mapping streams bytes without allocating a transformed atom.
 Numeric field guards such as `$3 > 100` lower through the shared
 `@wam_atom_field_i64_cmp_value` helper, which parses the projected field slice
 as a strict signed decimal `i64` and compares with numeric op codes.
+The parser itself is factored as `@wam_atom_field_i64_value`, returning a value
+plus success flag, so the same machinery also feeds scalar expressions such as
+`bytes += $3` and `last = $3`; PLAWK uses zero for failed numeric coercions in
+those scalar arithmetic contexts.
 The scalar counter
 path threads a native `i64` loop variable and prints it from the `END` action. Multiple scalar counters
 become parallel `i64` phi slots in the native streaming loop.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -92,10 +92,12 @@ compile to indexed native slots, e.g. `{ errors++; matches++ }`, and multiple
 guarded rules can update shared scalar slots before an `END` print. Scalar slots
 also support native `+=` with integer constants and field lengths, e.g.
 `$1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }`.
+They also support numeric field expressions through the same shared field parser,
+e.g. `$1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }`.
 Plain scalar assignment uses the same native slot path and preserves source
 order with later updates, e.g. `$1 == "ERROR" { last_len = length($0); hits++ }
 END { print hits, last_len }`. The current assignment expression subset is
-integer literals and `length($N)`.
+integer literals, `length($N)`, and numeric `$N`.
 Scalar slot updates can also sit behind native `if/else` guards, e.g.
 `{ if ($1 == "ERROR") { errors++; last_len = length($0) } else { non_errors++ } }
 END { print errors, non_errors, last_len }`. The first branch slice supports

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -233,6 +233,14 @@ $1 == "ERROR" { bytes += length($0); hits += 2 }
 END { print bytes, hits }
 ```
 
+They can also accumulate numeric fields. The field parser is strict, but scalar
+arithmetic uses zero when a field is missing or non-numeric:
+
+```awk
+$1 == "ERROR" { bytes += $3; last = $3 }
+END { print bytes, last }
+```
+
 They can also be assigned in the native loop. Assignment preserves source order
 with later updates:
 
@@ -241,7 +249,8 @@ $1 == "ERROR" { last_len = length($0); hits++ }
 END { print hits, last_len }
 ```
 
-The current assignment expression subset is integer literals and `length($N)`.
+The current assignment expression subset is integer literals, `length($N)`, and
+numeric `$N`.
 
 Numeric field guards are also native:
 

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -14,6 +14,7 @@
      llvm_emit_atom_field_subslice/7,
      llvm_emit_atom_field_index/7,
      llvm_emit_atom_field_i64_cmp_guard/7,
+     llvm_emit_atom_field_i64/5,
      llvm_emit_c_string_global/5,
      llvm_emit_printf_i64/5,
      llvm_emit_printf_slice/6,
@@ -41,6 +42,7 @@
 %      BEGIN { FS = ":" } $1 == "ERROR" { counts[$2]++ } END { print counts["disk"] }
 %      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
 %      $3 > 100 { big++ } END { print big }
+%      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
 %      $1 == "ERROR" { last_len = length($0); hits++ } END { print hits, last_len }
@@ -1318,10 +1320,14 @@ plawk_scalar_action_update(add(var(Name), int(Value)), Name, add(const(Value))) 
     Value >= 0.
 plawk_scalar_action_update(add(var(Name), length(field(FieldIndex))), Name, add(length(FieldIndex))) :-
     FieldIndex >= 0.
+plawk_scalar_action_update(add(var(Name), field(FieldIndex)), Name, add(field_i64(FieldIndex))) :-
+    FieldIndex >= 0.
 plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) :-
     integer(Value),
     Value >= 0.
 plawk_scalar_action_update(set(var(Name), length(field(FieldIndex))), Name, set(length(FieldIndex))) :-
+    FieldIndex >= 0.
+plawk_scalar_action_update(set(var(Name), field(FieldIndex)), Name, set(field_i64(FieldIndex))) :-
     FieldIndex >= 0.
 
 plawk_scalar_action_sequence_pairs([], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
@@ -1430,6 +1436,16 @@ plawk_scalar_update_operation_ir(add(length(FieldIndex)), FieldSeparator, Prefix
     format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
     format(atom(AddLine), '  ~w = add i64 ~w, %~w', [NextValue, InputValue, LengthBase]),
     format(atom(IR), '~w~n~w', [LengthCall, AddLine]).
+plawk_scalar_update_operation_ir(add(field_i64(FieldIndex)), FieldSeparator, Prefix, SlotIndex,
+        OpIndex, InputValue, NextValue, ''-IR) :-
+    format(atom(ParseBase), '~w_slot_~w_op_~w_field_i64', [Prefix, SlotIndex, OpIndex]),
+    llvm_emit_atom_field_i64('%line', FieldIndex, FieldSeparator, ParseBase, ParseCall),
+    format(atom(DeltaValue), '%~w_delta', [ParseBase]),
+    format(atom(DeltaLine), '  ~w = select i1 %~w_ok, i64 %~w_value, i64 0',
+        [DeltaValue, ParseBase, ParseBase]),
+    format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
+    format(atom(AddLine), '  ~w = add i64 ~w, ~w', [NextValue, InputValue, DeltaValue]),
+    format(atom(IR), '~w~n~w~n~w', [ParseCall, DeltaLine, AddLine]).
 plawk_scalar_update_operation_ir(set(const(Value)), _FieldSeparator, Prefix, SlotIndex,
         OpIndex, _InputValue, NextValue, ''-Line) :-
     format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
@@ -1441,6 +1457,14 @@ plawk_scalar_update_operation_ir(set(length(FieldIndex)), FieldSeparator, Prefix
     format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
     format(atom(SetLine), '  ~w = add i64 %~w, 0', [NextValue, LengthBase]),
     format(atom(IR), '~w~n~w', [LengthCall, SetLine]).
+plawk_scalar_update_operation_ir(set(field_i64(FieldIndex)), FieldSeparator, Prefix, SlotIndex,
+        OpIndex, _InputValue, NextValue, ''-IR) :-
+    format(atom(ParseBase), '~w_slot_~w_op_~w_field_i64', [Prefix, SlotIndex, OpIndex]),
+    llvm_emit_atom_field_i64('%line', FieldIndex, FieldSeparator, ParseBase, ParseCall),
+    format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
+    format(atom(SetLine), '  ~w = select i1 %~w_ok, i64 %~w_value, i64 0',
+        [NextValue, ParseBase, ParseBase]),
+    format(atom(IR), '~w~n~w', [ParseCall, SetLine]).
 
 plawk_branch_to_done_ir(none, _DoneLabel, '  br label %continue_loop') :-
     !.

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -21,6 +21,7 @@
 %      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
 %      { count++ } END { print "count", count }
 %      $3 > 100 { big++ } END { print big }
+%      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %      $1 == "DEBUG" { skipped++; next } { total++ } END { print total, skipped }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
@@ -349,6 +350,13 @@ scalar_delta_expr(int(Value)) -->
     { ValueCodes \== [],
       number_codes(Value, ValueCodes),
       Value >= 0 }.
+scalar_delta_expr(field(Index)) -->
+    "$",
+    integer_codes(IndexCodes),
+    { IndexCodes \== [],
+      number_codes(Index, IndexCodes),
+      Index >= 0
+    }.
 scalar_delta_expr(length(Field)) -->
     "length",
     ws,

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -53,6 +53,7 @@
     llvm_emit_atom_field_subslice/7,     % +ValueIR, +FieldIndex, +SepCode, +Start, +Len, +SliceBase, -CallIR
     llvm_emit_atom_field_index/7,        % +GlobalBase, +ValueIR, +FieldIndex, +Needle, +SepCode, +IndexBase, -GlobalIR-CallIR
     llvm_emit_atom_field_i64_cmp_guard/7,% +ValueIR, +FieldIndex, +OpCode, +Expected, +SepCode, +ResultIR, -CallIR
+    llvm_emit_atom_field_i64/5,          % +ValueIR, +FieldIndex, +SepCode, +ParseBase, -CallIR
     llvm_emit_c_string_global/5,         % +GlobalName, +Value, -GlobalIR, -StringLen, -BytesLen
     llvm_emit_printf_i64/5,              % +FmtGlobal, +FmtVar, +PrintVar, +ValueIR, -Parts
     llvm_emit_printf_slice/6,            % +FmtGlobal, +FmtVar, +PrintVar, +LenIR, +PtrIR, -Parts
@@ -5156,8 +5157,10 @@ afi.zero:
   ret i64 0
 }
 
-define i1 @wam_slice_i64_cmp_value(i8* %source_ptr, i64 %source_len, i64 %expected, i32 %op) {
+define %WamI64Parse @wam_slice_i64_parse_value(i8* %source_ptr, i64 %source_len) {
 entry:
+  %si64.no0 = insertvalue %WamI64Parse undef, i64 0, 0
+  %si64.no_value = insertvalue %WamI64Parse %si64.no0, i1 false, 1
   %si64.null = icmp eq i8* %source_ptr, null
   br i1 %si64.null, label %si64.no, label %si64.check_len
 
@@ -5179,7 +5182,7 @@ si64.loop:
   %si64.pos = phi i64 [ %si64.start, %si64.first ], [ %si64.next_pos, %si64.digit_step ]
   %si64.acc = phi i64 [ 0, %si64.first ], [ %si64.next_acc, %si64.digit_step ]
   %si64.done = icmp uge i64 %si64.pos, %source_len
-  br i1 %si64.done, label %si64.compare, label %si64.read_digit
+  br i1 %si64.done, label %si64.yes, label %si64.read_digit
 
 si64.read_digit:
   %si64.ch_ptr = getelementptr i8, i8* %source_ptr, i64 %si64.pos
@@ -5197,40 +5200,26 @@ si64.digit_step:
   %si64.next_pos = add i64 %si64.pos, 1
   br label %si64.loop
 
-si64.compare:
+si64.yes:
   %si64.value = mul i64 %si64.acc, %si64.sign
-  switch i32 %op, label %si64.no [
-    i32 0, label %si64.cmp_eq
-    i32 1, label %si64.cmp_ne
-    i32 2, label %si64.cmp_lt
-    i32 3, label %si64.cmp_le
-    i32 4, label %si64.cmp_gt
-    i32 5, label %si64.cmp_ge
-  ]
+  %si64.yes0 = insertvalue %WamI64Parse undef, i64 %si64.value, 0
+  %si64.yes_value = insertvalue %WamI64Parse %si64.yes0, i1 true, 1
+  ret %WamI64Parse %si64.yes_value
 
-si64.cmp_eq:
-  %si64.eq = icmp eq i64 %si64.value, %expected
-  br i1 %si64.eq, label %si64.yes, label %si64.no
+si64.no:
+  ret %WamI64Parse %si64.no_value
+}
 
-si64.cmp_ne:
-  %si64.ne = icmp ne i64 %si64.value, %expected
-  br i1 %si64.ne, label %si64.yes, label %si64.no
+define i1 @wam_slice_i64_cmp_value(i8* %source_ptr, i64 %source_len, i64 %expected, i32 %op) {
+entry:
+  %si64.cmp.parse = call %WamI64Parse @wam_slice_i64_parse_value(i8* %source_ptr, i64 %source_len)
+  %si64.cmp.value = extractvalue %WamI64Parse %si64.cmp.parse, 0
+  %si64.cmp.ok = extractvalue %WamI64Parse %si64.cmp.parse, 1
+  br i1 %si64.cmp.ok, label %si64.compare, label %si64.no
 
-si64.cmp_lt:
-  %si64.lt = icmp slt i64 %si64.value, %expected
-  br i1 %si64.lt, label %si64.yes, label %si64.no
-
-si64.cmp_le:
-  %si64.le = icmp sle i64 %si64.value, %expected
-  br i1 %si64.le, label %si64.yes, label %si64.no
-
-si64.cmp_gt:
-  %si64.gt = icmp sgt i64 %si64.value, %expected
-  br i1 %si64.gt, label %si64.yes, label %si64.no
-
-si64.cmp_ge:
-  %si64.ge = icmp sge i64 %si64.value, %expected
-  br i1 %si64.ge, label %si64.yes, label %si64.no
+si64.compare:
+  %si64.cmp.result = call i1 @wam_i64_cmp_value(i64 %si64.cmp.value, i64 %expected, i32 %op)
+  br i1 %si64.cmp.result, label %si64.yes, label %si64.no
 
 si64.yes:
   ret i1 true
@@ -5239,41 +5228,103 @@ si64.no:
   ret i1 false
 }
 
+define i1 @wam_i64_cmp_value(i64 %value, i64 %expected, i32 %op) {
+entry:
+  switch i32 %op, label %cmp.no [
+    i32 0, label %cmp.eq
+    i32 1, label %cmp.ne
+    i32 2, label %cmp.lt
+    i32 3, label %cmp.le
+    i32 4, label %cmp.gt
+    i32 5, label %cmp.ge
+  ]
+
+cmp.eq:
+  %cmp.eq_result = icmp eq i64 %value, %expected
+  br i1 %cmp.eq_result, label %cmp.yes, label %cmp.no
+
+cmp.ne:
+  %cmp.ne_result = icmp ne i64 %value, %expected
+  br i1 %cmp.ne_result, label %cmp.yes, label %cmp.no
+
+cmp.lt:
+  %cmp.lt_result = icmp slt i64 %value, %expected
+  br i1 %cmp.lt_result, label %cmp.yes, label %cmp.no
+
+cmp.le:
+  %cmp.le_result = icmp sle i64 %value, %expected
+  br i1 %cmp.le_result, label %cmp.yes, label %cmp.no
+
+cmp.gt:
+  %cmp.gt_result = icmp sgt i64 %value, %expected
+  br i1 %cmp.gt_result, label %cmp.yes, label %cmp.no
+
+cmp.ge:
+  %cmp.ge_result = icmp sge i64 %value, %expected
+  br i1 %cmp.ge_result, label %cmp.yes, label %cmp.no
+
+cmp.yes:
+  ret i1 true
+
+cmp.no:
+  ret i1 false
+}
+
+define %WamI64Parse @wam_atom_field_i64_value(%Value %atom_value, i64 %field_index, i8 %sep) {
+entry:
+  %afv.no0 = insertvalue %WamI64Parse undef, i64 0, 0
+  %afv.no_value = insertvalue %WamI64Parse %afv.no0, i1 false, 1
+  %afv.whole = icmp eq i64 %field_index, 0
+  br i1 %afv.whole, label %afv.whole_record, label %afv.field
+
+afv.whole_record:
+  %afv.t = call i32 @value_tag(%Value %atom_value)
+  %afv.is_atom = icmp eq i32 %afv.t, 0
+  br i1 %afv.is_atom, label %afv.lookup, label %afv.no
+
+afv.lookup:
+  %afv.aid = call i64 @value_payload(%Value %atom_value)
+  %afv.str = call i8* @wam_atom_to_string(i64 %afv.aid)
+  %afv.null = icmp eq i8* %afv.str, null
+  br i1 %afv.null, label %afv.no, label %afv.measure
+
+afv.measure:
+  %afv.len = call i64 @strlen(i8* %afv.str)
+  %afv.whole_value = call %WamI64Parse @wam_slice_i64_parse_value(i8* %afv.str, i64 %afv.len)
+  ret %WamI64Parse %afv.whole_value
+
+afv.field:
+  %afv.index_ok = icmp sgt i64 %field_index, 0
+  br i1 %afv.index_ok, label %afv.field_slice, label %afv.no
+
+afv.field_slice:
+  %afv.source = call %WamSlice @wam_atom_field_slice_value(%Value %atom_value, i64 %field_index, i8 %sep)
+  %afv.source_ptr = extractvalue %WamSlice %afv.source, 0
+  %afv.source_len = extractvalue %WamSlice %afv.source, 1
+  %afv.source_has_ptr = icmp ne i8* %afv.source_ptr, null
+  br i1 %afv.source_has_ptr, label %afv.parse, label %afv.no
+
+afv.parse:
+  %afv.field_value = call %WamI64Parse @wam_slice_i64_parse_value(i8* %afv.source_ptr, i64 %afv.source_len)
+  ret %WamI64Parse %afv.field_value
+
+afv.no:
+  ret %WamI64Parse %afv.no_value
+}
+
 define i1 @wam_atom_field_i64_cmp_value(%Value %atom_value, i64 %field_index, i8 %sep, i64 %expected, i32 %op) {
 entry:
-  %afc.whole = icmp eq i64 %field_index, 0
-  br i1 %afc.whole, label %afc.whole_record, label %afc.field
-
-afc.whole_record:
-  %afc.t = call i32 @value_tag(%Value %atom_value)
-  %afc.is_atom = icmp eq i32 %afc.t, 0
-  br i1 %afc.is_atom, label %afc.lookup, label %afc.no
-
-afc.lookup:
-  %afc.aid = call i64 @value_payload(%Value %atom_value)
-  %afc.str = call i8* @wam_atom_to_string(i64 %afc.aid)
-  %afc.null = icmp eq i8* %afc.str, null
-  br i1 %afc.null, label %afc.no, label %afc.measure
-
-afc.measure:
-  %afc.len = call i64 @strlen(i8* %afc.str)
-  %afc.whole_ok = call i1 @wam_slice_i64_cmp_value(i8* %afc.str, i64 %afc.len, i64 %expected, i32 %op)
-  ret i1 %afc.whole_ok
-
-afc.field:
-  %afc.index_ok = icmp sgt i64 %field_index, 0
-  br i1 %afc.index_ok, label %afc.field_slice, label %afc.no
-
-afc.field_slice:
-  %afc.source = call %WamSlice @wam_atom_field_slice_value(%Value %atom_value, i64 %field_index, i8 %sep)
-  %afc.source_ptr = extractvalue %WamSlice %afc.source, 0
-  %afc.source_len = extractvalue %WamSlice %afc.source, 1
-  %afc.source_has_ptr = icmp ne i8* %afc.source_ptr, null
-  br i1 %afc.source_has_ptr, label %afc.compare, label %afc.no
+  %afc.parse = call %WamI64Parse @wam_atom_field_i64_value(%Value %atom_value, i64 %field_index, i8 %sep)
+  %afc.value = extractvalue %WamI64Parse %afc.parse, 0
+  %afc.ok = extractvalue %WamI64Parse %afc.parse, 1
+  br i1 %afc.ok, label %afc.compare, label %afc.no
 
 afc.compare:
-  %afc.field_ok = call i1 @wam_slice_i64_cmp_value(i8* %afc.source_ptr, i64 %afc.source_len, i64 %expected, i32 %op)
-  ret i1 %afc.field_ok
+  %afc.result = call i1 @wam_i64_cmp_value(i64 %afc.value, i64 %expected, i32 %op)
+  br i1 %afc.result, label %afc.yes, label %afc.no
+
+afc.yes:
+  ret i1 true
 
 afc.no:
   ret i1 false
@@ -16832,6 +16883,19 @@ llvm_emit_atom_field_i64_cmp_guard(ValueIR, FieldIndex, OpCode, Expected, SepCod
     format(atom(CallIR),
         '  ~w = call i1 @wam_atom_field_i64_cmp_value(%Value ~w, i64 ~w, i8 ~w, i64 ~w, i32 ~w)',
         [ResultIR, ValueIR, FieldIndex, SepCode, Expected, OpCode]).
+
+%% llvm_emit_atom_field_i64(+ValueIR, +FieldIndex, +SepCode, +ParseBase, -CallIR)
+%
+%  Emit a native signed-decimal i64 parse over an atom-backed text record.
+%  Field 0 parses the whole record; positive fields parse the projected field
+%  slice. CallIR defines %ParseBase, %ParseBase_value, and %ParseBase_ok.
+llvm_emit_atom_field_i64(ValueIR, FieldIndex, SepCode, ParseBase, CallIR) :-
+    integer(FieldIndex),
+    format(atom(CallIR),
+        '  %~w = call %WamI64Parse @wam_atom_field_i64_value(%Value ~w, i64 ~w, i8 ~w)~n  %~w_value = extractvalue %WamI64Parse %~w, 0~n  %~w_ok = extractvalue %WamI64Parse %~w, 1',
+        [ParseBase, ValueIR, FieldIndex, SepCode,
+         ParseBase, ParseBase,
+         ParseBase, ParseBase]).
 
 %% llvm_emit_c_string_global(+GlobalName, +Value, -GlobalIR, -StringLen, -BytesLen)
 %

--- a/templates/targets/llvm_wam/types.ll.mustache
+++ b/templates/targets/llvm_wam/types.ll.mustache
@@ -8,6 +8,7 @@
 
 ; === Byte slice ===
 %WamSlice = type { i8*, i64 }             ; pointer, length
+%WamI64Parse = type { i64, i1 }           ; parsed value, success flag
 
 ; === Compound and List (heap-allocated) ===
 %Compound = type { i8*, i32, %Value* }    ; functor, arity, args

--- a/templates/targets/llvm_wam_wasm/types.ll.mustache
+++ b/templates/targets/llvm_wam_wasm/types.ll.mustache
@@ -10,6 +10,7 @@
 
 ; === Byte slice ===
 %WamSlice = type { i8*, i64 }             ; pointer, length
+%WamI64Parse = type { i64, i1 }           ; parsed value, success flag
 
 ; === Compound and List (linear memory offsets) ===
 ; On wasm32, pointers are i32 offsets into linear memory

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -181,6 +181,12 @@ test(parses_field_eq_scalar_add_assign_end_print_rule) :-
         [add(var(bytes), length(field(0))), add(var(hits), int(2))])],
         [end([print([var(bytes), var(hits)])])])).
 
+test(parses_field_numeric_scalar_add_assign_end_print_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { bytes += $3; last = $3 } END { print bytes, last }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [add(var(bytes), field(3)), set(var(last), field(3))])],
+        [end([print([var(bytes), var(last)])])])).
+
 test(parses_always_scalar_add_assign_end_print_rule) :-
     plawk_parse_string("{ total += 3 } END { print total }\n", Program),
     assertion(Program == program([], [rule(always, [add(var(total), int(3))])],
@@ -478,6 +484,16 @@ test(surface_field_eq_scalar_add_assign_accumulates_constants_and_lengths) :-
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR network down\n",
         "33 4\n").
 
+test(surface_field_numeric_scalar_add_assign_accumulates_values) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { bytes += $3; last = $3 } END { print bytes, last }\n",
+        "INFO boot 7\nERROR disk 10\nWARN cpu 20\nERROR net -3\nERROR bad nope\n",
+        "7 0\n").
+
+test(surface_begin_field_separator_drives_numeric_scalar_values) :-
+    run_surface_print_smoke("BEGIN { FS = \":\" } $1 == \"ERROR\" { bytes += $3; last = $3 } END { print bytes, last }\n",
+        "INFO:boot:7\nERROR:disk:10\nWARN:cpu:20\nERROR:net:-3\nERROR:bad:nope\n",
+        "7 0\n").
+
 test(surface_always_scalar_add_assign_accumulates_constants) :-
     run_surface_print_smoke("{ total += 3 } END { print total }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -759,6 +775,17 @@ test(surface_scalar_add_assign_uses_native_state_and_field_length) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_0 = add i64 %slot_0, %rule_0_body_slot_0_op_0_len'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_1_op_1 = add i64 %slot_1, 2'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%next_slot_0 = phi i64'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_scalar_add_assign_uses_native_field_i64_parse) :-
+    plawk_parse_string("BEGIN { FS = \":\" } $1 == \"ERROR\" { bytes += $3; last = $3 } END { print bytes, last }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_i64_value(%Value %line, i64 3, i8 58)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_field_i64_value = extractvalue %WamI64Parse'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '_field_i64_ok = extractvalue %WamI64Parse'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'select i1 %rule_0_body_slot_0_op_0_field_i64_ok'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, 'select i1 %rule_0_body_slot_1_op_1_field_i64_ok'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -203,6 +203,9 @@ test(full_runtime_generation) :-
     assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamSlice @wam_atom_field_subslice_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_slice_index_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i64 @wam_atom_field_index_value')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamI64Parse @wam_slice_i64_parse_value')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define %WamI64Parse @wam_atom_field_i64_value')),
+    assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_i64_cmp_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_slice_i64_cmp_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define i1 @wam_atom_field_i64_cmp_value')),
     assertion(sub_atom(RuntimeCode, _, _, _, 'define void @wam_print_ascii_lower_slice')),
@@ -258,6 +261,12 @@ test(atom_field_index_emitter) :-
 test(atom_field_i64_cmp_guard_emitter) :-
     llvm_emit_atom_field_i64_cmp_guard('%line', 3, 4, 100, 32, '%ok', CallIR),
     assertion(CallIR == '  %ok = call i1 @wam_atom_field_i64_cmp_value(%Value %line, i64 3, i8 32, i64 100, i32 4)').
+
+test(atom_field_i64_emitter) :-
+    llvm_emit_atom_field_i64('%line', 3, 58, plawk_value, CallIR),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_value = call %WamI64Parse @wam_atom_field_i64_value(%Value %line, i64 3, i8 58)')),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_value_value = extractvalue %WamI64Parse %plawk_value, 0')),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_value_ok = extractvalue %WamI64Parse %plawk_value, 1')).
 
 test(ascii_case_slice_print_emitter) :-
     llvm_emit_ascii_case_slice_print(lower, '%ptr', '%len', plawk_lower, LowerIR),


### PR DESCRIPTION
## Summary
- factor WAM/LLVM numeric field parsing into reusable value+success helpers
- keep numeric comparisons on shared op-code comparison helpers
- add PLAWK `$N` numeric scalar expressions for `+=` and assignment
- document zero-on-failed-parse scalar coercion and cover configured `FS`

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`

Note: `tests/test_wam_llvm_target.pl` still reports pre-existing choicepoint warnings in older tests while passing.