### PR TITLE
feat(wam-rust): automatic root-near boundary-band selection + precompute (P2c)

### DIFF
--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -1,6 +1,6 @@
 # WAM-Rust Boundary Distribution Optimization — Implementation Plan
 
-Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering DONE). The implementation-plan member of
+Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection DONE). The implementation-plan member of
 the design trio: **`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md`** (why — a
 disablable complexity-reduction compiler optimization, caching secondary),
 **`WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md`** (precise semantics, the
@@ -251,20 +251,32 @@ Phasing:
     precompute — with an empty side-table the kernel degrades to full enumeration
     (still correct), so the lowering is correct by default and the speedup is
     unlocked once boundary nodes are precomputed.
-  - **P2c-wiring/precompute [next].** Choose *which* boundary nodes to precompute
-    (root-near band per §3) and populate the side-table at setup — the step that
-    turns the correct-but-unaccelerated lowering into the measured speedup — then an
-    end-to-end LMDB run. Run the precompute as a root-down topological sweep with the
-    **liveness-prioritised eviction** of spec §8a: eviction from the side-table /
-    `boundary_basis` LMDB sub-db is triggered by a **memory/storage budget**, and the
-    consumer-count liveness signal supplies the *priority order* — dead interior
-    nodes (`refs = 0 ∧ p ∉ Bset`) first and **deepest-first within that class** (root-
-    near distributions are the most-reused hubs, most likely to be hit by a second
-    query, so keep them longer), live interior scratch next, the retained boundary
-    band last (spilled to LMDB, not dropped). This bounds the resident working set
-    under pressure toward the cone's frontier width plus the band, biased to retain
-    the root-near end, and is correctness-preserving (evicted entries are dead or
-    recomputable).
+  - **P2c-wiring/precompute/selection [DONE].** Band *selection* is now automatic:
+    `WamState::boundary_band_root_near(d_pre)` reads the distance-to-root table
+    (`min_dist`, loaded at setup like `s2i`) and returns the root-near band
+    `{ n : 1 <= min_dist(n) <= d_pre }` (§3); `build_boundary_suffix_root_near(root,
+    d_pre, max_depth, edge_pred)` selects that band and precomputes + installs its
+    suffix histograms in one call — the setup hook a harness calls after edges +
+    `min_dist` are loaded. An empty `min_dist` yields an empty band → full
+    enumeration (still correct). Unit tests (`boundary_kernel_tests`): the selection
+    matches the expected band, the precompute populates the side-table, and the
+    splice matches full enumeration; the lowering exec test
+    (`test_wam_rust_boundary_lowering.pl`) drives the emitted 3-ary wrapper through
+    the root-near selection path end-to-end. Any band is exact for the splice
+    (kernel splices at the first band node and stops), so root-near is a
+    coverage/performance choice, not a correctness one.
+  - **P2c-wiring/precompute/eviction [next].** Run the precompute as a root-down
+    topological sweep with the **liveness-prioritised eviction** of spec §8a:
+    eviction from the side-table / `boundary_basis` LMDB sub-db is triggered by a
+    **memory/storage budget**, and the consumer-count liveness signal supplies the
+    *priority order* — dead interior nodes (`refs = 0 ∧ p ∉ Bset`) first and
+    **deepest-first within that class** (root-near distributions are the most-reused
+    hubs, most likely to be hit by a second query, so keep them longer), live
+    interior scratch next, the retained boundary band last (spilled to LMDB, not
+    dropped). This bounds the resident working set under pressure toward the cone's
+    frontier width plus the band, biased to retain the root-near end, and is
+    correctness-preserving (evicted entries are dead or recomputable). Then an
+    end-to-end LMDB run.
   - The `boundary_basis` LMDB sub-db (persisted precompute) folds in here.
 - **P3 — the measurement in §6** (does it add wall-time *on top of* the edge
   cache, and from what `D_pre`). Gates whether P4 is worth building.

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -5778,9 +5778,11 @@ rust_boundary_wrapper_code(Pred, Kernel, Code) :-
 /// Upgraded from a detected category_ancestor kernel by
 /// boundary_optimization(true). Register parent edges on the VM first
 /// (register_ffi_fact_pairs or a lazy lookup source); precompute the
-/// boundary side-table with vm.build_boundary_suffix to unlock the
-/// splice speedup (an empty side-table degrades to full enumeration,
-/// still correct).
+/// boundary side-table to unlock the splice speedup — call
+/// vm.build_boundary_suffix_root_near(root, d_pre, max_depth, edge_pred)
+/// after loading min_dist to pick + precompute the root-near band, or
+/// vm.build_boundary_suffix(band, ..) for an explicit band. An empty
+/// side-table degrades to full enumeration (still correct).
 pub fn ~w(vm: &mut WamState, a1: Value, a2: Value, a3: Value) -> bool {
     vm.code = Vec::new();
     vm.labels = std::collections::HashMap::new();

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -925,6 +925,40 @@ impl WamState {
         self.boundary_suffix = table.into_iter().collect();
     }
 
+    /// Select the root-near boundary band from the distance-to-root table
+    /// (`min_dist`): every node `n` with `1 <= min_dist(n) <= d_pre`. This is the
+    /// band the boundary-distribution optimization wants (philosophy/spec §3):
+    /// value concentrates near the root, where the cone is largest and reuse
+    /// highest. Requires `min_dist` to be populated (loaded at setup like `s2i`);
+    /// returns an empty band otherwise, which makes the kernel degrade to full
+    /// enumeration (still correct). Excludes the root itself (`min_dist == 0`).
+    ///
+    /// Correctness note: any band is exact for the splice (each node's cached
+    /// suffix is its true node->root histogram and the kernel splices at the FIRST
+    /// band node it reaches, then stops), so the root-near choice is a
+    /// coverage/performance decision, not a correctness one. See
+    /// WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md §8.
+    pub fn boundary_band_root_near(&self, d_pre: usize) -> Vec<u32> {
+        let cap = d_pre as i32;
+        self.min_dist.iter()
+            .filter(|(_, &d)| d >= 1 && d <= cap)
+            .map(|(&n, _)| n as u32)
+            .collect()
+    }
+
+    /// Convenience: select the root-near band (`<= d_pre` hops from root, via
+    /// `min_dist`) and precompute + install its suffix histograms. A harness calls
+    /// this once at setup, after the graph (edges) and `min_dist` are loaded and
+    /// before queries, to populate the boundary cache the lowered
+    /// category_ancestor_boundary kernel splices against. With an empty `min_dist`
+    /// (no band) it is a no-op and the kernel runs by full enumeration.
+    pub fn build_boundary_suffix_root_near(
+        &mut self, root_id: u32, d_pre: usize, max_depth: usize, edge_pred: &str,
+    ) {
+        let band = self.boundary_band_root_near(d_pre);
+        self.build_boundary_suffix(&band, root_id, max_depth, edge_pred);
+    }
+
     /// Enable int-native edge mode: the lazy edge path treats the kernel's
     /// node id as the raw LMDB key directly, bypassing the wam<->lmdb maps.
     /// For int-native fixtures (raw page-id seeds/root/graph, no s2i).
@@ -2016,5 +2050,54 @@ mod boundary_kernel_tests {
             let spl = norm(boundary_hist(&vm, seed, root, budget));
             assert_eq!(full, spl, "budget {}", budget);
         }
+    }
+
+    // P2c-wiring/precompute: the root-near band is *selected* from the
+    // distance-to-root table (min_dist), and precomputing over that band yields a
+    // populated side-table whose splice matches full enumeration.
+    #[test]
+    fn root_near_band_selection_and_precompute() {
+        let mut vm = dag();
+        let root = vm.intern_atom("0");
+        let seed = vm.intern_atom("5");
+        let budget = 8usize;
+        // distance-to-root for the DAG (5->2->0 makes min_dist(5)=2):
+        let mut md: HashMap<i32, i32> = HashMap::new();
+        for (name, d) in [("0", 0), ("1", 1), ("2", 1), ("3", 2), ("4", 2), ("5", 2)] {
+            md.insert(vm.intern_atom(name) as i32, d);
+        }
+        vm.set_min_dist(&md);
+        // d_pre = 1 selects exactly the root-near band {1, 2}.
+        let n1 = vm.intern_atom("1");
+        let n2 = vm.intern_atom("2");
+        let mut band = vm.boundary_band_root_near(1);
+        band.sort();
+        let mut expect = vec![n1, n2];
+        expect.sort();
+        assert_eq!(band, expect, "root-near band (d_pre=1) should be {{1,2}}");
+        // d_pre = 2 widens to the whole upper cone {1,2,3,4,5}.
+        assert_eq!(vm.boundary_band_root_near(2).len(), 5, "d_pre=2 selects 5 nodes");
+        // precompute over the selected band; the splice must match full enumeration.
+        let full = norm(full_hist(&vm, seed, root, budget));
+        vm.build_boundary_suffix_root_near(root, 1, budget, "category_parent");
+        assert!(!vm.boundary_suffix.is_empty(), "side-table should be populated");
+        let spl = norm(boundary_hist(&vm, seed, root, budget));
+        assert_eq!(full, spl, "root-near splice must match full enumeration");
+    }
+
+    // Empty min_dist -> empty band -> no-op precompute -> kernel degrades to full
+    // enumeration (still correct).
+    #[test]
+    fn empty_min_dist_band_is_noop() {
+        let mut vm = dag();
+        let root = vm.intern_atom("0");
+        let seed = vm.intern_atom("5");
+        let budget = 8usize;
+        assert!(vm.boundary_band_root_near(3).is_empty(), "no min_dist -> empty band");
+        let full = norm(full_hist(&vm, seed, root, budget));
+        vm.build_boundary_suffix_root_near(root, 3, budget, "category_parent");
+        assert!(vm.boundary_suffix.is_empty(), "empty band -> empty side-table");
+        let spl = norm(boundary_hist(&vm, seed, root, budget));
+        assert_eq!(full, spl, "no-op precompute still correct (full enumeration)");
     }
 }

--- a/tests/test_wam_rust_boundary_lowering.pl
+++ b/tests/test_wam_rust_boundary_lowering.pl
@@ -143,6 +143,43 @@ fn wrapper_matches_production() {
         checked += 1;
     }
     assert_eq!(checked, 6);
+}
+
+// Same wrapper, but the side-table is populated via the root-near SELECTION path
+// (set_min_dist + build_boundary_suffix_root_near) rather than an explicit band.
+#[test]
+fn wrapper_with_root_near_precompute() {
+    let mut vm = WamState::new(vec![], HashMap::new());
+    vm.register_ffi_fact_pairs("bcat_parent", &[
+        ("5","4"),("5","2"),("4","3"),("4","1"),("3","1"),("3","2"),
+        ("1","0"),("2","0"),("6","5"),("7","4"),("8","6"),("8","7"),
+    ]);
+    let root = vm.intern_atom("0");
+    let budget = 10usize;
+    let n = 2.0f64;
+    // distance-to-root for the graph.
+    let mut md: HashMap<i32, i32> = HashMap::new();
+    for (name, d) in [("0",0),("1",1),("2",1),("3",2),("4",2),("5",2),("6",3),("7",3),("8",4)] {
+        md.insert(vm.intern_atom(name) as i32, d);
+    }
+    vm.set_min_dist(&md);
+    // pick + precompute the root-near band (<= 2 hops): {1,2,3,4,5}.
+    vm.build_boundary_suffix_root_near(root, 2, budget, "bcat_parent");
+    assert!(!vm.boundary_suffix.is_empty(), "root-near precompute should populate the side-table");
+    let mut checked = 0;
+    for sname in ["3","4","5","6","7","8"] {
+        let seed = vm.intern_atom(sname);
+        let wp = ws_production(&vm, seed, root, budget, n);
+        let out = Value::Unbound(format!("RnOut{}", checked));
+        let ok = bl::bcat_ancestor(&mut vm, Value::Atom(sname.to_string()),
+                                   Value::Atom("0".to_string()), out);
+        assert!(ok, "wrapper should succeed for seed {}", sname);
+        let got = match vm.deref_var(&vm.get_reg_raw("A3").unwrap()) {
+            Value::Float(f) => f, other => panic!("expected Float, got {:?}", other) };
+        assert!((wp - got).abs() < 1e-12, "seed {}: production {} != root-near {}", sname, wp, got);
+        checked += 1;
+    }
+    assert_eq!(checked, 6);
 }',
     setup_call_cleanup(open(TestPath, write, S),
                        format(S, "~w", [TestSrc]), close(S)),


### PR DESCRIPTION
## What

The **band-selection** step of P2c-wiring/precompute: choosing *which* nodes form the root-near boundary band, so a harness can populate the boundary cache the lowered `category_ancestor_boundary` kernel splices against. This is what turns the correct-but-unaccelerated lowering (already in main) into the actual splice speedup.

## Changes

`templates/targets/rust_wam/state.rs.mustache`:
- **`boundary_band_root_near(d_pre)`** — reads the distance-to-root table (`min_dist`, loaded at setup like `s2i`) and returns the root-near band `{ n : 1 ≤ min_dist(n) ≤ d_pre }` (philosophy/spec §3 — value concentrates near the root). Empty `min_dist` → empty band.
- **`build_boundary_suffix_root_near(root, d_pre, max_depth, edge_pred)`** — selects that band and precomputes + installs its suffix histograms in one call: the setup hook a harness invokes after edges + `min_dist` are loaded. Empty band → no-op → kernel degrades to full enumeration (still correct).
- **`boundary_kernel_tests`** — `root_near_band_selection_and_precompute` (selection matches `{1,2}` at `d_pre=1` / 5 nodes at `d_pre=2`; precompute populates the side-table; splice == full enumeration) and `empty_min_dist_band_is_noop`.

`src/unifyweaver/targets/wam_rust_target.pl`:
- The emitted 3-ary boundary wrapper's doc now points at `build_boundary_suffix_root_near` as the convenient root-near setup call.

`tests/test_wam_rust_boundary_lowering.pl`:
- `wrapper_with_root_near_precompute` drives the emitted wrapper through the root-near **selection** path (`set_min_dist` + `build_boundary_suffix_root_near`) end-to-end and matches the production aggregate.

## Correctness

Any band is exact for the splice — the kernel splices at the *first* band node it reaches and stops, and each node's cached suffix is its true node→root histogram — so root-near is a coverage/performance choice, not a correctness one (spec §8).

## Validation

- New `boundary_kernel_tests` (4/4) and the lowering exec tests pass.
- `test_wam_rust_boundary_foreign_dispatch.pl`, `test_wam_rust_boundary_kernel_exec.pl` still pass.

## Next

**P2c-wiring/precompute/eviction**: run the precompute as a root-down topological sweep with the budget-triggered, deepest-first liveness eviction (spec §8a), then an end-to-end LMDB run.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_