### PR TITLE
feat(wam-rust): lazy (demand-driven) boundary cache + approximation future-work doc

### DIFF
--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -1,6 +1,6 @@
 # WAM-Rust Boundary Distribution Optimization — Implementation Plan
 
-Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction, P2c-wiring/precompute/persistence, P3-measurement, P4-g_B-basis, P4-entry-frontier, P4-approx-rung1, P4-approx-rung2-binomial, P4-approx-cdf-fit, P4-approx-mixture, P4-approx-budget-mode, P4-repr-persistence DONE). The implementation-plan member of
+Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction, P2c-wiring/precompute/persistence, P3-measurement, P4-g_B-basis, P4-entry-frontier, P4-approx-rung1, P4-approx-rung2-binomial, P4-approx-cdf-fit, P4-approx-mixture, P4-approx-budget-mode, P4-repr-persistence, lazy-boundary-cache DONE). The implementation-plan member of
 the design trio: **`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md`** (why — a
 disablable complexity-reduction compiler optimization, caching secondary),
 **`WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md`** (precise semantics, the
@@ -296,6 +296,18 @@ Phasing:
     and `test_wam_rust_boundary_basis_lmdb.pl` — in a generated lmdb_zero crate,
     save -> load -> fresh re-open all return the identical table (cross-run
     persistence). lmdb_zero backend; heed parity is a follow-up.
+  - **Lazy (demand-driven) precompute [DONE].** `lazy_boundary_weightsum` fills the
+    band **on first demand** (per-query / top-down) instead of eagerly up front —
+    only the band-entry nodes the workload touches are computed (spec §8d). Identical
+    results to eager; best for sparse/unknown workloads, streaming queries, or when
+    `D_pre` is hard to pick, and it is the strategy available on the lazy/LMDB edge
+    path (enumerates via the `EdgeAccessor`, no `ffi_facts` needed). Measured (it
+    depends on **workload sparsity × query count K**, steady state being splice-
+    identical): **sparse** workloads favour lazy at every K; **dense + modest K**
+    favours eager (batched precompute beats on-demand warmup); **dense + large K**
+    tips back to lazy; bigger datasets shift toward lazy. Guarded by
+    `lazy_boundary_caches_on_demand_and_matches_eager`; the harness prints the
+    per-config winner.
   - **P2c-wiring/precompute/eviction/spill [later, NOT default].** Spill the *live*
     frontier (and optionally evicted dead interiors) to the `boundary_basis` sub-db
     mid-sweep when even the live budget is exceeded — turning the §8b stop-at-depth

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
@@ -323,6 +323,33 @@ only be considered if even the polynomial precompute became infeasible — at wh
 point the §9 storage ladder (continuous/parametric measure) is the principled
 exact-in-the-limit fallback, again before sampling.
 
+### 8d. Lazy vs eager precompute (evaluation strategy)
+
+The band can be filled two ways — the lazy/eager axis of
+`RECURRENCE_EVALUATION_STRATEGY` applied to the boundary suffixes:
+
+- **Eager** (`build_boundary_suffix_*`): materialise the whole band up front
+  (fixed-point / bottom-up). One batched shared-memo sweep; amortised across all
+  seeds; needs the in-memory `ffi_facts` edge table for the polynomial variants.
+  Best when the band is known and densely reused.
+- **Lazy** (`lazy_boundary_weightsum`): start empty and compute each band node's
+  suffix histogram **on first demand** (per-query / top-down), memoizing it — only
+  the band-entry nodes the workload touches are ever computed. Identical results
+  (any band is exact). Best when the touched subset is sparse or unknown, when there
+  is no good precompute moment (streaming / interactive), or when `D_pre` is hard to
+  pick a priori — the cache self-warms. Also the strategy available on the
+  **lazy/LMDB edge path** (it enumerates via the `EdgeAccessor`, not `ffi_facts`).
+
+Neither dominates, and the choice depends on **workload sparsity × query count K**,
+not a single number. Steady state is identical (both splice once warm), so the
+decision is entirely the *warmup* cost. Measured (`..._MEASUREMENT_2026-06-16.md`
+lazy addendum): **sparse/unknown** workloads favour lazy at every K (eager wastes
+precompute on a band it won't use); a **dense** workload with a **modest** K favours
+eager (batched precompute beats on-demand warmup); a dense workload with **large** K
+tips back to lazy (its smaller warm cache gives marginally faster rounds). Bigger
+datasets shift it toward lazy (the eager band grows with the graph; the touched
+subset is bounded by the workload).
+
 ## 9. Storage / approximation
 
 Exact discrete histograms by default. The §1a backings are the storage/scale

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
@@ -397,6 +397,28 @@ that certified bound for the affected nodes only). For typical small-budget boun
 histograms (support ≤ `budget`+1) the work trigger never fires; this matters at
 **large budget / deep paths**.
 
+### 9b. Remaining ladder rungs (future work)
+
+The error/CDF-gate machinery, the chooser (error- and storage-driven), and the
+persistence path are general — adding a representation is just another candidate in
+`representation_candidates` with a `bytes()` and a `pmf()`/`expand()`. Not yet
+implemented, in rough priority order:
+
+- **Quantised CDF table** — one monotone fixed-point CDF value per retained point
+  (16-bit → error ≤ `2^-16`). Best when prefix-mass / range queries dominate (O(1)
+  reads); a natural fit for the `cdf`/`quantile` result modes (§5).
+- **Beta-binomial** — `(D, α, β)`; the first upgrade when a node is *over-dispersed*
+  for a plain binomial (the CLT regime hasn't fully kicked in). Cheap params, same
+  CDF/W1 gate.
+- **Discretised Gaussian mixture** — `(weight, mean, variance)` per mode; the
+  **escalation-only** family for sharp/narrow modes that the binomial mixture fits
+  poorly. Continuous prior on discrete data, more params per mode — used only after
+  the binomial family fails the gate.
+
+Each rung is justified by **storage at a tolerance**, never compute (the exact
+splice is ~ns), so they are added on demand as large-budget / deep-path workloads
+appear.
+
 ## 10. Non-goals (this spec)
 
 - Changing the production kernel or the default (un-optimized) semantics.

--- a/docs/design/WAM_RUST_BOUNDARY_MEASUREMENT_2026-06-16.md
+++ b/docs/design/WAM_RUST_BOUNDARY_MEASUREMENT_2026-06-16.md
@@ -143,3 +143,57 @@ be re-truncated per query. `g_B` is the fixed-budget/fixed-functional specialisa
 the histogram is the general, budget-flexible form. (Validated:
 `weighted_power_basis_equals_histogram` — `g_B` WeightSum == histogram
 `weighted_power` == full enumeration, same fixed budget.)
+
+## Addendum — lazy (demand-driven) vs eager boundary cache
+
+The eager `build_boundary_suffix_*` precompute materialises the whole band up front
+(the *fixed-point / eager* strategy of `RECURRENCE_EVALUATION_STRATEGY`).
+`WamState::lazy_boundary_weightsum` is the *per-query / lazy* alternative: start
+empty and compute each band node's `node->root` histogram **on first demand**,
+memoizing it — only the band-entry nodes the workload actually touches are computed.
+
+Which wins is **not** a single number — it depends on **workload sparsity** (how
+much of the band the queries touch) and **query count K** (how many rounds amortize
+the warmup). Eager precomputes the *whole region band* — it does not know which
+seeds will be queried — then each round splices; lazy warms only the touched subset
+during round 1, then splices. Apples-to-apples on the same `min_dist <= D_pre = 2`
+band, total cost = (precompute or warmup) + K × steady-round:
+
+```
+                              eager        lazy        winner by K
+config  workload   band  pre_ms touched  warm_ms   K=1     K=10    K=100
+core120 dense 500   65   0.80    54      1.93      eager   eager   LAZY
+core120 sparse 20   65   0.80    33      0.28      LAZY    LAZY    LAZY
+core240 dense 500   71   0.94    51      3.36      eager   eager   LAZY
+core240 sparse 20   71   0.94    45      0.85      LAZY    LAZY    LAZY
+```
+
+**Findings (this corrects the earlier "lazy is just slower" note).**
+
+- **Steady-state is identical.** Once both caches are warm, a query round is a plain
+  splice for both (eager ≈ lazy per round, e.g. 0.60 vs 0.58 ms) — so K rounds
+  amortize the *same* way. The strategy choice is entirely about the *warmup* cost.
+- **Sparse workload -> lazy wins at every K.** When the queries touch little of the
+  band (20 seeds, ~33 of 65 nodes), eager wastes precompute on the whole region
+  (0.80 ms) while lazy warms only what's asked (0.28 ms) — lazy is 3× cheaper at K=1
+  and stays ahead as K grows.
+- **Dense workload + few queries -> eager wins.** When the queries touch most of the
+  band, eager's batched precompute (0.80 ms for 65 nodes) beats lazy's interleaved
+  on-demand warmup (1.93 ms) — so for K=1..~50 eager is cheaper.
+- **Dense workload + many queries -> lazy edges ahead** (K=100): lazy's smaller warm
+  cache (54 vs 65) gives marginally faster steady rounds, and the upfront-precompute
+  gap washes out. So even in the dense case the crossover is finite.
+- **Dataset size shifts it toward lazy.** The eager band is the whole root-near
+  region, which grows with the graph; the touched subset is bounded by the workload.
+  So a bigger graph with the same query workload widens lazy's precompute saving.
+
+**Takeaway:** lazy is the right strategy for **sparse or unknown** query
+distributions (don't precompute a band you won't use), for streaming/interactive
+workloads (self-warming, no precompute moment), and on the **lazy/LMDB edge path**
+(it enumerates via the `EdgeAccessor`; the eager shared-memo sweep needs the
+in-memory `ffi_facts`). Eager is the right strategy for a **known, densely-reused
+band with a modest query count**. Neither dominates — the harness prints the
+per-config winner.
+
+Guarded by `lazy_boundary_caches_on_demand_and_matches_eager` (a query touching one
+seed caches only that seed's entry; results match production).

--- a/examples/benchmark/wam_rust_boundary_measurement.pl
+++ b/examples/benchmark/wam_rust_boundary_measurement.pl
@@ -134,6 +134,67 @@ fn main() {
                 core, cp, dpre, ta, tb, tpre, ta / tb, region_sz, front_sz,
                 if eq { "yes" } else { "NO!" });
         }
+        // LAZY (on-demand warmup) vs EAGER (precompute the whole band), apples to
+        // apples on the SAME min_dist<=d_pre band, exposing the two axes that
+        // decide it: dataset size (the eager band grows; lazy computes only what is
+        // touched) and query count (steady state is splice-only, identical for
+        // both, so it amortizes the same way).
+        let dpre = 2usize;
+        let mut mk = |take: usize| -> (WamState, u32, Vec<u32>) {
+            let mut v = WamState::new(vec![], HashMap::new());
+            v.register_ffi_fact_pairs(edge_pred, &refs);
+            let r = v.intern_atom("0");
+            let mut m: HashMap<i32, i32> = HashMap::new();
+            for (&node, &d) in &md_num { m.insert(v.intern_atom(&node.to_string()) as i32, d); }
+            v.set_min_dist(&m);
+            let ss: Vec<u32> = seed_ids.iter().take(take).map(|&i| v.intern_atom(&i.to_string())).collect();
+            (v, r, ss)
+        };
+        // helper: time one steady-state query round (plain kernel over a warm cache).
+        fn query_round(vm: &WamState, seeds: &[u32], root: u32, budget: usize, edge_pred: &str, n: f64) -> (f64, f64) {
+            let acc = vm.resolve_edge_accessor(edge_pred);
+            let t = Instant::now();
+            let mut s = 0.0;
+            for &x in seeds {
+                let mut h: Vec<u64> = Vec::new();
+                let mut vis = vec![x];
+                vm.collect_native_category_ancestor_boundary_hist(x, root, &mut vis, budget, &acc, 0, &mut h);
+                s += wpow_hist(&h, n);
+            }
+            (t.elapsed().as_secs_f64() * 1e3, s)
+        }
+        // EAGER precomputes the WHOLE region band ONCE — it does not know which
+        // seeds will be queried, so it must materialise the full potential band.
+        let (mut evm, eroot, _) = mk(seed_ids.len());
+        let region = evm.boundary_band_root_near(dpre);
+        let region_n = region.len();
+        let pe = Instant::now();
+        evm.build_boundary_suffix(&region, eroot, budget, edge_pred);
+        let eager_pre = pe.elapsed().as_secs_f64() * 1e3;
+        // Compare two WORKLOADS on the same band: dense (all seeds, touches most of
+        // the band) and sparse (20 seeds, touches little). This is the axis that
+        // decides lazy vs eager.
+        for (wlabel, wsize) in [("dense ", seed_ids.len()), ("sparse", 20usize)] {
+            let wseeds: Vec<u32> = seed_ids.iter().take(wsize).map(|&i| evm.intern_atom(&i.to_string())).collect();
+            let (eq_round, esum) = query_round(&evm, &wseeds, eroot, budget, edge_pred, n);
+            // LAZY: fresh cache, warm it on demand over THIS workload only.
+            let (mut lvm, lroot, _) = mk(seed_ids.len());
+            let lws: Vec<u32> = seed_ids.iter().take(wsize).map(|&i| lvm.intern_atom(&i.to_string())).collect();
+            let pl = Instant::now();
+            let _ = lvm.lazy_boundary_weightsum(&lws, lroot, budget, edge_pred, dpre, n);
+            let lazy_warm = pl.elapsed().as_secs_f64() * 1e3;
+            let touched_n = lvm.boundary_suffix.len();
+            let (lz_round, lsum) = query_round(&lvm, &lws, lroot, budget, edge_pred, n);
+            let eq = (esum - lsum).abs() < 1e-9 * esum.abs().max(1.0);
+            println!("  [{}|{} seeds] eager: band={} pre={:.3}ms | lazy: touched={} warm={:.3}ms | steady eager={:.3}ms lazy={:.3}ms eq={}",
+                wlabel, wsize, region_n, eager_pre, touched_n, lazy_warm, eq_round, lz_round, if eq {"y"} else {"N"});
+            for k in [1usize, 10, 100] {
+                let etot = eager_pre + k as f64 * eq_round;       // eager: full precompute + K rounds
+                let ltot = lazy_warm + (k as f64 - 1.0) * lz_round; // lazy: warm (round 1) + (K-1) rounds
+                println!("       K={:<4} eager={:.2}ms lazy={:.2}ms winner={}",
+                    k, etot, ltot, if ltot < etot { "LAZY" } else { "eager" });
+            }
+        }
     }
 }').
 

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -1028,6 +1028,92 @@ impl WamState {
         }
     }
 
+    /// Collect the band-ENTRY nodes a single seed reaches: walking `seed -> root`,
+    /// the first node on each path with `1 <= min_dist <= d_pre` (where a periphery
+    /// seed crosses into the root-near region). Stops at each entry (the boundary
+    /// kernel would splice there). Read-only; the cheap `seed -> boundary` prefix
+    /// walk, not the expensive `boundary -> root` suffix. Empty `min_dist` -> no
+    /// entries.
+    pub fn boundary_entries_reached(
+        &self, seed: u32, root_id: u32, max_depth: usize, edge_pred: &str, d_pre: usize,
+    ) -> Vec<u32> {
+        let acc = self.resolve_edge_accessor(edge_pred);
+        let mut out: FxMap<u32, ()> = FxMap::default();
+        let mut visited: Vec<u32> = vec![seed];
+        self.collect_boundary_entries(seed, root_id, &mut visited, max_depth, &acc, 0, d_pre, &mut out);
+        out.into_iter().map(|(k, _)| k).collect()
+    }
+
+    fn collect_boundary_entries(
+        &self, node: u32, root_id: u32, visited: &mut Vec<u32>, max_depth: usize,
+        acc: &EdgeAccessor, depth: i64, d_pre: usize, out: &mut FxMap<u32, ()>,
+    ) {
+        if !self.min_dist.is_empty() {
+            match self.min_dist.get(&(node as i32)) {
+                Some(&d) => { if depth + (d as i64) > max_depth as i64 { return; } }
+                None => return,
+            }
+        }
+        if let Some(&d) = self.min_dist.get(&(node as i32)) {
+            if d >= 1 && (d as usize) <= d_pre {
+                out.insert(node, ()); // first band node on this path -> an entry; stop.
+                return;
+            }
+        }
+        if visited.len() >= max_depth { return; }
+        let parents = self.edge_parents_via(node, acc);
+        for parent_id in &parents {
+            if *parent_id == root_id { continue; } // reached root without crossing the band
+            if visited.contains(parent_id) { continue; }
+            visited.push(*parent_id);
+            self.collect_boundary_entries(*parent_id, root_id, visited, max_depth, acc, depth + 1, d_pre, out);
+            visited.pop();
+        }
+    }
+
+    /// LAZY (demand-driven) boundary cache: process `seeds`, computing each
+    /// `weighted_power(N)`, but populating `boundary_suffix` **on first demand**
+    /// instead of precomputing the whole band up front. For each seed it finds the
+    /// band-entry nodes it reaches and, for any not yet cached, computes that node's
+    /// `node->root` histogram (`enum_ancestor_hist`) once and memoizes it; then it
+    /// splices through the (growing) cache. So only band nodes the workload actually
+    /// touches are ever computed — the per-query / top-down evaluation strategy
+    /// (RECURRENCE_EVALUATION_STRATEGY: lazy = demand-driven) versus the eager
+    /// `build_boundary_suffix_*` precompute. Results are identical to eager (any
+    /// band is exact for the splice); the win is skipping cold band nodes when the
+    /// workload is sparse. Works on the lazy/LMDB edge path too (enumeration via the
+    /// accessor). Returns one `weighted_power` per seed.
+    pub fn lazy_boundary_weightsum(
+        &mut self, seeds: &[u32], root_id: u32, max_depth: usize, edge_pred: &str,
+        d_pre: usize, n: f64,
+    ) -> Vec<f64> {
+        let mut out = Vec::with_capacity(seeds.len());
+        for &seed in seeds {
+            for b in self.boundary_entries_reached(seed, root_id, max_depth, edge_pred, d_pre) {
+                if !self.boundary_suffix.contains_key(&b) {
+                    let h = {
+                        let acc = self.resolve_edge_accessor(edge_pred);
+                        let mut hist: Vec<u64> = Vec::new();
+                        let mut vis: Vec<u32> = vec![b];
+                        self.enum_ancestor_hist(b, root_id, &mut vis, max_depth, &acc, 0, &mut hist);
+                        hist
+                    };
+                    self.boundary_suffix.insert(b, h);
+                }
+            }
+            let wp = {
+                let acc = self.resolve_edge_accessor(edge_pred);
+                let mut hist: Vec<u64> = Vec::new();
+                let mut vis: Vec<u32> = vec![seed];
+                self.collect_native_category_ancestor_boundary_hist(
+                    seed, root_id, &mut vis, max_depth, &acc, 0, &mut hist);
+                crate::boundary_cache::f_weighted_power(&hist, n)
+            };
+            out.push(wp);
+        }
+        out
+    }
+
     /// Polynomial precompute: compute each band node's `node->root` suffix histogram
     /// via the SHARED memoised recurrence `H_v[L] = sum_{p in parents(v)} H_p[L-1]`
     /// (the proven `boundary_cache::suffix_histogram`), reusing ONE memo across all
@@ -2624,6 +2710,49 @@ mod boundary_kernel_tests {
             assert!((wref - wsp).abs() < 1e-12, "frontier seed {}: {} != {}", s, wref, wsp);
             assert!(wref > 0.0, "seed {} should reach root", s);
         }
+    }
+
+    // Lazy (demand-driven) boundary cache: identical results to eager, but only the
+    // band-entry nodes a query actually touches are ever computed/cached.
+    #[test]
+    fn lazy_boundary_caches_on_demand_and_matches_eager() {
+        let mut vm = WamState::new(vec![], HashMap::new());
+        vm.register_ffi_fact_pairs("category_parent", &[
+            ("1", "0"), ("2", "0"), ("3", "1"), ("4", "2"),
+            ("10", "3"), ("10", "4"), ("11", "3"), ("12", "10"),
+        ]);
+        let root = vm.intern_atom("0");
+        let budget = 8usize;
+        let n = 2.0f64;
+        let mut md: HashMap<i32, i32> = HashMap::new();
+        for (name, d) in [("0",0),("1",1),("2",1),("3",2),("4",2),("10",3),("11",3),("12",4)] {
+            md.insert(vm.intern_atom(name) as i32, d);
+        }
+        vm.set_min_dist(&md);
+        let pseeds: Vec<u32> = ["10", "11", "12"].iter().map(|s| vm.intern_atom(s)).collect();
+        let n3 = vm.intern_atom("3");
+        // production reference per seed
+        let prod: Vec<f64> = {
+            let acc = vm.resolve_edge_accessor("category_parent");
+            pseeds.iter().map(|&s| {
+                let mut fh = vec![]; let mut v = vec![s];
+                vm.enum_ancestor_hist(s, root, &mut v, budget, &acc, 0, &mut fh);
+                crate::boundary_cache::f_weighted_power(&fh, n)
+            }).collect()
+        };
+        // lazy over JUST seed 11 -> caches only its entry (node 3), not node 4.
+        assert!(vm.boundary_suffix.is_empty());
+        let s11 = vm.intern_atom("11");
+        let r11 = vm.lazy_boundary_weightsum(&[s11], root, budget, "category_parent", 2, n);
+        assert!((r11[0] - prod[1]).abs() < 1e-12, "lazy result must match production");
+        assert_eq!(vm.boundary_suffix.len(), 1, "lazy cached only the touched entry");
+        assert!(vm.boundary_suffix.contains_key(&n3), "the touched entry is node 3");
+        // lazy over all seeds -> cache grows to both entries {3,4}, results exact.
+        let rall = vm.lazy_boundary_weightsum(&pseeds, root, budget, "category_parent", 2, n);
+        for (i, _) in pseeds.iter().enumerate() {
+            assert!((rall[i] - prod[i]).abs() < 1e-12, "seed#{} lazy != production", i);
+        }
+        assert_eq!(vm.boundary_suffix.len(), 2, "now both entries {{3,4}} are cached");
     }
 
     // P4: opt-in storage-gated compression of the boundary table — work-triggered


### PR DESCRIPTION
The doc update (remaining approximation rungs → future work) plus the **lazy boundary cache**, with a measurement that now does it justice.

## You were right — the original conclusion was too narrow

My first pass measured a single dense batch and concluded "lazy is just slower." That held workload sparsity *and* query count fixed — exactly the two axes that decide it. Corrected, apples-to-apples on the same band (total = precompute/warmup + K × steady-round):

```
                              eager        lazy        winner by K
config  workload   band  pre_ms touched  warm_ms   K=1     K=10    K=100
core120 dense 500   65   0.80    54      1.93      eager   eager   LAZY
core120 sparse 20   65   0.80    33      0.28      LAZY    LAZY    LAZY
core240 dense 500   71   0.94    51      3.36      eager   eager   LAZY
core240 sparse 20   71   0.94    45      0.85      LAZY    LAZY    LAZY
```

- **Steady state is identical** (both splice once warm) — so the choice is entirely the *warmup* cost.
- **Sparse workload → lazy wins at every K** — eager wastes precompute on the whole band (0.8ms) while only ~33 of 65 nodes are touched; lazy warms only what's asked (0.28ms, ~3× cheaper).
- **Dense + modest K → eager wins** — batched precompute beats interleaved on-demand warmup.
- **Dense + large K → lazy edges ahead** — smaller warm cache → marginally faster rounds; the upfront gap washes out.
- **Bigger datasets shift toward lazy** — the eager band grows with the graph; the touched subset is bounded by the workload.

So it depends on **workload sparsity × query count**, just as you said. Lazy is the right call for sparse/unknown distributions, streaming/interactive queries, and the LMDB edge path; eager for a known densely-reused band with a modest query count. The harness prints the per-config winner.

## What's in the PR

- `lazy_boundary_weightsum` / `boundary_entries_reached` — demand-driven warmup; identical results to eager (any band is exact). Works on the lazy/LMDB edge path.
- Spec §8d (lazy vs eager, workload × K) and §9b (remaining approximation rungs as future work).
- 30 lib tests pass, incl. `lazy_boundary_caches_on_demand_and_matches_eager`.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua