### PR TITLE
perf(wam-rust): T9 fact tables — first-arg hash index

### DIFF
--- a/docs/proposals/wam_rust_t9_fact_table_design.md
+++ b/docs/proposals/wam_rust_t9_fact_table_design.md
@@ -5,11 +5,14 @@
 (classification seam in `classify_predicates`, gated by `fact_table_inline(true)`;
 `fact_table` arm in `generate_predicate_codes`), and Step 4 (query-mode exec
 matrix + emission tests + matrix doc) are landed. Enumeration uses a generic
-`fact_table_attempt` runtime method + a `"fact_table"` `resume_builtin` arm.
-Follow-ons: a real first-arg hash index (current code prefilters by a bound
-atomic first arg, then linear-scans) and `call`-site integration so other
-predicates can invoke a fact-table predicate via WAM dispatch (the exec matrix
-calls the generated `pub fn` directly).
+`fact_table_attempt` runtime method + a `"fact_table"` `resume_builtin` arm. The
+table is built once via `OnceLock` with a **first-argument hash index**
+(`Value::fact_index_key` keys both rows and the query arg): a bound atomic first
+arg selects its bucket in O(1), otherwise a full scan. Within-bucket order is
+source order, so the solution sequence matches the T4/WAM path.
+Follow-on: `call`-site integration so other predicates can invoke a fact-table
+predicate via WAM dispatch (the exec matrix calls the generated `pub fn`
+directly).
 
 Original design / spec / implementation plan below. Survey of the reference
 targets (R / Haskell / Lua) + the Rust target's current fact handling is folded in.

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -4999,18 +4999,18 @@ rust_t9_min_rows(Options, N) :-
 % --- T9 fact-table inline: emission -----------------------------------------
 %
 % emit_fact_table_rust(+Pred/Arity, +fact_info(Arity,Rows), +Options, -RustCode):
-% emit a row-builder fn + a public enumeration fn for a ground-fact predicate.
-% The enumeration fn dereferences its args, prefilters rows by a bound atomic
-% first argument (a cheap first-arg index; unbound/compound first arg => full
-% scan), then drives crate fact_table_attempt, which unifies every column and
-% leaves a choice point per remaining candidate so backtrack() yields the next
-% matching row — same solution sequence and order as the T4/WAM path.
+% emit a lazily-built (OnceLock) row table + first-argument hash index, and a
+% public enumeration fn. The fn dereferences its args; when the first arg is a
+% bound atomic value it selects that index bucket (O(1) lookup), otherwise it
+% scans all rows; it then drives crate fact_table_attempt, which unifies every
+% column and leaves a choice point per remaining candidate so backtrack() yields
+% the next matching row — same solution sequence/order as the T4/WAM path.
 emit_fact_table_rust(Pred/Arity, fact_info(Arity, Rows), _Options, RustCode) :-
     Arity >= 1,
     rust_safe_function_name(Pred/Arity, FName),
-    % row-builder: vec![ vec![<col literals>], ... ] in source order
+    % row literals: vec![ vec![<col literals>], ... ] in source order
     maplist(rust_fact_row_literal, Rows, RowLiterals),
-    atomic_list_concat(RowLiterals, ',\n        ', RowsBody),
+    atomic_list_concat(RowLiterals, ',\n            ', RowsBody),
     % public fn signature: (vm, a1: Value, .., aN: Value)
     numlist(1, Arity, Idxs),
     findall(AD, ( member(I, Idxs), format(atom(AD), 'a~w: Value', [I]) ), ArgDecls),
@@ -5019,23 +5019,32 @@ emit_fact_table_rust(Pred/Arity, fact_info(Arity, Rows), _Options, RustCode) :-
     atomic_list_concat(ArgNames, ', ', ArgsVec),
     length(Rows, NRows),
     format(string(RustCode),
-'fn ~w_rows() -> Vec<Vec<Value>> {
-    vec![
-        ~w
-    ]
+'#[allow(clippy::type_complexity)]
+fn ~w_table() -> &''static (Vec<Vec<Value>>, std::collections::HashMap<String, Vec<usize>>) {
+    static T: std::sync::OnceLock<(Vec<Vec<Value>>, std::collections::HashMap<String, Vec<usize>>)> = std::sync::OnceLock::new();
+    T.get_or_init(|| {
+        let rows: Vec<Vec<Value>> = vec![
+            ~w
+        ];
+        let mut idx: std::collections::HashMap<String, Vec<usize>> = std::collections::HashMap::new();
+        for (i, r) in rows.iter().enumerate() {
+            if let Some(k) = r[0].fact_index_key() {
+                idx.entry(k).or_default().push(i);
+            }
+        }
+        (rows, idx)
+    })
 }
 
-/// T9 fact table: ~w/~w (~w rows). First-arg prefilter + choice-point enumeration.
+/// T9 fact table: ~w/~w (~w rows). First-arg hash index + choice-point enumeration.
 pub fn ~w(~w) -> bool {
     let __args: Vec<Value> = vec![~w].iter().map(|v| vm.deref_var(&vm.deref_heap(v))).collect();
-    let __rows = ~w_rows();
-    let __cands: Vec<Value> = __rows.into_iter()
-        .filter(|r| match &__args[0] {
-            Value::Atom(_) | Value::Integer(_) | Value::Float(_) => r.get(0) == Some(&__args[0]),
-            _ => true,
-        })
-        .map(Value::List)
-        .collect();
+    let (__rows, __idx) = ~w_table();
+    // Bound atomic first arg -> that index bucket; otherwise full scan.
+    let __cands: Vec<Value> = match __args[0].fact_index_key() {
+        Some(k) => __idx.get(&k).map(|is| is.iter().map(|&i| Value::List(__rows[i].clone())).collect()).unwrap_or_default(),
+        None => __rows.iter().map(|r| Value::List(r.clone())).collect(),
+    };
     vm.fact_table_attempt(__args, __cands)
 }',
         [FName, RowsBody, Pred, Arity, NRows, FName, SigArgs, ArgsVec, FName]),

--- a/templates/targets/rust_wam/value.rs.mustache
+++ b/templates/targets/rust_wam/value.rs.mustache
@@ -29,6 +29,20 @@ pub enum Value {
 }
 
 impl Value {
+    /// First-argument index key for T9 fact tables: a type-tagged canonical
+    /// string for an atomic value (atom / integer / float), or None for
+    /// compound / list / unbound / ref values (which can only match via a full
+    /// scan). The same function keys both the stored rows and the query arg, so
+    /// a bound atomic first argument selects exactly the matching index bucket.
+    pub fn fact_index_key(&self) -> Option<String> {
+        match self {
+            Value::Atom(s) => Some(format!("a:{}", s)),
+            Value::Integer(n) => Some(format!("i:{}", n)),
+            Value::Float(f) => Some(format!("f:{}", f)),
+            _ => None,
+        }
+    }
+
     /// Check if this value is an unbound WAM variable.
     /// Corresponds to is_unbound_var/1 in wam_runtime.pl.
     pub fn is_unbound(&self) -> bool {

--- a/tests/test_wam_rust_fact_table_emit.pl
+++ b/tests/test_wam_rust_fact_table_emit.pl
@@ -21,13 +21,16 @@ gen(Opts, Dir, Src) :-
 
 :- begin_tests(wam_rust_fact_table_emit).
 
-% the value-literal emitter maps each ground term kind to its Value variant.
+% the value-literal emitter maps each ground term kind to its Value variant, and
+% the fn builds a OnceLock-cached table + first-arg hash index.
 test(value_literals) :-
     emit_fact_table_rust(p/2, fact_info(2, [[foo, 7], [bar, -3]]), [], Code),
     assertion(sub_string(Code, _, _, _, "Value::Atom(\"foo\".to_string())")),
     assertion(sub_string(Code, _, _, _, "Value::Integer(7)")),
     assertion(sub_string(Code, _, _, _, "Value::Integer(-3)")),
     assertion(sub_string(Code, _, _, _, "pub fn p_2(vm: &mut WamState, a1: Value, a2: Value) -> bool")),
+    assertion(sub_string(Code, _, _, _, "std::sync::OnceLock")),
+    assertion(sub_string(Code, _, _, _, "fact_index_key()")),
     assertion(sub_string(Code, _, _, _, "vm.fact_table_attempt(__args, __cands)")).
 
 % nested terms / lists / floats lower correctly.
@@ -40,14 +43,14 @@ test(value_literals_compound) :-
 test(opt_in_classifies_fact_table, [cleanup(safe_rmdir('output/test_t9_emit_on'))]) :-
     gen([fact_table_inline(true), t9_min_rows(4)], 'output/test_t9_emit_on', Src),
     assertion(sub_string(Src, _, _, _, "Strategy: fact_table")),
-    assertion(sub_string(Src, _, _, _, "fn edge_2_rows() -> Vec<Vec<Value>>")),
+    assertion(sub_string(Src, _, _, _, "fn edge_2_table()")),
     assertion(sub_string(Src, _, _, _, "vm.fact_table_attempt")).
 
 % default (no option): unchanged, no fact table emitted.
 test(default_off_no_fact_table, [cleanup(safe_rmdir('output/test_t9_emit_off'))]) :-
     gen([], 'output/test_t9_emit_off', Src),
     assertion(\+ sub_string(Src, _, _, _, "Strategy: fact_table")),
-    assertion(\+ sub_string(Src, _, _, _, "edge_2_rows")).
+    assertion(\+ sub_string(Src, _, _, _, "edge_2_table")).
 
 % below threshold even with the option: not a fact table.
 test(below_threshold_off, [cleanup(safe_rmdir('output/test_t9_emit_thresh'))]) :-


### PR DESCRIPTION
## What

T9 follow-on: give the Rust fact tables a real **first-argument hash index**. The base T9 PR (#3193) prefiltered candidate rows with a per-call linear scan — correct, but no faster than T4. This makes a bound atomic first argument an **O(1) bucket lookup**, which is the actual point of T9.

## How

- **`Value::fact_index_key()`** (value.rs template): a type-tagged canonical key for an atomic value — `a:<atom>` / `i:<int>` / `f:<float>` — and `None` for compound/list/unbound/ref. The same function keys both the stored rows and the query argument, so a bound atomic first arg maps to exactly the matching bucket. The type tag prevents atom `"1"` vs integer `1` collisions.
- **`emit_fact_table_rust`** now emits `<pred>_table() -> &'static (Vec<Vec<Value>>, HashMap<String, Vec<usize>>)`, built once via `OnceLock` (already used by the shared WAM table). The `pub fn` looks up the bucket for a bound atomic first arg, otherwise full-scans. Row indices are pushed into each bucket in source order, so **within-bucket enumeration order is source order** — the solution sequence and order are unchanged from the T4/WAM path.

The downstream `fact_table_attempt` (full per-column unification + choice-point enumeration) is unchanged, so the index only narrows candidates.

## Tests

- Query-mode exec matrix (`test_wam_rust_fact_table_exec.pl`) unchanged and still green — `(+,-)/(-,+)/(-,-)/(+,+)` all enumerate the same solutions in the same order, confirming the index preserves semantics.
- Emit test (`test_wam_rust_fact_table_emit.pl`) now asserts `OnceLock` + `fact_index_key()` in the generated code.
- Broad `test_wam_rust_target` green; generated project builds cleanly.

## Remaining follow-on

`call`-site WAM integration so other predicates can invoke a fact-table predicate via dispatch (the exec matrix calls the generated `pub fn` directly).

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_