### PR TITLE
feat(wam-rust): T9 fact-table inline (opt-in) — emission + classification seam

### DIFF
--- a/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
+++ b/docs/proposals/WAM_LOWERING_TAXONOMY_AND_MATRIX.md
@@ -96,7 +96,7 @@ lowerability gate + emit; T8 depth is roadmap-derived — see notes.)
 | Target  | T1 det | T2 ITE | T3 mc-1 | T4 mc-n | T5 mc→`->` | T6 idx | T7 par | T8 kernels | T9 facts | T10 mode | T11 LCO |
 |---------|:------:|:------:|:-------:|:-------:|:----------:|:------:|:------:|:----------:|:--------:|:--------:|:-------:|
 | scala   | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✓ | ✗ | ✗ |
-| rust    | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | `~` gated | ✓ | ✗ | ✗ | ✗ |
+| rust    | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | `~` gated | ✓ | `~` opt-in | ✗ | ✗ |
 | cpp     | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✗ | ✗ | ✗ | ✗ |
 | go      | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✗ | ✗ | ✗ |
 | haskell | ✓ | ✓ T2a | ✓ | ✓ | ✓ | `~` gated | ✗ | ✓ | ✓ | ✗ | ✗ |
@@ -159,10 +159,14 @@ Verification notes:
   `docs/reports/wam_rust_t7_speedup_benchmark.md`,
   `docs/reports/wam_rust_t7_RESUME.md`. (Like the LLVM T6 decline, the benchmark
   is what gated the decision — here it said "yes, but only behind the probe.")
-- **T9**: rust and scala's lowered *emitters* emit no fact tables; scala's
-  ✓ is the target-level fact-source backend (auto-inline ≤128 rows, then
-  CSV/TSV/LMDB) — a different mechanism than lua/r/haskell's emitter-level
-  inline tables, but it is fact-table inlining, so ✓. rust = ✗.
+- **T9**: scala's ✓ is the target-level fact-source backend (auto-inline ≤128
+  rows, then CSV/TSV/LMDB) — a different mechanism than lua/r/haskell's
+  emitter-level inline tables, but it is fact-table inlining, so ✓. **rust = `~`
+  (opt-in):** `fact_table_inline(true)` lowers an all-ground-facts predicate
+  above `t9_min_rows` (default 64) to a static row table + a first-arg-prefiltered
+  choice-point enumerator (`fact_table_attempt`); off by default. Query-mode
+  matrix + emission tests: `tests/test_wam_rust_fact_table_exec.pl`,
+  `tests/test_wam_rust_fact_table_emit.pl`.
 - **T8** (native kernels) is a curated library feature dispatched via shared
   `kernel_dispatch` plumbing, not a generic per-predicate lowering. ✓ marks
   the roadmap's validated full-parity set (Rust / Haskell / Elixir / Go /

--- a/docs/proposals/wam_rust_t9_fact_table_design.md
+++ b/docs/proposals/wam_rust_t9_fact_table_design.md
@@ -1,7 +1,18 @@
 # rust T9 — fact-table inline (design)
 
-**Status:** design / spec / implementation plan. Survey of the reference targets
-(R / Haskell / Lua) + the Rust target's current fact handling is folded in.
+**Status:** IMPLEMENTED (opt-in). Step 1 (detection/extraction), Step 2
+(emission: `emit_fact_table_rust/4` + `rust_term_to_value_literal/2`), Step 3
+(classification seam in `classify_predicates`, gated by `fact_table_inline(true)`;
+`fact_table` arm in `generate_predicate_codes`), and Step 4 (query-mode exec
+matrix + emission tests + matrix doc) are landed. Enumeration uses a generic
+`fact_table_attempt` runtime method + a `"fact_table"` `resume_builtin` arm.
+Follow-ons: a real first-arg hash index (current code prefilters by a bound
+atomic first arg, then linear-scans) and `call`-site integration so other
+predicates can invoke a fact-table predicate via WAM dispatch (the exec matrix
+calls the generated `pub fn` directly).
+
+Original design / spec / implementation plan below. Survey of the reference
+targets (R / Haskell / Lua) + the Rust target's current fact handling is folded in.
 
 ---
 

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -20,7 +20,9 @@
     detect_kernels/2,                    % +Predicates, -DetectedKernels
     generate_setup_foreign_predicates_rust/2, % +DetectedKernels, -RustCode
     escape_rust_string/2,
-    resolve_lmdb_crate/2                 % +Spec, -Crate  (lmdb_zero|heed|auto -> concrete)
+    resolve_lmdb_crate/2,                % +Spec, -Crate  (lmdb_zero|heed|auto -> concrete)
+    rust_fact_table_classify/3,          % +Module:Pred/Arity, +Options, -fact_info(Arity,Rows)
+    emit_fact_table_rust/4               % +Pred/Arity, +fact_info, +Options, -RustCode
 ]).
 
 :- use_module(library(lists)).
@@ -1119,6 +1121,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
     compile_execute_meta_builtin_to_rust(MetaBuiltinCode),
     compile_execute_foreign_predicate_to_rust(ForeignCode),
     compile_resume_builtin_to_rust(ResumeCode),
+    compile_fact_table_attempt_to_rust(FactTableAttemptCode),
     compile_foreign_result_helpers_to_rust(ForeignResultHelpersCode),
     compile_parse_foreign_tuple_layout_to_rust(ForeignTupleLayoutCode),
     compile_collect_native_category_ancestor_to_rust(NativeAncestorCode),
@@ -1145,6 +1148,7 @@ compile_wam_helpers_to_rust(_Options, RustCode) :-
         MetaBuiltinCode, '\n\n',
         ForeignCode, '\n\n',
         ResumeCode, '\n\n',
+        FactTableAttemptCode, '\n\n',
         ForeignResultHelpersCode, '\n\n',
         ForeignTupleLayoutCode, '\n\n',
         NativeAncestorCode, '\n\n',
@@ -2998,9 +3002,65 @@ compile_collect_native_astar_shortest_path_to_rust(Code) :-
         }
     }'.
 
+% T9 fact-table enumeration helper (generic, predicate-independent). Each
+% candidate is a Value::List of column values; unify all columns with the query
+% args. On the first match leave a choice point carrying the remaining candidates
+% (resumed via the "fact_table" arm of resume_builtin) so backtrack() yields the
+% next matching row. Mirrors builtin_between_attempt for choice-point bookkeeping.
+compile_fact_table_attempt_to_rust(Code) :-
+    Code = '    /// T9: try each candidate fact row against the query args, leaving a
+    /// choice point for the rest so backtrack() enumerates further matches.
+    pub fn fact_table_attempt(&mut self, args: Vec<Value>, cands: Vec<Value>) -> bool {
+        let mut rest = cands;
+        while !rest.is_empty() {
+            let row = rest.remove(0);
+            let cols = match &row { Value::List(c) => c.clone(), _ => continue };
+            if cols.len() != args.len() { continue; }
+            // Snapshot the machine BEFORE this row binds anything, so a later
+            // backtrack restores exactly here and resume_builtin retries on rest.
+            let cp_trail = self.trail.len();
+            let cp_heap = self.heap.len();
+            let cp_regs = self.save_regs();
+            let cp_stack = self.stack.clone();
+            let mut ok = true;
+            for (a, c) in args.iter().zip(cols.iter()) {
+                if !self.unify(a, c) { ok = false; break; }
+            }
+            if ok {
+                if !rest.is_empty() {
+                    self.choice_points.push(ChoicePoint {
+                        next_pc: self.pc,
+                        saved_args: cp_regs,
+                        stack: cp_stack,
+                        cp: self.cp,
+                        trail_len: cp_trail,
+                        heap_len: cp_heap,
+                        builtin_state: Some(BuiltinState {
+                            name: "fact_table".to_string(),
+                            args: args.clone(),
+                            data: rest,
+                        }),
+                        cut_barrier: self.cut_barrier,
+                    });
+                }
+                self.pc += 1;
+                return true;
+            }
+            // This row failed: undo any partial bindings/heap and try the next.
+            self.unwind_trail_to(cp_trail);
+            self.heap.truncate(cp_heap);
+        }
+        false
+    }'.
+
 compile_resume_builtin_to_rust(Code) :-
     Code = '    fn resume_builtin(&mut self, state: BuiltinState) -> bool {
         match state.name.as_str() {
+            "fact_table" => {
+                // T9: resume a fact-table scan at the next candidate row. The
+                // machine has already been restored to the pre-row snapshot.
+                self.fact_table_attempt(state.args, state.data)
+            }
             "aggregate_frame" => {
                 if state.args.len() != 3 { return false; }
                 let agg_type = match &state.args[0] {
@@ -4936,6 +4996,80 @@ rust_fact_clause(Head, Body) :-
 rust_t9_min_rows(Options, N) :-
     ( member(t9_min_rows(N), Options) -> true ; N = 64 ).
 
+% --- T9 fact-table inline: emission -----------------------------------------
+%
+% emit_fact_table_rust(+Pred/Arity, +fact_info(Arity,Rows), +Options, -RustCode):
+% emit a row-builder fn + a public enumeration fn for a ground-fact predicate.
+% The enumeration fn dereferences its args, prefilters rows by a bound atomic
+% first argument (a cheap first-arg index; unbound/compound first arg => full
+% scan), then drives crate fact_table_attempt, which unifies every column and
+% leaves a choice point per remaining candidate so backtrack() yields the next
+% matching row — same solution sequence and order as the T4/WAM path.
+emit_fact_table_rust(Pred/Arity, fact_info(Arity, Rows), _Options, RustCode) :-
+    Arity >= 1,
+    rust_safe_function_name(Pred/Arity, FName),
+    % row-builder: vec![ vec![<col literals>], ... ] in source order
+    maplist(rust_fact_row_literal, Rows, RowLiterals),
+    atomic_list_concat(RowLiterals, ',\n        ', RowsBody),
+    % public fn signature: (vm, a1: Value, .., aN: Value)
+    numlist(1, Arity, Idxs),
+    findall(AD, ( member(I, Idxs), format(atom(AD), 'a~w: Value', [I]) ), ArgDecls),
+    atomic_list_concat(['vm: &mut WamState'|ArgDecls], ', ', SigArgs),
+    findall(AN, ( member(I, Idxs), format(atom(AN), 'a~w', [I]) ), ArgNames),
+    atomic_list_concat(ArgNames, ', ', ArgsVec),
+    length(Rows, NRows),
+    format(string(RustCode),
+'fn ~w_rows() -> Vec<Vec<Value>> {
+    vec![
+        ~w
+    ]
+}
+
+/// T9 fact table: ~w/~w (~w rows). First-arg prefilter + choice-point enumeration.
+pub fn ~w(~w) -> bool {
+    let __args: Vec<Value> = vec![~w].iter().map(|v| vm.deref_var(&vm.deref_heap(v))).collect();
+    let __rows = ~w_rows();
+    let __cands: Vec<Value> = __rows.into_iter()
+        .filter(|r| match &__args[0] {
+            Value::Atom(_) | Value::Integer(_) | Value::Float(_) => r.get(0) == Some(&__args[0]),
+            _ => true,
+        })
+        .map(Value::List)
+        .collect();
+    vm.fact_table_attempt(__args, __cands)
+}',
+        [FName, RowsBody, Pred, Arity, NRows, FName, SigArgs, ArgsVec, FName]),
+    !.
+
+% One row -> `vec![<col1>, <col2>, ...]`.
+rust_fact_row_literal(Row, Literal) :-
+    maplist(rust_term_to_value_literal, Row, ColLits),
+    atomic_list_concat(ColLits, ', ', Inner),
+    format(string(Literal), 'vec![~w]', [Inner]).
+
+% A ground Prolog term -> a Rust `Value::...` literal (matches the runtime Value
+% enum: Atom/Integer/Float/Str/List). [] maps to an empty Value::List.
+rust_term_to_value_literal(T, Lit) :- integer(T), !,
+    format(string(Lit), 'Value::Integer(~w)', [T]).
+rust_term_to_value_literal(T, Lit) :- float(T), !,
+    format(string(Lit), 'Value::Float(~w)', [T]).
+rust_term_to_value_literal(T, Lit) :- is_list(T), !,
+    maplist(rust_term_to_value_literal, T, Es),
+    atomic_list_concat(Es, ', ', Inner),
+    format(string(Lit), 'Value::List(vec![~w])', [Inner]).
+rust_term_to_value_literal(T, Lit) :- atom(T), !,
+    escape_rust_string(T, E),
+    format(string(Lit), 'Value::Atom("~w".to_string())', [E]).
+rust_term_to_value_literal(T, Lit) :- string(T), !,
+    escape_rust_string(T, E),
+    format(string(Lit), 'Value::Atom("~w".to_string())', [E]).
+rust_term_to_value_literal(T, Lit) :- compound(T), !,
+    T =.. [F|Args],
+    escape_rust_string(F, EF),
+    maplist(rust_term_to_value_literal, Args, Es),
+    atomic_list_concat(Es, ', ', Inner),
+    format(string(Lit), 'Value::Str("~w".to_string(), vec![~w])', [EF, Inner]).
+
 % --- T7 embedded-aggregate wiring, step 1: pure clause-lifting pass ----------
 %
 % Apply lift_embedded_aggregate across a predicate's clauses, lifting every
@@ -5896,7 +6030,16 @@ classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
     (   PredIndicator = Module:Pred/Arity -> true
     ;   PredIndicator = Pred/Arity, Module = user
     ),
-    (   % Check for auto-detectable FFI kernel FIRST (unless suppressed)
+    (   % T9 fact-table inline (opt-in): a large all-ground-facts predicate
+        % compiles to a static row table + first-arg-prefiltered choice-point
+        % enumeration, instead of T4 instruction sequences. Checked first so it
+        % wins for eligible predicates; off by default (fact_table_inline(true)).
+        option(fact_table_inline(true), Options),
+        rust_fact_table_classify(Module:Pred/Arity, Options, FInfo),
+        catch(emit_fact_table_rust(Pred/Arity, FInfo, Options, FactCode), _, fail)
+    ->  format(user_error, '  ~w/~w: fact table (T9)~n', [Pred, Arity]),
+        Entry = classified(Module, Pred, Arity, fact_table, FactCode)
+    ;   % Check for auto-detectable FFI kernel FIRST (unless suppressed)
         \+ option(no_kernels(true), Options),
         \+ rust_runtime_parser_support_module(Module),
         functor(KHead, Pred, Arity),
@@ -6034,6 +6177,10 @@ generate_predicate_codes([classified(_, Pred, Arity, ffi_kernel, Kernel)|Rest],
 generate_predicate_codes([classified(_, _Pred, _Arity, native, PredCode)|Rest],
                          WamEntries, Options, [Code|RestCodes]) :-
     format(string(Code), "// Strategy: native\n~w", [PredCode]),
+    generate_predicate_codes(Rest, WamEntries, Options, RestCodes).
+generate_predicate_codes([classified(_, _Pred, _Arity, fact_table, PredCode)|Rest],
+                         WamEntries, Options, [Code|RestCodes]) :-
+    format(string(Code), "// Strategy: fact_table (T9)\n~w", [PredCode]),
     generate_predicate_codes(Rest, WamEntries, Options, RestCodes).
 generate_predicate_codes([classified(_, _Pred, _Arity, wam_foreign, PredCode)|Rest],
                          WamEntries, Options, [Code|RestCodes]) :-

--- a/tests/test_wam_rust_fact_table_emit.pl
+++ b/tests/test_wam_rust_fact_table_emit.pl
@@ -1,0 +1,57 @@
+% test_wam_rust_fact_table_emit.pl
+%
+% T9 fact-table inline (Rust) — emission + classification-seam checks (no cargo).
+% Verifies that with fact_table_inline(true) an eligible facts predicate lowers to
+% the fact_table strategy (static row table + fact_table_attempt enumerator), and
+% that WITHOUT the option it is unaffected (default path, no fact table).
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target',
+              [write_wam_rust_project/3, emit_fact_table_rust/4]).
+
+:- dynamic edge/2.
+edge(a, 1). edge(a, 2). edge(b, 3). edge(a, 4). edge(c, 5). edge(b, 6).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+gen(Opts, Dir, Src) :-
+    safe_rmdir(Dir),
+    once(write_wam_rust_project([user:edge/2], [module_name(eg)|Opts], Dir)),
+    atom_concat(Dir, '/src/lib.rs', LibRs),
+    read_file_to_string(LibRs, Src, []).
+
+:- begin_tests(wam_rust_fact_table_emit).
+
+% the value-literal emitter maps each ground term kind to its Value variant.
+test(value_literals) :-
+    emit_fact_table_rust(p/2, fact_info(2, [[foo, 7], [bar, -3]]), [], Code),
+    assertion(sub_string(Code, _, _, _, "Value::Atom(\"foo\".to_string())")),
+    assertion(sub_string(Code, _, _, _, "Value::Integer(7)")),
+    assertion(sub_string(Code, _, _, _, "Value::Integer(-3)")),
+    assertion(sub_string(Code, _, _, _, "pub fn p_2(vm: &mut WamState, a1: Value, a2: Value) -> bool")),
+    assertion(sub_string(Code, _, _, _, "vm.fact_table_attempt(__args, __cands)")).
+
+% nested terms / lists / floats lower correctly.
+test(value_literals_compound) :-
+    emit_fact_table_rust(q/1, fact_info(1, [[f(a, [1, 2])], [3.5]]), [], Code),
+    assertion(sub_string(Code, _, _, _, "Value::Str(\"f\".to_string(), vec![Value::Atom(\"a\".to_string()), Value::List(vec![Value::Integer(1), Value::Integer(2)])])")),
+    assertion(sub_string(Code, _, _, _, "Value::Float(3.5)")).
+
+% with the option: eligible predicate is classified fact_table.
+test(opt_in_classifies_fact_table, [cleanup(safe_rmdir('output/test_t9_emit_on'))]) :-
+    gen([fact_table_inline(true), t9_min_rows(4)], 'output/test_t9_emit_on', Src),
+    assertion(sub_string(Src, _, _, _, "Strategy: fact_table")),
+    assertion(sub_string(Src, _, _, _, "fn edge_2_rows() -> Vec<Vec<Value>>")),
+    assertion(sub_string(Src, _, _, _, "vm.fact_table_attempt")).
+
+% default (no option): unchanged, no fact table emitted.
+test(default_off_no_fact_table, [cleanup(safe_rmdir('output/test_t9_emit_off'))]) :-
+    gen([], 'output/test_t9_emit_off', Src),
+    assertion(\+ sub_string(Src, _, _, _, "Strategy: fact_table")),
+    assertion(\+ sub_string(Src, _, _, _, "edge_2_rows")).
+
+% below threshold even with the option: not a fact table.
+test(below_threshold_off, [cleanup(safe_rmdir('output/test_t9_emit_thresh'))]) :-
+    gen([fact_table_inline(true), t9_min_rows(100)], 'output/test_t9_emit_thresh', Src),
+    assertion(\+ sub_string(Src, _, _, _, "Strategy: fact_table")).
+
+:- end_tests(wam_rust_fact_table_emit).

--- a/tests/test_wam_rust_fact_table_exec.pl
+++ b/tests/test_wam_rust_fact_table_exec.pl
@@ -1,0 +1,108 @@
+% test_wam_rust_fact_table_exec.pl
+%
+% T9 fact-table inline (Rust) — query-mode exec matrix. A large all-ground-facts
+% predicate compiled with fact_table_inline(true) must enumerate exactly the same
+% solutions, in the same order, as the ordinary path across the four arg modes:
+%   (+,-) key bound        -> all values for that key, source order
+%   (-,+) value bound      -> the matching key(s)
+%   (-,-) both unbound     -> every row, source order
+%   (+,+) both bound       -> succeed iff the row exists
+% Backtracking is driven by vm.backtrack() resuming the fact_table choice point.
+%
+% cargo-gated.
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+
+:- dynamic edge/2.
+% 6 rows; t9_min_rows(4) makes this eligible. Distinct + repeated first-arg keys.
+edge(a, 1). edge(a, 2). edge(b, 3). edge(a, 4). edge(c, 5). edge(b, 6).
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- begin_tests(wam_rust_fact_table_exec).
+
+test(query_mode_matrix,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_t9_exec'))]) :-
+    Dir = 'output/test_t9_exec',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project(
+        [user:edge/2],
+        [module_name(eg), fact_table_inline(true), t9_min_rows(4)], Dir)),
+    atom_concat(Dir, '/src/lib.rs', LibRs),
+    read_file_to_string(LibRs, Src, []),
+    assertion(sub_string(Src, _, _, _, "Strategy: fact_table")),
+    assertion(sub_string(Src, _, _, _, "fact_table_attempt")),
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/eg_test.rs', TestPath),
+    TestSrc = '
+use eg::value::Value;
+use eg::state::WamState;
+use eg::edge_2;
+
+// Enumerate all solutions of `edge(a1, a2)`, reading the listed var bindings per
+// solution. Drives backtrack() (which resumes the fact_table choice point).
+fn solutions(a1: Value, a2: Value, vars: &[&str]) -> Vec<Vec<Value>> {
+    let mut vm = WamState::new(vec![], std::collections::HashMap::new());
+    let mut out = Vec::new();
+    if edge_2(&mut vm, a1, a2) {
+        loop {
+            out.push(vars.iter()
+                .map(|v| vm.bindings.get(*v).cloned().unwrap_or(Value::Unbound(v.to_string())))
+                .collect());
+            if !vm.backtrack() { break; }
+        }
+    }
+    out
+}
+fn at(s: &str) -> Value { Value::Atom(s.to_string()) }
+fn ity(n: i64) -> Value { Value::Integer(n) }
+fn ub(s: &str) -> Value { Value::Unbound(s.to_string()) }
+
+#[test]
+fn plus_minus_key_bound() {
+    // edge(a, X): values 1,2,4 in source order
+    let s = solutions(at("a"), ub("X"), &["X"]);
+    assert_eq!(s, vec![vec![ity(1)], vec![ity(2)], vec![ity(4)]]);
+}
+#[test]
+fn minus_plus_value_bound() {
+    // edge(K, 3): only b
+    let s = solutions(ub("K"), ity(3), &["K"]);
+    assert_eq!(s, vec![vec![at("b")]]);
+}
+#[test]
+fn minus_minus_all_rows() {
+    // edge(K, X): every row, source order
+    let s = solutions(ub("K"), ub("X"), &["K", "X"]);
+    assert_eq!(s, vec![
+        vec![at("a"), ity(1)], vec![at("a"), ity(2)], vec![at("b"), ity(3)],
+        vec![at("a"), ity(4)], vec![at("c"), ity(5)], vec![at("b"), ity(6)],
+    ]);
+}
+#[test]
+fn plus_plus_membership() {
+    assert_eq!(solutions(at("a"), ity(2), &[]).len(), 1, "edge(a,2) exists");
+    assert_eq!(solutions(at("a"), ity(3), &[]).len(), 0, "edge(a,3) absent");
+    assert_eq!(solutions(at("z"), ity(9), &[]).len(), 0, "unknown key fails");
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    format(atom(Cmd), 'cd "~w" && cargo test --test eg_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[T9 fact-table exec FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_fact_table_exec).


### PR DESCRIPTION
## What

Implements **T9 fact-table inline** for the Rust WAM target (opt-in). With `fact_table_inline(true)`, an all-ground-facts predicate above `t9_min_rows` (default 64) lowers to a **static row table + choice-point enumerator** instead of T4 instruction sequences. **Off by default** — existing output is unchanged.

Step 1 (detection/extraction, `rust_fact_table_classify`) was already landed; this PR adds Steps 2–4.

## How

- **Emission** — `emit_fact_table_rust/4` emits `<pred>_rows() -> Vec<Vec<Value>>` (rows in source order) and `pub fn <pred>_<arity>(vm, a1..aN) -> bool` that dereferences args, prefilters rows by a **bound atomic first argument** (unbound/compound first arg ⇒ full scan), and drives `fact_table_attempt`.
- **Value literals** — `rust_term_to_value_literal/2` maps a ground Prolog term to a Rust `Value` literal (`Atom`/`Integer`/`Float`/`Str`/`List`; `[]` → empty `List`).
- **Runtime enumeration** — a generic `fact_table_attempt` method unifies every column of each candidate row and leaves a choice point per remaining candidate; a `"fact_table"` `resume_builtin` arm resumes the scan on `backtrack()`, giving the **same solution sequence and order** as the ordinary path. Choice-point bookkeeping mirrors `builtin_between_attempt`.
- **Classification seam** — T9 is checked first in `classify_predicates` (gated by `fact_table_inline(true)`); a `fact_table` arm in `generate_predicate_codes` emits the code. Exports `rust_fact_table_classify/3` + `emit_fact_table_rust/4`.

## Tests

- `test_wam_rust_fact_table_exec.pl` (cargo-gated) — query-mode matrix over `edge/2`:
  - `(+,-)` key bound → values in source order
  - `(-,+)` value bound → matching key
  - `(-,-)` both unbound → every row in source order
  - `(+,+)` membership succeeds/fails correctly
  Backtracking via the `fact_table` choice point verified end-to-end.
- `test_wam_rust_fact_table_emit.pl` (fast, no cargo) — value-literal mapping (incl. nested `Str`/`List`/`Float`), opt-in classification, default-off, below-threshold-off.
- Regression: `test_wam_rust_target` (All tests passed), T9 step-1 (6/6), T7 embedded/threading exec all green; generated projects build cleanly.

Matrix doc updated (rust T9 `✗ → ~ opt-in`); design doc marked implemented.

## Follow-ons (documented)

- A real first-arg **hash index** (current code prefilters then linear-scans).
- `call`-site WAM integration so other predicates can invoke a fact-table predicate via dispatch (the exec matrix calls the generated `pub fn` directly).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_