### PR TITLE
fix(wam-rust): SwitchOnConstant drops multi-clause keys (repeated first-arg facts fail to enumerate)

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -960,29 +960,33 @@ wam_instruction_arm('Instruction::SwitchOnConstant(table)', Body) :-
     Body = '                let raw = self.get_reg_raw("A1").map(|v| self.deref_var(&v));
                 if let Some(val) = raw {
                     if !val.is_unbound() {
-                        // Binary search for Atom keys (table is sorted from BTreeMap)
-                        if let Value::Atom(ref needle) = val {
+                        // Find the matching key''s target label.
+                        let target: Option<&str> = if let Value::Atom(ref needle) = val {
+                            // Binary search for Atom keys (table is sorted from BTreeMap)
                             match table.binary_search_by_key(&needle.as_str(), |(k, _)| {
                                 if let Value::Atom(s) = k { s.as_str() } else { "" }
                             }) {
-                                Ok(idx) => {
-                                    if let Some(&pc) = self.labels.get(&table[idx].1) {
-                                        self.pc = pc; return true;
-                                    }
-                                }
-                                Err(_) => {}
+                                Ok(idx) => Some(table[idx].1.as_str()),
+                                Err(_) => None,
                             }
                         } else {
-                            // Fallback linear scan for non-Atom values
-                            for (key, label) in table {
-                                if *key == val {
-                                    if let Some(&pc) = self.labels.get(label) {
-                                        self.pc = pc; return true;
-                                    }
+                            // Linear scan for non-Atom (e.g. integer) keys
+                            table.iter().find(|(k, _)| *k == val).map(|(_, l)| l.as_str())
+                        };
+                        match target {
+                            // A key with multiple clauses maps to the "default"
+                            // sentinel: fall through to the try_me_else chain that
+                            // immediately follows the switch. (Treating it as a real
+                            // label silently failed, dropping every such clause.)
+                            Some("default") => { self.pc += 1; return true; }
+                            Some(label) => {
+                                if let Some(&pc) = self.labels.get(label) {
+                                    self.pc = pc; return true;
                                 }
+                                return false;
                             }
+                            None => return false, // no clause indexes this key
                         }
-                        return false;
                     }
                 }
                 // Unbound A1: skip dispatch, advance to next instruction

--- a/tests/test_wam_rust_repeated_key_fact_exec.pl
+++ b/tests/test_wam_rust_repeated_key_fact_exec.pl
@@ -1,0 +1,72 @@
+% test_wam_rust_repeated_key_fact_exec.pl
+%
+% Regression for the first-argument-indexing bug: a fact predicate with a
+% REPEATED first-argument key (rk(10,3). rk(10,4).) failed to enumerate when the
+% second arg was unbound. Root cause: switch_on_constant maps a multi-clause key
+% to the "default" sentinel (= fall through to the try_me_else chain), but the
+% SwitchOnConstant runtime arm treated "default" as a real label, found none, and
+% returned false -- dropping every clause of that key. Fixed to fall through.
+%
+% cargo-gated.
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+
+:- dynamic rk/2.
+rk(10, 3). rk(10, 4).   % repeated first-arg key 10 (multi-clause -> "default")
+rk(20, 5).              % distinct key 20 (single clause -> direct jump)
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- begin_tests(wam_rust_repeated_key_fact_exec).
+
+test(repeated_first_arg_key_enumerates,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_rk_exec'))]) :-
+    Dir = 'output/test_rk_exec',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project([user:rk/2], [module_name(rk)], Dir)),
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/rk_test.rs', TestPath),
+    TestSrc = '
+use rk::value::Value;
+use rk::state::WamState;
+use rk::rk_2;
+
+fn enum_x(n: i64) -> Vec<i64> {
+    let mut vm = WamState::new(vec![], std::collections::HashMap::new());
+    let mut out = Vec::new();
+    if rk_2(&mut vm, Value::Integer(n), Value::Unbound("X".to_string())) {
+        loop {
+            if let Some(Value::Integer(x)) = vm.bindings.get("X").cloned() { out.push(x); }
+            if !vm.backtrack() || !vm.run() { break; }
+        }
+    }
+    out
+}
+
+#[test]
+fn repeated_key_enumerates() {
+    assert_eq!(enum_x(10), vec![3, 4], "repeated key 10 must yield both clauses");
+    assert_eq!(enum_x(20), vec![5], "distinct key 20");
+    assert_eq!(enum_x(99), Vec::<i64>::new(), "unindexed key fails");
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    format(atom(Cmd), 'cd "~w" && cargo test --test rk_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[repeated-key exec FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_repeated_key_fact_exec).


### PR DESCRIPTION
## The bug

A fact predicate with a **repeated first-argument key** failed to enumerate when the second arg was unbound:
```prolog
rk(10, 3).  rk(10, 4).  rk(20, 5).
?- rk(10, X).   % returned NOTHING — should be X=3, X=4
```
Independent of T7 — it's in the indexed-fact path. (Found while debugging T7 input threading.)

## Root cause

First-arg indexing emits `switch_on_constant 10:default 20:L_rk_2_3_body`: a **multi-clause key** (`10`, two clauses) maps to the **`"default"` sentinel** = *"fall through to the `try_me_else` chain that follows the switch"*; a single-clause key (`20`) jumps to its body.

The `SwitchOnConstant` runtime arm treated the matched key's label as a real label: `self.labels.get("default")` → `None`, the `if let Some(&pc)` failed, and execution hit the trailing **`return false`** — failing the predicate and dropping *every* clause of that key.

(`SwitchOnConstantFallthrough` already documents this exact lesson; `SwitchOnStructure`/`A2` fall through after their match loop; only plain `SwitchOnConstant` `return false`-d.)

## Fix

Resolve the matched key to its target: a **`"default"`** target **falls through** (`self.pc += 1; true`) to the clause chain; a real label jumps; a key with no table entry still fails (nothing indexes it). Single-clause direct-jump and Atom-key binary search are unchanged.

## Verified
`rk(10,X) → [3,4]`, `rk(20,X) → [5]`, `rk(99,X) → []` (fails). Full `test_wam_rust_target.pl` regression **All tests passed** — every indexed predicate runs through this arm, so the broad suite is the guard.

`tests/test_wam_rust_repeated_key_fact_exec.pl` — cargo exec regression for the repeated-key case.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_