### PR TITLE
Generalize PLAWK print expression lowering

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -293,7 +293,11 @@ mixed, and assoc-only branch bodies now share the same rule-body action walker;
 branch phis use each branch's actual exit block, including assoc side-effect
 `_done` blocks. Branch-local `print` uses prefixed SSA names so multiple branch
 prints do not collide; branch-local `NR` printing uses the same native record
-counter threaded through the stream loop as top-level `print NR`. Terminal
+counter threaded through the stream loop as top-level `print NR`. Print
+expression lowering now shares one context-aware path for top-level and
+branch-local prints; the context supplies prefixed names while `$N`, `NF`,
+`length`, `substr`, `index`, and case transforms use the same expression
+lowering clauses. Terminal
 branch-local `next` branches directly to the stream-loop continuation and adds
 the selected branch's scalar values to the loop phi inputs. Terminal
 branch-local `break` branches to the same dedicated stream-close block as

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1807,50 +1807,110 @@ plawk_prefixed_print_field_ir(Field, FieldSeparator, Prefix, Index) -->
     },
     [GlobalIR-BodyIR].
 
-plawk_emit_print_expr_ir(special('NR'), _FieldSeparator, _Index,
-        i64(nr, nr, '%current_nr'), [], []).
+plawk_emit_print_expr_ir(Field, FieldSeparator, Index, Type, GlobalParts, SetupParts) :-
+    plawk_emit_print_expr_for_context(Field, FieldSeparator, print_context(normal, '', Index),
+        Type, GlobalParts, SetupParts).
 
-plawk_emit_print_expr_ir(special('NF'), FieldSeparator, Index,
-        i64(nf, nf, ValueIR), [], [CountIR]) :-
-    format(atom(Base), 'plawk_nf_~w', [Index]),
+plawk_emit_prefixed_print_expr_ir(Field, FieldSeparator, Prefix, Index,
+        Type, GlobalParts, SetupParts) :-
+    plawk_emit_print_expr_for_context(Field, FieldSeparator,
+        print_context(prefixed, Prefix, Index), Type, GlobalParts, SetupParts).
+
+plawk_emit_print_expr_for_context(special('NR'), _FieldSeparator, Context,
+        i64(FmtPrefix, PrintPrefix, '%current_nr'), [], []) :-
+    plawk_print_expr_output_names(Context, nr, FmtPrefix, PrintPrefix).
+
+plawk_emit_print_expr_for_context(string(Value), _FieldSeparator, Context,
+        string(Base, PtrIR), [GlobalIR], [StringPtr]) :-
+    plawk_print_expr_value_base(Context, string, Base),
+    llvm_emit_c_string_global(Base, Value, GlobalIR, _StringLen, BytesLen),
+    format(atom(StringPtr),
+        '  %~w_ptr = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0',
+        [Base, BytesLen, BytesLen, Base]),
+    format(atom(PtrIR), '%~w_ptr', [Base]).
+
+plawk_emit_print_expr_for_context(special('NF'), FieldSeparator, Context,
+        i64(FmtPrefix, PrintPrefix, ValueIR), [], [CountIR]) :-
+    plawk_print_expr_value_base(Context, nf, Base),
+    plawk_print_expr_output_names(Context, nf, FmtPrefix, PrintPrefix),
     llvm_emit_atom_field_count('%line', FieldSeparator, Base, CountIR),
     format(atom(ValueIR), '%~w', [Base]).
 
-plawk_emit_print_expr_ir(length(field(FieldIndex)), FieldSeparator, Index,
-        i64(length, length, ValueIR), [], [LengthIR]) :-
-    format(atom(Base), 'plawk_length_~w', [Index]),
+plawk_emit_print_expr_for_context(length(field(FieldIndex)), FieldSeparator, Context,
+        i64(FmtPrefix, PrintPrefix, ValueIR), [], [LengthIR]) :-
+    plawk_print_expr_value_base(Context, length, Base),
+    plawk_print_expr_output_names(Context, length, FmtPrefix, PrintPrefix),
     llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, Base, LengthIR),
     format(atom(ValueIR), '%~w', [Base]).
 
-plawk_emit_print_expr_ir(substr(field(FieldIndex), Start, Len), FieldSeparator, Index,
-        slice(substr, substr, LenIR, PtrIR), [], [SliceIR]) :-
-    format(atom(Base), 'plawk_substr_~w', [Index]),
+plawk_emit_print_expr_for_context(substr(field(FieldIndex), Start, Len), FieldSeparator, Context,
+        slice(FmtPrefix, PrintPrefix, LenIR, PtrIR), [], [SliceIR]) :-
+    plawk_print_expr_value_base(Context, substr, Base),
+    plawk_print_expr_output_names(Context, substr, FmtPrefix, PrintPrefix),
     llvm_emit_atom_field_subslice('%line', FieldIndex, FieldSeparator, Start, Len, Base, SliceIR),
     format(atom(LenIR), '%~w_len', [Base]),
     format(atom(PtrIR), '%~w_ptr', [Base]).
 
-plawk_emit_print_expr_ir(index(field(FieldIndex), string(Needle)), FieldSeparator, Index,
-        i64(index, index, ValueIR), [GlobalIR], [CallIR]) :-
-    format(atom(Base), 'plawk_index_~w', [Index]),
-    format(atom(GlobalBase), 'plawk_index_needle_~w', [Index]),
+plawk_emit_print_expr_for_context(index(field(FieldIndex), string(Needle)), FieldSeparator, Context,
+        i64(FmtPrefix, PrintPrefix, ValueIR), [GlobalIR], [CallIR]) :-
+    plawk_print_expr_value_base(Context, index, Base),
+    plawk_print_expr_value_base(Context, index_needle, GlobalBase),
+    plawk_print_expr_output_names(Context, index, FmtPrefix, PrintPrefix),
     llvm_emit_atom_field_index(GlobalBase, '%line', FieldIndex, Needle, FieldSeparator,
         Base, GlobalIR-CallIR),
     format(atom(ValueIR), '%~w', [Base]).
 
-plawk_emit_print_expr_ir(tolower(field(FieldIndex)), FieldSeparator, Index,
+plawk_emit_print_expr_for_context(tolower(field(FieldIndex)), FieldSeparator, Context,
         case_slice(lower, LowerBase, LenIR, PtrIR), [], SetupParts) :-
-    format(atom(LowerBase), 'plawk_tolower_~w', [Index]),
+    plawk_print_expr_value_base(Context, tolower, LowerBase),
     plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, LowerBase, LenIR, PtrIR,
         SetupParts).
 
-plawk_emit_print_expr_ir(toupper(field(FieldIndex)), FieldSeparator, Index,
+plawk_emit_print_expr_for_context(toupper(field(FieldIndex)), FieldSeparator, Context,
         case_slice(upper, UpperBase, LenIR, PtrIR), [], SetupParts) :-
-    format(atom(UpperBase), 'plawk_toupper_~w', [Index]),
+    plawk_print_expr_value_base(Context, toupper, UpperBase),
     plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, UpperBase, LenIR, PtrIR,
         SetupParts).
 
-plawk_emit_print_expr_ir(field(0), _FieldSeparator, Index,
-        slice(line, line, LenIR, '%line_s'), [], [LineLen64, LineLen]) :-
+plawk_emit_print_expr_for_context(field(0), _FieldSeparator, Context,
+        slice(FmtPrefix, PrintPrefix, LenIR, '%line_s'), [], [LineLen64, LineLen]) :-
+    plawk_print_expr_output_names(Context, line, FmtPrefix, PrintPrefix),
+    plawk_emit_print_line_length_ir(Context, LenIR, LineLen64, LineLen).
+
+plawk_emit_print_expr_for_context(field(FieldIndex), FieldSeparator, Context,
+        slice(FmtPrefix, PrintPrefix, LenIR, PtrIR), [], [SliceIR]) :-
+    FieldIndex > 0,
+    plawk_print_expr_value_base(Context, field, Base),
+    plawk_print_expr_output_names(Context, field, FmtPrefix, PrintPrefix),
+    llvm_emit_atom_field_slice('%line', FieldIndex, FieldSeparator, Base, SliceIR),
+    format(atom(LenIR), '%~w_len', [Base]),
+    format(atom(PtrIR), '%~w_ptr', [Base]).
+
+plawk_print_expr_value_base(print_context(normal, _Prefix, Index), Kind, Base) :-
+    plawk_normal_print_expr_value_base(Kind, Index, Base).
+plawk_print_expr_value_base(print_context(prefixed, Prefix, Index), Kind, Base) :-
+    format(atom(Base), '~w_~w_~w', [Prefix, Kind, Index]).
+
+plawk_normal_print_expr_value_base(nf, Index, Base) :-
+    format(atom(Base), 'plawk_nf_~w', [Index]).
+plawk_normal_print_expr_value_base(length, Index, Base) :-
+    format(atom(Base), 'plawk_length_~w', [Index]).
+plawk_normal_print_expr_value_base(substr, Index, Base) :-
+    format(atom(Base), 'plawk_substr_~w', [Index]).
+plawk_normal_print_expr_value_base(index, Index, Base) :-
+    format(atom(Base), 'plawk_index_~w', [Index]).
+plawk_normal_print_expr_value_base(index_needle, Index, Base) :-
+    format(atom(Base), 'plawk_index_needle_~w', [Index]).
+plawk_normal_print_expr_value_base(tolower, Index, Base) :-
+    format(atom(Base), 'plawk_tolower_~w', [Index]).
+plawk_normal_print_expr_value_base(toupper, Index, Base) :-
+    format(atom(Base), 'plawk_toupper_~w', [Index]).
+plawk_normal_print_expr_value_base(field, Index, Base) :-
+    format(atom(Base), 'plawk_field_~w', [Index]).
+plawk_normal_print_expr_value_base(string, Index, Base) :-
+    format(atom(Base), 'plawk_string_~w', [Index]).
+
+plawk_emit_print_line_length_ir(print_context(normal, _Prefix, Index), LenIR, LineLen64, LineLen) :-
     format(atom(LineLen64),
         '  %line_len64_~w = call i64 @strlen(i8* %line_s)',
         [Index]),
@@ -1858,69 +1918,7 @@ plawk_emit_print_expr_ir(field(0), _FieldSeparator, Index,
         '  %line_len_~w = trunc i64 %line_len64_~w to i32',
         [Index, Index]),
     format(atom(LenIR), '%line_len_~w', [Index]).
-
-plawk_emit_print_expr_ir(field(FieldIndex), FieldSeparator, Index,
-        slice(slice, slice, LenIR, PtrIR), [], [SliceIR]) :-
-    FieldIndex > 0,
-    format(atom(Base), 'plawk_field_~w', [Index]),
-    llvm_emit_atom_field_slice('%line', FieldIndex, FieldSeparator, Base, SliceIR),
-    format(atom(LenIR), '%~w_len', [Base]),
-    format(atom(PtrIR), '%~w_ptr', [Base]).
-
-plawk_emit_prefixed_print_expr_ir(special('NR'), _FieldSeparator, Prefix, Index,
-        i64(Base, Base, '%current_nr'), [], []) :-
-    format(atom(Base), '~w_nr_~w', [Prefix, Index]).
-
-plawk_emit_prefixed_print_expr_ir(string(Value), _FieldSeparator, Prefix, Index,
-        string(Base, PtrIR), [GlobalIR], [StringPtr]) :-
-    format(atom(Base), '~w_string_~w', [Prefix, Index]),
-    llvm_emit_c_string_global(Base, Value, GlobalIR, _StringLen, BytesLen),
-    format(atom(StringPtr),
-        '  %~w_ptr = getelementptr [~w x i8], [~w x i8]* @.~w, i32 0, i32 0',
-        [Base, BytesLen, BytesLen, Base]),
-    format(atom(PtrIR), '%~w_ptr', [Base]).
-
-plawk_emit_prefixed_print_expr_ir(special('NF'), FieldSeparator, Prefix, Index,
-        i64(Base, Base, ValueIR), [], [CountIR]) :-
-    format(atom(Base), '~w_nf_~w', [Prefix, Index]),
-    llvm_emit_atom_field_count('%line', FieldSeparator, Base, CountIR),
-    format(atom(ValueIR), '%~w', [Base]).
-
-plawk_emit_prefixed_print_expr_ir(length(field(FieldIndex)), FieldSeparator, Prefix, Index,
-        i64(Base, Base, ValueIR), [], [LengthIR]) :-
-    format(atom(Base), '~w_length_~w', [Prefix, Index]),
-    llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, Base, LengthIR),
-    format(atom(ValueIR), '%~w', [Base]).
-
-plawk_emit_prefixed_print_expr_ir(substr(field(FieldIndex), Start, Len), FieldSeparator, Prefix, Index,
-        slice(Base, Base, LenIR, PtrIR), [], [SliceIR]) :-
-    format(atom(Base), '~w_substr_~w', [Prefix, Index]),
-    llvm_emit_atom_field_subslice('%line', FieldIndex, FieldSeparator, Start, Len, Base, SliceIR),
-    format(atom(LenIR), '%~w_len', [Base]),
-    format(atom(PtrIR), '%~w_ptr', [Base]).
-
-plawk_emit_prefixed_print_expr_ir(index(field(FieldIndex), string(Needle)), FieldSeparator, Prefix, Index,
-        i64(Base, Base, ValueIR), [GlobalIR], [CallIR]) :-
-    format(atom(Base), '~w_index_~w', [Prefix, Index]),
-    format(atom(GlobalBase), '~w_index_needle_~w', [Prefix, Index]),
-    llvm_emit_atom_field_index(GlobalBase, '%line', FieldIndex, Needle, FieldSeparator,
-        Base, GlobalIR-CallIR),
-    format(atom(ValueIR), '%~w', [Base]).
-
-plawk_emit_prefixed_print_expr_ir(tolower(field(FieldIndex)), FieldSeparator, Prefix, Index,
-        case_slice(lower, LowerBase, LenIR, PtrIR), [], SetupParts) :-
-    format(atom(LowerBase), '~w_tolower_~w', [Prefix, Index]),
-    plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, LowerBase, LenIR, PtrIR,
-        SetupParts).
-
-plawk_emit_prefixed_print_expr_ir(toupper(field(FieldIndex)), FieldSeparator, Prefix, Index,
-        case_slice(upper, UpperBase, LenIR, PtrIR), [], SetupParts) :-
-    format(atom(UpperBase), '~w_toupper_~w', [Prefix, Index]),
-    plawk_emit_case_source_slice_ir(FieldIndex, FieldSeparator, UpperBase, LenIR, PtrIR,
-        SetupParts).
-
-plawk_emit_prefixed_print_expr_ir(field(0), _FieldSeparator, Prefix, Index,
-        slice(Base, Base, LenIR, '%line_s'), [], [LineLen64, LineLen]) :-
+plawk_emit_print_line_length_ir(print_context(prefixed, Prefix, Index), LenIR, LineLen64, LineLen) :-
     format(atom(Base), '~w_line_~w', [Prefix, Index]),
     format(atom(LineLen64),
         '  %~w_len64 = call i64 @strlen(i8* %line_s)',
@@ -1930,13 +1928,11 @@ plawk_emit_prefixed_print_expr_ir(field(0), _FieldSeparator, Prefix, Index,
         [Base, Base]),
     format(atom(LenIR), '%~w_len', [Base]).
 
-plawk_emit_prefixed_print_expr_ir(field(FieldIndex), FieldSeparator, Prefix, Index,
-        slice(Base, Base, LenIR, PtrIR), [], [SliceIR]) :-
-    FieldIndex > 0,
-    format(atom(Base), '~w_field_~w', [Prefix, Index]),
-    llvm_emit_atom_field_slice('%line', FieldIndex, FieldSeparator, Base, SliceIR),
-    format(atom(LenIR), '%~w_len', [Base]),
-    format(atom(PtrIR), '%~w_ptr', [Base]).
+plawk_print_expr_output_names(print_context(normal, _Prefix, _Index), field, slice, slice) :-
+    !.
+plawk_print_expr_output_names(print_context(normal, _Prefix, _Index), Kind, Kind, Kind).
+plawk_print_expr_output_names(print_context(prefixed, Prefix, Index), Kind, Base, Base) :-
+    format(atom(Base), '~w_~w_~w', [Prefix, Kind, Index]).
 
 plawk_emit_case_source_slice_ir(0, _FieldSeparator, Base, LenIR, '%line_s', [LineLen64]) :-
     format(atom(LineLen64),

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -866,6 +866,17 @@ test(surface_if_else_branch_string_print_uses_prefixed_globals) :-
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 
+test(surface_if_else_branch_print_uses_shared_prefixed_expr_lowering) :-
+    plawk_parse_string("{ if ($1 == \"ERROR\") { print length($2), substr($2, 1, 2), index($2, \"is\") } else { print NF } } END { print \"done\" }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_0_then_print_0_length_0 = call i64 @wam_atom_field_length_value(%Value %line, i64 2, i8 32)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_0_then_print_0_substr_1 = call %WamSlice @wam_atom_field_subslice_value(%Value %line, i64 2, i8 32, i64 1, i64 2)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@.rule_5F0_5Fbody_5Fif_5F0_5Fthen_5Fprint_5F0_5Findex_5Fneedle_5F2 = private constant [3 x i8] c"is\\00"'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_0_then_print_0_index_2 = call i64 @wam_atom_field_index_value(%Value %line, i64 2, i8 32'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_0_else_print_0_nf_0 = call i64 @wam_atom_field_count_value(%Value %line, i8 32)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
 test(surface_terminal_next_uses_native_continue_phi) :-
     plawk_parse_string("$1 == \"DEBUG\" { skipped++; next } { total++ } END { print total, skipped }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),


### PR DESCRIPTION
## Summary
- route top-level and branch-local PLAWK print expressions through one context-aware lowering path
- keep prefixed SSA/global naming for branch-local prints while sharing `$N`, `NF`, `length`, `substr`, `index`, and case-transform clauses
- add branch-local coverage for prefixed `length`, `substr`, `index`, and `NF` print expressions
- document the shared print-expression lowering boundary

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`