### PR TITLE
feat(wam-rust): T9 fact-table call-site integration (WAM call/execute dispatch)

### DIFF
--- a/docs/proposals/wam_rust_t9_fact_table_design.md
+++ b/docs/proposals/wam_rust_t9_fact_table_design.md
@@ -10,9 +10,13 @@ table is built once via `OnceLock` with a **first-argument hash index**
 (`Value::fact_index_key` keys both rows and the query arg): a bound atomic first
 arg selects its bucket in O(1), otherwise a full scan. Within-bucket order is
 source order, so the solution sequence matches the T4/WAM path.
-Follow-on: `call`-site integration so other predicates can invoke a fact-table
-predicate via WAM dispatch (the exec matrix calls the generated `pub fn`
-directly).
+**Call-site integration is done:** a WAM `call`/`execute` of a fact-table
+predicate is routed (by the Call/Execute instruction handlers) to a generated
+crate-level `fact_table_call(vm, pred, cont_pc)` dispatcher, which reads the A
+registers and drives the enumerator with the right continuation (`pc+1` for
+`call`, the saved `cp` for a tail-call `execute`). So an ordinary predicate can
+call a fact-table predicate and backtrack through it (incl. backtracking into the
+fact-table choice point from a downstream goal). No remaining T9 follow-ons.
 
 Original design / spec / implementation plan below. Survey of the reference
 targets (R / Haskell / Lua) + the Rust target's current fact handling is folded in.

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -674,6 +674,11 @@ wam_instruction_arm('Instruction::Call(p, _arity)', Body) :-
                         self.pc = self.cp;
                         true
                     } else { false }
+                } else if let Some(__ftr) = crate::fact_table_call(self, p, self.pc + 1) {
+                    // T9 fact table called as a deterministic-position goal:
+                    // continuation is the next instruction; the fact enumerator
+                    // sets pc/cp and leaves a choice point for further rows.
+                    __ftr
                 } else if Self::is_iso_meta_builtin(p) {
                     // ISO meta-builtins (catch/3, throw/1, succ/2) are
                     // emitted by the shared WAM compiler as Call rather
@@ -732,6 +737,10 @@ wam_instruction_arm('Instruction::Execute(p)', Body) :-
                     true
                 } else if self.foreign_predicates.contains(p) {
                     self.execute_foreign_predicate(p, 0)
+                } else if let Some(__ftr) = crate::fact_table_call(self, p, self.cp) {
+                    // T9 fact table in tail position: continuation is the saved
+                    // cp (the caller resumes there when the fact pred succeeds).
+                    __ftr
                 } else if Self::is_iso_meta_builtin(p) {
                     // Tail-position ISO meta-builtin: dispatch, then honor
                     // return semantics by jumping to the continuation.
@@ -3009,8 +3018,11 @@ compile_collect_native_astar_shortest_path_to_rust(Code) :-
 % next matching row. Mirrors builtin_between_attempt for choice-point bookkeeping.
 compile_fact_table_attempt_to_rust(Code) :-
     Code = '    /// T9: try each candidate fact row against the query args, leaving a
-    /// choice point for the rest so backtrack() enumerates further matches.
-    pub fn fact_table_attempt(&mut self, args: Vec<Value>, cands: Vec<Value>) -> bool {
+    /// choice point for the rest so backtrack() enumerates further matches. On
+    /// success the pc is set to cont_pc (the call site continuation: pc+1 for a
+    /// `call`, or the saved cp for a tail-call `execute`). The continuation is
+    /// stashed as the first data slot so resume_builtin can restore it.
+    pub fn fact_table_attempt(&mut self, args: Vec<Value>, cands: Vec<Value>, cont_pc: usize) -> bool {
         let mut rest = cands;
         while !rest.is_empty() {
             let row = rest.remove(0);
@@ -3028,8 +3040,11 @@ compile_fact_table_attempt_to_rust(Code) :-
             }
             if ok {
                 if !rest.is_empty() {
+                    let mut data = Vec::with_capacity(rest.len() + 1);
+                    data.push(Value::Integer(cont_pc as i64));
+                    data.append(&mut rest);
                     self.choice_points.push(ChoicePoint {
-                        next_pc: self.pc,
+                        next_pc: cont_pc,
                         saved_args: cp_regs,
                         stack: cp_stack,
                         cp: self.cp,
@@ -3038,12 +3053,12 @@ compile_fact_table_attempt_to_rust(Code) :-
                         builtin_state: Some(BuiltinState {
                             name: "fact_table".to_string(),
                             args: args.clone(),
-                            data: rest,
+                            data,
                         }),
                         cut_barrier: self.cut_barrier,
                     });
                 }
-                self.pc += 1;
+                self.pc = cont_pc;
                 return true;
             }
             // This row failed: undo any partial bindings/heap and try the next.
@@ -3058,8 +3073,12 @@ compile_resume_builtin_to_rust(Code) :-
         match state.name.as_str() {
             "fact_table" => {
                 // T9: resume a fact-table scan at the next candidate row. The
-                // machine has already been restored to the pre-row snapshot.
-                self.fact_table_attempt(state.args, state.data)
+                // machine has already been restored to the pre-row snapshot. The
+                // continuation pc is data[0]; the remaining candidates follow.
+                if state.data.is_empty() { return false; }
+                let cont_pc = match &state.data[0] { Value::Integer(n) => *n as usize, _ => return false };
+                let rest: Vec<Value> = state.data[1..].to_vec();
+                self.fact_table_attempt(state.args, rest, cont_pc)
             }
             "aggregate_frame" => {
                 if state.args.len() != 3 { return false; }
@@ -5037,17 +5056,24 @@ fn ~w_table() -> &''static (Vec<Vec<Value>>, std::collections::HashMap<String, V
 }
 
 /// T9 fact table: ~w/~w (~w rows). First-arg hash index + choice-point enumeration.
-pub fn ~w(~w) -> bool {
-    let __args: Vec<Value> = vec![~w].iter().map(|v| vm.deref_var(&vm.deref_heap(v))).collect();
+/// cont_pc is the call-site continuation (pc+1 for `call`, saved cp for `execute`).
+fn ~w_run(vm: &mut WamState, args: Vec<Value>, cont_pc: usize) -> bool {
+    let __args: Vec<Value> = args.iter().map(|v| vm.deref_var(&vm.deref_heap(v))).collect();
     let (__rows, __idx) = ~w_table();
     // Bound atomic first arg -> that index bucket; otherwise full scan.
     let __cands: Vec<Value> = match __args[0].fact_index_key() {
         Some(k) => __idx.get(&k).map(|is| is.iter().map(|&i| Value::List(__rows[i].clone())).collect()).unwrap_or_default(),
         None => __rows.iter().map(|r| Value::List(r.clone())).collect(),
     };
-    vm.fact_table_attempt(__args, __cands)
+    vm.fact_table_attempt(__args, __cands, cont_pc)
+}
+
+/// Public entry: direct callers get the next-instruction continuation (pc+1).
+pub fn ~w(~w) -> bool {
+    let __cont = vm.pc + 1;
+    ~w_run(vm, vec![~w], __cont)
 }',
-        [FName, RowsBody, Pred, Arity, NRows, FName, SigArgs, ArgsVec, FName]),
+        [FName, RowsBody, Pred, Arity, NRows, FName, FName, FName, SigArgs, FName, ArgsVec]),
     !.
 
 % One row -> `vec![<col1>, <col2>, ...]`.
@@ -6008,11 +6034,53 @@ pub fn shared_wam_program() -> (Vec<Instruction>, HashMap<String, usize>) {
         format(string(Body0), "~w\n\n~w", [SharedCode, PredCodesStr])
     ),
     (   ParWrappers == []
-    ->  Code = Body0
+    ->  Body1 = Body0
     ;   atomic_list_concat(ParWrappers, '\n\n', WrapStr),
-        format(string(Code), "~w\n\n// --- T7 parallel-aggregate wrappers (route 1) ---\n~w",
+        format(string(Body1), "~w\n\n// --- T7 parallel-aggregate wrappers (route 1) ---\n~w",
                [Body0, WrapStr])
-    ).
+    ),
+    % T9 call-site dispatch: a crate-level fact_table_call referenced by the
+    % Call/Execute handlers (always emitted; empty match when no fact tables).
+    rust_fact_table_dispatch_fn(Classified, DispatchCode),
+    format(string(Code), "~w\n\n~w", [Body1, DispatchCode]).
+
+%% rust_fact_table_dispatch_fn(+Classified, -Code)
+%  Emit `fact_table_call(vm, pred, cont_pc) -> Option<bool>`: a match over the
+%  fact-table predicates routing a WAM call/execute to the right `<fn>_run`,
+%  reading args from the A registers. Some(ok) if pred is a fact table, else None.
+rust_fact_table_dispatch_fn(Classified, Code) :-
+    findall(P/A,
+            member(classified(_, P, A, fact_table, _), Classified),
+            FactPIs),
+    maplist(rust_fact_dispatch_arm, FactPIs, Arms),
+    atomic_list_concat(Arms, '\n', ArmsStr),
+    format(string(Code),
+'/// T9 call-site dispatch: route a WAM call/execute of a fact-table predicate to
+/// its enumerator. Some(ok) if `pred` is a fact table, None otherwise.
+#[allow(unused_variables)]
+pub fn fact_table_call(vm: &mut WamState, pred: &str, cont_pc: usize) -> Option<bool> {
+    match pred {
+~w        _ => None,
+    }
+}', [ArmsStr]).
+
+rust_fact_dispatch_arm(Pred/Arity, Arm) :-
+    rust_safe_function_name(Pred/Arity, FName),
+    numlist(1, Arity, Idxs),
+    findall(Read,
+            ( member(I, Idxs),
+              format(atom(Read),
+                '            let a~w = vm.get_reg_raw("A~w").unwrap_or(Value::Unbound("_A~w".to_string()));',
+                [I, I, I]) ),
+            Reads),
+    atomic_list_concat(Reads, '\n', ReadsStr),
+    findall(AN, ( member(I, Idxs), format(atom(AN), 'a~w', [I]) ), ANs),
+    atomic_list_concat(ANs, ', ', ArgsVec),
+    format(string(Arm),
+'        "~w/~w" => {
+~w
+            Some(~w_run(vm, vec![~w], cont_pc))
+        }', [Pred, Arity, ReadsStr, FName, ArgsVec]).
 
 %% rust_pred_has_control_constructs(+Module:Pred/Arity)
 %  True if any clause body uses a backtracking-driven control construct

--- a/tests/test_wam_rust_fact_table_callsite_exec.pl
+++ b/tests/test_wam_rust_fact_table_callsite_exec.pl
@@ -1,0 +1,99 @@
+% test_wam_rust_fact_table_callsite_exec.pl
+%
+% T9 call-site integration: a WAM-compiled predicate that calls a fact-table
+% predicate through ordinary WAM dispatch (`call` for a non-last goal, `execute`
+% for a tail call) must enumerate the fact predicate's solutions correctly,
+% including backtracking into the fact-table choice point from a downstream goal.
+% The Call/Execute handlers route an unresolved predicate to the generated
+% crate::fact_table_call dispatcher.
+%
+% cargo-gated.
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+
+:- dynamic edge/2.
+edge(a, 1). edge(a, 2). edge(b, 3). edge(a, 4). edge(c, 5). edge(b, 6).
+qlast(X) :- edge(a, X).            % tail call -> execute edge/2
+qmid(X) :- edge(a, X), X > 1.      % non-last  -> call edge/2, then filter
+qall(K, L) :- findall(X, edge(K, X), L).   % aggregate enumerates via call edge/2
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- begin_tests(wam_rust_fact_table_callsite_exec).
+
+test(callers_dispatch_to_fact_table,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_t9_callsite_exec'))]) :-
+    Dir = 'output/test_t9_callsite_exec',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project(
+        [user:qlast/1, user:qmid/1, user:qall/2, user:edge/2],
+        [module_name(c), fact_table_inline(true), t9_min_rows(4)], Dir)),
+    atom_concat(Dir, '/src/lib.rs', LibRs),
+    read_file_to_string(LibRs, Src, []),
+    % edge/2 is a fact table; callers reach it via Call/Execute -> fact_table_call
+    assertion(sub_string(Src, _, _, _, "Strategy: fact_table")),
+    assertion(sub_string(Src, _, _, _, "fact_table_call")),
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/c_test.rs', TestPath),
+    TestSrc = '
+use c::value::Value;
+use c::state::WamState;
+use c::{qlast_1, qmid_1, qall_2, shared_wam_program};
+
+fn fresh() -> WamState {
+    let (code, labels) = shared_wam_program();
+    WamState::new(code, labels)
+}
+fn enum1(call: impl Fn(&mut WamState) -> bool, var: &str) -> Vec<i64> {
+    let mut vm = fresh();
+    let mut out = Vec::new();
+    if call(&mut vm) {
+        loop {
+            if let Some(Value::Integer(n)) = vm.bindings.get(var).cloned() { out.push(n); }
+            if !vm.backtrack() || !vm.run() { break; }
+        }
+    }
+    out
+}
+fn ints(v: &Value) -> Vec<i64> {
+    match v { Value::List(xs) => xs.iter().filter_map(|e| if let Value::Integer(n)=e {Some(*n)} else {None}).collect(), _ => vec![] }
+}
+
+#[test]
+fn execute_tailcall() {
+    // qlast(X) :- edge(a, X).  -> execute edge/2 ; X in {1,2,4}
+    assert_eq!(enum1(|vm| qlast_1(vm, Value::Unbound("X".into())), "X"), vec![1,2,4]);
+}
+#[test]
+fn call_nonlast_with_filter() {
+    // qmid(X) :- edge(a, X), X > 1.  -> call edge/2, backtrack into fact CP
+    assert_eq!(enum1(|vm| qmid_1(vm, Value::Unbound("X".into())), "X"), vec![2,4]);
+}
+#[test]
+fn findall_over_fact() {
+    // qall(a, L) :- findall(X, edge(a,X), L). -> L = [1,2,4]
+    let mut vm = fresh();
+    assert!(qall_2(&mut vm, Value::Atom("a".into()), Value::Unbound("L".into())));
+    assert_eq!(ints(&vm.bindings.get("L").cloned().unwrap()), vec![1,2,4]);
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    format(atom(Cmd), 'cd "~w" && cargo test --test c_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[T9 call-site exec FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_fact_table_callsite_exec).

--- a/tests/test_wam_rust_fact_table_emit.pl
+++ b/tests/test_wam_rust_fact_table_emit.pl
@@ -31,7 +31,7 @@ test(value_literals) :-
     assertion(sub_string(Code, _, _, _, "pub fn p_2(vm: &mut WamState, a1: Value, a2: Value) -> bool")),
     assertion(sub_string(Code, _, _, _, "std::sync::OnceLock")),
     assertion(sub_string(Code, _, _, _, "fact_index_key()")),
-    assertion(sub_string(Code, _, _, _, "vm.fact_table_attempt(__args, __cands)")).
+    assertion(sub_string(Code, _, _, _, "vm.fact_table_attempt(__args, __cands, cont_pc)")).
 
 % nested terms / lists / floats lower correctly.
 test(value_literals_compound) :-


### PR DESCRIPTION
## What

The final T9 follow-on: a WAM-compiled predicate can now invoke a fact-table predicate through **ordinary WAM `call`/`execute` dispatch**. Until now the generated `pub fn` was only callable directly (the exec matrices called it by hand).

## How

- **Call/Execute handlers** — after the existing labels/`foreign_predicates` checks, an unresolved predicate is routed to a generated crate-level `fact_table_call(vm, pred, cont_pc) -> Option<bool>`. `Some(ok)` if `pred` is a fact table, `None` otherwise (falls through to ISO-meta/fail exactly as before, so non-fact predicates are unaffected).
- **`fact_table_call`** (always emitted; empty match when a project has no fact tables) matches the predicate key, reads its `A` registers, and drives `<pred>_run` with the **call-site continuation**: `pc + 1` for `call`, the saved `cp` for a tail-call `execute`.
- **`fact_table_attempt`** now takes `cont_pc`: on success it sets `pc = cont_pc` and stashes `cont_pc` as `data[0]` of the choice point, so `resume_builtin` restores the right continuation on backtrack. `emit_fact_table_rust` splits the enumerator into a shared `<pred>_run(vm, args, cont_pc)` plus a simple public `<pred>_<arity>(vm, a1..aN)` (continuation `pc+1`) for direct callers.

Backtracking is preserved end-to-end: a downstream goal failure backtracks into the fact-table choice point and resumes the scan.

## Tests

`test_wam_rust_fact_table_callsite_exec.pl` (cargo) — `edge/2` is a fact table; three WAM callers reach it via dispatch:
- `qlast(X) :- edge(a, X).` → **tail call** (`execute`) → `[1,2,4]`
- `qmid(X) :- edge(a, X), X > 1.` → **`call`** + downstream filter, backtracking into the fact CP → `[2,4]`
- `qall(K, L) :- findall(X, edge(K, X), L).` → aggregate enumerates via `call` → `L = [1,2,4]`

Existing T9 exec/emit matrices updated for the new `fact_table_attempt` signature; broad `test_wam_rust_target` and the WAM-execution exec suites (repeated-key, embedded, threading, par-aggregate) all green — the Call/Execute change affects every generated project and shows no regression.

Design doc updated: **no remaining T9 follow-ons.**

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_