### PR TITLE
feat(wam-rust): pre-weighted g_B basis (P4) + thin entry-frontier band

### DIFF
--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -1,6 +1,6 @@
 # WAM-Rust Boundary Distribution Optimization — Implementation Plan
 
-Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction, P2c-wiring/precompute/persistence DONE). The implementation-plan member of
+Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction, P2c-wiring/precompute/persistence, P3-measurement, P4-g_B-basis, P4-entry-frontier DONE). The implementation-plan member of
 the design trio: **`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md`** (why — a
 disablable complexity-reduction compiler optimization, caching secondary),
 **`WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md`** (precise semantics, the
@@ -313,8 +313,27 @@ Phasing:
   invariant, guarded by `tests/test_wam_rust_boundary_integrated_scale.pl`). The
   shallow crossover confirms philosophy §3 (Python overhead had masked it). Boundary-
   hit-fraction vs `D_pre` and the LMDB-lazy-path variant remain to be measured.
-- **P4 — storage-gated approximate/specialised bases** (`g_B` dot-product for hot
-  functionals; fitted forms when a basis exceeds the storage budget).
+- **P4 — storage-gated approximate/specialised bases.**
+  - **`g_B` pre-weighted basis [DONE].** `build_boundary_basis_weighted_power(max_depth,
+    n)` collapses each cached histogram into `g_B[a] = Σ_b H_B[b]·(a+b)^(-N)`, and
+    `collect_native_category_ancestor_weightsum` accumulates WeightSum directly (a
+    dot-product splice — no convolution, no final `powf` loop). **Budget precondition
+    (§4a "budget-specialised"):** `g_B` bakes in the budget and `N`, so it serves
+    only queries with that *same fixed* budget and functional; variable budgets /
+    multiple functionals keep the histogram (`boundary_suffix`), the general
+    budget-flexible form. Validated `g_B` WeightSum == histogram `weighted_power` ==
+    full enumeration.
+  - **Entry-frontier band [DONE].** `boundary_band_entry_frontier(d_pre, edge_pred)`
+    caches only the region's *surface* — nodes with `1 ≤ min_dist ≤ d_pre` that have a
+    child *outside* the region — instead of the whole `boundary_band_root_near`
+    *volume*. Since the kernel splices at the first cached node and stops, periphery
+    seeds only use this cut, so storage scales with the region surface, not the
+    cumulative root-near node count (measured: band 38–83 vs region 313–711 at the
+    same `D_pre`, same-order speedup at the intended periphery-seed operating point).
+    Any band is exact, so this is a storage/coverage choice. The whole-region band
+    remains for maximal coverage when storage is not the constraint.
+  - **Fitted forms [next].** binomial / discretised-GMM bases when a basis exceeds the
+    storage budget (per `DISTRIBUTIONAL_COMPRESSION_THEORY.md`).
 
 ## 6. What to measure (re-derive, don't inherit)
 

--- a/docs/design/WAM_RUST_BOUNDARY_MEASUREMENT_2026-06-16.md
+++ b/docs/design/WAM_RUST_BOUNDARY_MEASUREMENT_2026-06-16.md
@@ -80,3 +80,66 @@ peak resident memo entries; `eq` = boundary aggregate == production exactly.
 
 Guarded by `tests/test_wam_rust_boundary_integrated_scale.pl` (the exact-match
 invariant at a moderate synthetic scale, deterministic / debug).
+
+## Addendum — entry-frontier band vs whole region (storage)
+
+The original table used `boundary_band_root_near(D_pre) = {1 ≤ min_dist ≤ D_pre}`,
+the **whole** root-near region. That `band` column grows with the *cumulative*
+node count (313, 599, 711 …) — it caches the region's *volume*. But the boundary
+kernel splices at the **first** cached node a seed reaches and stops, so a periphery
+seed only ever uses the region's **entry frontier** (region nodes with a child
+*outside* the region). `boundary_band_entry_frontier(D_pre, edge_pred)` caches just
+that cut — the region's *surface*:
+
+```
+config           Dpre   prod_ms  bound_ms    pre_ms   speedup  region   front   eq
+core=120  cp=3      1     18.06     5.602     0.052      3.2x       8       8  yes
+core=120  cp=3      2     18.06     0.728     0.108     24.8x      65      38  yes
+core=120  cp=3      3     18.06     2.191     0.130      8.2x     313      38  yes
+core=120  cp=3      4     18.06    11.292     0.094      1.6x     599       8  yes
+core=240  cp=3      2     23.64     1.477     0.179     16.0x      71      51  yes
+core=240  cp=3      3     23.64     1.179     0.233     20.0x     335      83  yes
+core=240  cp=3      4     23.64    14.913     0.161      1.6x     711      10  yes
+```
+
+`region` = whole-region band size; `front` = entry-frontier band size.
+
+**Findings.**
+
+- The entry frontier is the **thin cut** the design intends: at the intended
+  operating point (`D_pre=2`, where most seeds are still in the *periphery*, outside
+  the region) it gets ~16–25× with a band of 38–51 vs the region's 65–71 — same
+  order of speedup, a fraction of the storage. This is the fix for the
+  region-band "blowing up" with cumulative node count.
+- At large `D_pre` the speedup *falls* (8.2×, then 1.6×) — and that is the lesson,
+  not a regression: once `D_pre` is large enough that the region has swallowed the
+  periphery (`region` ≈ all 620 nodes), there is almost nothing *outside* it, so the
+  frontier collapses (8–10 nodes) and the now-in-region seeds enumerate the dense
+  interior cone the frontier does not cache. **A boundary cache wants seeds in the
+  periphery**: pick `D_pre` so the frontier sits between the seeds and the dense
+  core. The whole-region band hides this by caching the interior too — at a storage
+  cost that grows with the graph.
+- Correctness is unchanged (`eq = yes` throughout): any band is exact for the
+  splice, so the region-vs-frontier choice is purely a storage/coverage tradeoff.
+
+So `boundary_band_entry_frontier` is the storage-efficient default for the boundary-
+cache regime; `boundary_band_root_near` remains available when maximal coverage
+(caching the interior too) is wanted and storage is not the constraint.
+
+## Addendum — pre-weighted basis `g_B` (P4) and its budget precondition
+
+For a **fixed** functional and budget, each cached histogram `H_B` collapses to a
+single fixed-length vector `g_B[a] = Σ_b H_B[b]·(a+b)^(-N)` (prefix length `a`);
+a query reaching `B` at depth `a` adds `g_B[a]` to WeightSum directly — a
+dot-product splice that skips the histogram convolution and the final `powf` loop
+(`build_boundary_basis_weighted_power` / `collect_native_category_ancestor_weightsum`).
+
+**Precondition (plan §4a "budget-specialised").** `g_B` bakes the path-length budget
+and `N` into each scalar (it pre-sums suffixes with `a+b ≤ max_depth`), so it is
+valid only for queries with that *same fixed budget and N*. It cannot serve a query
+with a different/smaller max path length, nor a different functional — those need
+the **histogram** (`boundary_suffix`), which preserves the length breakdown and can
+be re-truncated per query. `g_B` is the fixed-budget/fixed-functional specialisation;
+the histogram is the general, budget-flexible form. (Validated:
+`weighted_power_basis_equals_histogram` — `g_B` WeightSum == histogram
+`weighted_power` == full enumeration, same fixed budget.)

--- a/examples/benchmark/wam_rust_boundary_measurement.pl
+++ b/examples/benchmark/wam_rust_boundary_measurement.pl
@@ -81,8 +81,8 @@ fn main() {
     let budget = 8usize;
     let n = 2.0f64;
     let edge_pred = "category_parent";
-    println!("{:<16} {:>4} {:>9} {:>9} {:>9} {:>9} {:>6} {:>7} {:>4}",
-        "config", "Dpre", "prod_ms", "bound_ms", "pre_ms", "speedup", "band", "peakR", "eq");
+    println!("{:<16} {:>4} {:>9} {:>9} {:>9} {:>9} {:>7} {:>7} {:>4}",
+        "config", "Dpre", "prod_ms", "bound_ms", "pre_ms", "speedup", "region", "front", "eq");
     for (core, periph, cp) in [(120u32, 500u32, 3usize), (180, 500, 3), (240, 500, 3)] {
         let (edges, seed_ids) = build(core, periph, cp, 42);
         let md_num = min_dist_to_root(&edges, 0);
@@ -110,9 +110,12 @@ fn main() {
             (t.elapsed().as_secs_f64() * 1e3, sa)
         };
         for dpre in [1usize, 2, 3, 4] {
-            let band = vm.boundary_band_root_near(dpre);
+            // entry-frontier band (thin cut) vs the whole root-near region.
+            let region_sz = vm.boundary_band_root_near(dpre).len();
+            let band = vm.boundary_band_entry_frontier(dpre, edge_pred);
+            let front_sz = band.len();
             let pre = Instant::now();
-            let stats = vm.build_boundary_suffix_sweep(&band, root, budget, edge_pred, 0, 0).unwrap();
+            vm.build_boundary_suffix_sweep(&band, root, budget, edge_pred, 0, 0).unwrap();
             let tpre = pre.elapsed().as_secs_f64() * 1e3;
             let (tb, sb) = {
                 let acc = vm.resolve_edge_accessor(edge_pred);
@@ -127,8 +130,8 @@ fn main() {
                 (t.elapsed().as_secs_f64() * 1e3, sb)
             };
             let eq = (sa - sb).abs() < 1e-6 * sa.abs().max(1.0);
-            println!("core={:<4} cp={:<2}    {:>4} {:>9.2} {:>9.3} {:>9.3} {:>8.1}x {:>6} {:>7} {:>4}",
-                core, cp, dpre, ta, tb, tpre, ta / tb, stats.retained, stats.peak_resident,
+            println!("core={:<4} cp={:<2}    {:>4} {:>9.2} {:>9.3} {:>9.3} {:>8.1}x {:>7} {:>7} {:>4}",
+                core, cp, dpre, ta, tb, tpre, ta / tb, region_sz, front_sz,
                 if eq { "yes" } else { "NO!" });
         }
     }

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -509,6 +509,14 @@ pub struct WamState {
     /// re-enumerating node->root — turning exponential path enumeration into a
     /// histogram splice. Empty = boundary mode off (default).
     pub boundary_suffix: FxMap<u32, Vec<u64>>,
+    /// Pre-weighted boundary basis (P4): node -> the `weighted_power(N)` basis
+    /// vector `g_B[a] = sum_b H_node->root[b] * (a+b)^(-N)` for prefix length
+    /// `a = 0..=max_depth`. A query reaching this node at prefix depth `a` adds
+    /// `g_B[a]` to WeightSum directly — a fixed-length dot-product splice that
+    /// skips the histogram convolution and the final powf loop, for a fixed
+    /// functional. Smaller (one f64 vector of length <= max_depth+1 vs a
+    /// variable-support histogram) and faster. Empty = basis mode off.
+    pub boundary_basis_wp: FxMap<u32, Vec<f64>>,
     /// Int-native edge mode: when true, the lazy edge path treats the kernel's
     /// u32 node id AS the raw LMDB int key directly (identity), bypassing
     /// `wam_to_lmdb`/`lmdb_to_wam`. Used for int-native fixtures whose seeds,
@@ -627,6 +635,7 @@ impl WamState {
             demand_set: FxSet::default(),
             min_dist: FxMap::default(),
             boundary_suffix: FxMap::default(),
+            boundary_basis_wp: FxMap::default(),
             bindings: HashMap::new(),
             var_counter: 0,
             cut_barrier: 0,
@@ -961,6 +970,47 @@ impl WamState {
             .collect()
     }
 
+    /// The thin **entry frontier** of the root-near region: nodes with
+    /// `1 <= min_dist <= d_pre` that have at least one child *outside* the region
+    /// (`min_dist > d_pre`, or no `min_dist` at all). These are exactly the nodes a
+    /// path from the periphery *first* reaches when it crosses into the region — and
+    /// since the boundary kernel splices at the first cached node and stops, they
+    /// are the only band nodes a periphery seed ever uses. Caching just this cut
+    /// (instead of the whole `boundary_band_root_near` region) keeps the band from
+    /// growing with the cumulative root-near node count — it scales with the
+    /// region's *surface*, not its *volume* — while serving the same seeds. Interior
+    /// region nodes (never an entry point) are dropped; seeds that start inside the
+    /// region simply enumerate their short cone to the root (cheap). Requires the
+    /// eager edge table to enumerate children; returns the whole region as a
+    /// fallback if the table is absent.
+    pub fn boundary_band_entry_frontier(&self, d_pre: usize, edge_pred: &str) -> Vec<u32> {
+        let cap = d_pre as i32;
+        let parents = match self.ffi_facts.get(edge_pred) {
+            Some(p) => p,
+            None => return self.boundary_band_root_near(d_pre),
+        };
+        let in_region = |id: u32| -> bool {
+            matches!(self.min_dist.get(&(id as i32)), Some(&d) if d >= 1 && d <= cap)
+        };
+        let outside = |id: u32| -> bool {
+            match self.min_dist.get(&(id as i32)) {
+                Some(&d) => d > cap,
+                None => true,
+            }
+        };
+        let mut entry: std::collections::HashSet<u32> = std::collections::HashSet::new();
+        for (&child, ps) in parents.iter() {
+            if outside(child) {
+                for &p in ps {
+                    if in_region(p) {
+                        entry.insert(p);
+                    }
+                }
+            }
+        }
+        entry.into_iter().collect()
+    }
+
     /// Convenience: select the root-near band (`<= d_pre` hops from root, via
     /// `min_dist`) and precompute + install its suffix histograms. A harness calls
     /// this once at setup, after the graph (edges) and `min_dist` are loaded and
@@ -1176,6 +1226,83 @@ impl WamState {
         };
         self.boundary_suffix = table.into_iter().collect();
         Some(stats)
+    }
+
+    /// Build the pre-weighted `weighted_power(N)` basis (P4) from the current
+    /// `boundary_suffix` histograms: for each cached node B, collapse its
+    /// `node->root` histogram `H_B` into the basis vector
+    /// `g_B[a] = sum_b H_B[b] * (a+b)^(-N)`, for prefix length `a = 0..=max_depth`
+    /// (the L>0 weighted-power filter is automatic — B != root so every suffix
+    /// length `b >= 1`, hence `a+b >= 1`). A query that reaches B at prefix depth
+    /// `a` then adds `g_B[a]` to WeightSum directly. Requires `build_boundary_
+    /// suffix*` to have populated `boundary_suffix` first.
+    ///
+    /// **Budget precondition (the §4a "budget-specialised" mode).** `g_B` bakes the
+    /// path-length budget `max_depth` AND the functional `(N)` into a single scalar
+    /// per prefix length — it sums over suffix lengths `b` with `a+b <= max_depth`.
+    /// So it is valid ONLY for queries with the *same* fixed budget and the *same*
+    /// `N`. It CANNOT serve a query with a different/smaller max path length (those
+    /// suffixes were already summed in) or a different functional — for variable
+    /// budgets or multiple functionals, keep the histogram (`boundary_suffix`),
+    /// which preserves the length breakdown and can be re-truncated per query.
+    /// `g_B` is the fixed-budget, fixed-functional specialisation; the histogram is
+    /// the general form.
+    pub fn build_boundary_basis_weighted_power(&mut self, max_depth: usize, n: f64) {
+        let mut basis: HashMap<u32, Vec<f64>> = HashMap::new();
+        for (&node, hist) in self.boundary_suffix.iter() {
+            let mut g = vec![0.0f64; max_depth + 1];
+            for (b, &c) in hist.iter().enumerate() {
+                if c == 0 { continue; }
+                let cf = c as f64;
+                for a in 0..=max_depth {
+                    let l = a + b;
+                    if l == 0 || l > max_depth { continue; }
+                    g[a] += cf * (l as f64).powf(-n);
+                }
+            }
+            basis.insert(node, g);
+        }
+        self.boundary_basis_wp = basis.into_iter().collect();
+    }
+
+    /// Direct `weighted_power(N)` WeightSum via the pre-weighted basis (P4).
+    /// Walks `cat_id -> root` exactly like `collect_native_category_ancestor_
+    /// boundary_hist`, but instead of building a histogram it accumulates the
+    /// scalar WeightSum: at a node carrying a `g_B` basis vector, add `g_B[depth]`
+    /// (the dot-product splice) and stop; at the root, add `(depth+1)^(-N)`. With
+    /// an empty basis it degrades to full enumeration of the weighted sum (still
+    /// exact). Returns the same value as
+    /// `f_weighted_power(collect_native_category_ancestor_boundary_hist(..), n)`.
+    pub fn collect_native_category_ancestor_weightsum(
+        &self, cat_id: u32, root_id: u32, visited: &mut Vec<u32>, max_depth: usize,
+        acc: &EdgeAccessor, depth: i64, n: f64, out: &mut f64,
+    ) {
+        if !self.min_dist.is_empty() {
+            match self.min_dist.get(&(cat_id as i32)) {
+                Some(&d) => { if depth + (d as i64) > max_depth as i64 { return; } }
+                None => return,
+            }
+        }
+        if let Some(g) = self.boundary_basis_wp.get(&cat_id) {
+            let a = depth as usize;
+            if a < g.len() {
+                *out += g[a];
+            }
+            return;
+        }
+        let parents = self.edge_parents_via(cat_id, acc);
+        if !visited.contains(&root_id) && parents.contains(&root_id) {
+            let l = (depth + 1) as f64;
+            *out += l.powf(-n);
+        }
+        if visited.len() >= max_depth { return; }
+        for parent_id in &parents {
+            if visited.contains(parent_id) { continue; }
+            visited.push(*parent_id);
+            self.collect_native_category_ancestor_weightsum(
+                *parent_id, root_id, visited, max_depth, acc, depth + 1, n, out);
+            visited.pop();
+        }
     }
 
     /// Enable int-native edge mode: the lazy edge path treats the kernel's
@@ -2412,6 +2539,99 @@ mod boundary_kernel_tests {
         let b = vm.intern_atom("1");
         assert!(vm.build_boundary_suffix_sweep(&[b], root, 8, "no_such_pred", 0, 0).is_none(),
                 "no eager table -> sweep is a no-op");
+    }
+
+    // The entry-frontier band is a thin cut (region surface, not volume) yet the
+    // splice through it still matches full enumeration for periphery seeds. Graph
+    // has a genuine periphery (nodes outside the root-near region).
+    #[test]
+    fn entry_frontier_band_is_thin_and_exact() {
+        let mut vm = WamState::new(vec![], HashMap::new());
+        // core near root 0, plus a periphery (10,11,12) hanging off the core.
+        vm.register_ffi_fact_pairs("category_parent", &[
+            ("1", "0"), ("2", "0"), ("3", "1"), ("4", "2"),
+            ("10", "3"), ("10", "4"), ("11", "3"), ("12", "10"),
+        ]);
+        let root = vm.intern_atom("0");
+        let budget = 8usize;
+        let n = 2.0f64;
+        let mut md: HashMap<i32, i32> = HashMap::new();
+        for (name, d) in [("0",0),("1",1),("2",1),("3",2),("4",2),("10",3),("11",3),("12",4)] {
+            md.insert(vm.intern_atom(name) as i32, d);
+        }
+        vm.set_min_dist(&md);
+        // d_pre=2: whole region is {1,2,3,4}; entry frontier is just {3,4}
+        // (the region nodes the periphery attaches to).
+        let region = vm.boundary_band_root_near(2);
+        let frontier = vm.boundary_band_entry_frontier(2, "category_parent");
+        assert!(frontier.len() < region.len(),
+            "entry frontier {} should be thinner than region {}", frontier.len(), region.len());
+        let mut fsorted = frontier.clone(); fsorted.sort();
+        let mut expect = vec![vm.intern_atom("3"), vm.intern_atom("4")]; expect.sort();
+        assert_eq!(fsorted, expect, "entry frontier should be exactly {{3,4}}");
+        // splice through the thin frontier == full enumeration for periphery seeds.
+        vm.build_boundary_suffix(&frontier, root, budget, "category_parent");
+        let pseeds: Vec<u32> = ["10", "11", "12"].iter().map(|s| vm.intern_atom(s)).collect();
+        let acc = vm.resolve_edge_accessor("category_parent");
+        for &s in &pseeds {
+            let mut fh = vec![]; let mut v = vec![s];
+            vm.enum_ancestor_hist(s, root, &mut v, budget, &acc, 0, &mut fh);
+            let wref = crate::boundary_cache::f_weighted_power(&fh, n);
+            let mut bh = vec![]; let mut v2 = vec![s];
+            vm.collect_native_category_ancestor_boundary_hist(s, root, &mut v2, budget, &acc, 0, &mut bh);
+            let wsp = crate::boundary_cache::f_weighted_power(&bh, n);
+            assert!((wref - wsp).abs() < 1e-12, "frontier seed {}: {} != {}", s, wref, wsp);
+            assert!(wref > 0.0, "seed {} should reach root", s);
+        }
+    }
+
+    // P4: the pre-weighted weighted_power basis (g_B dot-product splice) yields the
+    // SAME WeightSum as the histogram-based weighted_power == full enumeration.
+    #[test]
+    fn weighted_power_basis_equals_histogram() {
+        let mut vm = dag();
+        let root = vm.intern_atom("0");
+        let budget = 8usize;
+        let n = 2.0f64;
+        let seeds: Vec<u32> = ["5", "4", "3"].iter().map(|s| vm.intern_atom(s)).collect();
+        for bnames in &[vec!["1", "2"], vec!["3", "1", "2"], vec!["4"]] {
+            let bnodes: Vec<u32> = bnames.iter().map(|s| vm.intern_atom(s)).collect();
+            vm.build_boundary_suffix(&bnodes, root, budget, "category_parent");
+            vm.build_boundary_basis_weighted_power(budget, n);
+            let acc = vm.resolve_edge_accessor("category_parent");
+            for &s in &seeds {
+                let mut fh = vec![];
+                let mut v = vec![s];
+                vm.enum_ancestor_hist(s, root, &mut v, budget, &acc, 0, &mut fh);
+                let wref = crate::boundary_cache::f_weighted_power(&fh, n);
+                let mut ws = 0.0f64;
+                let mut v2 = vec![s];
+                vm.collect_native_category_ancestor_weightsum(s, root, &mut v2, budget, &acc, 0, n, &mut ws);
+                assert!((wref - ws).abs() < 1e-12,
+                    "basis {:?} seed {}: hist {} != basis {}", bnames, s, wref, ws);
+            }
+        }
+    }
+
+    // Empty basis -> the WeightSum kernel degrades to full enumeration (exact).
+    #[test]
+    fn weighted_power_basis_empty_is_full_enum() {
+        let mut vm = dag();
+        let root = vm.intern_atom("0");
+        let budget = 8usize;
+        let n = 2.0f64;
+        let seeds: Vec<u32> = ["5", "4", "3"].iter().map(|s| vm.intern_atom(s)).collect();
+        let acc = vm.resolve_edge_accessor("category_parent");
+        for &s in &seeds {
+            let mut fh = vec![];
+            let mut v = vec![s];
+            vm.enum_ancestor_hist(s, root, &mut v, budget, &acc, 0, &mut fh);
+            let wref = crate::boundary_cache::f_weighted_power(&fh, n);
+            let mut ws = 0.0f64;
+            let mut v2 = vec![s];
+            vm.collect_native_category_ancestor_weightsum(s, root, &mut v2, budget, &acc, 0, n, &mut ws);
+            assert!((wref - ws).abs() < 1e-12, "empty-basis seed {}: {} != {}", s, wref, ws);
+        }
     }
 
     // Shared precompute is eager-only: with no eager table it is a no-op (false).


### PR DESCRIPTION
This addresses both points you raised on the measurement — and you were right on both.

## 1. Pre-weighted `g_B` basis (P4) — and your budget constraint

`build_boundary_basis_weighted_power(max_depth, n)` collapses each cached histogram into `g_B[a] = Σ_b H_B[b]·(a+b)^(-N)`; `collect_native_category_ancestor_weightsum` then accumulates WeightSum directly (dot-product splice — no convolution, no final `powf`).

**Your constraint is exactly the dividing line, now documented as the precondition.** `g_B` bakes in *both* the path-length budget *and* `N` (it pre-sums suffixes with `a+b ≤ max_depth`), so it serves only queries with that **same fixed budget and functional**. A different/smaller max path length, or a different functional, needs the **histogram** (`boundary_suffix`), which keeps the length breakdown and can be re-truncated per query. So `g_B` is the fixed-budget/fixed-functional *specialisation* (plan §4a "budget-specialised"); the histogram stays the general form. This is precisely your "we can only do this if the max path length is fixed."

## 2. Entry-frontier band — your "blowing up" point

You were right that `boundary_band_root_near` caches the whole *region* `{1 ≤ min_dist ≤ d_pre}`, so the band grows with the cumulative node count (313 → 599 → 711). But the kernel splices at the **first** cached node and stops, so a periphery seed only ever uses the region's **entry frontier**. `boundary_band_entry_frontier(d_pre, edge_pred)` caches just that cut — the region's *surface*:

```
config           Dpre   bound_ms   speedup  region   front   eq
core=120  cp=3      2      0.728     24.8x      65      38  yes
core=120  cp=3      3      2.191      8.2x     313      38  yes
core=240  cp=3      3      1.179     20.0x     335      83  yes
```

At the intended operating point (`D_pre=2`, seeds in the periphery) it gets same-order speedup with a fraction of the storage. The falloff at large `D_pre` is itself the lesson: once the region swallows the periphery there's nothing outside it, the frontier collapses, and the now-in-region seeds enumerate the dense interior — i.e. **a boundary cache wants its seeds in the periphery**. Any band is exact, so region-vs-frontier is purely storage/coverage.

## Tests (19 lib tests pass)

- `weighted_power_basis_equals_histogram` — `g_B` WeightSum == histogram `weighted_power` == full enumeration (same fixed budget).
- `weighted_power_basis_empty_is_full_enum` — empty basis degrades correctly.
- `entry_frontier_band_is_thin_and_exact` — frontier strictly smaller than region, splice still exact for periphery seeds.

Plus the measurement harness now uses the entry frontier, and the report carries both addenda.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_