### PR TITLE
feat(wam-rust): shared-memo polynomial boundary precompute + two-budget eviction design

### DIFF
--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
@@ -281,6 +281,48 @@ Consequences:
   histogram. So the policy changes resource use, never any spliced result — it is a
   cache policy (recompute / reload on demand), not a one-shot deletion.
 
+### 8b. Two budgets: evictable vs live, and the stop-at-depth recourse
+
+The §8a budget governs entries we *can* drop (dead, or live-but-recomputable). But a
+top-down sweep also holds a **live, not-yet-discardable** set — the current frontier
+of nodes with `refs > 0`, whose parents are done but whose children are not. You
+cannot evict your way out of pressure on *that* set: those distributions are still
+required inputs to children not yet computed. So the precompute carries **two
+limits**:
+
+1. **Evictable budget** (§8a) — the cap on resident *droppable* entries (dead
+   interiors + spillable/recomputable scratch + the retained band). Exceeding it
+   triggers the priority-ordered eviction above.
+2. **Live budget** — a separate cap on the **non-discardable frontier** (`refs > 0`,
+   not yet spillable). This bounds the sweep's irreducible working set ≈ the cone's
+   *frontier antichain width* at the current depth.
+
+When the **live budget** is hit there is nothing to evict — the recourse is to **stop
+deepening**: freeze the precompute frontier at the current depth, treat everything
+below it as un-cached (those seeds fall back to enumeration, still correct), and
+retain what was computed. This makes the effective `D_pre` **dynamically bounded by
+memory**, not a fixed a-priori choice (philosophy §5 / plan §3): deepen the band only
+while the live frontier fits, then stop. (If the frontier may instead be *spilled* to
+the `boundary_basis` LMDB sub-db, the live budget is the in-memory portion and the
+sweep can continue against storage; stop-at-depth is the recourse when neither memory
+nor storage can hold a wider frontier.)
+
+### 8c. Why exact (vs path sampling)
+
+The one alternative that could rival the splice on *speed* is **Monte-Carlo path
+sampling**: estimate `WeightSum = Σ_L H[L]·L^(-N)` from a small random sample of
+seed→root paths instead of the full histogram. It is rejected here on **variance**,
+not speed: a sample estimator carries estimation error that (a) shrinks only as
+`1/√(samples)`, (b) is worst exactly where the functional is most sensitive — the
+short paths that dominate `L^(-N)` for `N>0` are rare in a uniform path sample of a
+diamond-dense cone — and (c) gives a *different* answer per run, breaking
+reproducibility and the linear-functional exactness the whole design rests on. The
+boundary splice computes the **exact** functional at ~ns from the cached histogram,
+so there is no accuracy/speed tradeoff to make: exact is also fast. Sampling would
+only be considered if even the polynomial precompute became infeasible — at which
+point the §9 storage ladder (continuous/parametric measure) is the principled
+exact-in-the-limit fallback, again before sampling.
+
 ## 9. Storage / approximation
 
 Exact discrete histograms by default. The §1a backings are the storage/scale

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -956,7 +956,49 @@ impl WamState {
         &mut self, root_id: u32, d_pre: usize, max_depth: usize, edge_pred: &str,
     ) {
         let band = self.boundary_band_root_near(d_pre);
-        self.build_boundary_suffix(&band, root_id, max_depth, edge_pred);
+        // Prefer the polynomial shared-memo precompute (eager edges); fall back to
+        // per-node enumeration for the lazy/LMDB path.
+        if !self.build_boundary_suffix_shared(&band, root_id, max_depth, edge_pred) {
+            self.build_boundary_suffix(&band, root_id, max_depth, edge_pred);
+        }
+    }
+
+    /// Polynomial precompute: compute each band node's `node->root` suffix histogram
+    /// via the SHARED memoised recurrence `H_v[L] = sum_{p in parents(v)} H_p[L-1]`
+    /// (the proven `boundary_cache::suffix_histogram`), reusing ONE memo across all
+    /// band nodes instead of re-enumerating the upper cone per node. This is the
+    /// "polynomial precompute plus O(budget) splice" the optimization promises
+    /// (philosophy §3): independent `enum_ancestor_hist` per band node recomputes
+    /// the shared upper cone once per node; the shared memo computes each node's `H`
+    /// exactly once. Produces the identical histograms — the min_dist prune in the
+    /// enumeration path only drops paths that cannot reach the root within budget,
+    /// which contribute nothing — so it is interchangeable with `build_boundary_
+    /// suffix` (validated in tests). The shared memo is the substrate the liveness
+    /// eviction of spec §8a/§8b operates on.
+    ///
+    /// Eager-edge only: needs the in-memory parents table (`ffi_facts[edge_pred]`).
+    /// Returns `false` (a no-op) when only a lazy/LMDB source is registered, so the
+    /// caller can fall back to the enumeration precompute.
+    pub fn build_boundary_suffix_shared(
+        &mut self, boundary: &[u32], root_id: u32, max_depth: usize, edge_pred: &str,
+    ) -> bool {
+        let table: HashMap<u32, Vec<u64>> = {
+            let parents = match self.ffi_facts.get(edge_pred) {
+                Some(p) => p,
+                None => return false,
+            };
+            let mut memo: HashMap<u32, crate::boundary_cache::Hist> = HashMap::new();
+            let mut on_stack: Vec<u32> = Vec::new();
+            let mut t: HashMap<u32, Vec<u64>> = HashMap::new();
+            for &b in boundary {
+                let h = crate::boundary_cache::suffix_histogram(
+                    b, root_id, parents, max_depth, &mut memo, &mut on_stack);
+                t.insert(b, h);
+            }
+            t
+        };
+        self.boundary_suffix = table.into_iter().collect();
+        true
     }
 
     /// Enable int-native edge mode: the lazy edge path treats the kernel's
@@ -2083,6 +2125,46 @@ mod boundary_kernel_tests {
         assert!(!vm.boundary_suffix.is_empty(), "side-table should be populated");
         let spl = norm(boundary_hist(&vm, seed, root, budget));
         assert_eq!(full, spl, "root-near splice must match full enumeration");
+    }
+
+    // The shared-memo polynomial precompute produces the IDENTICAL boundary-suffix
+    // table as per-node enumeration, and the spliced histogram still matches full
+    // enumeration.
+    #[test]
+    fn shared_memo_precompute_equals_enumeration() {
+        let mut vm = dag();
+        let root = vm.intern_atom("0");
+        let seed = vm.intern_atom("5");
+        let budget = 8usize;
+        let full = norm(full_hist(&vm, seed, root, budget));
+        for bnames in &[vec!["1", "2"], vec!["3", "1", "2"], vec!["4"], vec!["3", "4", "1", "2"]] {
+            let bnodes: Vec<u32> = bnames.iter().map(|s| vm.intern_atom(s)).collect();
+            // enumeration precompute -> snapshot table
+            vm.build_boundary_suffix(&bnodes, root, budget, "category_parent");
+            let mut enum_tbl: Vec<(u32, Vec<u64>)> =
+                vm.boundary_suffix.iter().map(|(&k, v)| (k, norm(v.clone()))).collect();
+            enum_tbl.sort_by_key(|(k, _)| *k);
+            // shared-memo precompute -> snapshot table
+            assert!(vm.build_boundary_suffix_shared(&bnodes, root, budget, "category_parent"),
+                    "shared precompute should run for eager edges");
+            let mut shared_tbl: Vec<(u32, Vec<u64>)> =
+                vm.boundary_suffix.iter().map(|(&k, v)| (k, norm(v.clone()))).collect();
+            shared_tbl.sort_by_key(|(k, _)| *k);
+            assert_eq!(enum_tbl, shared_tbl, "shared != enumeration table for {:?}", bnames);
+            // and the spliced result still matches full enumeration
+            let spl = norm(boundary_hist(&vm, seed, root, budget));
+            assert_eq!(full, spl, "shared splice != full enumeration for {:?}", bnames);
+        }
+    }
+
+    // Shared precompute is eager-only: with no eager table it is a no-op (false).
+    #[test]
+    fn shared_memo_precompute_eager_only() {
+        let mut vm = WamState::new(vec![], HashMap::new());
+        let root = vm.intern_atom("0");
+        let b = vm.intern_atom("1");
+        assert!(!vm.build_boundary_suffix_shared(&[b], root, 8, "no_such_pred"),
+                "no eager table -> shared precompute is a no-op");
     }
 
     // Empty min_dist -> empty band -> no-op precompute -> kernel degrades to full


### PR DESCRIPTION
Progress on **(a)**, the boundary-cache eviction: this lands the *substrate* eviction operates on (a shared-memo, polynomial precompute) and captures two design refinements from your last message.

## Implementation — the polynomial precompute

Today's `build_boundary_suffix` enumerates each band node's `node→root` paths **independently**, re-walking the shared upper cone once per band node. This replaces that with a **shared memo**:

- **`build_boundary_suffix_shared(band, root, max_depth, edge_pred)`** computes each band node's suffix histogram via the proven recurrence `H_v[L] = Σ_{p ∈ parents(v)} H_p[L−1]` (`boundary_cache::suffix_histogram`), reusing **one** memo across all band nodes — so each node's `H` is computed exactly once. This is the "polynomial precompute + O(budget) splice" the philosophy promises (§3), and the shared memo is exactly what the liveness eviction prunes.
- It's eager-edge only (needs the in-memory parents table); returns `false` for the lazy/LMDB path so the caller falls back to enumeration. `build_boundary_suffix_root_near` now prefers it.
- **Identical output:** the min_dist prune in the enumeration path only drops paths that can't reach the root within budget (zero contribution), so shared == enumeration — validated by `shared_memo_precompute_equals_enumeration` (same boundary-suffix table *and* same splice vs full enumeration, across several bands).

## Design — two refinements you raised

- **SPEC §8b "Two budgets."** Besides the §8a evictable budget, a separate **live budget** caps the non-discardable frontier (`refs > 0`). When the live budget is hit there's nothing to evict — the recourse is to **stop deepening**, freezing the precompute frontier. So the effective `D_pre` becomes **dynamically memory-bounded** rather than a fixed a-priori choice. (This is your "stop computing at that level of depth.")
- **SPEC §8c "Why exact (vs path sampling)."** Monte-Carlo path sampling is the only speed-competitive alternative but is rejected on **variance** — `1/√(samples)`, worst exactly on the short paths that dominate `L^(-N)`, and non-reproducible. The splice gives the *exact* functional at ~ns, so there's no accuracy/speed tradeoff to make. (Your point about sampling having "much higher estimation variance.")

## Validation

- Generated-crate suite: 11 lib tests + 6 boundary-kernel tests pass (incl. the two new ones).
- Lowering exec suite (`test_wam_rust_boundary_lowering.pl`) still passes — `build_boundary_suffix_root_near` now drives the shared-memo path end-to-end through the emitted wrapper.

## Next

**P2c-wiring/precompute/eviction:** the actual top-down sweep with the two-budget, deepest-first liveness eviction + stop-at-depth (§8a/§8b) on top of this shared memo. Then the §6 measurement.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_