### PR TITLE
Add PLAWK int field expression

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -261,6 +261,9 @@ prints can also call native `length($N)` through the shared
 `@wam_atom_field_length_value` helper, native `substr($N, Start, Len)` through
 the allocation-free `@wam_atom_field_subslice_value` helper, and native
 `index($N, "literal")` through the shared `@wam_atom_field_index_value` helper.
+Explicit print-side numeric coercions such as `int($N)` lower through the shared
+`@wam_atom_field_i64_value` parse helper and print zero when the field is
+missing or not a strict signed decimal.
 Print-only `tolower($N)` and `toupper($N)` lower through shared
 `@wam_print_ascii_lower_slice` and `@wam_print_ascii_upper_slice` helpers, so
 case mapping streams bytes without allocating a transformed atom.

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -83,6 +83,8 @@ such as `$1 == "ERROR" { print length($2), $2 }` and native byte substrings such
 as `$1 == "ERROR" { print substr($2, 1, 3) }`, and native byte searches such as
 `$1 == "ERROR" { print index($2, "sk") }`. Rule prints can also emit ASCII
 case-mapped field slices such as `$1 == "ERROR" { print tolower($2), toupper($0) }`.
+Explicit numeric field coercion is available as `int($N)`, e.g.
+`$1 == "ERROR" { print $3, int($3) }`; failed numeric parses print `0`.
 Numeric field guards use the shared WAM/LLVM `i64` comparison helper, so forms
 such as `$3 > 100 { print $1, $3 }` and `$2 <= -5 { cold++ }` stay in the native
 streaming loop.
@@ -97,7 +99,7 @@ e.g. `$1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }`.
 Plain scalar assignment uses the same native slot path and preserves source
 order with later updates, e.g. `$1 == "ERROR" { last_len = length($0); hits++ }
 END { print hits, last_len }`. The current assignment expression subset is
-integer literals, `length($N)`, and numeric `$N`.
+integer literals, `length($N)`, numeric `$N`, and explicit `int($N)`.
 Scalar slot updates can also sit behind native `if/else` guards, e.g.
 `{ if ($1 == "ERROR") { errors++; last_len = length($0) } else { non_errors++ } }
 END { print errors, non_errors, last_len }`. The first branch slice supports

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -123,7 +123,9 @@ The Phase 0 examples use the counter as `NR`, collect printed lines in
 The native Phase 2 surface can compile rule prints with `NR`, `NF`, selected
 fields, native field lengths such as `length($2)`, native byte substrings such as
 `substr($2, 1, 3)`, and `OFS`, matching the first awk-style example above. It can
-also compile a scalar counter and an `END` action:
+also print explicit numeric field coercions with `int($N)`, where missing or
+non-numeric fields become `0`. It can also compile a scalar counter and an `END`
+action:
 
 ```awk
 $1 == "ERROR" { count++ } END { print count }
@@ -369,6 +371,13 @@ present:
 
 ```awk
 $1 == "ERROR" { print index($2, "sk"), index($0, "disk") }
+```
+
+`int($N)` prints the strict signed-decimal numeric value of a field, or `0` for
+missing and non-numeric fields:
+
+```awk
+$1 == "ERROR" { print $3, int($3) }
 ```
 
 `tolower` and `toupper` can print ASCII case-mapped field bytes without

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -42,6 +42,7 @@
 %      BEGIN { FS = ":" } $1 == "ERROR" { counts[$2]++ } END { print counts["disk"] }
 %      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
 %      $3 > 100 { big++ } END { print big }
+%      $1 == "ERROR" { print $3, int($3) }
 %      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
@@ -1300,6 +1301,7 @@ plawk_rule_body_print_field(field(_)).
 plawk_rule_body_print_field(string(_)).
 plawk_rule_body_print_field(special('NR')).
 plawk_rule_body_print_field(special('NF')).
+plawk_rule_body_print_field(int(field(_))).
 plawk_rule_body_print_field(length(field(_))).
 plawk_rule_body_print_field(substr(field(_), _Start, _Len)).
 plawk_rule_body_print_field(index(field(_), string(_))).
@@ -1322,12 +1324,16 @@ plawk_scalar_action_update(add(var(Name), length(field(FieldIndex))), Name, add(
     FieldIndex >= 0.
 plawk_scalar_action_update(add(var(Name), field(FieldIndex)), Name, add(field_i64(FieldIndex))) :-
     FieldIndex >= 0.
+plawk_scalar_action_update(add(var(Name), int(field(FieldIndex))), Name, add(field_i64(FieldIndex))) :-
+    FieldIndex >= 0.
 plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) :-
     integer(Value),
     Value >= 0.
 plawk_scalar_action_update(set(var(Name), length(field(FieldIndex))), Name, set(length(FieldIndex))) :-
     FieldIndex >= 0.
 plawk_scalar_action_update(set(var(Name), field(FieldIndex)), Name, set(field_i64(FieldIndex))) :-
+    FieldIndex >= 0.
+plawk_scalar_action_update(set(var(Name), int(field(FieldIndex))), Name, set(field_i64(FieldIndex))) :-
     FieldIndex >= 0.
 
 plawk_scalar_action_sequence_pairs([], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
@@ -1862,6 +1868,13 @@ plawk_emit_print_expr_for_context(special('NF'), FieldSeparator, Context,
     plawk_print_expr_output_names(Context, nf, FmtPrefix, PrintPrefix),
     plawk_i64_expr_ir(nf, FieldSeparator, Base, Base, ValueIR, GlobalParts, SetupParts).
 
+plawk_emit_print_expr_for_context(int(field(FieldIndex)), FieldSeparator, Context,
+        i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
+    plawk_print_expr_value_base(Context, int, Base),
+    plawk_print_expr_output_names(Context, int, FmtPrefix, PrintPrefix),
+    plawk_i64_expr_ir(field_i64(FieldIndex), FieldSeparator, Base, Base,
+        ValueIR, GlobalParts, SetupParts).
+
 plawk_emit_print_expr_for_context(length(field(FieldIndex)), FieldSeparator, Context,
         i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
     plawk_print_expr_value_base(Context, length, Base),
@@ -1918,6 +1931,8 @@ plawk_print_expr_value_base(print_context(prefixed, Prefix, Index), Kind, Base) 
 
 plawk_normal_print_expr_value_base(nf, Index, Base) :-
     format(atom(Base), 'plawk_nf_~w', [Index]).
+plawk_normal_print_expr_value_base(int, Index, Base) :-
+    format(atom(Base), 'plawk_int_~w', [Index]).
 plawk_normal_print_expr_value_base(length, Index, Base) :-
     format(atom(Base), 'plawk_length_~w', [Index]).
 plawk_normal_print_expr_value_base(substr, Index, Base) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -21,6 +21,7 @@
 %      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
 %      { count++ } END { print "count", count }
 %      $3 > 100 { big++ } END { print big }
+%      $1 == "ERROR" { print $3, int($3) }
 %      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %      $1 == "DEBUG" { skipped++; next } { total++ } END { print total, skipped }
@@ -357,6 +358,15 @@ scalar_delta_expr(field(Index)) -->
       number_codes(Index, IndexCodes),
       Index >= 0
     }.
+scalar_delta_expr(int(Field)) -->
+    "int",
+    ws,
+    "(",
+    ws,
+    field_expr(Field),
+    ws,
+    ")",
+    { Field = field(_) }.
 scalar_delta_expr(length(Field)) -->
     "length",
     ws,
@@ -390,6 +400,15 @@ field_expr(special('NR')) -->
     "NR".
 field_expr(special('NF')) -->
     "NF".
+field_expr(int(Field)) -->
+    "int",
+    ws,
+    "(",
+    ws,
+    field_expr(Field),
+    ws,
+    ")",
+    { Field = field(_) }.
 field_expr(length(Field)) -->
     "length",
     ws,

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -75,6 +75,11 @@ test(parses_field_eq_print_index_field_rule) :-
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
         [print([index(field(2), string("sk")), index(field(0), string("disk"))])])], [])).
 
+test(parses_field_eq_print_int_field_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { print $3, int($3) }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [print([field(3), int(field(3))])])], [])).
+
 test(parses_field_eq_print_case_field_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { print tolower($2), toupper($0) }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
@@ -185,6 +190,12 @@ test(parses_field_numeric_scalar_add_assign_end_print_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { bytes += $3; last = $3 } END { print bytes, last }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
         [add(var(bytes), field(3)), set(var(last), field(3))])],
+        [end([print([var(bytes), var(last)])])])).
+
+test(parses_field_int_scalar_add_assign_end_print_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { bytes += int($3); last = int($3) } END { print bytes, last }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [add(var(bytes), int(field(3))), set(var(last), int(field(3)))])],
         [end([print([var(bytes), var(last)])])])).
 
 test(parses_always_scalar_add_assign_end_print_rule) :-
@@ -384,6 +395,11 @@ test(surface_field_eq_prints_native_index_values) :-
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR network down now\n",
         "3 7\n0 0\n").
 
+test(surface_field_eq_prints_native_int_values) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { print $3, int($3) }\n",
+        "INFO boot 7\nERROR disk 10\nWARN cpu 20\nERROR net -3\nERROR bad nope\n",
+        "10 10\n-3 -3\nnope 0\n").
+
 test(surface_field_eq_prints_native_case_values) :-
     run_surface_print_smoke("$1 == \"ERROR\" { print tolower($2), toupper($0) }\n",
         "INFO boot ok\nERROR Disk Full\nWARN cpu hot\nERROR network Down\n",
@@ -493,6 +509,11 @@ test(surface_begin_field_separator_drives_numeric_scalar_values) :-
     run_surface_print_smoke("BEGIN { FS = \":\" } $1 == \"ERROR\" { bytes += $3; last = $3 } END { print bytes, last }\n",
         "INFO:boot:7\nERROR:disk:10\nWARN:cpu:20\nERROR:net:-3\nERROR:bad:nope\n",
         "7 0\n").
+
+test(surface_begin_field_separator_drives_int_printing) :-
+    run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print $3, int($3) }\n",
+        "INFO:boot:7\nERROR:disk:10\nWARN:cpu:20\nERROR:net:-3\nERROR:bad:nope\n",
+        "10,10\n-3,-3\nnope,0\n").
 
 test(surface_always_scalar_add_assign_accumulates_constants) :-
     run_surface_print_smoke("{ total += 3 } END { print total }\n",
@@ -788,6 +809,17 @@ test(surface_scalar_add_assign_uses_native_field_i64_parse) :-
     assertion(once(sub_atom(DriverIR, _, _, _, 'select i1 %rule_0_body_slot_1_op_1_field_i64_ok'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_0_op_0 = add i64 %slot_0, %rule_0_body_slot_0_op_0_field_i64_value_or_default'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_slot_1_op_1 = add i64 0, %rule_0_body_slot_1_op_1_field_i64_value_or_default'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_int_print_uses_native_field_i64_parse) :-
+    plawk_parse_string("BEGIN { FS = \":\" } $1 == \"ERROR\" { print $3, int($3) }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_i64_value(%Value %line, i64 3, i8 58)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_1_value = extractvalue %WamI64Parse %plawk_int_1, 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_1_ok = extractvalue %WamI64Parse %plawk_int_1, 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_1_value_or_default = select i1 %plawk_int_1_ok, i64 %plawk_int_1_value, i64 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_int_1 = call i32 (i8*, ...) @printf(i8* %int_fmt_1, i64 %plawk_int_1_value_or_default)'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 


### PR DESCRIPTION
## Summary
- add `int($N)` parsing for rule print fields and scalar numeric expressions
- lower print-side `int($N)` through the shared native i64 field parser with zero-on-failed-parse semantics
- allow explicit `int($N)` in scalar `+=` and assignment while preserving existing `$N` numeric behavior
- document the new explicit numeric coercion form in the README, tutorial, and design notes

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests([plawk_surface_prefix_print:parses_field_eq_print_int_field_rule,plawk_surface_prefix_print:parses_field_int_scalar_add_assign_end_print_rule,plawk_surface_prefix_print:surface_field_eq_prints_native_int_values,plawk_surface_prefix_print:surface_begin_field_separator_drives_int_printing,plawk_surface_prefix_print:surface_int_print_uses_native_field_i64_parse,plawk_surface_prefix_print:surface_scalar_add_assign_uses_native_field_i64_parse])" -t halt`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`