### PR TITLE
fix(wam-rust): switch_on_constant dropped keys (binary search on an unsorted index table)

### DIFF
--- a/docs/reports/wam_rust_t9_fact_table_benchmark.md
+++ b/docs/reports/wam_rust_t9_fact_table_benchmark.md
@@ -71,13 +71,17 @@ timed as a sound baseline; see below).
 
 ## Correctness — why T4 is not a sound baseline
 
-The default T4 shared-table path **silently drops some keys**. With 500 distinct
-keys, `findall(X, edge(k5, X), L)` returned `L = []` while `k0`, `k1`, `k250`,
-`k499` resolved correctly — a pre-existing first-argument `switch_on_constant`
-indexing defect that surfaces at scale (related to, but not fixed by, the
-repeated-key fix in #3188, which addressed multi-clause keys). Because the T4
-baseline returns wrong results for these workloads, a like-for-like speed ratio
-is not meaningful; the comparison is correctness + code size + compile time.
+At the time of this benchmark the default T4 shared-table path **silently dropped
+some keys**. With 500 distinct keys, `findall(X, edge(k5, X), L)` returned
+`L = []` while `k0`, `k1`, `k250`, `k499` resolved correctly — a first-argument
+`switch_on_constant` indexing defect: the runtime binary-searched Atom keys
+assuming a lexically sorted table, but the table is emitted in clause order
+(`k0,k1,..,k9,k10,..`, which is not lexically sorted), so it mis-navigated and
+dropped keys whose clause order differed from lexical order. **Fixed** (the
+`SwitchOnConstant`/`SwitchOnConstantPc` handlers now linear-scan by value
+equality; regression: `tests/test_wam_rust_switch_on_constant_keydrop_exec.pl`).
+At the time, this meant a like-for-like T4 speed ratio was not meaningful, so the
+comparison here is correctness + code size + compile time.
 
 The committed throughput test asserts every one of 200 keys resolves to its
 exact row (and that no extra solution remains), so it also guards against this
@@ -92,5 +96,6 @@ minutes-to-never, emits no interpreter code, and is correct at scale**, at a
 point-lookup latency of ~8 µs/query. Recommended for any sizeable ground-fact
 predicate; gated behind `fact_table_inline(true)` so default output is unchanged.
 
-Follow-on (separate from T9): fix the T4 `switch_on_constant` key-dropping defect
-so the WAM path is also correct for large many-key fact sets.
+The T4 `switch_on_constant` key-dropping defect surfaced here has since been
+fixed (linear scan by value equality), so the WAM path is now correct for
+many-key fact sets too.

--- a/src/unifyweaver/targets/wam_rust_target.pl
+++ b/src/unifyweaver/targets/wam_rust_target.pl
@@ -977,19 +977,13 @@ wam_instruction_arm('Instruction::SwitchOnConstant(table)', Body) :-
     Body = '                let raw = self.get_reg_raw("A1").map(|v| self.deref_var(&v));
                 if let Some(val) = raw {
                     if !val.is_unbound() {
-                        // Find the matching key''s target label.
-                        let target: Option<&str> = if let Value::Atom(ref needle) = val {
-                            // Binary search for Atom keys (table is sorted from BTreeMap)
-                            match table.binary_search_by_key(&needle.as_str(), |(k, _)| {
-                                if let Value::Atom(s) = k { s.as_str() } else { "" }
-                            }) {
-                                Ok(idx) => Some(table[idx].1.as_str()),
-                                Err(_) => None,
-                            }
-                        } else {
-                            // Linear scan for non-Atom (e.g. integer) keys
-                            table.iter().find(|(k, _)| *k == val).map(|(_, l)| l.as_str())
-                        };
+                        // Linear scan by value equality. (A binary search would
+                        // require the table to be sorted by the search key; it is
+                        // emitted in clause order — e.g. k0,k1,..,k9,k10 — which
+                        // is NOT lexicographically sorted, so binary search
+                        // dropped keys whose clause order != lexical order.)
+                        let target: Option<&str> =
+                            table.iter().find(|(k, _)| *k == val).map(|(_, l)| l.as_str());
                         match target {
                             // A key with multiple clauses maps to the "default"
                             // sentinel: fall through to the try_me_else chain that
@@ -1034,22 +1028,13 @@ wam_instruction_arm('Instruction::SwitchOnConstantPc(table)', Body) :-
     Body = '                let raw = self.get_reg_raw("A1").map(|v| self.deref_var(&v));
                 if let Some(val) = raw {
                     if !val.is_unbound() {
-                        if let Value::Atom(ref needle) = val {
-                            match table.binary_search_by_key(&needle.as_str(), |(k, _)| {
-                                if let Value::Atom(s) = k { s.as_str() } else { "" }
-                            }) {
-                                Ok(idx) => {
-                                    self.pc = table[idx].1;
-                                    return true;
-                                }
-                                Err(_) => {}
-                            }
-                        } else {
-                            for (key, target_pc) in table {
-                                if *key == val {
-                                    self.pc = *target_pc;
-                                    return true;
-                                }
+                        // Linear scan by value equality (see SwitchOnConstant:
+                        // the table is in clause order, not lexically sorted, so a
+                        // binary search dropped keys).
+                        for (key, target_pc) in table {
+                            if *key == val {
+                                self.pc = *target_pc;
+                                return true;
                             }
                         }
                         return false;

--- a/tests/test_wam_rust_switch_on_constant_keydrop_exec.pl
+++ b/tests/test_wam_rust_switch_on_constant_keydrop_exec.pl
@@ -1,0 +1,82 @@
+% test_wam_rust_switch_on_constant_keydrop_exec.pl
+%
+% Regression for the switch_on_constant key-dropping bug: the WAM first-arg index
+% (switch_on_constant / *_pc) is emitted in CLAUSE order (k0,k1,..,k9,k10,..),
+% which is NOT lexicographically sorted (k10 < k2). The runtime looked up Atom
+% keys with binary_search_by_key (which assumes a lexically sorted table), so it
+% mis-navigated and dropped keys whose clause order differs from lexical order
+% (e.g. k5 -> no match). Fixed to a linear scan by value equality.
+%
+% Forces the T4/WAM shared-table path with fact_table_inline(false) (T9 fact
+% tables are the default in-range and would otherwise mask this). cargo-gated.
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+
+:- dynamic ek/2.
+% 25 unique atom keys in clause/numeric order (k0..k24): clause order != lexical
+% order, which is exactly what tripped the binary search.
+mk :- forall(between(0, 24, N), ( atom_concat(k, N, K), assertz(ek(K, N)) )).
+:- initialization(mk).
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- begin_tests(wam_rust_switch_on_constant_keydrop_exec).
+
+test(every_key_resolves,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_switch_keydrop'))]) :-
+    Dir = 'output/test_switch_keydrop',
+    safe_rmdir(Dir),
+    % fact_table_inline(false) -> the WAM shared table + switch_on_constant path
+    once(write_wam_rust_project(
+        [user:ek/2], [module_name(sk), fact_table_inline(false)], Dir)),
+    atom_concat(Dir, '/src/lib.rs', LibRs),
+    read_file_to_string(LibRs, Src, []),
+    assertion(sub_string(Src, _, _, _, "SwitchOnConstant")),  % the indexed path
+    assertion(\+ sub_string(Src, _, _, _, "Strategy: fact_table")),  % not T9
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/sk_test.rs', TestPath),
+    TestSrc = '
+use sk::value::Value;
+use sk::state::WamState;
+use sk::{ek_2, shared_wam_program};
+
+fn lookup(n: i64) -> Option<i64> {
+    let (code, labels) = shared_wam_program();
+    let mut vm = WamState::new(code, labels);
+    if ek_2(&mut vm, Value::Atom(format!("k{}", n)), Value::Unbound("X".into())) {
+        if let Some(Value::Integer(v)) = vm.bindings.get("X").cloned() { return Some(v); }
+    }
+    None
+}
+
+#[test]
+fn every_key_resolves() {
+    // Before the fix, keys like k5/k10/k11 (clause order != lexical order) were
+    // dropped by the binary search. Every key must now resolve to its own value.
+    for n in 0..25 {
+        assert_eq!(lookup(n), Some(n), "key k{} must resolve to {}", n, n);
+    }
+    // an unindexed key must still fail cleanly
+    assert_eq!(lookup(999), None, "unknown key fails");
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    format(atom(Cmd), 'cd "~w" && cargo test --test sk_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[switch keydrop exec FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_switch_on_constant_keydrop_exec).


### PR DESCRIPTION
## Bug

The T9 benchmark surfaced a first-argument indexing defect in the WAM (T4) path: with 500 distinct atom keys, `findall(X, edge(k5, X), L)` returned `[]` while `k0`, `k1`, `k250`, `k499` resolved correctly.

**Root cause:** `SwitchOnConstant` / `SwitchOnConstantPc` looked up Atom keys with `binary_search_by_key`, which requires the table to be sorted by the search key. But the index table is emitted in **clause order** (`k0,k1,..,k9,k10,..`) — which is **not** lexicographically sorted (`"k10" < "k2"`). So the binary search mis-navigated and dropped any key whose clause order differed from lexical order. (Distinct from the repeated-key/`default` fix in #3188, which addressed multi-clause keys.)

## Fix

Both handlers now **linear-scan by value equality** — the same approach the already-correct `SwitchOnConstantFallthrough` / `SwitchOnConstantA2` variants use. It is order- and type-independent (atoms and integers alike). Table sizes are small in practice (large fact sets are now handled by T9 inline or external sources), so the O(n) scan is not a concern; correctness beats a fragile sorted-table assumption.

## Test

`tests/test_wam_rust_switch_on_constant_keydrop_exec.pl` (cargo-gated) forces the T4/WAM path with `fact_table_inline(false)` over 25 clause-ordered keys (`k0..k24`, where clause order ≠ lexical order) and asserts:
- every key resolves to its own row,
- an unindexed key fails cleanly.

I verified it **fails without the fix** (keys dropped) and **passes with it**. Broad `test_wam_rust_target`, the repeated-key exec, and the T9 callsite exec are all green. Benchmark report updated to note the defect is fixed.

https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw

---
_Generated by [Claude Code](https://claude.ai/code/session_013gLfigNMgCkxybbp7m6fXw)_