### PR TITLE
Share PLAWK i64 expression lowering

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -297,7 +297,10 @@ counter threaded through the stream loop as top-level `print NR`. Print
 expression lowering now shares one context-aware path for top-level and
 branch-local prints; the context supplies prefixed names while `$N`, `NF`,
 `length`, `substr`, `index`, and case transforms use the same expression
-lowering clauses. Terminal
+lowering clauses. Numeric expression lowering is also factored through a shared
+`plawk_i64_expr_ir` layer, so scalar updates and print expressions both consume
+the same native `i64` emitters for constants, `NR`, `NF`, `length($N)`, numeric
+field coercion, and `index($N, "...")` where those forms apply. Terminal
 branch-local `next` branches directly to the stream-loop continuation and adds
 the selected branch's scalar values to the loop phi inputs. Terminal
 branch-local `break` branches to the same dedicated stream-close block as

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1442,21 +1442,47 @@ plawk_scalar_update_operation_ir(set(Expr), FieldSeparator, Prefix, SlotIndex,
     plawk_join_nonempty_ir([SetupIR, SetLine], IR).
 
 plawk_scalar_numeric_expr_ir(const(Value), _FieldSeparator, _Prefix, _SlotIndex,
-        _OpIndex, ValueIR, '') :-
-    integer(Value),
-    format(atom(ValueIR), '~w', [Value]).
+        _OpIndex, ValueIR, IR) :-
+    plawk_i64_expr_ir_parts(const(Value), 0, scalar_const, scalar_const_global,
+        ValueIR, IR).
 plawk_scalar_numeric_expr_ir(length(FieldIndex), FieldSeparator, Prefix, SlotIndex,
         OpIndex, ValueIR, IR) :-
     format(atom(LengthBase), '~w_slot_~w_op_~w_len', [Prefix, SlotIndex, OpIndex]),
-    llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, LengthBase, IR),
-    format(atom(ValueIR), '%~w', [LengthBase]).
+    plawk_i64_expr_ir_parts(length(FieldIndex), FieldSeparator, LengthBase, LengthBase,
+        ValueIR, IR).
 plawk_scalar_numeric_expr_ir(field_i64(FieldIndex), FieldSeparator, Prefix, SlotIndex,
         OpIndex, ValueIR, IR) :-
     format(atom(ParseBase), '~w_slot_~w_op_~w_field_i64',
         [Prefix, SlotIndex, OpIndex]),
-    format(atom(ValueIR), '%~w_value_or_default', [ParseBase]),
+    plawk_i64_expr_ir_parts(field_i64(FieldIndex), FieldSeparator, ParseBase, ParseBase,
+        ValueIR, IR).
+
+plawk_i64_expr_ir_parts(Expr, FieldSeparator, Base, GlobalBase, ValueIR, IR) :-
+    plawk_i64_expr_ir(Expr, FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts),
+    plawk_join_nonempty_ir(GlobalParts, GlobalIR),
+    atomic_list_concat(SetupParts, '\n', SetupIR),
+    plawk_join_nonempty_ir([GlobalIR, SetupIR], IR).
+
+plawk_i64_expr_ir(const(Value), _FieldSeparator, _Base, _GlobalBase, ValueIR, [], []) :-
+    integer(Value),
+    format(atom(ValueIR), '~w', [Value]).
+plawk_i64_expr_ir(nr, _FieldSeparator, _Base, _GlobalBase, '%current_nr', [], []).
+plawk_i64_expr_ir(nf, FieldSeparator, Base, _GlobalBase, ValueIR, [], [CountIR]) :-
+    llvm_emit_atom_field_count('%line', FieldSeparator, Base, CountIR),
+    format(atom(ValueIR), '%~w', [Base]).
+plawk_i64_expr_ir(length(FieldIndex), FieldSeparator, Base, _GlobalBase, ValueIR, [], [LengthIR]) :-
+    llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, Base, LengthIR),
+    format(atom(ValueIR), '%~w', [Base]).
+plawk_i64_expr_ir(field_i64(FieldIndex), FieldSeparator, Base, _GlobalBase, ValueIR, [], [ParseIR]) :-
+    format(atom(ValueIR), '%~w_value_or_default', [Base]),
     llvm_emit_atom_field_i64_or_default('%line', FieldIndex, FieldSeparator, 0,
-        ParseBase, ValueIR, IR).
+        Base, ValueIR, ParseIR).
+plawk_i64_expr_ir(index(FieldIndex, Needle), FieldSeparator, Base, GlobalBase,
+        ValueIR, [GlobalIR], [CallIR]) :-
+    llvm_emit_atom_field_index(GlobalBase, '%line', FieldIndex, Needle, FieldSeparator,
+        Base, GlobalIR-CallIR),
+    format(atom(ValueIR), '%~w', [Base]).
 
 plawk_branch_to_done_ir(none, _DoneLabel, '  br label %continue_loop') :-
     !.
@@ -1817,8 +1843,9 @@ plawk_emit_prefixed_print_expr_ir(Field, FieldSeparator, Prefix, Index,
         print_context(prefixed, Prefix, Index), Type, GlobalParts, SetupParts).
 
 plawk_emit_print_expr_for_context(special('NR'), _FieldSeparator, Context,
-        i64(FmtPrefix, PrintPrefix, '%current_nr'), [], []) :-
-    plawk_print_expr_output_names(Context, nr, FmtPrefix, PrintPrefix).
+        i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
+    plawk_print_expr_output_names(Context, nr, FmtPrefix, PrintPrefix),
+    plawk_i64_expr_ir(nr, 0, nr, nr, ValueIR, GlobalParts, SetupParts).
 
 plawk_emit_print_expr_for_context(string(Value), _FieldSeparator, Context,
         string(Base, PtrIR), [GlobalIR], [StringPtr]) :-
@@ -1830,18 +1857,17 @@ plawk_emit_print_expr_for_context(string(Value), _FieldSeparator, Context,
     format(atom(PtrIR), '%~w_ptr', [Base]).
 
 plawk_emit_print_expr_for_context(special('NF'), FieldSeparator, Context,
-        i64(FmtPrefix, PrintPrefix, ValueIR), [], [CountIR]) :-
+        i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
     plawk_print_expr_value_base(Context, nf, Base),
     plawk_print_expr_output_names(Context, nf, FmtPrefix, PrintPrefix),
-    llvm_emit_atom_field_count('%line', FieldSeparator, Base, CountIR),
-    format(atom(ValueIR), '%~w', [Base]).
+    plawk_i64_expr_ir(nf, FieldSeparator, Base, Base, ValueIR, GlobalParts, SetupParts).
 
 plawk_emit_print_expr_for_context(length(field(FieldIndex)), FieldSeparator, Context,
-        i64(FmtPrefix, PrintPrefix, ValueIR), [], [LengthIR]) :-
+        i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
     plawk_print_expr_value_base(Context, length, Base),
     plawk_print_expr_output_names(Context, length, FmtPrefix, PrintPrefix),
-    llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, Base, LengthIR),
-    format(atom(ValueIR), '%~w', [Base]).
+    plawk_i64_expr_ir(length(FieldIndex), FieldSeparator, Base, Base,
+        ValueIR, GlobalParts, SetupParts).
 
 plawk_emit_print_expr_for_context(substr(field(FieldIndex), Start, Len), FieldSeparator, Context,
         slice(FmtPrefix, PrintPrefix, LenIR, PtrIR), [], [SliceIR]) :-
@@ -1852,13 +1878,12 @@ plawk_emit_print_expr_for_context(substr(field(FieldIndex), Start, Len), FieldSe
     format(atom(PtrIR), '%~w_ptr', [Base]).
 
 plawk_emit_print_expr_for_context(index(field(FieldIndex), string(Needle)), FieldSeparator, Context,
-        i64(FmtPrefix, PrintPrefix, ValueIR), [GlobalIR], [CallIR]) :-
+        i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
     plawk_print_expr_value_base(Context, index, Base),
     plawk_print_expr_value_base(Context, index_needle, GlobalBase),
     plawk_print_expr_output_names(Context, index, FmtPrefix, PrintPrefix),
-    llvm_emit_atom_field_index(GlobalBase, '%line', FieldIndex, Needle, FieldSeparator,
-        Base, GlobalIR-CallIR),
-    format(atom(ValueIR), '%~w', [Base]).
+    plawk_i64_expr_ir(index(FieldIndex, Needle), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts).
 
 plawk_emit_print_expr_for_context(tolower(field(FieldIndex)), FieldSeparator, Context,
         case_slice(lower, LowerBase, LenIR, PtrIR), [], SetupParts) :-


### PR DESCRIPTION
## Summary
- add a shared `plawk_i64_expr_ir` layer for native i64 expression setup
- route scalar numeric updates for constants, `length($N)`, and numeric `$N` through the shared helper
- route print expressions for `NR`, `NF`, `length($N)`, and `index($N, "...")` through the same helper
- document the shared numeric expression boundary

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests([plawk_surface_prefix_print:surface_scalar_add_assign_uses_native_state_and_field_length,plawk_surface_prefix_print:surface_scalar_add_assign_uses_native_field_i64_parse,plawk_surface_prefix_print:surface_nr_print_uses_native_record_counter,plawk_surface_prefix_print:surface_nf_print_uses_native_field_count,plawk_surface_prefix_print:surface_length_print_uses_native_field_length,plawk_surface_prefix_print:surface_index_print_uses_native_field_index,plawk_surface_prefix_print:surface_if_else_branch_print_uses_shared_prefixed_expr_lowering])" -t halt`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`