### PR TITLE
fix(wam-rust): T7 embedded aggregates — decline input-taking case to stay correct

### DIFF
--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -4753,11 +4753,40 @@ rust_embedded_par_aggregate(QPI, _Options, Helpers,
     clause(Module:Head, Body),
     \+ forkable_aggregate(Body, _, _),           % not whole-body (that is route 1)
     rust_body_embedded_aggregate(Body, AggGoal),
+    % Correctness gate: only parallelise when the embedded aggregate's inner goal
+    % reads NO variable bound by the enclosing clause (head/other goals). Such
+    % "external inputs" are not yet threaded into the __par_enum/__par_body
+    % helpers (they would enumerate unbound -> wrong results, e.g. eg_p(1,R)
+    % returning every link's body instead of link(1)'s). With inputs present we
+    % decline, so the aggregate compiles SEQUENTIALLY (correct). Threading them
+    % into par_collect_labels via the container's input registers is a follow-on.
+    rust_embedded_aggregate_inputs(Head, Body, AggGoal, []),
     build_cost_model(Module, CM),
     parallel_aggregate_transform(AggGoal, CM, Pred, Helpers,
         par_aggregate(AggType, EnumName/1, BodyName/2, _Result)),
     rust_supported_par_agg_type(AggType),
     !.
+
+% External inputs of an embedded aggregate: variables its inner goal reads that
+% are bound by the enclosing clause (head or the other body goals), excluding the
+% result var. Non-empty ⇒ the aggregate depends on caller bindings the helpers
+% can't yet receive ⇒ decline parallelisation (compile sequentially).
+rust_embedded_aggregate_inputs(Head, Body, AggGoal, Ext) :-
+    forkable_aggregate(AggGoal, _Tmpl, InnerGoal),
+    aggregate_result(AggGoal, Result),
+    rust_conj_list(Body, Goals),
+    exclude(==(AggGoal), Goals, OtherGoals),
+    term_variables([Head|OtherGoals], OuterVars),
+    term_variables(InnerGoal, InnerVars),
+    % NB: a yall lambda would copy OuterVars/Result per call (breaking var
+    % identity); rust_is_ext_input/3 (defined above for route 1) is a named
+    % helper so == compares the real clause variables. It is symmetric in its
+    % first two list/var roles, so reusing it here is correct.
+    include(rust_is_ext_input(OuterVars, Result), InnerVars, Ext0),
+    rust_dedup_vars(Ext0, Ext).
+
+rust_conj_list((A, B), L) :- !, rust_conj_list(A, LA), rust_conj_list(B, LB), append(LA, LB, L).
+rust_conj_list(G, [G]).
 
 % Find the first forkable aggregate goal inside a (possibly nested) conjunction.
 rust_body_embedded_aggregate((A, B), Agg) :-

--- a/tests/test_wam_rust_embedded_input_decline_exec.pl
+++ b/tests/test_wam_rust_embedded_input_decline_exec.pl
@@ -1,0 +1,79 @@
+% test_wam_rust_embedded_input_decline_exec.pl
+%
+% Correctness regression: an EMBEDDED aggregate whose enumerator reads an
+% enclosing-clause input (e.g. findall(D,(link(N,X),down(X,D)),R) where N is a
+% head arg) was parallelised by route 2 with N UNBOUND -> it enumerated every
+% link, returning wrong results (eg_p(1,R) gave both links' bodies). The embedded
+% route now DECLINES such aggregates (no ParAggregate splice) so they compile
+% sequentially and are correct. (Threading the inputs to make them parallel is a
+% separate follow-on.)
+%
+% cargo-gated.
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+
+:- dynamic eg_link/2.
+eg_guard(_).
+eg_link(1, 3). eg_link(2, 4).          % distinct keys; N selects which
+eg_dn(0, []).
+eg_dn(N, [N|T]) :- N > 0, M is N - 1, eg_dn(M, T).
+% embedded aggregate whose inner goal reads the head-arg input N
+eg_p(N, R) :- eg_guard(N), findall(D, (eg_link(N, X), eg_dn(X, D)), R).
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- begin_tests(wam_rust_embedded_input_decline_exec).
+
+test(input_taking_embedded_declines_and_is_correct,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_emb_decline_exec'))]) :-
+    Dir = 'output/test_emb_decline_exec',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project(
+        [user:eg_p/2, user:eg_guard/1, user:eg_link/2, user:eg_dn/2],
+        [module_name(eg), parallel_aggregates(true)], Dir)),
+    % declined: no ParAggregate spliced for this input-taking embedded aggregate
+    atom_concat(Dir, '/src/lib.rs', LibRs),
+    read_file_to_string(LibRs, Src, []),
+    assertion(\+ sub_string(Src, _, _, _, "ParAggregate")),
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/eg_test.rs', TestPath),
+    TestSrc = '
+use eg::value::Value;
+use eg::state::WamState;
+use eg::eg_p_2;
+
+fn ii(v: &Value) -> Vec<Vec<i64>> {
+    match v { Value::List(xs) => xs.iter().map(|e| match e {
+        Value::List(ys) => ys.iter().filter_map(|z| if let Value::Integer(n)=z {Some(*n)} else {None}).collect(),
+        _ => vec![] }).collect(), _ => vec![] }
+}
+
+#[test]
+fn embedded_input_correct() {
+    let mut vm = WamState::new(vec![], std::collections::HashMap::new());
+    assert!(eg_p_2(&mut vm, Value::Integer(1), Value::Unbound("R".to_string())));
+    // only eg_link(1,3) -> eg_dn(3) = [3,2,1]; NOT eg_link(2,4) too.
+    assert_eq!(ii(&vm.bindings.get("R").cloned().unwrap()), vec![vec![3,2,1]],
+        "embedded aggregate must honour the head-arg input N=1");
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    format(atom(Cmd), 'cd "~w" && cargo test --test eg_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[embedded-decline exec FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_embedded_input_decline_exec).


### PR DESCRIPTION
## Problem

An embedded aggregate whose inner goal reads an **enclosing-clause input** was mis-parallelised by route 2. For

```prolog
eg_p(N, R) :- eg_guard(N), findall(D, (eg_link(N, X), eg_dn(X, D)), R).
```

`N` is a head arg, but route 2 spliced a `ParAggregate` that ran the `__par_enum`/`__par_body` helpers with `N` **unbound**, so it enumerated *every* `eg_link` and returned wrong results:

- `eg_p(1, R)` produced `[[3,2,1],[4,3,2,1]]` (both links' bodies)
- correct answer is just link(1)'s body: `[[3,2,1]]`

Route 2 does not yet thread external inputs into its helpers (the whole-body route 1 got this in "step 2", already on main).

## Fix (correctness-first)

`rust_embedded_par_aggregate` now **declines** any embedded aggregate that has external inputs, so it compiles **sequentially** and is correct. Input-less embedded aggregates are unaffected and still parallelise.

- New `rust_embedded_aggregate_inputs/4` computes the inner goal's external inputs (vars bound by the head / sibling goals, excluding the result var). Non-empty ⇒ decline.
- It reuses the existing `rust_is_ext_input/3` named helper. A yall lambda would copy the free vars per call and break `==` variable identity (a bug hit earlier and avoided here).
- Adds `rust_conj_list/2`.

## Tests

- `tests/test_wam_rust_embedded_input_decline_exec.pl` (cargo-gated): asserts **no** `ParAggregate` splice for the input-taking case, and that the generated `eg_p_2` honours `N=1` (`[[3,2,1]]`).
- Existing input-less embedded exec tests still pass (parallelisation intact).
- Broad `test_wam_rust_target.pl`: All tests passed. (Two pre-existing `cargo check failed` diagnostics are present on clean `main` as well — unrelated to this change.)

## Follow-on

Actually **threading** external inputs into the embedded route — `ParAggregate` carrying the container's input registers + `par_collect_labels` passing them, mirroring whole-body step 2 — so input-taking embedded aggregates parallelise *correctly* rather than falling back to sequential.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_