### PR TITLE
Support PLAWK i64 subtraction expressions

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -263,8 +263,9 @@ the allocation-free `@wam_atom_field_subslice_value` helper, and native
 `index($N, "literal")` through the shared `@wam_atom_field_index_value` helper.
 Explicit print-side numeric coercions such as `int($N)` lower through the shared
 `@wam_atom_field_i64_value` parse helper and print zero when the field is
-missing or not a strict signed decimal. The first composed arithmetic form,
-`int($N) + K`, lowers as the same native parse followed by an `add i64`.
+missing or not a strict signed decimal. The first composed arithmetic forms,
+`int($N) + K` and `int($N) - K`, lower as the same native parse followed by a
+shared binary `i64` operation.
 Print-only `tolower($N)` and `toupper($N)` lower through shared
 `@wam_print_ascii_lower_slice` and `@wam_print_ascii_upper_slice` helpers, so
 case mapping streams bytes without allocating a transformed atom.
@@ -304,7 +305,7 @@ branch-local prints; the context supplies prefixed names while `$N`, `NF`,
 lowering clauses. Numeric expression lowering is also factored through a shared
 `plawk_i64_expr_ir` layer, so scalar updates and print expressions both consume
 the same native `i64` emitters for constants, `NR`, `NF`, `length($N)`, numeric
-field coercion, `int($N) + K`, and `index($N, "...")` where those forms apply.
+field coercion, `int($N) +/- K`, and `index($N, "...")` where those forms apply.
 Terminal
 branch-local `next` branches directly to the stream-loop continuation and adds
 the selected branch's scalar values to the loop phi inputs. Terminal

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -85,7 +85,7 @@ as `$1 == "ERROR" { print substr($2, 1, 3) }`, and native byte searches such as
 case-mapped field slices such as `$1 == "ERROR" { print tolower($2), toupper($0) }`.
 Explicit numeric field coercion is available as `int($N)`, e.g.
 `$1 == "ERROR" { print $3, int($3) }`; failed numeric parses print `0`.
-The first arithmetic composition form is `int($N) + K`, e.g.
+The first arithmetic composition forms are `int($N) + K` and `int($N) - K`, e.g.
 `$1 == "ERROR" { print int($3) + 1 }`.
 Numeric field guards use the shared WAM/LLVM `i64` comparison helper, so forms
 such as `$3 > 100 { print $1, $3 }` and `$2 <= -5 { cold++ }` stay in the native
@@ -102,7 +102,7 @@ Plain scalar assignment uses the same native slot path and preserves source
 order with later updates, e.g. `$1 == "ERROR" { last_len = length($0); hits++ }
 END { print hits, last_len }`. The current assignment expression subset is
 integer literals, `length($N)`, numeric `$N`, explicit `int($N)`, and
-`int($N) + K`.
+`int($N) +/- K`.
 Scalar slot updates can also sit behind native `if/else` guards, e.g.
 `{ if ($1 == "ERROR") { errors++; last_len = length($0) } else { non_errors++ } }
 END { print errors, non_errors, last_len }`. The first branch slice supports

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -124,8 +124,9 @@ The native Phase 2 surface can compile rule prints with `NR`, `NF`, selected
 fields, native field lengths such as `length($2)`, native byte substrings such as
 `substr($2, 1, 3)`, and `OFS`, matching the first awk-style example above. It can
 also print explicit numeric field coercions with `int($N)`, where missing or
-non-numeric fields become `0`, and the first arithmetic composition form
-`int($N) + K`. It can also compile a scalar counter and an `END` action:
+non-numeric fields become `0`, and the first arithmetic composition forms
+`int($N) + K` and `int($N) - K`. It can also compile a scalar counter and an
+`END` action:
 
 ```awk
 $1 == "ERROR" { count++ } END { print count }
@@ -380,11 +381,12 @@ missing and non-numeric fields:
 $1 == "ERROR" { print $3, int($3) }
 ```
 
-The current arithmetic print subset can add a non-negative integer constant to
-that coerced value:
+The current arithmetic print subset can add or subtract a non-negative integer
+constant from that coerced value:
 
 ```awk
 $1 == "ERROR" { print int($3) + 1 }
+$1 == "ERROR" { print int($3) - 1 }
 ```
 
 `tolower` and `toupper` can print ASCII case-mapped field bytes without

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -1303,12 +1303,25 @@ plawk_rule_body_print_field(string(_)).
 plawk_rule_body_print_field(special('NR')).
 plawk_rule_body_print_field(special('NF')).
 plawk_rule_body_print_field(int(field(_))).
-plawk_rule_body_print_field(add_i64(int(field(_)), int(_))).
+plawk_rule_body_print_field(Expr) :-
+    plawk_i64_field_const_binary_expr(Expr).
 plawk_rule_body_print_field(length(field(_))).
 plawk_rule_body_print_field(substr(field(_), _Start, _Len)).
 plawk_rule_body_print_field(index(field(_), string(_))).
 plawk_rule_body_print_field(tolower(field(_))).
 plawk_rule_body_print_field(toupper(field(_))).
+
+plawk_i64_field_const_binary_expr(Expr) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, int(field(FieldIndex)), int(Value)),
+    FieldIndex >= 0,
+    integer(Value),
+    Value >= 0.
+
+plawk_i64_binary_expr(add_i64(Left, Right), add, add, Left, Right).
+plawk_i64_binary_expr(sub_i64(Left, Right), sub, sub, Left, Right).
+
+plawk_i64_binary_print_kind(add, int_add).
+plawk_i64_binary_print_kind(sub, int_sub).
 
 plawk_scalar_update_action_name(Action, Name) :-
     plawk_scalar_action_update(Action, Name, _Operation).
@@ -1328,11 +1341,8 @@ plawk_scalar_action_update(add(var(Name), field(FieldIndex)), Name, add(field_i6
     FieldIndex >= 0.
 plawk_scalar_action_update(add(var(Name), int(field(FieldIndex))), Name, add(field_i64(FieldIndex))) :-
     FieldIndex >= 0.
-plawk_scalar_action_update(add(var(Name), add_i64(int(field(FieldIndex)), int(Value))),
-        Name, add(add_i64(int(field(FieldIndex)), int(Value)))) :-
-    FieldIndex >= 0,
-    integer(Value),
-    Value >= 0.
+plawk_scalar_action_update(add(var(Name), Expr), Name, add(Expr)) :-
+    plawk_i64_field_const_binary_expr(Expr).
 plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) :-
     integer(Value),
     Value >= 0.
@@ -1342,11 +1352,8 @@ plawk_scalar_action_update(set(var(Name), field(FieldIndex)), Name, set(field_i6
     FieldIndex >= 0.
 plawk_scalar_action_update(set(var(Name), int(field(FieldIndex))), Name, set(field_i64(FieldIndex))) :-
     FieldIndex >= 0.
-plawk_scalar_action_update(set(var(Name), add_i64(int(field(FieldIndex)), int(Value))),
-        Name, set(add_i64(int(field(FieldIndex)), int(Value)))) :-
-    FieldIndex >= 0,
-    integer(Value),
-    Value >= 0.
+plawk_scalar_action_update(set(var(Name), Expr), Name, set(Expr)) :-
+    plawk_i64_field_const_binary_expr(Expr).
 
 plawk_scalar_action_sequence_pairs([], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
         OpIndex, Values, Values, OpIndex, CurrentLabel, []) -->
@@ -1474,12 +1481,13 @@ plawk_scalar_numeric_expr_ir(field_i64(FieldIndex), FieldSeparator, Prefix, Slot
         [Prefix, SlotIndex, OpIndex]),
     plawk_i64_expr_ir_parts(field_i64(FieldIndex), FieldSeparator, ParseBase, ParseBase,
         ValueIR, IR).
-plawk_scalar_numeric_expr_ir(add_i64(Left, int(Value)), FieldSeparator, Prefix, SlotIndex,
+plawk_scalar_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
         OpIndex, ValueIR, IR) :-
-    format(atom(AddBase), '~w_slot_~w_op_~w_i64_add',
-        [Prefix, SlotIndex, OpIndex]),
-    plawk_i64_expr_ir_parts(add_i64(Left, int(Value)), FieldSeparator, AddBase,
-        AddBase, ValueIR, IR).
+    plawk_i64_binary_expr(Expr, _LLVMOp, NamePart, _Left, _Right),
+    format(atom(BinaryBase), '~w_slot_~w_op_~w_i64_~w',
+        [Prefix, SlotIndex, OpIndex, NamePart]),
+    plawk_i64_expr_ir_parts(Expr, FieldSeparator, BinaryBase,
+        BinaryBase, ValueIR, IR).
 
 plawk_i64_expr_ir_parts(Expr, FieldSeparator, Base, GlobalBase, ValueIR, IR) :-
     plawk_i64_expr_ir(Expr, FieldSeparator, Base, GlobalBase,
@@ -1506,16 +1514,18 @@ plawk_i64_expr_ir(field_i64(FieldIndex), FieldSeparator, Base, _GlobalBase, Valu
     format(atom(ValueIR), '%~w_value_or_default', [Base]),
     llvm_emit_atom_field_i64_or_default('%line', FieldIndex, FieldSeparator, 0,
         Base, ValueIR, ParseIR).
-plawk_i64_expr_ir(add_i64(Left, int(Value)), FieldSeparator, Base, GlobalBase,
+plawk_i64_expr_ir(Expr, FieldSeparator, Base, GlobalBase,
         ValueIR, GlobalParts, SetupParts) :-
+    plawk_i64_binary_expr(Expr, LLVMOp, _NamePart, Left, int(Value)),
     integer(Value),
     format(atom(LeftBase), '~w_lhs', [Base]),
     format(atom(LeftGlobalBase), '~w_lhs', [GlobalBase]),
     plawk_i64_expr_ir(Left, FieldSeparator, LeftBase, LeftGlobalBase,
         LeftValueIR, GlobalParts, LeftSetupParts),
     format(atom(ValueIR), '%~w', [Base]),
-    format(atom(AddIR), '  ~w = add i64 ~w, ~w', [ValueIR, LeftValueIR, Value]),
-    append(LeftSetupParts, [AddIR], SetupParts).
+    format(atom(BinaryIR), '  ~w = ~w i64 ~w, ~w',
+        [ValueIR, LLVMOp, LeftValueIR, Value]),
+    append(LeftSetupParts, [BinaryIR], SetupParts).
 plawk_i64_expr_ir(index(FieldIndex, Needle), FieldSeparator, Base, GlobalBase,
         ValueIR, [GlobalIR], [CallIR]) :-
     llvm_emit_atom_field_index(GlobalBase, '%line', FieldIndex, Needle, FieldSeparator,
@@ -1907,11 +1917,13 @@ plawk_emit_print_expr_for_context(int(field(FieldIndex)), FieldSeparator, Contex
     plawk_i64_expr_ir(field_i64(FieldIndex), FieldSeparator, Base, Base,
         ValueIR, GlobalParts, SetupParts).
 
-plawk_emit_print_expr_for_context(add_i64(Left, int(Value)), FieldSeparator, Context,
+plawk_emit_print_expr_for_context(Expr, FieldSeparator, Context,
         i64(FmtPrefix, PrintPrefix, ValueIR), GlobalParts, SetupParts) :-
-    plawk_print_expr_value_base(Context, int_add, Base),
-    plawk_print_expr_output_names(Context, int_add, FmtPrefix, PrintPrefix),
-    plawk_i64_expr_ir(add_i64(Left, int(Value)), FieldSeparator, Base, Base,
+    plawk_i64_binary_expr(Expr, _LLVMOp, NamePart, _Left, _Right),
+    plawk_i64_binary_print_kind(NamePart, Kind),
+    plawk_print_expr_value_base(Context, Kind, Base),
+    plawk_print_expr_output_names(Context, Kind, FmtPrefix, PrintPrefix),
+    plawk_i64_expr_ir(Expr, FieldSeparator, Base, Base,
         ValueIR, GlobalParts, SetupParts).
 
 plawk_emit_print_expr_for_context(length(field(FieldIndex)), FieldSeparator, Context,
@@ -1974,6 +1986,8 @@ plawk_normal_print_expr_value_base(int, Index, Base) :-
     format(atom(Base), 'plawk_int_~w', [Index]).
 plawk_normal_print_expr_value_base(int_add, Index, Base) :-
     format(atom(Base), 'plawk_int_add_~w', [Index]).
+plawk_normal_print_expr_value_base(int_sub, Index, Base) :-
+    format(atom(Base), 'plawk_int_sub_~w', [Index]).
 plawk_normal_print_expr_value_base(length, Index, Base) :-
     format(atom(Base), 'plawk_length_~w', [Index]).
 plawk_normal_print_expr_value_base(substr, Index, Base) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -23,6 +23,7 @@
 %      $3 > 100 { big++ } END { print big }
 %      $1 == "ERROR" { print $3, int($3) }
 %      $1 == "ERROR" { print int($3) + 1 }
+%      $1 == "ERROR" { print int($3) - 1 }
 %      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %      $1 == "DEBUG" { skipped++; next } { total++ } END { print total, skipped }
@@ -352,15 +353,8 @@ scalar_delta_expr(int(Value)) -->
     { ValueCodes \== [],
       number_codes(Value, ValueCodes),
       Value >= 0 }.
-scalar_delta_expr(add_i64(Left, int(Value))) -->
-    int_field_expr(Left),
-    ws,
-    "+",
-    ws,
-    integer_codes(ValueCodes),
-    { ValueCodes \== [],
-      number_codes(Value, ValueCodes),
-      Value >= 0 }.
+scalar_delta_expr(Expr) -->
+    i64_field_const_binary_expr(Expr).
 scalar_delta_expr(field(Index)) -->
     "$",
     integer_codes(IndexCodes),
@@ -403,15 +397,8 @@ field_expr(special('NR')) -->
     "NR".
 field_expr(special('NF')) -->
     "NF".
-field_expr(add_i64(Left, int(Value))) -->
-    int_field_expr(Left),
-    ws,
-    "+",
-    ws,
-    integer_codes(ValueCodes),
-    { ValueCodes \== [],
-      number_codes(Value, ValueCodes),
-      Value >= 0 }.
+field_expr(Expr) -->
+    i64_field_const_binary_expr(Expr).
 field_expr(int(Field)) -->
     int_field_expr(int(Field)).
 field_expr(length(Field)) -->
@@ -508,6 +495,22 @@ int_field_expr(int(Field)) -->
     ws,
     ")",
     { Field = field(_) }.
+
+i64_field_const_binary_expr(Expr) -->
+    int_field_expr(Left),
+    ws,
+    i64_binary_surface_operator(Functor),
+    ws,
+    integer_codes(ValueCodes),
+    { ValueCodes \== [],
+      number_codes(Value, ValueCodes),
+      Value >= 0,
+      Expr =.. [Functor, Left, int(Value)] }.
+
+i64_binary_surface_operator(add_i64) -->
+    "+".
+i64_binary_surface_operator(sub_i64) -->
+    "-".
 
 assoc_key_expr(field(Index)) -->
     "$",

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -85,6 +85,11 @@ test(parses_field_eq_print_int_add_field_rule) :-
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
         [print([add_i64(int(field(3)), int(1))])])], [])).
 
+test(parses_field_eq_print_int_sub_field_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { print int($3) - 1 }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [print([sub_i64(int(field(3)), int(1))])])], [])).
+
 test(parses_field_eq_print_case_field_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { print tolower($2), toupper($0) }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
@@ -208,6 +213,13 @@ test(parses_field_int_add_scalar_add_assign_end_print_rule) :-
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
         [add(var(bytes), add_i64(int(field(3)), int(1))),
          set(var(last), add_i64(int(field(3)), int(1)))])],
+        [end([print([var(bytes), var(last)])])])).
+
+test(parses_field_int_sub_scalar_add_assign_end_print_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { bytes += int($3) - 1; last = int($3) - 1 } END { print bytes, last }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [add(var(bytes), sub_i64(int(field(3)), int(1))),
+         set(var(last), sub_i64(int(field(3)), int(1)))])],
         [end([print([var(bytes), var(last)])])])).
 
 test(parses_always_scalar_add_assign_end_print_rule) :-
@@ -537,10 +549,20 @@ test(surface_begin_field_separator_drives_int_add_printing) :-
         "INFO:boot:7\nERROR:disk:10\nWARN:cpu:20\nERROR:net:-3\nERROR:bad:nope\n",
         "10,11\n-3,-2\nnope,1\n").
 
+test(surface_begin_field_separator_drives_int_sub_printing) :-
+    run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print $3, int($3) - 1 }\n",
+        "INFO:boot:7\nERROR:disk:10\nWARN:cpu:20\nERROR:net:-3\nERROR:bad:nope\n",
+        "10,9\n-3,-4\nnope,-1\n").
+
 test(surface_field_int_add_scalar_accumulates_values) :-
     run_surface_print_smoke("$1 == \"ERROR\" { bytes += int($3) + 1; last = int($3) + 1 } END { print bytes, last }\n",
         "INFO boot 7\nERROR disk 10\nWARN cpu 20\nERROR net -3\nERROR bad nope\n",
         "10 1\n").
+
+test(surface_field_int_sub_scalar_accumulates_values) :-
+    run_surface_print_smoke("$1 == \"ERROR\" { bytes += int($3) - 1; last = int($3) - 1 } END { print bytes, last }\n",
+        "INFO boot 7\nERROR disk 10\nWARN cpu 20\nERROR net -3\nERROR bad nope\n",
+        "4 -1\n").
 
 test(surface_always_scalar_add_assign_accumulates_constants) :-
     run_surface_print_smoke("{ total += 3 } END { print total }\n",
@@ -860,6 +882,16 @@ test(surface_int_add_print_uses_shared_i64_add_lowering) :-
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 
+test(surface_int_sub_print_uses_shared_i64_sub_lowering) :-
+    plawk_parse_string("BEGIN { FS = \":\" } $1 == \"ERROR\" { print int($3) - 1 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '@wam_atom_field_i64_value(%Value %line, i64 3, i8 58)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_sub_0_lhs_value_or_default = select i1 %plawk_int_sub_0_lhs_ok, i64 %plawk_int_sub_0_lhs_value, i64 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_sub_0 = sub i64 %plawk_int_sub_0_lhs_value_or_default, 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_int_sub_0 = call i32 (i8*, ...) @printf(i8* %int_sub_fmt_0, i64 %plawk_int_sub_0)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
 test(surface_scalar_assignment_uses_ordered_native_state_ops) :-
     plawk_parse_string("$1 == \"ERROR\" { last_len = length($0); last_len += 2 } END { print last_len }\n", Program),
     plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
@@ -943,6 +975,18 @@ test(surface_if_else_branch_print_uses_shared_prefixed_expr_lowering) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '@.rule_5F0_5Fbody_5Fif_5F0_5Fthen_5Fprint_5F0_5Findex_5Fneedle_5F2 = private constant [3 x i8] c"is\\00"'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_0_then_print_0_index_2 = call i64 @wam_atom_field_index_value(%Value %line, i64 2, i8 32'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_0_else_print_0_nf_0 = call i64 @wam_atom_field_count_value(%Value %line, i8 32)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_if_else_branch_print_uses_shared_prefixed_i64_binary_lowering) :-
+    plawk_parse_string("{ if ($1 == \"ERROR\") { print int($3) - 1 } else { print int($3) + 1 } } END { print \"done\" }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_0_then_print_0_int_sub_0_lhs = call %WamI64Parse @wam_atom_field_i64_value(%Value %line, i64 3, i8 32)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_0_then_print_0_int_sub_0 = sub i64 %rule_0_body_if_0_then_print_0_int_sub_0_lhs_value_or_default, 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_rule_0_body_if_0_then_print_0_int_sub_0_0 = call i32 (i8*, ...) @printf(i8* %rule_0_body_if_0_then_print_0_int_sub_0_fmt_0, i64 %rule_0_body_if_0_then_print_0_int_sub_0)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_0_else_print_0_int_add_0_lhs = call %WamI64Parse @wam_atom_field_i64_value(%Value %line, i64 3, i8 32)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%rule_0_body_if_0_else_print_0_int_add_0 = add i64 %rule_0_body_if_0_else_print_0_int_add_0_lhs_value_or_default, 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%printed_rule_0_body_if_0_else_print_0_int_add_0_0 = call i32 (i8*, ...) @printf(i8* %rule_0_body_if_0_else_print_0_int_add_0_fmt_0, i64 %rule_0_body_if_0_else_print_0_int_add_0)'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 


### PR DESCRIPTION
  ## Summary

  - Extend the PLAWK surface parser to accept `int($N) - K` alongside `int($N) + K`.
  - Generalize native i64 binary expression lowering so print expressions and scalar updates share the same `add`/`sub`
  path.
  - Add parser, execution smoke, scalar accumulation, top-level print IR, and branch-local prefixed print IR coverage

  ## Tests

  - `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/uw_smoke'),run_tests" -t
  halt`
  - `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
  - `swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/uw_smoke'),run_tests" -t
  halt`
  - `swipl -q -s tests/test_plawk_native_outer_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/uw_smoke'),run_tests"
  -t halt`
  - `swipl -q -s tests/test_plawk_native_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/uw_smoke'),run_tests"
  -t halt`
  - `swipl -q -s tests/test_plawk_native_counter_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/
  uw_smoke'),run_tests" -t halt`
  - `swipl -q -s tests/test_plawk_native_output_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/
  uw_smoke'),run_tests" -t halt`
  - `swipl -q -s tests/test_plawk_native_lowered_handler_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/
  uw_smoke'),run_tests" -t halt`
  - `swipl -q -s tests/test_plawk_compiled_output_append.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/uw_smoke'),run_tests" -t
  halt`
  - `git diff --check`