### PR TITLE
fix(wam-rust): T7 input threading step 2 — whole-body runtime threading

### DIFF
--- a/src/unifyweaver/core/parallel_gate.pl
+++ b/src/unifyweaver/core/parallel_gate.pl
@@ -28,6 +28,7 @@
     parallel_aggregate_transform/5,  % +AggGoal, +Model, +Seed, -Helpers, -Plan
     parallel_aggregate_transform/6,  % +AggGoal, +ExternalInputs, +Model, +Seed, -Helpers, -Plan
     lift_embedded_aggregate/6,       % +Head, +Body, +Model, +Seed, -NewBody, -HelperClause
+    aggregate_result/2,              % +AggGoal, -ResultVar
     parallel_worthy_tier/1           % ?Tier   (multifile, overridable policy)
 ]).
 

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -29,7 +29,7 @@
 :- use_module('../bindings/rust_wam_bindings').
 :- use_module('../targets/wam_target', [compile_predicate_to_wam/3]).
 % T7 compile-time parallel-aggregate gate (consumer of the cost machinery).
-:- use_module('../core/parallel_gate', [forkable_aggregate/3, goal_parallel_decision/3, parallel_aggregate_transform/5, lift_embedded_aggregate/6]).
+:- use_module('../core/parallel_gate', [forkable_aggregate/3, goal_parallel_decision/3, parallel_aggregate_transform/5, parallel_aggregate_transform/6, lift_embedded_aggregate/6, aggregate_result/2]).
 :- use_module('../core/cost_analysis', [build_cost_model/2, goal_cost_tier/3]).
 :- use_module('../targets/wam_text_parser', [
     wam_classify_constant_token/2,
@@ -4598,25 +4598,61 @@ rust_parallel_aggregate_wrapper(QPI, Options, Helpers, WrapperRust) :-
     functor(Head, Pred, Arity),
     findall(t, clause(Module:Head, _), Marks), Marks = [t],  % exactly one clause
     clause(Module:Head, Body),                                % bind Head + Body
-    forkable_aggregate(Body, _Tmpl, _Gen),
-    build_cost_model(Module, CM),
-    parallel_aggregate_transform(Body, CM, Pred, Helpers,
-        par_aggregate(AggType, EnumName/1, BodyName/2, Result)),
+    forkable_aggregate(Body, _Tmpl, InnerGoal),
     Head =.. [Pred|Args],
+    build_cost_model(Module, CM),
+    aggregate_result(Body, Result0),
+    % External inputs = head args the aggregate's inner goal reads (minus result):
+    % they must be bound when the enum/body helpers run.
+    rust_external_inputs(InnerGoal, Args, Result0, ExternalInputs),
+    parallel_aggregate_transform(Body, ExternalInputs, CM, Pred, Helpers,
+        par_aggregate(AggType, EnumName/EnumArity, BodyName/BodyArity, Result)),
     nth1(ResultIdx, Args, ResultArg), ResultArg == Result, !,
     rust_safe_function_name(Pred/Arity, FName),
-    rust_safe_function_name(EnumName/1, EnumFn),
-    rust_safe_function_name(BodyName/2, BodyFn),
+    rust_safe_function_name(EnumName/EnumArity, EnumFn),
+    rust_safe_function_name(BodyName/BodyArity, BodyFn),
     build_rust_wam_arg_list(Arity, ArgList),
     rust_agg_reduce(AggType, ReduceExpr),
+    % Closure call-args: external-input clones (by head-arg position) then the
+    % tuple var (enum) / tuple var + value var (body).
+    rust_ext_clone_args(ExternalInputs, Args, CloneList),
+    append(CloneList, ['__in'], EnumCA), atomic_list_concat(EnumCA, ', ', EnumCallArgs),
+    append(CloneList, ['__in', '__v'], BodyCA), atomic_list_concat(BodyCA, ', ', BodyCallArgs),
     format(string(WrapperRust),
 '/// T7 parallel aggregate (route 1): ~w/~w
 pub fn ~w(~w) -> bool {
     let __base = vm.clone();
-    let __vals = crate::par_aggregate::par_collect(&__base, ~w, ~w);
+    let __vals = crate::par_aggregate::par_collect(&__base,
+        |__m, __in| crate::~w(__m, ~w),
+        |__m, __in, __v| crate::~w(__m, ~w));
     let __res = ~w;
     vm.unify(&a~w, &__res)
-}', [Pred, Arity, FName, ArgList, EnumFn, BodyFn, ReduceExpr, ResultIdx]).
+}', [Pred, Arity, FName, ArgList, EnumFn, EnumCallArgs, BodyFn, BodyCallArgs, ReduceExpr, ResultIdx]).
+
+% External inputs: distinct head-arg variables the inner goal reads, excluding
+% the result var. (Vars the aggregate enumerator/body need bound from the caller.)
+rust_external_inputs(InnerGoal, Args, Result, ExternalInputs) :-
+    term_variables(InnerGoal, IGVars),
+    % include/3 (not findall) so the collected vars stay IDENTICAL to the head
+    % args — rust_ext_clone_args/3 then finds each by ==.
+    include(rust_is_ext_input(IGVars, Result), Args, Raw),
+    rust_dedup_vars(Raw, ExternalInputs).
+
+rust_is_ext_input(IGVars, Result, A) :-
+    var(A), A \== Result, rust_var_member(IGVars, A).
+
+rust_var_member([V|_], A) :- V == A, !.
+rust_var_member([_|T], A) :- rust_var_member(T, A).
+
+rust_dedup_vars([], []).
+rust_dedup_vars([V|Vs], [V|R]) :- exclude(==(V), Vs, Vs1), rust_dedup_vars(Vs1, R).
+
+% Map each external-input var to "a<HeadIndex>.clone()".
+rust_ext_clone_args([], _, []).
+rust_ext_clone_args([V|Vs], Args, [Clone|Rest]) :-
+    nth1(Idx, Args, A), A == V, !,
+    format(atom(Clone), 'a~w.clone()', [Idx]),
+    rust_ext_clone_args(Vs, Args, Rest).
 
 % Reduce the collected per-branch values by aggregate type (mirrors the
 % aggregate_frame finalisation in the interpreter).

--- a/templates/targets/rust_wam/par_aggregate.rs.mustache
+++ b/templates/targets/rust_wam/par_aggregate.rs.mustache
@@ -21,13 +21,14 @@ use crate::state::WamState;
 const IN_VAR: &str = "__PAR_IN";
 const VAL_VAR: &str = "__PAR_VAL";
 
-/// Drive a unary predicate to exhaustion, collecting the binding of its argument
-/// across all solutions (the WAM result convention: pass `Unbound(name)`, read
-/// `bindings[name]`).
-fn collect_inputs(base: &WamState, enum_fn: fn(&mut WamState, Value) -> bool) -> Vec<Value> {
+/// Drive a unary enumerator to exhaustion, collecting the binding of its tuple
+/// argument across all solutions. `enum_c` is a closure so callers can bind the
+/// aggregate's external (head-arg) inputs before the tuple arg.
+fn collect_inputs<E>(base: &WamState, enum_c: &E) -> Vec<Value>
+where E: Fn(&mut WamState, Value) -> bool {
     let mut vm = base.clone();
     let mut out = Vec::new();
-    if enum_fn(&mut vm, Value::Unbound(IN_VAR.to_string())) {
+    if enum_c(&mut vm, Value::Unbound(IN_VAR.to_string())) {
         loop {
             if let Some(raw) = vm.bindings.get(IN_VAR).cloned() {
                 // resolve heap refs / nested terms, as EndAggregate does
@@ -46,15 +47,11 @@ fn collect_inputs(base: &WamState, enum_fn: fn(&mut WamState, Value) -> bool) ->
 
 /// Run the body for one input on machine `m` (reset to `base` first), collecting
 /// the value binding across all of the body's solutions.
-fn run_body(
-    base: &WamState,
-    m: &mut WamState,
-    body_fn: fn(&mut WamState, Value, Value) -> bool,
-    input: Value,
-) -> Vec<Value> {
+fn run_body<B>(base: &WamState, m: &mut WamState, body_c: &B, input: Value) -> Vec<Value>
+where B: Fn(&mut WamState, Value, Value) -> bool {
     *m = base.clone(); // each branch starts from a clean machine
     let mut vals = Vec::new();
-    if body_fn(m, input, Value::Unbound(VAL_VAR.to_string())) {
+    if body_c(m, input, Value::Unbound(VAL_VAR.to_string())) {
         loop {
             if let Some(raw) = m.bindings.get(VAL_VAR).cloned() {
                 vals.push(m.deref_var(&m.deref_heap(&raw)));
@@ -69,11 +66,8 @@ fn run_body(
 
 /// Run the body over all inputs, in parallel when there is enough to fan out,
 /// preserving generator order (chunks concatenated by input index).
-fn map_bodies(
-    base: &WamState,
-    inputs: &[Value],
-    body_fn: fn(&mut WamState, Value, Value) -> bool,
-) -> Vec<Value> {
+fn map_bodies<B>(base: &WamState, inputs: &[Value], body_c: &B) -> Vec<Value>
+where B: Fn(&mut WamState, Value, Value) -> bool + Sync {
     let n = inputs.len();
     let cores = thread::available_parallelism().map(|p| p.get()).unwrap_or(1).min(n);
     if n < 2 || cores < 2 {
@@ -81,7 +75,7 @@ fn map_bodies(
         let mut out = Vec::new();
         let mut m = base.clone();
         for inp in inputs {
-            out.extend(run_body(base, &mut m, body_fn, inp.clone()));
+            out.extend(run_body(base, &mut m, body_c, inp.clone()));
         }
         return out;
     }
@@ -99,7 +93,7 @@ fn map_bodies(
                 let mut m = base.clone(); // one clone per worker, reset per branch
                 let mut local = Vec::new();
                 for inp in slice {
-                    local.extend(run_body(base, &mut m, body_fn, inp.clone()));
+                    local.extend(run_body(base, &mut m, body_c, inp.clone()));
                 }
                 (lo, local)
             }));
@@ -115,30 +109,27 @@ fn map_bodies(
 }
 
 /// Parallel `collect` (findall/bag): the ordered sequence of body values over
-/// all enumerated inputs. The compile-time gate already decided this aggregate
-/// is worth parallelising; `map_bodies` falls back to sequential for tiny input
-/// sets so there is never a fan-out regression.
-pub fn par_collect(
-    base: &WamState,
-    enum_fn: fn(&mut WamState, Value) -> bool,
-    body_fn: fn(&mut WamState, Value, Value) -> bool,
-) -> Vec<Value> {
-    let inputs = collect_inputs(base, enum_fn);
-    map_bodies(base, &inputs, body_fn)
+/// all enumerated inputs. `enum_c`/`body_c` are closures (callers bind the
+/// aggregate's external inputs); a bare `fn` pointer is also a valid closure, so
+/// input-less aggregates pass their helper fns directly. `map_bodies` falls back
+/// to sequential for tiny input sets so there is never a fan-out regression.
+pub fn par_collect<E, B>(base: &WamState, enum_c: E, body_c: B) -> Vec<Value>
+where E: Fn(&mut WamState, Value) -> bool,
+      B: Fn(&mut WamState, Value, Value) -> bool + Sync {
+    let inputs = collect_inputs(base, &enum_c);
+    map_bodies(base, &inputs, &body_c)
 }
 
 /// The same collection done strictly sequentially — the reference the parallel
 /// path must match (used by tests and available as a fallback).
-pub fn seq_collect(
-    base: &WamState,
-    enum_fn: fn(&mut WamState, Value) -> bool,
-    body_fn: fn(&mut WamState, Value, Value) -> bool,
-) -> Vec<Value> {
-    let inputs = collect_inputs(base, enum_fn);
+pub fn seq_collect<E, B>(base: &WamState, enum_c: E, body_c: B) -> Vec<Value>
+where E: Fn(&mut WamState, Value) -> bool,
+      B: Fn(&mut WamState, Value, Value) -> bool {
+    let inputs = collect_inputs(base, &enum_c);
     let mut out = Vec::new();
     let mut m = base.clone();
     for inp in &inputs {
-        out.extend(run_body(base, &mut m, body_fn, inp.clone()));
+        out.extend(run_body(base, &mut m, &body_c, inp.clone()));
     }
     out
 }

--- a/tests/test_wam_rust_input_threading_exec.pl
+++ b/tests/test_wam_rust_input_threading_exec.pl
@@ -1,0 +1,87 @@
+% test_wam_rust_input_threading_exec.pl
+%
+% T7 input-threading fix (step 2): a WHOLE-BODY parallel aggregate whose
+% enumerator reads a HEAD-ARG input. Before the fix, par_collect ran the
+% enumerator with that input unbound (enumerating over everything); now the
+% wrapper threads the head arg into the enum/body helpers via closures. Builds +
+% runs a generated project and asserts the input is honoured.
+%
+% cargo-gated.
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+
+% wbi_link(N, X): distinct first-arg keys (avoids an unrelated first-arg-indexing
+% issue with repeated keys). N=1->X=3, N=2->X=4, N=3->X=5. The aggregate below
+% must use only the N it is CALLED with, not all N.
+:- dynamic wbi_link/2.
+wbi_link(1, 3). wbi_link(2, 4). wbi_link(3, 5).
+wbi_fib(0, 0).
+wbi_fib(1, 1).
+wbi_fib(N, F) :- N > 1, N1 is N - 1, N2 is N - 2,
+                 wbi_fib(N1, F1), wbi_fib(N2, F2), F is F1 + F2.
+% whole-body aggregate with a head-arg INPUT (N) feeding the enumerator
+wbi_q(N, L) :- findall(F, (wbi_link(N, X), wbi_fib(X, F)), L).
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- begin_tests(wam_rust_input_threading_exec).
+
+test(head_arg_input_is_threaded,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_inthread_exec'))]) :-
+    Dir = 'output/test_inthread_exec',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project(
+        [user:wbi_q/2, user:wbi_link/2, user:wbi_fib/2],
+        [module_name(wbi), parallel_aggregates(true)], Dir)),
+    % the generated wrapper threads the head arg into the enum closure
+    atom_concat(Dir, '/src/lib.rs', LibRs),
+    read_file_to_string(LibRs, Src, []),
+    assertion(sub_string(Src, _, _, _, "par_collect")),
+    assertion(sub_string(Src, _, _, _, "a1.clone()")),   % N threaded into the closures
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/inthread_test.rs', TestPath),
+    TestSrc = '
+use wbi::value::Value;
+use wbi::state::WamState;
+use wbi::wbi_q_2;
+
+fn ints(v: &Value) -> Vec<i64> {
+    match v { Value::List(xs) => xs.iter().filter_map(|e| match e {
+        Value::Integer(n) => Some(*n), _ => None }).collect(), _ => vec![] }
+}
+
+#[test]
+fn input_is_honoured() {
+    let mut vm = WamState::new(vec![], std::collections::HashMap::new());
+    // wbi_q(2, L): link of 2 is X=4 -> fib(4)=3. Must be [3], NOT all links
+    // [fib(3),fib(4),fib(5)] = [2,3,5] (which is what the unthreaded bug gave).
+    assert!(wbi_q_2(&mut vm, Value::Integer(2), Value::Unbound("L".to_string())));
+    match vm.bindings.get("L").cloned() {
+        Some(ref l @ Value::List(_)) => {
+            assert_eq!(ints(l), vec![3],
+                "must use only N=2's link (fib 4 = 3), not all N");
+        }
+        other => panic!("expected list, got {:?}", other),
+    }
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    format(atom(Cmd), 'cd "~w" && cargo test --test inthread_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[input-threading exec FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_input_threading_exec).


### PR DESCRIPTION
## What

**Fix step 2** of the input-threading bug (step 1 = transform support, #3176, merged). Fixes the latent defect where a **whole-body** parallel aggregate whose enumerator reads a **head-arg input** ran that input **unbound** (enumerating over everything).

- **`par_aggregate.rs`** — `par_collect`/`seq_collect`/`collect_inputs`/`run_body`/`map_bodies` are now generic over **closures** (`E: Fn(&mut WamState,Value)->bool`, `B: Fn(..)+Sync`) instead of bare `fn` pointers, so callers can bind the aggregate's external inputs before the tuple/value args. `fn` pointers still satisfy `Fn`, so **input-less callers are unaffected**.
- **`rust_parallel_aggregate_wrapper`** — computes the external inputs (head-arg vars the inner goal reads, minus the result) via **`include/3`** (not `findall` — `findall` copies vars and breaks `==`-identity with the head args), calls `parallel_aggregate_transform/6`, and emits a wrapper passing the head-arg values into the enum/body via closures (`a<idx>.clone()`).
- Export `aggregate_result/2` from `parallel_gate`; import `transform/6` + it.

## Verified
`wbi_q(2,L) :- findall(F,(wbi_link(N,X),wbi_fib(X,F)),L)` called with `N=2` now yields **`[3]`** (only `N=2`'s link) — not `[2,3,5]` (all links, the old unthreaded bug). Input-less whole-body exec (`test_wam_rust_parallel_injection_exec`) still green; transform unit tests green; full `test_wam_rust_target.pl` regression **All tests passed** (gate-off unchanged).

`tests/test_wam_rust_input_threading_exec.pl` — cargo exec test for the head-arg input case (distinct enumerator keys, to avoid an *unrelated* pre-existing repeated-first-arg indexing issue — noted below).

## Notes / follow-ups
- **Step 3** (embedded route-2 threading: `par_collect_labels` + the `ParAggregate` instruction passing the container's input registers) remains.
- **Separate pre-existing bug found:** a fact predicate with a **repeated first-argument key** (e.g. `wbi_link(10,_)` twice) fails to enumerate with the second arg unbound — a first-arg-indexing issue, independent of T7. Worth a separate look.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_