### PR TITLE
design(wam-rust): boundary distribution optimization — philosophy + specification (+ plan refit)

### DIFF
--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -1,17 +1,22 @@
-# WAM-Rust Boundary Distribution Cache — Implementation Plan
+# WAM-Rust Boundary Distribution Optimization — Implementation Plan
 
-Status: design / groundwork. Scopes porting the **boundary-splice / suffix-distribution
-cache** (prototyped and validated correct in Python by the `codex/*` distribution
-line) into the Rust WAM graph-search target. Companion to
-`DISTRIBUTION_CACHE_BENCHMARK_PLAN.md`, `DISTRIBUTIONAL_COMPRESSION_THEORY.md`,
-`RECURRENCE_EVALUATION_STRATEGY_*.md`, and the EnWiki splice-validation reports.
+Status: in progress (P1, P2a, P2c-parity DONE). The implementation-plan member of
+the design trio: **`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md`** (why — a
+disablable complexity-reduction compiler optimization, caching secondary),
+**`WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md`** (precise semantics, the
+scalar/histogram result-mode family, invariants, interface), and this plan (phased
+work + status). Also companion to `DISTRIBUTION_CACHE_BENCHMARK_PLAN.md`,
+`DISTRIBUTIONAL_COMPRESSION_THEORY.md`, `RECURRENCE_EVALUATION_STRATEGY_*.md`, and
+the EnWiki splice-validation reports.
 
-This plan deliberately **re-derives the cost tradeoffs for compiled Rust** rather
-than inheriting the Python prototype's performance conclusions — because, as with
-the edge cache (see below), several of those conclusions are interpreter-overhead
-artifacts, not properties of the algorithm.
+It ports the **boundary-splice / suffix-distribution** approach (prototyped and
+validated correct in Python by the `codex/*` line) into the Rust WAM graph-search
+target, as a gated compiler optimization. It deliberately **re-derives the cost
+tradeoffs for compiled Rust** rather than inheriting the Python prototype's
+performance conclusions — because, as with the edge cache, several of those
+conclusions are interpreter-overhead artifacts, not properties of the algorithm.
 
-## 1. What the boundary cache is, and why the splice is valid
+## 1. What the boundary distribution is, and why the splice is valid
 
 The effective-distance query aggregates over all bounded paths from a seed to a
 root up `category_parent`:
@@ -209,14 +214,18 @@ Phasing:
     the **production** `collect_native_category_ancestor_hops` aggregate across
     seeds (incl. deep ones through a root-near boundary band) — closing the gap
     that P2a compared only against an in-module oracle.
-  - **P2c-wiring [next].** Make it callable from a query: register a
+  - **P2c-wiring [next].** Make it callable from a query as a gated compiler
+    optimization (`boundary_optimization`, default off): register a
     `category_ancestor_boundary` native kind + dispatch arm, populate the
-    side-table at setup, gate it, and an end-to-end LMDB run. **Design note:** the
-    production kernel emits a *stream* of hops aggregated downstream; to preserve
-    the complexity win the boundary kernel must emit the *aggregate* (a scalar
-    `weighted_power`/`d_eff`), not re-expand the histogram into a hop stream — so
-    the wiring introduces a scalar-result foreign predicate rather than reusing the
-    stream result mode.
+    side-table at setup, and an end-to-end LMDB run. **Result-mode family** (spec
+    §5): the boundary kernel produces the histogram `H`; a *result extractor* emits
+    a single result via the existing `finish_foreign_results` **`deterministic`**
+    mode (`tuple(1)`, no choice point) — either a **scalar** (`f(H)` for a
+    functional, e.g. `weighted_power`/`d_eff`) **or the histogram itself**
+    (`Value::List` of counts) for distribution-output consumers. This must *not*
+    re-expand `H` into a hop stream (that re-introduces the exponential). So the
+    wiring adds extractors over one histogram kernel, not a scalar-only predicate —
+    the histogram-output generalisation keeps it from being built too narrowly.
   - The `boundary_basis` LMDB sub-db (persisted precompute) folds in here.
 - **P3 — the measurement in §6** (does it add wall-time *on top of* the edge
   cache, and from what `D_pre`). Gates whether P4 is worth building.

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md
@@ -1,0 +1,109 @@
+# WAM-Rust Boundary Distribution Optimization — Philosophy
+
+Why the Rust WAM graph-search target should grow a **boundary distribution**
+optimization, what kind of thing it is, and the principles that should shape it.
+Companions: `WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md` (precise semantics),
+`WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md` (phased implementation + status).
+
+## 1. The problem
+
+Root-anchored path-aggregate queries (e.g. `effective_distance`,
+`d_eff = (Σ_paths Hops^(-N))^(-1/N)`) aggregate over **every** path from a seed up
+to a root. In a graph with diamonds the number of such paths is **exponential**
+in the depth budget. The kernel enumerates them all.
+
+The edge cache (PRs #3127–#3196) makes each parent lookup cheap, but it **cannot
+change the number of paths enumerated** — it attacks I/O cost, not the
+combinatorics. So even with a perfect edge cache, a dense shared upper cone is
+re-enumerated, in full, for every seed that passes through it.
+
+## 2. The insight: a path-length histogram is a compact exponential
+
+The aggregate is a **linear functional of the path-length histogram**
+`H[L] = #{paths of length L}`:
+
+```
+WeightSum = Σ_L H[L] · L^(-N)        (and mass = Σ H[L], moment1 = Σ L·H[L], …)
+```
+
+and path histograms **compose by convolution** over any cut node B on the
+seed→root frontier:
+
+```
+H_seed→root = H_seed→B  (∗)  H_B→root
+```
+
+The histogram is the key: a vector of ~`budget` integers represents
+exponentially-many paths exactly. So if the upper cone's histogram `H_B→root` is
+known, a query that reaches B **splices** it (an O(budget) convolution) instead of
+re-enumerating the cone.
+
+## 3. What this primarily is: a complexity reduction (caching is secondary)
+
+The headline is **not** "another cache." It is a **complexity reduction**:
+exponential per-seed path enumeration becomes a polynomial precompute plus an
+O(budget) splice. Measured on a dense-core synthetic graph
+(`boundary_splice_complexity_bench.rs`), the splice is **300–700× faster than full
+enumeration and the speedup grows with scale** — the fingerprint of a
+complexity-class improvement, not a constant factor.
+
+**Caching is the secondary, related lever.** Precomputing the boundary histograms
+once and reusing them across seeds (and across queries) is what amortizes the
+precompute — important, but it rides on top of the complexity win, not the other
+way around. (This is the inverse emphasis of the edge cache, whose entire value
+*is* reuse.)
+
+## 4. What kind of feature: a disablable compiler optimization with a family of outputs
+
+This is best understood as a **compiler optimization**, gated and disablable:
+
+- **Recognize** a query shape — an aggregate of a path-length functional over
+  root-anchored paths, *or* a request for the path-length distribution itself.
+- **Substitute** the enumerating kernel with a **histogram-producing boundary
+  kernel** plus a **result extractor**.
+- **Gate** it (off by default / `boundary_optimization(false)`), so the optimized
+  and unoptimized outputs can be compared and the optimization can be disabled
+  whenever its preconditions are not met.
+
+Crucially, the natural output of the boundary kernel is the **histogram**, and a
+scalar aggregate is just *one extraction* from it. So the optimization is a
+**family**, not a scalar special case:
+
+| query wants | extractor | result Value |
+|-------------|-----------|--------------|
+| a scalar aggregate (`d_eff`, mass, moment) | apply the functional to `H` | `Float`/`Integer` |
+| the path-length **distribution** | return `H` directly | `List` of counts |
+| (future) CDF / quantiles / moments | the corresponding read of `H` | as needed |
+
+Both the scalar and histogram results emit through the existing
+`finish_foreign_results` **`deterministic`** mode (one result, no choice point) —
+no new result machinery. The histogram is the fundamental object; everything else
+is a cheap read of it. Designing for "scalar only" would be a premature
+specialisation that the histogram output (your point) rightly rejects.
+
+## 5. Principles
+
+- **Re-derive cost crossovers for compiled Rust.** The Python prototype concluded
+  the boundary cache was *slower* — an interpreter-overhead artifact (75.6%
+  residual traversal), exactly as on the edge cache (Python: "slower"; Rust:
+  2.5–3.5× faster). Inherit the *algorithm* and the *storage* decisions from the
+  Python line; **re-measure every wall-time crossover** (e.g. precompute depth
+  `D_pre`) in Rust.
+- **Histogram-first, exact-by-default.** Cache the raw histogram (general, all
+  functionals); a pre-weighted basis (`g_B`, a ~1 ns dot product) is a hot-path
+  specialisation. Because the exact splice is ~ns, the exact→approximate ladder is
+  justified by **storage** only, never compute.
+- **Correctness is gated, not assumed.** The splice is exact only under a proper
+  boundary cut (suffix disjoint from prefix on a DAG) and matching root/filter/
+  cycle/budget policy. The optimization must *verify or assume* these and be
+  disablable; correctness is checked against the production kernel (done:
+  `test_wam_rust_boundary_kernel_exec.pl`).
+- **Orthogonal to the edge cache.** Different levers: the edge cache removes seek
+  cost; the boundary distribution removes enumeration. They compose.
+
+## 6. Why now
+
+The complexity win is measured (300–700×), the splice identity is proven in Rust
+(P1), and the runtime kernel exists and matches the production kernel (P2a,
+P2c-parity). What remains is the optimization *wiring* — and the histogram-output
+generalisation above is what keeps that wiring from being built too narrowly.

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
@@ -1,0 +1,131 @@
+# WAM-Rust Boundary Distribution Optimization — Specification
+
+Precise semantics of the boundary distribution optimization. See
+`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md` (rationale) and
+`WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md` (phasing/status).
+
+## 1. Objects
+
+- **Path-length histogram** `H: [u64]`, `H[L]` = number of root-anchored paths of
+  edge-length `L` (within budget). Trailing zeros insignificant. Represented in
+  Rust as `Vec<u64>` (`boundary_cache::Hist`).
+- **Boundary set** `Bset ⊆ V`: nodes near the root at which suffix histograms are
+  cached. `boundary_suffix: FxMap<u32, Vec<u64>>` on `WamState` maps each boundary
+  node `B` to `H_B→root`.
+- **Budget** `max_depth: usize`: the path-length bound, as in the production
+  `category_ancestor` kernel.
+
+## 2. Aggregate functionals (linear in `H`)
+
+```
+f(H) = Σ_L w(L) · H[L]
+  mass          : w(L) = 1
+  moment1        : w(L) = L
+  weighted_power : w(L) = L^(-N)   (L>0)   -> WeightSum; d_eff = WeightSum^(-1/N)
+```
+
+Linearity is what makes the splice exact for *all* functionals simultaneously,
+and what lets the histogram be cached once and read many ways
+(`boundary_cache::{f_mass,f_moment1,f_weighted_power}`).
+
+## 3. The splice identity
+
+For any cut node `B` on a seed→root path, lengths add, so histograms convolve:
+
+```
+H_seed→root[L] = Σ_{a+b=L} H_seed→B[a] · H_B→root[b]
+```
+
+Over a boundary set, a seed→root path crosses the boundary at its **first**
+boundary node (or reaches root with no crossing). The boundary kernel therefore:
+walks seed→{root or first boundary node}; at a boundary node `B` reached at prefix
+depth `d`, adds `H_B→root[b]` into `H[d+b]` for all `d+b ≤ max_depth`, and stops;
+at root, adds `1` to `H[depth+1]`. (`WamState::collect_native_category_ancestor_
+boundary_hist`.)
+
+## 4. Correctness invariants (preconditions for exactness)
+
+1. **Proper cut.** Every `B→root` suffix path must be node-disjoint from any
+   `seed→B` prefix (so production's `visited` pruning never differs). On a DAG
+   (parent-only category edges) with `Bset` chosen as a root-near antichain this
+   holds. The optimization MUST be disabled, or fall back, when it cannot be
+   established.
+2. **Policy match.** Suffix histograms must be precomputed with the *same* root,
+   edge filter, and cycle policy the query uses.
+3. **Budget match.** The `d + b ≤ max_depth` truncation reproduces the production
+   `visited.len() >= max_depth` gate at the cut. Suffixes are precomputed up to
+   `max_depth` and truncated per prefix depth at splice time.
+4. **First-crossing only.** The walk stops at the first boundary node, so each
+   path is counted once.
+
+Conformance is verified against the production kernel
+(`collect_native_category_ancestor_hops`) in
+`tests/test_wam_rust_boundary_kernel_exec.pl`: equal `weighted_power` across seeds.
+
+## 5. Result modes (the output family)
+
+The boundary kernel produces `H`; a **result extractor** maps `H` to the foreign
+predicate's result. All use the existing `finish_foreign_results` **`deterministic`**
+mode (one result, no choice point, `tuple(1)` layout):
+
+| mode | result `Value` | extractor |
+|------|----------------|-----------|
+| `scalar(functional)` | `Float` (or `Integer`) | `f(H)` for the named functional |
+| `histogram` | `List([Integer(H[0]), …])` | identity |
+| `effective_distance` | `Float` | `WeightSum^(-1/N)` |
+
+This is the generalisation over a scalar-only design: `histogram` returns the full
+distribution (e.g. for downstream distribution-compression consumers); `scalar`
+returns an aggregate. Adding CDF/quantile/moment modes is a new extractor over the
+same `H`, not new kernel work.
+
+## 6. Foreign-predicate interface
+
+A native kind `category_ancestor_boundary`, registered like the existing kernels
+(`recursive_kernel_detection.pl` + the `execute_foreign_predicate` dispatch arm),
+result mode `deterministic`, layout `tuple(1)`. Configuration via the existing
+`register_foreign_*_config` channels:
+
+- `edge_pred` (e.g. `category_parent`), `max_depth`, `root`.
+- `result_extractor`: `histogram | scalar(weighted_power(N)) | effective_distance(N) | …`.
+
+Args (illustrative): `category_ancestor_boundary(Seed, Out)` with `Root`,
+`MaxDepth`, and the extractor bound by config; `Out` unifies with the scalar or the
+histogram list.
+
+## 7. Eligibility (what the optimization recognises)
+
+Gated by `boundary_optimization(true)` (default **false**). When on, the compiler
+may substitute the boundary kernel for a predicate whose body is:
+
+- an aggregate of a path-length functional over root-anchored paths
+  (`aggregate_all(sum(W), (path_to_root(Seed,Root,Hops), W is f(Hops)), Out)`),
+  emitted as `scalar(f)`; or
+- a collection of root-anchored path lengths into a list/distribution, emitted as
+  `histogram`.
+
+Non-matching predicates compile unchanged. With the gate off, the production
+kernel is used and output is identical — the basis for the disablability guarantee.
+
+## 8. Boundary set & precompute
+
+- `Bset` policy: root-near nodes (small `D_pre`); the *value* concentrates there
+  (high reuse + large cone) — `D_pre` to be **measured** in Rust, not inherited
+  from the Python curves (philosophy §5).
+- Precompute: `WamState::build_boundary_suffix(Bset, root, max_depth, edge_pred)`
+  enumerates each `B→root` histogram via `enum_ancestor_hist`.
+- Persistence (later): a `boundary_basis` LMDB sub-db (node → packed histogram),
+  loaded at setup like `s2i`/`min_dist`, so the precompute is not repeated per run.
+
+## 9. Storage / approximation
+
+Exact histograms by default. When a node's histogram exceeds a storage budget, a
+fitted form (binomial / discretised GMM, per `DISTRIBUTIONAL_COMPRESSION_THEORY.md`)
+may replace it, gated on a CDF/W1 error bound. Because the exact splice is ~ns,
+approximation is a **storage** decision only.
+
+## 10. Non-goals (this spec)
+
+- Changing the production kernel or the default (un-optimized) semantics.
+- Cross-thread/query persistence beyond the side-table + optional LMDB sub-db.
+- Non-DAG cycle exactness guarantees (handled by the cut precondition / fallback).


### PR DESCRIPTION
## Summary

Per your steer, pausing implementation to write the design docs and re-frame the boundary-distribution work as what it actually is: a **disablable compiler optimization** (complexity reduction primary, caching secondary) with a **family of result modes** — directly answering "what if we want a histogram output?".

Elevates it to the repo's standard design-doc trio:

- **`..._PHILOSOPHY.md`** (new) — why. The path-length histogram is a *compact exponential*; the splice turns exponential per-seed enumeration into a polynomial precompute + O(budget) splice (measured 300–700×, growing with scale). Caching is the secondary amortization. It's a gated compiler optimization that recognizes a path-*aggregate* **or** a path-*distribution* query and substitutes a histogram-producing kernel + result extractor. Re-derive cost crossovers for compiled Rust (Python overhead inverted them). Orthogonal to the edge cache (enumeration vs seeks).
- **`..._SPECIFICATION.md`** (new) — what. Histogram object; aggregate as a linear functional; the splice identity + four correctness invariants (proper cut, policy/budget match, first-crossing); the **result-mode family** (`scalar` / `histogram` / `effective_distance`), all via the existing `finish_foreign_results` **`deterministic`** mode (one result, `tuple(1)`, no choice point); the `category_ancestor_boundary` foreign interface; eligibility/gating (`boundary_optimization`, default off); boundary-set/precompute/storage.
- **`..._CACHE_PLAN.md`** (refit) — header → "Optimization", trio cross-refs, and the P2c-wiring item updated to the histogram-output generalization: **extractors over one histogram kernel**, the histogram emitted as `Value::List`, and explicitly *not* re-expanded into a hop stream (which would re-introduce the exponential).

## The key point

The **histogram is the fundamental output**; a scalar aggregate is just one cheap extraction from it. So the wiring is a family of substitutions over a single histogram-producing kernel, not a scalar-only special case — and adding CDF/quantile/moment modes later is a new extractor, not new kernel work.

Docs-only. With these as the agreed shape, P2c-wiring (the dispatch arm + extractors + gating + LMDB run) can proceed against a settled design.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_