### PR TITLE
Support PLAWK scalar NR expressions

### DIFF
--- a/examples/plawk/codegen/plawk_native_codegen.pl
+++ b/examples/plawk/codegen/plawk_native_codegen.pl
@@ -49,6 +49,7 @@
 %      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %      { adjusted += length($0) - 3; width = NF + 1 } END { print adjusted, width }
+%      { last = NR; prev = NR - 1; total += NR + 1 } END { print last, prev, total }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
 %      $1 == "ERROR" { last_len = length($0); hits++ } END { print hits, last_len }
 %      { if ($1 == "ERROR") { errors++ } else { warnings++ } } END { print errors, warnings }
@@ -112,8 +113,10 @@ plawk_program_native_driver_ir(
     plawk_mixed_rule_chain_ir(MixedPlan, FieldSeparator, OutputSeparator,
         RuleGlobalIR, RuleChainIR, RuleCount, BranchControlExits),
     plawk_rules_body_print_fields(Rules, BodyPrintFields),
-    append(PrintFields, BodyPrintFields, AllPrintFields),
-    plawk_print_record_counter_ir(AllPrintFields, RecordLoopPhiIR, RecordCounterIR),
+    plawk_rules_scalar_update_exprs(Rules, ScalarExprs),
+    append(PrintFields, BodyPrintFields, PrintExprs),
+    append(PrintExprs, ScalarExprs, RecordCounterExprs),
+    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
     plawk_state_loop_phi_ir(ScalarPlan, StateLoopPhiIR),
     plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
     plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
@@ -150,8 +153,10 @@ plawk_program_native_driver_ir(
     plawk_scalar_rule_chain_ir(Rules, StatePlan, FieldSeparator, OutputSeparator,
         RuleGlobalIR, RuleChainIR, RuleCount, BranchControlExits),
     plawk_rules_body_print_fields(Rules, BodyPrintFields),
-    append(PrintFields, BodyPrintFields, AllPrintFields),
-    plawk_print_record_counter_ir(AllPrintFields, RecordLoopPhiIR, RecordCounterIR),
+    plawk_rules_scalar_update_exprs(Rules, ScalarExprs),
+    append(PrintFields, BodyPrintFields, PrintExprs),
+    append(PrintExprs, ScalarExprs, RecordCounterExprs),
+    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
     plawk_state_loop_phi_ir(StatePlan, StateLoopPhiIR),
     plawk_join_nonempty_ir([StateLoopPhiIR, RecordLoopPhiIR], LoopPhiIR),
     plawk_join_nonempty_ir([RecordCounterIR, RuleChainIR], RecordIR),
@@ -188,8 +193,10 @@ plawk_program_native_driver_ir(
     plawk_assoc_entry_setup_ir(AssocPlan, EntrySetupIR),
     plawk_assoc_rule_chain_ir(AssocPlan, FieldSeparator, AssocRuleGlobalIR, AssocChainIR),
     plawk_rules_body_print_fields(Rules, BodyPrintFields),
-    append(PrintFields, BodyPrintFields, AllPrintFields),
-    plawk_print_record_counter_ir(AllPrintFields, RecordLoopPhiIR, RecordCounterIR),
+    plawk_rules_scalar_update_exprs(Rules, ScalarExprs),
+    append(PrintFields, BodyPrintFields, PrintExprs),
+    append(PrintExprs, ScalarExprs, RecordCounterExprs),
+    plawk_print_record_counter_ir(RecordCounterExprs, RecordLoopPhiIR, RecordCounterIR),
     plawk_join_nonempty_ir([RecordCounterIR, AssocChainIR], RecordIR),
     plawk_assoc_rule_controls(AssocPlan, AssocRuleControls),
     plawk_assoc_break_close_ir(AssocRuleControls, BreakCloseIR),
@@ -452,6 +459,29 @@ plawk_rules_body_print_fields(Rules, Fields) :-
           plawk_actions_body_print_field(Actions, Field)
         ),
         Fields).
+
+plawk_rules_scalar_update_exprs(Rules, Exprs) :-
+    findall(Expr,
+        ( member(rule(_Pattern, Actions), Rules),
+          plawk_actions_scalar_update_expr(Actions, Expr)
+        ),
+        Exprs).
+
+plawk_actions_scalar_update_expr(Actions, Expr) :-
+    member(Action, Actions),
+    plawk_action_scalar_update_expr(Action, Expr).
+
+plawk_action_scalar_update_expr(if(_Pattern, ThenActions, ElseActions), Expr) :-
+    !,
+    (   plawk_actions_scalar_update_expr(ThenActions, Expr)
+    ;   plawk_actions_scalar_update_expr(ElseActions, Expr)
+    ).
+plawk_action_scalar_update_expr(Action, Expr) :-
+    plawk_scalar_action_update(Action, _Name, Operation),
+    plawk_scalar_operation_expr(Operation, Expr).
+
+plawk_scalar_operation_expr(add(Expr), Expr).
+plawk_scalar_operation_expr(set(Expr), Expr).
 
 plawk_actions_body_print_field(Actions, Field) :-
     member(Action, Actions),
@@ -1333,11 +1363,15 @@ plawk_i64_scalar_const_binary_expr(Expr) :-
     integer(Value),
     Value >= 0.
 
-plawk_i64_scalar_binary_primary_expr(special('NF')).
-plawk_i64_scalar_binary_primary_expr(int(field(FieldIndex))) :-
+plawk_i64_scalar_primary_expr(special('NR')).
+plawk_i64_scalar_primary_expr(special('NF')).
+plawk_i64_scalar_primary_expr(int(field(FieldIndex))) :-
     FieldIndex >= 0.
-plawk_i64_scalar_binary_primary_expr(length(field(FieldIndex))) :-
+plawk_i64_scalar_primary_expr(length(field(FieldIndex))) :-
     FieldIndex >= 0.
+
+plawk_i64_scalar_binary_primary_expr(Expr) :-
+    plawk_i64_scalar_primary_expr(Expr).
 
 plawk_i64_binary_expr(add_i64(Left, Right), add, add, Left, Right).
 plawk_i64_binary_expr(sub_i64(Left, Right), sub, sub, Left, Right).
@@ -1364,6 +1398,8 @@ plawk_scalar_action_update(add(var(Name), field(FieldIndex)), Name, add(field_i6
 plawk_scalar_action_update(add(var(Name), int(field(FieldIndex))), Name, add(field_i64(FieldIndex))) :-
     FieldIndex >= 0.
 plawk_scalar_action_update(add(var(Name), Expr), Name, add(Expr)) :-
+    plawk_i64_scalar_primary_expr(Expr).
+plawk_scalar_action_update(add(var(Name), Expr), Name, add(Expr)) :-
     plawk_i64_scalar_const_binary_expr(Expr).
 plawk_scalar_action_update(set(var(Name), int(Value)), Name, set(const(Value))) :-
     integer(Value),
@@ -1374,6 +1410,8 @@ plawk_scalar_action_update(set(var(Name), field(FieldIndex)), Name, set(field_i6
     FieldIndex >= 0.
 plawk_scalar_action_update(set(var(Name), int(field(FieldIndex))), Name, set(field_i64(FieldIndex))) :-
     FieldIndex >= 0.
+plawk_scalar_action_update(set(var(Name), Expr), Name, set(Expr)) :-
+    plawk_i64_scalar_primary_expr(Expr).
 plawk_scalar_action_update(set(var(Name), Expr), Name, set(Expr)) :-
     plawk_i64_scalar_const_binary_expr(Expr).
 
@@ -1502,6 +1540,13 @@ plawk_scalar_numeric_expr_ir(field_i64(FieldIndex), FieldSeparator, Prefix, Slot
     format(atom(ParseBase), '~w_slot_~w_op_~w_field_i64',
         [Prefix, SlotIndex, OpIndex]),
     plawk_i64_expr_ir_parts(field_i64(FieldIndex), FieldSeparator, ParseBase, ParseBase,
+        ValueIR, IR).
+plawk_scalar_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
+        OpIndex, ValueIR, IR) :-
+    plawk_i64_scalar_primary_expr(Expr),
+    format(atom(PrimaryBase), '~w_slot_~w_op_~w_i64_primary',
+        [Prefix, SlotIndex, OpIndex]),
+    plawk_i64_expr_ir_parts(Expr, FieldSeparator, PrimaryBase, PrimaryBase,
         ValueIR, IR).
 plawk_scalar_numeric_expr_ir(Expr, FieldSeparator, Prefix, SlotIndex,
         OpIndex, ValueIR, IR) :-

--- a/examples/plawk/parser/plawk_parser.pl
+++ b/examples/plawk/parser/plawk_parser.pl
@@ -28,6 +28,7 @@
 %      $1 == "ERROR" { bytes += $3; last = $3 } END { print bytes, last }
 %      $1 == "ERROR" { bytes += length($0); hits += 2 } END { print bytes, hits }
 %      { adjusted += length($0) - 3; width = NF + 1 } END { print adjusted, width }
+%      { last = NR; prev = NR - 1; total += NR + 1 } END { print last, prev, total }
 %      $1 == "DEBUG" { skipped++; next } { total++ } END { print total, skipped }
 %      $1 == "ERROR" { hits++; break } { total++ } END { print hits, total }
 %      $1 == "ERROR" { last_len = length($0); hits++ } END { print hits, last_len }
@@ -328,10 +329,12 @@ increment_action(inc(var(Name))) -->
     "++".
 
 next_action(next) -->
-    "next".
+    "next",
+    identifier_boundary.
 
 break_action(break) -->
-    "break".
+    "break",
+    identifier_boundary.
 
 add_assign_action(add(var(Name), Delta)) -->
     identifier(Name),
@@ -357,6 +360,8 @@ scalar_delta_expr(int(Value)) -->
       Value >= 0 }.
 scalar_delta_expr(Expr) -->
     i64_const_binary_expr(Expr).
+scalar_delta_expr(special('NR')) -->
+    "NR".
 scalar_delta_expr(field(Index)) -->
     "$",
     integer_codes(IndexCodes),
@@ -568,6 +573,15 @@ identifier_rest([Code | Codes]) -->
     identifier_rest(Codes).
 identifier_rest([]) -->
     [].
+
+identifier_boundary([Code | Rest], [Code | Rest]) :-
+    \+ identifier_continue_code(Code).
+identifier_boundary([], []).
+
+identifier_continue_code(Code) :-
+    code_type(Code, alnum),
+    !.
+identifier_continue_code(0'_).
 
 required_ws -->
     [Code],

--- a/tests/test_plawk_surface_prefix_print.pl
+++ b/tests/test_plawk_surface_prefix_print.pl
@@ -162,6 +162,12 @@ test(parses_nonterminal_next_rule) :-
          rule(always, [inc(var(total))])],
         [end([print([var(total), var(skipped)])])])).
 
+test(parses_keyword_prefix_variable_names) :-
+    plawk_parse_string("{ next_total++; break_count++ } END { print next_total, break_count }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [inc(var(next_total)), inc(var(break_count))])],
+        [end([print([var(next_total), var(break_count)])])])).
+
 test(parses_terminal_break_scalar_rule) :-
     plawk_parse_string("$1 == \"ERROR\" { hits++; break } { total++ } END { print hits, total }\n", Program),
     assertion(Program == program([],
@@ -236,6 +242,15 @@ test(parses_i64_primary_binary_scalar_add_assign_end_print_rule) :-
          set(var(width), add_i64(special('NF'), int(1))),
          add(var(delta), add_i64(int(field(3)), int(1)))])],
         [end([print([var(adjusted), var(width), var(delta)])])])).
+
+test(parses_scalar_nr_add_assign_end_print_rule) :-
+    plawk_parse_string("{ last = NR; total += NR; prev = NR - 1; next_total += NR + 1 } END { print last, total, prev, next_total }\n", Program),
+    assertion(Program == program([], [rule(always,
+        [set(var(last), special('NR')),
+         add(var(total), special('NR')),
+         set(var(prev), sub_i64(special('NR'), int(1))),
+         add(var(next_total), add_i64(special('NR'), int(1)))])],
+        [end([print([var(last), var(total), var(prev), var(next_total)])])])).
 
 test(parses_always_scalar_add_assign_end_print_rule) :-
     plawk_parse_string("{ total += 3 } END { print total }\n", Program),
@@ -589,6 +604,11 @@ test(surface_i64_primary_binary_scalar_accumulates_values) :-
         "ERROR:disk:10\nWARN:cpu:20\nERROR:network:-3\n",
         "31 4 30\n").
 
+test(surface_scalar_nr_accumulates_values) :-
+    run_surface_print_smoke("{ last = NR; total += NR; prev = NR - 1; next_total += NR + 1 } END { print last, total, prev, next_total }\n",
+        "INFO boot ok\nERROR disk full\nWARN cpu hot\n",
+        "3 6 2 9\n").
+
 test(surface_always_scalar_add_assign_accumulates_constants) :-
     run_surface_print_smoke("{ total += 3 } END { print total }\n",
         "INFO boot ok\nERROR disk full\nWARN cpu hot\nERROR net down\n",
@@ -927,6 +947,17 @@ test(surface_i64_primary_binary_print_uses_shared_lowering) :-
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_sub_2 = sub i64 %plawk_int_sub_2_lhs, 3'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_add_3_lhs_value_or_default = select i1 %plawk_int_add_3_lhs_ok, i64 %plawk_int_add_3_lhs_value, i64 0'))),
     assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_int_add_3 = add i64 %plawk_int_add_3_lhs_value_or_default, 1'))),
+    assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
+    !.
+
+test(surface_scalar_nr_uses_native_record_counter) :-
+    plawk_parse_string("{ last = NR; total += NR; prev = NR - 1; next_total += NR + 1 } END { print last, total, prev, next_total }\n", Program),
+    plawk_program_native_driver_ir(Program, 'input.txt', DriverIR),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%plawk_nr = phi i64 [0, %check_handle_value], [%current_nr, %continue_loop]'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '%current_nr = add i64 %plawk_nr, 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 0, %current_nr'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= sub i64 %current_nr, 1'))),
+    assertion(once(sub_atom(DriverIR, _, _, _, '= add i64 %current_nr, 1'))),
     assertion(\+ sub_atom(DriverIR, _, _, _, '@run_loop')),
     !.
 


### PR DESCRIPTION
  ## Summary
  - Parse bare `NR` in scalar assignments and `+=` updates.
  - Lower scalar `NR` and `NR +/- K` updates through native i64 state codegen.
  - Include scalar update expressions in native record-counter detection so `%current_nr` is available when `NR` is only
  used for state.
  - Tighten `next`/`break` keyword parsing so variables like `next_total` and `break_count` are not parsed as control
  actions.

  ## Tests
  - `swipl -q -s tests/test_plawk_surface_prefix_print.pl -g "setenv('UW_SMOKE_TMPDIR', '/tmp/uw_smoke'),run_tests" -t
  halt`
  - `swipl -q -s examples/plawk/core/plawk_core_tests.pl -g run_tests -t halt`
  - `swipl -q -s tests/test_plawk_compiled_stream_core.pl -g run_tests -t halt`
  - `swipl -q -s tests/test_plawk_native_outer_loop_driver.pl -g run_tests -t halt`
  - `swipl -q -s tests/test_plawk_native_stream_loop_driver.pl -g run_tests -t halt`
  - `swipl -q -s tests/test_plawk_native_counter_stream_loop_driver.pl -g run_tests -t halt`
  - `swipl -q -s tests/test_plawk_native_output_stream_loop_driver.pl -g run_tests -t halt`
  - `swipl -q -s tests/test_plawk_native_lowered_handler_stream_loop_driver.pl -g run_tests -t halt`
  - `swipl -q -s tests/test_plawk_compiled_output_append.pl -g run_tests -t halt`
  - `git diff --check`