### PR TITLE
feat(wam-rust): port distribution approximation policy — rung 1 (tail prune + CDF certificates)

### DIFF
--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -1,6 +1,6 @@
 # WAM-Rust Boundary Distribution Optimization — Implementation Plan
 
-Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction, P2c-wiring/precompute/persistence, P3-measurement, P4-g_B-basis, P4-entry-frontier DONE). The implementation-plan member of
+Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction, P2c-wiring/precompute/persistence, P3-measurement, P4-g_B-basis, P4-entry-frontier, P4-approx-rung1 DONE). The implementation-plan member of
 the design trio: **`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md`** (why — a
 disablable complexity-reduction compiler optimization, caching secondary),
 **`WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md`** (precise semantics, the
@@ -296,11 +296,15 @@ Phasing:
     and `test_wam_rust_boundary_basis_lmdb.pl` — in a generated lmdb_zero crate,
     save -> load -> fresh re-open all return the identical table (cross-run
     persistence). lmdb_zero backend; heed parity is a follow-up.
-  - **P2c-wiring/precompute/eviction/spill [next].** Spill the *live* frontier (and
-    optionally evicted dead interiors) to the `boundary_basis` sub-db mid-sweep when
-    even the live budget is exceeded — turning the §8b stop-at-depth into spill-and-
-    continue-against-storage. Then an end-to-end LMDB run wiring the harness to
-    `load_boundary_basis` at setup / `save_boundary_basis` after precompute.
+  - **P2c-wiring/precompute/eviction/spill [later, NOT default].** Spill the *live*
+    frontier (and optionally evicted dead interiors) to the `boundary_basis` sub-db
+    mid-sweep when even the live budget is exceeded — turning the §8b stop-at-depth
+    into spill-and-continue-against-storage. **Design decision: spill is off by
+    default**; it engages only when the in-memory cache is too small for the problem,
+    and only after checking LMDB is actually available (installed / a writable env),
+    falling back to stop-at-depth otherwise. Then an end-to-end LMDB run wiring the
+    harness to `load_boundary_basis` at setup / `save_boundary_basis` after
+    precompute.
 - **P3 — the measurement in §6 [DONE].** Measured on the **real emitted kernels**
   (`build_boundary_suffix_sweep` + `collect_native_category_ancestor_boundary_hist`
   vs the production `collect_native_category_ancestor_hops`), harness
@@ -332,8 +336,18 @@ Phasing:
     same `D_pre`, same-order speedup at the intended periphery-seed operating point).
     Any band is exact, so this is a storage/coverage choice. The whole-region band
     remains for maximal coverage when storage is not the constraint.
-  - **Fitted forms [next].** binomial / discretised-GMM bases when a basis exceeds the
-    storage budget (per `DISTRIBUTIONAL_COMPRESSION_THEORY.md`).
+  - **Approximation ladder, rung 1 [DONE].** Ported the Python distribution-cache
+    policy (spec §9a): the support count is a **work trigger** (default 50), NOT an
+    acceptance gate — acceptance is the CDF **error certificate** (`ε_K` Kolmogorov,
+    default 0.001; `ε_W1` Wasserstein available). `boundary_cache::{cdf_max_error,
+    cdf_w1_error, tail_prune, compress_histogram}` + the opt-in
+    `WamState::compress_boundary_suffix`. Tail-pruned-exact is rung 1 (the dropped
+    fraction *is* the Kolmogorov error). OPT-IN: the cache stays exact unless called;
+    triggers only for large-budget/deep-path histograms (support > min_points).
+  - **Fitted forms [next].** binomial / beta-binomial / mixture-of-binomials bases
+    (discretised-GMM as escalation only), same CDF/W1 gate, when an exact or
+    tail-pruned histogram still exceeds the storage budget (per
+    `DISTRIBUTIONAL_COMPRESSION_THEORY.md`).
 
 ## 6. What to measure (re-derive, don't inherit)
 

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
@@ -335,6 +335,34 @@ dominate. Because the exact discrete splice is ~ns, choosing a non-exact form is
 **storage / very-large-scale** decision, not a compute one — at normal scale,
 exact discrete is both fastest and simplest.
 
+### 9a. The exact→approximate ladder (ported policy + defaults)
+
+Ported from the Python distribution-cache line (`DISTRIBUTIONAL_COMPRESSION_
+THEORY.md`); two principles that doc is emphatic about are carried over verbatim:
+
+- **The point count is a *work trigger*, not an acceptance gate.** "Is this over 50
+  points?" is *not* the decision rule — it only decides *when to try* compressing.
+  Acceptance is an **error certificate** on the CDF: Kolmogorov
+  `ε_K = max_t|F_exact(t) − F_approx(t)|` (and optionally Wasserstein-1
+  `ε_W1 = Σ_t|ΔF|`, which bounds Lipschitz-functional error). Defaults:
+  `min_points = 50` (trigger), `ε_K = 0.001` (certificate).
+- **Discrete-first ladder**, cheapest representation within the error budget:
+  exact histogram → **tail-pruned exact** → quantised CDF table → binomial →
+  beta-/mixture-of-binomials → discretised GMM (*escalation only* — bounded integer
+  path-length data favour binomial families; GMM is not the default fallback).
+
+Implemented (Rust, `boundary_cache.rs`): the **error metrics** (`cdf_max_error`,
+`cdf_w1_error`) and the **first rung — tail pruning** (`tail_prune`: drop the
+longest suffix whose cumulative mass ≤ the budget; the dropped fraction *is* the
+Kolmogorov error). `compress_histogram` is the work-triggered + certified default;
+`WamState::compress_boundary_suffix(min_points, ε_K)` applies it across the cached
+table. **All of this is OPT-IN** — the boundary cache is exact unless it is called,
+and even then a compressed node differs by at most `ε_K` (the splice becomes
+approximate within that certified bound for the affected nodes only). For typical
+small-budget boundary histograms (support ≤ `budget`+1) the trigger never fires;
+this matters at **large budget / deep paths**. Later rungs (binomial / mixture
+fits, with the same CDF/W1 gate) are future work.
+
 ## 10. Non-goals (this spec)
 
 - Changing the production kernel or the default (un-optimized) semantics.

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -156,6 +156,111 @@ pub fn decode_hist(b: &[u8]) -> Hist {
     out
 }
 
+// --- Storage-gated approximation (the exact->approximate ladder, first rung) ---
+//
+// Ported from the Python distribution-cache line (DISTRIBUTIONAL_COMPRESSION_
+// THEORY.md). Two things that doc is emphatic about, preserved here:
+//   * The point count is a WORK TRIGGER (when to TRY compressing), NOT an
+//     acceptance gate. The doc explicitly replaces "is it over 50 points?" with
+//     "which representation is cheapest at the requested error tolerance?".
+//   * Acceptance is an ERROR CERTIFICATE on the CDF — Kolmogorov epsilon_K (and
+//     optionally Wasserstein-1) — not a heuristic. Approximation only ever drops
+//     mass within that certified budget; everything kept stays exact.
+//
+// This is OPT-IN: the boundary cache is exact by default. These are the tools a
+// storage-budgeted precompute uses when an exact histogram does not fit. The
+// first ladder rung (tail-pruned exact) is implemented; binomial / mixture /
+// discretised-GMM fits are the later rungs (future).
+//
+// Note: typical boundary histograms have support <= budget+1 (the path-length
+// budget), so for the small-budget effective-distance query the work trigger
+// rarely fires — this matters for large-budget / deep-path graph search where the
+// histograms are long.
+
+/// Default work trigger: only TRY compressing a histogram with more than this many
+/// support points (DISTRIBUTIONAL_COMPRESSION_THEORY.md `max_recurrence_states`).
+pub const DEFAULT_COMPRESS_MIN_POINTS: usize = 50;
+/// Default acceptance certificate: max Kolmogorov CDF error (epsilon_K).
+pub const DEFAULT_COMPRESS_EPSILON_K: f64 = 0.001;
+
+/// Kolmogorov error `max_t |F_a(t) - F_b(t)|` between two histograms, each
+/// normalised to a PMF by its own total mass. Bounds prefix-mass / CDF query
+/// error. Two zero-mass histograms compare as 0.
+pub fn cdf_max_error(a: &Hist, b: &Hist) -> f64 {
+    let ta: f64 = a.iter().map(|&c| c as f64).sum();
+    let tb: f64 = b.iter().map(|&c| c as f64).sum();
+    if ta == 0.0 && tb == 0.0 { return 0.0; }
+    let n = a.len().max(b.len());
+    let (mut ca, mut cb, mut worst) = (0.0f64, 0.0f64, 0.0f64);
+    for i in 0..n {
+        ca += *a.get(i).unwrap_or(&0) as f64;
+        cb += *b.get(i).unwrap_or(&0) as f64;
+        let fa = if ta > 0.0 { ca / ta } else { 0.0 };
+        let fb = if tb > 0.0 { cb / tb } else { 0.0 };
+        worst = worst.max((fa - fb).abs());
+    }
+    worst
+}
+
+/// Wasserstein-1 error `sum_t |F_a(t) - F_b(t)|` between two histograms (PMF-
+/// normalised). Bounds Lipschitz functional error:
+/// `|E_a[g] - E_b[g]| <= Lip(g) * w1`.
+pub fn cdf_w1_error(a: &Hist, b: &Hist) -> f64 {
+    let ta: f64 = a.iter().map(|&c| c as f64).sum();
+    let tb: f64 = b.iter().map(|&c| c as f64).sum();
+    if ta == 0.0 && tb == 0.0 { return 0.0; }
+    let n = a.len().max(b.len());
+    let (mut ca, mut cb, mut total) = (0.0f64, 0.0f64, 0.0f64);
+    for i in 0..n {
+        ca += *a.get(i).unwrap_or(&0) as f64;
+        cb += *b.get(i).unwrap_or(&0) as f64;
+        let fa = if ta > 0.0 { ca / ta } else { 0.0 };
+        let fb = if tb > 0.0 { cb / tb } else { 0.0 };
+        total += (fa - fb).abs();
+    }
+    total
+}
+
+/// Tail-prune: drop the longest suffix of `h` whose cumulative count mass stays
+/// within `max_drop` (a FRACTION of the total mass). Exact where kept. Returns the
+/// pruned histogram and the actual dropped fraction — which equals the pruned
+/// histogram's Kolmogorov error vs `h` (the CDF is exact up to the cut, then flat).
+/// Never drops the whole histogram (keeps at least the leading bucket).
+pub fn tail_prune(h: &Hist, max_drop: f64) -> (Hist, f64) {
+    let total: u64 = h.iter().sum();
+    if total == 0 || h.is_empty() {
+        return (h.clone(), 0.0);
+    }
+    let cap = (max_drop.max(0.0) * total as f64).floor() as u64;
+    let mut dropped: u64 = 0;
+    let mut cut = h.len(); // exclusive end of the kept prefix
+    for i in (0..h.len()).rev() {
+        if cut <= 1 { break; } // always keep at least one bucket
+        if dropped + h[i] > cap { break; }
+        dropped += h[i];
+        cut -= 1;
+    }
+    let mut pruned = h[..cut].to_vec();
+    while pruned.len() > 1 && pruned.last() == Some(&0) {
+        pruned.pop();
+    }
+    (pruned, dropped as f64 / total as f64)
+}
+
+/// Default storage-gated compression of one histogram. The support count
+/// `> min_points` is the WORK TRIGGER; when triggered, tail-prune within the
+/// `epsilon_k` certificate and return the result only if it actually shortens the
+/// support, else return `h` unchanged. So the output is exact unless the histogram
+/// is both long *and* has a >`epsilon_k`-prunable tail, and even then it differs by
+/// at most `epsilon_k` Kolmogorov mass.
+pub fn compress_histogram(h: &Hist, min_points: usize, epsilon_k: f64) -> Hist {
+    if h.len() <= min_points {
+        return h.clone();
+    }
+    let (pruned, _drop) = tail_prune(h, epsilon_k);
+    if pruned.len() < h.len() { pruned } else { h.clone() }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -174,6 +279,51 @@ mod tests {
         // empty / sub-header buffers decode to empty
         assert_eq!(decode_hist(&[]), Vec::<u64>::new());
         assert_eq!(decode_hist(&[1, 0]), Vec::<u64>::new());
+    }
+
+    #[test]
+    fn cdf_errors_basic() {
+        let a = vec![1u64, 2, 3, 4];
+        assert_eq!(cdf_max_error(&a, &a), 0.0);
+        assert_eq!(cdf_w1_error(&a, &a), 0.0);
+        let empty: Hist = vec![];
+        assert_eq!(cdf_max_error(&empty, &empty), 0.0);
+        // shift all mass one bucket later -> nonzero CDF error
+        let b = vec![0u64, 1, 2, 3, 4];
+        assert!(cdf_max_error(&a, &b) > 0.0);
+        assert!(cdf_w1_error(&a, &b) >= cdf_max_error(&a, &b)); // w1 >= sup
+    }
+
+    #[test]
+    fn tail_prune_drops_low_mass_tail_within_budget() {
+        // 96% in the head bucket, a long 4% tail.
+        let h = vec![960u64, 10, 10, 10, 10];
+        let (p, drop) = tail_prune(&h, 0.05); // allow up to 5% dropped
+        assert!(drop <= 0.05 + 1e-9, "dropped {} exceeds budget", drop);
+        assert!(p.len() < h.len(), "should shorten support");
+        // the dropped fraction is exactly the Kolmogorov error vs the original.
+        assert!((cdf_max_error(&h, &p) - drop).abs() < 1e-9);
+        // a zero budget prunes nothing; a full-mass head is never fully dropped.
+        assert_eq!(tail_prune(&h, 0.0).0, h);
+        assert!(!tail_prune(&h, 1.0).0.is_empty());
+    }
+
+    #[test]
+    fn compress_histogram_is_work_triggered_and_certified() {
+        // short histogram (<= min_points): returned exact regardless of tail.
+        let short = vec![900u64, 1, 1];
+        assert_eq!(compress_histogram(&short, 50, 0.001), short);
+        // long histogram with a tiny prunable tail: compressed within epsilon.
+        let mut long = vec![0u64; 60];
+        long[0] = 1_000_000;
+        for i in 50..60 { long[i] = 1; } // 10 ppm tail
+        let c = compress_histogram(&long, 50, 0.001);
+        assert!(c.len() < long.len(), "long low-tail histogram should compress");
+        assert!(cdf_max_error(&long, &c) <= 0.001 + 1e-9, "error within epsilon_K");
+        // long histogram whose tail mass exceeds epsilon: left exact.
+        let mut heavy = vec![0u64; 60];
+        for i in 0..60 { heavy[i] = 100; } // uniform -> tail is heavy
+        assert_eq!(compress_histogram(&heavy, 50, 0.001), heavy);
     }
 
     // Sample DAG (child -> parents), root = 0. Diamonds produce multiple paths

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -1265,6 +1265,33 @@ impl WamState {
         self.boundary_basis_wp = basis.into_iter().collect();
     }
 
+    /// OPT-IN storage-gated compression of the cached `boundary_suffix` histograms
+    /// (P4, the exact->approximate ladder). Applies `boundary_cache::compress_
+    /// histogram` to each entry: the support count `> min_points` is the WORK
+    /// TRIGGER, and acceptance is the `epsilon_k` Kolmogorov certificate (so a kept
+    /// histogram is exact and a compressed one differs by at most `epsilon_k` tail
+    /// mass — making the splice APPROXIMATE within that bound for the affected
+    /// nodes). The cache stays exact unless this is called. Returns
+    /// `(entries_compressed, buckets_removed)`. For typical small-budget boundary
+    /// histograms (support <= budget+1) nothing triggers; this is for large-budget
+    /// / deep-path graphs. Defaults: `DEFAULT_COMPRESS_MIN_POINTS` (50),
+    /// `DEFAULT_COMPRESS_EPSILON_K` (0.001).
+    pub fn compress_boundary_suffix(&mut self, min_points: usize, epsilon_k: f64) -> (usize, usize) {
+        let mut compressed = 0usize;
+        let mut removed = 0usize;
+        let nodes: Vec<u32> = self.boundary_suffix.keys().copied().collect();
+        for node in nodes {
+            let h = self.boundary_suffix.get(&node).cloned().unwrap_or_default();
+            let c = crate::boundary_cache::compress_histogram(&h, min_points, epsilon_k);
+            if c.len() < h.len() {
+                compressed += 1;
+                removed += h.len() - c.len();
+                self.boundary_suffix.insert(node, c);
+            }
+        }
+        (compressed, removed)
+    }
+
     /// Direct `weighted_power(N)` WeightSum via the pre-weighted basis (P4).
     /// Walks `cat_id -> root` exactly like `collect_native_category_ancestor_
     /// boundary_hist`, but instead of building a histogram it accumulates the
@@ -2583,6 +2610,30 @@ mod boundary_kernel_tests {
             assert!((wref - wsp).abs() < 1e-12, "frontier seed {}: {} != {}", s, wref, wsp);
             assert!(wref > 0.0, "seed {} should reach root", s);
         }
+    }
+
+    // P4: opt-in storage-gated compression of the boundary table — work-triggered
+    // by support count, certified by epsilon_K, and a no-op on short histograms.
+    #[test]
+    fn compress_boundary_suffix_is_opt_in_and_certified() {
+        let mut vm = WamState::new(vec![], HashMap::new());
+        // one long low-tail histogram (compressible), one short one (untouched).
+        let mut long = vec![0u64; 60];
+        long[0] = 1_000_000;
+        for i in 50..60 { long[i] = 1; }
+        let short = vec![900u64, 1, 1];
+        let mut table: HashMap<u32, Vec<u64>> = HashMap::new();
+        table.insert(1, long.clone());
+        table.insert(2, short.clone());
+        vm.set_boundary_suffix(&table);
+        let (compressed, removed) = vm.compress_boundary_suffix(50, 0.001);
+        assert_eq!(compressed, 1, "only the long low-tail histogram compresses");
+        assert!(removed > 0);
+        let got_long = vm.boundary_suffix.get(&1).unwrap();
+        assert!(got_long.len() < long.len(), "long histogram shortened");
+        assert!(crate::boundary_cache::cdf_max_error(&long, got_long) <= 0.001 + 1e-9,
+            "compression stays within epsilon_K");
+        assert_eq!(vm.boundary_suffix.get(&2).unwrap(), &short, "short histogram untouched");
     }
 
     // P4: the pre-weighted weighted_power basis (g_B dot-product splice) yields the


### PR DESCRIPTION
Default rules for approximation, ported from the Python distribution-cache line — with one important correction to the 50-point rule of thumb.

## What the Python prototype actually does

I checked `DISTRIBUTIONAL_COMPRESSION_THEORY.md` and the `scripts/distribution_*.py` line. Two principles, both preserved here:

1. **The point count is a *work trigger*, not an acceptance gate.** The theory doc explicitly replaces *"is this over 50 points?"* with *"which representation is cheapest at the requested error tolerance?"* — so 50 decides *when to try* compressing, but **acceptance is an error certificate**: Kolmogorov `ε_K = max|ΔCDF|` (default `0.001`), optionally Wasserstein-1 (bounds Lipschitz-functional error). Your "50 points → approximate (granted, may not be optimal)" intuition is right as the *trigger*; the gate is the certified CDF error.
2. **Discrete-first ladder:** exact → **tail-pruned exact** → quantised-CDF → binomial → mixture-of-binomials → (GMM as *escalation only* — bounded integer path-length data favour binomial families). Python's first rung and tail-prune defaults `[0.01, 0.001, 0.0001]`.

## Ported (rung 1)

- `boundary_cache.rs`: `cdf_max_error` (Kolmogorov), `cdf_w1_error` (Wasserstein-1), `tail_prune(h, max_drop)` (drop the longest suffix whose cumulative mass ≤ budget — the dropped fraction *is* the Kolmogorov error), `compress_histogram` (work-triggered + certified), and the defaults.
- `state.rs`: `compress_boundary_suffix(min_points, ε_K)` — **opt-in** table compression. The cache stays exact unless called; a compressed node differs by at most `ε_K`.

**Important caveat (documented):** typical boundary histograms have support ≤ `budget`+1, so for the small-budget effective-distance query the trigger *never fires*. This matters for **large-budget / deep-path** graph search where the histograms are long. (And it dovetails with `g_B`: a thin entry-frontier band already keeps node count small, so approximation is about the *long-histogram* regime, not the node-count regime.)

## Your other points, recorded

- **Spill should not be default** — recorded as a design decision in the plan: spill engages only when the in-memory cache is too small for the problem *and* LMDB is confirmed available (installed / writable env), else fall back to stop-at-depth.
- **heed parity / lazy-path** — explained in the thread; both remain optional follow-ups.

## Tests (23 lib tests pass)

`cdf_errors_basic`, `tail_prune_drops_low_mass_tail_within_budget`, `compress_histogram_is_work_triggered_and_certified`, `compress_boundary_suffix_is_opt_in_and_certified`. Spec §9a documents the ladder; plan marks rung 1 done, fitted forms (binomial/mixture) next.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_