### PR TITLE
feat(wam-rust): persist boundary precompute to a boundary_basis LMDB sub-db (P2c)

### DIFF
--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -1,6 +1,6 @@
 # WAM-Rust Boundary Distribution Optimization — Implementation Plan
 
-Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction DONE). The implementation-plan member of
+Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction, P2c-wiring/precompute/persistence DONE). The implementation-plan member of
 the design trio: **`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md`** (why — a
 disablable complexity-reduction compiler optimization, caching secondary),
 **`WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md`** (precise semantics, the
@@ -285,11 +285,22 @@ Phasing:
     `evict_budget` evicts a dead interior yet leaves band results identical; tiny
     `live_budget` forces stop-at-depth with partial caching still correct; eager-only
     no-op. Eager-edge only; the lazy/LMDB path keeps the enumeration precompute.
-  - **P2c-wiring/precompute/eviction/LMDB [next].** Spill the retained band (and, if
-    chosen, the live frontier) to the `boundary_basis` LMDB sub-db rather than
-    dropping it, so storage pressure (not just memory) is handled and the precompute
-    is not repeated per run. Then an end-to-end LMDB run.
-  - The `boundary_basis` LMDB sub-db (persisted precompute) folds in here.
+  - **P2c-wiring/precompute/persistence [DONE].** The precompute persists to a
+    `boundary_basis` LMDB sub-db (u32 node -> packed histogram) so it is **not
+    repeated per run**: `LmdbFactSource::save_boundary_basis(table)` writes it in one
+    transaction and `load_boundary_basis()` reads it back at setup (empty when the
+    sub-db is absent -> kernel degrades to full enumeration). The packing format is
+    crate-independent `boundary_cache::encode_hist`/`decode_hist`
+    (`[len: u32 LE][counts: u64 LE * len]`), shared by both LMDB backends and
+    unit-tested without LMDB. Tests: `encode_decode_hist_roundtrip` (boundary_cache)
+    and `test_wam_rust_boundary_basis_lmdb.pl` — in a generated lmdb_zero crate,
+    save -> load -> fresh re-open all return the identical table (cross-run
+    persistence). lmdb_zero backend; heed parity is a follow-up.
+  - **P2c-wiring/precompute/eviction/spill [next].** Spill the *live* frontier (and
+    optionally evicted dead interiors) to the `boundary_basis` sub-db mid-sweep when
+    even the live budget is exceeded — turning the §8b stop-at-depth into spill-and-
+    continue-against-storage. Then an end-to-end LMDB run wiring the harness to
+    `load_boundary_basis` at setup / `save_boundary_basis` after precompute.
 - **P3 — the measurement in §6** (does it add wall-time *on top of* the edge
   cache, and from what `D_pre`). Gates whether P4 is worth building.
 - **P4 — storage-gated approximate/specialised bases** (`g_B` dot-product for hot

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -120,10 +120,61 @@ pub fn f_weighted_power(h: &Hist, n: f64) -> f64 {
         .sum()
 }
 
+// Serialization — pack a histogram to/from a flat little-endian byte string so a
+// boundary-basis table (node -> histogram) can be persisted (e.g. the LMDB
+// `boundary_basis` sub-db) and reloaded across runs, per spec §8/§9. Format:
+// u32 LE length prefix, then `len` u64 LE bucket counts. Crate-independent (no
+// LMDB), so it is testable everywhere and shared by both LMDB backends.
+
+/// Pack a histogram into `[len: u32 LE][counts: u64 LE * len]`.
+pub fn encode_hist(h: &Hist) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4 + h.len() * 8);
+    out.extend_from_slice(&(h.len() as u32).to_le_bytes());
+    for &c in h {
+        out.extend_from_slice(&c.to_le_bytes());
+    }
+    out
+}
+
+/// Unpack a histogram produced by `encode_hist`. Tolerant of a short/truncated
+/// buffer (stops at the last whole u64), and of an empty buffer (-> empty).
+pub fn decode_hist(b: &[u8]) -> Hist {
+    if b.len() < 4 {
+        return Vec::new();
+    }
+    let n = u32::from_le_bytes([b[0], b[1], b[2], b[3]]) as usize;
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        let o = 4 + i * 8;
+        if o + 8 <= b.len() {
+            out.push(u64::from_le_bytes([
+                b[o], b[o + 1], b[o + 2], b[o + 3],
+                b[o + 4], b[o + 5], b[o + 6], b[o + 7],
+            ]));
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[test]
+    fn encode_decode_hist_roundtrip() {
+        for h in [
+            vec![] as Hist,
+            vec![0u64, 1, 0, 2],
+            vec![5, 4, 3, 2, 1],
+            vec![u64::MAX, 0, 7],
+        ] {
+            assert_eq!(decode_hist(&encode_hist(&h)), h, "roundtrip {:?}", h);
+        }
+        // empty / sub-header buffers decode to empty
+        assert_eq!(decode_hist(&[]), Vec::<u64>::new());
+        assert_eq!(decode_hist(&[1, 0]), Vec::<u64>::new());
+    }
 
     // Sample DAG (child -> parents), root = 0. Diamonds produce multiple paths
     // of multiple lengths, so the full histogram (not just a scalar) is tested.

--- a/templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache
+++ b/templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache
@@ -168,6 +168,63 @@ impl LmdbFactSource {
         Ok(out)
     }
 
+    /// Load the persisted `boundary_basis` sub-db (u32 node -> path-length
+    /// histogram, packed by `boundary_cache::encode_hist`) into a map ready for
+    /// `WamState::set_boundary_suffix`. Returns an empty map when the sub-db is
+    /// absent, so a project that never ran the precompute treats it as "no cache"
+    /// and the boundary kernel degrades to full enumeration. See
+    /// WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md §8/§9.
+    pub fn load_boundary_basis(&self) -> Result<HashMap<u32, Vec<u64>>, lmdb::Error> {
+        let db = match lmdb::Database::open(
+            Arc::clone(&self.env),
+            Some("boundary_basis"),
+            &lmdb::DatabaseOptions::new(lmdb::db::Flags::empty()),
+        ) {
+            Ok(db) => db,
+            Err(_) => return Ok(HashMap::new()),
+        };
+        let txn = lmdb::ReadTransaction::new(&*self.env)?;
+        let access = txn.access();
+        let mut cursor = txn.cursor(&db)?;
+        let mut out = HashMap::new();
+        match cursor.first::<[u8], [u8]>(&access) {
+            Ok((k, v)) => {
+                out.insert(decode_u32(k), crate::boundary_cache::decode_hist(v));
+                while let Ok((k, v)) = cursor.next::<[u8], [u8]>(&access) {
+                    out.insert(decode_u32(k), crate::boundary_cache::decode_hist(v));
+                }
+            }
+            Err(lmdb::Error::Code(lmdb_zero::error::NOTFOUND)) => {}
+            Err(e) => return Err(e),
+        }
+        Ok(out)
+    }
+
+    /// Persist a boundary-basis table (u32 node -> histogram) to the
+    /// `boundary_basis` sub-db, creating it if absent. This is the spill/persist
+    /// half of the boundary precompute (spec §8b/§9): the retained band (and any
+    /// spilled frontier) is written once so subsequent runs `load_boundary_basis`
+    /// instead of recomputing. One write transaction; values are packed by
+    /// `boundary_cache::encode_hist`.
+    pub fn save_boundary_basis(&self, table: &HashMap<u32, Vec<u64>>) -> Result<(), lmdb::Error> {
+        let db = lmdb::Database::open(
+            Arc::clone(&self.env),
+            Some("boundary_basis"),
+            &lmdb::DatabaseOptions::new(lmdb::db::CREATE),
+        )?;
+        let txn = lmdb::WriteTransaction::new(&*self.env)?;
+        {
+            let mut access = txn.access();
+            for (&node, hist) in table {
+                let key = node.to_le_bytes();
+                let val = crate::boundary_cache::encode_hist(hist);
+                access.put(&db, &key[..], &val[..], lmdb::put::Flags::empty())?;
+            }
+        }
+        txn.commit()?;
+        Ok(())
+    }
+
     /// Look up all parents of `child_id` via cursor MDB_SET + MDB_NEXT_DUP.
     /// Returns an empty Vec if the key is absent.
     pub fn lookup_parents(&self, child_id: i32) -> Result<Vec<i32>, lmdb::Error> {
@@ -280,6 +337,14 @@ fn decode_i32(bytes: &[u8]) -> i32 {
     let len = bytes.len().min(4);
     buf[..len].copy_from_slice(&bytes[..len]);
     i32::from_le_bytes(buf)
+}
+
+fn decode_u32(bytes: &[u8]) -> u32 {
+    // boundary_basis keys are u32 node ids, little-endian.
+    let mut buf = [0u8; 4];
+    let len = bytes.len().min(4);
+    buf[..len].copy_from_slice(&bytes[..len]);
+    u32::from_le_bytes(buf)
 }
 
 fn decode_string(bytes: &[u8]) -> String {

--- a/tests/test_wam_rust_boundary_basis_lmdb.pl
+++ b/tests/test_wam_rust_boundary_basis_lmdb.pl
@@ -1,0 +1,104 @@
+% test_wam_rust_boundary_basis_lmdb.pl
+%
+% P2c-wiring/precompute persistence: the boundary precompute can be SPILLED to /
+% PERSISTED in the `boundary_basis` LMDB sub-db and reloaded across runs, so the
+% precompute is not repeated per run (spec §8b/§9). Validates, in a generated
+% lmdb_zero-mode crate:
+%   - LmdbFactSource::save_boundary_basis(table) writes node->histogram entries,
+%   - load_boundary_basis() reads them back identically,
+%   - a fresh LmdbFactSource::open over the same env still sees them (cross-run),
+%   - boundary_cache::{encode_hist,decode_hist} are the packing format.
+%
+% cargo-gated (also needs the lmdb-zero crate to build).
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+
+:- dynamic bbl_fact/2.
+bbl_fact(a, b).
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- begin_tests(wam_rust_boundary_basis_lmdb).
+
+test(boundary_basis_persist_roundtrip,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_bbl'))]) :-
+    Dir = 'output/test_bbl',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project([user:bbl_fact/2],
+        [module_name(bbl), lmdb_mode(cursor), lmdb_crate(lmdb_zero)], Dir)),
+    % the runtime must carry the persistence methods + the packing format.
+    atom_concat(Dir, '/src/lmdb_fact_source.rs', LmdbRs),
+    read_file_to_string(LmdbRs, LSrc, []),
+    sub_string(LSrc, _, _, _, "pub fn save_boundary_basis"),
+    sub_string(LSrc, _, _, _, "pub fn load_boundary_basis"),
+    atom_concat(Dir, '/src/boundary_cache.rs', BcRs),
+    read_file_to_string(BcRs, BSrc, []),
+    sub_string(BSrc, _, _, _, "pub fn encode_hist"),
+    sub_string(BSrc, _, _, _, "pub fn decode_hist"),
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/bbl_test.rs', TestPath),
+    TestSrc = '
+use bbl::lmdb_fact_source::LmdbFactSource;
+use lmdb_zero as lmdb;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// Create the Phase-1 sub-dbs (empty) so LmdbFactSource::open succeeds, then
+// round-trip a boundary_basis table through save/load and a fresh re-open.
+#[test]
+fn boundary_basis_roundtrip() {
+    let dir = std::env::temp_dir().join(format!("bbl_it_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.to_str().unwrap();
+    {
+        let env = unsafe {
+            let mut b = lmdb::EnvBuilder::new().unwrap();
+            b.set_maxdbs(16).unwrap();
+            b.set_mapsize(64 * 1024 * 1024).unwrap();
+            b.open(path, lmdb::open::Flags::empty(), 0o600).unwrap()
+        };
+        let env = Arc::new(env);
+        for name in ["s2i", "i2s"] {
+            let _ = lmdb::Database::open(Arc::clone(&env), Some(name),
+                &lmdb::DatabaseOptions::new(lmdb::db::CREATE)).unwrap();
+        }
+        for name in ["category_parent", "category_child"] {
+            let _ = lmdb::Database::open(Arc::clone(&env), Some(name),
+                &lmdb::DatabaseOptions::new(lmdb::db::CREATE | lmdb::db::DUPSORT)).unwrap();
+        }
+    }
+    let src = LmdbFactSource::open(path).unwrap();
+    assert!(src.load_boundary_basis().unwrap().is_empty(), "no sub-db yet -> empty");
+    let mut table: HashMap<u32, Vec<u64>> = HashMap::new();
+    table.insert(1, vec![0, 1]);
+    table.insert(2, vec![0, 0, 3, 1]);
+    table.insert(7, vec![]);
+    src.save_boundary_basis(&table).unwrap();
+    assert_eq!(src.load_boundary_basis().unwrap(), table, "round-trip");
+    // fresh open reads the persisted table (cross-run persistence).
+    let src2 = LmdbFactSource::open(path).unwrap();
+    assert_eq!(src2.load_boundary_basis().unwrap(), table, "persisted across re-open");
+    let _ = std::fs::remove_dir_all(&dir);
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    format(atom(Cmd), 'cd "~w" && cargo test --test bbl_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[boundary_basis lmdb FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_boundary_basis_lmdb).


### PR DESCRIPTION
The storage half of the boundary eviction design (spec §8b/§9): persist the precompute to a `boundary_basis` LMDB sub-db so it is **not recomputed per run**.

## Changes

- **`boundary_cache.rs`** — crate-independent histogram packing `encode_hist`/`decode_hist` (`[len: u32 LE][counts: u64 LE * len]`), shared by both LMDB backends and unit-testable without LMDB. Tolerant of empty/truncated buffers.
- **`lmdb_fact_source_lmdb_zero.rs`** — `load_boundary_basis()` reads the `boundary_basis` sub-db (u32 node → packed histogram) into a map ready for `WamState::set_boundary_suffix` (empty when the sub-db is absent → kernel degrades to full enumeration); `save_boundary_basis()` writes the table in one `WriteTransaction`, creating the sub-db if needed. Adds a `decode_u32` helper. **This is the first Rust-side LMDB writer** — the existing paths (`load_s2i`/`load_min_dist`/…) were all read-only, with writes done by the Python ingest.
- **`test_wam_rust_boundary_basis_lmdb.pl`** (cargo-gated) — in a generated lmdb_zero crate: save → load → **fresh re-open** all return the identical table (the cross-run persistence that matters).

## Validation discipline

I couldn't be sure LMDB write code would compile/behave here, so I first prototyped the exact `save`/`load` + serialization against `lmdb-zero` in a standalone crate and confirmed the round-trip, **then** transplanted the verified code into the template. The generated lmdb_zero crate builds, and the cargo-gated round-trip test passes (incl. cross-run re-open). The serialization unit test runs in every generated crate (16 lib tests pass).

## Scope / next

- lmdb_zero backend only; **heed parity** is a follow-up (additive, no caller depends on it yet).
- **Mid-sweep spill** — spill the live frontier to `boundary_basis` when even the live budget is exceeded, turning §8b's stop-at-depth into spill-and-continue-against-storage — is the next sub-step, followed by an end-to-end LMDB run wiring the harness to `load_boundary_basis` at setup / `save_boundary_basis` after precompute.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_