### PR TITLE
feat(wam-rust): LMDB lazy-edge measurement + non-default mid-sweep spill

### DIFF
--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -1,6 +1,6 @@
 # WAM-Rust Boundary Distribution Optimization — Implementation Plan
 
-Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction, P2c-wiring/precompute/persistence, P3-measurement, P4-g_B-basis, P4-entry-frontier, P4-approx-rung1, P4-approx-rung2-binomial, P4-approx-cdf-fit, P4-approx-mixture, P4-approx-budget-mode, P4-repr-persistence, lazy-boundary-cache, lmdb-lazy-edge-measurement DONE). The implementation-plan member of
+Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction, P2c-wiring/precompute/persistence, P3-measurement, P4-g_B-basis, P4-entry-frontier, P4-approx-rung1, P4-approx-rung2-binomial, P4-approx-cdf-fit, P4-approx-mixture, P4-approx-budget-mode, P4-repr-persistence, lazy-boundary-cache, lmdb-lazy-edge-measurement, eviction-spill DONE). The implementation-plan member of
 the design trio: **`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md`** (why — a
 disablable complexity-reduction compiler optimization, caching secondary),
 **`WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md`** (precise semantics, the
@@ -308,15 +308,19 @@ Phasing:
     tips back to lazy; bigger datasets shift toward lazy. Guarded by
     `lazy_boundary_caches_on_demand_and_matches_eager`; the harness prints the
     per-config winner.
-  - **P2c-wiring/precompute/eviction/spill [later, NOT default].** Spill the *live*
-    frontier (and optionally evicted dead interiors) to the `boundary_basis` sub-db
-    mid-sweep when even the live budget is exceeded — turning the §8b stop-at-depth
-    into spill-and-continue-against-storage. **Design decision: spill is off by
-    default**; it engages only when the in-memory cache is too small for the problem,
-    and only after checking LMDB is actually available (installed / a writable env),
-    falling back to stop-at-depth otherwise. Then an end-to-end LMDB run wiring the
-    harness to `load_boundary_basis` at setup / `save_boundary_basis` after
-    precompute.
+  - **P2c-wiring/precompute/eviction/spill [DONE, NOT default].** When the live
+    frontier exceeds its budget, `build_boundary_suffix_sweep_with_spill(..., spill:
+    &mut dyn SpillSink)` spills live entries (deepest-first) to the sink and reloads
+    them on demand — turning the §8b stop-at-depth into spill-and-continue-against-
+    storage, so the whole cone is swept (`stopped_early` false, `spilled` counts the
+    writes). **Off by default** (the plain `build_boundary_suffix_sweep` passes no
+    sink); engages only when a sink is supplied AND the in-memory live budget is
+    exceeded; falls back to stop-at-depth otherwise. `SpillSink` backends: an
+    in-memory map and the `boundary_spill` LMDB sub-db (`impl SpillSink for
+    LmdbFactSource`). Exact paging — results match the unbudgeted sweep. Tests:
+    `sweep_spill_completes_and_matches` (in-memory: no-sink stops early, with-sink
+    completes + spills + identical results) and cargo-gated
+    `test_wam_rust_boundary_spill_lmdb.pl` (the LMDB backend end to end).
 - **P3 — the measurement in §6 [DONE].** Measured on the **real emitted kernels**
   (`build_boundary_suffix_sweep` + `collect_native_category_ancestor_boundary_hist`
   vs the production `collect_native_category_ancestor_hops`), harness

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -1,6 +1,6 @@
 # WAM-Rust Boundary Distribution Optimization — Implementation Plan
 
-Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction, P2c-wiring/precompute/persistence, P3-measurement, P4-g_B-basis, P4-entry-frontier, P4-approx-rung1, P4-approx-rung2-binomial, P4-approx-cdf-fit, P4-approx-mixture, P4-approx-budget-mode, P4-repr-persistence, lazy-boundary-cache DONE). The implementation-plan member of
+Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction, P2c-wiring/precompute/persistence, P3-measurement, P4-g_B-basis, P4-entry-frontier, P4-approx-rung1, P4-approx-rung2-binomial, P4-approx-cdf-fit, P4-approx-mixture, P4-approx-budget-mode, P4-repr-persistence, lazy-boundary-cache, lmdb-lazy-edge-measurement DONE). The implementation-plan member of
 the design trio: **`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md`** (why — a
 disablable complexity-reduction compiler optimization, caching secondary),
 **`WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md`** (precise semantics, the
@@ -327,8 +327,17 @@ Phasing:
   precompute is sub-ms (amortizes within a single 500-seed batch); and the boundary
   aggregate equals production **exactly** at every `D_pre` (the §6 exact-match
   invariant, guarded by `tests/test_wam_rust_boundary_integrated_scale.pl`). The
-  shallow crossover confirms philosophy §3 (Python overhead had masked it). Boundary-
-  hit-fraction vs `D_pre` and the LMDB-lazy-path variant remain to be measured.
+  shallow crossover confirms philosophy §3 (Python overhead had masked it).
+  - **LMDB lazy-edge path [DONE].** `wam_rust_boundary_lazy_edge_measurement.pl`
+    writes the synthetic graph into a real LMDB env and registers it as the lazy
+    `category_parent/2` `LookupSource` (each lookup an LMDB seek through the L1/L2
+    edge cache), measuring production vs boundary there side by side with the eager
+    path. Result: production is ~4–5× slower on LMDB (85–108 ms vs 17–23 ms), and the
+    boundary win **persists and is often larger** (20–25× lazy vs 10–25× eager) —
+    the cache removes the *walk*, so the more each avoided lookup costs, the more it
+    saves (~82 ms removed per batch on LMDB vs ~16 ms in memory). Exact on both paths.
+    Closes the §6 "to be confirmed on the LMDB run" caveat.
+  - Boundary-hit-fraction vs `D_pre` remains a minor open measurement.
 - **P4 — storage-gated approximate/specialised bases.**
   - **`g_B` pre-weighted basis [DONE].** `build_boundary_basis_weighted_power(max_depth,
     n)` collapses each cached histogram into `g_B[a] = Σ_b H_B[b]·(a+b)^(-N)`, and

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
@@ -297,15 +297,25 @@ limits**:
    not yet spillable). This bounds the sweep's irreducible working set ≈ the cone's
    *frontier antichain width* at the current depth.
 
-When the **live budget** is hit there is nothing to evict — the recourse is to **stop
-deepening**: freeze the precompute frontier at the current depth, treat everything
-below it as un-cached (those seeds fall back to enumeration, still correct), and
-retain what was computed. This makes the effective `D_pre` **dynamically bounded by
-memory**, not a fixed a-priori choice (philosophy §5 / plan §3): deepen the band only
-while the live frontier fits, then stop. (If the frontier may instead be *spilled* to
-the `boundary_basis` LMDB sub-db, the live budget is the in-memory portion and the
-sweep can continue against storage; stop-at-depth is the recourse when neither memory
-nor storage can hold a wider frontier.)
+When the **live budget** is hit there is nothing to evict, and there are two
+recourses:
+
+- **Stop-at-depth (default).** Freeze the precompute frontier at the current depth,
+  treat everything below it as un-cached (those seeds fall back to enumeration, still
+  correct), and retain what was computed. This makes the effective `D_pre`
+  **dynamically bounded by memory**, not a fixed a-priori choice (philosophy §5 /
+  plan §3): deepen the band only while the live frontier fits, then stop.
+- **Spill-and-continue (non-default, implemented).** Given a `SpillSink`,
+  `build_boundary_suffix_sweep_with_spill` instead **spills** live frontier entries
+  (deepest-first — keep the root-near hubs resident) to the sink, removing them from
+  the memo, and **reloads** each on demand when a child consumes it. The whole cone
+  is swept (`stopped_early` stays false); `spilled` counts the writes. It is **exact
+  paging** — a spilled `H_p` reloads identically — so results match the unbudgeted
+  sweep. The sink is an in-memory map (RAM-overflow / testing) or the
+  `boundary_spill` LMDB sub-db (`impl SpillSink for LmdbFactSource`, one short txn per
+  put/get — a fallback path, not a hot loop). Spill is **off unless a sink is
+  supplied**, and engages only when the in-memory live budget is exceeded; stop-at-
+  depth remains the recourse when neither memory nor a sink can hold a wider frontier.
 
 ### 8c. Why exact (vs path sampling)
 

--- a/docs/design/WAM_RUST_BOUNDARY_MEASUREMENT_2026-06-16.md
+++ b/docs/design/WAM_RUST_BOUNDARY_MEASUREMENT_2026-06-16.md
@@ -73,7 +73,8 @@ peak resident memo entries; `eq` = boundary aggregate == production exactly.
   is the durable result.
 - This measures the eager (in-memory) edge path. The LMDB-backed lazy path adds
   seek cost to *both* baseline and boundary; the boundary still removes the walk, so
-  the relative win should persist (to be confirmed in the end-to-end LMDB run).
+  the relative win persists — **confirmed** in the LMDB addendum below (20–25× on the
+  lazy path, with production ~4–5× slower there, so the absolute saving is larger).
 - `boundary_splice_complexity_bench.rs` (P3, std-only) remains the complexity-class
   demonstration (splice flat vs full-enum growing); this report is its on-the-real-
   kernels counterpart.
@@ -197,3 +198,43 @@ per-config winner.
 
 Guarded by `lazy_boundary_caches_on_demand_and_matches_eager` (a query touching one
 seed caches only that seed's entry; results match production).
+
+## Addendum — the LMDB (lazy edge) path (closing the §6 caveat)
+
+The original §6 caveat: the measurement used eager in-memory `HashMap` edges, and
+the boundary win "should persist" on the LMDB-backed lazy path "to be confirmed in
+the end-to-end LMDB run." Confirmed. `wam_rust_boundary_lazy_edge_measurement.pl`
+writes the same synthetic graph into a real LMDB env (int-native: node id == LMDB
+key), registers it as the lazy `category_parent/2` `LookupSource` (so each parent
+lookup is an LMDB seek through the two-tier L1/L2 edge cache), and measures
+production vs boundary there — side by side with the eager path on the same graph.
+
+```
+config     | L_prod_ms  L_bnd_ms  L_speed | E_prod_ms  E_bnd_ms  E_speed | eq
+core=120   |    85.54     3.500    24.4x  |   17.16     0.690     24.9x  | yes
+core=180   |    96.64     3.898    24.8x  |   22.60     2.292      9.9x  | yes
+core=240   |   107.92     5.315    20.3x  |   23.45     1.398     16.8x  | yes
+```
+
+`L_*` = lazy/LMDB edge path; `E_*` = eager/in-memory path; same 500-seed workload,
+`D_pre=2` entry-frontier band.
+
+**Findings.**
+
+- **Production is ~4-5x slower on LMDB edges** (85-108 ms vs the eager 17-23 ms):
+  each parent lookup is an LMDB cursor seek through the L1/L2 cache, not a HashMap
+  hit. So the walk the boundary cache removes is *more expensive* on disk.
+- **The boundary win persists — and is comparable or larger on the lazy path**
+  (20-25x vs the eager 10-25x; e.g. core=180 is 24.8x lazy vs 9.9x eager). Because
+  the cache avoids the cone *walk*, the more each avoided lookup costs, the more it
+  saves: the absolute time removed per 500-seed batch is ~82 ms on LMDB vs ~16 ms
+  in memory.
+- **Exact on both paths** (`eq = yes`): lazy production == lazy boundary == eager
+  production == eager boundary.
+- **The boundary precompute runs on the lazy edge path** (`build_boundary_suffix`
+  enumerates via the `EdgeAccessor`), and the kernel splices the same cached
+  histograms — so no eager `ffi_facts` table is needed for the LMDB deployment.
+
+Implementation note: `LmdbFactSource` caches a per-thread read transaction, so the
+harness runs each config's lazy section in its own thread (a fresh env needs a fresh
+txn slot) — relevant for any code that opens multiple LMDB envs per process.

--- a/examples/benchmark/wam_rust_boundary_lazy_edge_measurement.pl
+++ b/examples/benchmark/wam_rust_boundary_lazy_edge_measurement.pl
@@ -1,0 +1,239 @@
+% wam_rust_boundary_lazy_edge_measurement.pl
+%
+% Closes the §6 "to be confirmed on the LMDB run" caveat: does the boundary win
+% hold (or grow) when each parent lookup is an LMDB seek (the two-tier edge cache)
+% instead of an in-memory HashMap hit? Measures production vs boundary on the LAZY
+% (LMDB-backed) edge path AND the eager (in-memory) path, SAME synthetic graph,
+% side by side. Int-native mode (raw integer node ids == LMDB keys) keeps the lazy
+% setup minimal (no s2i intern table).
+%
+% Run:  swipl examples/benchmark/wam_rust_boundary_lazy_edge_measurement.pl
+% (cargo-gated; builds an lmdb_zero crate in --release.)
+
+:- use_module('../../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+
+:- dynamic m_fact/2.
+m_fact(a, b).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+bench_rust('
+use bm::state::{WamState, LookupSource};
+use bm::lmdb_fact_source::LmdbFactSource;
+use lmdb_zero as lmdb;
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use std::time::Instant;
+
+// Minimal LookupSource over the LMDB parent table (int-native: the kernel node id
+// IS the LMDB key).
+struct LazyParents { src: LmdbFactSource }
+impl LookupSource for LazyParents {
+    fn lookup_key_for_atom(&self, _atom: &str) -> Option<i32> { None }
+    fn lookup_parents(&self, key: i32) -> Vec<i32> { self.src.lookup_parents(key).unwrap_or_default() }
+    fn atom_for_key(&self, _key: i32) -> Option<String> { None }
+}
+
+fn rnd(s: &mut u64) -> u64 { *s = s.wrapping_mul(6364136223846793005).wrapping_add(1); *s >> 33 }
+
+fn build(core: u32, periph: u32, cp: usize, seed: u64) -> (Vec<(u32, u32)>, Vec<u32>) {
+    let mut s = seed;
+    let mut edges: Vec<(u32, u32)> = Vec::new();
+    for i in 1..core {
+        let k = (cp as u32).min(i).max(1);
+        let mut ps: Vec<u32> = Vec::new();
+        for _ in 0..k { ps.push((rnd(&mut s) as u32) % i); }
+        ps.sort(); ps.dedup();
+        for p in ps { edges.push((i, p)); }
+    }
+    let w = 40u32.min(core - 1);
+    let mut seeds: Vec<u32> = Vec::new();
+    for i in core..core + periph {
+        let mut ps: Vec<u32> = Vec::new();
+        for _ in 0..2 { ps.push(core - w + (rnd(&mut s) as u32) % w); }
+        ps.sort(); ps.dedup();
+        for p in ps { edges.push((i, p)); }
+        seeds.push(i);
+    }
+    (edges, seeds)
+}
+
+fn min_dist_to_root(edges: &[(u32, u32)], root: u32) -> HashMap<u32, i32> {
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    for &(c, p) in edges { children.entry(p).or_default().push(c); }
+    let mut dist: HashMap<u32, i32> = HashMap::new();
+    dist.insert(root, 0);
+    let mut q = VecDeque::new();
+    q.push_back(root);
+    while let Some(node) = q.pop_front() {
+        let d = dist[&node];
+        if let Some(cs) = children.get(&node) {
+            for &c in cs { if !dist.contains_key(&c) { dist.insert(c, d + 1); q.push_back(c); } }
+        }
+    }
+    dist
+}
+
+fn wpow_hops(h: &[i64], n: f64) -> f64 { h.iter().map(|&x| (x as f64).powf(-n)).sum() }
+fn wpow_hist(h: &[u64], n: f64) -> f64 {
+    h.iter().enumerate().filter(|(l, _)| *l > 0).map(|(l, &c)| c as f64 * (l as f64).powf(-n)).sum()
+}
+
+// Write the synthetic graph into a fresh LMDB env (Phase-1 layout: empty s2i/i2s,
+// category_parent + category_child as DUPSORT int32_le).
+fn write_lmdb(path: &str, edges: &[(u32, u32)]) {
+    let env = unsafe {
+        let mut b = lmdb::EnvBuilder::new().unwrap();
+        b.set_maxdbs(16).unwrap();
+        b.set_mapsize(256 * 1024 * 1024).unwrap();
+        b.open(path, lmdb::open::Flags::empty(), 0o600).unwrap()
+    };
+    let env = Arc::new(env);
+    for name in ["s2i", "i2s"] {
+        let _ = lmdb::Database::open(Arc::clone(&env), Some(name),
+            &lmdb::DatabaseOptions::new(lmdb::db::CREATE)).unwrap();
+    }
+    let cp = lmdb::Database::open(Arc::clone(&env), Some("category_parent"),
+        &lmdb::DatabaseOptions::new(lmdb::db::CREATE | lmdb::db::DUPSORT)).unwrap();
+    let cc = lmdb::Database::open(Arc::clone(&env), Some("category_child"),
+        &lmdb::DatabaseOptions::new(lmdb::db::CREATE | lmdb::db::DUPSORT)).unwrap();
+    let txn = lmdb::WriteTransaction::new(&*env).unwrap();
+    {
+        let mut acc = txn.access();
+        for &(c, p) in edges {
+            let cb = (c as i32).to_le_bytes();
+            let pb = (p as i32).to_le_bytes();
+            acc.put(&cp, &cb[..], &pb[..], lmdb::put::Flags::empty()).unwrap();
+            acc.put(&cc, &pb[..], &cb[..], lmdb::put::Flags::empty()).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+}
+
+fn main() {
+    let budget = 8usize;
+    let n = 2.0f64;
+    let edge_pred = "category_parent";
+    let dpre = 2usize;
+    println!("{:<10} | {:>9} {:>9} {:>8} | {:>9} {:>9} {:>8} | {:>4}",
+        "config", "L_prod_ms", "L_bnd_ms", "L_speed", "E_prod_ms", "E_bnd_ms", "E_speed", "eq");
+    for (core, periph, cp) in [(120u32, 500u32, 3usize), (180, 500, 3), (240, 500, 3)] {
+        let (edges, seed_ids) = build(core, periph, cp, 42);
+        let md = min_dist_to_root(&edges, 0);
+
+        // ---------- LAZY (LMDB-backed) edge path ----------
+        // Run in a FRESH thread: LmdbFactSource caches a per-thread read txn, so
+        // opening a second env on the same thread would reuse the first env stale
+        // snapshot. A new thread gets a fresh (None) txn slot bound to this env.
+        let dir = std::env::temp_dir().join(format!("bnd_lazy_{}_{}", std::process::id(), core));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        write_lmdb(dir.to_str().unwrap(), &edges);
+        let (lazy_prod, lazy_bound) = std::thread::scope(|sc| {
+            sc.spawn(|| {
+                let lmdb_src = LmdbFactSource::open(dir.to_str().unwrap()).unwrap();
+                let mut lvm = WamState::new(vec![], HashMap::new());
+                lvm.register_lazy_lookup("category_parent/2", Arc::new(LazyParents { src: lmdb_src }));
+                lvm.set_int_native_edges(true);
+                let lmd: HashMap<i32, i32> = md.iter().map(|(&k, &v)| (k as i32, v)).collect();
+                lvm.set_min_dist(&lmd);
+                let lazy_prod = {
+                    let acc = lvm.resolve_edge_accessor(edge_pred);
+                    let t = Instant::now();
+                    let mut s = 0.0;
+                    for &seed in &seed_ids {
+                        let mut hops: Vec<i64> = Vec::new();
+                        let mut vis = vec![seed];
+                        lvm.collect_native_category_ancestor_hops(seed, 0, &mut vis, budget, &acc, 0, &mut hops);
+                        s += wpow_hops(&hops, n);
+                    }
+                    (t.elapsed().as_secs_f64() * 1e3, s)
+                };
+                let band = lvm.boundary_band_entry_frontier(dpre, edge_pred);
+                lvm.build_boundary_suffix(&band, 0, budget, edge_pred);
+                let lazy_bound = {
+                    let acc = lvm.resolve_edge_accessor(edge_pred);
+                    let t = Instant::now();
+                    let mut s = 0.0;
+                    for &seed in &seed_ids {
+                        let mut h: Vec<u64> = Vec::new();
+                        let mut vis = vec![seed];
+                        lvm.collect_native_category_ancestor_boundary_hist(seed, 0, &mut vis, budget, &acc, 0, &mut h);
+                        s += wpow_hist(&h, n);
+                    }
+                    (t.elapsed().as_secs_f64() * 1e3, s)
+                };
+                (lazy_prod, lazy_bound)
+            }).join().unwrap()
+        });
+        let _ = std::fs::remove_dir_all(&dir);
+
+        // ---------- EAGER (in-memory) edge path, same graph ----------
+        let mut evm = WamState::new(vec![], HashMap::new());
+        let owned: Vec<(String, String)> = edges.iter().map(|&(c, p)| (c.to_string(), p.to_string())).collect();
+        let refs: Vec<(&str, &str)> = owned.iter().map(|(a, b)| (a.as_str(), b.as_str())).collect();
+        evm.register_ffi_fact_pairs(edge_pred, &refs);
+        let eroot = evm.intern_atom("0");
+        let mut emd: HashMap<i32, i32> = HashMap::new();
+        for (&node, &d) in &md { emd.insert(evm.intern_atom(&node.to_string()) as i32, d); }
+        evm.set_min_dist(&emd);
+        let eseeds: Vec<u32> = seed_ids.iter().map(|&i| evm.intern_atom(&i.to_string())).collect();
+        let eager_prod = {
+            let acc = evm.resolve_edge_accessor(edge_pred);
+            let t = Instant::now();
+            let mut s = 0.0;
+            for &seed in &eseeds {
+                let mut hops: Vec<i64> = Vec::new();
+                let mut vis = vec![seed];
+                evm.collect_native_category_ancestor_hops(seed, eroot, &mut vis, budget, &acc, 0, &mut hops);
+                s += wpow_hops(&hops, n);
+            }
+            (t.elapsed().as_secs_f64() * 1e3, s)
+        };
+        let eband = evm.boundary_band_entry_frontier(dpre, edge_pred);
+        evm.build_boundary_suffix(&eband, eroot, budget, edge_pred);
+        let eager_bound = {
+            let acc = evm.resolve_edge_accessor(edge_pred);
+            let t = Instant::now();
+            let mut s = 0.0;
+            for &seed in &eseeds {
+                let mut h: Vec<u64> = Vec::new();
+                let mut vis = vec![seed];
+                evm.collect_native_category_ancestor_boundary_hist(seed, eroot, &mut vis, budget, &acc, 0, &mut h);
+                s += wpow_hist(&h, n);
+            }
+            (t.elapsed().as_secs_f64() * 1e3, s)
+        };
+
+        let eq = (lazy_prod.1 - lazy_bound.1).abs() < 1e-6 * lazy_prod.1.abs().max(1.0)
+            && (eager_prod.1 - eager_bound.1).abs() < 1e-6 * eager_prod.1.abs().max(1.0)
+            && (lazy_prod.1 - eager_prod.1).abs() < 1e-6 * eager_prod.1.abs().max(1.0);
+        println!("core={:<5} | {:>9.2} {:>9.3} {:>7.1}x | {:>9.2} {:>9.3} {:>7.1}x | {:>4}",
+            core, lazy_prod.0, lazy_bound.0, lazy_prod.0 / lazy_bound.0,
+            eager_prod.0, eager_bound.0, eager_prod.0 / eager_bound.0,
+            if eq { "yes" } else { "NO!" });
+    }
+}').
+
+main :-
+    Dir = 'output/boundary_lazy_edge',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project([user:m_fact/2],
+        [module_name(bm), lmdb_mode(cursor), lmdb_crate(lmdb_zero)], Dir)),
+    atom_concat(Dir, '/examples', ExDir),
+    make_directory_path(ExDir),
+    atom_concat(Dir, '/examples/lazy_edge.rs', ExPath),
+    bench_rust(Src),
+    setup_call_cleanup(open(ExPath, write, S), format(S, "~w", [Src]), close(S)),
+    format(atom(Cmd),
+        'cd "~w" && cargo run --release --example lazy_edge 2>&1', [Dir]),
+    format("Building + running (release, LMDB)...~n", []),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), process(Pid)]),
+        read_string(Out, _, OutS), close(Out)),
+    process_wait(Pid, Status),
+    format("~n=== wam-rust boundary LAZY-EDGE measurement (status ~w) ===~n~w~n", [Status, OutS]),
+    halt.
+
+:- initialization(main).

--- a/templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache
+++ b/templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache
@@ -387,6 +387,48 @@ impl LmdbFactSource {
     }
 }
 
+/// LMDB-backed `SpillSink` (the `boundary_spill` sub-db): the real storage target
+/// for the non-default mid-sweep spill (spec §8b). `spill_put` writes a histogram
+/// in its own short transaction; `spill_get` reads it back. Values packed by
+/// `boundary_cache::encode_hist`. One transaction per call — acceptable for a
+/// memory-overflow fallback path, not a hot loop.
+impl crate::state::SpillSink for LmdbFactSource {
+    fn spill_put(&mut self, node: u32, hist: &[u64]) {
+        let db = match lmdb::Database::open(
+            Arc::clone(&self.env),
+            Some("boundary_spill"),
+            &lmdb::DatabaseOptions::new(lmdb::db::CREATE),
+        ) {
+            Ok(db) => db,
+            Err(_) => return,
+        };
+        if let Ok(txn) = lmdb::WriteTransaction::new(&*self.env) {
+            {
+                let mut access = txn.access();
+                let key = node.to_le_bytes();
+                let val = crate::boundary_cache::encode_hist(&hist.to_vec());
+                let _ = access.put(&db, &key[..], &val[..], lmdb::put::Flags::empty());
+            }
+            let _ = txn.commit();
+        }
+    }
+
+    fn spill_get(&mut self, node: u32) -> Option<Vec<u64>> {
+        let db = lmdb::Database::open(
+            Arc::clone(&self.env),
+            Some("boundary_spill"),
+            &lmdb::DatabaseOptions::new(lmdb::db::Flags::empty()),
+        ).ok()?;
+        let txn = lmdb::ReadTransaction::new(&*self.env).ok()?;
+        let access = txn.access();
+        let key = node.to_le_bytes();
+        match access.get::<[u8], [u8]>(&db, &key[..]) {
+            Ok(v) => Some(crate::boundary_cache::decode_hist(v)),
+            Err(_) => None,
+        }
+    }
+}
+
 fn decode_i32(bytes: &[u8]) -> i32 {
     // Phase 1 layout stores int32 values little-endian.
     let mut buf = [0u8; 4];

--- a/templates/targets/rust_wam/state.rs.mustache
+++ b/templates/targets/rust_wam/state.rs.mustache
@@ -593,7 +593,9 @@ pub enum EdgeAccessor<'a> {
 /// the side-table; `evicted` = dead interior entries dropped under budget pressure;
 /// `peak_resident` = max simultaneous memo entries (the working-set high-water mark);
 /// `stopped_early` = the live budget forced stop-at-depth before the whole cone was
-/// swept. See WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md §8a/§8b.
+/// swept; `spilled` = live entries written to a `SpillSink` under pressure (the
+/// non-default spill fallback, instead of stop-at-depth).
+/// See WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md §8a/§8b.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct BoundarySweepStats {
     pub computed: usize,
@@ -601,6 +603,18 @@ pub struct BoundarySweepStats {
     pub evicted: usize,
     pub peak_resident: usize,
     pub stopped_early: bool,
+    pub spilled: usize,
+}
+
+/// Sink for **spilling** a live boundary histogram out of memory during the
+/// precompute sweep, then reloading it on demand — the non-default storage fallback
+/// for when the live (non-evictable) frontier exceeds its budget (spec §8b:
+/// spill-and-continue instead of stop-at-depth). Implementations: an in-memory map
+/// (testing / RAM overflow) or the LMDB `boundary_spill` sub-db
+/// (`LmdbFactSource`). Spill is OFF unless a sink is supplied.
+pub trait SpillSink {
+    fn spill_put(&mut self, node: u32, hist: &[u64]);
+    fn spill_get(&mut self, node: u32) -> Option<Vec<u64>>;
 }
 
 impl WamState {
@@ -1174,6 +1188,27 @@ impl WamState {
         &mut self, boundary: &[u32], root_id: u32, max_depth: usize, edge_pred: &str,
         evict_budget: usize, live_budget: usize,
     ) -> Option<BoundarySweepStats> {
+        self.boundary_sweep_impl(boundary, root_id, max_depth, edge_pred, evict_budget, live_budget, None)
+    }
+
+    /// Like `build_boundary_suffix_sweep`, but the NON-DEFAULT spill fallback: when
+    /// the **live** frontier exceeds `live_budget`, instead of stop-at-depth the
+    /// sweep SPILLS live entries to `spill` (deepest-first) and CONTINUES, reloading
+    /// each on demand when a child consumes it (spec §8b: spill-and-continue). So the
+    /// whole cone is swept even when the frontier does not fit in memory — at the
+    /// cost of `spill` round-trips. `spilled` counts the writes; `stopped_early` stays
+    /// false. Results are identical to the unbudgeted sweep (spill is exact paging).
+    pub fn build_boundary_suffix_sweep_with_spill(
+        &mut self, boundary: &[u32], root_id: u32, max_depth: usize, edge_pred: &str,
+        evict_budget: usize, live_budget: usize, spill: &mut dyn SpillSink,
+    ) -> Option<BoundarySweepStats> {
+        self.boundary_sweep_impl(boundary, root_id, max_depth, edge_pred, evict_budget, live_budget, Some(spill))
+    }
+
+    fn boundary_sweep_impl(
+        &mut self, boundary: &[u32], root_id: u32, max_depth: usize, edge_pred: &str,
+        evict_budget: usize, live_budget: usize, mut spill: Option<&mut dyn SpillSink>,
+    ) -> Option<BoundarySweepStats> {
         use std::collections::VecDeque;
         let (table, stats) = {
             let parents = self.ffi_facts.get(edge_pred)?;
@@ -1213,6 +1248,7 @@ impl WamState {
 
             // 3. Kahn topological sweep from the root.
             let mut memo: HashMap<u32, Vec<u64>> = HashMap::new();
+            let mut spilled: std::collections::HashSet<u32> = std::collections::HashSet::new();
             let mut depth: HashMap<u32, usize> = HashMap::new();
             let mut dead: Vec<u32> = Vec::new();
             let mut table: HashMap<u32, Vec<u64>> = HashMap::new();
@@ -1239,6 +1275,17 @@ impl WamState {
                                     if l2 <= max_depth {
                                         if out.len() <= l2 { out.resize(l2 + 1, 0); }
                                         out[l2] += c;
+                                    }
+                                }
+                            } else if spilled.contains(&p) {
+                                // a spilled live parent: reload from the sink for this child.
+                                if let Some(ph) = spill.as_deref_mut().and_then(|s| s.spill_get(p)) {
+                                    for (l, &c) in ph.iter().enumerate() {
+                                        let l2 = l + 1;
+                                        if l2 <= max_depth {
+                                            if out.len() <= l2 { out.resize(l2 + 1, 0); }
+                                            out[l2] += c;
+                                        }
                                     }
                                 }
                             }
@@ -1297,14 +1344,33 @@ impl WamState {
                     }
                 }
 
-                // stop-at-depth: if the live (refs>0) frontier exceeds its budget,
-                // there is nothing to evict -> stop deepening.
+                // live-budget recourse: the live (refs>0) frontier cannot be evicted.
+                // With a spill sink, SPILL live entries (deepest-first) and continue;
+                // otherwise stop-at-depth.
                 if live_budget > 0 {
-                    let live = refs.iter()
-                        .filter(|(k, &r)| r > 0 && memo.contains_key(k)).count();
-                    if live > live_budget {
-                        stats.stopped_early = true;
-                        ready.clear();
+                    let live_count = |memo: &HashMap<u32, Vec<u64>>| {
+                        refs.iter().filter(|(k, &r)| r > 0 && memo.contains_key(k)).count()
+                    };
+                    if live_count(&memo) > live_budget {
+                        if spill.is_some() {
+                            let mut victims: Vec<u32> = refs.iter()
+                                .filter(|(k, &r)| r > 0 && memo.contains_key(k))
+                                .map(|(&k, _)| k).collect();
+                            victims.sort_by_key(|nd| std::cmp::Reverse(depth.get(nd).copied().unwrap_or(0)));
+                            let mut i = 0;
+                            while live_count(&memo) > live_budget && i < victims.len() {
+                                let victim = victims[i];
+                                i += 1;
+                                if let Some(h) = memo.remove(&victim) {
+                                    if let Some(s) = spill.as_deref_mut() { s.spill_put(victim, &h); }
+                                    spilled.insert(victim);
+                                    stats.spilled += 1;
+                                }
+                            }
+                        } else {
+                            stats.stopped_early = true;
+                            ready.clear();
+                        }
                     }
                 }
             }
@@ -2666,6 +2732,36 @@ mod boundary_kernel_tests {
         let b = vm.intern_atom("1");
         assert!(vm.build_boundary_suffix_sweep(&[b], root, 8, "no_such_pred", 0, 0).is_none(),
                 "no eager table -> sweep is a no-op");
+    }
+
+    // In-memory spill sink for testing the spill mechanism without LMDB.
+    struct MemSpill { map: HashMap<u32, Vec<u64>>, puts: usize, gets: usize }
+    impl SpillSink for MemSpill {
+        fn spill_put(&mut self, node: u32, hist: &[u64]) { self.map.insert(node, hist.to_vec()); self.puts += 1; }
+        fn spill_get(&mut self, node: u32) -> Option<Vec<u64>> { self.gets += 1; self.map.get(&node).cloned() }
+    }
+
+    // Spill fallback: a tiny live budget WITHOUT a sink stops early; WITH a sink the
+    // sweep spills live entries and COMPLETES with identical band results.
+    #[test]
+    fn sweep_spill_completes_and_matches() {
+        let mut vm = dag();
+        let root = vm.intern_atom("0");
+        let budget = 8usize;
+        let bnodes: Vec<u32> = ["1", "2", "3", "4"].iter().map(|s| vm.intern_atom(s)).collect();
+        // reference: unbudgeted sweep
+        vm.build_boundary_suffix_sweep(&bnodes, root, budget, "category_parent", 0, 0).unwrap();
+        let ref_tbl = snapshot_table(&vm);
+        // tiny live budget, NO spill -> stop-at-depth (frontier can't fit)
+        let no_spill = vm.build_boundary_suffix_sweep(&bnodes, root, budget, "category_parent", 0, 1).unwrap();
+        assert!(no_spill.stopped_early, "live_budget=1 without spill should stop early");
+        // tiny live budget, WITH spill -> completes, spills, identical results
+        let mut spill = MemSpill { map: HashMap::new(), puts: 0, gets: 0 };
+        let s = vm.build_boundary_suffix_sweep_with_spill(&bnodes, root, budget, "category_parent", 0, 1, &mut spill).unwrap();
+        assert!(!s.stopped_early, "spill must not stop early");
+        assert!(s.spilled > 0, "spill should have written live entries");
+        assert!(spill.puts > 0 && spill.gets > 0, "sink should see puts and reload gets");
+        assert_eq!(snapshot_table(&vm), ref_tbl, "spill must produce identical band results");
     }
 
     // The entry-frontier band is a thin cut (region surface, not volume) yet the

--- a/tests/test_wam_rust_boundary_spill_lmdb.pl
+++ b/tests/test_wam_rust_boundary_spill_lmdb.pl
@@ -1,0 +1,115 @@
+% test_wam_rust_boundary_spill_lmdb.pl
+%
+% Non-default mid-sweep spill, real LMDB backend (spec §8b): when the live frontier
+% exceeds its budget, build_boundary_suffix_sweep_with_spill spills live histograms
+% to the boundary_spill LMDB sub-db (LmdbFactSource as a SpillSink) and reloads them
+% on demand, COMPLETING the sweep with identical band results instead of
+% stop-at-depth. Validated in a generated lmdb_zero crate.
+%
+% cargo-gated (needs the lmdb-zero crate to build).
+
+:- use_module('../src/unifyweaver/targets/wam_rust_target', [write_wam_rust_project/3]).
+
+:- dynamic bsp_fact/2.
+bsp_fact(a, b).
+
+cargo_ok :-
+    catch(( process_create(path(cargo), ['--version'],
+                           [stdout(null), stderr(null), process(P)]),
+            process_wait(P, exit(0)) ), _, fail).
+
+safe_rmdir(Dir) :- ( exists_directory(Dir) -> delete_directory_and_contents(Dir) ; true ).
+
+:- begin_tests(wam_rust_boundary_spill_lmdb).
+
+test(lmdb_spill_completes_and_matches,
+     [condition(cargo_ok), cleanup(safe_rmdir('output/test_bsp'))]) :-
+    Dir = 'output/test_bsp',
+    safe_rmdir(Dir),
+    once(write_wam_rust_project([user:bsp_fact/2],
+        [module_name(bsp), lmdb_mode(cursor), lmdb_crate(lmdb_zero)], Dir)),
+    atom_concat(Dir, '/src/lmdb_fact_source.rs', LmdbRs),
+    read_file_to_string(LmdbRs, LSrc, []),
+    sub_string(LSrc, _, _, _, "impl crate::state::SpillSink for LmdbFactSource"),
+    atom_concat(Dir, '/src/state.rs', StateRs),
+    read_file_to_string(StateRs, SSrc, []),
+    sub_string(SSrc, _, _, _, "pub fn build_boundary_suffix_sweep_with_spill"),
+    atom_concat(Dir, '/tests', TestsDir),
+    make_directory_path(TestsDir),
+    atom_concat(Dir, '/tests/bsp_test.rs', TestPath),
+    TestSrc = '
+use bsp::state::WamState;
+use bsp::lmdb_fact_source::LmdbFactSource;
+use lmdb_zero as lmdb;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn snapshot(vm: &WamState) -> Vec<(u32, Vec<u64>)> {
+    let mut t: Vec<(u32, Vec<u64>)> = vm.boundary_suffix.iter().map(|(&k, v)| {
+        let mut h = v.clone();
+        while h.len() > 1 && h.last() == Some(&0) { h.pop(); }
+        (k, h)
+    }).collect();
+    t.sort_by_key(|(k, _)| *k);
+    t
+}
+
+#[test]
+fn lmdb_spill_completes_and_matches() {
+    // temp env with the four Phase-1 sub-dbs so LmdbFactSource::open succeeds.
+    let dir = std::env::temp_dir().join(format!("bsp_it_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.to_str().unwrap();
+    {
+        let env = unsafe {
+            let mut b = lmdb::EnvBuilder::new().unwrap();
+            b.set_maxdbs(16).unwrap();
+            b.set_mapsize(64 * 1024 * 1024).unwrap();
+            b.open(path, lmdb::open::Flags::empty(), 0o600).unwrap()
+        };
+        let env = Arc::new(env);
+        for name in ["s2i", "i2s"] {
+            let _ = lmdb::Database::open(Arc::clone(&env), Some(name),
+                &lmdb::DatabaseOptions::new(lmdb::db::CREATE)).unwrap();
+        }
+        for name in ["category_parent", "category_child"] {
+            let _ = lmdb::Database::open(Arc::clone(&env), Some(name),
+                &lmdb::DatabaseOptions::new(lmdb::db::CREATE | lmdb::db::DUPSORT)).unwrap();
+        }
+    }
+    let mut sink = LmdbFactSource::open(path).unwrap();
+
+    // VM with EAGER edges (the sweep reads the cone from ffi_facts); LMDB is only
+    // the spill target. Diamond DAG toward root 0.
+    let mut vm = WamState::new(vec![], HashMap::new());
+    vm.register_ffi_fact_pairs("category_parent", &[
+        ("5","4"),("5","2"),("4","3"),("4","1"),("3","1"),("3","2"),("1","0"),("2","0"),
+    ]);
+    let root = vm.intern_atom("0");
+    let band: Vec<u32> = ["1","2","3","4"].iter().map(|s| vm.intern_atom(s)).collect();
+    // reference: unbudgeted sweep
+    vm.build_boundary_suffix_sweep(&band, root, 8, "category_parent", 0, 0).unwrap();
+    let refr = snapshot(&vm);
+    // tiny live budget WITH the LMDB spill sink -> completes via spill, identical.
+    let s = vm.build_boundary_suffix_sweep_with_spill(&band, root, 8, "category_parent", 0, 1, &mut sink).unwrap();
+    assert!(!s.stopped_early, "spill must not stop early");
+    assert!(s.spilled > 0, "spill should have written live entries to LMDB");
+    assert_eq!(snapshot(&vm), refr, "LMDB-spilled sweep must produce identical band results");
+    let _ = std::fs::remove_dir_all(&dir);
+}',
+    setup_call_cleanup(open(TestPath, write, S),
+                       format(S, "~w", [TestSrc]), close(S)),
+    format(atom(Cmd), 'cd "~w" && cargo test --test bsp_test -- --nocapture 2>&1', [Dir]),
+    setup_call_cleanup(
+        process_create(path(sh), ['-c', Cmd],
+                       [stdout(pipe(Out)), stderr(pipe(Err)), process(Pid)]),
+        ( read_string(Out, _, OutS), read_string(Err, _, ErrS) ),
+        ( close(Out), close(Err) )),
+    process_wait(Pid, Status),
+    ( Status == exit(0), sub_string(OutS, _, _, _, "test result: ok")
+    ->  true
+    ;   format(user_error, "~n[boundary spill lmdb FAILED] status=~w~n~w~n~w~n", [Status, OutS, ErrS]),
+        fail ).
+
+:- end_tests(wam_rust_boundary_spill_lmdb).


### PR DESCRIPTION
Two independent boundary-cache items on this branch (the second stacked on the first since the PR was already open).

## Commit 1 — LMDB lazy-edge measurement (`6313f896`)

Closes the §6 "to be confirmed on the LMDB run" caveat: does the boundary win hold when each parent lookup is an LMDB seek instead of a HashMap hit? `wam_rust_boundary_lazy_edge_measurement.pl` writes the synthetic graph into a real LMDB env (int-native), registers it as the lazy `category_parent/2` `LookupSource`, and measures production vs boundary there side-by-side with the eager path.

```
config     | L_prod_ms  L_bnd_ms  L_speed | E_prod_ms  E_bnd_ms  E_speed | eq
core=120   |    85.54     3.500    24.4x  |   17.16     0.690     24.9x  | yes
core=240   |   107.92     5.315    20.3x  |   23.45     1.398     16.8x  | yes
```

Production is ~4–5× slower on LMDB (seeks vs HashMap hits), so the boundary win **holds and is often larger** (20–25× lazy vs 10–25× eager) — the cache removes the *walk*, and the more each avoided lookup costs, the more it saves (~82ms removed/batch on LMDB vs ~16ms in memory). Exact on both paths.

## Commit 2 — non-default mid-sweep spill (`7ce97c37`)

When the sweep's **live** frontier exceeds its budget, the default is stop-at-depth; this adds **spill-and-continue** (spec §8b).

- `SpillSink { spill_put, spill_get }` + `BoundarySweepStats.spilled`. The sweep is refactored into `boundary_sweep_impl(..., Option<&mut dyn SpillSink>)`; `build_boundary_suffix_sweep` is the no-sink wrapper (**unchanged**), `build_boundary_suffix_sweep_with_spill` supplies a sink.
- Live entries spill **deepest-first** (keep root-near hubs resident), drop from the memo, **reload** on demand. Exact paging → identical results, `stopped_early` stays false.
- `impl SpillSink for LmdbFactSource` over a `boundary_spill` sub-db.
- **Off by default**: engages only when a sink is supplied *and* the live budget is exceeded, else stop-at-depth.

Tests: `sweep_spill_completes_and_matches` (in-memory: no-sink stops early, with-sink completes + spills + identical) and cargo-gated `test_wam_rust_boundary_spill_lmdb.pl` (LMDB backend end to end). 31 lib tests pass.

Docs: §6 caveat confirmed + LMDB addendum; spec §8b two-recourse + spill; plan P3 and spill marked done.

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua