### PR TITLE
test(wam-rust): T9 fact-table benchmark + throughput capstone

### DIFF
--- a/docs/proposals/wam_rust_t9_fact_table_design.md
+++ b/docs/proposals/wam_rust_t9_fact_table_design.md
@@ -17,6 +17,10 @@ registers and drives the enumerator with the right continuation (`pc+1` for
 `call`, the saved `cp` for a tail-call `execute`). So an ordinary predicate can
 call a fact-table predicate and backtrack through it (incl. backtracking into the
 fact-table choice point from a downstream goal). No remaining T9 follow-ons.
+**Benchmarked:** see `docs/reports/wam_rust_t9_fact_table_benchmark.md` — T9 emits
+0 interpreter instructions (vs ~4/fact for T4), compiles in seconds (T4: ~14 min
+at 500 facts, did not finish at 2000), point-looks-up at ~8 µs/query, and is
+correct at scale where the T4 shared-table first-arg index drops some keys.
 
 Original design / spec / implementation plan below. Survey of the reference
 targets (R / Haskell / Lua) + the Rust target's current fact handling is folded in.

--- a/docs/reports/wam_rust_t9_fact_table_benchmark.md
+++ b/docs/reports/wam_rust_t9_fact_table_benchmark.md
@@ -1,0 +1,96 @@
+# T9 fact-table inline (Rust) — benchmark
+
+Quantifies the T9 fact-table inline path (static row table + first-arg hash
+index + choice-point enumeration) against the default T4 path (the ground facts
+compiled into the shared WAM instruction table and enumerated by the
+interpreter). Parallels `wam_rust_t7_speedup_benchmark.md`.
+
+All measurements on this container; release builds; `edge(Key, Value)` fact sets
+with distinct string keys (`k0..kN-1`). Reproduce: `output/bench_t9` /
+`output/bench_t4` generators in the session, and the committed
+`tests/test_wam_rust_fact_table_throughput.pl` (T9 capstone, cargo-gated).
+
+## Headline
+
+For ground-fact predicates, T9 is the clear win, but **the decisive axes are code
+size, compile time, and correctness — not raw per-lookup latency**:
+
+| Axis | T4 (WAM shared table) | T9 (fact table) |
+|------|----------------------|-----------------|
+| WAM instructions emitted (per fact) | ~4 (one giant `vec!`) | **0** (data table) |
+| Release compile, 500 facts | **≈14 min** (pathological `vec!` opt) | seconds |
+| Release compile, 2000 facts | did **not finish** in 10 min | seconds |
+| Correctness, many keys | **drops some keys** (see below) | all keys correct |
+| Point-lookup latency | n/a (unsound baseline) | **~8 µs/query** |
+
+## Code size (instructions emitted)
+
+T9 emits **zero** interpreter instructions for a pure fact predicate — the rows
+are a `static` data table built once via `OnceLock`. T4 lowers every clause into
+the shared instruction `Vec<Instruction>`:
+
+| facts | T9 `lib.rs` lines | T9 WAM instrs | T4 `lib.rs` lines | T4 WAM instrs |
+|------:|------------------:|--------------:|------------------:|--------------:|
+|    64 |               140 |         **0** |               447 |           257 |
+|   256 |               332 |         **0** |             1 599 |         1 025 |
+|  1024 |             1 100 |         **0** |             6 207 |         4 097 |
+
+T4 grows at ~4 instructions/fact, all inside a single `vec![ ... ]` literal.
+
+## Compile time
+
+The T4 instruction `vec!` is the bottleneck: `rustc` optimises a multi-thousand
+element array literal pathologically slowly in release.
+
+- **500 facts**: the T4 release `cargo test` took **867 s** wall (≈14.5 min,
+  dominated by codegen); the equivalent T9 build+run finished in **~1 s**.
+- **2000 facts**: the T4 release build **did not finish within a 10-minute
+  budget** and was abandoned; T9 built and ran in seconds.
+
+This alone makes T9 the only practical option for large fact sets in release.
+
+## Runtime (T9, correct)
+
+Measured through the generated code, release:
+
+- **Point lookup** (committed throughput test): 200 unique keys, 100 000
+  point lookups via `edge_2` + a `backtrack()` exhaustion check —
+  **8.045 µs/query**, every key returns its single correct row, no dropped keys,
+  no spurious extra solution.
+- **`findall` point lookup** (create vm + clone the tiny shared program +
+  `findall/3` of one row, 1 000 000 queries): **16.3 µs/query** — the extra cost
+  over the direct call is the aggregate frame + per-call program clone.
+- **Bulk `findall`** (50 rows/key, atom keys, correct): **~550 µs/query ≈
+  11 µs/row**.
+
+Note: the per-call program clone in the generated `pub fn` wrappers is paid by
+both paths; T9's is negligible because its shared program is ~0 instructions,
+whereas T4 clones its multi-thousand-instruction program per call — another
+structural T9 advantage that the runtime numbers understate (T4 could not be
+timed as a sound baseline; see below).
+
+## Correctness — why T4 is not a sound baseline
+
+The default T4 shared-table path **silently drops some keys**. With 500 distinct
+keys, `findall(X, edge(k5, X), L)` returned `L = []` while `k0`, `k1`, `k250`,
+`k499` resolved correctly — a pre-existing first-argument `switch_on_constant`
+indexing defect that surfaces at scale (related to, but not fixed by, the
+repeated-key fix in #3188, which addressed multi-clause keys). Because the T4
+baseline returns wrong results for these workloads, a like-for-like speed ratio
+is not meaningful; the comparison is correctness + code size + compile time.
+
+The committed throughput test asserts every one of 200 keys resolves to its
+exact row (and that no extra solution remains), so it also guards against this
+class of regression on the T9 path.
+
+## Conclusion
+
+T9 fact-table inline turns a ground-fact predicate from ~4 interpreter
+instructions/fact (in a release-hostile `vec!`) into a zero-instruction static
+table with an O(1) first-arg index. The win is: **compiles in seconds instead of
+minutes-to-never, emits no interpreter code, and is correct at scale**, at a
+point-lookup latency of ~8 µs/query. Recommended for any sizeable ground-fact
+predicate; gated behind `fact_table_inline(true)` so default output is unchanged.
+
+Follow-on (separate from T9): fix the T4 `switch_on_constant` key-dropping defect
+so the WAM path is also correct for large many-key fact sets.

--- a/tests/test_wam_rust_fact_table_throughput.pl
+++ b/tests/test_wam_rust_fact_table_throughput.pl
@@ -1,0 +1,95 @@
+% test_wam_rust_fact_table_throughput.pl
+%
+% T9 capstone: a large fact predicate compiled with fact_table_inline(true) must
+% enumerate correctly AT SCALE (the kind of many-key workload where the WAM
+% shared-table first-arg index drops keys) and do so with low per-query latency.
+% Generates a 200-unique-key fact project, point-looks-up every key many times
+% through the generated code, asserts each lookup returns exactly its one row
+% (catching any dropped key), and prints the measured per-query latency.
+%
+% Release build so the timing is meaningful. cargo-gated.
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+
+:- dynamic edge/2.
+mk :- forall(between(0, 199, N), ( atom_concat(k, N, Key), assertz(edge(Key, N)) )).
+:- initialization(mk).
+% point lookup: each key has exactly one row
+lookup(K, X) :- edge(K, X).
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- begin_tests(wam_rust_fact_table_throughput).
+
+test(point_lookup_throughput,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_t9_throughput'))]) :-
+    Dir = 'output/test_t9_throughput',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project(
+        [user:lookup/2, user:edge/2],
+        [module_name(ft), fact_table_inline(true), t9_min_rows(10)], Dir)),
+    atom_concat(Dir, '/src/lib.rs', LibRs),
+    read_file_to_string(LibRs, Src, []),
+    assertion(sub_string(Src, _, _, _, "Strategy: fact_table")),
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/tp_test.rs', TestPath),
+    TestSrc = '
+use ft::value::Value;
+use ft::state::WamState;
+use ft::edge_2;
+
+#[test]
+fn point_lookup_throughput() {
+    let iters = 500;
+    let keys: Vec<Value> = (0..200).map(|k| Value::Atom(format!("k{}", k))).collect();
+    // warm
+    { let mut vm = WamState::new(vec![], std::collections::HashMap::new());
+      edge_2(&mut vm, keys[0].clone(), Value::Unbound("X".into())); }
+    let mut rows: usize = 0;
+    let t0 = std::time::Instant::now();
+    for _ in 0..iters {
+        for (i, key) in keys.iter().enumerate() {
+            let mut vm = WamState::new(vec![], std::collections::HashMap::new());
+            if edge_2(&mut vm, key.clone(), Value::Unbound("X".into())) {
+                // exactly one row per key, and it must be the right one
+                if let Some(Value::Integer(n)) = vm.bindings.get("X").cloned() {
+                    assert_eq!(n as usize, i, "key k{} must map to row {}", i, i);
+                    rows += 1;
+                }
+                assert!(!vm.backtrack(), "point lookup must leave no extra solutions");
+            } else {
+                panic!("key k{} not found (dropped)", i);
+            }
+        }
+    }
+    let n = iters * 200;
+    assert_eq!(rows, n, "every point lookup returns its one row");
+    let us = t0.elapsed().as_secs_f64() / (n as f64) * 1e6;
+    println!("T9_THROUGHPUT queries={} per_query_us={:.3}", n, us);
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    format(atom(Cmd),
+        'cd "~w" && cargo test --release --test tp_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( sub_string(OutS, B0, _, _, "T9_THROUGHPUT"),
+      sub_string(OutS, B0, 80, _, Line)
+    ->  format(user_error, "~n[T9 ~w]~n", [Line])
+    ;   true ),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[T9 throughput FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_fact_table_throughput).


### PR DESCRIPTION
## What

Benchmarks T9 fact-table inline against the default T4 path (ground facts compiled into the shared WAM instruction table), parallel to the T7 speedup benchmark. Adds a cargo-gated **throughput capstone test** and a report.

## Headline

For ground-fact predicates T9 is the clear win, but the decisive axes are **code size, compile time, and correctness** — not raw per-lookup latency:

| Axis | T4 (WAM shared table) | T9 (fact table) |
|---|---|---|
| WAM instructions / fact | ~4 (one giant `vec!`) | **0** (static data table) |
| Release compile, 500 facts | **≈14 min** | seconds |
| Release compile, 2000 facts | **did not finish** (10 min budget) | seconds |
| Correctness, many keys | **drops some keys** | all keys correct |
| Point-lookup latency | n/a (unsound baseline) | **~8 µs/query** |

## Findings

- **Code size** — T9 emits **zero** interpreter instructions (rows are a `static` `OnceLock` table); T4 grows ~4 instr/fact in a single `vec!` literal (257 / 1025 / 4097 instrs at 64 / 256 / 1024 facts).
- **Compile time** — `rustc` optimises the multi-thousand-element `vec!` pathologically slowly in release: 500 facts took **867 s** wall for T4 vs ~1 s for T9; 2000 facts didn't finish in 10 min for T4.
- **Runtime (T9, correct)** — point lookup **8.045 µs/query** (100k lookups, every key resolves to its single correct row); `findall` point lookup ~16 µs/query; bulk 50-row `findall` ~11 µs/row.
- **Correctness** — the T4 shared-table path **silently drops some keys** at scale (`edge(k5,X) → []` with 500 distinct keys; `k0/k1/k250/k499` resolve fine) — a pre-existing first-arg `switch_on_constant` defect, distinct from the repeated-key fix in #3188. Because T4 returns wrong results here, a like-for-like speed ratio isn't meaningful.

## Test

`tests/test_wam_rust_fact_table_throughput.pl` (cargo-gated, release): 200 unique keys × 500 iters of point lookups, asserts every key returns its one correct row with no spurious extra solution (guards against the key-dropping class on the T9 path) and prints per-query latency.

## Follow-on (separate from T9)

Fix the T4 `switch_on_constant` key-dropping defect so the WAM path is also correct for large many-key fact sets.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_