### PR TITLE
feat(wam-rust): binomial mixtures + budget-mode choice + fitted-repr persistence

### DIFF
--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -1,6 +1,6 @@
 # WAM-Rust Boundary Distribution Optimization — Implementation Plan
 
-Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction, P2c-wiring/precompute/persistence, P3-measurement, P4-g_B-basis, P4-entry-frontier, P4-approx-rung1, P4-approx-rung2-binomial, P4-approx-cdf-fit DONE). The implementation-plan member of
+Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction, P2c-wiring/precompute/persistence, P3-measurement, P4-g_B-basis, P4-entry-frontier, P4-approx-rung1, P4-approx-rung2-binomial, P4-approx-cdf-fit, P4-approx-mixture, P4-approx-budget-mode, P4-repr-persistence DONE). The implementation-plan member of
 the design trio: **`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md`** (why — a
 disablable complexity-reduction compiler optimization, caching secondary),
 **`WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md`** (precise semantics, the
@@ -358,10 +358,20 @@ Phasing:
     lower-bandwidth). `choose_representation` tries both fits and keeps the
     lower-error one. Validated: the CDF fit is ≤ the moment fit on W1 and strictly
     better when the mean is pulled by local PMF contamination.
-  - **Fitted forms [next].** beta-binomial (over-dispersion) and
-    mixture-of-binomials (EM), discretised-GMM as escalation only, same CDF/W1 gate;
-    plus wiring `choose_representation` into the persisted `boundary_basis` (store
-    binomial params, `expand` on load) to realise the storage win end-to-end.
+  - **Mixture of binomials + multi-objective choice + persistence [DONE].**
+    `fit_binomial_mixture` (EM, shared trials) + `HistRepr::Mixture` fit the
+    multimodal nodes a single binomial rejects (validated: a true 2-binomial mixture
+    is fit and chosen while a single binomial misses the gate).
+    `choose_representation_budget` adds the **storage-driven** complement to the
+    error-driven `choose_representation` — error is not always the binding
+    constraint; `min_points` is a storage proxy, not an intrinsic error gate (need
+    not be 50). End-to-end storage win wired: `WamState::boundary_suffix_reprs` +
+    `encode_repr`/`decode_repr` + `LmdbFactSource::save_boundary_reprs` /
+    `load_boundary_reprs` (the `boundary_basis_repr` sub-db; expand on load).
+    Cargo-gated `test_wam_rust_boundary_repr_lmdb.pl`: a binomial-shaped node persists
+    as ~21 bytes and reloads within `ε_K`; a short node round-trips exactly.
+  - **Fitted forms [next].** beta-binomial (over-dispersion), quantised-CDF table;
+    discretised-GMM as escalation only.
 
 ## 6. What to measure (re-derive, don't inherit)
 

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
@@ -369,10 +369,25 @@ Implemented (Rust, `boundary_cache.rs`):
   the Python `choose_distribution_representation`: the cheapest representation whose
   CDF error is within `ε_K` — exact (error 0), tail-pruned, or binomial (trying both
   fits and keeping the lower-error one). **The gate is a hard reject:** a fit that
-  misses `ε_K` (e.g. a bimodal histogram against a single binomial) is dropped and
-  the exact/tail-pruned form kept, so accuracy never silently degrades. Bounded
-  integer path-length data favour binomials; mixtures / discretised-GMM are the
-  escalation rungs (future).
+  misses `ε_K` is dropped and the exact/tail-pruned form kept, so accuracy never
+  silently degrades.
+- **Rung 3 — mixture of binomials** — `fit_binomial_mixture(h, k, iters)` (EM,
+  shared `trials`, PMF-weighted) fits the multimodal nodes a single binomial rejects
+  (a bottleneck / topic-mixture cone). `HistRepr::Mixture{trials,comps,total}` joins
+  the candidate set (`K = 2,3`). Discretised-GMM stays escalation-only — bounded
+  integer path-length data favour binomial families.
+- **Choice is multi-objective.** `choose_representation` is *error-driven* (cheapest
+  within `ε_K`); `choose_representation_budget` is the *storage-driven* complement
+  (smallest CDF error within a byte budget). Error is not always the binding
+  constraint — memory / storage (or, with a different cost model, compute) often is —
+  so the `min_points` work trigger is best read as a **storage proxy** ("this is
+  getting big"), not an intrinsic error threshold, and need not be exactly 50.
+- **Persistence (storage win, end to end).** `WamState::boundary_suffix_reprs` chooses
+  a representation per cached node; `encode_repr`/`decode_repr` pack it (self-
+  describing tag + fields); `LmdbFactSource::save_boundary_reprs` / `load_boundary_
+  reprs` persist to the `boundary_basis_repr` sub-db and **expand** on load (a
+  binomial node stores ~21 bytes instead of a histogram; a fitted node reconstructs
+  within its `ε_K` certificate).
 - `compress_histogram` / `WamState::compress_boundary_suffix(min_points, ε_K)` apply
   rung 1 across the cached table.
 

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -379,24 +379,31 @@ pub fn fit_binomial_cdf(h: &Hist) -> (usize, f64) {
 pub enum HistRepr {
     Exact(Hist),
     Binomial { trials: usize, p: f64, total: u64 },
+    /// Mixture of binomials (shared `trials`); `comps` are `(weight, p)` pairs.
+    /// The escalation rung for multimodal nodes a single binomial cannot fit.
+    Mixture { trials: usize, comps: Vec<(f64, f64)>, total: u64 },
 }
 
 impl HistRepr {
-    /// Approximate stored size in bytes (the cost the chooser minimises).
+    /// Approximate stored size in bytes (the cost the chooser minimises). Matches
+    /// the `encode_repr` wire size: a 1-byte tag plus the fields.
     pub fn bytes(&self) -> usize {
         match self {
-            HistRepr::Exact(h) => 4 + h.len() * 8,     // u32 len prefix + u64 counts
-            HistRepr::Binomial { .. } => 4 + 8 + 8,    // trials u32 + p f64 + total u64
+            HistRepr::Exact(h) => 1 + 4 + h.len() * 8,      // tag + u32 len + u64 counts
+            HistRepr::Binomial { .. } => 1 + 4 + 8 + 8,     // tag + trials + p + total
+            HistRepr::Mixture { comps, .. } => 1 + 4 + 4 + comps.len() * 16 + 8,
         }
     }
-    /// Reconstruct a count histogram (a binomial is expanded, scaled to `total`,
-    /// and rounded). The kernel always consumes counts, so a fitted node expands
-    /// on load.
+    /// Reconstruct a count histogram (parametric forms expand to the PMF scaled to
+    /// `total` and rounded). The kernel always consumes counts, so a fitted node
+    /// expands on load.
     pub fn expand(&self) -> Hist {
         match self {
             HistRepr::Exact(h) => h.clone(),
-            HistRepr::Binomial { trials, p, total } => binomial_pmf(*trials, *p)
-                .iter().map(|&pr| (pr * *total as f64).round() as u64).collect(),
+            _ => {
+                let total = self.total() as f64;
+                self.pmf().iter().map(|&pr| (pr * total).round() as u64).collect()
+            }
         }
     }
     /// The PMF of this representation.
@@ -404,49 +411,205 @@ impl HistRepr {
         match self {
             HistRepr::Exact(h) => to_pmf(h),
             HistRepr::Binomial { trials, p, .. } => binomial_pmf(*trials, *p),
+            HistRepr::Mixture { trials, comps, .. } => mixture_pmf(*trials, comps),
+        }
+    }
+    fn total(&self) -> u64 {
+        match self {
+            HistRepr::Exact(h) => h.iter().sum(),
+            HistRepr::Binomial { total, .. } | HistRepr::Mixture { total, .. } => *total,
         }
     }
 }
 
-/// Choose the cheapest (fewest bytes) representation of `h` whose Kolmogorov CDF
-/// error vs the exact histogram is within `epsilon_k`. Candidates: exact (always
-/// admissible, error 0), tail-pruned exact (rung 1), and the method-of-moments
-/// binomial (rung 2). Mirrors the Python `choose_distribution_representation`:
-/// cheapest within the error policy. The support count `> min_points` is the WORK
-/// TRIGGER for the lossy candidates; below it, exact is returned unchanged.
-pub fn choose_representation(h: &Hist, min_points: usize, epsilon_k: f64) -> HistRepr {
-    let exact = HistRepr::Exact(h.clone());
-    if h.len() <= min_points {
-        return exact;
-    }
-    let exact_pmf = to_pmf(h);
-    let mut best = exact.clone();
-    let mut best_bytes = exact.bytes();
-    // rung 1: tail-pruned exact (error == dropped fraction)
-    let (pruned, drop) = tail_prune(h, epsilon_k);
-    if pruned.len() < h.len() && drop <= epsilon_k {
-        let cand = HistRepr::Exact(pruned);
-        if cand.bytes() < best_bytes { best_bytes = cand.bytes(); best = cand; }
-    }
-    // rung 2: parametric binomial — try BOTH the moment fit and the CDF-space fit,
-    // keep whichever passes the gate with the smaller CDF error. The CDF fit
-    // optimises the cumulative (integral) form directly, so it is usually <= the
-    // moment fit on the metric the gate uses.
-    let total: u64 = h.iter().sum();
-    let mut best_binom: Option<(f64, HistRepr)> = None;
-    for (trials, p) in [fit_binomial(h), fit_binomial_cdf(h)] {
-        let err = cdf_max_error_pmf(&exact_pmf, &binomial_pmf(trials, p));
-        if err <= epsilon_k {
-            match &best_binom {
-                Some((be, _)) if *be <= err => {}
-                _ => best_binom = Some((err, HistRepr::Binomial { trials, p, total })),
-            }
+/// PMF of a binomial mixture: `sum_k w_k * Binomial(trials, p_k)`.
+pub fn mixture_pmf(trials: usize, comps: &[(f64, f64)]) -> Vec<f64> {
+    let mut out = vec![0.0f64; trials + 1];
+    for &(w, p) in comps {
+        for (i, &bi) in binomial_pmf(trials, p).iter().enumerate() {
+            if i < out.len() { out[i] += w * bi; }
         }
     }
-    if let Some((_, cand)) = best_binom {
-        if cand.bytes() < best_bytes { best = cand; }
+    out
+}
+
+/// Fit a `k`-component binomial mixture by EM (shared `trials = support-1`),
+/// weighted by the empirical PMF. Components start with `p` spread across (0,1) and
+/// equal weights; `iters` EM sweeps. Handles the multimodal nodes a single binomial
+/// rejects. Returns `(trials, [(weight, p)])`.
+pub fn fit_binomial_mixture(h: &Hist, k: usize, iters: usize) -> (usize, Vec<(f64, f64)>) {
+    let pmf = to_pmf(h);
+    let trials = pmf.len().saturating_sub(1);
+    let k = k.max(1);
+    if trials == 0 {
+        return (trials, vec![(1.0, 0.0)]);
     }
-    best
+    let mut comps: Vec<(f64, f64)> = (0..k)
+        .map(|j| (1.0 / k as f64, (j as f64 + 0.5) / k as f64))
+        .collect();
+    let n = pmf.len();
+    for _ in 0..iters {
+        let comp_pmfs: Vec<Vec<f64>> = comps.iter().map(|&(_, p)| binomial_pmf(trials, p)).collect();
+        let mut new_w = vec![0.0f64; k];
+        let mut num = vec![0.0f64; k]; // sum_i pmf[i] r_ij (i/trials)
+        for i in 0..n {
+            if pmf[i] <= 0.0 { continue; }
+            let mut resp = vec![0.0f64; k];
+            let mut denom = 0.0f64;
+            for j in 0..k {
+                let v = comps[j].0 * comp_pmfs[j].get(i).copied().unwrap_or(0.0);
+                resp[j] = v;
+                denom += v;
+            }
+            if denom <= 0.0 { continue; }
+            let frac = i as f64 / trials as f64;
+            for j in 0..k {
+                let wj = pmf[i] * (resp[j] / denom);
+                new_w[j] += wj;
+                num[j] += wj * frac;
+            }
+        }
+        let wsum: f64 = new_w.iter().sum();
+        if wsum <= 0.0 { break; }
+        for j in 0..k {
+            let w = new_w[j] / wsum;
+            let p = if new_w[j] > 0.0 { (num[j] / new_w[j]).clamp(0.0, 1.0) } else { comps[j].1 };
+            comps[j] = (w, p);
+        }
+    }
+    (trials, comps)
+}
+
+/// All candidate representations of `h`, each paired with its certified CDF error
+/// vs exact. Always includes `Exact` (error 0). Adds the lossy rungs — tail-pruned
+/// exact, single binomial (both fits), and K=2/3 binomial mixtures — only when the
+/// support count exceeds `min_points` (the work trigger / storage proxy).
+fn representation_candidates(h: &Hist, min_points: usize) -> Vec<(HistRepr, f64)> {
+    let mut cands: Vec<(HistRepr, f64)> = vec![(HistRepr::Exact(h.clone()), 0.0)];
+    if h.len() <= min_points {
+        return cands;
+    }
+    let exact_pmf = to_pmf(h);
+    let total: u64 = h.iter().sum();
+    for thr in [0.0001f64, 0.001, 0.01] {
+        let (pruned, drop) = tail_prune(h, thr);
+        if pruned.len() < h.len() {
+            cands.push((HistRepr::Exact(pruned), drop)); // dropped mass IS the Kolmogorov error
+        }
+    }
+    for (trials, p) in [fit_binomial(h), fit_binomial_cdf(h)] {
+        let err = cdf_max_error_pmf(&exact_pmf, &binomial_pmf(trials, p));
+        cands.push((HistRepr::Binomial { trials, p, total }, err));
+    }
+    for k in [2usize, 3] {
+        let (trials, comps) = fit_binomial_mixture(h, k, 60);
+        let err = cdf_max_error_pmf(&exact_pmf, &mixture_pmf(trials, &comps));
+        cands.push((HistRepr::Mixture { trials, comps, total }, err));
+    }
+    cands
+}
+
+/// ERROR-driven choice: the cheapest (fewest bytes) representation whose CDF error
+/// is within `epsilon_k`. Mirrors the Python `choose_distribution_representation`.
+/// `Exact` is always admissible, so this never fails. The support count
+/// `> min_points` is the work trigger for the lossy rungs.
+pub fn choose_representation(h: &Hist, min_points: usize, epsilon_k: f64) -> HistRepr {
+    representation_candidates(h, min_points).into_iter()
+        .filter(|(_, e)| *e <= epsilon_k)
+        .min_by(|(a, ea), (b, eb)| a.bytes().cmp(&b.bytes()).then(ea.partial_cmp(eb).unwrap()))
+        .map(|(r, _)| r)
+        .unwrap_or_else(|| HistRepr::Exact(h.clone()))
+}
+
+/// STORAGE-driven choice (the multi-objective complement): among candidates that
+/// fit within `max_bytes`, the one with the SMALLEST CDF error — i.e. storage is
+/// the binding constraint and error is what gets minimised, not the other way
+/// round. Falls back to the smallest-byte candidate when nothing fits the budget.
+/// (Memory / storage — or, with a different cost, compute — can be the real
+/// objective; the point count is just a storage proxy for "this is getting big".)
+pub fn choose_representation_budget(h: &Hist, min_points: usize, max_bytes: usize) -> HistRepr {
+    let cands = representation_candidates(h, min_points);
+    cands.iter()
+        .filter(|(r, _)| r.bytes() <= max_bytes)
+        .min_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+        .map(|(r, _)| r.clone())
+        .unwrap_or_else(|| {
+            cands.iter().min_by_key(|(r, _)| r.bytes()).map(|(r, _)| r.clone()).unwrap()
+        })
+}
+
+/// Encode a `HistRepr` to a self-describing byte string (1-byte tag + fields), so
+/// a chosen representation can be persisted (the `boundary_basis_repr` LMDB sub-db)
+/// and `expand`ed on load. Tags: 0 = Exact, 1 = Binomial, 2 = Mixture.
+pub fn encode_repr(r: &HistRepr) -> Vec<u8> {
+    let mut out = Vec::new();
+    match r {
+        HistRepr::Exact(h) => {
+            out.push(0u8);
+            out.extend_from_slice(&encode_hist(h));
+        }
+        HistRepr::Binomial { trials, p, total } => {
+            out.push(1u8);
+            out.extend_from_slice(&(*trials as u32).to_le_bytes());
+            out.extend_from_slice(&p.to_le_bytes());
+            out.extend_from_slice(&total.to_le_bytes());
+        }
+        HistRepr::Mixture { trials, comps, total } => {
+            out.push(2u8);
+            out.extend_from_slice(&(*trials as u32).to_le_bytes());
+            out.extend_from_slice(&(comps.len() as u32).to_le_bytes());
+            for &(w, p) in comps {
+                out.extend_from_slice(&w.to_le_bytes());
+                out.extend_from_slice(&p.to_le_bytes());
+            }
+            out.extend_from_slice(&total.to_le_bytes());
+        }
+    }
+    out
+}
+
+fn read_u32(b: &[u8], o: usize) -> u32 {
+    u32::from_le_bytes([b[o], b[o + 1], b[o + 2], b[o + 3]])
+}
+fn read_f64(b: &[u8], o: usize) -> f64 {
+    let mut a = [0u8; 8];
+    a.copy_from_slice(&b[o..o + 8]);
+    f64::from_le_bytes(a)
+}
+fn read_u64(b: &[u8], o: usize) -> u64 {
+    let mut a = [0u8; 8];
+    a.copy_from_slice(&b[o..o + 8]);
+    u64::from_le_bytes(a)
+}
+
+/// Decode a `HistRepr` produced by `encode_repr`. An empty / unrecognised buffer
+/// decodes to `Exact([])`.
+pub fn decode_repr(b: &[u8]) -> HistRepr {
+    if b.is_empty() {
+        return HistRepr::Exact(Vec::new());
+    }
+    match b[0] {
+        0 => HistRepr::Exact(decode_hist(&b[1..])),
+        1 if b.len() >= 1 + 4 + 8 + 8 => HistRepr::Binomial {
+            trials: read_u32(b, 1) as usize,
+            p: read_f64(b, 5),
+            total: read_u64(b, 13),
+        },
+        2 if b.len() >= 1 + 4 + 4 => {
+            let trials = read_u32(b, 1) as usize;
+            let k = read_u32(b, 5) as usize;
+            let mut comps = Vec::with_capacity(k);
+            let mut o = 9;
+            for _ in 0..k {
+                if o + 16 > b.len() { break; }
+                comps.push((read_f64(b, o), read_f64(b, o + 8)));
+                o += 16;
+            }
+            let total = if o + 8 <= b.len() { read_u64(b, o) } else { 0 };
+            HistRepr::Mixture { trials, comps, total }
+        }
+        _ => HistRepr::Exact(Vec::new()),
+    }
 }
 
 #[cfg(test)]
@@ -541,15 +704,60 @@ mod tests {
         assert!(cdf_max_error(&h, &repr.expand()) <= 0.01 + 1e-6);
     }
 
-    // A bimodal (non-binomial) histogram fails the gate -> exact/tail-pruned kept.
+    // A bimodal histogram: a single binomial fails the gate, but the mixture rung
+    // (escalation) fits it — and the chooser picks the Mixture (cheaper than exact).
     #[test]
-    fn choose_representation_rejects_bad_fit() {
-        let mut h = vec![0u64; 60];
-        for i in 3..8 { h[i] = 1000; }     // peak near 5
-        for i in 53..58 { h[i] = 1000; }   // peak near 55
+    fn mixture_fits_bimodal_single_binomial_rejects() {
+        // a genuine two-binomial mixture (modes a single binomial cannot span).
+        let trials = 59usize;
+        let lo = binomial_pmf(trials, 0.15);
+        let hi = binomial_pmf(trials, 0.85);
+        let h: Hist = (0..=trials)
+            .map(|i| ((0.5 * lo[i] + 0.5 * hi[i]) * 1_000_000.0).round() as u64)
+            .collect();
+        let exact_pmf = to_pmf(&h);
+        // single binomial cannot fit a bimodal shape
+        let (tb, pb) = fit_binomial(&h);
+        assert!(cdf_max_error_pmf(&exact_pmf, &binomial_pmf(tb, pb)) > 0.01,
+            "single binomial should miss the gate on a bimodal histogram");
+        // the K=2 mixture does
+        let (tm, comps) = fit_binomial_mixture(&h, 2, 60);
+        assert!(cdf_max_error_pmf(&exact_pmf, &mixture_pmf(tm, &comps)) <= 0.01,
+            "K=2 mixture should fit the bimodal histogram");
+        // and the chooser selects the Mixture (smaller than the exact 60-bucket hist)
         let repr = choose_representation(&h, 10, 0.01);
-        assert!(matches!(repr, HistRepr::Exact(_)),
-            "a bimodal histogram must not be fit by a single binomial: {:?}", repr);
+        assert!(matches!(repr, HistRepr::Mixture { .. }),
+            "expected Mixture for the bimodal histogram, got {:?}", repr);
+        assert!(repr.bytes() < HistRepr::Exact(h.clone()).bytes());
+    }
+
+    // Storage-budget chooser: a tight byte budget forces the smallest representation
+    // even past the error gate; a generous budget recovers the exact form.
+    #[test]
+    fn budget_chooser_respects_storage() {
+        let (trials, p) = (20usize, 0.4f64);
+        let h: Hist = binomial_pmf(trials, p).iter()
+            .map(|&pr| (pr * 1_000_000.0).round() as u64).collect();
+        // tight budget -> a parametric form (<= 49 bytes), not the exact histogram
+        let tight = choose_representation_budget(&h, 10, 30);
+        assert!(tight.bytes() <= 30, "must fit the byte budget");
+        assert!(!matches!(tight, HistRepr::Exact(_)), "tight budget rejects exact");
+        // huge budget -> exact is admissible and has the smallest error (0)
+        let loose = choose_representation_budget(&h, 10, 1_000_000);
+        assert!(matches!(loose, HistRepr::Exact(_)), "loose budget keeps exact (error 0)");
+    }
+
+    #[test]
+    fn encode_decode_repr_roundtrip() {
+        let reprs = [
+            HistRepr::Exact(vec![0u64, 3, 1, 0, 5]),
+            HistRepr::Binomial { trials: 12, p: 0.37, total: 9999 },
+            HistRepr::Mixture { trials: 20, comps: vec![(0.6, 0.2), (0.4, 0.8)], total: 12345 },
+        ];
+        for r in reprs {
+            assert_eq!(decode_repr(&encode_repr(&r)), r, "repr roundtrip {:?}", r);
+        }
+        assert_eq!(decode_repr(&[]), HistRepr::Exact(vec![]));
     }
 
     // Fitting in CDF space (minimising W1, the integral form) is at least as good

--- a/templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache
+++ b/templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache
@@ -225,6 +225,62 @@ impl LmdbFactSource {
         Ok(())
     }
 
+    /// Persist *fitted* boundary representations (exact / tail-pruned / binomial /
+    /// mixture, chosen by `WamState::boundary_suffix_reprs`) to the
+    /// `boundary_basis_repr` sub-db. This realises the storage win: a node that fits
+    /// a binomial stores ~21 bytes instead of a full histogram. Values are packed by
+    /// `boundary_cache::encode_repr` (self-describing tag + fields).
+    pub fn save_boundary_reprs(
+        &self, table: &HashMap<u32, crate::boundary_cache::HistRepr>,
+    ) -> Result<(), lmdb::Error> {
+        let db = lmdb::Database::open(
+            Arc::clone(&self.env),
+            Some("boundary_basis_repr"),
+            &lmdb::DatabaseOptions::new(lmdb::db::CREATE),
+        )?;
+        let txn = lmdb::WriteTransaction::new(&*self.env)?;
+        {
+            let mut access = txn.access();
+            for (&node, repr) in table {
+                let key = node.to_le_bytes();
+                let val = crate::boundary_cache::encode_repr(repr);
+                access.put(&db, &key[..], &val[..], lmdb::put::Flags::empty())?;
+            }
+        }
+        txn.commit()?;
+        Ok(())
+    }
+
+    /// Load the `boundary_basis_repr` sub-db and **expand** each representation back
+    /// to a count histogram (the kernel always consumes counts), ready for
+    /// `WamState::set_boundary_suffix`. Empty when the sub-db is absent. A fitted
+    /// node reconstructs within its `epsilon_k` certificate.
+    pub fn load_boundary_reprs(&self) -> Result<HashMap<u32, Vec<u64>>, lmdb::Error> {
+        let db = match lmdb::Database::open(
+            Arc::clone(&self.env),
+            Some("boundary_basis_repr"),
+            &lmdb::DatabaseOptions::new(lmdb::db::Flags::empty()),
+        ) {
+            Ok(db) => db,
+            Err(_) => return Ok(HashMap::new()),
+        };
+        let txn = lmdb::ReadTransaction::new(&*self.env)?;
+        let access = txn.access();
+        let mut cursor = txn.cursor(&db)?;
+        let mut out = HashMap::new();
+        match cursor.first::<[u8], [u8]>(&access) {
+            Ok((k, v)) => {
+                out.insert(decode_u32(k), crate::boundary_cache::decode_repr(v).expand());
+                while let Ok((k, v)) = cursor.next::<[u8], [u8]>(&access) {
+                    out.insert(decode_u32(k), crate::boundary_cache::decode_repr(v).expand());
+                }
+            }
+            Err(lmdb::Error::Code(lmdb_zero::error::NOTFOUND)) => {}
+            Err(e) => return Err(e),
+        }
+        Ok(out)
+    }
+
     /// Look up all parents of `child_id` via cursor MDB_SET + MDB_NEXT_DUP.
     /// Returns an empty Vec if the key is absent.
     pub fn lookup_parents(&self, child_id: i32) -> Result<Vec<i32>, lmdb::Error> {

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -1292,6 +1292,20 @@ impl WamState {
         (compressed, removed)
     }
 
+    /// Choose a storage representation (`boundary_cache::choose_representation`) for
+    /// each cached `boundary_suffix` histogram — exact, tail-pruned, binomial, or
+    /// mixture, the cheapest within the `epsilon_k` CDF certificate. The result is
+    /// the persistable form for the `boundary_basis_repr` LMDB sub-db
+    /// (`LmdbFactSource::save_boundary_reprs`); a later run `load_boundary_reprs`
+    /// expands them back to histograms. Does not mutate the in-memory cache.
+    pub fn boundary_suffix_reprs(
+        &self, min_points: usize, epsilon_k: f64,
+    ) -> HashMap<u32, crate::boundary_cache::HistRepr> {
+        self.boundary_suffix.iter()
+            .map(|(&k, h)| (k, crate::boundary_cache::choose_representation(h, min_points, epsilon_k)))
+            .collect()
+    }
+
     /// Direct `weighted_power(N)` WeightSum via the pre-weighted basis (P4).
     /// Walks `cat_id -> root` exactly like `collect_native_category_ancestor_
     /// boundary_hist`, but instead of building a histogram it accumulates the

--- a/tests/test_wam_rust_boundary_repr_lmdb.pl
+++ b/tests/test_wam_rust_boundary_repr_lmdb.pl
@@ -1,0 +1,108 @@
+% test_wam_rust_boundary_repr_lmdb.pl
+%
+% Wire choose_representation into the persisted boundary cache (the storage win,
+% end to end): WamState::boundary_suffix_reprs picks a fitted form (exact /
+% tail-pruned / binomial / mixture) per cached histogram; LmdbFactSource::
+% save_boundary_reprs persists them to the boundary_basis_repr sub-db; a later run
+% load_boundary_reprs decodes + EXPANDS them back to histograms within the epsilon_K
+% certificate. Validated in a generated lmdb_zero crate.
+%
+% cargo-gated (needs the lmdb-zero crate to build).
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+
+:- dynamic brl_fact/2.
+brl_fact(a, b).
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- begin_tests(wam_rust_boundary_repr_lmdb).
+
+test(boundary_repr_persist_roundtrip,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_brl'))]) :-
+    Dir = 'output/test_brl',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project([user:brl_fact/2],
+        [module_name(brl), lmdb_mode(cursor), lmdb_crate(lmdb_zero)], Dir)),
+    atom_concat(Dir, '/src/lmdb_fact_source.rs', LmdbRs),
+    read_file_to_string(LmdbRs, LSrc, []),
+    sub_string(LSrc, _, _, _, "pub fn save_boundary_reprs"),
+    sub_string(LSrc, _, _, _, "pub fn load_boundary_reprs"),
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/brl_test.rs', TestPath),
+    TestSrc = '
+use brl::state::WamState;
+use brl::lmdb_fact_source::LmdbFactSource;
+use brl::boundary_cache::{HistRepr, binomial_pmf, cdf_max_error};
+use lmdb_zero as lmdb;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[test]
+fn boundary_repr_roundtrip() {
+    let dir = std::env::temp_dir().join(format!("brl_it_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.to_str().unwrap();
+    {
+        let env = unsafe {
+            let mut b = lmdb::EnvBuilder::new().unwrap();
+            b.set_maxdbs(16).unwrap();
+            b.set_mapsize(64 * 1024 * 1024).unwrap();
+            b.open(path, lmdb::open::Flags::empty(), 0o600).unwrap()
+        };
+        let env = Arc::new(env);
+        for name in ["s2i", "i2s"] {
+            let _ = lmdb::Database::open(Arc::clone(&env), Some(name),
+                &lmdb::DatabaseOptions::new(lmdb::db::CREATE)).unwrap();
+        }
+        for name in ["category_parent", "category_child"] {
+            let _ = lmdb::Database::open(Arc::clone(&env), Some(name),
+                &lmdb::DatabaseOptions::new(lmdb::db::CREATE | lmdb::db::DUPSORT)).unwrap();
+        }
+    }
+    let src = LmdbFactSource::open(path).unwrap();
+    // a long, compressible (binomial-shaped) histogram + a short one.
+    let long: Vec<u64> = binomial_pmf(59, 0.4).iter()
+        .map(|&pr| (pr * 1_000_000.0).round() as u64).collect();
+    let short = vec![900u64, 1, 1];
+    let mut table: HashMap<u32, Vec<u64>> = HashMap::new();
+    table.insert(1, long.clone());
+    table.insert(2, short.clone());
+    let mut vm = WamState::new(vec![], HashMap::new());
+    vm.set_boundary_suffix(&table);
+    // choose a representation per node (work trigger 10, epsilon_K 0.01).
+    let reprs = vm.boundary_suffix_reprs(10, 0.01);
+    assert!(!matches!(reprs.get(&1).unwrap(), HistRepr::Exact(_)),
+        "long binomial-shaped histogram should compress to a parametric form");
+    assert!(matches!(reprs.get(&2).unwrap(), HistRepr::Exact(_)),
+        "short histogram stays exact");
+    // persist + reload (expanded back to counts).
+    src.save_boundary_reprs(&reprs).unwrap();
+    let loaded = src.load_boundary_reprs().unwrap();
+    assert!(cdf_max_error(&long, loaded.get(&1).unwrap()) <= 0.01 + 1e-6,
+        "expanded fit within the epsilon_K certificate");
+    assert_eq!(loaded.get(&2).unwrap(), &short, "exact node round-trips identically");
+    let _ = std::fs::remove_dir_all(&dir);
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    format(atom(Cmd), 'cd "~w" && cargo test --test brl_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[boundary repr lmdb FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_boundary_repr_lmdb).


### PR DESCRIPTION
Items (1) and (2) together, plus the multi-objective framing from your side note.

## (2) Mixture of binomials — the escalation rung

A single binomial can't fit a multimodal node (a bottleneck / topic-mixture cone). `fit_binomial_mixture(h, k, iters)` does EM (shared `trials`, PMF-weighted); `HistRepr::Mixture{trials, comps, total}` joins the candidate set (`K = 2,3`). Validated: a genuine 2-binomial mixture is **fit and chosen** while a single binomial **misses the gate** on the same histogram. Discretised-GMM stays escalation-only (bounded integer path-length data favour binomials).

## (1) Fitted-representation persistence — the storage win, end to end

- `encode_repr`/`decode_repr` — self-describing tagged wire format (exact / binomial / mixture).
- `WamState::boundary_suffix_reprs(min_points, ε_K)` — choose a representation per cached node.
- `LmdbFactSource::save_boundary_reprs` / `load_boundary_reprs` — persist to the `boundary_basis_repr` sub-db and **expand** back to histograms on load. A binomial node stores **~21 bytes instead of a full histogram**.
- Cargo-gated `test_wam_rust_boundary_repr_lmdb.pl`: a binomial-shaped node persists compactly and reloads within `ε_K`; a short node round-trips exactly.

## Your side note — compression is multi-objective

You're right that framing it purely as error-driven is incomplete: memory/storage (or compute) is often the *binding* constraint. So alongside the error-driven `choose_representation` (cheapest within `ε_K`), there's now `choose_representation_budget` — the **storage-driven** complement: smallest CDF error within a byte budget. And the docs now state plainly that `min_points` is a **storage proxy** ("this is getting big"), not an intrinsic error threshold — so it needn't be 50; it hints at whichever objective (error / memory / storage / compute) actually binds.

## Validation

29 lib tests pass (incl. `mixture_fits_bimodal_single_binomial_rejects`, `budget_chooser_respects_storage`, `encode_decode_repr_roundtrip`) + the cargo-gated LMDB repr round-trip. Spec §9a + plan updated.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua

---
_Generated by [Claude Code](https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua)_