### PR TITLE
[codex] Add PLAWK int field add expressions

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -263,7 +263,8 @@ the allocation-free `@wam_atom_field_subslice_value` helper, and native
 `index($N, "literal")` through the shared `@wam_atom_field_index_value` helper.
 Explicit print-side numeric coercions such as `int($N)` lower through the shared
 `@wam_atom_field_i64_value` parse helper and print zero when the field is
-missing or not a strict signed decimal.
+missing or not a strict signed decimal. The first composed arithmetic form,
+`int($N) + K`, lowers as the same native parse followed by an `add i64`.
 Print-only `tolower($N)` and `toupper($N)` lower through shared
 `@wam_print_ascii_lower_slice` and `@wam_print_ascii_upper_slice` helpers, so
 case mapping streams bytes without allocating a transformed atom.
@@ -303,7 +304,8 @@ branch-local prints; the context supplies prefixed names while `$N`, `NF`,
 lowering clauses. Numeric expression lowering is also factored through a shared
 `plawk_i64_expr_ir` layer, so scalar updates and print expressions both consume
 the same native `i64` emitters for constants, `NR`, `NF`, `length($N)`, numeric
-field coercion, and `index($N, "...")` where those forms apply. Terminal
+field coercion, `int($N) + K`, and `index($N, "...")` where those forms apply.
+Terminal
 branch-local `next` branches directly to the stream-loop continuation and adds
 the selected branch's scalar values to the loop phi inputs. Terminal
 branch-local `break` branches to the same dedicated stream-close block as

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -85,6 +85,8 @@ as `$1 == "ERROR" { print substr($2, 1, 3) }`, and native byte searches such as
 case-mapped field slices such as `$1 == "ERROR" { print tolower($2), toupper($0) }`.
 Explicit numeric field coercion is available as `int($N)`, e.g.
 `$1 == "ERROR" { print $3, int($3) }`; failed numeric parses print `0`.
+The first arithmetic composition form is `int($N) + K`, e.g.
+`$1 == "ERROR" { print int($3) + 1 }`.
 Numeric field guards use the shared WAM/LLVM `i64` comparison helper, so forms
 such as `$3 > 100 { print $1, $3 }` and `$2 <= -5 { cold++ }` stay in the native
 streaming loop.
@@ -99,7 +101,8 @@ e.g. `$1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }`.
 Plain scalar assignment uses the same native slot path and preserves source
 order with later updates, e.g. `$1 == "ERROR" { last_len = length($0); hits++ }
 END { print hits, last_len }`. The current assignment expression subset is
-integer literals, `length($N)`, numeric `$N`, and explicit `int($N)`.
+integer literals, `length($N)`, numeric `$N`, explicit `int($N)`, and
+`int($N) + K`.
 Scalar slot updates can also sit behind native `if/else` guards, e.g.
 `{ if ($1 == "ERROR") { errors++; last_len = length($0) } else { non_errors++ } }
 END { print errors, non_errors, last_len }`. The first branch slice supports

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -124,8 +124,8 @@ The native Phase 2 surface can compile rule prints with `NR`, `NF`, selected
 fields, native field lengths such as `length($2)`, native byte substrings such as
 `substr($2, 1, 3)`, and `OFS`, matching the first awk-style example above. It can
 also print explicit numeric field coercions with `int($N)`, where missing or
-non-numeric fields become `0`. It can also compile a scalar counter and an `END`
-action:
+non-numeric fields become `0`, and the first arithmetic composition form
+`int($N) + K`. It can also compile a scalar counter and an `END` action:
 
 ```awk
 $1 == "ERROR" { count++ } END { print count }
@@ -378,6 +378,13 @@ missing and non-numeric fields:
 
 ```awk
 $1 == "ERROR" { print $3, int($3) }
+```
+
+The current arithmetic print subset can add a non-negative integer constant to
+that coerced value:
+
+```awk
+$1 == "ERROR" { print int($3) + 1 }
 ```
 
 `tolower` and `toupper` can print ASCII case-mapped field bytes without

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -43,6 +43,7 @@
 %      BEGIN { FS = ":"; OFS = "," } $1 == "ERROR" { print $2, $3 }
 %      $3 > 100 { big++ } END { print big }
 %      $1 == "ERROR" { print $3, int($3) }
+%      $1 == "ERROR" { print int($3) + 1 }
 %      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
@@ -1302,6 +1303,7 @@ plawk_rule_body_print_field(string(_)).
 plawk_rule_body_print_field(special('NR')).
 plawk_rule_body_print_field(special('NF')).
 plawk_rule_body_print_field(int(field(_))).
+plawk_rule_body_print_field(add_i64(int(field(_)), int(_))).
 plawk_rule_body_print_field(length(field(_))).
 plawk_rule_body_print_field(substr(field(_), _Start, _Len)).
 plawk_rule_body_print_field(index(field(_), string(_))).
@@ -1326,6 +1328,11 @@ plawk_scalar_action_update(add(var(Name), field(FieldIndex)), Name, add(field_i6
     FieldIndex >= 0.
 plawk_scalar_action_update(add(var(Name), int(field(FieldIndex))), Name, add(field_i64(FieldIndex))) :-
     FieldIndex >= 0.
+plawk_scalar_action_update(add(var(Name), add_i64(int(field(FieldIndex)), int(Value))),
+        Name, add(add_i64(int(field(FieldIndex)), int(Value)))) :-
+    FieldIndex >= 0,
+    integer(Value),
+    Value >= 0.
 plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) :-
     integer(Value),
     Value >= 0.
@@ -1335,6 +1342,11 @@ plawk_scalar_action_update(set(var(Name), field(FieldIndex)), Name, set(field_i6
     FieldIndex >= 0.
 plawk_scalar_action_update(set(var(Name), int(field(FieldIndex))), Name, set(field_i64(FieldIndex))) :-
     FieldIndex >= 0.
+plawk_scalar_action_update(set(var(Name), add_i64(int(field(FieldIndex)), int(Value))),
+        Name, set(add_i64(int(field(FieldIndex)), int(Value)))) :-
+    FieldIndex >= 0,
+    integer(Value),
+    Value >= 0.
 
 plawk_scalar_action_sequence_pairs([], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
         OpIndex, Values, Values, OpIndex, CurrentLabel, []) -->
@@ -1462,6 +1474,12 @@ plawk_scalar_numeric_expr_ir(field_i64(FieldIndex), FieldSeparator, Prefix, Slot
         [Prefix, SlotIndex, OpIndex]),
     plawk_i64_expr_ir_parts(field_i64(FieldIndex), FieldSeparator, ParseBase, ParseBase,
         ValueIR, IR).
+plawk_scalar_numeric_expr_ir(add_i64(Left, int(Value)), FieldSeparator, Prefix, SlotIndex,
+        OpIndex, ValueIR, IR) :-
+    format(atom(AddBase), '~w_slot_~w_op_~w_i64_add',
+        [Prefix, SlotIndex, OpIndex]),
+    plawk_i64_expr_ir_parts(add_i64(Left, int(Value)), FieldSeparator, AddBase,
+        AddBase, ValueIR, IR).
 
 plawk_i64_expr_ir_parts(Expr, FieldSeparator, Base, GlobalBase, ValueIR, IR) :-
     plawk_i64_expr_ir(Expr, FieldSeparator, Base, GlobalBase,
@@ -1480,10 +1498,24 @@ plawk_i64_expr_ir(nf, FieldSeparator, Base, _GlobalBase, ValueIR, [], [CountIR])
 plawk_i64_expr_ir(length(FieldIndex), FieldSeparator, Base, _GlobalBase, ValueIR, [], [LengthIR]) :-
     llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, Base, LengthIR),
     format(atom(ValueIR), '%~w', [Base]).
+plawk_i64_expr_ir(int(field(FieldIndex)), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    plawk_i64_expr_ir(field_i64(FieldIndex), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts).
 plawk_i64_expr_ir(field_i64(FieldIndex), FieldSeparator, Base, _GlobalBase, ValueIR, [], [ParseIR]) :-
     format(atom(ValueIR), '%~w_value_or_default', [Base]),
     llvm_emit_atom_field_i64_or_default('%line', FieldIndex, FieldSeparator, 0,
         Base, ValueIR, ParseIR).
+plawk_i64_expr_ir(add_i64(Left, int(Value)), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    integer(Value),
+    format(atom(LeftBase), '~w_lhs', [Base]),
+    format(atom(LeftGlobalBase), '~w_lhs', [GlobalBase]),
+    plawk_i64_expr_ir(Left, FieldSeparator, LeftBase, LeftGlobalBase,
+        LeftValueIR, GlobalParts, LeftSetupParts),
+    format(atom(ValueIR), '%~w', [Base]),
+    format(atom(AddIR), '  ~w = add i64 ~w, ~w', [ValueIR, LeftValueIR, Value]),
+    append(LeftSetupParts, [AddIR], SetupParts).
 plawk_i64_expr_ir(index(FieldIndex, Needle), FieldSeparator, Base, GlobalBase,
         ValueIR, [GlobalIR], [CallIR]) :-
     llvm_emit_atom_field_index(GlobalBase, '%line', FieldIndex, Needle, FieldSeparator,
@@ -1875,6 +1907,13 @@ plawk_emit_print_expr_for_context(int(field(FieldIndex)), FieldSeparator, Contex
     plawk_i64_expr_ir(field_i64(FieldIndex), FieldSeparator, Base, Base,
         ValueIR, GlobalParts, SetupParts).
 
+plawk_emit_print_expr_for_context(add_i64(Left, int(Value)), FieldSeparator, Context,
+        i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
+    plawk_print_expr_value_base(Context, int_add, Base),
+    plawk_print_expr_output_names(Context, int_add, FmtPrefix, PrintPrefix),
+    plawk_i64_expr_ir(add_i64(Left, int(Value)), FieldSeparator, Base, Base,
+        ValueIR, GlobalParts, SetupParts).
+
 plawk_emit_print_expr_for_context(length(field(FieldIndex)), FieldSeparator, Context,
         i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
     plawk_print_expr_value_base(Context, length, Base),
@@ -1933,6 +1972,8 @@ plawk_normal_print_expr_value_base(nf, Index, Base) :-
     format(atom(Base), 'plawk_nf_~w', [Index]).
 plawk_normal_print_expr_value_base(int, Index, Base) :-
     format(atom(Base), 'plawk_int_~w', [Index]).
+plawk_normal_print_expr_value_base(int_add, Index, Base) :-
+    format(atom(Base), 'plawk_int_add_~w', [Index]).
 plawk_normal_print_expr_value_base(length, Index, Base) :-
     format(atom(Base), 'plawk_length_~w', [Index]).
 plawk_normal_print_expr_value_base(substr, Index, Base) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -22,6 +22,7 @@
 %      { count++ } END { print "count", count }
 %      $3 > 100 { big++ } END { print big }
 %      $1 == "ERROR" { print $3, int($3) }
+%      $1 == "ERROR" { print int($3) + 1 }
 %      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %      $1 == "DEBUG" { skipped++; next } { total++ } END { print total, skipped }
@@ -351,6 +352,15 @@ scalar_delta_expr(int(Value)) -->
     { ValueCodes \== [],
       number_codes(Value, ValueCodes),
       Value >= 0 }.
+scalar_delta_expr(add_i64(Left, int(Value))) -->
+    int_field_expr(Left),
+    ws,
+    "+",
+    ws,
+    integer_codes(ValueCodes),
+    { ValueCodes \== [],
+      number_codes(Value, ValueCodes),
+      Value >= 0 }.
 scalar_delta_expr(field(Index)) -->
     "$",
     integer_codes(IndexCodes),
@@ -359,14 +369,7 @@ scalar_delta_expr(field(Index)) -->
       Index >= 0
     }.
 scalar_delta_expr(int(Field)) -->
-    "int",
-    ws,
-    "(",
-    ws,
-    field_expr(Field),
-    ws,
-    ")",
-    { Field = field(_) }.
+    int_field_expr(int(Field)).
 scalar_delta_expr(length(Field)) -->
     "length",
     ws,
@@ -400,15 +403,17 @@ field_expr(special('NR')) -->
     "NR".
 field_expr(special('NF')) -->
     "NF".
+field_expr(add_i64(Left, int(Value))) -->
+    int_field_expr(Left),
+    ws,
+    "+",
+    ws,
+    integer_codes(ValueCodes),
+    { ValueCodes \== [],
+      number_codes(Value, ValueCodes),
+      Value >= 0 }.
 field_expr(int(Field)) -->
-    "int",
-    ws,
-    "(",
-    ws,
-    field_expr(Field),
-    ws,
-    ")",
-    { Field = field(_) }.
+    int_field_expr(int(Field)).
 field_expr(length(Field)) -->
     "length",
     ws,
@@ -493,6 +498,16 @@ field_expr(string(Value)) -->
     }.
 field_expr(var(Name)) -->
     identifier(Name).
+
+int_field_expr(int(Field)) -->
+    "int",
+    ws,
+    "(",
+    ws,
+    field_expr(Field),
+    ws,
+    ")",
+    { Field = field(_) }.
 
 assoc_key_expr(field(Index)) -->
     "$",

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -80,6 +80,11 @@ test(parses_field_eq_print_int_field_rule) :-
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
         [print([field(3), int(field(3))])])], [])).
 
+test(parses_field_eq_print_int_add_field_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { print int($3) + 1 }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [print([add_i64(int(field(3)), int(1))])])], [])).
+
 test(parses_field_eq_print_case_field_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { print tolower($2), toupper($0) }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
@@ -196,6 +201,13 @@ test(parses_field_int_scalar_add_assign_end_print_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { bytes += int($3); last = int($3) } END { print bytes, last }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
         [add(var(bytes), int(field(3))), set(var(last), int(field(3)))])],
+        [end([print([var(bytes), var(last)])])])).
+
+test(parses_field_int_add_scalar_add_assign_end_print_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { bytes += int($3) + 1; last = int($3) + 1 } END { print bytes, last }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [add(var(bytes), add_i64(int(field(3)), int(1))),
+         set(var(last), add_i64(int(field(3)), int(1)))])],
         [end([print([var(bytes), var(last)])])])).
 
 test(parses_always_scalar_add_assign_end_print_rule) :-
@@ -400,6 +412,11 @@ test(surface_field_eq_prints_native_int_values) :-
         "INFO boot 7\nERROR disk 10\nWARN cpu 20\nERROR net -3\nERROR bad nope\n",
         "10 10\n-3 -3\nnope 0\n").
 
+test(surface_field_eq_prints_native_int_add_values) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { print int($3) + 1 }\n",
+        "INFO boot 7\nERROR disk 10\nWARN cpu 20\nERROR net -3\nERROR bad nope\n",
+        "11\n-2\n1\n").
+
 test(surface_field_eq_prints_native_case_values) :-
     run_surface_print_smoke("$1 == \"ERROR\" { print tolower($2), toupper($0) }\n",
         "INFO boot ok\nERROR Disk Full\nWARN cpu hot\nERROR network Down\n",
@@ -514,6 +531,16 @@ test(surface_begin_field_separator_drives_int_printing) :-
     run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print $3, int($3) }\n",
         "INFO:boot:7\nERROR:disk:10\nWARN:cpu:20\nERROR:net:-3\nERROR:bad:nope\n",
         "10,10\n-3,-3\nnope,0\n").
+
+test(surface_begin_field_separator_drives_int_add_printing) :-
+    run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print $3, int($3) + 1 }\n",
+        "INFO:boot:7\nERROR:disk:10\nWARN:cpu:20\nERROR:net:-3\nERROR:bad:nope\n",
+        "10,11\n-3,-2\nnope,1\n").
+
+test(surface_field_int_add_scalar_accumulates_values) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { bytes += int($3) + 1; last = int($3) + 1 } END { print bytes, last }\n",
+        "INFO boot 7\nERROR disk 10\nWARN cpu 20\nERROR net -3\nERROR bad nope\n",
+        "10 1\n").
 
 test(surface_always_scalar_add_assign_accumulates_constants) :-
     run_surface_print_smoke("{ total += 3 } END { print total }\n",
@@ -820,6 +847,16 @@ test(surface_int_print_uses_native_field_i64_parse) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_1_ok = extractvalue %WamI64Parse %plawk_int_1, 1'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_1_value_or_default = select i1 %plawk_int_1_ok, i64 %plawk_int_1_value, i64 0'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%printed_int_1 = call i32 (i8*, ...) @printf(i8* %int_fmt_1, i64 %plawk_int_1_value_or_default)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_int_add_print_uses_shared_i64_add_lowering) :-
+    plawk_parse_string("BEGIN { FS = \":\" } $1 == \"ERROR\" { print int($3) + 1 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_i64_value(%Value %line, i64 3, i8 58)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_add_0_lhs_value_or_default = select i1 %plawk_int_add_0_lhs_ok, i64 %plawk_int_add_0_lhs_value, i64 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_add_0 = add i64 %plawk_int_add_0_lhs_value_or_default, 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_int_add_0 = call i32 (i8*, ...) @printf(i8* %int_add_fmt_0, i64 %plawk_int_add_0)'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 


### PR DESCRIPTION
## Summary
- add the first composed i64 expression form, `int($N) + K`, for PLAWK prints and scalar numeric updates
- lower the form through the shared `plawk_i64_expr_ir` path as parse/coerce plus native `add i64`
- cover default `FS`, configured `FS/OFS`, scalar accumulation, and generated IR
- document the currently supported arithmetic subset

## Tests
- `git diff --check`
- `git diff --cached --check`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests([plawk_surface_prefix_print:parses_field_eq_print_int_add_field_rule,plawk_surface_prefix_print:parses_field_int_add_scalar_add_assign_end_print_rule,plawk_surface_prefix_print:surface_field_eq_prints_native_int_add_values,plawk_surface_prefix_print:surface_begin_field_separator_drives_int_add_printing,plawk_surface_prefix_print:surface_field_int_add_scalar_accumulates_values,plawk_surface_prefix_print:surface_int_add_print_uses_shared_i64_add_lowering])" -t halt`
- `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR','/mnt/c/Users/johnc/Scratch'),run_tests" -t halt`