### PR TITLE
design(wam-rust): boundary precompute liveness & eviction rule (spec §8a)

### DIFF
--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -255,11 +255,13 @@ Phasing:
     (root-near band per §3) and populate the side-table at setup — the step that
     turns the correct-but-unaccelerated lowering into the measured speedup — then an
     end-to-end LMDB run. Run the precompute as a root-down topological sweep with the
-    **liveness/eviction rule** (spec §8a): a parent distribution `H_p` is live only
-    until its last child consumes it, so interior (non-`Bset`) scratch distributions
-    can be evicted from the side-table / `boundary_basis` LMDB sub-db once their
-    consumer count hits zero — bounding the working set to the cone's frontier width
-    and giving a correctness-preserving cache/storage eviction signal.
+    **liveness-prioritised eviction** of spec §8a: eviction from the side-table /
+    `boundary_basis` LMDB sub-db is triggered by a **memory/storage budget**, and the
+    consumer-count liveness signal supplies the *priority order* — dead interior
+    nodes (`refs = 0 ∧ p ∉ Bset`) first (zero-regret), live interior scratch next,
+    the retained boundary band last (spilled to LMDB, not dropped). This bounds the
+    resident working set under pressure toward the cone's frontier width plus the
+    band, and is correctness-preserving (evicted entries are dead or recomputable).
   - The `boundary_basis` LMDB sub-db (persisted precompute) folds in here.
 - **P3 — the measurement in §6** (does it add wall-time *on top of* the edge
   cache, and from what `D_pre`). Gates whether P4 is worth building.

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -258,10 +258,13 @@ Phasing:
     **liveness-prioritised eviction** of spec §8a: eviction from the side-table /
     `boundary_basis` LMDB sub-db is triggered by a **memory/storage budget**, and the
     consumer-count liveness signal supplies the *priority order* — dead interior
-    nodes (`refs = 0 ∧ p ∉ Bset`) first (zero-regret), live interior scratch next,
-    the retained boundary band last (spilled to LMDB, not dropped). This bounds the
-    resident working set under pressure toward the cone's frontier width plus the
-    band, and is correctness-preserving (evicted entries are dead or recomputable).
+    nodes (`refs = 0 ∧ p ∉ Bset`) first and **deepest-first within that class** (root-
+    near distributions are the most-reused hubs, most likely to be hit by a second
+    query, so keep them longer), live interior scratch next, the retained boundary
+    band last (spilled to LMDB, not dropped). This bounds the resident working set
+    under pressure toward the cone's frontier width plus the band, biased to retain
+    the root-near end, and is correctness-preserving (evicted entries are dead or
+    recomputable).
   - The `boundary_basis` LMDB sub-db (persisted precompute) folds in here.
 - **P3 — the measurement in §6** (does it add wall-time *on top of* the edge
   cache, and from what `D_pre`). Gates whether P4 is worth building.

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -254,7 +254,12 @@ Phasing:
   - **P2c-wiring/precompute [next].** Choose *which* boundary nodes to precompute
     (root-near band per §3) and populate the side-table at setup — the step that
     turns the correct-but-unaccelerated lowering into the measured speedup — then an
-    end-to-end LMDB run.
+    end-to-end LMDB run. Run the precompute as a root-down topological sweep with the
+    **liveness/eviction rule** (spec §8a): a parent distribution `H_p` is live only
+    until its last child consumes it, so interior (non-`Bset`) scratch distributions
+    can be evicted from the side-table / `boundary_basis` LMDB sub-db once their
+    consumer count hits zero — bounding the working set to the cone's frontier width
+    and giving a correctness-preserving cache/storage eviction signal.
   - The `boundary_basis` LMDB sub-db (persisted precompute) folds in here.
 - **P3 — the measurement in §6** (does it add wall-time *on top of* the edge
   cache, and from what `D_pre`). Gates whether P4 is worth building.

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
@@ -254,11 +254,17 @@ in-memory side-table and for the `boundary_basis` LMDB sub-db): entries are evic
 only when the budget is under pressure, *not* eagerly at `refs = 0`. When pressure
 hits, the liveness signal supplies the **priority order**:
 
-1. **Dead interior nodes first** (`refs = 0 ∧ p ∉ Bset`) — these are the nodes
-   identified above; they will never be read again in this sweep, so they are the
-   highest-priority, zero-regret eviction class.
+1. **Dead interior nodes first** (`refs = 0 ∧ p ∉ Bset`) — never read again in *this*
+   sweep, so the highest-priority class. **Within this class, evict deepest-first**
+   (largest depth-from-root): root-near distributions cover the largest cones and are
+   the most-reused hubs (philosophy §3), so they are the most likely to be hit again
+   by a *second query* — keep them resident longer; the deep, narrow-cone nodes have
+   little cross-query reuse value and go first. (So "zero-regret" holds within a
+   single sweep; across queries the regret rises toward the root, which is exactly
+   what depth-first eviction minimises.)
 2. then **still-live interior** scratch (by a secondary metric — e.g. furthest next
-   use / lowest remaining `refs`), accepting a possible recompute;
+   use / lowest remaining `refs`, again breaking ties deepest-first), accepting a
+   possible recompute;
 3. **retained boundary band** (`p ∈ Bset`) last, and even then it spills to the
    `boundary_basis` LMDB sub-db rather than being dropped, since queries still need
    it.
@@ -268,7 +274,8 @@ Consequences:
 - **Bounded working set.** Holding dead interiors until pressure (rather than freeing
   at `refs = 0`) keeps the resident scratch within the budget while preferring to
   keep what might still be reused; under steady pressure the resident set tends
-  toward the cone's *frontier antichain width* plus the retained band.
+  toward the cone's *frontier antichain width* plus the retained band — biased to
+  retain the **root-near** end of that scratch, the part with cross-query reuse.
 - **Exactness preserved.** Eviction only ever removes an entry that is either dead
   (no future read) or recomputable; a spilled/recomputed `H_p` yields the identical
   histogram. So the policy changes resource use, never any spliced result — it is a

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
@@ -237,29 +237,42 @@ H_v[L] = Σ_{p ∈ parents(v)} H_p[L−1]            (boundary_cache.rs:suffix_h
 ```
 
 So `H_p` is a *consumed input* to every child `v` with `p ∈ parents(v)`, and nothing
-else. This gives an exact **liveness rule** for the precompute sweep:
+else. This gives an exact **liveness signal** over the precompute sweep:
 
 > **`H_p` is live only from when it is first computed until its last child consumes
 > it.** Once the distributions of *all* descendants that name `p` as a parent have
-> been computed, `H_p` can be **evicted** — unless `p` is itself a retained boundary
-> node (`p ∈ Bset`), whose distribution is kept for query-time splicing.
+> been computed, `H_p` is **dead** — fully consumed — unless `p` is itself a retained
+> boundary node (`p ∈ Bset`), whose distribution is kept for query-time splicing.
 
-Equivalently, run the precompute as a root-down topological sweep with a per-node
-consumer count `refs(p) = #{v : p ∈ parents(v)} within the precomputed cone`;
-decrement on each child completion and free at zero. Consequences:
+Track it with a per-node consumer count `refs(p) = #{v : p ∈ parents(v)} within the
+precomputed cone`, decremented on each child completion; `refs(p) = 0 ∧ p ∉ Bset`
+marks `p` **dead**.
 
-- **Bounded working set.** The simultaneously-resident scratch distributions are
-  bounded by the cone's *frontier antichain width*, not by the number of nodes
-  swept — the precompute streams instead of holding every node at once.
-- **Storage/cache eviction hint.** The same count is an eviction signal for the
-  backing store: an interior (non-`Bset`) node's entry in the in-memory side-table
-  *or* in the `boundary_basis` LMDB sub-db is safe to drop once its consumer count
-  reaches zero. Only the retained boundary band must persist; the intermediates
-  above the band (between `Bset` and the root) are pure scratch.
-- **Exactness preserved.** Eviction frees an entry *after* its last read, so it
-  changes only resource use, never any spliced result. (Re-deriving an evicted `p`
-  later — e.g. a new `Bset` member appears below it — simply recomputes it; the
-  rule is a cache policy, not a one-shot deletion.)
+**The trigger is pressure, the liveness is the priority — they are separate.**
+Eviction is driven by a **memory / storage budget** (the reserved capacity for the
+in-memory side-table and for the `boundary_basis` LMDB sub-db): entries are evicted
+only when the budget is under pressure, *not* eagerly at `refs = 0`. When pressure
+hits, the liveness signal supplies the **priority order**:
+
+1. **Dead interior nodes first** (`refs = 0 ∧ p ∉ Bset`) — these are the nodes
+   identified above; they will never be read again in this sweep, so they are the
+   highest-priority, zero-regret eviction class.
+2. then **still-live interior** scratch (by a secondary metric — e.g. furthest next
+   use / lowest remaining `refs`), accepting a possible recompute;
+3. **retained boundary band** (`p ∈ Bset`) last, and even then it spills to the
+   `boundary_basis` LMDB sub-db rather than being dropped, since queries still need
+   it.
+
+Consequences:
+
+- **Bounded working set.** Holding dead interiors until pressure (rather than freeing
+  at `refs = 0`) keeps the resident scratch within the budget while preferring to
+  keep what might still be reused; under steady pressure the resident set tends
+  toward the cone's *frontier antichain width* plus the retained band.
+- **Exactness preserved.** Eviction only ever removes an entry that is either dead
+  (no future read) or recomputable; a spilled/recomputed `H_p` yields the identical
+  histogram. So the policy changes resource use, never any spliced result — it is a
+  cache policy (recompute / reload on demand), not a one-shot deletion.
 
 ## 9. Storage / approximation
 

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
@@ -226,6 +226,41 @@ kernel is used and output is identical — the basis for the disablability guara
 - Persistence (later): a `boundary_basis` LMDB sub-db (node → packed histogram),
   loaded at setup like `s2i`/`min_dist`, so the precompute is not repeated per run.
 
+### 8a. Precompute liveness & eviction
+
+The suffix recurrence builds a node's distribution **from its parents'** (the nodes
+one step *closer to the root*):
+
+```
+H_root = δ_0            (the empty path: atom of mass 1 at length 0)
+H_v[L] = Σ_{p ∈ parents(v)} H_p[L−1]            (boundary_cache.rs:suffix_histogram)
+```
+
+So `H_p` is a *consumed input* to every child `v` with `p ∈ parents(v)`, and nothing
+else. This gives an exact **liveness rule** for the precompute sweep:
+
+> **`H_p` is live only from when it is first computed until its last child consumes
+> it.** Once the distributions of *all* descendants that name `p` as a parent have
+> been computed, `H_p` can be **evicted** — unless `p` is itself a retained boundary
+> node (`p ∈ Bset`), whose distribution is kept for query-time splicing.
+
+Equivalently, run the precompute as a root-down topological sweep with a per-node
+consumer count `refs(p) = #{v : p ∈ parents(v)} within the precomputed cone`;
+decrement on each child completion and free at zero. Consequences:
+
+- **Bounded working set.** The simultaneously-resident scratch distributions are
+  bounded by the cone's *frontier antichain width*, not by the number of nodes
+  swept — the precompute streams instead of holding every node at once.
+- **Storage/cache eviction hint.** The same count is an eviction signal for the
+  backing store: an interior (non-`Bset`) node's entry in the in-memory side-table
+  *or* in the `boundary_basis` LMDB sub-db is safe to drop once its consumer count
+  reaches zero. Only the retained boundary band must persist; the intermediates
+  above the band (between `Bset` and the root) are pure scratch.
+- **Exactness preserved.** Eviction frees an entry *after* its last read, so it
+  changes only resource use, never any spliced result. (Re-deriving an evicted `p`
+  later — e.g. a new `Bset` member appears below it — simply recomputes it; the
+  rule is a cache policy, not a one-shot deletion.)
+
 ## 9. Storage / approximation
 
 Exact discrete histograms by default. The §1a backings are the storage/scale


### PR DESCRIPTION
## What

Capture a design insight (from @s243a) about the boundary-distribution precompute. The suffix recurrence

```
H_v[L] = Σ_{p ∈ parents(v)} H_p[L−1]
```

makes a parent distribution `H_p` a *consumed input* to exactly its children. So once the distributions of all descendants that name `p` as a parent are computed, `H_p` is **dead** (fully consumed) — unless `p` is a retained boundary node kept for query-time splicing.

## The policy: pressure triggers, liveness prioritises

These are **separate** (per follow-up review):

- **Trigger = memory/storage budget.** Eviction from the in-memory side-table and the `boundary_basis` LMDB sub-db fires only under reserved-capacity pressure — *not* eagerly at `refs = 0`. Holding dead interiors until pressure keeps what might still be reused.
- **Priority = the liveness signal.** When pressure hits, the consumer count `refs(p) = #{v : p ∈ parents(v)}` orders eviction:
  1. **dead interior nodes** (`refs = 0 ∧ p ∉ Bset`) first — zero-regret, never read again;
  2. **live interior** scratch next (accepting a possible recompute);
  3. **retained band** (`p ∈ Bset`) last, and even then *spilled to LMDB*, not dropped.

Consequences: the resident working set under steady pressure tends toward the cone's *frontier antichain width* plus the retained band; and the policy is **exactness-preserving** — every evicted entry is either dead (no future read) or recomputable, so a spilled/recomputed `H_p` is identical. It's a cache policy (recompute/reload on demand), not a one-shot deletion.

## Changes (docs only)

- **SPECIFICATION §8a** — the liveness signal, the `refs`/dead formulation, the pressure-vs-priority separation, and the priority ladder.
- **CACHE_PLAN** — P2c-wiring/precompute now runs the precompute as a root-down topological sweep applying §8a's liveness-prioritised, budget-triggered eviction.

No code changes; records the design ahead of the precompute implementation.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua