### PR TITLE
Generalize PLAWK i64 binary primary expressions

### DIFF
--- a/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
+++ b/docs/design/PLAWK_IMPLEMENTATION_PLAN.md
@@ -263,9 +263,10 @@ the allocation-free `@wam_atom_field_subslice_value` helper, and native
 `index($N, "literal")` through the shared `@wam_atom_field_index_value` helper.
 Explicit print-side numeric coercions such as `int($N)` lower through the shared
 `@wam_atom_field_i64_value` parse helper and print zero when the field is
-missing or not a strict signed decimal. The first composed arithmetic forms,
-`int($N) + K` and `int($N) - K`, lower as the same native parse followed by a
-shared binary `i64` operation.
+missing or not a strict signed decimal. The first composed arithmetic forms add
+or subtract a non-negative integer constant from native `i64` primaries such as
+`NR`, `NF`, `length($N)`, and `int($N)`; each lowers through the shared primary
+emitter followed by a shared binary `i64` operation.
 Print-only `tolower($N)` and `toupper($N)` lower through shared
 `@wam_print_ascii_lower_slice` and `@wam_print_ascii_upper_slice` helpers, so
 case mapping streams bytes without allocating a transformed atom.
@@ -305,7 +306,8 @@ branch-local prints; the context supplies prefixed names while `$N`, `NF`,
 lowering clauses. Numeric expression lowering is also factored through a shared
 `plawk_i64_expr_ir` layer, so scalar updates and print expressions both consume
 the same native `i64` emitters for constants, `NR`, `NF`, `length($N)`, numeric
-field coercion, `int($N) +/- K`, and `index($N, "...")` where those forms apply.
+field coercion, `index($N, "...")`, and native `NR`/`NF`/`length`/`int` primary
+`+/- K` forms where those forms apply.
 Terminal
 branch-local `next` branches directly to the stream-loop continuation and adds
 the selected branch's scalar values to the loop phi inputs. Terminal

--- a/examples/plawk/README.md
+++ b/examples/plawk/README.md
@@ -85,8 +85,10 @@ as `$1 == "ERROR" { print substr($2, 1, 3) }`, and native byte searches such as
 case-mapped field slices such as `$1 == "ERROR" { print tolower($2), toupper($0) }`.
 Explicit numeric field coercion is available as `int($N)`, e.g.
 `$1 == "ERROR" { print $3, int($3) }`; failed numeric parses print `0`.
-The first arithmetic composition forms are `int($N) + K` and `int($N) - K`, e.g.
-`$1 == "ERROR" { print int($3) + 1 }`.
+The first arithmetic composition forms add or subtract a non-negative integer
+constant from native `i64` primaries such as `NR`, `NF`, `length($N)`,
+and `int($N)`, e.g.
+`$1 == "ERROR" { print NR - 1, int($3) + 1 }`.
 Numeric field guards use the shared WAM/LLVM `i64` comparison helper, so forms
 such as `$3 > 100 { print $1, $3 }` and `$2 <= -5 { cold++ }` stay in the native
 streaming loop.
@@ -102,7 +104,8 @@ Plain scalar assignment uses the same native slot path and preserves source
 order with later updates, e.g. `$1 == "ERROR" { last_len = length($0); hits++ }
 END { print hits, last_len }`. The current assignment expression subset is
 integer literals, `length($N)`, numeric `$N`, explicit `int($N)`, and
-`int($N) +/- K`.
+native scalar `i64` primary `+/- K` forms such as `NF + K`, `length($N) - K`,
+and `int($N) + K`.
 Scalar slot updates can also sit behind native `if/else` guards, e.g.
 `{ if ($1 == "ERROR") { errors++; last_len = length($0) } else { non_errors++ } }
 END { print errors, non_errors, last_len }`. The first branch slice supports

--- a/examples/plawk/TUTORIAL.md
+++ b/examples/plawk/TUTORIAL.md
@@ -124,9 +124,10 @@ The native Phase 2 surface can compile rule prints with `NR`, `NF`, selected
 fields, native field lengths such as `length($2)`, native byte substrings such as
 `substr($2, 1, 3)`, and `OFS`, matching the first awk-style example above. It can
 also print explicit numeric field coercions with `int($N)`, where missing or
-non-numeric fields become `0`, and the first arithmetic composition forms
-`int($N) + K` and `int($N) - K`. It can also compile a scalar counter and an
-`END` action:
+non-numeric fields become `0`, and the first arithmetic composition forms add
+or subtract a non-negative integer constant from native `i64` primaries such as
+`NR`, `NF`, `length($N)`, and `int($N)`. It can also compile a scalar counter
+and an `END` action:
 
 ```awk
 $1 == "ERROR" { count++ } END { print count }
@@ -252,8 +253,9 @@ $1 == "ERROR" { last_len = length($0); hits++ }
 END { print hits, last_len }
 ```
 
-The current assignment expression subset is integer literals, `length($N)`, and
-numeric `$N`.
+The current assignment expression subset is integer literals, `length($N)`,
+numeric `$N`, explicit `int($N)`, and native scalar `i64` primary `+/- K` forms
+such as `NF + K`, `length($N) - K`, and `int($N) + K`.
 
 Numeric field guards are also native:
 
@@ -382,9 +384,10 @@ $1 == "ERROR" { print $3, int($3) }
 ```
 
 The current arithmetic print subset can add or subtract a non-negative integer
-constant from that coerced value:
+constant from native `i64` primaries:
 
 ```awk
+$1 == "ERROR" { print NR - 1, NF + 1, length($0) - 3 }
 $1 == "ERROR" { print int($3) + 1 }
 $1 == "ERROR" { print int($3) - 1 }
 ```

--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -44,8 +44,11 @@
 %      $3 > 100 { big++ } END { print big }
 %      $1 == "ERROR" { print $3, int($3) }
 %      $1 == "ERROR" { print int($3) + 1 }
+%      $1 == "ERROR" { print int($3) - 1 }
+%      $1 == "ERROR" { print NR - 1, NF + 1, length($0) - 3 }
 %      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
+%      { adjusted += length($0) - 3; width = NF + 1 } END { print adjusted, width }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
 %      $1 == "ERROR" { last_len = length($0); hits++ } END { print hits, last_len }
 %      { if ($1 == "ERROR") { errors++ } else { warnings++ } } END { print errors, warnings }
@@ -1304,18 +1307,37 @@ plawk_rule_body_print_field(special('NR')).
 plawk_rule_body_print_field(special('NF')).
 plawk_rule_body_print_field(int(field(_))).
 plawk_rule_body_print_field(Expr) :-
-    plawk_i64_field_const_binary_expr(Expr).
+    plawk_i64_const_binary_expr(Expr).
 plawk_rule_body_print_field(length(field(_))).
 plawk_rule_body_print_field(substr(field(_), _Start, _Len)).
 plawk_rule_body_print_field(index(field(_), string(_))).
 plawk_rule_body_print_field(tolower(field(_))).
 plawk_rule_body_print_field(toupper(field(_))).
 
-plawk_i64_field_const_binary_expr(Expr) :-
-    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, int(field(FieldIndex)), int(Value)),
-    FieldIndex >= 0,
+plawk_i64_const_binary_expr(Expr) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, int(Value)),
+    plawk_i64_binary_primary_expr(Left),
     integer(Value),
     Value >= 0.
+
+plawk_i64_binary_primary_expr(special('NR')).
+plawk_i64_binary_primary_expr(special('NF')).
+plawk_i64_binary_primary_expr(int(field(FieldIndex))) :-
+    FieldIndex >= 0.
+plawk_i64_binary_primary_expr(length(field(FieldIndex))) :-
+    FieldIndex >= 0.
+
+plawk_i64_scalar_const_binary_expr(Expr) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, int(Value)),
+    plawk_i64_scalar_binary_primary_expr(Left),
+    integer(Value),
+    Value >= 0.
+
+plawk_i64_scalar_binary_primary_expr(special('NF')).
+plawk_i64_scalar_binary_primary_expr(int(field(FieldIndex))) :-
+    FieldIndex >= 0.
+plawk_i64_scalar_binary_primary_expr(length(field(FieldIndex))) :-
+    FieldIndex >= 0.
 
 plawk_i64_binary_expr(add_i64(Left, Right), add, add, Left, Right).
 plawk_i64_binary_expr(sub_i64(Left, Right), sub, sub, Left, Right).
@@ -1342,7 +1364,7 @@ plawk_scalar_action_update(add(var(Name), field(FieldIndex)), Name, add(field_i6
 plawk_scalar_action_update(add(var(Name), int(field(FieldIndex))), Name, add(field_i64(FieldIndex))) :-
     FieldIndex >= 0.
 plawk_scalar_action_update(add(var(Name), Expr), Name, add(Expr)) :-
-    plawk_i64_field_const_binary_expr(Expr).
+    plawk_i64_scalar_const_binary_expr(Expr).
 plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) :-
     integer(Value),
     Value >= 0.
@@ -1353,7 +1375,7 @@ plawk_scalar_action_update(set(var(Name), field(FieldIndex)), Name, set(field_i6
 plawk_scalar_action_update(set(var(Name), int(field(FieldIndex))), Name, set(field_i64(FieldIndex))) :-
     FieldIndex >= 0.
 plawk_scalar_action_update(set(var(Name), Expr), Name, set(Expr)) :-
-    plawk_i64_field_const_binary_expr(Expr).
+    plawk_i64_scalar_const_binary_expr(Expr).
 
 plawk_scalar_action_sequence_pairs([], _Slots, _AssocPlan, _FieldSeparator, _OutputSeparator, _Prefix, CurrentLabel, _RuleIndex,
         OpIndex, Values, Values, OpIndex, CurrentLabel, []) -->
@@ -1503,6 +1525,18 @@ plawk_i64_expr_ir(nr, _FieldSeparator, _Base, _GlobalBase, '%current_nr', [], []
 plawk_i64_expr_ir(nf, FieldSeparator, Base, _GlobalBase, ValueIR, [], [CountIR]) :-
     llvm_emit_atom_field_count('%line', FieldSeparator, Base, CountIR),
     format(atom(ValueIR), '%~w', [Base]).
+plawk_i64_expr_ir(special('NR'), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    plawk_i64_expr_ir(nr, FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts).
+plawk_i64_expr_ir(special('NF'), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    plawk_i64_expr_ir(nf, FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts).
+plawk_i64_expr_ir(length(field(FieldIndex)), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts) :-
+    plawk_i64_expr_ir(length(FieldIndex), FieldSeparator, Base, GlobalBase,
+        ValueIR, GlobalParts, SetupParts).
 plawk_i64_expr_ir(length(FieldIndex), FieldSeparator, Base, _GlobalBase, ValueIR, [], [LengthIR]) :-
     llvm_emit_atom_field_length('%line', FieldIndex, FieldSeparator, Base, LengthIR),
     format(atom(ValueIR), '%~w', [Base]).
@@ -1776,12 +1810,21 @@ plawk_field_cmp_op_code(gt, 4).
 plawk_field_cmp_op_code(ge, 5).
 
 plawk_print_record_counter_ir(Fields, LoopPhiIR, RecordCounterIR) :-
-    (   member(special('NR'), Fields)
+    (   plawk_fields_include_nr(Fields)
     ->  LoopPhiIR = '  %plawk_nr = phi i64 [0, %check_handle_value], [%current_nr, %continue_loop]',
         RecordCounterIR = '  %current_nr = add i64 %plawk_nr, 1'
     ;   LoopPhiIR = '',
         RecordCounterIR = ''
     ).
+
+plawk_fields_include_nr(Fields) :-
+    member(Field, Fields),
+    plawk_expr_uses_nr(Field).
+
+plawk_expr_uses_nr(special('NR')).
+plawk_expr_uses_nr(Expr) :-
+    plawk_i64_binary_expr(Expr, _LLVMOp, _NamePart, Left, _Right),
+    plawk_expr_uses_nr(Left).
 
 plawk_print_action_ir([field(0)], _FieldSeparator, _OutputSeparator, ''-IR) :-
     !,

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -24,8 +24,10 @@
 %      $1 == "ERROR" { print $3, int($3) }
 %      $1 == "ERROR" { print int($3) + 1 }
 %      $1 == "ERROR" { print int($3) - 1 }
+%      $1 == "ERROR" { print NR - 1, NF + 1, length($0) - 3 }
 %      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
+%      { adjusted += length($0) - 3; width = NF + 1 } END { print adjusted, width }
 %      $1 == "DEBUG" { skipped++; next } { total++ } END { print total, skipped }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
 %      $1 == "ERROR" { last_len = length($0); hits++ } END { print hits, last_len }
@@ -354,7 +356,7 @@ scalar_delta_expr(int(Value)) -->
       number_codes(Value, ValueCodes),
       Value >= 0 }.
 scalar_delta_expr(Expr) -->
-    i64_field_const_binary_expr(Expr).
+    i64_const_binary_expr(Expr).
 scalar_delta_expr(field(Index)) -->
     "$",
     integer_codes(IndexCodes),
@@ -393,12 +395,12 @@ print_fields_rest([Field | Fields]) -->
 print_fields_rest([]) -->
     [].
 
+field_expr(Expr) -->
+    i64_const_binary_expr(Expr).
 field_expr(special('NR')) -->
     "NR".
 field_expr(special('NF')) -->
     "NF".
-field_expr(Expr) -->
-    i64_field_const_binary_expr(Expr).
 field_expr(int(Field)) -->
     int_field_expr(int(Field)).
 field_expr(length(Field)) -->
@@ -496,8 +498,8 @@ int_field_expr(int(Field)) -->
     ")",
     { Field = field(_) }.
 
-i64_field_const_binary_expr(Expr) -->
-    int_field_expr(Left),
+i64_const_binary_expr(Expr) -->
+    i64_binary_primary_expr(Left),
     ws,
     i64_binary_surface_operator(Functor),
     ws,
@@ -511,6 +513,29 @@ i64_binary_surface_operator(add_i64) -->
     "+".
 i64_binary_surface_operator(sub_i64) -->
     "-".
+
+i64_binary_primary_expr(special('NR')) -->
+    "NR".
+i64_binary_primary_expr(special('NF')) -->
+    "NF".
+i64_binary_primary_expr(Expr) -->
+    int_field_expr(Expr).
+i64_binary_primary_expr(length(Field)) -->
+    "length",
+    ws,
+    "(",
+    ws,
+    simple_field_expr(Field),
+    ws,
+    ")".
+
+simple_field_expr(field(Index)) -->
+    "$",
+    integer_codes(IndexCodes),
+    { IndexCodes \== [],
+      number_codes(Index, IndexCodes),
+      Index >= 0
+    }.
 
 assoc_key_expr(field(Index)) -->
     "$",

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -90,6 +90,13 @@ test(parses_field_eq_print_int_sub_field_rule) :-
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
         [print([sub_i64(int(field(3)), int(1))])])], [])).
 
+test(parses_field_eq_print_i64_primary_binary_rule) :-
+    plawk_parse_string("$1 == \"ERROR\" { print NR - 1, NF + 1, length($0) - 3 }\n", Program),
+    assertion(Program == program([], [rule(field_eq(1, "ERROR"),
+        [print([sub_i64(special('NR'), int(1)),
+                add_i64(special('NF'), int(1)),
+                sub_i64(length(field(0)), int(3))])])], [])).
+
 test(parses_field_eq_print_case_field_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { print tolower($2), toupper($0) }\n", Program),
     assertion(Program == program([], [rule(field_eq(1, "ERROR"),
@@ -221,6 +228,14 @@ test(parses_field_int_sub_scalar_add_assign_end_print_rule) :-
         [add(var(bytes), sub_i64(int(field(3)), int(1))),
          set(var(last), sub_i64(int(field(3)), int(1)))])],
         [end([print([var(bytes), var(last)])])])).
+
+test(parses_i64_primary_binary_scalar_add_assign_end_print_rule) :-
+    plawk_parse_string("{ adjusted += length($0) - 3; width = NF + 1; delta += int($3) + 1 } END { print adjusted, width, delta }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [add(var(adjusted), sub_i64(length(field(0)), int(3))),
+         set(var(width), add_i64(special('NF'), int(1))),
+         add(var(delta), add_i64(int(field(3)), int(1)))])],
+        [end([print([var(adjusted), var(width), var(delta)])])])).
 
 test(parses_always_scalar_add_assign_end_print_rule) :-
     plawk_parse_string("{ total += 3 } END { print total }\n", Program),
@@ -554,6 +569,11 @@ test(surface_begin_field_separator_drives_int_sub_printing) :-
         "INFO:boot:7\nERROR:disk:10\nWARN:cpu:20\nERROR:net:-3\nERROR:bad:nope\n",
         "10,9\n-3,-4\nnope,-1\n").
 
+test(surface_begin_field_separator_drives_i64_primary_binary_printing) :-
+    run_surface_print_smoke("BEGIN { FS = \":\"; OFS = \",\" } $1 == \"ERROR\" { print NR - 1, NF + 1, length($0) - 3, int($3) + 1 }\n",
+        "ERROR:disk:10\nWARN:cpu:20\nERROR:network:-3\n",
+        "0,4,10,11\n2,4,13,-2\n").
+
 test(surface_field_int_add_scalar_accumulates_values) :-
     run_surface_print_smoke("$1 == \"ERROR\" { bytes += int($3) + 1; last = int($3) + 1 } END { print bytes, last }\n",
         "INFO boot 7\nERROR disk 10\nWARN cpu 20\nERROR net -3\nERROR bad nope\n",
@@ -563,6 +583,11 @@ test(surface_field_int_sub_scalar_accumulates_values) :-
     run_surface_print_smoke("$1 == \"ERROR\" { bytes += int($3) - 1; last = int($3) - 1 } END { print bytes, last }\n",
         "INFO boot 7\nERROR disk 10\nWARN cpu 20\nERROR net -3\nERROR bad nope\n",
         "4 -1\n").
+
+test(surface_i64_primary_binary_scalar_accumulates_values) :-
+    run_surface_print_smoke("BEGIN { FS = \":\" } { adjusted += length($0) - 3; width = NF + 1; delta += int($3) + 1 } END { print adjusted, width, delta }\n",
+        "ERROR:disk:10\nWARN:cpu:20\nERROR:network:-3\n",
+        "31 4 30\n").
 
 test(surface_always_scalar_add_assign_accumulates_constants) :-
     run_surface_print_smoke("{ total += 3 } END { print total }\n",
@@ -889,6 +914,19 @@ test(surface_int_sub_print_uses_shared_i64_sub_lowering) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_sub_0_lhs_value_or_default = select i1 %plawk_int_sub_0_lhs_ok, i64 %plawk_int_sub_0_lhs_value, i64 0'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_sub_0 = sub i64 %plawk_int_sub_0_lhs_value_or_default, 1'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%printed_int_sub_0 = call i32 (i8*, ...) @printf(i8* %int_sub_fmt_0, i64 %plawk_int_sub_0)'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_i64_primary_binary_print_uses_shared_lowering) :-
+    plawk_parse_string("BEGIN { FS = \":\" } $1 == \"ERROR\" { print NR - 1, NF + 1, length($0) - 3, int($3) + 1 }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_sub_0 = sub i64 %current_nr, 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_add_1_lhs = call i64 @wam_atom_field_count_value(%Value %line, i8 58)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_add_1 = add i64 %plawk_int_add_1_lhs, 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_sub_2_lhs = call i64 @wam_atom_field_length_value(%Value %line, i64 0, i8 58)'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_sub_2 = sub i64 %plawk_int_sub_2_lhs, 3'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_add_3_lhs_value_or_default = select i1 %plawk_int_add_3_lhs_ok, i64 %plawk_int_add_3_lhs_value, i64 0'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_add_3 = add i64 %plawk_int_add_3_lhs_value_or_default, 1'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 


### PR DESCRIPTION
  ## Summary

  - Extend PLAWK parsing for `+/- K` binary expressions over native i64 primaries:
    - `NR`
    - `NF`
    - `length($N)`
    - `int($N)`
  - Reuse the shared native i64 expression lowering path for those binary forms.
  - Ensure print-side `NR - K` requests the native record-counter phi.
  - Add parser, native execution smoke, scalar accumulation, and LLVM IR coverage.
  - Update PLAWK docs and tutorial wording for the expanded expression subset.

  ## Notes

  This intentionally leaves `index($N, "...") +/- K` and scalar `NR +/- K` out of scope. Scalar `NR` needs separate
  state-expression record-counter wiring.

  ## Tests

  - `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/uw_smoke'),run_tests" -t
  halt`
  - `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
  - `swipl -q -s tests/test_plawk_compiled_stream_core.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/uw_smoke'),run_tests" -t
  halt`
  - `swipl -q -s tests/test_plawk_native_outer_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/uw_smoke'),run_tests"
  -t halt`
  - `swipl -q -s tests/test_plawk_native_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/uw_smoke'),run_tests"
  -t halt`
  - `swipl -q -s tests/test_plawk_native_counter_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/
  uw_smoke'),run_tests" -t halt`
  - `swipl -q -s tests/test_plawk_native_output_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/
  uw_smoke'),run_tests" -t halt`
  - `swipl -q -s tests/test_plawk_native_lowered_handler_stream_loop_driver.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/
  uw_smoke'),run_tests" -t halt`
  - `swipl -q -s tests/test_plawk_compiled_output_append.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/uw_smoke'),run_tests" -t
  halt`
  - `git diff --check`