### PR TITLE
Improve boundary coverage report narrative

### DIFF
--- a/docs/reports/lmdb_boundary_coverage_probe_summary_enwiki_mtc_boundary_coverage_root_cone_all_b3_b10_20_d6_8_20260614T054134Z.md
+++ b/docs/reports/lmdb_boundary_coverage_probe_summary_enwiki_mtc_boundary_coverage_root_cone_all_b3_b10_20_d6_8_20260614T054134Z.md
@@ -16,13 +16,48 @@ Root cone nodes: `15159`
 
 Boundary suffix mass measured: `False`
 
+Path value kernel: `count`
+
+Path value branching factor: `n/a`
+
+Path value power: `n/a`
+
 Boundary nodes: `977`
 
 Targets: `4`
 
 Path length budgets: `10,20`
 
-Exact mode enumerates simple parent-prefixes until root, boundary, or the path-length budget. Sample mode uses branch-product weighted random walks; its path-count totals are estimates, not direct counts. With `root-reachable`, parent expansion checks finite-horizon reachability recursively. With `root-cone`, parent expansion uses a precomputed root cone and keeps only parent nodes whose cone depth fits within the remaining path budget.
+## How This Was Generated
+
+- This older selection record stores observed boundary/target frontier counts over child-depths `3` and `6, 8`, but not the requested depth arguments separately.
+- This selection record predates sampler-limit provenance fields; newer JSONL records include child/frontier/per-depth sampling limits directly.
+- Mode `exact` controls the row generator: `exact` enumerates all simple parent prefixes until root, boundary, or budget; `sample` performs branch-product weighted boundary-stopped random walks; `root-sample` samples walks to root without stopping at boundaries.
+- Parent filter `root-cone` is applied during parent expansion. `root-cone` accepts only parents inside the precomputed root cone whose cone depth fits within the remaining path budget; `root-reachable` uses recursive finite-horizon reachability; `all` does no root-scope pruning.
+- The root cone was built to child depth `20` with `15159` nodes, `root_cone_children_per_node=32`, and `root_cone_frontier_limit=1000`.
+- Boundary suffix mass measured: `False`. When this is false, boundary-hit rows measure coverage only; they do not splice cached suffix mass into a total root-path estimate.
+- Path value kernel `count` defines the functional being estimated after path coverage is known. It is separate from the random-walk proposal correction.
+
+## Table Guide
+
+- `Selection` lists observed frontier sizes for boundary and target depths. In newer reports, the requested depths are stated above; the table may include intermediate traversal depths.
+- `Root Cone` shows the bounded child-reachable cone used for root-cone filtering. These are not parent-path counts; they are child-depth frontier counts from the root.
+- `Coverage Summary` aggregates observed terminal outcomes by mode and path-length budget. In exact mode these are enumerated simple-prefix counts; in sample/root-sample modes they are raw sample outcomes.
+- `Boundary Sample Estimates` and `Root Path Sample Estimates` contain branch-product weighted estimates. Use those estimate tables, not raw observed sample counts, when reasoning about path-space size.
+- `Target Rows` is per target and budget. `root_paths` counts direct root terminals reached before a boundary stop; `boundary_hit_prefixes` counts prefixes where the boundary condition would take over.
+- `root_unreachable_parent_skips` counts parent edges rejected by the active parent filter. Under `root-cone`, that includes parents outside the cone or too deep for the remaining budget, not only globally unreachable parents.
+- `budget_exhausted_prefixes`, `path_count_cap_hit_targets`, and `expansion_cap_hit_targets` identify rows whose result is limited by the path budget or safety caps.
+
+## Result Implications
+
+- Target evaluation completed `8/8` rows without path-count or expansion caps.
+- `exact` budget `10`: `33` terminal prefixes, `24` direct root paths, `8` boundary-hit prefixes, boundary-hit fraction `0.242424`, and `0` budget-exhausted prefixes.
+- `exact` budget `20`: `33` terminal prefixes, `24` direct root paths, `8` boundary-hit prefixes, boundary-hit fraction `0.242424`, and `0` budget-exhausted prefixes.
+- `6` target-budget rows have `root_paths=0` and positive boundary hits. In this report that means enumeration stopped at a boundary before reaching root; it is boundary coverage, not evidence that those targets lack root paths.
+- Boundary suffix mass was not measured, so boundary hits cannot yet be converted into total root-path mass or budgeted CDF mass from this report alone.
+- The active parent filter rejected `308` parent edges. Under `root-cone`, these skips are part of the scoped experiment definition, not necessarily data errors.
+- Simple-path cycle checks skipped `4` edges. That keeps rows cycle-free, but it also means cached suffixes must be interpreted with the same cycle policy.
+- Filtered dead ends occurred `2` times; these are prefixes whose remaining parents were removed by the active parent filter.
 
 ## Selection
 
@@ -60,14 +95,16 @@ Exact mode enumerates simple parent-prefixes until root, boundary, or the path-l
 
 ## Coverage Summary
 
-For sample mode, these are observed random-walk outcomes. Use `Sampled Estimates` for branch-product weighted path-space estimates.
+For sample and root-sample modes, these are observed random-walk outcomes. Use the estimate sections below for branch-product weighted path-space estimates.
 
-| mode | path_length_budget | targets | completed_targets | observed_terminal_prefixes | observed_root_paths | observed_boundary_hit_prefixes | observed_boundary_hit_fraction | observed_budget_exhausted_prefixes | observed_filtered_dead_ends | mean_boundary_suffix_path_mass | path_count_cap_hit_targets | expansion_cap_hit_targets | cycle_skips | root_unreachable_parent_skips |
-|------|-------------------:|--------:|------------------:|------------------:|-----------:|----------------------:|----------------------:|--------------------------:|----------------------------:|-------------------------------:|---------------------------:|--------------------------:|------------:|------------------------------:|
-| exact | 10 | 4 | 4 | 33 | 24 | 8 | 0.242424 | 0 | 1 | n/a | 0 | 0 | 2 | 154 |
-| exact | 20 | 4 | 4 | 33 | 24 | 8 | 0.242424 | 0 | 1 | n/a | 0 | 0 | 2 | 154 |
+| mode | path_length_budget | targets | completed_targets | observed_terminal_prefixes | observed_root_paths | observed_boundary_hit_prefixes | observed_boundary_hit_fraction | observed_budget_exhausted_prefixes | observed_filtered_dead_ends | mean_boundary_suffix_path_mass | mean_boundary_suffix_path_value | path_count_cap_hit_targets | expansion_cap_hit_targets | cycle_skips | root_unreachable_parent_skips |
+|------|-------------------:|--------:|------------------:|------------------:|-----------:|----------------------:|----------------------:|--------------------------:|----------------------------:|-------------------------------:|--------------------------------:|---------------------------:|--------------------------:|------------:|------------------------------:|
+| exact | 10 | 4 | 4 | 33 | 24 | 8 | 0.242424 | 0 | 1 | n/a | n/a | 0 | 0 | 2 | 154 |
+| exact | 20 | 4 | 4 | 33 | 24 | 8 | 0.242424 | 0 | 1 | n/a | n/a | 0 | 0 | 2 | 154 |
 
 ## Target Rows
+
+Each row is one target under one path-length budget. `root_paths` counts direct root-reaching terminals found before the search stops at a boundary. A row with `root_paths=0` and positive `boundary_hit_prefixes` is boundary-covered; it is not automatically root-unreachable. When boundary suffix mass is disabled, use these rows to judge boundary coverage rather than total root-path mass.
 
 | mode | target_node | path_length_budget | terminal_prefixes | root_paths | boundary_hit_prefixes | boundary_hit_fraction | budget_exhausted_prefixes | filtered_dead_end_prefixes | mean_boundary_remaining_budget | completed | cycle_skips | root_unreachable_parent_skips |
 |------|------------:|-------------------:|------------------:|-----------:|----------------------:|----------------------:|--------------------------:|---------------------------:|-------------------------------:|----------:|------------:|------------------------------:|

--- a/scripts/lmdb_boundary_coverage_probe.py
+++ b/scripts/lmdb_boundary_coverage_probe.py
@@ -959,6 +959,184 @@ def mean_optional_field(rows, field):
     return None if not values else statistics.mean(values)
 
 
+def sorted_depth_items(counts):
+    return sorted(counts.items(), key=lambda item: int(item[0]))
+
+
+def depths_text(values):
+    if values is None:
+        return None
+    return ", ".join(str(value) for value in values)
+
+
+def boundary_coverage_generation_notes(selection):
+    mode = selection.get("mode", "exact")
+    selection_source = selection.get("selection_source", "graph")
+    parent_filter = selection.get("parent_filter", "all")
+    lines = [
+        "## How This Was Generated",
+        "",
+    ]
+    boundary_depths = depths_text(selection.get("boundary_depths"))
+    target_depths = depths_text(selection.get("target_depths"))
+    if boundary_depths is None or target_depths is None:
+        lines.append(
+            "- This older selection record stores observed boundary/target frontier counts over child-depths `{}` and `{}`, but not the requested depth arguments separately.".format(
+                depths_text(depth for depth, _count in sorted_depth_items(selection.get("boundary_counts", {}))) or "none",
+                depths_text(depth for depth, _count in sorted_depth_items(selection.get("target_counts", {}))) or "none",
+            )
+        )
+    else:
+        lines.append(
+            "- Boundary candidates were sampled from requested child depth(s) `{}` and target rows from requested child depth(s) `{}` using selection source `{}`.".format(
+                boundary_depths,
+                target_depths,
+                selection_source,
+            )
+        )
+    if all(selection.get(key) is not None for key in ("children_per_node", "frontier_limit", "boundaries_per_depth", "targets_per_depth")):
+        lines.append(
+            "- The graph/root-cone sampler used `children_per_node={}` and `frontier_limit={}`; per-depth sample limits were `boundaries_per_depth={}` and `targets_per_depth={}`.".format(
+                selection.get("children_per_node"),
+                selection.get("frontier_limit"),
+                selection.get("boundaries_per_depth"),
+                selection.get("targets_per_depth"),
+            )
+        )
+    else:
+        lines.append(
+            "- This selection record predates sampler-limit provenance fields; newer JSONL records include child/frontier/per-depth sampling limits directly."
+        )
+    lines.append(
+        "- Mode `{}` controls the row generator: `exact` enumerates all simple parent prefixes until root, boundary, or budget; `sample` performs branch-product weighted boundary-stopped random walks; `root-sample` samples walks to root without stopping at boundaries.".format(mode)
+    )
+    lines.append(
+        "- Parent filter `{}` is applied during parent expansion. `root-cone` accepts only parents inside the precomputed root cone whose cone depth fits within the remaining path budget; `root-reachable` uses recursive finite-horizon reachability; `all` does no root-scope pruning.".format(parent_filter)
+    )
+    if selection.get("root_cone_counts"):
+        lines.append(
+            "- The root cone was built to child depth `{}` with `{}` nodes, `root_cone_children_per_node={}`, and `root_cone_frontier_limit={}`.".format(
+                selection.get("root_cone_depth", "n/a"),
+                selection.get("root_cone_nodes", 0),
+                selection.get("root_cone_children_per_node", "n/a"),
+                selection.get("root_cone_frontier_limit", "n/a"),
+            )
+        )
+    if selection.get("include_target_ancestor_boundaries"):
+        if selection.get("target_ancestor_boundary_limit") is None:
+            lines.append("- Target-ancestor boundary inclusion was enabled, so sampled boundary-depth ancestors of targets could be added to the selected boundary set.")
+        else:
+            lines.append(
+                "- Target-ancestor boundary inclusion was enabled, with `target_ancestor_boundary_limit={}`.".format(
+                    selection.get("target_ancestor_boundary_limit")
+                )
+            )
+    lines.append(
+        "- Boundary suffix mass measured: `{}`. When this is false, boundary-hit rows measure coverage only; they do not splice cached suffix mass into a total root-path estimate.".format(
+            selection.get("measure_boundary_suffix_mass", True)
+        )
+    )
+    lines.append(
+        "- Path value kernel `{}` defines the functional being estimated after path coverage is known. It is separate from the random-walk proposal correction.".format(
+            selection.get("path_value_kernel", "count")
+        )
+    )
+    return lines
+
+
+def boundary_coverage_table_guide():
+    return [
+        "## Table Guide",
+        "",
+        "- `Selection` lists observed frontier sizes for boundary and target depths. In newer reports, the requested depths are stated above; the table may include intermediate traversal depths.",
+        "- `Root Cone` shows the bounded child-reachable cone used for root-cone filtering. These are not parent-path counts; they are child-depth frontier counts from the root.",
+        "- `Coverage Summary` aggregates observed terminal outcomes by mode and path-length budget. In exact mode these are enumerated simple-prefix counts; in sample/root-sample modes they are raw sample outcomes.",
+        "- `Boundary Sample Estimates` and `Root Path Sample Estimates` contain branch-product weighted estimates. Use those estimate tables, not raw observed sample counts, when reasoning about path-space size.",
+        "- `Target Rows` is per target and budget. `root_paths` counts direct root terminals reached before a boundary stop; `boundary_hit_prefixes` counts prefixes where the boundary condition would take over.",
+        "- `root_unreachable_parent_skips` counts parent edges rejected by the active parent filter. Under `root-cone`, that includes parents outside the cone or too deep for the remaining budget, not only globally unreachable parents.",
+        "- `budget_exhausted_prefixes`, `path_count_cap_hit_targets`, and `expansion_cap_hit_targets` identify rows whose result is limited by the path budget or safety caps.",
+    ]
+
+
+def boundary_coverage_result_implications(selection, target_rows):
+    lines = ["## Result Implications", ""]
+    if not target_rows:
+        lines.append("- No target rows were generated, so this report only documents selection shape.")
+        return lines
+    by_mode_budget = {}
+    for row in target_rows:
+        by_mode_budget.setdefault((row["mode"], row["path_length_budget"]), []).append(row)
+    total_rows = len(target_rows)
+    complete_rows = sum(1 for row in target_rows if row.get("completed"))
+    cap_rows = total_rows - complete_rows
+    zero_root_boundary_rows = [
+        row for row in target_rows
+        if int(row.get("root_paths", 0)) == 0 and int(row.get("boundary_hit_prefixes", 0)) > 0
+    ]
+    budget_cutoff_rows = [row for row in target_rows if int(row.get("budget_exhausted_prefixes", 0)) > 0]
+    root_skip_total = sum(int(row.get("root_unreachable_parent_skips", 0)) for row in target_rows)
+    cycle_skip_total = sum(int(row.get("cycle_skips", 0)) for row in target_rows)
+    filtered_dead_total = sum(int(row.get("filtered_dead_end_prefixes", 0)) for row in target_rows)
+    lines.append("- Target evaluation completed `{}/{}` rows without path-count or expansion caps.".format(complete_rows, total_rows))
+    if cap_rows:
+        lines.append("- `{}` rows hit a path-count or expansion cap; read those rows as partial coverage evidence rather than full target-cone counts.".format(cap_rows))
+    for key in sorted(by_mode_budget):
+        mode, budget = key
+        rows = by_mode_budget[key]
+        aggregate = aggregate_rows(rows)
+        lines.append(
+            "- `{}` budget `{}`: `{}` terminal prefixes, `{}` direct root paths, `{}` boundary-hit prefixes, boundary-hit fraction `{}`, and `{}` budget-exhausted prefixes.".format(
+                mode,
+                budget,
+                aggregate["terminal_prefixes"],
+                aggregate["root_paths"],
+                aggregate["boundary_hit_prefixes"],
+                format_optional(aggregate["boundary_hit_fraction"], 6),
+                aggregate["budget_exhausted_prefixes"],
+            )
+        )
+    if zero_root_boundary_rows:
+        lines.append(
+            "- `{}` target-budget rows have `root_paths=0` and positive boundary hits. In this report that means enumeration stopped at a boundary before reaching root; it is boundary coverage, not evidence that those targets lack root paths.".format(
+                len(zero_root_boundary_rows)
+            )
+        )
+    if not selection.get("measure_boundary_suffix_mass", True):
+        lines.append(
+            "- Boundary suffix mass was not measured, so boundary hits cannot yet be converted into total root-path mass or budgeted CDF mass from this report alone."
+        )
+    elif any(row.get("boundary_suffix_path_mass_sum") for row in target_rows):
+        lines.append(
+            "- Boundary suffix mass was measured, so boundary-hit prefixes can be combined with suffix histograms to estimate total root-path mass under the remaining budget."
+        )
+    if root_skip_total:
+        lines.append(
+            "- The active parent filter rejected `{}` parent edges. Under `{}`, these skips are part of the scoped experiment definition, not necessarily data errors.".format(
+                root_skip_total,
+                selection.get("parent_filter", "all"),
+            )
+        )
+    if budget_cutoff_rows:
+        lines.append(
+            "- `{}` rows exhausted the path-length budget before root or boundary. Larger budgets may change coverage conclusions for those targets.".format(
+                len(budget_cutoff_rows)
+            )
+        )
+    if cycle_skip_total:
+        lines.append(
+            "- Simple-path cycle checks skipped `{}` edges. That keeps rows cycle-free, but it also means cached suffixes must be interpreted with the same cycle policy.".format(cycle_skip_total)
+        )
+    if filtered_dead_total:
+        lines.append(
+            "- Filtered dead ends occurred `{}` times; these are prefixes whose remaining parents were removed by the active parent filter.".format(filtered_dead_total)
+        )
+    if any(row.get("mode") in {"sample", "root-sample"} for row in target_rows):
+        lines.append(
+            "- Sample-mode rows are statistical estimates. Compare confidence intervals and increase `samples` before using them as performance-planning inputs."
+        )
+    return lines
+
+
 def summarize(records):
     selection = next((row for row in records if row.get("record_type") == "boundary_coverage_selection"), {})
     target_rows = [row for row in records if row.get("record_type") == "boundary_coverage_target"]
@@ -997,16 +1175,22 @@ def summarize(records):
         "",
         "Path length budgets: `{}`".format(",".join(str(value) for value in selection.get("budgets", []))),
         "",
-        "Exact mode enumerates simple parent-prefixes until root, boundary, or the path-length budget. Sample mode uses branch-product weighted random walks; its path-count totals are estimates, not direct counts. With `root-reachable`, parent expansion checks finite-horizon reachability recursively. With `root-cone`, parent expansion uses a precomputed root cone and keeps only parent nodes whose cone depth fits within the remaining path budget.",
+    ]
+    lines.extend(boundary_coverage_generation_notes(selection))
+    lines.extend([""])
+    lines.extend(boundary_coverage_table_guide())
+    lines.extend([""])
+    lines.extend(boundary_coverage_result_implications(selection, target_rows))
+    lines.extend([
         "",
         "## Selection",
         "",
         "| role | child_depth | sampled_frontier_nodes |",
         "|------|-------------|------------------------|",
-    ]
-    for depth, count in sorted(selection.get("boundary_counts", {}).items()):
+    ])
+    for depth, count in sorted_depth_items(selection.get("boundary_counts", {})):
         lines.append("| boundary | {} | {} |".format(depth, count))
-    for depth, count in sorted(selection.get("target_counts", {}).items()):
+    for depth, count in sorted_depth_items(selection.get("target_counts", {})):
         lines.append("| target | {} | {} |".format(depth, count))
     if selection.get("root_cone_counts"):
         lines.extend([
@@ -1016,7 +1200,7 @@ def summarize(records):
             "| child_depth | new_nodes |",
             "|------------:|----------:|",
         ])
-        for depth, count in sorted(selection.get("root_cone_counts", {}).items()):
+        for depth, count in sorted_depth_items(selection.get("root_cone_counts", {})):
             lines.append("| {} | {} |".format(depth, count))
 
     lines.extend([
@@ -1112,6 +1296,8 @@ def summarize(records):
     lines.extend([
         "",
         "## Target Rows",
+        "",
+        "Each row is one target under one path-length budget. `root_paths` counts direct root-reaching terminals found before the search stops at a boundary. A row with `root_paths=0` and positive `boundary_hit_prefixes` is boundary-covered; it is not automatically root-unreachable. When boundary suffix mass is disabled, use these rows to judge boundary coverage rather than total root-path mass.",
         "",
         "| mode | target_node | path_length_budget | terminal_prefixes | root_paths | boundary_hit_prefixes | boundary_hit_fraction | budget_exhausted_prefixes | filtered_dead_end_prefixes | mean_boundary_remaining_budget | completed | cycle_skips | root_unreachable_parent_skips |",
         "|------|------------:|-------------------:|------------------:|-----------:|----------------------:|----------------------:|--------------------------:|---------------------------:|-------------------------------:|----------:|------------:|------------------------------:|",
@@ -1288,6 +1474,7 @@ def run_probe(args):
             "record_type": "boundary_coverage_selection",
             "graph": args.graph_name,
             "root": args.root,
+            "seed": args.seed,
             "parent_filter": args.parent_filter,
             "path_value_kernel": path_value_kernel.name,
             "path_value_branching_factor": path_value_kernel.branching_factor,
@@ -1295,16 +1482,26 @@ def run_probe(args):
             "path_value_power": path_value_kernel.power,
             "path_value_branching_stats": path_value_branching_stats,
             "selection_source": args.selection_source,
+            "boundary_depths": boundary_depths,
+            "target_depths": target_depths,
             "root_cone_depth": root_cone_depth if root_cone_depth_by_node is not None else None,
             "root_cone_nodes": len(root_cone_depth_by_node or {}),
             "root_cone_counts": root_cone_counts,
             "root_cone_children_per_node": args.root_cone_children_per_node if args.root_cone_children_per_node is not None else args.children_per_node,
             "root_cone_frontier_limit": args.root_cone_frontier_limit if args.root_cone_frontier_limit is not None else args.frontier_limit,
+            "children_per_node": args.children_per_node,
+            "frontier_limit": args.frontier_limit,
+            "boundaries_per_depth": args.boundaries_per_depth,
+            "targets_per_depth": args.targets_per_depth,
+            "require_targets_in_root_cone": args.require_targets_in_root_cone,
+            "require_boundaries_in_root_cone": args.require_boundaries_in_root_cone,
             "boundary_counts": boundary_counts,
             "target_counts": target_counts,
             "boundary_nodes": len(boundary_nodes),
             "selected_boundary_nodes": len(selected_boundary_nodes),
             "target_ancestor_boundary_nodes_added": len(set(boundary_nodes) - selected_boundary_nodes),
+            "include_target_ancestor_boundaries": args.include_target_ancestor_boundaries,
+            "target_ancestor_boundary_limit": args.target_ancestor_boundary_limit,
             "targets": len(targets),
             "target_selection": target_selection_label,
             "budgets": budgets,

--- a/tests/test_lmdb_boundary_coverage_probe.py
+++ b/tests/test_lmdb_boundary_coverage_probe.py
@@ -17,6 +17,7 @@ from scripts.lmdb_boundary_coverage_probe import (
     sample_root_path_space,
     select_nodes_by_root_cone_depth,
     resolve_path_value_kernel,
+    summarize,
 )
 
 
@@ -332,6 +333,72 @@ class BoundaryCoverageProbeTests(unittest.TestCase):
         self.assertAlmostEqual(record["estimated_root_paths"], 2.0)
         self.assertAlmostEqual(record["estimated_root_value_sum"], 0.5)
         self.assertAlmostEqual(record["estimated_kernel_mean_root_path_length"], 2.0)
+
+    def test_summary_explains_boundary_coverage_report_tables(self):
+        graph = DictGraph({
+            "A": ["R"],
+            "B": ["A"],
+            "C": ["B"],
+        })
+        row = exact_boundary_coverage(
+            graph.parents,
+            "C",
+            "R",
+            3,
+            {"B"},
+            parent_filter_name="root-cone",
+            measure_suffix_mass=False,
+        )
+        row["graph"] = "fixture"
+        row["root"] = "R"
+        row["child_sample_depth"] = 3
+        summary = summarize([
+            {
+                "record_type": "boundary_coverage_selection",
+                "graph": "fixture",
+                "root": "R",
+                "seed": "fixture",
+                "parent_filter": "root-cone",
+                "path_value_kernel": "count",
+                "path_value_branching_factor": None,
+                "path_value_branching_factor_source": None,
+                "path_value_power": 1.0,
+                "selection_source": "root-cone",
+                "boundary_depths": [2],
+                "target_depths": [3],
+                "root_cone_depth": 3,
+                "root_cone_nodes": 4,
+                "root_cone_counts": {0: 1, 1: 1, 2: 1, 3: 1},
+                "root_cone_children_per_node": 10,
+                "root_cone_frontier_limit": 100,
+                "children_per_node": 10,
+                "frontier_limit": 100,
+                "boundaries_per_depth": 1,
+                "targets_per_depth": 1,
+                "boundary_counts": {2: 1},
+                "target_counts": {3: 1},
+                "boundary_nodes": 1,
+                "selected_boundary_nodes": 1,
+                "target_ancestor_boundary_nodes_added": 0,
+                "targets": 1,
+                "target_selection": "root-cone-child-depth",
+                "budgets": [3],
+                "mode": "exact",
+                "samples": 0,
+                "path_count_cap": 10,
+                "expansion_cap": 20,
+                "measure_boundary_suffix_mass": False,
+            },
+            row,
+        ])
+
+        self.assertIn("## How This Was Generated", summary)
+        self.assertIn("## Table Guide", summary)
+        self.assertIn("## Result Implications", summary)
+        self.assertIn("requested child depth(s) `2`", summary)
+        self.assertIn("`root_paths=0` and positive boundary hits", summary)
+        self.assertIn("boundary-covered", summary)
+        self.assertIn("`Target Rows` is per target and budget", summary)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add self-explanatory narrative sections to boundary coverage probe summaries: how the run was generated, how to read each table, and what the result implies.
- Persist requested depth and sampler provenance fields for future boundary coverage selection records.
- Re-render the EnWiki MTC root-cone boundary coverage report from existing JSONL so `Target Rows` explains why `root_paths=0` with positive boundary hits means boundary coverage, not root-unreachability.

## Validation
- `python3 -m unittest tests.test_lmdb_boundary_coverage_probe`
- `python3 -m py_compile scripts/lmdb_boundary_coverage_probe.py tests/test_lmdb_boundary_coverage_probe.py`
- `python3 -m unittest tests.test_lmdb_boundary_coverage_probe tests.test_lmdb_path_value_kernel_sweep tests.test_distribution_precompute_depth_estimator tests.test_lmdb_exact_sparse_depth_sweep tests.test_lmdb_parent_boundary_cache_benchmark`
- `git diff --check`