### PR TITLE
Generalize PLAWK numeric scalar lowering

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -270,7 +270,10 @@ as a strict signed decimal `i64` and compares with numeric op codes.
 The parser itself is factored as `@wam_atom_field_i64_value`, returning a value
 plus success flag, so the same machinery also feeds scalar expressions such as
 `bytes += $3` and `last = $3`; PLAWK uses zero for failed numeric coercions in
-those scalar arithmetic contexts.
+those scalar arithmetic contexts. That coercion is emitted through the
+target-side `llvm_emit_atom_field_i64_or_default/7` helper so future native
+numeric consumers can share the parse-plus-default lowering instead of
+rebuilding it in PLAWK-specific code.
 The scalar counter
 path threads a native `i64` loop variable and prints it from the `END` action. Multiple scalar counters
 become parallel `i64` phi slots in the native streaming loop.

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -14,7 +14,7 @@
      llvm_emit_atom_field_subslice/7,
      llvm_emit_atom_field_index/7,
      llvm_emit_atom_field_i64_cmp_guard/7,
-     llvm_emit_atom_field_i64/5,
+     llvm_emit_atom_field_i64_or_default/7,
      llvm_emit_c_string_global/5,
      llvm_emit_printf_i64/5,
      llvm_emit_printf_slice/6,
@@ -1425,46 +1425,38 @@ plawk_scalar_action_sequence_pairs([if(Pattern, ThenActions, ElseActions) | Rest
         NextOpIndex, Values1, Values, FinalOpIndex, ExitLabel, RestNextExits),
     { append(BranchNextExits, RestNextExits, NextExits) }.
 
-plawk_scalar_update_operation_ir(add(const(Value)), _FieldSeparator, Prefix, SlotIndex,
-        OpIndex, InputValue, NextValue, ''-Line) :-
-    format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
-    format(atom(Line), '  ~w = add i64 ~w, ~w', [NextValue, InputValue, Value]).
-plawk_scalar_update_operation_ir(add(length(FieldIndex)), FieldSeparator, Prefix, SlotIndex,
+plawk_scalar_update_operation_ir(add(Expr), FieldSeparator, Prefix, SlotIndex,
         OpIndex, InputValue, NextValue, ''-IR) :-
-    format(atom(LengthBase), '~w_slot_~w_op_~w_len', [Prefix, SlotIndex, OpIndex]),
-    llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, LengthCall),
+    plawk_scalar_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
+        OpIndex, ValueIR, SetupIR),
     format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
-    format(atom(AddLine), '  ~w = add i64 ~w, %~w', [NextValue, InputValue, LengthBase]),
-    format(atom(IR), '~w~n~w', [LengthCall, AddLine]).
-plawk_scalar_update_operation_ir(add(field_i64(FieldIndex)), FieldSeparator, Prefix, SlotIndex,
-        OpIndex, InputValue, NextValue, ''-IR) :-
-    format(atom(ParseBase), '~w_slot_~w_op_~w_field_i64', [Prefix, SlotIndex, OpIndex]),
-    llvm_emit_atom_field_i64('%line', FieldIndex, FieldSeparator, ParseBase, ParseCall),
-    format(atom(DeltaValue), '%~w_delta', [ParseBase]),
-    format(atom(DeltaLine), '  ~w = select i1 %~w_ok, i64 %~w_value, i64 0',
-        [DeltaValue, ParseBase, ParseBase]),
-    format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
-    format(atom(AddLine), '  ~w = add i64 ~w, ~w', [NextValue, InputValue, DeltaValue]),
-    format(atom(IR), '~w~n~w~n~w', [ParseCall, DeltaLine, AddLine]).
-plawk_scalar_update_operation_ir(set(const(Value)), _FieldSeparator, Prefix, SlotIndex,
-        OpIndex, _InputValue, NextValue, ''-Line) :-
-    format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
-    format(atom(Line), '  ~w = add i64 0, ~w', [NextValue, Value]).
-plawk_scalar_update_operation_ir(set(length(FieldIndex)), FieldSeparator, Prefix, SlotIndex,
+    format(atom(AddLine), '  ~w = add i64 ~w, ~w',
+        [NextValue, InputValue, ValueIR]),
+    plawk_join_nonempty_ir([SetupIR, AddLine], IR).
+plawk_scalar_update_operation_ir(set(Expr), FieldSeparator, Prefix, SlotIndex,
         OpIndex, _InputValue, NextValue, ''-IR) :-
+    plawk_scalar_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
+        OpIndex, ValueIR, SetupIR),
+    format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
+    format(atom(SetLine), '  ~w = add i64 0, ~w', [NextValue, ValueIR]),
+    plawk_join_nonempty_ir([SetupIR, SetLine], IR).
+
+plawk_scalar_numeric_expr_ir(const(Value), _FieldSeparator, _Prefix, _SlotIndex,
+        _OpIndex, ValueIR, '') :-
+    integer(Value),
+    format(atom(ValueIR), '~w', [Value]).
+plawk_scalar_numeric_expr_ir(length(FieldIndex), FieldSeparator, Prefix, SlotIndex,
+        OpIndex, ValueIR, IR) :-
     format(atom(LengthBase), '~w_slot_~w_op_~w_len', [Prefix, SlotIndex, OpIndex]),
-    llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, LengthCall),
-    format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
-    format(atom(SetLine), '  ~w = add i64 %~w, 0', [NextValue, LengthBase]),
-    format(atom(IR), '~w~n~w', [LengthCall, SetLine]).
-plawk_scalar_update_operation_ir(set(field_i64(FieldIndex)), FieldSeparator, Prefix, SlotIndex,
-        OpIndex, _InputValue, NextValue, ''-IR) :-
-    format(atom(ParseBase), '~w_slot_~w_op_~w_field_i64', [Prefix, SlotIndex, OpIndex]),
-    llvm_emit_atom_field_i64('%line', FieldIndex, FieldSeparator, ParseBase, ParseCall),
-    format(atom(NextValue), '%~w_slot_~w_op_~w', [Prefix, SlotIndex, OpIndex]),
-    format(atom(SetLine), '  ~w = select i1 %~w_ok, i64 %~w_value, i64 0',
-        [NextValue, ParseBase, ParseBase]),
-    format(atom(IR), '~w~n~w', [ParseCall, SetLine]).
+    llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, IR),
+    format(atom(ValueIR), '%~w', [LengthBase]).
+plawk_scalar_numeric_expr_ir(field_i64(FieldIndex), FieldSeparator, Prefix, SlotIndex,
+        OpIndex, ValueIR, IR) :-
+    format(atom(ParseBase), '~w_slot_~w_op_~w_field_i64',
+        [Prefix, SlotIndex, OpIndex]),
+    format(atom(ValueIR), '%~w_value_or_default', [ParseBase]),
+    llvm_emit_atom_field_i64_or_default('%line', FieldIndex, FieldSeparator, 0,
+        ParseBase, ValueIR, IR).
 
 plawk_branch_to_done_ir(none, _DoneLabel, '  br label %continue_loop') :-
     !.

--- a/src/unifyweaver/targets/wam_llvm_target.pl
+++ b/src/unifyweaver/targets/wam_llvm_target.pl
@@ -54,6 +54,7 @@
     llvm_emit_atom_field_index/7,        % +GlobalBase, +ValueIR, +FieldIndex, +Needle, +SepCode, +IndexBase, -GlobalIR-CallIR
     llvm_emit_atom_field_i64_cmp_guard/7,% +ValueIR, +FieldIndex, +OpCode, +Expected, +SepCode, +ResultIR, -CallIR
     llvm_emit_atom_field_i64/5,          % +ValueIR, +FieldIndex, +SepCode, +ParseBase, -CallIR
+    llvm_emit_atom_field_i64_or_default/7,% +ValueIR, +FieldIndex, +SepCode, +DefaultValue, +ParseBase, +ResultIR, -CallIR
     llvm_emit_c_string_global/5,         % +GlobalName, +Value, -GlobalIR, -StringLen, -BytesLen
     llvm_emit_printf_i64/5,              % +FmtGlobal, +FmtVar, +PrintVar, +ValueIR, -Parts
     llvm_emit_printf_slice/6,            % +FmtGlobal, +FmtVar, +PrintVar, +LenIR, +PtrIR, -Parts
@@ -16896,6 +16897,21 @@ llvm_emit_atom_field_i64(ValueIR, FieldIndex, SepCode, ParseBase, CallIR) :-
         [ParseBase, ValueIR, FieldIndex, SepCode,
          ParseBase, ParseBase,
          ParseBase, ParseBase]).
+
+%% llvm_emit_atom_field_i64_or_default(+ValueIR, +FieldIndex, +SepCode, +DefaultValue, +ParseBase, +ResultIR, -CallIR)
+%
+%  Emit a native signed-decimal i64 parse and coerce failed parses to
+%  DefaultValue. This is useful for AWK-style numeric contexts while keeping the
+%  parse value/success pair reusable for stricter consumers.
+llvm_emit_atom_field_i64_or_default(ValueIR, FieldIndex, SepCode, DefaultValue,
+        ParseBase, ResultIR, CallIR) :-
+    integer(FieldIndex),
+    integer(DefaultValue),
+    llvm_emit_atom_field_i64(ValueIR, FieldIndex, SepCode, ParseBase, ParseIR),
+    format(atom(SelectIR),
+        '  ~w = select i1 %~w_ok, i64 %~w_value, i64 ~w',
+        [ResultIR, ParseBase, ParseBase, DefaultValue]),
+    format(atom(CallIR), '~w~n~w', [ParseIR, SelectIR]).
 
 %% llvm_emit_c_string_global(+GlobalName, +Value, -GlobalIR, -StringLen, -BytesLen)
 %

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -786,6 +786,8 @@ test(surface_scalar_add_assign_uses_native_field_i64_parse) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '_field_i64_ok = extractvalue %WamI64Parse'))),
     assertion(once(sub_atom(DriverIR, _, _, _, 'select i1 %rule_0_body_slot_0_op_0_field_i64_ok'))),
     assertion(once(sub_atom(DriverIR, _, _, _, 'select i1 %rule_0_body_slot_1_op_1_field_i64_ok'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_0 = add i64 %slot_0, %rule_0_body_slot_0_op_0_field_i64_value_or_default'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_1_op_1 = add i64 0, %rule_0_body_slot_1_op_1_field_i64_value_or_default'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 
@@ -793,7 +795,7 @@ test(surface_scalar_assignment_uses_ordered_native_state_ops) :-
     plawk_parse_string("$1 == \"ERROR\" { last_len = length($0); last_len += 2 } END { print last_len }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
     assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_0_len = call i64 @wam_atom_field_length_value(%Value %line, i64 0'))),
-    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_0 = add i64 %rule_0_body_slot_0_op_0_len, 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_0 = add i64 0, %rule_0_body_slot_0_op_0_len'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_1 = add i64 %rule_0_body_slot_0_op_0, 2'))),
     assertion(once(sub_atom(DriverIR, _, _, _, 'i64 %final_slot_0'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),

--- a/tests/test_wam_llvm_target.pl
+++ b/tests/test_wam_llvm_target.pl
@@ -268,6 +268,14 @@ test(atom_field_i64_emitter) :-
     assertion(sub_atom(CallIR, _, _, _, '%plawk_value_value = extractvalue %WamI64Parse %plawk_value, 0')),
     assertion(sub_atom(CallIR, _, _, _, '%plawk_value_ok = extractvalue %WamI64Parse %plawk_value, 1')).
 
+test(atom_field_i64_or_default_emitter) :-
+    llvm_emit_atom_field_i64_or_default('%line', 3, 58, 0, plawk_value,
+        '%plawk_number', CallIR),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_value = call %WamI64Parse @wam_atom_field_i64_value(%Value %line, i64 3, i8 58)')),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_value_value = extractvalue %WamI64Parse %plawk_value, 0')),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_value_ok = extractvalue %WamI64Parse %plawk_value, 1')),
+    assertion(sub_atom(CallIR, _, _, _, '%plawk_number = select i1 %plawk_value_ok, i64 %plawk_value_value, i64 0')).
+
 test(ascii_case_slice_print_emitter) :-
     llvm_emit_ascii_case_slice_print(lower, '%ptr', '%len', plawk_lower, LowerIR),
     llvm_emit_ascii_case_slice_print(upper, '%ptr', '%len', plawk_upper, UpperIR),


### PR DESCRIPTION
## Summary
- add a shared WAM/LLVM emitter for numeric field parse-with-default coercion
- route PLAWK scalar `+=` and assignment through one numeric-expression lowering helper
- keep existing numeric field semantics while reducing PLAWK-specific parse/select code
- document the target-side coercion helper and cover its emitted IR

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_wam_llvm_target.pl -g run_tests -t halt`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`

Note: `tests/test_wam_llvm_target.pl` still reports pre-existing choicepoint warnings in older tests while passing.