### PR TITLE
feat(wam-rust): boundary-distribution optimization wiring — dispatch + gated lowering (P2c)

### DIFF
--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -1,6 +1,6 @@
 # WAM-Rust Boundary Distribution Optimization — Implementation Plan
 
-Status: in progress (P1, P2a, P2c-parity DONE). The implementation-plan member of
+Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch DONE). The implementation-plan member of
 the design trio: **`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md`** (why — a
 disablable complexity-reduction compiler optimization, caching secondary),
 **`WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md`** (precise semantics, the
@@ -214,18 +214,30 @@ Phasing:
     the **production** `collect_native_category_ancestor_hops` aggregate across
     seeds (incl. deep ones through a root-near boundary band) — closing the gap
     that P2a compared only against an in-module oracle.
-  - **P2c-wiring [next].** Make it callable from a query as a gated compiler
-    optimization (`boundary_optimization`, default off): register a
-    `category_ancestor_boundary` native kind + dispatch arm, populate the
-    side-table at setup, and an end-to-end LMDB run. **Result-mode family** (spec
-    §5): the boundary kernel produces the histogram `H`; a *result extractor* emits
-    a single result via the existing `finish_foreign_results` **`deterministic`**
-    mode (`tuple(1)`, no choice point) — either a **scalar** (`f(H)` for a
-    functional, e.g. `weighted_power`/`d_eff`) **or the histogram itself**
-    (`Value::List` of counts) for distribution-output consumers. This must *not*
-    re-expand `H` into a hop stream (that re-introduces the exponential). So the
-    wiring adds extractors over one histogram kernel, not a scalar-only predicate —
-    the histogram-output generalisation keeps it from being built too narrowly.
+  - **P2c-wiring/dispatch [DONE].** The boundary kernel is now reachable as a
+    **foreign kernel** through `execute_foreign_predicate`: a
+    `"category_ancestor_boundary"` dispatch arm in
+    `compile_execute_foreign_predicate_to_rust` reads `A1`/`A2` (cat/root) and the
+    `max_depth`/`edge_pred`/`weight_n`/`result_extractor` foreign config, runs
+    `collect_native_category_ancestor_boundary_hist` over the cached side-table, and
+    emits **one** result via `finish_foreign_results` **`deterministic`** mode
+    (`tuple(1)`, no choice point). **Result-mode family** (spec §5): the kernel
+    produces the histogram `H`; the `result_extractor` selects `scalar`
+    (`f(H)`, e.g. `weighted_power`), `effective_distance` (`d_eff = WeightSum^(-1/N)`),
+    or `distribution` (the histogram itself, `Value::List` of counts). It does *not*
+    re-expand `H` into a hop stream (that re-introduces the exponential) — so the
+    wiring adds extractors over one histogram kernel, not a scalar-only predicate.
+    Exec test `test_wam_rust_boundary_foreign_dispatch.pl`: in a generated crate,
+    registering the kernel as a foreign predicate and driving it through
+    `execute_foreign_predicate` reproduces the **production** kernel's aggregate for
+    both `scalar` and `effective_distance` across seeds.
+  - **P2c-wiring/lowering [next].** Make the compiler *choose* this lowering for a
+    recognized query shape (an aggregate of a path-length functional over
+    root-anchored paths, or a request for the path-length distribution) under the
+    gate `boundary_optimization` (default off): kernel-shape detection in
+    `recursive_kernel_detection.pl` emits the `register_foreign_native_kind(...,
+    category_ancestor_boundary)` + config, and a setup hook populates the side-table
+    via `build_boundary_suffix`. Then an end-to-end LMDB run.
   - The `boundary_basis` LMDB sub-db (persisted precompute) folds in here.
 - **P3 — the measurement in §6** (does it add wall-time *on top of* the edge
   cache, and from what `D_pre`). Gates whether P4 is worth building.

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -1,6 +1,6 @@
 # WAM-Rust Boundary Distribution Optimization — Implementation Plan
 
-Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch DONE). The implementation-plan member of
+Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering DONE). The implementation-plan member of
 the design trio: **`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md`** (why — a
 disablable complexity-reduction compiler optimization, caching secondary),
 **`WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md`** (precise semantics, the
@@ -231,13 +231,30 @@ Phasing:
     registering the kernel as a foreign predicate and driving it through
     `execute_foreign_predicate` reproduces the **production** kernel's aggregate for
     both `scalar` and `effective_distance` across seeds.
-  - **P2c-wiring/lowering [next].** Make the compiler *choose* this lowering for a
-    recognized query shape (an aggregate of a path-length functional over
-    root-anchored paths, or a request for the path-length distribution) under the
-    gate `boundary_optimization` (default off): kernel-shape detection in
-    `recursive_kernel_detection.pl` emits the `register_foreign_native_kind(...,
-    category_ancestor_boundary)` + config, and a setup hook populates the side-table
-    via `build_boundary_suffix`. Then an end-to-end LMDB run.
+  - **P2c-wiring/lowering [DONE].** The compiler now *chooses* this lowering under
+    the gate `boundary_optimization(true)` (default off), mirroring the
+    `kernel_mode(bidirectional)` opt-in upgrade. A detected `category_ancestor`
+    kernel is upgraded to a `category_ancestor_boundary` kernel
+    (`rust_maybe_upgrade_boundary/3`): the registry in
+    `recursive_kernel_detection.pl` gains the boundary metadata (native kind,
+    `tuple(1)` layout, **`deterministic`** result mode, arity 3), the existing
+    `emit_kernel_registration/1` auto-generates the
+    `register_foreign_native_kind(..., category_ancestor_boundary)` + `max_depth` /
+    `edge_pred` / `weight_n` / `result_extractor` config, and a public 3-ary wrapper
+    `Pred(Cat, Root, Result)` (`rust_boundary_wrapper_code/3`) is emitted.
+    Tunables: `boundary_weight_n(N)` (default 2.0), `boundary_result_extractor`
+    (`scalar` | `effective_distance` | `distribution`, default `scalar`). Exec test
+    `test_wam_rust_boundary_lowering.pl`: the default keeps the 4-ary streaming
+    kernel; the option upgrades to the 3-ary deterministic kernel; tunables flow
+    through; and the emitted wrapper reproduces the production aggregate in a built
+    crate. The boundary side-table (`build_boundary_suffix`) remains a separate
+    precompute — with an empty side-table the kernel degrades to full enumeration
+    (still correct), so the lowering is correct by default and the speedup is
+    unlocked once boundary nodes are precomputed.
+  - **P2c-wiring/precompute [next].** Choose *which* boundary nodes to precompute
+    (root-near band per §3) and populate the side-table at setup — the step that
+    turns the correct-but-unaccelerated lowering into the measured speedup — then an
+    end-to-end LMDB run.
   - The `boundary_basis` LMDB sub-db (persisted precompute) folds in here.
 - **P3 — the measurement in §6** (does it add wall-time *on top of* the edge
   cache, and from what `D_pre`). Gates whether P4 is worth building.

--- a/src/unifyweaver/core/recursive_kernel_detection.pl
+++ b/src/unifyweaver/core/recursive_kernel_detection.pl
@@ -92,6 +92,7 @@ kernel_detector(transitive_step_parent_distance5, detect_transitive_step_parent_
 
 kernel_native_kind(category_ancestor, category_ancestor).
 kernel_native_kind(bidirectional_ancestor, bidirectional_ancestor).
+kernel_native_kind(category_ancestor_boundary, category_ancestor_boundary).
 kernel_native_kind(transitive_closure2, transitive_closure2).
 kernel_native_kind(transitive_distance3, transitive_distance3).
 kernel_native_kind(weighted_shortest_path3, weighted_shortest_path3).
@@ -101,6 +102,7 @@ kernel_native_kind(transitive_step_parent_distance5, transitive_step_parent_dist
 
 kernel_result_layout(category_ancestor, tuple(1)).
 kernel_result_layout(bidirectional_ancestor, tuple(3)).  % (totalHops, parentHops, childHops)
+kernel_result_layout(category_ancestor_boundary, tuple(1)).  % one aggregate/distribution result
 kernel_result_layout(transitive_closure2, tuple(1)).
 kernel_result_layout(transitive_distance3, tuple(2)).  % (target, distance)
 kernel_result_layout(weighted_shortest_path3, tuple(2)).  % (target, weight)
@@ -110,6 +112,7 @@ kernel_result_layout(transitive_step_parent_distance5, tuple(4)).  % (target, st
 
 kernel_result_mode(category_ancestor, stream).
 kernel_result_mode(bidirectional_ancestor, stream).
+kernel_result_mode(category_ancestor_boundary, deterministic).  % ONE spliced aggregate, no choice point
 kernel_result_mode(transitive_closure2, stream).
 kernel_result_mode(transitive_distance3, stream).
 kernel_result_mode(weighted_shortest_path3, stream).
@@ -119,6 +122,7 @@ kernel_result_mode(transitive_step_parent_distance5, stream).
 
 kernel_expected_arity(category_ancestor, 4).
 kernel_expected_arity(bidirectional_ancestor, 5).
+kernel_expected_arity(category_ancestor_boundary, 3).
 kernel_expected_arity(transitive_closure2, 2).
 kernel_expected_arity(transitive_distance3, 3).
 kernel_expected_arity(weighted_shortest_path3, 3).
@@ -142,6 +146,12 @@ kernel_register_layout(bidirectional_ancestor, [
     output(3, integer),      % totalHops (result, tuple element 1)
     output(4, integer),      % parentHops (result, tuple element 2)
     output(5, integer)       % childHops (result, tuple element 3)
+]).
+
+kernel_register_layout(category_ancestor_boundary, [
+    input(1, atom),          % cat
+    input(2, atom),          % root
+    output(3, float)         % spliced aggregate (result; or a distribution List)
 ]).
 
 kernel_register_layout(category_ancestor, [

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -5671,12 +5671,54 @@ rust_bidirectional_config_extras(Options, Extras) :-
           option(Term, Options) ),
         Extras).
 
+%% rust_maybe_upgrade_boundary(+Options, +Kernel0, -Kernel)
+%  boundary_optimization(true) upgrades a detected category_ancestor kernel to
+%  the category_ancestor_boundary kernel (the boundary-distribution
+%  optimization). Explicit opt-in, never default — see
+%  WAM_RUST_BOUNDARY_DISTRIBUTION_{PHILOSOPHY,SPECIFICATION,CACHE_PLAN}.md.
+%  The upgraded kernel has a 3-ary interface:
+%      Pred(Cat, Root, Result)
+%  emitting ONE deterministic result (no choice point) read from the
+%  path-length measure of the spliced boundary histogram. The result_extractor
+%  config selects which read: scalar (weighted_power), effective_distance
+%  (d_eff = WeightSum^(-1/N)), or distribution (the raw histogram).
+%
+%  Config extras (project options, with defaults):
+%    boundary_weight_n(N)            — the functional exponent N (default 2.0)
+%    boundary_result_extractor(E)    — scalar | effective_distance | distribution
+%                                      (default scalar)
+%
+%  max_depth and edge_pred carry over from the detected category_ancestor
+%  config. The boundary side-table (build_boundary_suffix) is a separate runtime
+%  precompute; with an empty side-table the kernel degrades to full enumeration
+%  (still correct — the splice is an exact mirror of the production walk), so the
+%  lowering is correct by default and the speedup is unlocked once boundary
+%  nodes are precomputed.
+rust_maybe_upgrade_boundary(Options,
+        recursive_kernel(category_ancestor, Pred/4, Config0),
+        recursive_kernel(category_ancestor_boundary, Pred/3, Config)) :-
+    option(boundary_optimization(true), Options),
+    !,
+    option(boundary_weight_n(N), Options, 2.0),
+    option(boundary_result_extractor(Extractor), Options, scalar),
+    append(Config0, [weight_n(N), result_extractor(Extractor)], Config).
+rust_maybe_upgrade_boundary(_, Kernel, Kernel).
+
+%% rust_maybe_upgrade_kernel(+Options, +Kernel0, -Kernel)
+%  Apply the available opt-in upgrades to a detected category_ancestor kernel.
+%  bidirectional and boundary are mutually exclusive (both rewrite
+%  category_ancestor): if bidirectional fires first, the boundary upgrade no
+%  longer matches; if neither option is set, both are no-ops.
+rust_maybe_upgrade_kernel(Options, Kernel0, Kernel) :-
+    rust_maybe_upgrade_bidirectional(Options, Kernel0, Kernel1),
+    rust_maybe_upgrade_boundary(Options, Kernel1, Kernel).
+
 %% rust_upgrade_kernel_pair(+Options, +Key0-Kernel0, -Key-Kernel)
 %  Apply the bidirectional upgrade to a detected Key-Kernel pair,
 %  rewriting the key to the upgraded predicate indicator (Pred/5) so
 %  registration, dispatch, and the public wrapper stay consistent.
 rust_upgrade_kernel_pair(Options, Key0-Kernel0, Key-Kernel) :-
-    rust_maybe_upgrade_bidirectional(Options, Kernel0, Kernel),
+    rust_maybe_upgrade_kernel(Options, Kernel0, Kernel),
     (   Kernel0 == Kernel
     ->  Key = Key0
     ;   Kernel = recursive_kernel(Kind, Pred/Arity, _),
@@ -5715,6 +5757,38 @@ pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value, a4: Value, a5: Val
     vm.set_reg("A4", a4);
     vm.set_reg("A5", a5);
     vm.execute_foreign_predicate("~w", 5)
+}', [Pred, FuncName, RegLines, Pred]).
+
+%% rust_boundary_wrapper_code(+Pred, +Kernel, -Code)
+%  Public 3-ary wrapper for an upgraded category_ancestor_boundary kernel:
+%  Pred(Cat, Root, Result). Self-registers the kernel metadata + configs (like
+%  the other kernel wrappers) and dispatches through execute_foreign_predicate,
+%  binding A3 to the single deterministic result. Register parent edges on the
+%  VM first (register_ffi_fact_pairs or a lazy lookup source). The boundary
+%  side-table is a separate precompute (vm.build_boundary_suffix); with an empty
+%  side-table the kernel still returns the correct aggregate by full enumeration.
+rust_boundary_wrapper_code(Pred, Kernel, Code) :-
+    Kernel = recursive_kernel(category_ancestor_boundary, Pred/3, _),
+    rust_safe_function_name(Pred, FuncName),
+    format(atom(Key), '~w/3', [Pred]),
+    with_output_to(string(RegLines), emit_kernel_registration(Key-Kernel)),
+    format(string(Code),
+'/// Boundary-distribution ancestor kernel wrapper (3-ary):
+/// ~w(Cat, Root, Result).
+/// Upgraded from a detected category_ancestor kernel by
+/// boundary_optimization(true). Register parent edges on the VM first
+/// (register_ffi_fact_pairs or a lazy lookup source); precompute the
+/// boundary side-table with vm.build_boundary_suffix to unlock the
+/// splice speedup (an empty side-table degrades to full enumeration,
+/// still correct).
+pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool {
+    vm.code = Vec::new();
+    vm.labels = std::collections::HashMap::new();
+    vm.pc = 1;
+~w    vm.set_reg("A1", a1);
+    vm.set_reg("A2", a2);
+    vm.set_reg("A3", a3);
+    vm.execute_foreign_predicate("~w", 3)
 }', [Pred, FuncName, RegLines, Pred]).
 
 %% generate_setup_foreign_predicates_rust(+DetectedKernels, -RustCode)
@@ -5798,6 +5872,13 @@ emit_kernel_config_ops(Key, [Op|Rest]) :-
 %    kernel_mode(bidirectional) — upgrade detected category_ancestor
 %                          kernels to the 5-ary bidirectional_ancestor
 %                          kernel (see rust_maybe_upgrade_bidirectional/3)
+%    boundary_optimization(Bool) — upgrade detected category_ancestor
+%                          kernels to the 3-ary category_ancestor_boundary
+%                          kernel, the boundary-distribution optimization
+%                          (default false; see rust_maybe_upgrade_boundary/3).
+%                          Tunables: boundary_weight_n(N) (default 2.0),
+%                          boundary_result_extractor(scalar | effective_distance
+%                          | distribution; default scalar).
 %    csr_child_index(Bool) — emit src/csr_fact_source.rs, a LookupSource
 %                          over the reverse-CSR artifact for the
 %                          bidirectional kernel child direction
@@ -6187,7 +6268,7 @@ classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
         findall(KHead-KBody, Module:clause(KHead, KBody), KClauses),
         KClauses \= [],
         detect_recursive_kernel(Pred, Arity, KClauses, Kernel0)
-    ->  rust_maybe_upgrade_bidirectional(Options, Kernel0, Kernel),
+    ->  rust_maybe_upgrade_kernel(Options, Kernel0, Kernel),
         format(user_error, '  ~w/~w: ffi kernel (~w)~n', [Pred, Arity, Kernel]),
         % Besides the CallForeign dispatch route, emit a public Rust wrapper
         % function (bare predicate name) so library consumers can call the
@@ -6198,6 +6279,12 @@ classify_predicates([PredIndicator|Rest], Options, [Entry|RestEntries]) :-
             % (Cat, Root, TotalHops, ParentHops, ChildHops), so the
             % legacy 4-ary spec wrapper does not apply.
             rust_bidirectional_wrapper_code(Pred, Kernel, WrapperCode),
+            Entry = classified(Module, Pred, Arity, ffi_kernel,
+                               kernel_with_wrapper(Kernel, WrapperCode))
+        ;   Kernel = recursive_kernel(category_ancestor_boundary, _, _)
+        ->  % Upgraded boundary kernel: the public interface narrows to 3 args
+            % (Cat, Root, Result) — one deterministic aggregate/distribution.
+            rust_boundary_wrapper_code(Pred, Kernel, WrapperCode),
             Entry = classified(Module, Pred, Arity, ffi_kernel,
                                kernel_with_wrapper(Kernel, WrapperCode))
         ;   catch(rust_target:rust_foreign_lowering_spec(Pred, Arity, KClauses,

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -2360,6 +2360,63 @@ compile_execute_foreign_predicate_to_rust(Code) :-
                 }
                 self.finish_foreign_results(&pred_key, vec![value_reg], results)
             }
+            "category_ancestor_boundary" => {
+                // P2c: the boundary-distribution optimization as a foreign kernel.
+                // Runs the boundary-spliced ancestor walk (collect_native_category_
+                // ancestor_boundary_hist) over the cached boundary side-table, then
+                // reads the path-length measure into ONE result (deterministic mode)
+                // per the configured extractor. With an empty side-table it degrades
+                // to full enumeration (still correct). See
+                // WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md §5/§6.
+                let cat = match self.get_reg_raw("A1").map(|v| self.deref_var(&v)) {
+                    Some(Value::Atom(c)) => c,
+                    _ => return false,
+                };
+                let root = match self.get_reg_raw("A2").map(|v| self.deref_var(&v)) {
+                    Some(Value::Atom(r)) => r,
+                    _ => return false,
+                };
+                let out_reg = match self.get_reg_raw("A3") {
+                    Some(val) => val,
+                    None => return false,
+                };
+                let max_depth = match self.foreign_usize_config(&pred_key, "max_depth") {
+                    Some(limit) => limit,
+                    None => return false,
+                };
+                let edge_pred = match self.foreign_string_config(&pred_key, "edge_pred") {
+                    Some(p) => p.to_string(),
+                    None => return false,
+                };
+                let n = self.foreign_f64_config(&pred_key, "weight_n").unwrap_or(2.0);
+                let extractor = self.foreign_string_config(&pred_key, "result_extractor")
+                    .map(|s| s.to_string()).unwrap_or_else(|| "scalar".to_string());
+                let cat_id = self.intern_atom(&cat);
+                let root_id = self.intern_atom(&root);
+                let mut hist: Vec<u64> = Vec::new();
+                let mut visited: Vec<u32> = vec![cat_id];
+                let acc = self.resolve_edge_accessor(&edge_pred);
+                self.collect_native_category_ancestor_boundary_hist(
+                    cat_id, root_id, &mut visited, max_depth, &acc, 0, &mut hist);
+                // weighted_power read: WeightSum = sum_{L>0} H[L] * L^-n
+                let weight_sum = || -> f64 {
+                    hist.iter().enumerate().filter(|(l, _)| *l > 0)
+                        .map(|(l, &c)| c as f64 * (l as f64).powf(-n)).sum()
+                };
+                let result: Value = match extractor.as_str() {
+                    "distribution" => Value::List(
+                        hist.iter().map(|&c| Value::Integer(c as i64)).collect()),
+                    "effective_distance" => {
+                        let ws = weight_sum();
+                        if ws > 0.0 { Value::Float(ws.powf(-1.0 / n)) } else { return false; }
+                    }
+                    // default: scalar(weighted_power)
+                    _ => Value::Float(weight_sum()),
+                };
+                self.finish_foreign_results(
+                    &pred_key, vec![out_reg],
+                    vec![Value::Str("__tuple__".to_string(), vec![result])])
+            }
             _ => false,
         }
     }'.

--- a/tests/test_wam_rust_boundary_foreign_dispatch.pl
+++ b/tests/test_wam_rust_boundary_foreign_dispatch.pl
@@ -1,0 +1,153 @@
+% test_wam_rust_boundary_foreign_dispatch.pl
+%
+% P2c WIRING: the boundary-distribution optimization is reachable as a FOREIGN
+% KERNEL through execute_foreign_predicate. Where test_wam_rust_boundary_kernel_
+% exec.pl validates the kernel METHOD directly, this validates the full dispatch
+% path a compiled query takes:
+%
+%   register category_ancestor_boundary/3 as a foreign predicate
+%     -> native_kind "category_ancestor_boundary"
+%     -> result_mode "deterministic", layout "tuple:1"
+%     -> config: max_depth / edge_pred / weight_n / result_extractor
+%   set A1/A2/A3, call execute_foreign_predicate("category_ancestor_boundary", 3)
+%   read the ONE deterministic result back from A3
+%
+% and asserts the spliced scalar equals the PRODUCTION kernel's weighted-power
+% aggregate, for both the "scalar" and "effective_distance" extractors. This is
+% the wiring that lets the compiler substitute the boundary kernel for the
+% enumerating kernel. See WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md §5/§6.
+%
+% cargo-gated.
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+
+:- dynamic bd_fact/2.
+bd_fact(a, b).   % keeps the project non-trivial; the graph for the kernels is
+bd_fact(b, c).   % registered inside the cargo test via register_ffi_fact_pairs.
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- begin_tests(wam_rust_boundary_foreign_dispatch).
+
+test(boundary_kernel_reachable_via_foreign_dispatch,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_bd_dispatch'))]) :-
+    Dir = 'output/test_bd_dispatch',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project([user:bd_fact/2], [module_name(bd)], Dir)),
+    % the runtime must carry both the foreign dispatch arm and the kernel.
+    atom_concat(Dir, '/src/state.rs', LibRs),
+    read_file_to_string(LibRs, Src, []),
+    sub_string(Src, _, _, _, "\"category_ancestor_boundary\" =>"),
+    sub_string(Src, _, _, _, "collect_native_category_ancestor_boundary_hist"),
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/bd_test.rs', TestPath),
+    TestSrc = '
+use bd::state::WamState;
+use bd::value::Value;
+use std::collections::HashMap;
+
+// weighted_power(N=2) aggregate from the PRODUCTION kernel (hop stream).
+fn ws_production(vm: &WamState, seed: u32, root: u32, budget: usize, n: f64) -> f64 {
+    let acc = vm.resolve_edge_accessor("category_parent");
+    let mut hops: Vec<i64> = Vec::new();
+    let mut vis = vec![seed];
+    vm.collect_native_category_ancestor_hops(seed, root, &mut vis, budget, &acc, 0, &mut hops);
+    hops.iter().map(|&h| (h as f64).powf(-n)).sum()
+}
+
+// Drive the boundary kernel THROUGH the foreign-dispatch path and read the
+// single deterministic result back out of A3. A fresh output-variable name per
+// call mirrors the WAM allocating a new var per goal (a reused name would stay
+// bound from the previous call and the deterministic unify would then reject a
+// different result).
+fn dispatch_scalar(vm: &mut WamState, seed_name: &str, root_name: &str, tag: usize) -> Option<Value> {
+    vm.set_reg("A1", Value::Atom(seed_name.to_string()));
+    vm.set_reg("A2", Value::Atom(root_name.to_string()));
+    vm.set_reg("A3", Value::Unbound(format!("BdOut{}", tag)));
+    let ok = vm.execute_foreign_predicate("category_ancestor_boundary", 3);
+    if !ok { return None; }
+    Some(vm.deref_var(&vm.get_reg_raw("A3").unwrap()))
+}
+
+fn setup(extractor: &str) -> WamState {
+    let mut vm = WamState::new(vec![], HashMap::new());
+    vm.register_ffi_fact_pairs("category_parent", &[
+        ("5","4"),("5","2"),("4","3"),("4","1"),("3","1"),("3","2"),
+        ("1","0"),("2","0"),("6","5"),("7","4"),("8","6"),("8","7"),
+    ]);
+    let root = vm.intern_atom("0");
+    let budget = 10usize;
+    // boundary band near the root
+    let bnodes: Vec<u32> = ["1","2"].iter().map(|s| vm.intern_atom(s)).collect();
+    vm.build_boundary_suffix(&bnodes, root, budget, "category_parent");
+    // register the foreign kernel exactly as the compiler would lower it.
+    let key = "category_ancestor_boundary/3";
+    vm.register_foreign_predicate(key);
+    vm.register_foreign_native_kind(key, "category_ancestor_boundary");
+    vm.register_foreign_result_mode(key, "deterministic");
+    vm.register_foreign_result_layout(key, "tuple:1");
+    vm.register_foreign_usize_config(key, "max_depth", budget);
+    vm.register_foreign_string_config(key, "edge_pred", "category_parent");
+    vm.register_foreign_f64_config(key, "weight_n", 2.0);
+    vm.register_foreign_string_config(key, "result_extractor", extractor);
+    vm
+}
+
+#[test]
+fn scalar_extractor_matches_production() {
+    let mut vm = setup("scalar");
+    let root = vm.intern_atom("0");
+    let budget = 10usize;
+    let n = 2.0f64;
+    let mut checked = 0;
+    for sname in ["3","4","5","6","7","8"] {
+        let seed = vm.intern_atom(sname);
+        let wp = ws_production(&vm, seed, root, budget, n);
+        let got = dispatch_scalar(&mut vm, sname, "0", checked).expect("dispatch should bind A3");
+        let wb = match got { Value::Float(f) => f, other => panic!("expected Float, got {:?}", other) };
+        assert!((wp - wb).abs() < 1e-12, "seed {}: production {} != dispatch {}", sname, wp, wb);
+        assert!(wp > 0.0, "seed {} should reach root", sname);
+        checked += 1;
+    }
+    assert_eq!(checked, 6);
+}
+
+#[test]
+fn effective_distance_extractor_matches_closed_form() {
+    let mut vm = setup("effective_distance");
+    let root = vm.intern_atom("0");
+    let budget = 10usize;
+    let n = 2.0f64;
+    let mut checked = 0;
+    for sname in ["3","4","5","6","7","8"] {
+        let seed = vm.intern_atom(sname);
+        let ws = ws_production(&vm, seed, root, budget, n);
+        let expect = ws.powf(-1.0 / n);   // d_eff = WeightSum^(-1/N)
+        let got = dispatch_scalar(&mut vm, sname, "0", checked).expect("dispatch should bind A3");
+        let deff = match got { Value::Float(f) => f, other => panic!("expected Float, got {:?}", other) };
+        assert!((expect - deff).abs() < 1e-12, "seed {}: d_eff {} != {}", sname, deff, expect);
+        checked += 1;
+    }
+    assert_eq!(checked, 6);
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    format(atom(Cmd), 'cd "~w" && cargo test --test bd_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[boundary foreign dispatch FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_boundary_foreign_dispatch).

--- a/tests/test_wam_rust_boundary_lowering.pl
+++ b/tests/test_wam_rust_boundary_lowering.pl
@@ -1,0 +1,161 @@
+% test_wam_rust_boundary_lowering.pl
+%
+% P2c WIRING / lowering: the COMPILER chooses the boundary-distribution
+% optimization for a detected category_ancestor kernel, gated by the project
+% option boundary_optimization(true) (default off).
+%
+% Where test_wam_rust_boundary_foreign_dispatch.pl validates the runtime
+% dispatch path, this validates the *codegen* decision:
+%   - default (no option): the kernel lowers to the 4-ary streaming
+%     category_ancestor native kind (unchanged behaviour).
+%   - boundary_optimization(true): the kernel is UPGRADED to the 3-ary
+%     category_ancestor_boundary native kind — deterministic result mode,
+%     tuple(1) layout, with weight_n / result_extractor config — and a public
+%     3-ary wrapper Pred(Cat, Root, Result) is emitted.
+%
+% The cargo-gated case builds the upgraded crate and calls the emitted wrapper,
+% asserting it reproduces the production hop-stream aggregate.
+%
+% See WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md §5 (P2c-wiring/lowering).
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+:- use_module(library(lists)).
+
+:- dynamic bcat_ancestor/4.
+:- dynamic bcat_parent/2.
+:- dynamic max_depth/1.
+
+max_depth(10).
+
+bcat_ancestor(Cat, Parent, 1, Visited) :-
+    bcat_parent(Cat, Parent),
+    \+ member(Parent, Visited).
+bcat_ancestor(Cat, Ancestor, Hops, Visited) :-
+    max_depth(MaxD), length(Visited, D), D < MaxD, !,
+    bcat_parent(Cat, Mid),
+    \+ member(Mid, Visited),
+    bcat_ancestor(Mid, Ancestor, H1, [Mid|Visited]),
+    Hops is H1 + 1.
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+gen(Options, Dir) :-
+    safe_rmdir(Dir),
+    once(write_wam_rust_project([user:bcat_ancestor/4], [module_name(bl)|Options], Dir)).
+
+read_src(Dir, File, Src) :-
+    atom_concat(Dir, File, Path),
+    read_file_to_string(Path, Src, []).
+
+:- begin_tests(wam_rust_boundary_lowering).
+
+% Default: no boundary_optimization -> stays the 4-ary streaming kernel.
+test(default_keeps_streaming_category_ancestor,
+     [cleanup(safe_rmdir('output/test_bl_default'))]) :-
+    Dir = 'output/test_bl_default',
+    gen([], Dir),
+    read_src(Dir, '/src/lib.rs', Lib),
+    sub_string(Lib, _, _, _, "register_foreign_native_kind(\"bcat_ancestor/4\", \"category_ancestor\")"),
+    sub_string(Lib, _, _, _, "register_foreign_result_mode(\"bcat_ancestor/4\", \"stream\")"),
+    % the boundary kind must NOT appear in the registration
+    \+ sub_string(Lib, _, _, _, "\"category_ancestor_boundary\"").
+
+% boundary_optimization(true) -> upgraded to the 3-ary deterministic kernel.
+test(option_upgrades_to_boundary_kernel,
+     [cleanup(safe_rmdir('output/test_bl_boundary'))]) :-
+    Dir = 'output/test_bl_boundary',
+    gen([boundary_optimization(true)], Dir),
+    read_src(Dir, '/src/lib.rs', Lib),
+    % registration: 3-ary key, boundary native kind, deterministic, tuple(1)
+    sub_string(Lib, _, _, _, "register_foreign_native_kind(\"bcat_ancestor/3\", \"category_ancestor_boundary\")"),
+    sub_string(Lib, _, _, _, "register_foreign_result_mode(\"bcat_ancestor/3\", \"deterministic\")"),
+    sub_string(Lib, _, _, _, "register_foreign_result_layout(\"bcat_ancestor/3\", \"tuple(1)\")"),
+    % config carried over + defaults injected
+    sub_string(Lib, _, _, _, "register_foreign_usize_config(\"bcat_ancestor/3\", \"max_depth\", 10)"),
+    sub_string(Lib, _, _, _, "register_foreign_string_config(\"bcat_ancestor/3\", \"edge_pred\", \"bcat_parent\")"),
+    sub_string(Lib, _, _, _, "register_foreign_f64_config(\"bcat_ancestor/3\", \"weight_n\", 2.0)"),
+    sub_string(Lib, _, _, _, "register_foreign_string_config(\"bcat_ancestor/3\", \"result_extractor\", \"scalar\")"),
+    % the public 3-ary wrapper is emitted
+    sub_string(Lib, _, _, _, "pub fn bcat_ancestor(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool").
+
+% result-extractor / weight_n tunables flow into the registration.
+test(option_tunables_flow_through,
+     [cleanup(safe_rmdir('output/test_bl_tunables'))]) :-
+    Dir = 'output/test_bl_tunables',
+    gen([boundary_optimization(true),
+         boundary_weight_n(3.0),
+         boundary_result_extractor(effective_distance)], Dir),
+    read_src(Dir, '/src/lib.rs', Lib),
+    sub_string(Lib, _, _, _, "register_foreign_f64_config(\"bcat_ancestor/3\", \"weight_n\", 3.0)"),
+    sub_string(Lib, _, _, _, "register_foreign_string_config(\"bcat_ancestor/3\", \"result_extractor\", \"effective_distance\")").
+
+% cargo-gated: the upgraded crate builds and the emitted wrapper reproduces the
+% production hop-stream aggregate.
+test(boundary_wrapper_matches_production,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_bl_exec'))]) :-
+    Dir = 'output/test_bl_exec',
+    gen([boundary_optimization(true)], Dir),
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/bl_test.rs', TestPath),
+    TestSrc = '
+use bl::state::WamState;
+use bl::value::Value;
+use std::collections::HashMap;
+
+fn ws_production(vm: &WamState, seed: u32, root: u32, budget: usize, n: f64) -> f64 {
+    let acc = vm.resolve_edge_accessor("bcat_parent");
+    let mut hops: Vec<i64> = Vec::new();
+    let mut vis = vec![seed];
+    vm.collect_native_category_ancestor_hops(seed, root, &mut vis, budget, &acc, 0, &mut hops);
+    hops.iter().map(|&h| (h as f64).powf(-n)).sum()
+}
+
+#[test]
+fn wrapper_matches_production() {
+    let mut vm = WamState::new(vec![], HashMap::new());
+    vm.register_ffi_fact_pairs("bcat_parent", &[
+        ("5","4"),("5","2"),("4","3"),("4","1"),("3","1"),("3","2"),
+        ("1","0"),("2","0"),("6","5"),("7","4"),("8","6"),("8","7"),
+    ]);
+    let root = vm.intern_atom("0");
+    let budget = 10usize;
+    let n = 2.0f64;
+    let bnodes: Vec<u32> = ["1","2"].iter().map(|s| vm.intern_atom(s)).collect();
+    vm.build_boundary_suffix(&bnodes, root, budget, "bcat_parent");
+    let mut checked = 0;
+    for sname in ["3","4","5","6","7","8"] {
+        let seed = vm.intern_atom(sname);
+        let wp = ws_production(&vm, seed, root, budget, n);
+        // call the emitted 3-ary wrapper (self-registers the kernel).
+        let out = Value::Unbound(format!("Out{}", checked));
+        let ok = bl::bcat_ancestor(&mut vm, Value::Atom(sname.to_string()),
+                                   Value::Atom("0".to_string()), out);
+        assert!(ok, "wrapper should succeed for seed {}", sname);
+        let got = match vm.deref_var(&vm.get_reg_raw("A3").unwrap()) {
+            Value::Float(f) => f, other => panic!("expected Float, got {:?}", other) };
+        assert!((wp - got).abs() < 1e-12, "seed {}: production {} != wrapper {}", sname, wp, got);
+        checked += 1;
+    }
+    assert_eq!(checked, 6);
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    format(atom(Cmd), 'cd "~w" && cargo test --test bl_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[boundary lowering exec FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_boundary_lowering).


### PR DESCRIPTION
Two increments of the boundary-distribution plan's **P2c-wiring** milestone (`docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md` §5), on the same branch.

The boundary kernel (`collect_native_category_ancestor_boundary_hist`, landed in P2a) turns exponential per-seed path enumeration into a polynomial precompute + O(budget) splice (measured 300–700× on the dense-core bench). This PR makes it (1) reachable through the foreign-dispatch path, and (2) chosen by the compiler under a gate.

## Commit 1 — dispatch (`ec5f9b31`)

Make the kernel reachable from a query through `execute_foreign_predicate`.

- **`compile_execute_foreign_predicate_to_rust`**: add a `"category_ancestor_boundary"` arm. Reads `A1`/`A2` (cat/root) + `max_depth` / `edge_pred` / `weight_n` / `result_extractor` config, runs the spliced walk over the cached side-table, and emits **one** result via `finish_foreign_results` **`deterministic`** mode (`tuple(1)`, no choice point) — so the complexity win is *not* undone by re-expanding the histogram into a hop stream.
- **Result-mode family** (spec §5): `result_extractor` ∈ `scalar` (`Σ_{L>0} H[L]·L^(-N)`) / `effective_distance` (`d_eff = WeightSum^(-1/N)`) / `distribution` (raw histogram `Value::List`).
- **`tests/test_wam_rust_boundary_foreign_dispatch.pl`**: drives the kernel through `execute_foreign_predicate` in a generated crate; `scalar` and `effective_distance` both reproduce the production `collect_native_category_ancestor_hops` aggregate.

## Commit 2 — gated lowering (`1ee9ec25`)

Make the compiler *choose* the boundary lowering, gated by `boundary_optimization(true)` (default off) — mirroring the `kernel_mode(bidirectional)` opt-in upgrade.

- **`recursive_kernel_detection.pl`**: register `category_ancestor_boundary` kernel metadata (native kind, `tuple(1)`, `deterministic`, arity 3, register layout). An upgrade target, not a detected shape (like `bidirectional_ancestor`).
- **`wam_rust_target.pl`**: `rust_maybe_upgrade_boundary/3` upgrades `category_ancestor/4` → `category_ancestor_boundary/3`, appending `weight_n` / `result_extractor` config (tunables `boundary_weight_n` default 2.0, `boundary_result_extractor` default `scalar`); `rust_maybe_upgrade_kernel/3` chains the bidirectional + boundary upgrades (mutually exclusive), wired into both upgrade sites; `rust_boundary_wrapper_code/3` emits a public 3-ary wrapper `Pred(Cat, Root, Result)`. Registration is auto-generated by the existing `emit_kernel_registration/1`.
- **`tests/test_wam_rust_boundary_lowering.pl`**: default keeps the 4-ary streaming kernel; the option upgrades to the 3-ary deterministic kernel; tunables flow through; and (cargo-gated) the emitted wrapper reproduces the production aggregate in a built crate.

The boundary side-table (`build_boundary_suffix`) is a separate precompute — with an empty side-table the kernel degrades to full enumeration (still correct), so the lowering is correct by default and the speedup is unlocked once boundary nodes are chosen (**P2c-wiring/precompute**, next).

## Validation

- `test_wam_rust_boundary_foreign_dispatch.pl`, `test_wam_rust_boundary_lowering.pl` — pass (both incl. cargo-gated wrapper-vs-production checks).
- `test_wam_rust_boundary_kernel_exec.pl` — still passes.
- Full `test_wam_rust_target.pl` suite — all pass (bidirectional + default category_ancestor paths intact).

## Next

**P2c-wiring/precompute**: choose which boundary nodes to precompute (root-near band, §3) and populate the side-table at setup — the step that turns the correct-but-unaccelerated lowering into the measured speedup — then an end-to-end LMDB run.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua