### PR TITLE
bench(wam-rust): cache characterization at scale — thread interaction + synthetic enwiki-scale

### DIFF
--- a/docs/reports/wam_rust_cached_multithread_2026-06-15.md
+++ b/docs/reports/wam_rust_cached_multithread_2026-06-15.md
@@ -1,0 +1,53 @@
+# WAM-Rust Cached Graph-Search: Cache × Threads Interaction (2026-06-15)
+
+Companion to `wam_rust_cached_scaling_sweep_2026-06-14.md`, which measured the
+cached-vs-lazy win **single-threaded** to isolate the cache effect. The obvious
+follow-up: do the cache and multi-threading *stack*? This sweeps thread count on
+the largest fixture (10k, 25 227 edges) at fixed size.
+
+## Method
+
+Same cached / lazy crates as the scaling sweep. Fixed fixture `10k`, varying
+`WAM_THREADS`. `query_ms` is the min over 3 reps; attribution on.
+Reproduce: `THREADS=N examples/benchmark/run_wam_rust_cached_scaling_sweep.sh 10k`
+(machine here: 4 physical cores).
+
+## Result
+
+| threads | cached `query_ms` | lazy `query_ms` | **speedup** | L1 hits | L2 hits | misses |
+|---------|-------------------|-----------------|-------------|---------|---------|--------|
+| 1 |  82 | 283 | **3.45×** | 700 847 |     0 | 4 493 |
+| 2 |  53 | 142 | **2.68×** | 700 135 |   712 | 4 493 |
+| 4 |  38 |  73 | **1.92×** | 699 281 | 1 565 | 4 494 |
+| 8 |  36 |  74 | **2.06×** | 697 619 | 3 227 | 4 494 |
+
+(8 threads on 4 cores is oversubscribed — no gain over 4, as expected.)
+
+## Reading the numbers
+
+- **Cache and parallelism are partially substitutable.** Both attack the same
+  cost — LMDB parent-lookup seeks. So as threads independently hide seek latency,
+  the cache's *relative* advantage shrinks (3.45× → ~2×): lazy has more
+  parallelisable seek work to distribute, so it gains more from extra cores.
+- **The cache still wins ~2× at full core count**, and does far less work: ~4 500
+  inner seeks total vs lazy issuing a seek per lookup (~705 000). On this small
+  fixture the LMDB pages are warm in the OS cache so lazy's "seeks" are cheap RAM
+  reads; on a disk-bound graph (enwiki scale) each lazy miss is a real page
+  fault, so the substitutability weakens and the cache advantage should *grow*
+  with size even as cores rise.
+- **The two-tier cache behaves as designed under parallelism.** Single-threaded,
+  the per-thread L1 (65 536 slots) absorbs everything (L2 = 0). As threads rise,
+  each worker's L1 starts cold, so the shared L2 picks up the cross-thread reuse
+  (0 → 3 227 hits) — exactly its role. Miss count stays flat (~4 493), i.e. the
+  unique working set is covered regardless of thread count.
+- **Both optimisations are worth keeping**: parallelism cuts latency; the cache
+  cuts work/IO (energy, and disk traffic on cold graphs). They compose to the
+  fastest configuration (cached + all cores: 36 ms vs lazy single-thread 283 ms,
+  ~7.9×).
+
+## Scope
+
+Single fixture, 4 cores, OS-warm LMDB. The headline caveat — that the cache
+advantage is *understated* here because warm-cache lazy seeks are cheap — points
+at the same next step as the size sweep: an enwiki-scale, disk-bound fixture,
+where cache and parallelism should substitute less and the cache win widen.

--- a/docs/reports/wam_rust_cached_synthetic_scale_2026-06-15.md
+++ b/docs/reports/wam_rust_cached_synthetic_scale_2026-06-15.md
@@ -1,0 +1,100 @@
+# WAM-Rust Cached Graph-Search at Scale (Synthetic, 2026-06-15)
+
+The size/thread sweeps (`wam_rust_cached_scaling_sweep_2026-06-14.md`,
+`wam_rust_cached_multithread_2026-06-15.md`) all carried the same caveat: the
+in-repo fixtures are tiny (≤25k edges, working set ~1.7k ≪ the 65 536-slot
+per-thread L1), so the cache never overflows L1 and L2 capacity is never
+stressed. The clean next step was an enwiki-scale fixture.
+
+**A real dump is not reachable here** — the network policy blocks
+`dumps.wikimedia.org` (`403 host_not_allowed`) and no large graph is checked in.
+So this uses a **synthetic** category DAG
+(`examples/benchmark/generate_synthetic_category_graph.py`) sized to reach the
+regime that matters: working set several times the L1, exercising L2 under
+capacity pressure. Structure mimics the cache-relevant properties of a wiki
+category graph — a single root, a small set of high-in-degree hub ancestors near
+the root (path convergence → reuse), and otherwise locally-wired parents (depth).
+
+## Scales reached
+
+| graph | edges | seeds | total lookups | **working set** (distinct) | vs L1 (65 536) |
+|-------|-------|-------|---------------|----------------------------|----------------|
+| 200k cats | 398 832 | 86 476 | 6.93 M | 102 188 | **1.6×** |
+| 500k cats | 999 126 | 174 670 | 63.7 M | 256 462 | **3.9×** |
+
+(Correctness invariant holds at both: cached output == lazy output, exactly.)
+
+## Cached vs lazy (single-threaded query time)
+
+| graph | cached ms | lazy ms | **speedup** | hit rate | L1 hits | L2 hits | inner misses |
+|-------|-----------|---------|-------------|----------|---------|---------|--------------|
+| 200k | 1841 | 5176 | **2.81×** | 0.9853 | 6.80 M | 30 289 | 102 188 |
+| 500k | 25 453 | 63 819 | **2.51×** | 0.9960 | 63.1 M | 346 345 | 256 462 |
+
+The cache win **persists at scale** (2.5–2.8×) even with the working set 1.6–3.9×
+the L1. Hit rate doesn't fall as the working set overflows L1 — it *rises*
+(98.5% → 99.6%) because more total lookups concentrate ever harder on the hot
+hub ancestors, which stay resident in the per-thread L1. The cache is
+**L1-dominated**: L1 serves 98–99% of all lookups; L2 mops up a thin tail.
+
+## L2 capacity sweep — how much cache do you actually need?
+
+Single-threaded; the working set (102k / 256k) far exceeds every L2 size tried.
+
+200k (working set 102 188):
+
+| L2 capacity | hit rate | inner misses | query ms |
+|-------------|----------|--------------|----------|
+| 1 024 | 0.9841 | 109 863 | 1707 |
+| 8 192 | 0.9850 | 103 597 | 1644 |
+| 65 536 | 0.9852 | 102 687 | 1756 |
+| 4 000 000 | 0.9853 | 102 188 | 2182 |
+
+500k (working set 256 462):
+
+| L2 capacity | hit rate | inner misses | query ms |
+|-------------|----------|--------------|----------|
+| 1 024 | 0.9954 | 295 898 | 22 120 |
+| 65 536 | 0.9960 | 257 079 | 22 241 |
+| 262 144 | 0.9960 | 256 462 | 23 310 |
+| 4 000 000 | 0.9960 | 256 462 | 21 831 |
+
+**L2 capacity is largely insensitive.** A 1024-entry L2 (4 KB) is within ~0.1
+point of a 4 M-entry L2; by ~65 536 the hit rate is saturated. Oversizing L2
+buys nothing and can slightly hurt (allocation/locality — the 4 M case is
+no faster, sometimes slower). The reason is the same skew: the L2-cacheable
+benefit is only the small tail of keys evicted from L1 and re-accessed soon;
+once that tail fits, more L2 is dead weight.
+
+## Actionable conclusion
+
+For this graph-search workload the per-thread L1 plus skewed hub access do the
+work; **a modest L2 (on the order of the L1, not the working set) is sufficient**.
+This supports the R8b cost-model approach of clamping cache capacity rather than
+sizing to the full demand set — the demand set can be 4× L1 with no hit-rate
+penalty. Sizing L2 to the working set wastes memory for ~0.1 point of hit rate.
+
+## Caveats
+
+- **Synthetic, not real wiki.** The structure is chosen to be cache-realistic
+  (hub ancestors + depth), but it is not a real category graph. Conclusions about
+  the cache architecture (L1-dominance, L2-insensitivity, the persistent ~2.5×
+  win) are structural and should carry over; exact numbers would differ on a real
+  dump.
+- **Not disk-bound.** The LMDB is RAM-resident here, so an inner "seek" is a ~µs
+  page-cache read. On a graph too large for RAM each lazy miss would be a real
+  page fault, so the cache advantage measured here is a *lower bound* — it would
+  widen, and L2 would matter more, when seeks hit disk.
+
+## Reproduce
+
+```bash
+python3 examples/benchmark/generate_synthetic_category_graph.py \
+    --out /tmp/syn_src --categories 200000 --articles 200000 \
+    --hubs 512 --local-window 2000 --hub-prob 0.35 --seed 1
+mkdir -p /tmp/syn_fix
+python3 examples/benchmark/ingest_resident_lmdb_fixture.py /tmp/syn_src /tmp/syn_fix/lmdb_resident
+cp /tmp/syn_src/article_category.tsv /tmp/syn_fix/
+# then run the cached/lazy crates against /tmp/syn_fix with
+# UW_WAM_CACHE_ATTRIBUTION=1 and varying WAM_CACHE_CAPACITY / WAM_THREADS.
+```

--- a/docs/reports/wam_rust_cached_synthetic_scale_2026-06-15.md
+++ b/docs/reports/wam_rust_cached_synthetic_scale_2026-06-15.md
@@ -59,28 +59,65 @@ Single-threaded; the working set (102k / 256k) far exceeds every L2 size tried.
 | 262 144 | 0.9960 | 256 462 | 23 310 |
 | 4 000 000 | 0.9960 | 256 462 | 21 831 |
 
-**L2 capacity is largely insensitive.** A 1024-entry L2 (4 KB) is within ~0.1
-point of a 4 M-entry L2; by ~65 536 the hit rate is saturated. Oversizing L2
-buys nothing and can slightly hurt (allocation/locality — the 4 M case is
-no faster, sometimes slower). The reason is the same skew: the L2-cacheable
-benefit is only the small tail of keys evicted from L1 and re-accessed soon;
-once that tail fits, more L2 is dead weight.
+**Single-threaded, L2 capacity is largely insensitive.** A 1024-entry L2 (4 KB)
+is within ~0.1 point of a 4 M-entry L2; by ~65 536 the hit rate is saturated.
+The reason is skew: with one thread, the single per-thread L1 (65 536 slots)
+holds the hot hub ancestors, so the L2-cacheable benefit is only the thin tail of
+keys evicted from L1 and re-accessed soon. Once that tail fits, more L2 is dead
+weight (the 4 M case is no faster, sometimes slower).
+
+## Multi-threaded: the shared L2 carries cross-thread reuse
+
+The single-threaded picture above is misleading for real multi-core use. The L1
+is **per-thread**: with N worker threads each starts with a cold L1, so reuse of
+a hub ancestor *across* threads cannot hit any thread's L1 — it must hit the
+**shared L2**. So L2 capacity, irrelevant single-threaded, becomes load-bearing.
+Same 200k graph (working set 102 188), L2 capacity sweep at 1 vs 4 threads:
+
+| L2 capacity | 1 thread hit | 1 thread inner misses | 4 threads hit | 4 threads inner misses |
+|-------------|--------------|-----------------------|---------------|------------------------|
+| 1 024 | 0.9841 | 109 863 | **0.9745** | **176 944** |
+| 16 384 | 0.9851 | 103 179 | 0.9806 | 134 083 |
+| 65 536 | 0.9852 | 102 687 | 0.9838 | 112 303 |
+| 262 144 | 0.9853 | 102 188 | 0.9853 | 102 189 |
+| 4 000 000 | 0.9853 | 102 188 | 0.9853 | 102 188 |
+
+At 4 threads, shrinking L2 from the working-set size (262 144) to 1024 raises
+inner LMDB seeks from 102 k to **177 k (+73%)** and drops the hit rate a full
+point (98.5% → 97.5%); the shared-L2 hit count grows 16 k → 93 k across the
+sweep (vs only 23 k → 30 k single-threaded). The L2 recovers the single-threaded
+hit rate once it reaches roughly the cross-thread working set (~262 144 ≈ 2.5×
+the L1 here).
+
+(On this RAM-warm fixture those extra 75 k seeks barely move wall time — 589 vs
+678 ms — because parallelism hides them and a "seek" is a µs page-cache read. On
+a disk-bound graph each extra seek is a page fault, so under-sizing L2 would cost
+real time, not just I/O work.)
 
 ## Actionable conclusion
 
-For this graph-search workload the per-thread L1 plus skewed hub access do the
-work; **a modest L2 (on the order of the L1, not the working set) is sufficient**.
-This supports the R8b cost-model approach of clamping cache capacity rather than
-sizing to the full demand set — the demand set can be 4× L1 with no hit-rate
-penalty. Sizing L2 to the working set wastes memory for ~0.1 point of hit rate.
+The cache is **L1-dominated per thread, L2-dominated across threads**:
+
+- **Single-threaded / per-thread streams:** the L1 does the work; L2 can be tiny.
+- **Multi-core (the real deployment):** the shared L2 carries the cross-thread
+  hub reuse, so it should be sized to roughly the cross-thread working set, not
+  minimised — under-sizing it costs ~1 point of hit rate and ~73% more LMDB seeks
+  here (and proportionally more wall time when disk-bound). This matches the
+  earlier observation that the L2 provides most of the cache benefit: that holds
+  whenever reuse is cross-thread or cross-query (the L1 is per-thread and does not
+  persist across either).
+
+So the R8b cost-model clamp is right to bound capacity, but the floor it clamps
+*to* should track the cross-thread working set on multi-core runs — not shrink to
+L1 size, which is only safe single-threaded.
 
 ## Caveats
 
 - **Synthetic, not real wiki.** The structure is chosen to be cache-realistic
-  (hub ancestors + depth), but it is not a real category graph. Conclusions about
-  the cache architecture (L1-dominance, L2-insensitivity, the persistent ~2.5×
-  win) are structural and should carry over; exact numbers would differ on a real
-  dump.
+  (hub ancestors + depth), but it is not a real category graph. The architectural
+  conclusions (per-thread L1 dominance, shared-L2 cross-thread reuse, the
+  persistent ~2.5× win) are structural and should carry over; exact numbers would
+  differ on a real dump.
 - **Not disk-bound.** The LMDB is RAM-resident here, so an inner "seek" is a ~µs
   page-cache read. On a graph too large for RAM each lazy miss would be a real
   page fault, so the cache advantage measured here is a *lower bound* — it would

--- a/examples/benchmark/generate_synthetic_category_graph.py
+++ b/examples/benchmark/generate_synthetic_category_graph.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2026 John William Creighton (s243a)
+"""
+generate_synthetic_category_graph.py — large synthetic category DAG for the
+WAM-Rust graph-search cache benchmark, when a real wiki dump is unavailable
+(network-restricted environments). Produces the same three TSVs the matrix
+bench / ingest_resident_lmdb_fixture.py consume:
+
+    category_parent.tsv   child<TAB>parent   (+ header)
+    article_category.tsv  article<TAB>category
+    root_categories.tsv   category           (single root)
+
+Structure is chosen to mimic the cache-relevant properties of a wiki category
+graph: a single root, a small set of high-in-degree "hub" categories near the
+root (so many ancestor paths converge -> reuse -> cache hits), and otherwise
+locally-wired parents (so paths have depth). This makes the union of seed
+ancestor cones large enough to overflow the runtime's per-thread L1 cache and
+exercise the shared L2 under capacity pressure — the regime the small in-repo
+fixtures (working set ~1.7k << 65k-slot L1) cannot reach.
+
+Deterministic given --seed. Unlike a real dump there is no golden output, so the
+benchmark's correctness invariant is cached-output == lazy-output (caching must
+not change the answer), checked by the sweep driver.
+
+Usage:
+  generate_synthetic_category_graph.py --out DIR --categories N --articles M \
+      [--hubs H] [--local-window W] [--hub-prob P] [--max-parents K] [--seed S]
+"""
+import argparse
+import os
+import random
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--categories", type=int, default=200_000)
+    ap.add_argument("--articles", type=int, default=200_000)
+    ap.add_argument("--hubs", type=int, default=512,
+                    help="low-index categories that act as shared hub ancestors")
+    ap.add_argument("--local-window", type=int, default=2000,
+                    help="parents are drawn from the preceding window (gives depth)")
+    ap.add_argument("--hub-prob", type=float, default=0.35,
+                    help="probability a parent edge points at a hub (gives reuse)")
+    ap.add_argument("--max-parents", type=int, default=3)
+    ap.add_argument("--seed", type=int, default=1)
+    args = ap.parse_args()
+
+    rnd = random.Random(args.seed)
+    os.makedirs(args.out, exist_ok=True)
+    N, H, W = args.categories, max(1, args.hubs), max(1, args.local_window)
+
+    cp_path = os.path.join(args.out, "category_parent.tsv")
+    with open(cp_path, "w", encoding="utf-8") as f:
+        f.write("child\tparent\n")
+        # C0 is the root (no parents). Every other category points up toward
+        # lower indices: with hub-prob to a hub (C1..CH, near the root), else to
+        # a local predecessor within the window (creating depth). C1..CH chain to
+        # the root so hubs themselves are shallow.
+        for i in range(1, N):
+            if i <= H:
+                f.write(f"C{i}\tC0\n")
+                continue
+            k = rnd.randint(1, args.max_parents)
+            parents = set()
+            for _ in range(k):
+                if rnd.random() < args.hub_prob:
+                    parents.add(rnd.randint(1, H))           # hub
+                else:
+                    lo = max(1, i - W)
+                    parents.add(rnd.randint(lo, i - 1))      # local (depth)
+            for p in parents:
+                f.write(f"C{i}\tC{p}\n")
+
+    # Articles attach to leaf-ish (higher-index) categories so their ancestor
+    # cones are deep and broad; bias toward the upper half of the index range.
+    lo_art = max(1, N // 2)
+    ac_path = os.path.join(args.out, "article_category.tsv")
+    with open(ac_path, "w", encoding="utf-8") as f:
+        f.write("article\tcategory\n")
+        for j in range(args.articles):
+            f.write(f"A{j}\tC{rnd.randint(lo_art, N - 1)}\n")
+
+    with open(os.path.join(args.out, "root_categories.tsv"), "w", encoding="utf-8") as f:
+        f.write("category\nC0\n")
+
+    print(f"synthetic graph at {args.out}: {N} categories ({H} hubs), "
+          f"{args.articles} articles, root=C0")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmark/run_wam_rust_cached_scaling_sweep.sh
+++ b/examples/benchmark/run_wam_rust_cached_scaling_sweep.sh
@@ -8,13 +8,15 @@
 # benchmark fixture ingests an lmdb_resident database and measures query time,
 # cache hit rate, and inner LMDB seek time. Prints one row per fixture.
 #
-# Single-threaded (WAM_THREADS=1) for deterministic attribution and a clean
-# cache-vs-no-cache comparison (the cache benefit is lookup avoidance, not
-# parallelism). Query time is the min over a few reps (least noisy).
+# Defaults to single-threaded (THREADS=1) for deterministic attribution and a
+# clean cache-vs-no-cache comparison (the cache benefit is lookup avoidance, not
+# parallelism). Set THREADS=N to sweep at a given core count. Query time is the
+# min over a few reps (least noisy).
 #
 # Usage:
 #   examples/benchmark/run_wam_rust_cached_scaling_sweep.sh [fixture ...]
 #     default fixtures: 300 1k 5k 10k (dirs under data/benchmark/)
+#   THREADS=N  WAM worker threads (default 1)
 #
 # Requires: swipl, cargo, python3 with the `lmdb` package.
 set -euo pipefail
@@ -24,6 +26,7 @@ WORK="$(mktemp -d)"
 export LC_ALL="${LC_ALL:-C.UTF-8}" LANG="${LANG:-C.UTF-8}"
 REPS="${REPS:-3}"
 CAP="${WAM_CACHE_CAPACITY:-400000}"
+THREADS="${THREADS:-1}"
 FIXTURES=("$@")
 [ ${#FIXTURES[@]} -eq 0 ] && FIXTURES=(300 1k 5k 10k)
 
@@ -42,7 +45,7 @@ getv() { grep -oP "$2=\K[0-9.]+" "$1" | head -1; }
 min_query() { # <binary> <fixture-dir> -> min query_ms over REPS; leaves last run in $LASTLOG
     local best=99999999
     for _ in $(seq 1 "$REPS"); do
-        UW_WAM_CACHE_ATTRIBUTION=1 WAM_THREADS=1 WAM_CACHE_CAPACITY="$CAP" \
+        UW_WAM_CACHE_ATTRIBUTION=1 WAM_THREADS="$THREADS" WAM_CACHE_CAPACITY="$CAP" \
             "$1" "$2" >/dev/null 2>"$LASTLOG"
         local q; q=$(getv "$LASTLOG" query_ms); [ -z "$q" ] && q=99999999
         awk "BEGIN{exit !($q<$best)}" && best=$q
@@ -65,10 +68,10 @@ for fx in "${FIXTURES[@]}"; do
     hit=$(getv "$LASTLOG" cache_attr_hit_rate)
     look=$(getv "$LASTLOG" cache_attr_lookups)
     miss=$(getv "$LASTLOG" cache_attr_misses)
-    UW_WAM_CACHE_ATTRIBUTION=0 WAM_THREADS=1 "${BIN[cached]}" "$fixdir" >"$WORK/co_$fx.tsv" 2>/dev/null
+    UW_WAM_CACHE_ATTRIBUTION=0 WAM_THREADS="$THREADS" "${BIN[cached]}" "$fixdir" >"$WORK/co_$fx.tsv" 2>/dev/null
 
     LASTLOG="$WORK/l_$fx.log"; lms=$(min_query "${BIN[lazy]}" "$fixdir")
-    WAM_THREADS=1 "${BIN[lazy]}" "$fixdir" >"$WORK/lo_$fx.tsv" 2>/dev/null
+    WAM_THREADS="$THREADS" "${BIN[lazy]}" "$fixdir" >"$WORK/lo_$fx.tsv" 2>/dev/null
 
     speedup=$(awk "BEGIN{ if ($cms>0) printf \"%.2fx\", $lms/$cms; else print \"n/a\" }")
     # Correctness invariant: caching must not change the answer.


### PR DESCRIPTION
Three commits extending the cached graph-search characterization beyond the single-threaded size sweep (#3175).

## Commit 1 — cache × threads interaction (10k fixture)

Does the cache stack with multi-threading?

| threads | cached ms | lazy ms | speedup | L2 hits |
|---|---|---|---|---|
| 1 | 82 | 283 | **3.45×** | 0 |
| 2 | 53 | 142 | 2.68× | 712 |
| 4 | 38 | 73 | 1.92× | 1565 |

**Cache and parallelism partially substitute** — both attack LMDB seek cost, so the cache's *relative* advantage shrinks as cores hide seek latency, but cached stays ~2× faster at full cores. The shared L2 picks up cross-thread reuse (0 → 1565) as per-thread L1s go cold. Adds a `THREADS` env var to the sweep script.

## Commit 2 — synthetic enwiki-scale (L1 overflow + capacity pressure)

A real dump is unreachable here (network blocks `dumps.wikimedia.org`, 403; no large graph checked in), so a tunable **synthetic category-DAG generator** reaches the regime the in-repo fixtures cannot: working set several times the 65 536-slot L1.

| graph | edges | working set | vs L1 | speedup | hit rate |
|---|---|---|---|---|---|
| 200k cats | 398 832 | 102 188 | 1.6× | **2.81×** | 0.9853 |
| 500k cats | 999 126 | 256 462 | 3.9× | **2.51×** | 0.9960 |

Cache win persists at scale; hit rate rises as the working set overflows L1 because access is skewed (hot hubs stay resident in the per-thread L1). Correctness holds (cached output == lazy, exactly).

## Commit 3 — L2 finding correction: L1-dominated per thread, **L2-dominated across threads**

Commit 2's single-threaded L2 sweep showed L2 "largely insensitive" and concluded "size L2 ~L1". That is single-thread-specific and was corrected. The L1 is **per-thread**: with N workers each L1 starts cold, so cross-thread hub reuse must hit the **shared L2**. Re-running the L2 sweep at 4 threads (200k graph, working set 102 188):

| L2 capacity | 1-thread hit | 4-thread hit | 4-thread inner seeks |
|---|---|---|---|
| 1 024 | 0.9841 | **0.9745** | **176 944 (+73%)** |
| 65 536 | 0.9852 | 0.9838 | 112 303 |
| 262 144 | 0.9853 | 0.9853 | 102 189 |

Multi-threaded, shrinking L2 below the cross-thread working set costs ~1 pt hit rate and +73% LMDB seeks; shared-L2 hits grow 16k → 93k across the sweep (vs 23k → 30k single-threaded). **Corrected conclusion:** size the shared L2 to the cross-thread working set on multi-core, *not* to L1. This reconciles with the prior observation that L2 provides most of the cache benefit — true whenever reuse is cross-thread or cross-query, since the per-thread L1 persists across neither.

## Changes

- `examples/benchmark/run_wam_rust_cached_scaling_sweep.sh` — `THREADS` env var.
- `examples/benchmark/generate_synthetic_category_graph.py` — synthetic generator.
- `docs/reports/wam_rust_cached_multithread_2026-06-15.md`, `docs/reports/wam_rust_cached_synthetic_scale_2026-06-15.md`.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua