### PR TITLE
fix(wam-rust): T7 input threading step 1 — transform external-input support

### DIFF
--- a/src/unifyweaver/core/parallel_gate.pl
+++ b/src/unifyweaver/core/parallel_gate.pl
@@ -26,6 +26,7 @@
     goal_parallel_decision/3,        % +Generator, +Model, -Decision
     split_aggregate_generator/5,     % +InnerGoal, +Model, -Enum, -Body, -Frontier
     parallel_aggregate_transform/5,  % +AggGoal, +Model, +Seed, -Helpers, -Plan
+    parallel_aggregate_transform/6,  % +AggGoal, +ExternalInputs, +Model, +Seed, -Helpers, -Plan
     lift_embedded_aggregate/6,       % +Head, +Body, +Model, +Seed, -NewBody, -HelperClause
     parallel_worthy_tier/1           % ?Tier   (multifile, overridable policy)
 ]).
@@ -191,24 +192,40 @@ memberchk_eq([_|T], V) :- memberchk_eq(T, V).
 % the gate says parallel, and the inner goal splits soundly.
 
 parallel_aggregate_transform(AggGoal, Model, Seed, Helpers, Plan) :-
+    parallel_aggregate_transform(AggGoal, [], Model, Seed, Helpers, Plan).
+
+%% parallel_aggregate_transform(+AggGoal, +ExternalInputs, +Model, +Seed, -Helpers, -Plan)
+%  ExternalInputs are variables the aggregate's inner goal reads from OUTSIDE the
+%  aggregate (the enclosing predicate's head args / preceding goals). They become
+%  LEADING parameters of both helpers, so the enumerator/body run with those vars
+%  bound to the caller's values rather than free — without this, an aggregate like
+%  `findall(D,(link(Y,Z),down(Z,D)),R)` with `Y` an input enumerates over all `Y`.
+%  For `ExternalInputs = []` the output is identical to the original /5.
+parallel_aggregate_transform(AggGoal, ExternalInputs, Model, Seed, Helpers, Plan) :-
     forkable_aggregate(AggGoal, _Template, InnerGoal),
     agg_value_type(AggGoal, AggType, Value),
     aggregate_result(AggGoal, Result),
     goal_parallel_decision(InnerGoal, Model, parallel),
     split_aggregate_generator(InnerGoal, Model, Enum, Body, _Frontier),
-    % Input = enum-bound vars that the body or the collected value reads.
+    % Input tuple = enum-bound vars the body/value reads, MINUS external inputs
+    % (those are passed as leading params, not via the tuple).
     term_variables(Enum, EnumVars),
     term_variables(Body, BodyVars),
     term_variables(Value, ValueVars),
     append(BodyVars, ValueVars, Downstream),
-    shared_vars(EnumVars, Downstream, Input),
+    shared_vars(EnumVars, Downstream, Input0),
+    exclude(memberchk_eq(ExternalInputs), Input0, Input),
     InputTuple =.. [ti | Input],
     format(atom(EnumName), '__par_enum_~w', [Seed]),
     format(atom(BodyName), '__par_body_~w', [Seed]),
-    EnumHead =.. [EnumName, InputTuple],
-    BodyHead =.. [BodyName, InputTuple, Value],
+    append(ExternalInputs, [InputTuple], EnumArgs),
+    EnumHead =.. [EnumName | EnumArgs],
+    append(ExternalInputs, [InputTuple, Value], BodyArgs),
+    BodyHead =.. [BodyName | BodyArgs],
     Helpers = [ (EnumHead :- Enum), (BodyHead :- Body) ],
-    Plan = par_aggregate(AggType, EnumName/1, BodyName/2, Result).
+    length(ExternalInputs, K),
+    EnumArity is K + 1, BodyArity is K + 2,
+    Plan = par_aggregate(AggType, EnumName/EnumArity, BodyName/BodyArity, Result).
 
 % The per-solution value collected, and how it is reduced.
 agg_value_type(findall(Tmpl, _, _),          collect, Tmpl) :- !.

--- a/tests/test_parallel_gate.pl
+++ b/tests/test_parallel_gate.pl
@@ -30,6 +30,9 @@ pg_heavy(X, R) :-
 pg_down(0, []).
 pg_down(N, [N|T]) :- N > 0, M is N - 1, pg_down(M, T).
 
+% link facts, for an aggregate whose enumerator reads an EXTERNAL input
+pg_link(10, 1). pg_link(10, 2). pg_link(20, 3).
+
 :- begin_tests(parallel_gate).
 
 build(M) :- build_cost_model(user, M).
@@ -214,5 +217,35 @@ test(transform_declines_all_cheap) :-
 test(transform_declines_non_aggregate) :-
     build(M),
     assertion(\+ parallel_aggregate_transform(pg_down(3, _L), M, dseed6, _, _)).
+
+% --- external-input threading (the fix for head-arg inputs to the enumerator) --
+
+test(transform_with_no_external_inputs_is_unchanged) :-
+    build(M),
+    % /5 and /6-with-[] produce identical helpers/plan (arity 1/2)
+    parallel_aggregate_transform(findall(L, (pg_fact(X), pg_down(X, L)), _), M, e0a, H5, P5),
+    parallel_aggregate_transform(findall(L, (pg_fact(X2), pg_down(X2, L)), _), [], M, e0a, H6, P6),
+    P5 = par_aggregate(_, _/EA5, _/BA5, _), assertion(EA5 == 1), assertion(BA5 == 2),
+    P6 = par_aggregate(_, _/EA6, _/BA6, _), assertion(EA6 == 1), assertion(BA6 == 2),
+    assertion(H5 =@= H6).
+
+test(transform_threads_external_input) :-
+    build(M),
+    AggGoal = findall(D, (pg_link(Y, Z), pg_down(Z, D)), _R),
+    parallel_aggregate_transform(AggGoal, [Y], M, ext1, Helpers, Plan),
+    % helpers gain a leading param for the external input Y: arity 1+1 / 2+1
+    Plan = par_aggregate(collect, EN/EA, BN/BA, _),
+    assertion(EA == 2), assertion(BA == 3),
+    Helpers = [(EnumHead :- _), (_BodyHead :- _)],
+    EnumHead =.. [EN, EY, _Tuple], assertion(EY == Y),   % Y is the leading enum arg
+    % decisive: run the helpers with Y bound -> exactly the original aggregate
+    findall(D, (pg_link(10, Z), pg_down(Z, D)), Ref),
+    assertion(Ref == [[1], [2,1]]),
+    copy_term(Helpers, HC), forall(member(C, HC), assertz(user:C)),
+    EnumG =.. [EN, 10, IT], findall(IT, user:EnumG, ITs),
+    findall(DV, ( member(I, ITs), BG =.. [BN, 10, I, DV], call(user:BG) ), Got),
+    functor(EClean, EN, EA), retractall(user:EClean),
+    functor(BClean, BN, BA), retractall(user:BClean),
+    assertion(Got == Ref).
 
 :- end_tests(parallel_gate).


### PR DESCRIPTION
## Why

Latent correctness bug found while wiring embedded aggregates: `par_collect` / `par_collect_labels` run an aggregate's **enumerator with head-arg/external inputs unbound**. Affects **both** the whole-body wrapper *and* the route-2 embedded path on `main`; only unhit because every test used an input-less aggregate (e.g. `findall(F,(fact(X),body(X,F)),L)` — `X` is inner-goal-local). A case like `findall(D,(link(Y,Z),down(Z,D)),R)` with `Y` an input enumerates `link(_,Z)` over **all** `Y`.

## This PR (fix step 1 — the transform foundation)

`parallel_aggregate_transform/6` (and `/5 = /6` with `[]`): `ExternalInputs` are the vars the inner goal reads from outside the aggregate. They become **leading parameters** of both helpers — `__par_enum(Ext.., InputTuple)` / `__par_body(Ext.., InputTuple, Value)` — excluded from the input tuple, with helper arities in the plan reflecting them (`K+1` / `K+2`). **For `[]` the output is byte-identical to the old `/5`** (no breakage to the whole-body or route-2 callers).

## Tests
`test_parallel_gate.pl` +2: `/6`-with-`[]` equals `/5` (arity 1/2, helpers `=@=`); and the decisive `transform_threads_external_input` — for `findall(D,(pg_link(Y,Z),pg_down(Z,D)),R)` with `ExternalInputs=[Y]`, the helpers gain `Y` as the leading enum arg and, run with `Y=10` bound, collect exactly `[[1],[2,1]]`.

## Remaining (fix steps 2–3)
Thread the external-input **values at runtime**: `par_collect`/`seq_collect` over closures that pass the inputs to enum/body (whole-body); `par_collect_labels` + the `ParAggregate` instruction passing the container's input registers (embedded); compute `ExternalInputs` in `rust_parallel_aggregate_wrapper` + `rust_embedded_par_aggregate`; add input-taking exec tests for both paths.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_