### PR TITLE
wam-rust: boundary docs + quantised-CDF + discretised-GMM + functional-semiring theory

### DIFF
--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -1,6 +1,6 @@
 # WAM-Rust Boundary Distribution Optimization — Implementation Plan
 
-Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction, P2c-wiring/precompute/persistence, P3-measurement, P4-g_B-basis, P4-entry-frontier, P4-approx-rung1, P4-approx-rung2-binomial, P4-approx-cdf-fit, P4-approx-mixture, P4-approx-budget-mode, P4-repr-persistence, lazy-boundary-cache, lmdb-lazy-edge-measurement, eviction-spill, P4-approx-beta-binomial DONE). The implementation-plan member of
+Status: in progress (P1, P2a, P2c-parity, P2c-wiring/dispatch, P2c-wiring/lowering, P2c-wiring/precompute/selection, P2c-wiring/precompute/eviction, P2c-wiring/precompute/persistence, P3-measurement, P4-g_B-basis, P4-entry-frontier, P4-approx-rung1, P4-approx-rung2-binomial, P4-approx-cdf-fit, P4-approx-mixture, P4-approx-budget-mode, P4-repr-persistence, lazy-boundary-cache, lmdb-lazy-edge-measurement, eviction-spill, P4-approx-beta-binomial, P4-approx-quant-cdf DONE). The implementation-plan member of
 the design trio: **`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md`** (why — a
 disablable complexity-reduction compiler optimization, caching secondary),
 **`WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md`** (precise semantics, the
@@ -405,8 +405,15 @@ Phasing:
     mixture. Validated: a true beta-binomial is recovered by MoM, the single binomial
     misses the gate, and the chooser selects `BetaBinomial` over the costlier mixture.
     `encode_repr`/`decode_repr` tag 3.
-  - **Fitted forms [next].** quantised-CDF table (O(1) prefix-mass reads; the
-    cdf/quantile result modes); discretised-GMM as escalation only.
+  - **Quantised-CDF table [DONE].** `HistRepr::QuantCdf{qcdf,total}` stores the exact
+    CDF as one `u16` per support point (`quantize_cdf`/`dequantize_cdf`); always
+    admissible (error ≤ `2^-16`) at ~1/4 the bytes of raw counts, so it is the
+    fallback when no parametric form fits an irregular/multi-spike node (also O(1)
+    prefix-mass). `encode_repr`/`decode_repr` tag 4. Validated:
+    `quant_cdf_is_the_no_fit_fallback` (five spikes — binomial/mixture rejected, the
+    chooser falls back to QuantCdf, smaller than exact, within `ε_K`).
+  - **Fitted forms [next].** discretised-GMM as escalation only (the last rung;
+    bounded integer data make it lowest priority).
 
 ## 6. What to measure (re-derive, don't inherit)
 

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md
@@ -5,7 +5,9 @@ the design trio: **`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md`** (why — a
 disablable complexity-reduction compiler optimization, caching secondary),
 **`WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md`** (precise semantics, the
 scalar/histogram result-mode family, invariants, interface), and this plan (phased
-work + status). Also companion to `DISTRIBUTION_CACHE_BENCHMARK_PLAN.md`,
+work + status); plus **`WAM_RUST_BOUNDARY_DISTRIBUTION_HOWTO.md`** (the operator's
+manual — how to use it) and **`WAM_RUST_BOUNDARY_MEASUREMENT_2026-06-16.md`** (the
+measured results). Also companion to `DISTRIBUTION_CACHE_BENCHMARK_PLAN.md`,
 `DISTRIBUTIONAL_COMPRESSION_THEORY.md`, `RECURRENCE_EVALUATION_STRATEGY_*.md`, and
 the EnWiki splice-validation reports.
 

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_HOWTO.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_HOWTO.md
@@ -1,0 +1,304 @@
+# WAM-Rust Boundary Distribution — How-To
+
+A practical guide to **using** the boundary-distribution optimization in the Rust WAM
+graph-search target. For *why* it works see
+`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md`; for the *precise semantics* see
+`WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md`; for *what was measured* see
+`WAM_RUST_BOUNDARY_MEASUREMENT_2026-06-16.md`. This doc is the operator's manual.
+
+## What it is, in one paragraph
+
+A root-anchored path-aggregate query (e.g. `effective_distance`,
+`d_eff = (Σ_paths Hops^(-N))^(-1/N)`) enumerates **every** path from a seed up to a
+root — exponential in a graph with diamonds. The boundary cache precomputes, at
+root-near **boundary** nodes B, the path-length histogram `H_B→root`; a query that
+reaches B **splices** the cached suffix (an O(budget) convolution) instead of
+re-enumerating. Exponential per-seed enumeration becomes a polynomial precompute plus
+a cheap splice. It is **exact** (any boundary band gives the same answer) and
+**opt-in** (off by default).
+
+---
+
+## Architecture — the layers, the axes, and the strategy classes
+
+### The layers (a query flows top to bottom; precompute fills the middle)
+
+```
+  QUERY KERNELS    histogram splice  │  g_B scalar splice  │  foreign-dispatch wrapper
+                   (boundary_hist)      (weightsum)           (category_ancestor_boundary)
+                          │ read
+  BOUNDARY CACHE   boundary_suffix : node → path-length histogram   (+ boundary_basis_wp : node → g_B)
+                          │ filled by
+  PRECOMPUTE       eager: enum | shared-memo | topological sweep (+evict/spill)   │   lazy: demand-driven
+                          │ walks the cone via
+  EDGE ACCESS      eager: ffi_facts (HashMap)   │   lazy: LookupSource → LMDB + two-tier L1/L2 edge cache
+                          │ over
+  GRAPH            category_parent edges   +   min_dist (distance-to-root: band selection + budget prune)
+```
+
+The **edge cache** (L1/L2) and the **boundary cache** are *orthogonal layers*: the
+edge cache makes each parent lookup cheap; the boundary cache removes the *walk*
+itself. They compose — the boundary win sits on top of a warm edge cache (philosophy
+§3, measured).
+
+### The axes (each an independent architectural choice)
+
+| axis | options | default | knob |
+|---|---|---|---|
+| edge access | eager in-memory · lazy LMDB (+L1/L2 cache) | eager | `register_ffi_fact_pairs` / `register_lazy_lookup` |
+| band (the cut) | whole region · entry frontier | frontier (for storage) | `boundary_band_root_near` / `boundary_band_entry_frontier` |
+| precompute strategy | eager (enum / shared-memo / sweep) · lazy (demand-driven) | eager sweep | `build_boundary_suffix*` / `lazy_boundary_weightsum` |
+| working set | unbudgeted · two-budget eviction · spill-and-continue | unbudgeted | `evict_budget` / `live_budget` / `..._with_spill` |
+| representation | exact histogram · g_B pre-weighted basis · fitted (tail-prune/binomial/beta-binomial/mixture) | exact | `build_boundary_basis_weighted_power` / `boundary_suffix_reprs` |
+| persistence | ephemeral · LMDB histograms · LMDB fitted reprs | ephemeral | `save/load_boundary_basis` / `save/load_boundary_reprs` |
+| result | scalar · effective_distance · distribution | scalar | `boundary_result_extractor` / the extractor read |
+
+They are genuinely independent — e.g. *lazy LMDB edges + entry-frontier band + fitted
+reprs persisted to LMDB* is a valid configuration, as is *eager edges + region band +
+exact in-memory*.
+
+### Strategy classes (how this maps onto `RECURRENCE_EVALUATION_STRATEGY`)
+
+The boundary cache is the **`cached`** strategy class — precompute the suffix relation
+once, serve queries from it — applied to the *suffix* of the recurrence rather than
+the whole answer. Within it:
+
+- **Eager precompute** is a *fixed-point / bottom-up* materialisation of the suffix
+  histograms over the cone (the topological sweep is semi-naïve evaluation of
+  `H_v = Σ_p H_p[·-1]`).
+- **Lazy precompute** is *per-query / top-down*: compute a node's suffix on first
+  demand and memoise — demand-driven, only what is touched.
+- **The query itself is a hybrid**: a lazy outer walk (`seed → boundary`, graph
+  search) splicing a cached inner suffix (`boundary → root`). That is exactly the
+  "lazy outer, eager inner" hybrid of the strategy taxonomy — the boundary cut is
+  where the two meet.
+
+So "eager vs lazy boundary cache" is not a new dichotomy; it is the same lazy/eager
+*evaluation-order* axis the recurrence-strategy work defines, applied to the suffix.
+
+### Composition rules (what fits with what)
+
+- **Lazy/LMDB edges** ⇒ precompute with `build_boundary_suffix` (enumeration, walks via
+  the `EdgeAccessor`) or run the **lazy** boundary cache; the shared-memo sweep needs
+  the eager `ffi_facts` table.
+- **Eager edges** ⇒ any precompute; `build_boundary_suffix_shared` / `_sweep` are the
+  *polynomial* options (each node's `H` computed once).
+- **Persistence** (LMDB `boundary_basis` / `boundary_basis_repr`) is independent of
+  edge access — persist the side-table regardless of how it was built.
+- **`g_B`** is the fixed-budget / fixed-functional hot path; **fitted reprs** are the
+  large-budget storage play. Both are exact-or-certified, never silent approximation.
+
+---
+
+## 0. The shape of a session
+
+```
+COMPILE          enable the lowering (optional — you can also call the kernels directly)
+  └─ write_wam_rust_project([...], [boundary_optimization(true)], Dir)
+
+RUNTIME (once at setup)
+  1. load the graph        register_ffi_fact_pairs / register_lazy_lookup
+  2. load distance-to-root set_min_dist            (drives band selection + pruning)
+  3. pick a band           boundary_band_root_near | boundary_band_entry_frontier
+  4. precompute            build_boundary_suffix* (eager)  OR  lazy_boundary_weightsum (on demand)
+  (optional) compress / persist / build a g_B basis
+
+RUNTIME (per query)
+  splice                   collect_native_category_ancestor_boundary_hist  → a histogram
+                           collect_native_category_ancestor_weightsum      → a scalar (g_B)
+                           or the emitted 3-ary wrapper / foreign dispatch
+```
+
+---
+
+## 1. Compiler: enabling the lowering (optional)
+
+`boundary_optimization(true)` upgrades a detected `category_ancestor/4` kernel to a
+3-ary `category_ancestor_boundary/3` foreign kernel and emits a public wrapper
+`Pred(Cat, Root, Result)`:
+
+```prolog
+write_wam_rust_project([user:category_ancestor/4],
+    [ module_name(myapp),
+      boundary_optimization(true),          % off by default
+      boundary_weight_n(2.0),               % the functional exponent N (default 2.0)
+      boundary_result_extractor(scalar)     % scalar | effective_distance | distribution
+    ], 'output/myapp').
+```
+
+This is the *codegen* decision. At runtime the emitted wrapper splices against the
+side-table you populate (§4). **With an empty side-table the kernel is still correct**
+— it degrades to full enumeration — so the lowering is safe by default and the
+speedup is unlocked once you precompute a band. You can skip the compiler option
+entirely and call the runtime kernels directly (§5); the option just wires the
+dispatch + wrapper for you.
+
+---
+
+## 2. Runtime setup — load the graph and distances
+
+```rust
+let mut vm = WamState::new(vec![], HashMap::new());
+
+// (a) edges — eager (in memory) ...
+vm.register_ffi_fact_pairs("category_parent", &[("5","4"),("4","0"), ...]);
+// ... or lazy (LMDB-backed, for graphs too big for RAM):
+//   vm.register_lazy_lookup("category_parent/2", Arc::new(my_lookup_source));
+//   vm.set_int_native_edges(true);   // if node ids ARE the LMDB keys
+
+// (b) distance-to-root: keyed by node id, value = min hops to root. Drives band
+//     selection AND the kernel's budget prune. Load it like s2i/min_dist at setup.
+vm.set_min_dist(&min_dist_map);       // HashMap<i32, i32>
+```
+
+`min_dist` is the only "extra" input — compute it once (a BFS from the root over the
+reverse edges) and it powers both band selection and pruning.
+
+---
+
+## 3. Choosing the band
+
+The band is the set of nodes whose `node→root` histograms you cache. **Any band is
+exact** — it is purely a storage/coverage choice (spec §8).
+
+| selector | what it caches | use when |
+|---|---|---|
+| `boundary_band_root_near(d_pre)` | the whole region `{1 ≤ min_dist ≤ d_pre}` | you want maximal coverage and storage isn't tight |
+| `boundary_band_entry_frontier(d_pre, edge_pred)` | only the region's **surface** — nodes with a child *outside* the region | **the default** for the boundary-cache regime: storage scales with the cut, not the cumulative node count |
+
+The kernel splices at the **first** cached node a seed reaches and stops, so periphery
+seeds only ever use the entry frontier — `boundary_band_entry_frontier` caches just
+that and is the storage-efficient choice (measurement addendum: band 38 vs region 313
+at the same `D_pre`). Pick `d_pre` so the frontier sits **between** your seeds and the
+dense core (a boundary cache wants its seeds in the periphery).
+
+---
+
+## 4. Precompute — fill the side-table
+
+`boundary_suffix` (node → histogram) is the cache. Several ways to fill it:
+
+| method | strategy | notes |
+|---|---|---|
+| `build_boundary_suffix(band, root, max_depth, edge_pred)` | per-node enumeration | simplest; works on **eager AND lazy/LMDB** edges (via the `EdgeAccessor`) |
+| `build_boundary_suffix_shared(band, ...)` | shared-memo recurrence | polynomial (each node's `H` once); **eager-edge only**; returns `false` on lazy |
+| `build_boundary_suffix_sweep(band, ..., evict_budget, live_budget)` | top-down topological sweep with two-budget eviction | bounded working set; returns `BoundarySweepStats`; eager-edge only |
+| `build_boundary_suffix_sweep_with_spill(band, ..., evict_budget, live_budget, &mut sink)` | sweep + spill-and-continue | non-default; when the live frontier exceeds budget, spill to a `SpillSink` instead of stop-at-depth |
+| `build_boundary_suffix_root_near(root, d_pre, max_depth, edge_pred)` | convenience: select root-near band + shared precompute (eager) with enumeration fallback | one call for the common case |
+| `lazy_boundary_weightsum(seeds, root, max_depth, edge_pred, d_pre, n)` | **lazy** — compute each touched entry on first demand, memoize, splice | no precompute phase; only computes what the workload touches |
+
+**Eager vs lazy (the strategy choice).** Eager amortises a *known, densely-reused*
+band; lazy computes *only what's touched* and needs no precompute moment. Measured
+(report lazy addendum): sparse/unknown workloads favour lazy at every query count;
+a dense workload with a modest query count favours eager. Steady-state per-query cost
+is identical (both splice). Lazy is also the strategy available on the lazy/LMDB edge
+path.
+
+**Budgets (`build_boundary_suffix_sweep`).**
+
+- `evict_budget` (0 = unlimited): cap on resident memo entries; under pressure, evict
+  **dead interior** nodes (`refs = 0`, non-band) **deepest-first** (keep root-near
+  hubs). Never changes a result.
+- `live_budget` (0 = unlimited): cap on the **non-discardable** frontier (`refs > 0`).
+  When exceeded, the default is **stop-at-depth** (`stats.stopped_early`); supply a
+  `SpillSink` to `..._with_spill` to **spill-and-continue** instead (exact paging).
+
+---
+
+## 5. Querying
+
+```rust
+let acc = vm.resolve_edge_accessor("category_parent");
+
+// (a) full path-length histogram, then any functional:
+let mut hist: Vec<u64> = Vec::new();
+let mut visited = vec![seed];
+vm.collect_native_category_ancestor_boundary_hist(seed, root, &mut visited, budget, &acc, 0, &mut hist);
+let weight_sum = boundary_cache::f_weighted_power(&hist, n);   // d_eff = weight_sum.powf(-1/n)
+
+// (b) the scalar WeightSum directly via the pre-weighted g_B basis (skip the
+//     histogram + the powf loop) — build the basis once after precompute:
+vm.build_boundary_basis_weighted_power(budget, n);
+let mut ws = 0.0;
+let mut vis = vec![seed];
+vm.collect_native_category_ancestor_weightsum(seed, root, &mut vis, budget, &acc, 0, n, &mut ws);
+```
+
+`g_B` is a **fixed-budget, fixed-functional** specialisation — it bakes the budget and
+`N` into one scalar per prefix length, so it serves only queries with that *same*
+budget and `N`. For variable budgets / multiple functionals, keep the histogram form.
+
+If you compiled with `boundary_optimization(true)`, just call the emitted wrapper
+`Pred(Cat, Root, Result)` (or dispatch the foreign predicate) — it does (a) for you.
+
+---
+
+## 6. Approximation and persistence (optional)
+
+All **opt-in**; the cache is exact unless you invoke these.
+
+**Compress (storage):** for large-budget / deep-path graphs where histograms are long.
+
+```rust
+// rung 1 only (tail-prune) in place:
+vm.compress_boundary_suffix(50 /* min_points trigger */, 0.001 /* ε_K certificate */);
+
+// full ladder — choose the cheapest representation per node within ε_K:
+let reprs = vm.boundary_suffix_reprs(50, 0.001);   // HashMap<u32, HistRepr>
+```
+
+The chooser (`boundary_cache::choose_representation`) tries, cheapest-first within the
+Kolmogorov `ε_K` gate: **exact → tail-pruned → binomial → beta-binomial → mixture**.
+`choose_representation_budget(h, min_points, max_bytes)` is the storage-driven
+complement (smallest error within a byte budget). The point count `min_points` is a
+*work trigger* / storage proxy, not an acceptance gate — acceptance is always the CDF
+certificate. A fit that misses `ε_K` is rejected back to exact, so accuracy never
+silently degrades.
+
+**Persist (don't recompute per run), LMDB:**
+
+```rust
+// histograms:
+lmdb.save_boundary_basis(&table);                 // -> boundary_basis sub-db
+let table = lmdb.load_boundary_basis()?;          // reload at setup
+vm.set_boundary_suffix(&table);
+
+// fitted representations (the storage win — a binomial node is ~21 bytes):
+lmdb.save_boundary_reprs(&reprs);                 // -> boundary_basis_repr sub-db
+let table = lmdb.load_boundary_reprs()?;          // decodes + EXPANDS to histograms
+vm.set_boundary_suffix(&table);
+```
+
+`LmdbFactSource` also implements `SpillSink` (the `boundary_spill` sub-db) for the
+mid-sweep spill of §4.
+
+---
+
+## 7. Cheat sheet (decision flow)
+
+- **Just want it to work?** Compile with `boundary_optimization(true)`, then at setup:
+  `set_min_dist` → `build_boundary_suffix_root_near(root, 2, budget, edge_pred)`.
+- **Graph too big for RAM?** Lazy edges (`register_lazy_lookup` + `set_int_native_edges`)
+  + `build_boundary_suffix` (enumeration, lazy-compatible) **or** `lazy_boundary_weightsum`.
+- **Sparse / unknown query set?** Use `lazy_boundary_weightsum` (computes only what's
+  touched).
+- **Storage tight?** `boundary_band_entry_frontier` for the band, then
+  `boundary_suffix_reprs` + `save_boundary_reprs` to persist fitted forms.
+- **One fixed functional, hot path?** `build_boundary_basis_weighted_power` +
+  `collect_native_category_ancestor_weightsum` (the ~ns dot-product splice).
+- **Precompute frontier won't fit in memory?** `build_boundary_suffix_sweep_with_spill`
+  with an LMDB or in-memory `SpillSink`.
+
+---
+
+## 8. Where everything lives
+
+| concern | code | tests |
+|---|---|---|
+| splice kernels, band selection, precompute, lazy, sweep+eviction+spill, g_B, compress | `templates/targets/rust_wam/state.rs.mustache` | `boundary_kernel_tests` (in `state.rs.mustache`) |
+| histogram ops, splice identity, error metrics, fitting ladder, repr (de)code | `templates/targets/rust_wam/boundary_cache.rs.mustache` | its `#[cfg(test)] mod tests` |
+| LMDB persistence + `SpillSink` | `templates/targets/rust_wam/lmdb_fact_source_lmdb_zero.rs.mustache` | `tests/test_wam_rust_boundary_{basis,repr,spill}_lmdb.pl` |
+| compiler lowering / options | `src/unifyweaver/targets/wam_rust_target.pl`, `src/unifyweaver/core/recursive_kernel_detection.pl` | `tests/test_wam_rust_boundary_{lowering,foreign_dispatch}.pl` |
+| foreign dispatch + integrated scale | — | `tests/test_wam_rust_boundary_{kernel_exec,integrated_scale}.pl` |
+| measurement harnesses | `examples/benchmark/wam_rust_boundary_{measurement,lazy_edge_measurement}.pl`, `examples/benchmark/boundary_splice_complexity_bench.rs` | — |
+| design | `WAM_RUST_BOUNDARY_DISTRIBUTION_{PHILOSOPHY,SPECIFICATION,CACHE_PLAN}.md`, `WAM_RUST_BOUNDARY_MEASUREMENT_2026-06-16.md` | — |

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md
@@ -3,7 +3,9 @@
 Why the Rust WAM graph-search target should grow a **boundary distribution**
 optimization, what kind of thing it is, and the principles that should shape it.
 Companions: `WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md` (precise semantics),
-`WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md` (phased implementation + status).
+`WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md` (phased implementation + status),
+`WAM_RUST_BOUNDARY_DISTRIBUTION_HOWTO.md` (the operator's manual — how to use it),
+`WAM_RUST_BOUNDARY_MEASUREMENT_2026-06-16.md` (what was measured).
 
 ## 1. The problem
 
@@ -123,3 +125,40 @@ The complexity win is measured (300–700×), the splice identity is proven in R
 (P1), and the runtime kernel exists and matches the production kernel (P2a,
 P2c-parity). What remains is the optimization *wiring* — and the histogram-output
 generalisation above is what keeps that wiring from being built too narrowly.
+
+## 7. What the measurements showed (hypotheses → results)
+
+The wiring is now built and measured end to end (`WAM_RUST_BOUNDARY_MEASUREMENT_
+2026-06-16.md`, `WAM_RUST_BOUNDARY_DISTRIBUTION_HOWTO.md`). The §3/§5 hypotheses held:
+
+- **The win is real *on top of* the edge cache, and the crossover is shallow.** On
+  the real emitted kernels (not the Python prototype, not a std-only model), with the
+  baseline running over warm in-memory edges (= a perfect edge cache): ~3× at
+  `D_pre=1`, 16–26× at `D_pre=2`, >100× at `D_pre=3`. The optimal `D_pre` is *shallow*,
+  exactly as §3 predicted the Python overhead had been masking. Precompute is sub-ms —
+  it amortizes within a single 500-seed batch.
+- **It holds, and grows, on the LMDB lazy edge path.** When each parent lookup is an
+  LMDB seek rather than a HashMap hit, production is ~4–5× slower but the boundary win
+  *persists and is often larger* (20–25×): the cache removes the *walk*, so the more
+  each avoided lookup costs, the more it saves. This confirms §3's "layer on top of the
+  edge cache, not a replacement" — the boundary cache's headroom is exactly the
+  native-DFS time the edge cache leaves behind.
+- **Exact at scale, every time.** The boundary aggregate equals the production
+  hop-stream aggregate exactly across all `D_pre`, scales, and on both edge paths. The
+  "any boundary band is exact" property held under the real integrated path.
+- **The band must be a thin cut, and value concentrates root-near.** The whole-region
+  band blows up with cumulative node count; the *entry frontier* (the region's surface)
+  gets the same speedup at a fraction of the storage — and the speedup *falls* once
+  `D_pre` is large enough that the region swallows the periphery. "A boundary cache
+  wants its seeds in the periphery" is now a measured rule, not just intuition.
+- **Caching is genuinely secondary.** The complexity reduction stands on its own (the
+  precompute pays for itself within one batch); cross-run persistence and the lazy /
+  eager / spill strategy choices are amortization levers on top of an already-winning
+  algorithm — the inverse emphasis of the edge cache, as §3 argued.
+
+The remaining open questions are storage-shaped, not compute-shaped: the
+exact→approximate ladder (tail-prune → binomial/beta-binomial/mixture, CDF-gated) and
+the quantised-CDF / GMM rungs matter only at large budget / deep paths, where
+histograms are long — never for the small-budget effective-distance query, where exact
+is also fastest.
+

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
@@ -1,8 +1,10 @@
 # WAM-Rust Boundary Distribution Optimization — Specification
 
 Precise semantics of the boundary distribution optimization. See
-`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md` (rationale) and
-`WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md` (phasing/status).
+`WAM_RUST_BOUNDARY_DISTRIBUTION_PHILOSOPHY.md` (rationale),
+`WAM_RUST_BOUNDARY_DISTRIBUTION_CACHE_PLAN.md` (phasing/status),
+`WAM_RUST_BOUNDARY_DISTRIBUTION_HOWTO.md` (how to use it), and
+`WAM_RUST_BOUNDARY_MEASUREMENT_2026-06-16.md` (measured results).
 
 ## 1. The object: a measure over path length
 

--- a/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_BOUNDARY_DISTRIBUTION_SPECIFICATION.md
@@ -422,6 +422,13 @@ Implemented (Rust, `boundary_cache.rs`):
   rejects (a bottleneck / topic-mixture cone). `HistRepr::Mixture{trials,comps,total}`
   joins the candidate set (`K = 2,3`). Discretised-GMM stays escalation-only —
   bounded integer path-length data favour binomial families.
+- **Rung 5 — quantised CDF table** — `HistRepr::QuantCdf{qcdf,total}` stores the
+  exact CDF as one fixed-point `u16` per support point (`quantize_cdf` /
+  `dequantize_cdf`; `F(i) ≈ qcdf[i]/65535`). **Always admissible** (error bounded by
+  the quantisation step, `≤ 2^-16`) at ~1/4 the bytes of the raw `u64` counts, so it
+  is the fallback when *no* parametric form fits an irregular/multi-spike node — and
+  it gives O(1) prefix-mass reads (a natural fit for the `cdf`/`quantile` result
+  modes). The chooser still prefers a cheaper parametric form when one passes.
 - **Choice is multi-objective.** `choose_representation` is *error-driven* (cheapest
   within `ε_K`); `choose_representation_budget` is the *storage-driven* complement
   (smallest CDF error within a byte budget). Error is not always the binding
@@ -450,9 +457,6 @@ persistence path are general — adding a representation is just another candida
 `representation_candidates` with a `bytes()` and a `pmf()`/`expand()`. Not yet
 implemented, in rough priority order:
 
-- **Quantised CDF table** — one monotone fixed-point CDF value per retained point
-  (16-bit → error ≤ `2^-16`). Best when prefix-mass / range queries dominate (O(1)
-  reads); a natural fit for the `cdf`/`quantile` result modes (§5).
 - **Discretised Gaussian mixture** — `(weight, mean, variance)` per mode; the
   **escalation-only** family for sharp/narrow modes that the binomial mixture fits
   poorly. Continuous prior on discrete data, more params per mode — used only after

--- a/templates/targets/rust_wam/boundary_cache.rs.mustache
+++ b/templates/targets/rust_wam/boundary_cache.rs.mustache
@@ -386,6 +386,12 @@ pub enum HistRepr {
     /// Mixture of binomials (shared `trials`); `comps` are `(weight, p)` pairs.
     /// The escalation rung for multimodal nodes a single binomial cannot fit.
     Mixture { trials: usize, comps: Vec<(f64, f64)>, total: u64 },
+    /// Quantised CDF table: the exact CDF stored as one fixed-point `u16` per support
+    /// point (`F(i) ≈ qcdf[i]/65535`). Lossy-but-exact-shaped — error bounded by the
+    /// quantisation step (≤ 2^-16) — and **always admissible** for any histogram, at
+    /// ~1/4 the bytes of the raw `u64` counts. The fallback when no parametric form
+    /// fits; also gives O(1) prefix-mass reads.
+    QuantCdf { qcdf: Vec<u16>, total: u64 },
 }
 
 impl HistRepr {
@@ -397,6 +403,7 @@ impl HistRepr {
             HistRepr::Binomial { .. } => 1 + 4 + 8 + 8,     // tag + trials + p + total
             HistRepr::BetaBinomial { .. } => 1 + 4 + 8 + 8 + 8, // tag + trials + alpha + beta + total
             HistRepr::Mixture { comps, .. } => 1 + 4 + 4 + comps.len() * 16 + 8,
+            HistRepr::QuantCdf { qcdf, .. } => 1 + 4 + qcdf.len() * 2 + 8, // tag + u32 len + u16 cdf + total
         }
     }
     /// Reconstruct a count histogram (parametric forms expand to the PMF scaled to
@@ -418,6 +425,7 @@ impl HistRepr {
             HistRepr::Binomial { trials, p, .. } => binomial_pmf(*trials, *p),
             HistRepr::BetaBinomial { trials, alpha, beta, .. } => beta_binomial_pmf(*trials, *alpha, *beta),
             HistRepr::Mixture { trials, comps, .. } => mixture_pmf(*trials, comps),
+            HistRepr::QuantCdf { qcdf, .. } => dequantize_cdf(qcdf),
         }
     }
     fn total(&self) -> u64 {
@@ -425,9 +433,37 @@ impl HistRepr {
             HistRepr::Exact(h) => h.iter().sum(),
             HistRepr::Binomial { total, .. }
             | HistRepr::BetaBinomial { total, .. }
-            | HistRepr::Mixture { total, .. } => *total,
+            | HistRepr::Mixture { total, .. }
+            | HistRepr::QuantCdf { total, .. } => *total,
         }
     }
+}
+
+/// Quantise a histogram's CDF to one fixed-point `u16` per support point
+/// (`qcdf[i] = round(F(i) * 65535)`, monotone non-decreasing, last = 65535).
+pub fn quantize_cdf(h: &Hist) -> Vec<u16> {
+    let total: f64 = h.iter().map(|&c| c as f64).sum();
+    if total <= 0.0 { return Vec::new(); }
+    let mut acc = 0.0f64;
+    let mut prev = 0u16;
+    h.iter().map(|&c| {
+        acc += c as f64;
+        let q = (acc / total * 65535.0).round() as u16;
+        let q = q.max(prev); // enforce monotonicity against rounding
+        prev = q;
+        q
+    }).collect()
+}
+
+/// Recover the PMF from a quantised CDF table: `p[i] = (qcdf[i] - qcdf[i-1])/65535`.
+pub fn dequantize_cdf(qcdf: &[u16]) -> Vec<f64> {
+    let mut out = Vec::with_capacity(qcdf.len());
+    let mut prev = 0u16;
+    for &q in qcdf {
+        out.push((q.saturating_sub(prev)) as f64 / 65535.0);
+        prev = q;
+    }
+    out
 }
 
 /// PMF of `BetaBinomial(trials, alpha, beta)` over `0..=trials`, by the stable
@@ -563,6 +599,13 @@ fn representation_candidates(h: &Hist, min_points: usize) -> Vec<(HistRepr, f64)
         let err = cdf_max_error_pmf(&exact_pmf, &mixture_pmf(trials, &comps));
         cands.push((HistRepr::Mixture { trials, comps, total }, err));
     }
+    {
+        // always-admissible fallback: the exact CDF at u16 precision (~1/4 the bytes
+        // of raw counts), error bounded by the quantisation step.
+        let qcdf = quantize_cdf(h);
+        let err = cdf_max_error_pmf(&exact_pmf, &dequantize_cdf(&qcdf));
+        cands.push((HistRepr::QuantCdf { qcdf, total }, err));
+    }
     cands
 }
 
@@ -598,7 +641,7 @@ pub fn choose_representation_budget(h: &Hist, min_points: usize, max_bytes: usiz
 /// Encode a `HistRepr` to a self-describing byte string (1-byte tag + fields), so
 /// a chosen representation can be persisted (the `boundary_basis_repr` LMDB sub-db)
 /// and `expand`ed on load. Tags: 0 = Exact, 1 = Binomial, 2 = Mixture,
-/// 3 = BetaBinomial.
+/// 3 = BetaBinomial, 4 = QuantCdf.
 pub fn encode_repr(r: &HistRepr) -> Vec<u8> {
     let mut out = Vec::new();
     match r {
@@ -626,6 +669,14 @@ pub fn encode_repr(r: &HistRepr) -> Vec<u8> {
             for &(w, p) in comps {
                 out.extend_from_slice(&w.to_le_bytes());
                 out.extend_from_slice(&p.to_le_bytes());
+            }
+            out.extend_from_slice(&total.to_le_bytes());
+        }
+        HistRepr::QuantCdf { qcdf, total } => {
+            out.push(4u8);
+            out.extend_from_slice(&(qcdf.len() as u32).to_le_bytes());
+            for &q in qcdf {
+                out.extend_from_slice(&q.to_le_bytes());
             }
             out.extend_from_slice(&total.to_le_bytes());
         }
@@ -666,6 +717,18 @@ pub fn decode_repr(b: &[u8]) -> HistRepr {
             beta: read_f64(b, 13),
             total: read_u64(b, 21),
         },
+        4 if b.len() >= 1 + 4 => {
+            let len = read_u32(b, 1) as usize;
+            let mut qcdf = Vec::with_capacity(len);
+            let mut o = 5;
+            for _ in 0..len {
+                if o + 2 > b.len() { break; }
+                qcdf.push(u16::from_le_bytes([b[o], b[o + 1]]));
+                o += 2;
+            }
+            let total = if o + 8 <= b.len() { read_u64(b, o) } else { 0 };
+            HistRepr::QuantCdf { qcdf, total }
+        }
         2 if b.len() >= 1 + 4 + 4 => {
             let trials = read_u32(b, 1) as usize;
             let k = read_u32(b, 5) as usize;
@@ -825,11 +888,37 @@ mod tests {
             HistRepr::Binomial { trials: 12, p: 0.37, total: 9999 },
             HistRepr::BetaBinomial { trials: 30, alpha: 2.5, beta: 1.5, total: 8888 },
             HistRepr::Mixture { trials: 20, comps: vec![(0.6, 0.2), (0.4, 0.8)], total: 12345 },
+            HistRepr::QuantCdf { qcdf: vec![0u16, 100, 30000, 65535], total: 7777 },
         ];
         for r in reprs {
             assert_eq!(decode_repr(&encode_repr(&r)), r, "repr roundtrip {:?}", r);
         }
         assert_eq!(decode_repr(&[]), HistRepr::Exact(vec![]));
+    }
+
+    // The quantised-CDF table is always admissible (error ~ the quantisation step)
+    // and is chosen as the fallback when no parametric form fits — at ~1/4 the bytes
+    // of the exact histogram.
+    #[test]
+    fn quant_cdf_is_the_no_fit_fallback() {
+        // five sharp spikes: no unimodal (binomial/beta-binomial) nor K<=3 mixture fits.
+        let mut h = vec![0u64; 60];
+        for &i in &[3usize, 17, 28, 44, 55] { h[i] = 1000; }
+        let exact_pmf = to_pmf(&h);
+        // the quantised CDF reconstructs within the quantisation step
+        let q = quantize_cdf(&h);
+        assert!(cdf_max_error_pmf(&exact_pmf, &dequantize_cdf(&q)) < 1e-3);
+        // parametric fits all miss the gate on five spikes
+        let (tb, pb) = fit_binomial(&h);
+        assert!(cdf_max_error_pmf(&exact_pmf, &binomial_pmf(tb, pb)) > 0.01);
+        let (tm, comps) = fit_binomial_mixture(&h, 3, 60);
+        assert!(cdf_max_error_pmf(&exact_pmf, &mixture_pmf(tm, &comps)) > 0.01);
+        // so the chooser falls back to QuantCdf — smaller than the exact histogram.
+        let repr = choose_representation(&h, 10, 0.01);
+        assert!(matches!(repr, HistRepr::QuantCdf { .. }),
+            "expected QuantCdf fallback, got {:?}", repr);
+        assert!(repr.bytes() < HistRepr::Exact(h.clone()).bytes());
+        assert!(cdf_max_error(&h, &repr.expand()) <= 0.01 + 1e-6);
     }
 
     #[test]


### PR DESCRIPTION
Four commits on this branch. The first three complete the boundary-distribution approximation ladder; the fourth captures the theory for the next direction.

## Commit 1 — documentation pass (`97735a9a`)

Consolidated docs for the boundary-distribution optimization: new `..._HOWTO.md` operator's manual, an Architecture section, and Philosophy §7 "What the measurements showed."

## Commit 2 — quantised-CDF rung (`6f938b57`)

`HistRepr::QuantCdf{qcdf,total}` — the exact CDF at fixed-point `u16` precision: **always admissible** (error ≤ `2^-16`) at ~1/4 the bytes of raw counts, the fallback when no parametric form fits, plus O(1) prefix-mass reads. Tag 4. Test `quant_cdf_is_the_no_fit_fallback`.

## Commit 3 — discretised-GMM rung (`47dd09d3`)

`HistRepr::DiscGmm{support,comps,total}` — free-`(weight, mu, sigma)` EM components that place the **narrow interior modes** the mean-coupled binomial families cannot. Most params/mode, so the chooser selects it only when every cheaper rung misses the gate AND it undercuts the quant-CDF table on bytes. Tag 5. Test `disc_gmm_fits_narrow_interior_modes`. **The approximation ladder is now complete (Rungs 1–6).** 35 lib tests pass.

## Commit 4 — theory note: graph functional semirings (`56c2108f`)

`docs/design/WAM_RUST_GRAPH_FUNCTIONAL_SEMIRINGS.md` — the algebraic generalization that scopes the next increments (docs-only, no code). Generalizes the boundary cache from "cache the path-length histogram" to "propagate the **functionals** of that histogram directly, never forming it":

- **Composition law** — concatenation convolves histograms / unions add them, so a functional propagates on its own value exactly when it's a semiring homomorphism. Worked out for mass (counting), the raw-moment jet `(M,m₁,m₂)` (truncated power series), and the support interval `(min,max)` (min-plus × max-plus).
- **`PathSemiring` framework** — one algebraic-path-problem recurrence over a (product) semiring; n-tuples = product semirings; histogram / moment-jet / interval are all instances.
- **Ancestor-space domain** — the acyclic up-closure is the exact domain (root-near cores shared across ancestor spaces is why caching pays); cyclic up-sets fall back to the existing budget/visited closure.
- **Certified bracket** — `d_eff` is a power mean of path lengths, so `d_eff ∈ [min,max]` exactly: a certified bound on the real metric from two scalars. (And the honest non-example: `WeightSum` is not multiplicative under convolution, so it has no scalar splice — the `g_B` basis is the fixed-budget partial fix.)
- **Kernel-trick analogy** — the histogram is the implicit feature map; functionals are computed *through* it without materialization (with the honest limits: semiring homomorphism, not PSD; `WeightSum` = the non-factoring case).
- **CLT reconstruction** — the moment jet → discretised Normal at deep nodes, as a CDF-gated rung complementary to the discretised-GMM (and why min/max alone can't do it without the variance).
- **Roadmap** — generic payload on the ancestor space first (exact, validated against the histogram), distance/shortest-path kernels + cyclic closure second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uh3PhwRieXYvdDsxk6Zua