### PR TITLE
bench(wam-rust): cached-vs-lazy graph-search scaling sweep — cache win grows to 3.2x

### DIFF
--- a/docs/reports/wam_rust_cached_scaling_sweep_2026-06-14.md
+++ b/docs/reports/wam_rust_cached_scaling_sweep_2026-06-14.md
@@ -1,0 +1,63 @@
+# WAM-Rust Cached Graph-Search Scaling Sweep (2026-06-14)
+
+Follow-up to the cached runtime-attribution work
+(`wam_rust_cached_runtime_attribution_2026-06-14.md`, PRs #3127/#3140/#3151).
+That established the instrumentation and a 96.9% hit rate on a single fixture but
+explicitly was **not** a wall-clock result — the 10x fixture was too small for
+cold LMDB seeks to dominate. This sweep runs cached vs lazy across four fixture
+sizes to chart how the cache pays off as the graph grows, directly answering the
+open question from PR #3120 (the Python boundary-cache benchmark, where cached
+search was *slower*).
+
+## Method
+
+- One `cached` crate and one `lazy` (uncached, control) crate, built once
+  (fixture-independent; cache capacity overridden at runtime).
+- Each `data/benchmark/<fixture>` ingested to an `lmdb_resident` database via
+  `ingest_resident_lmdb_fixture.py`.
+- Single-threaded (`WAM_THREADS=1`) for deterministic attribution and a clean
+  cache-vs-no-cache comparison — the cache benefit measured here is lookup
+  avoidance, not parallelism. `query_ms` is the min over 3 reps.
+- Reproduce: `examples/benchmark/run_wam_rust_cached_scaling_sweep.sh`.
+
+## Result
+
+| fixture | edges | cached `query_ms` | hit rate | misses | inner LMDB ms | lazy `query_ms` | **speedup** |
+|---------|-------|-------------------|----------|--------|---------------|-----------------|-------------|
+| 300     |  6008 |  8 | 0.9819 |  888 | 0.48 |  18 | **2.25×** |
+| 1k      |  5933 | 10 | 0.9848 | 1010 | 0.60 |  25 | **2.50×** |
+| 5k      | 12981 | 39 | 0.9923 | 2254 | 1.64 | 113 | **2.90×** |
+| 10k     | 25227 | 88 | 0.9936 | 4493 | 3.86 | 279 | **3.17×** |
+
+`total_ms` tracks the same win once load is included — at 10k: cached 131 ms vs
+lazy 321 ms (~2.4× end-to-end; `load_ms` is ~15 ms for both).
+
+## Reading the numbers
+
+- **The cache is a clear wall-clock win, and it grows with graph size**
+  (2.25× → 3.17× on query time). This is the result the single-fixture report
+  could not show: at 6k edges the win is already 2.25×, and it widens as the
+  graph grows and cold LMDB seeks would otherwise dominate.
+- **This is the direct counter to PR #3120.** In the Python prototype, cached
+  search was *slower* (ratio 1.66) because residual traversal/interpreter
+  overhead swamped the cache savings. The compiled Rust kernel removes the
+  interpreter, so the 98–99% hit rate translates into real speedup instead of
+  being hidden.
+- **Hit rate rises with size** (98.2% → 99.4%): larger graphs route more seeds
+  through a denser set of shared root-near ancestors, so reuse increases.
+- **Inner LMDB time stays a small fraction** of query time (≤ 4 ms across ~4500
+  misses at 10k) — once warm, the cursor seeks are no longer the cost centre.
+- **Correctness:** for every fixture, cached output is identical to lazy output
+  (`c==l`), and matches the golden `reference_output.tsv` exactly on 300/1k/5k/10k.
+  (The 198-edge `dev` toy fixture is excluded: cached==lazy there too, but its
+  stored reference differs at ~1e-5 — a stale floating-point reference, not a
+  cache discrepancy.)
+
+## Caveats / next
+
+- Largest fixture here is 25k edges; the trend says the win keeps widening, so
+  an enwiki-scale `lmdb_resident` fixture (millions of edges, deep cones) should
+  amplify it further — the natural next measurement when such a fixture is
+  available.
+- Measured single-threaded to isolate the cache effect; the multi-threaded path
+  adds the T7 parallelism on top (orthogonal win).

--- a/examples/benchmark/run_wam_rust_cached_scaling_sweep.sh
+++ b/examples/benchmark/run_wam_rust_cached_scaling_sweep.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+#
+# run_wam_rust_cached_scaling_sweep.sh — cached-vs-lazy scaling sweep for the
+# WAM-Rust graph-search bench. Builds the cached and lazy crates ONCE (they are
+# fixture-independent; cache capacity is overridden at runtime), then for each
+# benchmark fixture ingests an lmdb_resident database and measures query time,
+# cache hit rate, and inner LMDB seek time. Prints one row per fixture.
+#
+# Single-threaded (WAM_THREADS=1) for deterministic attribution and a clean
+# cache-vs-no-cache comparison (the cache benefit is lookup avoidance, not
+# parallelism). Query time is the min over a few reps (least noisy).
+#
+# Usage:
+#   examples/benchmark/run_wam_rust_cached_scaling_sweep.sh [fixture ...]
+#     default fixtures: 300 1k 5k 10k (dirs under data/benchmark/)
+#
+# Requires: swipl, cargo, python3 with the `lmdb` package.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+export LC_ALL="${LC_ALL:-C.UTF-8}" LANG="${LANG:-C.UTF-8}"
+REPS="${REPS:-3}"
+CAP="${WAM_CACHE_CAPACITY:-400000}"
+FIXTURES=("$@")
+[ ${#FIXTURES[@]} -eq 0 ] && FIXTURES=(300 1k 5k 10k)
+
+echo "== building cached + lazy crates (once) =="
+declare -A BIN
+for mode in cached lazy; do
+    out="$WORK/crate_$mode"
+    swipl -q -s "$REPO_ROOT/examples/benchmark/generate_wam_rust_matrix_benchmark.pl" -- \
+        "$REPO_ROOT/examples/benchmark/effective_distance.pl" \
+        "$out" accumulated functions kernels_on cursor auto "$mode" 25227 >/dev/null 2>&1
+    ( cd "$out" && cargo build --release >/dev/null 2>&1 )
+    BIN[$mode]="$out/target/release/bench"
+done
+
+getv() { grep -oP "$2=\K[0-9.]+" "$1" | head -1; }
+min_query() { # <binary> <fixture-dir> -> min query_ms over REPS; leaves last run in $LASTLOG
+    local best=99999999
+    for _ in $(seq 1 "$REPS"); do
+        UW_WAM_CACHE_ATTRIBUTION=1 WAM_THREADS=1 WAM_CACHE_CAPACITY="$CAP" \
+            "$1" "$2" >/dev/null 2>"$LASTLOG"
+        local q; q=$(getv "$LASTLOG" query_ms); [ -z "$q" ] && q=99999999
+        awk "BEGIN{exit !($q<$best)}" && best=$q
+    done
+    echo "$best"
+}
+
+printf "\n%-6s %8s | %-9s %-8s | %-9s | %-7s %-10s %-10s | %s\n" \
+    fixture edges cached_ms hit_rate lazy_ms speedup lookups misses correct
+for fx in "${FIXTURES[@]}"; do
+    src="$REPO_ROOT/data/benchmark/$fx"
+    [ -f "$src/category_parent.tsv" ] || { echo "skip $fx (no fixture)"; continue; }
+    edges=$(( $(wc -l < "$src/category_parent.tsv") - 1 ))
+    fixdir="$WORK/fix_$fx"; mkdir -p "$fixdir"
+    python3 "$REPO_ROOT/examples/benchmark/ingest_resident_lmdb_fixture.py" \
+        "$src" "$fixdir/lmdb_resident" >/dev/null 2>&1
+    cp "$src/article_category.tsv" "$fixdir/"
+
+    LASTLOG="$WORK/c_$fx.log"; cms=$(min_query "${BIN[cached]}" "$fixdir")
+    hit=$(getv "$LASTLOG" cache_attr_hit_rate)
+    look=$(getv "$LASTLOG" cache_attr_lookups)
+    miss=$(getv "$LASTLOG" cache_attr_misses)
+    UW_WAM_CACHE_ATTRIBUTION=0 WAM_THREADS=1 "${BIN[cached]}" "$fixdir" >"$WORK/co_$fx.tsv" 2>/dev/null
+
+    LASTLOG="$WORK/l_$fx.log"; lms=$(min_query "${BIN[lazy]}" "$fixdir")
+    WAM_THREADS=1 "${BIN[lazy]}" "$fixdir" >"$WORK/lo_$fx.tsv" 2>/dev/null
+
+    speedup=$(awk "BEGIN{ if ($cms>0) printf \"%.2fx\", $lms/$cms; else print \"n/a\" }")
+    # Correctness invariant: caching must not change the answer.
+    if diff -q <(sort "$WORK/co_$fx.tsv") <(sort "$WORK/lo_$fx.tsv") >/dev/null; then ck="c==l"; else ck="c!=l!"; fi
+
+    printf "%-6s %8s | %-9s %-8s | %-9s | %-7s %-10s %-10s | %s\n" \
+        "$fx" "$edges" "$cms" "$hit" "$lms" "$speedup" "$look" "$miss" "$ck"
+done
+echo
+echo "work dir: $WORK"


### PR DESCRIPTION
## Summary

The wall-clock result the cached-attribution work was building toward. The single-fixture report (#3127/#3140/#3151) showed a 96.9% hit rate but was explicitly *not* a timing result — the 10x fixture was too small for cold LMDB seeks to dominate. This sweeps **cached vs lazy** across four fixture sizes and shows the cache delivers a real wall-clock speedup that **grows with the graph**, directly answering PR #3120 (the Python boundary-cache benchmark where cached was *slower*, ratio 1.66).

## Result (single-threaded, query time, min of 3 reps)

| fixture | edges | cached ms | hit rate | lazy ms | **speedup** |
|---|---|---|---|---|---|
| 300 | 6008 | 8 | 98.2% | 18 | **2.25×** |
| 1k | 5933 | 10 | 98.5% | 25 | **2.50×** |
| 5k | 12981 | 39 | 99.2% | 113 | **2.90×** |
| 10k | 25227 | 88 | 99.4% | 279 | **3.17×** |

`total_ms` tracks it too — at 10k: cached 131 ms vs lazy 321 ms (~2.4× end-to-end).

## Reading it

- **Clear, growing cache win.** The compiled Rust kernel removes the residual interpreter overhead that made cached *slower* in #3120's Python prototype, so the 98–99% hit rate becomes real speedup. The win widens with size (2.25× → 3.17×) as cold LMDB seeks would otherwise dominate.
- **Hit rate rises with size** (98.2% → 99.4%): more seeds route through a denser set of shared root-near ancestors.
- **Correctness:** cached output is identical to lazy (`c==l`) and matches the golden `reference_output.tsv` exactly on all four real fixtures. (`dev` toy fixture excluded — cached==lazy there too, but its stored reference differs at ~1e-5, a stale FP reference.)

## Changes

- `examples/benchmark/run_wam_rust_cached_scaling_sweep.sh` — builds cached+lazy once, ingests each fixture, runs single-threaded with attribution, prints the table. Validated end-to-end (exit 0).
- `docs/reports/wam_rust_cached_scaling_sweep_2026-06-14.md` — method, table, interpretation, caveats.

## Next

Largest fixture here is 25k edges; the trend says the win keeps widening, so an enwiki-scale `lmdb_resident` fixture is the natural amplification when available. Measured single-threaded to isolate the cache effect; the T7 parallelism stacks on top.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_